### PR TITLE
implement pushactivetobottom dispacher

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1288,9 +1288,9 @@ void CCompositor::changeWindowZOrder(CWindow* pWindow, bool top) {
     }
 
     for (auto& pw : toMove) {
-        moveToZ(pw, top);
+        moveToZ(pw, true);
 
-        changeWindowZOrder(pw, top);
+        changeWindowZOrder(pw, true);
     }
 }
 

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1244,10 +1244,6 @@ bool CCompositor::isWindowActive(CWindow* pWindow) {
     return PSURFACE == m_pLastFocus || pWindow == m_pLastWindow;
 }
 
-void CCompositor::moveWindowToTop(CWindow* pWindow) {
-    changeWindowZOrder(pWindow, true);
-}
-
 void CCompositor::changeWindowZOrder(CWindow* pWindow, bool top) {
     if (!windowValidMapped(pWindow))
         return;

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -28,8 +28,7 @@
 #include "hyprerror/HyprError.hpp"
 #include "plugins/PluginSystem.hpp"
 
-enum eManagersInitStage
-{
+enum eManagersInitStage {
     STAGE_PRIORITY = 0,
     STAGE_LATE
 };
@@ -161,6 +160,7 @@ class CCompositor {
     bool           doesSeatAcceptInput(wlr_surface*);
     bool           isWindowActive(CWindow*);
     void           moveWindowToTop(CWindow*);
+    void           changeWindowZOrder(CWindow*, bool);
     void           cleanupFadingOut(const int& monid);
     CWindow*       getWindowInDirection(CWindow*, char);
     CWindow*       getNextWindowOnWorkspace(CWindow*, bool focusableOnly = false);

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -159,7 +159,6 @@ class CCompositor {
     CWindow*       getFullscreenWindowOnWorkspace(const int&);
     bool           doesSeatAcceptInput(wlr_surface*);
     bool           isWindowActive(CWindow*);
-    void           moveWindowToTop(CWindow*);
     void           changeWindowZOrder(CWindow*, bool);
     void           cleanupFadingOut(const int& monid);
     CWindow*       getWindowInDirection(CWindow*, char);

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -393,7 +393,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
         // because the windows are animated on RealSize
         PWINDOW->m_vPseudoSize = PWINDOW->m_vRealSize.goalv();
 
-        g_pCompositor->moveWindowToTop(PWINDOW);
+        g_pCompositor->changeWindowZOrder(PWINDOW, true);
     } else {
         g_pLayoutManager->getCurrentLayout()->onWindowCreated(PWINDOW);
 
@@ -890,7 +890,7 @@ void Events::listener_activateXDG(wl_listener* listener, void* data) {
         return;
 
     if (PWINDOW->m_bIsFloating)
-        g_pCompositor->moveWindowToTop(PWINDOW);
+        g_pCompositor->changeWindowZOrder(PWINDOW, true);
 
     g_pCompositor->focusWindow(PWINDOW);
     Vector2D middle = PWINDOW->m_vRealPosition.goalv() + PWINDOW->m_vRealSize.goalv() / 2.f;
@@ -925,7 +925,7 @@ void Events::listener_activateX11(void* owner, void* data) {
         return;
 
     if (PWINDOW->m_bIsFloating)
-        g_pCompositor->moveWindowToTop(PWINDOW);
+        g_pCompositor->changeWindowZOrder(PWINDOW, true);
 
     g_pCompositor->focusWindow(PWINDOW);
     Vector2D middle = PWINDOW->m_vRealPosition.goalv() + PWINDOW->m_vRealSize.goalv() / 2.f;
@@ -974,7 +974,7 @@ void Events::listener_configureX11(void* owner, void* data) {
 
     PWINDOW->m_iWorkspaceID = g_pCompositor->getMonitorFromVector(PWINDOW->m_vRealPosition.vec() + PWINDOW->m_vRealSize.vec() / 2.f)->activeWorkspace;
 
-    g_pCompositor->moveWindowToTop(PWINDOW);
+    g_pCompositor->changeWindowZOrder(PWINDOW, true);
 
     PWINDOW->m_bCreatedOverFullscreen = true;
 
@@ -1031,7 +1031,7 @@ void Events::listener_unmanagedSetGeometry(void* owner, void* data) {
 
         PWINDOW->m_iWorkspaceID = g_pCompositor->getMonitorFromVector(PWINDOW->m_vRealPosition.vec() + PWINDOW->m_vRealSize.vec() / 2.f)->activeWorkspace;
 
-        g_pCompositor->moveWindowToTop(PWINDOW);
+        g_pCompositor->changeWindowZOrder(PWINDOW, true);
         PWINDOW->updateWindowDecos();
         g_pHyprRenderer->damageWindow(PWINDOW);
     }

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -849,7 +849,7 @@ void CHyprDwindleLayout::fullscreenRequestForWindow(CWindow* pWindow, eFullscree
 
     g_pXWaylandManager->setWindowSize(pWindow, pWindow->m_vRealSize.goalv());
 
-    g_pCompositor->moveWindowToTop(pWindow);
+    g_pCompositor->changeWindowZOrder(pWindow, true);
 
     recalculateMonitor(PMONITOR->ID);
 }

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -161,7 +161,7 @@ void IHyprLayout::onWindowCreatedFloating(CWindow* pWindow) {
     if (pWindow->m_iX11Type != 2) {
         g_pXWaylandManager->setWindowSize(pWindow, pWindow->m_vRealSize.goalv());
 
-        g_pCompositor->moveWindowToTop(pWindow);
+        g_pCompositor->changeWindowZOrder(pWindow, true);
     }
 }
 
@@ -237,7 +237,7 @@ void IHyprLayout::onBeginDragWindow() {
     g_pKeybindManager->shadowKeybinds();
 
     g_pCompositor->focusWindow(DRAGGINGWINDOW);
-    g_pCompositor->moveWindowToTop(DRAGGINGWINDOW);
+    g_pCompositor->changeWindowZOrder(DRAGGINGWINDOW, true);
 }
 
 void IHyprLayout::onEndDragWindow() {
@@ -436,7 +436,7 @@ void IHyprLayout::changeWindowFloatingMode(CWindow* pWindow) {
     } else {
         onWindowRemovedTiling(pWindow);
 
-        g_pCompositor->moveWindowToTop(pWindow);
+        g_pCompositor->changeWindowZOrder(pWindow, true);
 
         if (DELTALESSTHAN(pWindow->m_vRealSize.vec().x, pWindow->m_vLastFloatingSize.x, 10) && DELTALESSTHAN(pWindow->m_vRealSize.vec().y, pWindow->m_vLastFloatingSize.y, 10)) {
             pWindow->m_vRealPosition = pWindow->m_vRealPosition.goalv() + (pWindow->m_vRealSize.goalv() - pWindow->m_vLastFloatingSize) / 2.f + Vector2D{10, 10};

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -721,7 +721,7 @@ void CHyprMasterLayout::fullscreenRequestForWindow(CWindow* pWindow, eFullscreen
 
     g_pXWaylandManager->setWindowSize(pWindow, pWindow->m_vRealSize.goalv());
 
-    g_pCompositor->moveWindowToTop(pWindow);
+    g_pCompositor->changeWindowZOrder(pWindow, true);
 
     recalculateMonitor(PMONITOR->ID);
 }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1979,7 +1979,8 @@ void CKeybindManager::alterZOrder(std::string args) {
 
     if (!PWINDOW && g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_bIsFloating)
         PWINDOW = g_pCompositor->m_pLastWindow;
-    else {
+
+    if (!PWINDOW) {
         Debug::log(ERR, "alterZOrder: no window");
         return;
     }
@@ -1993,7 +1994,6 @@ void CKeybindManager::alterZOrder(std::string args) {
         return;
     }
 
-    // if follow_mouse && mouse_refocus ?
     g_pInputManager->simulateMouseMovement();
 }
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1968,7 +1968,7 @@ void CKeybindManager::mouse(std::string args) {
 
 void CKeybindManager::bringActiveToTop(std::string args) {
     if (g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_bIsFloating)
-        g_pCompositor->moveWindowToTop(g_pCompositor->m_pLastWindow);
+        g_pCompositor->changeWindowZOrder(g_pCompositor->m_pLastWindow, true);
 }
 
 void CKeybindManager::alterZOrder(std::string args) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -62,6 +62,7 @@ CKeybindManager::CKeybindManager() {
     m_mDispatchers["pin"]                           = pinActive;
     m_mDispatchers["mouse"]                         = mouse;
     m_mDispatchers["bringactivetotop"]              = bringActiveToTop;
+    m_mDispatchers["pushactivetobottom"]            = pushActiveToBottom;
     m_mDispatchers["focusurgentorlast"]             = focusUrgentOrLast;
     m_mDispatchers["focuscurrentorlast"]            = focusCurrentOrLast;
     m_mDispatchers["lockgroups"]                    = lockGroups;
@@ -1962,12 +1963,29 @@ void CKeybindManager::mouse(std::string args) {
                 g_pInputManager->dragMode               = MBIND_INVALID;
             }
         }
+    } else if (ARGS[0] == "bringactivetotop") {
+        if (PRESSED) {
+            bringActiveToTop("");
+        }
+    } else if (ARGS[0] == "pushactivetobottom") {
+        if (PRESSED) {
+            pushActiveToBottom("");
+        }
     }
 }
 
 void CKeybindManager::bringActiveToTop(std::string args) {
-    if (g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_bIsFloating)
+    if (g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_bIsFloating) {
         g_pCompositor->moveWindowToTop(g_pCompositor->m_pLastWindow);
+    }
+}
+
+void CKeybindManager::pushActiveToBottom(std::string args) {
+    if (g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_bIsFloating) {
+        g_pCompositor->changeWindowZOrder(g_pCompositor->m_pLastWindow, 0);
+        // if follow_mouse && mouse_refocus ?
+        g_pInputManager->simulateMouseMovement();
+    }
 }
 
 void CKeybindManager::fakeFullscreenActive(std::string args) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1967,9 +1967,8 @@ void CKeybindManager::mouse(std::string args) {
 }
 
 void CKeybindManager::bringActiveToTop(std::string args) {
-    if (g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_bIsFloating) {
+    if (g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_bIsFloating)
         g_pCompositor->moveWindowToTop(g_pCompositor->m_pLastWindow);
-    }
 }
 
 void CKeybindManager::alterZOrder(std::string args) {

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -139,7 +139,7 @@ class CKeybindManager {
     static void     pinActive(std::string);
     static void     mouse(std::string);
     static void     bringActiveToTop(std::string);
-    static void     pushActiveToBottom(std::string);
+    static void     alterZOrder(std::string);
     static void     lockGroups(std::string);
     static void     lockActiveGroup(std::string);
     static void     moveIntoGroup(std::string);

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -28,8 +28,7 @@ struct SKeybind {
     bool shadowed = false;
 };
 
-enum eFocusWindowMode
-{
+enum eFocusWindowMode {
     MODE_CLASS_REGEX = 0,
     MODE_TITLE_REGEX,
     MODE_ADDRESS,
@@ -140,6 +139,7 @@ class CKeybindManager {
     static void     pinActive(std::string);
     static void     mouse(std::string);
     static void     bringActiveToTop(std::string);
+    static void     pushActiveToBottom(std::string);
     static void     lockGroups(std::string);
     static void     lockActiveGroup(std::string);
     static void     moveIntoGroup(std::string);

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -587,7 +587,7 @@ void CInputManager::processMouseDownNormal(wlr_pointer_button_event* e) {
 
             // if clicked on a floating window make it top
             if (g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_bIsFloating)
-                g_pCompositor->moveWindowToTop(g_pCompositor->m_pLastWindow);
+                g_pCompositor->changeWindowZOrder(g_pCompositor->m_pLastWindow, true);
 
             break;
         case WLR_BUTTON_RELEASED: break;


### PR DESCRIPTION
Adds pushactivetobottom dispacher to manage Z-order of floating windows, opposite of bringactivetotop.
Makes both bringactivetotop and pushactivetobottom available to mouse binds.

I had issues with Compositor.cpp:1255 - making this generic with less code via:

```
auto begin = top ? m_vWindows.begin() : (m_vWindows.rbegin() + 1).base();
auto end = top ? m_vWindows.end() : m_vWindows.rend();
```

Never worked for `top=false` regardless of variations to m_vWindows.rbegin().  Being new to C++ I don't know if it's  because of the uses of begin & end inside the algo, or just my botching the cast of the reverse iterator.


In KeybindManager.cpp:1983 I kludged in mouse re-focus behavior without checking follow_mouse or mouse_refocus.  Is this the right place for it?  It doesn't refocus without the simulateMouseMovement() call, but with that call it doesn't obey those 2 options which I would have thought handled in InputManager.cpp around ln 400.

Need to resolve the above with your input, thanks.


