### PR TITLE
fix: use-after-free of CWindow* in CHyprGroupBarDecoration::draw

### DIFF
--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -57,6 +57,7 @@ void IHyprLayout::onWindowRemoved(CWindow* pWindow) {
             pWindow->setHidden(false);
 
             pWindow->updateWindowDecos();
+            curr->getGroupCurrent()->updateWindowDecos();
             g_pCompositor->updateWindowAnimatedDecorationValues(pWindow);
 
             return;


### PR DESCRIPTION
The dangling CWindow* pointer in `CHyprGroupBarDecoration.m_dwGroupMembers` triggered a use-after-free bug in `CHyprGroupBarDecoration::draw()`, leading to a crash in Hyprland when operating on `CTitleTex.szContent`.

https://github.com/hyprwm/Hyprland/blob/06d860c489b667cabe29d180b28321377f4df3d1/src/render/decorations/CHyprGroupBarDecoration.cpp#L134-L138

This patch includes a call to `CWindow::updateWindowDecos()` for the surviving group member when a window is destroyed, ensuring the removal of the dangling pointer from `CHyprGroupBarDecoration.m_dwGroupMembers`.

fixes: #3144