### PR TITLE
feat: add a new dispatcher that can move windows in and out of groups, or swap windows

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -221,7 +221,7 @@ void CConfigManager::setDefaultVars() {
     configValues["binds:workspace_back_and_forth"].intValue = 0;
     configValues["binds:allow_workspace_cycles"].intValue   = 0;
     configValues["binds:focus_preferred_method"].intValue   = 0;
-    configValues["binds:chicken_checkgrouplock"].intValue   = 0;
+    configValues["binds:check_group_lock"].intValue         = 0;
 
     configValues["gestures:workspace_swipe"].intValue                          = 0;
     configValues["gestures:workspace_swipe_fingers"].intValue                  = 3;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -221,7 +221,7 @@ void CConfigManager::setDefaultVars() {
     configValues["binds:workspace_back_and_forth"].intValue = 0;
     configValues["binds:allow_workspace_cycles"].intValue   = 0;
     configValues["binds:focus_preferred_method"].intValue   = 0;
-    configValues["binds:check_group_lock"].intValue         = 0;
+    configValues["binds:ignore_group_lock"].intValue        = 0;
 
     configValues["gestures:workspace_swipe"].intValue                          = 0;
     configValues["gestures:workspace_swipe_fingers"].intValue                  = 3;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -221,6 +221,7 @@ void CConfigManager::setDefaultVars() {
     configValues["binds:workspace_back_and_forth"].intValue = 0;
     configValues["binds:allow_workspace_cycles"].intValue   = 0;
     configValues["binds:focus_preferred_method"].intValue   = 0;
+    configValues["binds:chicken_checkgrouplock"].intValue   = 0;
 
     configValues["gestures:workspace_swipe"].intValue                          = 0;
     configValues["gestures:workspace_swipe_fingers"].intValue                  = 3;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -109,6 +109,7 @@ void CConfigManager::setDefaultVars() {
     configValues["misc:allow_session_lock_restore"].intValue   = 0;
     configValues["misc:groupbar_scrolling"].intValue           = 1;
     configValues["misc:group_insert_after_current"].intValue   = 1;
+    configValues["misc:group_focus_removed_window"].intValue   = 1;
     configValues["misc:render_titles_in_groupbar"].intValue    = 1;
     configValues["misc:groupbar_titles_font_size"].intValue    = 8;
     configValues["misc:groupbar_gradients"].intValue           = 1;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -100,7 +100,6 @@ void CConfigManager::setDefaultVars() {
     configValues["misc:swallow_exception_regex"].strValue      = STRVAL_EMPTY;
     configValues["misc:focus_on_activate"].intValue            = 0;
     configValues["misc:no_direct_scanout"].intValue            = 1;
-    configValues["misc:moveintogroup_lock_check"].intValue     = 0;
     configValues["misc:hide_cursor_on_touch"].intValue         = 1;
     configValues["misc:mouse_move_focuses_monitor"].intValue   = 1;
     configValues["misc:render_ahead_of_time"].intValue         = 0;

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2008,7 +2008,7 @@ void CKeybindManager::lockActiveGroup(std::string args) {
     g_pCompositor->updateWindowAnimatedDecorationValues(PWINDOW);
 }
 
-void moveWindowIntoGroup(CWindow* pWindow, CWindow* pWindowInDirection) {
+void CKeybindManager::moveWindowIntoGroup(CWindow* pWindow, CWindow* pWindowInDirection) {
     if (!pWindow->m_sGroupData.pNextWindow)
         pWindow->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(pWindow));
 
@@ -2025,7 +2025,7 @@ void moveWindowIntoGroup(CWindow* pWindow, CWindow* pWindowInDirection) {
     g_pCompositor->warpCursorTo(pWindow->middle());
 }
 
-void moveWindowOutOfGroup(CWindow* pWindow) {
+void CKeybindManager::moveWindowOutOfGroup(CWindow* pWindow) {
     static auto* const BFOCUSREMOVEDWINDOW = &g_pConfigManager->getConfigValuePtr("misc:group_focus_removed_window")->intValue;
     const auto         PWINDOWPREV         = pWindow->getGroupPrevious();
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2109,27 +2109,23 @@ void CKeybindManager::moveWindowOrGroup(std::string args) {
         if (ISWINDOWGROUPLOCKED && *BCHECKGROUPLOCK) {
             g_pLayoutManager->getCurrentLayout()->switchWindows(PWINDOW, PWINDOWINDIR);
             g_pCompositor->warpCursorTo(PWINDOW->middle());
-        } else {
+        } else
             moveWindowIntoGroup(PWINDOW, PWINDOWINDIR);
-        }
     } else if (ISWINDOWINDIRGROUPLOCKED) {
         if (*BCHECKGROUPLOCK) {
             g_pLayoutManager->getCurrentLayout()->switchWindows(PWINDOW, PWINDOWINDIR);
             g_pCompositor->warpCursorTo(PWINDOW->middle());
-        } else {
+        } else
             moveWindowIntoGroup(PWINDOW, PWINDOWINDIR);
-        }
     } else if (PWINDOWINDIR) {
-        if (ISWINDOWGROUP && (!*BCHECKGROUPLOCK || !ISWINDOWGROUPLOCKED)) {
+        if (ISWINDOWGROUP && (!*BCHECKGROUPLOCK || !ISWINDOWGROUPLOCKED))
             moveWindowOutOfGroup(PWINDOW);
-        } else {
+        else {
             g_pLayoutManager->getCurrentLayout()->switchWindows(PWINDOW, PWINDOWINDIR);
             g_pCompositor->warpCursorTo(PWINDOW->middle());
         }
-    } else {
-        if (ISWINDOWGROUP && (!*BCHECKGROUPLOCK || !ISWINDOWGROUPLOCKED)) {
-            moveWindowOutOfGroup(PWINDOW);
-        }
+    } else if (ISWINDOWGROUP && (!*BCHECKGROUPLOCK || !ISWINDOWGROUPLOCKED)) {
+        moveWindowOutOfGroup(PWINDOW);
     }
 }
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2095,8 +2095,10 @@ void CKeybindManager::moveWindowOrGroup(std::string args) {
     }
 
     const auto PWINDOW = g_pCompositor->m_pLastWindow;
-    if (!PWINDOW)
+
+    if (!PWINDOW || PWINDOW->m_bIsFullscreen)
         return;
+
     const auto ISWINDOWGROUP       = PWINDOW->m_sGroupData.pNextWindow;
     const auto ISWINDOWGROUPLOCKED = ISWINDOWGROUP && PWINDOW->getGroupHead()->m_sGroupData.locked;
 
@@ -2107,13 +2109,13 @@ void CKeybindManager::moveWindowOrGroup(std::string args) {
     // note: PWINDOWINDIR is not null implies !PWINDOW->m_bIsFloating
     if (ISWINDOWINDIRGROUP && !ISWINDOWINDIRGROUPLOCKED) {
         if (ISWINDOWGROUPLOCKED && !*BIGNOREGROUPLOCK) {
-            g_pLayoutManager->getCurrentLayout()->switchWindows(PWINDOW, PWINDOWINDIR);
+            g_pLayoutManager->getCurrentLayout()->moveWindowTo(PWINDOW, args);
             g_pCompositor->warpCursorTo(PWINDOW->middle());
         } else
             moveWindowIntoGroup(PWINDOW, PWINDOWINDIR);
     } else if (ISWINDOWINDIRGROUPLOCKED) {
         if (!*BIGNOREGROUPLOCK) {
-            g_pLayoutManager->getCurrentLayout()->switchWindows(PWINDOW, PWINDOWINDIR);
+            g_pLayoutManager->getCurrentLayout()->moveWindowTo(PWINDOW, args);
             g_pCompositor->warpCursorTo(PWINDOW->middle());
         } else
             moveWindowIntoGroup(PWINDOW, PWINDOWINDIR);
@@ -2121,7 +2123,7 @@ void CKeybindManager::moveWindowOrGroup(std::string args) {
         if (ISWINDOWGROUP && (*BIGNOREGROUPLOCK || !ISWINDOWGROUPLOCKED))
             moveWindowOutOfGroup(PWINDOW);
         else {
-            g_pLayoutManager->getCurrentLayout()->switchWindows(PWINDOW, PWINDOWINDIR);
+            g_pLayoutManager->getCurrentLayout()->moveWindowTo(PWINDOW, args);
             g_pCompositor->warpCursorTo(PWINDOW->middle());
         }
     } else if (ISWINDOWGROUP && (*BIGNOREGROUPLOCK || !ISWINDOWGROUPLOCKED)) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2103,19 +2103,6 @@ void CKeybindManager::moveWindowOrGroup(std::string args) {
     const auto ISWINDOWINDIRGROUP       = PWINDOWINDIR && PWINDOWINDIR->m_sGroupData.pNextWindow;
     const auto ISWINDOWINDIRGROUPLOCKED = ISWINDOWINDIRGROUP && PWINDOWINDIR->getGroupHead()->m_sGroupData.locked;
 
-    // !FIXME: remove logging
-    Debug::log(INFO, "==> movewindoworgroup");
-    Debug::log(INFO,
-               "\twindow           %x\n"
-               "\tis group:        %s\n"
-               "\tgroup is locked: %s\n",
-               PWINDOW, ISWINDOWGROUP ? "true" : "false", ISWINDOWGROUPLOCKED ? "true" : "false");
-    Debug::log(INFO,
-               "\tdirection                  %x\n"
-               "\tdirection is group:        %s\n"
-               "\tdirection group is locked: %s\n",
-               PWINDOWINDIR, ISWINDOWINDIRGROUP ? "true" : "false", ISWINDOWINDIRGROUPLOCKED ? "true" : "false");
-
     // note: PWINDOWINDIR is not null implies !PWINDOW->m_bIsFloating
     if (ISWINDOWINDIRGROUP && !ISWINDOWINDIRGROUPLOCKED) {
         if (ISWINDOWGROUPLOCKED && *BCHECKGROUPLOCK) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2118,17 +2118,15 @@ void CKeybindManager::moveWindowOrGroup(std::string args) {
         } else {
             moveWindowIntoGroup(PWINDOW, PWINDOWINDIR);
         }
-    } else if (PWINDOWINDIR) { // PWINDOWINDIR is not a group
+    } else if (PWINDOWINDIR) {
         if (ISWINDOWGROUP && (!*BCHECKGROUPLOCK || !ISWINDOWGROUPLOCKED)) {
             moveWindowOutOfGroup(PWINDOW);
         } else {
             g_pLayoutManager->getCurrentLayout()->switchWindows(PWINDOW, PWINDOWINDIR);
             g_pCompositor->warpCursorTo(PWINDOWINDIR->m_vRealPosition.vec() + PWINDOWINDIR->m_vRealSize.vec() / 2.0);
         }
-    } else { // no window in direction
-        if (ISWINDOWGROUPLOCKED && *BCHECKGROUPLOCK) {
-            // do nothing
-        } else if (ISWINDOWGROUP) {
+    } else {
+        if (ISWINDOWGROUP && (!*BCHECKGROUPLOCK || !ISWINDOWGROUPLOCKED)) {
             moveWindowOutOfGroup(PWINDOW);
         }
     }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2040,10 +2040,10 @@ void moveWindowOutOfGroup(CWindow* pWindow) {
 
     if (*BFOCUSREMOVEDWINDOW) {
         g_pCompositor->focusWindow(pWindow);
-        g_pCompositor->warpCursorTo(pWindow->m_vRealPosition.goalv() + pWindow->m_vRealSize.goalv() / 2.0);
+        g_pCompositor->warpCursorTo(pWindow->middle());
     } else {
         g_pCompositor->focusWindow(PWINDOWPREV);
-        g_pCompositor->warpCursorTo(PWINDOWPREV->m_vRealPosition.goalv() + PWINDOWPREV->m_vRealSize.goalv() / 2.0);
+        g_pCompositor->warpCursorTo(pWindow->middle());
     }
 }
 
@@ -2107,14 +2107,14 @@ void CKeybindManager::moveWindowOrGroup(std::string args) {
     if (ISWINDOWINDIRGROUP && !ISWINDOWINDIRGROUPLOCKED) {
         if (ISWINDOWGROUPLOCKED && *BCHECKGROUPLOCK) {
             g_pLayoutManager->getCurrentLayout()->switchWindows(PWINDOW, PWINDOWINDIR);
-            g_pCompositor->warpCursorTo(PWINDOWINDIR->m_vRealPosition.vec() + PWINDOWINDIR->m_vRealSize.vec() / 2.0);
+            g_pCompositor->warpCursorTo(PWINDOW->middle());
         } else {
             moveWindowIntoGroup(PWINDOW, PWINDOWINDIR);
         }
     } else if (ISWINDOWINDIRGROUPLOCKED) {
         if (*BCHECKGROUPLOCK) {
             g_pLayoutManager->getCurrentLayout()->switchWindows(PWINDOW, PWINDOWINDIR);
-            g_pCompositor->warpCursorTo(PWINDOWINDIR->m_vRealPosition.vec() + PWINDOWINDIR->m_vRealSize.vec() / 2.0);
+            g_pCompositor->warpCursorTo(PWINDOW->middle());
         } else {
             moveWindowIntoGroup(PWINDOW, PWINDOWINDIR);
         }
@@ -2123,7 +2123,7 @@ void CKeybindManager::moveWindowOrGroup(std::string args) {
             moveWindowOutOfGroup(PWINDOW);
         } else {
             g_pLayoutManager->getCurrentLayout()->switchWindows(PWINDOW, PWINDOWINDIR);
-            g_pCompositor->warpCursorTo(PWINDOWINDIR->m_vRealPosition.vec() + PWINDOWINDIR->m_vRealSize.vec() / 2.0);
+            g_pCompositor->warpCursorTo(PWINDOW->middle());
         }
     } else {
         if (ISWINDOWGROUP && (!*BCHECKGROUPLOCK || !ISWINDOWGROUPLOCKED)) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2024,6 +2024,9 @@ void moveWindowIntoGroup(CWindow* pWindow, CWindow* pWindowInDirection) {
 }
 
 void moveWindowOutOfGroup(CWindow* pWindow) {
+    static auto* const BFOCUSREMOVEDWINDOW = &g_pConfigManager->getConfigValuePtr("misc:group_focus_removed_window")->intValue;
+    static auto const  PWINDOWPREV         = pWindow->getGroupPrevious();
+
     g_pLayoutManager->getCurrentLayout()->onWindowRemoved(pWindow);
 
     const auto GROUPSLOCKEDPREV = g_pKeybindManager->m_bGroupsLocked;
@@ -2034,9 +2037,13 @@ void moveWindowOutOfGroup(CWindow* pWindow) {
 
     g_pKeybindManager->m_bGroupsLocked = GROUPSLOCKEDPREV;
 
-    // TODO: Add a variable to configure whether the focus should stay in the group or move to the window in question.
-    g_pCompositor->focusWindow(pWindow);
-    g_pCompositor->warpCursorTo(pWindow->m_vRealPosition.goalv() + pWindow->m_vRealSize.goalv() / 2.0);
+    if (*BFOCUSREMOVEDWINDOW) {
+        g_pCompositor->focusWindow(pWindow);
+        g_pCompositor->warpCursorTo(pWindow->m_vRealPosition.goalv() + pWindow->m_vRealSize.goalv() / 2.0);
+    } else {
+        g_pCompositor->focusWindow(PWINDOWPREV);
+        g_pCompositor->warpCursorTo(PWINDOWPREV->m_vRealPosition.goalv() + PWINDOWPREV->m_vRealSize.goalv() / 2.0);
+    }
 }
 
 void CKeybindManager::moveIntoGroup(std::string args) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2022,6 +2022,7 @@ void moveWindowIntoGroup(CWindow* pWindow, CWindow* pWindowInDirection) {
     pWindow->updateWindowDecos();
     g_pLayoutManager->getCurrentLayout()->recalculateWindow(pWindow);
     g_pCompositor->focusWindow(pWindow);
+    g_pCompositor->warpCursorTo(pWindow->middle());
 }
 
 void moveWindowOutOfGroup(CWindow* pWindow) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -69,6 +69,7 @@ CKeybindManager::CKeybindManager() {
     m_mDispatchers["moveintogroup"]                 = moveIntoGroup;
     m_mDispatchers["moveoutofgroup"]                = moveOutOfGroup;
     m_mDispatchers["movewindoworgroup"]             = moveWindowOrGroup;
+    m_mDispatchers["setgrouplockchecking"]          = setGroupLockChecking;
     m_mDispatchers["global"]                        = global;
 
     m_tScrollTimer.reset();
@@ -2144,6 +2145,15 @@ void CKeybindManager::moveWindowOrGroup(std::string args) {
             moveWindowOutOfGroup(PWINDOW);
         }
     }
+}
+
+void CKeybindManager::setGroupLockChecking(std::string args) {
+    static auto* const BCHECKGROUPLOCK = &g_pConfigManager->getConfigValuePtr("binds:check_group_lock")->intValue;
+
+    if (args == "toggle")
+        *BCHECKGROUPLOCK = !*BCHECKGROUPLOCK;
+    else
+        *BCHECKGROUPLOCK = args == "on";
 }
 
 void CKeybindManager::global(std::string args) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -68,7 +68,7 @@ CKeybindManager::CKeybindManager() {
     m_mDispatchers["lockactivegroup"]               = lockActiveGroup;
     m_mDispatchers["moveintogroup"]                 = moveIntoGroup;
     m_mDispatchers["moveoutofgroup"]                = moveOutOfGroup;
-    m_mDispatchers["chicken"]                       = chicken;
+    m_mDispatchers["movewindoworgroup"]             = moveWindowOrGroup;
     m_mDispatchers["global"]                        = global;
 
     m_tScrollTimer.reset();
@@ -2074,10 +2074,10 @@ void CKeybindManager::moveOutOfGroup(std::string args) {
     moveWindowOutOfGroup(PWINDOW);
 }
 
-void CKeybindManager::chicken(std::string args) {
+void CKeybindManager::moveWindowOrGroup(std::string args) {
     char               arg = args[0];
 
-    static auto* const CHECKGROUPLOCK = &g_pConfigManager->getConfigValuePtr("binds:chicken_checkgrouplock")->intValue;
+    static auto* const CHECKGROUPLOCK = &g_pConfigManager->getConfigValuePtr("binds:check_group_lock")->intValue;
 
     if (!isDirection(args)) {
         Debug::log(ERR, "Cannot move into group in direction %c, unsupported direction. Supported: l,r,u/t,d/b", arg);
@@ -2095,7 +2095,7 @@ void CKeybindManager::chicken(std::string args) {
     const auto ISWINDOWINDIRGROUPLOCKED = ISWINDOWINDIRGROUP && PWINDOWINDIR->getGroupHead()->m_sGroupData.locked;
 
     // !FIXME: remove logging
-    Debug::log(INFO, "==> chicken");
+    Debug::log(INFO, "==> movewindoworgroup");
     Debug::log(INFO,
                "\twindow           %x\n"
                "\tis group:        %s\n"

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2138,6 +2138,8 @@ void CKeybindManager::setIgnoreGroupLock(std::string args) {
         *BIGNOREGROUPLOCK = !*BIGNOREGROUPLOCK;
     else
         *BIGNOREGROUPLOCK = args == "on";
+
+    g_pEventManager->postEvent(SHyprIPCEvent{"ignoregrouplock", std::to_string(*BIGNOREGROUPLOCK)});
 }
 
 void CKeybindManager::global(std::string args) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2025,7 +2025,7 @@ void moveWindowIntoGroup(CWindow* pWindow, CWindow* pWindowInDirection) {
 
 void moveWindowOutOfGroup(CWindow* pWindow) {
     static auto* const BFOCUSREMOVEDWINDOW = &g_pConfigManager->getConfigValuePtr("misc:group_focus_removed_window")->intValue;
-    static auto const  PWINDOWPREV         = pWindow->getGroupPrevious();
+    const auto         PWINDOWPREV         = pWindow->getGroupPrevious();
 
     g_pLayoutManager->getCurrentLayout()->onWindowRemoved(pWindow);
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2034,9 +2034,9 @@ void moveWindowOutOfGroup(CWindow* pWindow) {
 
     g_pKeybindManager->m_bGroupsLocked = GROUPSLOCKEDPREV;
 
-    // TODO: configurable
+    // TODO: Add a variable to configure whether the focus should stay in the group or move to the window in question.
     g_pCompositor->focusWindow(pWindow);
-    g_pCompositor->warpCursorTo(pWindow->m_vRealPosition.vec() + pWindow->m_vRealSize.vec() / 2.0);
+    g_pCompositor->warpCursorTo(pWindow->m_vRealPosition.goalv() + pWindow->m_vRealSize.goalv() / 2.0);
 }
 
 void CKeybindManager::moveIntoGroup(std::string args) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2042,7 +2042,7 @@ void moveWindowOutOfGroup(CWindow* pWindow) {
 void CKeybindManager::moveIntoGroup(std::string args) {
     char               arg = args[0];
 
-    static auto* const GROUPLOCKCHECK = &g_pConfigManager->getConfigValuePtr("misc:moveintogroup_lock_check")->intValue;
+    static auto* const BCHECKGROUPLOCK = &g_pConfigManager->getConfigValuePtr("binds:check_group_lock")->intValue;
 
     if (!isDirection(args)) {
         Debug::log(ERR, "Cannot move into group in direction {}, unsupported direction. Supported: l,r,u/t,d/b", arg);
@@ -2059,7 +2059,8 @@ void CKeybindManager::moveIntoGroup(std::string args) {
     if (!PWINDOWINDIR || !PWINDOWINDIR->m_sGroupData.pNextWindow)
         return;
 
-    if (*GROUPLOCKCHECK && (PWINDOWINDIR->getGroupHead()->m_sGroupData.locked || (PWINDOW->m_sGroupData.pNextWindow && PWINDOW->m_sGroupData.locked)))
+    // Do not move window into locked group if binds:check_group_lock is true
+    if (*BCHECKGROUPLOCK && (PWINDOWINDIR->getGroupHead()->m_sGroupData.locked || (PWINDOW->m_sGroupData.pNextWindow && PWINDOW->getGroupHead()->m_sGroupData.locked)))
         return;
 
     moveWindowIntoGroup(PWINDOW, PWINDOWINDIR);
@@ -2077,7 +2078,7 @@ void CKeybindManager::moveOutOfGroup(std::string args) {
 void CKeybindManager::moveWindowOrGroup(std::string args) {
     char               arg = args[0];
 
-    static auto* const CHECKGROUPLOCK = &g_pConfigManager->getConfigValuePtr("binds:check_group_lock")->intValue;
+    static auto* const BCHECKGROUPLOCK = &g_pConfigManager->getConfigValuePtr("binds:check_group_lock")->intValue;
 
     if (!isDirection(args)) {
         Debug::log(ERR, "Cannot move into group in direction %c, unsupported direction. Supported: l,r,u/t,d/b", arg);
@@ -2109,28 +2110,28 @@ void CKeybindManager::moveWindowOrGroup(std::string args) {
 
     // note: PWINDOWINDIR is not null implies !PWINDOW->m_bIsFloating
     if (ISWINDOWINDIRGROUP && !ISWINDOWINDIRGROUPLOCKED) {
-        if (ISWINDOWGROUPLOCKED && *CHECKGROUPLOCK) {
+        if (ISWINDOWGROUPLOCKED && *BCHECKGROUPLOCK) {
             g_pLayoutManager->getCurrentLayout()->switchWindows(PWINDOW, PWINDOWINDIR);
             g_pCompositor->warpCursorTo(PWINDOWINDIR->m_vRealPosition.vec() + PWINDOWINDIR->m_vRealSize.vec() / 2.0);
         } else {
             moveWindowIntoGroup(PWINDOW, PWINDOWINDIR);
         }
     } else if (ISWINDOWINDIRGROUPLOCKED) {
-        if (*CHECKGROUPLOCK) {
+        if (*BCHECKGROUPLOCK) {
             g_pLayoutManager->getCurrentLayout()->switchWindows(PWINDOW, PWINDOWINDIR);
             g_pCompositor->warpCursorTo(PWINDOWINDIR->m_vRealPosition.vec() + PWINDOWINDIR->m_vRealSize.vec() / 2.0);
         } else {
             moveWindowIntoGroup(PWINDOW, PWINDOWINDIR);
         }
     } else if (PWINDOWINDIR) { // PWINDOWINDIR is not a group
-        if (ISWINDOWGROUP && (!*CHECKGROUPLOCK || !ISWINDOWGROUPLOCKED)) {
+        if (ISWINDOWGROUP && (!*BCHECKGROUPLOCK || !ISWINDOWGROUPLOCKED)) {
             moveWindowOutOfGroup(PWINDOW);
         } else {
             g_pLayoutManager->getCurrentLayout()->switchWindows(PWINDOW, PWINDOWINDIR);
             g_pCompositor->warpCursorTo(PWINDOWINDIR->m_vRealPosition.vec() + PWINDOWINDIR->m_vRealSize.vec() / 2.0);
         }
     } else { // no window in direction
-        if (ISWINDOWGROUPLOCKED && *CHECKGROUPLOCK) {
+        if (ISWINDOWGROUPLOCKED && *BCHECKGROUPLOCK) {
             // do nothing
         } else if (ISWINDOWGROUP) {
             moveWindowOutOfGroup(PWINDOW);

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -28,8 +28,7 @@ struct SKeybind {
     bool shadowed = false;
 };
 
-enum eFocusWindowMode
-{
+enum eFocusWindowMode {
     MODE_CLASS_REGEX = 0,
     MODE_TITLE_REGEX,
     MODE_ADDRESS,

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -145,6 +145,7 @@ class CKeybindManager {
     static void     moveOutOfGroup(std::string);
     static void     moveGroupWindow(std::string);
     static void     moveWindowOrGroup(std::string);
+    static void     setGroupLockChecking(std::string);
     static void     global(std::string);
 
     friend class CCompositor;

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -147,7 +147,7 @@ class CKeybindManager {
     static void     moveOutOfGroup(std::string);
     static void     moveGroupWindow(std::string);
     static void     moveWindowOrGroup(std::string);
-    static void     setGroupLockChecking(std::string);
+    static void     setIgnoreGroupLock(std::string);
     static void     global(std::string);
 
     friend class CCompositor;

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -144,7 +144,7 @@ class CKeybindManager {
     static void     moveIntoGroup(std::string);
     static void     moveOutOfGroup(std::string);
     static void     moveGroupWindow(std::string);
-    static void     chicken(std::string);
+    static void     moveWindowOrGroup(std::string);
     static void     global(std::string);
 
     friend class CCompositor;

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -144,6 +144,7 @@ class CKeybindManager {
     static void     moveIntoGroup(std::string);
     static void     moveOutOfGroup(std::string);
     static void     moveGroupWindow(std::string);
+    static void     chicken(std::string);
     static void     global(std::string);
 
     friend class CCompositor;

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -90,6 +90,8 @@ class CKeybindManager {
     bool                      ensureMouseBindState();
 
     static bool               tryMoveFocusToMonitor(CMonitor* monitor);
+    static void               moveWindowOutOfGroup(CWindow* pWindow);
+    static void               moveWindowIntoGroup(CWindow* pWindow, CWindow* pWindowInDirection);
 
     // -------------- Dispatchers -------------- //
     static void     killActive(std::string);


### PR DESCRIPTION
## [Breaking change] Add a new dispatcher `movewindoworgroup` that implements the behaviour of moveintowindow, swapwindow and moveoutofwindow.

Partial implementation of #2851

### Beehaviour
| active window                 | window in direction | default / ignore group lock     | implemented        | notes                                                                                                                                                              |
| ----------------------------- | ------------------- | ------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| group                         | group               | `moveIntoGroup`                 | :heavy_check_mark: | Because the direction of moveoutofgroup is not currently controllable, new dispatcher will not behave as `moveOutOfGroup` until directional control is implemented |
| group locked                  | group               | `moveWindowTo` / `moveIntoGroup`  | :heavy_check_mark: |
| window                        | group               | `moveIntoGroup`                 | :heavy_check_mark: |
| group / group locked / window | group locked        | `moveWindowTo` / `moveIntoGroup`  | :heavy_check_mark: |
| group                         | window              | `moveOutOfGroup`                | :heavy_check_mark: |
| group locked                  | window              | `moveWindowTo` / `moveOutOfGroup` | :heavy_check_mark: |
| window                        | window              | `moveWindowTo`                    | :heavy_check_mark: |
| group                         | null                | `moveOutOfGroup`                | :heavy_check_mark: | By default, the window retains its floating state for consistency. The name of a possible configuration flag is up for discussion.                                 |
| group locked                  | null                | `moveOutOfGroup` / no-op        | :heavy_check_mark: |
| window                        | null                | no-op                           | :heavy_check_mark: |

**legend**:
- `group`: The window is in a group.
- `group locked`: `m_sGroupData.pNextWindow` is true.
- `window`: The window is not in a group.
- `null`: No window in direction

**NOTE**:
- *Window in direction is not null* implies *active window is not floating*.
- Alternative behaviour is toggled via `binds:ignore_group_lock`

### TODO:

- [x] Give the dispatcher a meaningful name.
- [x] Give configuration variable a meaningful name.
- [x] moveWindowOutOfGroup: Make call to `focusWindow` configurable.
- [x] Remove debug logging in the dispatcher when PR is complete.
- [x] Implement alternative behaviour.
- [x] Toggle group lock checking using `setignoregrouplock` dispatcher

### Other Changes

- Move the behaviour code of `moveIntoGroup` and `moveOutOfGroup` to standalone functions.
- Call `g_pCompositor->focusWindow` in `moveWindowOutOfGroup`.
- Fix `moveintogroup` locking check.
- Remove `moveintogroup_lock_check`, `moveintogroup` will check `binds:ignore_group_lock` instead
