### PR TITLE
input: don't refocus when moving window to wp

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -941,7 +941,7 @@ void CKeybindManager::moveActiveToWorkspaceSilent(std::string args) {
     if (const auto PATCOORDS = g_pCompositor->vectorToWindowIdeal(OLDMIDDLE); PATCOORDS && PATCOORDS != PWINDOW)
         g_pCompositor->focusWindow(PATCOORDS);
     else
-        g_pInputManager->refocus();
+        g_pInputManager->simulateMouseMovement();
 }
 
 void CKeybindManager::moveFocusTo(std::string args) {


### PR DESCRIPTION
Fixes a behavior when moving a window to another workspace will sometimes (if the window is the last one of the current workspace) trigger a refocus following the cursor, even when disabled.


