### PR TITLE
Remove old headers first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ pluginenv:
 installheaders:
 	@if [ ! -f ./src/version.h ]; then echo -en "You need to run $(MAKE) all first.\n" && exit 1; fi
 
+	rm -fr ${PREFIX}/include/hyprland
 	mkdir -p ${PREFIX}/include/hyprland
 	mkdir -p ${PREFIX}/include/hyprland/protocols
 	mkdir -p ${PREFIX}/include/hyprland/wlroots


### PR DESCRIPTION
Windows.cpp was moved and I found myself having both versions in my include. Clear out the headers before dumping new ones.