### PR TITLE
IPCEvent: Add 5 IPC event with support for workspace ID

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2059,8 +2059,10 @@ void CCompositor::swapActiveWorkspaces(CMonitor* pMonitorA, CMonitor* pMonitorB)
 
     // event
     g_pEventManager->postEvent(SHyprIPCEvent{"moveworkspace", PWORKSPACEA->m_szName + "," + pMonitorB->szName});
+    g_pEventManager->postEvent(SHyprIPCEvent{"moveworkspacev2", std::format("{},{},{}", PWORKSPACEA->m_iID, PWORKSPACEA->m_szName, pMonitorB->szName)});
     EMIT_HOOK_EVENT("moveWorkspace", (std::vector<void*>{PWORKSPACEA, pMonitorB}));
     g_pEventManager->postEvent(SHyprIPCEvent{"moveworkspace", PWORKSPACEB->m_szName + "," + pMonitorA->szName});
+    g_pEventManager->postEvent(SHyprIPCEvent{"moveworkspacev2", std::format("{},{},{}", PWORKSPACEB->m_iID, PWORKSPACEB->m_szName, pMonitorA->szName)});
     EMIT_HOOK_EVENT("moveWorkspace", (std::vector<void*>{PWORKSPACEB, pMonitorA}));
 }
 
@@ -2241,6 +2243,7 @@ void CCompositor::moveWorkspaceToMonitor(CWorkspace* pWorkspace, CMonitor* pMoni
 
     // event
     g_pEventManager->postEvent(SHyprIPCEvent{"moveworkspace", pWorkspace->m_szName + "," + pMonitor->szName});
+    g_pEventManager->postEvent(SHyprIPCEvent{"moveworkspacev2", std::format("{},{},{}", pWorkspace->m_iID, pWorkspace->m_szName, pMonitor->szName)});
     EMIT_HOOK_EVENT("moveWorkspace", (std::vector<void*>{pWorkspace, pMonitor}));
 }
 
@@ -2577,10 +2580,7 @@ CWorkspace* CCompositor::createNewWorkspace(const int& id, const int& monid, con
 
     const bool SPECIAL = id >= SPECIAL_WORKSPACE_START && id <= -2;
 
-    const auto PWORKSPACE = m_vWorkspaces.emplace_back(std::make_unique<CWorkspace>(monID, NAME, SPECIAL)).get();
-
-    PWORKSPACE->m_iID        = id;
-    PWORKSPACE->m_iMonitorID = monID;
+    const auto PWORKSPACE = m_vWorkspaces.emplace_back(std::make_unique<CWorkspace>(id, monID, NAME, SPECIAL)).get();
 
     PWORKSPACE->m_fAlpha.setValueAndWarp(0);
 

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -386,6 +386,7 @@ void CWindow::moveToWorkspace(int workspaceID) {
 
     if (PWORKSPACE) {
         g_pEventManager->postEvent(SHyprIPCEvent{"movewindow", std::format("{:x},{}", (uintptr_t)this, PWORKSPACE->m_szName)});
+        g_pEventManager->postEvent(SHyprIPCEvent{"movewindowv2", std::format("{:x},{},{}", (uintptr_t)this, PWORKSPACE->m_iID, PWORKSPACE->m_szName)});
         EMIT_HOOK_EVENT("moveWindow", (std::vector<void*>{this, PWORKSPACE}));
     }
 

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -2,7 +2,7 @@
 #include "../Compositor.hpp"
 #include "../config/ConfigValue.hpp"
 
-CWorkspace::CWorkspace(int monitorID, std::string name, bool special) {
+CWorkspace::CWorkspace(int id, int monitorID, std::string name, bool special) {
     const auto PMONITOR = g_pCompositor->getMonitorFromID(monitorID);
 
     if (!PMONITOR) {
@@ -11,6 +11,7 @@ CWorkspace::CWorkspace(int monitorID, std::string name, bool special) {
     }
 
     m_iMonitorID          = monitorID;
+    m_iID                 = id;
     m_szName              = name;
     m_bIsSpecialWorkspace = special;
 
@@ -30,6 +31,7 @@ CWorkspace::CWorkspace(int monitorID, std::string name, bool special) {
         m_szName = RULEFORTHIS.defaultName.value();
 
     g_pEventManager->postEvent({"createworkspace", m_szName});
+    g_pEventManager->postEvent({"createworkspacev2", std::format("{},{}", m_iID, m_szName)});
     EMIT_HOOK_EVENT("createWorkspace", this);
 }
 
@@ -39,6 +41,7 @@ CWorkspace::~CWorkspace() {
     Debug::log(LOG, "Destroying workspace ID {}", m_iID);
 
     g_pEventManager->postEvent({"destroyworkspace", m_szName});
+    g_pEventManager->postEvent({"destroyworkspacev2", std::format("{},{}", m_iID, m_szName)});
     EMIT_HOOK_EVENT("destroyWorkspace", this);
 }
 

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -14,7 +14,7 @@ class CWindow;
 
 class CWorkspace {
   public:
-    CWorkspace(int monitorID, std::string name, bool special = false);
+    CWorkspace(int id, int monitorID, std::string name, bool special = false);
     ~CWorkspace();
 
     // Workspaces ID-based have IDs > 0

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -414,9 +414,7 @@ void CMonitor::setupDefaultWS(const SMonitorRule& monitorRule) {
         if (newDefaultWorkspaceName == "")
             newDefaultWorkspaceName = std::to_string(WORKSPACEID);
 
-        PNEWWORKSPACE = g_pCompositor->m_vWorkspaces.emplace_back(std::make_unique<CWorkspace>(ID, newDefaultWorkspaceName)).get();
-
-        PNEWWORKSPACE->m_iID = WORKSPACEID;
+        PNEWWORKSPACE = g_pCompositor->m_vWorkspaces.emplace_back(std::make_unique<CWorkspace>(WORKSPACEID, ID, newDefaultWorkspaceName)).get();
     }
 
     activeWorkspace = PNEWWORKSPACE->m_iID;
@@ -593,6 +591,7 @@ void CMonitor::changeWorkspace(CWorkspace* const pWorkspace, bool internal, bool
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(ID);
 
         g_pEventManager->postEvent(SHyprIPCEvent{"workspace", pWorkspace->m_szName});
+        g_pEventManager->postEvent(SHyprIPCEvent{"workspacev2", std::format("{},{}", pWorkspace->m_iID, pWorkspace->m_szName)});
         EMIT_HOOK_EVENT("workspace", pWorkspace);
     }
 


### PR DESCRIPTION
- `moveworkspacev2`:    returns workspaceID,workspaceName,monitorName
- `movewindowv2`:       returns windowAddress,workspaceID,workspaceName
- `createWorkspacev2`:  returns workspaceID,workspaceName
- `destroyWorkspacev2`: returns workspaceID,workspaceName
- `workspacev2`:        returns workspaceID,workspaceName

Include workspaceID as a parameter in CWorkspace constructor to support `createWorkspacev2`.

Resolves #4929

