### PR TITLE
fix: release all mouse buttons before focus on new surface

### DIFF
--- a/src/events/Layers.cpp
+++ b/src/events/Layers.cpp
@@ -148,6 +148,7 @@ void Events::listener_mapLayerSurface(void* owner, void* data) {
         (!g_pCompositor->m_sSeat.mouse || !g_pInputManager->isConstrained());
 
     if (GRABSFOCUS) {
+        g_pInputManager->releaseAllMouseButtons();
         g_pCompositor->focusSurface(layersurface->layerSurface->surface);
 
         const auto LOCAL =


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
I'm using waybar with a custom module for swaync, and is configured with a on click event that it should toggle the notification center. When I click the swaync module, it will open the notification center but it causes weird behavior. The issue arises because, when the compositor create a new layer surface (in this case, the notification center), its surface gains focus, which results in waybar being unable to detect the mouse click release. This leads to undesired behaviors, such as the bar not responding as expected, like reopening the notification center when clicking somewhere else.
So a potential solution is to notify the release of all mouse button before focusing in another new surface.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
#1348 https://github.com/Alexays/Waybar/issues/2473 https://github.com/ErikReider/SwayNotificationCenter/issues/292 https://github.com/Alexays/Waybar/issues/2166

#### Is it ready for merging, or does it need work?
Yes

