### PR TITLE
layout: add direction parameter to onWindowCreated and friends

### DIFF
--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -238,7 +238,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection dire
     static auto* const PUSEACTIVE    = &g_pConfigManager->getConfigValuePtr("dwindle:use_active_for_splits")->intValue;
     static auto* const PDEFAULTSPLIT = &g_pConfigManager->getConfigValuePtr("dwindle:default_split_ratio")->floatValue;
 
-    if (direction != eDirection::NONE)
+    if (direction != eDirection::DIRECTION_NONE)
         overrideDirection = direction;
 
     // Populate the node with our window's data
@@ -375,7 +375,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection dire
     bool               verticalOverride   = false;
 
     // let user select position -> top, right, bottom, left
-    if (overrideDirection != eDirection::DEFAULT) {
+    if (overrideDirection != eDirection::DIRECTION_DEFAULT) {
 
         // this is horizontal
         if (overrideDirection % 2 == 0)
@@ -394,7 +394,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection dire
 
         // whether or not the override persists after opening one window
         if (*PERMANENTDIRECTIONOVERRIDE == 0)
-            overrideDirection = eDirection::DEFAULT;
+            overrideDirection = eDirection::DIRECTION_DEFAULT;
     } else if (*PSMARTSPLIT == 1) {
         const auto tl = NEWPARENT->position;
         const auto tr = NEWPARENT->position + Vector2D(NEWPARENT->size.x, 0);
@@ -997,26 +997,26 @@ std::any CHyprDwindleLayout::layoutMessage(SLayoutMessageHeader header, std::str
         switch (direction.front()) {
             case 'u':
             case 't': {
-                overrideDirection = eDirection::UP;
+                overrideDirection = eDirection::DIRECTION_UP;
                 break;
             }
             case 'd':
             case 'b': {
-                overrideDirection = eDirection::DOWN;
+                overrideDirection = eDirection::DIRECTION_DOWN;
                 break;
             }
             case 'r': {
-                overrideDirection = eDirection::RIGHT;
+                overrideDirection = eDirection::DIRECTION_RIGHT;
                 break;
             }
             case 'l': {
-                overrideDirection = eDirection::LEFT;
+                overrideDirection = eDirection::DIRECTION_LEFT;
                 break;
             }
             default: {
                 // any other character resets the focus direction
                 // needed for the persistent mode
-                overrideDirection = eDirection::DEFAULT;
+                overrideDirection = eDirection::DIRECTION_DEFAULT;
                 break;
             }
         }

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -300,7 +300,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection dire
     // last fail-safe to avoid duplicate fullscreens
     if ((!OPENINGON || OPENINGON->pWindow == pWindow) && getNodesOnWorkspace(PNODE->workspaceID) > 1) {
         for (auto& node : m_lDwindleNodesData) {
-            if (node.workspaceID == PNODE->workspaceID && node.pWindow != pWindow) {
+            if (node.workspaceID == PNODE->workspaceID && node.pWindow != nullptr && node.pWindow != pWindow) {
                 OPENINGON = &node;
                 break;
             }

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -238,7 +238,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection dire
     static auto* const PUSEACTIVE    = &g_pConfigManager->getConfigValuePtr("dwindle:use_active_for_splits")->intValue;
     static auto* const PDEFAULTSPLIT = &g_pConfigManager->getConfigValuePtr("dwindle:default_split_ratio")->floatValue;
 
-    if (direction != eDirection::DIRECTION_NONE)
+    if (direction != DIRECTION_DEFAULT && overrideDirection == DIRECTION_DEFAULT)
         overrideDirection = direction;
 
     // Populate the node with our window's data
@@ -375,7 +375,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection dire
     bool               verticalOverride   = false;
 
     // let user select position -> top, right, bottom, left
-    if (overrideDirection != eDirection::DIRECTION_DEFAULT) {
+    if (overrideDirection != DIRECTION_DEFAULT) {
 
         // this is horizontal
         if (overrideDirection % 2 == 0)
@@ -394,7 +394,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection dire
 
         // whether or not the override persists after opening one window
         if (*PERMANENTDIRECTIONOVERRIDE == 0)
-            overrideDirection = eDirection::DIRECTION_DEFAULT;
+            overrideDirection = DIRECTION_DEFAULT;
     } else if (*PSMARTSPLIT == 1) {
         const auto tl = NEWPARENT->position;
         const auto tr = NEWPARENT->position + Vector2D(NEWPARENT->size.x, 0);
@@ -997,26 +997,26 @@ std::any CHyprDwindleLayout::layoutMessage(SLayoutMessageHeader header, std::str
         switch (direction.front()) {
             case 'u':
             case 't': {
-                overrideDirection = eDirection::DIRECTION_UP;
+                overrideDirection = DIRECTION_UP;
                 break;
             }
             case 'd':
             case 'b': {
-                overrideDirection = eDirection::DIRECTION_DOWN;
+                overrideDirection = DIRECTION_DOWN;
                 break;
             }
             case 'r': {
-                overrideDirection = eDirection::DIRECTION_RIGHT;
+                overrideDirection = DIRECTION_RIGHT;
                 break;
             }
             case 'l': {
-                overrideDirection = eDirection::DIRECTION_LEFT;
+                overrideDirection = DIRECTION_LEFT;
                 break;
             }
             default: {
                 // any other character resets the focus direction
                 // needed for the persistent mode
-                overrideDirection = eDirection::DIRECTION_DEFAULT;
+                overrideDirection = DIRECTION_DEFAULT;
                 break;
             }
         }

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -226,7 +226,7 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
     PWINDOW->updateWindowDecos();
 }
 
-void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow) {
+void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection direction) {
     if (pWindow->m_bIsFloating)
         return;
 
@@ -237,6 +237,9 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow) {
 
     static auto* const PUSEACTIVE    = &g_pConfigManager->getConfigValuePtr("dwindle:use_active_for_splits")->intValue;
     static auto* const PDEFAULTSPLIT = &g_pConfigManager->getConfigValuePtr("dwindle:default_split_ratio")->floatValue;
+
+    if (direction != eDirection::NONE)
+        overrideDirection = direction;
 
     // Populate the node with our window's data
     PNODE->workspaceID = pWindow->m_iWorkspaceID;
@@ -372,7 +375,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow) {
     bool               verticalOverride   = false;
 
     // let user select position -> top, right, bottom, left
-    if (overrideDirection != OneTimeFocus::NOFOCUS) {
+    if (overrideDirection != eDirection::DEFAULT) {
 
         // this is horizontal
         if (overrideDirection % 2 == 0)
@@ -391,7 +394,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow) {
 
         // whether or not the override persists after opening one window
         if (*PERMANENTDIRECTIONOVERRIDE == 0)
-            overrideDirection = OneTimeFocus::NOFOCUS;
+            overrideDirection = eDirection::DEFAULT;
     } else if (*PSMARTSPLIT == 1) {
         const auto tl = NEWPARENT->position;
         const auto tr = NEWPARENT->position + Vector2D(NEWPARENT->size.x, 0);
@@ -994,26 +997,26 @@ std::any CHyprDwindleLayout::layoutMessage(SLayoutMessageHeader header, std::str
         switch (direction.front()) {
             case 'u':
             case 't': {
-                overrideDirection = OneTimeFocus::UP;
+                overrideDirection = eDirection::UP;
                 break;
             }
             case 'd':
             case 'b': {
-                overrideDirection = OneTimeFocus::DOWN;
+                overrideDirection = eDirection::DOWN;
                 break;
             }
             case 'r': {
-                overrideDirection = OneTimeFocus::RIGHT;
+                overrideDirection = eDirection::RIGHT;
                 break;
             }
             case 'l': {
-                overrideDirection = OneTimeFocus::LEFT;
+                overrideDirection = eDirection::LEFT;
                 break;
             }
             default: {
                 // any other character resets the focus direction
                 // needed for the persistent mode
-                overrideDirection = OneTimeFocus::NOFOCUS;
+                overrideDirection = eDirection::DEFAULT;
                 break;
             }
         }

--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -10,15 +10,6 @@
 class CHyprDwindleLayout;
 enum eFullscreenMode : uint8_t;
 
-enum OneTimeFocus
-{
-    UP = 0,
-    RIGHT,
-    DOWN,
-    LEFT,
-    NOFOCUS,
-};
-
 struct SDwindleNodeData {
     SDwindleNodeData*                pParent = nullptr;
     bool                             isNode  = false;
@@ -51,7 +42,7 @@ struct SDwindleNodeData {
 
 class CHyprDwindleLayout : public IHyprLayout {
   public:
-    virtual void                     onWindowCreatedTiling(CWindow*);
+    virtual void                     onWindowCreatedTiling(CWindow*, eDirection direction = NONE);
     virtual void                     onWindowRemovedTiling(CWindow*);
     virtual bool                     isWindowTiled(CWindow*);
     virtual void                     recalculateMonitor(const int&);
@@ -90,7 +81,7 @@ class CHyprDwindleLayout : public IHyprLayout {
 
     void                    toggleSplit(CWindow*);
 
-    OneTimeFocus            overrideDirection = OneTimeFocus::NOFOCUS;
+    eDirection              overrideDirection = eDirection::DEFAULT;
 
     friend struct SDwindleNodeData;
 };

--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -42,7 +42,7 @@ struct SDwindleNodeData {
 
 class CHyprDwindleLayout : public IHyprLayout {
   public:
-    virtual void                     onWindowCreatedTiling(CWindow*, eDirection direction = NONE);
+    virtual void                     onWindowCreatedTiling(CWindow*, eDirection direction = DIRECTION_NONE);
     virtual void                     onWindowRemovedTiling(CWindow*);
     virtual bool                     isWindowTiled(CWindow*);
     virtual void                     recalculateMonitor(const int&);
@@ -81,7 +81,7 @@ class CHyprDwindleLayout : public IHyprLayout {
 
     void                    toggleSplit(CWindow*);
 
-    eDirection              overrideDirection = eDirection::DEFAULT;
+    eDirection              overrideDirection = eDirection::DIRECTION_DEFAULT;
 
     friend struct SDwindleNodeData;
 };

--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -42,7 +42,7 @@ struct SDwindleNodeData {
 
 class CHyprDwindleLayout : public IHyprLayout {
   public:
-    virtual void                     onWindowCreatedTiling(CWindow*, eDirection direction = DIRECTION_NONE);
+    virtual void                     onWindowCreatedTiling(CWindow*, eDirection direction = DIRECTION_DEFAULT);
     virtual void                     onWindowRemovedTiling(CWindow*);
     virtual bool                     isWindowTiled(CWindow*);
     virtual void                     recalculateMonitor(const int&);
@@ -81,7 +81,7 @@ class CHyprDwindleLayout : public IHyprLayout {
 
     void                    toggleSplit(CWindow*);
 
-    eDirection              overrideDirection = eDirection::DIRECTION_DEFAULT;
+    eDirection              overrideDirection = DIRECTION_DEFAULT;
 
     friend struct SDwindleNodeData;
 };

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -2,7 +2,7 @@
 #include "../defines.hpp"
 #include "../Compositor.hpp"
 
-void IHyprLayout::onWindowCreated(CWindow* pWindow) {
+void IHyprLayout::onWindowCreated(CWindow* pWindow, eDirection direction) {
     if (pWindow->m_bIsFloating) {
         onWindowCreatedFloating(pWindow);
     } else {
@@ -18,7 +18,7 @@ void IHyprLayout::onWindowCreated(CWindow* pWindow) {
 
         pWindow->m_vPseudoSize = pWindow->m_vLastFloatingSize;
 
-        onWindowCreatedTiling(pWindow);
+        onWindowCreatedTiling(pWindow, direction);
     }
 }
 

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -24,11 +24,11 @@ enum eRectCorner {
 };
 
 enum eDirection {
+    DIRECTION_DEFAULT = -1,
     DIRECTION_UP = 0,
     DIRECTION_RIGHT,
     DIRECTION_DOWN,
-    DIRECTION_LEFT,
-    DIRECTION_DEFAULT,
+    DIRECTION_LEFT
 };
 
 class IHyprLayout {

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -15,8 +15,7 @@ struct SLayoutMessageHeader {
 
 enum eFullscreenMode : uint8_t;
 
-enum eRectCorner
-{
+enum eRectCorner {
     CORNER_NONE = 0,
     CORNER_TOPLEFT,
     CORNER_TOPRIGHT,
@@ -30,13 +29,21 @@ class IHyprLayout {
     virtual void onEnable()  = 0;
     virtual void onDisable() = 0;
 
+    enum eDirection {
+        UP = 0,
+        RIGHT,
+        DOWN,
+        LEFT,
+        DEFAULT,
+        NONE
+    };
     /*
         Called when a window is created (mapped)
         The layout HAS TO set the goal pos and size (anim mgr will use it)
         If !animationinprogress, then the anim mgr will not apply an anim.
     */
-    virtual void onWindowCreated(CWindow*);
-    virtual void onWindowCreatedTiling(CWindow*) = 0;
+    virtual void onWindowCreated(CWindow*, eDirection direction = NONE);
+    virtual void onWindowCreatedTiling(CWindow*, eDirection direction = NONE) = 0;
     virtual void onWindowCreatedFloating(CWindow*);
 
     /*

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -23,27 +23,28 @@ enum eRectCorner {
     CORNER_BOTTOMLEFT
 };
 
+enum eDirection {
+    DIRECTION_NONE = -1,
+    DIRECTION_UP,
+    DIRECTION_RIGHT,
+    DIRECTION_DOWN,
+    DIRECTION_LEFT,
+    DIRECTION_DEFAULT,
+};
+
 class IHyprLayout {
   public:
     virtual ~IHyprLayout()   = 0;
     virtual void onEnable()  = 0;
     virtual void onDisable() = 0;
 
-    enum eDirection {
-        UP = 0,
-        RIGHT,
-        DOWN,
-        LEFT,
-        DEFAULT,
-        NONE
-    };
     /*
         Called when a window is created (mapped)
         The layout HAS TO set the goal pos and size (anim mgr will use it)
         If !animationinprogress, then the anim mgr will not apply an anim.
     */
-    virtual void onWindowCreated(CWindow*, eDirection direction = NONE);
-    virtual void onWindowCreatedTiling(CWindow*, eDirection direction = NONE) = 0;
+    virtual void onWindowCreated(CWindow*, eDirection direction = DIRECTION_NONE);
+    virtual void onWindowCreatedTiling(CWindow*, eDirection direction = DIRECTION_NONE) = 0;
     virtual void onWindowCreatedFloating(CWindow*);
 
     /*

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -24,8 +24,7 @@ enum eRectCorner {
 };
 
 enum eDirection {
-    DIRECTION_NONE = -1,
-    DIRECTION_UP,
+    DIRECTION_UP = 0,
     DIRECTION_RIGHT,
     DIRECTION_DOWN,
     DIRECTION_LEFT,
@@ -43,8 +42,8 @@ class IHyprLayout {
         The layout HAS TO set the goal pos and size (anim mgr will use it)
         If !animationinprogress, then the anim mgr will not apply an anim.
     */
-    virtual void onWindowCreated(CWindow*, eDirection direction = DIRECTION_NONE);
-    virtual void onWindowCreatedTiling(CWindow*, eDirection direction = DIRECTION_NONE) = 0;
+    virtual void onWindowCreated(CWindow*, eDirection direction = DIRECTION_DEFAULT);
+    virtual void onWindowCreatedTiling(CWindow*, eDirection direction = DIRECTION_DEFAULT) = 0;
     virtual void onWindowCreatedFloating(CWindow*);
 
     /*

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -68,7 +68,7 @@ SMasterNodeData* CHyprMasterLayout::getMasterNodeOnWorkspace(const int& ws) {
     return nullptr;
 }
 
-void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow) {
+void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection direction) {
     if (pWindow->m_bIsFloating)
         return;
 
@@ -294,11 +294,11 @@ void CHyprMasterLayout::calculateWorkspace(const int& ws) {
         }
     }
 
-    const float totalSize = (orientation == ORIENTATION_TOP || orientation == ORIENTATION_BOTTOM) ? WSSIZE.x : WSSIZE.y;
-    const float masterAverageSize = totalSize / MASTERS;
-    const float slaveAverageSize  = totalSize / STACKWINDOWS;
-    float masterAccumulatedSize = 0;
-    float slaveAccumulatedSize  = 0;
+    const float totalSize             = (orientation == ORIENTATION_TOP || orientation == ORIENTATION_BOTTOM) ? WSSIZE.x : WSSIZE.y;
+    const float masterAverageSize     = totalSize / MASTERS;
+    const float slaveAverageSize      = totalSize / STACKWINDOWS;
+    float       masterAccumulatedSize = 0;
+    float       slaveAccumulatedSize  = 0;
 
     if (*PSMARTRESIZING) {
         // check the total width and height so that later
@@ -674,13 +674,13 @@ void CHyprMasterLayout::resizeActiveWindow(const Vector2D& pixResize, eRectCorne
     bool               centered    = orientation == ORIENTATION_CENTER && (*ALWAYSCENTER == 1);
     double             delta       = 0;
 
-    const bool DISPLAYBOTTOM = STICKS(PWINDOW->m_vPosition.y + PWINDOW->m_vSize.y, PMONITOR->vecPosition.y + PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y);
-    const bool DISPLAYRIGHT  = STICKS(PWINDOW->m_vPosition.x + PWINDOW->m_vSize.x, PMONITOR->vecPosition.x + PMONITOR->vecSize.x - PMONITOR->vecReservedBottomRight.x);
-    const bool DISPLAYTOP    = STICKS(PWINDOW->m_vPosition.y, PMONITOR->vecPosition.y + PMONITOR->vecReservedTopLeft.y);
-    const bool DISPLAYLEFT   = STICKS(PWINDOW->m_vPosition.x, PMONITOR->vecPosition.x + PMONITOR->vecReservedTopLeft.x);
+    const bool         DISPLAYBOTTOM = STICKS(PWINDOW->m_vPosition.y + PWINDOW->m_vSize.y, PMONITOR->vecPosition.y + PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y);
+    const bool         DISPLAYRIGHT  = STICKS(PWINDOW->m_vPosition.x + PWINDOW->m_vSize.x, PMONITOR->vecPosition.x + PMONITOR->vecSize.x - PMONITOR->vecReservedBottomRight.x);
+    const bool         DISPLAYTOP    = STICKS(PWINDOW->m_vPosition.y, PMONITOR->vecPosition.y + PMONITOR->vecReservedTopLeft.y);
+    const bool         DISPLAYLEFT   = STICKS(PWINDOW->m_vPosition.x, PMONITOR->vecPosition.x + PMONITOR->vecReservedTopLeft.x);
 
-    const bool LEFT          = corner == CORNER_TOPLEFT || corner == CORNER_BOTTOMLEFT;
-    const bool TOP           = corner == CORNER_TOPLEFT || corner == CORNER_TOPRIGHT;
+    const bool         LEFT = corner == CORNER_TOPLEFT || corner == CORNER_BOTTOMLEFT;
+    const bool         TOP  = corner == CORNER_TOPLEFT || corner == CORNER_TOPRIGHT;
 
     if (getNodesOnWorkspace(PWINDOW->m_iWorkspaceID) == 1 && !centered)
         return;
@@ -732,19 +732,18 @@ void CHyprMasterLayout::resizeActiveWindow(const Vector2D& pixResize, eRectCorne
             nodesInSameColumn /= 2;
 
         if (RESIZEDELTA != 0 && nodesInSameColumn > 1) {
-            const auto NODEIT    = std::find(m_lMasterNodesData.begin(), m_lMasterNodesData.end(), *PNODE);
-            const auto REVNODEIT = std::find(m_lMasterNodesData.rbegin(), m_lMasterNodesData.rend(), *PNODE);
-            const auto SIZE = isStackVertical ?
-                (PMONITOR->vecSize.y - PMONITOR->vecReservedTopLeft.y - PMONITOR->vecReservedBottomRight.y) / nodesInSameColumn:
-                (PMONITOR->vecSize.x - PMONITOR->vecReservedTopLeft.x - PMONITOR->vecReservedBottomRight.x) / nodesInSameColumn;
+            const auto  NODEIT    = std::find(m_lMasterNodesData.begin(), m_lMasterNodesData.end(), *PNODE);
+            const auto  REVNODEIT = std::find(m_lMasterNodesData.rbegin(), m_lMasterNodesData.rend(), *PNODE);
+            const auto  SIZE      = isStackVertical ? (PMONITOR->vecSize.y - PMONITOR->vecReservedTopLeft.y - PMONITOR->vecReservedBottomRight.y) / nodesInSameColumn :
+                                                      (PMONITOR->vecSize.x - PMONITOR->vecReservedTopLeft.x - PMONITOR->vecReservedBottomRight.x) / nodesInSameColumn;
 
             const float totalSize       = isStackVertical ? WSSIZE.y : WSSIZE.x;
             const float minSize         = totalSize / nodesInSameColumn * 0.2;
             const bool  resizePrevNodes = isStackVertical ? (TOP || DISPLAYBOTTOM) && !DISPLAYTOP : (LEFT || DISPLAYRIGHT) && !DISPLAYLEFT;
 
-            int   nodesLeft = 0;
-            float sizeLeft  = 0;
-            int   nodeCount = 0;
+            int         nodesLeft = 0;
+            float       sizeLeft  = 0;
+            int         nodeCount = 0;
             // check the sizes of all the nodes to be resized for later calculation
             auto checkNodesLeft = [&sizeLeft, &nodesLeft, orientation, isStackVertical, &nodeCount, PNODE](auto it) {
                 if (it.isMaster != PNODE->isMaster || it.workspaceID != PNODE->workspaceID)
@@ -773,17 +772,16 @@ void CHyprMasterLayout::resizeActiveWindow(const Vector2D& pixResize, eRectCorne
             PNODE->percSize += resizeDiff / SIZE;
 
             // resize the other nodes
-            nodeCount = 0;
-            auto resizeNodesLeft = [maxSizeIncrease, resizeDiff, minSize, orientation, isStackVertical, SIZE, &nodeCount, nodesLeft, PNODE](auto &it) {
+            nodeCount            = 0;
+            auto resizeNodesLeft = [maxSizeIncrease, resizeDiff, minSize, orientation, isStackVertical, SIZE, &nodeCount, nodesLeft, PNODE](auto& it) {
                 if (it.isMaster != PNODE->isMaster || it.workspaceID != PNODE->workspaceID)
                     return;
                 nodeCount++;
                 // if center orientation, only resize when on the same side
                 if (!it.isMaster && orientation == ORIENTATION_CENTER && nodeCount % 2 == 1)
                     return;
-                const float size = isStackVertical ? it.size.y : it.size.x;
-                const float resizeDeltaForEach = maxSizeIncrease != 0 ?
-                            resizeDiff * (size - minSize) / maxSizeIncrease : resizeDiff / nodesLeft;
+                const float size               = isStackVertical ? it.size.y : it.size.x;
+                const float resizeDeltaForEach = maxSizeIncrease != 0 ? resizeDiff * (size - minSize) / maxSizeIncrease : resizeDiff / nodesLeft;
                 it.percSize -= resizeDeltaForEach / SIZE;
             };
             if (resizePrevNodes) {

--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -48,7 +48,7 @@ struct SMasterWorkspaceData {
 
 class CHyprMasterLayout : public IHyprLayout {
   public:
-    virtual void                     onWindowCreatedTiling(CWindow*, eDirection direction = NONE);
+    virtual void                     onWindowCreatedTiling(CWindow*, eDirection direction = DIRECTION_NONE);
     virtual void                     onWindowRemovedTiling(CWindow*);
     virtual bool                     isWindowTiled(CWindow*);
     virtual void                     recalculateMonitor(const int&);

--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -48,7 +48,7 @@ struct SMasterWorkspaceData {
 
 class CHyprMasterLayout : public IHyprLayout {
   public:
-    virtual void                     onWindowCreatedTiling(CWindow*, eDirection direction = DIRECTION_NONE);
+    virtual void                     onWindowCreatedTiling(CWindow*, eDirection direction = DIRECTION_DEFAULT);
     virtual void                     onWindowRemovedTiling(CWindow*);
     virtual bool                     isWindowTiled(CWindow*);
     virtual void                     recalculateMonitor(const int&);

--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -48,7 +48,7 @@ struct SMasterWorkspaceData {
 
 class CHyprMasterLayout : public IHyprLayout {
   public:
-    virtual void                     onWindowCreatedTiling(CWindow*);
+    virtual void                     onWindowCreatedTiling(CWindow*, eDirection direction = NONE);
     virtual void                     onWindowRemovedTiling(CWindow*);
     virtual bool                     isWindowTiled(CWindow*);
     virtual void                     recalculateMonitor(const int&);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1963,9 +1963,20 @@ void CKeybindManager::moveWindowIntoGroup(CWindow* pWindow, CWindow* pWindowInDi
     g_pCompositor->warpCursorTo(pWindow->middle());
 }
 
-void CKeybindManager::moveWindowOutOfGroup(CWindow* pWindow) {
-    static auto* const BFOCUSREMOVEDWINDOW = &g_pConfigManager->getConfigValuePtr("misc:group_focus_removed_window")->intValue;
-    const auto         PWINDOWPREV         = pWindow->getGroupPrevious();
+void CKeybindManager::moveWindowOutOfGroup(CWindow* pWindow, const std::string& dir) {
+    static auto* const      BFOCUSREMOVEDWINDOW = &g_pConfigManager->getConfigValuePtr("misc:group_focus_removed_window")->intValue;
+    const auto              PWINDOWPREV         = pWindow->getGroupPrevious();
+    IHyprLayout::eDirection direction;
+
+    switch (dir[0]) {
+        case 't':
+        case 'u': direction = IHyprLayout::eDirection::UP; break;
+        case 'd':
+        case 'b': direction = IHyprLayout::eDirection::DOWN; break;
+        case 'l': direction = IHyprLayout::eDirection::LEFT; break;
+        case 'r': direction = IHyprLayout::eDirection::RIGHT; break;
+        default: direction = IHyprLayout::NONE;
+    }
 
     g_pLayoutManager->getCurrentLayout()->onWindowRemoved(pWindow);
 
@@ -1973,7 +1984,7 @@ void CKeybindManager::moveWindowOutOfGroup(CWindow* pWindow) {
 
     g_pKeybindManager->m_bGroupsLocked = true;
 
-    g_pLayoutManager->getCurrentLayout()->onWindowCreated(pWindow);
+    g_pLayoutManager->getCurrentLayout()->onWindowCreated(pWindow, direction);
 
     g_pKeybindManager->m_bGroupsLocked = GROUPSLOCKEDPREV;
 
@@ -2059,13 +2070,13 @@ void CKeybindManager::moveWindowOrGroup(std::string args) {
             moveWindowIntoGroup(PWINDOW, PWINDOWINDIR);
     } else if (PWINDOWINDIR) {
         if (ISWINDOWGROUP && (*BIGNOREGROUPLOCK || !ISWINDOWGROUPLOCKED))
-            moveWindowOutOfGroup(PWINDOW);
+            moveWindowOutOfGroup(PWINDOW, args);
         else {
             g_pLayoutManager->getCurrentLayout()->moveWindowTo(PWINDOW, args);
             g_pCompositor->warpCursorTo(PWINDOW->middle());
         }
     } else if (ISWINDOWGROUP && (*BIGNOREGROUPLOCK || !ISWINDOWGROUPLOCKED)) {
-        moveWindowOutOfGroup(PWINDOW);
+        moveWindowOutOfGroup(PWINDOW, args);
     }
 }
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1966,16 +1966,16 @@ void CKeybindManager::moveWindowIntoGroup(CWindow* pWindow, CWindow* pWindowInDi
 void CKeybindManager::moveWindowOutOfGroup(CWindow* pWindow, const std::string& dir) {
     static auto* const      BFOCUSREMOVEDWINDOW = &g_pConfigManager->getConfigValuePtr("misc:group_focus_removed_window")->intValue;
     const auto              PWINDOWPREV         = pWindow->getGroupPrevious();
-    IHyprLayout::eDirection direction;
+    eDirection              direction;
 
     switch (dir[0]) {
         case 't':
-        case 'u': direction = IHyprLayout::eDirection::UP; break;
+        case 'u': direction = eDirection::DIRECTION_UP; break;
         case 'd':
-        case 'b': direction = IHyprLayout::eDirection::DOWN; break;
-        case 'l': direction = IHyprLayout::eDirection::LEFT; break;
-        case 'r': direction = IHyprLayout::eDirection::RIGHT; break;
-        default: direction = IHyprLayout::NONE;
+        case 'b': direction = eDirection::DIRECTION_DOWN; break;
+        case 'l': direction = eDirection::DIRECTION_LEFT; break;
+        case 'r': direction = eDirection::DIRECTION_RIGHT; break;
+        default: direction = eDirection::DIRECTION_NONE;
     }
 
     g_pLayoutManager->getCurrentLayout()->onWindowRemoved(pWindow);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1970,12 +1970,12 @@ void CKeybindManager::moveWindowOutOfGroup(CWindow* pWindow, const std::string& 
 
     switch (dir[0]) {
         case 't':
-        case 'u': direction = eDirection::DIRECTION_UP; break;
+        case 'u': direction = DIRECTION_UP; break;
         case 'd':
-        case 'b': direction = eDirection::DIRECTION_DOWN; break;
-        case 'l': direction = eDirection::DIRECTION_LEFT; break;
-        case 'r': direction = eDirection::DIRECTION_RIGHT; break;
-        default: direction = eDirection::DIRECTION_NONE;
+        case 'b': direction = DIRECTION_DOWN; break;
+        case 'l': direction = DIRECTION_LEFT; break;
+        case 'r': direction = DIRECTION_RIGHT; break;
+        default: direction = DIRECTION_DEFAULT;
     }
 
     g_pLayoutManager->getCurrentLayout()->onWindowRemoved(pWindow);

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -91,7 +91,7 @@ class CKeybindManager {
     bool                      ensureMouseBindState();
 
     static bool               tryMoveFocusToMonitor(CMonitor* monitor);
-    static void               moveWindowOutOfGroup(CWindow* pWindow);
+    static void               moveWindowOutOfGroup(CWindow* pWindow, const std::string& dir = "");
     static void               moveWindowIntoGroup(CWindow* pWindow, CWindow* pWindowInDirection);
     static void               switchToWindow(CWindow* PWINDOWTOCHANGETO);
 


### PR DESCRIPTION
## Abstract

Add a direction parameter with a default value to the onWindowCreated and onWindowCreatedTiling virtual methods of IHyprLayout. This parameter allows potential control over the direction of window creation.

Currently only DWindleLayout has an existing implementation of such control.
Does not affect master layout.

## Other Changes

- Implement directional moveWindowOutOfGroup for `movewindoworgroup`. (augmentation of #3006)
- Replace `DWindleLayout::OneTimeFocus` with `IHyprLayout::eDirection`.
- Slight formatting change (clang-format).
- Fix nullptr dereference in Dwindle window creation at https://github.com/hyprwm/Hyprland/blob/ed51fe7bac76248933c71d3958fdb9a973066dfd/src/layout/DwindleLayout.cpp#L298-L308

The probability of this nullptr dereference being triggered is low, perhaps elucidating its belated detection.