### PR TITLE
Improve Hyprpm Update Performance

### DIFF
--- a/hyprpm/src/core/PluginManager.cpp
+++ b/hyprpm/src/core/PluginManager.cpp
@@ -70,6 +70,9 @@ SHyprlandVersion CPluginManager::getHyprlandVersion() {
     std::string hlbranch = HLVERCALL.substr(HLVERCALL.find("from branch") + 12);
     hlbranch             = hlbranch.substr(0, hlbranch.find(" at commit "));
 
+    std::string hldate = HLVERCALL.substr(HLVERCALL.find("Date: ") + 6);
+    hldate = hldate.substr(0, hldate.find("\n"));
+
     std::string hlcommits;
 
     if (HLVERCALL.contains("commits:")) {
@@ -83,9 +86,9 @@ SHyprlandVersion CPluginManager::getHyprlandVersion() {
     } catch (...) { ; }
 
     if (m_bVerbose)
-        std::cout << Colors::BLUE << "[v] " << Colors::RESET << "parsed commit " << hlcommit << " at branch " << hlbranch << ", commits " << commits << "\n";
+        std::cout << Colors::BLUE << "[v] " << Colors::RESET << "parsed commit " << hlcommit << " at branch " << hlbranch << " on " << hldate << ", commits " << commits << "\n";
 
-    ver = SHyprlandVersion{hlbranch, hlcommit, commits};
+    ver = SHyprlandVersion{hlbranch, hlcommit, hldate, commits};
     return ver;
 }
 
@@ -398,7 +401,7 @@ bool CPluginManager::updateHeaders(bool force) {
 
     progress.printMessageAbove(std::string{Colors::YELLOW} + "!" + Colors::RESET + " Cloning https://github.com/hyprwm/hyprland, this might take a moment.");
 
-    std::string ret = execAndGet("cd /tmp/hyprpm && git clone --recursive https://github.com/hyprwm/hyprland hyprland");
+    std::string ret = execAndGet("cd /tmp/hyprpm && git clone --recursive https://github.com/hyprwm/hyprland hyprland --shallow-since='" + HLVER.date + "'");
 
     if (!std::filesystem::exists("/tmp/hyprpm/hyprland")) {
         std::cerr << "\n" << Colors::RED << "✖" << Colors::RESET << " Could not clone the hyprland repository. shell returned:\n" << ret << "\n";

--- a/hyprpm/src/core/PluginManager.cpp
+++ b/hyprpm/src/core/PluginManager.cpp
@@ -445,10 +445,6 @@ bool CPluginManager::updateHeaders(bool force) {
     progress.m_szCurrentMessage = "Installing sources";
     progress.print();
 
-    // progress.printMessageAbove(
-    //     std::string{Colors::YELLOW} + "!" + Colors::RESET +
-    //     " in order to install the sources, you will need to input your password.\n  If nothing pops up, make sure you have polkit and an authentication daemon running.");
-
     std::string cmd = std::format("sed -i -e \"s#PREFIX = /usr/local#PREFIX = {}#\" /tmp/hyprpm/hyprland/Makefile && cd /tmp/hyprpm/hyprland && make installheaders",
                                   DataState::getHeadersPath());
     if (m_bVerbose)

--- a/hyprpm/src/core/PluginManager.cpp
+++ b/hyprpm/src/core/PluginManager.cpp
@@ -71,7 +71,7 @@ SHyprlandVersion CPluginManager::getHyprlandVersion() {
     hlbranch             = hlbranch.substr(0, hlbranch.find(" at commit "));
 
     std::string hldate = HLVERCALL.substr(HLVERCALL.find("Date: ") + 6);
-    hldate = hldate.substr(0, hldate.find("\n"));
+    hldate             = hldate.substr(0, hldate.find("\n"));
 
     std::string hlcommits;
 
@@ -413,8 +413,8 @@ bool CPluginManager::updateHeaders(bool force) {
     progress.m_szCurrentMessage = "Checking out sources";
     progress.print();
 
-    ret =
-        execAndGet("cd /tmp/hyprpm/hyprland && git checkout " + HLVER.branch + " 2>&1 && git rm subprojects/tracy && git submodule update --init 2>&1 && git reset --hard --recurse-submodules " + HLVER.hash);
+    ret = execAndGet("cd /tmp/hyprpm/hyprland && git checkout " + HLVER.branch +
+                     " 2>&1 && git rm subprojects/tracy && git submodule update --init 2>&1 && git reset --hard --recurse-submodules " + HLVER.hash);
 
     if (m_bVerbose)
         progress.printMessageAbove(std::string{Colors::BLUE} + "[v] " + Colors::RESET + "git returned: " + ret);

--- a/hyprpm/src/core/PluginManager.cpp
+++ b/hyprpm/src/core/PluginManager.cpp
@@ -414,7 +414,7 @@ bool CPluginManager::updateHeaders(bool force) {
     progress.print();
 
     ret =
-        execAndGet("cd /tmp/hyprpm/hyprland && git checkout " + HLVER.branch + " 2>&1 && git submodule update --init 2>&1 && git reset --hard --recurse-submodules " + HLVER.hash);
+        execAndGet("cd /tmp/hyprpm/hyprland && git checkout " + HLVER.branch + " 2>&1 && git rm subprojects/tracy && git submodule update --init 2>&1 && git reset --hard --recurse-submodules " + HLVER.hash);
 
     if (m_bVerbose)
         progress.printMessageAbove(std::string{Colors::BLUE} + "[v] " + Colors::RESET + "git returned: " + ret);

--- a/hyprpm/src/core/PluginManager.hpp
+++ b/hyprpm/src/core/PluginManager.hpp
@@ -32,6 +32,7 @@ enum ePluginLoadStateReturn {
 struct SHyprlandVersion {
     std::string branch;
     std::string hash;
+    std::string date;
     int         commits = 0;
 };
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Improves the performance of the `hyprpm update` command by reducing the amount of data fetched over the network. The current version of hyprpm clones the entire Hyprland repo to do an update. This includes tens of thousands objects that are not used or referenced and are deleted after building the headers. In addition, the tracy submodule is also cloned, however it is never included in the build as hyprpm always builds headers in release mode. This PR changes these behaviors by:
- Using a shallow clone based on only history since the currently running commit, dramatically reducing the number of objects that need to be fetched (from a couple thousand to ~300 for any commit within the past couple months).
- Removing unused submodules (tracy) to avoid expensive cloning.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This performance improvement is only really noticeable on systems that have a slower internet connection (like mine). For me, running `hyprpm update` took around 4.5 minutes before the changes and around 2.4 minutes after.

#### Is it ready for merging, or does it need work?

Ready for merging.
