### PR TITLE
Fix xcursor scaling

### DIFF
--- a/src/managers/CursorManager.cpp
+++ b/src/managers/CursorManager.cpp
@@ -198,8 +198,10 @@ void CCursorManager::updateTheme() {
     float highestScale = 1.0;
 
     for (auto& m : g_pCompositor->m_vMonitors) {
-        if (m->scale > highestScale)
+        if (m->scale > highestScale) {
             highestScale = m->scale;
+            wlr_xcursor_manager_load(m_pWLRXCursorMgr, m->scale);
+        }
     }
 
     if (highestScale * m_iSize == m_sCurrentStyleInfo.size)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

#5009 introduces libhyprcursor support. However, it breaks xcursor scaling since related `wlr_xcursor_manager_load` function calls are deleted. For users using xcursor as fallback to hyprcursor, these codes are necessary to make cursor size scale properly.

This pr fixes xcursor scaling by adding `wlr_xcursor_manager_load(m_pWLRXCursorMgr, m->scale);` back.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Ready.
