### PR TITLE
add `PKGBUILD` to ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ hyprctl/hyprctl
 gmon.out
 *.out
 *.tar.gz
+
+PKGBUILD


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds `PKGBUILD` to gitignore. Simply a minor QoL improvement for Arch users that use `makepkg` to build Hyprland.
Has no effect on other distributions and users.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Unless formatting is unsatisfactory (somehow), it's good to go.

#### Is it ready for merging, or does it need work?
Ready.
