### PR TITLE
Honor debug:enable_stdout_logs on startup

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -248,9 +248,6 @@ void CCompositor::initServer() {
     wlr_multi_backend_add(m_sWLRBackend, m_sWLRHeadlessBackend);
 
     initManagers(STAGE_LATE);
-
-    Debug::log(LOG, "Disabling stdout logs! Check the log for further logs.");
-    Debug::disableStdout = true;
 }
 
 void CCompositor::initAllSignals() {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1430,6 +1430,8 @@ void CConfigManager::loadConfigLoadVars() {
     }
 
     Debug::disableStdout = !configValues["debug:enable_stdout_logs"].intValue;
+    if (Debug::disableStdout)
+        Debug::log(LOG, "Disabling stdout logs! Check the log for further logs.");
 
     for (auto& m : g_pCompositor->m_vMonitors) {
         // mark blur dirty


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
disableStdout is set via config in CConfigManager::init(), which is called early in CCompositor::initServer(). initServer() always disables stdout logs at the end though, even when stdout is enabled is config. With this commit, the config is respected.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
When debug:enable_stdout_logs=0, then nothing from CCompositor::initServer() will be logged to stdout (which it previously did). I can reenable that  behaviour if you want.


#### Is it ready for merging, or does it need work?
Ready