### PR TITLE
make split preselect available in config file

### DIFF
--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -841,7 +841,7 @@ void CHyprDwindleLayout::alterSplitRatio(CWindow* pWindow, float ratio, bool exa
 }
 
 std::any CHyprDwindleLayout::layoutMessage(SLayoutMessageHeader header, std::string message) {
-    const auto ARGS = CVarList(message, 0, ',');
+    const auto ARGS = CVarList(message, 0, ' ');
     if (ARGS[0] == "togglesplit") {
         toggleSplit(header.pWindow);
     } else if (ARGS[0] == "preselect") {

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -841,7 +841,7 @@ void CHyprDwindleLayout::alterSplitRatio(CWindow* pWindow, float ratio, bool exa
 }
 
 std::any CHyprDwindleLayout::layoutMessage(SLayoutMessageHeader header, std::string message) {
-    const auto ARGS = CVarList(message, 0, ' ');
+    const auto ARGS = CVarList(message, 0, ',');
     if (ARGS[0] == "togglesplit") {
         toggleSplit(header.pWindow);
     } else if (ARGS[0] == "preselect") {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -33,6 +33,7 @@ CKeybindManager::CKeybindManager() {
     m_mDispatchers["togglegroup"]                   = toggleGroup;
     m_mDispatchers["changegroupactive"]             = changeGroupActive;
     m_mDispatchers["togglesplit"]                   = toggleSplit;
+    m_mDispatchers["preselect"]                     = preSelect;
     m_mDispatchers["splitratio"]                    = alterSplitRatio;
     m_mDispatchers["focusmonitor"]                  = focusMonitor;
     m_mDispatchers["movecursortocorner"]            = moveCursorToCorner;
@@ -1228,6 +1229,16 @@ void CKeybindManager::toggleSplit(std::string args) {
         return;
 
     g_pLayoutManager->getCurrentLayout()->layoutMessage(header, "togglesplit");
+}
+
+void CKeybindManager::preSelect(std::string args) {
+    SLayoutMessageHeader header;
+    header.pWindow = g_pCompositor->m_pLastWindow;
+
+    if (!header.pWindow)
+        return;
+
+    g_pLayoutManager->getCurrentLayout()->layoutMessage(header, "preselect," + args);
 }
 
 void CKeybindManager::alterSplitRatio(std::string args) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1238,7 +1238,7 @@ void CKeybindManager::preSelect(std::string args) {
     if (!header.pWindow)
         return;
 
-    g_pLayoutManager->getCurrentLayout()->layoutMessage(header, "preselect," + args);
+    g_pLayoutManager->getCurrentLayout()->layoutMessage(header, "preselect " + args);
 }
 
 void CKeybindManager::alterSplitRatio(std::string args) {

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -114,6 +114,7 @@ class CKeybindManager {
     static void     alterSplitRatio(std::string);
     static void     focusMonitor(std::string);
     static void     toggleSplit(std::string);
+    static void     preSelect(std::string);
     static void     moveCursorToCorner(std::string);
     static void     moveCursor(std::string);
     static void     workspaceOpt(std::string);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
A little over a week ago split preselect was added, but the only way to use it was using the "layoutmsg" dispatcher in the config file, so I've added a normal "preselect" dispatcher

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I did change DwindleLayout.cpp so that it will split arguments on ',' instead of ' ', so you can use the "layoutmsg" dispatcher with comma separated arguments instead of space separated ones. This can break your config file if it still uses the "layoutmsg" dispatcher with space-separated arguments.

#### Is it ready for merging, or does it need work?
Ready for merging

