### PR TITLE
Don't update pseudoSize after window moved by mouse. 

### DIFF
--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -427,7 +427,8 @@ void IHyprLayout::changeWindowFloatingMode(CWindow* pWindow) {
         const auto PSAVEDSIZE = pWindow->m_vRealSize.goalv();
 
         // if the window is pseudo, update its size
-        pWindow->m_vPseudoSize = pWindow->m_vRealSize.goalv();
+        if (!pWindow->m_bDraggingTiled)
+            pWindow->m_vPseudoSize = pWindow->m_vRealSize.goalv();
 
         pWindow->m_vLastFloatingSize = PSAVEDSIZE;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes https://github.com/hyprwm/Hyprland/issues/3574
Prevents a pseudoTiled window size gets changed after moving it with the mouse. 
That size change makes sense when a floating window is turned to a pseudoTiled, but not after a mouse move.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
I tested it, and it seems to work.
I think it's ready, but double check please.

