### PR TITLE
center window improvements

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -885,11 +885,11 @@ void CConfigManager::handleUnbind(const std::string& command, const std::string&
 bool windowRuleValid(const std::string& RULE) {
     return !(RULE != "float" && RULE != "tile" && RULE.find("opacity") != 0 && RULE.find("move") != 0 && RULE.find("size") != 0 && RULE.find("minsize") != 0 &&
              RULE.find("maxsize") != 0 && RULE.find("pseudo") != 0 && RULE.find("monitor") != 0 && RULE.find("idleinhibit") != 0 && RULE != "nofocus" && RULE != "noblur" &&
-             RULE != "noshadow" && RULE != "nodim" && RULE != "noborder" && RULE != "center" && RULE != "opaque" && RULE != "forceinput" && RULE != "fullscreen" &&
-             RULE != "nofullscreenrequest" && RULE != "nomaximizerequest" && RULE != "fakefullscreen" && RULE != "nomaxsize" && RULE != "pin" && RULE != "noanim" &&
-             RULE != "dimaround" && RULE != "windowdance" && RULE != "maximize" && RULE != "keepaspectratio" && RULE.find("animation") != 0 && RULE.find("rounding") != 0 &&
-             RULE.find("workspace") != 0 && RULE.find("bordercolor") != 0 && RULE != "forcergbx" && RULE != "noinitialfocus" && RULE != "stayfocused" &&
-             RULE.find("bordersize") != 0 && RULE.find("xray") != 0);
+             RULE != "noshadow" && RULE != "nodim" && RULE != "noborder" && RULE != "opaque" && RULE != "forceinput" && RULE != "fullscreen" && RULE != "nofullscreenrequest" &&
+             RULE != "nomaximizerequest" && RULE != "fakefullscreen" && RULE != "nomaxsize" && RULE != "pin" && RULE != "noanim" && RULE != "dimaround" && RULE != "windowdance" &&
+             RULE != "maximize" && RULE != "keepaspectratio" && RULE.find("animation") != 0 && RULE.find("rounding") != 0 && RULE.find("workspace") != 0 &&
+             RULE.find("bordercolor") != 0 && RULE != "forcergbx" && RULE != "noinitialfocus" && RULE != "stayfocused" && RULE.find("bordersize") != 0 && RULE.find("xray") != 0 &&
+             RULE.find("center") != 0);
 }
 
 bool layerRuleValid(const std::string& RULE) {
@@ -917,7 +917,10 @@ void CConfigManager::handleWindowRule(const std::string& command, const std::str
         return;
     }
 
-    m_dWindowRules.push_back({RULE, VALUE});
+    if (RULE.find("size") == 0 || RULE.find("maxsize") == 0 || RULE.find("minsize") == 0)
+        m_dWindowRules.push_front({RULE, VALUE});
+    else
+        m_dWindowRules.push_back({RULE, VALUE});
 }
 
 void CConfigManager::handleLayerRule(const std::string& command, const std::string& value) {
@@ -1061,7 +1064,10 @@ void CConfigManager::handleWindowRuleV2(const std::string& command, const std::s
         return;
     }
 
-    m_dWindowRules.push_back(rule);
+    if (RULE.find("size") == 0 || RULE.find("maxsize") == 0 || RULE.find("minsize") == 0)
+        m_dWindowRules.push_front(rule);
+    else
+        m_dWindowRules.push_back(rule);
 }
 
 void CConfigManager::updateBlurredLS(const std::string& name, const bool forceBlur) {

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -412,7 +412,6 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
                     PWINDOW->setHidden(false);
                 } catch (...) { Debug::log(LOG, "Rule move failed, rule: %s -> %s", r.szRule.c_str(), r.szValue.c_str()); }
-            } else if (r.szRule == "center") {
             } else if (r.szRule.find("center") == 0) {
                 auto RESERVEDOFFSET = Vector2D();
                 try {

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -413,7 +413,14 @@ void Events::listener_mapWindow(void* owner, void* data) {
                     PWINDOW->setHidden(false);
                 } catch (...) { Debug::log(LOG, "Rule move failed, rule: %s -> %s", r.szRule.c_str(), r.szValue.c_str()); }
             } else if (r.szRule == "center") {
-                PWINDOW->m_vRealPosition = PMONITOR->vecPosition + PMONITOR->vecSize / 2.f - PWINDOW->m_vRealSize.goalv() / 2.f;
+            } else if (r.szRule.find("center") == 0) {
+                auto RESERVEDOFFSET = Vector2D();
+                try {
+                    if (std::stoi(r.szRule.substr(7)) == 1)
+                        RESERVEDOFFSET = (PMONITOR->vecReservedTopLeft - PMONITOR->vecReservedBottomRight) / 2.f;
+                } catch (std::exception& e) {}
+
+                PWINDOW->m_vRealPosition = PMONITOR->vecPosition + PMONITOR->vecSize / 2.f - PWINDOW->m_vRealSize.goalv() / 2.f + RESERVEDOFFSET;
             }
         }
 

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -414,10 +414,9 @@ void Events::listener_mapWindow(void* owner, void* data) {
                 } catch (...) { Debug::log(LOG, "Rule move failed, rule: %s -> %s", r.szRule.c_str(), r.szValue.c_str()); }
             } else if (r.szRule.find("center") == 0) {
                 auto RESERVEDOFFSET = Vector2D();
-                try {
-                    if (std::stoi(r.szRule.substr(7)) == 1)
-                        RESERVEDOFFSET = (PMONITOR->vecReservedTopLeft - PMONITOR->vecReservedBottomRight) / 2.f;
-                } catch (std::exception& e) {}
+                const auto ARGS = CVarList(r.szRule, 2, ' ');
+                if (ARGS[1] == "1")
+                    RESERVEDOFFSET = (PMONITOR->vecReservedTopLeft - PMONITOR->vecReservedBottomRight) / 2.f;
 
                 PWINDOW->m_vRealPosition = PMONITOR->vecPosition + PMONITOR->vecSize / 2.f - PWINDOW->m_vRealSize.goalv() / 2.f + RESERVEDOFFSET;
             }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -721,10 +721,8 @@ void CKeybindManager::centerWindow(std::string args) {
     const auto PMONITOR = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID);
 
     auto       RESERVEDOFFSET = Vector2D();
-    try {
-        if (std::stoi(args) == 1)
-            RESERVEDOFFSET = (PMONITOR->vecReservedTopLeft - PMONITOR->vecReservedBottomRight) / 2.f;
-    } catch (std::exception& e) {}
+    if (args == "1")
+        RESERVEDOFFSET = (PMONITOR->vecReservedTopLeft - PMONITOR->vecReservedBottomRight) / 2.f;
 
     PWINDOW->m_vRealPosition = PMONITOR->vecPosition + PMONITOR->vecSize / 2.f - PWINDOW->m_vRealSize.goalv() / 2.f + RESERVEDOFFSET;
     PWINDOW->m_vPosition     = PWINDOW->m_vRealPosition.goalv();

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -720,7 +720,13 @@ void CKeybindManager::centerWindow(std::string args) {
 
     const auto PMONITOR = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID);
 
-    PWINDOW->m_vRealPosition = PMONITOR->vecPosition + PMONITOR->vecSize / 2.f - PWINDOW->m_vRealSize.goalv() / 2.f;
+    auto       RESERVEDOFFSET = Vector2D();
+    try {
+        if (std::stoi(args) == 1)
+            RESERVEDOFFSET = (PMONITOR->vecReservedTopLeft - PMONITOR->vecReservedBottomRight) / 2.f;
+    } catch (std::exception& e) {}
+
+    PWINDOW->m_vRealPosition = PMONITOR->vecPosition + PMONITOR->vecSize / 2.f - PWINDOW->m_vRealSize.goalv() / 2.f + RESERVEDOFFSET;
     PWINDOW->m_vPosition     = PWINDOW->m_vRealPosition.goalv();
 }
 


### PR DESCRIPTION
fixes config order issues with size related window rules (closing https://github.com/hyprwm/Hyprland/issues/2807)
allows centerwindow (dispatcher) and center (window rule) to take into account monitor reserved space (closing https://github.com/hyprwm/Hyprland/issues/2289 and dupe https://github.com/hyprwm/Hyprland/issues/2839)

should not cause any issues

using size related window rules still messes up window spanning position but that's harder to fix (and can be avoided by using the center (window rule))

wiki (https://github.com/hyprwm/hyprland-wiki/pull/290)