### PR TITLE
fix(log): use std::format_string to catch formatting string errors at compile time 

### DIFF
--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -12,6 +12,7 @@
 #include <ranges>
 #include <algorithm>
 #include <signal.h>
+#include <format>
 
 #include <iostream>
 #include <string>
@@ -104,20 +105,6 @@ std::vector<SInstanceData> instances() {
     std::sort(result.begin(), result.end(), [&](const auto& a, const auto& b) { return a.time < b.time; });
 
     return result;
-}
-
-std::string getFormat(const char* fmt, ...) {
-    char*   outputStr = nullptr;
-
-    va_list args;
-    va_start(args, fmt);
-    vasprintf(&outputStr, fmt, args);
-    va_end(args);
-
-    std::string output = std::string(outputStr);
-    free(outputStr);
-
-    return output;
 }
 
 void request(std::string arg, int minArgs = 0) {
@@ -248,19 +235,19 @@ void instancesRequest(bool json) {
 
     if (!json) {
         for (auto& el : inst) {
-            result += getFormat("instance %s:\n\ttime: %llu\n\tpid: %llu\n\twl socket: %s\n\n", el.id.c_str(), el.time, el.pid, el.wlSocket.c_str());
+            result += std::format("instance {}:\n\ttime: {}\n\tpid: {}\n\twl socket: {}\n\n", el.id, el.time, el.pid, el.wlSocket);
         }
     } else {
         result += '[';
         for (auto& el : inst) {
-            result += getFormat(R"#(
-{
-    "instance": "%s",
-    "time": %llu,
-    "pid": %llu,
-    "wl_socket": "%s"
-},)#",
-                                el.id.c_str(), el.time, el.pid, el.wlSocket.c_str());
+            result += std::format(R"#(
+{{
+    "instance": "{}",
+    "time": {},
+    "pid": {},
+    "wl_socket": "{}"
+}},)#",
+                                  el.id, el.time, el.pid, el.wlSocket);
         }
 
         result.pop_back();

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -910,7 +910,7 @@ void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
 
     // Send an event
     g_pEventManager->postEvent(SHyprIPCEvent{"activewindow", g_pXWaylandManager->getAppIDClass(pWindow) + "," + pWindow->m_szTitle});
-    g_pEventManager->postEvent(SHyprIPCEvent{"activewindowv2", getFormat("{:x}", (uintptr_t)pWindow)});
+    g_pEventManager->postEvent(SHyprIPCEvent{"activewindowv2", std::format("{:x}", (uintptr_t)pWindow)});
 
     EMIT_HOOK_EVENT("activeWindow", pWindow);
 
@@ -2183,13 +2183,13 @@ CWindow* CCompositor::getWindowByRegex(const std::string& regexp) {
                 break;
             }
             case MODE_ADDRESS: {
-                std::string addr = getFormat("0x{:x}", (uintptr_t)w.get());
+                std::string addr = std::format("0x{:x}", (uintptr_t)w.get());
                 if (matchCheck != addr)
                     continue;
                 break;
             }
             case MODE_PID: {
-                std::string pid = getFormat("{}", w->getPID());
+                std::string pid = std::format("{}", w->getPID());
                 if (matchCheck != pid)
                     continue;
                 break;

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -340,7 +340,7 @@ void CWindow::moveToWorkspace(int workspaceID) {
     updateSpecialRenderData();
 
     if (PWORKSPACE) {
-        g_pEventManager->postEvent(SHyprIPCEvent{"movewindow", getFormat("{:x},{}", (uintptr_t)this, PWORKSPACE->m_szName)});
+        g_pEventManager->postEvent(SHyprIPCEvent{"movewindow", std::format("{:x},{}", (uintptr_t)this, PWORKSPACE->m_szName)});
         EMIT_HOOK_EVENT("moveWindow", (std::vector<void*>{this, PWORKSPACE}));
     }
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1206,7 +1206,7 @@ void CConfigManager::handleSource(const std::string& command, const std::string&
 
     if (auto r = glob(absolutePath(rawpath, configCurrentPath).c_str(), GLOB_TILDE, nullptr, glob_buf.get()); r != 0) {
         parseError = std::format("source= globbing error: {}", r == GLOB_NOMATCH ? "found no match" : GLOB_ABORTED ? "read error" : "out of memory");
-        Debug::log(ERR, parseError);
+        Debug::log(ERR, "{}", parseError);
         return;
     }
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1097,7 +1097,7 @@ void CConfigManager::updateBlurredLS(const std::string& name, const bool forceBl
         for (auto& lsl : m->m_aLayerSurfaceLayers) {
             for (auto& ls : lsl) {
                 if (BYADDRESS) {
-                    if (getFormat("0x{:x}", (uintptr_t)ls.get()) == matchName)
+                    if (std::format("0x{:x}", (uintptr_t)ls.get()) == matchName)
                         ls->forceBlur = forceBlur;
                 } else if (ls->szNamespace == matchName)
                     ls->forceBlur = forceBlur;
@@ -1942,7 +1942,7 @@ std::vector<SLayerRule> CConfigManager::getMatchingRules(SLayerSurface* pLS) {
 
     for (auto& lr : m_dLayerRules) {
         if (lr.targetNamespace.find("address:0x") == 0) {
-            if (getFormat("address:0x{:x}", (uintptr_t)pLS) != lr.targetNamespace)
+            if (std::format("address:0x{:x}", (uintptr_t)pLS) != lr.targetNamespace)
                 continue;
         } else {
             std::regex NSCHECK(lr.targetNamespace);

--- a/src/debug/CrashReporter.cpp
+++ b/src/debug/CrashReporter.cpp
@@ -45,15 +45,15 @@ void CrashReporter::createAndSaveCrash(int sig) {
     finalCrashReport += "--------------------------------------------\n   Hyprland Crash Report\n--------------------------------------------\n";
     finalCrashReport += getRandomMessage() + "\n\n";
 
-    finalCrashReport += getFormat("Hyprland received signal {} ({})\n\n", sig, (const char*)strsignal(sig));
+    finalCrashReport += std::format("Hyprland received signal {} ({})\n\n", sig, (const char*)strsignal(sig));
 
-    finalCrashReport += getFormat("Version: {}\nTag: {}\n\n", GIT_COMMIT_HASH, GIT_TAG);
+    finalCrashReport += std::format("Version: {}\nTag: {}\n\n", GIT_COMMIT_HASH, GIT_TAG);
 
     if (g_pPluginSystem && !g_pPluginSystem->getAllPlugins().empty()) {
         finalCrashReport += "Hyprland seems to be running with plugins. This crash might not be Hyprland's fault.\nPlugins:\n";
 
         for (auto& p : g_pPluginSystem->getAllPlugins()) {
-            finalCrashReport += getFormat("\t{} ({}) {}\n", p->name, p->author, p->version);
+            finalCrashReport += std::format("\t{} ({}) {}\n", p->name, p->author, p->version);
         }
 
         finalCrashReport += "\n\n";
@@ -65,7 +65,7 @@ void CrashReporter::createAndSaveCrash(int sig) {
     uname(&unameInfo);
 
     finalCrashReport +=
-        getFormat("\tSystem name: {}\n\tNode name: {}\n\tRelease: {}\n\tVersion: {}\n\n", unameInfo.sysname, unameInfo.nodename, unameInfo.release, unameInfo.version);
+        std::format("\tSystem name: {}\n\tNode name: {}\n\tRelease: {}\n\tVersion: {}\n\n", unameInfo.sysname, unameInfo.nodename, unameInfo.release, unameInfo.version);
 
 #if defined(__DragonFly__) || defined(__FreeBSD__)
     const std::string GPUINFO = execAndGet("pciconf -lv | fgrep -A4 vga");
@@ -75,7 +75,7 @@ void CrashReporter::createAndSaveCrash(int sig) {
 
     finalCrashReport += "GPU:\n\t" + GPUINFO;
 
-    finalCrashReport += getFormat("\n\nos-release:\n\t{}\n\n\n", replaceInString(execAndGet("cat /etc/os-release"), "\n", "\n\t"));
+    finalCrashReport += std::format("\n\nos-release:\n\t{}\n\n\n", replaceInString(execAndGet("cat /etc/os-release"), "\n", "\n\t"));
 
     finalCrashReport += "Backtrace:\n";
 
@@ -107,12 +107,12 @@ void CrashReporter::createAndSaveCrash(int sig) {
 #endif
 
     for (size_t i = 0; i < CALLSTACK.size(); ++i) {
-        finalCrashReport += getFormat("\t#{} | {}\n", i, CALLSTACK[i].desc);
+        finalCrashReport += std::format("\t#{} | {}\n", i, CALLSTACK[i].desc);
 
 #ifdef __clang__
-        const auto CMD = getFormat("llvm-addr2line -e {} -f 0x{:x}", FPATH.c_str(), (uint64_t)CALLSTACK[i].adr);
+        const auto CMD = std::format("llvm-addr2line -e {} -f 0x{:x}", FPATH.c_str(), (uint64_t)CALLSTACK[i].adr);
 #else
-        const auto CMD = getFormat("addr2line -e {} -f 0x{:x}", FPATH.c_str(), (uint64_t)CALLSTACK[i].adr);
+        const auto CMD = std::format("addr2line -e {} -f 0x{:x}", FPATH.c_str(), (uint64_t)CALLSTACK[i].adr);
 #endif
         const auto ADDR2LINE = replaceInString(execAndGet(CMD.c_str()), "\n", "\n\t\t");
         finalCrashReport += "\t\t" + ADDR2LINE.substr(0, ADDR2LINE.length() - 2);

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -112,7 +112,6 @@ static std::string getGroupedData(CWindow* w, HyprCtl::eHyprCtlOutputFormat form
     } while (curr != w);
 
     const auto         comma = isJson ? ", " : ",";
-    const auto         fmt   = isJson ? "\"0x{:x}\"" : "{:x}";
     std::ostringstream result;
 
     bool               first = true;
@@ -121,8 +120,10 @@ static std::string getGroupedData(CWindow* w, HyprCtl::eHyprCtlOutputFormat form
             first = false;
         else
             result << comma;
-
-        result << getFormat(fmt, (uintptr_t)gw);
+        if (isJson)
+            result << getFormat("\"0x{:x}\"", (uintptr_t)gw);
+        else
+            result << getFormat("{:x}", (uintptr_t)gw);
     }
 
     return result.str();
@@ -177,8 +178,8 @@ static std::string getWindowData(CWindow* w, HyprCtl::eHyprCtlOutputFormat forma
             (w->m_iWorkspaceID == -1                                ? "" :
                  g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID) ? g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID)->m_szName :
                                                                       std::string("Invalid workspace " + std::to_string(w->m_iWorkspaceID))),
-            (int)w->m_bIsFloating, (int64_t)w->m_iMonitorID, g_pXWaylandManager->getAppIDClass(w), g_pXWaylandManager->getTitle(w), w->m_szInitialClass, w->m_szInitialTitle, w->getPID(),
-            (int)w->m_bIsX11, (int)w->m_bPinned, (int)w->m_bIsFullscreen,
+            (int)w->m_bIsFloating, (int64_t)w->m_iMonitorID, g_pXWaylandManager->getAppIDClass(w), g_pXWaylandManager->getTitle(w), w->m_szInitialClass, w->m_szInitialTitle,
+            w->getPID(), (int)w->m_bIsX11, (int)w->m_bPinned, (int)w->m_bIsFullscreen,
             (w->m_bIsFullscreen ? (g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID) ? g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID)->m_efFullscreenMode : 0) : 0),
             (int)w->m_bFakeFullscreenState, getGroupedData(w, format), (uintptr_t)w->m_pSwallowed);
     }
@@ -416,7 +417,7 @@ std::string devicesRequest(HyprCtl::eHyprCtlOutputFormat format) {
         "type": "tabletTool",
         "belongsTo": "0x{:x}"
     }},)#",
-                (uintptr_t)&d, d.wlrTabletTool ? d.wlrTabletTool->data : 0);
+                (uintptr_t)&d, d.wlrTabletTool ? (uintptr_t)d.wlrTabletTool->data : 0);
         }
 
         trimTrailingComma(result);
@@ -481,7 +482,7 @@ std::string devicesRequest(HyprCtl::eHyprCtlOutputFormat format) {
         }
 
         for (auto& d : g_pInputManager->m_lTabletTools) {
-            result += getFormat("\tTablet Tool at {:x} (belongs to {:x})\n", (uintptr_t)&d, d.wlrTabletTool ? d.wlrTabletTool->data : 0);
+            result += getFormat("\tTablet Tool at {:x} (belongs to {:x})\n", (uintptr_t)&d, d.wlrTabletTool ? (uintptr_t)d.wlrTabletTool->data : 0);
         }
 
         result += "\n\nTouch:\n";

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -37,7 +37,7 @@ std::string monitorsRequest(HyprCtl::eHyprCtlOutputFormat format) {
             if (!m->output)
                 continue;
 
-            result += getFormat(
+            result += std::format(
                 R"#({{
     "id": {},
     "name": "{}",
@@ -82,16 +82,16 @@ std::string monitorsRequest(HyprCtl::eHyprCtlOutputFormat format) {
                 continue;
 
             result +=
-                getFormat("Monitor {} (ID {}):\n\t{}x{}@{:.5f} at {}x{}\n\tdescription: {}\n\tmake: {}\n\tmodel: {}\n\tserial: {}\n\tactive workspace: {} ({})\n\tspecial "
-                          "workspace: {} ({})\n\treserved: {} "
-                          "{} {} {}\n\tscale: {:.2f}\n\ttransform: "
-                          "{}\n\tfocused: {}\n\tdpmsStatus: {}\n\tvrr: {}\n\n",
-                          m->szName, m->ID, (int)m->vecPixelSize.x, (int)m->vecPixelSize.y, m->refreshRate, (int)m->vecPosition.x, (int)m->vecPosition.y,
-                          (m->output->description ? m->output->description : ""), (m->output->make ? m->output->make : ""), (m->output->model ? m->output->model : ""),
-                          (m->output->serial ? m->output->serial : ""), m->activeWorkspace, g_pCompositor->getWorkspaceByID(m->activeWorkspace)->m_szName, m->specialWorkspaceID,
-                          getWorkspaceNameFromSpecialID(m->specialWorkspaceID), (int)m->vecReservedTopLeft.x, (int)m->vecReservedTopLeft.y, (int)m->vecReservedBottomRight.x,
-                          (int)m->vecReservedBottomRight.y, m->scale, (int)m->transform, (m.get() == g_pCompositor->m_pLastMonitor ? "yes" : "no"), (int)m->dpmsStatus,
-                          (int)(m->output->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED));
+                std::format("Monitor {} (ID {}):\n\t{}x{}@{:.5f} at {}x{}\n\tdescription: {}\n\tmake: {}\n\tmodel: {}\n\tserial: {}\n\tactive workspace: {} ({})\n\tspecial "
+                            "workspace: {} ({})\n\treserved: {} "
+                            "{} {} {}\n\tscale: {:.2f}\n\ttransform: "
+                            "{}\n\tfocused: {}\n\tdpmsStatus: {}\n\tvrr: {}\n\n",
+                            m->szName, m->ID, (int)m->vecPixelSize.x, (int)m->vecPixelSize.y, m->refreshRate, (int)m->vecPosition.x, (int)m->vecPosition.y,
+                            (m->output->description ? m->output->description : ""), (m->output->make ? m->output->make : ""), (m->output->model ? m->output->model : ""),
+                            (m->output->serial ? m->output->serial : ""), m->activeWorkspace, g_pCompositor->getWorkspaceByID(m->activeWorkspace)->m_szName, m->specialWorkspaceID,
+                            getWorkspaceNameFromSpecialID(m->specialWorkspaceID), (int)m->vecReservedTopLeft.x, (int)m->vecReservedTopLeft.y, (int)m->vecReservedBottomRight.x,
+                            (int)m->vecReservedBottomRight.y, m->scale, (int)m->transform, (m.get() == g_pCompositor->m_pLastMonitor ? "yes" : "no"), (int)m->dpmsStatus,
+                            (int)(m->output->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED));
         }
     }
 
@@ -121,9 +121,9 @@ static std::string getGroupedData(CWindow* w, HyprCtl::eHyprCtlOutputFormat form
         else
             result << comma;
         if (isJson)
-            result << getFormat("\"0x{:x}\"", (uintptr_t)gw);
+            result << std::format("\"0x{:x}\"", (uintptr_t)gw);
         else
-            result << getFormat("{:x}", (uintptr_t)gw);
+            result << std::format("{:x}", (uintptr_t)gw);
     }
 
     return result.str();
@@ -131,7 +131,7 @@ static std::string getGroupedData(CWindow* w, HyprCtl::eHyprCtlOutputFormat form
 
 static std::string getWindowData(CWindow* w, HyprCtl::eHyprCtlOutputFormat format) {
     if (format == HyprCtl::FORMAT_JSON) {
-        return getFormat(
+        return std::format(
             R"#({{
     "address": "0x{:x}",
     "mapped": {},
@@ -168,7 +168,7 @@ static std::string getWindowData(CWindow* w, HyprCtl::eHyprCtlOutputFormat forma
             (w->m_bIsFullscreen ? (g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID) ? (int)g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID)->m_efFullscreenMode : 0) : 0),
             w->m_bFakeFullscreenState ? "true" : "false", getGroupedData(w, format), (uintptr_t)w->m_pSwallowed);
     } else {
-        return getFormat(
+        return std::format(
             "Window {:x} -> {}:\n\tmapped: {}\n\thidden: {}\n\tat: {},{}\n\tsize: {},{}\n\tworkspace: {} ({})\n\tfloating: {}\n\tmonitor: {}\n\tclass: {}\n\ttitle: "
             "{}\n\tinitialClass: {}\n\tinitialTitle: {}\n\tpid: "
             "{}\n\txwayland: {}\n\tpinned: "
@@ -209,7 +209,7 @@ static std::string getWorkspaceData(CWorkspace* w, HyprCtl::eHyprCtlOutputFormat
     const auto PLASTW   = w->getLastFocusedWindow();
     const auto PMONITOR = g_pCompositor->getMonitorFromID(w->m_iMonitorID);
     if (format == HyprCtl::FORMAT_JSON) {
-        return getFormat(R"#({{
+        return std::format(R"#({{
     "id": {},
     "name": "{}",
     "monitor": "{}",
@@ -218,12 +218,12 @@ static std::string getWorkspaceData(CWorkspace* w, HyprCtl::eHyprCtlOutputFormat
     "lastwindow": "0x{:x}",
     "lastwindowtitle": "{}"
 }})#",
-                         w->m_iID, escapeJSONStrings(w->m_szName), escapeJSONStrings(PMONITOR ? PMONITOR->szName : "?"), g_pCompositor->getWindowsOnWorkspace(w->m_iID),
-                         ((int)w->m_bHasFullscreenWindow == 1 ? "true" : "false"), (uintptr_t)PLASTW, PLASTW ? escapeJSONStrings(PLASTW->m_szTitle) : "");
+                           w->m_iID, escapeJSONStrings(w->m_szName), escapeJSONStrings(PMONITOR ? PMONITOR->szName : "?"), g_pCompositor->getWindowsOnWorkspace(w->m_iID),
+                           ((int)w->m_bHasFullscreenWindow == 1 ? "true" : "false"), (uintptr_t)PLASTW, PLASTW ? escapeJSONStrings(PLASTW->m_szTitle) : "");
     } else {
-        return getFormat("workspace ID {} ({}) on monitor {}:\n\twindows: {}\n\thasfullscreen: {}\n\tlastwindow: 0x{:x}\n\tlastwindowtitle: {}\n\n", w->m_iID, w->m_szName,
-                         PMONITOR ? PMONITOR->szName : "?", g_pCompositor->getWindowsOnWorkspace(w->m_iID), (int)w->m_bHasFullscreenWindow, (uintptr_t)PLASTW,
-                         PLASTW ? PLASTW->m_szTitle : "");
+        return std::format("workspace ID {} ({}) on monitor {}:\n\twindows: {}\n\thasfullscreen: {}\n\tlastwindow: 0x{:x}\n\tlastwindowtitle: {}\n\n", w->m_iID, w->m_szName,
+                           PMONITOR ? PMONITOR->szName : "?", g_pCompositor->getWindowsOnWorkspace(w->m_iID), (int)w->m_bHasFullscreenWindow, (uintptr_t)PLASTW,
+                           PLASTW ? PLASTW->m_szTitle : "");
     }
 }
 
@@ -275,7 +275,7 @@ std::string layersRequest(HyprCtl::eHyprCtlOutputFormat format) {
         result += "{\n";
 
         for (auto& mon : g_pCompositor->m_vMonitors) {
-            result += getFormat(
+            result += std::format(
                 R"#("{}": {{
     "levels": {{
 )#",
@@ -283,13 +283,13 @@ std::string layersRequest(HyprCtl::eHyprCtlOutputFormat format) {
 
             int layerLevel = 0;
             for (auto& level : mon->m_aLayerSurfaceLayers) {
-                result += getFormat(
+                result += std::format(
                     R"#(
         "{}": [
 )#",
                     layerLevel);
                 for (auto& layer : level) {
-                    result += getFormat(
+                    result += std::format(
                         R"#(                {{
                     "address": "0x{:x}",
                     "x": {},
@@ -322,15 +322,15 @@ std::string layersRequest(HyprCtl::eHyprCtlOutputFormat format) {
 
     } else {
         for (auto& mon : g_pCompositor->m_vMonitors) {
-            result += getFormat("Monitor {}:\n", mon->szName);
+            result += std::format("Monitor {}:\n", mon->szName);
             int                                     layerLevel = 0;
             static const std::array<std::string, 4> levelNames = {"background", "bottom", "top", "overlay"};
             for (auto& level : mon->m_aLayerSurfaceLayers) {
-                result += getFormat("\tLayer level {} ({}):\n", layerLevel, levelNames[layerLevel]);
+                result += std::format("\tLayer level {} ({}):\n", layerLevel, levelNames[layerLevel]);
 
                 for (auto& layer : level) {
-                    result += getFormat("\t\tLayer {:x}: xywh: {} {} {} {}, namespace: {}\n", (uintptr_t)layer.get(), layer->geometry.x, layer->geometry.y, layer->geometry.width,
-                                        layer->geometry.height, layer->szNamespace);
+                    result += std::format("\t\tLayer {:x}: xywh: {} {} {} {}, namespace: {}\n", (uintptr_t)layer.get(), layer->geometry.x, layer->geometry.y, layer->geometry.width,
+                                          layer->geometry.height, layer->szNamespace);
                 }
 
                 layerLevel++;
@@ -350,7 +350,7 @@ std::string devicesRequest(HyprCtl::eHyprCtlOutputFormat format) {
         result += "\"mice\": [\n";
 
         for (auto& m : g_pInputManager->m_lMice) {
-            result += getFormat(
+            result += std::format(
                 R"#(    {{
         "address": "0x{:x}",
         "name": "{}",
@@ -366,7 +366,7 @@ std::string devicesRequest(HyprCtl::eHyprCtlOutputFormat format) {
         result += "\"keyboards\": [\n";
         for (auto& k : g_pInputManager->m_lKeyboards) {
             const auto KM = g_pInputManager->getActiveLayoutForKeyboard(&k);
-            result += getFormat(
+            result += std::format(
                 R"#(    {{
         "address": "0x{:x}",
         "name": "{}",
@@ -389,7 +389,7 @@ std::string devicesRequest(HyprCtl::eHyprCtlOutputFormat format) {
         result += "\"tablets\": [\n";
 
         for (auto& d : g_pInputManager->m_lTabletPads) {
-            result += getFormat(
+            result += std::format(
                 R"#(    {{
         "address": "0x{:x}",
         "type": "tabletPad",
@@ -402,7 +402,7 @@ std::string devicesRequest(HyprCtl::eHyprCtlOutputFormat format) {
         }
 
         for (auto& d : g_pInputManager->m_lTablets) {
-            result += getFormat(
+            result += std::format(
                 R"#(    {{
         "address": "0x{:x}",
         "name": "{}"
@@ -411,7 +411,7 @@ std::string devicesRequest(HyprCtl::eHyprCtlOutputFormat format) {
         }
 
         for (auto& d : g_pInputManager->m_lTabletTools) {
-            result += getFormat(
+            result += std::format(
                 R"#(    {{
         "address": "0x{:x}",
         "type": "tabletTool",
@@ -426,7 +426,7 @@ std::string devicesRequest(HyprCtl::eHyprCtlOutputFormat format) {
         result += "\"touch\": [\n";
 
         for (auto& d : g_pInputManager->m_lTouchDevices) {
-            result += getFormat(
+            result += std::format(
                 R"#(    {{
         "address": "0x{:x}",
         "name": "{}"
@@ -440,7 +440,7 @@ std::string devicesRequest(HyprCtl::eHyprCtlOutputFormat format) {
         result += "\"switches\": [\n";
 
         for (auto& d : g_pInputManager->m_lSwitches) {
-            result += getFormat(
+            result += std::format(
                 R"#(    {{
         "address": "0x{:x}",
         "name": "{}"
@@ -457,7 +457,7 @@ std::string devicesRequest(HyprCtl::eHyprCtlOutputFormat format) {
         result += "mice:\n";
 
         for (auto& m : g_pInputManager->m_lMice) {
-            result += getFormat(
+            result += std::format(
                 "\tMouse at {:x}:\n\t\t{}\n\t\t\tdefault speed: {:.5f}\n", (uintptr_t)&m, m.name,
                 (wlr_input_device_is_libinput(m.mouse) ? libinput_device_config_accel_get_default_speed((libinput_device*)wlr_libinput_get_device_handle(m.mouse)) : 0.f));
         }
@@ -466,35 +466,35 @@ std::string devicesRequest(HyprCtl::eHyprCtlOutputFormat format) {
 
         for (auto& k : g_pInputManager->m_lKeyboards) {
             const auto KM = g_pInputManager->getActiveLayoutForKeyboard(&k);
-            result +=
-                getFormat("\tKeyboard at {:x}:\n\t\t{}\n\t\t\trules: r \"{}\", m \"{}\", l \"{}\", v \"{}\", o \"{}\"\n\t\t\tactive keymap: {}\n\t\t\tmain: {}\n", (uintptr_t)&k,
-                          k.name, k.currentRules.rules, k.currentRules.model, k.currentRules.layout, k.currentRules.variant, k.currentRules.options, KM, (k.active ? "yes" : "no"));
+            result += std::format("\tKeyboard at {:x}:\n\t\t{}\n\t\t\trules: r \"{}\", m \"{}\", l \"{}\", v \"{}\", o \"{}\"\n\t\t\tactive keymap: {}\n\t\t\tmain: {}\n",
+                                  (uintptr_t)&k, k.name, k.currentRules.rules, k.currentRules.model, k.currentRules.layout, k.currentRules.variant, k.currentRules.options, KM,
+                                  (k.active ? "yes" : "no"));
         }
 
         result += "\n\nTablets:\n";
 
         for (auto& d : g_pInputManager->m_lTabletPads) {
-            result += getFormat("\tTablet Pad at {:x} (belongs to {:x} -> {})\n", (uintptr_t)&d, (uintptr_t)d.pTabletParent, d.pTabletParent ? d.pTabletParent->name : "");
+            result += std::format("\tTablet Pad at {:x} (belongs to {:x} -> {})\n", (uintptr_t)&d, (uintptr_t)d.pTabletParent, d.pTabletParent ? d.pTabletParent->name : "");
         }
 
         for (auto& d : g_pInputManager->m_lTablets) {
-            result += getFormat("\tTablet at {:x}:\n\t\t{}\n", (uintptr_t)&d, d.name);
+            result += std::format("\tTablet at {:x}:\n\t\t{}\n", (uintptr_t)&d, d.name);
         }
 
         for (auto& d : g_pInputManager->m_lTabletTools) {
-            result += getFormat("\tTablet Tool at {:x} (belongs to {:x})\n", (uintptr_t)&d, d.wlrTabletTool ? (uintptr_t)d.wlrTabletTool->data : 0);
+            result += std::format("\tTablet Tool at {:x} (belongs to {:x})\n", (uintptr_t)&d, d.wlrTabletTool ? (uintptr_t)d.wlrTabletTool->data : 0);
         }
 
         result += "\n\nTouch:\n";
 
         for (auto& d : g_pInputManager->m_lTouchDevices) {
-            result += getFormat("\tTouch Device at {:x}:\n\t\t{}\n", (uintptr_t)&d, d.name);
+            result += std::format("\tTouch Device at {:x}:\n\t\t{}\n", (uintptr_t)&d, d.name);
         }
 
         result += "\n\nSwitches:\n";
 
         for (auto& d : g_pInputManager->m_lSwitches) {
-            result += getFormat("\tSwitch Device at {:x}:\n\t\t{}\n", (uintptr_t)&d, d.pWlrDevice ? d.pWlrDevice->name : "");
+            result += std::format("\tSwitch Device at {:x}:\n\t\t{}\n", (uintptr_t)&d, d.pWlrDevice ? d.pWlrDevice->name : "");
         }
     }
 
@@ -507,21 +507,21 @@ std::string animationsRequest(HyprCtl::eHyprCtlOutputFormat format) {
         ret += "animations:\n";
 
         for (auto& ac : g_pConfigManager->getAnimationConfig()) {
-            ret += getFormat("\n\tname: {}\n\t\toverriden: {}\n\t\tbezier: {}\n\t\tenabled: {}\n\t\tspeed: {:.2f}\n\t\tstyle: {}\n", ac.first, (int)ac.second.overridden,
-                             ac.second.internalBezier, ac.second.internalEnabled, ac.second.internalSpeed, ac.second.internalStyle);
+            ret += std::format("\n\tname: {}\n\t\toverriden: {}\n\t\tbezier: {}\n\t\tenabled: {}\n\t\tspeed: {:.2f}\n\t\tstyle: {}\n", ac.first, (int)ac.second.overridden,
+                               ac.second.internalBezier, ac.second.internalEnabled, ac.second.internalSpeed, ac.second.internalStyle);
         }
 
         ret += "beziers:\n";
 
         for (auto& bz : g_pAnimationManager->getAllBeziers()) {
-            ret += getFormat("\n\tname: {}\n", bz.first);
+            ret += std::format("\n\tname: {}\n", bz.first);
         }
     } else {
         // json
 
         ret += "[[";
         for (auto& ac : g_pConfigManager->getAnimationConfig()) {
-            ret += getFormat(R"#(
+            ret += std::format(R"#(
 {{
     "name": "{}",
     "overridden": {},
@@ -530,8 +530,8 @@ std::string animationsRequest(HyprCtl::eHyprCtlOutputFormat format) {
     "speed": {:.2f},
     "style": "{}"
 }},)#",
-                             ac.first, ac.second.overridden ? "true" : "false", ac.second.internalBezier, ac.second.internalEnabled ? "true" : "false", ac.second.internalSpeed,
-                             ac.second.internalStyle);
+                               ac.first, ac.second.overridden ? "true" : "false", ac.second.internalBezier, ac.second.internalEnabled ? "true" : "false", ac.second.internalSpeed,
+                               ac.second.internalStyle);
         }
 
         ret[ret.length() - 1] = ']';
@@ -539,11 +539,11 @@ std::string animationsRequest(HyprCtl::eHyprCtlOutputFormat format) {
         ret += ",\n[";
 
         for (auto& bz : g_pAnimationManager->getAllBeziers()) {
-            ret += getFormat(R"#(
+            ret += std::format(R"#(
 {{
     "name": "{}"
 }},)#",
-                             bz.first);
+                               bz.first);
         }
 
         trimTrailingComma(ret);
@@ -559,16 +559,16 @@ std::string globalShortcutsRequest(HyprCtl::eHyprCtlOutputFormat format) {
     const auto  SHORTCUTS = g_pProtocolManager->m_pGlobalShortcutsProtocolManager->getAllShortcuts();
     if (format == HyprCtl::eHyprCtlOutputFormat::FORMAT_NORMAL) {
         for (auto& sh : SHORTCUTS)
-            ret += getFormat("{}:{} -> {}\n", sh.appid, sh.id, sh.description);
+            ret += std::format("{}:{} -> {}\n", sh.appid, sh.id, sh.description);
     } else {
         ret += "[";
         for (auto& sh : SHORTCUTS) {
-            ret += getFormat(R"#(
+            ret += std::format(R"#(
 {{
     "name": "{}",
     "description": "{}"
 }},)#",
-                             escapeJSONStrings(sh.appid + ":" + sh.id), escapeJSONStrings(sh.description));
+                               escapeJSONStrings(sh.appid + ":" + sh.id), escapeJSONStrings(sh.description));
         }
         trimTrailingComma(ret);
         ret += "]\n";
@@ -593,14 +593,14 @@ std::string bindsRequest(HyprCtl::eHyprCtlOutputFormat format) {
             if (kb.nonConsuming)
                 ret += "n";
 
-            ret += getFormat("\n\tmodmask: {}\n\tsubmap: {}\n\tkey: {}\n\tkeycode: {}\n\tdispatcher: {}\n\targ: {}\n\n", kb.modmask, kb.submap, kb.key, kb.keycode, kb.handler,
-                             kb.arg);
+            ret += std::format("\n\tmodmask: {}\n\tsubmap: {}\n\tkey: {}\n\tkeycode: {}\n\tdispatcher: {}\n\targ: {}\n\n", kb.modmask, kb.submap, kb.key, kb.keycode, kb.handler,
+                               kb.arg);
         }
     } else {
         // json
         ret += "[";
         for (auto& kb : g_pKeybindManager->m_lKeybinds) {
-            ret += getFormat(
+            ret += std::format(
                 R"#(
 {{
     "locked": {},
@@ -649,7 +649,7 @@ std::string versionRequest(HyprCtl::eHyprCtlOutputFormat format) {
 
         return result;
     } else {
-        std::string result = getFormat(
+        std::string result = std::format(
             R"#({{
     "branch": "{}",
     "commit": "{}",
@@ -780,15 +780,15 @@ std::string cursorPosRequest(HyprCtl::eHyprCtlOutputFormat format) {
     const auto CURSORPOS = g_pInputManager->getMouseCoordsInternal().floor();
 
     if (format == HyprCtl::FORMAT_NORMAL) {
-        return getFormat("{}, {}", (int)CURSORPOS.x, (int)CURSORPOS.y);
+        return std::format("{}, {}", (int)CURSORPOS.x, (int)CURSORPOS.y);
     } else {
-        return getFormat(R"#(
+        return std::format(R"#(
 {{
     "x": {},
     "y": {}
 }}
 )#",
-                         (int)CURSORPOS.x, (int)CURSORPOS.y);
+                           (int)CURSORPOS.x, (int)CURSORPOS.y);
     }
 
     return "error";
@@ -1040,10 +1040,10 @@ std::string dispatchGetOption(std::string request, HyprCtl::eHyprCtlOutputFormat
         return "no such option";
 
     if (format == HyprCtl::eHyprCtlOutputFormat::FORMAT_NORMAL)
-        return getFormat("option {}\n\tint: {}\n\tfloat: {:.5f}\n\tstr: \"{}\"\n\tdata: {:x}\n\tset: {}", curitem, PCFGOPT->intValue, PCFGOPT->floatValue, PCFGOPT->strValue,
-                         (uintptr_t)PCFGOPT->data.get(), PCFGOPT->set);
+        return std::format("option {}\n\tint: {}\n\tfloat: {:.5f}\n\tstr: \"{}\"\n\tdata: {:x}\n\tset: {}", curitem, PCFGOPT->intValue, PCFGOPT->floatValue, PCFGOPT->strValue,
+                           (uintptr_t)PCFGOPT->data.get(), PCFGOPT->set);
     else {
-        return getFormat(
+        return std::format(
             R"#(
 {{
     "option": "{}",
@@ -1170,7 +1170,7 @@ std::string dispatchPlugin(std::string request) {
 
         std::string list = "";
         for (auto& p : PLUGINS) {
-            list += getFormat("\nPlugin {} by {}:\n\tHandle: {:x}\n\tVersion: {}\n\tDescription: {}\n", p->name, p->author, (uintptr_t)p->m_pHandle, p->version, p->description);
+            list += std::format("\nPlugin {} by {}:\n\tHandle: {:x}\n\tVersion: {}\n\tDescription: {}\n", p->name, p->author, (uintptr_t)p->m_pHandle, p->version, p->description);
         }
 
         return list;

--- a/src/debug/HyprDebugOverlay.cpp
+++ b/src/debug/HyprDebugOverlay.cpp
@@ -132,7 +132,7 @@ int CHyprMonitorDebugOverlay::draw(int offset) {
 
     yOffset += 17;
     cairo_move_to(g_pDebugOverlay->m_pCairo, 0, yOffset);
-    text = getFormat("{} FPS", (int)FPS);
+    text = std::format("{} FPS", (int)FPS);
     cairo_show_text(g_pDebugOverlay->m_pCairo, text.c_str());
     cairo_text_extents(g_pDebugOverlay->m_pCairo, text.c_str(), &cairoExtents);
     if (cairoExtents.width > maxX)
@@ -143,7 +143,7 @@ int CHyprMonitorDebugOverlay::draw(int offset) {
 
     yOffset += 11;
     cairo_move_to(g_pDebugOverlay->m_pCairo, 0, yOffset);
-    text = getFormat("Avg Frametime: {:.2f}ms (var {:.2f}ms)", avgFrametime, varFrametime);
+    text = std::format("Avg Frametime: {:.2f}ms (var {:.2f}ms)", avgFrametime, varFrametime);
     cairo_show_text(g_pDebugOverlay->m_pCairo, text.c_str());
     cairo_text_extents(g_pDebugOverlay->m_pCairo, text.c_str(), &cairoExtents);
     if (cairoExtents.width > maxX)
@@ -151,7 +151,7 @@ int CHyprMonitorDebugOverlay::draw(int offset) {
 
     yOffset += 11;
     cairo_move_to(g_pDebugOverlay->m_pCairo, 0, yOffset);
-    text = getFormat("Avg Rendertime: {:.2f}ms (var {:.2f}ms)", avgRenderTime, varRenderTime);
+    text = std::format("Avg Rendertime: {:.2f}ms (var {:.2f}ms)", avgRenderTime, varRenderTime);
     cairo_show_text(g_pDebugOverlay->m_pCairo, text.c_str());
     cairo_text_extents(g_pDebugOverlay->m_pCairo, text.c_str(), &cairoExtents);
     if (cairoExtents.width > maxX)
@@ -159,7 +159,7 @@ int CHyprMonitorDebugOverlay::draw(int offset) {
 
     yOffset += 11;
     cairo_move_to(g_pDebugOverlay->m_pCairo, 0, yOffset);
-    text = getFormat("Avg Rendertime (No Overlay): {:.2f}ms (var {:.2f}ms)", avgRenderTimeNoOverlay, varRenderTimeNoOverlay);
+    text = std::format("Avg Rendertime (No Overlay): {:.2f}ms (var {:.2f}ms)", avgRenderTimeNoOverlay, varRenderTimeNoOverlay);
     cairo_show_text(g_pDebugOverlay->m_pCairo, text.c_str());
     cairo_text_extents(g_pDebugOverlay->m_pCairo, text.c_str(), &cairoExtents);
     if (cairoExtents.width > maxX)
@@ -167,7 +167,7 @@ int CHyprMonitorDebugOverlay::draw(int offset) {
 
     yOffset += 11;
     cairo_move_to(g_pDebugOverlay->m_pCairo, 0, yOffset);
-    text = getFormat("Avg Anim Tick: {:.2f}ms (var {:.2f}ms) ({:.2f} TPS)", avgAnimMgrTick, varAnimMgrTick, 1.0 / (avgAnimMgrTick / 1000.0));
+    text = std::format("Avg Anim Tick: {:.2f}ms (var {:.2f}ms) ({:.2f} TPS)", avgAnimMgrTick, varAnimMgrTick, 1.0 / (avgAnimMgrTick / 1000.0));
     cairo_show_text(g_pDebugOverlay->m_pCairo, text.c_str());
     cairo_text_extents(g_pDebugOverlay->m_pCairo, text.c_str(), &cairoExtents);
     if (cairoExtents.width > maxX)

--- a/src/debug/Log.hpp
+++ b/src/debug/Log.hpp
@@ -29,7 +29,7 @@ namespace Debug {
 
     void               init(const std::string& IS);
     template <typename... Args>
-    void log(LogLevel level, const std::string& fmt, Args&&... args) {
+    void log(LogLevel level, std::format_string<Args...> fmt, Args&&... args) {
         if (disableLogs && *disableLogs)
             return;
 
@@ -64,7 +64,7 @@ namespace Debug {
         }
 
         try {
-            logMsg += std::vformat(fmt, std::make_format_args(args...));
+            logMsg += std::vformat(fmt.get(), std::make_format_args(args...));
         } catch (std::exception& e) {
             std::string exceptionMsg = e.what();
             Debug::log(ERR, "caught exception in Debug::log: {}", exceptionMsg);

--- a/src/debug/Log.hpp
+++ b/src/debug/Log.hpp
@@ -9,8 +9,7 @@
 
 #define LOGMESSAGESIZE 1024
 
-enum LogLevel
-{
+enum LogLevel {
     NONE = -1,
     LOG  = 0,
     WARN,
@@ -63,20 +62,12 @@ namespace Debug {
 #endif
         }
 
-        try {
-            logMsg += std::vformat(fmt.get(), std::make_format_args(args...));
-        } catch (std::exception& e) {
-            std::string exceptionMsg = e.what();
-            Debug::log(ERR, "caught exception in Debug::log: {}", exceptionMsg);
-
-            const auto CALLSTACK = getBacktrace();
-
-            Debug::log(LOG, "stacktrace:");
-
-            for (size_t i = 0; i < CALLSTACK.size(); ++i) {
-                Debug::log(NONE, "\t #{} | {}", i, CALLSTACK[i].desc);
-            }
-        }
+        // no need for try {} catch {} because std::format_string<Args...> ensures that vformat never throw std::format_error
+        // because
+        // 1. any faulty format specifier that sucks will cause a compilation error.
+        // 2. and `std::bad_alloc` is catastrophic, (Almost any operation in stdlib could throw this.)
+        // 3. this is actually what std::format in stdlib does
+        logMsg += std::vformat(fmt.get(), std::make_format_args(args...));
 
         ofs << logMsg << "\n";
 

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -592,7 +592,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
     auto workspaceID = requestedWorkspace != "" ? requestedWorkspace : PWORKSPACE->m_szName;
     g_pEventManager->postEvent(
-        SHyprIPCEvent{"openwindow", getFormat("{:x},{},{},{}", (uintptr_t)PWINDOW, workspaceID, g_pXWaylandManager->getAppIDClass(PWINDOW), PWINDOW->m_szTitle)});
+        SHyprIPCEvent{"openwindow", std::format("{:x},{},{},{}", (uintptr_t)PWINDOW, workspaceID, g_pXWaylandManager->getAppIDClass(PWINDOW), PWINDOW->m_szTitle)});
     EMIT_HOOK_EVENT("openWindow", PWINDOW);
 
     // recalc the values for this window
@@ -612,7 +612,7 @@ void Events::listener_unmapWindow(void* owner, void* data) {
         return;
     }
 
-    g_pEventManager->postEvent(SHyprIPCEvent{"closewindow", getFormat("{:x}", (uintptr_t)PWINDOW)});
+    g_pEventManager->postEvent(SHyprIPCEvent{"closewindow", std::format("{:x}", (uintptr_t)PWINDOW)});
     EMIT_HOOK_EVENT("closeWindow", PWINDOW);
 
     g_pProtocolManager->m_pToplevelExportProtocolManager->onWindowUnmap(PWINDOW);
@@ -806,12 +806,12 @@ void Events::listener_setTitleWindow(void* owner, void* data) {
         return;
 
     PWINDOW->m_szTitle = g_pXWaylandManager->getTitle(PWINDOW);
-    g_pEventManager->postEvent(SHyprIPCEvent{"windowtitle", getFormat("{:x}", (uintptr_t)PWINDOW)});
+    g_pEventManager->postEvent(SHyprIPCEvent{"windowtitle", std::format("{:x}", (uintptr_t)PWINDOW)});
     EMIT_HOOK_EVENT("windowTitle", PWINDOW);
 
     if (PWINDOW == g_pCompositor->m_pLastWindow) { // if it's the active, let's post an event to update others
         g_pEventManager->postEvent(SHyprIPCEvent{"activewindow", g_pXWaylandManager->getAppIDClass(PWINDOW) + "," + PWINDOW->m_szTitle});
-        g_pEventManager->postEvent(SHyprIPCEvent{"activewindowv2", getFormat("{:x}", (uintptr_t)PWINDOW)});
+        g_pEventManager->postEvent(SHyprIPCEvent{"activewindowv2", std::format("{:x}", (uintptr_t)PWINDOW)});
         EMIT_HOOK_EVENT("activeWindow", PWINDOW);
     }
 
@@ -896,7 +896,7 @@ void Events::listener_activateXDG(wl_listener* listener, void* data) {
     if (!PWINDOW || PWINDOW == g_pCompositor->m_pLastWindow)
         return;
 
-    g_pEventManager->postEvent(SHyprIPCEvent{"urgent", getFormat("{:x}", (uintptr_t)PWINDOW)});
+    g_pEventManager->postEvent(SHyprIPCEvent{"urgent", std::format("{:x}", (uintptr_t)PWINDOW)});
     EMIT_HOOK_EVENT("urgent", PWINDOW);
 
     PWINDOW->m_bIsUrgent = true;
@@ -932,7 +932,7 @@ void Events::listener_activateX11(void* owner, void* data) {
     if (PWINDOW == g_pCompositor->m_pLastWindow)
         return;
 
-    g_pEventManager->postEvent(SHyprIPCEvent{"urgent", getFormat("{:x}", (uintptr_t)PWINDOW)});
+    g_pEventManager->postEvent(SHyprIPCEvent{"urgent", std::format("{:x}", (uintptr_t)PWINDOW)});
     EMIT_HOOK_EVENT("urgent", PWINDOW);
 
     if (!*PFOCUSONACTIVATE)
@@ -1146,13 +1146,13 @@ void Events::listener_requestMinimize(void* owner, void* data) {
 
         const auto E = (wlr_xwayland_minimize_event*)data;
 
-        g_pEventManager->postEvent({"minimize", getFormat("{:x},{}", (uintptr_t)PWINDOW, (int)E->minimize)});
+        g_pEventManager->postEvent({"minimize", std::format("{:x},{}", (uintptr_t)PWINDOW, (int)E->minimize)});
         EMIT_HOOK_EVENT("minimize", (std::vector<void*>{PWINDOW, (void*)E->minimize}));
 
         wlr_xwayland_surface_set_minimized(PWINDOW->m_uSurface.xwayland, E->minimize && g_pCompositor->m_pLastWindow != PWINDOW); // fucking DXVK
     } else {
         const auto E = (wlr_foreign_toplevel_handle_v1_minimized_event*)data;
-        g_pEventManager->postEvent({"minimize", getFormat("{:x},{}", (uintptr_t)PWINDOW, E ? (int)E->minimized : 1)});
+        g_pEventManager->postEvent({"minimize", std::format("{:x},{}", (uintptr_t)PWINDOW, E ? (int)E->minimized : 1)});
         EMIT_HOOK_EVENT("minimize", (std::vector<void*>{PWINDOW, (void*)(E ? (uint64_t)E->minimized : 1)}));
     }
 }

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -707,7 +707,3 @@ void throwError(const std::string& err) {
     Debug::log(CRIT, "Critical error thrown: {}", err);
     throw std::runtime_error(err);
 }
-
-void sendToLog(uint8_t level, const std::string& s) {
-    Debug::log((LogLevel)level, "{}", s);
-}

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -709,5 +709,5 @@ void throwError(const std::string& err) {
 }
 
 void sendToLog(uint8_t level, const std::string& s) {
-    Debug::log((LogLevel)level, s);
+    Debug::log((LogLevel)level, "{}", s);
 }

--- a/src/helpers/MiscFunctions.hpp
+++ b/src/helpers/MiscFunctions.hpp
@@ -32,26 +32,10 @@ std::string                      replaceInString(std::string subject, const std:
 std::vector<SCallstackFrameInfo> getBacktrace();
 void                             throwError(const std::string& err);
 
-// why, C++.
-void sendToLog(uint8_t, const std::string&);
 template <typename... Args>
-std::string getFormat(std::format_string<Args...> fmt, Args&&... args) {
-    std::string fmtdMsg;
-
-    try {
-        fmtdMsg += std::vformat(fmt.get(), std::make_format_args(args...));
-    } catch (std::exception& e) {
-        std::string exceptionMsg = e.what();
-        sendToLog(2, std::format("caught exception in getFormat: {}", exceptionMsg));
-
-        const auto CALLSTACK = getBacktrace();
-
-        sendToLog(0, "stacktrace:");
-
-        for (size_t i = 0; i < CALLSTACK.size(); ++i) {
-            sendToLog(1, std::format("\t #{} | {}", i, CALLSTACK[i].desc));
-        }
-    }
-
-    return fmtdMsg;
+[[deprecated("use std::format instead")]] std::string getFormat(std::format_string<Args...> fmt, Args&&... args) {
+    // no need for try {} catch {} because std::format_string<Args...> ensures that vformat never throw std::format_error
+    // because any suck format specifier will cause a compilation error
+    // this is actually what std::format in stdlib does
+    return std::vformat(fmt.get(), std::make_format_args(args...));
 }

--- a/src/helpers/MiscFunctions.hpp
+++ b/src/helpers/MiscFunctions.hpp
@@ -35,11 +35,11 @@ void                             throwError(const std::string& err);
 // why, C++.
 void sendToLog(uint8_t, const std::string&);
 template <typename... Args>
-std::string getFormat(const std::string& fmt, Args&&... args) {
+std::string getFormat(std::format_string<Args...> fmt, Args&&... args) {
     std::string fmtdMsg;
 
     try {
-        fmtdMsg += std::vformat(fmt, std::make_format_args(args...));
+        fmtdMsg += std::vformat(fmt.get(), std::make_format_args(args...));
     } catch (std::exception& e) {
         std::string exceptionMsg = e.what();
         sendToLog(2, std::format("caught exception in getFormat: {}", exceptionMsg));

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -402,7 +402,7 @@ void IHyprLayout::changeWindowFloatingMode(CWindow* pWindow) {
     const auto TILED = isWindowTiled(pWindow);
 
     // event
-    g_pEventManager->postEvent(SHyprIPCEvent{"changefloatingmode", getFormat("{:x},{}", (uintptr_t)pWindow, (int)TILED)});
+    g_pEventManager->postEvent(SHyprIPCEvent{"changefloatingmode", std::format("{:x},{}", (uintptr_t)pWindow, (int)TILED)});
     EMIT_HOOK_EVENT("changeFloatingMode", pWindow);
 
     if (!TILED) {

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -58,8 +58,8 @@
 #define RASSERT(expr, reason, ...)                                                                                                                                                 \
     if (!(expr)) {                                                                                                                                                                 \
         Debug::log(CRIT, "\n==========================================================================================\nASSERTION FAILED! \n\n{}\n\nat: line {} in {}",            \
-                   getFormat(reason, ##__VA_ARGS__), __LINE__,                                                                                                                     \
-                   ([]() constexpr->std::string { return std::string(__FILE__).substr(std::string(__FILE__).find_last_of('/') + 1); })());                                         \
+                   std::format(reason, ##__VA_ARGS__), __LINE__,                                                                                                                   \
+                   ([]() constexpr -> std::string { return std::string(__FILE__).substr(std::string(__FILE__).find_last_of('/') + 1); })());                                       \
         printf("Assertion failed! See the log in /tmp/hypr/hyprland.log for more info.");                                                                                          \
         raise(SIGABRT);                                                                                                                                                            \
     }

--- a/src/managers/HookSystemManager.cpp
+++ b/src/managers/HookSystemManager.cpp
@@ -57,7 +57,7 @@ void CHookSystemManager::emit(const std::vector<SCallbackFNPtr>* callbacks, std:
         } catch (std::exception& e) {
             // TODO: this works only once...?
             faultyHandles.push_back(cb.handle);
-            Debug::log(ERR, " [hookSystem] Hook from plugin {:x} caused a SIGSEGV, queueing for unloading.", (uintptr_t)cb.handle);
+            Debug::log(ERR, "[hookSystem] Hook from plugin {:x} caused a SIGSEGV, queueing for unloading.", (uintptr_t)cb.handle);
         }
     }
 
@@ -73,7 +73,7 @@ std::vector<SCallbackFNPtr>* CHookSystemManager::getVecForEvent(const std::strin
     if (IT != m_lpRegisteredHooks.end())
         return &IT->second;
 
-    Debug::log(LOG, " [hookSystem] New hook event registered: {}", event);
+    Debug::log(LOG, "[hookSystem] New hook event registered: {}", event);
 
     return &m_lpRegisteredHooks.emplace_back(std::make_pair<>(event, std::vector<SCallbackFNPtr>{})).second;
 }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1611,7 +1611,7 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
                     const auto PREFERREDMODE = wlr_output_preferred_mode(pMonitor->output);
 
                     if (!PREFERREDMODE) {
-                        Debug::log(ERR, "Monitor {} has NO PREFERRED MODE, and an INVALID one was requested: {}x{}@{:2f}", (int)pMonitorRule->resolution.x,
+                        Debug::log(ERR, "Monitor {} has NO PREFERRED MODE, and an INVALID one was requested: {}x{}@{:2f}", pMonitor->ID, (int)pMonitorRule->resolution.x,
                                    (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate);
                         return true;
                     }
@@ -1724,7 +1724,7 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
                 const auto PREFERREDMODE = wlr_output_preferred_mode(pMonitor->output);
 
                 if (!PREFERREDMODE) {
-                    Debug::log(ERR, "Monitor {} has NO PREFERRED MODE, and an INVALID one was requested: {}x{}@{:2f}", (int)pMonitorRule->resolution.x,
+                    Debug::log(ERR, "Monitor {} has NO PREFERRED MODE, and an INVALID one was requested: {}x{}@{:2f}", pMonitor->ID, (int)pMonitorRule->resolution.x,
                                (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate);
                     return true;
                 }


### PR DESCRIPTION
## Abstract

This patch changed signature of `Debug::log` to
```cpp
void log(LogLevel level, std::format_string<Args...> fmt, Args&&... args);
```
`std::format_string<Args...>` would ensure that the format string and args is valid a compile time, eliminated any possibility of `std::vformat()` throwing `std::format_error`

Actually, `std::format()`, which does not throw `std::format_error` as specified in the c++20 standard in stdlib, is defined as follows in **libstdc++**

```cpp
  template<typename... _Args>
    [[nodiscard]]
    inline string
    format(format_string<_Args...> __fmt, _Args&&... __args)
    { return std::vformat(__fmt.get(), std::make_format_args(__args...)); }
```

Thus, `Debug::log` will now call `std::vformat()` without any exception handling for the above reason.

## Rational

The old signature of `Debug::log(LogLevel level, const std::string& fmt, Args&&... args)` is unsafe,
as the erroneous expressions are listed at compile time, causing `std::vformat()` to throw `std::format_error`.

For example, the current codebase contains the following types of mistakes.

#### Format string does not have enough args

https://github.com/hyprwm/Hyprland/blob/d8d0cd75c2db16a14086e1d5119ed937a60c701e/src/render/Renderer.cpp#L1614-L1615
https://github.com/hyprwm/Hyprland/blob/d8d0cd75c2db16a14086e1d5119ed937a60c701e/src/render/Renderer.cpp#L1727-L1728

#### Invalid format specifier

https://github.com/hyprwm/Hyprland/blob/d8d0cd75c2db16a14086e1d5119ed937a60c701e/src/debug/HyprCtl.cpp#L413-L419


Although `Debug::log` will catch and log such errors, this is suboptimal because:

- invalid formatting is handled at runtime (exception path is slower), 
- leads to subtle bugs, because we would not find out that a format string is invalid without triggering the exception and going through the logs.

## Other changes

- deprecate `getFormat` [1], replaced existing usage with `std::format` [2]
- remove `getFormat` in **hyprctl/main.cpp**


---

- [1] Some plugins or PR may use this.
- [2] `std::format` only throws `std::bad_alloc` as defined in standard, however, almost any stdlib types could potentially throw this if the host runs out of memory, and we are not writing code for nuclear plains or Mars rovers, so no recovery is necessary.