### PR TITLE
Fix breaking change in upstream wlroots (!4644)

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -158,7 +158,7 @@ void CCompositor::initServer() {
 
     wlr_renderer_init_wl_shm(m_sWLRRenderer, m_sWLDisplay);
 
-    if (wlr_renderer_get_dmabuf_texture_formats(m_sWLRRenderer)) {
+    if (wlr_renderer_get_texture_formats(m_sWLRRenderer, WLR_BUFFER_CAP_DMABUF)) {
         if (wlr_renderer_get_drm_fd(m_sWLRRenderer) >= 0)
             wlr_drm_create(m_sWLDisplay, m_sWLRRenderer);
 


### PR DESCRIPTION
https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4644
	modified:   src/Compositor.cpp

#### Describe your PR, what does it fix/add?
`wlr_renderer_get_dmabuf_texture_formats()` got nuked in favour of `wlr_renderer_get_texture_formats()` with `WLR_BUFFER_CAP_DMABUF`

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.

#### Is it ready for merging, or does it need work?
No. It should only be merged if/when `wlroots-hyprland` picks up those commits.

