### PR TITLE
openSUSE patches

### DIFF
--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -50,12 +50,6 @@ void request(std::string arg) {
         return;
     }
 
-    const auto SERVER = gethostbyname("localhost");
-
-    if (!SERVER) {
-        std::cout << "Couldn't get host (2)";
-        return;
-    }
 
     // get the instance signature
     auto instanceSig = getenv("HYPRLAND_INSTANCE_SIGNATURE");

--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,7 @@ if cpp_compiler.has_argument('-std=c++23')
 elif cpp_compiler.has_argument('-std=c++2b')
   add_global_arguments('-std=c++2b', language: 'cpp')
 else
-  error('Could not configure current C++ compiler (' + cpp_compiler.get_id() + ' ' + cpp_compiler.get_version() + ') with required C++ standard (C++23)')
+  error('Could not configure current C++ compiler (' + cpp_compiler.get_id() + ' ' + cpp_compiler.version() + ') with required C++ standard (C++23)')
 endif
 
 GIT_BRANCH = run_command('git', 'rev-parse', '--abbrev-ref', 'HEAD', check: false).stdout().strip()


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

These are the patches I apply to the Hyprland package on openSUSE, as described here:
https://github.com/hyprwm/hyprland-wiki/pull/10

> The package currently patches Hyprland twice, @vaxerski you might consider merging them?
> - it drops the deprecated `gethostbyname("localhost")` call in `hyprctl/main.cpp`, as binaries calling this should not be part of openSUSE (should use getaddrinfo instead); but in this case the call seems to be leftover from a previous iteration anyways and of little use. [gethostbyname.patch](https://opi-proxy.opensuse.org/?obs_api_link=https%3A%2F%2Fapi.opensuse.org%2Fsource%2FX11%3AWayland%2Fhyprland%2Fgethostbyname.patch&obs_instance=openSUSE)
> - it patches the <compiler>.get_version() to <compiler>.version() in `meson.build`, as the get_version() method was seemingly only introduced recently and the version() method was there since forever. This would allow building hyprland with older meson verions (but in the case of the package it was useless, since every distro shipping an outdated meson also had outdated libraries). [old-meson.patch](https://opi-proxy.opensuse.org/?obs_api_link=https%3A%2F%2Fapi.opensuse.org%2Fsource%2FX11%3AWayland%2Fhyprland%2Fold-meson.patch&obs_instance=openSUSE)


