### PR TITLE
fix: focusWindow on hidden workspace triggers another focusWindow

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -878,7 +878,7 @@ void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
         const auto PWORKSPACE            = getWorkspaceByID(pWindow->m_iWorkspaceID);
         PWORKSPACE->m_pLastFocusedWindow = pWindow;
         const auto PMONITOR              = getMonitorFromID(PWORKSPACE->m_iMonitorID);
-        PMONITOR->changeWorkspace(PWORKSPACE);
+        PMONITOR->changeWorkspace(PWORKSPACE, false, true);
         // changeworkspace already calls focusWindow
         return;
     }

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -494,7 +494,7 @@ float CMonitor::getDefaultScale() {
     return 1;
 }
 
-void CMonitor::changeWorkspace(CWorkspace* const pWorkspace, bool internal) {
+void CMonitor::changeWorkspace(CWorkspace* const pWorkspace, bool internal, bool noMouseMove) {
     if (!pWorkspace)
         return;
 
@@ -543,8 +543,8 @@ void CMonitor::changeWorkspace(CWorkspace* const pWorkspace, bool internal) {
 
             g_pCompositor->focusWindow(pWindow);
         }
-
-        g_pInputManager->simulateMouseMovement();
+        if (!noMouseMove)
+            g_pInputManager->simulateMouseMovement();
 
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(ID);
 

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -102,7 +102,7 @@ class CMonitor {
     void                       setMirror(const std::string&);
     bool                       isMirror();
     float                      getDefaultScale();
-    void                       changeWorkspace(CWorkspace* const pWorkspace, bool internal = false);
+    void                       changeWorkspace(CWorkspace* const pWorkspace, bool internal = false, bool noMouseMove = false);
     void                       changeWorkspace(const int& id, bool internal = false);
     void                       setSpecialWorkspace(CWorkspace* const pWorkspace);
     void                       setSpecialWorkspace(const int& id);


### PR DESCRIPTION
## Abstract
This commit address an issue where focusing a window on a hidden
workspace inadvertently triggered a second `focusWindow` call due to
simulated mouse movement. This behaviour led to the incorrect focus on
the window under the cursor instead of target window of method
`focusWindow()`, disrupting `focusurgentorlast` and `focuscurrentorlast`
dispatchers. 

## Implementation
Introduced a flag to the `CMonitor::changeWorkspace()`
method to prevent simulated mouse movements. This flag is set to false
by default. Changed the `focusWindow()` method accordingly to set this
flag to true when the target window is in a hidden workspace.


