### PR TITLE
Fix Compile error on non PCH system

### DIFF
--- a/src/helpers/Box.hpp
+++ b/src/helpers/Box.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <wlr/util/box.h>
 #include "Vector2D.hpp"
 #include "../SharedDefs.hpp"
-
+#include "../includes.hpp"
 class CBox {
   public:
     CBox(double x_, double y_, double w_, double h_) {

--- a/src/includes.hpp
+++ b/src/includes.hpp
@@ -105,7 +105,7 @@ extern "C" {
 #include <wlr/types/wlr_idle_notify_v1.h>
 #include <wlr/types/wlr_cursor_shape_v1.h>
 #include <wlr/types/wlr_tearing_control_v1.h>
-
+#include <wlr/util/box.h>
 #include <libdrm/drm_fourcc.h>
 
 #if WLR_HAS_X11_BACKEND


### PR DESCRIPTION
By Default on Gentoo, PCH is masked for GCC.

this PR fix the compilation issue on these systems. 

