### PR TITLE
group: dragging into floating groups

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -650,7 +650,7 @@ CWindow* CCompositor::vectorToWindowTiled(const Vector2D& pos) {
     return nullptr;
 }
 
-CWindow* CCompositor::vectorToWindowIdeal(const Vector2D& pos) {
+CWindow* CCompositor::vectorToWindowIdeal(const Vector2D& pos, CWindow* pIgnoreWindow) {
     const auto         PMONITOR          = getMonitorFromVector(pos);
     static auto* const PRESIZEONBORDER   = &g_pConfigManager->getConfigValuePtr("general:resize_on_border")->intValue;
     static auto* const PBORDERSIZE       = &g_pConfigManager->getConfigValuePtr("general:border_size")->intValue;
@@ -661,7 +661,7 @@ CWindow* CCompositor::vectorToWindowIdeal(const Vector2D& pos) {
     for (auto& w : m_vWindows | std::views::reverse) {
         const auto BB  = w->getWindowInputBox();
         CBox       box = {BB.x - BORDER_GRAB_AREA, BB.y - BORDER_GRAB_AREA, BB.width + 2 * BORDER_GRAB_AREA, BB.height + 2 * BORDER_GRAB_AREA};
-        if (w->m_bIsFloating && w->m_bIsMapped && !w->isHidden() && !w->m_bX11ShouldntFocus && w->m_bPinned && !w->m_bNoFocus) {
+        if (w->m_bIsFloating && w->m_bIsMapped && !w->isHidden() && !w->m_bX11ShouldntFocus && w->m_bPinned && !w->m_bNoFocus && w.get() != pIgnoreWindow) {
             if (box.containsPoint({m_sWLRCursor->x, m_sWLRCursor->y}))
                 return w.get();
 
@@ -681,7 +681,7 @@ CWindow* CCompositor::vectorToWindowIdeal(const Vector2D& pos) {
 
             const auto BB  = w->getWindowInputBox();
             CBox       box = {BB.x - BORDER_GRAB_AREA, BB.y - BORDER_GRAB_AREA, BB.width + 2 * BORDER_GRAB_AREA, BB.height + 2 * BORDER_GRAB_AREA};
-            if (w->m_bIsFloating && w->m_bIsMapped && isWorkspaceVisible(w->m_iWorkspaceID) && !w->isHidden() && !w->m_bPinned && !w->m_bNoFocus) {
+            if (w->m_bIsFloating && w->m_bIsMapped && isWorkspaceVisible(w->m_iWorkspaceID) && !w->isHidden() && !w->m_bPinned && !w->m_bNoFocus && w.get() != pIgnoreWindow) {
                 // OR windows should add focus to parent
                 if (w->m_bX11ShouldntFocus && w->m_iX11Type != 2)
                     continue;
@@ -711,7 +711,8 @@ CWindow* CCompositor::vectorToWindowIdeal(const Vector2D& pos) {
 
             const int64_t WORKSPACEID = special ? PMONITOR->specialWorkspaceID : PMONITOR->activeWorkspace;
 
-            if (!w->m_bIsX11 && !w->m_bIsFloating && w->m_bIsMapped && w->m_iWorkspaceID == WORKSPACEID && !w->isHidden() && !w->m_bX11ShouldntFocus && !w->m_bNoFocus) {
+            if (!w->m_bIsX11 && !w->m_bIsFloating && w->m_bIsMapped && w->m_iWorkspaceID == WORKSPACEID && !w->isHidden() && !w->m_bX11ShouldntFocus && !w->m_bNoFocus &&
+                w.get() != pIgnoreWindow) {
                 if ((w)->hasPopupAt(pos))
                     return w.get();
             }
@@ -723,7 +724,8 @@ CWindow* CCompositor::vectorToWindowIdeal(const Vector2D& pos) {
             const int64_t WORKSPACEID = special ? PMONITOR->specialWorkspaceID : PMONITOR->activeWorkspace;
 
             CBox          box = {w->m_vPosition.x, w->m_vPosition.y, w->m_vSize.x, w->m_vSize.y};
-            if (!w->m_bIsFloating && w->m_bIsMapped && box.containsPoint(pos) && w->m_iWorkspaceID == WORKSPACEID && !w->isHidden() && !w->m_bX11ShouldntFocus && !w->m_bNoFocus)
+            if (!w->m_bIsFloating && w->m_bIsMapped && box.containsPoint(pos) && w->m_iWorkspaceID == WORKSPACEID && !w->isHidden() && !w->m_bX11ShouldntFocus && !w->m_bNoFocus &&
+                w.get() != pIgnoreWindow)
                 return w.get();
         }
 

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -29,8 +29,7 @@
 #include "plugins/PluginSystem.hpp"
 #include "helpers/Watchdog.hpp"
 
-enum eManagersInitStage
-{
+enum eManagersInitStage {
     STAGE_PRIORITY = 0,
     STAGE_LATE
 };
@@ -137,7 +136,7 @@ class CCompositor {
     void           focusSurface(wlr_surface*, CWindow* pWindowOwner = nullptr);
     bool           windowExists(CWindow*);
     bool           windowValidMapped(CWindow*);
-    CWindow*       vectorToWindowIdeal(const Vector2D&); // used only for finding a window to focus on, basically a "findFocusableWindow"
+    CWindow*       vectorToWindowIdeal(const Vector2D&, CWindow* pIgnoreWindow = nullptr); // used only for finding a window to focus on, basically a "findFocusableWindow"
     CWindow*       vectorToWindowTiled(const Vector2D&);
     wlr_surface*   vectorToLayerSurface(const Vector2D&, std::vector<std::unique_ptr<SLayerSurface>>*, Vector2D*, SLayerSurface**);
     wlr_surface*   vectorWindowToSurface(const Vector2D&, CWindow*, Vector2D& sl);

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -270,7 +270,7 @@ void IHyprLayout::onEndDragWindow() {
         const auto MOUSECOORDS = g_pInputManager->getMouseCoordsInternal();
         CWindow*   pWindow     = g_pCompositor->vectorToWindowIdeal(MOUSECOORDS, DRAGGINGWINDOW);
 
-        if (pWindow) {
+        if (pWindow && pWindow->m_bIsFloating) {
             for (auto& wd : pWindow->m_dWindowDecorations) {
                 if (!(wd->getDecorationFlags() & DECORATION_ALLOWS_MOUSE_INPUT))
                     continue;

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -1,6 +1,7 @@
 #include "IHyprLayout.hpp"
 #include "../defines.hpp"
 #include "../Compositor.hpp"
+#include "../render/decorations/CHyprGroupBarDecoration.hpp"
 
 void IHyprLayout::onWindowCreated(CWindow* pWindow, eDirection direction) {
     if (pWindow->m_bIsFloating) {
@@ -264,10 +265,36 @@ void IHyprLayout::onEndDragWindow() {
         g_pInputManager->refocus();
         changeWindowFloatingMode(DRAGGINGWINDOW);
         DRAGGINGWINDOW->m_vLastFloatingSize = m_vDraggingWindowOriginalFloatSize;
+    } else if (g_pInputManager->dragMode == MBIND_MOVE) {
+        g_pHyprRenderer->damageWindow(DRAGGINGWINDOW);
+        const auto MOUSECOORDS = g_pInputManager->getMouseCoordsInternal();
+        CWindow*   pWindow     = g_pCompositor->vectorToWindowIdeal(MOUSECOORDS, DRAGGINGWINDOW);
+
+        if (pWindow) {
+            for (auto& wd : pWindow->m_dWindowDecorations) {
+                if (!(wd->getDecorationFlags() & DECORATION_ALLOWS_MOUSE_INPUT))
+                    continue;
+
+                if (g_pDecorationPositioner->getWindowDecorationBox(wd.get()).containsPoint(MOUSECOORDS)) {
+                    if (!wd->onEndWindowDragOnDeco(DRAGGINGWINDOW, MOUSECOORDS))
+                        return;
+                    break;
+                }
+            }
+
+            if (pWindow->m_sGroupData.pNextWindow && DRAGGINGWINDOW->canBeGroupedInto(pWindow)) {
+                static const auto* USECURRPOS = &g_pConfigManager->getConfigValuePtr("group:insert_after_current")->intValue;
+                (*USECURRPOS ? pWindow : pWindow->getGroupTail())->insertWindowToGroup(DRAGGINGWINDOW);
+                pWindow->setGroupCurrent(DRAGGINGWINDOW);
+                DRAGGINGWINDOW->updateWindowDecos();
+
+                if (!DRAGGINGWINDOW->getDecorationByType(DECORATION_GROUPBAR))
+                    DRAGGINGWINDOW->addWindowDeco(std::make_unique<CHyprGroupBarDecoration>(DRAGGINGWINDOW));
+            }
+        }
     }
 
     g_pHyprRenderer->damageWindow(DRAGGINGWINDOW);
-
     g_pCompositor->focusWindow(DRAGGINGWINDOW);
 
     g_pInputManager->m_bWasDraggingWindow = false;

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -344,6 +344,9 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(CWindow* pDraggedWindow, con
     pDraggedWindow->updateWindowDecos();
     g_pLayoutManager->getCurrentLayout()->recalculateWindow(pDraggedWindow);
 
+    if (!pDraggedWindow->getDecorationByType(DECORATION_GROUPBAR))
+        pDraggedWindow->addWindowDeco(std::make_unique<CHyprGroupBarDecoration>(pDraggedWindow));
+
     return false;
 }
 


### PR DESCRIPTION
allows dragging floating windows into floating groups

didn't find any issues caused by this PR


found unrelated issues
- each group window having a different z order
- same issue as on the other PR, windows having not being displayed properly until resize after https://github.com/hyprwm/Hyprland/commit/7f35f33b4ca16509e127976772db6abd9abf100b

I'll see if I can find what's causing the 2nd one