### PR TITLE
Fix error when running `hyprctl dispatch exec` with an arg that contains a `/`

### DIFF
--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -159,7 +159,7 @@ void dispatchRequest(int argc, char** argv) {
         return;
     }
 
-    std::string rq = "dispatch " + std::string(argv[2]) + " " + std::string(argv[3]);
+    std::string rq = "/dispatch " + std::string(argv[2]) + " " + std::string(argv[3]);
 
     request(rq);
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Stops `hyprctl` from failing when running a `dispatch exec <something>` when `<something>` contains a `/` character, like a file path.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No, its a small change just to fix this issue.

#### Is it ready for merging, or does it need work?
Should be ready.

