### PR TITLE
Fix hyprctl --batch treating empty curitem as last request

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -962,7 +962,7 @@ std::string dispatchBatch(eHyprCtlOutputFormat format, std::string request) {
 
     nextItem();
 
-    while (curitem != "") {
+    while (curitem != "" || request != "") {
         reply += g_pHyprCtl->getReply(curitem);
 
         nextItem();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Lets empty requests through `hyprctl --batch` when these empty requests are inbetween proper ones. E.g: 
`hyprctl --batch "dispatch togglespecialworkspace; ; dispatch exit"`
Addresses [issue #2347](https://github.com/hyprwm/Hyprland/issues/2347).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.

#### Is it ready for merging, or does it need work?
Tested it, doesn't seem to break anything.

