### PR TITLE
refactor: manually resets singletons

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -74,6 +74,24 @@ CCompositor::CCompositor() {
 
 CCompositor::~CCompositor() {
     cleanup();
+    g_pPluginSystem.reset();
+    g_pHyprNotificationOverlay.reset();
+    g_pDebugOverlay.reset();
+    g_pEventManager.reset();
+    g_pSessionLockManager.reset();
+    g_pProtocolManager.reset();
+    g_pXWaylandManager.reset();
+    g_pHyprRenderer.reset();
+    g_pHyprOpenGL.reset();
+    g_pInputManager.reset();
+    g_pThreadManager.reset();
+    g_pConfigManager.reset();
+    g_pLayoutManager.reset();
+    g_pHyprError.reset();
+    g_pConfigManager.reset();
+    g_pAnimationManager.reset();
+    g_pKeybindManager.reset();
+    g_pHookSystem.reset();
 }
 
 void CCompositor::setRandomSplash() {

--- a/src/helpers/AnimatedVariable.cpp
+++ b/src/helpers/AnimatedVariable.cpp
@@ -51,6 +51,8 @@ CAnimatedVariable::~CAnimatedVariable() {
 }
 
 void CAnimatedVariable::unregister() {
+    if (!g_pAnimationManager)
+        return;
     std::erase_if(g_pAnimationManager->m_vAnimatedVariables, [&](const auto& other) { return other == this; });
     m_bIsRegistered = false;
     disconnectFromActive();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -106,6 +106,7 @@ int main(int argc, char** argv) {
 
     // If we are here it means we got yote.
     Debug::log(LOG, "Hyprland reached the end.");
+    g_pCompositor.reset();
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Manually destroy global static objects, as some of them are interdependent and the wrong order of destruction can cause segfaults or other funny problems, such as libc++ build creating  files like `'$'\0x32\0x324\0xF'<'` during hyprland shutdown process.

---

Static objects are destroyed in the reverse order of construction, but for Hyprland they are not in the same translation unit, so the order of destruction could be rather chaotic, if I am not mistaken.
