### PR TITLE
Dont set active monitor when simulating mouse movement

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -624,7 +624,7 @@ void CInputManager::processMouseDownNormal(wlr_pointer_button_event* e) {
     }
 
     switch (e->state) {
-        case WLR_BUTTON_PRESSED:
+        case WL_POINTER_BUTTON_STATE_PRESSED:
             if (*PFOLLOWMOUSE == 3) // don't refocus on full loose
                 break;
 
@@ -646,7 +646,7 @@ void CInputManager::processMouseDownNormal(wlr_pointer_button_event* e) {
                 g_pCompositor->changeWindowZOrder(g_pCompositor->m_pLastWindow, true);
 
             break;
-        case WLR_BUTTON_RELEASED: break;
+        case WL_POINTER_BUTTON_STATE_RELEASED: break;
     }
 
     // notify app if we didnt handle it
@@ -659,7 +659,7 @@ void CInputManager::processMouseDownNormal(wlr_pointer_button_event* e) {
 
 void CInputManager::processMouseDownKill(wlr_pointer_button_event* e) {
     switch (e->state) {
-        case WLR_BUTTON_PRESSED: {
+        case WL_POINTER_BUTTON_STATE_PRESSED: {
             const auto PWINDOW = g_pCompositor->vectorToWindowUnified(getMouseCoordsInternal(), RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING);
 
             if (!PWINDOW) {
@@ -671,7 +671,7 @@ void CInputManager::processMouseDownKill(wlr_pointer_button_event* e) {
             kill(PWINDOW->getPID(), SIGKILL);
             break;
         }
-        case WLR_BUTTON_RELEASED: break;
+        case WL_POINTER_BUTTON_STATE_RELEASED: break;
         default: break;
     }
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -196,7 +196,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
 
     g_pLayoutManager->getCurrentLayout()->onMouseMove(getMouseCoordsInternal());
 
-    if (PMONITOR && PMONITOR != g_pCompositor->m_pLastMonitor && (*PMOUSEFOCUSMON || refocus))
+    if (PMONITOR && PMONITOR != g_pCompositor->m_pLastMonitor && (*PMOUSEFOCUSMON || refocus) && !m_pForcedFocus)
         g_pCompositor->setActiveMonitor(PMONITOR);
 
     if (g_pSessionLockManager->isSessionLocked()) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Dont set active monitor when simulating mouse movement.
This fixes an annoying bug where sometimes the cursor monitor is set to active even though i'm using another monitor with the keyboard
also fix some warnings about the wrong enum

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
ready

