### PR TITLE
hyprctl: order commands alphabetically

### DIFF
--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -26,33 +26,33 @@
 const std::string USAGE = R"#(usage: hyprctl [(opt)flags] [command] [(opt)args]
 
 commands:
-    monitors
-    workspaces
-    activeworkspace
-    workspacerules
-    clients
     activewindow
-    layers
-    devices
+    activeworkspace
     binds
+    clients
+    cursorpos
+    devices
     dispatch
-    keyword
-    version
-    kill
-    splash
+    getoption
+    globalshortcuts
     hyprpaper
+    instances
+    keyword
+    kill
+    layers
+    layouts
+    monitors
+    notify
+    plugin
     reload
     setcursor
-    getoption
-    cursorpos
-    switchxkblayout
     seterror
     setprop
-    plugin
-    notify
-    globalshortcuts
-    instances
-    layouts
+    splash
+    switchxkblayout
+    version
+    workspacerules
+    workspaces
 
 flags:
     -j -> output in JSON


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
When typing `hyprctl -h` the possible commands are randomly ordered, by ordering them alphabetically finding the correct command is easier and it looks better.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nothing.

#### Is it ready for merging, or does it need work?
It is ready.

