### PR TITLE
Add plugin configuration to home manager module

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -116,6 +116,13 @@ in {
   };
 
   config = lib.mkIf cfg.enable {
+    warnings =
+      if (cfg.systemdIntegration || cfg.plugins != []) && cfg.extraConfig == null then
+        [ ''You have enabled hyprland.systemdIntegration or listed plugins in hyprland.plugins.
+            Your hyprland config will be linked by home manager.
+            Set hyprland.extraConfig or unset hyprland.systemdIntegration and hyprland.plugins to remove this warning.'' ]
+      else [];
+
     home.packages =
       lib.optional (cfg.package != null) cfg.package
       ++ lib.optional cfg.xwayland.enable pkgs.xwayland;
@@ -131,7 +138,7 @@ in {
         + lib.concatStrings (builtins.map (entry: let
             plugin = if lib.types.package.check entry then "${entry}/lib/lib${entry.pname}.so" else entry;
           in "plugin = ${plugin}\n") cfg.plugins)
-        + cfg.extraConfig;
+        + (if cfg.extraConfig != null then cfg.extraConfig else "");
 
       onChange = let
         hyprlandPackage =


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds a plugins array to the home manager module which can take:
- packages (uses the path `${package}/lib/lib${package.pname}.so`)
- paths (uses the path directly)

The provided plugins are added to the beginning of the hyprland config using the `plugin = /absolute/path.so` method.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Yes