### PR TITLE
Reuse monitor IDs, and use minimum available monitor ID for next monitor

### DIFF
--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -101,6 +101,8 @@ class CCompositor {
     std::vector<CWindow*>                     m_vWindowsFadingOut;
     std::vector<SLayerSurface*>               m_vSurfacesFadingOut;
 
+    std::unordered_map<std::string, int64_t>  m_mMonitorIDMap;
+
     void                                      initServer();
     void                                      startCompositor();
     void                                      cleanup();
@@ -168,7 +170,7 @@ class CCompositor {
     CMonitor*      getMonitorInDirection(const char&);
     void           updateAllWindowsAnimatedDecorationValues();
     void           updateWindowAnimatedDecorationValues(CWindow*);
-    int            getNextAvailableMonitorID();
+    int            getNextAvailableMonitorID(std::string const & name);
     void           moveWorkspaceToMonitor(CWorkspace*, CMonitor*);
     void           swapActiveWorkspaces(CMonitor*, CMonitor*);
     CMonitor*      getMonitorFromString(const std::string&);

--- a/src/events/Monitors.cpp
+++ b/src/events/Monitors.cpp
@@ -76,7 +76,7 @@ void Events::listener_newOutput(wl_listener* listener, void* data) {
         Debug::log(LOG, "Adding completely new monitor.");
         PNEWMONITORWRAP = &g_pCompositor->m_vRealMonitors.emplace_back(std::make_shared<CMonitor>());
 
-        (*PNEWMONITORWRAP)->ID = g_pCompositor->getNextAvailableMonitorID();
+        (*PNEWMONITORWRAP)->ID = g_pCompositor->getNextAvailableMonitorID(OUTPUT->name);
     }
 
     const auto PNEWMONITOR = PNEWMONITORWRAP->get();


### PR DESCRIPTION
Fixes #2601

#### Describe your PR, what does it fix/add?
Instead of setting the next monitor's ID to the maximum available ID, this PR will find the minimum available ID. Unplugging and replugging a monitor will give it the same ID. Before this change, reconnecting a monitor would give it the maximum ID + 1.



#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
More info can be found in #2601

#### Is it ready for merging, or does it need work?
Ready for merging: tested on a laptop with 2 external monitors, unplugging and replugging them a couple of times.

