### PR TITLE
Fix typo and check grandchild PID in spawn()

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -792,9 +792,9 @@ uint64_t CKeybindManager::spawnRaw(std::string args) {
     close(socket[1]);
     read(socket[0], &grandchild, sizeof(grandchild));
     close(socket[0]);
-    // clear child and leave child to init
+    // clear child and leave grandchild to init
     waitpid(child, NULL, 0);
-    if (child < 0) {
+    if (grandchild < 0) {
         Debug::log(LOG, "Fail to create the second fork");
         return 0;
     }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fix a niche bug with `spawnraw()` where we check the child PID instead of granchild before returning with error

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Same fix from https://github.com/hyprwm/hypridle/pull/34

#### Is it ready for merging, or does it need work?
Ready

