### PR TITLE
config: fix layout invalidation for keyword commands

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -818,16 +818,12 @@ void CConfigManager::init() {
 }
 
 std::string CConfigManager::parseKeyword(const std::string& COMMAND, const std::string& VALUE) {
-    int        needsLayoutRecalc = COMMAND == "monitor"; // 0 - no, 1 - yes, 2 - maybe
-
     const auto RET = m_pConfig->parseDynamic(COMMAND.c_str(), VALUE.c_str());
 
     // invalidate layouts if they changed
-    if (needsLayoutRecalc) {
-        if (needsLayoutRecalc == 1 || COMMAND.contains("gaps_") || COMMAND.starts_with("dwindle:") || COMMAND.starts_with("master:")) {
-            for (auto& m : g_pCompositor->m_vMonitors)
-                g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m->ID);
-        }
+    if (COMMAND == "monitor" || COMMAND.contains("gaps_") || COMMAND.starts_with("dwindle:") || COMMAND.starts_with("master:")) {
+        for (auto& m : g_pCompositor->m_vMonitors)
+            g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m->ID);
     }
 
     // Update window border colors


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Previously, using `hyprctl keyword` with `gaps`, `dwindle`, or `master` commands would not immediately apply because the layout wasn't invalidated.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready

