### PR TITLE
fix: Nautilus Popup clipping outside monitor

### DIFF
--- a/src/events/Popups.cpp
+++ b/src/events/Popups.cpp
@@ -4,6 +4,7 @@
 #include "../helpers/WLClasses.hpp"
 #include "../managers/input/InputManager.hpp"
 #include "../render/Renderer.hpp"
+#include <wlr/util/region.h>
 
 // --------------------------------------------- //
 //   _____   ____  _____  _    _ _____   _____   //
@@ -185,6 +186,14 @@ void Events::listener_repositionPopupXDG(void* owner, void* data) {
 
     PPOPUP->lastPos             = {lx - extents.x, ly - extents.y};
     PPOPUP->repositionRequested = true;
+
+    const auto PMONITOR = g_pCompositor->m_pLastMonitor;
+
+    wlr_box    box = {.x      = PMONITOR->vecPosition.x - lx + PPOPUP->popup->current.geometry.x,
+                      .y      = PMONITOR->vecPosition.y - ly + PPOPUP->popup->current.geometry.y,
+                      .width  = PMONITOR->vecSize.x,
+                      .height = PMONITOR->vecSize.y};
+    wlr_xdg_popup_unconstrain_from_box(PPOPUP->popup, &box);
 }
 
 void Events::listener_unmapPopupXDG(void* owner, void* data) {

--- a/src/events/Popups.cpp
+++ b/src/events/Popups.cpp
@@ -188,10 +188,8 @@ void Events::listener_repositionPopupXDG(void* owner, void* data) {
 
     const auto PMONITOR = g_pCompositor->m_pLastMonitor;
 
-    wlr_box    box = {.x      = PMONITOR->vecPosition.x - lx + PPOPUP->popup->current.geometry.x,
-                      .y      = PMONITOR->vecPosition.y - ly + PPOPUP->popup->current.geometry.y,
-                      .width  = PMONITOR->vecSize.x,
-                      .height = PMONITOR->vecSize.y};
+    wlr_box    box = {PMONITOR->vecPosition.x - lx + PPOPUP->popup->current.geometry.x, PMONITOR->vecPosition.y - ly + PPOPUP->popup->current.geometry.y, PMONITOR->vecSize.x,
+                      PMONITOR->vecSize.y};
     wlr_xdg_popup_unconstrain_from_box(PPOPUP->popup, &box);
 }
 

--- a/src/events/Popups.cpp
+++ b/src/events/Popups.cpp
@@ -4,7 +4,6 @@
 #include "../helpers/WLClasses.hpp"
 #include "../managers/input/InputManager.hpp"
 #include "../render/Renderer.hpp"
-#include <wlr/util/region.h>
 
 // --------------------------------------------- //
 //   _____   ____  _____  _    _ _____   _____   //


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes Nautilus Popup clipping outside Monitor
https://github.com/hyprwm/Hyprland/issues/3038

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
-

#### Is it ready for merging, or does it need work?
I would say ready, tested nautilus, dolphin, thunar, firefox and a few smaller random programs, all work as expected.

Used the logic from sway, does this make sense?

```
	// the output box expressed in the coordinate system of the toplevel parent
	// of the popup
	struct wlr_box output_toplevel_sx_box = {
		.x = output->lx - view->container->pending.content_x + view->geometry.x,
		.y = output->ly - view->container->pending.content_y + view->geometry.y,
		.width = output->width,
		.height = output->height,
	};
```
