### PR TITLE
debug: check only ISDEBUG

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -715,10 +715,7 @@ std::string versionRequest(HyprCtl::eHyprCtlOutputFormat format) {
 #ifdef LEGACY_RENDERER
         result += "legacyrenderer\n";
 #endif
-#ifndef NDEBUG
-        result += "debug\n";
-#endif
-#ifdef HYPRLAND_DEBUG
+#ifndef ISDEBUG
         result += "debug\n";
 #endif
 #ifdef NO_XWAYLAND
@@ -740,10 +737,7 @@ std::string versionRequest(HyprCtl::eHyprCtlOutputFormat format) {
 #ifdef LEGACY_RENDERER
         result += "\"legacyrenderer\",";
 #endif
-#ifndef NDEBUG
-        result += "\"debug\",";
-#endif
-#ifdef HYPRLAND_DEBUG
+#ifndef ISDEBUG
         result += "\"debug\",";
 #endif
 #ifdef NO_XWAYLAND


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

`ISDEBUG` is set in https://github.com/andresilva/Hyprland/blob/b8541ca590a515d22a5623c9c7ce47fd2b4cf23c/src/macros.hpp#L7-L15 and accounts for `NDEBUG` and `HYPRLAND_DEBUG`. There's no reason to check both here, and right now it even leads to `hyprctl version` reporting `debug` flags for `release` builds (since `NDEBUG` is not defined).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Yes.
