### PR TITLE
Nix: corrections for overlays, overrideable systems

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -44,6 +44,21 @@
         "xdph": "xdph"
       }
     },
+    "systems": {
+      "locked": {
+        "lastModified": 1689347949,
+        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default-linux",
+        "type": "github"
+      }
+    },
     "wlroots": {
       "flake": false,
       "locked": {
@@ -70,14 +85,15 @@
         ],
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1691082525,
-        "narHash": "sha256-C5AO0KnyAFJaCkOn+5nJfWm0kyiPn/Awh0lKTjhgr7Y=",
+        "lastModified": 1691616171,
+        "narHash": "sha256-gmRJnEOLt4+XhrytVYK/+r/Eyt6bm/TdAyKk//2SISE=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "42747d267ab4345c4ceb78cd4a4fe99f072d80fc",
+        "rev": "9257b0c9b9a540b41e86f6357eb7b6bcb26af00f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -4,14 +4,17 @@
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
+        ],
+        "systems": [
+          "systems"
         ]
       },
       "locked": {
-        "lastModified": 1684265364,
-        "narHash": "sha256-AxNnWbthsuNx73HDQr0eBxrcE3+yfl/WsaXZqUFmkpQ=",
+        "lastModified": 1691753796,
+        "narHash": "sha256-zOEwiWoXk3j3+EoF3ySUJmberFewWlagvewDRuWYAso=",
         "owner": "hyprwm",
         "repo": "hyprland-protocols",
-        "rev": "8c279b9fb0f2b031427dc5ef4eab53f2ed835530",
+        "rev": "0c2ce70625cb30aef199cb388f99e19a61a6ce03",
         "type": "github"
       },
       "original": {
@@ -40,6 +43,7 @@
       "inputs": {
         "hyprland-protocols": "hyprland-protocols",
         "nixpkgs": "nixpkgs",
+        "systems": "systems",
         "wlroots": "wlroots",
         "xdph": "xdph"
       }
@@ -86,14 +90,16 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems"
+        "systems": [
+          "systems"
+        ]
       },
       "locked": {
-        "lastModified": 1691616171,
-        "narHash": "sha256-gmRJnEOLt4+XhrytVYK/+r/Eyt6bm/TdAyKk//2SISE=",
+        "lastModified": 1691841170,
+        "narHash": "sha256-RCTm1/MVWYPnReMgyp7tr2ogGYo/pvw38jZaFwemgPU=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "9257b0c9b9a540b41e86f6357eb7b6bcb26af00f",
+        "rev": "57a3a41ba6b358109e4fc25c6a4706b5f7d93c6b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -47,18 +47,7 @@
         ];
       });
   in {
-    overlays =
-      (import ./nix/overlays.nix {inherit self lib inputs;})
-      // {
-        default =
-          lib.mkJoinedOverlays
-          (with self.overlays; [
-            hyprland-packages
-            hyprland-extras
-            wlroots-hyprland
-            inputs.hyprland-protocols.overlays.default
-          ]);
-      };
+    overlays = import ./nix/overlays.nix {inherit self lib inputs;};
 
     checks = genSystems (system:
       (lib.filterAttrs

--- a/flake.nix
+++ b/flake.nix
@@ -41,10 +41,9 @@
     pkgsFor = eachSystem (system:
       import nixpkgs {
         localSystem = system;
-        overlays = [
-          self.overlays.hyprland-packages
-          self.overlays.wlroots-hyprland
-          inputs.hyprland-protocols.overlays.default
+        overlays = with self.overlays; [
+          hyprland-packages
+          hyprland-extras
         ];
       });
   in {
@@ -58,11 +57,27 @@
         inherit (self.packages.${system}) xdg-desktop-portal-hyprland;
       });
 
-    packages = eachSystem (system:
-      (self.overlays.default pkgsFor.${system} pkgsFor.${system})
-      // {
-        default = self.packages.${system}.hyprland;
-      });
+    packages = eachSystem (system: {
+      default = self.packages.${system}.hyprland;
+      inherit
+        (pkgsFor.${system})
+        # hyprland-packages
+        hyprland
+        hyprland-unwrapped
+        hyprland-debug
+        hyprland-hidpi
+        hyprland-nvidia
+        hyprland-no-hidpi
+        # hyprland-extras
+        xdg-desktop-portal-hyprland
+        hyprland-share-picker
+        waybar-hyprland
+        # dependencies
+        hyprland-protocols
+        wlroots-hyprland
+        udis86
+        ;
+    });
 
     devShells = eachSystem (system: {
       default = pkgsFor.${system}.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,7 @@
     devShells = genSystems (system: {
       default = pkgsFor.${system}.mkShell {
         name = "hyprland-shell";
-        nativeBuildInputs = with pkgsFor.${system}; [ cmake python3 ];
+        nativeBuildInputs = with pkgsFor.${system}; [cmake python3];
         buildInputs = [self.packages.${system}.wlroots-hyprland];
         inputsFrom = [
           self.packages.${system}.wlroots-hyprland
@@ -86,7 +86,7 @@
       };
     });
 
-    formatter = genSystems (system: pkgsFor.${system}.alejandra);
+    formatter = genSystems (system: nixpkgs.legacyPackages.${system}.alejandra);
 
     nixosModules.default = import ./nix/module.nix inputs;
     homeManagerModules.default = import ./nix/hm-module.nix self;

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
     nixpkgs,
     ...
   }: let
-    lib = nixpkgs.lib.extend (import ./nix/lib.nix);
+    inherit (nixpkgs) lib;
     genSystems = lib.genAttrs [
       # Add more systems if they are supported
       "aarch64-linux"

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -123,7 +123,7 @@ in
         ln -s ${wlroots}/include/wlr $dev/include/hyprland/wlroots
         ${lib.optionalString wrapRuntimeDeps ''
           wrapProgram $out/bin/Hyprland \
-            --suffix PATH : ${lib.makeBinPath [ binutils pciutils ]}
+            --suffix PATH : ${lib.makeBinPath [binutils pciutils]}
         ''}
       '';
 

--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -119,10 +119,14 @@ in {
 
   config = lib.mkIf cfg.enable {
     warnings =
-      if (cfg.systemdIntegration || cfg.plugins != []) && cfg.extraConfig == null then
-        [ ''You have enabled hyprland.systemdIntegration or listed plugins in hyprland.plugins.
-            Your Hyprland config will be linked by home manager.
-            Set hyprland.extraConfig or unset hyprland.systemdIntegration and hyprland.plugins to remove this warning.'' ]
+      if (cfg.systemdIntegration || cfg.plugins != []) && cfg.extraConfig == null
+      then [
+        ''
+          You have enabled hyprland.systemdIntegration or listed plugins in hyprland.plugins.
+          Your Hyprland config will be linked by home manager.
+          Set hyprland.extraConfig or unset hyprland.systemdIntegration and hyprland.plugins to remove this warning.
+        ''
+      ]
       else [];
 
     home.packages =
@@ -138,9 +142,17 @@ in {
           exec-once=${pkgs.dbus}/bin/dbus-update-activation-environment --systemd DISPLAY WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP && systemctl --user start hyprland-session.target
         '')
         + lib.concatStrings (builtins.map (entry: let
-            plugin = if lib.types.package.check entry then "${entry}/lib/lib${entry.pname}.so" else entry;
-          in "plugin = ${plugin}\n") cfg.plugins)
-        + (if cfg.extraConfig != null then cfg.extraConfig else "");
+          plugin =
+            if lib.types.package.check entry
+            then "${entry}/lib/lib${entry.pname}.so"
+            else entry;
+        in "plugin = ${plugin}\n")
+        cfg.plugins)
+        + (
+          if cfg.extraConfig != null
+          then cfg.extraConfig
+          else ""
+        );
 
       onChange = let
         hyprlandPackage =

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,8 +1,0 @@
-final: prev: let
-  lib = final;
-
-  mkJoinedOverlays = overlays: final: prev:
-    lib.foldl' (attrs: overlay: attrs // (overlay final prev)) {} overlays;
-in prev // {
-  inherit mkJoinedOverlays;
-}

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -50,16 +50,8 @@ in {
   # Packages for extra software recommended for usage with Hyprland,
   # including forked or patched packages for compatibility.
   hyprland-extras = mkJoinedOverlays [
-    # Include any inputs' specific overlays whose attributes should
-    # be re-exported by the Hyprland flake.
-    #
-    inputs.xdph.overlays.default
-    # Provides:
-    # - xdg-desktop-portal-hyprland
-    # - hyprland-share-picker
-    #
-    # Attributes for `hyprland-extras` defined by this flake can
-    # go in the oberlay below.
+    inputs.xdph.overlays.xdg-desktop-portal-hyprland
+    inputs.xdph.overlays.hyprland-share-picker
     self.overlays.waybar-hyprland
   ];
 

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -10,8 +10,11 @@
     (builtins.substring 4 2 longDate)
     (builtins.substring 6 2 longDate)
   ]);
+
+  mkJoinedOverlays = overlays: final: prev:
+    lib.foldl' (attrs: overlay: attrs // (overlay final prev)) {} overlays;
 in {
-  default = lib.mkJoinedOverlays (with self.overlays; [
+  default = mkJoinedOverlays (with self.overlays; [
     inputs.hyprland-protocols.overlays.default
     wlroots-hyprland
     hyprland-packages
@@ -46,7 +49,7 @@ in {
 
   # Packages for extra software recommended for usage with Hyprland,
   # including forked or patched packages for compatibility.
-  hyprland-extras = lib.mkJoinedOverlays [
+  hyprland-extras = mkJoinedOverlays [
     # Include any inputs' specific overlays whose attributes should
     # be re-exported by the Hyprland flake.
     #

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -50,20 +50,22 @@ in {
     #
     # Attributes for `hyprland-extras` defined by this flake can
     # go in the oberlay below.
-    (final: prev: {
-      waybar-hyprland = prev.waybar.overrideAttrs (old: {
-        postPatch = ''
-          # use hyprctl to switch workspaces
-          sed -i 's/zext_workspace_handle_v1_activate(workspace_handle_);/const std::string command = "hyprctl dispatch workspace " + name_;\n\tsystem(command.c_str());/g' src/modules/wlr/workspace_manager.cpp
-        '';
-        postFixup = ''
-          wrapProgram $out/bin/waybar \
-            --suffix PATH : ${lib.makeBinPath [final.hyprland]}
-        '';
-        mesonFlags = old.mesonFlags ++ ["-Dexperimental=true"];
-      });
-    })
+    self.overlays.waybar-hyprland
   ];
+
+  waybar-hyprland = final: prev: {
+    waybar-hyprland = prev.waybar.overrideAttrs (old: {
+      postPatch = ''
+        # use hyprctl to switch workspaces
+        sed -i 's/zext_workspace_handle_v1_activate(workspace_handle_);/const std::string command = "hyprctl dispatch workspace " + name_;\n\tsystem(command.c_str());/g' src/modules/wlr/workspace_manager.cpp
+      '';
+      postFixup = ''
+        wrapProgram $out/bin/waybar \
+          --suffix PATH : ${lib.makeBinPath [final.hyprland]}
+      '';
+      mesonFlags = old.mesonFlags ++ ["-Dexperimental=true"];
+    });
+  };
 
   # Patched version of wlroots for Hyprland.
   # It is under a new package name so as to not conflict with

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -11,6 +11,13 @@
     (builtins.substring 6 2 longDate)
   ]);
 in {
+  default = lib.mkJoinedOverlays (with self.overlays; [
+    inputs.hyprland-protocols.overlays.default
+    wlroots-hyprland
+    hyprland-packages
+    hyprland-extras
+  ]);
+
   # Packages for variations of Hyprland, and its dependencies.
   hyprland-packages = final: prev: {
     hyprland = final.callPackage ./default.nix {

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -24,12 +24,7 @@ in {
   # Packages for variations of Hyprland, and its dependencies.
   hyprland-packages = final: prev: {
     hyprland = final.callPackage ./default.nix {
-      version =
-        props.version
-        + "+date="
-        + (mkDate (self.lastModifiedDate or "19700101"))
-        + "_"
-        + (self.shortRev or "dirty");
+      version = "${props.version}+date=${mkDate (self.lastModifiedDate or "19700101")}_${self.shortRev or "dirty"}";
       wlroots = final.wlroots-hyprland;
       commit = self.rev or "";
       inherit (final) udis86 hyprland-protocols;
@@ -74,10 +69,7 @@ in {
   # the standard version in nixpkgs.
   wlroots-hyprland = final: prev: {
     wlroots-hyprland = final.callPackage ./wlroots.nix {
-      version =
-        mkDate (inputs.wlroots.lastModifiedDate or "19700101")
-        + "_"
-        + (inputs.wlroots.shortRev or "dirty");
+      version = "${mkDate (inputs.wlroots.lastModifiedDate or "19700101")}_${inputs.wlroots.shortRev or "dirty"}";
       src = inputs.wlroots;
       libdisplay-info = prev.libdisplay-info.overrideAttrs (old: {
         version = "0.1.1+date=2023-03-02";


### PR DESCRIPTION
Nearly identical to <https://github.com/hyprwm/xdg-desktop-portal-hyprland/pull/75> and <https://github.com/hyprwm/hyprland-protocols/pull/6>. Copied message and edited below.

1. The `nix fmt` command did not work for me so I have reverted it to use `legacyPackages` for simplicity. It works now.
   - Ran `nix fmt` on the whole flake, however the `overlays` in the `import nixpkgs` in `flake.nix` has some comments that get messed up when Alejandra has its way. I dislike Alejandra.
2. The overlay `hyprland-packages` used to include some dependencies (`udis86`) but not all of them. That was the job of the `default` overlay. I have changed it so that `hyprland-packages` will work correctly on its own, as now it includes all dependency overlays.
   - Now each package has its own overlay, while `default` combines the ones an end-user is expected to need.
   - ```nix
     $ nix eval 'path:.#overlays' --apply 'builtins.attrNames'
     [ "default" "hyprland-extras" "hyprland-packages" "udis86" "waybar-hyprland" "wlroots-hyprland" ]
     ```
3. Versions now use string interpolation rather than concatenation, because it looks nicer than when Alejandra tries to wrap concatenated strings.
   - ~~Perhaps we should adopt my (unpublished) changes from `Alexays/Waybar` and pull the first version fragment from `meson.build`.~~ The `props.json` file takes care of that. Maybe the other flakes could learn a thing or two?
4. Added another input `nix-systems` so that the `systems` is overrideable. I like this much better than using `flake-utils` or `flake-parts`.
   - Using `default-linux`, which is `[ "x86_64-linux" "aarch64-linux" ]`.
   - Updated usage when importing `nixpkgs` to correct for undocumented deprecation of `system`.
   - https://github.com/nix-systems/nix-systems
   - **Blocker:** This PR depends on <https://github.com/hyprwm/hyprland-protocols/pull/6> and for now you will see an error when evaluating flake outputs.
5. The attributes of the `packages` output are inherited from internal `pkgsFor`, which contains all of the overlays pre-applied.
   - ```nix
     $ nix eval 'path:.#packages.x86_64-linux' --apply 'builtins.attrNames'
     [ "default" "hyprland" "hyprland-debug" "hyprland-hidpi" "hyprland-no-hidpi" "hyprland-nvidia" "hyprland-protocols" "hyprland-share-picker" "hyprland-unwrapped" "udis86" "waybar-hyprland" "wlroots-hyprland" "xdg-desktop-portal-hyprland" ]
     ```