### PR TITLE
Fix getDeviceInt string arg "input:left_handed"

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -425,7 +425,7 @@ bool CKeybindManager::handleVT(xkb_keysym_t keysym) {
 
     const auto PSESSION = wlr_backend_get_session(g_pCompositor->m_sWLRBackend);
     if (PSESSION) {
-        const int TTY = keysym - XKB_KEY_XF86Switch_VT_1 + 1;
+        const unsigned int TTY = keysym - XKB_KEY_XF86Switch_VT_1 + 1;
 
         if (PSESSION->vtnr == TTY)
             return false; // don't do anything.

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -692,7 +692,7 @@ void CInputManager::setMouseConfigs() {
             else
                 libinput_device_config_click_set_method(LIBINPUTDEV, LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER);
 
-            if ((HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "left_handed") : g_pConfigManager->getInt("input:touchpad:left_handed")) == 0)
+            if ((HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "left_handed") : g_pConfigManager->getInt("input:left_handed")) == 0)
                 libinput_device_config_left_handed_set(LIBINPUTDEV, 0);
             else
                 libinput_device_config_left_handed_set(LIBINPUTDEV, 1);


### PR DESCRIPTION
Fixes https://github.com/hyprwm/Hyprland/issues/778
I guess it was intended this way?


