### PR TITLE
nix module: Fix attempted workaround for option name change

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -2,6 +2,7 @@ inputs: {
   config,
   lib,
   pkgs,
+  options,
   ...
 }:
 with lib; let
@@ -62,10 +63,11 @@ in {
   config = mkIf cfg.enable {
     environment.systemPackages = [cfg.finalPackage];
 
-    fonts =
-      if versionOlder config.system.stateVersion "23.11"
-      then {enableDefaultFonts = mkDefault true;}
-      else {enableDefaultPackages = mkDefault true;};
+    # NixOS changed the name of this attribute between NixOS 23.05 and
+    # 23.11
+    fonts = if builtins.hasAttr "enableDefaultPackages" options.fonts
+      then {enableDefaultPackages = mkDefault true;}
+      else {enableDefaultFonts = mkDefault true;};
 
     hardware.opengl.enable = mkDefault true;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This commit fixes an erroneous use of `system.stateVersion`, which causes warnings for NixOS-unstable users.

`system.stateVersion` is about *system state*, i.e., stuff that was created by old software versions on user's machines, like SQL databases that have moved to a different directory or such.

It will not help figure out whether an option has been renamed, because a NixOS 23.11 system may have *any* version set as `system.stateVersion`, and should match the version on which the user's NixOS was installed, which will often be much older.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Don't believe so; I double checked against stable and unstable to be sure this evaluates, didn't actually deploy though. @fufexan should probably review :)

#### Is it ready for merging, or does it need work?

Think it's ready!