### PR TITLE
Fix SEGV/ABRT core dump when exiting

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -412,6 +412,8 @@ void CCompositor::cleanup() {
         g_pXWaylandManager->m_sWLRXWayland = nullptr;
     }
 
+    g_pInputManager.reset();
+
     removeAllSignals();
 
     wl_display_destroy_clients(g_pCompositor->m_sWLDisplay);
@@ -425,7 +427,6 @@ void CCompositor::cleanup() {
     g_pProtocolManager.reset();
     g_pHyprRenderer.reset();
     g_pHyprOpenGL.reset();
-    g_pInputManager.reset();
     g_pThreadManager.reset();
     g_pConfigManager.reset();
     g_pLayoutManager.reset();

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -412,9 +412,9 @@ void CCompositor::cleanup() {
         g_pXWaylandManager->m_sWLRXWayland = nullptr;
     }
 
-    g_pInputManager.reset();
-
     removeAllSignals();
+
+    g_pInputManager.reset();
 
     wl_display_destroy_clients(g_pCompositor->m_sWLDisplay);
 


### PR DESCRIPTION
This tries to fix the core dump issue when exiting, descirbed here: https://github.com/hyprwm/Hyprland/pull/4811#issuecomment-1961278893

Limited testing done but working so far, there might be some uncovered cases still