### PR TITLE
Add follow mouse mode to avoid refocusing under cursor

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -151,6 +151,7 @@ void CConfigManager::setDefaultVars() {
     configValues["animations:enabled"].intValue = 1;
 
     configValues["input:follow_mouse"].intValue                     = 1;
+    configValues["input:mouse_refocus"].intValue                    = 1;
     configValues["input:sensitivity"].floatValue                    = 0.f;
     configValues["input:accel_profile"].strValue                    = STRVAL_EMPTY;
     configValues["input:kb_file"].strValue                          = STRVAL_EMPTY;

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1444,7 +1444,7 @@ void CKeybindManager::toggleSpecialWorkspace(std::string args) {
     }
 
     bool       requestedWorkspaceIsAlreadyOpen = false;
-    const auto PMONITOR                        = *PFOLLOWMOUSE == 1 ? g_pCompositor->getMonitorFromCursor() : g_pCompositor->m_pLastMonitor;
+    const auto PMONITOR                        = (*PFOLLOWMOUSE == 1 || *PFOLLOWMOUSE == 4) ? g_pCompositor->getMonitorFromCursor() : g_pCompositor->m_pLastMonitor;
     int        specialOpenOnMonitor            = PMONITOR->specialWorkspaceID;
 
     for (auto& m : g_pCompositor->m_vMonitors) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1444,7 +1444,7 @@ void CKeybindManager::toggleSpecialWorkspace(std::string args) {
     }
 
     bool       requestedWorkspaceIsAlreadyOpen = false;
-    const auto PMONITOR                        = (*PFOLLOWMOUSE == 1 || *PFOLLOWMOUSE == 4) ? g_pCompositor->getMonitorFromCursor() : g_pCompositor->m_pLastMonitor;
+    const auto PMONITOR                        = *PFOLLOWMOUSE == 1 ? g_pCompositor->getMonitorFromCursor() : g_pCompositor->m_pLastMonitor;
     int        specialOpenOnMonitor            = PMONITOR->specialWorkspaceID;
 
     for (auto& m : g_pCompositor->m_vMonitors) {

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -358,7 +358,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
         //     }
         // }
 
-        if (FOLLOWMOUSE != 1 && !refocus) {
+        if (FOLLOWMOUSE != 1 && FOLLOWMOUSE != 4 && !refocus) {
             if (pFoundWindow != g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow &&
                 ((pFoundWindow->m_bIsFloating && *PFLOATBEHAVIOR == 2) || (g_pCompositor->m_pLastWindow->m_bIsFloating != pFoundWindow->m_bIsFloating && *PFLOATBEHAVIOR != 0))) {
                 // enter if change floating style
@@ -382,8 +382,10 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
             m_bLastFocusOnLS = false;
             return; // don't enter any new surfaces
         } else {
-            if ((FOLLOWMOUSE != 3 && allowKeyboardRefocus) || refocus)
+            if (((FOLLOWMOUSE != 3 && allowKeyboardRefocus) || refocus) && (FOLLOWMOUSE != 4 || m_pLastMouseFocus != pFoundWindow)) {
+                m_pLastMouseFocus = pFoundWindow;
                 g_pCompositor->focusWindow(pFoundWindow, foundSurface);
+            }
         }
 
         m_bLastFocusOnLS = false;

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -47,6 +47,7 @@ void CInputManager::simulateMouseMovement() {
 
 void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
     static auto* const PFOLLOWMOUSE      = &g_pConfigManager->getConfigValuePtr("input:follow_mouse")->intValue;
+    static auto* const PMOUSEREFOCUS     = &g_pConfigManager->getConfigValuePtr("input:mouse_refocus")->intValue;
     static auto* const PMOUSEDPMS        = &g_pConfigManager->getConfigValuePtr("misc:mouse_move_enables_dpms")->intValue;
     static auto* const PFOLLOWONDND      = &g_pConfigManager->getConfigValuePtr("misc:always_follow_on_dnd")->intValue;
     static auto* const PHOGFOCUS         = &g_pConfigManager->getConfigValuePtr("misc:layers_hog_keyboard_focus")->intValue;
@@ -358,7 +359,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
         //     }
         // }
 
-        if (FOLLOWMOUSE != 1 && FOLLOWMOUSE != 4 && !refocus) {
+        if (FOLLOWMOUSE != 1 && !refocus) {
             if (pFoundWindow != g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow &&
                 ((pFoundWindow->m_bIsFloating && *PFLOATBEHAVIOR == 2) || (g_pCompositor->m_pLastWindow->m_bIsFloating != pFoundWindow->m_bIsFloating && *PFLOATBEHAVIOR != 0))) {
                 // enter if change floating style
@@ -382,7 +383,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
             m_bLastFocusOnLS = false;
             return; // don't enter any new surfaces
         } else {
-            if (((FOLLOWMOUSE != 3 && allowKeyboardRefocus) && (FOLLOWMOUSE != 4 || m_pLastMouseFocus != pFoundWindow)) || refocus) {
+            if (((FOLLOWMOUSE != 3 && allowKeyboardRefocus) && (*PMOUSEREFOCUS || m_pLastMouseFocus != pFoundWindow)) || refocus) {
                 m_pLastMouseFocus = pFoundWindow;
                 g_pCompositor->focusWindow(pFoundWindow, foundSurface);
             }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -382,7 +382,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
             m_bLastFocusOnLS = false;
             return; // don't enter any new surfaces
         } else {
-            if (((FOLLOWMOUSE != 3 && allowKeyboardRefocus) || refocus) && (FOLLOWMOUSE != 4 || m_pLastMouseFocus != pFoundWindow)) {
+            if (((FOLLOWMOUSE != 3 && allowKeyboardRefocus) && (FOLLOWMOUSE != 4 || m_pLastMouseFocus != pFoundWindow)) || refocus) {
                 m_pLastMouseFocus = pFoundWindow;
                 g_pCompositor->focusWindow(pFoundWindow, foundSurface);
             }

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -175,6 +175,9 @@ class CInputManager {
     // for hiding cursor on touch
     bool m_bLastInputTouch = false;
 
+    // for follow mouse 4
+    CWindow* m_pLastMouseFocus = nullptr;
+
   private:
     bool                 m_bCursorImageOverridden = false;
     eBorderIconDirection m_eBorderIconDirection   = BORDERICON_NONE;

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -175,7 +175,7 @@ class CInputManager {
     // for hiding cursor on touch
     bool m_bLastInputTouch = false;
 
-    // for follow mouse 4
+    // for tracking mouse refocus
     CWindow* m_pLastMouseFocus = nullptr;
 
   private:


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This PR adds a new follow_mouse mode (4), that is the same as 1 (focus follows mouse) except it requires crossing a window border to re-focus the hovered window. I find it useful because my window focus won't change if my mouse gets bumped.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I'm fairly sure adding `m_pLastMouseFocus` at the end of `CInputManager` keeps the plugin abi the same as long as it wasn't accessing private fields, but I'm also fairly sure thats not a concern anyway.


#### Is it ready for merging, or does it need work?
Ready to merge.

