### PR TITLE
config: option to open new window as group

### DIFF
--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -640,6 +640,20 @@ bool CWindow::hasPopupAt(const Vector2D& pos) {
     return resultSurf;
 }
 
+void CWindow::Group() {
+    if (!m_sGroupData.pNextWindow) {
+        m_sGroupData.pNextWindow = this;
+        m_sGroupData.head        = true;
+        m_sGroupData.locked      = false;
+
+        m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(this));
+        updateWindowDecos();
+
+        g_pLayoutManager->getCurrentLayout()->recalculateWindow(this);
+        g_pCompositor->updateAllWindowsAnimatedDecorationValues();
+    }
+}
+
 CWindow* CWindow::getGroupHead() {
     CWindow* curr = this;
     while (!curr->m_sGroupData.head)

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -341,6 +341,7 @@ class CWindow {
     bool                     isInCurvedCorner(double x, double y);
     bool                     hasPopupAt(const Vector2D& pos);
 
+    void                     Group();
     CWindow*                 getGroupHead();
     CWindow*                 getGroupTail();
     CWindow*                 getGroupCurrent();

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -81,6 +81,7 @@ void CConfigManager::setDefaultVars() {
     configValues["general:resize_on_border"].intValue        = 0;
     configValues["general:extend_border_grab_area"].intValue = 15;
     configValues["general:hover_icon_on_border"].intValue    = 1;
+    configValues["general:group_new_window"].intValue        = 0;
     configValues["general:layout"].strValue                  = "dwindle";
 
     configValues["misc:disable_hyprland_logo"].intValue        = 0;

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -237,6 +237,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow) {
 
     static auto* const PUSEACTIVE    = &g_pConfigManager->getConfigValuePtr("dwindle:use_active_for_splits")->intValue;
     static auto* const PDEFAULTSPLIT = &g_pConfigManager->getConfigValuePtr("dwindle:default_split_ratio")->floatValue;
+    static auto* const PASGROUP      = &g_pConfigManager->getConfigValuePtr("general:group_new_window")->intValue;
 
     // Populate the node with our window's data
     PNODE->workspaceID = pWindow->m_iWorkspaceID;
@@ -310,6 +311,9 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow) {
         PNODE->size     = PMONITOR->vecSize - PMONITOR->vecReservedTopLeft - PMONITOR->vecReservedBottomRight;
 
         applyNodeDataToWindow(PNODE);
+
+        if (*PASGROUP && pWindow->m_bFirstMap)
+            pWindow->Group();
 
         return;
     }
@@ -472,6 +476,10 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow) {
 
     applyNodeDataToWindow(PNODE);
     applyNodeDataToWindow(OPENINGON);
+
+    // if general:group_new_window = true, make this window a group
+    if (*PASGROUP && pWindow->m_bFirstMap)
+        pWindow->Group();
 }
 
 void CHyprDwindleLayout::onWindowRemovedTiling(CWindow* pWindow) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1148,14 +1148,7 @@ void CKeybindManager::toggleGroup(std::string args) {
     g_pCompositor->setWindowFullscreen(PWINDOW, false, FULLSCREEN_FULL);
 
     if (!PWINDOW->m_sGroupData.pNextWindow) {
-        PWINDOW->m_sGroupData.pNextWindow = PWINDOW;
-        PWINDOW->m_sGroupData.head        = true;
-        PWINDOW->m_sGroupData.locked      = false;
-
-        PWINDOW->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(PWINDOW));
-
-        PWINDOW->updateWindowDecos();
-        g_pLayoutManager->getCurrentLayout()->recalculateWindow(PWINDOW);
+        PWINDOW->Group();
     } else {
         if (PWINDOW->m_sGroupData.pNextWindow == PWINDOW) {
             PWINDOW->m_sGroupData.pNextWindow = nullptr;


### PR DESCRIPTION
Add `general:group_new_window`, if true, newly mapped window will open as group if

- no focused window
- focused window is not group
- focused window is locked group

As usual, `ignore_group_lock` has no effect on this. (as noted in the wiki, it currently only affects `moveintogroup`, `moveoutofgroup` and `movewindoworgroup`).

## Other changes

- Moved some general logic governing the transition of a window into a group to `CWindow::Group`.
- Rather wild **clang-format** shenanigans on `MasterLayout.cpp`, mayhap it's time to set up a git hook or CI to automatically format all modified files?

---

closes: #1505
wiki: hyprwm/hyprland-wiki#341