### PR TITLE
Fix crash when screen size is 0x0

### DIFF
--- a/src/events/Monitors.cpp
+++ b/src/events/Monitors.cpp
@@ -57,6 +57,11 @@ void Events::listener_newOutput(wl_listener* listener, void* data) {
         return;
     }
 
+    if (OUTPUT->width <= 0 || OUTPUT->height <= 0) {
+        Debug::log(ERR, "New monitor has no dimensions?? Ignoring");
+        return;
+    }
+
     if (g_pCompositor->m_bUnsafeState) {
         Debug::log(WARN, "Recovering from an unsafe state. May you be lucky.");
     }

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1165,7 +1165,7 @@ void CHyprOpenGLImpl::makeRawWindowSnapshot(CWindow* pWindow, CFramebuffer* pFra
     // we trust the window is valid.
     const auto PMONITOR = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
 
-    if (!PMONITOR || !PMONITOR->output)
+    if (!PMONITOR || !PMONITOR->output || PMONITOR->vecPixelSize.x <= 0 || PMONITOR->vecPixelSize.y <= 0)
         return;
 
     wlr_output_attach_render(PMONITOR->output, nullptr);
@@ -1224,7 +1224,7 @@ void CHyprOpenGLImpl::makeWindowSnapshot(CWindow* pWindow) {
     // we trust the window is valid.
     const auto PMONITOR = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
 
-    if (!PMONITOR || !PMONITOR->output)
+    if (!PMONITOR || !PMONITOR->output || PMONITOR->vecPixelSize.x <= 0 || PMONITOR->vecPixelSize.y <= 0)
         return;
 
     wlr_output_attach_render(PMONITOR->output, nullptr);
@@ -1288,7 +1288,7 @@ void CHyprOpenGLImpl::makeLayerSnapshot(SLayerSurface* pLayer) {
     // we trust the window is valid.
     const auto PMONITOR = g_pCompositor->getMonitorFromID(pLayer->monitorID);
 
-    if (!PMONITOR || !PMONITOR->output)
+    if (!PMONITOR || !PMONITOR->output || PMONITOR->vecPixelSize.x <= 0 || PMONITOR->vecPixelSize.y <= 0)
         return;
 
     wlr_output_attach_render(PMONITOR->output, nullptr);


### PR DESCRIPTION
Fix crash when screen size is 0x0 (When booting into laptop clam mode in dell XPS)
and also ignore any screen with size 0x0 in the first place

# Crash fix
When I boot into clam mode (lid is closed) on my laptop, the laptop screen is recognized as size 0x0.
Hyprland starts normally and treats it as a regular screen (which i cannot use of course).
Then I can crash it in two ways:
1. Try to disable the monitor (to move all workspaces to the external monitor)
2. Switch to a workspace on the laptop monitor, and close a window.

I get the following error:
```
ASSERTION FAILED! 

cannot alloc a FB with negative / zero size! (attempted 0x0)

at: line 6 in Framebuffer.cpp
```

## Additional work
Since there is no point in using a 0x0 screen,  listener_newOutput will ignore such screens
