### PR TITLE
Declarative plugin management

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -402,6 +402,7 @@ void CCompositor::initManagers(eManagersInitStage stage) {
 
             Debug::log(LOG, "Creating the PluginSystem!");
             g_pPluginSystem = std::make_unique<CPluginSystem>();
+            g_pConfigManager->handlePluginLoads();
         } break;
         default: UNREACHABLE();
     }

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1107,7 +1107,7 @@ void CConfigManager::handleEnv(const std::string& command, const std::string& va
 
 void CConfigManager::handlePlugin(const std::string& command, const std::string& path) {
     if (std::find(m_vDeclaredPlugins.begin(), m_vDeclaredPlugins.end(), path) != m_vDeclaredPlugins.end()) {
-        parseError = "plugin declared twice";
+        parseError = "plugin '" + path + "' declared twice";
         return;
     }
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1974,14 +1974,14 @@ void CConfigManager::handlePluginLoads() {
         return;
 
     bool pluginsChanged = false;
-    auto failedPlugins = g_pPluginSystem->updateConfigPlugins(m_vDeclaredPlugins, pluginsChanged);
+    auto failedPlugins  = g_pPluginSystem->updateConfigPlugins(m_vDeclaredPlugins, pluginsChanged);
 
     if (!failedPlugins.empty()) {
         std::stringstream error;
         error << "Failed to load the following plugins:";
 
         for (auto path : failedPlugins) {
-            error << "\n" << *path;
+            error << "\n" << path;
         }
 
         g_pHyprError->queueCreate(error.str(), CColor(1.0, 50.0 / 255.0, 50.0 / 255.0, 1.0));

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1105,6 +1105,15 @@ void CConfigManager::handleEnv(const std::string& command, const std::string& va
     }
 }
 
+void CConfigManager::handlePlugin(const std::string& command, const std::string& path) {
+    if (std::find(m_vDeclaredPlugins.begin(), m_vDeclaredPlugins.end(), path) != m_vDeclaredPlugins.end()) {
+        parseError = "plugin declared twice";
+        return;
+    }
+
+    m_vDeclaredPlugins.push_back(path);
+}
+
 std::string CConfigManager::parseKeyword(const std::string& COMMAND, const std::string& VALUE, bool dynamic) {
     if (dynamic) {
         parseError      = "";
@@ -1151,6 +1160,8 @@ std::string CConfigManager::parseKeyword(const std::string& COMMAND, const std::
         handleBindWS(COMMAND, VALUE);
     else if (COMMAND.find("env") == 0)
         handleEnv(COMMAND, VALUE);
+    else if (COMMAND.find("plugin") == 0)
+        handlePlugin(COMMAND, VALUE);
     else {
         configSetValueSafe(currentCategory + (currentCategory == "" ? "" : ":") + COMMAND, VALUE);
         needsLayoutRecalc = 2;
@@ -1303,6 +1314,7 @@ void CConfigManager::loadConfigLoadVars() {
     m_dBlurLSNamespaces.clear();
     boundWorkspaces.clear();
     setDefaultAnimationVars(); // reset anims
+    m_vDeclaredPlugins.clear();
 
     // paths
     configPaths.clear();
@@ -1441,6 +1453,9 @@ void CConfigManager::loadConfigLoadVars() {
 
     // Reset no monitor reload
     m_bNoMonitorReload = false;
+
+    // update plugins
+    handlePluginLoads();
 }
 
 void CConfigManager::tick() {
@@ -1952,6 +1967,31 @@ std::string CConfigManager::getBoundMonitorStringForWS(const std::string& wsname
 
 void CConfigManager::addExecRule(const SExecRequestedRule& rule) {
     execRequestedRules.push_back(rule);
+}
+
+void CConfigManager::handlePluginLoads() {
+    if (g_pPluginSystem == nullptr)
+        return;
+
+    bool pluginsChanged = false;
+    auto failedPlugins = g_pPluginSystem->updateConfigPlugins(m_vDeclaredPlugins, pluginsChanged);
+
+    if (!failedPlugins.empty()) {
+        std::stringstream error;
+        error << "Failed to load the following plugins:";
+
+        for (auto path : failedPlugins) {
+            error << "\n" << *path;
+        }
+
+        g_pHyprError->queueCreate(error.str(), CColor(1.0, 50.0 / 255.0, 50.0 / 255.0, 1.0));
+    }
+
+    if (pluginsChanged) {
+        g_pHyprError->destroy();
+        m_bForceReload = true;
+        tick();
+    }
 }
 
 ICustomConfigValueData::~ICustomConfigValueData() {

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -182,6 +182,8 @@ class CConfigManager {
 
     void                      addExecRule(const SExecRequestedRule&);
 
+    void                      handlePluginLoads();
+
     std::string               configCurrentPath;
 
   private:
@@ -203,6 +205,7 @@ class CConfigManager {
 
     std::vector<SExecRequestedRule>                                                            execRequestedRules; // rules requested with exec, e.g. [workspace 2] kitty
 
+    std::vector<std::string>                                                                   m_vDeclaredPlugins;
     std::unordered_map<HANDLE, std::unique_ptr<std::unordered_map<std::string, SConfigValue>>> pluginConfigs; // stores plugin configs
 
     bool                                                                                       isFirstLaunch = true; // For exec-once
@@ -250,6 +253,7 @@ class CConfigManager {
     void         handleBlurLS(const std::string&, const std::string&);
     void         handleBindWS(const std::string&, const std::string&);
     void         handleEnv(const std::string&, const std::string&);
+    void         handlePlugin(const std::string&, const std::string&);
 };
 
 inline std::unique_ptr<CConfigManager> g_pConfigManager;

--- a/src/hyprerror/HyprError.cpp
+++ b/src/hyprerror/HyprError.cpp
@@ -33,7 +33,6 @@ void CHyprError::queueCreate(std::string message, const CColor& color) {
 
 void CHyprError::createQueued() {
     if (m_bIsCreated) {
-        m_bQueuedDestroy = false;
         m_tTexture.destroyTexture();
     }
 
@@ -171,4 +170,6 @@ void CHyprError::draw() {
 void CHyprError::destroy() {
     if (m_bIsCreated)
         m_bQueuedDestroy = true;
+    else
+        m_szQueued = "";
 }

--- a/src/plugins/PluginSystem.cpp
+++ b/src/plugins/PluginSystem.cpp
@@ -119,6 +119,35 @@ void CPluginSystem::unloadAllPlugins() {
         unloadPlugin(p.get(), false); // Unload remaining plugins gracefully
 }
 
+std::vector<std::string*> CPluginSystem::updateConfigPlugins(const std::vector<std::string>& plugins, bool& changed) {
+    std::vector<std::string*> failures;
+
+    // unload all plugins that are no longer present
+    for (auto& p : m_vLoadedPlugins | std::views::reverse) {
+        if (p->m_bLoadedWithConfig && std::find(plugins.begin(), plugins.end(), p->path) == plugins.end()) {
+            Debug::log(LOG, "Unloading plugin %s which is no longer present in config", p->path.c_str());
+            unloadPlugin(p.get(), false);
+            changed = true;
+        }
+    }
+
+    // load all new plugins
+    for (auto& path : plugins) {
+        if (std::find_if(m_vLoadedPlugins.begin(), m_vLoadedPlugins.end(), [&](const auto& other) { return other->path == path; }) == m_vLoadedPlugins.end()) {
+            Debug::log(LOG, "Loading plugin %s which is now present in config", path.c_str());
+            const auto plugin = loadPlugin(path);
+
+            if (plugin) {
+                plugin->m_bLoadedWithConfig = true;
+                changed                     = true;
+            } else
+                failures.push_back((std::string*)&path);
+        }
+    }
+
+    return failures;
+}
+
 CPlugin* CPluginSystem::getPluginByPath(const std::string& path) {
     for (auto& p : m_vLoadedPlugins) {
         if (p->path == path)

--- a/src/plugins/PluginSystem.cpp
+++ b/src/plugins/PluginSystem.cpp
@@ -119,8 +119,8 @@ void CPluginSystem::unloadAllPlugins() {
         unloadPlugin(p.get(), false); // Unload remaining plugins gracefully
 }
 
-std::vector<std::string*> CPluginSystem::updateConfigPlugins(const std::vector<std::string>& plugins, bool& changed) {
-    std::vector<std::string*> failures;
+std::vector<std::string> CPluginSystem::updateConfigPlugins(const std::vector<std::string>& plugins, bool& changed) {
+    std::vector<std::string> failures;
 
     // unload all plugins that are no longer present
     for (auto& p : m_vLoadedPlugins | std::views::reverse) {
@@ -141,7 +141,7 @@ std::vector<std::string*> CPluginSystem::updateConfigPlugins(const std::vector<s
                 plugin->m_bLoadedWithConfig = true;
                 changed                     = true;
             } else
-                failures.push_back((std::string*)&path);
+                failures.push_back(path);
         }
     }
 

--- a/src/plugins/PluginSystem.hpp
+++ b/src/plugins/PluginSystem.hpp
@@ -29,15 +29,15 @@ class CPluginSystem {
   public:
     CPluginSystem();
 
-    CPlugin*                  loadPlugin(const std::string& path);
-    void                      unloadPlugin(const CPlugin* plugin, bool eject = false);
-    void                      unloadAllPlugins();
-    std::vector<std::string*> updateConfigPlugins(const std::vector<std::string>& plugins, bool& changed);
-    CPlugin*                  getPluginByPath(const std::string& path);
-    CPlugin*                  getPluginByHandle(HANDLE handle);
-    std::vector<CPlugin*>     getAllPlugins();
+    CPlugin*                 loadPlugin(const std::string& path);
+    void                     unloadPlugin(const CPlugin* plugin, bool eject = false);
+    void                     unloadAllPlugins();
+    std::vector<std::string> updateConfigPlugins(const std::vector<std::string>& plugins, bool& changed);
+    CPlugin*                 getPluginByPath(const std::string& path);
+    CPlugin*                 getPluginByHandle(HANDLE handle);
+    std::vector<CPlugin*>    getAllPlugins();
 
-    bool                      m_bAllowConfigVars = false;
+    bool                     m_bAllowConfigVars = false;
 
   private:
     std::vector<std::unique_ptr<CPlugin>> m_vLoadedPlugins;

--- a/src/plugins/PluginSystem.hpp
+++ b/src/plugins/PluginSystem.hpp
@@ -15,6 +15,8 @@ class CPlugin {
 
     std::string                                            path = "";
 
+    bool                                                   m_bLoadedWithConfig = false;
+
     HANDLE                                                 m_pHandle = nullptr;
 
     std::vector<IHyprLayout*>                              registeredLayouts;
@@ -27,14 +29,15 @@ class CPluginSystem {
   public:
     CPluginSystem();
 
-    CPlugin*              loadPlugin(const std::string& path);
-    void                  unloadPlugin(const CPlugin* plugin, bool eject = false);
-    void                  unloadAllPlugins();
-    CPlugin*              getPluginByPath(const std::string& path);
-    CPlugin*              getPluginByHandle(HANDLE handle);
-    std::vector<CPlugin*> getAllPlugins();
+    CPlugin*                  loadPlugin(const std::string& path);
+    void                      unloadPlugin(const CPlugin* plugin, bool eject = false);
+    void                      unloadAllPlugins();
+    std::vector<std::string*> updateConfigPlugins(const std::vector<std::string>& plugins, bool& changed);
+    CPlugin*                  getPluginByPath(const std::string& path);
+    CPlugin*                  getPluginByHandle(HANDLE handle);
+    std::vector<CPlugin*>     getAllPlugins();
 
-    bool                  m_bAllowConfigVars = false;
+    bool                      m_bAllowConfigVars = false;
 
   private:
     std::vector<std::unique_ptr<CPlugin>> m_vLoadedPlugins;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Allows declaring `plugin` entries in the hyprland configuration.
Plugins will be loaded if an entry is added and unloaded if that entry is removed.

Example:
Loading hyprland with
```
plugin = /absolute/path1.so
```
will load the plugin at that path. Removing the entry from the configuration will unload the plugin.
Adding an entry while hyprland is running will cause it to load the plugin.

This is useful for having a nicer config, and decoratively loading plugins.

Nixos example:

You update your system and your hyprland plugin rebuilds. It now has a different path due to the hash of the plugin's sources. After your update your configuration now looks like this

```diff
 # ...
-plugin = /nix/store/jy7lsy0xzyxpkyydk6biql6gpcsg3xh9-hy3-0.1/lib/libhy3.so
+plugin = /nix/store/38a2886e42a9bc982006f6607a983xh9-hy3-0.1/lib/libhy3.so
 # ...
```

Hyprland notices the change and first unloads the old plugin version. then loads the new one.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Yes, I'll write the wiki pr shortly.
