### PR TITLE
windows: add rule `group` to map windows grouped

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -875,7 +875,7 @@ void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
         const auto PWORKSPACE            = getWorkspaceByID(pWindow->m_iWorkspaceID);
         PWORKSPACE->m_pLastFocusedWindow = pWindow;
         PWORKSPACE->rememberPrevWorkspace(getWorkspaceByID(m_pLastMonitor->activeWorkspace));
-        const auto PMONITOR              = getMonitorFromID(PWORKSPACE->m_iMonitorID);
+        const auto PMONITOR = getMonitorFromID(PWORKSPACE->m_iMonitorID);
         PMONITOR->changeWorkspace(PWORKSPACE, false, true);
         // changeworkspace already calls focusWindow
         return;
@@ -1659,6 +1659,8 @@ void CCompositor::updateWindowAnimatedDecorationValues(CWindow* pWindow) {
     // optimization
     static auto* const ACTIVECOL              = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("general:col.active_border")->data.get();
     static auto* const INACTIVECOL            = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("general:col.inactive_border")->data.get();
+    static auto* const NOGROUPACTIVECOL       = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("general:col.nogroup_border_active")->data.get();
+    static auto* const NOGROUPINACTIVECOL     = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("general:col.nogroup_border")->data.get();
     static auto* const GROUPACTIVECOL         = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("general:col.group_border_active")->data.get();
     static auto* const GROUPINACTIVECOL       = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("general:col.group_border")->data.get();
     static auto* const GROUPACTIVELOCKEDCOL   = (CGradientValueData*)g_pConfigManager->getConfigValuePtr("general:col.group_border_locked_active")->data.get();
@@ -1688,12 +1690,14 @@ void CCompositor::updateWindowAnimatedDecorationValues(CWindow* pWindow) {
     else {
         const bool GROUPLOCKED = pWindow->m_sGroupData.pNextWindow ? pWindow->getGroupHead()->m_sGroupData.locked : false;
         if (pWindow == m_pLastWindow) {
-            const auto* const ACTIVECOLOR = !pWindow->m_sGroupData.pNextWindow ? ACTIVECOL : (GROUPLOCKED ? GROUPACTIVELOCKEDCOL : GROUPACTIVECOL);
+            const auto* const ACTIVECOLOR =
+                !pWindow->m_sGroupData.pNextWindow ? (!pWindow->m_sGroupData.deny ? ACTIVECOL : NOGROUPACTIVECOL) : (GROUPLOCKED ? GROUPACTIVELOCKEDCOL : GROUPACTIVECOL);
             setBorderColor(pWindow->m_sSpecialRenderData.activeBorderColor.toUnderlying() >= 0 ?
                                CGradientValueData(CColor(pWindow->m_sSpecialRenderData.activeBorderColor.toUnderlying())) :
                                *ACTIVECOLOR);
         } else {
-            const auto* const INACTIVECOLOR = !pWindow->m_sGroupData.pNextWindow ? INACTIVECOL : (GROUPLOCKED ? GROUPINACTIVELOCKEDCOL : GROUPINACTIVECOL);
+            const auto* const INACTIVECOLOR =
+                !pWindow->m_sGroupData.pNextWindow ? (!pWindow->m_sGroupData.deny ? INACTIVECOL : NOGROUPINACTIVECOL) : (GROUPLOCKED ? GROUPINACTIVELOCKEDCOL : GROUPINACTIVECOL);
             setBorderColor(pWindow->m_sSpecialRenderData.inactiveBorderColor.toUnderlying() >= 0 ?
                                CGradientValueData(CColor(pWindow->m_sSpecialRenderData.inactiveBorderColor.toUnderlying())) :
                                *INACTIVECOLOR);

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -640,6 +640,69 @@ bool CWindow::hasPopupAt(const Vector2D& pos) {
     return resultSurf;
 }
 
+void CWindow::applyGroupRules() {
+    if ((m_eGroupRules & GROUP_SET && m_bFirstMap) || m_eGroupRules & GROUP_SET_ALWAYS)
+        createGroup();
+
+    if (m_sGroupData.pNextWindow && ((m_eGroupRules & GROUP_LOCK && m_bFirstMap) || m_eGroupRules & GROUP_LOCK_ALWAYS))
+        getGroupHead()->m_sGroupData.locked = true;
+}
+
+void CWindow::createGroup() {
+    if (m_sGroupData.deny) {
+        Debug::log(LOG, "createGroup: window:{:x},title:{} is denied as a group, ignored", (uintptr_t)this, this->m_szTitle);
+        return;
+    }
+    if (!m_sGroupData.pNextWindow) {
+        m_sGroupData.pNextWindow = this;
+        m_sGroupData.head        = true;
+        m_sGroupData.locked      = false;
+        m_sGroupData.deny        = false;
+
+        m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(this));
+        updateWindowDecos();
+
+        g_pLayoutManager->getCurrentLayout()->recalculateWindow(this);
+        g_pCompositor->updateAllWindowsAnimatedDecorationValues();
+    }
+}
+
+void CWindow::destroyGroup() {
+    if (m_sGroupData.pNextWindow == this) {
+        if (m_eGroupRules & GROUP_SET_ALWAYS) {
+            Debug::log(LOG, "destoryGroup: window:{:x},title:{} has rule [group set always], ignored", (uintptr_t)this, this->m_szTitle);
+            return;
+        }
+        m_sGroupData.pNextWindow = nullptr;
+        updateWindowDecos();
+        return;
+    }
+
+    CWindow*              curr = this;
+    std::vector<CWindow*> members;
+    do {
+        const auto PLASTWIN                = curr;
+        curr                               = curr->m_sGroupData.pNextWindow;
+        PLASTWIN->m_sGroupData.pNextWindow = nullptr;
+        curr->setHidden(false);
+        members.push_back(curr);
+    } while (curr != this);
+
+    for (auto& w : members) {
+        if (w->m_sGroupData.head)
+            g_pLayoutManager->getCurrentLayout()->onWindowRemoved(curr);
+        w->m_sGroupData.head = false;
+    }
+
+    const bool GROUPSLOCKEDPREV        = g_pKeybindManager->m_bGroupsLocked;
+    g_pKeybindManager->m_bGroupsLocked = true;
+    for (auto& w : members) {
+        g_pLayoutManager->getCurrentLayout()->onWindowCreated(w);
+        w->updateWindowDecos();
+    }
+    g_pKeybindManager->m_bGroupsLocked = GROUPSLOCKEDPREV;
+}
+
 CWindow* CWindow::getGroupHead() {
     CWindow* curr = this;
     while (!curr->m_sGroupData.head)

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -25,7 +25,8 @@ enum eGroupRules {
     GROUP_BARRED      = 1 << 2, // Don't insert to focused group.
     GROUP_LOCK        = 1 << 3, // Lock m_sGroupData.lock
     GROUP_LOCK_ALWAYS = 1 << 4,
-    GROUP_OVERRIDE    = 1 << 5, // Override other rules
+    GROUP_INVADE      = 1 << 5, // Force enter a group, event if lock is engaged
+    GROUP_OVERRIDE    = 1 << 6, // Override other rules
 };
 
 template <typename T>
@@ -313,7 +314,7 @@ class CWindow {
         bool     locked      = false; // per group lock
         bool     deny        = false; // deny window from enter a group or made a group
     } m_sGroupData;
-    uint8_t m_eGroupRules = GROUP_NONE;
+    uint16_t m_eGroupRules = GROUP_NONE;
 
     // For the list lookup
     bool operator==(const CWindow& rhs) {

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -17,6 +17,17 @@ enum eIdleInhibitMode {
     IDLEINHIBIT_FOCUS
 };
 
+enum eGroupRules {
+    // effective only during first map, except for _ALWAYS variant
+    GROUP_NONE        = 0,
+    GROUP_SET         = 1 << 0, // Open as new group or add to focused group
+    GROUP_SET_ALWAYS  = 1 << 1,
+    GROUP_BARRED      = 1 << 2, // Don't insert to focused group.
+    GROUP_LOCK        = 1 << 3, // Lock m_sGroupData.lock
+    GROUP_LOCK_ALWAYS = 1 << 4,
+    GROUP_OVERRIDE    = 1 << 5, // Override other rules
+};
+
 template <typename T>
 class CWindowOverridableVar {
   public:
@@ -299,8 +310,10 @@ class CWindow {
     struct SGroupData {
         CWindow* pNextWindow = nullptr; // nullptr means no grouping. Self means single group.
         bool     head        = false;
-        bool     locked      = false;
+        bool     locked      = false; // per group lock
+        bool     deny        = false; // deny window from enter a group or made a group
     } m_sGroupData;
+    uint8_t m_eGroupRules = GROUP_NONE;
 
     // For the list lookup
     bool operator==(const CWindow& rhs) {
@@ -341,6 +354,9 @@ class CWindow {
     bool                     isInCurvedCorner(double x, double y);
     bool                     hasPopupAt(const Vector2D& pos);
 
+    void                     applyGroupRules();
+    void                     createGroup();
+    void                     destroyGroup();
     CWindow*                 getGroupHead();
     CWindow*                 getGroupTail();
     CWindow*                 getGroupCurrent();

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -17,6 +17,8 @@ extern "C" char** environ;
 CConfigManager::CConfigManager() {
     configValues["general:col.active_border"].data              = std::make_shared<CGradientValueData>(0xffffffff);
     configValues["general:col.inactive_border"].data            = std::make_shared<CGradientValueData>(0xff444444);
+    configValues["general:col.nogroup_border"].data             = std::make_shared<CGradientValueData>(0xffffaaff);
+    configValues["general:col.nogroup_border_active"].data      = std::make_shared<CGradientValueData>(0xffff00ff);
     configValues["general:col.group_border"].data               = std::make_shared<CGradientValueData>(0x66777700);
     configValues["general:col.group_border_active"].data        = std::make_shared<CGradientValueData>(0x66ffff00);
     configValues["general:col.group_border_locked"].data        = std::make_shared<CGradientValueData>(0x66775500);
@@ -72,6 +74,8 @@ void CConfigManager::setDefaultVars() {
     configValues["general:gaps_out"].intValue              = 20;
     ((CGradientValueData*)configValues["general:col.active_border"].data.get())->reset(0xffffffff);
     ((CGradientValueData*)configValues["general:col.inactive_border"].data.get())->reset(0xff444444);
+    ((CGradientValueData*)configValues["general:col.nogroup_border"].data.get())->reset(0xff444444);
+    ((CGradientValueData*)configValues["general:col.nogroup_border_active"].data.get())->reset(0xffff00ff);
     ((CGradientValueData*)configValues["general:col.group_border"].data.get())->reset(0x66777700);
     ((CGradientValueData*)configValues["general:col.group_border_active"].data.get())->reset(0x66ffff00);
     ((CGradientValueData*)configValues["general:col.group_border_locked"].data.get())->reset(0x66775500);
@@ -904,7 +908,7 @@ bool windowRuleValid(const std::string& RULE) {
              RULE != "nomaximizerequest" && RULE != "fakefullscreen" && RULE != "nomaxsize" && RULE != "pin" && RULE != "noanim" && RULE != "dimaround" && RULE != "windowdance" &&
              RULE != "maximize" && RULE != "keepaspectratio" && RULE.find("animation") != 0 && RULE.find("rounding") != 0 && RULE.find("workspace") != 0 &&
              RULE.find("bordercolor") != 0 && RULE != "forcergbx" && RULE != "noinitialfocus" && RULE != "stayfocused" && RULE.find("bordersize") != 0 && RULE.find("xray") != 0 &&
-             RULE.find("center") != 0);
+             RULE.find("center") != 0 && RULE.find("group") != 0);
 }
 
 bool layerRuleValid(const std::string& RULE) {

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -222,6 +222,8 @@ void Events::listener_mapWindow(void* owner, void* data) {
                     PWINDOW->m_eGroupRules |= (GROUP_SET | GROUP_BARRED);
                 } else if (v == "lock") {
                     PWINDOW->m_eGroupRules |= GROUP_LOCK;
+                } else if (v == "invade") {
+                    PWINDOW->m_eGroupRules |= GROUP_INVADE;
                 } else if (v == "barred") {
                     PWINDOW->m_eGroupRules |= GROUP_BARRED;
                 } else if (v == "deny") {

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -314,14 +314,18 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection dire
 
         applyNodeDataToWindow(PNODE);
 
+        pWindow->applyGroupRules();
+
         return;
     }
 
     // if it's a group, add the window
-    if (OPENINGON->pWindow->m_sGroupData.pNextWindow &&                                         // target is group
-        !OPENINGON->pWindow->getGroupHead()->m_sGroupData.locked &&                             // target unlocked
-        !(pWindow->m_sGroupData.pNextWindow && pWindow->getGroupHead()->m_sGroupData.locked) && // source unlocked or isn't group
-        !g_pKeybindManager->m_bGroupsLocked && !m_vOverrideFocalPoint) {
+    if (OPENINGON->pWindow->m_sGroupData.pNextWindow                                            // target is group
+        && !OPENINGON->pWindow->getGroupHead()->m_sGroupData.locked                             // target unlocked
+        && !(pWindow->m_sGroupData.pNextWindow && pWindow->getGroupHead()->m_sGroupData.locked) // source unlocked or isn't group
+        && !pWindow->m_sGroupData.deny                                                          // source is not denied entry
+        && !(pWindow->m_eGroupRules & GROUP_BARRED)                                             // group rule doesn't prevent adding window
+        && !g_pKeybindManager->m_bGroupsLocked && !m_vOverrideFocalPoint) {
         if (!pWindow->m_sGroupData.pNextWindow)
             pWindow->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(pWindow));
 
@@ -341,6 +345,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection dire
         }
 
         OPENINGON->pWindow->setGroupCurrent(pWindow);
+        pWindow->applyGroupRules();
         pWindow->updateWindowDecos();
         recalculateWindow(pWindow);
 
@@ -474,6 +479,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection dire
 
     applyNodeDataToWindow(PNODE);
     applyNodeDataToWindow(OPENINGON);
+    pWindow->applyGroupRules();
 }
 
 void CHyprDwindleLayout::onWindowRemovedTiling(CWindow* pWindow) {

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -320,12 +320,15 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection dire
     }
 
     // if it's a group, add the window
-    if (OPENINGON->pWindow->m_sGroupData.pNextWindow                                            // target is group
-        && !OPENINGON->pWindow->getGroupHead()->m_sGroupData.locked                             // target unlocked
-        && !(pWindow->m_sGroupData.pNextWindow && pWindow->getGroupHead()->m_sGroupData.locked) // source unlocked or isn't group
-        && !pWindow->m_sGroupData.deny                                                          // source is not denied entry
-        && !(pWindow->m_eGroupRules & GROUP_BARRED)                                             // group rule doesn't prevent adding window
-        && !g_pKeybindManager->m_bGroupsLocked && !m_vOverrideFocalPoint) {
+    if (OPENINGON->pWindow->m_sGroupData.pNextWindow                                                      // target is group
+        && !g_pKeybindManager->m_bGroupsLocked                                                            // global group lock disengaged
+        && ((pWindow->m_eGroupRules & GROUP_INVADE && pWindow->m_bFirstMap)                               // window ignore local group locks, or
+            || (!OPENINGON->pWindow->getGroupHead()->m_sGroupData.locked                                  //    target unlocked
+                && !(pWindow->m_sGroupData.pNextWindow && pWindow->getGroupHead()->m_sGroupData.locked))) //    source unlocked or isn't group
+        && !pWindow->m_sGroupData.deny                                                                    // source is not denied entry
+        && !(pWindow->m_eGroupRules & GROUP_BARRED && pWindow->m_bFirstMap)                               // group rule doesn't prevent adding window
+        && !m_vOverrideFocalPoint                                                                         // we are not moving window
+    ) {
         if (!pWindow->m_sGroupData.pNextWindow)
             pWindow->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(pWindow));
 

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -94,12 +94,15 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection direc
     const auto         MOUSECOORDS = g_pInputManager->getMouseCoordsInternal();
 
     // if it's a group, add the window
-    if (OPENINGON && OPENINGON != PNODE && OPENINGON->pWindow->m_sGroupData.pNextWindow         // target is group
-        && !OPENINGON->pWindow->getGroupHead()->m_sGroupData.locked                             // target unlocked
-        && !(pWindow->m_sGroupData.pNextWindow && pWindow->getGroupHead()->m_sGroupData.locked) // source unlocked or isn't group
-        && !pWindow->m_sGroupData.deny                                                          // source is not denied entry
-        && !(pWindow->m_eGroupRules & GROUP_BARRED)                                             // group rule doesn't prevent adding window
-        && !g_pKeybindManager->m_bGroupsLocked) {
+    if (OPENINGON && OPENINGON != PNODE && OPENINGON->pWindow->m_sGroupData.pNextWindow                   // target is group
+        && !g_pKeybindManager->m_bGroupsLocked                                                            // global group lock disengaged
+        && ((pWindow->m_eGroupRules & GROUP_INVADE && pWindow->m_bFirstMap)                               // window ignore local group locks, or
+            || (!OPENINGON->pWindow->getGroupHead()->m_sGroupData.locked                                  //    target unlocked
+                && !(pWindow->m_sGroupData.pNextWindow && pWindow->getGroupHead()->m_sGroupData.locked))) //    source unlocked or isn't group
+        && !pWindow->m_sGroupData.deny                                                                    // source is not denied entry
+        && !(pWindow->m_eGroupRules & GROUP_BARRED)                                                       // group rule doesn't prevent adding window
+    ) {
+
         if (!pWindow->m_sGroupData.pNextWindow)
             pWindow->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(pWindow));
 

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -150,6 +150,7 @@ class CKeybindManager {
     static void     moveGroupWindow(std::string);
     static void     moveWindowOrGroup(std::string);
     static void     setIgnoreGroupLock(std::string);
+    static void     denyWindowFromGroup(std::string);
     static void     global(std::string);
 
     friend class CCompositor;


### PR DESCRIPTION
## Changes

### `group` window rule
```
RULE = "group" {" " GROUP RULE}, WINDOW .
GROUP RULE = 
	| "set" [" always"] 
	| "new" 
	| "lock" [" always"] 
	| "barred" 
	| "invade"
	| "deny"
	| "override " {GROUP RULE}
	| "unset"
```

By default, all rules except `deny` are only effective for new windows (first card).
The `always` qualifier can be used to make some rules effective during the lifetime of a window.

- [x] **set**: Map window grouped if focused window isn't a group.
- [x] **new**: Shorthand of `set barred`. Can be used to open a new group event if the focused window is a group.
- [x] **lock**: Lock the group.
- [x] **barred**: Don't add the window to the focused group.
- [x] **invade**: Force open window in the locked group.
- [x] **deny**: Do not allow window to be toggled as or added to group. This sets `m_sGroupData.deny`
- [x] **override**: Override rules.
- [x] **unset**: Clear all rules.
- [x] **always** qualifier for **new** and **lock**, to make them effective outside first map

A naked `group` rule is a shorthand for `group set`.

### Ban a window from being toggled as a group or added to a group

- [x] `m_sGroupData.deny`: if true, window can't be added to groups or toggled as group.
- [x] **movewindoworgroup**, **moveintogroup**, **moveoutofgroup** respects `m_sGroupData.deny`.
- [x] `m_sGroupData.deny` can be toggled with dispatcher **denywindowfromgroup**.
- [x] window with `m_sGroupData.deny` can be colorized differently.

### Other

- refactor movewindoworgroup
- refactor: Move group creation and destruction logic from KeybindingManager to CWindow.

---
close: #1505 
close: #2987
