### PR TITLE
windows: recalculate monitor after updating windows

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -392,8 +392,12 @@ void CWindow::moveToWorkspace(PHLWORKSPACE pWorkspace) {
 
     g_pCompositor->updateWorkspaceWindows(OLDWORKSPACE->m_iID);
     g_pCompositor->updateWorkspaceSpecialRenderData(OLDWORKSPACE->m_iID);
+    g_pLayoutManager->getCurrentLayout()->recalculateMonitor(OLDWORKSPACE->m_iMonitorID);
+
     g_pCompositor->updateWorkspaceWindows(workspaceID());
     g_pCompositor->updateWorkspaceSpecialRenderData(workspaceID());
+    g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m_iMonitorID);
+
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 
     if (valid(pWorkspace)) {
@@ -486,6 +490,7 @@ void CWindow::onUnmap() {
 
     g_pCompositor->updateWorkspaceWindows(workspaceID());
     g_pCompositor->updateWorkspaceSpecialRenderData(workspaceID());
+    g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m_iMonitorID);
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 
     m_pWorkspace.reset();
@@ -853,9 +858,9 @@ void CWindow::createGroup() {
 
         addWindowDeco(std::make_unique<CHyprGroupBarDecoration>(this));
 
-        g_pLayoutManager->getCurrentLayout()->recalculateWindow(this);
         g_pCompositor->updateWorkspaceWindows(workspaceID());
         g_pCompositor->updateWorkspaceSpecialRenderData(workspaceID());
+        g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m_iMonitorID);
         g_pCompositor->updateAllWindowsAnimatedDecorationValues();
     }
 }
@@ -871,6 +876,7 @@ void CWindow::destroyGroup() {
         updateWindowDecos();
         g_pCompositor->updateWorkspaceWindows(workspaceID());
         g_pCompositor->updateWorkspaceSpecialRenderData(workspaceID());
+        g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m_iMonitorID);
         g_pCompositor->updateAllWindowsAnimatedDecorationValues();
         return;
     }
@@ -901,6 +907,7 @@ void CWindow::destroyGroup() {
 
     g_pCompositor->updateWorkspaceWindows(workspaceID());
     g_pCompositor->updateWorkspaceSpecialRenderData(workspaceID());
+    g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m_iMonitorID);
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 }
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -211,6 +211,7 @@ bool CKeybindManager::ensureMouseBindState() {
 
         g_pCompositor->updateWorkspaceWindows(lastDraggedWindow->workspaceID());
         g_pCompositor->updateWorkspaceSpecialRenderData(lastDraggedWindow->workspaceID());
+        g_pLayoutManager->getCurrentLayout()->recalculateMonitor(lastDraggedWindow->m_iMonitorID);
         g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 
         return true;
@@ -872,6 +873,7 @@ static void toggleActiveFloatingCore(std::string args, std::optional<bool> float
     }
     g_pCompositor->updateWorkspaceWindows(PWINDOW->workspaceID());
     g_pCompositor->updateWorkspaceSpecialRenderData(PWINDOW->workspaceID());
+    g_pLayoutManager->getCurrentLayout()->recalculateMonitor(PWINDOW->m_iMonitorID);
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes #5552
Recalculate monitor after updating windows for workspace selector match, so that the visuals added by the layout doesn't get overridden.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nope

#### Is it ready for merging, or does it need work?
ready