### PR TITLE
renderer: double lookup fix, input: double conversion fix

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -853,7 +853,7 @@ void CInputManager::applyConfigToKeyboard(SKeyboard* pKeyboard) {
     pKeyboard->repeatDelay = REPEATDELAY;
     pKeyboard->repeatRate  = REPEATRATE;
     pKeyboard->numlockOn   = NUMLOCKON;
-    pKeyboard->xkbFilePath = FILEPATH.c_str();
+    pKeyboard->xkbFilePath = FILEPATH;
 
     xkb_rule_names rules = {.rules = RULES.c_str(), .model = MODEL.c_str(), .layout = LAYOUT.c_str(), .variant = VARIANT.c_str(), .options = OPTIONS.c_str()};
 
@@ -1586,7 +1586,7 @@ void CInputManager::destroySwitch(SSwitchDevice* pDevice) {
 }
 
 void CInputManager::setCursorImageUntilUnset(std::string name) {
-    g_pHyprRenderer->setCursorFromName(name.c_str());
+    g_pHyprRenderer->setCursorFromName(name);
     m_bCursorImageOverridden   = true;
     m_sCursorSurfaceInfo.inUse = false;
 }

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -2024,16 +2024,23 @@ void CHyprOpenGLImpl::clearWithTex() {
 void CHyprOpenGLImpl::destroyMonitorResources(CMonitor* pMonitor) {
     g_pHyprRenderer->makeEGLCurrent();
 
-    g_pHyprOpenGL->m_mMonitorRenderResources[pMonitor].mirrorFB.release();
-    g_pHyprOpenGL->m_mMonitorRenderResources[pMonitor].offloadFB.release();
-    g_pHyprOpenGL->m_mMonitorRenderResources[pMonitor].mirrorSwapFB.release();
-    g_pHyprOpenGL->m_mMonitorRenderResources[pMonitor].monitorMirrorFB.release();
-    g_pHyprOpenGL->m_mMonitorRenderResources[pMonitor].blurFB.release();
-    g_pHyprOpenGL->m_mMonitorRenderResources[pMonitor].offMainFB.release();
-    g_pHyprOpenGL->m_mMonitorRenderResources[pMonitor].stencilTex.destroyTexture();
-    g_pHyprOpenGL->m_mMonitorBGTextures[pMonitor].destroyTexture();
-    g_pHyprOpenGL->m_mMonitorRenderResources.erase(pMonitor);
-    g_pHyprOpenGL->m_mMonitorBGTextures.erase(pMonitor);
+    auto RESIT = g_pHyprOpenGL->m_mMonitorRenderResources.find(pMonitor);
+    if (RESIT != g_pHyprOpenGL->m_mMonitorRenderResources.end()) {
+        RESIT->second.mirrorFB.release();
+        RESIT->second.offloadFB.release();
+        RESIT->second.mirrorSwapFB.release();
+        RESIT->second.monitorMirrorFB.release();
+        RESIT->second.blurFB.release();
+        RESIT->second.offMainFB.release();
+        RESIT->second.stencilTex.destroyTexture();
+        g_pHyprOpenGL->m_mMonitorRenderResources.erase(RESIT);
+    }
+
+    auto TEXIT = g_pHyprOpenGL->m_mMonitorBGTextures.find(pMonitor);
+    if (TEXIT != g_pHyprOpenGL->m_mMonitorBGTextures.end()) {
+        TEXIT->second.destroyTexture();
+        g_pHyprOpenGL->m_mMonitorBGTextures.erase(TEXIT);
+    }
 
     Debug::log(LOG, "Monitor {} -> destroyed all render data", pMonitor->szName);
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
1) Fix `std::string -> char* -> std::string `casting.
2) Avoid double lookup `std::unordered_map`. 

Furthermore, during the initialization of Hyprland, the method `CHyprOpenGLImpl::destroyMonitorResources` will be invoked twice on two empty unordered_maps, leading to the following sequence of events:
1) It will create a empty record inside two unordered_maps (via operator []).
2) Subsequent release methods will be called on empty record.
3) Finally, the record will be removed.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
Ready for merging

