### PR TITLE
Fix overzealous mouse capture by resize_on_border for XWayland applications

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -597,6 +597,9 @@ void CInputManager::processMouseDownNormal(wlr_pointer_button_event* e) {
     const auto         PASS            = g_pKeybindManager->onMouseEvent(e);
     static auto* const PFOLLOWMOUSE    = &g_pConfigManager->getConfigValuePtr("input:follow_mouse")->intValue;
     static auto* const PRESIZEONBORDER = &g_pConfigManager->getConfigValuePtr("general:resize_on_border")->intValue;
+    static auto* const PBORDERSIZE       = &g_pConfigManager->getConfigValuePtr("general:border_size")->intValue;
+    static auto* const PBORDERGRABEXTEND = &g_pConfigManager->getConfigValuePtr("general:extend_border_grab_area")->intValue;
+    const auto         BORDER_GRAB_AREA  = *PRESIZEONBORDER ? *PBORDERSIZE + *PBORDERGRABEXTEND : 0;
 
     if (!PASS && !*PPASSMOUSE)
         return;
@@ -621,7 +624,8 @@ void CInputManager::processMouseDownNormal(wlr_pointer_button_event* e) {
     if (*PRESIZEONBORDER && !m_bLastFocusOnLS) {
         if (w && !w->m_bIsFullscreen) {
             const CBox real = {w->m_vRealPosition.vec().x, w->m_vRealPosition.vec().y, w->m_vRealSize.vec().x, w->m_vRealSize.vec().y};
-            if ((!real.containsPoint(mouseCoords) || w->isInCurvedCorner(mouseCoords.x, mouseCoords.y)) && !w->hasPopupAt(mouseCoords)) {
+            const CBox grab = {real.x - BORDER_GRAB_AREA, real.y - BORDER_GRAB_AREA, real.width + 2 * BORDER_GRAB_AREA, real.height + 2 * BORDER_GRAB_AREA};
+            if ((grab.containsPoint(mouseCoords) && (!real.containsPoint(mouseCoords) || w->isInCurvedCorner(mouseCoords.x, mouseCoords.y))) && !w->hasPopupAt(mouseCoords)) {
                 g_pKeybindManager->resizeWithBorder(e);
                 return;
             }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes #2456

If an XWayland application has a menu that extends outside the range of the originating window, it's currently impossible to interact with that menu while the `resize_on_border` config option is enabled. On native Wayland apps, this case seems to be safeguarded against by `CWindow::hasPopupAt`, but that function is unimplemented for XWayland, presumably because X11 wasn't designed with that kind of query in mind. This fix only allows the mouse to be captured when the cursor is explicitly inside the configured resize border, rather than incorrectly assuming that a border-resize is the only reason mouse input might fall to a window while the cursor is outside the client area.

Video of fix, using the example program provided in the original issue:

https://github.com/hyprwm/Hyprland/assets/22502477/e120ae9c-cb68-441c-ace2-60d51d7a0446


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

- Also fixes a similar bug for drag and drop between XWayland windows.
- Remaining bug: If the menu item you want to select is directly on top of the resize border, the resize will "punch through" the menu and capture the mouse. Shouldn't be a problem except for large values of `extend_border_grab_area` or tiny menu items, but a more proper fix would implement `hasPopupAt` for X11 clients.


#### Is it ready for merging, or does it need work?

Should be ready to merge provided the tiny bit of code duplication between `CInputManager::processMouseDownNormal` and `CCompositor::vectorToWindowIdeal` is acceptable and the code fits the style. Again it's not a perfect fix, but it's a strict improvement over current behavior.