### PR TITLE
github: remove redundant instruction

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -13,7 +13,7 @@ body:
     id: ver
     attributes:
       label: Hyprland Version
-      description: "Paste here the output of `hyprctl version`. For hyprland after 0.34.0, paste `hyprctl systeminfo` instead."
+      description: "Paste the output of `hyprctl systeminfo` here."
       value: "<details>
         <summary>System/Version info</summary>
 


### PR DESCRIPTION
v0.34.0 is pretty old at this point.


