### PR TITLE
animations: fix m_Goal not being set after #4911

### DIFF
--- a/src/helpers/AnimatedVariable.hpp
+++ b/src/helpers/AnimatedVariable.hpp
@@ -202,6 +202,7 @@ class CAnimatedVariable : public CBaseAnimatedVariable {
     void create(const VarType& value, SAnimationPropertyConfig* pAnimConfig, void* pWindow, AVARDAMAGEPOLICY policy) {
         create(pAnimConfig, pWindow, policy);
         m_Value = value;
+        m_Goal  = value;
     }
 
     using CBaseAnimatedVariable::create;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes breakage in animations in #4911 where m_Goal is not set in the animation `create` call.

hy3 sets multiple animations to -1.0 as an "uninitialized" value. Before this MR m_Goal and m_Value were both set to the given value. Now only m_Value is. I don't know if this breaks anything in hyprland but it breaks hy3 tab bars. (I can fix this on my end but it seems like it should be fixed here.)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready