### PR TITLE
Fix outputmgr nullptr crash (kanshi/shikane like tools)

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -881,6 +881,16 @@ CMonitor* CCompositor::getMonitorFromOutput(wlr_output* out) {
     return nullptr;
 }
 
+CMonitor* CCompositor::getRealMonitorFromOutput(wlr_output* out) {
+    for (auto& m : m_vRealMonitors) {
+        if (m->output == out) {
+            return m.get();
+        }
+    }
+
+    return nullptr;
+}
+
 void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
 
     static auto* const PFOLLOWMOUSE        = &g_pConfigManager->getConfigValuePtr("input:follow_mouse")->intValue;

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -142,6 +142,7 @@ class CCompositor {
     wlr_surface*   vectorWindowToSurface(const Vector2D&, CWindow*, Vector2D& sl);
     Vector2D       vectorToSurfaceLocal(const Vector2D&, CWindow*, wlr_surface*);
     CMonitor*      getMonitorFromOutput(wlr_output*);
+    CMonitor*      getRealMonitorFromOutput(wlr_output*);
     CWindow*       getWindowForPopup(wlr_xdg_popup*);
     CWindow*       getWindowFromSurface(wlr_surface*);
     CWindow*       getWindowFromHandle(uint32_t);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1340,8 +1340,6 @@ void CHyprRenderer::outputMgrApplyTest(wlr_output_configuration_v1* config, bool
 
         std::string commandForCfg = "";
         const auto  OUTPUT        = head->state.output;
-        const auto  PMONITOR      = g_pCompositor->getMonitorFromOutput(OUTPUT);
-        RASSERT(PMONITOR, "nullptr monitor in outputMgrApplyTest");
 
         commandForCfg += std::string(OUTPUT->name) + ",";
 
@@ -1352,6 +1350,8 @@ void CHyprRenderer::outputMgrApplyTest(wlr_output_configuration_v1* config, bool
             continue;
         }
 
+        const auto PMONITOR = g_pCompositor->getRealMonitorFromOutput(OUTPUT);
+        RASSERT(PMONITOR, "nullptr monitor in outputMgrApplyTest");
         wlr_output_state_set_enabled(PMONITOR->state.wlr(), head->state.enabled);
 
         if (head->state.mode)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This PR fixes two (related) issues:
1. fixes `nullptr` crash in `outputmgr` when using `kanshictl reload` repeteadly;
2. fixes `nullptr` crash in `outputmgr` when using `kanshictl switch` to re-enable a disabled monitor (laptop's internal)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
The main thing here is that in `outputMgrApplyTest` we might get disabled monitors, and thus we should look into the `realMonitors` vector.  
I didn't check whether other code relying on `Compositor::getMonitorFromOutput` was well-managing disabled outputs, so I decided to create another `Compositor::getRealMonitorFromOutput` method. Maybe this can be changed, let me know

#### Is it ready for merging, or does it need work?
see above

