### PR TITLE
disable initial focus for xwayland dialogs

### DIFF
--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -222,9 +222,7 @@ bool CHyprXWaylandManager::shouldBeFloated(CWindow* pWindow, bool pending) {
                     pWindow->m_uSurface.xwayland->window_type[i] == HYPRATOMS["_NET_WM_WINDOW_TYPE_MENU"])
                     pWindow->m_bX11ShouldntFocus = true;
 
-                if (pWindow->m_uSurface.xwayland->window_type[i] != HYPRATOMS["_NET_WM_WINDOW_TYPE_DIALOG"])
-                    pWindow->m_bNoInitialFocus = true;
-
+                pWindow->m_bNoInitialFocus = true;
                 return true;
             }
 


### PR DESCRIPTION
context menus in Ableton kept disappearing otherwise