### PR TITLE
Add a fit-for-purpose code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,182 @@
+## Goal
+
+Our goal is to provide a space where it is safe for everyone to contribute to,
+and get support for, open-source software in a respectful and cooperative
+manner.
+
+We value all contributions and want to make this organization and its
+surrounding community a place for everyone.
+
+As members, contributors, and everyone else who may participate in the
+development, we strive to keep the entire experience civil.
+
+## Standards
+
+Our community standards exist in order to make sure everyone feels comfortable
+contributing to the project(s) together.
+
+1. **Anti-Discrimination:** Uphold a zero-tolerance stance against discrimination. Do not engage in any form of harassment, discrimination, or mistreatment based on protected traits, including but not limited to sex, religion, race, appearance, gender, identity, nationality, sexuality, disability, socioeconomic status, immigration status, age, or political affiliation.
+
+2. **Intersectional Equity:** Embrace intersectionality by acknowledging the intersections of identity and experience. Recognize that individuals may face multiple forms of discrimination simultaneously, such as those related to race, gender, sexuality, disability, and socioeconomic background. Be mindful of the unique challenges they encounter.
+
+3. **Cultural Sensitivity:** Show profound respect for diverse cultural backgrounds and experiences. Avoid cultural appropriation, stereotypes, or insensitive comments. Foster an environment that celebrates cultural diversity and promotes cross-cultural understanding.
+
+4. **Gender-Inclusive Language:** Utilize gender-inclusive language and respect individuals' preferred pronouns. This practice reflects the principles of queer theory, which challenge normative views of identity and sexuality while promoting inclusivity and recognition of the full spectrum of gender identities.
+
+5. **Amplify Marginalized Voices:** Actively seek to amplify the voices of marginalized and underrepresented contributors. Acknowledge the historic and systemic silencing of these voices and work to counteract it. Support initiatives that promote diversity and inclusion within our community.
+
+6. **Deconstructive Discourse:** Embrace deconstructive dialogue that dismantles oppressive structures through critical analysis. Challenge conventional language norms and foster discussions that question the inherent biases within language itself. Engage in thoughtful and introspective conversations that deconstruct power imbalances.
+
+7. **Narrative Disruption:** Encourage narrative disruption, which questions dominant narratives and perspectives. Promote alternative narratives that challenge established power structures. Engage in critical examinations of history, discourse, and representation to create space for diverse voices and counter hegemonic narratives.
+
+8. **Heteroglossic Engagement:** Embrace heteroglossic engagement, acknowledging the multiplicity of voices and perspectives within our community. This notion, inspired by Mikhail Bakhtin's heteroglossia, values the rich tapestry of experiences and viewpoints. Encourage dialogues that respect and celebrate the plurality of voices within our community, fostering a dynamic and inclusive environment.
+
+9. **Accessibility and Accommodation:** Commit to making our community accessible to all individuals, including those with disabilities. Ensure that digital content and communication platforms are accessible, and be open to accommodating specific needs to ensure everyone can fully participate.
+
+10. **Economic Justice:** Acknowledge the importance of economic justice in our community. Recognize and address economic disparities that may exist, and strive to create opportunities for all members, regardless of socioeconomic status, to engage and benefit from our community.
+
+11. **Environmental Responsibility:** Promote environmental responsibility by considering the environmental impact of our activities. Encourage sustainable practices and engage in discussions about the intersection of environmental justice and our work.
+
+12. **Digital Privacy:** Respect the digital privacy and security of all community members. Avoid sharing personal information without consent, and be vigilant about protecting sensitive data within our digital spaces.
+
+13. **Ethical Collaboration:** Prioritize ethical collaboration within our community. Promote transparency, honesty, and integrity in all interactions. Encourage open communication and constructive feedback to build trust and maintain ethical standards.
+
+14. **Educational Empowerment:** Recognize the power of education as a tool for empowerment. Encourage and support educational initiatives within our community, fostering an environment where members can learn, grow, and share knowledge freely.
+
+15. **Restorative Justice:** Embrace restorative justice principles to address conflicts and disputes within the community. Strive for resolutions that prioritize healing, understanding, and reconciliation, rather than punitive measures.
+
+16. **Scientific Rigor:** Maintain scientific rigor and intellectual honesty in discussions related to research or technical topics. Encourage evidence-based reasoning, critical thinking, and the responsible use of data.
+
+17. **Anti-Colonial Practices:** Be conscious of and challenge colonial legacies, especially within the context of knowledge production and resource allocation. Promote anti-colonial practices that respect indigenous knowledge, land, and rights.
+
+18. **Solidarity and Allyship:** Promote solidarity and allyship with marginalized and oppressed communities both within and outside our community. Actively engage in supporting social justice movements and initiatives that align with our values.
+
+19. **Decolonized Resource Allocation:** Ensure that resources and opportunities within the community are allocated in a manner that addresses historical imbalances and supports marginalized individuals and initiatives.
+
+20. **Conflict Resolution Skills:** Develop and encourage conflict resolution skills within the community. Equip members with tools for addressing disagreements constructively and fostering a culture of understanding and cooperation.
+
+21. **Historical Context:** Recognize and acknowledge the historical context in which our community operates. Understand the broader societal, cultural, and political factors that shape our work and interactions.
+
+22. **Community Accountability:** Foster a culture of community accountability, where individuals and the community as a whole are responsible for upholding these standards. Encourage open dialogue about accountability and improvement.
+
+23. **Continuous Learning:** Commit to ongoing learning and self-reflection. Embrace the idea that knowledge and understanding evolve, and be open to revisiting and revising our standards in light of new insights and perspectives.
+
+24. **Holistic Well-being:** Prioritize the holistic well-being of community members. Recognize that well-being encompasses mental, emotional, physical, and social dimensions, and support initiatives that promote health and balance.
+
+Examples of breaking each rule respectively include:
+
+1. **Anti-Discrimination:** A message that harasses or mocks someone based on their religion, making derogatory comments about their beliefs or practices.
+
+2. **Intersectional Equity:** A message that dismisses or belittles the experiences of an individual who identifies as both a racial minority and part of the LGBTQ+ community, implying that their experiences are not valid.
+
+3. **Cultural Sensitivity:** A message that makes fun of or perpetuates stereotypes about a specific cultural group, such as using caricatures or offensive jokes.
+
+4. **Gender-Inclusive Language:** A message that intentionally misgenders someone or refuses to use their preferred pronouns, despite being aware of their identity.
+
+5. **Amplify Marginalized Voices:** A message that consistently ignores or talks over contributions from members of historically marginalized groups, suppressing their voices within the community.
+
+6. **Deconstructive Discourse:** A message that dismisses critical analysis and constructive criticism, opting for personal attacks or derogatory language instead.
+
+7. **Narrative Disruption:** A message that insists on maintaining a dominant narrative without considering alternative perspectives or acknowledging the impact of that narrative on marginalized groups.
+
+8. **Heteroglossic Engagement:** A message that tries to silence or discredit voices within the community that hold different viewpoints or experiences, rather than engaging in respectful dialogue.
+
+9. **Accessibility and Accommodation:** A message that refuses to make accommodations for individuals with disabilities, such as not providing text alternatives for images or dismissing requests for accessibility features.
+
+10. **Economic Justice:** A message that belittles or marginalizes members who come from lower socioeconomic backgrounds, implying that their contributions or perspectives are less valuable.
+
+11. **Environmental Responsibility:** A message that ignores environmental concerns or makes jokes about environmental issues, undermining the importance of sustainability.
+
+12. **Digital Privacy:** A message that shares another member's personal information without their consent, violating their privacy.
+
+13. **Ethical Collaboration:** A message that engages in dishonest or manipulative behavior, such as spreading false information or attempting to deceive other community members.
+
+14. **Educational Empowerment:** A message that ridicules or belittles someone for asking questions or seeking to learn, creating a hostile learning environment.
+
+15. **Restorative Justice:** A message that insists on punitive measures and retaliation in response to a community dispute, rather than seeking understanding and reconciliation.
+
+16. **Scientific Rigor:** A message that promotes pseudoscience or conspiracy theories without providing credible evidence, undermining the community's commitment to evidence-based reasoning.
+
+17. **Anti-Colonial Practices:** A message that dismisses the importance of acknowledging and addressing the impact of colonialism on knowledge production and resource distribution.
+
+18. **Solidarity and Allyship:** A message that fails to show support or allyship with a marginalized community facing discrimination or injustice, choosing to remain silent or indifferent.
+
+19. **Decolonized Resource Allocation:** A message that opposes efforts to allocate resources equitably or challenges initiatives aimed at rectifying historical resource imbalances.
+
+20. **Conflict Resolution Skills:** A message that escalates conflicts by resorting to personal attacks, insults, or aggressive language instead of seeking constructive solutions.
+
+21. **Historical Context:** A message that dismisses the relevance of historical context in discussions about social issues, denying the importance of understanding how historical factors shape present-day challenges.
+
+22. **Community Accountability:** A message that deflects responsibility or accountability for one's actions within the community, refusing to engage in discussions about improving behavior.
+
+23. **Continuous Learning:** A message that resists revisiting or updating community standards in light of new insights or perspectives, insisting on maintaining outdated practices.
+
+24. **Holistic Well-being:** A message that mocks or belittles someone's mental health struggles or personal well-being, creating a hostile and unsupportive environment.
+
+## Enforcement
+
+Enforcement of this CoC is done by the members of the hyprwm organization.
+
+We, as the organization, will strive our best to keep this community civil and
+following the standards outlined above.
+
+### Reporting incidents
+
+If you believe an incident of breaking our standards has occurred, but nobody has
+taken appropriate action, you can privately contact the people responsible for dealing
+with such incidents in multiple ways:
+
+***E-Mail***
+ - `vaxry[at]vaxry.net`
+ - `mihai[at]fufexan.net`
+
+***Discord***
+ - `@vaxry`
+ - `@fufexan`
+
+***Matrix***
+ - `@vaxry:matrix.vaxry.net`
+ - `@fufexan:matrix.org`
+ 
+We, as members, guarantee your privacy and will not share those reports with anyone.
+
+## Enforcement Strategy
+
+Depending on the severity of the infraction, any action from the list below may be applied.
+Please keep in mind cases are reviewed on a per-case basis and members are the ultimate
+deciding factor in the type of punishment.
+
+If the matter would benefit from an outside opinion, a member might reach for more opinions
+from people unrelated to the organization, however, the final decision regarding the action
+to be taken is still up to the member.
+
+For example, if the matter at hand regards a representative of a marginalized group or minority,
+the member might ask for a first-hand opinion from another representative of such group.
+
+### Correction/Edit
+
+If your message is found to be misleading or poorly worded, a member might
+edit your message.
+
+### Warning/Deletion
+
+If your message is found inappropriate, a member might give you a public or private warning,
+and/or delete your message.
+
+### Mute
+
+If your message is disruptive, or you have been repeatedly violating the standards,
+a member might mute (or temporarily ban) you.
+
+### Ban
+
+If your message is hateful, very disruptive, or other, less serious infractions are repeated
+ignoring previous punishments, a member might ban you permanently.
+
+## Scope
+
+This CoC shall apply to all projects ran under the `hyprwm` organization and all _official_ communities
+outside of GitHub.
+
+However, it is worth noting that official communities outside of GitHub might have their own,
+additional sets of rules.


### PR DESCRIPTION
It is clear now that everyone agrees a code of conduct is absolutely necessary to protect minorities from harms within this community. However, one must notice that the code of conduct suggested in #3366 seems to only seek to protect specific, popular interests deemed necessary to "put out the fire." The purpose of a code of conduct should be to protect those vulnerable and empower everyone to participate in the community, not to tick boxes. My code of conduct ensures that ALL relevant harms are dealt with, not the minimum number necessary to please a blogger.

Please keep discussion about the PR, if you want to debate philosophy do it without silencing the voice of minorities.