### PR TITLE
Options for shadow/rounding when only 1 window

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -214,6 +214,8 @@ void CConfigManager::setDefaultVars() {
     configValues["master:always_center_master"].intValue   = 0;
     configValues["master:new_on_top"].intValue             = 0;
     configValues["master:no_gaps_when_only"].intValue      = 0;
+    configValues["master:no_rounding_when_only"].intValue  = 1;
+    configValues["master:no_shadow_when_only"].intValue    = 1;
     configValues["master:orientation"].strValue            = "left";
     configValues["master:inherit_fullscreen"].intValue     = 1;
     configValues["master:allow_small_split"].intValue      = 0;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -201,6 +201,8 @@ void CConfigManager::setDefaultVars() {
     configValues["dwindle:special_scale_factor"].floatValue       = 1.f;
     configValues["dwindle:split_width_multiplier"].floatValue     = 1.0f;
     configValues["dwindle:no_gaps_when_only"].intValue            = 0;
+    configValues["dwindle:no_rounding_when_only"].intValue        = 1;
+    configValues["dwindle:no_shadow_when_only"].intValue          = 1;
     configValues["dwindle:use_active_for_splits"].intValue        = 1;
     configValues["dwindle:default_split_ratio"].floatValue        = 1.f;
     configValues["dwindle:smart_split"].intValue                  = 0;

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -120,7 +120,7 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
 
     PWINDOW->updateSpecialRenderData();
 
-    static auto* const PGAPSIN         = &g_pConfigManager->getConfigValuePtr("general:gaps_in")->intValue;
+    static auto* const PGAPSIN             = &g_pConfigManager->getConfigValuePtr("general:gaps_in")->intValue;
     static auto* const PGAPSOUT            = &g_pConfigManager->getConfigValuePtr("general:gaps_out")->intValue;
     static auto* const PNOGAPSWHENONLY     = &g_pConfigManager->getConfigValuePtr("dwindle:no_gaps_when_only")->intValue;
     static auto* const PNOROUNDINGWHENONLY = &g_pConfigManager->getConfigValuePtr("dwindle:no_rounding_when_only")->intValue;

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -121,8 +121,10 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
     PWINDOW->updateSpecialRenderData();
 
     static auto* const PGAPSIN         = &g_pConfigManager->getConfigValuePtr("general:gaps_in")->intValue;
-    static auto* const PGAPSOUT        = &g_pConfigManager->getConfigValuePtr("general:gaps_out")->intValue;
-    static auto* const PNOGAPSWHENONLY = &g_pConfigManager->getConfigValuePtr("dwindle:no_gaps_when_only")->intValue;
+    static auto* const PGAPSOUT            = &g_pConfigManager->getConfigValuePtr("general:gaps_out")->intValue;
+    static auto* const PNOGAPSWHENONLY     = &g_pConfigManager->getConfigValuePtr("dwindle:no_gaps_when_only")->intValue;
+    static auto* const PNOROUNDINGWHENONLY = &g_pConfigManager->getConfigValuePtr("dwindle:no_rounding_when_only")->intValue;
+    static auto* const PNOSHADOWWHENONLY   = &g_pConfigManager->getConfigValuePtr("dwindle:no_shadow_when_only")->intValue;
 
     auto               gapsIn  = WORKSPACERULE.gapsIn.value_or(*PGAPSIN);
     auto               gapsOut = WORKSPACERULE.gapsOut.value_or(*PGAPSOUT);
@@ -146,8 +148,8 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
 
         PWINDOW->m_sSpecialRenderData.border   = WORKSPACERULE.border.value_or(*PNOGAPSWHENONLY == 2);
         PWINDOW->m_sSpecialRenderData.decorate = WORKSPACERULE.decorate.value_or(true);
-        PWINDOW->m_sSpecialRenderData.rounding = false;
-        PWINDOW->m_sSpecialRenderData.shadow   = false;
+        PWINDOW->m_sSpecialRenderData.rounding = !*PNOROUNDINGWHENONLY;
+        PWINDOW->m_sSpecialRenderData.shadow   = !*PNOSHADOWWHENONLY;
 
         PWINDOW->updateWindowDecos();
 

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -633,10 +633,12 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
 
     PWINDOW->updateSpecialRenderData();
 
-    static auto* const PGAPSIN         = &g_pConfigManager->getConfigValuePtr("general:gaps_in")->intValue;
-    static auto* const PGAPSOUT        = &g_pConfigManager->getConfigValuePtr("general:gaps_out")->intValue;
-    static auto* const PNOGAPSWHENONLY = &g_pConfigManager->getConfigValuePtr("master:no_gaps_when_only")->intValue;
-    static auto* const PANIMATE        = &g_pConfigManager->getConfigValuePtr("misc:animate_manual_resizes")->intValue;
+    static auto* const PGAPSIN             = &g_pConfigManager->getConfigValuePtr("general:gaps_in")->intValue;
+    static auto* const PGAPSOUT            = &g_pConfigManager->getConfigValuePtr("general:gaps_out")->intValue;
+    static auto* const PNOGAPSWHENONLY     = &g_pConfigManager->getConfigValuePtr("master:no_gaps_when_only")->intValue;
+    static auto* const PNOROUNDINGWHENONLY = &g_pConfigManager->getConfigValuePtr("master:no_rounding_when_only")->intValue;
+    static auto* const PNOSHADOWWHENONLY   = &g_pConfigManager->getConfigValuePtr("master:no_shadow_when_only")->intValue;
+    static auto* const PANIMATE            = &g_pConfigManager->getConfigValuePtr("misc:animate_manual_resizes")->intValue;
 
     auto               gapsIn  = WORKSPACERULE.gapsIn.value_or(*PGAPSIN);
     auto               gapsOut = WORKSPACERULE.gapsOut.value_or(*PGAPSOUT);
@@ -655,8 +657,8 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
 
         PWINDOW->m_sSpecialRenderData.border   = WORKSPACERULE.border.value_or(*PNOGAPSWHENONLY == 2);
         PWINDOW->m_sSpecialRenderData.decorate = WORKSPACERULE.decorate.value_or(true);
-        PWINDOW->m_sSpecialRenderData.rounding = false;
-        PWINDOW->m_sSpecialRenderData.shadow   = false;
+        PWINDOW->m_sSpecialRenderData.rounding = !*PNOROUNDINGWHENONLY;
+        PWINDOW->m_sSpecialRenderData.shadow   = !*PNOSHADOWWHENONLY;
 
         PWINDOW->updateWindowDecos();
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
- The options and their defaults:
```
dwindle:no_shadow_when_only = true
dwindle:no_rounding_when_only = true
master:no_shadow_when_only = true
master:no_rounding_when_only = true
```
- "when only" = there's only 1 window in workspace, similar to no_gaps_when_only

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
- nope

#### Is it ready for merging, or does it need work?
- i hope i don't mess up with only 12 changed lines 😬

