### PR TITLE
nix: fix overlay composition

### DIFF
--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -10,19 +10,16 @@
     (builtins.substring 4 2 longDate)
     (builtins.substring 6 2 longDate)
   ]);
-
-  mkJoinedOverlays = overlays: final: prev:
-    lib.foldl' (attrs: overlay: attrs // (overlay final prev)) {} overlays;
 in {
   # Contains what a user is most likely to care about:
   # Hyprland itself, XDPH and the Share Picker.
-  default = mkJoinedOverlays (with self.overlays; [
+  default = lib.composeManyExtensions (with self.overlays; [
     hyprland-packages
     hyprland-extras
   ]);
 
   # Packages for variations of Hyprland, dependencies included.
-  hyprland-packages = mkJoinedOverlays [
+  hyprland-packages = lib.composeManyExtensions [
     # Dependencies
     inputs.hyprland-protocols.overlays.default
     self.overlays.wlroots-hyprland
@@ -34,7 +31,7 @@ in {
       hyprland = final.callPackage ./default.nix {
         stdenv = final.gcc13Stdenv;
         version = "${props.version}+date=${date}_${self.shortRev or "dirty"}";
-        wlroots = final.wlroots-hyprland;
+        wlroots = prev.wlroots-hyprland;
         commit = self.rev or "";
         inherit (final) udis86 hyprland-protocols;
         inherit date;
@@ -59,7 +56,7 @@ in {
 
   # Packages for extra software recommended for usage with Hyprland,
   # including forked or patched packages for compatibility.
-  hyprland-extras = mkJoinedOverlays [
+  hyprland-extras = lib.composeManyExtensions [
     inputs.xdph.overlays.xdg-desktop-portal-hyprland
   ];
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

The nix overlay defined in `nix/overlays.nix` defines a function called `mkJoinedOverlays` to combine the correct dependencies for hyprland. This function however only *combines* the result of multiple overlays but does not provide the dependency overlay outputs to `callPackage` as an input when defining the `hyprland` package. This means that the internal dependency `wlroots-hyprland` must be defined on the final nixpkgs fixpoint.

To avoid name clashes, I personally shadow my flake input's overlays to provide a cleaner package set when selecting packages (i.e. hide internal dependencies). Because the hyprland overlay depends on the final package set to have a root `wlroots-hyprland` package, this prohibits my workflow. This PR fixes that. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This fix should be fully backwards compatible. I have tested that the overlay output package is a derivation. I have not tested the theoretical possibility of still manually overriding `wlroots-hyprland` using `hyprland.override { ... }`. This should however work since the hyprland package is a standard `mkDerivation` result.

#### Is it ready for merging, or does it need work?
ready, do I need formatting?


