### PR TITLE
Avoid messing with  --config

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1610,9 +1610,15 @@ void CConfigManager::loadConfigLoadVars() {
     ifs.open(mainConfigPath);
 
     if (!ifs.good()) {
-        Debug::log(WARN, "Config reading error. Attempting to generate, backing up old one if exists");
-
         ifs.close();
+
+        if (!g_pCompositor->explicitConfigPath.empty()) {
+            Debug::log(WARN, "Config reading error!");
+            parseError = "Broken config file! (Could not read)";
+            return;
+        }
+
+        Debug::log(WARN, "Config reading error. Attempting to generate, backing up old one if exists");
 
         if (std::filesystem::exists(mainConfigPath))
             std::filesystem::rename(mainConfigPath, mainConfigPath + ".backup");


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
It's possible that the config file doesn't have read permissions, in which case the code tries to rename the file and create a new one. This change prevents this behavior for a file passed by `--config`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.

#### Is it ready for merging, or does it need work?
Yes.
