### PR TITLE
Add count group flag in windowCount workspace selector prop

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1280,6 +1280,16 @@ int CCompositor::getWindowsOnWorkspace(const int& id, std::optional<bool> onlyTi
     return no;
 }
 
+int CCompositor::getGroupsOnWorkspace(const int& id, std::optional<bool> onlyTiled) {
+    int no = 0;
+    for (auto& w : m_vWindows) {
+        if (w->workspaceID() == id && w->m_bIsMapped && !(onlyTiled.has_value() && !w->m_bIsFloating != onlyTiled.value()) && w->m_sGroupData.head)
+            no++;
+    }
+
+    return no;
+}
+
 CWindow* CCompositor::getUrgentWindow() {
     for (auto& w : m_vWindows) {
         if (w->m_bIsMapped && w->m_bIsUrgent)

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -151,6 +151,7 @@ class CCompositor {
     void           sanityCheckWorkspaces();
     void           updateWorkspaceWindowDecos(const int&);
     int            getWindowsOnWorkspace(const int& id, std::optional<bool> onlyTiled = {});
+    int            getGroupsOnWorkspace(const int& id, std::optional<bool> onlyTiled = {});
     CWindow*       getUrgentWindow();
     bool           hasUrgentWindowOnWorkspace(const int&);
     CWindow*       getFirstWindowOnWorkspace(const int&);

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -852,6 +852,7 @@ void CWindow::destroyGroup() {
             return;
         }
         m_sGroupData.pNextWindow = nullptr;
+        m_sGroupData.head        = false;
         updateWindowDecos();
         return;
     }

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -245,7 +245,8 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
             // s - special: s[true]
             // n - named: n[true] or n[s:string] or n[e:string]
             // m - monitor: m[monitor_selector]
-            // w - windowCount: w[0-4] or w[1], optional flag t or f for tiled or floating, e.g. w[t0-1]
+            // w - windowCount: w[1-4] or w[1], optional flag t or f for tiled or floating, e.g. w[t1-2]
+            // g - groupCount: g[1-4] or g[1], optional flag t or f for tiled or floating, e.g. g[t1-2]
 
             const auto  NEXTSPACE = selector.find_first_of(' ', i);
             std::string prop      = selector.substr(i, NEXTSPACE == std::string::npos ? std::string::npos : NEXTSPACE - i);
@@ -341,9 +342,9 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
                 continue;
             }
 
-            if (cur == 'w') {
+            if (cur == 'w' || cur == 'g') {
                 int from = 0, to = 0;
-                if (!prop.starts_with("w[") || !prop.ends_with("]")) {
+                if ((!prop.starts_with("w[") && !prop.starts_with("g[")) || !prop.ends_with("]")) {
                     Debug::log(LOG, "Invalid selector {}", selector);
                     return false;
                 }
@@ -375,7 +376,15 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
                         return false;
                     }
 
-                    return g_pCompositor->getWindowsOnWorkspace(m_iID, wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled)) == from;
+                    int count = -1;
+                    if (cur == 'w')
+                        count = g_pCompositor->getWindowsOnWorkspace(m_iID, wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled));
+                    else if (cur == 'g')
+                        count = g_pCompositor->getGroupsOnWorkspace(m_iID, wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled));
+
+                    if (count != from)
+                        return false;
+                    continue;
                 }
 
                 const auto DASHPOS = prop.find("-");
@@ -399,8 +408,13 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
                     return false;
                 }
 
-                const auto WINDOWSONWORKSPACE = g_pCompositor->getWindowsOnWorkspace(m_iID, wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled));
-                if (std::clamp(WINDOWSONWORKSPACE, from, to) != WINDOWSONWORKSPACE)
+                int count = -1;
+                if (cur == 'w')
+                    count = g_pCompositor->getWindowsOnWorkspace(m_iID, wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled));
+                else if (cur == 'g')
+                    count = g_pCompositor->getGroupsOnWorkspace(m_iID, wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled));
+
+                if (std::clamp(count, from, to) != count)
                     return false;
                 continue;
             }

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -245,8 +245,8 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
             // s - special: s[true]
             // n - named: n[true] or n[s:string] or n[e:string]
             // m - monitor: m[monitor_selector]
-            // w - windowCount: w[1-4] or w[1], optional flag t or f for tiled or floating, e.g. w[t1-2]
-            // g - groupCount: g[1-4] or g[1], optional flag t or f for tiled or floating, e.g. g[t1-2]
+            // w - windowCount: w[1-4] or w[1], optional flag t or f for tiled or floating and
+            //                  flag g to count groups instead of windows, e.g. w[t1-2], w[fg4]
 
             const auto  NEXTSPACE = selector.find_first_of(' ', i);
             std::string prop      = selector.substr(i, NEXTSPACE == std::string::npos ? std::string::npos : NEXTSPACE - i);
@@ -342,24 +342,34 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
                 continue;
             }
 
-            if (cur == 'w' || cur == 'g') {
+            if (cur == 'w') {
                 int from = 0, to = 0;
-                if ((!prop.starts_with("w[") && !prop.starts_with("g[")) || !prop.ends_with("]")) {
+                if (!prop.starts_with("w[") || !prop.ends_with("]")) {
                     Debug::log(LOG, "Invalid selector {}", selector);
                     return false;
                 }
 
                 prop = prop.substr(2, prop.length() - 3);
 
-                int wantsOnlyTiled = -1;
+                int  wantsOnlyTiled  = -1;
+                bool wantsCountGroup = false;
 
-                if (prop.starts_with("t")) {
-                    wantsOnlyTiled = 1;
-                    prop           = prop.substr(1);
-                } else if (prop.starts_with("f")) {
-                    wantsOnlyTiled = 0;
-                    prop           = prop.substr(1);
+                int  flagCount = 0;
+                for (auto& flag : prop) {
+                    if (flag == 't' && wantsOnlyTiled == -1) {
+                        wantsOnlyTiled = 1;
+                        flagCount++;
+                    } else if (flag == 'f' && wantsOnlyTiled == -1) {
+                        wantsOnlyTiled = 0;
+                        flagCount++;
+                    } else if (flag == 'g' && !wantsCountGroup) {
+                        wantsCountGroup = true;
+                        flagCount++;
+                    } else {
+                        break;
+                    }
                 }
+                prop = prop.substr(flagCount);
 
                 if (!prop.contains("-")) {
                     // try single
@@ -376,11 +386,11 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
                         return false;
                     }
 
-                    int count = -1;
-                    if (cur == 'w')
-                        count = g_pCompositor->getWindowsOnWorkspace(m_iID, wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled));
-                    else if (cur == 'g')
+                    int count;
+                    if (wantsCountGroup)
                         count = g_pCompositor->getGroupsOnWorkspace(m_iID, wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled));
+                    else
+                        count = g_pCompositor->getWindowsOnWorkspace(m_iID, wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled));
 
                     if (count != from)
                         return false;
@@ -408,11 +418,11 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
                     return false;
                 }
 
-                int count = -1;
-                if (cur == 'w')
-                    count = g_pCompositor->getWindowsOnWorkspace(m_iID, wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled));
-                else if (cur == 'g')
+                int count;
+                if (wantsCountGroup)
                     count = g_pCompositor->getGroupsOnWorkspace(m_iID, wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled));
+                else
+                    count = g_pCompositor->getWindowsOnWorkspace(m_iID, wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled));
 
                 if (std::clamp(count, from, to) != count)
                     return false;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds the groupCount workspace selector prop.
The groupCount is the same as the windowCount but it counts groups instead of windows in a workspace.
Resolves #5488

Workspace rules can now do
```ini
workspace = g[t1], bordersize:10
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
A comment here shows an example using windowCount with range `0-4`. But this is invalid according to the code. Did you meant to make `0-4` a valid range or just typo in the comment?
```cpp
// w - windowCount: w[0-4] or w[1], optional flag t or f for tiled or floating, e.g. w[t0-1]
```
```cpp
if (to < from || to < 1 || from < 1) {
    Debug::log(LOG, "Invalid selector {}", selector);
    return false;
}
```

#### Is it ready for merging, or does it need work?
Ready, but wiki mr needed.