### PR TITLE
hyprpm: unbreak on 32-bit archs via static_cast

### DIFF
--- a/hyprpm/src/progress/CProgressBar.cpp
+++ b/hyprpm/src/progress/CProgressBar.cpp
@@ -47,7 +47,7 @@ void CProgressBar::print() {
     else
         percentDone = (float)m_iSteps / (float)m_iMaxSteps;
 
-    const auto BARWIDTH = std::clamp(w.ws_col - m_szCurrentMessage.length() - 2, 0UL, 50UL);
+    const auto BARWIDTH = std::clamp(w.ws_col - static_cast<unsigned long>(m_szCurrentMessage.length()) - 2, 0UL, 50UL);
 
     // draw bar
     message += std::string{" "} + Colors::GREEN;


### PR DESCRIPTION
Similar to #3589. `length()` returns `std::string::size_type` which may be `unsigned int`.
