### PR TITLE
fix crash

### DIFF
--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -819,15 +819,13 @@ void CHyprDwindleLayout::toggleWindowGroup(CWindow* pWindow) {
             PWINDOW->m_bHidden = false;
         }
 	    
-	if(PHEAD->pPreviousGroupMember)
-	{
-	  PHEAD->pPreviousGroupMember->pNextGroupMember = PHEAD->pNextGroupMember;
-	  PHEAD->pPreviousGroupMember = nullptr;
+	if(PHEAD->pPreviousGroupMember){
+	    PHEAD->pPreviousGroupMember->pNextGroupMember = PHEAD->pNextGroupMember;
+	    PHEAD->pPreviousGroupMember = nullptr;
 	}
-	if(PHEAD->pNextGroupMember)
-	{
-	  PHEAD->pNextGroupMember->pPreviousGroupMember = PHEAD->pPreviousGroupMember;
-	  PHEAD->pNextGroupMember = nullptr;
+	if(PHEAD->pNextGroupMember){
+	    PHEAD->pNextGroupMember->pPreviousGroupMember = PHEAD->pPreviousGroupMember;
+	    PHEAD->pNextGroupMember = nullptr;
 	}
 
         onWindowRemoved(PHEAD->pWindow);

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -819,11 +819,12 @@ void CHyprDwindleLayout::toggleWindowGroup(CWindow* pWindow) {
             PWINDOW->m_bHidden = false;
         }
 	    
-	if(PHEAD->pPreviousGroupMember){
+	if (PHEAD->pPreviousGroupMember) {
 	    PHEAD->pPreviousGroupMember->pNextGroupMember = PHEAD->pNextGroupMember;
 	    PHEAD->pPreviousGroupMember = nullptr;
 	}
-	if(PHEAD->pNextGroupMember){
+
+	if (PHEAD->pNextGroupMember) {
 	    PHEAD->pNextGroupMember->pPreviousGroupMember = PHEAD->pPreviousGroupMember;
 	    PHEAD->pNextGroupMember = nullptr;
 	}

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -818,9 +818,18 @@ void CHyprDwindleLayout::toggleWindowGroup(CWindow* pWindow) {
 
             PWINDOW->m_bHidden = false;
         }
+	    
+	if(PHEAD->pPreviousGroupMember)
+	{
+	  PHEAD->pPreviousGroupMember->pNextGroupMember = PHEAD->pNextGroupMember;
+	  PHEAD->pPreviousGroupMember = nullptr;
+	}
+	if(PHEAD->pNextGroupMember)
+	{
+	  PHEAD->pNextGroupMember->pPreviousGroupMember = PHEAD->pPreviousGroupMember;
+	  PHEAD->pNextGroupMember = nullptr;
+	}
 
-        PHEAD->pPreviousGroupMember = nullptr;
-        PHEAD->pNextGroupMember = nullptr;
         onWindowRemoved(PHEAD->pWindow);
 
         for (auto& pw : toAddWindows) {


### PR DESCRIPTION

#### Describe your PR, what does it fix/add?
Fixes #711

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I'm pretty shure this is not how you would do it!
there is a problem in toggleWindowGroup if that group is in fullscreen mode.
I think the pPrevious- and pNextGroupMember of the first window are set to nullptr, after that 
the nextGroupMember calls getGroupMemberCount, but with a Pointer to a group member that
has it's next prev pointers nulled, getGroupMemberCount will crash.
Since it is a crashing bug, if you don't have time to fix it yourself, use this first?

#### Is it ready for merging, or does it need work?
I think yes.
It's not a big change, look at it, what could possibly go wrong!?

