### PR TITLE
fix invalid json output by adding a missing comma

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -499,7 +499,7 @@ std::string versionRequest(HyprCtl::eHyprCtlOutputFormat format) {
 R"#({
     "branch": "%s",
     "commit": "%s",
-    "dirty": %s
+    "dirty": %s,
     "commit_message": "%s",
     "flags": [)#", GIT_BRANCH, GIT_COMMIT_HASH, (strcmp(GIT_DIRTY, "dirty") == 0 ? "true" : "false"), removeBeginEndSpacesTabs(GIT_COMMIT_MESSAGE).c_str());
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
fixes the json output when executing `hyprctl version -j`

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
nope

#### Is it ready for merging, or does it need work?
yes its ready!


