### PR TITLE
Add meson option to enable plugins support

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -37,9 +37,12 @@ wlroots = subproject('wlroots', default_options: ['examples=false', 'renderers=g
 have_xwlr = wlroots.get_variable('features').get('xwayland')
 xcb_dep = dependency('xcb', required: get_option('xwayland'))
 
-cmake = import('cmake')
-udis = cmake.subproject('udis86')
-udis86 = udis.dependency('libudis86')
+if get_option('plugins').enabled()
+  cmake = import('cmake')
+  udis = cmake.subproject('udis86')
+  udis86 = udis.dependency('libudis86')
+  add_project_arguments(['-DWITH_PLUGINS'], language: 'cpp')
+endif
 
 if get_option('xwayland').enabled() and not have_xwlr
 	error('Cannot enable Xwayland in Hyprland: wlroots has been built without Xwayland support')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('xwayland', type: 'feature', value: 'auto', description: 'Enable support for X11 applications')
 option('systemd', type: 'feature', value: 'auto', description: 'Enable systemd integration')
 option('legacy_renderer', type: 'feature', value: 'disabled', description: 'Enable legacy renderer')
+option('plugins', type: 'feature', value: 'disabled', description: 'Enable plugins support')

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -82,7 +82,9 @@ CCompositor::CCompositor() {
 CCompositor::~CCompositor() {
     cleanup();
     g_pDecorationPositioner.reset();
+#ifdef WITH_PLUGINS
     g_pPluginSystem.reset();
+#endif
     g_pHyprNotificationOverlay.reset();
     g_pDebugOverlay.reset();
     g_pEventManager.reset();
@@ -346,9 +348,11 @@ void CCompositor::cleanup() {
         sd_notify(0, "STOPPING=1");
 #endif
 
+#ifdef WITH_PLUGINS
     // unload all remaining plugins while the compositor is
     // still in a normal working state.
     g_pPluginSystem->unloadAllPlugins();
+#endif
 
     m_pLastFocus  = nullptr;
     m_pLastWindow = nullptr;
@@ -436,9 +440,11 @@ void CCompositor::initManagers(eManagersInitStage stage) {
             Debug::log(LOG, "Creating the HyprNotificationOverlay!");
             g_pHyprNotificationOverlay = std::make_unique<CHyprNotificationOverlay>();
 
+#ifdef WITH_PLUGINS
             Debug::log(LOG, "Creating the PluginSystem!");
             g_pPluginSystem = std::make_unique<CPluginSystem>();
             g_pConfigManager->handlePluginLoads();
+#endif
 
             Debug::log(LOG, "Creating the DecorationPositioner!");
             g_pDecorationPositioner = std::make_unique<CDecorationPositioner>();

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -26,7 +26,9 @@
 #include "render/Renderer.hpp"
 #include "render/OpenGL.hpp"
 #include "hyprerror/HyprError.hpp"
+#ifdef WITH_PLUGINS
 #include "plugins/PluginSystem.hpp"
+#endif
 #include "helpers/Watchdog.hpp"
 
 enum eManagersInitStage

--- a/src/debug/CrashReporter.cpp
+++ b/src/debug/CrashReporter.cpp
@@ -4,7 +4,9 @@
 #include <fstream>
 #include <signal.h>
 
+#ifdef WITH_PLUGINS
 #include "../plugins/PluginSystem.hpp"
+#endif
 
 #if defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__)
 #include <sys/sysctl.h>
@@ -48,6 +50,7 @@ void CrashReporter::createAndSaveCrash(int sig) {
 
     finalCrashReport += std::format("Version: {}\nTag: {}\n\n", GIT_COMMIT_HASH, GIT_TAG);
 
+#ifdef WITH_PLUGINS
     if (g_pPluginSystem && !g_pPluginSystem->getAllPlugins().empty()) {
         finalCrashReport += "Hyprland seems to be running with plugins. This crash might not be Hyprland's fault.\nPlugins:\n";
 
@@ -57,6 +60,7 @@ void CrashReporter::createAndSaveCrash(int sig) {
 
         finalCrashReport += "\n\n";
     }
+#endif
 
     finalCrashReport += "System info:\n";
 

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1260,6 +1260,7 @@ std::string dispatchOutput(std::string request) {
     return "ok";
 }
 
+#ifdef WITH_PLUGINS
 std::string dispatchPlugin(std::string request) {
     CVarList vars(request, 0, ' ');
 
@@ -1302,6 +1303,7 @@ std::string dispatchPlugin(std::string request) {
 
     return "ok";
 }
+#endif
 
 std::string dispatchNotify(std::string request) {
     CVarList vars(request, 0, ' ');
@@ -1401,8 +1403,10 @@ std::string getReply(std::string request) {
         return rollinglogRequest(format);
     else if (request == "layouts")
         return layoutsRequest(format);
+#ifdef WITH_PLUGINS
     else if (request.starts_with("plugin"))
         return dispatchPlugin(request);
+#endif
     else if (request.starts_with("notify"))
         return dispatchNotify(request);
     else if (request.starts_with("setprop"))

--- a/src/managers/HookSystemManager.cpp
+++ b/src/managers/HookSystemManager.cpp
@@ -1,6 +1,8 @@
 #include "HookSystemManager.hpp"
 
+#ifdef WITH_PLUGINS
 #include "../plugins/PluginSystem.hpp"
+#endif
 
 CHookSystemManager::CHookSystemManager() {
     ; //
@@ -61,10 +63,12 @@ void CHookSystemManager::emit(const std::vector<SCallbackFNPtr>* callbacks, SCal
         }
     }
 
+#ifdef WITH_PLUGINS
     if (!faultyHandles.empty()) {
         for (auto& h : faultyHandles)
             g_pPluginSystem->unloadPlugin(g_pPluginSystem->getPluginByHandle(h), true);
     }
+#endif
 }
 
 std::vector<SCallbackFNPtr>* CHookSystemManager::getVecForEvent(const std::string& event) {

--- a/src/managers/HookSystemManager.hpp
+++ b/src/managers/HookSystemManager.hpp
@@ -9,7 +9,9 @@
 
 #include <csetjmp>
 
+#ifdef WITH_PLUGINS
 #include "../plugins/PluginAPI.hpp"
+#endif
 
 // global typedef for hooked functions. Passes itself as a ptr when called, and `data` additionally.
 
@@ -20,6 +22,7 @@ struct SCallbackFNPtr {
     HANDLE            handle = nullptr;
 };
 
+#ifdef WITH_PLUGINS
 #define EMIT_HOOK_EVENT(name, param)                                                                                                                                               \
     {                                                                                                                                                                              \
         static auto* const PEVENTVEC = g_pHookSystem->getVecForEvent(name);                                                                                                        \
@@ -35,6 +38,12 @@ struct SCallbackFNPtr {
         if (info.cancelled)                                                                                                                                                        \
             return;                                                                                                                                                                \
     }
+#else
+#define EMIT_HOOK_EVENT(name, param)                                                                                                                                               \
+    {}
+#define EMIT_HOOK_EVENT_CANCELLABLE(name, param)                                                                                                                                   \
+    {}
+#endif
 
 class CHookSystemManager {
   public:

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,11 +1,7 @@
 globber = run_command('sh', '-c', 'find . -name "*.cpp" | sort', check: true)
 src = globber.stdout().strip().split('\n')
 
-executable('Hyprland', src,
-  cpp_args: ['-DWLR_USE_UNSTABLE'],
-  link_args: '-rdynamic',
-  cpp_pch: 'pch/pch.hpp',
-  dependencies: [
+dependencies = [
     server_protos,
     dependency('wayland-server'),
     dependency('wayland-client'),
@@ -18,13 +14,29 @@ executable('Hyprland', src,
     xcb_dep,
     backtrace_dep,
     systemd_dep,
-    udis86,
-
     dependency('pixman-1'),
     dependency('gl', 'opengl'),
     dependency('threads'),
     dependency('pango'),
     dependency('pangocairo')
-  ],
+]
+
+if get_option('plugins').enabled()
+  dependencies += [udis86]
+else
+tmp = []
+foreach item : src
+  if not item.contains('plugins')
+    tmp += item
+  endif
+endforeach
+src = tmp
+endif
+
+executable('Hyprland', src,
+  cpp_args: ['-DWLR_USE_UNSTABLE'],
+  link_args: '-rdynamic',
+  cpp_pch: 'pch/pch.hpp',
+  dependencies: dependencies,
   install : true
 )


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
The system of plugins and hooks noticeably slows down Hyprland.
Add a meson option to enable plugin support.
Thus, plugin support can only be enabled by those who need it.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Yes

