### PR TITLE
fix xwayland config option for nix

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -72,7 +72,7 @@ stdenv.mkDerivation {
     else "release";
 
   mesonFlags = builtins.concatLists [
-    (lib.optional (!enableXWayland) "-DNO_XWAYLAND=true")
+    (lib.optional (!enableXWayland) "-Dxwayland=disabled")
     (lib.optional legacyRenderer "-DLEGACY_RENDERER:STRING=true")
   ];
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
When building Hyprland in nix using the following home-manager recipe:

```nix
{}:

{
  wayland.windowManager.hyprland = {
    enable = true;
    xwayland = false;
  };
}
```

The default nix configuration still makes reference to a compile argument `NO_XWAYLAND`, but the `meson_options.txt` only makes reference to `xwayland`. This causes the build to fail with:

```
meson.build:1:0: ERROR: Unknown options: "NO_XWAYLAND"
```

This change fixes that issue.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This still doesn't allow you to build Hyprland without having XWayland installed (#178), but it should at least allow for valid nix configurations for when that issue gets resolved.

#### Is it ready for merging, or does it need work?
The change does not touch any of the actual code, but it might require the root `flake.nix` / `flake.lock` to be updated to bump the patch version.

