### PR TITLE
meson: enable ndebug on release builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,7 @@ project('Hyprland', 'cpp', 'c',
     'default_library=static',
     'optimization=3',
     'buildtype=release',
+    'b_ndebug=if-release',
     'debug=false'
     # 'cpp_std=c++23' # not yet supported by meson, as of version 0.63.0
     ])


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Disables asserts on release builds. Hyprland uses it's own assert macro that is unaffected by this, but it could apply to dependencies.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Yes.
