### PR TITLE
fix: update `alpha` of ZWLR_LAYER_SHELL_V1_LAYER_TOP only when Workspaces is active on the monitor.

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2065,9 +2065,11 @@ void CCompositor::updateFullscreenFadeOnWorkspace(CWorkspace* pWorkspace) {
 
     const auto PMONITOR = getMonitorFromID(pWorkspace->m_iMonitorID);
 
-    for (auto& ls : PMONITOR->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]) {
-        if (!ls->fadingOut)
-            ls->alpha = FULLSCREEN && pWorkspace->m_efFullscreenMode == FULLSCREEN_FULL ? 0.f : 1.f;
+    if (pWorkspace->m_iID == PMONITOR->activeWorkspace) {
+        for (auto& ls : PMONITOR->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]) {
+            if (!ls->fadingOut)
+                ls->alpha = FULLSCREEN && pWorkspace->m_efFullscreenMode == FULLSCREEN_FULL ? 0.f : 1.f;
+        }
     }
 }
 


### PR DESCRIPTION
Previously, the alpha of `ZWLR_LAYER_SHELL_V1_LAYER_TOP` was set based on whether the target workspaces (pWorkspace) of `CCompositor::updateFullscreenFadeOnWorkspace` had fullscreen windows open(m_bHasFullscreenWindow). This could be inconsistent if the target workspace wasn't the active workspace of the monitor, as the active workspace may not have had a fullscreen window open at all.

After this patch, the alpha of `ZWLR_LAYER_SHELL_V1_LAYER_TOP` will only be influenced by `pWorkspace->m_bHasFullscreenWindow` if pWorkspace is the active workspace of the monitor.

Fix: #2634