### PR TITLE
Improvements to CMakeLists

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,20 +30,14 @@ jobs:
       - name: Build Hyprland
         run: |
           git submodule sync --recursive && git submodule update --init --force --recursive
-          make all
+          cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DNO_DEV -DCMAKE_INSTALL_PREFIX='/usr'
+          cmake --build ${{github.workspace}}/build --config Release
       - name: Compress and package artifacts
         run: |
-          mkdir x86_64-pc-linux-gnu
           mkdir hyprland
-          mkdir hyprland/example
-          mkdir hyprland/assets
+          DESTDIR="hyprland" cmake --install ${{github.workspace}}/build
           cp ./LICENSE hyprland/
-          cp build/Hyprland hyprland/
-          cp hyprctl/hyprctl hyprland/
-          cp subprojects/wlroots/build/libwlroots.so.12032 hyprland/
-          cp build/Hyprland hyprland/
-          cp -r example/ hyprland/
-          cp -r assets/ hyprland/
+
           tar -cvf Hyprland.tar.xz hyprland
       - name: Release
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,14 +30,20 @@ jobs:
       - name: Build Hyprland
         run: |
           git submodule sync --recursive && git submodule update --init --force --recursive
-          cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DNO_DEV -DCMAKE_INSTALL_PREFIX='/usr'
-          cmake --build ${{github.workspace}}/build --config Release
+          make all
       - name: Compress and package artifacts
         run: |
+          mkdir x86_64-pc-linux-gnu
           mkdir hyprland
-          DESTDIR="hyprland" cmake --install ${{github.workspace}}/build
+          mkdir hyprland/example
+          mkdir hyprland/assets
           cp ./LICENSE hyprland/
-
+          cp build/Hyprland hyprland/
+          cp hyprctl/hyprctl hyprland/
+          cp subprojects/wlroots/build/libwlroots.so.12032 hyprland/
+          cp build/Hyprland hyprland/
+          cp -r example/ hyprland/
+          cp -r assets/ hyprland/
           tar -cvf Hyprland.tar.xz hyprland
       - name: Release
         uses: actions/upload-artifact@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,9 +79,9 @@ ExternalProject_Add(wlroots_build
     PREFIX wlroots
     SOURCE_DIR ${CMAKE_SOURCE_DIR}/subprojects/wlroots
     PATCH_COMMAND ${SED_EXE} -E -i -e "s/(soversion = 12)([^032]|$$)/soversion = ${WLROOTS_SOVERSION}/g" ${CMAKE_SOURCE_DIR}/subprojects/wlroots/meson.build
-    CONFIGURE_COMMAND ${MESON_EXE} setup --prefix ${CMAKE_CURRENT_BINARY_DIR}/wlroots . ${CMAKE_SOURCE_DIR}/subprojects/wlroots
+    CONFIGURE_COMMAND ${MESON_EXE} setup --prefix "/" . ${CMAKE_SOURCE_DIR}/subprojects/wlroots
     BUILD_COMMAND ${NINJA_EXE} -C .
-    INSTALL_COMMAND ${NINJA_EXE} -C . install
+    INSTALL_COMMAND ${MESON_EXE} install --destdir ${CMAKE_CURRENT_BINARY_DIR}/wlroots
 	BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/wlroots/lib/libwlroots.so.${WLROOTS_SOVERSION})
 
 set(wlroots_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/subprojects/wlroots/include/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,8 @@ ExternalProject_Add(wlroots_build
     PATCH_COMMAND ${SED_EXE} -E -i -e "s/(soversion = 12)([^032]|$$)/soversion = ${WLROOTS_SOVERSION}/g" ${CMAKE_SOURCE_DIR}/subprojects/wlroots/meson.build
     CONFIGURE_COMMAND ${MESON_EXE} setup --prefix ${CMAKE_CURRENT_BINARY_DIR}/wlroots . ${CMAKE_SOURCE_DIR}/subprojects/wlroots
     BUILD_COMMAND ${NINJA_EXE} -C .
-    INSTALL_COMMAND ${NINJA_EXE} -C . install)
+    INSTALL_COMMAND ${NINJA_EXE} -C . install
+	BUILD_BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/wlroots/lib/libwlroots.so.${WLROOTS_SOVERSION})
 
 set(wlroots_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/subprojects/wlroots/include/)
 set(wlroots_LIBRARY ${CMAKE_CURRENT_BINARY_DIR}/wlroots/lib/libwlroots.so.${WLROOTS_SOVERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,12 +83,12 @@ ExternalProject_Add(wlroots
     BUILD_COMMAND ${NINJA_EXE} -C .
     INSTALL_COMMAND ${NINJA_EXE} -C . install)
 
-set(wlroots_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/wlroots/include/)
-set(wlroots_LIB_PATH ${CMAKE_CURRENT_BINARY_DIR}/wlroots/lib/libwlroots.so.${WLROOTS_SOVERSION})
+set(wlroots_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/subprojects/wlroots/include/)
+set(wlroots_LIBRARY ${CMAKE_CURRENT_BINARY_DIR}/wlroots/lib/libwlroots.so.${WLROOTS_SOVERSION})
 
 add_library(wlroots_lib SHARED IMPORTED)
 set_target_properties(wlroots_lib PROPERTIES
-    IMPORTED_LOCATION ${wlroots_LIB_PATH}
+    IMPORTED_LOCATION ${wlroots_LIBRARY}
     INTERFACE_INCLUDE_DIRECTORIES ${wlroots_INCLUDE_DIR})
 
 add_subdirectory("subprojects/udis86" udis86)
@@ -200,7 +200,7 @@ target_link_libraries(Hyprland
 )
 
 install(TARGETS Hyprland hyprctl DESTINATION bin)
-install(FILES ${wlroots_LIB_PATH} DESTINATION lib)
+install(FILES ${wlroots_LIBRARY} DESTINATION lib)
 install(DIRECTORY assets/ DESTINATION share/hyprland PATTERN "meson.build" EXCLUDE)
 install(FILES example/hyprland.desktop DESTINATION share/wayland-sessions)
 install(FILES example/hyprland.conf DESTINATION share/hyprland)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.19)
 include(CheckIncludeFile)
+include(ExternalProject)
 
 # Get version
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/props.json PROPS)
@@ -12,7 +13,7 @@ project(Hyprland
 
 set(HYPRLAND_VERSION ${VER})
 set(PREFIX ${CMAKE_INSTALL_PREFIX})
-configure_file(hyprland.pc.in hyprland.pc @ONLY) 
+configure_file(hyprland.pc.in hyprland.pc @ONLY)
 
 set(CMAKE_MESSAGE_LOG_LEVEL "STATUS")
 
@@ -69,12 +70,29 @@ else()
     message(STATUS "Configuring Hyprland in Release with CMake")
 endif()
 
-include_directories(
-  .
-  "subprojects/wlroots/include/"
-  "subprojects/wlroots/build/include/"
-  "subprojects/udis86/"
-  "protocols/")
+set(WLROOTS_SOVERSION 12032)
+
+find_program(MESON_EXE NAMES meson)
+find_program(NINJA_EXE NAMES ninja)
+find_program(SED_EXE NAMES sed)
+ExternalProject_Add(wlroots
+    PREFIX wlroots
+    SOURCE_DIR ${CMAKE_SOURCE_DIR}/subprojects/wlroots
+    PATCH_COMMAND ${SED_EXE} -E -i -e "s/(soversion = 12)([^032]|$$)/soversion = ${WLROOTS_SOVERSION}/g" ${CMAKE_SOURCE_DIR}/subprojects/wlroots/meson.build
+    CONFIGURE_COMMAND ${MESON_EXE} setup --prefix ${CMAKE_CURRENT_BINARY_DIR}/wlroots . ${CMAKE_SOURCE_DIR}/subprojects/wlroots
+    BUILD_COMMAND ${NINJA_EXE} -C .
+    INSTALL_COMMAND ${NINJA_EXE} -C . install)
+
+set(wlroots_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/wlroots/include/)
+
+add_library(wlroots_lib SHARED IMPORTED)
+set_target_properties(wlroots_lib PROPERTIES
+    IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/wlroots/lib/libwlroots.so.${WLROOTS_SOVERSION}
+    INTERFACE_INCLUDE_DIRECTORIES ${wlroots_INCLUDE_DIR})
+
+add_subdirectory("subprojects/udis86" udis86)
+include_directories(${CMAKE_SOURCE_DIR}/subprojects/udis86/ "protocols/")
+
 set(CMAKE_CXX_STANDARD 23)
 add_compile_definitions(WLR_USE_UNSTABLE)
 add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wno-narrowing -Wno-pointer-arith)
@@ -84,14 +102,13 @@ set(CMAKE_ENABLE_EXPORTS TRUE)
 message(STATUS "Checking deps...")
 
 find_package(Threads REQUIRED)
-
 find_package(PkgConfig REQUIRED)
 find_package(OpenGL REQUIRED)
 pkg_check_modules(deps REQUIRED IMPORTED_TARGET wayland-server wayland-client wayland-cursor wayland-protocols cairo libdrm xkbcommon libinput pango pangocairo pixman-1) # we do not check for wlroots, as we provide it ourselves
-
 file(GLOB_RECURSE SRCFILES CONFIGURE_DEPENDS "src/*.cpp")
 
 add_executable(Hyprland ${SRCFILES})
+add_executable(hyprctl hyprctl/main.cpp)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES DEBUG)
     message(STATUS "Setting debug flags")
@@ -144,7 +161,6 @@ target_compile_definitions(Hyprland
     "GIT_DIRTY=\"${GIT_DIRTY}\""
     "GIT_TAG=\"${GIT_TAG}\"")
 
-target_link_libraries(Hyprland rt)
 
 set(CPACK_PROJECT_NAME ${PROJECT_NAME})
 set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
@@ -153,13 +169,13 @@ include(CPack)
 message(STATUS "Setting link libraries")
 
 function(protocol protoPath protoName external)
-    if (external)
+    if(external)
         execute_process(
             COMMAND ${WaylandScanner} server-header ${protoPath} protocols/${protoName}-protocol.h
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
         execute_process(
             COMMAND ${WaylandScanner} private-code ${protoPath} protocols/${protoName}-protocol.c
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})  
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
         target_sources(Hyprland PRIVATE protocols/${protoName}-protocol.c)
     else()
         execute_process(
@@ -167,20 +183,32 @@ function(protocol protoPath protoName external)
             WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
         execute_process(
             COMMAND ${WaylandScanner} private-code ${WAYLAND_PROTOCOLS_DIR}/${protoPath} protocols/${protoName}-protocol.c
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})  
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
         target_sources(Hyprland PRIVATE protocols/${protoName}-protocol.c)
     endif()
 endfunction()
 
-target_link_libraries(Hyprland PkgConfig::deps)
-
 target_link_libraries(Hyprland
-        ${CMAKE_SOURCE_DIR}/subprojects/wlroots/build/libwlroots.so.12032 # wlroots is provided by us
-        OpenGL::EGL
-        OpenGL::GL
-        Threads::Threads
-        ${CMAKE_SOURCE_DIR}/subprojects/udis86/build/libudis86/liblibudis86.a
+    rt
+    PkgConfig::deps
+    OpenGL::EGL
+    OpenGL::GL
+    Threads::Threads
+    wlroots_lib
+    udis86
 )
+
+install(TARGETS Hyprland hyprctl DESTINATION bin)
+install(DIRECTORY assets/ DESTINATION share/hyprland PATTERN "meson.build" EXCLUDE)
+install(FILES example/hyprland.desktop DESTINATION share/wayland-sessions)
+install(FILES example/hyprland.conf DESTINATION share/hyprland)
+install(FILES docs/hyprctl.1 docs/Hyprland.1 DESTINATION share/man/man1)
+
+install(DIRECTORY ${wlroots_INCLUDE_DIR}/ DESTINATION include/hyprland/wlroots)
+install(DIRECTORY protocols/ DESTINATION include/hyprland/protocols PATTERN "meson.build" EXCLUDE)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/hyprland.pc
+    DESTINATION share/pkgconfig)
 
 protocol("protocols/ext-workspace-unstable-v1.xml" "ext-workspace-unstable-v1" true)
 protocol("protocols/idle.xml" "idle" true)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,8 +214,8 @@ else()
     install(DIRECTORY ${wlroots_INCLUDE_DIR}/ DESTINATION include/hyprland/wlroots)
     install(DIRECTORY protocols/ DESTINATION include/hyprland/protocols FILES_MATCHING PATTERN "*.h")    
     install(DIRECTORY src/ DESTINATION include/hyprland/src FILES_MATCHING PATTERN "*.h*")
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/hyprland.pc DESTINATION share/pkgconfig)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/hyprland.pc DESTINATION /usr/share/pkgconfig)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/hyprland.pc
+        DESTINATION share/pkgconfig)
 endif()
 
 protocol("protocols/ext-workspace-unstable-v1.xml" "ext-workspace-unstable-v1" true)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ set(wlroots_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/subprojects/wlroots/include/)
 set(wlroots_LIBRARY ${CMAKE_CURRENT_BINARY_DIR}/wlroots/lib/libwlroots.so.${WLROOTS_SOVERSION})
 
 add_library(wlroots SHARED IMPORTED)
-set_target_properties(wlroots_lib PROPERTIES
+set_target_properties(wlroots PROPERTIES
     IMPORTED_LOCATION ${wlroots_LIBRARY}
     INTERFACE_INCLUDE_DIRECTORIES ${wlroots_INCLUDE_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ set(wlroots_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/subprojects/wlroots/include/)
 set(wlroots_LIBRARY ${CMAKE_CURRENT_BINARY_DIR}/wlroots/lib/libwlroots.so.${WLROOTS_SOVERSION})
 
 add_library(wlroots SHARED IMPORTED)
+add_dependencies(wlroots wlroots_build)
 set_target_properties(wlroots PROPERTIES
     IMPORTED_LOCATION ${wlroots_LIBRARY}
     INTERFACE_INCLUDE_DIRECTORIES ${wlroots_INCLUDE_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,8 +214,8 @@ else()
     install(DIRECTORY ${wlroots_INCLUDE_DIR}/ DESTINATION include/hyprland/wlroots)
     install(DIRECTORY protocols/ DESTINATION include/hyprland/protocols FILES_MATCHING PATTERN "*.h")    
     install(DIRECTORY src/ DESTINATION include/hyprland/src FILES_MATCHING PATTERN "*.h*")
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/hyprland.pc
-        DESTINATION share/pkgconfig)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/hyprland.pc DESTINATION share/pkgconfig)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/hyprland.pc DESTINATION /usr/share/pkgconfig)
 endif()
 
 protocol("protocols/ext-workspace-unstable-v1.xml" "ext-workspace-unstable-v1" true)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,11 +207,16 @@ install(FILES example/hyprland.desktop DESTINATION share/wayland-sessions)
 install(FILES example/hyprland.conf DESTINATION share/hyprland)
 install(FILES docs/hyprctl.1 docs/Hyprland.1 DESTINATION share/man/man1)
 
-install(DIRECTORY ${wlroots_INCLUDE_DIR}/ DESTINATION include/hyprland/wlroots)
-install(DIRECTORY protocols/ DESTINATION include/hyprland/protocols PATTERN "meson.build" EXCLUDE)
-
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/hyprland.pc
-    DESTINATION share/pkgconfig)
+if(NO_DEV)
+    message(STATUS "Development headers disabled")
+else()
+    message(STATUS "Development headers enabled")
+    install(DIRECTORY ${wlroots_INCLUDE_DIR}/ DESTINATION include/hyprland/wlroots)
+    install(DIRECTORY protocols/ DESTINATION include/hyprland/protocols FILES_MATCHING PATTERN "*.h")    
+    install(DIRECTORY src/ DESTINATION include/hyprland/src FILES_MATCHING PATTERN "*.h*")
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/hyprland.pc
+        DESTINATION share/pkgconfig)
+endif()
 
 protocol("protocols/ext-workspace-unstable-v1.xml" "ext-workspace-unstable-v1" true)
 protocol("protocols/idle.xml" "idle" true)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ set(WLROOTS_SOVERSION 12032)
 find_program(MESON_EXE NAMES meson)
 find_program(NINJA_EXE NAMES ninja)
 find_program(SED_EXE NAMES sed)
-ExternalProject_Add(wlroots
+ExternalProject_Add(wlroots_build
     PREFIX wlroots
     SOURCE_DIR ${CMAKE_SOURCE_DIR}/subprojects/wlroots
     PATCH_COMMAND ${SED_EXE} -E -i -e "s/(soversion = 12)([^032]|$$)/soversion = ${WLROOTS_SOVERSION}/g" ${CMAKE_SOURCE_DIR}/subprojects/wlroots/meson.build
@@ -86,7 +86,7 @@ ExternalProject_Add(wlroots
 set(wlroots_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/subprojects/wlroots/include/)
 set(wlroots_LIBRARY ${CMAKE_CURRENT_BINARY_DIR}/wlroots/lib/libwlroots.so.${WLROOTS_SOVERSION})
 
-add_library(wlroots_lib SHARED IMPORTED)
+add_library(wlroots SHARED IMPORTED)
 set_target_properties(wlroots_lib PROPERTIES
     IMPORTED_LOCATION ${wlroots_LIBRARY}
     INTERFACE_INCLUDE_DIRECTORIES ${wlroots_INCLUDE_DIR})
@@ -195,7 +195,7 @@ target_link_libraries(Hyprland
     OpenGL::EGL
     OpenGL::GL
     Threads::Threads
-    wlroots_lib
+    wlroots
     udis86
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,10 +84,11 @@ ExternalProject_Add(wlroots
     INSTALL_COMMAND ${NINJA_EXE} -C . install)
 
 set(wlroots_INCLUDE_DIR ${CMAKE_CURRENT_BINARY_DIR}/wlroots/include/)
+set(wlroots_LIB_PATH ${CMAKE_CURRENT_BINARY_DIR}/wlroots/lib/libwlroots.so.${WLROOTS_SOVERSION})
 
 add_library(wlroots_lib SHARED IMPORTED)
 set_target_properties(wlroots_lib PROPERTIES
-    IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/wlroots/lib/libwlroots.so.${WLROOTS_SOVERSION}
+    IMPORTED_LOCATION ${wlroots_LIB_PATH}
     INTERFACE_INCLUDE_DIRECTORIES ${wlroots_INCLUDE_DIR})
 
 add_subdirectory("subprojects/udis86" udis86)
@@ -199,6 +200,7 @@ target_link_libraries(Hyprland
 )
 
 install(TARGETS Hyprland hyprctl DESTINATION bin)
+install(FILES ${wlroots_LIB_PATH} DESTINATION lib)
 install(DIRECTORY assets/ DESTINATION share/hyprland PATTERN "meson.build" EXCLUDE)
 install(FILES example/hyprland.desktop DESTINATION share/wayland-sessions)
 install(FILES example/hyprland.conf DESTINATION share/hyprland)

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,19 @@
 PREFIX = /usr/local
 
 legacyrenderer:
-	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DLEGACY_RENDERER:BOOL=true -DCMAKE_INSTALL_PREFIX='/usr' -S . -B build -G Ninja
+	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DLEGACY_RENDERER:BOOL=true -S . -B build -G Ninja
 	cmake --build build --config Release -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
 legacyrendererdebug:
-	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -DLEGACY_RENDERER:BOOL=true -DCMAKE_INSTALL_PREFIX='/usr' -S . -B build -G Ninja
+	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -DLEGACY_RENDERER:BOOL=true -S . -B build -G Ninja
 	cmake --build build --config Release -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
 release:
-	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX='/usr' -S . -B build -G Ninja
+	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B build -G Ninja
 	cmake --build build --config Release -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
 debug:
-	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -DCMAKE_INSTALL_PREFIX='/usr' -S . -B build -G Ninja
+	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -S . -B build -G Ninja
 	cmake --build build --config Debug -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
 clear:
@@ -29,7 +29,7 @@ all:
 install:
 	$(MAKE) clear
 	$(MAKE) release
-	cmake --install build
+	cmake --install build --prefix "/usr"
 
 uninstall:
 	rm -f ${PREFIX}/share/wayland-sessions/hyprland.desktop

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,20 @@
 PREFIX = /usr/local
 
 legacyrenderer:
-	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DLEGACY_RENDERER:BOOL=true -S . -B ./build -G Ninja
-	cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
+	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DLEGACY_RENDERER:BOOL=true -S . -B build -G Ninja
+	cmake --build build --config Release -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
 legacyrendererdebug:
-	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -DLEGACY_RENDERER:BOOL=true -S . -B ./build -G Ninja
-	cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
+	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -DLEGACY_RENDERER:BOOL=true -S . -B build -G Ninja
+	cmake --build build --config Release -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
 release:
-	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B ./build -G Ninja
-	cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
+	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B build -G Ninja
+	cmake --build build --config Release -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
 debug:
-	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -S . -B ./build -G Ninja
-	cmake --build ./build --config Debug --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
+	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -S . -B build -G Ninja
+	cmake --build build --config Debug -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
 clear:
 	rm -rf build
@@ -24,48 +24,12 @@ clear:
 
 all:
 	$(MAKE) clear
-	$(MAKE) fixwlr
-	cd ./subprojects/wlroots && meson setup build/ --buildtype=release && ninja -C build/ && mkdir -p ${PREFIX}/lib/ && cp ./build/libwlroots.so.12032 ${PREFIX}/lib/ || echo "Could not install libwlroots to ${PREFIX}/lib/libwlroots.so.12032"
-	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B./build -G Ninja && cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 	$(MAKE) release
-	$(MAKE) -C hyprctl all
 
 install:
 	$(MAKE) clear
-	$(MAKE) fixwlr
-	cd ./subprojects/wlroots && meson setup build/ --buildtype=release && ninja -C build/ && mkdir -p ${PREFIX}/lib/ && cp ./build/libwlroots.so.12032 ${PREFIX}/lib/ || echo "Could not install libwlroots to ${PREFIX}/lib/libwlroots.so.12032"
-	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B./build -G Ninja && cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF` && cd ../..
 	$(MAKE) release
-	$(MAKE) -C hyprctl all
-
-	mkdir -p ${PREFIX}/share/wayland-sessions
-	mkdir -p ${PREFIX}/bin
-	cp -f ./build/Hyprland ${PREFIX}/bin
-	cp -f ./hyprctl/hyprctl ${PREFIX}/bin
-	if [ ! -f ${PREFIX}/share/wayland-sessions/hyprland.desktop ]; then cp ./example/hyprland.desktop ${PREFIX}/share/wayland-sessions; fi
-	mkdir -p ${PREFIX}/share/hyprland
-	cp ./assets/wall_2K.png ${PREFIX}/share/hyprland
-	cp ./assets/wall_4K.png ${PREFIX}/share/hyprland
-	cp ./assets/wall_8K.png ${PREFIX}/share/hyprland
-
-	mkdir -p ${PREFIX}/share/man/man1
-	install -m644 ./docs/*.1 ${PREFIX}/share/man/man1
-
-	mkdir -p ${PREFIX}/include/hyprland
-	mkdir -p ${PREFIX}/include/hyprland/protocols
-	mkdir -p ${PREFIX}/include/hyprland/wlroots
-	mkdir -p ${PREFIX}/share/pkgconfig
-	
-	find src -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland
-	cd subprojects/wlroots/include && find . -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland/wlroots && cd ../../..
-	cd subprojects/wlroots/build/include && find . -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland/wlroots && cd ../../../..
-	cp ./protocols/*-protocol.h ${PREFIX}/include/hyprland/protocols
-	cp ./build/hyprland.pc ${PREFIX}/share/pkgconfig
-	if [ -d /usr/share/pkgconfig ]; then cp ./build/hyprland.pc /usr/share/pkgconfig 2>/dev/null || true; fi
-
-cleaninstall:
-	echo -en "$(MAKE) cleaninstall has been DEPRECATED, you should avoid using it in the future.\nRunning $(MAKE) install instead...\n"
-	$(MAKE) install
+	cmake --install build
 
 uninstall:
 	rm -f ${PREFIX}/share/wayland-sessions/hyprland.desktop

--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,19 @@
 PREFIX = /usr/local
 
 legacyrenderer:
-	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DLEGACY_RENDERER:BOOL=true -S . -B build -G Ninja
+	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DLEGACY_RENDERER:BOOL=true -DCMAKE_INSTALL_PREFIX='/usr' -S . -B build -G Ninja
 	cmake --build build --config Release -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
 legacyrendererdebug:
-	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -DLEGACY_RENDERER:BOOL=true -S . -B build -G Ninja
+	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -DLEGACY_RENDERER:BOOL=true -DCMAKE_INSTALL_PREFIX='/usr' -S . -B build -G Ninja
 	cmake --build build --config Release -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
 release:
-	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B build -G Ninja
+	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX='/usr' -S . -B build -G Ninja
 	cmake --build build --config Release -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
 debug:
-	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -S . -B build -G Ninja
+	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -DCMAKE_INSTALL_PREFIX='/usr' -S . -B build -G Ninja
 	cmake --build build --config Debug -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
 clear:


### PR DESCRIPTION
This PR brings (as far as i can tell) all of the functionality of the Makefile into CMake, which makes it more automated and friendly to package maintainers, and it follows the typical CMake project convention.

Example build:
```sh
$ git clone <Hyprland>
$ cmake -B build -S Hyprland
$ cmake --build build
```
If desired, can be installed with `cmake --install build`

~~It should be ready to go as is.~~
Nvm, i found one issue