### PR TITLE
Fix wrong layout recalculate if statement

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1036,7 +1036,7 @@ std::string CConfigManager::parseKeyword(const std::string& COMMAND, const std::
 
         // invalidate layouts if they changed
         if (needsLayoutRecalc) {
-            if (needsLayoutRecalc == 1 || COMMAND.find("gaps_") != std::string::npos || COMMAND.find("dwindle:") == 0 || COMMAND.find("master:") == 0) {
+            if (needsLayoutRecalc == 1 || COMMAND.contains("gaps_") || COMMAND.find("dwindle:") == 0 || COMMAND.find("master:") == 0) {
                 for (auto& m : g_pCompositor->m_vMonitors)
                     g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m->ID);
             }

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1036,7 +1036,7 @@ std::string CConfigManager::parseKeyword(const std::string& COMMAND, const std::
 
         // invalidate layouts if they changed
         if (needsLayoutRecalc) {
-            if (needsLayoutRecalc == 1 || VALUE.find("gaps_") || VALUE.find("dwindle:") == 0 || VALUE.find("master:") == 0) {
+            if (needsLayoutRecalc == 1 || COMMAND.find("gaps_") != std::string::npos || COMMAND.find("dwindle:") == 0 || COMMAND.find("master:") == 0) {
                 for (auto& m : g_pCompositor->m_vMonitors)
                     g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m->ID);
             }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

The PR fixes the if statement [ConfigManager.cpp#L1039](https://github.com/hyprwm/Hyprland/blob/6aa26582f63c13e32dd0191015550a2d1eade7e6/src/config/ConfigManager.cpp#L1039) which I assume should pass if one of the following conditions is true:
1. `needsLayoutRecalc` is 1.
2. the keyword (for example "general:gaps_out") contains "gaps_".
3. the keyword starts with "dwindle".
4. the keyword starts with "master".

right now it seems only the first if condition is corrent, while the others aren't.
The pr fixes the other conditions by 
1. changing VALUE to COMMAND
2. fixing the second condition to currently check if the keyword contains "gaps_".

(for "hyprctl keyword general:gaps_out 120" it's: `VALUE = "120"` and `COMMAND = "general:gaps_out"`.)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no


#### Is it ready for merging, or does it need work?
Yes

