### PR TITLE
Make exec support compound bash commands

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -641,11 +641,6 @@ void CKeybindManager::spawn(std::string args) {
         args  = args.substr(args.find_first_of(']') + 1);
     }
 
-    if (g_pXWaylandManager->m_sWLRXWayland)
-        args = "WAYLAND_DISPLAY=" + std::string(g_pCompositor->m_szWLDisplaySocket) + " DISPLAY=" + std::string(g_pXWaylandManager->m_sWLRXWayland->display_name) + " " + args;
-    else
-        args = "WAYLAND_DISPLAY=" + std::string(g_pCompositor->m_szWLDisplaySocket) + " " + args;
-
     const uint64_t PROC = spawnRaw(args);
 
     if (!RULES.empty()) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Current behavior: exec/exec-once cannot run compound bash commands (if statements, loops, whatever the [[ ]] thing is called, etc) due to some hardcoded environment variables added in front.
These env vars are redundant because they are in `environ` already. Therefore, they are automaticlly used in `execl` anyway, so they should be safe to remove. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
ready

