### PR TITLE
fixes for dragging groups onto groupbars

### DIFF
--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -314,13 +314,14 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(CWindow* pDraggedWindow, con
     const int   WINDOWINDEX  = BARRELATIVEX < 0 ? -1 : (BARRELATIVEX) / (m_fBarWidth + BAR_HORIZONTAL_PADDING);
 
     CWindow*    pWindowInsertAfter = m_pWindow->getGroupWindowByIndex(WINDOWINDEX);
+    CWindow*    pDraggedHead       = pDraggedWindow->m_sGroupData.pNextWindow ? pDraggedWindow->getGroupHead() : pDraggedWindow;
 
-    g_pLayoutManager->getCurrentLayout()->onWindowRemoved(pDraggedWindow);
+    g_pLayoutManager->getCurrentLayout()->onWindowRemovedTiling(pDraggedWindow);
 
     pWindowInsertAfter->insertWindowToGroup(pDraggedWindow);
 
     if (WINDOWINDEX == -1)
-        std::swap(pDraggedWindow->m_sGroupData.head, pDraggedWindow->m_sGroupData.pNextWindow->m_sGroupData.head);
+        std::swap(pDraggedHead->m_sGroupData.head, pDraggedWindow->m_sGroupData.pNextWindow->m_sGroupData.head);
 
     m_pWindow->setGroupCurrent(pDraggedWindow);
     pDraggedWindow->applyGroupRules();


### PR DESCRIPTION
fixes issues when dragging multiple windows group into a groupbar

there is an issue when dragging a window out a group
seems to be caused by https://github.com/hyprwm/Hyprland/commit/7f35f33b4ca16509e127976772db6abd9abf100b
window does gets stretched (likely from the hacky way it's being handled) and does not get redrawn
not really related to this PR, but apart from that didn't find any other issues