### PR TITLE
libinput: add tap_button_map

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -154,6 +154,7 @@ void CConfigManager::setDefaultVars() {
     configValues["input:touchpad:natural_scroll"].intValue          = 0;
     configValues["input:touchpad:disable_while_typing"].intValue    = 1;
     configValues["input:touchpad:clickfinger_behavior"].intValue    = 0;
+    configValues["input:touchpad:tap_button_map"].strValue          = STRVAL_EMPTY;
     configValues["input:touchpad:middle_button_emulation"].intValue = 0;
     configValues["input:touchpad:tap-to-click"].intValue            = 1;
     configValues["input:touchpad:tap-and-drag"].intValue            = 1;
@@ -199,6 +200,7 @@ void CConfigManager::setDeviceDefaultVars(const std::string& dev) {
     cfgValues["repeat_rate"].intValue             = 25;
     cfgValues["repeat_delay"].intValue            = 600;
     cfgValues["natural_scroll"].intValue          = 0;
+    cfgValues["tap_button_map"].strValue          = STRVAL_EMPTY;
     cfgValues["numlock_by_default"].intValue      = 0;
     cfgValues["disable_while_typing"].intValue    = 1;
     cfgValues["clickfinger_behavior"].intValue    = 0;

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -761,6 +761,14 @@ void CInputManager::setPointerConfigs() {
                     libinput_device_config_middle_emulation_set_enabled(LIBINPUTDEV, LIBINPUT_CONFIG_MIDDLE_EMULATION_ENABLED);
                 else
                     libinput_device_config_middle_emulation_set_enabled(LIBINPUTDEV, LIBINPUT_CONFIG_MIDDLE_EMULATION_DISABLED);
+
+                const auto TAP_MAP = HASCONFIG ? g_pConfigManager->getDeviceString(devname, "tap_button_map") : g_pConfigManager->getString("input:touchpad:tap_button_map");
+                if (TAP_MAP == "" || TAP_MAP == "lrm")
+                    libinput_device_config_tap_set_button_map(LIBINPUTDEV, LIBINPUT_CONFIG_TAP_MAP_LRM);
+                else if (TAP_MAP == "lmr")
+                    libinput_device_config_tap_set_button_map(LIBINPUTDEV, LIBINPUT_CONFIG_TAP_MAP_LMR);
+                else
+                    Debug::log(WARN, "Tap button mapping unknown");
             }
 
             const auto SCROLLMETHOD = HASCONFIG ? g_pConfigManager->getDeviceString(devname, "scroll_method") : g_pConfigManager->getString("input:scroll_method");


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds `input:touchpad:tap_button_map` with 3 options: empty, `lrm` (default), or `lmr`.
This corresponds to the way the mappings work after being set. LMR -> 1 finger left click, 2 finger middle click, 3 finger right click.
Fixes #1489

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Not tested, please test this as I don't have time myself.
@coffebar

#### Is it ready for merging, or does it need work?
If testers say it works, it's mergeable.
