### PR TITLE
Add temporary fix for #2808 by adding nullptr check.

### DIFF
--- a/src/protocols/XDGOutput.cpp
+++ b/src/protocols/XDGOutput.cpp
@@ -77,7 +77,7 @@ void CXDGOutputProtocol::onManagerGetXDGOutput(wl_client* client, wl_resource* r
 
     SXDGOutput* pXDGOutput = m_vXDGOutputs.emplace_back(std::make_unique<SXDGOutput>(PMONITOR)).get();
 #ifndef NO_XWAYLAND
-    if (g_pXWaylandManager->m_sWLRXWayland != nullptr && g_pXWaylandManager->m_sWLRXWayland->server != nullptr && g_pXWaylandManager->m_sWLRXWayland->server->client == client)
+    if (g_pXWaylandManager->m_sWLRXWayland && g_pXWaylandManager->m_sWLRXWayland->server && g_pXWaylandManager->m_sWLRXWayland->server->client == client)
         pXDGOutput->isXWayland = true;
 #endif
     pXDGOutput->client = client;

--- a/src/protocols/XDGOutput.cpp
+++ b/src/protocols/XDGOutput.cpp
@@ -77,7 +77,7 @@ void CXDGOutputProtocol::onManagerGetXDGOutput(wl_client* client, wl_resource* r
 
     SXDGOutput* pXDGOutput = m_vXDGOutputs.emplace_back(std::make_unique<SXDGOutput>(PMONITOR)).get();
 #ifndef NO_XWAYLAND
-    if (g_pXWaylandManager->m_sWLRXWayland->server->client == client)
+    if (g_pXWaylandManager->m_sWLRXWayland != nullptr && g_pXWaylandManager->m_sWLRXWayland->server != nullptr && g_pXWaylandManager->m_sWLRXWayland->server->client == client)
         pXDGOutput->isXWayland = true;
 #endif
     pXDGOutput->client = client;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
It is a temporary fix for #2808, the fix makes Hyprland not to segfault when starting a client.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
There might be potential cases like #2808 where `nullptr` check is not performed properly and can lead to someone's running instance break after an update under rare circumstances.


#### Is it ready for merging, or does it need work?
It just adds `nullptr` checks in a if statement, should be able to merge without problem.

