### PR TITLE
Avoid calculating unused values in hsl2rgb.

### DIFF
--- a/src/render/shaders/Textures.hpp
+++ b/src/render/shaders/Textures.hpp
@@ -258,19 +258,18 @@ vec3 hsl2rgb(vec3 col) {
     float       sat = col.y;
     float       lum = col.z;
 
-    vec3        xt = vec3(rcpsixth * (hue - twothird), 0.0, rcpsixth * (1.0 - hue));
-
-    if (hue < twothird) {
-        xt.r = 0.0;
-        xt.g = rcpsixth * (twothird - hue);
-        xt.b = rcpsixth * (hue - onethird);
-    }
+    vec3        xt = vec3(0.0);
 
     if (hue < onethird) {
         xt.r = rcpsixth * (onethird - hue);
         xt.g = rcpsixth * hue;
         xt.b = 0.0;
-    }
+    } else if (hue < twothird) {
+        xt.r = 0.0;
+        xt.g = rcpsixth * (twothird - hue);
+        xt.b = rcpsixth * (hue - onethird);
+    } else
+        xt = vec3(rcpsixth * (hue - twothird), 0.0, rcpsixth * (1.0 - hue));
 
     xt = min(xt, 1.0);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
In the old code, if `hue < onethird` the first time `xt` is calculated at initialization, 
then it's overwritten because hue is smaller than `twothirds`,
then it's overwritten again because hue is smaller than `onethird`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
I think it's fine.

