### PR TITLE
fix: relative path resolution

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1203,8 +1203,9 @@ void CConfigManager::handleSource(const std::string& command, const std::string&
     std::unique_ptr<glob_t, void (*)(glob_t*)> glob_buf{new glob_t, [](glob_t* g) { globfree(g); }};
     memset(glob_buf.get(), 0, sizeof(glob_t));
 
-    if (glob(rawpath.c_str(), GLOB_TILDE, nullptr, glob_buf.get()) != 0) {
-        Debug::log(ERR, "source= globbing error");
+    if (auto r = glob(absolutePath(rawpath, configCurrentPath).c_str(), GLOB_TILDE, nullptr, glob_buf.get()); r != 0) {
+        parseError = std::format("source= globbing error: {}", r == GLOB_NOMATCH ? "found no match" : GLOB_ABORTED ? "read error" : "out of memory");
+        Debug::log(ERR, parseError);
         return;
     }
 

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -126,20 +126,22 @@ static const float transforms[][9] = {
 std::string absolutePath(const std::string& rawpath, const std::string& currentPath) {
     auto value = rawpath;
 
-    if (value[0] == '.') {
-        auto currentDir = currentPath.substr(0, currentPath.find_last_of('/'));
-
-        if (value[1] == '.') {
-            auto parentDir = currentDir.substr(0, currentDir.find_last_of('/'));
-            value.replace(0, 2 + currentPath.empty(), parentDir);
-        } else {
-            value.replace(0, 1 + currentPath.empty(), currentDir);
-        }
-    }
-
     if (value[0] == '~') {
         static const char* const ENVHOME = getenv("HOME");
         value.replace(0, 1, std::string(ENVHOME));
+    } else if (value[0] != '/') {
+        auto currentDir = currentPath.substr(0, currentPath.find_last_of('/'));
+
+        if (value[0] == '.') {
+            if (value[1] == '.' && value[2] == '/') {
+                auto parentDir = currentDir.substr(0, currentDir.find_last_of('/'));
+                value.replace(0, 2 + currentPath.empty(), parentDir);
+            } else if (value[1] == '/')
+                value.replace(0, 1 + currentPath.empty(), currentDir);
+            else
+                value = currentDir + '/' + value;
+        } else
+            value = currentDir + '/' + value;
     }
 
     return value;


### PR DESCRIPTION
Fix the following flaws in `absolutePath`

- Hidden file recognised as relative path
- Relative path not starting with `./` is not recognised

Fix the following globbing issues

- not resolving relative path 
- unintuitive error message

The following uses are supported

```
source = ./relative/path
source = relative/path
source = .hidden/path
source = /absolute/path
```

---

fix: #3307

