### PR TITLE
compositor: allow source monitor to be provided to `getMonitorInDirec…

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1802,8 +1802,14 @@ CWindow* CCompositor::getConstraintWindow(SMouse* pMouse) {
 }
 
 CMonitor* CCompositor::getMonitorInDirection(const char& dir) {
-    const auto POSA  = m_pLastMonitor->vecPosition;
-    const auto SIZEA = m_pLastMonitor->vecSize;
+    return this->getMonitorInDirection(m_pLastMonitor, dir);
+}
+
+CMonitor* CCompositor::getMonitorInDirection(CMonitor* pSourceMonitor, const char& dir) {
+    if(!pSourceMonitor) return nullptr;
+
+    const auto POSA  = pSourceMonitor->vecPosition;
+    const auto SIZEA = pSourceMonitor->vecSize;
 
     auto       longestIntersect        = -1;
     CMonitor*  longestIntersectMonitor = nullptr;

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -171,6 +171,7 @@ class CCompositor {
     bool           isPointOnReservedArea(const Vector2D& point, const CMonitor* monitor = nullptr);
     CWindow*       getConstraintWindow(SMouse*);
     CMonitor*      getMonitorInDirection(const char&);
+    CMonitor*      getMonitorInDirection(CMonitor*, const char&);
     void           updateAllWindowsAnimatedDecorationValues();
     void           updateWorkspaceWindows(const int64_t& id);
     void           updateWindowAnimatedDecorationValues(CWindow*);


### PR DESCRIPTION
Add trivial overload for `CCompositor::getMonitorInDirection` which allows the caller to provide a source monitor, which would be useful for some plugin functionality that I'm working on [the plugin needs to directionally-determine the monitor _from an arbitrary window's perspective_]