### PR TITLE
Set preferred scale on monitor config reload

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2101,6 +2101,13 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
 
     wlr_damage_ring_set_bounds(&pMonitor->damage, pMonitor->vecTransformedSize.x, pMonitor->vecTransformedSize.y);
 
+    // Set scale for all surfaces on this monitor, needed for some clients
+    // but not on unsafe state to avoid crashes
+    if (!g_pCompositor->m_bUnsafeState) {
+        for (auto& w : g_pCompositor->m_vWindows) {
+            w->updateSurfaceScaleTransformDetails();
+        }
+    }
     // updato us
     arrangeLayersForMonitor(pMonitor->ID);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fix #4363

Send preferred scale to surfaces on monitor config change. This is needed for
some applications to adjust their rendered scale properly, including
KeepassXC, alacritty, and mpv, otherwise the rendered scale is not updated for
the applications, resulting in blurry windows due to nearest neighbor or
linear scaling.  

Fix is confirmed to work as a patch on v0.34.0
