### PR TITLE
Add "next on monitor or empty" workspace parameter

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2025,8 +2025,8 @@ std::string CConfigManager::getBoundMonitorStringForWS(const std::string& wsname
     return "";
 }
 
-const std::vector<std::pair<std::string, std::string>>& CConfigManager::getAllBoundWorkspaces() {
-    return boundWorkspaces;
+const std::deque<SWorkspaceRule>& CConfigManager::getAllWorkspaceRules() {
+    return m_dWorkspaceRules;
 }
 
 void CConfigManager::addExecRule(const SExecRequestedRule& rule) {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2025,6 +2025,10 @@ std::string CConfigManager::getBoundMonitorStringForWS(const std::string& wsname
     return "";
 }
 
+const std::vector<std::pair<std::string, std::string>>& CConfigManager::getAllBoundWorkspaces() {
+    return boundWorkspaces;
+}
+
 void CConfigManager::addExecRule(const SExecRequestedRule& rule) {
     execRequestedRules.push_back(rule);
 }

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -169,6 +169,7 @@ class CConfigManager {
 
     CMonitor*                                                       getBoundMonitorForWS(const std::string&);
     std::string                                                     getBoundMonitorStringForWS(const std::string&);
+    const std::vector<std::pair<std::string, std::string>>&         getAllBoundWorkspaces();
 
     std::vector<SWindowRule>                                        getMatchingRules(CWindow*);
     std::vector<SLayerRule>                                         getMatchingRules(SLayerSurface*);

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -169,7 +169,7 @@ class CConfigManager {
 
     CMonitor*                                                       getBoundMonitorForWS(const std::string&);
     std::string                                                     getBoundMonitorStringForWS(const std::string&);
-    const std::vector<std::pair<std::string, std::string>>&         getAllBoundWorkspaces();
+    const std::deque<SWorkspaceRule>&                               getAllWorkspaceRules();
 
     std::vector<SWindowRule>                                        getMatchingRules(CWindow*);
     std::vector<SLayerRule>                                         getMatchingRules(SLayerSurface*);

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -389,6 +389,8 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
             const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(result);
             if (PWORKSPACE)
                 outName = g_pCompositor->getWorkspaceByID(result)->m_szName;
+            else
+                outName = std::to_string(finalWSID);
 
         } else if ((in[0] == 'm' || in[0] == 'e') && (in[1] == '-' || in[1] == '+') && isNumber(in.substr(2))) {
             bool onAllMonitors = in[0] == 'e';

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -335,28 +335,66 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
                 invalidWSes.insert(rule.workspaceId);
             }
 
+            // Prepare all named workspaces in case when we need them
+            std::vector<int> namedWSes;
+            for (auto& ws : g_pCompositor->m_vWorkspaces) {
+                if (ws->m_bIsSpecialWorkspace || (ws->m_iMonitorID != g_pCompositor->m_pLastMonitor->ID) || ws->m_iID >= 0)
+                    continue;
+
+                namedWSes.push_back(ws->m_iID);
+            }
+            std::sort(namedWSes.begin(), namedWSes.end());
+
             // Just take a blind guess at where we'll probably end up
             int  predictedWSID = g_pCompositor->m_pLastMonitor->activeWorkspace + remains;
             int  remainingWSes = 0;
             char walkDir       = in[1];
-            if (predictedWSID <= 0) {
-                // We overshot, get first valid
-                predictedWSID = 0;
-                walkDir       = '+';
-                remainingWSes = 1;
-            } else {
-                // Count how many invalidWSes are in between (how bad the prediction was)
-                int  beginID = in[1] == '+' ? g_pCompositor->m_pLastMonitor->activeWorkspace + 1 : predictedWSID;
-                int  endID   = in[1] == '+' ? predictedWSID : g_pCompositor->m_pLastMonitor->activeWorkspace;
-                auto begin   = invalidWSes.upper_bound(beginID - 1); // upper_bound is >, we want >=
-                for (auto it = begin; *it <= endID && it != invalidWSes.end(); it++) {
-                    remainingWSes++;
+
+            // sanitize. 0 means invalid oob in -
+            predictedWSID = std::max(predictedWSID, 0);
+
+            // Count how many invalidWSes are in between (how bad the prediction was)
+            int  beginID = in[1] == '+' ? g_pCompositor->m_pLastMonitor->activeWorkspace + 1 : predictedWSID;
+            int  endID   = in[1] == '+' ? predictedWSID : g_pCompositor->m_pLastMonitor->activeWorkspace;
+            auto begin   = invalidWSes.upper_bound(beginID - 1); // upper_bound is >, we want >=
+            for (auto it = begin; *it <= endID && it != invalidWSes.end(); it++) {
+                remainingWSes++;
+            }
+
+            // Handle named workspaces. They are treated like always before other workspaces
+            if (g_pCompositor->m_pLastMonitor->activeWorkspace < 0) {
+                // Behaviour similar to 'm'
+                // Find current
+                int currentItem = -1;
+                for (size_t i = 0; i < namedWSes.size(); i++) {
+                    if (namedWSes[i] == g_pCompositor->m_pLastMonitor->activeWorkspace) {
+                        currentItem = i;
+                        break;
+                    }
+                }
+
+                currentItem += remains;
+                currentItem = std::max(currentItem, 0);
+                if (currentItem >= (int)namedWSes.size()) {
+                    // At the seam between namedWSes and normal WSes. Behave like r+[diff] at imaginary ws 0
+                    int diff      = currentItem - (namedWSes.size() - 1);
+                    predictedWSID = diff;
+                    int  beginID  = 1;
+                    int  endID    = predictedWSID;
+                    auto begin    = invalidWSes.upper_bound(beginID - 1); // upper_bound is >, we want >=
+                    for (auto it = begin; *it <= endID && it != invalidWSes.end(); it++) {
+                        remainingWSes++;
+                    }
+                    walkDir = '+';
+                } else {
+                    // We found our final ws.
+                    remainingWSes = 0;
+                    predictedWSID = namedWSes[currentItem];
                 }
             }
 
             // Go in the search direction for remainingWSes
-            // This takes at most 2 * invalidWSes.size() steps(A workspace cannot be both behind predictedWSID and after predictedWSID.
-            // This is because the loop takes at most ([number of invalidWSes between beginID and endID] + [number of invalidWSes after/before endID]) steps and it is potentially run twice)
+            // The performance impact is directly proportional to the number of open and bound workspaces
             int finalWSID = predictedWSID;
             if (walkDir == '-') {
                 int beginID = finalWSID;
@@ -367,12 +405,21 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
                     }
                     finalWSID = curID;
                 }
-                if (invalidWSes.find(finalWSID) != invalidWSes.end()) {
-                    // Couldn't find valid workspace in negative direction, search last first one back up positive direction
-                    walkDir = '+';
-                    // We know, that everything less than beginID is invalid, so don't bother with that
-                    finalWSID     = beginID;
-                    remainingWSes = 1;
+                if (finalWSID <= 0 || invalidWSes.find(finalWSID) != invalidWSes.end()) {
+                    if (namedWSes.size()) {
+                        // Go to the named workspaces
+                        // Need remainingWSes more
+                        int namedWSIdx = namedWSes.size() - remainingWSes;
+                        // Sanitze
+                        namedWSIdx = std::clamp(namedWSIdx, 0, (int)namedWSes.size() - 1);
+                        finalWSID  = namedWSes[namedWSIdx];
+                    } else {
+                        // Couldn't find valid workspace in negative direction, search last first one back up positive direction
+                        walkDir = '+';
+                        // We know, that everything less than beginID is invalid, so don't bother with that
+                        finalWSID     = beginID;
+                        remainingWSes = 1;
+                    }
                 }
             }
             if (walkDir == '+') {

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -325,18 +325,14 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
                     invalidWSes.insert(ws->m_iID);
                 }
             }
-            for (auto& [ws, mon] : g_pConfigManager->getAllBoundWorkspaces()) {
-                const auto PMONITOR = g_pCompositor->getMonitorFromString(mon);
+            for (auto& rule : g_pConfigManager->getAllWorkspaceRules()) {
+                const auto PMONITOR = g_pCompositor->getMonitorFromName(rule.monitor);
                 if (!PMONITOR || PMONITOR->ID == g_pCompositor->m_pLastMonitor->ID) {
                     // Can't be invalid
                     continue;
                 }
-                const auto WSNAME     = ws.find("name:") == 0 ? ws.substr(5) : ws;
-                const auto PWORKSPACE = g_pCompositor->getWorkspaceByName(WSNAME);
-                if (PWORKSPACE) {
-                    // WS is bound to another monitor, can't jump to this
-                    invalidWSes.insert(PWORKSPACE->m_iID);
-                }
+                // WS is bound to another monitor, can't jump to this
+                invalidWSes.insert(rule.workspaceId);
             }
 
             // Just take a blind guess at where we'll probably end up


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Implements the following workspace parameter:
r+x/r-x (i.e. r+1): Behaves similar to the "m" parameter, but can also select empty workspaces and it doesn't wrap around

Example behaviour (Status: x[0-9] -> current workspace on mon [0-9]; o[0-9] -> open workspace on mon [0-9]; e -> empty workspace): 
Initial workspaces: 
|ID | 1| 2| 3| 4 | 5|
|----|---|---|---|---|---|
|Status | o1 | x1 | e | x2 | e |

- with "workspace r+1" on monitor 1:

|ID | 1| 2| 3| 4 | 5 |
|----|---|---|---|---| --- |
|Status | o1 | o1 | x1 | x2 | e |

- with "workspace m+1" on monitor 1 (Notice the difference in "x1"):

|ID | 1| 2| 3| 4 | 5 |
|----|---|---|---|---| --- |
|Status | x1 | o1 | e | x2 | e |

- with "workspace r+2" on monitor 1:

|ID | 1| 2| 3| 4 | 5 |
|----|---|---|---|---|---|
|Status | o1 | o1 | e | o2 | x1 |



#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
The "next or empty" equivalent for "e" is not implemented, since that is the same as +x/-x

#### Is it ready for merging, or does it need work?
Ready. Although I already tested it with multiple scenarios, further testing would probably be good.


