### PR TITLE
Add tablets calibration matrix for dynamic rotation with 2-in1/tablet PC usage

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -160,6 +160,8 @@ void CConfigManager::setDefaultVars() {
     configValues["input:touchpad:scroll_factor"].floatValue         = 1.f;
     configValues["input:touchdevice:transform"].intValue            = 0;
     configValues["input:touchdevice:output"].strValue               = STRVAL_EMPTY;
+    configValues["input:tablet:transform"].intValue                 = 0;
+    configValues["input:tablet:output"].strValue                    = STRVAL_EMPTY;
 
     configValues["binds:pass_mouse_when_bound"].intValue    = 0;
     configValues["binds:scroll_event_delay"].intValue       = 300;
@@ -1340,7 +1342,12 @@ SConfigValue CConfigManager::getConfigValueSafeDevice(const std::string& dev, co
             if (foundIt == std::string::npos)
                 continue;
 
-            if (cv.first == "input:" + val || cv.first == "input:touchpad:" + cv.first || cv.first == "input:touchdevice:" + val) {
+            if (cv.first == "input:" + val
+                || cv.first == "input:touchpad:" + cv.first
+                || cv.first == "input:touchdevice:" + val
+                || cv.first == "input:tablet:" + cv.first
+                || cv.first == "input:tablet:" + val
+            ) {
                 copy = cv.second;
             }
         }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1167,16 +1167,18 @@ void CInputManager::setTouchDeviceConfigs() {
 
 void CInputManager::setTabletConfigs() {
     for (auto& t : m_lTablets) {
+        Debug::log(LOG, "Checking for config for device %s", t.name);
         const auto HASCONFIG = g_pConfigManager->deviceConfigExists(t.name);
 
         if (wlr_input_device_is_libinput(t.wlrDevice)) {
+            Debug::log(LOG, "Device %s is a libinput device", t.name);
             const auto LIBINPUTDEV = (libinput_device*)wlr_libinput_get_device_handle(t.wlrDevice);
 
-            const int  ROTATION =
-                std::clamp(HASCONFIG ? g_pConfigManager->getDeviceInt(t.name, "transform") : g_pConfigManager->getInt("input:tablet:transform"), 0, 7);
+            const int  ROTATION = std::clamp(HASCONFIG ? g_pConfigManager->getDeviceInt(t.name, "transform") : g_pConfigManager->getInt("input:tablet:transform"), 0, 7);
+            Debug::log(LOG, "Setting calibration matrix for device %s", t.name);
             libinput_device_config_calibration_set_matrix(LIBINPUTDEV, MATRICES[ROTATION]);
 
-            const auto OUTPUT = HASCONFIG ? g_pConfigManager->getDeviceString(t.name, "output") : g_pConfigManager->getString("input:tablet:output");
+            const auto OUTPUT   = HASCONFIG ? g_pConfigManager->getDeviceString(t.name, "output") : g_pConfigManager->getString("input:tablet:output");
             const auto PMONITOR = g_pCompositor->getMonitorFromString(OUTPUT);
             if (!OUTPUT.empty() && OUTPUT != STRVAL_EMPTY && PMONITOR) {
                 wlr_cursor_map_input_to_output(g_pCompositor->m_sWLRCursor, t.wlrDevice, PMONITOR->output);

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1167,11 +1167,9 @@ void CInputManager::setTouchDeviceConfigs() {
 
 void CInputManager::setTabletConfigs() {
     for (auto& t : m_lTablets) {
-        Debug::log(LOG, "Checking for config for device %s", t.name);
         const auto HASCONFIG = g_pConfigManager->deviceConfigExists(t.name);
 
         if (wlr_input_device_is_libinput(t.wlrDevice)) {
-            Debug::log(LOG, "Device %s is a libinput device", t.name);
             const auto LIBINPUTDEV = (libinput_device*)wlr_libinput_get_device_handle(t.wlrDevice);
 
             const int  ROTATION = std::clamp(HASCONFIG ? g_pConfigManager->getDeviceInt(t.name, "transform") : g_pConfigManager->getInt("input:tablet:transform"), 0, 7);

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1146,12 +1146,10 @@ void CInputManager::newTouchDevice(wlr_input_device* pDevice) {
 void CInputManager::setTouchDeviceConfigs() {
     for (auto& m : m_lTouchDevices) {
         const auto PTOUCHDEV = &m;
-        Debug::log(LOG, "Checking for config for device %s", PTOUCHDEV->name);
 
         const auto HASCONFIG = g_pConfigManager->deviceConfigExists(PTOUCHDEV->name);
 
         if (wlr_input_device_is_libinput(m.pWlrDevice)) {
-            Debug::log(LOG, "Device %s is a libinput device", PTOUCHDEV->name);
             const auto LIBINPUTDEV = (libinput_device*)wlr_libinput_get_device_handle(m.pWlrDevice);
 
             const int  ROTATION =

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1173,11 +1173,11 @@ void CInputManager::setTabletConfigs() {
             const auto OUTPUT   = g_pConfigManager->getDeviceString(t.name, "output");
             const auto PMONITOR = g_pCompositor->getMonitorFromString(OUTPUT);
 
-            if (wlr_input_device_is_libinput(t.pWlrDevice)) {
-                const auto LIBINPUTDEV = (libinput_device*)wlr_libinput_get_device_handle(m.pWlrDevice);
+            if (wlr_input_device_is_libinput(t.wlrDevice)) {
+                const auto LIBINPUTDEV = (libinput_device*)wlr_libinput_get_device_handle(t.wlrDevice);
 
                 const int  ROTATION =
-                    std::clamp(HASCONFIG ? g_pConfigManager->getDeviceInt(PTOUCHDEV->name, "transform") : g_pConfigManager->getInt("input:touchdevice:transform"), 0, 7);
+                    std::clamp(HASCONFIG ? g_pConfigManager->getDeviceInt(t.name, "transform") : g_pConfigManager->getInt("input:touchdevice:transform"), 0, 7);
                 libinput_device_config_calibration_set_matrix(LIBINPUTDEV, MATRICES[ROTATION]);
             }
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1146,10 +1146,12 @@ void CInputManager::newTouchDevice(wlr_input_device* pDevice) {
 void CInputManager::setTouchDeviceConfigs() {
     for (auto& m : m_lTouchDevices) {
         const auto PTOUCHDEV = &m;
+        Debug::log(LOG, "Checking for config for device %s", PTOUCHDEV->name);
 
         const auto HASCONFIG = g_pConfigManager->deviceConfigExists(PTOUCHDEV->name);
 
         if (wlr_input_device_is_libinput(m.pWlrDevice)) {
+            Debug::log(LOG, "Device %s is a libinput device", PTOUCHDEV->name);
             const auto LIBINPUTDEV = (libinput_device*)wlr_libinput_get_device_handle(m.pWlrDevice);
 
             const int  ROTATION =

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -25,6 +25,26 @@ struct STouchData {
     Vector2D       touchSurfaceOrigin;
 };
 
+// The third row is always 0 0 1 and is not expected by `libinput_device_config_calibration_set_matrix`
+static const float MATRICES[8][6] = {
+  {// normal
+  1, 0, 0, 0, 1, 0},
+  {// rotation 90°
+  0, -1, 1, 1, 0, 0},
+  {// rotation 180°
+  -1, 0, 1, 0, -1, 1},
+  {// rotation 270°
+  0, 1, 0, -1, 0, 1},
+  {// flipped
+  -1, 0, 1, 0, 1, 0},
+  {// flipped + rotation 90°
+  0, 1, 0, 1, 0, 0},
+  {// flipped + rotation 180°
+  1, 0, 0, 0, -1, 1},
+  {// flipped + rotation 270°
+  0, -1, 1, -1, 0, 1}
+};
+
 class CKeybindManager;
 
 class CInputManager {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Intends to add rotation support for touch-screen stylus (by adding calibration matrix support to tablets), so we can rotate the display + digitizer (touchscreen + stylus) based on device orientation (via acceleration sensor) on the fly with `hyperctl` (tablet/2-in-1).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Only anecdotally tested (in one setup), not working yet (no noticable effect).
If you have a 2-in-1 with `nixos` [this HM module](https://github.com/ppenguin/nixos-modules/blob/main/home-manager/iiorient.nix) should make testing trivial.

#### Is it ready for merging, or does it need work?

~~Still needs work. Cleanly builds and runs, but the tablet (stylus) calibration does not have any effect yet. I.e. somehow the changes are still ineffective. A bit short on time now, so I'll need to pick this up later. (Or maybe somebody has an idea?)~~

Tested anecdotically (on my own 2-in-1) and works nicely.
