### PR TITLE
Add 1:1 swipe gestures to switch workspaces

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -87,6 +87,8 @@ CCompositor::CCompositor() {
     m_sWLRCursor = wlr_cursor_create();
     wlr_cursor_attach_output_layout(m_sWLRCursor, m_sWLROutputLayout);
 
+    m_sWLRPointerGestures = wlr_pointer_gestures_v1_create(m_sWLDisplay);
+
     m_sWLRXCursorMgr = wlr_xcursor_manager_create(nullptr, 24);
     wlr_xcursor_manager_load(m_sWLRXCursorMgr, 1);
 
@@ -145,6 +147,9 @@ void CCompositor::initAllSignals() {
     addWLSignal(&m_sWLRCursor->events.button, &Events::listen_mouseButton, m_sWLRCursor, "WLRCursor");
     addWLSignal(&m_sWLRCursor->events.axis, &Events::listen_mouseAxis, m_sWLRCursor, "WLRCursor");
     addWLSignal(&m_sWLRCursor->events.frame, &Events::listen_mouseFrame, m_sWLRCursor, "WLRCursor");
+    addWLSignal(&m_sWLRCursor->events.swipe_begin, &Events::listen_swipeBegin, m_sWLRCursor, "WLRCursor");
+    addWLSignal(&m_sWLRCursor->events.swipe_update, &Events::listen_swipeUpdate, m_sWLRCursor, "WLRCursor");
+    addWLSignal(&m_sWLRCursor->events.swipe_end, &Events::listen_swipeEnd, m_sWLRCursor, "WLRCursor");
     addWLSignal(&m_sWLRBackend->events.new_input, &Events::listen_newInput, m_sWLRBackend, "Backend");
     addWLSignal(&m_sSeat.seat->events.request_set_cursor, &Events::listen_requestMouse, &m_sSeat, "Seat");
     addWLSignal(&m_sSeat.seat->events.request_set_selection, &Events::listen_requestSetSel, &m_sSeat, "Seat");

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -42,6 +42,7 @@ public:
     wlr_layer_shell_v1*              m_sWLRLayerShell;
     wlr_xdg_shell*                   m_sWLRXDGShell;
     wlr_cursor*                      m_sWLRCursor;
+    wlr_pointer_gestures_v1* m_sWLRPointerGestures;
     wlr_xcursor_manager*             m_sWLRXCursorMgr;
     wlr_virtual_keyboard_manager_v1* m_sWLRVKeyboardMgr;
     wlr_output_manager_v1*           m_sWLROutputMgr;

--- a/src/events/Devices.cpp
+++ b/src/events/Devices.cpp
@@ -60,6 +60,24 @@ void Events::listener_requestMouse(wl_listener* listener, void* data) {
     g_pInputManager->processMouseRequest(EVENT);
 }
 
+void Events::listener_swipeBegin(wl_listener* listener, void* data) {
+     const auto EVENT = (wlr_pointer_swipe_begin_event*)data;
+
+     g_pInputManager->onSwipeBegin(EVENT);
+}
+
+void Events::listener_swipeUpdate(wl_listener* listener, void* data) {
+     const auto EVENT = (wlr_pointer_swipe_update_event*)data;
+
+     g_pInputManager->onSwipeUpdate(EVENT);
+}
+
+void Events::listener_swipeEnd(wl_listener* listener, void* data) {
+     const auto EVENT = (wlr_pointer_swipe_end_event*)data;
+
+     g_pInputManager->onSwipeEnd(EVENT);
+}
+
 void Events::listener_newInput(wl_listener* listener, void* data) {
     const auto DEVICE = (wlr_input_device*)data;
 

--- a/src/events/Events.hpp
+++ b/src/events/Events.hpp
@@ -59,6 +59,10 @@ namespace Events {
     LISTENER(mouseButton);
     LISTENER(mouseAxis);
     LISTENER(mouseFrame);
+
+    LISTENER(swipeBegin);
+    LISTENER(swipeUpdate);
+    LISTENER(swipeEnd);
     
     LISTENER(newInput);
 

--- a/src/helpers/AnimatedVariable.cpp
+++ b/src/helpers/AnimatedVariable.cpp
@@ -13,7 +13,7 @@ void CAnimatedVariable::create(ANIMATEDVARTYPE type, float* speed, int64_t* enab
     m_pWindow = pWindow;
     m_pBezier = pBezier;
 
-    g_pAnimationManager->m_lAnimatedVariables.push_back(this);
+    registerAnim();
 
     m_bDummy = false;
 }
@@ -53,6 +53,10 @@ void CAnimatedVariable::create(ANIMATEDVARTYPE type, std::any val, float* speed,
 
 CAnimatedVariable::~CAnimatedVariable() {
     unregister();
+}
+
+void CAnimatedVariable::registerAnim() {
+    g_pAnimationManager->m_lAnimatedVariables.push_back(this);
 }
 
 void CAnimatedVariable::unregister() {

--- a/src/helpers/AnimatedVariable.hpp
+++ b/src/helpers/AnimatedVariable.hpp
@@ -29,6 +29,7 @@ public:
 
     ~CAnimatedVariable();
 
+    void registerAnim();
     void unregister();
 
     // gets the current vector value (real time)

--- a/src/helpers/Workspace.hpp
+++ b/src/helpers/Workspace.hpp
@@ -36,7 +36,8 @@ public:
     bool            m_bDefaultFloating = false;
     bool            m_bDefaultPseudo = false;
 
-    void            startAnim(bool in, bool left, bool instant = false);
+    void            startAnim(bool in, bool left, bool instant = false, bool tick = true, bool resetPosition = true);
+    void            setAnimProgress(float progress);
     void            setActive(bool on);
 
     void            moveToMonitor(const int&);

--- a/src/includes.hpp
+++ b/src/includes.hpp
@@ -40,6 +40,7 @@ extern "C" {
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/types/wlr_cursor.h>
+#include <wlr/types/wlr_pointer_gestures_v1.h>
 #include <wlr/types/wlr_data_control_v1.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_export_dmabuf_v1.h>

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -19,6 +19,9 @@ public:
     void            onMouseButton(wlr_pointer_button_event*);
     void            onKeyboardKey(wlr_keyboard_key_event*, SKeyboard*);
     void            onKeyboardMod(void*, SKeyboard*);
+    void            onSwipeBegin(wlr_pointer_swipe_begin_event*);
+    void            onSwipeUpdate(wlr_pointer_swipe_update_event* e);
+    void            onSwipeEnd(wlr_pointer_swipe_end_event*);
 
     void            newKeyboard(wlr_input_device*);
     void            newMouse(wlr_input_device*);
@@ -80,6 +83,32 @@ private:
     STabletTool*    ensureTabletToolPresent(wlr_tablet_tool*);
 
     void            applyConfigToKeyboard(SKeyboard*);
+
+    enum class SwipeDirection {
+        UNDECIDED,
+        UP, DOWN, LEFT, RIGHT
+    };
+
+    struct Swipe {
+        uint32_t fingers;
+        SwipeDirection dir;
+
+        double dx, dy;
+        float progress;
+        bool done;
+    };
+
+    struct WorkspaceSwipe {
+        Swipe swipe;
+        CWorkspace* from;
+        CWorkspace* to;
+
+        // animation ends at 300 pixels
+        // TODO define this as pixel agnostic?
+        int dxMax = 300;
+    };
+
+    WorkspaceSwipe* m_curSwipe = nullptr;
 };
 
 inline std::unique_ptr<CInputManager> g_pInputManager;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
I wrote this to enable one-to-one touchpad gestures to switch workspaces as it is a really nice feature to have on laptops.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I have not tested this with multiple monitors, but presumably it should work fine as it uses the same animations as normal workspace switching.
The gesture is broken if you try to switch between two workspaces that skip an ID, such as going from 3->5. This would have to be fixed before merging.

#### Is it ready for merging, or does it need work?
No: the bug described above needs to be fixed, and this needs testing under more configs than my own. It would also be a good idea to make this feature configurable (number of fingers, on/off, sensitivity).
Additionally, I left some comments marked TODO which indicate bits of code that, though functional, might need rethinking.
