### PR TITLE
Optimize CAnimationManager::scheduleTick a bit.

### DIFF
--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -539,15 +539,14 @@ void CAnimationManager::scheduleTick() {
 
     const auto PMOSTHZ = g_pHyprRenderer->m_pMostHzMonitor;
 
-    float      refreshRate    = PMOSTHZ ? PMOSTHZ->refreshRate : 60.f;
-    float      refreshDelayMs = std::floor(1000.0 / refreshRate);
-
     if (!PMOSTHZ) {
-        wl_event_source_timer_update(m_pAnimationTick, refreshDelayMs);
+        wl_event_source_timer_update(m_pAnimationTick, 16.f);
         return;
     }
 
-    const float SINCEPRES = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - PMOSTHZ->lastPresentationTimer.chrono()).count() / 1000.0;
+    float      refreshDelayMs = std::floor(1000.f / PMOSTHZ->refreshRate);
+
+    const float SINCEPRES = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now() - PMOSTHZ->lastPresentationTimer.chrono()).count() / 1000.f;
 
     const auto  TOPRES = std::clamp(refreshDelayMs - SINCEPRES, 1.1f, 1000.f); // we can't send 0, that will disarm it
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
If the PMOSTHZ is not set some calculation can be ommited.
Doing so saves  one !PMOSTHZ check too.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This is very minor and wont change the performance much, but it's nicer i think.

#### Is it ready for merging, or does it need work?
Ready

