### PR TITLE
nix: use final.hyprland instead of prev.hyprland in waybar-hyprland

### DIFF
--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -58,7 +58,7 @@ in {
         '';
         postFixup = ''
           wrapProgram $out/bin/waybar \
-            --suffix PATH : ${lib.makeBinPath [ prev.hyprland ]}
+            --suffix PATH : ${lib.makeBinPath [ final.hyprland ]}
         '';
         mesonFlags = old.mesonFlags ++ ["-Dexperimental=true"];
       });


### PR DESCRIPTION
Currently, waybar-hyprland package adds `prev.hyprland` to `$PATH`. This is nixpkgs' default hyprland, not hyprland injected by this overlay. I'd expect we want waybar-hyprland to depend on what's in `pkgs.hyprland` after this (and possibly user's other overlays) are applied – which is `final.hyprland`.
