### PR TITLE
hyprpm(feat): Support specifying exact git revisions for plugin repo

### DIFF
--- a/hyprpm/src/core/DataState.cpp
+++ b/hyprpm/src/core/DataState.cpp
@@ -45,7 +45,8 @@ void DataState::addNewPluginRepo(const SPluginRepository& repo) {
         {"repository", toml::table{
             {"name", repo.name},
             {"hash", repo.hash},
-            {"url", repo.url}
+            {"url", repo.url},
+            {"rev", repo.rev}
         }}
     };
     for (auto& p : repo.plugins) {
@@ -178,12 +179,14 @@ std::vector<SPluginRepository> DataState::getAllRepositories() {
 
         const auto        NAME = STATE["repository"]["name"].value_or("");
         const auto        URL  = STATE["repository"]["url"].value_or("");
+        const auto        REV  = STATE["repository"]["rev"].value_or("");
         const auto        HASH = STATE["repository"]["hash"].value_or("");
 
         SPluginRepository repo;
         repo.hash = HASH;
         repo.name = NAME;
         repo.url  = URL;
+        repo.rev  = REV;
 
         for (const auto& [key, val] : STATE) {
             if (key == "repository")

--- a/hyprpm/src/core/Plugin.hpp
+++ b/hyprpm/src/core/Plugin.hpp
@@ -12,6 +12,7 @@ struct SPlugin {
 
 struct SPluginRepository {
     std::string          url;
+    std::string          rev;
     std::string          name;
     std::vector<SPlugin> plugins;
     std::string          hash;

--- a/hyprpm/src/core/PluginManager.hpp
+++ b/hyprpm/src/core/PluginManager.hpp
@@ -36,7 +36,7 @@ struct SHyprlandVersion {
 
 class CPluginManager {
   public:
-    bool                   addNewPluginRepo(const std::string& url);
+    bool                   addNewPluginRepo(const std::string& url, const std::string& rev);
     bool                   removePluginRepo(const std::string& urlOrName);
 
     eHeadersErrors         headersValid();

--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -11,7 +11,7 @@
 
 const std::string HELP = R"#(┏ hyprpm, a Hyprland Plugin Manager
 ┃
-┣ add [url] [git rev]    → Install a new plugin repository from git
+┣ add [url] [git rev]    → Install a new plugin repository from git. Git revision is optional, when set, commit locks are ignored.
 ┣ remove [url/name]      → Remove an installed plugin repository
 ┣ enable [name]          → Enable a plugin
 ┣ disable [name]         → Disable a plugin

--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -11,7 +11,8 @@
 
 const std::string HELP = R"#(┏ hyprpm, a Hyprland Plugin Manager
 ┃
-┣ add [url] [git rev]    → Install a new plugin repository from git. Git revision is optional, when set, commit locks are ignored.
+┣ add [url] [git rev]    → Install a new plugin repository from git. Git revision
+┃                          is optional, when set, commit locks are ignored.
 ┣ remove [url/name]      → Remove an installed plugin repository
 ┣ enable [name]          → Enable a plugin
 ┣ disable [name]         → Disable a plugin

--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -11,7 +11,7 @@
 
 const std::string HELP = R"#(┏ hyprpm, a Hyprland Plugin Manager
 ┃
-┣ add [url]              → Install a new plugin repository from git
+┣ add [url] [git rev]    → Install a new plugin repository from git
 ┣ remove [url/name]      → Remove an installed plugin repository
 ┣ enable [name]          → Enable a plugin
 ┣ disable [name]         → Disable a plugin

--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -77,7 +77,12 @@ int               main(int argc, char** argv, char** envp) {
             return 1;
         }
 
-        return g_pPluginManager->addNewPluginRepo(command[1]) ? 0 : 1;
+        std::string rev = "";
+        if (command.size() >= 3) {
+            rev = command[2];
+        }
+
+        return g_pPluginManager->addNewPluginRepo(command[1], rev) ? 0 : 1;
     } else if (command[0] == "remove") {
         if (ARGS.size() < 2) {
             std::cerr << Colors::RED << "✖" << Colors::RESET << " Not enough args for remove.\n";


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This introduces support to specify an exact git revision (commit/tag/branch) for a plugin. The revision can now be specified as the 2nd argument when adding a repo.

When a revision is specified, the commit pins will be ignored, so that the specified rev is used.

Fixes #4730

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

The revision will be specified for the entire repo, not the individual plugins in it. This basically means that all plugins of that repo will use the same locked revision.

#### Is it ready for merging, or does it need work?

Ready.
