### PR TITLE
Allow the layout to control how windows are raised in groups

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -829,10 +829,7 @@ void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
         return;
     }
 
-    if (pWindow && pWindow->isHidden() && pWindow->m_sGroupData.pNextWindow) {
-        // grouped, change the current to us
-        pWindow->setGroupCurrent(pWindow);
-    }
+    g_pLayoutManager->getCurrentLayout()->bringWindowToTop(pWindow);
 
     if (!pWindow || !windowValidMapped(pWindow)) {
         const auto PLASTWINDOW = m_pLastWindow;
@@ -2170,7 +2167,7 @@ CWindow* CCompositor::getWindowByRegex(const std::string& regexp) {
     }
 
     for (auto& w : g_pCompositor->m_vWindows) {
-        if (!w->m_bIsMapped || (w->isHidden() && !w->m_sGroupData.pNextWindow))
+        if (!w->m_bIsMapped || (w->isHidden() && !g_pLayoutManager->getCurrentLayout()->isWindowReachable(w.get())))
             continue;
 
         switch (mode) {

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -536,12 +536,22 @@ CWindow* IHyprLayout::getNextWindowCandidate(CWindow* pWindow) {
     return PWINDOWCANDIDATE;
 }
 
-void IHyprLayout::requestFocusForWindow(CWindow* pWindow) {
+bool IHyprLayout::isWindowReachable(CWindow* pWindow) {
+    return pWindow && (!pWindow->isHidden() || pWindow->m_sGroupData.pNextWindow);
+}
+
+void IHyprLayout::bringWindowToTop(CWindow* pWindow) {
+    if (pWindow == nullptr)
+        return;
+
     if (pWindow->isHidden() && pWindow->m_sGroupData.pNextWindow) {
         // grouped, change the current to this window
         pWindow->setGroupCurrent(pWindow);
     }
+}
 
+void IHyprLayout::requestFocusForWindow(CWindow* pWindow) {
+    bringWindowToTop(pWindow);
     g_pCompositor->focusWindow(pWindow);
 }
 

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -163,7 +163,6 @@ class IHyprLayout {
     /*
         Called before an attempt is made to focus a window.
         Brings the window to the top of any groups and ensures it is not hidden.
-
         If the window is unmapped following this call, the focus attempt will fail.
 	  */
     virtual void bringWindowToTop(CWindow*);
@@ -171,7 +170,6 @@ class IHyprLayout {
     /*
         Called via the foreign toplevel activation protocol.
         Focuses a window, bringing it to the top of its group if applicable.
-
 				May be ignored.
     */
     virtual void requestFocusForWindow(CWindow*);

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -157,20 +157,20 @@ class IHyprLayout {
 
     /*
         Determines if a window can be focused. If hidden this usually means the window is part of a group.
-		*/
+    */
     virtual bool isWindowReachable(CWindow*);
 
     /*
         Called before an attempt is made to focus a window.
         Brings the window to the top of any groups and ensures it is not hidden.
         If the window is unmapped following this call, the focus attempt will fail.
-	  */
+    */
     virtual void bringWindowToTop(CWindow*);
 
     /*
         Called via the foreign toplevel activation protocol.
         Focuses a window, bringing it to the top of its group if applicable.
-				May be ignored.
+        May be ignored.
     */
     virtual void requestFocusForWindow(CWindow*);
 

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -156,8 +156,22 @@ class IHyprLayout {
     virtual void replaceWindowDataWith(CWindow* from, CWindow* to) = 0;
 
     /*
+        Determines if a window can be focused. If hidden this usually means the window is part of a group.
+		*/
+    virtual bool isWindowReachable(CWindow*);
+
+    /*
+        Called before an attempt is made to focus a window.
+        Brings the window to the top of any groups and ensures it is not hidden.
+
+        If the window is unmapped following this call, the focus attempt will fail.
+	  */
+    virtual void bringWindowToTop(CWindow*);
+
+    /*
         Called via the foreign toplevel activation protocol.
         Focuses a window, bringing it to the top of its group if applicable.
+
 				May be ignored.
     */
     virtual void requestFocusForWindow(CWindow*);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Previously windows could only be focused if they weren't hidden or were part of a group. This shifts the logic for identifying group windows and showing them to the layout allowing for alternate group implementations to function normally.

Needed to fix outfoxxed/hy3#28 ([#3be4f05](outfoxxed/hy3/commit/3be4f0556bc47f388c6cd128199001c6b6eea3ad))

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready
