### PR TITLE
feat: dispatcher, add workspace renaming

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2071,6 +2071,25 @@ CWorkspace* CCompositor::createNewWorkspace(const int& id, const int& monid, con
     return PWORKSPACE;
 }
 
+CWorkspace* CCompositor::renameWorkspace(const int& id, const std::string& name) {
+    const auto PWORKSPACE = getWorkspaceByID(id);
+
+    if (!PWORKSPACE)
+        return nullptr;
+
+    const auto NAME  = name == "" ? std::to_string(id) : name;
+
+    const bool SPECIAL = id >= SPECIAL_WORKSPACE_START && id <= -2;
+
+    if (!SPECIAL) {
+        Debug::log(LOG, "renameWorkspace: Renaming workspace %d to %s", id, NAME);
+        wlr_ext_workspace_handle_v1_set_name(PWORKSPACE->m_pWlrHandle, NAME.c_str());
+        PWORKSPACE->m_szName = name;
+    }
+
+    return PWORKSPACE;
+}
+
 void CCompositor::setActiveMonitor(CMonitor* pMonitor) {
     if (m_pLastMonitor == pMonitor)
         return;

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2071,23 +2071,20 @@ CWorkspace* CCompositor::createNewWorkspace(const int& id, const int& monid, con
     return PWORKSPACE;
 }
 
-CWorkspace* CCompositor::renameWorkspace(const int& id, const std::string& name) {
+void CCompositor::renameWorkspace(const int& id, const std::string& name) {
     const auto PWORKSPACE = getWorkspaceByID(id);
 
-    if (!PWORKSPACE)
-        return nullptr;
-
-    const auto NAME  = name == "" ? std::to_string(id) : name;
-
-    const bool SPECIAL = id >= SPECIAL_WORKSPACE_START && id <= -2;
-
-    if (!SPECIAL) {
-        Debug::log(LOG, "renameWorkspace: Renaming workspace %d to %s", id, NAME);
-        wlr_ext_workspace_handle_v1_set_name(PWORKSPACE->m_pWlrHandle, NAME.c_str());
-        PWORKSPACE->m_szName = name;
+    if (!PWORKSPACE) {
+        return;
     }
 
-    return PWORKSPACE;
+    const auto NAME = name.empty() ? std::to_string(id) : name;
+
+    if (!isWorkspaceSpecial(id)) {
+        Debug::log(LOG, "renameWorkspace: Renaming workspace %d to %s", id, NAME);
+        wlr_ext_workspace_handle_v1_set_name(PWORKSPACE->m_pWlrHandle, NAME.c_str());
+        PWORKSPACE->m_szName = NAME;
+    }
 }
 
 void CCompositor::setActiveMonitor(CMonitor* pMonitor) {

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -391,10 +391,9 @@ void CCompositor::startCompositor() {
     if (sd_booted() > 0)
         // tell systemd that we are ready so it can start other bond, following, related units
         sd_notify(0, "READY=1");
-   else
+    else
         Debug::log(LOG, "systemd integration is baked in but system itself is not booted à la systemd!");
 #endif
-
 
     // This blocks until we are done.
     Debug::log(LOG, "Hyprland is ready, running the event loop!");
@@ -2074,15 +2073,15 @@ CWorkspace* CCompositor::createNewWorkspace(const int& id, const int& monid, con
 void CCompositor::renameWorkspace(const int& id, const std::string& name) {
     const auto PWORKSPACE = getWorkspaceByID(id);
 
-    if (!PWORKSPACE) {
+    if (!PWORKSPACE)
         return;
-    }
 
-    if (!isWorkspaceSpecial(id)) {
-        Debug::log(LOG, "renameWorkspace: Renaming workspace %d to '%s'", id, name);
-        wlr_ext_workspace_handle_v1_set_name(PWORKSPACE->m_pWlrHandle, name.c_str());
-        PWORKSPACE->m_szName = name;
-    }
+    if (isWorkspaceSpecial(id))
+        return;
+
+    Debug::log(LOG, "renameWorkspace: Renaming workspace %d to '%s'", id, name);
+    wlr_ext_workspace_handle_v1_set_name(PWORKSPACE->m_pWlrHandle, name.c_str());
+    PWORKSPACE->m_szName = name;
 }
 
 void CCompositor::setActiveMonitor(CMonitor* pMonitor) {

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2078,12 +2078,10 @@ void CCompositor::renameWorkspace(const int& id, const std::string& name) {
         return;
     }
 
-    const auto NAME = name.empty() ? std::to_string(id) : name;
-
     if (!isWorkspaceSpecial(id)) {
-        Debug::log(LOG, "renameWorkspace: Renaming workspace %d to %s", id, NAME);
-        wlr_ext_workspace_handle_v1_set_name(PWORKSPACE->m_pWlrHandle, NAME.c_str());
-        PWORKSPACE->m_szName = NAME;
+        Debug::log(LOG, "renameWorkspace: Renaming workspace %d to '%s'", id, name);
+        wlr_ext_workspace_handle_v1_set_name(PWORKSPACE->m_pWlrHandle, name.c_str());
+        PWORKSPACE->m_szName = name;
     }
 }
 

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -171,10 +171,10 @@ class CCompositor {
     void           forceReportSizesToWindowsOnWorkspace(const int&);
     bool           cursorOnReservedArea();
     CWorkspace*    createNewWorkspace(const int&, const int&, const std::string& name = ""); // will be deleted next frame if left empty and unfocused!
+    void           renameWorkspace(const int&, const std::string& name = "");
     void           setActiveMonitor(CMonitor*);
     bool           isWorkspaceSpecial(const int&);
     int            getNewSpecialID();
-    CWorkspace*    renameWorkspace(const int& id, const std::string& name = "");
 
     std::string    explicitConfigPath;
 

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -174,6 +174,7 @@ class CCompositor {
     void           setActiveMonitor(CMonitor*);
     bool           isWorkspaceSpecial(const int&);
     int            getNewSpecialID();
+    CWorkspace*    renameWorkspace(const int& id, const std::string& name = "");
 
     std::string    explicitConfigPath;
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1294,9 +1294,15 @@ void CKeybindManager::renameWorkspace(std::string args) {
     if (!args.contains(' '))
         return;
 
-    int workspace = std::stoi(args.substr(0, args.find_first_of(' ')));
-    std::string name = args.substr(args.find_first_of(' ') + 1);
-    g_pCompositor->renameWorkspace(workspace, name);
+    try {
+        int workspace = std::stoi(args.substr(0, args.find_first_of(' ')));
+        std::string name = args.substr(args.find_first_of(' ') + 1);
+        g_pCompositor->renameWorkspace(workspace, name);
+    }
+    catch (...) {
+        Debug::log(ERR, "Invalid arg in renameWorkspace, expected numeric id and string name. \"%s\".", args.c_str());
+        return;
+    }
 
 }
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1292,15 +1292,18 @@ void CKeybindManager::workspaceOpt(std::string args) {
 
 void CKeybindManager::renameWorkspace(std::string args) {
     try {
-        int workspace = std::stoi(args.substr(0, args.find_first_of(' ')));
-        std::string name = args.substr(args.find_first_of(' ') + 1);
-        g_pCompositor->renameWorkspace(workspace, name);
+        const auto POS_FIRST_SPACE = args.find_first_of(' ');
+        if (POS_FIRST_SPACE != std::string::npos) {
+            int workspace = std::stoi(args.substr(0, POS_FIRST_SPACE));
+            std::string name = args.substr(POS_FIRST_SPACE + 1);
+            g_pCompositor->renameWorkspace(workspace, name);
+        } else {
+            g_pCompositor->renameWorkspace(std::stoi(args), "");
+        }
     }
     catch (...) {
-        Debug::log(ERR, "Invalid arg in renameWorkspace, expected numeric id only and or numeric id and string name. \"%s\".", args.c_str());
-        return;
+        Debug::log(ERR, "Invalid arg in renameWorkspace, expected numeric id only or a numeric id and string name. \"%s\".", args.c_str());
     }
-
 }
 
 void CKeybindManager::exitHyprland(std::string argz) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -10,6 +10,7 @@ CKeybindManager::CKeybindManager() {
     m_mDispatchers["closewindow"]                   = kill;
     m_mDispatchers["togglefloating"]                = toggleActiveFloating;
     m_mDispatchers["workspace"]                     = changeworkspace;
+    m_mDispatchers["renameworkspace"]               = renameWorkspace;
     m_mDispatchers["fullscreen"]                    = fullscreenActive;
     m_mDispatchers["fakefullscreen"]                = fakeFullscreenActive;
     m_mDispatchers["movetoworkspace"]               = moveActiveToWorkspace;
@@ -1287,6 +1288,16 @@ void CKeybindManager::workspaceOpt(std::string args) {
 
     // recalc mon
     g_pLayoutManager->getCurrentLayout()->recalculateMonitor(g_pCompositor->m_pLastMonitor->ID);
+}
+
+void CKeybindManager::renameWorkspace(std::string args) {
+    if (!args.contains(' '))
+        return;
+
+    int workspace = std::stoi(args.substr(0, args.find_first_of(' ')));
+    std::string name = args.substr(args.find_first_of(' ') + 1);
+    g_pCompositor->renameWorkspace(workspace, name);
+
 }
 
 void CKeybindManager::exitHyprland(std::string argz) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1291,16 +1291,13 @@ void CKeybindManager::workspaceOpt(std::string args) {
 }
 
 void CKeybindManager::renameWorkspace(std::string args) {
-    if (!args.contains(' '))
-        return;
-
     try {
         int workspace = std::stoi(args.substr(0, args.find_first_of(' ')));
         std::string name = args.substr(args.find_first_of(' ') + 1);
         g_pCompositor->renameWorkspace(workspace, name);
     }
     catch (...) {
-        Debug::log(ERR, "Invalid arg in renameWorkspace, expected numeric id and string name. \"%s\".", args.c_str());
+        Debug::log(ERR, "Invalid arg in renameWorkspace, expected numeric id only and or numeric id and string name. \"%s\".", args.c_str());
         return;
     }
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1292,17 +1292,16 @@ void CKeybindManager::workspaceOpt(std::string args) {
 
 void CKeybindManager::renameWorkspace(std::string args) {
     try {
-        const auto POS_FIRST_SPACE = args.find_first_of(' ');
-        if (POS_FIRST_SPACE != std::string::npos) {
-            int workspace = std::stoi(args.substr(0, POS_FIRST_SPACE));
-            std::string name = args.substr(POS_FIRST_SPACE + 1);
+        const auto FIRSTSPACEPOS = args.find_first_of(' ');
+        if (FIRSTSPACEPOS != std::string::npos) {
+            int         workspace = std::stoi(args.substr(0, FIRSTSPACEPOS));
+            std::string name      = args.substr(FIRSTSPACEPOS + 1);
             g_pCompositor->renameWorkspace(workspace, name);
         } else {
             g_pCompositor->renameWorkspace(std::stoi(args), "");
         }
-    }
-    catch (...) {
-        Debug::log(ERR, "Invalid arg in renameWorkspace, expected numeric id only or a numeric id and string name. \"%s\".", args.c_str());
+    } catch (std::exception& e) {
+        Debug::log(ERR, "Invalid arg in renameWorkspace, expected numeric id only or a numeric id and string name. \"%s\": \"%s\"", args.c_str(), e.what());
     }
 }
 

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -104,6 +104,7 @@ class CKeybindManager {
     static void toggleSplit(std::string);
     static void moveCursorToCorner(std::string);
     static void workspaceOpt(std::string);
+    static void renameWorkspace(std::string);
     static void exitHyprland(std::string);
     static void moveCurrentWorkspaceToMonitor(std::string);
     static void moveWorkspaceToMonitor(std::string);


### PR DESCRIPTION
Hi, thanks for this cool project !

This PR add a dispatcher to rename temporary a workspace with hyprctl / or over socket.

```
$ hyprctl dispatcher renameworkspace 2 aaaaa
ok
```

I use waybar  (AUR waybar-hyprland-git) and I well see the workspace name changing with the module `wlr/workspaces`.
The name is also well propagate in `hyprctl workspaces -j`.

It is working for me.

![record_1673131215](https://user-images.githubusercontent.com/519083/211172996-949f99b4-e511-4fd6-8388-34ce564675f0.gif)


Regards,

