### PR TITLE
focusedmon event check change

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -988,7 +988,7 @@ void CKeybindManager::moveFocusTo(std::string args) {
             Vector2D middle = PWINDOWTOCHANGETO->m_vRealPosition.goalv() + PWINDOWTOCHANGETO->m_vRealSize.goalv() / 2.f;
             g_pCompositor->warpCursorTo(middle);
 
-            if (PWINDOWTOCHANGETO->m_iMonitorID != g_pCompositor->m_pLastMonitor->ID) {
+            if (PLASTWINDOW->m_iMonitorID != PWINDOWTOCHANGETO->m_iMonitorID) {
                 // event
                 const auto PNEWMON = g_pCompositor->getMonitorFromID(PWINDOWTOCHANGETO->m_iMonitorID);
                 const auto PNEWWS = g_pCompositor->getWorkspaceByID(PNEWMON->activeWorkspace);


### PR DESCRIPTION
Compare PLASTWINDOW & PWINDOWTOCHANGETO m_iMonitorID's instead of PWINDOWTOCHANGETO->m_iMonitorID & g_pCompositor->m_pLastMonitor->ID

#### Describe your PR, what does it fix/add?
fixes #758, compairing `PWINDOWTOCHANGETO->m_iMonitorID` to `g_pCompositor->m_pLastMonitor->ID` misses conditions

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I'm largely unfamiliar with the code and am both unsure this is reliable and unsure it is good practice or fit

#### Is it ready for merging, or does it need work?
yes, its a single line change with as far as i can tell little to no effect on anything else in the project

