### PR TITLE
Trampoline hooks %rip patching improvements

### DIFF
--- a/src/plugins/HookSystem.cpp
+++ b/src/plugins/HookSystem.cpp
@@ -104,7 +104,7 @@ CFunctionHook::SAssembly CFunctionHook::fixInstructionProbeRIPCalls(const SInstr
     std::ofstream ofs("/tmp/hypr/.hookcode.asm", std::ios::trunc);
     ofs << assemblyBuilder;
     ofs.close();
-    execAndGet("as /tmp/hypr/.hookcode.asm -o /tmp/hypr/.hookbinary.o && objcopy -O binary -j .text /tmp/hypr/.hookbinary.o /tmp/hypr/.hookbinary2.o");
+    execAndGet("cc -x assembler -c /tmp/hypr/.hookcode.asm -o /tmp/hypr/.hookbinary.o && objcopy -O binary -j .text /tmp/hypr/.hookbinary.o /tmp/hypr/.hookbinary2.o");
     if (!std::filesystem::exists("/tmp/hypr/.hookbinary2.o")) {
         std::filesystem::remove("/tmp/hypr/.hookcode.asm");
         std::filesystem::remove("/tmp/hypr/.hookbinary.asm");

--- a/src/plugins/HookSystem.hpp
+++ b/src/plugins/HookSystem.hpp
@@ -22,21 +22,31 @@ class CFunctionHook {
     void*          m_pOriginal = nullptr;
 
   private:
-    void*                                       m_pSource         = nullptr;
-    void*                                       m_pFunctionAddr   = nullptr;
-    void*                                       m_pTrampolineAddr = nullptr;
-    void*                                       m_pDestination    = nullptr;
-    size_t                                      m_iHookLen        = 0;
-    size_t                                      m_iTrampoLen      = 0;
-    HANDLE                                      m_pOwner          = nullptr;
-    bool                                        m_bActive         = false;
+    void*  m_pSource         = nullptr;
+    void*  m_pFunctionAddr   = nullptr;
+    void*  m_pTrampolineAddr = nullptr;
+    void*  m_pDestination    = nullptr;
+    size_t m_iHookLen        = 0;
+    size_t m_iTrampoLen      = 0;
+    HANDLE m_pOwner          = nullptr;
+    bool   m_bActive         = false;
 
-    std::vector<std::pair<size_t, std::string>> m_vTrampolineRIPUses;
+    void*  m_pOriginalBytes = nullptr;
 
-    void*                                       m_pOriginalBytes = nullptr;
+    struct SInstructionProbe {
+        size_t              len      = 0;
+        std::string         assembly = "";
+        std::vector<size_t> insSizes;
+    };
 
-    size_t                                      probeMinimumJumpSize(void* start, size_t min);
-    size_t                                      getInstructionLenAt(void* start);
+    struct SAssembly {
+        std::vector<char> bytes;
+    };
+
+    SInstructionProbe probeMinimumJumpSize(void* start, size_t min);
+    SInstructionProbe getInstructionLenAt(void* start);
+
+    SAssembly         fixInstructionProbeRIPCalls(const SInstructionProbe& probe);
 
     friend class CHookSystem;
 };


### PR DESCRIPTION
Now uses `as` and `objdump` to parse human-readable at&t asm instead of raw bytes.

Tested a bit, but @DreamMaoMao for further testing (hycov) and @jbeich for potential clang/bsd comments.

Seems to work alright on my end.

Should work with `%rip` being used in `mov`, `lea` and `call`