### PR TITLE
Remove `wlr_seat_pointer_notify_motion` in `CInputManager::onTouchMove`

### DIFF
--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -72,7 +72,7 @@ void CInputManager::onTouchMove(wlr_touch_motion_event* e) {
             local = local * m_sTouchData.touchFocusWindow->m_fX11SurfaceScaledBy;
 
         wlr_seat_touch_notify_motion(g_pCompositor->m_sSeat.seat, e->time_msec, e->touch_id, local.x, local.y);
-        wlr_seat_pointer_notify_motion(g_pCompositor->m_sSeat.seat, e->time_msec, local.x, local.y);
+        // wlr_seat_pointer_notify_motion(g_pCompositor->m_sSeat.seat, e->time_msec, local.x, local.y);
     } else if (m_sTouchData.touchFocusLS) {
         const auto PMONITOR = g_pCompositor->getMonitorFromID(m_sTouchData.touchFocusLS->monitorID);
 
@@ -81,7 +81,7 @@ void CInputManager::onTouchMove(wlr_touch_motion_event* e) {
         const auto local = g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchSurfaceOrigin;
 
         wlr_seat_touch_notify_motion(g_pCompositor->m_sSeat.seat, e->time_msec, e->touch_id, local.x, local.y);
-        wlr_seat_pointer_notify_motion(g_pCompositor->m_sSeat.seat, e->time_msec, local.x, local.y);
+        // wlr_seat_pointer_notify_motion(g_pCompositor->m_sSeat.seat, e->time_msec, local.x, local.y);
     }
 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

fixes #2557 

When using touchscreen, touch events and cursor move events comes together and makes waydroid not handling touch events correctly. This PR removes `wlr_seat_pointer_notify_motion` calls in `CInputManager::onTouchMove`, which can fix this issue.

Before

![image_2023-12-06_21-48-56](https://github.com/hyprwm/Hyprland/assets/26316494/ffc5fc9b-4852-45c9-9ce0-0f014bdccbab)

After

![image_2023-12-06_21-46-41](https://github.com/hyprwm/Hyprland/assets/26316494/d4c18082-9bdf-4a04-babd-2c630050ba4c)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Mouse still follows touches as usual, just not triggering cursor move events now.

#### Is it ready for merging, or does it need work?

Maybe ready meow.