### PR TITLE
Fix -Wfortify-source on BSDs

### DIFF
--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -80,7 +80,7 @@ void              request(std::string arg, int minArgs = 0) {
 
     std::string socketPath = "/tmp/hypr/" + instanceSigStr + "/.socket.sock";
 
-    strncpy(serverAddress.sun_path, socketPath.c_str(), 107);
+    strncpy(serverAddress.sun_path, socketPath.c_str(), sizeof(serverAddress.sun_path) - 1);
 
     if (connect(SERVERSOCKET, (sockaddr*)&serverAddress, SUN_LEN(&serverAddress)) < 0) {
         std::cout << "Couldn't connect to " << socketPath << ". (3)";
@@ -143,7 +143,7 @@ void requestHyprpaper(std::string arg) {
 
     std::string socketPath = "/tmp/hypr/" + instanceSigStr + "/.hyprpaper.sock";
 
-    strncpy(serverAddress.sun_path, socketPath.c_str(), 107);
+    strncpy(serverAddress.sun_path, socketPath.c_str(), sizeof(serverAddress.sun_path) - 1);
 
     if (connect(SERVERSOCKET, (sockaddr*)&serverAddress, SUN_LEN(&serverAddress)) < 0) {
         std::cout << "Couldn't connect to " << socketPath << ". (3)";

--- a/src/managers/EventManager.cpp
+++ b/src/managers/EventManager.cpp
@@ -67,7 +67,7 @@ void CEventManager::startThread() {
 
         sockaddr_un SERVERADDRESS = {.sun_family = AF_UNIX};
         std::string socketPath    = "/tmp/hypr/" + g_pCompositor->m_szInstanceSignature + "/.socket2.sock";
-        strncpy(SERVERADDRESS.sun_path, socketPath.c_str(), 107);
+        strncpy(SERVERADDRESS.sun_path, socketPath.c_str(), sizeof(SERVERADDRESS.sun_path) - 1);
 
         bind(SOCKET, (sockaddr*)&SERVERADDRESS, SUN_LEN(&SERVERADDRESS));
 


### PR DESCRIPTION
Fixes #2136. This could use [strlcpy(3)](https://man.freebsd.org/strlcpy/3) but it's [missing in glibc](https://sourceware.org/bugzilla/show_bug.cgi?id=178) unlike musl or bionic.