### PR TITLE
Workspace/core: Refactor workspace storage

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -801,7 +801,7 @@ CWindow* CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t propert
         if (properties & FLOATING_ONLY)
             return floating(false);
 
-        const int64_t WORKSPACEID = special ? PMONITOR->activeSpecialWorkspaceID(): PMONITOR->activeWorkspaceID();
+        const int64_t WORKSPACEID = special ? PMONITOR->activeSpecialWorkspaceID() : PMONITOR->activeWorkspaceID();
         const auto    PWORKSPACE  = getWorkspaceByID(WORKSPACEID);
 
         if (PWORKSPACE->m_bHasFullscreenWindow)
@@ -2701,7 +2701,7 @@ void CCompositor::moveWindowToWorkspaceSafe(CWindow* pWindow, PHLWORKSPACE pWork
     if (!pWindow->m_bIsFloating) {
         g_pLayoutManager->getCurrentLayout()->onWindowRemovedTiling(pWindow);
         pWindow->m_pWorkspace = pWorkspace;
-        pWindow->m_iMonitorID   = pWorkspace->m_iMonitorID;
+        pWindow->m_iMonitorID = pWorkspace->m_iMonitorID;
         g_pLayoutManager->getCurrentLayout()->onWindowCreatedTiling(pWindow);
     } else {
         const auto PWINDOWMONITOR = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
@@ -2710,7 +2710,7 @@ void CCompositor::moveWindowToWorkspaceSafe(CWindow* pWindow, PHLWORKSPACE pWork
         const auto PWORKSPACEMONITOR = g_pCompositor->getMonitorFromID(pWorkspace->m_iMonitorID);
 
         pWindow->m_pWorkspace = pWorkspace;
-        pWindow->m_iMonitorID   = pWorkspace->m_iMonitorID;
+        pWindow->m_iMonitorID = pWorkspace->m_iMonitorID;
 
         pWindow->m_vRealPosition = POSTOMON + PWORKSPACEMONITOR->vecPosition;
     }

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -751,20 +751,20 @@ CWindow* CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t propert
         auto floating = [&](bool aboveFullscreen) -> CWindow* {
             for (auto& w : m_vWindows | std::views::reverse) {
 
-                if (special && !isWorkspaceSpecial(w->m_iWorkspaceID)) // because special floating may creep up into regular
+                if (special && !w->onSpecialWorkspace()) // because special floating may creep up into regular
                     continue;
 
                 const auto BB             = w->getWindowBoxUnified(properties);
                 const auto PWINDOWMONITOR = getMonitorFromID(w->m_iMonitorID);
 
                 // to avoid focusing windows behind special workspaces from other monitors
-                if (!*PSPECIALFALLTHRU && PWINDOWMONITOR && PWINDOWMONITOR->specialWorkspaceID && w->m_iWorkspaceID != PWINDOWMONITOR->specialWorkspaceID &&
+                if (!*PSPECIALFALLTHRU && PWINDOWMONITOR && PWINDOWMONITOR->activeSpecialWorkspace && w->m_pWorkspace != PWINDOWMONITOR->activeSpecialWorkspace &&
                     BB.x >= PWINDOWMONITOR->vecPosition.x && BB.y >= PWINDOWMONITOR->vecPosition.y &&
                     BB.x + BB.width <= PWINDOWMONITOR->vecPosition.x + PWINDOWMONITOR->vecSize.x && BB.y + BB.height <= PWINDOWMONITOR->vecPosition.y + PWINDOWMONITOR->vecSize.y)
                     continue;
 
                 CBox box = {BB.x - BORDER_GRAB_AREA, BB.y - BORDER_GRAB_AREA, BB.width + 2 * BORDER_GRAB_AREA, BB.height + 2 * BORDER_GRAB_AREA};
-                if (w->m_bIsFloating && w->m_bIsMapped && isWorkspaceVisible(w->m_iWorkspaceID) && !w->isHidden() && !w->m_bPinned && !w->m_sAdditionalConfigData.noFocus &&
+                if (w->m_bIsFloating && w->m_bIsMapped && isWorkspaceVisible(w->workspaceID()) && !w->isHidden() && !w->m_bPinned && !w->m_sAdditionalConfigData.noFocus &&
                     w.get() != pIgnoreWindow && (!aboveFullscreen || w->m_bCreatedOverFullscreen)) {
                     // OR windows should add focus to parent
                     if (w->m_bX11ShouldntFocus && w->m_iX11Type != 2)
@@ -801,7 +801,7 @@ CWindow* CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t propert
         if (properties & FLOATING_ONLY)
             return floating(false);
 
-        const int64_t WORKSPACEID = special ? PMONITOR->specialWorkspaceID : PMONITOR->activeWorkspace;
+        const int64_t WORKSPACEID = special ? PMONITOR->activeSpecialWorkspaceID(): PMONITOR->activeWorkspaceID();
         const auto    PWORKSPACE  = getWorkspaceByID(WORKSPACEID);
 
         if (PWORKSPACE->m_bHasFullscreenWindow)
@@ -813,10 +813,10 @@ CWindow* CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t propert
 
         // for windows, we need to check their extensions too, first.
         for (auto& w : m_vWindows) {
-            if (special != isWorkspaceSpecial(w->m_iWorkspaceID))
+            if (special != w->onSpecialWorkspace())
                 continue;
 
-            if (!w->m_bIsX11 && !w->m_bIsFloating && w->m_bIsMapped && w->m_iWorkspaceID == WORKSPACEID && !w->isHidden() && !w->m_bX11ShouldntFocus &&
+            if (!w->m_bIsX11 && !w->m_bIsFloating && w->m_bIsMapped && w->workspaceID() == WORKSPACEID && !w->isHidden() && !w->m_bX11ShouldntFocus &&
                 !w->m_sAdditionalConfigData.noFocus && w.get() != pIgnoreWindow) {
                 if (w->hasPopupAt(pos))
                     return w.get();
@@ -824,11 +824,11 @@ CWindow* CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t propert
         }
 
         for (auto& w : m_vWindows) {
-            if (special != isWorkspaceSpecial(w->m_iWorkspaceID))
+            if (special != w->onSpecialWorkspace())
                 continue;
 
             CBox box = (properties & USE_PROP_TILED) ? w->getWindowBoxUnified(properties) : CBox{w->m_vPosition, w->m_vSize};
-            if (!w->m_bIsFloating && w->m_bIsMapped && box.containsPoint(pos) && w->m_iWorkspaceID == WORKSPACEID && !w->isHidden() && !w->m_bX11ShouldntFocus &&
+            if (!w->m_bIsFloating && w->m_bIsMapped && box.containsPoint(pos) && w->workspaceID() == WORKSPACEID && !w->isHidden() && !w->m_bX11ShouldntFocus &&
                 !w->m_sAdditionalConfigData.noFocus && w.get() != pIgnoreWindow)
                 return w.get();
         }
@@ -837,10 +837,10 @@ CWindow* CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t propert
     };
 
     // special workspace
-    if (PMONITOR->specialWorkspaceID && !*PSPECIALFALLTHRU)
+    if (PMONITOR->activeSpecialWorkspace && !*PSPECIALFALLTHRU)
         return windowForWorkspace(true);
 
-    if (PMONITOR->specialWorkspaceID) {
+    if (PMONITOR->activeSpecialWorkspace) {
         const auto PWINDOW = windowForWorkspace(true);
 
         if (PWINDOW)
@@ -997,15 +997,15 @@ void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
         return;
 
     if (pWindow->m_bPinned)
-        pWindow->m_iWorkspaceID = m_pLastMonitor->activeWorkspace;
+        pWindow->m_pWorkspace = m_pLastMonitor->activeWorkspace;
 
     const auto PMONITOR = getMonitorFromID(pWindow->m_iMonitorID);
 
-    if (!isWorkspaceVisible(pWindow->m_iWorkspaceID)) {
-        const auto PWORKSPACE = getWorkspaceByID(pWindow->m_iWorkspaceID);
+    if (!isWorkspaceVisible(pWindow->workspaceID())) {
+        const auto PWORKSPACE = pWindow->m_pWorkspace;
         // This is to fix incorrect feedback on the focus history.
         PWORKSPACE->m_pLastFocusedWindow = pWindow;
-        PWORKSPACE->rememberPrevWorkspace(getWorkspaceByID(m_pLastMonitor->activeWorkspace));
+        PWORKSPACE->rememberPrevWorkspace(m_pLastMonitor->activeWorkspace);
         PMONITOR->changeWorkspace(PWORKSPACE, false, true);
         // changeworkspace already calls focusWindow
         return;
@@ -1016,7 +1016,7 @@ void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
 
     /* If special fallthrough is enabled, this behavior will be disabled, as I have no better idea of nicely tracking which
        window focuses are "via keybinds" and which ones aren't. */
-    if (PMONITOR->specialWorkspaceID && PMONITOR->specialWorkspaceID != pWindow->m_iWorkspaceID && !pWindow->m_bPinned && !*PSPECIALFALLTHROUGH)
+    if (PMONITOR->activeSpecialWorkspace && PMONITOR->activeSpecialWorkspace != pWindow->m_pWorkspace && !pWindow->m_bPinned && !*PSPECIALFALLTHROUGH)
         PMONITOR->setSpecialWorkspace(nullptr);
 
     // we need to make the PLASTWINDOW not equal to m_pLastWindow so that RENDERDATA is correct for an unfocused window
@@ -1233,7 +1233,7 @@ CWindow* CCompositor::getWindowFromZWLRHandle(wl_resource* handle) {
 
 CWindow* CCompositor::getFullscreenWindowOnWorkspace(const int& ID) {
     for (auto& w : m_vWindows) {
-        if (w->m_iWorkspaceID == ID && w->m_bIsFullscreen)
+        if (w->workspaceID() == ID && w->m_bIsFullscreen)
             return w.get();
     }
 
@@ -1242,20 +1242,20 @@ CWindow* CCompositor::getFullscreenWindowOnWorkspace(const int& ID) {
 
 bool CCompositor::isWorkspaceVisible(const int& w) {
     for (auto& m : m_vMonitors) {
-        if (m->activeWorkspace == w)
+        if (m->activeWorkspaceID() == w)
             return true;
 
-        if (m->specialWorkspaceID == w)
+        if (m->activeSpecialWorkspaceID() == w)
             return true;
     }
 
     return false;
 }
 
-CWorkspace* CCompositor::getWorkspaceByID(const int& id) {
+PHLWORKSPACE CCompositor::getWorkspaceByID(const int& id) {
     for (auto& w : m_vWorkspaces) {
-        if (w->m_iID == id)
-            return w.get();
+        if (w->m_iID == id && !w->inert())
+            return w;
     }
 
     return nullptr;
@@ -1265,7 +1265,7 @@ void CCompositor::sanityCheckWorkspaces() {
     auto it = m_vWorkspaces.begin();
     while (it != m_vWorkspaces.end()) {
 
-        const auto WORKSPACERULES = g_pConfigManager->getWorkspaceRulesFor(it->get());
+        const auto WORKSPACERULES = g_pConfigManager->getWorkspaceRulesFor(*it);
         bool       isPersistent   = false;
         for (auto& wsRule : WORKSPACERULES) {
             if (wsRule.isPersistent)
@@ -1290,10 +1290,11 @@ void CCompositor::sanityCheckWorkspaces() {
 
                     const auto PMONITOR = getMonitorFromID(WORKSPACE->m_iMonitorID);
 
-                    if (PMONITOR && PMONITOR->specialWorkspaceID == WORKSPACE->m_iID)
+                    if (PMONITOR && PMONITOR->activeSpecialWorkspace == WORKSPACE)
                         PMONITOR->setSpecialWorkspace(nullptr);
                 }
 
+                it->get()->markInert();
                 it = m_vWorkspaces.erase(it);
                 continue;
             }
@@ -1314,7 +1315,7 @@ void CCompositor::sanityCheckWorkspaces() {
 int CCompositor::getWindowsOnWorkspace(const int& id, std::optional<bool> onlyTiled) {
     int no = 0;
     for (auto& w : m_vWindows) {
-        if (w->m_iWorkspaceID == id && w->m_bIsMapped && !(onlyTiled.has_value() && !w->m_bIsFloating != onlyTiled.value()))
+        if (w->workspaceID() == id && w->m_bIsMapped && !(onlyTiled.has_value() && !w->m_bIsFloating != onlyTiled.value()))
             no++;
     }
 
@@ -1332,7 +1333,7 @@ CWindow* CCompositor::getUrgentWindow() {
 
 bool CCompositor::hasUrgentWindowOnWorkspace(const int& id) {
     for (auto& w : m_vWindows) {
-        if (w->m_iWorkspaceID == id && w->m_bIsMapped && w->m_bIsUrgent)
+        if (w->workspaceID() == id && w->m_bIsMapped && w->m_bIsUrgent)
             return true;
     }
 
@@ -1341,7 +1342,7 @@ bool CCompositor::hasUrgentWindowOnWorkspace(const int& id) {
 
 CWindow* CCompositor::getFirstWindowOnWorkspace(const int& id) {
     for (auto& w : m_vWindows) {
-        if (w->m_iWorkspaceID == id && w->m_bIsMapped && !w->isHidden())
+        if (w->workspaceID() == id && w->m_bIsMapped && !w->isHidden())
             return w.get();
     }
 
@@ -1357,7 +1358,7 @@ CWindow* CCompositor::getTopLeftWindowOnWorkspace(const int& id) {
     const auto PMONITOR = getMonitorFromID(PWORKSPACE->m_iMonitorID);
 
     for (auto& w : m_vWindows) {
-        if (w->m_iWorkspaceID != id || !w->m_bIsMapped || w->isHidden())
+        if (w->workspaceID() != id || !w->m_bIsMapped || w->isHidden())
             continue;
 
         const auto WINDOWIDEALBB = w->getWindowIdealBoundingBoxIgnoreReserved();
@@ -1575,7 +1576,7 @@ CWindow* CCompositor::getWindowInDirection(CWindow* pWindow, char dir) {
     const auto POSA  = Vector2D(WINDOWIDEALBB.x, WINDOWIDEALBB.y);
     const auto SIZEA = Vector2D(WINDOWIDEALBB.width, WINDOWIDEALBB.height);
 
-    const auto PWORKSPACE   = g_pCompositor->getWorkspaceByID(pWindow->m_iWorkspaceID);
+    const auto PWORKSPACE   = pWindow->m_pWorkspace;
     auto       leaderValue  = -1;
     CWindow*   leaderWindow = nullptr;
 
@@ -1583,10 +1584,10 @@ CWindow* CCompositor::getWindowInDirection(CWindow* pWindow, char dir) {
 
         // for tiled windows, we calc edges
         for (auto& w : m_vWindows) {
-            if (w.get() == pWindow || !w->m_bIsMapped || w->isHidden() || (!w->m_bIsFullscreen && w->m_bIsFloating) || !isWorkspaceVisible(w->m_iWorkspaceID))
+            if (w.get() == pWindow || !w->m_bIsMapped || w->isHidden() || (!w->m_bIsFullscreen && w->m_bIsFloating) || !isWorkspaceVisible(w->workspaceID()))
                 continue;
 
-            if (pWindow->m_iMonitorID == w->m_iMonitorID && pWindow->m_iWorkspaceID != w->m_iWorkspaceID)
+            if (pWindow->m_iMonitorID == w->m_iMonitorID && pWindow->m_pWorkspace != w->m_pWorkspace)
                 continue;
 
             if (PWORKSPACE->m_bHasFullscreenWindow && !w->m_bIsFullscreen && !w->m_bCreatedOverFullscreen)
@@ -1672,10 +1673,10 @@ CWindow* CCompositor::getWindowInDirection(CWindow* pWindow, char dir) {
         constexpr float THRESHOLD    = 0.3 * M_PI;
 
         for (auto& w : m_vWindows) {
-            if (w.get() == pWindow || !w->m_bIsMapped || w->isHidden() || (!w->m_bIsFullscreen && !w->m_bIsFloating) || !isWorkspaceVisible(w->m_iWorkspaceID))
+            if (w.get() == pWindow || !w->m_bIsMapped || w->isHidden() || (!w->m_bIsFullscreen && !w->m_bIsFloating) || !isWorkspaceVisible(w->workspaceID()))
                 continue;
 
-            if (pWindow->m_iMonitorID == w->m_iMonitorID && pWindow->m_iWorkspaceID != w->m_iWorkspaceID)
+            if (pWindow->m_iMonitorID == w->m_iMonitorID && pWindow->m_pWorkspace != w->m_pWorkspace)
                 continue;
 
             if (PWORKSPACE->m_bHasFullscreenWindow && !w->m_bIsFullscreen && !w->m_bCreatedOverFullscreen)
@@ -1718,7 +1719,7 @@ CWindow* CCompositor::getNextWindowOnWorkspace(CWindow* pWindow, bool focusableO
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w->m_iWorkspaceID == pWindow->m_iWorkspaceID && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sAdditionalConfigData.noFocus))
+        if (w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sAdditionalConfigData.noFocus))
             return w.get();
     }
 
@@ -1726,7 +1727,7 @@ CWindow* CCompositor::getNextWindowOnWorkspace(CWindow* pWindow, bool focusableO
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w.get() != pWindow && w->m_iWorkspaceID == pWindow->m_iWorkspaceID && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sAdditionalConfigData.noFocus))
+        if (w.get() != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sAdditionalConfigData.noFocus))
             return w.get();
     }
 
@@ -1747,7 +1748,7 @@ CWindow* CCompositor::getPrevWindowOnWorkspace(CWindow* pWindow, bool focusableO
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w->m_iWorkspaceID == pWindow->m_iWorkspaceID && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sAdditionalConfigData.noFocus))
+        if (w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sAdditionalConfigData.noFocus))
             return w.get();
     }
 
@@ -1755,7 +1756,7 @@ CWindow* CCompositor::getPrevWindowOnWorkspace(CWindow* pWindow, bool focusableO
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w.get() != pWindow && w->m_iWorkspaceID == pWindow->m_iWorkspaceID && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sAdditionalConfigData.noFocus))
+        if (w.get() != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sAdditionalConfigData.noFocus))
             return w.get();
     }
 
@@ -1772,16 +1773,16 @@ int CCompositor::getNextAvailableNamedWorkspace() {
     return lowest - 1;
 }
 
-CWorkspace* CCompositor::getWorkspaceByName(const std::string& name) {
+PHLWORKSPACE CCompositor::getWorkspaceByName(const std::string& name) {
     for (auto& w : m_vWorkspaces) {
-        if (w->m_szName == name)
-            return w.get();
+        if (w->m_szName == name && !w->inert())
+            return w;
     }
 
     return nullptr;
 }
 
-CWorkspace* CCompositor::getWorkspaceByString(const std::string& str) {
+PHLWORKSPACE CCompositor::getWorkspaceByString(const std::string& str) {
     if (str.starts_with("name:")) {
         return getWorkspaceByName(str.substr(str.find_first_of(':') + 1));
     }
@@ -1896,7 +1897,7 @@ void CCompositor::updateAllWindowsAnimatedDecorationValues() {
 
 void CCompositor::updateWorkspaceWindows(const int64_t& id) {
     for (auto& w : m_vWindows) {
-        if (!w->m_bIsMapped || w->m_iWorkspaceID != id)
+        if (!w->m_bIsMapped || w->workspaceID() != id)
             continue;
 
         w->updateDynamicRules();
@@ -1964,7 +1965,7 @@ void CCompositor::updateWindowAnimatedDecorationValues(CWindow* pWindow) {
         pWindow->m_fBorderAngleAnimationProgress.setValueAndWarp(0.f);
 
     // opacity
-    const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(pWindow->m_iWorkspaceID);
+    const auto PWORKSPACE = pWindow->m_pWorkspace;
     if (pWindow->m_bIsFullscreen && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL) {
         pWindow->m_fActiveInactiveAlpha = *PFULLSCREENALPHA;
     } else {
@@ -2020,16 +2021,16 @@ int CCompositor::getNextAvailableMonitorID(std::string const& name) {
 
 void CCompositor::swapActiveWorkspaces(CMonitor* pMonitorA, CMonitor* pMonitorB) {
 
-    const auto PWORKSPACEA = g_pCompositor->getWorkspaceByID(pMonitorA->activeWorkspace);
-    const auto PWORKSPACEB = g_pCompositor->getWorkspaceByID(pMonitorB->activeWorkspace);
+    const auto PWORKSPACEA = pMonitorA->activeWorkspace;
+    const auto PWORKSPACEB = pMonitorB->activeWorkspace;
 
     PWORKSPACEA->m_iMonitorID = pMonitorB->ID;
     PWORKSPACEA->moveToMonitor(pMonitorB->ID);
 
     for (auto& w : m_vWindows) {
-        if (w->m_iWorkspaceID == PWORKSPACEA->m_iID) {
+        if (w->m_pWorkspace == PWORKSPACEA) {
             if (w->m_bPinned) {
-                w->m_iWorkspaceID = PWORKSPACEB->m_iID;
+                w->m_pWorkspace = PWORKSPACEB;
                 continue;
             }
 
@@ -2052,9 +2053,9 @@ void CCompositor::swapActiveWorkspaces(CMonitor* pMonitorA, CMonitor* pMonitorB)
     PWORKSPACEB->moveToMonitor(pMonitorA->ID);
 
     for (auto& w : m_vWindows) {
-        if (w->m_iWorkspaceID == PWORKSPACEB->m_iID) {
+        if (w->m_pWorkspace == PWORKSPACEB) {
             if (w->m_bPinned) {
-                w->m_iWorkspaceID = PWORKSPACEA->m_iID;
+                w->m_pWorkspace = PWORKSPACEA;
                 continue;
             }
 
@@ -2073,8 +2074,8 @@ void CCompositor::swapActiveWorkspaces(CMonitor* pMonitorA, CMonitor* pMonitorB)
         }
     }
 
-    pMonitorA->activeWorkspace = PWORKSPACEB->m_iID;
-    pMonitorB->activeWorkspace = PWORKSPACEA->m_iID;
+    pMonitorA->activeWorkspace = PWORKSPACEB;
+    pMonitorB->activeWorkspace = PWORKSPACEA;
 
     PWORKSPACEA->rememberPrevWorkspace(PWORKSPACEB);
     PWORKSPACEB->rememberPrevWorkspace(PWORKSPACEA);
@@ -2099,10 +2100,10 @@ void CCompositor::swapActiveWorkspaces(CMonitor* pMonitorA, CMonitor* pMonitorB)
     // event
     g_pEventManager->postEvent(SHyprIPCEvent{"moveworkspace", PWORKSPACEA->m_szName + "," + pMonitorB->szName});
     g_pEventManager->postEvent(SHyprIPCEvent{"moveworkspacev2", std::format("{},{},{}", PWORKSPACEA->m_iID, PWORKSPACEA->m_szName, pMonitorB->szName)});
-    EMIT_HOOK_EVENT("moveWorkspace", (std::vector<void*>{PWORKSPACEA, pMonitorB}));
+    EMIT_HOOK_EVENT("moveWorkspace", (std::vector<std::any>{PWORKSPACEA, pMonitorB}));
     g_pEventManager->postEvent(SHyprIPCEvent{"moveworkspace", PWORKSPACEB->m_szName + "," + pMonitorA->szName});
     g_pEventManager->postEvent(SHyprIPCEvent{"moveworkspacev2", std::format("{},{},{}", PWORKSPACEB->m_iID, PWORKSPACEB->m_szName, pMonitorA->szName)});
-    EMIT_HOOK_EVENT("moveWorkspace", (std::vector<void*>{PWORKSPACEB, pMonitorA}));
+    EMIT_HOOK_EVENT("moveWorkspace", (std::vector<std::any>{PWORKSPACEB, pMonitorA}));
 }
 
 CMonitor* CCompositor::getMonitorFromString(const std::string& name) {
@@ -2179,9 +2180,9 @@ CMonitor* CCompositor::getMonitorFromString(const std::string& name) {
     return nullptr;
 }
 
-void CCompositor::moveWorkspaceToMonitor(CWorkspace* pWorkspace, CMonitor* pMonitor, bool noWarpCursor) {
+void CCompositor::moveWorkspaceToMonitor(PHLWORKSPACE pWorkspace, CMonitor* pMonitor, bool noWarpCursor) {
 
-    // We trust the workspace and monitor to be correct.
+    // We trust the monitor to be correct.
 
     if (pWorkspace->m_iMonitorID == pMonitor->ID)
         return;
@@ -2190,7 +2191,7 @@ void CCompositor::moveWorkspaceToMonitor(CWorkspace* pWorkspace, CMonitor* pMoni
 
     const auto POLDMON = getMonitorFromID(pWorkspace->m_iMonitorID);
 
-    const bool SWITCHINGISACTIVE = POLDMON ? POLDMON->activeWorkspace == pWorkspace->m_iID : false;
+    const bool SWITCHINGISACTIVE = POLDMON ? POLDMON->activeWorkspace == pWorkspace : false;
 
     // fix old mon
     int nextWorkspaceOnMonitorID = -1;
@@ -2227,9 +2228,9 @@ void CCompositor::moveWorkspaceToMonitor(CWorkspace* pWorkspace, CMonitor* pMoni
     pWorkspace->moveToMonitor(pMonitor->ID);
 
     for (auto& w : m_vWindows) {
-        if (w->m_iWorkspaceID == pWorkspace->m_iID) {
+        if (w->m_pWorkspace == pWorkspace) {
             if (w->m_bPinned) {
-                w->m_iWorkspaceID = nextWorkspaceOnMonitorID;
+                w->m_pWorkspace = g_pCompositor->getWorkspaceByID(nextWorkspaceOnMonitorID);
                 continue;
             }
 
@@ -2255,13 +2256,13 @@ void CCompositor::moveWorkspaceToMonitor(CWorkspace* pWorkspace, CMonitor* pMoni
     }
 
     if (SWITCHINGISACTIVE && POLDMON == g_pCompositor->m_pLastMonitor) { // if it was active, preserve its' status. If it wasn't, don't.
-        Debug::log(LOG, "moveWorkspaceToMonitor: SWITCHINGISACTIVE, active {} -> {}", pMonitor->activeWorkspace, pWorkspace->m_iID);
+        Debug::log(LOG, "moveWorkspaceToMonitor: SWITCHINGISACTIVE, active {} -> {}", pMonitor->activeWorkspaceID(), pWorkspace->m_iID);
 
-        if (const auto PWORKSPACE = getWorkspaceByID(pMonitor->activeWorkspace); PWORKSPACE)
-            getWorkspaceByID(pMonitor->activeWorkspace)->startAnim(false, false);
+        if (valid(pMonitor->activeWorkspace))
+            pMonitor->activeWorkspace->startAnim(false, false);
 
         setActiveMonitor(pMonitor);
-        pMonitor->activeWorkspace = pWorkspace->m_iID;
+        pMonitor->activeWorkspace = pWorkspace;
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(pMonitor->ID);
 
         pWorkspace->startAnim(true, true, true);
@@ -2275,7 +2276,7 @@ void CCompositor::moveWorkspaceToMonitor(CWorkspace* pWorkspace, CMonitor* pMoni
     // finalize
     if (POLDMON) {
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(POLDMON->ID);
-        updateFullscreenFadeOnWorkspace(getWorkspaceByID(POLDMON->activeWorkspace));
+        updateFullscreenFadeOnWorkspace(POLDMON->activeWorkspace);
     }
 
     updateFullscreenFadeOnWorkspace(pWorkspace);
@@ -2283,7 +2284,7 @@ void CCompositor::moveWorkspaceToMonitor(CWorkspace* pWorkspace, CMonitor* pMoni
     // event
     g_pEventManager->postEvent(SHyprIPCEvent{"moveworkspace", pWorkspace->m_szName + "," + pMonitor->szName});
     g_pEventManager->postEvent(SHyprIPCEvent{"moveworkspacev2", std::format("{},{},{}", pWorkspace->m_iID, pWorkspace->m_szName, pMonitor->szName)});
-    EMIT_HOOK_EVENT("moveWorkspace", (std::vector<void*>{pWorkspace, pMonitor}));
+    EMIT_HOOK_EVENT("moveWorkspace", (std::vector<std::any>{pWorkspace, pMonitor}));
 }
 
 bool CCompositor::workspaceIDOutOfBounds(const int64_t& id) {
@@ -2304,12 +2305,12 @@ bool CCompositor::workspaceIDOutOfBounds(const int64_t& id) {
     return std::clamp(id, lowestID, highestID) != id;
 }
 
-void CCompositor::updateFullscreenFadeOnWorkspace(CWorkspace* pWorkspace) {
+void CCompositor::updateFullscreenFadeOnWorkspace(PHLWORKSPACE pWorkspace) {
 
     const auto FULLSCREEN = pWorkspace->m_bHasFullscreenWindow;
 
     for (auto& w : g_pCompositor->m_vWindows) {
-        if (w->m_iWorkspaceID == pWorkspace->m_iID) {
+        if (w->m_pWorkspace == pWorkspace) {
 
             if (w->m_bFadingOut || w->m_bPinned || w->m_bIsFullscreen)
                 continue;
@@ -2323,7 +2324,7 @@ void CCompositor::updateFullscreenFadeOnWorkspace(CWorkspace* pWorkspace) {
 
     const auto PMONITOR = getMonitorFromID(pWorkspace->m_iMonitorID);
 
-    if (pWorkspace->m_iID == PMONITOR->activeWorkspace || pWorkspace->m_iID == PMONITOR->specialWorkspaceID) {
+    if (pWorkspace->m_iID == PMONITOR->activeWorkspaceID() || pWorkspace->m_iID == PMONITOR->activeSpecialWorkspaceID()) {
         for (auto& ls : PMONITOR->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]) {
             if (!ls->fadingOut)
                 ls->alpha = FULLSCREEN && pWorkspace->m_efFullscreenMode == FULLSCREEN_FULL ? 0.f : 1.f;
@@ -2347,7 +2348,7 @@ void CCompositor::setWindowFullscreen(CWindow* pWindow, bool on, eFullscreenMode
 
     const auto PMONITOR = getMonitorFromID(pWindow->m_iMonitorID);
 
-    const auto PWORKSPACE = getWorkspaceByID(pWindow->m_iWorkspaceID);
+    const auto PWORKSPACE = pWindow->m_pWorkspace;
 
     const auto MODE = mode == FULLSCREEN_INVALID ? PWORKSPACE->m_efFullscreenMode : mode;
 
@@ -2364,14 +2365,14 @@ void CCompositor::setWindowFullscreen(CWindow* pWindow, bool on, eFullscreenMode
 
     // make all windows on the same workspace under the fullscreen window
     for (auto& w : m_vWindows) {
-        if (w->m_iWorkspaceID == PWORKSPACE->m_iID && !w->m_bIsFullscreen && !w->m_bFadingOut && !w->m_bPinned)
+        if (w->m_pWorkspace == PWORKSPACE && !w->m_bIsFullscreen && !w->m_bFadingOut && !w->m_bPinned)
             w->m_bCreatedOverFullscreen = false;
     }
     updateFullscreenFadeOnWorkspace(PWORKSPACE);
 
     g_pXWaylandManager->setWindowSize(pWindow, pWindow->m_vRealSize.goal(), true);
 
-    forceReportSizesToWindowsOnWorkspace(pWindow->m_iWorkspaceID);
+    forceReportSizesToWindowsOnWorkspace(pWindow->workspaceID());
 
     g_pInputManager->recheckIdleInhibitorStatus();
 
@@ -2398,7 +2399,7 @@ CWindow* CCompositor::getX11Parent(CWindow* pWindow) {
 
 void CCompositor::updateWorkspaceWindowDecos(const int& id) {
     for (auto& w : m_vWindows) {
-        if (w->m_iWorkspaceID != id)
+        if (w->workspaceID() != id)
             continue;
 
         w->updateWindowDecos();
@@ -2440,7 +2441,7 @@ CWindow* CCompositor::getWindowByRegex(const std::string& regexp) {
         const bool FLOAT = regexp.starts_with("floating");
 
         for (auto& w : m_vWindows) {
-            if (!w->m_bIsMapped || w->m_bIsFloating != FLOAT || w->m_iWorkspaceID != m_pLastWindow->m_iWorkspaceID || w->isHidden())
+            if (!w->m_bIsMapped || w->m_bIsFloating != FLOAT || w->m_pWorkspace != m_pLastWindow->m_pWorkspace || w->isHidden())
                 continue;
 
             return w.get();
@@ -2608,13 +2609,13 @@ Vector2D CCompositor::parseWindowVectorArgsRelative(const std::string& args, con
 
 void CCompositor::forceReportSizesToWindowsOnWorkspace(const int& wid) {
     for (auto& w : m_vWindows) {
-        if (w->m_iWorkspaceID == wid && w->m_bIsMapped && !w->isHidden()) {
+        if (w->workspaceID() == wid && w->m_bIsMapped && !w->isHidden()) {
             g_pXWaylandManager->setWindowSize(w.get(), w->m_vRealSize.value(), true);
         }
     }
 }
 
-CWorkspace* CCompositor::createNewWorkspace(const int& id, const int& monid, const std::string& name) {
+PHLWORKSPACE CCompositor::createNewWorkspace(const int& id, const int& monid, const std::string& name) {
     const auto NAME  = name == "" ? std::to_string(id) : name;
     auto       monID = monid;
 
@@ -2625,7 +2626,7 @@ CWorkspace* CCompositor::createNewWorkspace(const int& id, const int& monid, con
 
     const bool SPECIAL = id >= SPECIAL_WORKSPACE_START && id <= -2;
 
-    const auto PWORKSPACE = m_vWorkspaces.emplace_back(std::make_unique<CWorkspace>(id, monID, NAME, SPECIAL)).get();
+    const auto PWORKSPACE = m_vWorkspaces.emplace_back(CWorkspace::create(id, monID, NAME, SPECIAL));
 
     PWORKSPACE->m_fAlpha.setValueAndWarp(0);
 
@@ -2656,7 +2657,7 @@ void CCompositor::setActiveMonitor(CMonitor* pMonitor) {
         return;
     }
 
-    const auto PWORKSPACE = getWorkspaceByID(pMonitor->activeWorkspace);
+    const auto PWORKSPACE = pMonitor->activeWorkspace;
 
     g_pEventManager->postEvent(SHyprIPCEvent{"focusedmon", pMonitor->szName + "," + (PWORKSPACE ? PWORKSPACE->m_szName : "?")});
     EMIT_HOOK_EVENT("focusedMon", pMonitor);
@@ -2682,7 +2683,7 @@ void CCompositor::performUserChecks() {
     ; // intentional
 }
 
-void CCompositor::moveWindowToWorkspaceSafe(CWindow* pWindow, CWorkspace* pWorkspace) {
+void CCompositor::moveWindowToWorkspaceSafe(CWindow* pWindow, PHLWORKSPACE pWorkspace) {
     if (!pWindow || !pWorkspace)
         return;
 
@@ -2690,16 +2691,16 @@ void CCompositor::moveWindowToWorkspaceSafe(CWindow* pWindow, CWorkspace* pWorks
         return;
 
     const bool FULLSCREEN     = pWindow->m_bIsFullscreen;
-    const auto FULLSCREENMODE = getWorkspaceByID(pWindow->m_iWorkspaceID)->m_efFullscreenMode;
+    const auto FULLSCREENMODE = pWindow->m_pWorkspace->m_efFullscreenMode;
 
     if (FULLSCREEN)
         setWindowFullscreen(pWindow, false, FULLSCREEN_FULL);
 
-    pWindow->moveToWorkspace(pWorkspace->m_iID);
+    pWindow->moveToWorkspace(pWorkspace);
 
     if (!pWindow->m_bIsFloating) {
         g_pLayoutManager->getCurrentLayout()->onWindowRemovedTiling(pWindow);
-        pWindow->m_iWorkspaceID = pWorkspace->m_iID;
+        pWindow->m_pWorkspace = pWorkspace;
         pWindow->m_iMonitorID   = pWorkspace->m_iMonitorID;
         g_pLayoutManager->getCurrentLayout()->onWindowCreatedTiling(pWindow);
     } else {
@@ -2708,7 +2709,7 @@ void CCompositor::moveWindowToWorkspaceSafe(CWindow* pWindow, CWorkspace* pWorks
 
         const auto PWORKSPACEMONITOR = g_pCompositor->getMonitorFromID(pWorkspace->m_iMonitorID);
 
-        pWindow->m_iWorkspaceID = pWorkspace->m_iID;
+        pWindow->m_pWorkspace = pWorkspace;
         pWindow->m_iMonitorID   = pWorkspace->m_iMonitorID;
 
         pWindow->m_vRealPosition = POSTOMON + PWORKSPACEMONITOR->vecPosition;
@@ -2721,7 +2722,7 @@ void CCompositor::moveWindowToWorkspaceSafe(CWindow* pWindow, CWorkspace* pWorks
     if (pWindow->m_sGroupData.pNextWindow) {
         CWindow* next = pWindow->m_sGroupData.pNextWindow;
         while (next != pWindow) {
-            next->moveToWorkspace(pWorkspace->m_iID);
+            next->moveToWorkspace(pWorkspace);
             next->updateToplevel();
             next = next->m_sGroupData.pNextWindow;
         }
@@ -2731,12 +2732,12 @@ void CCompositor::moveWindowToWorkspaceSafe(CWindow* pWindow, CWorkspace* pWorks
         setWindowFullscreen(pWindow, true, FULLSCREENMODE);
 
     g_pCompositor->updateWorkspaceWindows(pWorkspace->m_iID);
-    g_pCompositor->updateWorkspaceWindows(pWindow->m_iWorkspaceID);
+    g_pCompositor->updateWorkspaceWindows(pWindow->workspaceID());
 }
 
 CWindow* CCompositor::getForceFocus() {
     for (auto& w : m_vWindows) {
-        if (!w->m_bIsMapped || w->isHidden() || !isWorkspaceVisible(w->m_iWorkspaceID))
+        if (!w->m_bIsMapped || w->isHidden() || !isWorkspaceVisible(w->workspaceID()))
             continue;
 
         if (!w->m_bStayFocused)
@@ -2885,6 +2886,6 @@ void CCompositor::updateSuspendedStates() {
         if (!w->m_bIsMapped)
             continue;
 
-        w->setSuspended(w->isHidden() || !isWorkspaceVisible(w->m_iWorkspaceID));
+        w->setSuspended(w->isHidden() || !isWorkspaceVisible(w->workspaceID()));
     }
 }

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -92,7 +92,7 @@ class CCompositor {
     std::vector<std::shared_ptr<CMonitor>>    m_vMonitors;
     std::vector<std::shared_ptr<CMonitor>>    m_vRealMonitors; // for all monitors, even those turned off
     std::vector<std::unique_ptr<CWindow>>     m_vWindows;
-    std::vector<std::unique_ptr<CWorkspace>>  m_vWorkspaces;
+    std::vector<PHLWORKSPACE>                 m_vWorkspaces;
     std::vector<CWindow*>                     m_vWindowsFadingOut;
     std::vector<SLayerSurface*>               m_vSurfacesFadingOut;
 
@@ -145,9 +145,9 @@ class CCompositor {
     CWindow*       getWindowFromHandle(uint32_t);
     CWindow*       getWindowFromZWLRHandle(wl_resource*);
     bool           isWorkspaceVisible(const int&);
-    CWorkspace*    getWorkspaceByID(const int&);
-    CWorkspace*    getWorkspaceByName(const std::string&);
-    CWorkspace*    getWorkspaceByString(const std::string&);
+    PHLWORKSPACE   getWorkspaceByID(const int&);
+    PHLWORKSPACE   getWorkspaceByName(const std::string&);
+    PHLWORKSPACE   getWorkspaceByString(const std::string&);
     void           sanityCheckWorkspaces();
     void           updateWorkspaceWindowDecos(const int&);
     int            getWindowsOnWorkspace(const int& id, std::optional<bool> onlyTiled = {});
@@ -172,12 +172,12 @@ class CCompositor {
     void           updateWorkspaceWindows(const int64_t& id);
     void           updateWindowAnimatedDecorationValues(CWindow*);
     int            getNextAvailableMonitorID(std::string const& name);
-    void           moveWorkspaceToMonitor(CWorkspace*, CMonitor*, bool noWarpCursor = false);
+    void           moveWorkspaceToMonitor(PHLWORKSPACE, CMonitor*, bool noWarpCursor = false);
     void           swapActiveWorkspaces(CMonitor*, CMonitor*);
     CMonitor*      getMonitorFromString(const std::string&);
     bool           workspaceIDOutOfBounds(const int64_t&);
     void           setWindowFullscreen(CWindow*, bool, eFullscreenMode mode = FULLSCREEN_INVALID);
-    void           updateFullscreenFadeOnWorkspace(CWorkspace*);
+    void           updateFullscreenFadeOnWorkspace(PHLWORKSPACE);
     CWindow*       getX11Parent(CWindow*);
     void           scheduleFrameForMonitor(CMonitor*);
     void           addToFadingOutSafe(SLayerSurface*);
@@ -189,13 +189,13 @@ class CCompositor {
     void           closeWindow(CWindow*);
     Vector2D       parseWindowVectorArgsRelative(const std::string&, const Vector2D&);
     void           forceReportSizesToWindowsOnWorkspace(const int&);
-    CWorkspace*    createNewWorkspace(const int&, const int&, const std::string& name = ""); // will be deleted next frame if left empty and unfocused!
+    PHLWORKSPACE   createNewWorkspace(const int&, const int&, const std::string& name = ""); // will be deleted next frame if left empty and unfocused!
     void           renameWorkspace(const int&, const std::string& name = "");
     void           setActiveMonitor(CMonitor*);
     bool           isWorkspaceSpecial(const int&);
     int            getNewSpecialID();
     void           performUserChecks();
-    void           moveWindowToWorkspaceSafe(CWindow* pWindow, CWorkspace* pWorkspace);
+    void           moveWindowToWorkspaceSafe(CWindow* pWindow, PHLWORKSPACE pWorkspace);
     CWindow*       getForceFocus();
     void           notifyIdleActivity();
     void           setIdleActivityInhibit(bool inhibit);

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -956,7 +956,7 @@ SMonitorRule CConfigManager::getMonitorRuleFor(const CMonitor& PMONITOR) {
     return SMonitorRule{.name = "", .resolution = Vector2D(0, 0), .offset = Vector2D(-INT32_MAX, -INT32_MAX), .scale = -1}; // 0, 0 is preferred and -1, -1 is auto
 }
 
-std::vector<SWorkspaceRule> CConfigManager::getWorkspaceRulesFor(CWorkspace* pWorkspace) {
+std::vector<SWorkspaceRule> CConfigManager::getWorkspaceRulesFor(PHLWORKSPACE pWorkspace) {
     std::vector<SWorkspaceRule> results;
     for (auto& rule : m_dWorkspaceRules) {
         if (pWorkspace->matchesStaticSelector(rule.workspaceString))
@@ -1056,13 +1056,13 @@ std::vector<SWindowRule> CConfigManager::getMatchingRules(CWindow* pWindow, bool
                 }
 
                 if (!rule.szOnWorkspace.empty()) {
-                    const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(pWindow->m_iWorkspaceID);
+                    const auto PWORKSPACE = pWindow->m_pWorkspace;
                     if (!PWORKSPACE || !PWORKSPACE->matchesStaticSelector(rule.szOnWorkspace))
                         continue;
                 }
 
                 if (!rule.szWorkspace.empty()) {
-                    const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(pWindow->m_iWorkspaceID);
+                    const auto PWORKSPACE = pWindow->m_pWorkspace;
 
                     if (!PWORKSPACE)
                         continue;
@@ -1287,7 +1287,7 @@ void CConfigManager::ensureVRR(CMonitor* pMonitor) {
             /* fullscreen */
             m->vrrActive = true;
 
-            const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(m->activeWorkspace);
+            const auto PWORKSPACE = m->activeWorkspace;
 
             if (!PWORKSPACE)
                 return; // ???

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -105,7 +105,7 @@ class CConfigManager {
     static std::string                                              getMainConfigPath();
 
     SMonitorRule                                                    getMonitorRuleFor(const CMonitor&);
-    std::vector<SWorkspaceRule>                                     getWorkspaceRulesFor(CWorkspace*);
+    std::vector<SWorkspaceRule>                                     getWorkspaceRulesFor(PHLWORKSPACE workspace);
     std::string                                                     getDefaultWorkspaceFor(const std::string&);
 
     CMonitor*                                                       getBoundMonitorForWS(const std::string&);

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -24,15 +24,6 @@ static void trimTrailingComma(std::string& str) {
         str.pop_back();
 }
 
-static std::string getWorkspaceNameFromSpecialID(const int workspaceID) {
-    if (workspaceID == 0)
-        return "";
-    const auto* workspace = g_pCompositor->getWorkspaceByID(workspaceID);
-    if (!workspace)
-        return "";
-    return workspace->m_szName;
-}
-
 static std::string formatToString(uint32_t drmFormat) {
     switch (drmFormat) {
         case DRM_FORMAT_XRGB2101010: return "XRGB2101010";
@@ -116,8 +107,8 @@ std::string monitorsRequest(eHyprCtlOutputFormat format, std::string request) {
 }},)#",
                 m->ID, escapeJSONStrings(m->szName), escapeJSONStrings(m->szShortDescription), (m->output->make ? m->output->make : ""), (m->output->model ? m->output->model : ""),
                 (m->output->serial ? m->output->serial : ""), (int)m->vecPixelSize.x, (int)m->vecPixelSize.y, m->refreshRate, (int)m->vecPosition.x, (int)m->vecPosition.y,
-                m->activeWorkspace, (m->activeWorkspace == -1 ? "" : escapeJSONStrings(g_pCompositor->getWorkspaceByID(m->activeWorkspace)->m_szName)), m->specialWorkspaceID,
-                escapeJSONStrings(getWorkspaceNameFromSpecialID(m->specialWorkspaceID)), (int)m->vecReservedTopLeft.x, (int)m->vecReservedTopLeft.y,
+                m->activeWorkspaceID(), (!m->activeWorkspace ? "" : escapeJSONStrings(m->activeWorkspace->m_szName)), m->activeSpecialWorkspaceID()  ,
+                escapeJSONStrings(m->activeSpecialWorkspace ? m->activeSpecialWorkspace->m_szName : ""), (int)m->vecReservedTopLeft.x, (int)m->vecReservedTopLeft.y,
                 (int)m->vecReservedBottomRight.x, (int)m->vecReservedBottomRight.y, m->scale, (int)m->transform, (m.get() == g_pCompositor->m_pLastMonitor ? "true" : "false"),
                 (m->dpmsStatus ? "true" : "false"), (m->output->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED ? "true" : "false"),
                 m->tearingState.activelyTearing ? "true" : "false", formatToString(m->drmFormat), availableModesForOutput(m.get(), format));
@@ -137,9 +128,9 @@ std::string monitorsRequest(eHyprCtlOutputFormat format, std::string request) {
                             "{} {} {}\n\tscale: {:.2f}\n\ttransform: "
                             "{}\n\tfocused: {}\n\tdpmsStatus: {}\n\tvrr: {}\n\tactivelyTearing: {}\n\tcurrentFormat: {}\n\tavailableModes: {}\n\n",
                             m->szName, m->ID, (int)m->vecPixelSize.x, (int)m->vecPixelSize.y, m->refreshRate, (int)m->vecPosition.x, (int)m->vecPosition.y, m->szShortDescription,
-                            (m->output->make ? m->output->make : ""), (m->output->model ? m->output->model : ""), (m->output->serial ? m->output->serial : ""), m->activeWorkspace,
-                            (m->activeWorkspace == -1 ? "" : g_pCompositor->getWorkspaceByID(m->activeWorkspace)->m_szName), m->specialWorkspaceID,
-                            getWorkspaceNameFromSpecialID(m->specialWorkspaceID), (int)m->vecReservedTopLeft.x, (int)m->vecReservedTopLeft.y, (int)m->vecReservedBottomRight.x,
+                            (m->output->make ? m->output->make : ""), (m->output->model ? m->output->model : ""), (m->output->serial ? m->output->serial : ""), m->activeWorkspaceID(),
+                            (!m->activeWorkspace ? "" : m->activeWorkspace->m_szName), m->activeSpecialWorkspaceID(),
+                            (m->activeSpecialWorkspace ? m->activeSpecialWorkspace->m_szName : ""), (int)m->vecReservedTopLeft.x, (int)m->vecReservedTopLeft.y, (int)m->vecReservedBottomRight.x,
                             (int)m->vecReservedBottomRight.y, m->scale, (int)m->transform, (m.get() == g_pCompositor->m_pLastMonitor ? "yes" : "no"), (int)m->dpmsStatus,
                             (int)(m->output->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED), m->tearingState.activelyTearing, formatToString(m->drmFormat),
                             availableModesForOutput(m.get(), format));
@@ -211,14 +202,12 @@ static std::string getWindowData(CWindow* w, eHyprCtlOutputFormat format) {
     "focusHistoryID": {}
 }},)#",
             (uintptr_t)w, (w->m_bIsMapped ? "true" : "false"), (w->isHidden() ? "true" : "false"), (int)w->m_vRealPosition.goal().x, (int)w->m_vRealPosition.goal().y,
-            (int)w->m_vRealSize.goal().x, (int)w->m_vRealSize.goal().y, w->m_iWorkspaceID,
-            escapeJSONStrings(w->m_iWorkspaceID == -1                                ? "" :
-                                  g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID) ? g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID)->m_szName :
-                                                                                       std::string("Invalid workspace " + std::to_string(w->m_iWorkspaceID))),
+            (int)w->m_vRealSize.goal().x, (int)w->m_vRealSize.goal().y, w->m_pWorkspace ? w->workspaceID() : WORKSPACE_INVALID,
+            escapeJSONStrings(!w->m_pWorkspace                                ? "" : w->m_pWorkspace->m_szName),
             ((int)w->m_bIsFloating == 1 ? "true" : "false"), (int64_t)w->m_iMonitorID, escapeJSONStrings(g_pXWaylandManager->getAppIDClass(w)),
             escapeJSONStrings(g_pXWaylandManager->getTitle(w)), escapeJSONStrings(w->m_szInitialClass), escapeJSONStrings(w->m_szInitialTitle), w->getPID(),
             ((int)w->m_bIsX11 == 1 ? "true" : "false"), (w->m_bPinned ? "true" : "false"), (w->m_bIsFullscreen ? "true" : "false"),
-            (w->m_bIsFullscreen ? (g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID) ? (int)g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID)->m_efFullscreenMode : 0) : 0),
+            (w->m_bIsFullscreen ? (w->m_pWorkspace ? (int)w->m_pWorkspace->m_efFullscreenMode : 0) : 0),
             w->m_bFakeFullscreenState ? "true" : "false", getGroupedData(w, format), (uintptr_t)w->m_pSwallowed, getFocusHistoryID(w));
     } else {
         return std::format(
@@ -227,13 +216,11 @@ static std::string getWindowData(CWindow* w, eHyprCtlOutputFormat format) {
             "{}\n\txwayland: {}\n\tpinned: "
             "{}\n\tfullscreen: {}\n\tfullscreenmode: {}\n\tfakefullscreen: {}\n\tgrouped: {}\n\tswallowing: {:x}\n\tfocusHistoryID: {}\n\n",
             (uintptr_t)w, w->m_szTitle, (int)w->m_bIsMapped, (int)w->isHidden(), (int)w->m_vRealPosition.goal().x, (int)w->m_vRealPosition.goal().y, (int)w->m_vRealSize.goal().x,
-            (int)w->m_vRealSize.goal().y, w->m_iWorkspaceID,
-            (w->m_iWorkspaceID == -1                                ? "" :
-                 g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID) ? g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID)->m_szName :
-                                                                      std::string("Invalid workspace " + std::to_string(w->m_iWorkspaceID))),
+            (int)w->m_vRealSize.goal().y, w->m_pWorkspace ? w->workspaceID() : WORKSPACE_INVALID,
+            (!w->m_pWorkspace                                ? "" : std::to_string(w->workspaceID())),
             (int)w->m_bIsFloating, (int64_t)w->m_iMonitorID, g_pXWaylandManager->getAppIDClass(w), g_pXWaylandManager->getTitle(w), w->m_szInitialClass, w->m_szInitialTitle,
             w->getPID(), (int)w->m_bIsX11, (int)w->m_bPinned, (int)w->m_bIsFullscreen,
-            (w->m_bIsFullscreen ? (g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID) ? g_pCompositor->getWorkspaceByID(w->m_iWorkspaceID)->m_efFullscreenMode : 0) : 0),
+            (w->m_bIsFullscreen ? (w->m_pWorkspace ? w->m_pWorkspace->m_efFullscreenMode : 0) : 0),
             (int)w->m_bFakeFullscreenState, getGroupedData(w, format), (uintptr_t)w->m_pSwallowed, getFocusHistoryID(w));
     }
 }
@@ -264,7 +251,7 @@ std::string clientsRequest(eHyprCtlOutputFormat format, std::string request) {
     return result;
 }
 
-static std::string getWorkspaceData(CWorkspace* w, eHyprCtlOutputFormat format) {
+static std::string getWorkspaceData(PHLWORKSPACE w, eHyprCtlOutputFormat format) {
     const auto PLASTW   = w->getLastFocusedWindow();
     const auto PMONITOR = g_pCompositor->getMonitorFromID(w->m_iMonitorID);
     if (format == eHyprCtlOutputFormat::FORMAT_JSON) {
@@ -339,9 +326,9 @@ std::string activeWorkspaceRequest(eHyprCtlOutputFormat format, std::string requ
         return "unsafe state";
 
     std::string result = "";
-    auto        w      = g_pCompositor->getWorkspaceByID(g_pCompositor->m_pLastMonitor->activeWorkspace);
+    auto        w      = g_pCompositor->m_pLastMonitor->activeWorkspace;
 
-    if (!w)
+    if (!valid(w))
         return "internal error";
 
     return getWorkspaceData(w, format);
@@ -353,7 +340,7 @@ std::string workspacesRequest(eHyprCtlOutputFormat format, std::string request) 
     if (format == eHyprCtlOutputFormat::FORMAT_JSON) {
         result += "[";
         for (auto& w : g_pCompositor->m_vWorkspaces) {
-            result += getWorkspaceData(w.get(), format);
+            result += getWorkspaceData(w, format);
             result += ",";
         }
 
@@ -361,7 +348,7 @@ std::string workspacesRequest(eHyprCtlOutputFormat format, std::string request) 
         result += "]";
     } else {
         for (auto& w : g_pCompositor->m_vWorkspaces) {
-            result += getWorkspaceData(w.get(), format);
+            result += getWorkspaceData(w, format);
         }
     }
 

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -107,7 +107,7 @@ std::string monitorsRequest(eHyprCtlOutputFormat format, std::string request) {
 }},)#",
                 m->ID, escapeJSONStrings(m->szName), escapeJSONStrings(m->szShortDescription), (m->output->make ? m->output->make : ""), (m->output->model ? m->output->model : ""),
                 (m->output->serial ? m->output->serial : ""), (int)m->vecPixelSize.x, (int)m->vecPixelSize.y, m->refreshRate, (int)m->vecPosition.x, (int)m->vecPosition.y,
-                m->activeWorkspaceID(), (!m->activeWorkspace ? "" : escapeJSONStrings(m->activeWorkspace->m_szName)), m->activeSpecialWorkspaceID()  ,
+                m->activeWorkspaceID(), (!m->activeWorkspace ? "" : escapeJSONStrings(m->activeWorkspace->m_szName)), m->activeSpecialWorkspaceID(),
                 escapeJSONStrings(m->activeSpecialWorkspace ? m->activeSpecialWorkspace->m_szName : ""), (int)m->vecReservedTopLeft.x, (int)m->vecReservedTopLeft.y,
                 (int)m->vecReservedBottomRight.x, (int)m->vecReservedBottomRight.y, m->scale, (int)m->transform, (m.get() == g_pCompositor->m_pLastMonitor ? "true" : "false"),
                 (m->dpmsStatus ? "true" : "false"), (m->output->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED ? "true" : "false"),
@@ -122,18 +122,17 @@ std::string monitorsRequest(eHyprCtlOutputFormat format, std::string request) {
             if (!m->output || m->ID == -1ull)
                 continue;
 
-            result +=
-                std::format("Monitor {} (ID {}):\n\t{}x{}@{:.5f} at {}x{}\n\tdescription: {}\n\tmake: {}\n\tmodel: {}\n\tserial: {}\n\tactive workspace: {} ({})\n\tspecial "
-                            "workspace: {} ({})\n\treserved: {} "
-                            "{} {} {}\n\tscale: {:.2f}\n\ttransform: "
-                            "{}\n\tfocused: {}\n\tdpmsStatus: {}\n\tvrr: {}\n\tactivelyTearing: {}\n\tcurrentFormat: {}\n\tavailableModes: {}\n\n",
-                            m->szName, m->ID, (int)m->vecPixelSize.x, (int)m->vecPixelSize.y, m->refreshRate, (int)m->vecPosition.x, (int)m->vecPosition.y, m->szShortDescription,
-                            (m->output->make ? m->output->make : ""), (m->output->model ? m->output->model : ""), (m->output->serial ? m->output->serial : ""), m->activeWorkspaceID(),
-                            (!m->activeWorkspace ? "" : m->activeWorkspace->m_szName), m->activeSpecialWorkspaceID(),
-                            (m->activeSpecialWorkspace ? m->activeSpecialWorkspace->m_szName : ""), (int)m->vecReservedTopLeft.x, (int)m->vecReservedTopLeft.y, (int)m->vecReservedBottomRight.x,
-                            (int)m->vecReservedBottomRight.y, m->scale, (int)m->transform, (m.get() == g_pCompositor->m_pLastMonitor ? "yes" : "no"), (int)m->dpmsStatus,
-                            (int)(m->output->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED), m->tearingState.activelyTearing, formatToString(m->drmFormat),
-                            availableModesForOutput(m.get(), format));
+            result += std::format(
+                "Monitor {} (ID {}):\n\t{}x{}@{:.5f} at {}x{}\n\tdescription: {}\n\tmake: {}\n\tmodel: {}\n\tserial: {}\n\tactive workspace: {} ({})\n\tspecial "
+                "workspace: {} ({})\n\treserved: {} "
+                "{} {} {}\n\tscale: {:.2f}\n\ttransform: "
+                "{}\n\tfocused: {}\n\tdpmsStatus: {}\n\tvrr: {}\n\tactivelyTearing: {}\n\tcurrentFormat: {}\n\tavailableModes: {}\n\n",
+                m->szName, m->ID, (int)m->vecPixelSize.x, (int)m->vecPixelSize.y, m->refreshRate, (int)m->vecPosition.x, (int)m->vecPosition.y, m->szShortDescription,
+                (m->output->make ? m->output->make : ""), (m->output->model ? m->output->model : ""), (m->output->serial ? m->output->serial : ""), m->activeWorkspaceID(),
+                (!m->activeWorkspace ? "" : m->activeWorkspace->m_szName), m->activeSpecialWorkspaceID(), (m->activeSpecialWorkspace ? m->activeSpecialWorkspace->m_szName : ""),
+                (int)m->vecReservedTopLeft.x, (int)m->vecReservedTopLeft.y, (int)m->vecReservedBottomRight.x, (int)m->vecReservedBottomRight.y, m->scale, (int)m->transform,
+                (m.get() == g_pCompositor->m_pLastMonitor ? "yes" : "no"), (int)m->dpmsStatus, (int)(m->output->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED),
+                m->tearingState.activelyTearing, formatToString(m->drmFormat), availableModesForOutput(m.get(), format));
         }
     }
 
@@ -203,25 +202,22 @@ static std::string getWindowData(CWindow* w, eHyprCtlOutputFormat format) {
 }},)#",
             (uintptr_t)w, (w->m_bIsMapped ? "true" : "false"), (w->isHidden() ? "true" : "false"), (int)w->m_vRealPosition.goal().x, (int)w->m_vRealPosition.goal().y,
             (int)w->m_vRealSize.goal().x, (int)w->m_vRealSize.goal().y, w->m_pWorkspace ? w->workspaceID() : WORKSPACE_INVALID,
-            escapeJSONStrings(!w->m_pWorkspace                                ? "" : w->m_pWorkspace->m_szName),
-            ((int)w->m_bIsFloating == 1 ? "true" : "false"), (int64_t)w->m_iMonitorID, escapeJSONStrings(g_pXWaylandManager->getAppIDClass(w)),
-            escapeJSONStrings(g_pXWaylandManager->getTitle(w)), escapeJSONStrings(w->m_szInitialClass), escapeJSONStrings(w->m_szInitialTitle), w->getPID(),
-            ((int)w->m_bIsX11 == 1 ? "true" : "false"), (w->m_bPinned ? "true" : "false"), (w->m_bIsFullscreen ? "true" : "false"),
-            (w->m_bIsFullscreen ? (w->m_pWorkspace ? (int)w->m_pWorkspace->m_efFullscreenMode : 0) : 0),
+            escapeJSONStrings(!w->m_pWorkspace ? "" : w->m_pWorkspace->m_szName), ((int)w->m_bIsFloating == 1 ? "true" : "false"), (int64_t)w->m_iMonitorID,
+            escapeJSONStrings(g_pXWaylandManager->getAppIDClass(w)), escapeJSONStrings(g_pXWaylandManager->getTitle(w)), escapeJSONStrings(w->m_szInitialClass),
+            escapeJSONStrings(w->m_szInitialTitle), w->getPID(), ((int)w->m_bIsX11 == 1 ? "true" : "false"), (w->m_bPinned ? "true" : "false"),
+            (w->m_bIsFullscreen ? "true" : "false"), (w->m_bIsFullscreen ? (w->m_pWorkspace ? (int)w->m_pWorkspace->m_efFullscreenMode : 0) : 0),
             w->m_bFakeFullscreenState ? "true" : "false", getGroupedData(w, format), (uintptr_t)w->m_pSwallowed, getFocusHistoryID(w));
     } else {
-        return std::format(
-            "Window {:x} -> {}:\n\tmapped: {}\n\thidden: {}\n\tat: {},{}\n\tsize: {},{}\n\tworkspace: {} ({})\n\tfloating: {}\n\tmonitor: {}\n\tclass: {}\n\ttitle: "
-            "{}\n\tinitialClass: {}\n\tinitialTitle: {}\n\tpid: "
-            "{}\n\txwayland: {}\n\tpinned: "
-            "{}\n\tfullscreen: {}\n\tfullscreenmode: {}\n\tfakefullscreen: {}\n\tgrouped: {}\n\tswallowing: {:x}\n\tfocusHistoryID: {}\n\n",
-            (uintptr_t)w, w->m_szTitle, (int)w->m_bIsMapped, (int)w->isHidden(), (int)w->m_vRealPosition.goal().x, (int)w->m_vRealPosition.goal().y, (int)w->m_vRealSize.goal().x,
-            (int)w->m_vRealSize.goal().y, w->m_pWorkspace ? w->workspaceID() : WORKSPACE_INVALID,
-            (!w->m_pWorkspace                                ? "" : std::to_string(w->workspaceID())),
-            (int)w->m_bIsFloating, (int64_t)w->m_iMonitorID, g_pXWaylandManager->getAppIDClass(w), g_pXWaylandManager->getTitle(w), w->m_szInitialClass, w->m_szInitialTitle,
-            w->getPID(), (int)w->m_bIsX11, (int)w->m_bPinned, (int)w->m_bIsFullscreen,
-            (w->m_bIsFullscreen ? (w->m_pWorkspace ? w->m_pWorkspace->m_efFullscreenMode : 0) : 0),
-            (int)w->m_bFakeFullscreenState, getGroupedData(w, format), (uintptr_t)w->m_pSwallowed, getFocusHistoryID(w));
+        return std::format("Window {:x} -> {}:\n\tmapped: {}\n\thidden: {}\n\tat: {},{}\n\tsize: {},{}\n\tworkspace: {} ({})\n\tfloating: {}\n\tmonitor: {}\n\tclass: {}\n\ttitle: "
+                           "{}\n\tinitialClass: {}\n\tinitialTitle: {}\n\tpid: "
+                           "{}\n\txwayland: {}\n\tpinned: "
+                           "{}\n\tfullscreen: {}\n\tfullscreenmode: {}\n\tfakefullscreen: {}\n\tgrouped: {}\n\tswallowing: {:x}\n\tfocusHistoryID: {}\n\n",
+                           (uintptr_t)w, w->m_szTitle, (int)w->m_bIsMapped, (int)w->isHidden(), (int)w->m_vRealPosition.goal().x, (int)w->m_vRealPosition.goal().y,
+                           (int)w->m_vRealSize.goal().x, (int)w->m_vRealSize.goal().y, w->m_pWorkspace ? w->workspaceID() : WORKSPACE_INVALID,
+                           (!w->m_pWorkspace ? "" : std::to_string(w->workspaceID())), (int)w->m_bIsFloating, (int64_t)w->m_iMonitorID, g_pXWaylandManager->getAppIDClass(w),
+                           g_pXWaylandManager->getTitle(w), w->m_szInitialClass, w->m_szInitialTitle, w->getPID(), (int)w->m_bIsX11, (int)w->m_bPinned, (int)w->m_bIsFullscreen,
+                           (w->m_bIsFullscreen ? (w->m_pWorkspace ? w->m_pWorkspace->m_efFullscreenMode : 0) : 0), (int)w->m_bFakeFullscreenState, getGroupedData(w, format),
+                           (uintptr_t)w->m_pSwallowed, getFocusHistoryID(w));
     }
 }
 

--- a/src/desktop/DesktopTypes.hpp
+++ b/src/desktop/DesktopTypes.hpp
@@ -1,0 +1,6 @@
+#pragma once
+#include <memory>
+
+class CWorkspace;
+
+typedef std::shared_ptr<CWorkspace> PHLWORKSPACE;

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -384,7 +384,7 @@ void CWindow::moveToWorkspace(PHLWORKSPACE pWorkspace) {
 
     static auto PCLOSEONLASTSPECIAL = CConfigValue<Hyprlang::INT>("misc:close_special_on_empty");
 
-    const auto   OLDWORKSPACE = m_pWorkspace;
+    const auto  OLDWORKSPACE = m_pWorkspace;
 
     m_pWorkspace = pWorkspace;
 
@@ -407,8 +407,8 @@ void CWindow::moveToWorkspace(PHLWORKSPACE pWorkspace) {
     g_pXWaylandManager->setWindowSize(this, m_vRealSize.value());
 
     if (OLDWORKSPACE && g_pCompositor->isWorkspaceSpecial(OLDWORKSPACE->m_iID) && g_pCompositor->getWindowsOnWorkspace(OLDWORKSPACE->m_iID) == 0 && *PCLOSEONLASTSPECIAL) {
-            if (const auto PMONITOR = g_pCompositor->getMonitorFromID(OLDWORKSPACE->m_iMonitorID); PMONITOR)
-                PMONITOR->setSpecialWorkspace(nullptr);
+        if (const auto PMONITOR = g_pCompositor->getMonitorFromID(OLDWORKSPACE->m_iMonitorID); PMONITOR)
+            PMONITOR->setSpecialWorkspace(nullptr);
     }
 }
 
@@ -1032,7 +1032,7 @@ void CWindow::updateGroupOutputs() {
     if (!m_sGroupData.pNextWindow)
         return;
 
-    CWindow* curr = m_sGroupData.pNextWindow;
+    CWindow*   curr = m_sGroupData.pNextWindow;
 
     const auto WS = m_pWorkspace;
 

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -4,6 +4,7 @@
 #include "../render/decorations/CHyprGroupBarDecoration.hpp"
 #include "../render/decorations/CHyprBorderDecoration.hpp"
 #include "../config/ConfigValue.hpp"
+#include <any>
 
 CWindow::CWindow() {
     m_vRealPosition.create(g_pConfigManager->getAnimationPropertyConfig("windowsIn"), this, AVARDAMAGE_ENTIRE);
@@ -377,43 +378,37 @@ void CWindow::updateSurfaceScaleTransformDetails() {
         this);
 }
 
-void CWindow::moveToWorkspace(int workspaceID) {
-    if (m_iWorkspaceID == workspaceID)
+void CWindow::moveToWorkspace(PHLWORKSPACE pWorkspace) {
+    if (m_pWorkspace == pWorkspace)
         return;
 
     static auto PCLOSEONLASTSPECIAL = CConfigValue<Hyprlang::INT>("misc:close_special_on_empty");
 
-    const int   OLDWORKSPACE = m_iWorkspaceID;
+    const auto   OLDWORKSPACE = m_pWorkspace;
 
-    m_iWorkspaceID = workspaceID;
-
-    const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(m_iWorkspaceID);
+    m_pWorkspace = pWorkspace;
 
     setAnimationsToMove();
 
     updateSpecialRenderData();
 
-    if (PWORKSPACE) {
-        g_pEventManager->postEvent(SHyprIPCEvent{"movewindow", std::format("{:x},{}", (uintptr_t)this, PWORKSPACE->m_szName)});
-        g_pEventManager->postEvent(SHyprIPCEvent{"movewindowv2", std::format("{:x},{},{}", (uintptr_t)this, PWORKSPACE->m_iID, PWORKSPACE->m_szName)});
-        EMIT_HOOK_EVENT("moveWindow", (std::vector<void*>{this, PWORKSPACE}));
+    if (valid(pWorkspace)) {
+        g_pEventManager->postEvent(SHyprIPCEvent{"movewindow", std::format("{:x},{}", (uintptr_t)this, pWorkspace->m_szName)});
+        g_pEventManager->postEvent(SHyprIPCEvent{"movewindowv2", std::format("{:x},{},{}", (uintptr_t)this, pWorkspace->m_iID, pWorkspace->m_szName)});
+        EMIT_HOOK_EVENT("moveWindow", (std::vector<std::any>{this, pWorkspace}));
     }
 
     if (m_pSwallowed) {
-        m_pSwallowed->moveToWorkspace(workspaceID);
+        m_pSwallowed->moveToWorkspace(pWorkspace);
         m_pSwallowed->m_iMonitorID = m_iMonitorID;
     }
 
     // update xwayland coords
     g_pXWaylandManager->setWindowSize(this, m_vRealSize.value());
 
-    if (g_pCompositor->isWorkspaceSpecial(OLDWORKSPACE) && g_pCompositor->getWindowsOnWorkspace(OLDWORKSPACE) == 0 && *PCLOSEONLASTSPECIAL) {
-        const auto PWS = g_pCompositor->getWorkspaceByID(OLDWORKSPACE);
-
-        if (PWS) {
-            if (const auto PMONITOR = g_pCompositor->getMonitorFromID(PWS->m_iMonitorID); PMONITOR)
+    if (OLDWORKSPACE && g_pCompositor->isWorkspaceSpecial(OLDWORKSPACE->m_iID) && g_pCompositor->getWindowsOnWorkspace(OLDWORKSPACE->m_iID) == 0 && *PCLOSEONLASTSPECIAL) {
+            if (const auto PMONITOR = g_pCompositor->getMonitorFromID(OLDWORKSPACE->m_iMonitorID); PMONITOR)
                 PMONITOR->setSpecialWorkspace(nullptr);
-        }
     }
 }
 
@@ -455,6 +450,8 @@ void CWindow::onUnmap() {
     if (g_pCompositor->m_pLastWindow == this)
         g_pCompositor->m_pLastWindow = nullptr;
 
+    m_iLastWorkspace = onSpecialWorkspace();
+
     m_vRealPosition.setCallbackOnEnd(unregisterVar);
     m_vRealSize.setCallbackOnEnd(unregisterVar);
     m_fBorderFadeAnimationProgress.setCallbackOnEnd(unregisterVar);
@@ -470,9 +467,9 @@ void CWindow::onUnmap() {
 
     hyprListener_unmapWindow.removeCallback();
 
-    if (*PCLOSEONLASTSPECIAL && g_pCompositor->getWindowsOnWorkspace(m_iWorkspaceID) == 0 && g_pCompositor->isWorkspaceSpecial(m_iWorkspaceID)) {
+    if (*PCLOSEONLASTSPECIAL && g_pCompositor->getWindowsOnWorkspace(workspaceID()) == 0 && onSpecialWorkspace()) {
         const auto PMONITOR = g_pCompositor->getMonitorFromID(m_iMonitorID);
-        if (PMONITOR && PMONITOR->specialWorkspaceID == m_iWorkspaceID)
+        if (PMONITOR && PMONITOR->activeSpecialWorkspace && PMONITOR->activeSpecialWorkspace == m_pWorkspace)
             PMONITOR->setSpecialWorkspace(nullptr);
     }
 
@@ -481,13 +478,14 @@ void CWindow::onUnmap() {
     if (PMONITOR && PMONITOR->solitaryClient == this)
         PMONITOR->solitaryClient = nullptr;
 
-    g_pCompositor->updateWorkspaceWindows(m_iWorkspaceID);
+    g_pCompositor->updateWorkspaceWindows(workspaceID());
 
     if (m_bIsX11)
         return;
 
     m_pSubsurfaceHead.reset();
     m_pPopupHead.reset();
+    m_pWorkspace.reset();
 }
 
 void CWindow::onMap() {
@@ -943,7 +941,7 @@ void CWindow::setGroupCurrent(CWindow* pWindow) {
 
     const auto PCURRENT   = getGroupCurrent();
     const bool FULLSCREEN = PCURRENT->m_bIsFullscreen;
-    const auto WORKSPACE  = g_pCompositor->getWorkspaceByID(PCURRENT->m_iWorkspaceID);
+    const auto WORKSPACE  = PCURRENT->m_pWorkspace;
 
     const auto PWINDOWSIZE = PCURRENT->m_vRealSize.goal();
     const auto PWINDOWPOS  = PCURRENT->m_vRealPosition.goal();
@@ -1036,9 +1034,11 @@ void CWindow::updateGroupOutputs() {
 
     CWindow* curr = m_sGroupData.pNextWindow;
 
+    const auto WS = m_pWorkspace;
+
     while (curr != this) {
         curr->m_iMonitorID = m_iMonitorID;
-        curr->moveToWorkspace(m_iWorkspaceID);
+        curr->moveToWorkspace(WS);
 
         curr->m_vRealPosition = m_vRealPosition.goal();
         curr->m_vRealSize     = m_vRealSize.goal();
@@ -1058,7 +1058,7 @@ bool CWindow::opaque() {
     if (m_vRealSize.goal().floor() != m_vReportedSize)
         return false;
 
-    const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(m_iWorkspaceID);
+    const auto PWORKSPACE = m_pWorkspace;
 
     if (m_pWLSurface.small() && !m_pWLSurface.m_bFillIgnoreSmall)
         return false;
@@ -1088,7 +1088,7 @@ float CWindow::rounding() {
 }
 
 void CWindow::updateSpecialRenderData() {
-    const auto  PWORKSPACE     = g_pCompositor->getWorkspaceByID(m_iWorkspaceID);
+    const auto  PWORKSPACE     = m_pWorkspace;
     const auto  WORKSPACERULES = PWORKSPACE ? g_pConfigManager->getWorkspaceRulesFor(PWORKSPACE) : std::vector<SWorkspaceRule>{};
     bool        border         = true;
 
@@ -1137,7 +1137,7 @@ bool CWindow::canBeTorn() {
 }
 
 bool CWindow::shouldSendFullscreenState() {
-    const auto MODE = g_pCompositor->getWorkspaceByID(m_iWorkspaceID)->m_efFullscreenMode;
+    const auto MODE = m_pWorkspace->m_efFullscreenMode;
     return m_bDontSendFullscreen ? false : (m_bFakeFullscreenState || (m_bIsFullscreen && (MODE == FULLSCREEN_FULL)));
 }
 
@@ -1173,7 +1173,7 @@ void CWindow::onWorkspaceAnimUpdate() {
     }
 
     Vector2D   offset;
-    const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(m_iWorkspaceID);
+    const auto PWORKSPACE = m_pWorkspace;
     if (!PWORKSPACE)
         return;
 
@@ -1211,4 +1211,12 @@ int CWindow::popupsCount() {
     wlr_xdg_surface_for_each_popup_surface(
         m_uSurface.xdg, [](wlr_surface* s, int x, int y, void* data) { *(int*)data += 1; }, &no);
     return no;
+}
+
+int CWindow::workspaceID() {
+    return m_pWorkspace ? m_pWorkspace->m_iID : m_iLastWorkspace;
+}
+
+bool CWindow::onSpecialWorkspace() {
+    return m_pWorkspace ? m_pWorkspace->m_bIsSpecialWorkspace : g_pCompositor->isWorkspaceSpecial(m_iLastWorkspace);
 }

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -242,24 +242,24 @@ class CWindow {
     Vector2D m_vFloatingOffset = Vector2D(0, 0);
 
     // this is used for pseudotiling
-    bool        m_bIsPseudotiled = false;
-    Vector2D    m_vPseudoSize    = Vector2D(0, 0);
+    bool         m_bIsPseudotiled = false;
+    Vector2D     m_vPseudoSize    = Vector2D(0, 0);
 
-    bool        m_bFirstMap           = false; // for layouts
-    bool        m_bIsFloating         = false;
-    bool        m_bDraggingTiled      = false; // for dragging around tiled windows
-    bool        m_bIsFullscreen       = false;
-    bool        m_bDontSendFullscreen = false;
-    bool        m_bWasMaximized       = false;
-    uint64_t    m_iMonitorID          = -1;
-    std::string m_szTitle             = "";
-    std::string m_szInitialTitle      = "";
-    std::string m_szInitialClass      = "";
-    PHLWORKSPACE         m_pWorkspace;
+    bool         m_bFirstMap           = false; // for layouts
+    bool         m_bIsFloating         = false;
+    bool         m_bDraggingTiled      = false; // for dragging around tiled windows
+    bool         m_bIsFullscreen       = false;
+    bool         m_bDontSendFullscreen = false;
+    bool         m_bWasMaximized       = false;
+    uint64_t     m_iMonitorID          = -1;
+    std::string  m_szTitle             = "";
+    std::string  m_szInitialTitle      = "";
+    std::string  m_szInitialClass      = "";
+    PHLWORKSPACE m_pWorkspace;
 
-    bool        m_bIsMapped = false;
+    bool         m_bIsMapped = false;
 
-    bool        m_bRequestsFloat = false;
+    bool         m_bRequestsFloat = false;
 
     // This is for fullscreen apps
     bool m_bCreatedOverFullscreen = false;
@@ -401,8 +401,8 @@ class CWindow {
     bool                     shouldSendFullscreenState();
     void                     setSuspended(bool suspend);
     bool                     visibleOnMonitor(CMonitor* pMonitor);
-    int workspaceID();
-    bool onSpecialWorkspace();
+    int                      workspaceID();
+    bool                     onSpecialWorkspace();
 
     int                      getRealBorderSize();
     void                     updateSpecialRenderData();
@@ -431,9 +431,9 @@ class CWindow {
 
   private:
     // For hidden windows and stuff
-    bool m_bHidden    = false;
-    bool m_bSuspended = false;
-    int m_iLastWorkspace = WORKSPACE_INVALID;
+    bool m_bHidden        = false;
+    bool m_bSuspended     = false;
+    int  m_iLastWorkspace = WORKSPACE_INVALID;
 };
 
 /**

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -11,6 +11,7 @@
 #include "Popup.hpp"
 #include "../macros.hpp"
 #include "../managers/XWaylandManager.hpp"
+#include "DesktopTypes.hpp"
 
 enum eIdleInhibitMode {
     IDLEINHIBIT_NONE = 0,
@@ -254,7 +255,7 @@ class CWindow {
     std::string m_szTitle             = "";
     std::string m_szInitialTitle      = "";
     std::string m_szInitialClass      = "";
-    int         m_iWorkspaceID        = -1;
+    PHLWORKSPACE         m_pWorkspace;
 
     bool        m_bIsMapped = false;
 
@@ -384,7 +385,7 @@ class CWindow {
     void                     destroyToplevelHandle();
     void                     updateToplevel();
     void                     updateSurfaceScaleTransformDetails();
-    void                     moveToWorkspace(int);
+    void                     moveToWorkspace(PHLWORKSPACE);
     CWindow*                 X11TransientFor();
     void                     onUnmap();
     void                     onMap();
@@ -400,6 +401,8 @@ class CWindow {
     bool                     shouldSendFullscreenState();
     void                     setSuspended(bool suspend);
     bool                     visibleOnMonitor(CMonitor* pMonitor);
+    int workspaceID();
+    bool onSpecialWorkspace();
 
     int                      getRealBorderSize();
     void                     updateSpecialRenderData();
@@ -430,6 +433,7 @@ class CWindow {
     // For hidden windows and stuff
     bool m_bHidden    = false;
     bool m_bSuspended = false;
+    int m_iLastWorkspace = WORKSPACE_INVALID;
 };
 
 /**
@@ -464,7 +468,7 @@ struct std::formatter<CWindow*, CharT> : std::formatter<CharT> {
         std::format_to(out, "[");
         std::format_to(out, "Window {:x}: title: \"{}\"", (uintptr_t)w, w->m_szTitle);
         if (formatWorkspace)
-            std::format_to(out, ", workspace: {}", w->m_iWorkspaceID);
+            std::format_to(out, ", workspace: {}", w->m_pWorkspace ? w->workspaceID() : WORKSPACE_INVALID);
         if (formatMonitor)
             std::format_to(out, ", monitor: {}", w->m_iMonitorID);
         if (formatClass)

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -3,6 +3,7 @@
 #include "../helpers/AnimatedVariable.hpp"
 #include <string>
 #include "../defines.hpp"
+#include "DesktopTypes.hpp"
 
 enum eFullscreenMode : int8_t {
     FULLSCREEN_INVALID = -1,
@@ -14,6 +15,8 @@ class CWindow;
 
 class CWorkspace {
   public:
+    static PHLWORKSPACE create(int id, int monitorID, std::string name, bool special = false);
+    // use create() don't use this
     CWorkspace(int id, int monitorID, std::string name, bool special = false);
     ~CWorkspace();
 
@@ -53,7 +56,10 @@ class CWorkspace {
     std::string m_szLastMonitor = "";
 
     // Whether the user configured command for on-created-empty has been executed, if any
-    bool        m_bOnCreatedEmptyExecuted = false;
+    bool m_bOnCreatedEmptyExecuted = false;
+
+    // Inert: destroyed and invalid. If this is true, release the ptr you have.
+    bool        inert();
 
     void        startAnim(bool in, bool left, bool instant = false);
     void        setActive(bool on);
@@ -61,12 +67,25 @@ class CWorkspace {
     void        moveToMonitor(const int&);
 
     CWindow*    getLastFocusedWindow();
-    void        rememberPrevWorkspace(const CWorkspace* prevWorkspace);
+    void        rememberPrevWorkspace(const PHLWORKSPACE& prevWorkspace);
 
     std::string getConfigName();
 
     bool        matchesStaticSelector(const std::string& selector);
 
+    void        markInert();
+
   private:
-    HOOK_CALLBACK_FN* m_pFocusedWindowHook = nullptr;
+    void                      init(PHLWORKSPACE self);
+
+    HOOK_CALLBACK_FN*         m_pFocusedWindowHook = nullptr;
+    bool                      m_bInert             = true;
+    std::weak_ptr<CWorkspace> m_pSelf;
 };
+
+inline bool valid(const PHLWORKSPACE& ref) {
+    if (!ref)
+        return false;
+
+    return !ref->inert();
+}

--- a/src/events/Layers.cpp
+++ b/src/events/Layers.cpp
@@ -163,7 +163,7 @@ void Events::listener_mapLayerSurface(void* owner, void* data) {
     CBox geomFixed = {layersurface->geometry.x + PMONITOR->vecPosition.x, layersurface->geometry.y + PMONITOR->vecPosition.y, layersurface->geometry.width,
                       layersurface->geometry.height};
     g_pHyprRenderer->damageBox(&geomFixed);
-    const auto WORKSPACE  = g_pCompositor->getWorkspaceByID(PMONITOR->activeWorkspace);
+    const auto WORKSPACE  = PMONITOR->activeWorkspace;
     const bool FULLSCREEN = WORKSPACE->m_bHasFullscreenWindow && WORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL;
 
     layersurface->startAnimation(!(layersurface->layer == ZWLR_LAYER_SHELL_V1_LAYER_TOP && FULLSCREEN && !GRABSFOCUS));
@@ -237,7 +237,7 @@ void Events::listener_unmapLayerSurface(void* owner, void* data) {
             foundSurface = g_pCompositor->vectorToLayerSurface(g_pInputManager->getMouseCoordsInternal(), &PMONITOR->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP],
                                                                &surfaceCoords, &pFoundLayerSurface);
 
-        if (!foundSurface && g_pCompositor->m_pLastWindow && g_pCompositor->isWorkspaceVisible(g_pCompositor->m_pLastWindow->m_iWorkspaceID)) {
+        if (!foundSurface && g_pCompositor->m_pLastWindow && g_pCompositor->isWorkspaceVisible(g_pCompositor->m_pLastWindow->workspaceID())) {
             // if there isn't any, focus the last window
             const auto PLASTWINDOW = g_pCompositor->m_pLastWindow;
             g_pCompositor->focusWindow(nullptr);

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -57,9 +57,9 @@ void Events::listener_mapWindow(void* owner, void* data) {
         g_pCompositor->setActiveMonitor(g_pCompositor->getMonitorFromVector({}));
         PMONITOR = g_pCompositor->m_pLastMonitor;
     }
-    auto PWORKSPACE = PMONITOR->activeSpecialWorkspace ? PMONITOR->activeSpecialWorkspace : PMONITOR->activeWorkspace;
+    auto PWORKSPACE           = PMONITOR->activeSpecialWorkspace ? PMONITOR->activeSpecialWorkspace : PMONITOR->activeWorkspace;
     PWINDOW->m_iMonitorID     = PMONITOR->ID;
-    PWINDOW->m_pWorkspace   = PWORKSPACE;
+    PWINDOW->m_pWorkspace     = PWORKSPACE;
     PWINDOW->m_bIsMapped      = true;
     PWINDOW->m_bReadyToDelete = false;
     PWINDOW->m_bFadingOut     = false;
@@ -288,7 +288,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
             PWORKSPACE = pWorkspace;
 
             PWINDOW->m_pWorkspace = pWorkspace;
-            PWINDOW->m_iMonitorID   = pWorkspace->m_iMonitorID;
+            PWINDOW->m_iMonitorID = pWorkspace->m_iMonitorID;
 
             if (g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID)->activeSpecialWorkspace && !pWorkspace->m_bIsSpecialWorkspace)
                 workspaceSilent = true;

--- a/src/helpers/AnimatedVariable.cpp
+++ b/src/helpers/AnimatedVariable.cpp
@@ -22,7 +22,7 @@ void CBaseAnimatedVariable::create(SAnimationPropertyConfig* pAnimConfig, SLayer
     m_bDummy = false;
 }
 
-void CBaseAnimatedVariable::create(SAnimationPropertyConfig* pAnimConfig, CWorkspace* pWorkspace, AVARDAMAGEPOLICY policy) {
+void CBaseAnimatedVariable::create(SAnimationPropertyConfig* pAnimConfig, PHLWORKSPACE pWorkspace, AVARDAMAGEPOLICY policy) {
     m_eDamagePolicy = policy;
     m_pConfig       = pAnimConfig;
     m_pWorkspace    = pWorkspace;

--- a/src/helpers/AnimatedVariable.hpp
+++ b/src/helpers/AnimatedVariable.hpp
@@ -8,6 +8,7 @@
 #include "Color.hpp"
 #include "../macros.hpp"
 #include "../debug/Log.hpp"
+#include "../desktop/DesktopTypes.hpp"
 
 enum ANIMATEDVARTYPE {
     AVARTYPE_INVALID = -1,
@@ -48,11 +49,11 @@ enum AVARDAMAGEPOLICY {
 };
 
 class CAnimationManager;
-class CWorkspace;
 struct SLayerSurface;
 struct SAnimationPropertyConfig;
 class CHyprRenderer;
 class CWindow;
+class CWorkspace;
 
 // Utility to define a concept as a list of possible type
 template <class T, class... U>
@@ -69,7 +70,7 @@ class CBaseAnimatedVariable {
     CBaseAnimatedVariable(ANIMATEDVARTYPE type);
     void create(SAnimationPropertyConfig* pAnimConfig, CWindow* pWindow, AVARDAMAGEPOLICY policy);
     void create(SAnimationPropertyConfig* pAnimConfig, SLayerSurface* pLayer, AVARDAMAGEPOLICY policy);
-    void create(SAnimationPropertyConfig* pAnimConfig, CWorkspace* pWorkspace, AVARDAMAGEPOLICY policy);
+    void create(SAnimationPropertyConfig* pAnimConfig, PHLWORKSPACE pWorkspace, AVARDAMAGEPOLICY policy);
     void create(SAnimationPropertyConfig* pAnimConfig, AVARDAMAGEPOLICY policy);
 
     CBaseAnimatedVariable(const CBaseAnimatedVariable&)            = delete;
@@ -144,9 +145,9 @@ class CBaseAnimatedVariable {
     }
 
   protected:
-    void*                                 m_pWindow    = nullptr;
-    void*                                 m_pWorkspace = nullptr;
-    void*                                 m_pLayer     = nullptr;
+    void*                                 m_pWindow = nullptr;
+    std::weak_ptr<CWorkspace>             m_pWorkspace;
+    void*                                 m_pLayer = nullptr;
 
     SAnimationPropertyConfig*             m_pConfig = nullptr;
 
@@ -217,7 +218,7 @@ class CAnimatedVariable : public CBaseAnimatedVariable {
         m_Value = value;
         m_Goal  = value;
     }
-    void create(const VarType& value, SAnimationPropertyConfig* pAnimConfig, CWorkspace* pWorkspace, AVARDAMAGEPOLICY policy) {
+    void create(const VarType& value, SAnimationPropertyConfig* pAnimConfig, PHLWORKSPACE pWorkspace, AVARDAMAGEPOLICY policy) {
         create(pAnimConfig, pWorkspace, policy);
         m_Value = value;
         m_Goal  = value;

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -347,7 +347,7 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
             std::sort(namedWSes.begin(), namedWSes.end());
 
             // Just take a blind guess at where we'll probably end up
-            int activeWSID = g_pCompositor->m_pLastMonitor->activeWorkspace ? g_pCompositor->m_pLastMonitor->activeWorkspace->m_iID : 1;
+            int  activeWSID    = g_pCompositor->m_pLastMonitor->activeWorkspace ? g_pCompositor->m_pLastMonitor->activeWorkspace->m_iID : 1;
             int  predictedWSID = activeWSID + remains;
             int  remainingWSes = 0;
             char walkDir       = in[1];
@@ -474,7 +474,7 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
             remains = remains < 0 ? -((-remains) % validWSes.size()) : remains % validWSes.size();
 
             // get the current item
-            int activeWSID = g_pCompositor->m_pLastMonitor->activeWorkspace ? g_pCompositor->m_pLastMonitor->activeWorkspace->m_iID : 1;
+            int activeWSID  = g_pCompositor->m_pLastMonitor->activeWorkspace ? g_pCompositor->m_pLastMonitor->activeWorkspace->m_iID : 1;
             int currentItem = -1;
             for (size_t i = 0; i < validWSes.size(); i++) {
                 if (validWSes[i] == activeWSID) {

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -289,9 +289,9 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
         if (!g_pCompositor->m_pLastMonitor)
             return WORKSPACE_INVALID;
 
-        const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(g_pCompositor->m_pLastMonitor->activeWorkspace);
+        const auto PWORKSPACE = g_pCompositor->m_pLastMonitor->activeWorkspace;
 
-        if (!PWORKSPACE)
+        if (!valid(PWORKSPACE))
             return WORKSPACE_INVALID;
 
         const auto PLASTWORKSPACE = g_pCompositor->getWorkspaceByID(PWORKSPACE->m_sPrevWorkspace.iID);
@@ -347,7 +347,8 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
             std::sort(namedWSes.begin(), namedWSes.end());
 
             // Just take a blind guess at where we'll probably end up
-            int  predictedWSID = g_pCompositor->m_pLastMonitor->activeWorkspace + remains;
+            int activeWSID = g_pCompositor->m_pLastMonitor->activeWorkspace ? g_pCompositor->m_pLastMonitor->activeWorkspace->m_iID : 1;
+            int  predictedWSID = activeWSID + remains;
             int  remainingWSes = 0;
             char walkDir       = in[1];
 
@@ -355,20 +356,20 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
             predictedWSID = std::max(predictedWSID, 0);
 
             // Count how many invalidWSes are in between (how bad the prediction was)
-            int  beginID = in[1] == '+' ? g_pCompositor->m_pLastMonitor->activeWorkspace + 1 : predictedWSID;
-            int  endID   = in[1] == '+' ? predictedWSID : g_pCompositor->m_pLastMonitor->activeWorkspace;
+            int  beginID = in[1] == '+' ? activeWSID + 1 : predictedWSID;
+            int  endID   = in[1] == '+' ? predictedWSID : activeWSID;
             auto begin   = invalidWSes.upper_bound(beginID - 1); // upper_bound is >, we want >=
             for (auto it = begin; *it <= endID && it != invalidWSes.end(); it++) {
                 remainingWSes++;
             }
 
             // Handle named workspaces. They are treated like always before other workspaces
-            if (g_pCompositor->m_pLastMonitor->activeWorkspace < 0) {
+            if (activeWSID < 0) {
                 // Behaviour similar to 'm'
                 // Find current
                 int currentItem = -1;
                 for (size_t i = 0; i < namedWSes.size(); i++) {
-                    if (namedWSes[i] == g_pCompositor->m_pLastMonitor->activeWorkspace) {
+                    if (namedWSes[i] == activeWSID) {
                         currentItem = i;
                         break;
                     }
@@ -473,9 +474,10 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
             remains = remains < 0 ? -((-remains) % validWSes.size()) : remains % validWSes.size();
 
             // get the current item
+            int activeWSID = g_pCompositor->m_pLastMonitor->activeWorkspace ? g_pCompositor->m_pLastMonitor->activeWorkspace->m_iID : 1;
             int currentItem = -1;
             for (size_t i = 0; i < validWSes.size(); i++) {
-                if (validWSes[i] == g_pCompositor->m_pLastMonitor->activeWorkspace) {
+                if (validWSes[i] == activeWSID) {
                     currentItem = i;
                     break;
                 }
@@ -496,7 +498,7 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
         } else {
             if (in[0] == '+' || in[0] == '-') {
                 if (g_pCompositor->m_pLastMonitor) {
-                    const auto PLUSMINUSRESULT = getPlusMinusKeywordResult(in, g_pCompositor->m_pLastMonitor->activeWorkspace);
+                    const auto PLUSMINUSRESULT = getPlusMinusKeywordResult(in, g_pCompositor->m_pLastMonitor->activeWorkspaceID());
                     if (!PLUSMINUSRESULT.has_value())
                         return WORKSPACE_INVALID;
 

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -599,7 +599,7 @@ void CMonitor::changeWorkspace(const PHLWORKSPACE& pWorkspace, bool internal, bo
     g_pCompositor->updateSuspendedStates();
 
     if (activeSpecialWorkspace)
-            g_pCompositor->updateFullscreenFadeOnWorkspace(activeSpecialWorkspace);
+        g_pCompositor->updateFullscreenFadeOnWorkspace(activeSpecialWorkspace);
 }
 
 void CMonitor::changeWorkspace(const int& id, bool internal, bool noMouseMove, bool noFocus) {
@@ -652,7 +652,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
 
     // open special
     pWorkspace->m_iMonitorID = ID;
-    activeSpecialWorkspace       = pWorkspace;
+    activeSpecialWorkspace   = pWorkspace;
     if (animate)
         pWorkspace->startAnim(true, true);
 
@@ -722,12 +722,12 @@ void CMonitor::updateMatrix() {
     }
 }
 
-    int64_t CMonitor::activeWorkspaceID() {
-        return activeWorkspace ? activeWorkspace->m_iID : 0;
-    }
-    int64_t CMonitor::activeSpecialWorkspaceID() {
-        return activeSpecialWorkspace ? activeSpecialWorkspace->m_iID : 0;
-    }
+int64_t CMonitor::activeWorkspaceID() {
+    return activeWorkspace ? activeWorkspace->m_iID : 0;
+}
+int64_t CMonitor::activeSpecialWorkspaceID() {
+    return activeSpecialWorkspace ? activeSpecialWorkspace->m_iID : 0;
+}
 
 CMonitorState::CMonitorState(CMonitor* owner) {
     m_pOwner = owner;

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -57,10 +57,11 @@ class CMonitor {
 
     bool            primary = false;
 
-    uint64_t        ID              = -1;
-    int             activeWorkspace = -1;
-    float           setScale        = 1; // scale set by cfg
-    float           scale           = 1; // real scale
+    uint64_t        ID                     = -1;
+    PHLWORKSPACE    activeWorkspace        = nullptr;
+    PHLWORKSPACE    activeSpecialWorkspace = nullptr;
+    float           setScale               = 1; // scale set by cfg
+    float           scale                  = 1; // real scale
 
     std::string     szName             = "";
     std::string     szDescription      = "";
@@ -119,9 +120,6 @@ class CMonitor {
         bool frameScheduledWhileBusy = false;
     } tearingState;
 
-    // for the special workspace. 0 means not open.
-    int                                                        specialWorkspaceID = 0;
-
     std::array<std::vector<std::unique_ptr<SLayerSurface>>, 4> m_aLayerSurfaceLayers;
 
     DYNLISTENER(monitorFrame);
@@ -142,13 +140,15 @@ class CMonitor {
     bool     isMirror();
     bool     matchesStaticSelector(const std::string& selector) const;
     float    getDefaultScale();
-    void     changeWorkspace(CWorkspace* const pWorkspace, bool internal = false, bool noMouseMove = false, bool noFocus = false);
+    void     changeWorkspace(const PHLWORKSPACE& pWorkspace, bool internal = false, bool noMouseMove = false, bool noFocus = false);
     void     changeWorkspace(const int& id, bool internal = false, bool noMouseMove = false, bool noFocus = false);
-    void     setSpecialWorkspace(CWorkspace* const pWorkspace);
+    void     setSpecialWorkspace(const PHLWORKSPACE& pWorkspace);
     void     setSpecialWorkspace(const int& id);
     void     moveTo(const Vector2D& pos);
     Vector2D middle();
     void     updateMatrix();
+    int64_t activeWorkspaceID();
+    int64_t activeSpecialWorkspaceID();
 
     bool     m_bEnabled             = false;
     bool     m_bRenderingInitPassed = false;

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -147,8 +147,8 @@ class CMonitor {
     void     moveTo(const Vector2D& pos);
     Vector2D middle();
     void     updateMatrix();
-    int64_t activeWorkspaceID();
-    int64_t activeSpecialWorkspaceID();
+    int64_t  activeWorkspaceID();
+    int64_t  activeSpecialWorkspaceID();
 
     bool     m_bEnabled             = false;
     bool     m_bRenderingInitPassed = false;

--- a/src/helpers/WLClasses.hpp
+++ b/src/helpers/WLClasses.hpp
@@ -280,16 +280,16 @@ struct SIdleInhibitor {
 };
 
 struct SSwipeGesture {
-    CWorkspace* pWorkspaceBegin = nullptr;
+    PHLWORKSPACE pWorkspaceBegin = nullptr;
 
-    double      delta = 0;
+    double       delta = 0;
 
-    int         initialDirection = 0;
-    float       avgSpeed         = 0;
-    int         speedPoints      = 0;
-    int         touch_id         = 0;
+    int          initialDirection = 0;
+    float        avgSpeed         = 0;
+    int          speedPoints      = 0;
+    int          touch_id         = 0;
 
-    CMonitor*   pMonitor = nullptr;
+    CMonitor*    pMonitor = nullptr;
 };
 
 struct SIMEKbGrab {

--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -78,7 +78,7 @@ class CHyprDwindleLayout : public IHyprLayout {
 
     int                     getNodesOnWorkspace(const int&);
     void                    applyNodeDataToWindow(SDwindleNodeData*, bool force = false);
-    void                    calculateWorkspace(const int& ws);
+    void                    calculateWorkspace(const PHLWORKSPACE& pWorkspace);
     SDwindleNodeData*       getNodeFromWindow(CWindow*);
     SDwindleNodeData*       getFirstNodeOnWorkspace(const int&);
     SDwindleNodeData*       getClosestNodeOnWorkspace(const int&, const Vector2D&);

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -675,8 +675,7 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
     PWINDOW->m_vPosition = pNode->position;
 
     if (*PNOGAPSWHENONLY && !PWINDOW->onSpecialWorkspace() &&
-        (getNodesOnWorkspace(PWINDOW->workspaceID()) == 1 ||
-         (PWINDOW->m_bIsFullscreen && PWINDOW->m_pWorkspace->m_efFullscreenMode == FULLSCREEN_MAXIMIZED))) {
+        (getNodesOnWorkspace(PWINDOW->workspaceID()) == 1 || (PWINDOW->m_bIsFullscreen && PWINDOW->m_pWorkspace->m_efFullscreenMode == FULLSCREEN_MAXIMIZED))) {
 
         PWINDOW->m_sSpecialRenderData.rounding = false;
         PWINDOW->m_sSpecialRenderData.shadow   = false;

--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -84,7 +84,7 @@ class CHyprMasterLayout : public IHyprLayout {
     SMasterNodeData*                  getNodeFromWindow(CWindow*);
     SMasterNodeData*                  getMasterNodeOnWorkspace(const int&);
     SMasterWorkspaceData*             getMasterWorkspaceData(const int&);
-    void                              calculateWorkspace(const int&);
+    void                              calculateWorkspace(PHLWORKSPACE);
     CWindow*                          getNextWindow(CWindow*, bool);
     int                               getMastersOnWorkspace(const int&);
 

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -79,11 +79,11 @@ void CAnimationManager::tick() {
         const float SPENT = av->getPercent();
 
         // window stuff
-        const auto PWINDOW            = (CWindow*)av->m_pWindow;
-        const auto PWORKSPACE         = (CWorkspace*)av->m_pWorkspace;
-        const auto PLAYER             = (SLayerSurface*)av->m_pLayer;
-        CMonitor*  PMONITOR           = nullptr;
-        bool       animationsDisabled = animGlobalDisabled;
+        const auto         PWINDOW            = (CWindow*)av->m_pWindow;
+        PHLWORKSPACE PWORKSPACE = av->m_pWorkspace.lock();
+        const auto         PLAYER             = (SLayerSurface*)av->m_pLayer;
+        CMonitor*          PMONITOR           = nullptr;
+        bool               animationsDisabled = animGlobalDisabled;
 
         if (PWINDOW) {
             if (av->m_eDamagePolicy == AVARDAMAGE_ENTIRE) {
@@ -111,7 +111,7 @@ void CAnimationManager::tick() {
 
             // TODO: just make this into a damn callback already vax...
             for (auto& w : g_pCompositor->m_vWindows) {
-                if (!w->m_bIsMapped || w->isHidden() || w->m_iWorkspaceID != PWORKSPACE->m_iID)
+                if (!w->m_bIsMapped || w->isHidden() || w->m_pWorkspace != PWORKSPACE)
                     continue;
 
                 if (w->m_bIsFloating && !w->m_bPinned) {
@@ -129,7 +129,7 @@ void CAnimationManager::tick() {
 
             // damage any workspace window that is on any monitor
             for (auto& w : g_pCompositor->m_vWindows) {
-                if (!g_pCompositor->windowValidMapped(w.get()) || w->m_iWorkspaceID != PWORKSPACE->m_iID || w->m_bPinned)
+                if (!g_pCompositor->windowValidMapped(w.get()) || w->m_pWorkspace != PWORKSPACE || w->m_bPinned)
                     continue;
 
                 g_pHyprRenderer->damageWindow(w.get());
@@ -146,7 +146,7 @@ void CAnimationManager::tick() {
             animationsDisabled = animationsDisabled || PLAYER->noAnimations;
         }
 
-        const bool VISIBLE = PWINDOW ? g_pCompositor->isWorkspaceVisible(PWINDOW->m_iWorkspaceID) : true;
+        const bool VISIBLE = PWINDOW && PWINDOW->m_pWorkspace ? g_pCompositor->isWorkspaceVisible(PWINDOW->workspaceID()) : true;
 
         // beziers are with a switch unforto
         // TODO: maybe do something cleaner
@@ -212,7 +212,7 @@ void CAnimationManager::tick() {
                     g_pHyprRenderer->damageWindow(PWINDOW);
                 } else if (PWORKSPACE) {
                     for (auto& w : g_pCompositor->m_vWindows) {
-                        if (!g_pCompositor->windowValidMapped(w.get()) || w->m_iWorkspaceID != PWORKSPACE->m_iID)
+                        if (!g_pCompositor->windowValidMapped(w.get()) || w->m_pWorkspace != PWORKSPACE)
                             continue;
 
                         w->updateWindowDecos();

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -79,11 +79,11 @@ void CAnimationManager::tick() {
         const float SPENT = av->getPercent();
 
         // window stuff
-        const auto         PWINDOW            = (CWindow*)av->m_pWindow;
-        PHLWORKSPACE PWORKSPACE = av->m_pWorkspace.lock();
-        const auto         PLAYER             = (SLayerSurface*)av->m_pLayer;
-        CMonitor*          PMONITOR           = nullptr;
-        bool               animationsDisabled = animGlobalDisabled;
+        const auto   PWINDOW            = (CWindow*)av->m_pWindow;
+        PHLWORKSPACE PWORKSPACE         = av->m_pWorkspace.lock();
+        const auto   PLAYER             = (SLayerSurface*)av->m_pLayer;
+        CMonitor*    PMONITOR           = nullptr;
+        bool         animationsDisabled = animGlobalDisabled;
 
         if (PWINDOW) {
             if (av->m_eDamagePolicy == AVARDAMAGE_ENTIRE) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2029,7 +2029,7 @@ void CKeybindManager::pinActive(std::string args) {
     if (!PWINDOW->m_bIsFloating || PWINDOW->m_bIsFullscreen)
         return;
 
-    PWINDOW->m_bPinned      = !PWINDOW->m_bPinned;
+    PWINDOW->m_bPinned    = !PWINDOW->m_bPinned;
     PWINDOW->m_pWorkspace = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID)->activeWorkspace;
 
     PWINDOW->updateDynamicRules();

--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -74,7 +74,7 @@ void CHyprXWaylandManager::activateWindow(CWindow* pWindow, bool activate) {
     }
 
     if (!pWindow->m_bPinned)
-        g_pCompositor->getWorkspaceByID(pWindow->m_iWorkspaceID)->m_pLastFocusedWindow = pWindow;
+        pWindow->m_pWorkspace->m_pLastFocusedWindow = pWindow;
 }
 
 void CHyprXWaylandManager::getGeometryForWindow(CWindow* pWindow, CBox* pbox) {

--- a/src/managers/input/IdleInhibitor.cpp
+++ b/src/managers/input/IdleInhibitor.cpp
@@ -65,7 +65,7 @@ void CInputManager::recheckIdleInhibitorStatus() {
             return;
         }
 
-        if (w->m_eIdleInhibitMode == IDLEINHIBIT_FULLSCREEN && w->m_bIsFullscreen && g_pCompositor->isWorkspaceVisible(w->m_iWorkspaceID)) {
+        if (w->m_eIdleInhibitMode == IDLEINHIBIT_FULLSCREEN && w->m_bIsFullscreen && g_pCompositor->isWorkspaceVisible(w->workspaceID())) {
             g_pCompositor->setIdleActivityInhibit(false);
             return;
         }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -230,7 +230,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
         foundSurface = g_pCompositor->vectorToLayerSurface(mouseCoords, &PMONITOR->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP], &surfaceCoords, &pFoundLayerSurface);
 
     // then, we check if the workspace doesnt have a fullscreen window
-    const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(PMONITOR->activeWorkspace);
+    const auto PWORKSPACE = PMONITOR->activeWorkspace;
     if (PWORKSPACE->m_bHasFullscreenWindow && !foundSurface && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL) {
         pFoundWindow = g_pCompositor->getFullscreenWindowOnWorkspace(PWORKSPACE->m_iID);
 
@@ -244,7 +244,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
 
         if (PWINDOWIDEAL &&
             ((PWINDOWIDEAL->m_bIsFloating && PWINDOWIDEAL->m_bCreatedOverFullscreen) /* floating over fullscreen */
-             || (PMONITOR->specialWorkspaceID == PWINDOWIDEAL->m_iWorkspaceID) /* on an open special workspace */))
+             || (PMONITOR->activeSpecialWorkspace == PWINDOWIDEAL->m_pWorkspace) /* on an open special workspace */))
             pFoundWindow = PWINDOWIDEAL;
 
         if (!pFoundWindow->m_bIsX11) {
@@ -260,10 +260,10 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
     if (!foundSurface) {
         if (PWORKSPACE->m_bHasFullscreenWindow && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_MAXIMIZED) {
 
-            if (PMONITOR->specialWorkspaceID) {
+            if (PMONITOR->activeSpecialWorkspace) {
                 pFoundWindow = g_pCompositor->vectorToWindowUnified(mouseCoords, RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING);
 
-                if (pFoundWindow && !g_pCompositor->isWorkspaceSpecial(pFoundWindow->m_iWorkspaceID)) {
+                if (pFoundWindow && !pFoundWindow->onSpecialWorkspace()) {
                     pFoundWindow = g_pCompositor->getFullscreenWindowOnWorkspace(PWORKSPACE->m_iID);
                 }
             } else {

--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -24,7 +24,7 @@ void CInputManager::onSwipeBegin(wlr_pointer_swipe_begin_event* e) {
 }
 
 void CInputManager::beginWorkspaceSwipe() {
-    const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(g_pCompositor->m_pLastMonitor->activeWorkspace);
+    const auto PWORKSPACE = g_pCompositor->m_pLastMonitor->activeWorkspace;
 
     Debug::log(LOG, "Starting a swipe from {}", PWORKSPACE->m_szName);
 
@@ -80,14 +80,14 @@ void CInputManager::endWorkspaceSwipe() {
         workspaceIDRight = maxWorkspace + 1;
     }
 
-    auto        PWORKSPACER = g_pCompositor->getWorkspaceByID(workspaceIDRight); // not guaranteed if PSWIPENEW || PSWIPENUMBER
-    auto        PWORKSPACEL = g_pCompositor->getWorkspaceByID(workspaceIDLeft);  // not guaranteed if PSWIPENUMBER
+    auto         PWORKSPACER = g_pCompositor->getWorkspaceByID(workspaceIDRight); // not guaranteed if PSWIPENEW || PSWIPENUMBER
+    auto         PWORKSPACEL = g_pCompositor->getWorkspaceByID(workspaceIDLeft);  // not guaranteed if PSWIPENUMBER
 
-    const auto  RENDEROFFSETMIDDLE = m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.value();
-    const auto  XDISTANCE          = m_sActiveSwipe.pMonitor->vecSize.x + *PWORKSPACEGAP;
-    const auto  YDISTANCE          = m_sActiveSwipe.pMonitor->vecSize.y + *PWORKSPACEGAP;
+    const auto   RENDEROFFSETMIDDLE = m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.value();
+    const auto   XDISTANCE          = m_sActiveSwipe.pMonitor->vecSize.x + *PWORKSPACEGAP;
+    const auto   YDISTANCE          = m_sActiveSwipe.pMonitor->vecSize.y + *PWORKSPACEGAP;
 
-    CWorkspace* pSwitchedTo = nullptr;
+    PHLWORKSPACE pSwitchedTo = nullptr;
 
     if ((abs(m_sActiveSwipe.delta) < *PSWIPEDIST * *PSWIPEPERC && (*PSWIPEFORC == 0 || (*PSWIPEFORC != 0 && m_sActiveSwipe.avgSpeed < *PSWIPEFORC))) ||
         abs(m_sActiveSwipe.delta) < 2) {

--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -37,7 +37,7 @@ void CInputManager::onTouchDown(wlr_touch_down_event* e) {
         return;
         // TODO: Don't swipe if you touched a floating window.
     } else if (*PSWIPETOUCH && (!m_pFoundLSToFocus || m_pFoundLSToFocus->layer <= ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM)) {
-        const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(PMONITOR->activeWorkspace);
+        const auto PWORKSPACE = PMONITOR->activeWorkspace;
         const bool VERTANIMS  = PWORKSPACE->m_vRenderOffset.getConfig()->pValues->internalStyle == "slidevert" ||
             PWORKSPACE->m_vRenderOffset.getConfig()->pValues->internalStyle.starts_with("slidefadevert");
         // TODO: support no_gaps_when_only?

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -224,7 +224,7 @@ bool CHyprOpenGLImpl::passRequiresIntrospection(CMonitor* pMonitor) {
         if (w->popupsCount() > 0 && *PBLURPOPUPS)
             return true;
 
-        if (!w->m_bIsFloating && *POPTIM && !g_pCompositor->isWorkspaceSpecial(w->m_iWorkspaceID))
+        if (!w->m_bIsFloating && *POPTIM && !w->onSpecialWorkspace())
             continue;
 
         if (w->m_sAdditionalConfigData.forceNoBlur.toUnderlying() == true || w->m_sAdditionalConfigData.xray.toUnderlying() == true)
@@ -1342,7 +1342,7 @@ void CHyprOpenGLImpl::preRender(CMonitor* pMonitor) {
 
         const auto  PSURFACE = pWindow->m_pWLSurface.wlr();
 
-        const auto  PWORKSPACE = g_pCompositor->getWorkspaceByID(pWindow->m_iWorkspaceID);
+        const auto  PWORKSPACE = pWindow->m_pWorkspace;
         const float A          = pWindow->m_fAlpha.value() * pWindow->m_fActiveInactiveAlpha.value() * PWORKSPACE->m_fAlpha.value();
 
         if (A >= 1.f) {
@@ -1364,7 +1364,7 @@ void CHyprOpenGLImpl::preRender(CMonitor* pMonitor) {
 
     bool hasWindows = false;
     for (auto& w : g_pCompositor->m_vWindows) {
-        if (w->m_iWorkspaceID == pMonitor->activeWorkspace && !w->isHidden() && w->m_bIsMapped && (!w->m_bIsFloating || *PBLURXRAY)) {
+        if (w->m_pWorkspace == pMonitor->activeWorkspace && !w->isHidden() && w->m_bIsMapped && (!w->m_bIsFloating || *PBLURXRAY)) {
 
             // check if window is valid
             if (!windowShouldBeBlurred(w.get()))
@@ -1456,7 +1456,7 @@ bool CHyprOpenGLImpl::shouldUseNewBlurOptimizations(SLayerSurface* pLayer, CWind
     if (pLayer && pLayer->xray == 0)
         return false;
 
-    if ((*PBLURNEWOPTIMIZE && pWindow && !pWindow->m_bIsFloating && !g_pCompositor->isWorkspaceSpecial(pWindow->m_iWorkspaceID)) || *PBLURXRAY)
+    if ((*PBLURNEWOPTIMIZE && pWindow && !pWindow->m_bIsFloating && !pWindow->onSpecialWorkspace()) || *PBLURXRAY)
         return true;
 
     if ((pLayer && pLayer->xray == 1) || (pWindow && pWindow->m_sAdditionalConfigData.xray.toUnderlying() == 1))

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -91,7 +91,7 @@ struct SMonitorRenderData {
 
 struct SCurrentRenderData {
     CMonitor*           pMonitor   = nullptr;
-    CWorkspace*         pWorkspace = nullptr;
+    PHLWORKSPACE        pWorkspace = nullptr;
     float               projection[9];
     float               savedProjection[9];
 

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -61,8 +61,8 @@ class CHyprRenderer {
     void                            calculateUVForSurface(CWindow*, wlr_surface*, bool main = false, const Vector2D& projSize = {}, bool fixMisalignedFSV1 = false);
     std::tuple<float, float, float> getRenderTimes(CMonitor* pMonitor); // avg max min
     void                            renderLockscreen(CMonitor* pMonitor, timespec* now, const CBox& geometry);
-    void                            setOccludedForBackLayers(CRegion& region, CWorkspace* pWorkspace);
-    void                            setOccludedForMainWorkspace(CRegion& region, CWorkspace* pWorkspace); // TODO: merge occlusion methods
+    void                            setOccludedForBackLayers(CRegion& region, PHLWORKSPACE pWorkspace);
+    void                            setOccludedForMainWorkspace(CRegion& region, PHLWORKSPACE pWorkspace); // TODO: merge occlusion methods
     bool                            canSkipBackBufferClear(CMonitor* pMonitor);
     void                            recheckSolitaryForMonitor(CMonitor* pMonitor);
     void                            setCursorSurface(wlr_surface* surf, int hotspotX, int hotspotY, bool force = false);
@@ -111,15 +111,15 @@ class CHyprRenderer {
 
   private:
     void           arrangeLayerArray(CMonitor*, const std::vector<std::unique_ptr<SLayerSurface>>&, bool, CBox*);
-    void           renderWorkspaceWindowsFullscreen(CMonitor*, CWorkspace*, timespec*); // renders workspace windows (fullscreen) (tiled, floating, pinned, but no special)
-    void           renderWorkspaceWindows(CMonitor*, CWorkspace*, timespec*);           // renders workspace windows (no fullscreen) (tiled, floating, pinned, but no special)
+    void           renderWorkspaceWindowsFullscreen(CMonitor*, PHLWORKSPACE, timespec*); // renders workspace windows (fullscreen) (tiled, floating, pinned, but no special)
+    void           renderWorkspaceWindows(CMonitor*, PHLWORKSPACE, timespec*);           // renders workspace windows (no fullscreen) (tiled, floating, pinned, but no special)
     void           renderWindow(CWindow*, CMonitor*, timespec*, bool, eRenderPassMode, bool ignorePosition = false, bool ignoreAllGeometry = false);
     void           renderLayer(SLayerSurface*, CMonitor*, timespec*, bool popups = false);
     void           renderSessionLockSurface(SSessionLockSurface*, CMonitor*, timespec*);
     void           renderDragIcon(CMonitor*, timespec*);
     void           renderIMEPopup(CInputPopup*, CMonitor*, timespec*);
-    void           renderWorkspace(CMonitor* pMonitor, CWorkspace* pWorkspace, timespec* now, const CBox& geometry);
-    void           renderAllClientsForWorkspace(CMonitor* pMonitor, CWorkspace* pWorkspace, timespec* now, const Vector2D& translate = {0, 0}, const float& scale = 1.f);
+    void           renderWorkspace(CMonitor* pMonitor, PHLWORKSPACE pWorkspace, timespec* now, const CBox& geometry);
+    void           renderAllClientsForWorkspace(CMonitor* pMonitor, PHLWORKSPACE pWorkspace, timespec* now, const Vector2D& translate = {0, 0}, const float& scale = 1.f);
 
     bool           m_bCursorHidden        = false;
     bool           m_bCursorHasSurface    = false;

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -36,7 +36,7 @@ CBox CHyprBorderDecoration::assignedBoxGlobal() {
     CBox box = m_bAssignedGeometry;
     box.translate(g_pDecorationPositioner->getEdgeDefinedPoint(DECORATION_EDGE_BOTTOM | DECORATION_EDGE_LEFT | DECORATION_EDGE_RIGHT | DECORATION_EDGE_TOP, m_pWindow));
 
-    const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(m_pWindow->m_iWorkspaceID);
+    const auto PWORKSPACE = m_pWindow->m_pWorkspace;
 
     if (!PWORKSPACE)
         return box;
@@ -95,7 +95,7 @@ void CHyprBorderDecoration::damageEntire() {
     const auto ROUNDINGSIZE = ROUNDING - M_SQRT1_2 * ROUNDING + 2;
     const auto BORDERSIZE   = m_pWindow->getRealBorderSize() + 1;
 
-    const auto PWINDOWWORKSPACE = g_pCompositor->getWorkspaceByID(m_pWindow->m_iWorkspaceID);
+    const auto PWINDOWWORKSPACE = m_pWindow->m_pWorkspace;
     if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_vRenderOffset.isBeingAnimated() && !m_pWindow->m_bPinned)
         surfaceBox.translate(PWINDOWWORKSPACE->m_vRenderOffset.value());
     surfaceBox.translate(m_pWindow->m_vFloatingOffset);

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -45,7 +45,7 @@ void CHyprDropShadowDecoration::damageEntire() {
                             m_pWindow->m_vRealSize.value().x + m_seExtents.topLeft.x + m_seExtents.bottomRight.x,
                             m_pWindow->m_vRealSize.value().y + m_seExtents.topLeft.y + m_seExtents.bottomRight.y};
 
-    const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(m_pWindow->m_iWorkspaceID);
+    const auto PWORKSPACE = m_pWindow->m_pWorkspace;
     if (PWORKSPACE && PWORKSPACE->m_vRenderOffset.isBeingAnimated() && !m_pWindow->m_bPinned)
         shadowBox.translate(PWORKSPACE->m_vRenderOffset.value());
     shadowBox.translate(m_pWindow->m_vFloatingOffset);
@@ -110,7 +110,7 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a) {
 
     const auto ROUNDINGBASE    = m_pWindow->rounding();
     const auto ROUNDING        = ROUNDINGBASE > 0 ? ROUNDINGBASE + m_pWindow->getRealBorderSize() : 0;
-    const auto PWORKSPACE      = g_pCompositor->getWorkspaceByID(m_pWindow->m_iWorkspaceID);
+    const auto PWORKSPACE      = m_pWindow->m_pWorkspace;
     const auto WORKSPACEOFFSET = PWORKSPACE && !m_pWindow->m_bPinned ? PWORKSPACE->m_vRenderOffset.value() : Vector2D();
 
     // draw the shadow

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -423,7 +423,7 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, CWindow
 }
 
 bool CHyprGroupBarDecoration::onMouseButtonOnDeco(const Vector2D& pos, wlr_pointer_button_event* e) {
-    if (m_pWindow->m_bIsFullscreen && g_pCompositor->getWorkspaceByID(m_pWindow->m_iWorkspaceID)->m_efFullscreenMode == FULLSCREEN_FULL)
+    if (m_pWindow->m_bIsFullscreen && m_pWindow->m_pWorkspace->m_efFullscreenMode == FULLSCREEN_FULL)
         return true;
 
     const float BARRELATIVEX = pos.x - assignedBoxGlobal().x;
@@ -506,7 +506,7 @@ CBox CHyprGroupBarDecoration::assignedBoxGlobal() {
     CBox box = m_bAssignedBox;
     box.translate(g_pDecorationPositioner->getEdgeDefinedPoint(DECORATION_EDGE_TOP, m_pWindow));
 
-    const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(m_pWindow->m_iWorkspaceID);
+    const auto PWORKSPACE = m_pWindow->m_pWorkspace;
 
     if (PWORKSPACE && !m_pWindow->m_bPinned)
         box.translate(PWORKSPACE->m_vRenderOffset.value());


### PR DESCRIPTION
1/3 (next: CMonitor, CWindow)

Rewrites how workspaces are stored. They are now shared pointers, passed around.

cc @outfoxxed (hy3) @fufexan (review)

todo:
 - [ ] wiki

breaking: 
 - all internal events with `CWorkspace*` now pass `PHLWORKSPACE`, plus vectors where applicable are `void*` -> `std::any`
 