### PR TITLE
Changed dispatcher: focusWindowByClass -> focusWindow. Now supports titles & classes

### DIFF
--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -61,7 +61,7 @@ private:
     static void         resizeActive(std::string);
     static void         moveActive(std::string);
     static void         circleNext(std::string);
-    static void         focusWindowByClass(std::string);
+    static void         focusWindow(std::string);
     static void         setSubmap(std::string);
 
     friend class CCompositor;


### PR DESCRIPTION
**Describe your PR, what does it fix/add?**
Before, you could only focus a window by a class and not differentiate ones of the same class. Now you can use a the title keyword, the same way as with window rules. 
title: `focuswindow title:^(.*)(WaniKani)(.*)$`
class: `focuswindow dolphin`

This is useful to, for example, sort multiple auto-launching browser windows to the right workspace. (I use it together with BroTab for Firefox to activate the right pinned tab beforehand)


**Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)**
focusWindow is backwards compatible to focusWindowByClass. So even though I removed it, I kept a dispatcher for focuswindowbyclass -> focusWindow to not break existing configs. 


**Is it ready for merging, or does it need work?**
ready

