### PR TITLE
remove shadow no_gaps_when_only

### DIFF
--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -104,6 +104,7 @@ struct SWindowSpecialRenderData {
     bool                       rounding   = true;
     bool                       border     = true;
     bool                       decorate   = true;
+    bool                       shadow     = true;
 };
 
 struct SWindowAdditionalConfigData {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1144,6 +1144,8 @@ void CConfigManager::handleWorkspaceRules(const std::string& command, const std:
             wsRule.borderSize = std::stoi(rule.substr(delim + 11));
         else if ((delim = rule.find("border:")) != std::string::npos)
             wsRule.border = configStringToInt(rule.substr(delim + 7));
+        else if ((delim = rule.find("shadow:")) != std::string::npos)
+            wsRule.shadow= configStringToInt(rule.substr(delim + 7));
         else if ((delim = rule.find("rounding:")) != std::string::npos)
             wsRule.rounding = configStringToInt(rule.substr(delim + 9));
         else if ((delim = rule.find("decorate:")) != std::string::npos)

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -48,6 +48,7 @@ struct SWorkspaceRule {
     std::optional<int>     border;
     std::optional<int>     rounding;
     std::optional<int>     decorate;
+    std::optional<int>     shadow;
 };
 
 struct SMonitorAdditionalReservedArea {

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -150,6 +150,7 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
         (NODESONWORKSPACE == 1 || (PWINDOW->m_bIsFullscreen && g_pCompositor->getWorkspaceByID(PWINDOW->m_iWorkspaceID)->m_efFullscreenMode == FULLSCREEN_MAXIMIZED))) {
 
         PWINDOW->m_sSpecialRenderData.rounding = false;
+        PWINDOW->m_sSpecialRenderData.shadow   = false;
         PWINDOW->m_sSpecialRenderData.decorate = WORKSPACERULE.decorate.value_or(true);
         PWINDOW->m_sSpecialRenderData.border   = WORKSPACERULE.border.value_or(*PNOGAPSWHENONLY == 2);
 
@@ -167,6 +168,7 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
 
     PWINDOW->m_sSpecialRenderData.rounding   = WORKSPACERULE.rounding.value_or(true);
     PWINDOW->m_sSpecialRenderData.decorate   = WORKSPACERULE.decorate.value_or(true);
+    PWINDOW->m_sSpecialRenderData.shadow     = WORKSPACERULE.shadow.value_or(true);
     PWINDOW->m_sSpecialRenderData.border     = WORKSPACERULE.border.value_or(true);
     PWINDOW->m_sSpecialRenderData.borderSize = WORKSPACERULE.borderSize.value_or(-1);
 

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -59,6 +59,9 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D
     if (!m_pWindow->m_sSpecialRenderData.decorate)
         return;
 
+    if (!m_pWindow->m_sSpecialRenderData.shadow)
+        return;
+
     if (m_pWindow->m_sAdditionalConfigData.forceNoShadow)
         return;
 


### PR DESCRIPTION
re-disables shadows when only and using no_gaps_when_only (https://github.com/hyprwm/Hyprland/issues/2953)

as a side effect adds shadow as a workspace rule