### PR TITLE
fix(layout): remove `focusWindow` calls from `onWindowCreatedTiling`

### DIFF
--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -341,7 +341,6 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow) {
             pWindow->updateWindowDecos();
             recalculateWindow(pWindow);
 
-            g_pCompositor->focusWindow(pWindow);
             return;
         }
     }

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -120,7 +120,6 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow) {
             pWindow->updateWindowDecos();
             recalculateWindow(pWindow);
 
-            g_pCompositor->focusWindow(pWindow);
             return;
         }
     }


### PR DESCRIPTION
## Abstract

Remove calls to `focusWindow()` from all implementations of `onWindowCreatedTiling()`

## Bug fixed

commit 05047f60f4a6303a26f5ecef712f249b770f27b9 (#2630) introduced a bug where the active workspace incorrectly changes when using silent workspace methods or rules if the target workspace contains an unlocked group.

### Current behaviour

When

- using the `moveActiveToWorkspaceSilent` dispatcher to move the active window to a target workspace
- or using the `[workspace silent]` rules to create a window in the target workspace

and the target workspace **contains an unlocked group**, the active workspace incorrectly changes to the target workspace instead of remaining in the current workspace as intended (not silent).

### Expected behaviour 

Active workspace should remain the same when `moveActiveToWorkspaceSilent` or `[workspace silent]` are used, regardless the content of target workspace.

## Changes

Upon initial static analysis and debugging results, I respectfully suggest that all direct or indirect callers of `onWindowCreatedTiling()` appear to be calling `focusWindow()` themselves, or implying that their operand is active within the context. Therefore, the following lines may be redundant or betray the intention of their direct or indirect callers.

https://github.com/hyprwm/Hyprland/blob/1a6f961de2eff84e4725255f09d33395c4a52fcc/src/layout/DwindleLayout.cpp#L344

https://github.com/hyprwm/Hyprland/blob/1a6f961de2eff84e4725255f09d33395c4a52fcc/src/layout/MasterLayout.cpp#L123

Thus they are removed in this patch.

Please let me know if I have overlooked any significant details or drawn any erroneous assumptions in my conclusions.

