### PR TITLE
Add GTK portal as fallback

### DIFF
--- a/assets/hyprland-portals.conf
+++ b/assets/hyprland-portals.conf
@@ -1,2 +1,2 @@
 [preferred]
-default=hyprland
+default=hyprland;gtk


### PR DESCRIPTION
On systems with xdg-desktop-portal 1.17+, the GTK portal is not started by default and cannot be used (even if started manually). This should fix issues on such systems like: theming/cursors being incorrect, not being able to open the file picker, and being unable to open links from other applications (#3258).

Users who wish to use an alternative portal (e.g. for QT-based dialogs) should still be able to do so by overriding this with their own preferences in `~/.config/xdg-desktop-portal/hyprland-portals.conf`. This PR just makes the portals act like they did before xdg-desktop-portal 1.17.

In my brief testing, this doesn't cause any regressions for those on xdg-desktop-portal 1.16.