### PR TITLE
Avoid connected monitor reusing unavailable ID

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1707,17 +1707,17 @@ void CCompositor::updateWindowAnimatedDecorationValues(CWindow* pWindow) {
 }
 
 int CCompositor::getNextAvailableMonitorID(std::string const& name) {
-    // reuse ID if it's already in the map
-    if (m_mMonitorIDMap.contains(name))
+    // reuse ID if it's already in the map, and the monitor with that ID is not being used by another monitor
+    if (m_mMonitorIDMap.contains(name) && !std::any_of(m_vRealMonitors.begin(), m_vRealMonitors.end(), [&](auto m) { return m->ID == m_mMonitorIDMap[name]; }))
         return m_mMonitorIDMap[name];
 
     // otherwise, find minimum available ID that is not in the map
-    std::unordered_set<int> usedIDs;
+    std::unordered_set<uint64_t> usedIDs;
     for (auto const& monitor : m_vRealMonitors) {
         usedIDs.insert(monitor->ID);
     }
 
-    int nextID = 0;
+    uint64_t nextID = 0;
     while (usedIDs.count(nextID) > 0) {
         nextID++;
     }

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -102,7 +102,7 @@ class CCompositor {
     std::vector<CWindow*>                     m_vWindowsFadingOut;
     std::vector<SLayerSurface*>               m_vSurfacesFadingOut;
 
-    std::unordered_map<std::string, int64_t>  m_mMonitorIDMap;
+    std::unordered_map<std::string, uint64_t>  m_mMonitorIDMap;
 
     void                                      initServer();
     void                                      startCompositor();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

@ti-mo noticed a bug in my previous PR: https://github.com/hyprwm/Hyprland/pull/2666#issuecomment-1637994116, where two monitors might get the same ID. This PR aims to fix this bug. 

The problem seems to happen when you have 2 monitors connected, and the monitor ID map looks something like this:

```jsonc
{
  DP-2 = 0 // connected
  DP-3 = 1 // connected
}
```
Disconnecting DP-2 and plugging it into DP-1 would give it ID=0 and update the map like this:
```jsonc
{
  DP-1 = 0 // connected
  DP-2 = 0 // disconnected
  DP-3 = 1 // connected
}
```
Then, disconnecting DP-3 and plugging it into DP-2 would still give it ID=0:
```jsonc
{
  DP-1 = 0 // connected
  DP-2 = 0 // connected
  DP-3 = 1 // disconnected
}
```

This PR fixes this, by checking whether no other currently connected monitor is using this ID. If it is, it will pick the next available ID. The last situtation would then look like this instead:
```jsonc
{
  DP-1 = 0 // connected
  DP-2 = 1 // connected
  DP-3 = 1 // disconnected
}
```

Maybe there's a better way to fix this, but I can't think of anything right now.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I couldn't reproduce the bug but I believe this will fix it. @ti-mo Can you verify this?

#### Is it ready for merging, or does it need work?
Needs to be tested just to be sure. I saw no problems with my own tests, but couldn't reproduce the issue before my changes.

