### PR TITLE
Add border gradients to windowrulev2

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1879,15 +1879,13 @@ void CCompositor::updateWindowAnimatedDecorationValues(CWindow* pWindow) {
         if (pWindow == m_pLastWindow) {
             const auto* const ACTIVECOLOR =
                 !pWindow->m_sGroupData.pNextWindow ? (!pWindow->m_sGroupData.deny ? ACTIVECOL : NOGROUPACTIVECOL) : (GROUPLOCKED ? GROUPACTIVELOCKEDCOL : GROUPACTIVECOL);
-            setBorderColor(pWindow->m_sSpecialRenderData.activeBorderColor.toUnderlying() >= 0 ?
-                               CGradientValueData(CColor(pWindow->m_sSpecialRenderData.activeBorderColor.toUnderlying())) :
-                               *ACTIVECOLOR);
+            setBorderColor(pWindow->m_sSpecialRenderData.activeBorderColor.toUnderlying().m_vColors.empty() ? *ACTIVECOLOR :
+                                                                                                              pWindow->m_sSpecialRenderData.activeBorderColor.toUnderlying());
         } else {
             const auto* const INACTIVECOLOR =
                 !pWindow->m_sGroupData.pNextWindow ? (!pWindow->m_sGroupData.deny ? INACTIVECOL : NOGROUPINACTIVECOL) : (GROUPLOCKED ? GROUPINACTIVELOCKEDCOL : GROUPINACTIVECOL);
-            setBorderColor(pWindow->m_sSpecialRenderData.inactiveBorderColor.toUnderlying() >= 0 ?
-                               CGradientValueData(CColor(pWindow->m_sSpecialRenderData.inactiveBorderColor.toUnderlying())) :
-                               *INACTIVECOLOR);
+            setBorderColor(pWindow->m_sSpecialRenderData.inactiveBorderColor.toUnderlying().m_vColors.empty() ? *INACTIVECOLOR :
+                                                                                                                pWindow->m_sSpecialRenderData.inactiveBorderColor.toUnderlying());
         }
     }
 

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -3,6 +3,8 @@
 #include "render/decorations/CHyprDropShadowDecoration.hpp"
 #include "render/decorations/CHyprGroupBarDecoration.hpp"
 #include "render/decorations/CHyprBorderDecoration.hpp"
+#include <vector>
+#include <cmath>
 
 CWindow::CWindow() {
     m_vRealPosition.create(AVARTYPE_VECTOR, g_pConfigManager->getAnimationPropertyConfig("windowsIn"), (void*)this, AVARDAMAGE_ENTIRE);
@@ -607,14 +609,55 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
         m_sAdditionalConfigData.animationStyle = STYLE;
     } else if (r.szRule.starts_with("bordercolor")) {
         try {
-            std::string colorPart = removeBeginEndSpacesTabs(r.szRule.substr(r.szRule.find_first_of(' ') + 1));
+            std::string colorPart   = removeBeginEndSpacesTabs(r.szRule.substr(r.szRule.find_first_of(' ') + 1));
+            std::string colorString = "";
+            bool        active      = true;
+            // Each vector will only get used if it has at least one color
+            CGradientValueData activeBorderGradient   = {};
+            CGradientValueData inactiveBorderGradient = {};
+            for (auto& c : colorPart) {
+                if (c == ' ' && active && colorString.contains("deg")) {
+                    activeBorderGradient.m_fAngle = std::stoi(colorString.substr(0, colorString.size() - 3)) * (PI / 180.0);
+                    active                        = false;
+                    colorString                   = "";
+                } else if (c == ' ' && colorString.contains("deg")) {
+                    inactiveBorderGradient.m_fAngle = std::stoi(colorString.substr(0, colorString.size() - 3)) * (PI / 180.0);
+                    colorString                     = "";
+                } else if (c == ' ' && active) {
+                    activeBorderGradient.m_vColors.push_back(configStringToInt(colorString));
+                    colorString = "";
+                } else if (c == ' ') {
+                    inactiveBorderGradient.m_vColors.push_back(configStringToInt(colorString));
+                    colorString = "";
+                } else {
+                    colorString += c;
+                }
+            }
 
-            if (colorPart.contains(' ')) {
-                // we have a space, 2 values
-                m_sSpecialRenderData.activeBorderColor   = configStringToInt(colorPart.substr(0, colorPart.find_first_of(' ')));
-                m_sSpecialRenderData.inactiveBorderColor = configStringToInt(colorPart.substr(colorPart.find_first_of(' ') + 1));
+            // Supports older form expecting colors instead of gradients
+            // The angle, or an explicit "0deg", splits active and inactive gradients if gradients are used
+            if (active && colorString.contains("deg")) {
+                activeBorderGradient.m_fAngle = std::stoi(colorString.substr(0, colorString.size() - 3)) * (PI / 180.0);
+            } else if (colorString.contains("deg")) {
+                inactiveBorderGradient.m_fAngle = std::stoi(colorString.substr(0, colorString.size() - 3)) * (PI / 180.0);
+            } else if (!colorPart.empty() && (activeBorderGradient.m_vColors.size() == 1 || !active)) {
+                inactiveBorderGradient.m_vColors.push_back(configStringToInt(colorString));
+            } else if (!colorPart.empty()) {
+                activeBorderGradient.m_vColors.push_back(configStringToInt(colorString));
+            }
+
+            // Includes sanity checks for the number of colors in each gradient
+            if (activeBorderGradient.m_vColors.size() > 10 || inactiveBorderGradient.m_vColors.size() > 10) {
+                Debug::log(WARN, "Bordercolor rule \"{}\" has more than 10 colors in one gradient, ignoring", r.szRule);
+            } else if (activeBorderGradient.m_vColors.empty()) {
+                Debug::log(WARN, "Bordercolor rule \"{}\" has no colors, ignoring", r.szRule);
+            } else if (inactiveBorderGradient.m_vColors.empty()) {
+                m_sSpecialRenderData.activeBorderColor = activeBorderGradient;
+            } else if (!inactiveBorderGradient.m_vColors.empty()) {
+                m_sSpecialRenderData.activeBorderColor   = activeBorderGradient;
+                m_sSpecialRenderData.inactiveBorderColor = inactiveBorderGradient;
             } else {
-                m_sSpecialRenderData.activeBorderColor = configStringToInt(colorPart);
+                Debug::log(WARN, "Bordercolor rule \"{}\" stumbled across a bug, please report it", r.szRule);
             }
         } catch (std::exception& e) { Debug::log(ERR, "BorderColor rule \"{}\" failed with: {}", r.szRule, e.what()); }
     } else if (r.szRule == "dimaround") {
@@ -644,8 +687,8 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
 }
 
 void CWindow::updateDynamicRules() {
-    m_sSpecialRenderData.activeBorderColor   = -1;
-    m_sSpecialRenderData.inactiveBorderColor = -1;
+    m_sSpecialRenderData.activeBorderColor   = CGradientValueData();
+    m_sSpecialRenderData.inactiveBorderColor = CGradientValueData();
     m_sSpecialRenderData.alpha               = 1.f;
     m_sSpecialRenderData.alphaInactive       = -1.f;
     m_sAdditionalConfigData.forceNoBlur      = false;

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -625,23 +625,22 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
                 if (active && token.contains("deg")) {
                     activeBorderGradient.m_fAngle = std::stoi(token.substr(0, token.size() - 3)) * (PI / 180.0);
                     active                        = false;
-                } else if (token.contains("deg")) {
+                } else if (token.contains("deg"))
                     inactiveBorderGradient.m_fAngle = std::stoi(token.substr(0, token.size() - 3)) * (PI / 180.0);
-                } else if (active) {
+                else if (active)
                     activeBorderGradient.m_vColors.push_back(configStringToInt(token));
-                } else {
+                else
                     inactiveBorderGradient.m_vColors.push_back(configStringToInt(token));
-                }
             }
 
             // Includes sanity checks for the number of colors in each gradient
-            if (activeBorderGradient.m_vColors.size() > 10 || inactiveBorderGradient.m_vColors.size() > 10) {
+            if (activeBorderGradient.m_vColors.size() > 10 || inactiveBorderGradient.m_vColors.size() > 10)
                 Debug::log(WARN, "Bordercolor rule \"{}\" has more than 10 colors in one gradient, ignoring", r.szRule);
-            } else if (activeBorderGradient.m_vColors.empty()) {
+            else if (activeBorderGradient.m_vColors.empty())
                 Debug::log(WARN, "Bordercolor rule \"{}\" has no colors, ignoring", r.szRule);
-            } else if (inactiveBorderGradient.m_vColors.empty()) {
+            else if (inactiveBorderGradient.m_vColors.empty())
                 m_sSpecialRenderData.activeBorderColor = activeBorderGradient;
-            } else {
+            else {
                 m_sSpecialRenderData.activeBorderColor   = activeBorderGradient;
                 m_sSpecialRenderData.inactiveBorderColor = inactiveBorderGradient;
             }

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -106,13 +106,13 @@ class CWindowOverridableVar {
 };
 
 struct SWindowSpecialRenderData {
-    CWindowOverridableVar<bool>    alphaOverride         = false;
-    CWindowOverridableVar<float>   alpha                 = 1.f;
-    CWindowOverridableVar<bool>    alphaInactiveOverride = false;
-    CWindowOverridableVar<float>   alphaInactive         = -1.f; // -1 means unset
+    CWindowOverridableVar<bool>               alphaOverride         = false;
+    CWindowOverridableVar<float>              alpha                 = 1.f;
+    CWindowOverridableVar<bool>               alphaInactiveOverride = false;
+    CWindowOverridableVar<float>              alphaInactive         = -1.f; // -1 means unset
 
-    CWindowOverridableVar<int64_t> activeBorderColor   = -1; // -1 means unset
-    CWindowOverridableVar<int64_t> inactiveBorderColor = -1; // -1 means unset
+    CWindowOverridableVar<CGradientValueData> activeBorderColor   = CGradientValueData(); // empty color vector means unset
+    CWindowOverridableVar<CGradientValueData> inactiveBorderColor = CGradientValueData(); // empty color vector means unset
 
     // set by the layout
     CWindowOverridableVar<int> borderSize = -1; // -1 means unset

--- a/src/config/ConfigDataValues.hpp
+++ b/src/config/ConfigDataValues.hpp
@@ -16,6 +16,7 @@ class ICustomConfigValueData {
 
 class CGradientValueData : public ICustomConfigValueData {
   public:
+    CGradientValueData(){};
     CGradientValueData(CColor col) {
         m_vColors.push_back(col);
     };

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1138,9 +1138,9 @@ std::string dispatchSetProp(std::string request) {
         } else if (PROP == "alphainactive") {
             PWINDOW->m_sSpecialRenderData.alphaInactive.forceSetIgnoreLocked(std::stof(VAL), lock);
         } else if (PROP == "activebordercolor") {
-            PWINDOW->m_sSpecialRenderData.activeBorderColor.forceSetIgnoreLocked(configStringToInt(VAL), lock);
+            PWINDOW->m_sSpecialRenderData.activeBorderColor.forceSetIgnoreLocked(CGradientValueData(CColor(configStringToInt(VAL))), lock);
         } else if (PROP == "inactivebordercolor") {
-            PWINDOW->m_sSpecialRenderData.inactiveBorderColor.forceSetIgnoreLocked(configStringToInt(VAL), lock);
+            PWINDOW->m_sSpecialRenderData.inactiveBorderColor.forceSetIgnoreLocked(CGradientValueData(CColor(configStringToInt(VAL))), lock);
         } else if (PROP == "forcergbx") {
             PWINDOW->m_sAdditionalConfigData.forceRGBX.forceSetIgnoreLocked(configStringToInt(VAL), lock);
         } else if (PROP == "bordersize") {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adding the ability for window rules to set a gradient for the border color.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Tested with debug build. Preserves backwards compatibility. Documented at https://github.com/hyprwm/hyprland-wiki/pull/429.

I added a constructor with zero parameters for the CGradientValueData class, which has an empty vector of colors. This was the cleanest way to have one of those objects designating "unset" and had benefits elsewhere. I made the [necessary changes](https://github.com/hyprwm/Hyprland/pull/4335/commits/69c7cdbc819c593e46e4325db2286022c1672d72#diff-3c089c6c6b23a85ab5b4cffb002e8880ad069c8a8b3462f7aafa9e5345c0333d) to ensure no empty gradients would make their way to the compositor

#### Is it ready for merging, or does it need work?
Ready for merging.

