### PR TITLE
Nix CI: split inputs and wlroots updating

### DIFF
--- a/.github/workflows/nix-update-inputs.yaml
+++ b/.github/workflows/nix-update-inputs.yaml
@@ -1,0 +1,40 @@
+name: "Nix update"
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  update:
+    name: "inputs"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Clone repository
+      uses: actions/checkout@v3
+
+    - name: Install nix
+      uses: cachix/install-nix-action@v20
+      with:
+        install_url: https://nixos.org/nix/install
+        extra_nix_config: |
+          auto-optimise-store = true
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+          experimental-features = nix-command flakes
+
+    - name: Update lockfile
+      run: nix/update-nixpkgs.sh
+
+    - uses: cachix/cachix-action@v12
+      with:
+        name: hyprland
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
+    - name: Build packages
+      run: nix flake check --print-build-logs --accept-flake-config
+
+    - name: Build Waybar-Hyprland
+      run: nix build .#waybar-hyprland --print-build-logs
+
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        commit_message: "Nix: bump inputs"

--- a/.github/workflows/nix-update-wlroots.yaml
+++ b/.github/workflows/nix-update-wlroots.yaml
@@ -1,13 +1,15 @@
-name: "Nix: update lockfile"
+name: "Nix update"
 
 on: [push, workflow_dispatch]
 
 jobs:
   update:
+    name: "wlroots"
     runs-on: ubuntu-latest
     steps:
     - name: Clone repository
       uses: actions/checkout@v3
+
     - name: Install nix
       uses: cachix/install-nix-action@v20
       with:
@@ -16,14 +18,18 @@ jobs:
           auto-optimise-store = true
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
           experimental-features = nix-command flakes
+
     - name: Update lockfile
-      run: nix/update-inputs.sh
+      run: nix/update-wlroots.sh
+
     - uses: cachix/cachix-action@v12
       with:
         name: hyprland
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - name: Build Waybar-Hyprland
-      run: nix build .#waybar-hyprland --print-build-logs
+
+    - name: Build packages
+      run: nix flake check --print-build-logs --accept-flake-config
+
     - uses: stefanzweifel/git-auto-commit-action@v4
       with:
-        commit_message: "[gha] bump flake inputs"
+        commit_message: "Nix: bump wlroots"

--- a/nix/update-wlroots.sh
+++ b/nix/update-wlroots.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env -S nix shell nixpkgs#gawk nixpkgs#git nixpkgs#gnused nixpkgs#jq nixpkgs#ripgrep -c bash
+
+# get wlroots revision from submodule
+SUB_REV=$(git submodule status | rg wlroots | awk '{ print substr($1,2)}')
+# and from lockfile
+CRT_REV=$(jq <flake.lock '.nodes.wlroots.locked.rev' -r)
+
+if [ "$SUB_REV" != "$CRT_REV" ]; then
+  echo "Updating wlroots..."
+  # update wlroots to submodule revision
+  nix flake lock --override-input wlroots "gitlab:wlroots/wlroots/$SUB_REV?host=gitlab.freedesktop.org"
+
+  # fix revision in wlroots.wrap
+  sed -Ei "s/[a-z0-9]{40}/$SUB_REV/g" subprojects/wlroots.wrap
+else
+  echo "wlroots is up to date!"
+fi


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Now there are separate update scripts for wlroots and for all other
inputs.
`nix/update-inputs.sh` will check daily for new versions of mesa in Nixpkgs and update the inputs if a newer one is found.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
From the limited testing I've done, it seems to work.

#### Is it ready for merging, or does it need work?
Ready, just need a few more eyes approving it.
@n3oney @NotAShelf @FlafyDev
