### PR TITLE
Unified border

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -408,6 +408,8 @@ void CHyprRenderer::renderAllClientsForMonitor(const int& ID, timespec* time) {
         return;
     }
 
+    CWindow* lastWindow = nullptr;
+
     // Non-floating main
     for (auto& w : g_pCompositor->m_vWindows) {
         if (w->isHidden() && !w->m_bIsMapped && !w->m_bFadingOut)
@@ -421,10 +423,19 @@ void CHyprRenderer::renderAllClientsForMonitor(const int& ID, timespec* time) {
 
         if (!shouldRenderWindow(w.get(), PMONITOR))
             continue;
+        
+        // render active window after all others of this pass
+        if (w.get() == g_pCompositor->m_pLastWindow) {
+            lastWindow = w.get();
+            continue;
+        }
 
         // render the bad boy
         renderWindow(w.get(), PMONITOR, time, true, RENDER_PASS_MAIN);
     }
+
+    if (lastWindow)
+        renderWindow(lastWindow, PMONITOR, time, true, RENDER_PASS_MAIN);
 
     // Non-floating popup
     for (auto& w : g_pCompositor->m_vWindows) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Using negative values for the "gaps_in" parameter already allows the user to create a unified border.
Here is an example config snippet for this case:


```
general {
    gaps_in = -1
    gaps_out = 0
    border_size = 2
}
```

Currently, the windows may be drawn in such an order that the border of the active window may not be displayed correctly.

This pull request ensures the active window is drawn last within the first rendering pass.

Here is an example illustrating the current and new behavior with "#" denoting the border of the active window:
```
Current behavior:      New behavior:
#########+--------+    ##########--------+
#        |        |    #        #        |
#        |        |    #        #        |
#########+--------+    ##########--------+
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nothing here.

#### Is it ready for merging, or does it need work?
It is ready for merging.