### PR TITLE
ci: use composite action to minimize code duplication

### DIFF
--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -1,0 +1,75 @@
+name: "Setup base"
+
+inputs:
+  INSTALL_XORG_PKGS:
+    description: 'Install xorg dependencies'
+    required: false
+    default: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get required pacman pkgs
+      shell: bash
+      run: |
+        sed -i 's/SigLevel    = Required DatabaseOptional/SigLevel    = Optional TrustAll/' /etc/pacman.conf
+        pacman --noconfirm --noprogressbar -Syyu
+        pacman --noconfirm --noprogressbar -Sy \
+          base-devel \
+          cairo \
+          clang \
+          cmake \
+          git \
+          glm \
+          glslang \
+          go \
+          jq \
+          libc++ \
+          libdisplay-info \
+          libdrm \
+          libepoxy \
+          libfontenc \
+          libglvnd \
+          libinput \
+          libliftoff \
+          libxcvt \
+          libxfont2 \
+          libxkbcommon \
+          libxkbfile \
+          lld \
+          meson \
+          ninja \
+          pango \
+          pixman \
+          pkgconf \
+          scdoc \
+          seatd \
+          systemd \
+          tomlplusplus \
+          wayland \
+          wayland-protocols \
+          xcb-util-errors \
+          xcb-util-renderutil \
+          xcb-util-wm
+
+    - name: Get Xorg pacman pkgs
+      shell: bash
+      if: inputs.INSTALL_XORG_PKGS == 'true'
+      run: |
+        pacman --noconfirm --noprogressbar -Sy \
+          xorg-fonts-encodings \
+          xorg-server-common \
+          xorg-setxkbmap \
+          xorg-xkbcomp \
+          xorg-xwayland
+
+    - name: Checkout Hyprland
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    # Fix an issue with actions/checkout where the checkout repo is not mark as safe
+    - name: Mark directory as safe for git
+      shell: bash
+      run: |
+        git config --global --add safe.directory /__w/Hyprland/Hyprland

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,29 +8,20 @@ jobs:
     container:
       image: archlinux
     steps:
-      - name: Get required pacman pkgs
-        run: |
-           sed -i 's/SigLevel    = Required DatabaseOptional/SigLevel    = Optional TrustAll/' /etc/pacman.conf
-           pacman --noconfirm --noprogressbar -Syyu
-           pacman --noconfirm --noprogressbar -Sy glslang libepoxy libfontenc libxcvt libxfont2 libxkbfile vulkan-headers vulkan-validation-layers xcb-util-errors xcb-util-renderutil xcb-util-wm xorg-fonts-encodings xorg-server-common xorg-setxkbmap xorg-xkbcomp xorg-xwayland git cmake go clang lld libc++ pkgconf meson ninja wayland wayland-protocols libinput libxkbcommon pixman glm libdrm libglvnd cairo pango systemd scdoc base-devel seatd python libliftoff tomlplusplus
-      - name: Set up user
-        run: |
-          useradd -m githubuser
-          echo -e "root ALL=(ALL:ALL) ALL\ngithubuser ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers
-      - name: Install libdisplay-info from the AUR
-        run: |
-          su githubuser -c "cd ~ && git clone https://aur.archlinux.org/libdisplay-info.git && cd ./libdisplay-info && makepkg -si --skippgpcheck --noconfirm --noprogressbar"
-      - name: Fix permissions for git
-        run: |
-          git config --global --add safe.directory /__w/Hyprland/Hyprland
-      - name: Checkout Hyprland
-        uses: actions/checkout@v3
+      - name: Checkout repository actions
+        uses: actions/checkout@v4
         with:
-          submodules: recursive
+          sparse-checkout: .github/actions
+
+      - name: Setup base
+        uses: ./.github/actions/setup_base
+        with:
+          INSTALL_XORG_PKGS: true
+
       - name: Build Hyprland
         run: |
-          git submodule sync --recursive && git submodule update --init --force --recursive
           make all
+
       - name: Compress and package artifacts
         run: |
           mkdir x86_64-pc-linux-gnu
@@ -45,6 +36,7 @@ jobs:
           cp -r example/ hyprland/
           cp -r assets/ hyprland/
           tar -cvf Hyprland.tar.xz hyprland
+
       - name: Release
         uses: actions/upload-artifact@v3
         with:
@@ -57,28 +49,19 @@ jobs:
     container:
       image: archlinux
     steps:
-      - name: Download dependencies
-        run: |
-          sed -i 's/SigLevel    = Required DatabaseOptional/SigLevel    = Optional TrustAll/' /etc/pacman.conf
-          pacman --noconfirm --noprogressbar -Syyu
-          pacman --noconfirm --noprogressbar -Sy glslang libepoxy libfontenc libxcvt libxfont2 libxkbfile vulkan-headers vulkan-validation-layers git go clang lld libc++ pkgconf meson ninja wayland wayland-protocols libinput libxkbcommon pixman glm libdrm libglvnd cairo pango systemd scdoc base-devel seatd cmake jq python libliftoff tomlplusplus
-      - name: Set up user
-        run: |
-          useradd -m githubuser
-          echo -e "root ALL=(ALL:ALL) ALL\ngithubuser ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers
-      - name: Install libdisplay-info from the AUR
-        run: |
-          su githubuser -c "cd ~ && git clone https://aur.archlinux.org/libdisplay-info.git && cd ./libdisplay-info && makepkg -si --skippgpcheck --noconfirm --noprogressbar"
-      - name: Checkout Hyprland
-        uses: actions/checkout@v3
+      - name: Checkout repository actions
+        uses: actions/checkout@v4
         with:
-          submodules: true
+          sparse-checkout: .github/actions
+
+      - name: Setup base
+        uses: ./.github/actions/setup_base
+
       - name: Configure
-        run: |
-          meson obj-x86_64-pc-linux-gnu \
-            -Ddefault_library=static
+        run: meson setup build -Ddefault_library=static
+
       - name: Compile
-        run: ninja -C obj-x86_64-pc-linux-gnu
+        run: ninja -C build
 
   noxwayland:
     name: "Build Hyprland in pure Wayland (Arch)"
@@ -86,24 +69,17 @@ jobs:
     container:
       image: archlinux
     steps:
-      - name: Download dependencies
-        run: |
-          sed -i 's/SigLevel    = Required DatabaseOptional/SigLevel    = Optional TrustAll/' /etc/pacman.conf
-          pacman --noconfirm --noprogressbar -Syyu
-          pacman --noconfirm --noprogressbar -Sy glslang libepoxy libfontenc libxcvt libxfont2 libxkbfile vulkan-headers vulkan-validation-layers git cmake go clang lld libc++ pkgconf meson ninja wayland wayland-protocols libinput libxkbcommon pixman glm libdrm libglvnd cairo pango systemd scdoc base-devel seatd libliftoff tomlplusplus
-      - name: Set up user
-        run: |
-          useradd -m githubuser
-          echo -e "root ALL=(ALL:ALL) ALL\ngithubuser ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers
-      - name: Install libdisplay-info from the AUR
-        run: |
-          su githubuser -c "cd ~ && git clone https://aur.archlinux.org/libdisplay-info.git && cd ./libdisplay-info && makepkg -si --skippgpcheck --noconfirm --noprogressbar"
-      - name: Checkout Hyprland
-        uses: actions/checkout@v3
+      - name: Checkout repository actions
+        uses: actions/checkout@v4
         with:
-          submodules: true
+          sparse-checkout: .github/actions
+
+      - name: Setup base
+        uses: ./.github/actions/setup_base
+
       - name: Configure
-        run: mkdir -p build && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DNO_XWAYLAND:STRING=true -H./ -B./build -G Ninja 
+        run: mkdir -p build && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DNO_XWAYLAND:STRING=true -H./ -B./build -G Ninja
+
       - name: Compile
         run: make release
 
@@ -113,25 +89,16 @@ jobs:
     container:
       image: archlinux
     steps:
-      - name: Download dependencies
-        run: |
-          sed -i 's/SigLevel    = Required DatabaseOptional/SigLevel    = Optional TrustAll/' /etc/pacman.conf
-          pacman --noconfirm --noprogressbar -Syyu
-          pacman --noconfirm --noprogressbar -Sy glslang libepoxy libfontenc libxcvt libxfont2 libxkbfile vulkan-headers vulkan-validation-layers git go clang lld libc++ pkgconf meson ninja wayland wayland-protocols libinput libxkbcommon pixman glm libdrm libglvnd cairo pango systemd scdoc base-devel seatd cmake jq python libliftoff tomlplusplus
-      - name: Set up user
-        run: |
-          useradd -m githubuser
-          echo -e "root ALL=(ALL:ALL) ALL\ngithubuser ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers
-      - name: Install libdisplay-info from the AUR
-        run: |
-          su githubuser -c "cd ~ && git clone https://aur.archlinux.org/libdisplay-info.git && cd ./libdisplay-info && makepkg -si --skippgpcheck --noconfirm --noprogressbar"
-      - name: Checkout Hyprland
-        uses: actions/checkout@v3
+      - name: Checkout repository actions
+        uses: actions/checkout@v4
         with:
-          submodules: true
+          sparse-checkout: .github/actions
+
+      - name: Setup base
+        uses: ./.github/actions/setup_base
+
       - name: Configure
-        run: |
-          meson obj-x86_64-pc-linux-gnu \
-            -Ddefault_library=static
+        run: meson setup build -Ddefault_library=static
+
       - name: clang-format check
-        run: ninja -C obj-x86_64-pc-linux-gnu clang-format-check
+        run: ninja -C build clang-format-check

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -24,13 +24,13 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: ${{github.workspace}}/flawfinder_results.sarif
-  
+
   codeql:
     name: CodeQL
     runs-on: ubuntu-latest
     container:
       image: archlinux
-    
+
     permissions:
       actions: read
       contents: read
@@ -42,34 +42,25 @@ jobs:
         language: [ 'cpp' ]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+    - name: Checkout repository actions
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: .github/actions
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
 
-    - name: Init Hyprland build
-      run: |
-        sed -i 's/SigLevel    = Required DatabaseOptional/SigLevel    = Optional TrustAll/' /etc/pacman.conf
-        pacman --noconfirm --noprogressbar -Syyu
-        pacman --noconfirm --noprogressbar -Sy glslang libepoxy libfontenc libxcvt libxfont2 libxkbfile vulkan-headers vulkan-validation-layers xcb-util-errors xcb-util-renderutil xcb-util-wm xorg-fonts-encodings xorg-server-common xorg-setxkbmap xorg-xkbcomp xorg-xwayland git cmake go clang lld libc++ pkgconf meson ninja wayland wayland-protocols libinput libxkbcommon pixman glm libdrm libglvnd cairo pango systemd scdoc base-devel seatd python libliftoff tomlplusplus
-        useradd -m githubuser
-        echo -e "root ALL=(ALL:ALL) ALL\ngithubuser ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers
-        su githubuser -c "cd ~ && git clone https://aur.archlinux.org/libdisplay-info.git && cd ./libdisplay-info && makepkg -si --skippgpcheck --noconfirm --noprogressbar"
-        git config --global --add safe.directory /__w/Hyprland/Hyprland
-    
-    - name: Checkout Hyprland
-      uses: actions/checkout@v3
+    - name: Setup base
+      uses: ./.github/actions/setup_base
       with:
-        submodules: recursive
+        INSTALL_XORG_PKGS: true
 
     - name: Build Hyprland
       run: |
-        git submodule sync --recursive && git submodule update --init --force --recursive
         make all
-    
+
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
       with:


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
The idea behind this code refactoring is to factorize the image setup process used in CI. The goal is also to make it more readable and easily maintainable

GitHub composite action seemed like a good choice for this purpose, as it implement in between steps. I also choose local action compare to remote for better control.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I also changed the build directory for meson from `obj-x86_64-pc-linux-gnu` to `build`. I did not find any reason for the old name, while the new is explicitly given in the contributing guide.

I also updated the `actions/checkout` to v4

#### Is it ready for merging, or does it need work?
Is ready for merging
