### PR TITLE
hyprchan: add disable options

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -86,6 +86,7 @@ void CConfigManager::setDefaultVars() {
 
     configValues["misc:disable_hyprland_logo"].intValue        = 0;
     configValues["misc:disable_splash_rendering"].intValue     = 0;
+    configValues["misc:disable_hypr_chan"].intValue            = 0;
     configValues["misc:force_hypr_chan"].intValue              = 0;
     configValues["misc:vfr"].intValue                          = 1;
     configValues["misc:vrr"].intValue                          = 0;

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1775,8 +1775,9 @@ void CHyprOpenGLImpl::renderSplash(cairo_t* const CAIRO, cairo_surface_t* const 
 void CHyprOpenGLImpl::createBGTextureForMonitor(CMonitor* pMonitor) {
     RASSERT(m_RenderData.pMonitor, "Tried to createBGTex without begin()!");
 
-    static auto* const              PNOSPLASH      = &g_pConfigManager->getConfigValuePtr("misc:disable_splash_rendering")->intValue;
-    static auto* const              PFORCEHYPRCHAN = &g_pConfigManager->getConfigValuePtr("misc:force_hypr_chan")->intValue;
+    static auto* const              PNOSPLASH        = &g_pConfigManager->getConfigValuePtr("misc:disable_splash_rendering")->intValue;
+    static auto* const              PDISABLEHYPRCHAN = &g_pConfigManager->getConfigValuePtr("misc:disable_hypr_chan")->intValue;
+    static auto* const              PFORCEHYPRCHAN   = &g_pConfigManager->getConfigValuePtr("misc:force_hypr_chan")->intValue;
 
     std::random_device              dev;
     std::mt19937                    engine(dev());
@@ -1797,7 +1798,10 @@ void CHyprOpenGLImpl::createBGTextureForMonitor(CMonitor* pMonitor) {
     // or configure the paths at build time
 
     // get the adequate tex
-    std::string texPath = "/usr/share/hyprland/wall_" + std::string(USEANIME ? (distribution2(engine) == 0 ? "anime_" : "anime2_") : "");
+    std::string texPath = "/usr/share/hyprland/wall_";
+    if (!*PDISABLEHYPRCHAN)
+        texPath += std::string(USEANIME ? (distribution2(engine) == 0 ? "anime_" : "anime2_") : "");
+
     // check if wallpapers exist
 
     Vector2D textureSize;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

A lot of people complained about how hard it is to disable Hyprchan while still keeping the default Hyprland logo wallpaper. This fixes the issue by allowing users to disable Hyprchan wallpapers from being selected when randomising the wallpaper, or completely remove the wallpaper from the Hyprland installation (if installed with Meson).

- meson: add option (not) to include hyprchan
- misc: add disable_hypr_chan option

Addresses https://github.com/hyprwm/Hyprland/issues/2930.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Ready.

