### PR TITLE
fixing cursor show/hide logic, #3698

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -324,13 +324,11 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
                 unsetCursorImage();
             }
 
-            if (g_pHyprRenderer->m_bHasARenderedCursor) {
-                // TODO: maybe wrap?
-                if (m_ecbClickBehavior == CLICKMODE_KILL)
-                    setCursorImageOverride("crosshair");
-                else
-                    setCursorImageOverride("left_ptr");
-            }
+            // TODO: maybe wrap?
+            if (m_ecbClickBehavior == CLICKMODE_KILL)
+                setCursorImageOverride("crosshair");
+            else
+                setCursorImageOverride("left_ptr");
 
             m_bEmptyFocusCursorSet = true;
         }
@@ -490,7 +488,7 @@ void CInputManager::processMouseRequest(wlr_seat_pointer_request_set_cursor_even
     else
         g_pHyprRenderer->m_bWindowRequestedCursorHide = false;
 
-    if (!cursorImageUnlocked() || !g_pHyprRenderer->m_bHasARenderedCursor)
+    if (!cursorImageUnlocked())
         return;
 
     if (e->seat_client == g_pCompositor->m_sSeat.seat->pointer_state.focused_client) {
@@ -513,7 +511,7 @@ void CInputManager::processMouseRequest(wlr_seat_pointer_request_set_cursor_even
 }
 
 void CInputManager::processMouseRequest(wlr_cursor_shape_manager_v1_request_set_shape_event* e) {
-    if (!g_pHyprRenderer->m_bHasARenderedCursor || !cursorImageUnlocked())
+    if (!cursorImageUnlocked())
         return;
 
     if (e->seat_client == g_pCompositor->m_sSeat.seat->pointer_state.focused_client) {
@@ -555,9 +553,6 @@ void CInputManager::setCursorImageOverride(const std::string& name) {
 }
 
 bool CInputManager::cursorImageUnlocked() {
-    if (!g_pHyprRenderer->m_bHasARenderedCursor)
-        return false;
-
     if (m_ecbClickBehavior == CLICKMODE_KILL)
         return false;
 

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -99,6 +99,8 @@ class CHyprRenderer {
     CTimer                                           m_tRenderTimer;
 
     struct {
+        int                         hotspotX;
+        int                         hotspotY;
         std::optional<wlr_surface*> surf = nullptr;
         std::string                 name;
     } m_sLastCursorData;
@@ -115,12 +117,12 @@ class CHyprRenderer {
     void           renderWorkspace(CMonitor* pMonitor, CWorkspace* pWorkspace, timespec* now, const CBox& geometry);
     void           renderAllClientsForWorkspace(CMonitor* pMonitor, CWorkspace* pWorkspace, timespec* now, const Vector2D& translate = {0, 0}, const float& scale = 1.f);
 
-    bool           m_bHasARenderedCursor  = true;
-    bool           m_bCursorHasSurface    = false;
-    CRenderbuffer* m_pCurrentRenderbuffer = nullptr;
-    wlr_buffer*    m_pCurrentWlrBuffer    = nullptr;
-    eRenderMode    m_eRenderMode          = RENDER_MODE_NORMAL;
-    int            m_iLastBufferAge       = 0;
+    bool           m_bTimeoutRequestedCursorHide = false;
+    bool           m_bCursorHasSurface           = false;
+    CRenderbuffer* m_pCurrentRenderbuffer        = nullptr;
+    wlr_buffer*    m_pCurrentWlrBuffer           = nullptr;
+    eRenderMode    m_eRenderMode                 = RENDER_MODE_NORMAL;
+    int            m_iLastBufferAge              = 0;
 
     bool           m_bNvidia = false;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fix for #3698.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

- All the hide/show logic is centralized in Renderer and easy to expand later if needed.
- Cursor is reliably turned on or off in Renderer.
- InputManager and other classes should not hesitate with setting cursor shape or name, they don't need to check any state, after this patch just set it and don't worry.

#### Is it ready for merging, or does it need work?

💯. Ready to merge.


