### PR TITLE
input: don't move monitor focus on wp change

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1751,7 +1751,7 @@ void CCompositor::swapActiveWorkspaces(CMonitor* pMonitorA, CMonitor* pMonitorB)
     updateFullscreenFadeOnWorkspace(PWORKSPACEB);
     updateFullscreenFadeOnWorkspace(PWORKSPACEA);
 
-    g_pInputManager->refocus();
+    g_pInputManager->simulateMouseMovement();
 
     // event
     g_pEventManager->postEvent(SHyprIPCEvent{"moveworkspace", PWORKSPACEA->m_szName + "," + pMonitorB->szName});
@@ -1936,7 +1936,7 @@ void CCompositor::moveWorkspaceToMonitor(CWorkspace* pWorkspace, CMonitor* pMoni
 
         wlr_cursor_warp(m_sWLRCursor, nullptr, pMonitor->vecPosition.x + pMonitor->vecTransformedSize.x / 2, pMonitor->vecPosition.y + pMonitor->vecTransformedSize.y / 2);
 
-        g_pInputManager->refocus();
+        g_pInputManager->simulateMouseMovement();
     }
 
     // finalize

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -538,7 +538,7 @@ void CMonitor::changeWorkspace(CWorkspace* const pWorkspace, bool internal) {
             g_pCompositor->focusWindow(PLASTWINDOW);
         else {
             g_pCompositor->focusWindow(nullptr);
-            g_pInputManager->refocus();
+            g_pInputManager->simulateMouseMovement();
         }
 
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(ID);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This PR fixes the variant 3 described in Issue #1954: on a multiscreen setup with follow_mouse and mouse_move_focuses_monitor disabled, changing the workspace on one screen with the cursor on another screen will make the focus to follow where the cursor is.

Uses the same logic as b748b07, which fixed the same bug when closing a window.


