### PR TITLE
Remove starting newline in demangled func name

### DIFF
--- a/src/plugins/PluginAPI.cpp
+++ b/src/plugins/PluginAPI.cpp
@@ -301,7 +301,7 @@ APICALL std::vector<SFunctionMatch> HyprlandAPI::findFunctionsByName(HANDLE hand
             count++;
         }
 
-        return SYMBOLSDEMANGLED.substr(pos, SYMBOLSDEMANGLED.find('\n', pos + 1) - pos);
+        return SYMBOLSDEMANGLED.substr(pos + 1, SYMBOLSDEMANGLED.find('\n', pos + 1) - pos - 1);
     };
 
     if (SYMBOLS.empty()) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

When searching for a Hyprland fucntion with `findFunctionsByName`, the returned vector of matches contain demangled names, which always seem to be prefixed with a newline. 

```c++ 
static const auto CREATE_GROUP_METHODS = HyprlandAPI::findFunctionsByName(PHANDLE, "createGroup");
for (auto& method : CREATE_GROUP_METHODS) {
    if (method.demangled == "\nCWindow::createGroup()") {
        g_pOriginalCreateGroup = (voidFunctionT)method.address;
    }
}
```

Notice the `if (method.demangled == "\nCWindow::createGroup()")` . There's no reason this should be the case, the newline character shouldn't be there. (tested with "createGroup", "destroyGroup", "getNodeFromWindow" fucntions).

---

From what I understand, this was caused by this lambda function:

https://github.com/hyprwm/Hyprland/blob/3d1a1679604e9de18a46a9a0819daf2044b08fa6/src/plugins/PluginAPI.cpp#L293-L305

Which is supposed to return the contents of nth line, by finding positions of `\n` characters, returning a substring from that `pos` to next newline.

However the `pos` variable was set to the position of last newline, so it's included too. Instead, it should probably just be `pos + 1` to skip that newline char.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Ready to be merged.
