### PR TITLE
xwayland: drop wlr_xwayland_surface.events.set_pid

### DIFF
--- a/src/helpers/XWaylandStubs.hpp
+++ b/src/helpers/XWaylandStubs.hpp
@@ -118,7 +118,6 @@ struct wlr_xwayland_surface {
         struct wl_signal set_class;
         struct wl_signal set_role;
         struct wl_signal set_parent;
-        struct wl_signal set_pid;
         struct wl_signal set_startup_id;
         struct wl_signal set_window_type;
         struct wl_signal set_hints;


### PR DESCRIPTION
The PID of an X11 window cannot change.
This is a remnant from the days when wlroots queried the PID with a
window property, instead of using XRes.
https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4306

