### PR TITLE
Make sure we're in git repo before getting new hash

### DIFF
--- a/hyprpm/src/core/PluginManager.cpp
+++ b/hyprpm/src/core/PluginManager.cpp
@@ -550,7 +550,7 @@ bool CPluginManager::updatePlugins(bool forceUpdateAll) {
         newrepo.plugins.clear();
         execAndGet(
             "cd /tmp/hyprpm/update/ && git pull --recurse-submodules && git reset --hard --recurse-submodules"); // repo hash in the state.toml has to match head and not any pin
-        std::string repohash = execAndGet("git rev-parse HEAD");
+        std::string repohash = execAndGet("cd /tmp/hyprpm/update && git rev-parse HEAD");
         if (repohash.length() > 0)
             repohash.pop_back();
         newrepo.hash = repohash;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
A bunch of my state.toml files had git errors about 'not a repo' in the hash field. This PR just makes sure to cd into the directory first. Seems to fix them all.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.


#### Is it ready for merging, or does it need work?
Sorry for my shit code


