### PR TITLE
Fix greedy mouse grab from keyboard_interactive layer

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1102,14 +1102,6 @@ wlr_surface* CCompositor::vectorToLayerSurface(const Vector2D& pos, std::vector<
 
         auto SURFACEAT = wlr_layer_surface_v1_surface_at(ls->layerSurface, pos.x - ls->geometry.x, pos.y - ls->geometry.y, &sCoords->x, &sCoords->y);
 
-        if (ls->layerSurface->current.keyboard_interactive && ls->layer >= ZWLR_LAYER_SHELL_V1_LAYER_TOP) {
-            if (!SURFACEAT)
-                SURFACEAT = ls->layerSurface->surface;
-
-            *ppLayerSurfaceFound = ls.get();
-            return SURFACEAT;
-        }
-
         if (SURFACEAT) {
             if (!pixman_region32_not_empty(&SURFACEAT->input_region))
                 continue;

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -359,7 +359,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
 
     bool allowKeyboardRefocus = true;
 
-    if (!refocus && g_pCompositor->m_pLastFocus) {
+    if (g_pCompositor->m_pLastFocus) {
         const auto PLS = g_pCompositor->getLayerSurfaceFromSurface(g_pCompositor->m_pLastFocus);
 
         if (PLS && PLS->layerSurface->current.keyboard_interactive == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE)
@@ -421,7 +421,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
             m_bLastFocusOnLS = false;
             return; // don't enter any new surfaces
         } else {
-            if (((FOLLOWMOUSE != 3 && allowKeyboardRefocus) && (*PMOUSEREFOCUS || m_pLastMouseFocus != pFoundWindow)) || refocus) {
+            if (allowKeyboardRefocus && ((FOLLOWMOUSE != 3 && (*PMOUSEREFOCUS || m_pLastMouseFocus != pFoundWindow)) || refocus)) {
                 m_pLastMouseFocus = pFoundWindow;
                 g_pCompositor->focusWindow(pFoundWindow, foundSurface);
             }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes #2017

This allows you to use your mouse on other (not covered) surfaces even when you have a keyboard_interactive layer active.

The bug was that a keyboard_interactive layer would always take precedence over everything else (even without KEYBOARD_INTERACTIVITY_EXCLUSIVE). The fix makes that layer not take precedence, and instead makes `refocus` respect KEYBOARD_INTERACTIVITY_EXCLUSIVE (i.e. the correct behavior).

So, you can
* use wvkbd to type into bemenu
   * click on an eww element even when rofi is open
* click or scroll another window when (some other keyboard_interactive layer) is open
    * this will not steal the keyboard focus from a KEYBOARD_INTERACTIVITY_EXCLUSIVE layer

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

One case I found where the KEYBOARD_INTERACTIVITY_EXCLUSIVE is not respected:

* keyboard focus will still be stolen (from the layer to a window) when you switch focus using movefocus (e.g. $mainMod, left)

this is an existing bug/feature (it may be intended behavior). Maybe it should be fixed now (so KEYBOARD_INTERACTIVITY_EXCLUSIVE layers keep the keyboard), or maybe fix it some other day?

#### Is it ready for merging, or does it need work?

This is ready. It fixes the unexpected and incorrect behavior that bothers me. (the existing movefocus behavior can be changed some other time, if that's what we want.)