### PR TITLE
refactor: implement std::formatter for common custom types

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -939,7 +939,7 @@ void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
     // move to front of the window history
     const auto HISTORYPIVOT = std::find_if(m_vWindowFocusHistory.begin(), m_vWindowFocusHistory.end(), [&](const auto& other) { return other == pWindow; });
     if (HISTORYPIVOT == m_vWindowFocusHistory.end()) {
-        Debug::log(ERR, "BUG THIS: Window {:x} has no pivot in history", (uintptr_t)pWindow);
+        Debug::log(ERR, "BUG THIS: {} has no pivot in history", pWindow);
     } else {
         std::rotate(m_vWindowFocusHistory.begin(), HISTORYPIVOT, HISTORYPIVOT + 1);
     }
@@ -984,7 +984,7 @@ void CCompositor::focusSurface(wlr_surface* pSurface, CWindow* pWindowOwner) {
     wl_signal_emit_mutable(&m_sSeat.seat->keyboard_state.events.focus_change, &event);
 
     if (pWindowOwner)
-        Debug::log(LOG, "Set keyboard focus to surface {:x}, with window name: {}", (uintptr_t)pSurface, pWindowOwner->m_szTitle);
+        Debug::log(LOG, "Set keyboard focus to surface {:x}, with {}", (uintptr_t)pSurface, pWindowOwner);
     else
         Debug::log(LOG, "Set keyboard focus to surface {:x}", (uintptr_t)pSurface);
 
@@ -2479,7 +2479,6 @@ void CCompositor::setIdleActivityInhibit(bool enabled) {
     wlr_idle_set_enabled(g_pCompositor->m_sWLRIdle, g_pCompositor->m_sSeat.seat, enabled);
     wlr_idle_notifier_v1_set_inhibited(g_pCompositor->m_sWLRIdleNotifier, !enabled);
 }
-
 void CCompositor::arrangeMonitors() {
     static auto* const     PXWLFORCESCALEZERO = &g_pConfigManager->getConfigValuePtr("xwayland:force_zero_scaling")->intValue;
 
@@ -2496,7 +2495,7 @@ void CCompositor::arrangeMonitors() {
 
         if (m->activeMonitorRule.offset != Vector2D{-INT32_MAX, -INT32_MAX}) {
             // explicit.
-            Debug::log(LOG, "arrangeMonitors: {} explicit [{:.2f}, {:.2f}]", m->szName, m->activeMonitorRule.offset.x, m->activeMonitorRule.offset.y);
+            Debug::log(LOG, "arrangeMonitors: {} explicit {:j2}", m->szName, m->activeMonitorRule.offset);
 
             m->moveTo(m->activeMonitorRule.offset);
             arranged.push_back(m);

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -1,6 +1,7 @@
 #include "Window.hpp"
 #include "Compositor.hpp"
 #include "render/decorations/CHyprDropShadowDecoration.hpp"
+#include "render/decorations/CHyprGroupBarDecoration.hpp"
 
 CWindow::CWindow() {
     m_vRealPosition.create(AVARTYPE_VECTOR, g_pConfigManager->getAnimationPropertyConfig("windowsIn"), (void*)this, AVARDAMAGE_ENTIRE);

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1904,7 +1904,7 @@ std::vector<SWindowRule> CConfigManager::getMatchingRules(CWindow* pWindow) {
         }
 
         // applies. Read the rule and behave accordingly
-        Debug::log(LOG, "Window rule {} -> {} matched {:x} [{}]", rule.szRule, rule.szValue, (uintptr_t)pWindow, pWindow->m_szTitle);
+        Debug::log(LOG, "Window rule {} -> {} matched {}", rule.szRule, rule.szValue, pWindow);
 
         returns.push_back(rule);
 

--- a/src/events/Popups.cpp
+++ b/src/events/Popups.cpp
@@ -70,8 +70,7 @@ void createNewPopup(wlr_xdg_popup* popup, SXDGPopup* pHyprPopup) {
 
     pHyprPopup->monitor = PMONITOR;
 
-    Debug::log(LOG, "Popup: Unconstrained from lx ly: {:.5f} {:.5f}, pHyprPopup lx ly: {:.5f} {:.5f}", (float)PMONITOR->vecPosition.x, (float)PMONITOR->vecPosition.y,
-               (float)pHyprPopup->lx, (float)pHyprPopup->ly);
+    Debug::log(LOG, "Popup: Unconstrained from lx ly: {:j5}, pHyprPopup lx ly: {:.5f} {:.5f}", PMONITOR->vecPosition, (float)pHyprPopup->lx, (float)pHyprPopup->ly);
 }
 
 void Events::listener_newPopup(void* owner, void* data) {
@@ -103,7 +102,7 @@ void Events::listener_newPopupXDG(void* owner, void* data) {
     if (!PWINDOW->m_bIsMapped)
         return;
 
-    Debug::log(LOG, "New layer popup created from XDG window {:x} -> {}", (uintptr_t)PWINDOW, PWINDOW->m_szTitle);
+    Debug::log(LOG, "New layer popup created from XDG window {}", PWINDOW);
 
     const auto WLRPOPUP = (wlr_xdg_popup*)data;
 
@@ -125,7 +124,7 @@ void Events::listener_newPopupFromPopupXDG(void* owner, void* data) {
     ASSERT(PPOPUP);
 
     if (PPOPUP->parentWindow)
-        Debug::log(LOG, "New popup created from XDG Window popup {:x} -> {}", (uintptr_t)PPOPUP, PPOPUP->parentWindow->m_szTitle);
+        Debug::log(LOG, "New popup created from XDG Window popup {:x} -> {}", (uintptr_t)PPOPUP, PPOPUP->parentWindow);
     else
         Debug::log(LOG, "New popup created from Non-Window popup {:x}", (uintptr_t)PPOPUP);
 

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -148,7 +148,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                 }
                 PWINDOW->m_iWorkspaceID = PMONITOR->specialWorkspaceID ? PMONITOR->specialWorkspaceID : PMONITOR->activeWorkspace;
 
-                Debug::log(ERR, "Rule monitor, applying to window {:x} -> mon: {}, workspace: {}", (uintptr_t)PWINDOW, PWINDOW->m_iMonitorID, PWINDOW->m_iWorkspaceID);
+                Debug::log(LOG, "Rule monitor, applying to {:mw}", PWINDOW);
             } catch (std::exception& e) { Debug::log(ERR, "Rule monitor failed, rule: {} -> {} | err: {}", r.szRule, r.szValue, e.what()); }
         } else if (r.szRule.find("workspace") == 0) {
             // check if it isnt unset
@@ -165,7 +165,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
             if (JUSTWORKSPACE == PWORKSPACE->m_szName || JUSTWORKSPACE == "name:" + PWORKSPACE->m_szName)
                 requestedWorkspace = "";
 
-            Debug::log(LOG, "Rule workspace matched by window {:x}, {} applied.", (uintptr_t)PWINDOW, r.szValue);
+            Debug::log(LOG, "Rule workspace matched by {}, {} applied.", PWINDOW, r.szValue);
         } else if (r.szRule.find("float") == 0) {
             PWINDOW->m_bIsFloating = true;
         } else if (r.szRule.find("tile") == 0) {
@@ -283,7 +283,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                         std::clamp(MAXSIZE.y, 20.0, PMONITOR->vecSize.y) :
                         (!SIZEYSTR.contains('%') ? std::stoi(SIZEYSTR) : std::stof(SIZEYSTR.substr(0, SIZEYSTR.length() - 1)) * 0.01 * PMONITOR->vecSize.y);
 
-                    Debug::log(LOG, "Rule size, applying to window {:x}", (uintptr_t)PWINDOW);
+                    Debug::log(LOG, "Rule size, applying to {}", PWINDOW);
 
                     PWINDOW->m_vRealSize = Vector2D(SIZEX, SIZEY);
                     g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goalv());
@@ -386,7 +386,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                                           (int)(PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PWINDOW->m_vRealSize.goalv().y - borderSize));
                     }
 
-                    Debug::log(LOG, "Rule move, applying to window {:x}", (uintptr_t)PWINDOW);
+                    Debug::log(LOG, "Rule move, applying to {}", PWINDOW);
 
                     PWINDOW->m_vRealPosition = Vector2D(posX, posY) + PMONITOR->vecPosition;
 
@@ -587,12 +587,10 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
     PWINDOW->m_bFirstMap = false;
 
-    Debug::log(LOG, "Map request dispatched, monitor {}, xywh: {:.5f} {:.5f} {:.5f} {:.5f}", PMONITOR->szName, PWINDOW->m_vRealPosition.goalv().x,
-               PWINDOW->m_vRealPosition.goalv().y, PWINDOW->m_vRealSize.goalv().x, PWINDOW->m_vRealSize.goalv().y);
+    Debug::log(LOG, "Map request dispatched, monitor {}, window pos: {:5j}, window size: {:5j}", PMONITOR->szName, PWINDOW->m_vRealPosition.goalv(), PWINDOW->m_vRealSize.goalv());
 
     auto workspaceID = requestedWorkspace != "" ? requestedWorkspace : PWORKSPACE->m_szName;
-    g_pEventManager->postEvent(
-        SHyprIPCEvent{"openwindow", std::format("{:x},{},{},{}", (uintptr_t)PWINDOW, workspaceID, g_pXWaylandManager->getAppIDClass(PWINDOW), PWINDOW->m_szTitle)});
+    g_pEventManager->postEvent(SHyprIPCEvent{"openwindow", std::format("{:x},{},{},{}", PWINDOW, workspaceID, g_pXWaylandManager->getAppIDClass(PWINDOW), PWINDOW->m_szTitle)});
     EMIT_HOOK_EVENT("openWindow", PWINDOW);
 
     // recalc the values for this window
@@ -604,15 +602,15 @@ void Events::listener_mapWindow(void* owner, void* data) {
 void Events::listener_unmapWindow(void* owner, void* data) {
     CWindow* PWINDOW = (CWindow*)owner;
 
-    Debug::log(LOG, "Window {:x} unmapped (class {})", (uintptr_t)PWINDOW, g_pXWaylandManager->getAppIDClass(PWINDOW));
+    Debug::log(LOG, "{:c} unmapped", PWINDOW);
 
     if (!PWINDOW->m_pWLSurface.exists() || !PWINDOW->m_bIsMapped) {
-        Debug::log(WARN, "Window {:x} unmapped without being mapped??", (uintptr_t)PWINDOW);
+        Debug::log(WARN, "{} unmapped without being mapped??", PWINDOW);
         PWINDOW->m_bFadingOut = false;
         return;
     }
 
-    g_pEventManager->postEvent(SHyprIPCEvent{"closewindow", std::format("{:x}", (uintptr_t)PWINDOW)});
+    g_pEventManager->postEvent(SHyprIPCEvent{"closewindow", std::format("{:x}", PWINDOW)});
     EMIT_HOOK_EVENT("closeWindow", PWINDOW);
 
     g_pProtocolManager->m_pToplevelExportProtocolManager->onWindowUnmap(PWINDOW);
@@ -684,7 +682,7 @@ void Events::listener_unmapWindow(void* owner, void* data) {
     if (wasLastWindow) {
         const auto PWINDOWCANDIDATE = g_pLayoutManager->getCurrentLayout()->getNextWindowCandidate(PWINDOW);
 
-        Debug::log(LOG, "On closed window, new focused candidate is {:x}", (uintptr_t)PWINDOWCANDIDATE);
+        Debug::log(LOG, "On closed window, new focused candidate is {}", PWINDOWCANDIDATE);
 
         if (PWINDOWCANDIDATE != g_pCompositor->m_pLastWindow) {
             if (!PWINDOWCANDIDATE)
@@ -698,7 +696,7 @@ void Events::listener_unmapWindow(void* owner, void* data) {
         Debug::log(LOG, "Unmapped was not focused, ignoring a refocus.");
     }
 
-    Debug::log(LOG, "Destroying the SubSurface tree of unmapped window {:x}", (uintptr_t)PWINDOW);
+    Debug::log(LOG, "Destroying the SubSurface tree of unmapped window {}", PWINDOW);
     SubsurfaceTree::destroySurfaceTree(PWINDOW->m_pSurfaceTree);
 
     PWINDOW->m_pSurfaceTree = nullptr;
@@ -765,7 +763,7 @@ void Events::listener_commitWindow(void* owner, void* data) {
 void Events::listener_destroyWindow(void* owner, void* data) {
     CWindow* PWINDOW = (CWindow*)owner;
 
-    Debug::log(LOG, "Window {:x} destroyed, queueing. (class {})", (uintptr_t)PWINDOW, g_pXWaylandManager->getAppIDClass(PWINDOW));
+    Debug::log(LOG, "{:c} destroyed, queueing.", PWINDOW);
 
     if (PWINDOW->m_bIsX11)
         Debug::log(LOG, "XWayland class raw: {}", PWINDOW->m_uSurface.xwayland->_class ? PWINDOW->m_uSurface.xwayland->_class : "null");
@@ -786,7 +784,7 @@ void Events::listener_destroyWindow(void* owner, void* data) {
     g_pLayoutManager->getCurrentLayout()->onWindowRemoved(PWINDOW);
 
     if (PWINDOW->m_pSurfaceTree) {
-        Debug::log(LOG, "Destroying Subsurface tree of {:x} in destroyWindow", (uintptr_t)PWINDOW);
+        Debug::log(LOG, "Destroying Subsurface tree of {} in destroyWindow", PWINDOW);
         SubsurfaceTree::destroySurfaceTree(PWINDOW->m_pSurfaceTree);
         PWINDOW->m_pSurfaceTree = nullptr;
     }
@@ -795,7 +793,7 @@ void Events::listener_destroyWindow(void* owner, void* data) {
 
     if (!PWINDOW->m_bFadingOut) {
         g_pCompositor->removeWindowFromVectorSafe(PWINDOW); // most likely X11 unmanaged or sumn
-        Debug::log(LOG, "Unmapped window {:x} removed instantly", (uintptr_t)PWINDOW);
+        Debug::log(LOG, "Unmapped {} removed instantly", PWINDOW);
     }
 }
 
@@ -819,7 +817,7 @@ void Events::listener_setTitleWindow(void* owner, void* data) {
     g_pCompositor->updateWindowAnimatedDecorationValues(PWINDOW);
     PWINDOW->updateToplevel();
 
-    Debug::log(LOG, "Window {:x} set title to {}", (uintptr_t)PWINDOW, PWINDOW->m_szTitle);
+    Debug::log(LOG, "Window {:x} set title to {}", PWINDOW, PWINDOW->m_szTitle);
 }
 
 void Events::listener_fullscreenWindow(void* owner, void* data) {
@@ -878,7 +876,7 @@ void Events::listener_fullscreenWindow(void* owner, void* data) {
 
     PWINDOW->updateToplevel();
 
-    Debug::log(LOG, "Window {:x} fullscreen to {}", (uintptr_t)PWINDOW, PWINDOW->m_bIsFullscreen);
+    Debug::log(LOG, "{} fullscreen to {}", PWINDOW, PWINDOW->m_bIsFullscreen);
 }
 
 void Events::listener_activateXDG(wl_listener* listener, void* data) {
@@ -916,11 +914,11 @@ void Events::listener_activateX11(void* owner, void* data) {
 
     static auto* const PFOCUSONACTIVATE = &g_pConfigManager->getConfigValuePtr("misc:focus_on_activate")->intValue;
 
-    Debug::log(LOG, "X11 Activate request for window {:x}", (uintptr_t)PWINDOW);
+    Debug::log(LOG, "X11 Activate request for window {}", PWINDOW);
 
     if (PWINDOW->m_iX11Type == 2) {
 
-        Debug::log(LOG, "Unmanaged X11 {:x} requests activate", (uintptr_t)PWINDOW);
+        Debug::log(LOG, "Unmanaged X11 {} requests activate", PWINDOW);
 
         if (g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->getPID() != PWINDOW->getPID())
             return;
@@ -1025,8 +1023,8 @@ void Events::listener_unmanagedSetGeometry(void* owner, void* data) {
 
     if (abs(std::floor(POS.x) - LOGICALPOS.x) > 2 || abs(std::floor(POS.y) - LOGICALPOS.y) > 2 || abs(std::floor(SIZ.x) - PWINDOW->m_uSurface.xwayland->width) > 2 ||
         abs(std::floor(SIZ.y) - PWINDOW->m_uSurface.xwayland->height) > 2) {
-        Debug::log(LOG, "Unmanaged window {:x} requests geometry update to {} {} {} {}", (uintptr_t)PWINDOW, (int)LOGICALPOS.x, (int)LOGICALPOS.y,
-                   (int)PWINDOW->m_uSurface.xwayland->width, (int)PWINDOW->m_uSurface.xwayland->height);
+        Debug::log(LOG, "Unmanaged window {} requests geometry update to {:j} {} {}", PWINDOW, LOGICALPOS, (int)PWINDOW->m_uSurface.xwayland->width,
+                   (int)PWINDOW->m_uSurface.xwayland->height);
 
         g_pHyprRenderer->damageWindow(PWINDOW);
         PWINDOW->m_vRealPosition.setValueAndWarp(Vector2D(LOGICALPOS.x, LOGICALPOS.y));
@@ -1119,7 +1117,7 @@ void Events::listener_requestMaximize(void* owner, void* data) {
     if (PWINDOW->m_bNoMaximizeRequest)
         return;
 
-    Debug::log(LOG, "Maximize request for {:x}", (uintptr_t)PWINDOW);
+    Debug::log(LOG, "Maximize request for {}", PWINDOW);
     if (!PWINDOW->m_bIsX11) {
         const auto EV = (wlr_foreign_toplevel_handle_v1_maximized_event*)data;
 
@@ -1138,7 +1136,7 @@ void Events::listener_requestMaximize(void* owner, void* data) {
 void Events::listener_requestMinimize(void* owner, void* data) {
     const auto PWINDOW = (CWindow*)owner;
 
-    Debug::log(LOG, "Minimize request for {:x}", (uintptr_t)PWINDOW);
+    Debug::log(LOG, "Minimize request for {}", PWINDOW);
 
     if (PWINDOW->m_bIsX11) {
         if (!PWINDOW->m_bMappedX11 || PWINDOW->m_iX11Type != 1)

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -134,8 +134,7 @@ void CMonitor::onConnect(bool noRule) {
 
     wlr_xcursor_manager_load(g_pCompositor->m_sWLRXCursorMgr, scale);
 
-    Debug::log(LOG, "Added new monitor with name {} at {},{} with size {}x{}, pointer {:x}", output->name, (int)vecPosition.x, (int)vecPosition.y, (int)vecPixelSize.x,
-               (int)vecPixelSize.y, (uintptr_t)output);
+    Debug::log(LOG, "Added new monitor with name {} at {:j0} with size {:j0}, pointer {:x}", output->name, vecPosition, vecPixelSize, (uintptr_t)output);
 
     setupDefaultWS(monitorRule);
 

--- a/src/helpers/SubsurfaceTree.cpp
+++ b/src/helpers/SubsurfaceTree.cpp
@@ -55,7 +55,7 @@ SSurfaceTreeNode* createSubsurfaceNode(SSurfaceTreeNode* pParent, SSubsurface* p
     PNODE->pParent     = pParent;
     PNODE->pSubsurface = pSubsurface;
 
-    Debug::log(LOG, "Creating a subsurface Node! (pWindow: {:x})", (uintptr_t)pWindow);
+    Debug::log(LOG, "Creating a subsurface Node! {}", pWindow);
 
     return PNODE;
 }
@@ -63,7 +63,7 @@ SSurfaceTreeNode* createSubsurfaceNode(SSurfaceTreeNode* pParent, SSubsurface* p
 SSurfaceTreeNode* SubsurfaceTree::createTreeRoot(wlr_surface* pSurface, applyGlobalOffsetFn fn, void* data, CWindow* pWindow) {
     const auto PNODE = createTree(pSurface, pWindow);
 
-    Debug::log(LOG, "Creating a surfaceTree Root! (pWindow: {:x})", (uintptr_t)pWindow);
+    Debug::log(LOG, "Creating a surfaceTree Root! {}", pWindow);
 
     PNODE->offsetfn         = fn;
     PNODE->globalOffsetData = data;
@@ -221,7 +221,7 @@ void Events::listener_commitSubsurface(void* owner, void* data) {
     if (!g_pHyprRenderer->shouldRenderWindow(pNode->pWindowOwner)) {
         static auto* const PLOGDAMAGE = &g_pConfigManager->getConfigValuePtr("debug:log_damage")->intValue;
         if (*PLOGDAMAGE)
-            Debug::log(LOG, "Refusing to commit damage from {:x} because it's invisible.", (uintptr_t)pNode->pWindowOwner);
+            Debug::log(LOG, "Refusing to commit damage from {} because it's invisible.", pNode->pWindowOwner);
         return;
     }
 

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -1,4 +1,5 @@
 #include "DwindleLayout.hpp"
+#include "../render/decorations/CHyprGroupBarDecoration.hpp"
 #include "../Compositor.hpp"
 
 void SDwindleNodeData::recalcSizePosRecursive(bool force, bool horizontalOverride, bool verticalOverride) {
@@ -104,7 +105,7 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
     }
 
     if (!PMONITOR) {
-        Debug::log(ERR, "Orphaned Node {:x} (workspace ID: {})!!", (uintptr_t)pNode, pNode->workspaceID);
+        Debug::log(ERR, "Orphaned Node {}!!", pNode);
         return;
     }
 
@@ -129,7 +130,7 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
     auto               gapsOut = WORKSPACERULE.gapsOut.value_or(*PGAPSOUT);
 
     if (!g_pCompositor->windowExists(PWINDOW) || !PWINDOW->m_bIsMapped) {
-        Debug::log(ERR, "Node {:x} holding invalid window {:x}!!", (uintptr_t)pNode, (uintptr_t)PWINDOW);
+        Debug::log(ERR, "Node {} holding invalid {}!!", pNode, PWINDOW);
         onWindowRemovedTiling(PWINDOW);
         return;
     }
@@ -273,7 +274,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection dire
     } else
         OPENINGON = getFirstNodeOnWorkspace(pWindow->m_iWorkspaceID);
 
-    Debug::log(LOG, "OPENINGON: {:x}, Workspace: {}, Monitor: {}", (uintptr_t)OPENINGON, PNODE->workspaceID, PMONITOR->ID);
+    Debug::log(LOG, "OPENINGON: {}, Monitor: {}", OPENINGON, PMONITOR->ID);
 
     if (OPENINGON && OPENINGON->workspaceID != PNODE->workspaceID) {
         // special workspace handling

--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
 #include "IHyprLayout.hpp"
+
 #include <list>
 #include <deque>
-#include "../render/decorations/CHyprGroupBarDecoration.hpp"
 #include <array>
 #include <optional>
+#include <format>
 
 class CHyprDwindleLayout;
 enum eFullscreenMode : uint8_t;
@@ -84,4 +85,18 @@ class CHyprDwindleLayout : public IHyprLayout {
     eDirection              overrideDirection = DIRECTION_DEFAULT;
 
     friend struct SDwindleNodeData;
+};
+
+template <typename CharT>
+struct std::formatter<SDwindleNodeData*, CharT> : std::formatter<CharT> {
+    template <typename FormatContext>
+    auto format(const SDwindleNodeData* const& node, FormatContext& ctx) const {
+        auto out = ctx.out();
+        if (!node)
+            return std::format_to(out, "[Node nullptr]");
+        std::format_to(out, "[Node {:x}: workspace: {}, pos: {:j2}, size: {:j2}", (uintptr_t)node, node->workspaceID, node->position, node->size);
+        if (!node->isNode && node->pWindow)
+            std::format_to(out, ", window: {:x}", node->pWindow);
+        return std::format_to(out, "]");
+    }
 };

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -89,7 +89,7 @@ void IHyprLayout::onWindowCreatedFloating(CWindow* pWindow) {
     static auto* const PXWLFORCESCALEZERO = &g_pConfigManager->getConfigValuePtr("xwayland:force_zero_scaling")->intValue;
 
     if (!PMONITOR) {
-        Debug::log(ERR, "Window {:x} ({}) has an invalid monitor in onWindowCreatedFloating!!!", (uintptr_t)pWindow, pWindow->m_szTitle);
+        Debug::log(ERR, "{:m} has an invalid monitor in onWindowCreatedFloating!!!", pWindow);
         return;
     }
 

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -1,5 +1,6 @@
 #include "MasterLayout.hpp"
 #include "../Compositor.hpp"
+#include "../render/decorations/CHyprGroupBarDecoration.hpp"
 #include <ranges>
 
 SMasterNodeData* CHyprMasterLayout::getNodeFromWindow(CWindow* pWindow) {
@@ -552,7 +553,7 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
     }
 
     if (!PMONITOR) {
-        Debug::log(ERR, "Orphaned Node {:x} (workspace ID: {})!!", (uintptr_t)pNode, pNode->workspaceID);
+        Debug::log(ERR, "Orphaned Node {}!!", pNode);
         return;
     }
 
@@ -578,7 +579,7 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
     auto               gapsOut = WORKSPACERULE.gapsOut.value_or(*PGAPSOUT);
 
     if (!g_pCompositor->windowValidMapped(PWINDOW)) {
-        Debug::log(ERR, "Node {:x} holding invalid window {:x}!!", (uintptr_t)pNode, (uintptr_t)PWINDOW);
+        Debug::log(ERR, "Node {} holding invalid {}!!", pNode, PWINDOW);
         return;
     }
 

--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -10,8 +10,7 @@
 enum eFullscreenMode : uint8_t;
 
 //orientation determines which side of the screen the master area resides
-enum eOrientation : uint8_t
-{
+enum eOrientation : uint8_t {
     ORIENTATION_LEFT = 0,
     ORIENTATION_TOP,
     ORIENTATION_RIGHT,
@@ -33,7 +32,7 @@ struct SMasterNodeData {
     int      workspaceID = -1;
 
     bool     operator==(const SMasterNodeData& rhs) const {
-            return pWindow == rhs.pWindow;
+        return pWindow == rhs.pWindow;
     }
 };
 
@@ -42,7 +41,7 @@ struct SMasterWorkspaceData {
     eOrientation orientation = ORIENTATION_LEFT;
 
     bool         operator==(const SMasterWorkspaceData& rhs) const {
-                return workspaceID == rhs.workspaceID;
+        return workspaceID == rhs.workspaceID;
     }
 };
 
@@ -88,4 +87,20 @@ class CHyprMasterLayout : public IHyprLayout {
 
     friend struct SMasterNodeData;
     friend struct SMasterWorkspaceData;
+};
+
+template <typename CharT>
+struct std::formatter<SMasterNodeData*, CharT> : std::formatter<CharT> {
+    template <typename FormatContext>
+    auto format(const SMasterNodeData* const& node, FormatContext& ctx) const {
+        auto out = ctx.out();
+        if (!node)
+            return std::format_to(out, "[Node nullptr]");
+        std::format_to(out, "[Node {:x}: workspace: {}, pos: {:j2}, size: {:j2}", (uintptr_t)node, node->workspaceID, node->position, node->size);
+        if (node->isMaster)
+            std::format_to(out, ", master");
+        if (node->pWindow)
+            std::format_to(out, ", window: {:x}", node->pWindow);
+        return std::format_to(out, "]");
+    }
 };

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "helpers/MiscFunctions.hpp"
-#include "debug/Log.hpp"
 #include <cmath>
 #include <csignal>
 #include <utility>
@@ -65,6 +63,32 @@
     }
 
 #define ASSERT(expr) RASSERT(expr, "?")
+
+// absolutely ridiculous formatter spec parsing
+#define FORMAT_PARSE(specs__, type__)                                                                                                                                              \
+    template <typename FormatContext>                                                                                                                                              \
+    constexpr auto parse(FormatContext& ctx) {                                                                                                                                     \
+        auto it = ctx.begin();                                                                                                                                                     \
+        for (; it != ctx.end() && *it != '}'; it++) {                                                                                                                              \
+            switch (*it) { specs__ default : throw std::format_error("invalid format specification"); }                                                                            \
+        }                                                                                                                                                                          \
+        return it;                                                                                                                                                                 \
+    }
+
+#define FORMAT_FLAG(spec__, flag__)                                                                                                                                                \
+    case spec__: (flag__) = true; break;
+
+#define FORMAT_NUMBER(buf__)                                                                                                                                                       \
+    case '0':                                                                                                                                                                      \
+    case '1':                                                                                                                                                                      \
+    case '2':                                                                                                                                                                      \
+    case '3':                                                                                                                                                                      \
+    case '4':                                                                                                                                                                      \
+    case '5':                                                                                                                                                                      \
+    case '6':                                                                                                                                                                      \
+    case '7':                                                                                                                                                                      \
+    case '8':                                                                                                                                                                      \
+    case '9': (buf__).push_back(*it); break;
 
 #if ISDEBUG
 #define UNREACHABLE()                                                                                                                                                              \

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1,4 +1,5 @@
 #include "KeybindManager.hpp"
+#include "../render/decorations/CHyprGroupBarDecoration.hpp"
 
 #include <regex>
 

--- a/src/managers/XWaylandManager.hpp
+++ b/src/managers/XWaylandManager.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
 #include "../defines.hpp"
-#include "../Window.hpp"
 #include <optional>
+
+class CWindow; // because clangd
 
 class CHyprXWaylandManager {
   public:

--- a/src/managers/input/IdleInhibitor.cpp
+++ b/src/managers/input/IdleInhibitor.cpp
@@ -33,7 +33,7 @@ void CInputManager::newIdleInhibitor(wlr_idle_inhibitor_v1* pInhibitor) {
     PINHIBIT->pWindow = g_pCompositor->getWindowFromSurface(pInhibitor->surface);
 
     if (PINHIBIT->pWindow)
-        Debug::log(LOG, "IdleInhibitor got window {:x} ({})", (uintptr_t)PINHIBIT->pWindow, PINHIBIT->pWindow->m_szTitle);
+        Debug::log(LOG, "IdleInhibitor got window {}", PINHIBIT->pWindow);
 
     recheckIdleInhibitorStatus();
 }

--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -149,14 +149,14 @@ void CToplevelExportProtocolManager::captureToplevel(wl_client* client, wl_resou
     PFRAME->pWindow       = pWindow;
 
     if (!PFRAME->pWindow) {
-        Debug::log(ERR, "Client requested sharing of window handle {:x} which does not exist!", (uintptr_t)PFRAME->pWindow);
+        Debug::log(ERR, "Client requested sharing of window handle {:x} which does not exist!", PFRAME->pWindow);
         hyprland_toplevel_export_frame_v1_send_failed(PFRAME->resource);
         removeFrame(PFRAME);
         return;
     }
 
     if (!PFRAME->pWindow->m_bIsMapped || PFRAME->pWindow->isHidden()) {
-        Debug::log(ERR, "Client requested sharing of window handle {:x} which is not shareable!", (uintptr_t)PFRAME->pWindow);
+        Debug::log(ERR, "Client requested sharing of window handle {:x} which is not shareable!", PFRAME->pWindow);
         hyprland_toplevel_export_frame_v1_send_failed(PFRAME->resource);
         removeFrame(PFRAME);
         return;
@@ -223,7 +223,7 @@ void CToplevelExportProtocolManager::copyFrame(wl_client* client, wl_resource* r
     }
 
     if (!PFRAME->pWindow->m_bIsMapped || PFRAME->pWindow->isHidden()) {
-        Debug::log(ERR, "Client requested sharing of window handle {:x} which is not shareable (2)!", (uintptr_t)PFRAME->pWindow);
+        Debug::log(ERR, "Client requested sharing of window handle {:x} which is not shareable (2)!", PFRAME->pWindow);
         hyprland_toplevel_export_frame_v1_send_failed(PFRAME->resource);
         removeFrame(PFRAME);
         return;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1111,7 +1111,7 @@ void CHyprRenderer::setWindowScanoutMode(CWindow* pWindow) {
 
     if (!pWindow->m_bIsFullscreen) {
         wlr_linux_dmabuf_v1_set_surface_feedback(g_pCompositor->m_sWLRLinuxDMABuf, pWindow->m_pWLSurface.wlr(), nullptr);
-        Debug::log(LOG, "Scanout mode OFF set for {:x}", (uintptr_t)pWindow);
+        Debug::log(LOG, "Scanout mode OFF set for {}", pWindow);
         return;
     }
 
@@ -1130,7 +1130,7 @@ void CHyprRenderer::setWindowScanoutMode(CWindow* pWindow) {
     wlr_linux_dmabuf_v1_set_surface_feedback(g_pCompositor->m_sWLRLinuxDMABuf, pWindow->m_pWLSurface.wlr(), &feedback);
     wlr_linux_dmabuf_feedback_v1_finish(&feedback);
 
-    Debug::log(LOG, "Scanout mode ON set for {:x}", (uintptr_t)pWindow);
+    Debug::log(LOG, "Scanout mode ON set for {}", pWindow);
 }
 
 void CHyprRenderer::outputMgrApplyTest(wlr_output_configuration_v1* config, bool test) {
@@ -1365,8 +1365,7 @@ void CHyprRenderer::arrangeLayersForMonitor(const int& monitor) {
 
     g_pLayoutManager->getCurrentLayout()->recalculateMonitor(monitor);
 
-    Debug::log(LOG, "Monitor {} layers arranged: reserved: {:.5f} {:.5f} {:.5f} {:.5f}", PMONITOR->szName, PMONITOR->vecReservedTopLeft.x, PMONITOR->vecReservedTopLeft.y,
-               PMONITOR->vecReservedBottomRight.x, PMONITOR->vecReservedBottomRight.y);
+    Debug::log(LOG, "Monitor {} layers arranged: reserved: {:5j} {:5j}", PMONITOR->szName, PMONITOR->vecReservedTopLeft, PMONITOR->vecReservedBottomRight);
 }
 
 void CHyprRenderer::damageSurface(wlr_surface* pSurface, double x, double y, double scale) {
@@ -1583,13 +1582,12 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
                     wlr_output_set_mode(pMonitor->output, mode);
 
                     if (!wlr_output_test(pMonitor->output)) {
-                        Debug::log(LOG, "Monitor {}: REJECTED available mode: {}x{}@{:2f}!", pMonitor->output->name, (int)pMonitorRule->resolution.x,
-                                   (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate, mode->width, mode->height, mode->refresh / 1000.f);
+                        Debug::log(LOG, "Monitor {}: REJECTED available mode: {}x{}@{:2f}!", pMonitor->output->name, mode->width, mode->height, mode->refresh / 1000.f);
                         continue;
                     }
 
-                    Debug::log(LOG, "Monitor {}: requested {}x{}@{:2f}, found available mode: {}x{}@{}mHz, applying.", pMonitor->output->name, (int)pMonitorRule->resolution.x,
-                               (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate, mode->width, mode->height, mode->refresh);
+                    Debug::log(LOG, "Monitor {}: requested {:X0}@{:2f}, found available mode: {}x{}@{}mHz, applying.", pMonitor->output->name, pMonitorRule->resolution,
+                               (float)pMonitorRule->refreshRate, mode->width, mode->height, mode->refresh);
 
                     found = true;
 
@@ -1611,23 +1609,21 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
                     const auto PREFERREDMODE = wlr_output_preferred_mode(pMonitor->output);
 
                     if (!PREFERREDMODE) {
-                        Debug::log(ERR, "Monitor {} has NO PREFERRED MODE, and an INVALID one was requested: {}x{}@{:2f}", pMonitor->ID, (int)pMonitorRule->resolution.x,
-                                   (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate);
+                        Debug::log(ERR, "Monitor {} has NO PREFERRED MODE, and an INVALID one was requested: {:X0}@{:2f}", pMonitor->ID, pMonitorRule->resolution,
+                                   (float)pMonitorRule->refreshRate);
                         return true;
                     }
 
                     // Preferred is valid
                     wlr_output_set_mode(pMonitor->output, PREFERREDMODE);
 
-                    Debug::log(ERR, "Monitor {} got an invalid requested mode: {}x{}@{:2f}, using the preferred one instead: {}x{}@{:2f}", pMonitor->output->name,
-                               (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate, PREFERREDMODE->width, PREFERREDMODE->height,
-                               PREFERREDMODE->refresh / 1000.f);
+                    Debug::log(ERR, "Monitor {} got an invalid requested mode: {:X0}@{:2f}, using the preferred one instead: {}x{}@{:2f}", pMonitor->output->name,
+                               pMonitorRule->resolution, (float)pMonitorRule->refreshRate, PREFERREDMODE->width, PREFERREDMODE->height, PREFERREDMODE->refresh / 1000.f);
 
                     pMonitor->refreshRate = PREFERREDMODE->refresh / 1000.f;
                     pMonitor->vecSize     = Vector2D(PREFERREDMODE->width, PREFERREDMODE->height);
                 } else {
-                    Debug::log(LOG, "Set a custom mode {}x{}@{:2f} (mode not found in monitor modes)", (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y,
-                               (float)pMonitorRule->refreshRate);
+                    Debug::log(LOG, "Set a custom mode {:X0}@{:2f} (mode not found in monitor modes)", pMonitorRule->resolution, (float)pMonitorRule->refreshRate);
                 }
             }
         } else {
@@ -1661,24 +1657,22 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
                 const auto PREFERREDMODE = wlr_output_preferred_mode(pMonitor->output);
 
                 if (!PREFERREDMODE) {
-                    Debug::log(ERR, "Monitor {} has NO PREFERRED MODE, and an INVALID one was requested: {}x{}@{:2f}", pMonitor->output->name, (int)pMonitorRule->resolution.x,
-                               (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate);
+                    Debug::log(ERR, "Monitor {} has NO PREFERRED MODE, and an INVALID one was requested: {:X0}@{:2f}", pMonitor->output->name, pMonitorRule->resolution,
+                               (float)pMonitorRule->refreshRate);
                     return true;
                 }
 
                 // Preferred is valid
                 wlr_output_set_mode(pMonitor->output, PREFERREDMODE);
 
-                Debug::log(ERR, "Monitor {} got an invalid requested mode: {}x{}@{:2f}, using the preferred one instead: {}x{}@{:2f}", pMonitor->output->name,
-                           (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate, PREFERREDMODE->width, PREFERREDMODE->height,
-                           PREFERREDMODE->refresh / 1000.f);
+                Debug::log(ERR, "Monitor {} got an invalid requested mode: {:X0}@{:2f}, using the preferred one instead: {}x{}@{:2f}", pMonitor->output->name,
+                           pMonitorRule->resolution, (float)pMonitorRule->refreshRate, PREFERREDMODE->width, PREFERREDMODE->height, PREFERREDMODE->refresh / 1000.f);
 
                 pMonitor->refreshRate   = PREFERREDMODE->refresh / 1000.f;
                 pMonitor->vecSize       = Vector2D(PREFERREDMODE->width, PREFERREDMODE->height);
                 pMonitor->customDrmMode = {};
             } else {
-                Debug::log(LOG, "Set a custom mode {}x{}@{:2f} (mode not found in monitor modes)", (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y,
-                           (float)pMonitorRule->refreshRate);
+                Debug::log(LOG, "Set a custom mode {:X0}@{:2f} (mode not found in monitor modes)", pMonitorRule->resolution, (float)pMonitorRule->refreshRate);
             }
         }
     } else if (pMonitorRule->resolution != Vector2D()) {
@@ -1718,30 +1712,28 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
             }
 
             if (!success) {
-                Debug::log(LOG, "Monitor {}: REJECTED mode: {}x{}@{:2f}! Falling back to preferred.", pMonitor->output->name, (int)pMonitorRule->resolution.x,
-                           (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate, mode->width, mode->height, mode->refresh / 1000.f);
+                Debug::log(LOG, "Monitor {}: REJECTED mode: {:X0}@{:2f}! Falling back to preferred: {}x{}@{:2f}", pMonitor->output->name, pMonitorRule->resolution,
+                           (float)pMonitorRule->refreshRate, mode->width, mode->height, mode->refresh / 1000.f);
 
                 const auto PREFERREDMODE = wlr_output_preferred_mode(pMonitor->output);
 
                 if (!PREFERREDMODE) {
-                    Debug::log(ERR, "Monitor {} has NO PREFERRED MODE, and an INVALID one was requested: {}x{}@{:2f}", pMonitor->ID, (int)pMonitorRule->resolution.x,
-                               (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate);
+                    Debug::log(ERR, "Monitor {} has NO PREFERRED MODE, and an INVALID one was requested: {:X0}@{:2f}", pMonitor->ID, pMonitorRule->resolution,
+                               (float)pMonitorRule->refreshRate);
                     return true;
                 }
 
                 // Preferred is valid
                 wlr_output_set_mode(pMonitor->output, PREFERREDMODE);
 
-                Debug::log(ERR, "Monitor {} got an invalid requested mode: {}x{}@{:2f}, using the preferred one instead: {}x{}@{:2f}", pMonitor->output->name,
-                           (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate, PREFERREDMODE->width, PREFERREDMODE->height,
-                           PREFERREDMODE->refresh / 1000.f);
+                Debug::log(ERR, "Monitor {} got an invalid requested mode: {:X0}@{:2f}, using the preferred one instead: {}x{}@{:2f}", pMonitor->output->name,
+                           pMonitorRule->resolution, (float)pMonitorRule->refreshRate, PREFERREDMODE->width, PREFERREDMODE->height, PREFERREDMODE->refresh / 1000.f);
 
                 pMonitor->refreshRate = PREFERREDMODE->refresh / 1000.f;
                 pMonitor->vecSize     = Vector2D(PREFERREDMODE->width, PREFERREDMODE->height);
             } else {
 
-                Debug::log(LOG, "Monitor {}: Applying highest mode {}x{}@{:2f}.", pMonitor->output->name, (int)currentWidth, (int)currentHeight, (int)currentRefresh / 1000.f,
-                           mode->width, mode->height, mode->refresh / 1000.f);
+                Debug::log(LOG, "Monitor {}: Applying highest mode {}x{}@{:2f}.", pMonitor->output->name, (int)currentWidth, (int)currentHeight, (int)currentRefresh / 1000.f);
 
                 pMonitor->refreshRate = currentRefresh / 1000.f;
                 pMonitor->vecSize     = Vector2D(currentWidth, currentHeight);
@@ -1751,7 +1743,7 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
         const auto PREFERREDMODE = wlr_output_preferred_mode(pMonitor->output);
 
         if (!PREFERREDMODE) {
-            Debug::log(ERR, "Monitor {} has NO PREFERRED MODE", (int)pMonitorRule->resolution.x, (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate);
+            Debug::log(ERR, "Monitor {} has NO PREFERRED MODE", pMonitor->output->name);
 
             if (!wl_list_empty(&pMonitor->output->modes)) {
                 wlr_output_mode* mode;
@@ -1760,13 +1752,12 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
                     wlr_output_set_mode(pMonitor->output, mode);
 
                     if (!wlr_output_test(pMonitor->output)) {
-                        Debug::log(LOG, "Monitor {}: REJECTED available mode: {}x{}@{:2f}!", pMonitor->output->name, (int)pMonitorRule->resolution.x,
-                                   (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate, mode->width, mode->height, mode->refresh / 1000.f);
+                        Debug::log(LOG, "Monitor {}: REJECTED available mode: {}x{}@{:2f}!", pMonitor->output->name, mode->width, mode->height, mode->refresh / 1000.f);
                         continue;
                     }
 
-                    Debug::log(LOG, "Monitor {}: requested {}x{}@{:2f}, found available mode: {}x{}@{}mHz, applying.", pMonitor->output->name, (int)pMonitorRule->resolution.x,
-                               (int)pMonitorRule->resolution.y, (float)pMonitorRule->refreshRate, mode->width, mode->height, mode->refresh);
+                    Debug::log(LOG, "Monitor {}: requested {:X0}@{:2f}, found available mode: {}x{}@{}mHz, applying.", pMonitor->output->name, pMonitorRule->resolution,
+                               (float)pMonitorRule->refreshRate, mode->width, mode->height, mode->refresh);
 
                     pMonitor->refreshRate = mode->refresh / 1000.f;
                     pMonitor->vecSize     = Vector2D(mode->width, mode->height);
@@ -1848,9 +1839,8 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
     // reload to fix mirrors
     g_pConfigManager->m_bWantsMonitorReload = true;
 
-    Debug::log(LOG, "Monitor {} data dump: res {}x{}@{:.2f}Hz, scale {:.2f}, transform {}, pos {}x{}, 10b {}", pMonitor->szName, (int)pMonitor->vecPixelSize.x,
-               (int)pMonitor->vecPixelSize.y, pMonitor->refreshRate, pMonitor->scale, (int)pMonitor->transform, (int)pMonitor->vecPosition.x, (int)pMonitor->vecPosition.y,
-               (int)pMonitor->enabled10bit);
+    Debug::log(LOG, "Monitor {} data dump: res {:X}@{:.2f}Hz, scale {:.2f}, transform {}, pos {:X}, 10b {}", pMonitor->szName, pMonitor->vecPixelSize, pMonitor->refreshRate,
+               pMonitor->scale, (int)pMonitor->transform, pMonitor->vecPosition, (int)pMonitor->enabled10bit);
 
     EMIT_HOOK_EVENT("monitorLayoutChanged", nullptr);
 


### PR DESCRIPTION
Implemented formatters for  Vector2D, CWindow*, SDwindleNodeData*, and SMasterNodeData*.

documented as comments.