### PR TITLE
Groupbar aesthetic

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1741,10 +1741,10 @@ void CCompositor::updateWindowAnimatedDecorationValues(CWindow* pWindow) {
     static auto* const INACTIVECOL            = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("general:col.inactive_border")->data.get();
     static auto* const NOGROUPACTIVECOL       = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("general:col.nogroup_border_active")->data.get();
     static auto* const NOGROUPINACTIVECOL     = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("general:col.nogroup_border")->data.get();
-    static auto* const GROUPINACTIVECOL       = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("group:col.border")->data.get();
     static auto* const GROUPACTIVECOL         = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("group:col.border_active")->data.get();
-    static auto* const GROUPINACTIVELOCKEDCOL = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("group:col.border_locked")->data.get();
+    static auto* const GROUPINACTIVECOL       = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("group:col.border_inactive")->data.get();
     static auto* const GROUPACTIVELOCKEDCOL   = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("group:col.border_locked_active")->data.get();
+    static auto* const GROUPINACTIVELOCKEDCOL = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("group:col.border_locked_inactive")->data.get();
     static auto* const PINACTIVEALPHA         = &g_pConfigManager->getConfigValuePtr("decoration:inactive_opacity")->floatValue;
     static auto* const PACTIVEALPHA           = &g_pConfigManager->getConfigValuePtr("decoration:active_opacity")->floatValue;
     static auto* const PFULLSCREENALPHA       = &g_pConfigManager->getConfigValuePtr("decoration:fullscreen_opacity")->floatValue;

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1741,10 +1741,10 @@ void CCompositor::updateWindowAnimatedDecorationValues(CWindow* pWindow) {
     static auto* const INACTIVECOL            = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("general:col.inactive_border")->data.get();
     static auto* const NOGROUPACTIVECOL       = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("general:col.nogroup_border_active")->data.get();
     static auto* const NOGROUPINACTIVECOL     = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("general:col.nogroup_border")->data.get();
-    static auto* const GROUPACTIVECOL         = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("general:col.group_border_active")->data.get();
-    static auto* const GROUPINACTIVECOL       = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("general:col.group_border")->data.get();
-    static auto* const GROUPACTIVELOCKEDCOL   = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("general:col.group_border_locked_active")->data.get();
-    static auto* const GROUPINACTIVELOCKEDCOL = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("general:col.group_border_locked")->data.get();
+    static auto* const GROUPINACTIVECOL       = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("group:col.border")->data.get();
+    static auto* const GROUPACTIVECOL         = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("group:col.border_active")->data.get();
+    static auto* const GROUPINACTIVELOCKEDCOL = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("group:col.border_locked")->data.get();
+    static auto* const GROUPACTIVELOCKEDCOL   = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("group:col.border_locked_active")->data.get();
     static auto* const PINACTIVEALPHA         = &g_pConfigManager->getConfigValuePtr("decoration:inactive_opacity")->floatValue;
     static auto* const PACTIVEALPHA           = &g_pConfigManager->getConfigValuePtr("decoration:active_opacity")->floatValue;
     static auto* const PFULLSCREENALPHA       = &g_pConfigManager->getConfigValuePtr("decoration:fullscreen_opacity")->floatValue;

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -813,6 +813,24 @@ CWindow* CCompositor::windowFloatingFromCursor() {
     return nullptr;
 }
 
+CWindow* CCompositor::windowFloatingFromCursorIgnore(CWindow* pWindow) {
+    for (auto& w : m_vWindows | std::views::reverse) {
+        wlr_box box = w->getWindowInputBox();
+        if (wlr_box_contains_point(&box, m_sWLRCursor->x, m_sWLRCursor->y) && w->m_bIsMapped && w->m_bIsFloating && !w->isHidden() && w->m_bPinned && !w->m_bNoFocus &&
+            w.get() != pWindow)
+            return w.get();
+    }
+
+    for (auto& w : m_vWindows | std::views::reverse) {
+        wlr_box box = w->getWindowInputBox();
+        if (wlr_box_contains_point(&box, m_sWLRCursor->x, m_sWLRCursor->y) && w->m_bIsMapped && w->m_bIsFloating && isWorkspaceVisible(w->m_iWorkspaceID) && !w->isHidden() &&
+            !w->m_bPinned && !w->m_bNoFocus && w.get() != pWindow)
+            return w.get();
+    }
+
+    return nullptr;
+}
+
 wlr_surface* CCompositor::vectorWindowToSurface(const Vector2D& pos, CWindow* pWindow, Vector2D& sl) {
 
     if (!windowValidMapped(pWindow))

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -29,8 +29,7 @@
 #include "plugins/PluginSystem.hpp"
 #include "helpers/Watchdog.hpp"
 
-enum eManagersInitStage
-{
+enum eManagersInitStage {
     STAGE_PRIORITY = 0,
     STAGE_LATE
 };
@@ -145,6 +144,7 @@ class CCompositor {
     Vector2D       vectorToSurfaceLocal(const Vector2D&, CWindow*, wlr_surface*);
     CWindow*       windowFromCursor();
     CWindow*       windowFloatingFromCursor();
+    CWindow*       windowFloatingFromCursorIgnore(CWindow*);
     CMonitor*      getMonitorFromOutput(wlr_output*);
     CWindow*       getWindowForPopup(wlr_xdg_popup*);
     CWindow*       getWindowFromSurface(wlr_surface*);

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -204,6 +204,27 @@ void CWindow::updateWindowDecos() {
         }
     }
 
+    // reset extents
+    m_seReservedInternal.topLeft     = Vector2D();
+    m_seReservedInternal.bottomRight = Vector2D();
+    m_seReservedExternal.topLeft     = Vector2D();
+    m_seReservedExternal.bottomRight = Vector2D();
+
+    for (auto& wd : m_dWindowDecorations) {
+        const auto RESERVED = wd->getWindowDecorationReservedArea();
+        if (RESERVED.isInternalDecoration) {
+            m_seReservedInternal.topLeft.x     = std::max(m_seReservedInternal.topLeft.x, RESERVED.topLeft.x);
+            m_seReservedInternal.topLeft.y     = std::max(m_seReservedInternal.topLeft.y, RESERVED.topLeft.y);
+            m_seReservedInternal.bottomRight.x = std::max(m_seReservedInternal.bottomRight.x, RESERVED.bottomRight.x);
+            m_seReservedInternal.bottomRight.y = std::max(m_seReservedInternal.bottomRight.y, RESERVED.bottomRight.y);
+        } else {
+            m_seReservedExternal.topLeft.x     = std::max(m_seReservedExternal.topLeft.x, RESERVED.topLeft.x);
+            m_seReservedExternal.topLeft.y     = std::max(m_seReservedExternal.topLeft.y, RESERVED.topLeft.y);
+            m_seReservedExternal.bottomRight.x = std::max(m_seReservedExternal.bottomRight.x, RESERVED.bottomRight.x);
+            m_seReservedExternal.bottomRight.y = std::max(m_seReservedExternal.bottomRight.y, RESERVED.bottomRight.y);
+        }
+    }
+
     if (recalc)
         g_pLayoutManager->getCurrentLayout()->recalculateWindow(this);
 

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -622,7 +622,7 @@ void CWindow::updateDynamicRules() {
 // it is assumed that the point is within the real window box (m_vRealPosition, m_vRealSize)
 // otherwise behaviour is undefined
 bool CWindow::isInCurvedCorner(double x, double y) {
-    const int ROUNDING = rounding();
+    const int ROUNDING = getRealRounding();
     if (getRealBorderSize() >= ROUNDING)
         return false;
 
@@ -919,14 +919,6 @@ bool CWindow::opaque() {
     return false;
 }
 
-float CWindow::rounding() {
-    static auto* const PROUNDING = &g_pConfigManager->getConfigValuePtr("decoration:rounding")->intValue;
-
-    float              rounding = m_sAdditionalConfigData.rounding.toUnderlying() == -1 ? *PROUNDING : m_sAdditionalConfigData.rounding.toUnderlying();
-
-    return rounding;
-}
-
 void CWindow::updateSpecialRenderData() {
     const auto PWORKSPACE    = g_pCompositor->getWorkspaceByID(m_iWorkspaceID);
     const auto WORKSPACERULE = PWORKSPACE ? g_pConfigManager->getWorkspaceRuleFor(PWORKSPACE) : SWorkspaceRule{};
@@ -940,6 +932,17 @@ void CWindow::updateSpecialRenderData() {
     m_sSpecialRenderData.decorate   = WORKSPACERULE.decorate.value_or(true);
     m_sSpecialRenderData.rounding   = WORKSPACERULE.rounding.value_or(true);
     m_sSpecialRenderData.shadow     = WORKSPACERULE.shadow.value_or(true);
+}
+
+int CWindow::getRealRounding() {
+
+    if (!m_sSpecialRenderData.rounding)
+        return 0;
+
+    if (m_sAdditionalConfigData.rounding.toUnderlying() != -1)
+        return m_sAdditionalConfigData.rounding.toUnderlying();
+
+    return g_pConfigManager->getConfigValuePtr("decoration:rounding")->intValue;
 }
 
 int CWindow::getRealBorderSize() {

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -930,10 +930,14 @@ int CWindow::getRealRounding() {
     if (!m_sSpecialRenderData.rounding)
         return 0;
 
-    if (m_sAdditionalConfigData.rounding.toUnderlying() != -1)
-        return m_sAdditionalConfigData.rounding.toUnderlying();
+    int rounding;
 
-    return g_pConfigManager->getConfigValuePtr("decoration:rounding")->intValue;
+    if (m_sAdditionalConfigData.rounding.toUnderlying() != -1)
+        rounding = m_sAdditionalConfigData.rounding.toUnderlying();
+    else
+        rounding = g_pConfigManager->getConfigValuePtr("decoration:rounding")->intValue;
+
+    return std::min(rounding, (int)std::min(m_vRealSize.vec().x, m_vRealSize.vec().y) / 2);
 }
 
 int CWindow::getRealBorderSize() {

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -285,6 +285,10 @@ class CWindow {
     std::deque<std::unique_ptr<IHyprWindowDecoration>> m_dWindowDecorations;
     std::vector<IHyprWindowDecoration*>                m_vDecosToRemove;
 
+    // Window decorations internal and external reserved area
+    SWindowDecorationExtents m_seReservedInternal;
+    SWindowDecorationExtents m_seReservedExternal;
+
     // Special render data, rules, etc
     SWindowSpecialRenderData    m_sSpecialRenderData;
     SWindowAdditionalConfigData m_sAdditionalConfigData;

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -356,10 +356,10 @@ class CWindow {
     SWindowDecorationExtents getFullWindowReservedArea();
     Vector2D                 middle();
     bool                     opaque();
-    float                    rounding();
     bool                     canBeTorn();
 
     int                      getRealBorderSize();
+    int                      getRealRounding();
     void                     updateSpecialRenderData();
 
     void                     onBorderAngleAnimEnd(void* ptr);

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -286,8 +286,10 @@ class CWindow {
     std::vector<IHyprWindowDecoration*>                m_vDecosToRemove;
 
     // Window decorations internal and external reserved area
-    SWindowDecorationExtents m_seReservedInternal;
-    SWindowDecorationExtents m_seReservedExternal;
+    CAnimatedVariable m_vReservedInternalTopLeft;
+    CAnimatedVariable m_vReservedInternalBottomRight;
+    CAnimatedVariable m_vReservedExternalTopLeft;
+    CAnimatedVariable m_vReservedExternalBottomRight;
 
     // Special render data, rules, etc
     SWindowSpecialRenderData    m_sSpecialRenderData;

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -337,6 +337,7 @@ class CWindow {
     SWindowDecorationExtents getFullWindowExtents();
     wlr_box                  getWindowInputBox();
     wlr_box                  getWindowIdealBoundingBoxIgnoreReserved();
+    wlr_box                  getWindowInternalBox();
     void                     updateWindowDecos();
     pid_t                    getPID();
     IHyprWindowDecoration*   getDecorationByType(eDecorationType);

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -124,8 +124,8 @@ void CConfigManager::setDefaultVars() {
     ((CGradientValueData*)configValues["group:col.border_inactive"].data.get())->reset(0x66777700);
     ((CGradientValueData*)configValues["group:col.border_locked_active"].data.get())->reset(0x66ff5500);
     ((CGradientValueData*)configValues["group:col.border_locked_inactive"].data.get())->reset(0x66775500);
-    configValues["group:insert_after_current"].intValue     = 1;
-    configValues["group:focus_removed_window"].intValue     = 1;
+    configValues["group:insert_after_current"].intValue = 1;
+    configValues["group:focus_removed_window"].intValue = 1;
 
     configValues["group:groupbar:enabled"].intValue          = 1;
     configValues["group:groupbar:font"].strValue             = "Sans";
@@ -1653,7 +1653,7 @@ void CConfigManager::loadConfigLoadVars() {
         w->updateSpecialRenderData();
 
         for (auto& wd : w->m_dWindowDecorations)
-            wd->forceReload(w.get());
+            wd->forceReload();
         g_pLayoutManager->getCurrentLayout()->recalculateWindow(w.get());
     }
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -128,7 +128,7 @@ void CConfigManager::setDefaultVars() {
 
     configValues["group:groupbar:font"].strValue             = "Sans";
     configValues["group:groupbar:height"].intValue           = 20;
-    configValues["group:groupbar:gradients"].intValue        = 1;
+    configValues["group:groupbar:mode"].intValue             = 1;
     configValues["group:groupbar:render_titles"].intValue    = 1;
     configValues["group:groupbar:scrolling"].intValue        = 1;
     configValues["group:groupbar:text_color"].intValue       = 0xffffffff;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -130,6 +130,7 @@ void CConfigManager::setDefaultVars() {
     configValues["group:groupbar:enabled"].intValue          = 1;
     configValues["group:groupbar:font"].strValue             = "Sans";
     configValues["group:groupbar:height"].intValue           = 20;
+    configValues["group:groupbar:max_width"].intValue        = 0;
     configValues["group:groupbar:mode"].intValue             = 1;
     configValues["group:groupbar:internal_bar"].intValue     = 1;
     configValues["group:groupbar:render_titles"].intValue    = 1;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -28,6 +28,7 @@ CConfigManager::CConfigManager() {
     configValues["group:groupbar:col.inactive"].data        = std::make_shared<CGradientValueData>(0x66777700);
     configValues["group:groupbar:col.locked_active"].data   = std::make_shared<CGradientValueData>(0x66ff5500);
     configValues["group:groupbar:col.locked_inactive"].data = std::make_shared<CGradientValueData>(0x66775500);
+    configValues["group:groupbar:col.background"].data      = std::make_shared<CGradientValueData>(0x66202000);
 
     setDefaultVars();
     setDefaultAnimationVars();
@@ -129,6 +130,7 @@ void CConfigManager::setDefaultVars() {
     configValues["group:groupbar:font"].strValue             = "Sans";
     configValues["group:groupbar:height"].intValue           = 20;
     configValues["group:groupbar:mode"].intValue             = 1;
+    configValues["group:groupbar:internal_border"].intValue  = 1;
     configValues["group:groupbar:render_titles"].intValue    = 1;
     configValues["group:groupbar:scrolling"].intValue        = 1;
     configValues["group:groupbar:text_color"].intValue       = 0xffffffff;
@@ -1651,6 +1653,10 @@ void CConfigManager::loadConfigLoadVars() {
         for (auto& wd : w->m_dWindowDecorations)
             wd->forceReload(w.get());
     }
+
+    // TODO: hack needed for decorations, fix later
+    for (auto& m : g_pCompositor->m_vMonitors)
+        g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m->ID);
 
     // Update window border colors
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -122,6 +122,7 @@ void CConfigManager::setDefaultVars() {
     configValues["group:focus_removed_window"].intValue = 1;
 
     configValues["group:groupbar:font"].strValue             = "Sans";
+    configValues["group:groupbar:height"].intValue           = 20;
     configValues["group:groupbar:gradients"].intValue        = 1;
     configValues["group:groupbar:render_titles"].intValue    = 1;
     configValues["group:groupbar:scrolling"].intValue        = 1;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1650,13 +1650,11 @@ void CConfigManager::loadConfigLoadVars() {
 
         w->updateDynamicRules();
         w->updateSpecialRenderData();
+
         for (auto& wd : w->m_dWindowDecorations)
             wd->forceReload(w.get());
+        g_pLayoutManager->getCurrentLayout()->recalculateWindow(w.get());
     }
-
-    // TODO: hack needed for decorations, fix later
-    for (auto& m : g_pCompositor->m_vMonitors)
-        g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m->ID);
 
     // Update window border colors
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -130,7 +130,7 @@ void CConfigManager::setDefaultVars() {
     configValues["group:groupbar:font"].strValue             = "Sans";
     configValues["group:groupbar:height"].intValue           = 20;
     configValues["group:groupbar:mode"].intValue             = 1;
-    configValues["group:groupbar:internal_border"].intValue  = 1;
+    configValues["group:groupbar:internal_bar"].intValue     = 1;
     configValues["group:groupbar:render_titles"].intValue    = 1;
     configValues["group:groupbar:scrolling"].intValue        = 1;
     configValues["group:groupbar:text_color"].intValue       = 0xffffffff;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1648,6 +1648,8 @@ void CConfigManager::loadConfigLoadVars() {
 
         w->updateDynamicRules();
         w->updateSpecialRenderData();
+        for (auto& wd : w->m_dWindowDecorations)
+            wd->forceReload(w.get());
     }
 
     // Update window border colors

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -126,6 +126,7 @@ void CConfigManager::setDefaultVars() {
     configValues["group:groupbar:scrolling"].intValue        = 1;
     configValues["group:groupbar:text_color"].intValue       = 0xffffffff;
     configValues["group:groupbar:titles_font_size"].intValue = 8;
+    configValues["group:groupbar:top"].intValue              = 1;
 
     configValues["debug:int"].intValue                = 0;
     configValues["debug:log_damage"].intValue         = 0;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -121,6 +121,7 @@ void CConfigManager::setDefaultVars() {
     configValues["group:insert_after_current"].intValue = 1;
     configValues["group:focus_removed_window"].intValue = 1;
 
+    configValues["group:groupbar:font"].strValue             = "Sans";
     configValues["group:groupbar:gradients"].intValue        = 1;
     configValues["group:groupbar:render_titles"].intValue    = 1;
     configValues["group:groupbar:scrolling"].intValue        = 1;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -19,10 +19,15 @@ CConfigManager::CConfigManager() {
     configValues["general:col.inactive_border"].data       = std::make_shared<CGradientValueData>(0xff444444);
     configValues["general:col.nogroup_border"].data        = std::make_shared<CGradientValueData>(0xffffaaff);
     configValues["general:col.nogroup_border_active"].data = std::make_shared<CGradientValueData>(0xffff00ff);
-    configValues["group:col.border"].data                  = std::make_shared<CGradientValueData>(0x66777700);
     configValues["group:col.border_active"].data           = std::make_shared<CGradientValueData>(0x66ffff00);
-    configValues["group:col.border_locked"].data           = std::make_shared<CGradientValueData>(0x66775500);
+    configValues["group:col.border_inactive"].data         = std::make_shared<CGradientValueData>(0x66777700);
     configValues["group:col.border_locked_active"].data    = std::make_shared<CGradientValueData>(0x66ff5500);
+    configValues["group:col.border_locked_inactive"].data  = std::make_shared<CGradientValueData>(0x66775500);
+
+    configValues["group:groupbar:col.active"].data          = std::make_shared<CGradientValueData>(0x66ffff00);
+    configValues["group:groupbar:col.inactive"].data        = std::make_shared<CGradientValueData>(0x66777700);
+    configValues["group:groupbar:col.locked_active"].data   = std::make_shared<CGradientValueData>(0x66ff5500);
+    configValues["group:groupbar:col.locked_inactive"].data = std::make_shared<CGradientValueData>(0x66775500);
 
     setDefaultVars();
     setDefaultAnimationVars();
@@ -114,12 +119,12 @@ void CConfigManager::setDefaultVars() {
     configValues["misc:background_color"].intValue                 = 0xff111111;
     configValues["misc:new_window_takes_over_fullscreen"].intValue = 0;
 
-    ((CGradientValueData*)configValues["group:col.border"].data.get())->reset(0x66777700);
     ((CGradientValueData*)configValues["group:col.border_active"].data.get())->reset(0x66ffff00);
-    ((CGradientValueData*)configValues["group:col.border_locked"].data.get())->reset(0x66775500);
+    ((CGradientValueData*)configValues["group:col.border_inactive"].data.get())->reset(0x66777700);
     ((CGradientValueData*)configValues["group:col.border_locked_active"].data.get())->reset(0x66ff5500);
-    configValues["group:insert_after_current"].intValue = 1;
-    configValues["group:focus_removed_window"].intValue = 1;
+    ((CGradientValueData*)configValues["group:col.border_locked_inactive"].data.get())->reset(0x66775500);
+    configValues["group:insert_after_current"].intValue     = 1;
+    configValues["group:focus_removed_window"].intValue     = 1;
 
     configValues["group:groupbar:font"].strValue             = "Sans";
     configValues["group:groupbar:height"].intValue           = 20;
@@ -129,6 +134,10 @@ void CConfigManager::setDefaultVars() {
     configValues["group:groupbar:text_color"].intValue       = 0xffffffff;
     configValues["group:groupbar:titles_font_size"].intValue = 8;
     configValues["group:groupbar:top"].intValue              = 1;
+    ((CGradientValueData*)configValues["group:groupbar:col.active"].data.get())->reset(0x66ffff00);
+    ((CGradientValueData*)configValues["group:groupbar:col.inactive"].data.get())->reset(0x66777700);
+    ((CGradientValueData*)configValues["group:groupbar:col.locked_active"].data.get())->reset(0x66ff5500);
+    ((CGradientValueData*)configValues["group:groupbar:col.locked_inactive"].data.get())->reset(0x66775500);
 
     configValues["debug:int"].intValue                = 0;
     configValues["debug:log_damage"].intValue         = 0;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -127,6 +127,7 @@ void CConfigManager::setDefaultVars() {
     configValues["group:insert_after_current"].intValue     = 1;
     configValues["group:focus_removed_window"].intValue     = 1;
 
+    configValues["group:groupbar:enabled"].intValue          = 1;
     configValues["group:groupbar:font"].strValue             = "Sans";
     configValues["group:groupbar:height"].intValue           = 20;
     configValues["group:groupbar:mode"].intValue             = 1;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -15,14 +15,14 @@
 extern "C" char** environ;
 
 CConfigManager::CConfigManager() {
-    configValues["general:col.active_border"].data              = std::make_shared<CGradientValueData>(0xffffffff);
-    configValues["general:col.inactive_border"].data            = std::make_shared<CGradientValueData>(0xff444444);
-    configValues["general:col.nogroup_border"].data             = std::make_shared<CGradientValueData>(0xffffaaff);
-    configValues["general:col.nogroup_border_active"].data      = std::make_shared<CGradientValueData>(0xffff00ff);
-    configValues["general:col.group_border"].data               = std::make_shared<CGradientValueData>(0x66777700);
-    configValues["general:col.group_border_active"].data        = std::make_shared<CGradientValueData>(0x66ffff00);
-    configValues["general:col.group_border_locked"].data        = std::make_shared<CGradientValueData>(0x66775500);
-    configValues["general:col.group_border_locked_active"].data = std::make_shared<CGradientValueData>(0x66ff5500);
+    configValues["general:col.active_border"].data         = std::make_shared<CGradientValueData>(0xffffffff);
+    configValues["general:col.inactive_border"].data       = std::make_shared<CGradientValueData>(0xff444444);
+    configValues["general:col.nogroup_border"].data        = std::make_shared<CGradientValueData>(0xffffaaff);
+    configValues["general:col.nogroup_border_active"].data = std::make_shared<CGradientValueData>(0xffff00ff);
+    configValues["group:col.border"].data                  = std::make_shared<CGradientValueData>(0x66777700);
+    configValues["group:col.border_active"].data           = std::make_shared<CGradientValueData>(0x66ffff00);
+    configValues["group:col.border_locked"].data           = std::make_shared<CGradientValueData>(0x66775500);
+    configValues["group:col.border_locked_active"].data    = std::make_shared<CGradientValueData>(0x66ff5500);
 
     setDefaultVars();
     setDefaultAnimationVars();
@@ -76,10 +76,6 @@ void CConfigManager::setDefaultVars() {
     ((CGradientValueData*)configValues["general:col.inactive_border"].data.get())->reset(0xff444444);
     ((CGradientValueData*)configValues["general:col.nogroup_border"].data.get())->reset(0xff444444);
     ((CGradientValueData*)configValues["general:col.nogroup_border_active"].data.get())->reset(0xffff00ff);
-    ((CGradientValueData*)configValues["general:col.group_border"].data.get())->reset(0x66777700);
-    ((CGradientValueData*)configValues["general:col.group_border_active"].data.get())->reset(0x66ffff00);
-    ((CGradientValueData*)configValues["general:col.group_border_locked"].data.get())->reset(0x66775500);
-    ((CGradientValueData*)configValues["general:col.group_border_locked_active"].data.get())->reset(0x66ff5500);
     configValues["general:cursor_inactive_timeout"].intValue = 0;
     configValues["general:no_cursor_warps"].intValue         = 0;
     configValues["general:no_focus_fallback"].intValue       = 0;
@@ -114,16 +110,22 @@ void CConfigManager::setDefaultVars() {
     configValues["misc:cursor_zoom_factor"].floatValue             = 1.f;
     configValues["misc:cursor_zoom_rigid"].intValue                = 0;
     configValues["misc:allow_session_lock_restore"].intValue       = 0;
-    configValues["misc:groupbar_scrolling"].intValue               = 1;
-    configValues["misc:group_insert_after_current"].intValue       = 1;
-    configValues["misc:group_focus_removed_window"].intValue       = 1;
-    configValues["misc:render_titles_in_groupbar"].intValue        = 1;
-    configValues["misc:groupbar_titles_font_size"].intValue        = 8;
-    configValues["misc:groupbar_gradients"].intValue               = 1;
     configValues["misc:close_special_on_empty"].intValue           = 1;
-    configValues["misc:groupbar_text_color"].intValue              = 0xffffffff;
     configValues["misc:background_color"].intValue                 = 0xff111111;
     configValues["misc:new_window_takes_over_fullscreen"].intValue = 0;
+
+    ((CGradientValueData*)configValues["group:col.border"].data.get())->reset(0x66777700);
+    ((CGradientValueData*)configValues["group:col.border_active"].data.get())->reset(0x66ffff00);
+    ((CGradientValueData*)configValues["group:col.border_locked"].data.get())->reset(0x66775500);
+    ((CGradientValueData*)configValues["group:col.border_locked_active"].data.get())->reset(0x66ff5500);
+    configValues["group:insert_after_current"].intValue = 1;
+    configValues["group:focus_removed_window"].intValue = 1;
+
+    configValues["group:groupbar:gradients"].intValue        = 1;
+    configValues["group:groupbar:render_titles"].intValue    = 1;
+    configValues["group:groupbar:scrolling"].intValue        = 1;
+    configValues["group:groupbar:text_color"].intValue       = 0xffffffff;
+    configValues["group:groupbar:titles_font_size"].intValue = 8;
 
     configValues["debug:int"].intValue                = 0;
     configValues["debug:log_damage"].intValue         = 0;

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -148,22 +148,16 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
         PWINDOW->m_sSpecialRenderData.rounding = false;
         PWINDOW->m_sSpecialRenderData.shadow   = false;
 
-        const auto RESERVED = PWINDOW->getFullWindowReservedArea();
-
-        const int  BORDERSIZE = PWINDOW->getRealBorderSize();
-
-        PWINDOW->m_vRealPosition = PWINDOW->m_vPosition + Vector2D(BORDERSIZE, BORDERSIZE) + RESERVED.topLeft;
-        PWINDOW->m_vRealSize     = PWINDOW->m_vSize - Vector2D(2 * BORDERSIZE, 2 * BORDERSIZE) - (RESERVED.topLeft + RESERVED.bottomRight);
+        PWINDOW->m_vRealPosition = PWINDOW->m_vPosition + PWINDOW->m_seReservedInternal.topLeft + PWINDOW->m_seReservedExternal.topLeft;
+        PWINDOW->m_vRealSize     = PWINDOW->m_vSize - (PWINDOW->m_seReservedInternal.topLeft + PWINDOW->m_seReservedInternal.bottomRight) - (PWINDOW->m_seReservedExternal.topLeft + PWINDOW->m_seReservedExternal.bottomRight);
 
         PWINDOW->updateWindowDecos();
 
         return;
     }
 
-    const int  BORDERSIZE = PWINDOW->getRealBorderSize();
-
-    auto       calcPos  = PWINDOW->m_vPosition + Vector2D(BORDERSIZE, BORDERSIZE);
-    auto       calcSize = PWINDOW->m_vSize - Vector2D(2 * BORDERSIZE, 2 * BORDERSIZE);
+    auto       calcPos  = PWINDOW->m_vPosition;
+    auto       calcSize = PWINDOW->m_vSize;
 
     const auto OFFSETTOPLEFT = Vector2D(DISPLAYLEFT ? gapsOut : gapsIn, DISPLAYTOP ? gapsOut : gapsIn);
 

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -148,9 +148,9 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
         PWINDOW->m_sSpecialRenderData.rounding = false;
         PWINDOW->m_sSpecialRenderData.shadow   = false;
 
-        PWINDOW->m_vRealPosition = PWINDOW->m_vPosition + PWINDOW->m_seReservedInternal.topLeft + PWINDOW->m_seReservedExternal.topLeft;
-        PWINDOW->m_vRealSize     = PWINDOW->m_vSize - (PWINDOW->m_seReservedInternal.topLeft + PWINDOW->m_seReservedInternal.bottomRight) -
-            (PWINDOW->m_seReservedExternal.topLeft + PWINDOW->m_seReservedExternal.bottomRight);
+        PWINDOW->m_vRealPosition = PWINDOW->m_vPosition + PWINDOW->m_vReservedInternalTopLeft.goalv() + PWINDOW->m_vReservedExternalTopLeft.goalv();
+        PWINDOW->m_vRealSize     = PWINDOW->m_vSize - (PWINDOW->m_vReservedInternalTopLeft.goalv() + PWINDOW->m_vReservedInternalBottomRight.goalv()) -
+            (PWINDOW->m_vReservedExternalTopLeft.goalv() + PWINDOW->m_vReservedExternalBottomRight.goalv());
 
         PWINDOW->updateWindowDecos();
 

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -260,7 +260,12 @@ void IHyprLayout::onEndDragWindow() {
         g_pInputManager->refocus();
         changeWindowFloatingMode(DRAGGINGWINDOW);
         DRAGGINGWINDOW->m_vLastFloatingSize = m_vDraggingWindowOriginalFloatSize;
-    } else if (g_pInputManager->dragMode == MBIND_MOVE) {
+    }
+
+    g_pHyprRenderer->damageWindow(DRAGGINGWINDOW);
+    g_pCompositor->focusWindow(DRAGGINGWINDOW);
+
+    if (g_pInputManager->dragMode == MBIND_MOVE && DRAGGINGWINDOW->m_bIsFloating) {
         CWindow* pWindow = g_pCompositor->windowFloatingFromCursorIgnore(DRAGGINGWINDOW);
         g_pHyprRenderer->damageWindow(DRAGGINGWINDOW);
 
@@ -293,12 +298,8 @@ void IHyprLayout::onEndDragWindow() {
             recalculateWindow(DRAGGINGWINDOW);
 
             g_pCompositor->focusWindow(DRAGGINGWINDOW);
-            return;
         }
     }
-
-    g_pHyprRenderer->damageWindow(DRAGGINGWINDOW);
-    g_pCompositor->focusWindow(DRAGGINGWINDOW);
 }
 
 void IHyprLayout::onMouseMove(const Vector2D& mousePos) {

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -624,22 +624,16 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
         PWINDOW->m_sSpecialRenderData.rounding = false;
         PWINDOW->m_sSpecialRenderData.shadow   = false;
 
-        const auto RESERVED = PWINDOW->getFullWindowReservedArea();
-
-        const int  BORDERSIZE = PWINDOW->getRealBorderSize();
-
-        PWINDOW->m_vRealPosition = PWINDOW->m_vPosition + Vector2D(BORDERSIZE, BORDERSIZE) + RESERVED.topLeft;
-        PWINDOW->m_vRealSize     = PWINDOW->m_vSize - Vector2D(2 * BORDERSIZE, 2 * BORDERSIZE) - (RESERVED.topLeft + RESERVED.bottomRight);
+        PWINDOW->m_vRealPosition = PWINDOW->m_vPosition + PWINDOW->m_seReservedInternal.topLeft + PWINDOW->m_seReservedExternal.topLeft;
+        PWINDOW->m_vRealSize = PWINDOW->m_vSize - (PWINDOW->m_seReservedInternal.topLeft + PWINDOW->m_seReservedInternal.bottomRight) - (PWINDOW->m_seReservedExternal.topLeft + PWINDOW->m_seReservedExternal.bottomRight);
 
         PWINDOW->updateWindowDecos();
 
         return;
     }
 
-    const int  BORDERSIZE = PWINDOW->getRealBorderSize();
-
-    auto       calcPos  = PWINDOW->m_vPosition + Vector2D(BORDERSIZE, BORDERSIZE);
-    auto       calcSize = PWINDOW->m_vSize - Vector2D(2 * BORDERSIZE, 2 * BORDERSIZE);
+    auto       calcPos  = PWINDOW->m_vPosition;
+    auto       calcSize = PWINDOW->m_vSize;
 
     const auto OFFSETTOPLEFT = Vector2D(DISPLAYLEFT ? gapsOut : gapsIn, DISPLAYTOP ? gapsOut : gapsIn);
 

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -630,9 +630,9 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
         PWINDOW->m_sSpecialRenderData.rounding = false;
         PWINDOW->m_sSpecialRenderData.shadow   = false;
 
-        PWINDOW->m_vRealPosition = PWINDOW->m_vPosition + PWINDOW->m_seReservedInternal.topLeft + PWINDOW->m_seReservedExternal.topLeft;
-        PWINDOW->m_vRealSize     = PWINDOW->m_vSize - (PWINDOW->m_seReservedInternal.topLeft + PWINDOW->m_seReservedInternal.bottomRight) -
-            (PWINDOW->m_seReservedExternal.topLeft + PWINDOW->m_seReservedExternal.bottomRight);
+        PWINDOW->m_vRealPosition = PWINDOW->m_vPosition + PWINDOW->m_vReservedInternalTopLeft.goalv() + PWINDOW->m_vReservedExternalTopLeft.goalv();
+        PWINDOW->m_vRealSize     = PWINDOW->m_vSize - (PWINDOW->m_vReservedInternalTopLeft.goalv() + PWINDOW->m_vReservedInternalBottomRight.goalv()) -
+            (PWINDOW->m_vReservedExternalTopLeft.goalv() + PWINDOW->m_vReservedExternalBottomRight.goalv());
 
         PWINDOW->updateWindowDecos();
 

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -109,16 +109,21 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection direc
 
         m_lMasterNodesData.remove(*PNODE);
 
-        const wlr_box box = OPENINGON->pWindow->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationRegion().getExtents();
-        if (wlr_box_contains_point(&box, MOUSECOORDS.x, MOUSECOORDS.y)) { // TODO: Deny when not using mouse
-            const int SIZE               = OPENINGON->pWindow->getGroupSize();
-            const int INDEX              = (int)((MOUSECOORDS.x - box.x) * 2 * SIZE / box.width + 1) / 2 - 1;
-            CWindow*  pWindowInsertAfter = OPENINGON->pWindow->getGroupWindowByIndex(INDEX);
-            pWindowInsertAfter->insertWindowToGroup(pWindow);
-            if (INDEX == -1)
-                std::swap(pWindow->m_sGroupData.pNextWindow->m_sGroupData.head, pWindow->m_sGroupData.head);
-        } else {
-            static const auto* USECURRPOS = &g_pConfigManager->getConfigValuePtr("misc:group_insert_after_current")->intValue;
+        bool handled = true;
+
+        for (auto& wd : OPENINGON->pWindow->m_dWindowDecorations) {
+            if (!wd->allowsInput())
+                continue;
+
+            if (wd->getWindowDecorationRegion().containsPoint(MOUSECOORDS)) {
+                wd->dragWindowToDecoration(pWindow, MOUSECOORDS);
+                handled = false;
+                break;
+            }
+        }
+
+        if (handled) {
+            static const auto* USECURRPOS = &g_pConfigManager->getConfigValuePtr("group:insert_after_current")->intValue;
             (*USECURRPOS ? OPENINGON->pWindow : OPENINGON->pWindow->getGroupTail())->insertWindowToGroup(pWindow);
         }
 
@@ -127,6 +132,7 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection direc
         pWindow->updateWindowDecos();
         recalculateWindow(pWindow);
 
+        g_pCompositor->focusWindow(pWindow);
         return;
     }
 
@@ -625,7 +631,8 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
         PWINDOW->m_sSpecialRenderData.shadow   = false;
 
         PWINDOW->m_vRealPosition = PWINDOW->m_vPosition + PWINDOW->m_seReservedInternal.topLeft + PWINDOW->m_seReservedExternal.topLeft;
-        PWINDOW->m_vRealSize = PWINDOW->m_vSize - (PWINDOW->m_seReservedInternal.topLeft + PWINDOW->m_seReservedInternal.bottomRight) - (PWINDOW->m_seReservedExternal.topLeft + PWINDOW->m_seReservedExternal.bottomRight);
+        PWINDOW->m_vRealSize     = PWINDOW->m_vSize - (PWINDOW->m_seReservedInternal.topLeft + PWINDOW->m_seReservedInternal.bottomRight) -
+            (PWINDOW->m_seReservedExternal.topLeft + PWINDOW->m_seReservedExternal.bottomRight);
 
         PWINDOW->updateWindowDecos();
 

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -247,11 +247,9 @@ void CAnimationManager::tick() {
                 const auto         PDECO = PWINDOW->getDecorationByType(DECORATION_SHADOW);
 
                 if (PDECO) {
-                    const auto EXTENTS = PDECO->getWindowDecorationExtents();
-
-                    wlr_box    dmg = {PWINDOW->m_vRealPosition.vec().x - EXTENTS.topLeft.x, PWINDOW->m_vRealPosition.vec().y - EXTENTS.topLeft.y,
-                                   PWINDOW->m_vRealSize.vec().x + EXTENTS.topLeft.x + EXTENTS.bottomRight.x,
-                                   PWINDOW->m_vRealSize.vec().y + EXTENTS.topLeft.y + EXTENTS.bottomRight.y};
+                    auto    EXTENTS = PDECO->getWindowDecorationExtents();
+                    wlr_box dmg     = PWINDOW->getWindowInternalBox();
+                    addExtentsToBox(&dmg, &EXTENTS);
 
                     if (!*PSHADOWIGNOREWINDOW) {
                         // easy, damage the entire box

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1975,8 +1975,7 @@ void CKeybindManager::moveWindowIntoGroup(CWindow* pWindow, CWindow* pWindowInDi
 }
 
 void CKeybindManager::moveWindowOutOfGroup(CWindow* pWindow, const std::string& dir) {
-
-    static auto* const BFOCUSREMOVEDWINDOW = &g_pConfigManager->getConfigValuePtr("misc:group_focus_removed_window")->intValue;
+    static auto* const BFOCUSREMOVEDWINDOW = &g_pConfigManager->getConfigValuePtr("group:focus_removed_window")->intValue;
     const auto         PWINDOWPREV         = pWindow->getGroupPrevious();
     eDirection         direction;
 
@@ -2037,6 +2036,20 @@ void CKeybindManager::moveIntoGroup(std::string args) {
         return;
 
     moveWindowIntoGroup(PWINDOW, PWINDOWINDIR);
+
+    if (!PWINDOW->m_sGroupData.pNextWindow)
+        PWINDOW->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(PWINDOW));
+
+    g_pLayoutManager->getCurrentLayout()->onWindowRemoved(PWINDOW); // This removes groupped property!
+
+    static const auto* USECURRPOS = &g_pConfigManager->getConfigValuePtr("group:insert_after_current")->intValue;
+    PWINDOWINDIR                  = *USECURRPOS ? PWINDOWINDIR : PWINDOWINDIR->getGroupTail();
+
+    PWINDOWINDIR->insertWindowToGroup(PWINDOW);
+    PWINDOWINDIR->setGroupCurrent(PWINDOW);
+    PWINDOW->updateWindowDecos();
+    g_pLayoutManager->getCurrentLayout()->recalculateWindow(PWINDOW);
+    g_pCompositor->focusWindow(PWINDOW);
 }
 
 void CKeybindManager::moveOutOfGroup(std::string args) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1831,25 +1831,22 @@ void CKeybindManager::mouse(std::string args) {
             const auto mouseCoords = g_pInputManager->getMouseCoordsInternal();
             CWindow*   pWindow     = g_pCompositor->vectorToWindowIdeal(mouseCoords);
 
-            if (pWindow && !pWindow->m_bIsFullscreen && !pWindow->hasPopupAt(mouseCoords) && pWindow->m_sGroupData.pNextWindow) {
-                const wlr_box box = pWindow->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationRegion().getExtents();
-                if (wlr_box_contains_point(&box, mouseCoords.x, mouseCoords.y)) {
-                    const int SIZE = pWindow->getGroupSize();
-                    pWindow        = pWindow->getGroupWindowByIndex((mouseCoords.x - box.x) * SIZE / box.width);
+            if (pWindow && !pWindow->m_bIsFullscreen && !pWindow->hasPopupAt(mouseCoords)) {
+                for (auto& wd : pWindow->m_dWindowDecorations) {
+                    if (!wd->allowsInput())
+                        continue;
 
-                    // hack
-                    g_pLayoutManager->getCurrentLayout()->onWindowRemoved(pWindow);
-                    if (!pWindow->m_bIsFloating) {
-                        const bool GROUPSLOCKEDPREV        = g_pKeybindManager->m_bGroupsLocked;
-                        g_pKeybindManager->m_bGroupsLocked = true;
-                        g_pLayoutManager->getCurrentLayout()->onWindowCreated(pWindow);
-                        g_pKeybindManager->m_bGroupsLocked = GROUPSLOCKEDPREV;
+                    if (wd->getWindowDecorationRegion().containsPoint(mouseCoords)) {
+                        wd->dragFromDecoration(mouseCoords);
+                        break;
                     }
                 }
             }
 
-            g_pInputManager->currentlyDraggedWindow = pWindow;
-            g_pInputManager->dragMode               = MBIND_MOVE;
+            if (g_pInputManager->currentlyDraggedWindow == nullptr)
+                g_pInputManager->currentlyDraggedWindow = pWindow;
+
+            g_pInputManager->dragMode = MBIND_MOVE;
             g_pLayoutManager->getCurrentLayout()->onBeginDragWindow();
         } else {
             g_pKeybindManager->m_bIsMouseBindActive = false;

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -621,7 +621,7 @@ void CInputManager::processMouseDownKill(wlr_pointer_button_event* e) {
 
 void CInputManager::onMouseWheel(wlr_pointer_axis_event* e) {
     static auto* const PSCROLLFACTOR      = &g_pConfigManager->getConfigValuePtr("input:touchpad:scroll_factor")->floatValue;
-    static auto* const PGROUPBARSCROLLING = &g_pConfigManager->getConfigValuePtr("misc:groupbar_scrolling")->intValue;
+    static auto* const PGROUPBARSCROLLING = &g_pConfigManager->getConfigValuePtr("group:groupbar:scrolling")->intValue;
 
     auto               factor = (*PSCROLLFACTOR <= 0.f || e->source != WLR_AXIS_SOURCE_FINGER ? 1.f : *PSCROLLFACTOR);
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -540,16 +540,16 @@ void CInputManager::processMouseDownNormal(wlr_pointer_button_event* e) {
     const auto mouseCoords = g_pInputManager->getMouseCoordsInternal();
     const auto w           = g_pCompositor->vectorToWindowIdeal(mouseCoords);
 
-    if (w && !w->m_bIsFullscreen && !w->hasPopupAt(mouseCoords) && w->m_sGroupData.pNextWindow) {
-        const wlr_box box = w->getDecorationByType(DECORATION_GROUPBAR)->getWindowDecorationRegion().getExtents();
-        if (wlr_box_contains_point(&box, mouseCoords.x, mouseCoords.y)) {
-            if (e->state == WLR_BUTTON_PRESSED) {
-                const int SIZE    = w->getGroupSize();
-                CWindow*  pWindow = w->getGroupWindowByIndex((mouseCoords.x - box.x) * SIZE / box.width);
-                if (w != pWindow)
-                    w->setGroupCurrent(pWindow);
+    if (w && !w->m_bIsFullscreen && !w->hasPopupAt(mouseCoords)) {
+        for (auto& wd : w->m_dWindowDecorations) {
+            if (!wd->allowsInput())
+                continue;
+
+            if (wd->getWindowDecorationRegion().containsPoint(mouseCoords)) {
+                if (e->state == WLR_BUTTON_PRESSED)
+                    wd->clickDecoration(mouseCoords);
+                return;
             }
-            return;
         }
     }
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -412,10 +412,10 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
             wlr_box borderBox;
 
             if (!pWindow->m_bIsFullscreen || PWORKSPACE->m_efFullscreenMode != FULLSCREEN_FULL)
-                borderBox = {renderdata.x - pMonitor->vecPosition.x - pWindow->m_seReservedInternal.topLeft.x,
-                             renderdata.y - pMonitor->vecPosition.y - pWindow->m_seReservedInternal.topLeft.y,
-                             renderdata.w + pWindow->m_seReservedInternal.topLeft.x + pWindow->m_seReservedInternal.bottomRight.x,
-                             renderdata.h + pWindow->m_seReservedInternal.topLeft.y + pWindow->m_seReservedInternal.bottomRight.y};
+                borderBox = {renderdata.x - pMonitor->vecPosition.x - pWindow->m_vReservedInternalTopLeft.goalv().x,
+                             renderdata.y - pMonitor->vecPosition.y - pWindow->m_vReservedInternalTopLeft.goalv().y,
+                             renderdata.w + pWindow->m_vReservedInternalTopLeft.goalv().x + pWindow->m_vReservedInternalBottomRight.goalv().x,
+                             renderdata.h + pWindow->m_vReservedInternalTopLeft.goalv().y + pWindow->m_vReservedInternalBottomRight.goalv().y};
             else
                 borderBox = windowBox;
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -329,11 +329,11 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
     renderdata.surface   = pWindow->m_pWLSurface.wlr();
     renderdata.w         = std::max(pWindow->m_vRealSize.vec().x, 5.0); // clamp the size to min 5,
     renderdata.h         = std::max(pWindow->m_vRealSize.vec().y, 5.0); // otherwise we'll have issues later with invalid boxes
-    renderdata.dontRound = (pWindow->m_bIsFullscreen && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL) || (!pWindow->m_sSpecialRenderData.rounding);
+    renderdata.dontRound = (pWindow->m_bIsFullscreen && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL);
     renderdata.fadeAlpha = pWindow->m_fAlpha.fl() * (pWindow->m_bPinned ? 1.f : PWORKSPACE->m_fAlpha.fl());
     renderdata.alpha     = pWindow->m_fActiveInactiveAlpha.fl();
     renderdata.decorate  = decorate && !pWindow->m_bX11DoesntWantBorders && (!pWindow->m_bIsFullscreen || PWORKSPACE->m_efFullscreenMode != FULLSCREEN_FULL);
-    renderdata.rounding  = ignoreAllGeometry || renderdata.dontRound ? 0 : pWindow->rounding() * pMonitor->scale;
+    renderdata.rounding  = ignoreAllGeometry || renderdata.dontRound ? 0 : pWindow->getRealRounding() * pMonitor->scale;
     renderdata.blur      = !ignoreAllGeometry; // if it shouldn't, it will be ignored later
     renderdata.pWindow   = pWindow;
 
@@ -1991,7 +1991,7 @@ void CHyprRenderer::setOccludedForBackLayers(CRegion& region, CWorkspace* pWorks
         if (!w->opaque())
             continue;
 
-        const auto     ROUNDING = w->rounding() * PMONITOR->scale;
+        const auto     ROUNDING = w->getRealRounding() * PMONITOR->scale;
         const Vector2D POS      = w->m_vRealPosition.vec() + Vector2D{ROUNDING, ROUNDING} - PMONITOR->vecPosition + (w->m_bPinned ? Vector2D{} : pWorkspace->m_vRenderOffset.vec());
         const Vector2D SIZE     = w->m_vRealSize.vec() - Vector2D{ROUNDING * 2, ROUNDING * 2};
 

--- a/src/render/Texture.hpp
+++ b/src/render/Texture.hpp
@@ -2,8 +2,7 @@
 
 #include "../defines.hpp"
 
-enum TEXTURETYPE
-{
+enum TEXTURETYPE {
     TEXTURE_INVALID,  // Invalid
     TEXTURE_RGBA,     // 4 channels
     TEXTURE_RGBX,     // discard A

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -148,7 +148,7 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D
             return; // prevent assert failed
         }
 
-        g_pHyprOpenGL->renderRect(&windowBox, CColor(0, 0, 0, 0), (ROUNDING + BORDERSIZE) * pMonitor->scale);
+        g_pHyprOpenGL->renderRect(&windowBox, CColor(0, 0, 0, 0), ROUNDING == 0 ? 0 : (ROUNDING + BORDERSIZE) * pMonitor->scale);
 
         glStencilFunc(GL_NOTEQUAL, 1, -1);
         glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -77,11 +77,12 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D
     if (*PSHADOWS != 1)
         return; // disabled
 
-    const auto ROUNDING   = m_pWindow->getRealRounding();
-    const auto BORDERSIZE = m_pWindow->getRealBorderSize();
+    const auto               ROUNDING   = m_pWindow->getRealRounding();
+    const auto               BORDERSIZE = m_pWindow->getRealBorderSize();
 
-    wlr_box    windowBox = {m_vLastWindowPos.x, m_vLastWindowPos.y, m_vLastWindowSize.x, m_vLastWindowSize.y};
-    addExtentsToBox(&windowBox, &m_pWindow->m_seReservedInternal);
+    wlr_box                  windowBox            = {m_vLastWindowPos.x, m_vLastWindowPos.y, m_vLastWindowSize.x, m_vLastWindowSize.y};
+    SWindowDecorationExtents m_seReservedInternal = {m_pWindow->m_vReservedInternalTopLeft.goalv(), m_pWindow->m_vReservedInternalBottomRight.goalv()};
+    addExtentsToBox(&windowBox, &m_seReservedInternal);
 
     windowBox.x -= pMonitor->vecPosition.x + BORDERSIZE;
     windowBox.y -= pMonitor->vecPosition.y + BORDERSIZE;

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -97,7 +97,6 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D
     fullBox.width          = NEWSIZE.x;
     fullBox.height         = NEWSIZE.y;
 
-    // either was broken or it is now
     if (PSHADOWOFFSET->x < 0) {
         fullBox.x += PSHADOWOFFSET->x;
     } else if (PSHADOWOFFSET->x > 0) {

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -114,12 +114,9 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D
         fullBox.y += ((windowBox.height + 2.0 * *PSHADOWSIZE) - NEWSIZE.y) / 2.0;
     }
 
-    //m_seExtents = {{m_vLastWindowPos.x - fullBox.x - pMonitor->vecPosition.x + 2, m_vLastWindowPos.y - fullBox.y - pMonitor->vecPosition.y + 2},
-    //               {fullBox.x + fullBox.width + pMonitor->vecPosition.x - m_vLastWindowPos.x - m_vLastWindowSize.x + 2,
-    //                fullBox.y + fullBox.height + pMonitor->vecPosition.y - m_vLastWindowPos.y - m_vLastWindowSize.y + 2}};
-
-    m_seExtents.topLeft        = {*PSHADOWSIZE, *PSHADOWSIZE};
-    m_seExtents.bottomRight    = {*PSHADOWSIZE, *PSHADOWSIZE};
+    m_seExtents.topLeft        = {std::max(0, windowBox.x - fullBox.x), std::max(0, windowBox.y - fullBox.y)};
+    m_seExtents.bottomRight    = {std::max(0, (fullBox.x + fullBox.width) - (windowBox.x + windowBox.width)),
+                                  std::max(0, (fullBox.y + fullBox.height) - (windowBox.y + windowBox.height))};
     m_seExtents.isReservedArea = false;
 
     fullBox.x += offset.x;

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -101,14 +101,14 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
         return;
 
     // Bottom left of groupbar
-    Vector2D pos = Vector2D(m_vLastWindowPos.x - pMonitor->vecPosition.x + offset.x + ROUNDING,
-                            std::floor(m_vLastWindowPos.y) - pMonitor->vecPosition.y + offset.y +
-                                (m_bOnTop ? (m_bInternalBorder ? 0 : -BORDERSIZE) :
-                                            std::floor(m_vLastWindowSize.y) + m_iBarInternalHeight + BAR_INTERNAL_PADDING + (m_bInternalBorder ? 0 : BORDERSIZE)));
+    Vector2D pos = Vector2D(
+        m_vLastWindowPos.x - pMonitor->vecPosition.x + offset.x + ROUNDING,
+        std::floor(m_vLastWindowPos.y) - pMonitor->vecPosition.y + offset.y +
+            (m_bOnTop ? (m_bInternalBar ? 0 : -BORDERSIZE) : std::floor(m_vLastWindowSize.y) + m_iBarInternalHeight + BAR_INTERNAL_PADDING + (m_bInternalBar ? 0 : BORDERSIZE)));
 
-    wlr_box  barBox  = {pos.x, pos.y - m_iBarHeight + (m_bOnTop ? -BAR_INTERNAL_PADDING : 0), BARW, m_iBarHeight};
-    wlr_box  gradBox = {pos.x, pos.y - m_iBarHeight + (m_bOnTop ? -2 * BAR_INTERNAL_PADDING : -BAR_INTERNAL_PADDING) - m_iGradientHeight, BARW, m_iGradientHeight};
-    wlr_box  textBox = m_iGradientHeight != 0 ? gradBox : barBox;
+    wlr_box barBox  = {pos.x, pos.y - m_iBarHeight + (m_bOnTop ? -BAR_INTERNAL_PADDING : 0), BARW, m_iBarHeight};
+    wlr_box gradBox = {pos.x, pos.y - m_iBarHeight + (m_bOnTop ? -2 * BAR_INTERNAL_PADDING : -BAR_INTERNAL_PADDING) - m_iGradientHeight, BARW, m_iGradientHeight};
+    wlr_box textBox = m_iGradientHeight != 0 ? gradBox : barBox;
     textBox.y += BAR_TEXT_PAD;
     textBox.height -= 2 * BAR_TEXT_PAD;
 
@@ -116,7 +116,7 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
     scaleBox(&textBox, pMonitor->scale);
     scaleBox(&gradBox, pMonitor->scale);
 
-    if (m_bInternalBorder) {
+    if (m_bInternalBar) {
         float alpha     = m_pWindow->m_fAlpha.fl() * (m_pWindow->m_bPinned ? 1.f : PWORKSPACE->m_fAlpha.fl()) * m_pWindow->m_fActiveInactiveAlpha.fl();
         auto  color     = ((CGradientValueData*)PGROUPCOLBACKGROUND->get())->m_vColors[0];
         color           = CColor(color.r, color.g, color.b, alpha);
@@ -339,22 +339,22 @@ void CHyprGroupBarDecoration::refreshGradients() {
 }
 
 void CHyprGroupBarDecoration::forceReload(CWindow* pWindow) {
-    static auto* const PENABLED        = &g_pConfigManager->getConfigValuePtr("group:groupbar:enabled")->intValue;
-    static auto* const PMODE           = &g_pConfigManager->getConfigValuePtr("group:groupbar:mode")->intValue;
-    static auto* const PHEIGHT         = &g_pConfigManager->getConfigValuePtr("group:groupbar:height")->intValue;
-    static auto* const PINTERNALBORDER = &g_pConfigManager->getConfigValuePtr("group:groupbar:internal_bar")->intValue;
+    static auto* const PENABLED     = &g_pConfigManager->getConfigValuePtr("group:groupbar:enabled")->intValue;
+    static auto* const PMODE        = &g_pConfigManager->getConfigValuePtr("group:groupbar:mode")->intValue;
+    static auto* const PHEIGHT      = &g_pConfigManager->getConfigValuePtr("group:groupbar:height")->intValue;
+    static auto* const PINTERNALBAR = &g_pConfigManager->getConfigValuePtr("group:groupbar:internal_bar")->intValue;
 
     m_bEnabled           = *PENABLED;
     m_iBarInternalHeight = *PHEIGHT + (*PMODE == 1 ? BAR_INDICATOR_HEIGHT + BAR_INTERNAL_PADDING : 0);
     m_iBarFullHeight     = m_iBarInternalHeight + BAR_INTERNAL_PADDING + BAR_EXTERNAL_PADDING;
 
-    m_bOnTop          = g_pConfigManager->getConfigValuePtr("group:groupbar:top")->intValue;
-    m_bInternalBorder = *PINTERNALBORDER;
+    m_bOnTop       = g_pConfigManager->getConfigValuePtr("group:groupbar:top")->intValue;
+    m_bInternalBar = *PINTERNALBAR;
 
     if (m_bEnabled) {
         m_seExtents.topLeft              = Vector2D(0, m_bOnTop ? m_iBarFullHeight : 0);
         m_seExtents.bottomRight          = Vector2D(0, m_bOnTop ? 0 : m_iBarFullHeight);
-        m_seExtents.isInternalDecoration = *PINTERNALBORDER;
+        m_seExtents.isInternalDecoration = *PINTERNALBAR;
     } else {
         m_seExtents.topLeft     = Vector2D(0, 0);
         m_seExtents.bottomRight = Vector2D(0, 0);
@@ -371,8 +371,8 @@ CRegion CHyprGroupBarDecoration::getWindowDecorationRegion() {
     const int BORDERSIZE = m_pWindow->getRealBorderSize();
     return CRegion(m_vLastWindowPos.x + ROUNDING,
                    m_vLastWindowPos.y +
-                       (m_bOnTop ? -BAR_INTERNAL_PADDING - m_iBarInternalHeight - (m_bInternalBorder ? 0 : BORDERSIZE) :
-                                   m_vLastWindowSize.y + BAR_INTERNAL_PADDING + (m_bInternalBorder ? 0 : BORDERSIZE)),
+                       (m_bOnTop ? -BAR_INTERNAL_PADDING - m_iBarInternalHeight - (m_bInternalBar ? 0 : BORDERSIZE) :
+                                   m_vLastWindowSize.y + BAR_INTERNAL_PADDING + (m_bInternalBar ? 0 : BORDERSIZE)),
                    m_vLastWindowSize.x - 2 * ROUNDING, m_iBarInternalHeight);
 }
 

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -90,11 +90,13 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
     const auto* const  PCOLINACTIVE = GROUPLOCKED ? PGROUPCOLINACTIVELOCKED : PGROUPCOLINACTIVE;
 
     // TODO: fix mouse event with rounding
-    const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(m_pWindow->m_iWorkspaceID);
-    const int  ROUNDING   = m_pWindow->getRealRounding();
-    const int  BORDERSIZE = m_pWindow->getRealBorderSize();
+    const auto  PWORKSPACE = g_pCompositor->getWorkspaceByID(m_pWindow->m_iWorkspaceID);
+    const int   ROUNDING   = m_pWindow->getRealRounding();
+    const int   BORDERSIZE = m_pWindow->getRealBorderSize();
 
-    const int  BARW = (m_vLastWindowSize.x - 2 * ROUNDING - BAR_HORIZONTAL_PADDING * (barsToDraw + (m_bInternalBar ? 1 : -1))) / barsToDraw;
+    const float BARW = (m_vLastWindowSize.x - 2 * ROUNDING - BAR_HORIZONTAL_PADDING * (barsToDraw + (m_bInternalBar ? 1 : -1))) / barsToDraw;
+
+    float       currentOffset = m_bInternalBar ? BAR_HORIZONTAL_PADDING : 0;
 
     //  TODO: check for invalid config
     if (BARW <= 0)
@@ -106,9 +108,8 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
         std::floor(m_vLastWindowPos.y) - pMonitor->vecPosition.y + offset.y +
             (m_bOnTop ? (m_bInternalBar ? 0 : -BORDERSIZE) : std::floor(m_vLastWindowSize.y) + m_iBarInternalHeight + BAR_INTERNAL_PADDING + (m_bInternalBar ? 0 : BORDERSIZE)));
 
-    wlr_box barBox  = {pos.x + (m_bInternalBar ? BAR_HORIZONTAL_PADDING : 0), pos.y - m_iBarHeight + (m_bOnTop ? -BAR_INTERNAL_PADDING : 0), BARW, m_iBarHeight};
-    wlr_box gradBox = {pos.x + (m_bInternalBar ? BAR_HORIZONTAL_PADDING : 0),
-                       pos.y - m_iBarHeight + (m_bOnTop ? -2 * BAR_INTERNAL_PADDING : -BAR_INTERNAL_PADDING) - m_iGradientHeight, BARW, m_iGradientHeight};
+    wlr_box barBox  = {pos.x, pos.y - m_iBarHeight + (m_bOnTop ? -BAR_INTERNAL_PADDING : 0), BARW, m_iBarHeight};
+    wlr_box gradBox = {pos.x, pos.y - m_iBarHeight + (m_bOnTop ? -2 * BAR_INTERNAL_PADDING : -BAR_INTERNAL_PADDING) - m_iGradientHeight, BARW, m_iGradientHeight};
     wlr_box textBox = m_iGradientHeight != 0 ? gradBox : barBox;
     textBox.y += BAR_TEXT_PAD;
     textBox.height -= 2 * BAR_TEXT_PAD;
@@ -164,6 +165,10 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
 
     for (int i = 0; i < barsToDraw; ++i) {
 
+        barBox.x  = pos.x + currentOffset;
+        gradBox.x = pos.x + currentOffset;
+        textBox.x = pos.x + currentOffset;
+
         CColor color =
             m_dwGroupMembers[i] == g_pCompositor->m_pLastWindow ? ((CGradientValueData*)PCOLACTIVE->get())->m_vColors[0] : ((CGradientValueData*)PCOLINACTIVE->get())->m_vColors[0];
         color.a *= a;
@@ -186,9 +191,7 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
                                          &gradBox, 1.0);
         }
 
-        barBox.x += (BAR_HORIZONTAL_PADDING + BARW) * pMonitor->scale;
-        gradBox.x += (BAR_HORIZONTAL_PADDING + BARW) * pMonitor->scale;
-        textBox.x += (BAR_HORIZONTAL_PADDING + BARW) * pMonitor->scale;
+        currentOffset += (float) (BAR_HORIZONTAL_PADDING + BARW) * pMonitor->scale;
     }
 
     if (*PRENDERTITLES)

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -91,7 +91,7 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
 
     // TODO: fix mouse event with rounding
     const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(m_pWindow->m_iWorkspaceID);
-    const int  ROUNDING   = !m_pWindow->m_sSpecialRenderData.rounding ? 0 : m_pWindow->rounding();
+    const int  ROUNDING   = m_pWindow->getRealRounding();
     const int  BORDERSIZE = m_pWindow->getRealBorderSize();
 
     const int  BARW = (m_vLastWindowSize.x - 2 * ROUNDING - BAR_HORIZONTAL_PADDING * (barsToDraw - 1)) / barsToDraw;
@@ -364,7 +364,7 @@ void CHyprGroupBarDecoration::forceReload(CWindow* pWindow) {
 }
 
 CRegion CHyprGroupBarDecoration::getWindowDecorationRegion() {
-    const int ROUNDING   = !m_pWindow->m_sSpecialRenderData.rounding ? 0 : m_pWindow->rounding();
+    const int ROUNDING   = m_pWindow->getRealRounding();
     const int BORDERSIZE = m_pWindow->getRealBorderSize();
     return CRegion(m_vLastWindowPos.x + ROUNDING,
                    m_vLastWindowPos.y +

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -345,7 +345,7 @@ void CHyprGroupBarDecoration::refreshGradients() {
 void CHyprGroupBarDecoration::forceReload(CWindow* pWindow) {
     static auto* const PMODE           = &g_pConfigManager->getConfigValuePtr("group:groupbar:mode")->intValue;
     static auto* const PHEIGHT         = &g_pConfigManager->getConfigValuePtr("group:groupbar:height")->intValue;
-    static auto* const PINTERNALBORDER = &g_pConfigManager->getConfigValuePtr("group:groupbar:internal_border")->intValue;
+    static auto* const PINTERNALBORDER = &g_pConfigManager->getConfigValuePtr("group:groupbar:internal_bar")->intValue;
 
     m_iBarInternalHeight = *PHEIGHT + (*PMODE == 1 ? BAR_INDICATOR_HEIGHT + BAR_INTERNAL_PADDING : 0);
     m_iBarFullHeight     = m_iBarInternalHeight + BAR_INTERNAL_PADDING + BAR_EXTERNAL_PADDING;

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -102,15 +102,20 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
     const auto* const  PCOLACTIVE   = GROUPLOCKED ? PGROUPCOLACTIVELOCKED : PGROUPCOLACTIVE;
     const auto* const  PCOLINACTIVE = GROUPLOCKED ? PGROUPCOLINACTIVELOCKED : PGROUPCOLINACTIVE;
 
-    const int          PAD  = 2; //2px
-    const int          BARW = (m_vLastWindowSize.x - PAD * (barsToDraw - 1)) / barsToDraw;
+    // TODO: fix mouse event with rounding
+    const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(m_pWindow->m_iWorkspaceID);
+    const int  ROUNDING =
+        (m_pWindow->m_bIsFullscreen && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL) || (!m_pWindow->m_sSpecialRenderData.rounding) ? 0 : m_pWindow->rounding();
+
+    const int PAD  = 2; //2px
+    const int BARW = (m_vLastWindowSize.x - 2 * ROUNDING - PAD * (barsToDraw - 1)) / barsToDraw;
 
     //  TODO: check for invalid config
     if (BARW <= 0)
         return;
 
     // Bottom left of groupbar
-    Vector2D pos = Vector2D(m_vLastWindowPos.x - pMonitor->vecPosition.x + offset.x,
+    Vector2D pos = Vector2D(m_vLastWindowPos.x - pMonitor->vecPosition.x + offset.x + ROUNDING,
                             m_vLastWindowPos.y - pMonitor->vecPosition.y + offset.y +
                                 (*PLOCATIONTOP ? -BORDERSIZE : m_vLastWindowSize.y + BORDERSIZE + getBarHeight() + BAR_INTERNAL_PADDING));
 

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -12,6 +12,8 @@ static CTexture m_tGradientLockedInactive;
 CHyprGroupBarDecoration::CHyprGroupBarDecoration(CWindow* pWindow) : IHyprWindowDecoration(pWindow) {
     m_pWindow = pWindow;
     loadConfig();
+    if (m_tGradientActive.m_iTexID == 0)
+        refreshGradients();
 }
 
 CHyprGroupBarDecoration::~CHyprGroupBarDecoration() {}

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -315,6 +315,8 @@ int CHyprGroupBarDecoration::getBarHeight() {
 void CHyprGroupBarDecoration::forceReload(CWindow* pWindow) {
     m_tGradientActive.destroyTexture();
     m_tGradientInactive.destroyTexture();
+    m_tGradientLockedActive.destroyTexture();
+    m_tGradientLockedInactive.destroyTexture();
     updateWindow(pWindow);
 }
 

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -148,7 +148,8 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
             glStencilFunc(GL_NOTEQUAL, 1, -1);
             glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
 
-            g_pHyprOpenGL->renderRect(&backBox, color, ROUNDING * pMonitor->scale);
+            if (backBox.width > 0 && backBox.height > 0)
+                g_pHyprOpenGL->renderRect(&backBox, color, ROUNDING * pMonitor->scale);
 
             // cleanup stencil
             glClearStencil(0);
@@ -156,9 +157,8 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
             glDisable(GL_STENCIL_TEST);
             glStencilMask(-1);
             glStencilFunc(GL_ALWAYS, 1, 0xFF);
-        } else {
+        } else if (backBox.width > 0 && backBox.height > 0)
             g_pHyprOpenGL->renderRect(&backBox, color, ROUNDING * pMonitor->scale);
-        }
     }
 
     for (int i = 0; i < barsToDraw; ++i) {

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -107,10 +107,10 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
 
         scaleBox(&rect, pMonitor->scale);
 
-        static auto* const PGROUPCOLINACTIVE       = &g_pConfigManager->getConfigValuePtr("group:col.border")->data;
-        static auto* const PGROUPCOLACTIVE         = &g_pConfigManager->getConfigValuePtr("group:col.border_active")->data;
-        static auto* const PGROUPCOLINACTIVELOCKED = &g_pConfigManager->getConfigValuePtr("group:col.border_locked")->data;
-        static auto* const PGROUPCOLACTIVELOCKED   = &g_pConfigManager->getConfigValuePtr("group:col.border_locked_active")->data;
+        static auto* const PGROUPCOLACTIVE         = &g_pConfigManager->getConfigValuePtr("group:groupbar:col.active")->data;
+        static auto* const PGROUPCOLINACTIVE       = &g_pConfigManager->getConfigValuePtr("group:groupbar:col.inactive")->data;
+        static auto* const PGROUPCOLACTIVELOCKED   = &g_pConfigManager->getConfigValuePtr("group:groupbar:col.locked_active")->data;
+        static auto* const PGROUPCOLINACTIVELOCKED = &g_pConfigManager->getConfigValuePtr("group:groupbar:col.locked_inactive")->data;
 
         const bool         GROUPLOCKED  = m_pWindow->getGroupHead()->m_sGroupData.locked;
         const auto* const  PCOLACTIVE   = GROUPLOCKED ? PGROUPCOLACTIVELOCKED : PGROUPCOLACTIVE;
@@ -288,10 +288,10 @@ void CHyprGroupBarDecoration::refreshGradients() {
     if (m_tGradientActive.m_iTexID > 0)
         return;
 
-    static auto* const PGROUPCOLINACTIVE       = &g_pConfigManager->getConfigValuePtr("group:col.border")->data;
-    static auto* const PGROUPCOLACTIVE         = &g_pConfigManager->getConfigValuePtr("group:col.border_active")->data;
-    static auto* const PGROUPCOLINACTIVELOCKED = &g_pConfigManager->getConfigValuePtr("group:col.border_locked")->data;
-    static auto* const PGROUPCOLACTIVELOCKED   = &g_pConfigManager->getConfigValuePtr("group:col.border_locked_active")->data;
+    static auto* const PGROUPCOLACTIVE         = &g_pConfigManager->getConfigValuePtr("group:groupbar:col.active")->data;
+    static auto* const PGROUPCOLINACTIVE       = &g_pConfigManager->getConfigValuePtr("group:groupbar:col.inactive")->data;
+    static auto* const PGROUPCOLACTIVELOCKED   = &g_pConfigManager->getConfigValuePtr("group:groupbar:col.locked_active")->data;
+    static auto* const PGROUPCOLINACTIVELOCKED = &g_pConfigManager->getConfigValuePtr("group:groupbar:col.locked_inactive")->data;
 
     const bool         GROUPLOCKED  = m_pWindow->getGroupHead()->m_sGroupData.locked;
     const auto* const  PCOLACTIVE   = GROUPLOCKED ? PGROUPCOLACTIVELOCKED : PGROUPCOLACTIVE;

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -101,10 +101,10 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
         return;
 
     // Bottom left of groupbar
-    Vector2D pos = Vector2D(std::round(m_vLastWindowPos.x - pMonitor->vecPosition.x + offset.x + ROUNDING),
-                            std::round(m_vLastWindowPos.y - pMonitor->vecPosition.y + offset.y) +
+    Vector2D pos = Vector2D(m_vLastWindowPos.x - pMonitor->vecPosition.x + offset.x + ROUNDING,
+                            std::floor(m_vLastWindowPos.y) - pMonitor->vecPosition.y + offset.y +
                                 (m_bOnTop ? (m_bInternalBorder ? 0 : -BORDERSIZE) :
-                                            std::round(m_vLastWindowSize.y) + m_iBarInternalHeight + BAR_INTERNAL_PADDING + (m_bInternalBorder ? 0 : BORDERSIZE)));
+                                            std::floor(m_vLastWindowSize.y) + m_iBarInternalHeight + BAR_INTERNAL_PADDING + (m_bInternalBorder ? 0 : BORDERSIZE)));
 
     wlr_box  barBox  = {pos.x, pos.y - m_iBarHeight + (m_bOnTop ? -BAR_INTERNAL_PADDING : 0), BARW, m_iBarHeight};
     wlr_box  gradBox = {pos.x, pos.y - m_iBarHeight + (m_bOnTop ? -2 * BAR_INTERNAL_PADDING : -BAR_INTERNAL_PADDING) - m_iGradientHeight, BARW, m_iGradientHeight};

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -72,7 +72,7 @@ void CHyprGroupBarDecoration::damageEntire() {
 }
 
 void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& offset) {
-    if (!m_pWindow->m_sSpecialRenderData.decorate)
+    if (!m_pWindow->m_sSpecialRenderData.decorate || !m_bEnabled)
         return;
 
     int                barsToDraw = m_dwGroupMembers.size();
@@ -339,19 +339,26 @@ void CHyprGroupBarDecoration::refreshGradients() {
 }
 
 void CHyprGroupBarDecoration::forceReload(CWindow* pWindow) {
+    static auto* const PENABLED        = &g_pConfigManager->getConfigValuePtr("group:groupbar:enabled")->intValue;
     static auto* const PMODE           = &g_pConfigManager->getConfigValuePtr("group:groupbar:mode")->intValue;
     static auto* const PHEIGHT         = &g_pConfigManager->getConfigValuePtr("group:groupbar:height")->intValue;
     static auto* const PINTERNALBORDER = &g_pConfigManager->getConfigValuePtr("group:groupbar:internal_bar")->intValue;
 
+    m_bEnabled           = *PENABLED;
     m_iBarInternalHeight = *PHEIGHT + (*PMODE == 1 ? BAR_INDICATOR_HEIGHT + BAR_INTERNAL_PADDING : 0);
     m_iBarFullHeight     = m_iBarInternalHeight + BAR_INTERNAL_PADDING + BAR_EXTERNAL_PADDING;
 
     m_bOnTop          = g_pConfigManager->getConfigValuePtr("group:groupbar:top")->intValue;
     m_bInternalBorder = *PINTERNALBORDER;
 
-    m_seExtents.topLeft              = Vector2D(0, m_bOnTop ? m_iBarFullHeight : 0);
-    m_seExtents.bottomRight          = Vector2D(0, m_bOnTop ? 0 : m_iBarFullHeight);
-    m_seExtents.isInternalDecoration = *PINTERNALBORDER;
+    if (m_bEnabled) {
+        m_seExtents.topLeft              = Vector2D(0, m_bOnTop ? m_iBarFullHeight : 0);
+        m_seExtents.bottomRight          = Vector2D(0, m_bOnTop ? 0 : m_iBarFullHeight);
+        m_seExtents.isInternalDecoration = *PINTERNALBORDER;
+    } else {
+        m_seExtents.topLeft     = Vector2D(0, 0);
+        m_seExtents.bottomRight = Vector2D(0, 0);
+    }
 
     m_iBarHeight      = *PMODE != 1 ? *PHEIGHT : BAR_INDICATOR_HEIGHT;
     m_iGradientHeight = *PMODE == 1 ? *PHEIGHT : 0;

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -363,6 +363,16 @@ void CHyprGroupBarDecoration::forceReload(CWindow* pWindow) {
     refreshGradients();
 }
 
+CRegion CHyprGroupBarDecoration::getWindowDecorationRegion() {
+    const int ROUNDING   = !m_pWindow->m_sSpecialRenderData.rounding ? 0 : m_pWindow->rounding();
+    const int BORDERSIZE = m_pWindow->getRealBorderSize();
+    return CRegion(m_vLastWindowPos.x + ROUNDING,
+                   m_vLastWindowPos.y +
+                       (m_bOnTop ? -BAR_INTERNAL_PADDING - m_iBarInternalHeight - (m_bInternalBorder ? 0 : BORDERSIZE) :
+                                   m_vLastWindowSize.y + BAR_INTERNAL_PADDING + (m_bInternalBorder ? 0 : BORDERSIZE)),
+                   m_vLastWindowSize.x - 2 * ROUNDING, m_iBarInternalHeight);
+}
+
 bool CHyprGroupBarDecoration::allowsInput() {
     return true;
 }

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -11,7 +11,7 @@ static CTexture m_tGradientLockedInactive;
 
 CHyprGroupBarDecoration::CHyprGroupBarDecoration(CWindow* pWindow) : IHyprWindowDecoration(pWindow) {
     m_pWindow = pWindow;
-    forceReload(m_pWindow);
+    loadConfig();
 }
 
 CHyprGroupBarDecoration::~CHyprGroupBarDecoration() {}
@@ -345,7 +345,7 @@ void CHyprGroupBarDecoration::refreshGradients() {
     renderGradientTo(m_tGradientLockedInactive, ((CGradientValueData*)PGROUPCOLINACTIVELOCKED->get())->m_vColors[0]);
 }
 
-void CHyprGroupBarDecoration::forceReload(CWindow* pWindow) {
+void CHyprGroupBarDecoration::loadConfig() {
     static auto* const PENABLED     = &g_pConfigManager->getConfigValuePtr("group:groupbar:enabled")->intValue;
     static auto* const PMODE        = &g_pConfigManager->getConfigValuePtr("group:groupbar:mode")->intValue;
     static auto* const PHEIGHT      = &g_pConfigManager->getConfigValuePtr("group:groupbar:height")->intValue;
@@ -369,7 +369,10 @@ void CHyprGroupBarDecoration::forceReload(CWindow* pWindow) {
 
     m_iBarHeight      = *PMODE != 1 ? *PHEIGHT : BAR_INDICATOR_HEIGHT;
     m_iGradientHeight = *PMODE == 1 ? *PHEIGHT : 0;
+}
 
+void CHyprGroupBarDecoration::forceReload() {
+    loadConfig();
     refreshGradients();
 }
 

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -180,6 +180,7 @@ CTitleTex::CTitleTex(CWindow* pWindow, const Vector2D& bufferSize) {
 
     static auto* const PTITLEFONTSIZE = &g_pConfigManager->getConfigValuePtr("group:groupbar:titles_font_size")->intValue;
     static auto* const PTEXTCOLOR     = &g_pConfigManager->getConfigValuePtr("group:groupbar:text_color")->intValue;
+    static auto* const PFONT          = &g_pConfigManager->getConfigValuePtr("group:groupbar:font")->strValue;
 
     const CColor       COLOR = CColor(*PTEXTCOLOR);
 
@@ -193,7 +194,7 @@ CTitleTex::CTitleTex(CWindow* pWindow, const Vector2D& bufferSize) {
     PangoLayout* layout = pango_cairo_create_layout(CAIRO);
     pango_layout_set_text(layout, szContent.c_str(), -1);
 
-    PangoFontDescription* fontDesc = pango_font_description_from_string("Sans");
+    PangoFontDescription* fontDesc = pango_font_description_from_string(PFONT->c_str());
     pango_font_description_set_size(fontDesc, *PTITLEFONTSIZE * PANGO_SCALE);
     pango_layout_set_font_description(layout, fontDesc);
     pango_font_description_free(fontDesc);

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -24,10 +24,11 @@ eDecorationType CHyprGroupBarDecoration::getDecorationType() {
     return DECORATION_GROUPBAR;
 }
 
-constexpr int BAR_INDICATOR_HEIGHT = 3;
-constexpr int BAR_INTERNAL_PADDING = 3;
-constexpr int BAR_EXTERNAL_PADDING = 3;
-constexpr int BAR_TEXT_PAD         = 3;
+constexpr int BAR_INDICATOR_HEIGHT   = 3;
+constexpr int BAR_INTERNAL_PADDING   = 3;
+constexpr int BAR_EXTERNAL_PADDING   = 3;
+constexpr int BAR_HORIZONTAL_PADDING = 5;
+constexpr int BAR_TEXT_PAD           = 3;
 
 //
 
@@ -93,8 +94,7 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
     const int  ROUNDING   = !m_pWindow->m_sSpecialRenderData.rounding ? 0 : m_pWindow->rounding();
     const int  BORDERSIZE = m_pWindow->getRealBorderSize();
 
-    const int  PAD  = 2; //2px
-    const int  BARW = (m_vLastWindowSize.x - 2 * ROUNDING - PAD * (barsToDraw - 1)) / barsToDraw;
+    const int  BARW = (m_vLastWindowSize.x - 2 * ROUNDING - BAR_HORIZONTAL_PADDING * (barsToDraw - 1)) / barsToDraw;
 
     //  TODO: check for invalid config
     if (BARW <= 0)
@@ -166,7 +166,7 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
         CColor color =
             m_dwGroupMembers[i] == g_pCompositor->m_pLastWindow ? ((CGradientValueData*)PCOLACTIVE->get())->m_vColors[0] : ((CGradientValueData*)PCOLINACTIVE->get())->m_vColors[0];
         color.a *= a;
-        g_pHyprOpenGL->renderRect(&barBox, color);
+        g_pHyprOpenGL->renderRect(&barBox, color, std::sqrt(m_iBarHeight) / 2);
 
         // render title if necessary
         if (*PRENDERTITLES) {
@@ -185,9 +185,9 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
                                          &gradBox, 1.0);
         }
 
-        barBox.x += (PAD + BARW) * pMonitor->scale;
-        gradBox.x += (PAD + BARW) * pMonitor->scale;
-        textBox.x += (PAD + BARW) * pMonitor->scale;
+        barBox.x += (BAR_HORIZONTAL_PADDING + BARW) * pMonitor->scale;
+        gradBox.x += (BAR_HORIZONTAL_PADDING + BARW) * pMonitor->scale;
+        textBox.x += (BAR_HORIZONTAL_PADDING + BARW) * pMonitor->scale;
     }
 
     if (*PRENDERTITLES)

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -34,8 +34,8 @@ void CHyprGroupBarDecoration::updateWindow(CWindow* pWindow) {
 
     const auto         WORKSPACEOFFSET = PWORKSPACE && !pWindow->m_bPinned ? PWORKSPACE->m_vRenderOffset.vec() : Vector2D();
 
-    static auto* const PRENDERTITLES  = &g_pConfigManager->getConfigValuePtr("misc:render_titles_in_groupbar")->intValue;
-    static auto* const PTITLEFONTSIZE = &g_pConfigManager->getConfigValuePtr("misc:groupbar_titles_font_size")->intValue;
+    static auto* const PRENDERTITLES  = &g_pConfigManager->getConfigValuePtr("group:groupbar:render_titles")->intValue;
+    static auto* const PTITLEFONTSIZE = &g_pConfigManager->getConfigValuePtr("group:groupbar:titles_font_size")->intValue;
 
     if (pWindow->m_vRealPosition.vec() + WORKSPACEOFFSET != m_vLastWindowPos || pWindow->m_vRealSize.vec() != m_vLastWindowSize) {
         // we draw 3px above the window's border with 3px
@@ -84,9 +84,9 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
     // get how many bars we will draw
     int                barsToDraw = m_dwGroupMembers.size();
 
-    static auto* const PRENDERTITLES  = &g_pConfigManager->getConfigValuePtr("misc:render_titles_in_groupbar")->intValue;
-    static auto* const PTITLEFONTSIZE = &g_pConfigManager->getConfigValuePtr("misc:groupbar_titles_font_size")->intValue;
-    static auto* const PGRADIENTS     = &g_pConfigManager->getConfigValuePtr("misc:groupbar_gradients")->intValue;
+    static auto* const PRENDERTITLES  = &g_pConfigManager->getConfigValuePtr("group:groupbar:render_titles")->intValue;
+    static auto* const PTITLEFONTSIZE = &g_pConfigManager->getConfigValuePtr("group:groupbar:titles_font_size")->intValue;
+    static auto* const PGRADIENTS     = &g_pConfigManager->getConfigValuePtr("group:groupbar:gradients")->intValue;
 
     const int          BORDERSIZE = m_pWindow->getRealBorderSize();
 
@@ -108,10 +108,10 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
 
         scaleBox(&rect, pMonitor->scale);
 
-        static auto* const PGROUPCOLACTIVE         = &g_pConfigManager->getConfigValuePtr("general:col.group_border_active")->data;
-        static auto* const PGROUPCOLINACTIVE       = &g_pConfigManager->getConfigValuePtr("general:col.group_border")->data;
-        static auto* const PGROUPCOLACTIVELOCKED   = &g_pConfigManager->getConfigValuePtr("general:col.group_border_locked_active")->data;
-        static auto* const PGROUPCOLINACTIVELOCKED = &g_pConfigManager->getConfigValuePtr("general:col.group_border_locked")->data;
+        static auto* const PGROUPCOLINACTIVE       = &g_pConfigManager->getConfigValuePtr("group:col.border")->data;
+        static auto* const PGROUPCOLACTIVE         = &g_pConfigManager->getConfigValuePtr("group:col.border_active")->data;
+        static auto* const PGROUPCOLINACTIVELOCKED = &g_pConfigManager->getConfigValuePtr("group:col.border_locked")->data;
+        static auto* const PGROUPCOLACTIVELOCKED   = &g_pConfigManager->getConfigValuePtr("group:col.border_locked_active")->data;
 
         const bool         GROUPLOCKED  = m_pWindow->getGroupHead()->m_sGroupData.locked;
         const auto* const  PCOLACTIVE   = GROUPLOCKED ? PGROUPCOLACTIVELOCKED : PGROUPCOLACTIVE;
@@ -156,8 +156,8 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
 }
 
 SWindowDecorationExtents CHyprGroupBarDecoration::getWindowDecorationReservedArea() {
-    static auto* const PRENDERTITLES  = &g_pConfigManager->getConfigValuePtr("misc:render_titles_in_groupbar")->intValue;
-    static auto* const PTITLEFONTSIZE = &g_pConfigManager->getConfigValuePtr("misc:groupbar_titles_font_size")->intValue;
+    static auto* const PRENDERTITLES  = &g_pConfigManager->getConfigValuePtr("group:groupbar:render_titles")->intValue;
+    static auto* const PTITLEFONTSIZE = &g_pConfigManager->getConfigValuePtr("group:groupbar:titles_font_size")->intValue;
     return SWindowDecorationExtents{{0, BAR_INDICATOR_HEIGHT + BAR_PADDING_OUTER_VERT * 2 + (*PRENDERTITLES ? *PTITLEFONTSIZE : 0)}, {}};
 }
 
@@ -180,8 +180,8 @@ CTitleTex::CTitleTex(CWindow* pWindow, const Vector2D& bufferSize) {
     const auto         CAIROSURFACE = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, bufferSize.x, bufferSize.y);
     const auto         CAIRO        = cairo_create(CAIROSURFACE);
 
-    static auto* const PTITLEFONTSIZE = &g_pConfigManager->getConfigValuePtr("misc:groupbar_titles_font_size")->intValue;
-    static auto* const PTEXTCOLOR     = &g_pConfigManager->getConfigValuePtr("misc:groupbar_text_color")->intValue;
+    static auto* const PTITLEFONTSIZE = &g_pConfigManager->getConfigValuePtr("group:groupbar:titles_font_size")->intValue;
+    static auto* const PTEXTCOLOR     = &g_pConfigManager->getConfigValuePtr("group:groupbar:text_color")->intValue;
 
     const CColor       COLOR = CColor(*PTEXTCOLOR);
 
@@ -289,10 +289,10 @@ void CHyprGroupBarDecoration::refreshGradients() {
     if (m_tGradientActive.m_iTexID > 0)
         return;
 
-    static auto* const PGROUPCOLACTIVE         = &g_pConfigManager->getConfigValuePtr("general:col.group_border_active")->data;
-    static auto* const PGROUPCOLINACTIVE       = &g_pConfigManager->getConfigValuePtr("general:col.group_border")->data;
-    static auto* const PGROUPCOLACTIVELOCKED   = &g_pConfigManager->getConfigValuePtr("general:col.group_border_locked_active")->data;
-    static auto* const PGROUPCOLINACTIVELOCKED = &g_pConfigManager->getConfigValuePtr("general:col.group_border_locked")->data;
+    static auto* const PGROUPCOLINACTIVE       = &g_pConfigManager->getConfigValuePtr("group:col.border")->data;
+    static auto* const PGROUPCOLACTIVE         = &g_pConfigManager->getConfigValuePtr("group:col.border_active")->data;
+    static auto* const PGROUPCOLINACTIVELOCKED = &g_pConfigManager->getConfigValuePtr("group:col.border_locked")->data;
+    static auto* const PGROUPCOLACTIVELOCKED   = &g_pConfigManager->getConfigValuePtr("group:col.border_locked_active")->data;
 
     const bool         GROUPLOCKED  = m_pWindow->getGroupHead()->m_sGroupData.locked;
     const auto* const  PCOLACTIVE   = GROUPLOCKED ? PGROUPCOLACTIVELOCKED : PGROUPCOLACTIVE;

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -107,9 +107,6 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
 
     float currentOffset = BAR_HORIZONTAL_PADDING;
 
-    if (m_fBarWidth <= 0)
-        return;
-
     // Bottom left of groupbar
     Vector2D pos = Vector2D(
         m_vLastWindowPos.x - pMonitor->vecPosition.x + offset.x + ROUNDING,
@@ -184,13 +181,12 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
             g_pHyprOpenGL->renderRect(&barBox, color, std::sqrt(m_iBarHeight) / 2);
 
         // render title if necessary
-        if (*PRENDERTITLES) {
+        if (*PRENDERTITLES && textBox.width > 0 && textBox.height > 0) {
             CTitleTex* pTitleTex = textureFromTitle(m_dwGroupMembers[i]->m_szTitle);
             if (!pTitleTex)
                 pTitleTex = m_sTitleTexs.titleTexs.emplace_back(std::make_unique<CTitleTex>(m_dwGroupMembers[i], Vector2D(textBox.width, textBox.height))).get();
 
-            if (textBox.width > 0 && textBox.height > 0)
-                g_pHyprOpenGL->renderTexture(pTitleTex->tex, &textBox, 1.f);
+            g_pHyprOpenGL->renderTexture(pTitleTex->tex, &textBox, 1.f);
         }
 
         if (gradBox.width > 0 && gradBox.height > 0) {

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -194,10 +194,6 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
         invalidateTextures();
 }
 
-SWindowDecorationExtents CHyprGroupBarDecoration::getWindowDecorationReservedArea() {
-    return m_seExtents;
-}
-
 CTitleTex* CHyprGroupBarDecoration::textureFromTitle(const std::string& title) {
     for (auto& tex : m_sTitleTexs.titleTexs) {
         if (tex->szContent == title)

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -94,7 +94,7 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
     const int  ROUNDING   = m_pWindow->getRealRounding();
     const int  BORDERSIZE = m_pWindow->getRealBorderSize();
 
-    const int  BARW = (m_vLastWindowSize.x - 2 * ROUNDING - BAR_HORIZONTAL_PADDING * (barsToDraw - 1)) / barsToDraw;
+    const int  BARW = (m_vLastWindowSize.x - 2 * ROUNDING - BAR_HORIZONTAL_PADDING * (barsToDraw + (m_bInternalBar ? 1 : -1))) / barsToDraw;
 
     //  TODO: check for invalid config
     if (BARW <= 0)
@@ -106,8 +106,9 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
         std::floor(m_vLastWindowPos.y) - pMonitor->vecPosition.y + offset.y +
             (m_bOnTop ? (m_bInternalBar ? 0 : -BORDERSIZE) : std::floor(m_vLastWindowSize.y) + m_iBarInternalHeight + BAR_INTERNAL_PADDING + (m_bInternalBar ? 0 : BORDERSIZE)));
 
-    wlr_box barBox  = {pos.x, pos.y - m_iBarHeight + (m_bOnTop ? -BAR_INTERNAL_PADDING : 0), BARW, m_iBarHeight};
-    wlr_box gradBox = {pos.x, pos.y - m_iBarHeight + (m_bOnTop ? -2 * BAR_INTERNAL_PADDING : -BAR_INTERNAL_PADDING) - m_iGradientHeight, BARW, m_iGradientHeight};
+    wlr_box barBox  = {pos.x + (m_bInternalBar ? BAR_HORIZONTAL_PADDING : 0), pos.y - m_iBarHeight + (m_bOnTop ? -BAR_INTERNAL_PADDING : 0), BARW, m_iBarHeight};
+    wlr_box gradBox = {pos.x + (m_bInternalBar ? BAR_HORIZONTAL_PADDING : 0),
+                       pos.y - m_iBarHeight + (m_bOnTop ? -2 * BAR_INTERNAL_PADDING : -BAR_INTERNAL_PADDING) - m_iGradientHeight, BARW, m_iGradientHeight};
     wlr_box textBox = m_iGradientHeight != 0 ? gradBox : barBox;
     textBox.y += BAR_TEXT_PAD;
     textBox.height -= 2 * BAR_TEXT_PAD;

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -89,16 +89,14 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
     const auto* const  PCOLACTIVE   = GROUPLOCKED ? PGROUPCOLACTIVELOCKED : PGROUPCOLACTIVE;
     const auto* const  PCOLINACTIVE = GROUPLOCKED ? PGROUPCOLINACTIVELOCKED : PGROUPCOLINACTIVE;
 
-    // TODO: fix mouse event with rounding
-    const auto  PWORKSPACE = g_pCompositor->getWorkspaceByID(m_pWindow->m_iWorkspaceID);
-    const int   ROUNDING   = m_pWindow->getRealRounding();
-    const int   BORDERSIZE = m_pWindow->getRealBorderSize();
+    const auto         PWORKSPACE = g_pCompositor->getWorkspaceByID(m_pWindow->m_iWorkspaceID);
+    const int          ROUNDING   = m_pWindow->getRealRounding();
+    const int          BORDERSIZE = m_pWindow->getRealBorderSize();
 
-    const float BARW = (m_vLastWindowSize.x - 2 * ROUNDING - BAR_HORIZONTAL_PADDING * (barsToDraw + (m_bInternalBar ? 1 : -1))) / barsToDraw;
+    const float        BARW = (m_vLastWindowSize.x - 2 * ROUNDING - BAR_HORIZONTAL_PADDING * (barsToDraw + (m_bInternalBar ? 1 : -1))) / barsToDraw;
 
-    float       currentOffset = m_bInternalBar ? BAR_HORIZONTAL_PADDING : 0;
+    float              currentOffset = m_bInternalBar ? BAR_HORIZONTAL_PADDING : 0;
 
-    //  TODO: check for invalid config
     if (BARW <= 0)
         return;
 
@@ -172,17 +170,20 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
         CColor color =
             m_dwGroupMembers[i] == g_pCompositor->m_pLastWindow ? ((CGradientValueData*)PCOLACTIVE->get())->m_vColors[0] : ((CGradientValueData*)PCOLINACTIVE->get())->m_vColors[0];
         color.a *= a;
-        g_pHyprOpenGL->renderRect(&barBox, color, std::sqrt(m_iBarHeight) / 2);
+        if (barBox.width > 0 && barBox.height > 0)
+            g_pHyprOpenGL->renderRect(&barBox, color, std::sqrt(m_iBarHeight) / 2);
 
         // render title if necessary
         if (*PRENDERTITLES) {
             CTitleTex* pTitleTex = textureFromTitle(m_dwGroupMembers[i]->m_szTitle);
             if (!pTitleTex)
                 pTitleTex = m_sTitleTexs.titleTexs.emplace_back(std::make_unique<CTitleTex>(m_dwGroupMembers[i], Vector2D(textBox.width, textBox.height))).get();
-            g_pHyprOpenGL->renderTexture(pTitleTex->tex, &textBox, 1.f);
+
+            if (textBox.width > 0 && textBox.height > 0)
+                g_pHyprOpenGL->renderTexture(pTitleTex->tex, &textBox, 1.f);
         }
 
-        if (m_iGradientHeight != 0) {
+        if (gradBox.width > 0 && gradBox.height > 0) {
             if (m_tGradientActive.m_iTexID == 0) // no idea why it doesn't work
                 refreshGradients();
 
@@ -191,7 +192,7 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
                                          &gradBox, 1.0);
         }
 
-        currentOffset += (float) (BAR_HORIZONTAL_PADDING + BARW) * pMonitor->scale;
+        currentOffset += (float)(BAR_HORIZONTAL_PADDING + BARW) * pMonitor->scale;
     }
 
     if (*PRENDERTITLES)
@@ -349,7 +350,7 @@ void CHyprGroupBarDecoration::forceReload(CWindow* pWindow) {
     static auto* const PINTERNALBAR = &g_pConfigManager->getConfigValuePtr("group:groupbar:internal_bar")->intValue;
 
     m_bEnabled           = *PENABLED;
-    m_iBarInternalHeight = *PHEIGHT + (*PMODE == 1 ? BAR_INDICATOR_HEIGHT + BAR_INTERNAL_PADDING : 0);
+    m_iBarInternalHeight = std::max((long int)0, *PHEIGHT) + (*PMODE == 1 ? BAR_INDICATOR_HEIGHT + BAR_INTERNAL_PADDING : 0);
     m_iBarFullHeight     = m_iBarInternalHeight + BAR_INTERNAL_PADDING + BAR_EXTERNAL_PADDING;
 
     m_bOnTop       = g_pConfigManager->getConfigValuePtr("group:groupbar:top")->intValue;

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -63,11 +63,13 @@ void CHyprGroupBarDecoration::updateWindow(CWindow* pWindow) {
 }
 
 void CHyprGroupBarDecoration::damageEntire() {
-    // TODO: do this properly
-    const int BORDERSIZE = m_pWindow->getRealBorderSize();
-    auto      RESERVED   = getWindowDecorationExtents();
-    wlr_box dm = {m_vLastWindowPos.x, m_vLastWindowPos.y + (RESERVED.topLeft.y != 0 ? -BORDERSIZE - RESERVED.topLeft.y : m_vLastWindowSize.y), m_vLastWindowSize.x + 2 * BORDERSIZE,
-                  RESERVED.topLeft.y + RESERVED.bottomRight.y + BORDERSIZE};
+    const int  BORDERSIZE = m_pWindow->getRealBorderSize();
+    const auto RESERVED   = getWindowDecorationExtents();
+    wlr_box    dm         = {m_vLastWindowPos.x,
+                             m_vLastWindowPos.y +
+                                 (m_bOnTop ? -BAR_INTERNAL_PADDING - m_iBarInternalHeight - (m_bInternalBar ? 0 : BORDERSIZE) :
+                                             m_vLastWindowSize.y + BAR_INTERNAL_PADDING + (m_bInternalBar ? 0 : BORDERSIZE)),
+                             m_vLastWindowSize.x, m_iBarInternalHeight};
     g_pHyprRenderer->damageBox(&dm);
 }
 

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -195,7 +195,7 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
 }
 
 SWindowDecorationExtents CHyprGroupBarDecoration::getWindowDecorationReservedArea() {
-    return {{0, m_bOnTop ? m_iBarFullHeight : 0}, {0, m_bOnTop ? 0 : m_iBarFullHeight}};
+    return m_seExtents;
 }
 
 CTitleTex* CHyprGroupBarDecoration::textureFromTitle(const std::string& title) {

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -37,6 +37,12 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
 
     virtual bool                     allowsInput();
 
+    virtual void                     dragWindowToDecoration(CWindow*, const Vector2D&);
+
+    virtual void                     clickDecoration(const Vector2D&);
+
+    virtual void                     dragFromDecoration(const Vector2D&);
+
   private:
     SWindowDecorationExtents m_seExtents;
 
@@ -54,6 +60,8 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
     bool                     m_bInternalBar;
     int                      m_iBarHeight;
     int                      m_iGradientHeight;
+
+    float                    m_fBarWidth;
 
     CTitleTex*               textureFromTitle(const std::string&);
     void                     invalidateTextures();

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -51,7 +51,7 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
     int                      m_iBarInternalHeight;
     int                      m_iBarFullHeight;
     bool                     m_bOnTop;
-    bool                     m_bInternalBorder;
+    bool                     m_bInternalBar;
     int                      m_iBarHeight;
     int                      m_iGradientHeight;
 

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -33,7 +33,7 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
 
     virtual CRegion                  getWindowDecorationRegion();
 
-    virtual void                     forceReload(CWindow*);
+    virtual void                     forceReload();
 
     virtual bool                     allowsInput();
 
@@ -67,6 +67,7 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
     void                     invalidateTextures();
 
     void                     refreshGradients();
+    void                     loadConfig();
 
     struct STitleTexs {
         // STitleTexs*                            overriden = nullptr; // TODO: make shit shared in-group to decrease VRAM usage.

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -31,8 +31,6 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
 
     virtual void                     damageEntire();
 
-    virtual SWindowDecorationExtents getWindowDecorationReservedArea();
-
     virtual CRegion                  getWindowDecorationRegion();
 
     virtual void                     forceReload(CWindow*);

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -33,6 +33,8 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
 
     virtual SWindowDecorationExtents getWindowDecorationReservedArea();
 
+    virtual CRegion                  getWindowDecorationRegion();
+
     virtual void                     forceReload(CWindow*);
 
     virtual bool                     allowsInput();

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -47,7 +47,12 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
 
     std::deque<CWindow*>     m_dwGroupMembers;
 
-    int                      getBarHeight();
+    int                      m_iBarInternalHeight;
+    int                      m_iBarFullHeight;
+    bool                     m_bOnTop;
+    bool                     m_bInternalBorder;
+    int                      m_iBarHeight;
+    int                      m_iGradientHeight;
 
     CTitleTex*               textureFromTitle(const std::string&);
     void                     invalidateTextures();

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -47,6 +47,7 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
 
     std::deque<CWindow*>     m_dwGroupMembers;
 
+    bool                     m_bEnabled;
     int                      m_iBarInternalHeight;
     int                      m_iBarFullHeight;
     bool                     m_bOnTop;

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -45,6 +45,8 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
 
     std::deque<CWindow*>     m_dwGroupMembers;
 
+    int                      getBarHeight();
+
     CTitleTex*               textureFromTitle(const std::string&);
     void                     invalidateTextures();
 

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -33,6 +33,8 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
 
     virtual SWindowDecorationExtents getWindowDecorationReservedArea();
 
+    virtual void                     forceReload(CWindow*);
+
     virtual bool                     allowsInput();
 
   private:

--- a/src/render/decorations/IHyprWindowDecoration.cpp
+++ b/src/render/decorations/IHyprWindowDecoration.cpp
@@ -32,3 +32,10 @@ void IHyprWindowDecoration::forceReload(CWindow* pWindow) {
 bool IHyprWindowDecoration::allowsInput() {
     return false;
 }
+
+void addExtentsToBox(wlr_box* box, SWindowDecorationExtents* extents) {
+    box->x -= extents->topLeft.x;
+    box->y -= extents->topLeft.y;
+    box->width += extents->topLeft.x + extents->bottomRight.x;
+    box->height += extents->topLeft.y + extents->bottomRight.y;
+}

--- a/src/render/decorations/IHyprWindowDecoration.cpp
+++ b/src/render/decorations/IHyprWindowDecoration.cpp
@@ -25,6 +25,10 @@ CRegion IHyprWindowDecoration::getWindowDecorationRegion() {
                           m_pWindow->m_vRealSize.vec().y + 2 * BORDERSIZE));
 }
 
+void IHyprWindowDecoration::forceReload(CWindow* pWindow) {
+    updateWindow(pWindow);
+}
+
 bool IHyprWindowDecoration::allowsInput() {
     return false;
 }

--- a/src/render/decorations/IHyprWindowDecoration.cpp
+++ b/src/render/decorations/IHyprWindowDecoration.cpp
@@ -14,7 +14,7 @@ SWindowDecorationExtents IHyprWindowDecoration::getWindowDecorationReservedArea(
 
 CRegion IHyprWindowDecoration::getWindowDecorationRegion() {
     const SWindowDecorationExtents RESERVED   = getWindowDecorationReservedArea();
-    const int                      BORDERSIZE = m_pWindow->getRealBorderSize();
+    const int                      BORDERSIZE = RESERVED.isInternalDecoration ? 0 : m_pWindow->getRealBorderSize();
     return CRegion(m_pWindow->m_vRealPosition.vec().x - (BORDERSIZE + RESERVED.topLeft.x) * (int)(RESERVED.topLeft.x != 0),
                    m_pWindow->m_vRealPosition.vec().y - (BORDERSIZE + RESERVED.topLeft.y) * (int)(RESERVED.topLeft.y != 0),
                    m_pWindow->m_vRealSize.vec().x + (BORDERSIZE + RESERVED.topLeft.x) * (int)(RESERVED.topLeft.x != 0) +

--- a/src/render/decorations/IHyprWindowDecoration.cpp
+++ b/src/render/decorations/IHyprWindowDecoration.cpp
@@ -32,6 +32,12 @@ bool IHyprWindowDecoration::allowsInput() {
     return false;
 }
 
+void IHyprWindowDecoration::dragWindowToDecoration(CWindow*, const Vector2D&) {}
+
+void IHyprWindowDecoration::clickDecoration(const Vector2D&) {}
+
+void IHyprWindowDecoration::dragFromDecoration(const Vector2D&) {}
+
 void addExtentsToBox(wlr_box* box, SWindowDecorationExtents* extents) {
     box->x -= extents->topLeft.x;
     box->y -= extents->topLeft.y;

--- a/src/render/decorations/IHyprWindowDecoration.cpp
+++ b/src/render/decorations/IHyprWindowDecoration.cpp
@@ -24,8 +24,8 @@ CRegion IHyprWindowDecoration::getWindowDecorationRegion() {
                           m_pWindow->m_vRealSize.vec().y + 2 * BORDERSIZE));
 }
 
-void IHyprWindowDecoration::forceReload(CWindow* pWindow) {
-    updateWindow(pWindow);
+void IHyprWindowDecoration::forceReload() {
+    updateWindow(m_pWindow);
 }
 
 bool IHyprWindowDecoration::allowsInput() {

--- a/src/render/decorations/IHyprWindowDecoration.cpp
+++ b/src/render/decorations/IHyprWindowDecoration.cpp
@@ -8,19 +8,18 @@ IHyprWindowDecoration::IHyprWindowDecoration(CWindow* pWindow) {
 
 IHyprWindowDecoration::~IHyprWindowDecoration() {}
 
-SWindowDecorationExtents IHyprWindowDecoration::getWindowDecorationReservedArea() {
-    return SWindowDecorationExtents{};
-}
-
 CRegion IHyprWindowDecoration::getWindowDecorationRegion() {
-    const SWindowDecorationExtents RESERVED   = getWindowDecorationReservedArea();
-    const int                      BORDERSIZE = RESERVED.isInternalDecoration ? 0 : m_pWindow->getRealBorderSize();
-    return CRegion(m_pWindow->m_vRealPosition.vec().x - (BORDERSIZE + RESERVED.topLeft.x) * (int)(RESERVED.topLeft.x != 0),
-                   m_pWindow->m_vRealPosition.vec().y - (BORDERSIZE + RESERVED.topLeft.y) * (int)(RESERVED.topLeft.y != 0),
-                   m_pWindow->m_vRealSize.vec().x + (BORDERSIZE + RESERVED.topLeft.x) * (int)(RESERVED.topLeft.x != 0) +
-                       (BORDERSIZE + RESERVED.bottomRight.x) * (int)(RESERVED.bottomRight.x != 0),
-                   m_pWindow->m_vRealSize.vec().y + (BORDERSIZE + RESERVED.topLeft.y) * (int)(RESERVED.topLeft.y != 0) +
-                       (BORDERSIZE + RESERVED.bottomRight.y) * (int)(RESERVED.bottomRight.y != 0))
+    const SWindowDecorationExtents EXTENTS = getWindowDecorationExtents();
+    if (!EXTENTS.isInternalDecoration && !EXTENTS.isReservedArea)
+        return CRegion(0, 0, 0, 0);
+
+    const int BORDERSIZE = EXTENTS.isInternalDecoration ? 0 : m_pWindow->getRealBorderSize();
+    return CRegion(m_pWindow->m_vRealPosition.vec().x - (BORDERSIZE + EXTENTS.topLeft.x) * (int)(EXTENTS.topLeft.x != 0),
+                   m_pWindow->m_vRealPosition.vec().y - (BORDERSIZE + EXTENTS.topLeft.y) * (int)(EXTENTS.topLeft.y != 0),
+                   m_pWindow->m_vRealSize.vec().x + (BORDERSIZE + EXTENTS.topLeft.x) * (int)(EXTENTS.topLeft.x != 0) +
+                       (BORDERSIZE + EXTENTS.bottomRight.x) * (int)(EXTENTS.bottomRight.x != 0),
+                   m_pWindow->m_vRealSize.vec().y + (BORDERSIZE + EXTENTS.topLeft.y) * (int)(EXTENTS.topLeft.y != 0) +
+                       (BORDERSIZE + EXTENTS.bottomRight.y) * (int)(EXTENTS.bottomRight.y != 0))
         .subtract(CRegion(m_pWindow->m_vRealPosition.vec().x - BORDERSIZE, m_pWindow->m_vRealPosition.vec().y - BORDERSIZE, m_pWindow->m_vRealSize.vec().x + 2 * BORDERSIZE,
                           m_pWindow->m_vRealSize.vec().y + 2 * BORDERSIZE));
 }

--- a/src/render/decorations/IHyprWindowDecoration.hpp
+++ b/src/render/decorations/IHyprWindowDecoration.hpp
@@ -13,6 +13,7 @@ enum eDecorationType {
 struct SWindowDecorationExtents {
     Vector2D topLeft;
     Vector2D bottomRight;
+    bool     isInternalDecoration = false;
 };
 
 class CWindow;

--- a/src/render/decorations/IHyprWindowDecoration.hpp
+++ b/src/render/decorations/IHyprWindowDecoration.hpp
@@ -37,7 +37,7 @@ class IHyprWindowDecoration {
 
     virtual void                     damageEntire() = 0;
 
-    virtual void                     forceReload(CWindow*);
+    virtual void                     forceReload();
 
     virtual CRegion                  getWindowDecorationRegion();
 

--- a/src/render/decorations/IHyprWindowDecoration.hpp
+++ b/src/render/decorations/IHyprWindowDecoration.hpp
@@ -14,6 +14,7 @@ struct SWindowDecorationExtents {
     Vector2D topLeft;
     Vector2D bottomRight;
     bool     isInternalDecoration = false;
+    bool     isReservedArea       = true; // External Decorations Only
 };
 
 void addExtentsToBox(wlr_box*, SWindowDecorationExtents*);
@@ -37,8 +38,6 @@ class IHyprWindowDecoration {
     virtual void                     damageEntire() = 0;
 
     virtual void                     forceReload(CWindow*);
-
-    virtual SWindowDecorationExtents getWindowDecorationReservedArea();
 
     virtual CRegion                  getWindowDecorationRegion();
 

--- a/src/render/decorations/IHyprWindowDecoration.hpp
+++ b/src/render/decorations/IHyprWindowDecoration.hpp
@@ -43,6 +43,12 @@ class IHyprWindowDecoration {
 
     virtual bool                     allowsInput();
 
+    virtual void                     dragWindowToDecoration(CWindow*, const Vector2D&);
+
+    virtual void                     clickDecoration(const Vector2D&);
+
+    virtual void                     dragFromDecoration(const Vector2D&);
+
   private:
     CWindow* m_pWindow = nullptr;
 };

--- a/src/render/decorations/IHyprWindowDecoration.hpp
+++ b/src/render/decorations/IHyprWindowDecoration.hpp
@@ -16,6 +16,8 @@ struct SWindowDecorationExtents {
     bool     isInternalDecoration = false;
 };
 
+void addExtentsToBox(wlr_box*, SWindowDecorationExtents*);
+
 class CWindow;
 class CMonitor;
 

--- a/src/render/decorations/IHyprWindowDecoration.hpp
+++ b/src/render/decorations/IHyprWindowDecoration.hpp
@@ -33,6 +33,8 @@ class IHyprWindowDecoration {
 
     virtual void                     damageEntire() = 0;
 
+    virtual void                     forceReload(CWindow*);
+
     virtual SWindowDecorationExtents getWindowDecorationReservedArea();
 
     virtual CRegion                  getWindowDecorationRegion();


### PR DESCRIPTION
Improves / adds more customization to groupbar:

- adds `group` and `groupbar` sections to free up `misc`
- add bottom as bar position
- separates border and bar colors
- allows setting groupbar heigh (bar height/gradient height depending on mode)
- adds `internal_bar`, `font` and background color options
- fixes gradients not updating with config reload

Mostly ready now, just needs some minors fixes

example of new config:

```
group {
    col.border_active = rgba(bb66ffee)
    #col.border_inactive = 0xffff0000 
    #col.border_locked_active = 0xff00ffff 
    #col.border_locked_inactive = 0xff0000ff 
    #--moveintogroup_lock_check = false-- #removed due to another commit, maybe should be moved here
    #insert_after_current = true
    groupbar {
        enabled = true
        col.active = rgba(cdd6f4cc)
        col.inactive = rgb(666699)
        #col.locked_active = 0xfff00f0f 
        #col.locked_inactive = 0xff0ff00f 
        col.background = rgb(bb66ff)
        #render_titles = false 
        #scrolling = true
        max_size = 200
        titles_font_size = 8
        mode = 0 # 0 - bar, 1 - gradient 
        height = 18
        #internal_bar = false 
        font = JetBrainsMono Nerd Font Mono
        top = no
        text_color = rgb(333333)
        #unified_border = 1
    }
}
```