### PR TITLE
Fixed ghost window when opened while fullscreen on a different workspace

### DIFF
--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -49,8 +49,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
     static auto* const PNEWTAKESOVERFS = (Hyprlang::INT* const*)g_pConfigManager->getConfigValuePtr("misc:new_window_takes_over_fullscreen");
 
     auto               PMONITOR = g_pCompositor->m_pLastMonitor;
-    auto               PWORKSPACE =
-        PMONITOR->specialWorkspaceID ? g_pCompositor->getWorkspaceByID(PMONITOR->specialWorkspaceID) : g_pCompositor->getWorkspaceByID(PMONITOR->activeWorkspace);
+    auto PWORKSPACE = PMONITOR->specialWorkspaceID ? g_pCompositor->getWorkspaceByID(PMONITOR->specialWorkspaceID) : g_pCompositor->getWorkspaceByID(PMONITOR->activeWorkspace);
     PWINDOW->m_iMonitorID     = PMONITOR->ID;
     PWINDOW->m_iWorkspaceID   = PMONITOR->specialWorkspaceID ? PMONITOR->specialWorkspaceID : PMONITOR->activeWorkspace;
     PWINDOW->m_bIsMapped      = true;

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -49,7 +49,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
     static auto* const PNEWTAKESOVERFS = (Hyprlang::INT* const*)g_pConfigManager->getConfigValuePtr("misc:new_window_takes_over_fullscreen");
 
     auto               PMONITOR = g_pCompositor->m_pLastMonitor;
-    const auto         PWORKSPACE =
+    auto               PWORKSPACE =
         PMONITOR->specialWorkspaceID ? g_pCompositor->getWorkspaceByID(PMONITOR->specialWorkspaceID) : g_pCompositor->getWorkspaceByID(PMONITOR->activeWorkspace);
     PWINDOW->m_iMonitorID     = PMONITOR->ID;
     PWINDOW->m_iWorkspaceID   = PMONITOR->specialWorkspaceID ? PMONITOR->specialWorkspaceID : PMONITOR->activeWorkspace;
@@ -279,6 +279,8 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
             if (!pWorkspace)
                 pWorkspace = g_pCompositor->createNewWorkspace(REQUESTEDWORKSPACEID, PWINDOW->m_iMonitorID, requestedWorkspaceName);
+
+            PWORKSPACE = pWorkspace;
 
             PWINDOW->m_iWorkspaceID = pWorkspace->m_iID;
             PWINDOW->m_iMonitorID   = pWorkspace->m_iMonitorID;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes #4687 and #4395.

When mapping a new window, we would get the current workspace into `PWORKSPACE`, then get the target workspace from rules into `pWorkspace`. And after that we check the fullscreen status of `PWORKSPACE`, so the window would not render if the origin workspace has a fullscreen window.

I re-assigned `PWORKSPACE` to the target workspace for the checks later to work with the target workspace of the window.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
Ready

