### PR TITLE
master: fix full height when all windows master

### DIFF
--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -369,7 +369,7 @@ void CHyprMasterLayout::calculateWorkspace(PHLWORKSPACE pWorkspace) {
         applyNodeDataToWindow(PMASTERNODE);
         return;
     } else if (orientation == ORIENTATION_TOP || orientation == ORIENTATION_BOTTOM) {
-        const float HEIGHT      = WSSIZE.y * PMASTERNODE->percMaster;
+        const float HEIGHT      = STACKWINDOWS != 0 ? WSSIZE.y * PMASTERNODE->percMaster : WSSIZE.y;
         float       widthLeft   = WSSIZE.x;
         int         mastersLeft = MASTERS;
         float       nextX       = 0;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Before this fix, if the master layout orientation was top or bottom and all windows are masters, there would be unwanted empty space.
![afbeelding](https://github.com/hyprwm/Hyprland/assets/62998174/d83d72bd-8c42-4a0e-9d92-229e8cc52b69)

This commit fixes this issue.
![afbeelding](https://github.com/hyprwm/Hyprland/assets/62998174/3a9b1f60-21e1-4b4f-9a2e-be6fc1649b8d)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
/

#### Is it ready for merging, or does it need work?
This change doesn't change much so everything should be fine, but I am not experienced C++ so a check would be good

