### PR TITLE
Add option for retrieving first empty workspace

### DIFF
--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -244,6 +244,13 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
             result = WORKSPACE->m_iID;
         }
         outName = WORKSPACENAME;
+    } else if (in.find("empty") == 0) {
+        int id = 0;
+        while (++id < INT_MAX) {
+            const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(id);
+            if (!PWORKSPACE || (g_pCompositor->getWindowsOnWorkspace(id) == 0))
+                return id;
+        }
     } else {
         if ((in[0] == 'm' || in[0] == 'e') && (in[1] == '-' || in[1] == '+') && isNumber(in.substr(2))) {
             bool onAllMonitors = in[0] == 'e';


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This pull request adds a new option to reference workspaces with: "empty".
It references the first empty workspace, i.e. the workspace with the smallest (positive) workspace ID without any windows.

The new option allows to e.g. focus an empty workspace or move a window to an empty workspace by using something like this:

```
bind = $MOD, $KEY1, workspace, empty
bind = $MOD, $KEY2, movetoworkspace, empty
```

These examples are equivalent to the `ws_empty` and `ws_empty_move` actions in spectrwm.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I will add a pull request for updating the wiki entry soon after.

#### Is it ready for merging, or does it need work?

It is ready for merging.
