### PR TITLE
Allow more sensible input options for enabling animations.

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1784,7 +1784,7 @@ std::optional<std::string> CConfigManager::handleAnimation(const std::string& co
     int64_t enabledInt = configStringToInt(ARGS[1]) == 1;
 
     // Checking that the int is 1 or 0 because the helper can return integers out of range.
-    if (enabledInt != "0" && enabledInt != "1")
+    if (enabledInt != 0 && enabledInt != 1)
         return "invalid animation on/off state";
 
     PANIM->second.internalEnabled = configStringToInt(ARGS[1]) == 1;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1780,15 +1780,14 @@ std::optional<std::string> CConfigManager::handleAnimation(const std::string& co
     PANIM->second.overridden = true;
     PANIM->second.pValues    = &PANIM->second;
 
-    // If user specifies on/off as "on", "true", or "1" then the animation is enabled.
-    // If user specifies on/off as "off", "false", or "0", then the animation is disabled.
-    // Otherwise, we will let the user know that they specified an invalid on/off state.
-    if (ARGS[1] == "on" || ARGS[1] == "true" || ARGS[1] == "1")
-        PANIM->second.internalEnabled = true;
-    else if (ARGS[1] == "off" || ARGS[1] == "false" || ARGS[1] == "0")
-        PANIM->second.internalEnabled = false;
-    else
+    // This helper casts strings like "1", "true", "off", "yes"... to int.
+    int64_t enabledInt = configStringToInt(ARGS[1]) == 1;
+
+    // Checking that the int is 1 or 0 because the helper can return integers out of range.
+    if (enabledInt != "0" && enabledInt != "1")
         return "invalid animation on/off state";
+
+    PANIM->second.internalEnabled = configStringToInt(ARGS[1]) == 1;
 
     if (PANIM->second.internalEnabled) {
         // speed

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1780,6 +1780,12 @@ std::optional<std::string> CConfigManager::handleAnimation(const std::string& co
     PANIM->second.overridden = true;
     PANIM->second.pValues    = &PANIM->second;
 
+    if (ARGS[1] == "on" || ARGS[1] == "true")
+	ARGS[1] = "1";
+
+    if (ARGS[1] == "off" || ARGS[1] == "false")
+	ARGS[1] = "0";
+
     // on/off
     PANIM->second.internalEnabled = ARGS[1] == "1";
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1780,16 +1780,14 @@ std::optional<std::string> CConfigManager::handleAnimation(const std::string& co
     PANIM->second.overridden = true;
     PANIM->second.pValues    = &PANIM->second;
 
-    if (ARGS[1] == "on" || ARGS[1] == "true")
-	ARGS[1] = "1";
-
-    if (ARGS[1] == "off" || ARGS[1] == "false")
-	ARGS[1] = "0";
-
-    // on/off
-    PANIM->second.internalEnabled = ARGS[1] == "1";
-
-    if (ARGS[1] != "0" && ARGS[1] != "1")
+    // If user specifies on/off as "on", "true", or "1" then the animation is enabled.
+    // If user specifies on/off as "off", "false", or "0", then the animation is disabled.
+    // Otherwise, we will let the user know that they specified an invalid on/off state.
+    if (ARGS[1] == "on" || ARGS[1] == "true" || ARGS[1] == "1")
+        PANIM->second.internalEnabled = true;
+    else if (ARGS[1] == "off" || ARGS[1] == "false" || ARGS[1] == "0")
+        PANIM->second.internalEnabled = false;
+    else
         return "invalid animation on/off state";
 
     if (PANIM->second.internalEnabled) {


### PR DESCRIPTION
Original Issue: https://github.com/hyprwm/Hyprland/issues/5500

#### Describe your PR, what does it fix/add?

**NOTE**: This is my first contribution to Hyprland! I was looking through GitHub issues to look for a good beginner task. If this should be done differently please let me know, I mostly just wanted to get to know the repo so I can contribute more in the future.

The originally reported issue was asking for the Animation config to use a more sensible input for the On/Off field in the animation config. Currently you specify whether or not the feature is enabled as 1 or 0, the reporter and I feel that a clear boolean input is more sensible. That said I did not want to break existing configs. So all I did here was add the option to specify this flag as "on" or "off" and "true" or "false".

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This should have little to no performance impact. I tested this many times with all valid inputs. And tested this with invalid inputs and behavior is always as expected.

The only thing I wonder if I should change is the amount of comments. Let me know if I should shorten them.

#### Is it ready for merging, or does it need work?
This is ready and manually tested by myself. Please verify my tests however.

