### PR TITLE
Avoid rounded shadows when rounding is 0

### DIFF
--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -75,7 +75,8 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D
     if (*PSHADOWS != 1)
         return; // disabled
 
-    const auto ROUNDING        = m_pWindow->rounding() + m_pWindow->getRealBorderSize();
+    const auto ROUNDINGBASE    = m_pWindow->rounding();
+    const auto ROUNDING        = ROUNDINGBASE > 0 ? ROUNDINGBASE + m_pWindow->getRealBorderSize() : 0;
     const auto PWORKSPACE      = g_pCompositor->getWorkspaceByID(m_pWindow->m_iWorkspaceID);
     const auto WORKSPACEOFFSET = PWORKSPACE && !m_pWindow->m_bPinned ? PWORKSPACE->m_vRenderOffset.vec() : Vector2D();
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Shadows were still rounded with `rounding = 0`. With a bit thicker borders it was noticeable.

An exaggerated example, to see it clearly:

![HDMI-A-1_2023-12-23_17-51-19](https://github.com/hyprwm/Hyprland/assets/150595692/bdbc6175-581d-401e-bd1c-9ff55fa55cb3)


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.

#### Is it ready for merging, or does it need work?
Yes.

