### PR TITLE
layout: fix interactions with fakefullscreen

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2257,7 +2257,7 @@ void CCompositor::setWindowFullscreen(CWindow* pWindow, bool on, eFullscreenMode
 
     g_pLayoutManager->getCurrentLayout()->fullscreenRequestForWindow(pWindow, MODE, on);
 
-    g_pXWaylandManager->setWindowFullscreen(pWindow, pWindow->m_bIsFullscreen && MODE == FULLSCREEN_FULL);
+    g_pXWaylandManager->setWindowFullscreen(pWindow, pWindow->shouldSendFullscreenState());
 
     pWindow->updateDynamicRules();
     updateWindowAnimatedDecorationValues(pWindow);

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -998,3 +998,8 @@ int CWindow::getRealBorderSize() {
 bool CWindow::canBeTorn() {
     return (m_sAdditionalConfigData.forceTearing.toUnderlying() || m_bTearingHint) && g_pHyprRenderer->m_bTearingEnvSatisfied;
 }
+
+bool CWindow::shouldSendFullscreenState() {
+    const auto MODE = g_pCompositor->getWorkspaceByID(m_iWorkspaceID)->m_efFullscreenMode;
+    return m_bFakeFullscreenState || (m_bIsFullscreen && (MODE == FULLSCREEN_FULL));
+}

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -366,6 +366,7 @@ class CWindow {
     bool                     opaque();
     float                    rounding();
     bool                     canBeTorn();
+    bool                     shouldSendFullscreenState();
 
     int                      getRealBorderSize();
     void                     updateSpecialRenderData();

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1918,8 +1918,7 @@ void CKeybindManager::fakeFullscreenActive(std::string args) {
     if (g_pCompositor->m_pLastWindow) {
         // will also set the flag
         g_pCompositor->m_pLastWindow->m_bFakeFullscreenState = !g_pCompositor->m_pLastWindow->m_bFakeFullscreenState;
-        g_pXWaylandManager->setWindowFullscreen(g_pCompositor->m_pLastWindow,
-                                                g_pCompositor->m_pLastWindow->m_bFakeFullscreenState || g_pCompositor->m_pLastWindow->m_bIsFullscreen);
+        g_pXWaylandManager->setWindowFullscreen(g_pCompositor->m_pLastWindow, g_pCompositor->m_pLastWindow->shouldSendFullscreenState());
     }
 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fix some edge case when using fakefullscreen, maximize and fullscreen at the same time 

This PR fixes two cases I encountered:
- In a maximized and fakefullscreen window, it was not possible to exit the fakefullscreen state
- In a fakefullscreen window, toggling fullscreen twice, the fakefullscreen would no longer be rendered when exiting fullscreen

Both can be easily tested with firefox, as the title bar goes away in fullscreen

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
Ready to merge