### PR TITLE
HookSystem: rename PAGESIZE_VAR from PAGESIZE to avoid conflict

### DIFF
--- a/src/plugins/HookSystem.cpp
+++ b/src/plugins/HookSystem.cpp
@@ -190,9 +190,9 @@ bool CFunctionHook::hook() {
         (uint64_t)((uint8_t*)m_pSource + sizeof(ABSOLUTE_JMP_ADDRESS));
 
     // make jump to hk
-    const auto     PAGESIZE  = sysconf(_SC_PAGE_SIZE);
-    const uint8_t* PROTSTART = (uint8_t*)m_pSource - ((uint64_t)m_pSource % PAGESIZE);
-    const size_t   PROTLEN   = std::ceil((float)(ORIGSIZE + ((uint64_t)m_pSource - (uint64_t)PROTSTART)) / (float)PAGESIZE) * PAGESIZE;
+    const auto     PAGESIZE_VAR = sysconf(_SC_PAGE_SIZE);
+    const uint8_t* PROTSTART    = (uint8_t*)m_pSource - ((uint64_t)m_pSource % PAGESIZE_VAR);
+    const size_t   PROTLEN      = std::ceil((float)(ORIGSIZE + ((uint64_t)m_pSource - (uint64_t)PROTSTART)) / (float)PAGESIZE_VAR) * PAGESIZE_VAR;
     mprotect((uint8_t*)PROTSTART, PROTLEN, PROT_READ | PROT_WRITE | PROT_EXEC);
     memcpy((uint8_t*)m_pSource, ABSOLUTE_JMP_ADDRESS, sizeof(ABSOLUTE_JMP_ADDRESS));
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This fixes a build issue with v0.34.0 (on [alpine linux](https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/58213#note_366729), and maybe others?)

```
In file included from /usr/include/limits.h:40,
                 from /usr/include/fortify/wchar.h:23,
                 from /usr/include/c++/13.2.1/cwchar:44,
                 from /usr/include/c++/13.2.1/bits/postypes.h:40,
                 from /usr/include/c++/13.2.1/iosfwd:42,
                 from /usr/include/c++/13.2.1/ios:40,
                 from /usr/include/c++/13.2.1/ostream:40,
                 from /usr/include/c++/13.2.1/bits/unique_ptr.h:42,
                 from /usr/include/c++/13.2.1/memory:78,
                 from ../src/Compositor.hpp:3,
                 from ../src/pch/pch.hpp:1:
../src/plugins/HookSystem.cpp: In member function 'bool CFunctionHook::hook()':
../src/plugins/HookSystem.cpp:193:20: error: expected unqualified-id before numeric constant
  193 |     const auto     PAGESIZE  = sysconf(_SC_PAGE_SIZE);
      |                    ^~~~~~~~
ninja: subcommand failed
>>> ERROR: hyprland: build failed
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?

Yes, it is ready for merging
