### PR TITLE
fix: include missing header

### DIFF
--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -5,6 +5,7 @@
 #include "helpers/AnimatedVariable.hpp"
 #include "render/decorations/IHyprWindowDecoration.hpp"
 #include <deque>
+#include <list>
 #include "config/ConfigDataValues.hpp"
 #include "helpers/Vector2D.hpp"
 #include "desktop/WLSurface.hpp"


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

missing `<list>` header in `Window.hpp` prevents plugins from building:

```
...
       > /nix/store/.../include/hyprland/src/Window.hpp:213:10: error: 'list' in namespace 'std' does not name a template type
       >   213 |     std::list<CWLSurface> m_lPopupSurfaces;
       >       |          ^~~~
       > /nix/store/.../include/hyprland/src/Window.hpp:14:1: note: 'std::list' is defined in header '<list>'; did you forget to '#include <list>'?
       >    13 | #include "managers/XWaylandManager.hpp"
       >   +++ |+#include <list>
       >    14 |
       > [10/12] Compiling C++ object src/gestures/test/test-gestures.p/test.cpp.o
       > ninja: build stopped: subcommand failed.
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

-

#### Is it ready for merging, or does it need work?

yes
