### PR TITLE
don't remove pinned focus on workspace change

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -569,7 +569,8 @@ void CMonitor::changeWorkspace(const PHLWORKSPACE& pWorkspace, bool internal, bo
                 w->moveToWorkspace(pWorkspace);
         }
 
-        if (!noFocus && !g_pCompositor->m_pLastMonitor->activeSpecialWorkspace) {
+        if (!noFocus && !g_pCompositor->m_pLastMonitor->activeSpecialWorkspace &&
+            !(g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_bPinned && g_pCompositor->m_pLastWindow->m_iMonitorID == ID)) {
             static auto PFOLLOWMOUSE = CConfigValue<Hyprlang::INT>("input:follow_mouse");
             CWindow*    pWindow      = pWorkspace->getLastFocusedWindow();
 
@@ -627,10 +628,12 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
 
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(ID);
 
-        if (const auto PLAST = activeWorkspace->getLastFocusedWindow(); PLAST)
-            g_pCompositor->focusWindow(PLAST);
-        else
-            g_pInputManager->refocus();
+        if (!(g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_bPinned && g_pCompositor->m_pLastWindow->m_iMonitorID == ID)) {
+            if (const auto PLAST = activeWorkspace->getLastFocusedWindow(); PLAST)
+                g_pCompositor->focusWindow(PLAST);
+            else
+                g_pInputManager->refocus();
+        }
 
         g_pCompositor->updateFullscreenFadeOnWorkspace(activeWorkspace);
 
@@ -693,10 +696,12 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
 
     g_pLayoutManager->getCurrentLayout()->recalculateMonitor(ID);
 
-    if (const auto PLAST = pWorkspace->getLastFocusedWindow(); PLAST)
-        g_pCompositor->focusWindow(PLAST);
-    else
-        g_pInputManager->refocus();
+    if (!(g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_bPinned && g_pCompositor->m_pLastWindow->m_iMonitorID == ID)) {
+        if (const auto PLAST = pWorkspace->getLastFocusedWindow(); PLAST)
+            g_pCompositor->focusWindow(PLAST);
+        else
+            g_pInputManager->refocus();
+    }
 
     g_pEventManager->postEvent(SHyprIPCEvent{"activespecial", pWorkspace->m_szName + "," + szName});
 


### PR DESCRIPTION
Doesn't remove focus from pinned window on workspace change.
partially fixes|: https://github.com/hyprwm/Hyprland/issues/5460
(changing between workspaces on different monitors doesn't restore focus to the pinned window, since the respective variable can't be set to it or restoring focus later won't work)

seems to work without causing issues