### PR TITLE
Bugfix unintentional cycling workspace with workspace_swipe

### DIFF
--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -188,7 +188,10 @@ void CInputManager::onSwipeUpdate(wlr_pointer_swipe_update_event* e) {
 
     m_sActiveSwipe.delta = std::clamp(m_sActiveSwipe.delta, (double)-*PSWIPEDIST, (double)*PSWIPEDIST);
 
-    if (((m_sActiveSwipe.pWorkspaceBegin->m_iID == workspaceIDLeft || m_sActiveSwipe.pWorkspaceBegin->m_iID == workspaceIDRight) && *PSWIPENEW && (m_sActiveSwipe.delta < 0)) || (m_sActiveSwipe.delta > 0 && g_pCompositor->getWindowsOnWorkspace(m_sActiveSwipe.pWorkspaceBegin->m_iID) == 0 && workspaceIDRight <= m_sActiveSwipe.pWorkspaceBegin->m_iID)) {
+    if ((m_sActiveSwipe.pWorkspaceBegin->m_iID == workspaceIDLeft && *PSWIPENEW && (m_sActiveSwipe.delta < 0)) ||
+        (m_sActiveSwipe.delta > 0 && g_pCompositor->getWindowsOnWorkspace(m_sActiveSwipe.pWorkspaceBegin->m_iID) == 0 && workspaceIDRight <= m_sActiveSwipe.pWorkspaceBegin->m_iID) ||
+        (m_sActiveSwipe.delta < 0 && m_sActiveSwipe.pWorkspaceBegin->m_iID <= workspaceIDLeft)) {
+
         m_sActiveSwipe.delta = 0;
         return;
     }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This PR solves the issue #1053 by adding a new option `workspace_swipe_left_cycle` to `gestures`.
If the option is enabled, it is possible to swipe left on the 1st workspace to go the the -1 workspace (old behaviour)
If the option is disabled, it is not possible to go to the other end of the workspaces by swiping (matching the auto new workspace behaviour)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
`workspace_swipe_left_cycle` is disabled by default (changing the default behaviour) but can be enabled if the user wishes

#### Is it ready for merging, or does it need work?
Yes, I would consider this ready for merging.

