### PR TITLE
nix: fix wallpaper location

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -61,6 +61,11 @@ stdenv.mkDerivation {
     ./meson-build.patch
   ];
 
+  # Fix hardcoded paths to /usr installation
+  postPatch = ''
+    sed -i "s#/usr#$out#" src/render/OpenGL.cpp
+  '';
+
   passthru.providedSessions = ["hyprland"];
 
   meta = with lib; {

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -926,6 +926,9 @@ void CHyprOpenGLImpl::createBGTextureForMonitor(SMonitor* pMonitor) {
 
     Debug::log(LOG, "Allocated texture for BGTex");
 
+    // TODO: use relative paths to the installation
+    // or configure the paths at build time
+
     // check if wallpapers exist
     if (!std::filesystem::exists("/usr/share/hyprland/wall_8K.png"))
         return; // the texture will be empty, oh well. We'll clear with a solid color anyways.


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes nix's build to search for the default walls in the correct place.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

As the TODO says, it would be nice to have those paths configured at build time, but this will do.

#### Is it ready for merging, or does it need work?

Ready.
