### PR TITLE
ignore VR headsets

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1195,6 +1195,11 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
         return true;
     }
 
+    // don't touch VR headsets
+    if (pMonitor->output->non_desktop) {
+        return true;
+    }
+
     if (!pMonitor->m_bEnabled) {
         pMonitor->onConnect(true); // enable it.
         force = true;


### PR DESCRIPTION
Don't interact with screens that have the non_desktop property set, fixes #1553.

This works for me, and seems simple enough so it shouldn't break anything - it's meant for and tested on a VR headset, but if any screen identifies as "not a desktop" on a driver level, it probably really isn't and we should probably ignore it. 