### PR TITLE
Touchscreen workspace swipe

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -498,6 +498,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("gestures:workspace_swipe_forever", Hyprlang::INT{0});
     m_pConfig->addConfigValue("gestures:workspace_swipe_numbered", Hyprlang::INT{0});
     m_pConfig->addConfigValue("gestures:workspace_swipe_use_r", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("gestures:workspace_swipe_touch", Hyprlang::INT{0});
 
     m_pConfig->addConfigValue("xwayland:use_nearest_neighbor", Hyprlang::INT{1});
     m_pConfig->addConfigValue("xwayland:force_zero_scaling", Hyprlang::INT{0});

--- a/src/helpers/WLClasses.hpp
+++ b/src/helpers/WLClasses.hpp
@@ -283,6 +283,7 @@ struct SSwipeGesture {
     int         initialDirection = 0;
     float       avgSpeed         = 0;
     int         speedPoints      = 0;
+    int         touch_id         = 0;
 
     CMonitor*   pMonitor = nullptr;
 };

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -231,6 +231,8 @@ class CInputManager {
 
     // swipe
     void beginWorkspaceSwipe();
+    void updateWorkspaceSwipe(double);
+    void endWorkspaceSwipe();
 
     void setBorderCursorIcon(eBorderIconDirection);
     void setCursorIconOnBorder(CWindow* w);

--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -1,7 +1,15 @@
 #include "InputManager.hpp"
 #include "../../Compositor.hpp"
+#include "../../config/ConfigValue.hpp"
 
 void CInputManager::onTouchDown(wlr_touch_down_event* e) {
+    static auto PSWIPETOUCH  = CConfigValue<Hyprlang::INT>("gestures:workspace_swipe_touch");
+    static auto PGAPSOUTDATA = CConfigValue<Hyprlang::CUSTOMTYPE>("general:gaps_out");
+    auto* const PGAPSOUT     = (CCssGapData*)(PGAPSOUTDATA.ptr())->getData();
+    // TODO: WORKSPACERULE.gapsOut.value_or()
+    auto        gapsOut     = *PGAPSOUT;
+    static auto PBORDERSIZE = CConfigValue<Hyprlang::INT>("general:border_size");
+    static auto PSWIPEINVR  = CConfigValue<Hyprlang::INT>("gestures:workspace_swipe_invert");
     EMIT_HOOK_EVENT_CANCELLABLE("touchDown", e);
 
     auto       PMONITOR = g_pCompositor->getMonitorFromName(e->touch->output_name ? e->touch->output_name : "");
@@ -22,6 +30,30 @@ void CInputManager::onTouchDown(wlr_touch_down_event* e) {
         e.state = WL_POINTER_BUTTON_STATE_PRESSED;
         g_pInputManager->processMouseDownKill(&e);
         return;
+    }
+
+    // Don't propagate new touches when a workspace swipe is in progress.
+    if (m_sActiveSwipe.pWorkspaceBegin) {
+        return;
+        // TODO: Don't swipe if you touched a floating window.
+    } else if (*PSWIPETOUCH && (!m_pFoundLSToFocus || m_pFoundLSToFocus->layer <= ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM)) {
+        const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(PMONITOR->activeWorkspace);
+        const bool VERTANIMS  = PWORKSPACE->m_vRenderOffset.getConfig()->pValues->internalStyle == "slidevert" ||
+            PWORKSPACE->m_vRenderOffset.getConfig()->pValues->internalStyle.starts_with("slidefadevert");
+        // TODO: support no_gaps_when_only?
+        const double TARGETLEFT  = ((VERTANIMS ? gapsOut.top : gapsOut.left) + *PBORDERSIZE) / (VERTANIMS ? PMONITOR->vecSize.y : PMONITOR->vecSize.x);
+        const double TARGETRIGHT = 1 - (((VERTANIMS ? gapsOut.bottom : gapsOut.right) + *PBORDERSIZE) / (VERTANIMS ? PMONITOR->vecSize.y : PMONITOR->vecSize.x));
+        const double POSITION    = (VERTANIMS ? e->y : e->x);
+        if (POSITION < TARGETLEFT || POSITION > TARGETRIGHT) {
+            beginWorkspaceSwipe();
+            m_sActiveSwipe.touch_id = e->touch_id;
+            // Set the initial direction based on which edge you started from
+            if (POSITION > 0.5)
+                m_sActiveSwipe.initialDirection = *PSWIPEINVR ? -1 : 1;
+            else
+                m_sActiveSwipe.initialDirection = *PSWIPEINVR ? 1 : -1;
+            return;
+        }
     }
 
     m_bLastInputTouch = true;
@@ -55,6 +87,13 @@ void CInputManager::onTouchDown(wlr_touch_down_event* e) {
 
 void CInputManager::onTouchUp(wlr_touch_up_event* e) {
     EMIT_HOOK_EVENT_CANCELLABLE("touchUp", e);
+    if (m_sActiveSwipe.pWorkspaceBegin) {
+        // If there was a swipe from this finger, end it.
+        if (e->touch_id == m_sActiveSwipe.touch_id)
+            endWorkspaceSwipe();
+        return;
+    }
+
     if (m_sTouchData.touchFocusSurface) {
         wlr_seat_touch_notify_up(g_pCompositor->m_sSeat.seat, e->time_msec, e->touch_id);
     }
@@ -62,6 +101,30 @@ void CInputManager::onTouchUp(wlr_touch_up_event* e) {
 
 void CInputManager::onTouchMove(wlr_touch_motion_event* e) {
     EMIT_HOOK_EVENT_CANCELLABLE("touchMove", e);
+    if (m_sActiveSwipe.pWorkspaceBegin) {
+        // Do nothing if this is using a different finger.
+        if (e->touch_id != m_sActiveSwipe.touch_id)
+            return;
+        const bool VERTANIMS = m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle == "slidevert" ||
+            m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle.starts_with("slidefadevert");
+        static auto PSWIPEINVR = CConfigValue<Hyprlang::INT>("gestures:workspace_swipe_invert");
+        static auto PSWIPEDIST = CConfigValue<Hyprlang::INT>("gestures:workspace_swipe_distance");
+        // Handle the workspace swipe if there is one
+        if (m_sActiveSwipe.initialDirection == -1) {
+            if (*PSWIPEINVR)
+                // go from 0 to -PSWIPEDIST
+                updateWorkspaceSwipe(*PSWIPEDIST * ((VERTANIMS ? e->y : e->x) - 1));
+            else
+                // go from 0 to -PSWIPEDIST
+                updateWorkspaceSwipe(*PSWIPEDIST * (-1 * (VERTANIMS ? e->y : e->x)));
+        } else if (*PSWIPEINVR)
+            // go from 0 to PSWIPEDIST
+            updateWorkspaceSwipe(*PSWIPEDIST * (VERTANIMS ? e->y : e->x));
+        else
+            // go from 0 to PSWIPEDIST
+            updateWorkspaceSwipe(*PSWIPEDIST * (1 - (VERTANIMS ? e->y : e->x)));
+        return;
+    }
     if (m_sTouchData.touchFocusWindow && g_pCompositor->windowValidMapped(m_sTouchData.touchFocusWindow)) {
         const auto PMONITOR = g_pCompositor->getMonitorFromID(m_sTouchData.touchFocusWindow->m_iMonitorID);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Adds support for workspace-swiping via touchscreen

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

It repurposes existing workspace swiping code, and so it supports most of the the ["Gestures" configuration parameters](https://wiki.hyprland.org/Configuring/Variables/#gestures):
* instead of `workspace_swipe`, it uses `workspace_swipe_touch` to enable/disable it.
* `workspace_swipe_fingers` not relevant
* `workspace_swipe_distance` is unused. Or rather, it is *ab*-used to map the touchscreen's width to [0,100%]
  * Probably should refactor that 'abuse' out before merging this.
* `workspace_swipe_forever` has no effect, because the touchscreen's width is mapped to 0-100x, so you can't swipe more than one at a time.
  * I imagine it could be useful to change multiple workspaces at a time, though I like how it feels to drag the workspace over and have it follow your thumb. Maybe we need some `workspace_swipe_touch_distance_multiplier` parameter to allow this? (but default to 1, which would be the preferred value)
      * This could be done in the future if someone wants it.
* `workspace_swipe_invert` is implemented (though it feels weird to use)
* `workspace_swipe_direction_lock` has no effect, because the direction is set based on which edge you grabbed

#### Is it ready for merging, or does it need work?

~~No, this is not ready for merging.~~  Done some work. I think now it could be fine to merge.
Work needed:
- [x] ~~Currently the margins are hard-coded (at 5%)~~. This needs to 
  - [x] Be based on gaps_out
  - [x] Account for a layer shell that might be in the way
  - [x] handle vertical workspace changing as well
- ~~probably need to test with a multimonitor setup (I imagine something needs to be done so we switch the right monitor)~~ I think this will work fine.
- [ ] Support no_gaps_when_only??? (maybe a nice enhancement)
    - ~~support fullscreened windows~~? (I don't use fullscreen on mobile, doing so one can get trapped, so actually a workspace swipe could help save from that)
    - [ ] maybe do something generic so that floating windows will obstruct this? (not sure how to detect that I touched a floating window).
- [X] hyprland-wiki PR to add documentation for this feature: https://github.com/hyprwm/hyprland-wiki/pull/448