### PR TITLE
Prevent stretching when resizing window

### DIFF
--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -176,7 +176,6 @@ void CHyprXWaylandManager::setWindowSize(CWindow* pWindow, Vector2D size, bool f
 
     pWindow->m_vReportedPosition    = windowPos;
     pWindow->m_vPendingReportedSize = size;
-    pWindow->m_vReportedSize        = size;
 
     pWindow->m_fX11SurfaceScaledBy = 1.f;
 

--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -176,6 +176,7 @@ void CHyprXWaylandManager::setWindowSize(CWindow* pWindow, Vector2D size, bool f
 
     pWindow->m_vReportedPosition    = windowPos;
     pWindow->m_vPendingReportedSize = size;
+    pWindow->m_vReportedSize        = size;
 
     pWindow->m_fX11SurfaceScaledBy = 1.f;
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -537,8 +537,6 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
             renderdata.blur = false;
         }
 
-        pWindow->m_vReportedSize = pWindow->m_vRealSize.goal();
-
         wlr_surface_for_each_surface(pWindow->m_pWLSurface.wlr(), renderSurface, &renderdata);
 
         g_pHyprOpenGL->m_RenderData.useNearestNeighbor = false;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -537,6 +537,8 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
             renderdata.blur = false;
         }
 
+        pWindow->m_vReportedSize = pWindow->m_vRealSize.goal();
+
         wlr_surface_for_each_surface(pWindow->m_pWLSurface.wlr(), renderSurface, &renderdata);
 
         g_pHyprOpenGL->m_RenderData.useNearestNeighbor = false;


### PR DESCRIPTION
kinda fixes https://github.com/hyprwm/Hyprland/issues/5044. It no longer makes the surface stretch but a frame of the original surface is still visible.


