### PR TITLE
animation: Refactor AnimatedVariable

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -843,7 +843,8 @@ wlr_surface* CCompositor::vectorWindowToSurface(const Vector2D& pos, CWindow* pW
     wlr_xdg_surface_get_geometry(pWindow->m_uSurface.xdg, geom.pWlr());
     geom.applyFromWlr();
 
-    const auto PFOUND = wlr_xdg_surface_surface_at(PSURFACE, pos.x - pWindow->m_vRealPosition.value().x + geom.x, pos.y - pWindow->m_vRealPosition.value().y + geom.y, &subx, &suby);
+    const auto PFOUND =
+        wlr_xdg_surface_surface_at(PSURFACE, pos.x - pWindow->m_vRealPosition.value().x + geom.x, pos.y - pWindow->m_vRealPosition.value().y + geom.y, &subx, &suby);
 
     if (PFOUND) {
         sl.x = subx;

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -843,7 +843,7 @@ wlr_surface* CCompositor::vectorWindowToSurface(const Vector2D& pos, CWindow* pW
     wlr_xdg_surface_get_geometry(pWindow->m_uSurface.xdg, geom.pWlr());
     geom.applyFromWlr();
 
-    const auto PFOUND = wlr_xdg_surface_surface_at(PSURFACE, pos.x - pWindow->m_vRealPosition.vec().x + geom.x, pos.y - pWindow->m_vRealPosition.vec().y + geom.y, &subx, &suby);
+    const auto PFOUND = wlr_xdg_surface_surface_at(PSURFACE, pos.x - pWindow->m_vRealPosition.value().x + geom.x, pos.y - pWindow->m_vRealPosition.value().y + geom.y, &subx, &suby);
 
     if (PFOUND) {
         sl.x = subx;
@@ -851,8 +851,8 @@ wlr_surface* CCompositor::vectorWindowToSurface(const Vector2D& pos, CWindow* pW
         return PFOUND;
     }
 
-    sl.x = pos.x - pWindow->m_vRealPosition.vec().x;
-    sl.y = pos.y - pWindow->m_vRealPosition.vec().y;
+    sl.x = pos.x - pWindow->m_vRealPosition.value().x;
+    sl.y = pos.y - pWindow->m_vRealPosition.value().y;
 
     sl.x += geom.x;
     sl.y += geom.y;
@@ -865,7 +865,7 @@ Vector2D CCompositor::vectorToSurfaceLocal(const Vector2D& vec, CWindow* pWindow
         return {};
 
     if (pWindow->m_bIsX11)
-        return vec - pWindow->m_vRealPosition.goalv();
+        return vec - pWindow->m_vRealPosition.goal();
 
     const auto                         PSURFACE = pWindow->m_uSurface.xdg;
 
@@ -887,9 +887,9 @@ Vector2D CCompositor::vectorToSurfaceLocal(const Vector2D& vec, CWindow* pWindow
     geom.applyFromWlr();
 
     if (std::get<1>(iterData) == -1337 && std::get<2>(iterData) == -1337)
-        return vec - pWindow->m_vRealPosition.goalv();
+        return vec - pWindow->m_vRealPosition.goal();
 
-    return vec - pWindow->m_vRealPosition.goalv() - Vector2D{std::get<1>(iterData), std::get<2>(iterData)} + Vector2D{geom.x, geom.y};
+    return vec - pWindow->m_vRealPosition.goal() - Vector2D{std::get<1>(iterData), std::get<2>(iterData)} + Vector2D{geom.x, geom.y};
 }
 
 CMonitor* CCompositor::getMonitorFromOutput(wlr_output* out) {
@@ -1123,7 +1123,7 @@ bool CCompositor::windowValidMapped(CWindow* pWindow) {
 wlr_surface* CCompositor::vectorToLayerSurface(const Vector2D& pos, std::vector<std::unique_ptr<SLayerSurface>>* layerSurfaces, Vector2D* sCoords,
                                                SLayerSurface** ppLayerSurfaceFound) {
     for (auto& ls : *layerSurfaces | std::views::reverse) {
-        if (ls->fadingOut || !ls->layerSurface || (ls->layerSurface && !ls->layerSurface->surface->mapped) || ls->alpha.fl() == 0.f)
+        if (ls->fadingOut || !ls->layerSurface || (ls->layerSurface && !ls->layerSurface->surface->mapped) || ls->alpha.value() == 0.f)
             continue;
 
         auto SURFACEAT = wlr_layer_surface_v1_surface_at(ls->layerSurface, pos.x - ls->geometry.x, pos.y - ls->geometry.y, &sCoords->x, &sCoords->y);
@@ -1241,7 +1241,7 @@ void CCompositor::sanityCheckWorkspaces() {
             if (!isWorkspaceVisible(WORKSPACE->m_iID)) {
 
                 if (WORKSPACE->m_bIsSpecialWorkspace) {
-                    if (WORKSPACE->m_fAlpha.fl() > 0.f /* don't abruptly end the fadeout */) {
+                    if (WORKSPACE->m_fAlpha.value() > 0.f /* don't abruptly end the fadeout */) {
                         ++it;
                         continue;
                     }
@@ -1422,7 +1422,7 @@ void CCompositor::cleanupFadingOut(const int& monid) {
 
         bool valid = windowExists(w);
 
-        if (!valid || !w->m_bFadingOut || w->m_fAlpha.fl() == 0.f) {
+        if (!valid || !w->m_bFadingOut || w->m_fAlpha.value() == 0.f) {
             if (valid && !w->m_bReadyToDelete)
                 continue;
 
@@ -2014,7 +2014,7 @@ void CCompositor::swapActiveWorkspaces(CMonitor* pMonitorA, CMonitor* pMonitorB)
 
             // additionally, move floating and fs windows manually
             if (w->m_bIsFloating)
-                w->m_vRealPosition = w->m_vRealPosition.vec() - pMonitorA->vecPosition + pMonitorB->vecPosition;
+                w->m_vRealPosition = w->m_vRealPosition.value() - pMonitorA->vecPosition + pMonitorB->vecPosition;
 
             if (w->m_bIsFullscreen) {
                 w->m_vRealPosition = pMonitorB->vecPosition;
@@ -2039,7 +2039,7 @@ void CCompositor::swapActiveWorkspaces(CMonitor* pMonitorA, CMonitor* pMonitorB)
 
             // additionally, move floating and fs windows manually
             if (w->m_bIsFloating)
-                w->m_vRealPosition = w->m_vRealPosition.vec() - pMonitorB->vecPosition + pMonitorA->vecPosition;
+                w->m_vRealPosition = w->m_vRealPosition.value() - pMonitorB->vecPosition + pMonitorA->vecPosition;
 
             if (w->m_bIsFullscreen) {
                 w->m_vRealPosition = pMonitorA->vecPosition;
@@ -2206,14 +2206,14 @@ void CCompositor::moveWorkspaceToMonitor(CWorkspace* pWorkspace, CMonitor* pMoni
             if (w->m_bIsMapped && !w->isHidden()) {
                 if (POLDMON) {
                     if (w->m_bIsFloating)
-                        w->m_vRealPosition = w->m_vRealPosition.vec() - POLDMON->vecPosition + pMonitor->vecPosition;
+                        w->m_vRealPosition = w->m_vRealPosition.value() - POLDMON->vecPosition + pMonitor->vecPosition;
 
                     if (w->m_bIsFullscreen) {
                         w->m_vRealPosition = pMonitor->vecPosition;
                         w->m_vRealSize     = pMonitor->vecSize;
                     }
                 } else {
-                    w->m_vRealPosition = Vector2D{(int)w->m_vRealPosition.goalv().x % (int)pMonitor->vecSize.x, (int)w->m_vRealPosition.goalv().y % (int)pMonitor->vecSize.y};
+                    w->m_vRealPosition = Vector2D{(int)w->m_vRealPosition.goal().x % (int)pMonitor->vecSize.x, (int)w->m_vRealPosition.goal().y % (int)pMonitor->vecSize.y};
                 }
             }
 
@@ -2330,7 +2330,7 @@ void CCompositor::setWindowFullscreen(CWindow* pWindow, bool on, eFullscreenMode
     }
     updateFullscreenFadeOnWorkspace(PWORKSPACE);
 
-    g_pXWaylandManager->setWindowSize(pWindow, pWindow->m_vRealSize.goalv(), true);
+    g_pXWaylandManager->setWindowSize(pWindow, pWindow->m_vRealSize.goal(), true);
 
     forceReportSizesToWindowsOnWorkspace(pWindow->m_iWorkspaceID);
 
@@ -2569,7 +2569,7 @@ Vector2D CCompositor::parseWindowVectorArgsRelative(const std::string& args, con
 void CCompositor::forceReportSizesToWindowsOnWorkspace(const int& wid) {
     for (auto& w : m_vWindows) {
         if (w->m_iWorkspaceID == wid && w->m_bIsMapped && !w->isHidden()) {
-            g_pXWaylandManager->setWindowSize(w.get(), w->m_vRealSize.vec(), true);
+            g_pXWaylandManager->setWindowSize(w.get(), w->m_vRealSize.value(), true);
         }
     }
 }
@@ -2670,7 +2670,7 @@ void CCompositor::moveWindowToWorkspaceSafe(CWindow* pWindow, CWorkspace* pWorks
         g_pLayoutManager->getCurrentLayout()->onWindowCreatedTiling(pWindow);
     } else {
         const auto PWINDOWMONITOR = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
-        const auto POSTOMON       = pWindow->m_vRealPosition.goalv() - PWINDOWMONITOR->vecPosition;
+        const auto POSTOMON       = pWindow->m_vRealPosition.goal() - PWINDOWMONITOR->vecPosition;
 
         const auto PWORKSPACEMONITOR = g_pCompositor->getMonitorFromID(pWorkspace->m_iMonitorID);
 

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -5,14 +5,14 @@
 #include "render/decorations/CHyprBorderDecoration.hpp"
 
 CWindow::CWindow() {
-    m_vRealPosition.create(AVARTYPE_VECTOR, g_pConfigManager->getAnimationPropertyConfig("windowsIn"), (void*)this, AVARDAMAGE_ENTIRE);
-    m_vRealSize.create(AVARTYPE_VECTOR, g_pConfigManager->getAnimationPropertyConfig("windowsIn"), (void*)this, AVARDAMAGE_ENTIRE);
-    m_fBorderFadeAnimationProgress.create(AVARTYPE_FLOAT, g_pConfigManager->getAnimationPropertyConfig("border"), (void*)this, AVARDAMAGE_BORDER);
-    m_fBorderAngleAnimationProgress.create(AVARTYPE_FLOAT, g_pConfigManager->getAnimationPropertyConfig("borderangle"), (void*)this, AVARDAMAGE_BORDER);
-    m_fAlpha.create(AVARTYPE_FLOAT, g_pConfigManager->getAnimationPropertyConfig("fadeIn"), (void*)this, AVARDAMAGE_ENTIRE);
-    m_fActiveInactiveAlpha.create(AVARTYPE_FLOAT, g_pConfigManager->getAnimationPropertyConfig("fadeSwitch"), (void*)this, AVARDAMAGE_ENTIRE);
-    m_cRealShadowColor.create(AVARTYPE_COLOR, g_pConfigManager->getAnimationPropertyConfig("fadeShadow"), (void*)this, AVARDAMAGE_SHADOW);
-    m_fDimPercent.create(AVARTYPE_FLOAT, g_pConfigManager->getAnimationPropertyConfig("fadeDim"), (void*)this, AVARDAMAGE_ENTIRE);
+    m_vRealPosition.create(g_pConfigManager->getAnimationPropertyConfig("windowsIn"), (void*)this, AVARDAMAGE_ENTIRE);
+    m_vRealSize.create(g_pConfigManager->getAnimationPropertyConfig("windowsIn"), (void*)this, AVARDAMAGE_ENTIRE);
+    m_fBorderFadeAnimationProgress.create(g_pConfigManager->getAnimationPropertyConfig("border"), (void*)this, AVARDAMAGE_BORDER);
+    m_fBorderAngleAnimationProgress.create(g_pConfigManager->getAnimationPropertyConfig("borderangle"), (void*)this, AVARDAMAGE_BORDER);
+    m_fAlpha.create(g_pConfigManager->getAnimationPropertyConfig("fadeIn"), (void*)this, AVARDAMAGE_ENTIRE);
+    m_fActiveInactiveAlpha.create(g_pConfigManager->getAnimationPropertyConfig("fadeSwitch"), (void*)this, AVARDAMAGE_ENTIRE);
+    m_cRealShadowColor.create(g_pConfigManager->getAnimationPropertyConfig("fadeShadow"), (void*)this, AVARDAMAGE_SHADOW);
+    m_fDimPercent.create(g_pConfigManager->getAnimationPropertyConfig("fadeDim"), (void*)this, AVARDAMAGE_ENTIRE);
 
     addWindowDeco(std::make_unique<CHyprDropShadowDecoration>(this));
     addWindowDeco(std::make_unique<CHyprBorderDecoration>(this));
@@ -39,8 +39,8 @@ SWindowDecorationExtents CWindow::getFullWindowExtents() {
 
     if (m_sAdditionalConfigData.dimAround) {
         const auto PMONITOR = g_pCompositor->getMonitorFromID(m_iMonitorID);
-        return {{m_vRealPosition.vec().x - PMONITOR->vecPosition.x, m_vRealPosition.vec().y - PMONITOR->vecPosition.y},
-                {PMONITOR->vecSize.x - (m_vRealPosition.vec().x - PMONITOR->vecPosition.x), PMONITOR->vecSize.y - (m_vRealPosition.vec().y - PMONITOR->vecPosition.y)}};
+        return {{m_vRealPosition.value().x - PMONITOR->vecPosition.x, m_vRealPosition.value().y - PMONITOR->vecPosition.y},
+                {PMONITOR->vecSize.x - (m_vRealPosition.value().x - PMONITOR->vecPosition.x), PMONITOR->vecSize.y - (m_vRealPosition.value().y - PMONITOR->vecPosition.y)}};
     }
 
     SWindowDecorationExtents maxExtents = {{BORDERSIZE + 2, BORDERSIZE + 2}, {BORDERSIZE + 2, BORDERSIZE + 2}};
@@ -101,8 +101,8 @@ CBox CWindow::getFullWindowBoundingBox() {
 
     auto maxExtents = getFullWindowExtents();
 
-    CBox finalBox = {m_vRealPosition.vec().x - maxExtents.topLeft.x, m_vRealPosition.vec().y - maxExtents.topLeft.y,
-                     m_vRealSize.vec().x + maxExtents.topLeft.x + maxExtents.bottomRight.x, m_vRealSize.vec().y + maxExtents.topLeft.y + maxExtents.bottomRight.y};
+    CBox finalBox = {m_vRealPosition.value().x - maxExtents.topLeft.x, m_vRealPosition.value().y - maxExtents.topLeft.y,
+                     m_vRealSize.value().x + maxExtents.topLeft.x + maxExtents.bottomRight.x, m_vRealSize.value().y + maxExtents.topLeft.y + maxExtents.bottomRight.y};
 
     return finalBox;
 }
@@ -154,14 +154,14 @@ CBox CWindow::getWindowBoxUnified(uint64_t properties) {
     if (properties & FULL_EXTENTS)
         EXTENTS.addExtents(g_pDecorationPositioner->getWindowDecorationExtents(this, false));
 
-    CBox box = {m_vRealPosition.vec().x, m_vRealPosition.vec().y, m_vRealSize.vec().x, m_vRealSize.vec().y};
+    CBox box = {m_vRealPosition.value().x, m_vRealPosition.value().y, m_vRealSize.value().x, m_vRealSize.value().y};
     box.addExtents(EXTENTS);
 
     return box;
 }
 
 CBox CWindow::getWindowMainSurfaceBox() {
-    return {m_vRealPosition.vec().x, m_vRealPosition.vec().y, m_vRealSize.vec().x, m_vRealSize.vec().y};
+    return {m_vRealPosition.value().x, m_vRealPosition.value().y, m_vRealSize.value().x, m_vRealSize.value().y};
 }
 
 SWindowDecorationExtents CWindow::getFullWindowReservedArea() {
@@ -392,7 +392,7 @@ void CWindow::moveToWorkspace(int workspaceID) {
     }
 
     // update xwayland coords
-    g_pXWaylandManager->setWindowSize(this, m_vRealSize.vec());
+    g_pXWaylandManager->setWindowSize(this, m_vRealSize.value());
 
     if (g_pCompositor->isWorkspaceSpecial(OLDWORKSPACE) && g_pCompositor->getWindowsOnWorkspace(OLDWORKSPACE) == 0 && **PCLOSEONLASTSPECIAL) {
         const auto PWS = g_pCompositor->getWorkspaceByID(OLDWORKSPACE);
@@ -433,7 +433,7 @@ void CWindow::removeDecorationByType(eDecorationType type) {
 }
 
 void unregisterVar(void* ptr) {
-    ((CAnimatedVariable*)ptr)->unregister();
+    ((CBaseAnimatedVariable*)ptr)->unregister();
 }
 
 void CWindow::onUnmap() {
@@ -530,7 +530,7 @@ void CWindow::onMap() {
 }
 
 void CWindow::onBorderAngleAnimEnd(void* ptr) {
-    const auto        PANIMVAR = (CAnimatedVariable*)ptr;
+    const auto        PANIMVAR = (CAnimatedVariable<float>*)ptr;
 
     const std::string STYLE = PANIMVAR->getConfig()->pValues->internalStyle;
 
@@ -727,10 +727,10 @@ bool CWindow::isInCurvedCorner(double x, double y) {
         return false;
 
     // (x0, y0), (x0, y1), ... are the center point of rounding at each corner
-    double x0 = m_vRealPosition.vec().x + ROUNDING;
-    double y0 = m_vRealPosition.vec().y + ROUNDING;
-    double x1 = m_vRealPosition.vec().x + m_vRealSize.vec().x - ROUNDING;
-    double y1 = m_vRealPosition.vec().y + m_vRealSize.vec().y - ROUNDING;
+    double x0 = m_vRealPosition.value().x + ROUNDING;
+    double y0 = m_vRealPosition.value().y + ROUNDING;
+    double x1 = m_vRealPosition.value().x + m_vRealSize.value().x - ROUNDING;
+    double y1 = m_vRealPosition.value().y + m_vRealSize.value().y - ROUNDING;
 
     if (x < x0 && y < y0) {
         return Vector2D{x0, y0}.distance(Vector2D{x, y}) > (double)ROUNDING;
@@ -763,7 +763,7 @@ bool CWindow::hasPopupAt(const Vector2D& pos) {
         return false;
 
     wlr_surface*          resultSurf = nullptr;
-    Vector2D              origin     = m_vRealPosition.vec();
+    Vector2D              origin     = m_vRealPosition.value();
     SExtensionFindingData data       = {origin, pos, &resultSurf};
     wlr_xdg_surface_for_each_popup_surface(m_uSurface.xdg, findExtensionForVector2D, &data);
 
@@ -902,8 +902,8 @@ void CWindow::setGroupCurrent(CWindow* pWindow) {
     const bool FULLSCREEN = PCURRENT->m_bIsFullscreen;
     const auto WORKSPACE  = g_pCompositor->getWorkspaceByID(PCURRENT->m_iWorkspaceID);
 
-    const auto PWINDOWSIZE = PCURRENT->m_vRealSize.goalv();
-    const auto PWINDOWPOS  = PCURRENT->m_vRealPosition.goalv();
+    const auto PWINDOWSIZE = PCURRENT->m_vRealSize.goal();
+    const auto PWINDOWPOS  = PCURRENT->m_vRealPosition.goal();
 
     const auto CURRENTISFOCUS = PCURRENT == g_pCompositor->m_pLastWindow;
 
@@ -997,19 +997,19 @@ void CWindow::updateGroupOutputs() {
         curr->m_iMonitorID = m_iMonitorID;
         curr->moveToWorkspace(m_iWorkspaceID);
 
-        curr->m_vRealPosition = m_vRealPosition.goalv();
-        curr->m_vRealSize     = m_vRealSize.goalv();
+        curr->m_vRealPosition = m_vRealPosition.goal();
+        curr->m_vRealSize     = m_vRealSize.goal();
 
         curr = curr->m_sGroupData.pNextWindow;
     }
 }
 
 Vector2D CWindow::middle() {
-    return m_vRealPosition.goalv() + m_vRealSize.goalv() / 2.f;
+    return m_vRealPosition.goal() + m_vRealSize.goal() / 2.f;
 }
 
 bool CWindow::opaque() {
-    if (m_fAlpha.fl() != 1.f || m_fActiveInactiveAlpha.fl() != 1.f)
+    if (m_fAlpha.value() != 1.f || m_fActiveInactiveAlpha.value() != 1.f)
         return false;
 
     const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(m_iWorkspaceID);
@@ -1017,7 +1017,7 @@ bool CWindow::opaque() {
     if (m_pWLSurface.small() && !m_pWLSurface.m_bFillIgnoreSmall)
         return false;
 
-    if (PWORKSPACE->m_fAlpha.fl() != 1.f)
+    if (PWORKSPACE->m_fAlpha.value() != 1.f)
         return false;
 
     if (m_bIsX11)

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -221,8 +221,8 @@ class CWindow {
     Vector2D m_vSize     = Vector2D(0, 0);
 
     // this is the real position and size used to draw the thing
-    CAnimatedVariable m_vRealPosition;
-    CAnimatedVariable m_vRealSize;
+    CAnimatedVariable<Vector2D> m_vRealPosition;
+    CAnimatedVariable<Vector2D> m_vRealSize;
 
     // for not spamming the protocols
     Vector2D                                     m_vReportedPosition;
@@ -282,13 +282,13 @@ class CWindow {
     std::unique_ptr<CPopup>      m_pPopupHead;
 
     // Animated border
-    CGradientValueData m_cRealBorderColor         = {0};
-    CGradientValueData m_cRealBorderColorPrevious = {0};
-    CAnimatedVariable  m_fBorderFadeAnimationProgress;
-    CAnimatedVariable  m_fBorderAngleAnimationProgress;
+    CGradientValueData       m_cRealBorderColor         = {0};
+    CGradientValueData       m_cRealBorderColorPrevious = {0};
+    CAnimatedVariable<float> m_fBorderFadeAnimationProgress;
+    CAnimatedVariable<float> m_fBorderAngleAnimationProgress;
 
     // Fade in-out
-    CAnimatedVariable        m_fAlpha;
+    CAnimatedVariable<float> m_fAlpha;
     bool                     m_bFadingOut     = false;
     bool                     m_bReadyToDelete = false;
     Vector2D                 m_vOriginalClosedPos;  // these will be used for calculations later on in
@@ -322,13 +322,13 @@ class CWindow {
     std::vector<std::unique_ptr<IWindowTransformer>> m_vTransformers;
 
     // for alpha
-    CAnimatedVariable m_fActiveInactiveAlpha;
+    CAnimatedVariable<float> m_fActiveInactiveAlpha;
 
     // animated shadow color
-    CAnimatedVariable m_cRealShadowColor;
+    CAnimatedVariable<CColor> m_cRealShadowColor;
 
     // animated tint
-    CAnimatedVariable m_fDimPercent;
+    CAnimatedVariable<float> m_fDimPercent;
 
     // swallowing
     CWindow* m_pSwallowed = nullptr;

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -171,8 +171,8 @@ static std::string getWindowData(CWindow* w, eHyprCtlOutputFormat format) {
     "swallowing": "0x{:x}",
     "focusHistoryID": {}
 }},)#",
-            (uintptr_t)w, (w->m_bIsMapped ? "true" : "false"), (w->isHidden() ? "true" : "false"), (int)w->m_vRealPosition.goalv().x, (int)w->m_vRealPosition.goalv().y,
-            (int)w->m_vRealSize.goalv().x, (int)w->m_vRealSize.goalv().y, w->m_iWorkspaceID,
+            (uintptr_t)w, (w->m_bIsMapped ? "true" : "false"), (w->isHidden() ? "true" : "false"), (int)w->m_vRealPosition.goal().x, (int)w->m_vRealPosition.goal().y,
+            (int)w->m_vRealSize.goal().x, (int)w->m_vRealSize.goal().y, w->m_iWorkspaceID,
             escapeJSONStrings(w->m_iWorkspaceID == -1                                ? "" :
                                   g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID) ? g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID)->m_szName :
                                                                                        std::string("Invalid workspace " + std::to_string(w->m_iWorkspaceID))),
@@ -187,8 +187,8 @@ static std::string getWindowData(CWindow* w, eHyprCtlOutputFormat format) {
             "{}\n\tinitialClass: {}\n\tinitialTitle: {}\n\tpid: "
             "{}\n\txwayland: {}\n\tpinned: "
             "{}\n\tfullscreen: {}\n\tfullscreenmode: {}\n\tfakefullscreen: {}\n\tgrouped: {}\n\tswallowing: {:x}\n\tfocusHistoryID: {}\n\n",
-            (uintptr_t)w, w->m_szTitle, (int)w->m_bIsMapped, (int)w->isHidden(), (int)w->m_vRealPosition.goalv().x, (int)w->m_vRealPosition.goalv().y,
-            (int)w->m_vRealSize.goalv().x, (int)w->m_vRealSize.goalv().y, w->m_iWorkspaceID,
+            (uintptr_t)w, w->m_szTitle, (int)w->m_bIsMapped, (int)w->isHidden(), (int)w->m_vRealPosition.goal().x, (int)w->m_vRealPosition.goal().y,
+            (int)w->m_vRealSize.goal().x, (int)w->m_vRealSize.goal().y, w->m_iWorkspaceID,
             (w->m_iWorkspaceID == -1                                ? "" :
                  g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID) ? g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID)->m_szName :
                                                                       std::string("Invalid workspace " + std::to_string(w->m_iWorkspaceID))),

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -187,8 +187,8 @@ static std::string getWindowData(CWindow* w, eHyprCtlOutputFormat format) {
             "{}\n\tinitialClass: {}\n\tinitialTitle: {}\n\tpid: "
             "{}\n\txwayland: {}\n\tpinned: "
             "{}\n\tfullscreen: {}\n\tfullscreenmode: {}\n\tfakefullscreen: {}\n\tgrouped: {}\n\tswallowing: {:x}\n\tfocusHistoryID: {}\n\n",
-            (uintptr_t)w, w->m_szTitle, (int)w->m_bIsMapped, (int)w->isHidden(), (int)w->m_vRealPosition.goal().x, (int)w->m_vRealPosition.goal().y,
-            (int)w->m_vRealSize.goal().x, (int)w->m_vRealSize.goal().y, w->m_iWorkspaceID,
+            (uintptr_t)w, w->m_szTitle, (int)w->m_bIsMapped, (int)w->isHidden(), (int)w->m_vRealPosition.goal().x, (int)w->m_vRealPosition.goal().y, (int)w->m_vRealSize.goal().x,
+            (int)w->m_vRealSize.goal().y, w->m_iWorkspaceID,
             (w->m_iWorkspaceID == -1                                ? "" :
                  g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID) ? g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID)->m_szName :
                                                                       std::string("Invalid workspace " + std::to_string(w->m_iWorkspaceID))),

--- a/src/desktop/Popup.cpp
+++ b/src/desktop/Popup.cpp
@@ -207,9 +207,9 @@ Vector2D CPopup::localToGlobal(const Vector2D& rel) {
 
 Vector2D CPopup::t1ParentCoords() {
     if (m_pWindowOwner)
-        return m_pWindowOwner->m_vRealPosition.vec();
+        return m_pWindowOwner->m_vRealPosition.value();
     if (m_pLayerOwner)
-        return m_pLayerOwner->realPosition.vec();
+        return m_pLayerOwner->realPosition.value();
 
     ASSERT(false);
     return {};

--- a/src/desktop/Subsurface.cpp
+++ b/src/desktop/Subsurface.cpp
@@ -236,7 +236,7 @@ Vector2D CSubsurface::coordsGlobal() {
     Vector2D coords = coordsRelativeToParent();
 
     if (m_pWindowParent)
-        coords += m_pWindowParent->m_vRealPosition.vec();
+        coords += m_pWindowParent->m_vRealPosition.value();
     else if (m_pPopupParent)
         coords += m_pPopupParent->coordsGlobal();
 

--- a/src/desktop/WLSurface.cpp
+++ b/src/desktop/WLSurface.cpp
@@ -65,7 +65,7 @@ Vector2D CWLSurface::correctSmallVec() const {
     const auto SIZE = getViewporterCorrectedSize();
 
     return Vector2D{(m_pWindowOwner->m_vReportedSize.x - SIZE.x) / 2, (m_pWindowOwner->m_vReportedSize.y - SIZE.y) / 2}.clamp({}, {INFINITY, INFINITY}) *
-        (m_pWindowOwner->m_vRealSize.vec() / m_pWindowOwner->m_vReportedSize);
+        (m_pWindowOwner->m_vRealSize.value() / m_pWindowOwner->m_vReportedSize);
 }
 
 Vector2D CWLSurface::getViewporterCorrectedSize() const {

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -14,8 +14,8 @@ CWorkspace::CWorkspace(int monitorID, std::string name, bool special) {
     m_bIsSpecialWorkspace = special;
 
     m_vRenderOffset.m_pWorkspace = this;
-    m_vRenderOffset.create(special ? g_pConfigManager->getAnimationPropertyConfig("specialWorkspace") : g_pConfigManager->getAnimationPropertyConfig("workspaces"),
-                           nullptr, AVARDAMAGE_ENTIRE);
+    m_vRenderOffset.create(special ? g_pConfigManager->getAnimationPropertyConfig("specialWorkspace") : g_pConfigManager->getAnimationPropertyConfig("workspaces"), nullptr,
+                           AVARDAMAGE_ENTIRE);
     m_fAlpha.m_pWorkspace = this;
     m_fAlpha.create(AVARTYPE_FLOAT, special ? g_pConfigManager->getAnimationPropertyConfig("specialWorkspace") : g_pConfigManager->getAnimationPropertyConfig("workspaces"),
                     nullptr, AVARDAMAGE_ENTIRE);

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -14,7 +14,7 @@ CWorkspace::CWorkspace(int monitorID, std::string name, bool special) {
     m_bIsSpecialWorkspace = special;
 
     m_vRenderOffset.m_pWorkspace = this;
-    m_vRenderOffset.create(AVARTYPE_VECTOR, special ? g_pConfigManager->getAnimationPropertyConfig("specialWorkspace") : g_pConfigManager->getAnimationPropertyConfig("workspaces"),
+    m_vRenderOffset.create(special ? g_pConfigManager->getAnimationPropertyConfig("specialWorkspace") : g_pConfigManager->getAnimationPropertyConfig("workspaces"),
                            nullptr, AVARDAMAGE_ENTIRE);
     m_fAlpha.m_pWorkspace = this;
     m_fAlpha.create(AVARTYPE_FLOAT, special ? g_pConfigManager->getAnimationPropertyConfig("specialWorkspace") : g_pConfigManager->getAnimationPropertyConfig("workspaces"),

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -35,9 +35,9 @@ class CWorkspace {
     wl_array        m_wlrCoordinateArr;
 
     // for animations
-    CAnimatedVariable m_vRenderOffset;
-    CAnimatedVariable m_fAlpha;
-    bool              m_bForceRendering = false;
+    CAnimatedVariable<Vector2D> m_vRenderOffset;
+    CAnimatedVariable<float>    m_fAlpha;
+    bool                        m_bForceRendering = false;
 
     // "scratchpad"
     bool m_bIsSpecialWorkspace = false;

--- a/src/events/Layers.cpp
+++ b/src/events/Layers.cpp
@@ -327,13 +327,13 @@ void Events::listener_commitLayerSurface(void* owner, void* data) {
         }
     }
 
-    if (layersurface->realPosition.goalv() != layersurface->geometry.pos()) {
+    if (layersurface->realPosition.goal() != layersurface->geometry.pos()) {
         if (layersurface->realPosition.isBeingAnimated())
             layersurface->realPosition = layersurface->geometry.pos();
         else
             layersurface->realPosition.setValueAndWarp(layersurface->geometry.pos());
     }
-    if (layersurface->realSize.goalv() != layersurface->geometry.size()) {
+    if (layersurface->realSize.goal() != layersurface->geometry.size()) {
         if (layersurface->realSize.isBeingAnimated())
             layersurface->realSize = layersurface->geometry.size();
         else

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -30,7 +30,7 @@ void addViewCoords(void* pWindow, int* x, int* y) {
 }
 
 void setAnimToMove(void* data) {
-    auto* const        PANIMCFG = g_pConfigManager->getAnimationPropertyConfig("windowsMove");
+    auto* const            PANIMCFG = g_pConfigManager->getAnimationPropertyConfig("windowsMove");
 
     CBaseAnimatedVariable* animvar = (CBaseAnimatedVariable*)data;
 
@@ -760,7 +760,7 @@ void Events::listener_unmapWindow(void* owner, void* data) {
 
     g_pHyprRenderer->damageMonitor(g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID));
 
-    if (!PWINDOW->m_bX11DoesntWantBorders)                                                  // don't animate out if they weren't animated in.
+    if (!PWINDOW->m_bX11DoesntWantBorders)                                                    // don't animate out if they weren't animated in.
         PWINDOW->m_vRealPosition = PWINDOW->m_vRealPosition.value() + Vector2D(0.01f, 0.01f); // it has to be animated, otherwise onWindowPostCreateClose will ignore it
 
     // anims

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -17,8 +17,8 @@
 
 void addViewCoords(void* pWindow, int* x, int* y) {
     const auto PWINDOW = (CWindow*)pWindow;
-    *x += PWINDOW->m_vRealPosition.goalv().x;
-    *y += PWINDOW->m_vRealPosition.goalv().y;
+    *x += PWINDOW->m_vRealPosition.goal().x;
+    *y += PWINDOW->m_vRealPosition.goal().y;
 
     if (!PWINDOW->m_bIsX11 && PWINDOW->m_bIsMapped) {
         wlr_box geom;
@@ -32,7 +32,7 @@ void addViewCoords(void* pWindow, int* x, int* y) {
 void setAnimToMove(void* data) {
     auto* const        PANIMCFG = g_pConfigManager->getAnimationPropertyConfig("windowsMove");
 
-    CAnimatedVariable* animvar = (CAnimatedVariable*)data;
+    CBaseAnimatedVariable* animvar = (CBaseAnimatedVariable*)data;
 
     animvar->setConfig(PANIMCFG);
 }
@@ -323,7 +323,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                     Debug::log(LOG, "Rule size, applying to {}", PWINDOW);
 
                     PWINDOW->m_vRealSize = Vector2D(SIZEX, SIZEY);
-                    g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goalv());
+                    g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal());
 
                     PWINDOW->setHidden(false);
                 } catch (...) { Debug::log(LOG, "Rule size failed, rule: {} -> {}", r.szRule, r.szValue); }
@@ -334,10 +334,10 @@ void Events::listener_mapWindow(void* owner, void* data) {
                     const auto SIZEYSTR = VALUE.substr(VALUE.find(' ') + 1);
 
                     const auto SIZE =
-                        Vector2D(std::max((double)std::stoll(SIZEXSTR), PWINDOW->m_vRealSize.goalv().x), std::max((double)std::stoll(SIZEYSTR), PWINDOW->m_vRealSize.goalv().y));
+                        Vector2D(std::max((double)std::stoll(SIZEXSTR), PWINDOW->m_vRealSize.goal().x), std::max((double)std::stoll(SIZEYSTR), PWINDOW->m_vRealSize.goal().y));
 
                     PWINDOW->m_vRealSize = SIZE;
-                    g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goalv());
+                    g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal());
 
                     PWINDOW->setHidden(false);
                 } catch (...) { Debug::log(LOG, "Rule minsize failed, rule: {} -> {}", r.szRule, r.szValue); }
@@ -348,10 +348,10 @@ void Events::listener_mapWindow(void* owner, void* data) {
                     const auto SIZEYSTR = VALUE.substr(VALUE.find(' ') + 1);
 
                     const auto SIZE =
-                        Vector2D(std::min((double)std::stoll(SIZEXSTR), PWINDOW->m_vRealSize.goalv().x), std::min((double)std::stoll(SIZEYSTR), PWINDOW->m_vRealSize.goalv().y));
+                        Vector2D(std::min((double)std::stoll(SIZEXSTR), PWINDOW->m_vRealSize.goal().x), std::min((double)std::stoll(SIZEYSTR), PWINDOW->m_vRealSize.goal().y));
 
                     PWINDOW->m_vRealSize = SIZE;
-                    g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goalv());
+                    g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal());
 
                     PWINDOW->setHidden(false);
                 } catch (...) { Debug::log(LOG, "Rule maxsize failed, rule: {} -> {}", r.szRule, r.szValue); }
@@ -390,7 +390,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                             posX = g_pInputManager->getMouseCoordsInternal().x - PMONITOR->vecPosition.x;
                         } else {
                             posX = g_pInputManager->getMouseCoordsInternal().x - PMONITOR->vecPosition.x +
-                                (!POSXSTR.contains('%') ? std::stoi(POSXSTR) : std::stof(POSXSTR.substr(0, POSXSTR.length() - 1)) * 0.01 * PWINDOW->m_vRealSize.goalv().x);
+                                (!POSXSTR.contains('%') ? std::stoi(POSXSTR) : std::stof(POSXSTR.substr(0, POSXSTR.length() - 1)) * 0.01 * PWINDOW->m_vRealSize.goal().x);
                         }
                     }
 
@@ -409,7 +409,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                             posY = g_pInputManager->getMouseCoordsInternal().y - PMONITOR->vecPosition.y;
                         } else {
                             posY = g_pInputManager->getMouseCoordsInternal().y - PMONITOR->vecPosition.y +
-                                (!POSYSTR.contains('%') ? std::stoi(POSYSTR) : std::stof(POSYSTR.substr(0, POSYSTR.length() - 1)) * 0.01 * PWINDOW->m_vRealSize.goalv().y);
+                                (!POSYSTR.contains('%') ? std::stoi(POSYSTR) : std::stof(POSYSTR.substr(0, POSYSTR.length() - 1)) * 0.01 * PWINDOW->m_vRealSize.goal().y);
                         }
                     }
 
@@ -417,10 +417,10 @@ void Events::listener_mapWindow(void* owner, void* data) {
                         int borderSize = PWINDOW->getRealBorderSize();
 
                         posX = std::clamp(posX, (int)(PMONITOR->vecReservedTopLeft.x + borderSize),
-                                          (int)(PMONITOR->vecSize.x - PMONITOR->vecReservedBottomRight.x - PWINDOW->m_vRealSize.goalv().x - borderSize));
+                                          (int)(PMONITOR->vecSize.x - PMONITOR->vecReservedBottomRight.x - PWINDOW->m_vRealSize.goal().x - borderSize));
 
                         posY = std::clamp(posY, (int)(PMONITOR->vecReservedTopLeft.y + borderSize),
-                                          (int)(PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PWINDOW->m_vRealSize.goalv().y - borderSize));
+                                          (int)(PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PWINDOW->m_vRealSize.goal().y - borderSize));
                     }
 
                     Debug::log(LOG, "Rule move, applying to {}", PWINDOW);
@@ -435,20 +435,20 @@ void Events::listener_mapWindow(void* owner, void* data) {
                 if (ARGS[1] == "1")
                     RESERVEDOFFSET = (PMONITOR->vecReservedTopLeft - PMONITOR->vecReservedBottomRight) / 2.f;
 
-                PWINDOW->m_vRealPosition = PMONITOR->middle() - PWINDOW->m_vRealSize.goalv() / 2.f + RESERVEDOFFSET;
+                PWINDOW->m_vRealPosition = PMONITOR->middle() - PWINDOW->m_vRealSize.value() / 2.f + RESERVEDOFFSET;
             }
         }
 
         // set the pseudo size to the GOAL of our current size
         // because the windows are animated on RealSize
-        PWINDOW->m_vPseudoSize = PWINDOW->m_vRealSize.goalv();
+        PWINDOW->m_vPseudoSize = PWINDOW->m_vRealSize.goal();
 
         g_pCompositor->changeWindowZOrder(PWINDOW, true);
     } else {
         g_pLayoutManager->getCurrentLayout()->onWindowCreated(PWINDOW);
 
         // Set the pseudo size here too so that it doesnt end up being 0x0
-        PWINDOW->m_vPseudoSize = PWINDOW->m_vRealSize.goalv() - Vector2D(10, 10);
+        PWINDOW->m_vPseudoSize = PWINDOW->m_vRealSize.goal() - Vector2D(10, 10);
     }
 
     const auto PFOCUSEDWINDOWPREV = g_pCompositor->m_pLastWindow;
@@ -617,7 +617,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
     PWINDOW->m_bFirstMap = false;
 
-    Debug::log(LOG, "Map request dispatched, monitor {}, window pos: {:5j}, window size: {:5j}", PMONITOR->szName, PWINDOW->m_vRealPosition.goalv(), PWINDOW->m_vRealSize.goalv());
+    Debug::log(LOG, "Map request dispatched, monitor {}, window pos: {:5j}, window size: {:5j}", PMONITOR->szName, PWINDOW->m_vRealPosition.goal(), PWINDOW->m_vRealSize.goal());
 
     auto workspaceID = requestedWorkspace != "" ? requestedWorkspace : PWORKSPACE->m_szName;
     g_pEventManager->postEvent(SHyprIPCEvent{"openwindow", std::format("{:x},{},{},{}", PWINDOW, workspaceID, g_pXWaylandManager->getAppIDClass(PWINDOW), PWINDOW->m_szTitle)});
@@ -670,8 +670,8 @@ void Events::listener_unmapWindow(void* owner, void* data) {
 
     const auto PMONITOR = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID);
     if (PMONITOR) {
-        PWINDOW->m_vOriginalClosedPos     = PWINDOW->m_vRealPosition.vec() - PMONITOR->vecPosition;
-        PWINDOW->m_vOriginalClosedSize    = PWINDOW->m_vRealSize.vec();
+        PWINDOW->m_vOriginalClosedPos     = PWINDOW->m_vRealPosition.value() - PMONITOR->vecPosition;
+        PWINDOW->m_vOriginalClosedSize    = PWINDOW->m_vRealSize.value();
         PWINDOW->m_eOriginalClosedExtents = PWINDOW->getFullWindowExtents();
     }
 
@@ -761,7 +761,7 @@ void Events::listener_unmapWindow(void* owner, void* data) {
     g_pHyprRenderer->damageMonitor(g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID));
 
     if (!PWINDOW->m_bX11DoesntWantBorders)                                                  // don't animate out if they weren't animated in.
-        PWINDOW->m_vRealPosition = PWINDOW->m_vRealPosition.vec() + Vector2D(0.01f, 0.01f); // it has to be animated, otherwise onWindowPostCreateClose will ignore it
+        PWINDOW->m_vRealPosition = PWINDOW->m_vRealPosition.value() + Vector2D(0.01f, 0.01f); // it has to be animated, otherwise onWindowPostCreateClose will ignore it
 
     // anims
     g_pAnimationManager->onWindowPostCreateClose(PWINDOW, true);
@@ -831,7 +831,7 @@ void Events::listener_commitWindow(void* owner, void* data) {
         PWINDOW->m_pPendingSizeAck.reset();
     }
 
-    g_pHyprRenderer->damageSurface(PWINDOW->m_pWLSurface.wlr(), PWINDOW->m_vRealPosition.goalv().x, PWINDOW->m_vRealPosition.goalv().y,
+    g_pHyprRenderer->damageSurface(PWINDOW->m_pWLSurface.wlr(), PWINDOW->m_vRealPosition.goal().x, PWINDOW->m_vRealPosition.goal().y,
                                    PWINDOW->m_bIsX11 ? 1.0 / PWINDOW->m_fX11SurfaceScaledBy : 1.0);
 
     if (!PWINDOW->m_bIsX11) {
@@ -848,7 +848,7 @@ void Events::listener_commitWindow(void* owner, void* data) {
     if (MAXSIZE < Vector2D{1, 1})
         return;
 
-    const auto REALSIZE = PWINDOW->m_vRealSize.goalv();
+    const auto REALSIZE = PWINDOW->m_vRealSize.goal();
     Vector2D   newSize  = REALSIZE;
 
     if (MAXSIZE.x < newSize.x)
@@ -862,7 +862,7 @@ void Events::listener_commitWindow(void* owner, void* data) {
 
     const Vector2D DELTA = REALSIZE - newSize;
 
-    PWINDOW->m_vRealPosition = PWINDOW->m_vRealPosition.goalv() + DELTA / 2.0;
+    PWINDOW->m_vRealPosition = PWINDOW->m_vRealPosition.goal() + DELTA / 2.0;
     PWINDOW->m_vRealSize     = newSize;
     g_pXWaylandManager->setWindowSize(PWINDOW, newSize, true);
     g_pHyprRenderer->damageWindow(PWINDOW);
@@ -1068,7 +1068,7 @@ void Events::listener_configureX11(void* owner, void* data) {
     g_pHyprRenderer->damageWindow(PWINDOW);
 
     if (!PWINDOW->m_bIsFloating || PWINDOW->m_bIsFullscreen || g_pInputManager->currentlyDraggedWindow == PWINDOW) {
-        g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goalv(), true);
+        g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal(), true);
         g_pInputManager->refocus();
         g_pHyprRenderer->damageWindow(PWINDOW);
         return;
@@ -1087,13 +1087,13 @@ void Events::listener_configureX11(void* owner, void* data) {
     static auto* const PXWLFORCESCALEZERO = (Hyprlang::INT* const*)g_pConfigManager->getConfigValuePtr("xwayland:force_zero_scaling");
     if (**PXWLFORCESCALEZERO) {
         if (const auto PMONITOR = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID); PMONITOR) {
-            PWINDOW->m_vRealSize.setValueAndWarp(PWINDOW->m_vRealSize.goalv() / PMONITOR->scale);
+            PWINDOW->m_vRealSize.setValueAndWarp(PWINDOW->m_vRealSize.goal() / PMONITOR->scale);
             PWINDOW->m_fX11SurfaceScaledBy = PMONITOR->scale;
         }
     }
 
-    PWINDOW->m_vPosition = PWINDOW->m_vRealPosition.vec();
-    PWINDOW->m_vSize     = PWINDOW->m_vRealSize.vec();
+    PWINDOW->m_vPosition = PWINDOW->m_vRealPosition.value();
+    PWINDOW->m_vSize     = PWINDOW->m_vRealSize.value();
 
     wlr_xwayland_surface_configure(PWINDOW->m_uSurface.xwayland, E->x, E->y, E->width, E->height);
 
@@ -1105,7 +1105,7 @@ void Events::listener_configureX11(void* owner, void* data) {
     if (!g_pCompositor->isWorkspaceVisible(PWINDOW->m_iWorkspaceID))
         return; // further things are only for visible windows
 
-    PWINDOW->m_iWorkspaceID = g_pCompositor->getMonitorFromVector(PWINDOW->m_vRealPosition.vec() + PWINDOW->m_vRealSize.vec() / 2.f)->activeWorkspace;
+    PWINDOW->m_iWorkspaceID = g_pCompositor->getMonitorFromVector(PWINDOW->m_vRealPosition.value() + PWINDOW->m_vRealSize.value() / 2.f)->activeWorkspace;
 
     g_pCompositor->changeWindowZOrder(PWINDOW, true);
 
@@ -1123,8 +1123,8 @@ void Events::listener_unmanagedSetGeometry(void* owner, void* data) {
     if (!PWINDOW->m_bIsMapped)
         return;
 
-    const auto POS = PWINDOW->m_vRealPosition.goalv();
-    const auto SIZ = PWINDOW->m_vRealSize.goalv();
+    const auto POS = PWINDOW->m_vRealPosition.goal();
+    const auto SIZ = PWINDOW->m_vRealSize.goal();
 
     if (PWINDOW->m_uSurface.xwayland->width > 1 && PWINDOW->m_uSurface.xwayland->height > 1)
         PWINDOW->setHidden(false);
@@ -1132,7 +1132,7 @@ void Events::listener_unmanagedSetGeometry(void* owner, void* data) {
         PWINDOW->setHidden(true);
 
     if (PWINDOW->m_bIsFullscreen || !PWINDOW->m_bIsFloating) {
-        g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goalv(), true);
+        g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal(), true);
         g_pHyprRenderer->damageWindow(PWINDOW);
         return;
     }
@@ -1154,23 +1154,23 @@ void Events::listener_unmanagedSetGeometry(void* owner, void* data) {
 
         if (**PXWLFORCESCALEZERO) {
             if (const auto PMONITOR = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID); PMONITOR) {
-                const Vector2D DELTA = PWINDOW->m_vRealSize.goalv() - PWINDOW->m_vRealSize.goalv() / PMONITOR->scale;
-                PWINDOW->m_vRealSize.setValueAndWarp(PWINDOW->m_vRealSize.goalv() / PMONITOR->scale);
-                PWINDOW->m_vRealPosition.setValueAndWarp(PWINDOW->m_vRealPosition.goalv() + DELTA / 2.0);
+                const Vector2D DELTA = PWINDOW->m_vRealSize.goal() - PWINDOW->m_vRealSize.goal() / PMONITOR->scale;
+                PWINDOW->m_vRealSize.setValueAndWarp(PWINDOW->m_vRealSize.goal() / PMONITOR->scale);
+                PWINDOW->m_vRealPosition.setValueAndWarp(PWINDOW->m_vRealPosition.goal() + DELTA / 2.0);
             }
         }
 
-        PWINDOW->m_vPosition = PWINDOW->m_vRealPosition.goalv();
-        PWINDOW->m_vSize     = PWINDOW->m_vRealSize.goalv();
+        PWINDOW->m_vPosition = PWINDOW->m_vRealPosition.goal();
+        PWINDOW->m_vSize     = PWINDOW->m_vRealSize.goal();
 
-        PWINDOW->m_iWorkspaceID = g_pCompositor->getMonitorFromVector(PWINDOW->m_vRealPosition.vec() + PWINDOW->m_vRealSize.vec() / 2.f)->activeWorkspace;
+        PWINDOW->m_iWorkspaceID = g_pCompositor->getMonitorFromVector(PWINDOW->m_vRealPosition.value() + PWINDOW->m_vRealSize.value() / 2.f)->activeWorkspace;
 
         g_pCompositor->changeWindowZOrder(PWINDOW, true);
         PWINDOW->updateWindowDecos();
         g_pHyprRenderer->damageWindow(PWINDOW);
 
-        PWINDOW->m_vReportedPosition    = PWINDOW->m_vRealPosition.goalv();
-        PWINDOW->m_vPendingReportedSize = PWINDOW->m_vRealSize.goalv();
+        PWINDOW->m_vReportedPosition    = PWINDOW->m_vRealPosition.goal();
+        PWINDOW->m_vPendingReportedSize = PWINDOW->m_vRealSize.goal();
     }
 }
 

--- a/src/helpers/AnimatedVariable.cpp
+++ b/src/helpers/AnimatedVariable.cpp
@@ -2,7 +2,7 @@
 #include "../managers/AnimationManager.hpp"
 #include "../config/ConfigManager.hpp"
 
-CBaseAnimatedVariable::CBaseAnimatedVariable() {
+CBaseAnimatedVariable::CBaseAnimatedVariable(ANIMATEDVARTYPE type) : m_Type(type) {
     ; // dummy var
 }
 

--- a/src/helpers/AnimatedVariable.cpp
+++ b/src/helpers/AnimatedVariable.cpp
@@ -2,12 +2,11 @@
 #include "../managers/AnimationManager.hpp"
 #include "../config/ConfigManager.hpp"
 
-CAnimatedVariable::CAnimatedVariable() {
+CBaseAnimatedVariable::CBaseAnimatedVariable() {
     ; // dummy var
 }
 
-void CAnimatedVariable::create(ANIMATEDVARTYPE type, SAnimationPropertyConfig* pAnimConfig, void* pWindow, AVARDAMAGEPOLICY policy) {
-    m_eVarType      = type;
+void CBaseAnimatedVariable::create(SAnimationPropertyConfig* pAnimConfig, void* pWindow, AVARDAMAGEPOLICY policy) {
     m_eDamagePolicy = policy;
     m_pConfig       = pAnimConfig;
     m_pWindow       = pWindow;
@@ -15,42 +14,11 @@ void CAnimatedVariable::create(ANIMATEDVARTYPE type, SAnimationPropertyConfig* p
     m_bDummy = false;
 }
 
-void CAnimatedVariable::create(ANIMATEDVARTYPE type, std::any val, SAnimationPropertyConfig* pAnimConfig, void* pWindow, AVARDAMAGEPOLICY policy) {
-    create(type, pAnimConfig, pWindow, policy);
-
-    try {
-        switch (type) {
-            case AVARTYPE_FLOAT: {
-                const auto V = std::any_cast<float>(val);
-                m_fValue     = V;
-                m_fGoal      = V;
-                break;
-            }
-            case AVARTYPE_VECTOR: {
-                const auto V = std::any_cast<Vector2D>(val);
-                m_vValue     = V;
-                m_vGoal      = V;
-                break;
-            }
-            case AVARTYPE_COLOR: {
-                const auto V = std::any_cast<CColor>(val);
-                m_cValue     = V;
-                m_cGoal      = V;
-                break;
-            }
-            default: ASSERT(false); break;
-        }
-    } catch (std::exception& e) {
-        Debug::log(ERR, "CAnimatedVariable create error: {}", e.what());
-        RASSERT(false, "CAnimatedVariable create error: {}", e.what());
-    }
-}
-
-CAnimatedVariable::~CAnimatedVariable() {
+CBaseAnimatedVariable::~CBaseAnimatedVariable() {
     unregister();
 }
 
-void CAnimatedVariable::unregister() {
+void CBaseAnimatedVariable::unregister() {
     if (!g_pAnimationManager)
         return;
     std::erase_if(g_pAnimationManager->m_vAnimatedVariables, [&](const auto& other) { return other == this; });
@@ -58,23 +26,23 @@ void CAnimatedVariable::unregister() {
     disconnectFromActive();
 }
 
-void CAnimatedVariable::registerVar() {
+void CBaseAnimatedVariable::registerVar() {
     if (!m_bIsRegistered)
         g_pAnimationManager->m_vAnimatedVariables.push_back(this);
     m_bIsRegistered = true;
 }
 
-int CAnimatedVariable::getDurationLeftMs() {
+int CBaseAnimatedVariable::getDurationLeftMs() {
     return std::max(
         (int)(m_pConfig->pValues->internalSpeed * 100) - (int)std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - animationBegin).count(), 0);
 }
 
-float CAnimatedVariable::getPercent() {
+float CBaseAnimatedVariable::getPercent() {
     const auto DURATIONPASSED = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now() - animationBegin).count();
     return std::clamp((DURATIONPASSED / 100.f) / m_pConfig->pValues->internalSpeed, 0.f, 1.f);
 }
 
-float CAnimatedVariable::getCurveValue() {
+float CBaseAnimatedVariable::getCurveValue() {
     if (!m_bIsBeingAnimated)
         return 1.f;
 
@@ -86,7 +54,7 @@ float CAnimatedVariable::getCurveValue() {
     return g_pAnimationManager->getBezier(m_pConfig->pValues->internalBezier)->getYForPoint(SPENT);
 }
 
-void CAnimatedVariable::connectToActive() {
+void CBaseAnimatedVariable::connectToActive() {
     g_pAnimationManager->scheduleTick(); // otherwise the animation manager will never pick this up
 
     if (!m_bIsConnectedToActive)
@@ -95,7 +63,7 @@ void CAnimatedVariable::connectToActive() {
     m_bIsConnectedToActive = true;
 }
 
-void CAnimatedVariable::disconnectFromActive() {
+void CBaseAnimatedVariable::disconnectFromActive() {
     std::erase_if(g_pAnimationManager->m_vActiveAnimatedVariables, [&](const auto& other) { return other == this; });
     m_bIsConnectedToActive = false;
 }

--- a/src/helpers/AnimatedVariable.hpp
+++ b/src/helpers/AnimatedVariable.hpp
@@ -18,20 +18,27 @@ enum ANIMATEDVARTYPE {
 
 // Utility to bind a type with its corresponding ANIMATEDVARTYPE
 template <class T>
-struct typeToANIMATEDVARTYPE_t { static constexpr ANIMATEDVARTYPE value = AVARTYPE_INVALID; };
+struct typeToANIMATEDVARTYPE_t {
+    static constexpr ANIMATEDVARTYPE value = AVARTYPE_INVALID;
+};
 
-template<>
-struct typeToANIMATEDVARTYPE_t<float> { static constexpr ANIMATEDVARTYPE value = AVARTYPE_FLOAT; };
+template <>
+struct typeToANIMATEDVARTYPE_t<float> {
+    static constexpr ANIMATEDVARTYPE value = AVARTYPE_FLOAT;
+};
 
-template<>
-struct typeToANIMATEDVARTYPE_t<Vector2D> { static constexpr ANIMATEDVARTYPE value = AVARTYPE_VECTOR; };
+template <>
+struct typeToANIMATEDVARTYPE_t<Vector2D> {
+    static constexpr ANIMATEDVARTYPE value = AVARTYPE_VECTOR;
+};
 
-template<>
-struct typeToANIMATEDVARTYPE_t<CColor> { static constexpr ANIMATEDVARTYPE value = AVARTYPE_COLOR; };
+template <>
+struct typeToANIMATEDVARTYPE_t<CColor> {
+    static constexpr ANIMATEDVARTYPE value = AVARTYPE_COLOR;
+};
 
 template <class T>
 inline constexpr ANIMATEDVARTYPE typeToANIMATEDVARTYPE = typeToANIMATEDVARTYPE_t<T>::value;
-
 
 enum AVARDAMAGEPOLICY {
     AVARDAMAGE_NONE   = -1,
@@ -73,7 +80,8 @@ class CBaseAnimatedVariable {
 
     virtual void warp(bool endCallback = true) = 0;
 
-    void         setConfig(SAnimationPropertyConfig* pConfig) {
+    //
+    void setConfig(SAnimationPropertyConfig* pConfig) {
         m_pConfig = pConfig;
     }
 
@@ -192,7 +200,6 @@ class CAnimatedVariable : public CBaseAnimatedVariable {
     CAnimatedVariable() : CBaseAnimatedVariable(typeToANIMATEDVARTYPE<VarType>) {} // dummy var
 
     void create(const VarType& value, SAnimationPropertyConfig* pAnimConfig, void* pWindow, AVARDAMAGEPOLICY policy) {
-
         create(pAnimConfig, pWindow, policy);
         m_Value = value;
     }

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -661,11 +661,11 @@ void CMonitor::setSpecialWorkspace(CWorkspace* const pWorkspace) {
             if (w->m_bIsFloating && !VECINRECT(MIDDLE, vecPosition.x, vecPosition.y, vecPosition.x + vecSize.x, vecPosition.y + vecSize.y) && w->m_iX11Type != 2) {
                 // if it's floating and the middle isnt on the current mon, move it to the center
                 const auto PMONFROMMIDDLE = g_pCompositor->getMonitorFromVector(MIDDLE);
-                Vector2D   pos            = w->m_vRealPosition.goalv();
+                Vector2D   pos            = w->m_vRealPosition.goal();
                 if (!VECINRECT(MIDDLE, PMONFROMMIDDLE->vecPosition.x, PMONFROMMIDDLE->vecPosition.y, PMONFROMMIDDLE->vecPosition.x + PMONFROMMIDDLE->vecSize.x,
                                PMONFROMMIDDLE->vecPosition.y + PMONFROMMIDDLE->vecSize.y)) {
                     // not on any monitor, center
-                    pos = middle() / 2.f - w->m_vRealSize.goalv() / 2.f;
+                    pos = middle() / 2.f - w->m_vRealSize.goal() / 2.f;
                 } else
                     pos = pos - PMONFROMMIDDLE->vecPosition + vecPosition;
 

--- a/src/helpers/WLClasses.cpp
+++ b/src/helpers/WLClasses.cpp
@@ -3,9 +3,9 @@
 #include "../Compositor.hpp"
 
 SLayerSurface::SLayerSurface() {
-    alpha.create(AVARTYPE_FLOAT, g_pConfigManager->getAnimationPropertyConfig("fadeLayers"), nullptr, AVARDAMAGE_ENTIRE);
-    realPosition.create(AVARTYPE_VECTOR, g_pConfigManager->getAnimationPropertyConfig("layers"), nullptr, AVARDAMAGE_ENTIRE);
-    realSize.create(AVARTYPE_VECTOR, g_pConfigManager->getAnimationPropertyConfig("layers"), nullptr, AVARDAMAGE_ENTIRE);
+    alpha.create(g_pConfigManager->getAnimationPropertyConfig("fadeLayers"), nullptr, AVARDAMAGE_ENTIRE);
+    realPosition.create(g_pConfigManager->getAnimationPropertyConfig("layers"), nullptr, AVARDAMAGE_ENTIRE);
+    realSize.create(g_pConfigManager->getAnimationPropertyConfig("layers"), nullptr, AVARDAMAGE_ENTIRE);
     alpha.m_pLayer        = this;
     realPosition.m_pLayer = this;
     realSize.m_pLayer     = this;
@@ -181,11 +181,11 @@ CRegion SConstraint::getLogicCoordsRegion() {
     result.add(&constraint->region); // surface-local coords
 
     if (!PWINDOWOWNER->m_bIsX11) {
-        result.translate(PWINDOWOWNER->m_vRealPosition.goalv());
+        result.translate(PWINDOWOWNER->m_vRealPosition.goal());
         return result;
     }
 
-    const auto COORDS = PWINDOWOWNER->m_bIsMapped ? PWINDOWOWNER->m_vRealPosition.goalv() :
+    const auto COORDS = PWINDOWOWNER->m_bIsMapped ? PWINDOWOWNER->m_vRealPosition.goal() :
                                                     g_pXWaylandManager->xwaylandToWaylandCoords({PWINDOWOWNER->m_uSurface.xwayland->x, PWINDOWOWNER->m_uSurface.xwayland->y});
 
     const auto PMONITOR = PWINDOWOWNER->m_bIsMapped ? g_pCompositor->getMonitorFromID(PWINDOWOWNER->m_iMonitorID) : g_pCompositor->getMonitorFromVector(COORDS);
@@ -210,9 +210,9 @@ Vector2D SConstraint::getLogicConstraintPos() {
         return {};
 
     if (!PWINDOWOWNER->m_bIsX11)
-        return PWINDOWOWNER->m_vRealPosition.goalv();
+        return PWINDOWOWNER->m_vRealPosition.goal();
 
-    const auto COORDS = PWINDOWOWNER->m_bIsMapped ? PWINDOWOWNER->m_vRealPosition.goalv() :
+    const auto COORDS = PWINDOWOWNER->m_bIsMapped ? PWINDOWOWNER->m_vRealPosition.goal() :
                                                     g_pXWaylandManager->xwaylandToWaylandCoords({PWINDOWOWNER->m_uSurface.xwayland->x, PWINDOWOWNER->m_uSurface.xwayland->y});
 
     return COORDS;
@@ -228,7 +228,7 @@ Vector2D SConstraint::getLogicConstraintSize() {
         return {};
 
     if (!PWINDOWOWNER->m_bIsX11)
-        return PWINDOWOWNER->m_vRealSize.goalv();
+        return PWINDOWOWNER->m_vRealSize.goal();
 
     const auto PMONITOR = PWINDOWOWNER->m_bIsMapped ?
         g_pCompositor->getMonitorFromID(PWINDOWOWNER->m_iMonitorID) :
@@ -237,7 +237,7 @@ Vector2D SConstraint::getLogicConstraintSize() {
     if (!PMONITOR)
         return {};
 
-    const auto SIZE = PWINDOWOWNER->m_bIsMapped ? PWINDOWOWNER->m_vRealSize.goalv() :
+    const auto SIZE = PWINDOWOWNER->m_bIsMapped ? PWINDOWOWNER->m_vRealSize.goal() :
                                                   Vector2D{PWINDOWOWNER->m_uSurface.xwayland->width, PWINDOWOWNER->m_uSurface.xwayland->height} * PMONITOR->xwaylandScale;
 
     return SIZE;

--- a/src/helpers/WLClasses.hpp
+++ b/src/helpers/WLClasses.hpp
@@ -19,19 +19,19 @@ struct SLayerSurface {
     SLayerSurface();
     ~SLayerSurface();
 
-    void                  applyRules();
-    void                  startAnimation(bool in, bool instant = false);
-    bool                  isFadedOut();
+    void                        applyRules();
+    void                        startAnimation(bool in, bool instant = false);
+    bool                        isFadedOut();
 
-    CAnimatedVariable     realPosition;
-    CAnimatedVariable     realSize;
+    CAnimatedVariable<Vector2D> realPosition;
+    CAnimatedVariable<Vector2D> realSize;
 
-    wlr_layer_surface_v1* layerSurface;
-    wl_list               link;
+    wlr_layer_surface_v1*       layerSurface;
+    wl_list                     link;
 
-    bool                  keyboardExclusive = false;
+    bool                        keyboardExclusive = false;
 
-    CWLSurface            surface;
+    CWLSurface                  surface;
 
     // desktop components
     std::unique_ptr<CPopup> popupHead;
@@ -51,7 +51,7 @@ struct SLayerSurface {
 
     std::string                szNamespace = "";
 
-    CAnimatedVariable          alpha;
+    CAnimatedVariable<float>   alpha;
     bool                       fadingOut     = false;
     bool                       readyToDelete = false;
     bool                       noProcess     = false;

--- a/src/hyprerror/HyprError.cpp
+++ b/src/hyprerror/HyprError.cpp
@@ -139,7 +139,7 @@ void CHyprError::draw() {
 
     if (m_bQueuedDestroy) {
         if (!m_fFadeOpacity.isBeingAnimated()) {
-            if (m_fFadeOpacity.fl() == 0.f) {
+            if (m_fFadeOpacity.value() == 0.f) {
                 m_bQueuedDestroy = false;
                 m_tTexture.destroyTexture();
                 m_bIsCreated = false;
@@ -164,7 +164,7 @@ void CHyprError::draw() {
 
     m_bMonitorChanged = false;
 
-    g_pHyprOpenGL->renderTexture(m_tTexture, &monbox, m_fFadeOpacity.fl(), 0);
+    g_pHyprOpenGL->renderTexture(m_tTexture, &monbox, m_fFadeOpacity.value(), 0);
 }
 
 void CHyprError::destroy() {

--- a/src/hyprerror/HyprError.hpp
+++ b/src/hyprerror/HyprError.hpp
@@ -16,16 +16,16 @@ class CHyprError {
     void destroy();
 
   private:
-    void              createQueued();
-    std::string       m_szQueued = "";
-    CColor            m_cQueued;
-    bool              m_bQueuedDestroy = false;
-    bool              m_bIsCreated     = false;
-    CTexture          m_tTexture;
-    CAnimatedVariable m_fFadeOpacity;
-    CBox              m_bDamageBox = {0, 0, 0, 0};
+    void                     createQueued();
+    std::string              m_szQueued = "";
+    CColor                   m_cQueued;
+    bool                     m_bQueuedDestroy = false;
+    bool                     m_bIsCreated     = false;
+    CTexture                 m_tTexture;
+    CAnimatedVariable<float> m_fFadeOpacity;
+    CBox                     m_bDamageBox = {0, 0, 0, 0};
 
-    bool              m_bMonitorChanged = false;
+    bool                     m_bMonitorChanged = false;
 };
 
 inline std::unique_ptr<CHyprError> g_pHyprError; // This is a full-screen error. Treat it with respect, and there can only be one at a time.

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -172,7 +172,7 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
         PWINDOW->m_vRealPosition = PWINDOW->m_vPosition + RESERVED.topLeft;
         PWINDOW->m_vRealSize     = PWINDOW->m_vSize - (RESERVED.topLeft + RESERVED.bottomRight);
 
-        g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goalv());
+        g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal());
 
         return;
     }
@@ -606,7 +606,7 @@ void CHyprDwindleLayout::resizeActiveWindow(const Vector2D& pixResize, eRectCorn
     const auto PNODE = getNodeFromWindow(PWINDOW);
 
     if (!PNODE) {
-        PWINDOW->m_vRealSize = Vector2D(std::max((PWINDOW->m_vRealSize.goalv() + pixResize).x, 20.0), std::max((PWINDOW->m_vRealSize.goalv() + pixResize).y, 20.0));
+        PWINDOW->m_vRealSize = Vector2D(std::max((PWINDOW->m_vRealSize.goal() + pixResize).x, 20.0), std::max((PWINDOW->m_vRealSize.goal() + pixResize).y, 20.0));
         PWINDOW->updateWindowDecos();
         return;
     }
@@ -625,7 +625,7 @@ void CHyprDwindleLayout::resizeActiveWindow(const Vector2D& pixResize, eRectCorn
         if (!m_PseudoDragFlags.started) {
             m_PseudoDragFlags.started = true;
 
-            const auto pseudoSize  = PWINDOW->m_vRealSize.goalv();
+            const auto pseudoSize  = PWINDOW->m_vRealSize.goal();
             const auto mouseOffset = g_pInputManager->getMouseCoordsInternal() - (PNODE->box.pos() + ((PNODE->box.size() / 2) - (pseudoSize / 2)));
 
             if (mouseOffset.x > 0 && mouseOffset.x < pseudoSize.x && mouseOffset.y > 0 && mouseOffset.y < pseudoSize.y) {
@@ -805,10 +805,10 @@ void CHyprDwindleLayout::fullscreenRequestForWindow(CWindow* pWindow, eFullscree
 
     // save position and size if floating
     if (pWindow->m_bIsFloating && on) {
-        pWindow->m_vLastFloatingSize     = pWindow->m_vRealSize.goalv();
-        pWindow->m_vLastFloatingPosition = pWindow->m_vRealPosition.goalv();
-        pWindow->m_vPosition             = pWindow->m_vRealPosition.goalv();
-        pWindow->m_vSize                 = pWindow->m_vRealSize.goalv();
+        pWindow->m_vLastFloatingSize     = pWindow->m_vRealSize.goal();
+        pWindow->m_vLastFloatingPosition = pWindow->m_vRealPosition.goal();
+        pWindow->m_vPosition             = pWindow->m_vRealPosition.goal();
+        pWindow->m_vSize                 = pWindow->m_vRealSize.goal();
     }
 
     // otherwise, accept it.
@@ -860,7 +860,7 @@ void CHyprDwindleLayout::fullscreenRequestForWindow(CWindow* pWindow, eFullscree
 
     g_pCompositor->updateWindowAnimatedDecorationValues(pWindow);
 
-    g_pXWaylandManager->setWindowSize(pWindow, pWindow->m_vRealSize.goalv());
+    g_pXWaylandManager->setWindowSize(pWindow, pWindow->m_vRealSize.goal());
 
     g_pCompositor->changeWindowZOrder(pWindow, true);
 

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -471,7 +471,8 @@ void IHyprLayout::changeWindowFloatingMode(CWindow* pWindow) {
         CBox wb = {pWindow->m_vRealPosition.goal() + (pWindow->m_vRealSize.goal() - pWindow->m_vLastFloatingSize) / 2.f, pWindow->m_vLastFloatingSize};
         wb.round();
 
-        if (DELTALESSTHAN(pWindow->m_vRealSize.value().x, pWindow->m_vLastFloatingSize.x, 10) && DELTALESSTHAN(pWindow->m_vRealSize.value().y, pWindow->m_vLastFloatingSize.y, 10)) {
+        if (DELTALESSTHAN(pWindow->m_vRealSize.value().x, pWindow->m_vLastFloatingSize.x, 10) &&
+            DELTALESSTHAN(pWindow->m_vRealSize.value().y, pWindow->m_vLastFloatingSize.y, 10)) {
             wb = {wb.pos() + Vector2D{10, 10}, wb.size() - Vector2D{20, 20}};
         }
 

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -105,7 +105,7 @@ void IHyprLayout::onWindowCreatedFloating(CWindow* pWindow) {
         }
 
         // reject any windows with size <= 5x5
-        if (pWindow->m_vRealSize.goalv().x <= 5 || pWindow->m_vRealSize.goalv().y <= 5)
+        if (pWindow->m_vRealSize.goal().x <= 5 || pWindow->m_vRealSize.goal().y <= 5)
             pWindow->m_vRealSize = PMONITOR->vecSize / 2.f;
 
         if (pWindow->m_bIsX11 && pWindow->m_uSurface.xwayland->override_redirect) {
@@ -113,11 +113,11 @@ void IHyprLayout::onWindowCreatedFloating(CWindow* pWindow) {
             if (pWindow->m_uSurface.xwayland->x != 0 && pWindow->m_uSurface.xwayland->y != 0)
                 pWindow->m_vRealPosition = g_pXWaylandManager->xwaylandToWaylandCoords({pWindow->m_uSurface.xwayland->x, pWindow->m_uSurface.xwayland->y});
             else
-                pWindow->m_vRealPosition = Vector2D(PMONITOR->vecPosition.x + (PMONITOR->vecSize.x - pWindow->m_vRealSize.goalv().x) / 2.f,
-                                                    PMONITOR->vecPosition.y + (PMONITOR->vecSize.y - pWindow->m_vRealSize.goalv().y) / 2.f);
+                pWindow->m_vRealPosition = Vector2D(PMONITOR->vecPosition.x + (PMONITOR->vecSize.x - pWindow->m_vRealSize.goal().x) / 2.f,
+                                                    PMONITOR->vecPosition.y + (PMONITOR->vecSize.y - pWindow->m_vRealSize.goal().y) / 2.f);
         } else {
-            pWindow->m_vRealPosition = Vector2D(PMONITOR->vecPosition.x + (PMONITOR->vecSize.x - pWindow->m_vRealSize.goalv().x) / 2.f,
-                                                PMONITOR->vecPosition.y + (PMONITOR->vecSize.y - pWindow->m_vRealSize.goalv().y) / 2.f);
+            pWindow->m_vRealPosition = Vector2D(PMONITOR->vecPosition.x + (PMONITOR->vecSize.x - pWindow->m_vRealSize.goal().x) / 2.f,
+                                                PMONITOR->vecPosition.y + (PMONITOR->vecSize.y - pWindow->m_vRealSize.goal().y) / 2.f);
         }
     } else {
         // we respect the size.
@@ -152,7 +152,7 @@ void IHyprLayout::onWindowCreatedFloating(CWindow* pWindow) {
     }
 
     if (**PXWLFORCESCALEZERO && pWindow->m_bIsX11)
-        pWindow->m_vRealSize = pWindow->m_vRealSize.goalv() / PMONITOR->scale;
+        pWindow->m_vRealSize = pWindow->m_vRealSize.goal() / PMONITOR->scale;
 
     if (pWindow->m_bX11DoesntWantBorders || (pWindow->m_bIsX11 && pWindow->m_uSurface.xwayland->override_redirect)) {
         pWindow->m_vRealPosition.warp();
@@ -160,11 +160,11 @@ void IHyprLayout::onWindowCreatedFloating(CWindow* pWindow) {
     }
 
     if (pWindow->m_iX11Type != 2) {
-        g_pXWaylandManager->setWindowSize(pWindow, pWindow->m_vRealSize.goalv());
+        g_pXWaylandManager->setWindowSize(pWindow, pWindow->m_vRealSize.goal());
 
         g_pCompositor->changeWindowZOrder(pWindow, true);
     } else {
-        pWindow->m_vPendingReportedSize = pWindow->m_vRealSize.goalv();
+        pWindow->m_vPendingReportedSize = pWindow->m_vRealSize.goal();
         pWindow->m_vReportedSize        = pWindow->m_vPendingReportedSize;
     }
 }
@@ -200,18 +200,18 @@ void IHyprLayout::onBeginDragWindow() {
 
     if (!DRAGGINGWINDOW->m_bIsFloating) {
         if (g_pInputManager->dragMode == MBIND_MOVE) {
-            DRAGGINGWINDOW->m_vLastFloatingSize = (DRAGGINGWINDOW->m_vRealSize.goalv() * 0.8489).clamp(Vector2D{5, 5}, Vector2D{}).floor();
+            DRAGGINGWINDOW->m_vLastFloatingSize = (DRAGGINGWINDOW->m_vRealSize.goal() * 0.8489).clamp(Vector2D{5, 5}, Vector2D{}).floor();
             changeWindowFloatingMode(DRAGGINGWINDOW);
             DRAGGINGWINDOW->m_bIsFloating    = true;
             DRAGGINGWINDOW->m_bDraggingTiled = true;
 
-            DRAGGINGWINDOW->m_vRealPosition = g_pInputManager->getMouseCoordsInternal() - DRAGGINGWINDOW->m_vRealSize.goalv() / 2.f;
+            DRAGGINGWINDOW->m_vRealPosition = g_pInputManager->getMouseCoordsInternal() - DRAGGINGWINDOW->m_vRealSize.goal() / 2.f;
         }
     }
 
     m_vBeginDragXY         = g_pInputManager->getMouseCoordsInternal();
-    m_vBeginDragPositionXY = DRAGGINGWINDOW->m_vRealPosition.goalv();
-    m_vBeginDragSizeXY     = DRAGGINGWINDOW->m_vRealSize.goalv();
+    m_vBeginDragPositionXY = DRAGGINGWINDOW->m_vRealPosition.goal();
+    m_vBeginDragSizeXY     = DRAGGINGWINDOW->m_vRealSize.goal();
     m_vLastDragXY          = m_vBeginDragXY;
 
     // get the grab corner
@@ -325,7 +325,7 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
 
     if (g_pInputManager->dragMode == MBIND_MOVE) {
 
-        CBox wb = {m_vBeginDragPositionXY + DELTA, DRAGGINGWINDOW->m_vRealSize.goalv()};
+        CBox wb = {m_vBeginDragPositionXY + DELTA, DRAGGINGWINDOW->m_vRealSize.goal()};
         wb.round();
 
         if (**PANIMATEMOUSE)
@@ -333,7 +333,7 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
         else
             DRAGGINGWINDOW->m_vRealPosition.setValueAndWarp(wb.pos());
 
-        g_pXWaylandManager->setWindowSize(DRAGGINGWINDOW, DRAGGINGWINDOW->m_vRealSize.goalv());
+        g_pXWaylandManager->setWindowSize(DRAGGINGWINDOW, DRAGGINGWINDOW->m_vRealSize.goal());
     } else if (g_pInputManager->dragMode == MBIND_RESIZE || g_pInputManager->dragMode == MBIND_RESIZE_FORCE_RATIO || g_pInputManager->dragMode == MBIND_RESIZE_BLOCK_RATIO) {
         if (DRAGGINGWINDOW->m_bIsFloating) {
 
@@ -394,14 +394,14 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
                 DRAGGINGWINDOW->m_vRealPosition.setValueAndWarp(wb.pos());
             }
 
-            g_pXWaylandManager->setWindowSize(DRAGGINGWINDOW, DRAGGINGWINDOW->m_vRealSize.goalv());
+            g_pXWaylandManager->setWindowSize(DRAGGINGWINDOW, DRAGGINGWINDOW->m_vRealSize.goal());
         } else {
             resizeActiveWindow(TICKDELTA, m_eGrabbedCorner, DRAGGINGWINDOW);
         }
     }
 
     // get middle point
-    Vector2D middle = DRAGGINGWINDOW->m_vRealPosition.vec() + DRAGGINGWINDOW->m_vRealSize.vec() / 2.f;
+    Vector2D middle = DRAGGINGWINDOW->m_vRealPosition.value() + DRAGGINGWINDOW->m_vRealSize.value() / 2.f;
 
     // and check its monitor
     const auto PMONITOR = g_pCompositor->getMonitorFromVector(middle);
@@ -435,18 +435,18 @@ void IHyprLayout::changeWindowFloatingMode(CWindow* pWindow) {
     EMIT_HOOK_EVENT("changeFloatingMode", pWindow);
 
     if (!TILED) {
-        const auto PNEWMON    = g_pCompositor->getMonitorFromVector(pWindow->m_vRealPosition.vec() + pWindow->m_vRealSize.vec() / 2.f);
+        const auto PNEWMON    = g_pCompositor->getMonitorFromVector(pWindow->m_vRealPosition.value() + pWindow->m_vRealSize.value() / 2.f);
         pWindow->m_iMonitorID = PNEWMON->ID;
         pWindow->moveToWorkspace(PNEWMON->specialWorkspaceID != 0 ? PNEWMON->specialWorkspaceID : PNEWMON->activeWorkspace);
         pWindow->updateGroupOutputs();
 
         // save real pos cuz the func applies the default 5,5 mid
-        const auto PSAVEDPOS  = pWindow->m_vRealPosition.goalv();
-        const auto PSAVEDSIZE = pWindow->m_vRealSize.goalv();
+        const auto PSAVEDPOS  = pWindow->m_vRealPosition.goal();
+        const auto PSAVEDSIZE = pWindow->m_vRealSize.goal();
 
         // if the window is pseudo, update its size
         if (!pWindow->m_bDraggingTiled)
-            pWindow->m_vPseudoSize = pWindow->m_vRealSize.goalv();
+            pWindow->m_vPseudoSize = pWindow->m_vRealSize.goal();
 
         pWindow->m_vLastFloatingSize = PSAVEDSIZE;
 
@@ -468,10 +468,10 @@ void IHyprLayout::changeWindowFloatingMode(CWindow* pWindow) {
 
         g_pCompositor->changeWindowZOrder(pWindow, true);
 
-        CBox wb = {pWindow->m_vRealPosition.goalv() + (pWindow->m_vRealSize.goalv() - pWindow->m_vLastFloatingSize) / 2.f, pWindow->m_vLastFloatingSize};
+        CBox wb = {pWindow->m_vRealPosition.goal() + (pWindow->m_vRealSize.goal() - pWindow->m_vLastFloatingSize) / 2.f, pWindow->m_vLastFloatingSize};
         wb.round();
 
-        if (DELTALESSTHAN(pWindow->m_vRealSize.vec().x, pWindow->m_vLastFloatingSize.x, 10) && DELTALESSTHAN(pWindow->m_vRealSize.vec().y, pWindow->m_vLastFloatingSize.y, 10)) {
+        if (DELTALESSTHAN(pWindow->m_vRealSize.value().x, pWindow->m_vLastFloatingSize.x, 10) && DELTALESSTHAN(pWindow->m_vRealSize.value().y, pWindow->m_vLastFloatingSize.y, 10)) {
             wb = {wb.pos() + Vector2D{10, 10}, wb.size() - Vector2D{20, 20}};
         }
 
@@ -505,7 +505,7 @@ void IHyprLayout::moveActiveWindow(const Vector2D& delta, CWindow* pWindow) {
         return;
     }
 
-    PWINDOW->m_vRealPosition = PWINDOW->m_vRealPosition.goalv() + delta;
+    PWINDOW->m_vRealPosition = PWINDOW->m_vRealPosition.goal() + delta;
 
     g_pHyprRenderer->damageWindow(PWINDOW);
 }

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -668,7 +668,7 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
         PWINDOW->m_vRealPosition = PWINDOW->m_vPosition + RESERVED.topLeft;
         PWINDOW->m_vRealSize     = PWINDOW->m_vSize - (RESERVED.topLeft + RESERVED.bottomRight);
 
-        g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goalv());
+        g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal());
 
         return;
     }
@@ -732,7 +732,7 @@ void CHyprMasterLayout::resizeActiveWindow(const Vector2D& pixResize, eRectCorne
     const auto PNODE = getNodeFromWindow(PWINDOW);
 
     if (!PNODE) {
-        PWINDOW->m_vRealSize = Vector2D(std::max((PWINDOW->m_vRealSize.goalv() + pixResize).x, 20.0), std::max((PWINDOW->m_vRealSize.goalv() + pixResize).y, 20.0));
+        PWINDOW->m_vRealSize = Vector2D(std::max((PWINDOW->m_vRealSize.goal() + pixResize).x, 20.0), std::max((PWINDOW->m_vRealSize.goal() + pixResize).y, 20.0));
         PWINDOW->updateWindowDecos();
         return;
     }
@@ -884,10 +884,10 @@ void CHyprMasterLayout::fullscreenRequestForWindow(CWindow* pWindow, eFullscreen
 
     // save position and size if floating
     if (pWindow->m_bIsFloating && on) {
-        pWindow->m_vLastFloatingSize     = pWindow->m_vRealSize.goalv();
-        pWindow->m_vLastFloatingPosition = pWindow->m_vRealPosition.goalv();
-        pWindow->m_vPosition             = pWindow->m_vRealPosition.goalv();
-        pWindow->m_vSize                 = pWindow->m_vRealSize.goalv();
+        pWindow->m_vLastFloatingSize     = pWindow->m_vRealSize.goal();
+        pWindow->m_vLastFloatingPosition = pWindow->m_vRealPosition.goal();
+        pWindow->m_vPosition             = pWindow->m_vRealPosition.goal();
+        pWindow->m_vSize                 = pWindow->m_vRealSize.goal();
     }
 
     // otherwise, accept it.
@@ -941,7 +941,7 @@ void CHyprMasterLayout::fullscreenRequestForWindow(CWindow* pWindow, eFullscreen
 
     g_pCompositor->updateWindowAnimatedDecorationValues(pWindow);
 
-    g_pXWaylandManager->setWindowSize(pWindow, pWindow->m_vRealSize.goalv());
+    g_pXWaylandManager->setWindowSize(pWindow, pWindow->m_vRealSize.goal());
 
     g_pCompositor->changeWindowZOrder(pWindow, true);
 

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -151,8 +151,7 @@ void CAnimationManager::tick() {
                 updateVariable(*typedAv);
                 break;
             }
-            default:
-                UNREACHABLE();
+            default: UNREACHABLE();
         }
         // set size and pos if valid, but only if damage policy entire (dont if border for example)
         if (g_pCompositor->windowValidMapped(PWINDOW) && av->m_eDamagePolicy == AVARDAMAGE_ENTIRE && PWINDOW->m_iX11Type != 2)

--- a/src/managers/AnimationManager.hpp
+++ b/src/managers/AnimationManager.hpp
@@ -28,8 +28,8 @@ class CAnimationManager {
 
     std::unordered_map<std::string, CBezierCurve> getAllBeziers();
 
-    std::vector<CAnimatedVariable*>               m_vAnimatedVariables;
-    std::vector<CAnimatedVariable*>               m_vActiveAnimatedVariables;
+    std::vector<CBaseAnimatedVariable*>               m_vAnimatedVariables;
+    std::vector<CBaseAnimatedVariable*>               m_vActiveAnimatedVariables;
 
     wl_event_source*                              m_pAnimationTick;
 

--- a/src/managers/AnimationManager.hpp
+++ b/src/managers/AnimationManager.hpp
@@ -28,8 +28,8 @@ class CAnimationManager {
 
     std::unordered_map<std::string, CBezierCurve> getAllBeziers();
 
-    std::vector<CBaseAnimatedVariable*>               m_vAnimatedVariables;
-    std::vector<CBaseAnimatedVariable*>               m_vActiveAnimatedVariables;
+    std::vector<CBaseAnimatedVariable*>           m_vAnimatedVariables;
+    std::vector<CBaseAnimatedVariable*>           m_vActiveAnimatedVariables;
 
     wl_event_source*                              m_pAnimationTick;
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -874,8 +874,8 @@ void CKeybindManager::centerWindow(std::string args) {
     if (args == "1")
         RESERVEDOFFSET = (PMONITOR->vecReservedTopLeft - PMONITOR->vecReservedBottomRight) / 2.f;
 
-    PWINDOW->m_vRealPosition = PMONITOR->middle() - PWINDOW->m_vRealSize.goalv() / 2.f + RESERVEDOFFSET;
-    PWINDOW->m_vPosition     = PWINDOW->m_vRealPosition.goalv();
+    PWINDOW->m_vRealPosition = PMONITOR->middle() - PWINDOW->m_vRealSize.goal() / 2.f + RESERVEDOFFSET;
+    PWINDOW->m_vPosition     = PWINDOW->m_vRealPosition.goal();
 }
 
 void CKeybindManager::toggleActivePseudo(std::string args) {
@@ -1222,14 +1222,14 @@ void CKeybindManager::moveActiveTo(std::string args) {
 
         switch (arg) {
             case 'l': vPos.x = PMONITOR->vecReservedTopLeft.x + BORDERSIZE + PMONITOR->vecPosition.x; break;
-            case 'r': vPos.x = PMONITOR->vecSize.x - PMONITOR->vecReservedBottomRight.x - PLASTWINDOW->m_vRealSize.goalv().x - BORDERSIZE + PMONITOR->vecPosition.x; break;
+            case 'r': vPos.x = PMONITOR->vecSize.x - PMONITOR->vecReservedBottomRight.x - PLASTWINDOW->m_vRealSize.goal().x - BORDERSIZE + PMONITOR->vecPosition.x; break;
             case 't':
             case 'u': vPos.y = PMONITOR->vecReservedTopLeft.y + BORDERSIZE + PMONITOR->vecPosition.y; break;
             case 'b':
-            case 'd': vPos.y = PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PLASTWINDOW->m_vRealSize.goalv().y - BORDERSIZE + PMONITOR->vecPosition.y; break;
+            case 'd': vPos.y = PMONITOR->vecSize.y - PMONITOR->vecReservedBottomRight.y - PLASTWINDOW->m_vRealSize.goal().y - BORDERSIZE + PMONITOR->vecPosition.y; break;
         }
 
-        PLASTWINDOW->m_vRealPosition = Vector2D(vPos.x != 0 ? vPos.x : PLASTWINDOW->m_vRealPosition.goalv().x, vPos.y != 0 ? vPos.y : PLASTWINDOW->m_vRealPosition.goalv().y);
+        PLASTWINDOW->m_vRealPosition = Vector2D(vPos.x != 0 ? vPos.x : PLASTWINDOW->m_vRealPosition.goal().x, vPos.y != 0 ? vPos.y : PLASTWINDOW->m_vRealPosition.goal().y);
         return;
     }
 
@@ -1377,22 +1377,22 @@ void CKeybindManager::moveCursorToCorner(std::string arg) {
     switch (CORNER) {
         case 0:
             // bottom left
-            wlr_cursor_warp(g_pCompositor->m_sWLRCursor, g_pCompositor->m_sSeat.mouse->mouse, PWINDOW->m_vRealPosition.vec().x,
-                            PWINDOW->m_vRealPosition.vec().y + PWINDOW->m_vRealSize.vec().y);
+            wlr_cursor_warp(g_pCompositor->m_sWLRCursor, g_pCompositor->m_sSeat.mouse->mouse, PWINDOW->m_vRealPosition.value().x,
+                            PWINDOW->m_vRealPosition.value().y + PWINDOW->m_vRealSize.value().y);
             break;
         case 1:
             // bottom right
-            wlr_cursor_warp(g_pCompositor->m_sWLRCursor, g_pCompositor->m_sSeat.mouse->mouse, PWINDOW->m_vRealPosition.vec().x + PWINDOW->m_vRealSize.vec().x,
-                            PWINDOW->m_vRealPosition.vec().y + PWINDOW->m_vRealSize.vec().y);
+            wlr_cursor_warp(g_pCompositor->m_sWLRCursor, g_pCompositor->m_sSeat.mouse->mouse, PWINDOW->m_vRealPosition.value().x + PWINDOW->m_vRealSize.value().x,
+                            PWINDOW->m_vRealPosition.value().y + PWINDOW->m_vRealSize.value().y);
             break;
         case 2:
             // top right
-            wlr_cursor_warp(g_pCompositor->m_sWLRCursor, g_pCompositor->m_sSeat.mouse->mouse, PWINDOW->m_vRealPosition.vec().x + PWINDOW->m_vRealSize.vec().x,
-                            PWINDOW->m_vRealPosition.vec().y);
+            wlr_cursor_warp(g_pCompositor->m_sWLRCursor, g_pCompositor->m_sSeat.mouse->mouse, PWINDOW->m_vRealPosition.value().x + PWINDOW->m_vRealSize.value().x,
+                            PWINDOW->m_vRealPosition.value().y);
             break;
         case 3:
             // top left
-            wlr_cursor_warp(g_pCompositor->m_sWLRCursor, g_pCompositor->m_sSeat.mouse->mouse, PWINDOW->m_vRealPosition.vec().x, PWINDOW->m_vRealPosition.vec().y);
+            wlr_cursor_warp(g_pCompositor->m_sWLRCursor, g_pCompositor->m_sSeat.mouse->mouse, PWINDOW->m_vRealPosition.value().x, PWINDOW->m_vRealPosition.value().y);
             break;
     }
 }
@@ -1457,8 +1457,8 @@ void CKeybindManager::workspaceOpt(std::string args) {
                 continue;
 
             if (!w->m_bRequestsFloat && w->m_bIsFloating != PWORKSPACE->m_bDefaultFloating) {
-                const auto SAVEDPOS  = w->m_vRealPosition.vec();
-                const auto SAVEDSIZE = w->m_vRealSize.vec();
+                const auto SAVEDPOS  = w->m_vRealPosition.value();
+                const auto SAVEDSIZE = w->m_vRealSize.value();
 
                 w->m_bIsFloating = PWORKSPACE->m_bDefaultFloating;
                 g_pLayoutManager->getCurrentLayout()->changeWindowFloatingMode(w);
@@ -1467,8 +1467,8 @@ void CKeybindManager::workspaceOpt(std::string args) {
                     w->m_vRealPosition.setValueAndWarp(SAVEDPOS);
                     w->m_vRealSize.setValueAndWarp(SAVEDSIZE);
                     g_pXWaylandManager->setWindowSize(w, SAVEDSIZE);
-                    w->m_vRealSize     = w->m_vRealSize.vec() + Vector2D(4, 4);
-                    w->m_vRealPosition = w->m_vRealPosition.vec() - Vector2D(2, 2);
+                    w->m_vRealSize     = w->m_vRealSize.value() + Vector2D(4, 4);
+                    w->m_vRealPosition = w->m_vRealPosition.value() - Vector2D(2, 2);
                 }
             }
         }
@@ -1651,14 +1651,14 @@ void CKeybindManager::resizeActive(std::string args) {
     if (!g_pCompositor->m_pLastWindow || g_pCompositor->m_pLastWindow->m_bIsFullscreen)
         return;
 
-    const auto SIZ = g_pCompositor->parseWindowVectorArgsRelative(args, g_pCompositor->m_pLastWindow->m_vRealSize.goalv());
+    const auto SIZ = g_pCompositor->parseWindowVectorArgsRelative(args, g_pCompositor->m_pLastWindow->m_vRealSize.goal());
 
     if (SIZ.x < 1 || SIZ.y < 1)
         return;
 
-    g_pLayoutManager->getCurrentLayout()->resizeActiveWindow(SIZ - g_pCompositor->m_pLastWindow->m_vRealSize.goalv());
+    g_pLayoutManager->getCurrentLayout()->resizeActiveWindow(SIZ - g_pCompositor->m_pLastWindow->m_vRealSize.goal());
 
-    if (g_pCompositor->m_pLastWindow->m_vRealSize.goalv().x > 1 && g_pCompositor->m_pLastWindow->m_vRealSize.goalv().y > 1)
+    if (g_pCompositor->m_pLastWindow->m_vRealSize.goal().x > 1 && g_pCompositor->m_pLastWindow->m_vRealSize.goal().y > 1)
         g_pCompositor->m_pLastWindow->setHidden(false);
 }
 
@@ -1666,9 +1666,9 @@ void CKeybindManager::moveActive(std::string args) {
     if (!g_pCompositor->m_pLastWindow || g_pCompositor->m_pLastWindow->m_bIsFullscreen)
         return;
 
-    const auto POS = g_pCompositor->parseWindowVectorArgsRelative(args, g_pCompositor->m_pLastWindow->m_vRealPosition.goalv());
+    const auto POS = g_pCompositor->parseWindowVectorArgsRelative(args, g_pCompositor->m_pLastWindow->m_vRealPosition.goal());
 
-    g_pLayoutManager->getCurrentLayout()->moveActiveWindow(POS - g_pCompositor->m_pLastWindow->m_vRealPosition.goalv());
+    g_pLayoutManager->getCurrentLayout()->moveActiveWindow(POS - g_pCompositor->m_pLastWindow->m_vRealPosition.goal());
 }
 
 void CKeybindManager::moveWindow(std::string args) {
@@ -1686,9 +1686,9 @@ void CKeybindManager::moveWindow(std::string args) {
     if (PWINDOW->m_bIsFullscreen)
         return;
 
-    const auto POS = g_pCompositor->parseWindowVectorArgsRelative(MOVECMD, PWINDOW->m_vRealPosition.goalv());
+    const auto POS = g_pCompositor->parseWindowVectorArgsRelative(MOVECMD, PWINDOW->m_vRealPosition.goal());
 
-    g_pLayoutManager->getCurrentLayout()->moveActiveWindow(POS - PWINDOW->m_vRealPosition.goalv(), PWINDOW);
+    g_pLayoutManager->getCurrentLayout()->moveActiveWindow(POS - PWINDOW->m_vRealPosition.goal(), PWINDOW);
 }
 
 void CKeybindManager::resizeWindow(std::string args) {
@@ -1706,14 +1706,14 @@ void CKeybindManager::resizeWindow(std::string args) {
     if (PWINDOW->m_bIsFullscreen)
         return;
 
-    const auto SIZ = g_pCompositor->parseWindowVectorArgsRelative(MOVECMD, PWINDOW->m_vRealSize.goalv());
+    const auto SIZ = g_pCompositor->parseWindowVectorArgsRelative(MOVECMD, PWINDOW->m_vRealSize.goal());
 
     if (SIZ.x < 1 || SIZ.y < 1)
         return;
 
-    g_pLayoutManager->getCurrentLayout()->resizeActiveWindow(SIZ - PWINDOW->m_vRealSize.goalv(), CORNER_NONE, PWINDOW);
+    g_pLayoutManager->getCurrentLayout()->resizeActiveWindow(SIZ - PWINDOW->m_vRealSize.goal(), CORNER_NONE, PWINDOW);
 
-    if (PWINDOW->m_vRealSize.goalv().x > 1 && PWINDOW->m_vRealSize.goalv().y > 1)
+    if (PWINDOW->m_vRealSize.goal().x > 1 && PWINDOW->m_vRealSize.goal().y > 1)
         PWINDOW->setHidden(false);
 }
 

--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -55,7 +55,7 @@ void CHyprXWaylandManager::activateSurface(wlr_surface* pSurface, bool activate)
 
 void CHyprXWaylandManager::activateWindow(CWindow* pWindow, bool activate) {
     if (pWindow->m_bIsX11) {
-        setWindowSize(pWindow, pWindow->m_vRealSize.vec()); // update xwayland output pos
+        setWindowSize(pWindow, pWindow->m_vRealSize.value()); // update xwayland output pos
 
         if (activate) {
             wlr_xwayland_surface_set_minimized(pWindow->m_uSurface.xwayland, false);
@@ -161,7 +161,7 @@ void CHyprXWaylandManager::setWindowSize(CWindow* pWindow, Vector2D size, bool f
 
     // calculate pos
     // TODO: this should be decoupled from setWindowSize IMO
-    Vector2D windowPos = pWindow->m_vRealPosition.vec();
+    Vector2D windowPos = pWindow->m_vRealPosition.value();
 
     if (pWindow->m_bIsX11 && PMONITOR) {
         windowPos = windowPos - PMONITOR->vecPosition; // normalize to monitor
@@ -266,7 +266,7 @@ void CHyprXWaylandManager::moveXWaylandWindow(CWindow* pWindow, const Vector2D& 
     if (!pWindow->m_bIsX11)
         return;
 
-    wlr_xwayland_surface_configure(pWindow->m_uSurface.xwayland, pos.x, pos.y, pWindow->m_vRealSize.vec().x, pWindow->m_vRealSize.vec().y);
+    wlr_xwayland_surface_configure(pWindow->m_uSurface.xwayland, pos.x, pos.y, pWindow->m_vRealSize.value().x, pWindow->m_vRealSize.value().y);
 }
 
 void CHyprXWaylandManager::checkBorders(CWindow* pWindow) {

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -66,7 +66,7 @@ void CInputManager::sendMotionEventsToFocused() {
     timespec   now;
     clock_gettime(CLOCK_MONOTONIC, &now);
 
-    const auto LOCAL = getMouseCoordsInternal() - (PWINDOW ? PWINDOW->m_vRealPosition.goalv() : (PLS ? Vector2D{PLS->geometry.x, PLS->geometry.y} : Vector2D{}));
+    const auto LOCAL = getMouseCoordsInternal() - (PWINDOW ? PWINDOW->m_vRealPosition.goal() : (PLS ? Vector2D{PLS->geometry.x, PLS->geometry.y} : Vector2D{}));
 
     wlr_seat_pointer_notify_enter(g_pCompositor->m_sSeat.seat, g_pCompositor->m_pLastFocus, LOCAL.x, LOCAL.y);
     wlr_seat_pointer_notify_motion(g_pCompositor->m_sSeat.seat, now.tv_sec * 1000 + now.tv_nsec / 10000000, LOCAL.x, LOCAL.y);
@@ -134,7 +134,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
 
     if (forcedFocus) {
         pFoundWindow = forcedFocus;
-        surfacePos   = pFoundWindow->m_vRealPosition.vec();
+        surfacePos   = pFoundWindow->m_vRealPosition.value();
         foundSurface = pFoundWindow->m_pWLSurface.wlr();
     }
 
@@ -182,7 +182,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
 
             if (CONSTRAINTWINDOW->m_bIsX11) {
                 foundSurface = CONSTRAINTWINDOW->m_pWLSurface.wlr();
-                surfacePos   = CONSTRAINTWINDOW->m_vRealPosition.vec();
+                surfacePos   = CONSTRAINTWINDOW->m_vRealPosition.value();
             } else {
                 g_pCompositor->vectorWindowToSurface(mouseCoords, CONSTRAINTWINDOW, surfaceCoords);
             }
@@ -273,7 +273,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
             surfacePos   = Vector2D(-1337, -1337);
         } else {
             foundSurface = pFoundWindow->m_pWLSurface.wlr();
-            surfacePos   = pFoundWindow->m_vRealPosition.vec();
+            surfacePos   = pFoundWindow->m_vRealPosition.value();
         }
     }
 
@@ -302,7 +302,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
                 foundSurface = g_pCompositor->vectorWindowToSurface(mouseCoords, pFoundWindow, surfaceCoords);
             } else {
                 foundSurface = pFoundWindow->m_pWLSurface.wlr();
-                surfacePos   = pFoundWindow->m_vRealPosition.vec();
+                surfacePos   = pFoundWindow->m_vRealPosition.value();
             }
         }
     }
@@ -626,7 +626,7 @@ void CInputManager::processMouseDownNormal(wlr_pointer_button_event* e) {
     // TODO detect click on LS properly
     if (**PRESIZEONBORDER && !m_bLastFocusOnLS && e->state == WLR_BUTTON_PRESSED) {
         if (w && !w->m_bIsFullscreen) {
-            const CBox real = {w->m_vRealPosition.vec().x, w->m_vRealPosition.vec().y, w->m_vRealSize.vec().x, w->m_vRealSize.vec().y};
+            const CBox real = {w->m_vRealPosition.value().x, w->m_vRealPosition.value().y, w->m_vRealSize.value().x, w->m_vRealSize.value().y};
             const CBox grab = {real.x - BORDER_GRAB_AREA, real.y - BORDER_GRAB_AREA, real.width + 2 * BORDER_GRAB_AREA, real.height + 2 * BORDER_GRAB_AREA};
 
             if ((grab.containsPoint(mouseCoords) && (!real.containsPoint(mouseCoords) || w->isInCurvedCorner(mouseCoords.x, mouseCoords.y))) && !w->hasPopupAt(mouseCoords)) {
@@ -1304,9 +1304,9 @@ void CInputManager::constrainMouse(SMouse* pMouse, wlr_pointer_constraint_v1* co
 
     if (const auto PWINDOW = g_pCompositor->getWindowFromSurface(constraint->surface); PWINDOW) {
         const auto RELATIVETO = PWINDOW->m_bIsX11 ?
-            (PWINDOW->m_bIsMapped ? PWINDOW->m_vRealPosition.goalv() :
+            (PWINDOW->m_bIsMapped ? PWINDOW->m_vRealPosition.goal() :
                                     g_pXWaylandManager->xwaylandToWaylandCoords({PWINDOW->m_uSurface.xwayland->x, PWINDOW->m_uSurface.xwayland->y})) :
-            PWINDOW->m_vRealPosition.goalv();
+            PWINDOW->m_vRealPosition.goal();
 
         PCONSTRAINT->cursorPosOnActivate = (MOUSECOORDS - RELATIVETO) * PWINDOW->m_fX11SurfaceScaledBy;
     }

--- a/src/managers/input/InputMethodRelay.cpp
+++ b/src/managers/input/InputMethodRelay.cpp
@@ -192,8 +192,8 @@ void CInputMethodRelay::updateInputPopup(SIMEPopup* pPopup) {
         const auto PWINDOW = g_pCompositor->getWindowFromSurface(PFOCUSEDSURFACE);
 
         if (PWINDOW) {
-            parentPos  = PWINDOW->m_vRealPosition.goalv();
-            parentSize = PWINDOW->m_vRealSize.goalv();
+            parentPos  = PWINDOW->m_vRealPosition.goal();
+            parentSize = PWINDOW->m_vRealSize.goal();
             pMonitor   = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID);
         }
     }
@@ -298,7 +298,7 @@ void CInputMethodRelay::damagePopup(SIMEPopup* pPopup) {
         const auto PWINDOW = g_pCompositor->getWindowFromSurface(PFOCUSEDSURFACE);
 
         if (PWINDOW) {
-            parentPos = PWINDOW->m_vRealPosition.goalv();
+            parentPos = PWINDOW->m_vRealPosition.goal();
         }
     }
 

--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -79,7 +79,7 @@ void CInputManager::onSwipeEnd(wlr_pointer_swipe_end_event* e) {
     auto        PWORKSPACER = g_pCompositor->getWorkspaceByID(workspaceIDRight); // not guaranteed if PSWIPENEW || PSWIPENUMBER
     auto        PWORKSPACEL = g_pCompositor->getWorkspaceByID(workspaceIDLeft);  // not guaranteed if PSWIPENUMBER
 
-    const auto  RENDEROFFSETMIDDLE = m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.vec();
+    const auto  RENDEROFFSETMIDDLE = m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.value();
     const auto  XDISTANCE          = m_sActiveSwipe.pMonitor->vecSize.x + **PWORKSPACEGAP;
     const auto  YDISTANCE          = m_sActiveSwipe.pMonitor->vecSize.y + **PWORKSPACEGAP;
 
@@ -118,7 +118,7 @@ void CInputManager::onSwipeEnd(wlr_pointer_swipe_end_event* e) {
         pSwitchedTo = m_sActiveSwipe.pWorkspaceBegin;
     } else if (m_sActiveSwipe.delta < 0) {
         // switch to left
-        const auto RENDEROFFSET = PWORKSPACEL ? PWORKSPACEL->m_vRenderOffset.vec() : Vector2D();
+        const auto RENDEROFFSET = PWORKSPACEL ? PWORKSPACEL->m_vRenderOffset.value() : Vector2D();
 
         if (PWORKSPACEL)
             m_sActiveSwipe.pMonitor->changeWorkspace(workspaceIDLeft);
@@ -144,7 +144,7 @@ void CInputManager::onSwipeEnd(wlr_pointer_swipe_end_event* e) {
         pSwitchedTo = PWORKSPACEL;
     } else {
         // switch to right
-        const auto RENDEROFFSET = PWORKSPACER ? PWORKSPACER->m_vRenderOffset.vec() : Vector2D();
+        const auto RENDEROFFSET = PWORKSPACER ? PWORKSPACER->m_vRenderOffset.value() : Vector2D();
 
         if (PWORKSPACER)
             m_sActiveSwipe.pMonitor->changeWorkspace(workspaceIDRight);

--- a/src/managers/input/Tablets.cpp
+++ b/src/managers/input/Tablets.cpp
@@ -267,7 +267,7 @@ void CInputManager::focusTablet(STablet* pTab, wlr_tablet_tool* pTool, bool moti
         }
 
         if (motion) {
-            auto local = CURSORPOS - PWINDOW->m_vRealPosition.goalv();
+            auto local = CURSORPOS - PWINDOW->m_vRealPosition.goal();
 
             if (PWINDOW->m_bIsX11)
                 local = local * PWINDOW->m_fX11SurfaceScaledBy;

--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -34,8 +34,8 @@ void CInputManager::onTouchDown(wlr_touch_down_event* e) {
 
     if (m_sTouchData.touchFocusWindow) {
         if (m_sTouchData.touchFocusWindow->m_bIsX11) {
-            local = (g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchFocusWindow->m_vRealPosition.goalv()) * m_sTouchData.touchFocusWindow->m_fX11SurfaceScaledBy;
-            m_sTouchData.touchSurfaceOrigin = m_sTouchData.touchFocusWindow->m_vRealPosition.goalv();
+            local = (g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchFocusWindow->m_vRealPosition.goal()) * m_sTouchData.touchFocusWindow->m_fX11SurfaceScaledBy;
+            m_sTouchData.touchSurfaceOrigin = m_sTouchData.touchFocusWindow->m_vRealPosition.goal();
         } else {
             g_pCompositor->vectorWindowToSurface(g_pInputManager->getMouseCoordsInternal(), m_sTouchData.touchFocusWindow, local);
             m_sTouchData.touchSurfaceOrigin = g_pInputManager->getMouseCoordsInternal() - local;

--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -212,7 +212,7 @@ void CToplevelExportProtocolManager::captureToplevel(wl_client* client, wl_resou
         PFRAME->dmabufFormat = DRM_FORMAT_INVALID;
     }
 
-    PFRAME->box = {0, 0, (int)(PFRAME->pWindow->m_vRealSize.vec().x * PMONITOR->scale), (int)(PFRAME->pWindow->m_vRealSize.vec().y * PMONITOR->scale)};
+    PFRAME->box = {0, 0, (int)(PFRAME->pWindow->m_vRealSize.value().x * PMONITOR->scale), (int)(PFRAME->pWindow->m_vRealSize.value().y * PMONITOR->scale)};
     int ow, oh;
     wlr_output_effective_resolution(PMONITOR->output, &ow, &oh);
     PFRAME->box.transform(PMONITOR->transform, ow, oh).round();
@@ -322,7 +322,7 @@ void CToplevelExportProtocolManager::onOutputCommit(CMonitor* pMonitor, wlr_outp
         if (PMONITOR != g_pCompositor->getMonitorFromID(f->pWindow->m_iMonitorID))
             continue;
 
-        CBox geometry = {f->pWindow->m_vRealPosition.vec().x, f->pWindow->m_vRealPosition.vec().y, f->pWindow->m_vRealSize.vec().x, f->pWindow->m_vRealSize.vec().y};
+        CBox geometry = {f->pWindow->m_vRealPosition.value().x, f->pWindow->m_vRealPosition.value().y, f->pWindow->m_vRealSize.value().x, f->pWindow->m_vRealSize.value().y};
 
         if (!wlr_output_layout_intersects(g_pCompositor->m_sWLROutputLayout, pMonitor->output, geometry.pWlr()))
             continue;
@@ -404,7 +404,7 @@ bool CToplevelExportProtocolManager::copyFrameShm(SScreencopyFrame* frame, times
     g_pHyprRenderer->m_bBlockSurfaceFeedback = false;
 
     if (frame->overlayCursor)
-        g_pHyprRenderer->renderSoftwareCursors(PMONITOR, fakeDamage, g_pInputManager->getMouseCoordsInternal() - frame->pWindow->m_vRealPosition.vec());
+        g_pHyprRenderer->renderSoftwareCursors(PMONITOR, fakeDamage, g_pInputManager->getMouseCoordsInternal() - frame->pWindow->m_vRealPosition.value());
 
     const auto PFORMAT = g_pHyprOpenGL->getPixelFormatFromDRM(format);
     if (!PFORMAT) {
@@ -450,7 +450,7 @@ bool CToplevelExportProtocolManager::copyFrameDmabuf(SScreencopyFrame* frame, ti
     g_pHyprRenderer->m_bBlockSurfaceFeedback = false;
 
     if (frame->overlayCursor)
-        g_pHyprRenderer->renderSoftwareCursors(PMONITOR, fakeDamage, g_pInputManager->getMouseCoordsInternal() - frame->pWindow->m_vRealPosition.vec());
+        g_pHyprRenderer->renderSoftwareCursors(PMONITOR, fakeDamage, g_pInputManager->getMouseCoordsInternal() - frame->pWindow->m_vRealPosition.value());
 
     g_pHyprRenderer->endRender();
     return true;

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -168,7 +168,7 @@ bool CHyprOpenGLImpl::passRequiresIntrospection(CMonitor* pMonitor) {
             if (!ws->m_bIsSpecialWorkspace || ws->m_iMonitorID != pMonitor->ID)
                 continue;
 
-            if (ws->m_fAlpha.fl() == 0)
+            if (ws->m_fAlpha.value() == 0)
                 continue;
 
             return true;
@@ -881,7 +881,7 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(const CTexture& tex, CBox*
 
         if (allowDim && m_pCurrentWindow && **PDIMINACTIVE) {
             glUniform1i(shader->applyTint, 1);
-            const auto DIM = m_pCurrentWindow->m_fDimPercent.fl();
+            const auto DIM = m_pCurrentWindow->m_fDimPercent.value();
             glUniform3f(shader->tint, 1.f - DIM, 1.f - DIM, 1.f - DIM);
         } else {
             glUniform1i(shader->applyTint, 0);
@@ -1292,7 +1292,7 @@ void CHyprOpenGLImpl::preRender(CMonitor* pMonitor) {
         const auto  PSURFACE = pWindow->m_pWLSurface.wlr();
 
         const auto  PWORKSPACE = g_pCompositor->getWorkspaceByID(pWindow->m_iWorkspaceID);
-        const float A          = pWindow->m_fAlpha.fl() * pWindow->m_fActiveInactiveAlpha.fl() * PWORKSPACE->m_fAlpha.fl();
+        const float A          = pWindow->m_fAlpha.value() * pWindow->m_fActiveInactiveAlpha.value() * PWORKSPACE->m_fAlpha.value();
 
         if (A >= 1.f) {
             if (PSURFACE->opaque)
@@ -1330,7 +1330,7 @@ void CHyprOpenGLImpl::preRender(CMonitor* pMonitor) {
                 if (!ls->layerSurface || ls->xray != 1)
                     continue;
 
-                if (ls->layerSurface->surface->opaque && ls->alpha.fl() >= 1.f)
+                if (ls->layerSurface->surface->opaque && ls->alpha.value() >= 1.f)
                     continue;
 
                 hasWindows = true;
@@ -1773,25 +1773,25 @@ void CHyprOpenGLImpl::renderSnapshot(CWindow** pWindow) {
     CBox       windowBox;
     // some mafs to figure out the correct box
     // the originalClosedPos is relative to the monitor's pos
-    Vector2D scaleXY = Vector2D((PMONITOR->scale * PWINDOW->m_vRealSize.vec().x / (PWINDOW->m_vOriginalClosedSize.x * PMONITOR->scale)),
-                                (PMONITOR->scale * PWINDOW->m_vRealSize.vec().y / (PWINDOW->m_vOriginalClosedSize.y * PMONITOR->scale)));
+    Vector2D scaleXY = Vector2D((PMONITOR->scale * PWINDOW->m_vRealSize.value().x / (PWINDOW->m_vOriginalClosedSize.x * PMONITOR->scale)),
+                                (PMONITOR->scale * PWINDOW->m_vRealSize.value().y / (PWINDOW->m_vOriginalClosedSize.y * PMONITOR->scale)));
 
     windowBox.width  = PMONITOR->vecTransformedSize.x * scaleXY.x;
     windowBox.height = PMONITOR->vecTransformedSize.y * scaleXY.y;
-    windowBox.x      = ((PWINDOW->m_vRealPosition.vec().x - PMONITOR->vecPosition.x) * PMONITOR->scale) - ((PWINDOW->m_vOriginalClosedPos.x * PMONITOR->scale) * scaleXY.x);
-    windowBox.y      = ((PWINDOW->m_vRealPosition.vec().y - PMONITOR->vecPosition.y) * PMONITOR->scale) - ((PWINDOW->m_vOriginalClosedPos.y * PMONITOR->scale) * scaleXY.y);
+    windowBox.x      = ((PWINDOW->m_vRealPosition.value().x - PMONITOR->vecPosition.x) * PMONITOR->scale) - ((PWINDOW->m_vOriginalClosedPos.x * PMONITOR->scale) * scaleXY.x);
+    windowBox.y      = ((PWINDOW->m_vRealPosition.value().y - PMONITOR->vecPosition.y) * PMONITOR->scale) - ((PWINDOW->m_vOriginalClosedPos.y * PMONITOR->scale) * scaleXY.y);
 
     CRegion fakeDamage{0, 0, PMONITOR->vecTransformedSize.x, PMONITOR->vecTransformedSize.y};
 
     if (**PDIMAROUND && (*pWindow)->m_sAdditionalConfigData.dimAround) {
         CBox monbox = {0, 0, g_pHyprOpenGL->m_RenderData.pMonitor->vecPixelSize.x, g_pHyprOpenGL->m_RenderData.pMonitor->vecPixelSize.y};
-        g_pHyprOpenGL->renderRect(&monbox, CColor(0, 0, 0, **PDIMAROUND * PWINDOW->m_fAlpha.fl()));
+        g_pHyprOpenGL->renderRect(&monbox, CColor(0, 0, 0, **PDIMAROUND * PWINDOW->m_fAlpha.value()));
         g_pHyprRenderer->damageMonitor(PMONITOR);
     }
 
     m_bEndFrame = true;
 
-    renderTextureInternalWithDamage(it->second.m_cTex, &windowBox, PWINDOW->m_fAlpha.fl(), &fakeDamage, 0);
+    renderTextureInternalWithDamage(it->second.m_cTex, &windowBox, PWINDOW->m_fAlpha.value(), &fakeDamage, 0);
 
     m_bEndFrame = false;
 }
@@ -1815,19 +1815,19 @@ void CHyprOpenGLImpl::renderSnapshot(SLayerSurface** pLayer) {
     CBox       layerBox;
     // some mafs to figure out the correct box
     // the originalClosedPos is relative to the monitor's pos
-    Vector2D scaleXY = Vector2D((PMONITOR->scale * PLAYER->realSize.vec().x / (PLAYER->geometry.w * PMONITOR->scale)),
-                                (PMONITOR->scale * PLAYER->realSize.vec().y / (PLAYER->geometry.h * PMONITOR->scale)));
+    Vector2D scaleXY = Vector2D((PMONITOR->scale * PLAYER->realSize.value().x / (PLAYER->geometry.w * PMONITOR->scale)),
+                                (PMONITOR->scale * PLAYER->realSize.value().y / (PLAYER->geometry.h * PMONITOR->scale)));
 
     layerBox.width  = PMONITOR->vecTransformedSize.x * scaleXY.x;
     layerBox.height = PMONITOR->vecTransformedSize.y * scaleXY.y;
-    layerBox.x = ((PLAYER->realPosition.vec().x - PMONITOR->vecPosition.x) * PMONITOR->scale) - (((PLAYER->geometry.x - PMONITOR->vecPosition.x) * PMONITOR->scale) * scaleXY.x);
-    layerBox.y = ((PLAYER->realPosition.vec().y - PMONITOR->vecPosition.y) * PMONITOR->scale) - (((PLAYER->geometry.y - PMONITOR->vecPosition.y) * PMONITOR->scale) * scaleXY.y);
+    layerBox.x = ((PLAYER->realPosition.value().x - PMONITOR->vecPosition.x) * PMONITOR->scale) - (((PLAYER->geometry.x - PMONITOR->vecPosition.x) * PMONITOR->scale) * scaleXY.x);
+    layerBox.y = ((PLAYER->realPosition.value().y - PMONITOR->vecPosition.y) * PMONITOR->scale) - (((PLAYER->geometry.y - PMONITOR->vecPosition.y) * PMONITOR->scale) * scaleXY.y);
 
     CRegion fakeDamage{0, 0, PMONITOR->vecTransformedSize.x, PMONITOR->vecTransformedSize.y};
 
     m_bEndFrame = true;
 
-    renderTextureInternalWithDamage(it->second.m_cTex, &layerBox, PLAYER->alpha.fl(), &fakeDamage, 0);
+    renderTextureInternalWithDamage(it->second.m_cTex, &layerBox, PLAYER->alpha.value(), &fakeDamage, 0);
 
     m_bEndFrame = false;
 }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2307,8 +2307,8 @@ void CHyprRenderer::setOccludedForMainWorkspace(CRegion& region, CWorkspace* pWo
             continue;
 
         const auto     ROUNDING = w->rounding() * PMONITOR->scale;
-        const Vector2D POS      = w->m_vRealPosition.value() + Vector2D{ROUNDING, ROUNDING} - PMONITOR->vecPosition + (w->m_bPinned ? Vector2D{} : pWorkspace->m_vRenderOffset.value());
-        const Vector2D SIZE     = w->m_vRealSize.value() - Vector2D{ROUNDING * 2, ROUNDING * 2};
+        const Vector2D POS  = w->m_vRealPosition.value() + Vector2D{ROUNDING, ROUNDING} - PMONITOR->vecPosition + (w->m_bPinned ? Vector2D{} : pWorkspace->m_vRenderOffset.value());
+        const Vector2D SIZE = w->m_vRealSize.value() - Vector2D{ROUNDING * 2, ROUNDING * 2};
 
         CBox           box = {POS.x, POS.y, SIZE.x, SIZE.y};
 
@@ -2333,8 +2333,8 @@ void CHyprRenderer::setOccludedForBackLayers(CRegion& region, CWorkspace* pWorks
             continue;
 
         const auto     ROUNDING = w->rounding() * PMONITOR->scale;
-        const Vector2D POS      = w->m_vRealPosition.value() + Vector2D{ROUNDING, ROUNDING} - PMONITOR->vecPosition + (w->m_bPinned ? Vector2D{} : pWorkspace->m_vRenderOffset.value());
-        const Vector2D SIZE     = w->m_vRealSize.value() - Vector2D{ROUNDING * 2, ROUNDING * 2};
+        const Vector2D POS  = w->m_vRealPosition.value() + Vector2D{ROUNDING, ROUNDING} - PMONITOR->vecPosition + (w->m_bPinned ? Vector2D{} : pWorkspace->m_vRenderOffset.value());
+        const Vector2D SIZE = w->m_vRealSize.value() - Vector2D{ROUNDING * 2, ROUNDING * 2};
 
         CBox           box = {POS.x, POS.y, SIZE.x, SIZE.y};
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -78,8 +78,8 @@ static void renderSurface(struct wlr_surface* surface, int x, int y, void* data)
                 windowBox.x += CORRECT.x;
                 windowBox.y += CORRECT.y;
 
-                windowBox.width  = SIZE.x * (PSURFACE->getWindow()->m_vRealSize.vec().x / PSURFACE->getWindow()->m_vReportedSize.x);
-                windowBox.height = SIZE.y * (PSURFACE->getWindow()->m_vRealSize.vec().y / PSURFACE->getWindow()->m_vReportedSize.y);
+                windowBox.width  = SIZE.x * (PSURFACE->getWindow()->m_vRealSize.value().x / PSURFACE->getWindow()->m_vReportedSize.x);
+                windowBox.height = SIZE.y * (PSURFACE->getWindow()->m_vRealSize.value().y / PSURFACE->getWindow()->m_vReportedSize.y);
             } else {
                 windowBox.width  = SIZE.x;
                 windowBox.height = SIZE.y;
@@ -90,8 +90,8 @@ static void renderSurface(struct wlr_surface* surface, int x, int y, void* data)
         windowBox = {(int)outputX + RDATA->x + x, (int)outputY + RDATA->y + y, std::max(surface->current.width, 2), std::max(surface->current.height, 2)};
         if (RDATA->pWindow && RDATA->pWindow->m_vRealSize.isBeingAnimated() && RDATA->surface && RDATA->surface != surface && RDATA->squishOversized /* subsurface */) {
             // adjust subsurfaces to the window
-            windowBox.width  = (windowBox.width / RDATA->pWindow->m_vReportedSize.x) * RDATA->pWindow->m_vRealSize.vec().x;
-            windowBox.height = (windowBox.height / RDATA->pWindow->m_vReportedSize.y) * RDATA->pWindow->m_vRealSize.vec().y;
+            windowBox.width  = (windowBox.width / RDATA->pWindow->m_vReportedSize.x) * RDATA->pWindow->m_vRealSize.value().x;
+            windowBox.height = (windowBox.height / RDATA->pWindow->m_vReportedSize.y) * RDATA->pWindow->m_vRealSize.value().y;
         }
     }
 
@@ -192,7 +192,7 @@ bool CHyprRenderer::shouldRenderWindow(CWindow* pWindow, CMonitor* pMonitor, CWo
             return true;
         } else {
             if (PWINDOWWORKSPACE->m_bHasFullscreenWindow && !pWindow->m_bIsFullscreen && !pWindow->m_bIsFloating && !pWindow->m_bCreatedOverFullscreen &&
-                pWindow->m_fAlpha.fl() == 0)
+                pWindow->m_fAlpha.value() == 0)
                 return false;
         }
     }
@@ -247,7 +247,7 @@ void CHyprRenderer::renderWorkspaceWindowsFullscreen(CMonitor* pMonitor, CWorksp
         if (!shouldRenderWindow(w.get(), pMonitor, pWorkspace))
             continue;
 
-        if (w->m_fAlpha.fl() == 0.f)
+        if (w->m_fAlpha.value() == 0.f)
             continue;
 
         if (w->m_bIsFullscreen || w->m_bIsFloating)
@@ -264,7 +264,7 @@ void CHyprRenderer::renderWorkspaceWindowsFullscreen(CMonitor* pMonitor, CWorksp
         if (!shouldRenderWindow(w.get(), pMonitor, pWorkspace))
             continue;
 
-        if (w->m_fAlpha.fl() == 0.f)
+        if (w->m_fAlpha.value() == 0.f)
             continue;
 
         if (w->m_bIsFullscreen || !w->m_bIsFloating)
@@ -408,12 +408,12 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
     TRACY_GPU_ZONE("RenderWindow");
 
     const auto         PWORKSPACE = g_pCompositor->getWorkspaceByID(pWindow->m_iWorkspaceID);
-    const auto         REALPOS    = pWindow->m_vRealPosition.vec() + (pWindow->m_bPinned ? Vector2D{} : PWORKSPACE->m_vRenderOffset.vec());
+    const auto         REALPOS    = pWindow->m_vRealPosition.value() + (pWindow->m_bPinned ? Vector2D{} : PWORKSPACE->m_vRenderOffset.value());
     static auto* const PDIMAROUND = (Hyprlang::FLOAT* const*)g_pConfigManager->getConfigValuePtr("decoration:dim_around");
     static auto* const PBLUR      = (Hyprlang::INT* const*)g_pConfigManager->getConfigValuePtr("decoration:blur:enabled");
 
     SRenderData        renderdata = {pMonitor, time};
-    CBox               textureBox = {REALPOS.x, REALPOS.y, std::max(pWindow->m_vRealSize.vec().x, 5.0), std::max(pWindow->m_vRealSize.vec().y, 5.0)};
+    CBox               textureBox = {REALPOS.x, REALPOS.y, std::max(pWindow->m_vRealSize.value().x, 5.0), std::max(pWindow->m_vRealSize.value().y, 5.0)};
 
     renderdata.x = textureBox.x;
     renderdata.y = textureBox.y;
@@ -430,8 +430,8 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
 
     renderdata.surface   = pWindow->m_pWLSurface.wlr();
     renderdata.dontRound = (pWindow->m_bIsFullscreen && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL) || (!pWindow->m_sSpecialRenderData.rounding);
-    renderdata.fadeAlpha = pWindow->m_fAlpha.fl() * (pWindow->m_bPinned ? 1.f : PWORKSPACE->m_fAlpha.fl());
-    renderdata.alpha     = pWindow->m_fActiveInactiveAlpha.fl();
+    renderdata.fadeAlpha = pWindow->m_fAlpha.value() * (pWindow->m_bPinned ? 1.f : PWORKSPACE->m_fAlpha.value());
+    renderdata.alpha     = pWindow->m_fActiveInactiveAlpha.value();
     renderdata.decorate  = decorate && !pWindow->m_bX11DoesntWantBorders && (!pWindow->m_bIsFullscreen || PWORKSPACE->m_efFullscreenMode != FULLSCREEN_FULL);
     renderdata.rounding  = ignoreAllGeometry || renderdata.dontRound ? 0 : pWindow->rounding() * pMonitor->scale;
     renderdata.blur      = !ignoreAllGeometry; // if it shouldn't, it will be ignored later
@@ -460,9 +460,9 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
     if (!ignorePosition && pWindow->m_bIsFloating && !pWindow->m_bPinned && !pWindow->m_bIsFullscreen) {
         Vector2D offset;
 
-        if (PWORKSPACE->m_vRenderOffset.vec().x != 0) {
+        if (PWORKSPACE->m_vRenderOffset.value().x != 0) {
             const auto PWSMON   = g_pCompositor->getMonitorFromID(PWORKSPACE->m_iMonitorID);
-            const auto PROGRESS = PWORKSPACE->m_vRenderOffset.vec().x / PWSMON->vecSize.x;
+            const auto PROGRESS = PWORKSPACE->m_vRenderOffset.value().x / PWSMON->vecSize.x;
             const auto WINBB    = pWindow->getFullWindowBoundingBox();
 
             if (WINBB.x < PWSMON->vecPosition.x) {
@@ -470,9 +470,9 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
             } else if (WINBB.x + WINBB.width > PWSMON->vecPosition.x + PWSMON->vecSize.x) {
                 offset.x = (WINBB.x + WINBB.width - PWSMON->vecPosition.x - PWSMON->vecSize.x) * PROGRESS;
             }
-        } else if (PWORKSPACE->m_vRenderOffset.vec().y != 0) {
+        } else if (PWORKSPACE->m_vRenderOffset.value().y != 0) {
             const auto PWSMON   = g_pCompositor->getMonitorFromID(PWORKSPACE->m_iMonitorID);
-            const auto PROGRESS = PWORKSPACE->m_vRenderOffset.vec().y / PWSMON->vecSize.y;
+            const auto PROGRESS = PWORKSPACE->m_vRenderOffset.value().y / PWSMON->vecSize.y;
             const auto WINBB    = pWindow->getFullWindowBoundingBox();
 
             if (WINBB.y < PWSMON->vecPosition.y) {
@@ -488,7 +488,7 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
 
     // if window is floating and we have a slide animation, clip it to its full bb
     if (!ignorePosition && pWindow->m_bIsFloating && !pWindow->m_bIsFullscreen && PWORKSPACE->m_vRenderOffset.isBeingAnimated() && !pWindow->m_bPinned) {
-        CRegion rg                          = pWindow->getFullWindowBoundingBox().translate(-pMonitor->vecPosition + PWORKSPACE->m_vRenderOffset.vec()).scale(pMonitor->scale);
+        CRegion rg                          = pWindow->getFullWindowBoundingBox().translate(-pMonitor->vecPosition + PWORKSPACE->m_vRenderOffset.value()).scale(pMonitor->scale);
         g_pHyprOpenGL->m_RenderData.clipBox = rg.getExtents();
     }
 
@@ -606,11 +606,11 @@ void CHyprRenderer::renderLayer(SLayerSurface* pLayer, CMonitor* pMonitor, times
 
     TRACY_GPU_ZONE("RenderLayer");
 
-    const auto  REALPOS = pLayer->realPosition.vec();
-    const auto  REALSIZ = pLayer->realSize.vec();
+    const auto  REALPOS = pLayer->realPosition.value();
+    const auto  REALSIZ = pLayer->realSize.value();
 
     SRenderData renderdata           = {pMonitor, time, REALPOS.x, REALPOS.y};
-    renderdata.fadeAlpha             = pLayer->alpha.fl();
+    renderdata.fadeAlpha             = pLayer->alpha.value();
     renderdata.blur                  = pLayer->forceBlur;
     renderdata.surface               = pLayer->layerSurface->surface;
     renderdata.decorate              = false;
@@ -698,7 +698,7 @@ void CHyprRenderer::renderAllClientsForWorkspace(CMonitor* pMonitor, CWorkspace*
     // TODO: check better with solitary after MR for tearing.
     const auto PFULLWINDOW = g_pCompositor->getFullscreenWindowOnWorkspace(pWorkspace->m_iID);
     if (!pWorkspace->m_bHasFullscreenWindow || pWorkspace->m_efFullscreenMode != FULLSCREEN_FULL || !PFULLWINDOW || PFULLWINDOW->m_vRealSize.isBeingAnimated() ||
-        !PFULLWINDOW->opaque() || pWorkspace->m_vRenderOffset.vec() != Vector2D{}) {
+        !PFULLWINDOW->opaque() || pWorkspace->m_vRenderOffset.value() != Vector2D{}) {
 
         if (!g_pHyprOpenGL->m_RenderData.pCurrentMonData->blurFBShouldRender)
             setOccludedForBackLayers(g_pHyprOpenGL->m_RenderData.damage, pWorkspace);
@@ -738,7 +738,7 @@ void CHyprRenderer::renderAllClientsForWorkspace(CMonitor* pMonitor, CWorkspace*
 
     // and then special
     for (auto& ws : g_pCompositor->m_vWorkspaces) {
-        if (ws->m_iMonitorID == pMonitor->ID && ws->m_fAlpha.fl() > 0.f && ws->m_bIsSpecialWorkspace) {
+        if (ws->m_iMonitorID == pMonitor->ID && ws->m_fAlpha.value() > 0.f && ws->m_bIsSpecialWorkspace) {
             const auto SPECIALANIMPROGRS = ws->m_vRenderOffset.isBeingAnimated() ? ws->m_vRenderOffset.getCurveValue() : ws->m_fAlpha.getCurveValue();
             const bool ANIMOUT           = !pMonitor->specialWorkspaceID;
 
@@ -758,7 +758,7 @@ void CHyprRenderer::renderAllClientsForWorkspace(CMonitor* pMonitor, CWorkspace*
 
     // special
     for (auto& ws : g_pCompositor->m_vWorkspaces) {
-        if (ws->m_iMonitorID == pMonitor->ID && ws->m_fAlpha.fl() > 0.f && ws->m_bIsSpecialWorkspace)
+        if (ws->m_iMonitorID == pMonitor->ID && ws->m_fAlpha.value() > 0.f && ws->m_bIsSpecialWorkspace)
             renderWorkspaceWindows(pMonitor, ws.get(), time);
     }
 
@@ -863,7 +863,7 @@ void CHyprRenderer::calculateUVForSurface(CWindow* pWindow, wlr_surface* pSurfac
         geom.applyFromWlr();
 
         // ignore X and Y, adjust uv
-        if (geom.x != 0 || geom.y != 0 || geom.width > pWindow->m_vRealSize.vec().x || geom.height > pWindow->m_vRealSize.vec().y) {
+        if (geom.x != 0 || geom.y != 0 || geom.width > pWindow->m_vRealSize.value().x || geom.height > pWindow->m_vRealSize.value().y) {
             const auto XPERC = (double)geom.x / (double)pSurface->current.width;
             const auto YPERC = (double)geom.y / (double)pSurface->current.height;
             const auto WPERC = (double)(geom.x + geom.width) / (double)pSurface->current.width;
@@ -874,7 +874,7 @@ void CHyprRenderer::calculateUVForSurface(CWindow* pWindow, wlr_surface* pSurfac
             uvTL               = uvTL + TOADDTL;
 
             // TODO: make this passed to the func. Might break in the future.
-            auto maxSize = pWindow->m_vRealSize.vec();
+            auto maxSize = pWindow->m_vRealSize.value();
 
             if (pWindow->m_pWLSurface.small() && !pWindow->m_pWLSurface.m_bFillIgnoreSmall)
                 maxSize = pWindow->m_pWLSurface.getViewporterCorrectedSize();
@@ -2307,8 +2307,8 @@ void CHyprRenderer::setOccludedForMainWorkspace(CRegion& region, CWorkspace* pWo
             continue;
 
         const auto     ROUNDING = w->rounding() * PMONITOR->scale;
-        const Vector2D POS      = w->m_vRealPosition.vec() + Vector2D{ROUNDING, ROUNDING} - PMONITOR->vecPosition + (w->m_bPinned ? Vector2D{} : pWorkspace->m_vRenderOffset.vec());
-        const Vector2D SIZE     = w->m_vRealSize.vec() - Vector2D{ROUNDING * 2, ROUNDING * 2};
+        const Vector2D POS      = w->m_vRealPosition.value() + Vector2D{ROUNDING, ROUNDING} - PMONITOR->vecPosition + (w->m_bPinned ? Vector2D{} : pWorkspace->m_vRenderOffset.value());
+        const Vector2D SIZE     = w->m_vRealSize.value() - Vector2D{ROUNDING * 2, ROUNDING * 2};
 
         CBox           box = {POS.x, POS.y, SIZE.x, SIZE.y};
 
@@ -2333,8 +2333,8 @@ void CHyprRenderer::setOccludedForBackLayers(CRegion& region, CWorkspace* pWorks
             continue;
 
         const auto     ROUNDING = w->rounding() * PMONITOR->scale;
-        const Vector2D POS      = w->m_vRealPosition.vec() + Vector2D{ROUNDING, ROUNDING} - PMONITOR->vecPosition + (w->m_bPinned ? Vector2D{} : pWorkspace->m_vRenderOffset.vec());
-        const Vector2D SIZE     = w->m_vRealSize.vec() - Vector2D{ROUNDING * 2, ROUNDING * 2};
+        const Vector2D POS      = w->m_vRealPosition.value() + Vector2D{ROUNDING, ROUNDING} - PMONITOR->vecPosition + (w->m_bPinned ? Vector2D{} : pWorkspace->m_vRenderOffset.value());
+        const Vector2D SIZE     = w->m_vRealSize.value() - Vector2D{ROUNDING * 2, ROUNDING * 2};
 
         CBox           box = {POS.x, POS.y, SIZE.x, SIZE.y};
 
@@ -2351,7 +2351,7 @@ bool CHyprRenderer::canSkipBackBufferClear(CMonitor* pMonitor) {
         if (!ls->layerSurface)
             continue;
 
-        if (ls->alpha.fl() < 1.f)
+        if (ls->alpha.value() < 1.f)
             continue;
 
         if (ls->geometry.x != pMonitor->vecPosition.x || ls->geometry.y != pMonitor->vecPosition.y || ls->geometry.width != pMonitor->vecSize.x ||
@@ -2381,7 +2381,7 @@ void CHyprRenderer::recheckSolitaryForMonitor(CMonitor* pMonitor) {
     const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(pMonitor->activeWorkspace);
 
     if (!PWORKSPACE || !PWORKSPACE->m_bHasFullscreenWindow || g_pInputManager->m_sDrag.drag || g_pCompositor->m_sSeat.exclusiveClient || pMonitor->specialWorkspaceID ||
-        PWORKSPACE->m_fAlpha.fl() != 1.f || PWORKSPACE->m_vRenderOffset.vec() != Vector2D{})
+        PWORKSPACE->m_fAlpha.value() != 1.f || PWORKSPACE->m_vRenderOffset.value() != Vector2D{})
         return;
 
     const auto PCANDIDATE = g_pCompositor->getFullscreenWindowOnWorkspace(PWORKSPACE->m_iID);
@@ -2392,7 +2392,7 @@ void CHyprRenderer::recheckSolitaryForMonitor(CMonitor* pMonitor) {
     if (!PCANDIDATE->opaque())
         return;
 
-    if (PCANDIDATE->m_vRealSize.vec() != pMonitor->vecSize || PCANDIDATE->m_vRealPosition.vec() != pMonitor->vecPosition || PCANDIDATE->m_vRealPosition.isBeingAnimated() ||
+    if (PCANDIDATE->m_vRealSize.value() != pMonitor->vecSize || PCANDIDATE->m_vRealPosition.value() != pMonitor->vecPosition || PCANDIDATE->m_vRealPosition.isBeingAnimated() ||
         PCANDIDATE->m_vRealSize.isBeingAnimated())
         return;
 
@@ -2400,7 +2400,7 @@ void CHyprRenderer::recheckSolitaryForMonitor(CMonitor* pMonitor) {
         return;
 
     for (auto& topls : pMonitor->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]) {
-        if (topls->alpha.fl() != 0.f)
+        if (topls->alpha.value() != 0.f)
             return;
     }
 

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -40,7 +40,7 @@ CBox CHyprBorderDecoration::assignedBoxGlobal() {
     if (!PWORKSPACE)
         return box;
 
-    const auto WORKSPACEOFFSET = PWORKSPACE && !m_pWindow->m_bPinned ? PWORKSPACE->m_vRenderOffset.vec() : Vector2D();
+    const auto WORKSPACEOFFSET = PWORKSPACE && !m_pWindow->m_bPinned ? PWORKSPACE->m_vRenderOffset.value() : Vector2D();
     return box.translate(WORKSPACEOFFSET);
 }
 
@@ -58,10 +58,10 @@ void CHyprBorderDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& of
 
     auto       grad     = m_pWindow->m_cRealBorderColor;
     const bool ANIMATED = m_pWindow->m_fBorderFadeAnimationProgress.isBeingAnimated();
-    float      a1       = a * (ANIMATED ? m_pWindow->m_fBorderFadeAnimationProgress.fl() : 1.f);
+    float      a1       = a * (ANIMATED ? m_pWindow->m_fBorderFadeAnimationProgress.value() : 1.f);
 
     if (m_pWindow->m_fBorderAngleAnimationProgress.getConfig()->pValues->internalEnabled) {
-        grad.m_fAngle += m_pWindow->m_fBorderAngleAnimationProgress.fl() * M_PI * 2;
+        grad.m_fAngle += m_pWindow->m_fBorderAngleAnimationProgress.value() * M_PI * 2;
         grad.m_fAngle = normalizeAngleRad(grad.m_fAngle);
     }
 
@@ -71,7 +71,7 @@ void CHyprBorderDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& of
     g_pHyprOpenGL->renderBorder(&windowBox, grad, ROUNDING, borderSize, a1);
 
     if (ANIMATED) {
-        float a2 = a * (1.f - m_pWindow->m_fBorderFadeAnimationProgress.fl());
+        float a2 = a * (1.f - m_pWindow->m_fBorderFadeAnimationProgress.value());
         g_pHyprOpenGL->renderBorder(&windowBox, m_pWindow->m_cRealBorderColorPrevious, ROUNDING, borderSize, a2);
     }
 }

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -46,8 +46,8 @@ void CHyprDropShadowDecoration::damageEntire() {
 }
 
 void CHyprDropShadowDecoration::updateWindow(CWindow* pWindow) {
-    m_vLastWindowPos  = m_pWindow->m_vRealPosition.vec();
-    m_vLastWindowSize = m_pWindow->m_vRealSize.vec();
+    m_vLastWindowPos  = m_pWindow->m_vRealPosition.value();
+    m_vLastWindowSize = m_pWindow->m_vRealSize.value();
 
     m_bLastWindowBox          = {m_vLastWindowPos.x, m_vLastWindowPos.y, m_vLastWindowSize.x, m_vLastWindowSize.y};
     m_bLastWindowBoxWithDecos = g_pDecorationPositioner->getBoxWithIncludedDecos(pWindow);
@@ -58,7 +58,7 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D
     if (!g_pCompositor->windowValidMapped(m_pWindow))
         return;
 
-    if (m_pWindow->m_cRealShadowColor.col() == CColor(0, 0, 0, 0))
+    if (m_pWindow->m_cRealShadowColor.value() == CColor(0, 0, 0, 0))
         return; // don't draw invisible shadows
 
     if (!m_pWindow->m_sSpecialRenderData.decorate)
@@ -82,7 +82,7 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D
     const auto ROUNDINGBASE    = m_pWindow->rounding();
     const auto ROUNDING        = ROUNDINGBASE > 0 ? ROUNDINGBASE + m_pWindow->getRealBorderSize() : 0;
     const auto PWORKSPACE      = g_pCompositor->getWorkspaceByID(m_pWindow->m_iWorkspaceID);
-    const auto WORKSPACEOFFSET = PWORKSPACE && !m_pWindow->m_bPinned ? PWORKSPACE->m_vRenderOffset.vec() : Vector2D();
+    const auto WORKSPACEOFFSET = PWORKSPACE && !m_pWindow->m_bPinned ? PWORKSPACE->m_vRenderOffset.value() : Vector2D();
 
     // draw the shadow
     CBox fullBox = m_bLastWindowBoxWithDecos;
@@ -147,7 +147,7 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D
         g_pHyprOpenGL->renderRect(&fullBox, CColor(0, 0, 0, 1), 0);
 
         // render white shadow with the alpha of the shadow color (otherwise we clear with alpha later and shit it to 2 bit)
-        g_pHyprOpenGL->renderRoundedShadow(&fullBox, ROUNDING * pMonitor->scale, **PSHADOWSIZE * pMonitor->scale, CColor(1, 1, 1, m_pWindow->m_cRealShadowColor.col().a), a);
+        g_pHyprOpenGL->renderRoundedShadow(&fullBox, ROUNDING * pMonitor->scale, **PSHADOWSIZE * pMonitor->scale, CColor(1, 1, 1, m_pWindow->m_cRealShadowColor.value().a), a);
 
         // render black window box ("clip")
         g_pHyprOpenGL->renderRect(&windowBox, CColor(0, 0, 0, 1.0), ROUNDING * pMonitor->scale);
@@ -155,7 +155,7 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D
         alphaSwapFB.bind();
 
         // alpha swap just has the shadow color. It will be the "texture" to render.
-        g_pHyprOpenGL->renderRect(&fullBox, m_pWindow->m_cRealShadowColor.col().stripA(), 0);
+        g_pHyprOpenGL->renderRect(&fullBox, m_pWindow->m_cRealShadowColor.value().stripA(), 0);
 
         LASTFB->bind();
 
@@ -166,7 +166,7 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D
 
         g_pHyprOpenGL->m_RenderData.damage = saveDamage;
     } else {
-        g_pHyprOpenGL->renderRoundedShadow(&fullBox, ROUNDING * pMonitor->scale, **PSHADOWSIZE * pMonitor->scale, m_pWindow->m_cRealShadowColor.col(), a);
+        g_pHyprOpenGL->renderRoundedShadow(&fullBox, ROUNDING * pMonitor->scale, **PSHADOWSIZE * pMonitor->scale, m_pWindow->m_cRealShadowColor.value(), a);
     }
 
     if (m_seExtents != m_seReportedExtents)

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -504,6 +504,6 @@ CBox CHyprGroupBarDecoration::assignedBoxGlobal() {
     if (!PWORKSPACE)
         return box;
 
-    const auto WORKSPACEOFFSET = PWORKSPACE && !m_pWindow->m_bPinned ? PWORKSPACE->m_vRenderOffset.vec() : Vector2D();
+    const auto WORKSPACEOFFSET = PWORKSPACE && !m_pWindow->m_bPinned ? PWORKSPACE->m_vRenderOffset.value() : Vector2D();
     return box.translate(WORKSPACEOFFSET);
 }

--- a/src/render/decorations/DecorationPositioner.cpp
+++ b/src/render/decorations/DecorationPositioner.cpp
@@ -124,7 +124,7 @@ void CDecorationPositioner::onWindowUpdate(CWindow* pWindow) {
         datas.push_back(getDataFor(wd.get(), pWindow));
     }
 
-    if (WINDOWDATA->lastWindowSize == pWindow->m_vRealSize.vec() /* position not changed */
+    if (WINDOWDATA->lastWindowSize == pWindow->m_vRealSize.value() /* position not changed */
         &&
         std::all_of(m_vWindowPositioningDatas.begin(), m_vWindowPositioningDatas.end(), [pWindow](const auto& data) { return pWindow != data->pWindow || !data->needsReposition; })
         /* all window datas are either not for this window or don't need a reposition */
@@ -132,7 +132,7 @@ void CDecorationPositioner::onWindowUpdate(CWindow* pWindow) {
     )
         return;
 
-    WINDOWDATA->lastWindowSize = pWindow->m_vRealSize.vec();
+    WINDOWDATA->lastWindowSize = pWindow->m_vRealSize.value();
     WINDOWDATA->needsRecalc    = false;
     const bool EPHEMERAL       = pWindow->m_vRealSize.isBeingAnimated();
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This commit decomposes the AnimatedVariable class into a base class with the common attribute to all variable types and a templated derived type containing strongly typed info on the type being animated.

Access to the typed version is perfomed using the visitor pattern. A utility is provided to build a visitor on the fly using lambdas.

Adding a new type to be animated should just be a matter of adding the typed in the list defined by the ANIMABLE_TYPES macro

The size of the commit is justified by the API change in the AnimatedVariable class. No more vec(), fl() or col() method but a unified value() method.

This PR reduces code duplication in the AnimatedVariable class and in the AnimationManager. Moreover, it improves it's extensibility to other types.

The tradeoff is a bit more complexity with all the templated arguments in AnimatedVariable.cpp but less code duplication and smaller memory footprint for these variables.

Note that the added complexity does't leak to much on the code that uses these variables.    

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This can break compatibility as it changes the way to declare and use AnimatedVariables.

#### Is it ready for merging, or does it need work?

It's ready to merge. I'm running this branch to test it while I'm redaction this PR.


