### PR TITLE
Fix possible usage of clamp with lo > hi in Vector2D (crash)

### DIFF
--- a/src/helpers/Vector2D.cpp
+++ b/src/helpers/Vector2D.cpp
@@ -29,7 +29,7 @@ Vector2D Vector2D::floor() {
 }
 
 Vector2D Vector2D::clamp(const Vector2D& min, const Vector2D& max) {
-    return Vector2D(std::clamp(this->x, min.x, max.x == 0 ? INFINITY : max.x), std::clamp(this->y, min.y, max.y == 0 ? INFINITY : max.y));
+    return Vector2D(std::clamp(this->x, min.x, max.x < min.x ? INFINITY : max.x), std::clamp(this->y, min.y, max.y < min.y ? INFINITY : max.y));
 }
 
 double Vector2D::distance(const Vector2D& other) {


### PR DESCRIPTION
Vector2D introduced a clamp function as Hyprland would crash if the windows got too small (see #100).
While the implementation might work for some, the usage might result in undefined behavior, as `std::clamp` does not define calling it with `lo > hi`. This is however not checked and will occur if windows get too small.

In my case this results again in a crash due to a failed assertion checking for `lo > hi` in the std library on my system (archlinux).

I am not sure if INFINITY is necessarily the correct value to set here (I just oriented myself to how it was previously), because I am very much missing context (I just wanted to debug this crash real quick).
This patch does however result in Hyprland not crashing no matter how many windows I open (which I think should be the default, lol).
(maybe not infinitely many, but enough that there are lots that are so tiny that they have a size of 0x0)

As the question of "Why in the world would you even create windows that small tho?" remained unanswered in #100, I want to answer it for my case here:
1. have 20px gaps
2. use dwindle layout with preserve_split set to yes and force_split to 2 (resulting in half the window size on each new window)
3. `evince docs{1..15}.pdf`


I would suggest to add an option to automatically open windows in floating mode if the window size of the new window would be below a certain threshold, but an implementation of that would be outside the scope of this PR.