### PR TITLE
fix incorrect link in per-device config comments

### DIFF
--- a/example/hyprland.conf
+++ b/example/hyprland.conf
@@ -98,7 +98,7 @@ gestures {
 }
 
 # Example per-device config
-# See https://wiki.hyprland.org/Configuring/Keywords/#executing for more
+# See https://wiki.hyprland.org/Configuring/Keywords/#per-device-input-configs for more
 device:epic-mouse-v1 {
     sensitivity = -0.5
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
A link in per-device comment in `example/hyprland.conf` is incorrect and it points to different parts of the same page.
This confused me for a while and I came to create this PR after I discovered this matter.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.
The wiki is very clear and it has helped me a lot.

#### Is it ready for merging, or does it need work?
Ready.

