### PR TITLE
fix: add missing groupbar decoration to the window

### DIFF
--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -733,9 +733,8 @@ void CWindow::insertWindowToGroup(CWindow* pWindow) {
     const auto BEGINAT = this;
     const auto ENDAT   = m_sGroupData.pNextWindow;
 
-    if (!pWindow->getDecorationByType(DECORATION_GROUPBAR)) {
+    if (!pWindow->getDecorationByType(DECORATION_GROUPBAR))
         pWindow->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(pWindow));
-    }
 
     if (!pWindow->m_sGroupData.pNextWindow) {
         BEGINAT->m_sGroupData.pNextWindow = pWindow;

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -733,6 +733,10 @@ void CWindow::insertWindowToGroup(CWindow* pWindow) {
     const auto BEGINAT = this;
     const auto ENDAT   = m_sGroupData.pNextWindow;
 
+    if (!pWindow->getDecorationByType(DECORATION_GROUPBAR)) {
+        pWindow->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(pWindow));
+    }
+
     if (!pWindow->m_sGroupData.pNextWindow) {
         BEGINAT->m_sGroupData.pNextWindow = pWindow;
         pWindow->m_sGroupData.pNextWindow = ENDAT;


### PR DESCRIPTION
Add groupbar decoration to the operand window of `CWindow::insertWindowToGroup` if it does not exist, to prevent segmentation faults when mouse events are triggered after moving the window to a group, where `getDecorationByType(DECORATION_GROUPBAR)` unexpectedly returns nullptr.

Also fixed a bug where the group bar disappeared when the moveIntoGroup dispatcher's operand window was in a group.
