### PR TITLE
swallow: Add swallow_exception_regex

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -81,6 +81,7 @@ void CConfigManager::setDefaultVars() {
     configValues["misc:disable_autoreload"].intValue           = 0;
     configValues["misc:enable_swallow"].intValue               = 0;
     configValues["misc:swallow_regex"].strValue                = STRVAL_EMPTY;
+    configValues["misc:swallow_exception_regex"].strValue      = STRVAL_EMPTY;
     configValues["misc:focus_on_activate"].intValue            = 0;
     configValues["misc:no_direct_scanout"].intValue            = 1;
     configValues["misc:hide_cursor_on_touch"].intValue         = 1;

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -40,11 +40,12 @@ void setAnimToMove(void* data) {
 void Events::listener_mapWindow(void* owner, void* data) {
     CWindow*           PWINDOW = (CWindow*)owner;
 
-    static auto* const PINACTIVEALPHA = &g_pConfigManager->getConfigValuePtr("decoration:inactive_opacity")->floatValue;
-    static auto* const PACTIVEALPHA   = &g_pConfigManager->getConfigValuePtr("decoration:active_opacity")->floatValue;
-    static auto* const PDIMSTRENGTH   = &g_pConfigManager->getConfigValuePtr("decoration:dim_strength")->floatValue;
-    static auto* const PSWALLOW       = &g_pConfigManager->getConfigValuePtr("misc:enable_swallow")->intValue;
-    static auto* const PSWALLOWREGEX  = &g_pConfigManager->getConfigValuePtr("misc:swallow_regex")->strValue;
+    static auto* const PINACTIVEALPHA  = &g_pConfigManager->getConfigValuePtr("decoration:inactive_opacity")->floatValue;
+    static auto* const PACTIVEALPHA    = &g_pConfigManager->getConfigValuePtr("decoration:active_opacity")->floatValue;
+    static auto* const PDIMSTRENGTH    = &g_pConfigManager->getConfigValuePtr("decoration:dim_strength")->floatValue;
+    static auto* const PSWALLOW        = &g_pConfigManager->getConfigValuePtr("misc:enable_swallow")->intValue;
+    static auto* const PSWALLOWREGEX   = &g_pConfigManager->getConfigValuePtr("misc:swallow_regex")->strValue;
+    static auto* const PSWALLOWEXREGEX = &g_pConfigManager->getConfigValuePtr("misc:swallow_exception_regex")->strValue;
 
     auto               PMONITOR = g_pCompositor->m_pLastMonitor;
     const auto         PWORKSPACE =
@@ -553,8 +554,10 @@ void Events::listener_mapWindow(void* owner, void* data) {
                 }
 
                 if (finalFound) {
-                    // check if it's the window we want
-                    if (std::regex_match(g_pXWaylandManager->getAppIDClass(finalFound), rgx)) {
+                    std::regex exc(*PSWALLOWEXREGEX);
+                    // check if it's the window we want & not exempt from getting swallowed
+                    if (std::regex_match(g_pXWaylandManager->getAppIDClass(finalFound), rgx) &&
+                        !std::regex_match(g_pXWaylandManager->getTitle(finalFound), exc)) {
                         // swallow
                         PWINDOW->m_pSwallowed = finalFound;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Currently, if a window class is specified in the swallow_regex (e.g. Kitty) it will swallow every other window spawned by it automatically. Many other WMs implementing this functionality allow for defining exceptions from this rule. For instance, we want Kitty to swallow sxiv or zathura but we do not want Kitty to swallow something like wev.

This commit adds an additional regex - swallow_exception_regex where these exceptions can be defined. This regex is then compared against the title of the window about to be swallowed and if it happens to be a match, aborts the swallowing.

This works because whenever an application that could be swallowed is launched by a terminal, the class of the terminal remains the same while the title changes to whatever the application's name is, thus letting it be matched against a regex.

#### Is it ready for merging, or does it need work?

The PR should be ready to be merged unless the config option name should be changed for some reason. Presumably the documentation will need to be updated as well.

Solves issue #2002 
