### PR TITLE
Fix crash reporter backtrace

### DIFF
--- a/src/debug/CrashReporter.cpp
+++ b/src/debug/CrashReporter.cpp
@@ -3,6 +3,7 @@
 #include <sys/utsname.h>
 #include <fstream>
 #include <signal.h>
+#include <link.h>
 
 #include "../plugins/PluginSystem.hpp"
 
@@ -105,16 +106,33 @@ void CrashReporter::createAndSaveCrash(int sig) {
     const auto FPATH = std::filesystem::canonical("/proc/self/exe");
 #endif
 
+    std::string addrs = "";
     for (size_t i = 0; i < CALLSTACK.size(); ++i) {
-        finalCrashReport += std::format("\t#{} | {}\n", i, CALLSTACK[i].desc);
+        // convert in memory address to VMA address
+        Dl_info          info;
+        struct link_map* linkMap;
+        dladdr1((void*)CALLSTACK[i].adr, &info, (void**)&linkMap, RTLD_DL_LINKMAP);
+        size_t vmaAddr = (size_t)CALLSTACK[i].adr - linkMap->l_addr;
 
+        addrs += std::format("0x{:x} ", vmaAddr);
+    }
 #ifdef __clang__
-        const auto CMD = std::format("llvm-addr2line -e {} -f 0x{:x}", FPATH.c_str(), (uint64_t)CALLSTACK[i].adr);
+    const auto CMD = std::format("llvm-addr2line -e {} -Cf {}", FPATH.c_str(), addrs);
 #else
-        const auto CMD = std::format("addr2line -e {} -f 0x{:x}", FPATH.c_str(), (uint64_t)CALLSTACK[i].adr);
+    const auto CMD   = std::format("addr2line -e {} -Cf {}", FPATH.c_str(), addrs);
 #endif
-        const auto ADDR2LINE = replaceInString(execAndGet(CMD.c_str()), "\n", "\n\t\t");
-        finalCrashReport += "\t\t" + ADDR2LINE.substr(0, ADDR2LINE.length() - 2);
+
+    const auto        ADDR2LINE = execAndGet(CMD.c_str());
+
+    std::stringstream ssin(ADDR2LINE);
+
+    for (size_t i = 0; i < CALLSTACK.size(); ++i) {
+        finalCrashReport += std::format("\t#{} | {}", i, CALLSTACK[i].desc);
+        std::string functionInfo;
+        std::string fileLineInfo;
+        std::getline(ssin, functionInfo);
+        std::getline(ssin, fileLineInfo);
+        finalCrashReport += std::format("\n\t\t{}\n\t\t{}\n", functionInfo, fileLineInfo);
     }
 
     finalCrashReport += "\n\nLog tail:\n";


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fix the crash reporter's backtrace so that in debug mode the crash report will actually log the backtrace of function calls, file names and line numbers, instead of the `?? ??:0`

example:
```
	#0 | ./build/Hyprland(_Z12getBacktracev+0x49) [0x6204629d1b33]
		getBacktrace()
		/home/example/Hyprland/src/helpers/MiscFunctions.cpp:758 (discriminator 1)
	#1 | ./build/Hyprland(_ZN13CrashReporter18createAndSaveCrashEi+0x77d) [0x62046296bfcd]
		CrashReporter::createAndSaveCrash(int)
		/home/example/Hyprland/src/debug/CrashReporter.cpp:106
	#2 | ./build/Hyprland(_Z25handleUnrecoverableSignali+0x8c) [0x6204628552fd]
		handleUnrecoverableSignal(int)
		/home/example/Hyprland/src/Compositor.cpp:34
	#3 | /usr/lib/libc.so.6(+0x3c770) [0x7926c896e770]
		??
		??:0
	#4 | ./build/Hyprland(_ZN15CKeybindManager12moveActiveToENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE+0x17c) [0x620462a428fc]
		CKeybindManager::moveActiveTo(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)
		/home/example/Hyprland/src/managers/KeybindManager.cpp:1189
	#5 | ./build/Hyprland(_ZSt13__invoke_implIvRPFvNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEJS5_EET_St14__invoke_otherOT0_DpOT1_+0x56) [0x620462a5281c]
		void std::__invoke_impl<void, void (*&)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >(std::__invoke_other, void (*&)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&)
		/usr/include/c++/13.2.1/bits/invoke.h:61 (discriminator 2)
	#6 | ./build/Hyprland(_ZSt10__invoke_rIvRPFvNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEJS5_EENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EESA_E4typeEOSB_DpOSC_+0x37) [0x620462a51a1c]
		std::enable_if<is_invocable_r_v<void, void (*&)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, void>::type std::__invoke_r<void, void (*&)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >(void (*&)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >), std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&)
		/usr/include/c++/13.2.1/bits/invoke.h:117
	#7 | ./build/Hyprland(_ZNSt17_Function_handlerIFvNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEPS6_E9_M_invokeERKSt9_Any_dataOS5_+0x37) [0x620462a50620]
		std::_Function_handler<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >), void (*)(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)>::_M_invoke(std::_Any_data const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&)
		/usr/include/c++/13.2.1/bits/std_function.h:291
	#8 | ./build/Hyprland(_ZNKSt8functionIFvNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEEEclES5_+0x49) [0x620462984b47]
		std::function<void (std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >)>::operator()(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) const
		/usr/include/c++/13.2.1/bits/std_function.h:591
	#9 | ./build/Hyprland(_ZN15CKeybindManager14handleKeybindsEjRK19SPressedKeyWithModsb+0x6f3) [0x620462a3f311]
		CKeybindManager::handleKeybinds(unsigned int, SPressedKeyWithMods const&, bool)
		/home/example/Hyprland/src/managers/KeybindManager.cpp:566 (discriminator 4)
	#10 | ./build/Hyprland(_ZN15CKeybindManager10onKeyEventEP22wlr_keyboard_key_eventP9SKeyboard+0x345) [0x620462a3da59]
		CKeybindManager::onKeyEvent(wlr_keyboard_key_event*, SKeyboard*)
		/home/example/Hyprland/src/managers/KeybindManager.cpp:331 (discriminator 1)
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
ready

