### PR TITLE
CMake pipeline improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
           mkdir hyprland/assets
           cp ./LICENSE hyprland/
           cp build/Hyprland hyprland/
-          cp hyprctl/hyprctl hyprland/
+          cp build/hyprctl/hyprctl hyprland/
           cp subprojects/wlroots/build/libwlroots.so.12032 hyprland/
           cp build/Hyprland hyprland/
           cp -r example/ hyprland/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,4 +105,4 @@ jobs:
       - name: Configure
         run: mkdir -p build && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DNO_XWAYLAND:STRING=true -H./ -B./build -G Ninja 
       - name: Compile
-        run: make config && make release
+        run: make release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,27 @@ execute_process(
 #
 #
 
+# udis
+add_subdirectory("subprojects/udis86")
+
+# wlroots
+message(STATUS "Setting up wlroots")
+
+include(ExternalProject)
+string(TOLOWER ${CMAKE_BUILD_TYPE} BUILDTYPE_LOWER)
+ExternalProject_Add(
+    wlroots
+    PREFIX ${CMAKE_SOURCE_DIR}/subprojects/wlroots
+    SOURCE_DIR ${CMAKE_SOURCE_DIR}/subprojects/wlroots
+    PATCH_COMMAND sed -E -i -e "s/(soversion = 12)([^032]|$$)/soversion = 12032/g" meson.build
+    CONFIGURE_COMMAND meson setup build --buildtype=${BUILDTYPE_LOWER} -Dwerror=false -Dexamples=false -Drenderers=gles2 $<IF:$<BOOL:${WITH_ASAN}>,-Db_sanitize=address,-Db_sanitize=none> && meson setup build --buildtype=${BUILDTYPE_LOWER} -Dwerror=false -Dexamples=false -Drenderers=gles2 $<IF:$<BOOL:${WITH_ASAN}>,-Db_sanitize=address,-Db_sanitize=none> --reconfigure
+    BUILD_COMMAND ninja -C build
+    BUILD_ALWAYS true
+    BUILD_IN_SOURCE true
+    BUILD_BYPRODUCTS ${CMAKE_SOURCE_DIR}/subprojects/wlroots/build/libwlroots.so.12032
+    INSTALL_COMMAND echo "wlroots: install not needed"
+)
+
 find_program(WaylandScanner NAMES wayland-scanner)
 message(STATUS "Found WaylandScanner at ${WaylandScanner}")
 execute_process(
@@ -201,3 +222,6 @@ protocol("staging/fractional-scale/fractional-scale-v1.xml" "fractional-scale-v1
 protocol("staging/tearing-control/tearing-control-v1.xml" "tearing-control-v1" false)
 protocol("unstable/text-input/text-input-unstable-v1.xml" "text-input-unstable-v1" false)
 protocol("staging/cursor-shape/cursor-shape-v1.xml" "cursor-shape-v1" false)
+
+# hyprctl
+add_subdirectory(hyprctl)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,7 @@ pkg_check_modules(deps REQUIRED IMPORTED_TARGET wayland-server wayland-client wa
 file(GLOB_RECURSE SRCFILES CONFIGURE_DEPENDS "src/*.cpp")
 
 add_executable(Hyprland ${SRCFILES})
+add_dependencies(Hyprland wlroots)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES DEBUG)
     message(STATUS "Setting debug flags")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,7 @@ target_link_libraries(Hyprland
         OpenGL::EGL
         OpenGL::GL
         Threads::Threads
-        ${CMAKE_SOURCE_DIR}/subprojects/udis86/build/libudis86/liblibudis86.a
+        libudis86
 )
 
 protocol("protocols/idle.xml" "idle" true)

--- a/Makefile
+++ b/Makefile
@@ -23,32 +23,20 @@ debug:
 clear:
 	rm -rf build
 	rm -f ./protocols/*-protocol.h ./protocols/*-protocol.c
-	rm -f ./hyprctl/hyprctl
 	rm -rf ./subprojects/wlroots/build
 
 all:
+	@if [[ "$EUID" = 0 ]]; then echo -en "Avoid running $(MAKE) all as sudo.\n"; fi
 	$(MAKE) clear
-	$(MAKE) fixwlr
-	cd ./subprojects/wlroots && meson setup build/ --buildtype=release && ninja -C build/ && mkdir -p ${PREFIX}/lib/ && cp ./build/libwlroots.so.12032 ${PREFIX}/lib/ || echo "Could not install libwlroots to ${PREFIX}/lib/libwlroots.so.12032"
-	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B./build -G Ninja && cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 	$(MAKE) release
-	$(MAKE) -C hyprctl all
 
 install:
-	$(MAKE) clear
-	$(MAKE) fixwlr
-	cd ./subprojects/wlroots && meson setup build/ --buildtype=release && ninja -C build/ && mkdir -p ${PREFIX}/lib/ && cp ./build/libwlroots.so.12032 ${PREFIX}/lib/ || echo "Could not install libwlroots to ${PREFIX}/lib/libwlroots.so.12032"
-	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B./build -G Ninja && cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF` && cd ../..
-	chmod -R 777 subprojects/udis86
-	chmod -R 777 subprojects/wlroots
-	$(MAKE) release
-	$(MAKE) -C hyprctl all
-	chmod 755 ./hyprctl/hyprctl
+	@if [ ! -d ./build/Hyprland ]; then echo -en "You need to run $(MAKE) all first.\n" && exit 1; fi
 
 	mkdir -p ${PREFIX}/share/wayland-sessions
 	mkdir -p ${PREFIX}/bin
 	cp -f ./build/Hyprland ${PREFIX}/bin
-	cp -f ./hyprctl/hyprctl ${PREFIX}/bin
+	cp -f ./build/hyprctl/hyprctl ${PREFIX}/bin
 	chmod 755 ${PREFIX}/bin/Hyprland
 	chmod 755 ${PREFIX}/bin/hyprctl
 	if [ ! -f ${PREFIX}/share/wayland-sessions/hyprland.desktop ]; then cp ./example/hyprland.desktop ${PREFIX}/share/wayland-sessions; fi
@@ -58,26 +46,10 @@ install:
 	mkdir -p ${PREFIX}/share/man/man1
 	install -m644 ./docs/*.1 ${PREFIX}/share/man/man1
 
-	mkdir -p ${PREFIX}/include/hyprland
-	mkdir -p ${PREFIX}/include/hyprland/protocols
-	mkdir -p ${PREFIX}/include/hyprland/wlroots
-	mkdir -p ${PREFIX}/share/pkgconfig
-	mkdir -p ${PREFIX}/share/xdg-desktop-portal
-	
-	find src -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland
-	cd subprojects/wlroots/include && find . -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland/wlroots && cd ../../..
-	cd subprojects/wlroots/build/include && find . -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland/wlroots && cd ../../../..
-	cp ./protocols/*-protocol.h ${PREFIX}/include/hyprland/protocols
-	cp ./build/hyprland.pc ${PREFIX}/share/pkgconfig
-	cp ./assets/hyprland-portals.conf ${PREFIX}/share/xdg-desktop-portal/
-	if [ -d /usr/share/pkgconfig ]; then cp ./build/hyprland.pc /usr/share/pkgconfig 2>/dev/null || true; fi
+	mkdir -p ${PREFIX}/lib/
+	cp ./build/libwlroots.so.12032 ${PREFIX}/lib/
 
-	chmod -R 755 ${PREFIX}/include/hyprland
-	chmod 755 ${PREFIX}/share/pkgconfig
-
-cleaninstall:
-	echo -en "$(MAKE) cleaninstall has been DEPRECATED, you should avoid using it in the future.\nRunning $(MAKE) install instead...\n"
-	$(MAKE) install
+	$(MAKE) installheaders
 
 uninstall:
 	rm -f ${PREFIX}/share/wayland-sessions/hyprland.desktop
@@ -88,37 +60,12 @@ uninstall:
 	rm -f ${PREFIX}/share/man/man1/Hyprland.1
 	rm -f ${PREFIX}/share/man/man1/hyprctl.1
 
-fixwlr:
-	sed -E -i -e 's/(soversion = 12)([^032]|$$)/soversion = 12032/g' subprojects/wlroots/meson.build
-
-	rm -rf ./subprojects/wlroots/build
-
-config:
-	$(MAKE) fixwlr
-
-	meson setup subprojects/wlroots/build subprojects/wlroots --prefix=${PREFIX} --buildtype=release -Dwerror=false -Dexamples=false -Drenderers="gles2"
-	ninja -C subprojects/wlroots/build/
-
-	ninja -C subprojects/wlroots/build/ install
-
-	chmod -R 777 subprojects/wlroots
-
-	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B ./build -G Ninja && cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
-
-	chmod -R 777 subprojects/udis86
-
 pluginenv:
-	cd subprojects/udis86 && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B ./build -G Ninja && cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
-
-	$(MAKE) fixwlr
-
-	meson setup subprojects/wlroots/build subprojects/wlroots --prefix=${PREFIX} --buildtype=release -Dwerror=false -Dexamples=false
-	ninja -C subprojects/wlroots/build/
-
-	chmod -R 777 subprojects/udis86
-	chmod -R 777 subprojects/wlroots
-
-	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -S . -B ./build -G Ninja
+	@echo -en "$(MAKE) pluginenv has been deprecated.\nPlease run $(MAKE) all && sudo $(MAKE) installheaders\n"
+	@exit 1
+	
+installheaders:
+	@if [ ! -d ./build/Hyprland ]; then echo -en "You need to run $(MAKE) all first.\n" && exit 1; fi
 
 	mkdir -p ${PREFIX}/include/hyprland
 	mkdir -p ${PREFIX}/include/hyprland/protocols
@@ -134,14 +81,6 @@ pluginenv:
 
 	chmod -R 755 ${PREFIX}/include/hyprland
 	chmod 755 ${PREFIX}/share/pkgconfig
-
-configdebug:
-	$(MAKE) fixwlr
-
-	meson setup subprojects/wlroots/build subprojects/wlroots --prefix=${PREFIX} --buildtype=debug -Dwerror=false -Dexamples=false -Drenderers="gles2" -Db_sanitize=address
-	ninja -C subprojects/wlroots/build/
-
-	ninja -C subprojects/wlroots/build/ install
 
 man:
 	pandoc ./docs/Hyprland.1.rst \

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ install:
 	install -m644 ./docs/*.1 ${PREFIX}/share/man/man1
 
 	mkdir -p ${PREFIX}/lib/
-	cp ./build/libwlroots.so.12032 ${PREFIX}/lib/
+	cp ./subprojects/wlroots/build/libwlroots.so.12032 ${PREFIX}/lib/
 
 	$(MAKE) installheaders
 

--- a/hyprctl/CMakeLists.txt
+++ b/hyprctl/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.19)
+
+project(
+    hyprctl
+    DESCRIPTION "Control utility for Hyprland"
+)
+
+add_executable(hyprctl "main.cpp")


### PR DESCRIPTION
Prolly Supersedes #2313

Improves cmake stuff:
 - cmake can build everything, no makefile needed to build. Just run `make all` or `make release` (or use your ide to configure & build with cmake) and it will work. -> this includes wlroots, hyprctl, udis.

 Changes to the makefile:
  - `make pluginenv` removed -> use `make release && sudo make installheaders`
  - `sudo make install` requires a prior `make all` (or `make release`) to avoid odd permissions on build files
 
TODOs:
 - [x] CI
 - [ ] Docs (wiki)
 - [ ] Homie kiss with fuffie :kissing_heart: 

