### PR TITLE
Option for handling axis events outside window area

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -440,6 +440,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("input:follow_mouse", Hyprlang::INT{1});
     m_pConfig->addConfigValue("input:mouse_refocus", Hyprlang::INT{1});
     m_pConfig->addConfigValue("input:special_fallthrough", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("input:off_window_axis_events", Hyprlang::INT{1});
     m_pConfig->addConfigValue("input:sensitivity", {0.f});
     m_pConfig->addConfigValue("input:accel_profile", {STRVAL_EMPTY});
     m_pConfig->addConfigValue("input:kb_file", {STRVAL_EMPTY});


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Tries to address #3485. Even though it was rejected, I often find myself annoyed by this issue.

So, indeed the mouse coordinates are sent to the application, but they are out of bounds of the window area. Some applications (a terminal) don't really care about this, and can handle it, but in some (browser, text editor, filemanager...) there are specific areas where pointer events are registered, though the coordinates need to be precise.

Most of the time the most important areas are next to the edge of the application's window (like a web-page content or the tabbar in a browser). Based on this fact, this PR adds an option to send a "fake" motionevent to the closest point inside the window area before sending the axis event, which allows the application to register the scroll event.

~~And it works well, however I marked it as a draft, because I'm not confident if I'm doing it correctly.
Is there a way to fake a scroll event to a specific point on the screen instead of warping the mouse? Or generally a more elegant way to solve this? (Or if this should be in the code at all, however I think it's not possible to do it via scripts at the moment.)~~

Option name: `input:off_window_axis_events`
```
0 - ignores axis events outside of the window area (so over decorations and gaps)
1 (default) - as it works currently (sends out of bound positions)
2 (or anything else other than listed) - fake pointer coordinates to the closest point in the window area
3 - same as 2 but it also warps the cursor
```