### PR TITLE
More fullscreen animation fixes

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -79,8 +79,12 @@ bool CHyprRenderer::shouldRenderWindow(CWindow* pWindow, CMonitor* pMonitor) {
     const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(pWindow->m_iWorkspaceID);
 
     if (PWORKSPACE && PWORKSPACE->m_iMonitorID == pMonitor->ID) {
-        if (!(!PWORKSPACE->m_bHasFullscreenWindow || pWindow->m_bIsFullscreen || (pWindow->m_bIsFloating && pWindow->m_bCreatedOverFullscreen)))
-            return false;
+        if (PWORKSPACE->m_vRenderOffset.isBeingAnimated() || PWORKSPACE->m_fAlpha.isBeingAnimated()) {
+            return true;
+        } else {
+            if (!(!PWORKSPACE->m_bHasFullscreenWindow || pWindow->m_bIsFullscreen || (pWindow->m_bIsFloating && pWindow->m_bCreatedOverFullscreen)))
+                return false;
+        }
     }
 
     if (pWindow->m_iWorkspaceID == pMonitor->activeWorkspace)

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -86,9 +86,11 @@ bool CHyprRenderer::shouldRenderWindow(CWindow* pWindow, CMonitor* pMonitor) {
     if (pWindow->m_iWorkspaceID == pMonitor->activeWorkspace)
         return true;
 
-    // if not, check if it maybe is active on a different monitor.                                                                                             vvv might be animation in progress
-    if (g_pCompositor->isWorkspaceVisible(pWindow->m_iWorkspaceID) || (PWORKSPACE && PWORKSPACE->m_iMonitorID == pMonitor->ID && PWORKSPACE->m_bForceRendering) || (PWORKSPACE && PWORKSPACE->m_iMonitorID == pMonitor->ID && (PWORKSPACE->m_vRenderOffset.isBeingAnimated() || PWORKSPACE->m_fAlpha.isBeingAnimated())))
-        return true;
+    // if not, check if it maybe is active on a different monitor.
+    if (g_pCompositor->isWorkspaceVisible(pWindow->m_iWorkspaceID) ||
+        (PWORKSPACE && PWORKSPACE->m_iMonitorID == pMonitor->ID && PWORKSPACE->m_bForceRendering) || // vvvv might be in animation progress vvvvv
+        (PWORKSPACE && PWORKSPACE->m_iMonitorID == pMonitor->ID && (PWORKSPACE->m_vRenderOffset.isBeingAnimated() || PWORKSPACE->m_fAlpha.isBeingAnimated())))
+        return !pWindow->m_bIsFullscreen; // Do not draw fullscreen windows on other monitors
 
     if (pMonitor->specialWorkspaceOpen && pWindow->m_iWorkspaceID == SPECIAL_WORKSPACE_ID)
         return true;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
When switching to a fullscreen workspace the window could get drawn on adjacent monitors.
Also when switching from a fullscreen workspace the animation wouldn't get drawn for the fullscreen window (similar to #439 just the opposite).
#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Played a bit with it and couldn't find any issues.

#### Is it ready for merging, or does it need work?
Ready for merging.

