### PR TITLE
Add option to disable/enable mouse window dragging animations

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -52,21 +52,22 @@ void CConfigManager::setDefaultVars() {
     configValues["general:hover_icon_on_border"].intValue    = 1;
     configValues["general:layout"].strValue                  = "dwindle";
 
-    configValues["misc:disable_hyprland_logo"].intValue      = 0;
-    configValues["misc:disable_splash_rendering"].intValue   = 0;
-    configValues["misc:vfr"].intValue                        = 1;
-    configValues["misc:vrr"].intValue                        = 0;
-    configValues["misc:mouse_move_enables_dpms"].intValue    = 0;
-    configValues["misc:always_follow_on_dnd"].intValue       = 1;
-    configValues["misc:layers_hog_keyboard_focus"].intValue  = 1;
-    configValues["misc:animate_manual_resizes"].intValue     = 0;
-    configValues["misc:disable_autoreload"].intValue         = 0;
-    configValues["misc:enable_swallow"].intValue             = 0;
-    configValues["misc:swallow_regex"].strValue              = STRVAL_EMPTY;
-    configValues["misc:focus_on_activate"].intValue          = 0;
-    configValues["misc:no_direct_scanout"].intValue          = 0;
-    configValues["misc:hide_cursor_on_touch"].intValue       = 1;
-    configValues["misc:mouse_move_focuses_monitor"].intValue = 1;
+    configValues["misc:disable_hyprland_logo"].intValue        = 0;
+    configValues["misc:disable_splash_rendering"].intValue     = 0;
+    configValues["misc:vfr"].intValue                          = 1;
+    configValues["misc:vrr"].intValue                          = 0;
+    configValues["misc:mouse_move_enables_dpms"].intValue      = 0;
+    configValues["misc:always_follow_on_dnd"].intValue         = 1;
+    configValues["misc:layers_hog_keyboard_focus"].intValue    = 1;
+    configValues["misc:animate_manual_resizes"].intValue       = 0;
+    configValues["misc:animate_mouse_windowdragging"].intValue = 0;
+    configValues["misc:disable_autoreload"].intValue           = 0;
+    configValues["misc:enable_swallow"].intValue               = 0;
+    configValues["misc:swallow_regex"].strValue                = STRVAL_EMPTY;
+    configValues["misc:focus_on_activate"].intValue            = 0;
+    configValues["misc:no_direct_scanout"].intValue            = 0;
+    configValues["misc:hide_cursor_on_touch"].intValue         = 1;
+    configValues["misc:mouse_move_focuses_monitor"].intValue   = 1;
 
     configValues["debug:int"].intValue             = 0;
     configValues["debug:log_damage"].intValue      = 0;
@@ -1837,3 +1838,4 @@ void CConfigManager::addPluginConfigVar(HANDLE handle, const std::string& name, 
 void CConfigManager::removePluginConfig(HANDLE handle) {
     std::erase_if(pluginConfigs, [&](const auto& other) { return other.first == handle; });
 }
+

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -272,7 +272,7 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
     const auto DELTA     = Vector2D(mousePos.x - m_vBeginDragXY.x, mousePos.y - m_vBeginDragXY.y);
     const auto TICKDELTA = Vector2D(mousePos.x - m_vLastDragXY.x, mousePos.y - m_vLastDragXY.y);
 
-    const auto PANIMATE = &g_pConfigManager->getConfigValuePtr("misc:animate_manual_resizes")->intValue;
+    const auto PANIMATE = &g_pConfigManager->getConfigValuePtr("misc:animate_mouse_windowdragging")->intValue;
 
     if (abs(TICKDELTA.x) < 1.f && abs(TICKDELTA.y) < 1.f)
         return;

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -272,7 +272,8 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
     const auto DELTA     = Vector2D(mousePos.x - m_vBeginDragXY.x, mousePos.y - m_vBeginDragXY.y);
     const auto TICKDELTA = Vector2D(mousePos.x - m_vLastDragXY.x, mousePos.y - m_vLastDragXY.y);
 
-    const auto PANIMATE = &g_pConfigManager->getConfigValuePtr("misc:animate_mouse_windowdragging")->intValue;
+    const auto PANIMATEMOUSE = &g_pConfigManager->getConfigValuePtr("misc:animate_mouse_windowdragging")->intValue;
+    const auto PANIMATE      = &g_pConfigManager->getConfigValuePtr("misc:animate_manual_resizes")->intValue;
 
     if (abs(TICKDELTA.x) < 1.f && abs(TICKDELTA.y) < 1.f)
         return;
@@ -283,7 +284,7 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
 
     if (g_pInputManager->dragMode == MBIND_MOVE) {
 
-        if (*PANIMATE) {
+        if (*PANIMATEMOUSE) {
             DRAGGINGWINDOW->m_vRealPosition = m_vBeginDragPositionXY + DELTA;
         } else {
             DRAGGINGWINDOW->m_vRealPosition.setValueAndWarp(m_vBeginDragPositionXY + DELTA);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Add a configuration flag for windows being animated when dragged with the mouse.
This doesn't replace animate_manual_resizes, instead it is an addition.

wiki entry: https://github.com/hyprwm/hyprland-wiki/pull/141

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Users would need to update their config to keep the floating window animations.

#### Is it ready for merging, or does it need work?
ready to merge.

