### PR TITLE
binds: emit lockgroups event

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1925,6 +1925,8 @@ void CKeybindManager::lockGroups(std::string args) {
         g_pKeybindManager->m_bGroupsLocked = !g_pKeybindManager->m_bGroupsLocked;
     else
         g_pKeybindManager->m_bGroupsLocked = false;
+
+    g_pEventManager->postEvent(SHyprIPCEvent{"lockgroups", g_pKeybindManager->m_bGroupsLocked ? "1" : "0"});
 }
 
 void CKeybindManager::lockActiveGroup(std::string args) {


### PR DESCRIPTION
Have the lockgroups dispatcher fire a `lockgroups` event when the global lock changes, which can be picked up by external programs.

---
doc: hyprwm/hyprland-wiki#346

close: #2768