### PR TITLE
Rework rounding shader

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -123,7 +123,16 @@ void CKeybindManager::updateXKBTranslationState() {
 
     const auto PCONTEXT = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
 
-    const auto PKEYMAP = FILEPATH == "" ? xkb_keymap_new_from_names(PCONTEXT, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS) : xkb_keymap_new_from_file(PCONTEXT, fopen(FILEPATH.c_str(), "r"), XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS);
+    auto PKEYMAP = FILEPATH == "" ? xkb_keymap_new_from_names(PCONTEXT, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS) : xkb_keymap_new_from_file(PCONTEXT, fopen(FILEPATH.c_str(), "r"), XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS);
+
+    if (!PKEYMAP) {
+        g_pHyprError->queueCreate("[Runtime Error] Invalid keyboard layout passed. ( rules: " + RULES + ", model: " + MODEL + ", variant: " + VARIANT + ", options: " + OPTIONS + ", layout: " + LAYOUT + " )", CColor(255, 50, 50, 255));
+
+        Debug::log(ERR, "[XKBTranslationState] Keyboard layout %s with variant %s (rules: %s, model: %s, options: %s) couldn't have been loaded.", rules.layout, rules.variant, rules.rules, rules.model, rules.options);
+        memset(&rules, 0, sizeof(rules));
+
+        PKEYMAP = xkb_keymap_new_from_names(PCONTEXT, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
+    }
 
     xkb_context_unref(PCONTEXT);
     m_pXKBTranslationState = xkb_state_new(PKEYMAP);

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1,3 +1,4 @@
+#include "Shaders.hpp"
 #include "OpenGL.hpp"
 #include "../Compositor.hpp"
 #include "../helpers/MiscFunctions.hpp"

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -8,7 +8,6 @@
 
 #include <cairo/cairo.h>
 
-#include "Shaders.hpp"
 #include "Shader.hpp"
 #include "Texture.hpp"
 #include "Framebuffer.hpp"

--- a/src/render/shaders/Textures.hpp
+++ b/src/render/shaders/Textures.hpp
@@ -13,9 +13,6 @@ inline static constexpr auto ROUNDED_SHADER_FUNC = [](const std::string colorVar
 
     if (pixCoord.x + pixCoord.y > radius) {
 
-	if (ignoreCorners == 1)
-	    discard;
-
 	float dist = length(pixCoord);
 
 	if (dist > radius)
@@ -64,7 +61,6 @@ uniform vec2 fullSize;
 uniform float radius;
 
 uniform int primitiveMultisample;
-uniform int ignoreCorners;
 
 void main() {
 
@@ -104,7 +100,6 @@ uniform int applyTint;
 uniform vec3 tint;
 
 uniform int primitiveMultisample;
-uniform int ignoreCorners;
 
 void main() {
 
@@ -141,7 +136,6 @@ uniform int applyTint;
 uniform vec3 tint;
 
 uniform int primitiveMultisample;
-uniform int ignoreCorners;
 
 void main() {
 
@@ -227,7 +221,6 @@ uniform int applyTint;
 uniform vec3 tint;
 
 uniform int primitiveMultisample;
-uniform int ignoreCorners;
 
 void main() {
 

--- a/src/render/shaders/Textures.hpp
+++ b/src/render/shaders/Textures.hpp
@@ -7,11 +7,11 @@ inline static constexpr auto ROUNDED_SHADER_FUNC = [](const std::string colorVar
 
     // branchless baby!
     highp vec2 pixCoord = vec2(gl_FragCoord);
-    pixCoord -= topLeft + fullSize / vec2(2.0);
-    pixCoord *= vec2(lessThan(pixCoord, vec2(0.0))) * vec2(-2.0) + vec2(1.0);
-    pixCoord -= fullSize * vec2(0.5) - vec2(radius);
+    pixCoord -= topLeft + fullSize * 0.5;
+    pixCoord *= vec2(lessThan(pixCoord, vec2(0.0))) * -2.0 + 1.0;
+    pixCoord -= fullSize * 0.5 - radius;
 
-    if (all(greaterThan(pixCoord, vec2(0.0)))) {
+    if (pixCoord.x + pixCoord.y > radius) {
 
 	if (ignoreCorners == 1)
 	    discard;

--- a/src/render/shaders/Textures.hpp
+++ b/src/render/shaders/Textures.hpp
@@ -22,15 +22,15 @@ inline static constexpr auto ROUNDED_SHADER_FUNC = [](const std::string colorVar
 
 	if (primitiveMultisample == 1 && dist > radius - 1.0) {
 	    float distances = 0.0;
-	    if (length(pixCoord + vec2(0.25, 0.25)) < radius) { distances = distances + 1.0; }
-	    if (length(pixCoord + vec2(0.75, 0.25)) < radius) { distances = distances + 1.0; }
-	    if (length(pixCoord + vec2(0.25, 0.75)) < radius) { distances = distances + 1.0; }
-	    if (length(pixCoord + vec2(0.75, 0.75)) < radius) { distances = distances + 1.0; }
+	    distances += float(length(pixCoord + vec2(0.25, 0.25)) < radius);
+	    distances += float(length(pixCoord + vec2(0.75, 0.25)) < radius);
+	    distances += float(length(pixCoord + vec2(0.25, 0.75)) < radius);
+	    distances += float(length(pixCoord + vec2(0.75, 0.75)) < radius);
 
 	    if (distances == 0.0)
 		discard;
 
-	    distances = distances / 4.0;
+	    distances /= 4.0;
 
 	    )#" + colorVarName + R"#( = )#" + colorVarName + R"#( * distances;
         }

--- a/src/render/shaders/Textures.hpp
+++ b/src/render/shaders/Textures.hpp
@@ -5,38 +5,38 @@
 inline static constexpr auto ROUNDED_SHADER_FUNC = [](const std::string colorVarName) -> std::string {
         return R"#(
 
-	// branchless baby!
-	vec2 pixCoord = v_texcoord - vec2(0.5);
-	pixCoord *= (vec2(lessThan(pixCoord, vec2(0.0))) * vec2(-2.0) + vec2(1.0)) * fullSize;
-	pixCoord -= (bottomRight - topLeft) * vec2(0.5);
+    // branchless baby!
+    vec2 pixCoord = v_texcoord - vec2(0.5);
+    pixCoord *= (vec2(lessThan(pixCoord, vec2(0.0))) * vec2(-2.0) + vec2(1.0)) * fullSize;
+    pixCoord -= (bottomRight - topLeft) * vec2(0.5);
 
-	if (all(greaterThan(pixCoord, vec2(0.0)))) {
+    if (all(greaterThan(pixCoord, vec2(0.0)))) {
 
-		if (ignoreCorners == 1)
-			discard;
+	if (ignoreCorners == 1)
+	    discard;
 
-		float dist = length(pixCoord);
+	float dist = length(pixCoord);
 
-		if (dist > radius)
-			discard;
+	if (dist > radius)
+	    discard;
 
-		if (primitiveMultisample == 1 && dist > radius - 1.0) {
-			float distances = 0.0;
-			if (length(pixCoord + vec2(0.25, 0.25)) < radius) { distances = distances + 1.0; }
-			if (length(pixCoord + vec2(0.75, 0.25)) < radius) { distances = distances + 1.0; }
-			if (length(pixCoord + vec2(0.25, 0.75)) < radius) { distances = distances + 1.0; }
-			if (length(pixCoord + vec2(0.75, 0.75)) < radius) { distances = distances + 1.0; }
+	if (primitiveMultisample == 1 && dist > radius - 1.0) {
+	    float distances = 0.0;
+	    if (length(pixCoord + vec2(0.25, 0.25)) < radius) { distances = distances + 1.0; }
+	    if (length(pixCoord + vec2(0.75, 0.25)) < radius) { distances = distances + 1.0; }
+	    if (length(pixCoord + vec2(0.25, 0.75)) < radius) { distances = distances + 1.0; }
+	    if (length(pixCoord + vec2(0.75, 0.75)) < radius) { distances = distances + 1.0; }
 
-			if (distances == 0.0)
-				discard;
+	    if (distances == 0.0)
+		discard;
 
-			distances = distances / 4.0;
+	    distances = distances / 4.0;
 
-			)#" + colorVarName + R"#( = )#" + colorVarName + R"#( * distances;
-		}
+	    )#" + colorVarName + R"#( = )#" + colorVarName + R"#( * distances;
+        }
 
-	}
-	)#";
+    }
+)#";
 };
 
 inline const std::string QUADVERTSRC = R"#(
@@ -67,13 +67,14 @@ uniform int primitiveMultisample;
 uniform int ignoreCorners;
 
 void main() {
-	vec4 pixColor = v_color;
 
-	if (radius > 0.0) {
-                )#" + ROUNDED_SHADER_FUNC("pixColor") + R"#(
-	}
+    vec4 pixColor = v_color;
 
-	gl_FragColor = pixColor;
+    if (radius > 0.0) {
+	)#" + ROUNDED_SHADER_FUNC("pixColor") + R"#(
+    }
+
+    gl_FragColor = pixColor;
 })#";
 
 inline const std::string TEXVERTSRC = R"#(
@@ -83,8 +84,8 @@ attribute vec2 texcoord;
 varying vec2 v_texcoord;
 
 void main() {
-	gl_Position = vec4(proj * vec3(pos, 1.0), 1.0);
-	v_texcoord = texcoord;
+    gl_Position = vec4(proj * vec3(pos, 1.0), 1.0);
+    v_texcoord = texcoord;
 })#";
 
 // this is texture rendering!!
@@ -109,21 +110,21 @@ uniform int ignoreCorners;
 
 void main() {
 
-	vec4 pixColor = texture2D(tex, v_texcoord);
+    vec4 pixColor = texture2D(tex, v_texcoord);
 
-	if (discardOpaque == 1 && pixColor[3] * alpha == 1.0)
-		discard;
+    if (discardOpaque == 1 && pixColor[3] * alpha == 1.0)
+	discard;
 
 
-	if (applyTint == 1) {
-		pixColor[0] = pixColor[0] * tint[0];
-		pixColor[1] = pixColor[1] * tint[1];
-		pixColor[2] = pixColor[2] * tint[2];
-	}
+    if (applyTint == 1) {
+	pixColor[0] = pixColor[0] * tint[0];
+	pixColor[1] = pixColor[1] * tint[1];
+	pixColor[2] = pixColor[2] * tint[2];
+    }
 
-	)#" + ROUNDED_SHADER_FUNC("pixColor") + R"#(
+    )#" + ROUNDED_SHADER_FUNC("pixColor") + R"#(
 
-	gl_FragColor = pixColor * alpha;
+    gl_FragColor = pixColor * alpha;
 })#";
 
 inline const std::string TEXFRAGSRCRGBX = R"#(
@@ -147,20 +148,20 @@ uniform int ignoreCorners;
 
 void main() {
 
-	if (discardOpaque == 1 && alpha == 1.0)
-		discard;
+    if (discardOpaque == 1 && alpha == 1.0)
+	discard;
 
-	vec4 pixColor = vec4(texture2D(tex, v_texcoord).rgb, 1.0);
+    vec4 pixColor = vec4(texture2D(tex, v_texcoord).rgb, 1.0);
 
-	if (applyTint == 1) {
-		pixColor[0] = pixColor[0] * tint[0];
-		pixColor[1] = pixColor[1] * tint[1];
-		pixColor[2] = pixColor[2] * tint[2];
-	}
+    if (applyTint == 1) {
+	pixColor[0] = pixColor[0] * tint[0];
+	pixColor[1] = pixColor[1] * tint[1];
+	pixColor[2] = pixColor[2] * tint[2];
+    }
 
-	)#" + ROUNDED_SHADER_FUNC("pixColor") + R"#(
+    )#" + ROUNDED_SHADER_FUNC("pixColor") + R"#(
 
-	gl_FragColor = pixColor * alpha;
+    gl_FragColor = pixColor * alpha;
 })#";
 
 inline const std::string FRAGBLUR1 = R"#(
@@ -173,15 +174,15 @@ uniform float radius;
 uniform vec2 halfpixel;
 
 void main() {
-	vec2 uv = v_texcoord * 2.0;
+    vec2 uv = v_texcoord * 2.0;
 
-        vec4 sum = texture2D(tex, uv) * 4.0;
-        sum += texture2D(tex, uv - halfpixel.xy * radius);
-        sum += texture2D(tex, uv + halfpixel.xy * radius);
-        sum += texture2D(tex, uv + vec2(halfpixel.x, -halfpixel.y) * radius);
-        sum += texture2D(tex, uv - vec2(halfpixel.x, -halfpixel.y) * radius);
+    vec4 sum = texture2D(tex, uv) * 4.0;
+    sum += texture2D(tex, uv - halfpixel.xy * radius);
+    sum += texture2D(tex, uv + halfpixel.xy * radius);
+    sum += texture2D(tex, uv + vec2(halfpixel.x, -halfpixel.y) * radius);
+    sum += texture2D(tex, uv - vec2(halfpixel.x, -halfpixel.y) * radius);
 
-        gl_FragColor = sum / 8.0;
+    gl_FragColor = sum / 8.0;
 }
 )#";
 
@@ -195,19 +196,19 @@ uniform float radius;
 uniform vec2 halfpixel;
 
 void main() {
-	vec2 uv = v_texcoord / 2.0;
+    vec2 uv = v_texcoord / 2.0;
 
-        vec4 sum = texture2D(tex, uv + vec2(-halfpixel.x * 2.0, 0.0) * radius);
+    vec4 sum = texture2D(tex, uv + vec2(-halfpixel.x * 2.0, 0.0) * radius);
 
-        sum += texture2D(tex, uv + vec2(-halfpixel.x, halfpixel.y) * radius) * 2.0;
-        sum += texture2D(tex, uv + vec2(0.0, halfpixel.y * 2.0) * radius);
-        sum += texture2D(tex, uv + vec2(halfpixel.x, halfpixel.y) * radius) * 2.0;
-        sum += texture2D(tex, uv + vec2(halfpixel.x * 2.0, 0.0) * radius);
-        sum += texture2D(tex, uv + vec2(halfpixel.x, -halfpixel.y) * radius) * 2.0;
-        sum += texture2D(tex, uv + vec2(0.0, -halfpixel.y * 2.0) * radius);
-        sum += texture2D(tex, uv + vec2(-halfpixel.x, -halfpixel.y) * radius) * 2.0;
+    sum += texture2D(tex, uv + vec2(-halfpixel.x, halfpixel.y) * radius) * 2.0;
+    sum += texture2D(tex, uv + vec2(0.0, halfpixel.y * 2.0) * radius);
+    sum += texture2D(tex, uv + vec2(halfpixel.x, halfpixel.y) * radius) * 2.0;
+    sum += texture2D(tex, uv + vec2(halfpixel.x * 2.0, 0.0) * radius);
+    sum += texture2D(tex, uv + vec2(halfpixel.x, -halfpixel.y) * radius) * 2.0;
+    sum += texture2D(tex, uv + vec2(0.0, -halfpixel.y * 2.0) * radius);
+    sum += texture2D(tex, uv + vec2(-halfpixel.x, -halfpixel.y) * radius) * 2.0;
 
-        gl_FragColor = sum / 12.0;
+    gl_FragColor = sum / 12.0;
 }
 )#";
 
@@ -234,18 +235,19 @@ uniform int ignoreCorners;
 
 void main() {
 
-	vec4 pixColor = texture2D(texture0, v_texcoord);
+    vec4 pixColor = texture2D(texture0, v_texcoord);
 
-	if (discardOpaque == 1 && pixColor[3] * alpha == 1.0)
-		discard;
+    if (discardOpaque == 1 && pixColor[3] * alpha == 1.0)
+	discard;
 
-	if (applyTint == 1) {
-		pixColor[0] = pixColor[0] * tint[0];
-		pixColor[1] = pixColor[1] * tint[1];
-		pixColor[2] = pixColor[2] * tint[2];
-	}
+    if (applyTint == 1) {
+	pixColor[0] = pixColor[0] * tint[0];
+	pixColor[1] = pixColor[1] * tint[1];
+	pixColor[2] = pixColor[2] * tint[2];
+    }
 
-	)#" + ROUNDED_SHADER_FUNC("pixColor") + R"#(
+    )#" + ROUNDED_SHADER_FUNC("pixColor") + R"#(
 
-	gl_FragColor = pixColor * alpha;
-})#";
+    gl_FragColor = pixColor * alpha;
+}
+)#";

--- a/src/render/shaders/Textures.hpp
+++ b/src/render/shaders/Textures.hpp
@@ -3,138 +3,38 @@
 #include <string>
 
 inline static constexpr auto ROUNDED_SHADER_FUNC = [](const std::string colorVarName) -> std::string {
-    return R"#(
-		if (pixCoord[0] < topLeft[0]) {
-		// we're close left
-		if (pixCoord[1] < topLeft[1]) {
-			// top
+        return R"#(
 
-			if (ignoreCorners == 1) {
+	// branchless baby!
+	vec2 pixCoord = v_texcoord - vec2(0.5);
+	pixCoord *= (vec2(lessThan(pixCoord, vec2(0.0))) * vec2(-2.0) + vec2(1.0)) * fullSize;
+	pixCoord -= (bottomRight - topLeft) * vec2(0.5);
+
+	if (all(greaterThan(pixCoord, vec2(0.0)))) {
+
+		if (ignoreCorners == 1)
+			discard;
+
+		float dist = length(pixCoord);
+
+		if (dist > radius)
+			discard;
+
+		if (primitiveMultisample == 1 && dist > radius - 1.0) {
+			float distances = 0.0;
+			if (length(pixCoord - vec2(0.25, 0.25)) < radius) { distances = distances + 1.0; }
+			if (length(pixCoord - vec2(0.75, 0.25)) < radius) { distances = distances + 1.0; }
+			if (length(pixCoord - vec2(0.25, 0.75)) < radius) { distances = distances + 1.0; }
+			if (length(pixCoord - vec2(0.75, 0.75)) < radius) { distances = distances + 1.0; }
+
+			if (distances == 0.0)
 				discard;
-				return;
-			}
 
-			float topLeftDistance = distance(topLeft, pixCoord);
+			distances = distances / 4.0;
 
-			if (topLeftDistance > radius - 1.0) {
-				if (primitiveMultisample == 0 && topLeftDistance > radius) {
-					discard;
-					return;
-				} else if (primitiveMultisample == 1) {
-					float distances = 0.0;
-					if (distance(topLeft, pixCoord + vec2(0.25, 0.25)) < radius) { distances = distances + 1.0; }
-					if (distance(topLeft, pixCoord + vec2(0.75, 0.25)) < radius) { distances = distances + 1.0; }
-					if (distance(topLeft, pixCoord + vec2(0.25, 0.75)) < radius) { distances = distances + 1.0; }
-					if (distance(topLeft, pixCoord + vec2(0.75, 0.75)) < radius) { distances = distances + 1.0; }
-
-					if (distances == 0.0) {
-						discard;
-						return;
-					}
-
-					distances = distances / 4.0;
-
-					)#" + colorVarName + R"#( = )#" + colorVarName + R"#( * distances;
-				}
-			}
-		} else if (pixCoord[1] > bottomRight[1]) {
-			// bottom
-
-			if (ignoreCorners == 1) {
-				discard;
-				return;
-			}
-
-			float topLeftDistance = distance(vec2(topLeft[0], bottomRight[1]), pixCoord);
-
-			if (topLeftDistance > radius - 1.0) {
-				if (primitiveMultisample == 0 && topLeftDistance > radius) {
-					discard;
-					return;
-				} else if (primitiveMultisample == 1) {
-					float distances = 0.0;
-					if (distance(vec2(topLeft[0], bottomRight[1]), pixCoord + vec2(0.25, 0.25)) < radius) { distances = distances + 1.0; }
-					if (distance(vec2(topLeft[0], bottomRight[1]), pixCoord + vec2(0.75, 0.25)) < radius) { distances = distances + 1.0; }
-					if (distance(vec2(topLeft[0], bottomRight[1]), pixCoord + vec2(0.25, 0.75)) < radius) { distances = distances + 1.0; }
-					if (distance(vec2(topLeft[0], bottomRight[1]), pixCoord + vec2(0.75, 0.75)) < radius) { distances = distances + 1.0; }
-
-					if (distances == 0.0) {
-						discard;
-						return;
-					}
-
-					distances = distances / 4.0;
-
-					)#" + colorVarName + R"#( = )#" + colorVarName + R"#( * distances;
-				}
-			}
+			/* )#" + colorVarName + R"#( = )#" + colorVarName + R"#( * distances; */
 		}
-	}
-	else if (pixCoord[0] > bottomRight[0]) {
-		// we're close right
-		if (pixCoord[1] < topLeft[1]) {
-			// top
 
-			if (ignoreCorners == 1) {
-				discard;
-				return;
-			}
-
-			float topLeftDistance = distance(vec2(bottomRight[0], topLeft[1]), pixCoord);
-
-			if (topLeftDistance > radius - 1.0) {
-				if (primitiveMultisample == 0 && topLeftDistance > radius) {
-					discard;
-					return;
-				} else if (primitiveMultisample == 1) {
-					float distances = 0.0;
-					if (distance(vec2(bottomRight[0], topLeft[1]), pixCoord + vec2(0.25, 0.25)) < radius) { distances = distances + 1.0; }
-					if (distance(vec2(bottomRight[0], topLeft[1]), pixCoord + vec2(0.75, 0.25)) < radius) { distances = distances + 1.0; }
-					if (distance(vec2(bottomRight[0], topLeft[1]), pixCoord + vec2(0.25, 0.75)) < radius) { distances = distances + 1.0; }
-					if (distance(vec2(bottomRight[0], topLeft[1]), pixCoord + vec2(0.75, 0.75)) < radius) { distances = distances + 1.0; }
-
-					if (distances == 0.0) {
-						discard;
-						return;
-					}
-
-					distances = distances / 4.0;
-
-					)#" + colorVarName + R"#( = )#" + colorVarName + R"#( * distances;
-				}
-			}
-		} else if (pixCoord[1] > bottomRight[1]) {
-			// bottom
-
-			if (ignoreCorners == 1) {
-				discard;
-				return;
-			}
-
-			float topLeftDistance = distance(bottomRight, pixCoord);
-
-			if (topLeftDistance > radius - 1.0) {
-				if (primitiveMultisample == 0 && topLeftDistance > radius) {
-					discard;
-					return;
-				} else if (primitiveMultisample == 1) {
-					float distances = 0.0;
-					if (distance(bottomRight, pixCoord + vec2(0.25, 0.25)) < radius) { distances = distances + 1.0; }
-					if (distance(bottomRight, pixCoord + vec2(0.75, 0.25)) < radius) { distances = distances + 1.0; }
-					if (distance(bottomRight, pixCoord + vec2(0.25, 0.75)) < radius) { distances = distances + 1.0; }
-					if (distance(bottomRight, pixCoord + vec2(0.75, 0.75)) < radius) { distances = distances + 1.0; }
-
-					if (distances == 0.0) {
-						discard;
-						return;
-					}
-
-					distances = distances / 4.0;
-
-					)#" + colorVarName + R"#( = )#" + colorVarName + R"#( * distances;
-				}
-			}
-		}
 	}
 	)#";
 };
@@ -167,16 +67,11 @@ uniform int primitiveMultisample;
 uniform int ignoreCorners;
 
 void main() {
-	if (radius == 0.0) {
-		gl_FragColor = v_color;
-		return;
-	}
-
 	vec4 pixColor = v_color;
 
-    vec2 pixCoord = fullSize * v_texcoord;
-
-	)#" + ROUNDED_SHADER_FUNC("pixColor") + R"#(
+	if (radius > 0.0) {
+                )#" + ROUNDED_SHADER_FUNC("pixColor") + R"#(
+	}
 
 	gl_FragColor = pixColor;
 })#";
@@ -192,6 +87,7 @@ void main() {
 	v_texcoord = texcoord;
 })#";
 
+// this is texture rendering!!
 inline const std::string TEXFRAGSRCRGBA = R"#(
 precision mediump float;
 varying vec2 v_texcoord; // is in 0-1
@@ -215,10 +111,9 @@ void main() {
 
 	vec4 pixColor = texture2D(tex, v_texcoord);
 
-	if (discardOpaque == 1 && pixColor[3] * alpha == 1.0) {
+	if (discardOpaque == 1 && pixColor[3] * alpha == 1.0)
 		discard;
-		return;
-	}
+
 
 	if (applyTint == 1) {
 		pixColor[0] = pixColor[0] * tint[0];
@@ -226,10 +121,7 @@ void main() {
 		pixColor[2] = pixColor[2] * tint[2];
 	}
 
-	vec2 pixCoord = fullSize * v_texcoord;
-
-	)#" + ROUNDED_SHADER_FUNC("pixColor") +
-                                          R"#(
+	)#" + ROUNDED_SHADER_FUNC("pixColor") + R"#(
 
 	gl_FragColor = pixColor * alpha;
 })#";
@@ -255,10 +147,8 @@ uniform int ignoreCorners;
 
 void main() {
 
-	if (discardOpaque == 1 && alpha == 1.0) {
+	if (discardOpaque == 1 && alpha == 1.0)
 		discard;
-		return;
-	}
 
 	vec4 pixColor = vec4(texture2D(tex, v_texcoord).rgb, 1.0);
 
@@ -268,10 +158,7 @@ void main() {
 		pixColor[2] = pixColor[2] * tint[2];
 	}
 
-	vec2 pixCoord = fullSize * v_texcoord;
-
-	)#" + ROUNDED_SHADER_FUNC("pixColor") +
-                                          R"#(
+	)#" + ROUNDED_SHADER_FUNC("pixColor") + R"#(
 
 	gl_FragColor = pixColor * alpha;
 })#";
@@ -288,12 +175,13 @@ uniform vec2 halfpixel;
 void main() {
 	vec2 uv = v_texcoord * 2.0;
 
-    vec4 sum = texture2D(tex, uv) * 4.0;
-    sum += texture2D(tex, uv - halfpixel.xy * radius);
-    sum += texture2D(tex, uv + halfpixel.xy * radius);
-    sum += texture2D(tex, uv + vec2(halfpixel.x, -halfpixel.y) * radius);
-    sum += texture2D(tex, uv - vec2(halfpixel.x, -halfpixel.y) * radius);
-    gl_FragColor = sum / 8.0;
+        vec4 sum = texture2D(tex, uv) * 4.0;
+        sum += texture2D(tex, uv - halfpixel.xy * radius);
+        sum += texture2D(tex, uv + halfpixel.xy * radius);
+        sum += texture2D(tex, uv + vec2(halfpixel.x, -halfpixel.y) * radius);
+        sum += texture2D(tex, uv - vec2(halfpixel.x, -halfpixel.y) * radius);
+
+        gl_FragColor = sum / 8.0;
 }
 )#";
 
@@ -309,17 +197,17 @@ uniform vec2 halfpixel;
 void main() {
 	vec2 uv = v_texcoord / 2.0;
 
-    vec4 sum = texture2D(tex, uv + vec2(-halfpixel.x * 2.0, 0.0) * radius);
+        vec4 sum = texture2D(tex, uv + vec2(-halfpixel.x * 2.0, 0.0) * radius);
 
-    sum += texture2D(tex, uv + vec2(-halfpixel.x, halfpixel.y) * radius) * 2.0;
-    sum += texture2D(tex, uv + vec2(0.0, halfpixel.y * 2.0) * radius);
-    sum += texture2D(tex, uv + vec2(halfpixel.x, halfpixel.y) * radius) * 2.0;
-    sum += texture2D(tex, uv + vec2(halfpixel.x * 2.0, 0.0) * radius);
-    sum += texture2D(tex, uv + vec2(halfpixel.x, -halfpixel.y) * radius) * 2.0;
-    sum += texture2D(tex, uv + vec2(0.0, -halfpixel.y * 2.0) * radius);
-    sum += texture2D(tex, uv + vec2(-halfpixel.x, -halfpixel.y) * radius) * 2.0;
+        sum += texture2D(tex, uv + vec2(-halfpixel.x, halfpixel.y) * radius) * 2.0;
+        sum += texture2D(tex, uv + vec2(0.0, halfpixel.y * 2.0) * radius);
+        sum += texture2D(tex, uv + vec2(halfpixel.x, halfpixel.y) * radius) * 2.0;
+        sum += texture2D(tex, uv + vec2(halfpixel.x * 2.0, 0.0) * radius);
+        sum += texture2D(tex, uv + vec2(halfpixel.x, -halfpixel.y) * radius) * 2.0;
+        sum += texture2D(tex, uv + vec2(0.0, -halfpixel.y * 2.0) * radius);
+        sum += texture2D(tex, uv + vec2(-halfpixel.x, -halfpixel.y) * radius) * 2.0;
 
-    gl_FragColor = sum / 12.0;
+        gl_FragColor = sum / 12.0;
 }
 )#";
 
@@ -348,10 +236,8 @@ void main() {
 
 	vec4 pixColor = texture2D(texture0, v_texcoord);
 
-	if (discardOpaque == 1 && pixColor[3] * alpha == 1.0) {
+	if (discardOpaque == 1 && pixColor[3] * alpha == 1.0)
 		discard;
-		return;
-	}
 
 	if (applyTint == 1) {
 		pixColor[0] = pixColor[0] * tint[0];
@@ -359,10 +245,7 @@ void main() {
 		pixColor[2] = pixColor[2] * tint[2];
 	}
 
-	vec2 pixCoord = fullSize * v_texcoord;
-
-	)#" + ROUNDED_SHADER_FUNC("pixColor") +
-                                         R"#(
+	)#" + ROUNDED_SHADER_FUNC("pixColor") + R"#(
 
 	gl_FragColor = pixColor * alpha;
 })#";


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This optimizes the rounding part of the Textures.hpp shaders.
Also the Shaders.h file is now only included by OpenGL.cpp, 
that way only OpenGL.cpp has to be recompiled if a shader was changed.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
It shouldn't change the behavior at all.

#### Is it ready for merging, or does it need work?
I tried it, and it is working for me, but should be tested in other configurations/ on other computers.

