### PR TITLE
Unbreak CMake build on FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,8 @@ message(STATUS "Checking deps...")
 find_package(Threads REQUIRED)
 
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(deps REQUIRED IMPORTED_TARGET wayland-server wayland-client wayland-cursor wayland-protocols cairo libdrm egl xkbcommon libinput pango pangocairo) # we do not check for wlroots, as we provide it ourselves
+find_package(OpenGL REQUIRED)
+pkg_check_modules(deps REQUIRED IMPORTED_TARGET wayland-server wayland-client wayland-cursor wayland-protocols cairo libdrm xkbcommon libinput pango pangocairo pixman-1) # we do not check for wlroots, as we provide it ourselves
 
 file(GLOB_RECURSE SRCFILES CONFIGURE_DEPENDS "src/*.cpp")
 
@@ -117,8 +118,8 @@ if(NO_XWAYLAND)
     add_compile_definitions(NO_XWAYLAND)
 else()
     message(STATUS "XWAYLAND Enabled (NO_XWAYLAND not defined) checking deps...")
-    pkg_check_modules(xcbdep REQUIRED xcb)
-    target_link_libraries(Hyprland xcb)
+    pkg_check_modules(xcbdep REQUIRED IMPORTED_TARGET xcb)
+    target_link_libraries(Hyprland PkgConfig::xcbdep)
 endif()
 
 if(NO_SYSTEMD)
@@ -175,11 +176,9 @@ target_link_libraries(Hyprland PkgConfig::deps)
 
 target_link_libraries(Hyprland
         ${CMAKE_SOURCE_DIR}/subprojects/wlroots/build/libwlroots.so.12032 # wlroots is provided by us
-        pixman-1
-        OpenGL
-        GLESv2
-        pthread
-        ${CMAKE_THREAD_LIBS_INIT}
+        OpenGL::EGL
+        OpenGL::GL
+        Threads::Threads
         ${CMAKE_SOURCE_DIR}/subprojects/udis86/build/libudis86/liblibudis86.a
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ endif()
 include(CheckLibraryExists)
 check_library_exists(execinfo backtrace "" HAVE_LIBEXECINFO)
 if(HAVE_LIBEXECINFO)
-    target_link_libraries(Hyprland PRIVATE execinfo)
+    target_link_libraries(Hyprland execinfo)
 endif()
 
 if(LEGACY_RENDERER)

--- a/Makefile
+++ b/Makefile
@@ -23,20 +23,20 @@ clear:
 	rm -rf ./subprojects/wlroots/build
 
 all:
-	make clear
-	make fixwlr
+	$(MAKE) clear
+	$(MAKE) fixwlr
 	cd ./subprojects/wlroots && meson setup build/ --buildtype=release && ninja -C build/ && cp ./build/libwlroots.so.12032 ${PREFIX}/lib/ || echo "Could not install libwlroots to ${PREFIX}/lib/libwlroots.so.12032"
 	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B./build -G Ninja && cmake --build ./build --config Release --target all -j$(shell nproc)
-	make release
-	make -C hyprctl all
+	$(MAKE) release
+	$(MAKE) -C hyprctl all
 
 install:
-	make clear
-	make fixwlr
+	$(MAKE) clear
+	$(MAKE) fixwlr
 	cd ./subprojects/wlroots && meson setup build/ --buildtype=release && ninja -C build/ && cp ./build/libwlroots.so.12032 ${PREFIX}/lib/ || echo "Could not install libwlroots to ${PREFIX}/lib/libwlroots.so.12032"
 	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B./build -G Ninja && cmake --build ./build --config Release --target all -j$(shell nproc) && cd ../..
-	make release
-	make -C hyprctl all
+	$(MAKE) release
+	$(MAKE) -C hyprctl all
 
 	mkdir -p ${PREFIX}/share/wayland-sessions
 	mkdir -p ${PREFIX}/bin
@@ -62,8 +62,8 @@ install:
 	cp ./build/hyprland.pc /usr/share/pkgconfig
 
 cleaninstall:
-	echo -en "make cleaninstall has been DEPRECATED, you should avoid using it in the future.\nRunning make install instead...\n"
-	make install
+	echo -en "$(MAKE) cleaninstall has been DEPRECATED, you should avoid using it in the future.\nRunning $(MAKE) install instead...\n"
+	$(MAKE) install
 
 uninstall:
 	rm -f ${PREFIX}/share/wayland-sessions/hyprland.desktop
@@ -80,7 +80,7 @@ fixwlr:
 	rm -rf ./subprojects/wlroots/build
 
 config:
-	make fixwlr
+	$(MAKE) fixwlr
 
 	meson setup subprojects/wlroots/build subprojects/wlroots --prefix=${PREFIX} --buildtype=release -Dwerror=false -Dexamples=false
 	ninja -C subprojects/wlroots/build/
@@ -92,7 +92,7 @@ config:
 pluginenv:
 	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B ./build -G Ninja && cmake --build ./build --config Release --target all -j$(shell nproc)
 
-	make fixwlr
+	$(MAKE) fixwlr
 
 	meson setup subprojects/wlroots/build subprojects/wlroots --prefix=${PREFIX} --buildtype=release -Dwerror=false -Dexamples=false
 	ninja -C subprojects/wlroots/build/
@@ -111,7 +111,7 @@ pluginenv:
 	cp ./build/hyprland.pc /usr/share/pkgconfig
 
 configdebug:
-	make fixwlr
+	$(MAKE) fixwlr
 
 	meson setup subprojects/wlroots/build subprojects/wlroots --prefix=${PREFIX} --buildtype=debug -Dwerror=false -Dexamples=false -Db_sanitize=address
 	ninja -C subprojects/wlroots/build/

--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,8 @@ install:
 	mkdir -p ${PREFIX}/include/hyprland/wlroots
 	mkdir -p ${PREFIX}/share/pkgconfig
 	
-	find src -name '*.h*' -exec cp --parents '{}' ${PREFIX}/include/hyprland ';'
-	cd subprojects/wlroots/include && find . -name '*.h*' -exec cp --parents '{}' ${PREFIX}/include/hyprland/wlroots ';' && cd ../../..
+	find src -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland
+	cd subprojects/wlroots/include && find . -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland/wlroots && cd ../../..
 	cp ./protocols/*-protocol.h ${PREFIX}/include/hyprland/protocols
 	cp ./build/hyprland.pc ${PREFIX}/share/pkgconfig
 	cp ./build/hyprland.pc /usr/share/pkgconfig
@@ -105,8 +105,8 @@ pluginenv:
 	mkdir -p ${PREFIX}/include/hyprland/wlroots
 	mkdir -p ${PREFIX}/share/pkgconfig
 	
-	find src -name '*.h*' -exec cp --parents '{}' ${PREFIX}/include/hyprland ';'
-	cd subprojects/wlroots/include && find . -name '*.h*' -exec cp --parents '{}' ${PREFIX}/include/hyprland/wlroots ';' && cd ../../..
+	find src -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland
+	cd subprojects/wlroots/include && find . -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland/wlroots && cd ../../..
 	cp ./protocols/*-protocol.h ${PREFIX}/include/hyprland/protocols
 	cp ./build/hyprland.pc ${PREFIX}/share/pkgconfig
 	cp ./build/hyprland.pc /usr/share/pkgconfig

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ uninstall:
 	rm -f ${PREFIX}/share/man/man1/hyprctl.1
 
 fixwlr:
-	sed -i -E 's/(soversion = 12)([^032]|$$)/soversion = 12032/g' subprojects/wlroots/meson.build
+	sed -E -i -e 's/(soversion = 12)([^032]|$$)/soversion = 12032/g' subprojects/wlroots/meson.build
 
 	rm -rf ./subprojects/wlroots/build
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,8 @@ install:
 	cp ./assets/wall_4K.png ${PREFIX}/share/hyprland
 	cp ./assets/wall_8K.png ${PREFIX}/share/hyprland
 
-	install -Dm644 -t ${PREFIX}/share/man/man1 ./docs/*.1
+	mkdir -p ${PREFIX}/share/man/man1
+	install -m644 ./docs/*.1 ${PREFIX}/share/man/man1
 
 	mkdir -p ${PREFIX}/include/hyprland
 	mkdir -p ${PREFIX}/include/hyprland/protocols

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ install:
 
 	mkdir -p ${PREFIX}/share/wayland-sessions
 	mkdir -p ${PREFIX}/bin
-	cp ./build/Hyprland ${PREFIX}/bin -f
-	cp ./hyprctl/hyprctl ${PREFIX}/bin -f
+	cp -f ./build/Hyprland ${PREFIX}/bin
+	cp -f ./hyprctl/hyprctl ${PREFIX}/bin
 	if [ ! -f ${PREFIX}/share/wayland-sessions/hyprland.desktop ]; then cp ./example/hyprland.desktop ${PREFIX}/share/wayland-sessions; fi
 	mkdir -p ${PREFIX}/share/hyprland
 	cp ./assets/wall_2K.png ${PREFIX}/share/hyprland

--- a/Makefile
+++ b/Makefile
@@ -2,19 +2,19 @@ PREFIX = /usr/local
 
 legacyrenderer:
 	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DLEGACY_RENDERER:BOOL=true -S . -B ./build -G Ninja
-	cmake --build ./build --config Release --target all -j$(shell nproc)
+	cmake --build ./build --config Release --target all -j`nproc`
 
 legacyrendererdebug:
 	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -DLEGACY_RENDERER:BOOL=true -S . -B ./build -G Ninja
-	cmake --build ./build --config Release --target all -j$(shell nproc)
+	cmake --build ./build --config Release --target all -j`nproc`
 
 release:
 	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B ./build -G Ninja
-	cmake --build ./build --config Release --target all -j$(shell nproc)
+	cmake --build ./build --config Release --target all -j`nproc`
 
 debug:
 	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -S . -B ./build -G Ninja
-	cmake --build ./build --config Debug --target all -j$(shell nproc)
+	cmake --build ./build --config Debug --target all -j`nproc`
 
 clear:
 	rm -rf build
@@ -26,7 +26,7 @@ all:
 	$(MAKE) clear
 	$(MAKE) fixwlr
 	cd ./subprojects/wlroots && meson setup build/ --buildtype=release && ninja -C build/ && cp ./build/libwlroots.so.12032 ${PREFIX}/lib/ || echo "Could not install libwlroots to ${PREFIX}/lib/libwlroots.so.12032"
-	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B./build -G Ninja && cmake --build ./build --config Release --target all -j$(shell nproc)
+	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B./build -G Ninja && cmake --build ./build --config Release --target all -j`nproc`
 	$(MAKE) release
 	$(MAKE) -C hyprctl all
 
@@ -34,7 +34,7 @@ install:
 	$(MAKE) clear
 	$(MAKE) fixwlr
 	cd ./subprojects/wlroots && meson setup build/ --buildtype=release && ninja -C build/ && cp ./build/libwlroots.so.12032 ${PREFIX}/lib/ || echo "Could not install libwlroots to ${PREFIX}/lib/libwlroots.so.12032"
-	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B./build -G Ninja && cmake --build ./build --config Release --target all -j$(shell nproc) && cd ../..
+	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B./build -G Ninja && cmake --build ./build --config Release --target all -j`nproc` && cd ../..
 	$(MAKE) release
 	$(MAKE) -C hyprctl all
 
@@ -87,10 +87,10 @@ config:
 
 	ninja -C subprojects/wlroots/build/ install
 
-	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B ./build -G Ninja && cmake --build ./build --config Release --target all -j$(shell nproc)
+	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B ./build -G Ninja && cmake --build ./build --config Release --target all -j`nproc`
 
 pluginenv:
-	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B ./build -G Ninja && cmake --build ./build --config Release --target all -j$(shell nproc)
+	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B ./build -G Ninja && cmake --build ./build --config Release --target all -j`nproc`
 
 	$(MAKE) fixwlr
 

--- a/Makefile
+++ b/Makefile
@@ -2,19 +2,19 @@ PREFIX = /usr/local
 
 legacyrenderer:
 	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DLEGACY_RENDERER:BOOL=true -S . -B ./build -G Ninja
-	cmake --build ./build --config Release --target all -j`nproc`
+	cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
 legacyrendererdebug:
 	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -DLEGACY_RENDERER:BOOL=true -S . -B ./build -G Ninja
-	cmake --build ./build --config Release --target all -j`nproc`
+	cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
 release:
 	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B ./build -G Ninja
-	cmake --build ./build --config Release --target all -j`nproc`
+	cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
 debug:
 	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -S . -B ./build -G Ninja
-	cmake --build ./build --config Debug --target all -j`nproc`
+	cmake --build ./build --config Debug --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
 clear:
 	rm -rf build
@@ -26,7 +26,7 @@ all:
 	$(MAKE) clear
 	$(MAKE) fixwlr
 	cd ./subprojects/wlroots && meson setup build/ --buildtype=release && ninja -C build/ && cp ./build/libwlroots.so.12032 ${PREFIX}/lib/ || echo "Could not install libwlroots to ${PREFIX}/lib/libwlroots.so.12032"
-	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B./build -G Ninja && cmake --build ./build --config Release --target all -j`nproc`
+	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B./build -G Ninja && cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 	$(MAKE) release
 	$(MAKE) -C hyprctl all
 
@@ -34,7 +34,7 @@ install:
 	$(MAKE) clear
 	$(MAKE) fixwlr
 	cd ./subprojects/wlroots && meson setup build/ --buildtype=release && ninja -C build/ && cp ./build/libwlroots.so.12032 ${PREFIX}/lib/ || echo "Could not install libwlroots to ${PREFIX}/lib/libwlroots.so.12032"
-	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B./build -G Ninja && cmake --build ./build --config Release --target all -j`nproc` && cd ../..
+	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B./build -G Ninja && cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF` && cd ../..
 	$(MAKE) release
 	$(MAKE) -C hyprctl all
 
@@ -87,10 +87,10 @@ config:
 
 	ninja -C subprojects/wlroots/build/ install
 
-	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B ./build -G Ninja && cmake --build ./build --config Release --target all -j`nproc`
+	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B ./build -G Ninja && cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
 pluginenv:
-	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B ./build -G Ninja && cmake --build ./build --config Release --target all -j`nproc`
+	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B ./build -G Ninja && cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
 	$(MAKE) fixwlr
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ clear:
 all:
 	$(MAKE) clear
 	$(MAKE) fixwlr
-	cd ./subprojects/wlroots && meson setup build/ --buildtype=release && ninja -C build/ && cp ./build/libwlroots.so.12032 ${PREFIX}/lib/ || echo "Could not install libwlroots to ${PREFIX}/lib/libwlroots.so.12032"
+	cd ./subprojects/wlroots && meson setup build/ --buildtype=release && ninja -C build/ && mkdir -p ${PREFIX}/lib/ && cp ./build/libwlroots.so.12032 ${PREFIX}/lib/ || echo "Could not install libwlroots to ${PREFIX}/lib/libwlroots.so.12032"
 	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B./build -G Ninja && cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 	$(MAKE) release
 	$(MAKE) -C hyprctl all
@@ -33,7 +33,7 @@ all:
 install:
 	$(MAKE) clear
 	$(MAKE) fixwlr
-	cd ./subprojects/wlroots && meson setup build/ --buildtype=release && ninja -C build/ && cp ./build/libwlroots.so.12032 ${PREFIX}/lib/ || echo "Could not install libwlroots to ${PREFIX}/lib/libwlroots.so.12032"
+	cd ./subprojects/wlroots && meson setup build/ --buildtype=release && ninja -C build/ && mkdir -p ${PREFIX}/lib/ && cp ./build/libwlroots.so.12032 ${PREFIX}/lib/ || echo "Could not install libwlroots to ${PREFIX}/lib/libwlroots.so.12032"
 	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B./build -G Ninja && cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF` && cd ../..
 	$(MAKE) release
 	$(MAKE) -C hyprctl all

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ install:
 	cd subprojects/wlroots/include && find . -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland/wlroots && cd ../../..
 	cp ./protocols/*-protocol.h ${PREFIX}/include/hyprland/protocols
 	cp ./build/hyprland.pc ${PREFIX}/share/pkgconfig
-	cp ./build/hyprland.pc /usr/share/pkgconfig
+	if [ -d /usr/share/pkgconfig ]; then cp ./build/hyprland.pc /usr/share/pkgconfig 2>/dev/null || true; fi
 
 cleaninstall:
 	echo -en "$(MAKE) cleaninstall has been DEPRECATED, you should avoid using it in the future.\nRunning $(MAKE) install instead...\n"
@@ -109,7 +109,7 @@ pluginenv:
 	cd subprojects/wlroots/include && find . -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland/wlroots && cd ../../..
 	cp ./protocols/*-protocol.h ${PREFIX}/include/hyprland/protocols
 	cp ./build/hyprland.pc ${PREFIX}/share/pkgconfig
-	cp ./build/hyprland.pc /usr/share/pkgconfig
+	if [ -d /usr/share/pkgconfig ]; then cp ./build/hyprland.pc /usr/share/pkgconfig 2>/dev/null || true; fi
 
 configdebug:
 	$(MAKE) fixwlr

--- a/hyprctl/Makefile
+++ b/hyprctl/Makefile
@@ -1,4 +1,4 @@
 all:
-	g++ -std=c++23 ./main.cpp -o ./hyprctl
+	$(CXX) -std=c++2b ./main.cpp -o ./hyprctl
 clean:
 	rm ./hyprctl


### PR DESCRIPTION
Most incompatibilities are caused by custom Makefile used to drive CMake.