### PR TITLE
Close keymap files.

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -140,10 +140,12 @@ void CKeybindManager::updateXKBTranslationState() {
 
     xkb_rule_names rules = {.rules = RULES.c_str(), .model = MODEL.c_str(), .layout = LAYOUT.c_str(), .variant = VARIANT.c_str(), .options = OPTIONS.c_str()};
 
-    const auto     PCONTEXT = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    const auto     PCONTEXT   = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    FILE* const    KEYMAPFILE = fopen(FILEPATH.c_str(), "r");
 
     auto           PKEYMAP = FILEPATH == "" ? xkb_keymap_new_from_names(PCONTEXT, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS) :
-                                              xkb_keymap_new_from_file(PCONTEXT, fopen(FILEPATH.c_str(), "r"), XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS);
+                                              xkb_keymap_new_from_file(PCONTEXT, KEYMAPFILE, XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS);
+    fclose(KEYMAPFILE);
 
     if (!PKEYMAP) {
         g_pHyprError->queueCreate("[Runtime Error] Invalid keyboard layout passed. ( rules: " + RULES + ", model: " + MODEL + ", variant: " + VARIANT + ", options: " + OPTIONS +

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -786,8 +786,11 @@ void CInputManager::applyConfigToKeyboard(SKeyboard* pKeyboard) {
 
         if (!std::filesystem::exists(path))
             Debug::log(ERR, "input:kb_file= file doesnt exist");
-        else
-            KEYMAP = xkb_keymap_new_from_file(CONTEXT, fopen(path.c_str(), "r"), XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS);
+        else {
+            FILE* const KEYMAPFILE = fopen(FILEPATH.c_str(), "r");
+            KEYMAP                 = xkb_keymap_new_from_file(CONTEXT, KEYMAPFILE, XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS);
+            fclose(KEYMAPFILE);
+        }
     }
 
     if (!KEYMAP)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
It was brought up in #2904 that keymap fd's are not properly closed, leading to memory leaks. This fixes #2904.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I do not personally use keymap files but this looked like a simple enough fix. Just need a pair of eyeballs to see if this is correct and I did not screw this simple thing up.

Also there is no error handling on fopen or fclose, as it stands there was no error handling anyways so i tried to be minimal with this change as possible. If there is a need to handle errors here, I can rewrite this to include so.

#### Is it ready for merging, or does it need work?
Should be ready for merging given a review and the above answered.

