### PR TITLE
fix: cursor changing on window move and resize

### DIFF
--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -175,24 +175,7 @@ void IHyprLayout::onBeginDragWindow() {
             m_iGrabbedCorner = 3;
     }
 
-    if (g_pInputManager->dragMode == MBIND_RESIZE) {
-        switch (m_iGrabbedCorner) {
-            case 0:
-                g_pInputManager->setCursorImageUntilUnset("top_left_corner");
-                break;
-            case 1:
-                g_pInputManager->setCursorImageUntilUnset("top_right_corner");
-                break;
-            case 3:
-                g_pInputManager->setCursorImageUntilUnset("bottom_right_corner");
-                break;
-            case 4:
-                g_pInputManager->setCursorImageUntilUnset("bottom_left_corner");
-                break;
-        }
-    } else {
-        g_pInputManager->setCursorImageUntilUnset("grabbing");
-    }
+    g_pInputManager->setCursorImageUntilUnset("grab");
 
     g_pHyprRenderer->damageWindow(DRAGGINGWINDOW);
 

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -143,8 +143,6 @@ void IHyprLayout::onBeginDragWindow() {
         return;
     }
 
-    g_pInputManager->setCursorImageUntilUnset("hand1");
-
     DRAGGINGWINDOW->m_bDraggingTiled = false;
 
     if (!DRAGGINGWINDOW->m_bIsFloating) {
@@ -175,6 +173,25 @@ void IHyprLayout::onBeginDragWindow() {
             m_iGrabbedCorner = 1;
         else
             m_iGrabbedCorner = 3;
+    }
+
+    if (g_pInputManager->dragMode == MBIND_RESIZE) {
+        switch (m_iGrabbedCorner) {
+            case 0:
+                g_pInputManager->setCursorImageUntilUnset("top_left_corner");
+                break;
+            case 1:
+                g_pInputManager->setCursorImageUntilUnset("top_right_corner");
+                break;
+            case 3:
+                g_pInputManager->setCursorImageUntilUnset("bottom_right_corner");
+                break;
+            case 4:
+                g_pInputManager->setCursorImageUntilUnset("bottom_left_corner");
+                break;
+        }
+    } else {
+        g_pInputManager->setCursorImageUntilUnset("grabbing");
     }
 
     g_pHyprRenderer->damageWindow(DRAGGINGWINDOW);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fix [inconsistent](https://github.com/hyprwm/Hyprland/issues/1214#issuecomment-1345787478) mouse cursor during window moving and also use the "corner"cursors during window resizing.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
The corner cursors might look kind of out-of-place if dragging from near the middle of the window, or from the wrong side when tiled? Not sure.

#### Is it ready for merging, or does it need work?
Yes.

