### PR TITLE
Feature: `monitoraddedv2` IPC event for monitor description

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -76,7 +76,7 @@ std::string monitorsRequest(eHyprCtlOutputFormat format, std::string request) {
     "vrr": {},
     "activelyTearing": {}
 }},)#",
-                m->ID, escapeJSONStrings(m->szName), escapeJSONStrings(m->szDescription), (m->output->make ? m->output->make : ""), (m->output->model ? m->output->model : ""),
+                m->ID, escapeJSONStrings(m->szName), escapeJSONStrings(m->szShortDescription), (m->output->make ? m->output->make : ""), (m->output->model ? m->output->model : ""),
                 (m->output->serial ? m->output->serial : ""), (int)m->vecPixelSize.x, (int)m->vecPixelSize.y, m->refreshRate, (int)m->vecPosition.x, (int)m->vecPosition.y,
                 m->activeWorkspace, (m->activeWorkspace == -1 ? "" : escapeJSONStrings(g_pCompositor->getWorkspaceByID(m->activeWorkspace)->m_szName)), m->specialWorkspaceID,
                 escapeJSONStrings(getWorkspaceNameFromSpecialID(m->specialWorkspaceID)), (int)m->vecReservedTopLeft.x, (int)m->vecReservedTopLeft.y,
@@ -98,7 +98,7 @@ std::string monitorsRequest(eHyprCtlOutputFormat format, std::string request) {
                             "workspace: {} ({})\n\treserved: {} "
                             "{} {} {}\n\tscale: {:.2f}\n\ttransform: "
                             "{}\n\tfocused: {}\n\tdpmsStatus: {}\n\tvrr: {}\n\tactivelyTearing: {}\n\n",
-                            m->szName, m->ID, (int)m->vecPixelSize.x, (int)m->vecPixelSize.y, m->refreshRate, (int)m->vecPosition.x, (int)m->vecPosition.y, m->szDescription,
+                            m->szName, m->ID, (int)m->vecPixelSize.x, (int)m->vecPixelSize.y, m->refreshRate, (int)m->vecPosition.x, (int)m->vecPosition.y, m->szShortDescription,
                             (m->output->make ? m->output->make : ""), (m->output->model ? m->output->model : ""), (m->output->serial ? m->output->serial : ""), m->activeWorkspace,
                             (m->activeWorkspace == -1 ? "" : g_pCompositor->getWorkspaceByID(m->activeWorkspace)->m_szName), m->specialWorkspaceID,
                             getWorkspaceNameFromSpecialID(m->specialWorkspaceID), (int)m->vecReservedTopLeft.x, (int)m->vecReservedTopLeft.y, (int)m->vecReservedBottomRight.x,

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1,5 +1,7 @@
 #include "Monitor.hpp"
 
+#include "MiscFunctions.hpp"
+
 #include "../Compositor.hpp"
 
 int ratHandler(void* data) {
@@ -53,6 +55,10 @@ void CMonitor::onConnect(bool noRule) {
     szDescription = output->description ? output->description : "";
     // remove comma character from description. This allow monitor specific rules to work on monitor with comma on their description
     szDescription.erase(std::remove(szDescription.begin(), szDescription.end(), ','), szDescription.end());
+
+    // field is backwards-compatible with intended usage of `szDescription` but excludes the parenthesized DRM node name suffix
+    szShortDescription =
+        removeBeginEndSpacesTabs(std::format("{} {} {}", output->make ? output->make : "", output->model ? output->model : "", output->serial ? output->serial : ""));
 
     if (!wlr_backend_is_drm(output->backend))
         createdByUser = true; // should be true. WL, X11 and Headless backends should be addable / removable

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -169,7 +169,7 @@ void CMonitor::onConnect(bool noRule) {
     //
 
     g_pEventManager->postEvent(SHyprIPCEvent{"monitoradded", szName});
-    g_pEventManager->postEvent(SHyprIPCEvent{"monitoraddedv2", std::format("{},{}", szName, szShortDescription)});
+    g_pEventManager->postEvent(SHyprIPCEvent{"monitoraddedv2", std::format("{},{},{}", ID, szName, szShortDescription)});
     EMIT_HOOK_EVENT("monitorAdded", this);
 
     if (!g_pCompositor->m_pLastMonitor) // set the last monitor if it isnt set yet

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -169,6 +169,7 @@ void CMonitor::onConnect(bool noRule) {
     //
 
     g_pEventManager->postEvent(SHyprIPCEvent{"monitoradded", szName});
+    g_pEventManager->postEvent(SHyprIPCEvent{"monitoraddedv2", std::format("{},{}", szName, szShortDescription)});
     EMIT_HOOK_EVENT("monitorAdded", this);
 
     if (!g_pCompositor->m_pLastMonitor) // set the last monitor if it isnt set yet

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -62,8 +62,9 @@ class CMonitor {
     float           setScale        = 1; // scale set by cfg
     float           scale           = 1; // real scale
 
-    std::string     szName        = "";
-    std::string     szDescription = "";
+    std::string     szName             = "";
+    std::string     szDescription      = "";
+    std::string     szShortDescription = "";
 
     Vector2D        vecReservedTopLeft     = Vector2D(0, 0);
     Vector2D        vecReservedBottomRight = Vector2D(0, 0);


### PR DESCRIPTION
Wiki PR not started. Will make a PR to add them to the table when this PR is approved.

#### Describe your PR, what does it fix/add?

Adds five new `.socket2.sock` events, `monitoraddedv2`, `monitorremovedv2`, `focusedmonv2`, `moveworkspacev2`, and `activespecialv2`.

### [Why?](https://github.com/spikespaz/dotfiles/blob/7a01cfc0efd57545bddaaa1e9f0a8f17ddf20f2c/users/jacob%40odyssey/hyprland/monitors.nix#L122-L142)

Each of the original events provided the parameter `MONNAME`. Since then, monitor "names" (or DRM node names) are non-deterministic; if I plug a monitor into DisplayPort on a Thunderbolt dock, it may show up as `DP-1` or `DP-5`, or `DP-6`. One cannot know.

An easy way to mitigate this is to parse the output from `hyprctl -j monitors`, but this is a somewhat ugly solution that requires many more lines of code on my side. Alternatively, this PR introduces eight lines of code, saving me dozens when using the socket.

![image](https://github.com/hyprwm/Hyprland/assets/12502988/d5cc0c96-b41e-4849-8a26-4b10fad34938)

Each new event, where the former had only `MONNAME`, now has an added the monitor description (`szDescription`, `MONDESC` will be in the wiki), so where `MONNAME` was, now it is `MONNAME,MONDESC`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I am currently still testing these, but the change is so trivial I think that it should probably be fine. I don't use C++, and have never contributed to Hyprland, so I might have broken something.

#### Is it ready for merging, or does it need work?

As long as Vaxry says it's fine, I'd trust.
