### PR TITLE
meson: Sort input file list

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -1,4 +1,4 @@
-globber = run_command('find', '.', '-name', '*.cpp', check: true)
+globber = run_command('sh', '-c', 'find . -name "*.cpp" | sort', check: true)
 src = globber.stdout().strip().split('\n')
 
 executable('Hyprland', src,


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Sort cpp input file list
so that `hyprland` builds in a reproducible way
in spite of non-deterministic filesystem readdir order.

See https://reproducible-builds.org/ for why this is good.

This patch was done while working on reproducible builds for openSUSE.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

requires a POSIX shell. It should be possible to replace the `find` with a python script, but I did not find a builtin sort function in meson.

#### Is it ready for merging, or does it need work?

I tested that it builds, so it should still work the same as before.