### PR TITLE
Allow disabling touchscreen input

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -255,6 +255,7 @@ void CConfigManager::setDefaultVars() {
     configValues["input:touchpad:scroll_factor"].floatValue         = 1.f;
     configValues["input:touchdevice:transform"].intValue            = 0;
     configValues["input:touchdevice:output"].strValue               = STRVAL_EMPTY;
+    configValues["input:touchdevice:enabled"].intValue              = 1;
     configValues["input:tablet:transform"].intValue                 = 0;
     configValues["input:tablet:output"].strValue                    = STRVAL_EMPTY;
     configValues["input:tablet:region_position"].vecValue           = Vector2D();

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -321,7 +321,7 @@ void CConfigManager::setDeviceDefaultVars(const std::string& dev) {
     cfgValues["scroll_points"].strValue           = STRVAL_EMPTY;
     cfgValues["transform"].intValue               = 0;
     cfgValues["output"].strValue                  = STRVAL_EMPTY;
-    cfgValues["enabled"].intValue                 = 1;          // only for mice / touchpads
+    cfgValues["enabled"].intValue                 = 1;          // only for mice, touchpads, and touchdevices
     cfgValues["region_position"].vecValue         = Vector2D(); // only for tablets
     cfgValues["region_size"].vecValue             = Vector2D(); // only for tablets
     cfgValues["relative_input"].intValue          = 0;          // only for tablets

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1460,12 +1460,16 @@ void CInputManager::newTouchDevice(wlr_input_device* pDevice) {
 }
 
 void CInputManager::setTouchDeviceConfigs(STouchDevice* dev) {
-
     auto setConfig = [&](STouchDevice* const PTOUCHDEV) -> void {
         if (wlr_input_device_is_libinput(PTOUCHDEV->pWlrDevice)) {
             const auto LIBINPUTDEV = (libinput_device*)wlr_libinput_get_device_handle(PTOUCHDEV->pWlrDevice);
 
-            const int  ROTATION = std::clamp(g_pConfigManager->getDeviceInt(PTOUCHDEV->name, "transform", "input:touchdevice:transform"), 0, 7);
+            const auto ENABLED = g_pConfigManager->getDeviceInt(PTOUCHDEV->name, "enabled", "input:touchdevice:enabled");
+            const auto mode    = ENABLED ? LIBINPUT_CONFIG_SEND_EVENTS_ENABLED : LIBINPUT_CONFIG_SEND_EVENTS_DISABLED;
+            if (libinput_device_config_send_events_get_mode(LIBINPUTDEV) != mode)
+                libinput_device_config_send_events_set_mode(LIBINPUTDEV, mode);
+
+            const int ROTATION = std::clamp(g_pConfigManager->getDeviceInt(PTOUCHDEV->name, "transform", "input:touchdevice:transform"), 0, 7);
             if (libinput_device_config_calibration_has_matrix(LIBINPUTDEV))
                 libinput_device_config_calibration_set_matrix(LIBINPUTDEV, MATRICES[ROTATION]);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Adds support for `input:touchdevice:enabled`/`device:$device:enabled` for touch devices.

Use case: I don't want to type/click on stuff when I turned the screen off.
```
# toggle touchscreen off/on with power button
bind = , XF86PowerOff, exec, hyprctl -i 0 dispatch dpms $(hyprctl -j -i 0 monitors | jq -r 'first|.dpmsStatus|if . then "off" else "on" end')
bind = , XF86PowerOff, exec, hyprctl -i 0 keyword input:touchdevice:enabled $(hyprctl -j getoption input:touchdevice:enabled | jq '.int==0')
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I wonder why we don't have a 'generic' way of doing this, since the libinput device config code is generic.

#### Is it ready for merging, or does it need work?

Yes, should be good to go!
