### PR TITLE
feat: Allow passing a window argument to the moveoutofgroup dispatcher

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -797,7 +797,7 @@ void CKeybindManager::clearKeybinds() {
 void CKeybindManager::toggleActiveFloating(std::string args) {
     CWindow* PWINDOW = nullptr;
 
-    if (args != "" && args != "active" && args.length() > 1)
+    if (args != "active" && args.length() > 1)
         PWINDOW = g_pCompositor->getWindowByRegex(args);
     else
         PWINDOW = g_pCompositor->m_pLastWindow;
@@ -1938,7 +1938,7 @@ void CKeybindManager::pinActive(std::string args) {
 
     CWindow* PWINDOW = nullptr;
 
-    if (args != "" && args != "active" && args.length() > 1)
+    if (args != "active" && args.length() > 1)
         PWINDOW = g_pCompositor->getWindowByRegex(args);
     else
         PWINDOW = g_pCompositor->m_pLastWindow;
@@ -2179,7 +2179,7 @@ void CKeybindManager::moveOutOfGroup(std::string args) {
 
     CWindow* PWINDOW = nullptr;
 
-    if (args != "" && args != "active" && args.length() > 1)
+    if (args != "active" && args.length() > 1)
         PWINDOW = g_pCompositor->getWindowByRegex(args);
     else
         PWINDOW = g_pCompositor->m_pLastWindow;

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2177,7 +2177,12 @@ void CKeybindManager::moveOutOfGroup(std::string args) {
     if (!*PIGNOREGROUPLOCK && g_pKeybindManager->m_bGroupsLocked)
         return;
 
-    const auto PWINDOW = g_pCompositor->m_pLastWindow;
+    CWindow* PWINDOW = nullptr;
+
+    if (args != "" && args != "active" && args.length() > 1)
+        PWINDOW = g_pCompositor->getWindowByRegex(args);
+    else
+        PWINDOW = g_pCompositor->m_pLastWindow;
 
     if (!PWINDOW || !PWINDOW->m_sGroupData.pNextWindow)
         return;


### PR DESCRIPTION
Very simple change that allows for moving a specific window out of a group. It follows the same convention as the `pin` and `togglefloating` dispatchers by accepting either no args or "active" to act on the focused windows and still remain backwards compatible