### PR TITLE
dwindle: add swapsplit dispatcher

### DIFF
--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -996,6 +996,8 @@ std::any CHyprDwindleLayout::layoutMessage(SLayoutMessageHeader header, std::str
     const auto ARGS = CVarList(message, 0, ' ');
     if (ARGS[0] == "togglesplit") {
         toggleSplit(header.pWindow);
+    } else if (ARGS[0] == "swapsplit") {
+        swapSplit(header.pWindow);
     } else if (ARGS[0] == "preselect") {
         std::string direction = ARGS[1];
 
@@ -1045,6 +1047,20 @@ void CHyprDwindleLayout::toggleSplit(CWindow* pWindow) {
         return;
 
     PNODE->pParent->splitTop = !PNODE->pParent->splitTop;
+
+    PNODE->pParent->recalcSizePosRecursive();
+}
+
+void CHyprDwindleLayout::swapSplit(CWindow* pWindow) {
+    const auto PNODE = getNodeFromWindow(pWindow);
+
+    if (!PNODE || !PNODE->pParent)
+        return;
+
+    if (pWindow->m_bIsFullscreen)
+        return;
+
+    std::swap(PNODE->pParent->children[0], PNODE->pParent->children[1]);
 
     PNODE->pParent->recalcSizePosRecursive();
 }

--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -83,6 +83,7 @@ class CHyprDwindleLayout : public IHyprLayout {
     SDwindleNodeData*       getMasterNodeOnWorkspace(const int&);
 
     void                    toggleSplit(CWindow*);
+    void                    swapSplit(CWindow*);
 
     eDirection              overrideDirection = DIRECTION_DEFAULT;
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -39,6 +39,7 @@ CKeybindManager::CKeybindManager() {
     m_mDispatchers["changegroupactive"]              = changeGroupActive;
     m_mDispatchers["movegroupwindow"]                = moveGroupWindow;
     m_mDispatchers["togglesplit"]                    = toggleSplit;
+    m_mDispatchers["swapsplit"]                      = swapSplit;
     m_mDispatchers["splitratio"]                     = alterSplitRatio;
     m_mDispatchers["focusmonitor"]                   = focusMonitor;
     m_mDispatchers["movecursortocorner"]             = moveCursorToCorner;
@@ -1284,6 +1285,21 @@ void CKeybindManager::toggleSplit(std::string args) {
         return;
 
     g_pLayoutManager->getCurrentLayout()->layoutMessage(header, "togglesplit");
+}
+
+void CKeybindManager::swapSplit(std::string args) {
+    SLayoutMessageHeader header;
+    header.pWindow = g_pCompositor->m_pLastWindow;
+
+    if (!header.pWindow)
+        return;
+
+    const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(header.pWindow->m_iWorkspaceID);
+
+    if (PWORKSPACE->m_bHasFullscreenWindow)
+        return;
+
+    g_pLayoutManager->getCurrentLayout()->layoutMessage(header, "swapsplit");
 }
 
 void CKeybindManager::alterSplitRatio(std::string args) {

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -127,6 +127,7 @@ class CKeybindManager {
     static void     alterSplitRatio(std::string);
     static void     focusMonitor(std::string);
     static void     toggleSplit(std::string);
+    static void     swapSplit(std::string);
     static void     moveCursorToCorner(std::string);
     static void     moveCursor(std::string);
     static void     workspaceOpt(std::string);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Adds a new `dwindle` command, mirroring functionality available in other bspwm-inspired tiling window managers.

Fixes: https://github.com/hyprwm/Hyprland/issues/4701

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I tested it, including corner cases (e.g. no windows, only single window) and it works perfectly. Code copied almost verbatim from `togglesplit`, so I don't imagine there being much of an issue otherwise.

#### Is it ready for merging, or does it need work?

Ready for merge, though needs a documentation update (which apparently lives outside the repo?)