### PR TITLE
fix: moveWindowOutOfGroup moves cursor to wrong window

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1996,7 +1996,7 @@ void CKeybindManager::moveWindowOutOfGroup(CWindow* pWindow, const std::string& 
         g_pCompositor->warpCursorTo(pWindow->middle());
     } else {
         g_pCompositor->focusWindow(PWINDOWPREV);
-        g_pCompositor->warpCursorTo(pWindow->middle());
+        g_pCompositor->warpCursorTo(PWINDOWPREV->middle());
     }
 }
 


### PR DESCRIPTION
In https://github.com/hyprwm/Hyprland/blob/2ad429dfe0687b34c1a4d950e7715f0c8550bed5/src/managers/KeybindManager.cpp#L1999 I mistakenly used `pWindow` instead of `PWINDOWPREV`.

Sorry for the inconvenience.