### PR TITLE
animations: add slidefade and slidefadevert styles for workspaces

### DIFF
--- a/src/helpers/Workspace.cpp
+++ b/src/helpers/Workspace.cpp
@@ -60,12 +60,12 @@ void CWorkspace::startAnim(bool in, bool left, bool instant) {
 
     if (ANIMSTYLE.find("slidefade") == 0) {
         const auto PMONITOR = g_pCompositor->getMonitorFromID(m_iMonitorID);
-        float      minPerc  = 0.f;
+        float      movePerc  = 0.f;
 
         if (ANIMSTYLE.find("%") != std::string::npos) {
             try {
                 auto percstr = ANIMSTYLE.substr(ANIMSTYLE.find_last_of(' '));
-                minPerc      = std::stoi(percstr.substr(0, percstr.length() - 1));
+                movePerc      = std::stoi(percstr.substr(0, percstr.length() - 1));
             } catch (std::exception& e) {
                 ; // oops
             }
@@ -77,24 +77,24 @@ void CWorkspace::startAnim(bool in, bool left, bool instant) {
         if (ANIMSTYLE.find("slidefadevert") == 0) { // vertical
             if (in) {
                 m_fAlpha.setValueAndWarp(0.f);
-                m_vRenderOffset.setValueAndWarp(Vector2D(0, (left ? PMONITOR->vecSize.y : -PMONITOR->vecSize.y) * (minPerc / 100.f)));
+                m_vRenderOffset.setValueAndWarp(Vector2D(0, (left ? PMONITOR->vecSize.y : -PMONITOR->vecSize.y) * (movePerc / 100.f)));
                 m_fAlpha        = 1.f;
                 m_vRenderOffset = Vector2D(0, 0);
             } else {
                 m_fAlpha.setValueAndWarp(1.f);
                 m_fAlpha        = 0.f;
-                m_vRenderOffset = Vector2D(0, (left ? -PMONITOR->vecSize.y : PMONITOR->vecSize.y) * (minPerc / 100.f));
+                m_vRenderOffset = Vector2D(0, (left ? -PMONITOR->vecSize.y : PMONITOR->vecSize.y) * (movePerc / 100.f));
             }
         } else { // horizontal
             if (in) {
                 m_fAlpha.setValueAndWarp(0.f);
-                m_vRenderOffset.setValueAndWarp(Vector2D((left ? PMONITOR->vecSize.x : -PMONITOR->vecSize.x) * (minPerc / 100.f), 0));
+                m_vRenderOffset.setValueAndWarp(Vector2D((left ? PMONITOR->vecSize.x : -PMONITOR->vecSize.x) * (movePerc / 100.f), 0));
                 m_fAlpha        = 1.f;
                 m_vRenderOffset = Vector2D(0, 0);
             } else {
                 m_fAlpha.setValueAndWarp(1.f);
                 m_fAlpha        = 0.f;
-                m_vRenderOffset = Vector2D((left ? -PMONITOR->vecSize.x : PMONITOR->vecSize.x) * (minPerc / 100.f), 0);
+                m_vRenderOffset = Vector2D((left ? -PMONITOR->vecSize.x : PMONITOR->vecSize.x) * (movePerc / 100.f), 0);
             }
         }
     } else if (ANIMSTYLE == "fade") {

--- a/src/helpers/Workspace.cpp
+++ b/src/helpers/Workspace.cpp
@@ -67,7 +67,7 @@ void CWorkspace::startAnim(bool in, bool left, bool instant) {
                 auto percstr = ANIMSTYLE.substr(ANIMSTYLE.find_last_of(' ') + 1);
                 movePerc     = std::stoi(percstr.substr(0, percstr.length() - 1));
             } catch (std::exception& e) {
-                ; // oops
+                Debug::log(ERR, "Error in startAnim: invalid percentage");
             }
         }
 

--- a/src/helpers/Workspace.cpp
+++ b/src/helpers/Workspace.cpp
@@ -64,7 +64,7 @@ void CWorkspace::startAnim(bool in, bool left, bool instant) {
 
         if (ANIMSTYLE.find("%") != std::string::npos) {
             try {
-                auto percstr = ANIMSTYLE.substr(ANIMSTYLE.find_last_of(' '));
+                auto percstr = ANIMSTYLE.substr(ANIMSTYLE.find_last_of(' ') + 1);
                 movePerc     = std::stoi(percstr.substr(0, percstr.length() - 1));
             } catch (std::exception& e) {
                 ; // oops

--- a/src/helpers/Workspace.cpp
+++ b/src/helpers/Workspace.cpp
@@ -60,7 +60,7 @@ void CWorkspace::startAnim(bool in, bool left, bool instant) {
 
     if (ANIMSTYLE.find("slidefade") == 0) {
         const auto PMONITOR = g_pCompositor->getMonitorFromID(m_iMonitorID);
-        float      movePerc  = 0.f;
+        float      movePerc  = 100.f;
 
         if (ANIMSTYLE.find("%") != std::string::npos) {
             try {

--- a/src/helpers/Workspace.cpp
+++ b/src/helpers/Workspace.cpp
@@ -60,21 +60,21 @@ void CWorkspace::startAnim(bool in, bool left, bool instant) {
 
     if (ANIMSTYLE.find("slidefade") == 0) {
         const auto PMONITOR = g_pCompositor->getMonitorFromID(m_iMonitorID);
-        float      movePerc  = 100.f;
+        float      movePerc = 100.f;
 
         if (ANIMSTYLE.find("%") != std::string::npos) {
             try {
                 auto percstr = ANIMSTYLE.substr(ANIMSTYLE.find_last_of(' '));
-                movePerc      = std::stoi(percstr.substr(0, percstr.length() - 1));
+                movePerc     = std::stoi(percstr.substr(0, percstr.length() - 1));
             } catch (std::exception& e) {
                 ; // oops
             }
         }
 
-        m_fAlpha.setValueAndWarp(1.f);                   // fix a bug, if switching from fade -> slide.
-        m_vRenderOffset.setValueAndWarp(Vector2D(0, 0)); // fix a bug, if switching from slide -> fade.
+        m_fAlpha.setValueAndWarp(1.f);
+        m_vRenderOffset.setValueAndWarp(Vector2D(0, 0));
 
-        if (ANIMSTYLE.find("slidefadevert") == 0) { // vertical
+        if (ANIMSTYLE.find("slidefadevert") == 0) {
             if (in) {
                 m_fAlpha.setValueAndWarp(0.f);
                 m_vRenderOffset.setValueAndWarp(Vector2D(0, (left ? PMONITOR->vecSize.y : -PMONITOR->vecSize.y) * (movePerc / 100.f)));
@@ -85,7 +85,7 @@ void CWorkspace::startAnim(bool in, bool left, bool instant) {
                 m_fAlpha        = 0.f;
                 m_vRenderOffset = Vector2D(0, (left ? -PMONITOR->vecSize.y : PMONITOR->vecSize.y) * (movePerc / 100.f));
             }
-        } else { // horizontal
+        } else {
             if (in) {
                 m_fAlpha.setValueAndWarp(0.f);
                 m_vRenderOffset.setValueAndWarp(Vector2D((left ? PMONITOR->vecSize.x : -PMONITOR->vecSize.x) * (movePerc / 100.f), 0));

--- a/src/helpers/Workspace.cpp
+++ b/src/helpers/Workspace.cpp
@@ -58,7 +58,46 @@ CWorkspace::~CWorkspace() {
 void CWorkspace::startAnim(bool in, bool left, bool instant) {
     const auto ANIMSTYLE = m_fAlpha.m_pConfig->pValues->internalStyle;
 
-    if (ANIMSTYLE == "fade") {
+    if (ANIMSTYLE.find("slidefade") == 0) {
+        const auto PMONITOR = g_pCompositor->getMonitorFromID(m_iMonitorID);
+        float      minPerc  = 0.f;
+
+        if (ANIMSTYLE.find("%") != std::string::npos) {
+            try {
+                auto percstr = ANIMSTYLE.substr(ANIMSTYLE.find_last_of(' '));
+                minPerc      = std::stoi(percstr.substr(0, percstr.length() - 1));
+            } catch (std::exception& e) {
+                ; // oops
+            }
+        }
+
+        m_fAlpha.setValueAndWarp(1.f);                   // fix a bug, if switching from fade -> slide.
+        m_vRenderOffset.setValueAndWarp(Vector2D(0, 0)); // fix a bug, if switching from slide -> fade.
+
+        if (ANIMSTYLE.find("slidefadevert") == 0) { // vertical
+            if (in) {
+                m_fAlpha.setValueAndWarp(0.f);
+                m_vRenderOffset.setValueAndWarp(Vector2D(0, (left ? PMONITOR->vecSize.y : -PMONITOR->vecSize.y) * (minPerc / 100.f)));
+                m_fAlpha        = 1.f;
+                m_vRenderOffset = Vector2D(0, 0);
+            } else {
+                m_fAlpha.setValueAndWarp(1.f);
+                m_fAlpha        = 0.f;
+                m_vRenderOffset = Vector2D(0, (left ? -PMONITOR->vecSize.y : PMONITOR->vecSize.y) * (minPerc / 100.f));
+            }
+        } else { // horizontal
+            if (in) {
+                m_fAlpha.setValueAndWarp(0.f);
+                m_vRenderOffset.setValueAndWarp(Vector2D((left ? PMONITOR->vecSize.x : -PMONITOR->vecSize.x) * (minPerc / 100.f), 0));
+                m_fAlpha        = 1.f;
+                m_vRenderOffset = Vector2D(0, 0);
+            } else {
+                m_fAlpha.setValueAndWarp(1.f);
+                m_fAlpha        = 0.f;
+                m_vRenderOffset = Vector2D((left ? -PMONITOR->vecSize.x : PMONITOR->vecSize.x) * (minPerc / 100.f), 0);
+            }
+        }
+    } else if (ANIMSTYLE == "fade") {
         m_vRenderOffset.setValueAndWarp(Vector2D(0, 0)); // fix a bug, if switching from slide -> fade.
 
         if (in) {

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -485,6 +485,22 @@ std::string CAnimationManager::styleValidInConfigVar(const std::string& config, 
     } else if (config == "workspaces" || config == "specialWorkspace") {
         if (style == "slide" || style == "slidevert" || style == "fade")
             return "";
+        else if (style.find("slidefade") == 0) { // slidefade and slidefadevert
+            // try parsing
+            float minPerc = 0.f;
+            if (style.find("%") != std::string::npos) {
+                try {
+                    auto percstr = style.substr(style.find_last_of(' '));
+                    minPerc      = std::stoi(percstr.substr(0, percstr.length() - 1));
+                } catch (std::exception& e) { return "invalid minperc"; }
+
+                return "";
+            }
+
+            minPerc; // fix warning
+
+            return "";
+        }
 
         return "unknown style";
     } else if (config == "borderangle") {

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -485,7 +485,7 @@ std::string CAnimationManager::styleValidInConfigVar(const std::string& config, 
     } else if (config == "workspaces" || config == "specialWorkspace") {
         if (style == "slide" || style == "slidevert" || style == "fade")
             return "";
-        else if (style.find("slidefade") == 0) { // slidefade and slidefadevert
+        else if (style.find("slidefade") == 0) {
             // try parsing
             float movePerc = 0.f;
             if (style.find("%") != std::string::npos) {

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -487,17 +487,17 @@ std::string CAnimationManager::styleValidInConfigVar(const std::string& config, 
             return "";
         else if (style.find("slidefade") == 0) { // slidefade and slidefadevert
             // try parsing
-            float minPerc = 0.f;
+            float movePerc = 0.f;
             if (style.find("%") != std::string::npos) {
                 try {
                     auto percstr = style.substr(style.find_last_of(' '));
-                    minPerc      = std::stoi(percstr.substr(0, percstr.length() - 1));
-                } catch (std::exception& e) { return "invalid minperc"; }
+                    movePerc     = std::stoi(percstr.substr(0, percstr.length() - 1));
+                } catch (std::exception& e) { return "invalid movePerc"; }
 
                 return "";
             }
 
-            minPerc; // fix warning
+            movePerc; // fix warning
 
             return "";
         }

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -490,7 +490,7 @@ std::string CAnimationManager::styleValidInConfigVar(const std::string& config, 
             float movePerc = 0.f;
             if (style.find("%") != std::string::npos) {
                 try {
-                    auto percstr = style.substr(style.find_last_of(' '));
+                    auto percstr = style.substr(style.find_last_of(' ') + 1);
                     movePerc     = std::stoi(percstr.substr(0, percstr.length() - 1));
                 } catch (std::exception& e) { return "invalid movePerc"; }
 

--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -51,7 +51,7 @@ void CInputManager::onSwipeEnd(wlr_pointer_swipe_end_event* e) {
     static auto* const PSWIPENUMBER = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_numbered")->intValue;
     static auto* const PSWIPEUSER   = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_use_r")->intValue;
     const bool         VERTANIMS    = m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle == "slidevert" ||
-        m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle == "slidevertfade";
+        m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle.find("slidefadevert") == 0;
 
     // commit
     std::string wsname           = "";
@@ -195,7 +195,8 @@ void CInputManager::onSwipeUpdate(wlr_pointer_swipe_update_event* e) {
     static auto* const PSWIPENUMBER  = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_numbered")->intValue;
     static auto* const PSWIPEUSER    = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_use_r")->intValue;
 
-    const bool         VERTANIMS = m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle == "slidevert";
+    const bool         VERTANIMS = m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle == "slidevert" || 
+        m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle.find("slidefadevert") == 0;
 
     m_sActiveSwipe.delta += VERTANIMS ? (*PSWIPEINVR ? -e->dy : e->dy) : (*PSWIPEINVR ? -e->dx : e->dx);
 

--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -50,7 +50,8 @@ void CInputManager::onSwipeEnd(wlr_pointer_swipe_end_event* e) {
     static auto* const PSWIPENEW    = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_create_new")->intValue;
     static auto* const PSWIPENUMBER = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_numbered")->intValue;
     static auto* const PSWIPEUSER   = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_use_r")->intValue;
-    const bool         VERTANIMS    = m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle == "slidevert";
+    const bool         VERTANIMS    = m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle == "slidevert" ||
+        m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle == "slidevertfade";
 
     // commit
     std::string wsname           = "";


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
- add `slidefade` and `slidefadevert` styles for workspaces
  - Usage: use as a workspace animation style with percentage: `slidefade MOVEMENT_PERCENTAGE%`, where MOVEMENT_PERCENTAGE% decides the distance by which windows will move. 
    - 100% = as much as `slide`/`slidevert`; 
    - 0% = fade only
    - default is 100%.
  - Example:
  ```ini
  animations {
      bezier = overshot, 0.05, 0.9, 0.1, 1.1
      animation = workspaces, 1, 3, overshot, slidefade 20%
  }
  ```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
- no

#### Is it ready for merging, or does it need work?
- ready

