### PR TITLE
floating windows lose last size while fullscreen

### DIFF
--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -776,12 +776,12 @@ void CHyprDwindleLayout::fullscreenRequestForWindow(CWindow* pWindow, eFullscree
         return;
     }
 
+    pWindow->updateDynamicRules();
+    pWindow->updateWindowDecos();
+
     // otherwise, accept it.
     pWindow->m_bIsFullscreen           = on;
     PWORKSPACE->m_bHasFullscreenWindow = !PWORKSPACE->m_bHasFullscreenWindow;
-
-    pWindow->updateDynamicRules();
-    pWindow->updateWindowDecos();
 
     g_pEventManager->postEvent(SHyprIPCEvent{"fullscreen", std::to_string((int)on)});
     EMIT_HOOK_EVENT("fullscreen", pWindow);

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -879,12 +879,12 @@ void CHyprMasterLayout::fullscreenRequestForWindow(CWindow* pWindow, eFullscreen
         return;
     }
 
+    pWindow->updateDynamicRules();
+    pWindow->updateWindowDecos();
+
     // otherwise, accept it.
     pWindow->m_bIsFullscreen           = on;
     PWORKSPACE->m_bHasFullscreenWindow = !PWORKSPACE->m_bHasFullscreenWindow;
-
-    pWindow->updateDynamicRules();
-    pWindow->updateWindowDecos();
 
     g_pEventManager->postEvent(SHyprIPCEvent{"fullscreen", std::to_string((int)on)});
     EMIT_HOOK_EVENT("fullscreen", pWindow);


### PR DESCRIPTION
As described in #4388 there is a regression where exiting fullscreen leaves the window size as maximized for floating windows, it happens because recalculateMonitors (called in updateDynamicRules) updates window.realSize.
Moving the update rules above the fullscreen properties will have recalculateMonitors skip the fullscreen ceremony.

Just a proposal to get it work again, we can also discuss better options.
