### PR TITLE
compositor: move wl_display_destroy_clients so we dont crash on exit

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -419,12 +419,10 @@ void CCompositor::cleanup() {
         g_pXWaylandManager->m_sWLRXWayland = nullptr;
     }
 
+    wl_display_destroy_clients(g_pCompositor->m_sWLDisplay);
     removeAllSignals();
 
     g_pInputManager.reset();
-
-    wl_display_destroy_clients(g_pCompositor->m_sWLDisplay);
-
     g_pDecorationPositioner.reset();
     g_pCursorManager.reset();
     g_pPluginSystem.reset();


### PR DESCRIPTION
if enough clients are open when destructing the compositor destroying clients will emit a wl_surface_unmap that a WLListener catches and doing so it calls listener_unmapLayerSurface that tries to iterate over input manager that is already destroyed, move the destruction of clients above g_pInputManager.reset() and removeAllSignals() to ensure we dont segfault at exit.

backtrace when exiting hyprland

```
Core was generated by `Hyprland'.
bt
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x000055555570309c in std::operator- (__x=..., __y=...) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/stl_deque.h:373
373		 * (__x._M_node - __y._M_node - bool(__x._M_node))
[Current thread is 1 (Thread 0x7ffff645eac0 (LWP 115365))]
(gdb) bt
#0  0x000055555570309c in std::operator-
    (__x=<error reading variable: Cannot access memory at address 0x360>, __y=<error reading variable: Cannot access memory at address 0x340>) at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/stl_deque.h:373
#1  0x0000555555702a05 in std::deque<SLayerSurface*, std::allocator<SLayerSurface*> >::size (this=0x330)
    at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/stl_deque.h:1269
#2  0x00005555557021d6 in std::erase<SLayerSurface*, std::allocator<SLayerSurface*>, SLayerSurface*>
    (__cont=<error reading variable: Cannot access memory at address 0x378>, __value=@0x7fffffffcbf0: 0x555557e3fba0)
    at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/deque:122
#3  0x0000555555700335 in Events::listener_unmapLayerSurface (owner=0x555557e3fba0, data=0x0) at ../hyprland-9999/src/events/Layers.cpp:188
#4  0x00005555556d8a83 in std::__invoke_impl<void, void (*&)(void*, void*), void*, void*>
    (__f=@0x555557e3ffa8: 0x5555557000c1 <Events::listener_unmapLayerSurface(void*, void*)>)
    at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/invoke.h:61
#5  0x00005555556d84f4 in std::__invoke_r<void, void (*&)(void*, void*), void*, void*>
    (__fn=@0x555557e3ffa8: 0x5555557000c1 <Events::listener_unmapLayerSurface(void*, void*)>)
    at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/invoke.h:111
#6  0x00005555556d7d5f in std::_Function_handler<void (void*, void*), void (*)(void*, void*)>::_M_invoke(std::_Any_data const&, void*&&, void*&&) (__functor=..., __args#0=@0x7fffffffce30: 0x555557e3fba0, __args#1=@0x7fffffffce28: 0x0)
    at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/std_function.h:290
#7  0x00005555557461d1 in std::function<void (void*, void*)>::operator()(void*, void*) const
    (this=0x555557e3ffa8, __args#0=0x555557e3fba0, __args#1=0x0)
    at /usr/lib/gcc/x86_64-pc-linux-gnu/13/include/g++-v13/bits/std_function.h:591
#8  0x0000555555745b4b in CHyprWLListener::emit (this=0x555557e3ff80, data=0x0) at ../hyprland-9999/src/helpers/WLListener.cpp:61
#9  0x00005555557458f2 in handleWrapped (listener=0x555557e3ff80, data=0x0) at ../hyprland-9999/src/helpers/WLListener.cpp:14
#10 0x00007ffff7f97ae8 in wl_signal_emit_mutable () at /usr/lib64/libwayland-server.so.0
#11 0x00005555558b1e99 in wlr_surface_unmap (surface=surface@entry=0x555557e3ef70)
    at ../hyprland-9999/subprojects/wlroots/types/wlr_compositor.c:854
#12 0x00005555558b3868 in wlr_surface_unmap (surface=0x555557e3ef70) at ../hyprland-9999/subprojects/wlroots/types/wlr_compositor.c:752
#13 surface_destroy_role_object (surface=0x555557e3ef70) at ../hyprland-9999/subprojects/wlroots/types/wlr_compositor.c:932
#14 surface_destroy_role_object (surface=0x555557e3ef70) at ../hyprland-9999/subprojects/wlroots/types/wlr_compositor.c:928
#15 surface_handle_resource_destroy (resource=<optimized out>) at ../hyprland-9999/subprojects/wlroots/types/wlr_compositor.c:727
#16 0x00007ffff7f933db in ??? () at /usr/lib64/libwayland-server.so.0
#17 0x00007ffff7f9950b in wl_client_destroy () at /usr/lib64/libwayland-server.so.0
#18 0x00007ffff7f996a9 in wl_display_destroy_clients () at /usr/lib64/libwayland-server.so.0
#19 0x00005555555e7b26 in CCompositor::cleanup (this=0x555555b6aca0) at ../hyprland-9999/src/Compositor.cpp:426
```

with this MR and #5495 i think the issue #4849 is solved. i havent hit a coredump yet after applying those. the traces are a bit different since -git contains a few changes compared to last release like the #5466

