### PR TITLE
Fix logic of "on" and "off"  for binding of switch

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1467,11 +1467,11 @@ void CInputManager::newSwitch(wlr_input_device* pDevice) {
 
             switch (E->switch_state) {
                 case WLR_SWITCH_STATE_OFF:
-                    Debug::log(LOG, "Switch {} turn on, triggering binds.", NAME);
+                    Debug::log(LOG, "Switch {} turn off, triggering binds.", NAME);
                     g_pKeybindManager->onSwitchOnEvent(NAME);
                     break;
                 case WLR_SWITCH_STATE_ON:
-                    Debug::log(LOG, "Switch {} turn off, triggering binds.", NAME);
+                    Debug::log(LOG, "Switch {} turn on, triggering binds.", NAME);
                     g_pKeybindManager->onSwitchOffEvent(NAME);
                     break;
             }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1466,11 +1466,11 @@ void CInputManager::newSwitch(wlr_input_device* pDevice) {
             g_pKeybindManager->onSwitchEvent(NAME);
 
             switch (E->switch_state) {
-                case WLR_SWITCH_STATE_ON:
+                case WLR_SWITCH_STATE_OFF:
                     Debug::log(LOG, "Switch {} turn on, triggering binds.", NAME);
                     g_pKeybindManager->onSwitchOnEvent(NAME);
                     break;
-                case WLR_SWITCH_STATE_OFF:
+                case WLR_SWITCH_STATE_ON:
                     Debug::log(LOG, "Switch {} turn off, triggering binds.", NAME);
                     g_pKeybindManager->onSwitchOffEvent(NAME);
                     break;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
according to [wiki](https://wiki.hyprland.org/Configuring/Binds/#switches)
```
# trigger when the switch is turning on
bindl=,switch:on:[switch name],exec,hyprctl keyword monitor "eDP-1, 2560x1600, 0x0, 1"
# trigger when the switch is turning off
bindl=,switch:off:[switch name],exec,hyprctl keyword monitor "eDP-1, disable"

```
when you turn off the lid,it trigger switch:off,but it behavior opposite now.
#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
It is ready for merging

