### PR TITLE
ext_workspace_unstable: send done after output_enter when wl_output is bound late

### DIFF
--- a/src/wlrunstable/wlr_ext_workspace_v1.cpp
+++ b/src/wlrunstable/wlr_ext_workspace_v1.cpp
@@ -419,6 +419,8 @@ static void workspace_handle_output_bind(struct wl_listener *listener,
 				evt->resource);
 		}
 	}
+
+	workspace_manager_update_idle_source(output->group_handle->manager);
 }
 
 static void workspace_handle_output_destroy(struct wl_listener *listener,


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

In #1480 I forgot to send "done" event.
