### PR TITLE
Add "on" and "off" for the bind of switch

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -287,6 +287,14 @@ void CKeybindManager::onSwitchEvent(const std::string& switchName) {
     handleKeybinds(0, "switch:" + switchName, 0, 0, true, 0);
 }
 
+void CKeybindManager::onSwitchOnEvent(const std::string& switchName) {
+    handleKeybinds(0, "switch:on:" + switchName, 0, 0, true, 0);
+}
+
+void CKeybindManager::onSwitchOffEvent(const std::string& switchName) {
+    handleKeybinds(0, "switch:off:" + switchName, 0, 0, true, 0);
+}
+
 int repeatKeyHandler(void* data) {
     SKeybind** ppActiveKeybind = (SKeybind**)data;
 

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -40,6 +40,8 @@ class CKeybindManager {
     bool                                                              onAxisEvent(wlr_pointer_axis_event*);
     bool                                                              onMouseEvent(wlr_pointer_button_event*);
     void                                                              onSwitchEvent(const std::string&);
+    void                                                              onSwitchOnEvent(const std::string&);
+    void                                                              onSwitchOffEvent(const std::string&);
 
     void                                                              addKeybind(SKeybind);
     void                                                              removeKeybind(uint32_t, const std::string&);

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1,5 +1,6 @@
 #include "InputManager.hpp"
 #include "../../Compositor.hpp"
+#include "wlr/types/wlr_switch.h"
 
 void CInputManager::onMouseMoved(wlr_pointer_motion_event* e) {
     static auto* const PSENS      = &g_pConfigManager->getConfigValuePtr("general:sensitivity")->floatValue;
@@ -1215,6 +1216,18 @@ void CInputManager::newSwitch(wlr_input_device* pDevice) {
             Debug::log(LOG, "Switch %s fired, triggering binds.", NAME.c_str());
 
             g_pKeybindManager->onSwitchEvent(NAME);
+
+            const auto event_data = (struct wlr_switch_toggle_event*)data;
+            switch (event_data->switch_state) {
+                case WLR_SWITCH_STATE_ON:
+                    Debug::log(LOG, "Switch %s turn on, triggering binds.", NAME.c_str());
+                    g_pKeybindManager->onSwitchOnEvent(NAME);
+                    break;
+                case WLR_SWITCH_STATE_OFF:
+                    Debug::log(LOG, "Switch %s turn off, triggering binds.", NAME.c_str());
+                    g_pKeybindManager->onSwitchOffEvent(NAME);
+                    break;
+            }
         },
         PNEWDEV, "SwitchDevice");
 }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1217,7 +1217,7 @@ void CInputManager::newSwitch(wlr_input_device* pDevice) {
 
             g_pKeybindManager->onSwitchEvent(NAME);
 
-            const auto event_data = (struct wlr_switch_toggle_event*)data;
+            const auto event_data = (wlr_switch_toggle_event*)data;
             switch (event_data->switch_state) {
                 case WLR_SWITCH_STATE_ON:
                     Debug::log(LOG, "Switch %s turn on, triggering binds.", NAME.c_str());


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
The old bind for lid switch cannot know whether the lid is open or close.
This PR add "on" and "off" for binding of switch

The old way:
```
bindl=,switch:Lid Switch, exec, switch.sh
```
switch.sh:
```bash
if grep open /proc/acpi/button/lid/LID0/state; then
    hyprctl keyword monitor "eDP-1, 2560x1600, 2560x700, 2"
else
    hyprctl keyword monitor "eDP-1, disable"
fi
```

You can write it now:
```
bindl=,switch:on:Lid Switch, exec, "hyprctl keyword monitor "eDP-1, 2560x1600, 2560x700, 2"
bindl=,switch:off:Lid Switch, exec, hyprctl keyword monitor "eDP-1, disable"
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?

It is ready for merging
