### PR TITLE
Small optimization in rgb2hsl.

### DIFF
--- a/src/render/shaders/Textures.hpp
+++ b/src/render/shaders/Textures.hpp
@@ -238,14 +238,13 @@ vec3 rgb2hsl(vec3 col) {
 
     vec3  adds = vec3(((green - blue) / delta), 2.0 + ((blue - red) / delta), 4.0 + ((red - green) / delta));
 
-    float deltaGtz = (delta > 0.0) ? 1.0 : 0.0;
+    if (delta > 0.0) {
+        hue += dot(adds, masks);
+        hue /= 6.0;
 
-    hue += dot(adds, masks);
-    hue *= deltaGtz;
-    hue /= 6.0;
-
-    if (hue < 0.0)
-        hue += 1.0;
+        if (hue < 0.0)
+            hue += 1.0;
+    }
 
     return vec3(hue, sat, lum);
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
In the old code, if `delta == 0.0` then deltaGtz would be 0.0 and hue gets multiplied with it.
That makes all the other operations (including `dot()`) useless.
So let's do the whole thing only if delta has a value > 0.0

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

#### Is it ready for merging, or does it need work?
Ready i think.

