### PR TITLE
remove border on fullscreen

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -550,7 +550,7 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
             }
         }
 
-        if (decorate) {
+        if (renderdata.decorate) {
             for (auto& wd : pWindow->m_dWindowDecorations) {
                 if (wd->getDecorationLayer() != DECORATION_LAYER_BOTTOM)
                     continue;
@@ -582,7 +582,7 @@ void CHyprRenderer::renderWindow(CWindow* pWindow, CMonitor* pMonitor, timespec*
 
         g_pHyprOpenGL->m_RenderData.useNearestNeighbor = false;
 
-        if (decorate) {
+        if (renderdata.decorate) {
             for (auto& wd : pWindow->m_dWindowDecorations) {
                 if (wd->getDecorationLayer() != DECORATION_LAYER_OVER)
                     continue;


### PR DESCRIPTION
checks if window isn't fullscreen before drawing borders (etc)
only happened in the non fullscreened monitors

on another note, during animations borders and shadows are going outside their monitor when tiled, disappearing when animation ends (doesn't come from here but seems related)

shouldn't cause problems