### PR TITLE
compositor: fix null pointer exception

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2615,6 +2615,9 @@ void CCompositor::setActiveMonitor(CMonitor* pMonitor) {
     }
 
     const auto PWORKSPACE = getWorkspaceByID(pMonitor->activeWorkspace);
+    if (!PWORKSPACE) {
+        return;
+    }
 
     g_pEventManager->postEvent(SHyprIPCEvent{"focusedmon", pMonitor->szName + "," + PWORKSPACE->m_szName});
     EMIT_HOOK_EVENT("focusedMon", pMonitor);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Hyprland randomly crash when turning on dpms.

```
                Stack trace of thread 1795:
                #0  0x000072c1fa7bf32c n/a (libc.so.6 + 0x8d32c)
                #1  0x000072c1fa76e6c8 raise (libc.so.6 + 0x3c6c8)
                #2  0x000072c1fa7564b8 abort (libc.so.6 + 0x244b8)
                #3  0x00005ebb5c43bdca _Z25handleUnrecoverableSignali (Hyprland + 0xacdca)
                #4  0x000072c1fa76e770 n/a (libc.so.6 + 0x3c770)
                #5  0x00005ebb5c4480e5 _ZN11CCompositor16setActiveMonitorEP8CMonitor (Hyprland + 0xb90e5)
                #6  0x00005ebb5c44e2ae _ZN11CCompositor22moveWorkspaceToMonitorEP10CWorkspaceP8CMonitorb (Hyprland + 0xbf2ae)
                #7  0x00005ebb5c4dd4ef _ZN8CMonitor14setupDefaultWSERK12SMonitorRule (Hyprland + 0x14e4ef)
                #8  0x00005ebb5c4de84f _ZN8CMonitor9onConnectEb (Hyprland + 0x14f84f)
                #9  0x00005ebb5c4c6d0b _ZN6Events18listener_newOutputEP11wl_listenerPv (Hyprland + 0x137d0b)
                #10 0x000072c1fb2c757e wl_signal_emit_mutable (libwayland-server.so.0 + 0xa57e)
                #11 0x000072c1fb2c757e wl_signal_emit_mutable (libwayland-server.so.0 + 0xa57e)
                #12 0x000072c1fb31b014 n/a (libwlroots.so.13032 + 0x47014)
                #13 0x000072c1fb2c757e wl_signal_emit_mutable (libwayland-server.so.0 + 0xa57e)
                #14 0x000072c1fb311419 n/a (libwlroots.so.13032 + 0x3d419)
                #15 0x000072c1fb2c97c3 wl_event_loop_dispatch (libwayland-server.so.0 + 0xc7c3)
                #16 0x000072c1fb2ca067 wl_display_run (libwayland-server.so.0 + 0xd067)
                #17 0x00005ebb5c42544e main (Hyprland + 0x9644e)
                #18 0x000072c1fa757cd0 n/a (libc.so.6 + 0x25cd0)
                #19 0x000072c1fa757d8a __libc_start_main (libc.so.6 + 0x25d8a)
                #20 0x00005ebb5c439755 _start (Hyprland + 0xaa755)
```

I use dual monitor and swayidle to dispatch dpms.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I already apply this patch and haven't got crash again.

I'm not sure what the side effect if it doesn't call `postEvent` on `listener_newOutput`

#### Is it ready for merging, or does it need work?


