### PR TITLE
Added some workspace-specific rules

### DIFF
--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -10,8 +10,7 @@
 #include "helpers/Vector2D.hpp"
 #include "helpers/WLSurface.hpp"
 
-enum eIdleInhibitMode
-{
+enum eIdleInhibitMode {
     IDLEINHIBIT_NONE = 0,
     IDLEINHIBIT_ALWAYS,
     IDLEINHIBIT_FULLSCREEN,
@@ -101,9 +100,10 @@ struct SWindowSpecialRenderData {
     CWindowOverridableVar<int64_t> inactiveBorderColor = -1; // -1 means unset
 
     // set by the layout
-    bool rounding = true;
-    bool border   = true;
-    bool decorate = true;
+    int  borderSize = -1;
+    bool rounding   = true;
+    bool border     = true;
+    bool decorate   = true;
 };
 
 struct SWindowAdditionalConfigData {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1035,10 +1035,7 @@ void CConfigManager::handleWorkspaceRules(const std::string& command, const std:
         rules                  = value.substr(WORKSPACE_DELIM + 1);
     }
 
-    size_t      pos = 0;
-    std::string rule;
-    while ((pos = rules.find(',')) != std::string::npos) {
-        rule         = rules.substr(0, pos);
+    auto assignRule = [&](std::string rule) {
         size_t delim = std::string::npos;
         Debug::log(INFO, "found workspacerule: %s", rule.c_str());
         if ((delim = rule.find("gapsin:")) != std::string::npos)
@@ -1055,8 +1052,16 @@ void CConfigManager::handleWorkspaceRules(const std::string& command, const std:
             wsRule.decorate = configStringToInt(rule.substr(delim + 9));
         else if ((delim = rule.find("monitor:")) != std::string::npos)
             wsRule.monitor = rule.substr(delim + 8);
+    };
+
+    size_t      pos = 0;
+    std::string rule;
+    while ((pos = rules.find(',')) != std::string::npos) {
+        rule = rules.substr(0, pos);
+        assignRule(rule);
         rules.erase(0, pos + 1);
     }
+    assignRule(rules); // match remaining rule
 
     wsRule.workspaceId    = id;
     wsRule.workspaceName  = name;

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -10,6 +10,7 @@
 #include <deque>
 #include <algorithm>
 #include <regex>
+#include <optional>
 #include "../Window.hpp"
 #include "../helpers/WLClasses.hpp"
 
@@ -46,16 +47,16 @@ struct SMonitorRule {
 };
 
 struct SWorkspaceRule {
-    std::string monitor         = "";
-    std::string workspaceString = "";
-    std::string workspaceName   = "";
-    int         workspaceId     = -1338;
-    int64_t     gapsIn          = 5;
-    int64_t     gapsOut         = 20;
-    int64_t     borderSize      = 1;
-    int         border          = 1;
-    int         rounding        = 1;
-    int         decorate        = 1;
+    std::string            monitor         = "";
+    std::string            workspaceString = "";
+    std::string            workspaceName   = "";
+    int                    workspaceId     = -1338;
+    std::optional<int64_t> gapsIn          = 5;
+    std::optional<int64_t> gapsOut         = 20;
+    std::optional<int64_t> borderSize      = 1;
+    std::optional<int>     border          = 1;
+    std::optional<int>     rounding        = 1;
+    std::optional<int>     decorate        = 1;
 };
 
 struct SMonitorAdditionalReservedArea {

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -45,6 +45,19 @@ struct SMonitorRule {
     bool                enable10bit = false;
 };
 
+struct SWorkspaceRule {
+    std::string monitor         = "";
+    std::string workspaceString = "";
+    std::string workspaceName   = "";
+    int         workspaceId     = -1338;
+    int64_t     gapsIn          = 5;
+    int64_t     gapsOut         = 20;
+    int64_t     borderSize      = 1;
+    int         border          = 1;
+    int         rounding        = 1;
+    int         decorate        = 1;
+};
+
 struct SMonitorAdditionalReservedArea {
     int top    = 0;
     int bottom = 0;
@@ -149,6 +162,7 @@ class CConfigManager {
     SConfigValue*                                                   getConfigValuePtrSafe(const std::string&);
 
     SMonitorRule                                                    getMonitorRuleFor(const std::string&, const std::string& displayName = "");
+    SWorkspaceRule                                                  getWorkspaceRuleFor(CWorkspace*);
     std::string                                                     getDefaultWorkspaceFor(const std::string&);
 
     CMonitor*                                                       getBoundMonitorForWS(const std::string&);
@@ -208,7 +222,7 @@ class CConfigManager {
     bool                                                                                       isFirstLaunch = true; // For exec-once
 
     std::deque<SMonitorRule>                                                                   m_dMonitorRules;
-    std::unordered_map<std::string, std::string>                                               m_mDefaultWorkspaces;
+    std::unordered_map<int, SWorkspaceRule>                                                    m_mWorkspaceRules;
     std::deque<SWindowRule>                                                                    m_dWindowRules;
     std::deque<SLayerRule>                                                                     m_dLayerRules;
     std::deque<std::string>                                                                    m_dBlurLSNamespaces;
@@ -242,7 +256,7 @@ class CConfigManager {
     void         handleWindowRule(const std::string&, const std::string&);
     void         handleLayerRule(const std::string&, const std::string&);
     void         handleWindowRuleV2(const std::string&, const std::string&);
-    void         handleDefaultWorkspace(const std::string&, const std::string&);
+    void         handleWorkspaceRules(const std::string&, const std::string&);
     void         handleBezier(const std::string&, const std::string&);
     void         handleAnimation(const std::string&, const std::string&);
     void         handleSource(const std::string&, const std::string&);

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -51,12 +51,12 @@ struct SWorkspaceRule {
     std::string            workspaceString = "";
     std::string            workspaceName   = "";
     int                    workspaceId     = -1;
-    std::optional<int64_t> gapsIn          = 5;
-    std::optional<int64_t> gapsOut         = 20;
-    std::optional<int64_t> borderSize      = 1;
-    std::optional<int>     border          = 1;
-    std::optional<int>     rounding        = 1;
-    std::optional<int>     decorate        = 1;
+    std::optional<int64_t> gapsIn;
+    std::optional<int64_t> gapsOut;
+    std::optional<int64_t> borderSize;
+    std::optional<int>     border;
+    std::optional<int>     rounding;
+    std::optional<int>     decorate;
 };
 
 struct SMonitorAdditionalReservedArea {

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -50,7 +50,7 @@ struct SWorkspaceRule {
     std::string            monitor         = "";
     std::string            workspaceString = "";
     std::string            workspaceName   = "";
-    int                    workspaceId     = -1338;
+    int                    workspaceId     = -1;
     std::optional<int64_t> gapsIn          = 5;
     std::optional<int64_t> gapsOut         = 20;
     std::optional<int64_t> borderSize      = 1;

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -151,9 +151,10 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
         return;
     }
 
-    PWINDOW->m_sSpecialRenderData.rounding = WORKSPACE_RULE.rounding.value_or(true);
-    PWINDOW->m_sSpecialRenderData.decorate = WORKSPACE_RULE.decorate.value_or(true);
-    PWINDOW->m_sSpecialRenderData.border   = WORKSPACE_RULE.border.value_or(true);
+    PWINDOW->m_sSpecialRenderData.rounding   = WORKSPACE_RULE.rounding.value_or(true);
+    PWINDOW->m_sSpecialRenderData.decorate   = WORKSPACE_RULE.decorate.value_or(true);
+    PWINDOW->m_sSpecialRenderData.border     = WORKSPACE_RULE.border.value_or(true);
+    PWINDOW->m_sSpecialRenderData.borderSize = borderSize;
 
     const auto OFFSETTOPLEFT = Vector2D(DISPLAYLEFT ? gapsOut : gapsIn, DISPLAYTOP ? gapsOut : gapsIn);
 

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -111,15 +111,15 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
     const auto PWINDOW = pNode->pWindow;
     // get specific gaps and rules for this workspace,
     // if user specified them in config
-    const auto WORKSPACE_RULE = g_pConfigManager->getWorkspaceRuleFor(g_pCompositor->getWorkspaceByID(PWINDOW->m_iWorkspaceID));
+    const auto         WORKSPACE_RULE = g_pConfigManager->getWorkspaceRuleFor(g_pCompositor->getWorkspaceByID(PWINDOW->m_iWorkspaceID));
 
-    auto       gapsIn     = WORKSPACE_RULE.gapsIn.value_or(g_pConfigManager->getConfigValuePtr("general:gaps_in")->intValue);
-    auto       gapsOut    = WORKSPACE_RULE.gapsOut.value_or(g_pConfigManager->getConfigValuePtr("general:gaps_out")->intValue);
-    auto       borderSize = WORKSPACE_RULE.borderSize.value_or(g_pConfigManager->getConfigValuePtr("general:border_size")->intValue);
+    static auto* const PGAPSIN     = &g_pConfigManager->getConfigValuePtr("general:gaps_in")->intValue;
+    static auto* const PGAPSOUT    = &g_pConfigManager->getConfigValuePtr("general:gaps_out")->intValue;
+    static auto* const PBORDERSIZE = &g_pConfigManager->getConfigValuePtr("general:border_size")->intValue;
 
-    const auto PGAPSIN     = &gapsIn;
-    const auto PGAPSOUT    = &gapsOut;
-    const auto PBORDERSIZE = &borderSize;
+    auto               gapsIn     = WORKSPACE_RULE.gapsIn.value_or(*PGAPSIN);
+    auto               gapsOut    = WORKSPACE_RULE.gapsOut.value_or(*PGAPSOUT);
+    auto               borderSize = WORKSPACE_RULE.borderSize.value_or(*PBORDERSIZE);
 
     if (!g_pCompositor->windowExists(PWINDOW) || !PWINDOW->m_bIsMapped) {
         Debug::log(ERR, "Node %lx holding invalid window %lx!!", pNode, PWINDOW);
@@ -132,15 +132,15 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
 
     static auto* const PNOGAPSWHENONLY = &g_pConfigManager->getConfigValuePtr("dwindle:no_gaps_when_only")->intValue;
 
-    auto               calcPos  = PWINDOW->m_vPosition + Vector2D(*PBORDERSIZE, *PBORDERSIZE);
-    auto               calcSize = PWINDOW->m_vSize - Vector2D(2 * *PBORDERSIZE, 2 * *PBORDERSIZE);
+    auto               calcPos  = PWINDOW->m_vPosition + Vector2D(borderSize, borderSize);
+    auto               calcSize = PWINDOW->m_vSize - Vector2D(2 * borderSize, 2 * borderSize);
 
     const auto         NODESONWORKSPACE = getNodesOnWorkspace(PWINDOW->m_iWorkspaceID);
 
     if (WORKSPACE_RULE.workspaceString.empty() && *PNOGAPSWHENONLY && !g_pCompositor->isWorkspaceSpecial(PWINDOW->m_iWorkspaceID) &&
         (NODESONWORKSPACE == 1 || (PWINDOW->m_bIsFullscreen && g_pCompositor->getWorkspaceByID(PWINDOW->m_iWorkspaceID)->m_efFullscreenMode == FULLSCREEN_MAXIMIZED))) {
-        PWINDOW->m_vRealPosition = calcPos - Vector2D(*PBORDERSIZE, *PBORDERSIZE);
-        PWINDOW->m_vRealSize     = calcSize + Vector2D(2 * *PBORDERSIZE, 2 * *PBORDERSIZE);
+        PWINDOW->m_vRealPosition = calcPos - Vector2D(borderSize, borderSize);
+        PWINDOW->m_vRealSize     = calcSize + Vector2D(2 * borderSize, 2 * borderSize);
 
         PWINDOW->updateWindowDecos();
 
@@ -155,9 +155,9 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
     PWINDOW->m_sSpecialRenderData.decorate = WORKSPACE_RULE.decorate.value_or(true);
     PWINDOW->m_sSpecialRenderData.border   = WORKSPACE_RULE.border.value_or(true);
 
-    const auto OFFSETTOPLEFT = Vector2D(DISPLAYLEFT ? *PGAPSOUT : *PGAPSIN, DISPLAYTOP ? *PGAPSOUT : *PGAPSIN);
+    const auto OFFSETTOPLEFT = Vector2D(DISPLAYLEFT ? gapsOut : gapsIn, DISPLAYTOP ? gapsOut : gapsIn);
 
-    const auto OFFSETBOTTOMRIGHT = Vector2D(DISPLAYRIGHT ? *PGAPSOUT : *PGAPSIN, DISPLAYBOTTOM ? *PGAPSOUT : *PGAPSIN);
+    const auto OFFSETBOTTOMRIGHT = Vector2D(DISPLAYRIGHT ? gapsOut : gapsIn, DISPLAYBOTTOM ? gapsOut : gapsIn);
 
     calcPos  = calcPos + OFFSETTOPLEFT;
     calcSize = calcSize - OFFSETTOPLEFT - OFFSETBOTTOMRIGHT;

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -109,23 +109,17 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
     const bool DISPLAYBOTTOM = STICKS(pNode->position.y + pNode->size.y, PMONITOR->vecPosition.y + PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y);
 
     const auto PWINDOW = pNode->pWindow;
-    // set specific gaps and rules for this workspace,
+    // get specific gaps and rules for this workspace,
     // if user specified them in config
-    const auto     WORKSPACE_RULE   = g_pConfigManager->getWorkspaceRuleFor(g_pCompositor->getWorkspaceByID(PWINDOW->m_iWorkspaceID));
-    bool           hasWorkspaceRule = !WORKSPACE_RULE.workspaceString.empty();
+    const auto WORKSPACE_RULE = g_pConfigManager->getWorkspaceRuleFor(g_pCompositor->getWorkspaceByID(PWINDOW->m_iWorkspaceID));
 
-    const int64_t* PGAPSIN;
-    const int64_t* PGAPSOUT;
-    const int64_t* PBORDERSIZE;
-    if (hasWorkspaceRule) {
-        PGAPSIN     = &WORKSPACE_RULE.gapsIn;
-        PGAPSOUT    = &WORKSPACE_RULE.gapsOut;
-        PBORDERSIZE = &WORKSPACE_RULE.borderSize;
-    } else {
-        PGAPSIN     = &g_pConfigManager->getConfigValuePtr("general:gaps_in")->intValue;
-        PGAPSOUT    = &g_pConfigManager->getConfigValuePtr("general:gaps_out")->intValue;
-        PBORDERSIZE = &g_pConfigManager->getConfigValuePtr("general:border_size")->intValue;
-    }
+    auto       gapsIn     = WORKSPACE_RULE.gapsIn.value_or(g_pConfigManager->getConfigValuePtr("general:gaps_in")->intValue);
+    auto       gapsOut    = WORKSPACE_RULE.gapsOut.value_or(g_pConfigManager->getConfigValuePtr("general:gaps_out")->intValue);
+    auto       borderSize = WORKSPACE_RULE.borderSize.value_or(g_pConfigManager->getConfigValuePtr("general:border_size")->intValue);
+
+    const auto PGAPSIN     = &gapsIn;
+    const auto PGAPSOUT    = &gapsOut;
+    const auto PBORDERSIZE = &borderSize;
 
     if (!g_pCompositor->windowExists(PWINDOW) || !PWINDOW->m_bIsMapped) {
         Debug::log(ERR, "Node %lx holding invalid window %lx!!", pNode, PWINDOW);
@@ -143,7 +137,7 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
 
     const auto         NODESONWORKSPACE = getNodesOnWorkspace(PWINDOW->m_iWorkspaceID);
 
-    if (!hasWorkspaceRule && *PNOGAPSWHENONLY && !g_pCompositor->isWorkspaceSpecial(PWINDOW->m_iWorkspaceID) &&
+    if (WORKSPACE_RULE.workspaceString.empty() && *PNOGAPSWHENONLY && !g_pCompositor->isWorkspaceSpecial(PWINDOW->m_iWorkspaceID) &&
         (NODESONWORKSPACE == 1 || (PWINDOW->m_bIsFullscreen && g_pCompositor->getWorkspaceByID(PWINDOW->m_iWorkspaceID)->m_efFullscreenMode == FULLSCREEN_MAXIMIZED))) {
         PWINDOW->m_vRealPosition = calcPos - Vector2D(*PBORDERSIZE, *PBORDERSIZE);
         PWINDOW->m_vRealSize     = calcSize + Vector2D(2 * *PBORDERSIZE, 2 * *PBORDERSIZE);
@@ -157,15 +151,9 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
         return;
     }
 
-    if (hasWorkspaceRule) {
-        PWINDOW->m_sSpecialRenderData.rounding = WORKSPACE_RULE.rounding == 1;
-        PWINDOW->m_sSpecialRenderData.decorate = WORKSPACE_RULE.decorate == 1;
-        PWINDOW->m_sSpecialRenderData.border   = WORKSPACE_RULE.border == 1;
-    } else {
-        PWINDOW->m_sSpecialRenderData.border   = true;
-        PWINDOW->m_sSpecialRenderData.rounding = true;
-        PWINDOW->m_sSpecialRenderData.decorate = true;
-    }
+    PWINDOW->m_sSpecialRenderData.rounding = WORKSPACE_RULE.rounding.value_or(true);
+    PWINDOW->m_sSpecialRenderData.decorate = WORKSPACE_RULE.decorate.value_or(true);
+    PWINDOW->m_sSpecialRenderData.border   = WORKSPACE_RULE.border.value_or(true);
 
     const auto OFFSETTOPLEFT = Vector2D(DISPLAYLEFT ? *PGAPSOUT : *PGAPSIN, DISPLAYTOP ? *PGAPSOUT : *PGAPSIN);
 

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -111,15 +111,15 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
     const auto PWINDOW = pNode->pWindow;
     // get specific gaps and rules for this workspace,
     // if user specified them in config
-    const auto         WORKSPACE_RULE = g_pConfigManager->getWorkspaceRuleFor(g_pCompositor->getWorkspaceByID(PWINDOW->m_iWorkspaceID));
+    const auto         WORKSPACERULE = g_pConfigManager->getWorkspaceRuleFor(g_pCompositor->getWorkspaceByID(PWINDOW->m_iWorkspaceID));
 
     static auto* const PGAPSIN     = &g_pConfigManager->getConfigValuePtr("general:gaps_in")->intValue;
     static auto* const PGAPSOUT    = &g_pConfigManager->getConfigValuePtr("general:gaps_out")->intValue;
     static auto* const PBORDERSIZE = &g_pConfigManager->getConfigValuePtr("general:border_size")->intValue;
 
-    auto               gapsIn     = WORKSPACE_RULE.gapsIn.value_or(*PGAPSIN);
-    auto               gapsOut    = WORKSPACE_RULE.gapsOut.value_or(*PGAPSOUT);
-    auto               borderSize = WORKSPACE_RULE.borderSize.value_or(*PBORDERSIZE);
+    auto               gapsIn     = WORKSPACERULE.gapsIn.value_or(*PGAPSIN);
+    auto               gapsOut    = WORKSPACERULE.gapsOut.value_or(*PGAPSOUT);
+    auto               borderSize = WORKSPACERULE.borderSize.value_or(*PBORDERSIZE);
 
     if (!g_pCompositor->windowExists(PWINDOW) || !PWINDOW->m_bIsMapped) {
         Debug::log(ERR, "Node %lx holding invalid window %lx!!", pNode, PWINDOW);
@@ -137,7 +137,7 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
 
     const auto         NODESONWORKSPACE = getNodesOnWorkspace(PWINDOW->m_iWorkspaceID);
 
-    if (WORKSPACE_RULE.workspaceString.empty() && *PNOGAPSWHENONLY && !g_pCompositor->isWorkspaceSpecial(PWINDOW->m_iWorkspaceID) &&
+    if (WORKSPACERULE.workspaceString.empty() && *PNOGAPSWHENONLY && !g_pCompositor->isWorkspaceSpecial(PWINDOW->m_iWorkspaceID) &&
         (NODESONWORKSPACE == 1 || (PWINDOW->m_bIsFullscreen && g_pCompositor->getWorkspaceByID(PWINDOW->m_iWorkspaceID)->m_efFullscreenMode == FULLSCREEN_MAXIMIZED))) {
         PWINDOW->m_vRealPosition = calcPos - Vector2D(borderSize, borderSize);
         PWINDOW->m_vRealSize     = calcSize + Vector2D(2 * borderSize, 2 * borderSize);
@@ -151,10 +151,10 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
         return;
     }
 
-    PWINDOW->m_sSpecialRenderData.rounding   = WORKSPACE_RULE.rounding.value_or(true);
-    PWINDOW->m_sSpecialRenderData.decorate   = WORKSPACE_RULE.decorate.value_or(true);
-    PWINDOW->m_sSpecialRenderData.border     = WORKSPACE_RULE.border.value_or(true);
-    PWINDOW->m_sSpecialRenderData.borderSize = borderSize;
+    PWINDOW->m_sSpecialRenderData.rounding   = WORKSPACERULE.rounding.value_or(true);
+    PWINDOW->m_sSpecialRenderData.decorate   = WORKSPACERULE.decorate.value_or(true);
+    PWINDOW->m_sSpecialRenderData.border     = WORKSPACERULE.border.value_or(true);
+    PWINDOW->m_sSpecialRenderData.borderSize = WORKSPACERULE.borderSize.value_or(-1);
 
     const auto OFFSETTOPLEFT = Vector2D(DISPLAYLEFT ? gapsOut : gapsIn, DISPLAYTOP ? gapsOut : gapsIn);
 

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -270,7 +270,7 @@ void CHyprMasterLayout::calculateWorkspace(const int& ws) {
     if ((WINDOWS < 2) && !centerMasterWindow) {
         PMASTERNODE->position = PMONITOR->vecReservedTopLeft + PMONITOR->vecPosition;
         PMASTERNODE->size     = Vector2D(PMONITOR->vecSize.x - PMONITOR->vecReservedTopLeft.x - PMONITOR->vecReservedBottomRight.x,
-                                         PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PMONITOR->vecReservedTopLeft.y);
+                                     PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PMONITOR->vecReservedTopLeft.y);
         applyNodeDataToWindow(PMASTERNODE);
         return;
     } else if (orientation == ORIENTATION_LEFT || orientation == ORIENTATION_RIGHT || (orientation == ORIENTATION_CENTER && STACKWINDOWS <= 1)) {
@@ -481,15 +481,15 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
     const auto PWINDOW = pNode->pWindow;
     // get specific gaps and rules for this workspace,
     // if user specified them in config
-    const auto         WORKSPACE_RULE = g_pConfigManager->getWorkspaceRuleFor(g_pCompositor->getWorkspaceByID(PWINDOW->m_iWorkspaceID));
+    const auto         WORKSPACERULE = g_pConfigManager->getWorkspaceRuleFor(g_pCompositor->getWorkspaceByID(PWINDOW->m_iWorkspaceID));
 
     static auto* const PGAPSIN     = &g_pConfigManager->getConfigValuePtr("general:gaps_in")->intValue;
     static auto* const PGAPSOUT    = &g_pConfigManager->getConfigValuePtr("general:gaps_out")->intValue;
     static auto* const PBORDERSIZE = &g_pConfigManager->getConfigValuePtr("general:border_size")->intValue;
 
-    auto               gapsIn     = WORKSPACE_RULE.gapsIn.value_or(*PGAPSIN);
-    auto               gapsOut    = WORKSPACE_RULE.gapsOut.value_or(*PGAPSOUT);
-    auto               borderSize = WORKSPACE_RULE.borderSize.value_or(*PBORDERSIZE);
+    auto               gapsIn     = WORKSPACERULE.gapsIn.value_or(*PGAPSIN);
+    auto               gapsOut    = WORKSPACERULE.gapsOut.value_or(*PGAPSOUT);
+    auto               borderSize = WORKSPACERULE.borderSize.value_or(*PBORDERSIZE);
 
     if (!g_pCompositor->windowValidMapped(PWINDOW)) {
         Debug::log(ERR, "Node %lx holding invalid window %lx!!", pNode, PWINDOW);
@@ -504,7 +504,7 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
     auto calcPos  = PWINDOW->m_vPosition + Vector2D(borderSize, borderSize);
     auto calcSize = PWINDOW->m_vSize - Vector2D(2 * borderSize, 2 * borderSize);
 
-    if (WORKSPACE_RULE.workspaceString.empty() && *PNOGAPSWHENONLY && !g_pCompositor->isWorkspaceSpecial(PWINDOW->m_iWorkspaceID) &&
+    if (WORKSPACERULE.workspaceString.empty() && *PNOGAPSWHENONLY && !g_pCompositor->isWorkspaceSpecial(PWINDOW->m_iWorkspaceID) &&
         (getNodesOnWorkspace(PWINDOW->m_iWorkspaceID) == 1 ||
          (PWINDOW->m_bIsFullscreen && g_pCompositor->getWorkspaceByID(PWINDOW->m_iWorkspaceID)->m_efFullscreenMode == FULLSCREEN_MAXIMIZED))) {
         PWINDOW->m_vRealPosition = calcPos - Vector2D(borderSize, borderSize);
@@ -519,10 +519,10 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
         return;
     }
 
-    PWINDOW->m_sSpecialRenderData.rounding   = WORKSPACE_RULE.rounding.value_or(true);
-    PWINDOW->m_sSpecialRenderData.decorate   = WORKSPACE_RULE.decorate.value_or(true);
-    PWINDOW->m_sSpecialRenderData.border     = WORKSPACE_RULE.border.value_or(true);
-    PWINDOW->m_sSpecialRenderData.borderSize = borderSize;
+    PWINDOW->m_sSpecialRenderData.rounding   = WORKSPACERULE.rounding.value_or(true);
+    PWINDOW->m_sSpecialRenderData.decorate   = WORKSPACERULE.decorate.value_or(true);
+    PWINDOW->m_sSpecialRenderData.border     = WORKSPACERULE.border.value_or(true);
+    PWINDOW->m_sSpecialRenderData.borderSize = WORKSPACERULE.borderSize.value_or(-1);
 
     const auto OFFSETTOPLEFT = Vector2D(DISPLAYLEFT ? gapsOut : gapsIn, DISPLAYTOP ? gapsOut : gapsIn);
 

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -481,15 +481,15 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
     const auto PWINDOW = pNode->pWindow;
     // get specific gaps and rules for this workspace,
     // if user specified them in config
-    const auto WORKSPACE_RULE = g_pConfigManager->getWorkspaceRuleFor(g_pCompositor->getWorkspaceByID(PWINDOW->m_iWorkspaceID));
+    const auto         WORKSPACE_RULE = g_pConfigManager->getWorkspaceRuleFor(g_pCompositor->getWorkspaceByID(PWINDOW->m_iWorkspaceID));
 
-    auto       gapsIn     = WORKSPACE_RULE.gapsIn.value_or(g_pConfigManager->getConfigValuePtr("general:gaps_in")->intValue);
-    auto       gapsOut    = WORKSPACE_RULE.gapsOut.value_or(g_pConfigManager->getConfigValuePtr("general:gaps_out")->intValue);
-    auto       borderSize = WORKSPACE_RULE.borderSize.value_or(g_pConfigManager->getConfigValuePtr("general:border_size")->intValue);
+    static auto* const PGAPSIN     = &g_pConfigManager->getConfigValuePtr("general:gaps_in")->intValue;
+    static auto* const PGAPSOUT    = &g_pConfigManager->getConfigValuePtr("general:gaps_out")->intValue;
+    static auto* const PBORDERSIZE = &g_pConfigManager->getConfigValuePtr("general:border_size")->intValue;
 
-    const auto PGAPSIN     = &gapsIn;
-    const auto PGAPSOUT    = &gapsOut;
-    const auto PBORDERSIZE = &borderSize;
+    auto               gapsIn     = WORKSPACE_RULE.gapsIn.value_or(*PGAPSIN);
+    auto               gapsOut    = WORKSPACE_RULE.gapsOut.value_or(*PGAPSOUT);
+    auto               borderSize = WORKSPACE_RULE.borderSize.value_or(*PBORDERSIZE);
 
     if (!g_pCompositor->windowValidMapped(PWINDOW)) {
         Debug::log(ERR, "Node %lx holding invalid window %lx!!", pNode, PWINDOW);
@@ -501,14 +501,14 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
     PWINDOW->m_vSize     = pNode->size;
     PWINDOW->m_vPosition = pNode->position;
 
-    auto calcPos  = PWINDOW->m_vPosition + Vector2D(*PBORDERSIZE, *PBORDERSIZE);
-    auto calcSize = PWINDOW->m_vSize - Vector2D(2 * *PBORDERSIZE, 2 * *PBORDERSIZE);
+    auto calcPos  = PWINDOW->m_vPosition + Vector2D(borderSize, borderSize);
+    auto calcSize = PWINDOW->m_vSize - Vector2D(2 * borderSize, 2 * borderSize);
 
     if (WORKSPACE_RULE.workspaceString.empty() && *PNOGAPSWHENONLY && !g_pCompositor->isWorkspaceSpecial(PWINDOW->m_iWorkspaceID) &&
         (getNodesOnWorkspace(PWINDOW->m_iWorkspaceID) == 1 ||
          (PWINDOW->m_bIsFullscreen && g_pCompositor->getWorkspaceByID(PWINDOW->m_iWorkspaceID)->m_efFullscreenMode == FULLSCREEN_MAXIMIZED))) {
-        PWINDOW->m_vRealPosition = calcPos - Vector2D(*PBORDERSIZE, *PBORDERSIZE);
-        PWINDOW->m_vRealSize     = calcSize + Vector2D(2 * *PBORDERSIZE, 2 * *PBORDERSIZE);
+        PWINDOW->m_vRealPosition = calcPos - Vector2D(borderSize, borderSize);
+        PWINDOW->m_vRealSize     = calcSize + Vector2D(2 * borderSize, 2 * borderSize);
 
         PWINDOW->updateWindowDecos();
 
@@ -523,9 +523,9 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
     PWINDOW->m_sSpecialRenderData.decorate = WORKSPACE_RULE.decorate.value_or(true);
     PWINDOW->m_sSpecialRenderData.border   = WORKSPACE_RULE.border.value_or(true);
 
-    const auto OFFSETTOPLEFT = Vector2D(DISPLAYLEFT ? *PGAPSOUT : *PGAPSIN, DISPLAYTOP ? *PGAPSOUT : *PGAPSIN);
+    const auto OFFSETTOPLEFT = Vector2D(DISPLAYLEFT ? gapsOut : gapsIn, DISPLAYTOP ? gapsOut : gapsIn);
 
-    const auto OFFSETBOTTOMRIGHT = Vector2D(DISPLAYRIGHT ? *PGAPSOUT : *PGAPSIN, DISPLAYBOTTOM ? *PGAPSOUT : *PGAPSIN);
+    const auto OFFSETBOTTOMRIGHT = Vector2D(DISPLAYRIGHT ? gapsOut : gapsIn, DISPLAYBOTTOM ? gapsOut : gapsIn);
 
     calcPos  = calcPos + OFFSETTOPLEFT;
     calcSize = calcSize - OFFSETTOPLEFT - OFFSETBOTTOMRIGHT;

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -519,9 +519,10 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
         return;
     }
 
-    PWINDOW->m_sSpecialRenderData.rounding = WORKSPACE_RULE.rounding.value_or(true);
-    PWINDOW->m_sSpecialRenderData.decorate = WORKSPACE_RULE.decorate.value_or(true);
-    PWINDOW->m_sSpecialRenderData.border   = WORKSPACE_RULE.border.value_or(true);
+    PWINDOW->m_sSpecialRenderData.rounding   = WORKSPACE_RULE.rounding.value_or(true);
+    PWINDOW->m_sSpecialRenderData.decorate   = WORKSPACE_RULE.decorate.value_or(true);
+    PWINDOW->m_sSpecialRenderData.border     = WORKSPACE_RULE.border.value_or(true);
+    PWINDOW->m_sSpecialRenderData.borderSize = borderSize;
 
     const auto OFFSETTOPLEFT = Vector2D(DISPLAYLEFT ? gapsOut : gapsIn, DISPLAYTOP ? gapsOut : gapsIn);
 

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1058,11 +1058,7 @@ void CHyprOpenGLImpl::renderBorder(wlr_box* box, const CGradientValueData& grad,
     static auto* const PBORDERSIZE  = &g_pConfigManager->getConfigValuePtr("general:border_size")->intValue;
     static auto* const PMULTISAMPLE = &g_pConfigManager->getConfigValuePtr("decoration:multisample_edges")->intValue;
 
-    if (borderSize < 0) {
-        borderSize = *PBORDERSIZE;
-    }
-
-    wlr_box newBox = *box;
+    wlr_box            newBox = *box;
     scaleBox(&newBox, m_RenderData.renderModif.scale);
     newBox.x += m_RenderData.renderModif.translate.x;
     newBox.y += m_RenderData.renderModif.translate.y;

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -816,7 +816,7 @@ CFramebuffer* CHyprOpenGLImpl::blurMainFramebufferWithDamage(float a, wlr_box* p
 }
 
 void CHyprOpenGLImpl::markBlurDirtyForMonitor(CMonitor* pMonitor) {
-    const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(pMonitor->activeWorkspace);
+    const auto PWORKSPACE  = g_pCompositor->getWorkspaceByID(pMonitor->activeWorkspace);
     const auto PFULLWINDOW = g_pCompositor->getFullscreenWindowOnWorkspace(pMonitor->activeWorkspace);
 
     if (PWORKSPACE->m_bHasFullscreenWindow && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL && PFULLWINDOW && !PFULLWINDOW->m_vRealSize.isBeingAnimated() &&
@@ -1048,7 +1048,7 @@ void pushVert2D(float x, float y, float* arr, int& counter, wlr_box* box) {
     counter++;
 }
 
-void CHyprOpenGLImpl::renderBorder(wlr_box* box, const CGradientValueData& grad, int round, float a, int borderSize) {
+void CHyprOpenGLImpl::renderBorder(wlr_box* box, const CGradientValueData& grad, int round, int borderSize, float a) {
     RASSERT((box->width > 0 && box->height > 0), "Tried to render rect with width/height < 0!");
     RASSERT(m_RenderData.pMonitor, "Tried to render rect without begin()!");
 

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1048,7 +1048,7 @@ void pushVert2D(float x, float y, float* arr, int& counter, wlr_box* box) {
     counter++;
 }
 
-void CHyprOpenGLImpl::renderBorder(wlr_box* box, const CGradientValueData& grad, int round, float a) {
+void CHyprOpenGLImpl::renderBorder(wlr_box* box, const CGradientValueData& grad, int round, float a, int borderSize) {
     RASSERT((box->width > 0 && box->height > 0), "Tried to render rect with width/height < 0!");
     RASSERT(m_RenderData.pMonitor, "Tried to render rect without begin()!");
 
@@ -1058,17 +1058,21 @@ void CHyprOpenGLImpl::renderBorder(wlr_box* box, const CGradientValueData& grad,
     static auto* const PBORDERSIZE  = &g_pConfigManager->getConfigValuePtr("general:border_size")->intValue;
     static auto* const PMULTISAMPLE = &g_pConfigManager->getConfigValuePtr("decoration:multisample_edges")->intValue;
 
-    wlr_box            newBox = *box;
+    if (borderSize < 0) {
+        borderSize = *PBORDERSIZE;
+    }
+
+    wlr_box newBox = *box;
     scaleBox(&newBox, m_RenderData.renderModif.scale);
     newBox.x += m_RenderData.renderModif.translate.x;
     newBox.y += m_RenderData.renderModif.translate.y;
 
     box = &newBox;
 
-    if (*PBORDERSIZE < 1)
+    if (borderSize < 1)
         return;
 
-    int scaledBorderSize = *PBORDERSIZE * m_RenderData.pMonitor->scale * m_RenderData.renderModif.scale;
+    int scaledBorderSize = borderSize * m_RenderData.pMonitor->scale * m_RenderData.renderModif.scale;
 
     // adjust box
     box->x -= scaledBorderSize;

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -23,8 +23,7 @@ inline const float fullVerts[] = {
 };
 inline const float fanVertsFull[] = {-1.0f, -1.0f, 1.0f, -1.0f, 1.0f, 1.0f, -1.0f, 1.0f};
 
-enum eDiscardMode
-{
+enum eDiscardMode {
     DISCARD_OPAQUE    = 1,
     DISCARD_ALPHAZERO = 1 << 1
 };
@@ -101,7 +100,7 @@ class CHyprOpenGLImpl {
     void                                       renderTexture(const CTexture&, wlr_box*, float a, int round = 0, bool discardActive = false, bool allowCustomUV = false);
     void                                       renderTextureWithBlur(const CTexture&, wlr_box*, float a, wlr_surface* pSurface, int round = 0, bool blockBlurOptimization = false);
     void                                       renderRoundedShadow(wlr_box*, int round, int range, float a = 1.0);
-    void                                       renderBorder(wlr_box*, const CGradientValueData&, int round, float a = 1.0);
+    void                                       renderBorder(wlr_box*, const CGradientValueData&, int round, float a = 1.0, int borderSize = -1);
 
     void                                       saveMatrix();
     void                                       setMatrixScaleTranslate(const Vector2D& translate, const float& scale);

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -100,7 +100,7 @@ class CHyprOpenGLImpl {
     void                                       renderTexture(const CTexture&, wlr_box*, float a, int round = 0, bool discardActive = false, bool allowCustomUV = false);
     void                                       renderTextureWithBlur(const CTexture&, wlr_box*, float a, wlr_surface* pSurface, int round = 0, bool blockBlurOptimization = false);
     void                                       renderRoundedShadow(wlr_box*, int round, int range, float a = 1.0);
-    void                                       renderBorder(wlr_box*, const CGradientValueData&, int round, float a = 1.0, int borderSize = -1);
+    void                                       renderBorder(wlr_box*, const CGradientValueData&, int round, int borderSize, float a = 1.0);
 
     void                                       saveMatrix();
     void                                       setMatrixScaleTranslate(const Vector2D& translate, const float& scale);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -342,7 +342,7 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
 
             scaleBox(&windowBox, pMonitor->scale);
 
-            g_pHyprOpenGL->renderBorder(&windowBox, grad, rounding, a1);
+            g_pHyprOpenGL->renderBorder(&windowBox, grad, rounding, a1, pWindow->m_sSpecialRenderData.borderSize);
 
             if (ANIMATED) {
                 float a2 = renderdata.fadeAlpha * renderdata.alpha * (1.f - g_pHyprOpenGL->m_pCurrentWindow->m_fBorderFadeAnimationProgress.fl());

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -342,11 +342,11 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
 
             scaleBox(&windowBox, pMonitor->scale);
 
-            g_pHyprOpenGL->renderBorder(&windowBox, grad, rounding, a1, pWindow->m_sSpecialRenderData.borderSize);
+            g_pHyprOpenGL->renderBorder(&windowBox, grad, rounding, pWindow->m_sSpecialRenderData.borderSize, a1);
 
             if (ANIMATED) {
                 float a2 = renderdata.fadeAlpha * renderdata.alpha * (1.f - g_pHyprOpenGL->m_pCurrentWindow->m_fBorderFadeAnimationProgress.fl());
-                g_pHyprOpenGL->renderBorder(&windowBox, g_pHyprOpenGL->m_pCurrentWindow->m_cRealBorderColorPrevious, rounding, a2);
+                g_pHyprOpenGL->renderBorder(&windowBox, g_pHyprOpenGL->m_pCurrentWindow->m_cRealBorderColorPrevious, rounding, pWindow->m_sSpecialRenderData.borderSize, a2);
             }
         }
     }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -248,6 +248,7 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
     const auto         REALPOS            = pWindow->m_vRealPosition.vec() + (pWindow->m_bPinned ? Vector2D{} : PWORKSPACE->m_vRenderOffset.vec());
     static auto* const PNOFLOATINGBORDERS = &g_pConfigManager->getConfigValuePtr("general:no_border_on_floating")->intValue;
     static auto* const PDIMAROUND         = &g_pConfigManager->getConfigValuePtr("decoration:dim_around")->floatValue;
+    static auto* const PBORDERSIZE        = &g_pConfigManager->getConfigValuePtr("general:border_size")->intValue;
 
     SRenderData        renderdata = {pMonitor, time, REALPOS.x, REALPOS.y};
     if (ignorePosition) {
@@ -342,11 +343,13 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
 
             scaleBox(&windowBox, pMonitor->scale);
 
-            g_pHyprOpenGL->renderBorder(&windowBox, grad, rounding, pWindow->m_sSpecialRenderData.borderSize, a1);
+            const int BORDERSIZE = pWindow->m_sSpecialRenderData.borderSize == -1 ? *PBORDERSIZE : pWindow->m_sSpecialRenderData.borderSize;
+
+            g_pHyprOpenGL->renderBorder(&windowBox, grad, rounding, BORDERSIZE, a1);
 
             if (ANIMATED) {
                 float a2 = renderdata.fadeAlpha * renderdata.alpha * (1.f - g_pHyprOpenGL->m_pCurrentWindow->m_fBorderFadeAnimationProgress.fl());
-                g_pHyprOpenGL->renderBorder(&windowBox, g_pHyprOpenGL->m_pCurrentWindow->m_cRealBorderColorPrevious, rounding, pWindow->m_sSpecialRenderData.borderSize, a2);
+                g_pHyprOpenGL->renderBorder(&windowBox, g_pHyprOpenGL->m_pCurrentWindow->m_cRealBorderColorPrevious, rounding, BORDERSIZE, a2);
             }
         }
     }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This PR adds some workspace-specific rules, using the already existing `workspace` config (until now only used for default workspaces for monitors).

More specifically, we are now able to have some custom rules that are applied to workspaces, such as having a different amount of gaps/borders, whether to have rounding, and so on.

The specific syntax on the config would be:
`workspace=monitor,workspace,gaps_in,gaps_out,border_size,drawBorder,doRounding,doDecorate`

where:

1.  `monitor` was the pre-existing argument;
2. `workspace` is a workspace (numbered, named, etc.);
3. `gaps_in` is an int;
4. `gaps_out` is an int;
5. `border_size` is an int;
6. `drawBorder` is a bool, and determines whether borders are drawn or not;
7. `doRounding` is a bool, same as before;
8. `doDecorate` is a bool, same as before.

Windows opened in the specified workspace, will be rendered with those specific rules. Notice, **this takes precedence over** `no_gaps_when_only` (i.e., if `no_gaps_when_only` is `true`, but a workspace rule is found for this specific workspace, `no_gaps_when_only` is ignored).
This basically implements what discussed in #1345.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This should not break any compatibility. I don't know, however, whether we want to keep this syntax for the config file, as having 8 arguments might feel like a bit too much for other people (doesn't look too bad to me tbh).

#### Is it ready for merging, or does it need work?
Theoretically ready for merging, but I guess this might need a little discussion.

