### PR TITLE
Makefile: remove hyprland symlink on uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ install:
 uninstall:
 	rm -f ${PREFIX}/share/wayland-sessions/hyprland.desktop
 	rm -f ${PREFIX}/bin/Hyprland
+	rm -f ${PREFIX}/bin/hyprland
 	rm -f ${PREFIX}/bin/hyprctl
 	rm -f ${PREFIX}/bin/hyprpm
 	rm -f ${PREFIX}/lib/libwlroots.so.13032


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

The recently added hyprland symlink wasn't removed on uninstall.

