### PR TITLE
windowrules: Fix resizeparams parsing.

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2542,7 +2542,7 @@ Vector2D CCompositor::parseWindowVectorArgsRelative(const std::string& args, con
     bool        isExact    = false;
 
     std::string x = args.substr(0, args.find_first_of(' '));
-    std::string y = args.substr(args.find_first_of(' ') + 1);
+    std::string y = args.substr(args.find_last_of(' ') + 1);
 
     if (x == "exact") {
         x       = y.substr(0, y.find_first_of(' '));


### PR DESCRIPTION


#### Describe your PR, what does it fix/add?

Parsing of resizeparams/relative vec2 did not correctly handle multiple spaces between x and y arguments, causing the following to fail to parse:


```conf
bind = $mainMod CTRL, h, resizeactive,  10       0
```

This is unexpected, because most other config values are whitespace insensitive.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

/

#### Is it ready for merging, or does it need work?

Ready to merge.

