### PR TITLE
feat: add renameWorkspace event

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1430,8 +1430,10 @@ void CKeybindManager::renameWorkspace(std::string args) {
             int         workspace = std::stoi(args.substr(0, FIRSTSPACEPOS));
             std::string name      = args.substr(FIRSTSPACEPOS + 1);
             g_pCompositor->renameWorkspace(workspace, name);
+            EMIT_HOOK_EVENT("rename", (std::vector<void*>{workspace, name}));
         } else {
             g_pCompositor->renameWorkspace(std::stoi(args), "");
+            EMIT_HOOK_EVENT("rename", (std::vector<void*>{std::stoi(args), ""}));
         }
     } catch (std::exception& e) {
         Debug::log(ERR, "Invalid arg in renameWorkspace, expected numeric id only or a numeric id and string name. \"%s\": \"%s\"", args.c_str(), e.what());

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1427,14 +1427,15 @@ void CKeybindManager::renameWorkspace(std::string args) {
     try {
         const auto FIRSTSPACEPOS = args.find_first_of(' ');
         if (FIRSTSPACEPOS != std::string::npos) {
-            int         workspace = std::stoi(args.substr(0, FIRSTSPACEPOS));
-            std::string name      = args.substr(FIRSTSPACEPOS + 1);
+            int workspace = std::stoi(args.substr(0, FIRSTSPACEPOS));
+            std::string name = args.substr(FIRSTSPACEPOS + 1);
             g_pCompositor->renameWorkspace(workspace, name);
-            EMIT_HOOK_EVENT("rename", (std::vector<void*>{workspace, name}));
         } else {
+            int workspace = std::stoi(args);
+            std::string name = "";
             g_pCompositor->renameWorkspace(std::stoi(args), "");
-            EMIT_HOOK_EVENT("rename", (std::vector<void*>{std::stoi(args), ""}));
         }
+        EMIT_HOOK_EVENT("renameWorkspace", (std::vector<void*>{workspace, name}));
     } catch (std::exception& e) {
         Debug::log(ERR, "Invalid arg in renameWorkspace, expected numeric id only or a numeric id and string name. \"%s\": \"%s\"", args.c_str(), e.what());
     }


### PR DESCRIPTION
This should help dev of new waybar hyprland module https://github.com/Alexays/Waybar/issues/2271

And be able to make it receive and display new name generate by `hyprland-autoname-workspace` since its broke with the removale of wlr workspace api https://github.com/hyprwm/Hyprland/commit/bb0933437f4602080a66cc877fee36dce8dcb3ff.

