### PR TITLE
keybindmgr: add optional `silent` suffix to `movewindow`.

### DIFF
--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -897,11 +897,13 @@ SWindowRenderLayoutHints CHyprDwindleLayout::requestRenderHints(CWindow* pWindow
     return hints;
 }
 
-void CHyprDwindleLayout::moveWindowTo(CWindow* pWindow, const std::string& dir) {
+void CHyprDwindleLayout::moveWindowTo(CWindow* pWindow, const std::string& dir, bool silent) {
     if (!isDirection(dir))
         return;
 
-    const auto PNODE = getNodeFromWindow(pWindow);
+    const auto     PNODE               = getNodeFromWindow(pWindow);
+    const int      originalWorkspaceID = pWindow->workspaceID();
+    const Vector2D originalPos         = pWindow->middle();
 
     if (!PNODE)
         return;
@@ -934,6 +936,13 @@ void CHyprDwindleLayout::moveWindowTo(CWindow* pWindow, const std::string& dir) 
     onWindowCreatedTiling(pWindow);
 
     m_vOverrideFocalPoint.reset();
+
+    // restore focus to the previous position
+    if (silent) {
+        const auto PNODETOFOCUS = getClosestNodeOnWorkspace(originalWorkspaceID, originalPos);
+        if (PNODETOFOCUS && PNODETOFOCUS->pWindow)
+            g_pCompositor->focusWindow(PNODETOFOCUS->pWindow);
+    }
 }
 
 void CHyprDwindleLayout::switchWindows(CWindow* pWindow, CWindow* pWindow2) {

--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -56,7 +56,7 @@ class CHyprDwindleLayout : public IHyprLayout {
     virtual std::any                 layoutMessage(SLayoutMessageHeader, std::string);
     virtual SWindowRenderLayoutHints requestRenderHints(CWindow*);
     virtual void                     switchWindows(CWindow*, CWindow*);
-    virtual void                     moveWindowTo(CWindow*, const std::string& dir);
+    virtual void                     moveWindowTo(CWindow*, const std::string& dir, bool silent);
     virtual void                     alterSplitRatio(CWindow*, float, bool);
     virtual std::string              getLayoutName();
     virtual void                     replaceWindowDataWith(CWindow* from, CWindow* to);

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -136,7 +136,7 @@ class IHyprLayout {
         Called when the user requests a window move in a direction.
         The layout is free to ignore.
     */
-    virtual void moveWindowTo(CWindow*, const std::string& direction) = 0;
+    virtual void moveWindowTo(CWindow*, const std::string& direction, bool silent = false) = 0;
 
     /*
         Called when the user requests to change the splitratio by or to X

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -949,7 +949,7 @@ SWindowRenderLayoutHints CHyprMasterLayout::requestRenderHints(CWindow* pWindow)
     return hints; // master doesnt have any hints
 }
 
-void CHyprMasterLayout::moveWindowTo(CWindow* pWindow, const std::string& dir) {
+void CHyprMasterLayout::moveWindowTo(CWindow* pWindow, const std::string& dir, bool silent) {
     if (!isDirection(dir))
         return;
 
@@ -965,12 +965,16 @@ void CHyprMasterLayout::moveWindowTo(CWindow* pWindow, const std::string& dir) {
         onWindowRemovedTiling(pWindow);
         pWindow->moveToWorkspace(PWINDOW2->m_pWorkspace);
         pWindow->m_iMonitorID = PWINDOW2->m_iMonitorID;
-        const auto pMonitor   = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
-        g_pCompositor->setActiveMonitor(pMonitor);
+        if (!silent) {
+            const auto pMonitor = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
+            g_pCompositor->setActiveMonitor(pMonitor);
+        }
         onWindowCreatedTiling(pWindow);
     } else {
         // if same monitor, switch windows
         switchWindows(pWindow, PWINDOW2);
+        if (silent)
+            g_pCompositor->focusWindow(PWINDOW2);
     }
 }
 

--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -62,7 +62,7 @@ class CHyprMasterLayout : public IHyprLayout {
     virtual std::any                 layoutMessage(SLayoutMessageHeader, std::string);
     virtual SWindowRenderLayoutHints requestRenderHints(CWindow*);
     virtual void                     switchWindows(CWindow*, CWindow*);
-    virtual void                     moveWindowTo(CWindow*, const std::string& dir);
+    virtual void                     moveWindowTo(CWindow*, const std::string& dir, bool silent);
     virtual void                     alterSplitRatio(CWindow*, float, bool);
     virtual std::string              getLayoutName();
     virtual void                     replaceWindowDataWith(CWindow* from, CWindow* to);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1216,15 +1216,20 @@ void CKeybindManager::swapActive(std::string args) {
 }
 
 void CKeybindManager::moveActiveTo(std::string args) {
-    char arg = args[0];
+    char arg    = args[0];
+    bool silent = args.ends_with(" silent");
+    if (silent)
+        args = args.substr(0, args.length() - 7);
 
     if (args.starts_with("mon:")) {
         const auto PNEWMONITOR = g_pCompositor->getMonitorFromString(args.substr(4));
         if (!PNEWMONITOR)
             return;
 
-        moveActiveToWorkspace(PNEWMONITOR->activeWorkspace->getConfigName());
-        return;
+        if (silent)
+            moveActiveToWorkspaceSilent(PNEWMONITOR->activeWorkspace->getConfigName());
+        else
+            moveActiveToWorkspace(PNEWMONITOR->activeWorkspace->getConfigName());
     }
 
     if (!isDirection(args)) {
@@ -1258,8 +1263,9 @@ void CKeybindManager::moveActiveTo(std::string args) {
     // If the window to change to is on the same workspace, switch them
     const auto PWINDOWTOCHANGETO = g_pCompositor->getWindowInDirection(PLASTWINDOW, arg);
     if (PWINDOWTOCHANGETO) {
-        g_pLayoutManager->getCurrentLayout()->moveWindowTo(PLASTWINDOW, args);
-        g_pCompositor->warpCursorTo(PLASTWINDOW->middle());
+        g_pLayoutManager->getCurrentLayout()->moveWindowTo(PLASTWINDOW, args, silent);
+        if (!silent)
+            g_pCompositor->warpCursorTo(PLASTWINDOW->middle());
         return;
     }
 
@@ -1269,8 +1275,10 @@ void CKeybindManager::moveActiveTo(std::string args) {
         return;
 
     const auto PWORKSPACE = PMONITORTOCHANGETO->activeWorkspace;
-
-    moveActiveToWorkspace(PWORKSPACE->getConfigName());
+    if (silent)
+        moveActiveToWorkspaceSilent(PWORKSPACE->getConfigName());
+    else
+        moveActiveToWorkspace(PWORKSPACE->getConfigName());
 }
 
 void CKeybindManager::toggleGroup(std::string args) {


### PR DESCRIPTION
With the `silent` suffix, the focus remains on the current position in the layout or the current monitor, instead of following the moved window. When combined with `movewindow mon:X`, this this allows you to get the same behavior as xmonad's `windowToScreen` command.

Personally I don't have a use case for `movewindow <direction> silent`, but I thought it would be better to make `movewindow` more powerful instead of adding another `movewindowtomonitorsilent` dispatcher.


