### PR TITLE
input: fix crash with text-input-v1

### DIFF
--- a/src/managers/input/TextInput.cpp
+++ b/src/managers/input/TextInput.cpp
@@ -71,9 +71,10 @@ void CTextInput::onEnabled(wlr_surface* surfV1) {
     // v1 only, map surface to PTI
     if (!isV3()) {
         wlr_surface* pSurface = surfV1;
-        setFocusedSurface(pSurface);
         if (g_pCompositor->m_pLastFocus == pSurface)
             enter(pSurface);
+        else
+            setFocusedSurface(pSurface);
     }
 
     wlr_input_method_v2_send_activate(g_pInputManager->m_sIMERelay.m_pWLRIME);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes a crash when you leave a layer with text-input-v1.

At `onEnabled()`, `focusedSurface` is set to `pSurface`. At the subsequent `enter()`, it checks if the `focusedSurface` is equal to `pSurface` (which will be true because it was just set). This makes the `enterLocks` to be not incremented and when it tries to leave, `enterLock--;` will be ran and the value becomes -1. After that the assertion `RASSERT(enterLocks == 0, "TextInput had != 0 locks in leave");` in `leave()` will fail.

#5231 might be related but I'm not sure because this PR is about leaving the input but #5231 is about entering the input.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?

Ready