### PR TITLE
IME: fix ime on closing window

### DIFF
--- a/src/managers/input/InputMethodRelay.cpp
+++ b/src/managers/input/InputMethodRelay.cpp
@@ -160,6 +160,25 @@ void CInputMethodRelay::updateAllPopups() {
     }
 }
 
+void CInputMethodRelay::activateIME(CTextInput* pInput) {
+    if (!m_pWLRIME)
+        return;
+
+    wlr_input_method_v2_send_activate(g_pInputManager->m_sIMERelay.m_pWLRIME);
+    commitIMEState(pInput);
+}
+
+void CInputMethodRelay::deactivateIME(CTextInput* pInput) {
+    if (!m_pWLRIME)
+        return;
+
+    if (!m_pWLRIME->active)
+        return;
+
+    wlr_input_method_v2_send_deactivate(g_pInputManager->m_sIMERelay.m_pWLRIME);
+    commitIMEState(pInput);
+}
+
 void CInputMethodRelay::commitIMEState(CTextInput* pInput) {
     if (!m_pWLRIME)
         return;

--- a/src/managers/input/InputMethodRelay.hpp
+++ b/src/managers/input/InputMethodRelay.hpp
@@ -20,6 +20,8 @@ class CInputMethodRelay {
 
     wlr_input_method_v2* m_pWLRIME = nullptr;
 
+    void                 activateIME(CTextInput* pInput);
+    void                 deactivateIME(CTextInput* pInput);
     void                 commitIMEState(CTextInput* pInput);
     void                 removeTextInput(CTextInput* pInput);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fix IME not working sometimes when closing a window.

When closing a window, sometimes IME gets deactivated by textInputDestroy callback after IME have been activated for another surface.
This causes the IME to not work on the another surface and have to leave and reenter to get the IME working.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Not really

#### Is it ready for merging, or does it need work?
Ready for merging

