### PR TITLE
Fix master resizing wrong window behind in special workspace

### DIFF
--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -742,8 +742,9 @@ void CHyprMasterLayout::resizeActiveWindow(const Vector2D& pixResize, eRectCorne
         default: UNREACHABLE();
     }
 
+    const auto workspaceIdForResizing = PMONITOR->specialWorkspaceID == 0 ? PMONITOR->activeWorkspace : PMONITOR->specialWorkspaceID;
     for (auto& n : m_lMasterNodesData) {
-        if (n.isMaster && n.workspaceID == PMONITOR->activeWorkspace)
+        if (n.isMaster && n.workspaceID == workspaceIdForResizing)
             n.percMaster = std::clamp(n.percMaster + delta, 0.05, 0.95);
     }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fix master layout. When resizing in special workspace, it's resizing the wrong window behind in the normal ws.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No


#### Is it ready for merging, or does it need work?
Ready

