### PR TITLE
add workspace id to `closewindow` event

### DIFF
--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -484,7 +484,7 @@ void Events::listener_unmapWindow(void* owner, void* data) {
 
     Debug::log(LOG, "Window %x unmapped (class %s)", PWINDOW, g_pXWaylandManager->getAppIDClass(PWINDOW).c_str());
 
-    g_pEventManager->postEvent(SHyprIPCEvent{"closewindow", getFormat("%x", PWINDOW)});
+    g_pEventManager->postEvent(SHyprIPCEvent{"closewindow", getFormat("%x,%i", PWINDOW, PWINDOW->m_iWorkspaceID)});
 
     if (!PWINDOW->m_bIsX11) {
         Debug::log(LOG, "Unregistered late callbacks XDG");


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Add the ability to get the workspace id of a window that was closed

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This will now have the same shape as `movewindow`

#### Is it ready for merging, or does it need work?
Tested locally, confirmed working:
![image](https://user-images.githubusercontent.com/10949200/196550747-e8a23055-eb35-4a40-931c-48e6c34afe35.png)



