### PR TITLE
monitor: remove comma from monitor description

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -574,7 +574,7 @@ CMonitor* CCompositor::getMonitorFromName(const std::string& name) {
 
 CMonitor* CCompositor::getMonitorFromDesc(const std::string& desc) {
     for (auto& m : m_vMonitors) {
-        if (m->output->description && std::string(m->output->description).starts_with(desc))
+        if (m->szDescription.starts_with(desc))
             return m.get();
     }
     return nullptr;
@@ -2059,7 +2059,7 @@ CMonitor* CCompositor::getMonitorFromString(const std::string& name) {
             if (!m->output)
                 continue;
 
-            if (m->output->description && std::string(m->output->description).starts_with(DESCRIPTION)) {
+            if (m->szDescription.starts_with(DESCRIPTION)) {
                 return m.get();
             }
         }

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2082,7 +2082,7 @@ void CConfigManager::performMonitorReload() {
         if (!m->output || m->isUnsafeFallback)
             continue;
 
-        auto rule = getMonitorRuleFor(m->szName, m->output->description ? m->output->description : "");
+        auto rule = getMonitorRuleFor(m->szName, m->szDescription);
 
         if (!g_pHyprRenderer->applyMonitorRule(m.get(), &rule)) {
             overAgain = true;
@@ -2163,7 +2163,7 @@ void CConfigManager::ensureMonitorStatus() {
         if (!rm->output || rm->isUnsafeFallback)
             continue;
 
-        auto rule = getMonitorRuleFor(rm->szName, rm->output->description ? rm->output->description : "");
+        auto rule = getMonitorRuleFor(rm->szName, rm->szDescription);
 
         if (rule.disabled == rm->m_bEnabled)
             g_pHyprRenderer->applyMonitorRule(rm.get(), &rule);

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -75,7 +75,7 @@ std::string monitorsRequest(std::string request, HyprCtl::eHyprCtlOutputFormat f
     "vrr": {},
     "activelyTearing": {}
 }},)#",
-                m->ID, escapeJSONStrings(m->szName), escapeJSONStrings(m->output->description ? m->output->description : ""), (m->output->make ? m->output->make : ""),
+                m->ID, escapeJSONStrings(m->szName), escapeJSONStrings(m->szDescription), (m->output->make ? m->output->make : ""),
                 (m->output->model ? m->output->model : ""), (m->output->serial ? m->output->serial : ""), (int)m->vecPixelSize.x, (int)m->vecPixelSize.y, m->refreshRate,
                 (int)m->vecPosition.x, (int)m->vecPosition.y, m->activeWorkspace,
                 (m->activeWorkspace == -1 ? "" : escapeJSONStrings(g_pCompositor->getWorkspaceByID(m->activeWorkspace)->m_szName)), m->specialWorkspaceID,
@@ -99,7 +99,7 @@ std::string monitorsRequest(std::string request, HyprCtl::eHyprCtlOutputFormat f
                 "{} {} {}\n\tscale: {:.2f}\n\ttransform: "
                 "{}\n\tfocused: {}\n\tdpmsStatus: {}\n\tvrr: {}\n\tactivelyTearing: {}\n\n",
                 m->szName, m->ID, (int)m->vecPixelSize.x, (int)m->vecPixelSize.y, m->refreshRate, (int)m->vecPosition.x, (int)m->vecPosition.y,
-                (m->output->description ? m->output->description : ""), (m->output->make ? m->output->make : ""), (m->output->model ? m->output->model : ""),
+                m->szDescription, (m->output->make ? m->output->make : ""), (m->output->model ? m->output->model : ""),
                 (m->output->serial ? m->output->serial : ""), m->activeWorkspace, (m->activeWorkspace == -1 ? "" : g_pCompositor->getWorkspaceByID(m->activeWorkspace)->m_szName),
                 m->specialWorkspaceID, getWorkspaceNameFromSpecialID(m->specialWorkspaceID), (int)m->vecReservedTopLeft.x, (int)m->vecReservedTopLeft.y,
                 (int)m->vecReservedBottomRight.x, (int)m->vecReservedBottomRight.y, m->scale, (int)m->transform, (m.get() == g_pCompositor->m_pLastMonitor ? "yes" : "no"),

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -50,6 +50,10 @@ void CMonitor::onConnect(bool noRule) {
 
     szName = output->name;
 
+    szDescription = output->description ? output->description : "";
+    // remove comma character from description. This allow monitor specific rules to work on monitor with comma on their description
+    szDescription.erase(std::remove(szDescription.begin(), szDescription.end(), ','), szDescription.end());
+
     if (!wlr_backend_is_drm(output->backend))
         createdByUser = true; // should be true. WL, X11 and Headless backends should be addable / removable
 

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -43,6 +43,7 @@ class CMonitor {
     float           scale           = 1;
 
     std::string     szName = "";
+    std::string     szDescription = "";
 
     Vector2D        vecReservedTopLeft     = Vector2D(0, 0);
     Vector2D        vecReservedBottomRight = Vector2D(0, 0);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1473,7 +1473,7 @@ void CKeybindManager::forceRendererReload(std::string args) {
         if (!m->output)
             continue;
 
-        auto rule = g_pConfigManager->getMonitorRuleFor(m->szName, m->output->description ? m->output->description : "");
+        auto rule = g_pConfigManager->getMonitorRuleFor(m->szName, m->szDescription);
         if (!g_pHyprRenderer->applyMonitorRule(m.get(), &rule, true)) {
             overAgain = true;
             break;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This PR fixes issue #2457, it sanitize the monitor description, removing all comma from the description, to allow for monitor specific rules to apply.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I did some code refactor, replacing all `m->output->description` by `m->getOutputDescription()`. It should not change anything.

I check the code with my monitor (it have the comma issue) and it works fine.

#### Is it ready for merging, or does it need work?
It should be ready to merge

