### PR TITLE
hyprctl: add missing newline in error case of missing `HYPRLAND_INSTA…

### DIFF
--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -367,7 +367,7 @@ int main(int argc, char** argv) {
         const auto ISIG = getenv("HYPRLAND_INSTANCE_SIGNATURE");
 
         if (!ISIG) {
-            std::cout << "HYPRLAND_INSTANCE_SIGNATURE not set! (is hyprland running?)";
+            std::cout << "HYPRLAND_INSTANCE_SIGNATURE not set! (is hyprland running?)\n";
             return 1;
         }
 


### PR DESCRIPTION
…NCE_SIGNATURE`

Before the change running a `hyprctl` in incomplete `Hyprland` environment merged error message and prompt for me as:

    $ hyprctl activewindow
    HYPRLAND_INSTANCE_SIGNATURE not set! (is hyprland running?)$

(note trailing `$` prompt).

After the change the newline is present as expected:

    $ hyprctl activewindow
    HYPRLAND_INSTANCE_SIGNATURE not set! (is hyprland running?)
    $
