### PR TITLE
Unify input handling on decorations

### DIFF
--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -222,6 +222,24 @@ void CWindow::removeWindowDeco(IHyprWindowDecoration* deco) {
     g_pLayoutManager->getCurrentLayout()->recalculateWindow(this);
 }
 
+bool CWindow::checkInputOnDecos(const eInputType type, const Vector2D& mouseCoords, std::any data) {
+    if (type != INPUT_TYPE_DRAG_END && hasPopupAt(mouseCoords))
+        return false;
+
+    for (auto& wd : m_dWindowDecorations) {
+        if (!(wd->getDecorationFlags() & DECORATION_ALLOWS_MOUSE_INPUT))
+            continue;
+
+        if (!g_pDecorationPositioner->getWindowDecorationBox(wd.get()).containsPoint(mouseCoords))
+            continue;
+
+        if (wd->onInputOnDeco(type, mouseCoords, data))
+            return true;
+    }
+
+    return false;
+}
+
 pid_t CWindow::getPID() {
     pid_t PID = -1;
     if (!m_bIsX11) {

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -348,6 +348,7 @@ class CWindow {
     void                     addWindowDeco(std::unique_ptr<IHyprWindowDecoration> deco);
     void                     updateWindowDecos();
     void                     removeWindowDeco(IHyprWindowDecoration* deco);
+    bool                     checkInputOnDecos(const eInputType, const Vector2D&, std::any = 0);
     pid_t                    getPID();
     IHyprWindowDecoration*   getDecorationByType(eDecorationType);
     void                     removeDecorationByType(eDecorationType);

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -348,7 +348,7 @@ class CWindow {
     void                     addWindowDeco(std::unique_ptr<IHyprWindowDecoration> deco);
     void                     updateWindowDecos();
     void                     removeWindowDeco(IHyprWindowDecoration* deco);
-    bool                     checkInputOnDecos(const eInputType, const Vector2D&, std::any = 0);
+    bool                     checkInputOnDecos(const eInputType, const Vector2D&, std::any = {});
     pid_t                    getPID();
     IHyprWindowDecoration*   getDecorationByType(eDecorationType);
     void                     removeDecorationByType(eDecorationType);

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -316,16 +316,8 @@ void CHyprDwindleLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection dire
     }
 
     if (!m_vOverrideFocalPoint && g_pInputManager->m_bWasDraggingWindow) {
-        for (auto& wd : OPENINGON->pWindow->m_dWindowDecorations) {
-            if (!(wd->getDecorationFlags() & DECORATION_ALLOWS_MOUSE_INPUT))
-                continue;
-
-            if (g_pDecorationPositioner->getWindowDecorationBox(wd.get()).containsPoint(MOUSECOORDS)) {
-                if (!wd->onEndWindowDragOnDeco(pWindow, MOUSECOORDS))
-                    return;
-                break;
-            }
-        }
+        if (OPENINGON->pWindow->checkInputOnDecos(INPUT_TYPE_DRAG_END, MOUSECOORDS, pWindow))
+            return;
     }
 
     // if it's a group, add the window

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -271,16 +271,8 @@ void IHyprLayout::onEndDragWindow() {
         CWindow*   pWindow     = g_pCompositor->vectorToWindowIdeal(MOUSECOORDS, DRAGGINGWINDOW);
 
         if (pWindow && pWindow->m_bIsFloating) {
-            for (auto& wd : pWindow->m_dWindowDecorations) {
-                if (!(wd->getDecorationFlags() & DECORATION_ALLOWS_MOUSE_INPUT))
-                    continue;
-
-                if (g_pDecorationPositioner->getWindowDecorationBox(wd.get()).containsPoint(MOUSECOORDS)) {
-                    if (!wd->onEndWindowDragOnDeco(DRAGGINGWINDOW, MOUSECOORDS))
-                        return;
-                    break;
-                }
-            }
+            if (pWindow->checkInputOnDecos(INPUT_TYPE_DRAG_END, MOUSECOORDS, DRAGGINGWINDOW))
+                return;
 
             if (pWindow->m_sGroupData.pNextWindow && DRAGGINGWINDOW->canBeGroupedInto(pWindow)) {
                 static const auto* USECURRPOS = &g_pConfigManager->getConfigValuePtr("group:insert_after_current")->intValue;

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -102,16 +102,8 @@ void CHyprMasterLayout::onWindowCreatedTiling(CWindow* pWindow, eDirection direc
     const auto         MOUSECOORDS = g_pInputManager->getMouseCoordsInternal();
 
     if (g_pInputManager->m_bWasDraggingWindow && OPENINGON) {
-        for (auto& wd : OPENINGON->pWindow->m_dWindowDecorations) {
-            if (!(wd->getDecorationFlags() & DECORATION_ALLOWS_MOUSE_INPUT))
-                continue;
-
-            if (g_pDecorationPositioner->getWindowDecorationBox(wd.get()).containsPoint(MOUSECOORDS)) {
-                if (!wd->onEndWindowDragOnDeco(pWindow, MOUSECOORDS))
-                    return;
-                break;
-            }
-        }
+        if (OPENINGON->pWindow->checkInputOnDecos(INPUT_TYPE_DRAG_END, MOUSECOORDS, pWindow))
+            return;
     }
 
     // if it's a group, add the window

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1840,17 +1840,8 @@ void CKeybindManager::mouse(std::string args) {
             const auto mouseCoords = g_pInputManager->getMouseCoordsInternal();
             CWindow*   pWindow     = g_pCompositor->vectorToWindowIdeal(mouseCoords);
 
-            if (pWindow && !pWindow->m_bIsFullscreen && !pWindow->hasPopupAt(mouseCoords)) {
-                for (auto& wd : pWindow->m_dWindowDecorations) {
-                    if (!(wd->getDecorationFlags() & DECORATION_ALLOWS_MOUSE_INPUT))
-                        continue;
-
-                    if (g_pDecorationPositioner->getWindowDecorationBox(wd.get()).containsPoint(mouseCoords)) {
-                        wd->onBeginWindowDragOnDeco(mouseCoords);
-                        break;
-                    }
-                }
-            }
+            if (pWindow && !pWindow->m_bIsFullscreen)
+                pWindow->checkInputOnDecos(INPUT_TYPE_DRAG_START, mouseCoords);
 
             if (!g_pInputManager->currentlyDraggedWindow)
                 g_pInputManager->currentlyDraggedWindow = pWindow;

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -32,6 +32,14 @@ enum eBorderIconDirection {
     BORDERICON_DOWN_RIGHT,
 };
 
+enum eInputType {
+    INPUT_TYPE_AXIS = 0,
+    INPUT_TYPE_BUTTON,
+    INPUT_TYPE_DRAG_START,
+    INPUT_TYPE_DRAG_END,
+    INPUT_TYPE_MOTION
+};
+
 struct STouchData {
     CWindow*       touchFocusWindow  = nullptr;
     SLayerSurface* touchFocusLS      = nullptr;

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -35,14 +35,6 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
 
     virtual void                       damageEntire();
 
-    virtual bool                       onBeginWindowDragOnDeco(const Vector2D&);
-
-    virtual bool                       onEndWindowDragOnDeco(const Vector2D&, CWindow*);
-
-    virtual bool                       onMouseButtonOnDeco(const Vector2D&, wlr_pointer_button_event*);
-
-    virtual bool                       onScrollOnDeco(const Vector2D&, wlr_pointer_axis_event*);
-
     virtual bool                       onInputOnDeco(const eInputType, const Vector2D&, std::any = 0);
 
     virtual eDecorationLayer           getDecorationLayer();
@@ -66,6 +58,11 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
     void                     invalidateTextures();
 
     CBox                     assignedBoxGlobal();
+
+    bool                     onBeginWindowDragOnDeco(const Vector2D&);
+    bool                     onEndWindowDragOnDeco(const Vector2D&, CWindow*);
+    bool                     onMouseButtonOnDeco(const Vector2D&, wlr_pointer_button_event*);
+    bool                     onScrollOnDeco(const Vector2D&, wlr_pointer_axis_event*);
 
     struct STitleTexs {
         // STitleTexs*                            overriden = nullptr; // TODO: make shit shared in-group to decrease VRAM usage.

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -35,7 +35,7 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
 
     virtual void                       damageEntire();
 
-    virtual bool                       onInputOnDeco(const eInputType, const Vector2D&, std::any = 0);
+    virtual bool                       onInputOnDeco(const eInputType, const Vector2D&, std::any = {});
 
     virtual eDecorationLayer           getDecorationLayer();
 

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -35,11 +35,15 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
 
     virtual void                       damageEntire();
 
-    virtual void                       onBeginWindowDragOnDeco(const Vector2D&);
+    virtual bool                       onBeginWindowDragOnDeco(const Vector2D&);
 
-    virtual bool                       onEndWindowDragOnDeco(CWindow* pDraggedWindow, const Vector2D&);
+    virtual bool                       onEndWindowDragOnDeco(const Vector2D&, CWindow*);
 
-    virtual void                       onMouseButtonOnDeco(const Vector2D&, wlr_pointer_button_event*);
+    virtual bool                       onMouseButtonOnDeco(const Vector2D&, wlr_pointer_button_event*);
+
+    virtual bool                       onScrollOnDeco(const Vector2D&, wlr_pointer_axis_event*);
+
+    virtual bool                       onInputOnDeco(const eInputType, const Vector2D&, std::any = 0);
 
     virtual eDecorationLayer           getDecorationLayer();
 

--- a/src/render/decorations/IHyprWindowDecoration.cpp
+++ b/src/render/decorations/IHyprWindowDecoration.cpp
@@ -8,16 +8,8 @@ IHyprWindowDecoration::IHyprWindowDecoration(CWindow* pWindow) {
 
 IHyprWindowDecoration::~IHyprWindowDecoration() {}
 
-void IHyprWindowDecoration::onBeginWindowDragOnDeco(const Vector2D&) {
-    ;
-}
-
-bool IHyprWindowDecoration::onEndWindowDragOnDeco(CWindow* pDraggedWindow, const Vector2D&) {
-    return true;
-}
-
-void IHyprWindowDecoration::onMouseButtonOnDeco(const Vector2D&, wlr_pointer_button_event*) {
-    ;
+bool IHyprWindowDecoration::onInputOnDeco(const eInputType, const Vector2D&, std::any) {
+    return false;
 }
 
 eDecorationLayer IHyprWindowDecoration::getDecorationLayer() {
@@ -31,3 +23,4 @@ uint64_t IHyprWindowDecoration::getDecorationFlags() {
 std::string IHyprWindowDecoration::getDisplayName() {
     return "Unknown Decoration";
 }
+

--- a/src/render/decorations/IHyprWindowDecoration.cpp
+++ b/src/render/decorations/IHyprWindowDecoration.cpp
@@ -23,4 +23,3 @@ uint64_t IHyprWindowDecoration::getDecorationFlags() {
 std::string IHyprWindowDecoration::getDisplayName() {
     return "Unknown Decoration";
 }
-

--- a/src/render/decorations/IHyprWindowDecoration.hpp
+++ b/src/render/decorations/IHyprWindowDecoration.hpp
@@ -2,6 +2,7 @@
 
 #include "../../defines.hpp"
 #include "../../helpers/Region.hpp"
+#include "../../managers/input/InputManager.hpp"
 #include "DecorationPositioner.hpp"
 
 enum eDecorationType {
@@ -46,11 +47,7 @@ class IHyprWindowDecoration {
 
     virtual void                       damageEntire() = 0; // should be ignored by non-absolute decos
 
-    virtual void                       onBeginWindowDragOnDeco(const Vector2D&); // called when the user calls the "movewindow" mouse dispatcher on the deco
-
-    virtual bool                       onEndWindowDragOnDeco(CWindow* pDraggedWindow, const Vector2D&); // returns true if the window should be placed by the layout
-
-    virtual void                       onMouseButtonOnDeco(const Vector2D&, wlr_pointer_button_event*);
+    virtual bool                       onInputOnDeco(const eInputType, const Vector2D&, std::any = 0);
 
     virtual eDecorationLayer           getDecorationLayer();
 

--- a/src/render/decorations/IHyprWindowDecoration.hpp
+++ b/src/render/decorations/IHyprWindowDecoration.hpp
@@ -47,7 +47,7 @@ class IHyprWindowDecoration {
 
     virtual void                       damageEntire() = 0; // should be ignored by non-absolute decos
 
-    virtual bool                       onInputOnDeco(const eInputType, const Vector2D&, std::any = 0);
+    virtual bool                       onInputOnDeco(const eInputType, const Vector2D&, std::any = {});
 
     virtual eDecorationLayer           getDecorationLayer();
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
As discussed in #4177. Just making a draft to see if I'm on the right path.

Added methods:
```cpp
// picks the right event handler based on eInputType (set in InputManager.hpp), each decoration can use their own logic
// true if the input is consumed
bool IHyprWindowDecoration::onInputOnDeco(const eInputType, const Vector2D&, std::any = 0);

// loops through the decorations and calls the first appropriate `onInputOnDeco` and stops
// true if one of the decos consumed the input
bool CWindow::checkInputOnDecos(const eInputType type, const Vector2D& mouseCoords, std::any data)
```

This PR should not have behavioral changes, it follows the current logic.

(I only changed the positions of `onEndWindowDragOnDeco` and `onBeginWindowDragOnDeco` in the file, git diff shows more dramatic changes)