### PR TITLE
Add a Code Rights Declaration

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,3 +7,7 @@
 #### Is it ready for merging, or does it need work?
 
 
+#### Code Rights Declaration
+
+Please see [our Code Rights Declaration](https://github.com/hyprwm/Hyprland/blob/main/docs/RIGHTS_DECLARATION.md) and agree to it by checking the box below.
+- [ ] By checking this box I confirm that I have read and agree to the Declaration of Code Rights linked above.

--- a/docs/RIGHTS_DECLARATION.md
+++ b/docs/RIGHTS_DECLARATION.md
@@ -18,6 +18,6 @@ By making a contribution to this project, I certify that:
 
  Ⅲ) I give full rights to Hypr Development to redistribute this contribution as a part of the parent project in both source and binary form.
 
- Ⅳ) I give full rights to Hypr Development to relicense the parent project to which I am contributing at a later date to any license as long as that license does not hinder the ability of one to contribute to, or view the source code of the project.
+ Ⅳ) I give full rights to Hypr Development to relicense the parent project to which I am contributing at a later date to any license as long as that license does not hinder the ability of any non-commercial entity to contribute to, redistribute or view the source code of the project.
 
  Ⅴ) I understand this document may change in the future, although any contributions made will be subject to the version at the time of the submission.

--- a/docs/RIGHTS_DECLARATION.md
+++ b/docs/RIGHTS_DECLARATION.md
@@ -1,0 +1,23 @@
+Hypr Development Code Rights Declaration
+
+Last revision: 01 III 2024
+
+Copyright 2024, Hypr Development, vaxerski.
+
+/\ - /\ - /\ - /\
+
+TL;DR: I made this and I am okay with you guys relicensing this later as long as it's still open source.
+
+By making a contribution to this project, I certify that:
+
+ Ⅰ) This contribution is made entirely by myself, or in a way that
+ gives me full rights to the contribution.
+
+ Ⅱ) I realize and understand this contribution will be permanently recorded
+ under this repository alongside the information attached to it (Such as my Github username)
+
+ Ⅲ) I give full rights to Hypr Development to redistribute this contribution as a part of the parent project in both source and binary form.
+
+ Ⅳ) I give full rights to Hypr Development to relicense the parent project to which I am contributing at a later date to any license as long as that license does not hinder the ability of one to contribute to, or view the source code of the project.
+
+ Ⅴ) I understand this document may change in the future, although any contributions made will be subject to the version at the time of the submission.


### PR DESCRIPTION
This adds a code rights declaration, a short DCO/CLA-style document to agree to when submitting a PR.

Everything is up to discussion, obviously.

cc @fufexan 

The link in the PR template is broken atm (because it points to parent) but will work once merged.

### Reasoning

Hyprland is growing in popularity and I want to make sure no big entities try to fuck us over like Apple did with BSD.

GPL is too restrictive.

Basically, I will never make this closed source, but I want the rights to at one point say "commercial usage only under some conditions under certain terms"

This is a very lenient agreement, and I will not pull a MongoDB on y'all, pinky promise.

### Your input

I am open to suggestions, changes, and opposing views. Feel free to voice them.