### PR TITLE
Unload plugins on compositor cleanup

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -285,6 +285,10 @@ void CCompositor::cleanup() {
 
     m_bIsShuttingDown = true;
 
+    // unload all remaining plugins while the compositor is
+    // still in a normal working state.
+    g_pPluginSystem->unloadAllPlugins();
+
     m_pLastFocus  = nullptr;
     m_pLastWindow = nullptr;
 

--- a/src/plugins/PluginSystem.cpp
+++ b/src/plugins/PluginSystem.cpp
@@ -1,6 +1,7 @@
 #include "PluginSystem.hpp"
 
 #include <dlfcn.h>
+#include <ranges>
 #include "../Compositor.hpp"
 
 CPluginSystem::CPluginSystem() {
@@ -111,6 +112,11 @@ void CPluginSystem::unloadPlugin(const CPlugin* plugin, bool eject) {
     Debug::log(LOG, " [PluginSystem] Plugin %s unloaded.", plugin->name.c_str());
 
     std::erase_if(m_vLoadedPlugins, [&](const auto& other) { return other->m_pHandle == plugin->m_pHandle; });
+}
+
+void CPluginSystem::unloadAllPlugins() {
+    for (auto& p : m_vLoadedPlugins | std::views::reverse)
+        unloadPlugin(p.get(), false); // Unload remaining plugins gracefully
 }
 
 CPlugin* CPluginSystem::getPluginByPath(const std::string& path) {

--- a/src/plugins/PluginSystem.hpp
+++ b/src/plugins/PluginSystem.hpp
@@ -29,6 +29,7 @@ class CPluginSystem {
 
     CPlugin*              loadPlugin(const std::string& path);
     void                  unloadPlugin(const CPlugin* plugin, bool eject = false);
+    void                  unloadAllPlugins();
     CPlugin*              getPluginByPath(const std::string& path);
     CPlugin*              getPluginByHandle(HANDLE handle);
     std::vector<CPlugin*> getAllPlugins();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Unloads plugins (in reverse order of loading) on compositor cleanup i.e. exit.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
The current plugins out there don't benefit much from it, and should have clean exits anyway, so it shouldn't break compatibility. As bigger plugins appear I would predict this will be useful enough to warrant being the default, instead of forcing each plugin to hook the exit and do it on its own.

#### Is it ready for merging, or does it need work?
The functionality is there. Potentially it might be useful to be able to mark plugins as "special" and only unload those, but I'm not sure introducing inconsistency like that will do any good really.

