### PR TITLE
Send workspace events during swapActiveWorkspaces and focusWorkspaceOnCurrentMonitor (when swapping)

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2053,6 +2053,11 @@ void CCompositor::swapActiveWorkspaces(CMonitor* pMonitorA, CMonitor* pMonitorB)
         const auto LASTWIN = pMonitorA->ID == g_pCompositor->m_pLastMonitor->ID ? PWORKSPACEB->getLastFocusedWindow() : PWORKSPACEA->getLastFocusedWindow();
         g_pCompositor->focusWindow(LASTWIN ? LASTWIN :
                                              (g_pCompositor->vectorToWindowUnified(g_pInputManager->getMouseCoordsInternal(), RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING)));
+
+        const auto PNEWWORKSPACE = pMonitorA->ID == g_pCompositor->m_pLastMonitor->ID ? PWORKSPACEB : PWORKSPACEA;
+        g_pEventManager->postEvent(SHyprIPCEvent{"workspace", PNEWWORKSPACE->m_szName});
+        g_pEventManager->postEvent(SHyprIPCEvent{"workspacev2", std::format("{},{}", PNEWWORKSPACE->m_iID, PNEWWORKSPACE->m_szName)});
+        EMIT_HOOK_EVENT("workspace", PNEWWORKSPACE);
     }
 
     // event


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
When swapping active workspaces, it should send an event because it's focusing on the new workspace that gets swapped in.
Since swapping is also called in focusWorkspaceOnCurrentMonitor, this should also fix the issue that the workspace event is not sent sometimes when focusWorkspaceOnCurrentMonitor is called.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Not really. Just events anyway doesnt change any behavior

#### Is it ready for merging, or does it need work?
Probably ready

