### PR TITLE
Fix float windows

### DIFF
--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -214,6 +214,8 @@ class CWindow {
     // for restoring floating statuses
     Vector2D m_vLastFloatingSize;
     Vector2D m_vLastFloatingPosition;
+    Vector2D m_vLastFloatingCropSize;
+    bool     m_vLastFloatingCenterScreen;
 
     // this is used for pseudotiling
     bool        m_bIsPseudotiled = false;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -94,6 +94,8 @@ void CConfigManager::setDefaultVars() {
     configValues["general:resize_on_border"].intValue        = 0;
     configValues["general:extend_border_grab_area"].intValue = 15;
     configValues["general:hover_icon_on_border"].intValue    = 1;
+    configValues["general:float_min_crop"].vecValue          = Vector2D(0.25, 0.25);
+    configValues["general:float_center_screen"].intValue     = 0;
     configValues["general:layout"].strValue                  = "dwindle";
     configValues["general:allow_tearing"].intValue           = 0;
 

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -1043,13 +1043,21 @@ void Events::listener_configureX11(void* owner, void* data) {
     PWINDOW->m_vRealPosition.setValueAndWarp(LOGICALPOS);
     PWINDOW->m_vRealSize.setValueAndWarp(Vector2D(E->width, E->height));
 
+    auto PMONITOR = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID);
+    if (!PMONITOR) {
+        PMONITOR              = g_pCompositor->getMonitorFromVector(PWINDOW->m_vRealPosition.goalv() + PWINDOW->m_vRealSize.goalv() / 2.0);
+        PWINDOW->m_iMonitorID = PMONITOR->ID;
+    }
     static auto* const PXWLFORCESCALEZERO = &g_pConfigManager->getConfigValuePtr("xwayland:force_zero_scaling")->intValue;
     if (*PXWLFORCESCALEZERO) {
-        if (const auto PMONITOR = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID); PMONITOR) {
-            const Vector2D DELTA = PWINDOW->m_vRealSize.goalv() - PWINDOW->m_vRealSize.goalv() / PMONITOR->scale;
-            PWINDOW->m_vRealSize.setValueAndWarp(PWINDOW->m_vRealSize.goalv() / PMONITOR->scale);
-            PWINDOW->m_vRealPosition.setValueAndWarp(PWINDOW->m_vRealPosition.goalv() + DELTA / 2.0);
-        }
+        PWINDOW->m_vRealSize.setValueAndWarp(PWINDOW->m_vRealSize.goalv() / PMONITOR->scale);
+        static auto* const FLOATCENTERSCREEN = &g_pConfigManager->getConfigValuePtr("general:float_center_screen")->intValue;
+        PWINDOW->m_vLastFloatingCenterScreen = *FLOATCENTERSCREEN;
+        if (*FLOATCENTERSCREEN)
+            PWINDOW->m_vRealPosition.setValueAndWarp(PMONITOR->vecPosition + (PMONITOR->vecSize - PWINDOW->m_vRealSize.goalv()) / 2.0);
+        else
+            PWINDOW->m_vRealPosition.setValueAndWarp(PMONITOR->vecPosition + PMONITOR->vecReservedTopLeft +
+                                                     (PMONITOR->vecSize - PMONITOR->vecReservedTopLeft - PMONITOR->vecReservedBottomRight - PWINDOW->m_vRealSize.goalv()) / 2.0);
     }
 
     PWINDOW->m_vPosition = PWINDOW->m_vRealPosition.vec();
@@ -1057,7 +1065,7 @@ void Events::listener_configureX11(void* owner, void* data) {
 
     wlr_xwayland_surface_configure(PWINDOW->m_uSurface.xwayland, E->x, E->y, E->width, E->height);
 
-    PWINDOW->m_iWorkspaceID = g_pCompositor->getMonitorFromVector(PWINDOW->m_vRealPosition.vec() + PWINDOW->m_vRealSize.vec() / 2.f)->activeWorkspace;
+    PWINDOW->m_iWorkspaceID = PMONITOR->activeWorkspace;
 
     g_pCompositor->changeWindowZOrder(PWINDOW, true);
 
@@ -1108,18 +1116,28 @@ void Events::listener_unmanagedSetGeometry(void* owner, void* data) {
         if (abs(std::floor(SIZ.x) - PWINDOW->m_uSurface.xwayland->width) > 2 || abs(std::floor(SIZ.y) - PWINDOW->m_uSurface.xwayland->height) > 2)
             PWINDOW->m_vRealSize.setValueAndWarp(Vector2D(PWINDOW->m_uSurface.xwayland->width, PWINDOW->m_uSurface.xwayland->height));
 
+        auto PMONITOR = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID);
+        if (!PMONITOR) {
+            PMONITOR              = g_pCompositor->getMonitorFromVector(PWINDOW->m_vRealPosition.goalv() + PWINDOW->m_vRealSize.goalv() / 2.0);
+            PWINDOW->m_iMonitorID = PMONITOR->ID;
+        }
+
         if (*PXWLFORCESCALEZERO) {
-            if (const auto PMONITOR = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID); PMONITOR) {
-                const Vector2D DELTA = PWINDOW->m_vRealSize.goalv() - PWINDOW->m_vRealSize.goalv() / PMONITOR->scale;
-                PWINDOW->m_vRealSize.setValueAndWarp(PWINDOW->m_vRealSize.goalv() / PMONITOR->scale);
-                PWINDOW->m_vRealPosition.setValueAndWarp(PWINDOW->m_vRealPosition.goalv() + DELTA / 2.0);
-            }
+            PWINDOW->m_vRealSize.setValueAndWarp(PWINDOW->m_vRealSize.goalv() / PMONITOR->scale);
+            static auto* const FLOATCENTERSCREEN = &g_pConfigManager->getConfigValuePtr("general:float_center_screen")->intValue;
+            PWINDOW->m_vLastFloatingCenterScreen = *FLOATCENTERSCREEN;
+            if (*FLOATCENTERSCREEN)
+                PWINDOW->m_vRealPosition.setValueAndWarp(PMONITOR->vecPosition + (PMONITOR->vecSize - PWINDOW->m_vRealSize.goalv()) / 2.0);
+            else
+                PWINDOW->m_vRealPosition.setValueAndWarp(PMONITOR->vecPosition + PMONITOR->vecReservedTopLeft +
+                                                         (PMONITOR->vecSize - PMONITOR->vecReservedTopLeft - PMONITOR->vecReservedBottomRight - PWINDOW->m_vRealSize.goalv()) /
+                                                             2.0);
         }
 
         PWINDOW->m_vPosition = PWINDOW->m_vRealPosition.goalv();
         PWINDOW->m_vSize     = PWINDOW->m_vRealSize.goalv();
 
-        PWINDOW->m_iWorkspaceID = g_pCompositor->getMonitorFromVector(PWINDOW->m_vRealPosition.vec() + PWINDOW->m_vRealSize.vec() / 2.f)->activeWorkspace;
+        PWINDOW->m_iWorkspaceID = PMONITOR->activeWorkspace;
 
         g_pCompositor->changeWindowZOrder(PWINDOW, true);
         PWINDOW->updateWindowDecos();


### PR DESCRIPTION
**Changelog:**
 - Add vector2 parameter general:float_min_crop for support minimal cropping size
    for windows that cannot transition to float. If 0 < value < 1.0 then use part of windows size, else pixel size. Example: `0.1 0.2`, `400 300`
 - Add parameter general:float_center_screen to control spawn new float windows.
   1 - New float windows spawn in center screen.
   0 - Сonsider the trimming at the top and bottom to calculate the center of the screen.
   For example, consider the size of the waybar.
 - Fix float windows
 - Fix togglefloat. Window did not return to the center of the screen, 
   for example, if there are two windows on the desktop, then the float window is 
   positioned in the center of half the screen.
 - Fix windows that start float and then go into a normal window, aka
   program launchers. Example: Blizzard battle.net client.
   The bug render full-screen programs partially behind the screen.
   Now the xwayland games launch normally.
 - Code cleanup and refactoring.
 - Replaced vec() with goalv() in logic other than animation,
   it seemed to me more correct because goalv() is used in many places.
   Not sure if this is correct.

Related bug reports: https://github.com/hyprwm/Hyprland/issues/3029

Tested programs: Blender, Jetbrains IDEs, Blizzard battle.net client, qt float program.

**Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)**
No

**Is it ready for merging, or does it need work?**
Yes.

Fix this:
![screenshot_1700794200](https://github.com/hyprwm/Hyprland/assets/10059293/d9993100-e384-43fe-bb0e-2375e2b68502)
![screenshot_1700799073](https://github.com/hyprwm/Hyprland/assets/10059293/a5433a59-f456-4cb9-8a16-78715c7af9b4)



