### PR TITLE
Update PluginAPI.hpp

### DIFF
--- a/src/plugins/PluginAPI.hpp
+++ b/src/plugins/PluginAPI.hpp
@@ -20,6 +20,7 @@ Feel like the API is missing something you'd like to use in your plugin? Open an
 
 #define HYPRLAND_API_VERSION "0.1"
 
+#include "../version.h"
 #include "../helpers/Color.hpp"
 #include "HookSystem.hpp"
 #include "../SharedDefs.hpp"


### PR DESCRIPTION
Include version.h for GIT_COMMIT_HASH definition

#### Describe your PR, what does it fix/add?

The commit d5a572bd39e5b29af8a17af792a43b409ae1cb06 which added a version query, does not include relevant "version.h" file for definitions

#### Is it ready for merging, or does it need work?

Previously will not compile, currently will compile after being patched.

