### PR TITLE
Avoid passing unix socket descriptors to children

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1305,7 +1305,7 @@ int hyprCtlFDTick(int fd, uint32_t mask, void* data) {
     sockaddr_in clientAddress;
     socklen_t   clientSize = sizeof(clientAddress);
 
-    const auto  ACCEPTEDCONNECTION = accept(HyprCtl::iSocketFD, (sockaddr*)&clientAddress, &clientSize);
+    const auto  ACCEPTEDCONNECTION = accept4(HyprCtl::iSocketFD, (sockaddr*)&clientAddress, &clientSize, SOCK_CLOEXEC);
 
     char        readBuffer[1024];
 
@@ -1336,7 +1336,7 @@ int hyprCtlFDTick(int fd, uint32_t mask, void* data) {
 
 void HyprCtl::startHyprCtlSocket() {
 
-    iSocketFD = socket(AF_UNIX, SOCK_STREAM, 0);
+    iSocketFD = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
 
     if (iSocketFD < 0) {
         Debug::log(ERR, "Couldn't start the Hyprland Socket. (1) IPC will not work.");

--- a/src/managers/EventManager.cpp
+++ b/src/managers/EventManager.cpp
@@ -60,7 +60,7 @@ int fdHandleWrite(int fd, uint32_t mask, void* data) {
 
 void CEventManager::startThread() {
     m_tThread = std::thread([&]() {
-        const auto SOCKET = socket(AF_UNIX, SOCK_STREAM, 0);
+        const auto SOCKET = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
 
         if (SOCKET < 0) {
             Debug::log(ERR, "Couldn't start the Hyprland Socket 2. (1) IPC will not work.");
@@ -82,7 +82,7 @@ void CEventManager::startThread() {
         Debug::log(LOG, "Hypr socket 2 started at %s", socketPath.c_str());
 
         while (1) {
-            const auto ACCEPTEDCONNECTION = accept(SOCKET, (sockaddr*)&clientAddress, &clientSize);
+            const auto ACCEPTEDCONNECTION = accept4(SOCKET, (sockaddr*)&clientAddress, &clientSize, SOCK_CLOEXEC);
 
             if (ACCEPTEDCONNECTION > 0) {
                 // new connection!


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Add FD_CLOEXEC flags to the server-side connection FDs to make them closed during exec-family functions execution.

STR:
1. Initiate a new terminal window
2. Spawn event command reader:
```
nc -U /tmp/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock
```
3. Initiate one more window
4. Type the following commands in it [3]:

```
$ lsof /tmp/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket{2,}.sock 2>/dev/null| grep $$
bash      1061789 hyprland-test   36u  unix 0x000000004aaa7091      0t0 18495726 /tmp/hypr/8407a9af0a333ade66d4deff7ef654a4594fe58f_1688619429/.socket.sock type=STREAM (LISTEN)
bash      1061789 hyprland-test   44u  unix 0x000000001fe46f8c      0t0 18493131 /tmp/hypr/8407a9af0a333ade66d4deff7ef654a4594fe58f_1688619429/.socket2.sock type=STREAM (LISTEN)
bash      1061789 hyprland-test   79u  unix 0x0000000072ffe8f2      0t0 18493151 /tmp/hypr/8407a9af0a333ade66d4deff7ef654a4594fe58f_1688619429/.socket2.sock type=STREAM (CONNECTED)
```
As you can see bash instance (pid=1061789) has retrieved FDs from Hyprland, even the connection socket that was initiated in [2].

5. Try to make some dirt using instance [3]:
```
$ echo fakemsg 1>&79
```
6. Check the instance [2]:
```activewindow>>Alacritty,hyprland-test:~
activewindowv2>>7f0bcc538f20
>>>>fakemsg<<<<
windowtitle>>7f0bcc538f20
activewindowv2>>7f0bcc538f20
activewindow>>Alacritty,hyprland-test:~
activewindow>>Alacritty,hyprland-test:~
activewindowv2>>7f0bcf4f2700
```

So currently any child could access Hyprland-side descriptors and even accept inbound connections to command and event sockets.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Ready
