### PR TITLE
Add flags to clang when no CXXFLAGS is available

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,8 +14,10 @@ project('Hyprland', 'cpp', 'c',
 cpp_compiler = meson.get_compiler('cpp')
 if cpp_compiler.has_argument('-std=c++23')
   add_global_arguments('-std=c++23', language: 'cpp')
-elif cpp_compiler.has_argument('-std=c++2b')
+elif cpp_compiler.get_id() == 'clang'
   add_global_arguments('-std=c++2b', language: 'cpp')
+  add_global_arguments('-stdlib=libc++', language: 'cpp')
+  add_global_arguments('-fexperimental-library', language: 'cpp')
 else
   error('Could not configure current C++ compiler (' + cpp_compiler.get_id() + ' ' + cpp_compiler.version() + ') with required C++ standard (C++23)')
 endif


### PR DESCRIPTION
c++2b needs experimental library and libc++ to build instead of gnu stdlib.

#### Describe your PR, what does it fix/add?
It added flags to build with clang when no CXXFLAGS is available

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I cannot build with c++2b without 2 flags: `-fexperimental-library` and `-stdlib=libc++`

#### Is it ready for merging, or does it need work?

It need to be tested with Clang 14. I only tested it with clang 16.
