### PR TITLE
Fix workspace name selector returning true early

### DIFF
--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -334,10 +334,10 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
 
                 prop = prop.substr(2, prop.length() - 3);
 
-                if (prop.starts_with("s:"))
-                    return m_szName.starts_with(prop.substr(2));
-                if (prop.starts_with("e:"))
-                    return m_szName.ends_with(prop.substr(2));
+                if (prop.starts_with("s:") && !m_szName.starts_with(prop.substr(2)))
+                    return false;
+                if (prop.starts_with("e:") && !m_szName.ends_with(prop.substr(2)))
+                    return false;
 
                 const auto WANTSNAMED = configStringToInt(prop);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fix the issue where the workspace name selector returns true early
When there is a match, it shouldn't return true immediately. It should continue and check the next prop. This makes the behavior consistent with the rest of the code.

This fixes the issue that sometimes workspace rules are matching the workspace incorrectly if there's more than 1 prop.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
ready

