### PR TITLE
managers: fix debug log using printf format

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1903,7 +1903,7 @@ void CKeybindManager::alterZOrder(std::string args) {
     else if (POSITION == "bottom")
         g_pCompositor->changeWindowZOrder(PWINDOW, 0);
     else {
-        Debug::log(ERR, "alterZOrder: bad position: %s", POSITION);
+        Debug::log(ERR, "alterZOrder: bad position: {}", POSITION);
         return;
     }
 
@@ -2055,7 +2055,7 @@ void CKeybindManager::moveWindowOrGroup(std::string args) {
     static auto* const PIGNOREGROUPLOCK = &g_pConfigManager->getConfigValuePtr("binds:ignore_group_lock")->intValue;
 
     if (!isDirection(args)) {
-        Debug::log(ERR, "Cannot move into group in direction %c, unsupported direction. Supported: l,r,u/t,d/b", arg);
+        Debug::log(ERR, "Cannot move into group in direction {}, unsupported direction. Supported: l,r,u/t,d/b", arg);
         return;
     }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Some debug messages where using printf format style to print variable content instead of std::format format.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I checked the rest of the code for similar mistake, those two were the only one I found

#### Is it ready for merging, or does it need work?
Yes ready to merge

