### PR TITLE
Update wiki link in manpage

### DIFF
--- a/docs/Hyprland.1
+++ b/docs/Hyprland.1
@@ -24,7 +24,7 @@ Although Hyprland is pretty stable, it may have some bugs.
 .SH CONFIGURATION
 .PP
 For configuration information please see
-<\f[I]https://github.com/hyprwm/Hyprland/wiki\f[R]>.
+<\f[I]https://wiki.hyprland.org\f[R]>.
 .SH OPTIONS
 .TP
 .B \f[B]\-h\f[R], \f[B]\-\-help\f[R]


### PR DESCRIPTION
As wiki is migrated to wiki.hyprland.org, I changed the github wiki link to wiki.hyprland.org in the manpage.

