### PR TITLE
Added center orientation to master layout

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -114,6 +114,7 @@ void CConfigManager::setDefaultVars() {
 
     configValues["master:special_scale_factor"].floatValue = 0.8f;
     configValues["master:new_is_master"].intValue          = 1;
+    configValues["master:always_center_master"].intValue   = 0;
     configValues["master:new_on_top"].intValue             = 0;
     configValues["master:no_gaps_when_only"].intValue      = 0;
     configValues["master:orientation"].strValue            = "left";

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -1033,7 +1033,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
         }
 
         recalculateMonitor(header.pWindow->m_iMonitorID);
-    } else if (command == "orientationleft" || command == "orientationright" || command == "orientationtop" || command == "orientationbottom") {
+    } else if (command == "orientationleft" || command == "orientationright" || command == "orientationtop" || command == "orientationbottom" || command == "orientationcenter") {
         const auto PWINDOW = header.pWindow;
 
         if (!PWINDOW)
@@ -1051,6 +1051,8 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
             PWORKSPACEDATA->orientation = ORIENTATION_TOP;
         else if (command == "orientationbottom")
             PWORKSPACEDATA->orientation = ORIENTATION_BOTTOM;
+        else if (command == "orientationcenter")
+            PWORKSPACEDATA->orientation = ORIENTATION_CENTER;
 
         recalculateMonitor(header.pWindow->m_iMonitorID);
 

--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -14,7 +14,8 @@ enum eOrientation : uint8_t
     ORIENTATION_LEFT = 0,
     ORIENTATION_TOP,
     ORIENTATION_RIGHT,
-    ORIENTATION_BOTTOM
+    ORIENTATION_BOTTOM,
+    ORIENTATION_CENTER
 };
 
 struct SMasterNodeData {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This adds support for a new orientation for master layout.  It is very close to the request in #1250 .

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

For my workflow I prefer my main work window to be centered.  So, this implementation centers the master window immediately when a single slave is created.  This may be a bit awkward for some folks as this leaves empty space on the right side.  If there is a strong preference I can change this to split into halves when only two windows are open.

Only other issue I found is that the mouse resize operation is a bit wonky when in this mode.

The following was added to the master layout config:
 
- orientation: added "center"
- always_center_master: bool - only used for center orientation - if true, while in center orientation the master window will always occupy the center of the screen, otherwise center orientation behaves like left orientation until three windows are open
- layoutmsg: orientationcenter

#### Is it ready for merging, or does it need work?

See above.