### PR TITLE
keybindmgr:fix workspace_back_and_forth

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -999,7 +999,7 @@ void CKeybindManager::changeworkspace(std::string args) {
     if (BISWORKSPACECURRENT) {
         if (*PALLOWWORKSPACECYCLES)
             pWorkspaceToChangeTo->rememberPrevWorkspace(PCURRENTWORKSPACE);
-        else if (!EXPLICITPREVIOUS)
+        else if (!EXPLICITPREVIOUS && !*PBACKANDFORTH)
             pWorkspaceToChangeTo->rememberPrevWorkspace(nullptr);
     } else
         pWorkspaceToChangeTo->rememberPrevWorkspace(PCURRENTWORKSPACE);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
When the **workspace_back_and_forth** option is enabled, if a workspace is moved to the same workspace, the previous workspace of the current workspace should not be cleared.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
#5581 

#### Is it ready for merging, or does it need work?
ready for merging.
