### PR TITLE
movewindow to screen edge for floating windows

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1159,23 +1159,20 @@ void CKeybindManager::moveActiveTo(std::string args) {
         return;
 
     if (PLASTWINDOW->m_bIsFloating) {
-        auto               wPos        = PLASTWINDOW->m_vRealPosition.goalv();
-        auto               PMONITOR    = g_pCompositor->m_pLastMonitor;
-        static auto* const PBORDERSIZE = &g_pConfigManager->getConfigValuePtr("general:border_size")->intValue;
-        int borderSize = PLASTWINDOW->m_sSpecialRenderData.borderSize.toUnderlying() == -1 ? *PBORDERSIZE : PLASTWINDOW->m_sSpecialRenderData.borderSize.toUnderlying();
-        if (PLASTWINDOW->m_sAdditionalConfigData.borderSize.toUnderlying() != -1)
-            borderSize = PLASTWINDOW->m_sAdditionalConfigData.borderSize.toUnderlying();
+        auto vPos       = PLASTWINDOW->m_vRealPosition.goalv();
+        auto PMONITOR   = g_pCompositor->getMonitorFromID(PLASTWINDOW->m_iMonitorID);
+        int  borderSize = PLASTWINDOW->getRealBorderSize();
 
         switch (arg) {
-            case 'l': wPos.x = PMONITOR->vecReservedTopLeft.x + borderSize; break;
-            case 'r': wPos.x = PMONITOR->vecSize.x - PMONITOR->vecReservedBottomRight.x - PLASTWINDOW->m_vRealSize.goalv().x - borderSize; break;
+            case 'l': vPos.x = PMONITOR->vecReservedTopLeft.x + borderSize; break;
+            case 'r': vPos.x = PMONITOR->vecSize.x - PMONITOR->vecReservedBottomRight.x - PLASTWINDOW->m_vRealSize.goalv().x - borderSize; break;
             case 't':
-            case 'u': wPos.y = PMONITOR->vecReservedTopLeft.y + borderSize; break;
+            case 'u': vPos.y = PMONITOR->vecReservedTopLeft.y + borderSize; break;
             case 'b':
-            case 'd': wPos.y = PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PLASTWINDOW->m_vRealSize.goalv().y - borderSize; break;
+            case 'd': vPos.y = PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PLASTWINDOW->m_vRealSize.goalv().y - borderSize; break;
         }
 
-        PLASTWINDOW->m_vRealPosition = wPos + PMONITOR->vecPosition;
+        PLASTWINDOW->m_vRealPosition = vPos + PMONITOR->vecPosition;
         return;
     }
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1159,17 +1159,17 @@ void CKeybindManager::moveActiveTo(std::string args) {
         return;
 
     if (PLASTWINDOW->m_bIsFloating) {
-        auto vPos       = PLASTWINDOW->m_vRealPosition.goalv();
-        auto PMONITOR   = g_pCompositor->getMonitorFromID(PLASTWINDOW->m_iMonitorID);
-        int  borderSize = PLASTWINDOW->getRealBorderSize();
+        auto       vPos       = PLASTWINDOW->m_vRealPosition.goalv();
+        const auto PMONITOR   = g_pCompositor->getMonitorFromID(PLASTWINDOW->m_iMonitorID);
+        const auto BORDERSIZE = PLASTWINDOW->getRealBorderSize();
 
         switch (arg) {
-            case 'l': vPos.x = PMONITOR->vecReservedTopLeft.x + borderSize; break;
-            case 'r': vPos.x = PMONITOR->vecSize.x - PMONITOR->vecReservedBottomRight.x - PLASTWINDOW->m_vRealSize.goalv().x - borderSize; break;
+            case 'l': vPos.x = PMONITOR->vecReservedTopLeft.x + BORDERSIZE; break;
+            case 'r': vPos.x = PMONITOR->vecSize.x - PMONITOR->vecReservedBottomRight.x - PLASTWINDOW->m_vRealSize.goalv().x - BORDERSIZE; break;
             case 't':
-            case 'u': vPos.y = PMONITOR->vecReservedTopLeft.y + borderSize; break;
+            case 'u': vPos.y = PMONITOR->vecReservedTopLeft.y + BORDERSIZE; break;
             case 'b':
-            case 'd': vPos.y = PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PLASTWINDOW->m_vRealSize.goalv().y - borderSize; break;
+            case 'd': vPos.y = PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PLASTWINDOW->m_vRealSize.goalv().y - BORDERSIZE; break;
         }
 
         PLASTWINDOW->m_vRealPosition = vPos + PMONITOR->vecPosition;

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1158,6 +1158,27 @@ void CKeybindManager::moveActiveTo(std::string args) {
     if (!PLASTWINDOW || PLASTWINDOW->m_bIsFullscreen)
         return;
 
+    if (PLASTWINDOW->m_bIsFloating) {
+        auto               wPos        = PLASTWINDOW->m_vRealPosition.goalv();
+        auto               PMONITOR    = g_pCompositor->m_pLastMonitor;
+        static auto* const PBORDERSIZE = &g_pConfigManager->getConfigValuePtr("general:border_size")->intValue;
+        int borderSize = PLASTWINDOW->m_sSpecialRenderData.borderSize.toUnderlying() == -1 ? *PBORDERSIZE : PLASTWINDOW->m_sSpecialRenderData.borderSize.toUnderlying();
+        if (PLASTWINDOW->m_sAdditionalConfigData.borderSize.toUnderlying() != -1)
+            borderSize = PLASTWINDOW->m_sAdditionalConfigData.borderSize.toUnderlying();
+
+        switch (arg) {
+            case 'l': wPos.x = PMONITOR->vecReservedTopLeft.x + borderSize; break;
+            case 'r': wPos.x = PMONITOR->vecSize.x - PMONITOR->vecReservedBottomRight.x - PLASTWINDOW->m_vRealSize.goalv().x - borderSize; break;
+            case 't':
+            case 'u': wPos.y = PMONITOR->vecReservedTopLeft.y + borderSize; break;
+            case 'b':
+            case 'd': wPos.y = PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PLASTWINDOW->m_vRealSize.goalv().y - borderSize; break;
+        }
+
+        PLASTWINDOW->m_vRealPosition = wPos + PMONITOR->vecPosition;
+        return;
+    }
+
     // If the window to change to is on the same workspace, switch them
     const auto PWINDOWTOCHANGETO = g_pCompositor->getWindowInDirection(PLASTWINDOW, arg);
     if (PWINDOWTOCHANGETO) {


### PR DESCRIPTION
Implements move to screen edge in the `movewindow` dispatcher.  If the active window is floating, move it to the designated screen edge.

I think this is ready for merge but I'm not sure about the formatting of the switch{} block.  Looks bad to me but I am pretty sure your .clang-format is being followed.
