### PR TITLE
Add options to set tablet's active area

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -477,6 +477,8 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("input:tablet:region_size", Hyprlang::VEC2{0, 0});
     m_pConfig->addConfigValue("input:tablet:relative_input", Hyprlang::INT{0});
     m_pConfig->addConfigValue("input:tablet:left_handed", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("input:tablet:active_area_position", Hyprlang::VEC2{0, 0});
+    m_pConfig->addConfigValue("input:tablet:active_area_size", Hyprlang::VEC2{0, 0});
 
     m_pConfig->addConfigValue("binds:pass_mouse_when_bound", Hyprlang::INT{0});
     m_pConfig->addConfigValue("binds:scroll_event_delay", Hyprlang::INT{300});
@@ -557,6 +559,8 @@ CConfigManager::CConfigManager() {
     m_pConfig->addSpecialConfigValue("device", "region_position", Hyprlang::VEC2{0, 0}); // only for tablets
     m_pConfig->addSpecialConfigValue("device", "region_size", Hyprlang::VEC2{0, 0});     // only for tablets
     m_pConfig->addSpecialConfigValue("device", "relative_input", Hyprlang::INT{0});      // only for tablets
+    m_pConfig->addSpecialConfigValue("device", "active_area_position", Hyprlang::VEC2{0, 0}); // only for tablets
+    m_pConfig->addSpecialConfigValue("device", "active_area_size", Hyprlang::VEC2{0, 0});     // only for tablets
 
     // keywords
     m_pConfig->registerHandler(&::handleRawExec, "exec", {false});

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -555,10 +555,10 @@ CConfigManager::CConfigManager() {
     m_pConfig->addSpecialConfigValue("device", "scroll_points", {STRVAL_EMPTY});
     m_pConfig->addSpecialConfigValue("device", "transform", Hyprlang::INT{0});
     m_pConfig->addSpecialConfigValue("device", "output", {STRVAL_EMPTY});
-    m_pConfig->addSpecialConfigValue("device", "enabled", Hyprlang::INT{1});             // only for mice, touchpads, and touchdevices
-    m_pConfig->addSpecialConfigValue("device", "region_position", Hyprlang::VEC2{0, 0}); // only for tablets
-    m_pConfig->addSpecialConfigValue("device", "region_size", Hyprlang::VEC2{0, 0});     // only for tablets
-    m_pConfig->addSpecialConfigValue("device", "relative_input", Hyprlang::INT{0});      // only for tablets
+    m_pConfig->addSpecialConfigValue("device", "enabled", Hyprlang::INT{1});                  // only for mice, touchpads, and touchdevices
+    m_pConfig->addSpecialConfigValue("device", "region_position", Hyprlang::VEC2{0, 0});      // only for tablets
+    m_pConfig->addSpecialConfigValue("device", "region_size", Hyprlang::VEC2{0, 0});          // only for tablets
+    m_pConfig->addSpecialConfigValue("device", "relative_input", Hyprlang::INT{0});           // only for tablets
     m_pConfig->addSpecialConfigValue("device", "active_area_position", Hyprlang::VEC2{0, 0}); // only for tablets
     m_pConfig->addSpecialConfigValue("device", "active_area_size", Hyprlang::VEC2{0, 0});     // only for tablets
 

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -633,7 +633,7 @@ std::string devicesRequest(eHyprCtlOutputFormat format, std::string request) {
         }
 
         for (auto& d : g_pInputManager->m_lTablets) {
-            result += std::format("\tTablet at {:x}:\n\t\t{}\n", (uintptr_t)&d, d.name);
+            result += std::format("\tTablet at {:x}:\n\t\t{}\n\t\t\tsize: {}x{}mm\n", (uintptr_t)&d, d.name, d.wlrTablet->width_mm, d.wlrTablet->height_mm);
         }
 
         for (auto& d : g_pInputManager->m_lTabletTools) {

--- a/src/helpers/WLClasses.hpp
+++ b/src/helpers/WLClasses.hpp
@@ -217,6 +217,8 @@ struct STablet {
 
     std::string           boundOutput = "";
 
+    CBox                  activeArea;
+
     //
     bool operator==(const STablet& b) const {
         return wlrDevice == b.wlrDevice;

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1438,6 +1438,13 @@ void CInputManager::setTabletConfigs() {
             auto       regionBox   = CBox{REGION_POS.x, REGION_POS.y, REGION_SIZE.x, REGION_SIZE.y};
             if (!regionBox.empty())
                 wlr_cursor_map_input_to_region(g_pCompositor->m_sWLRCursor, t.wlrDevice, regionBox.pWlr());
+
+            const auto ACTIVE_AREA_SIZE = g_pConfigManager->getDeviceVec(t.name, "active_area_size", "input:tablet:active_area_size");
+            const auto ACTIVE_AREA_POS  = g_pConfigManager->getDeviceVec(t.name, "active_area_position", "input:tablet:active_area_position");
+            if (ACTIVE_AREA_SIZE.x != 0 || ACTIVE_AREA_SIZE.y != 0) {
+                t.activeArea = CBox{ACTIVE_AREA_POS.x / t.wlrTablet->width_mm, ACTIVE_AREA_POS.y / t.wlrTablet->height_mm,
+                                    (ACTIVE_AREA_POS.x + ACTIVE_AREA_SIZE.x) / t.wlrTablet->width_mm, (ACTIVE_AREA_POS.y + ACTIVE_AREA_SIZE.y) / t.wlrTablet->height_mm};
+            }
         }
     }
 }

--- a/src/managers/input/Tablets.cpp
+++ b/src/managers/input/Tablets.cpp
@@ -36,12 +36,6 @@ void CInputManager::newTabletTool(wlr_input_device* pDevice) {
             const auto EVENT = (wlr_tablet_tool_axis_event*)data;
             const auto PTAB  = (STablet*)owner;
 
-            // Get tablet active area in mm and calculate bounds
-            const auto ACTIVE_AREA_SIZE = g_pConfigManager->getDeviceVec(PTAB->name, "active_area_size", "input:tablet:active_area_size");
-            const auto ACTIVE_AREA_POS = g_pConfigManager->getDeviceVec(PTAB->name, "active_area_position", "input:tablet:active_area_position");
-            const auto MIN_BOUNDS = Vector2D { ACTIVE_AREA_POS.x / PTAB->wlrTablet->width_mm, ACTIVE_AREA_POS.y / PTAB->wlrTablet->height_mm };
-            const auto MAX_BOUNDS = Vector2D { ( ACTIVE_AREA_POS.x + ACTIVE_AREA_SIZE.x ) / PTAB->wlrTablet->width_mm, ( ACTIVE_AREA_POS.y + ACTIVE_AREA_SIZE.y ) / PTAB->wlrTablet->height_mm };
-
             switch (EVENT->tool->type) {
                 case WLR_TABLET_TOOL_TYPE_MOUSE:
                     wlr_cursor_move(g_pCompositor->m_sWLRCursor, PTAB->wlrDevice, EVENT->dx, EVENT->dy);
@@ -57,12 +51,11 @@ void CInputManager::newTabletTool(wlr_input_device* pDevice) {
 
                     if (PTAB->relativeInput)
                         wlr_cursor_move(g_pCompositor->m_sWLRCursor, PTAB->wlrDevice, dx, dy);
-                    else
-                    {
-                        // Calculate transformations if upper bounds are set
-                        if(MAX_BOUNDS.x != 0 || MAX_BOUNDS.y != 0) {
-                            x = (x - MIN_BOUNDS.x) / (MAX_BOUNDS.x - MIN_BOUNDS.x);
-                            y = (y - MIN_BOUNDS.y) / (MAX_BOUNDS.y - MIN_BOUNDS.y);
+                    else {
+                        // Calculate transformations if active area is set
+                        if (!PTAB->activeArea.empty()) {
+                            x = (x - PTAB->activeArea.x) / (PTAB->activeArea.w - PTAB->activeArea.x);
+                            y = (y - PTAB->activeArea.y) / (PTAB->activeArea.h - PTAB->activeArea.y);
                         }
                         wlr_cursor_warp_absolute(g_pCompositor->m_sWLRCursor, PTAB->wlrDevice, x, y);
                     }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adding options to set the active\usable drawing area of graphics tablets. It's useful when you need to match the aspect ratio of the monitor to the drawing area.

`active_area_size` and `active_area_position` are in mm to match the reported drawing dimensions in `wlr_tablet`. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
Not yet. Better name for options? Also, `hyprctl devices` could report the tablet's size in mm.  `libinput list-devices` can report that for the time being.

