### PR TITLE
Add 'v' flag for workspace selector: counts only visible windows

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1273,11 +1273,13 @@ void CCompositor::sanityCheckWorkspaces() {
     }
 }
 
-int CCompositor::getWindowsOnWorkspace(const int& id, std::optional<bool> onlyTiled) {
+int CCompositor::getWindowsOnWorkspace(const int& id, std::optional<bool> onlyTiled, std::optional<bool> onlyVisible) {
     int no = 0;
     for (auto& w : m_vWindows) {
-        if (w->workspaceID() == id && w->m_bIsMapped && !(onlyTiled.has_value() && !w->m_bIsFloating != onlyTiled.value()))
-            no++;
+        if (w->workspaceID() == id && w->m_bIsMapped && !(onlyTiled.has_value() && !w->m_bIsFloating != onlyTiled.value())) {
+            if (!(onlyVisible.has_value() && w->isHidden() == onlyVisible.value()))
+                no++;
+        }
     }
 
     return no;
@@ -1286,8 +1288,10 @@ int CCompositor::getWindowsOnWorkspace(const int& id, std::optional<bool> onlyTi
 int CCompositor::getGroupsOnWorkspace(const int& id, std::optional<bool> onlyTiled) {
     int no = 0;
     for (auto& w : m_vWindows) {
-        if (w->workspaceID() == id && w->m_bIsMapped && !(onlyTiled.has_value() && !w->m_bIsFloating != onlyTiled.value()) && w->m_sGroupData.head)
-            no++;
+        if (w->workspaceID() == id && w->m_bIsMapped && !(onlyTiled.has_value() && !w->m_bIsFloating != onlyTiled.value()) && w->m_sGroupData.head) {
+            if (!(onlyVisible.has_value() && w->isHidden() == onlyVisible.value()))
+                no++;
+        }
     }
 
     return no;

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1285,7 +1285,7 @@ int CCompositor::getWindowsOnWorkspace(const int& id, std::optional<bool> onlyTi
     return no;
 }
 
-int CCompositor::getGroupsOnWorkspace(const int& id, std::optional<bool> onlyTiled) {
+int CCompositor::getGroupsOnWorkspace(const int& id, std::optional<bool> onlyTiled, std::optional<bool> onlyVisible) {
     int no = 0;
     for (auto& w : m_vWindows) {
         if (w->workspaceID() == id && w->m_bIsMapped && !(onlyTiled.has_value() && !w->m_bIsFloating != onlyTiled.value()) && w->m_sGroupData.head) {

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1276,10 +1276,13 @@ void CCompositor::sanityCheckWorkspaces() {
 int CCompositor::getWindowsOnWorkspace(const int& id, std::optional<bool> onlyTiled, std::optional<bool> onlyVisible) {
     int no = 0;
     for (auto& w : m_vWindows) {
-        if (w->workspaceID() == id && w->m_bIsMapped && !(onlyTiled.has_value() && !w->m_bIsFloating != onlyTiled.value())) {
-            if (!(onlyVisible.has_value() && w->isHidden() == onlyVisible.value()))
-                no++;
-        }
+        if (w->workspaceID() != id || !w->m_bIsMapped)
+            continue;
+        if (onlyTiled.has_value() && w->m_bIsFloating == onlyTiled.value())
+            continue;
+        if (onlyVisible.has_value() && w->isHidden() == onlyVisible.value())
+            continue;
+        no++;
     }
 
     return no;
@@ -1288,12 +1291,16 @@ int CCompositor::getWindowsOnWorkspace(const int& id, std::optional<bool> onlyTi
 int CCompositor::getGroupsOnWorkspace(const int& id, std::optional<bool> onlyTiled, std::optional<bool> onlyVisible) {
     int no = 0;
     for (auto& w : m_vWindows) {
-        if (w->workspaceID() == id && w->m_bIsMapped && !(onlyTiled.has_value() && !w->m_bIsFloating != onlyTiled.value()) && w->m_sGroupData.head) {
-            if (!(onlyVisible.has_value() && w->isHidden() == onlyVisible.value()))
-                no++;
-        }
+        if (w->workspaceID() != id || !w->m_bIsMapped)
+            continue;
+        if (!w->m_sGroupData.head)
+            continue;
+        if (onlyTiled.has_value() && w->m_bIsFloating == onlyTiled.value())
+            continue;
+        if (onlyVisible.has_value() && w->isHidden() == onlyVisible.value())
+            continue;
+        no++;
     }
-
     return no;
 }
 

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -151,8 +151,8 @@ class CCompositor {
     void           sanityCheckWorkspaces();
     void           updateWorkspaceWindowDecos(const int&);
     void           updateWorkspaceSpecialRenderData(const int&);
-    int            getWindowsOnWorkspace(const int& id, std::optional<bool> onlyTiled = {});
-    int            getGroupsOnWorkspace(const int& id, std::optional<bool> onlyTiled = {});
+    int            getWindowsOnWorkspace(const int& id, std::optional<bool> onlyTiled = {}, std::optional<bool> onlyVisible = {});
+    int            getGroupsOnWorkspace(const int& id, std::optional<bool> onlyTiled = {}, std::optional<bool> onlyVisible = {});
     CWindow*       getUrgentWindow();
     bool           hasUrgentWindowOnWorkspace(const int&);
     CWindow*       getFirstWindowOnWorkspace(const int&);

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -251,6 +251,7 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
             // m - monitor: m[monitor_selector]
             // w - windowCount: w[1-4] or w[1], optional flag t or f for tiled or floating and
             //                  flag g to count groups instead of windows, e.g. w[t1-2], w[fg4]
+            //                  flag v will count only visible windows
 
             const auto  NEXTSPACE = selector.find_first_of(' ', i);
             std::string prop      = selector.substr(i, NEXTSPACE == std::string::npos ? std::string::npos : NEXTSPACE - i);
@@ -355,8 +356,9 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
 
                 prop = prop.substr(2, prop.length() - 3);
 
-                int  wantsOnlyTiled  = -1;
-                bool wantsCountGroup = false;
+                int  wantsOnlyTiled    = -1;
+                bool wantsCountGroup   = false;
+                bool wantsCountVisible = false;
 
                 int  flagCount = 0;
                 for (auto& flag : prop) {
@@ -368,6 +370,9 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
                         flagCount++;
                     } else if (flag == 'g' && !wantsCountGroup) {
                         wantsCountGroup = true;
+                        flagCount++;
+                    } else if (flag == 'v' && !wantsCountVisible) {
+                        wantsCountVisible = true;
                         flagCount++;
                     } else {
                         break;
@@ -392,9 +397,11 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
 
                     int count;
                     if (wantsCountGroup)
-                        count = g_pCompositor->getGroupsOnWorkspace(m_iID, wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled));
+                        count = g_pCompositor->getGroupsOnWorkspace(m_iID, wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled),
+                                                                    wantsCountVisible ? std::optional<bool>(wantsCountVisible) : std::nullopt);
                     else
-                        count = g_pCompositor->getWindowsOnWorkspace(m_iID, wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled));
+                        count = g_pCompositor->getWindowsOnWorkspace(m_iID, wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled),
+                                                                     wantsCountVisible ? std::optional<bool>(wantsCountVisible) : std::nullopt);
 
                     if (count != from)
                         return false;
@@ -424,9 +431,11 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
 
                 int count;
                 if (wantsCountGroup)
-                    count = g_pCompositor->getGroupsOnWorkspace(m_iID, wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled));
+                    count = g_pCompositor->getGroupsOnWorkspace(m_iID, wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled),
+                                                                wantsCountVisible ? std::optional<bool>(wantsCountVisible) : std::nullopt);
                 else
-                    count = g_pCompositor->getWindowsOnWorkspace(m_iID, wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled));
+                    count = g_pCompositor->getWindowsOnWorkspace(m_iID, wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled),
+                                                                 wantsCountVisible ? std::optional<bool>(wantsCountVisible) : std::nullopt);
 
                 if (std::clamp(count, from, to) != count)
                     return false;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds a 'v' flag to the workspace w[] selector. This only counts visible windows. Effectively turns grouped windows into a single window as far as window count goes.



#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no?

#### Is it ready for merging, or does it need work?
Ready

