### PR TITLE
Implement notification dimissing

### DIFF
--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -33,6 +33,7 @@ commands:
     cursorpos
     decorations
     devices
+    dismissnotify
     dispatch
     getoption
     globalshortcuts
@@ -385,6 +386,8 @@ int main(int argc, char** argv) {
         request(fullRequest, 3);
     else if (fullRequest.contains("/plugin"))
         request(fullRequest, 1);
+    else if (fullRequest.contains("/dismissnotify"))
+        request(fullRequest, 0);
     else if (fullRequest.contains("/notify"))
         request(fullRequest, 2);
     else if (fullRequest.contains("/output"))

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1423,6 +1423,26 @@ std::string dispatchNotify(eHyprCtlOutputFormat format, std::string request) {
     return "ok";
 }
 
+std::string dispatchDismissNotify(eHyprCtlOutputFormat format, std::string request) {
+    CVarList vars(request, 0, ' ');
+
+    int      amount = -1;
+
+    if (vars.size() > 1) {
+        const auto AMOUNT = vars[1];
+        if (!isNumber(AMOUNT))
+            return "invalid arg 1";
+
+        try {
+            amount = std::stoi(AMOUNT);
+        } catch (std::exception& e) { return "invalid arg 1"; }
+    }
+
+    g_pHyprNotificationOverlay->dismissNotifications(amount);
+
+    return "ok";
+}
+
 CHyprCtl::CHyprCtl() {
     registerCommand(SHyprCtlCommand{"workspaces", true, workspacesRequest});
     registerCommand(SHyprCtlCommand{"workspacerules", true, workspaceRulesRequest});
@@ -1446,6 +1466,7 @@ CHyprCtl::CHyprCtl() {
     registerCommand(SHyprCtlCommand{"reload", false, reloadRequest});
     registerCommand(SHyprCtlCommand{"plugin", false, dispatchPlugin});
     registerCommand(SHyprCtlCommand{"notify", false, dispatchNotify});
+    registerCommand(SHyprCtlCommand{"dismissnotify", false, dispatchDismissNotify});
     registerCommand(SHyprCtlCommand{"setprop", false, dispatchSetProp});
     registerCommand(SHyprCtlCommand{"seterror", false, dispatchSeterror});
     registerCommand(SHyprCtlCommand{"switchxkblayout", false, switchXKBLayoutRequest});

--- a/src/debug/HyprNotificationOverlay.cpp
+++ b/src/debug/HyprNotificationOverlay.cpp
@@ -50,6 +50,18 @@ void CHyprNotificationOverlay::addNotification(const std::string& text, const CC
     }
 }
 
+void CHyprNotificationOverlay::dismissNotifications(const int amount) {
+    if (amount == -1)
+        m_dNotifications.clear();
+    else {
+        const int AMT = std::min(amount, static_cast<int>(m_dNotifications.size()));
+
+        for (int i = 0; i < AMT; ++i) {
+            m_dNotifications.pop_front();
+        }
+    }
+}
+
 CBox CHyprNotificationOverlay::drawNotifications(CMonitor* pMonitor) {
     static constexpr auto ANIM_DURATION_MS   = 600.0;
     static constexpr auto ANIM_LAG_MS        = 100.0;

--- a/src/debug/HyprNotificationOverlay.hpp
+++ b/src/debug/HyprNotificationOverlay.hpp
@@ -41,6 +41,7 @@ class CHyprNotificationOverlay {
 
     void draw(CMonitor* pMonitor);
     void addNotification(const std::string& text, const CColor& color, const float timeMs, const eIcons icon = ICON_NONE);
+    void dismissNotifications(const int amount);
     bool hasAny();
 
   private:


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This adds logic for notification dismissing via hyprctl. Fixes #4787


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I'm don't really love the name `dismissnotify` for the hyprctl command. I wanted to do `notifydismiss` instead originally. 

However, I wasn't able to do that with the way command registering works now, where if there's already a `notify` command, all commands prefixed with `notify` will be handled from there. There is an `exact` option when registering, but that wouldn't allow any arguments to be passed. 

Short of changing the way this logic works, one thing that comes to mind would be `if (vars[0] == "notifydismiss")` in the `dispatchNotify` func, but I didn't see this kind of logic anywhere else in the dispatch handlers, and I'm not sure this prefix based handling was actually intended, so I chose to go with the unique `dismissnotify` name.

Another thing I will mention is that if there isn't enough notifications to dismiss, the command will still respond with `ok`, if desired, I can add some other message for this case.

#### Is it ready for merging, or does it need work?

Yes