### PR TITLE
Fix xwl cursor locking for scaled monitors

### DIFF
--- a/src/desktop/Constraint.cpp
+++ b/src/desktop/Constraint.cpp
@@ -67,14 +67,14 @@ void CConstraint::onCommit() {
 
         m_bHintSet = true;
 
-        auto SCALE = 1.f;
-        const auto window = m_pOwner->getWindow();
-        if (window) {
-            const auto ISXWL = window->m_bIsX11;
-            SCALE = ISXWL && *PXWLFORCESCALEZERO ? window->m_fX11SurfaceScaledBy : 1.f;
+        float scale = 1.f;
+        const auto PWINDOW = m_pOwner->getWindow();
+        if (PWINDOW) {
+            const auto ISXWL = PWINDOW->m_bIsX11;
+            scale = ISXWL && *PXWLFORCESCALEZERO ? PWINDOW->m_fX11SurfaceScaledBy : 1.f;
         }
 
-        m_vPositionHint = {m_pConstraint->current.cursor_hint.x / SCALE, m_pConstraint->current.cursor_hint.y / SCALE};
+        m_vPositionHint = {m_pConstraint->current.cursor_hint.x / scale, m_pConstraint->current.cursor_hint.y / scale};
         g_pInputManager->simulateMouseMovement();
     }
 

--- a/src/desktop/Constraint.cpp
+++ b/src/desktop/Constraint.cpp
@@ -67,11 +67,11 @@ void CConstraint::onCommit() {
 
         m_bHintSet = true;
 
-        float scale = 1.f;
+        float      scale   = 1.f;
         const auto PWINDOW = m_pOwner->getWindow();
         if (PWINDOW) {
             const auto ISXWL = PWINDOW->m_bIsX11;
-            scale = ISXWL && *PXWLFORCESCALEZERO ? PWINDOW->m_fX11SurfaceScaledBy : 1.f;
+            scale            = ISXWL && *PXWLFORCESCALEZERO ? PWINDOW->m_fX11SurfaceScaledBy : 1.f;
         }
 
         m_vPositionHint = {m_pConstraint->current.cursor_hint.x / scale, m_pConstraint->current.cursor_hint.y / scale};

--- a/src/desktop/Constraint.cpp
+++ b/src/desktop/Constraint.cpp
@@ -65,10 +65,16 @@ void CConstraint::onCommit() {
     if (COMMITTED & WLR_POINTER_CONSTRAINT_V1_STATE_CURSOR_HINT) {
         static auto PXWLFORCESCALEZERO = CConfigValue<Hyprlang::INT>("xwayland:force_zero_scaling");
 
-        m_bHintSet       = true;
-        const auto ISXWL = m_pOwner->getWindow()->m_bIsX11;
-        const auto SCALE = ISXWL && *PXWLFORCESCALEZERO ? m_pOwner->m_fLastScale : 1;
-        m_vPositionHint  = {m_pConstraint->current.cursor_hint.x / SCALE, m_pConstraint->current.cursor_hint.y / SCALE};
+        m_bHintSet = true;
+
+        auto SCALE = 1.f;
+        const auto window = m_pOwner->getWindow();
+        if (window) {
+            const auto ISXWL = window->m_bIsX11;
+            SCALE = ISXWL && *PXWLFORCESCALEZERO ? m_pOwner->m_fLastScale : 1.f;
+        }
+
+        m_vPositionHint = {m_pConstraint->current.cursor_hint.x / SCALE, m_pConstraint->current.cursor_hint.y / SCALE};
         g_pInputManager->simulateMouseMovement();
     }
 

--- a/src/desktop/Constraint.cpp
+++ b/src/desktop/Constraint.cpp
@@ -1,6 +1,7 @@
 #include "Constraint.hpp"
 #include "WLSurface.hpp"
 #include "../Compositor.hpp"
+#include "../config/ConfigValue.hpp"
 
 CConstraint::CConstraint(wlr_pointer_constraint_v1* constraint, CWLSurface* owner) : m_pOwner(owner), m_pConstraint(constraint) {
     RASSERT(!constraint->data, "CConstraint: attempted to duplicate ownership");
@@ -62,8 +63,12 @@ void CConstraint::onCommit() {
     const auto COMMITTED = m_pConstraint->current.committed;
 
     if (COMMITTED & WLR_POINTER_CONSTRAINT_V1_STATE_CURSOR_HINT) {
-        m_bHintSet      = true;
-        m_vPositionHint = {m_pConstraint->current.cursor_hint.x, m_pConstraint->current.cursor_hint.y};
+        static auto PXWLFORCESCALEZERO = CConfigValue<Hyprlang::INT>("xwayland:force_zero_scaling");
+
+        m_bHintSet       = true;
+        const auto ISXWL = m_pOwner->getWindow()->m_bIsX11;
+        const auto SCALE = ISXWL && *PXWLFORCESCALEZERO ? m_pOwner->m_fLastScale : 1;
+        m_vPositionHint  = {m_pConstraint->current.cursor_hint.x / SCALE, m_pConstraint->current.cursor_hint.y / SCALE};
         g_pInputManager->simulateMouseMovement();
     }
 

--- a/src/desktop/Constraint.cpp
+++ b/src/desktop/Constraint.cpp
@@ -71,7 +71,7 @@ void CConstraint::onCommit() {
         const auto window = m_pOwner->getWindow();
         if (window) {
             const auto ISXWL = window->m_bIsX11;
-            SCALE = ISXWL && *PXWLFORCESCALEZERO ? m_pOwner->m_fLastScale : 1.f;
+            SCALE = ISXWL && *PXWLFORCESCALEZERO ? window->m_fX11SurfaceScaledBy : 1.f;
         }
 
         m_vPositionHint = {m_pConstraint->current.cursor_hint.x / SCALE, m_pConstraint->current.cursor_hint.y / SCALE};


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

When an xwayland app locks the cursor, xwayland:force_zero_scaling=true is set and the monitor is scaled in the config, the xwayland app will use the unscaled display size to calculate the cursor position within the window. For scales greater than 1, this position can be off or out of bounds, so it will not warp the cursor at all.

This PR fixes this behavior.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This fix has only been tested with Minecraft, but as long as other xwayland apps work the same, it should be fine.

Also, I'm not sure if m_pOwner->m_fLastScale in line 70 is the ideal way to get the scale of the monitor the app window is in.

#### Is it ready for merging, or does it need work?

Ready for merging