### PR TITLE
adds use_current_group_pos

### DIFF
--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -664,7 +664,7 @@ void CWindow::setGroupCurrent(CWindow* pWindow) {
 }
 
 void CWindow::insertWindowToGroup(CWindow* pWindow) {
-    static const auto* USECURRPOS = &g_pConfigManager->getConfigValuePtr("misc:use_current_group_pos")->intValue;
+    static const auto* USECURRPOS = &g_pConfigManager->getConfigValuePtr("misc:group_insert_after_current")->intValue;
 
     const auto BEGINAT = *USECURRPOS ? this : getGroupTail();
     const auto ENDAT   = *USECURRPOS ? m_sGroupData.pNextWindow : getGroupHead();

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -664,31 +664,24 @@ void CWindow::setGroupCurrent(CWindow* pWindow) {
 }
 
 void CWindow::insertWindowToGroup(CWindow* pWindow) {
-    const auto PHEAD = getGroupHead();
-    const auto PTAIL = getGroupTail();
+    static const auto* USECURRPOS = &g_pConfigManager->getConfigValuePtr("misc:use_current_group_pos")->intValue;
 
-    if (pWindow->m_sGroupData.pNextWindow) {
-        const auto            PHEAD = pWindow->getGroupHead();
-        std::vector<CWindow*> members;
-        CWindow*              curr = PHEAD;
-        do {
-            const auto PLAST = curr;
-            members.push_back(curr);
-            curr                            = curr->m_sGroupData.pNextWindow;
-            PLAST->m_sGroupData.pNextWindow = nullptr;
-            PLAST->m_sGroupData.head        = false;
-            PLAST->m_sGroupData.locked      = false;
-        } while (curr != PHEAD);
+    const auto BEGINAT = *USECURRPOS ? this : getGroupTail();
+    const auto ENDAT   = *USECURRPOS ? m_sGroupData.pNextWindow : getGroupHead();
 
-        for (auto& w : members) {
-            insertWindowToGroup(w);
-        }
-
+    if (!pWindow->m_sGroupData.pNextWindow) {
+        BEGINAT->m_sGroupData.pNextWindow = pWindow;
+        pWindow->m_sGroupData.pNextWindow = ENDAT;
+        pWindow->m_sGroupData.head        = false;
         return;
     }
 
-    PTAIL->m_sGroupData.pNextWindow   = pWindow;
-    pWindow->m_sGroupData.pNextWindow = PHEAD;
+    const auto SHEAD = pWindow->getGroupHead();
+    const auto STAIL = pWindow->getGroupTail();
+
+    SHEAD->m_sGroupData.head          = false;
+    BEGINAT->m_sGroupData.pNextWindow = SHEAD;
+    STAIL->m_sGroupData.pNextWindow   = ENDAT;
 }
 
 CWindow* CWindow::getGroupPrevious() {
@@ -704,30 +697,23 @@ void CWindow::switchWithWindowInGroup(CWindow* pWindow) {
     if (!m_sGroupData.pNextWindow || !pWindow->m_sGroupData.pNextWindow)
         return;
 
-    // TODO: probably can be done more easily but I let C++ do the algorithm stuff for us
+    if (m_sGroupData.pNextWindow == pWindow) { // A -> this -> pWindow -> B >> A -> pWindow -> this -> B
+        getGroupPrevious()->m_sGroupData.pNextWindow = pWindow;
+        m_sGroupData.pNextWindow                     = pWindow->m_sGroupData.pNextWindow;
+        pWindow->m_sGroupData.pNextWindow            = this;
 
-    std::vector<CWindow*> group;
-    group.push_back(this);
-    CWindow* curr = this->m_sGroupData.pNextWindow;
-    while (curr != this) {
-        group.push_back(curr);
-        curr = curr->m_sGroupData.pNextWindow;
-    }
+    } else if (pWindow->m_sGroupData.pNextWindow == this) { // A -> pWindow -> this -> B >> A -> this -> pWindow -> B
+        pWindow->getGroupPrevious()->m_sGroupData.pNextWindow = this;
+        pWindow->m_sGroupData.pNextWindow                     = m_sGroupData.pNextWindow;
+        m_sGroupData.pNextWindow                              = pWindow;
 
-    auto it1 = std::find(group.begin(), group.end(), this);
-    auto it2 = std::find(group.begin(), group.end(), pWindow);
-
-    std::iter_swap(it1, it2);
-
-    for (auto it = group.begin(); it != group.end(); ++it) {
-        if (std::next(it) == group.end()) {
-            (*it)->m_sGroupData.pNextWindow = *group.begin();
-        } else {
-            (*it)->m_sGroupData.pNextWindow = *std::next(it);
-        }
+    } else { // A -> this -> B | C -> pWindow -> D >> A -> pWindow -> B | C -> this -> D
+        std::swap(m_sGroupData.pNextWindow, pWindow->m_sGroupData.pNextWindow);
+        std::swap(getGroupPrevious()->m_sGroupData.pNextWindow, pWindow->getGroupPrevious()->m_sGroupData.pNextWindow);
     }
 
     std::swap(m_sGroupData.head, pWindow->m_sGroupData.head);
+    std::swap(m_sGroupData.locked, pWindow->m_sGroupData.locked);
 }
 
 void CWindow::updateGroupOutputs() {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -107,6 +107,7 @@ void CConfigManager::setDefaultVars() {
     configValues["misc:cursor_zoom_factor"].floatValue         = 1.f;
     configValues["misc:cursor_zoom_rigid"].intValue            = 0;
     configValues["misc:allow_session_lock_restore"].intValue   = 0;
+    configValues["misc:use_current_group_pos"].intValue        = 1;
     configValues["misc:render_titles_in_groupbar"].intValue    = 1;
     configValues["misc:groupbar_titles_font_size"].intValue    = 8;
     configValues["misc:groupbar_gradients"].intValue           = 1;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -107,7 +107,7 @@ void CConfigManager::setDefaultVars() {
     configValues["misc:cursor_zoom_factor"].floatValue         = 1.f;
     configValues["misc:cursor_zoom_rigid"].intValue            = 0;
     configValues["misc:allow_session_lock_restore"].intValue   = 0;
-    configValues["misc:use_current_group_pos"].intValue        = 1;
+    configValues["misc:group_insert_after_current"].intValue   = 1;
     configValues["misc:render_titles_in_groupbar"].intValue    = 1;
     configValues["misc:groupbar_titles_font_size"].intValue    = 8;
     configValues["misc:groupbar_gradients"].intValue           = 1;

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2035,13 +2035,13 @@ void CKeybindManager::moveIntoGroup(std::string args) {
     if (!PWINDOWINDIR || !PWINDOWINDIR->m_sGroupData.pNextWindow)
         return;
 
+    if (PWINDOW->m_sGroupData.locked || PWINDOWINDIR->m_sGroupData.locked)
+        return;
+
     if (!PWINDOW->m_sGroupData.pNextWindow)
         PWINDOW->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(PWINDOW));
 
     g_pLayoutManager->getCurrentLayout()->onWindowRemoved(PWINDOW); // This removes groupped property!
-
-    PWINDOW->m_sGroupData.locked = false;
-    PWINDOW->m_sGroupData.head   = false;
 
     PWINDOWINDIR->insertWindowToGroup(PWINDOW);
     PWINDOWINDIR->setGroupCurrent(PWINDOW);
@@ -2086,9 +2086,11 @@ void CKeybindManager::moveGroupWindow(std::string args) {
     if (!g_pCompositor->m_pLastWindow || !g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow)
         return;
 
-    if ((!BACK && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow->m_sGroupData.head) || (BACK && g_pCompositor->m_pLastWindow->m_sGroupData.head))
+    if ((!BACK && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow->m_sGroupData.head) || (BACK && g_pCompositor->m_pLastWindow->m_sGroupData.head)) {
         std::swap(g_pCompositor->m_pLastWindow->m_sGroupData.head, g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow->m_sGroupData.head);
-    else
+        std::swap(g_pCompositor->m_pLastWindow->m_sGroupData.locked, g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow->m_sGroupData.locked);
+    } else
         g_pCompositor->m_pLastWindow->switchWithWindowInGroup(BACK ? g_pCompositor->m_pLastWindow->getGroupPrevious() : g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow);
+
     g_pCompositor->m_pLastWindow->updateWindowDecos();
 }


### PR DESCRIPTION
adds use_current_group_pos (bool) to decide whether to put new windows at current group position or at the tail.
this might need a better name

also simplifies the insertWindowToGroup and rewrites getGroupPrevious (the last condition seems to work but didn't test it a lot because there are no dispatchers for it)
also fixes locked groups in some cases

didn't find any bugs or broken stuff