### PR TITLE
fix(hyprctl): allow dispatcher to have no args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ _deps
 build/
 result*
 /.vscode/
+/.idea/
 .envrc
 .cache
 

--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -170,7 +170,7 @@ void requestHyprpaper(std::string arg) {
 
 int dispatchRequest(int argc, char** argv) {
 
-    if (argc < 4) {
+    if (argc < 3) {
         std::cout << "Usage: hyprctl dispatch <dispatcher> <arg>\n\
             Execute a hyprland keybind dispatcher with the given argument";
         return 1;


### PR DESCRIPTION
## Why

Fixes #1463 

## What

- fix(hyprctl): allow dispatch subcommand's dispatcher to have no args
- chore: add `.idea/` to gitignore

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

no

#### Is it ready for merging, or does it need work?

Should be ready it's really simple. I'll probably contribute again at some point or another so I added `.idea/` to gitignore for clion's project settings
