### PR TITLE
add on-screen constraint to wrv2 'move'

### DIFF
--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -377,10 +377,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                     }
 
                     if (ONSCREEN) {
-                        static auto* const PBORDERSIZE = &g_pConfigManager->getConfigValuePtr("general:border_size")->intValue;
-                        int borderSize = PWINDOW->m_sSpecialRenderData.borderSize.toUnderlying() == -1 ? *PBORDERSIZE : PWINDOW->m_sSpecialRenderData.borderSize.toUnderlying();
-                        if (PWINDOW->m_sAdditionalConfigData.borderSize.toUnderlying() != -1)
-                            borderSize = PWINDOW->m_sAdditionalConfigData.borderSize.toUnderlying();
+                        int borderSize = PWINDOW->getRealBorderSize();
 
                         // left
                         if (posX < PMONITOR->vecReservedTopLeft.x + borderSize)

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -322,6 +322,11 @@ void Events::listener_mapWindow(void* owner, void* data) {
                 try {
                     auto       value = r.szRule.substr(r.szRule.find(' ') + 1);
 
+                    const bool ONSCREEN = value.find("onscreen") == 0;
+
+                    if (ONSCREEN)
+                        value = value.substr(value.find_first_of(' ') + 1);
+
                     const bool CURSOR = value.find("cursor") == 0;
 
                     if (CURSOR)
@@ -334,8 +339,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                     int        posY = 0;
 
                     if (POSXSTR.find("100%-") == 0) {
-                        const auto PMONITOR = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID);
-                        const auto POSXRAW  = POSXSTR.substr(5);
+                        const auto POSXRAW = POSXSTR.substr(5);
                         posX =
                             PMONITOR->vecSize.x - (!POSXRAW.contains('%') ? std::stoi(POSXRAW) : std::stof(POSXRAW.substr(0, POSXRAW.length() - 1)) * 0.01 * PMONITOR->vecSize.x);
 
@@ -354,8 +358,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                     }
 
                     if (POSYSTR.find("100%-") == 0) {
-                        const auto PMONITOR = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID);
-                        const auto POSYRAW  = POSYSTR.substr(5);
+                        const auto POSYRAW = POSYSTR.substr(5);
                         posY =
                             PMONITOR->vecSize.y - (!POSYRAW.contains('%') ? std::stoi(POSYRAW) : std::stof(POSYRAW.substr(0, POSYRAW.length() - 1)) * 0.01 * PMONITOR->vecSize.y);
 
@@ -371,6 +374,27 @@ void Events::listener_mapWindow(void* owner, void* data) {
                             posY = g_pInputManager->getMouseCoordsInternal().y - PMONITOR->vecPosition.y +
                                 (!POSYSTR.contains('%') ? std::stoi(POSYSTR) : std::stof(POSYSTR.substr(0, POSYSTR.length() - 1)) * 0.01 * PWINDOW->m_vRealSize.goalv().y);
                         }
+                    }
+
+                    if (ONSCREEN) {
+                        static auto* const PBORDERSIZE = &g_pConfigManager->getConfigValuePtr("general:border_size")->intValue;
+                        int borderSize = PWINDOW->m_sSpecialRenderData.borderSize.toUnderlying() == -1 ? *PBORDERSIZE : PWINDOW->m_sSpecialRenderData.borderSize.toUnderlying();
+                        if (PWINDOW->m_sAdditionalConfigData.borderSize.toUnderlying() != -1)
+                            borderSize = PWINDOW->m_sAdditionalConfigData.borderSize.toUnderlying();
+
+                        // left
+                        if (posX < PMONITOR->vecReservedTopLeft.x + borderSize)
+                            posX = PMONITOR->vecReservedTopLeft.x + borderSize;
+                        // right
+                        if (posX > PMONITOR->vecSize.x - PMONITOR->vecReservedBottomRight.x - PWINDOW->m_vRealSize.goalv().x - borderSize)
+                            posX = PMONITOR->vecSize.x - PMONITOR->vecReservedBottomRight.x - PWINDOW->m_vRealSize.goalv().x - borderSize;
+
+                        // top
+                        if (posY < PMONITOR->vecReservedTopLeft.y + borderSize)
+                            posY = PMONITOR->vecReservedTopLeft.y + borderSize;
+                        // bottom
+                        if (posY > PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PWINDOW->m_vRealSize.goalv().y - borderSize)
+                            posY = PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PWINDOW->m_vRealSize.goalv().y - borderSize;
                     }
 
                     Debug::log(LOG, "Rule move, applying to window {:x}", (uintptr_t)PWINDOW);

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -379,19 +379,11 @@ void Events::listener_mapWindow(void* owner, void* data) {
                     if (ONSCREEN) {
                         int borderSize = PWINDOW->getRealBorderSize();
 
-                        // left
-                        if (posX < PMONITOR->vecReservedTopLeft.x + borderSize)
-                            posX = PMONITOR->vecReservedTopLeft.x + borderSize;
-                        // right
-                        if (posX > PMONITOR->vecSize.x - PMONITOR->vecReservedBottomRight.x - PWINDOW->m_vRealSize.goalv().x - borderSize)
-                            posX = PMONITOR->vecSize.x - PMONITOR->vecReservedBottomRight.x - PWINDOW->m_vRealSize.goalv().x - borderSize;
+                        posX = std::clamp(posX, int(PMONITOR->vecReservedTopLeft.x + borderSize),
+                                          int(PMONITOR->vecSize.x - PMONITOR->vecReservedBottomRight.x - PWINDOW->m_vRealSize.goalv().x - borderSize));
 
-                        // top
-                        if (posY < PMONITOR->vecReservedTopLeft.y + borderSize)
-                            posY = PMONITOR->vecReservedTopLeft.y + borderSize;
-                        // bottom
-                        if (posY > PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PWINDOW->m_vRealSize.goalv().y - borderSize)
-                            posY = PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PWINDOW->m_vRealSize.goalv().y - borderSize;
+                        posY = std::clamp(posY, int(PMONITOR->vecReservedTopLeft.y + borderSize),
+                                          int(PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PWINDOW->m_vRealSize.goalv().y - borderSize));
                     }
 
                     Debug::log(LOG, "Rule move, applying to window {:x}", (uintptr_t)PWINDOW);

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -379,11 +379,11 @@ void Events::listener_mapWindow(void* owner, void* data) {
                     if (ONSCREEN) {
                         int borderSize = PWINDOW->getRealBorderSize();
 
-                        posX = std::clamp(posX, int(PMONITOR->vecReservedTopLeft.x + borderSize),
-                                          int(PMONITOR->vecSize.x - PMONITOR->vecReservedBottomRight.x - PWINDOW->m_vRealSize.goalv().x - borderSize));
+                        posX = std::clamp(posX, (int)(PMONITOR->vecReservedTopLeft.x + borderSize),
+                                          (int)(PMONITOR->vecSize.x - PMONITOR->vecReservedBottomRight.x - PWINDOW->m_vRealSize.goalv().x - borderSize));
 
-                        posY = std::clamp(posY, int(PMONITOR->vecReservedTopLeft.y + borderSize),
-                                          int(PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PWINDOW->m_vRealSize.goalv().y - borderSize));
+                        posY = std::clamp(posY, (int)(PMONITOR->vecReservedTopLeft.y + borderSize),
+                                          (int)(PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PWINDOW->m_vRealSize.goalv().y - borderSize));
                     }
 
                     Debug::log(LOG, "Rule move, applying to window {:x}", (uintptr_t)PWINDOW);


### PR DESCRIPTION
Implements an `onscreen` directive to windowsrulev2 `move` that causes the window to be fully on the screen (if it is not too large). 

My usage for this is:
`windowrulev2 = move onscreen cursor -50% -50%,floating:1,class:^(xfce4-terminal|kitty)$`
This will place my terminals centered under the mouse unless it's toward the edge of the screen where they will be nudged to remain fully within the screen.

For too-large windows, the bottom right corner is forced onto the screen.  It could be top left with additional code.

Ready for merge.

