### PR TITLE
meson: use gl instead of GL

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -18,7 +18,7 @@ executable('Hyprland', src,
     xcb_dep,
 
     dependency('pixman-1'),
-    dependency('GL', 'opengl'),
+    dependency('gl', 'opengl'),
     dependency('threads')
   ],
   install : true


### PR DESCRIPTION
`/usr/lib/pkgconfig/gl.pc`

#### Describe your PR, what does it fix/add?

this changes the dependency name of opengl to `gl` from `GL`, this is mainly for compatibility reasons.

#### Is it ready for merging, or does it need work?

[use src for globber](https://github.com/hyprwm/Hyprland/pull/936/commits/6c2487ec6ede13c723e3e66113d1eac0cd0ba8fd) needs testing.