### PR TITLE
allow switching monitors when no_warp_cursor is enabled

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -530,7 +530,7 @@ void CMonitor::changeWorkspace(CWorkspace* const pWorkspace, bool internal, bool
         else {
             CWindow* pWindow = nullptr;
 
-            if (*PFOLLOWMOUSE == 1)
+            if (*PFOLLOWMOUSE == 1 && this == g_pCompositor->getMonitorFromCursor())
                 pWindow = g_pCompositor->vectorToWindowIdeal(g_pInputManager->getMouseCoordsInternal());
 
             if (!pWindow)

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -870,10 +870,12 @@ void CKeybindManager::changeworkspace(std::string args) {
     } else
         pWorkspaceToChangeTo->rememberPrevWorkspace(PCURRENTWORKSPACE);
 
-    if (!g_pCompositor->m_pLastFocus)
+    if (!g_pCompositor->m_pLastFocus && PMONITORWORKSPACEOWNER == g_pCompositor->getMonitorFromCursor()) {
         g_pInputManager->simulateMouseMovement();
-    else
+    } else {
+        g_pCompositor->focusWindow(pWorkspaceToChangeTo->getLastFocusedWindow());
         g_pInputManager->sendMotionEventsToFocused();
+    }
 }
 
 void CKeybindManager::fullscreenActive(std::string args) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
fixes #2967 
This pr changes it to only focus under the cursor when not switching monitors. Fixes the issue where current monitor gets refocused when switching to an empty workspace on another monitor.
Also fixes the issue that focus doesnt come back when you switch back to a monitor 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
ready

