### PR TITLE
fix some partly opaque windows getting treated as fully opaque

### DIFF
--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -799,10 +799,6 @@ bool CWindow::opaque() {
     if (m_uSurface.xdg->surface->opaque)
         return true;
 
-    const auto EXTENTS = pixman_region32_extents(&m_uSurface.xdg->surface->opaque_region);
-    if (EXTENTS->x2 - EXTENTS->x1 >= m_uSurface.xdg->surface->current.buffer_width && EXTENTS->y2 - EXTENTS->y1 >= m_uSurface.xdg->surface->current.buffer_height)
-        return true;
-
     return false;
 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This fixes some partly opaque windows (e.g. firefox with a transparent sidebar) getting treated as fully opaque when Hyprland is launched from the tty.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This error only occurs when launching hyprland from the tty because the opaque region covers the whole application. If Hyperland is launched as a wayland client, the bounding box for the opaque area has the correct size. 

#### Is it ready for merging, or does it need work?
Ready

