### PR TITLE
Don't render tiled windows below fullscreen windows

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -125,7 +125,7 @@ void CHyprRenderer::renderWorkspaceWithFullscreenWindow(CMonitor* pMonitor, CWor
         if (w->m_iWorkspaceID != pMonitor->activeWorkspace)
             continue;
 
-        if (w->m_fAlpha.fl() == 0.f)
+        if (w->m_fAlpha.fl() == 0.f || !w->m_bFadingOut)
             continue;
 
         if (w->m_bIsFullscreen || w->m_bIsFloating)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Stops tiled windows from being rendered on a fullscreen workspace.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
Ready to merge

