### PR TITLE
Fix dragging cursor being forced on fullscreen windows

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -338,8 +338,12 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
 
     if (pFoundWindow) {
         // change cursor icon if hovering over border
-        if (*PRESIZEONBORDER && *PRESIZECURSORICON && !pFoundWindow->m_bIsFullscreen && !pFoundWindow->hasPopupAt(mouseCoords)) {
-            setCursorIconOnBorder(pFoundWindow);
+        if (*PRESIZEONBORDER && *PRESIZECURSORICON) {
+            if (!pFoundWindow->m_bIsFullscreen && !pFoundWindow->hasPopupAt(mouseCoords)) {
+                setCursorIconOnBorder(pFoundWindow);
+            } else if (m_eBorderIconDirection != BORDERICON_NONE) {
+                unsetCursorImage();
+            }
         }
 
         // if we're on an input deco, reset cursor. Don't on overridden


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes two edge cases causing the dragging mouse cursor to be forced on fullscreen windows:
- hovering over a window border and running the fullscreen dispatcher
- moving mouse focus from a monitor with the resize cursor set to a different monitor with a fullscreen window

Video of bug:
https://user-images.githubusercontent.com/83010835/233523999-87e17b64-b22b-41e1-b42f-bd8ea1ded13b.mp4


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No


#### Is it ready for merging, or does it need work?
Ready for merge


