### PR TITLE
bug: fix invalid pointer access

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -24,7 +24,7 @@ void handleUnrecoverableSignal(int sig) {
     signal(SIGABRT, SIG_DFL);
     signal(SIGSEGV, SIG_DFL);
 
-    if (g_pHookSystem->m_bCurrentEventPlugin) {
+    if (g_pHookSystem && g_pHookSystem->m_bCurrentEventPlugin) {
         longjmp(g_pHookSystem->m_jbHookFaultJumpBuf, 1);
         return;
     }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
The compositor sometimes segfaults on exit, so this fix checks first in the handler if the global pointer "g_pHookSystem" is valid before calling "longjump".

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
If I'm not mistaken, this bug might mean that this behaviour isn't intended, so this might require further lookup in the future.

#### Is it ready for merging, or does it need work?
Yes, it's.

