### PR TITLE
git: ignore wlroots dirty changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,4 @@
 [submodule "subprojects/wlroots-hyprland"]
 	path = subprojects/wlroots-hyprland
 	url = https://github.com/hyprwm/wlroots-hyprland
+	ignore = dirty


### PR DESCRIPTION
when patches are applied in wlroots they are shown as unstaged modified content.
we can ignore wlroots dirty changes caused by the applied patches.
after this it will only show up as modified if you set the subproject to a different commit.