### PR TITLE
assets/meson.build: install new wallpapers

### DIFF
--- a/assets/meson.build
+++ b/assets/meson.build
@@ -1,5 +1,7 @@
-wallpapers = ['wall_2K.png', 'wall_4K.png', 'wall_8K.png']
+wallpaper_types = ['', 'anime_', 'anime2_']
 
-foreach wallpaper : wallpapers
-  install_data(wallpapers, install_dir: join_paths(get_option('datadir'), 'hyprland'), install_tag: 'runtime')
+foreach type : wallpaper_types
+  foreach size : [2, 4, 8]
+    install_data(f'wall_@type@@size@K.png', install_dir: join_paths(get_option('datadir'), 'hyprland'), install_tag: 'runtime')
+  endforeach
 endforeach


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Previous changes added new wallpapers and rng in which is used. Meson got left out so those who use it might silently get either the normal og wallpaper or nothing. And the cause wouldnt be obvious.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
-

#### Is it ready for merging, or does it need work?
Ready to merge unless the solution is overdone and just an array with the names plainly is preferred.

