### PR TITLE
Fix crash from moving current workspace to nonexistent (null) monitor.

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1011,6 +1011,9 @@ void CKeybindManager::moveCurrentWorkspaceToMonitor(std::string args) {
         return;
     }
 
+    if (!PMONITOR)
+        return;
+
     // get the current workspace
     const auto PCURRENTWORKSPACE = g_pCompositor->getWorkspaceByID(g_pCompositor->m_pLastMonitor->activeWorkspace);
 


### PR DESCRIPTION
This fixes an issue where `movecurrentworkspacetomonitor` crashes Hyprland if the monitor doesn't exist.
I didn't add a debug log, but instead just a simple return to avoid the crash like with the `PCURRENTWORKSPACE` check below it.
I built and ran the debug build, and it seems to fix the issue.

