### PR TITLE
Add movewindowinv dispatcher

### DIFF
--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -128,7 +128,7 @@ public:
     SMonitor*               getMonitorInDirection(const char&);
     void                    updateAllWindowsBorders();
     void                    updateWindowBorderColor(CWindow*);
-    void                    moveWindowToWorkspace(CWindow*, const std::string&);
+    void                    moveWindowToWorkspace(CWindow*, const int);
     int                     getNextAvailableMonitorID();
     void                    moveWorkspaceToMonitor(CWorkspace*, SMonitor*);
     bool                    workspaceIDOutOfBounds(const int&);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -579,6 +579,7 @@ void CKeybindManager::moveActiveTo(std::string args) {
 void CKeybindManager::moveInactiveTo(std::string args) {
     const auto LASTMONITOR = g_pCompositor->m_pLastMonitor;
     const auto PACTIVE = g_pCompositor->m_pLastWindow;
+    const auto CURSOR_COORDS = Vector2D(g_pCompositor->m_sWLRCursor->x, g_pCompositor->m_sWLRCursor->y);
 
     focusMonitor(args);
 
@@ -595,6 +596,8 @@ void CKeybindManager::moveInactiveTo(std::string args) {
     }
 
     g_pCompositor->focusWindow(PACTIVE);
+    changeworkspace(std::to_string(PACTIVE->m_iWorkspaceID));
+    wlr_cursor_warp(g_pCompositor->m_sWLRCursor, g_pCompositor->m_sSeat.mouse->mouse, CURSOR_COORDS.x, CURSOR_COORDS.y);
 }
 
 void CKeybindManager::toggleGroup(std::string args) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -596,7 +596,6 @@ void CKeybindManager::moveInactiveTo(std::string args) {
     }
 
     g_pCompositor->focusWindow(PACTIVE);
-    changeworkspace(std::to_string(PACTIVE->m_iWorkspaceID));
     wlr_cursor_warp(g_pCompositor->m_sWLRCursor, g_pCompositor->m_sSeat.mouse->mouse, CURSOR_COORDS.x, CURSOR_COORDS.y);
 }
 

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -29,7 +29,6 @@ private:
     std::list<SKeybind> m_lKeybinds;
 
     bool                handleInternalKeybinds(xkb_keysym_t);
-    static void         moveWindowToWorkspace(CWindow*, int);
 
     inline static bool  m_bSuppressWorkspaceChangeEvents = false;
 

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -29,6 +29,7 @@ private:
     std::list<SKeybind> m_lKeybinds;
 
     bool                handleInternalKeybinds(xkb_keysym_t);
+    static void         moveWindowToWorkspace(CWindow*, int);
 
     inline static bool  m_bSuppressWorkspaceChangeEvents = false;
 
@@ -43,6 +44,7 @@ private:
     static void         moveActiveToWorkspaceSilent(std::string);
     static void         moveFocusTo(std::string);
     static void         moveActiveTo(std::string);
+    static void         moveInactiveTo(std::string);
     static void         toggleGroup(std::string);
     static void         changeGroupActive(std::string);
     static void         alterSplitRatio(std::string);


### PR DESCRIPTION
Adds the `movewindowinv` dispatcher, which is similar to `movewindow` but moves all windows within the active workspace _except_ the active window (and takes only a monitor as its argument). Useful for when you want to quickly give space to particular window. 

This also moves most of the code from the `moveActiveToWorkspace` method into a new method so that it can be used by the new dispatcher. I've tested both the `movewindowinv` dispatcher and the affected `movewindow` dispatcher.

Example config:
```
bind=SUPER,left,movewindowinv,l
bind=SUPER,right,movewindowinv,r
```

 
Demo video using the above config (I couldn't get the second monitor to be recorded, but that's where the windows are going):

https://user-images.githubusercontent.com/44363049/173507834-f6742ead-b32b-4622-801f-e3a143ea57e3.mp4