### PR TITLE
Fix broken pipe crash when event listener terminates

### DIFF
--- a/src/managers/EventManager.cpp
+++ b/src/managers/EventManager.cpp
@@ -108,7 +108,9 @@ void CEventManager::flushEvents() {
     for (auto& ev : m_dQueuedEvents) {
         std::string eventString = (ev.event + ">>" + ev.data).substr(0, 1022) + "\n";
         for (auto& fd : m_dAcceptedSocketFDs) {
-            write(fd.first, eventString.c_str(), eventString.length());
+            try {
+                write(fd.first, eventString.c_str(), eventString.length());
+            } catch(...) {}
         }
     }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes a case where hyprland can crash due to a broken IPC pipe.

Here's how to reproduce it:
```bash
socat -d -d -d -U - "UNIX-CONNECT:/tmp/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock" | (while read -r line; do echo "$line"; kill -SIGINT 0; done)
```

Open two windows.  Run that in one.  Change focus (or generate any other IPC event).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This is a race between https://github.com/hyprwm/Hyprland/blob/5627b70981730cf1839ae4477f9fd086d4fc7a6c/src/managers/EventManager.cpp#L27 and https://github.com/hyprwm/Hyprland/blob/5627b70981730cf1839ae4477f9fd086d4fc7a6c/src/managers/EventManager.cpp#L111

The array that keeps track of the FDs does eventually get cleaned up, and maybe this catch block should clean it up immediately, but ignoring it seems ok too.

#### Is it ready for merging, or does it need work?
Ready for merging.

