### PR TITLE
IME: fix crash and auto enter

### DIFF
--- a/src/managers/input/InputMethodRelay.cpp
+++ b/src/managers/input/InputMethodRelay.cpp
@@ -49,7 +49,7 @@ void CInputMethodRelay::onNewIME(wlr_input_method_v2* pIME) {
             Debug::log(LOG, "IME Destroy");
 
             if (PTI)
-                PTI->enter(PTI->focusedSurface());
+                PTI->leave();
         },
         this, "IMERelay");
 
@@ -92,8 +92,18 @@ void CInputMethodRelay::onNewIME(wlr_input_method_v2* pIME) {
         },
         this, "IMERelay");
 
-    if (const auto PTI = getFocusedTextInput(); PTI)
-        PTI->enter(PTI->focusedSurface());
+    if (!g_pCompositor->m_pLastFocus)
+        return;
+
+    for (auto& ti : m_vTextInputs) {
+        if (ti->client() != wl_resource_get_client(g_pCompositor->m_pLastFocus->resource))
+            continue;
+
+        if (ti->isV3())
+            ti->enter(g_pCompositor->m_pLastFocus);
+        else
+            ti->onEnabled(g_pCompositor->m_pLastFocus);
+    }
 }
 
 void CInputMethodRelay::setIMEPopupFocus(CInputPopup* pPopup, wlr_surface* pSurface) {

--- a/src/protocols/TextInputV1.cpp
+++ b/src/protocols/TextInputV1.cpp
@@ -167,11 +167,13 @@ void CTextInputV1ProtocolManager::handleActivate(wl_client* client, wl_resource*
         Debug::log(WARN, "Text-input-v1 PTI{:x}: No surface to activate text input on!", (uintptr_t)PTI);
         return;
     }
+    PTI->active = true;
     PTI->pTextInput->onEnabled(wlr_surface_from_resource(surface));
 }
 
 void CTextInputV1ProtocolManager::handleDeactivate(wl_client* client, wl_resource* resource, wl_resource* seat) {
     const auto PTI = tiFromResource(resource);
+    PTI->active    = false;
     PTI->pTextInput->onDisabled();
 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes a crash with IME.
Fix auto entering a focused text input when new IME.

When the last focused surface before IME exit gets closed, it's not removed from `m_vTextInputs`. After this when you launch IME and try to move to a different text input, hyprland crashes.

Steps to reproduce
1. Open any application with text input v1 or v3
2. Exit/Kill IME
3. Close the application from step 1
4. Open two application with text input v1 or v3
5. Focus on one application and launch IME
6. Try change focus to another application
7. Crash

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Not really

#### Is it ready for merging, or does it need work?
I think so

