### PR TITLE
Expand on window matching

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2410,9 +2410,8 @@ void CCompositor::scheduleFrameForMonitor(CMonitor* pMonitor) {
 }
 
 CWindow* CCompositor::getWindowByRegex(const std::string& regexp) {
-    if (regexp == "activewindow") {
+    if (regexp.starts_with("active"))
         return m_pLastWindow;
-    }
 
     eFocusWindowMode mode = MODE_CLASS_REGEX;
 
@@ -2464,7 +2463,7 @@ CWindow* CCompositor::getWindowByRegex(const std::string& regexp) {
                 break;
             }
             case MODE_INITIAL_CLASS_REGEX: {
-                const auto initialWindowClass = w.get()->m_szInitialClass;
+                const auto initialWindowClass = w->m_szInitialClass;
                 if (!std::regex_search(initialWindowClass, regexCheck))
                     continue;
                 break;
@@ -2476,7 +2475,7 @@ CWindow* CCompositor::getWindowByRegex(const std::string& regexp) {
                 break;
             }
             case MODE_INITIAL_TITLE_REGEX: {
-                const auto initialWindowTitle = w.get()->m_szInitialTitle;
+                const auto initialWindowTitle = w->m_szInitialTitle;
                 if (!std::regex_search(initialWindowTitle, regexCheck))
                     continue;
                 break;

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -32,9 +32,12 @@ struct SKeybind {
 
 enum eFocusWindowMode {
     MODE_CLASS_REGEX = 0,
+    MODE_INITIAL_CLASS_REGEX,
     MODE_TITLE_REGEX,
+    MODE_INITIAL_TITLE_REGEX,
     MODE_ADDRESS,
-    MODE_PID
+    MODE_PID,
+    MODE_ACTIVE_WINDOW
 };
 
 struct SPressedKeyWithMods {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds `activewindow`, `initialtitle` and `initialclass` as valid targets for window matching. Also allows explicitly specifying `class:`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
\-

#### Is it ready for merging, or does it need work?
Ready