### PR TITLE
Add snapping to floating windows

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -116,6 +116,8 @@ void CConfigManager::setDefaultVars() {
     configValues["misc:close_special_on_empty"].intValue       = 1;
     configValues["misc:groupbar_text_color"].intValue          = 0xffffffff;
     configValues["misc:background_color"].intValue             = 0xff111111;
+    configValues["misc:snap_floating"].strValue                = STRVAL_EMPTY;
+    configValues["misc:snap_floating_strength"].intValue       = 50;
 
     configValues["debug:int"].intValue                = 0;
     configValues["debug:log_damage"].intValue         = 0;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -117,9 +117,8 @@ void CConfigManager::setDefaultVars() {
     configValues["misc:groupbar_text_color"].intValue          = 0xffffffff;
     configValues["misc:background_color"].intValue             = 0xff111111;
     configValues["misc:snap_floating"].strValue                = STRVAL_EMPTY;
-    configValues["misc:snap_floating_strength"].intValue         = 50;
-    configValues["misc:snap_floating_outside"].intValue          = 0;
-
+    configValues["misc:snap_floating_strength"].intValue       = 50;
+    configValues["misc:snap_floating_outside"].intValue        = 0;
 
     configValues["debug:int"].intValue                = 0;
     configValues["debug:log_damage"].intValue         = 0;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -117,7 +117,9 @@ void CConfigManager::setDefaultVars() {
     configValues["misc:groupbar_text_color"].intValue          = 0xffffffff;
     configValues["misc:background_color"].intValue             = 0xff111111;
     configValues["misc:snap_floating"].strValue                = STRVAL_EMPTY;
-    configValues["misc:snap_floating_strength"].intValue       = 50;
+    configValues["misc:snap_floating_strength"].intValue         = 50;
+    configValues["misc:snap_floating_outside"].intValue          = 0;
+
 
     configValues["debug:int"].intValue                = 0;
     configValues["debug:log_damage"].intValue         = 0;

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -407,19 +407,33 @@ bool IHyprLayout::snapToBounding(const Vector2D& size, Vector2D& newPosition, co
     bool snapped = false;
     int  snap    = 60;
 
-    if (newPosition.x <= boundingPosition.x + snap && newPosition.x >= boundingPosition.x - snap) {
-        newPosition.x = boundingPosition.x;
+    double leftSide = newPosition.x;
+    double topSide = newPosition.y;
+    double rightSide = newPosition.x + size.x;
+    double bottomSide = newPosition.y +size.y;
+
+    double boundingLeftSide = boundingPosition.x;
+    double boundingTopSide = boundingPosition.y;
+    double boundingRightSide = boundingPosition.x + boundTo.x;
+    double boundingBottomSide = boundingPosition.y + boundTo.y;
+
+    if (leftSide <= boundingLeftSide + snap && 
+        leftSide >= boundingLeftSide - snap) {
+        newPosition.x = boundingLeftSide;
         snapped       = true;
-    } else if (size.x + newPosition.x >= boundingPosition.x + boundTo.x - snap && size.x + newPosition.x <= boundingPosition.x + boundTo.x + snap) {
-        newPosition.x = boundingPosition.x + boundTo.x - size.x;
+    } else if (rightSide >= boundingRightSide - snap && 
+               rightSide <= boundingRightSide + snap) {
+        newPosition.x = boundingRightSide - size.x;
         snapped       = true;
     }
 
-    if (newPosition.y <= boundingPosition.y + snap && newPosition.y >= boundingPosition.y - snap) {
-        newPosition.y = boundingPosition.y;
+    if (topSide <= boundingTopSide + snap && 
+        topSide >= boundingTopSide - snap) {
+        newPosition.y = boundingTopSide;
         snapped       = true;
-    } else if (size.y + newPosition.y >= boundingPosition.y + boundTo.y - snap && size.y + newPosition.y <= boundingPosition.y + boundTo.y + snap) {
-        newPosition.y = boundingPosition.y + boundTo.y - size.y;
+    } else if (bottomSide >= boundingBottomSide - snap && 
+               bottomSide <= boundingBottomSide + snap) {
+        newPosition.y = boundingBottomSide - size.y;
         snapped       = true;
     }
 

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -308,8 +308,7 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
 
             for (auto& w : g_pCompositor->m_vWindows) {
                 if (w->m_iWorkspaceID == DRAGGINGWINDOW->m_iWorkspaceID && DRAGGINGWINDOW->getPID() != w->getPID()) {
-                    if (snapToBounding(DRAGGINGWINDOW->m_vRealSize.vec(), newPosition, w->m_vRealPosition.vec(), w->m_vRealSize.vec()))
-                        break;
+                    snapToBounding(DRAGGINGWINDOW->m_vRealSize.vec(), newPosition, w->m_vRealPosition.vec(), w->m_vRealSize.vec());
                 }
             }
         }
@@ -420,6 +419,7 @@ bool IHyprLayout::snapToBounding(const Vector2D& size, Vector2D& newPosition, co
     double boundingTopSide = boundingPosition.y;
     double boundingRightSide = boundingPosition.x + boundTo.x;
     double boundingBottomSide = boundingPosition.y + boundTo.y;
+
 
     // Horizontal Snapping
     if (isInRangeForSnapping(leftSide, boundingLeftSide, snap)) {

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -403,6 +403,10 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
     g_pHyprRenderer->damageWindow(DRAGGINGWINDOW);
 }
 
+bool IHyprLayout::isInRangeForSnapping(double snapSide, double boundingSide, int snapStrength) {
+    return snapSide <= boundingSide + snapStrength && snapSide >= boundingSide - snapStrength;
+}
+
 bool IHyprLayout::snapToBounding(const Vector2D& size, Vector2D& newPosition, const Vector2D& boundingPosition, const Vector2D& boundTo) {
     bool snapped = false;
     int  snap    = 60;
@@ -417,22 +421,20 @@ bool IHyprLayout::snapToBounding(const Vector2D& size, Vector2D& newPosition, co
     double boundingRightSide = boundingPosition.x + boundTo.x;
     double boundingBottomSide = boundingPosition.y + boundTo.y;
 
-    if (leftSide <= boundingLeftSide + snap && 
-        leftSide >= boundingLeftSide - snap) {
+    // Horizontal Snapping
+    if (isInRangeForSnapping(leftSide, boundingLeftSide, snap)) {
         newPosition.x = boundingLeftSide;
         snapped       = true;
-    } else if (rightSide >= boundingRightSide - snap && 
-               rightSide <= boundingRightSide + snap) {
+    } else if (isInRangeForSnapping(rightSide, boundingRightSide, snap)) {
         newPosition.x = boundingRightSide - size.x;
         snapped       = true;
     }
 
-    if (topSide <= boundingTopSide + snap && 
-        topSide >= boundingTopSide - snap) {
+    // Vertical Snapping
+    if (isInRangeForSnapping(topSide, boundingTopSide, snap)) {
         newPosition.y = boundingTopSide;
         snapped       = true;
-    } else if (bottomSide >= boundingBottomSide - snap && 
-               bottomSide <= boundingBottomSide + snap) {
+    } else if (isInRangeForSnapping(bottomSide, boundingBottomSide, snap)) {
         newPosition.y = boundingBottomSide - size.y;
         snapped       = true;
     }

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -407,9 +407,10 @@ void IHyprLayout::snapToMonitor(Vector2D& newPosition, CWindow* window, int snap
     if (window == nullptr)
         return;
 
-    const auto monitorSize = g_pCompositor->getMonitorFromID(window->m_iMonitorID)->vecSize;
-    updateNewPositionSnapping(window->m_vRealSize.vec().x, newPosition.x, 0, monitorSize.x, snapStrength, allowOutsideSnap);
-    updateNewPositionSnapping(window->m_vRealSize.vec().y, newPosition.y, 0, monitorSize.y, snapStrength, allowOutsideSnap);
+
+    const auto monitor = g_pCompositor->getMonitorFromID(window->m_iMonitorID);
+    updateNewPositionSnapping(window->m_vRealSize.vec().x, newPosition.x, monitor->vecPosition.x, monitor->vecSize.x, snapStrength, allowOutsideSnap);
+    updateNewPositionSnapping(window->m_vRealSize.vec().y, newPosition.y, monitor->vecPosition.y, monitor->vecSize.y, snapStrength, allowOutsideSnap);
 }
 
 void IHyprLayout::snapToWindows(Vector2D& newPosition, CWindow* window, int snapStrength, bool allowOutsideSnap) {

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -426,10 +426,12 @@ void IHyprLayout::snapToWindows(Vector2D& newPosition, CWindow* window, int snap
                 continue;
 
             if (!snappedHorizontal)
-                snappedHorizontal = updateNewPositionSnapping(window->m_vRealSize.vec().x, newPosition.x, w->m_vRealPosition.vec().x, w->m_vRealSize.vec().x, snapStrength, allowOutsideSnap);
+                snappedHorizontal =
+                    updateNewPositionSnapping(window->m_vRealSize.vec().x, newPosition.x, w->m_vRealPosition.vec().x, w->m_vRealSize.vec().x, snapStrength, allowOutsideSnap);
 
             if (!snappedVertical)
-                snappedVertical = updateNewPositionSnapping(window->m_vRealSize.vec().y, newPosition.y, w->m_vRealPosition.vec().y, w->m_vRealSize.vec().y, snapStrength, allowOutsideSnap);
+                snappedVertical =
+                    updateNewPositionSnapping(window->m_vRealSize.vec().y, newPosition.y, w->m_vRealPosition.vec().y, w->m_vRealSize.vec().y, snapStrength, allowOutsideSnap);
 
             if (snappedHorizontal && snappedVertical)
                 break;
@@ -441,7 +443,8 @@ bool IHyprLayout::isInRangeForSnapping(double snapSide, double boundingSide, int
     return snapSide <= boundingSide + snapStrength && snapSide >= boundingSide - snapStrength;
 }
 
-bool IHyprLayout::updateNewPositionSnapping(const double size, double& newPosition, const double boundingPosition, const double boundSize, int snapStrength, bool allowOutsideSnap) {
+bool IHyprLayout::updateNewPositionSnapping(const double size, double& newPosition, const double boundingPosition, const double boundSize, int snapStrength,
+                                            bool allowOutsideSnap) {
     bool   snapped = true;
     double minSide = newPosition;        // left or top
     double maxSide = newPosition + size; // right of bottom
@@ -454,9 +457,9 @@ bool IHyprLayout::updateNewPositionSnapping(const double size, double& newPositi
     } else if (isInRangeForSnapping(maxSide, boundingMaxSide, snapStrength)) {
         newPosition = boundingMaxSide - size;
     } else if (allowOutsideSnap && isInRangeForSnapping(maxSide, boundingMinSide, snapStrength)) {
-      newPosition = boundingMinSide - size;
+        newPosition = boundingMinSide - size;
     } else if (allowOutsideSnap && isInRangeForSnapping(minSide, boundingMaxSide, snapStrength)) {
-      newPosition = boundingMaxSide;
+        newPosition = boundingMaxSide;
     } else {
         snapped = false;
     }

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -451,7 +451,7 @@ bool IHyprLayout::updateNewPositionSnapping(const double size, double& newPositi
                                             bool allowOutsideSnap) {
     bool   snapped = true;
     double minSide = newPosition;        // left or top
-    double maxSide = newPosition + size; // right of bottom
+    double maxSide = newPosition + size; // right or bottom
 
     double boundingMinSide = boundingPosition;
     double boundingMaxSide = boundingPosition + boundSize;

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -404,14 +404,18 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
 }
 
 void IHyprLayout::snapToMonitor(Vector2D& newPosition, CWindow* window, int snapStrength, bool allowOutsideSnap) {
-    if (window != nullptr) {
-        const auto monitorSize = g_pCompositor->getMonitorFromID(window->m_iMonitorID)->vecSize;
-        updateNewPositionSnapping(window->m_vRealSize.vec().x, newPosition.x, 0, monitorSize.x, snapStrength, allowOutsideSnap);
-        updateNewPositionSnapping(window->m_vRealSize.vec().y, newPosition.y, 0, monitorSize.y, snapStrength, allowOutsideSnap);
-    }
+    if (window == nullptr)
+        return;
+
+    const auto monitorSize = g_pCompositor->getMonitorFromID(window->m_iMonitorID)->vecSize;
+    updateNewPositionSnapping(window->m_vRealSize.vec().x, newPosition.x, 0, monitorSize.x, snapStrength, allowOutsideSnap);
+    updateNewPositionSnapping(window->m_vRealSize.vec().y, newPosition.y, 0, monitorSize.y, snapStrength, allowOutsideSnap);
 }
 
 void IHyprLayout::snapToWindows(Vector2D& newPosition, CWindow* window, int snapStrength, bool allowOutsideSnap) {
+    if (window == nullptr)
+        return;
+
     bool snappedHorizontal = false;
     bool snappedVertical   = false;
     auto currentBox        = window->getFullWindowBoundingBox();

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -307,18 +307,16 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
         auto newPosition = m_vBeginDragPositionXY + DELTA;
 
         if (DRAGGINGWINDOW->m_bIsFloating && *SNAPFLOATING != "") {
-            if (*SNAPFLOATING == "monitor") {
+            if (*SNAPFLOATING == "monitor")
                 snapToMonitor(newPosition, DRAGGINGWINDOW, *SNAPFLOATINGSTRENGTH, *SNAPFLOATINGOUTSIDE);
-            } else if (*SNAPFLOATING == "windows") {
+            else if (*SNAPFLOATING == "windows")
                 snapToWindows(newPosition, DRAGGINGWINDOW, *SNAPFLOATINGSTRENGTH, *SNAPFLOATINGOUTSIDE);
-            }
         }
 
-        if (*PANIMATEMOUSE) {
+        if (*PANIMATEMOUSE)
             DRAGGINGWINDOW->m_vRealPosition = newPosition;
-        } else {
+        else
             DRAGGINGWINDOW->m_vRealPosition.setValueAndWarp(newPosition);
-        }
 
         g_pXWaylandManager->setWindowSize(DRAGGINGWINDOW, DRAGGINGWINDOW->m_vRealSize.goalv());
     } else if (g_pInputManager->dragMode == MBIND_RESIZE || g_pInputManager->dragMode == MBIND_RESIZE_FORCE_RATIO || g_pInputManager->dragMode == MBIND_RESIZE_BLOCK_RATIO) {
@@ -407,10 +405,9 @@ void IHyprLayout::snapToMonitor(Vector2D& newPosition, CWindow* window, int snap
     if (window == nullptr)
         return;
 
-
-    const auto monitor = g_pCompositor->getMonitorFromID(window->m_iMonitorID);
-    updateNewPositionSnapping(window->m_vRealSize.vec().x, newPosition.x, monitor->vecPosition.x, monitor->vecSize.x, snapStrength, allowOutsideSnap);
-    updateNewPositionSnapping(window->m_vRealSize.vec().y, newPosition.y, monitor->vecPosition.y, monitor->vecSize.y, snapStrength, allowOutsideSnap);
+    const auto MONITOR = g_pCompositor->getMonitorFromID(window->m_iMonitorID);
+    updateNewPositionSnapping(window->m_vRealSize.vec().x, newPosition.x, MONITOR->vecPosition.x, MONITOR->vecSize.x, snapStrength, allowOutsideSnap);
+    updateNewPositionSnapping(window->m_vRealSize.vec().y, newPosition.y, MONITOR->vecPosition.y, MONITOR->vecSize.y, snapStrength, allowOutsideSnap);
 }
 
 void IHyprLayout::snapToWindows(Vector2D& newPosition, CWindow* window, int snapStrength, bool allowOutsideSnap) {
@@ -457,17 +454,16 @@ bool IHyprLayout::updateNewPositionSnapping(const double size, double& newPositi
     double boundingMinSide = boundingPosition;
     double boundingMaxSide = boundingPosition + boundSize;
 
-    if (isInRangeForSnapping(minSide, boundingMinSide, snapStrength)) {
+    if (isInRangeForSnapping(minSide, boundingMinSide, snapStrength))
         newPosition = boundingMinSide;
-    } else if (isInRangeForSnapping(maxSide, boundingMaxSide, snapStrength)) {
+    else if (isInRangeForSnapping(maxSide, boundingMaxSide, snapStrength))
         newPosition = boundingMaxSide - size;
-    } else if (allowOutsideSnap && isInRangeForSnapping(maxSide, boundingMinSide, snapStrength)) {
+    else if (allowOutsideSnap && isInRangeForSnapping(maxSide, boundingMinSide, snapStrength))
         newPosition = boundingMinSide - size;
-    } else if (allowOutsideSnap && isInRangeForSnapping(minSide, boundingMaxSide, snapStrength)) {
+    else if (allowOutsideSnap && isInRangeForSnapping(minSide, boundingMaxSide, snapStrength))
         newPosition = boundingMaxSide;
-    } else {
+    else
         snapped = false;
-    }
 
     return snapped;
 }

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -171,7 +171,6 @@ class IHyprLayout {
 
     CWindow*    m_pLastTiledWindow = nullptr;
 
-    bool        snapToBoundingHorizontal(const Vector2D& size, Vector2D& newPosition, const Vector2D& boundingPosition, const Vector2D& boundTo);
-    bool        snapToBoundingVertical(const Vector2D& size, Vector2D& newPosition, const Vector2D& boundingPosition, const Vector2D& boundTo);
+    bool        updateNewPositionSnapping(const double size, double &newPosition, const double boundingPosition, const double boundSize);
     bool        isInRangeForSnapping(double snapSide, double boundingSide, int snapStrength);
 };

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -171,6 +171,8 @@ class IHyprLayout {
 
     CWindow*    m_pLastTiledWindow = nullptr;
 
-    bool        updateNewPositionSnapping(const double size, double &newPosition, const double boundingPosition, const double boundSize);
+    void        snapToWindows(Vector2D& newPosition, CWindow* window, int snapStrength);
+    void        snapToMonitor(Vector2D& newPosition, CWindow* window, int snapStrength);
+    bool        updateNewPositionSnapping(const double size, double& newPosition, const double boundingPosition, const double boundSize, int snapStrength);
     bool        isInRangeForSnapping(double snapSide, double boundingSide, int snapStrength);
 };

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -171,6 +171,7 @@ class IHyprLayout {
 
     CWindow*    m_pLastTiledWindow = nullptr;
 
-    bool        snapToBounding(const Vector2D& size, Vector2D& newPosition, const Vector2D& boundingPosition, const Vector2D& boundTo);
+    bool        snapToBoundingHorizontal(const Vector2D& size, Vector2D& newPosition, const Vector2D& boundingPosition, const Vector2D& boundTo);
+    bool        snapToBoundingVertical(const Vector2D& size, Vector2D& newPosition, const Vector2D& boundingPosition, const Vector2D& boundTo);
     bool        isInRangeForSnapping(double snapSide, double boundingSide, int snapStrength);
 };

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -15,8 +15,7 @@ struct SLayoutMessageHeader {
 
 enum eFullscreenMode : uint8_t;
 
-enum eRectCorner
-{
+enum eRectCorner {
     CORNER_NONE = 0,
     CORNER_TOPLEFT,
     CORNER_TOPRIGHT,
@@ -171,4 +170,6 @@ class IHyprLayout {
     eRectCorner m_eGrabbedCorner = CORNER_TOPLEFT;
 
     CWindow*    m_pLastTiledWindow = nullptr;
+
+    bool        snapToBounding(const Vector2D& size, Vector2D& newPosition, const Vector2D& boundingPosition, const Vector2D& boundTo);
 };

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -171,8 +171,8 @@ class IHyprLayout {
 
     CWindow*    m_pLastTiledWindow = nullptr;
 
-    void        snapToWindows(Vector2D& newPosition, CWindow* window, int snapStrength);
-    void        snapToMonitor(Vector2D& newPosition, CWindow* window, int snapStrength);
-    bool        updateNewPositionSnapping(const double size, double& newPosition, const double boundingPosition, const double boundSize, int snapStrength);
+    void        snapToWindows(Vector2D& newPosition, CWindow* window, int snapStrength, bool allowOutsideSnap);
+    void        snapToMonitor(Vector2D& newPosition, CWindow* window, int snapStrength, bool allowOutsideSnap);
+    bool        updateNewPositionSnapping(const double size, double& newPosition, const double boundingPosition, const double boundSize, int snapStrength, bool allowOutsideSnap);
     bool        isInRangeForSnapping(double snapSide, double boundingSide, int snapStrength);
 };

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -172,4 +172,5 @@ class IHyprLayout {
     CWindow*    m_pLastTiledWindow = nullptr;
 
     bool        snapToBounding(const Vector2D& size, Vector2D& newPosition, const Vector2D& boundingPosition, const Vector2D& boundTo);
+    bool        isInRangeForSnapping(double snapSide, double boundingSide, int snapStrength);
 };


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds a floating window snapping option: https://github.com/hyprwm/Hyprland/issues/3230

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

It adds 3 configuration options:
1. **misc:snap_floating**: Enable snapping to either the windows or the monitor's edge (values: "", monitor, windows)
2. **misc:snap_floating_strength**: determines the distance at which snapping occurs
3. **misc:snap_floating_outside**: if false, windows will only snap to the inside of windows/monitor. If true, windows will snap inside and outside. I disabled it by default, because it reacts a bit weird depending on gap size and strength. Especially if strength is bigger then gap size.

#### Is it ready for merging, or does it need work?
Ready

