### PR TITLE
notify: fix notifications visibility on manually rotated monitor

### DIFF
--- a/src/debug/HyprNotificationOverlay.cpp
+++ b/src/debug/HyprNotificationOverlay.cpp
@@ -76,7 +76,7 @@ CBox CHyprNotificationOverlay::drawNotifications(CMonitor* pMonitor) {
 
     const auto            SCALE = pMonitor->scale;
 
-    const auto            MONSIZE = pMonitor->vecPixelSize;
+    const auto            MONSIZE = pMonitor->vecTransformedSize;
 
     cairo_text_extents_t  cairoExtents;
     int                   iconW = 0, iconH = 0;
@@ -185,16 +185,19 @@ CBox CHyprNotificationOverlay::drawNotifications(CMonitor* pMonitor) {
 
 void CHyprNotificationOverlay::draw(CMonitor* pMonitor) {
 
-    if (m_pLastMonitor != pMonitor || !m_pCairo || !m_pCairoSurface) {
+    const auto MONSIZE = pMonitor->vecTransformedSize;
+
+    if (m_pLastMonitor != pMonitor || m_vecLastSize != MONSIZE || !m_pCairo || !m_pCairoSurface) {
 
         if (m_pCairo && m_pCairoSurface) {
             cairo_destroy(m_pCairo);
             cairo_surface_destroy(m_pCairoSurface);
         }
 
-        m_pCairoSurface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, pMonitor->vecPixelSize.x, pMonitor->vecPixelSize.y);
+        m_pCairoSurface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, MONSIZE.x, MONSIZE.y);
         m_pCairo        = cairo_create(m_pCairoSurface);
         m_pLastMonitor  = pMonitor;
+        m_vecLastSize   = MONSIZE;
     }
 
     // Draw the notifications
@@ -232,9 +235,9 @@ void CHyprNotificationOverlay::draw(CMonitor* pMonitor) {
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED);
 #endif
 
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, pMonitor->vecPixelSize.x, pMonitor->vecPixelSize.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, DATA);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, MONSIZE.x, MONSIZE.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, DATA);
 
-    CBox pMonBox = {0, 0, pMonitor->vecPixelSize.x, pMonitor->vecPixelSize.y};
+    CBox pMonBox = {0, 0, MONSIZE.x, MONSIZE.y};
     g_pHyprOpenGL->renderTexture(m_tTexture, &pMonBox, 1.f);
 }
 

--- a/src/debug/HyprNotificationOverlay.hpp
+++ b/src/debug/HyprNotificationOverlay.hpp
@@ -55,6 +55,7 @@ class CHyprNotificationOverlay {
     cairo_t*                                   m_pCairo        = nullptr;
 
     CMonitor*                                  m_pLastMonitor = nullptr;
+    Vector2D                                   m_vecLastSize  = Vector2D(-1, -1);
 
     CTexture                                   m_tTexture;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

If you rotate monitor with eg `hyprctl keyword monitor HDMI-A-1,highrr,0x0,1,transform,3`, you then cannot see any notifications produced by `hyprctl notify` on the rotated monitor.

Fix is pretty simple: use `vecTransformedSize` instead of `vecPixelSize`

I also added extra check if monitor has changed its rotation/size. Without this check number of notifs on screen is limited by monitor's initial height (for 1080 with default settings that number is 37).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Cannot test with multiple monitors, but this shouldn't be a problem.

#### Is it ready for merging, or does it need work?

Should be ready.

