### PR TITLE
nix: add home-manager module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,7 @@
     formatter = genSystems (system: pkgsFor.${system}.alejandra);
 
     nixosModules.default = import ./nix/module.nix self;
+    homeManagerModules.default = import ./nix/hm-module.nix self;
 
     overlay = throw "Hyprland: .overlay output is deprecated, please use the .overlays.default output";
   };

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -1,0 +1,98 @@
+self: {
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.wayland.windowManager.hyprland;
+  defaultHyprlandPackage = self.packages.${pkgs.system}.default.override {
+    enableXWayland = cfg.xwayland;
+  };
+in {
+  options.wayland.windowManager.hyprland = {
+    enable = lib.mkEnableOption "hyprland wayland compositor";
+    package = lib.mkOption {
+      type = with lib.types; nullOr package;
+      default = defaultHyprlandPackage;
+      description = ''
+        Hyprland package to use. Will override the 'xwayland' option.
+
+        Defaults to the one provided by the flake. Set it to
+        <literal>pkgs.hyprland</literal> to use the one provided by nixpkgs or
+        if you have an overlay.
+
+        Set to null to not add any Hyprland package to your path. This should
+        be done if you want to use the NixOS module to install Hyprland.
+      '';
+    };
+    systemdIntegration = lib.mkOption {
+      type = lib.types.bool;
+      default = pkgs.stdenv.isLinux;
+      description = ''
+        Whether to enable <filename>hyprland-session.target</filename> on
+        hyprland startup. This links to <filename>graphical-session.target</filename>.
+        Some important environment variables will be imported to systemd
+        and dbus user environment before reaching the target, including
+        <itemizedlist>
+          <listitem><para><literal>DISPLAY</literal></para></listitem>
+          <listitem><para><literal>WAYLAND_DISPLAY</literal></para></listitem>
+          <listitem><para><literal>HYPRLAND_INSTANCE_SIGNATURE</literal></para></listitem>
+          <listitem><para><literal>XDG_CURRENT_DESKTOP</literal></para></listitem>
+        </itemizedlist>
+      '';
+    };
+    xwayland = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Enable xwayland.
+      '';
+    };
+
+    extraConfig = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      description = ''
+        Extra configuration lines to add to ~/.config/hypr/hyprland.conf.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages =
+      lib.optional (cfg.package != null) cfg.package
+      ++ lib.optional cfg.xwayland pkgs.xwayland;
+
+    xdg.configFile."hypr/hyprland.conf" = {
+      text =
+        (lib.optionalString cfg.systemdIntegration "
+            exec-once=${pkgs.dbus}/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP; systemctl --user start hyprland-session.target
+          ")
+        + cfg.extraConfig;
+
+      onChange = let
+        hyprlandPackage =
+          if cfg.package == null
+          then defaultHyprlandPackage
+          else cfg.package;
+      in "${hyprlandPackage}/bin/hyprctl reload";
+    };
+
+    systemd.user.targets.hyprland-session = lib.mkIf cfg.systemdIntegration {
+      Unit = {
+        Description = "hyprland compositor session";
+        Documentation = ["man:systemd.special(7)"];
+        BindsTo = ["graphical-session.target"];
+        Wants = ["graphical-session-pre.target"];
+        After = ["graphical-session-pre.target"];
+      };
+    };
+
+    systemd.user.targets.tray = {
+      Unit = {
+        Description = "Home Manager System Tray";
+        Requires = ["graphical-session-pre.target"];
+      };
+    };
+  };
+}


### PR DESCRIPTION
Hey, folks!

### Describe your PR, what does it fix/add?

Adds a [home-manager](https://github.com/nix-community/home-manager) module.

I built this module for my own use a few weeks ago, so I decided to polish it up and upstream it :)

For those uninitiated with nix: home-manager has modules (abstractions) for doing things on the user (instead of system, as is for NixOS modules) level. It has a lot more (and more extensive) modules than NixOS when we're talking about "dotfiley" stuff (editors, window-managers, terminals, etc).

[Some example usage on my config repo](https://github.com/Misterio77/nix-config/blob/d19cf7ae7d47d1b9ee7ed7521efa16f64f1d886c/home/misterio/desktop/hyprland/default.nix#L8)

### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I think I read somewhere someone was working on a home-manager module, sorry if this somehow clashes with what you have possibly already written.

Please feel free to use this code as you folks wish, even if you end up merging another implementation. I'll be glad to contribute in any way I can <3

### Is it ready for merging, or does it need work?

Should be ready to go:)
