### PR TITLE
fix: keys without keysyms triggering random binds

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -510,7 +510,19 @@ bool CKeybindManager::handleKeybinds(const uint32_t modmask, const SPressedKeyWi
         } else {
             // oMg such performance hit!!11!
             // this little maneouver is gonna cost us 4µs
-            const auto KBKEY      = xkb_keysym_from_name(k.key.c_str(), XKB_KEYSYM_CASE_INSENSITIVE);
+            const auto KBKEY = xkb_keysym_from_name(k.key.c_str(), XKB_KEYSYM_CASE_INSENSITIVE);
+
+            if (KBKEY == 0) {
+                // Keysym failed to resolve from the key name of the the currently iterated bind.
+                // This happens for names such as `switch:off:Lid Switch` as well as some keys
+                // (such as yen and ro).
+                //
+                // We can't let compare a 0-value with currently pressed key below,
+                // because if this key also have no keysym (i.e. key.keysym == 0) it will incorrectly trigger the
+                // currently iterated bind. That's confirmed to be happening with yen and ro keys.
+                continue;
+            }
+
             const auto KBKEYUPPER = xkb_keysym_to_upper(KBKEY);
 
             if (key.keysym != KBKEY && key.keysym != KBKEYUPPER)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes https://github.com/hyprwm/Hyprland/issues/4667

In #4667 it was deducted that only yen and ro keys are buggy, so I remapped my keyboard to be able to output yen key. In Hyprland I debug-logged yen key when passed to `handleKeybinds` it turns out its keysym can't be resolved correctly for some reason. So it's keysym is 0-value: 
```
key.keyName: ""
key.keycode: 248
key.keysym: 0
```

In `handleKeybinds` some keybinds kinda incorrectly take the `else` branch from the `if-elseif-else` conditional, e.g. `switch:off:Lid Switch` as in this branch `xkb_keysym_from_name` is called on them and that results in `KBKEY = 0`. That is later compared to keysym of current key event and voila - for yen/ro key it will be `0 == 0` comparison here and it will incorrectly trigger currenlty iterated keybind https://github.com/hyprwm/Hyprland/blob/b36a2009d2f400e0564af8cf6c5ec0d8e80523b5/src/managers/KeybindManager.cpp#L528-L529  

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Honestly, I'm still not sure why 37b76cd made that regression, and I've already spent too much time trying to figure it out with no results, so I moved on and instead tried to fix it based on what we know about the bug.

#### Is it ready for merging, or does it need work?

Waiting for @pschmitt to confirm it's fixed, then should be good to go.