### PR TITLE
CGradientValueData: fix toString() method

### DIFF
--- a/src/config/ConfigDataValues.hpp
+++ b/src/config/ConfigDataValues.hpp
@@ -61,6 +61,7 @@ class CGradientValueData : public ICustomConfigValueData {
         }
 
         result += std::format("{}deg", (int)(m_fAngle * 180.0 / M_PI));
+        return result;
     }
 };
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
It fixes a compiler warning that I've got when compiling an external plugin:

```
[ 28%] Building CXX object CMakeFiles/hy3.dir/src/SelectionHook.cpp.o
[ 28%] Building CXX object CMakeFiles/hy3.dir/src/TabGroup.cpp.o
In file included from /usr/local/stow/hyprland/include/hyprland/src/Window.hpp:8,
                 from /home/holger/src/hypr/hy3/src/Hy3Node.hpp:9,
                 from /home/holger/src/hypr/hy3/src/TabGroup.hpp:13,
                 from /home/holger/src/hypr/hy3/src/TabGroup.cpp:1:
/usr/local/stow/hyprland/include/hyprland/src/config/ConfigDataValues.hpp: In member function virtual std::string CGradientValueData::toString()’:
/usr/local/stow/hyprland/include/hyprland/src/config/ConfigDataValues.hpp:64:5: warning: no return statement in function returning non-void [-Wreturn-type]
   64 |     }
```

Clearly the `toString()` method computed a `result` but didn't return it.

#### Is it ready for merging, or does it need work?
Hyprland compiles for me with that change, so it should be okay for merging.

