### PR TITLE
hyprctl: add missing commands to usage

### DIFF
--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -30,6 +30,7 @@ commands:
     activeworkspace
     binds
     clients
+    configerrors
     cursorpos
     decorations
     devices
@@ -45,8 +46,10 @@ commands:
     layouts
     monitors
     notify
+    output
     plugin
     reload
+    rollinglog
     setcursor
     seterror
     setprop


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Add missing commands to the help text for `hyprctl`, as I confused after update by trying to find new config errors command in it, but apparently there are several of them missing.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No, just a string changed

#### Is it ready for merging, or does it need work?
ugh, maybe `rollinglog` is intentionally hidden, because it's not even mentioned in wiki, dunno.

