### PR TITLE
config: unbreak on BSDs due to undeclared `environ`

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -10,6 +10,8 @@
 #include <fstream>
 #include <iostream>
 
+extern "C" char** environ;
+
 CConfigManager::CConfigManager() {
     configValues["general:col.active_border"].data       = std::make_shared<CGradientValueData>(0xffffffff);
     configValues["general:col.inactive_border"].data     = std::make_shared<CGradientValueData>(0xff444444);


### PR DESCRIPTION
According to [POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xbd_chap08.html):
> The variable *environ* is not intended to be declared in any header, but rather to be declared by the user for accessing the array of strings that is the environment. This is the traditional usage of the symbol. Putting it into a header could break some programs that use the symbol for their own purposes.

Neither [DragonFly](https://man.dragonflybsd.org/?command=environ&section=7) nor [FreeBSD](https://man.freebsd.org/environ/7) nor [NetBSD](https://man.netbsd.org/environ.7) nor [OpenBSD](https://man.openbsd.org/man7/environ.7) declare `environ` in any header like POSIX suggested. However, Linux (bionic, glibc, musl) declares `environ` in `<unistd.h>`.
