### PR TITLE
docs: add man pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ PKGS = wlroots wayland-server xcb xkbcommon libinput
 CFLAGS += $(foreach p,$(PKGS),$(shell pkg-config --cflags $(p)))
 LDLIBS += $(foreach p,$(PKGS),$(shell pkg-config --libs $(p)))
 
+VERSION=0.7.1beta
+DATE=$(shell date "+%d %b %Y")
+
 xdg-shell-protocol.h:
 	$(WAYLAND_SCANNER) server-header \
 		$(WAYLAND_PROTOCOLS)/stable/xdg-shell/xdg-shell.xml $@
@@ -124,8 +127,7 @@ install:
 	cp ./assets/wall_4K.png ${PREFIX}/share/hyprland
 	cp ./assets/wall_8K.png ${PREFIX}/share/hyprland
 
-	rst2man ./docs/hyprctl.1.rst | gzip -c > /usr/share/man/man1/hyprctl.1.gz
-	rst2man ./docs/Hyprland.1.rst | gzip -c > /usr/share/man/man1/Hyprland.1.gz
+	make man
 
 uninstall:
 	rm -f ${PREFIX}/share/wayland-sessions/hyprland.desktop
@@ -150,3 +152,22 @@ config:
 	cd subprojects/wlroots && ninja -C build/
 
 	cd subprojects/wlroots && ninja -C build/ install
+
+man:
+	pandoc ./docs/Hyprland.1.rst \
+		--standalone \
+		--variable=header:"Hyprland User Manual" \
+		--variable=footer:${VERSION} \
+		--variable=date:"${DATE}" \
+		--variable=section:1 \
+		--from rst \
+		--to man | gzip -c > /usr/share/man/man1/Hyprland.1.gz
+
+	pandoc ./docs/hyprctl.1.rst \
+		--standalone \
+		--variable=header:"hyprctl User Manual" \
+		--variable=footer:${VERSION} \
+		--variable=date:"${DATE}" \
+		--variable=section:1 \
+		--from rst \
+		--to man | gzip -c > /usr/share/man/man1/hyprctl.1.gz

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ PKGS = wlroots wayland-server xcb xkbcommon libinput
 CFLAGS += $(foreach p,$(PKGS),$(shell pkg-config --cflags $(p)))
 LDLIBS += $(foreach p,$(PKGS),$(shell pkg-config --libs $(p)))
 
-VERSION=0.7.1beta
 DATE=$(shell date "+%d %b %Y")
 
 xdg-shell-protocol.h:
@@ -157,7 +156,6 @@ man:
 	pandoc ./docs/Hyprland.1.rst \
 		--standalone \
 		--variable=header:"Hyprland User Manual" \
-		--variable=footer:${VERSION} \
 		--variable=date:"${DATE}" \
 		--variable=section:1 \
 		--from rst \
@@ -166,7 +164,6 @@ man:
 	pandoc ./docs/hyprctl.1.rst \
 		--standalone \
 		--variable=header:"hyprctl User Manual" \
-		--variable=footer:${VERSION} \
 		--variable=date:"${DATE}" \
 		--variable=section:1 \
 		--from rst \

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,8 @@ install:
 	cp ./assets/wall_4K.png ${PREFIX}/share/hyprland
 	cp ./assets/wall_8K.png ${PREFIX}/share/hyprland
 
+	rst2man ./docs/hyprctl.1.rst | gzip -c > /usr/share/man/man1/hyprctl.1.gz
+	rst2man ./docs/Hyprland.1.rst | gzip -c > /usr/share/man/man1/Hyprland.1.gz
 
 uninstall:
 	rm -f ${PREFIX}/share/wayland-sessions/hyprland.desktop

--- a/docs/Hyprland.1.rst
+++ b/docs/Hyprland.1.rst
@@ -1,30 +1,24 @@
-========
-Hyprland
-========
+:title: Hyprland
+:author: Vaxerski <*https://github.com/vaxerski*>
 
----------------------------------
-Dynamic tiling Wayland compositor
----------------------------------
+NAME
+====
 
-:Date: 15 Jul 2022
-:Copyright: Copyright (c) 2022, vaxerski
-:Version: 0.7.1beta
-:Manual section: 1
-:Manual group: Hyprland
+Hyprland - Dynamic tiling Wayland compositor
 
 SYNOPSIS
 ========
 
-``Hyprland`` [arg [...]].
+**Hyprland** [*arg [...]*].
 
 DESCRIPTION
 ===========
 
-``Hyprland`` is a dynamic tiling Wayland compositor based on
+**Hyprland** is a dynamic tiling Wayland compositor based on
 wlroots that doesn't sacrifice on its looks.
 
 You can launch Hyprland by either going into a TTY and
-executing ``Hyprland``, or with a login manager.
+executing **Hyprland**, or with a login manager.
 
 NOTICE
 ======
@@ -36,30 +30,29 @@ Although Hyprland is pretty stable, it may have some bugs.
 CONFIGURATION
 =============
 
-For configuration information please see <`https://github.com/hyprwm/Hyprland/wiki`>.
+For configuration information please see <*https://github.com/hyprwm/Hyprland/wiki*>.
 
 OPTIONS
 =======
 
--h, --help
+**-h**, **--help**
     Show command usage.
 
--c, --config
+**-c**, **--config**
     Specify config file to use.
 
 BUGS
 ====
 
 Submit bug reports and request features online at:
-
-    <`https://github.com/hyprwm/Hyprland/issues`>
+    <*https://github.com/hyprwm/Hyprland/issues*>
 
 SEE ALSO
 ========
 
-Sources at: <`https://github.com/hyprwm/Hyprland`>
+Sources at: <*https://github.com/hyprwm/Hyprland*>
 
-AUTHORS
-=======
+COPYRIGHT
+=========
 
-Vaxerski <`https://github.com/vaxerski`>
+Copyright (c) 2022, vaxerski

--- a/docs/Hyprland.1.rst
+++ b/docs/Hyprland.1.rst
@@ -52,7 +52,7 @@ OPTIONS
 =======
 
 -h, --help
-    Show this help message.
+    Show command usage.
 
 -c, --config
     Specify config file to use.
@@ -60,7 +60,7 @@ OPTIONS
 BUGS
 ====
 
-Submit bug reports and feature requests online at:
+Submit bug reports and request features online at:
 
     <`https://github.com/hyprwm/Hyprland/issues`>
 

--- a/docs/Hyprland.1.rst
+++ b/docs/Hyprland.1.rst
@@ -10,7 +10,7 @@ Dynamic tiling Wayland compositor
 :Copyright: Copyright (c) 2022, vaxerski
 :Version: 0.7.1beta
 :Manual section: 1
-:Manual group: HYPRLAND
+:Manual group: Hyprland
 
 SYNOPSIS
 ========
@@ -23,6 +23,9 @@ DESCRIPTION
 ``Hyprland`` is a dynamic tiling Wayland compositor based on
 wlroots that doesn't sacrifice on its looks.
 
+You can launch Hyprland by either going into a TTY and
+executing ``Hyprland``, or with a login manager.
+
 NOTICE
 ======
 
@@ -34,19 +37,6 @@ CONFIGURATION
 =============
 
 For configuration information please see <`https://github.com/hyprwm/Hyprland/wiki`>.
-
-LAUNCHING
-=========
-
-You can launch Hyprland by either going into a TTY and executing ``Hyprland``, or with a login manager.
-
-`IMPORTANT`: Do `not` launch ``Hyprland`` with `root` permissions (don't `sudo`)
-
-Login managers are not officially supported, but here's a short compatibility list:
-
-    * SDDM -> Works flawlessly.
-    * GDM -> Works with the caveat of crashing `Hyprland` on the first launch.
-    * ly -> Works with minor issues and/or caveats.
 
 OPTIONS
 =======

--- a/docs/Hyprland.1.rst
+++ b/docs/Hyprland.1.rst
@@ -1,0 +1,75 @@
+========
+Hyprland
+========
+
+---------------------------------
+Dynamic tiling Wayland compositor
+---------------------------------
+
+:Date: 15 Jul 2022
+:Copyright: Copyright (c) 2022, vaxerski
+:Version: 0.7.1beta
+:Manual section: 1
+:Manual group: HYPRLAND
+
+SYNOPSIS
+========
+
+``Hyprland`` [arg [...]].
+
+DESCRIPTION
+===========
+
+``Hyprland`` is a dynamic tiling Wayland compositor based on
+wlroots that doesn't sacrifice on its looks.
+
+NOTICE
+======
+
+Hyprland is still in pretty early development compared to some other Wayland compositors.
+
+Although Hyprland is pretty stable, it may have some bugs.
+
+CONFIGURATION
+=============
+
+For configuration information please see <`https://github.com/hyprwm/Hyprland/wiki`>.
+
+LAUNCHING
+=========
+
+You can launch Hyprland by either going into a TTY and executing ``Hyprland``, or with a login manager.
+
+`IMPORTANT`: Do `not` launch ``Hyprland`` with `root` permissions (don't `sudo`)
+
+Login managers are not officially supported, but here's a short compatibility list:
+
+    * SDDM -> Works flawlessly.
+    * GDM -> Works with the caveat of crashing `Hyprland` on the first launch.
+    * ly -> Works with minor issues and/or caveats.
+
+OPTIONS
+=======
+
+-h, --help
+    Show this help message.
+
+-c, --config
+    Specify config file to use.
+
+BUGS
+====
+
+Submit bug reports and feature requests online at:
+
+    <`https://github.com/hyprwm/Hyprland/issues`>
+
+SEE ALSO
+========
+
+Sources at: <`https://github.com/hyprwm/Hyprland`>
+
+AUTHORS
+=======
+
+Vaxerski <`https://github.com/vaxerski`>

--- a/docs/hyprctl.1.rst
+++ b/docs/hyprctl.1.rst
@@ -21,7 +21,6 @@ DESCRIPTION
 ===========
 
 ``hyprctl`` is a utility for controlling some parts of the compositor from a CLI or a script.
-If you install with make install, or any package, it should automatically be installed.
 
 COMMANDS
 ========

--- a/docs/hyprctl.1.rst
+++ b/docs/hyprctl.1.rst
@@ -1,0 +1,131 @@
+=======
+hyprctl
+=======
+
+----------------------------------------------------------------
+Utility for controlling parts of Hyprland from a CLI or a script
+----------------------------------------------------------------
+
+:Date: 15 Jul 2022
+:Copyright: Copyright (c) 2022, vaxerski
+:Version: 0.7.1beta
+:Manual section: 1
+:Manual group: hyprctl
+
+SYNOPSIS
+========
+
+``hyprctl`` [(opt)flags] [command] [(opt)args]
+
+DESCRIPTION
+===========
+
+``hyprctl`` is a utility for controlling some parts of the compositor from a CLI or a script.
+If you install with make install, or any package, it should automatically be installed.
+
+COMMANDS
+========
+
+Control
+
+    ``dispatch``
+
+        Call a keybinding dispatcher with an argument.
+
+        An argument must be present.
+        For dispatchers without parameters it can be anything.
+
+        Returns: `ok` on success, and an error message on failure.
+
+        Examples:
+
+            ``hyprctl`` `dispatch exec kitty`
+
+            ``hyprctl`` `dispatch pseudo x`
+
+    ``keyword``
+
+        Call a config keyword dynamically.
+
+        Returns: `ok` on success, and an error message on failure.
+
+        Examples:
+
+            ``hyprctl`` `keyword bind SUPER,0,pseudo`
+
+            ``hyprctl`` `keyword general:border_size 10`
+
+    ``reload``
+
+        Force a reload of the config file.
+
+    ``kill``
+
+        Enter kill mode, where you can kill an app by clicking on it.
+        You can exit with ESCAPE.
+
+Info
+
+    ``version``
+
+        Prints the hyprland version, meaning flags, commit and branch of build.
+
+    ``monitors``
+
+        Lists all the outputs with their properties.
+
+    ``workspaces``
+
+        Lists all workspaces with their properties.
+
+    ``clients``
+
+        Lists all windows with their properties.
+
+    ``devices``
+
+        Lists all connected keyboards and mice.
+
+    ``activewindow``
+
+        Gets the active window name.
+
+    ``layers``
+
+        Lists all the layers.
+
+    ``splash``
+
+        Prints the current random splash.
+
+OPTIONS
+=======
+
+--batch
+    Specify a batch of commands to execute.
+
+    Example:
+
+        ``hyprctl`` `--batch "keyword general:border_size 2 ; keyword general:gaps_out 20"`
+
+        `;` separates the commands.
+
+-j
+    Outputs information in JSON.
+
+BUGS
+====
+
+Submit bug reports and feature requests online at:
+
+    <`https://github.com/hyprwm/hyprctl/issues`>
+
+SEE ALSO
+========
+
+Sources at: <`https://github.com/hyprwm/hyprctl`>
+
+AUTHORS
+=======
+
+Vaxerski  <`https://github.com/vaxerski`>

--- a/docs/hyprctl.1.rst
+++ b/docs/hyprctl.1.rst
@@ -1,130 +1,121 @@
-=======
-hyprctl
-=======
+:title: hyprctl(1)
+:author: Vaxerski <*https://github.com/vaxerski*>
 
-----------------------------------------------------------------
-Utility for controlling parts of Hyprland from a CLI or a script
-----------------------------------------------------------------
+NAME
+====
 
-:Date: 15 Jul 2022
-:Copyright: Copyright (c) 2022, vaxerski
-:Version: 0.7.1beta
-:Manual section: 1
-:Manual group: hyprctl
+hyprctl - Utility for controlling parts of Hyprland from a CLI or a script
 
 SYNOPSIS
 ========
 
-``hyprctl`` [(opt)flags] [command] [(opt)args]
+**hyprctl** [*(opt)flags*] [**command**] [*(opt)args*]
 
 DESCRIPTION
 ===========
 
-``hyprctl`` is a utility for controlling some parts of the compositor from a CLI or a script.
+**hyprctl** is a utility for controlling some parts of the compositor from a CLI or a script.
 
-COMMANDS
-========
+CONTROL COMMANDS
+================
 
-Control
+**dispatch**
 
-    ``dispatch``
+    Call a dispatcher with an argument.
 
-        Call a dispatcher with an argument.
+    An argument must be present.
+    For dispatchers without parameters it can be anything.
 
-        An argument must be present.
-        For dispatchers without parameters it can be anything.
+    Returns: *ok* on success, and an error message on failure.
 
-        Returns: `ok` on success, and an error message on failure.
+    Examples:
+        **hyprctl** *dispatch exec kitty*
 
-        Examples:
+        **hyprctl** *dispatch pseudo x*
 
-            ``hyprctl`` `dispatch exec kitty`
+**keyword**
 
-            ``hyprctl`` `dispatch pseudo x`
+    Set a config keyword dynamically.
 
-    ``keyword``
+    Returns: *ok* on success, and an error message on failure.
 
-        Set a config keyword dynamically.
+    Examples:
+        **hyprctl** *keyword bind SUPER,0,pseudo*
 
-        Returns: `ok` on success, and an error message on failure.
+        **hyprctl** *keyword general:border_size 10*
 
-        Examples:
+**reload**
 
-            ``hyprctl`` `keyword bind SUPER,0,pseudo`
+    Force a reload of the config file.
 
-            ``hyprctl`` `keyword general:border_size 10`
+**kill**
 
-    ``reload``
+    Enter kill mode, where you can kill an app by clicking on it.
+    You can exit by pressing ESCAPE.
 
-        Force a reload of the config file.
+INFO COMMANDS
+=============
 
-    ``kill``
+**version**
 
-        Enter kill mode, where you can kill an app by clicking on it.
-        You can exit by pressing ESCAPE.
+    Prints the Hyprland version, flags, commit and branch of build.
 
-Info
+**monitors**
 
-    ``version``
+    Lists all the outputs with their properties.
 
-        Prints the Hyprland version, flags, commit and branch of build.
+**workspaces**
 
-    ``monitors``
+    Lists all workspaces with their properties.
 
-        Lists all the outputs with their properties.
+**clients**
 
-    ``workspaces``
+    Lists all windows with their properties.
 
-        Lists all workspaces with their properties.
+**devices**
 
-    ``clients``
+    Lists all connected input devices.
 
-        Lists all windows with their properties.
+**activewindow**
 
-    ``devices``
+    Returns the active window name.
 
-        Lists all connected input devices.
+**layers**
 
-    ``activewindow``
+    Lists all the layers.
 
-        Returns the active window name.
+**splash**
 
-    ``layers``
-
-        Lists all the layers.
-
-    ``splash``
-
-        Returns the current random splash.
+    Returns the current random splash.
 
 OPTIONS
 =======
 
---batch
+**--batch**
+
     Specify a batch of commands to execute.
 
     Example:
+        **hyprctl** *--batch "keyword general:border_size 2 ; keyword general:gaps_out 20"*
 
-        ``hyprctl`` `--batch "keyword general:border_size 2 ; keyword general:gaps_out 20"`
+        *;* separates the commands.
 
-        `;` separates the commands.
+**-j**
 
--j
     Outputs information in JSON.
 
 BUGS
 ====
 
-Submit bug reports and feature requests online at:
-
-    <`https://github.com/hyprwm/hyprctl/issues`>
+Submit bug reports and request features online at:
+    <*https://github.com/hyprwm/Hyprland/issues*>
 
 SEE ALSO
 ========
 
-Sources at: <`https://github.com/hyprwm/hyprctl`>
+Sources at: <*https://github.com/hyprwm/Hyprland*>
 
-AUTHORS
-=======
+COPYRIGHT
+=========
 
-Vaxerski  <`https://github.com/vaxerski`>
+Copyright (c) 2022, vaxerski

--- a/docs/hyprctl.1.rst
+++ b/docs/hyprctl.1.rst
@@ -30,7 +30,7 @@ Control
 
     ``dispatch``
 
-        Call a keybinding dispatcher with an argument.
+        Call a dispatcher with an argument.
 
         An argument must be present.
         For dispatchers without parameters it can be anything.
@@ -45,7 +45,7 @@ Control
 
     ``keyword``
 
-        Call a config keyword dynamically.
+        Set a config keyword dynamically.
 
         Returns: `ok` on success, and an error message on failure.
 
@@ -62,13 +62,13 @@ Control
     ``kill``
 
         Enter kill mode, where you can kill an app by clicking on it.
-        You can exit with ESCAPE.
+        You can exit by pressing ESCAPE.
 
 Info
 
     ``version``
 
-        Prints the hyprland version, meaning flags, commit and branch of build.
+        Prints the Hyprland version, flags, commit and branch of build.
 
     ``monitors``
 
@@ -84,11 +84,11 @@ Info
 
     ``devices``
 
-        Lists all connected keyboards and mice.
+        Lists all connected input devices.
 
     ``activewindow``
 
-        Gets the active window name.
+        Returns the active window name.
 
     ``layers``
 
@@ -96,7 +96,7 @@ Info
 
     ``splash``
 
-        Prints the current random splash.
+        Returns the current random splash.
 
 OPTIONS
 =======


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This PR adds a man page for both `Hyprland` and `hyprctl`.

The man pages are written in `.rst` format so it is easy to read and edit.

`rst2man` is used during install to convert the pages. They are then piped into `gzip` for compression and finally written to the proper man directory.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
There should be no bugs added as there is no code changed except for the two lines added into the Makefile.

#### Is it ready for merging, or does it need work?
This is ready to be merged afaik.

The man pages can be extended later to include a `Hyprland-conf.5` page for configurations.

Let me know of anything you would change. I have built and tested using the cmake method from the documentation.

To test the man pages you do not need to build the whole program. You can use `rst2man ./docs/hyprctl.1.rst | man -l -`

`python-docutils` for Arch should probably be added as a build dependency in the wiki when this is merged.