### PR TITLE
fix(build): include version.h in PluginAPI.hpp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ all:
 	$(MAKE) release
 
 install:
-	@if [ ! -d ./build/Hyprland ]; then echo -en "You need to run $(MAKE) all first.\n" && exit 1; fi
 	@echo -en "!NOTE: Please note make install does not compile Hyprland and only installs the already built files."
 
 	mkdir -p ${PREFIX}/share/wayland-sessions
@@ -66,7 +65,7 @@ pluginenv:
 	@exit 1
 	
 installheaders:
-	@if [ ! -d ./build/Hyprland ]; then echo -en "You need to run $(MAKE) all first.\n" && exit 1; fi
+	@if [ ! -f ./build/Hyprland ]; then echo -en "You need to run $(MAKE) all first.\n" && exit 1; fi
 
 	mkdir -p ${PREFIX}/include/hyprland
 	mkdir -p ${PREFIX}/include/hyprland/protocols

--- a/src/plugins/PluginAPI.hpp
+++ b/src/plugins/PluginAPI.hpp
@@ -23,6 +23,7 @@ Feel like the API is missing something you'd like to use in your plugin? Open an
 #include "../helpers/Color.hpp"
 #include "HookSystem.hpp"
 #include "../SharedDefs.hpp"
+#include "../version.h"
 
 #include <any>
 #include <functional>


### PR DESCRIPTION
- Include "version.h" in PluginAPI.hpp, otherwise meson or plugin build will fail.
- Also, use `[ -f ]` to test files in Makefile instead of `-d`
