### PR TITLE
nix: add libGL to build inputs

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -10,6 +10,7 @@
   git,
   hyprland-protocols,
   jq,
+  libGL,
   libdrm,
   libinput,
   libxcb,
@@ -71,6 +72,7 @@ assert lib.assertMsg (!hidpiXWayland) "The option `hidpiXWayland` has been remov
         git
         cairo
         hyprland-protocols
+        libGL
         libdrm
         libinput
         libxkbcommon


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes nix build after recent nixpkgs update.

```
hyprland> Run-time dependency egl found: NO (tried pkgconfig)
hyprland> src/meson.build:15:4: ERROR: Dependency "egl" not found, tried pkgconfig
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Yes.
