### PR TITLE
workspace: fix crash on destruction of compositor

### DIFF
--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -57,11 +57,15 @@ CWorkspace::~CWorkspace() {
 
     Debug::log(LOG, "Destroying workspace ID {}", m_iID);
 
-    g_pHookSystem->unhook(m_pFocusedWindowHook);
+    // check if g_pHookSystem and g_pEventManager exist, they might be destroyed as in when the compositor is closing.
+    if (g_pHookSystem)
+        g_pHookSystem->unhook(m_pFocusedWindowHook);
 
-    g_pEventManager->postEvent({"destroyworkspace", m_szName});
-    g_pEventManager->postEvent({"destroyworkspacev2", std::format("{},{}", m_iID, m_szName)});
-    EMIT_HOOK_EVENT("destroyWorkspace", this);
+    if (g_pEventManager) {
+        g_pEventManager->postEvent({"destroyworkspace", m_szName});
+        g_pEventManager->postEvent({"destroyworkspacev2", std::format("{},{}", m_iID, m_szName)});
+        EMIT_HOOK_EVENT("destroyWorkspace", this);
+    }
 }
 
 void CWorkspace::startAnim(bool in, bool left, bool instant) {


### PR DESCRIPTION
when the compositor destructs because of exiting hyprland the hookmanager and eventmanager is already destroyed, add an if check in the destructor of workspace so it doesnt segfault on exit.


backtrace when exiting hyprland

```
Thread 1 "Hyprland" received signal SIGSEGV, Segmentation fault.
0x0000555555c69235 in std::__cxx11::list<std::function<void (void*, SCallbackInfo&, std::any)>, std::allocator<std::function<void (void*, SCallbackInfo&, std::any)> > >::begin() (this=0xe8) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/stl_list.h:1022
1022	     begin() _GLIBCXX_NOEXCEPT
(gdb) bt
#0  0x0000555555c69235 in std::__cxx11::list<std::function<void (void*, SCallbackInfo&, std::any)>, std::allocator<std::function<void (void*, SCallbackInfo&, std::any)> > >::begin() (this=0xe8) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/stl_list.h:1022
#1  std::__cxx11::list<std::function<void(void*, SCallbackInfo&, std::any)>, std::allocator<std::function<void(void*, SCallbackInfo&, std::any)> > >::remove_if<CHookSystemManager::unhook(HOOK_CALLBACK_FN*)::<lambda(const auto:64&)> > (__pred=..., this=0xe8)
    at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/list.tcc:549
#2  std::erase_if<std::function<void(void*, SCallbackInfo&, std::any)>, std::allocator<std::function<void(void*, SCallbackInfo&, std::any)> >, CHookSystemManager::unhook(HOOK_CALLBACK_FN*)::<lambda(const auto:64&)> >
    (__pred=..., __cont=<error reading variable: Cannot access memory at address 0xe8>) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/list:96
#3  CHookSystemManager::unhook(std::function<void (void*, SCallbackInfo&, std::any)>*) (this=0x0, fn=0x6040000748a0) at /home/tom/dev/Hyprland/src/managers/HookSystemManager.cpp:23
#4  0x0000555555a96644 in CWorkspace::~CWorkspace (this=0x61700000eb10, __in_chrg=<optimized out>) at /home/tom/dev/Hyprland/src/desktop/Workspace.cpp:62
#5  0x00005555557d4a29 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use (this=0x61700000eb00) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/shared_ptr_base.h:175
#6  std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use_cold (this=0x61700000eb00) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/shared_ptr_base.h:199
#7  0x0000555555b55981 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count (this=0x61c0000190f8, __in_chrg=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/shared_ptr_base.h:1071
#8  std::__shared_ptr<CWorkspace, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr (this=0x61c0000190f0, __in_chrg=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/shared_ptr_base.h:1524
#9  std::shared_ptr<CWorkspace>::~shared_ptr (this=0x61c0000190f0, __in_chrg=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/shared_ptr.h:175
#10 CMonitor::~CMonitor (this=0x61c000019090, __in_chrg=<optimized out>) at /home/tom/dev/Hyprland/src/helpers/Monitor.cpp:29
#11 0x000055555577f640 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=0x61c000019080) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/shared_ptr_base.h:346
#12 std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release (this=0x61c000019080) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/shared_ptr_base.h:317
#13 std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count (this=0x603000111fd8, __in_chrg=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/shared_ptr_base.h:1071
#14 std::__shared_ptr<CMonitor, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr (this=0x603000111fd0, __in_chrg=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/shared_ptr_base.h:1524
#15 std::shared_ptr<CMonitor>::~shared_ptr (this=0x603000111fd0, __in_chrg=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/shared_ptr.h:175
#16 std::destroy_at<std::shared_ptr<CMonitor> > (__location=0x603000111fd0) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/stl_construct.h:88
#17 std::_Destroy<std::shared_ptr<CMonitor> > (__pointer=0x603000111fd0) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/stl_construct.h:149
#18 std::_Destroy_aux<false>::__destroy<std::shared_ptr<CMonitor>*> (__last=0x603000111ff0, __first=0x603000111fd0) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/stl_construct.h:163
#19 std::_Destroy<std::shared_ptr<CMonitor>*> (__last=0x603000111ff0, __first=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/stl_construct.h:196
#20 std::_Destroy<std::shared_ptr<CMonitor>*, std::shared_ptr<CMonitor> > (__last=0x603000111ff0, __first=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/alloc_traits.h:948
#21 std::vector<std::shared_ptr<CMonitor>, std::allocator<std::shared_ptr<CMonitor> > >::~vector (this=0x618000000650, __in_chrg=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/stl_vector.h:732
#22 CCompositor::~CCompositor (this=this@entry=0x618000000480, __in_chrg=<optimized out>) at /home/tom/dev/Hyprland/src/Compositor.cpp:88
#23 0x000055555572bd38 in std::default_delete<CCompositor>::operator() (__ptr=0x618000000480, this=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/unique_ptr.h:93
#24 std::__uniq_ptr_impl<CCompositor, std::default_delete<CCompositor> >::reset (__p=0x0, this=0x5555563131d0 <g_pCompositor>) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/unique_ptr.h:211
#25 std::unique_ptr<CCompositor, std::default_delete<CCompositor> >::reset (__p=0x0, this=0x5555563131d0 <g_pCompositor>) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/unique_ptr.h:509
#26 main (argc=<optimized out>, argv=<optimized out>) at /home/tom/dev/Hyprland/src/main.cpp:117
```
