### PR TITLE
Renamed deprecated `fonts.enableDefaultFonts` value in nix config

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -72,7 +72,7 @@ in {
       };
     };
 
-    fonts.enableDefaultFonts = mkDefault true;
+    fonts.enableDefaultPackages = mkDefault true;
     hardware.opengl.enable = mkDefault true;
 
     programs = {


### PR DESCRIPTION
Changed the deprecated `fonts.enableDefaultFonts` to `fonts.enableDefaultPackages` in nix/module.nix.
See https://github.com/NixOS/nixpkgs/commit/83793ca8980283a6f62c028ebed336b9d1bbf80f for more info.
