### PR TITLE
make ext_workspace_unstable impl more atomic

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -960,6 +960,9 @@ void CKeybindManager::changeworkspace(std::string args) {
     if (ANOTHERMONITOR)
         g_pCompositor->warpCursorTo(PMONITOR->vecPosition + PMONITOR->vecSize / 2.f);
 
+    // Destroy old workspace if it is empty
+    g_pCompositor->sanityCheckWorkspaces();
+
     Debug::log(LOG, "Changed to workspace %i", workspaceToChangeTo);
 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

When switching form an empty workspace, destroy the old workspace before sending `zext_workspace_manager_v1.done`

Fixes  #2015