### PR TITLE
Ignore some input events when focus is on a layer surface

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -880,10 +880,12 @@ void CKeybindManager::changeworkspace(std::string args) {
     } else
         pWorkspaceToChangeTo->rememberPrevWorkspace(PCURRENTWORKSPACE);
 
-    if (!g_pCompositor->m_pLastFocus)
-        g_pInputManager->simulateMouseMovement();
-    else
-        g_pInputManager->sendMotionEventsToFocused();
+    if (!g_pInputManager->m_bLastFocusOnLS) {
+        if (g_pCompositor->m_pLastFocus)
+            g_pInputManager->sendMotionEventsToFocused();
+        else
+            g_pInputManager->simulateMouseMovement();
+    }
 }
 
 void CKeybindManager::fullscreenActive(std::string args) {

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -687,11 +687,13 @@ void CInputManager::onMouseWheel(wlr_pointer_axis_event* e) {
     if (!passEvent)
         return;
 
-    const auto MOUSECOORDS = g_pInputManager->getMouseCoordsInternal();
-    const auto PWINDOW     = g_pCompositor->vectorToWindowIdeal(MOUSECOORDS);
+    if (!m_bLastFocusOnLS) {
+        const auto MOUSECOORDS = g_pInputManager->getMouseCoordsInternal();
+        const auto PWINDOW     = g_pCompositor->vectorToWindowIdeal(MOUSECOORDS);
 
-    if (PWINDOW && PWINDOW->checkInputOnDecos(INPUT_TYPE_AXIS, MOUSECOORDS, e))
-        return;
+        if (PWINDOW && PWINDOW->checkInputOnDecos(INPUT_TYPE_AXIS, MOUSECOORDS, e))
+            return;
+    }
 
     wlr_seat_pointer_notify_axis(g_pCompositor->m_sSeat.seat, e->time_msec, e->orientation, factor * e->delta, std::round(factor * e->delta_discrete), e->source);
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
The video tries to demonstrate all the listed issues (using waybar):
- Clicking on workspace buttons sends a motion event to the focused window, and because of that the cursor changes, also the focus is lost from waybar (as you can see the (top-border) hover effect disappears). You have to move the cursor to bring back waybar focus and change back the cursor.
- Similar/same issue when scrolling, but since the window gets the focus, scrolling events are sent to the window, instead of waybar, so the window will scroll not the workspaces.
- (not waybar related) Moving the cursor over non reserved area, and switching workspaces via shortcuts changes the cursor even if there's nothing under it.

Maybe #3737, at least the second comment there mentions my second issue.

Also ignore scroll events when an overlay is over the groupbar (or any window decoration)

https://github.com/hyprwm/Hyprland/assets/150595692/e41fea0d-6391-46d6-b6f6-7d6d23038656

#### Is it ready for merging, or does it need work?
Yes.


