### PR TITLE
Attempt to fix force_zero_scaling for tablet and touch

### DIFF
--- a/src/managers/input/Tablets.cpp
+++ b/src/managers/input/Tablets.cpp
@@ -244,8 +244,6 @@ void CInputManager::focusTablet(STablet* pTab, wlr_tablet_tool* pTool, bool moti
     if (const auto PWINDOW = g_pCompositor->m_pLastWindow; PWINDOW) {
         const auto CURSORPOS = g_pInputManager->getMouseCoordsInternal();
 
-        const auto LOCAL = CURSORPOS - PWINDOW->m_vRealPosition.goalv();
-
         if (PTOOL->pSurface != g_pCompositor->m_pLastFocus)
             wlr_tablet_v2_tablet_tool_notify_proximity_out(PTOOL->wlrTabletToolV2);
 
@@ -254,8 +252,14 @@ void CInputManager::focusTablet(STablet* pTab, wlr_tablet_tool* pTool, bool moti
             wlr_tablet_v2_tablet_tool_notify_proximity_in(PTOOL->wlrTabletToolV2, pTab->wlrTabletV2, g_pCompositor->m_pLastFocus);
         }
 
-        if (motion)
-            wlr_tablet_v2_tablet_tool_notify_motion(PTOOL->wlrTabletToolV2, LOCAL.x, LOCAL.y);
+        if (motion) {
+            auto local = CURSORPOS - PWINDOW->m_vRealPosition.goalv();
+
+            if(PWINDOW->m_bIsX11)
+                local = local * PWINDOW->m_fX11SurfaceScaledBy;
+
+            wlr_tablet_v2_tablet_tool_notify_motion(PTOOL->wlrTabletToolV2, local.x, local.y);
+        }
     } else {
         if (PTOOL->pSurface)
             wlr_tablet_v2_tablet_tool_notify_proximity_out(PTOOL->wlrTabletToolV2);

--- a/src/managers/input/Tablets.cpp
+++ b/src/managers/input/Tablets.cpp
@@ -255,7 +255,7 @@ void CInputManager::focusTablet(STablet* pTab, wlr_tablet_tool* pTool, bool moti
         if (motion) {
             auto local = CURSORPOS - PWINDOW->m_vRealPosition.goalv();
 
-            if(PWINDOW->m_bIsX11)
+            if (PWINDOW->m_bIsX11)
                 local = local * PWINDOW->m_fX11SurfaceScaledBy;
 
             wlr_tablet_v2_tablet_tool_notify_motion(PTOOL->wlrTabletToolV2, local.x, local.y);

--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -33,7 +33,7 @@ void CInputManager::onTouchDown(wlr_touch_down_event* e) {
     if (m_sTouchData.touchFocusWindow) {
         if (m_sTouchData.touchFocusWindow->m_bIsX11) {
             local = (g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchFocusWindow->m_vRealPosition.goalv()) * m_sTouchData.touchFocusWindow->m_fX11SurfaceScaledBy;
-            m_sTouchData.touchSurfaceOrigin = (g_pInputManager->getMouseCoordsInternal() * m_sTouchData.touchFocusWindow->m_fX11SurfaceScaledBy) - local;
+            m_sTouchData.touchSurfaceOrigin = m_sTouchData.touchFocusWindow->m_vRealPosition.goalv();
         } else {
             g_pCompositor->vectorWindowToSurface(g_pInputManager->getMouseCoordsInternal(), m_sTouchData.touchFocusWindow, local);
             m_sTouchData.touchSurfaceOrigin = g_pInputManager->getMouseCoordsInternal() - local;
@@ -64,9 +64,8 @@ void CInputManager::onTouchMove(wlr_touch_motion_event* e) {
         wlr_cursor_warp(g_pCompositor->m_sWLRCursor, nullptr, PMONITOR->vecPosition.x + e->x * PMONITOR->vecSize.x, PMONITOR->vecPosition.y + e->y * PMONITOR->vecSize.y);
 
         auto local = g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchSurfaceOrigin;
-        if (m_sTouchData.touchFocusWindow->m_bIsX11) {
-            local = (g_pInputManager->getMouseCoordsInternal() * m_sTouchData.touchFocusWindow->m_fX11SurfaceScaledBy) - m_sTouchData.touchSurfaceOrigin;
-        }
+        if (m_sTouchData.touchFocusWindow->m_bIsX11)
+            local = local * m_sTouchData.touchFocusWindow->m_fX11SurfaceScaledBy;
 
         wlr_seat_touch_notify_motion(g_pCompositor->m_sSeat.seat, e->time_msec, e->touch_id, local.x, local.y);
         wlr_seat_pointer_notify_motion(g_pCompositor->m_sSeat.seat, e->time_msec, local.x, local.y);

--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -64,7 +64,7 @@ void CInputManager::onTouchMove(wlr_touch_motion_event* e) {
         wlr_cursor_warp(g_pCompositor->m_sWLRCursor, nullptr, PMONITOR->vecPosition.x + e->x * PMONITOR->vecSize.x, PMONITOR->vecPosition.y + e->y * PMONITOR->vecSize.y);
 
         auto local = g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchSurfaceOrigin;
-        if(m_sTouchData.touchFocusWindow->m_bIsX11) {
+        if (m_sTouchData.touchFocusWindow->m_bIsX11) {
             local = (g_pInputManager->getMouseCoordsInternal() * m_sTouchData.touchFocusWindow->m_fX11SurfaceScaledBy) - m_sTouchData.touchSurfaceOrigin;
         }
 

--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -32,12 +32,12 @@ void CInputManager::onTouchDown(wlr_touch_down_event* e) {
 
     if (m_sTouchData.touchFocusWindow) {
         if (m_sTouchData.touchFocusWindow->m_bIsX11) {
-            local = g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchFocusWindow->m_vRealPosition.goalv();
+            local = (g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchFocusWindow->m_vRealPosition.goalv()) * m_sTouchData.touchFocusWindow->m_fX11SurfaceScaledBy;
+            m_sTouchData.touchSurfaceOrigin = (g_pInputManager->getMouseCoordsInternal() * m_sTouchData.touchFocusWindow->m_fX11SurfaceScaledBy) - local;
         } else {
             g_pCompositor->vectorWindowToSurface(g_pInputManager->getMouseCoordsInternal(), m_sTouchData.touchFocusWindow, local);
+            m_sTouchData.touchSurfaceOrigin = g_pInputManager->getMouseCoordsInternal() - local;
         }
-
-        m_sTouchData.touchSurfaceOrigin = g_pInputManager->getMouseCoordsInternal() - local;
     } else if (m_sTouchData.touchFocusLS) {
         local = g_pInputManager->getMouseCoordsInternal() - Vector2D(m_sTouchData.touchFocusLS->geometry.x, m_sTouchData.touchFocusLS->geometry.y);
 
@@ -63,7 +63,10 @@ void CInputManager::onTouchMove(wlr_touch_motion_event* e) {
 
         wlr_cursor_warp(g_pCompositor->m_sWLRCursor, nullptr, PMONITOR->vecPosition.x + e->x * PMONITOR->vecSize.x, PMONITOR->vecPosition.y + e->y * PMONITOR->vecSize.y);
 
-        const auto local = g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchSurfaceOrigin;
+        auto local = g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchSurfaceOrigin;
+        if(m_sTouchData.touchFocusWindow->m_bIsX11) {
+            local = (g_pInputManager->getMouseCoordsInternal() * m_sTouchData.touchFocusWindow->m_fX11SurfaceScaledBy) - m_sTouchData.touchSurfaceOrigin;
+        }
 
         wlr_seat_touch_notify_motion(g_pCompositor->m_sSeat.seat, e->time_msec, e->touch_id, local.x, local.y);
         wlr_seat_pointer_notify_motion(g_pCompositor->m_sSeat.seat, e->time_msec, local.x, local.y);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Tries to fix tablet and touch events not scaled back (mouse is OK) when using `force_zero_scaling` on XWayland windows and output scale is not 1. (Fixing #3573 ) 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

My knowledge of the code base and event propagation mechanisms of Hyprland is really limited. I hope I haven't forgotten anything.

#### Is it ready for merging, or does it need work?

It needs to be thoroughly tested. I'm currently using it with Krita (which doesn't support Wayland) and I've done some tests with xev to check that mouse, tablet and touch positions match. 


