### PR TITLE
Add "highest" mode to Monitor for autoconfiguration.

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -460,6 +460,8 @@ void CConfigManager::handleMonitor(const std::string& command, const std::string
 
     if (curitem.find("pref") == 0) {
         newrule.resolution = Vector2D();
+    } else if(curitem.find("high") == 0) {
+        newrule.resolution = Vector2D(-1,-1);
     } else {
         newrule.resolution.x = stoi(curitem.substr(0, curitem.find_first_of('x')));
         newrule.resolution.y = stoi(curitem.substr(curitem.find_first_of('x') + 1, curitem.find_first_of('@')));

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -460,8 +460,10 @@ void CConfigManager::handleMonitor(const std::string& command, const std::string
 
     if (curitem.find("pref") == 0) {
         newrule.resolution = Vector2D();
-    } else if(curitem.find("high") == 0) {
+    } else if(curitem.find("highrr") == 0) {
         newrule.resolution = Vector2D(-1,-1);
+    } else if(curitem.find("highres") == 0) {
+        newrule.resolution = Vector2D(-1,-2);
     } else {
         newrule.resolution.x = stoi(curitem.substr(0, curitem.find_first_of('x')));
         newrule.resolution.y = stoi(curitem.substr(curitem.find_first_of('x') + 1, curitem.find_first_of('@')));

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -924,7 +924,7 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
     pMonitor->vecPosition = pMonitorRule->offset;
 
     // loop over modes and choose an appropriate one.
-    if (pMonitorRule->resolution != Vector2D()) {
+    if (pMonitorRule->resolution != Vector2D() && pMonitorRule->resolution != Vector2D(-1,-1)) {
         if (!wl_list_empty(&pMonitor->output->modes)) {
             wlr_output_mode* mode;
             bool found = false;
@@ -962,9 +962,6 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
                     Debug::log(ERR, "Custom resolution FAILED, falling back to preferred");
 
                     const auto PREFERREDMODE = wlr_output_preferred_mode(pMonitor->output);
-                    wl_list_for_each(mode, &pMonitor->output->modes, link) {
-                        if(mode > pMonitorRule-refreshRate)
-                            pMonitorRule->refreshRate = mode;
 
                     if (!PREFERREDMODE) {
                         Debug::log(ERR, "Monitor %s has NO PREFERRED MODE, and an INVALID one was requested: %ix%i@%2f",
@@ -985,17 +982,61 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
                     Debug::log(LOG, "Set a custom mode %ix%i@%2f (mode not found in monitor modes)", (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate);
                 }
             }
-        } else {
-            wlr_output_set_custom_mode(pMonitor->output, (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y, (int)pMonitorRule->refreshRate * 1000);
-            pMonitor->vecSize = pMonitorRule->resolution;
+          }
+        } else if(pMonitorRule->resolution != Vector2D()) {
+            if (!wl_list_empty(&pMonitor->output->modes)) {
+                wlr_output_mode* mode;
+                float currentWidth = 0;
+                float currentHeight = 0;
+                float currentRefresh  = 0;
+                bool success = false;
 
-            Debug::log(LOG, "Setting custom mode for %s", pMonitor->output->name);
-        }
-    } else {
+                wl_list_for_each(mode, &pMonitor->output->modes, link) {
+                    if(mode->width >= currentWidth && mode->height >= currentHeight && mode->refresh >= currentRefresh) {
+                    wlr_output_set_mode(pMonitor->output, mode);
+                        if (wlr_output_test(pMonitor->output)) {
+                            currentWidth = mode->width;
+                            currentHeight = mode->height;
+                            currentRefresh = mode->refresh;
+                            success = true;
+                        }
+                    }   
+                }
+
+                if (!success) {
+                    Debug::log(LOG, "Monitor %s: REJECTED highest mode: %ix%i@%2f! Falling back to preferred.",
+                               pMonitor->output->name, (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate,
+                               mode->width, mode->height, mode->refresh / 1000.f);
+ 
+                    const auto PREFERREDMODE = wlr_output_preferred_mode(pMonitor->output);
+
+                    if (!PREFERREDMODE) {
+                        Debug::log(ERR, "Monitor %s has NO PREFERRED MODE, and an INVALID one was requested: %ix%i@%2f",
+                                   (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate);
+                        return true;
+                    }
+
+                    // Preferred is valid
+                    wlr_output_set_mode(pMonitor->output, PREFERREDMODE);
+
+                    Debug::log(ERR, "Monitor %s got an invalid requested mode: %ix%i@%2f, using the preferred one instead: %ix%i@%2f",
+                               pMonitor->output->name, (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate,
+                               PREFERREDMODE->width, PREFERREDMODE->height, PREFERREDMODE->refresh / 1000.f);
+
+                    pMonitor->refreshRate = PREFERREDMODE->refresh / 1000.f;
+                    pMonitor->vecSize = Vector2D(PREFERREDMODE->width, PREFERREDMODE->height);
+                } else {
+
+                    Debug::log(LOG, "Monitor %s: Applying highest mode %ix%i@%imHz.",
+                               pMonitor->output->name, (int)currentWidth, (int)currentHeight, (int)currentRefresh / 1000.f,
+                               mode->width, mode->height, mode->refresh);
+
+                    pMonitor->refreshRate = currentRefresh / 1000.f;
+                    pMonitor->vecSize = Vector2D(currentWidth, currentHeight);
+                }
+            }
+        } else {
         const auto PREFERREDMODE = wlr_output_preferred_mode(pMonitor->output);
-        wl_list_for_each(mode, &pMonitor->output->modes, link) {
-            if(mode > pMonitorRule-refreshRate)
-                pMonitorRule->refreshRate = mode;
 
         if (!PREFERREDMODE) {
             Debug::log(ERR, "Monitor %s has NO PREFERRED MODE",

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1072,7 +1072,6 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
                         continue;
                     }
 
-
                     Debug::log(LOG, "Monitor %s: requested %ix%i@%2f, found available mode: %ix%i@%imHz, applying.",
                                pMonitor->output->name, (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate,
                                mode->width, mode->height, mode->refresh);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -962,6 +962,9 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
                     Debug::log(ERR, "Custom resolution FAILED, falling back to preferred");
 
                     const auto PREFERREDMODE = wlr_output_preferred_mode(pMonitor->output);
+                    wl_list_for_each(mode, &pMonitor->output->modes, link) {
+                        if(mode > pMonitorRule-refreshRate)
+                            pMonitorRule->refreshRate = mode;
 
                     if (!PREFERREDMODE) {
                         Debug::log(ERR, "Monitor %s has NO PREFERRED MODE, and an INVALID one was requested: %ix%i@%2f",
@@ -990,6 +993,9 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
         }
     } else {
         const auto PREFERREDMODE = wlr_output_preferred_mode(pMonitor->output);
+        wl_list_for_each(mode, &pMonitor->output->modes, link) {
+            if(mode > pMonitorRule-refreshRate)
+                pMonitorRule->refreshRate = mode;
 
         if (!PREFERREDMODE) {
             Debug::log(ERR, "Monitor %s has NO PREFERRED MODE",

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -982,6 +982,9 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
                     Debug::log(LOG, "Set a custom mode %ix%i@%2f (mode not found in monitor modes)", (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate);
                 }
             } else {
+                wlr_output_set_custom_mode(pMonitor->output, (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y, (int)pMonitorRule->refreshRate * 1000);
+                pMonitor->vecSize = pMonitorRule->resolution;
+
                 Debug::log(LOG, "Setting custom mode for %s", pMonitor->output->name);
             }
         }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -981,76 +981,78 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
                 } else {
                     Debug::log(LOG, "Set a custom mode %ix%i@%2f (mode not found in monitor modes)", (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate);
                 }
+            } else {
+                Debug::log(LOG, "Setting custom mode for %s", pMonitor->output->name);
             }
-          }
-        } else if(pMonitorRule->resolution != Vector2D()) {
-            if (!wl_list_empty(&pMonitor->output->modes)) {
-                wlr_output_mode* mode;
-                float currentWidth = 0;
-                float currentHeight = 0;
-                float currentRefresh  = 0;
-                bool success = false;
+        }
+    } else if(pMonitorRule->resolution != Vector2D()) {
+        if (!wl_list_empty(&pMonitor->output->modes)) {
+            wlr_output_mode* mode;
+            float currentWidth = 0;
+            float currentHeight = 0;
+            float currentRefresh  = 0;
+            bool success = false;
 
-                //(-1,-1) indicates a preference to refreshrate over resolution, (-1,-2) preference to resolution 
-                if(pMonitorRule->resolution == Vector2D(-1,-1)) {
-                    wl_list_for_each(mode, &pMonitor->output->modes, link) {
-                       if( ( mode->width >= currentWidth && mode->height >= currentHeight && mode->refresh >= ( currentRefresh - 1000.f ) ) || mode->refresh > ( currentRefresh + 3000.f ) ) {
-                       wlr_output_set_mode(pMonitor->output, mode);
-                           if (wlr_output_test(pMonitor->output)) {
-                               currentWidth = mode->width;
-                               currentHeight = mode->height;
-                               currentRefresh = mode->refresh;
-                               success = true;
-                           }
+            //(-1,-1) indicates a preference to refreshrate over resolution, (-1,-2) preference to resolution 
+            if(pMonitorRule->resolution == Vector2D(-1,-1)) {
+                wl_list_for_each(mode, &pMonitor->output->modes, link) {
+                   if( ( mode->width >= currentWidth && mode->height >= currentHeight && mode->refresh >= ( currentRefresh - 1000.f ) ) || mode->refresh > ( currentRefresh + 3000.f ) ) {
+                   wlr_output_set_mode(pMonitor->output, mode);
+                       if (wlr_output_test(pMonitor->output)) {
+                           currentWidth = mode->width;
+                           currentHeight = mode->height;
+                           currentRefresh = mode->refresh;
+                           success = true;
                        }
-                    }
-                } else {
-                    wl_list_for_each(mode, &pMonitor->output->modes, link) {
-                       if( ( mode->width >= currentWidth && mode->height >= currentHeight && mode->refresh >= ( currentRefresh - 1000.f ) ) || ( mode->width > currentWidth && mode->height > currentHeight ) ) {
-                       wlr_output_set_mode(pMonitor->output, mode);
-                           if (wlr_output_test(pMonitor->output)) {
-                               currentWidth = mode->width;
-                               currentHeight = mode->height;
-                               currentRefresh = mode->refresh;
-                               success = true;
-                           }
-                       }
-                    }
+                   }
                 }
+            } else {
+                wl_list_for_each(mode, &pMonitor->output->modes, link) {
+                   if( ( mode->width >= currentWidth && mode->height >= currentHeight && mode->refresh >= ( currentRefresh - 1000.f ) ) || ( mode->width > currentWidth && mode->height > currentHeight ) ) {
+                   wlr_output_set_mode(pMonitor->output, mode);
+                       if (wlr_output_test(pMonitor->output)) {
+                           currentWidth = mode->width;
+                           currentHeight = mode->height;
+                           currentRefresh = mode->refresh;
+                           success = true;
+                       }
+                   }
+                }
+            }
 
-                if (!success) {
-                    Debug::log(LOG, "Monitor %s: REJECTED mode: %ix%i@%2f! Falling back to preferred.",
-                               pMonitor->output->name, (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate,
-                               mode->width, mode->height, mode->refresh / 1000.f);
+            if (!success) {
+                Debug::log(LOG, "Monitor %s: REJECTED mode: %ix%i@%2f! Falling back to preferred.",
+                           pMonitor->output->name, (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate,
+                           mode->width, mode->height, mode->refresh / 1000.f);
  
-                    const auto PREFERREDMODE = wlr_output_preferred_mode(pMonitor->output);
+                const auto PREFERREDMODE = wlr_output_preferred_mode(pMonitor->output);
 
-                    if (!PREFERREDMODE) {
-                        Debug::log(ERR, "Monitor %s has NO PREFERRED MODE, and an INVALID one was requested: %ix%i@%2f",
-                                   (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate);
-                        return true;
-                    }
-
-                    // Preferred is valid
-                    wlr_output_set_mode(pMonitor->output, PREFERREDMODE);
-
-                    Debug::log(ERR, "Monitor %s got an invalid requested mode: %ix%i@%2f, using the preferred one instead: %ix%i@%2f",
-                               pMonitor->output->name, (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate,
-                               PREFERREDMODE->width, PREFERREDMODE->height, PREFERREDMODE->refresh / 1000.f);
-
-                    pMonitor->refreshRate = PREFERREDMODE->refresh / 1000.f;
-                    pMonitor->vecSize = Vector2D(PREFERREDMODE->width, PREFERREDMODE->height);
-                } else {
-
-                    Debug::log(LOG, "Monitor %s: Applying highest mode %ix%i@%2f.",
-                               pMonitor->output->name, (int)currentWidth, (int)currentHeight, (int)currentRefresh / 1000.f,
-                               mode->width, mode->height, mode->refresh / 1000.f);
-
-                    pMonitor->refreshRate = currentRefresh / 1000.f;
-                    pMonitor->vecSize = Vector2D(currentWidth, currentHeight);
+                if (!PREFERREDMODE) {
+                    Debug::log(ERR, "Monitor %s has NO PREFERRED MODE, and an INVALID one was requested: %ix%i@%2f",
+                               (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate);
+                    return true;
                 }
+
+                // Preferred is valid
+                wlr_output_set_mode(pMonitor->output, PREFERREDMODE);
+
+                Debug::log(ERR, "Monitor %s got an invalid requested mode: %ix%i@%2f, using the preferred one instead: %ix%i@%2f",
+                           pMonitor->output->name, (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate,
+                           PREFERREDMODE->width, PREFERREDMODE->height, PREFERREDMODE->refresh / 1000.f);
+
+                pMonitor->refreshRate = PREFERREDMODE->refresh / 1000.f;
+                pMonitor->vecSize = Vector2D(PREFERREDMODE->width, PREFERREDMODE->height);
+            } else {
+
+                Debug::log(LOG, "Monitor %s: Applying highest mode %ix%i@%2f.",
+                           pMonitor->output->name, (int)currentWidth, (int)currentHeight, (int)currentRefresh / 1000.f,
+                           mode->width, mode->height, mode->refresh / 1000.f);
+
+                pMonitor->refreshRate = currentRefresh / 1000.f;
+                pMonitor->vecSize = Vector2D(currentWidth, currentHeight);
             }
-        } else {
+        }
+    } else {
         const auto PREFERREDMODE = wlr_output_preferred_mode(pMonitor->output);
 
         if (!PREFERREDMODE) {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1028,8 +1028,8 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
                 } else {
 
                     Debug::log(LOG, "Monitor %s: Applying highest mode %ix%i@%imHz.",
-                               pMonitor->output->name, (int)currentWidth, (int)currentHeight, (int)currentRefresh / 1000.f,
-                               mode->width, mode->height, mode->refresh);
+                               pMonitor->output->name, (int)currentWidth, (int)currentHeight, (int)currentRefresh,
+                               mode->width, mode->height, mode->refresh / 1000.f);
 
                     pMonitor->refreshRate = currentRefresh / 1000.f;
                     pMonitor->vecSize = Vector2D(currentWidth, currentHeight);
@@ -1054,6 +1054,7 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
                                    mode->width, mode->height, mode->refresh / 1000.f);
                         continue;
                     }
+
 
                     Debug::log(LOG, "Monitor %s: requested %ix%i@%2f, found available mode: %ix%i@%imHz, applying.",
                                pMonitor->output->name, (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate,


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds 2 new monitor resolution modes.
-- highrr -> highest with refreshrate preference
-- highres -> highest with resolution preference

Should none be possible for whatever reason, then it will default to preferred.

These 2 features are useful to autoconfigure monitors that do not have a good preferred mode. aka 4k monitor defaulting to 1080p or high refreshrate defaulting to 60.
This also means that switching between them is now possible.

this would add a rule for all random monitors to use their "best" possible setting.
monitor=,highrr,auto,1
OR
monitor=,highres,auto,1

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
If someone has wonky setups that can be tested with this, then please do so, it was intended for exactly this.

#### Is it ready for merging, or does it need work?
Compiles and works as intended on the monitors I was able to test.
Review needed obviously, otherwise ready imo.


