### PR TITLE
meson: unbreak build with BSD find(1)

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -1,4 +1,4 @@
-globber = run_command('find', '-name', '*.cpp', check: true)
+globber = run_command('find', '.', '-name', '*.cpp', check: true)
 src = globber.stdout().strip().split('\n')
 
 executable('Hyprland', src,


### PR DESCRIPTION
According to [POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/find.html) *path* argument is not optional. Compare [GNU find(1)](https://www.man7.org/linux/man-pages/man1/find.1.html) with [FreeBSD find(1)](https://man.freebsd.org/find/1).

See also [downstream package](https://freshports.org/x11-wm/hyprland-devel).
