### PR TITLE
focusCurrentOrLast dispatcher

### DIFF
--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -98,6 +98,7 @@ class CKeybindManager {
     static void moveActiveToWorkspaceSilent(std::string);
     static void moveFocusTo(std::string);
     static void focusUrgentOrLast(std::string);
+    static void focusCurrentOrLast(std::string);
     static void centerWindow(std::string);
     static void moveActiveTo(std::string);
     static void toggleGroup(std::string);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
+ It adds a `focusCurrentOrLast` dispatcher, which is a slight modification of `focusUrgentOrLast`. 
+ This function allows users to switch back and forth (toggle) between the currently focused and the previously focused window _across workspaces_ or within the same workspace. 
+ It is similar to `dwl`'s `view` function with `{0}` argument (in the config).
+ Users can bind this dispatcher to `Mod+Tab` or to their preference to quickly toggle between two windows.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
The entire function is a copy of `focusUrgentOrLast`. I have modified 5 lines in total (3 lines of the function).

#### Is it ready for merging, or does it need work?
It is very simple so it should be good.

