### PR TITLE
Fix background not being cleared

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1723,19 +1723,15 @@ void CHyprOpenGLImpl::createBGTextureForMonitor(CMonitor* pMonitor) {
         texName += "2K.png";
     }
 
-    // goto is banned? ok have a do while.
-    std::string texPath = "/usr/share/hyprland/" + texName;
-    do {
-        if (std::filesystem::exists(texPath))
-            break;
-        texPath = "/usr/local/share/hyprland/" + texName;
-        if (std::filesystem::exists(texPath))
-            break;
-        texPath = "assets/" + texName;
+    std::string texPath;
+    auto        paths = {"/usr/share/hyprland/", "/usr/local/share/hyprland/", "assets/"};
+
+    for (auto& path : paths) {
+        texPath = path + texName;
         if (std::filesystem::exists(texPath))
             break;
         texPath = "";
-    } while (false);
+    }
 
     PTEX->m_vSize = textureSize;
 
@@ -1771,7 +1767,7 @@ void CHyprOpenGLImpl::createBGTextureForMonitor(CMonitor* pMonitor) {
 
     if (texPath.empty()) {
         cairo_set_source_rgba(CAIRO, 0.106, 0.106, 0.106, 1.0);
-        cairo_rectangle(CAIRO, 0, 0, box.width, box.height);
+        cairo_rectangle(CAIRO, 0, 0, textureSize.x, textureSize.y);
         cairo_fill(CAIRO);
     }
 

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1723,17 +1723,19 @@ void CHyprOpenGLImpl::createBGTextureForMonitor(CMonitor* pMonitor) {
         texName += "2K.png";
     }
 
+    // goto is banned? ok have a do while.
     std::string texPath = "/usr/share/hyprland/" + texName;
-    if (std::filesystem::exists(texPath))
-        goto hastex;
-    texPath = "/usr/local/share/hyprland/" + texName;
-    if (std::filesystem::exists(texPath))
-        goto hastex;
-    texPath = "assets/" + texName;
-    if (std::filesystem::exists(texPath))
-        goto hastex;
-    texPath = "";
-hastex:
+    do {
+        if (std::filesystem::exists(texPath))
+            break;
+        texPath = "/usr/local/share/hyprland/" + texName;
+        if (std::filesystem::exists(texPath))
+            break;
+        texPath = "assets/" + texName;
+        if (std::filesystem::exists(texPath))
+            break;
+        texPath = "";
+    } while (false);
 
     PTEX->m_vSize = textureSize;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Previously no image would be rendered if hyprland could not find one to use, leaving the last frame as the background. This generates a grey image if hl can't find a background (with the splash overlayed this time).

Additionally it adds `assets/` as an image search path for use in dev. (nix does not store assets in /usr paths which is why I noticed this at all)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
ready to merge

