### PR TITLE
Make bind modifiers case-insensitive

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -102,6 +102,7 @@ void CKeybindManager::removeKeybind(uint32_t mod, const std::string& key) {
 
 uint32_t CKeybindManager::stringToModMask(std::string mods) {
     uint32_t modMask = 0;
+    std::transform(mods.begin(), mods.end(), mods.begin(), ::toupper);
     if (mods.contains("SHIFT"))
         modMask |= WLR_MODIFIER_SHIFT;
     if (mods.contains("CAPS"))


### PR DESCRIPTION
Hyprland is very lenient when it comes to modifiers: `SUPERSHIFT`, `SUPER + SHIFT`, and `_xSUPERfoobarSHIFTx_` are all treated equally, but  `SUPER + shift` is treated as `SUPER`.

Thus, the config line

    bind = $mod + shift, T,       exec, notify-send Hello

unexpectedly binds notify-send to `$mod` not `$mod + SHIFT`. No warning is printed.

This PR makes modifiers case-insensitive. It has been tested and is ready to be merged.

Feel free to close this, if you don't like the change.