### PR TITLE
Partial revert of Commit 302ec13:

### DIFF
--- a/src/events/Monitors.cpp
+++ b/src/events/Monitors.cpp
@@ -57,11 +57,6 @@ void Events::listener_newOutput(wl_listener* listener, void* data) {
         return;
     }
 
-    if (OUTPUT->width <= 0 || OUTPUT->height <= 0) {
-        Debug::log(ERR, "New monitor has no dimensions?? Ignoring");
-        return;
-    }
-
     if (g_pCompositor->m_bUnsafeState) {
         Debug::log(WARN, "Recovering from an unsafe state. May you be lucky.");
     }


### PR DESCRIPTION
Fix crash when screen size is 0x0 (#2523)

Reason: The disable of a monitor with 0x0 size
is causing issuses with some users.

https://github.com/hyprwm/Hyprland/issues/2537

Left the defensive code to resolve the crash.
Will continue to investigate and find a solution for the dell xps disabled monitor

#### Describe your PR, what does it fix/add?


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?


