### PR TITLE
windowrules: add 'solo' rule

### DIFF
--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -169,6 +169,7 @@ struct SWindowRule {
     int         bFullscreen  = -1;
     int         bPinned      = -1;
     int         bFocus       = -1;
+    int         bSolo        = -1;
     int         iOnWorkspace = -1;
     std::string szWorkspace  = ""; // empty means any
 };


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This adds a new window rule which matches a window if and only if it is the only non-floating window visible. Alternatively, it matches the window only if it is the 'root' of the layout tree.

See https://github.com/hyprwm/Hyprland/issues/2324

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This is not necessarily the most elegant way of handling this condition. Perhaps it would be better to allow directly querying the number of floating / non-floating windows on the workspace, for example. That would allow encoding this rule with 'fullscreen:1` and `onworkspacenonfloating:1` (as two separate window rules).

But, I can't think of a good name for the "on workspace but non floating" rule. Maybe it would be better to instead generalize this substantially, so we could encode conditions in a more flexible way. But that is probably out-of-scope for this change.

#### Is it ready for merging, or does it need work?

Tested and working but see above.