### PR TITLE
Improve fallback behavior for unset device config values

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1685,7 +1685,7 @@ SConfigValue CConfigManager::getConfigValueSafe(const std::string& val) {
     return copy;
 }
 
-SConfigValue CConfigManager::getConfigValueSafeDevice(const std::string& dev, const std::string& val) {
+SConfigValue CConfigManager::getConfigValueSafeDevice(const std::string& dev, const std::string& val, const std::string& fallback = "") {
     std::lock_guard<std::mutex> lg(configmtx);
 
     const auto                  it = deviceConfigs.find(dev);
@@ -1695,18 +1695,14 @@ SConfigValue CConfigManager::getConfigValueSafeDevice(const std::string& dev, co
         return SConfigValue();
     }
 
-    return it->second[val];
-}
-
-SConfigValue CConfigManager::getConfigValueSafeDevice(const std::string& dev, const std::string& val, const std::string& fallback) {
-    auto device_config = getConfigValueSafeDevice(dev, val);
+    const SConfigValue deviceConfig = it->second[val];
 
     // fallback if not set explicitly
-    if (!device_config.set) {
+    if (!deviceConfig.set && !fallback.empty()) {
         return configValues[fallback];
     }
 
-    return device_config;
+    return deviceConfig;
 }
 
 int CConfigManager::getInt(const std::string& v) {
@@ -1726,32 +1722,15 @@ std::string CConfigManager::getString(const std::string& v) {
     return VAL;
 }
 
-int CConfigManager::getDeviceInt(const std::string& dev, const std::string& v) {
-    return getConfigValueSafeDevice(dev, v).intValue;
-}
-
-int CConfigManager::getDeviceInt(const std::string& dev, const std::string& v, const std::string& fallback) {
+int CConfigManager::getDeviceInt(const std::string& dev, const std::string& v, const std::string& fallback = "") {
     return getConfigValueSafeDevice(dev, v, fallback).intValue;
 }
 
-float CConfigManager::getDeviceFloat(const std::string& dev, const std::string& v) {
-    return getConfigValueSafeDevice(dev, v).floatValue;
-}
-
-float CConfigManager::getDeviceFloat(const std::string& dev, const std::string& v, const std::string& fallback) {
+float CConfigManager::getDeviceFloat(const std::string& dev, const std::string& v, const std::string& fallback = "") {
     return getConfigValueSafeDevice(dev, v, fallback).floatValue;
 }
 
-std::string CConfigManager::getDeviceString(const std::string& dev, const std::string& v) {
-    auto VAL = getConfigValueSafeDevice(dev, v).strValue;
-
-    if (VAL == STRVAL_EMPTY)
-        return "";
-
-    return VAL;
-}
-
-std::string CConfigManager::getDeviceString(const std::string& dev, const std::string& v, const std::string& fallback) {
+std::string CConfigManager::getDeviceString(const std::string& dev, const std::string& v, const std::string& fallback = "") {
     auto VAL = getConfigValueSafeDevice(dev, v, fallback).strValue;
 
     if (VAL == STRVAL_EMPTY)

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1695,14 +1695,14 @@ SConfigValue CConfigManager::getConfigValueSafeDevice(const std::string& dev, co
         return SConfigValue();
     }
 
-    const SConfigValue deviceConfig = it->second[val];
+    const SConfigValue DEVICECONFIG = it->second[val];
 
     // fallback if not set explicitly
-    if (!deviceConfig.set && !fallback.empty()) {
+    if (!DEVICECONFIG.set && !fallback.empty()) {
         return configValues[fallback];
     }
 
-    return deviceConfig;
+    return DEVICECONFIG;
 }
 
 int CConfigManager::getInt(const std::string& v) {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1685,7 +1685,7 @@ SConfigValue CConfigManager::getConfigValueSafe(const std::string& val) {
     return copy;
 }
 
-SConfigValue CConfigManager::getConfigValueSafeDevice(const std::string& dev, const std::string& val, std::optional<bool> touchpad) {
+SConfigValue CConfigManager::getConfigValueSafeDevice(const std::string& dev, const std::string& val) {
     std::lock_guard<std::mutex> lg(configmtx);
 
     const auto                  it = deviceConfigs.find(dev);
@@ -1695,23 +1695,18 @@ SConfigValue CConfigManager::getConfigValueSafeDevice(const std::string& dev, co
         return SConfigValue();
     }
 
-    SConfigValue copy = it->second[val];
+    return it->second[val];
+}
+
+SConfigValue CConfigManager::getConfigValueSafeDevice(const std::string& dev, const std::string& val, const std::string& fallback) {
+    auto device_config = getConfigValueSafeDevice(dev, val);
 
     // fallback if not set explicitly
-    if (!copy.set) {
-        for (auto& cv : configValues) {
-            auto foundIt = cv.first.find(val);
-            if (foundIt == std::string::npos)
-                continue;
-
-            if (cv.first == "input:" + val || (touchpad.value_or(true) && cv.first == "input:touchpad:" + val) || cv.first == "input:touchdevice:" + val ||
-                cv.first == "input:tablet:" + val || cv.first == "input:tablet:" + val) {
-                copy = cv.second;
-            }
-        }
+    if (!device_config.set) {
+        return configValues[fallback];
     }
 
-    return copy;
+    return device_config;
 }
 
 int CConfigManager::getInt(const std::string& v) {
@@ -1731,16 +1726,33 @@ std::string CConfigManager::getString(const std::string& v) {
     return VAL;
 }
 
-int CConfigManager::getDeviceInt(const std::string& dev, const std::string& v, std::optional<bool> touchpad) {
-    return getConfigValueSafeDevice(dev, v, touchpad).intValue;
+int CConfigManager::getDeviceInt(const std::string& dev, const std::string& v) {
+    return getConfigValueSafeDevice(dev, v).intValue;
 }
 
-float CConfigManager::getDeviceFloat(const std::string& dev, const std::string& v, std::optional<bool> touchpad) {
-    return getConfigValueSafeDevice(dev, v, touchpad).floatValue;
+int CConfigManager::getDeviceInt(const std::string& dev, const std::string& v, const std::string& fallback) {
+    return getConfigValueSafeDevice(dev, v, fallback).intValue;
 }
 
-std::string CConfigManager::getDeviceString(const std::string& dev, const std::string& v, std::optional<bool> touchpad) {
-    auto VAL = getConfigValueSafeDevice(dev, v, touchpad).strValue;
+float CConfigManager::getDeviceFloat(const std::string& dev, const std::string& v) {
+    return getConfigValueSafeDevice(dev, v).floatValue;
+}
+
+float CConfigManager::getDeviceFloat(const std::string& dev, const std::string& v, const std::string& fallback) {
+    return getConfigValueSafeDevice(dev, v, fallback).floatValue;
+}
+
+std::string CConfigManager::getDeviceString(const std::string& dev, const std::string& v) {
+    auto VAL = getConfigValueSafeDevice(dev, v).strValue;
+
+    if (VAL == STRVAL_EMPTY)
+        return "";
+
+    return VAL;
+}
+
+std::string CConfigManager::getDeviceString(const std::string& dev, const std::string& v, const std::string& fallback) {
+    auto VAL = getConfigValueSafeDevice(dev, v, fallback).strValue;
 
     if (VAL == STRVAL_EMPTY)
         return "";

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1685,7 +1685,7 @@ SConfigValue CConfigManager::getConfigValueSafe(const std::string& val) {
     return copy;
 }
 
-SConfigValue CConfigManager::getConfigValueSafeDevice(const std::string& dev, const std::string& val, const std::string& fallback = "") {
+SConfigValue CConfigManager::getConfigValueSafeDevice(const std::string& dev, const std::string& val, const std::string& fallback) {
     std::lock_guard<std::mutex> lg(configmtx);
 
     const auto                  it = deviceConfigs.find(dev);
@@ -1722,15 +1722,15 @@ std::string CConfigManager::getString(const std::string& v) {
     return VAL;
 }
 
-int CConfigManager::getDeviceInt(const std::string& dev, const std::string& v, const std::string& fallback = "") {
+int CConfigManager::getDeviceInt(const std::string& dev, const std::string& v, const std::string& fallback) {
     return getConfigValueSafeDevice(dev, v, fallback).intValue;
 }
 
-float CConfigManager::getDeviceFloat(const std::string& dev, const std::string& v, const std::string& fallback = "") {
+float CConfigManager::getDeviceFloat(const std::string& dev, const std::string& v, const std::string& fallback) {
     return getConfigValueSafeDevice(dev, v, fallback).floatValue;
 }
 
-std::string CConfigManager::getDeviceString(const std::string& dev, const std::string& v, const std::string& fallback = "") {
+std::string CConfigManager::getDeviceString(const std::string& dev, const std::string& v, const std::string& fallback) {
     auto VAL = getConfigValueSafeDevice(dev, v, fallback).strValue;
 
     if (VAL == STRVAL_EMPTY)

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -156,12 +156,9 @@ class CConfigManager {
     void                                                            setInt(const std::string&, int);
     void                                                            setString(const std::string&, const std::string&);
 
-    int                                                             getDeviceInt(const std::string&, const std::string&);
-    int                                                             getDeviceInt(const std::string&, const std::string&, const std::string& fallback);
-    float                                                           getDeviceFloat(const std::string&, const std::string&);
-    float                                                           getDeviceFloat(const std::string&, const std::string&, const std::string& fallback);
-    std::string                                                     getDeviceString(const std::string&, const std::string&);
-    std::string                                                     getDeviceString(const std::string&, const std::string&, const std::string& fallback);
+    int                                                             getDeviceInt(const std::string&, const std::string&, const std::string& fallback = "");
+    float                                                           getDeviceFloat(const std::string&, const std::string&, const std::string& fallback = "");
+    std::string                                                     getDeviceString(const std::string&, const std::string&, const std::string& fallback = "");
     bool                                                            deviceConfigExists(const std::string&);
     bool                                                            shouldBlurLS(const std::string&);
 
@@ -258,8 +255,7 @@ class CConfigManager {
     void         applyUserDefinedVars(std::string&, const size_t);
     void         loadConfigLoadVars();
     SConfigValue getConfigValueSafe(const std::string&);
-    SConfigValue getConfigValueSafeDevice(const std::string&, const std::string&);
-    SConfigValue getConfigValueSafeDevice(const std::string&, const std::string&, const std::string& fallback);
+    SConfigValue getConfigValueSafeDevice(const std::string&, const std::string&, const std::string& fallback = "");
     void         parseLine(std::string&);
     void         configSetValueSafe(const std::string&, const std::string&);
     void         handleDeviceConfig(const std::string&, const std::string&);

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -156,9 +156,12 @@ class CConfigManager {
     void                                                            setInt(const std::string&, int);
     void                                                            setString(const std::string&, const std::string&);
 
-    int                                                             getDeviceInt(const std::string&, const std::string&, std::optional<bool> touchpad = {});
-    float                                                           getDeviceFloat(const std::string&, const std::string&, std::optional<bool> touchpad = {});
-    std::string                                                     getDeviceString(const std::string&, const std::string&, std::optional<bool> touchpad = {});
+    int                                                             getDeviceInt(const std::string&, const std::string&);
+    int                                                             getDeviceInt(const std::string&, const std::string&, const std::string& fallback);
+    float                                                           getDeviceFloat(const std::string&, const std::string&);
+    float                                                           getDeviceFloat(const std::string&, const std::string&, const std::string& fallback);
+    std::string                                                     getDeviceString(const std::string&, const std::string&);
+    std::string                                                     getDeviceString(const std::string&, const std::string&, const std::string& fallback);
     bool                                                            deviceConfigExists(const std::string&);
     bool                                                            shouldBlurLS(const std::string&);
 
@@ -255,7 +258,8 @@ class CConfigManager {
     void         applyUserDefinedVars(std::string&, const size_t);
     void         loadConfigLoadVars();
     SConfigValue getConfigValueSafe(const std::string&);
-    SConfigValue getConfigValueSafeDevice(const std::string&, const std::string&, std::optional<bool> touchpad);
+    SConfigValue getConfigValueSafeDevice(const std::string&, const std::string&);
+    SConfigValue getConfigValueSafeDevice(const std::string&, const std::string&, const std::string& fallback);
     void         parseLine(std::string&);
     void         configSetValueSafe(const std::string&, const std::string&);
     void         handleDeviceConfig(const std::string&, const std::string&);

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1037,9 +1037,11 @@ void CInputManager::setPointerConfigs() {
 
             libinput_device_config_scroll_set_button(LIBINPUTDEV, SCROLLBUTTON == 0 ? libinput_device_config_scroll_get_default_button(LIBINPUTDEV) : SCROLLBUTTON);
 
-            const auto SCROLLBUTTONLOCK = HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "scroll_button_lock", 0) : g_pConfigManager->getInt("input:scroll_button_lock");
+            const auto SCROLLBUTTONLOCK =
+                HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "scroll_button_lock", "input:scroll_button_lock") : g_pConfigManager->getInt("input:scroll_button_lock");
 
-            libinput_device_config_scroll_set_button_lock(LIBINPUTDEV, SCROLLBUTTONLOCK == 0 ? LIBINPUT_CONFIG_SCROLL_BUTTON_LOCK_DISABLED : LIBINPUT_CONFIG_SCROLL_BUTTON_LOCK_ENABLED);
+            libinput_device_config_scroll_set_button_lock(LIBINPUTDEV,
+                                                          SCROLLBUTTONLOCK == 0 ? LIBINPUT_CONFIG_SCROLL_BUTTON_LOCK_DISABLED : LIBINPUT_CONFIG_SCROLL_BUTTON_LOCK_ENABLED);
 
             Debug::log(LOG, "Applied config to mouse {}, sens {:.2f}", m.name.c_str(), LIBINPUTSENS);
         }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1400,8 +1400,9 @@ void CInputManager::setTouchDeviceConfigs(STouchDevice* dev) {
         if (wlr_input_device_is_libinput(PTOUCHDEV->pWlrDevice)) {
             const auto LIBINPUTDEV = (libinput_device*)wlr_libinput_get_device_handle(PTOUCHDEV->pWlrDevice);
 
-            const int  ROTATION = std::clamp(
-                HASCONFIG ? g_pConfigManager->getDeviceInt(PTOUCHDEV->name, "transform", "input:touchdevice") : g_pConfigManager->getInt("input:touchdevice:transform"), 0, 7);
+            const int  ROTATION = std::clamp(HASCONFIG ? g_pConfigManager->getDeviceInt(PTOUCHDEV->name, "transform", "input:touchdevice:transform") :
+                                                         g_pConfigManager->getInt("input:touchdevice:transform"),
+                                            0, 7);
             if (libinput_device_config_calibration_has_matrix(LIBINPUTDEV))
                 libinput_device_config_calibration_set_matrix(LIBINPUTDEV, MATRICES[ROTATION]);
 
@@ -1434,7 +1435,7 @@ void CInputManager::setTabletConfigs() {
             const auto LIBINPUTDEV = (libinput_device*)wlr_libinput_get_device_handle(t.wlrDevice);
 
             const int  ROTATION =
-                std::clamp(HASCONFIG ? g_pConfigManager->getDeviceInt(t.name, "transform", "input:tablet:tranform") : g_pConfigManager->getInt("input:tablet:transform"), 0, 7);
+                std::clamp(HASCONFIG ? g_pConfigManager->getDeviceInt(t.name, "transform", "input:tablet:transform") : g_pConfigManager->getInt("input:tablet:transform"), 0, 7);
             Debug::log(LOG, "Setting calibration matrix for device {}", t.name.c_str());
             libinput_device_config_calibration_set_matrix(LIBINPUTDEV, MATRICES[ROTATION]);
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -750,17 +750,18 @@ void CInputManager::applyConfigToKeyboard(SKeyboard* pKeyboard) {
     if (!wlr_keyboard_from_input_device(pKeyboard->keyboard))
         return;
 
-    const auto REPEATRATE  = HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "repeat_rate") : g_pConfigManager->getInt("input:repeat_rate");
-    const auto REPEATDELAY = HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "repeat_delay") : g_pConfigManager->getInt("input:repeat_delay");
+    const auto REPEATRATE  = HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "repeat_rate", "input:repeat_rate") : g_pConfigManager->getInt("input:repeat_rate");
+    const auto REPEATDELAY = HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "repeat_delay", "input:repeat_delay") : g_pConfigManager->getInt("input:repeat_delay");
 
-    const auto NUMLOCKON = HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "numlock_by_default") : g_pConfigManager->getInt("input:numlock_by_default");
+    const auto NUMLOCKON =
+        HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "numlock_by_default", "input:numlock_by_default") : g_pConfigManager->getInt("input:numlock_by_default");
 
-    const auto FILEPATH = HASCONFIG ? g_pConfigManager->getDeviceString(devname, "kb_file") : g_pConfigManager->getString("input:kb_file");
-    const auto RULES    = HASCONFIG ? g_pConfigManager->getDeviceString(devname, "kb_rules") : g_pConfigManager->getString("input:kb_rules");
-    const auto MODEL    = HASCONFIG ? g_pConfigManager->getDeviceString(devname, "kb_model") : g_pConfigManager->getString("input:kb_model");
-    const auto LAYOUT   = HASCONFIG ? g_pConfigManager->getDeviceString(devname, "kb_layout") : g_pConfigManager->getString("input:kb_layout");
-    const auto VARIANT  = HASCONFIG ? g_pConfigManager->getDeviceString(devname, "kb_variant") : g_pConfigManager->getString("input:kb_variant");
-    const auto OPTIONS  = HASCONFIG ? g_pConfigManager->getDeviceString(devname, "kb_options") : g_pConfigManager->getString("input:kb_options");
+    const auto FILEPATH = HASCONFIG ? g_pConfigManager->getDeviceString(devname, "kb_file", "input:kb_file") : g_pConfigManager->getString("input:kb_file");
+    const auto RULES    = HASCONFIG ? g_pConfigManager->getDeviceString(devname, "kb_rules", "input:kb_rules") : g_pConfigManager->getString("input:kb_rules");
+    const auto MODEL    = HASCONFIG ? g_pConfigManager->getDeviceString(devname, "kb_model", "input:kb_model") : g_pConfigManager->getString("input:kb_model");
+    const auto LAYOUT   = HASCONFIG ? g_pConfigManager->getDeviceString(devname, "kb_layout", "input:kb_layout") : g_pConfigManager->getString("input:kb_layout");
+    const auto VARIANT  = HASCONFIG ? g_pConfigManager->getDeviceString(devname, "kb_variant", "input:kb_variant") : g_pConfigManager->getString("input:kb_variant");
+    const auto OPTIONS  = HASCONFIG ? g_pConfigManager->getDeviceString(devname, "kb_options", "input:kb_options") : g_pConfigManager->getString("input:kb_options");
 
     const auto ENABLED = HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "enabled") : true;
 
@@ -923,26 +924,26 @@ void CInputManager::setPointerConfigs() {
             const auto ISTOUCHPAD = libinput_device_has_capability(LIBINPUTDEV, LIBINPUT_DEVICE_CAP_POINTER) &&
                 libinput_device_get_size(LIBINPUTDEV, &touchw, &touchh) == 0; // pointer with size is a touchpad
 
-            if ((HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "clickfinger_behavior", ISTOUCHPAD) : g_pConfigManager->getInt("input:touchpad:clickfinger_behavior")) ==
-                0) // toggle software buttons or clickfinger
+            if ((HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "clickfinger_behavior", "input:touchpad:clickfinger_behavior") :
+                             g_pConfigManager->getInt("input:touchpad:clickfinger_behavior")) == 0) // toggle software buttons or clickfinger
                 libinput_device_config_click_set_method(LIBINPUTDEV, LIBINPUT_CONFIG_CLICK_METHOD_BUTTON_AREAS);
             else
                 libinput_device_config_click_set_method(LIBINPUTDEV, LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER);
 
-            if ((HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "left_handed", ISTOUCHPAD) : g_pConfigManager->getInt("input:left_handed")) == 0)
+            if ((HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "left_handed", "input:left_handed") : g_pConfigManager->getInt("input:left_handed")) == 0)
                 libinput_device_config_left_handed_set(LIBINPUTDEV, 0);
             else
                 libinput_device_config_left_handed_set(LIBINPUTDEV, 1);
 
             if (libinput_device_config_middle_emulation_is_available(LIBINPUTDEV)) { // middleclick on r+l mouse button pressed
-                if ((HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "middle_button_emulation", ISTOUCHPAD) :
+                if ((HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "middle_button_emulation", "input:touchpad:middle_button_emulation") :
                                  g_pConfigManager->getInt("input:touchpad:middle_button_emulation")) == 1)
                     libinput_device_config_middle_emulation_set_enabled(LIBINPUTDEV, LIBINPUT_CONFIG_MIDDLE_EMULATION_ENABLED);
                 else
                     libinput_device_config_middle_emulation_set_enabled(LIBINPUTDEV, LIBINPUT_CONFIG_MIDDLE_EMULATION_DISABLED);
 
-                const auto TAP_MAP =
-                    HASCONFIG ? g_pConfigManager->getDeviceString(devname, "tap_button_map", ISTOUCHPAD) : g_pConfigManager->getString("input:touchpad:tap_button_map");
+                const auto TAP_MAP = HASCONFIG ? g_pConfigManager->getDeviceString(devname, "tap_button_map", "input:touchpad:tap_button_map") :
+                                                 g_pConfigManager->getString("input:touchpad:tap_button_map");
                 if (TAP_MAP == "" || TAP_MAP == "lrm")
                     libinput_device_config_tap_set_button_map(LIBINPUTDEV, LIBINPUT_CONFIG_TAP_MAP_LRM);
                 else if (TAP_MAP == "lmr")
@@ -951,7 +952,8 @@ void CInputManager::setPointerConfigs() {
                     Debug::log(WARN, "Tap button mapping unknown");
             }
 
-            const auto SCROLLMETHOD = HASCONFIG ? g_pConfigManager->getDeviceString(devname, "scroll_method", ISTOUCHPAD) : g_pConfigManager->getString("input:scroll_method");
+            const auto SCROLLMETHOD =
+                HASCONFIG ? g_pConfigManager->getDeviceString(devname, "scroll_method", "input:scroll_method") : g_pConfigManager->getString("input:scroll_method");
             if (SCROLLMETHOD == "") {
                 libinput_device_config_scroll_set_method(LIBINPUTDEV, libinput_device_config_scroll_get_default_method(LIBINPUTDEV));
             } else if (SCROLLMETHOD == "no_scroll") {
@@ -966,42 +968,47 @@ void CInputManager::setPointerConfigs() {
                 Debug::log(WARN, "Scroll method unknown");
             }
 
-            if ((HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "tap-and-drag", ISTOUCHPAD) : g_pConfigManager->getInt("input:touchpad:tap-and-drag")) == 0)
+            if ((HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "tap-and-drag", "input:touchpad:tap-and-drag") : g_pConfigManager->getInt("input:touchpad:tap-and-drag")) == 0)
                 libinput_device_config_tap_set_drag_enabled(LIBINPUTDEV, LIBINPUT_CONFIG_DRAG_DISABLED);
             else
                 libinput_device_config_tap_set_drag_enabled(LIBINPUTDEV, LIBINPUT_CONFIG_DRAG_ENABLED);
 
-            if ((HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "drag_lock", ISTOUCHPAD) : g_pConfigManager->getInt("input:touchpad:drag_lock")) == 0)
+            if ((HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "drag_lock", "input:touchpad:drag_lock") : g_pConfigManager->getInt("input:touchpad:drag_lock")) == 0)
                 libinput_device_config_tap_set_drag_lock_enabled(LIBINPUTDEV, LIBINPUT_CONFIG_DRAG_LOCK_DISABLED);
             else
                 libinput_device_config_tap_set_drag_lock_enabled(LIBINPUTDEV, LIBINPUT_CONFIG_DRAG_LOCK_ENABLED);
 
             if (libinput_device_config_tap_get_finger_count(LIBINPUTDEV)) // this is for tapping (like on a laptop)
-                if ((HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "tap-to-click", ISTOUCHPAD) : g_pConfigManager->getInt("input:touchpad:tap-to-click")) == 1)
+                if ((HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "tap-to-click", "input:touchpad:tap-to-click") :
+                                 g_pConfigManager->getInt("input:touchpad:tap-to-click")) == 1)
                     libinput_device_config_tap_set_enabled(LIBINPUTDEV, LIBINPUT_CONFIG_TAP_ENABLED);
 
             if (libinput_device_config_scroll_has_natural_scroll(LIBINPUTDEV)) {
 
                 if (ISTOUCHPAD)
-                    libinput_device_config_scroll_set_natural_scroll_enabled(
-                        LIBINPUTDEV,
-                        (HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "natural_scroll", ISTOUCHPAD) : g_pConfigManager->getInt("input:touchpad:natural_scroll")));
+                    libinput_device_config_scroll_set_natural_scroll_enabled(LIBINPUTDEV,
+                                                                             (HASCONFIG ?
+                                                                                  g_pConfigManager->getDeviceInt(devname, "natural_scroll", "input:touchpad:natural_scroll") :
+                                                                                  g_pConfigManager->getInt("input:touchpad:natural_scroll")));
                 else
                     libinput_device_config_scroll_set_natural_scroll_enabled(
-                        LIBINPUTDEV, (HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "natural_scroll", ISTOUCHPAD) : g_pConfigManager->getInt("input:natural_scroll")));
+                        LIBINPUTDEV,
+                        (HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "natural_scroll", "input:natural_scroll") : g_pConfigManager->getInt("input:natural_scroll")));
             }
 
             if (libinput_device_config_dwt_is_available(LIBINPUTDEV)) {
-                const auto DWT = static_cast<enum libinput_config_dwt_state>((HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "disable_while_typing", ISTOUCHPAD) :
-                                                                                          g_pConfigManager->getInt("input:touchpad:disable_while_typing")) != 0);
+                const auto DWT = static_cast<enum libinput_config_dwt_state>(
+                    (HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "disable_while_typing", "input:touchpad:disable_while_typing") :
+                                 g_pConfigManager->getInt("input:touchpad:disable_while_typing")) != 0);
                 libinput_device_config_dwt_set_enabled(LIBINPUTDEV, DWT);
             }
 
-            const auto LIBINPUTSENS =
-                std::clamp((HASCONFIG ? g_pConfigManager->getDeviceFloat(devname, "sensitivity", ISTOUCHPAD) : g_pConfigManager->getFloat("input:sensitivity")), -1.f, 1.f);
+            const auto LIBINPUTSENS = std::clamp(
+                (HASCONFIG ? g_pConfigManager->getDeviceFloat(devname, "sensitivity", "input:sensitivity") : g_pConfigManager->getFloat("input:sensitivity")), -1.f, 1.f);
             libinput_device_config_accel_set_speed(LIBINPUTDEV, LIBINPUTSENS);
 
-            const auto ACCELPROFILE = HASCONFIG ? g_pConfigManager->getDeviceString(devname, "accel_profile", ISTOUCHPAD) : g_pConfigManager->getString("input:accel_profile");
+            const auto ACCELPROFILE =
+                HASCONFIG ? g_pConfigManager->getDeviceString(devname, "accel_profile", "input:accel_profile") : g_pConfigManager->getString("input:accel_profile");
 
             if (ACCELPROFILE == "") {
                 libinput_device_config_accel_set_profile(LIBINPUTDEV, libinput_device_config_accel_get_default_profile(LIBINPUTDEV));
@@ -1026,7 +1033,7 @@ void CInputManager::setPointerConfigs() {
                 Debug::log(WARN, "Unknown acceleration profile, falling back to default");
             }
 
-            const auto SCROLLBUTTON = HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "scroll_button", ISTOUCHPAD) : g_pConfigManager->getInt("input:scroll_button");
+            const auto SCROLLBUTTON = HASCONFIG ? g_pConfigManager->getDeviceInt(devname, "scroll_button", "input:scroll_button") : g_pConfigManager->getInt("input:scroll_button");
 
             libinput_device_config_scroll_set_button(LIBINPUTDEV, SCROLLBUTTON == 0 ? libinput_device_config_scroll_get_default_button(LIBINPUTDEV) : SCROLLBUTTON);
 
@@ -1391,12 +1398,13 @@ void CInputManager::setTouchDeviceConfigs(STouchDevice* dev) {
         if (wlr_input_device_is_libinput(PTOUCHDEV->pWlrDevice)) {
             const auto LIBINPUTDEV = (libinput_device*)wlr_libinput_get_device_handle(PTOUCHDEV->pWlrDevice);
 
-            const int  ROTATION =
-                std::clamp(HASCONFIG ? g_pConfigManager->getDeviceInt(PTOUCHDEV->name, "transform") : g_pConfigManager->getInt("input:touchdevice:transform"), 0, 7);
+            const int  ROTATION = std::clamp(
+                HASCONFIG ? g_pConfigManager->getDeviceInt(PTOUCHDEV->name, "transform", "input:touchdevice") : g_pConfigManager->getInt("input:touchdevice:transform"), 0, 7);
             if (libinput_device_config_calibration_has_matrix(LIBINPUTDEV))
                 libinput_device_config_calibration_set_matrix(LIBINPUTDEV, MATRICES[ROTATION]);
 
-            const auto OUTPUT = HASCONFIG ? g_pConfigManager->getDeviceString(PTOUCHDEV->name, "output") : g_pConfigManager->getString("input:touchdevice:output");
+            const auto OUTPUT =
+                HASCONFIG ? g_pConfigManager->getDeviceString(PTOUCHDEV->name, "output", "input:touchdevice:output") : g_pConfigManager->getString("input:touchdevice:output");
             if (!OUTPUT.empty() && OUTPUT != STRVAL_EMPTY)
                 PTOUCHDEV->boundOutput = OUTPUT;
             else
@@ -1423,11 +1431,12 @@ void CInputManager::setTabletConfigs() {
         if (wlr_input_device_is_libinput(t.wlrDevice)) {
             const auto LIBINPUTDEV = (libinput_device*)wlr_libinput_get_device_handle(t.wlrDevice);
 
-            const int  ROTATION = std::clamp(HASCONFIG ? g_pConfigManager->getDeviceInt(t.name, "transform") : g_pConfigManager->getInt("input:tablet:transform"), 0, 7);
+            const int  ROTATION =
+                std::clamp(HASCONFIG ? g_pConfigManager->getDeviceInt(t.name, "transform", "input:tablet:tranform") : g_pConfigManager->getInt("input:tablet:transform"), 0, 7);
             Debug::log(LOG, "Setting calibration matrix for device {}", t.name.c_str());
             libinput_device_config_calibration_set_matrix(LIBINPUTDEV, MATRICES[ROTATION]);
 
-            const auto OUTPUT   = HASCONFIG ? g_pConfigManager->getDeviceString(t.name, "output") : g_pConfigManager->getString("input:tablet:output");
+            const auto OUTPUT   = HASCONFIG ? g_pConfigManager->getDeviceString(t.name, "output", "input:tablet:output") : g_pConfigManager->getString("input:tablet:output");
             const auto PMONITOR = g_pCompositor->getMonitorFromString(OUTPUT);
             if (!OUTPUT.empty() && OUTPUT != STRVAL_EMPTY && PMONITOR) {
                 wlr_cursor_map_input_to_output(g_pCompositor->m_sWLRCursor, t.wlrDevice, PMONITOR->output);
@@ -1580,7 +1589,7 @@ void CInputManager::setCursorIconOnBorder(CWindow* w) {
     wlr_box              box              = {w->m_vRealPosition.vec().x, w->m_vRealPosition.vec().y, w->m_vRealSize.vec().x, w->m_vRealSize.vec().y};
     eBorderIconDirection direction        = BORDERICON_NONE;
     wlr_box              boxFullGrabInput = {box.x - *PEXTENDBORDERGRAB - BORDERSIZE, box.y - *PEXTENDBORDERGRAB - BORDERSIZE, box.width + 2 * (*PEXTENDBORDERGRAB + BORDERSIZE),
-                                box.height + 2 * (*PEXTENDBORDERGRAB + BORDERSIZE)};
+                                             box.height + 2 * (*PEXTENDBORDERGRAB + BORDERSIZE)};
 
     if (!wlr_box_contains_point(&boxFullGrabInput, mouseCoords.x, mouseCoords.y) || (!m_lCurrentlyHeldButtons.empty() && !currentlyDraggedWindow)) {
         direction = BORDERICON_NONE;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This should improve the fallback process for device specific, unset config values. It replaces the touchpad bool parameter for `getDevice...` functions with an optional fallback configuration key that describes the global configuration key to fall back to if the device specific key is unset. The previous implementation didn't quite work for me, as it would reset `natural_scroll` to disabled even when just enabling/disabling my touchpad. This should also handle conflicts between the fallback configs `input:touchdevice:transform` and `input:tablet:transform` and `input:touchdevice:output` and `input:tablet:output` better as the current implementation has a hardcoded order which prefers `touchdevice:*` keys over `tablet:*` keys, even for tablet devices.

#### Alternative solution

An alternative solution would be to use the same key structure as the normal keys for device config keys. This could improve intuitiveness for users (the keys aren't just the last section and potentially conflicting) and it would make the extra fallback argument unnecessary.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

`CConfigManager::getConfigValueSafeDevice` is overloaded and spreads to `CConfigManager::getDevice...`, so I originally tried to use `std::optional` (I have very little C++ experience). Is there a better way to describe an optional string reference?

#### Is it ready for merging, or does it need work?

If it looks good and the alternative solution is not something to be implemented, it's ready :smiley: .
