### PR TITLE
use focused monitor for `focusWorkspaceOnCurrentMonitor`

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1512,7 +1512,7 @@ void CKeybindManager::focusWorkspaceOnCurrentMonitor(std::string args) {
         return;
     }
 
-    const auto PCURRMONITOR = g_pCompositor->getMonitorFromCursor();
+    const auto PCURRMONITOR = g_pCompositor->m_pLastMonitor;
 
     if (!PCURRMONITOR) {
         Debug::log(ERR, "focusWorkspaceOnCurrentMonitor monitor doesn't exist!");


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
fixes https://github.com/hyprwm/Hyprland/issues/4617, uses the focused monitor rather than just the monitor that the cursor is in

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
nop

#### Is it ready for merging, or does it need work?
ready

