### PR TITLE
Add Meson optimizations

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,10 +2,7 @@ project('Hyprland', 'cpp', 'c',
   version : run_command('jq', '-r', '.version', join_paths(meson.source_root(), 'props.json'), check: true).stdout().strip(),
   default_options : [
     'warning_level=2',
-    'default_library=static',
-    'optimization=3',
-    'buildtype=release',
-    'debug=false'
+    'default_library=static'
     # 'cpp_std=c++23' # not yet supported by meson, as of version 0.63.0
     ])
 
@@ -18,6 +15,13 @@ elif cpp_compiler.has_argument('-std=c++2b')
   add_global_arguments('-std=c++2b', language: 'cpp')
 else
   error('Could not configure current C++ compiler (' + cpp_compiler.get_id() + ' ' + cpp_compiler.version() + ') with required C++ standard (C++23)')
+endif
+
+if get_option('fast_math').enabled()
+  add_global_arguments(
+  cpp_compiler.get_supported_arguments(
+    ['-ffast-math', '-falign-functions=32']
+  ), language: 'cpp')
 endif
 
 add_project_arguments(
@@ -33,7 +37,9 @@ if cpp_compiler.check_header('execinfo.h')
   add_project_arguments('-DHAS_EXECINFO', language: 'cpp')
 endif
 
-wlroots = subproject('wlroots', default_options: ['examples=false', 'renderers=gles2'])
+wlroots = subproject('wlroots', default_options:
+  ['examples=false', 'renderers=gles2', 'backends=[\'libinput\', \'drm\']']
+)
 have_xwlr = wlroots.get_variable('features').get('xwayland')
 xcb_dep = dependency('xcb', required: get_option('xwayland'))
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('xwayland', type: 'feature', value: 'auto', description: 'Enable support for X11 applications')
 option('systemd', type: 'feature', value: 'auto', description: 'Enable systemd integration')
 option('legacy_renderer', type: 'feature', value: 'disabled', description: 'Enable legacy renderer')
+option('fast_math', type: 'feature', value: 'disabled', description: 'Enable -ffast-math optimization')


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Remove:
```
'optimization=3',
'buildtype=release',
'debug=false'
```
The usage is redundant. The -O3 compiler flag is not safe, in synthetic tests in certain sections of the code we can get acceleration, but -O3 greatly increases the amount of machine code, which creates more frequent misses in the processor cache and breaks branch prediction. `buildtype` already has optimization and debug flags.

Instead, I suggest adding the -ffast-math flag for better optimization. In computer graphics, using -ffast-math is safe, and we can sacrifice accuracy and some checks in mathematical calculations for the sake of performance. In computer graphics, everyone used less accurate but faster calculations, such as sqrt calculation. Added a flag to align function addresses on a 32-byte boundary, this is safe and gives better use of the processor cache. For example gamescope uses -ffast-math.

Remove the unnecessary X11 backend.

https://kristerw.github.io/2021/10/19/fast-math/
https://en.wikipedia.org/wiki/Fast_inverse_square_root

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Yes

