### PR TITLE
Keep fullscreen mode in moveWindowToWorkspaceSafe

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2348,7 +2348,8 @@ void CCompositor::moveWindowToWorkspaceSafe(CWindow* pWindow, CWorkspace* pWorks
     if (!pWindow || !pWorkspace)
         return;
 
-    const bool FULLSCREEN = pWindow->m_bIsFullscreen;
+    const bool FULLSCREEN     = pWindow->m_bIsFullscreen;
+    const auto FULLSCREENMODE = getWorkspaceByID(pWindow->m_iWorkspaceID)->m_efFullscreenMode;
 
     if (FULLSCREEN)
         setWindowFullscreen(pWindow, false, FULLSCREEN_FULL);
@@ -2374,5 +2375,5 @@ void CCompositor::moveWindowToWorkspaceSafe(CWindow* pWindow, CWorkspace* pWorks
     }
 
     if (FULLSCREEN)
-        setWindowFullscreen(pWindow, true, FULLSCREEN_FULL);
+        setWindowFullscreen(pWindow, true, FULLSCREENMODE);
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Moving a maximized window would always result in the window being fullscreen instead of maximized. This PR keeps the fullscreen mode when transitioning

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
CWindow doesn't track fullscreen mode, so the mode of the original workspace of the window is used instead. Since only one window per workspace can be fullscreen, this should be fine.

Assumes, that CWindow::m_iWorkspaceID is always valid(Is this a correct assumption?).

#### Is it ready for merging, or does it need work?
Ready