### PR TITLE
fix tap-to-click and tap-and-drag names

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -462,8 +462,8 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("input:touchpad:clickfinger_behavior", Hyprlang::INT{0});
     m_pConfig->addConfigValue("input:touchpad:tap_button_map", {STRVAL_EMPTY});
     m_pConfig->addConfigValue("input:touchpad:middle_button_emulation", Hyprlang::INT{0});
-    m_pConfig->addConfigValue("input:touchpad:tap-to-click", Hyprlang::INT{1});
-    m_pConfig->addConfigValue("input:touchpad:tap-and-drag", Hyprlang::INT{1});
+    m_pConfig->addConfigValue("input:touchpad:tap_to_click", Hyprlang::INT{1});
+    m_pConfig->addConfigValue("input:touchpad:tap_and_drag", Hyprlang::INT{1});
     m_pConfig->addConfigValue("input:touchpad:drag_lock", Hyprlang::INT{0});
     m_pConfig->addConfigValue("input:touchpad:scroll_factor", {1.f});
     m_pConfig->addConfigValue("input:touchdevice:transform", Hyprlang::INT{0});
@@ -539,8 +539,8 @@ CConfigManager::CConfigManager() {
     m_pConfig->addSpecialConfigValue("device", "disable_while_typing", Hyprlang::INT{1});
     m_pConfig->addSpecialConfigValue("device", "clickfinger_behavior", Hyprlang::INT{0});
     m_pConfig->addSpecialConfigValue("device", "middle_button_emulation", Hyprlang::INT{0});
-    m_pConfig->addSpecialConfigValue("device", "tap-to-click", Hyprlang::INT{1});
-    m_pConfig->addSpecialConfigValue("device", "tap-and-drag", Hyprlang::INT{1});
+    m_pConfig->addSpecialConfigValue("device", "tap_to_click", Hyprlang::INT{1});
+    m_pConfig->addSpecialConfigValue("device", "tap_and_drag", Hyprlang::INT{1});
     m_pConfig->addSpecialConfigValue("device", "drag_lock", Hyprlang::INT{0});
     m_pConfig->addSpecialConfigValue("device", "left_handed", Hyprlang::INT{0});
     m_pConfig->addSpecialConfigValue("device", "scroll_method", {STRVAL_EMPTY});

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1012,7 +1012,7 @@ void CInputManager::setPointerConfigs() {
                 Debug::log(WARN, "Scroll method unknown");
             }
 
-            if (g_pConfigManager->getDeviceInt(devname, "tap-and-drag", "input:touchpad:tap-and-drag") == 0)
+            if (g_pConfigManager->getDeviceInt(devname, "tap_and_drag", "input:touchpad:tap_and_drag") == 0)
                 libinput_device_config_tap_set_drag_enabled(LIBINPUTDEV, LIBINPUT_CONFIG_DRAG_DISABLED);
             else
                 libinput_device_config_tap_set_drag_enabled(LIBINPUTDEV, LIBINPUT_CONFIG_DRAG_ENABLED);
@@ -1023,7 +1023,7 @@ void CInputManager::setPointerConfigs() {
                 libinput_device_config_tap_set_drag_lock_enabled(LIBINPUTDEV, LIBINPUT_CONFIG_DRAG_LOCK_ENABLED);
 
             if (libinput_device_config_tap_get_finger_count(LIBINPUTDEV)) // this is for tapping (like on a laptop)
-                if (g_pConfigManager->getDeviceInt(devname, "tap-to-click", "input:touchpad:tap-to-click") == 1)
+                if (g_pConfigManager->getDeviceInt(devname, "tap_to_click", "input:touchpad:tap_to_click") == 1)
                     libinput_device_config_tap_set_enabled(LIBINPUTDEV, LIBINPUT_CONFIG_TAP_ENABLED);
 
             if (libinput_device_config_scroll_has_natural_scroll(LIBINPUTDEV)) {


### PR DESCRIPTION
this follows how every other config variable is formatted

#### Describe your PR, what does it fix/add?
Every other config variable is using underscores to separate words but these are the only ones that do not follow that convention.
All I did was change where it used dashes to underscores.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
If this is merged the wiki will also have to be edited to fix the renaming

