### PR TITLE
Feat: Implement tearing control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,16 @@ text-input-unstable-v1-protocol.c:
 
 text-input-unstable-v1-protocol.o: text-input-unstable-v1-protocol.h
 
+tearing-control-v1-protocol.h:
+	$(WAYLAND_SCANNER) server-header \
+		$(WAYLAND_PROTOCOLS)/staging/tearing-control/tearing-control-v1.xml $@
+
+tearing-control-v1-protocol.c:
+	$(WAYLAND_SCANNER) private-code \
+		$(WAYLAND_PROTOCOLS)/staging/tearing-control/tearing-control-v1.xml $@
+
+tearing-control-v1-protocol.o: tearing-control-v1-protocol.h
+
 legacyrenderer:
 	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DLEGACY_RENDERER:BOOL=true -S . -B ./build -G Ninja
 	cmake --build ./build --config Release --target all -j$(shell nproc)
@@ -206,7 +216,7 @@ uninstall:
 	rm -f ${PREFIX}/share/man/man1/Hyprland.1
 	rm -f ${PREFIX}/share/man/man1/hyprctl.1
 
-protocols: xdg-shell-protocol.o wlr-layer-shell-unstable-v1-protocol.o wlr-screencopy-unstable-v1-protocol.o idle-protocol.o ext-workspace-unstable-v1-protocol.o pointer-constraints-unstable-v1-protocol.o tablet-unstable-v2-protocol.o wlr-output-power-management-unstable-v1-protocol.o linux-dmabuf-unstable-v1-protocol.o hyprland-toplevel-export-v1-protocol.o wlr-foreign-toplevel-management-unstable-v1-protocol.o fractional-scale-v1-protocol.o text-input-unstable-v1-protocol.o
+protocols: xdg-shell-protocol.o wlr-layer-shell-unstable-v1-protocol.o wlr-screencopy-unstable-v1-protocol.o idle-protocol.o ext-workspace-unstable-v1-protocol.o pointer-constraints-unstable-v1-protocol.o tablet-unstable-v2-protocol.o wlr-output-power-management-unstable-v1-protocol.o linux-dmabuf-unstable-v1-protocol.o hyprland-toplevel-export-v1-protocol.o wlr-foreign-toplevel-management-unstable-v1-protocol.o fractional-scale-v1-protocol.o text-input-unstable-v1-protocol.o tearing-control-v1-protocol.o
 
 fixwlr:
 	sed -i -E 's/(soversion = 12)([^032]|$$)/soversion = 12032/g' subprojects/wlroots/meson.build

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -23,6 +23,7 @@ protocols = [
   [wl_protocol_dir, 'unstable/linux-dmabuf/linux-dmabuf-unstable-v1.xml'],
   [wl_protocol_dir, 'unstable/text-input/text-input-unstable-v1.xml'],
   [wl_protocol_dir, 'staging/fractional-scale/fractional-scale-v1.xml'],
+  [wl_protocol_dir, 'staging/tearing-control/tearing-control-v1.xml'],
   ['wlr-foreign-toplevel-management-unstable-v1.xml'],
   ['wlr-layer-shell-unstable-v1.xml'],
   ['wlr-output-power-management-unstable-v1.xml'],

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -242,6 +242,8 @@ void CCompositor::initServer() {
 
     m_sWLRSessionLockMgr = wlr_session_lock_manager_v1_create(m_sWLDisplay);
 
+    m_sWLRTearingMgr = wlr_tearing_control_manager_v1_create(m_sWLDisplay, 1);
+
     if (!m_sWLRHeadlessBackend) {
         Debug::log(CRIT, "Couldn't create the headless backend");
         throw std::runtime_error("wlr_headless_backend_create() failed!");
@@ -298,6 +300,7 @@ void CCompositor::initAllSignals() {
     addWLSignal(&m_sWLRTextInputMgr->events.text_input, &Events::listen_newTextInput, m_sWLRTextInputMgr, "TextInputMgr");
     addWLSignal(&m_sWLRActivation->events.request_activate, &Events::listen_activateXDG, m_sWLRActivation, "ActivationV1");
     addWLSignal(&m_sWLRSessionLockMgr->events.new_lock, &Events::listen_newSessionLock, m_sWLRSessionLockMgr, "SessionLockMgr");
+    addWLSignal(&m_sWLRTearingMgr->events.new_object, &Events::listen_newTearingObject, m_sWLRTearingMgr, "TearingMgr");
 
     if (m_sWRLDRMLeaseMgr)
         addWLSignal(&m_sWRLDRMLeaseMgr->events.request, &Events::listen_leaseRequest, &m_sWRLDRMLeaseMgr, "DRM");

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2308,4 +2308,12 @@ void CCompositor::performUserChecks() {
                                                         15000, ICON_ERROR);
         }
     }
+
+    for (auto& wr : g_pConfigManager->getAllWindowRules()) {
+        if (wr.szRule == "immediate" && !g_pHyprRenderer->m_bTearingSupported) {
+            g_pHyprNotificationOverlay->addNotification("You have an \"immediate\" window rule set up, but immediate presentations are not available on your configuration. Try adding env = WLR_DRM_NO_ATOMIC,1 to your config.",
+                                                        CColor(0), 15000, ICON_WARNING);
+            break;
+        }
+    }
 }

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -83,6 +83,7 @@ class CCompositor {
     wlr_linux_dmabuf_v1*                       m_sWLRLinuxDMABuf;
     wlr_backend*                               m_sWLRHeadlessBackend;
     wlr_session_lock_manager_v1*               m_sWLRSessionLockMgr;
+    wlr_tearing_control_manager_v1*            m_sWLRTearingMgr;
     // ------------------------------------------------- //
 
     std::string                               m_szWLDisplaySocket   = "";

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -119,6 +119,7 @@ struct SWindowAdditionalConfigData {
     CWindowOverridableVar<bool> windowDanceCompat    = false;
     CWindowOverridableVar<bool> noMaxSize            = false;
     CWindowOverridableVar<bool> dimAround            = false;
+    CWindowOverridableVar<bool> forceTearing         = false;
 };
 
 struct SWindowRule {
@@ -284,6 +285,10 @@ class CWindow {
         bool     head        = false;
     } m_sGroupData;
 
+    // for tearing
+    bool m_bTearingHint = false;
+    uint32_t m_iLastTearingSeq = 0;
+
     // For the list lookup
     bool operator==(const CWindow& rhs) {
         return m_uSurface.xdg == rhs.m_uSurface.xdg && m_uSurface.xwayland == rhs.m_uSurface.xwayland && m_vPosition == rhs.m_vPosition && m_vSize == rhs.m_vSize &&
@@ -322,6 +327,8 @@ class CWindow {
     void                     setGroupCurrent(CWindow* pWindow);
     void                     insertWindowToGroup(CWindow* pWindow);
     void                     updateGroupOutputs();
+
+    bool                     canBeTorn();
 
   private:
     // For hidden windows and stuff

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -780,7 +780,7 @@ bool windowRuleValid(const std::string& RULE) {
              RULE.find("maxsize") != 0 && RULE.find("pseudo") != 0 && RULE.find("monitor") != 0 && RULE.find("idleinhibit") != 0 && RULE != "nofocus" && RULE != "noblur" &&
              RULE != "noshadow" && RULE != "noborder" && RULE != "center" && RULE != "opaque" && RULE != "forceinput" && RULE != "fullscreen" && RULE != "nofullscreenrequest" &&
              RULE != "nomaxsize" && RULE != "pin" && RULE != "noanim" && RULE != "dimaround" && RULE != "windowdance" && RULE != "maximize" && RULE.find("animation") != 0 &&
-             RULE.find("rounding") != 0 && RULE.find("workspace") != 0 && RULE.find("bordercolor") != 0);
+             RULE.find("rounding") != 0 && RULE.find("workspace") != 0 && RULE.find("bordercolor") != 0 && RULE != "immediate");
 }
 
 bool layerRuleValid(const std::string& RULE) {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1946,3 +1946,11 @@ std::string CConfigManager::getDefaultWorkspaceFor(const std::string& name) {
         return "";
     return IT->second;
 }
+
+std::vector<SWindowRule> CConfigManager::getAllWindowRules() {
+    std::vector<SWindowRule> rules{m_dWindowRules.size()};
+    for (int i = 0; i < m_dWindowRules.size(); ++i)
+        rules[i] = m_dWindowRules[i];
+
+    return rules;
+}

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -156,6 +156,7 @@ class CConfigManager {
 
     std::vector<SWindowRule>                                        getMatchingRules(CWindow*);
     std::vector<SLayerRule>                                         getMatchingRules(SLayerSurface*);
+    std::vector<SWindowRule>                                        getAllWindowRules();
 
     std::unordered_map<std::string, SMonitorAdditionalReservedArea> m_mAdditionalReservedAreas;
 

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -960,6 +960,8 @@ std::string dispatchSetProp(std::string request) {
             PWINDOW->m_sSpecialRenderData.activeBorderColor.forceSetIgnoreLocked(configStringToInt(VAL), lock);
         } else if (PROP == "inactivebordercolor") {
             PWINDOW->m_sSpecialRenderData.inactiveBorderColor.forceSetIgnoreLocked(configStringToInt(VAL), lock);
+        } else if (PROP == "immediate") {
+            PWINDOW->m_sAdditionalConfigData.forceTearing.forceSetIgnoreLocked(configStringToInt(VAL), lock);
         } else {
             return "prop not found";
         }

--- a/src/events/Events.hpp
+++ b/src/events/Events.hpp
@@ -161,4 +161,7 @@ namespace Events {
 
     // Session Lock
     LISTENER(newSessionLock);
+
+    // Tearing
+    LISTENER(newTearingObject);
 };

--- a/src/events/Monitors.cpp
+++ b/src/events/Monitors.cpp
@@ -131,6 +131,9 @@ void Events::listener_monitorFrame(void* owner, void* data) {
 
     PMONITOR->lastPresentationTimer.reset();
 
+    if (PMONITOR->m_pSolitaryClient && PMONITOR->m_pSolitaryClient->canBeTorn())
+        return; // the client shall schedule repaints
+
     if (*PENABLERAT) {
         if (!PMONITOR->RATScheduled) {
             // render

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -709,8 +709,6 @@ void Events::listener_commitWindow(void* owner, void* data) {
     PWINDOW->updateSurfaceOutputs();
 
     g_pHyprRenderer->damageSurface(PWINDOW->m_pWLSurface.wlr(), PWINDOW->m_vRealPosition.goalv().x, PWINDOW->m_vRealPosition.goalv().y);
-
-    // Debug::log(LOG, "Window %x committed", PWINDOW); // SPAM!
 }
 
 void Events::listener_destroyWindow(void* owner, void* data) {

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -49,6 +49,7 @@ class CMonitor {
     wl_event_source*    renderTimer  = nullptr; // for RAT
     bool                RATScheduled = false;
     CTimer              lastPresentationTimer;
+    CTimer              lastFrameTimer;
 
     // mirroring
     CMonitor*              pMirrorOf = nullptr;
@@ -56,6 +57,8 @@ class CMonitor {
 
     // for the special workspace. 0 means not open.
     int                                                        specialWorkspaceID = 0;
+
+    CWindow*                                                   m_pSolitaryClient            = nullptr;
 
     std::array<std::vector<std::unique_ptr<SLayerSurface>>, 4> m_aLayerSurfaceLayers;
 

--- a/src/helpers/WLClasses.hpp
+++ b/src/helpers/WLClasses.hpp
@@ -375,3 +375,14 @@ struct SSwitchDevice {
         return pWlrDevice == other.pWlrDevice;
     }
 };
+
+struct STearingController {
+    wlr_tearing_control_v1* pWlrHint = nullptr;
+
+    DYNLISTENER(set);
+    DYNLISTENER(destroy);
+
+    bool operator==(const STearingController& other) {
+        return pWlrHint == other.pWlrHint;
+    }
+};

--- a/src/includes.hpp
+++ b/src/includes.hpp
@@ -104,6 +104,7 @@ extern "C" {
 #include <wlr/backend/wayland.h>
 #include <wlr/types/wlr_session_lock_v1.h>
 #include <wlr/types/wlr_single_pixel_buffer_v1.h>
+#include <wlr/types/wlr_tearing_control_v1.h>
 
 #include <drm_fourcc.h>
 

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -31,7 +31,9 @@ struct SSessionLockSurface;
 
 class CHyprRenderer {
   public:
-    void                            renderMonitor(CMonitor* pMonitor);
+    CHyprRenderer();
+
+    void                            renderMonitor(CMonitor* pMonitor, bool async = false);
     void                            renderAllClientsForMonitor(const int&, timespec*);
     void                            outputMgrApplyTest(wlr_output_configuration_v1*, bool);
     void                            arrangeLayersForMonitor(const int&);
@@ -53,13 +55,17 @@ class CHyprRenderer {
     bool                            m_bWindowRequestedCursorHide = false;
     bool                            m_bBlockSurfaceFeedback      = false;
     bool                            m_bRenderingSnapshot         = false;
+    bool                            m_bTearingSupported          = false;
     CWindow*                        m_pLastScanout               = nullptr;
     CMonitor*                       m_pMostHzMonitor             = nullptr;
 
     DAMAGETRACKINGMODES             damageTrackingModeFromStr(const std::string&);
 
     bool                            attemptDirectScanout(CMonitor*);
+    void                            updateSolitaryClient(CMonitor*);
     void                            setWindowScanoutMode(CWindow*);
+
+    std::list<STearingController> m_lTearingControllers;
 
   private:
     void arrangeLayerArray(CMonitor*, const std::vector<std::unique_ptr<SLayerSurface>>&, bool, wlr_box*);


### PR DESCRIPTION
Requires wlroots [MR 3871](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/3871)

Implements proper tearing on DRM backends

requires `WLR_DRM_NO_ATOMIC=1`

Todo:
 - [ ] Leaving fullscreen sometimes doesn't properly remove the solitary client leading to artifacts
 - [ ] Some apps (e.g. CSGO) for some reason start committing at (your hz) after you click on them, disabling the possibility of tearing? 