### PR TITLE
Update hyprctl to output json with `--batch`

### DIFF
--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -22,6 +22,7 @@
 #include <deque>
 #include <filesystem>
 #include <stdarg.h>
+#include <regex>
 
 const std::string USAGE = R"#(usage: hyprctl [(opt)flags] [command] [(opt)args]
 
@@ -234,9 +235,14 @@ void requestHyprpaper(std::string arg) {
     std::cout << std::string(buffer);
 }
 
-void batchRequest(std::string arg) {
-    std::string rq = "[[BATCH]]" + arg.substr(arg.find_first_of(" ") + 1);
+void batchRequest(std::string arg, bool json) {
+    std::string commands = arg.substr(arg.find_first_of(" ") + 1);
 
+    if (json) {
+        commands = "j/" + std::regex_replace(commands, std::regex(";\\s*"), ";j/");
+    }
+
+    std::string rq = "[[BATCH]]" + commands;
     request(rq);
 }
 
@@ -383,7 +389,7 @@ int main(int argc, char** argv) {
     int exitStatus = 0;
 
     if (fullRequest.contains("/--batch"))
-        batchRequest(fullRequest);
+        batchRequest(fullRequest, json);
     else if (fullRequest.contains("/hyprpaper"))
         requestHyprpaper(fullRequest);
     else if (fullRequest.contains("/switchxkblayout"))


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Using `-j` now along with `--batch` would output JSON as expected.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Not sure if using regex is overkill for this but it looks neat this way and saves the headache of dealing with mixed whitespace after semicolons like this `"command; command;command;  command"` (if somebody decided to write commands this way).

#### Is it ready for merging, or does it need work?
I guess?

