### PR TITLE
explicit config path for autoreload config #1423

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1322,7 +1322,6 @@ void CConfigManager::tick() {
 
     std::string CONFIGPATH;
     if (g_pCompositor->explicitConfigPath == "") {
-        static const char* const ENVHOME = getenv("HOME");
         CONFIGPATH                       = ENVHOME + (ISDEBUG ? (std::string) "/.config/hypr/hyprlandd.conf" : (std::string) "/.config/hypr/hyprland.conf");
     } else {
         CONFIGPATH = g_pCompositor->explicitConfigPath;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1318,10 +1318,9 @@ void CConfigManager::loadConfigLoadVars() {
 }
 
 void CConfigManager::tick() {
-    static const char* const ENVHOME = getenv("HOME");
-
     std::string CONFIGPATH;
-    if (g_pCompositor->explicitConfigPath == "") {
+    if (g_pCompositor->explicitConfigPath.empty()) {
+        static const char* const ENVHOME = getenv("HOME");
         CONFIGPATH                       = ENVHOME + (ISDEBUG ? (std::string) "/.config/hypr/hyprlandd.conf" : (std::string) "/.config/hypr/hyprland.conf");
     } else {
         CONFIGPATH = g_pCompositor->explicitConfigPath;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1320,8 +1320,14 @@ void CConfigManager::loadConfigLoadVars() {
 void CConfigManager::tick() {
     static const char* const ENVHOME = getenv("HOME");
 
-    const std::string        CONFIGPATH = ENVHOME + (ISDEBUG ? (std::string) "/.config/hypr/hyprlandd.conf" : (std::string) "/.config/hypr/hyprland.conf");
-
+    std::string CONFIGPATH;
+    if (g_pCompositor->explicitConfigPath == "") {
+        static const char* const ENVHOME = getenv("HOME");
+        CONFIGPATH                       = ENVHOME + (ISDEBUG ? (std::string) "/.config/hypr/hyprlandd.conf" : (std::string) "/.config/hypr/hyprland.conf");
+    } else {
+        CONFIGPATH = g_pCompositor->explicitConfigPath;
+    }
+    
     if (!std::filesystem::exists(CONFIGPATH)) {
         Debug::log(ERR, "Config doesn't exist??");
         return;


### PR DESCRIPTION
### This PR is not ready for merge, i did not tested it and will not tested by me
Need help to validate this change.

### What it does
_I hope_ Fixing issue #1423 Autoreload of configuration doesn't work when configuration path is not default path.

### Idea of change
[src/config/ConfigManager.cpp](https://github.com/hyprwm/Hyprland/compare/main...coffebar:Hyprland:fix_config_path?expand=1#diff-9993bc2bbc311ab9e2cb878dbc44bc4f9d5edc5216b9aa3172e4b10b9b0d61f5) config auto-read function 
`void CConfigManager::tick() {`
did not contain read of `explicitConfigPath` variable
