### PR TITLE
Window resizing for pseudotiled windows

### DIFF
--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -46,6 +46,7 @@ class CHyprDwindleLayout : public IHyprLayout {
     virtual bool                     isWindowTiled(CWindow*);
     virtual void                     recalculateMonitor(const int&);
     virtual void                     recalculateWindow(CWindow*);
+    virtual void                     onBeginDragWindow();
     virtual void                     resizeActiveWindow(const Vector2D&, CWindow* pWindow = nullptr);
     virtual void                     fullscreenRequestForWindow(CWindow*, eFullscreenMode, bool);
     virtual std::any                 layoutMessage(SLayoutMessageHeader, std::string);
@@ -61,13 +62,20 @@ class CHyprDwindleLayout : public IHyprLayout {
   private:
     std::list<SDwindleNodeData> m_lDwindleNodesData;
 
-    int                         getNodesOnWorkspace(const int&);
-    void                        applyNodeDataToWindow(SDwindleNodeData*, bool force = false);
-    SDwindleNodeData*           getNodeFromWindow(CWindow*);
-    SDwindleNodeData*           getFirstNodeOnWorkspace(const int&);
-    SDwindleNodeData*           getMasterNodeOnWorkspace(const int&);
+    struct {
+        bool started = false;
+        bool pseudo  = false;
+        bool xExtent = false;
+        bool yExtent = false;
+    } m_PseudoDragFlags;
 
-    void                        toggleSplit(CWindow*);
+    int               getNodesOnWorkspace(const int&);
+    void              applyNodeDataToWindow(SDwindleNodeData*, bool force = false);
+    SDwindleNodeData* getNodeFromWindow(CWindow*);
+    SDwindleNodeData* getFirstNodeOnWorkspace(const int&);
+    SDwindleNodeData* getMasterNodeOnWorkspace(const int&);
+
+    void              toggleSplit(CWindow*);
 
     friend struct SDwindleNodeData;
 };


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds resize support to pseudotiled windows. When resizing outside of the window the pseudotiled space is resized, but when resizing inside of the window, the window itself is resized. If the pseudotiled window has a floating size bigger than its pseudotiled area then its floating size is set to the visible pseudotiled size.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Not sure if you use nested structs at all, haven't seen any in hyprland so far. I used one here.

A lot of code is duplicated from `applyNodeDataToWindow`, this could probably be done better.

#### Is it ready for merging, or does it need work?
Yes if the above is not a concern.
