### PR TITLE
Fix cycleprev bug introduced in 46891b12cf (#1213)

### DIFF
--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -793,7 +793,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
 
         const bool inheritFullscreen = prepareLoseFocus(PWINDOW);
 
-        const auto PPREVWINDOW = getNextWindow(PWINDOW, true);
+        const auto PPREVWINDOW = getNextWindow(PWINDOW, false);
         switchToWindow(PPREVWINDOW);
         prepareNewFocus(PPREVWINDOW, inheritFullscreen);
     } else if (message == "swapnext") {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This pull request fixes that `cycleprev` always focuses the next window (like `cyclenext`) instead of the previous one.

The reason for this is an incorrect boolean flag for `getNextWindow()` introduced in commit 46891b12cf belonging to #1213.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Nothing here.

#### Is it ready for merging, or does it need work?

It is ready for merging.
