### PR TITLE
Add "tick" event for plugins

### DIFF
--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -1,5 +1,6 @@
 #include "AnimationManager.hpp"
 #include "../Compositor.hpp"
+#include "HookSystemManager.hpp"
 
 int wlTick(void* data) {
 
@@ -8,6 +9,8 @@ int wlTick(void* data) {
     wl_event_source_timer_update(g_pAnimationManager->m_pAnimationTick, 1000 / refreshRate);
 
     g_pAnimationManager->tick();
+
+    EMIT_HOOK_EVENT("tick", nullptr);
 
     return 0;
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Add a "tick" event for plugins to use for periodic calls, useful for handling async problems.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Could theoretically pass the delta time between ticks as a param of the event? I personally don't think it would be useful, and if needed can be kept plugin-side anyway.

#### Is it ready for merging, or does it need work?
Ready

