### PR TITLE
surface: ensure global pointers valid before using in destructor

### DIFF
--- a/src/helpers/WLSurface.cpp
+++ b/src/helpers/WLSurface.cpp
@@ -83,11 +83,11 @@ void CWLSurface::destroy() {
     m_pWLRSurface->data = nullptr;
     m_pOwner            = nullptr;
 
-    if (g_pCompositor->m_pLastFocus == m_pWLRSurface)
+    if (g_pCompositor && g_pCompositor->m_pLastFocus == m_pWLRSurface)
         g_pCompositor->m_pLastFocus = nullptr;
-    if (g_pInputManager->m_pLastMouseSurface == m_pWLRSurface)
+    if (g_pInputManager && g_pInputManager->m_pLastMouseSurface == m_pWLRSurface)
         g_pInputManager->m_pLastMouseSurface = nullptr;
-    if (g_pHyprRenderer->m_sLastCursorData.surf == m_pWLRSurface)
+    if (g_pHyprRenderer && g_pHyprRenderer->m_sLastCursorData.surf == m_pWLRSurface)
         g_pHyprRenderer->m_sLastCursorData.surf.reset();
 
     m_pWLRSurface = nullptr;


### PR DESCRIPTION
This fixes an observed SigSegV resulting from the cursor surface using `g_pInputManager` when invoked from the `CInputManager` destructor.  Event chain:

- Hyprland exit dispatcher invoked
- ....
- `g_pInputManager` is destroyed
- `CInputManager::m_sCursorSurfaceInfo` is destroyed
- `cursorSI::wlSurface` is destroyed
- `WLSurface::destroy()` is invoked (from the `WLSurface` destructor)
- `g_pInputManager->m_pLastMouseSurface` is accessed by the `WLSurface`
- `g_pInputManager` is no longer valid, and a SigSegV occurs

Change is trivial, just adds a guard to `g_pInputManager` before accessing.  Also added guards to `g_pCompositor` and `g_pHyprRenderer` in case of similar cycles occurring, though I have not observed this.





