### PR TITLE
Fix drop_at_cursor on workspace 2

### DIFF
--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -139,6 +139,8 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection direc
     if (*PDROPATCURSOR && g_pInputManager->dragMode == MBIND_MOVE) {
         // if dragging window to move, drop it at the cursor position instead of bottom/top of stack
         for (auto it = m_lMasterNodesData.begin(); it != m_lMasterNodesData.end(); ++it) {
+            if (it->workspaceID != pWindow->m_iWorkspaceID)
+                continue;
             const wlr_box box = it->pWindow->getWindowIdealBoundingBoxIgnoreReserved();
             if (wlr_box_contains_point(&box, MOUSECOORDS.x, MOUSECOORDS.y)) { // TODO: Deny when not using mouse
                 switch (orientation) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Hot fix for master layout drop_at_cursor inconsistent behavior on workspaces other than 1.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready

