### PR TITLE
fix: manage active keyboard for seat after destroying one

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1162,7 +1162,6 @@ void CInputManager::destroyKeyboard(SKeyboard* pKeyboard) {
         m_pActiveKeyboard = nullptr;
         wlr_seat_set_keyboard(g_pCompositor->m_sSeat.seat, nullptr);
     }
-
 }
 
 void CInputManager::destroyMouse(wlr_input_device* mouse) {

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1152,17 +1152,17 @@ void CInputManager::destroyKeyboard(SKeyboard* pKeyboard) {
 
     xkb_state_unref(pKeyboard->xkbTranslationState);
 
-    if (pKeyboard->active) {
-        m_lKeyboards.remove(*pKeyboard);
+    m_lKeyboards.remove(*pKeyboard);
 
-        if (m_lKeyboards.size() > 0) {
-            m_pActiveKeyboard         = &m_lKeyboards.back();
-            m_pActiveKeyboard->active = true;
-        } else {
-            m_pActiveKeyboard = nullptr;
-        }
-    } else
-        m_lKeyboards.remove(*pKeyboard);
+    if (m_lKeyboards.size() > 0) {
+        m_pActiveKeyboard         = &m_lKeyboards.back();
+        m_pActiveKeyboard->active = true;
+        wlr_seat_set_keyboard(g_pCompositor->m_sSeat.seat, wlr_keyboard_from_input_device(m_pActiveKeyboard->keyboard));
+    } else {
+        m_pActiveKeyboard = nullptr;
+        wlr_seat_set_keyboard(g_pCompositor->m_sSeat.seat, nullptr);
+    }
+
 }
 
 void CInputManager::destroyMouse(wlr_input_device* mouse) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
There is a bug in the management of keyboard focus when you have more than one keyboard connected (like a laptop with external KVM switch scenario) and then you disconnect one.
To reproduce:
- Focus on window 0
- Disconnect a keyboard
- Focus on window 1
- Type something with the remaining keyboard

Then you will see that what you are typing will be listen by the old window 0 instead of the focused window 1

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Check if the check for  `pKeyboard->active` is really needed to change the `m_pActiveKeyboard` after destroying the keyboard
