### PR TITLE
Fix crash in CConfigManager::parseKeyword

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1164,8 +1164,10 @@ std::string CConfigManager::parseKeyword(const std::string& COMMAND, const std::
         // manual crash
         if (configValues["debug:manual_crash"].intValue && !m_bManualCrashInitiated) {
             m_bManualCrashInitiated = true;
-            g_pHyprNotificationOverlay->addNotification("Manual crash has been set up. Set debug:manual_crash back to 0 in order to crash the compositor.", CColor(0), 5000,
-                                                        ICON_INFO);
+            if (g_pHyprNotificationOverlay) {
+                g_pHyprNotificationOverlay->addNotification("Manual crash has been set up. Set debug:manual_crash back to 0 in order to crash the compositor.", CColor(0), 5000,
+                                                            ICON_INFO);
+            }
         } else if (m_bManualCrashInitiated && !configValues["debug:manual_crash"].intValue) {
             // cowabunga it is
             g_pHyprRenderer->initiateManualCrash();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
If debug:manual_crash is set on startup, parseKeyword tries to call g_pHyprNotificationOverlay->addNotification, but g_pHyprNotificationOverlay isn't initialized yet (is nullptr)

This commit adds a nullptr check for that.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This fixes the symptom, not the cause. With this fix the notification won't ever be displayed.

#### Is it ready for merging, or does it need work?
Ready, as it is a simple fix

