### PR TITLE
special workspace id fix

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2348,7 +2348,7 @@ bool CCompositor::isWorkspaceSpecial(const int& id) {
 }
 
 int CCompositor::getNewSpecialID() {
-    int highest = -100;
+    int highest = SPECIAL_WORKSPACE_START;
     for (auto& ws : m_vWorkspaces) {
         if (ws->m_bIsSpecialWorkspace && ws->m_iID > highest) {
             highest = ws->m_iID;


### PR DESCRIPTION
sets highest as -99 instead of -100, so named special workspaces can't have id = -99