### PR TITLE
Add keyboards' leds update on Key/Mod press

### DIFF
--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -115,6 +115,8 @@ public:
 
     CInputMethodRelay m_sIMERelay;
 
+    void            updateKeyboardsLeds(wlr_input_device* pKeyboard);
+
     // for shared mods
     uint32_t        accumulateModsFromAllKBs();
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

It fixes an issue with some keyboards that attach a few devices at the same time (e.g. picture attached). When one of the mentioned devices changes its mods/keys state, other same-group keyboards are not aware of this change, hence they won't turn on/off the respective keyboard LEDs.

![image](https://user-images.githubusercontent.com/5362310/201471515-0b8a13ba-821b-481d-8219-198fed9ac330.png)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Probably this introduces another bug - other keyboards, which do not have modifiers locked, will show up as having one (because of the whole keyboard list update). The best solution, I suppose, would be to filter out/have a list of same-group keyboards and update LEDs only for them. Or just sync mods with other keyboards.

Gnome's mutter or wayfire (I only took a look at their code of keyboard LEDs sync because they worked for my keyboard) - synchronizes all keyboards' mods/LEDs.

#### Is it ready for merging, or does it need work?

As a quick fix, maybe yes. However, it all depends on how the member of this team decides. I suppose it would be beneficial to implement so mentioned solution, however, I am still not very familiar with keyboard logic in WLR.
