### PR TITLE
fix: remove hardcoded hyprctl commands.

### DIFF
--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -371,73 +371,12 @@ int main(int argc, char** argv) {
 
     if (fullRequest.contains("/--batch"))
         batchRequest(fullRequest);
-    else if (fullRequest.contains("/monitors"))
-        request(fullRequest);
-    else if (fullRequest.contains("/clients"))
-        request(fullRequest);
-    else if (fullRequest.contains("/workspaces"))
-        request(fullRequest);
-    else if (fullRequest.contains("/activeworkspace"))
-        request(fullRequest);
-    else if (fullRequest.contains("/workspacerules"))
-        request(fullRequest);
-    else if (fullRequest.contains("/activewindow"))
-        request(fullRequest);
-    else if (fullRequest.contains("/layers"))
-        request(fullRequest);
-    else if (fullRequest.contains("/version"))
-        request(fullRequest);
-    else if (fullRequest.contains("/kill"))
-        request(fullRequest);
-    else if (fullRequest.contains("/systeminfo"))
-        request(fullRequest);
-    else if (fullRequest.contains("/splash"))
-        request(fullRequest);
-    else if (fullRequest.contains("/devices"))
-        request(fullRequest);
-    else if (fullRequest.contains("/reload"))
-        request(fullRequest);
-    else if (fullRequest.contains("/getoption"))
-        request(fullRequest);
-    else if (fullRequest.contains("/binds"))
-        request(fullRequest);
-    else if (fullRequest.contains("/cursorpos"))
-        request(fullRequest);
-    else if (fullRequest.contains("/animations"))
-        request(fullRequest);
-    else if (fullRequest.contains("/globalshortcuts"))
-        request(fullRequest);
-    else if (fullRequest.contains("/rollinglog"))
-        request(fullRequest);
-    else if (fullRequest.contains("/switchxkblayout"))
-        request(fullRequest, 2);
-    else if (fullRequest.contains("/seterror"))
-        request(fullRequest, 1);
-    else if (fullRequest.contains("/setprop"))
-        request(fullRequest, 3);
-    else if (fullRequest.contains("/plugin"))
-        request(fullRequest, 1);
-    else if (fullRequest.contains("/notify"))
-        request(fullRequest, 2);
-    else if (fullRequest.contains("/output"))
-        request(fullRequest, 2);
-    else if (fullRequest.contains("/setcursor"))
-        request(fullRequest, 1);
-    else if (fullRequest.contains("/dispatch"))
-        request(fullRequest, 1);
-    else if (fullRequest.contains("/keyword"))
-        request(fullRequest, 2);
-    else if (fullRequest.contains("/decorations"))
-        request(fullRequest, 1);
     else if (fullRequest.contains("/hyprpaper"))
         requestHyprpaper(fullRequest);
-    else if (fullRequest.contains("/layouts"))
-        request(fullRequest);
     else if (fullRequest.contains("/--help"))
         printf("%s", USAGE.c_str());
     else {
-        printf("%s\n", USAGE.c_str());
-        return 1;
+        request(fullRequest);
     }
 
     printf("\n");

--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -373,6 +373,26 @@ int main(int argc, char** argv) {
         batchRequest(fullRequest);
     else if (fullRequest.contains("/hyprpaper"))
         requestHyprpaper(fullRequest);
+    else if (fullRequest.contains("/switchxkblayout"))
+        request(fullRequest, 2);
+    else if (fullRequest.contains("/seterror"))
+        request(fullRequest, 1);
+    else if (fullRequest.contains("/setprop"))
+        request(fullRequest, 3);
+    else if (fullRequest.contains("/plugin"))
+        request(fullRequest, 1);
+    else if (fullRequest.contains("/notify"))
+        request(fullRequest, 2);
+    else if (fullRequest.contains("/output"))
+        request(fullRequest, 2);
+    else if (fullRequest.contains("/setcursor"))
+        request(fullRequest, 1);
+    else if (fullRequest.contains("/dispatch"))
+        request(fullRequest, 1);
+    else if (fullRequest.contains("/keyword"))
+        request(fullRequest, 2);
+    else if (fullRequest.contains("/decorations"))
+        request(fullRequest, 1);
     else if (fullRequest.contains("/--help"))
         printf("%s", USAGE.c_str());
     else {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Removed hardcoded commands from hyprctl. This allows plugins to properly register hyprctl commands.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I don't know if there was a reason why hyprctl commands were hardcoded

#### Is it ready for merging, or does it need work?
Ready to merge

