### PR TITLE
quote hash for the GIT_COMMIT_HASH macro

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Create tarball with submodules
         id: tar
         run: |
-          sed -i "1s/^/#define GIT_COMMIT_HASH $(git rev-parse HEAD)\n#define GIT_TAG \"$(git describe --tags)\"\n/" ./src/defines.hpp
+          sed -i "1s/^/#define GIT_COMMIT_HASH \"$(git rev-parse HEAD)\"\n#define GIT_TAG \"$(git describe --tags)\"\n/" ./src/defines.hpp
           mkdir hyprland-source; mv ./* ./hyprland-source || tar -czv --owner=0 --group=0 --no-same-owner --no-same-permissions -f source.tar.gz *
 
       - id: whatrelease


### PR DESCRIPTION
otherwise compilation fails with smth like
```
../src/debug/../plugins/../defines.hpp:1:25:
error: ‘f27873a6f06dc2f87600edb890f3c38298bfb55f’ was not declared in this scope
```



