### PR TITLE
fix: typo on defaultConfig.hpp

### DIFF
--- a/src/config/defaultConfig.hpp
+++ b/src/config/defaultConfig.hpp
@@ -51,7 +51,7 @@ input {
         natural_scroll = no
     }
 
-    sensitivity = 0 # -1.0 - 1.0, 0 means no modification.
+    sensitivity = 0 # -1.0 to 1.0, 0 means no modification.
 }
 
 general {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fix a minuscule typo. This reflects the respective wiki [content](https://wiki.hyprland.org/Configuring/Variables/#input)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I hope this is the intended correction

#### Is it ready for merging, or does it need work?
I guess it's ready

