### PR TITLE
groupbar fixes

### DIFF
--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -670,8 +670,9 @@ void CWindow::insertWindowToGroup(CWindow* pWindow) {
     const auto PTAIL = getGroupTail();
 
     if (pWindow->m_sGroupData.pNextWindow) {
+        const auto SHEAD = pWindow->getGroupHead();
         std::vector<CWindow*> members;
-        CWindow*              curr = pWindow;
+        CWindow*              curr = SHEAD;
         do {
             const auto PLAST = curr;
             members.push_back(curr);
@@ -679,7 +680,7 @@ void CWindow::insertWindowToGroup(CWindow* pWindow) {
             PLAST->m_sGroupData.pNextWindow = nullptr;
             PLAST->m_sGroupData.head        = false;
             PLAST->m_sGroupData.locked      = false;
-        } while (curr != pWindow);
+        } while (curr != SHEAD);
 
         for (auto& w : members) {
             insertWindowToGroup(w);
@@ -690,8 +691,6 @@ void CWindow::insertWindowToGroup(CWindow* pWindow) {
 
     PTAIL->m_sGroupData.pNextWindow   = pWindow;
     pWindow->m_sGroupData.pNextWindow = PHEAD;
-
-    setGroupCurrent(pWindow);
 }
 
 void CWindow::updateGroupOutputs() {

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -670,9 +670,9 @@ void CWindow::insertWindowToGroup(CWindow* pWindow) {
     const auto PTAIL = getGroupTail();
 
     if (pWindow->m_sGroupData.pNextWindow) {
-        const auto SHEAD = pWindow->getGroupHead();
+        const auto            PHEAD = pWindow->getGroupHead();
         std::vector<CWindow*> members;
-        CWindow*              curr = SHEAD;
+        CWindow*              curr = PHEAD;
         do {
             const auto PLAST = curr;
             members.push_back(curr);
@@ -680,7 +680,7 @@ void CWindow::insertWindowToGroup(CWindow* pWindow) {
             PLAST->m_sGroupData.pNextWindow = nullptr;
             PLAST->m_sGroupData.head        = false;
             PLAST->m_sGroupData.locked      = false;
-        } while (curr != SHEAD);
+        } while (curr != PHEAD);
 
         for (auto& w : members) {
             insertWindowToGroup(w);

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -311,18 +311,33 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow) {
     }
 
     // if it's a group, add the window
-    if (OPENINGON->pWindow->m_sGroupData.pNextWindow && !OPENINGON->pWindow->getGroupHead()->m_sGroupData.locked && // target is an unlocked group
-        (!pWindow->m_sGroupData.pNextWindow || !pWindow->getGroupHead()->m_sGroupData.locked)                       // source is not group or is a unlocked group
-        && !g_pKeybindManager->m_bGroupsLocked) {
-        m_lDwindleNodesData.remove(*PNODE);
+    if (OPENINGON->pWindow->m_sGroupData.pNextWindow && !OPENINGON->pWindow->getGroupHead()->m_sGroupData.locked &&
+        !g_pKeybindManager->m_bGroupsLocked) { // target is an unlocked group
 
-        OPENINGON->pWindow->insertWindowToGroup(pWindow);
+        if (!pWindow->m_sGroupData.pNextWindow) { // source is not group
+            m_lDwindleNodesData.remove(*PNODE);
+            OPENINGON->pWindow->insertWindowToGroup(pWindow);
+            OPENINGON->pWindow->setGroupCurrent(pWindow);
 
-        pWindow->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(pWindow));
-        pWindow->updateWindowDecos();
-        recalculateWindow(pWindow);
+            pWindow->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(pWindow));
+            pWindow->updateWindowDecos();
+            recalculateWindow(pWindow);
 
-        return;
+            g_pCompositor->focusWindow(pWindow);
+            return;
+        }
+
+        if (!pWindow->getGroupHead()->m_sGroupData.locked) { // source is a unlocked group
+            m_lDwindleNodesData.remove(*PNODE);
+            OPENINGON->pWindow->insertWindowToGroup(pWindow);
+            OPENINGON->pWindow->setGroupCurrent(pWindow);
+
+            pWindow->updateWindowDecos();
+            recalculateWindow(pWindow);
+
+            g_pCompositor->focusWindow(pWindow);
+            return;
+        }
     }
 
     // If it's not, get the node under our cursor

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -314,7 +314,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow) {
     if (OPENINGON->pWindow->m_sGroupData.pNextWindow && !OPENINGON->pWindow->getGroupHead()->m_sGroupData.locked &&
         !g_pKeybindManager->m_bGroupsLocked) { // target is an unlocked group
 
-        if (!pWindow->m_sGroupData.pNextWindow) { // source is not group
+        if (!pWindow->m_sGroupData.pNextWindow) { // source is not a group
             m_lDwindleNodesData.remove(*PNODE);
             OPENINGON->pWindow->insertWindowToGroup(pWindow);
             OPENINGON->pWindow->setGroupCurrent(pWindow);
@@ -327,7 +327,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow) {
             return;
         }
 
-        if (!pWindow->getGroupHead()->m_sGroupData.locked) { // source is a unlocked group
+        if (!pWindow->getGroupHead()->m_sGroupData.locked) { // source is an unlocked group
             m_lDwindleNodesData.remove(*PNODE);
             OPENINGON->pWindow->insertWindowToGroup(pWindow);
             OPENINGON->pWindow->setGroupCurrent(pWindow);

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -91,16 +91,34 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow) {
                       getNodeFromWindow(g_pCompositor->m_pLastWindow) :
                       getMasterNodeOnWorkspace(pWindow->m_iWorkspaceID);
 
-    if (OPENINGON && OPENINGON->pWindow->m_sGroupData.pNextWindow && !OPENINGON->pWindow->getGroupHead()->m_sGroupData.locked && // target is an unlocked group
-        (!pWindow->m_sGroupData.pNextWindow || !pWindow->getGroupHead()->m_sGroupData.locked)                                    // source is not group or is an unlocked group
-        && OPENINGON != PNODE && !g_pKeybindManager->m_bGroupsLocked) {
-        m_lMasterNodesData.remove(*PNODE);
+    // if it's a group, add the window
+    if (OPENINGON && OPENINGON->pWindow->m_sGroupData.pNextWindow && !OPENINGON->pWindow->getGroupHead()->m_sGroupData.locked && !g_pKeybindManager->m_bGroupsLocked &&
+        OPENINGON != PNODE) { // target is an unlocked group
 
-        OPENINGON->pWindow->insertWindowToGroup(pWindow);
+        if (!pWindow->m_sGroupData.pNextWindow) { // source is not group
+            m_lMasterNodesData.remove(*PNODE);
+            OPENINGON->pWindow->insertWindowToGroup(pWindow);
+            OPENINGON->pWindow->setGroupCurrent(pWindow);
 
-        pWindow->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(pWindow));
+            pWindow->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(pWindow));
+            pWindow->updateWindowDecos();
+            recalculateWindow(pWindow);
 
-        return;
+            g_pCompositor->focusWindow(pWindow);
+            return;
+        }
+
+        if (!pWindow->getGroupHead()->m_sGroupData.locked) { // source is a unlocked group
+            m_lMasterNodesData.remove(*PNODE);
+            OPENINGON->pWindow->insertWindowToGroup(pWindow);
+            OPENINGON->pWindow->setGroupCurrent(pWindow);
+
+            pWindow->updateWindowDecos();
+            recalculateWindow(pWindow);
+
+            g_pCompositor->focusWindow(pWindow);
+            return;
+        }
     }
 
     if (*PNEWISMASTER || WINDOWSONWORKSPACE == 1 || (!pWindow->m_bFirstMap && OPENINGON->isMaster)) {

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -95,7 +95,7 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow) {
     if (OPENINGON && OPENINGON->pWindow->m_sGroupData.pNextWindow && !OPENINGON->pWindow->getGroupHead()->m_sGroupData.locked && !g_pKeybindManager->m_bGroupsLocked &&
         OPENINGON != PNODE) { // target is an unlocked group
 
-        if (!pWindow->m_sGroupData.pNextWindow) { // source is not group
+        if (!pWindow->m_sGroupData.pNextWindow) { // source is not a group
             m_lMasterNodesData.remove(*PNODE);
             OPENINGON->pWindow->insertWindowToGroup(pWindow);
             OPENINGON->pWindow->setGroupCurrent(pWindow);
@@ -108,7 +108,7 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow) {
             return;
         }
 
-        if (!pWindow->getGroupHead()->m_sGroupData.locked) { // source is a unlocked group
+        if (!pWindow->getGroupHead()->m_sGroupData.locked) { // source is an unlocked group
             m_lMasterNodesData.remove(*PNODE);
             OPENINGON->pWindow->insertWindowToGroup(pWindow);
             OPENINGON->pWindow->setGroupCurrent(pWindow);
@@ -294,7 +294,7 @@ void CHyprMasterLayout::calculateWorkspace(const int& ws) {
     if ((WINDOWS < 2) && !centerMasterWindow) {
         PMASTERNODE->position = PMONITOR->vecReservedTopLeft + PMONITOR->vecPosition;
         PMASTERNODE->size     = Vector2D(PMONITOR->vecSize.x - PMONITOR->vecReservedTopLeft.x - PMONITOR->vecReservedBottomRight.x,
-                                         PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PMONITOR->vecReservedTopLeft.y);
+                                     PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PMONITOR->vecReservedTopLeft.y);
         applyNodeDataToWindow(PMASTERNODE);
         return;
     } else if (orientation == ORIENTATION_LEFT || orientation == ORIENTATION_RIGHT || (orientation == ORIENTATION_CENTER && STACKWINDOWS <= 1)) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1170,6 +1170,8 @@ void CKeybindManager::moveActiveTo(std::string args) {
 
 void CKeybindManager::toggleGroup(std::string args) {
     const auto PWINDOW = g_pCompositor->m_pLastWindow;
+   
+    g_pCompositor->setWindowFullscreen(PWINDOW, false, FULLSCREEN_FULL);
 
     if (!PWINDOW)
         return;

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1219,6 +1219,7 @@ void CKeybindManager::toggleGroup(std::string args) {
 
 void CKeybindManager::changeGroupActive(std::string args) {
     const auto PWINDOW = g_pCompositor->m_pLastWindow;
+
     if (!PWINDOW)
         return;
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1170,11 +1170,11 @@ void CKeybindManager::moveActiveTo(std::string args) {
 
 void CKeybindManager::toggleGroup(std::string args) {
     const auto PWINDOW = g_pCompositor->m_pLastWindow;
-   
-    g_pCompositor->setWindowFullscreen(PWINDOW, false, FULLSCREEN_FULL);
 
     if (!PWINDOW)
         return;
+
+    g_pCompositor->setWindowFullscreen(PWINDOW, false, FULLSCREEN_FULL);
 
     if (!PWINDOW->m_sGroupData.pNextWindow) {
         PWINDOW->m_sGroupData.pNextWindow = PWINDOW;
@@ -1219,7 +1219,6 @@ void CKeybindManager::toggleGroup(std::string args) {
 
 void CKeybindManager::changeGroupActive(std::string args) {
     const auto PWINDOW = g_pCompositor->m_pLastWindow;
-
     if (!PWINDOW)
         return;
 
@@ -2029,11 +2028,16 @@ void CKeybindManager::moveIntoGroup(std::string args) {
     if (!PWINDOWINDIR || !PWINDOWINDIR->m_sGroupData.pNextWindow)
         return;
 
-    g_pLayoutManager->getCurrentLayout()->onWindowRemoved(PWINDOW);
+    if (!PWINDOW->m_sGroupData.pNextWindow) {
+        PWINDOW->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(PWINDOW));
+    }
+
+    g_pLayoutManager->getCurrentLayout()->onWindowRemoved(PWINDOW); // This removes groupped property!
+
+    PWINDOW->m_sGroupData.locked = false;
+    PWINDOW->m_sGroupData.head   = false;
 
     PWINDOWINDIR->insertWindowToGroup(PWINDOW);
-
-    PWINDOW->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(PWINDOW));
 
     PWINDOW->updateWindowDecos();
     g_pLayoutManager->getCurrentLayout()->recalculateWindow(PWINDOW);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1207,10 +1207,12 @@ void CKeybindManager::toggleGroup(std::string args) {
                 w->m_sGroupData.head = false;
             }
 
+            g_pKeybindManager->m_bGroupsLocked = true;
             for (auto& w : members) {
                 g_pLayoutManager->getCurrentLayout()->onWindowCreated(w);
                 w->updateWindowDecos();
             }
+            g_pKeybindManager->m_bGroupsLocked = false;
         }
     }
 
@@ -2029,9 +2031,8 @@ void CKeybindManager::moveIntoGroup(std::string args) {
     if (!PWINDOWINDIR || !PWINDOWINDIR->m_sGroupData.pNextWindow)
         return;
 
-    if (!PWINDOW->m_sGroupData.pNextWindow) {
+    if (!PWINDOW->m_sGroupData.pNextWindow)
         PWINDOW->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(PWINDOW));
-    }
 
     g_pLayoutManager->getCurrentLayout()->onWindowRemoved(PWINDOW); // This removes groupped property!
 
@@ -2039,9 +2040,10 @@ void CKeybindManager::moveIntoGroup(std::string args) {
     PWINDOW->m_sGroupData.head   = false;
 
     PWINDOWINDIR->insertWindowToGroup(PWINDOW);
-
+    PWINDOWINDIR->setGroupCurrent(PWINDOW);
     PWINDOW->updateWindowDecos();
     g_pLayoutManager->getCurrentLayout()->recalculateWindow(PWINDOW);
+    g_pCompositor->focusWindow(PWINDOW);
 }
 
 void CKeybindManager::moveOutOfGroup(std::string args) {

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -42,7 +42,7 @@ void CHyprGroupBarDecoration::updateWindow(CWindow* pWindow) {
         // we draw 3px above the window's border with 3px
         static auto* const PBORDERSIZE = &g_pConfigManager->getConfigValuePtr("general:border_size")->intValue;
 
-        m_seExtents.topLeft     = Vector2D(0, *PBORDERSIZE + BAR_PADDING_OUTER_VERT * 2 + BAR_INDICATOR_HEIGHT + (*PRENDERTITLES ? *PTITLEFONTSIZE : 0));
+        m_seExtents.topLeft     = Vector2D(0, *PBORDERSIZE + BAR_PADDING_OUTER_VERT * 2 + BAR_INDICATOR_HEIGHT + (*PRENDERTITLES ? *PTITLEFONTSIZE : 0) + 2);
         m_seExtents.bottomRight = Vector2D();
 
         m_vLastWindowPos  = pWindow->m_vRealPosition.vec() + WORKSPACEOFFSET;
@@ -80,9 +80,8 @@ void CHyprGroupBarDecoration::updateWindow(CWindow* pWindow) {
 }
 
 void CHyprGroupBarDecoration::damageEntire() {
-    const auto EXTENTS = getWindowDecorationReservedArea();
-    wlr_box    dm      = {m_vLastWindowPos.x - m_seExtents.topLeft.x + EXTENTS.topLeft.x, m_vLastWindowPos.y - m_seExtents.topLeft.y + EXTENTS.topLeft.y - 2,
-                          m_vLastWindowSize.x + m_seExtents.topLeft.x + m_seExtents.bottomRight.x, m_seExtents.topLeft.y};
+    wlr_box dm = {m_vLastWindowPos.x - m_seExtents.topLeft.x, m_vLastWindowPos.y - m_seExtents.topLeft.y, m_vLastWindowSize.x + m_seExtents.topLeft.x + m_seExtents.bottomRight.x,
+                  m_seExtents.topLeft.y};
     g_pHyprRenderer->damageBox(&dm);
 }
 


### PR DESCRIPTION
Fixes multiple groupbar decoration issues:
- togglegroup removes fullscreen to avoid to avoid weird state
- fixes issue where a group had multiple windows with head = true
- fixes issue where merging 2 groups would cause a window to have 2 groupbar decorations
- fixes issue where merging a group with more than 1 window into another group would make windows have no groupbar decoration
- fixes issue where ungrouping windows could just move them into another group on the same workspace  

probably more but I don't remember

Dwindle Layout as been tested and seems stable and working as intended.
Master Layout seem to work as well, but has been less tested and I'm less familiar with how it works. 

Known issues:
- Still haven't found the cause of the focused window groupbar not getting correctly updated when there are multiple groups open side by side (text gets streched) (was already on main branch). Probably related to multiple groupbar damage issues open here.

- There is also an unusual animation the first time opening a window that was in a group after merging it with another group (only on Master Layout). Still haven't found the cause. (was already on main branch as well)

Probably ready to merge, but a bit of testing would be good

Closes:
- https://github.com/hyprwm/Hyprland/issues/1595