### PR TITLE
makefile: fix build failure with some PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ install:
 	mkdir -p ${PREFIX}/include/hyprland/protocols
 	mkdir -p ${PREFIX}/include/hyprland/wlroots
 	mkdir -p ${PREFIX}/share/pkgconfig
+	mkdir -p ${PREFIX}/share/xdg-desktop-portal
 	
 	find src -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland
 	cd subprojects/wlroots/include && find . -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland/wlroots && cd ../../..


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixed build failure with PREFIX=/usr/local due to _xdg-desktop-portal_ not existing.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?

Ready.