### PR TITLE
master layout: change the mfact dispatcher to use splitratio

### DIFF
--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -1314,19 +1314,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
     } else if (command == "orientationcycle") {
         runOrientationCycle(header, &vars, 1);
     } else if (command == "mfact") {
-        if (vars.size() >= 2) {
-            float newMfact = 0;
-            try {
-                newMfact = std::stof(vars[1]);
-            } catch (std::exception& e) {
-                Debug::log(ERR, "Argument is invalid: {}", e.what());
-                return 0;
-            }
-            for (auto& nd : m_lMasterNodesData) {
-                if (nd.isMaster)
-                    nd.percMaster = std::clamp(newMfact, 0.05f, 0.95f);
-            }
-        }
+        g_pKeybindManager->m_mDispatchers["splitratio"](vars[1] + vars[2]);
     } else if (command == "rollnext") {
         const auto PWINDOW = header.pWindow;
         const auto PNODE   = getNodeFromWindow(PWINDOW);

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -1314,7 +1314,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
     } else if (command == "orientationcycle") {
         runOrientationCycle(header, &vars, 1);
     } else if (command == "mfact") {
-        g_pKeybindManager->m_mDispatchers["splitratio"](vars[1] + vars[2]);
+        g_pKeybindManager->m_mDispatchers["splitratio"](vars[1] + " " + vars[2]);
     } else if (command == "rollnext") {
         const auto PWINDOW = header.pWindow;
         const auto PNODE   = getNodeFromWindow(PWINDOW);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Change the mfact dispatcher to use split ratio, allowing increment/decrement.
I realized this dispatcher does the same thing as `splitratio`, so I'm just changing it to call the latter, this allows you to increment/decrement the mfact in addition to only being able to set the exact mfact.

I also thought about just removing it since splitratio exists, but the splitratio dispatcher is really confusing, as it does two different and not necessarily related things in dwindle and master. You also wont find it in the master layout wiki when you look for it since it's not a layout specific dispatcher, but it kinda should be imo. The mfact is a very layout-specific config that is specific to master, and you usually won't look in the universal dispatchers for such a thing, and it's not clear that splitratio changes the mfact in master. I think it would make more sense in the future to have two different dispatchers separately in dwindle and master that will do what this `splitratio` dispatcher does. Having a dispatcher for the mfact itself seems much more easier to understand. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Needs wiki mr

#### Is it ready for merging, or does it need work?


