### PR TITLE
Xdg config home support

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1310,6 +1310,7 @@ void CConfigManager::loadConfigLoadVars() {
     // paths
     configPaths.clear();
     std::string mainConfigPath = getMainConfigPath();
+    Debug::log(LOG, "Using config: %s", mainConfigPath.c_str());
     configPaths.push_back(mainConfigPath);
     std::string configPath = mainConfigPath.substr(0, mainConfigPath.find_last_of('/'));
     // find_last_of never returns npos since main_config atleast has /hpyr/

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -147,6 +147,7 @@ class CConfigManager {
 
     SConfigValue*                                                   getConfigValuePtr(const std::string&);
     SConfigValue*                                                   getConfigValuePtrSafe(const std::string&);
+    static std::string                                                     getMainConfigPath();
 
     SMonitorRule                                                    getMonitorRuleFor(const std::string&, const std::string& displayName = "");
     std::string                                                     getDefaultWorkspaceFor(const std::string&);

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -332,7 +332,14 @@ void CHyprOpenGLImpl::applyScreenShader(const std::string& path) {
     if (path == "" || path == STRVAL_EMPTY)
         return;
 
-    std::ifstream infile(absolutePath(path, std::string(getenv("HOME")) + "/.config/hypr"));
+    const char* xdgConfigHome = getenv("XDG_CONFIG_HOME");
+    std::string        configPath;
+    if (!xdgConfigHome)
+        configPath = getenv("HOME") + std::string("/.config");
+    else
+        configPath = xdgConfigHome;
+
+    std::ifstream infile(absolutePath(path, configPath));
 
     if (!infile.good()) {
         g_pConfigManager->addParseError("Screen shader parser: Screen shader path not found");


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

The default config path will now first check if XDG_CONFIG_HOME exists and will use it rather than $HOME/.config if it does exist.

I addressed the comments on #2047, reformatted the commit messages to fit the project and to be more accurate.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?

Tested it locally, seems to work in all cases.

Contributes to: #1040
Supersedes: #2047