### PR TITLE
meson: add -DGIT arguments

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,12 +4,22 @@ project('Hyprland', 'cpp', 'c',
 
 add_global_arguments('-std=c++23', language: 'cpp')
 
+GIT_BRANCH = run_command('git', 'rev-parse', '--abbrev-ref', 'HEAD', check: false).stdout().strip()
+GIT_COMMIT_HASH = run_command('git', 'rev-parse', 'HEAD', check: false).stdout().strip()
+GIT_COMMIT_MESSAGE = run_command('bash', '-c', 'git show | head -n 5 | tail -n 1', check: false).stdout().strip()
+GIT_DIRTY = run_command('bash', '-c', 'git diff-index --quiet HEAD -- || echo "dirty"', check: false).stdout().strip()
+
 add_project_arguments(
   [
     '-Wno-unused-parameter',
     '-Wno-unused-value',
     '-Wno-missing-field-initializers',
     '-Wno-narrowing',
+
+    f'-DGIT_BRANCH="@GIT_BRANCH@"',
+    f'-DGIT_COMMIT_HASH="@GIT_COMMIT_HASH@"',
+    f'-DGIT_COMMIT_MESSAGE="@GIT_COMMIT_MESSAGE@"',
+    f'-DGIT_DIRTY="@GIT_DIRTY@"',
   ],
   language: 'cpp')
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -5,6 +5,7 @@
   pkg-config,
   meson,
   ninja,
+  git,
   libdrm,
   libinput,
   libxcb,
@@ -36,6 +37,7 @@ stdenv.mkDerivation {
 
   buildInputs =
     [
+      git
       libdrm
       libinput
       libxcb


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds functionality like [this](https://github.com/hyprwm/Hyprland/blob/main/CMakeLists.txt#L12-L34) and [this](https://github.com/hyprwm/Hyprland/blob/main/CMakeLists.txt#L69-L72) to meson.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Compiling with the official meson instructions and then checking out `build/hyprctl/hyprctl version` yields the wrong result:
```
 › build/hyprctl/hyprctl version
Hyprland, built from branch ? at commit ?? (?).
flags: (if any)
debug
```

#### Is it ready for merging, or does it need work?
Still needs the above problem figuring out.

