### PR TITLE
fix: expose/use flake's own hyprland-protocols in overlays.default

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,7 @@
             hyprland-packages
             hyprland-extras
             wlroots-hyprland
+            inputs.hyprland-protocols.overlays.default
           ]);
       };
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

The `overlays.default` output of this repo doesn't use the flake's own `hyprland-protocols` version, so a user who tries to use this overlay in their configuration _may_ see a failure that looks like
```bash
$ nix build github:johnrichardrinehart/johnos/3272048990abebb8ae7f139fc286d1d56e7f05f7#nixosConfigurations.framework-laptop.pkgs.hyprland

warning: 'https://johnos.cachix.org' does not appear to be a binary cache
error: builder for '/nix/store/f318mxf3k8cwi5axk06rr8rh498kdiad-hyprland-0.25.0+date=2023-05-03_da093a8.drv' failed with exit code 1;
       last 10 log lines:
       > Run-time dependency wayland-protocols found: YES 1.31
       > Dependency hyprland-protocols found: NO found 0.1 but need: '>=0.2'
       > Did not find CMake 'cmake'
       > Found CMake: NO
       > Run-time dependency hyprland-protocols found: NO (tried pkgconfig and cmake)
       > Looking for a fallback subproject for the dependency hyprland-protocols
       >
       > protocols/meson.build:7:18: ERROR: Subproject exists but has no meson.build file
       >
       > A full log can be found at /build/source/build/meson-logs/meson-log.txt
       For full logs, run 'nix log /nix/store/f318mxf3k8cwi5axk06rr8rh498kdiad-hyprland-0.25.0+date=2023-05-03_da093a8.drv'.
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I spoke with @fufexan about implementing this change.

#### Is it ready for merging, or does it need work?

I think it should be ready, but I'm not an expert. I _did_ confirm that pointing my own system flake to this branch and using this branch's `overlays.default` in my system config fixed the problem. So, that's good....


