### PR TITLE
screenshader: rename output uniform to monitor

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -526,10 +526,10 @@ void CHyprOpenGLImpl::applyScreenShader(const std::string& path) {
         return;
     }
 
-    m_sFinalScreenShader.proj   = glGetUniformLocation(m_sFinalScreenShader.program, "proj");
-    m_sFinalScreenShader.tex    = glGetUniformLocation(m_sFinalScreenShader.program, "tex");
-    m_sFinalScreenShader.time   = glGetUniformLocation(m_sFinalScreenShader.program, "time");
-    m_sFinalScreenShader.output = glGetUniformLocation(m_sFinalScreenShader.program, "output");
+    m_sFinalScreenShader.proj    = glGetUniformLocation(m_sFinalScreenShader.program, "proj");
+    m_sFinalScreenShader.tex     = glGetUniformLocation(m_sFinalScreenShader.program, "tex");
+    m_sFinalScreenShader.time    = glGetUniformLocation(m_sFinalScreenShader.program, "time");
+    m_sFinalScreenShader.monitor = glGetUniformLocation(m_sFinalScreenShader.program, "monitor");
     if (m_sFinalScreenShader.time != -1 && g_pConfigManager->getInt("debug:damage_tracking") != 0 && !g_pHyprRenderer->m_bCrashingInProgress) {
         // The screen shader uses the "time" uniform
         // Since the screen shader could change every frame, damage tracking *needs* to be disabled
@@ -821,8 +821,8 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(const CTexture& tex, CBox*
         glUniform1f(shader->time, 0.f);
     }
 
-    if (usingFinalShader && shader->output != -1)
-        glUniform1i(shader->output, m_RenderData.pMonitor->ID);
+    if (usingFinalShader && shader->monitor != -1)
+        glUniform1i(shader->monitor, m_RenderData.pMonitor->ID);
 
     if (CRASHING) {
         glUniform1f(shader->distort, g_pHyprRenderer->m_fCrashingDistort);

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -526,10 +526,10 @@ void CHyprOpenGLImpl::applyScreenShader(const std::string& path) {
         return;
     }
 
-    m_sFinalScreenShader.proj    = glGetUniformLocation(m_sFinalScreenShader.program, "proj");
-    m_sFinalScreenShader.tex     = glGetUniformLocation(m_sFinalScreenShader.program, "tex");
-    m_sFinalScreenShader.time    = glGetUniformLocation(m_sFinalScreenShader.program, "time");
-    m_sFinalScreenShader.monitor = glGetUniformLocation(m_sFinalScreenShader.program, "monitor");
+    m_sFinalScreenShader.proj      = glGetUniformLocation(m_sFinalScreenShader.program, "proj");
+    m_sFinalScreenShader.tex       = glGetUniformLocation(m_sFinalScreenShader.program, "tex");
+    m_sFinalScreenShader.time      = glGetUniformLocation(m_sFinalScreenShader.program, "time");
+    m_sFinalScreenShader.wl_output = glGetUniformLocation(m_sFinalScreenShader.program, "wl_output");
     if (m_sFinalScreenShader.time != -1 && g_pConfigManager->getInt("debug:damage_tracking") != 0 && !g_pHyprRenderer->m_bCrashingInProgress) {
         // The screen shader uses the "time" uniform
         // Since the screen shader could change every frame, damage tracking *needs* to be disabled
@@ -821,8 +821,8 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(const CTexture& tex, CBox*
         glUniform1f(shader->time, 0.f);
     }
 
-    if (usingFinalShader && shader->monitor != -1)
-        glUniform1i(shader->monitor, m_RenderData.pMonitor->ID);
+    if (usingFinalShader && shader->wl_output != -1)
+        glUniform1i(shader->wl_output, m_RenderData.pMonitor->ID);
 
     if (CRASHING) {
         glUniform1f(shader->distort, g_pHyprRenderer->m_fCrashingDistort);

--- a/src/render/Shader.hpp
+++ b/src/render/Shader.hpp
@@ -44,7 +44,7 @@ class CShader {
 
     GLint   time    = -1;
     GLint   distort = -1;
-    GLint   output  = -1;
+    GLint   monitor = -1;
 
     // Blur prepare
     GLint contrast = -1;

--- a/src/render/Shader.hpp
+++ b/src/render/Shader.hpp
@@ -42,9 +42,9 @@ class CShader {
     GLint   gradientLength = -1;
     GLint   angle          = -1;
 
-    GLint   time    = -1;
-    GLint   distort = -1;
-    GLint   monitor = -1;
+    GLint   time      = -1;
+    GLint   distort   = -1;
+    GLint   wl_output = -1;
 
     // Blur prepare
     GLint contrast = -1;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
I recently switched my GPU from NVIDIA to AMD and for some reason the `output` screenshader uniform no longer works because it's considered a reserved word:

```
[wlr] [GLES2] 0:4(13): error: illegal use of reserved word `output'
[wlr] [GLES2] 0:4(13): error: syntax error, unexpected ERROR_TOK, expecting ',' or ';'
```

Renaming the uniform to `monitor` fixes it.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Assuming this affects all AMD GPUs, it's probably safe to assume that very few people use this feature so hopefully it shouldn't be too disruptive?

#### Is it ready for merging, or does it need work?

Ready
