### PR TITLE
main: fix segfault when -c is given with no other arguments

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char** argv) {
 
             ignoreSudo = true;
         } else if (it->compare("-c") == 0 || it->compare("--config") == 0) {
-            if (std::next(it)->c_str() == nullptr) {
+            if (std::next(it) == args.end()) {
                 help();
                 return 1;
             }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Has the proper check to prevent `Hyprland -c` from segfaulting.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I'm not gonna lie I'm not totally sure what the preexisting code was trying to do but I don't think it was working so I fixed it.

#### Is it ready for merging, or does it need work?
Should be good to go.

