### PR TITLE
Add ability to split master when only 1 additional window

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -145,7 +145,7 @@ void CConfigManager::setDefaultVars() {
     configValues["master:inherit_fullscreen"].intValue     = 1;
 
     //master cannot be increased when you have 2 windows or less open by default
-    configValues["master:split_master_lt_2"].strValue = "false";
+    configValues["master:allow_small_split"].intValue = 0;
 
     configValues["animations:enabled"].intValue = 1;
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -144,6 +144,9 @@ void CConfigManager::setDefaultVars() {
     configValues["master:orientation"].strValue            = "left";
     configValues["master:inherit_fullscreen"].intValue     = 1;
 
+    //master cannot be increased when you have 2 windows or less open by default
+    configValues["master:split_master_lt_2"].strValue = "false";
+
     configValues["animations:enabled"].intValue = 1;
 
     configValues["input:follow_mouse"].intValue                     = 1;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -143,9 +143,7 @@ void CConfigManager::setDefaultVars() {
     configValues["master:no_gaps_when_only"].intValue      = 0;
     configValues["master:orientation"].strValue            = "left";
     configValues["master:inherit_fullscreen"].intValue     = 1;
-
-    //master cannot be increased when you have 2 windows or less open by default
-    configValues["master:allow_small_split"].intValue = 0;
+    configValues["master:allow_small_split"].intValue      = 0;
 
     configValues["animations:enabled"].intValue = 1;
 

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -953,10 +953,11 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
 
         const auto PNODE = getNodeFromWindow(header.pWindow);
 
-        const auto WINDOWS = getNodesOnWorkspace(header.pWindow->m_iWorkspaceID);
-        const auto MASTERS = getMastersOnWorkspace(header.pWindow->m_iWorkspaceID);
+        const auto WINDOWS   = getNodesOnWorkspace(header.pWindow->m_iWorkspaceID);
+        const auto MASTERS   = getMastersOnWorkspace(header.pWindow->m_iWorkspaceID);
+        const bool MIN_SPLIT = g_pCompositor->getConfigValuePtr("master:allow_small_split") == "false";
 
-        if (MASTERS + 2 > WINDOWS)
+        if (MASTERS + 2 > WINDOWS && MIN_SPLIT)
             return 0;
 
         prepareLoseFocus(header.pWindow);

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -153,9 +153,9 @@ void CHyprMasterLayout::onWindowRemovedTiling(CWindow* pWindow) {
     if (!PNODE)
         return;
 
-    const auto  WORKSPACEID = PNODE->workspaceID;
-    const auto  MASTERSLEFT = getMastersOnWorkspace(WORKSPACEID);
-    const auto* SMALLSPLIT  = &g_pConfigManager->getConfigValuePtr("master:allow_small_split")->intValue;
+    static const auto  WORKSPACEID = PNODE->workspaceID;
+    static const auto  MASTERSLEFT = getMastersOnWorkspace(WORKSPACEID);
+    static const auto* SMALLSPLIT  = &g_pConfigManager->getConfigValuePtr("master:allow_small_split")->intValue;
 
     pWindow->m_sSpecialRenderData.rounding = true;
     pWindow->m_sSpecialRenderData.border   = true;
@@ -966,11 +966,11 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
         if (header.pWindow->m_bIsFloating)
             return 0;
 
-        const auto  PNODE = getNodeFromWindow(header.pWindow);
+        const auto         PNODE = getNodeFromWindow(header.pWindow);
 
-        const auto  WINDOWS    = getNodesOnWorkspace(header.pWindow->m_iWorkspaceID);
-        const auto  MASTERS    = getMastersOnWorkspace(header.pWindow->m_iWorkspaceID);
-        const auto* SMALLSPLIT = &g_pConfigManager->getConfigValuePtr("master:allow_small_split")->intValue;
+        static const auto  WINDOWS    = getNodesOnWorkspace(header.pWindow->m_iWorkspaceID);
+        static const auto  MASTERS    = getMastersOnWorkspace(header.pWindow->m_iWorkspaceID);
+        static const auto* SMALLSPLIT = &g_pConfigManager->getConfigValuePtr("master:allow_small_split")->intValue;
 
         if (MASTERS + 2 > WINDOWS && *SMALLSPLIT == 0)
             return 0;

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -153,8 +153,8 @@ void CHyprMasterLayout::onWindowRemovedTiling(CWindow* pWindow) {
     if (!PNODE)
         return;
 
-    static const auto  WORKSPACEID = PNODE->workspaceID;
-    static const auto  MASTERSLEFT = getMastersOnWorkspace(WORKSPACEID);
+    const auto         WORKSPACEID = PNODE->workspaceID;
+    const auto         MASTERSLEFT = getMastersOnWorkspace(WORKSPACEID);
     static const auto* SMALLSPLIT  = &g_pConfigManager->getConfigValuePtr("master:allow_small_split")->intValue;
 
     pWindow->m_sSpecialRenderData.rounding = true;
@@ -968,8 +968,8 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
 
         const auto         PNODE = getNodeFromWindow(header.pWindow);
 
-        static const auto  WINDOWS    = getNodesOnWorkspace(header.pWindow->m_iWorkspaceID);
-        static const auto  MASTERS    = getMastersOnWorkspace(header.pWindow->m_iWorkspaceID);
+        const auto         WINDOWS    = getNodesOnWorkspace(header.pWindow->m_iWorkspaceID);
+        const auto         MASTERS    = getMastersOnWorkspace(header.pWindow->m_iWorkspaceID);
         static const auto* SMALLSPLIT = &g_pConfigManager->getConfigValuePtr("master:allow_small_split")->intValue;
 
         if (MASTERS + 2 > WINDOWS && *SMALLSPLIT == 0)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Regarding  [Issue: #1836 ](https://github.com/hyprwm/Hyprland/issues/1836)
Add functionality to master & stack layout.
this pull request allows the user to optionally enable DWM like master splitting with as few windows as they would like.
````
master {
    allow_small_split = true
}
````

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Found 3 minor issues:

1. (pre-existing behaviour) when increasing the number of masters on "center" orientation, it is possible to end up with a blank pane to the right  if you add too many masters.
2. (bug with this PR) if you close a window while all windows are masters. they will not re-flow & fill the whole screen until you open a new window.
3. (bug with this PR) if you close the top master window, you cannot select the bottom one until you open a new window.

#### Is it ready for merging, or does it need work?
It could be merged as an "in development" feature?
otherwise, happy to work on the bugs listed above.

