### PR TITLE
Fix various inaccurate damage tracking issues and some incorrect offset issues

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1152,6 +1152,35 @@ void CWindow::setAnimationsToMove() {
     m_bAnimatingIn = false;
 }
 
+void CWindow::onWorkspaceAnimUpdate() {
+    const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(m_iWorkspaceID);
+    // clip box for animated offsets
+    Vector2D offset;
+    if (PWORKSPACE->m_vRenderOffset.value().x != 0) {
+        const auto PWSMON   = g_pCompositor->getMonitorFromID(PWORKSPACE->m_iMonitorID);
+        const auto PROGRESS = PWORKSPACE->m_vRenderOffset.value().x / PWSMON->vecSize.x;
+        const auto WINBB    = getFullWindowBoundingBox();
+
+        if (WINBB.x < PWSMON->vecPosition.x) {
+            offset.x = (PWSMON->vecPosition.x - WINBB.x) * PROGRESS;
+        } else if (WINBB.x + WINBB.width > PWSMON->vecPosition.x + PWSMON->vecSize.x) {
+            offset.x = (WINBB.x + WINBB.width - PWSMON->vecPosition.x - PWSMON->vecSize.x) * PROGRESS;
+        }
+    } else if (PWORKSPACE->m_vRenderOffset.value().y != 0) {
+        const auto PWSMON   = g_pCompositor->getMonitorFromID(PWORKSPACE->m_iMonitorID);
+        const auto PROGRESS = PWORKSPACE->m_vRenderOffset.value().y / PWSMON->vecSize.y;
+        const auto WINBB    = getFullWindowBoundingBox();
+
+        if (WINBB.y < PWSMON->vecPosition.y) {
+            offset.y = (PWSMON->vecPosition.y - WINBB.y) * PROGRESS;
+        } else if (WINBB.y + WINBB.height > PWSMON->vecPosition.y + PWSMON->vecSize.y) {
+            offset.y = (WINBB.y + WINBB.height - PWSMON->vecPosition.y - PWSMON->vecSize.y) * PROGRESS;
+        }
+    }
+
+    m_vFloatingOffset = offset;
+}
+
 int CWindow::popupsCount() {
     if (m_bIsX11)
         return 1;

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1154,6 +1154,11 @@ void CWindow::setAnimationsToMove() {
 
 void CWindow::onWorkspaceAnimUpdate() {
     // clip box for animated offsets
+    if (!m_bIsFloating || m_bPinned || m_bIsFullscreen) {
+        m_vFloatingOffset = Vector2D(0, 0);
+        return;
+    }
+
     Vector2D   offset;
     const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(m_iWorkspaceID);
     if (!PWORKSPACE)

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1153,29 +1153,27 @@ void CWindow::setAnimationsToMove() {
 }
 
 void CWindow::onWorkspaceAnimUpdate() {
-    const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(m_iWorkspaceID);
     // clip box for animated offsets
-    Vector2D offset;
+    Vector2D   offset;
+    const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(m_iWorkspaceID);
+    const auto PWSMON     = g_pCompositor->getMonitorFromID(PWORKSPACE->m_iMonitorID);
+    const auto WINBB      = getFullWindowBoundingBox();
     if (PWORKSPACE->m_vRenderOffset.value().x != 0) {
-        const auto PWSMON   = g_pCompositor->getMonitorFromID(PWORKSPACE->m_iMonitorID);
         const auto PROGRESS = PWORKSPACE->m_vRenderOffset.value().x / PWSMON->vecSize.x;
-        const auto WINBB    = getFullWindowBoundingBox();
 
-        if (WINBB.x < PWSMON->vecPosition.x) {
-            offset.x = (PWSMON->vecPosition.x - WINBB.x) * PROGRESS;
-        } else if (WINBB.x + WINBB.width > PWSMON->vecPosition.x + PWSMON->vecSize.x) {
-            offset.x = (WINBB.x + WINBB.width - PWSMON->vecPosition.x - PWSMON->vecSize.x) * PROGRESS;
-        }
+        if (WINBB.x < PWSMON->vecPosition.x)
+            offset.x += (PWSMON->vecPosition.x - WINBB.x) * PROGRESS;
+
+        if (WINBB.x + WINBB.width > PWSMON->vecPosition.x + PWSMON->vecSize.x)
+            offset.x += (WINBB.x + WINBB.width - PWSMON->vecPosition.x - PWSMON->vecSize.x) * PROGRESS;
     } else if (PWORKSPACE->m_vRenderOffset.value().y != 0) {
-        const auto PWSMON   = g_pCompositor->getMonitorFromID(PWORKSPACE->m_iMonitorID);
         const auto PROGRESS = PWORKSPACE->m_vRenderOffset.value().y / PWSMON->vecSize.y;
-        const auto WINBB    = getFullWindowBoundingBox();
 
-        if (WINBB.y < PWSMON->vecPosition.y) {
-            offset.y = (PWSMON->vecPosition.y - WINBB.y) * PROGRESS;
-        } else if (WINBB.y + WINBB.height > PWSMON->vecPosition.y + PWSMON->vecSize.y) {
-            offset.y = (WINBB.y + WINBB.height - PWSMON->vecPosition.y - PWSMON->vecSize.y) * PROGRESS;
-        }
+        if (WINBB.y < PWSMON->vecPosition.y)
+            offset.y += (PWSMON->vecPosition.y - WINBB.y) * PROGRESS;
+
+        if (WINBB.y + WINBB.height > PWSMON->vecPosition.y + PWSMON->vecSize.y)
+            offset.y += (WINBB.y + WINBB.height - PWSMON->vecPosition.y - PWSMON->vecSize.y) * PROGRESS;
     }
 
     m_vFloatingOffset = offset;

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1156,8 +1156,14 @@ void CWindow::onWorkspaceAnimUpdate() {
     // clip box for animated offsets
     Vector2D   offset;
     const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(m_iWorkspaceID);
-    const auto PWSMON     = g_pCompositor->getMonitorFromID(PWORKSPACE->m_iMonitorID);
-    const auto WINBB      = getFullWindowBoundingBox();
+    if (!PWORKSPACE)
+        return;
+
+    const auto PWSMON = g_pCompositor->getMonitorFromID(PWORKSPACE->m_iMonitorID);
+    if (!PWSMON)
+        return;
+
+    const auto WINBB = getFullWindowBoundingBox();
     if (PWORKSPACE->m_vRenderOffset.value().x != 0) {
         const auto PROGRESS = PWORKSPACE->m_vRenderOffset.value().x / PWSMON->vecSize.x;
 

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -237,6 +237,9 @@ class CWindow {
     Vector2D m_vLastFloatingSize;
     Vector2D m_vLastFloatingPosition;
 
+    // for floating window offset in workspace animations
+    Vector2D m_vFloatingOffset = Vector2D(0, 0);
+
     // this is used for pseudotiling
     bool        m_bIsPseudotiled = false;
     Vector2D    m_vPseudoSize    = Vector2D(0, 0);

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -424,6 +424,7 @@ class CWindow {
     void                     updateGroupOutputs();
     void                     switchWithWindowInGroup(CWindow* pWindow);
     void                     setAnimationsToMove();
+    void                     onWorkspaceAnimUpdate();
 
   private:
     // For hidden windows and stuff

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -48,15 +48,14 @@ void CWorkspace::startAnim(bool in, bool left, bool instant) {
     static auto PWORKSPACEGAP = CConfigValue<Hyprlang::INT>("general:gaps_workspaces");
 
     // set floating windows offset callbacks
-    for (auto& w : g_pCompositor->m_vWindows) {
-        if (!g_pCompositor->windowValidMapped(w.get()))
-            continue;
+    m_vRenderOffset.setUpdateCallback([&](void*) {
+        for (auto& w : g_pCompositor->m_vWindows) {
+            if (!g_pCompositor->windowValidMapped(w.get()))
+                continue;
 
-        if (w->m_bIsFloating && !w->m_bPinned && !w->m_bIsFullscreen)
-            m_vRenderOffset.setUpdateCallback([&](void*) { w->onWorkspaceAnimUpdate(); });
-        else
-            w->m_vFloatingOffset = Vector2D(0, 0);
-    }
+            w->onWorkspaceAnimUpdate();
+        };
+    });
 
     if (ANIMSTYLE.starts_with("slidefade")) {
         const auto PMONITOR = g_pCompositor->getMonitorFromID(m_iMonitorID);

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -49,11 +49,8 @@ void CWorkspace::startAnim(bool in, bool left, bool instant) {
 
     // set floating windows offset callbacks
     for (auto& w : g_pCompositor->m_vWindows) {
-        if (g_pCompositor->windowValidMapped(w.get()) && w->m_bIsFloating && !w->m_bPinned && !w->m_bIsFullscreen) {
-            m_vRenderOffset.setCallbackOnBegin([&](void*) { w->m_vFloatingOffset = Vector2D(0, 0); });
+        if (g_pCompositor->windowValidMapped(w.get()) && w->m_bIsFloating && !w->m_bPinned && !w->m_bIsFullscreen)
             m_vRenderOffset.setUpdateCallback([&](void*) { w->onWorkspaceAnimUpdate(); });
-            m_vRenderOffset.setCallbackOnEnd([&](void*) { w->m_vFloatingOffset = Vector2D(0, 0); });
-        }
     }
 
     if (ANIMSTYLE.starts_with("slidefade")) {

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -47,6 +47,15 @@ void CWorkspace::startAnim(bool in, bool left, bool instant) {
     const auto  ANIMSTYLE     = m_fAlpha.m_pConfig->pValues->internalStyle;
     static auto PWORKSPACEGAP = CConfigValue<Hyprlang::INT>("general:gaps_workspaces");
 
+    // set floating windows offset callbacks
+    for (auto& w : g_pCompositor->m_vWindows) {
+        if (g_pCompositor->windowValidMapped(w.get()) && w->m_bIsFloating && !w->m_bPinned && !w->m_bIsFullscreen) {
+            m_vRenderOffset.setCallbackOnBegin([&](void*) { w->m_vFloatingOffset = Vector2D(0, 0); });
+            m_vRenderOffset.setUpdateCallback([&](void*) { w->onWorkspaceAnimUpdate(); });
+            m_vRenderOffset.setCallbackOnEnd([&](void*) { w->m_vFloatingOffset = Vector2D(0, 0); });
+        }
+    }
+
     if (ANIMSTYLE.starts_with("slidefade")) {
         const auto PMONITOR = g_pCompositor->getMonitorFromID(m_iMonitorID);
         float      movePerc = 100.f;
@@ -131,12 +140,6 @@ void CWorkspace::startAnim(bool in, bool left, bool instant) {
             m_fAlpha.setValueAndWarp(1.f);
             m_fAlpha = 0.f;
         }
-    }
-
-    // set floating windows offset
-    for (auto& w : g_pCompositor->m_vWindows) {
-        if (g_pCompositor->windowValidMapped(w.get()) && w->m_bIsFloating && !w->m_bPinned && !w->m_bIsFullscreen)
-            m_vRenderOffset.setUpdateCallback([&](void*) { w->onWorkspaceAnimUpdate(); });
     }
 
     if (instant) {

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -50,7 +50,7 @@ void CWorkspace::startAnim(bool in, bool left, bool instant) {
     // set floating windows offset callbacks
     m_vRenderOffset.setUpdateCallback([&](void*) {
         for (auto& w : g_pCompositor->m_vWindows) {
-            if (!g_pCompositor->windowValidMapped(w.get()))
+            if (!g_pCompositor->windowValidMapped(w.get()) || w->m_iWorkspaceID != m_iID)
                 continue;
 
             w->onWorkspaceAnimUpdate();

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -49,8 +49,13 @@ void CWorkspace::startAnim(bool in, bool left, bool instant) {
 
     // set floating windows offset callbacks
     for (auto& w : g_pCompositor->m_vWindows) {
-        if (g_pCompositor->windowValidMapped(w.get()) && w->m_bIsFloating && !w->m_bPinned && !w->m_bIsFullscreen)
+        if (!g_pCompositor->windowValidMapped(w.get()))
+            continue;
+
+        if (w->m_bIsFloating && !w->m_bPinned && !w->m_bIsFullscreen)
             m_vRenderOffset.setUpdateCallback([&](void*) { w->onWorkspaceAnimUpdate(); });
+        else
+            w->m_vFloatingOffset = Vector2D(0, 0);
     }
 
     if (ANIMSTYLE.starts_with("slidefade")) {

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -133,6 +133,12 @@ void CWorkspace::startAnim(bool in, bool left, bool instant) {
         }
     }
 
+    // set floating windows offset
+    for (auto& w : g_pCompositor->m_vWindows) {
+        if (g_pCompositor->windowValidMapped(w.get()) && w->m_bIsFloating && !w->m_bPinned && !w->m_bIsFullscreen)
+            m_vRenderOffset.setUpdateCallback([&](void*) { w->onWorkspaceAnimUpdate(); });
+    }
+
     if (instant) {
         m_vRenderOffset.warp();
         m_fAlpha.warp();

--- a/src/helpers/Box.cpp
+++ b/src/helpers/Box.cpp
@@ -115,6 +115,11 @@ CBox& CBox::shrink(const double& value) {
     w -= value * 2.0;
     h -= value * 2.0;
 
+    if (w <= 0 || h <= 0) {
+        w = 0;
+        h = 0;
+    }
+
     return *this;
 }
 

--- a/src/helpers/Box.cpp
+++ b/src/helpers/Box.cpp
@@ -109,6 +109,15 @@ CBox& CBox::expand(const double& value) {
     return *this;
 }
 
+CBox& CBox::shrink(const double& value) {
+    x += value;
+    y += value;
+    w -= value * 2.0;
+    h -= value * 2.0;
+
+    return *this;
+}
+
 CBox& CBox::noNegativeSize() {
     std::clamp(w, 0.0, std::numeric_limits<double>::infinity());
     std::clamp(h, 0.0, std::numeric_limits<double>::infinity());

--- a/src/helpers/Box.cpp
+++ b/src/helpers/Box.cpp
@@ -116,22 +116,20 @@ CBox& CBox::noNegativeSize() {
     return *this;
 }
 
-CBox& CBox::intersection(const CBox other) {
-    const float newTop    = std::max(y, other.y);
+CBox CBox::intersection(const CBox other) const {
+    const float newX      = std::max(x, other.x);
+    const float newY      = std::max(y, other.y);
     const float newBottom = std::min(y + h, other.y + other.h);
-    const float newLeft   = std::max(x, other.x);
     const float newRight  = std::min(x + w, other.x + other.w);
-    y                     = newTop;
-    x                     = newLeft;
-    w                     = newRight - newLeft;
-    h                     = newBottom - newTop;
+    float       newW      = newRight - newX;
+    float       newH      = newBottom - newY;
 
-    if (w <= 0 || h <= 0) {
-        w = 0;
-        h = 0;
+    if (newW <= 0 || newH <= 0) {
+        newW = 0;
+        newH = 0;
     }
 
-    return *this;
+    return {newX, newY, newW, newH};
 }
 
 CBox CBox::roundInternal() {

--- a/src/helpers/Box.cpp
+++ b/src/helpers/Box.cpp
@@ -106,15 +106,6 @@ CBox& CBox::expand(const double& value) {
     w += value * 2.0;
     h += value * 2.0;
 
-    return *this;
-}
-
-CBox& CBox::shrink(const double& value) {
-    x += value;
-    y += value;
-    w -= value * 2.0;
-    h -= value * 2.0;
-
     if (w <= 0 || h <= 0) {
         w = 0;
         h = 0;

--- a/src/helpers/Box.hpp
+++ b/src/helpers/Box.hpp
@@ -51,7 +51,6 @@ class CBox {
     CBox&                    transform(const wl_output_transform t, double w, double h);
     CBox&                    addExtents(const SWindowDecorationExtents& e);
     CBox&                    expand(const double& value);
-    CBox&                    shrink(const double& value);
     CBox&                    noNegativeSize();
 
     CBox                     copy() const;

--- a/src/helpers/Box.hpp
+++ b/src/helpers/Box.hpp
@@ -52,9 +52,9 @@ class CBox {
     CBox&                    addExtents(const SWindowDecorationExtents& e);
     CBox&                    expand(const double& value);
     CBox&                    noNegativeSize();
-    CBox&                    intersection(const CBox other);
 
     CBox                     copy() const;
+    CBox                     intersection(const CBox other) const;
 
     SWindowDecorationExtents extentsFrom(const CBox&); // this is the big box
 

--- a/src/helpers/Box.hpp
+++ b/src/helpers/Box.hpp
@@ -51,6 +51,7 @@ class CBox {
     CBox&                    transform(const wl_output_transform t, double w, double h);
     CBox&                    addExtents(const SWindowDecorationExtents& e);
     CBox&                    expand(const double& value);
+    CBox&                    shrink(const double& value);
     CBox&                    noNegativeSize();
 
     CBox                     copy() const;

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -114,7 +114,7 @@ void CAnimationManager::tick() {
             for (auto& w : g_pCompositor->m_vWindows) {
                 // still doing the full damage hack for floating because sometimes when the window
                 // goes through multiple monitors the last rendered frame is missing damage somehow??
-                if (!w->isHidden() && w->m_bIsMapped && w->m_bIsFloating && !w->m_bPinned) {
+                if (g_pCompositor->windowValidMapped(w.get()) && w->m_bIsFloating && !w->m_bPinned) {
                     const CBox windowBoxNoOffset = w->getFullWindowBoundingBox();
                     const CBox monitorBox        = {PMONITOR->vecPosition, PMONITOR->vecSize};
                     if (windowBoxNoOffset.intersection(monitorBox) != windowBoxNoOffset) // on edges between multiple monitors
@@ -205,10 +205,7 @@ void CAnimationManager::tick() {
                     g_pHyprRenderer->damageWindow(PWINDOW);
                 } else if (PWORKSPACE) {
                     for (auto& w : g_pCompositor->m_vWindows) {
-                        if (!w->m_bIsMapped || w->isHidden())
-                            continue;
-
-                        if (w->m_iWorkspaceID != PWORKSPACE->m_iID)
+                        if (!g_pCompositor->windowValidMapped(w.get()) || w->m_iWorkspaceID != PWORKSPACE->m_iID)
                             continue;
 
                         w->updateWindowDecos();

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -114,8 +114,12 @@ void CAnimationManager::tick() {
             for (auto& w : g_pCompositor->m_vWindows) {
                 // still doing the full damage hack for floating because sometimes when the window
                 // goes through multiple monitors the last rendered frame is missing damage somehow??
-                if (!w->isHidden() && w->m_bIsMapped && w->m_bIsFloating && !w->m_bPinned)
-                    g_pHyprRenderer->damageWindow(w.get(), true);
+                if (!w->isHidden() && w->m_bIsMapped && w->m_bIsFloating && !w->m_bPinned) {
+                    const CBox windowBoxNoOffset = w->getFullWindowBoundingBox();
+                    const CBox monitorBox        = {PMONITOR->vecPosition, PMONITOR->vecSize};
+                    if (windowBoxNoOffset.intersection(monitorBox) != windowBoxNoOffset) // on edges between multiple monitors
+                        g_pHyprRenderer->damageWindow(w.get(), true);
+                }
             }
 
             // damage any workspace window that is on any monitor

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -124,7 +124,7 @@ void CAnimationManager::tick() {
 
             // damage any workspace window that is on any monitor
             for (auto& w : g_pCompositor->m_vWindows) {
-                if (w->m_iWorkspaceID != PWORKSPACE->m_iID || !g_pCompositor->windowValidMapped(w.get()) || w->m_bPinned)
+                if (!g_pCompositor->windowValidMapped(w.get()) || w->m_iWorkspaceID != PWORKSPACE->m_iID || w->m_bPinned)
                     continue;
 
                 g_pHyprRenderer->damageWindow(w.get());

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -112,14 +112,20 @@ void CAnimationManager::tick() {
 
             // TODO: just make this into a damn callback already vax...
             for (auto& w : g_pCompositor->m_vWindows) {
-                // still doing the full damage hack for floating because sometimes when the window
-                // goes through multiple monitors the last rendered frame is missing damage somehow??
-                if (g_pCompositor->windowValidMapped(w.get()) && w->m_bIsFloating && !w->m_bPinned) {
+                if (!g_pCompositor->windowValidMapped(w.get()) || w->m_iWorkspaceID != PWORKSPACE->m_iID)
+                    continue;
+
+                if (w->m_bIsFloating && !w->m_bPinned) {
+                    // still doing the full damage hack for floating because sometimes when the window
+                    // goes through multiple monitors the last rendered frame is missing damage somehow??
                     const CBox windowBoxNoOffset = w->getFullWindowBoundingBox();
                     const CBox monitorBox        = {PMONITOR->vecPosition, PMONITOR->vecSize};
                     if (windowBoxNoOffset.intersection(monitorBox) != windowBoxNoOffset) // on edges between multiple monitors
                         g_pHyprRenderer->damageWindow(w.get(), true);
                 }
+
+                if (PWORKSPACE->m_bIsSpecialWorkspace)
+                    g_pHyprRenderer->damageWindow(w.get(), true); // hack for special too because it can cross multiple monitors
             }
 
             // damage any workspace window that is on any monitor

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -114,13 +114,13 @@ void CAnimationManager::tick() {
             for (auto& w : g_pCompositor->m_vWindows) {
                 // still doing the full damage hack for floating because sometimes when the window
                 // goes through multiple monitors the last rendered frame is missing damage somehow??
-                if (!w->isHidden() && w->m_bIsMapped && w->m_bIsFloating)
+                if (!w->isHidden() && w->m_bIsMapped && w->m_bIsFloating && !w->m_bPinned)
                     g_pHyprRenderer->damageWindow(w.get(), true);
             }
 
             // damage any workspace window that is on any monitor
             for (auto& w : g_pCompositor->m_vWindows) {
-                if (w->m_iWorkspaceID != PWORKSPACE->m_iID || !g_pCompositor->windowValidMapped(w.get()))
+                if (w->m_iWorkspaceID != PWORKSPACE->m_iID || !g_pCompositor->windowValidMapped(w.get()) || w->m_bPinned)
                     continue;
 
                 g_pHyprRenderer->damageWindow(w.get());

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -92,6 +92,9 @@ void CAnimationManager::tick() {
             } else if (av->m_eDamagePolicy == AVARDAMAGE_BORDER) {
                 const auto PDECO = PWINDOW->getDecorationByType(DECORATION_BORDER);
                 PDECO->damageEntire();
+            } else if (av->m_eDamagePolicy == AVARDAMAGE_SHADOW) {
+                const auto PDECO = PWINDOW->getDecorationByType(DECORATION_SHADOW);
+                PDECO->damageEntire();
             }
 
             PMONITOR = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID);

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -110,7 +110,7 @@ void CAnimationManager::tick() {
             // TODO: just make this into a damn callback already vax...
             for (auto& w : g_pCompositor->m_vWindows) {
                 if (!w->isHidden() && w->m_bIsMapped && w->m_bIsFloating)
-                    g_pHyprRenderer->damageWindow(w.get(), true);
+                    g_pHyprRenderer->damageWindow(w.get());
             }
 
             // if a special workspace window is on any monitor, damage it
@@ -205,7 +205,7 @@ void CAnimationManager::tick() {
                         w->updateWindowDecos();
 
                         if (w->m_bIsFloating)
-                            g_pHyprRenderer->damageWindow(w.get(), true);
+                            g_pHyprRenderer->damageWindow(w.get());
                     }
                 } else if (PLAYER) {
                     if (PLAYER->layer == ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND || PLAYER->layer == ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM)

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -110,7 +110,7 @@ void CAnimationManager::tick() {
             // TODO: just make this into a damn callback already vax...
             for (auto& w : g_pCompositor->m_vWindows) {
                 if (!w->isHidden() && w->m_bIsMapped && w->m_bIsFloating)
-                    g_pHyprRenderer->damageWindow(w.get());
+                    g_pHyprRenderer->damageWindow(w.get(), true);
             }
 
             // if a special workspace window is on any monitor, damage it
@@ -205,7 +205,7 @@ void CAnimationManager::tick() {
                         w->updateWindowDecos();
 
                         if (w->m_bIsFloating)
-                            g_pHyprRenderer->damageWindow(w.get());
+                            g_pHyprRenderer->damageWindow(w.get(), true);
                     }
                 } else if (PLAYER) {
                     if (PLAYER->layer == ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND || PLAYER->layer == ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM)

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -237,6 +237,9 @@ bool CHyprRenderer::shouldRenderWindow(CWindow* pWindow, CMonitor* pMonitor) {
     if (pWindow->m_iMonitorID == pMonitor->ID)
         return true;
 
+    if (!g_pCompositor->isWorkspaceVisible(pWindow->m_iWorkspaceID) && pWindow->m_iMonitorID != pMonitor->ID)
+        return false;
+
     // if not, check if it maybe is active on a different monitor.
     if (g_pCompositor->isWorkspaceVisible(pWindow->m_iWorkspaceID) && pWindow->m_bIsFloating /* tiled windows can't be multi-ws */)
         return !pWindow->m_bIsFullscreen; // Do not draw fullscreen windows on other monitors

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1743,13 +1743,14 @@ void CHyprRenderer::damageWindow(CWindow* pWindow) {
     if (g_pCompositor->m_bUnsafeState)
         return;
 
-    CBox       damageBox        = pWindow->getFullWindowBoundingBox();
+    CBox       windowBox        = pWindow->getFullWindowBoundingBox();
     const auto PWINDOWWORKSPACE = g_pCompositor->getWorkspaceByID(pWindow->m_iWorkspaceID);
     if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_vRenderOffset.isBeingAnimated())
-        damageBox.translate(PWINDOWWORKSPACE->m_vRenderOffset.value());
+        windowBox.translate(PWINDOWWORKSPACE->m_vRenderOffset.value());
+
     for (auto& m : g_pCompositor->m_vMonitors) {
         if (g_pHyprRenderer->shouldRenderWindow(pWindow, m.get())) { // only damage if window is rendered on monitor
-            CBox fixedDamageBox = {damageBox.x - m->vecPosition.x, damageBox.y - m->vecPosition.y, damageBox.width, damageBox.height};
+            CBox fixedDamageBox = {windowBox.x - m->vecPosition.x, windowBox.y - m->vecPosition.y, windowBox.width, windowBox.height};
             fixedDamageBox.scale(m->scale);
             m->addDamage(&fixedDamageBox);
         }
@@ -1761,7 +1762,7 @@ void CHyprRenderer::damageWindow(CWindow* pWindow) {
     static auto PLOGDAMAGE = CConfigValue<Hyprlang::INT>("debug:log_damage");
 
     if (*PLOGDAMAGE)
-        Debug::log(LOG, "Damage: Window ({}): xy: {}, {} wh: {}, {}", pWindow->m_szTitle, damageBox.x, damageBox.y, damageBox.width, damageBox.height);
+        Debug::log(LOG, "Damage: Window ({}): xy: {}, {} wh: {}, {}", pWindow->m_szTitle, windowBox.x, windowBox.y, windowBox.width, windowBox.height);
 }
 
 void CHyprRenderer::damageMonitor(CMonitor* pMonitor) {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1741,7 +1741,7 @@ void CHyprRenderer::damageSurface(wlr_surface* pSurface, double x, double y, dou
                    damageBox.pixman()->extents.x2 - damageBox.pixman()->extents.x1, damageBox.pixman()->extents.y2 - damageBox.pixman()->extents.y1);
 }
 
-void CHyprRenderer::damageWindow(CWindow* pWindow, bool forceFull) {
+void CHyprRenderer::damageWindow(CWindow* pWindow) {
     if (g_pCompositor->m_bUnsafeState)
         return;
 
@@ -1752,7 +1752,7 @@ void CHyprRenderer::damageWindow(CWindow* pWindow, bool forceFull) {
     windowBox.translate(pWindow->m_vFloatingOffset);
 
     for (auto& m : g_pCompositor->m_vMonitors) {
-        if (g_pHyprRenderer->shouldRenderWindow(pWindow, m.get()) || forceFull) { // only damage if window is rendered on monitor
+        if (g_pHyprRenderer->shouldRenderWindow(pWindow, m.get())) { // only damage if window is rendered on monitor
             CBox fixedDamageBox = {windowBox.x - m->vecPosition.x, windowBox.y - m->vecPosition.y, windowBox.width, windowBox.height};
             fixedDamageBox.scale(m->scale);
             m->addDamage(&fixedDamageBox);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -546,14 +546,14 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
                 if (wd->getDecorationLayer() != DECORATION_LAYER_BOTTOM)
                     continue;
 
-                wd->draw(pMonitor, renderdata.alpha * renderdata.fadeAlpha, pWindow->m_vFloatingOffset);
+                wd->draw(pMonitor, renderdata.alpha * renderdata.fadeAlpha);
             }
 
             for (auto& wd : pWindow->m_dWindowDecorations) {
                 if (wd->getDecorationLayer() != DECORATION_LAYER_UNDER)
                     continue;
 
-                wd->draw(pMonitor, renderdata.alpha * renderdata.fadeAlpha, pWindow->m_vFloatingOffset);
+                wd->draw(pMonitor, renderdata.alpha * renderdata.fadeAlpha);
             }
         }
 
@@ -578,7 +578,7 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
                 if (wd->getDecorationLayer() != DECORATION_LAYER_OVER)
                     continue;
 
-                wd->draw(pMonitor, renderdata.alpha * renderdata.fadeAlpha, pWindow->m_vFloatingOffset);
+                wd->draw(pMonitor, renderdata.alpha * renderdata.fadeAlpha);
             }
         }
 
@@ -639,7 +639,7 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
                 if (wd->getDecorationLayer() != DECORATION_LAYER_OVERLAY)
                     continue;
 
-                wd->draw(pMonitor, renderdata.alpha * renderdata.fadeAlpha, pWindow->m_vFloatingOffset);
+                wd->draw(pMonitor, renderdata.alpha * renderdata.fadeAlpha);
             }
         }
     }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -523,7 +523,6 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
             const auto PWSMON   = g_pCompositor->getMonitorFromID(PWORKSPACE->m_iMonitorID);
             const auto PROGRESS = PWORKSPACE->m_vRenderOffset.value().x / PWSMON->vecSize.x;
             const auto WINBB    = pWindow->getFullWindowBoundingBox();
-            // WINBB.translate(PWORKSPACE->m_vRenderOffset.value());
 
             if (WINBB.x < PWSMON->vecPosition.x) {
                 offset.x = (PWSMON->vecPosition.x - WINBB.x) * PROGRESS;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1746,7 +1746,7 @@ void CHyprRenderer::damageWindow(CWindow* pWindow, bool forceFull) {
 
     CBox       windowBox        = pWindow->getFullWindowBoundingBox();
     const auto PWINDOWWORKSPACE = g_pCompositor->getWorkspaceByID(pWindow->m_iWorkspaceID);
-    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_vRenderOffset.isBeingAnimated())
+    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_vRenderOffset.isBeingAnimated() && !pWindow->m_bPinned)
         windowBox.translate(PWINDOWWORKSPACE->m_vRenderOffset.value());
     windowBox.translate(pWindow->m_vFloatingOffset);
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1741,7 +1741,7 @@ void CHyprRenderer::damageSurface(wlr_surface* pSurface, double x, double y, dou
                    damageBox.pixman()->extents.x2 - damageBox.pixman()->extents.x1, damageBox.pixman()->extents.y2 - damageBox.pixman()->extents.y1);
 }
 
-void CHyprRenderer::damageWindow(CWindow* pWindow) {
+void CHyprRenderer::damageWindow(CWindow* pWindow, bool forceFull) {
     if (g_pCompositor->m_bUnsafeState)
         return;
 
@@ -1752,7 +1752,7 @@ void CHyprRenderer::damageWindow(CWindow* pWindow) {
     windowBox.translate(pWindow->m_vFloatingOffset);
 
     for (auto& m : g_pCompositor->m_vMonitors) {
-        if (g_pHyprRenderer->shouldRenderWindow(pWindow, m.get())) { // only damage if window is rendered on monitor
+        if (g_pHyprRenderer->shouldRenderWindow(pWindow, m.get()) || forceFull) { // only damage if window is rendered on monitor
             CBox fixedDamageBox = {windowBox.x - m->vecPosition.x, windowBox.y - m->vecPosition.y, windowBox.width, windowBox.height};
             fixedDamageBox.scale(m->scale);
             m->addDamage(&fixedDamageBox);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -253,7 +253,11 @@ bool CHyprRenderer::shouldRenderWindow(CWindow* pWindow, CMonitor* pMonitor) {
             return false;
         // render window if window and monitor intersect
         // (when moving out of or through a monitor)
-        const CBox windowBox  = pWindow->getFullWindowBoundingBox();
+        CBox windowBox = pWindow->getFullWindowBoundingBox();
+        if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_vRenderOffset.isBeingAnimated())
+            windowBox.translate(PWINDOWWORKSPACE->m_vRenderOffset.value());
+        windowBox.translate(pWindow->m_vFloatingOffset);
+
         const CBox monitorBox = {pMonitor->vecPosition, pMonitor->vecSize};
         if (!windowBox.intersection(monitorBox).empty())
             return true;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -537,7 +537,7 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
             if (WINBB.y < PWSMON->vecPosition.y) {
                 offset.y = (PWSMON->vecPosition.y - WINBB.y) * PROGRESS;
             } else if (WINBB.y + WINBB.height > PWSMON->vecPosition.y + PWSMON->vecSize.y) {
-                offset.y = (WINBB.y + WINBB.width - PWSMON->vecPosition.y - PWSMON->vecSize.y) * PROGRESS;
+                offset.y = (WINBB.y + WINBB.height - PWSMON->vecPosition.y - PWSMON->vecSize.y) * PROGRESS;
             }
         }
 

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -46,7 +46,7 @@ class CHyprRenderer {
     void                            outputMgrApplyTest(wlr_output_configuration_v1*, bool);
     void                            arrangeLayersForMonitor(const int&);
     void                            damageSurface(wlr_surface*, double, double, double scale = 1.0);
-    void                            damageWindow(CWindow*, bool forceFull = false);
+    void                            damageWindow(CWindow*);
     void                            damageBox(CBox*);
     void                            damageBox(const int& x, const int& y, const int& w, const int& h);
     void                            damageRegion(const CRegion&);

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -46,7 +46,7 @@ class CHyprRenderer {
     void                            outputMgrApplyTest(wlr_output_configuration_v1*, bool);
     void                            arrangeLayersForMonitor(const int&);
     void                            damageSurface(wlr_surface*, double, double, double scale = 1.0);
-    void                            damageWindow(CWindow*);
+    void                            damageWindow(CWindow*, bool forceFull = false);
     void                            damageBox(CBox*);
     void                            damageBox(const int& x, const int& y, const int& w, const int& h);
     void                            damageRegion(const CRegion&);

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -47,14 +47,13 @@ class CHyprRenderer {
     void                            arrangeLayersForMonitor(const int&);
     void                            damageSurface(wlr_surface*, double, double, double scale = 1.0);
     void                            damageWindow(CWindow*);
-    void                            damageWindowRenderedParts(CWindow*);
     void                            damageBox(CBox*);
     void                            damageBox(const int& x, const int& y, const int& w, const int& h);
     void                            damageRegion(const CRegion&);
     void                            damageMonitor(CMonitor*);
     void                            damageMirrorsWith(CMonitor*, const CRegion&);
     bool                            applyMonitorRule(CMonitor*, SMonitorRule*, bool force = false);
-    bool                            shouldRenderWindow(CWindow*, CMonitor*, CWorkspace*);
+    bool                            shouldRenderWindow(CWindow*, CMonitor*);
     bool                            shouldRenderWindow(CWindow*);
     void                            ensureCursorRenderingMode();
     bool                            shouldRenderCursor();

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -47,6 +47,7 @@ class CHyprRenderer {
     void                            arrangeLayersForMonitor(const int&);
     void                            damageSurface(wlr_surface*, double, double, double scale = 1.0);
     void                            damageWindow(CWindow*);
+    void                            damageWindowRenderedParts(CWindow*);
     void                            damageBox(CBox*);
     void                            damageBox(const int& x, const int& y, const int& w, const int& h);
     void                            damageRegion(const CRegion&);

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -96,7 +96,7 @@ void CHyprBorderDecoration::damageEntire() {
     const auto BORDERSIZE   = m_pWindow->getRealBorderSize();
 
     const auto PWINDOWWORKSPACE = g_pCompositor->getWorkspaceByID(m_pWindow->m_iWorkspaceID);
-    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_vRenderOffset.isBeingAnimated())
+    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_vRenderOffset.isBeingAnimated() && !m_pWindow->m_bPinned)
         windowBox.translate(PWINDOWWORKSPACE->m_vRenderOffset.value());
     windowBox.translate(m_pWindow->m_vFloatingOffset);
 

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -45,14 +45,14 @@ CBox CHyprBorderDecoration::assignedBoxGlobal() {
     return box.translate(WORKSPACEOFFSET);
 }
 
-void CHyprBorderDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& offset) {
+void CHyprBorderDecoration::draw(CMonitor* pMonitor, float a) {
     if (doesntWantBorders())
         return;
 
     if (m_bAssignedGeometry.width < m_seExtents.topLeft.x + 1 || m_bAssignedGeometry.height < m_seExtents.topLeft.y + 1)
         return;
 
-    CBox windowBox = assignedBoxGlobal().translate(-pMonitor->vecPosition + offset).expand(-m_pWindow->getRealBorderSize()).scale(pMonitor->scale).round();
+    CBox windowBox = assignedBoxGlobal().translate(-pMonitor->vecPosition + m_pWindow->m_vFloatingOffset).expand(-m_pWindow->getRealBorderSize()).scale(pMonitor->scale).round();
 
     if (windowBox.width < 1 || windowBox.height < 1)
         return;

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -98,6 +98,7 @@ void CHyprBorderDecoration::damageEntire() {
     const auto PWINDOWWORKSPACE = g_pCompositor->getWorkspaceByID(m_pWindow->m_iWorkspaceID);
     if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_vRenderOffset.isBeingAnimated())
         windowBox.translate(PWINDOWWORKSPACE->m_vRenderOffset.value());
+    windowBox.translate(m_pWindow->m_vFloatingOffset);
 
     std::vector<CBox> borderBoxes;
     borderBoxes.push_back({windowBox.x - BORDERSIZE, windowBox.y - BORDERSIZE, windowBox.width + 2 * BORDERSIZE, BORDERSIZE + ROUNDINGSIZE});                      // top

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -103,7 +103,7 @@ void CHyprBorderDecoration::damageEntire() {
     CBox surfaceBoxExpandedBorder = surfaceBox;
     surfaceBoxExpandedBorder.expand(BORDERSIZE);
     CBox surfaceBoxShrunkRounding = surfaceBox;
-    surfaceBoxShrunkRounding.shrink(ROUNDINGSIZE);
+    surfaceBoxShrunkRounding.expand(-ROUNDINGSIZE);
 
     CRegion borderRegion(surfaceBoxExpandedBorder);
     borderRegion.subtract(surfaceBoxShrunkRounding);

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -96,7 +96,7 @@ void CHyprBorderDecoration::damageEntire() {
     const auto BORDERSIZE   = m_pWindow->getRealBorderSize();
 
     const auto PWINDOWWORKSPACE = g_pCompositor->getWorkspaceByID(m_pWindow->m_iWorkspaceID);
-    if (PWINDOWWORKSPACE)
+    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_vRenderOffset.isBeingAnimated())
         windowBox.translate(PWINDOWWORKSPACE->m_vRenderOffset.value());
 
     std::vector<CBox> borderBoxes;
@@ -108,9 +108,9 @@ void CHyprBorderDecoration::damageEntire() {
     for (auto& m : g_pCompositor->m_vMonitors) {
         if (g_pHyprRenderer->shouldRenderWindow(m_pWindow, m.get())) {
             for (auto borderBox : borderBoxes) {
-                CBox fixedDamageBox = {borderBox.x - m->vecPosition.x, borderBox.y - m->vecPosition.y, borderBox.width, borderBox.height};
-                fixedDamageBox.scale(m->scale);
-                m->addDamage(&fixedDamageBox);
+                const CBox monitorBox = {m->vecPosition, m->vecSize};
+                CBox       damageBox  = borderBox.intersection(monitorBox);
+                g_pHyprRenderer->damageBox(&damageBox);
             }
         }
     }

--- a/src/render/decorations/CHyprBorderDecoration.hpp
+++ b/src/render/decorations/CHyprBorderDecoration.hpp
@@ -11,7 +11,7 @@ class CHyprBorderDecoration : public IHyprWindowDecoration {
 
     virtual void                       onPositioningReply(const SDecorationPositioningReply& reply);
 
-    virtual void                       draw(CMonitor*, float a, const Vector2D& offset);
+    virtual void                       draw(CMonitor*, float a);
 
     virtual eDecorationType            getDecorationType();
 

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -82,7 +82,7 @@ void CHyprDropShadowDecoration::updateWindow(CWindow* pWindow) {
     m_bLastWindowBoxWithDecos = g_pDecorationPositioner->getBoxWithIncludedDecos(pWindow);
 }
 
-void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& offset) {
+void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a) {
 
     if (!g_pCompositor->windowValidMapped(m_pWindow))
         return;
@@ -132,7 +132,7 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D
                    {fullBox.x + fullBox.width + pMonitor->vecPosition.x - m_vLastWindowPos.x - m_vLastWindowSize.x + 2,
                     fullBox.y + fullBox.height + pMonitor->vecPosition.y - m_vLastWindowPos.y - m_vLastWindowSize.y + 2}};
 
-    fullBox.translate(offset);
+    fullBox.translate(m_pWindow->m_vFloatingOffset);
 
     if (fullBox.width < 1 || fullBox.height < 1)
         return; // don't draw invisible shadows
@@ -154,8 +154,8 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D
         windowBox.translate(-pMonitor->vecPosition + WORKSPACEOFFSET);
         withDecos.translate(-pMonitor->vecPosition + WORKSPACEOFFSET);
 
-        windowBox.translate(offset);
-        withDecos.translate(offset);
+        windowBox.translate(m_pWindow->m_vFloatingOffset);
+        withDecos.translate(m_pWindow->m_vFloatingOffset);
 
         auto scaledExtentss = withDecos.extentsFrom(windowBox);
         scaledExtentss      = scaledExtentss * pMonitor->scale;

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -43,7 +43,14 @@ void CHyprDropShadowDecoration::damageEntire() {
 
     CBox dm = {m_vLastWindowPos.x - m_seExtents.topLeft.x, m_vLastWindowPos.y - m_seExtents.topLeft.y, m_vLastWindowSize.x + m_seExtents.topLeft.x + m_seExtents.bottomRight.x,
                m_vLastWindowSize.y + m_seExtents.topLeft.y + m_seExtents.bottomRight.y};
-    g_pHyprRenderer->damageBox(&dm);
+
+    for (auto& m : g_pCompositor->m_vMonitors) {
+        if (g_pHyprRenderer->shouldRenderWindow(m_pWindow, m.get())) {
+            const CBox monitorBox = {m->vecPosition, m->vecSize};
+            CBox       damageBox  = monitorBox.intersection(dm);
+            g_pHyprRenderer->damageBox(&damageBox);
+        }
+    }
 }
 
 void CHyprDropShadowDecoration::updateWindow(CWindow* pWindow) {

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -60,7 +60,7 @@ void CHyprDropShadowDecoration::damageEntire() {
         if (PWORKSPACE && PWORKSPACE->m_vRenderOffset.isBeingAnimated() && !m_pWindow->m_bPinned)
             surfaceBox.translate(PWORKSPACE->m_vRenderOffset.value());
         surfaceBox.translate(m_pWindow->m_vFloatingOffset);
-        surfaceBox.shrink(ROUNDINGSIZE);
+        surfaceBox.expand(-ROUNDINGSIZE);
         shadowRegion.subtract(CRegion(surfaceBox));
     }
 

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -46,7 +46,7 @@ void CHyprDropShadowDecoration::damageEntire() {
                             m_pWindow->m_vRealSize.value().y + m_seExtents.topLeft.y + m_seExtents.bottomRight.y};
 
     const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(m_pWindow->m_iWorkspaceID);
-    if (PWORKSPACE)
+    if (PWORKSPACE && PWORKSPACE->m_vRenderOffset.isBeingAnimated() && !m_pWindow->m_bPinned)
         shadowBox.translate(PWORKSPACE->m_vRenderOffset.value());
     shadowBox.translate(m_pWindow->m_vFloatingOffset);
 

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -105,6 +105,8 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D
     // scale the box in relation to the center of the box
     fullBox.scaleFromCenter(SHADOWSCALE).translate(*PSHADOWOFFSET);
 
+    m_vLastWindowPos  = m_pWindow->m_vRealPosition.value();
+    m_vLastWindowSize = m_pWindow->m_vRealSize.value();
     m_vLastWindowPos += WORKSPACEOFFSET;
     m_seExtents = {{m_vLastWindowPos.x - fullBox.x - pMonitor->vecPosition.x + 2, m_vLastWindowPos.y - fullBox.y - pMonitor->vecPosition.y + 2},
                    {fullBox.x + fullBox.width + pMonitor->vecPosition.x - m_vLastWindowPos.x - m_vLastWindowSize.x + 2,
@@ -131,6 +133,9 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a, const Vector2D
         // get window box
         windowBox.translate(-pMonitor->vecPosition + WORKSPACEOFFSET);
         withDecos.translate(-pMonitor->vecPosition + WORKSPACEOFFSET);
+
+        windowBox.translate(offset);
+        withDecos.translate(offset);
 
         auto scaledExtentss = withDecos.extentsFrom(windowBox);
         scaledExtentss      = scaledExtentss * pMonitor->scale;

--- a/src/render/decorations/CHyprDropShadowDecoration.hpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.hpp
@@ -11,7 +11,7 @@ class CHyprDropShadowDecoration : public IHyprWindowDecoration {
 
     virtual void                       onPositioningReply(const SDecorationPositioningReply& reply);
 
-    virtual void                       draw(CMonitor*, float a, const Vector2D& offset);
+    virtual void                       draw(CMonitor*, float a);
 
     virtual eDecorationType            getDecorationType();
 

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -87,7 +87,7 @@ void CHyprGroupBarDecoration::damageEntire() {
     g_pHyprRenderer->damageBox(&box);
 }
 
-void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& offset) {
+void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a) {
     // get how many bars we will draw
     int         barsToDraw = m_dwGroupMembers.size();
 
@@ -111,8 +111,9 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
     int xoff = 0;
 
     for (int i = 0; i < barsToDraw; ++i) {
-        CBox rect = {ASSIGNEDBOX.x + xoff - pMonitor->vecPosition.x + offset.x,
-                     ASSIGNEDBOX.y + ASSIGNEDBOX.h - BAR_INDICATOR_HEIGHT - BAR_PADDING_OUTER_VERT - pMonitor->vecPosition.y + offset.y, m_fBarWidth, BAR_INDICATOR_HEIGHT};
+        CBox rect = {ASSIGNEDBOX.x + xoff - pMonitor->vecPosition.x + m_pWindow->m_vFloatingOffset.x,
+                     ASSIGNEDBOX.y + ASSIGNEDBOX.h - BAR_INDICATOR_HEIGHT - BAR_PADDING_OUTER_VERT - pMonitor->vecPosition.y + m_pWindow->m_vFloatingOffset.y, m_fBarWidth,
+                     BAR_INDICATOR_HEIGHT};
 
         if (rect.width <= 0 || rect.height <= 0)
             break;
@@ -136,7 +137,8 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a, const Vector2D& 
         color.a *= a;
         g_pHyprOpenGL->renderRect(&rect, color);
 
-        rect = {ASSIGNEDBOX.x + xoff - pMonitor->vecPosition.x + offset.x, ASSIGNEDBOX.y - pMonitor->vecPosition.y + offset.y + BAR_PADDING_OUTER_VERT, m_fBarWidth,
+        rect = {ASSIGNEDBOX.x + xoff - pMonitor->vecPosition.x + m_pWindow->m_vFloatingOffset.x,
+                ASSIGNEDBOX.y - pMonitor->vecPosition.y + m_pWindow->m_vFloatingOffset.y + BAR_PADDING_OUTER_VERT, m_fBarWidth,
                 ASSIGNEDBOX.h - BAR_INDICATOR_HEIGHT - BAR_PADDING_OUTER_VERT * 2};
         rect.scale(pMonitor->scale);
 

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -83,6 +83,7 @@ void CHyprGroupBarDecoration::updateWindow(CWindow* pWindow) {
 
 void CHyprGroupBarDecoration::damageEntire() {
     auto box = assignedBoxGlobal();
+    box.translate(m_pWindow->m_vFloatingOffset);
     g_pHyprRenderer->damageBox(&box);
 }
 
@@ -505,9 +506,8 @@ CBox CHyprGroupBarDecoration::assignedBoxGlobal() {
 
     const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(m_pWindow->m_iWorkspaceID);
 
-    if (!PWORKSPACE)
-        return box;
+    if (PWORKSPACE && PWORKSPACE->m_vRenderOffset.isBeingAnimated() && !m_pWindow->m_bPinned)
+        box.translate(PWORKSPACE->m_vRenderOffset.value());
 
-    const auto WORKSPACEOFFSET = PWORKSPACE && !m_pWindow->m_bPinned ? PWORKSPACE->m_vRenderOffset.value() : Vector2D();
-    return box.translate(WORKSPACEOFFSET);
+    return box;
 }

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -27,7 +27,7 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
 
     virtual void                       onPositioningReply(const SDecorationPositioningReply& reply);
 
-    virtual void                       draw(CMonitor*, float a, const Vector2D& offset);
+    virtual void                       draw(CMonitor*, float a);
 
     virtual eDecorationType            getDecorationType();
 

--- a/src/render/decorations/IHyprWindowDecoration.hpp
+++ b/src/render/decorations/IHyprWindowDecoration.hpp
@@ -39,7 +39,7 @@ class IHyprWindowDecoration {
 
     virtual void                       onPositioningReply(const SDecorationPositioningReply& reply) = 0;
 
-    virtual void                       draw(CMonitor*, float a, const Vector2D& offset = Vector2D()) = 0;
+    virtual void                       draw(CMonitor*, float a) = 0;
 
     virtual eDecorationType            getDecorationType() = 0;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes https://github.com/hyprwm/Hyprland/issues/3514
Fixes https://github.com/hyprwm/Hyprland/issues/4912

1. Fix incorrect rendering and damage of floating windows when the window expands across multiple monitors.
2. Remove unnecessary damage from workspace offset. Mentioned here: https://github.com/hyprwm/Hyprland/pull/5202#discussion_r1534579041
3. Fix incorrect rendering and damage of floating drop shadows when the window expands across multiple monitors.
4. Fix incorrect clip box for floating slide.
5. Fix some incorrect damage of tiling drop shadows due to incorrect offset.
6. Fix an issue of wrong floating window position caused by a wrong offset when using workspace slidevert.
7. Move border damage to border class, and also remove some unnecessary border damage on the wrong monitor
8. Don't damage the entire monitor on workspace change, but only the windows (unless special workspace because dim/blur)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Haven't had any issues myself but who knows. Should have some positive GPU impact because there is less damage

#### Is it ready for merging, or does it need work?
Hopefully ready but to be determined