### PR TITLE
Fix blur for passes set to 0.

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -975,13 +975,10 @@ CFramebuffer* CHyprOpenGLImpl::blurMainFramebufferWithDamage(float a, CRegion* o
 
     // damage region will be scaled, make a temp
     CRegion tempDamage{damage};
-    wlr_region_scale(tempDamage.pixman(), damage.pixman(), 1.f / 2.f); // when DOWNscaling, we make the region twice as small because it's the TARGET
-
-    drawPass(&m_RenderData.pCurrentMonData->m_shBLUR1, &tempDamage);
 
     // and draw
-    for (int i = 1; i < *PBLURPASSES; ++i) {
-        wlr_region_scale(tempDamage.pixman(), damage.pixman(), 1.f / (1 << (i + 1)));
+    for (int i = 1; i <= *PBLURPASSES; ++i) {
+        wlr_region_scale(tempDamage.pixman(), damage.pixman(), 1.f / (1 << i));
         drawPass(&m_RenderData.pCurrentMonData->m_shBLUR1, &tempDamage); // down
     }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

we can get rid of the first blur pass outside of the loops, 1 << 1 is 2, so if passes is set to anything > 0 the the behaviour wont be changed.
If blur.passes is set to zero and blur is enabled, before this change it did produce a 1/4 size image of the background.
After this change, if passes is zero, no blur is applied, but brightness contrast and noice still work as expected.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I think it's fine


#### Is it ready for merging, or does it need work?

I think it's fine
