### PR TITLE
ext_workspace_unstable: send output_enter when wl_output is bound late

### DIFF
--- a/src/wlrunstable/wlr_ext_workspace_v1.cpp
+++ b/src/wlrunstable/wlr_ext_workspace_v1.cpp
@@ -405,6 +405,22 @@ static void group_send_output(struct wlr_ext_workspace_group_handle_v1 *group,
 	}
 }
 
+static void workspace_handle_output_bind(struct wl_listener *listener,
+		void *data) {
+	struct wlr_output_event_bind *evt = (wlr_output_event_bind *)data;
+	struct wlr_ext_workspace_group_handle_v1_output *output =
+		wl_container_of(listener, output, output_bind);
+	struct wl_client *client = wl_resource_get_client(evt->resource);
+
+	struct wl_resource *group_resource, *tmp;
+	wl_resource_for_each_safe(group_resource, tmp, &output->group_handle->resources) {
+		if (client == wl_resource_get_client(group_resource)) {
+			zext_workspace_group_handle_v1_send_output_enter(group_resource,
+				evt->resource);
+		}
+	}
+}
+
 static void workspace_handle_output_destroy(struct wl_listener *listener,
 		void *data) {
 	struct wlr_ext_workspace_group_handle_v1_output *output =
@@ -431,6 +447,9 @@ void wlr_ext_workspace_group_handle_v1_output_enter(
 	group_output->output = output;
 	group_output->group_handle = group;
 	wl_list_insert(&group->outputs, &group_output->link);
+
+	group_output->output_bind.notify = workspace_handle_output_bind;
+	wl_signal_add(&output->events.bind, &group_output->output_bind);
 
 	group_output->output_destroy.notify = workspace_handle_output_destroy;
 	wl_signal_add(&output->events.destroy, &group_output->output_destroy);

--- a/src/wlrunstable/wlr_ext_workspace_v1.hpp
+++ b/src/wlrunstable/wlr_ext_workspace_v1.hpp
@@ -52,6 +52,7 @@ struct wlr_ext_workspace_group_handle_v1_create_workspace_event {
 
 struct wlr_ext_workspace_group_handle_v1_output {
 	struct wl_list link; // wlr_ext_workspace_group_handle_v1::outputs
+	struct wl_listener output_bind;
 	struct wl_listener output_destroy;
 	struct wlr_output *output;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes #1466

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

`output_leave` is never sent. Also workspace groups are never destroyed, each time I plug/unplug a monitor the number of groups keeps increasing. But this is a different bug that I'll probably fix in a separate PR.

#### Is it ready for merging, or does it need work?


Ready.