### PR TITLE
Add switching to previous workspace

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -35,6 +35,7 @@ void CConfigManager::setDefaultVars() {
     configValues["general:main_mod"].strValue = "SUPER";                                               // exposed to the user for easier configuring
     configValues["general:main_mod_internal"].intValue = g_pKeybindManager->stringToModMask("SUPER");  // actually used and automatically calculated
     configValues["general:workspace_back_and_forth"].intValue = 0;
+    configValues["general:allow_workspace_cycles"].intValue = 0;
 
     configValues["general:damage_tracking"].strValue = "full";
     configValues["general:damage_tracking_internal"].intValue = DAMAGE_TRACKING_FULL;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -34,8 +34,6 @@ void CConfigManager::setDefaultVars() {
     configValues["general:apply_sens_to_raw"].intValue = 0;
     configValues["general:main_mod"].strValue = "SUPER";                                               // exposed to the user for easier configuring
     configValues["general:main_mod_internal"].intValue = g_pKeybindManager->stringToModMask("SUPER");  // actually used and automatically calculated
-    configValues["general:workspace_back_and_forth"].intValue = 0;
-    configValues["general:allow_workspace_cycles"].intValue = 0;
 
     configValues["general:damage_tracking"].strValue = "full";
     configValues["general:damage_tracking_internal"].intValue = DAMAGE_TRACKING_FULL;
@@ -142,6 +140,8 @@ void CConfigManager::setDefaultVars() {
 
     configValues["binds:pass_mouse_when_bound"].intValue = 1;
     configValues["binds:scroll_event_delay"].intValue = 300;
+    configValues["binds:workspace_back_and_forth"].intValue = 0;
+    configValues["binds:allow_workspace_cycles"].intValue = 0;
 
     configValues["gestures:workspace_swipe"].intValue = 0;
     configValues["gestures:workspace_swipe_fingers"].intValue = 3;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -34,6 +34,7 @@ void CConfigManager::setDefaultVars() {
     configValues["general:apply_sens_to_raw"].intValue = 0;
     configValues["general:main_mod"].strValue = "SUPER";                                               // exposed to the user for easier configuring
     configValues["general:main_mod_internal"].intValue = g_pKeybindManager->stringToModMask("SUPER");  // actually used and automatically calculated
+    configValues["general:workspace_back_and_forth"].intValue = 0;
 
     configValues["general:damage_tracking"].strValue = "full";
     configValues["general:damage_tracking_internal"].intValue = DAMAGE_TRACKING_FULL;

--- a/src/helpers/Workspace.hpp
+++ b/src/helpers/Workspace.hpp
@@ -20,7 +20,7 @@ public:
     uint64_t        m_iMonitorID = -1;
     // Previous workspace ID is stored during a workspace change, allowing travel
     // to the previous workspace.
-    int m_iPrevWorkspaceID = -1;
+    int             m_iPrevWorkspaceID = -1;
     bool            m_bHasFullscreenWindow = false;
     eFullscreenMode m_efFullscreenMode = FULLSCREEN_FULL;
 

--- a/src/helpers/Workspace.hpp
+++ b/src/helpers/Workspace.hpp
@@ -18,6 +18,9 @@ public:
     int             m_iID = -1;
     std::string     m_szName = "";
     uint64_t        m_iMonitorID = -1;
+    // Previous workspace ID is stored during a workspace change, allowing travel
+    // to the previous workspace.
+    int m_iPrevWorkspaceID = -1;
     bool            m_bHasFullscreenWindow = false;
     eFullscreenMode m_efFullscreenMode = FULLSCREEN_FULL;
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -454,11 +454,31 @@ void CKeybindManager::changeworkspace(std::string args) {
     int workspaceToChangeTo = 0;
     std::string workspaceName = "";
 
+    // Flag needed so that the previous workspace is not recorded when switching
+    // to a previous workspace.
+    bool isSwitchingToPrevious = false;
+
     if (args.find("[internal]") == 0) {
         workspaceToChangeTo = std::stoi(args.substr(10));
         const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(workspaceToChangeTo);
         if (PWORKSPACE)
             workspaceName = PWORKSPACE->m_szName;
+    } else if (args.find("previous") == 0) {
+        const auto P_MONITOR = g_pCompositor->getMonitorFromCursor();
+        const auto P_CURRENT_WORKSPACE = g_pCompositor->getWorkspaceByID(P_MONITOR->activeWorkspace);
+
+        // Do nothing if there's no previous workspace, otherwise switch to it.
+        if (P_CURRENT_WORKSPACE->m_iPrevWorkspaceID == -1) {
+            Debug::log(LOG, "No previous workspace to change to");
+            return;
+        }
+        else {
+            workspaceToChangeTo = P_CURRENT_WORKSPACE->m_iPrevWorkspaceID;
+            isSwitchingToPrevious = true;
+
+            // TODO: Add support for cycles
+            P_CURRENT_WORKSPACE->m_iPrevWorkspaceID = -1;
+        }
     } else {
         workspaceToChangeTo = getWorkspaceIDFromString(args, workspaceName);
     }
@@ -476,6 +496,10 @@ void CKeybindManager::changeworkspace(std::string args) {
         const auto PMONITOR = g_pCompositor->getMonitorFromID(g_pCompositor->getWorkspaceByID(workspaceToChangeTo)->m_iMonitorID);
 
         const auto PWORKSPACETOCHANGETO = g_pCompositor->getWorkspaceByID(workspaceToChangeTo);
+
+        if (!isSwitchingToPrevious)
+            // Remember previous workspace.
+            PWORKSPACETOCHANGETO->m_iPrevWorkspaceID = g_pCompositor->getMonitorFromCursor()->activeWorkspace;
 
         if (workspaceToChangeTo == SPECIAL_WORKSPACE_ID)
             PWORKSPACETOCHANGETO->m_iMonitorID = PMONITOR->ID;
@@ -540,6 +564,10 @@ void CKeybindManager::changeworkspace(std::string args) {
         POLDWORKSPACE->startAnim(false, ANIMTOLEFT);
 
     const auto PWORKSPACE = g_pCompositor->m_vWorkspaces.emplace_back(std::make_unique<CWorkspace>(PMONITOR->ID, workspaceName, workspaceToChangeTo == SPECIAL_WORKSPACE_ID)).get();
+
+    if (!isSwitchingToPrevious)
+        // Remember previous workspace.
+        PWORKSPACE->m_iPrevWorkspaceID = OLDWORKSPACE;
 
     // start anim on new workspace
     PWORKSPACE->startAnim(true, ANIMTOLEFT);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -465,7 +465,7 @@ void CKeybindManager::changeworkspace(std::string args) {
             workspaceName = PWORKSPACE->m_szName;
     } else if (args.find("previous") == 0) {
         const auto PCURRENTWORKSPACE = g_pCompositor->getWorkspaceByID(
-            g_pCompositor->getMonitorFromCursor()->activeWorkspace);
+            g_pCompositor->m_pLastMonitor->activeWorkspace);
 
         // Do nothing if there's no previous workspace, otherwise switch to it.
         if (PCURRENTWORKSPACE->m_iPrevWorkspaceID == -1) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -464,8 +464,8 @@ void CKeybindManager::changeworkspace(std::string args) {
         if (PWORKSPACE)
             workspaceName = PWORKSPACE->m_szName;
     } else if (args.find("previous") == 0) {
-        const auto P_MONITOR = g_pCompositor->getMonitorFromCursor();
-        const auto P_CURRENT_WORKSPACE = g_pCompositor->getWorkspaceByID(P_MONITOR->activeWorkspace);
+        const auto P_CURRENT_WORKSPACE = g_pCompositor->getWorkspaceByID(
+            g_pCompositor->getMonitorFromCursor()->activeWorkspace);
 
         // Do nothing if there's no previous workspace, otherwise switch to it.
         if (P_CURRENT_WORKSPACE->m_iPrevWorkspaceID == -1) {
@@ -486,6 +486,21 @@ void CKeybindManager::changeworkspace(std::string args) {
     if (workspaceToChangeTo == INT_MAX) {
         Debug::log(ERR, "Error in changeworkspace, invalid value");
         return;
+    }
+
+    // Workspace_back_and_forth being enabled means that an attempt to switch to 
+    // the current workspace will instead switch to the previous.
+    if (g_pConfigManager->getConfigValuePtr("general:workspace_back_and_forth")->intValue == 1
+        && g_pCompositor->getMonitorFromCursor()->activeWorkspace == workspaceToChangeTo) {
+        
+        const auto P_CURRENT_WORKSPACE = g_pCompositor->getWorkspaceByID(
+            g_pCompositor->getMonitorFromCursor()->activeWorkspace);
+
+        workspaceToChangeTo = P_CURRENT_WORKSPACE->m_iPrevWorkspaceID;
+        isSwitchingToPrevious = true;
+
+        // TODO: Add support for cycles
+        P_CURRENT_WORKSPACE->m_iPrevWorkspaceID = -1;
     }
 
     // remove constraints 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -493,11 +493,12 @@ void CKeybindManager::changeworkspace(std::string args) {
 
     // Workspace_back_and_forth being enabled means that an attempt to switch to 
     // the current workspace will instead switch to the previous.
+    const auto PCURRENTWORKSPACE = g_pCompositor->getWorkspaceByID(
+        g_pCompositor->m_pLastMonitor->activeWorkspace);
     static auto *const PBACKANDFORTH = &g_pConfigManager->getConfigValuePtr("binds:workspace_back_and_forth")->intValue;
-    if (*PBACKANDFORTH && g_pCompositor->m_pLastMonitor->activeWorkspace == workspaceToChangeTo) {
-        
-        const auto PCURRENTWORKSPACE = g_pCompositor->getWorkspaceByID(
-            g_pCompositor->m_pLastMonitor->activeWorkspace);
+    if (*PBACKANDFORTH 
+        && PCURRENTWORKSPACE->m_iID == workspaceToChangeTo
+        && PCURRENTWORKSPACE->m_iPrevWorkspaceID != -1) {
 
         workspaceToChangeTo = PCURRENTWORKSPACE->m_iPrevWorkspaceID;
         isSwitchingToPrevious = true;

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -476,8 +476,10 @@ void CKeybindManager::changeworkspace(std::string args) {
             workspaceToChangeTo = P_CURRENT_WORKSPACE->m_iPrevWorkspaceID;
             isSwitchingToPrevious = true;
 
-            // TODO: Add support for cycles
-            P_CURRENT_WORKSPACE->m_iPrevWorkspaceID = -1;
+            // If the previous workspace ID isn't reset, cycles can form when continually going
+            // to the previous workspace again and again.
+            if (!g_pConfigManager->getConfigValuePtr("general:allow_workspace_cycles")->intValue)
+                P_CURRENT_WORKSPACE->m_iPrevWorkspaceID = -1;
         }
     } else {
         workspaceToChangeTo = getWorkspaceIDFromString(args, workspaceName);
@@ -499,8 +501,10 @@ void CKeybindManager::changeworkspace(std::string args) {
         workspaceToChangeTo = P_CURRENT_WORKSPACE->m_iPrevWorkspaceID;
         isSwitchingToPrevious = true;
 
-        // TODO: Add support for cycles
-        P_CURRENT_WORKSPACE->m_iPrevWorkspaceID = -1;
+        // If the previous workspace ID isn't reset, cycles can form when continually going
+        // to the previous workspace again and again.
+        if (!g_pConfigManager->getConfigValuePtr("general:allow_workspace_cycles")->intValue)
+            P_CURRENT_WORKSPACE->m_iPrevWorkspaceID = -1;
     }
 
     // remove constraints 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Add the ability to switch to the last visited workspace as described in #324, inspired by i3. The syntax suggested in the issue has been adopted: `bind=MODIFIER,KEY,workspace,previous`.

Also included is a toggle setting `general:auto_back_and_forth` to allow switching back to the previous workspace by trying to switch to the same workspace again. I use it all the time in sway and my workflow would be _greatly_ improved by the ability to quickly switch to and from a workspace to check on email, discord, spotify, etc. 
E.g. start in workspace 1, then `Super+7` to workspace 7, and then `Super+7` again will move to workspace 1. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I've moved a lot of code from `CKeybindManager::changeworkspace` to `CCompositor::changeWorkspace`, to make it easier to reuse the raw workspace switching.

This is also my first pull request, so my apologies if I've broken any conventions, just let me know and I'll fix it. I'm also not super experienced with C++, but I think I worked out enough for this small change.

#### Is it ready for merging, or does it need work?
Yes it's ready as far as I know (it builds and works in debug mode). However:

- I'm not sure if I've put `m_bAutoBackAndForth` in the right place - let me know if there's somewhere else for settings like that to go.
- Not sure if some hyprctl commands need to be added too.
- Of course wiki updates will be necessary too, but I don't know how that's normally done.