### PR TITLE
Added support for layoutmsg params and added the param 'newfocus' for 'swapwithmaster' and 'focusmaster'

### DIFF
--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -747,7 +747,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
 
     CVarList vars(message, 0, ' ');
 
-    if (vars.size() < 1 || vars[0] == "") {
+    if (vars.size() < 1 || vars[0].empty()) {
         Debug::log(ERR, "layoutmsg called without params");
         return 0;
     }
@@ -773,10 +773,10 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
         // * child - keep the focus at the new child
         // * auto (default) - swap the focus (keep the focus of the previously selected window)
         if (PMASTER->pWindow != PWINDOW) {
-            auto newChild = PMASTER->pWindow;
+            const auto NEWCHILD = PMASTER->pWindow;
             switchWindows(PWINDOW, PMASTER->pWindow);
             if (vars.size() >= 2 && vars[1] == "child")
-                switchToWindow(newChild);
+                switchToWindow(NEWCHILD);
             else // default switch to new master
                 switchToWindow(PMASTER->pWindow);
         } else {

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -745,7 +745,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
         g_pCompositor->warpCursorTo(PWINDOWTOCHANGETO->m_vRealPosition.goalv() + PWINDOWTOCHANGETO->m_vRealSize.goalv() / 2.f);
     };
 
-    CVarList vars(message);
+    CVarList vars(message, 0, ' ');
 
     if (vars.size() < 1 || vars[0] == "") {
         Debug::log(ERR, "layoutmsg called without params");

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -745,7 +745,16 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
         g_pCompositor->warpCursorTo(PWINDOWTOCHANGETO->m_vRealPosition.goalv() + PWINDOWTOCHANGETO->m_vRealSize.goalv() / 2.f);
     };
 
-    if (message == "swapwithmaster") {
+    CVarList vars(message);
+
+    if (vars.size() < 1 || vars[0] == "") {
+        Debug::log(ERR, "layoutmsg called without params");
+        return 0;
+    }
+
+    auto command = vars[0];
+
+    if (command == "swapwithmaster") {
         const auto PWINDOW = header.pWindow;
 
         if (!PWINDOW)
@@ -759,21 +768,34 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
         if (!PMASTER)
             return 0;
 
+        // first message argument can have the following values:
+        // * master - keep the focus at the new master
+        // * child - keep the focus at the new child
+        // * auto (default) - swap the focus (keep the focus of the previously selected window)
         if (PMASTER->pWindow != PWINDOW) {
+            auto newChild = PMASTER->pWindow;
             switchWindows(PWINDOW, PMASTER->pWindow);
-            switchToWindow(PWINDOW);
+            if (vars.size() >= 2 && vars[1] == "child")
+                switchToWindow(newChild);
+            else // default switch to new master
+                switchToWindow(PMASTER->pWindow);
         } else {
             for (auto& n : m_lMasterNodesData) {
                 if (n.workspaceID == PMASTER->workspaceID && !n.isMaster) {
                     switchWindows(n.pWindow, PMASTER->pWindow);
-                    switchToWindow(n.pWindow);
+                    // if master is focused keep master focused (don't do anything)
+                    if (vars.size() >= 2 && vars[1] == "master") {
+                        switchToWindow(PMASTER->pWindow);
+                    } else { // default switch to child
+                        switchToWindow(n.pWindow);
+                    }
                     break;
                 }
             }
         }
 
         return 0;
-    } else if (message == "focusmaster") {
+    } else if (command == "focusmaster") {
         const auto PWINDOW = header.pWindow;
 
         if (!PWINDOW)
@@ -786,10 +808,16 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
         if (!PMASTER)
             return 0;
 
+        // first message argument can have the following values:
+        // * master - keep the focus at the new master, even if it was focused before
+        // * auto (default) - swap the focus with the first child, if the current focus was master, otherwise focus master
         if (PMASTER->pWindow != PWINDOW) {
             switchToWindow(PMASTER->pWindow);
             prepareNewFocus(PMASTER->pWindow, inheritFullscreen);
+        } else if (vars.size() >= 2 && vars[1] == "master") {
+              return 0;
         } else {
+            // if master is focused keep master focused (don't do anything)
             for (auto& n : m_lMasterNodesData) {
                 if (n.workspaceID == PMASTER->workspaceID && !n.isMaster) {
                     switchToWindow(n.pWindow);
@@ -800,7 +828,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
         }
 
         return 0;
-    } else if (message == "cyclenext") {
+    } else if (command == "cyclenext") {
         const auto PWINDOW = header.pWindow;
 
         if (!PWINDOW)
@@ -811,7 +839,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
         const auto PNEXTWINDOW = getNextWindow(PWINDOW, true);
         switchToWindow(PNEXTWINDOW);
         prepareNewFocus(PNEXTWINDOW, inheritFullscreen);
-    } else if (message == "cycleprev") {
+    } else if (command == "cycleprev") {
         const auto PWINDOW = header.pWindow;
 
         if (!PWINDOW)
@@ -822,7 +850,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
         const auto PPREVWINDOW = getNextWindow(PWINDOW, false);
         switchToWindow(PPREVWINDOW);
         prepareNewFocus(PPREVWINDOW, inheritFullscreen);
-    } else if (message == "swapnext") {
+    } else if (command == "swapnext") {
         if (!g_pCompositor->windowValidMapped(header.pWindow))
             return 0;
 
@@ -838,7 +866,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
             switchWindows(header.pWindow, PWINDOWTOSWAPWITH);
             g_pCompositor->focusWindow(header.pWindow);
         }
-    } else if (message == "swapprev") {
+    } else if (command == "swapprev") {
         if (!g_pCompositor->windowValidMapped(header.pWindow))
             return 0;
 
@@ -854,7 +882,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
             switchWindows(header.pWindow, PWINDOWTOSWAPWITH);
             g_pCompositor->focusWindow(header.pWindow);
         }
-    } else if (message == "addmaster") {
+    } else if (command == "addmaster") {
         if (!g_pCompositor->windowValidMapped(header.pWindow))
             return 0;
 
@@ -885,7 +913,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
 
         recalculateMonitor(header.pWindow->m_iMonitorID);
 
-    } else if (message == "removemaster") {
+    } else if (command == "removemaster") {
 
         if (!g_pCompositor->windowValidMapped(header.pWindow))
             return 0;
@@ -916,7 +944,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
         }
 
         recalculateMonitor(header.pWindow->m_iMonitorID);
-    } else if (message == "orientationleft" || message == "orientationright" || message == "orientationtop" || message == "orientationbottom") {
+    } else if (command == "orientationleft" || command == "orientationright" || command == "orientationtop" || command == "orientationbottom") {
         const auto PWINDOW = header.pWindow;
 
         if (!PWINDOW)
@@ -926,18 +954,18 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
 
         const auto PWORKSPACEDATA = getMasterWorkspaceData(PWINDOW->m_iWorkspaceID);
 
-        if (message == "orientationleft")
+        if (command == "orientationleft")
             PWORKSPACEDATA->orientation = ORIENTATION_LEFT;
-        else if (message == "orientationright")
+        else if (command == "orientationright")
             PWORKSPACEDATA->orientation = ORIENTATION_RIGHT;
-        else if (message == "orientationtop")
+        else if (command == "orientationtop")
             PWORKSPACEDATA->orientation = ORIENTATION_TOP;
-        else if (message == "orientationbottom")
+        else if (command == "orientationbottom")
             PWORKSPACEDATA->orientation = ORIENTATION_BOTTOM;
 
         recalculateMonitor(header.pWindow->m_iMonitorID);
 
-    } else if (message == "orientationnext") {
+    } else if (command == "orientationnext") {
         const auto PWINDOW = header.pWindow;
 
         if (!PWINDOW)
@@ -954,7 +982,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
         }
 
         recalculateMonitor(header.pWindow->m_iMonitorID);
-    } else if (message == "orientationprev") {
+    } else if (command == "orientationprev") {
         const auto PWINDOW = header.pWindow;
 
         if (!PWINDOW)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

It adds the possibility to add parameters to the `layoutmsg` dispatcher for the Master layout.
It also adds the parameter `newfocus` for the `layoutmsg` dispatchers `swapwithmaster` and `focusmaster`,
which can have the following values for `swapwithmaster`:
* `master` - focus at the new master after swap
* `child` - focus the new child after swap
* `auto` - keep the focus on the previously focused window (default and also current behavior)

For `focusmaster` it can have the following values:
* `master` - focus the master, or keep the focus at master if it is already focused
* `auto` - swap the focus with the first child, if the current focus was master, otherwise focus master (default and also current behavior)

Fixes #674 with for example the following binding:
```
bind = $mod,P,layoutmsg,swapwithmaster master
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

The PR itself doesn't introduce any breaking compatibility.

I think `CVarList` should have `size() == 0` when the given parameter for the constructor is an empty string (while it is `1` and the first parameter is the empty string).

I haven't changed this behavior in fear that anything breaks that depends on the current behavior.

I'm working around it with a check like this right now: `CVarList::size() > 0 && vars[0] != ""`.


#### Is it ready for merging, or does it need work?

Yes it's ready for merge, though we might need to update the hyprland-wiki as well with the new Master layout layoutmsg para, should I add a PR there?