### PR TITLE
Swipe direction lock

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -226,6 +226,7 @@ void CConfigManager::setDefaultVars() {
     configValues["gestures:workspace_swipe_min_speed_to_force"].intValue = 30;
     configValues["gestures:workspace_swipe_cancel_ratio"].floatValue     = 0.5f;
     configValues["gestures:workspace_swipe_create_new"].intValue         = 1;
+    configValues["gestures:workspace_swipe_direction_lock"].intValue     = 1;
     configValues["gestures:workspace_swipe_forever"].intValue            = 0;
     configValues["gestures:workspace_swipe_numbered"].intValue           = 0;
     configValues["gestures:workspace_swipe_use_r"].intValue              = 0;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -219,17 +219,18 @@ void CConfigManager::setDefaultVars() {
     configValues["binds:allow_workspace_cycles"].intValue   = 0;
     configValues["binds:focus_preferred_method"].intValue   = 0;
 
-    configValues["gestures:workspace_swipe"].intValue                    = 0;
-    configValues["gestures:workspace_swipe_fingers"].intValue            = 3;
-    configValues["gestures:workspace_swipe_distance"].intValue           = 300;
-    configValues["gestures:workspace_swipe_invert"].intValue             = 1;
-    configValues["gestures:workspace_swipe_min_speed_to_force"].intValue = 30;
-    configValues["gestures:workspace_swipe_cancel_ratio"].floatValue     = 0.5f;
-    configValues["gestures:workspace_swipe_create_new"].intValue         = 1;
-    configValues["gestures:workspace_swipe_direction_lock"].intValue     = 1;
-    configValues["gestures:workspace_swipe_forever"].intValue            = 0;
-    configValues["gestures:workspace_swipe_numbered"].intValue           = 0;
-    configValues["gestures:workspace_swipe_use_r"].intValue              = 0;
+    configValues["gestures:workspace_swipe"].intValue                          = 0;
+    configValues["gestures:workspace_swipe_fingers"].intValue                  = 3;
+    configValues["gestures:workspace_swipe_distance"].intValue                 = 300;
+    configValues["gestures:workspace_swipe_invert"].intValue                   = 1;
+    configValues["gestures:workspace_swipe_min_speed_to_force"].intValue       = 30;
+    configValues["gestures:workspace_swipe_cancel_ratio"].floatValue           = 0.5f;
+    configValues["gestures:workspace_swipe_create_new"].intValue               = 1;
+    configValues["gestures:workspace_swipe_direction_lock"].intValue           = 1;
+    configValues["gestures:workspace_swipe_direction_lock_threshold"].intValue = 10;
+    configValues["gestures:workspace_swipe_forever"].intValue                  = 0;
+    configValues["gestures:workspace_swipe_numbered"].intValue                 = 0;
+    configValues["gestures:workspace_swipe_use_r"].intValue                    = 0;
 
     configValues["xwayland:use_nearest_neighbor"].intValue = 1;
     configValues["xwayland:force_zero_scaling"].intValue   = 0;

--- a/src/helpers/WLClasses.hpp
+++ b/src/helpers/WLClasses.hpp
@@ -309,6 +309,7 @@ struct SSwipeGesture {
 
     double      delta = 0;
 
+    int         initialDirection = 0;
     float       avgSpeed    = 0;
     int         speedPoints = 0;
 

--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -228,11 +228,12 @@ void CInputManager::onSwipeUpdate(wlr_pointer_swipe_update_event* e) {
         return;
     }
 
-    if (*PSWIPEDIRLOCK)
+    if (*PSWIPEDIRLOCK) {
         if (m_sActiveSwipe.initialDirection != 0 && m_sActiveSwipe.initialDirection != (m_sActiveSwipe.delta < 0 ? -1 : 1))
             m_sActiveSwipe.delta = 0;
         else if (m_sActiveSwipe.initialDirection == 0 && abs(m_sActiveSwipe.delta) > *PSWIPEDIRLOCKTHRESHOLD)
             m_sActiveSwipe.initialDirection = m_sActiveSwipe.delta < 0 ? -1 : 1;
+    }
 
     if (m_sActiveSwipe.delta < 0) {
         const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(workspaceIDLeft);

--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -224,6 +224,7 @@ void CInputManager::onSwipeUpdate(wlr_pointer_swipe_update_event* e) {
         (m_sActiveSwipe.delta < 0 && m_sActiveSwipe.pWorkspaceBegin->m_iID <= workspaceIDLeft)) {
 
         m_sActiveSwipe.delta = 0;
+        return;
     }
 
     if (*PSWIPEDIRLOCK) {

--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -228,13 +228,12 @@ void CInputManager::onSwipeUpdate(wlr_pointer_swipe_update_event* e) {
         return;
     }
 
-    if (*PSWIPEDIRLOCK) {
+    if (*PSWIPEDIRLOCK)
         if (m_sActiveSwipe.initialDirection != 0 && m_sActiveSwipe.initialDirection != (m_sActiveSwipe.delta < 0 ? -1 : 1))
             m_sActiveSwipe.delta = 0;
         else if (m_sActiveSwipe.initialDirection == 0 && abs(m_sActiveSwipe.delta) > *PSWIPEDIRLOCKTHRESHOLD) {
             m_sActiveSwipe.initialDirection = m_sActiveSwipe.delta < 0 ? -1 : 1;
         }
-    }
 
     if (m_sActiveSwipe.delta < 0) {
         const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(workspaceIDLeft);

--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -189,13 +189,14 @@ void CInputManager::onSwipeUpdate(wlr_pointer_swipe_update_event* e) {
     if (!m_sActiveSwipe.pWorkspaceBegin)
         return;
 
-    static auto* const PSWIPEDIST    = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_distance")->intValue;
-    static auto* const PSWIPEINVR    = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_invert")->intValue;
-    static auto* const PSWIPENEW     = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_create_new")->intValue;
-    static auto* const PSWIPEDIRLOCK = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_direction_lock")->intValue;
-    static auto* const PSWIPEFOREVER = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_forever")->intValue;
-    static auto* const PSWIPENUMBER  = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_numbered")->intValue;
-    static auto* const PSWIPEUSER    = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_use_r")->intValue;
+    static auto* const PSWIPEDIST             = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_distance")->intValue;
+    static auto* const PSWIPEINVR             = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_invert")->intValue;
+    static auto* const PSWIPENEW              = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_create_new")->intValue;
+    static auto* const PSWIPEDIRLOCK          = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_direction_lock")->intValue;
+    static auto* const PSWIPEDIRLOCKTHRESHOLD = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_direction_lock_threshold")->intValue;
+    static auto* const PSWIPEFOREVER          = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_forever")->intValue;
+    static auto* const PSWIPENUMBER           = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_numbered")->intValue;
+    static auto* const PSWIPEUSER             = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_use_r")->intValue;
 
     const bool         VERTANIMS = m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle == "slidevert" ||
         m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle.find("slidefadevert") == 0;
@@ -228,9 +229,9 @@ void CInputManager::onSwipeUpdate(wlr_pointer_swipe_update_event* e) {
     }
 
     if (*PSWIPEDIRLOCK) {
-        if (m_sActiveSwipe.initialDirection != 0 && m_sActiveSwipe.initialDirection != (m_sActiveSwipe.delta < 0 ? -1 : 1)) {
+        if (m_sActiveSwipe.initialDirection != 0 && m_sActiveSwipe.initialDirection != (m_sActiveSwipe.delta < 0 ? -1 : 1))
             m_sActiveSwipe.delta = 0;
-        } else if (m_sActiveSwipe.initialDirection == 0) {
+        else if (m_sActiveSwipe.initialDirection == 0 && abs(m_sActiveSwipe.delta) > *PSWIPEDIRLOCKTHRESHOLD) {
             m_sActiveSwipe.initialDirection = m_sActiveSwipe.delta < 0 ? -1 : 1;
         }
     }

--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -231,9 +231,8 @@ void CInputManager::onSwipeUpdate(wlr_pointer_swipe_update_event* e) {
     if (*PSWIPEDIRLOCK)
         if (m_sActiveSwipe.initialDirection != 0 && m_sActiveSwipe.initialDirection != (m_sActiveSwipe.delta < 0 ? -1 : 1))
             m_sActiveSwipe.delta = 0;
-        else if (m_sActiveSwipe.initialDirection == 0 && abs(m_sActiveSwipe.delta) > *PSWIPEDIRLOCKTHRESHOLD) {
+        else if (m_sActiveSwipe.initialDirection == 0 && abs(m_sActiveSwipe.delta) > *PSWIPEDIRLOCKTHRESHOLD)
             m_sActiveSwipe.initialDirection = m_sActiveSwipe.delta < 0 ? -1 : 1;
-        }
 
     if (m_sActiveSwipe.delta < 0) {
         const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(workspaceIDLeft);

--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -174,7 +174,7 @@ void CInputManager::onSwipeEnd(wlr_pointer_swipe_end_event* e) {
         PWORKSPACER->m_bForceRendering = false;
     m_sActiveSwipe.pWorkspaceBegin->m_bForceRendering = false;
 
-    m_sActiveSwipe.pWorkspaceBegin = nullptr;
+    m_sActiveSwipe.pWorkspaceBegin  = nullptr;
     m_sActiveSwipe.initialDirection = 0;
 
     g_pInputManager->refocus();
@@ -226,15 +226,16 @@ void CInputManager::onSwipeUpdate(wlr_pointer_swipe_update_event* e) {
         m_sActiveSwipe.delta = 0;
     }
 
-    if(*PSWIPEDIRLOCK && m_sActiveSwipe.initialDirection != 0 && m_sActiveSwipe.initialDirection != (m_sActiveSwipe.delta < 0 ? -1 : 1)) {
-        m_sActiveSwipe.delta = 0;
+    if (*PSWIPEDIRLOCK) {
+        if (m_sActiveSwipe.initialDirection != 0 && m_sActiveSwipe.initialDirection != (m_sActiveSwipe.delta < 0 ? -1 : 1)) {
+            m_sActiveSwipe.delta = 0;
+        } else if (m_sActiveSwipe.initialDirection == 0) {
+            m_sActiveSwipe.initialDirection = m_sActiveSwipe.delta < 0 ? -1 : 1;
+        }
     }
 
     if (m_sActiveSwipe.delta < 0) {
         const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(workspaceIDLeft);
-
-        if (m_sActiveSwipe.initialDirection == 0)
-            m_sActiveSwipe.initialDirection = -1;
 
         if (workspaceIDLeft > m_sActiveSwipe.pWorkspaceBegin->m_iID || !PWORKSPACE) {
             if (*PSWIPENEW || *PSWIPENUMBER) {
@@ -277,9 +278,6 @@ void CInputManager::onSwipeUpdate(wlr_pointer_swipe_update_event* e) {
         g_pCompositor->updateWorkspaceWindowDecos(workspaceIDLeft);
     } else {
         const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(workspaceIDRight);
-
-        if (m_sActiveSwipe.initialDirection == 0)
-            m_sActiveSwipe.initialDirection = 1;
 
         if (workspaceIDRight < m_sActiveSwipe.pWorkspaceBegin->m_iID || !PWORKSPACE) {
             if (*PSWIPENEW || *PSWIPENUMBER) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
- Adds the config option `gestures:workspace_swipe_direction_lock`, which forces the destination to be in one direction only once the user starts swiping. 
  - True by default
  - Let's say the user wants to switch to workspace on the right. They swipe halfway and change their mind and swipe back to cancel that. Setting this to true prevents over-swiping to the workspace on the left.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
- Since the option is true by default, it introduces a change in default behavior. But I guess it makes sense (Windows is like that).

#### Is it ready for merging, or does it need work?
- Ready
