### PR TITLE
fix: ioctl use /dev/tty instead of fd 0 for VT_GETSTATE

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -527,7 +527,7 @@ bool CKeybindManager::handleVT(xkb_keysym_t keysym) {
                 ttynum = st.v_active;
 #elif defined(VT_GETACTIVE)
             int vt;
-            if (!ioctl(0, VT_GETACTIVE, &vt))
+            if (!ioctl(fd, VT_GETACTIVE, &vt))
                 ttynum = vt;
 #endif
             close(fd);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -3,6 +3,7 @@
 #include <regex>
 
 #include <sys/ioctl.h>
+#include <fcntl.h>
 #if defined(__linux__)
 #include <linux/vt.h>
 #elif defined(__NetBSD__) || defined(__OpenBSD__)
@@ -519,9 +520,13 @@ bool CKeybindManager::handleVT(xkb_keysym_t keysym) {
         // vtnr is bugged for some reason.
         unsigned int ttynum = 0;
 #if defined(VT_GETSTATE)
+        int            fd;
         struct vt_stat st;
-        if (!ioctl(0, VT_GETSTATE, &st))
-            ttynum = st.v_active;
+        if ((fd = open("/dev/tty", O_RDONLY | O_NOCTTY)) >= 0) {
+            if (!ioctl(fd, VT_GETSTATE, &st))
+                ttynum = st.v_active;
+            close(fd);
+        }
 #elif defined(VT_GETACTIVE)
         int vt;
         if (!ioctl(0, VT_GETACTIVE, &vt))

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -519,19 +519,19 @@ bool CKeybindManager::handleVT(xkb_keysym_t keysym) {
 
         // vtnr is bugged for some reason.
         unsigned int ttynum = 0;
-#if defined(VT_GETSTATE)
-        int            fd;
-        struct vt_stat st;
+        int          fd;
         if ((fd = open("/dev/tty", O_RDONLY | O_NOCTTY)) >= 0) {
+#if defined(VT_GETSTATE)
+            struct vt_stat st;
             if (!ioctl(fd, VT_GETSTATE, &st))
                 ttynum = st.v_active;
+#elif defined(VT_GETACTIVE)
+            int vt;
+            if (!ioctl(0, VT_GETACTIVE, &vt))
+                ttynum = vt;
+#endif
             close(fd);
         }
-#elif defined(VT_GETACTIVE)
-        int vt;
-        if (!ioctl(0, VT_GETACTIVE, &vt))
-            ttynum = vt;
-#endif
 
         if (ttynum == TTY)
             return true;


### PR DESCRIPTION
ioctl VT_GETSTATE on stdin fails if it is not console, such as when using GDM.  `/dev/tty` should be used instead.

- `/dev/tty` is a synonym for the controlling terminal of a process, if there is one.

---

Fixes #2460

