### PR TITLE
Use canonical instead of read_symlink

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -52,19 +52,21 @@ int main(int argc, char** argv) {
 
                 return 1;
             }
-            std::string next_arg = std::next(it)->c_str();
+            configPath = std::next(it)->c_str();
 
-            if (std::filesystem::is_symlink(next_arg))
-                next_arg = std::filesystem::read_symlink(next_arg);
+            try {
+                configPath = std::filesystem::canonical(configPath);
 
-            if (!std::filesystem::is_regular_file(next_arg)) {
-                std::cerr << "[ ERROR ] Config file '" << next_arg << "' doesn't exist!\n";
+                if (!std::filesystem::is_regular_file(configPath)) {
+                    throw std::exception();
+                }
+            } catch (...) {
+                std::cerr << "[ ERROR ] Config file '" << configPath << "' doesn't exist!\n";
                 help();
 
                 return 1;
             }
 
-            configPath = std::filesystem::weakly_canonical(next_arg);
             Debug::log(LOG, "User-specified config location: '{}'", configPath);
 
             it++;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
`filesystem::canonical` (or other similar functions) already handles symlinks. Though they can throw (non-existent file, recursive symlinks...).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.

#### Is it ready for merging, or does it need work?
Yes.