### PR TITLE
nix: fix wlroots build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703255338,
-        "narHash": "sha256-Z6wfYJQKmDN9xciTwU3cOiOk+NElxdZwy/FiHctCzjU=",
+        "lastModified": 1703438236,
+        "narHash": "sha256-aqVBq1u09yFhL7bj1/xyUeJjzr92fXVvQSSEx6AdB1M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6df37dc6a77654682fe9f071c62b4242b5342e04",
+        "rev": "5f64a12a728902226210bf01d25ec6cbb9d9265b",
         "type": "github"
       },
       "original": {

--- a/nix/wlroots.nix
+++ b/nix/wlroots.nix
@@ -2,9 +2,6 @@
   version,
   src,
   wlroots,
-  hwdata,
-  libdisplay-info,
-  libliftoff,
   enableXWayland ? true,
 }:
 wlroots.overrideAttrs (old: {
@@ -12,11 +9,5 @@ wlroots.overrideAttrs (old: {
 
   pname = "${old.pname}-hyprland";
 
-  buildInputs =
-    old.buildInputs
-    ++ [
-      hwdata
-      libliftoff
-      libdisplay-info
-    ];
+  patches = [ ]; # don't inherit old.patches
 })


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Upstream `wlroots` was updated to 0.17 which already includes the build inputs declared here and also includes a patch that doesn't apply (https://github.com/NixOS/nixpkgs/pull/269359). We can remove the overriding of patches once https://github.com/NixOS/nixpkgs/pull/276322 hits `nixpkgs-unstable`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Yes.
