### PR TITLE
nix: install shell completions

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -3,6 +3,7 @@
   stdenv,
   pkg-config,
   pkgconf,
+  installShellFiles,
   makeWrapper,
   meson,
   ninja,
@@ -86,6 +87,7 @@ in
     '';
 
     nativeBuildInputs = [
+      installShellFiles
       jq
       makeWrapper
       meson
@@ -149,6 +151,16 @@ in
           pkgconf
         ]}
       ''}
+
+      installShellCompletion --cmd hyprctl \
+        --bash $src/hyprctl/hyprctl.bash   \
+        --fish $src/hyprctl/hyprctl.fish   \
+        --zsh  $src/hyprctl/hyprctl.zsh
+
+      installShellCompletion --cmd hyprpm \
+        --bash $src/hyprpm/hyprpm.bash    \
+        --fish $src/hyprpm/hyprpm.fish    \
+        --zsh  $src/hyprpm/hyprpm.zsh
     '';
 
     passthru.providedSessions = ["hyprland"];


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Uses nixpkgs function [`installShellCompletion`](https://nixos.org/manual/nixpkgs/stable/#installshellfiles) to install the newly-added Bash, Fish and Zsh completions for `hyprctl` and `hyprpm` commands

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Nope

#### Is it ready for merging, or does it need work?

Ready
