### PR TITLE
Fix nullptr crash when disconnecting a monitor

### DIFF
--- a/src/helpers/SubsurfaceTree.cpp
+++ b/src/helpers/SubsurfaceTree.cpp
@@ -262,7 +262,7 @@ void Events::listener_commitSubsurface(void* owner, void* data) {
 
         // tearing: if solitary, redraw it. This still might be a single surface window
         const auto PMONITOR = g_pCompositor->getMonitorFromID(pNode->pWindowOwner->m_iMonitorID);
-        if (PMONITOR->solitaryClient == pNode->pWindowOwner && pNode->pWindowOwner->canBeTorn() && PMONITOR->tearingState.canTear &&
+        if (PMONITOR && PMONITOR->solitaryClient == pNode->pWindowOwner && pNode->pWindowOwner->canBeTorn() && PMONITOR->tearingState.canTear &&
             pNode->pSurface->wlr()->current.committed & WLR_SURFACE_STATE_BUFFER) {
             CRegion damageBox{&pNode->pSurface->wlr()->buffer_damage};
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

I was able to reproduce the crash frequently by having a kitty terminal on an monitor running the following command and then unplugging that monitor:

`while true; do echo "" && sleep 0.02; done`


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

I think it is ready, unless there is a better way to handle this race condition.
