### PR TITLE
Makefile: force ln command to overwrite symlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ install:
 	chmod 755 ${PREFIX}/bin/Hyprland
 	chmod 755 ${PREFIX}/bin/hyprctl
 	chmod 755 ${PREFIX}/bin/hyprpm
-	ln -s -r ${PREFIX}/bin/Hyprland ${PREFIX}/bin/hyprland
+	ln -s -r -f ${PREFIX}/bin/Hyprland ${PREFIX}/bin/hyprland
 	if [ ! -f ${PREFIX}/share/wayland-sessions/hyprland.desktop ]; then cp ./example/hyprland.desktop ${PREFIX}/share/wayland-sessions; fi
 	mkdir -p ${PREFIX}/share/hyprland
 	cp ./assets/wall_* ${PREFIX}/share/hyprland


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

When running `make install` twice it fails with an error:
```
ln -s -r /usr/local/bin/Hyprland /usr/local/bin/hyprland
ln: failed to create symbolic link '/usr/local/bin/hyprland': File exists
```

This MR fixes it with `-f` flag.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

no

#### Is it ready for merging, or does it need work?

ready
