### PR TITLE
screen_shader config fixes

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -550,7 +550,7 @@ void CConfigManager::configSetValueSafe(const std::string& COMMAND, const std::s
         }
     }
 
-    if (COMMAND == "decoration:screen_shader") {
+    if (COMMAND == "decoration:screen_shader" && VALUE != STRVAL_EMPTY) {
         const auto PATH = absolutePath(VALUE, configCurrentPath);
 
         configPaths.push_back(PATH);

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1402,10 +1402,17 @@ std::string getReply(std::string request) {
     auto format = HyprCtl::FORMAT_NORMAL;
 
     // process flags for non-batch requests
-    if (!request.contains("[[BATCH]]") && request.contains("/")) {
+    if (!request.starts_with("[[BATCH]]") && request.contains("/")) {
         long unsigned int sepIndex = 0;
         for (const auto& c : request) {
             if (c == '/') { // stop at separator
+                break;
+            }
+
+            // after whitespace assume the first word as a keyword,
+            // so its value can have slashes (e.g., a path)
+            if (c == ' ') {
+                sepIndex = request.size();
                 break;
             }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
- Workaround: Setting `--batch "keyword decoration:screen_shader ~/test.frag"` wasn't possible because the slash is used for flags. The commit is more like a patch than a real solution, as it makes an assumption; if there is a space after the first word than it's probably a keyword. But now it's possible to use flags and slashes at the same time.
- Fix: `keyword decoration:screen_shader [[EMPTY]]` previously created a tick for a non-existent file.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.

#### Is it ready for merging, or does it need work?
Yes.