### PR TITLE
Fallback to xcursor if failed to render hyprcursor

### DIFF
--- a/src/managers/CursorManager.cpp
+++ b/src/managers/CursorManager.cpp
@@ -122,6 +122,7 @@ void CCursorManager::setCursorFromName(const std::string& name) {
 
         if (m_sCurrentCursorShapeData.images.size() < 1) {
             Debug::log(ERR, "BUG THIS: No fallback found for a cursor in setCursorFromName");
+            wlr_cursor_set_xcursor(g_pCompositor->m_sWLRCursor, m_pWLRXCursorMgr, name.c_str());
             return;
         }
     }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fallback to xcursor as last resort. Should bandaid invisible cursors on broken themes.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
\-

#### Is it ready for merging, or does it need work?
Ready
