### PR TITLE
Improve the control of shadow_render_power & make it less confusing.

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -79,7 +79,7 @@ void CConfigManager::setDefaultVars() {
     configValues["decoration:no_blur_on_oversized"].intValue = 0;
     configValues["decoration:drop_shadow"].intValue = 1;
     configValues["decoration:shadow_range"].intValue = 4;
-    configValues["decoration:shadow_render_power"].intValue = 3;
+    configValues["decoration:shadow_render_power"].floatValue = 0.5f;
     configValues["decoration:shadow_ignore_window"].intValue = 1;
     configValues["decoration:shadow_offset"].vecValue = Vector2D();
     configValues["decoration:col.shadow"].intValue = 0xee1a1a1a;

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1038,9 +1038,9 @@ void CHyprOpenGLImpl::renderRoundedShadow(wlr_box* box, int round, int range, fl
     RASSERT((box->width > 0 && box->height > 0), "Tried to render shadow with width/height < 0!");
     RASSERT(m_pCurrentWindow, "Tried to render shadow without a window!");
 
-    static auto *const PSHADOWPOWER = &g_pConfigManager->getConfigValuePtr("decoration:shadow_render_power")->intValue;
+    static auto *const PSHADOWPOWER = &g_pConfigManager->getConfigValuePtr("decoration:shadow_render_power")->floatValue;
 
-    const auto SHADOWPOWER = std::clamp((int)*PSHADOWPOWER, 1, 4);
+    const auto SHADOWPOWER = std::max(*PSHADOWPOWER , 0.0f); // TODO: we should do that only once at startup and if the config changed
 
     const auto col = m_pCurrentWindow->m_cRealShadowColor.col();
 
@@ -1069,7 +1069,7 @@ void CHyprOpenGLImpl::renderRoundedShadow(wlr_box* box, int round, int range, fl
     glUniform2f(m_RenderData.pCurrentMonData->m_shSHADOW.topLeft, (float)TOPLEFT.x, (float)TOPLEFT.y);
     glUniform2f(m_RenderData.pCurrentMonData->m_shSHADOW.bottomRight, (float)BOTTOMRIGHT.x, (float)BOTTOMRIGHT.y);
     glUniform2f(m_RenderData.pCurrentMonData->m_shSHADOW.fullSize, (float)FULLSIZE.x, (float)FULLSIZE.y);
-    glUniform1f(m_RenderData.pCurrentMonData->m_shSHADOW.radius, range + round);
+    glUniform1f(m_RenderData.pCurrentMonData->m_shSHADOW.radius, round);
     glUniform1f(m_RenderData.pCurrentMonData->m_shSHADOW.range, range);
     glUniform1f(m_RenderData.pCurrentMonData->m_shSHADOW.shadowPower, SHADOWPOWER);
 

--- a/src/render/shaders/Shadow.hpp
+++ b/src/render/shaders/Shadow.hpp
@@ -14,26 +14,26 @@ uniform float radius;
 uniform float range;
 uniform float shadowPower;
 
-float pixAlphaRoundedDistance(float distanceToCorner) {
-     if (distanceToCorner > radius) {
-        return 0.0;
-    }
+float pixAlphaRoundedDistance(float distanceToRadiusCenter) {
+    float distanceToCorner = distanceToRadiusCenter - radius;
 
-    if (distanceToCorner > radius - range) {
-        return pow((range - (distanceToCorner - radius + range)) / range, shadowPower); // i think?
-    }
+    if (distanceToCorner > range)
+        return 0.0;
+
+    if (distanceToCorner > 0.0)
+        return 1.0 - pow(distanceToCorner / range, shadowPower);
 
     return 1.0;
 }
 
 void main() {
 
-	vec4 pixColor = v_color;
+    vec4 pixColor = v_color;
     float originalAlpha = pixColor[3];
 
     bool done = false;
 
-	vec2 pixCoord = fullSize * v_texcoord;
+    vec2 pixCoord = fullSize * v_texcoord;
 
     // ok, now we check the distance to a border.
 
@@ -66,17 +66,17 @@ void main() {
         float distanceL = pixCoord[0];
         float distanceR = fullSize[0] - pixCoord[0];
 
-        // get the smallest
-        float smallest = min(min(distanceT, distanceB), min(distanceL, distanceR));
+        // get the distance to the closest edge
+        float distanceToEdge = range - min(min(distanceT, distanceB), min(distanceL, distanceR));
 
-        if (smallest < range) {
-            pixColor[3] = pixColor[3] * pow((smallest / range), shadowPower);
+        if (distanceToEdge > 0.0) {
+            pixColor[3] *= 1.0 - pow(distanceToEdge / range, shadowPower);
         }
     }
 
-    if (pixColor[3] == 0.0) {
+    if (pixColor[3] == 0.0) { // TODO: is this necessary?
         discard; return;
     }
 
-	gl_FragColor = pixColor;
+    gl_FragColor = pixColor;
 })#";


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
I changed the variable `shadow_render_power` to be a float.
further i changed how that works internally.
Now you have finegrained control over the power of the shadow:
At 0.0 no shadow will be visible (but it should not be confused with turning shadows off,
that should still be done by setting the `drop_shadow`)
I think this is less confusing to users who just think its the power of the shadow, and now nothing about `distance^x`.
until a value of 1.0 there is a smooth transition from full to no shadow within the range.
values more than 1.0 will result in a shadow that has it's full opacity for some way, and than starts to fade to 0.0 within the range.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

If you really prefer the way it worked before (higher power means stronger fading) i 
can change it to that with the same fine grained control as this one has.
But as mentioned above i think this is more intuitive.

@vaxerski i think it would be cool to have the shadow power be an animated variable.
Than if we later add individual window rules (right now it's just the color or am i wrong here?)
it could make a nice animation when switching windows.

#### Is it ready for merging, or does it need work?

It's ready to be tested by @fufexan (seems to be the tester here!?).
