### PR TITLE
fix: Use monitor refreshrate tick for resizing and/or moving windows

### DIFF
--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -296,7 +296,7 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
     if ((abs(TICKDELTA.x) < 1.f && abs(TICKDELTA.y) < 1.f) ||
         (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - TIMER).count() <
              1000.0 / g_pHyprRenderer->m_pMostHzMonitor->refreshRate &&
-         *PANIMATEMOUSE))
+         (*PANIMATEMOUSE || *PANIMATE)))
         return;
 
     TIMER = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
when using the following 2 settings: animate_mouse_windowdragging=false and animate_manual_resizes=true
The animations for resizing are currently not using monitor refreshrate ticks due to this being locked behind PANIMATEMOUSE, which is only active with animate_mouse_windowdragging.

This results in animations being "laggy" again. (at least for me)

This simply activates the feature for both, meaning both can benefit from the improved tick.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
ready

