### PR TITLE
Make master workspace orientation rule dynamic

### DIFF
--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -339,6 +339,23 @@ void CHyprMasterLayout::calculateWorkspace(const int& ws) {
     if (!PMASTERNODE)
         return;
 
+    // dynamic workspace rules
+    const auto layoutoptsForWs = g_pConfigManager->getWorkspaceRuleFor(g_pCompositor->getWorkspaceByID(ws)).layoutopts;
+    if (layoutoptsForWs.contains("orientation")) {
+        const std::string orientationForWs = layoutoptsForWs.at("orientation");
+        if (orientationForWs == "top") {
+            PWORKSPACEDATA->orientation = ORIENTATION_TOP;
+        } else if (orientationForWs == "right") {
+            PWORKSPACEDATA->orientation = ORIENTATION_RIGHT;
+        } else if (orientationForWs == "bottom") {
+            PWORKSPACEDATA->orientation = ORIENTATION_BOTTOM;
+        } else if (orientationForWs == "center") {
+            PWORKSPACEDATA->orientation = ORIENTATION_CENTER;
+        } else if (orientationForWs == "left") {
+            PWORKSPACEDATA->orientation = ORIENTATION_LEFT;
+        }
+    }
+
     eOrientation orientation        = PWORKSPACEDATA->orientation;
     bool         centerMasterWindow = false;
     static auto  ALWAYSCENTER       = CConfigValue<Hyprlang::INT>("master:always_center_master");

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -53,17 +53,16 @@ SMasterWorkspaceData* CHyprMasterLayout::getMasterWorkspaceData(const int& ws) {
             orientationForWs = wsRule.layoutopts.at("orientation");
     }
 
-    if (orientationForWs == "top") {
+    if (orientationForWs == "top")
         PWORKSPACEDATA->orientation = ORIENTATION_TOP;
-    } else if (orientationForWs == "right") {
+    else if (orientationForWs == "right")
         PWORKSPACEDATA->orientation = ORIENTATION_RIGHT;
-    } else if (orientationForWs == "bottom") {
+    else if (orientationForWs == "bottom")
         PWORKSPACEDATA->orientation = ORIENTATION_BOTTOM;
-    } else if (orientationForWs == "center") {
+    else if (orientationForWs == "center")
         PWORKSPACEDATA->orientation = ORIENTATION_CENTER;
-    } else {
+    else
         PWORKSPACEDATA->orientation = ORIENTATION_LEFT;
-    }
 
     return PWORKSPACEDATA;
 }
@@ -348,17 +347,16 @@ void CHyprMasterLayout::calculateWorkspace(const int& ws) {
             orientationForWs = wsRule.layoutopts.at("orientation");
     }
 
-    if (orientationForWs == "top") {
+    if (orientationForWs == "top")
         PWORKSPACEDATA->orientation = ORIENTATION_TOP;
-    } else if (orientationForWs == "right") {
+    else if (orientationForWs == "right")
         PWORKSPACEDATA->orientation = ORIENTATION_RIGHT;
-    } else if (orientationForWs == "bottom") {
+    else if (orientationForWs == "bottom")
         PWORKSPACEDATA->orientation = ORIENTATION_BOTTOM;
-    } else if (orientationForWs == "center") {
+    else if (orientationForWs == "center")
         PWORKSPACEDATA->orientation = ORIENTATION_CENTER;
-    } else if (orientationForWs == "left") {
+    else if (orientationForWs == "left")
         PWORKSPACEDATA->orientation = ORIENTATION_LEFT;
-    }
 
     eOrientation orientation        = PWORKSPACEDATA->orientation;
     bool         centerMasterWindow = false;

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -774,7 +774,7 @@ void CHyprMasterLayout::resizeActiveWindow(const Vector2D& pixResize, eRectCorne
     }
 
     const auto   PMONITOR       = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID);
-    const auto   PWORKSPACEDATA = getMasterWorkspaceData(PMONITOR->activeWorkspace);
+    const auto   PWORKSPACEDATA = getMasterWorkspaceData(PWINDOW->m_iWorkspaceID);
     static auto  ALWAYSCENTER   = CConfigValue<Hyprlang::INT>("master:always_center_master");
     static auto  PSMARTRESIZING = CConfigValue<Hyprlang::INT>("master:smart_resizing");
 

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -340,20 +340,24 @@ void CHyprMasterLayout::calculateWorkspace(const int& ws) {
         return;
 
     // dynamic workspace rules
-    const auto layoutoptsForWs = g_pConfigManager->getWorkspaceRuleFor(g_pCompositor->getWorkspaceByID(ws)).layoutopts;
-    if (layoutoptsForWs.contains("orientation")) {
-        const std::string orientationForWs = layoutoptsForWs.at("orientation");
-        if (orientationForWs == "top") {
-            PWORKSPACEDATA->orientation = ORIENTATION_TOP;
-        } else if (orientationForWs == "right") {
-            PWORKSPACEDATA->orientation = ORIENTATION_RIGHT;
-        } else if (orientationForWs == "bottom") {
-            PWORKSPACEDATA->orientation = ORIENTATION_BOTTOM;
-        } else if (orientationForWs == "center") {
-            PWORKSPACEDATA->orientation = ORIENTATION_CENTER;
-        } else if (orientationForWs == "left") {
-            PWORKSPACEDATA->orientation = ORIENTATION_LEFT;
-        }
+    const auto  WORKSPACERULES = g_pConfigManager->getWorkspaceRulesFor(g_pCompositor->getWorkspaceByID(ws));
+    std::string orientationForWs;
+
+    for (auto& wsRule : WORKSPACERULES) {
+        if (wsRule.layoutopts.contains("orientation"))
+            orientationForWs = wsRule.layoutopts.at("orientation");
+    }
+
+    if (orientationForWs == "top") {
+        PWORKSPACEDATA->orientation = ORIENTATION_TOP;
+    } else if (orientationForWs == "right") {
+        PWORKSPACEDATA->orientation = ORIENTATION_RIGHT;
+    } else if (orientationForWs == "bottom") {
+        PWORKSPACEDATA->orientation = ORIENTATION_BOTTOM;
+    } else if (orientationForWs == "center") {
+        PWORKSPACEDATA->orientation = ORIENTATION_CENTER;
+    } else if (orientationForWs == "left") {
+        PWORKSPACEDATA->orientation = ORIENTATION_LEFT;
     }
 
     eOrientation orientation        = PWORKSPACEDATA->orientation;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Make master workspace orientation rule dynamic to allow more control. With this if you move a workspace to a different monitor etc it will follow the rules you set for the monitor.

addresses https://github.com/hyprwm/Hyprland/issues/3174
also closes https://github.com/hyprwm/Hyprland/issues/5312

also fixes a special workspace resizing bug

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
ready

