### PR TITLE
meson.build,CMakeLists.txt: use sh instead of bash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,13 +22,13 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 execute_process(
-    COMMAND bash -c "git show ${GIT_COMMIT_HASH} | head -n 5 | tail -n 1"
+    COMMAND sh -c "git show ${GIT_COMMIT_HASH} | head -n 5 | tail -n 1"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     OUTPUT_VARIABLE GIT_COMMIT_MESSAGE
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 execute_process(
-    COMMAND bash -c "git diff-index --quiet HEAD -- || echo \"dirty\""
+    COMMAND sh -c "git diff-index --quiet HEAD -- || echo \"dirty\""
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     OUTPUT_VARIABLE GIT_DIRTY
     OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/meson.build
+++ b/meson.build
@@ -20,8 +20,8 @@ endif
 
 GIT_BRANCH = run_command('git', 'rev-parse', '--abbrev-ref', 'HEAD', check: false).stdout().strip()
 GIT_COMMIT_HASH = run_command('git', 'rev-parse', 'HEAD', check: false).stdout().strip()
-GIT_COMMIT_MESSAGE = run_command('bash', '-c', 'git show | head -n 5 | tail -n 1', check: false).stdout().strip()
-GIT_DIRTY = run_command('bash', '-c', 'git diff-index --quiet HEAD -- || echo "dirty"', check: false).stdout().strip()
+GIT_COMMIT_MESSAGE = run_command('sh', '-c', 'git show | head -n 5 | tail -n 1', check: false).stdout().strip()
+GIT_DIRTY = run_command('sh', '-c', 'git diff-index --quiet HEAD -- || echo "dirty"', check: false).stdout().strip()
 
 add_project_arguments(
   [


### PR DESCRIPTION
the commands ran under bash do not need bash's features, and bash doesn't exist on many systems.

in meson, theres a better way to get such variables.


