### PR TITLE
Reloads animated decoration values set on window rules 

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1564,7 +1564,7 @@ void CConfigManager::loadConfigLoadVars() {
     // Update window border colors
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 
-     // Updates dynamic window rules
+    // Updates dynamic window rules
     for (auto& w : g_pCompositor->m_vWindows) {
         if(!w->m_bIsMapped)
             continue;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1564,6 +1564,14 @@ void CConfigManager::loadConfigLoadVars() {
     // Update window border colors
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 
+     // Updates dynamic window rules
+    for (auto& w : g_pCompositor->m_vWindows) {
+        if(!w->m_bIsMapped)
+            continue;
+        
+        w.get()->updateDynamicRules();
+    }
+    
     // update layout
     g_pLayoutManager->switchToLayout(configValues["general:layout"].strValue);
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1566,10 +1566,10 @@ void CConfigManager::loadConfigLoadVars() {
 
     // Updates dynamic window rules
     for (auto& w : g_pCompositor->m_vWindows) {
-        if(!w->m_bIsMapped)
+        if (!w->m_bIsMapped)
             continue;
         
-        w.get()->updateDynamicRules();
+        w->updateDynamicRules();
     }
     
     // update layout

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1561,9 +1561,6 @@ void CConfigManager::loadConfigLoadVars() {
         ensureVRR();
     }
 
-    // Update window border colors
-    g_pCompositor->updateAllWindowsAnimatedDecorationValues();
-
     // Updates dynamic window rules
     for (auto& w : g_pCompositor->m_vWindows) {
         if (!w->m_bIsMapped)
@@ -1571,6 +1568,9 @@ void CConfigManager::loadConfigLoadVars() {
         
         w->updateDynamicRules();
     }
+    
+    // Update window border colors
+    g_pCompositor->updateAllWindowsAnimatedDecorationValues();
     
     // update layout
     g_pLayoutManager->switchToLayout(configValues["general:layout"].strValue);


### PR DESCRIPTION
Reloads animated decoration values like border color and opacity set on window rule on config reload.
didn't notice it wasn't working last time lol