### PR TITLE
Add option to resolve keybinds by sym instead of code

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -448,6 +448,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("input:repeat_delay", {600L});
     m_pConfig->addConfigValue("input:natural_scroll", {0L});
     m_pConfig->addConfigValue("input:numlock_by_default", {0L});
+    m_pConfig->addConfigValue("input:resolve_binds_by_sym", {0L});
     m_pConfig->addConfigValue("input:force_no_accel", {0L});
     m_pConfig->addConfigValue("input:float_switch_override_focus", {1L});
     m_pConfig->addConfigValue("input:left_handed", {0L});
@@ -533,6 +534,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addSpecialConfigValue("device", "natural_scroll", {0L});
     m_pConfig->addSpecialConfigValue("device", "tap_button_map", {STRVAL_EMPTY});
     m_pConfig->addSpecialConfigValue("device", "numlock_by_default", {0L});
+    m_pConfig->addSpecialConfigValue("device", "resolve_binds_by_sym", {0L});
     m_pConfig->addSpecialConfigValue("device", "disable_while_typing", {1L});
     m_pConfig->addSpecialConfigValue("device", "clickfinger_behavior", {0L});
     m_pConfig->addSpecialConfigValue("device", "middle_button_emulation", {0L});

--- a/src/helpers/WLClasses.hpp
+++ b/src/helpers/WLClasses.hpp
@@ -127,15 +127,17 @@ struct SKeyboard {
     bool               active    = false;
     bool               enabled   = true;
 
-    xkb_layout_index_t activeLayout = 0;
+    xkb_layout_index_t activeLayout        = 0;
+    xkb_state*         xkbTranslationState = nullptr;
 
     std::string        name        = "";
     std::string        xkbFilePath = "";
 
     SStringRuleNames   currentRules;
-    int                repeatRate  = 0;
-    int                repeatDelay = 0;
-    int                numlockOn   = -1;
+    int                repeatRate        = 0;
+    int                repeatDelay       = 0;
+    int                numlockOn         = -1;
+    bool               resolveBindsBySym = false;
 
     // For the list lookup
     bool operator==(const SKeyboard& rhs) const {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -304,7 +304,7 @@ bool CKeybindManager::onKeyEvent(wlr_keyboard_key_event* e, SKeyboard* pKeyboard
 
     const auto         KEYCODE = e->keycode + 8; // Because to xkbcommon it's +8 from libinput
 
-    const xkb_keysym_t keysym         = xkb_state_key_get_one_sym(m_pXKBTranslationState, KEYCODE);
+    const xkb_keysym_t keysym         = xkb_state_key_get_one_sym(pKeyboard->resolveBindsBySym ? pKeyboard->xkbTranslationState : m_pXKBTranslationState, KEYCODE);
     const xkb_keysym_t internalKeysym = xkb_state_key_get_one_sym(wlr_keyboard_from_input_device(pKeyboard->keyboard)->xkb_state, KEYCODE);
 
     if (handleInternalKeybinds(internalKeysym))


### PR DESCRIPTION
#### Description

This commit adds the new configuration option 'resolve_binds_by_sym' which can be set globally or per-device. It is off by default, which preserves the current behavior.

This setting only affects the behavior of keybinds that are defined via key symbols, not those defined via keycode. Binds defined by symbols currently activate if the keycode pressed would generate the specified symbol on the first layout specified in the input section. If enabled, keys pressed on the relevant device will instead match keybinds by the symbols they produce with their current layout.

Closes #1881.

#### Status

This PR is ready to be merged from my end. If you'd prefer a different name for the option I'm happy to rename it.
I have prepared an appropriate update to the documentation in hyprwm/hyprland-wiki#493.
