### PR TITLE
Implement urgency hint for workspaces

### DIFF
--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -135,6 +135,7 @@ class CCompositor {
     void           sanityCheckWorkspaces();
     void           updateWorkspaceWindowDecos(const int&);
     int            getWindowsOnWorkspace(const int&);
+    bool           hasUrgentWindowOnWorkspace(const int&);
     CWindow*       getFirstWindowOnWorkspace(const int&);
     CWindow*       getFullscreenWindowOnWorkspace(const int&);
     bool           doesSeatAcceptInput(wlr_surface*);

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -157,6 +157,9 @@ class CWindow {
     // For pinned (sticky) windows
     bool m_bPinned = false;
 
+    // urgency hint
+    bool m_bIsUrgent = false;
+
     // fakefullscreen
     bool m_bFakeFullscreenState = false;
 

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -803,12 +803,22 @@ void Events::listener_activateXDG(wl_listener* listener, void* data) {
 
     Debug::log(LOG, "Activate request for surface at %x", E->surface);
 
-    if (!*PFOCUSONACTIVATE || !wlr_surface_is_xdg_surface(E->surface))
+    if (!wlr_surface_is_xdg_surface(E->surface))
         return;
 
     const auto PWINDOW = g_pCompositor->getWindowFromSurface(E->surface);
 
     if (!PWINDOW || PWINDOW == g_pCompositor->m_pLastWindow)
+        return;
+
+    PWINDOW->m_bIsUrgent = true;
+
+    const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(PWINDOW->m_iWorkspaceID);
+    if (PWORKSPACE->m_pWlrHandle) {
+        wlr_ext_workspace_handle_v1_set_urgent(PWORKSPACE->m_pWlrHandle, 1);
+    }
+
+    if (!*PFOCUSONACTIVATE)
         return;
 
     if (PWINDOW->m_bIsFloating)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

There is `focus_on_activate` variable, which unconditionally focuses a window as soon as it requests activation.

This is not always desired, for example if you are working and a chat app requests activation because someone messaged you.

This PR is a first step towards allowing controlled handling of windows that request activation.

With it, every workspace that has an unfocused window that requests activation, will be marked as urgent, following e.g. sway's behavior. If there are multiple windows requesting activation, all of them need to receive focus, before workspace will have its urgency status removed.

Panels like waybar already handle this, and mark the workspace e.g. in a special color. 

In order to test, you need to find an app that can request activation (for example kitty terminal) and a way to see whether workspace is urgent (for example waybar), and then you can test like so:

1. Open workspace 1
1. Open 1st kitty, run `sleep 2 && printf '\a'`
1. Open 2nd kitty
1. Move to workspace 2
1. After 2s, observe that workspace 1 is marked as urgent
1. Move to workspace 1, focus is on 2nd kitty, so workspace is still urgent, as 1st kitty was not focused yet
1. Move focus to the 1st kitty - workspace will no longer be marked as urgent.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I didn't handle XWayland as I am both not sure how to test, and how to mark workspace as urgent. Unless you know how to do it and can give me a hint, maybe this could be added separately, by a more knowledgeable person?

#### Is it ready for merging, or does it need work?

Yes, unless you want to wait for XWayland implementation before merging.

The next step would be implementing a dispatcher that can focus either the next urgent workspace, or go to the last workspace, thus allowing you with one keybinding to check the chat app and then go back to work. But this will come in a separate PR.
