### PR TITLE
Buffer over-read in removeBeginEndSpacesTabs()

### DIFF
--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -209,7 +209,7 @@ std::string removeBeginEndSpacesTabs(std::string str) {
     }
 
     int countAfter = 0;
-    while (str.length() != 0 && (str[str.length() - countAfter - 1] == ' ' || str[str.length() - 1 - countAfter] == '\t')) {
+    while ((int)str.length() - countAfter - 1 >= 0 && (str[str.length() - countAfter - 1] == ' ' || str[str.length() - 1 - countAfter] == '\t')) {
         countAfter++;
     }
 


### PR DESCRIPTION
If a string given to removeBeginEndSpacesTabs() was only tabs/spaces, or had tabs/spaces followed by a comment, it would lead to buffer over-read. 

The reason is that the code `str.length() != 0` , doesn't do anything, since we don't modify the string inside the while loop. Because of this the loop will run forever until `str.length() - countAfter - 1` wraps around and tries to read memory beyond the scope of the string.