### PR TITLE
Fix meson.build nix patch

### DIFF
--- a/nix/patches/meson-build.patch
+++ b/nix/patches/meson-build.patch
@@ -1,10 +1,10 @@
 diff --git a/meson.build b/meson.build
-index 726933bc..28b4d9ac 100644
+index 1d2c7f9f..c5ef4e67 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -29,20 +29,7 @@ add_project_arguments(
-   ],
-   language: 'cpp')
+@@ -33,20 +33,7 @@ if cpp_compiler.check_header('execinfo.h')
+   add_project_arguments('-DHAS_EXECINFO', language: 'cpp')
+ endif
  
 -wlroots = subproject('wlroots', default_options: ['examples=false', 'renderers=gles2'])
 -have_xwlr = wlroots.get_variable('features').get('xwayland')
@@ -24,7 +24,7 @@ index 726933bc..28b4d9ac 100644
    add_project_arguments('-DNO_XWAYLAND', language: 'cpp')
  endif
  
-@@ -71,8 +58,6 @@ foreach file : headers
+@@ -75,8 +62,6 @@ foreach file : headers
    install_headers(file, subdir: 'hyprland', preserve_path: true)
  endforeach
  
@@ -34,7 +34,7 @@ index 726933bc..28b4d9ac 100644
  subdir('src')
  subdir('hyprctl')
 diff --git a/src/meson.build b/src/meson.build
-index 2065c6f5..55530605 100644
+index 0af864b9..38723b8c 100644
 --- a/src/meson.build
 +++ b/src/meson.build
 @@ -9,16 +9,16 @@ executable('Hyprland', src,


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
`meson.build` was modified in #3547 but `nix/patches/meson-build.patch` was not updated to reflect the changes.

Nix itself seems to be applying the patches via a different tool that is resilient to changes in the hunk, but `git apply` is not. This fixes `git apply ./nix/patches/meson-build.patch`

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Yes



