### PR TITLE
Drop X11 headers (unused)

### DIFF
--- a/src/includes.hpp
+++ b/src/includes.hpp
@@ -108,8 +108,6 @@ extern "C" {
 #ifndef NO_XWAYLAND
 #include <wlr/backend/x11.h>
 #include <wlr/xwayland.h>
-#include <X11/Xlib.h>
-#include <X11/Xproto.h>
 #endif
 }
 

--- a/src/includes.hpp
+++ b/src/includes.hpp
@@ -6,7 +6,6 @@
 #pragma diag_suppress 1696
 #endif
 
-#include <X11/Xlib.h>
 #include <getopt.h>
 #include <libinput.h>
 #include <linux/input-event-codes.h>
@@ -109,6 +108,7 @@ extern "C" {
 #ifndef NO_XWAYLAND
 #include <wlr/backend/x11.h>
 #include <wlr/xwayland.h>
+#include <X11/Xlib.h>
 #include <X11/Xproto.h>
 #endif
 }


### PR DESCRIPTION
Xwayland support uses libxcb instead of libX11. Found while building everything without X11 (not just Hyprland).