### PR TITLE
input: Handling multiple surfaces for the text-input-v1 protocol implementation and imporve InputMethodRelay logic

### DIFF
--- a/src/helpers/WLClasses.hpp
+++ b/src/helpers/WLClasses.hpp
@@ -291,15 +291,14 @@ struct SSwipeGesture {
 struct STextInputV1;
 
 struct STextInput {
-    wlr_text_input_v3* pWlrInput = nullptr;
-    STextInputV1*      pV1Input  = nullptr;
+    wlr_text_input_v3* pWlrInput      = nullptr;
+    STextInputV1*      pV1Input       = nullptr;
     wlr_surface*       focusedSurface = nullptr;
 
     DYNLISTENER(textInputEnable);
     DYNLISTENER(textInputDisable);
     DYNLISTENER(textInputCommit);
     DYNLISTENER(textInputDestroy);
-
 };
 
 struct SIMEKbGrab {

--- a/src/helpers/WLClasses.hpp
+++ b/src/helpers/WLClasses.hpp
@@ -293,15 +293,13 @@ struct STextInputV1;
 struct STextInput {
     wlr_text_input_v3* pWlrInput = nullptr;
     STextInputV1*      pV1Input  = nullptr;
-
-    wlr_surface*       pPendingSurface = nullptr;
+    wlr_surface*       focusedSurface = nullptr;
 
     DYNLISTENER(textInputEnable);
     DYNLISTENER(textInputDisable);
     DYNLISTENER(textInputCommit);
     DYNLISTENER(textInputDestroy);
 
-    DYNLISTENER(pendingSurfaceDestroy);
 };
 
 struct SIMEKbGrab {

--- a/src/managers/input/InputMethodRelay.cpp
+++ b/src/managers/input/InputMethodRelay.cpp
@@ -319,17 +319,12 @@ void CInputMethodRelay::onNewTextInput(wlr_text_input_v3* pInput) {
 }
 
 void CInputMethodRelay::createNewTextInput(wlr_text_input_v3* pInput, STextInputV1* pTIV1) {
-    // if client already has a version, reject
+
     if (pInput) {
         if (!setTextInputVersion(wl_resource_get_client(pInput->resource), 3))
-            //reject
             return;
-
-    } else {
-        if (!setTextInputVersion(pTIV1->client, 1))
-            // reject
-            return;
-    }
+    } else if (!setTextInputVersion(pTIV1->client, 1))
+        return;
 
     const auto PTEXTINPUT = &m_lTextInputs.emplace_back();
 
@@ -493,9 +488,10 @@ void CInputMethodRelay::onKeyboardFocus(wlr_surface* pSurface) {
     if (getTextInputVersion(wl_resource_get_client(pSurface->resource)) == 3) {
         if (!getTextInput(pSurface)) {
             auto client = [](STextInput* pTI) -> wl_client* { return pTI->pWlrInput ? wl_resource_get_client(pTI->pWlrInput->resource) : pTI->pV1Input->client; };
-            for (auto& ti : m_lTextInputs)
+            for (auto& ti : m_lTextInputs) {
                 if (client(&ti) == wl_resource_get_client(pSurface->resource) && ti.pWlrInput)
                     setSurfaceToPTI(pSurface, &ti);
+            }
         }
     }
 

--- a/src/managers/input/InputMethodRelay.cpp
+++ b/src/managers/input/InputMethodRelay.cpp
@@ -89,7 +89,6 @@ void CInputMethodRelay::onNewIME(wlr_input_method_v2* pIME) {
 
             if (PTI)
                 onTextInputEnter(PTI->focusedSurface);
-
         },
         this, "IMERelay");
 
@@ -141,7 +140,6 @@ void CInputMethodRelay::onNewIME(wlr_input_method_v2* pIME) {
 
     if (const auto PTI = getFocusedTextInput(); PTI)
         onTextInputEnter(PTI->focusedSurface);
-
 }
 
 wlr_surface* CInputMethodRelay::focusedSurface(STextInput* pTI) {
@@ -322,13 +320,13 @@ void CInputMethodRelay::onNewTextInput(wlr_text_input_v3* pInput) {
 
 void CInputMethodRelay::createNewTextInput(wlr_text_input_v3* pInput, STextInputV1* pTIV1) {
     // if client already has a version, reject
-    if(pInput){
-        if(!setTextInputVersion(wl_resource_get_client(pInput->resource), 3))
+    if (pInput) {
+        if (!setTextInputVersion(wl_resource_get_client(pInput->resource), 3))
             //reject
             return;
 
-    }else{
-        if(!setTextInputVersion(pTIV1->client, 1))
+    } else {
+        if (!setTextInputVersion(pTIV1->client, 1))
             // reject
             return;
     }
@@ -352,11 +350,11 @@ void CInputMethodRelay::createNewTextInput(wlr_text_input_v3* pInput, STextInput
             }
 
             // v1 only, map surface to PTI
-            if(PINPUT->pV1Input) {
-                wlr_surface* pSurface = wlr_surface_from_resource((wl_resource*)data);
+            if (PINPUT->pV1Input) {
+                wlr_surface* pSurface  = wlr_surface_from_resource((wl_resource*)data);
                 PINPUT->focusedSurface = pSurface;
                 setSurfaceToPTI(pSurface, PINPUT);
-                if(m_pFocusedSurface == pSurface)
+                if (m_pFocusedSurface == pSurface)
                     onTextInputEnter(pSurface);
             }
 
@@ -474,11 +472,11 @@ void CInputMethodRelay::onKeyboardFocus(wlr_surface* pSurface) {
     if (!m_pWLRIME)
         return;
 
-    if(pSurface == m_pFocusedSurface)
+    if (pSurface == m_pFocusedSurface)
         return;
 
     // say goodbye to the last focused surface
-    if (STextInput* lastTI = getTextInput(m_pFocusedSurface); lastTI){
+    if (STextInput* lastTI = getTextInput(m_pFocusedSurface); lastTI) {
         wlr_input_method_v2_send_deactivate(m_pWLRIME);
         commitIMEState(lastTI);
         onTextInputLeave(m_pFocusedSurface);
@@ -492,11 +490,11 @@ void CInputMethodRelay::onKeyboardFocus(wlr_surface* pSurface) {
          * POSSIBLE BUG here: if one client has multiple STextInput and multiple surfaces, for any pSurface we can only record the last found ti.
          * since original code has the same problem, it may not be a big deal.
     */
-    if(getTextInputVersion(wl_resource_get_client(pSurface->resource)) == 3){
-        if (!getTextInput(pSurface)){
+    if (getTextInputVersion(wl_resource_get_client(pSurface->resource)) == 3) {
+        if (!getTextInput(pSurface)) {
             auto client = [](STextInput* pTI) -> wl_client* { return pTI->pWlrInput ? wl_resource_get_client(pTI->pWlrInput->resource) : pTI->pV1Input->client; };
             for (auto& ti : m_lTextInputs)
-                if (client(&ti) == wl_resource_get_client(pSurface->resource)  && ti.pWlrInput)
+                if (client(&ti) == wl_resource_get_client(pSurface->resource) && ti.pWlrInput)
                     setSurfaceToPTI(pSurface, &ti);
         }
     }
@@ -504,8 +502,7 @@ void CInputMethodRelay::onKeyboardFocus(wlr_surface* pSurface) {
     onTextInputEnter(m_pFocusedSurface);
 }
 
-
- void CInputMethodRelay::onTextInputLeave(wlr_surface *pSurface){
+void CInputMethodRelay::onTextInputLeave(wlr_surface* pSurface) {
     if (!pSurface)
         return;
 
@@ -522,7 +519,7 @@ void CInputMethodRelay::onKeyboardFocus(wlr_surface* pSurface) {
     }
 }
 
-void CInputMethodRelay::onTextInputEnter(wlr_surface *pSurface){
+void CInputMethodRelay::onTextInputEnter(wlr_surface* pSurface) {
     if (!pSurface)
         return;
 
@@ -539,23 +536,21 @@ void CInputMethodRelay::onTextInputEnter(wlr_surface *pSurface){
     }
 }
 
-void  CInputMethodRelay::setSurfaceToPTI(wlr_surface* pSurface, STextInput* pInput){
-    if(pSurface){
+void CInputMethodRelay::setSurfaceToPTI(wlr_surface* pSurface, STextInput* pInput) {
+    if (pSurface) {
         m_mSurfaceToTextInput[pSurface] = pInput;
-        pInput->focusedSurface = pSurface;
+        pInput->focusedSurface          = pSurface;
     }
 }
 
-
-void  CInputMethodRelay::removeSurfaceToPTI(STextInput* pInput){
-    if(pInput->focusedSurface){
+void CInputMethodRelay::removeSurfaceToPTI(STextInput* pInput) {
+    if (pInput->focusedSurface) {
         m_mSurfaceToTextInput.erase(pInput->focusedSurface);
         pInput->focusedSurface = nullptr;
     }
 }
 
-
-STextInput* CInputMethodRelay::getTextInput(wlr_surface* pSurface){
+STextInput* CInputMethodRelay::getTextInput(wlr_surface* pSurface) {
     auto result = m_mSurfaceToTextInput.find(pSurface);
     if (result != m_mSurfaceToTextInput.end())
         return result->second;
@@ -564,7 +559,7 @@ STextInput* CInputMethodRelay::getTextInput(wlr_surface* pSurface){
 }
 
 int CInputMethodRelay::setTextInputVersion(wl_client* pClient, int version) {
-    if(int v = getTextInputVersion(pClient); v != 0 && v != version){
+    if (int v = getTextInputVersion(pClient); v != 0 && v != version) {
         Debug::log(WARN, "Client attempt to register text-input-v{}, but it has already registered text-input-v{}, ignored", version, v);
         return 0;
     }
@@ -572,7 +567,7 @@ int CInputMethodRelay::setTextInputVersion(wl_client* pClient, int version) {
     return 1;
 }
 
-int  CInputMethodRelay::getTextInputVersion(wl_client* pClient) {
+int CInputMethodRelay::getTextInputVersion(wl_client* pClient) {
     auto result = m_mClientTextInputVersion.find(pClient);
     if (result != m_mClientTextInputVersion.end())
         return result->second;
@@ -580,6 +575,6 @@ int  CInputMethodRelay::getTextInputVersion(wl_client* pClient) {
     return 0;
 }
 
-void  CInputMethodRelay::removeTextInputVersion(wl_client* pClient){
+void CInputMethodRelay::removeTextInputVersion(wl_client* pClient) {
     m_mClientTextInputVersion.erase(pClient);
 }

--- a/src/managers/input/InputMethodRelay.hpp
+++ b/src/managers/input/InputMethodRelay.hpp
@@ -23,7 +23,6 @@ class CInputMethodRelay {
 
     STextInput*          getFocusedTextInput();
 
-
     SIMEKbGrab*          getIMEKeyboardGrab(SKeyboard*);
 
     void                 setIMEPopupFocus(SIMEPopup*, wlr_surface*);
@@ -43,26 +42,22 @@ class CInputMethodRelay {
     DYNLISTENER(IMEGrab);
     DYNLISTENER(IMENewPopup);
 
-    void         createNewTextInput(wlr_text_input_v3*, STextInputV1* tiv1 = nullptr);
+    void                                          createNewTextInput(wlr_text_input_v3*, STextInputV1* tiv1 = nullptr);
 
-    wlr_surface* focusedSurface(STextInput* pInput);
-    wlr_surface* m_pFocusedSurface;
-    void onTextInputLeave(wlr_surface* pSurface);
-    void onTextInputEnter(wlr_surface* pSurface);
+    wlr_surface*                                  focusedSurface(STextInput* pInput);
+    wlr_surface*                                  m_pFocusedSurface;
+    void                                          onTextInputLeave(wlr_surface* pSurface);
+    void                                          onTextInputEnter(wlr_surface* pSurface);
 
     std::unordered_map<wlr_surface*, STextInput*> m_mSurfaceToTextInput;
-    void setSurfaceToPTI(wlr_surface* pSurface,STextInput* pInput);
-    STextInput* getTextInput(wlr_surface* pSurface);
-    void removeSurfaceToPTI(STextInput* pInput);
+    void                                          setSurfaceToPTI(wlr_surface* pSurface, STextInput* pInput);
+    STextInput*                                   getTextInput(wlr_surface* pSurface);
+    void                                          removeSurfaceToPTI(STextInput* pInput);
 
-    std::unordered_map<wl_client*, int> m_mClientTextInputVersion;
-    int setTextInputVersion(wl_client* pClient, int version);
-    int getTextInputVersion(wl_client* pClient);
-    void removeTextInputVersion(wl_client* pClient);
-
-
-
-
+    std::unordered_map<wl_client*, int>           m_mClientTextInputVersion;
+    int                                           setTextInputVersion(wl_client* pClient, int version);
+    int                                           getTextInputVersion(wl_client* pClient);
+    void                                          removeTextInputVersion(wl_client* pClient);
 
     friend class CHyprRenderer;
     friend class CInputManager;

--- a/src/managers/input/InputMethodRelay.hpp
+++ b/src/managers/input/InputMethodRelay.hpp
@@ -22,9 +22,7 @@ class CInputMethodRelay {
     void                 onKeyboardFocus(wlr_surface*);
 
     STextInput*          getFocusedTextInput();
-    STextInput*          getFocusableTextInput();
 
-    void                 setPendingSurface(STextInput*, wlr_surface*);
 
     SIMEKbGrab*          getIMEKeyboardGrab(SKeyboard*);
 
@@ -46,7 +44,25 @@ class CInputMethodRelay {
     DYNLISTENER(IMENewPopup);
 
     void         createNewTextInput(wlr_text_input_v3*, STextInputV1* tiv1 = nullptr);
+
     wlr_surface* focusedSurface(STextInput* pInput);
+    wlr_surface* m_pFocusedSurface;
+    void onTextInputLeave(wlr_surface* pSurface);
+    void onTextInputEnter(wlr_surface* pSurface);
+
+    std::unordered_map<wlr_surface*, STextInput*> m_mSurfaceToTextInput;
+    void setSurfaceToPTI(wlr_surface* pSurface,STextInput* pInput);
+    STextInput* getTextInput(wlr_surface* pSurface);
+    void removeSurfaceToPTI(STextInput* pInput);
+
+    std::unordered_map<wl_client*, int> m_mClientTextInputVersion;
+    int setTextInputVersion(wl_client* pClient, int version);
+    int getTextInputVersion(wl_client* pClient);
+    void removeTextInputVersion(wl_client* pClient);
+
+
+
+
 
     friend class CHyprRenderer;
     friend class CInputManager;

--- a/src/protocols/TextInputV1.cpp
+++ b/src/protocols/TextInputV1.cpp
@@ -113,8 +113,6 @@ void CTextInputV1ProtocolManager::removeTI(STextInputV1* pTI) {
     // if ((*TI)->resourceImpl)
     //  wl_resource_destroy((*TI)->resourceImpl);
 
-    g_pInputManager->m_sIMERelay.removeTextInput((*TI)->pTextInput);
-
     std::erase_if(m_pClients, [&](const auto& other) { return other.get() == pTI; });
 }
 
@@ -165,7 +163,11 @@ void CTextInputV1ProtocolManager::createTI(wl_client* client, wl_resource* resou
 
 void CTextInputV1ProtocolManager::handleActivate(wl_client* client, wl_resource* resource, wl_resource* seat, wl_resource* surface) {
     const auto PTI = tiFromResource(resource);
-    PTI->pTextInput->hyprListener_textInputEnable.emit(nullptr);
+    if(!surface){
+        Debug::log(WARN, "Text-input-v1 PTI{:x}: No surface to activate text input on!", (uintptr_t)PTI);
+        return;
+    }
+    PTI->pTextInput->hyprListener_textInputEnable.emit(surface);
 }
 
 void CTextInputV1ProtocolManager::handleDeactivate(wl_client* client, wl_resource* resource, wl_resource* seat) {

--- a/src/protocols/TextInputV1.cpp
+++ b/src/protocols/TextInputV1.cpp
@@ -163,7 +163,7 @@ void CTextInputV1ProtocolManager::createTI(wl_client* client, wl_resource* resou
 
 void CTextInputV1ProtocolManager::handleActivate(wl_client* client, wl_resource* resource, wl_resource* seat, wl_resource* surface) {
     const auto PTI = tiFromResource(resource);
-    if(!surface){
+    if (!surface) {
         Debug::log(WARN, "Text-input-v1 PTI{:x}: No surface to activate text input on!", (uintptr_t)PTI);
         return;
     }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This PR addresses the issue where the text-input-v1 protocol could not handle cases where a client creates multiple `TextInput`.

The case one client creates multiple `TextInput` is common. e.g. chromium-based client applications create a `TextInput` for each separate surface. They then send `activate` request with `surface` param which indirectly specifies the `TextInput`. Because every `TextInput` object is bind to specific `surface`. 

Previously, the code iterated through a linked list and returned upon finding a match by comparing the current focus surface's client with `TextInput`'s client. This approach always returned the first matched  `TextInput`, whose internal surface pointed to a different surface rather than the current focus surface. This was the root cause of issue #2708.

Moreover, the original code heavily relied on iterating through linked list is not so efficient comparing to a hash lookup way. Therefore, in the  `InputMethodRelay`, a map from `surface -> TextInput `has been established, centered around the `surface.` The `InputMethodRelay` now records the current focus `surface`, enabling the retrieval of `TextInput` based on the surface. Consequently, the logic for `pendingSurface` in the original code has been removed, as the `TextInput` can now be obtained at any time through the focused surface.

About issue #2708 mentioned 

> Similar to the behavior of versions below electron21 mentioned at [[WIP\] text-input-v1 support #1778](https://github.com/hyprwm/Hyprland/pull/1778) .

yeah it's the same problem. It seems that electron below electron 21 will create a transparent surface. So in former implementation, we always caught that transparent surface's `TextInput`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Firstly, I rarely write C++, so there might be some naive mistakes.  Please forgive me ~. Though this patch has been running on my main computer for two days without any issues.  

Secondly, there's a comment in the `InputMethodRelay.cpp` code marked "BUG POSSIBLE". This is because the logic for handling  surfaces in `text-input-v3` is quite different from `v1`. It requires the  server to proactively inform the client. Apart from using the client for matching, I can't think of a better method. However, using the client  for matching is the original code's method, so the issue mentioned for text-input-v3 still persists. But as far as the user experience with Kitty is concerned, there doesn't seem to be any major problem.


#### Is it ready for merging, or does it need work?

yeah


https://github.com/hyprwm/Hyprland/assets/54235339/856e0aad-3299-4c53-8926-ccb83b3fd36a

