### PR TITLE
Add layerrule ignorefocus

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -996,14 +996,18 @@ wlr_surface* CCompositor::vectorToLayerSurface(const Vector2D& pos, std::vector<
                 SURFACEAT = ls->layerSurface->surface;
 
             *ppLayerSurfaceFound = ls.get();
+            if ((*ppLayerSurfaceFound)->ignoreFocus)
+                continue;
+
             return SURFACEAT;
         }
 
         if (SURFACEAT) {
             if (!pixman_region32_not_empty(&SURFACEAT->input_region))
                 continue;
-
             *ppLayerSurfaceFound = ls.get();
+            if ((*ppLayerSurfaceFound)->ignoreFocus)
+                continue;
             return SURFACEAT;
         }
     }

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -803,7 +803,7 @@ bool windowRuleValid(const std::string& RULE) {
 }
 
 bool layerRuleValid(const std::string& RULE) {
-    return !(RULE != "noanim" && RULE != "blur" && RULE != "ignorezero");
+    return !(RULE != "noanim" && RULE != "blur" && RULE != "ignorezero" && RULE != "ignorefocus");
 }
 
 void CConfigManager::handleWindowRule(const std::string& command, const std::string& value) {
@@ -840,16 +840,14 @@ void CConfigManager::handleLayerRule(const std::string& command, const std::stri
 
     if (RULE == "unset") {
         std::erase_if(m_dLayerRules, [&](const SLayerRule& other) { return other.targetNamespace == VALUE; });
-        return;
+    } else {
+        if (!layerRuleValid(RULE)) {
+            Debug::log(ERR, "Invalid rule found: %s", RULE.c_str());
+            parseError = "Invalid rule found: " + RULE;
+            return;
+        }
+        m_dLayerRules.push_back({VALUE, RULE});
     }
-
-    if (!layerRuleValid(RULE)) {
-        Debug::log(ERR, "Invalid rule found: %s", RULE.c_str());
-        parseError = "Invalid rule found: " + RULE;
-        return;
-    }
-
-    m_dLayerRules.push_back({VALUE, RULE});
 
     for (auto& m : g_pCompositor->m_vMonitors)
         for (auto& lsl : m->m_aLayerSurfaceLayers)

--- a/src/helpers/WLClasses.cpp
+++ b/src/helpers/WLClasses.cpp
@@ -1,5 +1,6 @@
 #include "WLClasses.hpp"
 #include "../config/ConfigManager.hpp"
+#include "src/Compositor.hpp"
 
 SLayerSurface::SLayerSurface() {
     alpha.create(AVARTYPE_FLOAT, g_pConfigManager->getAnimationPropertyConfig("fadeIn"), nullptr, AVARDAMAGE_ENTIRE);
@@ -11,6 +12,7 @@ void SLayerSurface::applyRules() {
     noAnimations = false;
     forceBlur    = false;
     ignoreZero   = false;
+    ignoreFocus  = false;
 
     for (auto& rule : g_pConfigManager->getMatchingRules(this)) {
         if (rule.rule == "noanim")
@@ -19,5 +21,43 @@ void SLayerSurface::applyRules() {
             forceBlur = true;
         else if (rule.rule == "ignorezero")
             ignoreZero = true;
+        else if (rule.rule == "ignorefocus") {
+            ignoreFocus = true;
+            if(g_pCompositor->m_pLastFocus == layerSurface->surface) {
+                unfocus();
+            }
+        }
+    }
+}
+
+void SLayerSurface::unfocus() {
+    const auto PMONITOR = g_pCompositor->getMonitorFromOutput(layerSurface->output);
+    if (!PMONITOR)
+        return;
+
+    g_pInputManager->releaseAllMouseButtons();
+
+    Vector2D       surfaceCoords;
+    SLayerSurface* pFoundLayerSurface = nullptr;
+    wlr_surface*   foundSurface       = nullptr;
+
+    g_pCompositor->m_pLastFocus = nullptr;
+
+    // find LS-es to focus
+    foundSurface = g_pCompositor->vectorToLayerSurface(g_pInputManager->getMouseCoordsInternal(), &PMONITOR->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY],
+                                                       &surfaceCoords, &pFoundLayerSurface);
+
+    if (!foundSurface)
+        foundSurface = g_pCompositor->vectorToLayerSurface(g_pInputManager->getMouseCoordsInternal(), &PMONITOR->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP],
+                                                           &surfaceCoords, &pFoundLayerSurface);
+
+    if (!foundSurface) {
+        // if there isn't any, focus the last window
+        const auto PLASTWINDOW = g_pCompositor->m_pLastWindow;
+        g_pCompositor->focusWindow(nullptr);
+        g_pCompositor->focusWindow(PLASTWINDOW);
+    } else {
+        // otherwise, full refocus
+        g_pInputManager->refocus();
     }
 }

--- a/src/helpers/WLClasses.hpp
+++ b/src/helpers/WLClasses.hpp
@@ -17,6 +17,7 @@ struct SLayerSurface {
     SLayerSurface();
 
     void                  applyRules();
+    void                  unfocus();
 
     wlr_layer_surface_v1* layerSurface;
     wl_list               link;
@@ -46,8 +47,9 @@ struct SLayerSurface {
     bool                      noProcess     = false;
     bool                      noAnimations  = false;
 
-    bool                      forceBlur  = false;
-    bool                      ignoreZero = false;
+    bool                      forceBlur   = false;
+    bool                      ignoreZero  = false;
+    bool                      ignoreFocus = false;
 
     // For the list lookup
     bool operator==(const SLayerSurface& rhs) const {

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -325,7 +325,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
     if (*PHOGFOCUS && !refocus && g_pCompositor->m_pLastFocus) {
         const auto PLS = g_pCompositor->getLayerSurfaceFromSurface(g_pCompositor->m_pLastFocus);
 
-        if (PLS && PLS->layerSurface->current.keyboard_interactive) {
+        if (PLS && !PLS->ignoreFocus && PLS->layerSurface->current.keyboard_interactive) {
             allowKeyboardRefocus = false;
         }
     }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Adds a new layerrule for `ignorefocus`.  This lets me script a fullscreen `eww` overlay like so:

```bash
preload_dashboard() {
	eww open dashboard
	hyprctl keyword layerrule ignorefocus,eww-dashboard # bypass interaction
}

show_dashboard() {
	hyprctl keyword blurls eww-dashboard          # enable blur
	hyprctl keyword layerrule unset,eww-dashboard # allow interaction
	eww update reveal=true                        # show dashboard
}

hide_dashboard() {
	eww update reveal=false                             #hide dashboard
	hyprctl keyword blurls remove,eww-dashboard         # remove blur
	hyprctl keyword layerrule ignorefocus,eww-dashboard # bypass interaction
}
```

with a `defwindow` that looks like:
```yuck
(defwindow dashboard
  :monitor 0
  :geometry (geometry :x "0px" :y "0px" :width "100%" :height "100%" :anchor "center")
  :stacking "ov"
  :windowtype "dock"
  :focusable true
  :namespace "eww-dashboard"
  (container
    (system)))
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Tested a bunch of different focus/unfocus scenarios.  I think I got all the edge cases.

Also fixed a bug where layerrules were not being applied when `unset`.

#### Is it ready for merging, or does it need work?

Ready for merging.  Not very risky because logic should be the same for anyone not invoking the new `ignorefocus` rule.