### PR TITLE
monitor desc support

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -498,6 +498,16 @@ CMonitor* CCompositor::getMonitorFromName(const std::string& name) {
     return nullptr;
 }
 
+CMonitor* CCompositor::getMonitorFromDesc(const std::string& desc) {
+    for (auto& m : m_vMonitors) {
+        if (desc == m->output->description) {
+            return m.get();
+        }
+    }
+
+    return nullptr;
+}
+
 CMonitor* CCompositor::getMonitorFromCursor() {
     const auto COORDS = Vector2D(m_sWLRCursor->x, m_sWLRCursor->y);
 

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -28,8 +28,7 @@
 #include "hyprerror/HyprError.hpp"
 #include "plugins/PluginSystem.hpp"
 
-enum eManagersInitStage
-{
+enum eManagersInitStage {
     STAGE_PRIORITY = 0,
     STAGE_LATE
 };
@@ -123,6 +122,7 @@ class CCompositor {
 
     CMonitor*      getMonitorFromID(const int&);
     CMonitor*      getMonitorFromName(const std::string&);
+    CMonitor*      getMonitorFromDesc(const std::string&);
     CMonitor*      getMonitorFromCursor();
     CMonitor*      getMonitorFromVector(const Vector2D&);
     void           removeWindowFromVectorSafe(CWindow*);

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2106,7 +2106,11 @@ void CConfigManager::addParseError(const std::string& err) {
 }
 
 CMonitor* CConfigManager::getBoundMonitorForWS(const std::string& wsname) {
-    return g_pCompositor->getMonitorFromName(getBoundMonitorStringForWS(wsname));
+    auto monitor = getBoundMonitorStringForWS(wsname);
+    if (monitor.substr(0, 5) == "desc:")
+        return g_pCompositor->getMonitorFromDesc(monitor.substr(5));
+    else
+        return g_pCompositor->getMonitorFromName(monitor);
 }
 
 std::string CConfigManager::getBoundMonitorStringForWS(const std::string& wsname) {


### PR DESCRIPTION
Adds monitor description support in workspace rules (by using "monitor:desc:<description_here>")

maybe config format is not ideal but seems consistent with monitor conf
wiki should probably mention this feature
