### PR TITLE
Remove wlr_output_damage.h

### DIFF
--- a/src/includes.hpp
+++ b/src/includes.hpp
@@ -71,7 +71,6 @@ extern "C" {
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/types/wlr_subcompositor.h>
 #include <wlr/types/wlr_scene.h>
-#include <wlr/types/wlr_output_damage.h>
 #include <wlr/types/wlr_input_inhibitor.h>
 #include <wlr/types/wlr_keyboard_shortcuts_inhibit_v1.h>
 #include <wlr/types/wlr_virtual_pointer_v1.h>


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This is [removed](https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/9ef98452a31c0936187e8a877f6a99c4308b9976) upstream and hyprland wasn't using it anyway.

This alone will probably not fix the CI but this will allow to clean build hyprland in many configurations.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.

#### Is it ready for merging, or does it need work?
Ready for merge.

