### PR TITLE
refactor: raise SIGABRT instead of nullptr write

### DIFF
--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -3,6 +3,7 @@
 #include "helpers/MiscFunctions.hpp"
 #include "debug/Log.hpp"
 #include <cmath>
+#include <csignal>
 #include <utility>
 
 #ifndef NDEBUG
@@ -57,9 +58,9 @@
     if (!(expr)) {                                                                                                                                                                 \
         Debug::log(CRIT, "\n==========================================================================================\nASSERTION FAILED! \n\n%s\n\nat: line %d in %s",            \
                    getFormat(reason, ##__VA_ARGS__).c_str(), __LINE__,                                                                                                             \
-                   ([]() constexpr->std::string { return std::string(__FILE__).substr(std::string(__FILE__).find_last_of('/') + 1); })().c_str());                                 \
+                   ([]() constexpr -> std::string { return std::string(__FILE__).substr(std::string(__FILE__).find_last_of('/') + 1); })().c_str());                               \
         printf("Assertion failed! See the log in /tmp/hypr/hyprland.log for more info.");                                                                                          \
-        *((int*)nullptr) = 1; /* so that we crash and get a coredump */                                                                                                            \
+        raise(SIGABRT);                                                                                                                                                            \
     }
 #else
 #define RASSERT(expr, reason, ...)
@@ -71,7 +72,7 @@
 #define UNREACHABLE()                                                                                                                                                              \
     {                                                                                                                                                                              \
         Debug::log(CRIT, "\n\nMEMORY CORRUPTED: Unreachable failed! (Reached an unreachable position, memory corruption!!!)");                                                     \
-        *((int*)nullptr) = 1;                                                                                                                                                      \
+        raise(SIGABRT);                                                                                                                                                            \
     }
 #else
 #define UNREACHABLE() std::unreachable();

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1973,7 +1973,7 @@ static int handleCrashLoop(void* data) {
     g_pHyprRenderer->m_fCrashingDistort += 0.5f;
 
     if (g_pHyprRenderer->m_fCrashingDistort >= 5.5f)
-        *((int*)nullptr) = 1337;
+        raise(SIGABRT);
 
     wl_event_source_timer_update(g_pHyprRenderer->m_pCrashingLoop, 1000);
 


### PR DESCRIPTION
Use `raise(SIBABRT)` instead of `*((int*)nullptr) = 1337` because writing to the null address may not guarantee a reliable crash, and Hyprland registers a signal handler which will eventually call `abort()`.