### PR TITLE
Make nix ci use hyprland cachix

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -26,4 +26,4 @@ jobs:
           name: hyprland
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-      - run: nix build .#${{ matrix.package }} -L
+      - run: nix build .#${{ matrix.package }} --extra-substituters "https://hyprland.cachix.org" -L


### PR DESCRIPTION
I noticed that the nix ci build task is not using the hyprland cachix due to it not trusting the flake substituters
This commit makes it use https://hyprland.cachix.org 
This can also be done by passing --accept-flake-config instead of --substituters however I prefer to be explicit in what caches to trust.
It can be done the other way if you prefer

#### Describe your PR, what does it fix/add?
This makes ci builds use the hyprland cachix which will hopefully speed up builds slightly

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This probably doesn't improve build speeds that much but it wont hurt
closed other pr 5683 I messed up the rebase
#### Is it ready for merging, or does it need work?
should be good to merge
