### PR TITLE
Add bordercolor windowrule

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1415,7 +1415,9 @@ void CCompositor::updateWindowAnimatedDecorationValues(CWindow* pWindow) {
     if (RENDERDATA.isBorderColor)
         pWindow->m_cRealBorderColor = RENDERDATA.borderColor;
     else
-        pWindow->m_cRealBorderColor = CColor(pWindow == m_pLastWindow ? *ACTIVECOL : *INACTIVECOL);
+        pWindow->m_cRealBorderColor = CColor(pWindow == m_pLastWindow ?
+                                                        (pWindow->m_sSpecialRenderData.activeBorderColor >= 0 ? pWindow->m_sSpecialRenderData.activeBorderColor : *ACTIVECOL) :
+                                                        (pWindow->m_sSpecialRenderData.inactiveBorderColor >= 0 ? pWindow->m_sSpecialRenderData.inactiveBorderColor : *INACTIVECOL));
 
 
     // opacity

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -18,6 +18,9 @@ struct SWindowSpecialRenderData {
     float alpha = 1.f;
     float alphaInactive = -1.f; // -1 means unset
 
+    int64_t activeBorderColor = -1; // -1 means unset
+    int64_t inactiveBorderColor = -1; // -1 means unset
+
     // set by the layout
     bool rounding = true;
     bool border = true;

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -216,6 +216,20 @@ void Events::listener_mapWindow(void* owner, void* data) {
             } else {
                 Debug::log(ERR, "Rule idleinhibit: unknown mode %s", IDLERULE.c_str());
             }
+        } else if (r.szRule.find("bordercolor") == 0) {
+            try {
+                std::string colorPart = r.szRule.substr(r.szRule.find_first_of(' ') + 1);
+
+                if (colorPart.contains(' ')) {
+                    // we have a comma, 2 values
+                    PWINDOW->m_sSpecialRenderData.activeBorderColor = configStringToInt(colorPart.substr(0, colorPart.find_first_of(' ')));
+                    PWINDOW->m_sSpecialRenderData.inactiveBorderColor = configStringToInt(colorPart.substr(colorPart.find_first_of(' ') + 1));
+                } else {
+                    PWINDOW->m_sSpecialRenderData.activeBorderColor = configStringToInt(colorPart);
+                }
+            } catch(std::exception& e) {
+                Debug::log(ERR, "BorderColor rule \"%s\" failed with: %s", r.szRule.c_str(), e.what());
+            }
         }
     }
 
@@ -259,7 +273,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
         if (!PWORKSPACE) {
             std::string workspaceName = "";
             int workspaceID = 0;
-            
+
             if (requestedWorkspace.find("name:") == 0) {
                 workspaceName = requestedWorkspace.substr(5);
                 workspaceID = g_pCompositor->getNextAvailableNamedWorkspace();

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -187,10 +187,10 @@ void Events::listener_mapWindow(void* owner, void* data) {
             }
         } else if (r.szRule.find("opacity") == 0) {
             try {
-                std::string alphaPart = r.szRule.substr(r.szRule.find_first_of(' ') + 1);
+                std::string alphaPart = removeBeginEndSpacesTabs(r.szRule.substr(r.szRule.find_first_of(' ') + 1));
 
                 if (alphaPart.contains(' ')) {
-                    // we have a comma, 2 values
+                    // we have a space, 2 values
                     PWINDOW->m_sSpecialRenderData.alpha = std::stof(alphaPart.substr(0, alphaPart.find_first_of(' ')));
                     PWINDOW->m_sSpecialRenderData.alphaInactive = std::stof(alphaPart.substr(alphaPart.find_first_of(' ') + 1));
                 } else {
@@ -218,10 +218,10 @@ void Events::listener_mapWindow(void* owner, void* data) {
             }
         } else if (r.szRule.find("bordercolor") == 0) {
             try {
-                std::string colorPart = r.szRule.substr(r.szRule.find_first_of(' ') + 1);
+                std::string colorPart = removeBeginEndSpacesTabs(r.szRule.substr(r.szRule.find_first_of(' ') + 1));
 
                 if (colorPart.contains(' ')) {
-                    // we have a comma, 2 values
+                    // we have a space, 2 values
                     PWINDOW->m_sSpecialRenderData.activeBorderColor = configStringToInt(colorPart.substr(0, colorPart.find_first_of(' ')));
                     PWINDOW->m_sSpecialRenderData.inactiveBorderColor = configStringToInt(colorPart.substr(colorPart.find_first_of(' ') + 1));
                 } else {

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -484,6 +484,5 @@ int64_t configStringToInt(const std::string& VALUE) {
     } else if (VALUE.find("false") == 0 || VALUE.find("off") == 0 || VALUE.find("no") == 0) {
         return 0;
     }
-    else
-        return stol(VALUE);
+    return stol(VALUE);
 }

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -450,3 +450,40 @@ int64_t getPPIDof(int64_t pid) {
     }
 #endif
 }
+
+int64_t configStringToInt(const std::string& VALUE) {
+    if (VALUE.find("0x") == 0) {
+        // Values with 0x are hex
+        const auto VALUEWITHOUTHEX = VALUE.substr(2);
+        return stol(VALUEWITHOUTHEX, nullptr, 16);
+    } else if (VALUE.find("rgba(") == 0 && VALUE.find(")") == VALUE.length() - 1) {
+        const auto VALUEWITHOUTFUNC = VALUE.substr(5, VALUE.length() - 6);
+
+        if (removeBeginEndSpacesTabs(VALUEWITHOUTFUNC).length() != 8) {
+            Debug::log(WARN, "invalid length %i for rgba", VALUEWITHOUTFUNC.length());
+            throw std::invalid_argument("rgba() expects length of 8 characters (4 bytes)");
+        }
+
+        const auto RGBA = std::stol(VALUEWITHOUTFUNC, nullptr, 16);
+
+        // now we need to RGBA -> ARGB. The config holds ARGB only.
+        return (RGBA >> 8) + 0x1000000 * (RGBA & 0xFF);
+    } else if (VALUE.find("rgb(") == 0 && VALUE.find(")") == VALUE.length() - 1) {
+        const auto VALUEWITHOUTFUNC = VALUE.substr(4, VALUE.length() - 5);
+
+        if (removeBeginEndSpacesTabs(VALUEWITHOUTFUNC).length() != 6) {
+            Debug::log(WARN, "invalid length %i for rgb", VALUEWITHOUTFUNC.length());
+            throw std::invalid_argument("rgb() expects length of 6 characters (3 bytes)");
+        }
+
+        const auto RGB = std::stol(VALUEWITHOUTFUNC, nullptr, 16);
+
+        return RGB + 0xFF000000; // 0xFF for opaque
+    } else if (VALUE.find("true") == 0 || VALUE.find("on") == 0 || VALUE.find("yes") == 0) {
+        return 1;
+    } else if (VALUE.find("false") == 0 || VALUE.find("off") == 0 || VALUE.find("no") == 0) {
+        return 0;
+    }
+    else
+        return stol(VALUE);
+}

--- a/src/helpers/MiscFunctions.hpp
+++ b/src/helpers/MiscFunctions.hpp
@@ -15,6 +15,7 @@ float vecToRectDistanceSquared(const Vector2D& vec, const Vector2D& p1, const Ve
 void logSystemInfo();
 std::string execAndGet(const char*);
 int64_t getPPIDof(int64_t pid);
+int64_t configStringToInt(const std::string&);
 
 float getPlusMinusKeywordResult(std::string in, float relative);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
#880 Add a windowrule to change the bordercolor of the window. This overrides the active bordercolor OR the active bordercolor and inactive bordercolor.
i.e.
windowrulev2 = bordercolor rgb(EE4B55) rgb(880808),class:^(blueman-manager)$
windowrulev2 = bordercolor rgb(EE4B2B),class:^(foot)$

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?


