### PR TITLE
layers: separate anim configs for open/close

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -646,6 +646,10 @@ void CConfigManager::setDefaultAnimationVars() {
         INITANIMCFG("windowsOut");
         INITANIMCFG("windowsMove");
 
+        // layers
+        INITANIMCFG("layersIn");
+        INITANIMCFG("layersOut");
+
         // fade
         INITANIMCFG("fadeIn");
         INITANIMCFG("fadeOut");
@@ -669,6 +673,9 @@ void CConfigManager::setDefaultAnimationVars() {
     CREATEANIMCFG("borderangle", "global");
     CREATEANIMCFG("workspaces", "global");
 
+    CREATEANIMCFG("layersIn", "layers");
+    CREATEANIMCFG("layersOut", "layers");
+
     CREATEANIMCFG("windowsIn", "windows");
     CREATEANIMCFG("windowsOut", "windows");
     CREATEANIMCFG("windowsMove", "windows");
@@ -679,6 +686,8 @@ void CConfigManager::setDefaultAnimationVars() {
     CREATEANIMCFG("fadeShadow", "fade");
     CREATEANIMCFG("fadeDim", "fade");
     CREATEANIMCFG("fadeLayers", "fade");
+    CREATEANIMCFG("fadeLayersIn", "fadeLayers");
+    CREATEANIMCFG("fadeLayersOut", "fadeLayers");
 
     CREATEANIMCFG("specialWorkspace", "workspaces");
 }

--- a/src/helpers/WLClasses.cpp
+++ b/src/helpers/WLClasses.cpp
@@ -3,9 +3,9 @@
 #include "../Compositor.hpp"
 
 SLayerSurface::SLayerSurface() {
-    alpha.create(g_pConfigManager->getAnimationPropertyConfig("fadeLayers"), this, AVARDAMAGE_ENTIRE);
-    realPosition.create(g_pConfigManager->getAnimationPropertyConfig("layers"), this, AVARDAMAGE_ENTIRE);
-    realSize.create(g_pConfigManager->getAnimationPropertyConfig("layers"), this, AVARDAMAGE_ENTIRE);
+    alpha.create(g_pConfigManager->getAnimationPropertyConfig("fadeLayersIn"), this, AVARDAMAGE_ENTIRE);
+    realPosition.create(g_pConfigManager->getAnimationPropertyConfig("layersIn"), this, AVARDAMAGE_ENTIRE);
+    realSize.create(g_pConfigManager->getAnimationPropertyConfig("layersIn"), this, AVARDAMAGE_ENTIRE);
     alpha.registerVar();
     realPosition.registerVar();
     realSize.registerVar();
@@ -61,6 +61,15 @@ void SLayerSurface::applyRules() {
 
 void SLayerSurface::startAnimation(bool in, bool instant) {
     const auto ANIMSTYLE = animationStyle.value_or(realPosition.m_pConfig->pValues->internalStyle);
+    if (in) {
+        realPosition.m_pConfig = g_pConfigManager->getAnimationPropertyConfig("layersIn");
+        realSize.m_pConfig     = g_pConfigManager->getAnimationPropertyConfig("layersIn");
+        alpha.m_pConfig        = g_pConfigManager->getAnimationPropertyConfig("fadeLayersIn");
+    } else {
+        realPosition.m_pConfig = g_pConfigManager->getAnimationPropertyConfig("layersOut");
+        realSize.m_pConfig     = g_pConfigManager->getAnimationPropertyConfig("layersOut");
+        alpha.m_pConfig        = g_pConfigManager->getAnimationPropertyConfig("fadeLayersOut");
+    }
 
     if (ANIMSTYLE.starts_with("slide")) {
         // get closest edge


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
- New layer anim configs: 
  - `layersIn`, `layersOut` (children of `layers`)
  - `fadeLayersIn`, `fadeLayersOut` (children of `fadeLayers`)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
- I'm not sure if I should add `INITANIMCFG("fadeLayers");` and its children or not

#### Is it ready for merging, or does it need work?
- Tested, works, should be ready

