### PR TITLE
Set xwayland's name prop

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -91,18 +91,18 @@
       "flake": false,
       "locked": {
         "host": "gitlab.freedesktop.org",
-        "lastModified": 1708558866,
-        "narHash": "sha256-Mz6hCtommq7RQfcPnxLINigO4RYSNt23HeJHC6mVmWI=",
+        "lastModified": 1709983277,
+        "narHash": "sha256-wXWIJLd4F2JZeMaihWVDW/yYXCLEC8OpeNJZg9a9ly8=",
         "owner": "wlroots",
         "repo": "wlroots",
-        "rev": "0cb091f1a2d345f37d2ee445f4ffd04f7f4ec9e5",
+        "rev": "50eae512d9cecbf0b3b1898bb1f0b40fa05fe19b",
         "type": "gitlab"
       },
       "original": {
         "host": "gitlab.freedesktop.org",
         "owner": "wlroots",
         "repo": "wlroots",
-        "rev": "0cb091f1a2d345f37d2ee445f4ffd04f7f4ec9e5",
+        "rev": "50eae512d9cecbf0b3b1898bb1f0b40fa05fe19b",
         "type": "gitlab"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
       host = "gitlab.freedesktop.org";
       owner = "wlroots";
       repo = "wlroots";
-      rev = "0cb091f1a2d345f37d2ee445f4ffd04f7f4ec9e5";
+      rev = "50eae512d9cecbf0b3b1898bb1f0b40fa05fe19b";
       flake = false;
     };
 

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -234,4 +234,7 @@ inline std::map<std::string, xcb_atom_t> HYPRATOMS = {HYPRATOM("_NET_WM_WINDOW_T
                                                       HYPRATOM("_NET_WM_WINDOW_TYPE_POPUP_MENU"),
                                                       HYPRATOM("_NET_WM_WINDOW_TYPE_TOOLTIP"),
                                                       HYPRATOM("_NET_WM_WINDOW_TYPE_NOTIFICATION"),
-                                                      HYPRATOM("_KDE_NET_WM_WINDOW_TYPE_OVERRIDE")};
+                                                      HYPRATOM("_KDE_NET_WM_WINDOW_TYPE_OVERRIDE"),
+                                                      HYPRATOM("_NET_SUPPORTING_WM_CHECK"),
+                                                      HYPRATOM("_NET_WM_NAME"),
+                                                      HYPRATOM("UTF8_STRING")};

--- a/src/events/Misc.cpp
+++ b/src/events/Misc.cpp
@@ -63,6 +63,8 @@ void Events::listener_readyXWayland(wl_listener* listener, void* data) {
         }
 
         ATOM.second = reply->atom;
+
+        free(reply);
     }
 
     wlr_xwayland_set_seat(g_pXWaylandManager->m_sWLRXWayland, g_pCompositor->m_sSeat.seat);
@@ -72,6 +74,19 @@ void Events::listener_readyXWayland(wl_listener* listener, void* data) {
         wlr_xwayland_set_cursor(g_pXWaylandManager->m_sWLRXWayland, XCURSOR->images[0]->buffer, XCURSOR->images[0]->width * 4, XCURSOR->images[0]->width,
                                 XCURSOR->images[0]->height, XCURSOR->images[0]->hotspot_x, XCURSOR->images[0]->hotspot_y);
     }
+
+    const auto  ROOT   = xcb_setup_roots_iterator(xcb_get_setup(XCBCONNECTION)).data->root;
+    auto        cookie = xcb_get_property(XCBCONNECTION, 0, ROOT, HYPRATOMS["_NET_SUPPORTING_WM_CHECK"], XCB_ATOM_ANY, 0, 2048);
+    auto        reply  = xcb_get_property_reply(XCBCONNECTION, cookie, nullptr);
+
+    const auto  XWMWINDOW = *(xcb_window_t*)xcb_get_property_value(reply);
+    const char* name      = "Hyprland";
+
+    xcb_change_property(wlr_xwayland_xwm_get_connection(g_pXWaylandManager->m_sWLRXWayland), XCB_PROP_MODE_REPLACE, XWMWINDOW, HYPRATOMS["_NET_WM_NAME"], HYPRATOMS["UTF8_STRING"],
+                        8, // format
+                        strlen(name), name);
+
+    free(reply);
 
     xcb_disconnect(XCBCONNECTION);
 #endif

--- a/src/events/Misc.cpp
+++ b/src/events/Misc.cpp
@@ -82,7 +82,7 @@ void Events::listener_readyXWayland(wl_listener* listener, void* data) {
     const auto  XWMWINDOW = *(xcb_window_t*)xcb_get_property_value(reply);
     const char* name      = "Hyprland";
 
-    xcb_change_property(wlr_xwayland_xwm_get_connection(g_pXWaylandManager->m_sWLRXWayland), XCB_PROP_MODE_REPLACE, XWMWINDOW, HYPRATOMS["_NET_WM_NAME"], HYPRATOMS["UTF8_STRING"],
+    xcb_change_property(wlr_xwayland_get_xwm_connection(g_pXWaylandManager->m_sWLRXWayland), XCB_PROP_MODE_REPLACE, XWMWINDOW, HYPRATOMS["_NET_WM_NAME"], HYPRATOMS["UTF8_STRING"],
                         8, // format
                         strlen(name), name);
 


### PR DESCRIPTION
Allows xwayland apps to see "Hyprland" and not "wlroots wm"

Also fixes a small memory leak.

Depends on https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4588