### PR TITLE
Don't override fullscreen opacity if only two opacities are provided

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -603,19 +603,16 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
                     continue;
 
                 if (r == "override") {
-                    if (opacityIDX == 1) {
-                        m_sSpecialRenderData.alphaOverride           = true;
-                        m_sSpecialRenderData.alphaInactiveOverride   = true;
-                        m_sSpecialRenderData.alphaFullscreenOverride = true;
-                    } else if (opacityIDX == 2)
+                    if (opacityIDX == 1)
+                        m_sSpecialRenderData.alphaOverride = true;
+                    else if (opacityIDX == 2)
                         m_sSpecialRenderData.alphaInactiveOverride = true;
                     else if (opacityIDX == 3)
                         m_sSpecialRenderData.alphaFullscreenOverride = true;
                 } else {
                     if (opacityIDX == 0) {
-                        m_sSpecialRenderData.alpha           = std::stof(r);
-                        m_sSpecialRenderData.alphaInactive   = std::stof(r);
-                        m_sSpecialRenderData.alphaFullscreen = std::stof(r);
+                        m_sSpecialRenderData.alpha         = std::stof(r);
+                        m_sSpecialRenderData.alphaOverride = false;
                     } else if (opacityIDX == 1) {
                         m_sSpecialRenderData.alphaInactive         = std::stof(r);
                         m_sSpecialRenderData.alphaInactiveOverride = false;
@@ -628,6 +625,13 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
 
                     opacityIDX++;
                 }
+            }
+
+            if (opacityIDX == 1) {
+                m_sSpecialRenderData.alphaInactiveOverride   = m_sSpecialRenderData.alphaOverride;
+                m_sSpecialRenderData.alphaInactive           = m_sSpecialRenderData.alpha;
+                m_sSpecialRenderData.alphaFullscreenOverride = m_sSpecialRenderData.alphaOverride;
+                m_sSpecialRenderData.alphaFullscreen         = m_sSpecialRenderData.alpha;
             }
         } catch (std::exception& e) { Debug::log(ERR, "Opacity rule \"{}\" failed with: {}", r.szRule, e.what()); }
     } else if (r.szRule == "noanim") {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Specifying single value in opacity window rule correctly sets it for all three states (active, inactive, fullscreen), but providing two values unintentionally sets fullscreen one too. This makes fullscreen opacity to be unset if two are specified (wiki's already written as if this is the case).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
~~Removed ...Override = falses since they are already false by default.~~
Got confused by the fact the `alpha` (active) didn't do this, unlike inactive/fullscreen, but this makes it impossible to reset the `override` lock.
Added `m_sSpecialRenderData.alphaOverride = false;` instead to allow resetting the active alpha's lock.

#### Is it ready for merging, or does it need work?
Ready
