### PR TITLE
Fix changegroupactive dispatcher

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1321,7 +1321,25 @@ void CKeybindManager::changeGroupActive(std::string args) {
     if (PWINDOW->m_sGroupData.pNextWindow == PWINDOW)
         return;
 
-    PWINDOW->setGroupCurrent(PWINDOW->m_sGroupData.pNextWindow);
+    if (args != "b") {
+        // forward
+        PWINDOW->setGroupCurrent(PWINDOW->m_sGroupData.pNextWindow);
+        return;
+    }
+
+    // back
+    if (PWINDOW->m_sGroupData.head) {
+        PWINDOW->setGroupCurrent(PWINDOW->getGroupTail());
+        return;
+    }
+
+    auto prev = PWINDOW->getGroupHead();
+
+    while (prev->m_sGroupData.pNextWindow != PWINDOW) {
+        prev = prev->m_sGroupData.pNextWindow;
+    }
+
+    PWINDOW->setGroupCurrent(prev);
 }
 
 void CKeybindManager::toggleSplit(std::string args) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This commit re-adds the option to specify direction (b - backward, anything else - forward), as it was before #1580.
Fixes #1594.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

If the active window is head, it automatically switches to the tail window. Otherwise, it starts finding the previous window at the group head instead of the next window. This way, the average time to find the previous window is less than the number of windows.

#### Is it ready for merging, or does it need work?

Yes.