### PR TITLE
Revert rounding of window size

### DIFF
--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -176,9 +176,9 @@ void CHyprXWaylandManager::setWindowSize(CWindow* pWindow, Vector2D size, bool f
     }
 
     if (pWindow->m_bIsX11)
-        wlr_xwayland_surface_configure(pWindow->m_uSurface.xwayland, windowPos.x, windowPos.y, std::round(size.x), std::round(size.y));
+        wlr_xwayland_surface_configure(pWindow->m_uSurface.xwayland, windowPos.x, windowPos.y, size.x, size.y);
     else
-        wlr_xdg_toplevel_set_size(pWindow->m_uSurface.xdg->toplevel, std::round(size.x), std::round(size.y));
+        wlr_xdg_toplevel_set_size(pWindow->m_uSurface.xdg->toplevel, size.x, size.y);
 }
 
 void CHyprXWaylandManager::setWindowStyleTiled(CWindow* pWindow, uint32_t edgez) {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -271,7 +271,7 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
     static auto* const PDIMAROUND  = &g_pConfigManager->getConfigValuePtr("decoration:dim_around")->floatValue;
     static auto* const PBORDERSIZE = &g_pConfigManager->getConfigValuePtr("general:border_size")->intValue;
 
-    SRenderData        renderdata = {pMonitor, time, std::round(REALPOS.x), std::round(REALPOS.y)};
+    SRenderData        renderdata = {pMonitor, time, REALPOS.x, REALPOS.y};
     if (ignorePosition) {
         renderdata.x = pMonitor->vecPosition.x;
         renderdata.y = pMonitor->vecPosition.y;
@@ -281,8 +281,8 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
         decorate = false;
 
     renderdata.surface   = pWindow->m_pWLSurface.wlr();
-    renderdata.w         = std::round(std::max(pWindow->m_vRealSize.vec().x, 5.0)); // clamp the size to min 5,
-    renderdata.h         = std::round(std::max(pWindow->m_vRealSize.vec().y, 5.0)); // otherwise we'll have issues later with invalid boxes
+    renderdata.w         = std::max(pWindow->m_vRealSize.vec().x, 5.0); // clamp the size to min 5,
+    renderdata.h         = std::max(pWindow->m_vRealSize.vec().y, 5.0); // otherwise we'll have issues later with invalid boxes
     renderdata.dontRound = (pWindow->m_bIsFullscreen && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL) || (!pWindow->m_sSpecialRenderData.rounding);
     renderdata.fadeAlpha = pWindow->m_fAlpha.fl() * (pWindow->m_bPinned ? 1.f : PWORKSPACE->m_fAlpha.fl());
     renderdata.alpha     = pWindow->m_fActiveInactiveAlpha.fl();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Rounding the window sizes make the windows render incorrectly. The first window in the workspace seems to be fine but the other ones have teared up borders.

https://imgur.com/qGqrblP (third, fourth and fifth window on the workspace)


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I dont know why rounding was added, removing it might cause the issue again that was intended to be resolved.

#### Is it ready for merging, or does it need work?
Ready for merging.


