### PR TITLE
Make movetoworkspace register previous workspace

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -881,9 +881,9 @@ void CKeybindManager::moveActiveToWorkspace(std::string args) {
         return;
     }
 
-    auto       pWorkspace = g_pCompositor->getWorkspaceByID(WORKSPACEID);
-    CMonitor*  pMonitor   = nullptr;
-    const auto POLDWS     = g_pCompositor->getWorkspaceByID(PWINDOW->m_iWorkspaceID);
+    auto               pWorkspace            = g_pCompositor->getWorkspaceByID(WORKSPACEID);
+    CMonitor*          pMonitor              = nullptr;
+    const auto         POLDWS                = g_pCompositor->getWorkspaceByID(PWINDOW->m_iWorkspaceID);
     static auto* const PALLOWWORKSPACECYCLES = &g_pConfigManager->getConfigValuePtr("binds:allow_workspace_cycles")->intValue;
 
     g_pHyprRenderer->damageWindow(PWINDOW);
@@ -905,9 +905,8 @@ void CKeybindManager::moveActiveToWorkspace(std::string args) {
     g_pCompositor->focusWindow(PWINDOW);
     g_pCompositor->warpCursorTo(PWINDOW->middle());
 
-    if(*PALLOWWORKSPACECYCLES) {
+    if (*PALLOWWORKSPACECYCLES)
         pWorkspace->m_sPrevWorkspace = {POLDWS->m_iID, POLDWS->m_szName};
-    }
 }
 
 void CKeybindManager::moveActiveToWorkspaceSilent(std::string args) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -884,6 +884,7 @@ void CKeybindManager::moveActiveToWorkspace(std::string args) {
     auto       pWorkspace = g_pCompositor->getWorkspaceByID(WORKSPACEID);
     CMonitor*  pMonitor   = nullptr;
     const auto POLDWS     = g_pCompositor->getWorkspaceByID(PWINDOW->m_iWorkspaceID);
+    static auto* const PALLOWWORKSPACECYCLES = &g_pConfigManager->getConfigValuePtr("binds:allow_workspace_cycles")->intValue;
 
     g_pHyprRenderer->damageWindow(PWINDOW);
 
@@ -903,6 +904,10 @@ void CKeybindManager::moveActiveToWorkspace(std::string args) {
 
     g_pCompositor->focusWindow(PWINDOW);
     g_pCompositor->warpCursorTo(PWINDOW->middle());
+
+    if(*PALLOWWORKSPACECYCLES) {
+        pWorkspace->m_sPrevWorkspace = {POLDWS->m_iID, POLDWS->m_szName};
+    }
 }
 
 void CKeybindManager::moveActiveToWorkspaceSilent(std::string args) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
`movetoworkspace` didn't register previous workspace so there was no way to go back to previous workspace by using `workspace, previous` even if `binds/allow_workspace_cycles` is enabled.

Fixed it such that `movetoworkspace` will update the previous workspace if `binds/allow_workspace_cycles` is enabled.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.

#### Is it ready for merging, or does it need work?

Ready to merge.


