### PR TITLE
Keep aspect ratio

### DIFF
--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -532,6 +532,8 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
         } catch (std::exception& e) { Debug::log(ERR, "BorderColor rule \"%s\" failed with: %s", r.szRule.c_str(), e.what()); }
     } else if (r.szRule == "dimaround") {
         m_sAdditionalConfigData.dimAround = true;
+    } else if (r.szRule == "keepaspectratio") {
+        m_sAdditionalConfigData.keepAspectRatio = true;
     }
 }
 
@@ -546,12 +548,13 @@ void CWindow::updateDynamicRules() {
     m_sAdditionalConfigData.forceNoDim       = false;
     if (!m_sAdditionalConfigData.forceOpaqueOverridden)
         m_sAdditionalConfigData.forceOpaque = false;
-    m_sAdditionalConfigData.forceNoAnims   = false;
-    m_sAdditionalConfigData.animationStyle = std::string("");
-    m_sAdditionalConfigData.rounding       = -1;
-    m_sAdditionalConfigData.dimAround      = false;
-    m_sAdditionalConfigData.forceRGBX      = false;
-    m_sAdditionalConfigData.borderSize     = -1;
+    m_sAdditionalConfigData.forceNoAnims    = false;
+    m_sAdditionalConfigData.animationStyle  = std::string("");
+    m_sAdditionalConfigData.rounding        = -1;
+    m_sAdditionalConfigData.dimAround       = false;
+    m_sAdditionalConfigData.forceRGBX       = false;
+    m_sAdditionalConfigData.borderSize      = -1;
+    m_sAdditionalConfigData.keepAspectRatio = false;
 
     const auto WINDOWRULES = g_pConfigManager->getMatchingRules(this);
     for (auto& r : WINDOWRULES) {

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -10,8 +10,7 @@
 #include "helpers/Vector2D.hpp"
 #include "helpers/WLSurface.hpp"
 
-enum eIdleInhibitMode
-{
+enum eIdleInhibitMode {
     IDLEINHIBIT_NONE = 0,
     IDLEINHIBIT_ALWAYS,
     IDLEINHIBIT_FULLSCREEN,
@@ -122,6 +121,7 @@ struct SWindowAdditionalConfigData {
     CWindowOverridableVar<bool> noMaxSize             = false;
     CWindowOverridableVar<bool> dimAround             = false;
     CWindowOverridableVar<bool> forceRGBX             = false;
+    CWindowOverridableVar<bool> keepAspectRatio       = false;
     CWindowOverridableVar<int>  borderSize            = -1; // -1 means unset, takes precedence over the renderdata one
 };
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -886,8 +886,9 @@ bool windowRuleValid(const std::string& RULE) {
              RULE.find("maxsize") != 0 && RULE.find("pseudo") != 0 && RULE.find("monitor") != 0 && RULE.find("idleinhibit") != 0 && RULE != "nofocus" && RULE != "noblur" &&
              RULE != "noshadow" && RULE != "nodim" && RULE != "noborder" && RULE != "center" && RULE != "opaque" && RULE != "forceinput" && RULE != "fullscreen" &&
              RULE != "nofullscreenrequest" && RULE != "nomaximizerequest" && RULE != "fakefullscreen" && RULE != "nomaxsize" && RULE != "pin" && RULE != "noanim" &&
-             RULE != "dimaround" && RULE != "windowdance" && RULE != "maximize" && RULE.find("animation") != 0 && RULE.find("rounding") != 0 && RULE.find("workspace") != 0 &&
-             RULE.find("bordercolor") != 0 && RULE != "forcergbx" && RULE != "noinitialfocus" && RULE != "stayfocused" && RULE.find("bordersize") != 0);
+             RULE != "dimaround" && RULE != "windowdance" && RULE != "maximize" && RULE != "keepaspectratio" && RULE.find("animation") != 0 && RULE.find("rounding") != 0 &&
+             RULE.find("workspace") != 0 && RULE.find("bordercolor") != 0 && RULE != "forcergbx" && RULE != "noinitialfocus" && RULE != "stayfocused" &&
+             RULE.find("bordersize") != 0);
 }
 
 bool layerRuleValid(const std::string& RULE) {

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1002,6 +1002,8 @@ std::string dispatchSetProp(std::string request) {
             PWINDOW->m_sAdditionalConfigData.forceRGBX.forceSetIgnoreLocked(configStringToInt(VAL), lock);
         } else if (PROP == "bordersize") {
             PWINDOW->m_sSpecialRenderData.borderSize.forceSetIgnoreLocked(configStringToInt(VAL), lock);
+        } else if (PROP == "keepaspectratio") {
+            PWINDOW->m_sAdditionalConfigData.keepAspectRatio.forceSetIgnoreLocked(configStringToInt(VAL), lock);
         } else {
             return "prop not found";
         }

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -339,12 +339,15 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
 
                 const float RATIO = m_vBeginDragSizeXY.y / m_vBeginDragSizeXY.x;
 
-                if (RATIO > 1) {
+                if (MINSIZE.x * RATIO > MINSIZE.y) {
                     MINSIZE = Vector2D(MINSIZE.x, MINSIZE.x * RATIO);
-                    MAXSIZE = Vector2D(MAXSIZE.x, MAXSIZE.x * RATIO);
-
                 } else {
                     MINSIZE = Vector2D(MINSIZE.y / RATIO, MINSIZE.y);
+                }
+
+                if (MAXSIZE.x * RATIO < MAXSIZE.y) {
+                    MAXSIZE = Vector2D(MAXSIZE.x, MAXSIZE.x * RATIO);
+                } else {
                     MAXSIZE = Vector2D(MAXSIZE.y / RATIO, MAXSIZE.y);
                 }
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1941,7 +1941,8 @@ void CKeybindManager::pinActive(std::string args) {
 }
 
 void CKeybindManager::mouse(std::string args) {
-    const auto TRUEARG = args.substr(1);
+    const auto TRUEARG = args.substr(1, args.find(' ') - 1);
+    const auto EXTRARG = args.substr(args.find(' ') + 1);
     const auto PRESSED = args[0] == '1';
 
     if (TRUEARG == "movewindow") {
@@ -1966,8 +1967,16 @@ void CKeybindManager::mouse(std::string args) {
             g_pKeybindManager->m_bIsMouseBindActive = true;
 
             g_pInputManager->currentlyDraggedWindow = g_pCompositor->vectorToWindowIdeal(g_pInputManager->getMouseCoordsInternal());
-            g_pInputManager->dragMode               = MBIND_RESIZE;
 
+            if (isNumber(EXTRARG)) {
+                switch (stoi(EXTRARG)) {
+                    case 1: g_pInputManager->dragMode = MBIND_RESIZE_FORCE_RATIO; break;
+                    case 2: g_pInputManager->dragMode = MBIND_RESIZE_BLOCK_RATIO; break;
+                    default: g_pInputManager->dragMode = MBIND_RESIZE;
+                }
+            } else {
+                g_pInputManager->dragMode = MBIND_RESIZE;
+            }
             g_pLayoutManager->getCurrentLayout()->onBeginDragWindow();
         } else {
             g_pKeybindManager->m_bIsMouseBindActive = false;

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -7,21 +7,20 @@
 #include "../../helpers/Timer.hpp"
 #include "InputMethodRelay.hpp"
 
-enum eClickBehaviorMode
-{
+enum eClickBehaviorMode {
     CLICKMODE_DEFAULT = 0,
     CLICKMODE_KILL
 };
 
-enum eMouseBindMode
-{
-    MBIND_INVALID = -1,
-    MBIND_MOVE    = 0,
-    MBIND_RESIZE
+enum eMouseBindMode {
+    MBIND_INVALID            = -1,
+    MBIND_MOVE               = 0,
+    MBIND_RESIZE             = 1,
+    MBIND_RESIZE_BLOCK_RATIO = 2,
+    MBIND_RESIZE_FORCE_RATIO = 3
 };
 
-enum eBorderIconDirection
-{
+enum eBorderIconDirection {
     BORDERICON_NONE,
     BORDERICON_UP,
     BORDERICON_DOWN,


### PR DESCRIPTION
Allows resizing of windows without changing their aspect ratio

Implements window rule, prop and resize mode argument to mouse bind `resizewindow`

didn't check max size constrain
shouldn't cause any issues

will make wiki PR soon

Closes issue: https://github.com/hyprwm/Hyprland/issues/2008