### PR TITLE
Optionally expose time to screen shaders

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -32,7 +32,7 @@ CHyprOpenGLImpl::CHyprOpenGLImpl() {
 
     RASSERT(eglMakeCurrent(wlr_egl_get_display(g_pCompositor->m_sWLREGL), EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT), "Couldn't unset current EGL!");
 
-    m_Timer.reset();
+    m_tGlobalTimer.reset();
 }
 
 GLuint CHyprOpenGLImpl::createProgram(const std::string& vert, const std::string& frag, bool dynamic) {
@@ -522,7 +522,7 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(const CTexture& tex, wlr_b
     glUniform1i(shader->tex, 0);
 
     if (usingFinalShader && g_pConfigManager->getInt("debug:damage_tracking") == 0) {
-        glUniform1f(shader->time, m_Timer.getSeconds());
+        glUniform1f(shader->time, m_tGlobalTimer.getSeconds());
     } else if (usingFinalShader) {
         // Don't let time be unitialised
         glUniform1f(shader->time, 0.f);

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -134,7 +134,7 @@ class CHyprOpenGLImpl {
     bool              m_bApplyFinalShader = false;
 
     CShader           m_sFinalScreenShader;
-    CTimer            m_Timer;
+    CTimer            m_tGlobalTimer;
 
     GLuint            createProgram(const std::string&, const std::string&, bool dynamic = false);
     GLuint            compileShader(const GLuint&, std::string, bool dynamic = false);

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -3,6 +3,7 @@
 #include "../defines.hpp"
 #include "../helpers/Monitor.hpp"
 #include "../helpers/Color.hpp"
+#include "../helpers/Timer.hpp"
 #include <list>
 #include <unordered_map>
 
@@ -133,6 +134,7 @@ class CHyprOpenGLImpl {
     bool              m_bApplyFinalShader = false;
 
     CShader           m_sFinalScreenShader;
+    CTimer            m_Timer;
 
     GLuint            createProgram(const std::string&, const std::string&, bool dynamic = false);
     GLuint            compileShader(const GLuint&, std::string, bool dynamic = false);

--- a/src/render/Shader.hpp
+++ b/src/render/Shader.hpp
@@ -37,6 +37,8 @@ class CShader {
     GLint  gradientLength;
     GLint  angle;
 
+    GLint  time;
+
     GLint  getUniformLocation(const std::string&);
 
     void   destroy();


### PR DESCRIPTION
This PR adds a way to have access to time in screen shaders. Time is essential for advanced, animated post-process shader effects (i.e. CRT effect, glitch effects, ...). 
Since that requires damage tracking to be disabled, I implemented it as "Pay for what you use". This means time is only added, if it is actually used in the shader; and users that don't use it have no disadvantage. 
If damage tracking is enabled and time is used an error is displayed. 

Implements part of https://github.com/hyprwm/Hyprland/issues/1502

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This requires, that "damage_tracking = 0" updates every frame, which seems to be the case.

#### Is it ready for merging, or does it need work?
Ready. Criticisms/suggestions welcome though.