### PR TITLE
Added overflow check for blur radius

### DIFF
--- a/src/events/Monitors.cpp
+++ b/src/events/Monitors.cpp
@@ -234,7 +234,8 @@ void Events::listener_monitorFrame(void* owner, void* data) {
             // TODO: can this be optimized?
             static auto* const PBLURSIZE   = &g_pConfigManager->getConfigValuePtr("decoration:blur_size")->intValue;
             static auto* const PBLURPASSES = &g_pConfigManager->getConfigValuePtr("decoration:blur_passes")->intValue;
-            const auto         BLURRADIUS  = *PBLURPASSES > 10 ? pow(2, 15) : *PBLURSIZE * pow(2, *PBLURPASSES); // is this 2^pass? I don't know but it works... I think.
+            const auto         BLURRADIUS =
+                *PBLURPASSES > 10 ? pow(2, 15) : std::clamp(*PBLURSIZE, (int64_t)1, (int64_t)40) * pow(2, *PBLURPASSES); // is this 2^pass? I don't know but it works... I think.
 
             // now, prep the damage, get the extended damage region
             wlr_region_expand(&damage, &damage, BLURRADIUS); // expand for proper blurring

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -651,8 +651,7 @@ CFramebuffer* CHyprOpenGLImpl::blurMainFramebufferWithDamage(float a, wlr_box* p
     pixman_region32_copy(&damage, originalDamage);
     wlr_region_transform(&damage, &damage, wlr_output_transform_invert(m_RenderData.pMonitor->transform), m_RenderData.pMonitor->vecTransformedSize.x,
                          m_RenderData.pMonitor->vecTransformedSize.y);
-
-    wlr_region_expand(&damage, &damage, *PBLURPASSES > 10 ? pow(2, 15) : *PBLURSIZE * pow(2, *PBLURPASSES));
+    wlr_region_expand(&damage, &damage, *PBLURPASSES > 10 ? pow(2, 15) : std::clamp(*PBLURSIZE, (int64_t)1, (int64_t)40) * pow(2, *PBLURPASSES));
 
     // helper
     const auto    PMIRRORFB     = &m_RenderData.pCurrentMonData->mirrorFB;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Added a (temporary) fix to prevent blur radius from overflowing. When the value if decoration::blur_size and/or decoration::blur_passes is large, the expression `*BLUR_SIZE * pow(2, *BLURPASSES)` might return a value that won't fit into an `int` so an overflow occurs when the returned value is implicitly casted to an `int` when it gets passed to `wlr_region_expand`.

`wlr_region_expand` has this assertion which made me find out about the overflow:

    assert(distance >= 0);
#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This is not supposed to be a permanent (or even temporary) fix, I'm sure someone who has a better understanding might figure out something better as I'm not yet familiar with the codebase at all.

#### Is it ready for merging, or does it need work?
Ready for merging.