### PR TITLE
Make moveintogroup locking check configurable

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -100,6 +100,7 @@ void CConfigManager::setDefaultVars() {
     configValues["misc:swallow_exception_regex"].strValue      = STRVAL_EMPTY;
     configValues["misc:focus_on_activate"].intValue            = 0;
     configValues["misc:no_direct_scanout"].intValue            = 1;
+    configValues["misc:moveintogroup_lock_check"].intValue     = 0;
     configValues["misc:hide_cursor_on_touch"].intValue         = 1;
     configValues["misc:mouse_move_focuses_monitor"].intValue   = 1;
     configValues["misc:suppress_portal_warnings"].intValue     = 0;

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2035,9 +2035,6 @@ void CKeybindManager::moveIntoGroup(std::string args) {
     if (!PWINDOWINDIR || !PWINDOWINDIR->m_sGroupData.pNextWindow)
         return;
 
-    if (PWINDOW->m_sGroupData.locked || PWINDOWINDIR->m_sGroupData.locked)
-        return;
-
     if (!PWINDOW->m_sGroupData.pNextWindow)
         PWINDOW->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(PWINDOW));
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2018,7 +2018,9 @@ void CKeybindManager::lockActiveGroup(std::string args) {
 }
 
 void CKeybindManager::moveIntoGroup(std::string args) {
-    char arg = args[0];
+    char               arg = args[0];
+
+    static auto* const GROUPLOCKCHECK = &g_pConfigManager->getConfigValuePtr("misc:moveintogroup_lock_check")->intValue;
 
     if (!isDirection(args)) {
         Debug::log(ERR, "Cannot move into group in direction %c, unsupported direction. Supported: l,r,u/t,d/b", arg);
@@ -2033,6 +2035,9 @@ void CKeybindManager::moveIntoGroup(std::string args) {
     const auto PWINDOWINDIR = g_pCompositor->getWindowInDirection(PWINDOW, arg);
 
     if (!PWINDOWINDIR || !PWINDOWINDIR->m_sGroupData.pNextWindow)
+        return;
+
+    if (*GROUPLOCKCHECK && (PWINDOWINDIR->getGroupHead()->m_sGroupData.locked || (PWINDOW->m_sGroupData.pNextWindow && PWINDOW->m_sGroupData.locked)))
         return;
 
     if (!PWINDOW->m_sGroupData.pNextWindow)


### PR DESCRIPTION
A new `moveintogroup_lock_check` configuration variable has been added to enable/disable lock checking in moveintogroup dispatch. 

This variable is set to false by default because the original behaviour of moveintogroup is to ignore `m_sGroupData.locked` as the call to the dispatcher is considered explicit.