### PR TITLE
layer: don't change workspace when restoring focus

### DIFF
--- a/src/events/Layers.cpp
+++ b/src/events/Layers.cpp
@@ -237,7 +237,7 @@ void Events::listener_unmapLayerSurface(void* owner, void* data) {
             foundSurface = g_pCompositor->vectorToLayerSurface(g_pInputManager->getMouseCoordsInternal(), &PMONITOR->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP],
                                                                &surfaceCoords, &pFoundLayerSurface);
 
-        if (!foundSurface && g_pCompositor->m_pLastWindow) {
+        if (!foundSurface && g_pCompositor->m_pLastWindow && g_pCompositor->isWorkspaceVisible(g_pCompositor->m_pLastWindow->m_iWorkspaceID)) {
             // if there isn't any, focus the last window
             const auto PLASTWINDOW = g_pCompositor->m_pLastWindow;
             g_pCompositor->focusWindow(nullptr);


### PR DESCRIPTION
checks if the previously focused window is in a visible workspace before giving it focus, when closing a layer with input

shouldn't cause issues