### PR TITLE
opengl: fix compilation on legacy renderer

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -353,7 +353,11 @@ void CHyprOpenGLImpl::end() {
     // check for gl errors
     const GLenum ERR = glGetError();
 
+#ifdef GLES2
+    if (ERR == GL_CONTEXT_LOST_KHR) /* We don't have infra to recover from this */
+#else
     if (ERR == GL_CONTEXT_LOST) /* We don't have infra to recover from this */
+#endif
         RASSERT(false, "glGetError at Opengl::end() returned GL_CONTEXT_LOST. Cannot continue until proper GPU reset handling is implemented.");
 }
 
@@ -2057,9 +2061,15 @@ void CHyprOpenGLImpl::createBGTextureForMonitor(CMonitor* pMonitor) {
     tex.m_vSize = IMAGESIZE * scale;
 
     // copy the data to an OpenGL texture we have
-    const GLint glIFormat = CAIROFORMAT == CAIRO_FORMAT_RGB96F ? GL_RGB32F : GL_RGBA;
-    const GLint glFormat  = CAIROFORMAT == CAIRO_FORMAT_RGB96F ? GL_RGB : GL_RGBA;
-    const GLint glType    = CAIROFORMAT == CAIRO_FORMAT_RGB96F ? GL_FLOAT : GL_UNSIGNED_BYTE;
+    const GLint glIFormat = CAIROFORMAT == CAIRO_FORMAT_RGB96F ?
+#ifdef GLES2
+        GL_RGB32F_EXT :
+#else
+        GL_RGB32F :
+#endif
+        GL_RGBA;
+    const GLint glFormat = CAIROFORMAT == CAIRO_FORMAT_RGB96F ? GL_RGB : GL_RGBA;
+    const GLint glType   = CAIROFORMAT == CAIRO_FORMAT_RGB96F ? GL_FLOAT : GL_UNSIGNED_BYTE;
 
     const auto  DATA = cairo_image_surface_get_data(CAIROSURFACE);
     glBindTexture(GL_TEXTURE_2D, tex.m_iTexID);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Commits 72987dee88a0359d42af9f3064a62b934dcd7be0 and 2e3f0d5991874edb01f1bfe4ffc75701f8b398dc broke compilation when using legacy renderer on 0.35.0 and 0.36.0, because `GL_CONTEXT_LOST` and `GL_RGB32F` are not defined in GLES2.
This PR uses the correct symbols for GLES2

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Compilation log when using legacy renderer without this patch:
```
../hyprland-9999/src/render/OpenGL.cpp: In member function ‘void CHyprOpenGLImpl::end()’:
../hyprland-9999/src/render/OpenGL.cpp:356:16: error: ‘GL_CONTEXT_LOST’ was not declared in this scope; did you mean ‘EGL_CONTEXT_LOST’?
  356 |     if (ERR == GL_CONTEXT_LOST) /* We don't have infra to recover from this */
      |                ^~~~~~~~~~~~~~~
      |                EGL_CONTEXT_LOST
../hyprland-9999/src/render/OpenGL.cpp: In member function ‘void CHyprOpenGLImpl::createBGTextureForMonitor(CMonitor*)’:
../hyprland-9999/src/render/OpenGL.cpp:2060:66: error: ‘GL_RGB32F’ was not declared in this scope; did you mean ‘GL_RGB565’?
 2060 |     const GLint glIFormat = CAIROFORMAT == CAIRO_FORMAT_RGB96F ? GL_RGB32F : GL_RGBA;
      |                                                                  ^~~~~~~~~
      |                                                                  GL_RGB565

```

#### Is it ready for merging, or does it need work?
Ready for merging

