### PR TITLE
hyprpm: add missing newline

### DIFF
--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -56,7 +56,7 @@ int               main(int argc, char** argv, char** envp) {
                 force = true;
                 std::cout << Colors::RED << "!" << Colors::RESET << " Using --force, I hope you know what you are doing.\n";
             } else {
-                std::cerr << "Unrecognized option " << ARGS[i];
+                std::cerr << "Unrecognized option " << ARGS[i] << "\n";
                 return 1;
             }
         } else {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
There was no newline at the end of `hyprpm`'s Unrecognized option. This PR fixes it.  
![image](https://github.com/hyprwm/Hyprland/assets/49565677/a071f072-5292-411a-bce2-96433954f78c)


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
None

#### Is it ready for merging, or does it need work?
Ready to merge

