### PR TITLE
Fix the rounding of the size of fractionally scaled monitors

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2260,7 +2260,7 @@ bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorR
 
     int x, y;
     wlr_output_transformed_resolution(pMonitor->output, &x, &y);
-    pMonitor->vecSize            = (Vector2D(x, y) / pMonitor->scale).floor();
+    pMonitor->vecSize            = (Vector2D(x, y) / pMonitor->scale).round();
     pMonitor->vecTransformedSize = Vector2D(x, y);
 
     if (pMonitor->createdByUser) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This fixes the issue of some monitors with fractional scaling having their vecSize 1 pixel less than they should be. In my case, my 2560x1600 monitor with 1.33x scaling would end up with dimensions 1919.999...x1119.999..., which would then get floored to 1919x1119. This caused a 1-pixel outline around the edges of the monitor where nothing happened (very visible if I set background_color to 0x00ff0000 or something and fullscreened anything or had a dark wallpaper. The problem would be exacerbated if external monitors are positioned with auto, because due to the incorrect vecSize the monitors would end up actually overlapping by a single pixel. This would cause all sorts of problems like vfr breaking on certain fullscreened apps (firefox in particular) and also popup menus not working on fullscreened apps for some reason.

Fixes:
#3511
#3778
#4474
#4781
and *possibly* #5399 (not sure if related)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I'm not sure if this is the right way to go about this and it might still have problems if there is no clean divisor for the scaling factor but it's better than nothing I think.

#### Is it ready for merging, or does it need work?
Seems ready to me.
