### PR TITLE
Allow movefocus for empty workspaces

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -63,6 +63,7 @@ void CConfigManager::setDefaultVars() {
     ((CGradientValueData*)configValues["general:col.group_border_active"].data.get())->reset(0x66ffff00);
     configValues["general:cursor_inactive_timeout"].intValue = 0;
     configValues["general:no_cursor_warps"].intValue         = 0;
+    configValues["general:no_focus_fallback"].intValue       = 0;
     configValues["general:resize_on_border"].intValue        = 0;
     configValues["general:extend_border_grab_area"].intValue = 15;
     configValues["general:hover_icon_on_border"].intValue    = 1;

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -175,9 +175,8 @@ bool CKeybindManager::ensureMouseBindState() {
 
 bool CKeybindManager::tryMoveFocusToMonitorInDirection(const char& dir) {
     const auto PNEWMONITOR = g_pCompositor->getMonitorInDirection(dir);
-    if (!PNEWMONITOR) {
+    if (!PNEWMONITOR)
         return false;
-    }
 
     Debug::log(LOG, "switching to monitor");
     const auto PNEWWORKSPACE = g_pCompositor->getWorkspaceByID(PNEWMONITOR->activeWorkspace);
@@ -1189,21 +1188,18 @@ void CKeybindManager::moveFocusTo(std::string args) {
 
     Debug::log(LOG, "No window found in direction %c, looking for a monitor", arg);
 
-    if (tryMoveFocusToMonitorInDirection(arg)) {
+    if (tryMoveFocusToMonitorInDirection(arg))
         return;
-    }
 
     static auto* const PNOFALLBACK = &g_pConfigManager->getConfigValuePtr("general:no_focus_fallback")->intValue;
-    if (*PNOFALLBACK) {
+    if (*PNOFALLBACK)
         return;
-    }
 
     Debug::log(LOG, "No monitor found in direction %c, falling back to next window on current workspace", arg);
 
     const auto PWINDOWNEXT = g_pCompositor->getNextWindowOnWorkspace(PLASTWINDOW, true);
-    if (PWINDOWNEXT) {
+    if (PWINDOWNEXT)
         switchToWindow(PWINDOWNEXT);
-    }
 }
 
 void CKeybindManager::focusUrgentOrLast(std::string args) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1193,6 +1193,11 @@ void CKeybindManager::moveFocusTo(std::string args) {
         return;
     }
 
+    static auto* const PNOFALLBACK = &g_pConfigManager->getConfigValuePtr("general:no_focus_fallback")->intValue;
+    if (*PNOFALLBACK) {
+        return;
+    }
+
     Debug::log(LOG, "No monitor found in direction %c, falling back to next window on current workspace", arg);
 
     const auto PWINDOWNEXT = g_pCompositor->getNextWindowOnWorkspace(PLASTWINDOW, true);

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -90,6 +90,8 @@ class CKeybindManager {
     void                      updateXKBTranslationState();
     bool                      ensureMouseBindState();
 
+    static bool               tryMoveFocusToMonitorInDirection(const char&);
+
     // -------------- Dispatchers -------------- //
     static void     killActive(std::string);
     static void     kill(std::string);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

As discussed in #1999, this PR implements moving to and from empty workspaces using `movefocus`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I've tried to adapt to your naming schemes, but I'm not sure in which cases you use the `P` prefix for variables, and if I'm correct in assuming that all local window/workspace/monitor variables in functions should be all uppercase (e.g. `PNEWWINDOW`). I'd like having at least underscore to separate words for readability (`P_NEW_WINDOW`), but I'll use the current style if that's what you prefer.

I was also wondering, if a workspace has no current focused window, is it possible that there are still windows? I imagine that could happen if a silent move to a workspace occurred. See my TODO in the code for that.

#### Is it ready for merging, or does it need work?

I was unsure about how this functionality should be activated, since it's potentially breaking the workflow of current users who depend on a fallback to any window if no window is found in the direction. It would also be possible to still do that fallback behavior if no monitor was found in that direction.

My idea would be to add an option to enable the fallback behavior (`getNextWindowOnWorkspace`) and enable it by default.