### PR TITLE
Fix plugin argument-less hyprctl calls

### DIFF
--- a/src/plugins/PluginAPI.cpp
+++ b/src/plugins/PluginAPI.cpp
@@ -39,8 +39,10 @@ APICALL bool HyprlandAPI::unregisterCallback(HANDLE handle, HOOK_CALLBACK_FN* fn
 }
 
 APICALL std::string HyprlandAPI::invokeHyprctlCommand(const std::string& call, const std::string& args, const std::string& format) {
-    std::string COMMAND = format + "/" + call + " " + args;
-    return HyprCtl::makeDynamicCall(COMMAND);
+    if (args.empty())
+        return HyprCtl::makeDynamicCall(format + "/" + call);
+    else
+        return HyprCtl::makeDynamicCall(format + "/" + call + " " + args);
 }
 
 APICALL bool HyprlandAPI::addLayout(HANDLE handle, const std::string& name, IHyprLayout* layout) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
The current way of internal hyprctl commands adds whitespace at the end of the call. Due to the way `HyprCtl::getReply` handles argument-less commands like "version", the whitespace added by `HyprlandAPI::invokeHyprctlCommand` breaks the hard comparison of eg. `"version" == "version "`. This fixes that by just not adding unnecessary whitespace.

#### Is it ready for merging, or does it need work?
Seems ready to me

