### PR TITLE
Move exit trigger to monitor frame

### DIFF
--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -118,6 +118,7 @@ class CCompositor {
     bool                                      m_bUnsafeState    = false;   // unsafe state is when there is no monitors.
     bool                                      m_bNextIsUnsafe   = false;   // because wlroots
     CMonitor*                                 m_pUnsafeOutput   = nullptr; // fallback output for the unsafe state
+    bool                                      m_bExitTriggered = false;    // For exit dispatcher
     bool                                      m_bIsShuttingDown = false;
 
     // ------------------------------------------------- //

--- a/src/events/Monitors.cpp
+++ b/src/events/Monitors.cpp
@@ -117,6 +117,13 @@ void Events::listener_newOutput(wl_listener* listener, void* data) {
 }
 
 void Events::listener_monitorFrame(void* owner, void* data) {
+    if (g_pCompositor->m_bExitTriggered) {
+        // Only signal cleanup once
+        g_pCompositor->m_bExitTriggered = false;
+        g_pCompositor->cleanup();
+        return;
+    }
+
     CMonitor* const PMONITOR = (CMonitor*)owner;
 
     if ((g_pCompositor->m_sWLRSession && !g_pCompositor->m_sWLRSession->active) || !g_pCompositor->m_bSessionActive || g_pCompositor->m_bUnsafeState) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1512,7 +1512,7 @@ void CKeybindManager::renameWorkspace(std::string args) {
 }
 
 void CKeybindManager::exitHyprland(std::string argz) {
-    g_pInputManager->m_bExitTriggered = true;
+    g_pCompositor->m_bExitTriggered = true;
 }
 
 void CKeybindManager::moveCurrentWorkspaceToMonitor(std::string args) {

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1189,9 +1189,6 @@ void CInputManager::onKeyboardKey(wlr_keyboard_key_event* e, SKeyboard* pKeyboar
 
         updateKeyboardsLeds(pKeyboard->keyboard);
     }
-
-    if (m_bExitTriggered)
-        g_pCompositor->cleanup();
 }
 
 void CInputManager::onKeyboardMod(void* data, SKeyboard* pKeyboard) {

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -251,8 +251,6 @@ class CInputManager {
 
     void restoreCursorIconToApp(); // no-op if restored
 
-    bool m_bExitTriggered = false; // for exit dispatcher
-
     friend class CKeybindManager;
     friend class CWLSurface;
 };


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This is a fix for #4599 .  It works by moving the exit checking logic to the monitor frame event listener.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Because there can be multiple monitors, the first monitor to have a frame event resets the trigger.

#### Is it ready for merging, or does it need work?
It works, and is tested on my machine.

