### PR TITLE
Fullscreen without sending fullscreen to application, fixes #1817

### DIFF
--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -1064,7 +1064,7 @@ bool CWindow::canBeTorn() {
 
 bool CWindow::shouldSendFullscreenState() {
     const auto MODE = g_pCompositor->getWorkspaceByID(m_iWorkspaceID)->m_efFullscreenMode;
-    return m_bFakeFullscreenState || (m_bIsFullscreen && (MODE == FULLSCREEN_FULL));
+    return m_bDontSendFullscreen ? false : (m_bFakeFullscreenState || (m_bIsFullscreen && (MODE == FULLSCREEN_FULL)));
 }
 
 void CWindow::setSuspended(bool suspend) {

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -240,16 +240,17 @@ class CWindow {
     bool        m_bIsPseudotiled = false;
     Vector2D    m_vPseudoSize    = Vector2D(0, 0);
 
-    bool        m_bFirstMap      = false; // for layouts
-    bool        m_bIsFloating    = false;
-    bool        m_bDraggingTiled = false; // for dragging around tiled windows
-    bool        m_bIsFullscreen  = false;
-    bool        m_bWasMaximized  = false;
-    uint64_t    m_iMonitorID     = -1;
-    std::string m_szTitle        = "";
-    std::string m_szInitialTitle = "";
-    std::string m_szInitialClass = "";
-    int         m_iWorkspaceID   = -1;
+    bool        m_bFirstMap           = false; // for layouts
+    bool        m_bIsFloating         = false;
+    bool        m_bDraggingTiled      = false; // for dragging around tiled windows
+    bool        m_bIsFullscreen       = false;
+    bool        m_bDontSendFullscreen = false;
+    bool        m_bWasMaximized       = false;
+    uint64_t    m_iMonitorID          = -1;
+    std::string m_szTitle             = "";
+    std::string m_szInitialTitle      = "";
+    std::string m_szInitialClass      = "";
+    int         m_iWorkspaceID        = -1;
 
     bool        m_bIsMapped = false;
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -964,6 +964,12 @@ void CKeybindManager::fullscreenActive(std::string args) {
     if (g_pCompositor->isWorkspaceSpecial(PWINDOW->m_iWorkspaceID))
         return;
 
+    PWINDOW->m_bDontSendFullscreen = false;
+    if (args == "2") {
+        PWINDOW->m_bDontSendFullscreen = true;
+        g_pCompositor->setWindowFullscreen(PWINDOW, !PWINDOW->m_bIsFullscreen, FULLSCREEN_FULL);
+        return;
+    }
     g_pCompositor->setWindowFullscreen(PWINDOW, !PWINDOW->m_bIsFullscreen, args == "1" ? FULLSCREEN_MAXIMIZED : FULLSCREEN_FULL);
 }
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -965,11 +965,8 @@ void CKeybindManager::fullscreenActive(std::string args) {
         return;
 
     PWINDOW->m_bDontSendFullscreen = false;
-    if (args == "2") {
+    if (args == "2")
         PWINDOW->m_bDontSendFullscreen = true;
-        g_pCompositor->setWindowFullscreen(PWINDOW, !PWINDOW->m_bIsFullscreen, FULLSCREEN_FULL);
-        return;
-    }
     g_pCompositor->setWindowFullscreen(PWINDOW, !PWINDOW->m_bIsFullscreen, args == "1" ? FULLSCREEN_MAXIMIZED : FULLSCREEN_FULL);
 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes #1817
Adds option to fullscreen dispatcher so you can fullscreen an application to cover your entire screen without telling the application, useful for fullscreening chromium and keeping the tab bar.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready

