### PR TITLE
shaders: Use sin-less hash for noise

### DIFF
--- a/src/render/shaders/Textures.hpp
+++ b/src/render/shaders/Textures.hpp
@@ -400,7 +400,9 @@ uniform float     noise;
 uniform float     brightness;
 
 float hash(vec2 p) {
-    return fract(sin(dot(p, vec2(12.9898, 78.233))) * 43758.5453);
+    vec3 p3 = fract(vec3(p.xyx) * 1689.1984);
+    p3 += dot(p3, p3.yzx + 33.33);
+    return fract((p3.x + p3.y) * p3.z);
 }
 
 void main() {


### PR DESCRIPTION
Changes the hash function in the noise shader to avoid sin(). Fixes diagonal lines from noise observed in #3806.

Needs testing on older nvidia hardware/drivers, and AMD/Intel hardware to make sure it works on all platforms. I have only tested on 4000 series GPUs with the 550 driver.
