### PR TITLE
IME: fix IME popup mouse inputs (again)

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -171,26 +171,26 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
     updateDragIcon();
 
     if (!m_sDrag.drag && !m_lCurrentlyHeldButtons.empty() && g_pCompositor->m_pLastFocus && m_pLastMouseSurface) {
-        if (m_bLastFocusOnLS) {
-            foundSurface       = m_pLastMouseSurface;
-            pFoundLayerSurface = g_pCompositor->getLayerSurfaceFromSurface(foundSurface);
-            if (pFoundLayerSurface) {
-                surfacePos              = g_pCompositor->getLayerSurfaceFromSurface(foundSurface)->position;
-                m_bFocusHeldByButtons   = true;
-                m_bRefocusHeldByButtons = refocus;
-            } else {
-                // ?
-                foundSurface       = nullptr;
-                pFoundLayerSurface = nullptr;
-            }
-        } else if (g_pCompositor->m_pLastWindow) {
-            foundSurface = m_pLastMouseSurface;
-            pFoundWindow = g_pCompositor->m_pLastWindow;
-
-            surfaceCoords = g_pCompositor->vectorToSurfaceLocal(mouseCoords, pFoundWindow, foundSurface);
-
+        foundSurface       = m_pLastMouseSurface;
+        pFoundLayerSurface = g_pCompositor->getLayerSurfaceFromSurface(foundSurface);
+        if (pFoundLayerSurface) {
+            surfacePos              = pFoundLayerSurface->position;
             m_bFocusHeldByButtons   = true;
             m_bRefocusHeldByButtons = refocus;
+        } else {
+            CInputPopup* foundPopup = m_sIMERelay.popupFromSurface(foundSurface);
+            if (foundPopup) {
+                surfacePos              = foundPopup->globalBox().pos();
+                m_bFocusHeldByButtons   = true;
+                m_bRefocusHeldByButtons = refocus;
+            } else if (g_pCompositor->m_pLastWindow) {
+                foundSurface = m_pLastMouseSurface;
+                pFoundWindow = g_pCompositor->m_pLastWindow;
+
+                surfaceCoords           = g_pCompositor->vectorToSurfaceLocal(mouseCoords, pFoundWindow, foundSurface);
+                m_bFocusHeldByButtons   = true;
+                m_bRefocusHeldByButtons = refocus;
+            }
         }
     }
 

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -184,6 +184,8 @@ class CInputManager {
     // for some bugs in follow mouse 0
     bool m_bLastFocusOnLS = false;
 
+    bool m_bLastFocusOnIMEPopup = false;
+
     // for hiding cursor on touch
     bool m_bLastInputTouch = false;
 

--- a/src/managers/input/InputMethodPopup.hpp
+++ b/src/managers/input/InputMethodPopup.hpp
@@ -32,7 +32,6 @@ class CInputPopup {
     wlr_input_popup_surface_v2* pWlr = nullptr;
     CWLSurface                  surface;
     CBox                        lastBoxLocal;
-    Vector2D                    lastPopupSize;
     uint64_t                    lastMonitor = -1;
 
     DYNLISTENER(mapPopup);

--- a/src/managers/input/InputMethodRelay.cpp
+++ b/src/managers/input/InputMethodRelay.cpp
@@ -192,3 +192,12 @@ CInputPopup* CInputMethodRelay::popupFromCoords(const Vector2D& point) {
 
     return nullptr;
 }
+
+CInputPopup* CInputMethodRelay::popupFromSurface(const wlr_surface* surface) {
+    for (auto& p : m_vIMEPopups) {
+        if (p->getWlrSurface() == surface)
+            return p.get();
+    }
+
+    return nullptr;
+}

--- a/src/managers/input/InputMethodRelay.hpp
+++ b/src/managers/input/InputMethodRelay.hpp
@@ -33,6 +33,7 @@ class CInputMethodRelay {
     void                 removePopup(CInputPopup*);
 
     CInputPopup*         popupFromCoords(const Vector2D& point);
+    CInputPopup*         popupFromSurface(const wlr_surface* surface);
 
     void                 updateAllPopups();
 


### PR DESCRIPTION
`lastBoxLocal`'s size should be the actual popup's size instead of the cursor rectangle's size. Also, the rectangle position is now relative to the popup. (Actually fixes https://github.com/hyprwm/Hyprland/issues/5255 imho.)

One thing #3922 missed was handling focus held by buttons. Let's hope I get it right this time.

There should be no regression in scaling and rendering, but I'm not entirely sure. cc @q234rty @sungyoonc 

Before:

![hyprland_ime_pointer_before_c](https://github.com/hyprwm/Hyprland/assets/70618504/4309ae43-e101-4305-80d1-0a351e6ad561)


After:
![hyprland_ime_pointer_after_c](https://github.com/hyprwm/Hyprland/assets/70618504/59022bcb-7ffd-4566-83d8-82b7a7bd2f62)
