### PR TITLE
Add vrr to hyprctl monitor

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -60,13 +60,13 @@ std::string monitorsRequest(HyprCtl::eHyprCtlOutputFormat format) {
         for (auto& m : g_pCompositor->m_vMonitors) {
             result += getFormat("Monitor %s (ID %i):\n\t%ix%i@%f at %ix%i\n\tdescription: %s\n\tmake: %s\n\tmodel: %s\n\tserial: %s\n\tactive workspace: %i (%s)\n\treserved: %i "
                                 "%i %i %i\n\tscale: %.2f\n\ttransform: "
-                                "%i\n\tfocused: %s\n\tdpmsStatus: %i\n\tvariable refresh rate: %s\n\n",
+                                "%i\n\tfocused: %s\n\tdpmsStatus: %i\n\tvrr: %s\n\n",
                                 m->szName.c_str(), m->ID, (int)m->vecPixelSize.x, (int)m->vecPixelSize.y, m->refreshRate, (int)m->vecPosition.x, (int)m->vecPosition.y,
                                 (m->output->description ? m->output->description : ""), (m->output->make ? m->output->make : ""), (m->output->model ? m->output->model : ""),
                                 (m->output->serial ? m->output->serial : ""), m->activeWorkspace, g_pCompositor->getWorkspaceByID(m->activeWorkspace)->m_szName.c_str(),
                                 (int)m->vecReservedTopLeft.x, (int)m->vecReservedTopLeft.y, (int)m->vecReservedBottomRight.x, (int)m->vecReservedBottomRight.y, m->scale,
                                 (int)m->transform, (m.get() == g_pCompositor->m_pLastMonitor ? "yes" : "no"),
-                                (int)m->dpmsStatus, m->output->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED ? "yes" : "no");
+                                (int)m->dpmsStatus, m->output->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED ? "1" : "0");
         }
     }
 

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -41,14 +41,15 @@ std::string monitorsRequest(HyprCtl::eHyprCtlOutputFormat format) {
     "scale": %.2f,
     "transform": %i,
     "focused": %s,
-    "dpmsStatus": %s
+    "dpmsStatus": %s,
+    "vrr: %s"
 },)#",
                 m->ID, escapeJSONStrings(m->szName).c_str(), escapeJSONStrings(m->output->description ? m->output->description : "").c_str(),
                 (m->output->make ? m->output->make : ""), (m->output->model ? m->output->model : ""), (m->output->serial ? m->output->serial : ""), (int)m->vecPixelSize.x,
                 (int)m->vecPixelSize.y, m->refreshRate, (int)m->vecPosition.x, (int)m->vecPosition.y, m->activeWorkspace,
                 escapeJSONStrings(g_pCompositor->getWorkspaceByID(m->activeWorkspace)->m_szName).c_str(), (int)m->vecReservedTopLeft.x, (int)m->vecReservedTopLeft.y,
                 (int)m->vecReservedBottomRight.x, (int)m->vecReservedBottomRight.y, m->scale, (int)m->transform, (m.get() == g_pCompositor->m_pLastMonitor ? "true" : "false"),
-                (m->dpmsStatus ? "true" : "false"));
+                (m->dpmsStatus ? "true" : "false"), (m->output->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED ? "true" : "false"));
         }
 
         // remove trailing comma
@@ -59,12 +60,13 @@ std::string monitorsRequest(HyprCtl::eHyprCtlOutputFormat format) {
         for (auto& m : g_pCompositor->m_vMonitors) {
             result += getFormat("Monitor %s (ID %i):\n\t%ix%i@%f at %ix%i\n\tdescription: %s\n\tmake: %s\n\tmodel: %s\n\tserial: %s\n\tactive workspace: %i (%s)\n\treserved: %i "
                                 "%i %i %i\n\tscale: %.2f\n\ttransform: "
-                                "%i\n\tfocused: %s\n\tdpmsStatus: %i\n\n",
+                                "%i\n\tfocused: %s\n\tdpmsStatus: %i\n\tvariable refresh rate: %s\n\n",
                                 m->szName.c_str(), m->ID, (int)m->vecPixelSize.x, (int)m->vecPixelSize.y, m->refreshRate, (int)m->vecPosition.x, (int)m->vecPosition.y,
                                 (m->output->description ? m->output->description : ""), (m->output->make ? m->output->make : ""), (m->output->model ? m->output->model : ""),
                                 (m->output->serial ? m->output->serial : ""), m->activeWorkspace, g_pCompositor->getWorkspaceByID(m->activeWorkspace)->m_szName.c_str(),
                                 (int)m->vecReservedTopLeft.x, (int)m->vecReservedTopLeft.y, (int)m->vecReservedBottomRight.x, (int)m->vecReservedBottomRight.y, m->scale,
-                                (int)m->transform, (m.get() == g_pCompositor->m_pLastMonitor ? "yes" : "no"), (int)m->dpmsStatus);
+                                (int)m->transform, (m.get() == g_pCompositor->m_pLastMonitor ? "yes" : "no"),
+                                (int)m->dpmsStatus, m->output->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED ? "yes" : "no");
         }
     }
 

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -60,13 +60,13 @@ std::string monitorsRequest(HyprCtl::eHyprCtlOutputFormat format) {
         for (auto& m : g_pCompositor->m_vMonitors) {
             result += getFormat("Monitor %s (ID %i):\n\t%ix%i@%f at %ix%i\n\tdescription: %s\n\tmake: %s\n\tmodel: %s\n\tserial: %s\n\tactive workspace: %i (%s)\n\treserved: %i "
                                 "%i %i %i\n\tscale: %.2f\n\ttransform: "
-                                "%i\n\tfocused: %s\n\tdpmsStatus: %i\n\tvrr: %s\n\n",
+                                "%i\n\tfocused: %s\n\tdpmsStatus: %i\n\tvrr: %i\n\n",
                                 m->szName.c_str(), m->ID, (int)m->vecPixelSize.x, (int)m->vecPixelSize.y, m->refreshRate, (int)m->vecPosition.x, (int)m->vecPosition.y,
                                 (m->output->description ? m->output->description : ""), (m->output->make ? m->output->make : ""), (m->output->model ? m->output->model : ""),
                                 (m->output->serial ? m->output->serial : ""), m->activeWorkspace, g_pCompositor->getWorkspaceByID(m->activeWorkspace)->m_szName.c_str(),
                                 (int)m->vecReservedTopLeft.x, (int)m->vecReservedTopLeft.y, (int)m->vecReservedBottomRight.x, (int)m->vecReservedBottomRight.y, m->scale,
                                 (int)m->transform, (m.get() == g_pCompositor->m_pLastMonitor ? "yes" : "no"),
-                                (int)m->dpmsStatus, m->output->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED ? "1" : "0");
+                                (int)m->dpmsStatus, (int)(m->output->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED));
         }
     }
 


### PR DESCRIPTION
Since the (re)addition of vrr in 127e80692f78b0d91450194fcb4ce0009c2a98a4, it is very useful to know, whether a given monitor has vrr enabled or not, since not all monitors support it. Now hyprctl reports, whether a monitor has vrr enabled or not.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I'm unsure, whether my approach is the right way to check for vrr. Though through my testing with both a vrr monitor and a non-vrr monitor, it seems to work properly.


#### Is it ready for merging, or does it need work?
Ready for merging.


