### PR TITLE
fix: support clang in meson build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,8 +1,22 @@
 project('Hyprland', 'cpp', 'c',
   version : '0.10.0beta',
-  default_options : ['warning_level=2', 'default_library=static', 'optimization=3'])
+  default_options : [
+    'warning_level=2',
+    'default_library=static',
+    'optimization=3',
+    # 'cpp_std=c++23' # not yet supported by meson, as of version 0.63.0
+    ])
 
-add_global_arguments('-std=c++23', language: 'cpp')
+# clang v14.0.6 uses C++2b instead of C++23, so we've gotta account for that
+# replace the following with a project default option once meson gets support for C++23
+cpp_compiler = meson.get_compiler('cpp')
+if cpp_compiler.has_argument('-std=c++23')
+  add_global_arguments('-std=c++23', language: 'cpp')
+elif cpp_compiler.has_argument('-std=c++2b')
+  add_global_arguments('-std=c++2b', language: 'cpp')
+else
+  error('Could not configure current C++ compiler (' + cpp_compiler.get_id() + ' ' + cpp_compiler.get_version() + ') with required C++ standard (C++23)')
+endif
 
 GIT_BRANCH = run_command('git', 'rev-parse', '--abbrev-ref', 'HEAD', check: false).stdout().strip()
 GIT_COMMIT_HASH = run_command('git', 'rev-parse', 'HEAD', check: false).stdout().strip()


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes an error when building with Clang, which doesn't yet support `-std=c++23`, and instead uses `-std=c++2b`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Tested with Clang 14.0.6 and GCC 12.1.1.

Ideally, someone will replace this with `default_options : [ ..., 'cpp_std=c++23' ]` once Meson supports that.

#### Is it ready for merging, or does it need work?

:+1: 