### PR TITLE
Fix duplication of "special:" in special workspace name

### DIFF
--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -207,7 +207,7 @@ void CWorkspace::rememberPrevWorkspace(const PHLWORKSPACE& prev) {
 
 std::string CWorkspace::getConfigName() {
     if (m_bIsSpecialWorkspace) {
-        return "special:" + m_szName;
+        return m_szName;
     }
 
     if (m_iID > 0)

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -256,7 +256,7 @@ bool isDirection(const char& arg) {
 int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
     int result = WORKSPACE_INVALID;
     if (in.starts_with("special")) {
-        outName = "special";
+        outName = "special:special";
 
         if (in.length() > 8) {
             const auto NAME = in.substr(8);


### PR DESCRIPTION
	modified:   src/desktop/Workspace.cpp

#### Describe your PR, what does it fix/add?
Tokens for special workspaces have a duplicated `special:` string causing them to not spawn the windows properly.
(i.e. a special workspace called `terminal` would show up as `special:special:terminal` in the log)
Fixes #5726's special workspace spawning problems

Special workspaces always have a name that either: defaults to `special` when not specified on creation or must have `special:` prepended to their name when setting workspace rules.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
~~I don't know where else this `getConfigName()` function is called so I don't know if it breaks something else.~~
Did a search through the project and it seems that KeybindManager.cpp is the only place where it is called as is. From my testing, `movetoworkspace` and its variants are all fine, `togglespecialworkspace` is also fine and `workspace` does not apply to special workspaces.

#### Is it ready for merging, or does it need work?
Ready for merging

