### PR TITLE
eventmanager: drop obsoleted ignore events flag

### DIFF
--- a/src/helpers/Workspace.cpp
+++ b/src/helpers/Workspace.cpp
@@ -36,7 +36,7 @@ CWorkspace::CWorkspace(int monitorID, std::string name, bool special) {
     m_vRenderOffset.registerVar();
     m_fAlpha.registerVar();
 
-    g_pEventManager->postEvent({"createworkspace", m_szName}, true);
+    g_pEventManager->postEvent({"createworkspace", m_szName});
     EMIT_HOOK_EVENT("createWorkspace", this);
 }
 
@@ -51,7 +51,7 @@ CWorkspace::~CWorkspace() {
         m_pWlrHandle = nullptr;
     }
 
-    g_pEventManager->postEvent({"destroyworkspace", m_szName}, true);
+    g_pEventManager->postEvent({"destroyworkspace", m_szName});
     EMIT_HOOK_EVENT("destroyWorkspace", this);
 }
 

--- a/src/managers/EventManager.cpp
+++ b/src/managers/EventManager.cpp
@@ -121,9 +121,9 @@ void CEventManager::flushEvents() {
     eventQueueMutex.unlock();
 }
 
-void CEventManager::postEvent(const SHyprIPCEvent event, bool force) {
+void CEventManager::postEvent(const SHyprIPCEvent event) {
 
-    if ((m_bIgnoreEvents && !force) || g_pCompositor->m_bIsShuttingDown) {
+    if (g_pCompositor->m_bIsShuttingDown) {
         Debug::log(WARN, "Suppressed (ignoreevents true / shutting down) event of type %s, content: %s", event.event.c_str(), event.data.c_str());
         return;
     }

--- a/src/managers/EventManager.hpp
+++ b/src/managers/EventManager.hpp
@@ -15,14 +15,11 @@ class CEventManager {
   public:
     CEventManager();
 
-    void        postEvent(const SHyprIPCEvent event, bool force = false);
+    void        postEvent(const SHyprIPCEvent event);
 
     void        startThread();
 
-    bool        m_bIgnoreEvents = false;
-
     std::thread m_tThread;
-
   private:
     void                                         flushEvents();
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -637,7 +637,7 @@ void CInputManager::newKeyboard(wlr_input_device* keyboard) {
             const auto PKEYBOARD = (SKeyboard*)owner;
             const auto LAYOUT    = getActiveLayoutForKeyboard(PKEYBOARD);
 
-            g_pEventManager->postEvent(SHyprIPCEvent{"activelayout", PKEYBOARD->name + "," + LAYOUT}, true); // force as this should ALWAYS be sent
+            g_pEventManager->postEvent(SHyprIPCEvent{"activelayout", PKEYBOARD->name + "," + LAYOUT});
             EMIT_HOOK_EVENT("activeLayout", (std::vector<void*>{PKEYBOARD, (void*)&LAYOUT}));
         },
         PNEWKEYBOARD, "Keyboard");
@@ -676,7 +676,7 @@ void CInputManager::newVirtualKeyboard(wlr_input_device* keyboard) {
             const auto PKEYBOARD = (SKeyboard*)owner;
             const auto LAYOUT    = getActiveLayoutForKeyboard(PKEYBOARD);
 
-            g_pEventManager->postEvent(SHyprIPCEvent{"activelayout", PKEYBOARD->name + "," + LAYOUT}, true); // force as this should ALWAYS be sent
+            g_pEventManager->postEvent(SHyprIPCEvent{"activelayout", PKEYBOARD->name + "," + LAYOUT});
             EMIT_HOOK_EVENT("activeLayout", (std::vector<void*>{PKEYBOARD, (void*)&LAYOUT}));
         },
         PNEWKEYBOARD, "Keyboard");
@@ -820,7 +820,7 @@ void CInputManager::applyConfigToKeyboard(SKeyboard* pKeyboard) {
 
     const auto LAYOUTSTR = getActiveLayoutForKeyboard(pKeyboard);
 
-    g_pEventManager->postEvent(SHyprIPCEvent{"activelayout", pKeyboard->name + "," + LAYOUTSTR}, true); // force as this should ALWAYS be sent
+    g_pEventManager->postEvent(SHyprIPCEvent{"activelayout", pKeyboard->name + "," + LAYOUTSTR});
     EMIT_HOOK_EVENT("activeLayout", (std::vector<void*>{pKeyboard, (void*)&LAYOUTSTR}));
 
     Debug::log(LOG, "Set the keyboard layout to %s and variant to %s for keyboard \"%s\"", rules.layout, rules.variant, pKeyboard->keyboard->name);
@@ -1106,7 +1106,7 @@ void CInputManager::onKeyboardMod(void* data, SKeyboard* pKeyboard) {
 
         const auto LAYOUT = getActiveLayoutForKeyboard(pKeyboard);
 
-        g_pEventManager->postEvent(SHyprIPCEvent{"activelayout", pKeyboard->name + "," + LAYOUT}, true); // force as this should ALWAYS be sent
+        g_pEventManager->postEvent(SHyprIPCEvent{"activelayout", pKeyboard->name + "," + LAYOUT});
         EMIT_HOOK_EVENT("activeLayout", (std::vector<void*>{pKeyboard, (void*)&LAYOUT}));
     }
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This flag became obsoleted in the commit
287e6c4ede30c8e5e85863cd85f157e17e24879c

Consequentially force argument in postEvent changes nothing cause m_bIgnoreEvents is always false, thus can be removed.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Look like no, any event is forced in the current codebase.

#### Is it ready for merging, or does it need work?

Ready
