### PR TITLE
fix(nix): missing dependency

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -14,6 +14,7 @@
   mesa,
   mount,
   pango,
+  pciutils,
   wayland,
   wayland-protocols,
   wayland-scanner,
@@ -68,6 +69,7 @@ in
           wayland
           wayland-protocols
           wayland-scanner
+          pciutils
           (wlroots.override {inherit enableXWayland hidpiXWayland nvidiaPatches;})
         ]
         ++ lib.optionals enableXWayland [libxcb xcbutilwm xwayland];


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
fixes `sh: lspci: command not found` while launching hyprland od NixOS

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
not really

#### Is it ready for merging, or does it need work?
its a fairly easy fix, tested via `nix build` and it now works, so yeah its ready to be merged.

