### PR TITLE
fix(dwindle): don't merge groups when moving window

### DIFF
--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -318,8 +318,8 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection dire
     }
 
     // if it's a group, add the window
-    if (OPENINGON->pWindow->m_sGroupData.pNextWindow && !OPENINGON->pWindow->getGroupHead()->m_sGroupData.locked &&
-        !g_pKeybindManager->m_bGroupsLocked) { // target is an unlocked group
+    if (OPENINGON->pWindow->m_sGroupData.pNextWindow && !OPENINGON->pWindow->getGroupHead()->m_sGroupData.locked && !g_pKeybindManager->m_bGroupsLocked &&
+        !m_vOverrideFocalPoint) { // target is an unlocked group
 
         if (!pWindow->m_sGroupData.pNextWindow || !pWindow->getGroupHead()->m_sGroupData.locked) { // source is not a group or an unlocked group
             if (!pWindow->m_sGroupData.pNextWindow)


### PR DESCRIPTION
Currently movewindow in dwindle layout will merge groups, which is rather unexpected as the master layout does not beehave like this and we already have `movewindowintogroup` and `movewindoworgroup` for that purpose.