### PR TITLE
groupbar mouse interaction

### DIFF
--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -170,6 +170,19 @@ wlr_box CWindow::getWindowInputBox() {
     return finalBox;
 }
 
+wlr_box CWindow::getWindowGroupBarBox() {
+    const auto PWORKSPACE      = g_pCompositor->getWorkspaceByID(m_iWorkspaceID);
+    const auto WORKSPACEOFFSET = PWORKSPACE && !m_bPinned ? PWORKSPACE->m_vRenderOffset.vec() : Vector2D();
+    const int  BORDERSIZE      = getRealBorderSize();
+    for (auto& wd : m_dWindowDecorations) {
+        if (wd->getDecorationType() == DECORATION_GROUPBAR) {
+            const SWindowDecorationExtents EXTENTS = wd->getWindowDecorationReservedArea();
+            return {m_vRealPosition.vec().x, m_vRealPosition.vec().y - BORDERSIZE - EXTENTS.topLeft.y, m_vRealSize.vec().x, EXTENTS.topLeft.y};
+        }
+    }
+    return {0, 0, 0, 0};
+}
+
 SWindowDecorationExtents CWindow::getFullWindowReservedArea() {
     SWindowDecorationExtents extents;
 

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -170,19 +170,6 @@ wlr_box CWindow::getWindowInputBox() {
     return finalBox;
 }
 
-wlr_box CWindow::getWindowGroupBarBox() {
-    const auto PWORKSPACE      = g_pCompositor->getWorkspaceByID(m_iWorkspaceID);
-    const auto WORKSPACEOFFSET = PWORKSPACE && !m_bPinned ? PWORKSPACE->m_vRenderOffset.vec() : Vector2D();
-    const int  BORDERSIZE      = getRealBorderSize();
-    for (auto& wd : m_dWindowDecorations) {
-        if (wd->getDecorationType() == DECORATION_GROUPBAR) {
-            const SWindowDecorationExtents EXTENTS = wd->getWindowDecorationReservedArea();
-            return {m_vRealPosition.vec().x, m_vRealPosition.vec().y - BORDERSIZE - EXTENTS.topLeft.y, m_vRealSize.vec().x, EXTENTS.topLeft.y};
-        }
-    }
-    return {0, 0, 0, 0};
-}
-
 SWindowDecorationExtents CWindow::getFullWindowReservedArea() {
     SWindowDecorationExtents extents;
 

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -714,10 +714,8 @@ void CWindow::setGroupCurrent(CWindow* pWindow) {
 }
 
 void CWindow::insertWindowToGroup(CWindow* pWindow) {
-    static const auto* USECURRPOS = &g_pConfigManager->getConfigValuePtr("misc:group_insert_after_current")->intValue;
-
-    const auto         BEGINAT = *USECURRPOS ? this : getGroupTail();
-    const auto         ENDAT   = *USECURRPOS ? m_sGroupData.pNextWindow : getGroupHead();
+    const auto BEGINAT = this;
+    const auto ENDAT   = m_sGroupData.pNextWindow;
 
     if (!pWindow->m_sGroupData.pNextWindow) {
         BEGINAT->m_sGroupData.pNextWindow = pWindow;

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -678,7 +678,7 @@ int CWindow::getGroupSize() {
 
 CWindow* CWindow::getGroupWindowByIndex(int index) {
     const int SIZE = getGroupSize();
-    index          = index % SIZE;
+    index          = ((index % SIZE) + SIZE) % SIZE;
     CWindow* curr  = getGroupHead();
     while (index > 0) {
         curr = curr->m_sGroupData.pNextWindow;

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -666,6 +666,27 @@ CWindow* CWindow::getGroupCurrent() {
     return curr;
 }
 
+int CWindow::getGroupSize() {
+    int      size = 1;
+    CWindow* curr = this;
+    while (curr->m_sGroupData.pNextWindow != this) {
+        curr = curr->m_sGroupData.pNextWindow;
+        size++;
+    }
+    return size;
+}
+
+CWindow* CWindow::getGroupWindowByIndex(int index) {
+    const int SIZE = getGroupSize();
+    index          = index % SIZE;
+    CWindow* curr  = getGroupHead();
+    while (index > 0) {
+        curr = curr->m_sGroupData.pNextWindow;
+        index--;
+    }
+    return curr;
+}
+
 void CWindow::setGroupCurrent(CWindow* pWindow) {
     CWindow* curr     = this->m_sGroupData.pNextWindow;
     bool     isMember = false;

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -313,6 +313,7 @@ class CWindow {
     SWindowDecorationExtents getFullWindowExtents();
     wlr_box                  getWindowInputBox();
     wlr_box                  getWindowIdealBoundingBoxIgnoreReserved();
+    wlr_box                  getWindowGroupBarBox();
     void                     updateWindowDecos();
     pid_t                    getPID();
     IHyprWindowDecoration*   getDecorationByType(eDecorationType);

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -313,7 +313,6 @@ class CWindow {
     SWindowDecorationExtents getFullWindowExtents();
     wlr_box                  getWindowInputBox();
     wlr_box                  getWindowIdealBoundingBoxIgnoreReserved();
-    wlr_box                  getWindowGroupBarBox();
     void                     updateWindowDecos();
     pid_t                    getPID();
     IHyprWindowDecoration*   getDecorationByType(eDecorationType);

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -346,6 +346,8 @@ class CWindow {
     CWindow*                 getGroupTail();
     CWindow*                 getGroupCurrent();
     CWindow*                 getGroupPrevious();
+    CWindow*                 getGroupWindowByIndex(int);
+    int                      getGroupSize();
     void                     setGroupCurrent(CWindow* pWindow);
     void                     insertWindowToGroup(CWindow* pWindow);
     void                     updateGroupOutputs();

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -108,6 +108,7 @@ void CConfigManager::setDefaultVars() {
     configValues["misc:cursor_zoom_factor"].floatValue         = 1.f;
     configValues["misc:cursor_zoom_rigid"].intValue            = 0;
     configValues["misc:allow_session_lock_restore"].intValue   = 0;
+    configValues["misc:groupbar_scrolling"].intValue           = 1;
     configValues["misc:group_insert_after_current"].intValue   = 1;
     configValues["misc:render_titles_in_groupbar"].intValue    = 1;
     configValues["misc:groupbar_titles_font_size"].intValue    = 8;

--- a/src/helpers/Region.cpp
+++ b/src/helpers/Region.cpp
@@ -92,6 +92,15 @@ std::vector<pixman_box32_t> CRegion::getRects() const {
     return result;
 }
 
+wlr_box CRegion::getExtents() {
+    pixman_box32_t* box = pixman_region32_extents(&m_rRegion);
+    return {box->x1, box->y1, box->x2 - box->x1, box->y2 - box->y1};
+}
+
+bool CRegion::containsPoint(const Vector2D& vec) {
+    return pixman_region32_contains_point(&m_rRegion, vec.x, vec.y, nullptr);
+}
+
 bool CRegion::empty() {
     return !pixman_region32_not_empty(&m_rRegion);
 }

--- a/src/helpers/Region.hpp
+++ b/src/helpers/Region.hpp
@@ -42,6 +42,8 @@ class CRegion {
     CRegion&                    intersect(double x, double y, double w, double h);
     CRegion&                    translate(const Vector2D& vec);
     CRegion&                    invert(pixman_box32_t* box);
+    wlr_box                     getExtents();
+    bool                        containsPoint(const Vector2D& vec);
     bool                        empty();
 
     std::vector<pixman_box32_t> getRects() const;

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -316,24 +316,16 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow) {
     if (OPENINGON->pWindow->m_sGroupData.pNextWindow && !OPENINGON->pWindow->getGroupHead()->m_sGroupData.locked &&
         !g_pKeybindManager->m_bGroupsLocked) { // target is an unlocked group
 
-        if (!pWindow->m_sGroupData.pNextWindow) { // source is not a group
+        if (!pWindow->m_sGroupData.pNextWindow || !pWindow->getGroupHead()->m_sGroupData.locked) { // source is not a group or an unlocked group
+            if (!pWindow->m_sGroupData.pNextWindow)
+                pWindow->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(pWindow));
+
             m_lDwindleNodesData.remove(*PNODE);
+            static const auto* USECURRPOS = &g_pConfigManager->getConfigValuePtr("misc:group_insert_after_current")->intValue;
+            OPENINGON->pWindow            = *USECURRPOS ? OPENINGON->pWindow : OPENINGON->pWindow->getGroupTail();
+
             OPENINGON->pWindow->insertWindowToGroup(pWindow);
             OPENINGON->pWindow->setGroupCurrent(pWindow);
-
-            pWindow->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(pWindow));
-            pWindow->updateWindowDecos();
-            recalculateWindow(pWindow);
-
-            g_pCompositor->focusWindow(pWindow);
-            return;
-        }
-
-        if (!pWindow->getGroupHead()->m_sGroupData.locked) { // source is an unlocked group
-            m_lDwindleNodesData.remove(*PNODE);
-            OPENINGON->pWindow->insertWindowToGroup(pWindow);
-            OPENINGON->pWindow->setGroupCurrent(pWindow);
-
             pWindow->updateWindowDecos();
             recalculateWindow(pWindow);
 

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -330,9 +330,8 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow) {
                 const int INDEX              = (int)((MOUSECOORDS.x - box.x) * 2 * SIZE / box.width + 1) / 2 - 1;
                 CWindow*  pWindowInsertAfter = OPENINGON->pWindow->getGroupWindowByIndex(INDEX);
                 pWindowInsertAfter->insertWindowToGroup(pWindow);
-                if (INDEX == -1) {
+                if (INDEX == -1)
                     std::swap(pWindow->m_sGroupData.pNextWindow->m_sGroupData.head, pWindow->m_sGroupData.head);
-                }
             } else {
                 static const auto* USECURRPOS = &g_pConfigManager->getConfigValuePtr("misc:group_insert_after_current")->intValue;
                 (*USECURRPOS ? OPENINGON->pWindow : OPENINGON->pWindow->getGroupTail())->insertWindowToGroup(pWindow);

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -324,7 +324,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow) {
 
             m_lDwindleNodesData.remove(*PNODE);
 
-            const wlr_box box = OPENINGON->pWindow->getWindowGroupBarBox();
+            const wlr_box box = OPENINGON->pWindow->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationBox();
             if (wlr_box_contains_point(&box, MOUSECOORDS.x, MOUSECOORDS.y)) { // TODO: Deny when not using mouse
                 const int SIZE               = OPENINGON->pWindow->getGroupSize();
                 const int INDEX              = (int)((MOUSECOORDS.x - box.x) * 2 * SIZE / box.width + 1) / 2 - 1;

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -324,7 +324,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow) {
 
             m_lDwindleNodesData.remove(*PNODE);
 
-            const wlr_box box = OPENINGON->pWindow->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationBox().getExtents();
+            const wlr_box box = OPENINGON->pWindow->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationRegion().getExtents();
             if (wlr_box_contains_point(&box, MOUSECOORDS.x, MOUSECOORDS.y)) { // TODO: Deny when not using mouse
                 const int SIZE               = OPENINGON->pWindow->getGroupSize();
                 const int INDEX              = (int)((MOUSECOORDS.x - box.x) * 2 * SIZE / box.width + 1) / 2 - 1;

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -324,7 +324,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow) {
 
             m_lDwindleNodesData.remove(*PNODE);
 
-            const wlr_box box = OPENINGON->pWindow->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationBox();
+            const wlr_box box = OPENINGON->pWindow->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationBox().getExtents();
             if (wlr_box_contains_point(&box, MOUSECOORDS.x, MOUSECOORDS.y)) { // TODO: Deny when not using mouse
                 const int SIZE               = OPENINGON->pWindow->getGroupSize();
                 const int INDEX              = (int)((MOUSECOORDS.x - box.x) * 2 * SIZE / box.width + 1) / 2 - 1;

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -56,6 +56,9 @@ void IHyprLayout::onWindowRemoved(CWindow* pWindow) {
 
             pWindow->setHidden(false);
 
+            pWindow->updateWindowDecos();
+            g_pCompositor->updateWindowAnimatedDecorationValues(pWindow);
+
             return;
         }
     }

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -103,7 +103,7 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow) {
 
             m_lMasterNodesData.remove(*PNODE);
 
-            const wlr_box box = OPENINGON->pWindow->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationBox().getExtents();
+            const wlr_box box = OPENINGON->pWindow->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationRegion().getExtents();
             if (wlr_box_contains_point(&box, MOUSECOORDS.x, MOUSECOORDS.y)) { // TODO: Deny when not using mouse
                 const int SIZE               = OPENINGON->pWindow->getGroupSize();
                 const int INDEX              = (int)((MOUSECOORDS.x - box.x) * 2 * SIZE / box.width + 1) / 2 - 1;

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -103,7 +103,7 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow) {
 
             m_lMasterNodesData.remove(*PNODE);
 
-            const wlr_box box = OPENINGON->pWindow->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationBox();
+            const wlr_box box = OPENINGON->pWindow->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationBox().getExtents();
             if (wlr_box_contains_point(&box, MOUSECOORDS.x, MOUSECOORDS.y)) { // TODO: Deny when not using mouse
                 const int SIZE               = OPENINGON->pWindow->getGroupSize();
                 const int INDEX              = (int)((MOUSECOORDS.x - box.x) * 2 * SIZE / box.width + 1) / 2 - 1;

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -109,9 +109,8 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow) {
                 const int INDEX              = (int)((MOUSECOORDS.x - box.x) * 2 * SIZE / box.width + 1) / 2 - 1;
                 CWindow*  pWindowInsertAfter = OPENINGON->pWindow->getGroupWindowByIndex(INDEX);
                 pWindowInsertAfter->insertWindowToGroup(pWindow);
-                if (INDEX == -1) {
+                if (INDEX == -1)
                     std::swap(pWindow->m_sGroupData.pNextWindow->m_sGroupData.head, pWindow->m_sGroupData.head);
-                }
             } else {
                 static const auto* USECURRPOS = &g_pConfigManager->getConfigValuePtr("misc:group_insert_after_current")->intValue;
                 (*USECURRPOS ? OPENINGON->pWindow : OPENINGON->pWindow->getGroupTail())->insertWindowToGroup(pWindow);

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -103,7 +103,7 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow) {
 
             m_lMasterNodesData.remove(*PNODE);
 
-            const wlr_box box = OPENINGON->pWindow->getWindowGroupBarBox();
+            const wlr_box box = OPENINGON->pWindow->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationBox();
             if (wlr_box_contains_point(&box, MOUSECOORDS.x, MOUSECOORDS.y)) { // TODO: Deny when not using mouse
                 const int SIZE               = OPENINGON->pWindow->getGroupSize();
                 const int INDEX              = (int)((MOUSECOORDS.x - box.x) * 2 * SIZE / box.width + 1) / 2 - 1;

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -95,24 +95,16 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow) {
     if (OPENINGON && OPENINGON->pWindow->m_sGroupData.pNextWindow && !OPENINGON->pWindow->getGroupHead()->m_sGroupData.locked && !g_pKeybindManager->m_bGroupsLocked &&
         OPENINGON != PNODE) { // target is an unlocked group
 
-        if (!pWindow->m_sGroupData.pNextWindow) { // source is not a group
+        if (!pWindow->m_sGroupData.pNextWindow || !pWindow->getGroupHead()->m_sGroupData.locked) { // source is not a group or an unlocked group
+            if (!pWindow->m_sGroupData.pNextWindow)
+                pWindow->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(pWindow));
+
             m_lMasterNodesData.remove(*PNODE);
+            static const auto* USECURRPOS = &g_pConfigManager->getConfigValuePtr("misc:group_insert_after_current")->intValue;
+            OPENINGON->pWindow            = *USECURRPOS ? OPENINGON->pWindow : OPENINGON->pWindow->getGroupTail();
+
             OPENINGON->pWindow->insertWindowToGroup(pWindow);
             OPENINGON->pWindow->setGroupCurrent(pWindow);
-
-            pWindow->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(pWindow));
-            pWindow->updateWindowDecos();
-            recalculateWindow(pWindow);
-
-            g_pCompositor->focusWindow(pWindow);
-            return;
-        }
-
-        if (!pWindow->getGroupHead()->m_sGroupData.locked) { // source is an unlocked group
-            m_lMasterNodesData.remove(*PNODE);
-            OPENINGON->pWindow->insertWindowToGroup(pWindow);
-            OPENINGON->pWindow->setGroupCurrent(pWindow);
-
             pWindow->updateWindowDecos();
             recalculateWindow(pWindow);
 
@@ -266,8 +258,8 @@ void CHyprMasterLayout::calculateWorkspace(const int& ws) {
         return;
 
     const auto PWORKSPACEDATA = getMasterWorkspaceData(ws);
-    const auto PMONITOR = g_pCompositor->getMonitorFromID(PWORKSPACE->m_iMonitorID);
-    const auto PMASTERNODE = getMasterNodeOnWorkspace(PWORKSPACE->m_iID);
+    const auto PMONITOR       = g_pCompositor->getMonitorFromID(PWORKSPACE->m_iMonitorID);
+    const auto PMASTERNODE    = getMasterNodeOnWorkspace(PWORKSPACE->m_iID);
 
     if (!PMASTERNODE)
         return;
@@ -276,11 +268,11 @@ void CHyprMasterLayout::calculateWorkspace(const int& ws) {
     bool               centerMasterWindow = false;
     static auto* const ALWAYSCENTER       = &g_pConfigManager->getConfigValuePtr("master:always_center_master")->intValue;
 
-    const auto MASTERS      = getMastersOnWorkspace(PWORKSPACE->m_iID);
-    const auto WINDOWS      = getNodesOnWorkspace(PWORKSPACE->m_iID);
-    const auto STACKWINDOWS = WINDOWS - MASTERS;
-    const auto WSSIZE       = PMONITOR->vecSize - PMONITOR->vecReservedTopLeft - PMONITOR->vecReservedBottomRight;
-    const auto WSPOS        = PMONITOR->vecPosition + PMONITOR->vecReservedTopLeft;
+    const auto         MASTERS      = getMastersOnWorkspace(PWORKSPACE->m_iID);
+    const auto         WINDOWS      = getNodesOnWorkspace(PWORKSPACE->m_iID);
+    const auto         STACKWINDOWS = WINDOWS - MASTERS;
+    const auto         WSSIZE       = PMONITOR->vecSize - PMONITOR->vecReservedTopLeft - PMONITOR->vecReservedBottomRight;
+    const auto         WSPOS        = PMONITOR->vecPosition + PMONITOR->vecReservedTopLeft;
 
     if (orientation == ORIENTATION_CENTER) {
         if (STACKWINDOWS >= 2 || (*ALWAYSCENTER == 1)) {
@@ -315,7 +307,7 @@ void CHyprMasterLayout::calculateWorkspace(const int& ws) {
             if (WIDTH > widthLeft * 0.9f && mastersLeft > 1)
                 WIDTH = widthLeft * 0.9f;
 
-            nd.size = Vector2D(WIDTH, HEIGHT);
+            nd.size     = Vector2D(WIDTH, HEIGHT);
             nd.position = WSPOS + Vector2D(nextX, nextY);
             applyNodeDataToWindow(&nd);
 
@@ -324,11 +316,11 @@ void CHyprMasterLayout::calculateWorkspace(const int& ws) {
             nextX += WIDTH;
         }
     } else { // orientation left, right or center
-        float WIDTH        = WSSIZE.x;
-        float heightLeft   = WSSIZE.y;
-        int   mastersLeft  = MASTERS;
-        float nextX        = 0;
-        float nextY        = 0;
+        float WIDTH       = WSSIZE.x;
+        float heightLeft  = WSSIZE.y;
+        int   mastersLeft = MASTERS;
+        float nextX       = 0;
+        float nextY       = 0;
 
         if (STACKWINDOWS > 0 || centerMasterWindow)
             WIDTH *= PMASTERNODE->percMaster;
@@ -347,7 +339,7 @@ void CHyprMasterLayout::calculateWorkspace(const int& ws) {
             if (HEIGHT > heightLeft * 0.9f && mastersLeft > 1)
                 HEIGHT = heightLeft * 0.9f;
 
-            nd.size = Vector2D(WIDTH, HEIGHT);
+            nd.size     = Vector2D(WIDTH, HEIGHT);
             nd.position = WSPOS + Vector2D(nextX, nextY);
             applyNodeDataToWindow(&nd);
 
@@ -379,7 +371,7 @@ void CHyprMasterLayout::calculateWorkspace(const int& ws) {
             if (WIDTH > widthLeft * 0.9f && slavesLeft > 1)
                 WIDTH = widthLeft * 0.9f;
 
-            nd.size = Vector2D(WIDTH, HEIGHT);
+            nd.size     = Vector2D(WIDTH, HEIGHT);
             nd.position = WSPOS + Vector2D(nextX, nextY);
             applyNodeDataToWindow(&nd);
 
@@ -404,7 +396,7 @@ void CHyprMasterLayout::calculateWorkspace(const int& ws) {
             if (HEIGHT > heightLeft * 0.9f && slavesLeft > 1)
                 HEIGHT = heightLeft * 0.9f;
 
-            nd.size = Vector2D(WIDTH, HEIGHT);
+            nd.size     = Vector2D(WIDTH, HEIGHT);
             nd.position = WSPOS + Vector2D(nextX, nextY);
             applyNodeDataToWindow(&nd);
 
@@ -431,13 +423,13 @@ void CHyprMasterLayout::calculateWorkspace(const int& ws) {
                 continue;
 
             if (onRight) {
-                nextX = WIDTH + PMASTERNODE->size.x;
-                nextY = nextYR;
+                nextX      = WIDTH + PMASTERNODE->size.x;
+                nextY      = nextYR;
                 heightLeft = heightLeftR;
                 slavesLeft = slavesLeftR;
             } else {
-                nextX = 0;
-                nextY = nextYL;
+                nextX      = 0;
+                nextY      = nextYL;
                 heightLeft = heightLeftL;
                 slavesLeft = slavesLeftL;
             }
@@ -446,7 +438,7 @@ void CHyprMasterLayout::calculateWorkspace(const int& ws) {
             if (HEIGHT > heightLeft * 0.9f && slavesLeft > 1)
                 HEIGHT = heightLeft * 0.9f;
 
-            nd.size = Vector2D(WIDTH, HEIGHT);
+            nd.size     = Vector2D(WIDTH, HEIGHT);
             nd.position = WSPOS + Vector2D(nextX, nextY);
             applyNodeDataToWindow(&nd);
 
@@ -593,13 +585,13 @@ void CHyprMasterLayout::resizeActiveWindow(const Vector2D& pixResize, eRectCorne
         return;
     }
 
-    const  auto        PMONITOR       = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID);
-    const  auto        PWORKSPACEDATA = getMasterWorkspaceData(PMONITOR->activeWorkspace);
+    const auto         PMONITOR       = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID);
+    const auto         PWORKSPACEDATA = getMasterWorkspaceData(PMONITOR->activeWorkspace);
     static auto* const ALWAYSCENTER   = &g_pConfigManager->getConfigValuePtr("master:always_center_master")->intValue;
 
-    eOrientation orientation = PWORKSPACEDATA->orientation;
-    bool         centered    = orientation == ORIENTATION_CENTER && (*ALWAYSCENTER == 1);
-    double       delta       = 0;
+    eOrientation       orientation = PWORKSPACEDATA->orientation;
+    bool               centered    = orientation == ORIENTATION_CENTER && (*ALWAYSCENTER == 1);
+    double             delta       = 0;
 
     if (getNodesOnWorkspace(PWINDOW->m_iWorkspaceID) == 1 && !centered)
         return;
@@ -631,9 +623,10 @@ void CHyprMasterLayout::resizeActiveWindow(const Vector2D& pixResize, eRectCorne
                 (PMONITOR->vecSize.y - PMONITOR->vecReservedTopLeft.y - PMONITOR->vecReservedBottomRight.y) / getMastersOnWorkspace(PNODE->workspaceID);
             PNODE->percSize = std::clamp(PNODE->percSize + RESIZEDELTA / SIZE, 0.05, 1.95);
         } else if (!PNODE->isMaster && (getNodesOnWorkspace(PWINDOW->m_iWorkspaceID) - getMastersOnWorkspace(PNODE->workspaceID)) > 1) {
-            const auto SIZE = PWORKSPACEDATA->orientation % 2 == 1 ?
-                (PMONITOR->vecSize.x - PMONITOR->vecReservedTopLeft.x - PMONITOR->vecReservedBottomRight.x) / (getNodesOnWorkspace(PNODE->workspaceID) - getMastersOnWorkspace(PNODE->workspaceID)) :
-                (PMONITOR->vecSize.y - PMONITOR->vecReservedTopLeft.y - PMONITOR->vecReservedBottomRight.y) / (getNodesOnWorkspace(PNODE->workspaceID) - getMastersOnWorkspace(PNODE->workspaceID));
+            const auto SIZE = PWORKSPACEDATA->orientation % 2 == 1 ? (PMONITOR->vecSize.x - PMONITOR->vecReservedTopLeft.x - PMONITOR->vecReservedBottomRight.x) /
+                    (getNodesOnWorkspace(PNODE->workspaceID) - getMastersOnWorkspace(PNODE->workspaceID)) :
+                                                                     (PMONITOR->vecSize.y - PMONITOR->vecReservedTopLeft.y - PMONITOR->vecReservedBottomRight.y) /
+                    (getNodesOnWorkspace(PNODE->workspaceID) - getMastersOnWorkspace(PNODE->workspaceID));
             PNODE->percSize = std::clamp(PNODE->percSize + RESIZEDELTA / SIZE, 0.05, 1.95);
         }
     }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1954,7 +1954,7 @@ void CKeybindManager::mouse(std::string args) {
             const auto mouseCoords = g_pInputManager->getMouseCoordsInternal();
             CWindow*   pWindow     = g_pCompositor->vectorToWindowIdeal(mouseCoords);
 
-            if (pWindow && !pWindow->m_bIsFullscreen && !pWindow->m_bIsFloating && !pWindow->hasPopupAt(mouseCoords) && pWindow->m_sGroupData.pNextWindow) {
+            if (pWindow && !pWindow->m_bIsFullscreen && !pWindow->hasPopupAt(mouseCoords) && pWindow->m_sGroupData.pNextWindow) {
                 const wlr_box box = pWindow->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationBox();
                 if (wlr_box_contains_point(&box, mouseCoords.x, mouseCoords.y)) {
                     const int SIZE = pWindow->getGroupSize();

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2046,7 +2046,7 @@ void CKeybindManager::moveIntoGroup(std::string args) {
     if (!PWINDOW || PWINDOW->m_bIsFloating)
         return;
 
-    const auto PWINDOWINDIR = g_pCompositor->getWindowInDirection(PWINDOW, arg);
+    auto PWINDOWINDIR = g_pCompositor->getWindowInDirection(PWINDOW, arg);
 
     if (!PWINDOWINDIR || !PWINDOWINDIR->m_sGroupData.pNextWindow)
         return;
@@ -2058,6 +2058,9 @@ void CKeybindManager::moveIntoGroup(std::string args) {
         PWINDOW->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(PWINDOW));
 
     g_pLayoutManager->getCurrentLayout()->onWindowRemoved(PWINDOW); // This removes groupped property!
+
+    static const auto* USECURRPOS = &g_pConfigManager->getConfigValuePtr("misc:group_insert_after_current")->intValue;
+    PWINDOWINDIR                  = *USECURRPOS ? PWINDOWINDIR : PWINDOWINDIR->getGroupTail();
 
     PWINDOWINDIR->insertWindowToGroup(PWINDOW);
     PWINDOWINDIR->setGroupCurrent(PWINDOW);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1955,7 +1955,7 @@ void CKeybindManager::mouse(std::string args) {
             CWindow*   pWindow     = g_pCompositor->vectorToWindowIdeal(mouseCoords);
 
             if (pWindow && !pWindow->m_bIsFullscreen && !pWindow->hasPopupAt(mouseCoords) && pWindow->m_sGroupData.pNextWindow) {
-                const wlr_box box = pWindow->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationBox().getExtents();
+                const wlr_box box = pWindow->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationRegion().getExtents();
                 if (wlr_box_contains_point(&box, mouseCoords.x, mouseCoords.y)) {
                     const int SIZE = pWindow->getGroupSize();
                     pWindow        = pWindow->getGroupWindowByIndex((mouseCoords.x - box.x) * SIZE / box.width);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1955,7 +1955,7 @@ void CKeybindManager::mouse(std::string args) {
             CWindow*   pWindow     = g_pCompositor->vectorToWindowIdeal(mouseCoords);
 
             if (pWindow && !pWindow->m_bIsFullscreen && !pWindow->m_bIsFloating && !pWindow->hasPopupAt(mouseCoords) && pWindow->m_sGroupData.pNextWindow) {
-                const wlr_box box = pWindow->getWindowGroupBarBox();
+                const wlr_box box = pWindow->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationBox();
                 if (wlr_box_contains_point(&box, mouseCoords.x, mouseCoords.y)) {
                     const int SIZE = pWindow->getGroupSize();
                     pWindow        = pWindow->getGroupWindowByIndex((mouseCoords.x - box.x) * SIZE / box.width);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1226,13 +1226,13 @@ void CKeybindManager::toggleGroup(std::string args) {
                 w->m_sGroupData.head = false;
             }
 
-            bool prevState                     = g_pKeybindManager->m_bGroupsLocked;
+            const bool GROUPSLOCKEDPREV        = g_pKeybindManager->m_bGroupsLocked;
             g_pKeybindManager->m_bGroupsLocked = true;
             for (auto& w : members) {
                 g_pLayoutManager->getCurrentLayout()->onWindowCreated(w);
                 w->updateWindowDecos();
             }
-            g_pKeybindManager->m_bGroupsLocked = prevState;
+            g_pKeybindManager->m_bGroupsLocked = GROUPSLOCKEDPREV;
         }
     }
 
@@ -1951,9 +1951,26 @@ void CKeybindManager::mouse(std::string args) {
         if (PRESSED) {
             g_pKeybindManager->m_bIsMouseBindActive = true;
 
-            g_pInputManager->currentlyDraggedWindow = g_pCompositor->vectorToWindowIdeal(g_pInputManager->getMouseCoordsInternal());
-            g_pInputManager->dragMode               = MBIND_MOVE;
+            const auto mouseCoords = g_pInputManager->getMouseCoordsInternal();
+            CWindow*   pWindow     = g_pCompositor->vectorToWindowIdeal(mouseCoords);
 
+            if (pWindow && !pWindow->m_bIsFullscreen && !pWindow->hasPopupAt(mouseCoords) && pWindow->m_sGroupData.pNextWindow) {
+                const wlr_box box = pWindow->getWindowGroupBarBox();
+                if (wlr_box_contains_point(&box, mouseCoords.x, mouseCoords.y)) {
+                    const int SIZE = pWindow->getGroupSize();
+                    pWindow        = pWindow->getGroupWindowByIndex((mouseCoords.x - box.x) * SIZE / box.width);
+
+                    // hack
+                    g_pLayoutManager->getCurrentLayout()->onWindowRemoved(pWindow);
+                    const bool GROUPSLOCKEDPREV        = g_pKeybindManager->m_bGroupsLocked;
+                    g_pKeybindManager->m_bGroupsLocked = true;
+                    g_pLayoutManager->getCurrentLayout()->onWindowCreated(pWindow);
+                    g_pKeybindManager->m_bGroupsLocked = GROUPSLOCKEDPREV;
+                }
+            }
+
+            g_pInputManager->currentlyDraggedWindow = pWindow;
+            g_pInputManager->dragMode               = MBIND_MOVE;
             g_pLayoutManager->getCurrentLayout()->onBeginDragWindow();
         } else {
             g_pKeybindManager->m_bIsMouseBindActive = false;

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1954,7 +1954,7 @@ void CKeybindManager::mouse(std::string args) {
             const auto mouseCoords = g_pInputManager->getMouseCoordsInternal();
             CWindow*   pWindow     = g_pCompositor->vectorToWindowIdeal(mouseCoords);
 
-            if (pWindow && !pWindow->m_bIsFullscreen && !pWindow->hasPopupAt(mouseCoords) && pWindow->m_sGroupData.pNextWindow) {
+            if (pWindow && !pWindow->m_bIsFullscreen && !pWindow->m_bIsFloating && !pWindow->hasPopupAt(mouseCoords) && pWindow->m_sGroupData.pNextWindow) {
                 const wlr_box box = pWindow->getWindowGroupBarBox();
                 if (wlr_box_contains_point(&box, mouseCoords.x, mouseCoords.y)) {
                     const int SIZE = pWindow->getGroupSize();

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1962,10 +1962,12 @@ void CKeybindManager::mouse(std::string args) {
 
                     // hack
                     g_pLayoutManager->getCurrentLayout()->onWindowRemoved(pWindow);
-                    const bool GROUPSLOCKEDPREV        = g_pKeybindManager->m_bGroupsLocked;
-                    g_pKeybindManager->m_bGroupsLocked = true;
-                    g_pLayoutManager->getCurrentLayout()->onWindowCreated(pWindow);
-                    g_pKeybindManager->m_bGroupsLocked = GROUPSLOCKEDPREV;
+                    if (!pWindow->m_bIsFloating) {
+                        const bool GROUPSLOCKEDPREV        = g_pKeybindManager->m_bGroupsLocked;
+                        g_pKeybindManager->m_bGroupsLocked = true;
+                        g_pLayoutManager->getCurrentLayout()->onWindowCreated(pWindow);
+                        g_pKeybindManager->m_bGroupsLocked = GROUPSLOCKEDPREV;
+                    }
                 }
             }
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1955,7 +1955,7 @@ void CKeybindManager::mouse(std::string args) {
             CWindow*   pWindow     = g_pCompositor->vectorToWindowIdeal(mouseCoords);
 
             if (pWindow && !pWindow->m_bIsFullscreen && !pWindow->hasPopupAt(mouseCoords) && pWindow->m_sGroupData.pNextWindow) {
-                const wlr_box box = pWindow->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationBox();
+                const wlr_box box = pWindow->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationBox().getExtents();
                 if (wlr_box_contains_point(&box, mouseCoords.x, mouseCoords.y)) {
                     const int SIZE = pWindow->getGroupSize();
                     pWindow        = pWindow->getGroupWindowByIndex((mouseCoords.x - box.x) * SIZE / box.width);

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -564,21 +564,10 @@ void CInputManager::processMouseDownNormal(wlr_pointer_button_event* e) {
         const wlr_box box = w->getWindowGroupBarBox();
         if (wlr_box_contains_point(&box, mouseCoords.x, mouseCoords.y)) {
             if (e->state == WLR_BUTTON_PRESSED) {
-                int      size = 1;
-                CWindow* curr = w;
-                while (curr->m_sGroupData.pNextWindow != w) {
-                    curr = curr->m_sGroupData.pNextWindow;
-                    size++;
-                }
-
-                int      index   = (mouseCoords.x - box.x) * size / box.width;
-                CWindow* pWindow = w->getGroupHead();
-                while (index > 0) {
-                    pWindow = pWindow->m_sGroupData.pNextWindow;
-                    index--;
-                }
-
-                w->setGroupCurrent(pWindow);
+                const int SIZE    = w->getGroupSize();
+                CWindow*  pWindow = w->getGroupWindowByIndex((mouseCoords.x - box.x) * SIZE / box.width);
+                if (w != pWindow)
+                    w->setGroupCurrent(pWindow);
             }
             return;
         }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -549,7 +549,7 @@ void CInputManager::processMouseDownNormal(wlr_pointer_button_event* e) {
     const auto w           = g_pCompositor->vectorToWindowIdeal(mouseCoords);
 
     if (w && !w->m_bIsFullscreen && !w->hasPopupAt(mouseCoords) && w->m_sGroupData.pNextWindow) {
-        const wlr_box box = w->getWindowGroupBarBox();
+        const wlr_box box = w->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationBox();
         if (wlr_box_contains_point(&box, mouseCoords.x, mouseCoords.y)) {
             if (e->state == WLR_BUTTON_PRESSED) {
                 const int SIZE    = w->getGroupSize();

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -549,7 +549,7 @@ void CInputManager::processMouseDownNormal(wlr_pointer_button_event* e) {
     const auto w           = g_pCompositor->vectorToWindowIdeal(mouseCoords);
 
     if (w && !w->m_bIsFullscreen && !w->hasPopupAt(mouseCoords) && w->m_sGroupData.pNextWindow) {
-        const wlr_box box = w->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationBox();
+        const wlr_box box = w->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationBox().getExtents();
         if (wlr_box_contains_point(&box, mouseCoords.x, mouseCoords.y)) {
             if (e->state == WLR_BUTTON_PRESSED) {
                 const int SIZE    = w->getGroupSize();

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -548,18 +548,6 @@ void CInputManager::processMouseDownNormal(wlr_pointer_button_event* e) {
     const auto mouseCoords = g_pInputManager->getMouseCoordsInternal();
     const auto w           = g_pCompositor->vectorToWindowIdeal(mouseCoords);
 
-    // clicking on border triggers resize
-    // TODO detect click on LS properly
-    if (*PRESIZEONBORDER && !m_bLastFocusOnLS) {
-        if (w && !w->m_bIsFullscreen) {
-            const wlr_box real = {w->m_vRealPosition.vec().x, w->m_vRealPosition.vec().y, w->m_vRealSize.vec().x, w->m_vRealSize.vec().y};
-            if ((!wlr_box_contains_point(&real, mouseCoords.x, mouseCoords.y) || w->isInCurvedCorner(mouseCoords.x, mouseCoords.y)) && !w->hasPopupAt(mouseCoords)) {
-                g_pKeybindManager->resizeWithBorder(e);
-                return;
-            }
-        }
-    }
-
     if (w && !w->m_bIsFullscreen && !w->hasPopupAt(mouseCoords) && w->m_sGroupData.pNextWindow) {
         const wlr_box box = w->getWindowGroupBarBox();
         if (wlr_box_contains_point(&box, mouseCoords.x, mouseCoords.y)) {
@@ -570,6 +558,18 @@ void CInputManager::processMouseDownNormal(wlr_pointer_button_event* e) {
                     w->setGroupCurrent(pWindow);
             }
             return;
+        }
+    }
+
+    // clicking on border triggers resize
+    // TODO detect click on LS properly
+    if (*PRESIZEONBORDER && !m_bLastFocusOnLS) {
+        if (w && !w->m_bIsFullscreen) {
+            const wlr_box real = {w->m_vRealPosition.vec().x, w->m_vRealPosition.vec().y, w->m_vRealSize.vec().x, w->m_vRealSize.vec().y};
+            if ((!wlr_box_contains_point(&real, mouseCoords.x, mouseCoords.y) || w->isInCurvedCorner(mouseCoords.x, mouseCoords.y)) && !w->hasPopupAt(mouseCoords)) {
+                g_pKeybindManager->resizeWithBorder(e);
+                return;
+            }
         }
     }
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -549,7 +549,7 @@ void CInputManager::processMouseDownNormal(wlr_pointer_button_event* e) {
     const auto w           = g_pCompositor->vectorToWindowIdeal(mouseCoords);
 
     if (w && !w->m_bIsFullscreen && !w->hasPopupAt(mouseCoords) && w->m_sGroupData.pNextWindow) {
-        const wlr_box box = w->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationBox().getExtents();
+        const wlr_box box = w->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationRegion().getExtents();
         if (wlr_box_contains_point(&box, mouseCoords.x, mouseCoords.y)) {
             if (e->state == WLR_BUTTON_PRESSED) {
                 const int SIZE    = w->getGroupSize();
@@ -640,7 +640,7 @@ void CInputManager::onMouseWheel(wlr_pointer_axis_event* e) {
     const auto pWindow     = g_pCompositor->vectorToWindowIdeal(MOUSECOORDS);
 
     if (*PGROUPBARSCROLLING && pWindow && !pWindow->m_bIsFullscreen && !pWindow->hasPopupAt(MOUSECOORDS) && pWindow->m_sGroupData.pNextWindow) {
-        const wlr_box box = pWindow->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationBox().getExtents();
+        const wlr_box box = pWindow->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationRegion().getExtents();
         if (wlr_box_contains_point(&box, MOUSECOORDS.x, MOUSECOORDS.y)) {
             if (e->delta > 0)
                 pWindow->setGroupCurrent(pWindow->m_sGroupData.pNextWindow);

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -2,7 +2,7 @@
 
 #include "../../Compositor.hpp"
 
-CHyprDropShadowDecoration::CHyprDropShadowDecoration(CWindow* pWindow) {
+CHyprDropShadowDecoration::CHyprDropShadowDecoration(CWindow* pWindow) : IHyprWindowDecoration(pWindow) {
     m_pWindow = pWindow;
 }
 

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -306,3 +306,7 @@ void CHyprGroupBarDecoration::refreshGradients() {
     renderGradientTo(m_tGradientActive, ((CGradientValueData*)PCOLACTIVE->get())->m_vColors[0]);
     renderGradientTo(m_tGradientInactive, ((CGradientValueData*)PCOLINACTIVE->get())->m_vColors[0]);
 }
+
+bool CHyprGroupBarDecoration::allowsInput() {
+    return true;
+}

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -7,7 +7,7 @@
 static CTexture m_tGradientActive;
 static CTexture m_tGradientInactive;
 
-CHyprGroupBarDecoration::CHyprGroupBarDecoration(CWindow* pWindow) {
+CHyprGroupBarDecoration::CHyprGroupBarDecoration(CWindow* pWindow) : IHyprWindowDecoration(pWindow) {
     m_pWindow = pWindow;
 }
 

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -33,6 +33,8 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
 
     virtual SWindowDecorationExtents getWindowDecorationReservedArea();
 
+    virtual bool                     allowsInput();
+
   private:
     SWindowDecorationExtents m_seExtents;
 

--- a/src/render/decorations/IHyprWindowDecoration.cpp
+++ b/src/render/decorations/IHyprWindowDecoration.cpp
@@ -2,10 +2,35 @@
 
 #include "../../Window.hpp"
 
+IHyprWindowDecoration::IHyprWindowDecoration(CWindow* pWindow) {
+    m_pWindow = pWindow;
+}
+
 IHyprWindowDecoration::~IHyprWindowDecoration() {}
 
 SWindowDecorationExtents IHyprWindowDecoration::getWindowDecorationReservedArea() {
     return SWindowDecorationExtents{};
+}
+
+wlr_box IHyprWindowDecoration::getWindowDecorationBox() {
+    const SWindowDecorationExtents RESERVED   = getWindowDecorationReservedArea();
+    const int                      BORDERSIZE = m_pWindow->getRealBorderSize();
+    switch ((RESERVED.topLeft.x != 0) + (RESERVED.topLeft.y != 0) + (RESERVED.bottomRight.x != 0) + (RESERVED.bottomRight.y != 0)) {
+        case 0: return {0, 0, 0, 0};
+        case 1:
+            return {m_pWindow->m_vRealPosition.vec().x - (BORDERSIZE + RESERVED.topLeft.x) * (int)(RESERVED.topLeft.x != 0),
+                    m_pWindow->m_vRealPosition.vec().y - (BORDERSIZE + RESERVED.topLeft.y) * (int)(RESERVED.topLeft.y != 0),
+                    (RESERVED.topLeft.y || RESERVED.bottomRight.y) ? m_pWindow->m_vRealSize.vec().x : RESERVED.topLeft.x + RESERVED.bottomRight.x,
+                    (RESERVED.topLeft.x || RESERVED.bottomRight.x) ? m_pWindow->m_vRealSize.vec().y : RESERVED.topLeft.y + RESERVED.bottomRight.y};
+        default:
+            // untested
+            return {m_pWindow->m_vRealPosition.vec().x - (BORDERSIZE + RESERVED.topLeft.x) * (int)(RESERVED.topLeft.x != 0),
+                    m_pWindow->m_vRealPosition.vec().y - (BORDERSIZE + RESERVED.topLeft.y) * (int)(RESERVED.topLeft.y != 0),
+                    m_pWindow->m_vRealSize.vec().x + (BORDERSIZE + RESERVED.topLeft.x) * (int)(RESERVED.topLeft.x != 0) +
+                        (BORDERSIZE + RESERVED.bottomRight.x) * (int)(RESERVED.bottomRight.x != 0),
+                    m_pWindow->m_vRealSize.vec().y + (BORDERSIZE + RESERVED.topLeft.y) * (int)(RESERVED.topLeft.y != 0) +
+                        (BORDERSIZE + RESERVED.bottomRight.y) * (int)(RESERVED.bottomRight.y != 0)};
+    }
 }
 
 bool IHyprWindowDecoration::allowsInput() {

--- a/src/render/decorations/IHyprWindowDecoration.cpp
+++ b/src/render/decorations/IHyprWindowDecoration.cpp
@@ -12,25 +12,17 @@ SWindowDecorationExtents IHyprWindowDecoration::getWindowDecorationReservedArea(
     return SWindowDecorationExtents{};
 }
 
-wlr_box IHyprWindowDecoration::getWindowDecorationBox() {
+CRegion IHyprWindowDecoration::getWindowDecorationBox() {
     const SWindowDecorationExtents RESERVED   = getWindowDecorationReservedArea();
     const int                      BORDERSIZE = m_pWindow->getRealBorderSize();
-    switch ((RESERVED.topLeft.x != 0) + (RESERVED.topLeft.y != 0) + (RESERVED.bottomRight.x != 0) + (RESERVED.bottomRight.y != 0)) {
-        case 0: return {0, 0, 0, 0};
-        case 1:
-            return {m_pWindow->m_vRealPosition.vec().x - (BORDERSIZE + RESERVED.topLeft.x) * (int)(RESERVED.topLeft.x != 0),
-                    m_pWindow->m_vRealPosition.vec().y - (BORDERSIZE + RESERVED.topLeft.y) * (int)(RESERVED.topLeft.y != 0),
-                    (RESERVED.topLeft.y || RESERVED.bottomRight.y) ? m_pWindow->m_vRealSize.vec().x : RESERVED.topLeft.x + RESERVED.bottomRight.x,
-                    (RESERVED.topLeft.x || RESERVED.bottomRight.x) ? m_pWindow->m_vRealSize.vec().y : RESERVED.topLeft.y + RESERVED.bottomRight.y};
-        default:
-            // untested
-            return {m_pWindow->m_vRealPosition.vec().x - (BORDERSIZE + RESERVED.topLeft.x) * (int)(RESERVED.topLeft.x != 0),
-                    m_pWindow->m_vRealPosition.vec().y - (BORDERSIZE + RESERVED.topLeft.y) * (int)(RESERVED.topLeft.y != 0),
-                    m_pWindow->m_vRealSize.vec().x + (BORDERSIZE + RESERVED.topLeft.x) * (int)(RESERVED.topLeft.x != 0) +
-                        (BORDERSIZE + RESERVED.bottomRight.x) * (int)(RESERVED.bottomRight.x != 0),
-                    m_pWindow->m_vRealSize.vec().y + (BORDERSIZE + RESERVED.topLeft.y) * (int)(RESERVED.topLeft.y != 0) +
-                        (BORDERSIZE + RESERVED.bottomRight.y) * (int)(RESERVED.bottomRight.y != 0)};
-    }
+    return CRegion(m_pWindow->m_vRealPosition.vec().x - (BORDERSIZE + RESERVED.topLeft.x) * (int)(RESERVED.topLeft.x != 0),
+                   m_pWindow->m_vRealPosition.vec().y - (BORDERSIZE + RESERVED.topLeft.y) * (int)(RESERVED.topLeft.y != 0),
+                   m_pWindow->m_vRealSize.vec().x + (BORDERSIZE + RESERVED.topLeft.x) * (int)(RESERVED.topLeft.x != 0) +
+                       (BORDERSIZE + RESERVED.bottomRight.x) * (int)(RESERVED.bottomRight.x != 0),
+                   m_pWindow->m_vRealSize.vec().y + (BORDERSIZE + RESERVED.topLeft.y) * (int)(RESERVED.topLeft.y != 0) +
+                       (BORDERSIZE + RESERVED.bottomRight.y) * (int)(RESERVED.bottomRight.y != 0))
+        .subtract(CRegion(m_pWindow->m_vRealPosition.vec().x - BORDERSIZE, m_pWindow->m_vRealPosition.vec().y - BORDERSIZE, m_pWindow->m_vRealSize.vec().x + 2 * BORDERSIZE,
+                          m_pWindow->m_vRealSize.vec().y + 2 * BORDERSIZE));
 }
 
 bool IHyprWindowDecoration::allowsInput() {

--- a/src/render/decorations/IHyprWindowDecoration.cpp
+++ b/src/render/decorations/IHyprWindowDecoration.cpp
@@ -12,7 +12,7 @@ SWindowDecorationExtents IHyprWindowDecoration::getWindowDecorationReservedArea(
     return SWindowDecorationExtents{};
 }
 
-CRegion IHyprWindowDecoration::getWindowDecorationBox() {
+CRegion IHyprWindowDecoration::getWindowDecorationRegion() {
     const SWindowDecorationExtents RESERVED   = getWindowDecorationReservedArea();
     const int                      BORDERSIZE = m_pWindow->getRealBorderSize();
     return CRegion(m_pWindow->m_vRealPosition.vec().x - (BORDERSIZE + RESERVED.topLeft.x) * (int)(RESERVED.topLeft.x != 0),

--- a/src/render/decorations/IHyprWindowDecoration.hpp
+++ b/src/render/decorations/IHyprWindowDecoration.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../../defines.hpp"
+#include "../../helpers/Region.hpp"
 
 enum eDecorationType {
     DECORATION_NONE = -1,
@@ -34,7 +35,7 @@ class IHyprWindowDecoration {
 
     virtual SWindowDecorationExtents getWindowDecorationReservedArea();
 
-    virtual wlr_box                  getWindowDecorationBox();
+    virtual CRegion                  getWindowDecorationBox();
 
     virtual bool                     allowsInput();
 

--- a/src/render/decorations/IHyprWindowDecoration.hpp
+++ b/src/render/decorations/IHyprWindowDecoration.hpp
@@ -35,7 +35,7 @@ class IHyprWindowDecoration {
 
     virtual SWindowDecorationExtents getWindowDecorationReservedArea();
 
-    virtual CRegion                  getWindowDecorationBox();
+    virtual CRegion                  getWindowDecorationRegion();
 
     virtual bool                     allowsInput();
 

--- a/src/render/decorations/IHyprWindowDecoration.hpp
+++ b/src/render/decorations/IHyprWindowDecoration.hpp
@@ -19,6 +19,7 @@ class CMonitor;
 
 class IHyprWindowDecoration {
   public:
+    IHyprWindowDecoration(CWindow*);
     virtual ~IHyprWindowDecoration() = 0;
 
     virtual SWindowDecorationExtents getWindowDecorationExtents() = 0;
@@ -33,5 +34,10 @@ class IHyprWindowDecoration {
 
     virtual SWindowDecorationExtents getWindowDecorationReservedArea();
 
+    virtual wlr_box                  getWindowDecorationBox();
+
     virtual bool                     allowsInput();
+
+  private:
+    CWindow* m_pWindow = nullptr;
 };


### PR DESCRIPTION
allows mouse to better interact with groupbar:

- clicking on window bar to set it as active
- drag specific window from groupbar (movewindow)
- drag window into group's groupbar to move it into the group at a specific position (movewindow)

dragging out of floating groups is not allowed, because of crashes (same that happens with moveoutofgroup in main branch)
I'll look into that later

future improvements:
- allow constricted moving window inside group (hold mouse down normal)
- visual hints for what's happening
- fix cursor icon

didn't find any major issues
should be ready for merge