### PR TITLE
misc: fix autocompletions for meson (hyprctl/hyprpm)

### DIFF
--- a/hyprctl/meson.build
+++ b/hyprctl/meson.build
@@ -2,6 +2,6 @@ executable('hyprctl', 'main.cpp',
   install: true
 )
 
-install_data('hyprctl.bash', install_dir: join_paths(get_option('datadir'), 'bash-completion'), install_tag: 'runtime', rename: 'hyprctl')
+install_data('hyprctl.bash', install_dir: join_paths(get_option('datadir'), 'bash-completion/completions'), install_tag: 'runtime', rename: 'hyprctl')
 install_data('hyprctl.fish', install_dir: join_paths(get_option('datadir'), 'fish/vendor_completions.d'), install_tag: 'runtime')
 install_data('hyprctl.zsh', install_dir: join_paths(get_option('datadir'), 'zsh/site-functions'), install_tag: 'runtime', rename: '_hyprctl')

--- a/hyprpm/src/meson.build
+++ b/hyprpm/src/meson.build
@@ -9,6 +9,6 @@ executable('hyprpm', src,
   install : true
 )
 
-install_data('../hyprpm.bash', install_dir: join_paths(get_option('datadir'), 'bash-completion'), install_tag: 'runtime', rename: 'hyprpm')
+install_data('../hyprpm.bash', install_dir: join_paths(get_option('datadir'), 'bash-completion/completions'), install_tag: 'runtime', rename: 'hyprpm')
 install_data('../hyprpm.fish', install_dir: join_paths(get_option('datadir'), 'fish/vendor_completions.d'), install_tag: 'runtime')
 install_data('../hyprpm.zsh', install_dir: join_paths(get_option('datadir'), 'zsh/site-functions'), install_tag: 'runtime', rename: '_hyprpm')


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Bash completions actually go in `/usr/share/bash-completion/completions`, this PR puts them in the correct place

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready to merge

