### PR TITLE
Add custom fontsize support for notifications

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1422,7 +1422,7 @@ std::string dispatchNotify(eHyprCtlOutputFormat format, std::string request) {
 
     CColor color = configStringToInt(vars[3]);
 
-    int    msgidx   = 4;
+    size_t msgidx   = 4;
     float  fontsize = 13.f;
     if (vars[msgidx].length() > 9 && vars[msgidx].compare(0, 10, "fontsize:")) {
         const auto FONTSIZE = vars[msgidx].substr(9);

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1440,13 +1440,9 @@ std::string dispatchNotify(eHyprCtlOutputFormat format, std::string request) {
     if (vars.size() <= msgidx)
         return "not enough args";
 
-    std::string message = "";
-    for (size_t i = msgidx; i < vars.size(); ++i) {
-        message += vars[i] + " ";
-    }
-    message.pop_back();
+    const auto MESSAGE = vars.join(" ", msgidx);
 
-    g_pHyprNotificationOverlay->addNotification(message, color, time, (eIcons)icon, fontsize);
+    g_pHyprNotificationOverlay->addNotification(MESSAGE, color, time, (eIcons)icon, fontsize);
 
     return "ok";
 }

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1397,7 +1397,7 @@ std::string dispatchPlugin(eHyprCtlOutputFormat format, std::string request) {
 std::string dispatchNotify(eHyprCtlOutputFormat format, std::string request) {
     CVarList vars(request, 0, ' ');
 
-    if (vars.size() < 6)
+    if (vars.size() < 5)
         return "not enough args";
 
     const auto ICON = vars[1];
@@ -1420,24 +1420,30 @@ std::string dispatchNotify(eHyprCtlOutputFormat format, std::string request) {
         time = std::stoi(TIME);
     } catch (std::exception& e) { return "invalid arg 2"; }
 
-    CColor     color = configStringToInt(vars[3]);
+    CColor color = configStringToInt(vars[3]);
 
-    const auto FONTSIZE = vars[4];
+    int    msgidx   = 4;
+    float  fontsize = 13.f;
+    if (vars[msgidx].length() > 9 && vars[msgidx].compare(0, 10, "fontsize:")) {
+        const auto FONTSIZE = vars[msgidx].substr(9);
 
-    if (!isNumber(FONTSIZE, true))
-        return "invalid arg 4";
+        if (!isNumber(FONTSIZE, true))
+            return "invalid fontsize kwarg";
 
-    float fontsize = -1;
-    try {
-        fontsize = std::stoi(FONTSIZE);
-    } catch (std::exception& e) { return "invalid arg 4"; }
+        try {
+            fontsize = std::stoi(FONTSIZE);
+        } catch (std::exception& e) { return "invalid fontsize karg"; }
 
-    std::string message = "";
-
-    for (size_t i = 5; i < vars.size(); ++i) {
-        message += vars[i] + " ";
+        ++msgidx;
     }
 
+    if (vars.size() <= msgidx)
+        return "not enough args";
+
+    std::string message = "";
+    for (size_t i = msgidx; i < vars.size(); ++i) {
+        message += vars[i] + " ";
+    }
     message.pop_back();
 
     g_pHyprNotificationOverlay->addNotification(message, color, time, (eIcons)icon, fontsize);

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1425,12 +1425,12 @@ std::string dispatchNotify(eHyprCtlOutputFormat format, std::string request) {
     const auto FONTSIZE = vars[4];
 
     if (!isNumber(FONTSIZE, true))
-        return "invalid arg 4 (NaN: '" + FONTSIZE + "')";
+        return "invalid arg 4";
 
     float fontsize = -1;
     try {
         fontsize = std::stoi(FONTSIZE);
-    } catch (std::exception& e) { return "invalid arg 4 (stoi)"; }
+    } catch (std::exception& e) { return "invalid arg 4"; }
 
     std::string message = "";
 

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1397,7 +1397,7 @@ std::string dispatchPlugin(eHyprCtlOutputFormat format, std::string request) {
 std::string dispatchNotify(eHyprCtlOutputFormat format, std::string request) {
     CVarList vars(request, 0, ' ');
 
-    if (vars.size() < 5)
+    if (vars.size() < 6)
         return "not enough args";
 
     const auto ICON = vars[1];
@@ -1420,17 +1420,27 @@ std::string dispatchNotify(eHyprCtlOutputFormat format, std::string request) {
         time = std::stoi(TIME);
     } catch (std::exception& e) { return "invalid arg 2"; }
 
-    CColor      color = configStringToInt(vars[3]);
+    CColor     color = configStringToInt(vars[3]);
+
+    const auto FONTSIZE = vars[4];
+
+    if (!isNumber(FONTSIZE, true))
+        return "invalid arg 4 (NaN: '" + FONTSIZE + "')";
+
+    float fontsize = -1;
+    try {
+        fontsize = std::stoi(FONTSIZE);
+    } catch (std::exception& e) { return "invalid arg 4 (stoi)"; }
 
     std::string message = "";
 
-    for (size_t i = 4; i < vars.size(); ++i) {
+    for (size_t i = 5; i < vars.size(); ++i) {
         message += vars[i] + " ";
     }
 
     message.pop_back();
 
-    g_pHyprNotificationOverlay->addNotification(message, color, time, (eIcons)icon);
+    g_pHyprNotificationOverlay->addNotification(message, color, time, (eIcons)icon, fontsize);
 
     return "ok";
 }

--- a/src/debug/HyprNotificationOverlay.cpp
+++ b/src/debug/HyprNotificationOverlay.cpp
@@ -36,14 +36,15 @@ CHyprNotificationOverlay::CHyprNotificationOverlay() {
     m_szIconFontName = fonts.substr(COLON + 2, LASTCHAR - (COLON + 2));
 }
 
-void CHyprNotificationOverlay::addNotification(const std::string& text, const CColor& color, const float timeMs, const eIcons icon) {
+void CHyprNotificationOverlay::addNotification(const std::string& text, const CColor& color, const float timeMs, const eIcons icon, const float fontSize) {
     const auto PNOTIF = m_dNotifications.emplace_back(std::make_unique<SNotification>()).get();
 
     PNOTIF->text  = text;
     PNOTIF->color = color == CColor(0) ? ICONS_COLORS[icon] : color;
     PNOTIF->started.reset();
-    PNOTIF->timeMs = timeMs;
-    PNOTIF->icon   = icon;
+    PNOTIF->timeMs   = timeMs;
+    PNOTIF->icon     = icon;
+    PNOTIF->fontSize = fontSize;
 
     for (auto& m : g_pCompositor->m_vMonitors) {
         g_pCompositor->scheduleFrameForMonitor(m.get());
@@ -73,28 +74,25 @@ CBox CHyprNotificationOverlay::drawNotifications(CMonitor* pMonitor) {
     float                 offsetY  = 10;
     float                 maxWidth = 0;
 
-    const auto            SCALE    = pMonitor->scale;
-    const auto            FONTSIZE = std::clamp((int)(13.f * ((pMonitor->vecPixelSize.x * SCALE) / 1920.f)), 8, 40);
+    const auto            SCALE = pMonitor->scale;
 
     const auto            MONSIZE = pMonitor->vecPixelSize;
 
     cairo_text_extents_t  cairoExtents;
     int                   iconW = 0, iconH = 0;
 
-    PangoLayout*          pangoLayout;
-    PangoFontDescription* pangoFD;
-
-    pangoLayout = pango_cairo_create_layout(m_pCairo);
-    pangoFD     = pango_font_description_from_string(("Sans " + std::to_string(FONTSIZE * ICON_SCALE)).c_str());
-    pango_layout_set_font_description(pangoLayout, pangoFD);
-
     cairo_select_font_face(m_pCairo, "Sans", CAIRO_FONT_SLANT_NORMAL, CAIRO_FONT_WEIGHT_NORMAL);
-    cairo_set_font_size(m_pCairo, FONTSIZE);
 
     const auto PBEZIER = g_pAnimationManager->getBezier("default");
 
     for (auto& notif : m_dNotifications) {
-        const auto ICONPADFORNOTIF = notif->icon == ICON_NONE ? 0 : ICON_PAD;
+        const auto            ICONPADFORNOTIF = notif->icon == ICON_NONE ? 0 : ICON_PAD;
+        const auto            FONTSIZE        = std::clamp((int)(notif->fontSize * ((pMonitor->vecPixelSize.x * SCALE) / 1920.f)), 8, 40);
+
+        PangoLayout*          pangoLayout = pango_cairo_create_layout(m_pCairo);
+        PangoFontDescription* pangoFD     = pango_font_description_from_string(("Sans " + std::to_string(FONTSIZE * ICON_SCALE)).c_str());
+        pango_layout_set_font_description(pangoLayout, pangoFD);
+        cairo_set_font_size(m_pCairo, FONTSIZE);
 
         // first rect (bg, col)
         const float FIRSTRECTANIMP =
@@ -174,10 +172,10 @@ CBox CHyprNotificationOverlay::drawNotifications(CMonitor* pMonitor) {
 
         if (maxWidth < NOTIFSIZE.x)
             maxWidth = NOTIFSIZE.x;
-    }
 
-    pango_font_description_free(pangoFD);
-    g_object_unref(pangoLayout);
+        pango_font_description_free(pangoFD);
+        g_object_unref(pangoLayout);
+    }
 
     // cleanup notifs
     std::erase_if(m_dNotifications, [](const auto& notif) { return notif->started.getMillis() > notif->timeMs; });

--- a/src/debug/HyprNotificationOverlay.hpp
+++ b/src/debug/HyprNotificationOverlay.hpp
@@ -33,7 +33,7 @@ struct SNotification {
     CTimer      started;
     float       timeMs   = 0;
     eIcons      icon     = ICON_NONE;
-    float       fontSize = 18.f;
+    float       fontSize = 13.f;
 };
 
 class CHyprNotificationOverlay {
@@ -41,7 +41,7 @@ class CHyprNotificationOverlay {
     CHyprNotificationOverlay();
 
     void draw(CMonitor* pMonitor);
-    void addNotification(const std::string& text, const CColor& color, const float timeMs, const eIcons icon = ICON_NONE, const float fontSize = 18.f);
+    void addNotification(const std::string& text, const CColor& color, const float timeMs, const eIcons icon = ICON_NONE, const float fontSize = 13.f);
     void dismissNotifications(const int amount);
     bool hasAny();
 

--- a/src/debug/HyprNotificationOverlay.hpp
+++ b/src/debug/HyprNotificationOverlay.hpp
@@ -31,8 +31,9 @@ struct SNotification {
     std::string text = "";
     CColor      color;
     CTimer      started;
-    float       timeMs = 0;
-    eIcons      icon   = ICON_NONE;
+    float       timeMs   = 0;
+    eIcons      icon     = ICON_NONE;
+    float       fontSize = 18.f;
 };
 
 class CHyprNotificationOverlay {
@@ -40,7 +41,7 @@ class CHyprNotificationOverlay {
     CHyprNotificationOverlay();
 
     void draw(CMonitor* pMonitor);
-    void addNotification(const std::string& text, const CColor& color, const float timeMs, const eIcons icon = ICON_NONE);
+    void addNotification(const std::string& text, const CColor& color, const float timeMs, const eIcons icon = ICON_NONE, const float fontSize = 18.f);
     void dismissNotifications(const int amount);
     bool hasAny();
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This adds support for specifying a custom font size the notification will be rendered with.

Fixes #4866

![image](https://github.com/hyprwm/Hyprland/assets/20902250/ab5f38ea-a13c-42b1-8095-986eca3c481c)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This is technically a breaking change for anyone who is currently using `hyprctl notify`, as it requires an extra argument for the font size.

Note that I'm not entirely sure how the font size calculation worked in the original code here:

```cpp
        const auto            FONTSIZE        = std::clamp((int)(notif->fontSize * ((pMonitor->vecPixelSize.x * SCALE) / 1920.f)), 8, 40);
```

I pretty much just reused this code and used `notif->fontSize`, instead of the hard-coded value. I think this is the correct way to do it, but I'm not certain of it.

#### Is it ready for merging, or does it need work?

Ready.
