### PR TITLE
Nix: enable systemd only when it's available on hostPlatform

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -30,7 +30,7 @@
   hidpiXWayland ? false,
   legacyRenderer ? false,
   nvidiaPatches ? false,
-  withSystemd ? true,
+  withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
   wrapRuntimeDeps ? true,
   version ? "git",
   commit,


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
When the `hostPlatform` does not support systemd, it is natural to disable this option. 
[This practice is frequently used in nixpkgs](https://github.com/search?q=repo%3ANixOS%2Fnixpkgs%20withSystemd&type=code)
#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?


