### PR TITLE
Fix fractional scale updates in some cases

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1929,6 +1929,8 @@ void CCompositor::moveWorkspaceToMonitor(CWorkspace* pWorkspace, CMonitor* pMoni
             }
 
             w->updateToplevel();
+
+            g_pProtocolManager->m_pFractionalScaleProtocolManager->setPreferredScaleForSurface(w->m_pWLSurface.wlr(), pMonitor->scale);
         }
     }
 

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -291,8 +291,11 @@ void CWindow::moveToWorkspace(int workspaceID) {
 
     m_iWorkspaceID = workspaceID;
 
-    const auto PMONITOR   = g_pCompositor->getMonitorFromID(m_iMonitorID);
     const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(m_iWorkspaceID);
+
+    m_iMonitorID = PWORKSPACE->m_iMonitorID;
+
+    const auto PMONITOR   = g_pCompositor->getMonitorFromID(m_iMonitorID);
 
     if (PWORKSPACE) {
         g_pEventManager->postEvent(SHyprIPCEvent{"movewindow", getFormat("%lx,%s", this, PWORKSPACE->m_szName.c_str())});


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

The fractional scale of windows was not updated on "keyboard" moves (`movecurrentworkspacetomonitor` and `movetoworkspace` if the target workspace is on a different monitor), while it worked as expected when dragging a window with the mouse. Similar to https://github.com/hyprwm/Hyprland/issues/1794. Although that issue was already fixed, I am observing the same behavior on current `main`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This is my first time doing anything with Hyprland (or even Wayland for that matter), so not sure if I did it right.

In `CWindow::moveToWorkspace()`, the scale used appears to be the one from the previous monitor (where the window used to be), but I'm not sure if there are any unintended side-effects from setting `m_iMonitorID`. If that is bad, the scaling behavior was also fixed by only creating `PMONITOR` from `PWORKSPACE->m_iMonitorID`.

#### Is it ready for merging, or does it need work?

Apart from the above disclaimer, I think it's ready (for what it's worth). I tested it with two monitors of different scale (2.0 and 1.6), and alacritty as client.