### PR TITLE
Add support for smart splitting

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -157,7 +157,7 @@ void CConfigManager::setDefaultVars() {
     configValues["dwindle:no_gaps_when_only"].intValue            = 0;
     configValues["dwindle:use_active_for_splits"].intValue        = 1;
     configValues["dwindle:default_split_ratio"].floatValue        = 1.f;
-    configValues["dwindle:smart_split"].intValue                  = 1;
+    configValues["dwindle:smart_split"].intValue                  = 0;
 
     configValues["master:special_scale_factor"].floatValue = 0.8f;
     configValues["master:mfact"].floatValue                = 0.55f;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -157,6 +157,7 @@ void CConfigManager::setDefaultVars() {
     configValues["dwindle:no_gaps_when_only"].intValue            = 0;
     configValues["dwindle:use_active_for_splits"].intValue        = 1;
     configValues["dwindle:default_split_ratio"].floatValue        = 1.f;
+    configValues["dwindle:smart_split"].intValue                  = 1;
 
     configValues["master:special_scale_factor"].floatValue = 0.8f;
     configValues["master:mfact"].floatValue                = 0.55f;

--- a/src/helpers/Vector2D.cpp
+++ b/src/helpers/Vector2D.cpp
@@ -37,3 +37,11 @@ double Vector2D::distance(const Vector2D& other) const {
     double dy = y - other.y;
     return std::sqrt(dx * dx + dy * dy);
 }
+
+bool Vector2D::inTriangle(const Vector2D& p1, const Vector2D& p2, const Vector2D& p3) const {
+    const auto a = ((p2.y - p3.y)*(x - p3.x) + (p3.x - p2.x)*(y - p3.y)) / ((p2.y - p3.y)*(p1.x - p3.x) + (p3.x - p2.x)*(p1.y - p3.y));
+    const auto b = ((p3.y - p1.y)*(x - p3.x) + (p1.x - p3.x)*(y - p3.y)) / ((p2.y - p3.y)*(p1.x - p3.x) + (p3.x - p2.x)*(p1.y - p3.y));
+    const auto c = 1 - a - b;
+
+    return 0 <= a && a <= 1 && 0 <= b && b <= 1 && 0 <= c && c <= 1;
+}

--- a/src/helpers/Vector2D.cpp
+++ b/src/helpers/Vector2D.cpp
@@ -39,8 +39,8 @@ double Vector2D::distance(const Vector2D& other) const {
 }
 
 bool Vector2D::inTriangle(const Vector2D& p1, const Vector2D& p2, const Vector2D& p3) const {
-    const auto a = ((p2.y - p3.y)*(x - p3.x) + (p3.x - p2.x)*(y - p3.y)) / ((p2.y - p3.y)*(p1.x - p3.x) + (p3.x - p2.x)*(p1.y - p3.y));
-    const auto b = ((p3.y - p1.y)*(x - p3.x) + (p1.x - p3.x)*(y - p3.y)) / ((p2.y - p3.y)*(p1.x - p3.x) + (p3.x - p2.x)*(p1.y - p3.y));
+    const auto a = ((p2.y - p3.y) * (x - p3.x) + (p3.x - p2.x) * (y - p3.y)) / ((p2.y - p3.y) * (p1.x - p3.x) + (p3.x - p2.x) * (p1.y - p3.y));
+    const auto b = ((p3.y - p1.y) * (x - p3.x) + (p1.x - p3.x) * (y - p3.y)) / ((p2.y - p3.y) * (p1.x - p3.x) + (p3.x - p2.x) * (p1.y - p3.y));
     const auto c = 1 - a - b;
 
     return 0 <= a && a <= 1 && 0 <= b && b <= 1 && 0 <= c && c <= 1;

--- a/src/helpers/Vector2D.hpp
+++ b/src/helpers/Vector2D.hpp
@@ -48,4 +48,6 @@ class Vector2D {
     Vector2D clamp(const Vector2D& min, const Vector2D& max = Vector2D()) const;
 
     Vector2D floor() const;
+
+    bool inTriangle(const Vector2D& p1, const Vector2D& p2, const Vector2D& p3) const;
 };

--- a/src/helpers/Vector2D.hpp
+++ b/src/helpers/Vector2D.hpp
@@ -49,5 +49,5 @@ class Vector2D {
 
     Vector2D floor() const;
 
-    bool inTriangle(const Vector2D& p1, const Vector2D& p2, const Vector2D& p3) const;
+    bool     inTriangle(const Vector2D& p1, const Vector2D& p2, const Vector2D& p3) const;
 };

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -397,19 +397,19 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow) {
         const auto cc = NEWPARENT->position + NEWPARENT->size / 2;
 
         if (MOUSECOORDS.inTriangle(tl, tr, cc)) {
-            NEWPARENT->splitTop = true;
+            NEWPARENT->splitTop    = true;
             NEWPARENT->children[0] = PNODE;
             NEWPARENT->children[1] = OPENINGON;
         } else if (MOUSECOORDS.inTriangle(tr, cc, br)) {
-            NEWPARENT->splitTop = false;
+            NEWPARENT->splitTop    = false;
             NEWPARENT->children[0] = OPENINGON;
             NEWPARENT->children[1] = PNODE;
         } else if (MOUSECOORDS.inTriangle(br, bl, cc)) {
-            NEWPARENT->splitTop = true;
+            NEWPARENT->splitTop    = true;
             NEWPARENT->children[0] = OPENINGON;
             NEWPARENT->children[1] = PNODE;
         } else {
-            NEWPARENT->splitTop = false;
+            NEWPARENT->splitTop    = false;
             NEWPARENT->children[0] = PNODE;
             NEWPARENT->children[1] = OPENINGON;
         }

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -6,10 +6,11 @@ void SDwindleNodeData::recalcSizePosRecursive(bool force, bool horizontalOverrid
 
         const auto         REVERSESPLITRATIO = 2.f - splitRatio;
 
+        static auto* const PSMARTSPLIT    = &g_pConfigManager->getConfigValuePtr("dwindle:smart_split")->intValue;
         static auto* const PPRESERVESPLIT = &g_pConfigManager->getConfigValuePtr("dwindle:preserve_split")->intValue;
         static auto* const PFLMULT        = &g_pConfigManager->getConfigValuePtr("dwindle:split_width_multiplier")->floatValue;
 
-        if (*PPRESERVESPLIT == 0) {
+        if (*PPRESERVESPLIT == 0 && *PSMARTSPLIT == 0) {
             splitTop = size.y * *PFLMULT > size.x;
         }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Imagine a square or rectangular box. Picture two diagonal lines crossing each other to form an 'X' that divides the box into four equal sections or triangles. Each triangle is an equal quarter of the box.

This PR adds support for splitting depending on which section the mouse cursor is currently over. Personally, I find this slightly more intuitive.

A new configuration option has been added `dwindle:smart_split`, which has to be set to `1` in order for this functionality to be enabled.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Not that I know- but I'm new to the codebase so feel free to check!

#### Is it ready for merging, or does it need work?

Maybe give it a different name. "smart_split" isn't very smart ;)

Also, maybe a second option to only enabling this when *moving* a window?
