### PR TITLE
Don't use the default nixpkgs.hyprland package in the nix flake

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -19,7 +19,7 @@ in {
 
     package = mkOption {
       type = types.package;
-      default = self.packages.${pkgs.system}.default;
+      default = self.packages.${pkgs.system}.default or pkgs.hyprland;
       defaultText = literalExpression "<Hyprland flake>.packages.<system>.default";
       example = literalExpression "<Hyprland flake>.packages.<system>.default.override { }";
       description = ''

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -19,7 +19,7 @@ in {
 
     package = mkOption {
       type = types.package;
-      default = self.packages.${pkgs.system}.default or pkgs.hyprland;
+      default = self.packages.${pkgs.system}.default;
       defaultText = literalExpression "<Hyprland flake>.packages.<system>.default";
       example = literalExpression "<Hyprland flake>.packages.<system>.default.override { }";
       description = ''

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -19,7 +19,7 @@ in {
 
     package = mkOption {
       type = types.package;
-      default = pkgs.hyprland or self.packages.${pkgs.system}.default;
+      default = self.packages.${pkgs.system}.default;
       defaultText = literalExpression "<Hyprland flake>.packages.<system>.default";
       example = literalExpression "<Hyprland flake>.packages.<system>.default.override { }";
       description = ''


### PR DESCRIPTION
After hyprland package was merged into nigpkgs, the following code in my NixOS flake no longer works:

```nix
modules = [
  hyprland.nixosModules.default
  { programs.hyprland.enable = true;}
];
```

`nixos-rebuild` fails with the following error:

```
error: Package, 'hyprland-0.6.1beta', did not specify any session names, as strings, in
       'passthru.providedSessions'. This is required when used as a session package.

       The session names can be looked up in:
         /nix/store/mblhy3nhyyycnblyx3038pl9md8xsf1b-hyprland-0.6.1beta/share/xsessions
         /nix/store/mblhy3nhyyycnblyx3038pl9md8xsf1b-hyprland-0.6.1beta/share/wayland-sessions
```

Seems like nixpkgs.hyprland is broken, but that's not the point of this PR.

For some reason the local flake uses that default package instead of the local one. If this was the intended behavior, can some nix guru explain me why?

It seems to me that if I am using custom git flake instead of nixpkgs it is reasonable to choose the package inside the flake by default.