### PR TITLE
fix(build): do not include wlr headers directly, use includes.hpp instead.

### DIFF
--- a/src/debug/Log.hpp
+++ b/src/debug/Log.hpp
@@ -1,10 +1,10 @@
 #pragma once
 #include <string>
-#include <wlr/util/log.h>
 #include <format>
 #include <iostream>
 #include <fstream>
 #include <chrono>
+#include "../includes.hpp"
 #include "../helpers/MiscFunctions.hpp"
 
 #define LOGMESSAGESIZE 1024


### PR DESCRIPTION
Otherwise linker error because the function has been mangled.