### PR TITLE
movegroupwindow-improvement

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2086,14 +2086,9 @@ void CKeybindManager::moveGroupWindow(std::string args) {
     if (!g_pCompositor->m_pLastWindow || !g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow)
         return;
 
-    if (!BACK && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow->m_sGroupData.head) {
-        g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow->m_sGroupData.head = false;
-        g_pCompositor->m_pLastWindow->m_sGroupData.head                           = true;
-    } else if (BACK && g_pCompositor->m_pLastWindow->m_sGroupData.head) {
-        g_pCompositor->m_pLastWindow->m_sGroupData.head                           = false;
-        g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow->m_sGroupData.head = true;
-    } else {
+    if ((!BACK && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow->m_sGroupData.head) || (BACK && g_pCompositor->m_pLastWindow->m_sGroupData.head))
+        std::swap(g_pCompositor->m_pLastWindow->m_sGroupData.head, g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow->m_sGroupData.head);
+    else
         g_pCompositor->m_pLastWindow->switchWithWindowInGroup(BACK ? g_pCompositor->m_pLastWindow->getGroupPrevious() : g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow);
-    }
     g_pCompositor->m_pLastWindow->updateWindowDecos();
 }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1013,11 +1013,9 @@ void CKeybindManager::moveFocusTo(std::string args) {
         }
     };
 
-    const auto PWINDOWTOCHANGETO = PLASTWINDOW->m_bIsFullscreen
-      ? (arg == 'd' || arg == 'b' || arg == 'r'
-          ? g_pCompositor->getNextWindowOnWorkspace(PLASTWINDOW, true)
-          : g_pCompositor->getPrevWindowOnWorkspace(PLASTWINDOW, true))
-      : g_pCompositor->getWindowInDirection(PLASTWINDOW, arg);
+    const auto PWINDOWTOCHANGETO = PLASTWINDOW->m_bIsFullscreen ?
+        (arg == 'd' || arg == 'b' || arg == 'r' ? g_pCompositor->getNextWindowOnWorkspace(PLASTWINDOW, true) : g_pCompositor->getPrevWindowOnWorkspace(PLASTWINDOW, true)) :
+        g_pCompositor->getWindowInDirection(PLASTWINDOW, arg);
 
     // Found window in direction, switch to it
     if (PWINDOWTOCHANGETO) {
@@ -2088,6 +2086,14 @@ void CKeybindManager::moveGroupWindow(std::string args) {
     if (!g_pCompositor->m_pLastWindow || !g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow)
         return;
 
-    g_pCompositor->m_pLastWindow->switchWithWindowInGroup(BACK ? g_pCompositor->m_pLastWindow->getGroupPrevious() : g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow);
+    if (!BACK && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow->m_sGroupData.head) {
+        g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow->m_sGroupData.head = false;
+        g_pCompositor->m_pLastWindow->m_sGroupData.head                           = true;
+    } else if (BACK && g_pCompositor->m_pLastWindow->m_sGroupData.head) {
+        g_pCompositor->m_pLastWindow->m_sGroupData.head                           = false;
+        g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow->m_sGroupData.head = true;
+    } else {
+        g_pCompositor->m_pLastWindow->switchWithWindowInGroup(BACK ? g_pCompositor->m_pLastWindow->getGroupPrevious() : g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow);
+    }
     g_pCompositor->m_pLastWindow->updateWindowDecos();
 }


### PR DESCRIPTION
do not swap on group head and tail, instead move the window from one side to the other.
was kinda strange before so don't thing it needs a variable to turn on this behaviour

the other part of the diff is clang-format's doing