### PR TITLE
Fix mirrored displays when transformed and preserve aspect ratio

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -825,6 +825,10 @@ void CConfigManager::postConfigReload(const Hyprlang::CParseResult& result) {
 
         // Force the compositor to fully re-render all monitors
         m->forceFullFrames = 2;
+
+        // also force mirrors, as the aspect ratio could've changed
+        for (auto& mirror : m->mirrors)
+            mirror->forceFullFrames = 3;
     }
 
     // Reset no monitor reload

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1967,11 +1967,11 @@ void CHyprOpenGLImpl::renderRoundedShadow(CBox* box, int round, int range, const
 
 void CHyprOpenGLImpl::renderMirrored() {
 
-    auto monitor = m_RenderData.pMonitor;
-    auto mirrored = monitor->pMirrorOf;
+    auto   monitor  = m_RenderData.pMonitor;
+    auto   mirrored = monitor->pMirrorOf;
 
-    double scale = std::min(monitor->vecTransformedSize.x / mirrored->vecTransformedSize.x, monitor->vecTransformedSize.y / mirrored->vecTransformedSize.y);
-    CBox monbox = {0, 0, mirrored->vecTransformedSize.x * scale, mirrored->vecTransformedSize.y * scale};
+    double scale  = std::min(monitor->vecTransformedSize.x / mirrored->vecTransformedSize.x, monitor->vecTransformedSize.y / mirrored->vecTransformedSize.y);
+    CBox   monbox = {0, 0, mirrored->vecTransformedSize.x * scale, mirrored->vecTransformedSize.y * scale};
 
     // transform box as it will be drawn on a transformed projection
     monbox.transform(mirrored->transform, mirrored->vecTransformedSize.x * scale, mirrored->vecTransformedSize.y * scale);

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -67,8 +67,6 @@ struct SMonitorRenderData {
     CFramebuffer mirrorSwapFB; // etc
     CFramebuffer offMainFB;
 
-    CFramebuffer monitorMirrorFB; // used for mirroring outputs
-
     CTexture     stencilTex;
 
     CFramebuffer blurFB;
@@ -172,7 +170,6 @@ class CHyprOpenGLImpl {
     bool                  preBlurQueued();
     void                  preRender(CMonitor*);
 
-    void                  saveBufferForMirror();
     void                  renderMirrored();
 
     void                  applyScreenShader(const std::string& path);

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -172,7 +172,7 @@ class CHyprOpenGLImpl {
     bool                  preBlurQueued();
     void                  preRender(CMonitor*);
 
-    void                  saveBufferForMirror();
+    void                  saveBufferForMirror(CBox*);
     void                  renderMirrored();
 
     void                  applyScreenShader(const std::string& path);

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -67,6 +67,8 @@ struct SMonitorRenderData {
     CFramebuffer mirrorSwapFB; // etc
     CFramebuffer offMainFB;
 
+    CFramebuffer monitorMirrorFB; // used for mirroring outputs, does not contain artifacts like offloadFB
+
     CTexture     stencilTex;
 
     CFramebuffer blurFB;
@@ -170,6 +172,7 @@ class CHyprOpenGLImpl {
     bool                  preBlurQueued();
     void                  preRender(CMonitor*);
 
+    void                  saveBufferForMirror();
     void                  renderMirrored();
 
     void                  applyScreenShader(const std::string& path);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Currently, the [mirroring](https://wiki.hyprland.org/Configuring/Monitors/#mirrored-displays) of monitors is unusable with different aspect ratios or straight out broken when using transformed monitors.

This PR does the following:
- When drawing on the mirror framebuffer, it undoes the transforms of the mirrored monitor, so the mirror framebuffer always contains the monitor in the normal transform.
- When drawing on the mirrored monitor, instead of stretching the framebuffer accross the entire surface, it respects the aspect ratio, meaning there will be black bars if the aspect ratios do not match.

This makes mirroring usable when the source and/or target monitor is transformed. I also think preserving the aspect ratio should be the normal behaviour, as stretching is not what's ideal in most usecases.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
As mentioned, we currently copy the buffer of the monitor into a separate mirror buffer which is then drawn on the target monitors. The buffer of the monitor is already transformed with the monitor transform, so this PR renders the buffer with the inverse transform. 

To do that, the transform and the matrices of the monitor are temporarily changed for this one render, which is a bit of a janky solution. Otherwise we'd have to override or add a second transform in the `renderTextureInternalWithDamage` which would probably require a lot of changes.

Also, for what reason is the monitor framebuffer copied to the mirror buffer, which is then rendered? Couldn't we just directly render the `offloadFB` of the mirrored monitor on the target?

#### Is it ready for merging, or does it need work?
The current approach works fine on both my systems, and I did quite a bit of testing with all possible transforms. So I think it is ready.

I could also do a "cleaner" implementation as mentioned above (i.e. pass an extra transform to the render method) if you want.
