### PR TITLE
fix unnamed special workspace rules

### DIFF
--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -199,7 +199,7 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
 
     } else if (selector.starts_with("name:")) {
         return m_szName == selector.substr(5);
-    } else if (selector.starts_with("special:")) {
+    } else if (selector.starts_with("special")) {
         return m_szName == selector;
     } else {
         // parse selector


### PR DESCRIPTION
fixes parsing unnamed special workspace rules
e.g. `workspace = special, gapsout:100`

seems to work without issues