### PR TITLE
Add the 'catchall' keyword that matches all keys

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1820,6 +1820,11 @@ std::optional<std::string> CConfigManager::handleBind(const std::string& command
     if (KEY != "") {
         SParsedKey parsedKey = parseKey(KEY);
 
+        if (parsedKey.catchAll && m_szCurrentSubmap == "") {
+            Debug::log(ERR, "Catchall not allowed outside of submap!");
+            return "Invalid catchall, catchall keybinds are only allowed in submaps.";
+        }
+
         g_pKeybindManager->addKeybind(SKeybind{parsedKey.key, parsedKey.keycode, parsedKey.catchAll, MOD, HANDLER, COMMAND, locked, m_szCurrentSubmap, release, repeat, mouse,
                                                nonConsuming, transparent, ignoreMods});
     }

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -718,8 +718,8 @@ std::string bindsRequest(eHyprCtlOutputFormat format, std::string request) {
             if (kb.nonConsuming)
                 ret += "n";
 
-            ret += std::format("\n\tmodmask: {}\n\tsubmap: {}\n\tkey: {}\n\tkeycode: {}\n\tdispatcher: {}\n\targ: {}\n\n", kb.modmask, kb.submap, kb.key, kb.keycode, kb.handler,
-                               kb.arg);
+            ret += std::format("\n\tmodmask: {}\n\tsubmap: {}\n\tkey: {}\n\tkeycode: {}\n\tcatchall: {}\n\tdispatcher: {}\n\targ: {}\n\n", kb.modmask, kb.submap, kb.key,
+                               kb.keycode, kb.catchAll, kb.handler, kb.arg);
         }
     } else {
         // json
@@ -737,11 +737,13 @@ std::string bindsRequest(eHyprCtlOutputFormat format, std::string request) {
     "submap": "{}",
     "key": "{}",
     "keycode": {},
+    "catch_all": {},
     "dispatcher": "{}",
     "arg": "{}"
 }},)#",
                 kb.locked ? "true" : "false", kb.mouse ? "true" : "false", kb.release ? "true" : "false", kb.repeat ? "true" : "false", kb.nonConsuming ? "true" : "false",
-                kb.modmask, escapeJSONStrings(kb.submap), escapeJSONStrings(kb.key), kb.keycode, escapeJSONStrings(kb.handler), escapeJSONStrings(kb.arg));
+                kb.modmask, escapeJSONStrings(kb.submap), escapeJSONStrings(kb.key), kb.keycode, kb.catchAll ? "true" : "false", escapeJSONStrings(kb.handler),
+                escapeJSONStrings(kb.arg));
         }
         trimTrailingComma(ret);
         ret += "]";

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -95,18 +95,9 @@ void CKeybindManager::addKeybind(SKeybind kb) {
     m_pActiveKeybind = nullptr;
 }
 
-void CKeybindManager::removeKeybind(uint32_t mod, const std::string& key) {
+void CKeybindManager::removeKeybind(uint32_t mod, const SParsedKey& key) {
     for (auto it = m_lKeybinds.begin(); it != m_lKeybinds.end(); ++it) {
-        if (isNumber(key) && std::stoi(key) > 9) {
-            const uint32_t KEYNUM = std::stoi(key);
-
-            if (it->modmask == mod && it->keycode == KEYNUM) {
-                it = m_lKeybinds.erase(it);
-
-                if (it == m_lKeybinds.end())
-                    break;
-            }
-        } else if (it->modmask == mod && it->key == key) {
+        if (it->modmask == mod && it->key == key.key && it->keycode == key.keycode && it->catchAll == key.catchAll) {
             it = m_lKeybinds.erase(it);
 
             if (it == m_lKeybinds.end())
@@ -526,6 +517,9 @@ bool CKeybindManager::handleKeybinds(const uint32_t modmask, const SPressedKeyWi
                 continue;
         } else if (k.keycode != 0) {
             if (key.keycode != k.keycode)
+                continue;
+        } else if (k.catchAll) {
+            if (found)
                 continue;
         } else {
             // oMg such performance hit!!11!

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -13,6 +13,7 @@ class CPluginSystem;
 struct SKeybind {
     std::string key          = "";
     uint32_t    keycode      = 0;
+    bool        catchAll     = false;
     uint32_t    modmask      = 0;
     std::string handler      = "";
     std::string arg          = "";
@@ -44,6 +45,12 @@ struct SPressedKeyWithMods {
     bool         sent               = false;
 };
 
+struct SParsedKey {
+    std::string key      = "";
+    uint32_t    keycode  = 0;
+    bool        catchAll = false;
+};
+
 class CKeybindManager {
   public:
     CKeybindManager();
@@ -57,7 +64,7 @@ class CKeybindManager {
     void                                                              onSwitchOffEvent(const std::string&);
 
     void                                                              addKeybind(SKeybind);
-    void                                                              removeKeybind(uint32_t, const std::string&);
+    void                                                              removeKeybind(uint32_t, const SParsedKey&);
     uint32_t                                                          stringToModMask(std::string);
     uint32_t                                                          keycodeToModifier(xkb_keycode_t);
     void                                                              clearKeybinds();


### PR DESCRIPTION
## Description

This keyword can be used to define arbitrary keybinds. The only special behavior that it exhibits is that it matches every key, including modifier keys. Any flags still apply normally.

## Motivation

I use submaps to create modal keymaps similar to those implemented by many Vim configs, e.g. [LazyVim](http://www.lazyvim.org/keymaps). Then I might hit `<leader> l m` to launch my system monitor. While in a submap I would like to ignore any keys that are not mapped and open a help window that reminds me of my forgotten binds. Adding a catch-all bind seemed to be the most straight-forward way to achieve that.

This or a similar feature is also requsted by #3638, #3405 and #1972.

## Fixed Issues

This commit also fixes an issue that keys bound via the `code:KEYCODE` format were not unbound correctly. This problem stemmed from a duplication of the code that translates the key specification in a bind rule (i.e. its second argument) to keysym/keycode. Since I had to touch that code anyway and to avoid similar problems in the future, I extracted that code into a function.

## Open questions
### Syntax 

The keyword could theoretically collide with a keysym. However, I believe it to be unlikely that a keysym with such a name will ever exist, so this is a limited risk. To be extra sure or future proof for new keywords, it is conceivable to instead use syntax such as `special:catchall`. The current `code:` syntax for binding by keycode would be precedent for that.

I am also not 100% sold on the formatting by hyprctl or more specifically the casing of the name. I tried to remain consistent with the existing fields, specifically `non_consuming` being snake_case in the JSON output and everything being lowercase in the other output.

### Footgun

Using this keyword outside a submap will prevent essentially all keys from being forwarded to applications (unless defined as non-consuming). This might make it difficult to revert the setting. The setting could be made to only work in a submap to mitigate that.

Since switching to a TTY should still work, I don't view this as a huge problem. I would rather remain consistent with existing behavior and introduce fewer special cases.

## Documentation

I have prepared an accompanying PR at hyprwm/Hyprland-wiki#499.
