### PR TITLE
Master layout: fix drop_at_cursor when there are only two windows

### DIFF
--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -192,7 +192,8 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection direc
         }
     }
 
-    if (*PNEWISMASTER || WINDOWSONWORKSPACE == 1 || (WINDOWSONWORKSPACE > 2 && !pWindow->m_bFirstMap && OPENINGON->isMaster) || forceDropAsMaster) {
+    if ((*PNEWISMASTER && g_pInputManager->dragMode != MBIND_MOVE) || WINDOWSONWORKSPACE == 1 || (WINDOWSONWORKSPACE > 2 && !pWindow->m_bFirstMap && OPENINGON->isMaster) ||
+        forceDropAsMaster) {
         for (auto& nd : m_lMasterNodesData) {
             if (nd.isMaster && nd.workspaceID == PNODE->workspaceID) {
                 nd.isMaster      = false;

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -133,34 +133,66 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection direc
     const auto         PWORKSPACEDATA = getMasterWorkspaceData(pWindow->m_iWorkspaceID);
     eOrientation       orientation    = PWORKSPACEDATA->orientation;
     const auto         NODEIT         = std::find(m_lMasterNodesData.begin(), m_lMasterNodesData.end(), *PNODE);
+
+    bool               forceDropAsMaster = false;
+    // if dragging window to move, drop it at the cursor position instead of bottom/top of stack
     if (*PDROPATCURSOR && g_pInputManager->dragMode == MBIND_MOVE) {
-        // if dragging window to move, drop it at the cursor position instead of bottom/top of stack
-        for (auto it = m_lMasterNodesData.begin(); it != m_lMasterNodesData.end(); ++it) {
-            if (it->workspaceID != pWindow->m_iWorkspaceID)
-                continue;
-            const wlr_box box = it->pWindow->getWindowIdealBoundingBoxIgnoreReserved();
-            if (wlr_box_contains_point(&box, MOUSECOORDS.x, MOUSECOORDS.y)) { // TODO: Deny when not using mouse
-                switch (orientation) {
-                    case ORIENTATION_LEFT:
-                    case ORIENTATION_RIGHT:
-                        if (MOUSECOORDS.y > it->pWindow->middle().y)
-                            ++it;
-                        break;
-                    case ORIENTATION_TOP:
-                    case ORIENTATION_BOTTOM:
-                        if (MOUSECOORDS.x > it->pWindow->middle().x)
-                            ++it;
-                        break;
-                    case ORIENTATION_CENTER: break;
-                    default: UNREACHABLE();
+        if (WINDOWSONWORKSPACE > 2) {
+            for (auto it = m_lMasterNodesData.begin(); it != m_lMasterNodesData.end(); ++it) {
+                if (it->workspaceID != pWindow->m_iWorkspaceID)
+                    continue;
+                const wlr_box box = it->pWindow->getWindowIdealBoundingBoxIgnoreReserved();
+                if (wlr_box_contains_point(&box, MOUSECOORDS.x, MOUSECOORDS.y)) {
+                    switch (orientation) {
+                        case ORIENTATION_LEFT:
+                        case ORIENTATION_RIGHT:
+                            if (MOUSECOORDS.y > it->pWindow->middle().y)
+                                ++it;
+                            break;
+                        case ORIENTATION_TOP:
+                        case ORIENTATION_BOTTOM:
+                            if (MOUSECOORDS.x > it->pWindow->middle().x)
+                                ++it;
+                            break;
+                        case ORIENTATION_CENTER: break;
+                        default: UNREACHABLE();
+                    }
+                    m_lMasterNodesData.splice(it, m_lMasterNodesData, NODEIT);
+                    break;
                 }
-                m_lMasterNodesData.splice(it, m_lMasterNodesData, NODEIT);
-                break;
+            }
+        } else if (WINDOWSONWORKSPACE == 2) {
+            // when dropping as the second tiled window in the workspace,
+            // make it the master only if the cursor is on the master side of the screen
+            for (auto& nd : m_lMasterNodesData) {
+                if (nd.isMaster && nd.workspaceID == PNODE->workspaceID) {
+                    switch (orientation) {
+                        case ORIENTATION_LEFT:
+                        case ORIENTATION_CENTER:
+                            if (MOUSECOORDS.x < nd.pWindow->middle().x)
+                                forceDropAsMaster = true;
+                            break;
+                        case ORIENTATION_RIGHT:
+                            if (MOUSECOORDS.x > nd.pWindow->middle().x)
+                                forceDropAsMaster = true;
+                            break;
+                        case ORIENTATION_TOP:
+                            if (MOUSECOORDS.y < nd.pWindow->middle().y)
+                                forceDropAsMaster = true;
+                            break;
+                        case ORIENTATION_BOTTOM:
+                            if (MOUSECOORDS.y > nd.pWindow->middle().y)
+                                forceDropAsMaster = true;
+                            break;
+                        default: UNREACHABLE();
+                    }
+                    break;
+                }
             }
         }
     }
 
-    if (*PNEWISMASTER || WINDOWSONWORKSPACE == 1 || (!pWindow->m_bFirstMap && OPENINGON->isMaster)) {
+    if (*PNEWISMASTER || WINDOWSONWORKSPACE == 1 || (WINDOWSONWORKSPACE > 2 && !pWindow->m_bFirstMap && OPENINGON->isMaster) || forceDropAsMaster) {
         for (auto& nd : m_lMasterNodesData) {
             if (nd.isMaster && nd.workspaceID == PNODE->workspaceID) {
                 nd.isMaster      = false;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
drop_at_cursor currently doesn't work when there are only two windows in the workspace (it always makes the dropped window the master even when it's dropped on the stack's side of the screen).
The pr fixes this so that when the window is dropped on the stack's side, it becomes a stack window instead. If it's dropped on the master's side, it becomes the master.

Also fixes drop_at_cursor when new_is_master is enabled. Previously didn't work.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready

