### PR TITLE
feat: add ipc set title window event

### DIFF
--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -805,6 +805,7 @@ void Events::listener_setTitleWindow(void* owner, void* data) {
         return;
 
     PWINDOW->m_szTitle = g_pXWaylandManager->getTitle(PWINDOW);
+    g_pEventManager->postEvent(SHyprIPCEvent{"settitlewindow", getFormat("%lx", PWINDOW)});
 
     if (PWINDOW == g_pCompositor->m_pLastWindow) { // if it's the active, let's post an event to update others
         g_pEventManager->postEvent(SHyprIPCEvent{"activewindow", g_pXWaylandManager->getAppIDClass(PWINDOW) + "," + PWINDOW->m_szTitle});

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -805,7 +805,8 @@ void Events::listener_setTitleWindow(void* owner, void* data) {
         return;
 
     PWINDOW->m_szTitle = g_pXWaylandManager->getTitle(PWINDOW);
-    g_pEventManager->postEvent(SHyprIPCEvent{"settitlewindow", getFormat("%lx", PWINDOW)});
+    g_pEventManager->postEvent(SHyprIPCEvent{"windowtitle", getFormat("%lx", PWINDOW)});
+    EMIT_HOOK_EVENT("windowTitle", PWINDOW);
 
     if (PWINDOW == g_pCompositor->m_pLastWindow) { // if it's the active, let's post an event to update others
         g_pEventManager->postEvent(SHyprIPCEvent{"activewindow", g_pXWaylandManager->getAppIDClass(PWINDOW) + "," + PWINDOW->m_szTitle});


### PR DESCRIPTION
Hi, 

This is a very basic PR to be able to get an event only when a window title change. (active and inactive windows)

This will allow me to refresh https://github.com/hyprland-community/hyprland-autoname-workspaces on title update.

Also, hyprland-rs PR is ready for this: https://github.com/hyprland-community/hyprland-rs/pull/56/files

I don't understand/know if we need also to add a `EMIT_HOOK_EVENT("windowTitle", PWINDOW);`

Should I ?