### PR TITLE
only return 0 when using -h

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,7 @@ int main(int argc, char** argv) {
         } else if (it->compare("-c") == 0 || it->compare("--config") == 0) {
             if (std::next(it) == args.end()) {
                 help();
+
                 return 1;
             }
             std::string next_arg = std::next(it)->c_str();
@@ -66,9 +67,15 @@ int main(int argc, char** argv) {
             it++;
 
             continue;
-        } else {
+        } else if (it->compare("-h") == 0 || it->compare("--help") == 0) {
             help();
+
             return 0;
+        } else {
+            std::cerr << "[ ERROR ] Unknown option '" << it->c_str() << "'!\n";
+            help();
+
+            return 1;
         }
     }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
It makes no sense to return 0 when the user is using the program in an unintended way (`Hyprland -idk`). Hyprland should treat random arguments and `--help` differently

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
-

#### Is it ready for merging, or does it need work?
Ready to go


