### PR TITLE
Fix CMake minimum required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.19)
 include(CheckIncludeFile)
 
 # Get version


### PR DESCRIPTION
The CMakeLists.txt file uses string(JSON), which was not introduced until 3.19.

I have attempted to build on 3.18 (Debian Bullseye), it does not work.

https://gitlab.kitware.com/cmake/cmake/-/merge_requests/5159
