### PR TITLE
fix workspace focus change

### DIFF
--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -269,6 +269,8 @@ void IHyprLayout::onEndDragWindow() {
     }
 
     g_pHyprRenderer->damageWindow(DRAGGINGWINDOW);
+
+    g_pCompositor->focusWindow(DRAGGINGWINDOW);
 }
 
 void IHyprLayout::onMouseMove(const Vector2D& mousePos) {


### PR DESCRIPTION
partial revert of https://github.com/hyprwm/Hyprland/pull/2706

finally found why the focus was being set at the onEndDragWindow

now focus is set at onBeginDragWindow (https://github.com/hyprwm/Hyprland/pull/2706) to update the border (and other properties) when move/resize starts
and also in onEndDragWindow (implemented here) to update the focused window when workspace is changed

(maybe the workspace change shouldn't change the focus but idk if that will break something else)