### PR TITLE
Update blurriness of layersurfaces after hyprctl keyword blurls

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -932,17 +932,16 @@ void CConfigManager::updateBlurredLS(const std::string& name, const bool forceBl
     }
 }
 
-void CConfigManager::handleBlurLS(const std::string& command, const std::string& value, const bool dynamic) {
+void CConfigManager::handleBlurLS(const std::string& command, const std::string& value) {
     if (value.find("remove,") == 0) {
         const auto TOREMOVE = removeBeginEndSpacesTabs(value.substr(7));
-        if (std::erase_if(m_dBlurLSNamespaces, [&](const auto& other) { return other == TOREMOVE; }) && dynamic)
+        if (std::erase_if(m_dBlurLSNamespaces, [&](const auto& other) { return other == TOREMOVE; }))
             updateBlurredLS(TOREMOVE, false);
         return;
     }
 
     m_dBlurLSNamespaces.emplace_back(value);
-    if (dynamic)
-        updateBlurredLS(value, true);
+    updateBlurredLS(value, true);
 }
 
 void CConfigManager::handleDefaultWorkspace(const std::string& command, const std::string& value) {
@@ -1071,7 +1070,7 @@ std::string CConfigManager::parseKeyword(const std::string& COMMAND, const std::
     else if (COMMAND == "submap")
         handleSubmap(COMMAND, VALUE);
     else if (COMMAND == "blurls")
-        handleBlurLS(COMMAND, VALUE, dynamic);
+        handleBlurLS(COMMAND, VALUE);
     else if (COMMAND == "wsbind")
         handleBindWS(COMMAND, VALUE);
     else {

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -235,7 +235,7 @@ class CConfigManager {
     void         handleAnimation(const std::string&, const std::string&);
     void         handleSource(const std::string&, const std::string&);
     void         handleSubmap(const std::string&, const std::string&);
-    void         handleBlurLS(const std::string&, const std::string&, const bool);
+    void         handleBlurLS(const std::string&, const std::string&);
     void         handleBindWS(const std::string&, const std::string&);
 };
 

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -214,6 +214,7 @@ class CConfigManager {
     void         setDeviceDefaultVars(const std::string&);
 
     void         setAnimForChildren(SAnimationPropertyConfig* const);
+    void         updateBlurredLS(const std::string&, const bool);
 
     void         applyUserDefinedVars(std::string&, const size_t);
     void         loadConfigLoadVars();
@@ -234,7 +235,7 @@ class CConfigManager {
     void         handleAnimation(const std::string&, const std::string&);
     void         handleSource(const std::string&, const std::string&);
     void         handleSubmap(const std::string&, const std::string&);
-    void         handleBlurLS(const std::string&, const std::string&);
+    void         handleBlurLS(const std::string&, const std::string&, const bool);
     void         handleBindWS(const std::string&, const std::string&);
 };
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
It makes `hyprctl keyword blurls` update the blurriness of existing layer surfaces instead of needing them to close and reopen.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I'm not super confident in my understanding of the rendering stack, if there's something I'm neglecting to update or if I'm doing something wrong let me know.

#### Is it ready for merging, or does it need work?
It seems to be fine working for me.