### PR TITLE
Misc FreeBSD fixes

### DIFF
--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -6,11 +6,11 @@
 #include <iomanip>
 #include <sstream>
 
-#if defined(__DragonFly__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#if defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #include <sys/sysctl.h>
 #if defined(__DragonFly__)
 #include <sys/kinfo.h> // struct kinfo_proc
-#elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+#elif defined(__FreeBSD__)
 #include <sys/user.h> // struct kinfo_proc
 #endif
 
@@ -23,7 +23,7 @@
 #endif
 #if defined(__DragonFly__)
 #define KP_PPID(kp) kp.kp_ppid
-#elif defined(__FreeBSD__) || defined(__FreeBSD_kernel__)
+#elif defined(__FreeBSD__)
 #define KP_PPID(kp) kp.ki_ppid
 #else
 #define KP_PPID(kp) kp.p_ppid

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -469,11 +469,11 @@ bool CKeybindManager::handleVT(xkb_keysym_t keysym) {
 
         // vtnr is bugged for some reason.
         unsigned int ttynum = 0;
-#if defined(__linux__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#if defined(VT_GETSTATE)
         struct vt_stat st;
         if (!ioctl(0, VT_GETSTATE, &st))
             ttynum = st.v_active;
-#elif defined(__DragonFly__) || defined(__FreeBSD__)
+#elif defined(VT_GETACTIVE)
         int vt;
         if (!ioctl(0, VT_GETACTIVE, &vt))
             ttynum = vt;

--- a/src/plugins/PluginAPI.cpp
+++ b/src/plugins/PluginAPI.cpp
@@ -279,8 +279,13 @@ APICALL std::vector<SFunctionMatch> HyprlandAPI::findFunctionsByName(HANDLE hand
     const auto FPATH = std::filesystem::canonical("/proc/self/exe");
 #endif
 
+#ifdef __clang__
+    const auto SYMBOLS          = execAndGet(("llvm-nm -D -j " + FPATH.string()).c_str());
+    const auto SYMBOLSDEMANGLED = execAndGet(("llvm-nm -D -j --demangle " + FPATH.string()).c_str());
+#else
     const auto SYMBOLS          = execAndGet(("nm -D -j " + FPATH.string()).c_str());
     const auto SYMBOLSDEMANGLED = execAndGet(("nm -D -j --demangle=auto " + FPATH.string()).c_str());
+#endif
 
     auto       demangledFromID = [&](size_t id) -> std::string {
         size_t pos   = 0;

--- a/src/plugins/PluginAPI.cpp
+++ b/src/plugins/PluginAPI.cpp
@@ -7,6 +7,8 @@
 #include <sys/sysctl.h>
 #endif
 
+#include <sstream>
+
 APICALL bool HyprlandAPI::registerCallbackStatic(HANDLE handle, const std::string& event, HOOK_CALLBACK_FN* fn) {
     auto* const PLUGIN = g_pPluginSystem->getPluginByHandle(handle);
 


### PR DESCRIPTION
FreeBSD currently uses `nm` from [ElfToolChain](https://sourceforge.net/projects/elftoolchain/) but plans to [switch to LLVM](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=258872). DragonFly and NetBSD probably still use GNU binutils because it's required by GCC, anyway.