### PR TITLE
only warp cursor on deactivate if constraint is locked. fix #5055

### DIFF
--- a/src/desktop/Constraint.cpp
+++ b/src/desktop/Constraint.cpp
@@ -94,7 +94,9 @@ void CConstraint::deactivate() {
 
     wlr_pointer_constraint_v1_send_deactivated(m_pConstraint);
     m_bActive = false;
-    g_pCompositor->warpCursorTo(logicPositionHint(), true);
+
+    if (isLocked())
+        g_pCompositor->warpCursorTo(logicPositionHint(), true);
 
     if (m_pConstraint->lifetime == ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_ONESHOT)
         m_bDead = true;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Resolves an issue where the cursor would warp on constraint deactivation incorrectly.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
N/A

#### Is it ready for merging, or does it need work?
Ready for merging

