### PR TITLE
Decos: Window decoration flags, shadow improvements

### DIFF
--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -146,7 +146,7 @@ wlr_box CWindow::getWindowInputBox() {
 
     for (auto& wd : m_dWindowDecorations) {
 
-        if (!wd->allowsInput())
+        if (!(wd->getDecorationFlags() & DECORATION_ALLOWS_MOUSE_INPUT))
             continue;
 
         const auto EXTENTS = wd->getWindowDecorationExtents();

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -317,7 +317,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection dire
 
     if (!m_vOverrideFocalPoint && g_pInputManager->m_bWasDraggingWindow) {
         for (auto& wd : OPENINGON->pWindow->m_dWindowDecorations) {
-            if (!wd->allowsInput())
+            if (!(wd->getDecorationFlags() & DECORATION_ALLOWS_MOUSE_INPUT))
                 continue;
 
             if (wd->getWindowDecorationRegion().containsPoint(MOUSECOORDS)) {

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -96,7 +96,7 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection direc
 
     if (g_pInputManager->m_bWasDraggingWindow && OPENINGON) {
         for (auto& wd : OPENINGON->pWindow->m_dWindowDecorations) {
-            if (!wd->allowsInput())
+            if (!(wd->getDecorationFlags() & DECORATION_ALLOWS_MOUSE_INPUT))
                 continue;
 
             if (wd->getWindowDecorationRegion().containsPoint(MOUSECOORDS)) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1841,7 +1841,7 @@ void CKeybindManager::mouse(std::string args) {
 
             if (pWindow && !pWindow->m_bIsFullscreen && !pWindow->hasPopupAt(mouseCoords)) {
                 for (auto& wd : pWindow->m_dWindowDecorations) {
-                    if (!wd->allowsInput())
+                    if (!(wd->getDecorationFlags() & DECORATION_ALLOWS_MOUSE_INPUT))
                         continue;
 
                     if (wd->getWindowDecorationRegion().containsPoint(mouseCoords)) {

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -585,7 +585,7 @@ void CInputManager::processMouseDownNormal(wlr_pointer_button_event* e) {
 
     if (w && !w->m_bIsFullscreen && !w->hasPopupAt(mouseCoords)) {
         for (auto& wd : w->m_dWindowDecorations) {
-            if (!wd->allowsInput())
+            if (!(wd->getDecorationFlags() & DECORATION_ALLOWS_MOUSE_INPUT))
                 continue;
 
             if (wd->getWindowDecorationRegion().containsPoint(mouseCoords)) {
@@ -1634,11 +1634,11 @@ void CInputManager::setCursorIconOnBorder(CWindow* w) {
 
         bool onDeco = false;
 
-        for (auto& d : w->m_dWindowDecorations) {
-            if (!d->allowsInput())
+        for (auto& wd : w->m_dWindowDecorations) {
+            if (!(wd->getDecorationFlags() & DECORATION_ALLOWS_MOUSE_INPUT))
                 continue;
 
-            if (d->getWindowDecorationRegion().containsPoint(mouseCoords)) {
+            if (wd->getWindowDecorationRegion().containsPoint(mouseCoords)) {
                 onDeco = true;
                 break;
             }

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -111,7 +111,7 @@ class CHyprOpenGLImpl {
     void               renderTexture(wlr_texture*, wlr_box*, float a, int round = 0, bool allowCustomUV = false);
     void               renderTexture(const CTexture&, wlr_box*, float a, int round = 0, bool discardActive = false, bool allowCustomUV = false);
     void               renderTextureWithBlur(const CTexture&, wlr_box*, float a, wlr_surface* pSurface, int round = 0, bool blockBlurOptimization = false, float blurA = 1.f);
-    void               renderRoundedShadow(wlr_box*, int round, int range, float a = 1.0);
+    void               renderRoundedShadow(wlr_box*, int round, int range, float a = 1.0, CFramebuffer* matte = nullptr);
     void               renderBorder(wlr_box*, const CGradientValueData&, int round, int borderSize, float a = 1.0, int outerRound = -1 /* use round */);
 
     void               saveMatrix();

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -424,9 +424,21 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
             }
         }
 
-        if (!pWindow->m_bIsFullscreen || PWORKSPACE->m_efFullscreenMode != FULLSCREEN_FULL)
-            for (auto& wd : pWindow->m_dWindowDecorations)
+        if (!pWindow->m_bIsFullscreen || PWORKSPACE->m_efFullscreenMode != FULLSCREEN_FULL) {
+            for (auto& wd : pWindow->m_dWindowDecorations) {
+                if (wd->getDecorationLayer() != DECORATION_LAYER_BOTTOM)
+                    continue;
+
                 wd->draw(pMonitor, renderdata.alpha * renderdata.fadeAlpha, Vector2D{renderdata.x, renderdata.y} - PREOFFSETPOS);
+            }
+
+            for (auto& wd : pWindow->m_dWindowDecorations) {
+                if (wd->getDecorationLayer() != DECORATION_LAYER_UNDER)
+                    continue;
+
+                wd->draw(pMonitor, renderdata.alpha * renderdata.fadeAlpha, Vector2D{renderdata.x, renderdata.y} - PREOFFSETPOS);
+            }
+        }
 
         static auto* const PXWLUSENN = &g_pConfigManager->getConfigValuePtr("xwayland:use_nearest_neighbor")->intValue;
         if ((pWindow->m_bIsX11 && *PXWLUSENN) || pWindow->m_sAdditionalConfigData.nearestNeighbor.toUnderlying())
@@ -469,6 +481,13 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
             }
         }
 
+        for (auto& wd : pWindow->m_dWindowDecorations) {
+            if (wd->getDecorationLayer() != DECORATION_LAYER_OVER)
+                continue;
+
+            wd->draw(pMonitor, renderdata.alpha * renderdata.fadeAlpha, Vector2D{renderdata.x, renderdata.y} - PREOFFSETPOS);
+        }
+
         if (TRANSFORMERSPRESENT) {
 
             CFramebuffer* last = g_pHyprOpenGL->m_RenderData.currentFB;
@@ -499,6 +518,13 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
             wlr_xdg_surface_for_each_popup_surface(pWindow->m_uSurface.xdg, renderSurface, &renderdata);
 
             g_pHyprOpenGL->m_RenderData.useNearestNeighbor = false;
+        }
+
+        for (auto& wd : pWindow->m_dWindowDecorations) {
+            if (wd->getDecorationLayer() != DECORATION_LAYER_OVERLAY)
+                continue;
+
+            wd->draw(pMonitor, renderdata.alpha * renderdata.fadeAlpha, Vector2D{renderdata.x, renderdata.y} - PREOFFSETPOS);
         }
     }
 

--- a/src/render/Shader.hpp
+++ b/src/render/Shader.hpp
@@ -10,10 +10,12 @@ class CShader {
     GLuint  program           = 0;
     GLint   proj              = -1;
     GLint   color             = -1;
+    GLint   alphaMatte        = -1;
     GLint   tex               = -1;
     GLint   alpha             = -1;
     GLint   posAttrib         = -1;
     GLint   texAttrib         = -1;
+    GLint   matteTexAttrib    = -1;
     GLint   discardOpaque     = -1;
     GLint   discardAlpha      = -1;
     GLfloat discardAlphaValue = -1;
@@ -29,8 +31,9 @@ class CShader {
 
     GLint   halfpixel = -1;
 
-    GLint   range       = -1;
-    GLint   shadowPower = -1;
+    GLint   range         = -1;
+    GLint   shadowPower   = -1;
+    GLint   useAlphaMatte = -1; // always inverted
 
     GLint   applyTint = -1;
     GLint   tint      = -1;
@@ -43,9 +46,9 @@ class CShader {
     GLint   distort = -1;
     GLint   output  = -1;
 
-    GLint   noise  = -1;
-    GLint   contrast  = -1;
-    GLint   brightness  = -1;
+    GLint   noise      = -1;
+    GLint   contrast   = -1;
+    GLint   brightness = -1;
 
     GLint   getUniformLocation(const std::string&);
 

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -132,9 +132,9 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D
         fullBox.y += ((m_bLastWindowBox.height + 2.0 * *PSHADOWSIZE) - NEWSIZE.y) / 2.0;
     }
 
-    m_seExtents = {{m_bLastWindowBox.x - fullBox.x - pMonitor->vecPosition.x + 2, m_bLastWindowBox.y - fullBox.y - pMonitor->vecPosition.y + 2},
-                   {fullBox.x + fullBox.width + pMonitor->vecPosition.x - m_bLastWindowBox.x - m_bLastWindowBox.width + 2,
-                    fullBox.y + fullBox.height + pMonitor->vecPosition.y - m_bLastWindowBox.y - m_bLastWindowBox.height + 2}};
+    m_seExtents = {{m_vLastWindowPos.x - fullBox.x - pMonitor->vecPosition.x + 2, m_vLastWindowPos.y - fullBox.y - pMonitor->vecPosition.y + 2},
+                   {fullBox.x + fullBox.width + pMonitor->vecPosition.x - m_vLastWindowPos.x - m_vLastWindowSize.x + 2,
+                    fullBox.y + fullBox.height + pMonitor->vecPosition.y - m_vLastWindowPos.y - m_vLastWindowSize.y + 2}};
 
     fullBox.x += offset.x;
     fullBox.y += offset.y;

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -94,7 +94,6 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D
 
     static auto* const PSHADOWS            = &g_pConfigManager->getConfigValuePtr("decoration:drop_shadow")->intValue;
     static auto* const PSHADOWSIZE         = &g_pConfigManager->getConfigValuePtr("decoration:shadow_range")->intValue;
-    static auto* const PROUNDING           = &g_pConfigManager->getConfigValuePtr("decoration:rounding")->intValue;
     static auto* const PSHADOWIGNOREWINDOW = &g_pConfigManager->getConfigValuePtr("decoration:shadow_ignore_window")->intValue;
     static auto* const PSHADOWSCALE        = &g_pConfigManager->getConfigValuePtr("decoration:shadow_scale")->floatValue;
     static auto* const PSHADOWOFFSET       = &g_pConfigManager->getConfigValuePtr("decoration:shadow_offset")->vecValue;

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -45,6 +45,33 @@ void CHyprDropShadowDecoration::updateWindow(CWindow* pWindow) {
         m_vLastWindowSize = pWindow->m_vRealSize.vec();
 
         damageEntire();
+
+        const auto BORDER = m_pWindow->getRealBorderSize();
+
+        // calculate extents of decos with the DECORATION_PART_OF_MAIN_WINDOW flag
+        SWindowDecorationExtents maxExtents;
+
+        for (auto& wd : m_pWindow->m_dWindowDecorations) {
+            // conveniently, this will also skip us.
+            if (!(wd->getDecorationFlags() & DECORATION_PART_OF_MAIN_WINDOW))
+                continue;
+
+            const auto EXTENTS = wd->getWindowDecorationExtents();
+
+            if (maxExtents.topLeft.x < EXTENTS.topLeft.x)
+                maxExtents.topLeft.x = EXTENTS.topLeft.x;
+            if (maxExtents.topLeft.y < EXTENTS.topLeft.y)
+                maxExtents.topLeft.y = EXTENTS.topLeft.y;
+            if (maxExtents.bottomRight.x < EXTENTS.bottomRight.x)
+                maxExtents.bottomRight.x = EXTENTS.bottomRight.x;
+            if (maxExtents.bottomRight.y < EXTENTS.bottomRight.y)
+                maxExtents.bottomRight.y = EXTENTS.bottomRight.y;
+        }
+
+        // +1 +1 -2 -2 is to avoid artifacts with AA. TODO: figure out a better method. Alpha blending? This same shit will happen on hyprbars.
+        m_bLastWindowBox = {(int)(m_vLastWindowPos.x - maxExtents.topLeft.x - BORDER + 1), (int)(m_vLastWindowPos.y - maxExtents.topLeft.y - BORDER + 1),
+                            (int)(m_vLastWindowSize.x + maxExtents.topLeft.x + maxExtents.bottomRight.x + 2 * BORDER - 2),
+                            (int)(m_vLastWindowSize.y + maxExtents.topLeft.y + maxExtents.bottomRight.y + 2 * BORDER - 2)};
     }
 }
 
@@ -75,12 +102,11 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D
     if (*PSHADOWS != 1)
         return; // disabled
 
-    const auto ROUNDING = !m_pWindow->m_sSpecialRenderData.rounding ?
-        0 :
-        (m_pWindow->m_sAdditionalConfigData.rounding.toUnderlying() == -1 ? *PROUNDING : m_pWindow->m_sAdditionalConfigData.rounding.toUnderlying());
+    const auto ROUNDING = m_pWindow->rounding() + m_pWindow->getRealBorderSize();
 
     // draw the shadow
-    wlr_box fullBox = {m_vLastWindowPos.x - *PSHADOWSIZE, m_vLastWindowPos.y - *PSHADOWSIZE, m_vLastWindowSize.x + 2.0 * *PSHADOWSIZE, m_vLastWindowSize.y + 2.0 * *PSHADOWSIZE};
+    wlr_box fullBox = {m_bLastWindowBox.x - *PSHADOWSIZE, m_bLastWindowBox.y - *PSHADOWSIZE, m_bLastWindowBox.width + 2.0 * *PSHADOWSIZE,
+                       m_bLastWindowBox.height + 2.0 * *PSHADOWSIZE};
 
     fullBox.x -= pMonitor->vecPosition.x;
     fullBox.y -= pMonitor->vecPosition.y;
@@ -95,22 +121,22 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D
     if (PSHADOWOFFSET->x < 0) {
         fullBox.x += PSHADOWOFFSET->x;
     } else if (PSHADOWOFFSET->x > 0) {
-        fullBox.x = m_vLastWindowPos.x + m_vLastWindowSize.x - fullBox.width + (SHADOWSCALE * *PSHADOWSIZE) + PSHADOWOFFSET->x - pMonitor->vecPosition.x;
+        fullBox.x = m_bLastWindowBox.x + m_bLastWindowBox.width - fullBox.width + (SHADOWSCALE * *PSHADOWSIZE) + PSHADOWOFFSET->x - pMonitor->vecPosition.x;
     } else {
-        fullBox.x += ((m_vLastWindowSize.x + 2.0 * *PSHADOWSIZE) - NEWSIZE.x) / 2.0;
+        fullBox.x += ((m_bLastWindowBox.width + 2.0 * *PSHADOWSIZE) - NEWSIZE.x) / 2.0;
     }
 
     if (PSHADOWOFFSET->y < 0) {
         fullBox.y += PSHADOWOFFSET->y;
     } else if (PSHADOWOFFSET->y > 0) {
-        fullBox.y = m_vLastWindowPos.y + m_vLastWindowSize.y - fullBox.height + (SHADOWSCALE * *PSHADOWSIZE) + PSHADOWOFFSET->y - pMonitor->vecPosition.y;
+        fullBox.y = m_bLastWindowBox.y + m_bLastWindowBox.height - fullBox.height + (SHADOWSCALE * *PSHADOWSIZE) + PSHADOWOFFSET->y - pMonitor->vecPosition.y;
     } else {
-        fullBox.y += ((m_vLastWindowSize.y + 2.0 * *PSHADOWSIZE) - NEWSIZE.y) / 2.0;
+        fullBox.y += ((m_bLastWindowBox.height + 2.0 * *PSHADOWSIZE) - NEWSIZE.y) / 2.0;
     }
 
-    m_seExtents = {{m_vLastWindowPos.x - fullBox.x - pMonitor->vecPosition.x + 2, m_vLastWindowPos.y - fullBox.y - pMonitor->vecPosition.y + 2},
-                   {fullBox.x + fullBox.width + pMonitor->vecPosition.x - m_vLastWindowPos.x - m_vLastWindowSize.x + 2,
-                    fullBox.y + fullBox.height + pMonitor->vecPosition.y - m_vLastWindowPos.y - m_vLastWindowSize.y + 2}};
+    m_seExtents = {{m_bLastWindowBox.x - fullBox.x - pMonitor->vecPosition.x + 2, m_bLastWindowBox.y - fullBox.y - pMonitor->vecPosition.y + 2},
+                   {fullBox.x + fullBox.width + pMonitor->vecPosition.x - m_bLastWindowBox.x - m_bLastWindowBox.width + 2,
+                    fullBox.y + fullBox.height + pMonitor->vecPosition.y - m_bLastWindowBox.y - m_bLastWindowBox.height + 2}};
 
     fullBox.x += offset.x;
     fullBox.y += offset.y;
@@ -129,7 +155,7 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D
         glStencilFunc(GL_ALWAYS, 1, -1);
         glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
 
-        wlr_box windowBox = {m_vLastWindowPos.x - pMonitor->vecPosition.x, m_vLastWindowPos.y - pMonitor->vecPosition.y, m_vLastWindowSize.x, m_vLastWindowSize.y};
+        wlr_box windowBox = {m_bLastWindowBox.x - pMonitor->vecPosition.x, m_bLastWindowBox.y - pMonitor->vecPosition.y, m_bLastWindowBox.width, m_bLastWindowBox.height};
 
         scaleBox(&windowBox, pMonitor->scale);
 
@@ -155,4 +181,8 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D
         glClear(GL_STENCIL_BUFFER_BIT);
         glDisable(GL_STENCIL_TEST);
     }
+}
+
+eDecorationLayer CHyprDropShadowDecoration::getDecorationLayer() {
+    return DECORATION_LAYER_BOTTOM;
 }

--- a/src/render/decorations/CHyprDropShadowDecoration.hpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.hpp
@@ -17,6 +17,8 @@ class CHyprDropShadowDecoration : public IHyprWindowDecoration {
 
     virtual void                     damageEntire();
 
+    virtual eDecorationLayer         getDecorationLayer();
+
   private:
     SWindowDecorationExtents m_seExtents;
 
@@ -24,4 +26,6 @@ class CHyprDropShadowDecoration : public IHyprWindowDecoration {
 
     Vector2D                 m_vLastWindowPos;
     Vector2D                 m_vLastWindowSize;
+
+    wlr_box                  m_bLastWindowBox = {0};
 };

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -301,10 +301,6 @@ void CHyprGroupBarDecoration::refreshGradients() {
     renderGradientTo(m_tGradientInactive, ((CGradientValueData*)PCOLINACTIVE->get())->m_vColors[0]);
 }
 
-bool CHyprGroupBarDecoration::allowsInput() {
-    return true;
-}
-
 bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(CWindow* pDraggedWindow, const Vector2D& pos) {
 
     if (!pDraggedWindow->canBeGroupedInto(m_pWindow))
@@ -406,4 +402,12 @@ void CHyprGroupBarDecoration::onBeginWindowDragOnDeco(const Vector2D& pos) {
 
     if (!g_pCompositor->isWindowActive(pWindow))
         g_pCompositor->focusWindow(pWindow);
+}
+
+eDecorationLayer CHyprGroupBarDecoration::getDecorationLayer() {
+    return DECORATION_LAYER_OVER;
+}
+
+uint64_t CHyprGroupBarDecoration::getDecorationFlags() {
+    return DECORATION_ALLOWS_MOUSE_INPUT;
 }

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -33,13 +33,15 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
 
     virtual SWindowDecorationExtents getWindowDecorationReservedArea();
 
-    virtual bool                     allowsInput();
-
     virtual void                     onBeginWindowDragOnDeco(const Vector2D&);
 
     virtual bool                     onEndWindowDragOnDeco(CWindow* pDraggedWindow, const Vector2D&);
 
     virtual void                     onMouseButtonOnDeco(const Vector2D&, wlr_pointer_button_event*);
+
+    virtual eDecorationLayer         getDecorationLayer();
+
+    virtual uint64_t                 getDecorationFlags();
 
   private:
     SWindowDecorationExtents m_seExtents;

--- a/src/render/decorations/IHyprWindowDecoration.cpp
+++ b/src/render/decorations/IHyprWindowDecoration.cpp
@@ -25,14 +25,22 @@ CRegion IHyprWindowDecoration::getWindowDecorationRegion() {
                           m_pWindow->m_vRealSize.vec().y + 2 * BORDERSIZE));
 }
 
-bool IHyprWindowDecoration::allowsInput() {
-    return false;
+void IHyprWindowDecoration::onBeginWindowDragOnDeco(const Vector2D&) {
+    ;
 }
-
-void IHyprWindowDecoration::onBeginWindowDragOnDeco(const Vector2D&) {}
 
 bool IHyprWindowDecoration::onEndWindowDragOnDeco(CWindow* pDraggedWindow, const Vector2D&) {
     return true;
 }
 
-void IHyprWindowDecoration::onMouseButtonOnDeco(const Vector2D&, wlr_pointer_button_event*) {}
+void IHyprWindowDecoration::onMouseButtonOnDeco(const Vector2D&, wlr_pointer_button_event*) {
+    ;
+}
+
+eDecorationLayer IHyprWindowDecoration::getDecorationLayer() {
+    return DECORATION_LAYER_UNDER;
+}
+
+uint64_t IHyprWindowDecoration::getDecorationFlags() {
+    return 0;
+}

--- a/src/render/decorations/IHyprWindowDecoration.hpp
+++ b/src/render/decorations/IHyprWindowDecoration.hpp
@@ -3,7 +3,8 @@
 #include "../../defines.hpp"
 #include "../../helpers/Region.hpp"
 
-enum eDecorationType {
+enum eDecorationType
+{
     DECORATION_NONE = -1,
     DECORATION_GROUPBAR,
     DECORATION_SHADOW,
@@ -13,6 +14,20 @@ enum eDecorationType {
 struct SWindowDecorationExtents {
     Vector2D topLeft;
     Vector2D bottomRight;
+};
+
+enum eDecorationLayer
+{
+    DECORATION_LAYER_BOTTOM = 0, /* lowest. */
+    DECORATION_LAYER_UNDER,      /* under the window, but above BOTTOM */
+    DECORATION_LAYER_OVER,       /* above the window, but below its popups */
+    DECORATION_LAYER_OVERLAY     /* above everything of the window, including popups */
+};
+
+enum eDecorationFlags
+{
+    DECORATION_ALLOWS_MOUSE_INPUT  = 1 << 0, /* this decoration accepts mouse input */
+    DECORATION_PART_OF_MAIN_WINDOW = 1 << 1, /* this decoration is a *seamless* part of the main window, so stuff like shadows will include it */
 };
 
 class CWindow;
@@ -37,13 +52,15 @@ class IHyprWindowDecoration {
 
     virtual CRegion                  getWindowDecorationRegion();
 
-    virtual bool                     allowsInput();
-
     virtual void                     onBeginWindowDragOnDeco(const Vector2D&); // called when the user calls the "movewindow" mouse dispatcher on the deco
 
     virtual bool                     onEndWindowDragOnDeco(CWindow* pDraggedWindow, const Vector2D&); // returns true if the window should be placed by the layout
 
     virtual void                     onMouseButtonOnDeco(const Vector2D&, wlr_pointer_button_event*);
+
+    virtual eDecorationLayer         getDecorationLayer();
+
+    virtual uint64_t                 getDecorationFlags();
 
   private:
     CWindow* m_pWindow = nullptr;

--- a/src/render/shaders/Shadow.hpp
+++ b/src/render/shaders/Shadow.hpp
@@ -5,7 +5,9 @@
 inline const std::string FRAGSHADOW = R"#(
 precision mediump float;
 varying vec4 v_color;
+uniform sampler2D alphaMatte;
 varying vec2 v_texcoord;
+varying vec2 v_texcoordMatte;
 
 uniform vec2 topLeft;
 uniform vec2 bottomRight;
@@ -13,6 +15,7 @@ uniform vec2 fullSize;
 uniform float radius;
 uniform float range;
 uniform float shadowPower;
+uniform int useAlphaMatte;
 
 float pixAlphaRoundedDistance(float distanceToCorner) {
      if (distanceToCorner > radius) {
@@ -72,6 +75,10 @@ void main() {
         if (smallest < range) {
             pixColor[3] = pixColor[3] * pow((smallest / range), shadowPower);
         }
+    }
+
+    if (useAlphaMatte == 1) {
+        pixColor[3] *= 1.0 - texture2D(alphaMatte, v_texcoordMatte)[3];
     }
 
     if (pixColor[3] == 0.0) {

--- a/src/render/shaders/Textures.hpp
+++ b/src/render/shaders/Textures.hpp
@@ -37,13 +37,16 @@ uniform mat3 proj;
 uniform vec4 color;
 attribute vec2 pos;
 attribute vec2 texcoord;
+attribute vec2 texcoordMatte;
 varying vec4 v_color;
 varying vec2 v_texcoord;
+varying vec2 v_texcoordMatte;
 
 void main() {
     gl_Position = vec4(proj * vec3(pos, 1.0), 1.0);
     v_color = color;
     v_texcoord = texcoord;
+    v_texcoordMatte = texcoordMatte;
 })#";
 
 inline const std::string QUADFRAGSRC = R"#(


### PR DESCRIPTION
## Motivation

Mostly code cleanup + this:

![20231103_17h41m41s](https://github.com/hyprwm/Hyprland/assets/43317083/aed05c81-8b5a-4cc4-ae40-13df5d8d7dba)

*Notice how the shadow includes the top bar*

### Breaking Stuff
`IHyprWindowDecoration::allowsInput` yeeten

## RFC
@MightyPlaza (deco MRs)

#### Numero uno

```cpp
enum eDecorationFlags {
    DECORATION_ALLOWS_MOUSE_INPUT  = 1 << 0, /* this decoration accepts mouse input */
    DECORATION_PART_OF_MAIN_WINDOW = 1 << 1, /* this decoration is a *seamless* part of the main window, so stuff like shadows will include it */
};
```

Is this enough? Do we want any other flags? We have space for 64.

#### Numero dos

Another thing is how we stencil the shadow.

https://github.com/hyprwm/Hyprland/blob/66b8b8096476a0fa8fef5f6e798529b3c7f57693/src/render/decorations/CHyprDropShadowDecoration.cpp#L71-L74

Currently, I have to do this, because the stencil is very 0/1. Even if we do a != 1, there still will be an issue if the top bar is transparent:
![image](https://github.com/hyprwm/Hyprland/assets/43317083/8ff78bc2-0142-4b1e-bab8-8aafdccbfe1a)

There is no way to avoid this with the current stencil solution. Are we able to make some sort of an alpha blending mask here? Any opengl wizards with some khronos docs / ideas?