### PR TITLE
renderer: Add dimaround layer rule

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1910,8 +1910,8 @@ bool windowRuleValid(const std::string& RULE) {
 }
 
 bool layerRuleValid(const std::string& RULE) {
-    return RULE == "noanim" || RULE == "blur" || RULE == "blurpopups" || RULE.starts_with("ignorealpha") || RULE.starts_with("ignorezero") || RULE.starts_with("xray") ||
-        RULE.starts_with("animation");
+    return RULE == "noanim" || RULE == "blur" || RULE == "blurpopups" || RULE.starts_with("ignorealpha") || RULE.starts_with("ignorezero") || RULE == "dimaround" ||
+        RULE.starts_with("xray") || RULE.starts_with("animation");
 }
 
 std::optional<std::string> CConfigManager::handleWindowRule(const std::string& command, const std::string& value) {

--- a/src/helpers/WLClasses.cpp
+++ b/src/helpers/WLClasses.cpp
@@ -10,6 +10,11 @@ SLayerSurface::SLayerSurface() {
     realPosition.registerVar();
     realSize.registerVar();
 
+    alpha.setUpdateCallback([this](void*) {
+        if (dimAround)
+            g_pHyprRenderer->damageMonitor(g_pCompositor->getMonitorFromID(monitorID));
+    });
+
     alpha.setValueAndWarp(0.f);
 }
 
@@ -26,6 +31,7 @@ void SLayerSurface::applyRules() {
     forceBlur        = false;
     ignoreAlpha      = false;
     ignoreAlphaValue = 0.f;
+    dimAround        = false;
     xray             = -1;
     animationStyle.reset();
 
@@ -47,6 +53,8 @@ void SLayerSurface::applyRules() {
                 if (!alphaValue.empty())
                     ignoreAlphaValue = std::stof(alphaValue);
             } catch (...) { Debug::log(ERR, "Invalid value passed to ignoreAlpha"); }
+        } else if (rule.rule == "dimaround") {
+            dimAround = true;
         } else if (rule.rule.starts_with("xray")) {
             CVarList vars{rule.rule, 0, ' '};
             try {

--- a/src/helpers/WLClasses.hpp
+++ b/src/helpers/WLClasses.hpp
@@ -63,6 +63,7 @@ struct SLayerSurface {
     int                        xray             = -1;
     bool                       ignoreAlpha      = false;
     float                      ignoreAlphaValue = 0.f;
+    bool                       dimAround        = false;
 
     std::optional<std::string> animationStyle;
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -654,6 +654,13 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
 }
 
 void CHyprRenderer::renderLayer(SLayerSurface* pLayer, CMonitor* pMonitor, timespec* time, bool popups) {
+    static auto PDIMAROUND = CConfigValue<Hyprlang::FLOAT>("decoration:dim_around");
+
+    if (*PDIMAROUND && pLayer->dimAround && !m_bRenderingSnapshot && !popups) {
+        CBox monbox = {0, 0, g_pHyprOpenGL->m_RenderData.pMonitor->vecTransformedSize.x, g_pHyprOpenGL->m_RenderData.pMonitor->vecTransformedSize.y};
+        g_pHyprOpenGL->renderRect(&monbox, CColor(0, 0, 0, *PDIMAROUND * pLayer->alpha.value()));
+    }
+
     if (pLayer->fadingOut) {
         g_pHyprOpenGL->renderSnapshot(&pLayer);
         return;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

I literally just copied the code from the dimaround window rule and it seems to work.

Fixes #1657, Fixes #1889

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Probably related to #3633. The same weird behaviour that shows up when applying `dimaround` to tiled windows would also happen here for shells on the same layer. There'd also be double-dimaround if there are any dimaround windows behind the layer.

#### Is it ready for merging, or does it need work?

It is ready for merging.
