### PR TITLE
nix: override libdrm to use newer version

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,5 +1,6 @@
 {
   lib,
+  fetchurl,
   stdenv,
   pkg-config,
   makeWrapper,
@@ -38,6 +39,16 @@
   nvidiaPatches ? false,
   hidpiXWayland ? false,
 }:
+let
+  # NOTE: remove after https://github.com/NixOS/nixpkgs/pull/271096 reaches nixos-unstable
+  libdrm_2_4_118 = libdrm.overrideAttrs(attrs: rec {
+    version = "2.4.118";
+    src = fetchurl {
+      url = "https://dri.freedesktop.org/${attrs.pname}/${attrs.pname}-${version}.tar.xz";
+      hash = "sha256-p3e9hfK1/JxX+IbIIFgwBXgxfK/bx30Kdp1+mpVnq4g=";
+    };
+  });
+in
 assert lib.assertMsg (!nvidiaPatches) "The option `nvidiaPatches` has been removed.";
 assert lib.assertMsg (!enableNvidiaPatches) "The option `enableNvidiaPatches` has been removed.";
 assert lib.assertMsg (!hidpiXWayland) "The option `hidpiXWayland` has been removed. Please refer https://wiki.hyprland.org/Configuring/XWayland";
@@ -74,7 +85,7 @@ assert lib.assertMsg (!hidpiXWayland) "The option `hidpiXWayland` has been remov
         cairo
         hyprland-protocols
         libGL
-        libdrm
+        libdrm_2_4_118
         libinput
         libxkbcommon
         mesa

--- a/nix/wlroots.nix
+++ b/nix/wlroots.nix
@@ -1,18 +1,31 @@
 {
+  fetchurl,
   version,
   src,
   wlroots,
   hwdata,
   libdisplay-info,
   libliftoff,
+  libdrm,
   enableXWayland ? true,
 }:
+let
+  # NOTE: remove after https://github.com/NixOS/nixpkgs/pull/271096 reaches nixos-unstable
+  libdrm_2_4_118 = libdrm.overrideAttrs(old: rec {
+    version = "2.4.118";
+    src = fetchurl {
+      url = "https://dri.freedesktop.org/${old.pname}/${old.pname}-${version}.tar.xz";
+      hash = "sha256-p3e9hfK1/JxX+IbIIFgwBXgxfK/bx30Kdp1+mpVnq4g=";
+    };
+  });
+in
 wlroots.overrideAttrs (old: {
   inherit version src enableXWayland;
 
   pname = "${old.pname}-hyprland";
 
-  buildInputs = old.buildInputs ++ [hwdata libliftoff libdisplay-info];
+  # HACK: libdrm_2_4_118 is placed at the head of list to take precedence over libdrm in `old.buildInputs`
+  buildInputs = [libdrm_2_4_118] ++ old.buildInputs ++ [hwdata libliftoff libdisplay-info];
 
   NIX_CFLAGS_COMPILE = toString [
     "-Wno-error=maybe-uninitialized"


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Temporary libdrm override until the update gets into upstream nixpkgs.

Fixes https://github.com/hyprwm/Hyprland/issues/3999.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Yes.

