### PR TITLE
Set limit on how many windows in special workspace

### DIFF
--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -417,6 +417,8 @@ void CWindow::onUnmap() {
 
 void CWindow::onMap() {
 
+    static auto* const PISOLATESPECIAL = &g_pConfigManager->getConfigValuePtr("misc:isolate_special")->intValue;
+
     m_pWLSurface.assign(g_pXWaylandManager->getWindowSurface(this));
 
     // JIC, reset the callbacks. If any are set, we'll make sure they are cleared so we don't accidentally unset them. (In case a window got remapped)
@@ -447,6 +449,12 @@ void CWindow::onMap() {
 
     hyprListener_unmapWindow.initCallback(m_bIsX11 ? &m_uSurface.xwayland->surface->events.unmap : &m_uSurface.xdg->surface->events.unmap, &Events::listener_unmapWindow, this,
                                           "CWindow");
+    
+    if (*PISOLATESPECIAL && g_pCompositor->getWindowsOnWorkspace(m_iWorkspaceID) > *PISOLATESPECIAL && g_pCompositor->isWorkspaceSpecial(m_iWorkspaceID)) {
+        const auto PMONITOR = g_pCompositor->getMonitorFromID(m_iMonitorID);
+        this->moveToWorkspace(PMONITOR->activeWorkspace);
+    }
+
 }
 
 void CWindow::onBorderAngleAnimEnd(void* ptr) {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -114,6 +114,7 @@ void CConfigManager::setDefaultVars() {
     configValues["misc:groupbar_titles_font_size"].intValue    = 8;
     configValues["misc:groupbar_gradients"].intValue           = 1;
     configValues["misc:close_special_on_empty"].intValue       = 1;
+    configValues["misc:isolate_special"].intValue              = 0;
     configValues["misc:groupbar_text_color"].intValue          = 0xffffffff;
     configValues["misc:background_color"].intValue             = 0xff111111;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixing point 1 of #2596

Added config option `misc:isolate_special INT` 
For windows in special workspace > INT the new window is send to the active workspace (behind special)
#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Possible bug : Assign negative number to config 

#### Is it ready for merging, or does it need work?
Tested on a nested Hyprland Session and works as expected.

