### PR TITLE
Restore full screen while moving or closing a fullscreen window

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -96,12 +96,15 @@ assert lib.assertMsg (!hidpiXWayland) "The option `hidpiXWayland` has been remov
       then "debug"
       else "release";
 
+    dontStrip = debug;
+
     mesonAutoFeatures = "disabled";
 
     mesonFlags = builtins.concatLists [
       (lib.optional enableXWayland "-Dxwayland=enabled")
       (lib.optional legacyRenderer "-Dlegacy_renderer=enabled")
       (lib.optional withSystemd "-Dsystemd=enabled")
+      (lib.optional debug "-Ddebug=${if debug then "true" else "false"}")
     ];
 
     patches = [

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2684,8 +2684,9 @@ void CCompositor::moveWindowToWorkspaceSafe(CWindow* pWindow, CWorkspace* pWorks
     if (pWindow->m_bPinned && pWorkspace->m_bIsSpecialWorkspace)
         return;
 
+    const int  OLDWORKSPACE   = pWindow->m_iWorkspaceID;
     const bool FULLSCREEN     = pWindow->m_bIsFullscreen;
-    const auto FULLSCREENMODE = getWorkspaceByID(pWindow->m_iWorkspaceID)->m_efFullscreenMode;
+    const auto FULLSCREENMODE = getWorkspaceByID(OLDWORKSPACE)->m_efFullscreenMode;
 
     if (FULLSCREEN)
         setWindowFullscreen(pWindow, false, FULLSCREEN_FULL);
@@ -2726,6 +2727,14 @@ void CCompositor::moveWindowToWorkspaceSafe(CWindow* pWindow, CWorkspace* pWorks
 
     g_pCompositor->updateWorkspaceWindows(pWorkspace->m_iID);
     g_pCompositor->updateWorkspaceWindows(pWindow->m_iWorkspaceID);
+
+    // restore fullscreen in the previous workspace if we move a fullscreen window in another workspace
+    CWindow* FWINDOW = g_pCompositor->getFirstWindowOnWorkspace(OLDWORKSPACE);
+
+    if (FWINDOW && FULLSCREEN) {
+        Debug::log(LOG, "Set fullscreen in the first window of workspace {}", OLDWORKSPACE);
+        g_pCompositor->setWindowFullscreen(FWINDOW, true, FULLSCREENMODE);
+    }
 }
 
 CWindow* CCompositor::getForceFocus() {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

currently windows go into tile mode after a window closes or moves to another workspace (https://github.com/hyprwm/Hyprland/issues/3093). In this PR the first window will be put in fullscreen mode keeping a consistent behavior while working on fullscreen windows

minor fix: I did add a few configurations to let Nix add symbols to the generated binary otherwise was not possible to debug

#### Is it ready for merging, or does it need work?

Tested on my dual monitor setup and with the single window in a nested environment and everything is working as expected