### PR TITLE
Fix grouped windows not being properly focused on activation

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -826,6 +826,7 @@ CMonitor* CCompositor::getMonitorFromOutput(wlr_output* out) {
 }
 
 void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
+
     if (g_pCompositor->m_sSeat.exclusiveClient) {
         Debug::log(LOG, "Disallowing setting focus to a window due to there being an active input inhibitor layer.");
         return;

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -826,10 +826,14 @@ CMonitor* CCompositor::getMonitorFromOutput(wlr_output* out) {
 }
 
 void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
-
     if (g_pCompositor->m_sSeat.exclusiveClient) {
         Debug::log(LOG, "Disallowing setting focus to a window due to there being an active input inhibitor layer.");
         return;
+    }
+
+    if (pWindow && pWindow->isHidden() && pWindow->m_sGroupData.pNextWindow) {
+        // grouped, change the current to us
+        pWindow->setGroupCurrent(pWindow);
     }
 
     if (!pWindow || !windowValidMapped(pWindow)) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1708,11 +1708,6 @@ void CKeybindManager::focusWindow(std::string regexp) {
         changeworkspace(PWORKSPACE->getConfigName());
     }
 
-    if (PWINDOW->isHidden() && PWINDOW->m_sGroupData.pNextWindow) {
-        // grouped, change the current to us
-        PWINDOW->setGroupCurrent(PWINDOW);
-    }
-
     g_pCompositor->focusWindow(PWINDOW);
 
     const auto MIDPOINT = PWINDOW->m_vRealPosition.goalv() + PWINDOW->m_vRealSize.goalv() / 2.f;


### PR DESCRIPTION
This bug could happen if you:
1. Open two Chromium windows in a single group
2. Open some tabs in both of the windows
3. Using tabs search (Ctrl+Shift+A) try to switch to a tab in the second window from the first one.
When this happens any window focus would be lost (hyprctl activewindow starts to output "Invalid") and also the mouse cursor would become centered relatively to the second window.