### PR TITLE
Fix infinite loop in workspace selector caused by integer overflow 💀

### DIFF
--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -218,7 +218,7 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
 
             const auto  NEXTSPACE = selector.find_first_of(' ', i);
             std::string prop      = selector.substr(i, NEXTSPACE == std::string::npos ? std::string::npos : NEXTSPACE - i);
-            i                     = NEXTSPACE;
+            i                     = std::min(NEXTSPACE, std::string::npos - 1);
 
             if (cur == 'r') {
                 int from = 0, to = 0;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fix infinite loop in workspace selector caused by integer overflow 💀

When `NEXTSPACE == npos`, `i++` at the end of the loop turns i into 0 again 💀

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?


