### PR TITLE
fix: refocus after destroy focused surface

### DIFF
--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -163,7 +163,7 @@ void CSessionLockManager::removeSessionLockSurface(SSessionLockSurface* pSLS) {
     for (auto& sls : m_sSessionLock.vSessionLockSurfaces) {
         if (!sls->mapped)
             continue;
-        
+
         g_pCompositor->focusSurface(sls->pWlrLockSurface->surface);
         break;
     }

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -157,7 +157,7 @@ bool CSessionLockManager::isSurfaceSessionLock(wlr_surface* pSurface) {
 void CSessionLockManager::removeSessionLockSurface(SSessionLockSurface* pSLS) {
     std::erase_if(m_sSessionLock.vSessionLockSurfaces, [&](const auto& other) { return pSLS == other.get(); });
 
-    if (g_pCompositor->m_pLastFocus != nullptr)
+    if (g_pCompositor->m_pLastFocus)
         return;
 
     for (auto& sls : m_sSessionLock.vSessionLockSurfaces) {

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -156,6 +156,16 @@ bool CSessionLockManager::isSurfaceSessionLock(wlr_surface* pSurface) {
 
 void CSessionLockManager::removeSessionLockSurface(SSessionLockSurface* pSLS) {
     std::erase_if(m_sSessionLock.vSessionLockSurfaces, [&](const auto& other) { return pSLS == other.get(); });
+
+    if (g_pCompositor->m_pLastFocus != nullptr)
+        return;
+
+    for (auto& sls : m_sSessionLock.vSessionLockSurfaces) {
+        if (sls->mapped) {
+            g_pCompositor->focusSurface(sls->pWlrLockSurface->surface);
+            break;
+        }
+    }
 }
 
 void CSessionLockManager::activateLock() {

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -161,10 +161,11 @@ void CSessionLockManager::removeSessionLockSurface(SSessionLockSurface* pSLS) {
         return;
 
     for (auto& sls : m_sSessionLock.vSessionLockSurfaces) {
-        if (sls->mapped) {
-            g_pCompositor->focusSurface(sls->pWlrLockSurface->surface);
-            break;
-        }
+        if (!sls->mapped)
+            continue;
+        
+        g_pCompositor->focusSurface(sls->pWlrLockSurface->surface);
+        break;
     }
 }
 


### PR DESCRIPTION
This will try to fix the issue of losing focus when disconnecting a monitor while in a locked session. This happens when the focus is on a surface of the monitor that is disconnecting, so this means that it will be impossible to interact with the keyboard such as writing the password to unlock the locked session. These changes will try to put focus on one of the remaining session lock surfaces when the focus is lost