### PR TITLE
Only force nearest neighbor when the sizes are off by one or two

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -118,6 +118,7 @@ static void renderSurface(struct wlr_surface* surface, int x, int y, void* data)
     const auto NEARESTNEIGHBORSET = g_pHyprOpenGL->m_RenderData.useNearestNeighbor;
     if (std::floor(RDATA->pMonitor->scale) != RDATA->pMonitor->scale /* Fractional */ && surface->current.scale == 1 /* fs protocol */ &&
         windowBox.size() != Vector2D{surface->current.buffer_width, surface->current.buffer_height} /* misaligned */ &&
+        DELTALESSTHAN(windowBox.width, surface->current.buffer_width, 3) && DELTALESSTHAN(windowBox.height, surface->current.buffer_height, 3) /* off by one-or-two */ &&
         (!RDATA->pWindow || (!RDATA->pWindow->m_vRealSize.isBeingAnimated() && !INTERACTIVERESIZEINPROGRESS)) /* not window or not animated/resizing */)
         g_pHyprOpenGL->m_RenderData.useNearestNeighbor = true;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes https://github.com/hyprwm/Hyprland/issues/4225#issuecomment-1873003483

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
In my testing, a maximum offset of 2 is enough to force both electron apps and `foot` into nearest neighbor, while keeping tdesktop in bilinear.

#### Is it ready for merging, or does it need work?
Ready.
