### PR TITLE
movefocus: Set new workspace as active when focusing new monitor

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1132,8 +1132,12 @@ void CKeybindManager::moveFocusTo(std::string args) {
             if (PLASTWINDOW->m_iMonitorID != PWINDOWTOCHANGETO->m_iMonitorID) {
                 // event
                 const auto PNEWMON = g_pCompositor->getMonitorFromID(PWINDOWTOCHANGETO->m_iMonitorID);
+                const auto PNEWWORKSPACE = g_pCompositor->getWorkspaceByID(PWINDOWTOCHANGETO->m_iWorkspaceID);
 
                 g_pCompositor->setActiveMonitor(PNEWMON);
+
+                g_pCompositor->deactivateAllWLRWorkspaces(PNEWWORKSPACE->m_pWlrHandle);
+                PNEWWORKSPACE->setActive(true);
             }
         }
     };


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Prior to this patch, using `movefocus` to change focus to a different monitor wouldn't set the new workspace as active, which meant that status bars were not notified of the workspace change. They would continue to show the previous monitor/workspace as active.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.

#### Is it ready for merging, or does it need work?
It's ready.