### PR TITLE
meson: fix hyprctl fish completions & install hyprpm completions

### DIFF
--- a/hyprctl/meson.build
+++ b/hyprctl/meson.build
@@ -3,5 +3,5 @@ executable('hyprctl', 'main.cpp',
 )
 
 install_data('hyprctl.bash', install_dir: join_paths(get_option('datadir'), 'bash-completions'), install_tag: 'runtime', rename: 'hyprctl')
-install_data('hyprctl.fish', install_dir: join_paths(get_option('datadir'), 'fish/completions'), install_tag: 'runtime')
+install_data('hyprctl.fish', install_dir: join_paths(get_option('datadir'), 'fish/vendor_completions.d'), install_tag: 'runtime')
 install_data('hyprctl.zsh', install_dir: join_paths(get_option('datadir'), 'zsh/site-functions'), install_tag: 'runtime', rename: '_hyprctl')

--- a/hyprpm/src/meson.build
+++ b/hyprpm/src/meson.build
@@ -8,3 +8,7 @@ executable('hyprpm', src,
   ],
   install : true
 )
+
+install_data('../hyprpm.bash', install_dir: join_paths(get_option('datadir'), 'bash-completions'), install_tag: 'runtime', rename: 'hyprpm')
+install_data('../hyprpm.fish', install_dir: join_paths(get_option('datadir'), 'fish/vendor_completions.d'), install_tag: 'runtime')
+install_data('../hyprpm.zsh', install_dir: join_paths(get_option('datadir'), 'zsh/site-functions'), install_tag: 'runtime', rename: '_hyprpm')


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

- Changes `fish/completions` to `fish/vendor_completions.d`, which fixes fish completions for hyprctl.
- Install hyprpm completions

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Nope

#### Is it ready for merging, or does it need work?

Ready
