### PR TITLE
allow reload and fix locked groupbar gradient

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1,6 +1,8 @@
 #include "ConfigManager.hpp"
 #include "../managers/KeybindManager.hpp"
 
+#include "../render/decorations/CHyprGroupBarDecoration.hpp"
+
 #include <string.h>
 #include <string>
 #include <sys/stat.h>
@@ -79,7 +81,7 @@ void CConfigManager::setDefaultVars() {
     configValues["general:no_border_on_floating"].intValue = 0;
     configValues["general:gaps_in"].intValue               = 5;
     configValues["general:gaps_out"].intValue              = 20;
-    configValues["general:gaps_workspaces"].intValue        = 0;
+    configValues["general:gaps_workspaces"].intValue       = 0;
     ((CGradientValueData*)configValues["general:col.active_border"].data.get())->reset(0xffffffff);
     ((CGradientValueData*)configValues["general:col.inactive_border"].data.get())->reset(0xff444444);
     ((CGradientValueData*)configValues["general:col.nogroup_border"].data.get())->reset(0xff444444);
@@ -1667,6 +1669,9 @@ void CConfigManager::loadConfigLoadVars() {
         ensureMonitorStatus();
         ensureVRR();
     }
+
+    if (!isFirstLaunch && !g_pCompositor->m_bUnsafeState)
+        refreshGroupBarGradients();
 
     // Updates dynamic window and workspace rules
     for (auto& w : g_pCompositor->m_vWindows) {

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -16,6 +16,8 @@ class CTitleTex {
     CWindow*    pWindowOwner = nullptr;
 };
 
+void refreshGroupBarGradients();
+
 class CHyprGroupBarDecoration : public IHyprWindowDecoration {
   public:
     CHyprGroupBarDecoration(CWindow*);
@@ -56,8 +58,6 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
 
     CTitleTex*               textureFromTitle(const std::string&);
     void                     invalidateTextures();
-
-    void                     refreshGradients();
 
     CBox                     assignedBoxGlobal();
 


### PR DESCRIPTION
allows groupbar gradient hot reloading
also fixes gradients for locked groups

closes: https://github.com/hyprwm/Hyprland/issues/2595

not sure if the best way to implement this but shouldn't cause any other issues 