### PR TITLE
Unbreak build with libc++

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -11,6 +11,7 @@
 #include <unistd.h>
 #include <errno.h>
 
+#include <sstream>
 #include <string>
 
 std::string monitorsRequest(HyprCtl::eHyprCtlOutputFormat format) {

--- a/src/helpers/BezierCurve.cpp
+++ b/src/helpers/BezierCurve.cpp
@@ -1,5 +1,7 @@
 #include "BezierCurve.hpp"
 
+#include <algorithm>
+
 void CBezierCurve::setup(std::vector<Vector2D>* pVec) {
     m_dPoints.clear();
 

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -4,6 +4,7 @@
 #include "../Compositor.hpp"
 #include <sys/utsname.h>
 #include <iomanip>
+#include <sstream>
 
 #if defined(__DragonFly__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #include <sys/sysctl.h>

--- a/src/helpers/SubsurfaceTree.hpp
+++ b/src/helpers/SubsurfaceTree.hpp
@@ -24,7 +24,7 @@ struct SSurfaceTreeNode {
     void*                  globalOffsetData;
     CWindow*               pWindowOwner = nullptr;
 
-    bool                   operator==(const SSurfaceTreeNode& rhs) {
+    bool                   operator==(const SSurfaceTreeNode& rhs) const {
         return pSurface == rhs.pSurface;
     }
 };
@@ -41,7 +41,7 @@ struct SSubsurface {
 
     CWindow* pWindowOwner = nullptr;
 
-    bool     operator==(const SSubsurface& rhs) {
+    bool     operator==(const SSubsurface& rhs) const {
         return pSubsurface == rhs.pSubsurface;
     }
 };

--- a/src/helpers/WLClasses.hpp
+++ b/src/helpers/WLClasses.hpp
@@ -43,7 +43,7 @@ struct SLayerSurface {
     bool                      forceBlur = false;
 
     // For the list lookup
-    bool operator==(const SLayerSurface& rhs) {
+    bool operator==(const SLayerSurface& rhs) const {
         return layerSurface == rhs.layerSurface && monitorID == rhs.monitorID;
     }
 };
@@ -123,7 +123,7 @@ struct SKeyboard {
     int                numlockOn   = -1;
 
     // For the list lookup
-    bool operator==(const SKeyboard& rhs) {
+    bool operator==(const SKeyboard& rhs) const {
         return keyboard == rhs.keyboard;
     }
 };
@@ -145,7 +145,7 @@ struct SMouse {
     DYNLISTENER(commitConstraint);
     DYNLISTENER(destroyMouse);
 
-    bool operator==(const SMouse& b) {
+    bool operator==(const SMouse& b) const {
         return mouse == b.mouse;
     }
 };
@@ -160,7 +160,7 @@ struct SConstraint {
     DYNLISTENER(setConstraintRegion);
     DYNLISTENER(destroyConstraint);
 
-    bool operator==(const SConstraint& b) {
+    bool operator==(const SConstraint& b) const {
         return constraint == b.constraint;
     }
 };
@@ -185,7 +185,7 @@ struct SXDGPopup {
     SSurfaceTreeNode* pSurfaceTree = nullptr;
 
     // For the list lookup
-    bool operator==(const SXDGPopup& rhs) {
+    bool operator==(const SXDGPopup& rhs) const {
         return popup == rhs.popup;
     }
 };
@@ -229,7 +229,7 @@ struct STablet {
 
     std::string           name = "";
 
-    bool                  operator==(const STablet& b) {
+    bool                  operator==(const STablet& b) const {
         return wlrDevice == b.wlrDevice;
     }
 };
@@ -252,7 +252,7 @@ struct STabletTool {
     DYNLISTENER(TabletToolDestroy);
     DYNLISTENER(TabletToolSetCursor);
 
-    bool operator==(const STabletTool& b) {
+    bool operator==(const STabletTool& b) const {
         return wlrTabletTool == b.wlrTabletTool;
     }
 };
@@ -270,7 +270,7 @@ struct STabletPad {
     DYNLISTENER(Ring);
     DYNLISTENER(Destroy);
 
-    bool operator==(const STabletPad& b) {
+    bool operator==(const STabletPad& b) const {
         return wlrTabletPadV2 == b.wlrTabletPadV2;
     }
 };
@@ -281,7 +281,7 @@ struct SIdleInhibitor {
 
     DYNLISTENER(Destroy);
 
-    bool operator==(const SIdleInhibitor& b) {
+    bool operator==(const SIdleInhibitor& b) const {
         return pWlrInhibitor == b.pWlrInhibitor;
     }
 };
@@ -333,7 +333,7 @@ struct SIMEPopup {
 
     DYNLISTENER(focusedSurfaceUnmap);
 
-    bool operator==(const SIMEPopup& other) {
+    bool operator==(const SIMEPopup& other) const {
         return pSurface == other.pSurface;
     }
 };
@@ -347,7 +347,7 @@ struct STouchDevice {
 
     DYNLISTENER(destroy);
 
-    bool operator==(const STouchDevice& other) {
+    bool operator==(const STouchDevice& other) const {
         return pWlrDevice == other.pWlrDevice;
     }
 };
@@ -358,7 +358,7 @@ struct SSwitchDevice {
     DYNLISTENER(destroy);
     DYNLISTENER(toggle);
 
-    bool operator==(const SSwitchDevice& other) {
+    bool operator==(const SSwitchDevice& other) const {
         return pWlrDevice == other.pWlrDevice;
     }
 };

--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -33,7 +33,7 @@ struct SDwindleNodeData {
     bool                             valid = true;
 
     // For list lookup
-    bool operator==(const SDwindleNodeData& rhs) {
+    bool operator==(const SDwindleNodeData& rhs) const {
         return pWindow == rhs.pWindow && workspaceID == rhs.workspaceID && position == rhs.position && size == rhs.size && pParent == rhs.pParent &&
             children[0] == rhs.children[0] && children[1] == rhs.children[1];
     }

--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -30,7 +30,7 @@ struct SMasterNodeData {
 
     int      workspaceID = -1;
 
-    bool     operator==(const SMasterNodeData& rhs) {
+    bool     operator==(const SMasterNodeData& rhs) const {
         return pWindow == rhs.pWindow;
     }
 };
@@ -39,7 +39,7 @@ struct SMasterWorkspaceData {
     int          workspaceID = -1;
     eOrientation orientation = ORIENTATION_LEFT;
 
-    bool         operator==(const SMasterWorkspaceData& rhs) {
+    bool         operator==(const SMasterWorkspaceData& rhs) const {
         return workspaceID == rhs.workspaceID;
     }
 };

--- a/src/protocols/ToplevelExport.hpp
+++ b/src/protocols/ToplevelExport.hpp
@@ -14,7 +14,7 @@ struct SToplevelClient {
     int          ref      = 0;
     wl_resource* resource = nullptr;
 
-    bool         operator==(const SToplevelClient& other) {
+    bool         operator==(const SToplevelClient& other) const {
         return resource == other.resource;
     }
 };
@@ -36,7 +36,7 @@ struct SToplevelFrame {
 
     CWindow*         pWindow = nullptr;
 
-    bool             operator==(const SToplevelFrame& other) {
+    bool             operator==(const SToplevelFrame& other) const {
         return resource == other.resource && client == other.client;
     }
 };

--- a/src/wlrunstable/wlr_ext_workspace_v1.cpp
+++ b/src/wlrunstable/wlr_ext_workspace_v1.cpp
@@ -1,5 +1,3 @@
-#define _POSIX_C_SOURCE 200809L
-
 #include "../includes.hpp"
 #include "../helpers/MiscFunctions.hpp"
 #include "ext-workspace-unstable-v1-protocol.h"


### PR DESCRIPTION
Affects systems where Clang is default e.g., FreeBSD, OpenBSD, OpenMandriva, Chimera Linux. To test on GCC-based systems try:
```
$ export CC=clang CXX=clang++ CXXFLAGS=-stdlib=libc++
$ meson setup /tmp/hyprland_build
$ meson compile -C /tmp/hyprland_build
```

Note, [requires](https://github.com/llvm/llvm-project/commit/b8cb1dc9ea87) libc++ >= 16 (libc++ 15 can use [`-fexperimental-library`](https://github.com/llvm/llvm-project/commit/deb3b5552f04)) to [avoid](https://github.com/llvm/llvm-project/commit/0e3dc1a52ffe) the following:
```c++
hyprctl/main.cpp:265:12: error: no member named 'all_of' in namespace 'std::ranges'; did you mean 'std::all_of'?
    return std::ranges::all_of(str.begin(), str.end(), [&](char c) { return isdigit(c) != 0 || c == '-' || (allowfloat && c == '.'); });
           ^~~~~~~~~~~~~~~~~~~
           std::all_of
/usr/include/c++/v1/__algorithm/all_of.h:23:1: note: 'std::all_of' declared here
all_of(_InputIterator __first, _InputIterator __last, _Predicate __pred) {
^
```
