### PR TITLE
Fix new LAYER_TOP layer surface rendering above fullscreen windows

### DIFF
--- a/src/events/Layers.cpp
+++ b/src/events/Layers.cpp
@@ -157,9 +157,11 @@ void Events::listener_mapLayerSurface(void* owner, void* data) {
     wlr_box geomFixed = {layersurface->geometry.x + PMONITOR->vecPosition.x, layersurface->geometry.y + PMONITOR->vecPosition.y, layersurface->geometry.width,
                          layersurface->geometry.height};
     g_pHyprRenderer->damageBox(&geomFixed);
+    const auto WORKSPACE  = g_pCompositor->getWorkspaceByID(PMONITOR->activeWorkspace);
+    const bool FULLSCREEN = WORKSPACE->m_bHasFullscreenWindow && WORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL;
 
     layersurface->alpha.setValue(0);
-    layersurface->alpha         = 1.f;
+    layersurface->alpha         = ((layersurface->layer == ZWLR_LAYER_SHELL_V1_LAYER_TOP && FULLSCREEN) ? 0.f : 1.f);
     layersurface->readyToDelete = false;
     layersurface->fadingOut     = false;
 


### PR DESCRIPTION

#### Describe your PR, what does it fix/add?

Any newly created LAYER_TOP layer surface renders above fullscreen windows because the alpha for that depth is only set when the window initially goes fullscreen. This PR sets new TOP layer surfaces' alpha value to zero if there is a fullscreen window in the active workspace.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No?


#### Is it ready for merging, or does it need work?
It should be ready, although it feels a bit weird to have the layer map event go poking around in the workspace state? Maybe there's a better way to do this?


