### PR TITLE
Added `toggleswallow` dispatcher

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -450,8 +450,10 @@ void CWindow::moveToWorkspace(PHLWORKSPACE pWorkspace) {
     }
 
     if (const auto SWALLOWED = m_pSwallowed.lock()) {
-        SWALLOWED->moveToWorkspace(pWorkspace);
-        SWALLOWED->m_pMonitor = m_pMonitor;
+        if (SWALLOWED->m_bCurrentlySwallowed) {
+            SWALLOWED->moveToWorkspace(pWorkspace);
+            SWALLOWED->m_pMonitor = m_pMonitor;
+        }
     }
 
     // update xwayland coords

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -355,7 +355,7 @@ class CWindow {
     // swallowing
     PHLWINDOWREF m_pSwallowed;
     bool         m_bCurrentlySwallowed = false;
-    bool         m_bGroupSwallowed = false;
+    bool         m_bGroupSwallowed     = false;
 
     // focus stuff
     bool m_bStayFocused = false;

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -354,6 +354,7 @@ class CWindow {
 
     // swallowing
     PHLWINDOWREF m_pSwallowed;
+    bool         m_bCurrentlySwallowed = false;
     bool         m_bGroupSwallowed = false;
 
     // focus stuff

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -385,6 +385,9 @@ void Events::listener_mapWindow(void* owner, void* data) {
     // Verify window swallowing. Get the swallower before calling onWindowCreated(PWINDOW) because getSwallower() wouldn't get it after if PWINDOW gets auto grouped.
     const auto SWALLOWER  = PWINDOW->getSwallower();
     PWINDOW->m_pSwallowed = SWALLOWER;
+    if (PWINDOW->m_pSwallowed) {
+        PWINDOW->m_pSwallowed->m_bCurrentlySwallowed = true;
+    }
 
     if (PWINDOW->m_bIsFloating) {
         g_pLayoutManager->getCurrentLayout()->onWindowCreated(PWINDOW);
@@ -724,12 +727,15 @@ void Events::listener_unmapWindow(void* owner, void* data) {
 
     // swallowing
     if (valid(PWINDOW->m_pSwallowed)) {
-        PWINDOW->m_pSwallowed->setHidden(false);
+        if (PWINDOW->m_pSwallowed->m_bCurrentlySwallowed) {
+            PWINDOW->m_pSwallowed->m_bCurrentlySwallowed = false;
+            PWINDOW->m_pSwallowed->setHidden(false);
 
-        if (PWINDOW->m_sGroupData.pNextWindow.lock())
-            PWINDOW->m_pSwallowed->m_bGroupSwallowed = true; // flag for the swallowed window to be created into the group where it belongs when auto_group = false.
+            if (PWINDOW->m_sGroupData.pNextWindow.lock())
+                PWINDOW->m_pSwallowed->m_bGroupSwallowed = true; // flag for the swallowed window to be created into the group where it belongs when auto_group = false.
 
-        g_pLayoutManager->getCurrentLayout()->onWindowCreated(PWINDOW->m_pSwallowed.lock());
+            g_pLayoutManager->getCurrentLayout()->onWindowCreated(PWINDOW->m_pSwallowed.lock());
+        }
 
         PWINDOW->m_pSwallowed->m_bGroupSwallowed = false;
         PWINDOW->m_pSwallowed.reset();

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -385,9 +385,8 @@ void Events::listener_mapWindow(void* owner, void* data) {
     // Verify window swallowing. Get the swallower before calling onWindowCreated(PWINDOW) because getSwallower() wouldn't get it after if PWINDOW gets auto grouped.
     const auto SWALLOWER  = PWINDOW->getSwallower();
     PWINDOW->m_pSwallowed = SWALLOWER;
-    if (PWINDOW->m_pSwallowed) {
+    if (PWINDOW->m_pSwallowed)
         PWINDOW->m_pSwallowed->m_bCurrentlySwallowed = true;
-    }
 
     if (PWINDOW->m_bIsFloating) {
         g_pLayoutManager->getCurrentLayout()->onWindowCreated(PWINDOW);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -115,6 +115,7 @@ CKeybindManager::CKeybindManager() {
     m_mDispatchers["focuswindowbyclass"]             = focusWindow;
     m_mDispatchers["focuswindow"]                    = focusWindow;
     m_mDispatchers["tagwindow"]                      = tagWindow;
+    m_mDispatchers["toggleswallow"]                  = toggleSwallow;
     m_mDispatchers["submap"]                         = setSubmap;
     m_mDispatchers["pass"]                           = pass;
     m_mDispatchers["sendshortcut"]                   = sendshortcut;
@@ -2301,6 +2302,27 @@ SDispatchResult CKeybindManager::tagWindow(std::string args) {
     if (PWINDOW && PWINDOW->m_tags.applyTag(vars[0])) {
         PWINDOW->updateDynamicRules();
         g_pCompositor->updateWindowAnimatedDecorationValues(PWINDOW->m_pSelf.lock());
+    }
+
+    return {};
+}
+
+SDispatchResult CKeybindManager::toggleSwallow(std::string args) {
+    PHLWINDOWREF pWindow = g_pCompositor->m_pLastWindow;
+
+    if (!valid(pWindow) || !valid(pWindow->m_pSwallowed))
+        return {};
+
+    if (pWindow->m_pSwallowed->m_bCurrentlySwallowed) {
+        // Unswallow
+        pWindow->m_pSwallowed->m_bCurrentlySwallowed = false;
+        pWindow->m_pSwallowed->setHidden(false);
+        g_pLayoutManager->getCurrentLayout()->onWindowCreated(pWindow->m_pSwallowed.lock());
+    } else {
+        // Reswallow
+        pWindow->m_pSwallowed->m_bCurrentlySwallowed = true;
+        pWindow->m_pSwallowed->setHidden(true);
+        g_pLayoutManager->getCurrentLayout()->onWindowRemoved(pWindow->m_pSwallowed.lock());
     }
 
     return {};

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -199,6 +199,7 @@ class CKeybindManager {
     static SDispatchResult circleNext(std::string);
     static SDispatchResult focusWindow(std::string);
     static SDispatchResult tagWindow(std::string);
+    static SDispatchResult toggleSwallow(std::string);
     static SDispatchResult setSubmap(std::string);
     static SDispatchResult pass(std::string);
     static SDispatchResult sendshortcut(std::string);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
New feature: `toggleswallow` dispatcher which allows to toggle the swallowed window with a keybind. Only if the window was originally swallowed will it work. Meaning that you can only "unswallow" and then "swallow" again a window, and so on.

Useful when you want to have your terminal swallowed, but sometimes you also want to check the logs of your running application.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
Ready

