### PR TITLE
refactor: create a function for grouping conditions

### DIFF
--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -767,6 +767,15 @@ int CWindow::getGroupSize() {
     return size;
 }
 
+bool CWindow::canBeGroupedInto(CWindow* pWindow) {
+    return !g_pKeybindManager->m_bGroupsLocked                                          // global group lock disengaged
+        && ((m_eGroupRules & GROUP_INVADE && m_bFirstMap)                               // window ignore local group locks, or
+            || (!pWindow->getGroupHead()->m_sGroupData.locked                           //      target unlocked
+                && !(m_sGroupData.pNextWindow && getGroupHead()->m_sGroupData.locked))) //      source unlocked or isn't group
+        && !m_sGroupData.deny                                                           // source is not denied entry
+        && !(m_eGroupRules & GROUP_BARRED && m_bFirstMap);                              // group rule doesn't prevent adding window
+}
+
 CWindow* CWindow::getGroupWindowByIndex(int index) {
     const int SIZE = getGroupSize();
     index          = ((index % SIZE) + SIZE) % SIZE;

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -11,16 +11,14 @@
 #include "macros.hpp"
 #include "managers/XWaylandManager.hpp"
 
-enum eIdleInhibitMode
-{
+enum eIdleInhibitMode {
     IDLEINHIBIT_NONE = 0,
     IDLEINHIBIT_ALWAYS,
     IDLEINHIBIT_FULLSCREEN,
     IDLEINHIBIT_FOCUS
 };
 
-enum eGroupRules
-{
+enum eGroupRules {
     // effective only during first map, except for _ALWAYS variant
     GROUP_NONE        = 0,
     GROUP_SET         = 1 << 0, // Open as new group or add to focused group
@@ -379,6 +377,7 @@ class CWindow {
     CWindow*                 getGroupPrevious();
     CWindow*                 getGroupWindowByIndex(int);
     int                      getGroupSize();
+    bool                     canBeGroupedInto(CWindow* pWindow);
     void                     setGroupCurrent(CWindow* pWindow);
     void                     insertWindowToGroup(CWindow* pWindow);
     void                     updateGroupOutputs();

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -326,15 +326,8 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection dire
     }
 
     // if it's a group, add the window
-    if (OPENINGON->pWindow->m_sGroupData.pNextWindow                                                      // target is group
-        && !g_pKeybindManager->m_bGroupsLocked                                                            // global group lock disengaged
-        && ((pWindow->m_eGroupRules & GROUP_INVADE && pWindow->m_bFirstMap)                               // window ignore local group locks, or
-            || (!OPENINGON->pWindow->getGroupHead()->m_sGroupData.locked                                  //    target unlocked
-                && !(pWindow->m_sGroupData.pNextWindow && pWindow->getGroupHead()->m_sGroupData.locked))) //    source unlocked or isn't group
-        && !pWindow->m_sGroupData.deny                                                                    // source is not denied entry
-        && !(pWindow->m_eGroupRules & GROUP_BARRED && pWindow->m_bFirstMap)                               // group rule doesn't prevent adding window
-        && !m_vOverrideFocalPoint                                                                         // we are not moving window
-    ) {
+    if (OPENINGON->pWindow->m_sGroupData.pNextWindow                                  // target is group
+        && pWindow->canBeGroupedInto(OPENINGON->pWindow) && !m_vOverrideFocalPoint) { // we are not moving window
         if (!pWindow->m_sGroupData.pNextWindow)
             pWindow->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(pWindow));
 

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -108,14 +108,8 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection direc
     }
 
     // if it's a group, add the window
-    if (OPENINGON && OPENINGON != PNODE && OPENINGON->pWindow->m_sGroupData.pNextWindow                   // target is group
-        && !g_pKeybindManager->m_bGroupsLocked                                                            // global group lock disengaged
-        && ((pWindow->m_eGroupRules & GROUP_INVADE && pWindow->m_bFirstMap)                               // window ignore local group locks, or
-            || (!OPENINGON->pWindow->getGroupHead()->m_sGroupData.locked                                  //    target unlocked
-                && !(pWindow->m_sGroupData.pNextWindow && pWindow->getGroupHead()->m_sGroupData.locked))) //    source unlocked or isn't group
-        && !pWindow->m_sGroupData.deny                                                                    // source is not denied entry
-        && !(pWindow->m_eGroupRules & GROUP_BARRED)                                                       // group rule doesn't prevent adding window
-    ) {
+    if (OPENINGON && OPENINGON != PNODE && OPENINGON->pWindow->m_sGroupData.pNextWindow // target is group
+        && pWindow->canBeGroupedInto(OPENINGON->pWindow)) {
 
         if (!pWindow->m_sGroupData.pNextWindow)
             pWindow->m_dWindowDecorations.emplace_back(std::make_unique<CHyprGroupBarDecoration>(pWindow));

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -307,12 +307,7 @@ bool CHyprGroupBarDecoration::allowsInput() {
 
 bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(CWindow* pDraggedWindow, const Vector2D& pos) {
 
-    if (!(!g_pKeybindManager->m_bGroupsLocked                                                                             // global group lock disengaged
-          && ((pDraggedWindow->m_eGroupRules & GROUP_INVADE && pDraggedWindow->m_bFirstMap)                               // window ignore local group locks, or
-              || (!m_pWindow->getGroupHead()->m_sGroupData.locked                                                         //    target unlocked
-                  && !(pDraggedWindow->m_sGroupData.pNextWindow && pDraggedWindow->getGroupHead()->m_sGroupData.locked))) //    source unlocked or isn't group
-          && !pDraggedWindow->m_sGroupData.deny                                                                           // source is not denied entry
-          && !(pDraggedWindow->m_eGroupRules & GROUP_BARRED && pDraggedWindow->m_bFirstMap)))                             // group rule doesn't prevent adding window
+    if (!pDraggedWindow->canBeGroupedInto(m_pWindow))
         return true;
 
     const float BARRELATIVEX = pos.x - m_vLastWindowPos.x - m_fBarWidth / 2;


### PR DESCRIPTION
creates `canBeGroupedInto(CWindow*)` to check whether a window can be grouped or not
simply moves duplicated code
didn't find any and shouldn't cause any issues

function might need a better name