### PR TITLE
Fix makefile using `-d` test for a binary file AND re-add missing portals conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ all:
 	$(MAKE) release
 
 install:
-	@if [ ! -d ./build/Hyprland ]; then echo -en "You need to run $(MAKE) all first.\n" && exit 1; fi
+	@if [ ! -f ./build/Hyprland ]; then echo -en "You need to run $(MAKE) all first.\n" && exit 1; fi
 	@echo -en "!NOTE: Please note make install does not compile Hyprland and only installs the already built files."
 
 	mkdir -p ${PREFIX}/share/wayland-sessions
@@ -66,7 +66,7 @@ pluginenv:
 	@exit 1
 	
 installheaders:
-	@if [ ! -d ./build/Hyprland ]; then echo -en "You need to run $(MAKE) all first.\n" && exit 1; fi
+	@if [ ! -f ./build/Hyprland ]; then echo -en "You need to run $(MAKE) all first.\n" && exit 1; fi
 
 	mkdir -p ${PREFIX}/include/hyprland
 	mkdir -p ${PREFIX}/include/hyprland/protocols

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,8 @@ install:
 	if [ ! -f ${PREFIX}/share/wayland-sessions/hyprland.desktop ]; then cp ./example/hyprland.desktop ${PREFIX}/share/wayland-sessions; fi
 	mkdir -p ${PREFIX}/share/hyprland
 	cp ./assets/wall_* ${PREFIX}/share/hyprland
+	mkdir -p ${PREFIX}/share/xdg-desktop-portal
+	cp ./assets/hyprland-portals.conf ${PREFIX}/share/xdg-desktop-portal
 
 	mkdir -p ${PREFIX}/share/man/man1
 	install -m644 ./docs/*.1 ${PREFIX}/share/man/man1


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
The current changed Makefile uses `-d` to test if `make all` had been run. The problem is that `-d` is to test for the existence of a directory, while the Makefile uses it to test for the Hyprland binary (via `-d ./build/Hyprland`). This causes the Makefile to instantly fail when running either `make install` or `make installheaders`.

Additionally, since I noticed `./assets/hyprland-portals.conf` was not being copied in the Makefile, I added a declaration to do that as well, since it was part of the original Makefile.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
None

#### Is it ready for merging, or does it need work?
Ready for merging.
