### PR TITLE
output valid json when there are no clients

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -102,7 +102,8 @@ R"#({
         }
 
         // remove trailing comma
-        result.pop_back();
+        if (result != "[")
+          result.pop_back();
 
         result += "]";
     } else {


### PR DESCRIPTION
The json formatter pops off a character assuming it's a comma, but if there are no clients it pops off the `[` instead:

```
$ hyprctl -j clients
]
```
This fixes that up:

```
$ hyprctl -j clients
[]
```

