### PR TITLE
Replace find() with C++20 starts_with(), ends_with() and contains()

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -554,7 +554,7 @@ CMonitor* CCompositor::getMonitorFromName(const std::string& name) {
 
 CMonitor* CCompositor::getMonitorFromDesc(const std::string& desc) {
     for (auto& m : m_vMonitors) {
-        if (m->output->description && std::string(m->output->description).find(desc) == 0)
+        if (m->output->description && std::string(m->output->description).starts_with(desc))
             return m.get();
     }
     return nullptr;
@@ -1617,7 +1617,7 @@ CWorkspace* CCompositor::getWorkspaceByName(const std::string& name) {
 }
 
 CWorkspace* CCompositor::getWorkspaceByString(const std::string& str) {
-    if (str.find("name:") == 0) {
+    if (str.starts_with("name:")) {
         return getWorkspaceByName(str.substr(str.find_first_of(':') + 1));
     }
 
@@ -1976,14 +1976,14 @@ CMonitor* CCompositor::getMonitorFromString(const std::string& name) {
             Debug::log(ERR, "Error in getMonitorFromString: invalid arg 1");
             return nullptr;
         }
-    } else if (name.find("desc:") == 0) {
+    } else if (name.starts_with("desc:")) {
         const auto DESCRIPTION = name.substr(5);
 
         for (auto& m : m_vMonitors) {
             if (!m->output)
                 continue;
 
-            if (m->output->description && std::string(m->output->description).find(DESCRIPTION) == 0) {
+            if (m->output->description && std::string(m->output->description).starts_with(DESCRIPTION)) {
                 return m.get();
             }
         }
@@ -2245,13 +2245,13 @@ CWindow* CCompositor::getWindowByRegex(const std::string& regexp) {
 
     std::regex       regexCheck(regexp);
     std::string      matchCheck;
-    if (regexp.find("title:") == 0) {
+    if (regexp.starts_with("title:")) {
         mode       = MODE_TITLE_REGEX;
         regexCheck = std::regex(regexp.substr(6));
-    } else if (regexp.find("address:") == 0) {
+    } else if (regexp.starts_with("address:")) {
         mode       = MODE_ADDRESS;
         matchCheck = regexp.substr(8);
-    } else if (regexp.find("pid:") == 0) {
+    } else if (regexp.starts_with("pid:")) {
         mode       = MODE_PID;
         matchCheck = regexp.substr(4);
     }

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -499,15 +499,15 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
             m_sAdditionalConfigData.forceOpaque = true;
     } else if (r.szRule == "immediate") {
         m_sAdditionalConfigData.forceTearing = true;
-    } else if (r.szRule.find("rounding") == 0) {
+    } else if (r.szRule.starts_with("rounding")) {
         try {
             m_sAdditionalConfigData.rounding = std::stoi(r.szRule.substr(r.szRule.find_first_of(' ') + 1));
         } catch (std::exception& e) { Debug::log(ERR, "Rounding rule \"{}\" failed with: {}", r.szRule, e.what()); }
-    } else if (r.szRule.find("bordersize") == 0) {
+    } else if (r.szRule.starts_with("bordersize")) {
         try {
             m_sAdditionalConfigData.borderSize = std::stoi(r.szRule.substr(r.szRule.find_first_of(' ') + 1));
         } catch (std::exception& e) { Debug::log(ERR, "Bordersize rule \"{}\" failed with: {}", r.szRule, e.what()); }
-    } else if (r.szRule.find("opacity") == 0) {
+    } else if (r.szRule.starts_with("opacity")) {
         try {
             CVarList vars(r.szRule, 0, ' ');
 
@@ -540,10 +540,10 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
         } catch (std::exception& e) { Debug::log(ERR, "Opacity rule \"{}\" failed with: {}", r.szRule, e.what()); }
     } else if (r.szRule == "noanim") {
         m_sAdditionalConfigData.forceNoAnims = true;
-    } else if (r.szRule.find("animation") == 0) {
+    } else if (r.szRule.starts_with("animation")) {
         auto STYLE                             = r.szRule.substr(r.szRule.find_first_of(' ') + 1);
         m_sAdditionalConfigData.animationStyle = STYLE;
-    } else if (r.szRule.find("bordercolor") == 0) {
+    } else if (r.szRule.starts_with("bordercolor")) {
         try {
             std::string colorPart = removeBeginEndSpacesTabs(r.szRule.substr(r.szRule.find_first_of(' ') + 1));
 
@@ -559,7 +559,7 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
         m_sAdditionalConfigData.dimAround = true;
     } else if (r.szRule == "keepaspectratio") {
         m_sAdditionalConfigData.keepAspectRatio = true;
-    } else if (r.szRule.find("xray") == 0) {
+    } else if (r.szRule.starts_with("xray")) {
         CVarList vars(r.szRule, 0, ' ');
 
         try {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -369,7 +369,7 @@ void CConfigManager::init() {
 }
 
 void CConfigManager::configSetValueSafe(const std::string& COMMAND, const std::string& VALUE) {
-    if (configValues.find(COMMAND) == configValues.end()) {
+    if (!configValues.contains(COMMAND)) {
         if (!COMMAND.starts_with("device:") /* devices parsed later */ && !COMMAND.starts_with("plugin:") /* plugins parsed later */) {
             if (COMMAND[0] == '$') {
                 // register a dynamic var
@@ -2110,9 +2110,7 @@ bool CConfigManager::deviceConfigExists(const std::string& dev) {
     auto copy = dev;
     std::replace(copy.begin(), copy.end(), ' ', '-');
 
-    const auto it = deviceConfigs.find(copy);
-
-    return it != deviceConfigs.end();
+    return deviceConfigs.contains(copy);
 }
 
 bool CConfigManager::shouldBlurLS(const std::string& ns) {

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -961,7 +961,7 @@ std::string dispatchSetProp(std::string request) {
     bool       lock = false;
 
     if (vars.size() > 4) {
-        if (vars[4].find("lock") == 0) {
+        if (vars[4].starts_with("lock")) {
             lock = true;
         }
     }
@@ -1271,7 +1271,7 @@ std::string getReply(std::string request) {
         return layersRequest(format);
     else if (request == "version")
         return versionRequest(format);
-    else if (request.find("reload") == 0)
+    else if (request.starts_with("reload"))
         return reloadRequest(request);
     else if (request == "devices")
         return devicesRequest(format);
@@ -1285,27 +1285,27 @@ std::string getReply(std::string request) {
         return globalShortcutsRequest(format);
     else if (request == "animations")
         return animationsRequest(format);
-    else if (request.find("plugin") == 0)
+    else if (request.starts_with("plugin"))
         return dispatchPlugin(request);
-    else if (request.find("notify") == 0)
+    else if (request.starts_with("notify"))
         return dispatchNotify(request);
-    else if (request.find("setprop") == 0)
+    else if (request.starts_with("setprop"))
         return dispatchSetProp(request);
-    else if (request.find("seterror") == 0)
+    else if (request.starts_with("seterror"))
         return dispatchSeterror(request);
-    else if (request.find("switchxkblayout") == 0)
+    else if (request.starts_with("switchxkblayout"))
         return switchXKBLayoutRequest(request);
-    else if (request.find("output") == 0)
+    else if (request.starts_with("output"))
         return dispatchOutput(request);
-    else if (request.find("dispatch") == 0)
+    else if (request.starts_with("dispatch"))
         return dispatchRequest(request);
-    else if (request.find("keyword") == 0)
+    else if (request.starts_with("keyword"))
         return dispatchKeyword(request);
-    else if (request.find("setcursor") == 0)
+    else if (request.starts_with("setcursor"))
         return dispatchSetCursor(request);
-    else if (request.find("getoption") == 0)
+    else if (request.starts_with("getoption"))
         return dispatchGetOption(request, format);
-    else if (request.find("[[BATCH]]") == 0)
+    else if (request.starts_with("[[BATCH]]"))
         return dispatchBatch(request);
 
     return "unknown request";

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -117,7 +117,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
     PWINDOW->m_szInitialClass = g_pXWaylandManager->getAppIDClass(PWINDOW);
 
     for (auto& r : WINDOWRULES) {
-        if (r.szRule.find("monitor") == 0) {
+        if (r.szRule.starts_with("monitor")) {
             try {
                 const auto MONITORSTR = removeBeginEndSpacesTabs(r.szRule.substr(r.szRule.find(' ')));
 
@@ -151,7 +151,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
                 Debug::log(LOG, "Rule monitor, applying to {:mw}", PWINDOW);
             } catch (std::exception& e) { Debug::log(ERR, "Rule monitor failed, rule: {} -> {} | err: {}", r.szRule, r.szValue, e.what()); }
-        } else if (r.szRule.find("workspace") == 0) {
+        } else if (r.szRule.starts_with("workspace")) {
             // check if it isnt unset
             const auto WORKSPACERQ = r.szRule.substr(r.szRule.find_first_of(' ') + 1);
 
@@ -167,19 +167,19 @@ void Events::listener_mapWindow(void* owner, void* data) {
                 requestedWorkspace = "";
 
             Debug::log(LOG, "Rule workspace matched by {}, {} applied.", PWINDOW, r.szValue);
-        } else if (r.szRule.find("float") == 0) {
+        } else if (r.szRule.starts_with("float")) {
             PWINDOW->m_bIsFloating = true;
-        } else if (r.szRule.find("tile") == 0) {
+        } else if (r.szRule.starts_with("tile")) {
             PWINDOW->m_bIsFloating = false;
-        } else if (r.szRule.find("pseudo") == 0) {
+        } else if (r.szRule.starts_with("pseudo")) {
             PWINDOW->m_bIsPseudotiled = true;
-        } else if (r.szRule.find("nofocus") == 0) {
+        } else if (r.szRule.starts_with("nofocus")) {
             PWINDOW->m_bNoFocus = true;
-        } else if (r.szRule.find("noinitialfocus") == 0) {
+        } else if (r.szRule.starts_with("noinitialfocus")) {
             PWINDOW->m_bNoInitialFocus = true;
-        } else if (r.szRule.find("nofullscreenrequest") == 0) {
+        } else if (r.szRule.starts_with("nofullscreenrequest")) {
             PWINDOW->m_bNoFullscreenRequest = true;
-        } else if (r.szRule.find("nomaximizerequest") == 0) {
+        } else if (r.szRule.starts_with("nomaximizerequest")) {
             PWINDOW->m_bNoMaximizeRequest = true;
         } else if (r.szRule == "fullscreen") {
             requestsFullscreen     = true;
@@ -199,7 +199,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
             overridingNoMaximize = true;
         } else if (r.szRule == "stayfocused") {
             PWINDOW->m_bStayFocused = true;
-        } else if (r.szRule.find("group") == 0) {
+        } else if (r.szRule.starts_with("group")) {
             if (PWINDOW->m_eGroupRules & GROUP_OVERRIDE)
                 continue;
 
@@ -246,7 +246,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                 }
                 vPrev = v;
             }
-        } else if (r.szRule.find("idleinhibit") == 0) {
+        } else if (r.szRule.starts_with("idleinhibit")) {
             auto IDLERULE = r.szRule.substr(r.szRule.find_first_of(' ') + 1);
 
             if (IDLERULE == "none") {
@@ -273,7 +273,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
     const CVarList WORKSPACEARGS = CVarList(requestedWorkspace, 0, ' ');
 
     if (!WORKSPACEARGS[0].empty()) {
-        if (WORKSPACEARGS[WORKSPACEARGS.size() - 1].find("silent") == 0)
+        if (WORKSPACEARGS[WORKSPACEARGS.size() - 1].starts_with("silent"))
             workspaceSilent = true;
 
         std::string requestedWorkspaceName;
@@ -309,7 +309,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
         // size and move rules
         for (auto& r : WINDOWRULES) {
-            if (r.szRule.find("size") == 0) {
+            if (r.szRule.starts_with("size")) {
                 try {
                     const auto VALUE    = r.szRule.substr(r.szRule.find(' ') + 1);
                     const auto SIZEXSTR = VALUE.substr(0, VALUE.find(' '));
@@ -331,7 +331,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
                     PWINDOW->setHidden(false);
                 } catch (...) { Debug::log(LOG, "Rule size failed, rule: {} -> {}", r.szRule, r.szValue); }
-            } else if (r.szRule.find("minsize") == 0) {
+            } else if (r.szRule.starts_with("minsize")) {
                 try {
                     const auto VALUE    = r.szRule.substr(r.szRule.find(' ') + 1);
                     const auto SIZEXSTR = VALUE.substr(0, VALUE.find(' '));
@@ -345,7 +345,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
                     PWINDOW->setHidden(false);
                 } catch (...) { Debug::log(LOG, "Rule minsize failed, rule: {} -> {}", r.szRule, r.szValue); }
-            } else if (r.szRule.find("maxsize") == 0) {
+            } else if (r.szRule.starts_with("maxsize")) {
                 try {
                     const auto VALUE    = r.szRule.substr(r.szRule.find(' ') + 1);
                     const auto SIZEXSTR = VALUE.substr(0, VALUE.find(' '));
@@ -359,16 +359,16 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
                     PWINDOW->setHidden(false);
                 } catch (...) { Debug::log(LOG, "Rule maxsize failed, rule: {} -> {}", r.szRule, r.szValue); }
-            } else if (r.szRule.find("move") == 0) {
+            } else if (r.szRule.starts_with("move")) {
                 try {
                     auto       value = r.szRule.substr(r.szRule.find(' ') + 1);
 
-                    const bool ONSCREEN = value.find("onscreen") == 0;
+                    const bool ONSCREEN = value.starts_with("onscreen");
 
                     if (ONSCREEN)
                         value = value.substr(value.find_first_of(' ') + 1);
 
-                    const bool CURSOR = value.find("cursor") == 0;
+                    const bool CURSOR = value.starts_with("cursor");
 
                     if (CURSOR)
                         value = value.substr(value.find_first_of(' ') + 1);
@@ -379,7 +379,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                     int        posX = 0;
                     int        posY = 0;
 
-                    if (POSXSTR.find("100%-") == 0) {
+                    if (POSXSTR.starts_with("100%-")) {
                         const auto POSXRAW = POSXSTR.substr(5);
                         posX =
                             PMONITOR->vecSize.x - (!POSXRAW.contains('%') ? std::stoi(POSXRAW) : std::stof(POSXRAW.substr(0, POSXRAW.length() - 1)) * 0.01 * PMONITOR->vecSize.x);
@@ -398,7 +398,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                         }
                     }
 
-                    if (POSYSTR.find("100%-") == 0) {
+                    if (POSYSTR.starts_with("100%-")) {
                         const auto POSYRAW = POSYSTR.substr(5);
                         posY =
                             PMONITOR->vecSize.y - (!POSYRAW.contains('%') ? std::stoi(POSYRAW) : std::stof(POSYRAW.substr(0, POSYRAW.length() - 1)) * 0.01 * PMONITOR->vecSize.y);
@@ -433,7 +433,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
                     PWINDOW->setHidden(false);
                 } catch (...) { Debug::log(LOG, "Rule move failed, rule: {} -> {}", r.szRule, r.szValue); }
-            } else if (r.szRule.find("center") == 0) {
+            } else if (r.szRule.starts_with("center")) {
                 auto       RESERVEDOFFSET = Vector2D();
                 const auto ARGS           = CVarList(r.szRule, 2, ' ');
                 if (ARGS[1] == "1")

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -391,12 +391,12 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
                 int beginID = finalWSID;
                 int curID   = finalWSID;
                 while (--curID > 0 && remainingWSes > 0) {
-                    if (invalidWSes.find(curID) == invalidWSes.end()) {
+                    if (!invalidWSes.contains(curID)) {
                         remainingWSes--;
                     }
                     finalWSID = curID;
                 }
-                if (finalWSID <= 0 || invalidWSes.find(finalWSID) != invalidWSes.end()) {
+                if (finalWSID <= 0 || invalidWSes.contains(finalWSID)) {
                     if (namedWSes.size()) {
                         // Go to the named workspaces
                         // Need remainingWSes more
@@ -416,7 +416,7 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
             if (walkDir == '+') {
                 int curID = finalWSID;
                 while (++curID < INT32_MAX && remainingWSes > 0) {
-                    if (invalidWSes.find(curID) == invalidWSes.end()) {
+                    if (!invalidWSes.contains(curID)) {
                         remainingWSes--;
                     }
                     finalWSID = curID;

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -250,7 +250,7 @@ bool isDirection(const std::string& arg) {
 
 int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
     int result = INT_MAX;
-    if (in.find("special") == 0) {
+    if (in.starts_with("special")) {
         outName = "special";
 
         if (in.length() > 8) {
@@ -264,7 +264,7 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
         }
 
         return SPECIAL_WORKSPACE_START;
-    } else if (in.find("name:") == 0) {
+    } else if (in.starts_with("name:")) {
         const auto WORKSPACENAME = in.substr(in.find_first_of(':') + 1);
         const auto WORKSPACE     = g_pCompositor->getWorkspaceByName(WORKSPACENAME);
         if (!WORKSPACE) {
@@ -273,14 +273,14 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
             result = WORKSPACE->m_iID;
         }
         outName = WORKSPACENAME;
-    } else if (in.find("empty") == 0) {
+    } else if (in.starts_with("empty")) {
         int id = 0;
         while (++id < INT_MAX) {
             const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(id);
             if (!PWORKSPACE || (g_pCompositor->getWindowsOnWorkspace(id) == 0))
                 return id;
         }
-    } else if (in.find("prev") == 0) {
+    } else if (in.starts_with("prev")) {
         if (!g_pCompositor->m_pLastMonitor)
             return INT_MAX;
 
@@ -594,8 +594,8 @@ int64_t getPPIDof(int64_t pid) {
 
     return 0;
 #else
-    std::string       dir     = "/proc/" + std::to_string(pid) + "/status";
-    FILE*             infile;
+    std::string dir = "/proc/" + std::to_string(pid) + "/status";
+    FILE*       infile;
 
     infile = fopen(dir.c_str(), "r");
     if (!infile)
@@ -628,11 +628,11 @@ int64_t getPPIDof(int64_t pid) {
 }
 
 int64_t configStringToInt(const std::string& VALUE) {
-    if (VALUE.find("0x") == 0) {
+    if (VALUE.starts_with("0x")) {
         // Values with 0x are hex
         const auto VALUEWITHOUTHEX = VALUE.substr(2);
         return stol(VALUEWITHOUTHEX, nullptr, 16);
-    } else if (VALUE.find("rgba(") == 0 && VALUE.find(')') == VALUE.length() - 1) {
+    } else if (VALUE.starts_with("rgba(") && VALUE.ends_with(')')) {
         const auto VALUEWITHOUTFUNC = VALUE.substr(5, VALUE.length() - 6);
 
         if (removeBeginEndSpacesTabs(VALUEWITHOUTFUNC).length() != 8) {
@@ -644,7 +644,7 @@ int64_t configStringToInt(const std::string& VALUE) {
 
         // now we need to RGBA -> ARGB. The config holds ARGB only.
         return (RGBA >> 8) + 0x1000000 * (RGBA & 0xFF);
-    } else if (VALUE.find("rgb(") == 0 && VALUE.find(')') == VALUE.length() - 1) {
+    } else if (VALUE.starts_with("rgb(") && VALUE.ends_with(')')) {
         const auto VALUEWITHOUTFUNC = VALUE.substr(4, VALUE.length() - 5);
 
         if (removeBeginEndSpacesTabs(VALUEWITHOUTFUNC).length() != 6) {
@@ -655,9 +655,9 @@ int64_t configStringToInt(const std::string& VALUE) {
         const auto RGB = std::stol(VALUEWITHOUTFUNC, nullptr, 16);
 
         return RGB + 0xFF000000; // 0xFF for opaque
-    } else if (VALUE.find("true") == 0 || VALUE.find("on") == 0 || VALUE.find("yes") == 0) {
+    } else if (VALUE.starts_with("true") || VALUE.starts_with("on") || VALUE.starts_with("yes")) {
         return 1;
-    } else if (VALUE.find("false") == 0 || VALUE.find("off") == 0 || VALUE.find("no") == 0) {
+    } else if (VALUE.starts_with("false") || VALUE.starts_with("off") || VALUE.starts_with("no")) {
         return 0;
     }
     return std::stoll(VALUE);

--- a/src/helpers/WLClasses.cpp
+++ b/src/helpers/WLClasses.cpp
@@ -20,7 +20,7 @@ void SLayerSurface::applyRules() {
             noAnimations = true;
         else if (rule.rule == "blur")
             forceBlur = true;
-        else if (rule.rule.find("ignorealpha") == 0 || rule.rule.find("ignorezero") == 0) {
+        else if (rule.rule.starts_with("ignorealpha") || rule.rule.starts_with("ignorezero")) {
             const auto  FIRST_SPACE_POS = rule.rule.find_first_of(' ');
             std::string alphaValue      = "";
             if (FIRST_SPACE_POS != std::string::npos)
@@ -31,7 +31,7 @@ void SLayerSurface::applyRules() {
                 if (!alphaValue.empty())
                     ignoreAlphaValue = std::stof(alphaValue);
             } catch (...) { Debug::log(ERR, "Invalid value passed to ignoreAlpha"); }
-        } else if (rule.rule.find("xray") == 0) {
+        } else if (rule.rule.starts_with("xray")) {
             CVarList vars{rule.rule, 0, ' '};
             try {
                 xray = configStringToInt(vars[1]);

--- a/src/helpers/Workspace.cpp
+++ b/src/helpers/Workspace.cpp
@@ -40,7 +40,7 @@ CWorkspace::~CWorkspace() {
 void CWorkspace::startAnim(bool in, bool left, bool instant) {
     const auto ANIMSTYLE = m_fAlpha.m_pConfig->pValues->internalStyle;
 
-    if (ANIMSTYLE.find("slidefade") == 0) {
+    if (ANIMSTYLE.starts_with("slidefade")) {
         const auto PMONITOR = g_pCompositor->getMonitorFromID(m_iMonitorID);
         float      movePerc = 100.f;
 
@@ -54,7 +54,7 @@ void CWorkspace::startAnim(bool in, bool left, bool instant) {
         m_fAlpha.setValueAndWarp(1.f);
         m_vRenderOffset.setValueAndWarp(Vector2D(0, 0));
 
-        if (ANIMSTYLE.find("slidefadevert") == 0) {
+        if (ANIMSTYLE.starts_with("slidefadevert")) {
             if (in) {
                 m_fAlpha.setValueAndWarp(0.f);
                 m_vRenderOffset.setValueAndWarp(Vector2D(0, (left ? PMONITOR->vecSize.y : -PMONITOR->vecSize.y) * (movePerc / 100.f)));

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -256,8 +256,8 @@ void CAnimationManager::tick() {
                     const auto EXTENTS = PDECO->getWindowDecorationExtents();
 
                     wlr_box    dmg = {PWINDOW->m_vRealPosition.vec().x - EXTENTS.topLeft.x, PWINDOW->m_vRealPosition.vec().y - EXTENTS.topLeft.y,
-                                   PWINDOW->m_vRealSize.vec().x + EXTENTS.topLeft.x + EXTENTS.bottomRight.x,
-                                   PWINDOW->m_vRealSize.vec().y + EXTENTS.topLeft.y + EXTENTS.bottomRight.y};
+                                      PWINDOW->m_vRealSize.vec().x + EXTENTS.topLeft.x + EXTENTS.bottomRight.x,
+                                      PWINDOW->m_vRealSize.vec().y + EXTENTS.topLeft.y + EXTENTS.bottomRight.y};
 
                     if (!*PSHADOWIGNOREWINDOW) {
                         // easy, damage the entire box
@@ -429,7 +429,7 @@ void CAnimationManager::onWindowPostCreateClose(CWindow* pWindow, bool close) {
 
     if (pWindow->m_sAdditionalConfigData.animationStyle != "") {
         // the window has config'd special anim
-        if (pWindow->m_sAdditionalConfigData.animationStyle.find("slide") == 0) {
+        if (pWindow->m_sAdditionalConfigData.animationStyle.starts_with("slide")) {
             if (pWindow->m_sAdditionalConfigData.animationStyle.contains(' ')) {
                 // has a direction
                 animationSlide(pWindow, pWindow->m_sAdditionalConfigData.animationStyle.substr(pWindow->m_sAdditionalConfigData.animationStyle.find(' ') + 1), close);
@@ -458,7 +458,7 @@ void CAnimationManager::onWindowPostCreateClose(CWindow* pWindow, bool close) {
             // anim popin, fallback
 
             float minPerc = 0.f;
-            if (ANIMSTYLE.find("%") != 0) {
+            if (!ANIMSTYLE.starts_with("%")) {
                 try {
                     auto percstr = ANIMSTYLE.substr(ANIMSTYLE.find_last_of(' '));
                     minPerc      = std::stoi(percstr.substr(0, percstr.length() - 1));
@@ -473,10 +473,10 @@ void CAnimationManager::onWindowPostCreateClose(CWindow* pWindow, bool close) {
 }
 
 std::string CAnimationManager::styleValidInConfigVar(const std::string& config, const std::string& style) {
-    if (config.find("window") == 0) {
+    if (config.starts_with("window")) {
         if (style == "slide") {
             return "";
-        } else if (style.find("popin") == 0) {
+        } else if (style.starts_with("popin")) {
             // try parsing
             float minPerc = 0.f;
             if (style.find("%") != std::string::npos) {
@@ -497,7 +497,7 @@ std::string CAnimationManager::styleValidInConfigVar(const std::string& config, 
     } else if (config == "workspaces" || config == "specialWorkspace") {
         if (style == "slide" || style == "slidevert" || style == "fade")
             return "";
-        else if (style.find("slidefade") == 0) {
+        else if (style.starts_with("slidefade")) {
             // try parsing
             float movePerc = 0.f;
             if (style.find("%") != std::string::npos) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -808,9 +808,9 @@ void CKeybindManager::changeworkspace(std::string args) {
 
     const auto         PMONITOR          = g_pCompositor->m_pLastMonitor;
     const auto         PCURRENTWORKSPACE = g_pCompositor->getWorkspaceByID(PMONITOR->activeWorkspace);
-    const bool         EXPLICITPREVIOUS  = args.find("previous") == 0;
+    const bool         EXPLICITPREVIOUS  = args.starts_with("previous");
 
-    if (args.find("previous") == 0) {
+    if (args.starts_with("previous")) {
         // Do nothing if there's no previous workspace, otherwise switch to it.
         if (PCURRENTWORKSPACE->m_sPrevWorkspace.iID == -1) {
             Debug::log(LOG, "No previous workspace to change to");
@@ -1094,7 +1094,7 @@ void CKeybindManager::swapActive(std::string args) {
 void CKeybindManager::moveActiveTo(std::string args) {
     char arg = args[0];
 
-    if (args.find("mon:") == 0) {
+    if (args.starts_with("mon:")) {
         const auto PNEWMONITOR = g_pCompositor->getMonitorFromString(args.substr(4));
         if (!PNEWMONITOR)
             return;
@@ -1221,7 +1221,7 @@ void CKeybindManager::alterSplitRatio(std::string args) {
     }
 
     if (splitratio == 0) {
-        if (args.find("exact") == 0) {
+        if (args.starts_with("exact")) {
             exact      = true;
             splitratio = getPlusMinusKeywordResult(args.substr(5), 0);
         } else {
@@ -1721,10 +1721,10 @@ void CKeybindManager::toggleOpaque(std::string unused) {
 }
 
 void CKeybindManager::dpms(std::string arg) {
-    bool        enable = arg.find("on") == 0;
+    bool        enable = arg.starts_with("on");
     std::string port   = "";
 
-    if (arg.find("toggle") == 0)
+    if (arg.starts_with("toggle"))
         enable = !std::any_of(g_pCompositor->m_vMonitors.begin(), g_pCompositor->m_vMonitors.end(), [&](const auto& other) { return !other->dpmsStatus; }); // enable if any is off
 
     if (arg.find_first_of(' ') != std::string::npos)

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1001,7 +1001,7 @@ void CInputManager::setPointerConfigs() {
                 libinput_device_config_accel_set_profile(LIBINPUTDEV, LIBINPUT_CONFIG_ACCEL_PROFILE_ADAPTIVE);
             } else if (ACCELPROFILE == "flat") {
                 libinput_device_config_accel_set_profile(LIBINPUTDEV, LIBINPUT_CONFIG_ACCEL_PROFILE_FLAT);
-            } else if (ACCELPROFILE.find("custom") == 0) {
+            } else if (ACCELPROFILE.starts_with("custom")) {
                 CVarList args = {ACCELPROFILE, 0, ' '};
                 try {
                     double              step = std::stod(args[1]);
@@ -1582,7 +1582,7 @@ void CInputManager::setCursorIconOnBorder(CWindow* w) {
     wlr_box              box              = {w->m_vRealPosition.vec().x, w->m_vRealPosition.vec().y, w->m_vRealSize.vec().x, w->m_vRealSize.vec().y};
     eBorderIconDirection direction        = BORDERICON_NONE;
     wlr_box              boxFullGrabInput = {box.x - *PEXTENDBORDERGRAB - BORDERSIZE, box.y - *PEXTENDBORDERGRAB - BORDERSIZE, box.width + 2 * (*PEXTENDBORDERGRAB + BORDERSIZE),
-                                box.height + 2 * (*PEXTENDBORDERGRAB + BORDERSIZE)};
+                                             box.height + 2 * (*PEXTENDBORDERGRAB + BORDERSIZE)};
 
     if (!wlr_box_contains_point(&boxFullGrabInput, mouseCoords.x, mouseCoords.y) || (!m_lCurrentlyHeldButtons.empty() && !currentlyDraggedWindow)) {
         direction = BORDERICON_NONE;

--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -51,7 +51,7 @@ void CInputManager::onSwipeEnd(wlr_pointer_swipe_end_event* e) {
     static auto* const PSWIPENUMBER = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_numbered")->intValue;
     static auto* const PSWIPEUSER   = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_use_r")->intValue;
     const bool         VERTANIMS    = m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle == "slidevert" ||
-        m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle.find("slidefadevert") == 0;
+        m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle.starts_with("slidefadevert");
 
     // commit
     std::string wsname           = "";
@@ -200,7 +200,7 @@ void CInputManager::onSwipeUpdate(wlr_pointer_swipe_update_event* e) {
     static auto* const PSWIPEUSER             = &g_pConfigManager->getConfigValuePtr("gestures:workspace_swipe_use_r")->intValue;
 
     const bool         VERTANIMS = m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle == "slidevert" ||
-        m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle.find("slidefadevert") == 0;
+        m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle.starts_with("slidefadevert");
 
     m_sActiveSwipe.delta += VERTANIMS ? (*PSWIPEINVR ? -e->dy : e->dy) : (*PSWIPEINVR ? -e->dx : e->dx);
 

--- a/src/plugins/PluginAPI.cpp
+++ b/src/plugins/PluginAPI.cpp
@@ -153,7 +153,7 @@ APICALL bool HyprlandAPI::addConfigValue(HANDLE handle, const std::string& name,
     if (!PLUGIN)
         return false;
 
-    if (name.find("plugin:") != 0)
+    if (!name.starts_with("plugin:"))
         return false;
 
     g_pConfigManager->addPluginConfigVar(handle, name, value);

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -122,7 +122,7 @@ void CHyprOpenGLImpl::begin(CMonitor* pMonitor, CRegion* pDamage, bool fake) {
     m_iWLROutputFb = m_iCurrentOutputFb;
 
     // ensure a framebuffer for the monitor exists
-    if (m_mMonitorRenderResources.find(pMonitor) == m_mMonitorRenderResources.end() || m_RenderData.pCurrentMonData->primaryFB.m_vSize != pMonitor->vecPixelSize) {
+    if (!m_mMonitorRenderResources.contains(pMonitor) || m_RenderData.pCurrentMonData->primaryFB.m_vSize != pMonitor->vecPixelSize) {
         m_RenderData.pCurrentMonData->stencilTex.allocate();
 
         m_RenderData.pCurrentMonData->primaryFB.m_pStencilTex    = &m_RenderData.pCurrentMonData->stencilTex;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Most importantly it replaces `find(...) == 0` and `find(...) == length() - 1` for strings with `starts_with(...)` and `ends_with(...)`, as it fails earlier than `find()`. Additionally `find(...) != npos` for maps gets replaced by `contains()` for readability.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Follow up for C++23: `contains(...)` for strings.

#### Is it ready for merging, or does it need work?

Ready

