### PR TITLE
move/resize window visual improvments

### DIFF
--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -241,6 +241,9 @@ void IHyprLayout::onBeginDragWindow() {
     g_pHyprRenderer->damageWindow(DRAGGINGWINDOW);
 
     g_pKeybindManager->shadowKeybinds();
+
+    g_pCompositor->focusWindow(DRAGGINGWINDOW);
+    g_pCompositor->moveWindowToTop(DRAGGINGWINDOW);
 }
 
 void IHyprLayout::onEndDragWindow() {
@@ -266,8 +269,6 @@ void IHyprLayout::onEndDragWindow() {
     }
 
     g_pHyprRenderer->damageWindow(DRAGGINGWINDOW);
-
-    g_pCompositor->focusWindow(DRAGGINGWINDOW);
 }
 
 void IHyprLayout::onMouseMove(const Vector2D& mousePos) {


### PR DESCRIPTION
Moves window to top when moving/resizing starts
Also moves focus to window when moving/resizing starts instead of when moving/resizing ends

didn't find any issues/reason to do it at the end instead of beggining
closes https://github.com/hyprwm/Hyprland/issues/2684