### PR TITLE
Link against tomlplusplus when using cmake

### DIFF
--- a/hyprpm/CMakeLists.txt
+++ b/hyprpm/CMakeLists.txt
@@ -9,6 +9,8 @@ file(GLOB_RECURSE SRCFILES CONFIGURE_DEPENDS "src/*.cpp")
 
 set(CMAKE_CXX_STANDARD 23)
 
-pkg_check_modules(deps REQUIRED IMPORTED_TARGET tomlplusplus)
+pkg_check_modules(tomlplusplus REQUIRED IMPORTED_TARGET tomlplusplus)
 
 add_executable(hyprpm ${SRCFILES})
+
+target_link_libraries(hyprpm PUBLIC PkgConfig::tomlplusplus)


### PR DESCRIPTION
This reduces the compilation time and is consistent with the meson version.

