### PR TITLE
lock: fix red screen issues with multiple monitors

### DIFF
--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -15,8 +15,6 @@ static void handleSurfaceMap(void* owner, void* data) {
 
     if (PMONITOR)
         g_pHyprRenderer->damageMonitor(PMONITOR);
-
-    g_pSessionLockManager->activateLock(); // activate lock here to prevent the red screen from flashing before that
 }
 
 static void handleSurfaceCommit(void* owner, void* data) {
@@ -126,6 +124,8 @@ void CSessionLockManager::onNewSessionLock(wlr_session_lock_v1* pWlrLock) {
         pWlrLock, "wlr_session_lock_v1");
 
     wlr_session_lock_v1_send_locked(pWlrLock);
+
+    g_pSessionLockManager->activateLock();
 }
 
 bool CSessionLockManager::isSessionLocked() {

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -132,7 +132,7 @@ bool CSessionLockManager::isSessionLocked() {
     return m_sSessionLock.active;
 }
 
-SSessionLockSurface* CSessionLockManager::getSessionLockSurfaceForMonitor(const int& id) {
+SSessionLockSurface* CSessionLockManager::getSessionLockSurfaceForMonitor(uint64_t id) {
     for (auto& sls : m_sSessionLock.vSessionLockSurfaces) {
         if (sls->iMonitorID == id) {
             if (sls->mapped)

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -158,7 +158,7 @@ float CSessionLockManager::getRedScreenAlphaForMonitor(uint64_t id) {
         return 0.f;
     }
 
-    return std::clamp(NOMAPPEDSURFACETIMER->second.getSeconds(), 0.f, 1.f);
+    return std::clamp(NOMAPPEDSURFACETIMER->second.getSeconds() - /* delay for screencopy */ 0.5f, 0.f, 1.f);
 }
 
 bool CSessionLockManager::isSurfaceSessionLock(wlr_surface* pSurface) {

--- a/src/managers/SessionLockManager.hpp
+++ b/src/managers/SessionLockManager.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
 #include "../defines.hpp"
+#include <cstdint>
 
 struct SSessionLockSurface {
     wlr_session_lock_surface_v1* pWlrLockSurface = nullptr;
-    int                          iMonitorID      = -1;
+    uint64_t                     iMonitorID      = -1;
 
     bool                         mapped = false;
 
@@ -30,7 +31,7 @@ class CSessionLockManager {
     ~CSessionLockManager() = default;
 
     void                 onNewSessionLock(wlr_session_lock_v1*);
-    SSessionLockSurface* getSessionLockSurfaceForMonitor(const int&);
+    SSessionLockSurface* getSessionLockSurfaceForMonitor(uint64_t);
 
     bool                 isSessionLocked();
     bool                 isSurfaceSessionLock(wlr_surface*);

--- a/src/managers/SessionLockManager.hpp
+++ b/src/managers/SessionLockManager.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "../defines.hpp"
+#include "../helpers/Timer.hpp"
 #include <cstdint>
+#include <unordered_map>
 
 struct SSessionLockSurface {
     wlr_session_lock_surface_v1* pWlrLockSurface = nullptr;
@@ -19,6 +21,7 @@ struct SSessionLock {
     wlr_session_lock_v1*                              pWlrLock = nullptr;
 
     std::vector<std::unique_ptr<SSessionLockSurface>> vSessionLockSurfaces;
+    std::unordered_map<uint64_t, CTimer>              mMonitorsWithoutMappedSurfaceTimers;
 
     DYNLISTENER(newSurface);
     DYNLISTENER(unlock);
@@ -32,6 +35,8 @@ class CSessionLockManager {
 
     void                 onNewSessionLock(wlr_session_lock_v1*);
     SSessionLockSurface* getSessionLockSurfaceForMonitor(uint64_t);
+
+    float                getRedScreenAlphaForMonitor(uint64_t);
 
     bool                 isSessionLocked();
     bool                 isSurfaceSessionLock(wlr_surface*);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -823,8 +823,10 @@ void CHyprRenderer::renderLockscreen(CMonitor* pMonitor, timespec* now, const CB
             CBox       monbox = {translate.x, translate.y, pMonitor->vecTransformedSize.x * scale, pMonitor->vecTransformedSize.y * scale};
             g_pHyprOpenGL->renderRect(&monbox, CColor(1.0, 0.2, 0.2, ALPHA));
 
-            if (ALPHA < 1.f) /* animate */
+            if (ALPHA < 1.f) /* animate */ {
+                damageMonitor(pMonitor);
                 g_pCompositor->scheduleFrameForMonitor(pMonitor);
+            }
         } else {
             renderSessionLockSurface(PSLS, pMonitor, now);
         }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -823,10 +823,8 @@ void CHyprRenderer::renderLockscreen(CMonitor* pMonitor, timespec* now, const CB
             CBox       monbox = {translate.x, translate.y, pMonitor->vecTransformedSize.x * scale, pMonitor->vecTransformedSize.y * scale};
             g_pHyprOpenGL->renderRect(&monbox, CColor(1.0, 0.2, 0.2, ALPHA));
 
-            if (ALPHA < 1.f) /* animate */ {
+            if (ALPHA < 1.f) /* animate */
                 damageMonitor(pMonitor);
-                g_pCompositor->scheduleFrameForMonitor(pMonitor);
-            }
         } else {
             renderSessionLockSurface(PSLS, pMonitor, now);
         }

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -59,7 +59,7 @@ class CHyprRenderer {
     void                            setCursorHidden(bool hide);
     void                            calculateUVForSurface(CWindow*, wlr_surface*, bool main = false, const Vector2D& projSize = {}, bool fixMisalignedFSV1 = false);
     std::tuple<float, float, float> getRenderTimes(CMonitor* pMonitor); // avg max min
-    void                            renderLockscreen(CMonitor* pMonitor, timespec* now);
+    void                            renderLockscreen(CMonitor* pMonitor, timespec* now, const CBox& geometry);
     void                            setOccludedForBackLayers(CRegion& region, CWorkspace* pWorkspace);
     void                            setOccludedForMainWorkspace(CRegion& region, CWorkspace* pWorkspace); // TODO: merge occlusion methods
     bool                            canSkipBackBufferClear(CMonitor* pMonitor);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes hyprlock screenshot red screen issues with multiple monitors.

It might take a while for `handleSurfaceMap` to be called. It can happen that hyprlock's screenshot feature then screenshots the solid red color. We could wait in hyprlock for the screenshot to be taken as is currently done for other compositors.

But this way it also fixes some red flashes that happen for me with multi monitor setups regardless of waiting for the screenshot or not.

However, if the map event would never happen, then we would never fall back to the red color which could be a problem.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Not sure if
1. It is OK to not render anything on a call to `renderLockscreen` if the surface is not mapped.
2. As mentioned it could be a problem that we never render the solid color when the map event never happens.

But it fixes our red screen issues. Confirmed by a friend.

#### Is it ready for merging, or does it need work?

Ready if there is nothing fundamentally wrong with.
