### PR TITLE
hyprctl empty dispatcher

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -686,8 +686,11 @@ std::string dispatchRequest(std::string in) {
     in = in.substr(in.find_first_of(' ') + 1);
 
     const auto DISPATCHSTR = in.substr(0, in.find_first_of(' '));
+    
+    auto DISPATCHARG = std::string();
+    if ((int) in.find_first_of(' ') != -1)
+        DISPATCHARG = in.substr(in.find_first_of(' ') + 1);
 
-    const auto DISPATCHARG = in.substr(in.find_first_of(' ') + 1);
 
     const auto DISPATCHER = g_pKeybindManager->m_mDispatchers.find(DISPATCHSTR);
     if (DISPATCHER == g_pKeybindManager->m_mDispatchers.end())


### PR DESCRIPTION
passes empty str as arg when in (var) doesn't have any empty spaces

should probably be added to the other hyprctl options, but only causes problems when argument can be none or not, which only happens in dispatchers afaik