### PR TITLE
Only use true/false in default config to reduce confusion

### DIFF
--- a/example/hyprland.conf
+++ b/example/hyprland.conf
@@ -30,7 +30,7 @@ input {
     follow_mouse = 1
 
     touchpad {
-        natural_scroll = no
+        natural_scroll = false
     }
 
     sensitivity = 0 # -1.0 - 1.0, 0 means no modification.
@@ -52,19 +52,19 @@ decoration {
     # See https://wiki.hyprland.org/Configuring/Variables/ for more
 
     rounding = 10
-    blur = yes
+    blur = true
     blur_size = 3
     blur_passes = 1
-    blur_new_optimizations = on
+    blur_new_optimizations = true
 
-    drop_shadow = yes
+    drop_shadow = true
     shadow_range = 4
     shadow_render_power = 3
     col.shadow = rgba(1a1a1aee)
 }
 
 animations {
-    enabled = yes
+    enabled = true
 
     # Some default animations, see https://wiki.hyprland.org/Configuring/Animations/ for more
 
@@ -80,8 +80,8 @@ animations {
 
 dwindle {
     # See https://wiki.hyprland.org/Configuring/Dwindle-Layout/ for more
-    pseudotile = yes # master switch for pseudotiling. Enabling is bound to mainMod + P in the keybinds section below
-    preserve_split = yes # you probably want this
+    pseudotile = true # master switch for pseudotiling. Enabling is bound to mainMod + P in the keybinds section below
+    preserve_split = true # you probably want this
 }
 
 master {
@@ -91,7 +91,7 @@ master {
 
 gestures {
     # See https://wiki.hyprland.org/Configuring/Variables/ for more
-    workspace_swipe = off
+    workspace_swipe = false
 }
 
 # Example per-device config
@@ -112,10 +112,10 @@ $mainMod = SUPER
 
 # Example binds, see https://wiki.hyprland.org/Configuring/Binds/ for more
 bind = $mainMod, Q, exec, kitty
-bind = $mainMod, C, killactive, 
-bind = $mainMod, M, exit, 
+bind = $mainMod, C, killactive,
+bind = $mainMod, M, exit,
 bind = $mainMod, E, exec, dolphin
-bind = $mainMod, V, togglefloating, 
+bind = $mainMod, V, togglefloating,
 bind = $mainMod, R, exec, wofi --show drun
 bind = $mainMod, P, pseudo, # dwindle
 bind = $mainMod, J, togglesplit, # dwindle


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Hello, 

I think it would be a good idea to standardize the format of all the boolean values in the example configuration file in order to always use `true`/`false`.

I think the different `true`/`false`/`on`/`off`/`yes`/`no` leads to more confusion for the new users even if the values in themselves are perfectly valid.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?

It is ready if you think the changes are a good idea :smile: 