### PR TITLE
Nix: fix hidpi & make it non-default

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -81,8 +81,9 @@
         inherit udis86;
       };
       hyprland-debug = hyprland.override {debug = true;};
-      hyprland-no-hidpi = hyprland.override {hidpiXWayland = false;};
+      hyprland-hidpi = hyprland.override {hidpiXWayland = true;};
       hyprland-nvidia = hyprland.override {nvidiaPatches = true;};
+      hyprland-no-hidpi = builtins.trace "hyprland-no-hidpi was removed. Please use the default package." hyprland;
 
       udis86 = prev.callPackage ./nix/udis86.nix {};
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -25,7 +25,7 @@
   xwayland,
   debug ? false,
   enableXWayland ? true,
-  hidpiXWayland ? true,
+  hidpiXWayland ? false,
   legacyRenderer ? false,
   nvidiaPatches ? false,
   withSystemd ? true,

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -67,7 +67,7 @@ in {
       };
       hidpi = lib.mkOption {
         type = lib.types.bool;
-        default = true;
+        default = false;
         description = ''
           Enable HiDPI XWayland.
         '';

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -47,7 +47,7 @@ in {
       };
       hidpi = mkOption {
         type = types.bool;
-        default = true;
+        default = false;
         description = ''
           Enable HiDPI XWayland.
         '';

--- a/nix/wlroots-hidpi.patch
+++ b/nix/wlroots-hidpi.patch
@@ -1,25 +1,25 @@
 diff --git a/include/xwayland/xwm.h b/include/xwayland/xwm.h
-index c69504e8..40d8de8c 100644
+index 3d540522..1c5a2e37 100644
 --- a/include/xwayland/xwm.h
 +++ b/include/xwayland/xwm.h
 @@ -88,6 +88,7 @@ enum atom_name {
  	DND_ACTION_PRIVATE,
  	NET_CLIENT_LIST,
  	NET_CLIENT_LIST_STACKING,
-+  XWAYLAND_GLOBAL_OUTPUT_SCALE,
++	XWAYLAND_GLOBAL_OUTPUT_SCALE,
  	ATOM_LAST // keep last
  };
  
-@@ -98,6 +99,7 @@ struct wlr_xwm {
+@@ -96,6 +97,7 @@ struct wlr_xwm {
  	struct wl_event_source *event_source;
  	struct wlr_seat *seat;
  	uint32_t ping_timeout;
-+  uint32_t scale;
++	uint32_t scale;
  
  	xcb_atom_t atoms[ATOM_LAST];
  	xcb_connection_t *xcb_conn;
 diff --git a/xwayland/xwm.c b/xwayland/xwm.c
-index 5a36dc21..83981a87 100644
+index 5f857f24..21584ebd 100644
 --- a/xwayland/xwm.c
 +++ b/xwayland/xwm.c
 @@ -19,6 +19,14 @@
@@ -34,10 +34,10 @@ index 5a36dc21..83981a87 100644
 +	return (val + xwm->scale/2) / xwm->scale;
 +}
 +
- const char *const atom_map[ATOM_LAST] = {
+ static const char *const atom_map[ATOM_LAST] = {
  	[WL_SURFACE_ID] = "WL_SURFACE_ID",
  	[WL_SURFACE_SERIAL] = "WL_SURFACE_SERIAL",
-@@ -90,6 +98,7 @@ const char *const atom_map[ATOM_LAST] = {
+@@ -90,6 +98,7 @@ static const char *const atom_map[ATOM_LAST] = {
  	[DND_ACTION_PRIVATE] = "XdndActionPrivate",
  	[NET_CLIENT_LIST] = "_NET_CLIENT_LIST",
  	[NET_CLIENT_LIST_STACKING] = "_NET_CLIENT_LIST_STACKING",
@@ -45,7 +45,7 @@ index 5a36dc21..83981a87 100644
  };
  
  #define STARTUP_INFO_REMOVE_PREFIX "remove: ID="
-@@ -968,8 +977,8 @@ static void xwm_handle_create_notify(struct wlr_xwm *xwm,
+@@ -965,8 +974,8 @@ static void xwm_handle_create_notify(struct wlr_xwm *xwm,
  		return;
  	}
  
@@ -56,7 +56,7 @@ index 5a36dc21..83981a87 100644
  }
  
  static void xwm_handle_destroy_notify(struct wlr_xwm *xwm,
-@@ -1000,10 +1009,10 @@ static void xwm_handle_configure_request(struct wlr_xwm *xwm,
+@@ -997,10 +1006,10 @@ static void xwm_handle_configure_request(struct wlr_xwm *xwm,
  
  	struct wlr_xwayland_surface_configure_event wlr_event = {
  		.surface = surface,
@@ -71,7 +71,7 @@ index 5a36dc21..83981a87 100644
  		.mask = mask,
  	};
  
-@@ -1018,14 +1027,14 @@ static void xwm_handle_configure_notify(struct wlr_xwm *xwm,
+@@ -1015,14 +1024,14 @@ static void xwm_handle_configure_notify(struct wlr_xwm *xwm,
  	}
  
  	bool geometry_changed =
@@ -92,7 +92,7 @@ index 5a36dc21..83981a87 100644
  	}
  
  	if (xsurface->override_redirect != ev->override_redirect) {
-@@ -1136,6 +1145,20 @@ static void xwm_handle_property_notify(struct wlr_xwm *xwm,
+@@ -1133,6 +1142,20 @@ static void xwm_handle_property_notify(struct wlr_xwm *xwm,
  		xcb_property_notify_event_t *ev) {
  	struct wlr_xwayland_surface *xsurface = lookup_surface(xwm, ev->window);
  	if (xsurface == NULL) {
@@ -113,7 +113,7 @@ index 5a36dc21..83981a87 100644
  		return;
  	}
  
-@@ -1763,16 +1786,17 @@ void wlr_xwayland_surface_configure(struct wlr_xwayland_surface *xsurface,
+@@ -1760,16 +1783,17 @@ void wlr_xwayland_surface_configure(struct wlr_xwayland_surface *xsurface,
  	int old_w = xsurface->width;
  	int old_h = xsurface->height;
  
@@ -133,7 +133,7 @@ index 5a36dc21..83981a87 100644
  	xcb_configure_window(xwm->xcb_conn, xsurface->window_id, mask, values);
  
  	// If the window size did not change, then we cannot rely on
-@@ -1780,15 +1804,15 @@ void wlr_xwayland_surface_configure(struct wlr_xwayland_surface *xsurface,
+@@ -1777,15 +1801,15 @@ void wlr_xwayland_surface_configure(struct wlr_xwayland_surface *xsurface,
  	// we are supposed to send a synthetic event. See ICCCM part
  	// 4.1.5. But we ignore override-redirect windows as ICCCM does
  	// not apply to them.
@@ -154,7 +154,7 @@ index 5a36dc21..83981a87 100644
  		};
  
  		xcb_send_event(xwm->xcb_conn, 0, xsurface->window_id,
-@@ -2125,6 +2149,7 @@ struct wlr_xwm *xwm_create(struct wlr_xwayland *xwayland, int wm_fd) {
+@@ -2122,6 +2146,7 @@ struct wlr_xwm *xwm_create(struct wlr_xwayland *xwayland, int wm_fd) {
  	wl_list_init(&xwm->pending_startup_ids);
  	xwm->ping_timeout = 10000;
  


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
- Nix: rebase wlroots-hidpi patch
- Nix: disable HiDPI for default package

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Closes #1851. That patch is fine, but this one is complete.
Fixes #1842.

**NOTE**: The `default` package **no longer** has HiDPI enabled. That functionality has been moved into `hyprland-hidpi`.
Also, `hyprland-no-hidpi` is redundant now, so it was **removed**.

#### Is it ready for merging, or does it need work?
Ready.

