### PR TITLE
Master layout: add option to drag and drop windows at cursor position

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -187,6 +187,7 @@ void CConfigManager::setDefaultVars() {
     configValues["master:inherit_fullscreen"].intValue     = 1;
     configValues["master:allow_small_split"].intValue      = 0;
     configValues["master:smart_resizing"].intValue         = 1;
+    configValues["master:drop_at_cursor"].intValue         = 1;
 
     configValues["animations:enabled"].intValue = 1;
 

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -132,6 +132,35 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection direc
 
     pWindow->applyGroupRules();
 
+    static auto* const PDROPATCURSOR  = &g_pConfigManager->getConfigValuePtr("master:drop_at_cursor")->intValue;
+    const auto         PWORKSPACEDATA = getMasterWorkspaceData(pWindow->m_iWorkspaceID);
+    eOrientation       orientation    = PWORKSPACEDATA->orientation;
+    const auto         NODEIT         = std::find(m_lMasterNodesData.begin(), m_lMasterNodesData.end(), *PNODE);
+    if (*PDROPATCURSOR && g_pInputManager->dragMode == MBIND_MOVE) {
+        // if dragging window to move, drop it at the cursor position instead of bottom/top of stack
+        for (auto it = m_lMasterNodesData.begin(); it != m_lMasterNodesData.end(); ++it) {
+            const wlr_box box = it->pWindow->getFullWindowBoundingBox();
+            if (wlr_box_contains_point(&box, MOUSECOORDS.x, MOUSECOORDS.y)) { // TODO: Deny when not using mouse
+                switch (orientation) {
+                    case ORIENTATION_LEFT:
+                    case ORIENTATION_RIGHT:
+                        if (MOUSECOORDS.y > it->pWindow->middle().y)
+                            ++it;
+                        break;
+                    case ORIENTATION_TOP:
+                    case ORIENTATION_BOTTOM:
+                        if (MOUSECOORDS.x > it->pWindow->middle().x)
+                            ++it;
+                        break;
+                    case ORIENTATION_CENTER: break;
+                    default: UNREACHABLE();
+                }
+                m_lMasterNodesData.splice(it, m_lMasterNodesData, NODEIT);
+                break;
+            }
+        }
+    }
+
     if (*PNEWISMASTER || WINDOWSONWORKSPACE == 1 || (!pWindow->m_bFirstMap && OPENINGON->isMaster)) {
         for (auto& nd : m_lMasterNodesData) {
             if (nd.isMaster && nd.workspaceID == PNODE->workspaceID) {

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -139,7 +139,7 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection direc
     if (*PDROPATCURSOR && g_pInputManager->dragMode == MBIND_MOVE) {
         // if dragging window to move, drop it at the cursor position instead of bottom/top of stack
         for (auto it = m_lMasterNodesData.begin(); it != m_lMasterNodesData.end(); ++it) {
-            const wlr_box box = it->pWindow->getFullWindowBoundingBox();
+            const wlr_box box = it->pWindow->getWindowIdealBoundingBoxIgnoreReserved();
             if (wlr_box_contains_point(&box, MOUSECOORDS.x, MOUSECOORDS.y)) { // TODO: Deny when not using mouse
                 switch (orientation) {
                     case ORIENTATION_LEFT:


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Current behavior: in master layout, if you drag a window with the mouse and drop it at the stack side, it always goes to the bottom of the stack (or top, depending on new_on_top), and you can't drop a window in the middle of the stack.
This PR allows you to drop the window in the middle of the stack.
Doesn't change the behavior when the option is disabled.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready

