### PR TITLE
fix:wrong workspace name when focus on a named special workspace

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1550,7 +1550,7 @@ void CKeybindManager::toggleSpecialWorkspace(std::string args) {
     static auto* const PFOLLOWMOUSE = &g_pConfigManager->getConfigValuePtr("input:follow_mouse")->intValue;
 
     std::string        workspaceName = "";
-    int                workspaceID   = getWorkspaceIDFromString("special:" + args, workspaceName);
+    int                workspaceID   = getWorkspaceIDFromString(args.starts_with("special:") ? args : "special:" + args, workspaceName);
 
     if (workspaceID == WORKSPACE_INVALID || !g_pCompositor->isWorkspaceSpecial(workspaceID)) {
         Debug::log(ERR, "Invalid workspace passed to special");


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
fix wrong workspace name when focus on a named special workspace,see the issue 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

#4556 
#### Is it ready for merging, or does it need work?
i am not good at cpp,so i am not sure substr is a good idea,but i think m_szName need to be fixed when tooglespecialworkspace

