### PR TITLE
save and restore layout

### DIFF
--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -416,7 +416,9 @@ int main(int argc, char** argv) {
         request(fullRequest, 2);
     else if (fullRequest.contains("/hyprpaper"))
         requestHyprpaper(fullRequest);
-    else if (fullRequest.contains("/--help"))
+    else if (fullRequest.contains("/necromancy")) {
+        request(fullRequest + " --cwd " + std::filesystem::current_path().string(), 1);
+    } else if (fullRequest.contains("/--help"))
         printf("%s", USAGE.c_str());
     else {
         printf("%s\n", USAGE.c_str());

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -97,6 +97,7 @@ class CConfigManager {
     SConfigValue*                                                   getConfigValuePtr(const std::string&);
     SConfigValue*                                                   getConfigValuePtrSafe(const std::string&);
     static std::string                                              getConfigDir();
+    static std::string                                              getDataDir();
     static std::string                                              getMainConfigPath();
 
     SMonitorRule                                                    getMonitorRuleFor(const std::string&, const std::string& displayName = "");

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -707,3 +707,12 @@ void throwError(const std::string& err) {
     Debug::log(CRIT, "Critical error thrown: {}", err);
     throw std::runtime_error(err);
 }
+std::string getCmdline(pid_t pid) {
+    std::ifstream cmdlineIfs{"/proc/" + std::to_string(pid) + "/cmdline", std::ios::binary};
+    std::string   cmdline{std::istreambuf_iterator<char>{cmdlineIfs}, {}};
+
+    std::replace(cmdline.begin(), cmdline.end(), '\0', ' ');
+    if (!cmdline.empty() && cmdline.back() == ' ')
+        cmdline.pop_back();
+    return cmdline;
+}

--- a/src/helpers/MiscFunctions.hpp
+++ b/src/helpers/MiscFunctions.hpp
@@ -31,6 +31,7 @@ double                           normalizeAngleRad(double ang);
 std::string                      replaceInString(std::string subject, const std::string& search, const std::string& replace);
 std::vector<SCallstackFrameInfo> getBacktrace();
 void                             throwError(const std::string& err);
+std::string                      getCmdline(pid_t pid);
 
 template <typename... Args>
 [[deprecated("use std::format instead")]] std::string getFormat(std::format_string<Args...> fmt, Args&&... args) {
@@ -39,3 +40,14 @@ template <typename... Args>
     // this is actually what std::format in stdlib does
     return std::vformat(fmt.get(), std::make_format_args(args...));
 }
+
+using strpair_t = std::pair<const std::string, const std::string>;
+
+template <>
+struct std::hash<strpair_t> {
+    std::size_t operator()(strpair_t const& sp) const noexcept {
+        std::size_t r = std::hash<std::string>{}(sp.first);
+        std::size_t l = std::hash<std::string>{}(sp.second);
+        return r + 0x9e3779b97f4a7a97 + (l << 6) + (l >> 2);
+    }
+};

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -1338,3 +1338,7 @@ void CHyprMasterLayout::onEnable() {
 void CHyprMasterLayout::onDisable() {
     m_lMasterNodesData.clear();
 }
+
+void CHyprMasterLayout::save(std::ostream& os) {}
+
+void CHyprMasterLayout::restore(std::istream& is) {}

--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -61,6 +61,8 @@ class CHyprMasterLayout : public IHyprLayout {
     virtual void                     alterSplitRatio(CWindow*, float, bool);
     virtual std::string              getLayoutName();
     virtual void                     replaceWindowDataWith(CWindow* from, CWindow* to);
+    virtual void                     save(std::ostream& os);
+    virtual void                     restore(std::istream& is);
 
     virtual void                     onEnable();
     virtual void                     onDisable();

--- a/src/layout/Necromancy.cpp
+++ b/src/layout/Necromancy.cpp
@@ -1,0 +1,331 @@
+
+#include "Necromancy.hpp"
+#include "../managers/XWaylandManager.hpp"
+#include "Compositor.hpp"
+#include <ranges>
+
+necromancy_error::necromancy_error(const std::string& msg) : std::runtime_error(msg) {}
+necromancy_error::necromancy_error(const char* msg) : std::runtime_error(msg) {}
+
+void necromancy_error::notify(const float duration) const {
+    g_pHyprNotificationOverlay->addNotification(what(), CColor(0), duration, ICON_ERROR);
+}
+
+necromancy_error& necromancy_error::log() {
+    Debug::log(ERR, "{}", what());
+    return *this;
+}
+
+namespace Necromancy {
+    template <>
+    void dump(std::ostream& os, const std::string& data) {
+        dump(os, data.length());
+        os.write(data.c_str(), data.length());
+    }
+
+    template <>
+    void dump(std::ostream& os, const Vector2D& data) {
+        dump(os, data.x);
+        dump(os, data.y);
+    }
+
+    template <>
+    void load(std::istream& is, std::string& data) {
+        size_t len;
+        load(is, len);
+        data.resize(len);
+        is.read(data.data(), len);
+    }
+
+    template <>
+    void load(std::istream& is, Vector2D& data) {
+        load(is, data.x);
+        load(is, data.y);
+    }
+
+    bool isWindowSavable(CWindow* pWindow) {
+        return pWindow->m_bIsMapped && pWindow->m_iWorkspaceID != -1 && pWindow->m_iWorkspaceID != STRAYS_WORKSPACE_ID;
+    }
+
+    void createHeader(std::ostream& os) {
+        os.write(SIGNATURE.c_str(), SIGNATURE.length());
+        dump(os, VERSION);
+    }
+
+    bool validateHeader(std::istream& is) {
+        std::string signature(SIGNATURE.length(), ' ');
+        int         version = 0;
+
+        is.read(signature.data(), SIGNATURE.length());
+        load(is, version);
+        return signature == SIGNATURE && version == VERSION;
+    }
+
+    void saveLayout(std::string location) {
+        static const auto PSAVE_FILE_PATH = &g_pConfigManager->getConfigValuePtr("misc:layout_save_file")->strValue;
+        location                          = absolutePath(location.empty() ? *PSAVE_FILE_PATH : location, g_pConfigManager->getDataDir());
+
+        std::ofstream ofs{location, std::ios::binary};
+        if (!ofs.is_open())
+            throw necromancy_error(std::format("necromancy: Cannot write layout file: {}", location)).log();
+
+        createHeader(ofs);
+
+        std::string layoutName = g_pLayoutManager->getCurrentLayout()->getLayoutName();
+        dump(ofs, layoutName);
+
+        g_pLayoutManager->getCurrentLayout()->save(ofs);
+    }
+
+    void restoreLayout(std::string location) {
+        static const auto PSAVE_FILE_PATH = &g_pConfigManager->getConfigValuePtr("misc:layout_save_file")->strValue;
+        location                          = absolutePath(location.empty() ? *PSAVE_FILE_PATH : location, g_pConfigManager->getDataDir());
+
+        std::ifstream ifs{location, std::ios::binary};
+        if (!ifs.is_open())
+            throw necromancy_error(std::format("necromancy: Cannot read layout file: {}", location)).log();
+
+        if (!validateHeader(ifs))
+            throw necromancy_error(std::format("necromancy: Layout file invalid: {}", location)).log();
+
+        std::string layoutName;
+        load(ifs, layoutName);
+
+        if (const auto currentLayoutName = g_pLayoutManager->getCurrentLayout()->getLayoutName(); layoutName != currentLayoutName) {
+            Debug::log(LOG, "Layout snapshot varies from the current one, wants: {}, current: {} switching", layoutName, currentLayoutName);
+            g_pLayoutManager->switchToLayout(layoutName);
+        }
+
+        g_pLayoutManager->getCurrentLayout()->restore(ifs);
+        g_pCompositor->updateAllWindowsAnimatedDecorationValues();
+        // TODO: probably restore focus and cursor position when appropriate (follow_mouse=1)
+        g_pInputManager->simulateMouseMovement();
+    }
+}
+
+/* Window states */
+SWindowState::SWindowState(CWindow* pWindow) {
+    self    = pWindow;
+    cmdline = getCmdline(pWindow->getPID());
+
+    workspaceId  = pWindow->m_iWorkspaceID;
+    monitorId    = pWindow->m_iMonitorID;
+    title        = pWindow->m_szTitle;
+    class_       = g_pXWaylandManager->getAppIDClass(pWindow);
+    initialTitle = pWindow->m_szInitialTitle;
+    initialClass = pWindow->m_szInitialClass;
+
+    isFloating       = pWindow->m_bIsFloating;
+    isPinned         = pWindow->m_bPinned;
+    isFullscreen     = pWindow->m_bIsFullscreen;
+    isFakeFullscreen = pWindow->m_bFakeFullscreenState;
+    isPseudotiled    = pWindow->m_bIsPseudotiled;
+    isHidden         = pWindow->isHidden();
+
+    realPosition = pWindow->m_vRealPosition.goalv();
+    realSize     = pWindow->m_vRealSize.goalv();
+
+    groupData.next   = (uintptr_t)pWindow->m_sGroupData.pNextWindow;
+    groupData.head   = pWindow->m_sGroupData.head;
+    groupData.locked = pWindow->m_sGroupData.locked;
+}
+
+void SWindowState::apply(const auto&& callback) {
+    // clang-format off
+    std::apply([&](auto&&... data) { (callback(data), ...); }, std::tie(
+        cmdline,
+        workspaceId,
+        monitorId,
+        title,
+        class_,
+        initialTitle,
+        initialClass,
+        isFloating,
+        isPinned,
+        isFullscreen,
+        isFakeFullscreen,
+        isPseudotiled,
+        isHidden,
+        realPosition,
+        realSize,
+        groupData.next,
+        groupData.head,
+        groupData.locked
+    ));
+    // clang-format on
+}
+
+void SWindowState::applyToWindow() {
+    if (!self) {
+        Debug::log(LOG, "necromancy: not applying this soulless SWindowState\n  {}", *this);
+        return;
+    }
+    if (!self->m_bIsMapped) {
+        Debug::log(LOG, "necromancy: {} is invalid", self);
+        return;
+    }
+    auto layout = g_pLayoutManager->getCurrentLayout();
+    self->setHidden(isHidden);
+    // workspace
+    self->moveToWorkspace(workspaceId); // sets m_iWorkspaceID = workspaceId
+    self->m_iMonitorID = monitorId;
+    self->updateToplevel();
+
+    // fake fullscreen
+    g_pXWaylandManager->setWindowFullscreen(self, isFakeFullscreen);
+    // fullscreen
+    if (!isHidden && isFullscreen != self->m_bIsFullscreen) {
+        // it's only possible for visible window to have fullscreen status
+        auto* pWorkspace = g_pCompositor->getWorkspaceByID(workspaceId);
+        layout->fullscreenRequestForWindow(self, pWorkspace->m_efFullscreenMode, isFullscreen);
+        g_pXWaylandManager->setWindowFullscreen(self, self->m_bIsFullscreen);
+
+        for (auto& w : g_pCompositor->m_vWindows) {
+            if (w->m_iWorkspaceID == workspaceId && !w->m_bIsFullscreen && !w->m_bFadingOut && !w->m_bPinned)
+                w->m_bCreatedOverFullscreen = false;
+        }
+        g_pCompositor->updateFullscreenFadeOnWorkspace(pWorkspace);
+        g_pXWaylandManager->setWindowSize(self, self->m_vRealSize.goalv(), true);
+        g_pCompositor->forceReportSizesToWindowsOnWorkspace(workspaceId);
+        g_pInputManager->recheckIdleInhibitorStatus();
+        g_pHyprRenderer->setWindowScanoutMode(self);
+        g_pConfigManager->ensureVRR(g_pCompositor->getMonitorFromID(monitorId));
+    }
+
+    // pseudo
+    if (isPseudotiled && !self->m_bIsFullscreen) {
+        self->m_bIsPseudotiled = true;
+        self->m_vPosition      = realPosition;
+        self->m_vSize          = realSize;
+        layout->recalculateWindow(self);
+    }
+
+    // floating
+    if (isFloating && !isHidden) {
+        g_pCompositor->changeWindowZOrder(self, true);
+        g_pHyprRenderer->damageMonitor(g_pCompositor->getMonitorFromID(monitorId));
+        restoreSize();
+    }
+    self->m_bIsFloating = isFloating;
+    self->m_bPinned     = isPinned;
+
+    self->updateDynamicRules();
+
+    if (isPseudotiled && !self->m_bIsFullscreen)
+        restoreSize();
+}
+
+void SWindowState::restoreSize() {
+    self->m_vRealPosition = realPosition;
+    self->m_vRealSize     = realSize;
+    self->updateSpecialRenderData();
+    self->updateToplevel();
+}
+
+bool SWindowState::isValid() {
+    return self && (!self->m_bIsX11 && self->m_bMappedX11) && self->m_bIsMapped && self->m_iWorkspaceID != -1;
+}
+
+bool SWindowState::matchWindow(CWindow* pWindow) {
+    const auto CLASS = g_pXWaylandManager->getAppIDClass(pWindow);
+    return (class_ == CLASS && title == pWindow->m_szTitle)                            //
+        || (class_ == pWindow->m_szInitialClass && title == pWindow->m_szInitialTitle) //
+        || (initialClass == CLASS && initialTitle == pWindow->m_szTitle)               //
+        || (initialClass == pWindow->m_szInitialClass && initialTitle == pWindow->m_szInitialTitle);
+}
+
+std::unique_ptr<window_state_map_t> SWindowState::collectAll() {
+    auto states = std::make_unique<window_state_map_t>();
+    for (const auto& w : g_pCompositor->m_vWindows) {
+        if (!Necromancy::isWindowSavable(w.get()))
+            continue;
+        (*states)[(uintptr_t)w.get()] = SWindowState{w.get()};
+    }
+    return states;
+}
+
+void SWindowState::dumpAll(std::ostream& os) {
+    const auto states = SWindowState::collectAll();
+    Necromancy::dump(os, states->size());
+    for (auto& ws : *states | std::views::values)
+        ws.marshal(os);
+}
+
+std::unique_ptr<window_state_map_t> SWindowState::loadAll(std::istream& is) {
+    auto   states = std::make_unique<window_state_map_t>();
+    size_t count  = 0;
+    Necromancy::load(is, count);
+    for (size_t i = 0; i < count; i++) {
+        SWindowState ws;
+        uintptr_t    key = ws.unmarshal(is);
+        (*states)[key]   = ws;
+    }
+    return states;
+}
+
+void SWindowState::marshal(std::ostream& os) {
+    Necromancy::dump(os, (uintptr_t)self);
+    apply([&]<typename T>(T& data) { Necromancy::dump(os, data); });
+}
+
+uintptr_t SWindowState::unmarshal(std::istream& is) {
+    uintptr_t key;
+    Necromancy::load(is, key);
+    apply([&]<typename T>(T& data) { Necromancy::load(is, data); });
+    return key;
+}
+
+/* Workspace states */
+SWorkspaceState::SWorkspaceState(CWorkspace* pWorkspace) {
+    id        = pWorkspace->m_iID;
+    name      = pWorkspace->m_szName;
+    monitorId = pWorkspace->m_iMonitorID;
+
+    prev.id   = pWorkspace->m_sPrevWorkspace.iID;
+    prev.name = pWorkspace->m_sPrevWorkspace.name;
+
+    isSpecial       = pWorkspace->m_bIsSpecialWorkspace;
+    defaultFloating = pWorkspace->m_bDefaultFloating;
+    defaultPseudo   = pWorkspace->m_bDefaultPseudo;
+    fullscreenMode  = pWorkspace->m_efFullscreenMode;
+    immortal        = pWorkspace->m_bIndestructible;
+}
+
+void SWorkspaceState::apply(const auto&& callback) {
+    // clang-format off
+    std::apply([&](auto&&... data) { (callback(data), ...); }, std::tie(
+        id,
+        name,
+        monitorId,
+        prev.id,
+        prev.name,
+        isSpecial,
+        defaultFloating,
+        defaultPseudo,
+        fullscreenMode,
+        immortal
+    ));
+    // clang-format on
+}
+
+void SWorkspaceState::applyToWorkspace() {
+    auto pWorkspace = g_pCompositor->getWorkspaceByID(id);
+    if (!pWorkspace)
+        pWorkspace = g_pCompositor->createNewWorkspace(id, monitorId);
+    else
+        g_pCompositor->renameWorkspace(id, name == "" ? std::to_string(id) : name);
+    pWorkspace->m_sPrevWorkspace      = {prev.id, prev.name};
+    pWorkspace->m_bIsSpecialWorkspace = isSpecial;
+    pWorkspace->m_bDefaultFloating    = defaultFloating;
+    pWorkspace->m_bDefaultPseudo      = defaultPseudo;
+    pWorkspace->m_efFullscreenMode    = fullscreenMode;
+    pWorkspace->m_bIndestructible     = immortal;
+}
+
+void SWorkspaceState::marshal(std::ostream& os) {
+    apply([&]<typename T>(T& data) { Necromancy::dump(os, data); });
+}
+
+void SWorkspaceState::unmarshal(std::istream& is) {
+    apply([&]<typename T>(T& data) { Necromancy::load(is, data); });
+}

--- a/src/layout/Necromancy.hpp
+++ b/src/layout/Necromancy.hpp
@@ -1,0 +1,340 @@
+#pragma once
+
+#include "../helpers/Vector2D.hpp"
+#include "../Window.hpp"
+#include "../helpers/Workspace.hpp"
+
+#include <iostream>
+#include <istream>
+#include <ostream>
+#include <algorithm>
+
+#define STRAYS_WORKSPACE_NAME "strays"
+#define STRAYS_WORKSPACE_ID   (INT_MAX - 1)
+
+class necromancy_error : public std::runtime_error {
+  public:
+    explicit necromancy_error(const std::string&);
+    explicit necromancy_error(const char*);
+
+    // display as a notification, duration is in milliseconds
+    void notify(const float duration = 10000) const;
+    // log error in Hyprland log file
+    necromancy_error& log();
+};
+
+// clangd, four fucking generations of inbreeding
+struct SWindowState;
+typedef std::unordered_map<uintptr_t, SWindowState> window_state_map_t;
+
+namespace Necromancy {
+    const std::string SIGNATURE = "HYPR NECROMANCY";
+    const int         VERSION   = 1;
+
+    /**
+		Serialize data to binary stream
+	*/
+    template <typename T>
+    void dump(std::ostream& os, const T& data) {
+        os.write(reinterpret_cast<const char*>(&data), sizeof(data));
+    }
+
+    template <>
+    void dump(std::ostream& os, const std::string& data);
+
+    template <>
+    void dump(std::ostream& os, const Vector2D& data);
+
+    /**
+		Deserialize from binary stream to data
+	*/
+    template <typename T>
+    void load(std::istream& is, T& data) {
+        is.read(reinterpret_cast<char*>(&data), sizeof(data));
+    }
+
+    template <>
+    void load(std::istream& is, std::string& data);
+
+    template <>
+    void load(std::istream& is, Vector2D& data);
+
+    // check if window is qualified for saving
+    bool isWindowSavable(CWindow* pWindow);
+
+    void createHeader(std::ostream& os);
+    // return true is head is valid
+    bool validateHeader(std::istream& is);
+
+    /**
+        @param location location of save file, use default location specified in config if it's empty
+        @throw necromancy_error if layout cannot be written to filesystem.
+    */
+    void saveLayout(std::string location = "");
+    /**
+        @param location location of save file, use default location specified in config if it's empty
+        @throw necromancy_error if layout save file cannot be read.
+    */
+    void restoreLayout(std::string location = "");
+} // namespace Necromancy
+
+// A snapshot of a window's woefully ephemeral mortal life
+struct SWindowState {
+    SWindowState() = default;
+    SWindowState(CWindow*);
+
+    CWindow* self = nullptr;
+
+    // the following will be saved
+    std::string cmdline = "";
+
+    int         workspaceId = -1;
+    int         monitorId   = -1;
+
+    std::string title        = "";
+    std::string class_       = "";
+    std::string initialTitle = "";
+    std::string initialClass = "";
+
+    bool        isFloating       = false;
+    bool        isFullscreen     = false;
+    bool        isFakeFullscreen = false;
+    bool        isPseudotiled    = false;
+    bool        isPinned         = false;
+    bool        isHidden         = false;
+
+    // only used for floating window and pseudo
+    Vector2D realPosition = {-1, -1};
+    Vector2D realSize     = {-1, -1};
+
+    struct GroupData {
+        uintptr_t next   = 0;
+        bool      head   = false;
+        bool      locked = false;
+    } groupData;
+
+    /**
+        Apply window state to window
+    */
+    void applyToWindow();
+    /**
+        Check if window state is valid (this->self != nullptr)
+    */
+    bool isValid();
+    /**
+        Match window
+    */
+    bool matchWindow(CWindow* pWindow);
+    /**
+        Collect all states for all window except for these in workspace for strays (orphanage)
+    */
+    static std::unique_ptr<window_state_map_t> collectAll();
+    /**
+        Dump all window states
+    */
+    static void dumpAll(std::ostream& os);
+    /**
+        Load all window states
+    */
+    static std::unique_ptr<window_state_map_t> loadAll(std::istream& is);
+    /**
+        Serialize window state into binary stream
+    */
+    void marshal(std::ostream& os);
+    /**
+        Fetch window state from binary stream
+    */
+    uintptr_t unmarshal(std::istream& is);
+
+  private:
+    void restoreSize();
+    void apply(const auto&& callback);
+};
+
+struct SWorkspaceState {
+    SWorkspaceState() = default;
+    SWorkspaceState(CWorkspace*);
+    int         id        = -1;
+    std::string name      = "";
+    uint64_t    monitorId = -1;
+
+    struct SPrevWorkspaceData {
+        int         id   = -1;
+        std::string name = "";
+    } prev;
+
+    bool            isSpecial       = false;
+    bool            defaultFloating = false;
+    bool            defaultPseudo   = false;
+    bool            immortal        = false;
+    eFullscreenMode fullscreenMode  = FULLSCREEN_FULL;
+
+    /**
+        Apply state to workspace
+    */
+    void applyToWorkspace();
+    /**
+        Serialize workspace state into binary stream
+    */
+    void marshal(std::ostream& os);
+    /**
+        Fetch workspace state from binary stream
+    */
+    void unmarshal(std::istream& is);
+
+  private:
+    void apply(const auto&& callback);
+};
+
+// libc++ had a goddamn stroke with formatter specialisation
+template <typename CharT>
+struct std::formatter<SWindowState, CharT> : std::formatter<CharT> {
+    bool use_json   = false;
+    bool incomplete = false;
+    FORMAT_PARSE(FORMAT_FLAG('j', use_json)    //
+                 FORMAT_FLAG('I', incomplete), //
+                 SWindowState)
+
+    template <typename FormatContext>
+    auto format(const SWindowState& ws, FormatContext& ctx) const {
+        if (use_json)
+            return std::format_to(ctx.out(), R"#(
+      "hidden": {},
+      "at": {:j},
+      "size": {:j},
+      "workspace": {},
+      "floating": {},
+      "class": "{}",
+      "title": "{}",
+      "initialClass": "{}",
+      "initialTitle": "{}",
+      "cmdline": "{}",
+      "pinned": {},
+      "fullscreen": {},
+      "fakefullscreen": {},
+      "pseudo": {})#",
+                                  ws.isHidden, ws.realPosition, ws.realSize, ws.workspaceId, ws.isFloating, ws.class_, escapeJSONStrings(ws.title),
+                                  escapeJSONStrings(ws.initialClass), escapeJSONStrings(ws.initialTitle), escapeJSONStrings(ws.cmdline), ws.isPinned, ws.isFullscreen,
+                                  ws.isFakeFullscreen, ws.isPseudotiled);
+        auto heading = incomplete ? "" : std::format("Window: {:x} -> {}:\n", (uintptr_t)ws.self, ws.title);
+        auto group   = incomplete ? "" : std::format("\n\tgroupped:       next:{:x}, head:{}, locked: {}\n", ws.groupData.next, ws.groupData.head, ws.groupData.locked);
+        return std::format_to( //
+            ctx.out(),
+            "{}"
+            "\thidden:         {}\n"
+            "\tat:             {}\n"
+            "\tsize:           {}\n"
+            "\tworkspace:      {}\n"
+            "\tfloating:       {}\n"
+            "\tclass:          {}\n"
+            "\ttitle:          {}\n"
+            "\tinitialClass:   {}\n"
+            "\tinitialTitle:   {}\n"
+            "\tcmdline:        {}\n"
+            "\tpinned:         {}\n"
+            "\tfullscreen:     {}\n"
+            "\tfakefullscreen: {}\n"
+            "\tpseudo:         {}"
+            "{}",
+            heading,             //
+            ws.isHidden,         //
+            ws.realPosition,     //
+            ws.realSize,         //
+            ws.workspaceId,      //
+            ws.isFloating,       //
+            ws.class_,           //
+            ws.title,            //
+            ws.initialClass,     //
+            ws.initialTitle,     //
+            ws.cmdline,          //
+            ws.isPinned,         //
+            ws.isFullscreen,     //
+            ws.isFakeFullscreen, //
+            ws.isPseudotiled,    //
+            group);
+    }
+};
+
+template <typename CharT>
+struct std::formatter<window_state_map_t, CharT> : std::formatter<CharT> {
+    bool use_json = false;
+    FORMAT_PARSE(FORMAT_FLAG('j', use_json), window_state_map_t)
+
+    template <typename FormatContext>
+    auto format(const window_state_map_t& wsmap, FormatContext& ctx) const {
+        std::ostringstream out;
+        if (use_json)
+            out << "[\n";
+
+        size_t i = 0;
+        for (auto& [addr, ws] : wsmap) {
+            // window
+            if (use_json) {
+                out << std::format("    {{\n      \"address\": \"{:x}\",", addr);
+                out << std::format("{:jI}", ws);
+            } else {
+                out << std::format("Window: {:x} -> {}:\n", addr, ws.title);
+                out << std::format("{:I}\n", ws);
+            }
+            // group member
+            if (ws.groupData.next != 0) {
+                std::list<uintptr_t> members;
+                uintptr_t            curr = addr;
+                do {
+                    members.push_back(curr);
+                    curr = wsmap.at(curr).groupData.next;
+                } while (curr != addr && curr != 0);
+
+                if (use_json) {
+                    out << std::format(",\n      \"grouped\": [\"{:x}\"", addr);
+                    std::for_each(std::next(members.begin()), members.end(), [&](const uintptr_t& m) { out << std::format(", \"{:x}\"", m); });
+                    out << "]";
+                } else {
+                    out << std::format("\tgrouped: {:x}", addr);
+                    std::for_each(std::next(members.begin()), members.end(), [&](const uintptr_t& m) { out << std::format(", {:x}", m); });
+                }
+                out << "\n";
+            }
+
+            if (use_json)
+                out << (i < wsmap.size() - 1 ? "    },\n" : "    }\n");
+            else
+                out << "\n";
+            i++;
+        }
+        if (use_json)
+            out << "  ]";
+        return std::format_to(ctx.out(), "{}", out.str());
+    }
+};
+
+template <typename CharT>
+struct std::formatter<SWorkspaceState, CharT> : std::formatter<CharT> {
+    bool use_json = false;
+    FORMAT_PARSE(FORMAT_FLAG('j', use_json), SWorkspaceState);
+
+    template <typename FormatContext>
+    auto format(const SWorkspaceState& wss, FormatContext& ctx) const {
+        if (use_json)
+            return std::format_to( //
+                ctx.out(),         //
+                R"#(    {{
+      "id": {},
+      "name": "{}",
+      "monitor": {},
+      "defaultFloating": {},
+      "defaultPseudo": {},
+      "special": {}
+    }})#",
+                wss.id, escapeJSONStrings(wss.name), wss.monitorId, wss.defaultFloating, wss.defaultPseudo, wss.isSpecial);
+        return std::format_to( //
+            ctx.out(),
+            "Workspace: {}\n"
+            "\tname:            {}\n"
+            "\tmonitor:         {}\n"
+            "\tdefaultFloating: {}\n"
+            "\tdefaultPseudo:   {}\n"
+            "\tspecial:         {}",
+            wss.id, wss.name, wss.monitorId, wss.defaultFloating, wss.defaultPseudo, wss.isSpecial);
+    }
+};

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1,7 +1,11 @@
 #include "KeybindManager.hpp"
 #include "../render/decorations/CHyprGroupBarDecoration.hpp"
+#include "../layout/Necromancy.hpp"
+#include <source_location>
 
+#include <cassert>
 #include <regex>
+#include <ranges>
 
 #include <sys/ioctl.h>
 #include <fcntl.h>
@@ -74,6 +78,7 @@ CKeybindManager::CKeybindManager() {
     m_mDispatchers["setignoregrouplock"]            = setIgnoreGroupLock;
     m_mDispatchers["denywindowfromgroup"]           = denyWindowFromGroup;
     m_mDispatchers["global"]                        = global;
+    m_mDispatchers["necromancy"]                    = necromancy;
 
     m_tScrollTimer.reset();
 
@@ -748,7 +753,7 @@ void CKeybindManager::toggleActiveFloating(std::string args) {
         return;
 
     if (PWINDOW->m_sGroupData.pNextWindow && PWINDOW->m_sGroupData.pNextWindow != PWINDOW) {
-
+        // we are in a group with multiple members
         const auto PCURRENT     = PWINDOW->getGroupCurrent();
         PCURRENT->m_bIsFloating = !PCURRENT->m_bIsFloating;
         g_pLayoutManager->getCurrentLayout()->changeWindowFloatingMode(PCURRENT);
@@ -2124,4 +2129,14 @@ void CKeybindManager::moveGroupWindow(std::string args) {
         g_pCompositor->m_pLastWindow->switchWithWindowInGroup(BACK ? g_pCompositor->m_pLastWindow->getGroupPrevious() : g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow);
 
     g_pCompositor->m_pLastWindow->updateWindowDecos();
+}
+
+void CKeybindManager::necromancy(std::string args) {
+    CVarList argv{args, 0, 's', true};
+    try {
+        if (argv[0] == "save")
+            Necromancy::saveLayout(argv[1]);
+        else
+            Necromancy::restoreLayout(argv[1]);
+    } catch (necromancy_error& e) { e.notify(); }
 }

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -153,6 +153,7 @@ class CKeybindManager {
     static void     setIgnoreGroupLock(std::string);
     static void     denyWindowFromGroup(std::string);
     static void     global(std::string);
+    static void     necromancy(std::string);
 
     friend class CCompositor;
     friend class CInputManager;


### PR DESCRIPTION
## Features

Window floating, fullscreen, group states are retained.
For dwindle, the layout should be restored as is, preserving size and orientation. 
Any windows that do not match will be moved as a group to the last workspace. 

### Dispatcher

use the dispatcher `necromancy` to save and restore layout.

- `necromancy save`: save layout (on disk)
- `necromancy restore`: restore layout (on disk)

The dispatcher can take the path to the save file as an optional argument.

### Hyprctl / IPC

Added hyprctl subcommand `necromancy` to support the following syntax

- **save [path]**: save layout
- **restore [path]**: restore layout
- **inspect [path]**: inspect layout file, support JSON output

### Notes

Currently,

- layout restoration is only implemented with 'dwindle'.
- multiple monitor support has not been tested.

## TODO

- [x] add a dispatcher
  - [x] specific save/restore location in args
- [x] persistent layout save across session (save file)
- [x] configuration save location
- [x] Better error handling

### Restore window state

- [x] group, including local lock
- [x] fake fullscreen
- [x] fullscreen
- [x] pseudo tilling
- [x] floating
  - [x] size, position
  - [x] pin

### Restore workspace state

- [x] workspace id, name
- [x] previous workspace
- [x] special workspace

### Restore layout

- [x] dwindle layout
- ~~master layout~~ I am  unfamiliar with it, so no interest at present
- [x] deal with stray windows (not in layout save file)

### Other

- ~~comply to name convention, advNamely adjHungarian nNotation~~
- [x] remove testing code
- [x] hyprctl command for inspecting current saved layout

## Implementation

Third party dependencies need to be introduced as subprojects and build scripts need to be modified when using popular formats such as JSON, **so this implementation uses simple binary serialisation for ease of development**.

The layout file is located at `~/.local/share/hypr/layout.bin`, or `~/.local/share/hypr/layoutd.bin` for debug builds.

### Serialization format

| Section     |             |                                                  |
| ----------- | ----------- | ------------------------------------------------ |
| Header      | signature   | `"HYPR NECROMANCY"`, for ident                   |
|             | version     | `int`, for verification                          |
|             | layout name | `std::string`                                    |
| Window      | count       | `size_t`                                         |
|             | entries     | `map<(uintptr_t)CWindow*,SWindowState>`          |
| Workspaces  | count       | `size_t`                                         |
|             | entries     | `SWorkspaceState[]`                              |
| LayoutNodes | count       | `size_t`                                         |
|             | entries     | `map<SNodeData*, SNodeData>` (depends on layout) |

- Variable length structures are stored with their length

---

close: #1426