### PR TITLE
Fixed a crash when waking up monitors in power-saving mode

### DIFF
--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -82,13 +82,19 @@ void CAnimationManager::tick() {
         if (PWINDOW) {
             WLRBOXPREV         = PWINDOW->getFullWindowBoundingBox();
             PMONITOR           = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID);
+            if (!PMONITOR)
+                continue;
             animationsDisabled = animationsDisabled || PWINDOW->m_sAdditionalConfigData.forceNoAnims;
         } else if (PWORKSPACE) {
             PMONITOR   = g_pCompositor->getMonitorFromID(PWORKSPACE->m_iMonitorID);
+            if (!PMONITOR)
+                continue;
             WLRBOXPREV = {(int)PMONITOR->vecPosition.x, (int)PMONITOR->vecPosition.y, (int)PMONITOR->vecSize.x, (int)PMONITOR->vecSize.y};
         } else if (PLAYER) {
             WLRBOXPREV = PLAYER->geometry;
             PMONITOR   = g_pCompositor->getMonitorFromVector(Vector2D(PLAYER->geometry.x, PLAYER->geometry.y) + Vector2D(PLAYER->geometry.width, PLAYER->geometry.height) / 2.f);
+            if (!PMONITOR)
+                continue;
             animationsDisabled = animationsDisabled || PLAYER->noAnimations;
         }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
When waking up my monitors with dpms on after they powered down into power-saving mode, hyprland would crash in the animation manager.  I don't know what specifically in my setup causes it (one monitor takes longer to power on, 3 monitors, etc.), but this lets it wake without crashing.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
The workspaces get reordered all incorrectly when waking up (they are all bound to a specific monitor), but for now I can just fix it with a dispatch script.  If there's another way you want it fixed, or more information, let me know.

#### Is it ready for merging, or does it need work?
Ready

