### PR TITLE
fix: filepath handling and null check return value of fopen

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -139,13 +139,12 @@ void CKeybindManager::updateXKBTranslationState() {
     const auto     VARIANT  = g_pConfigManager->getString("input:kb_variant");
     const auto     OPTIONS  = g_pConfigManager->getString("input:kb_options");
 
-    xkb_rule_names rules = {.rules = RULES.c_str(), .model = MODEL.c_str(), .layout = LAYOUT.c_str(), .variant = VARIANT.c_str(), .options = OPTIONS.c_str()};
-
+    xkb_rule_names rules      = {.rules = RULES.c_str(), .model = MODEL.c_str(), .layout = LAYOUT.c_str(), .variant = VARIANT.c_str(), .options = OPTIONS.c_str()};
     const auto     PCONTEXT   = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-    FILE* const    KEYMAPFILE = FILEPATH == "" ? NULL : fopen(FILEPATH.c_str(), "r");
+    FILE* const    KEYMAPFILE = FILEPATH == "" ? NULL : fopen(absolutePath(FILEPATH, g_pConfigManager->configCurrentPath).c_str(), "r");
 
-    auto           PKEYMAP = FILEPATH == "" ? xkb_keymap_new_from_names(PCONTEXT, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS) :
-                                              xkb_keymap_new_from_file(PCONTEXT, KEYMAPFILE, XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS);
+    auto           PKEYMAP = KEYMAPFILE ? xkb_keymap_new_from_file(PCONTEXT, KEYMAPFILE, XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS) :
+                                          xkb_keymap_new_from_names(PCONTEXT, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
     if (KEYMAPFILE)
         fclose(KEYMAPFILE);
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -784,10 +784,9 @@ void CInputManager::applyConfigToKeyboard(SKeyboard* pKeyboard) {
     if (!FILEPATH.empty()) {
         auto path = absolutePath(FILEPATH, g_pConfigManager->configCurrentPath);
 
-        if (!std::filesystem::exists(path))
-            Debug::log(ERR, "input:kb_file= file doesnt exist");
+        if (FILE* const KEYMAPFILE = fopen(path.c_str(), "r"); !KEYMAPFILE)
+            Debug::log(ERR, "Cannot open input:kb_file= file for reading");
         else {
-            FILE* const KEYMAPFILE = fopen(FILEPATH.c_str(), "r");
             KEYMAP                 = xkb_keymap_new_from_file(CONTEXT, KEYMAPFILE, XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS);
             fclose(KEYMAPFILE);
         }


### PR DESCRIPTION
## Abstract
Improved file path handling in the KeybindManager and InputManager classes by adding null checking for the return value of fopen and resolving the absolute path of `input:kb_file'.

## Motivation

The original code did not properly handle tildes in file paths or check for null return values from fopen. These oversights could lead to runtime errors.

Also, the previous use of `std::filesystem::exists` only checked whether the file existed, not whether it could be read.

Fixes: #3060