### PR TITLE
Disable fortify for devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,7 @@
           name = "hyprland-shell";
           nativeBuildInputs = with pkgsFor.${system}; [cmake python3];
           buildInputs = [self.packages.${system}.wlroots-hyprland];
+          hardeningDisable = [ "fortify" ];
           inputsFrom = [
             self.packages.${system}.wlroots-hyprland
             self.packages.${system}.hyprland


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This disables '_FORTIFY_SOURCE' Werrors trying to compile wlroots. Long standing issue in https://github.com/NixOS/nixpkgs/issues/60919 afaik.

![disable_fortify](https://github.com/hyprwm/Hyprland/assets/470767/68280ce8-c91a-4892-bcef-0a3e7549ffd6)

After this change you should be able to:
```
nix develop
meson setup build -Dbuildtype=debug
ninja -C build
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
seems legit

