### PR TITLE
Add left_handed option for tablets

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -476,6 +476,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("input:tablet:region_position", Hyprlang::VEC2{0, 0});
     m_pConfig->addConfigValue("input:tablet:region_size", Hyprlang::VEC2{0, 0});
     m_pConfig->addConfigValue("input:tablet:relative_input", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("input:tablet:left_handed", Hyprlang::INT{0});
 
     m_pConfig->addConfigValue("binds:pass_mouse_when_bound", Hyprlang::INT{0});
     m_pConfig->addConfigValue("binds:scroll_event_delay", Hyprlang::INT{300});

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1418,7 +1418,7 @@ void CInputManager::setTabletConfigs() {
             Debug::log(LOG, "Setting calibration matrix for device {}", t.name);
             libinput_device_config_calibration_set_matrix(LIBINPUTDEV, MATRICES[ROTATION]);
 
-            if (g_pConfigManager->getDeviceInt(t.name, "left_handed", "input:left_handed") == 0)
+            if (g_pConfigManager->getDeviceInt(t.name, "left_handed", "input:tablet:left_handed") == 0)
                 libinput_device_config_left_handed_set(LIBINPUTDEV, 0);
             else
                 libinput_device_config_left_handed_set(LIBINPUTDEV, 1);

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1418,6 +1418,11 @@ void CInputManager::setTabletConfigs() {
             Debug::log(LOG, "Setting calibration matrix for device {}", t.name);
             libinput_device_config_calibration_set_matrix(LIBINPUTDEV, MATRICES[ROTATION]);
 
+            if (g_pConfigManager->getDeviceInt(t.name, "left_handed", "input:left_handed") == 0)
+                libinput_device_config_left_handed_set(LIBINPUTDEV, 0);
+            else
+                libinput_device_config_left_handed_set(LIBINPUTDEV, 1);
+
             const auto OUTPUT   = g_pConfigManager->getDeviceString(t.name, "output", "input:tablet:output");
             const auto PMONITOR = g_pCompositor->getMonitorFromString(OUTPUT);
             if (!OUTPUT.empty() && OUTPUT != STRVAL_EMPTY && PMONITOR) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adding `left_handed` option for tablets allow them to be rotated 180 degrees.
I've had issues with using transform with my tablet, and `libinput_device_config_left_handed_set` was missing.
Adding this options fixed the rotation issue I had. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
Yes.

