### PR TITLE
Nix modules: fix default environment variables

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -92,7 +92,7 @@ in {
       ++ lib.optional cfg.xwayland.enable pkgs.xwayland;
 
     home.sessionVariables = lib.mkIf cfg.recommendedEnvironment {
-      GDK_BACKEND = "wayland";
+      GDK_BACKEND = "wayland,x11";
       _JAVA_AWT_WM_NONREPARENTING = "1";
       NIXOS_OZONE_WL = "1";
       XCURSOR_SIZE = toString config.home.pointerCursor.size or "24";

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -47,7 +47,7 @@ in {
       systemPackages = lib.optional (cfg.package != null) cfg.package;
 
       sessionVariables = mkIf cfg.recommendedEnvironment {
-        GDK_BACKEND = "wayland";
+        GDK_BACKEND = "wayland,x11";
         _JAVA_AWT_WM_NONREPARENTING = "1";
         NIXOS_OZONE_WL = "1";
         XCURSOR_SIZE = "24";


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This PR fixes a problem with the environment variables automatically set by the nix module as seen in #726.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
The nixos module was tested but the hm-module was not.
However it should not be a problem as the solution should be the same.

#### Is it ready for merging, or does it need work?
This PR is ready to be merged.

@fufexan @viperML