### PR TITLE
Remove redundant clamp of smoothsteps return value.

### DIFF
--- a/src/render/shaders/Border.hpp
+++ b/src/render/shaders/Border.hpp
@@ -71,11 +71,11 @@ void main() {
 
 	    if (dist < radius - h) {
             // lower
-            float normalized = clamp(smoothstep(0.0, 1.0, dist - radius + thick + 0.5), 0.0, 1.0);
+            float normalized = smoothstep(0.0, 1.0, dist - radius + thick + 0.5);
             additionalAlpha *= normalized;
         } else {
             // higher
-            float normalized = 1.0 - clamp(smoothstep(0.0, 1.0, dist - radius + 0.5), 0.0, 1.0);
+            float normalized = 1.0 - smoothstep(0.0, 1.0, dist - radius + 0.5);
             additionalAlpha *= normalized;
         }
 

--- a/src/render/shaders/Textures.hpp
+++ b/src/render/shaders/Textures.hpp
@@ -22,7 +22,7 @@ inline static constexpr auto ROUNDED_SHADER_FUNC = [](const std::string colorVar
 	    if (dist > radius - 1.0) {
 	        float dist = length(pixCoord);
 
-            float normalized = 1.0 - clamp(smoothstep(0.0, 1.0, dist - radius + 0.5), 0.0, 1.0);
+            float normalized = 1.0 - smoothstep(0.0, 1.0, dist - radius + 0.5);
 
 	        )#" +
         colorVarName + R"#( = )#" + colorVarName + R"#( * normalized;
@@ -100,7 +100,7 @@ void main() {
 
     if (discardOpaque == 1 && pixColor[3] * alpha == 1.0)
 	    discard;
-    
+
     if (discardAlpha == 1 && pixColor[3] <= discardAlphaValue)
         discard;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
It removes the clamp around smoothstep.
Smoothstep already clamps the return value.
Reference: https://registry.khronos.org/OpenGL-Refpages/gl4/html/smoothstep.xhtml
In the description t is clamped to 0.0 ,1.0,
the equation `t * t * (3.0 - 2.0 * t )` will always be between 0.0 and 1.0 for that clamped t.
As proof plot the function `3*x^2 - 2*x^3` which is equal to `t * t * (3.0 -2.0 * t)`
#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
Ready

