### PR TITLE
unlock the event queue before sleeping

### DIFF
--- a/src/managers/EventManager.cpp
+++ b/src/managers/EventManager.cpp
@@ -80,8 +80,8 @@ void CEventManager::startThread() {
             eventQueueMutex.lock();
 
             if (m_dQueuedEvents.empty()){ // if queue empty, sleep and ignore
-                std::this_thread::sleep_for(std::chrono::milliseconds(1));
                 eventQueueMutex.unlock();
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
                 continue;
             }
 


### PR DESCRIPTION
I'm seeing weird ordering of events over the socket, I think it's because the event queue mutex is held while it sleeps. It just continues after waking up, so it can be unlocked before sleep.

For example, flipping through the workspaces:

```
$ hsock | grep "^workspace"
workspace>>3
workspace>>2
workspace>>5
workspace>>4
workspace>>6
workspace>>7
workspace>>8
workspace>>10
workspace>>9
```

Same thing but unlocking before sleep:

```
$ hsock | grep "^workspace"
workspace>>2
workspace>>3
workspace>>4
workspace>>5
workspace>>6
workspace>>7
workspace>>8
workspace>>9
workspace>>10
```