### PR TITLE
general:cursor_inactive_position

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -88,14 +88,15 @@ void CConfigManager::setDefaultVars() {
     ((CGradientValueData*)configValues["general:col.inactive_border"].data.get())->reset(0xff444444);
     ((CGradientValueData*)configValues["general:col.nogroup_border"].data.get())->reset(0xff444444);
     ((CGradientValueData*)configValues["general:col.nogroup_border_active"].data.get())->reset(0xffff00ff);
-    configValues["general:cursor_inactive_timeout"].intValue = 0;
-    configValues["general:no_cursor_warps"].intValue         = 0;
-    configValues["general:no_focus_fallback"].intValue       = 0;
-    configValues["general:resize_on_border"].intValue        = 0;
-    configValues["general:extend_border_grab_area"].intValue = 15;
-    configValues["general:hover_icon_on_border"].intValue    = 1;
-    configValues["general:layout"].strValue                  = "dwindle";
-    configValues["general:allow_tearing"].intValue           = 0;
+    configValues["general:cursor_inactive_timeout"].intValue  = 0;
+    configValues["general:cursor_inactive_position"].vecValue = Vector2D(-1, -1);
+    configValues["general:no_cursor_warps"].intValue          = 0;
+    configValues["general:no_focus_fallback"].intValue        = 0;
+    configValues["general:resize_on_border"].intValue         = 0;
+    configValues["general:extend_border_grab_area"].intValue  = 15;
+    configValues["general:hover_icon_on_border"].intValue     = 1;
+    configValues["general:layout"].strValue                   = "dwindle";
+    configValues["general:allow_tearing"].intValue            = 0;
 
     configValues["misc:disable_hyprland_logo"].intValue            = 0;
     configValues["misc:disable_splash_rendering"].intValue         = 0;

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -103,6 +103,8 @@ class CHyprRenderer {
         int                         hotspotY;
         std::optional<wlr_surface*> surf = nullptr;
         std::string                 name;
+        double                      x; // used only while hiding or showing cursor
+        double                      y; // used only while hiding or showing cursor
     } m_sLastCursorData;
 
   private:


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

When hidden, cursor still triggers hover events at the position where it was hidden, for instance web browser will show hyperlink tooltips during scroll when hyperlink falls under hidden cursor position.

This PR adds `general:cursor_inactive_position` [vec2] variable with the defaults [-1 -1]. Defining any other value than -1 -1, for instance

    cursor_inactive_position = 500 200

will move cursor to those x,y coordinates when hiding and restore previous position before becomes visible. Visually doesn't change anything but choosing out of the way x and y prevents tooltips and similar mouse interaction UI to show uninvited.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I have no idea how to add `general:cursor_inactive_position` to documentation (https://wiki.hyprland.org/Configuring/Variables/) so some kind soul must do that for me or tell me how to do it.

#### Is it ready for merging, or does it need work?

💯. Ready to merge.

