### PR TITLE
Add missing nix devshell dependencies for make asan

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -91,7 +91,7 @@
           stdenv = pkgsFor.${system}.gcc13Stdenv;
         } {
           name = "hyprland-shell";
-          nativeBuildInputs = with pkgsFor.${system}; [cmake python3];
+          nativeBuildInputs = with pkgsFor.${system}; [cmake python3 expat libxml2];
           buildInputs = [self.packages.${system}.wlroots-hyprland];
           hardeningDisable = ["fortify"];
           inputsFrom = [


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
``expat`` and ``libxml2`` as native build inputs for the flake devshell.
Makes running ``make asan`` more convenient on nix.
You can just run nix develop and ``make asan`` from the nix shell

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
shouldn't break anything

#### Is it ready for merging, or does it need work?
small change, there should be no issue


