### PR TITLE
meson: build with -O3

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,15 @@
 project('Hyprland', 'cpp', 'c',
   version : '0.6.2beta',
-  default_options : ['warning_level=3', 'cpp_std=c++20', 'default_library=static'])
+  default_options : ['warning_level=2', 'cpp_std=c++20', 'default_library=static', 'optimization=3'])
+
+add_project_arguments(
+  [
+    '-Wno-unused-parameter',
+    '-Wno-unused-value',
+    '-Wno-missing-field-initializers',
+    '-Wno-narrowing',
+  ],
+  language: 'cpp')
 
 wlroots = subproject('wlroots', default_options: ['examples=false'])
 have_xwlr = wlroots.get_variable('features').get('xwayland')


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds `-O3` to builds by default.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No issues.

#### Is it ready for merging, or does it need work?
I'm also thinking of setting a lower default warning level, and using level 3 for debug builds. `-Wpedantic` is over-eagerly filling up the entire history of my terminal.
@sp1ritCS thoughts?

