### PR TITLE
Prefer bundled wlroots headers to system ones

### DIFF
--- a/hyprland.pc.in
+++ b/hyprland.pc.in
@@ -5,4 +5,4 @@ Name: Hyprland
 URL: https://github.com/hyprwm/Hyprland
 Description: Hyprland header files
 Version: @HYPRLAND_VERSION@
-Cflags: -I"${includedir}" -I"${includedir}/hyprland/protocols" -I"${includedir}/hyprland/wlroots"
+Cflags: -I"${includedir}/hyprland/protocols" -I"${includedir}/hyprland/wlroots" -I"${includedir}"


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

In the case that the prefix is `/usr`, system wlroots headers installed in `/usr/include/wlr` will be preferred over those bundled by hyprland as `-I` directories are searched [from left to right](https://gcc.gnu.org/onlinedocs/cpp/Search-Path.html), which is not great since the system wlroots headers might not be compatible with hyprland. Fix the order of cflags so bundled wlroots headers will be preferred over system ones.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Ready for merge.


