### PR TITLE
fix keys getting stuck + minor refactor & optimizations to keybind handling

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -933,7 +933,7 @@ void CConfigManager::handleBind(const std::string& command, const std::string& v
             g_pKeybindManager->addKeybind(
                 SKeybind{"", std::stoi(KEY.substr(5)), MOD, HANDLER, COMMAND, locked, m_szCurrentSubmap, release, repeat, mouse, nonConsuming, transparent, ignoreMods});
         else
-            g_pKeybindManager->addKeybind(SKeybind{KEY, -1, MOD, HANDLER, COMMAND, locked, m_szCurrentSubmap, release, repeat, mouse, nonConsuming, transparent, ignoreMods});
+            g_pKeybindManager->addKeybind(SKeybind{KEY, 0, MOD, HANDLER, COMMAND, locked, m_szCurrentSubmap, release, repeat, mouse, nonConsuming, transparent, ignoreMods});
     }
 }
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -301,14 +301,14 @@ bool CKeybindManager::onKeyEvent(wlr_keyboard_key_event* e, SKeyboard* pKeyboard
             m_pActiveKeybind            = nullptr;
         }
 
-        const auto key = SPressedKeyWithMods{
+        const auto KEY = SPressedKeyWithMods{
             .keysym             = keysym,
             .keycode            = KEYCODE,
             .modmaskAtPressTime = MODS,
         };
-        m_dPressedKeys.push_back(key);
+        m_dPressedKeys.push_back(KEY);
 
-        found = handleKeybinds(MODS, "", key, true, e->time_msec);
+        found = handleKeybinds(MODS, "", KEY, true, e->time_msec);
 
         if (found)
             shadowKeybinds(keysym, KEYCODE);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -310,7 +310,7 @@ bool CKeybindManager::onKeyEvent(wlr_keyboard_key_event* e, SKeyboard* pKeyboard
 
         m_dPressedKeys.push_back(KEY);
 
-        found = handleKeybinds(MODS, KEY, true, e->time_msec);
+        found = handleKeybinds(MODS, KEY, true);
 
         if (found)
             shadowKeybinds(keysym, KEYCODE);
@@ -326,7 +326,7 @@ bool CKeybindManager::onKeyEvent(wlr_keyboard_key_event* e, SKeyboard* pKeyboard
         for (auto it = m_dPressedKeys.begin(); it != m_dPressedKeys.end();) {
             if (it->keycode == KEYCODE) {
                 if (!foundInPressedKeys) {
-                    found              = handleKeybinds(MODS, *it, false, e->time_msec);
+                    found              = handleKeybinds(MODS, *it, false);
                     foundInPressedKeys = true;
                 }
                 it = m_dPressedKeys.erase(it);
@@ -337,7 +337,7 @@ bool CKeybindManager::onKeyEvent(wlr_keyboard_key_event* e, SKeyboard* pKeyboard
         if (!foundInPressedKeys) {
             Debug::log(ERR, "BUG THIS: key not found in m_dPressedKeys");
             // fallback with wrong `KEY.modmaskAtPressTime`, this can be buggy
-            found = handleKeybinds(MODS, KEY, false, e->time_msec);
+            found = handleKeybinds(MODS, KEY, false);
         }
 
         shadowKeybinds();
@@ -361,14 +361,14 @@ bool CKeybindManager::onAxisEvent(wlr_pointer_axis_event* e) {
     bool found = false;
     if (e->source == WLR_AXIS_SOURCE_WHEEL && e->orientation == WLR_AXIS_ORIENTATION_VERTICAL) {
         if (e->delta < 0)
-            found = handleKeybinds(MODS, SPressedKeyWithMods{.keyName = "mouse_down"}, true, 0);
+            found = handleKeybinds(MODS, SPressedKeyWithMods{.keyName = "mouse_down"}, true);
         else
-            found = handleKeybinds(MODS, SPressedKeyWithMods{.keyName = "mouse_up"}, true, 0);
+            found = handleKeybinds(MODS, SPressedKeyWithMods{.keyName = "mouse_up"}, true);
     } else if (e->source == WLR_AXIS_SOURCE_WHEEL && e->orientation == WLR_AXIS_ORIENTATION_HORIZONTAL) {
         if (e->delta < 0)
-            found = handleKeybinds(MODS, SPressedKeyWithMods{.keyName = "mouse_left"}, true, 0);
+            found = handleKeybinds(MODS, SPressedKeyWithMods{.keyName = "mouse_left"}, true);
         else
-            found = handleKeybinds(MODS, SPressedKeyWithMods{.keyName = "mouse_right"}, true, 0);
+            found = handleKeybinds(MODS, SPressedKeyWithMods{.keyName = "mouse_right"}, true);
     }
 
     if (found)
@@ -398,7 +398,7 @@ bool CKeybindManager::onMouseEvent(wlr_pointer_button_event* e) {
     if (e->state == WLR_BUTTON_PRESSED) {
         m_dPressedKeys.push_back(KEY);
 
-        found = handleKeybinds(MODS, KEY, true, 0);
+        found = handleKeybinds(MODS, KEY, true);
 
         if (found)
             shadowKeybinds();
@@ -407,7 +407,7 @@ bool CKeybindManager::onMouseEvent(wlr_pointer_button_event* e) {
         for (auto it = m_dPressedKeys.begin(); it != m_dPressedKeys.end();) {
             if (it->keyName == KEY_NAME) {
                 if (!foundInPressedKeys) {
-                    found              = handleKeybinds(MODS, *it, false, e->time_msec);
+                    found              = handleKeybinds(MODS, *it, false);
                     foundInPressedKeys = true;
                 }
                 it = m_dPressedKeys.erase(it);
@@ -418,7 +418,7 @@ bool CKeybindManager::onMouseEvent(wlr_pointer_button_event* e) {
         if (!foundInPressedKeys) {
             Debug::log(ERR, "BUG THIS: key not found in m_dPressedKeys (2)");
             // fallback with wrong `KEY.modmaskAtPressTime`, this can be buggy
-            found = handleKeybinds(MODS, KEY, false, e->time_msec);
+            found = handleKeybinds(MODS, KEY, false);
         }
 
         shadowKeybinds();
@@ -436,15 +436,15 @@ void CKeybindManager::resizeWithBorder(wlr_pointer_button_event* e) {
 }
 
 void CKeybindManager::onSwitchEvent(const std::string& switchName) {
-    handleKeybinds(0, SPressedKeyWithMods{.keyName = "switch:" + switchName}, true, 0);
+    handleKeybinds(0, SPressedKeyWithMods{.keyName = "switch:" + switchName}, true);
 }
 
 void CKeybindManager::onSwitchOnEvent(const std::string& switchName) {
-    handleKeybinds(0, SPressedKeyWithMods{.keyName = "switch:on:" + switchName}, true, 0);
+    handleKeybinds(0, SPressedKeyWithMods{.keyName = "switch:on:" + switchName}, true);
 }
 
 void CKeybindManager::onSwitchOffEvent(const std::string& switchName) {
-    handleKeybinds(0, SPressedKeyWithMods{.keyName = "switch:off:" + switchName}, true, 0);
+    handleKeybinds(0, SPressedKeyWithMods{.keyName = "switch:off:" + switchName}, true);
 }
 
 int repeatKeyHandler(void* data) {
@@ -463,7 +463,7 @@ int repeatKeyHandler(void* data) {
     return 0;
 }
 
-bool CKeybindManager::handleKeybinds(const uint32_t modmask, const SPressedKeyWithMods& key, bool pressed, uint32_t time) {
+bool CKeybindManager::handleKeybinds(const uint32_t modmask, const SPressedKeyWithMods& key, bool pressed) {
     bool found = false;
 
     if (g_pCompositor->m_sSeat.exclusiveClient)

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -96,7 +96,7 @@ void CKeybindManager::addKeybind(SKeybind kb) {
 void CKeybindManager::removeKeybind(uint32_t mod, const std::string& key) {
     for (auto it = m_lKeybinds.begin(); it != m_lKeybinds.end(); ++it) {
         if (isNumber(key) && std::stoi(key) > 9) {
-            const auto KEYNUM = std::stoi(key);
+            const uint32_t KEYNUM = std::stoi(key);
 
             if (it->modmask == mod && it->keycode == KEYNUM) {
                 it = m_lKeybinds.erase(it);
@@ -483,7 +483,7 @@ bool CKeybindManager::handleKeybinds(const uint32_t modmask, const SPressedKeyWi
         if (!key.keyName.empty()) {
             if (key.keyName != k.key)
                 continue;
-        } else if (k.keycode != -1) {
+        } else if (k.keycode != 0) {
             if (key.keycode != k.keycode)
                 continue;
         } else {
@@ -562,7 +562,7 @@ bool CKeybindManager::handleKeybinds(const uint32_t modmask, const SPressedKeyWi
     return found;
 }
 
-void CKeybindManager::shadowKeybinds(const xkb_keysym_t& doesntHave, const int& doesntHaveCode) {
+void CKeybindManager::shadowKeybinds(const xkb_keysym_t& doesntHave, const uint32_t doesntHaveCode) {
     // shadow disables keybinds after one has been triggered
 
     for (auto& k : m_lKeybinds) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -597,7 +597,7 @@ void CKeybindManager::shadowKeybinds(const xkb_keysym_t& doesntHave, const uint3
         const auto KBKEYUPPER = xkb_keysym_to_upper(KBKEY);
 
         for (auto& pk : m_dPressedKeys) {
-            if ((pk.keysym == KBKEY || pk.keysym == KBKEYUPPER)) {
+            if ((pk.keysym != 0 && (pk.keysym == KBKEY || pk.keysym == KBKEYUPPER))) {
                 shadow = true;
 
                 if (pk.keysym == doesntHave && doesntHave != 0) {
@@ -606,7 +606,7 @@ void CKeybindManager::shadowKeybinds(const xkb_keysym_t& doesntHave, const uint3
                 }
             }
 
-            if (pk.keycode == k.keycode) {
+            if (pk.keycode != 0 && pk.keycode == k.keycode) {
                 shadow = true;
 
                 if (pk.keycode == doesntHaveCode && doesntHaveCode != 0) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -321,8 +321,17 @@ bool CKeybindManager::onKeyEvent(wlr_keyboard_key_event* e, SKeyboard* pKeyboard
         }
 
         auto it = std::find_if(m_dPressedKeys.begin(), m_dPressedKeys.end(), [&](const SPressedKeyWithMods& other) { return other.keycode == KEYCODE; });
-        // If not found, crash on purpose, because it's wrong and should be fixed.
-        found = handleKeybinds(MODS, "", *it, false, e->time_msec);
+        if (it != m_dPressedKeys.end()) {
+            found = handleKeybinds(MODS, "", *it, false, e->time_msec);
+        } else {
+            Debug::log(ERR, "Expected to find key in m_dPressedKeys, but not found; falling back to a buggy behavior.");
+            const auto FALLBACK_KEY = SPressedKeyWithMods{
+                .keysym             = keysym,
+                .keycode            = KEYCODE,
+                .modmaskAtPressTime = MODS,
+            };
+            found = handleKeybinds(MODS, "", FALLBACK_KEY, false, e->time_msec);
+        }
 
         m_dPressedKeys.erase(std::remove_if(m_dPressedKeys.begin(), m_dPressedKeys.end(), [&](const SPressedKeyWithMods& other) { return other.keycode == KEYCODE; }),
                              m_dPressedKeys.end());

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -588,7 +588,7 @@ void CKeybindManager::shadowKeybinds(const xkb_keysym_t& doesntHave, const uint3
             if (pk.keycode == k.keycode) {
                 shadow = true;
 
-                if (pk.keycode == doesntHaveCode && doesntHaveCode != 0 && doesntHaveCode != -1) {
+                if (pk.keycode == doesntHaveCode && doesntHaveCode != 0) {
                     shadow = false;
                     break;
                 }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -140,6 +140,8 @@ uint32_t CKeybindManager::stringToModMask(std::string mods) {
 
 uint32_t CKeybindManager::keycodeToModifier(xkb_keycode_t keycode) {
     switch (keycode - 8) {
+        case KEY_LEFTMETA: return WLR_MODIFIER_LOGO;
+        case KEY_RIGHTMETA: return WLR_MODIFIER_LOGO;
         case KEY_LEFTSHIFT: return WLR_MODIFIER_SHIFT;
         case KEY_RIGHTSHIFT: return WLR_MODIFIER_SHIFT;
         case KEY_LEFTCTRL: return WLR_MODIFIER_CTRL;

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -314,7 +314,7 @@ bool CKeybindManager::onKeyEvent(wlr_keyboard_key_event* e, SKeyboard* pKeyboard
 
         if (found)
             shadowKeybinds(keysym, KEYCODE);
-    } else if (e->state == WL_KEYBOARD_KEY_STATE_RELEASED) {
+    } else { // key release
         // clean repeat
         if (m_pActiveKeybindEventSource) {
             wl_event_source_remove(m_pActiveKeybindEventSource);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -7,6 +7,7 @@
 
 #include <sys/ioctl.h>
 #include <fcntl.h>
+#include <vector>
 #if defined(__linux__)
 #include <linux/vt.h>
 #elif defined(__NetBSD__) || defined(__OpenBSD__)
@@ -333,8 +334,7 @@ bool CKeybindManager::onKeyEvent(wlr_keyboard_key_event* e, SKeyboard* pKeyboard
             found = handleKeybinds(MODS, "", FALLBACK_KEY, false, e->time_msec);
         }
 
-        m_dPressedKeys.erase(std::remove_if(m_dPressedKeys.begin(), m_dPressedKeys.end(), [&](const SPressedKeyWithMods& other) { return other.keycode == KEYCODE; }),
-                             m_dPressedKeys.end());
+        std::erase_if(m_dPressedKeys, [&](const SPressedKeyWithMods& other) { return other.keycode == KEYCODE; });
 
         shadowKeybinds();
     }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -334,7 +334,7 @@ bool CKeybindManager::onKeyEvent(wlr_keyboard_key_event* e, SKeyboard* pKeyboard
             }
         }
         if (!foundInPressedKeys) {
-            Debug::log(ERR, "Expected to find key in m_dPressedKeys, but not found; falling back to a buggy behavior.");
+            Debug::log(ERR, "BUG THIS: key not found in m_dPressedKeys");
             const auto FALLBACK_KEY = SPressedKeyWithMods{
                 .keysym             = keysym,
                 .keycode            = KEYCODE,

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -441,7 +441,7 @@ int repeatKeyHandler(void* data) {
     return 0;
 }
 
-bool CKeybindManager::handleKeybinds(const uint32_t modmask, const std::string& key, const SPressedKeyWithMods keyNumeric, bool pressed, uint32_t time) {
+bool CKeybindManager::handleKeybinds(const uint32_t modmask, const std::string& key, const SPressedKeyWithMods& keyNumeric, bool pressed, uint32_t time) {
     bool found = false;
 
     if (g_pCompositor->m_sSeat.exclusiveClient)

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -58,6 +58,7 @@ class CKeybindManager {
     void                                                              addKeybind(SKeybind);
     void                                                              removeKeybind(uint32_t, const std::string&);
     uint32_t                                                          stringToModMask(std::string);
+    uint32_t                                                          keycodeToModifier(xkb_keycode_t);
     void                                                              clearKeybinds();
     void                                                              shadowKeybinds(const xkb_keysym_t& doesntHave = 0, const uint32_t doesntHaveCode = 0);
 

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -36,6 +36,12 @@ enum eFocusWindowMode {
     MODE_PID
 };
 
+struct SPressedKeyWithMods {
+    xkb_keysym_t keysym             = 0;
+    int          keycode            = 0;
+    uint32_t     modmaskAtPressTime = 0;
+};
+
 class CKeybindManager {
   public:
     CKeybindManager();
@@ -63,38 +69,37 @@ class CKeybindManager {
     std::list<SKeybind>                                               m_lKeybinds;
 
   private:
-    std::deque<xkb_keysym_t>  m_dPressedKeysyms;
-    std::deque<int>           m_dPressedKeycodes;
+    std::deque<SPressedKeyWithMods> m_dPressedKeys;
 
-    inline static std::string m_szCurrentSelectedSubmap = "";
+    inline static std::string       m_szCurrentSelectedSubmap = "";
 
-    SKeybind*                 m_pActiveKeybind = nullptr;
+    SKeybind*                       m_pActiveKeybind = nullptr;
 
-    uint32_t                  m_uTimeLastMs    = 0;
-    uint32_t                  m_uLastCode      = 0;
-    uint32_t                  m_uLastMouseCode = 0;
+    uint32_t                        m_uTimeLastMs    = 0;
+    uint32_t                        m_uLastCode      = 0;
+    uint32_t                        m_uLastMouseCode = 0;
 
-    bool                      m_bIsMouseBindActive = false;
-    std::vector<SKeybind*>    m_vPressedSpecialBinds;
+    bool                            m_bIsMouseBindActive = false;
+    std::vector<SKeybind*>          m_vPressedSpecialBinds;
 
-    int                       m_iPassPressed = -1; // used for pass
+    int                             m_iPassPressed = -1; // used for pass
 
-    CTimer                    m_tScrollTimer;
+    CTimer                          m_tScrollTimer;
 
-    bool                      handleKeybinds(const uint32_t&, const std::string&, const xkb_keysym_t&, const int&, bool, uint32_t);
+    bool                            handleKeybinds(const uint32_t, const std::string&, const SPressedKeyWithMods, bool, uint32_t);
 
-    bool                      handleInternalKeybinds(xkb_keysym_t);
-    bool                      handleVT(xkb_keysym_t);
+    bool                            handleInternalKeybinds(xkb_keysym_t);
+    bool                            handleVT(xkb_keysym_t);
 
-    xkb_state*                m_pXKBTranslationState = nullptr;
+    xkb_state*                      m_pXKBTranslationState = nullptr;
 
-    void                      updateXKBTranslationState();
-    bool                      ensureMouseBindState();
+    void                            updateXKBTranslationState();
+    bool                            ensureMouseBindState();
 
-    static bool               tryMoveFocusToMonitor(CMonitor* monitor);
-    static void               moveWindowOutOfGroup(CWindow* pWindow, const std::string& dir = "");
-    static void               moveWindowIntoGroup(CWindow* pWindow, CWindow* pWindowInDirection);
-    static void               switchToWindow(CWindow* PWINDOWTOCHANGETO);
+    static bool                     tryMoveFocusToMonitor(CMonitor* monitor);
+    static void                     moveWindowOutOfGroup(CWindow* pWindow, const std::string& dir = "");
+    static void                     moveWindowIntoGroup(CWindow* pWindow, CWindow* pWindowInDirection);
+    static void                     switchToWindow(CWindow* PWINDOWTOCHANGETO);
 
     // -------------- Dispatchers -------------- //
     static void     killActive(std::string);

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -12,7 +12,7 @@ class CPluginSystem;
 
 struct SKeybind {
     std::string key          = "";
-    int         keycode      = -1;
+    uint32_t    keycode      = 0;
     uint32_t    modmask      = 0;
     std::string handler      = "";
     std::string arg          = "";
@@ -39,7 +39,7 @@ enum eFocusWindowMode {
 struct SPressedKeyWithMods {
     std::string  keyName            = "";
     xkb_keysym_t keysym             = 0;
-    int          keycode            = 0;
+    uint32_t     keycode            = 0;
     uint32_t     modmaskAtPressTime = 0;
 };
 
@@ -59,7 +59,7 @@ class CKeybindManager {
     void                                                              removeKeybind(uint32_t, const std::string&);
     uint32_t                                                          stringToModMask(std::string);
     void                                                              clearKeybinds();
-    void                                                              shadowKeybinds(const xkb_keysym_t& doesntHave = 0, const int& doesntHaveCode = 0);
+    void                                                              shadowKeybinds(const xkb_keysym_t& doesntHave = 0, const uint32_t doesntHaveCode = 0);
 
     std::unordered_map<std::string, std::function<void(std::string)>> m_mDispatchers;
 

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -87,7 +87,7 @@ class CKeybindManager {
 
     CTimer                          m_tScrollTimer;
 
-    bool                            handleKeybinds(const uint32_t, const SPressedKeyWithMods&, bool, uint32_t);
+    bool                            handleKeybinds(const uint32_t, const SPressedKeyWithMods&, bool);
 
     bool                            handleInternalKeybinds(xkb_keysym_t);
     bool                            handleVT(xkb_keysym_t);

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -86,7 +86,7 @@ class CKeybindManager {
 
     CTimer                          m_tScrollTimer;
 
-    bool                            handleKeybinds(const uint32_t, const std::string&, const SPressedKeyWithMods, bool, uint32_t);
+    bool                            handleKeybinds(const uint32_t, const std::string&, const SPressedKeyWithMods&, bool, uint32_t);
 
     bool                            handleInternalKeybinds(xkb_keysym_t);
     bool                            handleVT(xkb_keysym_t);

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -37,6 +37,7 @@ enum eFocusWindowMode {
 };
 
 struct SPressedKeyWithMods {
+    std::string  keyName            = "";
     xkb_keysym_t keysym             = 0;
     int          keycode            = 0;
     uint32_t     modmaskAtPressTime = 0;
@@ -86,7 +87,7 @@ class CKeybindManager {
 
     CTimer                          m_tScrollTimer;
 
-    bool                            handleKeybinds(const uint32_t, const std::string&, const SPressedKeyWithMods&, bool, uint32_t);
+    bool                            handleKeybinds(const uint32_t, const SPressedKeyWithMods&, bool, uint32_t);
 
     bool                            handleInternalKeybinds(xkb_keysym_t);
     bool                            handleVT(xkb_keysym_t);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes #4013 

It's fixed by keeping track of mods pressed at the time of key activation and using this info to correctly handle a case, where key was pressed before mod.

Analogous issue with `bindr` was also fixed.

Also:
- Remove unnecessary duplicate `handleKeybinds` calls, which were supposed to be "keycode check runs" but in reality didn't do anything useful.
- "Merge" 3 related params in `handleKeybinds` to a single `SPressedKeyWithMods`

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Nothing in particular.

#### Is it ready for merging, or does it need work?

- ~I'm not sure what to do on line 323.~
- ~Maybe code around 323-327 could be optimized, since the lambdas are the same. But idk C++ good enough to think of any improvement.~