### PR TITLE
Unbreak build without precompiled headers

### DIFF
--- a/src/helpers/Region.cpp
+++ b/src/helpers/Region.cpp
@@ -1,6 +1,8 @@
 #include "Region.hpp"
+extern "C" {
 #include <wlr/util/box.h>
 #include <wlr/util/region.h>
+}
 
 CRegion::CRegion() {
     pixman_region32_init(&m_rRegion);

--- a/src/helpers/VarList.cpp
+++ b/src/helpers/VarList.cpp
@@ -1,3 +1,4 @@
+#include "MiscFunctions.hpp"
 #include "VarList.hpp"
 #include <ranges>
 #include <algorithm>


### PR DESCRIPTION
Fixes build with `-DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON` (CMake) or `-Db_pch=false` (Meson).
