### PR TITLE
Map touch devices and tablets bound to an output

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2080,7 +2080,11 @@ void CCompositor::swapActiveWorkspaces(CMonitor* pMonitorA, CMonitor* pMonitorB)
 }
 
 CMonitor* CCompositor::getMonitorFromString(const std::string& name) {
-    if (name[0] == '+' || name[0] == '-') {
+    if (name == "current")
+        return g_pCompositor->m_pLastMonitor;
+    else if (isDirection(name))
+        return getMonitorInDirection(name[0]);
+    else if (name[0] == '+' || name[0] == '-') {
         // relative
 
         if (m_vMonitors.size() == 1)
@@ -2135,31 +2139,13 @@ CMonitor* CCompositor::getMonitorFromString(const std::string& name) {
             Debug::log(ERR, "Error in getMonitorFromString: invalid arg 1");
             return nullptr;
         }
-    } else if (name.starts_with("desc:")) {
-        const auto DESCRIPTION = name.substr(5);
-
+    } else {
         for (auto& m : m_vMonitors) {
             if (!m->output)
                 continue;
 
-            if (m->szDescription.starts_with(DESCRIPTION)) {
+            if (m->matchesStaticSelector(name)) {
                 return m.get();
-            }
-        }
-
-        return nullptr;
-    } else {
-        if (name == "current")
-            return g_pCompositor->m_pLastMonitor;
-
-        if (isDirection(name)) {
-            const auto PMONITOR = getMonitorInDirection(name[0]);
-            return PMONITOR;
-        } else {
-            for (auto& m : m_vMonitors) {
-                if (m->szName == name) {
-                    return m.get();
-                }
             }
         }
     }

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -465,7 +465,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("input:touchpad:drag_lock", {0L});
     m_pConfig->addConfigValue("input:touchpad:scroll_factor", {1.f});
     m_pConfig->addConfigValue("input:touchdevice:transform", {0L});
-    m_pConfig->addConfigValue("input:touchdevice:output", {STRVAL_EMPTY});
+    m_pConfig->addConfigValue("input:touchdevice:output", {"[[Auto]]"});
     m_pConfig->addConfigValue("input:touchdevice:enabled", {1L});
     m_pConfig->addConfigValue("input:tablet:transform", {0L});
     m_pConfig->addConfigValue("input:tablet:output", {STRVAL_EMPTY});

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -102,7 +102,7 @@ class CConfigManager {
     static std::string                                              getConfigDir();
     static std::string                                              getMainConfigPath();
 
-    SMonitorRule                                                    getMonitorRuleFor(const std::string&, const std::string& displayName = "");
+    SMonitorRule                                                    getMonitorRuleFor(const CMonitor&);
     SWorkspaceRule                                                  getWorkspaceRuleFor(CWorkspace*);
     std::string                                                     getDefaultWorkspaceFor(const std::string&);
 

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -64,7 +64,7 @@ void CMonitor::onConnect(bool noRule) {
         createdByUser = true; // should be true. WL, X11 and Headless backends should be addable / removable
 
     // get monitor rule that matches
-    SMonitorRule monitorRule = g_pConfigManager->getMonitorRuleFor(output->name, output->description ? output->description : "");
+    SMonitorRule monitorRule = g_pConfigManager->getMonitorRuleFor(*this);
 
     // if it's disabled, disable and ignore
     if (monitorRule.disabled) {
@@ -449,7 +449,7 @@ void CMonitor::setMirror(const std::string& mirrorOf) {
         pMirrorOf = nullptr;
 
         // set rule
-        const auto RULE = g_pConfigManager->getMonitorRuleFor(this->szName, this->output->description ? this->output->description : "");
+        const auto RULE = g_pConfigManager->getMonitorRuleFor(*this);
 
         vecPosition = RULE.offset;
 

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -140,6 +140,7 @@ class CMonitor {
     void     addDamage(const CBox* box);
     void     setMirror(const std::string&);
     bool     isMirror();
+    bool     matchesStaticSelector(const std::string& selector) const;
     float    getDefaultScale();
     void     changeWorkspace(CWorkspace* const pWorkspace, bool internal = false, bool noMouseMove = false, bool noFocus = false);
     void     changeWorkspace(const int& id, bool internal = false, bool noMouseMove = false, bool noFocus = false);

--- a/src/helpers/WLClasses.hpp
+++ b/src/helpers/WLClasses.hpp
@@ -259,6 +259,8 @@ struct STablet {
 
     std::string           name = "";
 
+    std::string           boundOutput = "";
+
     //
     bool operator==(const STablet& b) const {
         return wlrDevice == b.wlrDevice;

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1632,7 +1632,7 @@ void CKeybindManager::forceRendererReload(std::string args) {
         if (!m->output)
             continue;
 
-        auto rule = g_pConfigManager->getMonitorRuleFor(m->szName, m->szDescription);
+        auto rule = g_pConfigManager->getMonitorRuleFor(*m);
         if (!g_pHyprRenderer->applyMonitorRule(m.get(), &rule, true)) {
             overAgain = true;
             break;

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1495,9 +1495,10 @@ void CInputManager::setTouchDeviceConfigs(STouchDevice* dev) {
             if (libinput_device_config_calibration_has_matrix(LIBINPUTDEV))
                 libinput_device_config_calibration_set_matrix(LIBINPUTDEV, MATRICES[ROTATION]);
 
-            auto output = g_pConfigManager->getDeviceString(PTOUCHDEV->name, "output", "input:touchdevice:output");
-            bool bound  = !output.empty() && output != STRVAL_EMPTY;
-            if (!bound) {
+            auto       output     = g_pConfigManager->getDeviceString(PTOUCHDEV->name, "output", "input:touchdevice:output");
+            bool       bound      = !output.empty() && output != STRVAL_EMPTY;
+            const bool AUTODETECT = output == "[[Auto]]";
+            if (!bound && AUTODETECT) {
                 const auto DEFAULTOUTPUT = wlr_touch_from_input_device(PTOUCHDEV->pWlrDevice)->output_name;
                 if (DEFAULTOUTPUT) {
                     output = DEFAULTOUTPUT;
@@ -1509,7 +1510,7 @@ void CInputManager::setTouchDeviceConfigs(STouchDevice* dev) {
             if (PMONITOR) {
                 Debug::log(LOG, "Binding touch device {} to output {}", PTOUCHDEV->name, PMONITOR->szName);
                 wlr_cursor_map_input_to_output(g_pCompositor->m_sWLRCursor, PTOUCHDEV->pWlrDevice, PMONITOR->output);
-            } else
+            } else if (bound)
                 Debug::log(ERR, "Failed to bind touch device {} to output '{}': monitor not found", PTOUCHDEV->name, output);
         }
     };

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1491,14 +1491,26 @@ void CInputManager::setTouchDeviceConfigs(STouchDevice* dev) {
                 libinput_device_config_send_events_set_mode(LIBINPUTDEV, mode);
 
             const int ROTATION = std::clamp(g_pConfigManager->getDeviceInt(PTOUCHDEV->name, "transform", "input:touchdevice:transform"), 0, 7);
+            Debug::log(LOG, "Setting calibration matrix for device {}", PTOUCHDEV->name);
             if (libinput_device_config_calibration_has_matrix(LIBINPUTDEV))
                 libinput_device_config_calibration_set_matrix(LIBINPUTDEV, MATRICES[ROTATION]);
 
-            const auto OUTPUT = g_pConfigManager->getDeviceString(PTOUCHDEV->name, "output", "input:touchdevice:output");
-            if (!OUTPUT.empty() && OUTPUT != STRVAL_EMPTY)
-                PTOUCHDEV->boundOutput = OUTPUT;
-            else
-                PTOUCHDEV->boundOutput = "";
+            auto output = g_pConfigManager->getDeviceString(PTOUCHDEV->name, "output", "input:touchdevice:output");
+            bool bound  = !output.empty() && output != STRVAL_EMPTY;
+            if (!bound) {
+                const auto DEFAULTOUTPUT = wlr_touch_from_input_device(PTOUCHDEV->pWlrDevice)->output_name;
+                if (DEFAULTOUTPUT) {
+                    output = DEFAULTOUTPUT;
+                    bound  = true;
+                }
+            }
+            PTOUCHDEV->boundOutput = bound ? output : "";
+            const auto PMONITOR    = bound ? g_pCompositor->getMonitorFromName(output) : nullptr;
+            if (PMONITOR) {
+                Debug::log(LOG, "Binding touch device {} to output {}", PTOUCHDEV->name, PMONITOR->szName);
+                wlr_cursor_map_input_to_output(g_pCompositor->m_sWLRCursor, PTOUCHDEV->pWlrDevice, PMONITOR->output);
+            } else
+                Debug::log(ERR, "Failed to bind touch device {} to output '{}': monitor not found", PTOUCHDEV->name, output);
         }
     };
 
@@ -1529,9 +1541,12 @@ void CInputManager::setTabletConfigs() {
             const auto OUTPUT   = g_pConfigManager->getDeviceString(t.name, "output", "input:tablet:output");
             const auto PMONITOR = g_pCompositor->getMonitorFromString(OUTPUT);
             if (!OUTPUT.empty() && OUTPUT != STRVAL_EMPTY && PMONITOR) {
+                Debug::log(LOG, "Binding tablet {} to output {}", t.name, PMONITOR->szName);
                 wlr_cursor_map_input_to_output(g_pCompositor->m_sWLRCursor, t.wlrDevice, PMONITOR->output);
                 wlr_cursor_map_input_to_region(g_pCompositor->m_sWLRCursor, t.wlrDevice, nullptr);
-            }
+                t.boundOutput = OUTPUT;
+            } else if (!PMONITOR)
+                Debug::log(ERR, "Failed to bind tablet {} to output '{}': monitor not found", t.name, OUTPUT);
 
             const auto REGION_POS  = g_pConfigManager->getDeviceVec(t.name, "region_position", "input:tablet:region_position");
             const auto REGION_SIZE = g_pConfigManager->getDeviceVec(t.name, "region_size", "input:tablet:region_size");


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

tries to fix: #3538.

This transfers the rotation for an output to any bound touch devices if the `transform` configuration hasn't been set explicitly.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?

Not tested yet (I don't have a 2in1).
