### PR TITLE
Add hyprland to waybar-hyprland path as fallback for hyprctl

### DIFF
--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -56,6 +56,10 @@ in {
           # use hyprctl to switch workspaces
           sed -i 's/zext_workspace_handle_v1_activate(workspace_handle_);/const std::string command = "hyprctl dispatch workspace " + name_;\n\tsystem(command.c_str());/g' src/modules/wlr/workspace_manager.cpp
         '';
+        postFixup = ''
+          wrapProgram $out/bin/waybar \
+            --suffix PATH : ${lib.makeBinPath [ prev.hyprland ]}
+        '';
         mesonFlags = old.mesonFlags ++ ["-Dexperimental=true"];
       });
     })


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
In some environments, such as using the [home-manager waybar module's systemd integration](https://github.com/nix-community/home-manager/blob/master/modules/programs/waybar.nix#L198), hyprctl may not be in `PATH`. As a result, waybar crashes when attempting to call out to hyprctl to get information for eg. the currently active workspace.

This PR adds a wrapper to the waybar binary, appending hyprctl to `PATH`. This allows waybar to use the current environment's hyprctl, if one exists, and falls back to the default hyprland package if there is none.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This might not be the most efficient way to do this, as it always pulls the `hyprland` derivation no matter what the user is actually using. People using patched versions of hyprland (eg. `hyprland-nvidia`) would end up pulling two copies of Hyprland into the store. While (to my knowledge) this shouldn't break anything in waybar, this does result in a potentially unnecessary copy of Hyprland being added to the store. I'm open to suggestions on improving this.

#### Is it ready for merging, or does it need work?
Assuming the caveat I described above is fine, this should be ready to merge.
