### PR TITLE
Dwindle: Make resize more intuitive

### DIFF
--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -672,41 +672,43 @@ void CHyprDwindleLayout::resizeActiveWindow(const Vector2D& pixResize, eRectCorn
         const auto PPARENT = PCURRENT->pParent;
 
         if (!PVOUTER && PPARENT->splitTop && ((TOP && PPARENT->children[1] == PCURRENT) || (BOTTOM && PPARENT->children[0] == PCURRENT)))
-            PVOUTER = PPARENT;
-        else if (!PVOUTER && !PVINNER && PPARENT->splitTop && ((TOP && PPARENT->children[0] == PCURRENT) || (BOTTOM && PPARENT->children[1] == PCURRENT)))
-            PVINNER = PPARENT;
+            PVOUTER = PCURRENT;
+        else if (!PVOUTER && !PVINNER && PPARENT->splitTop)
+            PVINNER = PCURRENT;
         else if (!PHOUTER && !PPARENT->splitTop && ((LEFT && PPARENT->children[1] == PCURRENT) || (RIGHT && PPARENT->children[0] == PCURRENT)))
-            PHOUTER = PPARENT;
-        else if (!PHOUTER && !PHINNER && !PPARENT->splitTop && ((LEFT && PPARENT->children[0] == PCURRENT) || (RIGHT && PPARENT->children[1] == PCURRENT)))
-            PHINNER = PPARENT;
+            PHOUTER = PCURRENT;
+        else if (!PHOUTER && !PHINNER && !PPARENT->splitTop)
+            PHINNER = PCURRENT;
     }
 
     if (PHOUTER) {
-        PHOUTER->splitRatio = std::clamp(PHOUTER->splitRatio + allowedMovement.x * 2.f / PHOUTER->size.x, 0.1, 1.9);
+        PHOUTER->pParent->splitRatio = std::clamp(PHOUTER->pParent->splitRatio + allowedMovement.x * 2.f / PHOUTER->pParent->size.x, 0.1, 1.9);
 
         if (PHINNER) {
-            const auto ORIGINAL = PHINNER->children[LEFT ? 0 : 1]->size.x;
-            PHOUTER->recalcSizePosRecursive(*PANIMATE == 0);
-            const auto DELTA      = LEFT ? -allowedMovement.x : allowedMovement.x;
-            const auto SPLITRATIO = std::clamp((ORIGINAL + DELTA) / PHINNER->size.x * 2.f, 0.1, 1.9);
-            PHINNER->splitRatio   = LEFT ? SPLITRATIO : (2.f - SPLITRATIO);
-            PHINNER->recalcSizePosRecursive(*PANIMATE == 0);
+            const auto ORIGINAL = PHINNER->size.x;
+            PHOUTER->pParent->recalcSizePosRecursive(*PANIMATE == 0);
+            if (PHINNER->pParent->children[0] == PHINNER)
+                PHINNER->pParent->splitRatio = std::clamp((ORIGINAL - allowedMovement.x) / PHINNER->pParent->size.x * 2.f, 0.1, 1.9);
+            else
+                PHINNER->pParent->splitRatio = std::clamp(2 - (ORIGINAL + allowedMovement.x) / PHINNER->pParent->size.x * 2.f, 0.1, 1.9);
+            PHINNER->pParent->recalcSizePosRecursive(*PANIMATE == 0);
         } else
-            PHOUTER->recalcSizePosRecursive(*PANIMATE == 0);
+            PHOUTER->pParent->recalcSizePosRecursive(*PANIMATE == 0);
     }
 
     if (PVOUTER) {
-        PVOUTER->splitRatio = std::clamp(PVOUTER->splitRatio + allowedMovement.y * 2.f / PVOUTER->size.y, 0.1, 1.9);
+        PVOUTER->pParent->splitRatio = std::clamp(PVOUTER->pParent->splitRatio + allowedMovement.y * 2.f / PVOUTER->pParent->size.y, 0.1, 1.9);
 
         if (PVINNER) {
-            const auto ORIGINAL = PVINNER->children[TOP ? 0 : 1]->size.y;
-            PVOUTER->recalcSizePosRecursive(*PANIMATE == 0);
-            const auto DELTA      = TOP ? -allowedMovement.y : allowedMovement.y;
-            const auto SPLITRATIO = std::clamp((ORIGINAL + DELTA) / PVINNER->size.y * 2.f, 0.1, 1.9);
-            PVINNER->splitRatio   = TOP ? SPLITRATIO : (2.f - SPLITRATIO);
-            PVINNER->recalcSizePosRecursive(*PANIMATE == 0);
+            const auto ORIGINAL = PVINNER->size.y;
+            PVOUTER->pParent->recalcSizePosRecursive(*PANIMATE == 0);
+            if (PVINNER->pParent->children[0] == PVINNER)
+                PVINNER->pParent->splitRatio = std::clamp((ORIGINAL - allowedMovement.y) / PVINNER->pParent->size.y * 2.f, 0.1, 1.9);
+            else
+                PVINNER->pParent->splitRatio = std::clamp(2 - (ORIGINAL + allowedMovement.y) / PVINNER->pParent->size.y * 2.f, 0.1, 1.9);
+            PVINNER->pParent->recalcSizePosRecursive(*PANIMATE == 0);
         } else
-            PVOUTER->recalcSizePosRecursive(*PANIMATE == 0);
+            PVOUTER->pParent->recalcSizePosRecursive(*PANIMATE == 0);
     }
 }
 

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -663,10 +663,10 @@ void CHyprDwindleLayout::resizeActiveWindow(const Vector2D& pixResize, eRectCorn
     SDwindleNodeData* PHOUTER = nullptr;
     SDwindleNodeData* PHINNER = nullptr;
 
-    const auto LEFT = corner == CORNER_TOPLEFT || corner == CORNER_BOTTOMLEFT;
-    const auto TOP = corner == CORNER_TOPLEFT || corner == CORNER_TOPRIGHT;
-    const auto RIGHT = corner == CORNER_TOPRIGHT || corner == CORNER_BOTTOMRIGHT;
-    const auto BOTTOM = corner == CORNER_BOTTOMLEFT || corner == CORNER_BOTTOMRIGHT;
+    const auto        LEFT   = corner == CORNER_TOPLEFT || corner == CORNER_BOTTOMLEFT;
+    const auto        TOP    = corner == CORNER_TOPLEFT || corner == CORNER_TOPRIGHT;
+    const auto        RIGHT  = corner == CORNER_TOPRIGHT || corner == CORNER_BOTTOMRIGHT;
+    const auto        BOTTOM = corner == CORNER_BOTTOMLEFT || corner == CORNER_BOTTOMRIGHT;
 
     for (auto PCURRENT = PNODE; PCURRENT && PCURRENT->pParent; PCURRENT = PCURRENT->pParent) {
         const auto PPARENT = PCURRENT->pParent;
@@ -687,9 +687,9 @@ void CHyprDwindleLayout::resizeActiveWindow(const Vector2D& pixResize, eRectCorn
         if (PHINNER) {
             const auto ORIGINAL = PHINNER->children[LEFT ? 0 : 1]->size.x;
             PHOUTER->recalcSizePosRecursive(*PANIMATE == 0);
-            const auto DELTA = LEFT ? -allowedMovement.x : allowedMovement.x;
+            const auto DELTA      = LEFT ? -allowedMovement.x : allowedMovement.x;
             const auto SPLITRATIO = std::clamp((ORIGINAL + DELTA) / PHINNER->size.x * 2.f, 0.1, 1.9);
-            PHINNER->splitRatio = LEFT ? SPLITRATIO : (2.f - SPLITRATIO);
+            PHINNER->splitRatio   = LEFT ? SPLITRATIO : (2.f - SPLITRATIO);
             PHINNER->recalcSizePosRecursive(*PANIMATE == 0);
         } else
             PHOUTER->recalcSizePosRecursive(*PANIMATE == 0);
@@ -701,14 +701,13 @@ void CHyprDwindleLayout::resizeActiveWindow(const Vector2D& pixResize, eRectCorn
         if (PVINNER) {
             const auto ORIGINAL = PVINNER->children[TOP ? 0 : 1]->size.y;
             PVOUTER->recalcSizePosRecursive(*PANIMATE == 0);
-            const auto DELTA = TOP ? -allowedMovement.y : allowedMovement.y;
+            const auto DELTA      = TOP ? -allowedMovement.y : allowedMovement.y;
             const auto SPLITRATIO = std::clamp((ORIGINAL + DELTA) / PVINNER->size.y * 2.f, 0.1, 1.9);
-            PVINNER->splitRatio = TOP ? SPLITRATIO : (2.f - SPLITRATIO);
+            PVINNER->splitRatio   = TOP ? SPLITRATIO : (2.f - SPLITRATIO);
             PVINNER->recalcSizePosRecursive(*PANIMATE == 0);
         } else
             PVOUTER->recalcSizePosRecursive(*PANIMATE == 0);
     }
-    
 }
 
 void CHyprDwindleLayout::fullscreenRequestForWindow(CWindow* pWindow, eFullscreenMode fullscreenMode, bool on) {

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -656,7 +656,7 @@ void CHyprDwindleLayout::resizeActiveWindow(const Vector2D& pixResize, eRectCorn
     if (DISPLAYBOTTOM && DISPLAYTOP)
         allowedMovement.y = 0;
 
-    // Identify inner and outer parent nodes for both directions.
+    // Identify inner and outer nodes for both directions.
 
     SDwindleNodeData* PVOUTER = nullptr;
     SDwindleNodeData* PVINNER = nullptr;
@@ -667,18 +667,22 @@ void CHyprDwindleLayout::resizeActiveWindow(const Vector2D& pixResize, eRectCorn
     const auto        TOP    = corner == CORNER_TOPLEFT || corner == CORNER_TOPRIGHT;
     const auto        RIGHT  = corner == CORNER_TOPRIGHT || corner == CORNER_BOTTOMRIGHT;
     const auto        BOTTOM = corner == CORNER_BOTTOMLEFT || corner == CORNER_BOTTOMRIGHT;
+    const auto        NONE   = corner == CORNER_NONE;
 
     for (auto PCURRENT = PNODE; PCURRENT && PCURRENT->pParent; PCURRENT = PCURRENT->pParent) {
         const auto PPARENT = PCURRENT->pParent;
 
-        if (!PVOUTER && PPARENT->splitTop && ((TOP && PPARENT->children[1] == PCURRENT) || (BOTTOM && PPARENT->children[0] == PCURRENT)))
+        if (!PVOUTER && PPARENT->splitTop && (NONE || (TOP && PPARENT->children[1] == PCURRENT) || (BOTTOM && PPARENT->children[0] == PCURRENT)))
             PVOUTER = PCURRENT;
         else if (!PVOUTER && !PVINNER && PPARENT->splitTop)
             PVINNER = PCURRENT;
-        else if (!PHOUTER && !PPARENT->splitTop && ((LEFT && PPARENT->children[1] == PCURRENT) || (RIGHT && PPARENT->children[0] == PCURRENT)))
+        else if (!PHOUTER && !PPARENT->splitTop && (NONE || (LEFT && PPARENT->children[1] == PCURRENT) || (RIGHT && PPARENT->children[0] == PCURRENT)))
             PHOUTER = PCURRENT;
         else if (!PHOUTER && !PHINNER && !PPARENT->splitTop)
             PHINNER = PCURRENT;
+
+        if (PVOUTER && PHOUTER)
+            break;
     }
 
     if (PHOUTER) {

--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -55,7 +55,7 @@ class CHyprDwindleLayout : public IHyprLayout {
     virtual void                     recalculateMonitor(const int&);
     virtual void                     recalculateWindow(CWindow*);
     virtual void                     onBeginDragWindow();
-    virtual void                     resizeActiveWindow(const Vector2D&, eRectCorner corner, CWindow* pWindow = nullptr);
+    virtual void                     resizeActiveWindow(const Vector2D&, eRectCorner corner = CORNER_NONE, CWindow* pWindow = nullptr);
     virtual void                     fullscreenRequestForWindow(CWindow*, eFullscreenMode, bool);
     virtual std::any                 layoutMessage(SLayoutMessageHeader, std::string);
     virtual SWindowRenderLayoutHints requestRenderHints(CWindow*);

--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -55,7 +55,7 @@ class CHyprDwindleLayout : public IHyprLayout {
     virtual void                     recalculateMonitor(const int&);
     virtual void                     recalculateWindow(CWindow*);
     virtual void                     onBeginDragWindow();
-    virtual void                     resizeActiveWindow(const Vector2D&, CWindow* pWindow = nullptr);
+    virtual void                     resizeActiveWindow(const Vector2D&, eRectCorner corner, CWindow* pWindow = nullptr);
     virtual void                     fullscreenRequestForWindow(CWindow*, eFullscreenMode, bool);
     virtual std::any                 layoutMessage(SLayoutMessageHeader, std::string);
     virtual SWindowRenderLayoutHints requestRenderHints(CWindow*);

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -344,7 +344,7 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
 
             g_pXWaylandManager->setWindowSize(DRAGGINGWINDOW, DRAGGINGWINDOW->m_vRealSize.goalv());
         } else {
-            resizeActiveWindow(TICKDELTA, DRAGGINGWINDOW);
+            resizeActiveWindow(TICKDELTA, m_eGrabbedCorner, DRAGGINGWINDOW);
         }
     }
 

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -15,8 +15,7 @@ struct SLayoutMessageHeader {
 
 enum eFullscreenMode : uint8_t;
 
-enum eRectCorner
-{
+enum eRectCorner {
     CORNER_TOPLEFT = 0,
     CORNER_TOPRIGHT,
     CORNER_BOTTOMRIGHT,
@@ -146,7 +145,7 @@ interface IHyprLayout {
     /*
         Called for replacing any data a layout has for a new window
     */
-    virtual void replaceWindowDataWith(CWindow * from, CWindow * to) = 0;
+    virtual void replaceWindowDataWith(CWindow* from, CWindow* to) = 0;
 
   private:
     Vector2D    m_vBeginDragXY;

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -16,7 +16,8 @@ struct SLayoutMessageHeader {
 enum eFullscreenMode : uint8_t;
 
 enum eRectCorner {
-    CORNER_TOPLEFT = 0,
+    CORNER_NONE = 0,
+    CORNER_TOPLEFT,
     CORNER_TOPRIGHT,
     CORNER_BOTTOMRIGHT,
     CORNER_BOTTOMLEFT
@@ -75,7 +76,7 @@ interface IHyprLayout {
         Vector2D holds pixel values
         Optional pWindow for a specific window
     */
-    virtual void resizeActiveWindow(const Vector2D&, eRectCorner corner, CWindow* pWindow = nullptr) = 0;
+    virtual void resizeActiveWindow(const Vector2D&, eRectCorner corner = CORNER_NONE, CWindow* pWindow = nullptr) = 0;
     /*
         Called when a user requests a move of the current window by a vec
         Vector2D holds pixel values

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -76,7 +76,7 @@ interface IHyprLayout {
         Vector2D holds pixel values
         Optional pWindow for a specific window
     */
-    virtual void resizeActiveWindow(const Vector2D&, CWindow* pWindow = nullptr) = 0;
+    virtual void resizeActiveWindow(const Vector2D&, eRectCorner corner, CWindow* pWindow = nullptr) = 0;
     /*
         Called when a user requests a move of the current window by a vec
         Vector2D holds pixel values

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -590,7 +590,7 @@ bool CHyprMasterLayout::isWindowTiled(CWindow* pWindow) {
     return getNodeFromWindow(pWindow) != nullptr;
 }
 
-void CHyprMasterLayout::resizeActiveWindow(const Vector2D& pixResize, CWindow* pWindow) {
+void CHyprMasterLayout::resizeActiveWindow(const Vector2D& pixResize, eRectCorner corner, CWindow* pWindow) {
     const auto PWINDOW = pWindow ? pWindow : g_pCompositor->m_pLastWindow;
 
     if (!g_pCompositor->windowValidMapped(PWINDOW))

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -294,7 +294,7 @@ void CHyprMasterLayout::calculateWorkspace(const int& ws) {
     if ((WINDOWS < 2) && !centerMasterWindow) {
         PMASTERNODE->position = PMONITOR->vecReservedTopLeft + PMONITOR->vecPosition;
         PMASTERNODE->size     = Vector2D(PMONITOR->vecSize.x - PMONITOR->vecReservedTopLeft.x - PMONITOR->vecReservedBottomRight.x,
-                                     PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PMONITOR->vecReservedTopLeft.y);
+                                         PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PMONITOR->vecReservedTopLeft.y);
         applyNodeDataToWindow(PMASTERNODE);
         return;
     } else if (orientation == ORIENTATION_LEFT || orientation == ORIENTATION_RIGHT || (orientation == ORIENTATION_CENTER && STACKWINDOWS <= 1)) {

--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -51,7 +51,7 @@ class CHyprMasterLayout : public IHyprLayout {
     virtual bool                     isWindowTiled(CWindow*);
     virtual void                     recalculateMonitor(const int&);
     virtual void                     recalculateWindow(CWindow*);
-    virtual void                     resizeActiveWindow(const Vector2D&, eRectCorner corner, CWindow* pWindow = nullptr);
+    virtual void                     resizeActiveWindow(const Vector2D&, eRectCorner corner = CORNER_NONE, CWindow* pWindow = nullptr);
     virtual void                     fullscreenRequestForWindow(CWindow*, eFullscreenMode, bool);
     virtual std::any                 layoutMessage(SLayoutMessageHeader, std::string);
     virtual SWindowRenderLayoutHints requestRenderHints(CWindow*);

--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -52,7 +52,7 @@ class CHyprMasterLayout : public IHyprLayout {
     virtual bool                     isWindowTiled(CWindow*);
     virtual void                     recalculateMonitor(const int&);
     virtual void                     recalculateWindow(CWindow*);
-    virtual void                     resizeActiveWindow(const Vector2D&, CWindow* pWindow = nullptr);
+    virtual void                     resizeActiveWindow(const Vector2D&, eRectCorner corner, CWindow* pWindow = nullptr);
     virtual void                     fullscreenRequestForWindow(CWindow*, eFullscreenMode, bool);
     virtual std::any                 layoutMessage(SLayoutMessageHeader, std::string);
     virtual SWindowRenderLayoutHints requestRenderHints(CWindow*);

--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -9,8 +9,7 @@
 enum eFullscreenMode : uint8_t;
 
 //orientation determines which side of the screen the master area resides
-enum eOrientation : uint8_t
-{
+enum eOrientation : uint8_t {
     ORIENTATION_LEFT = 0,
     ORIENTATION_TOP,
     ORIENTATION_RIGHT,

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1583,7 +1583,7 @@ void CKeybindManager::resizeActive(std::string args) {
     if (SIZ.x < 1 || SIZ.y < 1)
         return;
 
-    g_pLayoutManager->getCurrentLayout()->resizeActiveWindow(SIZ - g_pCompositor->m_pLastWindow->m_vRealSize.goalv(), CORNER_BOTTOMRIGHT);
+    g_pLayoutManager->getCurrentLayout()->resizeActiveWindow(SIZ - g_pCompositor->m_pLastWindow->m_vRealSize.goalv());
 
     if (g_pCompositor->m_pLastWindow->m_vRealSize.goalv().x > 1 && g_pCompositor->m_pLastWindow->m_vRealSize.goalv().y > 1)
         g_pCompositor->m_pLastWindow->setHidden(false);
@@ -1638,7 +1638,7 @@ void CKeybindManager::resizeWindow(std::string args) {
     if (SIZ.x < 1 || SIZ.y < 1)
         return;
 
-    g_pLayoutManager->getCurrentLayout()->resizeActiveWindow(SIZ - PWINDOW->m_vRealSize.goalv(), CORNER_BOTTOMRIGHT, PWINDOW);
+    g_pLayoutManager->getCurrentLayout()->resizeActiveWindow(SIZ - PWINDOW->m_vRealSize.goalv(), CORNER_NONE, PWINDOW);
 
     if (PWINDOW->m_vRealSize.goalv().x > 1 && PWINDOW->m_vRealSize.goalv().y > 1)
         PWINDOW->setHidden(false);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1583,7 +1583,7 @@ void CKeybindManager::resizeActive(std::string args) {
     if (SIZ.x < 1 || SIZ.y < 1)
         return;
 
-    g_pLayoutManager->getCurrentLayout()->resizeActiveWindow(SIZ - g_pCompositor->m_pLastWindow->m_vRealSize.goalv());
+    g_pLayoutManager->getCurrentLayout()->resizeActiveWindow(SIZ - g_pCompositor->m_pLastWindow->m_vRealSize.goalv(), CORNER_BOTTOMRIGHT);
 
     if (g_pCompositor->m_pLastWindow->m_vRealSize.goalv().x > 1 && g_pCompositor->m_pLastWindow->m_vRealSize.goalv().y > 1)
         g_pCompositor->m_pLastWindow->setHidden(false);
@@ -1638,7 +1638,7 @@ void CKeybindManager::resizeWindow(std::string args) {
     if (SIZ.x < 1 || SIZ.y < 1)
         return;
 
-    g_pLayoutManager->getCurrentLayout()->resizeActiveWindow(SIZ - PWINDOW->m_vRealSize.goalv(), PWINDOW);
+    g_pLayoutManager->getCurrentLayout()->resizeActiveWindow(SIZ - PWINDOW->m_vRealSize.goalv(), CORNER_BOTTOMRIGHT, PWINDOW);
 
     if (PWINDOW->m_vRealSize.goalv().x > 1 && PWINDOW->m_vRealSize.goalv().y > 1)
         PWINDOW->setHidden(false);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This improves resizing to make it a little more intuitive. It allows you to to change the size by dragging any corner of the window while anchoring the opposite side.

I think this issue is related:
https://github.com/hyprwm/Hyprland/issues/2112

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Not currently.

#### Is it ready for merging, or does it need work?

Couple of questions:

Should this behavior be opt-in? 
When using keyboard resizing, should we use the old behavior?
