### PR TITLE
Make device configs queryable

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2015,19 +2015,35 @@ SConfigValue* CConfigManager::getConfigValuePtr(const std::string& val) {
 }
 
 SConfigValue* CConfigManager::getConfigValuePtrSafe(const std::string& val) {
-    const auto IT = configValues.find(val);
+    if (val.starts_with("device:")) {
+        const auto DEVICE    = val.substr(7, val.find_last_of(':') - 7);
+        const auto CONFIGVAR = val.substr(val.find_last_of(':') + 1);
 
-    if (IT == configValues.end()) {
-        // maybe plugin
+        const auto DEVICECONF = deviceConfigs.find(DEVICE);
+        if (DEVICECONF == deviceConfigs.end())
+            return nullptr;
+
+        const auto IT = DEVICECONF->second.find(CONFIGVAR);
+
+        if (IT == DEVICECONF->second.end())
+            return nullptr;
+
+        return &IT->second;
+    } else if (val.starts_with("plugin:")) {
         for (auto& [pl, pMap] : pluginConfigs) {
-            const auto PLIT = pMap->find(val);
+            const auto IT = pMap->find(val);
 
-            if (PLIT != pMap->end())
-                return &PLIT->second;
+            if (IT != pMap->end())
+                return &IT->second;
         }
 
         return nullptr;
     }
+
+    const auto IT = configValues.find(val);
+
+    if (IT == configValues.end())
+        return nullptr;
 
     return &(IT->second);
 }

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1039,8 +1039,8 @@ std::string dispatchGetOption(std::string request, HyprCtl::eHyprCtlOutputFormat
         return "no such option";
 
     if (format == HyprCtl::eHyprCtlOutputFormat::FORMAT_NORMAL)
-        return getFormat("option {}\n\tint: {}\n\tfloat: {:.5f}\n\tstr: \"{}\"\n\tdata: {:x}", curitem, PCFGOPT->intValue, PCFGOPT->floatValue, PCFGOPT->strValue,
-                         (uintptr_t)PCFGOPT->data.get());
+        return getFormat("option {}\n\tint: {}\n\tfloat: {:.5f}\n\tstr: \"{}\"\n\tdata: {:x}\n\tset: {}", curitem, PCFGOPT->intValue, PCFGOPT->floatValue, PCFGOPT->strValue,
+                         (uintptr_t)PCFGOPT->data.get(), PCFGOPT->set);
     else {
         return getFormat(
             R"#(
@@ -1049,10 +1049,11 @@ std::string dispatchGetOption(std::string request, HyprCtl::eHyprCtlOutputFormat
     "int": {},
     "float": {:.5f},
     "str": "{}",
-    "data": "0x{:x}"
+    "data": "0x{:x}",
+    "set": {}
 }}
 )#",
-            curitem, PCFGOPT->intValue, PCFGOPT->floatValue, PCFGOPT->strValue, (uintptr_t)PCFGOPT->data.get());
+            curitem, PCFGOPT->intValue, PCFGOPT->floatValue, PCFGOPT->strValue, (uintptr_t)PCFGOPT->data.get(), PCFGOPT->set);
     }
 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Make `device:` configuration options queryable with the `getoption` command on [`.socket.sock`](https://wiki.hyprland.org/IPC/#tmphyprhissocketsock).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?

Ready.
