### PR TITLE
renderer: fix legacy_renderer build

### DIFF
--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -757,7 +757,12 @@ uint32_t drmFormatToGL(uint32_t drm) {
         case DRM_FORMAT_XRGB8888:
         case DRM_FORMAT_XBGR8888: return GL_RGBA; // doesn't matter, opengl is gucci in this case.
         case DRM_FORMAT_XRGB2101010:
-        case DRM_FORMAT_XBGR2101010: return GL_RGB10_A2;
+        case DRM_FORMAT_XBGR2101010:
+#ifdef GLES2
+            return GL_RGB10_A2_EXT;
+#else
+            return GL_RGB10_A2;
+#endif
         default: return GL_RGBA;
     }
     UNREACHABLE();

--- a/src/render/Framebuffer.cpp
+++ b/src/render/Framebuffer.cpp
@@ -6,7 +6,13 @@ bool CFramebuffer::alloc(int w, int h, uint32_t drmFormat) {
     RASSERT((w > 1 && h > 1), "cannot alloc a FB with negative / zero size! (attempted {}x{})", w, h);
 
     uint32_t glFormat = drmFormatToGL(drmFormat);
-    uint32_t glType   = glFormat != GL_RGBA ? GL_UNSIGNED_INT_2_10_10_10_REV : GL_UNSIGNED_BYTE;
+    uint32_t glType   = glFormat != GL_RGBA ?
+#ifdef GLES2
+        GL_UNSIGNED_INT_2_10_10_10_REV_EXT :
+#else
+        GL_UNSIGNED_INT_2_10_10_10_REV :
+#endif
+        GL_UNSIGNED_BYTE;
 
     if (m_iFb == (uint32_t)-1) {
         firstAlloc = true;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

4b592d0 added  `GL_RGB10_A2` and `GL_UNSIGNED_INT_2_10_10_10_REV`, which are defined in GLES2 as `GL_RGB10_A2_EXT` and `GL_UNSIGNED_INT_2_10_10_10_REV_EXT` respectively. This causes legacy_renderer builds to fail.

```
[30/90] Building CXX object CMakeFiles/Hyprland.dir/src/helpers/MiscFunctions.cpp.o
FAILED: CMakeFiles/Hyprland.dir/src/helpers/MiscFunctions.cpp.o 
/usr/bin/c++ -DHAS_EXECINFO -DHyprland_EXPORTS -DLEGACY_RENDERER -DWLR_USE_UNSTABLE -I/home/me/src/Hyprland/. -I/home/me/src/Hyprland/src -I/home/me/src/Hyprland/subprojects/wlroots/include -I/home/me/src/Hyprland/subprojects/wlroots/build/include -I/home/me/src/Hyprland/subprojects/udis86 -I/home/me/src/Hyprland/protocols -I/home/me/src/Hyprland/subprojects/udis86/libudis86 -isystem /usr/include/libdrm -isystem /usr/include/pango-1.0 -isystem /usr/include/cairo -isystem /usr/include/glib-2.0 -isystem /usr/lib64/glib-2.0/include -isystem /usr/include/pixman-1 -isystem /usr/include/freetype2 -isystem /usr/include/harfbuzz -isystem /usr/include/blkid -isystem /usr/include/fribidi -isystem /usr/include/libmount -isystem /usr/include/libpng16 -isystem /usr/lib64/libffi/include -O3 -DNDEBUG -std=gnu++23 -O3 -Wall -Wextra -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wno-narrowing -Wno-pointer-arith -pthread -Winvalid-pch -include /home/me/src/Hyprland/build/CMakeFiles/Hyprland.dir/cmake_pch.hxx -MD -MT CMakeFiles/Hyprland.dir/src/helpers/MiscFunctions.cpp.o -MF CMakeFiles/Hyprland.dir/src/helpers/MiscFunctions.cpp.o.d -o CMakeFiles/Hyprland.dir/src/helpers/MiscFunctions.cpp.o -c /home/me/src/Hyprland/src/helpers/MiscFunctions.cpp
/home/me/src/Hyprland/src/helpers/MiscFunctions.cpp: In function ‘uint32_t drmFormatToGL(uint32_t)’:
/home/me/src/Hyprland/src/helpers/MiscFunctions.cpp:760:45: error: ‘GL_RGB10_A2’ was not declared in this scope; did you mean ‘GL_RGB10_EXT’?
  760 |         case DRM_FORMAT_XBGR2101010: return GL_RGB10_A2;
      |                                             ^~~~~~~~~~~
      |                                             GL_RGB10_EXT
```

#### Is it ready for merging, or does it need work?

Ready.