### PR TITLE
Add scroll_points option for device

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2,6 +2,7 @@
 #include "../managers/KeybindManager.hpp"
 
 #include "../render/decorations/CHyprGroupBarDecoration.hpp"
+#include "macros.hpp"
 
 #include <string.h>
 #include <string>
@@ -244,6 +245,7 @@ void CConfigManager::setDefaultVars() {
     configValues["input:touchpad:tap-and-drag"].intValue            = 1;
     configValues["input:touchpad:drag_lock"].intValue               = 0;
     configValues["input:touchpad:scroll_factor"].floatValue         = 1.f;
+    configValues["input:touchpad:scroll_points"].strValue           = STRVAL_EMPTY;
     configValues["input:touchdevice:transform"].intValue            = 0;
     configValues["input:touchdevice:output"].strValue               = STRVAL_EMPTY;
     configValues["input:tablet:transform"].intValue                 = 0;
@@ -305,6 +307,7 @@ void CConfigManager::setDeviceDefaultVars(const std::string& dev) {
     cfgValues["scroll_method"].strValue           = STRVAL_EMPTY;
     cfgValues["scroll_button"].intValue           = 0;
     cfgValues["scroll_button_lock"].intValue      = 0;
+    cfgValues["scroll_points"].strValue           = STRVAL_EMPTY;
     cfgValues["transform"].intValue               = 0;
     cfgValues["output"].strValue                  = STRVAL_EMPTY;
     cfgValues["enabled"].intValue                 = 1;          // only for mice / touchpads

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -235,6 +235,7 @@ void CConfigManager::setDefaultVars() {
     configValues["input:scroll_method"].strValue                    = STRVAL_EMPTY;
     configValues["input:scroll_button"].intValue                    = 0;
     configValues["input:scroll_button_lock"].intValue               = 0;
+    configValues["input:scroll_points"].strValue                    = STRVAL_EMPTY;
     configValues["input:touchpad:natural_scroll"].intValue          = 0;
     configValues["input:touchpad:disable_while_typing"].intValue    = 1;
     configValues["input:touchpad:clickfinger_behavior"].intValue    = 0;
@@ -244,7 +245,6 @@ void CConfigManager::setDefaultVars() {
     configValues["input:touchpad:tap-and-drag"].intValue            = 1;
     configValues["input:touchpad:drag_lock"].intValue               = 0;
     configValues["input:touchpad:scroll_factor"].floatValue         = 1.f;
-    configValues["input:touchpad:scroll_points"].strValue           = STRVAL_EMPTY;
     configValues["input:touchdevice:transform"].intValue            = 0;
     configValues["input:touchdevice:output"].strValue               = STRVAL_EMPTY;
     configValues["input:tablet:transform"].intValue                 = 0;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2,7 +2,6 @@
 #include "../managers/KeybindManager.hpp"
 
 #include "../render/decorations/CHyprGroupBarDecoration.hpp"
-#include "macros.hpp"
 
 #include <string.h>
 #include <string>

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1,6 +1,5 @@
 #include "InputManager.hpp"
 #include "../../Compositor.hpp"
-#include "config/ConfigManager.hpp"
 #include "wlr/types/wlr_switch.h"
 #include <ranges>
 
@@ -1069,34 +1068,38 @@ void CInputManager::setPointerConfigs() {
             const auto ACCELPROFILE = g_pConfigManager->getDeviceString(devname, "accel_profile", "input:accel_profile");
             const auto SCROLLPOINTS = g_pConfigManager->getDeviceString(devname, "scroll_points", "input:touchpad:scroll_points");
 
-            if (ACCELPROFILE == "") {
+            if (ACCELPROFILE.empty()) {
                 libinput_device_config_accel_set_profile(LIBINPUTDEV, libinput_device_config_accel_get_default_profile(LIBINPUTDEV));
             } else if (ACCELPROFILE == "adaptive") {
                 libinput_device_config_accel_set_profile(LIBINPUTDEV, LIBINPUT_CONFIG_ACCEL_PROFILE_ADAPTIVE);
             } else if (ACCELPROFILE == "flat") {
                 libinput_device_config_accel_set_profile(LIBINPUTDEV, LIBINPUT_CONFIG_ACCEL_PROFILE_FLAT);
             } else if (ACCELPROFILE.starts_with("custom")) {
-                CVarList accel_values = {ACCELPROFILE, 0, ' '};
+                CVarList accelValues = {ACCELPROFILE, 0, ' '};
 
                 try {
-                    double              accel_step = std::stod(accel_values[1]);
-                    std::vector<double> accel_points;
-                    for (size_t i = 2; i < accel_values.size(); ++i)
-                        accel_points.push_back(std::stod(accel_values[i]));
+                    double              accelStep = std::stod(accelValues[1]);
+                    std::vector<double> accelPoints;
+                    for (size_t i = 2; i < accelValues.size(); ++i) {
+                        accelPoints.push_back(std::stod(accelValues[i]));
+                    }
 
                     const auto CONFIG = libinput_config_accel_create(LIBINPUT_CONFIG_ACCEL_PROFILE_CUSTOM);
 
-                    if (SCROLLPOINTS != "") {
-                        CVarList            scroll_values = {SCROLLPOINTS, 0, ' '};
-                        double              scroll_step   = std::stod(scroll_values[0]);
-                        std::vector<double> scroll_points;
-                        for (size_t i = 1; i < scroll_values.size(); ++i)
-                            scroll_points.push_back(std::stod(scroll_values[i]));
+                    if (!SCROLLPOINTS.empty()) {
+                        CVarList scrollValues = {SCROLLPOINTS, 0, ' '};
+                        try {
+                            double              scrollStep = std::stod(scrollValues[0]);
+                            std::vector<double> scrollPoints;
+                            for (size_t i = 1; i < scrollValues.size(); ++i) {
+                                scrollPoints.push_back(std::stod(scrollValues[i]));
+                            }
 
-                        libinput_config_accel_set_points(CONFIG, LIBINPUT_ACCEL_TYPE_SCROLL, scroll_step, scroll_points.size(), scroll_points.data());
+                            libinput_config_accel_set_points(CONFIG, LIBINPUT_ACCEL_TYPE_SCROLL, scrollStep, scrollPoints.size(), scrollPoints.data());
+                        } catch (std::exception& e) { Debug::log(ERR, "Invalid values in scroll_points"); }
                     }
 
-                    libinput_config_accel_set_points(CONFIG, LIBINPUT_ACCEL_TYPE_MOTION, accel_step, accel_points.size(), accel_points.data());
+                    libinput_config_accel_set_points(CONFIG, LIBINPUT_ACCEL_TYPE_MOTION, accelStep, accelPoints.size(), accelPoints.data());
                     libinput_device_config_accel_apply(LIBINPUTDEV, CONFIG);
                     libinput_config_accel_destroy(CONFIG);
                 } catch (std::exception& e) { Debug::log(ERR, "Invalid values in custom accel profile"); }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1066,7 +1066,7 @@ void CInputManager::setPointerConfigs() {
             libinput_device_config_accel_set_speed(LIBINPUTDEV, LIBINPUTSENS);
 
             const auto ACCELPROFILE = g_pConfigManager->getDeviceString(devname, "accel_profile", "input:accel_profile");
-            const auto SCROLLPOINTS = g_pConfigManager->getDeviceString(devname, "scroll_points", "input:touchpad:scroll_points");
+            const auto SCROLLPOINTS = g_pConfigManager->getDeviceString(devname, "scroll_points", "input:scroll_points");
 
             if (ACCELPROFILE.empty()) {
                 libinput_device_config_accel_set_profile(LIBINPUTDEV, libinput_device_config_accel_get_default_profile(LIBINPUTDEV));


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds `device:*:scroll_points = <step> <points>`, which allows users to define a custom scroll acceleration profile, similar to `device:*:accel_profile = custom <step> <points>`. 

It does not work without having a custom accel_profile, due to `libinput` limitations.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

TODO:
- [x] Wiki PR https://github.com/hyprwm/hyprland-wiki/pull/415

#### Is it ready for merging, or does it need work?

Testing is welcome. From my limited testing, it works. For anyone wanting to try it out, I've modified a [script](https://gist.github.com/yinonburgansky/7be4d0489a0df8c06a923240b8eb0191) taken from [the original MR](https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/775). It can be found [here](https://gist.github.com/fufexan/de2099bc3086f3a6c83d61fc1fcc06c9).

