### PR TITLE
Update splash text properties to be configurable

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -293,6 +293,8 @@ CConfigManager::CConfigManager() {
 
     m_pConfig->addConfigValue("misc:disable_hyprland_logo", {0L});
     m_pConfig->addConfigValue("misc:disable_splash_rendering", {0L});
+    m_pConfig->addConfigValue("misc:col.splash", {0xffffffffL});
+    m_pConfig->addConfigValue("misc:splash_font_family", {"Sans"});
     m_pConfig->addConfigValue("misc:force_default_wallpaper", {-1L});
     m_pConfig->addConfigValue("misc:vfr", {1L});
     m_pConfig->addConfigValue("misc:vrr", {0L});

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1912,16 +1912,16 @@ void CHyprOpenGLImpl::renderMirrored() {
 }
 
 void CHyprOpenGLImpl::renderSplash(cairo_t* const CAIRO, cairo_surface_t* const CAIROSURFACE, double offsetY, const Vector2D& size) {
-    static auto* const PSPLASHCOLOR = &g_pConfigManager->getConfigValuePtr("misc:col.splash")->intValue;
+    static auto* const PSPLASHCOLOR = (Hyprlang::INT* const*)g_pConfigManager->getConfigValuePtr("misc:col.splash");
 
-    static auto* const PSPLASHFONT = &g_pConfigManager->getConfigValuePtr("misc:splash_font_family")->strValue;
+    static auto* const PSPLASHFONT = (Hyprlang::STRING const*)g_pConfigManager->getConfigValuePtr("misc:splash_font_family");
 
-    cairo_select_font_face(CAIRO, PSPLASHFONT->c_str(), CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
+    cairo_select_font_face(CAIRO, *PSPLASHFONT, CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
 
     const auto FONTSIZE = (int)(size.y / 76);
     cairo_set_font_size(CAIRO, FONTSIZE);
 
-    const auto COLOR = CColor(*PSPLASHCOLOR);
+    const auto COLOR = CColor(**PSPLASHCOLOR);
 
     cairo_set_source_rgba(CAIRO, COLOR.r, COLOR.g, COLOR.b, COLOR.a);
 
@@ -2019,7 +2019,7 @@ void CHyprOpenGLImpl::createBGTextureForMonitor(CMonitor* pMonitor) {
     cairo_set_source_surface(CAIRO, CAIROISURFACE, 0, 0);
     cairo_paint(CAIRO);
 
-    if (!*PNOSPLASH)
+    if (!**PNOSPLASH)
         renderSplash(CAIRO, CAIROSURFACE, origin.y * WPRATIO / MONRATIO * scale, IMAGESIZE);
 
     cairo_surface_flush(CAIROSURFACE);

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1912,12 +1912,18 @@ void CHyprOpenGLImpl::renderMirrored() {
 }
 
 void CHyprOpenGLImpl::renderSplash(cairo_t* const CAIRO, cairo_surface_t* const CAIROSURFACE, double offsetY, const Vector2D& size) {
-    cairo_select_font_face(CAIRO, "Sans", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
+    static auto* const PSPLASHCOLOR = &g_pConfigManager->getConfigValuePtr("misc:col.splash")->intValue;
+
+    static auto* const PSPLASHFONT = &g_pConfigManager->getConfigValuePtr("misc:splash_font_family")->strValue;
+
+    cairo_select_font_face(CAIRO, PSPLASHFONT->c_str(), CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
 
     const auto FONTSIZE = (int)(size.y / 76);
     cairo_set_font_size(CAIRO, FONTSIZE);
 
-    cairo_set_source_rgba(CAIRO, 1.0, 1.0, 1.0, 0.32);
+    const auto COLOR = CColor(*PSPLASHCOLOR);
+
+    cairo_set_source_rgba(CAIRO, COLOR.r, COLOR.g, COLOR.b, COLOR.a);
 
     cairo_text_extents_t textExtents;
     cairo_text_extents(CAIRO, g_pCompositor->m_szCurrentSplash.c_str(), &textExtents);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
I like the splash text that renders over my wallpaper. However, this text does not follow the theme I configured for the rest of my system. I have added the ability to configure the splash text's font and color properties. This change includes adding new configuration values for the splash screen color and font. The rendering of the splash screen is also adjusted to use these new config values, allowing for easy customization of the splash text appearance.

The config values have been placed under the `misc` section, with the keys `col.splash` and `splash_font_family` for each of the new settings.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I have done limited testing on this capability, but so far it seems like it works without issues for a range of color values. 

Regarding fonts, I haven't done any testing regarding what happens when an invalid font is utilized.

#### Is it ready for merging, or does it need work?
Other than the testing issues, I think it's pretty much ready for merging. The changes are pretty small, so hopefully there's not much room for error.

