### PR TITLE
feat: add focus to urgent or last window

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1084,6 +1084,15 @@ int CCompositor::getWindowsOnWorkspace(const int& id) {
     return no;
 }
 
+CWindow* CCompositor::getUrgentWindow() {
+    for (auto& w : m_vWindows) {
+        if (w->m_bIsMapped && w->m_bIsUrgent)
+            return w.get();
+    }
+
+    return nullptr;
+}
+
 bool CCompositor::hasUrgentWindowOnWorkspace(const int& id) {
     for (auto& w : m_vWindows) {
         if (w->m_iWorkspaceID == id && w->m_bIsMapped && w->m_bIsUrgent)

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -137,6 +137,7 @@ class CCompositor {
     void           sanityCheckWorkspaces();
     void           updateWorkspaceWindowDecos(const int&);
     int            getWindowsOnWorkspace(const int&);
+    CWindow*       getUrgentWindow();
     bool           hasUrgentWindowOnWorkspace(const int&);
     CWindow*       getFirstWindowOnWorkspace(const int&);
     CWindow*       getFullscreenWindowOnWorkspace(const int&);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -48,7 +48,7 @@ CKeybindManager::CKeybindManager() {
     m_mDispatchers["pin"]                           = pinActive;
     m_mDispatchers["mouse"]                         = mouse;
     m_mDispatchers["bringactivetotop"]              = bringActiveToTop;
-    m_mDispatchers["focusurgentorlastwindow"]       = focusUrgentOrLastWindow;
+    m_mDispatchers["focusurgentorlast"]             = focusUrgentOrLast;
 
     m_tScrollTimer.reset();
 }
@@ -1100,7 +1100,7 @@ void CKeybindManager::moveFocusTo(std::string args) {
     }
 }
 
-void CKeybindManager::focusUrgentOrLastWindow(std::string args) {
+void CKeybindManager::focusUrgentOrLast(std::string args) {
     const auto PWINDOWURGENT = g_pCompositor->getUrgentWindow();
     const auto PWINDOWPREV = g_pCompositor->m_pLastWindow
         ? (g_pCompositor->m_vWindowFocusHistory.size() < 2 ? nullptr : g_pCompositor->m_vWindowFocusHistory[1])

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -48,6 +48,7 @@ CKeybindManager::CKeybindManager() {
     m_mDispatchers["pin"]                           = pinActive;
     m_mDispatchers["mouse"]                         = mouse;
     m_mDispatchers["bringactivetotop"]              = bringActiveToTop;
+    m_mDispatchers["focusurgentorlastwindow"]       = focusUrgentOrLastWindow;
 
     m_tScrollTimer.reset();
 }
@@ -1097,6 +1098,43 @@ void CKeybindManager::moveFocusTo(std::string args) {
             switchToWindow(PWINDOWNEXT);
         }
     }
+}
+
+void CKeybindManager::focusUrgentOrLastWindow(std::string args) {
+    const auto PWINDOWURGENT = g_pCompositor->getUrgentWindow();
+    const auto PWINDOWPREV = g_pCompositor->m_pLastWindow
+        ? (g_pCompositor->m_vWindowFocusHistory.size() < 2 ? nullptr : g_pCompositor->m_vWindowFocusHistory[1])
+        : (g_pCompositor->m_vWindowFocusHistory.empty() ? nullptr : g_pCompositor->m_vWindowFocusHistory[0]);
+
+    if (!PWINDOWURGENT && !PWINDOWPREV)
+        return;
+
+    // remove constraints
+    g_pInputManager->unconstrainMouse();
+
+    auto switchToWindow = [&](CWindow* PWINDOWTOCHANGETO) {
+        if (PWINDOWTOCHANGETO == g_pCompositor->m_pLastWindow || !PWINDOWTOCHANGETO)
+            return;
+
+        if (g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_iWorkspaceID == PWINDOWTOCHANGETO->m_iWorkspaceID && g_pCompositor->m_pLastWindow->m_bIsFullscreen) {
+            const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(g_pCompositor->m_pLastWindow->m_iWorkspaceID);
+            const auto FSMODE     = PWORKSPACE->m_efFullscreenMode;
+
+            if (!PWINDOWTOCHANGETO->m_bPinned)
+                g_pCompositor->setWindowFullscreen(g_pCompositor->m_pLastWindow, false, FULLSCREEN_FULL);
+
+            g_pCompositor->focusWindow(PWINDOWTOCHANGETO);
+
+            if (!PWINDOWTOCHANGETO->m_bPinned)
+                g_pCompositor->setWindowFullscreen(PWINDOWTOCHANGETO, true, FSMODE);
+        } else {
+            g_pCompositor->focusWindow(PWINDOWTOCHANGETO);
+            Vector2D middle = PWINDOWTOCHANGETO->m_vRealPosition.goalv() + PWINDOWTOCHANGETO->m_vRealSize.goalv() / 2.f;
+            g_pCompositor->warpCursorTo(middle);
+        }
+    };
+
+    switchToWindow(PWINDOWURGENT ? PWINDOWURGENT : PWINDOWPREV);
 }
 
 void CKeybindManager::moveActiveTo(std::string args) {

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -97,6 +97,7 @@ class CKeybindManager {
     static void moveActiveToWorkspace(std::string);
     static void moveActiveToWorkspaceSilent(std::string);
     static void moveFocusTo(std::string);
+    static void focusUrgentOrLastWindow(std::string);
     static void centerWindow(std::string);
     static void moveActiveTo(std::string);
     static void toggleGroup(std::string);

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -97,7 +97,7 @@ class CKeybindManager {
     static void moveActiveToWorkspace(std::string);
     static void moveActiveToWorkspaceSilent(std::string);
     static void moveFocusTo(std::string);
-    static void focusUrgentOrLastWindow(std::string);
+    static void focusUrgentOrLast(std::string);
     static void centerWindow(std::string);
     static void moveActiveTo(std::string);
     static void toggleGroup(std::string);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Following the PR https://github.com/hyprwm/Hyprland/pull/1379, with @maximbaz we try to implement the dispatcher to jump to urgent window, or last window, if no urgent window - we also need to jump between workspace if needed.

The code to jump to the urgent window works, but we are not able to keep track of the PREVIOUS window.
A urgent window come, I see the workspace blinking in my waybar, I trigger `focusurgentorlastwindow` keybind which lead me to well jump on the urgent one, but then, if I trigger again the keybind, sadly, I can't go back to the previous one to continue my work.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

We together try different way, but everytime we loose the track of this previous window.

We try to set `g_pCompositor->m_pPrevWindow;` from `src/managers/XWaylandManager.cpp` in `activate()`, or from `switchToWindow()` in `src/managers/KeybindManager.cpp` but looks like, we always loose the trace of the last window where the user was, before jumping to urgent one. 

Any idea of what is our problem, what make us loose the track of the previous window ?

ps: need `focus_on_activate = false` to reproduce.

#### Is it ready for merging, or does it need work?

No, @vaxerski we need help 🙏

