### PR TITLE
Add variable to focus on a noinitialfocus window if the workspace is empty

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -350,6 +350,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("misc:new_window_takes_over_fullscreen", Hyprlang::INT{0});
     m_pConfig->addConfigValue("misc:enable_hyprcursor", Hyprlang::INT{1});
     m_pConfig->addConfigValue("misc:hide_cursor_on_key_press", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("misc:focus_noinitial_if_no_window", Hyprlang::INT{0});
 
     m_pConfig->addConfigValue("group:insert_after_current", Hyprlang::INT{1});
     m_pConfig->addConfigValue("group:focus_removed_window", Hyprlang::INT{1});

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -44,13 +44,14 @@ void setAnimToMove(void* data) {
 void Events::listener_mapWindow(void* owner, void* data) {
     CWindow*    PWINDOW = (CWindow*)owner;
 
-    static auto PINACTIVEALPHA  = CConfigValue<Hyprlang::FLOAT>("decoration:inactive_opacity");
-    static auto PACTIVEALPHA    = CConfigValue<Hyprlang::FLOAT>("decoration:active_opacity");
-    static auto PDIMSTRENGTH    = CConfigValue<Hyprlang::FLOAT>("decoration:dim_strength");
-    static auto PSWALLOW        = CConfigValue<Hyprlang::INT>("misc:enable_swallow");
-    static auto PSWALLOWREGEX   = CConfigValue<std::string>("misc:swallow_regex");
-    static auto PSWALLOWEXREGEX = CConfigValue<std::string>("misc:swallow_exception_regex");
-    static auto PNEWTAKESOVERFS = CConfigValue<Hyprlang::INT>("misc:new_window_takes_over_fullscreen");
+    static auto PINACTIVEALPHA     = CConfigValue<Hyprlang::FLOAT>("decoration:inactive_opacity");
+    static auto PACTIVEALPHA       = CConfigValue<Hyprlang::FLOAT>("decoration:active_opacity");
+    static auto PDIMSTRENGTH       = CConfigValue<Hyprlang::FLOAT>("decoration:dim_strength");
+    static auto PSWALLOW           = CConfigValue<Hyprlang::INT>("misc:enable_swallow");
+    static auto PSWALLOWREGEX      = CConfigValue<std::string>("misc:swallow_regex");
+    static auto PSWALLOWEXREGEX    = CConfigValue<std::string>("misc:swallow_exception_regex");
+    static auto PNEWTAKESOVERFS    = CConfigValue<Hyprlang::INT>("misc:new_window_takes_over_fullscreen");
+    static auto PFALLBACKNOINITIAL = CConfigValue<Hyprlang::INT>("misc:focus_noinitial_if_no_window");
 
     auto        PMONITOR = g_pCompositor->m_pLastMonitor;
     if (!g_pCompositor->m_pLastMonitor) {
@@ -463,8 +464,8 @@ void Events::listener_mapWindow(void* owner, void* data) {
         PWINDOW->m_fActiveInactiveAlpha.setValueAndWarp(*PACTIVEALPHA);
         PWINDOW->m_fDimPercent.setValueAndWarp(PWINDOW->m_sAdditionalConfigData.forceNoDim ? 0.f : *PDIMSTRENGTH);
     } else {
-        if (g_pCompositor->m_pLastWindow == nullptr)
-          g_pCompositor->focusWindow(PWINDOW);
+        if (g_pCompositor->m_pLastWindow == nullptr && *PFALLBACKNOINITIAL == 1)
+            g_pCompositor->focusWindow(PWINDOW);
         PWINDOW->m_fActiveInactiveAlpha.setValueAndWarp(*PINACTIVEALPHA);
         PWINDOW->m_fDimPercent.setValueAndWarp(0);
     }

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -463,6 +463,8 @@ void Events::listener_mapWindow(void* owner, void* data) {
         PWINDOW->m_fActiveInactiveAlpha.setValueAndWarp(*PACTIVEALPHA);
         PWINDOW->m_fDimPercent.setValueAndWarp(PWINDOW->m_sAdditionalConfigData.forceNoDim ? 0.f : *PDIMSTRENGTH);
     } else {
+        if (g_pCompositor->m_pLastWindow == nullptr)
+          g_pCompositor->focusWindow(PWINDOW);
         PWINDOW->m_fActiveInactiveAlpha.setValueAndWarp(*PINACTIVEALPHA);
         PWINDOW->m_fDimPercent.setValueAndWarp(0);
     }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
I have configured `windowrule=noinitialfocus,(.*)`, so when I open a new window, hyprland doesn't focus on it. This is good when you are using some app and don't want a popup to steal focus.
This works as intended, but I think there is no reason not to focus on a new window if there is no focused one.
This PR adds a new variable `misc:focus_noinitial_if_no_window`, which allows to change this behaviour. It will focus on a new window even if it is marked as `noinitialfocus` when the workspace is empty.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I can't think a better name for this variable. Apart from that, I can't find any bugs/problems.

#### Is it ready for merging, or does it need work?
If you good with this name, it is ready to merge, I think.

