### PR TITLE
Honor previous maximize on defullscreen request

### DIFF
--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -111,6 +111,7 @@ class CWindow {
     bool        m_bIsFloating    = false;
     bool        m_bDraggingTiled = false; // for dragging around tiled windows
     bool        m_bIsFullscreen  = false;
+    bool        m_bWasMaximized  = false;
     uint64_t    m_iMonitorID     = -1;
     std::string m_szTitle        = "";
     int         m_iWorkspaceID   = -1;

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -767,11 +767,23 @@ void Events::listener_fullscreenWindow(void* owner, void* data) {
         if (REQUESTED->fullscreen && PWINDOW->m_bIsFullscreen) {
             const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(PWINDOW->m_iWorkspaceID);
             if (PWORKSPACE->m_efFullscreenMode != FULLSCREEN_FULL) {
+                // Store that we were maximized
+                PWINDOW->m_bWasMaximized = true;
                 g_pCompositor->setWindowFullscreen(PWINDOW, false, FULLSCREEN_MAXIMIZED);
                 g_pCompositor->setWindowFullscreen(PWINDOW, true, FULLSCREEN_FULL);
             }
-        } else if (REQUESTED->fullscreen != PWINDOW->m_bIsFullscreen && !PWINDOW->m_bFakeFullscreenState)
+            else
+                PWINDOW->m_bWasMaximized = false;
+        } else if (REQUESTED->fullscreen != PWINDOW->m_bIsFullscreen && !PWINDOW->m_bFakeFullscreenState) {
             g_pCompositor->setWindowFullscreen(PWINDOW, REQUESTED->fullscreen, FULLSCREEN_FULL);
+            if (PWINDOW->m_bWasMaximized && !REQUESTED->fullscreen) {
+                // Was maximized before the fullscreen request, return now back to maximized instead of normal
+                g_pCompositor->setWindowFullscreen(PWINDOW, true, FULLSCREEN_MAXIMIZED);
+            }
+        }
+
+        // Disable the maximize flag when we recieve a de-fullscreen request
+        PWINDOW->m_bWasMaximized &= REQUESTED->fullscreen;
 
         requestedFullState = REQUESTED->fullscreen;
 


### PR DESCRIPTION
When defullscreening a window by the apps' request, we would return the window to normal mode, even if the window was previously maximized. Now a defullscreening request honors the previous maximized state.

#### Describe your PR, what does it fix/add?
See #1390

#### Is it ready for merging, or does it need work?
It is ready to merge. Since the issue it is fixing, is expected behaviour, the behaviour could probably be controlled by a configuration, which could still be done(I'll have to look into that). 

