### PR TITLE
Close special workspace after moving windows out of it

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -949,6 +949,12 @@ void CKeybindManager::moveActiveToWorkspace(std::string args) {
 
     POLDWS->m_pLastFocusedWindow = g_pCompositor->getFirstWindowOnWorkspace(POLDWS->m_iID);
 
+    CMonitor* pOldMonitor = g_pCompositor->getMonitorFromID(POLDWS->m_iMonitorID);
+    if (pWorkspace->m_bIsSpecialWorkspace)
+        pOldMonitor->setSpecialWorkspace(pWorkspace);
+    else if (POLDWS->m_bIsSpecialWorkspace)
+        pOldMonitor->setSpecialWorkspace(nullptr);
+
     pMonitor->changeWorkspace(pWorkspace);
 
     g_pCompositor->focusWindow(PWINDOW);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -949,11 +949,10 @@ void CKeybindManager::moveActiveToWorkspace(std::string args) {
 
     POLDWS->m_pLastFocusedWindow = g_pCompositor->getFirstWindowOnWorkspace(POLDWS->m_iID);
 
-    CMonitor* pOldMonitor = g_pCompositor->getMonitorFromID(POLDWS->m_iMonitorID);
     if (pWorkspace->m_bIsSpecialWorkspace)
-        pOldMonitor->setSpecialWorkspace(pWorkspace);
+        pMonitor->setSpecialWorkspace(pWorkspace);
     else if (POLDWS->m_bIsSpecialWorkspace)
-        pOldMonitor->setSpecialWorkspace(nullptr);
+        g_pCompositor->getMonitorFromID(POLDWS->m_iMonitorID)->setSpecialWorkspace(nullptr);
 
     pMonitor->changeWorkspace(pWorkspace);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fix the issue that currently when you use `movetoworkspace` to move a window out of the special workspace into a regular WS, it doesn't close the special WS. This also causes weird behavior like being able to move windows in regular workspaces around when in the special WS. 
Seems to me that the correct behavior should be getting out of the special workspace and showing the regular workspace. If I wanted to stay in the current special WS, I would use `movetoworkspacesilent` instead.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
pending review