### PR TITLE
opengl: report shader compilation errors from screen_shader

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -61,24 +61,19 @@ CHyprOpenGLImpl::CHyprOpenGLImpl() {
 
 static void CHyprOpenGLImpl::logError(const GLuint& shader, bool program = false) {
     GLint maxLength = 0;
-    if (program) {
+    if (program)
         glGetProgramiv(shader, GL_INFO_LOG_LENGTH, &maxLength);
-    } else {
+    else
         glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &maxLength);
-    }
 
     std::vector<GLchar> errorLog(maxLength);
-    if (program) {
+    if (program)
         glGetProgramInfoLog(shader, maxLength, &maxLength, errorLog.data());
-    } else {
+    else
         glGetShaderInfoLog(shader, maxLength, &maxLength, errorLog.data());
-    }
     std::string errorStr(errorLog.begin(), errorLog.end());
 
-    g_pConfigManager->addParseError(
-        (program ? "Screen shader parser: Error linking program:" : "Screen shader parser: Error compiling shader: ")
-        + errorStr
-    );
+    g_pConfigManager->addParseError((program ? "Screen shader parser: Error linking program:" : "Screen shader parser: Error compiling shader: ") + errorStr);
 
     return 0;
 }

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -59,7 +59,7 @@ CHyprOpenGLImpl::CHyprOpenGLImpl() {
     m_tGlobalTimer.reset();
 }
 
-static void logError(const GLuint& shader, bool program = false) {
+static void CHyprOpenGLImpl::logError(const GLuint& shader, bool program = false) {
     GLint maxLength = 0;
     if (program) {
         glGetProgramiv(shader, GL_INFO_LOG_LENGTH, &maxLength);

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -59,7 +59,7 @@ CHyprOpenGLImpl::CHyprOpenGLImpl() {
     m_tGlobalTimer.reset();
 }
 
-static void CHyprOpenGLImpl::logError(const GLuint& shader, bool program = false) {
+void CHyprOpenGLImpl::logError(const GLuint& shader, bool program) {
     GLint maxLength = 0;
     if (program)
         glGetProgramiv(shader, GL_INFO_LOG_LENGTH, &maxLength);
@@ -74,8 +74,6 @@ static void CHyprOpenGLImpl::logError(const GLuint& shader, bool program = false
     std::string errorStr(errorLog.begin(), errorLog.end());
 
     g_pConfigManager->addParseError((program ? "Screen shader parser: Error linking program:" : "Screen shader parser: Error compiling shader: ") + errorStr);
-
-    return 0;
 }
 
 GLuint CHyprOpenGLImpl::createProgram(const std::string& vert, const std::string& frag, bool dynamic) {
@@ -108,8 +106,10 @@ GLuint CHyprOpenGLImpl::createProgram(const std::string& vert, const std::string
     GLint ok;
     glGetProgramiv(prog, GL_LINK_STATUS, &ok);
     if (dynamic) {
-        if (ok == GL_FALSE)
+        if (ok == GL_FALSE) {
             logError(prog, true);
+            return 0;
+        }
     } else {
         RASSERT(ok != GL_FALSE, "createProgram() failed! GL_LINK_STATUS not OK!");
     }
@@ -129,8 +129,10 @@ GLuint CHyprOpenGLImpl::compileShader(const GLuint& type, std::string src, bool 
     glGetShaderiv(shader, GL_COMPILE_STATUS, &ok);
 
     if (dynamic) {
-        if (ok == GL_FALSE)
+        if (ok == GL_FALSE) {
             logError(shader, false);
+            return 0;
+        }
     } else {
         RASSERT(ok != GL_FALSE, "compileShader() failed! GL_COMPILE_STATUS not OK!");
     }

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -59,7 +59,7 @@ CHyprOpenGLImpl::CHyprOpenGLImpl() {
     m_tGlobalTimer.reset();
 }
 
-void CHyprOpenGLImpl::logError(const GLuint& shader, bool program) {
+void CHyprOpenGLImpl::logShaderError(const GLuint& shader, bool program) {
     GLint maxLength = 0;
     if (program)
         glGetProgramiv(shader, GL_INFO_LOG_LENGTH, &maxLength);
@@ -107,7 +107,7 @@ GLuint CHyprOpenGLImpl::createProgram(const std::string& vert, const std::string
     glGetProgramiv(prog, GL_LINK_STATUS, &ok);
     if (dynamic) {
         if (ok == GL_FALSE) {
-            logError(prog, true);
+            logShaderError(prog, true);
             return 0;
         }
     } else {
@@ -130,7 +130,7 @@ GLuint CHyprOpenGLImpl::compileShader(const GLuint& type, std::string src, bool 
 
     if (dynamic) {
         if (ok == GL_FALSE) {
-            logError(shader, false);
+            logShaderError(shader, false);
             return 0;
         }
     } else {

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -95,7 +95,7 @@ GLuint CHyprOpenGLImpl::createProgram(const std::string& vert, const std::string
 
             // The maxLength includes the NULL character
             std::vector<GLchar> errorLog(maxLength);
-            glGetProgramInfoLog(prog, maxLength, &maxLength, &errorLog[0]);
+            glGetProgramInfoLog(prog, maxLength, &maxLength, errorLog.data());
             std::string errorStr(errorLog.begin(), errorLog.end());
 
             g_pConfigManager->addParseError("Screen shader parser: Error linking program:" + errorStr);
@@ -127,7 +127,7 @@ GLuint CHyprOpenGLImpl::compileShader(const GLuint& type, std::string src, bool 
 
             // The maxLength includes the NULL character
             std::vector<GLchar> errorLog(maxLength);
-            glGetShaderInfoLog(shader, maxLength, &maxLength, &errorLog[0]);
+            glGetShaderInfoLog(shader, maxLength, &maxLength, errorLog.data());
             std::string errorStr(errorLog.begin(), errorLog.end());
 
             g_pConfigManager->addParseError("Screen shader parser: Error compiling shader: " + errorStr);

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -61,7 +61,11 @@ CHyprOpenGLImpl::CHyprOpenGLImpl() {
 
 static void logError(const GLuint& shader, bool program = false) {
     GLint maxLength = 0;
-    glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &maxLength);
+    if (program) {
+        glGetProgramiv(shader, GL_INFO_LOG_LENGTH, &maxLength);
+    } else {
+        glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &maxLength);
+    }
 
     std::vector<GLchar> errorLog(maxLength);
     if (program) {

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -219,7 +219,7 @@ class CHyprOpenGLImpl {
     CShader           m_sFinalScreenShader;
     CTimer            m_tGlobalTimer;
 
-    void              logError(const GLuint&, bool program = false);
+    void              logShaderError(const GLuint&, bool program = false);
     GLuint            createProgram(const std::string&, const std::string&, bool dynamic = false);
     GLuint            compileShader(const GLuint&, std::string, bool dynamic = false);
     void              createBGTextureForMonitor(CMonitor*);

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -219,6 +219,7 @@ class CHyprOpenGLImpl {
     CShader           m_sFinalScreenShader;
     CTimer            m_tGlobalTimer;
 
+    void              logError(const GLuint&, bool program = false);
     GLuint            createProgram(const std::string&, const std::string&, bool dynamic = false);
     GLuint            compileShader(const GLuint&, std::string, bool dynamic = false);
     void              createBGTextureForMonitor(CMonitor*);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Currently, if a shader set by `screen_shader` errors for any reason, be it a type error, syntax error, etc., the user will receive no error, and no error will be logged. This is because a call to `glGetShaderInfoLog` is never actually made. This PR makes said call, and outputs the error to `addParseError`, making a similar edit to program compilation for completeness' sake.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I'm unsure of how exactly elevating an error like this from the OpenGL module should go (sorry for my limited C++ knowledge) - I've just left it at removing the usual `"Screen shader parser: Screen shader parse failed"` error and hoping whatever caused it will make its own call to `addParseError`, but this might not be the ideal solution. Additionally, this means any `dynamic` shaders will behave this way, but nothing else is marked as `dynamic` currently except the shader configured by `screen_shader`.

#### Is it ready for merging, or does it need work?

I'm not confident at all this would be the best way to do this; but if it is, it's good to go.
