### PR TITLE
Use window->middle() when cursor is on reserved area

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1723,6 +1723,15 @@ bool CCompositor::isPointOnAnyMonitor(const Vector2D& point) {
     return false;
 }
 
+bool CCompositor::isPointOnReservedArea(const Vector2D& point, const CMonitor* pMonitor) {
+    const auto PMONITOR = pMonitor ? pMonitor : getMonitorFromVector(point);
+
+    const auto XY1 = PMONITOR->vecPosition + PMONITOR->vecReservedTopLeft;
+    const auto XY2 = PMONITOR->vecPosition + PMONITOR->vecSize - PMONITOR->vecReservedBottomRight;
+
+    return !VECINRECT(point, XY1.x, XY1.y, XY2.x, XY2.y);
+}
+
 void checkFocusSurfaceIter(wlr_surface* pSurface, int x, int y, void* data) {
     auto pair    = (std::pair<wlr_surface*, bool>*)data;
     pair->second = pair->second || pSurface == pair->first;
@@ -2526,17 +2535,6 @@ void CCompositor::forceReportSizesToWindowsOnWorkspace(const int& wid) {
             g_pXWaylandManager->setWindowSize(w.get(), w->m_vRealSize.vec(), true);
         }
     }
-}
-
-bool CCompositor::cursorOnReservedArea() {
-    const auto PMONITOR = getMonitorFromCursor();
-
-    const auto XY1 = PMONITOR->vecPosition + PMONITOR->vecReservedTopLeft;
-    const auto XY2 = PMONITOR->vecPosition + PMONITOR->vecSize - PMONITOR->vecReservedBottomRight;
-
-    const auto CURSORPOS = g_pInputManager->getMouseCoordsInternal();
-
-    return !VECINRECT(CURSORPOS, XY1.x, XY1.y, XY2.x, XY2.y);
 }
 
 CWorkspace* CCompositor::createNewWorkspace(const int& id, const int& monid, const std::string& name) {

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -169,6 +169,7 @@ class CCompositor {
     CWindow*       getPrevWindowOnWorkspace(CWindow*, bool focusableOnly = false, std::optional<bool> floating = {});
     int            getNextAvailableNamedWorkspace();
     bool           isPointOnAnyMonitor(const Vector2D&);
+    bool           isPointOnReservedArea(const Vector2D& point, const CMonitor* monitor = nullptr);
     CWindow*       getConstraintWindow(SMouse*);
     CMonitor*      getMonitorInDirection(const char&);
     void           updateAllWindowsAnimatedDecorationValues();
@@ -192,7 +193,6 @@ class CCompositor {
     void           closeWindow(CWindow*);
     Vector2D       parseWindowVectorArgsRelative(const std::string&, const Vector2D&);
     void           forceReportSizesToWindowsOnWorkspace(const int&);
-    bool           cursorOnReservedArea();
     CWorkspace*    createNewWorkspace(const int&, const int&, const std::string& name = ""); // will be deleted next frame if left empty and unfocused!
     void           renameWorkspace(const int&, const std::string& name = "");
     void           setActiveMonitor(CMonitor*);

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -254,10 +254,11 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection dire
 
     const auto        MOUSECOORDS   = m_vOverrideFocalPoint.value_or(g_pInputManager->getMouseCoordsInternal());
     const auto        MONFROMCURSOR = g_pCompositor->getMonitorFromVector(MOUSECOORDS);
+    const auto        TARGETCOORDS  = PMONITOR->ID == MONFROMCURSOR->ID && g_pCompositor->isPointOnReservedArea(MOUSECOORDS, PMONITOR) ? pWindow->middle() : MOUSECOORDS;
 
     if (PMONITOR->ID == MONFROMCURSOR->ID &&
         (PNODE->workspaceID == PMONITOR->activeWorkspace || (g_pCompositor->isWorkspaceSpecial(PNODE->workspaceID) && PMONITOR->specialWorkspaceID)) && !*PUSEACTIVE) {
-        OPENINGON = getNodeFromWindow(g_pCompositor->vectorToWindowTiled(MOUSECOORDS));
+        OPENINGON = getNodeFromWindow(g_pCompositor->vectorToWindowTiled(TARGETCOORDS));
 
         // happens on reserved area
         if (!OPENINGON && g_pCompositor->getWindowsOnWorkspace(PNODE->workspaceID) > 0)
@@ -268,7 +269,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection dire
             g_pCompositor->m_pLastWindow->m_iWorkspaceID == pWindow->m_iWorkspaceID && g_pCompositor->m_pLastWindow->m_bIsMapped) {
             OPENINGON = getNodeFromWindow(g_pCompositor->m_pLastWindow);
         } else {
-            OPENINGON = getNodeFromWindow(g_pCompositor->vectorToWindowTiled(MOUSECOORDS));
+            OPENINGON = getNodeFromWindow(g_pCompositor->vectorToWindowTiled(TARGETCOORDS));
         }
 
         if (!OPENINGON && g_pCompositor->getWindowsOnWorkspace(PNODE->workspaceID) > 0)
@@ -399,15 +400,15 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection dire
         const auto br = NEWPARENT->box.pos() + NEWPARENT->box.size();
         const auto cc = NEWPARENT->box.pos() + NEWPARENT->box.size() / 2;
 
-        if (MOUSECOORDS.inTriangle(tl, tr, cc)) {
+        if (TARGETCOORDS.inTriangle(tl, tr, cc)) {
             NEWPARENT->splitTop    = true;
             NEWPARENT->children[0] = PNODE;
             NEWPARENT->children[1] = OPENINGON;
-        } else if (MOUSECOORDS.inTriangle(tr, cc, br)) {
+        } else if (TARGETCOORDS.inTriangle(tr, cc, br)) {
             NEWPARENT->splitTop    = false;
             NEWPARENT->children[0] = OPENINGON;
             NEWPARENT->children[1] = PNODE;
-        } else if (MOUSECOORDS.inTriangle(br, bl, cc)) {
+        } else if (TARGETCOORDS.inTriangle(br, bl, cc)) {
             NEWPARENT->splitTop    = true;
             NEWPARENT->children[0] = OPENINGON;
             NEWPARENT->children[1] = PNODE;
@@ -418,9 +419,9 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection dire
         }
     } else if (*PFORCESPLIT == 0 || !pWindow->m_bFirstMap) {
         if ((SIDEBYSIDE &&
-             VECINRECT(MOUSECOORDS, NEWPARENT->box.x, NEWPARENT->box.y / *PWIDTHMULTIPLIER, NEWPARENT->box.x + NEWPARENT->box.w / 2.f, NEWPARENT->box.y + NEWPARENT->box.h)) ||
+             VECINRECT(TARGETCOORDS, NEWPARENT->box.x, NEWPARENT->box.y / *PWIDTHMULTIPLIER, NEWPARENT->box.x + NEWPARENT->box.w / 2.f, NEWPARENT->box.y + NEWPARENT->box.h)) ||
             (!SIDEBYSIDE &&
-             VECINRECT(MOUSECOORDS, NEWPARENT->box.x, NEWPARENT->box.y / *PWIDTHMULTIPLIER, NEWPARENT->box.x + NEWPARENT->box.w, NEWPARENT->box.y + NEWPARENT->box.h / 2.f))) {
+             VECINRECT(TARGETCOORDS, NEWPARENT->box.x, NEWPARENT->box.y / *PWIDTHMULTIPLIER, NEWPARENT->box.x + NEWPARENT->box.w, NEWPARENT->box.y + NEWPARENT->box.h / 2.f))) {
             // we are hovering over the first node, make PNODE first.
             NEWPARENT->children[1] = OPENINGON;
             NEWPARENT->children[0] = PNODE;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
I have two tiled windows beside each other. My cursor is over reserved area, and I accidentally float the window on the right, and when I reverse it to tiling mode the window will move to the left, instead of staying where it was. With more than two windows the placing is even more erratic.

Using the window's center instead of the cursor position makes placing a bit more predictable.

Before:
https://github.com/hyprwm/Hyprland/assets/150595692/bce5a66b-d9e4-4e34-b900-29e21238a079

After:
https://github.com/hyprwm/Hyprland/assets/150595692/88862c74-153f-4f0e-ab6a-92af41c5d652

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I repurposed the `cursorOnReservedArea` (it wasn't used at all) to a more generic form `isPointOnReservedArea`.

#### Is it ready for merging, or does it need work?
Yes.

