### PR TITLE
Default unconfigured monitors to open to the right

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2736,7 +2736,7 @@ void CCompositor::arrangeMonitors() {
 
         if (m->activeMonitorRule.offset != Vector2D{-INT32_MAX, -INT32_MAX}) {
             // explicit.
-            Debug::log(LOG, "arrangeMonitors: {} explicit {:j2}", m->szName, m->activeMonitorRule.offset);
+            Debug::log(LOG, "arrangeMonitors: {} explicit {:j}", m->szName, m->activeMonitorRule.offset);
 
             m->moveTo(m->activeMonitorRule.offset);
             arranged.push_back(m);
@@ -2771,33 +2771,37 @@ void CCompositor::arrangeMonitors() {
 
     // Iterates through all non-explicitly placed monitors.
     for (auto& m : toArrange) {
-        Debug::log(LOG, "arrangeMonitors: {} auto [{}, {:.2f}]", m->szName, maxXOffsetRight, 0.f);
         // Moves the monitor to their appropriate position on the x/y axis and
         // increments/decrements the corresponding max offset.
-        if (m->activeMonitorRule.autoDir == eAutoDirs::DIR_AUTO_UP) {
-            m->moveTo({0, maxYOffsetUp - m->vecSize.y});
-            maxYOffsetUp = m->vecPosition.y;
-        } else if (m->activeMonitorRule.autoDir == eAutoDirs::DIR_AUTO_DOWN) {
-            m->moveTo({0, maxYOffsetDown});
-            maxYOffsetDown += m->vecSize.y;
-        } else if (m->activeMonitorRule.autoDir == eAutoDirs::DIR_AUTO_LEFT) {
-            m->moveTo({maxXOffsetLeft - m->vecSize.x, 0});
-            maxXOffsetLeft = m->vecPosition.x;
-        } else if (m->activeMonitorRule.autoDir == eAutoDirs::DIR_AUTO_RIGHT) {
-            m->moveTo({maxXOffsetRight, 0});
-            maxXOffsetRight += m->vecSize.x;
-        } else {
-            Debug::log(WARN,
-                       "Invalid auto direction. Valid options are 'auto',"
-                       "'auto-up', 'auto-down', 'auto-left', and 'auto-right'.");
+        Vector2D newPosition = {0, 0};
+        switch (m->activeMonitorRule.autoDir) {
+            case eAutoDirs::DIR_AUTO_UP:
+                newPosition.y = maxYOffsetUp - m->vecSize.y;
+                maxYOffsetUp  = newPosition.y;
+                break;
+            case eAutoDirs::DIR_AUTO_DOWN:
+                newPosition.y = maxYOffsetDown;
+                maxYOffsetDown += m->vecSize.y;
+                break;
+            case eAutoDirs::DIR_AUTO_LEFT:
+                newPosition.x  = maxXOffsetLeft - m->vecSize.x;
+                maxXOffsetLeft = newPosition.x;
+                break;
+            case eAutoDirs::DIR_AUTO_RIGHT:
+                newPosition.x = maxXOffsetRight;
+                maxXOffsetRight += m->vecSize.x;
+                break;
+            default: UNREACHABLE();
         }
+        Debug::log(LOG, "arrangeMonitors: {} auto {:j}", m->szName, m->vecPosition);
+        m->moveTo(newPosition);
     }
 
     // reset maxXOffsetRight (reuse)
     // and set xwayland positions aka auto for all
     maxXOffsetRight = 0;
     for (auto& m : m_vMonitors) {
-        Debug::log(LOG, "arrangeMonitors: {} xwayland [{}, {:.2f}]", m->szName, maxXOffsetRight, 0.f);
+        Debug::log(LOG, "arrangeMonitors: {} xwayland [{}, {}]", m->szName, maxXOffsetRight, 0);
         m->vecXWaylandPosition = {maxXOffsetRight, 0};
         maxXOffsetRight += (*PXWLFORCESCALEZERO ? m->vecTransformedSize.x : m->vecSize.x);
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1659,7 +1659,12 @@ std::optional<std::string> CConfigManager::handleMonitor(const std::string& comm
             newrule.autoDir = eAutoDirs::DIR_AUTO_UP;
         else if (ARGS[2] == "auto-down")
             newrule.autoDir = eAutoDirs::DIR_AUTO_DOWN;
-
+        else {
+            Debug::log(WARN,
+                       "Invalid auto direction. Valid options are 'auto',"
+                       "'auto-up', 'auto-down', 'auto-left', and 'auto-right'.");
+            error += "invalid auto direction ";
+        }
     } else {
         if (!ARGS[2].contains("x")) {
             error += "invalid offset ";

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -966,7 +966,11 @@ SMonitorRule CConfigManager::getMonitorRuleFor(const CMonitor& PMONITOR) {
 
     Debug::log(WARN, "No rules configured. Using the default hardcoded one.");
 
-    return SMonitorRule{.name = "", .resolution = Vector2D(0, 0), .offset = Vector2D(-INT32_MAX, -INT32_MAX), .scale = -1}; // 0, 0 is preferred and -1, -1 is auto
+    return SMonitorRule{.autoDir    = eAutoDirs::DIR_AUTO_RIGHT,
+                        .name       = "",
+                        .resolution = Vector2D(0, 0),
+                        .offset     = Vector2D(-INT32_MAX, -INT32_MAX),
+                        .scale      = -1}; // 0, 0 is preferred and -1, -1 is auto
 }
 
 SWorkspaceRule CConfigManager::getWorkspaceRuleFor(PHLWORKSPACE pWorkspace) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This PR returns the functionality of making unconfigured monitors default to opening to the right (previously all the if statements fell through and they ended up opening up, the enum zero value). It also improves the logging for invalid auto directions. Finally, it makes the logging performed in arrangeMonitors actually accurate under the new directional auto system, instead of just stating the next available rightwards position even when the new monitor isn't being arranged to the right.

I also noticed that since the max monitor positions are being stored as ints, there was inconsistent use of decimals in the arrangeMonitor logging. Seeing as how monitor positions can only be integers values anyways, I opted to just remove all decimals in the logging.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I'm not too sure if the logging changes are really in the scope of the PR but the inconsistencies were really bugging me and I didn't want to make a whole new PR to edit logging.

#### Is it ready for merging, or does it need work?


