### PR TITLE
meson: generate version.h before install_headers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -69,13 +69,13 @@ if get_option('buildtype') == 'debug'
   add_project_arguments('-DHYPRLAND_DEBUG', language: 'cpp')
 endif
 
+version_h = run_command('sh', '-c', 'scripts/generateVersion.sh')
+
 globber = run_command('find', 'src', '-name', '*.h*', check: true)
 headers = globber.stdout().strip().split('\n')
 foreach file : headers
   install_headers(file, subdir: 'hyprland', preserve_path: true)
 endforeach
-
-version_h = run_command('sh', '-c', 'scripts/generateVersion.sh')
 
 subdir('protocols')
 subdir('src')

--- a/nix/patches/meson-build.patch
+++ b/nix/patches/meson-build.patch
@@ -24,15 +24,15 @@ index 1d2c7f9f..c5ef4e67 100644
    add_project_arguments('-DNO_XWAYLAND', language: 'cpp')
  endif
  
-@@ -75,8 +62,6 @@ foreach file : headers
-   install_headers(file, subdir: 'hyprland', preserve_path: true)
- endforeach
+@@ -69,8 +56,6 @@ if get_option('buildtype') == 'debug'
+   add_project_arguments('-DHYPRLAND_DEBUG', language: 'cpp')
+ endif
  
 -version_h = run_command('sh', '-c', 'scripts/generateVersion.sh')
 -
- subdir('protocols')
- subdir('src')
- subdir('hyprctl')
+ globber = run_command('find', 'src', '-name', '*.h*', check: true)
+ headers = globber.stdout().strip().split('\n')
+ foreach file : headers
 diff --git a/src/meson.build b/src/meson.build
 index 0af864b9..38723b8c 100644
 --- a/src/meson.build


### PR DESCRIPTION
Otherwise, `meson install` command would not install version.h as a header in a clean build.
