### PR TITLE
Nix: fix nvidia patch for dual gpu system

### DIFF
--- a/nix/patches/wlroots-nvidia.patch
+++ b/nix/patches/wlroots-nvidia.patch
@@ -1,3 +1,16 @@
+diff --git a/render/gles2/renderer.c b/render/gles2/renderer.c
+index 9fe934f7..9662d4ee 100644
+--- a/render/gles2/renderer.c
++++ b/render/gles2/renderer.c
+@@ -176,7 +176,7 @@ static bool gles2_bind_buffer(struct wlr_renderer *wlr_renderer,
+ 		assert(wlr_egl_is_current(renderer->egl));
+ 
+ 		push_gles2_debug(renderer);
+-		glFlush();
++		glFinish();
+ 		glBindFramebuffer(GL_FRAMEBUFFER, 0);
+ 		pop_gles2_debug(renderer);
+ 
 diff --git a/types/output/render.c b/types/output/render.c
 index 2e38919a..97f78608 100644
 --- a/types/output/render.c

--- a/nix/wlroots.nix
+++ b/nix/wlroots.nix
@@ -46,15 +46,6 @@ assert (lib.assertMsg (hidpiXWayland -> enableXWayland) ''
         ++ (lib.optionals nvidiaPatches [
           ./patches/wlroots-nvidia.patch
         ]);
-      postPatch =
-        (old.postPatch or "")
-        + (
-          if nvidiaPatches
-          then ''
-            substituteInPlace render/gles2/renderer.c --replace "glFlush();" "glFinish();"
-          ''
-          else ""
-        );
       buildInputs = old.buildInputs ++ [hwdata libliftoff libdisplay-info];
 
       NIX_CFLAGS_COMPILE = toString [


### PR DESCRIPTION
**Describe your PR, what does it fix/add?**
- Update ```wlroots-nvidia.patch```  patch in order fix the random flickering on the external output connected to Dgpu
- Updated patch to maintain distro packages downstream.
- Also update the wlroots.nix since  ```wlroots-nvidia.patch``` now patch renderer.c

**Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)**

This PR was created since last change to wlroots include with Hyprland 0.27.2 broke the patch use by gentoo.
Bug report here: https://bugs.gentoo.org/910576

**Is it ready for merging, or does it need work?**

Ready to merge

Patch tested on my Lenovo Legion 5, both in Hybrid and Discrete mode and the random flickering is not present anymore.
Also ran the workflow and can confirm the Hyprland still build fine on Nix.

![image](https://github.com/hyprwm/Hyprland/assets/68701049/31d4d685-abdf-4d3b-a5a3-050f5073dc65)

```wlroots-nvidia.patch``` logs:
![image](https://github.com/hyprwm/Hyprland/assets/68701049/fd537f36-cfb5-4939-9d1c-2fb33ce79486)




