### PR TITLE
nix: overlay polish for prev parameter

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -24,7 +24,7 @@
   wayland,
   wayland-protocols,
   wayland-scanner,
-  wlroots,
+  wlroots-hyprland,
   xcbutilwm,
   xwayland,
   debug ? false,
@@ -86,7 +86,7 @@ assert lib.assertMsg (!hidpiXWayland) "The option `hidpiXWayland` has been remov
         udis86
         wayland
         wayland-protocols
-        wlroots
+        wlroots-hyprland
       ]
       ++ lib.optionals enableXWayland [libxcb xcbutilwm xwayland]
       ++ lib.optionals withSystemd [systemd];
@@ -129,7 +129,7 @@ assert lib.assertMsg (!hidpiXWayland) "The option `hidpiXWayland` has been remov
     '';
 
     postInstall = ''
-      ln -s ${wlroots}/include/wlr $dev/include/hyprland/wlroots
+      ln -s ${wlroots-hyprland}/include/wlr $dev/include/hyprland/wlroots
       ${lib.optionalString wrapRuntimeDeps ''
         wrapProgram $out/bin/Hyprland \
           --suffix PATH : ${lib.makeBinPath [

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -24,7 +24,7 @@
   wayland,
   wayland-protocols,
   wayland-scanner,
-  wlroots-hyprland,
+  wlroots,
   xcbutilwm,
   xwayland,
   debug ? false,
@@ -86,7 +86,7 @@ assert lib.assertMsg (!hidpiXWayland) "The option `hidpiXWayland` has been remov
         udis86
         wayland
         wayland-protocols
-        wlroots-hyprland
+        wlroots
       ]
       ++ lib.optionals enableXWayland [libxcb xcbutilwm xwayland]
       ++ lib.optionals withSystemd [systemd];
@@ -129,7 +129,7 @@ assert lib.assertMsg (!hidpiXWayland) "The option `hidpiXWayland` has been remov
     '';
 
     postInstall = ''
-      ln -s ${wlroots-hyprland}/include/wlr $dev/include/hyprland/wlroots
+      ln -s ${wlroots}/include/wlr $dev/include/hyprland/wlroots
       ${lib.optionalString wrapRuntimeDeps ''
         wrapProgram $out/bin/Hyprland \
           --suffix PATH : ${lib.makeBinPath [

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -28,12 +28,10 @@ in {
     (final: prev: let
       date = mkDate (self.lastModifiedDate or "19700101");
     in {
-      hyprland = final.callPackage ./default.nix {
-        stdenv = final.gcc13Stdenv;
+      hyprland = prev.callPackage ./default.nix {
+        stdenv = prev.gcc13Stdenv;
         version = "${props.version}+date=${date}_${self.shortRev or "dirty"}";
-        wlroots = prev.wlroots-hyprland;
         commit = self.rev or "";
-        inherit (final) udis86 hyprland-protocols;
         inherit date;
       };
       hyprland-unwrapped = final.hyprland.override {wrapRuntimeDeps = false;};

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -33,7 +33,7 @@ in {
         version = "${props.version}+date=${date}_${self.shortRev or "dirty"}";
         commit = self.rev or "";
         wlroots = final.wlroots-hyprland; # explicit override until decided on breaking change of the name
-        udis86 = final.hyprland-udis86; # explicit override until decided on breaking change of the name
+        udis86 = final.udis86-hyprland; # explicit override until decided on breaking change of the name
         inherit date;
       };
       hyprland-unwrapped = final.hyprland.override {wrapRuntimeDeps = false;};
@@ -61,7 +61,7 @@ in {
   ];
 
   udis86 = final: prev: {
-    hyprland-udis86 = final.callPackage ./udis86.nix {};
+    udis86-hyprland = final.callPackage ./udis86.nix {};
   };
 
   # Patched version of wlroots for Hyprland.

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -28,10 +28,12 @@ in {
     (final: prev: let
       date = mkDate (self.lastModifiedDate or "19700101");
     in {
-      hyprland = prev.callPackage ./default.nix {
+      hyprland = final.callPackage ./default.nix {
         stdenv = prev.gcc13Stdenv;
         version = "${props.version}+date=${date}_${self.shortRev or "dirty"}";
+        wlroots = prev.wlroots-hyprland;
         commit = self.rev or "";
+        inherit (prev) udis86 hyprland-protocols;
         inherit date;
       };
       hyprland-unwrapped = final.hyprland.override {wrapRuntimeDeps = false;};

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -32,6 +32,8 @@ in {
         stdenv = final.gcc13Stdenv;
         version = "${props.version}+date=${date}_${self.shortRev or "dirty"}";
         commit = self.rev or "";
+        wlroots = final.wlroots-hyprland; # explicit override until decided on breaking change of the name
+        udis86 = final.hyprland-udis86; # explicit override until decided on breaking change of the name
         inherit date;
       };
       hyprland-unwrapped = final.hyprland.override {wrapRuntimeDeps = false;};
@@ -59,7 +61,7 @@ in {
   ];
 
   udis86 = final: prev: {
-    udis86 = final.callPackage ./udis86.nix {};
+    hyprland-udis86 = final.callPackage ./udis86.nix {};
   };
 
   # Patched version of wlroots for Hyprland.

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -29,11 +29,9 @@ in {
       date = mkDate (self.lastModifiedDate or "19700101");
     in {
       hyprland = final.callPackage ./default.nix {
-        stdenv = prev.gcc13Stdenv;
+        stdenv = final.gcc13Stdenv;
         version = "${props.version}+date=${date}_${self.shortRev or "dirty"}";
-        wlroots = prev.wlroots-hyprland;
         commit = self.rev or "";
-        inherit (prev) udis86 hyprland-protocols;
         inherit date;
       };
       hyprland-unwrapped = final.hyprland.override {wrapRuntimeDeps = false;};


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

After a good night's sleep, I realized I was a bit too quick in #4555. Since the overlay composition also overrides `udis86`, `hyprland-protocols` and `wlroots-hyprland`. These too, should be taken from `prev` instead of `final`, or my shadowing trick would not work anymore. This is changed in this PR.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I don't know if `callPackage` should be taken from `final` or `prev` in this case. Since it's just a function, I assume either would be fine if there is no explicit overriding in this project. Something to note then would be the requirement to explicitly reference all custom inputs not taken from `nixpkgs` when making the `hyprland` derivation.

In the same mindset, one might want to change the references to `final.hyprland` to something tied to the scope of the overlay. There exists a function `makeScope` in nixpkgs for this. I have not looked at this yet and would be implemented in a following PR. For now, for my workflow with shadowing input overlays, this could easily be worked around by adding a overlay that exports the hyprland package from my shadowed name set, should I need these extra outputs. 

#### Is it ready for merging, or does it need work?
ready, might want to add a comment

