### PR TITLE
Add option for animating workspaces as an infinite band

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -432,6 +432,7 @@ CConfigManager::CConfigManager() {
 
     m_pConfig->addConfigValue("animations:enabled", {1L});
     m_pConfig->addConfigValue("animations:first_launch_animation", {1L});
+    m_pConfig->addConfigValue("animations:workspace_wraparound", {0L});
 
     m_pConfig->addConfigValue("input:follow_mouse", {1L});
     m_pConfig->addConfigValue("input:mouse_refocus", {1L});

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -521,6 +521,15 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
     return result;
 }
 
+std::optional<bool> isWorkspaceChangeDirectionLeft(const std::string& args) {
+    if ((args[0] == '-' || args[0] == '+') && isNumber(args.substr(1)))
+        return args[0] == '+';
+    else if ((args[0] == 'r' || args[0] == 'm' || args[0] == 'e') && (args[1] == '-' || args[1] == '+') && isNumber(args.substr(2)))
+        return args[1] == '+';
+    else
+        return {};
+}
+
 std::optional<std::string> cleanCmdForWorkspace(const std::string& inWorkspaceName, std::string dirtyCmd) {
 
     std::string cmd = removeBeginEndSpacesTabs(dirtyCmd);

--- a/src/helpers/MiscFunctions.hpp
+++ b/src/helpers/MiscFunctions.hpp
@@ -22,6 +22,7 @@ bool                             isNumber(const std::string&, bool allowfloat = 
 bool                             isDirection(const std::string&);
 bool                             isDirection(const char&);
 int                              getWorkspaceIDFromString(const std::string&, std::string&);
+std::optional<bool>              isWorkspaceChangeDirectionLeft(const std::string&);
 std::optional<std::string>       cleanCmdForWorkspace(const std::string&, std::string);
 float                            vecToRectDistanceSquared(const Vector2D& vec, const Vector2D& p1, const Vector2D& p2);
 void                             logSystemInfo();

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -536,7 +536,7 @@ float CMonitor::getDefaultScale() {
     return 1;
 }
 
-void CMonitor::changeWorkspace(CWorkspace* const pWorkspace, bool internal, bool noMouseMove, bool noFocus) {
+void CMonitor::changeWorkspace(CWorkspace* const pWorkspace, bool internal, bool noMouseMove, bool noFocus, std::optional<bool> animateLeftOverride) {
     if (!pWorkspace)
         return;
 
@@ -556,7 +556,7 @@ void CMonitor::changeWorkspace(CWorkspace* const pWorkspace, bool internal, bool
     activeWorkspace = pWorkspace->m_iID;
 
     if (!internal) {
-        const auto ANIMTOLEFT = pWorkspace->m_iID > POLDWORKSPACE->m_iID;
+        const auto ANIMTOLEFT = animateLeftOverride.value_or(pWorkspace->m_iID > POLDWORKSPACE->m_iID);
         POLDWORKSPACE->startAnim(false, ANIMTOLEFT);
         pWorkspace->startAnim(true, ANIMTOLEFT);
 

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -142,7 +142,7 @@ class CMonitor {
     bool     isMirror();
     bool     matchesStaticSelector(const std::string& selector) const;
     float    getDefaultScale();
-    void     changeWorkspace(CWorkspace* const pWorkspace, bool internal = false, bool noMouseMove = false, bool noFocus = false);
+    void     changeWorkspace(CWorkspace* const pWorkspace, bool internal = false, bool noMouseMove = false, bool noFocus = false, std::optional<bool> animateLeftOverride = {});
     void     changeWorkspace(const int& id, bool internal = false, bool noMouseMove = false, bool noFocus = false);
     void     setSpecialWorkspace(CWorkspace* const pWorkspace);
     void     setSpecialWorkspace(const int& id);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -895,6 +895,7 @@ void CKeybindManager::changeworkspace(std::string args) {
     static auto* const PBACKANDFORTH         = (Hyprlang::INT* const*)g_pConfigManager->getConfigValuePtr("binds:workspace_back_and_forth");
     static auto* const PALLOWWORKSPACECYCLES = (Hyprlang::INT* const*)g_pConfigManager->getConfigValuePtr("binds:allow_workspace_cycles");
     static auto* const PWORKSPACECENTERON    = (Hyprlang::INT* const*)g_pConfigManager->getConfigValuePtr("binds:workspace_center_on");
+    static auto* const PWORKSPACEWRAPAROUND  = (Hyprlang::INT* const*)g_pConfigManager->getConfigValuePtr("animations:workspace_wraparound");
 
     const auto         PMONITOR = g_pCompositor->m_pLastMonitor;
 
@@ -955,7 +956,12 @@ void CKeybindManager::changeworkspace(std::string args) {
 
     g_pCompositor->setActiveMonitor(PMONITORWORKSPACEOWNER);
 
-    PMONITORWORKSPACEOWNER->changeWorkspace(pWorkspaceToChangeTo, false, true);
+    if (**PWORKSPACEWRAPAROUND) {
+        const auto ANIMATELEFT = isWorkspaceChangeDirectionLeft(args);
+        PMONITORWORKSPACEOWNER->changeWorkspace(pWorkspaceToChangeTo, false, true, false, ANIMATELEFT);
+    } else {
+        PMONITORWORKSPACEOWNER->changeWorkspace(pWorkspaceToChangeTo, false, true);
+    }
 
     if (PMONITOR != PMONITORWORKSPACEOWNER) {
         Vector2D middle = PMONITORWORKSPACEOWNER->middle();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

fix:  #4527

Adds an option for animating workspaces with the `workspace` dispatcher in a wraparound mode:
![image](https://github.com/hyprwm/Hyprland/assets/39028343/1f6f1d54-17c6-4955-a50a-141cafe4e05d)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Credit for the name `animations:workspace_wraparound` goes to @KoyeBosh.

#### Is it ready for merging, or does it need work?

- [x] Wiki PR.