### PR TITLE
Input: Fix unlock mouse warp

### DIFF
--- a/src/events/Devices.cpp
+++ b/src/events/Devices.cpp
@@ -105,6 +105,10 @@ void Events::listener_newConstraint(wl_listener* listener, void* data) {
     CONSTRAINT->pMouse = g_pCompositor->m_sSeat.mouse;
     CONSTRAINT->constraint = PCONSTRAINT;
 
+    // HACK: Store last mouse pos
+    CONSTRAINT->x = g_pCompositor->m_sWLRCursor->x;
+    CONSTRAINT->y = g_pCompositor->m_sWLRCursor->y;
+
     CONSTRAINT->hyprListener_destroyConstraint.initCallback(&PCONSTRAINT->events.destroy, &Events::listener_destroyConstraint, CONSTRAINT, "Constraint");
     CONSTRAINT->hyprListener_setConstraintRegion.initCallback(&PCONSTRAINT->events.set_region, &Events::listener_setConstraintRegion, CONSTRAINT, "Constraint");
 
@@ -128,10 +132,9 @@ void Events::listener_destroyConstraint(void* owner, void* data) {
 
                 wlr_seat_pointer_warp(PCONSTRAINT->constraint->seat, PCONSTRAINT->constraint->current.cursor_hint.x, PCONSTRAINT->constraint->current.cursor_hint.y);
             } else {
-                wlr_cursor_warp(g_pCompositor->m_sWLRCursor, nullptr,
-                                PCONSTRAINT->constraint->current.cursor_hint.x + PWINDOW->m_vRealPosition.vec().x, PCONSTRAINT->constraint->current.cursor_hint.y + PWINDOW->m_vRealPosition.vec().y);
-
-                wlr_seat_pointer_warp(PCONSTRAINT->constraint->seat, PCONSTRAINT->constraint->current.cursor_hint.x, PCONSTRAINT->constraint->current.cursor_hint.y);
+                // HACK: Warp to last position (cursor_hint.xy is always (0, 0))
+                wlr_cursor_warp(g_pCompositor->m_sWLRCursor, nullptr, PCONSTRAINT->x, PCONSTRAINT->y);
+                wlr_seat_pointer_warp(PCONSTRAINT->constraint->seat, PCONSTRAINT->x - PWINDOW->m_vRealPosition.vec().x, PCONSTRAINT->y - PWINDOW->m_vRealPosition.vec().y);
             }
         }
 

--- a/src/helpers/WLClasses.hpp
+++ b/src/helpers/WLClasses.hpp
@@ -146,6 +146,9 @@ struct SConstraint {
     SMouse* pMouse = nullptr;
     wlr_pointer_constraint_v1* constraint = nullptr;
 
+    // HACK: Store last mouse position
+    double x,y;
+
     DYNLISTENER(setConstraintRegion);
     DYNLISTENER(destroyConstraint);
 


### PR DESCRIPTION
Unconstraining a locked mouse would result in the mouse warping to (0, 0), since wlroots give us these as the current mouse position. This PR adds a rather hacky fix for this by manually storing the last mouse position and warp the cursor upon unlocking

Tested with GLFW and glfwSetInputMode() (For reference, GLFW uses zwp_relative_pointer and zwp_locked_pointer)

Current behavior 
 - Lock cursor at (x,y) with glfwSetInputMode(GLFW_CURSOR_DISABLED)
 - Move mouse
 - Unlock mouse with glfwSetInputMode(GLFW_CURSOR_NORMAL)
 - Cursor is warped to the topleft of the window (0,0)
 
Behavior with this PR
 - Lock cursor at (x,y) with glfwSetInputMode(GLFW_CURSOR_DISABLED)
 - Move mouse
 - Unlock mouse with glfwSetInputMode(GLFW_CURSOR_NORMAL)
 - Cursor is warped back to (x,y)

Unfortunately I'm not that familiar of wlroots so I don't know if (un)constraining a mouse is the only time newConstraint/destroyConstraint is called.  

This PR is ready for merging, though I'm open for suggestions/improvements


