### PR TITLE
Set splash as environment variable

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -75,6 +75,7 @@ CCompositor::CCompositor() {
     Debug::log(INFO, "If you are crashing, or encounter any bugs, please consult https://wiki.hyprland.org/Crashes-and-Bugs/\n\n");
 
     setRandomSplash();
+    setenv("HYPRLAND_SPLASH", m_szCurrentSplash.c_str(), true);
 
     Debug::log(LOG, "\nCurrent splash: {}\n\n", m_szCurrentSplash);
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
It loads the random selected splash into an environment variable. This to make the user able to access it later. Useful for customization.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This is a one-liner edit.

#### Is it ready for merging, or does it need work?
Ready for merging
