### PR TITLE
fix: restore configCurrenPath after sourcing file

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1234,6 +1234,8 @@ void CConfigManager::handleSource(const std::string& command, const std::string&
         std::string line    = "";
         int         linenum = 1;
         if (ifs.is_open()) {
+            auto configCurrentPathBackup = configCurrentPath;
+            
             while (std::getline(ifs, line)) {
                 // Read line by line.
                 try {
@@ -1254,6 +1256,8 @@ void CConfigManager::handleSource(const std::string& command, const std::string&
             }
 
             ifs.close();
+            
+            configCurrentPath = configCurrentPathBackup;
         }
     }
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
When using the source keyword, `configCurrentPath`, which is used to deduce absolute paths from relative ones, is changed to the folder containing the file to be sourced. However, it is not reverted after the file is read.
This means that you cannot source with a relative path multiple times (using keybinds and/or scripts) if the target file is not in the root of the config directory.

For example: 

1. `configCurrentPath` is `/home/user/.config/hypr/`.
2. `~/.config/hypr/hyprland.conf` sources the file `~/.config/hypr/sub/sub.conf` using `source = ./sub/sub.conf`.
3. The file `/home/user/.config/hypr/sub/sub.conf` is read -> No error.
4. `configCurrentPath` is now ~/.config/hypr/sub.
5. Same as step 2
6. The file `/home/user/.config/hypr/sub/sub/sub.conf` is read -> File not found error (notice the duplicate `sub/`.

This fixes it by doing a backup of `configCurrentPath` before reading the file, and restoring it after the file has been read.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
When sourcing a file, its a bit like a `cd` command, meaning a source changes the directory in which following sources will search. I have no idea if this is the intended behavior or not, but i decided to keep it.
If this behavior is kept, the difference between absolute and relative path for the source command should be documented in the wiki.

#### Is it ready for merging, or does it need work?
I managed to build and test successfully the changes on my machine, but it was on a commit before #3276 (not sure on the exact one). It should still work as intended.