### PR TITLE
Fix wlr_output_management_unstable_v1 protocol

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -580,12 +580,12 @@ void CConfigManager::handleMonitor(const std::string& command, const std::string
                 return;
             }
 
-            wl_output_transform transform = (wl_output_transform)std::stoi(ARGS[2]);
+            const auto TRANSFORM = (wl_output_transform)TSF;
 
             // overwrite if exists
             for (auto& r : m_dMonitorRules) {
                 if (r.name == newrule.name) {
-                    r.transform = transform;
+                    r.transform = TRANSFORM;
                     return;
                 }
             }

--- a/src/events/Monitors.cpp
+++ b/src/events/Monitors.cpp
@@ -38,8 +38,18 @@ void Events::listener_change(wl_listener* listener, void* data) {
 
         CONFIGHEAD->state.enabled = m->output->enabled;
         CONFIGHEAD->state.mode    = m->output->current_mode;
-        CONFIGHEAD->state.x       = m->vecPosition.x;
-        CONFIGHEAD->state.y       = m->vecPosition.y;
+        if (!m->output->current_mode) {
+            CONFIGHEAD->state.custom_mode = {
+                m->output->width,
+                m->output->height,
+                m->output->refresh,
+            };
+        }
+        CONFIGHEAD->state.x                     = m->vecPosition.x;
+        CONFIGHEAD->state.y                     = m->vecPosition.y;
+        CONFIGHEAD->state.transform             = m->transform;
+        CONFIGHEAD->state.scale                 = m->scale;
+        CONFIGHEAD->state.adaptive_sync_enabled = m->vrrActive;
     }
 
     wlr_output_manager_v1_set_configuration(g_pCompositor->m_sWLROutputMgr, CONFIG);

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -86,8 +86,6 @@ void CMonitor::onConnect(bool noRule) {
         if (!wlr_output_commit(output))
             Debug::log(ERR, "Couldn't commit disabled state on output {}", output->name);
 
-        Events::listener_change(nullptr, nullptr);
-
         m_bEnabled = false;
 
         hyprListener_monitorFrame.removeCallback();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes #3220 and #829. The issue is split into two separate bugs:

1.  The `transform` property does not get applied because the function `CHyprRenderer::outputMgrApplyTest` checks for a difference between `OUTPUT->transform` and `PMONITOR->transform` and only applies the new property when they differ. This is a mistake since these properties both represent the active configration (they are the same and don't change until the new rules are applied).
2. Hyprland does not send notifications for monitor configuration changes via the [`head`](https://wayland.app/protocols/wlr-output-management-unstable-v1#zwlr_output_manager_v1:event:head) event. The function `wlr_output_manager_v1_set_configuration` internally sends this event and gets called from `Events::listener_change` which should get called when the properties of a monitor get changed. Instead it only got called in `CMonitor::onConnect()` when a new monitor got added. Additionally the configuration properties sent by `Events::listener_change` were missing the `custom_mode`, `transform` and `adaptive_sync_enabled` property.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Not including the `transform` property in `CHyprRenderer::outputMgrApplyTest` is not possible since the other properties set in `commandForCfg` variable reset the monitor rule for the applicable monitor.

#### Is it ready for merging, or does it need work?

Ready