### PR TITLE
Fix for issue #2797

### DIFF
--- a/src/init/initHelpers.cpp
+++ b/src/init/initHelpers.cpp
@@ -6,7 +6,7 @@ bool Init::isSudo() {
 
 void Init::gainRealTime() {
     const int                minPrio = sched_get_priority_min(SCHED_RR);
-	int old_policy;
+    int old_policy;
     struct sched_param param;
 
 	if (pthread_getschedparam(pthread_self(), &old_policy, &param)) {

--- a/src/init/initHelpers.cpp
+++ b/src/init/initHelpers.cpp
@@ -6,7 +6,15 @@ bool Init::isSudo() {
 
 void Init::gainRealTime() {
     const int                minPrio = sched_get_priority_min(SCHED_RR);
-    const struct sched_param param   = {.sched_priority = minPrio};
+	int old_policy;
+    struct sched_param param;
+
+	if (pthread_getschedparam(pthread_self(), &old_policy, &param)) {
+        Debug::log(WARN, "Failed to get old pthread scheduling priority");
+        return;
+    }
+
+	param.sched_priority = minPrio;
 
     if (pthread_setschedparam(pthread_self(), SCHED_RR, &param)) {
         Debug::log(WARN, "Failed to change process scheduling strategy");

--- a/src/init/initHelpers.cpp
+++ b/src/init/initHelpers.cpp
@@ -9,12 +9,12 @@ void Init::gainRealTime() {
     int old_policy;
     struct sched_param param;
 
-	if (pthread_getschedparam(pthread_self(), &old_policy, &param)) {
+    if (pthread_getschedparam(pthread_self(), &old_policy, &param)) {
         Debug::log(WARN, "Failed to get old pthread scheduling priority");
         return;
     }
 
-	param.sched_priority = minPrio;
+    param.sched_priority = minPrio;
 
     if (pthread_setschedparam(pthread_self(), SCHED_RR, &param)) {
         Debug::log(WARN, "Failed to change process scheduling strategy");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -89,7 +89,6 @@ int main(int argc, char** argv) {
     }
 
     std::cout << "Welcome to Hyprland!\n";
-    Init::gainRealTime();
 
     // let's init the compositor.
     // it initializes basic Wayland stuff in the constructor.
@@ -97,6 +96,8 @@ int main(int argc, char** argv) {
     g_pCompositor->explicitConfigPath = configPath;
 
     g_pCompositor->initServer();
+
+    Init::gainRealTime();
 
     Debug::log(LOG, "Hyprland init finished.");
 


### PR DESCRIPTION
Fixes issue https://github.com/hyprwm/Hyprland/issues/2797

There was some weird issue with setting the priority to realtime before calling g_pCompositor initserver that was making wlroots very unhappy resulting in a crash in some instances.

Also some params were being lost by not reading the current params then modifying the priority and instead creating new params with only a priority.


