### PR TITLE
fix fullscreen + floating on monitor focus change

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1568,7 +1568,7 @@ CWindow* CCompositor::getWindowInDirection(CWindow* pWindow, char dir) {
 
         // for tiled windows, we calc edges
         for (auto& w : m_vWindows) {
-            if (w.get() == pWindow || !w->m_bIsMapped || w->isHidden() || w->m_bIsFloating || !isWorkspaceVisible(w->m_iWorkspaceID))
+            if (w.get() == pWindow || !w->m_bIsMapped || w->isHidden() || (!w->m_bIsFullscreen && w->m_bIsFloating) || !isWorkspaceVisible(w->m_iWorkspaceID))
                 continue;
 
             if (pWindow->m_iMonitorID == w->m_iMonitorID && pWindow->m_iWorkspaceID != w->m_iWorkspaceID)
@@ -1657,7 +1657,7 @@ CWindow* CCompositor::getWindowInDirection(CWindow* pWindow, char dir) {
         constexpr float THRESHOLD    = 0.3 * M_PI;
 
         for (auto& w : m_vWindows) {
-            if (w.get() == pWindow || !w->m_bIsMapped || w->isHidden() || !w->m_bIsFloating || !isWorkspaceVisible(w->m_iWorkspaceID))
+            if (w.get() == pWindow || !w->m_bIsMapped || w->isHidden() || (!w->m_bIsFullscreen && !w->m_bIsFloating) || !isWorkspaceVisible(w->m_iWorkspaceID))
                 continue;
 
             if (pWindow->m_iMonitorID == w->m_iMonitorID && pWindow->m_iWorkspaceID != w->m_iWorkspaceID)


### PR DESCRIPTION
doesn't reject floating windows if they're also fullscreened in `CCompositor::getWindowInDirection()` (also opposite case)

shouldn't cause issues