### PR TITLE
Setting wayland environment variables at startup

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -92,7 +92,6 @@ in {
       ++ lib.optional cfg.xwayland.enable pkgs.xwayland;
 
     home.sessionVariables = lib.mkIf cfg.recommendedEnvironment {
-      GDK_BACKEND = "wayland,x11";
       _JAVA_AWT_WM_NONREPARENTING = "1";
       NIXOS_OZONE_WL = "1";
       XCURSOR_SIZE = toString config.home.pointerCursor.size or "24";

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -92,10 +92,7 @@ in {
       ++ lib.optional cfg.xwayland.enable pkgs.xwayland;
 
     home.sessionVariables = lib.mkIf cfg.recommendedEnvironment {
-      _JAVA_AWT_WM_NONREPARENTING = "1";
       NIXOS_OZONE_WL = "1";
-      XCURSOR_SIZE = toString config.home.pointerCursor.size or "24";
-      XDG_SESSION_TYPE = "wayland";
     };
 
     xdg.configFile."hypr/hyprland.conf" = {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -47,7 +47,6 @@ in {
       systemPackages = lib.optional (cfg.package != null) cfg.package;
 
       sessionVariables = mkIf cfg.recommendedEnvironment {
-        GDK_BACKEND = "wayland,x11";
         _JAVA_AWT_WM_NONREPARENTING = "1";
         NIXOS_OZONE_WL = "1";
         XCURSOR_SIZE = "24";

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -47,10 +47,7 @@ in {
       systemPackages = lib.optional (cfg.package != null) cfg.package;
 
       sessionVariables = mkIf cfg.recommendedEnvironment {
-        _JAVA_AWT_WM_NONREPARENTING = "1";
         NIXOS_OZONE_WL = "1";
-        XCURSOR_SIZE = "24";
-        XDG_SESSION_TYPE = "wayland";
       };
     };
     fonts.enableDefaultFonts = mkDefault true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,7 +20,7 @@ int main(int argc, char** argv) {
         cmd += std::string(i == 0 ? "" : " ") + argv[i];
     setenv("HYPRLAND_CMD", cmd.c_str(), 1);
     setenv("XDG_BACKEND", "wayland", 1);
-    setenv("_JAVA_AWT_WM_NONREPARENTING", "1", 1);
+    setenv("_JAVA_AWT_WM_NONREPARENTING", "1", 0);
 
     // parse some args
     std::string configPath;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,8 @@ int main(int argc, char** argv) {
     for (auto i = 0; i < argc; ++i)
         cmd += std::string(i == 0 ? "" : " ") + argv[i];
     setenv("HYPRLAND_CMD", cmd.c_str(), 1);
+    setenv("XDG_BACKEND", "wayland", 1);
+    setenv("_JAVA_AWT_WM_NONREPARENTING", "1", 1);
 
     // parse some args
     std::string configPath;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Answers different issues brought up in #850
- sets `XDG_BACKEND` and `_JAVA_AWT_WM_NONREPARENTING` to `wayland` and `1` at startup, so that the user doesn't have to worry setting these up.
- removed these variables from nix modules recommended environment
- removed XCURSOR_SIZE from nix modules as it is already set

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
`NIXOS_OZONE_WL` for now stays in the nix modules as it would clutter non-nixos users environment variables and doesn't seem to interact badly with x11 sessions, though it it possible that it could.

#### Is it ready for merging, or does it need work?
it is fully ready to be merged

@fufexan