### PR TITLE
Match all workspace rules instead of the first one only

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1259,8 +1259,13 @@ void CCompositor::sanityCheckWorkspaces() {
     auto it = m_vWorkspaces.begin();
     while (it != m_vWorkspaces.end()) {
 
-        const auto WORKSPACERULE = g_pConfigManager->getWorkspaceRuleFor(it->get());
-        if (WORKSPACERULE.isPersistent) {
+        const auto WORKSPACERULES = g_pConfigManager->getWorkspaceRulesFor(it->get());
+        bool       isPersistent   = false;
+        for (auto& wsRule : WORKSPACERULES) {
+            if (wsRule.isPersistent)
+                isPersistent = true;
+        }
+        if (isPersistent) {
             ++it;
             continue;
         }
@@ -1287,8 +1292,10 @@ void CCompositor::sanityCheckWorkspaces() {
                 continue;
             }
             if (!WORKSPACE->m_bOnCreatedEmptyExecuted) {
-                if (auto cmd = WORKSPACERULE.onCreatedEmptyRunCmd)
-                    g_pKeybindManager->spawn(*cmd);
+                for (auto& wsRule : WORKSPACERULES) {
+                    if (auto cmd = wsRule.onCreatedEmptyRunCmd)
+                        g_pKeybindManager->spawn(*cmd);
+                }
 
                 WORKSPACE->m_bOnCreatedEmptyExecuted = true;
             }

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -956,11 +956,13 @@ SMonitorRule CConfigManager::getMonitorRuleFor(const CMonitor& PMONITOR) {
     return SMonitorRule{.name = "", .resolution = Vector2D(0, 0), .offset = Vector2D(-INT32_MAX, -INT32_MAX), .scale = -1}; // 0, 0 is preferred and -1, -1 is auto
 }
 
-SWorkspaceRule CConfigManager::getWorkspaceRuleFor(CWorkspace* pWorkspace) {
-    const auto IT = std::find_if(m_dWorkspaceRules.begin(), m_dWorkspaceRules.end(), [&](const auto& other) { return pWorkspace->matchesStaticSelector(other.workspaceString); });
-    if (IT == m_dWorkspaceRules.end())
-        return SWorkspaceRule{};
-    return *IT;
+std::vector<SWorkspaceRule> CConfigManager::getWorkspaceRulesFor(CWorkspace* pWorkspace) {
+    std::vector<SWorkspaceRule> results;
+    for (auto& rule : m_dWorkspaceRules) {
+        if (pWorkspace->matchesStaticSelector(rule.workspaceString))
+            results.push_back(rule);
+    }
+    return results;
 }
 
 std::vector<SWindowRule> CConfigManager::getMatchingRules(CWindow* pWindow, bool dynamic, bool shadowExec) {

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -105,7 +105,7 @@ class CConfigManager {
     static std::string                                              getMainConfigPath();
 
     SMonitorRule                                                    getMonitorRuleFor(const CMonitor&);
-    SWorkspaceRule                                                  getWorkspaceRuleFor(CWorkspace*);
+    std::vector<SWorkspaceRule>                                     getWorkspaceRulesFor(CWorkspace*);
     std::string                                                     getDefaultWorkspaceFor(const std::string&);
 
     CMonitor*                                                       getBoundMonitorForWS(const std::string&);

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1088,20 +1088,33 @@ float CWindow::rounding() {
 }
 
 void CWindow::updateSpecialRenderData() {
-    const auto  PWORKSPACE    = g_pCompositor->getWorkspaceByID(m_iWorkspaceID);
-    const auto  WORKSPACERULE = PWORKSPACE ? g_pConfigManager->getWorkspaceRuleFor(PWORKSPACE) : SWorkspaceRule{};
-    bool        border        = true;
+    const auto  PWORKSPACE     = g_pCompositor->getWorkspaceByID(m_iWorkspaceID);
+    const auto  WORKSPACERULES = PWORKSPACE ? g_pConfigManager->getWorkspaceRulesFor(PWORKSPACE) : std::vector<SWorkspaceRule>{};
+    bool        border         = true;
 
     static auto PNOBORDERONFLOATING = CConfigValue<Hyprlang::INT>("general:no_border_on_floating");
 
     if (m_bIsFloating && *PNOBORDERONFLOATING == 1)
         border = false;
 
-    m_sSpecialRenderData.border     = WORKSPACERULE.border.value_or(border);
-    m_sSpecialRenderData.borderSize = WORKSPACERULE.borderSize.value_or(-1);
-    m_sSpecialRenderData.decorate   = WORKSPACERULE.decorate.value_or(true);
-    m_sSpecialRenderData.rounding   = WORKSPACERULE.rounding.value_or(true);
-    m_sSpecialRenderData.shadow     = WORKSPACERULE.shadow.value_or(true);
+    m_sSpecialRenderData.border     = border;
+    m_sSpecialRenderData.borderSize = -1;
+    m_sSpecialRenderData.decorate   = true;
+    m_sSpecialRenderData.rounding   = true;
+    m_sSpecialRenderData.shadow     = true;
+
+    for (auto& wsRule : WORKSPACERULES) {
+        if (wsRule.border.has_value())
+            m_sSpecialRenderData.border = wsRule.border.value();
+        if (wsRule.borderSize.has_value())
+            m_sSpecialRenderData.borderSize = wsRule.borderSize.value();
+        if (wsRule.decorate.has_value())
+            m_sSpecialRenderData.decorate = wsRule.decorate.value();
+        if (wsRule.rounding.has_value())
+            m_sSpecialRenderData.rounding = wsRule.rounding.value();
+        if (wsRule.shadow.has_value())
+            m_sSpecialRenderData.shadow = wsRule.shadow.value();
+    }
 }
 
 int CWindow::getRealBorderSize() {

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -24,9 +24,11 @@ CWorkspace::CWorkspace(int id, int monitorID, std::string name, bool special) {
     m_vRenderOffset.registerVar();
     m_fAlpha.registerVar();
 
-    const auto RULEFORTHIS = g_pConfigManager->getWorkspaceRuleFor(this);
-    if (RULEFORTHIS.defaultName.has_value())
-        m_szName = RULEFORTHIS.defaultName.value();
+    const auto RULESFORTHIS = g_pConfigManager->getWorkspaceRulesFor(this);
+    for (auto& rule : RULESFORTHIS) {
+        if (rule.defaultName.has_value())
+            m_szName = rule.defaultName.value();
+    }
 
     g_pEventManager->postEvent({"createworkspace", m_szName});
     g_pEventManager->postEvent({"createworkspacev2", std::format("{},{}", m_iID, m_szName)});


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Make workspaces match all workspace rules instead of the first one only.
Currently if you have two workspace rules that match the same workspace like this
```
workspace = 1, monitor:WL-1, default:true
workspace = w[t1], border:no, gapsout:0
```
only the first one gets applied

This will fix that and apply all the rules.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
not really

#### Is it ready for merging, or does it need work?
ready

