### PR TITLE
input: Apply scaling to cursorPosOnActivate position

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1202,7 +1202,7 @@ void CInputManager::constrainMouse(SMouse* pMouse, wlr_pointer_constraint_v1* co
                                     g_pXWaylandManager->xwaylandToWaylandCoords({PWINDOW->m_uSurface.xwayland->x, PWINDOW->m_uSurface.xwayland->y})) :
             PWINDOW->m_vRealPosition.goalv();
 
-        PCONSTRAINT->cursorPosOnActivate = MOUSECOORDS - RELATIVETO;
+        PCONSTRAINT->cursorPosOnActivate = (MOUSECOORDS - RELATIVETO) * PWINDOW->m_fX11SurfaceScaledBy;
     }
 
     if (constraint->current.committed & WLR_POINTER_CONSTRAINT_V1_STATE_CURSOR_HINT) {


### PR DESCRIPTION
When the cursor is reset in a constraint, the hint given to us is scaled by the monitor's scaling value.  If we don't get a hint, the backup position (cursorPosOnActivate) should also be scaled so that the position is correct when we unscale it later.


