### PR TITLE
Fix crash when when swallowed window is closed

### DIFF
--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -687,7 +687,7 @@ void Events::listener_unmapWindow(void* owner, void* data) {
     g_pHyprOpenGL->makeWindowSnapshot(PWINDOW);
 
     // swallowing
-    if (PWINDOW->m_pSwallowed && g_pCompositor->windowExists(PWINDOW->m_pSwallowed)) {
+    if (PWINDOW->m_pSwallowed && g_pCompositor->windowExists(PWINDOW->m_pSwallowed) && !PWINDOW->m_pSwallowed->m_bReadyToDelete) {
         PWINDOW->m_pSwallowed->setHidden(false);
         g_pLayoutManager->getCurrentLayout()->onWindowCreated(PWINDOW->m_pSwallowed);
         PWINDOW->m_pSwallowed = nullptr;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes a crash when a swallowed window is closed. From what I've discovered it happens randomly depending on which window is closed first, at least it appears to be the cause.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I don't know if it's the right way to fix this crash, but it works.

#### Is it ready for merging, or does it need work?
Ready

