### PR TITLE
renderer: Adding an option to disable first launch animation

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -209,7 +209,8 @@ void CConfigManager::setDefaultVars() {
     configValues["master:smart_resizing"].intValue         = 1;
     configValues["master:drop_at_cursor"].intValue         = 1;
 
-    configValues["animations:enabled"].intValue = 1;
+    configValues["animations:enabled"].intValue                = 1;
+    configValues["animations:first_launch_animation"].intValue = 1;
 
     configValues["input:follow_mouse"].intValue                     = 1;
     configValues["input:mouse_refocus"].intValue                    = 1;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -858,6 +858,7 @@ void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
     static auto* const                                    PRENDERTEX          = &g_pConfigManager->getConfigValuePtr("misc:disable_hyprland_logo")->intValue;
     static auto* const                                    PBACKGROUNDCOLOR    = &g_pConfigManager->getConfigValuePtr("misc:background_color")->intValue;
     static auto* const                                    PANIMENABLED        = &g_pConfigManager->getConfigValuePtr("animations:enabled")->intValue;
+    static auto* const                                    PFIRSTLAUNCHANIM    = &g_pConfigManager->getConfigValuePtr("animations:first_launch_animation")->intValue;
     static auto* const                                    PTEARINGENABLED     = &g_pConfigManager->getConfigValuePtr("general:allow_tearing")->intValue;
 
     static int                                            damageBlinkCleanup = 0; // because double-buffered
@@ -866,7 +867,7 @@ void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
         damageBlinkCleanup = 0;
 
     static bool firstLaunch           = true;
-    static bool firstLaunchAnimActive = true;
+    static bool firstLaunchAnimActive = *PFIRSTLAUNCHANIM;
 
     float       zoomInFactorFirstLaunch = 1.f;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
It adds an option to enable/disable the zoom in animation when Hyprland is first launched.
It is needed to have more fine tune (especially when transitioning from a display manager to Hyprland).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nope.

#### Is it ready for merging, or does it need work?
It is ready for merging.
