### PR TITLE
remove IsSwitchingToPrevious variable and checks

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -641,10 +641,6 @@ void CKeybindManager::changeworkspace(std::string args) {
     int         workspaceToChangeTo = 0;
     std::string workspaceName       = "";
 
-    // Flag needed so that the previous workspace is not recorded when switching
-    // to a previous workspace.
-    bool isSwitchingToPrevious = false;
-
     bool internal = false;
 
     if (args.find("[internal]") == 0) {
@@ -669,10 +665,6 @@ void CKeybindManager::changeworkspace(std::string args) {
             else
                 workspaceName = std::to_string(workspaceToChangeTo);
 
-            isSwitchingToPrevious = true;
-
-            // If the previous workspace ID isn't reset, cycles can form when continually going
-            // to the previous workspace again and again.
             static auto* const PALLOWWORKSPACECYCLES = &g_pConfigManager->getConfigValuePtr("binds:allow_workspace_cycles")->intValue;
             if (!*PALLOWWORKSPACECYCLES)
                 PCURRENTWORKSPACE->m_iPrevWorkspaceID = -1;
@@ -702,10 +694,7 @@ void CKeybindManager::changeworkspace(std::string args) {
         else
             workspaceName = std::to_string(workspaceToChangeTo);
 
-        isSwitchingToPrevious = true;
 
-        // If the previous workspace ID isn't reset, cycles can form when continually going
-        // to the previous workspace again and again.
         static auto* const PALLOWWORKSPACECYCLES = &g_pConfigManager->getConfigValuePtr("binds:allow_workspace_cycles")->intValue;
         if (!*PALLOWWORKSPACECYCLES)
             PCURRENTWORKSPACE->m_iPrevWorkspaceID = -1;
@@ -728,7 +717,7 @@ void CKeybindManager::changeworkspace(std::string args) {
 
         const auto PWORKSPACETOCHANGETO = g_pCompositor->getWorkspaceByID(workspaceToChangeTo);
 
-        if (!isSwitchingToPrevious && !internal)
+        if (!internal)
             // Remember previous workspace.
             PWORKSPACETOCHANGETO->m_iPrevWorkspaceID = g_pCompositor->m_pLastMonitor->activeWorkspace;
 
@@ -823,9 +812,7 @@ void CKeybindManager::changeworkspace(std::string args) {
 
     const bool ANOTHERMONITOR = PMONITOR != g_pCompositor->m_pLastMonitor;
 
-    if (!isSwitchingToPrevious)
-        // Remember previous workspace.
-        PWORKSPACE->m_iPrevWorkspaceID = OLDWORKSPACE;
+    PWORKSPACE->m_iPrevWorkspaceID = OLDWORKSPACE;
 
     // start anim on new workspace
     PWORKSPACE->startAnim(true, ANIMTOLEFT);


### PR DESCRIPTION
fixes #1218

#### Describe your PR, what does it fix/add?
it removes the IsSwitchingToPrevious variable from the previous workspace logic. this means that when switching to a previous workspace, switching to the previous workspace again will bring you to the window that switched to previous workspace ie; workspace 1 > previous workspace 2 > previous  workspace 1 > previous  workspace 2

this is in line with it's implementation on other window managers, as well as more consistent with what is expected when switching to the previous workspace.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
could break some workflows, although I can't seem to find anyone that wanted this behavior, apart from maybe the original coder of this functionality. using this alone for a few days, I haven't seen anything break, nor have I seen this variable in other parts of the project.

#### Is it ready for merging, or does it need work?
maybe it's better to have a config option to decide this rather than a hardcoded fix. I don't think there's any problems with this patch apart from that.

