### PR TITLE
compositor: ignore grab extend behind special workspaces

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -742,15 +742,13 @@ CWindow* CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t propert
                 const auto BB             = w->getWindowBoxUnified(properties);
                 const auto PWINDOWMONITOR = getMonitorFromID(w->m_iMonitorID);
 
-                /* if special fallthrough is disabled and the window is contained within its monitor, do not apply border grab extends
-                   to avoid focusing windows behind special workspaces from other monitors */
-                auto box = (!**PSPECIALFALLTHRU && PWINDOWMONITOR && PWINDOWMONITOR->specialWorkspaceID && w->m_iWorkspaceID != PWINDOWMONITOR->specialWorkspaceID &&
-                            BB.x >= PWINDOWMONITOR->vecPosition.x && BB.y >= PWINDOWMONITOR->vecPosition.y &&
-                            BB.x + BB.width <= PWINDOWMONITOR->vecPosition.x + PWINDOWMONITOR->vecSize.x &&
-                            BB.y + BB.height <= PWINDOWMONITOR->vecPosition.y + PWINDOWMONITOR->vecSize.y) ?
-                    CBox{BB.x, BB.y, BB.width, BB.height} :
-                    CBox{BB.x - BORDER_GRAB_AREA, BB.y - BORDER_GRAB_AREA, BB.width + 2 * BORDER_GRAB_AREA, BB.height + 2 * BORDER_GRAB_AREA};
+                // to avoid focusing windows behind special workspaces from other monitors
+                if (!**PSPECIALFALLTHRU && PWINDOWMONITOR && PWINDOWMONITOR->specialWorkspaceID && w->m_iWorkspaceID != PWINDOWMONITOR->specialWorkspaceID &&
+                    BB.x >= PWINDOWMONITOR->vecPosition.x && BB.y >= PWINDOWMONITOR->vecPosition.y &&
+                    BB.x + BB.width <= PWINDOWMONITOR->vecPosition.x + PWINDOWMONITOR->vecSize.x && BB.y + BB.height <= PWINDOWMONITOR->vecPosition.y + PWINDOWMONITOR->vecSize.y)
+                    continue;
 
+                CBox box = {BB.x - BORDER_GRAB_AREA, BB.y - BORDER_GRAB_AREA, BB.width + 2 * BORDER_GRAB_AREA, BB.height + 2 * BORDER_GRAB_AREA};
                 if (w->m_bIsFloating && w->m_bIsMapped && isWorkspaceVisible(w->m_iWorkspaceID) && !w->isHidden() && !w->m_bPinned && !w->m_sAdditionalConfigData.noFocus &&
                     w.get() != pIgnoreWindow && (!aboveFullscreen || w->m_bCreatedOverFullscreen)) {
                     // OR windows should add focus to parent

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -739,8 +739,18 @@ CWindow* CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t propert
                 if (special && !isWorkspaceSpecial(w->m_iWorkspaceID)) // because special floating may creep up into regular
                     continue;
 
-                const auto BB  = w->getWindowBoxUnified(properties);
-                CBox       box = {BB.x - BORDER_GRAB_AREA, BB.y - BORDER_GRAB_AREA, BB.width + 2 * BORDER_GRAB_AREA, BB.height + 2 * BORDER_GRAB_AREA};
+                const auto BB             = w->getWindowBoxUnified(properties);
+                const auto PWINDOWMONITOR = getMonitorFromID(w->m_iMonitorID);
+
+                /* if special fallthrough is disabled and the window is contained within its monitor, do not apply border grab extends
+                   to avoid focusing windows behind special workspaces from other monitors */
+                auto box = (!**PSPECIALFALLTHRU && PWINDOWMONITOR && PWINDOWMONITOR->specialWorkspaceID && w->m_iWorkspaceID != PWINDOWMONITOR->specialWorkspaceID &&
+                            BB.x >= PWINDOWMONITOR->vecPosition.x && BB.y >= PWINDOWMONITOR->vecPosition.y &&
+                            BB.x + BB.width <= PWINDOWMONITOR->vecPosition.x + PWINDOWMONITOR->vecSize.x &&
+                            BB.y + BB.height <= PWINDOWMONITOR->vecPosition.y + PWINDOWMONITOR->vecSize.y) ?
+                    CBox{BB.x, BB.y, BB.width, BB.height} :
+                    CBox{BB.x - BORDER_GRAB_AREA, BB.y - BORDER_GRAB_AREA, BB.width + 2 * BORDER_GRAB_AREA, BB.height + 2 * BORDER_GRAB_AREA};
+
                 if (w->m_bIsFloating && w->m_bIsMapped && isWorkspaceVisible(w->m_iWorkspaceID) && !w->isHidden() && !w->m_bPinned && !w->m_sAdditionalConfigData.noFocus &&
                     w.get() != pIgnoreWindow && (!aboveFullscreen || w->m_bCreatedOverFullscreen)) {
                     // OR windows should add focus to parent


### PR DESCRIPTION
Fixes this problem where, when crossing monitor borders, special workspaces would automatically close in a jarring way if the gap between a floating window and the monitor edge was less than `extend_border_grab_area`:

https://github.com/hyprwm/Hyprland/assets/61563764/22d67519-3237-4a28-95cc-e3e04cd7be5b

It's only an issue when `special_fallthrough` is disabled and `extend_border_grab_area > 0`.

It's ready to merge, but I'm not sure if it's the best solution. Is there a cleaner way to check if a window is fully contained inside its monitor?