### PR TITLE
Make new windows taking over fullscreen keep the existing mode

### DIFF
--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -473,6 +473,8 @@ void Events::listener_mapWindow(void* owner, void* data) {
             PWINDOW->m_bNoInitialFocus = true;
         else if (*PNEWTAKESOVERFS == 2)
             g_pCompositor->setWindowFullscreen(g_pCompositor->getFullscreenWindowOnWorkspace(PWORKSPACE->m_iID), false, FULLSCREEN_INVALID);
+        else if (PWORKSPACE->m_efFullscreenMode == FULLSCREEN_MAXIMIZED)
+            requestsMaximize = true;
         else
             requestsFullscreen = true;
     }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

I thought it was strange that, with `misc:new_window_takes_over_fullscreen` set to 1, creating a new window while a window was currently maximized would cause the new window to open in fullscreen. This PR makes new windows match the fullscreen mode of the existing fullscreened window.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

It should be good to go
