### PR TITLE
build: use PCH to reduce compile time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ endif()
 
 include_directories(
   .
+  "src/"
   "subprojects/wlroots/include/"
   "subprojects/wlroots/build/include/"
   "subprojects/udis86/"
@@ -167,6 +168,10 @@ target_compile_definitions(Hyprland
 set(CPACK_PROJECT_NAME ${PROJECT_NAME})
 set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
 include(CPack)
+
+message(STATUS "Setting precompiled headers")
+
+target_precompile_headers(Hyprland PRIVATE $<$<COMPILE_LANGUAGE:CXX>:src/pch/pch.hpp>)
 
 message(STATUS "Setting link libraries")
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -4,6 +4,7 @@ src = globber.stdout().strip().split('\n')
 executable('Hyprland', src,
   cpp_args: ['-DWLR_USE_UNSTABLE'],
   link_args: '-rdynamic',
+  cpp_pch: 'pch/pch.hpp',
   dependencies: [
     server_protos,
     dependency('wayland-server'),

--- a/src/pch/pch.hpp
+++ b/src/pch/pch.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "Compositor.hpp"
+
+#include <algorithm>
+#include <any>
+#include <array>
+#include <chrono>
+#include <concepts>
+#include <deque>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <iterator>
+#include <list>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <random>
+#include <ranges>
+#include <regex>
+#include <set>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <tuple>
+#include <unordered_map>
+#include <vector>

--- a/src/pch/pch.hpp
+++ b/src/pch/pch.hpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "Compositor.hpp"
 
 #include <algorithm>


### PR DESCRIPTION
Using precompiled headers can consistently reduce initial build time by approximately 26%, and incremental build time by 30% to 40% in relative terms. However, this comes at the cost of increased disk usage during compilation.

For example, on a single zen2 core, compilation time, not including the linking process:

| PCH | initial build | incremental build | total object files generated |
| --- | ------------- | ----------------- | ---------------------------- |
| no  | 238.22s       |    36.839s        | 244.8 MiB                    |
| yes | 186.16s        |     22.202s       | 505.6 MiB                    |


During meson setup PCH can be disabled with `b_pch=false`
```bash
meson setup build -Db_pch=false
```
During cmake setup PCH can be disabled with `CMAKE_DISABLE_PRECOMPILE_HEADERS=ON`
```bash
cmake -S . -B ./build -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
```

### Caveats

Using precompiled headers makes compilation of source files in src/ uncacheable by ccache

However, this is unlikely to have a significant impact, as the use of global variables and frequent header changes often invalidate the previous cache, leading to a full rebuild.