### PR TITLE
Xdg config home support

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1310,6 +1310,7 @@ void CConfigManager::loadConfigLoadVars() {
     // paths
     configPaths.clear();
     std::string mainConfigPath = getMainConfigPath();
+    Debug::log(LOG, "Using config: %s", mainConfigPath.c_str());
     configPaths.push_back(mainConfigPath);
     std::string configPath = mainConfigPath.substr(0, mainConfigPath.find_last_of('/'));
     // find_last_of never returns npos since main_config atleast has /hpyr/

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -29,19 +29,21 @@ CConfigManager::CConfigManager() {
     populateEnvironment();
 }
 
-std::string CConfigManager::getMainConfigPath() {
-    if (!g_pCompositor->explicitConfigPath.empty())
-        return g_pCompositor->explicitConfigPath;
-
+std::string CConfigManager::getConfigDir() {
     static const char* xdgConfigHome = getenv("XDG_CONFIG_HOME");
     std::string        configPath;
     if (!xdgConfigHome)
         configPath = getenv("HOME") + std::string("/.config");
     else
         configPath = xdgConfigHome;
-    std::string configDebug = "/hypr/hyprlandd.conf";
-    std::string config      = "/hypr/hyprland.conf";
-    return configPath + (ISDEBUG ? configDebug : config);
+    return configPath;
+}
+
+std::string CConfigManager::getMainConfigPath() {
+    if (!g_pCompositor->explicitConfigPath.empty())
+        return g_pCompositor->explicitConfigPath;
+
+    return getConfigDir() + (ISDEBUG ? "/hypr/hyprlandd.conf" : "/hypr/hyprland.conf");
 }
 
 void CConfigManager::populateEnvironment() {
@@ -1313,7 +1315,7 @@ void CConfigManager::loadConfigLoadVars() {
     Debug::log(LOG, "Using config: %s", mainConfigPath.c_str());
     configPaths.push_back(mainConfigPath);
     std::string configPath = mainConfigPath.substr(0, mainConfigPath.find_last_of('/'));
-    // find_last_of never returns npos since main_config atleast has /hpyr/
+    // find_last_of never returns npos since main_config at least has /hypr/
 
     if (!std::filesystem::is_directory(configPath)) {
         Debug::log(WARN, "Creating config home directory");

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -43,7 +43,7 @@ std::string CConfigManager::getMainConfigPath() {
     if (!g_pCompositor->explicitConfigPath.empty())
         return g_pCompositor->explicitConfigPath;
 
-    return getConfigDir() + (ISDEBUG ? "/hypr/hyprlandd.conf" : "/hypr/hyprland.conf");
+    return getConfigDir() + "/hypr/" + (ISDEBUG ? "hyprlandd.conf" : "hyprland.conf");
 }
 
 void CConfigManager::populateEnvironment() {
@@ -1322,7 +1322,7 @@ void CConfigManager::loadConfigLoadVars() {
         try {
             std::filesystem::create_directories(configPath);
         } catch (...) {
-            parseError = "Broken config file! (Could not create directory)";
+            parseError = "Broken config file! (Could not create config directory)";
             return;
         }
     }

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -147,6 +147,7 @@ class CConfigManager {
 
     SConfigValue*                                                   getConfigValuePtr(const std::string&);
     SConfigValue*                                                   getConfigValuePtrSafe(const std::string&);
+    static std::string                                                     getMainConfigPath();
 
     SMonitorRule                                                    getMonitorRuleFor(const std::string&, const std::string& displayName = "");
     std::string                                                     getDefaultWorkspaceFor(const std::string&);

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -147,7 +147,8 @@ class CConfigManager {
 
     SConfigValue*                                                   getConfigValuePtr(const std::string&);
     SConfigValue*                                                   getConfigValuePtrSafe(const std::string&);
-    static std::string                                                     getMainConfigPath();
+    static std::string                                              getConfigDir();
+    static std::string                                              getMainConfigPath();
 
     SMonitorRule                                                    getMonitorRuleFor(const std::string&, const std::string& displayName = "");
     std::string                                                     getDefaultWorkspaceFor(const std::string&);

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -332,14 +332,7 @@ void CHyprOpenGLImpl::applyScreenShader(const std::string& path) {
     if (path == "" || path == STRVAL_EMPTY)
         return;
 
-    const char* xdgConfigHome = getenv("XDG_CONFIG_HOME");
-    std::string        configPath;
-    if (!xdgConfigHome)
-        configPath = getenv("HOME") + std::string("/.config");
-    else
-        configPath = xdgConfigHome;
-
-    std::ifstream infile(absolutePath(path, configPath));
+    std::ifstream infile(absolutePath(path, g_pConfigManager->getConfigDir()));
 
     if (!infile.good()) {
         g_pConfigManager->addParseError("Screen shader parser: Screen shader path not found");

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -332,7 +332,14 @@ void CHyprOpenGLImpl::applyScreenShader(const std::string& path) {
     if (path == "" || path == STRVAL_EMPTY)
         return;
 
-    std::ifstream infile(absolutePath(path, std::string(getenv("HOME")) + "/.config/hypr"));
+    const char* xdgConfigHome = getenv("XDG_CONFIG_HOME");
+    std::string        configPath;
+    if (!xdgConfigHome)
+        configPath = getenv("HOME") + std::string("/.config");
+    else
+        configPath = xdgConfigHome;
+
+    std::ifstream infile(absolutePath(path, configPath));
 
     if (!infile.good()) {
         g_pConfigManager->addParseError("Screen shader parser: Screen shader path not found");


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

The default config path will now first check if XDG_CONFIG_HOME exists and will use it rather than $HOME/.config if it does exist.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I didn't read deep enough into the code to understand what OpenGL.cpp is doing, so I am not 100% sure my change makes sense there.

#### Is it ready for merging, or does it need work?

Tested it locally, seems to work in all cases.

Related to #1040 
