### PR TITLE
build: protocols: require wayland-protocols >= 1.32

### DIFF
--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -1,5 +1,5 @@
 wayland_protos = dependency('wayland-protocols',
-	version: '>=1.25',
+	version: '>=1.32',
 	fallback: 'wayland-protocols',
 	default_options: ['tests=false'],
 )


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

The `cursor-shape-v1` protocol was not available until `wayland-protocols` v1.32.

#### Is it ready for merging, or does it need work?

This should be mergeable as-is.
