### PR TITLE
Fix preedit styling in chromium

### DIFF
--- a/src/managers/input/InputMethodRelay.cpp
+++ b/src/managers/input/InputMethodRelay.cpp
@@ -46,12 +46,12 @@ void CInputMethodRelay::onNewIME(wlr_input_method_v2* pIME) {
             } else {
                 if (PIMR->m_pWLRIME->current.preedit.text) {
                     zwp_text_input_v1_send_preedit_cursor(PTI->pV1Input->resourceImpl, PIMR->m_pWLRIME->current.preedit.cursor_begin);
-                    zwp_text_input_v1_send_preedit_styling(PTI->pV1Input->resourceImpl, 0, std::string(PIMR->m_pWLRIME->current.preedit.text).length() - 1,
-                                                           ZWP_TEXT_INPUT_V1_PREEDIT_STYLE_NONE);
+                    zwp_text_input_v1_send_preedit_styling(PTI->pV1Input->resourceImpl, 0, std::string(PIMR->m_pWLRIME->current.preedit.text).length(),
+                                                           ZWP_TEXT_INPUT_V1_PREEDIT_STYLE_HIGHLIGHT);
                     zwp_text_input_v1_send_preedit_string(PTI->pV1Input->resourceImpl, PTI->pV1Input->serial, PIMR->m_pWLRIME->current.preedit.text, "");
                 } else {
                     zwp_text_input_v1_send_preedit_cursor(PTI->pV1Input->resourceImpl, PIMR->m_pWLRIME->current.preedit.cursor_begin);
-                    zwp_text_input_v1_send_preedit_styling(PTI->pV1Input->resourceImpl, 0, 0, ZWP_TEXT_INPUT_V1_PREEDIT_STYLE_NONE);
+                    zwp_text_input_v1_send_preedit_styling(PTI->pV1Input->resourceImpl, 0, 0, ZWP_TEXT_INPUT_V1_PREEDIT_STYLE_HIGHLIGHT);
                     zwp_text_input_v1_send_preedit_string(PTI->pV1Input->resourceImpl, PTI->pV1Input->serial, "", "");
                 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

`ZWP_TEXT_INPUT_V1_PREEDIT_STYLE_NONE` seems to be [ignored](https://source.chromium.org/chromium/chromium/src/+/main:out/Debug/gen/third_party/wayland-protocols/src/unstable/text-input/text-input-unstable-v1-client-protocol.h;drc=6f4c64436342c818aa41e6a5c55034e74ec9c6b6;l=283) in chromium, causing chromium to fallback on the yellow background mentioned in https://github.com/hyprwm/Hyprland/issues/1746#issuecomment-1468179122, which unfortunately doesn't look great under dark themes.

Change it to `ZWP_TEXT_INPUT_V1_PREEDIT_STYLE_HIGHLIGHT` which causes chromium to draw a thick underline under the preedit.

This PR also fixes the [length](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/1.32/unstable/text-input/text-input-unstable-v1.xml?ref_type=tags#L273) of the preedit styling so the last character gets underlined as well.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Alternatives are:
`ZWP_TEXT_INPUT_V1_PREEDIT_STYLE_DEFAULT`, which in chromium means no styling at all and preedit text will look like regular text, which is not great IMO.
`ZWP_TEXT_INPUT_V1_PREEDIT_STYLE_UNDERLINE`, which gives a thinner underline than `ZWP_TEXT_INPUT_V1_PREEDIT_STYLE_HIGHLIGHT` in chromium.
#### Is it ready for merging, or does it need work?
Ready.


