### PR TITLE
workspacerules: add back on-created-empty functionality

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1256,10 +1256,21 @@ PHLWORKSPACE CCompositor::getWorkspaceByID(const int& id) {
 void CCompositor::sanityCheckWorkspaces() {
     auto it = m_vWorkspaces.begin();
     while (it != m_vWorkspaces.end()) {
+        const auto& WORKSPACE          = *it;
+
         // If ref == 1, only the compositor holds a ref, which means it's inactive and has no mapped windows.
-        if (!(*it)->m_bPersistent && it->use_count() == 1) {
+        if (!WORKSPACE->m_bPersistent && WORKSPACE.use_count() == 1) {
             it = m_vWorkspaces.erase(it);
             continue;
+        }
+
+        const auto WORKSPACERULE = g_pConfigManager->getWorkspaceRuleFor(*it);
+
+        if (!WORKSPACE->m_bOnCreatedEmptyExecuted) {
+             if (auto cmd = WORKSPACERULE.onCreatedEmptyRunCmd)
+                 g_pKeybindManager->spawn(*cmd);
+
+            WORKSPACE->m_bOnCreatedEmptyExecuted = true;
         }
 
         ++it;

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1264,15 +1264,6 @@ void CCompositor::sanityCheckWorkspaces() {
             continue;
         }
 
-        const auto WORKSPACERULE = g_pConfigManager->getWorkspaceRuleFor(*it);
-
-        if (!WORKSPACE->m_bOnCreatedEmptyExecuted) {
-            if (auto cmd = WORKSPACERULE.onCreatedEmptyRunCmd)
-                g_pKeybindManager->spawn(*cmd);
-
-            WORKSPACE->m_bOnCreatedEmptyExecuted = true;
-        }
-
         ++it;
     }
 }

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1256,7 +1256,7 @@ PHLWORKSPACE CCompositor::getWorkspaceByID(const int& id) {
 void CCompositor::sanityCheckWorkspaces() {
     auto it = m_vWorkspaces.begin();
     while (it != m_vWorkspaces.end()) {
-        const auto& WORKSPACE          = *it;
+        const auto& WORKSPACE = *it;
 
         // If ref == 1, only the compositor holds a ref, which means it's inactive and has no mapped windows.
         if (!WORKSPACE->m_bPersistent && WORKSPACE.use_count() == 1) {
@@ -1267,8 +1267,8 @@ void CCompositor::sanityCheckWorkspaces() {
         const auto WORKSPACERULE = g_pConfigManager->getWorkspaceRuleFor(*it);
 
         if (!WORKSPACE->m_bOnCreatedEmptyExecuted) {
-             if (auto cmd = WORKSPACERULE.onCreatedEmptyRunCmd)
-                 g_pKeybindManager->spawn(*cmd);
+            if (auto cmd = WORKSPACERULE.onCreatedEmptyRunCmd)
+                g_pKeybindManager->spawn(*cmd);
 
             WORKSPACE->m_bOnCreatedEmptyExecuted = true;
         }

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2237,8 +2237,8 @@ std::optional<std::string> CConfigManager::handleWorkspaceRules(const std::strin
     //     rules                  = value.substr(WORKSPACE_DELIM + 1);
     // }
 
-    const static std::string ruleOnCreatedEmtpy    = "on-created-empty:";
-    const static int         ruleOnCreatedEmtpyLen = ruleOnCreatedEmtpy.length();
+    const static std::string ruleOnCreatedEmpty    = "on-created-empty:";
+    const static int         ruleOnCreatedEmptyLen = ruleOnCreatedEmpty.length();
 
     auto                     assignRule = [&](std::string rule) -> std::optional<std::string> {
         size_t delim = std::string::npos;
@@ -2274,8 +2274,8 @@ std::optional<std::string> CConfigManager::handleWorkspaceRules(const std::strin
             wsRule.isPersistent = configStringToInt(rule.substr(delim + 11));
         else if ((delim = rule.find("defaultName:")) != std::string::npos)
             wsRule.defaultName = rule.substr(delim + 12);
-        else if ((delim = rule.find(ruleOnCreatedEmtpy)) != std::string::npos)
-            wsRule.onCreatedEmptyRunCmd = cleanCmdForWorkspace(name, rule.substr(delim + ruleOnCreatedEmtpyLen));
+        else if ((delim = rule.find(ruleOnCreatedEmpty)) != std::string::npos)
+            wsRule.onCreatedEmptyRunCmd = cleanCmdForWorkspace(name, rule.substr(delim + ruleOnCreatedEmptyLen));
         else if ((delim = rule.find("layoutopt:")) != std::string::npos) {
             std::string opt = rule.substr(delim + 10);
             if (!opt.contains(":")) {

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -44,6 +44,9 @@ void CWorkspace::init(PHLWORKSPACE self) {
     const auto WORKSPACERULE = g_pConfigManager->getWorkspaceRuleFor(self);
     m_bPersistent            = WORKSPACERULE.isPersistent;
 
+    if (auto cmd = WORKSPACERULE.onCreatedEmptyRunCmd)
+        g_pKeybindManager->spawn(*cmd);
+
     g_pEventManager->postEvent({"createworkspace", m_szName});
     g_pEventManager->postEvent({"createworkspacev2", std::format("{},{}", m_iID, m_szName)});
     EMIT_HOOK_EVENT("createWorkspace", this);

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -58,7 +58,7 @@ class CWorkspace {
     // last monitor (used on reconnect)
     std::string m_szLastMonitor = "";
 
-    bool m_bPersistent = false;
+    bool        m_bPersistent = false;
 
     // Inert: destroyed and invalid. If this is true, release the ptr you have.
     bool        inert();

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -58,9 +58,6 @@ class CWorkspace {
     // last monitor (used on reconnect)
     std::string m_szLastMonitor = "";
 
-    // Whether the user configured command for on-created-empty has been executed, if any
-    bool m_bOnCreatedEmptyExecuted = false;
-
     bool m_bPersistent = false;
 
     // Inert: destroyed and invalid. If this is true, release the ptr you have.

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -179,6 +179,7 @@ class CKeybindManager {
     friend class CCompositor;
     friend class CInputManager;
     friend class CConfigManager;
+    friend class CWorkspace;
 };
 
 inline std::unique_ptr<CKeybindManager> g_pKeybindManager;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
`on-created-empty` stopped working after https://github.com/hyprwm/Hyprland/commit/094bce811831675b03939e4a2d527998850c906d. i guess the `m_bOnCreatedEmptyExecuted` check was mistakenly removed while simplying the function. 



#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no


#### Is it ready for merging, or does it need work?
ready to merge
