### PR TITLE
Add input:touchdevice:transform config

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -147,7 +147,7 @@ void CConfigManager::setDefaultVars() {
     configValues["input:touchpad:tap-to-click"].intValue = 1;
     configValues["input:touchpad:drag_lock"].intValue = 0;
     configValues["input:touchpad:scroll_factor"].floatValue = 1.f;
-    configValues["input:touchdevice:td_rotation"].intValue = 0;
+    configValues["input:touchdevice:transform"].intValue = 0;
 
     configValues["binds:pass_mouse_when_bound"].intValue = 0;
     configValues["binds:scroll_event_delay"].intValue = 300;
@@ -188,7 +188,7 @@ void CConfigManager::setDeviceDefaultVars(const std::string& dev) {
     cfgValues["drag_lock"].intValue = 0;
     cfgValues["left_handed"].intValue = 0;
     cfgValues["scroll_method"].strValue = STRVAL_EMPTY;
-    cfgValues["td_rotation"].intValue = 0;
+    cfgValues["transform"].intValue = 0;
 }
 
 void CConfigManager::setDefaultAnimationVars() {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -188,7 +188,7 @@ void CConfigManager::setDeviceDefaultVars(const std::string& dev) {
     cfgValues["drag_lock"].intValue = 0;
     cfgValues["left_handed"].intValue = 0;
     cfgValues["scroll_method"].strValue = STRVAL_EMPTY;
-    cfgValues["transform"].intValue = 0;
+    cfgValues["touch_transform"].intValue = 0;
 }
 
 void CConfigManager::setDefaultAnimationVars() {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -147,6 +147,7 @@ void CConfigManager::setDefaultVars() {
     configValues["input:touchpad:tap-to-click"].intValue = 1;
     configValues["input:touchpad:drag_lock"].intValue = 0;
     configValues["input:touchpad:scroll_factor"].floatValue = 1.f;
+    configValues["input:touchdevice:td_rotation"].intValue = 0;
 
     configValues["binds:pass_mouse_when_bound"].intValue = 0;
     configValues["binds:scroll_event_delay"].intValue = 300;
@@ -187,6 +188,7 @@ void CConfigManager::setDeviceDefaultVars(const std::string& dev) {
     cfgValues["drag_lock"].intValue = 0;
     cfgValues["left_handed"].intValue = 0;
     cfgValues["scroll_method"].strValue = STRVAL_EMPTY;
+    cfgValues["td_rotation"].intValue = 0;
 }
 
 void CConfigManager::setDefaultAnimationVars() {
@@ -1139,6 +1141,7 @@ void CConfigManager::loadConfigLoadVars() {
     if (!isFirstLaunch) {
         g_pInputManager->setKeyboardLayout();
         g_pInputManager->setPointerConfigs();
+        g_pInputManager->setTouchDeviceConfigs();
     }
 
     // Calculate the internal vars
@@ -1424,6 +1427,7 @@ void CConfigManager::dispatchExecOnce() {
     // set input, fixes some certain issues
     g_pInputManager->setKeyboardLayout();
     g_pInputManager->setPointerConfigs();
+    g_pInputManager->setTouchDeviceConfigs();
 
     // set ws names again
     for (auto& ws : g_pCompositor->m_vWorkspaces) {

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -562,6 +562,7 @@ std::string dispatchKeyword(std::string in) {
     if (COMMAND.contains("input") || COMMAND.contains("device:")) {
         g_pInputManager->setKeyboardLayout(); // update kb layout
         g_pInputManager->setPointerConfigs(); // update mouse cfgs
+        g_pInputManager->setTouchDeviceConfigs(); // update touch device cfgs
     }
 
     if (COMMAND.contains("general:layout"))

--- a/src/helpers/WLClasses.hpp
+++ b/src/helpers/WLClasses.hpp
@@ -326,6 +326,8 @@ struct SIMEPopup {
 struct STouchDevice {
     wlr_input_device* pWlrDevice = nullptr;
 
+    std::string name = "";
+
     DYNLISTENER(destroy);
 
     bool operator==(const STouchDevice& other) {

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1045,7 +1045,7 @@ void CInputManager::newTouchDevice(wlr_input_device* pDevice) {
 
 void CInputManager::setTouchDeviceConfigs() {
     // The third row is always 0 0 1 and is not expected by `libinput_device_config_calibration_set_matrix`
-    const float MATRICES[8][6] = {
+    static const float MATRICES[8][6] = {
        { // normal
         1, 0, 0,
         0, 1, 0

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1090,7 +1090,7 @@ void CInputManager::setTouchDeviceConfigs() {
         if (wlr_input_device_is_libinput(m.pWlrDevice)) {
             const auto LIBINPUTDEV = (libinput_device*)wlr_libinput_get_device_handle(m.pWlrDevice);
 
-            const int ROTATION = std::clamp(HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "transform") : g_pConfigManager->getInt("input:touchdevice:transform"), 0, 7);
+            const int ROTATION = std::clamp(HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "touch_transform") : g_pConfigManager->getInt("input:touchdevice:transform"), 0, 7);
             libinput_device_config_calibration_set_matrix(LIBINPUTDEV, MATRICES[ROTATION]);
         }
     }

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -53,6 +53,7 @@ public:
 
     void            setKeyboardLayout();
     void            setPointerConfigs();
+    void            setTouchDeviceConfigs();
 
     void            updateDragIcon();
     void            updateCapabilities(wlr_input_device*);


### PR DESCRIPTION
Add support for touch device roation. 

The rotation is set globally with `input:touchdevice:td_rotation` and by device with `td_rotation` in a device block.

#### Describe your PR, what does it fix/add?

When rotating the display of a touch screen, the input from the touch device don't take into acount the roation. This PR allows to set a calibration matrix that rotate the input of a touch device by steeps of 90°.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I'm not sure about how to configure the calibration matrix. I ended up getting an index from the config file to select a matrix from an array of matrices defined in `setTouchDeviceConfigs()`, but there is probably a better way to do it.

#### Is it ready for merging, or does it need work?

It works on my machine :tm:, but I'm not familiar with this code base, so this needs a good proofreading by someone who is.