### PR TITLE
fix: hyprland crashing wenn moving window -1 from first monitor

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1704,7 +1704,7 @@ CMonitor* CCompositor::getMonitorFromString(const std::string& name) {
         currentPlace += offsetLeft;
 
         if (currentPlace < 0) {
-            currentPlace = m_vMonitors.size() - currentPlace;
+            currentPlace = m_vMonitors.size() + currentPlace;
         } else {
             currentPlace = currentPlace % m_vMonitors.size();
         }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

It fixes a crash that occurs wenn moving a window from the first Monitor backwards (i.e. movewindow,mon:-1) 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I tested it on my machine and it worked perfectly without resulting in a crash.
I only tried `movewindow,mon:-1` though and not much more.

#### Is it ready for merging, or does it need work?

Unless there is something preventing this change it should be ready to merge.
