### PR TITLE
Fix recursion in package overlays

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,6 @@
           self.overlays.wlroots-hyprland
           self.overlays.wayland-latest
           inputs.hyprland-protocols.overlays.default
-          inputs.xdph.overlays.default
         ];
       });
 

--- a/flake.nix
+++ b/flake.nix
@@ -36,10 +36,10 @@
       import nixpkgs {
         inherit system;
         overlays = [
-          (_: prev: {
+          (final: prev: {
             wayland = prev.wayland.overrideAttrs (old: rec {
               version = "1.22.0";
-              src = prev.fetchurl {
+              src = final.fetchurl {
                 url = "https://gitlab.freedesktop.org/wayland/wayland/-/releases/${version}/downloads/${old.pname}-${version}.tar.xz";
                 hash = "sha256-FUCvHqaYpHHC2OnSiDMsfg/TYMjx0Sk267fny8JCWEI=";
               };
@@ -56,13 +56,13 @@
       (builtins.substring 6 2 longDate)
     ]);
   in {
-    overlays.default = _: prev: rec {
-      wlroots-hyprland = prev.callPackage ./nix/wlroots.nix {
+    overlays.default = final: prev: rec {
+      wlroots-hyprland = final.callPackage ./nix/wlroots.nix {
         version = mkDate (inputs.wlroots.lastModifiedDate or "19700101") + "_" + (inputs.wlroots.shortRev or "dirty");
         src = inputs.wlroots;
         libdisplay-info = prev.libdisplay-info.overrideAttrs (old: {
           version = "0.1.1+date=2023-03-02";
-          src = prev.fetchFromGitLab {
+          src = final.fetchFromGitLab {
             domain = "gitlab.freedesktop.org";
             owner = "emersion";
             repo = old.pname;
@@ -73,7 +73,7 @@
 
         libliftoff = prev.libliftoff.overrideAttrs (old: {
           version = "0.5.0-dev";
-          src = prev.fetchFromGitLab {
+          src = final.fetchFromGitLab {
             domain = "gitlab.freedesktop.org";
             owner = "emersion";
             repo = old.pname;
@@ -86,8 +86,8 @@
           ];
         });
       };
-      hyprland = prev.callPackage ./nix/default.nix {
-        stdenv = prev.gcc12Stdenv;
+      hyprland = final.callPackage ./nix/default.nix {
+        stdenv = final.gcc12Stdenv;
         version = props.version + "+date=" + (mkDate (self.lastModifiedDate or "19700101")) + "_" + (self.shortRev or "dirty");
         wlroots = wlroots-hyprland;
         commit = self.rev or "";
@@ -99,7 +99,7 @@
       hyprland-nvidia = hyprland.override {nvidiaPatches = true;};
       hyprland-no-hidpi = builtins.trace "hyprland-no-hidpi was removed. Please use the default package." hyprland;
 
-      udis86 = prev.callPackage ./nix/udis86.nix {};
+      udis86 = final.callPackage ./nix/udis86.nix {};
 
       waybar-hyprland = prev.waybar.overrideAttrs (oldAttrs: {
         postPatch = ''
@@ -119,7 +119,7 @@
       // {inherit (self.packages.${system}) xdg-desktop-portal-hyprland;});
 
     packages = genSystems (system:
-      (self.overlays.default null pkgsFor.${system})
+      (self.overlays.default pkgsFor.${system} pkgsFor.${system})
       // {
         default = self.packages.${system}.hyprland;
       });

--- a/flake.nix
+++ b/flake.nix
@@ -47,106 +47,18 @@
 
     mkJoinedOverlays = overlays: final: prev:
       lib.foldl' (attrs: overlay: attrs // (overlay final prev)) {} overlays;
-
-    props = builtins.fromJSON (builtins.readFile ./props.json);
-
-    mkDate = longDate: (lib.concatStringsSep "-" [
-      (builtins.substring 0 4 longDate)
-      (builtins.substring 4 2 longDate)
-      (builtins.substring 6 2 longDate)
-    ]);
   in {
-    overlays = {
-      default =
-        mkJoinedOverlays
-        (with self.overlays; [
-          hyprland-packages
-          hyprland-extras
-          wlroots-hyprland
-        ]);
-
-      hyprland-packages = final: prev: {
-        hyprland = final.callPackage ./nix/default.nix {
-          stdenv = final.gcc12Stdenv;
-          version =
-            props.version
-            + "+date="
-            + (mkDate (self.lastModifiedDate or "19700101"))
-            + "_"
-            + (self.shortRev or "dirty");
-          wlroots = final.wlroots-hyprland;
-          commit = self.rev or "";
-          inherit (final) udis86 hyprland-protocols;
-        };
-
-        hyprland-debug = final.hyprland.override {debug = true;};
-        hyprland-hidpi = final.hyprland.override {hidpiXWayland = true;};
-        hyprland-nvidia = final.hyprland.override {nvidiaPatches = true;};
-        hyprland-no-hidpi =
-          builtins.trace
-          "hyprland-no-hidpi was removed. Please use the default package."
-          final.hyprland;
-
-        udis86 = final.callPackage ./nix/udis86.nix {};
-
-        xdg-desktop-portal-hyprland = prev.xdg-desktop-portal-hyprland.override {
-          hyprland-share-picker = prev.hyprland-share-picker.override {inherit (final) hyprland;};
-        };
+    overlays =
+      (import ./nix/overlays.nix {inherit self lib inputs;})
+      // {
+        default =
+          mkJoinedOverlays
+          (with self.overlays; [
+            hyprland-packages
+            hyprland-extras
+            wlroots-hyprland
+          ]);
       };
-
-      hyprland-extras = final: prev: {
-        waybar-hyprland = prev.waybar.overrideAttrs (oldAttrs: {
-          postPatch = ''
-            # use hyprctl to switch workspaces
-            sed -i 's/zext_workspace_handle_v1_activate(workspace_handle_);/const std::string command = "hyprctl dispatch workspace " + name_;\n\tsystem(command.c_str());/g' src/modules/wlr/workspace_manager.cpp
-          '';
-          mesonFlags = oldAttrs.mesonFlags ++ ["-Dexperimental=true"];
-        });
-      };
-
-      wlroots-hyprland = final: prev: {
-        wlroots-hyprland = final.callPackage ./nix/wlroots.nix {
-          version =
-            mkDate (inputs.wlroots.lastModifiedDate or "19700101")
-            + "_"
-            + (inputs.wlroots.shortRev or "dirty");
-          src = inputs.wlroots;
-          libdisplay-info = prev.libdisplay-info.overrideAttrs (old: {
-            version = "0.1.1+date=2023-03-02";
-            src = final.fetchFromGitLab {
-              domain = "gitlab.freedesktop.org";
-              owner = "emersion";
-              repo = old.pname;
-              rev = "147d6611a64a6ab04611b923e30efacaca6fc678";
-              sha256 = "sha256-/q79o13Zvu7x02SBGu0W5yQznQ+p7ltZ9L6cMW5t/o4=";
-            };
-          });
-
-          libliftoff = prev.libliftoff.overrideAttrs (old: {
-            version = "0.5.0-dev";
-            src = final.fetchFromGitLab {
-              domain = "gitlab.freedesktop.org";
-              owner = "emersion";
-              repo = old.pname;
-              rev = "d98ae243280074b0ba44bff92215ae8d785658c0";
-              sha256 = "sha256-DjwlS8rXE7srs7A8+tHqXyUsFGtucYSeq6X0T/pVOc8=";
-            };
-
-            NIX_CFLAGS_COMPILE = toString ["-Wno-error=sign-conversion"];
-          });
-        };
-      };
-
-      wayland-latest = final: prev: {
-        wayland = prev.wayland.overrideAttrs (old: rec {
-          version = "1.22.0";
-          src = final.fetchurl {
-            url = "https://gitlab.freedesktop.org/wayland/wayland/-/releases/${version}/downloads/${old.pname}-${version}.tar.xz";
-            hash = "sha256-FUCvHqaYpHHC2OnSiDMsfg/TYMjx0Sk267fny8JCWEI=";
-          };
-        });
-      };
-    };
 
     checks = genSystems (system:
       (lib.filterAttrs

--- a/flake.nix
+++ b/flake.nix
@@ -76,9 +76,7 @@
 
     devShells = genSystems (system: {
       default =
-        pkgsFor.${system}.mkShell.override {
-          stdenv = pkgsFor.${system}.gcc12Stdenv;
-        } {
+        pkgsFor.${system}.mkShell {
           name = "hyprland-shell";
           nativeBuildInputs = with pkgsFor.${system}; [cmake];
           buildInputs = [self.packages.${system}.wlroots-hyprland];

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,0 +1,8 @@
+final: prev: let
+  lib = final;
+
+  mkJoinedOverlays = overlays: final: prev:
+    lib.foldl' (attrs: overlay: attrs // (overlay final prev)) {} overlays;
+in prev // {
+  inherit mkJoinedOverlays;
+}

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -35,11 +35,6 @@ in {
       final.hyprland;
 
     udis86 = final.callPackage ./udis86.nix {};
-
-    xdg-desktop-portal-hyprland = prev.xdg-desktop-portal-hyprland.override {
-      hyprland-share-picker =
-        prev.hyprland-share-picker.override {inherit (final) hyprland;};
-    };
   };
 
   # Packages for extra software recommended for usage with Hyprland,

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -14,7 +14,6 @@ in {
   # Packages for variations of Hyprland, and its dependencies.
   hyprland-packages = final: prev: {
     hyprland = final.callPackage ./default.nix {
-      stdenv = final.gcc12Stdenv;
       version =
         props.version
         + "+date="

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -1,0 +1,102 @@
+{
+  self,
+  lib,
+  inputs,
+}: let
+  props = builtins.fromJSON (builtins.readFile ../props.json);
+
+  mkDate = longDate: (lib.concatStringsSep "-" [
+    (builtins.substring 0 4 longDate)
+    (builtins.substring 4 2 longDate)
+    (builtins.substring 6 2 longDate)
+  ]);
+in {
+  # Packages for variations of Hyprland, and its dependencies.
+  hyprland-packages = final: prev: {
+    hyprland = final.callPackage ./default.nix {
+      stdenv = final.gcc12Stdenv;
+      version =
+        props.version
+        + "+date="
+        + (mkDate (self.lastModifiedDate or "19700101"))
+        + "_"
+        + (self.shortRev or "dirty");
+      wlroots = final.wlroots-hyprland;
+      commit = self.rev or "";
+      inherit (final) udis86 hyprland-protocols;
+    };
+
+    hyprland-debug = final.hyprland.override {debug = true;};
+    hyprland-hidpi = final.hyprland.override {hidpiXWayland = true;};
+    hyprland-nvidia = final.hyprland.override {nvidiaPatches = true;};
+    hyprland-no-hidpi =
+      builtins.trace
+      "hyprland-no-hidpi was removed. Please use the default package."
+      final.hyprland;
+
+    udis86 = final.callPackage ./udis86.nix {};
+
+    xdg-desktop-portal-hyprland = prev.xdg-desktop-portal-hyprland.override {
+      hyprland-share-picker =
+        prev.hyprland-share-picker.override {inherit (final) hyprland;};
+    };
+  };
+
+  # Packages for extra software recommended for usage with Hyprland,
+  # including forked or patched packages for compatibility.
+  hyprland-extras = final: prev: {
+    waybar-hyprland = prev.waybar.overrideAttrs (oldAttrs: {
+      postPatch = ''
+        # use hyprctl to switch workspaces
+        sed -i 's/zext_workspace_handle_v1_activate(workspace_handle_);/const std::string command = "hyprctl dispatch workspace " + name_;\n\tsystem(command.c_str());/g' src/modules/wlr/workspace_manager.cpp
+      '';
+      mesonFlags = oldAttrs.mesonFlags ++ ["-Dexperimental=true"];
+    });
+  };
+
+  # Patched version of wlroots for Hyprland.
+  # It is under a new package name so as to not conflict with
+  # the standard version in nixpkgs.
+  wlroots-hyprland = final: prev: {
+    wlroots-hyprland = final.callPackage ./wlroots.nix {
+      version =
+        mkDate (inputs.wlroots.lastModifiedDate or "19700101")
+        + "_"
+        + (inputs.wlroots.shortRev or "dirty");
+      src = inputs.wlroots;
+      libdisplay-info = prev.libdisplay-info.overrideAttrs (old: {
+        version = "0.1.1+date=2023-03-02";
+        src = final.fetchFromGitLab {
+          domain = "gitlab.freedesktop.org";
+          owner = "emersion";
+          repo = old.pname;
+          rev = "147d6611a64a6ab04611b923e30efacaca6fc678";
+          sha256 = "sha256-/q79o13Zvu7x02SBGu0W5yQznQ+p7ltZ9L6cMW5t/o4=";
+        };
+      });
+      libliftoff = prev.libliftoff.overrideAttrs (old: {
+        version = "0.5.0-dev";
+        src = final.fetchFromGitLab {
+          domain = "gitlab.freedesktop.org";
+          owner = "emersion";
+          repo = old.pname;
+          rev = "d98ae243280074b0ba44bff92215ae8d785658c0";
+          sha256 = "sha256-DjwlS8rXE7srs7A8+tHqXyUsFGtucYSeq6X0T/pVOc8=";
+        };
+
+        NIX_CFLAGS_COMPILE = toString ["-Wno-error=sign-conversion"];
+      });
+    };
+  };
+
+  # Temporary override for latest wayland version. May be useless in the future.
+  wayland-latest = final: prev: {
+    wayland = prev.wayland.overrideAttrs (old: rec {
+      version = "1.22.0";
+      src = final.fetchurl {
+        url = "https://gitlab.freedesktop.org/wayland/wayland/-/releases/${version}/downloads/${old.pname}-${version}.tar.xz";
+        hash = "sha256-FUCvHqaYpHHC2OnSiDMsfg/TYMjx0Sk267fny8JCWEI=";
+      };
+    });
+  };
+}


### PR DESCRIPTION
@fufexan 

**Edit:**

It started with the first commit but I've pushed more work and the PR needs some explanation.

# Description

Previously, the way the flake constructed its `packages` output was to call the `overlays.default` output with `null` for the fixed-point and `prev` for the instance of `pkgs` to modify. Instead of using packages from `final` to use in the derivations overridden from `prev`, it would use the `rec` keyword to use packages adjacent.

Now, `packages` is constructed with a new instance of `pkgs` for both `final` and `prev`, and the overlays themselves use `final` and `prev` correctly. This was done so that some flake packages could depend on other packages also exported by the flake. However, because `packages` was created through the use of `overlays`, this is incorrect and defies the purpose of the overlay mechanism.

This new instance of `pkgs` that overlays receive will include all other dependency packages exposed by the flake (and its inputs, in the case of `hyprland-protocols`). This means that anywhere a package was previously used to create an overridden derivation, where it was before using `rec`, it now properly uses the package from `final` recursively, properly utilizing fixed-point extension.

# Why?

The dependency graph was incorrect, and overlay packages instantiated incorrectly.

This fixes the behavior of both overlays and usage of packages, as well as usage of a combination of the two. Previously, Hyprland could not be built if the flake's `default` overlay was applied to current `nixpkgs/nixos-unstable`, because of a version conflict with `wayland-server` (needed `1.22`, has `1.21`). Now the `wayland-latest` overlay will be applied to packages from the `packages` output, and additionally the other overlays from the flake can be used separately without rebuilding everything in *nixpkgs* that depends on `wayland`.

# Is it ready to merge?

Yes