### PR TITLE
Fix nix build options

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -59,12 +59,16 @@ endif
 backtrace_dep = cpp_compiler.find_library('execinfo', required: false)
 systemd_dep = dependency('libsystemd', required: get_option('systemd'))
 
-if get_option('systemd').enabled() 
+if get_option('systemd').enabled()
   if systemd_dep.found()
     add_project_arguments('-DUSES_SYSTEMD', language: 'cpp')
-  else 
+  else
   	error('Cannot enable systemd in Hyprland: libsystemd was not found')
   endif
+endif
+
+if get_option('legacy_renderer').enabled()
+  add_project_arguments('-DLEGACY_RENDERER', language: 'cpp')
 endif
 
 if get_option('buildtype') == 'debug'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
 option('xwayland', type: 'feature', value: 'auto', description: 'Enable support for X11 applications')
 option('systemd', type: 'feature', value: 'auto', description: 'Enable systemd integration')
+option('legacy_renderer', type: 'feature', value: 'disabled', description: 'Enable legacy renderer')

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -89,8 +89,9 @@ in
         else "release";
 
       mesonFlags = builtins.concatLists [
-        (lib.optional (!enableXWayland) "-Dxwayland=disabled")
-        (lib.optional legacyRenderer "-DLEGACY_RENDERER:STRING=true")
+        ["-Dauto_features=disabled"]
+        (lib.optional enableXWayland "-Dxwayland=enabled")
+        (lib.optional legacyRenderer "-Dlegacy_renderer=enabled")
         (lib.optional withSystemd "-Dsystemd=enabled")
       ];
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Some of the build options in the Nix derivative currently don't work. For example, setting `legacyRenderer` to `true` does nothing (it is built with the legacy renderer off), and setting `withSystemd` to `false` does nothing (it is built with systemd enabled). I spent a long time debugging why Hyprland was not running with on Asahi Linux even with the legacy renderer on before I realized that the binary was not being built with legacy renderer.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I am not familiar with Meson and am not sure whether this is the right way to implement this. Please let me know if changes need to be made.

#### Is it ready for merging, or does it need work?

It works in my tests.