### PR TITLE
feat: add options to skip cursor warps

### DIFF
--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -627,6 +627,16 @@ bool CWindow::isInCurvedCorner(double x, double y) {
     return false;
 }
 
+bool CWindow::isNearEdge(const Vector2D& pos, double threshold) {
+    const auto wbox = getWindowIdealBoundingBoxIgnoreReserved();
+    const auto ibox = wlr_box{wbox.x + threshold, wbox.y + threshold, wbox.width - 2 * threshold, wbox.height - 2 * threshold};
+
+    if (wlr_box_contains_point(&wbox, pos.x, pos.y) && !wlr_box_contains_point(&ibox, pos.x, pos.y))
+        return true;
+
+    return false;
+}
+
 void findExtensionForVector2D(wlr_surface* surface, int x, int y, void* data) {
     const auto DATA = (SExtensionFindingData*)data;
 

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -360,6 +360,7 @@ class CWindow {
 
     void                     onBorderAngleAnimEnd(void* ptr);
     bool                     isInCurvedCorner(double x, double y);
+    bool                     isNearEdge(const Vector2D& pos, double threshold = 1.f);
     bool                     hasPopupAt(const Vector2D& pos);
 
     void                     applyGroupRules();

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -80,14 +80,15 @@ void CConfigManager::setDefaultVars() {
     ((CGradientValueData*)configValues["general:col.group_border_active"].data.get())->reset(0x66ffff00);
     ((CGradientValueData*)configValues["general:col.group_border_locked"].data.get())->reset(0x66775500);
     ((CGradientValueData*)configValues["general:col.group_border_locked_active"].data.get())->reset(0x66ff5500);
-    configValues["general:cursor_inactive_timeout"].intValue = 0;
-    configValues["general:no_cursor_warps"].intValue         = 0;
-    configValues["general:no_focus_fallback"].intValue       = 0;
-    configValues["general:resize_on_border"].intValue        = 0;
-    configValues["general:extend_border_grab_area"].intValue = 15;
-    configValues["general:hover_icon_on_border"].intValue    = 1;
-    configValues["general:layout"].strValue                  = "dwindle";
-    configValues["general:allow_tearing"].intValue           = 0;
+    configValues["general:cursor_inactive_timeout"].intValue    = 0;
+    configValues["general:no_cursor_warps"].intValue            = 0;
+    configValues["general:no_cursor_warps_if_focused"].intValue = 0;
+    configValues["general:no_focus_fallback"].intValue          = 0;
+    configValues["general:resize_on_border"].intValue           = 0;
+    configValues["general:extend_border_grab_area"].intValue    = 15;
+    configValues["general:hover_icon_on_border"].intValue       = 1;
+    configValues["general:layout"].strValue                     = "dwindle";
+    configValues["general:allow_tearing"].intValue              = 0;
 
     configValues["misc:disable_hyprland_logo"].intValue        = 0;
     configValues["misc:disable_splash_rendering"].intValue     = 0;


### PR DESCRIPTION
## Abstruct

Adds a config `general:no_cursor_warps_if_focused` which, if true,
allows the cursor to the cursor to stay in place if it is already in the
focused window. This can help reduce unnecessary cursor movement.

Affects all cursor warps.

doc: hyprwm/hyprland-wiki#340