### PR TITLE
Focus: Fix incorrect keyboard focus taken when no window was present

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -422,10 +422,8 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
             unsetCursorImage();
         }
 
-        if (pFoundLayerSurface &&
-            (pFoundLayerSurface->layerSurface->current.keyboard_interactive != ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE ||
-             (pFoundLayerSurface->layer >= ZWLR_LAYER_SHELL_V1_LAYER_TOP && !g_pCompositor->m_pLastWindow)) &&
-            FOLLOWMOUSE != 3 && allowKeyboardRefocus) {
+        if (pFoundLayerSurface && (pFoundLayerSurface->layerSurface->current.keyboard_interactive != ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE) && FOLLOWMOUSE != 3 &&
+            allowKeyboardRefocus) {
             g_pCompositor->focusSurface(foundSurface);
         }
 


### PR DESCRIPTION
A non-keyboard layer never needs keyboard focus

#### Describe your PR, what does it fix/add?

Fixes a focus issue that was common on touchscreen-only devices

1. launch a layer shell (bemenu, nwggrid, rofi)
2. launch a virtual keyboard
3. Type in the keyboard
(Previously, the typing in the virtual keyboard would only go to the layer shell if there was a window beneath everything. When there was **not** a window beneath everything, the virtual keyboard would steal keyboard focus from the layer shell)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This code was recently touched in https://github.com/hyprwm/Hyprland/commit/98059b52d759965916e0185ca35a01cc20a797b6, but the change didn't go far enough to fix this.

#### Is it ready for merging, or does it need work?

Yes

