### PR TITLE
patches group toplevel-activated

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -929,9 +929,8 @@ void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
         auto curr = pWindow;
         do {
             curr = curr->m_sGroupData.pNextWindow;
-            if (curr->m_phForeignToplevel) {
+            if (curr->m_phForeignToplevel)
                 wlr_foreign_toplevel_handle_v1_set_activated(curr->m_phForeignToplevel, false);
-            }
         } while (curr->m_sGroupData.pNextWindow != pWindow);
     }
 

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -932,8 +932,7 @@ void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
             if (curr->m_phForeignToplevel) {
                 wlr_foreign_toplevel_handle_v1_set_activated(curr->m_phForeignToplevel, false);
             }
-
-        } while (curr != pWindow);
+        } while (curr->m_sGroupData.pNextWindow != pWindow);
     }
 
     if (pWindow->m_phForeignToplevel)

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -924,6 +924,18 @@ void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
 
     g_pLayoutManager->getCurrentLayout()->onWindowFocusChange(pWindow);
 
+    // TODO: implement this better
+    if (!PLASTWINDOW && pWindow->m_sGroupData.pNextWindow && pWindow->m_sGroupData.pNextWindow != pWindow) {
+        auto curr = pWindow;
+        do {
+            curr = curr->m_sGroupData.pNextWindow;
+            if (curr->m_phForeignToplevel) {
+                wlr_foreign_toplevel_handle_v1_set_activated(curr->m_phForeignToplevel, false);
+            }
+
+        } while (curr != pWindow);
+    }
+
     if (pWindow->m_phForeignToplevel)
         wlr_foreign_toplevel_handle_v1_set_activated(pWindow->m_phForeignToplevel, true);
 

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -687,7 +687,7 @@ void CWindow::setGroupCurrent(CWindow* pWindow) {
         g_pCompositor->setWindowFullscreen(PCURRENT, false, WORKSPACE->m_efFullscreenMode);
 
     PCURRENT->setHidden(true);
-    pWindow->setHidden(false);
+    pWindow->setHidden(false); // can remove m_pLastWindow 
 
     g_pLayoutManager->getCurrentLayout()->replaceWindowDataWith(PCURRENT, pWindow);
 


### PR DESCRIPTION
fixes hidden group windows always having toplevel activated status

not ideal, but doing it the right way seems to require messing with other functions, which will likely break stuff