### PR TITLE
refactor(varlist): replace unintuitive string splitting

### DIFF
--- a/src/helpers/VarList.cpp
+++ b/src/helpers/VarList.cpp
@@ -1,47 +1,6 @@
 #include "VarList.hpp"
 #include <ranges>
 #include <algorithm>
-#include <assert.h>
-
-auto old_func(const std::string& in, const size_t lastArgNo, const char separator, const bool removeEmpty) {
-    std::vector<std::string> m_vArgs;
-    //
-    std::string curitem  = "";
-    std::string argZ     = in;
-    const bool  SPACESEP = separator == 's';
-
-    auto        nextItem = [&]() {
-        auto idx = lastArgNo != 0 && m_vArgs.size() >= lastArgNo - 1 ? std::string::npos : ([&]() -> size_t {
-            if (!SPACESEP)
-                return argZ.find_first_of(separator);
-
-            uint64_t pos = -1;
-            while (!std::isspace(argZ[++pos]) && pos < argZ.length())
-                ;
-
-            return pos < argZ.length() ? pos : std::string::npos;
-        }());
-
-        if (idx != std::string::npos) {
-            curitem = argZ.substr(0, idx);
-            argZ    = argZ.substr(idx + 1);
-        } else {
-            curitem = argZ;
-            argZ    = STRVAL_EMPTY;
-        }
-    };
-
-    nextItem();
-
-    while (curitem != STRVAL_EMPTY) {
-        m_vArgs.push_back(removeBeginEndSpacesTabs(curitem));
-        nextItem();
-    }
-    if (removeEmpty)
-        std::erase_if(m_vArgs, [](std::string a) { return a.empty(); });
-
-    return m_vArgs;
-}
 
 CVarList::CVarList(const std::string& in, const size_t lastArgNo, const char delim, const bool removeEmpty) {
     if (in.empty())
@@ -63,13 +22,6 @@ CVarList::CVarList(const std::string& in, const size_t lastArgNo, const char del
         pos += s.size() + 1;
         m_vArgs.emplace_back(removeBeginEndSpacesTabs(std::string_view{s}.data()));
     }
-#if HYPRLAND_DEBUG
-    auto argv = old_func(in, lastArgNo, delim, removeEmpty);
-    assert(m_vArgs.size() == argv.size());
-    for (size_t i = 0; i < m_vArgs.size(); i++) {
-        assert(m_vArgs[i] == argv[i]);
-    }
-#endif
 }
 
 std::string CVarList::join(const std::string& joiner, size_t from, size_t to) const {

--- a/src/helpers/VarList.cpp
+++ b/src/helpers/VarList.cpp
@@ -1,6 +1,11 @@
 #include "VarList.hpp"
+#include <ranges>
+#include <algorithm>
+#include <assert.h>
 
-CVarList::CVarList(const std::string& in, long unsigned int lastArgNo, const char separator) {
+auto old_func(const std::string& in, const size_t lastArgNo, const char separator, const bool removeEmpty) {
+    std::vector<std::string> m_vArgs;
+    //
     std::string curitem  = "";
     std::string argZ     = in;
     const bool  SPACESEP = separator == 's';
@@ -32,6 +37,39 @@ CVarList::CVarList(const std::string& in, long unsigned int lastArgNo, const cha
         m_vArgs.push_back(removeBeginEndSpacesTabs(curitem));
         nextItem();
     }
+    if (removeEmpty)
+        std::erase_if(m_vArgs, [](std::string a) { return a.empty(); });
+
+    return m_vArgs;
+}
+
+CVarList::CVarList(const std::string& in, const size_t lastArgNo, const char delim, const bool removeEmpty) {
+    if (in.empty())
+        m_vArgs.emplace_back("");
+
+    std::string args{in};
+    size_t      idx = 0;
+    size_t      pos = 0;
+    std::ranges::replace_if(
+        args, [&](const char& c) { return delim == 's' ? std::isspace(c) : c == delim; }, 0);
+
+    for (const auto& s : args | std::views::split(0)) {
+        if (removeEmpty && s.empty())
+            continue;
+        if (++idx == lastArgNo) {
+            m_vArgs.emplace_back(removeBeginEndSpacesTabs(in.substr(pos)));
+            break;
+        }
+        pos += s.size() + 1;
+        m_vArgs.emplace_back(removeBeginEndSpacesTabs(std::string_view{s}.data()));
+    }
+#if HYPRLAND_DEBUG
+    auto argv = old_func(in, lastArgNo, delim, removeEmpty);
+    assert(m_vArgs.size() == argv.size());
+    for (size_t i = 0; i < m_vArgs.size(); i++) {
+        assert(m_vArgs[i] == argv[i]);
+    }
+#endif
 }
 
 std::string CVarList::join(const std::string& joiner, size_t from, size_t to) const {

--- a/src/helpers/VarList.hpp
+++ b/src/helpers/VarList.hpp
@@ -5,8 +5,12 @@
 
 class CVarList {
   public:
-    /* passing 's' as a separator will use std::isspace */
-    CVarList(const std::string& in, long unsigned int lastArgNo = 0, const char separator = ',');
+    /** Split string into arg list
+        @param lastArgNo stop splitting after argv reaches maximum size, last arg will contain rest of unsplit args
+        @param delim if delimiter is 's', use std::isspace
+        @param removeEmpty remove empty args from argv
+    */
+    CVarList(const std::string& in, const size_t maxSize = 0, const char delim = ',', const bool removeEmpty = false);
 
     ~CVarList() = default;
 
@@ -16,7 +20,7 @@ class CVarList {
 
     std::string join(const std::string& joiner, size_t from = 0, size_t to = 0) const;
 
-    std::string operator[](const long unsigned int& idx) const {
+    std::string operator[](const size_t& idx) const {
         if (idx >= m_vArgs.size())
             return "";
         return m_vArgs[idx];


### PR DESCRIPTION
Tested with asserts, result should be identical to old logic.

Also added `removeEmpty` as an optional arg to remove empty args from argv, defaults to false,