### PR TITLE
Fix master workspace orientation not being restored after workspace rule no longer applies

### DIFF
--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -80,6 +80,7 @@ class CHyprMasterLayout : public IHyprLayout {
     void                              buildOrientationCycleVectorFromVars(std::vector<eOrientation>& cycle, CVarList& vars);
     void                              buildOrientationCycleVectorFromEOperation(std::vector<eOrientation>& cycle);
     void                              runOrientationCycle(SLayoutMessageHeader& header, CVarList* vars, int next);
+    eOrientation                      getDynamicOrientation(PHLWORKSPACE);
     int                               getNodesOnWorkspace(const int&);
     void                              applyNodeDataToWindow(SMasterNodeData*);
     SMasterNodeData*                  getNodeFromWindow(CWindow*);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fix master workspace orientation not being restored after workspace rule no longer applies
The bug is described here: https://github.com/hyprwm/Hyprland/issues/5312#issuecomment-2029071918

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
ready

