### PR TITLE
cmake: sync pkg-config --cflags with meson

### DIFF
--- a/hyprland.pc.in
+++ b/hyprland.pc.in
@@ -5,4 +5,4 @@ Name: Hyprland
 URL: https://github.com/hyprwm/Hyprland
 Description: Hyprland header files
 Version: @HYPRLAND_VERSION@
-Cflags: -I"${includedir}/hyprland" -I"${includedir}/hyprland/protocols"
+Cflags: -I"${includedir}" -I"${includedir}/hyprland/protocols"


### PR DESCRIPTION
```
$ git clone https://github.com/hyprwm/hyprland-plugins
$ meson setup /tmp/hyprbars_build hyprland-plugins/hyprbars
$ meson compile -C /tmp/hyprbars_build
c++ -Ilibhyprbars.so.p -I. -Ihyprland-plugins/hyprbars -I/usr/local/include -I/usr/local/include/hyprland/protocols -I/usr/local/include/pixman-1 -I/usr/local/include/libdrm -fcolor-diagnostics -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -O3 -std=c++2b -fPIC -MD -MQ libhyprbars.so.p/main.cpp.o -MF libhyprbars.so.p/main.cpp.o.d -o libhyprbars.so.p/main.cpp.o -c hyprland-plugins/hyprbars/main.cpp
hyprland-plugins/hyprbars/main.cpp:6:10: fatal error: 'src/Compositor.hpp' file not found
#include <src/Compositor.hpp>
         ^~~~~~~~~~~~~~~~~~~~
1 error generated.
```
