### PR TITLE
Add CXXFLAGS to hyprlctl's Makefile

### DIFF
--- a/hyprctl/Makefile
+++ b/hyprctl/Makefile
@@ -1,4 +1,4 @@
 all:
-	$(CXX) -std=c++2b ./main.cpp -o ./hyprctl
+	$(CXX) $(CXXFLAGS) -std=c++2b ./main.cpp -o ./hyprctl
 clean:
 	rm ./hyprctl


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
When you use clang++ to build hyprctl, cxxflags is missing from argument, then the build fails with linked to gnustd library.


#### Is it ready for merging, or does it need work?

It should be fine.
