### PR TITLE
Master layout: fix issue of active monitor not changing when moving windows around

### DIFF
--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -977,6 +977,8 @@ void CHyprMasterLayout::moveWindowTo(CWindow* pWindow, const std::string& dir) {
         onWindowRemovedTiling(pWindow);
         pWindow->moveToWorkspace(PWINDOW2->m_iWorkspaceID);
         pWindow->m_iMonitorID = PWINDOW2->m_iMonitorID;
+        const auto pMonitor   = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
+        g_pCompositor->setActiveMonitor(pMonitor);
         onWindowCreatedTiling(pWindow);
     } else {
         // if same monitor, switch windows


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Master layout: fix issue of active monitor sometimes not changing when moving a window across monitors
This issue sometimes prevents you from moving a window to another monitor for some reason

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready

