### PR TITLE
protocols: add missing header for g_pCompositor

### DIFF
--- a/src/protocols/RelativePointer.cpp
+++ b/src/protocols/RelativePointer.cpp
@@ -1,4 +1,5 @@
 #include "RelativePointer.hpp"
+#include "Compositor.hpp"
 #include <algorithm>
 
 CRelativePointer::CRelativePointer(SP<CZwpRelativePointerV1> resource_) : resource(resource_) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

adds missing header to RelativePointer.cpp, build fails for me on gentoo otherwise on g_pCompositor.

