### PR TITLE
Remove all `.c_str()` calls when using `std::vformat`

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -53,7 +53,7 @@ CCompositor::CCompositor() {
 
     Debug::init(m_szInstanceSignature);
 
-    Debug::log(LOG, "Instance Signature: {}", m_szInstanceSignature.c_str());
+    Debug::log(LOG, "Instance Signature: {}", m_szInstanceSignature);
 
     Debug::log(LOG, "Hyprland PID: {}", m_iHyprlandPID);
 
@@ -69,7 +69,7 @@ CCompositor::CCompositor() {
 
     setRandomSplash();
 
-    Debug::log(LOG, "\nCurrent splash: {}\n\n", m_szCurrentSplash.c_str());
+    Debug::log(LOG, "\nCurrent splash: {}\n\n", m_szCurrentSplash);
 }
 
 CCompositor::~CCompositor() {
@@ -441,10 +441,10 @@ void CCompositor::startCompositor() {
         const auto RETVAL       = wl_display_add_socket(m_sWLDisplay, CANDIDATESTR.c_str());
         if (RETVAL >= 0) {
             m_szWLDisplaySocket = CANDIDATESTR;
-            Debug::log(LOG, "wl_display_add_socket for {} succeeded with {}", CANDIDATESTR.c_str(), RETVAL);
+            Debug::log(LOG, "wl_display_add_socket for {} succeeded with {}", CANDIDATESTR, RETVAL);
             break;
         } else {
-            Debug::log(WARN, "wl_display_add_socket for {} returned {}: skipping candidate {}", CANDIDATESTR.c_str(), RETVAL, candidate);
+            Debug::log(WARN, "wl_display_add_socket for {} returned {}: skipping candidate {}", CANDIDATESTR, RETVAL, candidate);
         }
     }
 
@@ -474,7 +474,7 @@ void CCompositor::startCompositor() {
             "dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP HYPRLAND_INSTANCE_SIGNATURE",
             nullptr);
 
-    Debug::log(LOG, "Running on WAYLAND_DISPLAY: {}", m_szWLDisplaySocket.c_str());
+    Debug::log(LOG, "Running on WAYLAND_DISPLAY: {}", m_szWLDisplaySocket);
 
     if (!wlr_backend_start(m_sWLRBackend)) {
         Debug::log(CRIT, "Backend did not start!");
@@ -988,7 +988,7 @@ void CCompositor::focusSurface(wlr_surface* pSurface, CWindow* pWindowOwner) {
     wl_signal_emit_mutable(&m_sSeat.seat->keyboard_state.events.focus_change, &event);
 
     if (pWindowOwner)
-        Debug::log(LOG, "Set keyboard focus to surface {:x}, with window name: {}", (uintptr_t)pSurface, pWindowOwner->m_szTitle.c_str());
+        Debug::log(LOG, "Set keyboard focus to surface {:x}, with window name: {}", (uintptr_t)pSurface, pWindowOwner->m_szTitle);
     else
         Debug::log(LOG, "Set keyboard focus to surface {:x}", (uintptr_t)pSurface);
 
@@ -2357,7 +2357,7 @@ void CCompositor::renameWorkspace(const int& id, const std::string& name) {
     if (isWorkspaceSpecial(id))
         return;
 
-    Debug::log(LOG, "renameWorkspace: Renaming workspace {} to '{}'", id, name.c_str());
+    Debug::log(LOG, "renameWorkspace: Renaming workspace {} to '{}'", id, name);
     PWORKSPACE->m_szName = name;
 
     g_pEventManager->postEvent({"renameworkspace", std::to_string(PWORKSPACE->m_iID) + "," + PWORKSPACE->m_szName});
@@ -2485,7 +2485,7 @@ void CCompositor::arrangeMonitors() {
 
         if (m->activeMonitorRule.offset != Vector2D{-INT32_MAX, -INT32_MAX}) {
             // explicit.
-            Debug::log(LOG, "arrangeMonitors: {} explicit [{:.2f}, {:.2f}]", m->szName.c_str(), m->activeMonitorRule.offset.x, m->activeMonitorRule.offset.y);
+            Debug::log(LOG, "arrangeMonitors: {} explicit [{:.2f}, {:.2f}]", m->szName, m->activeMonitorRule.offset.x, m->activeMonitorRule.offset.y);
 
             m->moveTo(m->activeMonitorRule.offset);
             arranged.push_back(m);
@@ -2508,7 +2508,7 @@ void CCompositor::arrangeMonitors() {
     }
 
     for (auto& m : toArrange) {
-        Debug::log(LOG, "arrangeMonitors: {} auto [{}, {:.2f}]", m->szName.c_str(), maxOffset, 0.f);
+        Debug::log(LOG, "arrangeMonitors: {} auto [{}, {:.2f}]", m->szName, maxOffset, 0.f);
         m->moveTo({maxOffset, 0});
         maxOffset += m->vecSize.x;
     }
@@ -2517,7 +2517,7 @@ void CCompositor::arrangeMonitors() {
     // and set xwayland positions aka auto for all
     maxOffset = 0;
     for (auto& m : m_vMonitors) {
-        Debug::log(LOG, "arrangeMonitors: {} xwayland [{}, {:.2f}]", m->szName.c_str(), maxOffset, 0.f);
+        Debug::log(LOG, "arrangeMonitors: {} xwayland [{}, {:.2f}]", m->szName, maxOffset, 0.f);
         m->vecXWaylandPosition = {maxOffset, 0};
         maxOffset += (*PXWLFORCESCALEZERO ? m->vecTransformedSize.x : m->vecSize.x);
     }

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -494,11 +494,11 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
     } else if (r.szRule.find("rounding") == 0) {
         try {
             m_sAdditionalConfigData.rounding = std::stoi(r.szRule.substr(r.szRule.find_first_of(' ') + 1));
-        } catch (std::exception& e) { Debug::log(ERR, "Rounding rule \"{}\" failed with: {}", r.szRule.c_str(), e.what()); }
+        } catch (std::exception& e) { Debug::log(ERR, "Rounding rule \"{}\" failed with: {}", r.szRule, e.what()); }
     } else if (r.szRule.find("bordersize") == 0) {
         try {
             m_sAdditionalConfigData.borderSize = std::stoi(r.szRule.substr(r.szRule.find_first_of(' ') + 1));
-        } catch (std::exception& e) { Debug::log(ERR, "Bordersize rule \"{}\" failed with: {}", r.szRule.c_str(), e.what()); }
+        } catch (std::exception& e) { Debug::log(ERR, "Bordersize rule \"{}\" failed with: {}", r.szRule, e.what()); }
     } else if (r.szRule.find("opacity") == 0) {
         try {
             CVarList vars(r.szRule, 0, ' ');
@@ -529,7 +529,7 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
                     opacityIDX++;
                 }
             }
-        } catch (std::exception& e) { Debug::log(ERR, "Opacity rule \"{}\" failed with: {}", r.szRule.c_str(), e.what()); }
+        } catch (std::exception& e) { Debug::log(ERR, "Opacity rule \"{}\" failed with: {}", r.szRule, e.what()); }
     } else if (r.szRule == "noanim") {
         m_sAdditionalConfigData.forceNoAnims = true;
     } else if (r.szRule.find("animation") == 0) {
@@ -546,7 +546,7 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
             } else {
                 m_sSpecialRenderData.activeBorderColor = configStringToInt(colorPart);
             }
-        } catch (std::exception& e) { Debug::log(ERR, "BorderColor rule \"{}\" failed with: {}", r.szRule.c_str(), e.what()); }
+        } catch (std::exception& e) { Debug::log(ERR, "BorderColor rule \"{}\" failed with: {}", r.szRule, e.what()); }
     } else if (r.szRule == "dimaround") {
         m_sAdditionalConfigData.dimAround = true;
     } else if (r.szRule == "keepaspectratio") {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -343,7 +343,7 @@ void CConfigManager::configSetValueSafe(const std::string& COMMAND, const std::s
         if (COMMAND.find("device:") != 0 /* devices parsed later */ && COMMAND.find("plugin:") != 0 /* plugins parsed later */) {
             if (COMMAND[0] == '$') {
                 // register a dynamic var
-                Debug::log(LOG, "Registered dynamic var \"{}\" -> {}", COMMAND.c_str(), VALUE.c_str());
+                Debug::log(LOG, "Registered dynamic var \"{}\" -> {}", COMMAND, VALUE);
                 configDynamicVars.emplace_back(std::make_pair<>(COMMAND.substr(1), VALUE));
 
                 std::sort(configDynamicVars.begin(), configDynamicVars.end(), [&](const auto& a, const auto& b) { return a.first.length() > b.first.length(); });
@@ -401,21 +401,21 @@ void CConfigManager::configSetValueSafe(const std::string& COMMAND, const std::s
         try {
             CONFIGENTRY->intValue = configStringToInt(VALUE);
         } catch (std::exception& e) {
-            Debug::log(WARN, "Error reading value of {}", COMMAND.c_str());
+            Debug::log(WARN, "Error reading value of {}", COMMAND);
             parseError = "Error setting value <" + VALUE + "> for field <" + COMMAND + ">. " + e.what();
         }
     } else if (CONFIGENTRY->floatValue != -__FLT_MAX__) {
         try {
             CONFIGENTRY->floatValue = stof(VALUE);
         } catch (...) {
-            Debug::log(WARN, "Error reading value of {}", COMMAND.c_str());
+            Debug::log(WARN, "Error reading value of {}", COMMAND);
             parseError = "Error setting value <" + VALUE + "> for field <" + COMMAND + ">.";
         }
     } else if (CONFIGENTRY->strValue != "") {
         try {
             CONFIGENTRY->strValue = VALUE;
         } catch (...) {
-            Debug::log(WARN, "Error reading value of {}", COMMAND.c_str());
+            Debug::log(WARN, "Error reading value of {}", COMMAND);
             parseError = "Error setting value <" + VALUE + "> for field <" + COMMAND + ">.";
         }
     } else if (CONFIGENTRY->vecValue != Vector2D(-__FLT_MAX__, -__FLT_MAX__)) {
@@ -428,11 +428,11 @@ void CConfigManager::configSetValueSafe(const std::string& COMMAND, const std::s
                     CONFIGENTRY->vecValue = Vector2D(std::stof(X), std::stof(Y));
                 }
             } else {
-                Debug::log(WARN, "Error reading value of {}", COMMAND.c_str());
+                Debug::log(WARN, "Error reading value of {}", COMMAND);
                 parseError = "Error setting value <" + VALUE + "> for field <" + COMMAND + ">.";
             }
         } catch (...) {
-            Debug::log(WARN, "Error reading value of {}", COMMAND.c_str());
+            Debug::log(WARN, "Error reading value of {}", COMMAND);
             parseError = "Error setting value <" + VALUE + "> for field <" + COMMAND + ">.";
         }
     } else if (CONFIGENTRY->data.get() != nullptr) {
@@ -451,7 +451,7 @@ void CConfigManager::configSetValueSafe(const std::string& COMMAND, const std::s
                         try {
                             data->m_fAngle = std::stoi(var.substr(0, var.find("deg"))) * (PI / 180.0); // radians
                         } catch (...) {
-                            Debug::log(WARN, "Error reading value of {}", COMMAND.c_str());
+                            Debug::log(WARN, "Error reading value of {}", COMMAND);
                             parseError = "Error setting value <" + VALUE + "> for field <" + COMMAND + ">.";
                         }
 
@@ -459,7 +459,7 @@ void CConfigManager::configSetValueSafe(const std::string& COMMAND, const std::s
                     }
 
                     if (data->m_vColors.size() >= 10) {
-                        Debug::log(WARN, "Error reading value of {}", COMMAND.c_str());
+                        Debug::log(WARN, "Error reading value of {}", COMMAND);
                         parseError = "Error setting value <" + VALUE + "> for field <" + COMMAND + ">. Max colors in a gradient is 10.";
                         break;
                     }
@@ -467,13 +467,13 @@ void CConfigManager::configSetValueSafe(const std::string& COMMAND, const std::s
                     try {
                         data->m_vColors.push_back(CColor(configStringToInt(var)));
                     } catch (std::exception& e) {
-                        Debug::log(WARN, "Error reading value of {}", COMMAND.c_str());
+                        Debug::log(WARN, "Error reading value of {}", COMMAND);
                         parseError = "Error setting value <" + VALUE + "> for field <" + COMMAND + ">. " + e.what();
                     }
                 }
 
                 if (data->m_vColors.size() == 0) {
-                    Debug::log(WARN, "Error reading value of {}", COMMAND.c_str());
+                    Debug::log(WARN, "Error reading value of {}", COMMAND);
                     parseError = "Error setting value <" + VALUE + "> for field <" + COMMAND + ">. No colors provided.";
 
                     data->m_vColors.push_back(0); // transparent
@@ -495,7 +495,7 @@ void CConfigManager::configSetValueSafe(const std::string& COMMAND, const std::s
         struct stat fileStat;
         int         err = stat(PATH.c_str(), &fileStat);
         if (err != 0) {
-            Debug::log(WARN, "Error at ticking config at {}, error {}: {}", PATH.c_str(), err, strerror(err));
+            Debug::log(WARN, "Error at ticking config at {}, error {}: {}", PATH, err, strerror(err));
             return;
         }
 
@@ -552,7 +552,7 @@ static bool parseModeLine(const std::string& modeline, drmModeModeInfo& mode) {
         if (it != flagsmap.end())
             mode.flags |= it->second;
         else
-            Debug::log(ERR, "invalid flag {} in modeline", it->first.c_str());
+            Debug::log(ERR, "invalid flag {} in modeline", it->first);
     }
 
     snprintf(mode.name, sizeof(mode.name), "%dx%d@%d", mode.hdisplay, mode.vdisplay, mode.vrefresh / 1000);
@@ -923,7 +923,7 @@ void CConfigManager::handleWindowRule(const std::string& command, const std::str
 
     // verify we support a rule
     if (!windowRuleValid(RULE)) {
-        Debug::log(ERR, "Invalid rule found: {}", RULE.c_str());
+        Debug::log(ERR, "Invalid rule found: {}", RULE);
         parseError = "Invalid rule found: " + RULE;
         return;
     }
@@ -948,7 +948,7 @@ void CConfigManager::handleLayerRule(const std::string& command, const std::stri
     }
 
     if (!layerRuleValid(RULE)) {
-        Debug::log(ERR, "Invalid rule found: {}", RULE.c_str());
+        Debug::log(ERR, "Invalid rule found: {}", RULE);
         parseError = "Invalid rule found: " + RULE;
         return;
     }
@@ -966,7 +966,7 @@ void CConfigManager::handleWindowRuleV2(const std::string& command, const std::s
     const auto VALUE = value.substr(value.find_first_of(',') + 1);
 
     if (!windowRuleValid(RULE) && RULE != "unset") {
-        Debug::log(ERR, "Invalid rulev2 found: {}", RULE.c_str());
+        Debug::log(ERR, "Invalid rulev2 found: {}", RULE);
         parseError = "Invalid rulev2 found: " + RULE;
         return;
     }
@@ -987,7 +987,7 @@ void CConfigManager::handleWindowRuleV2(const std::string& command, const std::s
 
     if (TITLEPOS == std::string::npos && CLASSPOS == std::string::npos && X11POS == std::string::npos && FLOATPOS == std::string::npos && FULLSCREENPOS == std::string::npos &&
         PINNEDPOS == std::string::npos && WORKSPACEPOS == std::string::npos) {
-        Debug::log(ERR, "Invalid rulev2 syntax: {}", VALUE.c_str());
+        Debug::log(ERR, "Invalid rulev2 syntax: {}", VALUE);
         parseError = "Invalid rulev2 syntax: " + VALUE;
         return;
     }
@@ -1132,7 +1132,7 @@ void CConfigManager::handleWorkspaceRules(const std::string& command, const std:
         auto       wsIdent         = removeBeginEndSpacesTabs(value.substr(FIRST_DELIM + 1, (WORKSPACE_DELIM - FIRST_DELIM - 1)));
         id                         = getWorkspaceIDFromString(wsIdent, name);
         if (id == INT_MAX) {
-            Debug::log(ERR, "Invalid workspace identifier found: {}", wsIdent.c_str());
+            Debug::log(ERR, "Invalid workspace identifier found: {}", wsIdent);
             parseError = "Invalid workspace identifier found: " + wsIdent;
             return;
         }
@@ -1211,7 +1211,7 @@ void CConfigManager::handleSource(const std::string& command, const std::string&
     struct stat fileStat;
     int         err = stat(value.c_str(), &fileStat);
     if (err != 0) {
-        Debug::log(WARN, "Error at ticking config at {}, error {}: {}", value.c_str(), err, strerror(err));
+        Debug::log(WARN, "Error at ticking config at {}, error {}: {}", value, err, strerror(err));
         return;
     }
 
@@ -1271,7 +1271,7 @@ void CConfigManager::handleEnv(const std::string& command, const std::string& va
 #endif
             "dbus-update-activation-environment --systemd " +
             ARGS[0];
-        handleRawExec("", CMD.c_str());
+        handleRawExec("", CMD);
     }
 }
 
@@ -1491,7 +1491,7 @@ void CConfigManager::loadConfigLoadVars() {
     // paths
     configPaths.clear();
     std::string mainConfigPath = getMainConfigPath();
-    Debug::log(LOG, "Using config: {}", mainConfigPath.c_str());
+    Debug::log(LOG, "Using config: {}", mainConfigPath);
     configPaths.push_back(mainConfigPath);
     std::string configPath = mainConfigPath.substr(0, mainConfigPath.find_last_of('/'));
     // find_last_of never returns npos since main_config at least has /hypr/
@@ -1549,7 +1549,7 @@ void CConfigManager::loadConfigLoadVars() {
                 parseLine(line);
             } catch (...) {
                 Debug::log(ERR, "Error reading line from config. Line:");
-                Debug::log(NONE, "{}", line.c_str());
+                Debug::log(NONE, "{}", line);
 
                 parseError += "Config error at line " + std::to_string(linenum) + " (" + mainConfigPath + "): Line parsing error.";
             }
@@ -1658,7 +1658,7 @@ void CConfigManager::tick() {
         struct stat fileStat;
         int         err = stat(cf.c_str(), &fileStat);
         if (err != 0) {
-            Debug::log(WARN, "Error at ticking config at {}, error {}: {}", cf.c_str(), err, strerror(err));
+            Debug::log(WARN, "Error at ticking config at {}, error {}: {}", cf, err, strerror(err));
             continue;
         }
 
@@ -1692,7 +1692,7 @@ SConfigValue CConfigManager::getConfigValueSafeDevice(const std::string& dev, co
 
     if (it == deviceConfigs.end()) {
         if (fallback.empty()) {
-            Debug::log(ERR, "getConfigValueSafeDevice: No device config for {} found???", dev.c_str());
+            Debug::log(ERR, "getConfigValueSafeDevice: No device config for {} found???", dev);
             return SConfigValue();
         }
         return configValues[fallback];
@@ -1768,7 +1768,7 @@ SMonitorRule CConfigManager::getMonitorRuleFor(const std::string& name, const st
     if (found)
         return *found;
 
-    Debug::log(WARN, "No rule found for {}, trying to use the first.", name.c_str());
+    Debug::log(WARN, "No rule found for {}, trying to use the first.", name);
 
     for (auto& r : m_dMonitorRules) {
         if (r.name == "") {
@@ -1801,7 +1801,7 @@ std::vector<SWindowRule> CConfigManager::getMatchingRules(CWindow* pWindow) {
     std::string              title      = g_pXWaylandManager->getTitle(pWindow);
     std::string              appidclass = g_pXWaylandManager->getAppIDClass(pWindow);
 
-    Debug::log(LOG, "Searching for matching rules for {} (title: {})", appidclass.c_str(), title.c_str());
+    Debug::log(LOG, "Searching for matching rules for {} (title: {})", appidclass, title);
 
     // since some rules will be applied later, we need to store some flags
     bool hasFloating   = pWindow->m_bIsFloating;
@@ -1824,7 +1824,7 @@ std::vector<SWindowRule> CConfigManager::getMatchingRules(CWindow* pWindow) {
                         continue;
                 }
             } catch (...) {
-                Debug::log(ERR, "Regex error at {}", rule.szValue.c_str());
+                Debug::log(ERR, "Regex error at {}", rule.szValue);
                 continue;
             }
         } else {
@@ -1884,13 +1884,13 @@ std::vector<SWindowRule> CConfigManager::getMatchingRules(CWindow* pWindow) {
                     }
                 }
             } catch (std::exception& e) {
-                Debug::log(ERR, "Regex error at {} ({})", rule.szValue.c_str(), e.what());
+                Debug::log(ERR, "Regex error at {} ({})", rule.szValue, e.what());
                 continue;
             }
         }
 
         // applies. Read the rule and behave accordingly
-        Debug::log(LOG, "Window rule {} -> {} matched {:x} [{}]", rule.szRule.c_str(), rule.szValue.c_str(), (uintptr_t)pWindow, pWindow->m_szTitle.c_str());
+        Debug::log(LOG, "Window rule {} -> {} matched {:x} [{}]", rule.szRule, rule.szValue, (uintptr_t)pWindow, pWindow->m_szTitle);
 
         returns.push_back(rule);
 

--- a/src/debug/CrashReporter.cpp
+++ b/src/debug/CrashReporter.cpp
@@ -14,19 +14,19 @@
 std::string getRandomMessage() {
 
     const std::vector<std::string>  MESSAGES = {"Sorry, didn't mean to...",
-                                               "This was an accident, I swear!",
-                                               "Calm down, it was a misinput! MISINPUT!",
-                                               "Oops",
-                                               "Vaxry is going to be upset.",
-                                               "Who tried dividing by zero?!",
-                                               "Maybe you should try dusting your PC in the meantime?",
-                                               "I tried so hard, and got so far...",
-                                               "I don't feel so good...",
-                                               "*thud*",
-                                               "Well this is awkward.",
-                                               "\"stable\"",
-                                               "I hope you didn't have any unsaved progress.",
-                                               "All these computers..."};
+                                                "This was an accident, I swear!",
+                                                "Calm down, it was a misinput! MISINPUT!",
+                                                "Oops",
+                                                "Vaxry is going to be upset.",
+                                                "Who tried dividing by zero?!",
+                                                "Maybe you should try dusting your PC in the meantime?",
+                                                "I tried so hard, and got so far...",
+                                                "I don't feel so good...",
+                                                "*thud*",
+                                                "Well this is awkward.",
+                                                "\"stable\"",
+                                                "I hope you didn't have any unsaved progress.",
+                                                "All these computers..."};
 
     std::random_device              dev;
     std::mt19937                    engine(dev());
@@ -53,7 +53,7 @@ void CrashReporter::createAndSaveCrash(int sig) {
         finalCrashReport += "Hyprland seems to be running with plugins. This crash might not be Hyprland's fault.\nPlugins:\n";
 
         for (auto& p : g_pPluginSystem->getAllPlugins()) {
-            finalCrashReport += getFormat("\t{} ({}) {}\n", p->name.c_str(), p->author.c_str(), p->version.c_str());
+            finalCrashReport += getFormat("\t{} ({}) {}\n", p->name, p->author, p->version);
         }
 
         finalCrashReport += "\n\n";
@@ -75,7 +75,7 @@ void CrashReporter::createAndSaveCrash(int sig) {
 
     finalCrashReport += "GPU:\n\t" + GPUINFO;
 
-    finalCrashReport += getFormat("\n\nos-release:\n\t{}\n\n\n", replaceInString(execAndGet("cat /etc/os-release"), "\n", "\n\t").c_str());
+    finalCrashReport += getFormat("\n\nos-release:\n\t{}\n\n\n", replaceInString(execAndGet("cat /etc/os-release"), "\n", "\n\t"));
 
     finalCrashReport += "Backtrace:\n";
 
@@ -107,7 +107,7 @@ void CrashReporter::createAndSaveCrash(int sig) {
 #endif
 
     for (size_t i = 0; i < CALLSTACK.size(); ++i) {
-        finalCrashReport += getFormat("\t#{} | {}\n", i, CALLSTACK[i].desc.c_str());
+        finalCrashReport += getFormat("\t#{} | {}\n", i, CALLSTACK[i].desc);
 
 #ifdef __clang__
         const auto CMD = getFormat("llvm-addr2line -e {} -f 0x{:x}", FPATH.c_str(), (uint64_t)CALLSTACK[i].adr);
@@ -156,5 +156,5 @@ void CrashReporter::createAndSaveCrash(int sig) {
     ofs.close();
 
     Debug::disableStdout = false;
-    Debug::log(CRIT, "Hyprland has crashed :( Consult the crash report at {} for more information.", path.c_str());
+    Debug::log(CRIT, "Hyprland has crashed :( Consult the crash report at {} for more information.", path);
 }

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -65,11 +65,10 @@ std::string monitorsRequest(HyprCtl::eHyprCtlOutputFormat format) {
     "dpmsStatus": {},
     "vrr": {}
 }},)#",
-                m->ID, escapeJSONStrings(m->szName).c_str(), escapeJSONStrings(m->output->description ? m->output->description : "").c_str(),
-                (m->output->make ? m->output->make : ""), (m->output->model ? m->output->model : ""), (m->output->serial ? m->output->serial : ""), (int)m->vecPixelSize.x,
-                (int)m->vecPixelSize.y, m->refreshRate, (int)m->vecPosition.x, (int)m->vecPosition.y, m->activeWorkspace,
-                escapeJSONStrings(g_pCompositor->getWorkspaceByID(m->activeWorkspace)->m_szName).c_str(), m->specialWorkspaceID,
-                escapeJSONStrings(getWorkspaceNameFromSpecialID(m->specialWorkspaceID)).c_str(), (int)m->vecReservedTopLeft.x, (int)m->vecReservedTopLeft.y,
+                m->ID, escapeJSONStrings(m->szName), escapeJSONStrings(m->output->description ? m->output->description : ""), (m->output->make ? m->output->make : ""),
+                (m->output->model ? m->output->model : ""), (m->output->serial ? m->output->serial : ""), (int)m->vecPixelSize.x, (int)m->vecPixelSize.y, m->refreshRate,
+                (int)m->vecPosition.x, (int)m->vecPosition.y, m->activeWorkspace, escapeJSONStrings(g_pCompositor->getWorkspaceByID(m->activeWorkspace)->m_szName),
+                m->specialWorkspaceID, escapeJSONStrings(getWorkspaceNameFromSpecialID(m->specialWorkspaceID)), (int)m->vecReservedTopLeft.x, (int)m->vecReservedTopLeft.y,
                 (int)m->vecReservedBottomRight.x, (int)m->vecReservedBottomRight.y, m->scale, (int)m->transform, (m.get() == g_pCompositor->m_pLastMonitor ? "true" : "false"),
                 (m->dpmsStatus ? "true" : "false"), (m->output->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED ? "true" : "false"));
         }
@@ -82,17 +81,17 @@ std::string monitorsRequest(HyprCtl::eHyprCtlOutputFormat format) {
             if (!m->output)
                 continue;
 
-            result += getFormat("Monitor {} (ID {}):\n\t{}x{}@{:.5f} at {}x{}\n\tdescription: {}\n\tmake: {}\n\tmodel: {}\n\tserial: {}\n\tactive workspace: {} ({})\n\tspecial "
-                                "workspace: {} ({})\n\treserved: {} "
-                                "{} {} {}\n\tscale: {:.2f}\n\ttransform: "
-                                "{}\n\tfocused: {}\n\tdpmsStatus: {}\n\tvrr: {}\n\n",
-                                m->szName.c_str(), m->ID, (int)m->vecPixelSize.x, (int)m->vecPixelSize.y, m->refreshRate, (int)m->vecPosition.x, (int)m->vecPosition.y,
-                                (m->output->description ? m->output->description : ""), (m->output->make ? m->output->make : ""), (m->output->model ? m->output->model : ""),
-                                (m->output->serial ? m->output->serial : ""), m->activeWorkspace, g_pCompositor->getWorkspaceByID(m->activeWorkspace)->m_szName.c_str(),
-                                m->specialWorkspaceID, getWorkspaceNameFromSpecialID(m->specialWorkspaceID).c_str(), (int)m->vecReservedTopLeft.x, (int)m->vecReservedTopLeft.y,
-                                (int)m->vecReservedBottomRight.x, (int)m->vecReservedBottomRight.y, m->scale, (int)m->transform,
-                                (m.get() == g_pCompositor->m_pLastMonitor ? "yes" : "no"), (int)m->dpmsStatus,
-                                (int)(m->output->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED));
+            result +=
+                getFormat("Monitor {} (ID {}):\n\t{}x{}@{:.5f} at {}x{}\n\tdescription: {}\n\tmake: {}\n\tmodel: {}\n\tserial: {}\n\tactive workspace: {} ({})\n\tspecial "
+                          "workspace: {} ({})\n\treserved: {} "
+                          "{} {} {}\n\tscale: {:.2f}\n\ttransform: "
+                          "{}\n\tfocused: {}\n\tdpmsStatus: {}\n\tvrr: {}\n\n",
+                          m->szName, m->ID, (int)m->vecPixelSize.x, (int)m->vecPixelSize.y, m->refreshRate, (int)m->vecPosition.x, (int)m->vecPosition.y,
+                          (m->output->description ? m->output->description : ""), (m->output->make ? m->output->make : ""), (m->output->model ? m->output->model : ""),
+                          (m->output->serial ? m->output->serial : ""), m->activeWorkspace, g_pCompositor->getWorkspaceByID(m->activeWorkspace)->m_szName, m->specialWorkspaceID,
+                          getWorkspaceNameFromSpecialID(m->specialWorkspaceID), (int)m->vecReservedTopLeft.x, (int)m->vecReservedTopLeft.y, (int)m->vecReservedBottomRight.x,
+                          (int)m->vecReservedBottomRight.y, m->scale, (int)m->transform, (m.get() == g_pCompositor->m_pLastMonitor ? "yes" : "no"), (int)m->dpmsStatus,
+                          (int)(m->output->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED));
         }
     }
 
@@ -173,15 +172,15 @@ static std::string getWindowData(CWindow* w, HyprCtl::eHyprCtlOutputFormat forma
             "{}\n\tinitialClass: {}\n\tinitialTitle: {}\n\tpid: "
             "{}\n\txwayland: {}\n\tpinned: "
             "{}\n\tfullscreen: {}\n\tfullscreenmode: {}\n\tfakefullscreen: {}\n\tgrouped: {}\n\tswallowing: {:x}\n\n",
-            (uintptr_t)w, w->m_szTitle.c_str(), (int)w->m_bIsMapped, (int)w->isHidden(), (int)w->m_vRealPosition.goalv().x, (int)w->m_vRealPosition.goalv().y,
+            (uintptr_t)w, w->m_szTitle, (int)w->m_bIsMapped, (int)w->isHidden(), (int)w->m_vRealPosition.goalv().x, (int)w->m_vRealPosition.goalv().y,
             (int)w->m_vRealSize.goalv().x, (int)w->m_vRealSize.goalv().y, w->m_iWorkspaceID,
             (w->m_iWorkspaceID == -1                                ? "" :
-                 g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID) ? g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID)->m_szName.c_str() :
-                                                                      std::string("Invalid workspace " + std::to_string(w->m_iWorkspaceID)).c_str()),
-            (int)w->m_bIsFloating, w->m_iMonitorID, g_pXWaylandManager->getAppIDClass(w).c_str(), g_pXWaylandManager->getTitle(w).c_str(), w->m_szInitialClass.c_str(),
-            w->m_szInitialTitle.c_str(), w->getPID(), (int)w->m_bIsX11, (int)w->m_bPinned, (int)w->m_bIsFullscreen,
+                 g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID) ? g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID)->m_szName :
+                                                                      std::string("Invalid workspace " + std::to_string(w->m_iWorkspaceID))),
+            (int)w->m_bIsFloating, w->m_iMonitorID, g_pXWaylandManager->getAppIDClass(w), g_pXWaylandManager->getTitle(w), w->m_szInitialClass, w->m_szInitialTitle, w->getPID(),
+            (int)w->m_bIsX11, (int)w->m_bPinned, (int)w->m_bIsFullscreen,
             (w->m_bIsFullscreen ? (g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID) ? g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID)->m_efFullscreenMode : 0) : 0),
-            (int)w->m_bFakeFullscreenState, getGroupedData(w, format).c_str(), (uintptr_t)w->m_pSwallowed);
+            (int)w->m_bFakeFullscreenState, getGroupedData(w, format), (uintptr_t)w->m_pSwallowed);
     }
 }
 
@@ -218,13 +217,12 @@ static std::string getWorkspaceData(CWorkspace* w, HyprCtl::eHyprCtlOutputFormat
     "lastwindow": "0x{:x}",
     "lastwindowtitle": "{}"
 }})#",
-                         w->m_iID, escapeJSONStrings(w->m_szName).c_str(), escapeJSONStrings(PMONITOR ? PMONITOR->szName : "?").c_str(),
-                         g_pCompositor->getWindowsOnWorkspace(w->m_iID), ((int)w->m_bHasFullscreenWindow == 1 ? "true" : "false"), (uintptr_t)PLASTW,
-                         PLASTW ? escapeJSONStrings(PLASTW->m_szTitle).c_str() : "");
+                         w->m_iID, escapeJSONStrings(w->m_szName), escapeJSONStrings(PMONITOR ? PMONITOR->szName : "?"), g_pCompositor->getWindowsOnWorkspace(w->m_iID),
+                         ((int)w->m_bHasFullscreenWindow == 1 ? "true" : "false"), (uintptr_t)PLASTW, PLASTW ? escapeJSONStrings(PLASTW->m_szTitle) : "");
     } else {
-        return getFormat("workspace ID {} ({}) on monitor {}:\n\twindows: {}\n\thasfullscreen: {}\n\tlastwindow: 0x{:x}\n\tlastwindowtitle: {}\n\n", w->m_iID, w->m_szName.c_str(),
-                         PMONITOR ? PMONITOR->szName.c_str() : "?", g_pCompositor->getWindowsOnWorkspace(w->m_iID), (int)w->m_bHasFullscreenWindow, (uintptr_t)PLASTW,
-                         PLASTW ? PLASTW->m_szTitle.c_str() : "");
+        return getFormat("workspace ID {} ({}) on monitor {}:\n\twindows: {}\n\thasfullscreen: {}\n\tlastwindow: 0x{:x}\n\tlastwindowtitle: {}\n\n", w->m_iID, w->m_szName,
+                         PMONITOR ? PMONITOR->szName : "?", g_pCompositor->getWindowsOnWorkspace(w->m_iID), (int)w->m_bHasFullscreenWindow, (uintptr_t)PLASTW,
+                         PLASTW ? PLASTW->m_szTitle : "");
     }
 }
 
@@ -280,7 +278,7 @@ std::string layersRequest(HyprCtl::eHyprCtlOutputFormat format) {
                 R"#("{}": {{
     "levels": {{
 )#",
-                escapeJSONStrings(mon->szName).c_str());
+                escapeJSONStrings(mon->szName));
 
             int layerLevel = 0;
             for (auto& level : mon->m_aLayerSurfaceLayers) {
@@ -299,7 +297,7 @@ std::string layersRequest(HyprCtl::eHyprCtlOutputFormat format) {
                     "h": {},
                     "namespace": "{}"
                 }},)#",
-                        (uintptr_t)layer.get(), layer->geometry.x, layer->geometry.y, layer->geometry.width, layer->geometry.height, escapeJSONStrings(layer->szNamespace).c_str());
+                        (uintptr_t)layer.get(), layer->geometry.x, layer->geometry.y, layer->geometry.width, layer->geometry.height, escapeJSONStrings(layer->szNamespace));
                 }
 
                 trimTrailingComma(result);
@@ -323,15 +321,15 @@ std::string layersRequest(HyprCtl::eHyprCtlOutputFormat format) {
 
     } else {
         for (auto& mon : g_pCompositor->m_vMonitors) {
-            result += getFormat("Monitor {}:\n", mon->szName.c_str());
+            result += getFormat("Monitor {}:\n", mon->szName);
             int                                     layerLevel = 0;
             static const std::array<std::string, 4> levelNames = {"background", "bottom", "top", "overlay"};
             for (auto& level : mon->m_aLayerSurfaceLayers) {
-                result += getFormat("\tLayer level {} ({}):\n", layerLevel, levelNames[layerLevel].c_str());
+                result += getFormat("\tLayer level {} ({}):\n", layerLevel, levelNames[layerLevel]);
 
                 for (auto& layer : level) {
                     result += getFormat("\t\tLayer {:x}: xywh: {} {} {} {}, namespace: {}\n", (uintptr_t)layer.get(), layer->geometry.x, layer->geometry.y, layer->geometry.width,
-                                        layer->geometry.height, layer->szNamespace.c_str());
+                                        layer->geometry.height, layer->szNamespace);
                 }
 
                 layerLevel++;
@@ -357,7 +355,7 @@ std::string devicesRequest(HyprCtl::eHyprCtlOutputFormat format) {
         "name": "{}",
         "defaultSpeed": {:.5f}
     }},)#",
-                (uintptr_t)&m, escapeJSONStrings(m.name).c_str(),
+                (uintptr_t)&m, escapeJSONStrings(m.name),
                 wlr_input_device_is_libinput(m.mouse) ? libinput_device_config_accel_get_default_speed((libinput_device*)wlr_libinput_get_device_handle(m.mouse)) : 0.f);
         }
 
@@ -379,9 +377,9 @@ std::string devicesRequest(HyprCtl::eHyprCtlOutputFormat format) {
         "active_keymap": "{}",
         "main": {}
     }},)#",
-                (uintptr_t)&k, escapeJSONStrings(k.name).c_str(), escapeJSONStrings(k.currentRules.rules).c_str(), escapeJSONStrings(k.currentRules.model).c_str(),
-                escapeJSONStrings(k.currentRules.layout).c_str(), escapeJSONStrings(k.currentRules.variant).c_str(), escapeJSONStrings(k.currentRules.options).c_str(),
-                escapeJSONStrings(KM).c_str(), (k.active ? "true" : "false"));
+                (uintptr_t)&k, escapeJSONStrings(k.name), escapeJSONStrings(k.currentRules.rules), escapeJSONStrings(k.currentRules.model),
+                escapeJSONStrings(k.currentRules.layout), escapeJSONStrings(k.currentRules.variant), escapeJSONStrings(k.currentRules.options), escapeJSONStrings(KM),
+                (k.active ? "true" : "false"));
         }
 
         trimTrailingComma(result);
@@ -399,7 +397,7 @@ std::string devicesRequest(HyprCtl::eHyprCtlOutputFormat format) {
             "name": "{}"
         }}
     }},)#",
-                (uintptr_t)&d, (uintptr_t)d.pTabletParent, escapeJSONStrings(d.pTabletParent ? d.pTabletParent->name : "").c_str());
+                (uintptr_t)&d, (uintptr_t)d.pTabletParent, escapeJSONStrings(d.pTabletParent ? d.pTabletParent->name : ""));
         }
 
         for (auto& d : g_pInputManager->m_lTablets) {
@@ -408,7 +406,7 @@ std::string devicesRequest(HyprCtl::eHyprCtlOutputFormat format) {
         "address": "0x{:x}",
         "name": "{}"
     }},)#",
-                (uintptr_t)&d, escapeJSONStrings(d.name).c_str());
+                (uintptr_t)&d, escapeJSONStrings(d.name));
         }
 
         for (auto& d : g_pInputManager->m_lTabletTools) {
@@ -432,7 +430,7 @@ std::string devicesRequest(HyprCtl::eHyprCtlOutputFormat format) {
         "address": "0x{:x}",
         "name": "{}"
     }},)#",
-                (uintptr_t)&d, d.name.c_str());
+                (uintptr_t)&d, d.name);
         }
 
         trimTrailingComma(result);
@@ -459,7 +457,7 @@ std::string devicesRequest(HyprCtl::eHyprCtlOutputFormat format) {
 
         for (auto& m : g_pInputManager->m_lMice) {
             result += getFormat(
-                "\tMouse at {:x}:\n\t\t{}\n\t\t\tdefault speed: {:.5f}\n", (uintptr_t)&m, m.name.c_str(),
+                "\tMouse at {:x}:\n\t\t{}\n\t\t\tdefault speed: {:.5f}\n", (uintptr_t)&m, m.name,
                 (wlr_input_device_is_libinput(m.mouse) ? libinput_device_config_accel_get_default_speed((libinput_device*)wlr_libinput_get_device_handle(m.mouse)) : 0.f));
         }
 
@@ -467,19 +465,19 @@ std::string devicesRequest(HyprCtl::eHyprCtlOutputFormat format) {
 
         for (auto& k : g_pInputManager->m_lKeyboards) {
             const auto KM = g_pInputManager->getActiveLayoutForKeyboard(&k);
-            result += getFormat("\tKeyboard at {:x}:\n\t\t{}\n\t\t\trules: r \"{}\", m \"{}\", l \"{}\", v \"{}\", o \"{}\"\n\t\t\tactive keymap: {}\n\t\t\tmain: {}\n",
-                                (uintptr_t)&k, k.name.c_str(), k.currentRules.rules.c_str(), k.currentRules.model.c_str(), k.currentRules.layout.c_str(),
-                                k.currentRules.variant.c_str(), k.currentRules.options.c_str(), KM.c_str(), (k.active ? "yes" : "no"));
+            result +=
+                getFormat("\tKeyboard at {:x}:\n\t\t{}\n\t\t\trules: r \"{}\", m \"{}\", l \"{}\", v \"{}\", o \"{}\"\n\t\t\tactive keymap: {}\n\t\t\tmain: {}\n", (uintptr_t)&k,
+                          k.name, k.currentRules.rules, k.currentRules.model, k.currentRules.layout, k.currentRules.variant, k.currentRules.options, KM, (k.active ? "yes" : "no"));
         }
 
         result += "\n\nTablets:\n";
 
         for (auto& d : g_pInputManager->m_lTabletPads) {
-            result += getFormat("\tTablet Pad at {:x} (belongs to {:x} -> {})\n", (uintptr_t)&d, (uintptr_t)d.pTabletParent, d.pTabletParent ? d.pTabletParent->name.c_str() : "");
+            result += getFormat("\tTablet Pad at {:x} (belongs to {:x} -> {})\n", (uintptr_t)&d, (uintptr_t)d.pTabletParent, d.pTabletParent ? d.pTabletParent->name : "");
         }
 
         for (auto& d : g_pInputManager->m_lTablets) {
-            result += getFormat("\tTablet at {:x}:\n\t\t{}\n", (uintptr_t)&d, d.name.c_str());
+            result += getFormat("\tTablet at {:x}:\n\t\t{}\n", (uintptr_t)&d, d.name);
         }
 
         for (auto& d : g_pInputManager->m_lTabletTools) {
@@ -489,7 +487,7 @@ std::string devicesRequest(HyprCtl::eHyprCtlOutputFormat format) {
         result += "\n\nTouch:\n";
 
         for (auto& d : g_pInputManager->m_lTouchDevices) {
-            result += getFormat("\tTouch Device at {:x}:\n\t\t{}\n", (uintptr_t)&d, d.name.c_str());
+            result += getFormat("\tTouch Device at {:x}:\n\t\t{}\n", (uintptr_t)&d, d.name);
         }
 
         result += "\n\nSwitches:\n";
@@ -508,14 +506,14 @@ std::string animationsRequest(HyprCtl::eHyprCtlOutputFormat format) {
         ret += "animations:\n";
 
         for (auto& ac : g_pConfigManager->getAnimationConfig()) {
-            ret += getFormat("\n\tname: {}\n\t\toverriden: {}\n\t\tbezier: {}\n\t\tenabled: {}\n\t\tspeed: {:.2f}\n\t\tstyle: {}\n", ac.first.c_str(), (int)ac.second.overridden,
-                             ac.second.internalBezier.c_str(), ac.second.internalEnabled, ac.second.internalSpeed, ac.second.internalStyle.c_str());
+            ret += getFormat("\n\tname: {}\n\t\toverriden: {}\n\t\tbezier: {}\n\t\tenabled: {}\n\t\tspeed: {:.2f}\n\t\tstyle: {}\n", ac.first, (int)ac.second.overridden,
+                             ac.second.internalBezier, ac.second.internalEnabled, ac.second.internalSpeed, ac.second.internalStyle);
         }
 
         ret += "beziers:\n";
 
         for (auto& bz : g_pAnimationManager->getAllBeziers()) {
-            ret += getFormat("\n\tname: {}\n", bz.first.c_str());
+            ret += getFormat("\n\tname: {}\n", bz.first);
         }
     } else {
         // json
@@ -531,8 +529,8 @@ std::string animationsRequest(HyprCtl::eHyprCtlOutputFormat format) {
     "speed": {:.2f},
     "style": "{}"
 }},)#",
-                             ac.first.c_str(), ac.second.overridden ? "true" : "false", ac.second.internalBezier.c_str(), ac.second.internalEnabled ? "true" : "false",
-                             ac.second.internalSpeed, ac.second.internalStyle.c_str());
+                             ac.first, ac.second.overridden ? "true" : "false", ac.second.internalBezier, ac.second.internalEnabled ? "true" : "false", ac.second.internalSpeed,
+                             ac.second.internalStyle);
         }
 
         ret[ret.length() - 1] = ']';
@@ -544,7 +542,7 @@ std::string animationsRequest(HyprCtl::eHyprCtlOutputFormat format) {
 {{
     "name": "{}"
 }},)#",
-                             bz.first.c_str());
+                             bz.first);
         }
 
         trimTrailingComma(ret);
@@ -560,7 +558,7 @@ std::string globalShortcutsRequest(HyprCtl::eHyprCtlOutputFormat format) {
     const auto  SHORTCUTS = g_pProtocolManager->m_pGlobalShortcutsProtocolManager->getAllShortcuts();
     if (format == HyprCtl::eHyprCtlOutputFormat::FORMAT_NORMAL) {
         for (auto& sh : SHORTCUTS)
-            ret += getFormat("{}:{} -> {}\n", sh.appid.c_str(), sh.id.c_str(), sh.description.c_str());
+            ret += getFormat("{}:{} -> {}\n", sh.appid, sh.id, sh.description);
     } else {
         ret += "[";
         for (auto& sh : SHORTCUTS) {
@@ -569,7 +567,7 @@ std::string globalShortcutsRequest(HyprCtl::eHyprCtlOutputFormat format) {
     "name": "{}",
     "description": "{}"
 }},)#",
-                             escapeJSONStrings(sh.appid + ":" + sh.id).c_str(), escapeJSONStrings(sh.description).c_str());
+                             escapeJSONStrings(sh.appid + ":" + sh.id), escapeJSONStrings(sh.description));
         }
         trimTrailingComma(ret);
         ret += "]\n";
@@ -594,8 +592,8 @@ std::string bindsRequest(HyprCtl::eHyprCtlOutputFormat format) {
             if (kb.nonConsuming)
                 ret += "n";
 
-            ret += getFormat("\n\tmodmask: {}\n\tsubmap: {}\n\tkey: {}\n\tkeycode: {}\n\tdispatcher: {}\n\targ: {}\n\n", kb.modmask, kb.submap.c_str(), kb.key.c_str(), kb.keycode,
-                             kb.handler.c_str(), kb.arg.c_str());
+            ret += getFormat("\n\tmodmask: {}\n\tsubmap: {}\n\tkey: {}\n\tkeycode: {}\n\tdispatcher: {}\n\targ: {}\n\n", kb.modmask, kb.submap, kb.key, kb.keycode, kb.handler,
+                             kb.arg);
         }
     } else {
         // json
@@ -617,8 +615,7 @@ std::string bindsRequest(HyprCtl::eHyprCtlOutputFormat format) {
     "arg": "{}"
 }},)#",
                 kb.locked ? "true" : "false", kb.mouse ? "true" : "false", kb.release ? "true" : "false", kb.repeat ? "true" : "false", kb.nonConsuming ? "true" : "false",
-                kb.modmask, escapeJSONStrings(kb.submap).c_str(), escapeJSONStrings(kb.key).c_str(), kb.keycode, escapeJSONStrings(kb.handler).c_str(),
-                escapeJSONStrings(kb.arg).c_str());
+                kb.modmask, escapeJSONStrings(kb.submap), escapeJSONStrings(kb.key), kb.keycode, escapeJSONStrings(kb.handler), escapeJSONStrings(kb.arg));
         }
         trimTrailingComma(ret);
         ret += "]";
@@ -659,7 +656,7 @@ std::string versionRequest(HyprCtl::eHyprCtlOutputFormat format) {
     "commit_message": "{}",
     "tag": "{}",
     "flags": [)#",
-            GIT_BRANCH, GIT_COMMIT_HASH, (strcmp(GIT_DIRTY, "dirty") == 0 ? "true" : "false"), escapeJSONStrings(commitMsg).c_str(), GIT_TAG);
+            GIT_BRANCH, GIT_COMMIT_HASH, (strcmp(GIT_DIRTY, "dirty") == 0 ? "true" : "false"), escapeJSONStrings(commitMsg), GIT_TAG);
 
 #ifdef LEGACY_RENDERER
         result += "\"legacyrenderer\",";
@@ -700,7 +697,7 @@ std::string dispatchRequest(std::string in) {
 
     DISPATCHER->second(DISPATCHARG);
 
-    Debug::log(LOG, "Hyprctl: dispatcher {} : {}", DISPATCHSTR.c_str(), DISPATCHARG.c_str());
+    Debug::log(LOG, "Hyprctl: dispatcher {} : {}", DISPATCHSTR, DISPATCHARG);
 
     return "ok";
 }
@@ -745,7 +742,7 @@ std::string dispatchKeyword(std::string in) {
         }
     }
 
-    Debug::log(LOG, "Hyprctl: keyword {} : {}", COMMAND.c_str(), VALUE.c_str());
+    Debug::log(LOG, "Hyprctl: keyword {} : {}", COMMAND, VALUE);
 
     if (retval == "")
         return "ok";
@@ -1171,8 +1168,7 @@ std::string dispatchPlugin(std::string request) {
 
         std::string list = "";
         for (auto& p : PLUGINS) {
-            list += getFormat("\nPlugin {} by {}:\n\tHandle: {:x}\n\tVersion: {}\n\tDescription: {}\n", p->name.c_str(), p->author.c_str(), (uintptr_t)p->m_pHandle,
-                              p->version.c_str(), p->description.c_str());
+            list += getFormat("\nPlugin {} by {}:\n\tHandle: {:x}\n\tVersion: {}\n\tDescription: {}\n", p->name, p->author, (uintptr_t)p->m_pHandle, p->version, p->description);
         }
 
         return list;
@@ -1375,7 +1371,7 @@ void HyprCtl::startHyprCtlSocket() {
     // 10 max queued.
     listen(iSocketFD, 10);
 
-    Debug::log(LOG, "Hypr socket started at {}", socketPath.c_str());
+    Debug::log(LOG, "Hypr socket started at {}", socketPath);
 
     wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, iSocketFD, WL_EVENT_READABLE, hyprCtlFDTick, nullptr);
 }

--- a/src/events/Layers.cpp
+++ b/src/events/Layers.cpp
@@ -26,7 +26,7 @@ void Events::listener_newLayerSurface(wl_listener* listener, void* data) {
             return;
         }
 
-        Debug::log(LOG, "New LayerSurface has no preferred monitor. Assigning Monitor {}", PMONITOR->szName.c_str());
+        Debug::log(LOG, "New LayerSurface has no preferred monitor. Assigning Monitor {}", PMONITOR->szName);
 
         WLRLAYERSURFACE->output = PMONITOR->output;
     }
@@ -56,7 +56,7 @@ void Events::listener_newLayerSurface(wl_listener* listener, void* data) {
     layerSurface->forceBlur = g_pConfigManager->shouldBlurLS(layerSurface->szNamespace);
 
     Debug::log(LOG, "LayerSurface {:x} (namespace {} layer {}) created on monitor {}", (uintptr_t)layerSurface->layerSurface, layerSurface->layerSurface->_namespace,
-               (int)layerSurface->layer, PMONITOR->szName.c_str());
+               (int)layerSurface->layer, PMONITOR->szName);
 }
 
 void Events::listener_destroyLayerSurface(void* owner, void* data) {

--- a/src/events/Misc.cpp
+++ b/src/events/Misc.cpp
@@ -58,7 +58,7 @@ void Events::listener_readyXWayland(wl_listener* listener, void* data) {
         xcb_intern_atom_reply_t* reply  = xcb_intern_atom_reply(XCBCONNECTION, cookie, NULL);
 
         if (!reply) {
-            Debug::log(LogLevel::ERR, "XWayland -> Atom failed: {}", ATOM.first.c_str());
+            Debug::log(LogLevel::ERR, "XWayland -> Atom failed: {}", ATOM.first);
             continue;
         }
 

--- a/src/events/Monitors.cpp
+++ b/src/events/Monitors.cpp
@@ -186,7 +186,7 @@ void Events::listener_monitorDestroy(void* owner, void* data) {
     pMonitor->output                 = nullptr;
     pMonitor->m_bRenderingInitPassed = false;
 
-    Debug::log(LOG, "Removing monitor {} from realMonitors", pMonitor->szName.c_str());
+    Debug::log(LOG, "Removing monitor {} from realMonitors", pMonitor->szName);
 
     std::erase_if(g_pCompositor->m_vRealMonitors, [&](std::shared_ptr<CMonitor>& el) { return el.get() == pMonitor; });
 }

--- a/src/events/Popups.cpp
+++ b/src/events/Popups.cpp
@@ -103,7 +103,7 @@ void Events::listener_newPopupXDG(void* owner, void* data) {
     if (!PWINDOW->m_bIsMapped)
         return;
 
-    Debug::log(LOG, "New layer popup created from XDG window {:x} -> {}", (uintptr_t)PWINDOW, PWINDOW->m_szTitle.c_str());
+    Debug::log(LOG, "New layer popup created from XDG window {:x} -> {}", (uintptr_t)PWINDOW, PWINDOW->m_szTitle);
 
     const auto WLRPOPUP = (wlr_xdg_popup*)data;
 
@@ -125,7 +125,7 @@ void Events::listener_newPopupFromPopupXDG(void* owner, void* data) {
     ASSERT(PPOPUP);
 
     if (PPOPUP->parentWindow)
-        Debug::log(LOG, "New popup created from XDG Window popup {:x} -> {}", (uintptr_t)PPOPUP, PPOPUP->parentWindow->m_szTitle.c_str());
+        Debug::log(LOG, "New popup created from XDG Window popup {:x} -> {}", (uintptr_t)PPOPUP, PPOPUP->parentWindow->m_szTitle);
     else
         Debug::log(LOG, "New popup created from Non-Window popup {:x}", (uintptr_t)PPOPUP);
 

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -134,7 +134,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                         if (PMONITOR)
                             PWINDOW->m_iMonitorID = PMONITOR->ID;
                         else {
-                            Debug::log(ERR, "No monitor in monitor {} rule", MONITORSTR.c_str());
+                            Debug::log(ERR, "No monitor in monitor {} rule", MONITORSTR);
                             continue;
                         }
                     }
@@ -149,7 +149,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                 PWINDOW->m_iWorkspaceID = PMONITOR->specialWorkspaceID ? PMONITOR->specialWorkspaceID : PMONITOR->activeWorkspace;
 
                 Debug::log(ERR, "Rule monitor, applying to window {:x} -> mon: {}, workspace: {}", (uintptr_t)PWINDOW, PWINDOW->m_iMonitorID, PWINDOW->m_iWorkspaceID);
-            } catch (std::exception& e) { Debug::log(ERR, "Rule monitor failed, rule: {} -> {} | err: {}", r.szRule.c_str(), r.szValue.c_str(), e.what()); }
+            } catch (std::exception& e) { Debug::log(ERR, "Rule monitor failed, rule: {} -> {} | err: {}", r.szRule, r.szValue, e.what()); }
         } else if (r.szRule.find("workspace") == 0) {
             // check if it isnt unset
             const auto WORKSPACERQ = r.szRule.substr(r.szRule.find_first_of(' ') + 1);
@@ -165,7 +165,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
             if (JUSTWORKSPACE == PWORKSPACE->m_szName || JUSTWORKSPACE == "name:" + PWORKSPACE->m_szName)
                 requestedWorkspace = "";
 
-            Debug::log(LOG, "Rule workspace matched by window {:x}, {} applied.", (uintptr_t)PWINDOW, r.szValue.c_str());
+            Debug::log(LOG, "Rule workspace matched by window {:x}, {} applied.", (uintptr_t)PWINDOW, r.szValue);
         } else if (r.szRule.find("float") == 0) {
             PWINDOW->m_bIsFloating = true;
         } else if (r.szRule.find("tile") == 0) {
@@ -210,7 +210,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
             } else if (IDLERULE == "fullscreen") {
                 PWINDOW->m_eIdleInhibitMode = IDLEINHIBIT_FULLSCREEN;
             } else {
-                Debug::log(ERR, "Rule idleinhibit: unknown mode {}", IDLERULE.c_str());
+                Debug::log(ERR, "Rule idleinhibit: unknown mode {}", IDLERULE);
             }
         }
         PWINDOW->applyDynamicRule(r);
@@ -289,7 +289,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                     g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goalv());
 
                     PWINDOW->setHidden(false);
-                } catch (...) { Debug::log(LOG, "Rule size failed, rule: {} -> {}", r.szRule.c_str(), r.szValue.c_str()); }
+                } catch (...) { Debug::log(LOG, "Rule size failed, rule: {} -> {}", r.szRule, r.szValue); }
             } else if (r.szRule.find("minsize") == 0) {
                 try {
                     const auto VALUE    = r.szRule.substr(r.szRule.find(' ') + 1);
@@ -303,7 +303,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                     g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goalv());
 
                     PWINDOW->setHidden(false);
-                } catch (...) { Debug::log(LOG, "Rule minsize failed, rule: {} -> {}", r.szRule.c_str(), r.szValue.c_str()); }
+                } catch (...) { Debug::log(LOG, "Rule minsize failed, rule: {} -> {}", r.szRule, r.szValue); }
             } else if (r.szRule.find("maxsize") == 0) {
                 try {
                     const auto VALUE    = r.szRule.substr(r.szRule.find(' ') + 1);
@@ -317,7 +317,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                     g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goalv());
 
                     PWINDOW->setHidden(false);
-                } catch (...) { Debug::log(LOG, "Rule maxsize failed, rule: {} -> {}", r.szRule.c_str(), r.szValue.c_str()); }
+                } catch (...) { Debug::log(LOG, "Rule maxsize failed, rule: {} -> {}", r.szRule, r.szValue); }
             } else if (r.szRule.find("move") == 0) {
                 try {
                     auto       value = r.szRule.substr(r.szRule.find(' ') + 1);
@@ -378,7 +378,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                     PWINDOW->m_vRealPosition = Vector2D(posX, posY) + PMONITOR->vecPosition;
 
                     PWINDOW->setHidden(false);
-                } catch (...) { Debug::log(LOG, "Rule move failed, rule: {} -> {}", r.szRule.c_str(), r.szValue.c_str()); }
+                } catch (...) { Debug::log(LOG, "Rule move failed, rule: {} -> {}", r.szRule, r.szValue); }
             } else if (r.szRule.find("center") == 0) {
                 auto       RESERVEDOFFSET = Vector2D();
                 const auto ARGS           = CVarList(r.szRule, 2, ' ');
@@ -572,12 +572,12 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
     PWINDOW->m_bFirstMap = false;
 
-    Debug::log(LOG, "Map request dispatched, monitor {}, xywh: {:.5f} {:.5f} {:.5f} {:.5f}", PMONITOR->szName.c_str(), PWINDOW->m_vRealPosition.goalv().x,
+    Debug::log(LOG, "Map request dispatched, monitor {}, xywh: {:.5f} {:.5f} {:.5f} {:.5f}", PMONITOR->szName, PWINDOW->m_vRealPosition.goalv().x,
                PWINDOW->m_vRealPosition.goalv().y, PWINDOW->m_vRealSize.goalv().x, PWINDOW->m_vRealSize.goalv().y);
 
     auto workspaceID = requestedWorkspace != "" ? requestedWorkspace : PWORKSPACE->m_szName;
-    g_pEventManager->postEvent(SHyprIPCEvent{
-        "openwindow", getFormat("{:x},{},{},{}", (uintptr_t)PWINDOW, workspaceID.c_str(), g_pXWaylandManager->getAppIDClass(PWINDOW).c_str(), PWINDOW->m_szTitle.c_str())});
+    g_pEventManager->postEvent(
+        SHyprIPCEvent{"openwindow", getFormat("{:x},{},{},{}", (uintptr_t)PWINDOW, workspaceID, g_pXWaylandManager->getAppIDClass(PWINDOW), PWINDOW->m_szTitle)});
     EMIT_HOOK_EVENT("openWindow", PWINDOW);
 
     // recalc the values for this window
@@ -589,7 +589,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
 void Events::listener_unmapWindow(void* owner, void* data) {
     CWindow* PWINDOW = (CWindow*)owner;
 
-    Debug::log(LOG, "Window {:x} unmapped (class {})", (uintptr_t)PWINDOW, g_pXWaylandManager->getAppIDClass(PWINDOW).c_str());
+    Debug::log(LOG, "Window {:x} unmapped (class {})", (uintptr_t)PWINDOW, g_pXWaylandManager->getAppIDClass(PWINDOW));
 
     if (!PWINDOW->m_pWLSurface.exists() || !PWINDOW->m_bIsMapped) {
         Debug::log(WARN, "Window {:x} unmapped without being mapped??", (uintptr_t)PWINDOW);
@@ -750,7 +750,7 @@ void Events::listener_commitWindow(void* owner, void* data) {
 void Events::listener_destroyWindow(void* owner, void* data) {
     CWindow* PWINDOW = (CWindow*)owner;
 
-    Debug::log(LOG, "Window {:x} destroyed, queueing. (class {})", (uintptr_t)PWINDOW, g_pXWaylandManager->getAppIDClass(PWINDOW).c_str());
+    Debug::log(LOG, "Window {:x} destroyed, queueing. (class {})", (uintptr_t)PWINDOW, g_pXWaylandManager->getAppIDClass(PWINDOW));
 
     if (PWINDOW->m_bIsX11)
         Debug::log(LOG, "XWayland class raw: {}", PWINDOW->m_uSurface.xwayland->_class ? PWINDOW->m_uSurface.xwayland->_class : "null");
@@ -804,7 +804,7 @@ void Events::listener_setTitleWindow(void* owner, void* data) {
     g_pCompositor->updateWindowAnimatedDecorationValues(PWINDOW);
     PWINDOW->updateToplevel();
 
-    Debug::log(LOG, "Window {:x} set title to {}", (uintptr_t)PWINDOW, PWINDOW->m_szTitle.c_str());
+    Debug::log(LOG, "Window {:x} set title to {}", (uintptr_t)PWINDOW, PWINDOW->m_szTitle);
 }
 
 void Events::listener_fullscreenWindow(void* owner, void* data) {

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -210,7 +210,7 @@ float getPlusMinusKeywordResult(std::string source, float relative) {
     try {
         return relative + stof(source);
     } catch (...) {
-        Debug::log(ERR, "Invalid arg \"{}\" in getPlusMinusKeywordResult!", source.c_str());
+        Debug::log(ERR, "Invalid arg \"{}\" in getPlusMinusKeywordResult!", source);
         return INT_MAX;
     }
 }
@@ -537,7 +537,7 @@ void logSystemInfo() {
 #else
     const std::string GPUINFO = execAndGet("lspci -vnn | grep VGA");
 #endif
-    Debug::log(LOG, "GPU information:\n{}\n", GPUINFO.c_str());
+    Debug::log(LOG, "GPU information:\n{}\n", GPUINFO);
 
     if (GPUINFO.contains("NVIDIA")) {
         Debug::log(WARN, "Warning: you're using an NVIDIA GPU. Make sure you follow the instructions on the wiki if anything is amiss.\n");
@@ -546,7 +546,7 @@ void logSystemInfo() {
     // log etc
     Debug::log(LOG, "os-release:");
 
-    Debug::log(NONE, "{}", execAndGet("cat /etc/os-release").c_str());
+    Debug::log(NONE, "{}", execAndGet("cat /etc/os-release"));
 }
 
 void matrixProjection(float mat[9], int w, int h, wl_output_transform tr) {
@@ -590,8 +590,8 @@ int64_t getPPIDof(int64_t pid) {
 
     return 0;
 #else
-    std::string       dir     = "/proc/" + std::to_string(pid) + "/status";
-    FILE*             infile;
+    std::string dir = "/proc/" + std::to_string(pid) + "/status";
+    FILE*       infile;
 
     infile = fopen(dir.c_str(), "r");
     if (!infile)
@@ -702,7 +702,7 @@ std::vector<SCallstackFrameInfo> getBacktrace() {
 }
 
 void throwError(const std::string& err) {
-    Debug::log(CRIT, "Critical error thrown: {}", err.c_str());
+    Debug::log(CRIT, "Critical error thrown: {}", err);
     throw std::runtime_error(err);
 }
 

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -239,7 +239,7 @@ void CMonitor::onDisconnect() {
         m_aLayerSurfaceLayers[i].clear();
     }
 
-    Debug::log(LOG, "Removed monitor {}!", szName.c_str());
+    Debug::log(LOG, "Removed monitor {}!", szName);
 
     g_pEventManager->postEvent(SHyprIPCEvent{"monitorremoved", szName});
     EMIT_HOOK_EVENT("monitorRemoved", this);
@@ -356,7 +356,7 @@ void CMonitor::setupDefaultWS(const SMonitorRule& monitorRule) {
         WORKSPACEID             = g_pCompositor->m_vWorkspaces.size() + 1;
         newDefaultWorkspaceName = std::to_string(WORKSPACEID);
 
-        Debug::log(LOG, "Invalid workspace= directive name in monitor parsing, workspace name \"{}\" is invalid.", g_pConfigManager->getDefaultWorkspaceFor(szName).c_str());
+        Debug::log(LOG, "Invalid workspace= directive name in monitor parsing, workspace name \"{}\" is invalid.", g_pConfigManager->getDefaultWorkspaceFor(szName));
     }
 
     auto PNEWWORKSPACE = g_pCompositor->getWorkspaceByID(WORKSPACEID);

--- a/src/helpers/WLListener.cpp
+++ b/src/helpers/WLListener.cpp
@@ -25,7 +25,7 @@ CHyprWLListener::~CHyprWLListener() {
 
 void CHyprWLListener::removeCallback() {
     if (isConnected()) {
-        Debug::log(LOG, "Callback {:x} -> {:x}, {} removed.", (uintptr_t)&m_pCallback, (uintptr_t)&m_pOwner, m_szAuthor.c_str());
+        Debug::log(LOG, "Callback {:x} -> {:x}, {} removed.", (uintptr_t)&m_pCallback, (uintptr_t)&m_pOwner, m_szAuthor);
         wl_list_remove(&m_swWrapper.m_sListener.link);
         wl_list_init(&m_swWrapper.m_sListener.link);
     }

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -89,7 +89,7 @@ void IHyprLayout::onWindowCreatedFloating(CWindow* pWindow) {
     static auto* const PXWLFORCESCALEZERO = &g_pConfigManager->getConfigValuePtr("xwayland:force_zero_scaling")->intValue;
 
     if (!PMONITOR) {
-        Debug::log(ERR, "Window {:x} ({}) has an invalid monitor in onWindowCreatedFloating!!!", (uintptr_t)pWindow, pWindow->m_szTitle.c_str());
+        Debug::log(ERR, "Window {:x} ({}) has an invalid monitor in onWindowCreatedFloating!!!", (uintptr_t)pWindow, pWindow->m_szTitle);
         return;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,7 +62,7 @@ int main(int argc, char** argv) {
             }
 
             configPath = next_arg;
-            Debug::log(LOG, "User-specified config location: '{}'", configPath.c_str());
+            Debug::log(LOG, "User-specified config location: '{}'", configPath);
 
             it++;
 

--- a/src/managers/EventManager.cpp
+++ b/src/managers/EventManager.cpp
@@ -79,7 +79,7 @@ void CEventManager::startThread() {
         sockaddr_in clientAddress;
         socklen_t   clientSize = sizeof(clientAddress);
 
-        Debug::log(LOG, "Hypr socket 2 started at {}", socketPath.c_str());
+        Debug::log(LOG, "Hypr socket 2 started at {}", socketPath);
 
         while (1) {
             const auto ACCEPTEDCONNECTION = accept4(SOCKET, (sockaddr*)&clientAddress, &clientSize, SOCK_CLOEXEC);
@@ -112,7 +112,7 @@ void CEventManager::flushEvents() {
         for (auto& fd : m_dAcceptedSocketFDs) {
             try {
                 write(fd.first, eventString.c_str(), eventString.length());
-            } catch(...) {}
+            } catch (...) {}
         }
     }
 
@@ -124,7 +124,7 @@ void CEventManager::flushEvents() {
 void CEventManager::postEvent(const SHyprIPCEvent event) {
 
     if (g_pCompositor->m_bIsShuttingDown) {
-        Debug::log(WARN, "Suppressed (ignoreevents true / shutting down) event of type {}, content: {}", event.event.c_str(), event.data.c_str());
+        Debug::log(WARN, "Suppressed (ignoreevents true / shutting down) event of type {}, content: {}", event.event, event.data);
         return;
     }
 

--- a/src/managers/HookSystemManager.cpp
+++ b/src/managers/HookSystemManager.cpp
@@ -73,7 +73,7 @@ std::vector<SCallbackFNPtr>* CHookSystemManager::getVecForEvent(const std::strin
     if (IT != m_lpRegisteredHooks.end())
         return &IT->second;
 
-    Debug::log(LOG, " [hookSystem] New hook event registered: {}", event.c_str());
+    Debug::log(LOG, " [hookSystem] New hook event registered: {}", event);
 
     return &m_lpRegisteredHooks.emplace_back(std::make_pair<>(event, std::vector<SCallbackFNPtr>{})).second;
 }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -428,10 +428,10 @@ bool CKeybindManager::handleKeybinds(const uint32_t& modmask, const std::string&
 
         // Should never happen, as we check in the ConfigManager, but oh well
         if (DISPATCHER == m_mDispatchers.end()) {
-            Debug::log(ERR, "Invalid handler in a keybind! (handler {} does not exist)", k.handler.c_str());
+            Debug::log(ERR, "Invalid handler in a keybind! (handler {} does not exist)", k.handler);
         } else {
             // call the dispatcher
-            Debug::log(LOG, "Keybind triggered, calling dispatcher ({}, {}, {})", modmask, key.c_str(), keysym);
+            Debug::log(LOG, "Keybind triggered, calling dispatcher ({}, {}, {})", modmask, key, keysym);
 
             m_iPassPressed = (int)pressed;
 
@@ -603,7 +603,7 @@ void CKeybindManager::spawn(std::string args) {
 }
 
 uint64_t CKeybindManager::spawnRaw(std::string args) {
-    Debug::log(LOG, "Executing {}", args.c_str());
+    Debug::log(LOG, "Executing {}", args);
 
     int socket[2];
     if (pipe(socket) != 0) {
@@ -1415,7 +1415,7 @@ void CKeybindManager::workspaceOpt(std::string args) {
             }
         }
     } else {
-        Debug::log(ERR, "Invalid arg in workspaceOpt, opt \"{}\" doesn't exist.", args.c_str());
+        Debug::log(ERR, "Invalid arg in workspaceOpt, opt \"{}\" doesn't exist.", args);
         return;
     }
 
@@ -1433,9 +1433,7 @@ void CKeybindManager::renameWorkspace(std::string args) {
         } else {
             g_pCompositor->renameWorkspace(std::stoi(args), "");
         }
-    } catch (std::exception& e) {
-        Debug::log(ERR, "Invalid arg in renameWorkspace, expected numeric id only or a numeric id and string name. \"{}\": \"{}\"", args.c_str(), e.what());
-    }
+    } catch (std::exception& e) { Debug::log(ERR, "Invalid arg in renameWorkspace, expected numeric id only or a numeric id and string name. \"{}\": \"{}\"", args, e.what()); }
 }
 
 void CKeybindManager::exitHyprland(std::string argz) {
@@ -1661,7 +1659,7 @@ void CKeybindManager::focusWindow(std::string regexp) {
     if (!PWINDOW)
         return;
 
-    Debug::log(LOG, "Focusing to window name: {}", PWINDOW->m_szTitle.c_str());
+    Debug::log(LOG, "Focusing to window name: {}", PWINDOW->m_szTitle);
 
     if (g_pCompositor->m_pLastMonitor->activeWorkspace != PWINDOW->m_iWorkspaceID) {
         Debug::log(LOG, "Fake executing workspace to move focus");
@@ -1692,14 +1690,14 @@ void CKeybindManager::setSubmap(std::string submap) {
     for (auto& k : g_pKeybindManager->m_lKeybinds) {
         if (k.submap == submap) {
             m_szCurrentSelectedSubmap = submap;
-            Debug::log(LOG, "Changed keybind submap to {}", submap.c_str());
+            Debug::log(LOG, "Changed keybind submap to {}", submap);
             g_pEventManager->postEvent(SHyprIPCEvent{"submap", submap});
             EMIT_HOOK_EVENT("submap", m_szCurrentSelectedSubmap);
             return;
         }
     }
 
-    Debug::log(ERR, "Cannot set submap {}, submap doesn't exist (wasn't registered!)", submap.c_str());
+    Debug::log(ERR, "Cannot set submap {}, submap doesn't exist (wasn't registered!)", submap);
 }
 
 void CKeybindManager::pass(std::string regexp) {
@@ -1816,7 +1814,7 @@ void CKeybindManager::dpms(std::string arg) {
         m->dpmsStatus = enable;
 
         if (!wlr_output_commit(m->output)) {
-            Debug::log(ERR, "Couldn't commit output {}", m->szName.c_str());
+            Debug::log(ERR, "Couldn't commit output {}", m->szName);
         }
 
         if (enable)

--- a/src/managers/LayoutManager.cpp
+++ b/src/managers/LayoutManager.cpp
@@ -31,7 +31,7 @@ bool CLayoutManager::addLayout(const std::string& name, IHyprLayout* layout) {
 
     m_vLayouts.emplace_back(std::make_pair<>(name, layout));
 
-    Debug::log(LOG, "Added new layout {} at {:x}", name.c_str(), (uintptr_t)layout);
+    Debug::log(LOG, "Added new layout {} at {:x}", name, (uintptr_t)layout);
 
     return true;
 }
@@ -45,7 +45,7 @@ bool CLayoutManager::removeLayout(IHyprLayout* layout) {
     if (m_iCurrentLayoutID == IT - m_vLayouts.begin())
         switchToLayout("dwindle");
 
-    Debug::log(LOG, "Removed a layout {} at {:x}", IT->first.c_str(), (uintptr_t)layout);
+    Debug::log(LOG, "Removed a layout {} at {:x}", IT->first, (uintptr_t)layout);
 
     std::erase(m_vLayouts, *IT);
 

--- a/src/managers/input/IdleInhibitor.cpp
+++ b/src/managers/input/IdleInhibitor.cpp
@@ -33,7 +33,7 @@ void CInputManager::newIdleInhibitor(wlr_idle_inhibitor_v1* pInhibitor) {
     PINHIBIT->pWindow = g_pCompositor->getWindowFromSurface(pInhibitor->surface);
 
     if (PINHIBIT->pWindow)
-        Debug::log(LOG, "IdleInhibitor got window {:x} ({})", (uintptr_t)PINHIBIT->pWindow, PINHIBIT->pWindow->m_szTitle.c_str());
+        Debug::log(LOG, "IdleInhibitor got window {:x} ({})", (uintptr_t)PINHIBIT->pWindow, PINHIBIT->pWindow->m_szTitle);
 
     recheckIdleInhibitorStatus();
 }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -743,7 +743,7 @@ void CInputManager::applyConfigToKeyboard(SKeyboard* pKeyboard) {
 
     const auto HASCONFIG = g_pConfigManager->deviceConfigExists(devname);
 
-    Debug::log(LOG, "ApplyConfigToKeyboard for \"{}\", hasconfig: {}", pKeyboard->name.c_str(), (int)HASCONFIG);
+    Debug::log(LOG, "ApplyConfigToKeyboard for \"{}\", hasconfig: {}", pKeyboard->name, (int)HASCONFIG);
 
     ASSERT(pKeyboard);
 
@@ -1029,7 +1029,7 @@ void CInputManager::setPointerConfigs() {
             libinput_device_config_scroll_set_button_lock(LIBINPUTDEV,
                                                           SCROLLBUTTONLOCK == 0 ? LIBINPUT_CONFIG_SCROLL_BUTTON_LOCK_DISABLED : LIBINPUT_CONFIG_SCROLL_BUTTON_LOCK_ENABLED);
 
-            Debug::log(LOG, "Applied config to mouse {}, sens {:.2f}", m.name.c_str(), LIBINPUTSENS);
+            Debug::log(LOG, "Applied config to mouse {}, sens {:.2f}", m.name, LIBINPUTSENS);
         }
     }
 }
@@ -1414,7 +1414,7 @@ void CInputManager::setTabletConfigs() {
             const auto LIBINPUTDEV = (libinput_device*)wlr_libinput_get_device_handle(t.wlrDevice);
 
             const int  ROTATION = std::clamp(g_pConfigManager->getDeviceInt(t.name, "transform", "input:tablet:transform"), 0, 7);
-            Debug::log(LOG, "Setting calibration matrix for device {}", t.name.c_str());
+            Debug::log(LOG, "Setting calibration matrix for device {}", t.name);
             libinput_device_config_calibration_set_matrix(LIBINPUTDEV, MATRICES[ROTATION]);
 
             const auto OUTPUT   = g_pConfigManager->getDeviceString(t.name, "output", "input:tablet:output");
@@ -1454,17 +1454,17 @@ void CInputManager::newSwitch(wlr_input_device* pDevice) {
             if (PDEVICE->status != -1 && PDEVICE->status == E->switch_state)
                 return;
 
-            Debug::log(LOG, "Switch {} fired, triggering binds.", NAME.c_str());
+            Debug::log(LOG, "Switch {} fired, triggering binds.", NAME);
 
             g_pKeybindManager->onSwitchEvent(NAME);
 
             switch (E->switch_state) {
                 case WLR_SWITCH_STATE_ON:
-                    Debug::log(LOG, "Switch {} turn on, triggering binds.", NAME.c_str());
+                    Debug::log(LOG, "Switch {} turn on, triggering binds.", NAME);
                     g_pKeybindManager->onSwitchOnEvent(NAME);
                     break;
                 case WLR_SWITCH_STATE_OFF:
-                    Debug::log(LOG, "Switch {} turn off, triggering binds.", NAME.c_str());
+                    Debug::log(LOG, "Switch {} turn off, triggering binds.", NAME);
                     g_pKeybindManager->onSwitchOffEvent(NAME);
                     break;
             }

--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -25,7 +25,7 @@ void CInputManager::onSwipeBegin(wlr_pointer_swipe_begin_event* e) {
 void CInputManager::beginWorkspaceSwipe() {
     const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(g_pCompositor->m_pLastMonitor->activeWorkspace);
 
-    Debug::log(LOG, "Starting a swipe from {}", PWORKSPACE->m_szName.c_str());
+    Debug::log(LOG, "Starting a swipe from {}", PWORKSPACE->m_szName);
 
     m_sActiveSwipe.pWorkspaceBegin = PWORKSPACE;
     m_sActiveSwipe.delta           = 0;

--- a/src/plugins/PluginAPI.cpp
+++ b/src/plugins/PluginAPI.cpp
@@ -277,7 +277,7 @@ APICALL std::vector<SFunctionMatch> HyprlandAPI::findFunctionsByName(HANDLE hand
     const auto FPATH = std::filesystem::canonical(exe);
 #elif defined(__OpenBSD__)
     // Neither KERN_PROC_PATHNAME nor /proc are supported
-    const auto        FPATH            = std::filesystem::canonical("/usr/local/bin/Hyprland");
+    const auto FPATH = std::filesystem::canonical("/usr/local/bin/Hyprland");
 #else
     const auto FPATH = std::filesystem::canonical("/proc/self/exe");
 #endif
@@ -305,7 +305,7 @@ APICALL std::vector<SFunctionMatch> HyprlandAPI::findFunctionsByName(HANDLE hand
     };
 
     if (SYMBOLS.empty()) {
-        Debug::log(ERR, "Unable to search for function \"{}\": no symbols found in binary (is \"{}\" in path?)", name.c_str(),
+        Debug::log(ERR, "Unable to search for function \"{}\": no symbols found in binary (is \"{}\" in path?)", name,
 #ifdef __clang__
                    "llvm-nm"
 #else

--- a/src/plugins/PluginSystem.cpp
+++ b/src/plugins/PluginSystem.cpp
@@ -22,7 +22,7 @@ CPlugin* CPluginSystem::loadPlugin(const std::string& path) {
     HANDLE MODULE = dlopen(path.c_str(), RTLD_LAZY);
 
     if (!MODULE) {
-        Debug::log(ERR, " [PluginSystem] Plugin {} could not be loaded: {}", path.c_str(), dlerror());
+        Debug::log(ERR, " [PluginSystem] Plugin {} could not be loaded: {}", path, dlerror());
         m_vLoadedPlugins.pop_back();
         return nullptr;
     }
@@ -33,7 +33,7 @@ CPlugin* CPluginSystem::loadPlugin(const std::string& path) {
     PPLUGIN_INIT_FUNC        initFunc   = (PPLUGIN_INIT_FUNC)dlsym(MODULE, PLUGIN_INIT_FUNC_STR);
 
     if (!apiVerFunc || !initFunc) {
-        Debug::log(ERR, " [PluginSystem] Plugin {} could not be loaded. (No apiver/init func)", path.c_str());
+        Debug::log(ERR, " [PluginSystem] Plugin {} could not be loaded. (No apiver/init func)", path);
         dlclose(MODULE);
         m_vLoadedPlugins.pop_back();
         return nullptr;
@@ -42,7 +42,7 @@ CPlugin* CPluginSystem::loadPlugin(const std::string& path) {
     const std::string PLUGINAPIVER = apiVerFunc();
 
     if (PLUGINAPIVER != HYPRLAND_API_VERSION) {
-        Debug::log(ERR, " [PluginSystem] Plugin {} could not be loaded. (API version mismatch)", path.c_str());
+        Debug::log(ERR, " [PluginSystem] Plugin {} could not be loaded. (API version mismatch)", path);
         dlclose(MODULE);
         m_vLoadedPlugins.pop_back();
         return nullptr;
@@ -60,7 +60,7 @@ CPlugin* CPluginSystem::loadPlugin(const std::string& path) {
         }
     } catch (std::exception& e) {
         m_bAllowConfigVars = false;
-        Debug::log(ERR, " [PluginSystem] Plugin {} (Handle {:x}) crashed in init. Unloading.", path.c_str(), (uintptr_t)MODULE);
+        Debug::log(ERR, " [PluginSystem] Plugin {} (Handle {:x}) crashed in init. Unloading.", path, (uintptr_t)MODULE);
         unloadPlugin(PLUGIN, true); // Plugin could've already hooked/done something
         return nullptr;
     }
@@ -72,8 +72,8 @@ CPlugin* CPluginSystem::loadPlugin(const std::string& path) {
     PLUGIN->version     = PLUGINDATA.version;
     PLUGIN->name        = PLUGINDATA.name;
 
-    Debug::log(LOG, " [PluginSystem] Plugin {} loaded. Handle: {:x}, path: \"{}\", author: \"{}\", description: \"{}\", version: \"{}\"", PLUGINDATA.name.c_str(),
-               (uintptr_t)MODULE, path.c_str(), PLUGINDATA.author.c_str(), PLUGINDATA.description.c_str(), PLUGINDATA.version.c_str());
+    Debug::log(LOG, " [PluginSystem] Plugin {} loaded. Handle: {:x}, path: \"{}\", author: \"{}\", description: \"{}\", version: \"{}\"", PLUGINDATA.name, (uintptr_t)MODULE, path,
+               PLUGINDATA.author, PLUGINDATA.description, PLUGINDATA.version);
 
     return PLUGIN;
 }
@@ -109,7 +109,7 @@ void CPluginSystem::unloadPlugin(const CPlugin* plugin, bool eject) {
 
     dlclose(plugin->m_pHandle);
 
-    Debug::log(LOG, " [PluginSystem] Plugin {} unloaded.", plugin->name.c_str());
+    Debug::log(LOG, " [PluginSystem] Plugin {} unloaded.", plugin->name);
 
     std::erase_if(m_vLoadedPlugins, [&](const auto& other) { return other->m_pHandle == plugin->m_pHandle; });
 
@@ -128,7 +128,7 @@ std::vector<std::string> CPluginSystem::updateConfigPlugins(const std::vector<st
     // unload all plugins that are no longer present
     for (auto& p : m_vLoadedPlugins | std::views::reverse) {
         if (p->m_bLoadedWithConfig && std::find(plugins.begin(), plugins.end(), p->path) == plugins.end()) {
-            Debug::log(LOG, "Unloading plugin {} which is no longer present in config", p->path.c_str());
+            Debug::log(LOG, "Unloading plugin {} which is no longer present in config", p->path);
             unloadPlugin(p.get(), false);
             changed = true;
         }
@@ -137,7 +137,7 @@ std::vector<std::string> CPluginSystem::updateConfigPlugins(const std::vector<st
     // load all new plugins
     for (auto& path : plugins) {
         if (std::find_if(m_vLoadedPlugins.begin(), m_vLoadedPlugins.end(), [&](const auto& other) { return other->path == path; }) == m_vLoadedPlugins.end()) {
-            Debug::log(LOG, "Loading plugin {} which is now present in config", path.c_str());
+            Debug::log(LOG, "Loading plugin {} which is now present in config", path);
             const auto plugin = loadPlugin(path);
 
             if (plugin) {

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1868,7 +1868,7 @@ void CHyprOpenGLImpl::createBGTextureForMonitor(CMonitor* pMonitor) {
     cairo_surface_destroy(CAIROSURFACE);
     cairo_destroy(CAIRO);
 
-    Debug::log(LOG, "Background created for monitor {}", pMonitor->szName.c_str());
+    Debug::log(LOG, "Background created for monitor {}", pMonitor->szName);
 }
 
 void CHyprOpenGLImpl::clearWithTex() {
@@ -1900,7 +1900,7 @@ void CHyprOpenGLImpl::destroyMonitorResources(CMonitor* pMonitor) {
     g_pHyprOpenGL->m_mMonitorRenderResources.erase(pMonitor);
     g_pHyprOpenGL->m_mMonitorBGTextures.erase(pMonitor);
 
-    Debug::log(LOG, "Monitor {} -> destroyed all render data", pMonitor->szName.c_str());
+    Debug::log(LOG, "Monitor {} -> destroyed all render data", pMonitor->szName);
 
     wlr_output_rollback(pMonitor->output);
 }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -763,7 +763,7 @@ bool CHyprRenderer::attemptDirectScanout(CMonitor* pMonitor) {
     if (wlr_output_commit(pMonitor->output)) {
         if (!m_pLastScanout) {
             m_pLastScanout = PCANDIDATE;
-            Debug::log(LOG, "Entered a direct scanout to {:x}: \"{}\"", (uintptr_t)PCANDIDATE, PCANDIDATE->m_szTitle.c_str());
+            Debug::log(LOG, "Entered a direct scanout to {:x}: \"{}\"", (uintptr_t)PCANDIDATE, PCANDIDATE->m_szTitle);
         }
     } else {
         m_pLastScanout = nullptr;
@@ -827,7 +827,7 @@ void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
         if (!pMonitor->noFrameSchedule)
             g_pCompositor->scheduleFrameForMonitor(pMonitor);
         else {
-            Debug::log(LOG, "NoFrameSchedule hit for {}.", pMonitor->szName.c_str());
+            Debug::log(LOG, "NoFrameSchedule hit for {}.", pMonitor->szName);
         }
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(pMonitor->ID);
 
@@ -862,12 +862,12 @@ void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
         const auto PGAMMACTRL = wlr_gamma_control_manager_v1_get_control(g_pCompositor->m_sWLRGammaCtrlMgr, pMonitor->output);
 
         if (!wlr_gamma_control_v1_apply(PGAMMACTRL, &pMonitor->output->pending)) {
-            Debug::log(ERR, "Could not apply gamma control to {}", pMonitor->szName.c_str());
+            Debug::log(ERR, "Could not apply gamma control to {}", pMonitor->szName);
             return;
         }
 
         if (!wlr_output_test(pMonitor->output)) {
-            Debug::log(ERR, "Output test failed for setting gamma to {}", pMonitor->szName.c_str());
+            Debug::log(ERR, "Output test failed for setting gamma to {}", pMonitor->szName);
             wlr_output_rollback(pMonitor->output);
             wlr_gamma_control_v1_send_failed_and_destroy(PGAMMACTRL);
         }
@@ -908,7 +908,7 @@ void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
         wlr_output_lock_software_cursors(pMonitor->output, true);
 
     if (!wlr_output_attach_render(pMonitor->output, &bufferAge)) {
-        Debug::log(ERR, "Couldn't attach render to display {} ???", pMonitor->szName.c_str());
+        Debug::log(ERR, "Couldn't attach render to display {} ???", pMonitor->szName);
 
         if (UNLOCK_SC)
             wlr_output_lock_software_cursors(pMonitor->output, false);
@@ -1370,7 +1370,7 @@ void CHyprRenderer::arrangeLayersForMonitor(const int& monitor) {
 
     g_pLayoutManager->getCurrentLayout()->recalculateMonitor(monitor);
 
-    Debug::log(LOG, "Monitor {} layers arranged: reserved: {:.5f} {:.5f} {:.5f} {:.5f}", PMONITOR->szName.c_str(), PMONITOR->vecReservedTopLeft.x, PMONITOR->vecReservedTopLeft.y,
+    Debug::log(LOG, "Monitor {} layers arranged: reserved: {:.5f} {:.5f} {:.5f} {:.5f}", PMONITOR->szName, PMONITOR->vecReservedTopLeft.x, PMONITOR->vecReservedTopLeft.y,
                PMONITOR->vecReservedBottomRight.x, PMONITOR->vecReservedBottomRight.y);
 }
 
@@ -1435,7 +1435,7 @@ void CHyprRenderer::damageWindow(CWindow* pWindow) {
     static auto* const PLOGDAMAGE = &g_pConfigManager->getConfigValuePtr("debug:log_damage")->intValue;
 
     if (*PLOGDAMAGE)
-        Debug::log(LOG, "Damage: Window ({}): xy: {}, {} wh: {}, {}", pWindow->m_szTitle.c_str(), damageBox.x, damageBox.y, damageBox.width, damageBox.height);
+        Debug::log(LOG, "Damage: Window ({}): xy: {}, {} wh: {}, {}", pWindow->m_szTitle, damageBox.x, damageBox.y, damageBox.width, damageBox.height);
 }
 
 void CHyprRenderer::damageMonitor(CMonitor* pMonitor) {
@@ -1448,7 +1448,7 @@ void CHyprRenderer::damageMonitor(CMonitor* pMonitor) {
     static auto* const PLOGDAMAGE = &g_pConfigManager->getConfigValuePtr("debug:log_damage")->intValue;
 
     if (*PLOGDAMAGE)
-        Debug::log(LOG, "Damage: Monitor {}", pMonitor->szName.c_str());
+        Debug::log(LOG, "Damage: Monitor {}", pMonitor->szName);
 }
 
 void CHyprRenderer::damageBox(wlr_box* pBox) {
@@ -1522,7 +1522,7 @@ DAMAGETRACKINGMODES CHyprRenderer::damageTrackingModeFromStr(const std::string& 
 
 bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorRule, bool force) {
 
-    Debug::log(LOG, "Applying monitor rule for {}", pMonitor->szName.c_str());
+    Debug::log(LOG, "Applying monitor rule for {}", pMonitor->szName);
 
     pMonitor->activeMonitorRule = *pMonitorRule;
 
@@ -1541,7 +1541,7 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
 
     if (!pMonitor->m_bEnabled) {
         pMonitor->onConnect(true); // enable it.
-        Debug::log(LOG, "Monitor {} is disabled but is requested to be enabled", pMonitor->szName.c_str());
+        Debug::log(LOG, "Monitor {} is disabled but is requested to be enabled", pMonitor->szName);
         force = true;
     }
 
@@ -1554,7 +1554,7 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
         pMonitor->transform == pMonitorRule->transform && pMonitorRule->enable10bit == pMonitor->enabled10bit &&
         !memcmp(&pMonitor->customDrmMode, &pMonitorRule->drmMode, sizeof(pMonitor->customDrmMode))) {
 
-        Debug::log(LOG, "Not applying a new rule to {} because it's already applied!", pMonitor->szName.c_str());
+        Debug::log(LOG, "Not applying a new rule to {} because it's already applied!", pMonitor->szName);
         return true;
     }
 
@@ -1853,7 +1853,7 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
     // reload to fix mirrors
     g_pConfigManager->m_bWantsMonitorReload = true;
 
-    Debug::log(LOG, "Monitor {} data dump: res {}x{}@{:.2f}Hz, scale {:.2f}, transform {}, pos {}x{}, 10b {}", pMonitor->szName.c_str(), (int)pMonitor->vecPixelSize.x,
+    Debug::log(LOG, "Monitor {} data dump: res {}x{}@{:.2f}Hz, scale {:.2f}, transform {}, pos {}x{}, 10b {}", pMonitor->szName, (int)pMonitor->vecPixelSize.x,
                (int)pMonitor->vecPixelSize.y, pMonitor->refreshRate, pMonitor->scale, (int)pMonitor->transform, (int)pMonitor->vecPosition.x, (int)pMonitor->vecPosition.y,
                (int)pMonitor->enabled10bit);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

@vaxerski [wished for `c_str()` calls to be removed in a `vformat` context](https://github.com/hyprwm/Hyprland/pull/3195#discussion_r1317477943) (in `Log::...` and `getFormat()`) but was [lazy](https://github.com/hyprwm/Hyprland/pull/3195#discussion_r1317575123) so I did it.

#### Is it ready for merging, or does it need work?

Ready when you are. Should be soon though since this is quite a big changeset and could conflict with a lot.
