### PR TITLE
nix: add cmake to devshell and create a "wlroots-ready" devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -81,17 +81,14 @@
         nativeBuildInputs = with pkgsFor.${system}; [
           cmake
         ];
+        buildInputs = [
+          self.packages.${system}.wlroots-hyprland
+        ];
         inputsFrom = [
           self.packages.${system}.wlroots-hyprland
           self.packages.${system}.hyprland
         ];
       };
-      wlroots-ready = default.overrideAttrs (oldAttrs: {
-        name = "hyprland-shell-wlroots-ready";
-        buildInputs = oldAttrs.buildInputs ++ [
-          self.packages.${system}.wlroots-hyprland
-        ];
-      });
     });
 
     formatter = genSystems (system: pkgsFor.${system}.alejandra);

--- a/flake.nix
+++ b/flake.nix
@@ -75,9 +75,12 @@
         default = self.packages.${system}.hyprland;
       });
 
-    devShells = genSystems (system: {
+    devShells = genSystems (system: rec {
       default = pkgsFor.${system}.mkShell.override {stdenv = pkgsFor.${system}.gcc12Stdenv;} {
         name = "hyprland-shell";
+        nativeBuildInputs = with pkgsFor.${system}; [
+          cmake
+        ];
         inputsFrom = [
           self.packages.${system}.wlroots-hyprland
           self.packages.${system}.hyprland

--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,12 @@
           self.packages.${system}.hyprland
         ];
       };
+      wlroots-ready = default.overrideAttrs (oldAttrs: {
+        name = "hyprland-shell-wlroots-ready";
+        buildInputs = oldAttrs.buildInputs ++ [
+          self.packages.${system}.wlroots-hyprland
+        ];
+      });
     });
 
     formatter = genSystems (system: pkgsFor.${system}.alejandra);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

- fixes `sh: line 1: cmake: command not found` when running `make debug` by adding `cmake` as a nativeBuildInput.

- adds a `wlroots-ready` devshell which puts wlroots in the devshell so nix compiles it.
  Especially useful for NixOS since `make config` can't install `wlroots`: (no `/usr/include`)
```
Installing subdir /mnt/general/repos/flafydev/Hyprland/subprojects/wlroots/include/wlr to /usr/include/wlr
Installation failed due to insufficient permissions.
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
none

#### Is it ready for merging, or does it need work?
ready for review/merge.

