### PR TITLE
Update InputManager.cpp

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -303,7 +303,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
         m_pFoundSurfaceToFocus = foundSurface;
     }
 
-    if (pFoundWindow) {
+    if (pFoundWindow && g_pInputManager->currentlyDraggedWindow == nullptr) {
         // change cursor icon if hovering over border
         if (*PRESIZEONBORDER && *PRESIZECURSORICON && !pFoundWindow->m_bIsFullscreen && !pFoundWindow->hasPopupAt(mouseCoords)) {
             setCursorIconOnBorder(pFoundWindow);

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -325,7 +325,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
             if (pFoundWindow != g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow &&
                 ((pFoundWindow->m_bIsFloating && *PFLOATBEHAVIOR == 2) || (g_pCompositor->m_pLastWindow->m_bIsFloating != pFoundWindow->m_bIsFloating && *PFLOATBEHAVIOR != 0))) {
                 // enter if change floating style
-                if (*PFOLLOWMOUSE != 3 && allowKeyboardRefocus)
+                if (g_pInputManager->currentlyDraggedWindow == nullptr && (*PFOLLOWMOUSE != 3 && allowKeyboardRefocus))
                     g_pCompositor->focusWindow(pFoundWindow, foundSurface);
                 wlr_seat_pointer_notify_enter(g_pCompositor->m_sSeat.seat, foundSurface, surfaceLocal.x, surfaceLocal.y);
             } else if (*PFOLLOWMOUSE == 2 || *PFOLLOWMOUSE == 3) {
@@ -349,7 +349,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
             m_bLastFocusOnLS = false;
             return; // don't enter any new surfaces
         } else {
-            if ((*PFOLLOWMOUSE != 3 && allowKeyboardRefocus) || refocus)
+            if (g_pInputManager->currentlyDraggedWindow == nullptr && ((*PFOLLOWMOUSE != 3 && allowKeyboardRefocus) || refocus))
                 g_pCompositor->focusWindow(pFoundWindow, foundSurface);
         }
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -325,7 +325,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
             if (pFoundWindow != g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow &&
                 ((pFoundWindow->m_bIsFloating && *PFLOATBEHAVIOR == 2) || (g_pCompositor->m_pLastWindow->m_bIsFloating != pFoundWindow->m_bIsFloating && *PFLOATBEHAVIOR != 0))) {
                 // enter if change floating style
-                if (g_pInputManager->currentlyDraggedWindow == nullptr && (*PFOLLOWMOUSE != 3 && allowKeyboardRefocus))
+                if (*PFOLLOWMOUSE != 3 && allowKeyboardRefocus)
                     g_pCompositor->focusWindow(pFoundWindow, foundSurface);
                 wlr_seat_pointer_notify_enter(g_pCompositor->m_sSeat.seat, foundSurface, surfaceLocal.x, surfaceLocal.y);
             } else if (*PFOLLOWMOUSE == 2 || *PFOLLOWMOUSE == 3) {
@@ -349,7 +349,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
             m_bLastFocusOnLS = false;
             return; // don't enter any new surfaces
         } else {
-            if (g_pInputManager->currentlyDraggedWindow == nullptr && ((*PFOLLOWMOUSE != 3 && allowKeyboardRefocus) || refocus))
+            if ((*PFOLLOWMOUSE != 3 && allowKeyboardRefocus) || refocus)
                 g_pCompositor->focusWindow(pFoundWindow, foundSurface);
         }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
fixes #1711 by adding a check for dragging when changing focus from moveMouseUnified in InputManager.cpp. This means that whenever a user drags a window, they cannot change focus with their mouse, and the focus stays on its current window unless changed via keybind.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Tested a few times before and after the patch. I was unable to change focus as described in #1711 with my patch, whereas without the patch I could reproduce the issue. slightly deeper testing seems to only produce expected behaviors.

#### Is it ready for merging, or does it need work?
I think this patch is ready for merging.

