### PR TITLE
CoC: remove redundant verbage and simplify

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,14 +1,8 @@
 ## Goal
 
-Our goal is to provide a space where it is safe for everyone to contribute to,
-and get support for, open-source software in a respectful and cooperative
-manner.
-
-We value all contributions and want to make this organization and its
-surrounding community a place for everyone.
-
-As members, contributors, and everyone else who may participate in the
-development, we strive to keep the entire experience civil.
+Our goal is to accept and value all contributions to our software, and to
+uphold the values of free and open-source software while encouraging civil
+discussion and cooperation.
 
 ## Standards
 
@@ -16,16 +10,9 @@ Our community standards exist in order to make sure everyone feels comfortable
 contributing to the project(s) together.
 
 Our standards are:
- - Do not harass, attack, or in any other way discriminate against anyone, including
-for their protected traits, including, but not limited to, sex, religion, race,
-appearance, gender, identity, nationality, sexuality, etc.
+ - Do not harass, attack, or in any other way discriminate against anyone.
  - Do not go off-topic, do not post spam.
  - Treat everyone with respect.
-
-Examples of breaking each rule respectively include:
- - Harassment, bullying or inappropriate jokes about another person.
- - Posting distasteful imagery, trolling, or posting things unrelated to the topic at hand.
- - Treating someone as worse because of their lack of understanding of an issue.
 
 ## Enforcement
 
@@ -56,41 +43,5 @@ We, as members, guarantee your privacy and will not share those reports with any
 
 ## Enforcement Strategy
 
-Depending on the severity of the infraction, any action from the list below may be applied.
-Please keep in mind cases are reviewed on a per-case basis and members are the ultimate
-deciding factor in the type of punishment.
-
-If the matter would benefit from an outside opinion, a member might reach for more opinions
-from people unrelated to the organization, however, the final decision regarding the action
-to be taken is still up to the member.
-
-For example, if the matter at hand regards a representative of a marginalized group or minority,
-the member might ask for a first-hand opinion from another representative of such group.
-
-### Correction/Edit
-
-If your message is found to be misleading or poorly worded, a member might
-edit your message.
-
-### Warning/Deletion
-
-If your message is found inappropriate, a member might give you a public or private warning,
-and/or delete your message.
-
-### Mute
-
-If your message is disruptive, or you have been repeatedly violating the standards,
-a member might mute (or temporarily ban) you.
-
-### Ban
-
-If your message is hateful, very disruptive, or other, less serious infractions are repeated
-ignoring previous punishments, a member might ban you permanently.
-
-## Scope
-
-This CoC shall apply to all projects ran under the `hyprwm` organization and all _official_ communities
-outside of GitHub.
-
-However, it is worth noting that official communities outside of GitHub might have their own,
-additional sets of rules.
+Violation of our standards will result in appropriate disciplinary action or warning,
+at the discretion of organization members.


### PR DESCRIPTION
This simplifies the Code of Conduct by removing language that is redundant, too verbose, or otherwise unnecessary for the reader to understand the point of the Code of Conduct.

