### PR TITLE
crashReporter: try `$XDG_CACHE_HOME` before `$HOME`

### DIFF
--- a/src/debug/CrashReporter.cpp
+++ b/src/debug/CrashReporter.cpp
@@ -129,16 +129,28 @@ void CrashReporter::createAndSaveCrash(int sig) {
     finalCrashReport += execAndGet(("cat \"" + Debug::logFile + "\" | tail -n 50").c_str());
 
     const auto HOME = getenv("HOME");
+    const auto CACHE_HOME = getenv("XDG_CACHE_HOME");
 
     if (!HOME)
         return;
 
-    if (!std::filesystem::exists(std::string(HOME) + "/.hyprland")) {
-        std::filesystem::create_directory(std::string(HOME) + "/.hyprland");
-        std::filesystem::permissions(std::string(HOME) + "/.hyprland", std::filesystem::perms::all, std::filesystem::perm_options::replace);
-    }
+    if (!CACHE_HOME) {
+        if (!std::filesystem::exists(std::string(HOME) + "/.hyprland")) {
+            std::filesystem::create_directory(std::string(HOME) + "/.hyprland");
+            std::filesystem::permissions(std::string(HOME) + "/.hyprland", std::filesystem::perms::all, std::filesystem::perm_options::replace);
+        }
 
-    std::ofstream ofs(std::string(HOME) + "/.hyprland/hyprlandCrashReport" + std::to_string(PID) + ".txt", std::ios::trunc);
+        std::ofstream ofs(std::string(HOME) + "/.hyprland/hyprlandCrashReport" + std::to_string(PID) + ".txt", std::ios::trunc);
+
+    } else if (CACHE_HOME) {
+        if (!std::filesystem::exists(std::string(CACHE_HOME) + "/hyprland")) {
+            std::filesystem::create_directory(std::string(CACHE_HOME) + "/hyprland");
+            std::filesystem::permissions(std::string(CACHE_HOME) + "/hyprland", std::filesystem::perms::all, std::filesystem::perm_options::replace);
+        }
+
+        std::ofstream ofs(std::string(CACHE_HOME) + "/hyprland/hyprlandCrashReport" + std::to_string(PID) + ".txt", std::ios::trunc);
+    } else
+        return;
 
     ofs << finalCrashReport;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
To follow [XDG Base Directory Specifications](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html), we attempt to place Hyprland crash reports in `$XDG_CACHE_HOME/hyprland` before using `$HOME/.hyprland`, which should be kept clean of cache/config files in favor of XDG_{CACHE,CONFIG}_HOME directories.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I have been using C++ for a maximum of ten days as of writing this PR. Code "unchecked" as in my LSPs cannot comprehend Hyprland's codebase.


#### Is it ready for merging, or does it need work?
Probably both. Could not build due to nix deciding I am not worthy. Definitely needs manual review to avoid ruining someone's day.

