### PR TITLE
Add option to round corners on layers

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -887,6 +887,16 @@ void CConfigManager::handleBlurLS(const std::string& command, const std::string&
     m_dBlurLSNamespaces.emplace_back(value);
 }
 
+void CConfigManager::handleRoundingLS(const std::string& command, const std::string& value) {
+    if (value.find("remove,") == 0) {
+        const auto TOREMOVE = removeBeginEndSpacesTabs(value.substr(7));
+        std::erase_if(m_dRoundingLSNamespaces, [&](const auto& other) { return other == TOREMOVE; });
+        return;
+    }
+
+    m_dRoundingLSNamespaces.emplace_back(value);
+}
+
 void CConfigManager::handleDefaultWorkspace(const std::string& command, const std::string& value) {
     const auto ARGS = CVarList(value);
 
@@ -1012,6 +1022,8 @@ std::string CConfigManager::parseKeyword(const std::string& COMMAND, const std::
         handleSubmap(COMMAND, VALUE);
     else if (COMMAND == "blurls")
         handleBlurLS(COMMAND, VALUE);
+    else if (COMMAND == "roundingls")
+        handleRoundingLS(COMMAND, VALUE);
     else if (COMMAND == "wsbind")
         handleBindWS(COMMAND, VALUE);
     else {
@@ -1143,6 +1155,7 @@ void CConfigManager::loadConfigLoadVars() {
     configDynamicVars.clear();
     deviceConfigs.clear();
     m_dBlurLSNamespaces.clear();
+    m_dRoundingLSNamespaces.clear();
     boundWorkspaces.clear();
     setDefaultAnimationVars(); // reset anims
 
@@ -1594,6 +1607,16 @@ bool CConfigManager::deviceConfigExists(const std::string& dev) {
 bool CConfigManager::shouldBlurLS(const std::string& ns) {
     for (auto& bls : m_dBlurLSNamespaces) {
         if (bls == ns) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool CConfigManager::shouldRoundLS(const std::string& ns) {
+    for (auto& rls : m_dRoundingLSNamespaces) {
+        if (rls == ns) {
             return true;
         }
     }

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -142,6 +142,7 @@ class CConfigManager {
     std::string                                                     getDeviceString(const std::string&, const std::string&);
     bool                                                            deviceConfigExists(const std::string&);
     bool                                                            shouldBlurLS(const std::string&);
+    bool                                                            shouldRoundLS(const std::string&);
 
     SConfigValue*                                                   getConfigValuePtr(const std::string&);
     SConfigValue*                                                   getConfigValuePtrSafe(const std::string&);
@@ -199,6 +200,7 @@ class CConfigManager {
     std::deque<SMonitorRule>                                                       m_dMonitorRules;
     std::deque<SWindowRule>                                                        m_dWindowRules;
     std::deque<std::string>                                                        m_dBlurLSNamespaces;
+    std::deque<std::string>                                                        m_dRoundingLSNamespaces;
 
     bool                                                                           firstExecDispatched = false;
     std::deque<std::string>                                                        firstExecRequests;
@@ -229,6 +231,7 @@ class CConfigManager {
     void         handleSource(const std::string&, const std::string&);
     void         handleSubmap(const std::string&, const std::string&);
     void         handleBlurLS(const std::string&, const std::string&);
+    void         handleRoundingLS(const std::string&, const std::string&);
     void         handleBindWS(const std::string&, const std::string&);
 };
 

--- a/src/events/Layers.cpp
+++ b/src/events/Layers.cpp
@@ -53,7 +53,8 @@ void Events::listener_newLayerSurface(wl_listener* listener, void* data) {
     WLRLAYERSURFACE->data      = layerSurface;
     layerSurface->monitorID    = PMONITOR->ID;
 
-    layerSurface->forceBlur = g_pConfigManager->shouldBlurLS(layerSurface->szNamespace);
+    layerSurface->forceBlur     = g_pConfigManager->shouldBlurLS(layerSurface->szNamespace);
+    layerSurface->forceRounding = g_pConfigManager->shouldRoundLS(layerSurface->szNamespace);
 
     Debug::log(LOG, "LayerSurface %x (namespace %s layer %d) created on monitor %s", layerSurface->layerSurface, layerSurface->layerSurface->_namespace, layerSurface->layer,
                PMONITOR->szName.c_str());

--- a/src/helpers/WLClasses.hpp
+++ b/src/helpers/WLClasses.hpp
@@ -35,6 +35,7 @@ struct SLayerSurface {
     bool                      noProcess     = false;
 
     bool                      forceBlur = false;
+    bool                      forceRounding = false;
 
     // For the list lookup
     bool operator==(const SLayerSurface& rhs) {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -354,10 +354,11 @@ void CHyprRenderer::renderLayer(SLayerSurface* pLayer, CMonitor* pMonitor, times
     renderdata.w                     = pLayer->layerSurface->surface->current.width;
     renderdata.h                     = pLayer->layerSurface->surface->current.height;
     renderdata.blockBlurOptimization = pLayer->layer == ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM || pLayer->layer == ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND;
+    renderdata.dontRound             = !pLayer->forceRounding;
+    renderdata.rounding              = g_pConfigManager->getConfigValuePtr("decoration:rounding")->intValue;
     wlr_surface_for_each_surface(pLayer->layerSurface->surface, renderSurface, &renderdata);
 
     renderdata.squishOversized = false; // don't squish popups
-    renderdata.dontRound       = true;
     wlr_layer_surface_v1_for_each_popup_surface(pLayer->layerSurface, renderSurface, &renderdata);
 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Adds the keyword `roundls` (similar to `blurls`) to add rounded corner to a specified layer.

This is useful because it enables us to have rounder corner and blur on notifications, Rofi, and similar tools. Indeed, even though we can make those applications rounded without Hyprland (using CSS generally), if we do so and also use blur, we will see some artefacts in the windows corner:

![2022-12-16T23:42:44,794219812+01:00](https://user-images.githubusercontent.com/17860659/208201130-996f3616-3ff8-4928-8844-4d0410344b6c.png)

To fix that, I added the option to render with rounded corners in layers.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

There is not much change, and it seems to work perfectly, but this is my first time working on a WM, so you might want to check everything.

#### Is it ready for merging, or does it need work?

I hope it is. Let me know if anything isn't right.