### PR TITLE
add maxsize window rule

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -722,6 +722,7 @@ bool windowRuleValid(const std::string& RULE) {
         && RULE.find("move") != 0
         && RULE.find("size") != 0
         && RULE.find("minsize") != 0
+        && RULE.find("maxsize") != 0
         && RULE.find("pseudo") != 0
         && RULE.find("monitor") != 0
         && RULE != "nofocus"

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -269,6 +269,21 @@ void Events::listener_mapWindow(void* owner, void* data) {
                 } catch (...) {
                     Debug::log(LOG, "Rule minsize failed, rule: %s -> %s", r.szRule.c_str(), r.szValue.c_str());
                 }
+            } else if (r.szRule.find("maxsize") == 0) {
+                try {
+                    const auto VALUE = r.szRule.substr(r.szRule.find(" ") + 1);
+                    const auto SIZEXSTR = VALUE.substr(0, VALUE.find(" "));
+                    const auto SIZEYSTR = VALUE.substr(VALUE.find(" ") + 1);
+
+                    const auto SIZE = Vector2D(std::min((double)std::stoll(SIZEXSTR), PWINDOW->m_vRealSize.goalv().x), std::min((double)std::stoll(SIZEYSTR), PWINDOW->m_vRealSize.goalv().y));
+
+                    PWINDOW->m_vRealSize = SIZE;
+                    g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goalv());
+
+                    PWINDOW->setHidden(false);
+                } catch (...) {
+                    Debug::log(LOG, "Rule maxsize failed, rule: %s -> %s", r.szRule.c_str(), r.szValue.c_str());
+                }
             } else if (r.szRule.find("move") == 0) {
                 try {
                     const auto VALUE = r.szRule.substr(r.szRule.find(" ") + 1);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Adds the `max-size [x] [y]` window rule, basically the same as #788 just for limiting the max size of a window on spawn. Initially I thought only a min-size rule would be useful but having the option to also set max-size is quite handy.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Not the best at C++, but I think I did the right thing here by just replacing `std::max` (in the min-size rule) with `std::min` for getting the smaller size of the two. Seems to work as expected after testing.

#### Is it ready for merging, or does it need work?

Should be ready for merge :)
