### PR TITLE
Stop propagating axis events after valid binds

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -699,6 +699,9 @@ void CInputManager::onMouseWheel(wlr_pointer_axis_event* e) {
 
     g_pCompositor->notifyIdleActivity();
 
+    if (!passEvent)
+        return;
+
     const auto MOUSECOORDS = g_pInputManager->getMouseCoordsInternal();
     const auto pWindow     = g_pCompositor->vectorToWindowIdeal(MOUSECOORDS);
 
@@ -713,8 +716,7 @@ void CInputManager::onMouseWheel(wlr_pointer_axis_event* e) {
         }
     }
 
-    if (passEvent)
-        wlr_seat_pointer_notify_axis(g_pCompositor->m_sSeat.seat, e->time_msec, e->orientation, factor * e->delta, std::round(factor * e->delta_discrete), e->source);
+    wlr_seat_pointer_notify_axis(g_pCompositor->m_sSeat.seat, e->time_msec, e->orientation, factor * e->delta, std::round(factor * e->delta_discrete), e->source);
 }
 
 Vector2D CInputManager::getMouseCoordsInternal() {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Currently using a mouse wheel shortcut, like SUPER + mouse_up/down for zooming/changing volume, will also activate group switching if the cursor is over a groupbar.

This change will make sure that only my binds are activated.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.

#### Is it ready for merging, or does it need work?
Yes.

