### PR TITLE
Fix focus not changing on (empty) workspace change

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -781,6 +781,10 @@ void CKeybindManager::changeworkspace(std::string args) {
                 g_pInputManager->refocus();
         } else if (g_pCompositor->getWindowsOnWorkspace(PWORKSPACETOCHANGETO->m_iID) > 0)
             g_pInputManager->refocus();
+        else {
+            // if there are no windows on the workspace, just unfocus the window on the previous workspace
+            g_pCompositor->focusWindow(nullptr);
+        }
 
         // set the new monitor as the last (no warps would bug otherwise)
         g_pCompositor->setActiveMonitor(g_pCompositor->getMonitorFromID(PWORKSPACETOCHANGETO->m_iMonitorID));


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

When using e.g. `focusmonitor` to switch to a monitor without any windows on it, the focus gets stuck on the last window of the previous monitor.

This pull request fixes this bug by explicitly unfocusing the previous window in such a case.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Nothing here.

#### Is it ready for merging, or does it need work?

It is ready for merging.
