### PR TITLE
Remove texcoord from QUADFRAGSRC.

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -151,7 +151,6 @@ void CHyprOpenGLImpl::initShaders() {
     m_RenderData.pCurrentMonData->m_shQUAD.proj = glGetUniformLocation(prog, "proj");
     m_RenderData.pCurrentMonData->m_shQUAD.color = glGetUniformLocation(prog, "color");
     m_RenderData.pCurrentMonData->m_shQUAD.posAttrib = glGetAttribLocation(prog, "pos");
-    m_RenderData.pCurrentMonData->m_shQUAD.texAttrib = glGetAttribLocation(prog, "texcoord");
     m_RenderData.pCurrentMonData->m_shQUAD.topLeft = glGetUniformLocation(prog, "topLeft");
     m_RenderData.pCurrentMonData->m_shQUAD.fullSize = glGetUniformLocation(prog, "fullSize");
     m_RenderData.pCurrentMonData->m_shQUAD.radius = glGetUniformLocation(prog, "radius");

--- a/src/render/shaders/Textures.hpp
+++ b/src/render/shaders/Textures.hpp
@@ -54,7 +54,6 @@ void main() {
 inline const std::string QUADFRAGSRC = R"#(
 precision mediump float;
 varying vec4 v_color;
-varying vec2 v_texcoord;
 
 uniform vec2 topLeft;
 uniform vec2 fullSize;


### PR DESCRIPTION
Fixes gl errors if drop_shadows are enabled

texcoord is unused in the rounding part of the textureshaders. 
QUADFRAGSRC isn't using that variable inside the non rounding code. 
Because of that opengl optimizes that variable out, and is complaining if glGetAttribLocation is called on it.

