### PR TITLE
convert bordercolors to GradientValueData correctly

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1431,8 +1431,8 @@ void CCompositor::updateWindowAnimatedDecorationValues(CWindow* pWindow) {
         setBorderColor(RENDERDATA.borderColor);
     else
         setBorderColor(pWindow == m_pLastWindow ?
-                                            (pWindow->m_sSpecialRenderData.activeBorderColor >= 0 ? CGradientValueData(pWindow->m_sSpecialRenderData.activeBorderColor) : *ACTIVECOL) :
-                                            (pWindow->m_sSpecialRenderData.inactiveBorderColor >= 0 ? CGradientValueData(pWindow->m_sSpecialRenderData.inactiveBorderColor) : *INACTIVECOL));
+                                            (pWindow->m_sSpecialRenderData.activeBorderColor >= 0 ? CGradientValueData(CColor(pWindow->m_sSpecialRenderData.activeBorderColor)  * (1.f / 255.f)) : *ACTIVECOL) :
+                                            (pWindow->m_sSpecialRenderData.inactiveBorderColor >= 0 ? CGradientValueData(CColor(pWindow->m_sSpecialRenderData.inactiveBorderColor)  * (1.f / 255.f)) : *INACTIVECOL));
 
 
     // opacity


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Conversion from int to CGradientValueData did not happen correctly after gradient border rework

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?


