### PR TITLE
Group/Tab Rework

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1576,6 +1576,8 @@ void CCompositor::updateWindowAnimatedDecorationValues(CWindow* pWindow) {
     // optimization
     static auto* const ACTIVECOL          = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("general:col.active_border")->data.get();
     static auto* const INACTIVECOL        = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("general:col.inactive_border")->data.get();
+    static auto* const GROUPACTIVECOL     = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("general:col.group_border_active")->data.get();
+    static auto* const GROUPINACTIVECOL   = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("general:col.group_border")->data.get();
     static auto* const PINACTIVEALPHA     = &g_pConfigManager->getConfigValuePtr("decoration:inactive_opacity")->floatValue;
     static auto* const PACTIVEALPHA       = &g_pConfigManager->getConfigValuePtr("decoration:active_opacity")->floatValue;
     static auto* const PFULLSCREENALPHA   = &g_pConfigManager->getConfigValuePtr("decoration:fullscreen_opacity")->floatValue;
@@ -1597,13 +1599,19 @@ void CCompositor::updateWindowAnimatedDecorationValues(CWindow* pWindow) {
     const auto RENDERDATA = g_pLayoutManager->getCurrentLayout()->requestRenderHints(pWindow);
     if (RENDERDATA.isBorderGradient)
         setBorderColor(*RENDERDATA.borderGradient);
-    else
-        setBorderColor(pWindow == m_pLastWindow ? (pWindow->m_sSpecialRenderData.activeBorderColor.toUnderlying() >= 0 ?
-                                                       CGradientValueData(CColor(pWindow->m_sSpecialRenderData.activeBorderColor.toUnderlying())) :
-                                                       *ACTIVECOL) :
-                                                  (pWindow->m_sSpecialRenderData.inactiveBorderColor.toUnderlying() >= 0 ?
-                                                       CGradientValueData(CColor(pWindow->m_sSpecialRenderData.inactiveBorderColor.toUnderlying())) :
-                                                       *INACTIVECOL));
+    else {
+        if (pWindow == m_pLastWindow) {
+            const auto* const ACTIVECOLOR = !pWindow->m_sGroupData.pNextWindow ? ACTIVECOL : GROUPACTIVECOL;
+            setBorderColor(pWindow->m_sSpecialRenderData.activeBorderColor.toUnderlying() >= 0 ?
+                               CGradientValueData(CColor(pWindow->m_sSpecialRenderData.activeBorderColor.toUnderlying())) :
+                               *ACTIVECOLOR);
+        } else {
+            const auto* const INACTIVECOLOR = !pWindow->m_sGroupData.pNextWindow ? INACTIVECOL : GROUPINACTIVECOL;
+            setBorderColor(pWindow->m_sSpecialRenderData.inactiveBorderColor.toUnderlying() >= 0 ?
+                               CGradientValueData(CColor(pWindow->m_sSpecialRenderData.inactiveBorderColor.toUnderlying())) :
+                               *INACTIVECOLOR);
+        }
+    }
 
     // tick angle if it's not running (aka dead)
     if (!pWindow->m_fBorderAngleAnimationProgress.isBeingAnimated())

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -273,6 +273,12 @@ class CWindow {
     // for idle inhibiting windows
     eIdleInhibitMode m_eIdleInhibitMode = IDLEINHIBIT_NONE;
 
+    // for groups
+    struct SGroupData {
+        CWindow* pNextWindow = nullptr; // nullptr means no grouping. Self means single group.
+        bool     head        = false;
+    } m_sGroupData;
+
     // For the list lookup
     bool operator==(const CWindow& rhs) {
         return m_uSurface.xdg == rhs.m_uSurface.xdg && m_uSurface.xwayland == rhs.m_uSurface.xwayland && m_vPosition == rhs.m_vPosition && m_vSize == rhs.m_vSize &&
@@ -302,6 +308,12 @@ class CWindow {
     void                   onBorderAngleAnimEnd(void* ptr);
     bool                   isInCurvedCorner(double x, double y);
     bool                   hasPopupAt(const Vector2D& pos);
+
+    CWindow*               getGroupHead();
+    CWindow*               getGroupTail();
+    CWindow*               getGroupCurrent();
+    void                   setGroupCurrent(CWindow* pWindow);
+    void                   insertWindowToGroup(CWindow* pWindow);
 
   private:
     // For hidden windows and stuff

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -13,8 +13,8 @@
 CConfigManager::CConfigManager() {
     configValues["general:col.active_border"].data       = std::make_shared<CGradientValueData>(0xffffffff);
     configValues["general:col.inactive_border"].data     = std::make_shared<CGradientValueData>(0xff444444);
-    configValues["dwindle:col.group_border"].data        = std::make_shared<CGradientValueData>(0x66777700);
-    configValues["dwindle:col.group_border_active"].data = std::make_shared<CGradientValueData>(0x66ffff00);
+    configValues["general:col.group_border"].data        = std::make_shared<CGradientValueData>(0x66777700);
+    configValues["general:col.group_border_active"].data = std::make_shared<CGradientValueData>(0x66ffff00);
 
     setDefaultVars();
     setDefaultAnimationVars();
@@ -44,6 +44,8 @@ void CConfigManager::setDefaultVars() {
     configValues["general:gaps_out"].intValue              = 20;
     ((CGradientValueData*)configValues["general:col.active_border"].data.get())->reset(0xffffffff);
     ((CGradientValueData*)configValues["general:col.inactive_border"].data.get())->reset(0xff444444);
+    ((CGradientValueData*)configValues["general:col.group_border"].data.get())->reset(0x66777700);
+    ((CGradientValueData*)configValues["general:col.group_border_active"].data.get())->reset(0x66ffff00);
     configValues["general:cursor_inactive_timeout"].intValue = 0;
     configValues["general:no_cursor_warps"].intValue         = 0;
     configValues["general:resize_on_border"].intValue        = 0;
@@ -102,8 +104,6 @@ void CConfigManager::setDefaultVars() {
     configValues["decoration:dim_around"].floatValue           = 0.4f;
     configValues["decoration:screen_shader"].strValue          = STRVAL_EMPTY;
 
-    ((CGradientValueData*)configValues["dwindle:col.group_border"].data.get())->reset(0x66777700);
-    ((CGradientValueData*)configValues["dwindle:col.group_border_active"].data.get())->reset(0x66ffff00);
     configValues["dwindle:pseudotile"].intValue               = 0;
     configValues["dwindle:force_split"].intValue              = 0;
     configValues["dwindle:preserve_split"].intValue           = 0;

--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -19,10 +19,6 @@ struct SDwindleNodeData {
 
     bool                             splitTop = false; // for preserve_split
 
-    bool                             groupHead            = false;
-    SDwindleNodeData*                pNextGroupMember     = nullptr;
-    SDwindleNodeData*                pPreviousGroupMember = nullptr;
-
     Vector2D                         position;
     Vector2D                         size;
 
@@ -40,11 +36,6 @@ struct SDwindleNodeData {
 
     void                recalcSizePosRecursive(bool force = false);
     void                getAllChildrenRecursive(std::deque<SDwindleNodeData*>*);
-    bool                isGroupMember();
-    SDwindleNodeData*   getGroupHead();
-    SDwindleNodeData*   getGroupVisible();
-    int                 getGroupMemberCount();
-    void                setGroupFocusedNode(SDwindleNodeData*);
     CHyprDwindleLayout* layout = nullptr;
 };
 
@@ -62,6 +53,7 @@ class CHyprDwindleLayout : public IHyprLayout {
     virtual void                     switchWindows(CWindow*, CWindow*);
     virtual void                     alterSplitRatio(CWindow*, float, bool);
     virtual std::string              getLayoutName();
+    virtual void                     replaceWindowDataWith(CWindow* from, CWindow* to);
 
     virtual void                     onEnable();
     virtual void                     onDisable();
@@ -75,10 +67,7 @@ class CHyprDwindleLayout : public IHyprLayout {
     SDwindleNodeData*           getFirstNodeOnWorkspace(const int&);
     SDwindleNodeData*           getMasterNodeOnWorkspace(const int&);
 
-    void                        toggleWindowGroup(CWindow*);
-    void                        switchGroupWindow(CWindow*, bool forward, CWindow* to = nullptr);
     void                        toggleSplit(CWindow*);
-    std::deque<CWindow*>        getGroupMembers(CWindow*);
 
     friend struct SDwindleNodeData;
 };

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -24,6 +24,36 @@ void IHyprLayout::onWindowRemoved(CWindow* pWindow) {
     if (pWindow->m_bIsFullscreen)
         g_pCompositor->setWindowFullscreen(pWindow, false, FULLSCREEN_FULL);
 
+    if (pWindow->m_sGroupData.pNextWindow) {
+        if (pWindow->m_sGroupData.pNextWindow == pWindow)
+            pWindow->m_sGroupData.pNextWindow = nullptr;
+        else {
+            // find last window and update
+            CWindow*   curr           = pWindow;
+            const auto CURRWASVISIBLE = curr->getGroupCurrent() == curr;
+
+            while (curr->m_sGroupData.pNextWindow != pWindow)
+                curr = curr->m_sGroupData.pNextWindow;
+
+            if (CURRWASVISIBLE)
+                curr->setGroupCurrent(curr);
+
+            curr->m_sGroupData.pNextWindow = pWindow->m_sGroupData.pNextWindow;
+
+            pWindow->m_sGroupData.pNextWindow = nullptr;
+
+            if (pWindow->m_sGroupData.head) {
+                pWindow->m_sGroupData.head = false;
+                curr->m_sGroupData.head    = true;
+            }
+
+            if (pWindow == m_pLastTiledWindow)
+                m_pLastTiledWindow = nullptr;
+
+            return;
+        }
+    }
+
     if (pWindow->m_bIsFloating) {
         onWindowRemovedFloating(pWindow);
     } else {

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -143,6 +143,11 @@ interface IHyprLayout {
     */
     virtual void onWindowFocusChange(CWindow*);
 
+    /*
+        Called for replacing any data a layout has for a new window
+    */
+    virtual void replaceWindowDataWith(CWindow * from, CWindow * to) = 0;
+
   private:
     Vector2D    m_vBeginDragXY;
     Vector2D    m_vLastDragXY;

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -83,6 +83,20 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow) {
     const auto         WINDOWSONWORKSPACE = getNodesOnWorkspace(PNODE->workspaceID);
     float              lastSplitPercent   = 0.5f;
 
+    auto               OPENINGON = isWindowTiled(g_pCompositor->m_pLastWindow) && g_pCompositor->m_pLastWindow->m_iWorkspaceID == pWindow->m_iWorkspaceID ?
+                      getNodeFromWindow(g_pCompositor->m_pLastWindow) :
+                      getMasterNodeOnWorkspace(pWindow->m_iWorkspaceID);
+
+    if (OPENINGON && OPENINGON->pWindow->m_sGroupData.pNextWindow) {
+        m_lMasterNodesData.remove(*PNODE);
+
+        OPENINGON->pWindow->insertWindowToGroup(pWindow);
+
+        pWindow->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(pWindow));
+
+        return;
+    }
+
     if (*PNEWISMASTER || WINDOWSONWORKSPACE == 1) {
         for (auto& nd : m_lMasterNodesData) {
             if (nd.isMaster && nd.workspaceID == PNODE->workspaceID) {
@@ -228,7 +242,7 @@ void CHyprMasterLayout::calculateWorkspace(const int& ws) {
     if (getNodesOnWorkspace(PWORKSPACE->m_iID) < 2) {
         PMASTERNODE->position = PMONITOR->vecReservedTopLeft + PMONITOR->vecPosition;
         PMASTERNODE->size     = Vector2D(PMONITOR->vecSize.x - PMONITOR->vecReservedTopLeft.x - PMONITOR->vecReservedBottomRight.x,
-                                         PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PMONITOR->vecReservedTopLeft.y);
+                                     PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PMONITOR->vecReservedTopLeft.y);
         applyNodeDataToWindow(PMASTERNODE);
         return;
     } else if (PWORKSPACEDATA->orientation == ORIENTATION_LEFT || PWORKSPACEDATA->orientation == ORIENTATION_RIGHT) {
@@ -1008,6 +1022,17 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
     }
 
     return 0;
+}
+
+void CHyprMasterLayout::replaceWindowDataWith(CWindow* from, CWindow* to) {
+    const auto PNODE = getNodeFromWindow(from);
+
+    if (!PNODE)
+        return;
+
+    PNODE->pWindow = to;
+
+    applyNodeDataToWindow(PNODE);
 }
 
 void CHyprMasterLayout::onEnable() {

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -87,7 +87,7 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow) {
                       getNodeFromWindow(g_pCompositor->m_pLastWindow) :
                       getMasterNodeOnWorkspace(pWindow->m_iWorkspaceID);
 
-    if (OPENINGON && OPENINGON->pWindow->m_sGroupData.pNextWindow) {
+    if (OPENINGON && OPENINGON->pWindow->m_sGroupData.pNextWindow && OPENINGON != PNODE) {
         m_lMasterNodesData.remove(*PNODE);
 
         OPENINGON->pWindow->insertWindowToGroup(pWindow);

--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -58,6 +58,7 @@ class CHyprMasterLayout : public IHyprLayout {
     virtual void                     switchWindows(CWindow*, CWindow*);
     virtual void                     alterSplitRatio(CWindow*, float, bool);
     virtual std::string              getLayoutName();
+    virtual void                     replaceWindowDataWith(CWindow* from, CWindow* to);
 
     virtual void                     onEnable();
     virtual void                     onDisable();

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -33,24 +33,29 @@ void CHyprGroupBarDecoration::updateWindow(CWindow* pWindow) {
         m_vLastWindowSize = pWindow->m_vRealSize.vec();
     }
 
-    // let's check if the window group is different.
-
-    if (g_pLayoutManager->getCurrentLayout()->getLayoutName() != "dwindle") {
-        // ????
+    if (!m_pWindow->m_sGroupData.pNextWindow) {
         m_pWindow->m_vDecosToRemove.push_back(this);
         return;
     }
 
-    // get the group info
-    SLayoutMessageHeader header;
-    header.pWindow = m_pWindow;
+    m_dwGroupMembers.clear();
+    CWindow* curr = pWindow;
+    CWindow* head = nullptr;
+    while (!curr->m_sGroupData.head) {
+        curr = curr->m_sGroupData.pNextWindow;
+    }
 
-    m_dwGroupMembers = std::any_cast<std::deque<CWindow*>>(g_pLayoutManager->getCurrentLayout()->layoutMessage(header, "groupinfo"));
+    head = curr;
+    m_dwGroupMembers.push_back(curr);
+    curr = curr->m_sGroupData.pNextWindow;
+    while (curr != head) {
+        m_dwGroupMembers.push_back(curr);
+        curr = curr->m_sGroupData.pNextWindow;
+    }
 
     damageEntire();
 
     if (m_dwGroupMembers.size() == 0) {
-        // remove
         m_pWindow->m_vDecosToRemove.push_back(this);
         return;
     }
@@ -86,8 +91,8 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
 
         scaleBox(&rect, pMonitor->scale);
 
-        static auto* const PGROUPCOLACTIVE   = &g_pConfigManager->getConfigValuePtr("dwindle:col.group_border_active")->data;
-        static auto* const PGROUPCOLINACTIVE = &g_pConfigManager->getConfigValuePtr("dwindle:col.group_border")->data;
+        static auto* const PGROUPCOLACTIVE   = &g_pConfigManager->getConfigValuePtr("general:col.group_border_active")->data;
+        static auto* const PGROUPCOLINACTIVE = &g_pConfigManager->getConfigValuePtr("general:col.group_border")->data;
 
         CColor             color = m_dwGroupMembers[i] == g_pCompositor->m_pLastWindow ? ((CGradientValueData*)PGROUPCOLACTIVE->get())->m_vColors[0] :
                                                                                          ((CGradientValueData*)PGROUPCOLINACTIVE->get())->m_vColors[0];


### PR DESCRIPTION
Reworks how groups work internally, making them independent of layouts, allows for floating them, etc.

Fixes: #1576 #770 
Closes: #593 (impossible to achieve, superseded)

Breaking changes:
`dwindle:col.group...` -> `general:col.group...`

Behavior changes: 
 - groups are now always created as singular (they don't "eat" neighbors)