### PR TITLE
Drag single window instead of destroying group

### DIFF
--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -317,6 +317,9 @@ void refreshGroupBarGradients() {
 }
 
 bool CHyprGroupBarDecoration::onBeginWindowDragOnDeco(const Vector2D& pos) {
+    if (m_pWindow == m_pWindow->m_sGroupData.pNextWindow)
+        return false;
+
     const float BARRELATIVEX = pos.x - assignedBoxGlobal().x;
     const int   WINDOWINDEX  = (BARRELATIVEX) / (m_fBarWidth + BAR_HORIZONTAL_PADDING);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Prevents destroying a group with only one window when that's dragged from the groupbar. It will just normally drag/move the window instead. `togglegroup` still can be used if someone wants to deactivate the group.

#### Is it ready for merging, or does it need work?
Yes.