### PR TITLE
Add map to region options for tablets

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -222,6 +222,8 @@ void CConfigManager::setDefaultVars() {
     configValues["input:touchdevice:output"].strValue               = STRVAL_EMPTY;
     configValues["input:tablet:transform"].intValue                 = 0;
     configValues["input:tablet:output"].strValue                    = STRVAL_EMPTY;
+    configValues["input:tablet:region_position"].vecValue           = Vector2D();
+    configValues["input:tablet:region_size"].vecValue               = Vector2D();
 
     configValues["binds:pass_mouse_when_bound"].intValue    = 0;
     configValues["binds:scroll_event_delay"].intValue       = 300;
@@ -278,6 +280,8 @@ void CConfigManager::setDeviceDefaultVars(const std::string& dev) {
     cfgValues["transform"].intValue               = 0;
     cfgValues["output"].strValue                  = STRVAL_EMPTY;
     cfgValues["enabled"].intValue                 = 1; // only for mice / touchpads
+    cfgValues["region_position"].vecValue         = Vector2D(); // only for tablets
+    cfgValues["region_size"].vecValue             = Vector2D(); // only for tablets
 }
 
 void CConfigManager::setDefaultAnimationVars() {
@@ -1737,6 +1741,10 @@ float CConfigManager::getFloat(const std::string& v) {
     return getConfigValueSafe(v).floatValue;
 }
 
+Vector2D CConfigManager::getVec(const std::string& v) {
+    return getConfigValueSafe(v).vecValue;
+}
+
 std::string CConfigManager::getString(const std::string& v) {
     auto VAL = getConfigValueSafe(v).strValue;
 
@@ -1754,6 +1762,10 @@ float CConfigManager::getDeviceFloat(const std::string& dev, const std::string& 
     return getConfigValueSafeDevice(dev, v, fallback).floatValue;
 }
 
+Vector2D CConfigManager::getDeviceVec(const std::string& dev, const std::string& v, const std::string& fallback) {
+    return getConfigValueSafeDevice(dev, v, fallback).vecValue;
+}
+
 std::string CConfigManager::getDeviceString(const std::string& dev, const std::string& v, const std::string& fallback) {
     auto VAL = getConfigValueSafeDevice(dev, v, fallback).strValue;
 
@@ -1769,6 +1781,10 @@ void CConfigManager::setInt(const std::string& v, int val) {
 
 void CConfigManager::setFloat(const std::string& v, float val) {
     configValues[v].floatValue = val;
+}
+
+void CConfigManager::setVec(const std::string& v, Vector2D val) {
+    configValues[v].vecValue = val;
 }
 
 void CConfigManager::setString(const std::string& v, const std::string& val) {

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -83,13 +83,16 @@ class CConfigManager {
 
     int                                                             getInt(const std::string&);
     float                                                           getFloat(const std::string&);
+    Vector2D                                                        getVec(const std::string&);
     std::string                                                     getString(const std::string&);
     void                                                            setFloat(const std::string&, float);
     void                                                            setInt(const std::string&, int);
+    void                                                            setVec(const std::string&, Vector2D);
     void                                                            setString(const std::string&, const std::string&);
 
     int                                                             getDeviceInt(const std::string&, const std::string&, const std::string& fallback = "");
     float                                                           getDeviceFloat(const std::string&, const std::string&, const std::string& fallback = "");
+    Vector2D                                                        getDeviceVec(const std::string&, const std::string&, const std::string& fallback = "");
     std::string                                                     getDeviceString(const std::string&, const std::string&, const std::string& fallback = "");
     bool                                                            deviceConfigExists(const std::string&);
     bool                                                            shouldBlurLS(const std::string&);

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1447,10 +1447,9 @@ void CInputManager::setTabletConfigs() {
 
             const auto REGION_POS  = g_pConfigManager->getDeviceVec(t.name, "region_position", "input:tablet:region_position");
             const auto REGION_SIZE = g_pConfigManager->getDeviceVec(t.name, "region_size", "input:tablet:region_size");
-            const auto REGION      = (struct wlr_box){REGION_POS.x, REGION_POS.y, REGION_SIZE.x, REGION_SIZE.y};
-            if (!wlr_box_empty(&REGION)) {
+            const auto REGION      = wlr_box{REGION_POS.x, REGION_POS.y, REGION_SIZE.x, REGION_SIZE.y};
+            if (!wlr_box_empty(&REGION))
                 wlr_cursor_map_input_to_region(g_pCompositor->m_sWLRCursor, t.wlrDevice, &REGION);
-            }
         }
     }
 }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1444,6 +1444,13 @@ void CInputManager::setTabletConfigs() {
                 wlr_cursor_map_input_to_output(g_pCompositor->m_sWLRCursor, t.wlrDevice, PMONITOR->output);
                 wlr_cursor_map_input_to_region(g_pCompositor->m_sWLRCursor, t.wlrDevice, nullptr);
             }
+
+            const auto REGION_POS  = g_pConfigManager->getDeviceVec(t.name, "region_position", "input:tablet:region_position");
+            const auto REGION_SIZE = g_pConfigManager->getDeviceVec(t.name, "region_size", "input:tablet:region_size");
+            const auto REGION      = (struct wlr_box){REGION_POS.x, REGION_POS.y, REGION_SIZE.x, REGION_SIZE.y};
+            if (!wlr_box_empty(&REGION)) {
+                wlr_cursor_map_input_to_region(g_pCompositor->m_sWLRCursor, t.wlrDevice, &REGION);
+            }
         }
     }
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Added support for mapping tablet input to a region in output layout.
Besides, this PR also added:
- Functions for getting/setting Vector2D variables
- 2 variables for tablet devices: `region_position` and `region_size`

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Mapping will be reserved after `region_position` and `region_size` variables are removed from the configuration file. Unplug and replug tablet will solve this problem.

#### Is it ready for merging, or does it need work?
Ready
