### PR TITLE
Further unsafe state improvements

### DIFF
--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -119,7 +119,8 @@ class CCompositor {
     bool                                      m_bReadyToProcess = false;
     bool                                      m_bSessionActive  = true;
     bool                                      m_bDPMSStateON    = true;
-    bool                                      m_bUnsafeState    = false; // unsafe state is when there is no monitors.
+    bool                                      m_bUnsafeState    = false;   // unsafe state is when there is no monitors.
+    wlr_output*                               m_pUnsafeOutput   = nullptr; // fallback output for the unsafe state
     bool                                      m_bIsShuttingDown = false;
 
     // ------------------------------------------------- //
@@ -202,6 +203,8 @@ class CCompositor {
     void           notifyIdleActivity();
     void           setIdleActivityInhibit(bool inhibit);
     void           arrangeMonitors();
+    void           enterUnsafeState();
+    void           leaveUnsafeState();
 
     std::string    explicitConfigPath;
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2020,9 +2020,6 @@ void CConfigManager::performMonitorReload() {
     if (overAgain)
         performMonitorReload();
 
-    if (!g_pCompositor->m_vMonitors.empty()) // reset unsafe state if we have monitors
-        g_pCompositor->leaveUnsafeState();
-
     m_bWantsMonitorReload = false;
 
     EMIT_HOOK_EVENT("monitorLayoutChanged", nullptr);

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2021,7 +2021,7 @@ void CConfigManager::performMonitorReload() {
         performMonitorReload();
 
     if (!g_pCompositor->m_vMonitors.empty()) // reset unsafe state if we have monitors
-        g_pCompositor->m_bUnsafeState = false;
+        g_pCompositor->leaveUnsafeState();
 
     m_bWantsMonitorReload = false;
 

--- a/src/events/Monitors.cpp
+++ b/src/events/Monitors.cpp
@@ -112,7 +112,6 @@ void Events::listener_newOutput(wl_listener* listener, void* data) {
         }
 
         g_pCompositor->m_bReadyToProcess = true;
-        g_pCompositor->leaveUnsafeState();
     }
 
     g_pConfigManager->m_bWantsMonitorReload = true;
@@ -138,6 +137,11 @@ void Events::listener_monitorFrame(void* owner, void* data) {
 
     if ((g_pCompositor->m_sWLRSession && !g_pCompositor->m_sWLRSession->active) || !g_pCompositor->m_bSessionActive || g_pCompositor->m_bUnsafeState) {
         Debug::log(WARN, "Attempted to render frame on inactive session!");
+
+        if (g_pCompositor->m_bUnsafeState && PMONITOR->output != g_pCompositor->m_pUnsafeOutput) {
+            // restore from unsafe state
+            g_pCompositor->leaveUnsafeState();
+        }
 
         return; // cannot draw on session inactive (different tty)
     }

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -243,7 +243,7 @@ void CMonitor::onDisconnect() {
 
     if (!BACKUPMON) {
         Debug::log(WARN, "Unplugged last monitor, entering an unsafe state. Good luck my friend.");
-        g_pCompositor->m_bUnsafeState = true;
+        g_pCompositor->enterUnsafeState();
     }
 
     if (BACKUPMON) {


### PR DESCRIPTION
Instead of allowing Hyprland to sit in a state where there are no monitors, which various parts of the code don't like, we create a fake headless output on all monitor disconnect, and then remove it when a monitor appears.

cc @primalmotion @rszyma 

possibly fixes stuff like #3175 #3403 #3067