### PR TITLE
events: update render data after workspace window rule

### DIFF
--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -258,8 +258,6 @@ void Events::listener_mapWindow(void* owner, void* data) {
         PWINDOW->applyDynamicRule(r);
     }
 
-    PWINDOW->updateSpecialRenderData();
-
     // disallow tiled pinned
     if (PWINDOW->m_bPinned && !PWINDOW->m_bIsFloating)
         PWINDOW->m_bPinned = false;
@@ -298,6 +296,8 @@ void Events::listener_mapWindow(void* owner, void* data) {
         } else
             workspaceSilent = false;
     }
+
+    PWINDOW->updateSpecialRenderData();
 
     if (PWINDOW->m_bIsFloating) {
         g_pLayoutManager->getCurrentLayout()->onWindowCreatedFloating(PWINDOW);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This fixes workspace rules not applying to windows that match both a `float` window rule and a `workspace` window rule.

The problem was that `updateSpecialRenderData` got called before the `workspace` rule was applied (so the workspace ID was outdated). This wasn't a problem for non-floating windows because the dwindle/master layout code calls `updateSpecialRenderData` again when the window tiles.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready
