### PR TITLE
Prevent hiding current workspace when swiping

### DIFF
--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -265,7 +265,7 @@ void CInputManager::onSwipeUpdate(wlr_pointer_swipe_update_event* e) {
         PWORKSPACE->m_bForceRendering = true;
         PWORKSPACE->m_fAlpha.setValueAndWarp(1.f);
 
-        if (workspaceIDLeft != workspaceIDRight) {
+        if (workspaceIDLeft != workspaceIDRight && workspaceIDRight != m_sActiveSwipe.pWorkspaceBegin->m_iID) {
             const auto PWORKSPACER = g_pCompositor->getWorkspaceByID(workspaceIDRight);
 
             if (PWORKSPACER) {
@@ -305,7 +305,7 @@ void CInputManager::onSwipeUpdate(wlr_pointer_swipe_update_event* e) {
         PWORKSPACE->m_bForceRendering = true;
         PWORKSPACE->m_fAlpha.setValueAndWarp(1.f);
 
-        if (workspaceIDLeft != workspaceIDRight) {
+        if (workspaceIDLeft != workspaceIDRight && workspaceIDLeft != m_sActiveSwipe.pWorkspaceBegin->m_iID) {
             const auto PWORKSPACEL = g_pCompositor->getWorkspaceByID(workspaceIDLeft);
 
             if (PWORKSPACEL) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
When workspace_swipe_use_r is enabled, swiping from WS 1 to a non-empty WS 2 would hide WS 1 (Similar effect to issue #4076). This is caused by a faulty check which doesn't consider, that workspaceIDLeft could be the current workspace.
This bug is only a problem for r, because m wraps around on WS 1 m-1, whereas r stays on WS 1.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
The first check ```(workspaceIDRight != ...)``` is technically not needed for the bug fix. Though to be extra sure I added it, since there is no reason why you'd want to hide the current workspace when swiping. If you want, I can remove it though.
I also have not checked ```+/-1```, though I see absolutely no reason why this would break something.

#### Is it ready for merging, or does it need work?
Ready.

