### PR TITLE
Close socket2 client descriptor on hangup

### DIFF
--- a/src/managers/EventManager.cpp
+++ b/src/managers/EventManager.cpp
@@ -30,6 +30,8 @@ int fdHandleWrite(int fd, uint32_t mask, void* data) {
                 it++;
             }
         }
+
+        close(fd);
     };
 
     if (mask & WL_EVENT_ERROR || mask & WL_EVENT_HANGUP) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Each process has a limited number of file descriptors. Exhausting such a limit will lead to a crash.

STR:
1. Get the ~current fd count:
`ls -l /proc/$(ps ux|grep Hyprland|grep -v grep|awk '{print $2}')/fd|wc -l`
2. Initiate several connections and terminate them:
`COUNT=5;PIDS=(); for i in $(seq 1 $COUNT); do nc -dU /tmp/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock &; LP=$!; PIDS+=("${LP}");done;sleep 2;for p in "${PIDS[@]}"; do kill -9 $p; done`
3. Double-check the number after execution:
`ls -l /proc/$(ps ux|grep Hyprland|grep -v grep|awk '{print $2}')/fd|wc -l`

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready

