### PR TITLE
fix: improved focus behaviour on workspace switching for follow_mouse!=1

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1195,6 +1195,17 @@ CWindow* CCompositor::getFirstWindowOnWorkspace(const int& id) {
     return nullptr;
 }
 
+CWindow* CCompositor::getTopLeftWindowOnWorkspace(const int& id) {
+    for (auto& w : m_vWindows) {
+        if (w->m_iWorkspaceID != id || !w->m_bIsMapped || w->isHidden())
+            continue;
+        const auto WINDOWIDEALBB = w->getWindowIdealBoundingBoxIgnoreReserved();
+        if (WINDOWIDEALBB.x == 1 && WINDOWIDEALBB.y == 1)
+            return w.get();
+    }
+    return nullptr;
+}
+
 bool CCompositor::doesSeatAcceptInput(wlr_surface* surface) {
     if (g_pSessionLockManager->isSessionLocked()) {
         if (g_pSessionLockManager->isSurfaceSessionLock(surface))

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1196,11 +1196,20 @@ CWindow* CCompositor::getFirstWindowOnWorkspace(const int& id) {
 }
 
 CWindow* CCompositor::getTopLeftWindowOnWorkspace(const int& id) {
+    const auto PWORKSPACE = getWorkspaceByID(id);
+
+    if (!PWORKSPACE)
+        return nullptr;
+
+    const auto PMONITOR = getMonitorFromID(PWORKSPACE->m_iMonitorID);
+
     for (auto& w : m_vWindows) {
         if (w->m_iWorkspaceID != id || !w->m_bIsMapped || w->isHidden())
             continue;
+
         const auto WINDOWIDEALBB = w->getWindowIdealBoundingBoxIgnoreReserved();
-        if (WINDOWIDEALBB.x == 1 && WINDOWIDEALBB.y == 1)
+
+        if (WINDOWIDEALBB.x <= PMONITOR->vecPosition.x + 1 && WINDOWIDEALBB.y <= PMONITOR->vecPosition.y + 1)
             return w.get();
     }
     return nullptr;

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -158,6 +158,7 @@ class CCompositor {
     CWindow*       getUrgentWindow();
     bool           hasUrgentWindowOnWorkspace(const int&);
     CWindow*       getFirstWindowOnWorkspace(const int&);
+    CWindow*       getTopLeftWindowOnWorkspace(const int&);
     CWindow*       getFullscreenWindowOnWorkspace(const int&);
     bool           doesSeatAcceptInput(wlr_surface*);
     bool           isWindowActive(CWindow*);

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -553,7 +553,12 @@ void CMonitor::changeWorkspace(CWorkspace* const pWorkspace, bool internal) {
 
         if (const auto PLASTWINDOW = pWorkspace->getLastFocusedWindow(); PLASTWINDOW)
             g_pCompositor->focusWindow(PLASTWINDOW);
-        else {
+        else if (g_pConfigManager->getConfigValuePtr("input:follow_mouse")->intValue != 1) {
+            CWindow* pWindow = g_pCompositor->getTopLeftWindowOnWorkspace(pWorkspace->m_iID);
+            if (!pWindow)
+                pWindow = g_pCompositor->getFirstWindowOnWorkspace(pWorkspace->m_iID);
+            g_pCompositor->focusWindow(pWindow);
+        } else {
             g_pCompositor->focusWindow(nullptr);
             g_pInputManager->simulateMouseMovement();
         }

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -558,6 +558,7 @@ void CMonitor::changeWorkspace(CWorkspace* const pWorkspace, bool internal) {
             if (!pWindow)
                 pWindow = g_pCompositor->getFirstWindowOnWorkspace(pWorkspace->m_iID);
             g_pCompositor->focusWindow(pWindow);
+            g_pInputManager->simulateMouseMovement();
         } else {
             g_pCompositor->focusWindow(nullptr);
             g_pInputManager->simulateMouseMovement();

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -551,18 +551,26 @@ void CMonitor::changeWorkspace(CWorkspace* const pWorkspace, bool internal) {
             }
         }
 
+        static auto* const PFOLLOWMOUSE = &g_pConfigManager->getConfigValuePtr("input:follow_mouse")->intValue;
+
         if (const auto PLASTWINDOW = pWorkspace->getLastFocusedWindow(); PLASTWINDOW)
             g_pCompositor->focusWindow(PLASTWINDOW);
-        else if (g_pConfigManager->getConfigValuePtr("input:follow_mouse")->intValue != 1) {
-            CWindow* pWindow = g_pCompositor->getTopLeftWindowOnWorkspace(pWorkspace->m_iID);
+        else {
+            CWindow* pWindow = nullptr;
+
+            if (*PFOLLOWMOUSE == 1)
+                pWindow = g_pCompositor->vectorToWindowIdeal(g_pInputManager->getMouseCoordsInternal());
+
+            if (!pWindow)
+                pWindow = g_pCompositor->getTopLeftWindowOnWorkspace(pWorkspace->m_iID);
+
             if (!pWindow)
                 pWindow = g_pCompositor->getFirstWindowOnWorkspace(pWorkspace->m_iID);
+
             g_pCompositor->focusWindow(pWindow);
-            g_pInputManager->simulateMouseMovement();
-        } else {
-            g_pCompositor->focusWindow(nullptr);
-            g_pInputManager->simulateMouseMovement();
         }
+
+        g_pInputManager->simulateMouseMovement();
 
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(ID);
 


### PR DESCRIPTION
## Abstract

When `input:follow_mouse` is not set to 1 (`Cursor movement will always change focus to the window under the cursor`), focus the top-left-most window on a workspace if there is no last focused window when switching workspaces.

Fix: #2451

## Motivation

Currently, if there is no last focused window on a workspace, switching to that workspace results in no focused window. This is particularly inconvenient for users when `input:follow_mouse != 1`, as they will be forced to use the mouse to focus a window, thus degrading the experience. 

## Implementation

This PR updates the `CMonitor::changeWorkspace()` method to check if there is no last focused window, and if so, focus the top-left-most window found for that workspace instead.

The top-left-most window is determined by calling the new `CCompositor::getTopLeftWindowOnWorkspace()` method.

If `CCompositor::getTopLeftWindowOnWorkspace` returns `nullptr`, `CCompositor::getFirstWindowOnWorkspace` will be used as a fallback to find a window to focus.