### PR TITLE
build: attempt to fix broken cache

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           ref: ${{ github.ref }}
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: cachix/install-nix-action@v25
       - uses: DeterminateSystems/magic-nix-cache-action@main
       - uses: cachix/cachix-action@v12
         with:


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

`DeterminateSystems/nix-installer-action` is somehow causing hash inconsistency between the CI & local build, which breaks the binary cache. Changing it to `cachix/install-nix-action` (which is recommended by the official Cachix guide anyways) fixes the issue.

For example take the following [job](https://github.com/hyprwm/Hyprland/actions/runs/8138864422/job/22240678370). Here are the paths that the job pushed to cachix:

```
Pushing /nix/store/aqkmnlxvhm89vqqjf17pvdzyyh9ys3k8-hyprland-0.36.0+date=2024-03-04_12da0fc-man (2.57 KiB)
Pushing /nix/store/npplz0nhfgnq1is2mk0a5mvnvbkb2xnb-hyprland-0.36.0+date=2024-03-04_12da0fc-dev (607.52 KiB)
Pushing /nix/store/x99hq5bansj87z30svsgqnbacq4mj94w-hyprland-0.36.0+date=2024-03-04_12da0fc (50.38 MiB)
```

We can try it out ourselves in a local repo:

```bash
git clone https://github.com/hyprwm/Hyprland
cd Hyprland
git checkout 12da0fc
```

Then we check the outputs of the derivation (this does not require any building):

```bash
$ nix derivation show .#hyprland | jq 'first(.[]) | .outputs'
{
  "dev": {
    "path": "/nix/store/wych3vibdam6nwrch2gpq7iza16k2s4p-hyprland-0.36.0+date=2024-03-04_12da0fc-dev"
  },
  "man": {
    "path": "/nix/store/zfrwfc6ij500v46dv7y15lfnfkrix5yw-hyprland-0.36.0+date=2024-03-04_12da0fc-man"
  },
  "out": {
    "path": "/nix/store/2g3jrs0s2qj0k8hj7wmr979h9jrx2mr6-hyprland-0.36.0+date=2024-03-04_12da0fc"
  }
}
```

As you can, see the hashes are all different. With `cachix/install-nix-action`, the hashes are the same.


Fix: https://github.com/hyprwm/Hyprland/issues/2540

