### PR TITLE
layout: warp the cursor when focusing windows

### DIFF
--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -593,6 +593,7 @@ void IHyprLayout::bringWindowToTop(CWindow* pWindow) {
 void IHyprLayout::requestFocusForWindow(CWindow* pWindow) {
     bringWindowToTop(pWindow);
     g_pCompositor->focusWindow(pWindow);
+    g_pCompositor->warpCursorTo(pWindow->middle());
 }
 
 Vector2D IHyprLayout::predictSizeForNewWindow() {


### PR DESCRIPTION
Similar to the `focuswindow` dispatcher, when focusing a window with wlr-foreign-toplevel-management, the cursor should be warped. Otherwise, the focus is lost immediately after the cursor moves.