### PR TITLE
Have hyprctl -j activewindows return empty json object if there are no activewindows

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -157,7 +157,7 @@ std::string activeWindowRequest(HyprCtl::eHyprCtlOutputFormat format) {
     const auto PWINDOW = g_pCompositor->m_pLastWindow;
 
     if (!g_pCompositor->windowValidMapped(PWINDOW))
-        return "Invalid";
+        return format == HyprCtl::FORMAT_JSON ? "{}" : "Invalid";
 
     if (format == HyprCtl::FORMAT_JSON) {
         return getFormat(


### PR DESCRIPTION
If there are no activewindows, have `hyprctl -j activewindow` return `{}` instead of `Invalid`
