### PR TITLE
Splash position fix

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1171,6 +1171,8 @@ void CHyprOpenGLImpl::createBGTextureForMonitor(CMonitor* pMonitor) {
 
     const auto CAIRO = cairo_create(CAIROSURFACE);
 
+    cairo_scale(CAIRO, textureSize.x / pMonitor->vecTransformedSize.x, textureSize.y / pMonitor->vecTransformedSize.y);
+
     if (!*PNOSPLASH)
         renderSplash(CAIRO, CAIROSURFACE);
 

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1113,18 +1113,19 @@ void CHyprOpenGLImpl::renderMirrored() {
     renderTexture(PFB->m_cTex, &monbox, 255.f, 0, false, false);
 }
 
-void CHyprOpenGLImpl::renderSplash(cairo_t *const CAIRO, cairo_surface_t *const CAIROSURFACE) {
+void CHyprOpenGLImpl::renderSplash(cairo_t *const CAIRO, cairo_surface_t *const CAIROSURFACE, double offsetY) {
     cairo_select_font_face(CAIRO, "Sans", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
 
     const auto FONTSIZE = (int)(m_RenderData.pMonitor->vecPixelSize.y / 76);
     cairo_set_font_size(CAIRO, FONTSIZE);
 
-    cairo_set_source_rgba(CAIRO, 1.f, 1.f, 1.f, 0.32f);
+    cairo_set_source_rgba(CAIRO, 1.0, 1.0, 1.0, 0.32);
 
     cairo_text_extents_t textExtents;
     cairo_text_extents(CAIRO, g_pCompositor->m_szCurrentSplash.c_str(), &textExtents);
 
-    cairo_move_to(CAIRO, m_RenderData.pMonitor->vecPixelSize.x / 2.f - textExtents.width / 2.f, m_RenderData.pMonitor->vecPixelSize.y - textExtents.height - 1);
+    cairo_move_to(CAIRO, (m_RenderData.pMonitor->vecPixelSize.x - textExtents.width) / 2.0, m_RenderData.pMonitor->vecPixelSize.y - textExtents.height + offsetY);
+
     cairo_show_text(CAIRO, g_pCompositor->m_szCurrentSplash.c_str());
 
     cairo_surface_flush(CAIROSURFACE);
@@ -1166,15 +1167,37 @@ void CHyprOpenGLImpl::createBGTextureForMonitor(CMonitor* pMonitor) {
 
     PTEX->m_vSize = textureSize;
 
+    // calc the target box
+    const double MONRATIO = m_RenderData.pMonitor->vecTransformedSize.x / m_RenderData.pMonitor->vecTransformedSize.y;
+    const double WPRATIO = 1.77;
+
+    Vector2D origin;
+    double scale;
+
+    if (MONRATIO > WPRATIO) {
+        scale = m_RenderData.pMonitor->vecTransformedSize.x / PTEX->m_vSize.x;
+
+        origin.y = (m_RenderData.pMonitor->vecTransformedSize.y - PTEX->m_vSize.y * scale) / 2.0;
+    } else {
+        scale = m_RenderData.pMonitor->vecTransformedSize.y / PTEX->m_vSize.y;
+
+        origin.x = (m_RenderData.pMonitor->vecTransformedSize.x - PTEX->m_vSize.x * scale) / 2.0;
+    }
+
+    wlr_box box = {origin.x, origin.y, PTEX->m_vSize.x * scale, PTEX->m_vSize.y * scale};
+
+    m_mMonitorRenderResources[pMonitor].backgroundTexBox = box;
+
     // create a new one with cairo
     const auto CAIROSURFACE = cairo_image_surface_create_from_png(texPath.c_str());
-
     const auto CAIRO = cairo_create(CAIROSURFACE);
 
+    // scale it to fit the current monitor
     cairo_scale(CAIRO, textureSize.x / pMonitor->vecTransformedSize.x, textureSize.y / pMonitor->vecTransformedSize.y);
 
+    // render splash on wallpaper
     if (!*PNOSPLASH)
-        renderSplash(CAIRO, CAIROSURFACE);
+        renderSplash(CAIRO, CAIROSURFACE, origin.y * WPRATIO / MONRATIO);
 
     // copy the data to an OpenGL texture we have
     const auto DATA = cairo_image_surface_get_data(CAIROSURFACE);
@@ -1189,28 +1212,6 @@ void CHyprOpenGLImpl::createBGTextureForMonitor(CMonitor* pMonitor) {
 
     cairo_surface_destroy(CAIROSURFACE);
     cairo_destroy(CAIRO);
-
-    // calc the target box
-
-    const float MONRATIO = m_RenderData.pMonitor->vecTransformedSize.x / m_RenderData.pMonitor->vecTransformedSize.y;
-    const float WPRATIO = 1.77f;
-
-    Vector2D origin;
-    float scale;
-
-    if (MONRATIO > WPRATIO) {
-        scale = m_RenderData.pMonitor->vecTransformedSize.x / PTEX->m_vSize.x;
-
-        origin.y = -(PTEX->m_vSize.y * scale - m_RenderData.pMonitor->vecTransformedSize.y) / 2.f / scale;
-    } else {
-        scale = m_RenderData.pMonitor->vecTransformedSize.y / PTEX->m_vSize.y;
-
-        origin.x = -(PTEX->m_vSize.x * scale - m_RenderData.pMonitor->vecTransformedSize.x) / 2.f / scale;
-    }
-
-    wlr_box box = {origin.x * scale, origin.y * scale, PTEX->m_vSize.x * scale, PTEX->m_vSize.y * scale};
-
-    m_mMonitorRenderResources[pMonitor].backgroundTexBox = box;
 
     Debug::log(LOG, "Background created for monitor %s", pMonitor->szName.c_str());
 }

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -140,8 +140,7 @@ private:
     CFramebuffer*           blurMainFramebufferWithDamage(float a, wlr_box* pBox, pixman_region32_t* damage);
 
     void                    renderTextureInternalWithDamage(const CTexture&, wlr_box* pBox, float a, pixman_region32_t* damage, int round = 0, bool discardOpaque = false, bool noAA = false, bool allowCustomUV = false, bool allowDim = false);
-
-    void                    renderSplash(cairo_t *const, cairo_surface_t *const);
+    void                    renderSplash(cairo_t *const, cairo_surface_t *const, double);
 
     void                    preBlurForCurrentMonitor();
 };


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This fixes the offcenter splash rendering

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Fixes https://github.com/hyprwm/Hyprland/issues/679
On screens with a higher than texture ratio, the splash will be offscreen (below),
this is not introduced by this pr.
The splash has to be moved by the same amount as the origin.y value
in createBGTextureForMonitor in those cases.

#### Is it ready for merging, or does it need work?
I think yes, it doesn't fix the problem totally, but it makes things better.

