### PR TITLE
Fix UAF in animation end callback if callback deletes the animation

### DIFF
--- a/src/helpers/AnimatedVariable.hpp
+++ b/src/helpers/AnimatedVariable.hpp
@@ -268,8 +268,10 @@ class CAnimatedVariable {
     // methods
     void onAnimationEnd() {
         if (m_fEndCallback) {
+            // loading m_bRemoveEndAfterRan before calling the callback allows the callback to delete this animation safely if it is false.
+            auto removeEndCallback = m_bRemoveEndAfterRan;
             m_fEndCallback(this);
-            if (m_bRemoveEndAfterRan)
+            if (removeEndCallback)
                 m_fEndCallback = nullptr; // reset
         }
     }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Removes use after free when the end callback deletes the animation as long as `m_bRemoveEndAfterRan` is false.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
ready for merge
