### PR TITLE
fixing gentoo ebuild due to lack of precompiled headrs in build env

### DIFF
--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -4,6 +4,7 @@
 #include <any>
 
 class CWindow;
+class CGradientValueData;
 
 struct SWindowRenderLayoutHints {
     bool                isBorderGradient = false;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Gentoo ebuild was failing due to lack of precompiled headers in build env 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?

Ready for merge
