### PR TITLE
Master layout: lose or inherit fullscreen on deliberate window switching

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -110,6 +110,7 @@ void CConfigManager::setDefaultVars() {
     configValues["master:new_on_top"].intValue = 0;
     configValues["master:no_gaps_when_only"].intValue = 0;
     configValues["master:orientation"].strValue = "left";
+    configValues["master:inherit_fullscreen"].intValue = 1;
 
     configValues["animations:enabled"].intValue = 1;
     configValues["animations:speed"].floatValue = 7.f;

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -580,6 +580,8 @@ void CHyprMasterLayout::switchWindows(CWindow* pWindow, CWindow* pWindow2) {
     if (!PNODE2 || !PNODE)
         return;
 
+    prepareLoseFocus(pWindow);
+
     if (PNODE->workspaceID != PNODE2->workspaceID) {
         std::swap(pWindow2->m_iMonitorID, pWindow->m_iMonitorID);
         std::swap(pWindow2->m_iWorkspaceID, pWindow->m_iWorkspaceID);
@@ -681,6 +683,15 @@ CWindow* CHyprMasterLayout::getNextWindow(CWindow* pWindow, bool next) {
     return nullptr;
 }
 
+void CHyprMasterLayout::prepareLoseFocus(CWindow * pWindow) {
+    if (!pWindow)
+        return;
+
+    //if the current window is fullscreen, make it normal again if we are about to lose focus
+    if (pWindow->m_bIsFullscreen)
+        g_pCompositor->setWindowFullscreen(pWindow, false, FULLSCREEN_FULL);
+}
+
 std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::string message) {
     auto switchToWindow = [&](CWindow* PWINDOWTOCHANGETO) {
         if (!g_pCompositor->windowValidMapped(PWINDOWTOCHANGETO))
@@ -704,6 +715,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
         if (!PMASTER)
             return 0;
 
+
         if (PMASTER->pWindow != PWINDOW) {
             switchWindows(PWINDOW, PMASTER->pWindow);
             switchToWindow(PWINDOW);
@@ -723,6 +735,8 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
 
         if (!PWINDOW)
             return 0;
+
+        prepareLoseFocus(PWINDOW);
 
         const auto PMASTER = getMasterNodeOnWorkspace(PWINDOW->m_iWorkspaceID);
 
@@ -747,12 +761,16 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
         if (!PWINDOW)
             return 0;
 
+        prepareLoseFocus(PWINDOW);
+
         switchToWindow(getNextWindow(PWINDOW, true));
     } else if (message == "cycleprev") {
         const auto PWINDOW = header.pWindow;
 
         if (!PWINDOW)
             return 0;
+
+        prepareLoseFocus(PWINDOW);
 
         switchToWindow(getNextWindow(PWINDOW, false));
     } else if (message == "swapnext") {
@@ -767,6 +785,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
         const auto PWINDOWTOSWAPWITH = getNextWindow(header.pWindow, true);
 
         if (PWINDOWTOSWAPWITH) {
+            prepareLoseFocus(header.pWindow);
             switchWindows(header.pWindow, PWINDOWTOSWAPWITH);
             g_pCompositor->focusWindow(header.pWindow);
         }
@@ -782,6 +801,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
         const auto PWINDOWTOSWAPWITH = getNextWindow(header.pWindow, false);
 
         if (PWINDOWTOSWAPWITH) {
+            prepareLoseFocus(header.pWindow);
             switchWindows(header.pWindow, PWINDOWTOSWAPWITH);
             g_pCompositor->focusWindow(header.pWindow);
         }
@@ -799,6 +819,8 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
 
         if (MASTERS + 2 > WINDOWS)
             return 0;
+
+        prepareLoseFocus(header.pWindow);
 
         if (!PNODE || PNODE->isMaster) {
             // first non-master node
@@ -830,6 +852,8 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
         if (WINDOWS < 2 || MASTERS < 2)
             return 0;
 
+        prepareLoseFocus(header.pWindow);
+
         if (!PNODE || !PNODE->isMaster) {
             // first non-master node
             for (auto it = m_lMasterNodesData.rbegin(); it != m_lMasterNodesData.rend(); it++) {
@@ -848,6 +872,8 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
 
         if (!PWINDOW)
             return 0;
+
+        prepareLoseFocus(PWINDOW);
 
         const auto PWORKSPACEDATA = getMasterWorkspaceData(PWINDOW->m_iWorkspaceID);
 
@@ -868,6 +894,8 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
         if (!PWINDOW)
             return 0;
 
+        prepareLoseFocus(PWINDOW);
+
         const auto PWORKSPACEDATA = getMasterWorkspaceData(PWINDOW->m_iWorkspaceID);
 
         if (PWORKSPACEDATA->orientation == ORIENTATION_BOTTOM) {
@@ -882,6 +910,8 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
 
         if (!PWINDOW)
             return 0;
+
+        prepareLoseFocus(PWINDOW);
 
         const auto PWORKSPACEDATA = getMasterWorkspaceData(PWINDOW->m_iWorkspaceID);
 

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -649,14 +649,14 @@ CWindow* CHyprMasterLayout::getNextWindow(CWindow* pWindow, bool next) {
         }
     } else {
         if (PNODE->isMaster) {
-            // focus the first non master
+            // focus the last non master
             for (auto it = m_lMasterNodesData.rbegin(); it != m_lMasterNodesData.rend(); it++) {
                 if (it->pWindow != pWindow && it->workspaceID == pWindow->m_iWorkspaceID) {
                     return it->pWindow;
                 }
             }
         } else {
-            // focus next
+            // focus previous
             bool reached = false;
             bool found = false;
             for (auto it = m_lMasterNodesData.rbegin(); it != m_lMasterNodesData.rend(); it++) {

--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -51,6 +51,7 @@ public:
     virtual void        recalculateWindow(CWindow*);
     virtual void        resizeActiveWindow(const Vector2D&, CWindow* pWindow = nullptr);
     virtual void        fullscreenRequestForWindow(CWindow*, eFullscreenMode, bool);
+    virtual void        prepareLoseFocus(CWindow*);
     virtual std::any    layoutMessage(SLayoutMessageHeader, std::string);
     virtual SWindowRenderLayoutHints requestRenderHints(CWindow*);
     virtual void        switchWindows(CWindow*, CWindow*);

--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -51,7 +51,6 @@ public:
     virtual void        recalculateWindow(CWindow*);
     virtual void        resizeActiveWindow(const Vector2D&, CWindow* pWindow = nullptr);
     virtual void        fullscreenRequestForWindow(CWindow*, eFullscreenMode, bool);
-    virtual void        prepareLoseFocus(CWindow*);
     virtual std::any    layoutMessage(SLayoutMessageHeader, std::string);
     virtual SWindowRenderLayoutHints requestRenderHints(CWindow*);
     virtual void        switchWindows(CWindow*, CWindow*);
@@ -76,6 +75,8 @@ private:
     void                calculateWorkspace(const int&);
     CWindow*            getNextWindow(CWindow*, bool);
     int                 getMastersOnWorkspace(const int&);
+    bool                prepareLoseFocus(CWindow*);
+    void                prepareNewFocus(CWindow*, bool inherit_fullscreen);
 
     friend struct SMasterNodeData;
     friend struct SMasterWorkspaceData;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

In the master layout as implemented up to this point, when you have a master window, some slave windows and you fullscreen any of them, the fullscreen status remained on the old window even if  you switch to another window via `cyclenext`,`cycleprev`, `swapmaster`, etc...   This meant you effectively couldn't see the window you switched to, had to switch back and manually toggle off fullscreen again. I consider this a bug (though surprisingly didn't find an open issue about it). This PR fixes it in one of two ways:

1. Simply automatically unset the fullscreen status when explicitly switching away from it, showing you all the tiles again (new default behaviour)
2. Like one, but additionally inherit the fullscreen status by immediately re-setting it on the new window. This requires that a new property `master:inherit_fullscreen` is set. This results in behaviour like 'monocle' layout in other tiling WMs. May also be somewhat related to #516. I think this is also more in line with how the dwindle layout does things, judging the comment in #523.

In some cases (like the new orientating switching), I implemented option 1 as the sole option which made sense, otherwise the result of the action would be invisible.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I introduced two new helper functions `prepareLoseFocus` and `prepareNewFocus` to keep the amount of repetition in the code lower.

#### Is it ready for merging, or does it need work?

Should be ready to go
