### PR TITLE
Fix focus not moving along when moving workspace

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2156,7 +2156,7 @@ void CCompositor::moveWorkspaceToMonitor(CWorkspace* pWorkspace, CMonitor* pMoni
         }
 
         Debug::log(LOG, "moveWorkspaceToMonitor: Plugging gap with existing {}", nextWorkspaceOnMonitorID);
-        POLDMON->changeWorkspace(nextWorkspaceOnMonitorID);
+        POLDMON->changeWorkspace(nextWorkspaceOnMonitorID, false, true, true);
     }
 
     // move the workspace

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2197,6 +2197,7 @@ void CCompositor::moveWorkspaceToMonitor(CWorkspace* pWorkspace, CMonitor* pMoni
         if (const auto PWORKSPACE = getWorkspaceByID(pMonitor->activeWorkspace); PWORKSPACE)
             getWorkspaceByID(pMonitor->activeWorkspace)->startAnim(false, false);
 
+        setActiveMonitor(pMonitor);
         pMonitor->activeWorkspace = pWorkspace->m_iID;
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(pMonitor->ID);
 

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -571,8 +571,8 @@ void CMonitor::changeWorkspace(CWorkspace* const pWorkspace, bool internal, bool
     g_pCompositor->updateSuspendedStates();
 }
 
-void CMonitor::changeWorkspace(const int& id, bool internal) {
-    changeWorkspace(g_pCompositor->getWorkspaceByID(id), internal);
+void CMonitor::changeWorkspace(const int& id, bool internal, bool noMouseMove, bool noFocus) {
+    changeWorkspace(g_pCompositor->getWorkspaceByID(id), internal, noMouseMove, noFocus);
 }
 
 void CMonitor::setSpecialWorkspace(CWorkspace* const pWorkspace) {

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -142,7 +142,7 @@ class CMonitor {
     bool     isMirror();
     float    getDefaultScale();
     void     changeWorkspace(CWorkspace* const pWorkspace, bool internal = false, bool noMouseMove = false, bool noFocus = false);
-    void     changeWorkspace(const int& id, bool internal = false);
+    void     changeWorkspace(const int& id, bool internal = false, bool noMouseMove = false, bool noFocus = false);
     void     setSpecialWorkspace(CWorkspace* const pWorkspace);
     void     setSpecialWorkspace(const int& id);
     void     moveTo(const Vector2D& pos);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1459,14 +1459,18 @@ void CKeybindManager::exitHyprland(std::string argz) {
 void CKeybindManager::moveCurrentWorkspaceToMonitor(std::string args) {
     CMonitor* PMONITOR = g_pCompositor->getMonitorFromString(args);
 
-    if (!PMONITOR)
+    if (!PMONITOR) {
+        Debug::log(ERR, "Ignoring moveCurrentWorkspaceToMonitor: monitor doesnt exist");
         return;
+    }
 
     // get the current workspace
     const auto PCURRENTWORKSPACE = g_pCompositor->getWorkspaceByID(g_pCompositor->m_pLastMonitor->activeWorkspace);
 
-    if (!PCURRENTWORKSPACE)
+    if (!PCURRENTWORKSPACE) {
+        Debug::log(ERR, "moveCurrentWorkspaceToMonitor invalid workspace!");
         return;
+    }
 
     g_pCompositor->moveWorkspaceToMonitor(PCURRENTWORKSPACE, PMONITOR);
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Closes #4459

Previously when you were using `movecurrentworkspacetomonitor`, the window and workspace focus would not carry over, while the cursor would.
Switching the old monitor to a different workspace would move the focus to that workspace.
The compositor would also not update the active monitor which would prevent us from using relative monitor positions to move it back to where it was.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I am not sure if `moveworkspacetomonitor` was also affected by this.

#### Is it ready for merging, or does it need work?

Should be ready to merge!
