### PR TITLE
meson: Fallback to 'opengl' when 'GL' is not found.

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -18,7 +18,7 @@ executable('Hyprland', src,
     xcb_dep,
 
     dependency('pixman-1'),
-    dependency('GL'),
+    dependency('GL', 'opengl'),
     dependency('threads')
   ],
   install : true


### PR DESCRIPTION
This patch adds 'opengl' as a fallback to 'GL' for dependency lookup, to link with libglvnd configured without X11 support.

For OpenGL, libglvnd provides two pkg-config files: `gl.pc` with GLX support while `opengl.pc` not.  When building without X11 support, the former won't be installed.

#### Describe your PR, what does it fix/add?


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
N

#### Is it ready for merging, or does it need work?
It's ready for merging.

