### PR TITLE
xwayland: fix vertical pointer movement bug

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1175,7 +1175,7 @@ void CInputManager::constrainMouse(SMouse* pMouse, wlr_pointer_constraint_v1* co
                 if (PWINDOW) {
                     if (PWINDOW->m_bIsX11) {
                         wlr_cursor_warp(g_pCompositor->m_sWLRCursor, nullptr, constraint->current.cursor_hint.x + PWINDOW->m_uSurface.xwayland->x,
-                                        PWINDOW->m_uSurface.xwayland->y + PWINDOW->m_vRealPosition.vec().y);
+                                        constraint->current.cursor_hint.y + PWINDOW->m_uSurface.xwayland->y);
 
                         wlr_seat_pointer_warp(constraint->seat, constraint->current.cursor_hint.x, constraint->current.cursor_hint.y);
                     } else {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This should _partially_ fix #2376, preventing the strange vertical-axis twitching behaviour seen in some XWayland applications and games.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
As far as I can tell, #2376 is likely describing more than one issue. Perhaps it should be split up?

#### Is it ready for merging, or does it need work?
This is a single-line commit fixing an obvious inconsistency between X- and Y-axes in a relevant part of the code, so I don't think there's much to say.
