### PR TITLE
fix: handle window change directions in fullscreen

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1013,8 +1013,11 @@ void CKeybindManager::moveFocusTo(std::string args) {
         }
     };
 
-    const auto PWINDOWTOCHANGETO = PLASTWINDOW->m_bIsFullscreen ? g_pCompositor->getNextWindowOnWorkspace(PLASTWINDOW, arg == 'u' || arg == 't' || arg == 'r') :
-                                                                  g_pCompositor->getWindowInDirection(PLASTWINDOW, arg);
+    const auto PWINDOWTOCHANGETO = PLASTWINDOW->m_bIsFullscreen
+      ? (arg == 'd' || arg == 'b' || arg == 'r'
+          ? g_pCompositor->getNextWindowOnWorkspace(PLASTWINDOW, true)
+          : g_pCompositor->getPrevWindowOnWorkspace(PLASTWINDOW, true))
+      : g_pCompositor->getWindowInDirection(PLASTWINDOW, arg);
 
     // Found window in direction, switch to it
     if (PWINDOWTOCHANGETO) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

It fixes the first part of #1802 by picking a window in the direction based on the parameter of the `movefocus` dispatcher:

> When in fullscreen mode it's not possible to go backwards through the stack of windows, you can only go forwards.
> 
> `movefocus l` and `movefocus r` both go forwards in the window stack when they should go opposite directions. Same thing for `movefocus u` and `movefocus d`.

But it runs into the same problem as mentioned in the second part of the issue by @leg7, which still also happens with `cyclenext prev`:

> `cyclenext prev` starts cycling in the opposite direction of `cyclenext` but after the 2nd call it will go back to the original window, so if we have windows 1-2-3 and we are on window 1 it will do this:
> 
> ```
> -> window 1
> cyclenext prev -> window 3
> cyclenext prev -> window 1 (should be 2)
> cyclenext prev -> window 3 (should be 1)
> cyclenext prev -> window 1 ...
> ```

(It just keeps switching between two windows. I guess that this could be due to the fact that the window focus history still keeps changing while going backwards, which makes `getPrevWindowOnWorkspace` misbehave.)

#### Is it ready for merging, or does it need work?

I might try figuring out the issue with `cyclenext prev` as well, so this could be considered a draft, but the first part is already useful, as you can at least go backwards one window if you accidentally skip over the one you're looking for while switching, and you don't need to flip through all of them again just to get back to the previous one.