### PR TITLE
Window storage rework - part 1

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -916,7 +916,7 @@ void CCompositor::focusWindow(PHLWINDOW pWindow, wlr_surface* pSurface) {
 
     if (!pWindow || !validMapped(pWindow)) {
 
-        if (!m_pLastWindow.lock() && !pWindow)
+        if (m_pLastWindow.expired() && !pWindow)
             return;
 
         const auto PLASTWINDOW = m_pLastWindow.lock();
@@ -1279,7 +1279,7 @@ bool CCompositor::doesSeatAcceptInput(wlr_surface* surface) {
 }
 
 bool CCompositor::isWindowActive(PHLWINDOW pWindow) {
-    if (!m_pLastWindow.lock() && !m_pLastFocus)
+    if (m_pLastWindow.expired() && !m_pLastFocus)
         return false;
 
     if (!pWindow->m_bIsMapped)
@@ -2643,7 +2643,7 @@ void CCompositor::moveWindowToWorkspaceSafe(PHLWINDOW pWindow, PHLWORKSPACE pWor
     pWindow->updateDynamicRules();
     pWindow->uncacheWindowDecos();
 
-    if (pWindow->m_sGroupData.pNextWindow.lock()) {
+    if (!pWindow->m_sGroupData.pNextWindow.expired()) {
         PHLWINDOW next = pWindow->m_sGroupData.pNextWindow.lock();
         while (next != pWindow) {
             next->moveToWorkspace(pWorkspace);

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -362,7 +362,7 @@ void CCompositor::cleanup() {
     // still in a normal working state.
     g_pPluginSystem->unloadAllPlugins();
 
-    m_pLastFocus  = nullptr;
+    m_pLastFocus = nullptr;
     m_pLastWindow.reset();
 
     // end threads
@@ -693,8 +693,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
         for (auto& w : m_vWindows | std::views::reverse) {
             const auto BB  = w->getWindowBoxUnified(properties);
             CBox       box = {BB.x - BORDER_GRAB_AREA, BB.y - BORDER_GRAB_AREA, BB.width + 2 * BORDER_GRAB_AREA, BB.height + 2 * BORDER_GRAB_AREA};
-            if (w->m_bIsFloating && w->m_bIsMapped && !w->isHidden() && !w->m_bX11ShouldntFocus && w->m_bPinned && !w->m_sAdditionalConfigData.noFocus &&
-                w != pIgnoreWindow) {
+            if (w->m_bIsFloating && w->m_bIsMapped && !w->isHidden() && !w->m_bX11ShouldntFocus && w->m_bPinned && !w->m_sAdditionalConfigData.noFocus && w != pIgnoreWindow) {
                 if (box.containsPoint({m_sWLRCursor->x, m_sWLRCursor->y}))
                     return w;
 
@@ -734,7 +733,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
                         if (w->m_bIsX11 && w->m_iX11Type == 2 && !wlr_xwayland_or_surface_wants_focus(w->m_uSurface.xwayland)) {
                             // Override Redirect
                             return g_pCompositor->m_pLastWindow.lock(); // we kinda trick everything here.
-                                                                 // TODO: this is wrong, we should focus the parent, but idk how to get it considering it's nullptr in most cases.
+                                // TODO: this is wrong, we should focus the parent, but idk how to get it considering it's nullptr in most cases.
                         }
 
                         return w;
@@ -934,7 +933,7 @@ void CCompositor::focusWindow(PHLWINDOW pWindow, wlr_surface* pSurface) {
         g_pEventManager->postEvent(SHyprIPCEvent{"activewindow", ","});
         g_pEventManager->postEvent(SHyprIPCEvent{"activewindowv2", ","});
 
-        EMIT_HOOK_EVENT("activeWindow", (PHLWINDOW)nullptr);
+        EMIT_HOOK_EVENT("activeWindow", (PHLWINDOW) nullptr);
 
         g_pLayoutManager->getCurrentLayout()->onWindowFocusChange(nullptr);
 
@@ -1327,7 +1326,7 @@ void CCompositor::changeWindowZOrder(PHLWINDOW pWindow, bool top) {
 
         std::deque<PHLWINDOW> toMove;
 
-        auto                 x11Stack = [&](PHLWINDOW pw, bool top, auto&& x11Stack) -> void {
+        auto                  x11Stack = [&](PHLWINDOW pw, bool top, auto&& x11Stack) -> void {
             if (top)
                 toMove.emplace_back(pw);
             else
@@ -1464,7 +1463,7 @@ PHLWINDOW CCompositor::getWindowInDirection(PHLWINDOW pWindow, char dir) {
 
     const auto PWORKSPACE   = pWindow->m_pWorkspace;
     auto       leaderValue  = -1;
-    PHLWINDOW   leaderWindow = nullptr;
+    PHLWINDOW  leaderWindow = nullptr;
 
     if (!pWindow->m_bIsFloating) {
 
@@ -1839,8 +1838,8 @@ void CCompositor::updateWindowAnimatedDecorationValues(PHLWINDOW pWindow) {
             setBorderColor(pWindow->m_sSpecialRenderData.activeBorderColor.toUnderlying().m_vColors.empty() ? *ACTIVECOLOR :
                                                                                                               pWindow->m_sSpecialRenderData.activeBorderColor.toUnderlying());
         } else {
-            const auto* const INACTIVECOLOR =
-                !pWindow->m_sGroupData.pNextWindow.lock() ? (!pWindow->m_sGroupData.deny ? INACTIVECOL : NOGROUPINACTIVECOL) : (GROUPLOCKED ? GROUPINACTIVELOCKEDCOL : GROUPINACTIVECOL);
+            const auto* const INACTIVECOLOR = !pWindow->m_sGroupData.pNextWindow.lock() ? (!pWindow->m_sGroupData.deny ? INACTIVECOL : NOGROUPINACTIVECOL) :
+                                                                                          (GROUPLOCKED ? GROUPINACTIVELOCKEDCOL : GROUPINACTIVECOL);
             setBorderColor(pWindow->m_sSpecialRenderData.inactiveBorderColor.toUnderlying().m_vColors.empty() ? *INACTIVECOLOR :
                                                                                                                 pWindow->m_sSpecialRenderData.inactiveBorderColor.toUnderlying());
         }

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -363,7 +363,7 @@ void CCompositor::cleanup() {
     g_pPluginSystem->unloadAllPlugins();
 
     m_pLastFocus  = nullptr;
-    m_pLastWindow = nullptr;
+    m_pLastWindow.reset();
 
     // end threads
     g_pEventManager->m_tThread = std::thread();
@@ -662,27 +662,13 @@ CMonitor* CCompositor::getMonitorFromVector(const Vector2D& point) {
     return getMonitorFromOutput(OUTPUT);
 }
 
-void CCompositor::removeWindowFromVectorSafe(CWindow* pWindow) {
-    if (windowExists(pWindow) && !pWindow->m_bFadingOut) {
+void CCompositor::removeWindowFromVectorSafe(PHLWINDOW pWindow) {
+    if (!pWindow->m_bFadingOut) {
         EMIT_HOOK_EVENT("destroyWindow", pWindow);
 
-        std::erase_if(m_vWindows, [&](std::unique_ptr<CWindow>& el) { return el.get() == pWindow; });
-        std::erase_if(m_vWindowsFadingOut, [&](CWindow* el) { return el == pWindow; });
+        std::erase_if(m_vWindows, [&](SP<CWindow>& el) { return el == pWindow; });
+        std::erase_if(m_vWindowsFadingOut, [&](PHLWINDOWREF el) { return el.lock() == pWindow; });
     }
-}
-
-bool CCompositor::windowExists(CWindow* pWindow) {
-    for (auto& w : m_vWindows) {
-        if (w.get() == pWindow)
-            return true;
-    }
-
-    // FIXME: this is here only temporarily,
-    // remove this func altogether if no reports
-    // of this being hit.
-    RASSERT(!pWindow, "windowExists: attempted UAF");
-
-    return false;
 }
 
 bool CCompositor::monitorExists(CMonitor* pMonitor) {
@@ -694,7 +680,7 @@ bool CCompositor::monitorExists(CMonitor* pMonitor) {
     return false;
 }
 
-CWindow* CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t properties, CWindow* pIgnoreWindow) {
+PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t properties, PHLWINDOW pIgnoreWindow) {
     const auto  PMONITOR          = getMonitorFromVector(pos);
     static auto PRESIZEONBORDER   = CConfigValue<Hyprlang::INT>("general:resize_on_border");
     static auto PBORDERSIZE       = CConfigValue<Hyprlang::INT>("general:border_size");
@@ -708,20 +694,20 @@ CWindow* CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t propert
             const auto BB  = w->getWindowBoxUnified(properties);
             CBox       box = {BB.x - BORDER_GRAB_AREA, BB.y - BORDER_GRAB_AREA, BB.width + 2 * BORDER_GRAB_AREA, BB.height + 2 * BORDER_GRAB_AREA};
             if (w->m_bIsFloating && w->m_bIsMapped && !w->isHidden() && !w->m_bX11ShouldntFocus && w->m_bPinned && !w->m_sAdditionalConfigData.noFocus &&
-                w.get() != pIgnoreWindow) {
+                w != pIgnoreWindow) {
                 if (box.containsPoint({m_sWLRCursor->x, m_sWLRCursor->y}))
-                    return w.get();
+                    return w;
 
                 if (!w->m_bIsX11) {
                     if (w->hasPopupAt(pos))
-                        return w.get();
+                        return w;
                 }
             }
         }
     }
 
-    auto windowForWorkspace = [&](bool special) -> CWindow* {
-        auto floating = [&](bool aboveFullscreen) -> CWindow* {
+    auto windowForWorkspace = [&](bool special) -> PHLWINDOW {
+        auto floating = [&](bool aboveFullscreen) -> PHLWINDOW {
             for (auto& w : m_vWindows | std::views::reverse) {
 
                 if (special && !w->onSpecialWorkspace()) // because special floating may creep up into regular
@@ -738,7 +724,7 @@ CWindow* CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t propert
 
                 CBox box = {BB.x - BORDER_GRAB_AREA, BB.y - BORDER_GRAB_AREA, BB.width + 2 * BORDER_GRAB_AREA, BB.height + 2 * BORDER_GRAB_AREA};
                 if (w->m_bIsFloating && w->m_bIsMapped && isWorkspaceVisible(w->m_pWorkspace) && !w->isHidden() && !w->m_bPinned && !w->m_sAdditionalConfigData.noFocus &&
-                    w.get() != pIgnoreWindow && (!aboveFullscreen || w->m_bCreatedOverFullscreen)) {
+                    w != pIgnoreWindow && (!aboveFullscreen || w->m_bCreatedOverFullscreen)) {
                     // OR windows should add focus to parent
                     if (w->m_bX11ShouldntFocus && w->m_iX11Type != 2)
                         continue;
@@ -747,16 +733,16 @@ CWindow* CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t propert
 
                         if (w->m_bIsX11 && w->m_iX11Type == 2 && !wlr_xwayland_or_surface_wants_focus(w->m_uSurface.xwayland)) {
                             // Override Redirect
-                            return g_pCompositor->m_pLastWindow; // we kinda trick everything here.
+                            return g_pCompositor->m_pLastWindow.lock(); // we kinda trick everything here.
                                                                  // TODO: this is wrong, we should focus the parent, but idk how to get it considering it's nullptr in most cases.
                         }
 
-                        return w.get();
+                        return w;
                     }
 
                     if (!w->m_bIsX11) {
                         if (w->hasPopupAt(pos))
-                            return w.get();
+                            return w;
                     }
                 }
             }
@@ -790,9 +776,9 @@ CWindow* CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t propert
                 continue;
 
             if (!w->m_bIsX11 && !w->m_bIsFloating && w->m_bIsMapped && w->workspaceID() == WORKSPACEID && !w->isHidden() && !w->m_bX11ShouldntFocus &&
-                !w->m_sAdditionalConfigData.noFocus && w.get() != pIgnoreWindow) {
+                !w->m_sAdditionalConfigData.noFocus && w != pIgnoreWindow) {
                 if (w->hasPopupAt(pos))
-                    return w.get();
+                    return w;
             }
         }
 
@@ -802,8 +788,8 @@ CWindow* CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t propert
 
             CBox box = (properties & USE_PROP_TILED) ? w->getWindowBoxUnified(properties) : CBox{w->m_vPosition, w->m_vSize};
             if (!w->m_bIsFloating && w->m_bIsMapped && box.containsPoint(pos) && w->workspaceID() == WORKSPACEID && !w->isHidden() && !w->m_bX11ShouldntFocus &&
-                !w->m_sAdditionalConfigData.noFocus && w.get() != pIgnoreWindow)
-                return w.get();
+                !w->m_sAdditionalConfigData.noFocus && w != pIgnoreWindow)
+                return w;
         }
 
         return nullptr;
@@ -823,9 +809,9 @@ CWindow* CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t propert
     return windowForWorkspace(false);
 }
 
-wlr_surface* CCompositor::vectorWindowToSurface(const Vector2D& pos, CWindow* pWindow, Vector2D& sl) {
+wlr_surface* CCompositor::vectorWindowToSurface(const Vector2D& pos, PHLWINDOW pWindow, Vector2D& sl) {
 
-    if (!windowValidMapped(pWindow))
+    if (!validMapped(pWindow))
         return nullptr;
 
     RASSERT(!pWindow->m_bIsX11, "Cannot call vectorWindowToSurface on an X11 window!");
@@ -857,8 +843,8 @@ wlr_surface* CCompositor::vectorWindowToSurface(const Vector2D& pos, CWindow* pW
     return PSURFACE->surface;
 }
 
-Vector2D CCompositor::vectorToSurfaceLocal(const Vector2D& vec, CWindow* pWindow, wlr_surface* pSurface) {
-    if (!windowValidMapped(pWindow))
+Vector2D CCompositor::vectorToSurfaceLocal(const Vector2D& vec, PHLWINDOW pWindow, wlr_surface* pSurface) {
+    if (!validMapped(pWindow))
         return {};
 
     if (pWindow->m_bIsX11)
@@ -909,7 +895,7 @@ CMonitor* CCompositor::getRealMonitorFromOutput(wlr_output* out) {
     return nullptr;
 }
 
-void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
+void CCompositor::focusWindow(PHLWINDOW pWindow, wlr_surface* pSurface) {
 
     static auto PFOLLOWMOUSE        = CConfigValue<Hyprlang::INT>("input:follow_mouse");
     static auto PSPECIALFALLTHROUGH = CConfigValue<Hyprlang::INT>("input:special_fallthrough");
@@ -929,15 +915,15 @@ void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
 
     g_pLayoutManager->getCurrentLayout()->bringWindowToTop(pWindow);
 
-    if (!pWindow || !windowValidMapped(pWindow)) {
+    if (!pWindow || !validMapped(pWindow)) {
 
-        if (!m_pLastWindow && !pWindow)
+        if (!m_pLastWindow.lock() && !pWindow)
             return;
 
-        const auto PLASTWINDOW = m_pLastWindow;
-        m_pLastWindow          = nullptr;
+        const auto PLASTWINDOW = m_pLastWindow.lock();
+        m_pLastWindow.reset();
 
-        if (windowValidMapped(PLASTWINDOW)) {
+        if (PLASTWINDOW && PLASTWINDOW->m_bIsMapped) {
             updateWindowAnimatedDecorationValues(PLASTWINDOW);
 
             g_pXWaylandManager->activateWindow(PLASTWINDOW, false);
@@ -948,7 +934,7 @@ void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
         g_pEventManager->postEvent(SHyprIPCEvent{"activewindow", ","});
         g_pEventManager->postEvent(SHyprIPCEvent{"activewindowv2", ","});
 
-        EMIT_HOOK_EVENT("activeWindow", (CWindow*)nullptr);
+        EMIT_HOOK_EVENT("activeWindow", (PHLWINDOW)nullptr);
 
         g_pLayoutManager->getCurrentLayout()->onWindowFocusChange(nullptr);
 
@@ -963,7 +949,7 @@ void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
         return;
     }
 
-    if (m_pLastWindow == pWindow && m_sSeat.seat->keyboard_state.focused_surface == pSurface)
+    if (m_pLastWindow.lock() == pWindow && m_sSeat.seat->keyboard_state.focused_surface == pSurface)
         return;
 
     if (pWindow->m_bPinned)
@@ -984,7 +970,7 @@ void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
         return;
     }
 
-    const auto PLASTWINDOW = m_pLastWindow;
+    const auto PLASTWINDOW = m_pLastWindow.lock();
     m_pLastWindow          = pWindow;
 
     /* If special fallthrough is enabled, this behavior will be disabled, as I have no better idea of nicely tracking which
@@ -993,7 +979,7 @@ void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
         PMONITOR->setSpecialWorkspace(nullptr);
 
     // we need to make the PLASTWINDOW not equal to m_pLastWindow so that RENDERDATA is correct for an unfocused window
-    if (windowValidMapped(PLASTWINDOW)) {
+    if (PLASTWINDOW && PLASTWINDOW->m_bIsMapped) {
         PLASTWINDOW->updateDynamicRules();
 
         updateWindowAnimatedDecorationValues(PLASTWINDOW);
@@ -1019,7 +1005,7 @@ void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
 
     // Send an event
     g_pEventManager->postEvent(SHyprIPCEvent{"activewindow", g_pXWaylandManager->getAppIDClass(pWindow) + "," + pWindow->m_szTitle});
-    g_pEventManager->postEvent(SHyprIPCEvent{"activewindowv2", std::format("{:x}", (uintptr_t)pWindow)});
+    g_pEventManager->postEvent(SHyprIPCEvent{"activewindowv2", std::format("{:x}", (uintptr_t)pWindow.get())});
 
     EMIT_HOOK_EVENT("activeWindow", pWindow);
 
@@ -1028,7 +1014,7 @@ void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
     g_pInputManager->recheckIdleInhibitorStatus();
 
     // move to front of the window history
-    const auto HISTORYPIVOT = std::find_if(m_vWindowFocusHistory.begin(), m_vWindowFocusHistory.end(), [&](const auto& other) { return other == pWindow; });
+    const auto HISTORYPIVOT = std::find_if(m_vWindowFocusHistory.begin(), m_vWindowFocusHistory.end(), [&](const auto& other) { return other.lock() == pWindow; });
     if (HISTORYPIVOT == m_vWindowFocusHistory.end()) {
         Debug::log(ERR, "BUG THIS: {} has no pivot in history", pWindow);
     } else {
@@ -1039,7 +1025,7 @@ void CCompositor::focusWindow(CWindow* pWindow, wlr_surface* pSurface) {
         g_pInputManager->sendMotionEventsToFocused();
 }
 
-void CCompositor::focusSurface(wlr_surface* pSurface, CWindow* pWindowOwner) {
+void CCompositor::focusSurface(wlr_surface* pSurface, PHLWINDOW pWindowOwner) {
 
     if (m_sSeat.seat->keyboard_state.focused_surface == pSurface || (pWindowOwner && m_sSeat.seat->keyboard_state.focused_surface == pWindowOwner->m_pWLSurface.wlr()))
         return; // Don't focus when already focused on this.
@@ -1094,22 +1080,6 @@ void CCompositor::focusSurface(wlr_surface* pSurface, CWindow* pWindowOwner) {
         SURF->constraint()->activate();
 }
 
-bool CCompositor::windowValidMapped(CWindow* pWindow) {
-    if (!pWindow)
-        return false;
-
-    if (!windowExists(pWindow))
-        return false;
-
-    if (!pWindow->m_bIsMapped)
-        return false;
-
-    if (pWindow->isHidden())
-        return false;
-
-    return true;
-}
-
 wlr_surface* CCompositor::vectorToLayerPopupSurface(const Vector2D& pos, CMonitor* monitor, Vector2D* sCoords, SLayerSurface** ppLayerSurfaceFound) {
     for (auto& lsl : monitor->m_aLayerSurfaceLayers | std::views::reverse) {
         for (auto& ls : lsl | std::views::reverse) {
@@ -1151,32 +1121,32 @@ wlr_surface* CCompositor::vectorToLayerSurface(const Vector2D& pos, std::vector<
     return nullptr;
 }
 
-CWindow* CCompositor::getWindowFromSurface(wlr_surface* pSurface) {
+PHLWINDOW CCompositor::getWindowFromSurface(wlr_surface* pSurface) {
     for (auto& w : m_vWindows) {
         if (!w->m_bIsMapped || w->m_bFadingOut)
             continue;
 
         if (w->m_pWLSurface.wlr() == pSurface)
-            return w.get();
+            return w;
     }
 
     return nullptr;
 }
 
-CWindow* CCompositor::getWindowFromHandle(uint32_t handle) {
+PHLWINDOW CCompositor::getWindowFromHandle(uint32_t handle) {
     for (auto& w : m_vWindows) {
         if ((uint32_t)(((uint64_t)w.get()) & 0xFFFFFFFF) == handle) {
-            return w.get();
+            return w;
         }
     }
 
     return nullptr;
 }
 
-CWindow* CCompositor::getFullscreenWindowOnWorkspace(const int& ID) {
+PHLWINDOW CCompositor::getFullscreenWindowOnWorkspace(const int& ID) {
     for (auto& w : m_vWindows) {
         if (w->workspaceID() == ID && w->m_bIsFullscreen)
-            return w.get();
+            return w;
     }
 
     return nullptr;
@@ -1241,10 +1211,10 @@ int CCompositor::getGroupsOnWorkspace(const int& id, std::optional<bool> onlyTil
     return no;
 }
 
-CWindow* CCompositor::getUrgentWindow() {
+PHLWINDOW CCompositor::getUrgentWindow() {
     for (auto& w : m_vWindows) {
         if (w->m_bIsMapped && w->m_bIsUrgent)
-            return w.get();
+            return w;
     }
 
     return nullptr;
@@ -1259,16 +1229,16 @@ bool CCompositor::hasUrgentWindowOnWorkspace(const int& id) {
     return false;
 }
 
-CWindow* CCompositor::getFirstWindowOnWorkspace(const int& id) {
+PHLWINDOW CCompositor::getFirstWindowOnWorkspace(const int& id) {
     for (auto& w : m_vWindows) {
         if (w->workspaceID() == id && w->m_bIsMapped && !w->isHidden())
-            return w.get();
+            return w;
     }
 
     return nullptr;
 }
 
-CWindow* CCompositor::getTopLeftWindowOnWorkspace(const int& id) {
+PHLWINDOW CCompositor::getTopLeftWindowOnWorkspace(const int& id) {
     const auto PWORKSPACE = getWorkspaceByID(id);
 
     if (!PWORKSPACE)
@@ -1283,7 +1253,7 @@ CWindow* CCompositor::getTopLeftWindowOnWorkspace(const int& id) {
         const auto WINDOWIDEALBB = w->getWindowIdealBoundingBoxIgnoreReserved();
 
         if (WINDOWIDEALBB.x <= PMONITOR->vecPosition.x + 1 && WINDOWIDEALBB.y <= PMONITOR->vecPosition.y + 1)
-            return w.get();
+            return w;
     }
     return nullptr;
 }
@@ -1309,8 +1279,8 @@ bool CCompositor::doesSeatAcceptInput(wlr_surface* surface) {
     return true;
 }
 
-bool CCompositor::isWindowActive(CWindow* pWindow) {
-    if (!m_pLastWindow && !m_pLastFocus)
+bool CCompositor::isWindowActive(PHLWINDOW pWindow) {
+    if (!m_pLastWindow.lock() && !m_pLastFocus)
         return false;
 
     if (!pWindow->m_bIsMapped)
@@ -1318,24 +1288,24 @@ bool CCompositor::isWindowActive(CWindow* pWindow) {
 
     const auto PSURFACE = pWindow->m_pWLSurface.wlr();
 
-    return PSURFACE == m_pLastFocus || pWindow == m_pLastWindow;
+    return PSURFACE == m_pLastFocus || pWindow == m_pLastWindow.lock();
 }
 
-void CCompositor::changeWindowZOrder(CWindow* pWindow, bool top) {
-    if (!windowValidMapped(pWindow))
+void CCompositor::changeWindowZOrder(PHLWINDOW pWindow, bool top) {
+    if (!validMapped(pWindow))
         return;
 
-    auto moveToZ = [&](CWindow* pw, bool top) -> void {
+    auto moveToZ = [&](PHLWINDOW pw, bool top) -> void {
         if (top) {
             for (auto it = m_vWindows.begin(); it != m_vWindows.end(); ++it) {
-                if (it->get() == pw) {
+                if (*it == pw) {
                     std::rotate(it, it + 1, m_vWindows.end());
                     break;
                 }
             }
         } else {
             for (auto it = m_vWindows.rbegin(); it != m_vWindows.rend(); ++it) {
-                if (it->get() == pw) {
+                if (*it == pw) {
                     std::rotate(it, it + 1, m_vWindows.rend());
                     break;
                 }
@@ -1355,9 +1325,9 @@ void CCompositor::changeWindowZOrder(CWindow* pWindow, bool top) {
     } else {
         // move X11 window stack
 
-        std::deque<CWindow*> toMove;
+        std::deque<PHLWINDOW> toMove;
 
-        auto                 x11Stack = [&](CWindow* pw, bool top, auto&& x11Stack) -> void {
+        auto                 x11Stack = [&](PHLWINDOW pw, bool top, auto&& x11Stack) -> void {
             if (top)
                 toMove.emplace_back(pw);
             else
@@ -1365,7 +1335,7 @@ void CCompositor::changeWindowZOrder(CWindow* pWindow, bool top) {
 
             for (auto& w : m_vWindows) {
                 if (w->m_bIsMapped && !w->isHidden() && w->m_bIsX11 && w->X11TransientFor() == pw) {
-                    x11Stack(w.get(), top, x11Stack);
+                    x11Stack(w, top, x11Stack);
                 }
             }
         };
@@ -1379,7 +1349,9 @@ void CCompositor::changeWindowZOrder(CWindow* pWindow, bool top) {
 }
 
 void CCompositor::cleanupFadingOut(const int& monid) {
-    for (auto& w : m_vWindowsFadingOut) {
+    for (auto& ww : m_vWindowsFadingOut) {
+
+        const auto w = ww.lock();
 
         if (w->m_iMonitorID != (long unsigned int)monid)
             continue;
@@ -1462,8 +1434,8 @@ void CCompositor::addToFadingOutSafe(SLayerSurface* pLS) {
     m_vSurfacesFadingOut.emplace_back(pLS);
 }
 
-void CCompositor::addToFadingOutSafe(CWindow* pWindow) {
-    const auto FOUND = std::find_if(m_vWindowsFadingOut.begin(), m_vWindowsFadingOut.end(), [&](CWindow* other) { return other == pWindow; });
+void CCompositor::addToFadingOutSafe(PHLWINDOW pWindow) {
+    const auto FOUND = std::find_if(m_vWindowsFadingOut.begin(), m_vWindowsFadingOut.end(), [&](PHLWINDOWREF& other) { return other.lock() == pWindow; });
 
     if (FOUND != m_vWindowsFadingOut.end())
         return; // if it's already added, don't add it.
@@ -1471,7 +1443,7 @@ void CCompositor::addToFadingOutSafe(CWindow* pWindow) {
     m_vWindowsFadingOut.emplace_back(pWindow);
 }
 
-CWindow* CCompositor::getWindowInDirection(CWindow* pWindow, char dir) {
+PHLWINDOW CCompositor::getWindowInDirection(PHLWINDOW pWindow, char dir) {
 
     if (!isDirection(dir))
         return nullptr;
@@ -1492,13 +1464,13 @@ CWindow* CCompositor::getWindowInDirection(CWindow* pWindow, char dir) {
 
     const auto PWORKSPACE   = pWindow->m_pWorkspace;
     auto       leaderValue  = -1;
-    CWindow*   leaderWindow = nullptr;
+    PHLWINDOW   leaderWindow = nullptr;
 
     if (!pWindow->m_bIsFloating) {
 
         // for tiled windows, we calc edges
         for (auto& w : m_vWindows) {
-            if (w.get() == pWindow || !w->m_bIsMapped || w->isHidden() || (!w->m_bIsFullscreen && w->m_bIsFloating) || !isWorkspaceVisible(w->m_pWorkspace))
+            if (w == pWindow || !w->m_bIsMapped || w->isHidden() || (!w->m_bIsFullscreen && w->m_bIsFloating) || !isWorkspaceVisible(w->m_pWorkspace))
                 continue;
 
             if (pWindow->m_iMonitorID == w->m_iMonitorID && pWindow->m_pWorkspace != w->m_pWorkspace)
@@ -1545,7 +1517,7 @@ CWindow* CCompositor::getWindowInDirection(CWindow* pWindow, char dir) {
                     // get idx
                     int windowIDX = -1;
                     for (size_t i = 0; i < g_pCompositor->m_vWindowFocusHistory.size(); ++i) {
-                        if (g_pCompositor->m_vWindowFocusHistory[i] == w.get()) {
+                        if (g_pCompositor->m_vWindowFocusHistory[i].lock() == w) {
                             windowIDX = i;
                             break;
                         }
@@ -1555,13 +1527,13 @@ CWindow* CCompositor::getWindowInDirection(CWindow* pWindow, char dir) {
 
                     if (windowIDX > leaderValue) {
                         leaderValue  = windowIDX;
-                        leaderWindow = w.get();
+                        leaderWindow = w;
                     }
                 }
             } else /* length */ {
                 if (intersectLength > leaderValue) {
                     leaderValue  = intersectLength;
-                    leaderWindow = w.get();
+                    leaderWindow = w;
                 }
             }
         }
@@ -1587,7 +1559,7 @@ CWindow* CCompositor::getWindowInDirection(CWindow* pWindow, char dir) {
         constexpr float THRESHOLD    = 0.3 * M_PI;
 
         for (auto& w : m_vWindows) {
-            if (w.get() == pWindow || !w->m_bIsMapped || w->isHidden() || (!w->m_bIsFullscreen && !w->m_bIsFloating) || !isWorkspaceVisible(w->m_pWorkspace))
+            if (w == pWindow || !w->m_bIsMapped || w->isHidden() || (!w->m_bIsFullscreen && !w->m_bIsFloating) || !isWorkspaceVisible(w->m_pWorkspace))
                 continue;
 
             if (pWindow->m_iMonitorID == w->m_iMonitorID && pWindow->m_pWorkspace != w->m_pWorkspace)
@@ -1605,7 +1577,7 @@ CWindow* CCompositor::getWindowInDirection(CWindow* pWindow, char dir) {
             if ((bestAngleAbs < THRESHOLD && DIST < leaderValue && ANGLE < THRESHOLD) || (ANGLE < bestAngleAbs && bestAngleAbs > THRESHOLD) || leaderValue == -1) {
                 leaderValue  = DIST;
                 bestAngleAbs = ANGLE;
-                leaderWindow = w.get();
+                leaderWindow = w;
             }
         }
 
@@ -1619,13 +1591,13 @@ CWindow* CCompositor::getWindowInDirection(CWindow* pWindow, char dir) {
     return nullptr;
 }
 
-CWindow* CCompositor::getNextWindowOnWorkspace(CWindow* pWindow, bool focusableOnly, std::optional<bool> floating) {
+PHLWINDOW CCompositor::getNextWindowOnWorkspace(PHLWINDOW pWindow, bool focusableOnly, std::optional<bool> floating) {
     bool gotToWindow = false;
     for (auto& w : m_vWindows) {
-        if (w.get() != pWindow && !gotToWindow)
+        if (w != pWindow && !gotToWindow)
             continue;
 
-        if (w.get() == pWindow) {
+        if (w == pWindow) {
             gotToWindow = true;
             continue;
         }
@@ -1634,27 +1606,27 @@ CWindow* CCompositor::getNextWindowOnWorkspace(CWindow* pWindow, bool focusableO
             continue;
 
         if (w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sAdditionalConfigData.noFocus))
-            return w.get();
+            return w;
     }
 
     for (auto& w : m_vWindows) {
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w.get() != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sAdditionalConfigData.noFocus))
-            return w.get();
+        if (w != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sAdditionalConfigData.noFocus))
+            return w;
     }
 
     return nullptr;
 }
 
-CWindow* CCompositor::getPrevWindowOnWorkspace(CWindow* pWindow, bool focusableOnly, std::optional<bool> floating) {
+PHLWINDOW CCompositor::getPrevWindowOnWorkspace(PHLWINDOW pWindow, bool focusableOnly, std::optional<bool> floating) {
     bool gotToWindow = false;
     for (auto& w : m_vWindows | std::views::reverse) {
-        if (w.get() != pWindow && !gotToWindow)
+        if (w != pWindow && !gotToWindow)
             continue;
 
-        if (w.get() == pWindow) {
+        if (w == pWindow) {
             gotToWindow = true;
             continue;
         }
@@ -1663,15 +1635,15 @@ CWindow* CCompositor::getPrevWindowOnWorkspace(CWindow* pWindow, bool focusableO
             continue;
 
         if (w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sAdditionalConfigData.noFocus))
-            return w.get();
+            return w;
     }
 
     for (auto& w : m_vWindows | std::views::reverse) {
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w.get() != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sAdditionalConfigData.noFocus))
-            return w.get();
+        if (w != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sAdditionalConfigData.noFocus))
+            return w;
     }
 
     return nullptr;
@@ -1805,7 +1777,7 @@ void CCompositor::updateAllWindowsAnimatedDecorationValues() {
         if (!w->m_bIsMapped)
             continue;
 
-        updateWindowAnimatedDecorationValues(w.get());
+        updateWindowAnimatedDecorationValues(w);
     }
 }
 
@@ -1818,7 +1790,7 @@ void CCompositor::updateWorkspaceWindows(const int64_t& id) {
     }
 }
 
-void CCompositor::updateWindowAnimatedDecorationValues(CWindow* pWindow) {
+void CCompositor::updateWindowAnimatedDecorationValues(PHLWINDOW pWindow) {
     // optimization
     static auto PACTIVECOL              = CConfigValue<Hyprlang::CUSTOMTYPE>("general:col.active_border");
     static auto PINACTIVECOL            = CConfigValue<Hyprlang::CUSTOMTYPE>("general:col.inactive_border");
@@ -1860,15 +1832,15 @@ void CCompositor::updateWindowAnimatedDecorationValues(CWindow* pWindow) {
     if (RENDERDATA.isBorderGradient)
         setBorderColor(*RENDERDATA.borderGradient);
     else {
-        const bool GROUPLOCKED = pWindow->m_sGroupData.pNextWindow ? pWindow->getGroupHead()->m_sGroupData.locked : false;
-        if (pWindow == m_pLastWindow) {
+        const bool GROUPLOCKED = pWindow->m_sGroupData.pNextWindow.lock() ? pWindow->getGroupHead()->m_sGroupData.locked : false;
+        if (pWindow == m_pLastWindow.lock()) {
             const auto* const ACTIVECOLOR =
-                !pWindow->m_sGroupData.pNextWindow ? (!pWindow->m_sGroupData.deny ? ACTIVECOL : NOGROUPACTIVECOL) : (GROUPLOCKED ? GROUPACTIVELOCKEDCOL : GROUPACTIVECOL);
+                !pWindow->m_sGroupData.pNextWindow.lock() ? (!pWindow->m_sGroupData.deny ? ACTIVECOL : NOGROUPACTIVECOL) : (GROUPLOCKED ? GROUPACTIVELOCKEDCOL : GROUPACTIVECOL);
             setBorderColor(pWindow->m_sSpecialRenderData.activeBorderColor.toUnderlying().m_vColors.empty() ? *ACTIVECOLOR :
                                                                                                               pWindow->m_sSpecialRenderData.activeBorderColor.toUnderlying());
         } else {
             const auto* const INACTIVECOLOR =
-                !pWindow->m_sGroupData.pNextWindow ? (!pWindow->m_sGroupData.deny ? INACTIVECOL : NOGROUPINACTIVECOL) : (GROUPLOCKED ? GROUPINACTIVELOCKEDCOL : GROUPINACTIVECOL);
+                !pWindow->m_sGroupData.pNextWindow.lock() ? (!pWindow->m_sGroupData.deny ? INACTIVECOL : NOGROUPINACTIVECOL) : (GROUPLOCKED ? GROUPINACTIVELOCKEDCOL : GROUPINACTIVECOL);
             setBorderColor(pWindow->m_sSpecialRenderData.inactiveBorderColor.toUnderlying().m_vColors.empty() ? *INACTIVECOLOR :
                                                                                                                 pWindow->m_sSpecialRenderData.inactiveBorderColor.toUnderlying());
         }
@@ -1886,7 +1858,7 @@ void CCompositor::updateWindowAnimatedDecorationValues(CWindow* pWindow) {
                                                                                     pWindow->m_sSpecialRenderData.alphaFullscreen.toUnderlying() * *PFULLSCREENALPHA) :
             *PFULLSCREENALPHA;
     } else {
-        if (pWindow == m_pLastWindow)
+        if (pWindow == m_pLastWindow.lock())
             pWindow->m_fActiveInactiveAlpha = pWindow->m_sSpecialRenderData.alphaOverride.toUnderlying() ? pWindow->m_sSpecialRenderData.alpha.toUnderlying() :
                                                                                                            pWindow->m_sSpecialRenderData.alpha.toUnderlying() * *PACTIVEALPHA;
         else
@@ -1897,7 +1869,7 @@ void CCompositor::updateWindowAnimatedDecorationValues(CWindow* pWindow) {
     }
 
     // dim
-    if (pWindow == m_pLastWindow || pWindow->m_sAdditionalConfigData.forceNoDim || !*PDIMENABLED) {
+    if (pWindow == m_pLastWindow.lock() || pWindow->m_sAdditionalConfigData.forceNoDim || !*PDIMENABLED) {
         pWindow->m_fDimPercent = 0;
     } else {
         pWindow->m_fDimPercent = *PDIMSTRENGTH;
@@ -1905,7 +1877,7 @@ void CCompositor::updateWindowAnimatedDecorationValues(CWindow* pWindow) {
 
     // shadow
     if (pWindow->m_iX11Type != 2 && !pWindow->m_bX11DoesntWantBorders) {
-        if (pWindow == m_pLastWindow) {
+        if (pWindow == m_pLastWindow.lock()) {
             pWindow->m_cRealShadowColor = CColor(*PSHADOWCOL);
         } else {
             pWindow->m_cRealShadowColor = CColor(*PSHADOWCOLINACTIVE != INT_MAX ? *PSHADOWCOLINACTIVE : *PSHADOWCOL);
@@ -2252,8 +2224,8 @@ void CCompositor::updateFullscreenFadeOnWorkspace(PHLWORKSPACE pWorkspace) {
     }
 }
 
-void CCompositor::setWindowFullscreen(CWindow* pWindow, bool on, eFullscreenMode mode) {
-    if (!windowValidMapped(pWindow) || g_pCompositor->m_bUnsafeState)
+void CCompositor::setWindowFullscreen(PHLWINDOW pWindow, bool on, eFullscreenMode mode) {
+    if (!validMapped(pWindow) || g_pCompositor->m_bUnsafeState)
         return;
 
     if (pWindow->m_bPinned) {
@@ -2302,7 +2274,7 @@ void CCompositor::setWindowFullscreen(CWindow* pWindow, bool on, eFullscreenMode
     g_pConfigManager->ensureVRR(PMONITOR);
 }
 
-CWindow* CCompositor::getX11Parent(CWindow* pWindow) {
+PHLWINDOW CCompositor::getX11Parent(PHLWINDOW pWindow) {
     if (!pWindow->m_bIsX11)
         return nullptr;
 
@@ -2311,7 +2283,7 @@ CWindow* CCompositor::getX11Parent(CWindow* pWindow) {
             continue;
 
         if (w->m_uSurface.xwayland == pWindow->m_uSurface.xwayland->parent)
-            return w.get();
+            return w;
     }
 
     return nullptr;
@@ -2351,9 +2323,9 @@ void CCompositor::scheduleFrameForMonitor(CMonitor* pMonitor) {
     wlr_output_schedule_frame(pMonitor->output);
 }
 
-CWindow* CCompositor::getWindowByRegex(const std::string& regexp) {
+PHLWINDOW CCompositor::getWindowByRegex(const std::string& regexp) {
     if (regexp.starts_with("active"))
-        return m_pLastWindow;
+        return m_pLastWindow.lock();
 
     eFocusWindowMode mode = MODE_CLASS_REGEX;
 
@@ -2378,28 +2350,28 @@ CWindow* CCompositor::getWindowByRegex(const std::string& regexp) {
         matchCheck = regexp.substr(4);
     } else if (regexp.starts_with("floating") || regexp.starts_with("tiled")) {
         // first floating on the current ws
-        if (!m_pLastWindow)
+        if (!valid(m_pLastWindow))
             return nullptr;
 
         const bool FLOAT = regexp.starts_with("floating");
 
         for (auto& w : m_vWindows) {
-            if (!w->m_bIsMapped || w->m_bIsFloating != FLOAT || w->m_pWorkspace != m_pLastWindow->m_pWorkspace || w->isHidden())
+            if (!w->m_bIsMapped || w->m_bIsFloating != FLOAT || w->m_pWorkspace != m_pLastWindow.lock()->m_pWorkspace || w->isHidden())
                 continue;
 
-            return w.get();
+            return w;
         }
 
         return nullptr;
     }
 
     for (auto& w : g_pCompositor->m_vWindows) {
-        if (!w->m_bIsMapped || (w->isHidden() && !g_pLayoutManager->getCurrentLayout()->isWindowReachable(w.get())))
+        if (!w->m_bIsMapped || (w->isHidden() && !g_pLayoutManager->getCurrentLayout()->isWindowReachable(w)))
             continue;
 
         switch (mode) {
             case MODE_CLASS_REGEX: {
-                const auto windowClass = g_pXWaylandManager->getAppIDClass(w.get());
+                const auto windowClass = g_pXWaylandManager->getAppIDClass(w);
                 if (!std::regex_search(windowClass, regexCheck))
                     continue;
                 break;
@@ -2411,7 +2383,7 @@ CWindow* CCompositor::getWindowByRegex(const std::string& regexp) {
                 break;
             }
             case MODE_TITLE_REGEX: {
-                const auto windowTitle = g_pXWaylandManager->getTitle(w.get());
+                const auto windowTitle = g_pXWaylandManager->getTitle(w);
                 if (!std::regex_search(windowTitle, regexCheck))
                     continue;
                 break;
@@ -2437,7 +2409,7 @@ CWindow* CCompositor::getWindowByRegex(const std::string& regexp) {
             default: break;
         }
 
-        return w.get();
+        return w;
     }
 
     return nullptr;
@@ -2476,8 +2448,8 @@ SLayerSurface* CCompositor::getLayerSurfaceFromWlr(wlr_layer_surface_v1* pLS) {
     return nullptr;
 }
 
-void CCompositor::closeWindow(CWindow* pWindow) {
-    if (pWindow && windowValidMapped(pWindow)) {
+void CCompositor::closeWindow(PHLWINDOW pWindow) {
+    if (pWindow && validMapped(pWindow)) {
         g_pXWaylandManager->sendCloseWindow(pWindow);
     }
 }
@@ -2565,7 +2537,7 @@ Vector2D CCompositor::parseWindowVectorArgsRelative(const std::string& args, con
 void CCompositor::forceReportSizesToWindowsOnWorkspace(const int& wid) {
     for (auto& w : m_vWindows) {
         if (w->workspaceID() == wid && w->m_bIsMapped && !w->isHidden()) {
-            g_pXWaylandManager->setWindowSize(w.get(), w->m_vRealSize.value(), true);
+            g_pXWaylandManager->setWindowSize(w, w->m_vRealSize.value(), true);
         }
     }
 }
@@ -2638,7 +2610,7 @@ void CCompositor::performUserChecks() {
     ; // intentional
 }
 
-void CCompositor::moveWindowToWorkspaceSafe(CWindow* pWindow, PHLWORKSPACE pWorkspace) {
+void CCompositor::moveWindowToWorkspaceSafe(PHLWINDOW pWindow, PHLWORKSPACE pWorkspace) {
     if (!pWindow || !pWorkspace)
         return;
 
@@ -2672,12 +2644,12 @@ void CCompositor::moveWindowToWorkspaceSafe(CWindow* pWindow, PHLWORKSPACE pWork
     pWindow->updateDynamicRules();
     pWindow->uncacheWindowDecos();
 
-    if (pWindow->m_sGroupData.pNextWindow) {
-        CWindow* next = pWindow->m_sGroupData.pNextWindow;
+    if (pWindow->m_sGroupData.pNextWindow.lock()) {
+        PHLWINDOW next = pWindow->m_sGroupData.pNextWindow.lock();
         while (next != pWindow) {
             next->moveToWorkspace(pWorkspace);
             next->updateToplevel();
-            next = next->m_sGroupData.pNextWindow;
+            next = next->m_sGroupData.pNextWindow.lock();
         }
     }
 
@@ -2688,7 +2660,7 @@ void CCompositor::moveWindowToWorkspaceSafe(CWindow* pWindow, PHLWORKSPACE pWork
     g_pCompositor->updateWorkspaceWindows(pWindow->workspaceID());
 }
 
-CWindow* CCompositor::getForceFocus() {
+PHLWINDOW CCompositor::getForceFocus() {
     for (auto& w : m_vWindows) {
         if (!w->m_bIsMapped || w->isHidden() || !isWorkspaceVisible(w->m_pWorkspace))
             continue;
@@ -2696,7 +2668,7 @@ CWindow* CCompositor::getForceFocus() {
         if (!w->m_bStayFocused)
             continue;
 
-        return w.get();
+        return w;
     }
 
     return nullptr;
@@ -2874,4 +2846,15 @@ void CCompositor::updateSuspendedStates() {
 
         w->setSuspended(w->isHidden() || !isWorkspaceVisible(w->m_pWorkspace));
     }
+}
+
+PHLWINDOW CCompositor::windowForCPointer(CWindow* pWindow) {
+    for (auto& w : m_vWindows) {
+        if (w.get() != pWindow)
+            continue;
+
+        return w;
+    }
+
+    return {};
 }

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -78,11 +78,11 @@ class CCompositor {
     std::string                               m_szInstanceSignature = "";
     std::string                               m_szCurrentSplash     = "error";
 
-    std::vector<std::shared_ptr<CMonitor>>    m_vMonitors;
-    std::vector<std::shared_ptr<CMonitor>>    m_vRealMonitors; // for all monitors, even those turned off
-    std::vector<std::unique_ptr<CWindow>>     m_vWindows;
+    std::vector<SP<CMonitor>>                 m_vMonitors;
+    std::vector<SP<CMonitor>>                 m_vRealMonitors; // for all monitors, even those turned off
+    std::vector<PHLWINDOW>                    m_vWindows;
     std::vector<PHLWORKSPACE>                 m_vWorkspaces;
-    std::vector<CWindow*>                     m_vWindowsFadingOut;
+    std::vector<PHLWINDOWREF>                 m_vWindowsFadingOut;
     std::vector<SLayerSurface*>               m_vSurfacesFadingOut;
 
     std::unordered_map<std::string, uint64_t> m_mMonitorIDMap;
@@ -93,11 +93,11 @@ class CCompositor {
     void                                      createLockFile();
     void                                      removeLockFile();
 
-    wlr_surface*                              m_pLastFocus   = nullptr;
-    CWindow*                                  m_pLastWindow  = nullptr;
+    wlr_surface*                              m_pLastFocus = nullptr;
+    PHLWINDOWREF                              m_pLastWindow;
     CMonitor*                                 m_pLastMonitor = nullptr;
 
-    std::vector<CWindow*>                     m_vWindowFocusHistory; // first element is the most recently focused.
+    std::vector<PHLWINDOWREF>                 m_vWindowFocusHistory; // first element is the most recently focused.
 
     SSeat                                     m_sSeat;
 
@@ -117,21 +117,19 @@ class CCompositor {
     CMonitor*      getMonitorFromDesc(const std::string&);
     CMonitor*      getMonitorFromCursor();
     CMonitor*      getMonitorFromVector(const Vector2D&);
-    void           removeWindowFromVectorSafe(CWindow*);
-    void           focusWindow(CWindow*, wlr_surface* pSurface = nullptr);
-    void           focusSurface(wlr_surface*, CWindow* pWindowOwner = nullptr);
-    bool           windowExists(CWindow*);
-    bool           windowValidMapped(CWindow*);
+    void           removeWindowFromVectorSafe(PHLWINDOW);
+    void           focusWindow(PHLWINDOW, wlr_surface* pSurface = nullptr);
+    void           focusSurface(wlr_surface*, PHLWINDOW pWindowOwner = nullptr);
     bool           monitorExists(CMonitor*);
-    CWindow*       vectorToWindowUnified(const Vector2D&, uint8_t properties, CWindow* pIgnoreWindow = nullptr);
+    PHLWINDOW      vectorToWindowUnified(const Vector2D&, uint8_t properties, PHLWINDOW pIgnoreWindow = nullptr);
     wlr_surface*   vectorToLayerSurface(const Vector2D&, std::vector<std::unique_ptr<SLayerSurface>>*, Vector2D*, SLayerSurface**);
     wlr_surface*   vectorToLayerPopupSurface(const Vector2D&, CMonitor* monitor, Vector2D*, SLayerSurface**);
-    wlr_surface*   vectorWindowToSurface(const Vector2D&, CWindow*, Vector2D& sl);
-    Vector2D       vectorToSurfaceLocal(const Vector2D&, CWindow*, wlr_surface*);
+    wlr_surface*   vectorWindowToSurface(const Vector2D&, PHLWINDOW, Vector2D& sl);
+    Vector2D       vectorToSurfaceLocal(const Vector2D&, PHLWINDOW, wlr_surface*);
     CMonitor*      getMonitorFromOutput(wlr_output*);
     CMonitor*      getRealMonitorFromOutput(wlr_output*);
-    CWindow*       getWindowFromSurface(wlr_surface*);
-    CWindow*       getWindowFromHandle(uint32_t);
+    PHLWINDOW      getWindowFromSurface(wlr_surface*);
+    PHLWINDOW      getWindowFromHandle(uint32_t);
     bool           isWorkspaceVisible(PHLWORKSPACE);
     PHLWORKSPACE   getWorkspaceByID(const int&);
     PHLWORKSPACE   getWorkspaceByName(const std::string&);
@@ -141,18 +139,18 @@ class CCompositor {
     void           updateWorkspaceSpecialRenderData(const int&);
     int            getWindowsOnWorkspace(const int& id, std::optional<bool> onlyTiled = {}, std::optional<bool> onlyVisible = {});
     int            getGroupsOnWorkspace(const int& id, std::optional<bool> onlyTiled = {}, std::optional<bool> onlyVisible = {});
-    CWindow*       getUrgentWindow();
+    PHLWINDOW      getUrgentWindow();
     bool           hasUrgentWindowOnWorkspace(const int&);
-    CWindow*       getFirstWindowOnWorkspace(const int&);
-    CWindow*       getTopLeftWindowOnWorkspace(const int&);
-    CWindow*       getFullscreenWindowOnWorkspace(const int&);
+    PHLWINDOW      getFirstWindowOnWorkspace(const int&);
+    PHLWINDOW      getTopLeftWindowOnWorkspace(const int&);
+    PHLWINDOW      getFullscreenWindowOnWorkspace(const int&);
     bool           doesSeatAcceptInput(wlr_surface*);
-    bool           isWindowActive(CWindow*);
-    void           changeWindowZOrder(CWindow*, bool);
+    bool           isWindowActive(PHLWINDOW);
+    void           changeWindowZOrder(PHLWINDOW, bool);
     void           cleanupFadingOut(const int& monid);
-    CWindow*       getWindowInDirection(CWindow*, char);
-    CWindow*       getNextWindowOnWorkspace(CWindow*, bool focusableOnly = false, std::optional<bool> floating = {});
-    CWindow*       getPrevWindowOnWorkspace(CWindow*, bool focusableOnly = false, std::optional<bool> floating = {});
+    PHLWINDOW      getWindowInDirection(PHLWINDOW, char);
+    PHLWINDOW      getNextWindowOnWorkspace(PHLWINDOW, bool focusableOnly = false, std::optional<bool> floating = {});
+    PHLWINDOW      getPrevWindowOnWorkspace(PHLWINDOW, bool focusableOnly = false, std::optional<bool> floating = {});
     int            getNextAvailableNamedWorkspace();
     bool           isPointOnAnyMonitor(const Vector2D&);
     bool           isPointOnReservedArea(const Vector2D& point, const CMonitor* monitor = nullptr);
@@ -160,23 +158,23 @@ class CCompositor {
     CMonitor*      getMonitorInDirection(CMonitor*, const char&);
     void           updateAllWindowsAnimatedDecorationValues();
     void           updateWorkspaceWindows(const int64_t& id);
-    void           updateWindowAnimatedDecorationValues(CWindow*);
+    void           updateWindowAnimatedDecorationValues(PHLWINDOW);
     int            getNextAvailableMonitorID(std::string const& name);
     void           moveWorkspaceToMonitor(PHLWORKSPACE, CMonitor*, bool noWarpCursor = false);
     void           swapActiveWorkspaces(CMonitor*, CMonitor*);
     CMonitor*      getMonitorFromString(const std::string&);
     bool           workspaceIDOutOfBounds(const int64_t&);
-    void           setWindowFullscreen(CWindow*, bool, eFullscreenMode mode = FULLSCREEN_INVALID);
+    void           setWindowFullscreen(PHLWINDOW, bool, eFullscreenMode mode = FULLSCREEN_INVALID);
     void           updateFullscreenFadeOnWorkspace(PHLWORKSPACE);
-    CWindow*       getX11Parent(CWindow*);
+    PHLWINDOW      getX11Parent(PHLWINDOW);
     void           scheduleFrameForMonitor(CMonitor*);
     void           addToFadingOutSafe(SLayerSurface*);
-    void           addToFadingOutSafe(CWindow*);
-    CWindow*       getWindowByRegex(const std::string&);
+    void           addToFadingOutSafe(PHLWINDOW);
+    PHLWINDOW      getWindowByRegex(const std::string&);
     void           warpCursorTo(const Vector2D&, bool force = false);
     SLayerSurface* getLayerSurfaceFromWlr(wlr_layer_surface_v1*);
     SLayerSurface* getLayerSurfaceFromSurface(wlr_surface*);
-    void           closeWindow(CWindow*);
+    void           closeWindow(PHLWINDOW);
     Vector2D       parseWindowVectorArgsRelative(const std::string&, const Vector2D&);
     void           forceReportSizesToWindowsOnWorkspace(const int&);
     PHLWORKSPACE   createNewWorkspace(const int&, const int&, const std::string& name = ""); // will be deleted next frame if left empty and unfocused!
@@ -185,8 +183,8 @@ class CCompositor {
     bool           isWorkspaceSpecial(const int&);
     int            getNewSpecialID();
     void           performUserChecks();
-    void           moveWindowToWorkspaceSafe(CWindow* pWindow, PHLWORKSPACE pWorkspace);
-    CWindow*       getForceFocus();
+    void           moveWindowToWorkspaceSafe(PHLWINDOW pWindow, PHLWORKSPACE pWorkspace);
+    PHLWINDOW      getForceFocus();
     void           notifyIdleActivity();
     void           setIdleActivityInhibit(bool inhibit);
     void           arrangeMonitors();
@@ -195,6 +193,7 @@ class CCompositor {
     void           setPreferredScaleForSurface(wlr_surface* pSurface, double scale);
     void           setPreferredTransformForSurface(wlr_surface* pSurface, wl_output_transform transform);
     void           updateSuspendedStates();
+    PHLWINDOW      windowForCPointer(CWindow*);
 
     std::string    explicitConfigPath;
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1018,8 +1018,8 @@ SWorkspaceRule CConfigManager::mergeWorkspaceRules(const SWorkspaceRule& rule1, 
     return mergedRule;
 }
 
-std::vector<SWindowRule> CConfigManager::getMatchingRules(CWindow* pWindow, bool dynamic, bool shadowExec) {
-    if (!g_pCompositor->windowExists(pWindow))
+std::vector<SWindowRule> CConfigManager::getMatchingRules(PHLWINDOW pWindow, bool dynamic, bool shadowExec) {
+    if (!valid(pWindow))
         return std::vector<SWindowRule>();
 
     std::vector<SWindowRule> returns;
@@ -1104,7 +1104,7 @@ std::vector<SWindowRule> CConfigManager::getMatchingRules(CWindow* pWindow, bool
                 }
 
                 if (rule.bFocus != -1) {
-                    if (rule.bFocus != (g_pCompositor->m_pLastWindow == pWindow))
+                    if (rule.bFocus != (g_pCompositor->m_pLastWindow.lock() == pWindow))
                         continue;
                 }
 

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -113,7 +113,7 @@ class CConfigManager {
     std::string                                                     getBoundMonitorStringForWS(const std::string&);
     const std::deque<SWorkspaceRule>&                               getAllWorkspaceRules();
 
-    std::vector<SWindowRule>                                        getMatchingRules(CWindow*, bool dynamic = true, bool shadowExec = false);
+    std::vector<SWindowRule>                                        getMatchingRules(PHLWINDOW, bool dynamic = true, bool shadowExec = false);
     std::vector<SLayerRule>                                         getMatchingRules(SLayerSurface*);
 
     std::unordered_map<std::string, SMonitorAdditionalReservedArea> m_mAdditionalReservedAreas;

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -143,7 +143,7 @@ std::string monitorsRequest(eHyprCtlOutputFormat format, std::string request) {
 
 static std::string getGroupedData(PHLWINDOW w, eHyprCtlOutputFormat format) {
     const bool isJson = format == eHyprCtlOutputFormat::FORMAT_JSON;
-    if (!w->m_sGroupData.pNextWindow.lock())
+    if (w->m_sGroupData.pNextWindow.expired())
         return isJson ? "" : "0";
 
     std::ostringstream result;

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -148,8 +148,8 @@ static std::string getGroupedData(PHLWINDOW w, eHyprCtlOutputFormat format) {
 
     std::ostringstream result;
 
-    PHLWINDOW           head = w->getGroupHead();
-    PHLWINDOW           curr = head;
+    PHLWINDOW          head = w->getGroupHead();
+    PHLWINDOW          curr = head;
     while (true) {
         if (isJson)
             result << std::format("\"0x{:x}\"", (uintptr_t)curr.get());

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -141,21 +141,21 @@ std::string monitorsRequest(eHyprCtlOutputFormat format, std::string request) {
     return result;
 }
 
-static std::string getGroupedData(CWindow* w, eHyprCtlOutputFormat format) {
+static std::string getGroupedData(PHLWINDOW w, eHyprCtlOutputFormat format) {
     const bool isJson = format == eHyprCtlOutputFormat::FORMAT_JSON;
-    if (!w->m_sGroupData.pNextWindow)
+    if (!w->m_sGroupData.pNextWindow.lock())
         return isJson ? "" : "0";
 
     std::ostringstream result;
 
-    CWindow*           head = w->getGroupHead();
-    CWindow*           curr = head;
+    PHLWINDOW           head = w->getGroupHead();
+    PHLWINDOW           curr = head;
     while (true) {
         if (isJson)
-            result << std::format("\"0x{:x}\"", (uintptr_t)curr);
+            result << std::format("\"0x{:x}\"", (uintptr_t)curr.get());
         else
-            result << std::format("{:x}", (uintptr_t)curr);
-        curr = curr->m_sGroupData.pNextWindow;
+            result << std::format("{:x}", (uintptr_t)curr.get());
+        curr = curr->m_sGroupData.pNextWindow.lock();
         // We've wrapped around to the start, break out without trailing comma
         if (curr == head)
             break;
@@ -165,10 +165,10 @@ static std::string getGroupedData(CWindow* w, eHyprCtlOutputFormat format) {
     return result.str();
 }
 
-static std::string getWindowData(CWindow* w, eHyprCtlOutputFormat format) {
-    auto getFocusHistoryID = [](CWindow* wnd) -> int {
+static std::string getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
+    auto getFocusHistoryID = [](PHLWINDOW wnd) -> int {
         for (size_t i = 0; i < g_pCompositor->m_vWindowFocusHistory.size(); ++i) {
-            if (g_pCompositor->m_vWindowFocusHistory[i] == wnd)
+            if (g_pCompositor->m_vWindowFocusHistory[i].lock() == wnd)
                 return i;
         }
         return -1;
@@ -202,24 +202,24 @@ static std::string getWindowData(CWindow* w, eHyprCtlOutputFormat format) {
     "swallowing": "0x{:x}",
     "focusHistoryID": {}
 }},)#",
-            (uintptr_t)w, (w->m_bIsMapped ? "true" : "false"), (w->isHidden() ? "true" : "false"), (int)w->m_vRealPosition.goal().x, (int)w->m_vRealPosition.goal().y,
+            (uintptr_t)w.get(), (w->m_bIsMapped ? "true" : "false"), (w->isHidden() ? "true" : "false"), (int)w->m_vRealPosition.goal().x, (int)w->m_vRealPosition.goal().y,
             (int)w->m_vRealSize.goal().x, (int)w->m_vRealSize.goal().y, w->m_pWorkspace ? w->workspaceID() : WORKSPACE_INVALID,
             escapeJSONStrings(!w->m_pWorkspace ? "" : w->m_pWorkspace->m_szName), ((int)w->m_bIsFloating == 1 ? "true" : "false"), (int64_t)w->m_iMonitorID,
             escapeJSONStrings(g_pXWaylandManager->getAppIDClass(w)), escapeJSONStrings(g_pXWaylandManager->getTitle(w)), escapeJSONStrings(w->m_szInitialClass),
             escapeJSONStrings(w->m_szInitialTitle), w->getPID(), ((int)w->m_bIsX11 == 1 ? "true" : "false"), (w->m_bPinned ? "true" : "false"),
             (w->m_bIsFullscreen ? "true" : "false"), (w->m_bIsFullscreen ? (w->m_pWorkspace ? (int)w->m_pWorkspace->m_efFullscreenMode : 0) : 0),
-            w->m_bFakeFullscreenState ? "true" : "false", getGroupedData(w, format), (uintptr_t)w->m_pSwallowed, getFocusHistoryID(w));
+            w->m_bFakeFullscreenState ? "true" : "false", getGroupedData(w, format), (uintptr_t)w->m_pSwallowed.lock().get(), getFocusHistoryID(w));
     } else {
         return std::format("Window {:x} -> {}:\n\tmapped: {}\n\thidden: {}\n\tat: {},{}\n\tsize: {},{}\n\tworkspace: {} ({})\n\tfloating: {}\n\tmonitor: {}\n\tclass: {}\n\ttitle: "
                            "{}\n\tinitialClass: {}\n\tinitialTitle: {}\n\tpid: "
                            "{}\n\txwayland: {}\n\tpinned: "
                            "{}\n\tfullscreen: {}\n\tfullscreenmode: {}\n\tfakefullscreen: {}\n\tgrouped: {}\n\tswallowing: {:x}\n\tfocusHistoryID: {}\n\n",
-                           (uintptr_t)w, w->m_szTitle, (int)w->m_bIsMapped, (int)w->isHidden(), (int)w->m_vRealPosition.goal().x, (int)w->m_vRealPosition.goal().y,
+                           (uintptr_t)w.get(), w->m_szTitle, (int)w->m_bIsMapped, (int)w->isHidden(), (int)w->m_vRealPosition.goal().x, (int)w->m_vRealPosition.goal().y,
                            (int)w->m_vRealSize.goal().x, (int)w->m_vRealSize.goal().y, w->m_pWorkspace ? w->workspaceID() : WORKSPACE_INVALID,
                            (!w->m_pWorkspace ? "" : w->m_pWorkspace->m_szName), (int)w->m_bIsFloating, (int64_t)w->m_iMonitorID, g_pXWaylandManager->getAppIDClass(w),
                            g_pXWaylandManager->getTitle(w), w->m_szInitialClass, w->m_szInitialTitle, w->getPID(), (int)w->m_bIsX11, (int)w->m_bPinned, (int)w->m_bIsFullscreen,
                            (w->m_bIsFullscreen ? (w->m_pWorkspace ? w->m_pWorkspace->m_efFullscreenMode : 0) : 0), (int)w->m_bFakeFullscreenState, getGroupedData(w, format),
-                           (uintptr_t)w->m_pSwallowed, getFocusHistoryID(w));
+                           (uintptr_t)w->m_pSwallowed.lock().get(), getFocusHistoryID(w));
     }
 }
 
@@ -232,7 +232,7 @@ std::string clientsRequest(eHyprCtlOutputFormat format, std::string request) {
             if (!w->m_bIsMapped && !g_pHyprCtl->m_sCurrentRequestParams.all)
                 continue;
 
-            result += getWindowData(w.get(), format);
+            result += getWindowData(w, format);
         }
 
         trimTrailingComma(result);
@@ -243,7 +243,7 @@ std::string clientsRequest(eHyprCtlOutputFormat format, std::string request) {
             if (!w->m_bIsMapped && !g_pHyprCtl->m_sCurrentRequestParams.all)
                 continue;
 
-            result += getWindowData(w.get(), format);
+            result += getWindowData(w, format);
         }
     }
     return result;
@@ -265,11 +265,11 @@ static std::string getWorkspaceData(PHLWORKSPACE w, eHyprCtlOutputFormat format)
 }})#",
                            w->m_iID, escapeJSONStrings(w->m_szName), escapeJSONStrings(PMONITOR ? PMONITOR->szName : "?"),
                            escapeJSONStrings(PMONITOR ? std::to_string(PMONITOR->ID) : "null"), g_pCompositor->getWindowsOnWorkspace(w->m_iID),
-                           ((int)w->m_bHasFullscreenWindow == 1 ? "true" : "false"), (uintptr_t)PLASTW, PLASTW ? escapeJSONStrings(PLASTW->m_szTitle) : "");
+                           ((int)w->m_bHasFullscreenWindow == 1 ? "true" : "false"), (uintptr_t)PLASTW.get(), PLASTW ? escapeJSONStrings(PLASTW->m_szTitle) : "");
     } else {
         return std::format("workspace ID {} ({}) on monitor {}:\n\tmonitorID: {}\n\twindows: {}\n\thasfullscreen: {}\n\tlastwindow: 0x{:x}\n\tlastwindowtitle: {}\n\n", w->m_iID,
                            w->m_szName, PMONITOR ? PMONITOR->szName : "?", PMONITOR ? std::to_string(PMONITOR->ID) : "null", g_pCompositor->getWindowsOnWorkspace(w->m_iID),
-                           (int)w->m_bHasFullscreenWindow, (uintptr_t)PLASTW, PLASTW ? PLASTW->m_szTitle : "");
+                           (int)w->m_bHasFullscreenWindow, (uintptr_t)PLASTW.get(), PLASTW ? PLASTW->m_szTitle : "");
     }
 }
 
@@ -374,9 +374,9 @@ std::string workspaceRulesRequest(eHyprCtlOutputFormat format, std::string reque
 }
 
 std::string activeWindowRequest(eHyprCtlOutputFormat format, std::string request) {
-    const auto PWINDOW = g_pCompositor->m_pLastWindow;
+    const auto PWINDOW = g_pCompositor->m_pLastWindow.lock();
 
-    if (!g_pCompositor->windowValidMapped(PWINDOW))
+    if (!validMapped(PWINDOW))
         return format == eHyprCtlOutputFormat::FORMAT_JSON ? "{}" : "Invalid";
 
     auto result = getWindowData(PWINDOW, format);
@@ -1142,7 +1142,7 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
     if (vars.size() < 4)
         return "not enough args";
 
-    const auto PLASTWINDOW = g_pCompositor->m_pLastWindow;
+    const auto PLASTWINDOW = g_pCompositor->m_pLastWindow.lock();
     const auto PWINDOW     = g_pCompositor->getWindowByRegex(vars[1]);
 
     if (!PWINDOW)

--- a/src/defines.hpp
+++ b/src/defines.hpp
@@ -4,8 +4,6 @@
 #include "helpers/Color.hpp"
 #include "macros.hpp"
 
-#include <type_traits>
-
 class CWindow;
 
 /* Shared pointer to a window */

--- a/src/defines.hpp
+++ b/src/defines.hpp
@@ -3,3 +3,12 @@
 #include "helpers/WLListener.hpp"
 #include "helpers/Color.hpp"
 #include "macros.hpp"
+
+#include <type_traits>
+
+class CWindow;
+
+/* Shared pointer to a window */
+typedef SP<CWindow> PHLWINDOW;
+/* Weak pointer to a window */
+typedef WP<CWindow> PHLWINDOWREF;

--- a/src/desktop/Popup.cpp
+++ b/src/desktop/Popup.cpp
@@ -69,7 +69,7 @@ static void onRepositionPopup(void* owner, void* data) {
 void CPopup::initAllSignals() {
 
     if (!m_pWLR) {
-        if (m_pWindowOwner.lock())
+        if (!m_pWindowOwner.expired())
             hyprListener_newPopup.initCallback(&m_pWindowOwner.lock()->m_uSurface.xdg->events.new_popup, ::onNewPopup, this, "CPopup Head");
         else if (m_pLayerOwner)
             hyprListener_newPopup.initCallback(&m_pLayerOwner->layerSurface->events.new_popup, ::onNewPopup, this, "CPopup Head");
@@ -146,7 +146,7 @@ void CPopup::onCommit(bool ignoreSiblings) {
         return;
     }
 
-    if (m_pWindowOwner.lock() && (!m_pWindowOwner.lock()->m_bIsMapped || !m_pWindowOwner.lock()->m_pWorkspace->m_bVisible)) {
+    if (!m_pWindowOwner.expired() && (!m_pWindowOwner.lock()->m_bIsMapped || !m_pWindowOwner.lock()->m_pWorkspace->m_bVisible)) {
         m_vLastSize = {m_pWLR->base->current.geometry.width, m_pWLR->base->current.geometry.height};
 
         static auto PLOGDAMAGE = CConfigValue<Hyprlang::INT>("debug:log_damage");
@@ -230,7 +230,7 @@ Vector2D CPopup::localToGlobal(const Vector2D& rel) {
 }
 
 Vector2D CPopup::t1ParentCoords() {
-    if (m_pWindowOwner.lock())
+    if (!m_pWindowOwner.expired())
         return m_pWindowOwner.lock()->m_vRealPosition.value();
     if (m_pLayerOwner)
         return m_pLayerOwner->realPosition.value();
@@ -260,7 +260,7 @@ Vector2D CPopup::size() {
 }
 
 void CPopup::sendScale() {
-    if (m_pWindowOwner.lock())
+    if (!m_pWindowOwner.expired())
         g_pCompositor->setPreferredScaleForSurface(m_sWLSurface.wlr(), m_pWindowOwner.lock()->m_pWLSurface.m_fLastScale);
     else if (m_pLayerOwner)
         g_pCompositor->setPreferredScaleForSurface(m_sWLSurface.wlr(), m_pLayerOwner->surface.m_fLastScale);

--- a/src/desktop/Popup.cpp
+++ b/src/desktop/Popup.cpp
@@ -2,7 +2,7 @@
 #include "../config/ConfigValue.hpp"
 #include "../Compositor.hpp"
 
-CPopup::CPopup(CWindow* pOwner) : m_pWindowOwner(pOwner) {
+CPopup::CPopup(PHLWINDOW pOwner) : m_pWindowOwner(pOwner) {
     initAllSignals();
 }
 
@@ -69,8 +69,8 @@ static void onRepositionPopup(void* owner, void* data) {
 void CPopup::initAllSignals() {
 
     if (!m_pWLR) {
-        if (m_pWindowOwner)
-            hyprListener_newPopup.initCallback(&m_pWindowOwner->m_uSurface.xdg->events.new_popup, ::onNewPopup, this, "CPopup Head");
+        if (m_pWindowOwner.lock())
+            hyprListener_newPopup.initCallback(&m_pWindowOwner.lock()->m_uSurface.xdg->events.new_popup, ::onNewPopup, this, "CPopup Head");
         else if (m_pLayerOwner)
             hyprListener_newPopup.initCallback(&m_pLayerOwner->layerSurface->events.new_popup, ::onNewPopup, this, "CPopup Head");
         else
@@ -146,12 +146,12 @@ void CPopup::onCommit(bool ignoreSiblings) {
         return;
     }
 
-    if (m_pWindowOwner && (!m_pWindowOwner->m_bIsMapped || !m_pWindowOwner->m_pWorkspace->m_bVisible)) {
+    if (m_pWindowOwner.lock() && (!m_pWindowOwner.lock()->m_bIsMapped || !m_pWindowOwner.lock()->m_pWorkspace->m_bVisible)) {
         m_vLastSize = {m_pWLR->base->current.geometry.width, m_pWLR->base->current.geometry.height};
 
         static auto PLOGDAMAGE = CConfigValue<Hyprlang::INT>("debug:log_damage");
         if (*PLOGDAMAGE)
-            Debug::log(LOG, "Refusing to commit damage from a subsurface of {} because it's invisible.", m_pWindowOwner);
+            Debug::log(LOG, "Refusing to commit damage from a subsurface of {} because it's invisible.", m_pWindowOwner.lock());
         return;
     }
 
@@ -230,8 +230,8 @@ Vector2D CPopup::localToGlobal(const Vector2D& rel) {
 }
 
 Vector2D CPopup::t1ParentCoords() {
-    if (m_pWindowOwner)
-        return m_pWindowOwner->m_vRealPosition.value();
+    if (m_pWindowOwner.lock())
+        return m_pWindowOwner.lock()->m_vRealPosition.value();
     if (m_pLayerOwner)
         return m_pLayerOwner->realPosition.value();
 
@@ -260,8 +260,8 @@ Vector2D CPopup::size() {
 }
 
 void CPopup::sendScale() {
-    if (m_pWindowOwner)
-        g_pCompositor->setPreferredScaleForSurface(m_sWLSurface.wlr(), m_pWindowOwner->m_pWLSurface.m_fLastScale);
+    if (m_pWindowOwner.lock())
+        g_pCompositor->setPreferredScaleForSurface(m_sWLSurface.wlr(), m_pWindowOwner.lock()->m_pWLSurface.m_fLastScale);
     else if (m_pLayerOwner)
         g_pCompositor->setPreferredScaleForSurface(m_sWLSurface.wlr(), m_pLayerOwner->surface.m_fLastScale);
     else

--- a/src/desktop/Popup.hpp
+++ b/src/desktop/Popup.hpp
@@ -9,7 +9,7 @@ struct SLayerSurface;
 class CPopup {
   public:
     // dummy head nodes
-    CPopup(CWindow* pOwner);
+    CPopup(PHLWINDOW pOwner);
     CPopup(SLayerSurface* pOwner);
 
     // real nodes
@@ -35,8 +35,8 @@ class CPopup {
 
   private:
     // T1 owners, each popup has to have one of these
-    CWindow*       m_pWindowOwner = nullptr;
-    SLayerSurface* m_pLayerOwner  = nullptr;
+    PHLWINDOWREF   m_pWindowOwner;
+    SLayerSurface* m_pLayerOwner = nullptr;
 
     // T2 owners
     CPopup*        m_pParent = nullptr;

--- a/src/desktop/Subsurface.cpp
+++ b/src/desktop/Subsurface.cpp
@@ -73,7 +73,7 @@ void CSubsurface::initSignals() {
         hyprListener_mapSubsurface.initCallback(&m_pSubsurface->surface->events.map, &onMapSubsurface, this, "CSubsurface");
         hyprListener_unmapSubsurface.initCallback(&m_pSubsurface->surface->events.unmap, &onUnmapSubsurface, this, "CSubsurface");
     } else {
-        if (m_pWindowParent.lock())
+        if (!m_pWindowParent.expired())
             hyprListener_newSubsurface.initCallback(&m_pWindowParent.lock()->m_pWLSurface.wlr()->events.new_subsurface, &::onNewSubsurface, this, "CSubsurface Head");
         else if (m_pPopupParent)
             hyprListener_newSubsurface.initCallback(&m_pPopupParent->m_sWLSurface.wlr()->events.new_subsurface, &::onNewSubsurface, this, "CSubsurface Head");
@@ -106,7 +106,7 @@ void CSubsurface::recheckDamageForSubsurfaces() {
 
 void CSubsurface::onCommit() {
     // no damaging if it's not visible
-    if (m_pWindowParent.lock() && (!m_pWindowParent.lock()->m_bIsMapped || !m_pWindowParent.lock()->m_pWorkspace->m_bVisible)) {
+    if (!m_pWindowParent.expired() && (!m_pWindowParent.lock()->m_bIsMapped || !m_pWindowParent.lock()->m_pWorkspace->m_bVisible)) {
         m_vLastSize = Vector2D{m_sWLSurface.wlr()->current.width, m_sWLSurface.wlr()->current.height};
 
         static auto PLOGDAMAGE = CConfigValue<Hyprlang::INT>("debug:log_damage");
@@ -121,7 +121,7 @@ void CSubsurface::onCommit() {
 
     if (m_pPopupParent)
         m_pPopupParent->recheckTree();
-    if (m_pWindowParent.lock()) // I hate you firefox why are you doing this
+    if (!m_pWindowParent.expired()) // I hate you firefox why are you doing this
         m_pWindowParent.lock()->m_pPopupHead->recheckTree();
 
     // I do not think this is correct, but it solves a lot of issues with some apps (e.g. firefox)
@@ -152,7 +152,7 @@ void CSubsurface::onDestroy() {
 void CSubsurface::onNewSubsurface(wlr_subsurface* pSubsurface) {
     CSubsurface* PSUBSURFACE = nullptr;
 
-    if (m_pWindowParent.lock())
+    if (!m_pWindowParent.expired())
         PSUBSURFACE = m_vChildren.emplace_back(std::make_unique<CSubsurface>(pSubsurface, m_pWindowParent.lock())).get();
     else if (m_pPopupParent)
         PSUBSURFACE = m_vChildren.emplace_back(std::make_unique<CSubsurface>(pSubsurface, m_pPopupParent)).get();
@@ -169,7 +169,7 @@ void CSubsurface::onMap() {
     box.expand(4);
     g_pHyprRenderer->damageBox(&box);
 
-    if (m_pWindowParent.lock())
+    if (!m_pWindowParent.expired())
         m_pWindowParent.lock()->updateSurfaceScaleTransformDetails();
 }
 
@@ -206,7 +206,7 @@ Vector2D CSubsurface::coordsRelativeToParent() {
 Vector2D CSubsurface::coordsGlobal() {
     Vector2D coords = coordsRelativeToParent();
 
-    if (m_pWindowParent.lock())
+    if (!m_pWindowParent.expired())
         coords += m_pWindowParent.lock()->m_vRealPosition.value();
     else if (m_pPopupParent)
         coords += m_pPopupParent->coordsGlobal();

--- a/src/desktop/Subsurface.hpp
+++ b/src/desktop/Subsurface.hpp
@@ -4,17 +4,16 @@
 #include <vector>
 #include "WLSurface.hpp"
 
-class CWindow;
 class CPopup;
 
 class CSubsurface {
   public:
     // root dummy nodes
-    CSubsurface(CWindow* pOwner);
+    CSubsurface(PHLWINDOW pOwner);
     CSubsurface(CPopup* pOwner);
 
     // real nodes
-    CSubsurface(wlr_subsurface* pSubsurface, CWindow* pOwner);
+    CSubsurface(wlr_subsurface* pSubsurface, PHLWINDOW pOwner);
     CSubsurface(wlr_subsurface* pSubsurface, CPopup* pOwner);
 
     ~CSubsurface();
@@ -46,7 +45,7 @@ class CSubsurface {
     // if nullptr, means it's a dummy node
     CSubsurface*                              m_pParent = nullptr;
 
-    CWindow*                                  m_pWindowParent = nullptr;
+    PHLWINDOWREF                                  m_pWindowParent;
     CPopup*                                   m_pPopupParent  = nullptr;
 
     std::vector<std::unique_ptr<CSubsurface>> m_vChildren;

--- a/src/desktop/Subsurface.hpp
+++ b/src/desktop/Subsurface.hpp
@@ -45,8 +45,8 @@ class CSubsurface {
     // if nullptr, means it's a dummy node
     CSubsurface*                              m_pParent = nullptr;
 
-    PHLWINDOWREF                                  m_pWindowParent;
-    CPopup*                                   m_pPopupParent  = nullptr;
+    PHLWINDOWREF                              m_pWindowParent;
+    CPopup*                                   m_pPopupParent = nullptr;
 
     std::vector<std::unique_ptr<CSubsurface>> m_vChildren;
 

--- a/src/desktop/WLSurface.cpp
+++ b/src/desktop/WLSurface.cpp
@@ -113,10 +113,10 @@ void CWLSurface::destroy() {
     hyprListener_commit.removeCallback();
     m_pWLRSurface->data = nullptr;
     m_pWindowOwner.reset();
-    m_pLayerOwner       = nullptr;
-    m_pPopupOwner       = nullptr;
-    m_pSubsurfaceOwner  = nullptr;
-    m_bInert            = true;
+    m_pLayerOwner      = nullptr;
+    m_pPopupOwner      = nullptr;
+    m_pSubsurfaceOwner = nullptr;
+    m_bInert           = true;
 
     if (g_pCompositor && g_pCompositor->m_pLastFocus == m_pWLRSurface)
         g_pCompositor->m_pLastFocus = nullptr;

--- a/src/desktop/WLSurface.cpp
+++ b/src/desktop/WLSurface.cpp
@@ -167,14 +167,14 @@ CSubsurface* CWLSurface::getSubsurface() {
 }
 
 bool CWLSurface::desktopComponent() {
-    return m_pLayerOwner || m_pWindowOwner.lock() || m_pSubsurfaceOwner || m_pPopupOwner;
+    return m_pLayerOwner || !m_pWindowOwner.expired() || m_pSubsurfaceOwner || m_pPopupOwner;
 }
 
 std::optional<CBox> CWLSurface::getSurfaceBoxGlobal() {
     if (!desktopComponent())
         return {};
 
-    if (m_pWindowOwner.lock())
+    if (!m_pWindowOwner.expired())
         return m_pWindowOwner.lock()->getWindowMainSurfaceBox();
     if (m_pLayerOwner)
         return m_pLayerOwner->geometry;

--- a/src/desktop/WLSurface.hpp
+++ b/src/desktop/WLSurface.hpp
@@ -17,7 +17,7 @@ class CWLSurface {
 
     // anonymous surfaces are non-desktop components, e.g. a cursor surface or a DnD
     void assign(wlr_surface* pSurface);
-    void assign(wlr_surface* pSurface, CWindow* pOwner);
+    void assign(wlr_surface* pSurface, PHLWINDOW pOwner);
     void assign(wlr_surface* pSurface, SLayerSurface* pOwner);
     void assign(wlr_surface* pSurface, CSubsurface* pOwner);
     void assign(wlr_surface* pSurface, CPopup* pOwner);
@@ -37,7 +37,7 @@ class CWLSurface {
     void         onCommit();
 
     // getters for owners.
-    CWindow*       getWindow();
+    PHLWINDOW      getWindow();
     SLayerSurface* getLayer();
     CPopup*        getPopup();
     CSubsurface*   getSubsurface();
@@ -94,7 +94,7 @@ class CWLSurface {
 
     wlr_surface*   m_pWLRSurface = nullptr;
 
-    CWindow*       m_pWindowOwner     = nullptr;
+    PHLWINDOWREF   m_pWindowOwner;
     SLayerSurface* m_pLayerOwner      = nullptr;
     CPopup*        m_pPopupOwner      = nullptr;
     CSubsurface*   m_pSubsurfaceOwner = nullptr;

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -458,7 +458,7 @@ void CWindow::onUnmap() {
 
     m_vRealSize.setCallbackOnBegin(nullptr);
 
-    std::erase_if(g_pCompositor->m_vWindowFocusHistory, [&](const auto& other) { return !other.lock() || other.lock().get() == this; });
+    std::erase_if(g_pCompositor->m_vWindowFocusHistory, [&](const auto& other) { return other.expired() || other.lock().get() == this; });
 
     hyprListener_unmapWindow.removeCallback();
 
@@ -827,7 +827,7 @@ void CWindow::createGroup() {
         return;
     }
 
-    if (!m_sGroupData.pNextWindow.lock()) {
+    if (m_sGroupData.pNextWindow.expired()) {
         m_sGroupData.pNextWindow = m_pSelf;
         m_sGroupData.head        = true;
         m_sGroupData.locked      = false;
@@ -1043,7 +1043,7 @@ void CWindow::switchWithWindowInGroup(PHLWINDOW pWindow) {
 }
 
 void CWindow::updateGroupOutputs() {
-    if (!m_sGroupData.pNextWindow.lock())
+    if (m_sGroupData.pNextWindow.expired())
         return;
 
     PHLWINDOW  curr = m_sGroupData.pNextWindow.lock();

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -849,7 +849,7 @@ void CWindow::destroyGroup() {
             return;
         }
         m_sGroupData.pNextWindow.reset();
-        m_sGroupData.head        = false;
+        m_sGroupData.head = false;
         updateWindowDecos();
         g_pCompositor->updateWorkspaceWindows(workspaceID());
         g_pCompositor->updateWorkspaceSpecialRenderData(workspaceID());
@@ -861,8 +861,8 @@ void CWindow::destroyGroup() {
     PHLWINDOW              curr = m_pSelf.lock();
     std::vector<PHLWINDOW> members;
     do {
-        const auto PLASTWIN                = curr;
-        curr                               = curr->m_sGroupData.pNextWindow.lock();
+        const auto PLASTWIN = curr;
+        curr                = curr->m_sGroupData.pNextWindow.lock();
         PLASTWIN->m_sGroupData.pNextWindow.reset();
         curr->setHidden(false);
         members.push_back(curr);
@@ -920,12 +920,12 @@ int CWindow::getGroupSize() {
 }
 
 bool CWindow::canBeGroupedInto(PHLWINDOW pWindow) {
-    return !g_pKeybindManager->m_bGroupsLocked                                          // global group lock disengaged
-        && ((m_eGroupRules & GROUP_INVADE && m_bFirstMap)                               // window ignore local group locks, or
-            || (!pWindow->getGroupHead()->m_sGroupData.locked                           //      target unlocked
+    return !g_pKeybindManager->m_bGroupsLocked                                                 // global group lock disengaged
+        && ((m_eGroupRules & GROUP_INVADE && m_bFirstMap)                                      // window ignore local group locks, or
+            || (!pWindow->getGroupHead()->m_sGroupData.locked                                  //      target unlocked
                 && !(m_sGroupData.pNextWindow.lock() && getGroupHead()->m_sGroupData.locked))) //      source unlocked or isn't group
-        && !m_sGroupData.deny                                                           // source is not denied entry
-        && !(m_eGroupRules & GROUP_BARRED && m_bFirstMap);                              // group rule doesn't prevent adding window
+        && !m_sGroupData.deny                                                                  // source is not denied entry
+        && !(m_eGroupRules & GROUP_BARRED && m_bFirstMap);                                     // group rule doesn't prevent adding window
 }
 
 PHLWINDOW CWindow::getGroupWindowByIndex(int index) {

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -43,7 +43,7 @@ CWindow::~CWindow() {
         return;
 
     g_pHyprRenderer->makeEGLCurrent();
-    std::erase_if(g_pHyprOpenGL->m_mWindowFramebuffers, [&](const auto& other) { return other.first.lock().get() == this; });
+    std::erase_if(g_pHyprOpenGL->m_mWindowFramebuffers, [&](const auto& other) { return !other.first.lock() || other.first.lock().get() == this; });
 }
 
 SWindowDecorationExtents CWindow::getFullWindowExtents() {

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -370,9 +370,9 @@ class CWindow {
     // for groups
     struct SGroupData {
         PHLWINDOWREF pNextWindow; // nullptr means no grouping. Self means single group.
-        bool         head        = false;
-        bool         locked      = false; // per group lock
-        bool         deny        = false; // deny window from enter a group or made a group
+        bool         head   = false;
+        bool         locked = false; // per group lock
+        bool         deny   = false; // deny window from enter a group or made a group
     } m_sGroupData;
     uint16_t m_eGroupRules = GROUP_NONE;
 

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -49,7 +49,7 @@ class CWorkspace {
     bool m_bIsSpecialWorkspace = false;
 
     // last window
-    CWindow* m_pLastFocusedWindow = nullptr;
+    PHLWINDOWREF m_pLastFocusedWindow;
 
     // user-set
     bool m_bDefaultFloating = false;
@@ -68,7 +68,7 @@ class CWorkspace {
 
     void        moveToMonitor(const int&);
 
-    CWindow*    getLastFocusedWindow();
+    PHLWINDOW   getLastFocusedWindow();
     void        rememberPrevWorkspace(const PHLWORKSPACE& prevWorkspace);
 
     std::string getConfigName();

--- a/src/events/Layers.cpp
+++ b/src/events/Layers.cpp
@@ -237,9 +237,9 @@ void Events::listener_unmapLayerSurface(void* owner, void* data) {
             foundSurface = g_pCompositor->vectorToLayerSurface(g_pInputManager->getMouseCoordsInternal(), &PMONITOR->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP],
                                                                &surfaceCoords, &pFoundLayerSurface);
 
-        if (!foundSurface && g_pCompositor->m_pLastWindow && g_pCompositor->isWorkspaceVisible(g_pCompositor->m_pLastWindow->m_pWorkspace)) {
+        if (!foundSurface && g_pCompositor->m_pLastWindow.lock() && g_pCompositor->isWorkspaceVisible(g_pCompositor->m_pLastWindow.lock()->m_pWorkspace)) {
             // if there isn't any, focus the last window
-            const auto PLASTWINDOW = g_pCompositor->m_pLastWindow;
+            const auto PLASTWINDOW = g_pCompositor->m_pLastWindow.lock();
             g_pCompositor->focusWindow(nullptr);
             g_pCompositor->focusWindow(PLASTWINDOW);
         } else {

--- a/src/events/Misc.cpp
+++ b/src/events/Misc.cpp
@@ -141,7 +141,7 @@ void Events::listener_destroyDrag(void* owner, void* data) {
     g_pInputManager->m_sDrag.dragIcon = nullptr;
     g_pInputManager->m_sDrag.hyprListener_destroy.removeCallback();
 
-    g_pCompositor->focusWindow(g_pCompositor->m_pLastWindow, g_pCompositor->m_pLastWindow ? g_pXWaylandManager->getWindowSurface(g_pCompositor->m_pLastWindow) : nullptr);
+    g_pCompositor->focusWindow(g_pCompositor->m_pLastWindow.lock(), g_pCompositor->m_pLastWindow.lock() ? g_pXWaylandManager->getWindowSurface(g_pCompositor->m_pLastWindow.lock()) : nullptr);
 }
 
 void Events::listener_mapDragIcon(void* owner, void* data) {

--- a/src/events/Misc.cpp
+++ b/src/events/Misc.cpp
@@ -141,7 +141,8 @@ void Events::listener_destroyDrag(void* owner, void* data) {
     g_pInputManager->m_sDrag.dragIcon = nullptr;
     g_pInputManager->m_sDrag.hyprListener_destroy.removeCallback();
 
-    g_pCompositor->focusWindow(g_pCompositor->m_pLastWindow.lock(), g_pCompositor->m_pLastWindow.lock() ? g_pXWaylandManager->getWindowSurface(g_pCompositor->m_pLastWindow.lock()) : nullptr);
+    g_pCompositor->focusWindow(g_pCompositor->m_pLastWindow.lock(),
+                               g_pCompositor->m_pLastWindow.lock() ? g_pXWaylandManager->getWindowSurface(g_pCompositor->m_pLastWindow.lock()) : nullptr);
 }
 
 void Events::listener_mapDragIcon(void* owner, void* data) {

--- a/src/events/Monitors.cpp
+++ b/src/events/Monitors.cpp
@@ -146,7 +146,7 @@ void Events::listener_monitorFrame(void* owner, void* data) {
 
     PMONITOR->tearingState.busy = false;
 
-    if (PMONITOR->tearingState.activelyTearing && PMONITOR->solitaryClient /* can be invalidated by a recheck */) {
+    if (PMONITOR->tearingState.activelyTearing && PMONITOR->solitaryClient.lock() /* can be invalidated by a recheck */) {
 
         if (!PMONITOR->tearingState.frameScheduledWhileBusy)
             return; // we did not schedule a frame yet to be displayed, but we are tearing. Why render?

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -505,14 +505,16 @@ void Events::listener_mapWindow(void* owner, void* data) {
         PWINDOW->hyprListener_requestMinimize.initCallback(&PWINDOW->m_uSurface.xdg->toplevel->events.request_minimize, &Events::listener_requestMinimize, PWINDOW.get(),
                                                            "XDG Window Late");
         PWINDOW->hyprListener_requestMove.initCallback(&PWINDOW->m_uSurface.xdg->toplevel->events.request_move, &Events::listener_requestMove, PWINDOW.get(), "XDG Window Late");
-        PWINDOW->hyprListener_requestResize.initCallback(&PWINDOW->m_uSurface.xdg->toplevel->events.request_resize, &Events::listener_requestResize, PWINDOW.get(), "XDG Window Late");
+        PWINDOW->hyprListener_requestResize.initCallback(&PWINDOW->m_uSurface.xdg->toplevel->events.request_resize, &Events::listener_requestResize, PWINDOW.get(),
+                                                         "XDG Window Late");
         PWINDOW->hyprListener_fullscreenWindow.initCallback(&PWINDOW->m_uSurface.xdg->toplevel->events.request_fullscreen, &Events::listener_fullscreenWindow, PWINDOW.get(),
                                                             "XDG Window Late");
         PWINDOW->hyprListener_ackConfigure.initCallback(&PWINDOW->m_uSurface.xdg->events.ack_configure, &Events::listener_ackConfigure, PWINDOW.get(), "XDG Window Late");
     } else {
         PWINDOW->hyprListener_fullscreenWindow.initCallback(&PWINDOW->m_uSurface.xwayland->events.request_fullscreen, &Events::listener_fullscreenWindow, PWINDOW.get(),
                                                             "XWayland Window Late");
-        PWINDOW->hyprListener_activateX11.initCallback(&PWINDOW->m_uSurface.xwayland->events.request_activate, &Events::listener_activateX11, PWINDOW.get(), "XWayland Window Late");
+        PWINDOW->hyprListener_activateX11.initCallback(&PWINDOW->m_uSurface.xwayland->events.request_activate, &Events::listener_activateX11, PWINDOW.get(),
+                                                       "XWayland Window Late");
         PWINDOW->hyprListener_setTitleWindow.initCallback(&PWINDOW->m_uSurface.xwayland->events.set_title, &Events::listener_setTitleWindow, PWINDOW.get(), "XWayland Window Late");
         PWINDOW->hyprListener_requestMinimize.initCallback(&PWINDOW->m_uSurface.xwayland->events.request_minimize, &Events::listener_requestMinimize, PWINDOW.get(),
                                                            "Xwayland Window Late");
@@ -670,7 +672,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
 }
 
 void Events::listener_unmapWindow(void* owner, void* data) {
-    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
+    PHLWINDOW PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     Debug::log(LOG, "{:c} unmapped", PWINDOW);
 
@@ -727,9 +729,9 @@ void Events::listener_unmapWindow(void* owner, void* data) {
     bool wasLastWindow = false;
 
     if (PWINDOW == g_pCompositor->m_pLastWindow.lock()) {
-        wasLastWindow                = true;
+        wasLastWindow = true;
         g_pCompositor->m_pLastWindow.reset();
-        g_pCompositor->m_pLastFocus  = nullptr;
+        g_pCompositor->m_pLastFocus = nullptr;
 
         g_pInputManager->releaseAllMouseButtons();
     }
@@ -763,7 +765,7 @@ void Events::listener_unmapWindow(void* owner, void* data) {
         if (PWINDOW == g_pCompositor->m_pLastWindow.lock() || !g_pCompositor->m_pLastWindow.lock()) {
             g_pEventManager->postEvent(SHyprIPCEvent{"activewindow", ","});
             g_pEventManager->postEvent(SHyprIPCEvent{"activewindowv2", ","});
-            EMIT_HOOK_EVENT("activeWindow", (PHLWINDOW)nullptr);
+            EMIT_HOOK_EVENT("activeWindow", (PHLWINDOW) nullptr);
         }
     } else {
         Debug::log(LOG, "Unmapped was not focused, ignoring a refocus.");
@@ -793,7 +795,7 @@ void Events::listener_unmapWindow(void* owner, void* data) {
 }
 
 void Events::listener_ackConfigure(void* owner, void* data) {
-    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
+    PHLWINDOW  PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
     const auto E       = (wlr_xdg_surface_configure*)data;
 
     // find last matching serial
@@ -807,7 +809,7 @@ void Events::listener_ackConfigure(void* owner, void* data) {
 }
 
 void Events::listener_commitWindow(void* owner, void* data) {
-    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
+    PHLWINDOW PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     if (!PWINDOW->m_bIsX11 && PWINDOW->m_uSurface.xdg->initial_commit) {
         Vector2D predSize = g_pLayoutManager->getCurrentLayout()->predictSizeForNewWindow(PWINDOW);
@@ -883,7 +885,7 @@ void Events::listener_commitWindow(void* owner, void* data) {
 }
 
 void Events::listener_destroyWindow(void* owner, void* data) {
-    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
+    PHLWINDOW PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     Debug::log(LOG, "{:c} destroyed, queueing.", PWINDOW);
 
@@ -892,7 +894,7 @@ void Events::listener_destroyWindow(void* owner, void* data) {
 
     if (PWINDOW == g_pCompositor->m_pLastWindow.lock()) {
         g_pCompositor->m_pLastWindow.reset();
-        g_pCompositor->m_pLastFocus  = nullptr;
+        g_pCompositor->m_pLastFocus = nullptr;
     }
 
     PWINDOW->m_pWLSurface.unassign();
@@ -919,7 +921,7 @@ void Events::listener_destroyWindow(void* owner, void* data) {
 }
 
 void Events::listener_setTitleWindow(void* owner, void* data) {
-    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
+    PHLWINDOW PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     if (!validMapped(PWINDOW))
         return;
@@ -947,7 +949,7 @@ void Events::listener_setTitleWindow(void* owner, void* data) {
 }
 
 void Events::listener_fullscreenWindow(void* owner, void* data) {
-    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
+    PHLWINDOW PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     if (!PWINDOW->m_bIsMapped) {
         PWINDOW->m_bWantsInitialFullscreen = true;
@@ -1022,7 +1024,7 @@ void Events::listener_activateXDG(wl_listener* listener, void* data) {
 }
 
 void Events::listener_activateX11(void* owner, void* data) {
-    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
+    PHLWINDOW PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     Debug::log(LOG, "X11 Activate request for window {}", PWINDOW);
 
@@ -1047,7 +1049,7 @@ void Events::listener_activateX11(void* owner, void* data) {
 }
 
 void Events::listener_configureX11(void* owner, void* data) {
-    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
+    PHLWINDOW  PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     const auto E = (wlr_xwayland_surface_configure_event*)data;
 
@@ -1113,7 +1115,7 @@ void Events::listener_configureX11(void* owner, void* data) {
 }
 
 void Events::listener_unmanagedSetGeometry(void* owner, void* data) {
-    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
+    PHLWINDOW PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     if (!PWINDOW->m_bIsMapped)
         return;
@@ -1178,7 +1180,7 @@ void Events::listener_setOverrideRedirect(void* owner, void* data) {
 }
 
 void Events::listener_associateX11(void* owner, void* data) {
-    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
+    PHLWINDOW PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     PWINDOW->hyprListener_mapWindow.initCallback(&PWINDOW->m_uSurface.xwayland->surface->events.map, &Events::listener_mapWindow, PWINDOW.get(), "XWayland Window");
     PWINDOW->hyprListener_commitWindow.initCallback(&PWINDOW->m_uSurface.xwayland->surface->events.commit, &Events::listener_commitWindow, PWINDOW.get(), "XWayland Window");
@@ -1187,7 +1189,7 @@ void Events::listener_associateX11(void* owner, void* data) {
 }
 
 void Events::listener_dissociateX11(void* owner, void* data) {
-    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
+    PHLWINDOW PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     PWINDOW->m_pWLSurface.unassign();
 
@@ -1235,7 +1237,7 @@ void Events::listener_newXDGToplevel(wl_listener* listener, void* data) {
 }
 
 void Events::listener_requestMaximize(void* owner, void* data) {
-    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
+    PHLWINDOW PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     if (PWINDOW->m_eSuppressedEvents & SUPPRESS_MAXIMIZE)
         return;
@@ -1256,7 +1258,7 @@ void Events::listener_requestMaximize(void* owner, void* data) {
 }
 
 void Events::listener_requestMinimize(void* owner, void* data) {
-   PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
+    PHLWINDOW PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     Debug::log(LOG, "Minimize request for {}", PWINDOW);
 
@@ -1277,14 +1279,14 @@ void Events::listener_requestMinimize(void* owner, void* data) {
 }
 
 void Events::listener_requestMove(void* owner, void* data) {
-    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
+    PHLWINDOW PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     // ignore
     wlr_xdg_surface_schedule_configure(PWINDOW->m_uSurface.xdg);
 }
 
 void Events::listener_requestResize(void* owner, void* data) {
-    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
+    PHLWINDOW PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     // ignore
     wlr_xdg_surface_schedule_configure(PWINDOW->m_uSurface.xdg);

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -95,7 +95,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                 if (*PINITIALWSTRACKING == 1) // one-shot token
                     g_pTokenManager->removeToken(TOKEN);
                 else if (*PINITIALWSTRACKING == 2) { // persistent
-                    if (!WS.primaryOwner.lock()) {
+                    if (WS.primaryOwner.expired()) {
                         WS.primaryOwner = PWINDOW;
                         TOKEN->data     = WS;
                     }

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -43,7 +43,7 @@ void setAnimToMove(void* data) {
 }
 
 void Events::listener_mapWindow(void* owner, void* data) {
-    CWindow*    PWINDOW = (CWindow*)owner;
+    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     static auto PINACTIVEALPHA     = CConfigValue<Hyprlang::FLOAT>("decoration:inactive_opacity");
     static auto PACTIVEALPHA       = CConfigValue<Hyprlang::FLOAT>("decoration:active_opacity");
@@ -95,7 +95,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                 if (*PINITIALWSTRACKING == 1) // one-shot token
                     g_pTokenManager->removeToken(TOKEN);
                 else if (*PINITIALWSTRACKING == 2) { // persistent
-                    if (!WS.primaryOwner) {
+                    if (!WS.primaryOwner.lock()) {
                         WS.primaryOwner = PWINDOW;
                         TOKEN->data     = WS;
                     }
@@ -462,7 +462,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
         PWINDOW->m_vPseudoSize = PWINDOW->m_vRealSize.goal() - Vector2D(10, 10);
     }
 
-    const auto PFOCUSEDWINDOWPREV = g_pCompositor->m_pLastWindow;
+    const auto PFOCUSEDWINDOWPREV = g_pCompositor->m_pLastWindow.lock();
 
     if (PWINDOW->m_sAdditionalConfigData.forceAllowsInput) {
         PWINDOW->m_sAdditionalConfigData.noFocus = false;
@@ -499,28 +499,28 @@ void Events::listener_mapWindow(void* owner, void* data) {
     }
 
     if (!PWINDOW->m_bIsX11) {
-        PWINDOW->hyprListener_setTitleWindow.initCallback(&PWINDOW->m_uSurface.xdg->toplevel->events.set_title, &Events::listener_setTitleWindow, PWINDOW, "XDG Window Late");
-        PWINDOW->hyprListener_requestMaximize.initCallback(&PWINDOW->m_uSurface.xdg->toplevel->events.request_maximize, &Events::listener_requestMaximize, PWINDOW,
+        PWINDOW->hyprListener_setTitleWindow.initCallback(&PWINDOW->m_uSurface.xdg->toplevel->events.set_title, &Events::listener_setTitleWindow, PWINDOW.get(), "XDG Window Late");
+        PWINDOW->hyprListener_requestMaximize.initCallback(&PWINDOW->m_uSurface.xdg->toplevel->events.request_maximize, &Events::listener_requestMaximize, PWINDOW.get(),
                                                            "XDG Window Late");
-        PWINDOW->hyprListener_requestMinimize.initCallback(&PWINDOW->m_uSurface.xdg->toplevel->events.request_minimize, &Events::listener_requestMinimize, PWINDOW,
+        PWINDOW->hyprListener_requestMinimize.initCallback(&PWINDOW->m_uSurface.xdg->toplevel->events.request_minimize, &Events::listener_requestMinimize, PWINDOW.get(),
                                                            "XDG Window Late");
-        PWINDOW->hyprListener_requestMove.initCallback(&PWINDOW->m_uSurface.xdg->toplevel->events.request_move, &Events::listener_requestMove, PWINDOW, "XDG Window Late");
-        PWINDOW->hyprListener_requestResize.initCallback(&PWINDOW->m_uSurface.xdg->toplevel->events.request_resize, &Events::listener_requestResize, PWINDOW, "XDG Window Late");
-        PWINDOW->hyprListener_fullscreenWindow.initCallback(&PWINDOW->m_uSurface.xdg->toplevel->events.request_fullscreen, &Events::listener_fullscreenWindow, PWINDOW,
+        PWINDOW->hyprListener_requestMove.initCallback(&PWINDOW->m_uSurface.xdg->toplevel->events.request_move, &Events::listener_requestMove, PWINDOW.get(), "XDG Window Late");
+        PWINDOW->hyprListener_requestResize.initCallback(&PWINDOW->m_uSurface.xdg->toplevel->events.request_resize, &Events::listener_requestResize, PWINDOW.get(), "XDG Window Late");
+        PWINDOW->hyprListener_fullscreenWindow.initCallback(&PWINDOW->m_uSurface.xdg->toplevel->events.request_fullscreen, &Events::listener_fullscreenWindow, PWINDOW.get(),
                                                             "XDG Window Late");
-        PWINDOW->hyprListener_ackConfigure.initCallback(&PWINDOW->m_uSurface.xdg->events.ack_configure, &Events::listener_ackConfigure, PWINDOW, "XDG Window Late");
+        PWINDOW->hyprListener_ackConfigure.initCallback(&PWINDOW->m_uSurface.xdg->events.ack_configure, &Events::listener_ackConfigure, PWINDOW.get(), "XDG Window Late");
     } else {
-        PWINDOW->hyprListener_fullscreenWindow.initCallback(&PWINDOW->m_uSurface.xwayland->events.request_fullscreen, &Events::listener_fullscreenWindow, PWINDOW,
+        PWINDOW->hyprListener_fullscreenWindow.initCallback(&PWINDOW->m_uSurface.xwayland->events.request_fullscreen, &Events::listener_fullscreenWindow, PWINDOW.get(),
                                                             "XWayland Window Late");
-        PWINDOW->hyprListener_activateX11.initCallback(&PWINDOW->m_uSurface.xwayland->events.request_activate, &Events::listener_activateX11, PWINDOW, "XWayland Window Late");
-        PWINDOW->hyprListener_setTitleWindow.initCallback(&PWINDOW->m_uSurface.xwayland->events.set_title, &Events::listener_setTitleWindow, PWINDOW, "XWayland Window Late");
-        PWINDOW->hyprListener_requestMinimize.initCallback(&PWINDOW->m_uSurface.xwayland->events.request_minimize, &Events::listener_requestMinimize, PWINDOW,
+        PWINDOW->hyprListener_activateX11.initCallback(&PWINDOW->m_uSurface.xwayland->events.request_activate, &Events::listener_activateX11, PWINDOW.get(), "XWayland Window Late");
+        PWINDOW->hyprListener_setTitleWindow.initCallback(&PWINDOW->m_uSurface.xwayland->events.set_title, &Events::listener_setTitleWindow, PWINDOW.get(), "XWayland Window Late");
+        PWINDOW->hyprListener_requestMinimize.initCallback(&PWINDOW->m_uSurface.xwayland->events.request_minimize, &Events::listener_requestMinimize, PWINDOW.get(),
                                                            "Xwayland Window Late");
-        PWINDOW->hyprListener_requestMaximize.initCallback(&PWINDOW->m_uSurface.xwayland->events.request_maximize, &Events::listener_requestMaximize, PWINDOW,
+        PWINDOW->hyprListener_requestMaximize.initCallback(&PWINDOW->m_uSurface.xwayland->events.request_maximize, &Events::listener_requestMaximize, PWINDOW.get(),
                                                            "Xwayland Window Late");
 
         if (PWINDOW->m_iX11Type == 2)
-            PWINDOW->hyprListener_setGeometryX11U.initCallback(&PWINDOW->m_uSurface.xwayland->events.set_geometry, &Events::listener_unmanagedSetGeometry, PWINDOW,
+            PWINDOW->hyprListener_setGeometryX11U.initCallback(&PWINDOW->m_uSurface.xwayland->events.set_geometry, &Events::listener_unmanagedSetGeometry, PWINDOW.get(),
                                                                "XWayland Window Late");
     }
 
@@ -550,7 +550,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
     PWINDOW->updateToplevel();
 
     if (workspaceSilent) {
-        if (g_pCompositor->windowValidMapped(PFOCUSEDWINDOWPREV)) {
+        if (validMapped(PFOCUSEDWINDOWPREV)) {
             g_pCompositor->focusWindow(PFOCUSEDWINDOWPREV);
             PFOCUSEDWINDOWPREV->updateWindowDecos(); // need to for some reason i cba to find out why
         } else if (!PFOCUSEDWINDOWPREV)
@@ -579,14 +579,14 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
             if (ppid) {
                 // get window by pid
-                std::vector<CWindow*> found;
-                CWindow*              finalFound = nullptr;
+                std::vector<PHLWINDOW> found;
+                PHLWINDOW              finalFound;
                 for (auto& w : g_pCompositor->m_vWindows) {
                     if (!w->m_bIsMapped || w->isHidden())
                         continue;
 
                     if (w->getPID() == ppid) {
-                        found.push_back(w.get());
+                        found.push_back(w);
                     }
                 }
 
@@ -670,7 +670,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
 }
 
 void Events::listener_unmapWindow(void* owner, void* data) {
-    CWindow* PWINDOW = (CWindow*)owner;
+    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     Debug::log(LOG, "{:c} unmapped", PWINDOW);
 
@@ -718,17 +718,17 @@ void Events::listener_unmapWindow(void* owner, void* data) {
     g_pHyprOpenGL->makeWindowSnapshot(PWINDOW);
 
     // swallowing
-    if (PWINDOW->m_pSwallowed && g_pCompositor->windowExists(PWINDOW->m_pSwallowed)) {
-        PWINDOW->m_pSwallowed->setHidden(false);
-        g_pLayoutManager->getCurrentLayout()->onWindowCreated(PWINDOW->m_pSwallowed);
-        PWINDOW->m_pSwallowed = nullptr;
+    if (valid(PWINDOW->m_pSwallowed)) {
+        PWINDOW->m_pSwallowed.lock()->setHidden(false);
+        g_pLayoutManager->getCurrentLayout()->onWindowCreated(PWINDOW->m_pSwallowed.lock());
+        PWINDOW->m_pSwallowed.reset();
     }
 
     bool wasLastWindow = false;
 
-    if (PWINDOW == g_pCompositor->m_pLastWindow) {
+    if (PWINDOW == g_pCompositor->m_pLastWindow.lock()) {
         wasLastWindow                = true;
-        g_pCompositor->m_pLastWindow = nullptr;
+        g_pCompositor->m_pLastWindow.reset();
         g_pCompositor->m_pLastFocus  = nullptr;
 
         g_pInputManager->releaseAllMouseButtons();
@@ -751,7 +751,7 @@ void Events::listener_unmapWindow(void* owner, void* data) {
 
         Debug::log(LOG, "On closed window, new focused candidate is {}", PWINDOWCANDIDATE);
 
-        if (PWINDOWCANDIDATE != g_pCompositor->m_pLastWindow && PWINDOWCANDIDATE)
+        if (PWINDOWCANDIDATE != g_pCompositor->m_pLastWindow.lock() && PWINDOWCANDIDATE)
             g_pCompositor->focusWindow(PWINDOWCANDIDATE);
 
         if (!PWINDOWCANDIDATE && g_pCompositor->getWindowsOnWorkspace(PWINDOW->workspaceID()) == 0)
@@ -760,10 +760,10 @@ void Events::listener_unmapWindow(void* owner, void* data) {
         g_pInputManager->sendMotionEventsToFocused();
 
         // CWindow::onUnmap will remove this window's active status, but we can't really do it above.
-        if (PWINDOW == g_pCompositor->m_pLastWindow || !g_pCompositor->m_pLastWindow) {
+        if (PWINDOW == g_pCompositor->m_pLastWindow.lock() || !g_pCompositor->m_pLastWindow.lock()) {
             g_pEventManager->postEvent(SHyprIPCEvent{"activewindow", ","});
             g_pEventManager->postEvent(SHyprIPCEvent{"activewindowv2", ","});
-            EMIT_HOOK_EVENT("activeWindow", (CWindow*)nullptr);
+            EMIT_HOOK_EVENT("activeWindow", (PHLWINDOW)nullptr);
         }
     } else {
         Debug::log(LOG, "Unmapped was not focused, ignoring a refocus.");
@@ -793,7 +793,7 @@ void Events::listener_unmapWindow(void* owner, void* data) {
 }
 
 void Events::listener_ackConfigure(void* owner, void* data) {
-    CWindow*   PWINDOW = (CWindow*)owner;
+    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
     const auto E       = (wlr_xdg_surface_configure*)data;
 
     // find last matching serial
@@ -807,7 +807,7 @@ void Events::listener_ackConfigure(void* owner, void* data) {
 }
 
 void Events::listener_commitWindow(void* owner, void* data) {
-    CWindow* PWINDOW = (CWindow*)owner;
+    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     if (!PWINDOW->m_bIsX11 && PWINDOW->m_uSurface.xdg->initial_commit) {
         Vector2D predSize = g_pLayoutManager->getCurrentLayout()->predictSizeForNewWindow(PWINDOW);
@@ -867,7 +867,7 @@ void Events::listener_commitWindow(void* owner, void* data) {
 
     // tearing: if solitary, redraw it. This still might be a single surface window
     const auto PMONITOR = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID);
-    if (PMONITOR && PMONITOR->solitaryClient == PWINDOW && PWINDOW->canBeTorn() && PMONITOR->tearingState.canTear &&
+    if (PMONITOR && PMONITOR->solitaryClient.lock() == PWINDOW && PWINDOW->canBeTorn() && PMONITOR->tearingState.canTear &&
         PWINDOW->m_pWLSurface.wlr()->current.committed & WLR_SURFACE_STATE_BUFFER) {
         CRegion damageBox{&PWINDOW->m_pWLSurface.wlr()->buffer_damage};
 
@@ -883,15 +883,15 @@ void Events::listener_commitWindow(void* owner, void* data) {
 }
 
 void Events::listener_destroyWindow(void* owner, void* data) {
-    CWindow* PWINDOW = (CWindow*)owner;
+    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     Debug::log(LOG, "{:c} destroyed, queueing.", PWINDOW);
 
     if (PWINDOW->m_bIsX11)
         Debug::log(LOG, "XWayland class raw: {}", PWINDOW->m_uSurface.xwayland->_class ? PWINDOW->m_uSurface.xwayland->_class : "null");
 
-    if (PWINDOW == g_pCompositor->m_pLastWindow) {
-        g_pCompositor->m_pLastWindow = nullptr;
+    if (PWINDOW == g_pCompositor->m_pLastWindow.lock()) {
+        g_pCompositor->m_pLastWindow.reset();
         g_pCompositor->m_pLastFocus  = nullptr;
     }
 
@@ -919,9 +919,9 @@ void Events::listener_destroyWindow(void* owner, void* data) {
 }
 
 void Events::listener_setTitleWindow(void* owner, void* data) {
-    CWindow* PWINDOW = (CWindow*)owner;
+    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
-    if (!g_pCompositor->windowValidMapped(PWINDOW))
+    if (!validMapped(PWINDOW))
         return;
 
     const auto NEWTITLE = g_pXWaylandManager->getTitle(PWINDOW);
@@ -930,12 +930,12 @@ void Events::listener_setTitleWindow(void* owner, void* data) {
         return;
 
     PWINDOW->m_szTitle = NEWTITLE;
-    g_pEventManager->postEvent(SHyprIPCEvent{"windowtitle", std::format("{:x}", (uintptr_t)PWINDOW)});
+    g_pEventManager->postEvent(SHyprIPCEvent{"windowtitle", std::format("{:x}", (uintptr_t)PWINDOW.get())});
     EMIT_HOOK_EVENT("windowTitle", PWINDOW);
 
-    if (PWINDOW == g_pCompositor->m_pLastWindow) { // if it's the active, let's post an event to update others
+    if (PWINDOW == g_pCompositor->m_pLastWindow.lock()) { // if it's the active, let's post an event to update others
         g_pEventManager->postEvent(SHyprIPCEvent{"activewindow", g_pXWaylandManager->getAppIDClass(PWINDOW) + "," + PWINDOW->m_szTitle});
-        g_pEventManager->postEvent(SHyprIPCEvent{"activewindowv2", std::format("{:x}", (uintptr_t)PWINDOW)});
+        g_pEventManager->postEvent(SHyprIPCEvent{"activewindowv2", std::format("{:x}", (uintptr_t)PWINDOW.get())});
         EMIT_HOOK_EVENT("activeWindow", PWINDOW);
     }
 
@@ -947,7 +947,7 @@ void Events::listener_setTitleWindow(void* owner, void* data) {
 }
 
 void Events::listener_fullscreenWindow(void* owner, void* data) {
-    CWindow* PWINDOW = (CWindow*)owner;
+    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     if (!PWINDOW->m_bIsMapped) {
         PWINDOW->m_bWantsInitialFullscreen = true;
@@ -1015,14 +1015,14 @@ void Events::listener_activateXDG(wl_listener* listener, void* data) {
 
     const auto PWINDOW = g_pCompositor->getWindowFromSurface(E->surface);
 
-    if (!PWINDOW || PWINDOW == g_pCompositor->m_pLastWindow || (PWINDOW->m_eSuppressedEvents & SUPPRESS_ACTIVATE))
+    if (!PWINDOW || PWINDOW == g_pCompositor->m_pLastWindow.lock() || (PWINDOW->m_eSuppressedEvents & SUPPRESS_ACTIVATE))
         return;
 
     PWINDOW->activate();
 }
 
 void Events::listener_activateX11(void* owner, void* data) {
-    const auto PWINDOW = (CWindow*)owner;
+    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     Debug::log(LOG, "X11 Activate request for window {}", PWINDOW);
 
@@ -1030,7 +1030,7 @@ void Events::listener_activateX11(void* owner, void* data) {
 
         Debug::log(LOG, "Unmanaged X11 {} requests activate", PWINDOW);
 
-        if (g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->getPID() != PWINDOW->getPID())
+        if (g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow.lock()->getPID() != PWINDOW->getPID())
             return;
 
         if (!wlr_xwayland_or_surface_wants_focus(PWINDOW->m_uSurface.xwayland))
@@ -1040,14 +1040,14 @@ void Events::listener_activateX11(void* owner, void* data) {
         return;
     }
 
-    if (PWINDOW == g_pCompositor->m_pLastWindow || (PWINDOW->m_eSuppressedEvents & SUPPRESS_ACTIVATE))
+    if (PWINDOW == g_pCompositor->m_pLastWindow.lock() || (PWINDOW->m_eSuppressedEvents & SUPPRESS_ACTIVATE))
         return;
 
     PWINDOW->activate();
 }
 
 void Events::listener_configureX11(void* owner, void* data) {
-    CWindow*   PWINDOW = (CWindow*)owner;
+    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     const auto E = (wlr_xwayland_surface_configure_event*)data;
 
@@ -1062,7 +1062,7 @@ void Events::listener_configureX11(void* owner, void* data) {
 
     g_pHyprRenderer->damageWindow(PWINDOW);
 
-    if (!PWINDOW->m_bIsFloating || PWINDOW->m_bIsFullscreen || g_pInputManager->currentlyDraggedWindow == PWINDOW) {
+    if (!PWINDOW->m_bIsFloating || PWINDOW->m_bIsFullscreen || g_pInputManager->currentlyDraggedWindow.lock() == PWINDOW) {
         g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal(), true);
         g_pInputManager->refocus();
         g_pHyprRenderer->damageWindow(PWINDOW);
@@ -1113,7 +1113,7 @@ void Events::listener_configureX11(void* owner, void* data) {
 }
 
 void Events::listener_unmanagedSetGeometry(void* owner, void* data) {
-    CWindow* PWINDOW = (CWindow*)owner;
+    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     if (!PWINDOW->m_bIsMapped)
         return;
@@ -1178,16 +1178,16 @@ void Events::listener_setOverrideRedirect(void* owner, void* data) {
 }
 
 void Events::listener_associateX11(void* owner, void* data) {
-    const auto PWINDOW = (CWindow*)owner;
+    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
-    PWINDOW->hyprListener_mapWindow.initCallback(&PWINDOW->m_uSurface.xwayland->surface->events.map, &Events::listener_mapWindow, PWINDOW, "XWayland Window");
-    PWINDOW->hyprListener_commitWindow.initCallback(&PWINDOW->m_uSurface.xwayland->surface->events.commit, &Events::listener_commitWindow, PWINDOW, "XWayland Window");
+    PWINDOW->hyprListener_mapWindow.initCallback(&PWINDOW->m_uSurface.xwayland->surface->events.map, &Events::listener_mapWindow, PWINDOW.get(), "XWayland Window");
+    PWINDOW->hyprListener_commitWindow.initCallback(&PWINDOW->m_uSurface.xwayland->surface->events.commit, &Events::listener_commitWindow, PWINDOW.get(), "XWayland Window");
 
     PWINDOW->m_pWLSurface.assign(g_pXWaylandManager->getWindowSurface(PWINDOW), PWINDOW);
 }
 
 void Events::listener_dissociateX11(void* owner, void* data) {
-    const auto PWINDOW = (CWindow*)owner;
+    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     PWINDOW->m_pWLSurface.unassign();
 
@@ -1202,7 +1202,7 @@ void Events::listener_surfaceXWayland(wl_listener* listener, void* data) {
     if (XWSURFACE->parent)
         Debug::log(LOG, "Window parent data: {} at {:x}", XWSURFACE->parent->_class ? XWSURFACE->parent->_class : "null", (uintptr_t)XWSURFACE->parent);
 
-    const auto PNEWWINDOW = (CWindow*)g_pCompositor->m_vWindows.emplace_back(std::make_unique<CWindow>()).get();
+    const auto PNEWWINDOW = g_pCompositor->m_vWindows.emplace_back(CWindow::create());
 
     PNEWWINDOW->m_uSurface.xwayland = XWSURFACE;
     PNEWWINDOW->m_iX11Type          = XWSURFACE->override_redirect ? 2 : 1;
@@ -1210,11 +1210,11 @@ void Events::listener_surfaceXWayland(wl_listener* listener, void* data) {
 
     PNEWWINDOW->m_pX11Parent = g_pCompositor->getX11Parent(PNEWWINDOW);
 
-    PNEWWINDOW->hyprListener_associateX11.initCallback(&XWSURFACE->events.associate, &Events::listener_associateX11, PNEWWINDOW, "XWayland Window");
-    PNEWWINDOW->hyprListener_dissociateX11.initCallback(&XWSURFACE->events.dissociate, &Events::listener_dissociateX11, PNEWWINDOW, "XWayland Window");
-    PNEWWINDOW->hyprListener_destroyWindow.initCallback(&XWSURFACE->events.destroy, &Events::listener_destroyWindow, PNEWWINDOW, "XWayland Window");
-    PNEWWINDOW->hyprListener_setOverrideRedirect.initCallback(&XWSURFACE->events.set_override_redirect, &Events::listener_setOverrideRedirect, PNEWWINDOW, "XWayland Window");
-    PNEWWINDOW->hyprListener_configureX11.initCallback(&XWSURFACE->events.request_configure, &Events::listener_configureX11, PNEWWINDOW, "XWayland Window");
+    PNEWWINDOW->hyprListener_associateX11.initCallback(&XWSURFACE->events.associate, &Events::listener_associateX11, PNEWWINDOW.get(), "XWayland Window");
+    PNEWWINDOW->hyprListener_dissociateX11.initCallback(&XWSURFACE->events.dissociate, &Events::listener_dissociateX11, PNEWWINDOW.get(), "XWayland Window");
+    PNEWWINDOW->hyprListener_destroyWindow.initCallback(&XWSURFACE->events.destroy, &Events::listener_destroyWindow, PNEWWINDOW.get(), "XWayland Window");
+    PNEWWINDOW->hyprListener_setOverrideRedirect.initCallback(&XWSURFACE->events.set_override_redirect, &Events::listener_setOverrideRedirect, PNEWWINDOW.get(), "XWayland Window");
+    PNEWWINDOW->hyprListener_configureX11.initCallback(&XWSURFACE->events.request_configure, &Events::listener_configureX11, PNEWWINDOW.get(), "XWayland Window");
 }
 
 void Events::listener_newXDGToplevel(wl_listener* listener, void* data) {
@@ -1224,18 +1224,18 @@ void Events::listener_newXDGToplevel(wl_listener* listener, void* data) {
 
     Debug::log(LOG, "New XDG Toplevel created. (class: {})", XDGSURFACE->toplevel->app_id ? XDGSURFACE->toplevel->app_id : "null");
 
-    const auto PNEWWINDOW      = g_pCompositor->m_vWindows.emplace_back(std::make_unique<CWindow>()).get();
+    const auto PNEWWINDOW      = g_pCompositor->m_vWindows.emplace_back(CWindow::create());
     PNEWWINDOW->m_uSurface.xdg = XDGSURFACE;
 
-    PNEWWINDOW->hyprListener_mapWindow.initCallback(&XDGSURFACE->surface->events.map, &Events::listener_mapWindow, PNEWWINDOW, "XDG Window");
-    PNEWWINDOW->hyprListener_destroyWindow.initCallback(&XDGSURFACE->events.destroy, &Events::listener_destroyWindow, PNEWWINDOW, "XDG Window");
-    PNEWWINDOW->hyprListener_commitWindow.initCallback(&XDGSURFACE->surface->events.commit, &Events::listener_commitWindow, PNEWWINDOW, "XDG Window");
+    PNEWWINDOW->hyprListener_mapWindow.initCallback(&XDGSURFACE->surface->events.map, &Events::listener_mapWindow, PNEWWINDOW.get(), "XDG Window");
+    PNEWWINDOW->hyprListener_destroyWindow.initCallback(&XDGSURFACE->events.destroy, &Events::listener_destroyWindow, PNEWWINDOW.get(), "XDG Window");
+    PNEWWINDOW->hyprListener_commitWindow.initCallback(&XDGSURFACE->surface->events.commit, &Events::listener_commitWindow, PNEWWINDOW.get(), "XDG Window");
 
     PNEWWINDOW->m_pWLSurface.assign(g_pXWaylandManager->getWindowSurface(PNEWWINDOW), PNEWWINDOW);
 }
 
 void Events::listener_requestMaximize(void* owner, void* data) {
-    const auto PWINDOW = (CWindow*)owner;
+    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     if (PWINDOW->m_eSuppressedEvents & SUPPRESS_MAXIMIZE)
         return;
@@ -1256,7 +1256,7 @@ void Events::listener_requestMaximize(void* owner, void* data) {
 }
 
 void Events::listener_requestMinimize(void* owner, void* data) {
-    const auto PWINDOW = (CWindow*)owner;
+   PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     Debug::log(LOG, "Minimize request for {}", PWINDOW);
 
@@ -1266,25 +1266,25 @@ void Events::listener_requestMinimize(void* owner, void* data) {
 
         const auto E = (wlr_xwayland_minimize_event*)data;
 
-        g_pEventManager->postEvent({"minimize", std::format("{:x},{}", (uintptr_t)PWINDOW, (int)E->minimize)});
-        EMIT_HOOK_EVENT("minimize", (std::vector<void*>{PWINDOW, (void*)E->minimize}));
+        g_pEventManager->postEvent({"minimize", std::format("{:x},{}", (uintptr_t)PWINDOW.get(), (int)E->minimize)});
+        EMIT_HOOK_EVENT("minimize", (std::vector<std::any>{PWINDOW, E->minimize}));
 
-        wlr_xwayland_surface_set_minimized(PWINDOW->m_uSurface.xwayland, E->minimize && g_pCompositor->m_pLastWindow != PWINDOW); // fucking DXVK
+        wlr_xwayland_surface_set_minimized(PWINDOW->m_uSurface.xwayland, E->minimize && g_pCompositor->m_pLastWindow.lock() != PWINDOW); // fucking DXVK
     } else {
-        g_pEventManager->postEvent({"minimize", std::format("{:x},{}", (uintptr_t)PWINDOW, 1)});
-        EMIT_HOOK_EVENT("minimize", (std::vector<void*>{PWINDOW, (void*)(1)}));
+        g_pEventManager->postEvent({"minimize", std::format("{:x},{}", (uintptr_t)PWINDOW.get(), 1)});
+        EMIT_HOOK_EVENT("minimize", (std::vector<std::any>{PWINDOW, (int64_t)(1)}));
     }
 }
 
 void Events::listener_requestMove(void* owner, void* data) {
-    const auto PWINDOW = (CWindow*)owner;
+    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     // ignore
     wlr_xdg_surface_schedule_configure(PWINDOW->m_uSurface.xdg);
 }
 
 void Events::listener_requestResize(void* owner, void* data) {
-    const auto PWINDOW = (CWindow*)owner;
+    PHLWINDOW   PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     // ignore
     wlr_xdg_surface_schedule_configure(PWINDOW->m_uSurface.xdg);

--- a/src/helpers/AnimatedVariable.cpp
+++ b/src/helpers/AnimatedVariable.cpp
@@ -6,7 +6,7 @@ CBaseAnimatedVariable::CBaseAnimatedVariable(ANIMATEDVARTYPE type) : m_Type(type
     ; // dummy var
 }
 
-void CBaseAnimatedVariable::create(SAnimationPropertyConfig* pAnimConfig, CWindow* pWindow, AVARDAMAGEPOLICY policy) {
+void CBaseAnimatedVariable::create(SAnimationPropertyConfig* pAnimConfig, PHLWINDOW pWindow, AVARDAMAGEPOLICY policy) {
     m_eDamagePolicy = policy;
     m_pConfig       = pAnimConfig;
     m_pWindow       = pWindow;

--- a/src/helpers/AnimatedVariable.hpp
+++ b/src/helpers/AnimatedVariable.hpp
@@ -6,7 +6,7 @@
 #include <type_traits>
 #include "Vector2D.hpp"
 #include "Color.hpp"
-#include "../macros.hpp"
+#include "../defines.hpp"
 #include "../debug/Log.hpp"
 #include "../desktop/DesktopTypes.hpp"
 
@@ -68,7 +68,7 @@ concept Animable = OneOf<T, Vector2D, float, CColor>;
 class CBaseAnimatedVariable {
   public:
     CBaseAnimatedVariable(ANIMATEDVARTYPE type);
-    void create(SAnimationPropertyConfig* pAnimConfig, CWindow* pWindow, AVARDAMAGEPOLICY policy);
+    void create(SAnimationPropertyConfig* pAnimConfig, PHLWINDOW pWindow, AVARDAMAGEPOLICY policy);
     void create(SAnimationPropertyConfig* pAnimConfig, SLayerSurface* pLayer, AVARDAMAGEPOLICY policy);
     void create(SAnimationPropertyConfig* pAnimConfig, PHLWORKSPACE pWorkspace, AVARDAMAGEPOLICY policy);
     void create(SAnimationPropertyConfig* pAnimConfig, AVARDAMAGEPOLICY policy);
@@ -140,12 +140,12 @@ class CBaseAnimatedVariable {
         m_bRemoveEndAfterRan   = false;
     }
 
-    CWindow* getWindow() {
-        return (CWindow*)m_pWindow;
+    PHLWINDOW getWindow() {
+        return m_pWindow.lock();
     }
 
   protected:
-    void*                                 m_pWindow = nullptr;
+    PHLWINDOWREF                          m_pWindow;
     std::weak_ptr<CWorkspace>             m_pWorkspace;
     void*                                 m_pLayer = nullptr;
 
@@ -208,7 +208,7 @@ class CAnimatedVariable : public CBaseAnimatedVariable {
   public:
     CAnimatedVariable() : CBaseAnimatedVariable(typeToANIMATEDVARTYPE<VarType>) {} // dummy var
 
-    void create(const VarType& value, SAnimationPropertyConfig* pAnimConfig, CWindow* pWindow, AVARDAMAGEPOLICY policy) {
+    void create(const VarType& value, SAnimationPropertyConfig* pAnimConfig, PHLWINDOW pWindow, AVARDAMAGEPOLICY policy) {
         create(pAnimConfig, pWindow, policy);
         m_Value = value;
         m_Goal  = value;

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -303,8 +303,8 @@ void CMonitor::onDisconnect(bool destroy) {
             w->startAnim(true, true, true);
         }
     } else {
-        g_pCompositor->m_pLastFocus   = nullptr;
-        g_pCompositor->m_pLastWindow  = nullptr;
+        g_pCompositor->m_pLastFocus = nullptr;
+        g_pCompositor->m_pLastWindow.reset();
         g_pCompositor->m_pLastMonitor = nullptr;
     }
 
@@ -577,9 +577,9 @@ void CMonitor::changeWorkspace(const PHLWORKSPACE& pWorkspace, bool internal, bo
         }
 
         if (!noFocus && !g_pCompositor->m_pLastMonitor->activeSpecialWorkspace &&
-            !(g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_bPinned && g_pCompositor->m_pLastWindow->m_iMonitorID == ID)) {
+            !(g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow.lock()->m_bPinned && g_pCompositor->m_pLastWindow.lock()->m_iMonitorID == ID)) {
             static auto PFOLLOWMOUSE = CConfigValue<Hyprlang::INT>("input:follow_mouse");
-            CWindow*    pWindow      = pWorkspace->getLastFocusedWindow();
+            auto        pWindow      = pWorkspace->getLastFocusedWindow();
 
             if (!pWindow) {
                 if (*PFOLLOWMOUSE == 1)
@@ -635,7 +635,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
 
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(ID);
 
-        if (!(g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_bPinned && g_pCompositor->m_pLastWindow->m_iMonitorID == ID)) {
+        if (!(g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow.lock()->m_bPinned && g_pCompositor->m_pLastWindow.lock()->m_iMonitorID == ID)) {
             if (const auto PLAST = activeWorkspace->getLastFocusedWindow(); PLAST)
                 g_pCompositor->focusWindow(PLAST);
             else
@@ -703,7 +703,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
 
     g_pLayoutManager->getCurrentLayout()->recalculateMonitor(ID);
 
-    if (!(g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_bPinned && g_pCompositor->m_pLastWindow->m_iMonitorID == ID)) {
+    if (!(g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow.lock()->m_bPinned && g_pCompositor->m_pLastWindow.lock()->m_iMonitorID == ID)) {
         if (const auto PLAST = pWorkspace->getLastFocusedWindow(); PLAST)
             g_pCompositor->focusWindow(PLAST);
         else

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -118,7 +118,7 @@ class CMonitor {
     std::vector<CMonitor*> mirrors;
 
     // for tearing
-    CWindow* solitaryClient = nullptr;
+    PHLWINDOWREF solitaryClient;
 
     struct {
         bool canTear         = false;

--- a/src/helpers/WLClasses.hpp
+++ b/src/helpers/WLClasses.hpp
@@ -108,9 +108,9 @@ struct SRenderData {
     bool squishOversized = true;
 
     // for calculating UV
-    CWindow* pWindow = nullptr;
+    PHLWINDOW pWindow;
 
-    bool     popup = false;
+    bool      popup = false;
 };
 
 struct SExtensionFindingData {

--- a/src/helpers/WLListener.cpp
+++ b/src/helpers/WLListener.cpp
@@ -12,7 +12,7 @@ void handleWrapped(wl_listener* listener, void* data) {
 
     try {
         pWrap->m_pSelf->emit(data);
-    } catch (std::exception& e) { Debug::log(ERR, "Listener {} timed out and was killed by Watchdog!!!", (uintptr_t)listener); }
+    } catch (std::exception& e) { Debug::log(ERR, "Listener {} threw or timed out and was killed by Watchdog!!! This is bad. what(): {}", (uintptr_t)listener, e.what()); }
 
     if (g_pWatchdog)
         g_pWatchdog->endWatching();

--- a/src/helpers/signal/Signal.cpp
+++ b/src/helpers/signal/Signal.cpp
@@ -12,7 +12,7 @@ void CSignal::emit(std::any data) {
     }
 
     if (dirty)
-        std::erase_if(m_vListeners, [](const auto& other) { return !other.lock(); });
+        std::erase_if(m_vListeners, [](const auto& other) { return other.expired(); });
 }
 
 CHyprSignalListener CSignal::registerListener(std::function<void(std::any)> handler) {

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -339,7 +339,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
     }
 
     // if it's a group, add the window
-    if (OPENINGON->pWindow.lock()->m_sGroupData.pNextWindow.lock()                                  // target is group
+    if (OPENINGON->pWindow.lock()->m_sGroupData.pNextWindow.lock()                           // target is group
         && pWindow->canBeGroupedInto(OPENINGON->pWindow.lock()) && !m_vOverrideFocalPoint) { // we are not moving window
         m_lDwindleNodesData.remove(*PNODE);
 
@@ -984,13 +984,13 @@ void CHyprDwindleLayout::switchWindows(PHLWINDOW pWindow, PHLWINDOW pWindow2) {
         getMasterNodeOnWorkspace(PNODE2->workspaceID)->recalcSizePosRecursive();
 
     if (ACTIVE1) {
-        ACTIVE1->box                  = PNODE->box;
+        ACTIVE1->box                         = PNODE->box;
         ACTIVE1->pWindow.lock()->m_vPosition = ACTIVE1->box.pos();
         ACTIVE1->pWindow.lock()->m_vSize     = ACTIVE1->box.size();
     }
 
     if (ACTIVE2) {
-        ACTIVE2->box                  = PNODE2->box;
+        ACTIVE2->box                         = PNODE2->box;
         ACTIVE2->pWindow.lock()->m_vPosition = ACTIVE2->box.pos();
         ACTIVE2->pWindow.lock()->m_vSize     = ACTIVE2->box.size();
     }
@@ -1140,7 +1140,7 @@ Vector2D CHyprDwindleLayout::predictSizeForNewWindowTiled() {
         if (!PNODE)
             return {};
 
-        node         = *PNODE;
+        node = *PNODE;
         node.pWindow.reset();
 
         CBox        box = PNODE->box;

--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -34,7 +34,8 @@ struct SDwindleNodeData {
 
     // For list lookup
     bool operator==(const SDwindleNodeData& rhs) const {
-        return pWindow.lock() == rhs.pWindow.lock();
+        return pWindow.lock() == rhs.pWindow.lock() && workspaceID == rhs.workspaceID && box == rhs.box && pParent == rhs.pParent && children[0] == rhs.children[0] &&
+            children[1] == rhs.children[1];
     }
 
     void                recalcSizePosRecursive(bool force = false, bool horizontalOverride = false, bool verticalOverride = false);

--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -101,7 +101,7 @@ struct std::formatter<SDwindleNodeData*, CharT> : std::formatter<CharT> {
         if (!node)
             return std::format_to(out, "[Node nullptr]");
         std::format_to(out, "[Node {:x}: workspace: {}, pos: {:j2}, size: {:j2}", (uintptr_t)node, node->workspaceID, node->box.pos(), node->box.size());
-        if (!node->isNode && node->pWindow.lock())
+        if (!node->isNode && !node->pWindow.expired())
             std::format_to(out, ", window: {:x}", node->pWindow.lock());
         return std::format_to(out, "]");
     }

--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -16,7 +16,7 @@ struct SDwindleNodeData {
     SDwindleNodeData*                pParent = nullptr;
     bool                             isNode  = false;
 
-    CWindow*                         pWindow = nullptr;
+    PHLWINDOWREF                     pWindow;
 
     std::array<SDwindleNodeData*, 2> children = {nullptr, nullptr};
 
@@ -34,8 +34,7 @@ struct SDwindleNodeData {
 
     // For list lookup
     bool operator==(const SDwindleNodeData& rhs) const {
-        return pWindow == rhs.pWindow && workspaceID == rhs.workspaceID && box == rhs.box && pParent == rhs.pParent && children[0] == rhs.children[0] &&
-            children[1] == rhs.children[1];
+        return pWindow.lock() == rhs.pWindow.lock();
     }
 
     void                recalcSizePosRecursive(bool force = false, bool horizontalOverride = false, bool verticalOverride = false);
@@ -45,21 +44,21 @@ struct SDwindleNodeData {
 
 class CHyprDwindleLayout : public IHyprLayout {
   public:
-    virtual void                     onWindowCreatedTiling(CWindow*, eDirection direction = DIRECTION_DEFAULT);
-    virtual void                     onWindowRemovedTiling(CWindow*);
-    virtual bool                     isWindowTiled(CWindow*);
+    virtual void                     onWindowCreatedTiling(PHLWINDOW, eDirection direction = DIRECTION_DEFAULT);
+    virtual void                     onWindowRemovedTiling(PHLWINDOW);
+    virtual bool                     isWindowTiled(PHLWINDOW);
     virtual void                     recalculateMonitor(const int&);
-    virtual void                     recalculateWindow(CWindow*);
+    virtual void                     recalculateWindow(PHLWINDOW);
     virtual void                     onBeginDragWindow();
-    virtual void                     resizeActiveWindow(const Vector2D&, eRectCorner corner = CORNER_NONE, CWindow* pWindow = nullptr);
-    virtual void                     fullscreenRequestForWindow(CWindow*, eFullscreenMode, bool);
+    virtual void                     resizeActiveWindow(const Vector2D&, eRectCorner corner = CORNER_NONE, PHLWINDOW pWindow = nullptr);
+    virtual void                     fullscreenRequestForWindow(PHLWINDOW, eFullscreenMode, bool);
     virtual std::any                 layoutMessage(SLayoutMessageHeader, std::string);
-    virtual SWindowRenderLayoutHints requestRenderHints(CWindow*);
-    virtual void                     switchWindows(CWindow*, CWindow*);
-    virtual void                     moveWindowTo(CWindow*, const std::string& dir, bool silent);
-    virtual void                     alterSplitRatio(CWindow*, float, bool);
+    virtual SWindowRenderLayoutHints requestRenderHints(PHLWINDOW);
+    virtual void                     switchWindows(PHLWINDOW, PHLWINDOW);
+    virtual void                     moveWindowTo(PHLWINDOW, const std::string& dir, bool silent);
+    virtual void                     alterSplitRatio(PHLWINDOW, float, bool);
     virtual std::string              getLayoutName();
-    virtual void                     replaceWindowDataWith(CWindow* from, CWindow* to);
+    virtual void                     replaceWindowDataWith(PHLWINDOW from, PHLWINDOW to);
     virtual Vector2D                 predictSizeForNewWindowTiled();
 
     virtual void                     onEnable();
@@ -80,13 +79,13 @@ class CHyprDwindleLayout : public IHyprLayout {
     int                     getNodesOnWorkspace(const int&);
     void                    applyNodeDataToWindow(SDwindleNodeData*, bool force = false);
     void                    calculateWorkspace(const PHLWORKSPACE& pWorkspace);
-    SDwindleNodeData*       getNodeFromWindow(CWindow*);
+    SDwindleNodeData*       getNodeFromWindow(PHLWINDOW);
     SDwindleNodeData*       getFirstNodeOnWorkspace(const int&);
     SDwindleNodeData*       getClosestNodeOnWorkspace(const int&, const Vector2D&);
     SDwindleNodeData*       getMasterNodeOnWorkspace(const int&);
 
-    void                    toggleSplit(CWindow*);
-    void                    swapSplit(CWindow*);
+    void                    toggleSplit(PHLWINDOW);
+    void                    swapSplit(PHLWINDOW);
 
     eDirection              overrideDirection = DIRECTION_DEFAULT;
 
@@ -101,8 +100,8 @@ struct std::formatter<SDwindleNodeData*, CharT> : std::formatter<CharT> {
         if (!node)
             return std::format_to(out, "[Node nullptr]");
         std::format_to(out, "[Node {:x}: workspace: {}, pos: {:j2}, size: {:j2}", (uintptr_t)node, node->workspaceID, node->box.pos(), node->box.size());
-        if (!node->isNode && node->pWindow)
-            std::format_to(out, ", window: {:x}", node->pWindow);
+        if (!node->isNode && node->pWindow.lock())
+            std::format_to(out, ", window: {:x}", node->pWindow.lock());
         return std::format_to(out, "]");
     }
 };

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -29,7 +29,7 @@ void IHyprLayout::onWindowRemoved(PHLWINDOW pWindow) {
     if (pWindow->m_bIsFullscreen)
         g_pCompositor->setWindowFullscreen(pWindow, false, FULLSCREEN_FULL);
 
-    if (pWindow->m_sGroupData.pNextWindow.lock()) {
+    if (!pWindow->m_sGroupData.pNextWindow.expired()) {
         if (pWindow->m_sGroupData.pNextWindow.lock() == pWindow)
             pWindow->m_sGroupData.pNextWindow.reset();
         else {

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -283,7 +283,7 @@ void IHyprLayout::onEndDragWindow() {
     g_pInputManager->unsetCursorImage();
 
     g_pInputManager->currentlyDraggedWindow.reset();
-    g_pInputManager->m_bWasDraggingWindow   = true;
+    g_pInputManager->m_bWasDraggingWindow = true;
 
     if (DRAGGINGWINDOW->m_bDraggingTiled) {
         DRAGGINGWINDOW->m_bIsFloating = false;

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -5,7 +5,7 @@
 #include "../config/ConfigValue.hpp"
 #include "../desktop/Window.hpp"
 
-void IHyprLayout::onWindowCreated(CWindow* pWindow, eDirection direction) {
+void IHyprLayout::onWindowCreated(PHLWINDOW pWindow, eDirection direction) {
     if (pWindow->m_bIsFloating) {
         onWindowCreatedFloating(pWindow);
     } else {
@@ -25,32 +25,32 @@ void IHyprLayout::onWindowCreated(CWindow* pWindow, eDirection direction) {
     }
 }
 
-void IHyprLayout::onWindowRemoved(CWindow* pWindow) {
+void IHyprLayout::onWindowRemoved(PHLWINDOW pWindow) {
     if (pWindow->m_bIsFullscreen)
         g_pCompositor->setWindowFullscreen(pWindow, false, FULLSCREEN_FULL);
 
-    if (pWindow->m_sGroupData.pNextWindow) {
-        if (pWindow->m_sGroupData.pNextWindow == pWindow)
-            pWindow->m_sGroupData.pNextWindow = nullptr;
+    if (pWindow->m_sGroupData.pNextWindow.lock()) {
+        if (pWindow->m_sGroupData.pNextWindow.lock() == pWindow)
+            pWindow->m_sGroupData.pNextWindow.reset();
         else {
             // find last window and update
-            CWindow*   PWINDOWPREV     = pWindow->getGroupPrevious();
+            PHLWINDOW  PWINDOWPREV     = pWindow->getGroupPrevious();
             const auto WINDOWISVISIBLE = pWindow->getGroupCurrent() == pWindow;
 
             if (WINDOWISVISIBLE)
-                PWINDOWPREV->setGroupCurrent(pWindow->m_sGroupData.head ? pWindow->m_sGroupData.pNextWindow : PWINDOWPREV);
+                PWINDOWPREV->setGroupCurrent(pWindow->m_sGroupData.head ? pWindow->m_sGroupData.pNextWindow.lock() : PWINDOWPREV);
 
             PWINDOWPREV->m_sGroupData.pNextWindow = pWindow->m_sGroupData.pNextWindow;
 
-            pWindow->m_sGroupData.pNextWindow = nullptr;
+            pWindow->m_sGroupData.pNextWindow.reset();
 
             if (pWindow->m_sGroupData.head) {
-                std::swap(PWINDOWPREV->m_sGroupData.pNextWindow->m_sGroupData.head, pWindow->m_sGroupData.head);
-                std::swap(PWINDOWPREV->m_sGroupData.pNextWindow->m_sGroupData.locked, pWindow->m_sGroupData.locked);
+                std::swap(PWINDOWPREV->m_sGroupData.pNextWindow.lock()->m_sGroupData.head, pWindow->m_sGroupData.head);
+                std::swap(PWINDOWPREV->m_sGroupData.pNextWindow.lock()->m_sGroupData.locked, pWindow->m_sGroupData.locked);
             }
 
-            if (pWindow == m_pLastTiledWindow)
-                m_pLastTiledWindow = nullptr;
+            if (pWindow == m_pLastTiledWindow.lock())
+                m_pLastTiledWindow.reset();
 
             pWindow->setHidden(false);
 
@@ -68,15 +68,15 @@ void IHyprLayout::onWindowRemoved(CWindow* pWindow) {
         onWindowRemovedTiling(pWindow);
     }
 
-    if (pWindow == m_pLastTiledWindow)
-        m_pLastTiledWindow = nullptr;
+    if (pWindow == m_pLastTiledWindow.lock())
+        m_pLastTiledWindow.reset();
 }
 
-void IHyprLayout::onWindowRemovedFloating(CWindow* pWindow) {
+void IHyprLayout::onWindowRemovedFloating(PHLWINDOW pWindow) {
     return; // no-op
 }
 
-void IHyprLayout::onWindowCreatedFloating(CWindow* pWindow) {
+void IHyprLayout::onWindowCreatedFloating(PHLWINDOW pWindow) {
 
     CBox desiredGeometry = {0};
     g_pXWaylandManager->getGeometryForWindow(pWindow, &desiredGeometry);
@@ -172,15 +172,15 @@ void IHyprLayout::onWindowCreatedFloating(CWindow* pWindow) {
 }
 
 void IHyprLayout::onBeginDragWindow() {
-    const auto DRAGGINGWINDOW = g_pInputManager->currentlyDraggedWindow;
+    const auto DRAGGINGWINDOW = g_pInputManager->currentlyDraggedWindow.lock();
 
     m_iMouseMoveEventCount = 1;
     m_vBeginDragSizeXY     = Vector2D();
 
     // Window will be floating. Let's check if it's valid. It should be, but I don't like crashing.
-    if (!g_pCompositor->windowValidMapped(DRAGGINGWINDOW)) {
+    if (!validMapped(DRAGGINGWINDOW)) {
         Debug::log(ERR, "Dragging attempted on an invalid window!");
-        g_pInputManager->currentlyDraggedWindow = nullptr;
+        g_pInputManager->currentlyDraggedWindow.reset();
         return;
     }
 
@@ -193,7 +193,7 @@ void IHyprLayout::onBeginDragWindow() {
 
     if (PWORKSPACE->m_bHasFullscreenWindow && (!DRAGGINGWINDOW->m_bCreatedOverFullscreen || !DRAGGINGWINDOW->m_bIsFloating)) {
         Debug::log(LOG, "Rejecting drag on a fullscreen workspace. (window under fullscreen)");
-        g_pInputManager->currentlyDraggedWindow = nullptr;
+        g_pInputManager->currentlyDraggedWindow.reset();
         return;
     }
 
@@ -268,21 +268,21 @@ void IHyprLayout::onBeginDragWindow() {
 }
 
 void IHyprLayout::onEndDragWindow() {
-    const auto DRAGGINGWINDOW = g_pInputManager->currentlyDraggedWindow;
+    const auto DRAGGINGWINDOW = g_pInputManager->currentlyDraggedWindow.lock();
 
     m_iMouseMoveEventCount = 1;
 
-    if (!g_pCompositor->windowValidMapped(DRAGGINGWINDOW)) {
+    if (!validMapped(DRAGGINGWINDOW)) {
         if (DRAGGINGWINDOW) {
             g_pInputManager->unsetCursorImage();
-            g_pInputManager->currentlyDraggedWindow = nullptr;
+            g_pInputManager->currentlyDraggedWindow.reset();
         }
         return;
     }
 
     g_pInputManager->unsetCursorImage();
 
-    g_pInputManager->currentlyDraggedWindow = nullptr;
+    g_pInputManager->currentlyDraggedWindow.reset();
     g_pInputManager->m_bWasDraggingWindow   = true;
 
     if (DRAGGINGWINDOW->m_bDraggingTiled) {
@@ -293,13 +293,13 @@ void IHyprLayout::onEndDragWindow() {
     } else if (g_pInputManager->dragMode == MBIND_MOVE) {
         g_pHyprRenderer->damageWindow(DRAGGINGWINDOW);
         const auto MOUSECOORDS = g_pInputManager->getMouseCoordsInternal();
-        CWindow*   pWindow     = g_pCompositor->vectorToWindowUnified(MOUSECOORDS, RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING | FLOATING_ONLY, DRAGGINGWINDOW);
+        PHLWINDOW  pWindow     = g_pCompositor->vectorToWindowUnified(MOUSECOORDS, RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING | FLOATING_ONLY, DRAGGINGWINDOW);
 
         if (pWindow) {
             if (pWindow->checkInputOnDecos(INPUT_TYPE_DRAG_END, MOUSECOORDS, DRAGGINGWINDOW))
                 return;
 
-            if (pWindow->m_sGroupData.pNextWindow && DRAGGINGWINDOW->canBeGroupedInto(pWindow)) {
+            if (pWindow->m_sGroupData.pNextWindow.lock() && DRAGGINGWINDOW->canBeGroupedInto(pWindow)) {
                 static auto USECURRPOS = CConfigValue<Hyprlang::INT>("group:insert_after_current");
                 (*USECURRPOS ? pWindow : pWindow->getGroupTail())->insertWindowToGroup(DRAGGINGWINDOW);
                 pWindow->setGroupCurrent(DRAGGINGWINDOW);
@@ -318,12 +318,12 @@ void IHyprLayout::onEndDragWindow() {
 }
 
 void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
-    const auto DRAGGINGWINDOW = g_pInputManager->currentlyDraggedWindow;
+    const auto DRAGGINGWINDOW = g_pInputManager->currentlyDraggedWindow.lock();
 
     // Window invalid or drag begin size 0,0 meaning we rejected it.
-    if (!g_pCompositor->windowValidMapped(DRAGGINGWINDOW) || m_vBeginDragSizeXY == Vector2D()) {
+    if (!validMapped(DRAGGINGWINDOW) || m_vBeginDragSizeXY == Vector2D()) {
         onEndDragWindow();
-        g_pInputManager->currentlyDraggedWindow = nullptr;
+        g_pInputManager->currentlyDraggedWindow.reset();
         return;
     }
 
@@ -461,7 +461,7 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
     g_pHyprRenderer->damageWindow(DRAGGINGWINDOW);
 }
 
-void IHyprLayout::changeWindowFloatingMode(CWindow* pWindow) {
+void IHyprLayout::changeWindowFloatingMode(PHLWINDOW pWindow) {
 
     if (pWindow->m_bIsFullscreen) {
         Debug::log(LOG, "changeWindowFloatingMode: fullscreen");
@@ -473,7 +473,7 @@ void IHyprLayout::changeWindowFloatingMode(CWindow* pWindow) {
     const auto TILED = isWindowTiled(pWindow);
 
     // event
-    g_pEventManager->postEvent(SHyprIPCEvent{"changefloatingmode", std::format("{:x},{}", (uintptr_t)pWindow, (int)TILED)});
+    g_pEventManager->postEvent(SHyprIPCEvent{"changefloatingmode", std::format("{:x},{}", (uintptr_t)pWindow.get(), (int)TILED)});
     EMIT_HOOK_EVENT("changeFloatingMode", pWindow);
 
     if (!TILED) {
@@ -508,7 +508,7 @@ void IHyprLayout::changeWindowFloatingMode(CWindow* pWindow) {
         // fix pseudo leaving artifacts
         g_pHyprRenderer->damageMonitor(g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID));
 
-        if (pWindow == g_pCompositor->m_pLastWindow)
+        if (pWindow == g_pCompositor->m_pLastWindow.lock())
             m_pLastTiledWindow = pWindow;
     } else {
         onWindowRemovedTiling(pWindow);
@@ -533,8 +533,8 @@ void IHyprLayout::changeWindowFloatingMode(CWindow* pWindow) {
 
         pWindow->updateSpecialRenderData();
 
-        if (pWindow == m_pLastTiledWindow)
-            m_pLastTiledWindow = nullptr;
+        if (pWindow == m_pLastTiledWindow.lock())
+            m_pLastTiledWindow.reset();
     }
 
     g_pCompositor->updateWindowAnimatedDecorationValues(pWindow);
@@ -542,10 +542,10 @@ void IHyprLayout::changeWindowFloatingMode(CWindow* pWindow) {
     pWindow->updateToplevel();
 }
 
-void IHyprLayout::moveActiveWindow(const Vector2D& delta, CWindow* pWindow) {
-    const auto PWINDOW = pWindow ? pWindow : g_pCompositor->m_pLastWindow;
+void IHyprLayout::moveActiveWindow(const Vector2D& delta, PHLWINDOW pWindow) {
+    const auto PWINDOW = pWindow ? pWindow : g_pCompositor->m_pLastWindow.lock();
 
-    if (!g_pCompositor->windowValidMapped(PWINDOW))
+    if (!validMapped(PWINDOW))
         return;
 
     if (!PWINDOW->m_bIsFloating) {
@@ -560,11 +560,11 @@ void IHyprLayout::moveActiveWindow(const Vector2D& delta, CWindow* pWindow) {
     g_pHyprRenderer->damageWindow(PWINDOW);
 }
 
-void IHyprLayout::onWindowFocusChange(CWindow* pNewFocus) {
+void IHyprLayout::onWindowFocusChange(PHLWINDOW pNewFocus) {
     m_pLastTiledWindow = pNewFocus && !pNewFocus->m_bIsFloating ? pNewFocus : m_pLastTiledWindow;
 }
 
-CWindow* IHyprLayout::getNextWindowCandidate(CWindow* pWindow) {
+PHLWINDOW IHyprLayout::getNextWindowCandidate(PHLWINDOW pWindow) {
     // although we don't expect nullptrs here, let's verify jic
     if (!pWindow)
         return nullptr;
@@ -580,17 +580,17 @@ CWindow* IHyprLayout::getNextWindowCandidate(CWindow* pWindow) {
         // find whether there is a floating window below this one
         for (auto& w : g_pCompositor->m_vWindows) {
             if (w->m_bIsMapped && !w->isHidden() && w->m_bIsFloating && w->m_iX11Type != 2 && w->m_pWorkspace == pWindow->m_pWorkspace && !w->m_bX11ShouldntFocus &&
-                !w->m_sAdditionalConfigData.noFocus && w.get() != pWindow) {
+                !w->m_sAdditionalConfigData.noFocus && w != pWindow) {
                 if (VECINRECT((pWindow->m_vSize / 2.f + pWindow->m_vPosition), w->m_vPosition.x, w->m_vPosition.y, w->m_vPosition.x + w->m_vSize.x,
                               w->m_vPosition.y + w->m_vSize.y)) {
-                    return w.get();
+                    return w;
                 }
             }
         }
 
         // let's try the last tiled window.
-        if (m_pLastTiledWindow && m_pLastTiledWindow->m_pWorkspace == pWindow->m_pWorkspace)
-            return m_pLastTiledWindow;
+        if (m_pLastTiledWindow.lock() && m_pLastTiledWindow.lock()->m_pWorkspace == pWindow->m_pWorkspace)
+            return m_pLastTiledWindow.lock();
 
         // if we don't, let's try to find any window that is in the middle
         if (const auto PWINDOWCANDIDATE = g_pCompositor->vectorToWindowUnified(pWindow->middle(), RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING);
@@ -600,8 +600,8 @@ CWindow* IHyprLayout::getNextWindowCandidate(CWindow* pWindow) {
         // if not, floating window
         for (auto& w : g_pCompositor->m_vWindows) {
             if (w->m_bIsMapped && !w->isHidden() && w->m_bIsFloating && w->m_iX11Type != 2 && w->m_pWorkspace == pWindow->m_pWorkspace && !w->m_bX11ShouldntFocus &&
-                !w->m_sAdditionalConfigData.noFocus && w.get() != pWindow)
-                return w.get();
+                !w->m_sAdditionalConfigData.noFocus && w != pWindow)
+                return w;
         }
 
         // if there is no candidate, too bad
@@ -624,27 +624,27 @@ CWindow* IHyprLayout::getNextWindowCandidate(CWindow* pWindow) {
     return pWindowCandidate;
 }
 
-bool IHyprLayout::isWindowReachable(CWindow* pWindow) {
-    return pWindow && (!pWindow->isHidden() || pWindow->m_sGroupData.pNextWindow);
+bool IHyprLayout::isWindowReachable(PHLWINDOW pWindow) {
+    return pWindow && (!pWindow->isHidden() || pWindow->m_sGroupData.pNextWindow.lock());
 }
 
-void IHyprLayout::bringWindowToTop(CWindow* pWindow) {
+void IHyprLayout::bringWindowToTop(PHLWINDOW pWindow) {
     if (pWindow == nullptr)
         return;
 
-    if (pWindow->isHidden() && pWindow->m_sGroupData.pNextWindow) {
+    if (pWindow->isHidden() && pWindow->m_sGroupData.pNextWindow.lock()) {
         // grouped, change the current to this window
         pWindow->setGroupCurrent(pWindow);
     }
 }
 
-void IHyprLayout::requestFocusForWindow(CWindow* pWindow) {
+void IHyprLayout::requestFocusForWindow(PHLWINDOW pWindow) {
     bringWindowToTop(pWindow);
     g_pCompositor->focusWindow(pWindow);
     g_pCompositor->warpCursorTo(pWindow->middle());
 }
 
-Vector2D IHyprLayout::predictSizeForNewWindowFloating(CWindow* pWindow) { // get all rules, see if we have any size overrides.
+Vector2D IHyprLayout::predictSizeForNewWindowFloating(PHLWINDOW pWindow) { // get all rules, see if we have any size overrides.
     Vector2D sizeOverride = {};
     if (g_pCompositor->m_pLastMonitor) {
         for (auto& r : g_pConfigManager->getMatchingRules(pWindow, true, true)) {
@@ -674,7 +674,7 @@ Vector2D IHyprLayout::predictSizeForNewWindowFloating(CWindow* pWindow) { // get
     return sizeOverride;
 }
 
-Vector2D IHyprLayout::predictSizeForNewWindow(CWindow* pWindow) {
+Vector2D IHyprLayout::predictSizeForNewWindow(PHLWINDOW pWindow) {
     bool shouldBeFloated = g_pXWaylandManager->shouldBeFloated(pWindow, true);
 
     if (!shouldBeFloated) {

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -12,7 +12,7 @@ struct SWindowRenderLayoutHints {
 };
 
 struct SLayoutMessageHeader {
-    CWindow* pWindow = nullptr;
+    PHLWINDOW pWindow;
 };
 
 enum eFullscreenMode : int8_t;
@@ -44,21 +44,21 @@ class IHyprLayout {
         The layout HAS TO set the goal pos and size (anim mgr will use it)
         If !animationinprogress, then the anim mgr will not apply an anim.
     */
-    virtual void onWindowCreated(CWindow*, eDirection direction = DIRECTION_DEFAULT);
-    virtual void onWindowCreatedTiling(CWindow*, eDirection direction = DIRECTION_DEFAULT) = 0;
-    virtual void onWindowCreatedFloating(CWindow*);
+    virtual void onWindowCreated(PHLWINDOW, eDirection direction = DIRECTION_DEFAULT);
+    virtual void onWindowCreatedTiling(PHLWINDOW, eDirection direction = DIRECTION_DEFAULT) = 0;
+    virtual void onWindowCreatedFloating(PHLWINDOW);
 
     /*
         Return tiled status
     */
-    virtual bool isWindowTiled(CWindow*) = 0;
+    virtual bool isWindowTiled(PHLWINDOW) = 0;
 
     /*
         Called when a window is removed (unmapped)
     */
-    virtual void onWindowRemoved(CWindow*);
-    virtual void onWindowRemovedTiling(CWindow*) = 0;
-    virtual void onWindowRemovedFloating(CWindow*);
+    virtual void onWindowRemoved(PHLWINDOW);
+    virtual void onWindowRemovedTiling(PHLWINDOW) = 0;
+    virtual void onWindowRemovedFloating(PHLWINDOW);
     /*
         Called when the monitor requires a layout recalculation
         this usually means reserved area changes
@@ -69,12 +69,12 @@ class IHyprLayout {
         Called when the compositor requests a window
         to be recalculated, e.g. when pseudo is toggled.
     */
-    virtual void recalculateWindow(CWindow*) = 0;
+    virtual void recalculateWindow(PHLWINDOW) = 0;
 
     /*
         Called when a window is requested to be floated
     */
-    virtual void changeWindowFloatingMode(CWindow*);
+    virtual void changeWindowFloatingMode(PHLWINDOW);
     /*
         Called when a window is clicked on, beginning a drag
         this might be a resize, move, whatever the layout defines it
@@ -86,13 +86,13 @@ class IHyprLayout {
         Vector2D holds pixel values
         Optional pWindow for a specific window
     */
-    virtual void resizeActiveWindow(const Vector2D&, eRectCorner corner = CORNER_NONE, CWindow* pWindow = nullptr) = 0;
+    virtual void resizeActiveWindow(const Vector2D&, eRectCorner corner = CORNER_NONE, PHLWINDOW pWindow = nullptr) = 0;
     /*
         Called when a user requests a move of the current window by a vec
         Vector2D holds pixel values
         Optional pWindow for a specific window
     */
-    virtual void moveActiveWindow(const Vector2D&, CWindow* pWindow = nullptr);
+    virtual void moveActiveWindow(const Vector2D&, PHLWINDOW pWindow = nullptr);
     /*
         Called when a window is ended being dragged
         (mouse up)
@@ -110,7 +110,7 @@ class IHyprLayout {
         The layout sets all the fullscreen flags.
         It can either accept or ignore.
     */
-    virtual void fullscreenRequestForWindow(CWindow*, eFullscreenMode, bool) = 0;
+    virtual void fullscreenRequestForWindow(PHLWINDOW, eFullscreenMode, bool) = 0;
 
     /*
         Called when a dispatcher requests a custom message
@@ -124,25 +124,25 @@ class IHyprLayout {
         Called when the renderer requests any special draw flags for
         a specific window, e.g. border color for groups.
     */
-    virtual SWindowRenderLayoutHints requestRenderHints(CWindow*) = 0;
+    virtual SWindowRenderLayoutHints requestRenderHints(PHLWINDOW) = 0;
 
     /*
         Called when the user requests two windows to be swapped places.
         The layout is free to ignore.
     */
-    virtual void switchWindows(CWindow*, CWindow*) = 0;
+    virtual void switchWindows(PHLWINDOW, PHLWINDOW) = 0;
 
     /*
         Called when the user requests a window move in a direction.
         The layout is free to ignore.
     */
-    virtual void moveWindowTo(CWindow*, const std::string& direction, bool silent = false) = 0;
+    virtual void moveWindowTo(PHLWINDOW, const std::string& direction, bool silent = false) = 0;
 
     /*
         Called when the user requests to change the splitratio by or to X
         on a window
     */
-    virtual void alterSplitRatio(CWindow*, float, bool exact = false) = 0;
+    virtual void alterSplitRatio(PHLWINDOW, float, bool exact = false) = 0;
 
     /*
         Called when something wants the current layout's name
@@ -152,36 +152,36 @@ class IHyprLayout {
     /*
         Called for getting the next candidate for a focus
     */
-    virtual CWindow* getNextWindowCandidate(CWindow*);
+    virtual PHLWINDOW getNextWindowCandidate(PHLWINDOW);
 
     /*
         Internal: called when window focus changes
     */
-    virtual void onWindowFocusChange(CWindow*);
+    virtual void onWindowFocusChange(PHLWINDOW);
 
     /*
         Called for replacing any data a layout has for a new window
     */
-    virtual void replaceWindowDataWith(CWindow* from, CWindow* to) = 0;
+    virtual void replaceWindowDataWith(PHLWINDOW from, PHLWINDOW to) = 0;
 
     /*
         Determines if a window can be focused. If hidden this usually means the window is part of a group.
     */
-    virtual bool isWindowReachable(CWindow*);
+    virtual bool isWindowReachable(PHLWINDOW);
 
     /*
         Called before an attempt is made to focus a window.
         Brings the window to the top of any groups and ensures it is not hidden.
         If the window is unmapped following this call, the focus attempt will fail.
     */
-    virtual void bringWindowToTop(CWindow*);
+    virtual void bringWindowToTop(PHLWINDOW);
 
     /*
         Called via the foreign toplevel activation protocol.
         Focuses a window, bringing it to the top of its group if applicable.
         May be ignored.
     */
-    virtual void requestFocusForWindow(CWindow*);
+    virtual void requestFocusForWindow(PHLWINDOW);
 
     /*
         Called to predict the size of a newly opened window to send it a configure.
@@ -192,17 +192,17 @@ class IHyprLayout {
     /*
         Prefer not overriding, use predictSizeForNewWindowTiled.
     */
-    virtual Vector2D predictSizeForNewWindow(CWindow* pWindow);
-    virtual Vector2D predictSizeForNewWindowFloating(CWindow* pWindow);
+    virtual Vector2D predictSizeForNewWindow(PHLWINDOW pWindow);
+    virtual Vector2D predictSizeForNewWindowFloating(PHLWINDOW pWindow);
 
   private:
-    int         m_iMouseMoveEventCount;
-    Vector2D    m_vBeginDragXY;
-    Vector2D    m_vLastDragXY;
-    Vector2D    m_vBeginDragPositionXY;
-    Vector2D    m_vBeginDragSizeXY;
-    Vector2D    m_vDraggingWindowOriginalFloatSize;
-    eRectCorner m_eGrabbedCorner = CORNER_TOPLEFT;
+    int          m_iMouseMoveEventCount;
+    Vector2D     m_vBeginDragXY;
+    Vector2D     m_vLastDragXY;
+    Vector2D     m_vBeginDragPositionXY;
+    Vector2D     m_vBeginDragSizeXY;
+    Vector2D     m_vDraggingWindowOriginalFloatSize;
+    eRectCorner  m_eGrabbedCorner = CORNER_TOPLEFT;
 
-    CWindow*    m_pLastTiledWindow = nullptr;
+    PHLWINDOWREF m_pLastTiledWindow;
 };

--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -104,7 +104,7 @@ struct std::formatter<SMasterNodeData*, CharT> : std::formatter<CharT> {
         std::format_to(out, "[Node {:x}: workspace: {}, pos: {:j2}, size: {:j2}", (uintptr_t)node, node->workspaceID, node->position, node->size);
         if (node->isMaster)
             std::format_to(out, ", master");
-        if (node->pWindow.lock())
+        if (!node->pWindow.expired())
             std::format_to(out, ", window: {:x}", node->pWindow.lock());
         return std::format_to(out, "]");
     }

--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -20,23 +20,23 @@ enum eOrientation : uint8_t {
 };
 
 struct SMasterNodeData {
-    bool     isMaster   = false;
-    float    percMaster = 0.5f;
+    bool         isMaster   = false;
+    float        percMaster = 0.5f;
 
-    CWindow* pWindow = nullptr;
+    PHLWINDOWREF pWindow;
 
-    Vector2D position;
-    Vector2D size;
+    Vector2D     position;
+    Vector2D     size;
 
-    float    percSize = 1.f; // size multiplier for resizing children
+    float        percSize = 1.f; // size multiplier for resizing children
 
-    int      workspaceID = -1;
+    int          workspaceID = -1;
 
-    bool     ignoreFullscreenChecks = false;
+    bool         ignoreFullscreenChecks = false;
 
     //
     bool operator==(const SMasterNodeData& rhs) const {
-        return pWindow == rhs.pWindow;
+        return pWindow.lock() == rhs.pWindow.lock();
     }
 };
 
@@ -52,20 +52,20 @@ struct SMasterWorkspaceData {
 
 class CHyprMasterLayout : public IHyprLayout {
   public:
-    virtual void                     onWindowCreatedTiling(CWindow*, eDirection direction = DIRECTION_DEFAULT);
-    virtual void                     onWindowRemovedTiling(CWindow*);
-    virtual bool                     isWindowTiled(CWindow*);
+    virtual void                     onWindowCreatedTiling(PHLWINDOW, eDirection direction = DIRECTION_DEFAULT);
+    virtual void                     onWindowRemovedTiling(PHLWINDOW);
+    virtual bool                     isWindowTiled(PHLWINDOW);
     virtual void                     recalculateMonitor(const int&);
-    virtual void                     recalculateWindow(CWindow*);
-    virtual void                     resizeActiveWindow(const Vector2D&, eRectCorner corner = CORNER_NONE, CWindow* pWindow = nullptr);
-    virtual void                     fullscreenRequestForWindow(CWindow*, eFullscreenMode, bool);
+    virtual void                     recalculateWindow(PHLWINDOW);
+    virtual void                     resizeActiveWindow(const Vector2D&, eRectCorner corner = CORNER_NONE, PHLWINDOW pWindow = nullptr);
+    virtual void                     fullscreenRequestForWindow(PHLWINDOW, eFullscreenMode, bool);
     virtual std::any                 layoutMessage(SLayoutMessageHeader, std::string);
-    virtual SWindowRenderLayoutHints requestRenderHints(CWindow*);
-    virtual void                     switchWindows(CWindow*, CWindow*);
-    virtual void                     moveWindowTo(CWindow*, const std::string& dir, bool silent);
-    virtual void                     alterSplitRatio(CWindow*, float, bool);
+    virtual SWindowRenderLayoutHints requestRenderHints(PHLWINDOW);
+    virtual void                     switchWindows(PHLWINDOW, PHLWINDOW);
+    virtual void                     moveWindowTo(PHLWINDOW, const std::string& dir, bool silent);
+    virtual void                     alterSplitRatio(PHLWINDOW, float, bool);
     virtual std::string              getLayoutName();
-    virtual void                     replaceWindowDataWith(CWindow* from, CWindow* to);
+    virtual void                     replaceWindowDataWith(PHLWINDOW from, PHLWINDOW to);
     virtual Vector2D                 predictSizeForNewWindowTiled();
 
     virtual void                     onEnable();
@@ -83,11 +83,11 @@ class CHyprMasterLayout : public IHyprLayout {
     eOrientation                      getDynamicOrientation(PHLWORKSPACE);
     int                               getNodesOnWorkspace(const int&);
     void                              applyNodeDataToWindow(SMasterNodeData*);
-    SMasterNodeData*                  getNodeFromWindow(CWindow*);
+    SMasterNodeData*                  getNodeFromWindow(PHLWINDOW);
     SMasterNodeData*                  getMasterNodeOnWorkspace(const int&);
     SMasterWorkspaceData*             getMasterWorkspaceData(const int&);
     void                              calculateWorkspace(PHLWORKSPACE);
-    CWindow*                          getNextWindow(CWindow*, bool);
+    PHLWINDOW                         getNextWindow(PHLWINDOW, bool);
     int                               getMastersOnWorkspace(const int&);
 
     friend struct SMasterNodeData;
@@ -104,8 +104,8 @@ struct std::formatter<SMasterNodeData*, CharT> : std::formatter<CharT> {
         std::format_to(out, "[Node {:x}: workspace: {}, pos: {:j2}, size: {:j2}", (uintptr_t)node, node->workspaceID, node->position, node->size);
         if (node->isMaster)
             std::format_to(out, ", master");
-        if (node->pWindow)
-            std::format_to(out, ", window: {:x}", node->pWindow);
+        if (node->pWindow.lock())
+            std::format_to(out, ", window: {:x}", node->pWindow.lock());
         return std::format_to(out, "]");
     }
 };

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -4,6 +4,10 @@
 #include <csignal>
 #include <utility>
 
+#define SP std::shared_ptr
+#define UP std::unique_ptr
+#define WP std::weak_ptr
+
 #ifndef NDEBUG
 #ifdef HYPRLAND_DEBUG
 #define ISDEBUG true

--- a/src/managers/AnimationManager.hpp
+++ b/src/managers/AnimationManager.hpp
@@ -21,7 +21,7 @@ class CAnimationManager {
     void                                          addBezierWithName(std::string, const Vector2D&, const Vector2D&);
     void                                          removeAllBeziers();
 
-    void                                          onWindowPostCreateClose(CWindow*, bool close = false);
+    void                                          onWindowPostCreateClose(PHLWINDOW, bool close = false);
 
     bool                                          bezierExists(const std::string&);
     CBezierCurve*                                 getBezier(const std::string&);
@@ -50,8 +50,8 @@ class CAnimationManager {
     bool                                          m_bTickScheduled = false;
 
     // Anim stuff
-    void animationPopin(CWindow*, bool close = false, float minPerc = 0.f);
-    void animationSlide(CWindow*, std::string force = "", bool close = false);
+    void animationPopin(PHLWINDOW, bool close = false, float minPerc = 0.f);
+    void animationSlide(PHLWINDOW, std::string force = "", bool close = false);
 };
 
 inline std::unique_ptr<CAnimationManager> g_pAnimationManager;

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -35,7 +35,7 @@ static std::vector<std::pair<std::string, std::string>> getHyprlandLaunchEnv() {
     result.push_back(std::make_pair<>(
         "HL_INITIAL_WORKSPACE_TOKEN",
         g_pTokenManager->registerNewToken(
-            SInitialWorkspaceToken{nullptr, PMONITOR->activeSpecialWorkspace ? PMONITOR->activeSpecialWorkspace->getConfigName() : PMONITOR->activeWorkspace->getConfigName()},
+            SInitialWorkspaceToken{{}, PMONITOR->activeSpecialWorkspace ? PMONITOR->activeSpecialWorkspace->getConfigName() : PMONITOR->activeWorkspace->getConfigName()},
             std::chrono::months(1337))));
 
     return result;
@@ -225,12 +225,12 @@ bool CKeybindManager::ensureMouseBindState() {
     if (!m_bIsMouseBindActive)
         return false;
 
-    if (g_pInputManager->currentlyDraggedWindow) {
-        CWindow* lastDraggedWindow = g_pInputManager->currentlyDraggedWindow;
+    if (g_pInputManager->currentlyDraggedWindow.lock()) {
+        PHLWINDOW lastDraggedWindow = g_pInputManager->currentlyDraggedWindow.lock();
 
         m_bIsMouseBindActive = false;
         g_pLayoutManager->getCurrentLayout()->onEndDragWindow();
-        g_pInputManager->currentlyDraggedWindow = nullptr;
+        g_pInputManager->currentlyDraggedWindow.reset();
         g_pInputManager->dragMode               = MBIND_INVALID;
 
         g_pCompositor->updateWorkspaceWindows(lastDraggedWindow->workspaceID());
@@ -271,7 +271,7 @@ bool CKeybindManager::tryMoveFocusToMonitor(CMonitor* monitor) {
 
         g_pInputManager->m_pForcedFocus = PNEWWINDOW;
         g_pInputManager->simulateMouseMovement();
-        g_pInputManager->m_pForcedFocus = nullptr;
+        g_pInputManager->m_pForcedFocus.reset();
     } else {
         g_pCompositor->focusWindow(nullptr);
         g_pCompositor->warpCursorTo(monitor->middle());
@@ -281,8 +281,8 @@ bool CKeybindManager::tryMoveFocusToMonitor(CMonitor* monitor) {
     return true;
 }
 
-void CKeybindManager::switchToWindow(CWindow* PWINDOWTOCHANGETO) {
-    const auto PLASTWINDOW = g_pCompositor->m_pLastWindow;
+void CKeybindManager::switchToWindow(PHLWINDOW PWINDOWTOCHANGETO) {
+    const auto PLASTWINDOW = g_pCompositor->m_pLastWindow.lock();
 
     if (PWINDOWTOCHANGETO == PLASTWINDOW || !PWINDOWTOCHANGETO)
         return;
@@ -307,7 +307,7 @@ void CKeybindManager::switchToWindow(CWindow* PWINDOWTOCHANGETO) {
 
         g_pInputManager->m_pForcedFocus = PWINDOWTOCHANGETO;
         g_pInputManager->simulateMouseMovement();
-        g_pInputManager->m_pForcedFocus = nullptr;
+        g_pInputManager->m_pForcedFocus.reset();
 
         if (PLASTWINDOW && PLASTWINDOW->m_iMonitorID != PWINDOWTOCHANGETO->m_iMonitorID) {
             // event
@@ -851,7 +851,7 @@ uint64_t CKeybindManager::spawnRaw(std::string args) {
 }
 
 void CKeybindManager::killActive(std::string args) {
-    g_pCompositor->closeWindow(g_pCompositor->m_pLastWindow);
+    g_pCompositor->closeWindow(g_pCompositor->m_pLastWindow.lock());
 }
 
 void CKeybindManager::kill(std::string args) {
@@ -870,12 +870,12 @@ void CKeybindManager::clearKeybinds() {
 }
 
 static void toggleActiveFloatingCore(std::string args, std::optional<bool> floatState) {
-    CWindow* PWINDOW = nullptr;
+    PHLWINDOW PWINDOW = nullptr;
 
     if (args != "active" && args.length() > 1)
         PWINDOW = g_pCompositor->getWindowByRegex(args);
     else
-        PWINDOW = g_pCompositor->m_pLastWindow;
+        PWINDOW = g_pCompositor->m_pLastWindow.lock();
 
     if (!PWINDOW)
         return;
@@ -884,18 +884,18 @@ static void toggleActiveFloatingCore(std::string args, std::optional<bool> float
         return;
 
     // remove drag status
-    g_pInputManager->currentlyDraggedWindow = nullptr;
+    g_pInputManager->currentlyDraggedWindow.reset();
 
-    if (PWINDOW->m_sGroupData.pNextWindow && PWINDOW->m_sGroupData.pNextWindow != PWINDOW) {
+    if (PWINDOW->m_sGroupData.pNextWindow.lock() && PWINDOW->m_sGroupData.pNextWindow.lock() != PWINDOW) {
         const auto PCURRENT = PWINDOW->getGroupCurrent();
 
         PCURRENT->m_bIsFloating = !PCURRENT->m_bIsFloating;
         g_pLayoutManager->getCurrentLayout()->changeWindowFloatingMode(PCURRENT);
 
-        CWindow* curr = PCURRENT->m_sGroupData.pNextWindow;
+        PHLWINDOW curr = PCURRENT->m_sGroupData.pNextWindow.lock();
         while (curr != PCURRENT) {
             curr->m_bIsFloating = PCURRENT->m_bIsFloating;
-            curr                = curr->m_sGroupData.pNextWindow;
+            curr                = curr->m_sGroupData.pNextWindow.lock();
         }
     } else {
         PWINDOW->m_bIsFloating = !PWINDOW->m_bIsFloating;
@@ -921,7 +921,7 @@ void CKeybindManager::setActiveTiled(std::string args) {
 }
 
 void CKeybindManager::centerWindow(std::string args) {
-    const auto PWINDOW = g_pCompositor->m_pLastWindow;
+    const auto PWINDOW = g_pCompositor->m_pLastWindow.lock();
 
     if (!PWINDOW || !PWINDOW->m_bIsFloating || PWINDOW->m_bIsFullscreen)
         return;
@@ -937,7 +937,7 @@ void CKeybindManager::centerWindow(std::string args) {
 }
 
 void CKeybindManager::toggleActivePseudo(std::string args) {
-    const auto ACTIVEWINDOW = g_pCompositor->m_pLastWindow;
+    const auto ACTIVEWINDOW = g_pCompositor->m_pLastWindow.lock();
 
     if (!ACTIVEWINDOW)
         return;
@@ -1046,7 +1046,7 @@ void CKeybindManager::changeworkspace(std::string args) {
 }
 
 void CKeybindManager::fullscreenActive(std::string args) {
-    const auto PWINDOW = g_pCompositor->m_pLastWindow;
+    const auto PWINDOW = g_pCompositor->m_pLastWindow.lock();
 
     if (!PWINDOW)
         return;
@@ -1059,13 +1059,13 @@ void CKeybindManager::fullscreenActive(std::string args) {
 
 void CKeybindManager::moveActiveToWorkspace(std::string args) {
 
-    CWindow* PWINDOW = nullptr;
+    PHLWINDOW PWINDOW = nullptr;
 
     if (args.contains(',')) {
         PWINDOW = g_pCompositor->getWindowByRegex(args.substr(args.find_last_of(',') + 1));
         args    = args.substr(0, args.find_last_of(','));
     } else {
-        PWINDOW = g_pCompositor->m_pLastWindow;
+        PWINDOW = g_pCompositor->m_pLastWindow.lock();
     }
 
     if (!PWINDOW)
@@ -1119,7 +1119,7 @@ void CKeybindManager::moveActiveToWorkspace(std::string args) {
 }
 
 void CKeybindManager::moveActiveToWorkspaceSilent(std::string args) {
-    CWindow*   PWINDOW = nullptr;
+    PHLWINDOW   PWINDOW = nullptr;
 
     const auto ORIGINALARGS = args;
 
@@ -1127,7 +1127,7 @@ void CKeybindManager::moveActiveToWorkspaceSilent(std::string args) {
         PWINDOW = g_pCompositor->getWindowByRegex(args.substr(args.find_last_of(',') + 1));
         args    = args.substr(0, args.find_last_of(','));
     } else {
-        PWINDOW = g_pCompositor->m_pLastWindow;
+        PWINDOW = g_pCompositor->m_pLastWindow.lock();
     }
 
     if (!PWINDOW)
@@ -1157,7 +1157,7 @@ void CKeybindManager::moveActiveToWorkspaceSilent(std::string args) {
         g_pCompositor->moveWindowToWorkspaceSafe(PWINDOW, pWorkspace);
     }
 
-    if (PWINDOW == g_pCompositor->m_pLastWindow) {
+    if (PWINDOW == g_pCompositor->m_pLastWindow.lock()) {
         if (const auto PATCOORDS = g_pCompositor->vectorToWindowUnified(OLDMIDDLE, RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING, PWINDOW); PATCOORDS)
             g_pCompositor->focusWindow(PATCOORDS);
         else
@@ -1174,7 +1174,7 @@ void CKeybindManager::moveFocusTo(std::string args) {
         return;
     }
 
-    const auto PLASTWINDOW = g_pCompositor->m_pLastWindow;
+    const auto PLASTWINDOW = g_pCompositor->m_pLastWindow.lock();
     if (!PLASTWINDOW) {
         tryMoveFocusToMonitor(g_pCompositor->getMonitorInDirection(arg));
         return;
@@ -1208,8 +1208,8 @@ void CKeybindManager::moveFocusTo(std::string args) {
 
 void CKeybindManager::focusUrgentOrLast(std::string args) {
     const auto PWINDOWURGENT = g_pCompositor->getUrgentWindow();
-    const auto PWINDOWPREV   = g_pCompositor->m_pLastWindow ? (g_pCompositor->m_vWindowFocusHistory.size() < 2 ? nullptr : g_pCompositor->m_vWindowFocusHistory[1]) :
-                                                              (g_pCompositor->m_vWindowFocusHistory.empty() ? nullptr : g_pCompositor->m_vWindowFocusHistory[0]);
+    const auto PWINDOWPREV   = g_pCompositor->m_pLastWindow.lock() ? (g_pCompositor->m_vWindowFocusHistory.size() < 2 ? nullptr : g_pCompositor->m_vWindowFocusHistory[1].lock()) :
+                                                              (g_pCompositor->m_vWindowFocusHistory.empty() ? nullptr : g_pCompositor->m_vWindowFocusHistory[0].lock());
 
     if (!PWINDOWURGENT && !PWINDOWPREV)
         return;
@@ -1218,8 +1218,8 @@ void CKeybindManager::focusUrgentOrLast(std::string args) {
 }
 
 void CKeybindManager::focusCurrentOrLast(std::string args) {
-    const auto PWINDOWPREV = g_pCompositor->m_pLastWindow ? (g_pCompositor->m_vWindowFocusHistory.size() < 2 ? nullptr : g_pCompositor->m_vWindowFocusHistory[1]) :
-                                                            (g_pCompositor->m_vWindowFocusHistory.empty() ? nullptr : g_pCompositor->m_vWindowFocusHistory[0]);
+    const auto PWINDOWPREV = g_pCompositor->m_pLastWindow.lock() ? (g_pCompositor->m_vWindowFocusHistory.size() < 2 ? nullptr : g_pCompositor->m_vWindowFocusHistory[1].lock()) :
+                                                            (g_pCompositor->m_vWindowFocusHistory.empty() ? nullptr : g_pCompositor->m_vWindowFocusHistory[0].lock());
 
     if (!PWINDOWPREV)
         return;
@@ -1236,7 +1236,7 @@ void CKeybindManager::swapActive(std::string args) {
     }
 
     Debug::log(LOG, "Swapping active window in direction {}", arg);
-    const auto PLASTWINDOW = g_pCompositor->m_pLastWindow;
+    const auto PLASTWINDOW = g_pCompositor->m_pLastWindow.lock();
     if (!PLASTWINDOW || PLASTWINDOW->m_bIsFullscreen)
         return;
 
@@ -1270,7 +1270,7 @@ void CKeybindManager::moveActiveTo(std::string args) {
         return;
     }
 
-    const auto PLASTWINDOW = g_pCompositor->m_pLastWindow;
+    const auto PLASTWINDOW = g_pCompositor->m_pLastWindow.lock();
 
     if (!PLASTWINDOW || PLASTWINDOW->m_bIsFullscreen)
         return;
@@ -1315,29 +1315,29 @@ void CKeybindManager::moveActiveTo(std::string args) {
 }
 
 void CKeybindManager::toggleGroup(std::string args) {
-    const auto PWINDOW = g_pCompositor->m_pLastWindow;
+    const auto PWINDOW = g_pCompositor->m_pLastWindow.lock();
 
     if (!PWINDOW)
         return;
 
     g_pCompositor->setWindowFullscreen(PWINDOW, false, FULLSCREEN_FULL);
 
-    if (!PWINDOW->m_sGroupData.pNextWindow)
+    if (!PWINDOW->m_sGroupData.pNextWindow.lock())
         PWINDOW->createGroup();
     else
         PWINDOW->destroyGroup();
 }
 
 void CKeybindManager::changeGroupActive(std::string args) {
-    const auto PWINDOW = g_pCompositor->m_pLastWindow;
+    const auto PWINDOW = g_pCompositor->m_pLastWindow.lock();
 
     if (!PWINDOW)
         return;
 
-    if (!PWINDOW->m_sGroupData.pNextWindow)
+    if (!PWINDOW->m_sGroupData.pNextWindow.lock())
         return;
 
-    if (PWINDOW->m_sGroupData.pNextWindow == PWINDOW)
+    if (PWINDOW->m_sGroupData.pNextWindow.lock() == PWINDOW)
         return;
 
     if (isNumber(args, false)) {
@@ -1353,7 +1353,7 @@ void CKeybindManager::changeGroupActive(std::string args) {
     }
 
     if (args != "b" && args != "prev") {
-        PWINDOW->setGroupCurrent(PWINDOW->m_sGroupData.pNextWindow);
+        PWINDOW->setGroupCurrent(PWINDOW->m_sGroupData.pNextWindow.lock());
     } else {
         PWINDOW->setGroupCurrent(PWINDOW->getGroupPrevious());
     }
@@ -1361,7 +1361,7 @@ void CKeybindManager::changeGroupActive(std::string args) {
 
 void CKeybindManager::toggleSplit(std::string args) {
     SLayoutMessageHeader header;
-    header.pWindow = g_pCompositor->m_pLastWindow;
+    header.pWindow = g_pCompositor->m_pLastWindow.lock();
 
     if (!header.pWindow)
         return;
@@ -1376,7 +1376,7 @@ void CKeybindManager::toggleSplit(std::string args) {
 
 void CKeybindManager::swapSplit(std::string args) {
     SLayoutMessageHeader header;
-    header.pWindow = g_pCompositor->m_pLastWindow;
+    header.pWindow = g_pCompositor->m_pLastWindow.lock();
 
     if (!header.pWindow)
         return;
@@ -1404,7 +1404,7 @@ void CKeybindManager::alterSplitRatio(std::string args) {
         return;
     }
 
-    const auto PLASTWINDOW = g_pCompositor->m_pLastWindow;
+    const auto PLASTWINDOW = g_pCompositor->m_pLastWindow.lock();
 
     if (!PLASTWINDOW)
         return;
@@ -1430,7 +1430,7 @@ void CKeybindManager::moveCursorToCorner(std::string arg) {
         return;
     }
 
-    const auto PWINDOW = g_pCompositor->m_pLastWindow;
+    const auto PWINDOW = g_pCompositor->m_pLastWindow.lock();
 
     if (!PWINDOW)
         return;
@@ -1509,9 +1509,9 @@ void CKeybindManager::workspaceOpt(std::string args) {
         // apply
 
         // we make a copy because changeWindowFloatingMode might invalidate the iterator
-        std::deque<CWindow*> ptrs;
+        std::deque<PHLWINDOW> ptrs;
         for (auto& w : g_pCompositor->m_vWindows)
-            ptrs.push_back(w.get());
+            ptrs.push_back(w);
 
         for (auto& w : ptrs) {
             if (!w->m_bIsMapped || w->m_pWorkspace != PWORKSPACE || w->isHidden())
@@ -1719,27 +1719,31 @@ void CKeybindManager::forceRendererReload(std::string args) {
 }
 
 void CKeybindManager::resizeActive(std::string args) {
-    if (!g_pCompositor->m_pLastWindow || g_pCompositor->m_pLastWindow->m_bIsFullscreen)
+    const auto PLASTWINDOW = g_pCompositor->m_pLastWindow.lock();
+
+    if (!PLASTWINDOW || PLASTWINDOW->m_bIsFullscreen)
         return;
 
-    const auto SIZ = g_pCompositor->parseWindowVectorArgsRelative(args, g_pCompositor->m_pLastWindow->m_vRealSize.goal());
+    const auto SIZ = g_pCompositor->parseWindowVectorArgsRelative(args, PLASTWINDOW->m_vRealSize.goal());
 
     if (SIZ.x < 1 || SIZ.y < 1)
         return;
 
-    g_pLayoutManager->getCurrentLayout()->resizeActiveWindow(SIZ - g_pCompositor->m_pLastWindow->m_vRealSize.goal());
+    g_pLayoutManager->getCurrentLayout()->resizeActiveWindow(SIZ - PLASTWINDOW->m_vRealSize.goal());
 
-    if (g_pCompositor->m_pLastWindow->m_vRealSize.goal().x > 1 && g_pCompositor->m_pLastWindow->m_vRealSize.goal().y > 1)
-        g_pCompositor->m_pLastWindow->setHidden(false);
+    if (PLASTWINDOW->m_vRealSize.goal().x > 1 && PLASTWINDOW->m_vRealSize.goal().y > 1)
+        PLASTWINDOW->setHidden(false);
 }
 
 void CKeybindManager::moveActive(std::string args) {
-    if (!g_pCompositor->m_pLastWindow || g_pCompositor->m_pLastWindow->m_bIsFullscreen)
+    const auto PLASTWINDOW = g_pCompositor->m_pLastWindow.lock();
+
+    if (!PLASTWINDOW || PLASTWINDOW->m_bIsFullscreen)
         return;
 
-    const auto POS = g_pCompositor->parseWindowVectorArgsRelative(args, g_pCompositor->m_pLastWindow->m_vRealPosition.goal());
+    const auto POS = g_pCompositor->parseWindowVectorArgsRelative(args, PLASTWINDOW->m_vRealPosition.goal());
 
-    g_pLayoutManager->getCurrentLayout()->moveActiveWindow(POS - g_pCompositor->m_pLastWindow->m_vRealPosition.goal());
+    g_pLayoutManager->getCurrentLayout()->moveActiveWindow(POS - PLASTWINDOW->m_vRealPosition.goal());
 }
 
 void CKeybindManager::moveWindow(std::string args) {
@@ -1790,7 +1794,7 @@ void CKeybindManager::resizeWindow(std::string args) {
 
 void CKeybindManager::circleNext(std::string arg) {
 
-    if (!g_pCompositor->m_pLastWindow) {
+    if (!g_pCompositor->m_pLastWindow.lock()) {
         // if we have a clear focus, find the first window and get the next focusable.
         if (g_pCompositor->getWindowsOnWorkspace(g_pCompositor->m_pLastMonitor->activeWorkspaceID()) > 0) {
             const auto PWINDOW = g_pCompositor->getFirstWindowOnWorkspace(g_pCompositor->m_pLastMonitor->activeWorkspaceID());
@@ -1810,9 +1814,9 @@ void CKeybindManager::circleNext(std::string arg) {
         floatStatus = true;
 
     if (args.contains("prev") || args.contains("p") || args.contains("last") || args.contains("l"))
-        switchToWindow(g_pCompositor->getPrevWindowOnWorkspace(g_pCompositor->m_pLastWindow, true, floatStatus));
+        switchToWindow(g_pCompositor->getPrevWindowOnWorkspace(g_pCompositor->m_pLastWindow.lock(), true, floatStatus));
     else
-        switchToWindow(g_pCompositor->getNextWindowOnWorkspace(g_pCompositor->m_pLastWindow, true, floatStatus));
+        switchToWindow(g_pCompositor->getNextWindowOnWorkspace(g_pCompositor->m_pLastWindow.lock(), true, floatStatus));
 }
 
 void CKeybindManager::focusWindow(std::string regexp) {
@@ -1902,7 +1906,7 @@ void CKeybindManager::pass(std::string regexp) {
         return;
     }
 
-    const auto XWTOXW       = PWINDOW->m_bIsX11 && g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_bIsX11;
+    const auto XWTOXW       = PWINDOW->m_bIsX11 && g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow.lock()->m_bIsX11;
     const auto SL           = Vector2D(g_pCompositor->m_sSeat.seat->pointer_state.sx, g_pCompositor->m_sSeat.seat->pointer_state.sy);
     uint32_t   keycodes[32] = {0};
 
@@ -1961,12 +1965,12 @@ void CKeybindManager::pass(std::string regexp) {
 }
 
 void CKeybindManager::layoutmsg(std::string msg) {
-    SLayoutMessageHeader hd = {g_pCompositor->m_pLastWindow};
+    SLayoutMessageHeader hd = {g_pCompositor->m_pLastWindow.lock()};
     g_pLayoutManager->getCurrentLayout()->layoutMessage(hd, msg);
 }
 
 void CKeybindManager::toggleOpaque(std::string unused) {
-    const auto PWINDOW = g_pCompositor->m_pLastWindow;
+    const auto PWINDOW = g_pCompositor->m_pLastWindow.lock();
 
     if (!PWINDOW)
         return;
@@ -2009,16 +2013,16 @@ void CKeybindManager::dpms(std::string arg) {
 
 void CKeybindManager::swapnext(std::string arg) {
 
-    CWindow* toSwap = nullptr;
+    PHLWINDOW toSwap = nullptr;
 
-    if (!g_pCompositor->m_pLastWindow)
+    if (!g_pCompositor->m_pLastWindow.lock())
         return;
 
-    const auto PLASTWINDOW = g_pCompositor->m_pLastWindow;
+    const auto PLASTWINDOW = g_pCompositor->m_pLastWindow.lock();
 
-    const auto PLASTCYCLED = g_pCompositor->windowValidMapped(g_pCompositor->m_pLastWindow->m_pLastCycledWindow) &&
-            g_pCompositor->m_pLastWindow->m_pLastCycledWindow->m_pWorkspace == PLASTWINDOW->m_pWorkspace ?
-        g_pCompositor->m_pLastWindow->m_pLastCycledWindow :
+    const auto PLASTCYCLED = validMapped(g_pCompositor->m_pLastWindow.lock()->m_pLastCycledWindow) &&
+            g_pCompositor->m_pLastWindow.lock()->m_pLastCycledWindow.lock()->m_pWorkspace == PLASTWINDOW->m_pWorkspace ?
+        g_pCompositor->m_pLastWindow.lock()->m_pLastCycledWindow.lock() :
         nullptr;
 
     if (arg == "last" || arg == "l" || arg == "prev" || arg == "p")
@@ -2056,12 +2060,12 @@ void CKeybindManager::swapActiveWorkspaces(std::string args) {
 
 void CKeybindManager::pinActive(std::string args) {
 
-    CWindow* PWINDOW = nullptr;
+    PHLWINDOW PWINDOW = nullptr;
 
     if (args != "active" && args.length() > 1)
         PWINDOW = g_pCompositor->getWindowByRegex(args);
     else
-        PWINDOW = g_pCompositor->m_pLastWindow;
+        PWINDOW = g_pCompositor->m_pLastWindow.lock();
 
     if (!PWINDOW) {
         Debug::log(ERR, "pin: window not found");
@@ -2081,7 +2085,7 @@ void CKeybindManager::pinActive(std::string args) {
 
     PWORKSPACE->m_pLastFocusedWindow = g_pCompositor->vectorToWindowUnified(g_pInputManager->getMouseCoordsInternal(), RESERVED_EXTENTS | INPUT_EXTENTS);
 
-    g_pEventManager->postEvent(SHyprIPCEvent{"pin", std::format("{:x},{}", (uintptr_t)PWINDOW, (int)PWINDOW->m_bPinned)});
+    g_pEventManager->postEvent(SHyprIPCEvent{"pin", std::format("{:x},{}", (uintptr_t)PWINDOW.get(), (int)PWINDOW->m_bPinned)});
     EMIT_HOOK_EVENT("pin", PWINDOW);
 }
 
@@ -2094,12 +2098,12 @@ void CKeybindManager::mouse(std::string args) {
             g_pKeybindManager->m_bIsMouseBindActive = true;
 
             const auto mouseCoords = g_pInputManager->getMouseCoordsInternal();
-            CWindow*   pWindow     = g_pCompositor->vectorToWindowUnified(mouseCoords, RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING);
+            PHLWINDOW   pWindow     = g_pCompositor->vectorToWindowUnified(mouseCoords, RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING);
 
             if (pWindow && !pWindow->m_bIsFullscreen)
                 pWindow->checkInputOnDecos(INPUT_TYPE_DRAG_START, mouseCoords);
 
-            if (!g_pInputManager->currentlyDraggedWindow)
+            if (!g_pInputManager->currentlyDraggedWindow.lock())
                 g_pInputManager->currentlyDraggedWindow = pWindow;
 
             g_pInputManager->dragMode = MBIND_MOVE;
@@ -2107,9 +2111,9 @@ void CKeybindManager::mouse(std::string args) {
         } else {
             g_pKeybindManager->m_bIsMouseBindActive = false;
 
-            if (g_pInputManager->currentlyDraggedWindow) {
+            if (g_pInputManager->currentlyDraggedWindow.lock()) {
                 g_pLayoutManager->getCurrentLayout()->onEndDragWindow();
-                g_pInputManager->currentlyDraggedWindow = nullptr;
+                g_pInputManager->currentlyDraggedWindow.reset();
                 g_pInputManager->dragMode               = MBIND_INVALID;
             }
         }
@@ -2131,9 +2135,9 @@ void CKeybindManager::mouse(std::string args) {
         } else {
             g_pKeybindManager->m_bIsMouseBindActive = false;
 
-            if (g_pInputManager->currentlyDraggedWindow) {
+            if (g_pInputManager->currentlyDraggedWindow.lock()) {
                 g_pLayoutManager->getCurrentLayout()->onEndDragWindow();
-                g_pInputManager->currentlyDraggedWindow = nullptr;
+                g_pInputManager->currentlyDraggedWindow.reset();
                 g_pInputManager->dragMode               = MBIND_INVALID;
             }
         }
@@ -2141,8 +2145,8 @@ void CKeybindManager::mouse(std::string args) {
 }
 
 void CKeybindManager::bringActiveToTop(std::string args) {
-    if (g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_bIsFloating)
-        g_pCompositor->changeWindowZOrder(g_pCompositor->m_pLastWindow, true);
+    if (g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow.lock()->m_bIsFloating)
+        g_pCompositor->changeWindowZOrder(g_pCompositor->m_pLastWindow.lock(), true);
 }
 
 void CKeybindManager::alterZOrder(std::string args) {
@@ -2150,8 +2154,8 @@ void CKeybindManager::alterZOrder(std::string args) {
     const auto POSITION    = args.substr(0, args.find_first_of(','));
     auto       PWINDOW     = g_pCompositor->getWindowByRegex(WINDOWREGEX);
 
-    if (!PWINDOW && g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_bIsFloating)
-        PWINDOW = g_pCompositor->m_pLastWindow;
+    if (!PWINDOW && g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow.lock()->m_bIsFloating)
+        PWINDOW = g_pCompositor->m_pLastWindow.lock();
 
     if (!PWINDOW) {
         Debug::log(ERR, "alterZOrder: no window");
@@ -2171,10 +2175,10 @@ void CKeybindManager::alterZOrder(std::string args) {
 }
 
 void CKeybindManager::fakeFullscreenActive(std::string args) {
-    if (g_pCompositor->m_pLastWindow) {
+    if (g_pCompositor->m_pLastWindow.lock()) {
         // will also set the flag
-        g_pCompositor->m_pLastWindow->m_bFakeFullscreenState = !g_pCompositor->m_pLastWindow->m_bFakeFullscreenState;
-        g_pXWaylandManager->setWindowFullscreen(g_pCompositor->m_pLastWindow, g_pCompositor->m_pLastWindow->shouldSendFullscreenState());
+        g_pCompositor->m_pLastWindow.lock()->m_bFakeFullscreenState = !g_pCompositor->m_pLastWindow.lock()->m_bFakeFullscreenState;
+        g_pXWaylandManager->setWindowFullscreen(g_pCompositor->m_pLastWindow.lock(), g_pCompositor->m_pLastWindow.lock()->shouldSendFullscreenState());
     }
 }
 
@@ -2190,9 +2194,9 @@ void CKeybindManager::lockGroups(std::string args) {
 }
 
 void CKeybindManager::lockActiveGroup(std::string args) {
-    const auto PWINDOW = g_pCompositor->m_pLastWindow;
+    const auto PWINDOW = g_pCompositor->m_pLastWindow.lock();
 
-    if (!PWINDOW || !PWINDOW->m_sGroupData.pNextWindow)
+    if (!PWINDOW || !PWINDOW->m_sGroupData.pNextWindow.lock())
         return;
 
     const auto PHEAD = PWINDOW->getGroupHead();
@@ -2207,7 +2211,7 @@ void CKeybindManager::lockActiveGroup(std::string args) {
     g_pCompositor->updateWindowAnimatedDecorationValues(PWINDOW);
 }
 
-void CKeybindManager::moveWindowIntoGroup(CWindow* pWindow, CWindow* pWindowInDirection) {
+void CKeybindManager::moveWindowIntoGroup(PHLWINDOW pWindow, PHLWINDOW pWindowInDirection) {
     if (pWindow->m_sGroupData.deny)
         return;
 
@@ -2227,7 +2231,7 @@ void CKeybindManager::moveWindowIntoGroup(CWindow* pWindow, CWindow* pWindowInDi
         pWindow->addWindowDeco(std::make_unique<CHyprGroupBarDecoration>(pWindow));
 }
 
-void CKeybindManager::moveWindowOutOfGroup(CWindow* pWindow, const std::string& dir) {
+void CKeybindManager::moveWindowOutOfGroup(PHLWINDOW pWindow, const std::string& dir) {
     static auto BFOCUSREMOVEDWINDOW = CConfigValue<Hyprlang::INT>("group:focus_removed_window");
     const auto  PWINDOWPREV         = pWindow->getGroupPrevious();
     eDirection  direction;
@@ -2242,7 +2246,7 @@ void CKeybindManager::moveWindowOutOfGroup(CWindow* pWindow, const std::string& 
         default: direction = DIRECTION_DEFAULT;
     }
 
-    if (pWindow->m_sGroupData.pNextWindow == pWindow) {
+    if (pWindow->m_sGroupData.pNextWindow.lock() == pWindow) {
         pWindow->destroyGroup();
     } else {
         g_pLayoutManager->getCurrentLayout()->onWindowRemoved(pWindow);
@@ -2277,18 +2281,18 @@ void CKeybindManager::moveIntoGroup(std::string args) {
         return;
     }
 
-    const auto PWINDOW = g_pCompositor->m_pLastWindow;
+    const auto PWINDOW = g_pCompositor->m_pLastWindow.lock();
 
     if (!PWINDOW || PWINDOW->m_bIsFloating || PWINDOW->m_sGroupData.deny)
         return;
 
     auto PWINDOWINDIR = g_pCompositor->getWindowInDirection(PWINDOW, arg);
 
-    if (!PWINDOWINDIR || !PWINDOWINDIR->m_sGroupData.pNextWindow)
+    if (!PWINDOWINDIR || !PWINDOWINDIR->m_sGroupData.pNextWindow.lock())
         return;
 
     // Do not move window into locked group if binds:ignore_group_lock is false
-    if (!*PIGNOREGROUPLOCK && (PWINDOWINDIR->getGroupHead()->m_sGroupData.locked || (PWINDOW->m_sGroupData.pNextWindow && PWINDOW->getGroupHead()->m_sGroupData.locked)))
+    if (!*PIGNOREGROUPLOCK && (PWINDOWINDIR->getGroupHead()->m_sGroupData.locked || (PWINDOW->m_sGroupData.pNextWindow.lock() && PWINDOW->getGroupHead()->m_sGroupData.locked)))
         return;
 
     moveWindowIntoGroup(PWINDOW, PWINDOWINDIR);
@@ -2300,14 +2304,14 @@ void CKeybindManager::moveOutOfGroup(std::string args) {
     if (!*PIGNOREGROUPLOCK && g_pKeybindManager->m_bGroupsLocked)
         return;
 
-    CWindow* PWINDOW = nullptr;
+    PHLWINDOW PWINDOW = nullptr;
 
     if (args != "active" && args.length() > 1)
         PWINDOW = g_pCompositor->getWindowByRegex(args);
     else
-        PWINDOW = g_pCompositor->m_pLastWindow;
+        PWINDOW = g_pCompositor->m_pLastWindow.lock();
 
-    if (!PWINDOW || !PWINDOW->m_sGroupData.pNextWindow)
+    if (!PWINDOW || !PWINDOW->m_sGroupData.pNextWindow.lock())
         return;
 
     moveWindowOutOfGroup(PWINDOW);
@@ -2323,7 +2327,7 @@ void CKeybindManager::moveWindowOrGroup(std::string args) {
         return;
     }
 
-    const auto PWINDOW = g_pCompositor->m_pLastWindow;
+    const auto PWINDOW = g_pCompositor->m_pLastWindow.lock();
     if (!PWINDOW || PWINDOW->m_bIsFullscreen)
         return;
 
@@ -2334,12 +2338,12 @@ void CKeybindManager::moveWindowOrGroup(std::string args) {
 
     const auto PWINDOWINDIR = g_pCompositor->getWindowInDirection(PWINDOW, arg);
 
-    const bool ISWINDOWGROUP       = PWINDOW->m_sGroupData.pNextWindow;
+    const bool ISWINDOWGROUP       = PWINDOW->m_sGroupData.pNextWindow.lock().get();
     const bool ISWINDOWGROUPLOCKED = ISWINDOWGROUP && PWINDOW->getGroupHead()->m_sGroupData.locked;
-    const bool ISWINDOWGROUPSINGLE = ISWINDOWGROUP && PWINDOW->m_sGroupData.pNextWindow == PWINDOW;
+    const bool ISWINDOWGROUPSINGLE = ISWINDOWGROUP && PWINDOW->m_sGroupData.pNextWindow.lock() == PWINDOW;
 
     // note: PWINDOWINDIR is not null implies !PWINDOW->m_bIsFloating
-    if (PWINDOWINDIR && PWINDOWINDIR->m_sGroupData.pNextWindow) { // target is group
+    if (PWINDOWINDIR && PWINDOWINDIR->m_sGroupData.pNextWindow.lock()) { // target is group
         if (!*PIGNOREGROUPLOCK && (PWINDOWINDIR->getGroupHead()->m_sGroupData.locked || ISWINDOWGROUPLOCKED || PWINDOW->m_sGroupData.deny)) {
             g_pLayoutManager->getCurrentLayout()->moveWindowTo(PWINDOW, args);
             g_pCompositor->warpCursorTo(PWINDOW->middle());
@@ -2373,8 +2377,8 @@ void CKeybindManager::setIgnoreGroupLock(std::string args) {
 }
 
 void CKeybindManager::denyWindowFromGroup(std::string args) {
-    const auto PWINDOW = g_pCompositor->m_pLastWindow;
-    if (!PWINDOW || (PWINDOW && PWINDOW->m_sGroupData.pNextWindow))
+    const auto PWINDOW = g_pCompositor->m_pLastWindow.lock();
+    if (!PWINDOW || (PWINDOW && PWINDOW->m_sGroupData.pNextWindow.lock()))
         return;
 
     if (args == "toggle")
@@ -2401,14 +2405,16 @@ void CKeybindManager::global(std::string args) {
 void CKeybindManager::moveGroupWindow(std::string args) {
     const auto BACK = args == "b" || args == "prev";
 
-    if (!g_pCompositor->m_pLastWindow || !g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow)
+    const auto PLASTWINDOW = g_pCompositor->m_pLastWindow.lock();
+
+    if (!PLASTWINDOW || !PLASTWINDOW->m_sGroupData.pNextWindow.lock())
         return;
 
-    if ((!BACK && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow->m_sGroupData.head) || (BACK && g_pCompositor->m_pLastWindow->m_sGroupData.head)) {
-        std::swap(g_pCompositor->m_pLastWindow->m_sGroupData.head, g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow->m_sGroupData.head);
-        std::swap(g_pCompositor->m_pLastWindow->m_sGroupData.locked, g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow->m_sGroupData.locked);
+    if ((!BACK && PLASTWINDOW->m_sGroupData.pNextWindow.lock()->m_sGroupData.head) || (BACK && PLASTWINDOW->m_sGroupData.head)) {
+        std::swap(PLASTWINDOW->m_sGroupData.head, PLASTWINDOW->m_sGroupData.pNextWindow.lock()->m_sGroupData.head);
+        std::swap(PLASTWINDOW->m_sGroupData.locked, PLASTWINDOW->m_sGroupData.pNextWindow.lock()->m_sGroupData.locked);
     } else
-        g_pCompositor->m_pLastWindow->switchWithWindowInGroup(BACK ? g_pCompositor->m_pLastWindow->getGroupPrevious() : g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow);
+        PLASTWINDOW->switchWithWindowInGroup(BACK ? PLASTWINDOW->getGroupPrevious() : PLASTWINDOW->m_sGroupData.pNextWindow.lock());
 
-    g_pCompositor->m_pLastWindow->updateWindowDecos();
+    PLASTWINDOW->updateWindowDecos();
 }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -231,7 +231,7 @@ bool CKeybindManager::ensureMouseBindState() {
         m_bIsMouseBindActive = false;
         g_pLayoutManager->getCurrentLayout()->onEndDragWindow();
         g_pInputManager->currentlyDraggedWindow.reset();
-        g_pInputManager->dragMode               = MBIND_INVALID;
+        g_pInputManager->dragMode = MBIND_INVALID;
 
         g_pCompositor->updateWorkspaceWindows(lastDraggedWindow->workspaceID());
         g_pCompositor->updateWorkspaceSpecialRenderData(lastDraggedWindow->workspaceID());
@@ -1119,7 +1119,7 @@ void CKeybindManager::moveActiveToWorkspace(std::string args) {
 }
 
 void CKeybindManager::moveActiveToWorkspaceSilent(std::string args) {
-    PHLWINDOW   PWINDOW = nullptr;
+    PHLWINDOW  PWINDOW = nullptr;
 
     const auto ORIGINALARGS = args;
 
@@ -1209,7 +1209,7 @@ void CKeybindManager::moveFocusTo(std::string args) {
 void CKeybindManager::focusUrgentOrLast(std::string args) {
     const auto PWINDOWURGENT = g_pCompositor->getUrgentWindow();
     const auto PWINDOWPREV   = g_pCompositor->m_pLastWindow.lock() ? (g_pCompositor->m_vWindowFocusHistory.size() < 2 ? nullptr : g_pCompositor->m_vWindowFocusHistory[1].lock()) :
-                                                              (g_pCompositor->m_vWindowFocusHistory.empty() ? nullptr : g_pCompositor->m_vWindowFocusHistory[0].lock());
+                                                                     (g_pCompositor->m_vWindowFocusHistory.empty() ? nullptr : g_pCompositor->m_vWindowFocusHistory[0].lock());
 
     if (!PWINDOWURGENT && !PWINDOWPREV)
         return;
@@ -1219,7 +1219,7 @@ void CKeybindManager::focusUrgentOrLast(std::string args) {
 
 void CKeybindManager::focusCurrentOrLast(std::string args) {
     const auto PWINDOWPREV = g_pCompositor->m_pLastWindow.lock() ? (g_pCompositor->m_vWindowFocusHistory.size() < 2 ? nullptr : g_pCompositor->m_vWindowFocusHistory[1].lock()) :
-                                                            (g_pCompositor->m_vWindowFocusHistory.empty() ? nullptr : g_pCompositor->m_vWindowFocusHistory[0].lock());
+                                                                   (g_pCompositor->m_vWindowFocusHistory.empty() ? nullptr : g_pCompositor->m_vWindowFocusHistory[0].lock());
 
     if (!PWINDOWPREV)
         return;
@@ -2098,7 +2098,7 @@ void CKeybindManager::mouse(std::string args) {
             g_pKeybindManager->m_bIsMouseBindActive = true;
 
             const auto mouseCoords = g_pInputManager->getMouseCoordsInternal();
-            PHLWINDOW   pWindow     = g_pCompositor->vectorToWindowUnified(mouseCoords, RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING);
+            PHLWINDOW  pWindow     = g_pCompositor->vectorToWindowUnified(mouseCoords, RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING);
 
             if (pWindow && !pWindow->m_bIsFullscreen)
                 pWindow->checkInputOnDecos(INPUT_TYPE_DRAG_START, mouseCoords);
@@ -2114,7 +2114,7 @@ void CKeybindManager::mouse(std::string args) {
             if (g_pInputManager->currentlyDraggedWindow.lock()) {
                 g_pLayoutManager->getCurrentLayout()->onEndDragWindow();
                 g_pInputManager->currentlyDraggedWindow.reset();
-                g_pInputManager->dragMode               = MBIND_INVALID;
+                g_pInputManager->dragMode = MBIND_INVALID;
             }
         }
     } else if (ARGS[0] == "resizewindow") {
@@ -2138,7 +2138,7 @@ void CKeybindManager::mouse(std::string args) {
             if (g_pInputManager->currentlyDraggedWindow.lock()) {
                 g_pLayoutManager->getCurrentLayout()->onEndDragWindow();
                 g_pInputManager->currentlyDraggedWindow.reset();
-                g_pInputManager->dragMode               = MBIND_INVALID;
+                g_pInputManager->dragMode = MBIND_INVALID;
             }
         }
     }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -225,7 +225,7 @@ bool CKeybindManager::ensureMouseBindState() {
     if (!m_bIsMouseBindActive)
         return false;
 
-    if (g_pInputManager->currentlyDraggedWindow.lock()) {
+    if (!g_pInputManager->currentlyDraggedWindow.expired()) {
         PHLWINDOW lastDraggedWindow = g_pInputManager->currentlyDraggedWindow.lock();
 
         m_bIsMouseBindActive = false;
@@ -1322,7 +1322,7 @@ void CKeybindManager::toggleGroup(std::string args) {
 
     g_pCompositor->setWindowFullscreen(PWINDOW, false, FULLSCREEN_FULL);
 
-    if (!PWINDOW->m_sGroupData.pNextWindow.lock())
+    if (PWINDOW->m_sGroupData.pNextWindow.expired())
         PWINDOW->createGroup();
     else
         PWINDOW->destroyGroup();
@@ -1334,7 +1334,7 @@ void CKeybindManager::changeGroupActive(std::string args) {
     if (!PWINDOW)
         return;
 
-    if (!PWINDOW->m_sGroupData.pNextWindow.lock())
+    if (PWINDOW->m_sGroupData.pNextWindow.expired())
         return;
 
     if (PWINDOW->m_sGroupData.pNextWindow.lock() == PWINDOW)
@@ -1794,7 +1794,7 @@ void CKeybindManager::resizeWindow(std::string args) {
 
 void CKeybindManager::circleNext(std::string arg) {
 
-    if (!g_pCompositor->m_pLastWindow.lock()) {
+    if (g_pCompositor->m_pLastWindow.expired()) {
         // if we have a clear focus, find the first window and get the next focusable.
         if (g_pCompositor->getWindowsOnWorkspace(g_pCompositor->m_pLastMonitor->activeWorkspaceID()) > 0) {
             const auto PWINDOW = g_pCompositor->getFirstWindowOnWorkspace(g_pCompositor->m_pLastMonitor->activeWorkspaceID());
@@ -2015,7 +2015,7 @@ void CKeybindManager::swapnext(std::string arg) {
 
     PHLWINDOW toSwap = nullptr;
 
-    if (!g_pCompositor->m_pLastWindow.lock())
+    if (g_pCompositor->m_pLastWindow.expired())
         return;
 
     const auto PLASTWINDOW = g_pCompositor->m_pLastWindow.lock();
@@ -2103,7 +2103,7 @@ void CKeybindManager::mouse(std::string args) {
             if (pWindow && !pWindow->m_bIsFullscreen)
                 pWindow->checkInputOnDecos(INPUT_TYPE_DRAG_START, mouseCoords);
 
-            if (!g_pInputManager->currentlyDraggedWindow.lock())
+            if (g_pInputManager->currentlyDraggedWindow.expired())
                 g_pInputManager->currentlyDraggedWindow = pWindow;
 
             g_pInputManager->dragMode = MBIND_MOVE;
@@ -2111,7 +2111,7 @@ void CKeybindManager::mouse(std::string args) {
         } else {
             g_pKeybindManager->m_bIsMouseBindActive = false;
 
-            if (g_pInputManager->currentlyDraggedWindow.lock()) {
+            if (!g_pInputManager->currentlyDraggedWindow.expired()) {
                 g_pLayoutManager->getCurrentLayout()->onEndDragWindow();
                 g_pInputManager->currentlyDraggedWindow.reset();
                 g_pInputManager->dragMode = MBIND_INVALID;
@@ -2135,7 +2135,7 @@ void CKeybindManager::mouse(std::string args) {
         } else {
             g_pKeybindManager->m_bIsMouseBindActive = false;
 
-            if (g_pInputManager->currentlyDraggedWindow.lock()) {
+            if (!g_pInputManager->currentlyDraggedWindow.expired()) {
                 g_pLayoutManager->getCurrentLayout()->onEndDragWindow();
                 g_pInputManager->currentlyDraggedWindow.reset();
                 g_pInputManager->dragMode = MBIND_INVALID;
@@ -2175,7 +2175,7 @@ void CKeybindManager::alterZOrder(std::string args) {
 }
 
 void CKeybindManager::fakeFullscreenActive(std::string args) {
-    if (g_pCompositor->m_pLastWindow.lock()) {
+    if (!g_pCompositor->m_pLastWindow.expired()) {
         // will also set the flag
         g_pCompositor->m_pLastWindow.lock()->m_bFakeFullscreenState = !g_pCompositor->m_pLastWindow.lock()->m_bFakeFullscreenState;
         g_pXWaylandManager->setWindowFullscreen(g_pCompositor->m_pLastWindow.lock(), g_pCompositor->m_pLastWindow.lock()->shouldSendFullscreenState());

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -111,9 +111,9 @@ class CKeybindManager {
     bool                            ensureMouseBindState();
 
     static bool                     tryMoveFocusToMonitor(CMonitor* monitor);
-    static void                     moveWindowOutOfGroup(CWindow* pWindow, const std::string& dir = "");
-    static void                     moveWindowIntoGroup(CWindow* pWindow, CWindow* pWindowInDirection);
-    static void                     switchToWindow(CWindow* PWINDOWTOCHANGETO);
+    static void                     moveWindowOutOfGroup(PHLWINDOW pWindow, const std::string& dir = "");
+    static void                     moveWindowIntoGroup(PHLWINDOW pWindow, PHLWINDOW pWindowInDirection);
+    static void                     switchToWindow(PHLWINDOW PWINDOWTOCHANGETO);
 
     // -------------- Dispatchers -------------- //
     static void     killActive(std::string);

--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -29,7 +29,7 @@ CHyprXWaylandManager::CHyprXWaylandManager() {
 
 CHyprXWaylandManager::~CHyprXWaylandManager() {}
 
-wlr_surface* CHyprXWaylandManager::getWindowSurface(CWindow* pWindow) {
+wlr_surface* CHyprXWaylandManager::getWindowSurface(PHLWINDOW pWindow) {
     if (pWindow->m_bIsX11)
         return pWindow->m_uSurface.xwayland->surface;
 
@@ -53,7 +53,7 @@ void CHyprXWaylandManager::activateSurface(wlr_surface* pSurface, bool activate)
     }
 }
 
-void CHyprXWaylandManager::activateWindow(CWindow* pWindow, bool activate) {
+void CHyprXWaylandManager::activateWindow(PHLWINDOW pWindow, bool activate) {
     if (pWindow->m_bIsX11) {
         setWindowSize(pWindow, pWindow->m_vRealSize.value()); // update xwayland output pos
 
@@ -76,7 +76,7 @@ void CHyprXWaylandManager::activateWindow(CWindow* pWindow, bool activate) {
         pWindow->m_pWorkspace->m_pLastFocusedWindow = pWindow;
 }
 
-void CHyprXWaylandManager::getGeometryForWindow(CWindow* pWindow, CBox* pbox) {
+void CHyprXWaylandManager::getGeometryForWindow(PHLWINDOW pWindow, CBox* pbox) {
     if (pWindow->m_bIsX11) {
         const auto SIZEHINTS = pWindow->m_uSurface.xwayland->size_hints;
 
@@ -97,7 +97,7 @@ void CHyprXWaylandManager::getGeometryForWindow(CWindow* pWindow, CBox* pbox) {
     }
 }
 
-std::string CHyprXWaylandManager::getTitle(CWindow* pWindow) {
+std::string CHyprXWaylandManager::getTitle(PHLWINDOW pWindow) {
     try {
         if (pWindow->m_bIsX11) {
             if (!pWindow->m_bIsMapped)
@@ -121,7 +121,7 @@ std::string CHyprXWaylandManager::getTitle(CWindow* pWindow) {
     return "";
 }
 
-std::string CHyprXWaylandManager::getAppIDClass(CWindow* pWindow) {
+std::string CHyprXWaylandManager::getAppIDClass(PHLWINDOW pWindow) {
     try {
         if (pWindow->m_bIsX11) {
             if (!pWindow->m_bIsMapped)
@@ -144,14 +144,14 @@ std::string CHyprXWaylandManager::getAppIDClass(CWindow* pWindow) {
     return "";
 }
 
-void CHyprXWaylandManager::sendCloseWindow(CWindow* pWindow) {
+void CHyprXWaylandManager::sendCloseWindow(PHLWINDOW pWindow) {
     if (pWindow->m_bIsX11)
         wlr_xwayland_surface_close(pWindow->m_uSurface.xwayland);
     else
         wlr_xdg_toplevel_send_close(pWindow->m_uSurface.xdg->toplevel);
 }
 
-void CHyprXWaylandManager::setWindowSize(CWindow* pWindow, Vector2D size, bool force) {
+void CHyprXWaylandManager::setWindowSize(PHLWINDOW pWindow, Vector2D size, bool force) {
 
     static auto PXWLFORCESCALEZERO = CConfigValue<Hyprlang::INT>("xwayland:force_zero_scaling");
 
@@ -189,7 +189,7 @@ void CHyprXWaylandManager::setWindowSize(CWindow* pWindow, Vector2D size, bool f
         pWindow->m_vPendingSizeAcks.push_back(std::make_pair<>(wlr_xdg_toplevel_set_size(pWindow->m_uSurface.xdg->toplevel, size.x, size.y), size.floor()));
 }
 
-void CHyprXWaylandManager::setWindowStyleTiled(CWindow* pWindow, uint32_t edgez) {
+void CHyprXWaylandManager::setWindowStyleTiled(PHLWINDOW pWindow, uint32_t edgez) {
     if (pWindow->m_bIsX11)
         return;
 
@@ -197,14 +197,14 @@ void CHyprXWaylandManager::setWindowStyleTiled(CWindow* pWindow, uint32_t edgez)
     wlr_xdg_toplevel_set_maximized(pWindow->m_uSurface.xdg->toplevel, true);
 }
 
-wlr_surface* CHyprXWaylandManager::surfaceAt(CWindow* pWindow, const Vector2D& client, Vector2D& surface) {
+wlr_surface* CHyprXWaylandManager::surfaceAt(PHLWINDOW pWindow, const Vector2D& client, Vector2D& surface) {
     if (pWindow->m_bIsX11)
         return wlr_surface_surface_at(pWindow->m_uSurface.xwayland->surface, client.x, client.y, &surface.x, &surface.y);
 
     return wlr_xdg_surface_surface_at(pWindow->m_uSurface.xdg, client.x, client.y, &surface.x, &surface.y);
 }
 
-bool CHyprXWaylandManager::shouldBeFloated(CWindow* pWindow, bool pending) {
+bool CHyprXWaylandManager::shouldBeFloated(PHLWINDOW pWindow, bool pending) {
     if (pWindow->m_bIsX11) {
         for (size_t i = 0; i < pWindow->m_uSurface.xwayland->window_type_len; i++)
             if (pWindow->m_uSurface.xwayland->window_type[i] == HYPRATOMS["_NET_WM_WINDOW_TYPE_DIALOG"] ||
@@ -257,8 +257,8 @@ bool CHyprXWaylandManager::shouldBeFloated(CWindow* pWindow, bool pending) {
     return false;
 }
 
-void CHyprXWaylandManager::moveXWaylandWindow(CWindow* pWindow, const Vector2D& pos) {
-    if (!g_pCompositor->windowValidMapped(pWindow))
+void CHyprXWaylandManager::moveXWaylandWindow(PHLWINDOW pWindow, const Vector2D& pos) {
+    if (!validMapped(pWindow))
         return;
 
     if (!pWindow->m_bIsX11)
@@ -267,7 +267,7 @@ void CHyprXWaylandManager::moveXWaylandWindow(CWindow* pWindow, const Vector2D& 
     wlr_xwayland_surface_configure(pWindow->m_uSurface.xwayland, pos.x, pos.y, pWindow->m_vRealSize.value().x, pWindow->m_vRealSize.value().y);
 }
 
-void CHyprXWaylandManager::checkBorders(CWindow* pWindow) {
+void CHyprXWaylandManager::checkBorders(PHLWINDOW pWindow) {
     if (!pWindow->m_bIsX11)
         return;
 
@@ -290,15 +290,15 @@ void CHyprXWaylandManager::checkBorders(CWindow* pWindow) {
     }
 }
 
-void CHyprXWaylandManager::setWindowFullscreen(CWindow* pWindow, bool fullscreen) {
+void CHyprXWaylandManager::setWindowFullscreen(PHLWINDOW pWindow, bool fullscreen) {
     if (pWindow->m_bIsX11)
         wlr_xwayland_surface_set_fullscreen(pWindow->m_uSurface.xwayland, fullscreen);
     else
         wlr_xdg_toplevel_set_fullscreen(pWindow->m_uSurface.xdg->toplevel, fullscreen);
 }
 
-Vector2D CHyprXWaylandManager::getMaxSizeForWindow(CWindow* pWindow) {
-    if (!g_pCompositor->windowValidMapped(pWindow))
+Vector2D CHyprXWaylandManager::getMaxSizeForWindow(PHLWINDOW pWindow) {
+    if (!validMapped(pWindow))
         return Vector2D(99999, 99999);
 
     if ((pWindow->m_bIsX11 && !pWindow->m_uSurface.xwayland->size_hints) || (!pWindow->m_bIsX11 && !pWindow->m_uSurface.xdg->toplevel) ||
@@ -316,8 +316,8 @@ Vector2D CHyprXWaylandManager::getMaxSizeForWindow(CWindow* pWindow) {
     return MAXSIZE;
 }
 
-Vector2D CHyprXWaylandManager::getMinSizeForWindow(CWindow* pWindow) {
-    if (!g_pCompositor->windowValidMapped(pWindow))
+Vector2D CHyprXWaylandManager::getMinSizeForWindow(PHLWINDOW pWindow) {
+    if (!validMapped(pWindow))
         return Vector2D(0, 0);
 
     if ((pWindow->m_bIsX11 && !pWindow->m_uSurface.xwayland->size_hints) || (!pWindow->m_bIsX11 && !pWindow->m_uSurface.xdg->toplevel))

--- a/src/managers/XWaylandManager.hpp
+++ b/src/managers/XWaylandManager.hpp
@@ -4,6 +4,7 @@
 #include <optional>
 
 class CWindow; // because clangd
+typedef SP<CWindow> PHLWINDOW;
 
 class CHyprXWaylandManager {
   public:
@@ -12,22 +13,22 @@ class CHyprXWaylandManager {
 
     wlr_xwayland* m_sWLRXWayland = nullptr;
 
-    wlr_surface*  getWindowSurface(CWindow*);
+    wlr_surface*  getWindowSurface(PHLWINDOW);
     void          activateSurface(wlr_surface*, bool);
-    void          activateWindow(CWindow*, bool);
-    void          getGeometryForWindow(CWindow*, CBox*);
-    std::string   getTitle(CWindow*);
-    std::string   getAppIDClass(CWindow*);
-    void          sendCloseWindow(CWindow*);
-    void          setWindowSize(CWindow*, Vector2D, bool force = false);
-    void          setWindowStyleTiled(CWindow*, uint32_t);
-    void          setWindowFullscreen(CWindow*, bool);
-    wlr_surface*  surfaceAt(CWindow*, const Vector2D&, Vector2D&);
-    bool          shouldBeFloated(CWindow*, bool pending = false);
-    void          moveXWaylandWindow(CWindow*, const Vector2D&);
-    void          checkBorders(CWindow*);
-    Vector2D      getMaxSizeForWindow(CWindow*);
-    Vector2D      getMinSizeForWindow(CWindow*);
+    void          activateWindow(PHLWINDOW, bool);
+    void          getGeometryForWindow(PHLWINDOW, CBox*);
+    std::string   getTitle(PHLWINDOW);
+    std::string   getAppIDClass(PHLWINDOW);
+    void          sendCloseWindow(PHLWINDOW);
+    void          setWindowSize(PHLWINDOW, Vector2D, bool force = false);
+    void          setWindowStyleTiled(PHLWINDOW, uint32_t);
+    void          setWindowFullscreen(PHLWINDOW, bool);
+    wlr_surface*  surfaceAt(PHLWINDOW, const Vector2D&, Vector2D&);
+    bool          shouldBeFloated(PHLWINDOW, bool pending = false);
+    void          moveXWaylandWindow(PHLWINDOW, const Vector2D&);
+    void          checkBorders(PHLWINDOW);
+    Vector2D      getMaxSizeForWindow(PHLWINDOW);
+    Vector2D      getMinSizeForWindow(PHLWINDOW);
     Vector2D      xwaylandToWaylandCoords(const Vector2D&);
 };
 

--- a/src/managers/input/IdleInhibitor.cpp
+++ b/src/managers/input/IdleInhibitor.cpp
@@ -29,7 +29,7 @@ void CInputManager::newIdleInhibitor(std::any inhibitor) {
 void CInputManager::recheckIdleInhibitorStatus() {
 
     for (auto& ii : m_vIdleInhibitors) {
-        if (!ii->pWindow.lock()) {
+        if (ii->pWindow.expired()) {
             g_pCompositor->setIdleActivityInhibit(false);
             return;
         } else if (g_pHyprRenderer->shouldRenderWindow(ii->pWindow.lock())) {

--- a/src/managers/input/IdleInhibitor.cpp
+++ b/src/managers/input/IdleInhibitor.cpp
@@ -19,7 +19,7 @@ void CInputManager::newIdleInhibitor(std::any inhibitor) {
         PINHIBIT->pWindow               = PWINDOW;
         PINHIBIT->windowDestroyListener = PWINDOW->events.destroy.registerListener([PINHIBIT](std::any data) {
             Debug::log(WARN, "Inhibitor got its window destroyed before its inhibitor resource.");
-            PINHIBIT->pWindow = nullptr;
+            PINHIBIT->pWindow.reset();
         });
     } else
         Debug::log(WARN, "Inhibitor is for no window?");
@@ -29,10 +29,10 @@ void CInputManager::newIdleInhibitor(std::any inhibitor) {
 void CInputManager::recheckIdleInhibitorStatus() {
 
     for (auto& ii : m_vIdleInhibitors) {
-        if (!ii->pWindow) {
+        if (!ii->pWindow.lock()) {
             g_pCompositor->setIdleActivityInhibit(false);
             return;
-        } else if (g_pHyprRenderer->shouldRenderWindow(ii->pWindow)) {
+        } else if (g_pHyprRenderer->shouldRenderWindow(ii->pWindow.lock())) {
             g_pCompositor->setIdleActivityInhibit(false);
             return;
         }
@@ -48,7 +48,7 @@ void CInputManager::recheckIdleInhibitorStatus() {
             return;
         }
 
-        if (w->m_eIdleInhibitMode == IDLEINHIBIT_FOCUS && g_pCompositor->isWindowActive(w.get())) {
+        if (w->m_eIdleInhibitMode == IDLEINHIBIT_FOCUS && g_pCompositor->isWindowActive(w)) {
             g_pCompositor->setIdleActivityInhibit(false);
             return;
         }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -118,13 +118,13 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
 
     const auto  FOLLOWMOUSE = *PFOLLOWONDND && m_sDrag.drag ? 1 : *PFOLLOWMOUSE;
 
-    m_pFoundSurfaceToFocus      = nullptr;
-    m_pFoundLSToFocus           = nullptr;
+    m_pFoundSurfaceToFocus = nullptr;
+    m_pFoundLSToFocus      = nullptr;
     m_pFoundWindowToFocus.reset();
     wlr_surface*   foundSurface = nullptr;
     Vector2D       surfaceCoords;
-    Vector2D       surfacePos         = Vector2D(-1337, -1337);
-    PHLWINDOW       pFoundWindow;
+    Vector2D       surfacePos = Vector2D(-1337, -1337);
+    PHLWINDOW      pFoundWindow;
     SLayerSurface* pFoundLayerSurface = nullptr;
 
     if (!g_pCompositor->m_bReadyToProcess || g_pCompositor->m_bIsShuttingDown || g_pCompositor->m_bUnsafeState)
@@ -419,7 +419,8 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
 
         if (FOLLOWMOUSE != 1 && !refocus) {
             if (pFoundWindow != g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow.lock() &&
-                ((pFoundWindow->m_bIsFloating && *PFLOATBEHAVIOR == 2) || (g_pCompositor->m_pLastWindow.lock()->m_bIsFloating != pFoundWindow->m_bIsFloating && *PFLOATBEHAVIOR != 0))) {
+                ((pFoundWindow->m_bIsFloating && *PFLOATBEHAVIOR == 2) ||
+                 (g_pCompositor->m_pLastWindow.lock()->m_bIsFloating != pFoundWindow->m_bIsFloating && *PFLOATBEHAVIOR != 0))) {
                 // enter if change floating style
                 if (FOLLOWMOUSE != 3 && allowKeyboardRefocus)
                     g_pCompositor->focusWindow(pFoundWindow, foundSurface);

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -213,7 +213,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
                 surfacePos              = foundPopup->globalBox().pos();
                 m_bFocusHeldByButtons   = true;
                 m_bRefocusHeldByButtons = refocus;
-            } else if (g_pCompositor->m_pLastWindow.lock()) {
+            } else if (!g_pCompositor->m_pLastWindow.expired()) {
                 foundSurface = m_pLastMouseSurface;
                 pFoundWindow = g_pCompositor->m_pLastWindow.lock();
 
@@ -226,7 +226,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
 
     g_pLayoutManager->getCurrentLayout()->onMouseMove(getMouseCoordsInternal());
 
-    if (PMONITOR && PMONITOR != g_pCompositor->m_pLastMonitor && (*PMOUSEFOCUSMON || refocus) && !m_pForcedFocus.lock())
+    if (PMONITOR && PMONITOR != g_pCompositor->m_pLastMonitor && (*PMOUSEFOCUSMON || refocus) && m_pForcedFocus.expired())
         g_pCompositor->setActiveMonitor(PMONITOR);
 
     if (g_pSessionLockManager->isSessionLocked()) {
@@ -356,7 +356,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
         wlr_seat_pointer_clear_focus(g_pCompositor->m_sSeat.seat);
         m_pLastMouseSurface = nullptr;
 
-        if (refocus || !g_pCompositor->m_pLastWindow.lock()) // if we are forcing a refocus, and we don't find a surface, clear the kb focus too!
+        if (refocus || g_pCompositor->m_pLastWindow.expired()) // if we are forcing a refocus, and we don't find a surface, clear the kb focus too!
             g_pCompositor->focusWindow(nullptr);
 
         return;
@@ -1637,7 +1637,7 @@ void CInputManager::setCursorIconOnBorder(PHLWINDOW w) {
 
     if (w->hasPopupAt(mouseCoords))
         direction = BORDERICON_NONE;
-    else if (!boxFullGrabInput.containsPoint(mouseCoords) || (!m_lCurrentlyHeldButtons.empty() && !currentlyDraggedWindow.lock()))
+    else if (!boxFullGrabInput.containsPoint(mouseCoords) || (!m_lCurrentlyHeldButtons.empty() && currentlyDraggedWindow.expired()))
         direction = BORDERICON_NONE;
     else {
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -120,11 +120,11 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
 
     m_pFoundSurfaceToFocus      = nullptr;
     m_pFoundLSToFocus           = nullptr;
-    m_pFoundWindowToFocus       = nullptr;
+    m_pFoundWindowToFocus.reset();
     wlr_surface*   foundSurface = nullptr;
     Vector2D       surfaceCoords;
     Vector2D       surfacePos         = Vector2D(-1337, -1337);
-    CWindow*       pFoundWindow       = nullptr;
+    PHLWINDOW       pFoundWindow;
     SLayerSurface* pFoundLayerSurface = nullptr;
 
     if (!g_pCompositor->m_bReadyToProcess || g_pCompositor->m_bIsShuttingDown || g_pCompositor->m_bUnsafeState)
@@ -157,10 +157,10 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
     if (*PZOOMFACTOR != 1.f)
         g_pHyprRenderer->damageMonitor(PMONITOR);
 
-    if (!PMONITOR->solitaryClient && g_pHyprRenderer->shouldRenderCursor() && PMONITOR->output->software_cursor_locks > 0)
+    if (!PMONITOR->solitaryClient.lock() && g_pHyprRenderer->shouldRenderCursor() && PMONITOR->output->software_cursor_locks > 0)
         g_pCompositor->scheduleFrameForMonitor(PMONITOR);
 
-    CWindow* forcedFocus = m_pForcedFocus;
+    PHLWINDOW forcedFocus = m_pForcedFocus.lock();
 
     if (!forcedFocus)
         forcedFocus = g_pCompositor->getForceFocus();
@@ -213,9 +213,9 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
                 surfacePos              = foundPopup->globalBox().pos();
                 m_bFocusHeldByButtons   = true;
                 m_bRefocusHeldByButtons = refocus;
-            } else if (g_pCompositor->m_pLastWindow) {
+            } else if (g_pCompositor->m_pLastWindow.lock()) {
                 foundSurface = m_pLastMouseSurface;
-                pFoundWindow = g_pCompositor->m_pLastWindow;
+                pFoundWindow = g_pCompositor->m_pLastWindow.lock();
 
                 surfaceCoords           = g_pCompositor->vectorToSurfaceLocal(mouseCoords, pFoundWindow, foundSurface);
                 m_bFocusHeldByButtons   = true;
@@ -226,7 +226,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
 
     g_pLayoutManager->getCurrentLayout()->onMouseMove(getMouseCoordsInternal());
 
-    if (PMONITOR && PMONITOR != g_pCompositor->m_pLastMonitor && (*PMOUSEFOCUSMON || refocus) && !m_pForcedFocus)
+    if (PMONITOR && PMONITOR != g_pCompositor->m_pLastMonitor && (*PMOUSEFOCUSMON || refocus) && !m_pForcedFocus.lock())
         g_pCompositor->setActiveMonitor(PMONITOR);
 
     if (g_pSessionLockManager->isSessionLocked()) {
@@ -356,7 +356,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
         wlr_seat_pointer_clear_focus(g_pCompositor->m_sSeat.seat);
         m_pLastMouseSurface = nullptr;
 
-        if (refocus || !g_pCompositor->m_pLastWindow) // if we are forcing a refocus, and we don't find a surface, clear the kb focus too!
+        if (refocus || !g_pCompositor->m_pLastWindow.lock()) // if we are forcing a refocus, and we don't find a surface, clear the kb focus too!
             g_pCompositor->focusWindow(nullptr);
 
         return;
@@ -393,7 +393,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
         m_pFoundSurfaceToFocus = foundSurface;
     }
 
-    if (currentlyDraggedWindow && pFoundWindow != currentlyDraggedWindow) {
+    if (currentlyDraggedWindow.lock() && pFoundWindow != currentlyDraggedWindow.lock()) {
         wlr_seat_pointer_notify_enter(g_pCompositor->m_sSeat.seat, foundSurface, surfaceLocal.x, surfaceLocal.y);
         wlr_seat_pointer_notify_motion(g_pCompositor->m_sSeat.seat, time, surfaceLocal.x, surfaceLocal.y);
         return;
@@ -418,8 +418,8 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
         }
 
         if (FOLLOWMOUSE != 1 && !refocus) {
-            if (pFoundWindow != g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow &&
-                ((pFoundWindow->m_bIsFloating && *PFLOATBEHAVIOR == 2) || (g_pCompositor->m_pLastWindow->m_bIsFloating != pFoundWindow->m_bIsFloating && *PFLOATBEHAVIOR != 0))) {
+            if (pFoundWindow != g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow.lock() &&
+                ((pFoundWindow->m_bIsFloating && *PFLOATBEHAVIOR == 2) || (g_pCompositor->m_pLastWindow.lock()->m_bIsFloating != pFoundWindow->m_bIsFloating && *PFLOATBEHAVIOR != 0))) {
                 // enter if change floating style
                 if (FOLLOWMOUSE != 3 && allowKeyboardRefocus)
                     g_pCompositor->focusWindow(pFoundWindow, foundSurface);
@@ -430,24 +430,24 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
                 wlr_seat_pointer_notify_enter(g_pCompositor->m_sSeat.seat, foundSurface, surfaceLocal.x, surfaceLocal.y);
             }
 
-            if (pFoundWindow == g_pCompositor->m_pLastWindow) {
+            if (pFoundWindow == g_pCompositor->m_pLastWindow.lock()) {
                 m_pLastMouseSurface = foundSurface;
                 wlr_seat_pointer_notify_enter(g_pCompositor->m_sSeat.seat, foundSurface, surfaceLocal.x, surfaceLocal.y);
             }
 
-            if (FOLLOWMOUSE != 0 || pFoundWindow == g_pCompositor->m_pLastWindow)
+            if (FOLLOWMOUSE != 0 || pFoundWindow == g_pCompositor->m_pLastWindow.lock())
                 wlr_seat_pointer_notify_motion(g_pCompositor->m_sSeat.seat, time, surfaceLocal.x, surfaceLocal.y);
 
             m_bLastFocusOnLS = false;
             return; // don't enter any new surfaces
         } else {
-            if (allowKeyboardRefocus && ((FOLLOWMOUSE != 3 && (*PMOUSEREFOCUS || m_pLastMouseFocus != pFoundWindow)) || refocus)) {
-                if (m_pLastMouseFocus != pFoundWindow || g_pCompositor->m_pLastWindow != pFoundWindow || g_pCompositor->m_pLastFocus != foundSurface || refocus) {
+            if (allowKeyboardRefocus && ((FOLLOWMOUSE != 3 && (*PMOUSEREFOCUS || m_pLastMouseFocus.lock() != pFoundWindow)) || refocus)) {
+                if (m_pLastMouseFocus.lock() != pFoundWindow || g_pCompositor->m_pLastWindow.lock() != pFoundWindow || g_pCompositor->m_pLastFocus != foundSurface || refocus) {
                     m_pLastMouseFocus = pFoundWindow;
 
                     // TODO: this looks wrong. When over a popup, it constantly is switching.
                     // Temp fix until that's figured out. Otherwise spams windowrule lookups and other shit.
-                    if (m_pLastMouseFocus != pFoundWindow || g_pCompositor->m_pLastWindow != pFoundWindow)
+                    if (m_pLastMouseFocus.lock() != pFoundWindow || g_pCompositor->m_pLastWindow.lock() != pFoundWindow)
                         g_pCompositor->focusWindow(pFoundWindow, foundSurface);
                     else
                         g_pCompositor->focusSurface(foundSurface, pFoundWindow);
@@ -642,7 +642,7 @@ void CInputManager::processMouseDownNormal(wlr_pointer_button_event* e) {
                 break;
 
             if ((!g_pCompositor->m_sSeat.mouse || !isConstrained()) /* No constraints */
-                && (w && g_pCompositor->m_pLastWindow != w) /* window should change */) {
+                && (w && g_pCompositor->m_pLastWindow.lock() != w) /* window should change */) {
                 // a bit hacky
                 // if we only pressed one button, allow us to refocus. m_lCurrentlyHeldButtons.size() > 0 will stick the focus
                 if (m_lCurrentlyHeldButtons.size() == 1) {
@@ -655,8 +655,8 @@ void CInputManager::processMouseDownNormal(wlr_pointer_button_event* e) {
             }
 
             // if clicked on a floating window make it top
-            if (g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_bIsFloating)
-                g_pCompositor->changeWindowZOrder(g_pCompositor->m_pLastWindow, true);
+            if (g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow.lock()->m_bIsFloating)
+                g_pCompositor->changeWindowZOrder(g_pCompositor->m_pLastWindow.lock(), true);
 
             break;
         case WL_POINTER_BUTTON_STATE_RELEASED: break;
@@ -1615,7 +1615,7 @@ void CInputManager::releaseAllMouseButtons() {
     m_lCurrentlyHeldButtons.clear();
 }
 
-void CInputManager::setCursorIconOnBorder(CWindow* w) {
+void CInputManager::setCursorIconOnBorder(PHLWINDOW w) {
     // do not override cursor icons set by mouse binds
     if (g_pKeybindManager->m_bIsMouseBindActive) {
         m_eBorderIconDirection = BORDERICON_NONE;
@@ -1636,7 +1636,7 @@ void CInputManager::setCursorIconOnBorder(CWindow* w) {
 
     if (w->hasPopupAt(mouseCoords))
         direction = BORDERICON_NONE;
-    else if (!boxFullGrabInput.containsPoint(mouseCoords) || (!m_lCurrentlyHeldButtons.empty() && !currentlyDraggedWindow))
+    else if (!boxFullGrabInput.containsPoint(mouseCoords) || (!m_lCurrentlyHeldButtons.empty() && !currentlyDraggedWindow.lock()))
         direction = BORDERICON_NONE;
     else {
 

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -38,7 +38,7 @@ enum eBorderIconDirection {
 };
 
 struct STouchData {
-    CWindow*       touchFocusWindow  = nullptr;
+    PHLWINDOWREF   touchFocusWindow;
     SLayerSurface* touchFocusLS      = nullptr;
     wlr_surface*   touchFocusSurface = nullptr;
     Vector2D       touchSurfaceOrigin;
@@ -114,12 +114,12 @@ class CInputManager {
     STouchData         m_sTouchData;
 
     // for dragging floating windows
-    CWindow*       currentlyDraggedWindow = nullptr;
-    eMouseBindMode dragMode               = MBIND_INVALID;
-    bool           m_bWasDraggingWindow   = false;
+    PHLWINDOWREF   currentlyDraggedWindow;
+    eMouseBindMode dragMode             = MBIND_INVALID;
+    bool           m_bWasDraggingWindow = false;
 
     // for refocus to be forced
-    CWindow*             m_pForcedFocus = nullptr;
+    PHLWINDOWREF         m_pForcedFocus;
 
     SDrag                m_sDrag;
 
@@ -188,7 +188,7 @@ class CInputManager {
     bool m_bLastInputTouch = false;
 
     // for tracking mouse refocus
-    CWindow*     m_pLastMouseFocus   = nullptr;
+    PHLWINDOWREF m_pLastMouseFocus;
     wlr_surface* m_pLastMouseSurface = nullptr;
 
     //
@@ -226,7 +226,7 @@ class CInputManager {
     // this will be set after a refocus()
     wlr_surface*   m_pFoundSurfaceToFocus = nullptr;
     SLayerSurface* m_pFoundLSToFocus      = nullptr;
-    CWindow*       m_pFoundWindowToFocus  = nullptr;
+    PHLWINDOWREF   m_pFoundWindowToFocus;
 
     // for holding focus on buttons held
     bool m_bFocusHeldByButtons   = false;
@@ -238,7 +238,7 @@ class CInputManager {
     // idle inhibitors
     struct SIdleInhibitor {
         std::shared_ptr<CIdleInhibitor> inhibitor;
-        CWindow*                        pWindow = nullptr;
+        PHLWINDOWREF                    pWindow;
         CHyprSignalListener             windowDestroyListener;
     };
     std::vector<std::unique_ptr<SIdleInhibitor>> m_vIdleInhibitors;
@@ -249,7 +249,7 @@ class CInputManager {
     void endWorkspaceSwipe();
 
     void setBorderCursorIcon(eBorderIconDirection);
-    void setCursorIconOnBorder(CWindow* w);
+    void setCursorIconOnBorder(PHLWINDOW w);
 
     // temporary. Obeys setUntilUnset.
     void setCursorImageOverride(const std::string& name);

--- a/src/managers/input/Tablets.cpp
+++ b/src/managers/input/Tablets.cpp
@@ -263,7 +263,7 @@ void CInputManager::newTabletPad(wlr_input_device* pDevice) {
 void CInputManager::focusTablet(STablet* pTab, wlr_tablet_tool* pTool, bool motion) {
     const auto PTOOL = g_pInputManager->ensureTabletToolPresent(pTool);
 
-    if (const auto PWINDOW = g_pCompositor->m_pLastWindow; PWINDOW) {
+    if (const auto PWINDOW = g_pCompositor->m_pLastWindow.lock(); PWINDOW) {
         const auto CURSORPOS = g_pInputManager->getMouseCoordsInternal();
 
         if (PTOOL->pSurface != g_pInputManager->m_pLastMouseSurface)

--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -64,12 +64,12 @@ void CInputManager::onTouchDown(wlr_touch_down_event* e) {
 
     Vector2D local;
 
-    if (m_sTouchData.touchFocusWindow) {
-        if (m_sTouchData.touchFocusWindow->m_bIsX11) {
-            local = (g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchFocusWindow->m_vRealPosition.goal()) * m_sTouchData.touchFocusWindow->m_fX11SurfaceScaledBy;
-            m_sTouchData.touchSurfaceOrigin = m_sTouchData.touchFocusWindow->m_vRealPosition.goal();
+    if (m_sTouchData.touchFocusWindow.lock()) {
+        if (m_sTouchData.touchFocusWindow.lock()->m_bIsX11) {
+            local = (g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchFocusWindow.lock()->m_vRealPosition.goal()) * m_sTouchData.touchFocusWindow.lock()->m_fX11SurfaceScaledBy;
+            m_sTouchData.touchSurfaceOrigin = m_sTouchData.touchFocusWindow.lock()->m_vRealPosition.goal();
         } else {
-            g_pCompositor->vectorWindowToSurface(g_pInputManager->getMouseCoordsInternal(), m_sTouchData.touchFocusWindow, local);
+            g_pCompositor->vectorWindowToSurface(g_pInputManager->getMouseCoordsInternal(), m_sTouchData.touchFocusWindow.lock(), local);
             m_sTouchData.touchSurfaceOrigin = g_pInputManager->getMouseCoordsInternal() - local;
         }
     } else if (m_sTouchData.touchFocusLS) {
@@ -126,14 +126,14 @@ void CInputManager::onTouchMove(wlr_touch_motion_event* e) {
             updateWorkspaceSwipe(SWIPEDISTANCE * (1 - (VERTANIMS ? e->y : e->x)));
         return;
     }
-    if (m_sTouchData.touchFocusWindow && g_pCompositor->windowValidMapped(m_sTouchData.touchFocusWindow)) {
-        const auto PMONITOR = g_pCompositor->getMonitorFromID(m_sTouchData.touchFocusWindow->m_iMonitorID);
+    if (validMapped(m_sTouchData.touchFocusWindow)) {
+        const auto PMONITOR = g_pCompositor->getMonitorFromID(m_sTouchData.touchFocusWindow.lock()->m_iMonitorID);
 
         wlr_cursor_warp(g_pCompositor->m_sWLRCursor, nullptr, PMONITOR->vecPosition.x + e->x * PMONITOR->vecSize.x, PMONITOR->vecPosition.y + e->y * PMONITOR->vecSize.y);
 
         auto local = g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchSurfaceOrigin;
-        if (m_sTouchData.touchFocusWindow->m_bIsX11)
-            local = local * m_sTouchData.touchFocusWindow->m_fX11SurfaceScaledBy;
+        if (m_sTouchData.touchFocusWindow.lock()->m_bIsX11)
+            local = local * m_sTouchData.touchFocusWindow.lock()->m_fX11SurfaceScaledBy;
 
         wlr_seat_touch_notify_motion(g_pCompositor->m_sSeat.seat, e->time_msec, e->touch_id, local.x, local.y);
         // wlr_seat_pointer_notify_motion(g_pCompositor->m_sSeat.seat, e->time_msec, local.x, local.y);

--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -66,7 +66,8 @@ void CInputManager::onTouchDown(wlr_touch_down_event* e) {
 
     if (m_sTouchData.touchFocusWindow.lock()) {
         if (m_sTouchData.touchFocusWindow.lock()->m_bIsX11) {
-            local = (g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchFocusWindow.lock()->m_vRealPosition.goal()) * m_sTouchData.touchFocusWindow.lock()->m_fX11SurfaceScaledBy;
+            local = (g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchFocusWindow.lock()->m_vRealPosition.goal()) *
+                m_sTouchData.touchFocusWindow.lock()->m_fX11SurfaceScaledBy;
             m_sTouchData.touchSurfaceOrigin = m_sTouchData.touchFocusWindow.lock()->m_vRealPosition.goal();
         } else {
             g_pCompositor->vectorWindowToSurface(g_pInputManager->getMouseCoordsInternal(), m_sTouchData.touchFocusWindow.lock(), local);

--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -64,7 +64,7 @@ void CInputManager::onTouchDown(wlr_touch_down_event* e) {
 
     Vector2D local;
 
-    if (m_sTouchData.touchFocusWindow.lock()) {
+    if (!m_sTouchData.touchFocusWindow.expired()) {
         if (m_sTouchData.touchFocusWindow.lock()->m_bIsX11) {
             local = (g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchFocusWindow.lock()->m_vRealPosition.goal()) *
                 m_sTouchData.touchFocusWindow.lock()->m_fX11SurfaceScaledBy;

--- a/src/plugins/PluginAPI.cpp
+++ b/src/plugins/PluginAPI.cpp
@@ -99,13 +99,13 @@ APICALL bool HyprlandAPI::removeFunctionHook(HANDLE handle, CFunctionHook* hook)
     return g_pFunctionHookSystem->removeHook(hook);
 }
 
-APICALL bool HyprlandAPI::addWindowDecoration(HANDLE handle, CWindow* pWindow, std::unique_ptr<IHyprWindowDecoration> pDecoration) {
+APICALL bool HyprlandAPI::addWindowDecoration(HANDLE handle, PHLWINDOW pWindow, std::unique_ptr<IHyprWindowDecoration> pDecoration) {
     auto* const PLUGIN = g_pPluginSystem->getPluginByHandle(handle);
 
     if (!PLUGIN)
         return false;
 
-    if (!g_pCompositor->windowValidMapped(pWindow))
+    if (!validMapped(pWindow))
         return false;
 
     PLUGIN->registeredDecorations.push_back(pDecoration.get());

--- a/src/plugins/PluginAPI.hpp
+++ b/src/plugins/PluginAPI.hpp
@@ -64,7 +64,7 @@ struct SConfigValue;
 class CWindow;
 
 typedef std::shared_ptr<CWindow> PHLWINDOW;
-typedef std::weak_ptr<CWindow> PHLWINDOWREF;
+typedef std::weak_ptr<CWindow>   PHLWINDOWREF;
 
 /*
     These methods are for the plugin to implement

--- a/src/plugins/PluginAPI.hpp
+++ b/src/plugins/PluginAPI.hpp
@@ -219,7 +219,7 @@ namespace HyprlandAPI {
 
         returns: true on success. False otherwise.
     */
-    APICALL bool addWindowDecoration(HANDLE handle, CWindow* pWindow, std::unique_ptr<IHyprWindowDecoration> pDecoration);
+    APICALL bool addWindowDecoration(HANDLE handle, PHLWINDOW pWindow, std::unique_ptr<IHyprWindowDecoration> pDecoration);
 
     /*
         Removes a window decoration

--- a/src/plugins/PluginAPI.hpp
+++ b/src/plugins/PluginAPI.hpp
@@ -61,6 +61,10 @@ class IHyprLayout;
 class CWindow;
 class IHyprWindowDecoration;
 struct SConfigValue;
+class CWindow;
+
+typedef std::shared_ptr<CWindow> PHLWINDOW;
+typedef std::weak_ptr<CWindow> PHLWINDOWREF;
 
 /*
     These methods are for the plugin to implement

--- a/src/plugins/PluginSystem.cpp
+++ b/src/plugins/PluginSystem.cpp
@@ -97,8 +97,8 @@ void CPluginSystem::unloadPlugin(const CPlugin* plugin, bool eject) {
     }
 
     for (auto& [k, v] : plugin->registeredCallbacks) {
-        if (const auto SP = v.lock())
-            g_pHookSystem->unhook(SP);
+        if (const auto SHP = v.lock())
+            g_pHookSystem->unhook(SHP);
     }
 
     const auto ls = plugin->registeredLayouts;

--- a/src/protocols/ForeignToplevel.cpp
+++ b/src/protocols/ForeignToplevel.cpp
@@ -67,7 +67,7 @@ void CForeignToplevelList::onMap(PHLWINDOW pWindow) {
 }
 
 SP<CForeignToplevelHandle> CForeignToplevelList::handleForWindow(PHLWINDOW pWindow) {
-    std::erase_if(handles, [](const auto& wp) { return !wp.lock(); });
+    std::erase_if(handles, [](const auto& wp) { return wp.expired(); });
     const auto IT = std::find_if(handles.begin(), handles.end(), [pWindow](const auto& h) { return h.lock()->window() == pWindow; });
     return IT == handles.end() ? SP<CForeignToplevelHandle>{} : IT->lock();
 }

--- a/src/protocols/ForeignToplevel.cpp
+++ b/src/protocols/ForeignToplevel.cpp
@@ -3,7 +3,7 @@
 
 #define LOGM PROTO::foreignToplevel->protoLog
 
-CForeignToplevelHandle::CForeignToplevelHandle(SP<CExtForeignToplevelHandleV1> resource_, CWindow* pWindow_) : resource(resource_), pWindow(pWindow_) {
+CForeignToplevelHandle::CForeignToplevelHandle(SP<CExtForeignToplevelHandleV1> resource_, PHLWINDOW pWindow_) : resource(resource_), pWindow(pWindow_) {
     if (!resource_->resource())
         return;
 
@@ -15,8 +15,8 @@ bool CForeignToplevelHandle::good() {
     return resource->resource();
 }
 
-CWindow* CForeignToplevelHandle::window() {
-    return pWindow;
+PHLWINDOW CForeignToplevelHandle::window() {
+    return pWindow.lock();
 }
 
 CForeignToplevelList::CForeignToplevelList(SP<CExtForeignToplevelListV1> resource_) : resource(resource_) {
@@ -36,11 +36,11 @@ CForeignToplevelList::CForeignToplevelList(SP<CExtForeignToplevelListV1> resourc
         if (!w->m_bIsMapped || w->m_bFadingOut)
             continue;
 
-        onMap(w.get());
+        onMap(w);
     }
 }
 
-void CForeignToplevelList::onMap(CWindow* pWindow) {
+void CForeignToplevelList::onMap(PHLWINDOW pWindow) {
     if (finished)
         return;
 
@@ -54,7 +54,7 @@ void CForeignToplevelList::onMap(CWindow* pWindow) {
         return;
     }
 
-    const auto IDENTIFIER = std::format("{:08x}->{:016x}", static_cast<uint32_t>((uintptr_t)this & 0xFFFFFFFF), (uintptr_t)pWindow);
+    const auto IDENTIFIER = std::format("{:08x}->{:016x}", static_cast<uint32_t>((uintptr_t)this & 0xFFFFFFFF), (uintptr_t)pWindow.get());
 
     LOGM(LOG, "Newly mapped window gets an identifier of {}", IDENTIFIER);
     resource->sendToplevel(NEWHANDLE->resource.get());
@@ -66,13 +66,13 @@ void CForeignToplevelList::onMap(CWindow* pWindow) {
     handles.push_back(NEWHANDLE);
 }
 
-SP<CForeignToplevelHandle> CForeignToplevelList::handleForWindow(CWindow* pWindow) {
+SP<CForeignToplevelHandle> CForeignToplevelList::handleForWindow(PHLWINDOW pWindow) {
     std::erase_if(handles, [](const auto& wp) { return !wp.lock(); });
     const auto IT = std::find_if(handles.begin(), handles.end(), [pWindow](const auto& h) { return h.lock()->window() == pWindow; });
     return IT == handles.end() ? SP<CForeignToplevelHandle>{} : IT->lock();
 }
 
-void CForeignToplevelList::onTitle(CWindow* pWindow) {
+void CForeignToplevelList::onTitle(PHLWINDOW pWindow) {
     if (finished)
         return;
 
@@ -83,7 +83,7 @@ void CForeignToplevelList::onTitle(CWindow* pWindow) {
     H->resource->sendTitle(pWindow->m_szTitle.c_str());
 }
 
-void CForeignToplevelList::onClass(CWindow* pWindow) {
+void CForeignToplevelList::onClass(PHLWINDOW pWindow) {
     if (finished)
         return;
 
@@ -94,7 +94,7 @@ void CForeignToplevelList::onClass(CWindow* pWindow) {
     H->resource->sendAppId(g_pXWaylandManager->getAppIDClass(pWindow).c_str());
 }
 
-void CForeignToplevelList::onUnmap(CWindow* pWindow) {
+void CForeignToplevelList::onUnmap(PHLWINDOW pWindow) {
     if (finished)
         return;
 
@@ -113,19 +113,19 @@ bool CForeignToplevelList::good() {
 CForeignToplevelProtocol::CForeignToplevelProtocol(const wl_interface* iface, const int& ver, const std::string& name) : IWaylandProtocol(iface, ver, name) {
     static auto P = g_pHookSystem->hookDynamic("openWindow", [this](void* self, SCallbackInfo& info, std::any data) {
         for (auto& m : m_vManagers) {
-            m->onMap(std::any_cast<CWindow*>(data));
+            m->onMap(std::any_cast<PHLWINDOW>(data));
         }
     });
 
     static auto P1 = g_pHookSystem->hookDynamic("closeWindow", [this](void* self, SCallbackInfo& info, std::any data) {
         for (auto& m : m_vManagers) {
-            m->onUnmap(std::any_cast<CWindow*>(data));
+            m->onUnmap(std::any_cast<PHLWINDOW>(data));
         }
     });
 
     static auto P2 = g_pHookSystem->hookDynamic("windowTitle", [this](void* self, SCallbackInfo& info, std::any data) {
         for (auto& m : m_vManagers) {
-            m->onTitle(std::any_cast<CWindow*>(data));
+            m->onTitle(std::any_cast<PHLWINDOW>(data));
         }
     });
 }

--- a/src/protocols/ForeignToplevel.hpp
+++ b/src/protocols/ForeignToplevel.hpp
@@ -6,19 +6,17 @@
 #include "WaylandProtocol.hpp"
 #include "ext-foreign-toplevel-list-v1.hpp"
 
-class CWindow;
-
 class CForeignToplevelHandle {
   public:
-    CForeignToplevelHandle(SP<CExtForeignToplevelHandleV1> resource_, CWindow* pWindow);
+    CForeignToplevelHandle(SP<CExtForeignToplevelHandleV1> resource_, PHLWINDOW pWindow);
 
-    bool     good();
-    CWindow* window();
+    bool      good();
+    PHLWINDOW window();
 
   private:
     SP<CExtForeignToplevelHandleV1> resource;
-    CWindow*                        pWindow = nullptr;
-    bool                            closed  = false;
+    PHLWINDOWREF                    pWindow;
+    bool                            closed = false;
 
     friend class CForeignToplevelList;
 };
@@ -27,10 +25,10 @@ class CForeignToplevelList {
   public:
     CForeignToplevelList(SP<CExtForeignToplevelListV1> resource_);
 
-    void onMap(CWindow* pWindow);
-    void onTitle(CWindow* pWindow);
-    void onClass(CWindow* pWindow);
-    void onUnmap(CWindow* pWindow);
+    void onMap(PHLWINDOW pWindow);
+    void onTitle(PHLWINDOW pWindow);
+    void onClass(PHLWINDOW pWindow);
+    void onUnmap(PHLWINDOW pWindow);
 
     bool good();
 
@@ -38,7 +36,7 @@ class CForeignToplevelList {
     SP<CExtForeignToplevelListV1>           resource;
     bool                                    finished = false;
 
-    SP<CForeignToplevelHandle>              handleForWindow(CWindow* pWindow);
+    SP<CForeignToplevelHandle>              handleForWindow(PHLWINDOW pWindow);
 
     std::vector<WP<CForeignToplevelHandle>> handles;
 };

--- a/src/protocols/ForeignToplevelWlr.cpp
+++ b/src/protocols/ForeignToplevelWlr.cpp
@@ -207,7 +207,7 @@ void CForeignToplevelWlrManager::onMap(PHLWINDOW pWindow) {
 }
 
 SP<CForeignToplevelHandleWlr> CForeignToplevelWlrManager::handleForWindow(PHLWINDOW pWindow) {
-    std::erase_if(handles, [](const auto& wp) { return !wp.lock(); });
+    std::erase_if(handles, [](const auto& wp) { return wp.expired(); });
     const auto IT = std::find_if(handles.begin(), handles.end(), [pWindow](const auto& h) { return h.lock()->window() == pWindow; });
     return IT == handles.end() ? SP<CForeignToplevelHandleWlr>{} : IT->lock();
 }

--- a/src/protocols/ForeignToplevelWlr.cpp
+++ b/src/protocols/ForeignToplevelWlr.cpp
@@ -4,7 +4,7 @@
 
 #define LOGM PROTO::foreignToplevelWlr->protoLog
 
-CForeignToplevelHandleWlr::CForeignToplevelHandleWlr(SP<CZwlrForeignToplevelHandleV1> resource_, CWindow* pWindow_) : resource(resource_), pWindow(pWindow_) {
+CForeignToplevelHandleWlr::CForeignToplevelHandleWlr(SP<CZwlrForeignToplevelHandleV1> resource_, PHLWINDOW pWindow_) : resource(resource_), pWindow(pWindow_) {
     if (!resource_->resource())
         return;
 
@@ -12,70 +12,82 @@ CForeignToplevelHandleWlr::CForeignToplevelHandleWlr(SP<CZwlrForeignToplevelHand
     resource->setDestroy([this](CZwlrForeignToplevelHandleV1* h) { PROTO::foreignToplevelWlr->destroyHandle(this); });
 
     resource->setActivate([this](CZwlrForeignToplevelHandleV1* p, wl_resource* seat) {
-        if (!pWindow)
+        const auto PWINDOW = pWindow.lock();
+
+        if (!PWINDOW)
             return;
 
-        if (pWindow->m_eSuppressedEvents & SUPPRESS_ACTIVATE)
+        if (PWINDOW->m_eSuppressedEvents & SUPPRESS_ACTIVATE)
             return;
 
-        pWindow->activate();
+        PWINDOW->activate();
     });
 
     resource->setSetFullscreen([this](CZwlrForeignToplevelHandleV1* p, wl_resource* output) {
-        if (!pWindow)
+        const auto PWINDOW = pWindow.lock();
+
+        if (!PWINDOW)
             return;
 
-        if (pWindow->m_eSuppressedEvents & SUPPRESS_FULLSCREEN)
+        if (PWINDOW->m_eSuppressedEvents & SUPPRESS_FULLSCREEN)
             return;
 
-        if (!pWindow->m_bIsMapped) {
-            pWindow->m_bWantsInitialFullscreen = true;
+        if (!PWINDOW->m_bIsMapped) {
+            PWINDOW->m_bWantsInitialFullscreen = true;
             return;
         }
 
-        g_pCompositor->setWindowFullscreen(pWindow, true);
+        g_pCompositor->setWindowFullscreen(PWINDOW, true);
     });
 
     resource->setUnsetFullscreen([this](CZwlrForeignToplevelHandleV1* p) {
-        if (!pWindow)
+        const auto PWINDOW = pWindow.lock();
+
+        if (!PWINDOW)
             return;
 
-        if (pWindow->m_eSuppressedEvents & SUPPRESS_FULLSCREEN)
+        if (PWINDOW->m_eSuppressedEvents & SUPPRESS_FULLSCREEN)
             return;
 
-        g_pCompositor->setWindowFullscreen(pWindow, false);
+        g_pCompositor->setWindowFullscreen(PWINDOW, false);
     });
 
     resource->setSetMaximized([this](CZwlrForeignToplevelHandleV1* p) {
-        if (!pWindow)
+        const auto PWINDOW = pWindow.lock();
+
+        if (!PWINDOW)
             return;
 
-        if (pWindow->m_eSuppressedEvents & SUPPRESS_MAXIMIZE)
+        if (PWINDOW->m_eSuppressedEvents & SUPPRESS_MAXIMIZE)
             return;
 
-        if (!pWindow->m_bIsMapped) {
-            pWindow->m_bWantsInitialFullscreen = true;
+        if (!PWINDOW->m_bIsMapped) {
+            PWINDOW->m_bWantsInitialFullscreen = true;
             return;
         }
 
-        g_pCompositor->setWindowFullscreen(pWindow, true, FULLSCREEN_MAXIMIZED);
+        g_pCompositor->setWindowFullscreen(PWINDOW, true, FULLSCREEN_MAXIMIZED);
     });
 
     resource->setUnsetMaximized([this](CZwlrForeignToplevelHandleV1* p) {
-        if (!pWindow)
+        const auto PWINDOW = pWindow.lock();
+
+        if (!PWINDOW)
             return;
 
-        if (pWindow->m_eSuppressedEvents & SUPPRESS_MAXIMIZE)
+        if (PWINDOW->m_eSuppressedEvents & SUPPRESS_MAXIMIZE)
             return;
 
-        g_pCompositor->setWindowFullscreen(pWindow, false);
+        g_pCompositor->setWindowFullscreen(PWINDOW, false);
     });
 
     resource->setClose([this](CZwlrForeignToplevelHandleV1* p) {
-        if (!pWindow)
+        const auto PWINDOW = pWindow.lock();
+
+        if (!PWINDOW)
             return;
 
-        g_pCompositor->closeWindow(pWindow);
+        g_pCompositor->closeWindow(PWINDOW);
     });
 }
 
@@ -83,8 +95,8 @@ bool CForeignToplevelHandleWlr::good() {
     return resource->resource();
 }
 
-CWindow* CForeignToplevelHandleWlr::window() {
-    return pWindow;
+PHLWINDOW CForeignToplevelHandleWlr::window() {
+    return pWindow.lock();
 }
 
 wl_resource* CForeignToplevelHandleWlr::res() {
@@ -119,20 +131,22 @@ void CForeignToplevelHandleWlr::sendMonitor(CMonitor* pMonitor) {
 }
 
 void CForeignToplevelHandleWlr::sendState() {
-    if (!pWindow || !pWindow->m_pWorkspace || !pWindow->m_bIsMapped)
+    const auto PWINDOW = pWindow.lock();
+
+    if (!PWINDOW || !PWINDOW->m_pWorkspace || !PWINDOW->m_bIsMapped)
         return;
 
     wl_array state;
     wl_array_init(&state);
 
-    if (pWindow == g_pCompositor->m_pLastWindow) {
+    if (PWINDOW == g_pCompositor->m_pLastWindow.lock()) {
         auto p = (uint32_t*)wl_array_add(&state, sizeof(uint32_t));
         *p     = ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_STATE_ACTIVATED;
     }
 
-    if (pWindow->m_bIsFullscreen) {
+    if (PWINDOW->m_bIsFullscreen) {
         auto p = (uint32_t*)wl_array_add(&state, sizeof(uint32_t));
-        if (pWindow->m_pWorkspace->m_efFullscreenMode == FULLSCREEN_FULL)
+        if (PWINDOW->m_pWorkspace->m_efFullscreenMode == FULLSCREEN_FULL)
             *p = ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_STATE_FULLSCREEN;
         else
             *p = ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_STATE_MAXIMIZED;
@@ -160,13 +174,13 @@ CForeignToplevelWlrManager::CForeignToplevelWlrManager(SP<CZwlrForeignToplevelMa
         if (!w->m_bIsMapped || w->m_bFadingOut)
             continue;
 
-        onMap(w.get());
+        onMap(w);
     }
 
     lastFocus = g_pCompositor->m_pLastWindow;
 }
 
-void CForeignToplevelWlrManager::onMap(CWindow* pWindow) {
+void CForeignToplevelWlrManager::onMap(PHLWINDOW pWindow) {
     if (finished)
         return;
 
@@ -180,7 +194,7 @@ void CForeignToplevelWlrManager::onMap(CWindow* pWindow) {
         return;
     }
 
-    LOGM(LOG, "Newly mapped window {:016x}", (uintptr_t)pWindow);
+    LOGM(LOG, "Newly mapped window {:016x}", (uintptr_t)pWindow.get());
     resource->sendToplevel(NEWHANDLE->resource.get());
     NEWHANDLE->resource->sendAppId(pWindow->m_szInitialClass.c_str());
     NEWHANDLE->resource->sendTitle(pWindow->m_szInitialTitle.c_str());
@@ -192,13 +206,13 @@ void CForeignToplevelWlrManager::onMap(CWindow* pWindow) {
     handles.push_back(NEWHANDLE);
 }
 
-SP<CForeignToplevelHandleWlr> CForeignToplevelWlrManager::handleForWindow(CWindow* pWindow) {
+SP<CForeignToplevelHandleWlr> CForeignToplevelWlrManager::handleForWindow(PHLWINDOW pWindow) {
     std::erase_if(handles, [](const auto& wp) { return !wp.lock(); });
     const auto IT = std::find_if(handles.begin(), handles.end(), [pWindow](const auto& h) { return h.lock()->window() == pWindow; });
     return IT == handles.end() ? SP<CForeignToplevelHandleWlr>{} : IT->lock();
 }
 
-void CForeignToplevelWlrManager::onTitle(CWindow* pWindow) {
+void CForeignToplevelWlrManager::onTitle(PHLWINDOW pWindow) {
     if (finished)
         return;
 
@@ -210,7 +224,7 @@ void CForeignToplevelWlrManager::onTitle(CWindow* pWindow) {
     H->resource->sendDone();
 }
 
-void CForeignToplevelWlrManager::onClass(CWindow* pWindow) {
+void CForeignToplevelWlrManager::onClass(PHLWINDOW pWindow) {
     if (finished)
         return;
 
@@ -222,7 +236,7 @@ void CForeignToplevelWlrManager::onClass(CWindow* pWindow) {
     H->resource->sendDone();
 }
 
-void CForeignToplevelWlrManager::onUnmap(CWindow* pWindow) {
+void CForeignToplevelWlrManager::onUnmap(PHLWINDOW pWindow) {
     if (finished)
         return;
 
@@ -235,7 +249,7 @@ void CForeignToplevelWlrManager::onUnmap(CWindow* pWindow) {
     H->closed = true;
 }
 
-void CForeignToplevelWlrManager::onMoveMonitor(CWindow* pWindow) {
+void CForeignToplevelWlrManager::onMoveMonitor(PHLWINDOW pWindow) {
     if (finished)
         return;
 
@@ -252,7 +266,7 @@ void CForeignToplevelWlrManager::onMoveMonitor(CWindow* pWindow) {
     H->resource->sendDone();
 }
 
-void CForeignToplevelWlrManager::onFullscreen(CWindow* pWindow) {
+void CForeignToplevelWlrManager::onFullscreen(PHLWINDOW pWindow) {
     if (finished)
         return;
 
@@ -264,11 +278,11 @@ void CForeignToplevelWlrManager::onFullscreen(CWindow* pWindow) {
     H->resource->sendDone();
 }
 
-void CForeignToplevelWlrManager::onNewFocus(CWindow* pWindow) {
+void CForeignToplevelWlrManager::onNewFocus(PHLWINDOW pWindow) {
     if (finished)
         return;
 
-    if (const auto HOLD = handleForWindow(lastFocus); HOLD) {
+    if (const auto HOLD = handleForWindow(lastFocus.lock()); HOLD) {
         HOLD->sendState();
         HOLD->resource->sendDone();
     }
@@ -289,42 +303,42 @@ bool CForeignToplevelWlrManager::good() {
 
 CForeignToplevelWlrProtocol::CForeignToplevelWlrProtocol(const wl_interface* iface, const int& ver, const std::string& name) : IWaylandProtocol(iface, ver, name) {
     static auto P = g_pHookSystem->hookDynamic("openWindow", [this](void* self, SCallbackInfo& info, std::any data) {
-        const auto PWINDOW = std::any_cast<CWindow*>(data);
+        const auto PWINDOW = std::any_cast<PHLWINDOW>(data);
         for (auto& m : m_vManagers) {
             m->onMap(PWINDOW);
         }
     });
 
     static auto P1 = g_pHookSystem->hookDynamic("closeWindow", [this](void* self, SCallbackInfo& info, std::any data) {
-        const auto PWINDOW = std::any_cast<CWindow*>(data);
+        const auto PWINDOW = std::any_cast<PHLWINDOW>(data);
         for (auto& m : m_vManagers) {
             m->onUnmap(PWINDOW);
         }
     });
 
     static auto P2 = g_pHookSystem->hookDynamic("windowTitle", [this](void* self, SCallbackInfo& info, std::any data) {
-        const auto PWINDOW = std::any_cast<CWindow*>(data);
+        const auto PWINDOW = std::any_cast<PHLWINDOW>(data);
         for (auto& m : m_vManagers) {
             m->onTitle(PWINDOW);
         }
     });
 
     static auto P3 = g_pHookSystem->hookDynamic("activeWindow", [this](void* self, SCallbackInfo& info, std::any data) {
-        const auto PWINDOW = std::any_cast<CWindow*>(data);
+        const auto PWINDOW = std::any_cast<PHLWINDOW>(data);
         for (auto& m : m_vManagers) {
             m->onNewFocus(PWINDOW);
         }
     });
 
     static auto P4 = g_pHookSystem->hookDynamic("moveWindow", [this](void* self, SCallbackInfo& info, std::any data) {
-        const auto PWINDOW = std::any_cast<CWindow*>(std::any_cast<std::vector<std::any>>(data).at(0));
+        const auto PWINDOW = std::any_cast<PHLWINDOW>(std::any_cast<std::vector<std::any>>(data).at(0));
         for (auto& m : m_vManagers) {
             m->onMoveMonitor(PWINDOW);
         }
     });
 
     static auto P5 = g_pHookSystem->hookDynamic("fullscreen", [this](void* self, SCallbackInfo& info, std::any data) {
-        const auto PWINDOW = std::any_cast<CWindow*>(data);
+        const auto PWINDOW = std::any_cast<PHLWINDOW>(data);
         for (auto& m : m_vManagers) {
             m->onFullscreen(PWINDOW);
         }
@@ -350,7 +364,7 @@ void CForeignToplevelWlrProtocol::destroyHandle(CForeignToplevelHandleWlr* handl
     std::erase_if(m_vHandles, [&](const auto& other) { return other.get() == handle; });
 }
 
-CWindow* CForeignToplevelWlrProtocol::windowFromHandleResource(wl_resource* res) {
+PHLWINDOW CForeignToplevelWlrProtocol::windowFromHandleResource(wl_resource* res) {
     for (auto& h : m_vHandles) {
         if (h->res() != res)
             continue;

--- a/src/protocols/ForeignToplevelWlr.hpp
+++ b/src/protocols/ForeignToplevelWlr.hpp
@@ -10,15 +10,15 @@ class CMonitor;
 
 class CForeignToplevelHandleWlr {
   public:
-    CForeignToplevelHandleWlr(SP<CZwlrForeignToplevelHandleV1> resource_, CWindow* pWindow);
+    CForeignToplevelHandleWlr(SP<CZwlrForeignToplevelHandleV1> resource_, PHLWINDOW pWindow);
 
     bool         good();
-    CWindow*     window();
+    PHLWINDOW    window();
     wl_resource* res();
 
   private:
     SP<CZwlrForeignToplevelHandleV1> resource;
-    CWindow*                         pWindow       = nullptr;
+    PHLWINDOWREF                     pWindow;
     bool                             closed        = false;
     int64_t                          lastMonitorID = -1;
 
@@ -32,22 +32,22 @@ class CForeignToplevelWlrManager {
   public:
     CForeignToplevelWlrManager(SP<CZwlrForeignToplevelManagerV1> resource_);
 
-    void onMap(CWindow* pWindow);
-    void onTitle(CWindow* pWindow);
-    void onClass(CWindow* pWindow);
-    void onMoveMonitor(CWindow* pWindow);
-    void onFullscreen(CWindow* pWindow);
-    void onNewFocus(CWindow* pWindow);
-    void onUnmap(CWindow* pWindow);
+    void onMap(PHLWINDOW pWindow);
+    void onTitle(PHLWINDOW pWindow);
+    void onClass(PHLWINDOW pWindow);
+    void onMoveMonitor(PHLWINDOW pWindow);
+    void onFullscreen(PHLWINDOW pWindow);
+    void onNewFocus(PHLWINDOW pWindow);
+    void onUnmap(PHLWINDOW pWindow);
 
     bool good();
 
   private:
     SP<CZwlrForeignToplevelManagerV1>          resource;
-    bool                                       finished  = false;
-    CWindow*                                   lastFocus = nullptr; // READ-ONLY
+    bool                                       finished = false;
+    PHLWINDOWREF                               lastFocus; // READ-ONLY
 
-    SP<CForeignToplevelHandleWlr>              handleForWindow(CWindow* pWindow);
+    SP<CForeignToplevelHandleWlr>              handleForWindow(PHLWINDOW pWindow);
 
     std::vector<WP<CForeignToplevelHandleWlr>> handles;
 };
@@ -58,7 +58,7 @@ class CForeignToplevelWlrProtocol : public IWaylandProtocol {
 
     virtual void bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id);
 
-    CWindow*     windowFromHandleResource(wl_resource* res);
+    PHLWINDOW    windowFromHandleResource(wl_resource* res);
 
   private:
     void onManagerResourceDestroy(CForeignToplevelWlrManager* mgr);

--- a/src/protocols/Screencopy.hpp
+++ b/src/protocols/Screencopy.hpp
@@ -56,7 +56,7 @@ struct SScreencopyFrame {
     wlr_buffer*        buffer = nullptr;
 
     CMonitor*          pMonitor = nullptr;
-    CWindow*           pWindow  = nullptr;
+    PHLWINDOWREF       pWindow;
 
     bool               operator==(const SScreencopyFrame& other) const {
         return resource == other.resource && client == other.client;

--- a/src/protocols/TearingControl.cpp
+++ b/src/protocols/TearingControl.cpp
@@ -66,7 +66,7 @@ void CTearingControl::onHint(wpTearingControlV1PresentationHint hint_) {
 }
 
 void CTearingControl::updateWindow() {
-    if (!pWindow.lock())
+    if (pWindow.expired())
         return;
 
     pWindow.lock()->m_bTearingHint = hint == WP_TEARING_CONTROL_V1_PRESENTATION_HINT_ASYNC;

--- a/src/protocols/TearingControl.cpp
+++ b/src/protocols/TearingControl.cpp
@@ -4,7 +4,8 @@
 #include "../Compositor.hpp"
 
 CTearingControlProtocol::CTearingControlProtocol(const wl_interface* iface, const int& ver, const std::string& name) : IWaylandProtocol(iface, ver, name) {
-    static auto P = g_pHookSystem->hookDynamic("destroyWindow", [this](void* self, SCallbackInfo& info, std::any param) { this->onWindowDestroy(std::any_cast<PHLWINDOW>(param)); });
+    static auto P =
+        g_pHookSystem->hookDynamic("destroyWindow", [this](void* self, SCallbackInfo& info, std::any param) { this->onWindowDestroy(std::any_cast<PHLWINDOW>(param)); });
 }
 
 void CTearingControlProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {

--- a/src/protocols/TearingControl.hpp
+++ b/src/protocols/TearingControl.hpp
@@ -27,8 +27,8 @@ class CTearingControl {
     void                               updateWindow();
 
     SP<CWpTearingControlV1>            resource;
-    CWindow*                           pWindow = nullptr;
-    wpTearingControlV1PresentationHint hint    = WP_TEARING_CONTROL_V1_PRESENTATION_HINT_VSYNC;
+    PHLWINDOWREF                       pWindow;
+    wpTearingControlV1PresentationHint hint = WP_TEARING_CONTROL_V1_PRESENTATION_HINT_VSYNC;
 
     friend class CTearingControlProtocol;
 };
@@ -43,7 +43,7 @@ class CTearingControlProtocol : public IWaylandProtocol {
     void onManagerResourceDestroy(wl_resource* res);
     void onControllerDestroy(CTearingControl* control);
     void onGetController(wl_client* client, wl_resource* resource, uint32_t id, wlr_surface* surf);
-    void onWindowDestroy(CWindow* pWindow);
+    void onWindowDestroy(PHLWINDOW pWindow);
 
     //
     std::vector<UP<CWpTearingControlManagerV1>> m_vManagers;

--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -136,7 +136,7 @@ void CToplevelExportProtocolManager::removeFrame(SScreencopyFrame* frame, bool f
     m_lFrames.remove(*frame);
 }
 
-void CToplevelExportProtocolManager::captureToplevel(wl_client* client, wl_resource* resource, uint32_t frame, int32_t overlay_cursor, CWindow* pWindow) {
+void CToplevelExportProtocolManager::captureToplevel(wl_client* client, wl_resource* resource, uint32_t frame, int32_t overlay_cursor, PHLWINDOW pWindow) {
     const auto PCLIENT = clientFromResource(resource);
 
     // create a frame
@@ -145,15 +145,15 @@ void CToplevelExportProtocolManager::captureToplevel(wl_client* client, wl_resou
     PFRAME->resource      = wl_resource_create(client, &hyprland_toplevel_export_frame_v1_interface, wl_resource_get_version(resource), frame);
     PFRAME->pWindow       = pWindow;
 
-    if (!PFRAME->pWindow) {
-        Debug::log(ERR, "Client requested sharing of window handle {:x} which does not exist!", PFRAME->pWindow);
+    if (!pWindow) {
+        Debug::log(ERR, "Client requested sharing of window handle {:x} which does not exist!", pWindow);
         hyprland_toplevel_export_frame_v1_send_failed(PFRAME->resource);
         removeFrame(PFRAME);
         return;
     }
 
-    if (!PFRAME->pWindow->m_bIsMapped || PFRAME->pWindow->isHidden()) {
-        Debug::log(ERR, "Client requested sharing of window handle {:x} which is not shareable!", PFRAME->pWindow);
+    if (!pWindow->m_bIsMapped || pWindow->isHidden()) {
+        Debug::log(ERR, "Client requested sharing of window handle {:x} which is not shareable!", pWindow);
         hyprland_toplevel_export_frame_v1_send_failed(PFRAME->resource);
         removeFrame(PFRAME);
         return;
@@ -171,7 +171,7 @@ void CToplevelExportProtocolManager::captureToplevel(wl_client* client, wl_resou
     PFRAME->client = PCLIENT;
     PCLIENT->ref++;
 
-    const auto PMONITOR = g_pCompositor->getMonitorFromID(PFRAME->pWindow->m_iMonitorID);
+    const auto PMONITOR = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
 
     g_pHyprRenderer->makeEGLCurrent();
 
@@ -197,7 +197,7 @@ void CToplevelExportProtocolManager::captureToplevel(wl_client* client, wl_resou
         PFRAME->dmabufFormat = DRM_FORMAT_INVALID;
     }
 
-    PFRAME->box = {0, 0, (int)(PFRAME->pWindow->m_vRealSize.value().x * PMONITOR->scale), (int)(PFRAME->pWindow->m_vRealSize.value().y * PMONITOR->scale)};
+    PFRAME->box = {0, 0, (int)(pWindow->m_vRealSize.value().x * PMONITOR->scale), (int)(pWindow->m_vRealSize.value().y * PMONITOR->scale)};
     int ow, oh;
     wlr_output_effective_resolution(PMONITOR->output, &ow, &oh);
     PFRAME->box.transform(PMONITOR->transform, ow, oh).round();
@@ -221,15 +221,17 @@ void CToplevelExportProtocolManager::copyFrame(wl_client* client, wl_resource* r
         return;
     }
 
-    if (!g_pCompositor->windowValidMapped(PFRAME->pWindow)) {
-        Debug::log(ERR, "Client requested sharing of window handle {:x} which is gone!", (uintptr_t)PFRAME->pWindow);
+    const auto PWINDOW = PFRAME->pWindow.lock();
+
+    if (!validMapped(PWINDOW)) {
+        Debug::log(ERR, "Client requested sharing of window handle {:x} which is gone!", (uintptr_t)PWINDOW.get());
         hyprland_toplevel_export_frame_v1_send_failed(PFRAME->resource);
         removeFrame(PFRAME);
         return;
     }
 
-    if (!PFRAME->pWindow->m_bIsMapped || PFRAME->pWindow->isHidden()) {
-        Debug::log(ERR, "Client requested sharing of window handle {:x} which is not shareable (2)!", PFRAME->pWindow);
+    if (!PWINDOW->m_bIsMapped || PWINDOW->isHidden()) {
+        Debug::log(ERR, "Client requested sharing of window handle {:x} which is not shareable (2)!", PWINDOW);
         hyprland_toplevel_export_frame_v1_send_failed(PFRAME->resource);
         removeFrame(PFRAME);
         return;
@@ -299,15 +301,17 @@ void CToplevelExportProtocolManager::onOutputCommit(CMonitor* pMonitor, wlr_outp
 
     // share frame if correct output
     for (auto& f : m_vFramesAwaitingWrite) {
-        if (!f->pWindow) {
+        const auto PWINDOW = f->pWindow.lock();
+
+        if (!validMapped(PWINDOW)) {
             framesToRemove.push_back(f);
             continue;
         }
 
-        if (PMONITOR != g_pCompositor->getMonitorFromID(f->pWindow->m_iMonitorID))
+        if (PMONITOR != g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID))
             continue;
 
-        CBox geometry = {f->pWindow->m_vRealPosition.value().x, f->pWindow->m_vRealPosition.value().y, f->pWindow->m_vRealSize.value().x, f->pWindow->m_vRealSize.value().y};
+        CBox geometry = {PWINDOW->m_vRealPosition.value().x, PWINDOW->m_vRealPosition.value().y, PWINDOW->m_vRealSize.value().x, PWINDOW->m_vRealSize.value().y};
 
         if (!wlr_output_layout_intersects(g_pCompositor->m_sWLROutputLayout, pMonitor->output, geometry.pWlr()))
             continue;
@@ -326,7 +330,7 @@ void CToplevelExportProtocolManager::onOutputCommit(CMonitor* pMonitor, wlr_outp
 }
 
 void CToplevelExportProtocolManager::shareFrame(SScreencopyFrame* frame) {
-    if (!frame->buffer || !g_pCompositor->windowValidMapped(frame->pWindow))
+    if (!frame->buffer || !validMapped(frame->pWindow))
         return;
 
     timespec now;
@@ -365,7 +369,7 @@ bool CToplevelExportProtocolManager::copyFrameShm(SScreencopyFrame* frame, times
         return false;
 
     // render the client
-    const auto PMONITOR = g_pCompositor->getMonitorFromID(frame->pWindow->m_iMonitorID);
+    const auto PMONITOR = g_pCompositor->getMonitorFromID(frame->pWindow.lock()->m_iMonitorID);
     CRegion    fakeDamage{0, 0, PMONITOR->vecPixelSize.x * 10, PMONITOR->vecPixelSize.y * 10};
 
     g_pHyprRenderer->makeEGLCurrent();
@@ -384,12 +388,12 @@ bool CToplevelExportProtocolManager::copyFrameShm(SScreencopyFrame* frame, times
     g_pHyprOpenGL->clear(CColor(0, 0, 0, 1.0));
 
     // render client at 0,0
-    g_pHyprRenderer->m_bBlockSurfaceFeedback = g_pHyprRenderer->shouldRenderWindow(frame->pWindow); // block the feedback to avoid spamming the surface if it's visible
-    g_pHyprRenderer->renderWindow(frame->pWindow, PMONITOR, now, false, RENDER_PASS_ALL, true, true);
+    g_pHyprRenderer->m_bBlockSurfaceFeedback = g_pHyprRenderer->shouldRenderWindow(frame->pWindow.lock()); // block the feedback to avoid spamming the surface if it's visible
+    g_pHyprRenderer->renderWindow(frame->pWindow.lock(), PMONITOR, now, false, RENDER_PASS_ALL, true, true);
     g_pHyprRenderer->m_bBlockSurfaceFeedback = false;
 
     if (frame->overlayCursor)
-        g_pHyprRenderer->renderSoftwareCursors(PMONITOR, fakeDamage, g_pInputManager->getMouseCoordsInternal() - frame->pWindow->m_vRealPosition.value());
+        g_pHyprRenderer->renderSoftwareCursors(PMONITOR, fakeDamage, g_pInputManager->getMouseCoordsInternal() - frame->pWindow.lock()->m_vRealPosition.value());
 
     const auto PFORMAT = g_pHyprOpenGL->getPixelFormatFromDRM(format);
     if (!PFORMAT) {
@@ -422,7 +426,7 @@ bool CToplevelExportProtocolManager::copyFrameShm(SScreencopyFrame* frame, times
 }
 
 bool CToplevelExportProtocolManager::copyFrameDmabuf(SScreencopyFrame* frame, timespec* now) {
-    const auto PMONITOR = g_pCompositor->getMonitorFromID(frame->pWindow->m_iMonitorID);
+    const auto PMONITOR = g_pCompositor->getMonitorFromID(frame->pWindow.lock()->m_iMonitorID);
 
     CRegion    fakeDamage{0, 0, INT16_MAX, INT16_MAX};
 
@@ -431,21 +435,21 @@ bool CToplevelExportProtocolManager::copyFrameDmabuf(SScreencopyFrame* frame, ti
 
     g_pHyprOpenGL->clear(CColor(0, 0, 0, 1.0));
 
-    g_pHyprRenderer->m_bBlockSurfaceFeedback = g_pHyprRenderer->shouldRenderWindow(frame->pWindow); // block the feedback to avoid spamming the surface if it's visible
-    g_pHyprRenderer->renderWindow(frame->pWindow, PMONITOR, now, false, RENDER_PASS_ALL, true, true);
+    g_pHyprRenderer->m_bBlockSurfaceFeedback = g_pHyprRenderer->shouldRenderWindow(frame->pWindow.lock()); // block the feedback to avoid spamming the surface if it's visible
+    g_pHyprRenderer->renderWindow(frame->pWindow.lock(), PMONITOR, now, false, RENDER_PASS_ALL, true, true);
     g_pHyprRenderer->m_bBlockSurfaceFeedback = false;
 
     if (frame->overlayCursor)
-        g_pHyprRenderer->renderSoftwareCursors(PMONITOR, fakeDamage, g_pInputManager->getMouseCoordsInternal() - frame->pWindow->m_vRealPosition.value());
+        g_pHyprRenderer->renderSoftwareCursors(PMONITOR, fakeDamage, g_pInputManager->getMouseCoordsInternal() - frame->pWindow.lock()->m_vRealPosition.value());
 
     g_pHyprOpenGL->m_RenderData.blockScreenShader = true;
     g_pHyprRenderer->endRender();
     return true;
 }
 
-void CToplevelExportProtocolManager::onWindowUnmap(CWindow* pWindow) {
+void CToplevelExportProtocolManager::onWindowUnmap(PHLWINDOW pWindow) {
     for (auto& f : m_lFrames) {
-        if (f.pWindow == pWindow)
-            f.pWindow = nullptr;
+        if (f.pWindow.lock() == pWindow)
+            f.pWindow.reset();
     }
 }

--- a/src/protocols/ToplevelExport.hpp
+++ b/src/protocols/ToplevelExport.hpp
@@ -15,12 +15,12 @@ class CToplevelExportProtocolManager {
     CToplevelExportProtocolManager();
 
     void bindManager(wl_client* client, void* data, uint32_t version, uint32_t id);
-    void captureToplevel(wl_client* client, wl_resource* resource, uint32_t frame, int32_t overlay_cursor, CWindow* handle);
+    void captureToplevel(wl_client* client, wl_resource* resource, uint32_t frame, int32_t overlay_cursor, PHLWINDOW handle);
     void removeClient(CScreencopyClient* client, bool force = false);
     void removeFrame(SScreencopyFrame* frame, bool force = false);
     void copyFrame(wl_client* client, wl_resource* resource, wl_resource* buffer, int32_t ignore_damage);
     void displayDestroy();
-    void onWindowUnmap(CWindow* pWindow);
+    void onWindowUnmap(PHLWINDOW pWindow);
     void onOutputCommit(CMonitor* pMonitor, wlr_output_event_commit* e);
 
   private:

--- a/src/protocols/WaylandProtocol.hpp
+++ b/src/protocols/WaylandProtocol.hpp
@@ -9,10 +9,6 @@
     if (!resname)                                                                                                                                                                  \
         return;
 
-#define SP std::shared_ptr
-#define UP std::unique_ptr
-#define WP std::weak_ptr
-
 #define PROTO NProtocols
 
 class IWaylandProtocol {

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -167,7 +167,7 @@ bool CHyprOpenGLImpl::passRequiresIntrospection(CMonitor* pMonitor) {
     if (m_RenderData.pCurrentMonData->blurFBShouldRender)
         return true;
 
-    if (pMonitor->solitaryClient.lock())
+    if (!pMonitor->solitaryClient.expired())
         return false;
 
     for (auto& ls : pMonitor->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]) {
@@ -1333,7 +1333,7 @@ void CHyprOpenGLImpl::preRender(CMonitor* pMonitor) {
         return;
 
     // ignore if solitary present, nothing to blur
-    if (pMonitor->solitaryClient.lock())
+    if (!pMonitor->solitaryClient.expired())
         return;
 
     // check if we need to update the blur fb

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -167,7 +167,7 @@ bool CHyprOpenGLImpl::passRequiresIntrospection(CMonitor* pMonitor) {
     if (m_RenderData.pCurrentMonData->blurFBShouldRender)
         return true;
 
-    if (pMonitor->solitaryClient)
+    if (pMonitor->solitaryClient.lock())
         return false;
 
     for (auto& ls : pMonitor->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]) {
@@ -224,7 +224,7 @@ bool CHyprOpenGLImpl::passRequiresIntrospection(CMonitor* pMonitor) {
         if (!w->m_bIsMapped || w->isHidden())
             continue;
 
-        if (!g_pHyprRenderer->shouldRenderWindow(w.get()))
+        if (!g_pHyprRenderer->shouldRenderWindow(w))
             continue;
 
         if (w->popupsCount() > 0 && *PBLURPOPUPS)
@@ -873,7 +873,7 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(const CTexture& tex, CBox*
         }
     }
 
-    if (m_pCurrentWindow && m_pCurrentWindow->m_sAdditionalConfigData.forceRGBX)
+    if (m_pCurrentWindow.lock() && m_pCurrentWindow.lock()->m_sAdditionalConfigData.forceRGBX)
         shader = &m_RenderData.pCurrentMonData->m_shRGBX;
 
     glActiveTexture(GL_TEXTURE0);
@@ -940,9 +940,9 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(const CTexture& tex, CBox*
         glUniform2f(shader->fullSize, FULLSIZE.x, FULLSIZE.y);
         glUniform1f(shader->radius, round);
 
-        if (allowDim && m_pCurrentWindow && *PDIMINACTIVE) {
+        if (allowDim && m_pCurrentWindow.lock() && *PDIMINACTIVE) {
             glUniform1i(shader->applyTint, 1);
-            const auto DIM = m_pCurrentWindow->m_fDimPercent.value();
+            const auto DIM = m_pCurrentWindow.lock()->m_fDimPercent.value();
             glUniform3f(shader->tint, 1.f - DIM, 1.f - DIM, 1.f - DIM);
         } else {
             glUniform1i(shader->applyTint, 0);
@@ -1333,14 +1333,14 @@ void CHyprOpenGLImpl::preRender(CMonitor* pMonitor) {
         return;
 
     // ignore if solitary present, nothing to blur
-    if (pMonitor->solitaryClient)
+    if (pMonitor->solitaryClient.lock())
         return;
 
     // check if we need to update the blur fb
     // if there are no windows that would benefit from it,
     // we will ignore that the blur FB is dirty.
 
-    auto windowShouldBeBlurred = [&](CWindow* pWindow) -> bool {
+    auto windowShouldBeBlurred = [&](PHLWINDOW pWindow) -> bool {
         if (!pWindow)
             return false;
 
@@ -1377,7 +1377,7 @@ void CHyprOpenGLImpl::preRender(CMonitor* pMonitor) {
         if (w->m_pWorkspace == pMonitor->activeWorkspace && !w->isHidden() && w->m_bIsMapped && (!w->m_bIsFloating || *PBLURXRAY)) {
 
             // check if window is valid
-            if (!windowShouldBeBlurred(w.get()))
+            if (!windowShouldBeBlurred(w))
                 continue;
 
             hasWindows = true;
@@ -1453,7 +1453,7 @@ bool CHyprOpenGLImpl::preBlurQueued() {
     return !(!m_RenderData.pCurrentMonData->blurFBDirty || !*PBLURNEWOPTIMIZE || !*PBLUR || !m_RenderData.pCurrentMonData->blurFBShouldRender);
 }
 
-bool CHyprOpenGLImpl::shouldUseNewBlurOptimizations(SLayerSurface* pLayer, CWindow* pWindow) {
+bool CHyprOpenGLImpl::shouldUseNewBlurOptimizations(SLayerSurface* pLayer, PHLWINDOW pWindow) {
     static auto PBLURNEWOPTIMIZE = CConfigValue<Hyprlang::INT>("decoration:blur:new_optimizations");
     static auto PBLURXRAY        = CConfigValue<Hyprlang::INT>("decoration:blur:xray");
 
@@ -1493,7 +1493,7 @@ void CHyprOpenGLImpl::renderTextureWithBlur(const CTexture& tex, CBox* pBox, flo
     m_RenderData.renderModif.applyToRegion(texDamage);
 
     if (*PBLURENABLED == 0 || (*PNOBLUROVERSIZED && m_RenderData.primarySurfaceUVTopLeft != Vector2D(-1, -1)) ||
-        (m_pCurrentWindow && (m_pCurrentWindow->m_sAdditionalConfigData.forceNoBlur || m_pCurrentWindow->m_sAdditionalConfigData.forceRGBX))) {
+        (m_pCurrentWindow.lock() && (m_pCurrentWindow.lock()->m_sAdditionalConfigData.forceNoBlur || m_pCurrentWindow.lock()->m_sAdditionalConfigData.forceRGBX))) {
         renderTexture(tex, pBox, a, round, false, true);
         return;
     }
@@ -1517,7 +1517,7 @@ void CHyprOpenGLImpl::renderTextureWithBlur(const CTexture& tex, CBox* pBox, flo
     wlr_region_scale(inverseOpaque.pixman(), inverseOpaque.pixman(), m_RenderData.pMonitor->scale);
 
     //   vvv TODO: layered blur fbs?
-    const bool    USENEWOPTIMIZE = shouldUseNewBlurOptimizations(m_pCurrentLayer, m_pCurrentWindow) && !blockBlurOptimization;
+    const bool    USENEWOPTIMIZE = shouldUseNewBlurOptimizations(m_pCurrentLayer, m_pCurrentWindow.lock()) && !blockBlurOptimization;
 
     CFramebuffer* POUTFB = nullptr;
     if (!USENEWOPTIMIZE) {
@@ -1590,7 +1590,7 @@ void CHyprOpenGLImpl::renderBorder(CBox* box, const CGradientValueData& grad, in
 
     TRACY_GPU_ZONE("RenderBorder");
 
-    if (m_RenderData.damage.empty() || (m_pCurrentWindow && m_pCurrentWindow->m_sAdditionalConfigData.forceNoBorder))
+    if (m_RenderData.damage.empty() || (m_pCurrentWindow.lock() && m_pCurrentWindow.lock()->m_sAdditionalConfigData.forceNoBorder))
         return;
 
     CBox newBox = *box;
@@ -1681,7 +1681,7 @@ void CHyprOpenGLImpl::renderBorder(CBox* box, const CGradientValueData& grad, in
     blend(BLEND);
 }
 
-void CHyprOpenGLImpl::makeRawWindowSnapshot(CWindow* pWindow, CFramebuffer* pFramebuffer) {
+void CHyprOpenGLImpl::makeRawWindowSnapshot(PHLWINDOW pWindow, CFramebuffer* pFramebuffer) {
     // we trust the window is valid.
     const auto PMONITOR = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
 
@@ -1729,7 +1729,7 @@ void CHyprOpenGLImpl::makeRawWindowSnapshot(CWindow* pWindow, CFramebuffer* pFra
     g_pHyprRenderer->endRender();
 }
 
-void CHyprOpenGLImpl::makeWindowSnapshot(CWindow* pWindow) {
+void CHyprOpenGLImpl::makeWindowSnapshot(PHLWINDOW pWindow) {
     // we trust the window is valid.
     const auto PMONITOR = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
 
@@ -1744,9 +1744,11 @@ void CHyprOpenGLImpl::makeWindowSnapshot(CWindow* pWindow) {
     // this is temporary, doesnt mess with the actual wlr damage
     CRegion fakeDamage{0, 0, (int)PMONITOR->vecTransformedSize.x, (int)PMONITOR->vecTransformedSize.y};
 
+    PHLWINDOWREF ref{pWindow};
+
     g_pHyprRenderer->makeEGLCurrent();
 
-    const auto PFRAMEBUFFER = &m_mWindowFramebuffers[pWindow];
+    const auto PFRAMEBUFFER = &m_mWindowFramebuffers[ref];
 
     PFRAMEBUFFER->alloc(PMONITOR->vecPixelSize.x, PMONITOR->vecPixelSize.y, PMONITOR->drmFormat);
 
@@ -1819,46 +1821,46 @@ void CHyprOpenGLImpl::makeLayerSnapshot(SLayerSurface* pLayer) {
     g_pHyprRenderer->m_bRenderingSnapshot = false;
 }
 
-void CHyprOpenGLImpl::renderSnapshot(CWindow** pWindow) {
+void CHyprOpenGLImpl::renderSnapshot(PHLWINDOW pWindow) {
     RASSERT(m_RenderData.pMonitor, "Tried to render snapshot rect without begin()!");
-    const auto  PWINDOW = *pWindow;
 
     static auto PDIMAROUND = CConfigValue<Hyprlang::FLOAT>("decoration:dim_around");
 
-    auto        it = m_mWindowFramebuffers.begin();
-    for (; it != m_mWindowFramebuffers.end(); it++) {
-        if (it->first == PWINDOW) {
-            break;
-        }
-    }
+    PHLWINDOWREF ref{pWindow};
 
-    if (it == m_mWindowFramebuffers.end() || !it->second.m_cTex.m_iTexID)
+
+    if (!m_mWindowFramebuffers.contains(ref))
         return;
 
-    const auto PMONITOR = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID);
+    const auto FBDATA = &m_mWindowFramebuffers.at(ref);
+
+    if (!FBDATA->m_cTex.m_iTexID)
+        return;
+
+    const auto PMONITOR = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
 
     CBox       windowBox;
     // some mafs to figure out the correct box
     // the originalClosedPos is relative to the monitor's pos
-    Vector2D scaleXY = Vector2D((PMONITOR->scale * PWINDOW->m_vRealSize.value().x / (PWINDOW->m_vOriginalClosedSize.x * PMONITOR->scale)),
-                                (PMONITOR->scale * PWINDOW->m_vRealSize.value().y / (PWINDOW->m_vOriginalClosedSize.y * PMONITOR->scale)));
+    Vector2D scaleXY = Vector2D((PMONITOR->scale * pWindow->m_vRealSize.value().x / (pWindow->m_vOriginalClosedSize.x * PMONITOR->scale)),
+                                (PMONITOR->scale * pWindow->m_vRealSize.value().y / (pWindow->m_vOriginalClosedSize.y * PMONITOR->scale)));
 
     windowBox.width  = PMONITOR->vecTransformedSize.x * scaleXY.x;
     windowBox.height = PMONITOR->vecTransformedSize.y * scaleXY.y;
-    windowBox.x      = ((PWINDOW->m_vRealPosition.value().x - PMONITOR->vecPosition.x) * PMONITOR->scale) - ((PWINDOW->m_vOriginalClosedPos.x * PMONITOR->scale) * scaleXY.x);
-    windowBox.y      = ((PWINDOW->m_vRealPosition.value().y - PMONITOR->vecPosition.y) * PMONITOR->scale) - ((PWINDOW->m_vOriginalClosedPos.y * PMONITOR->scale) * scaleXY.y);
+    windowBox.x      = ((pWindow->m_vRealPosition.value().x - PMONITOR->vecPosition.x) * PMONITOR->scale) - ((pWindow->m_vOriginalClosedPos.x * PMONITOR->scale) * scaleXY.x);
+    windowBox.y      = ((pWindow->m_vRealPosition.value().y - PMONITOR->vecPosition.y) * PMONITOR->scale) - ((pWindow->m_vOriginalClosedPos.y * PMONITOR->scale) * scaleXY.y);
 
     CRegion fakeDamage{0, 0, PMONITOR->vecTransformedSize.x, PMONITOR->vecTransformedSize.y};
 
-    if (*PDIMAROUND && (*pWindow)->m_sAdditionalConfigData.dimAround) {
+    if (*PDIMAROUND && pWindow->m_sAdditionalConfigData.dimAround) {
         CBox monbox = {0, 0, g_pHyprOpenGL->m_RenderData.pMonitor->vecPixelSize.x, g_pHyprOpenGL->m_RenderData.pMonitor->vecPixelSize.y};
-        g_pHyprOpenGL->renderRect(&monbox, CColor(0, 0, 0, *PDIMAROUND * PWINDOW->m_fAlpha.value()));
+        g_pHyprOpenGL->renderRect(&monbox, CColor(0, 0, 0, *PDIMAROUND * pWindow->m_fAlpha.value()));
         g_pHyprRenderer->damageMonitor(PMONITOR);
     }
 
     m_bEndFrame = true;
 
-    renderTextureInternalWithDamage(it->second.m_cTex, &windowBox, PWINDOW->m_fAlpha.value(), &fakeDamage, 0);
+    renderTextureInternalWithDamage(FBDATA->m_cTex, &windowBox, pWindow->m_fAlpha.value(), &fakeDamage, 0);
 
     m_bEndFrame = false;
 }
@@ -1902,7 +1904,7 @@ void CHyprOpenGLImpl::renderSnapshot(SLayerSurface** pLayer) {
 void CHyprOpenGLImpl::renderRoundedShadow(CBox* box, int round, int range, const CColor& color, float a) {
     RASSERT(m_RenderData.pMonitor, "Tried to render shadow without begin()!");
     RASSERT((box->width > 0 && box->height > 0), "Tried to render shadow with width/height < 0!");
-    RASSERT(m_pCurrentWindow, "Tried to render shadow without a window!");
+    RASSERT(m_pCurrentWindow.lock(), "Tried to render shadow without a window!");
 
     if (m_RenderData.damage.empty())
         return;

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1742,7 +1742,7 @@ void CHyprOpenGLImpl::makeWindowSnapshot(PHLWINDOW pWindow) {
     // we need to "damage" the entire monitor
     // so that we render the entire window
     // this is temporary, doesnt mess with the actual wlr damage
-    CRegion fakeDamage{0, 0, (int)PMONITOR->vecTransformedSize.x, (int)PMONITOR->vecTransformedSize.y};
+    CRegion      fakeDamage{0, 0, (int)PMONITOR->vecTransformedSize.x, (int)PMONITOR->vecTransformedSize.y};
 
     PHLWINDOWREF ref{pWindow};
 
@@ -1824,10 +1824,9 @@ void CHyprOpenGLImpl::makeLayerSnapshot(SLayerSurface* pLayer) {
 void CHyprOpenGLImpl::renderSnapshot(PHLWINDOW pWindow) {
     RASSERT(m_RenderData.pMonitor, "Tried to render snapshot rect without begin()!");
 
-    static auto PDIMAROUND = CConfigValue<Hyprlang::FLOAT>("decoration:dim_around");
+    static auto  PDIMAROUND = CConfigValue<Hyprlang::FLOAT>("decoration:dim_around");
 
     PHLWINDOWREF ref{pWindow};
-
 
     if (!m_mWindowFramebuffers.contains(ref))
         return;

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -7,6 +7,7 @@
 #include "../helpers/Region.hpp"
 #include <list>
 #include <unordered_map>
+#include <map>
 
 #include <cairo/cairo.h>
 
@@ -151,12 +152,12 @@ class CHyprOpenGLImpl {
 
     void                  blend(bool enabled);
 
-    void                  makeWindowSnapshot(CWindow*);
-    void                  makeRawWindowSnapshot(CWindow*, CFramebuffer*);
+    void                  makeWindowSnapshot(PHLWINDOW);
+    void                  makeRawWindowSnapshot(PHLWINDOW, CFramebuffer*);
     void                  makeLayerSnapshot(SLayerSurface*);
-    void                  renderSnapshot(CWindow**);
+    void                  renderSnapshot(PHLWINDOW);
     void                  renderSnapshot(SLayerSurface**);
-    bool                  shouldUseNewBlurOptimizations(SLayerSurface* pLayer, CWindow* pWindow);
+    bool                  shouldUseNewBlurOptimizations(SLayerSurface* pLayer, PHLWINDOW pWindow);
 
     void                  clear(const CColor&);
     void                  clearWithTex();
@@ -192,10 +193,10 @@ class CHyprOpenGLImpl {
 
     bool                  m_bReloadScreenShader = true; // at launch it can be set
 
-    CWindow*              m_pCurrentWindow = nullptr; // hack to get the current rendered window
-    SLayerSurface*        m_pCurrentLayer  = nullptr; // hack to get the current rendered layer
+    PHLWINDOWREF          m_pCurrentWindow;          // hack to get the current rendered window
+    SLayerSurface*        m_pCurrentLayer = nullptr; // hack to get the current rendered layer
 
-    std::unordered_map<CWindow*, CFramebuffer>        m_mWindowFramebuffers;
+    std::map<PHLWINDOWREF, CFramebuffer, std::owner_less<PHLWINDOWREF>>    m_mWindowFramebuffers;
     std::unordered_map<SLayerSurface*, CFramebuffer>  m_mLayerFramebuffers;
     std::unordered_map<CMonitor*, SMonitorRenderData> m_mMonitorRenderResources;
     std::unordered_map<CMonitor*, CFramebuffer>       m_mMonitorBGFBs;

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -196,10 +196,10 @@ class CHyprOpenGLImpl {
     PHLWINDOWREF          m_pCurrentWindow;          // hack to get the current rendered window
     SLayerSurface*        m_pCurrentLayer = nullptr; // hack to get the current rendered layer
 
-    std::map<PHLWINDOWREF, CFramebuffer, std::owner_less<PHLWINDOWREF>>    m_mWindowFramebuffers;
-    std::unordered_map<SLayerSurface*, CFramebuffer>  m_mLayerFramebuffers;
-    std::unordered_map<CMonitor*, SMonitorRenderData> m_mMonitorRenderResources;
-    std::unordered_map<CMonitor*, CFramebuffer>       m_mMonitorBGFBs;
+    std::map<PHLWINDOWREF, CFramebuffer, std::owner_less<PHLWINDOWREF>> m_mWindowFramebuffers;
+    std::unordered_map<SLayerSurface*, CFramebuffer>                    m_mLayerFramebuffers;
+    std::unordered_map<CMonitor*, SMonitorRenderData>                   m_mMonitorRenderResources;
+    std::unordered_map<CMonitor*, CFramebuffer>                         m_mMonitorBGFBs;
 
     struct {
         PFNGLEGLIMAGETARGETRENDERBUFFERSTORAGEOESPROC glEGLImageTargetRenderbufferStorageOES = nullptr;

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -46,19 +46,19 @@ class CHyprRenderer {
     void                            outputMgrApplyTest(wlr_output_configuration_v1*, bool);
     void                            arrangeLayersForMonitor(const int&);
     void                            damageSurface(wlr_surface*, double, double, double scale = 1.0);
-    void                            damageWindow(CWindow*, bool forceFull = false);
+    void                            damageWindow(PHLWINDOW, bool forceFull = false);
     void                            damageBox(CBox*);
     void                            damageBox(const int& x, const int& y, const int& w, const int& h);
     void                            damageRegion(const CRegion&);
     void                            damageMonitor(CMonitor*);
     void                            damageMirrorsWith(CMonitor*, const CRegion&);
     bool                            applyMonitorRule(CMonitor*, SMonitorRule*, bool force = false);
-    bool                            shouldRenderWindow(CWindow*, CMonitor*);
-    bool                            shouldRenderWindow(CWindow*);
+    bool                            shouldRenderWindow(PHLWINDOW, CMonitor*);
+    bool                            shouldRenderWindow(PHLWINDOW);
     void                            ensureCursorRenderingMode();
     bool                            shouldRenderCursor();
     void                            setCursorHidden(bool hide);
-    void                            calculateUVForSurface(CWindow*, wlr_surface*, bool main = false, const Vector2D& projSize = {}, bool fixMisalignedFSV1 = false);
+    void                            calculateUVForSurface(PHLWINDOW, wlr_surface*, bool main = false, const Vector2D& projSize = {}, bool fixMisalignedFSV1 = false);
     std::tuple<float, float, float> getRenderTimes(CMonitor* pMonitor); // avg max min
     void                            renderLockscreen(CMonitor* pMonitor, timespec* now, const CBox& geometry);
     void                            setOccludedForBackLayers(CRegion& region, PHLWORKSPACE pWorkspace);
@@ -76,21 +76,21 @@ class CHyprRenderer {
 
     // if RENDER_MODE_NORMAL, provided damage will be written to.
     // otherwise, it will be the one used.
-    bool      beginRender(CMonitor* pMonitor, CRegion& damage, eRenderMode mode = RENDER_MODE_NORMAL, wlr_buffer* buffer = nullptr, CFramebuffer* fb = nullptr);
-    void      endRender();
+    bool         beginRender(CMonitor* pMonitor, CRegion& damage, eRenderMode mode = RENDER_MODE_NORMAL, wlr_buffer* buffer = nullptr, CFramebuffer* fb = nullptr);
+    void         endRender();
 
-    bool      m_bBlockSurfaceFeedback  = false;
-    bool      m_bRenderingSnapshot     = false;
-    CWindow*  m_pLastScanout           = nullptr;
-    CMonitor* m_pMostHzMonitor         = nullptr;
-    bool      m_bDirectScanoutBlocked  = false;
-    bool      m_bSoftwareCursorsLocked = false;
+    bool         m_bBlockSurfaceFeedback = false;
+    bool         m_bRenderingSnapshot    = false;
+    PHLWINDOWREF m_pLastScanout;
+    CMonitor*    m_pMostHzMonitor         = nullptr;
+    bool         m_bDirectScanoutBlocked  = false;
+    bool         m_bSoftwareCursorsLocked = false;
 
     DAMAGETRACKINGMODES
     damageTrackingModeFromStr(const std::string&);
 
     bool             attemptDirectScanout(CMonitor*);
-    void             setWindowScanoutMode(CWindow*);
+    void             setWindowScanoutMode(PHLWINDOW);
     void             initiateManualCrash();
 
     bool             m_bCrashingInProgress = false;
@@ -111,7 +111,7 @@ class CHyprRenderer {
     void           arrangeLayerArray(CMonitor*, const std::vector<std::unique_ptr<SLayerSurface>>&, bool, CBox*);
     void           renderWorkspaceWindowsFullscreen(CMonitor*, PHLWORKSPACE, timespec*); // renders workspace windows (fullscreen) (tiled, floating, pinned, but no special)
     void           renderWorkspaceWindows(CMonitor*, PHLWORKSPACE, timespec*);           // renders workspace windows (no fullscreen) (tiled, floating, pinned, but no special)
-    void           renderWindow(CWindow*, CMonitor*, timespec*, bool, eRenderPassMode, bool ignorePosition = false, bool ignoreAllGeometry = false);
+    void           renderWindow(PHLWINDOW, CMonitor*, timespec*, bool, eRenderPassMode, bool ignorePosition = false, bool ignoreAllGeometry = false);
     void           renderLayer(SLayerSurface*, CMonitor*, timespec*, bool popups = false);
     void           renderSessionLockSurface(SSessionLockSurface*, CMonitor*, timespec*);
     void           renderDragIcon(CMonitor*, timespec*);

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -52,7 +52,8 @@ void CHyprBorderDecoration::draw(CMonitor* pMonitor, float a) {
     if (m_bAssignedGeometry.width < m_seExtents.topLeft.x + 1 || m_bAssignedGeometry.height < m_seExtents.topLeft.y + 1)
         return;
 
-    CBox windowBox = assignedBoxGlobal().translate(-pMonitor->vecPosition + m_pWindow.lock()->m_vFloatingOffset).expand(-m_pWindow.lock()->getRealBorderSize()).scale(pMonitor->scale).round();
+    CBox windowBox =
+        assignedBoxGlobal().translate(-pMonitor->vecPosition + m_pWindow.lock()->m_vFloatingOffset).expand(-m_pWindow.lock()->getRealBorderSize()).scale(pMonitor->scale).round();
 
     if (windowBox.width < 1 || windowBox.height < 1)
         return;

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -2,7 +2,7 @@
 #include "../../Compositor.hpp"
 #include "../../config/ConfigValue.hpp"
 
-CHyprBorderDecoration::CHyprBorderDecoration(CWindow* pWindow) : IHyprWindowDecoration(pWindow) {
+CHyprBorderDecoration::CHyprBorderDecoration(PHLWINDOW pWindow) : IHyprWindowDecoration(pWindow) {
     m_pWindow = pWindow;
 }
 
@@ -11,7 +11,7 @@ CHyprBorderDecoration::~CHyprBorderDecoration() {
 }
 
 SDecorationPositioningInfo CHyprBorderDecoration::getPositioningInfo() {
-    const auto BORDERSIZE = m_pWindow->getRealBorderSize();
+    const auto BORDERSIZE = m_pWindow.lock()->getRealBorderSize();
     m_seExtents           = {{BORDERSIZE, BORDERSIZE}, {BORDERSIZE, BORDERSIZE}};
 
     if (doesntWantBorders())
@@ -34,14 +34,14 @@ void CHyprBorderDecoration::onPositioningReply(const SDecorationPositioningReply
 
 CBox CHyprBorderDecoration::assignedBoxGlobal() {
     CBox box = m_bAssignedGeometry;
-    box.translate(g_pDecorationPositioner->getEdgeDefinedPoint(DECORATION_EDGE_BOTTOM | DECORATION_EDGE_LEFT | DECORATION_EDGE_RIGHT | DECORATION_EDGE_TOP, m_pWindow));
+    box.translate(g_pDecorationPositioner->getEdgeDefinedPoint(DECORATION_EDGE_BOTTOM | DECORATION_EDGE_LEFT | DECORATION_EDGE_RIGHT | DECORATION_EDGE_TOP, m_pWindow.lock()));
 
-    const auto PWORKSPACE = m_pWindow->m_pWorkspace;
+    const auto PWORKSPACE = m_pWindow.lock()->m_pWorkspace;
 
     if (!PWORKSPACE)
         return box;
 
-    const auto WORKSPACEOFFSET = PWORKSPACE && !m_pWindow->m_bPinned ? PWORKSPACE->m_vRenderOffset.value() : Vector2D();
+    const auto WORKSPACEOFFSET = PWORKSPACE && !m_pWindow.lock()->m_bPinned ? PWORKSPACE->m_vRenderOffset.value() : Vector2D();
     return box.translate(WORKSPACEOFFSET);
 }
 
@@ -52,28 +52,28 @@ void CHyprBorderDecoration::draw(CMonitor* pMonitor, float a) {
     if (m_bAssignedGeometry.width < m_seExtents.topLeft.x + 1 || m_bAssignedGeometry.height < m_seExtents.topLeft.y + 1)
         return;
 
-    CBox windowBox = assignedBoxGlobal().translate(-pMonitor->vecPosition + m_pWindow->m_vFloatingOffset).expand(-m_pWindow->getRealBorderSize()).scale(pMonitor->scale).round();
+    CBox windowBox = assignedBoxGlobal().translate(-pMonitor->vecPosition + m_pWindow.lock()->m_vFloatingOffset).expand(-m_pWindow.lock()->getRealBorderSize()).scale(pMonitor->scale).round();
 
     if (windowBox.width < 1 || windowBox.height < 1)
         return;
 
-    auto       grad     = m_pWindow->m_cRealBorderColor;
-    const bool ANIMATED = m_pWindow->m_fBorderFadeAnimationProgress.isBeingAnimated();
-    float      a1       = a * (ANIMATED ? m_pWindow->m_fBorderFadeAnimationProgress.value() : 1.f);
+    auto       grad     = m_pWindow.lock()->m_cRealBorderColor;
+    const bool ANIMATED = m_pWindow.lock()->m_fBorderFadeAnimationProgress.isBeingAnimated();
+    float      a1       = a * (ANIMATED ? m_pWindow.lock()->m_fBorderFadeAnimationProgress.value() : 1.f);
 
-    if (m_pWindow->m_fBorderAngleAnimationProgress.getConfig()->pValues->internalEnabled) {
-        grad.m_fAngle += m_pWindow->m_fBorderAngleAnimationProgress.value() * M_PI * 2;
+    if (m_pWindow.lock()->m_fBorderAngleAnimationProgress.getConfig()->pValues->internalEnabled) {
+        grad.m_fAngle += m_pWindow.lock()->m_fBorderAngleAnimationProgress.value() * M_PI * 2;
         grad.m_fAngle = normalizeAngleRad(grad.m_fAngle);
     }
 
-    int        borderSize = m_pWindow->getRealBorderSize();
-    const auto ROUNDING   = m_pWindow->rounding() * pMonitor->scale;
+    int        borderSize = m_pWindow.lock()->getRealBorderSize();
+    const auto ROUNDING   = m_pWindow.lock()->rounding() * pMonitor->scale;
 
     g_pHyprOpenGL->renderBorder(&windowBox, grad, ROUNDING, borderSize, a1);
 
     if (ANIMATED) {
-        float a2 = a * (1.f - m_pWindow->m_fBorderFadeAnimationProgress.value());
-        g_pHyprOpenGL->renderBorder(&windowBox, m_pWindow->m_cRealBorderColorPrevious, ROUNDING, borderSize, a2);
+        float a2 = a * (1.f - m_pWindow.lock()->m_fBorderFadeAnimationProgress.value());
+        g_pHyprOpenGL->renderBorder(&windowBox, m_pWindow.lock()->m_cRealBorderColorPrevious, ROUNDING, borderSize, a2);
     }
 }
 
@@ -81,24 +81,24 @@ eDecorationType CHyprBorderDecoration::getDecorationType() {
     return DECORATION_BORDER;
 }
 
-void CHyprBorderDecoration::updateWindow(CWindow*) {
-    if (m_pWindow->getRealBorderSize() != m_seExtents.topLeft.x)
+void CHyprBorderDecoration::updateWindow(PHLWINDOW) {
+    if (m_pWindow.lock()->getRealBorderSize() != m_seExtents.topLeft.x)
         g_pDecorationPositioner->repositionDeco(this);
 }
 
 void CHyprBorderDecoration::damageEntire() {
-    if (!g_pCompositor->windowValidMapped(m_pWindow))
+    if (!validMapped(m_pWindow))
         return;
 
-    auto       surfaceBox   = m_pWindow->getWindowMainSurfaceBox();
-    const auto ROUNDING     = m_pWindow->rounding();
+    auto       surfaceBox   = m_pWindow.lock()->getWindowMainSurfaceBox();
+    const auto ROUNDING     = m_pWindow.lock()->rounding();
     const auto ROUNDINGSIZE = ROUNDING - M_SQRT1_2 * ROUNDING + 2;
-    const auto BORDERSIZE   = m_pWindow->getRealBorderSize() + 1;
+    const auto BORDERSIZE   = m_pWindow.lock()->getRealBorderSize() + 1;
 
-    const auto PWINDOWWORKSPACE = m_pWindow->m_pWorkspace;
-    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_vRenderOffset.isBeingAnimated() && !m_pWindow->m_bPinned)
+    const auto PWINDOWWORKSPACE = m_pWindow.lock()->m_pWorkspace;
+    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_vRenderOffset.isBeingAnimated() && !m_pWindow.lock()->m_bPinned)
         surfaceBox.translate(PWINDOWWORKSPACE->m_vRenderOffset.value());
-    surfaceBox.translate(m_pWindow->m_vFloatingOffset);
+    surfaceBox.translate(m_pWindow.lock()->m_vFloatingOffset);
 
     CBox surfaceBoxExpandedBorder = surfaceBox;
     surfaceBoxExpandedBorder.expand(BORDERSIZE);
@@ -109,7 +109,7 @@ void CHyprBorderDecoration::damageEntire() {
     borderRegion.subtract(surfaceBoxShrunkRounding);
 
     for (auto& m : g_pCompositor->m_vMonitors) {
-        if (!g_pHyprRenderer->shouldRenderWindow(m_pWindow, m.get())) {
+        if (!g_pHyprRenderer->shouldRenderWindow(m_pWindow.lock(), m.get())) {
             const CRegion monitorRegion({m->vecPosition, m->vecSize});
             borderRegion.subtract(monitorRegion);
         }
@@ -133,5 +133,5 @@ std::string CHyprBorderDecoration::getDisplayName() {
 }
 
 bool CHyprBorderDecoration::doesntWantBorders() {
-    return !m_pWindow->m_sSpecialRenderData.border || m_pWindow->m_bX11DoesntWantBorders || m_pWindow->getRealBorderSize() == 0;
+    return !m_pWindow.lock()->m_sSpecialRenderData.border || m_pWindow.lock()->m_bX11DoesntWantBorders || m_pWindow.lock()->getRealBorderSize() == 0;
 }

--- a/src/render/decorations/CHyprBorderDecoration.hpp
+++ b/src/render/decorations/CHyprBorderDecoration.hpp
@@ -4,7 +4,7 @@
 
 class CHyprBorderDecoration : public IHyprWindowDecoration {
   public:
-    CHyprBorderDecoration(CWindow*);
+    CHyprBorderDecoration(PHLWINDOW);
     virtual ~CHyprBorderDecoration();
 
     virtual SDecorationPositioningInfo getPositioningInfo();
@@ -15,7 +15,7 @@ class CHyprBorderDecoration : public IHyprWindowDecoration {
 
     virtual eDecorationType            getDecorationType();
 
-    virtual void                       updateWindow(CWindow*);
+    virtual void                       updateWindow(PHLWINDOW);
 
     virtual void                       damageEntire();
 
@@ -29,7 +29,7 @@ class CHyprBorderDecoration : public IHyprWindowDecoration {
     SWindowDecorationExtents m_seExtents;
     SWindowDecorationExtents m_seReportedExtents;
 
-    CWindow*                 m_pWindow = nullptr;
+    PHLWINDOWREF             m_pWindow;
 
     Vector2D                 m_vLastWindowPos;
     Vector2D                 m_vLastWindowSize;

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -3,7 +3,7 @@
 #include "../../Compositor.hpp"
 #include "../../config/ConfigValue.hpp"
 
-CHyprDropShadowDecoration::CHyprDropShadowDecoration(CWindow* pWindow) : IHyprWindowDecoration(pWindow) {
+CHyprDropShadowDecoration::CHyprDropShadowDecoration(PHLWINDOW pWindow) : IHyprWindowDecoration(pWindow) {
     m_pWindow = pWindow;
 }
 
@@ -24,7 +24,7 @@ SDecorationPositioningInfo CHyprDropShadowDecoration::getPositioningInfo() {
 }
 
 void CHyprDropShadowDecoration::onPositioningReply(const SDecorationPositioningReply& reply) {
-    updateWindow(m_pWindow);
+    updateWindow(m_pWindow.lock());
 }
 
 uint64_t CHyprDropShadowDecoration::getDecorationFlags() {
@@ -41,31 +41,33 @@ void CHyprDropShadowDecoration::damageEntire() {
     if (*PSHADOWS != 1)
         return; // disabled
 
-    CBox       shadowBox = {m_pWindow->m_vRealPosition.value().x - m_seExtents.topLeft.x, m_pWindow->m_vRealPosition.value().y - m_seExtents.topLeft.y,
-                            m_pWindow->m_vRealSize.value().x + m_seExtents.topLeft.x + m_seExtents.bottomRight.x,
-                            m_pWindow->m_vRealSize.value().y + m_seExtents.topLeft.y + m_seExtents.bottomRight.y};
+    const auto PWINDOW = m_pWindow.lock();
 
-    const auto PWORKSPACE = m_pWindow->m_pWorkspace;
-    if (PWORKSPACE && PWORKSPACE->m_vRenderOffset.isBeingAnimated() && !m_pWindow->m_bPinned)
+    CBox       shadowBox = {PWINDOW->m_vRealPosition.value().x - m_seExtents.topLeft.x, PWINDOW->m_vRealPosition.value().y - m_seExtents.topLeft.y,
+                            PWINDOW->m_vRealSize.value().x + m_seExtents.topLeft.x + m_seExtents.bottomRight.x,
+                            PWINDOW->m_vRealSize.value().y + m_seExtents.topLeft.y + m_seExtents.bottomRight.y};
+
+    const auto PWORKSPACE = PWINDOW->m_pWorkspace;
+    if (PWORKSPACE && PWORKSPACE->m_vRenderOffset.isBeingAnimated() && !PWINDOW->m_bPinned)
         shadowBox.translate(PWORKSPACE->m_vRenderOffset.value());
-    shadowBox.translate(m_pWindow->m_vFloatingOffset);
+    shadowBox.translate(PWINDOW->m_vFloatingOffset);
 
     static auto PSHADOWIGNOREWINDOW = CConfigValue<Hyprlang::INT>("decoration:shadow_ignore_window");
-    const auto  ROUNDING            = m_pWindow->rounding();
+    const auto  ROUNDING            = PWINDOW->rounding();
     const auto  ROUNDINGSIZE        = ROUNDING - M_SQRT1_2 * ROUNDING + 1;
 
     CRegion     shadowRegion(shadowBox);
     if (*PSHADOWIGNOREWINDOW) {
-        CBox surfaceBox = m_pWindow->getWindowMainSurfaceBox();
-        if (PWORKSPACE && PWORKSPACE->m_vRenderOffset.isBeingAnimated() && !m_pWindow->m_bPinned)
+        CBox surfaceBox = PWINDOW->getWindowMainSurfaceBox();
+        if (PWORKSPACE && PWORKSPACE->m_vRenderOffset.isBeingAnimated() && !PWINDOW->m_bPinned)
             surfaceBox.translate(PWORKSPACE->m_vRenderOffset.value());
-        surfaceBox.translate(m_pWindow->m_vFloatingOffset);
+        surfaceBox.translate(PWINDOW->m_vFloatingOffset);
         surfaceBox.expand(-ROUNDINGSIZE);
         shadowRegion.subtract(CRegion(surfaceBox));
     }
 
     for (auto& m : g_pCompositor->m_vMonitors) {
-        if (!g_pHyprRenderer->shouldRenderWindow(m_pWindow, m.get())) {
+        if (!g_pHyprRenderer->shouldRenderWindow(PWINDOW, m.get())) {
             const CRegion monitorRegion({m->vecPosition, m->vecSize});
             shadowRegion.subtract(monitorRegion);
         }
@@ -74,9 +76,11 @@ void CHyprDropShadowDecoration::damageEntire() {
     g_pHyprRenderer->damageRegion(shadowRegion);
 }
 
-void CHyprDropShadowDecoration::updateWindow(CWindow* pWindow) {
-    m_vLastWindowPos  = m_pWindow->m_vRealPosition.value();
-    m_vLastWindowSize = m_pWindow->m_vRealSize.value();
+void CHyprDropShadowDecoration::updateWindow(PHLWINDOW pWindow) {
+    const auto PWINDOW = m_pWindow.lock();
+
+    m_vLastWindowPos  = PWINDOW->m_vRealPosition.value();
+    m_vLastWindowSize = PWINDOW->m_vRealSize.value();
 
     m_bLastWindowBox          = {m_vLastWindowPos.x, m_vLastWindowPos.y, m_vLastWindowSize.x, m_vLastWindowSize.y};
     m_bLastWindowBoxWithDecos = g_pDecorationPositioner->getBoxWithIncludedDecos(pWindow);
@@ -84,19 +88,21 @@ void CHyprDropShadowDecoration::updateWindow(CWindow* pWindow) {
 
 void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a) {
 
-    if (!g_pCompositor->windowValidMapped(m_pWindow))
+    const auto PWINDOW = m_pWindow.lock();
+
+    if (!validMapped(PWINDOW))
         return;
 
-    if (m_pWindow->m_cRealShadowColor.value() == CColor(0, 0, 0, 0))
+    if (PWINDOW->m_cRealShadowColor.value() == CColor(0, 0, 0, 0))
         return; // don't draw invisible shadows
 
-    if (!m_pWindow->m_sSpecialRenderData.decorate)
+    if (!PWINDOW->m_sSpecialRenderData.decorate)
         return;
 
-    if (!m_pWindow->m_sSpecialRenderData.shadow)
+    if (!PWINDOW->m_sSpecialRenderData.shadow)
         return;
 
-    if (m_pWindow->m_sAdditionalConfigData.forceNoShadow)
+    if (PWINDOW->m_sAdditionalConfigData.forceNoShadow)
         return;
 
     static auto PSHADOWS            = CConfigValue<Hyprlang::INT>("decoration:drop_shadow");
@@ -108,10 +114,10 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a) {
     if (*PSHADOWS != 1)
         return; // disabled
 
-    const auto ROUNDINGBASE    = m_pWindow->rounding();
-    const auto ROUNDING        = ROUNDINGBASE > 0 ? ROUNDINGBASE + m_pWindow->getRealBorderSize() : 0;
-    const auto PWORKSPACE      = m_pWindow->m_pWorkspace;
-    const auto WORKSPACEOFFSET = PWORKSPACE && !m_pWindow->m_bPinned ? PWORKSPACE->m_vRenderOffset.value() : Vector2D();
+    const auto ROUNDINGBASE    = PWINDOW->rounding();
+    const auto ROUNDING        = ROUNDINGBASE > 0 ? ROUNDINGBASE + PWINDOW->getRealBorderSize() : 0;
+    const auto PWORKSPACE      = PWINDOW->m_pWorkspace;
+    const auto WORKSPACEOFFSET = PWORKSPACE && !PWINDOW->m_bPinned ? PWORKSPACE->m_vRenderOffset.value() : Vector2D();
 
     // draw the shadow
     CBox fullBox = m_bLastWindowBoxWithDecos;
@@ -126,13 +132,13 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a) {
     // scale the box in relation to the center of the box
     fullBox.scaleFromCenter(SHADOWSCALE).translate(*PSHADOWOFFSET);
 
-    updateWindow(m_pWindow);
+    updateWindow(PWINDOW);
     m_vLastWindowPos += WORKSPACEOFFSET;
     m_seExtents = {{m_vLastWindowPos.x - fullBox.x - pMonitor->vecPosition.x + 2, m_vLastWindowPos.y - fullBox.y - pMonitor->vecPosition.y + 2},
                    {fullBox.x + fullBox.width + pMonitor->vecPosition.x - m_vLastWindowPos.x - m_vLastWindowSize.x + 2,
                     fullBox.y + fullBox.height + pMonitor->vecPosition.y - m_vLastWindowPos.y - m_vLastWindowSize.y + 2}};
 
-    fullBox.translate(m_pWindow->m_vFloatingOffset);
+    fullBox.translate(PWINDOW->m_vFloatingOffset);
 
     if (fullBox.width < 1 || fullBox.height < 1)
         return; // don't draw invisible shadows
@@ -154,8 +160,8 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a) {
         windowBox.translate(-pMonitor->vecPosition + WORKSPACEOFFSET);
         withDecos.translate(-pMonitor->vecPosition + WORKSPACEOFFSET);
 
-        windowBox.translate(m_pWindow->m_vFloatingOffset);
-        withDecos.translate(m_pWindow->m_vFloatingOffset);
+        windowBox.translate(PWINDOW->m_vFloatingOffset);
+        withDecos.translate(PWINDOW->m_vFloatingOffset);
 
         auto scaledExtentss = withDecos.extentsFrom(windowBox);
         scaledExtentss      = scaledExtentss * pMonitor->scale;
@@ -181,7 +187,7 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a) {
         g_pHyprOpenGL->renderRect(&fullBox, CColor(0, 0, 0, 1), 0);
 
         // render white shadow with the alpha of the shadow color (otherwise we clear with alpha later and shit it to 2 bit)
-        g_pHyprOpenGL->renderRoundedShadow(&fullBox, ROUNDING * pMonitor->scale, *PSHADOWSIZE * pMonitor->scale, CColor(1, 1, 1, m_pWindow->m_cRealShadowColor.value().a), a);
+        g_pHyprOpenGL->renderRoundedShadow(&fullBox, ROUNDING * pMonitor->scale, *PSHADOWSIZE * pMonitor->scale, CColor(1, 1, 1, PWINDOW->m_cRealShadowColor.value().a), a);
 
         // render black window box ("clip")
         g_pHyprOpenGL->renderRect(&windowBox, CColor(0, 0, 0, 1.0), ROUNDING * pMonitor->scale);
@@ -189,7 +195,7 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a) {
         alphaSwapFB.bind();
 
         // alpha swap just has the shadow color. It will be the "texture" to render.
-        g_pHyprOpenGL->renderRect(&fullBox, m_pWindow->m_cRealShadowColor.value().stripA(), 0);
+        g_pHyprOpenGL->renderRect(&fullBox, PWINDOW->m_cRealShadowColor.value().stripA(), 0);
 
         LASTFB->bind();
 
@@ -202,7 +208,7 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a) {
 
         g_pHyprOpenGL->m_RenderData.damage = saveDamage;
     } else {
-        g_pHyprOpenGL->renderRoundedShadow(&fullBox, ROUNDING * pMonitor->scale, *PSHADOWSIZE * pMonitor->scale, m_pWindow->m_cRealShadowColor.value(), a);
+        g_pHyprOpenGL->renderRoundedShadow(&fullBox, ROUNDING * pMonitor->scale, *PSHADOWSIZE * pMonitor->scale, PWINDOW->m_cRealShadowColor.value(), a);
     }
 
     if (m_seExtents != m_seReportedExtents)

--- a/src/render/decorations/CHyprDropShadowDecoration.hpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.hpp
@@ -4,7 +4,7 @@
 
 class CHyprDropShadowDecoration : public IHyprWindowDecoration {
   public:
-    CHyprDropShadowDecoration(CWindow*);
+    CHyprDropShadowDecoration(PHLWINDOW);
     virtual ~CHyprDropShadowDecoration();
 
     virtual SDecorationPositioningInfo getPositioningInfo();
@@ -15,7 +15,7 @@ class CHyprDropShadowDecoration : public IHyprWindowDecoration {
 
     virtual eDecorationType            getDecorationType();
 
-    virtual void                       updateWindow(CWindow*);
+    virtual void                       updateWindow(PHLWINDOW);
 
     virtual void                       damageEntire();
 
@@ -29,7 +29,7 @@ class CHyprDropShadowDecoration : public IHyprWindowDecoration {
     SWindowDecorationExtents m_seExtents;
     SWindowDecorationExtents m_seReportedExtents;
 
-    CWindow*                 m_pWindow = nullptr;
+    PHLWINDOWREF                 m_pWindow;
 
     Vector2D                 m_vLastWindowPos;
     Vector2D                 m_vLastWindowSize;

--- a/src/render/decorations/CHyprDropShadowDecoration.hpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.hpp
@@ -29,7 +29,7 @@ class CHyprDropShadowDecoration : public IHyprWindowDecoration {
     SWindowDecorationExtents m_seExtents;
     SWindowDecorationExtents m_seReportedExtents;
 
-    PHLWINDOWREF                 m_pWindow;
+    PHLWINDOWREF             m_pWindow;
 
     Vector2D                 m_vLastWindowPos;
     Vector2D                 m_vLastWindowSize;

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -58,7 +58,7 @@ eDecorationType CHyprGroupBarDecoration::getDecorationType() {
 //
 
 void CHyprGroupBarDecoration::updateWindow(PHLWINDOW pWindow) {
-    if (!m_pWindow.lock()->m_sGroupData.pNextWindow.lock()) {
+    if (m_pWindow.lock()->m_sGroupData.pNextWindow.expired()) {
         m_pWindow.lock()->removeWindowDeco(this);
         return;
     }
@@ -374,7 +374,7 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, PHLWIND
     PHLWINDOW   pWindowInsertEnd   = pWindowInsertAfter->m_sGroupData.pNextWindow.lock();
     PHLWINDOW   pDraggedHead       = pDraggedWindow->m_sGroupData.pNextWindow.lock() ? pDraggedWindow->getGroupHead() : pDraggedWindow;
 
-    if (pDraggedWindow->m_sGroupData.pNextWindow.lock()) {
+    if (!pDraggedWindow->m_sGroupData.pNextWindow.expired()) {
 
         // stores group data
         std::vector<PHLWINDOW> members;
@@ -469,7 +469,7 @@ bool CHyprGroupBarDecoration::onMouseButtonOnDeco(const Vector2D& pos, wlr_point
 bool CHyprGroupBarDecoration::onScrollOnDeco(const Vector2D& pos, wlr_pointer_axis_event* e) {
     static auto PGROUPBARSCROLLING = CConfigValue<Hyprlang::INT>("group:groupbar:scrolling");
 
-    if (!*PGROUPBARSCROLLING || !m_pWindow.lock()->m_sGroupData.pNextWindow.lock())
+    if (!*PGROUPBARSCROLLING || m_pWindow.lock()->m_sGroupData.pNextWindow.expired())
         return false;
 
     if (e->delta > 0)

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -144,7 +144,7 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a) {
 
         if (*PGRADIENTS) {
             const auto& GRADIENTTEX = (m_dwGroupMembers[i].lock() == g_pCompositor->m_pLastWindow.lock() ? (GROUPLOCKED ? m_tGradientLockedActive : m_tGradientActive) :
-                                                                                             (GROUPLOCKED ? m_tGradientLockedInactive : m_tGradientInactive));
+                                                                                                           (GROUPLOCKED ? m_tGradientLockedInactive : m_tGradientInactive));
             if (GRADIENTTEX.m_iTexID != 0)
                 g_pHyprOpenGL->renderTexture(GRADIENTTEX, &rect, 1.0);
         }
@@ -370,16 +370,16 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, PHLWIND
     const float BARRELATIVEX = pos.x - assignedBoxGlobal().x - m_fBarWidth / 2;
     const int   WINDOWINDEX  = BARRELATIVEX < 0 ? -1 : (BARRELATIVEX) / (m_fBarWidth + BAR_HORIZONTAL_PADDING);
 
-    PHLWINDOW    pWindowInsertAfter = m_pWindow.lock()->getGroupWindowByIndex(WINDOWINDEX);
-    PHLWINDOW    pWindowInsertEnd   = pWindowInsertAfter->m_sGroupData.pNextWindow.lock();
-    PHLWINDOW    pDraggedHead       = pDraggedWindow->m_sGroupData.pNextWindow.lock() ? pDraggedWindow->getGroupHead() : pDraggedWindow;
+    PHLWINDOW   pWindowInsertAfter = m_pWindow.lock()->getGroupWindowByIndex(WINDOWINDEX);
+    PHLWINDOW   pWindowInsertEnd   = pWindowInsertAfter->m_sGroupData.pNextWindow.lock();
+    PHLWINDOW   pDraggedHead       = pDraggedWindow->m_sGroupData.pNextWindow.lock() ? pDraggedWindow->getGroupHead() : pDraggedWindow;
 
     if (pDraggedWindow->m_sGroupData.pNextWindow.lock()) {
 
         // stores group data
         std::vector<PHLWINDOW> members;
         PHLWINDOW              curr      = pDraggedHead;
-        const bool            WASLOCKED = pDraggedHead->m_sGroupData.locked;
+        const bool             WASLOCKED = pDraggedHead->m_sGroupData.locked;
         do {
             members.push_back(curr);
             curr = curr->m_sGroupData.pNextWindow.lock();
@@ -388,8 +388,8 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, PHLWIND
         // removes all windows
         for (PHLWINDOW w : members) {
             w->m_sGroupData.pNextWindow.reset();
-            w->m_sGroupData.head        = false;
-            w->m_sGroupData.locked      = false;
+            w->m_sGroupData.head   = false;
+            w->m_sGroupData.locked = false;
             g_pLayoutManager->getCurrentLayout()->onWindowRemoved(w);
         }
 

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -15,7 +15,7 @@ constexpr int   BAR_PADDING_OUTER_VERT = 2;
 constexpr int   BAR_TEXT_PAD           = 2;
 constexpr int   BAR_HORIZONTAL_PADDING = 2;
 
-CHyprGroupBarDecoration::CHyprGroupBarDecoration(CWindow* pWindow) : IHyprWindowDecoration(pWindow) {
+CHyprGroupBarDecoration::CHyprGroupBarDecoration(PHLWINDOW pWindow) : IHyprWindowDecoration(pWindow) {
     static auto PGRADIENTS = CConfigValue<Hyprlang::INT>("group:groupbar:enabled");
     static auto PENABLED   = CConfigValue<Hyprlang::INT>("group:groupbar:gradients");
     m_pWindow              = pWindow;
@@ -39,7 +39,7 @@ SDecorationPositioningInfo CHyprGroupBarDecoration::getPositioningInfo() {
     info.priority = *PPRIORITY;
     info.reserved = true;
 
-    if (*PENABLED && m_pWindow->m_sSpecialRenderData.decorate)
+    if (*PENABLED && m_pWindow.lock()->m_sSpecialRenderData.decorate)
         info.desiredExtents = {{0, BAR_PADDING_OUTER_VERT * 2 + BAR_INDICATOR_HEIGHT + (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0) + 2}, {0, 0}};
     else
         info.desiredExtents = {{0, 0}, {0, 0}};
@@ -57,33 +57,33 @@ eDecorationType CHyprGroupBarDecoration::getDecorationType() {
 
 //
 
-void CHyprGroupBarDecoration::updateWindow(CWindow* pWindow) {
-    if (!m_pWindow->m_sGroupData.pNextWindow) {
-        m_pWindow->removeWindowDeco(this);
+void CHyprGroupBarDecoration::updateWindow(PHLWINDOW pWindow) {
+    if (!m_pWindow.lock()->m_sGroupData.pNextWindow.lock()) {
+        m_pWindow.lock()->removeWindowDeco(this);
         return;
     }
 
     m_dwGroupMembers.clear();
-    CWindow* head = pWindow->getGroupHead();
+    PHLWINDOW head = pWindow->getGroupHead();
     m_dwGroupMembers.push_back(head);
 
-    CWindow* curr = head->m_sGroupData.pNextWindow;
+    PHLWINDOW curr = head->m_sGroupData.pNextWindow.lock();
     while (curr != head) {
         m_dwGroupMembers.push_back(curr);
-        curr = curr->m_sGroupData.pNextWindow;
+        curr = curr->m_sGroupData.pNextWindow.lock();
     }
 
     damageEntire();
 
     if (m_dwGroupMembers.size() == 0) {
-        m_pWindow->removeWindowDeco(this);
+        m_pWindow.lock()->removeWindowDeco(this);
         return;
     }
 }
 
 void CHyprGroupBarDecoration::damageEntire() {
     auto box = assignedBoxGlobal();
-    box.translate(m_pWindow->m_vFloatingOffset);
+    box.translate(m_pWindow.lock()->m_vFloatingOffset);
     g_pHyprRenderer->damageBox(&box);
 }
 
@@ -97,7 +97,7 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a) {
     static auto PHEIGHT        = CConfigValue<Hyprlang::INT>("group:groupbar:height");
     static auto PGRADIENTS     = CConfigValue<Hyprlang::INT>("group:groupbar:gradients");
 
-    if (!*PENABLED || !m_pWindow->m_sSpecialRenderData.decorate)
+    if (!*PENABLED || !m_pWindow.lock()->m_sSpecialRenderData.decorate)
         return;
 
     const auto ASSIGNEDBOX = assignedBoxGlobal();
@@ -111,8 +111,8 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a) {
     int xoff = 0;
 
     for (int i = 0; i < barsToDraw; ++i) {
-        CBox rect = {ASSIGNEDBOX.x + xoff - pMonitor->vecPosition.x + m_pWindow->m_vFloatingOffset.x,
-                     ASSIGNEDBOX.y + ASSIGNEDBOX.h - BAR_INDICATOR_HEIGHT - BAR_PADDING_OUTER_VERT - pMonitor->vecPosition.y + m_pWindow->m_vFloatingOffset.y, m_fBarWidth,
+        CBox rect = {ASSIGNEDBOX.x + xoff - pMonitor->vecPosition.x + m_pWindow.lock()->m_vFloatingOffset.x,
+                     ASSIGNEDBOX.y + ASSIGNEDBOX.h - BAR_INDICATOR_HEIGHT - BAR_PADDING_OUTER_VERT - pMonitor->vecPosition.y + m_pWindow.lock()->m_vFloatingOffset.y, m_fBarWidth,
                      BAR_INDICATOR_HEIGHT};
 
         if (rect.width <= 0 || rect.height <= 0)
@@ -129,32 +129,32 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a) {
         auto* const       GROUPCOLACTIVELOCKED    = (CGradientValueData*)(PGROUPCOLACTIVELOCKED.ptr())->getData();
         auto* const       GROUPCOLINACTIVELOCKED  = (CGradientValueData*)(PGROUPCOLINACTIVELOCKED.ptr())->getData();
 
-        const bool        GROUPLOCKED  = m_pWindow->getGroupHead()->m_sGroupData.locked;
+        const bool        GROUPLOCKED  = m_pWindow.lock()->getGroupHead()->m_sGroupData.locked;
         const auto* const PCOLACTIVE   = GROUPLOCKED ? GROUPCOLACTIVELOCKED : GROUPCOLACTIVE;
         const auto* const PCOLINACTIVE = GROUPLOCKED ? GROUPCOLINACTIVELOCKED : GROUPCOLINACTIVE;
 
-        CColor            color = m_dwGroupMembers[i] == g_pCompositor->m_pLastWindow ? PCOLACTIVE->m_vColors[0] : PCOLINACTIVE->m_vColors[0];
+        CColor            color = m_dwGroupMembers[i].lock() == g_pCompositor->m_pLastWindow.lock() ? PCOLACTIVE->m_vColors[0] : PCOLINACTIVE->m_vColors[0];
         color.a *= a;
         g_pHyprOpenGL->renderRect(&rect, color);
 
-        rect = {ASSIGNEDBOX.x + xoff - pMonitor->vecPosition.x + m_pWindow->m_vFloatingOffset.x,
-                ASSIGNEDBOX.y - pMonitor->vecPosition.y + m_pWindow->m_vFloatingOffset.y + BAR_PADDING_OUTER_VERT, m_fBarWidth,
+        rect = {ASSIGNEDBOX.x + xoff - pMonitor->vecPosition.x + m_pWindow.lock()->m_vFloatingOffset.x,
+                ASSIGNEDBOX.y - pMonitor->vecPosition.y + m_pWindow.lock()->m_vFloatingOffset.y + BAR_PADDING_OUTER_VERT, m_fBarWidth,
                 ASSIGNEDBOX.h - BAR_INDICATOR_HEIGHT - BAR_PADDING_OUTER_VERT * 2};
         rect.scale(pMonitor->scale);
 
         if (*PGRADIENTS) {
-            const auto& GRADIENTTEX = (m_dwGroupMembers[i] == g_pCompositor->m_pLastWindow ? (GROUPLOCKED ? m_tGradientLockedActive : m_tGradientActive) :
+            const auto& GRADIENTTEX = (m_dwGroupMembers[i].lock() == g_pCompositor->m_pLastWindow.lock() ? (GROUPLOCKED ? m_tGradientLockedActive : m_tGradientActive) :
                                                                                              (GROUPLOCKED ? m_tGradientLockedInactive : m_tGradientInactive));
             if (GRADIENTTEX.m_iTexID != 0)
                 g_pHyprOpenGL->renderTexture(GRADIENTTEX, &rect, 1.0);
         }
 
         if (*PRENDERTITLES) {
-            CTitleTex* pTitleTex = textureFromTitle(m_dwGroupMembers[i]->m_szTitle);
+            CTitleTex* pTitleTex = textureFromTitle(m_dwGroupMembers[i].lock()->m_szTitle);
 
             if (!pTitleTex)
                 pTitleTex = m_sTitleTexs.titleTexs
-                                .emplace_back(std::make_unique<CTitleTex>(m_dwGroupMembers[i],
+                                .emplace_back(std::make_unique<CTitleTex>(m_dwGroupMembers[i].lock(),
                                                                           Vector2D{m_fBarWidth * pMonitor->scale, (*PTITLEFONTSIZE + 2 * BAR_TEXT_PAD) * pMonitor->scale}))
                                 .get();
 
@@ -184,7 +184,7 @@ void CHyprGroupBarDecoration::invalidateTextures() {
     m_sTitleTexs.titleTexs.clear();
 }
 
-CTitleTex::CTitleTex(CWindow* pWindow, const Vector2D& bufferSize) {
+CTitleTex::CTitleTex(PHLWINDOW pWindow, const Vector2D& bufferSize) {
     szContent                 = pWindow->m_szTitle;
     pWindowOwner              = pWindow;
     const auto   CAIROSURFACE = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, bufferSize.x, bufferSize.y);
@@ -335,7 +335,7 @@ void refreshGroupBarGradients() {
 }
 
 bool CHyprGroupBarDecoration::onBeginWindowDragOnDeco(const Vector2D& pos) {
-    if (m_pWindow == m_pWindow->m_sGroupData.pNextWindow)
+    if (m_pWindow.lock() == m_pWindow.lock()->m_sGroupData.pNextWindow.lock())
         return false;
 
     const float BARRELATIVEX = pos.x - assignedBoxGlobal().x;
@@ -344,7 +344,7 @@ bool CHyprGroupBarDecoration::onBeginWindowDragOnDeco(const Vector2D& pos) {
     if (BARRELATIVEX - (m_fBarWidth + BAR_HORIZONTAL_PADDING) * WINDOWINDEX > m_fBarWidth)
         return false;
 
-    CWindow* pWindow = m_pWindow->getGroupWindowByIndex(WINDOWINDEX);
+    PHLWINDOW pWindow = m_pWindow.lock()->getGroupWindowByIndex(WINDOWINDEX);
 
     // hack
     g_pLayoutManager->getCurrentLayout()->onWindowRemoved(pWindow);
@@ -363,31 +363,31 @@ bool CHyprGroupBarDecoration::onBeginWindowDragOnDeco(const Vector2D& pos) {
     return true;
 }
 
-bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, CWindow* pDraggedWindow) {
-    if (!pDraggedWindow->canBeGroupedInto(m_pWindow))
+bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, PHLWINDOW pDraggedWindow) {
+    if (!pDraggedWindow->canBeGroupedInto(m_pWindow.lock()))
         return false;
 
     const float BARRELATIVEX = pos.x - assignedBoxGlobal().x - m_fBarWidth / 2;
     const int   WINDOWINDEX  = BARRELATIVEX < 0 ? -1 : (BARRELATIVEX) / (m_fBarWidth + BAR_HORIZONTAL_PADDING);
 
-    CWindow*    pWindowInsertAfter = m_pWindow->getGroupWindowByIndex(WINDOWINDEX);
-    CWindow*    pWindowInsertEnd   = pWindowInsertAfter->m_sGroupData.pNextWindow;
-    CWindow*    pDraggedHead       = pDraggedWindow->m_sGroupData.pNextWindow ? pDraggedWindow->getGroupHead() : pDraggedWindow;
+    PHLWINDOW    pWindowInsertAfter = m_pWindow.lock()->getGroupWindowByIndex(WINDOWINDEX);
+    PHLWINDOW    pWindowInsertEnd   = pWindowInsertAfter->m_sGroupData.pNextWindow.lock();
+    PHLWINDOW    pDraggedHead       = pDraggedWindow->m_sGroupData.pNextWindow.lock() ? pDraggedWindow->getGroupHead() : pDraggedWindow;
 
-    if (pDraggedWindow->m_sGroupData.pNextWindow) {
+    if (pDraggedWindow->m_sGroupData.pNextWindow.lock()) {
 
         // stores group data
-        std::vector<CWindow*> members;
-        CWindow*              curr      = pDraggedHead;
+        std::vector<PHLWINDOW> members;
+        PHLWINDOW              curr      = pDraggedHead;
         const bool            WASLOCKED = pDraggedHead->m_sGroupData.locked;
         do {
             members.push_back(curr);
-            curr = curr->m_sGroupData.pNextWindow;
+            curr = curr->m_sGroupData.pNextWindow.lock();
         } while (curr != members[0]);
 
         // removes all windows
-        for (CWindow* w : members) {
-            w->m_sGroupData.pNextWindow = nullptr;
+        for (PHLWINDOW w : members) {
+            w->m_sGroupData.pNextWindow.reset();
             w->m_sGroupData.head        = false;
             w->m_sGroupData.locked      = false;
             g_pLayoutManager->getCurrentLayout()->onWindowRemoved(w);
@@ -411,7 +411,7 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, CWindow
     if (WINDOWINDEX == -1)
         std::swap(pDraggedHead->m_sGroupData.head, pWindowInsertEnd->m_sGroupData.head);
 
-    m_pWindow->setGroupCurrent(pDraggedWindow);
+    m_pWindow.lock()->setGroupCurrent(pDraggedWindow);
     pDraggedWindow->applyGroupRules();
     pDraggedWindow->updateWindowDecos();
     g_pLayoutManager->getCurrentLayout()->recalculateWindow(pDraggedWindow);
@@ -423,7 +423,7 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, CWindow
 }
 
 bool CHyprGroupBarDecoration::onMouseButtonOnDeco(const Vector2D& pos, wlr_pointer_button_event* e) {
-    if (m_pWindow->m_bIsFullscreen && m_pWindow->m_pWorkspace->m_efFullscreenMode == FULLSCREEN_FULL)
+    if (m_pWindow.lock()->m_bIsFullscreen && m_pWindow.lock()->m_pWorkspace->m_efFullscreenMode == FULLSCREEN_FULL)
         return true;
 
     const float BARRELATIVEX = pos.x - assignedBoxGlobal().x;
@@ -437,7 +437,7 @@ bool CHyprGroupBarDecoration::onMouseButtonOnDeco(const Vector2D& pos, wlr_point
         if (e->state == WL_POINTER_BUTTON_STATE_PRESSED)
             pressedCursorPos = pos;
         else if (e->state == WL_POINTER_BUTTON_STATE_RELEASED && pressedCursorPos == pos)
-            g_pXWaylandManager->sendCloseWindow(m_pWindow->getGroupWindowByIndex(WINDOWINDEX));
+            g_pXWaylandManager->sendCloseWindow(m_pWindow.lock()->getGroupWindowByIndex(WINDOWINDEX));
 
         return true;
     }
@@ -447,14 +447,14 @@ bool CHyprGroupBarDecoration::onMouseButtonOnDeco(const Vector2D& pos, wlr_point
 
     // click on padding
     if (BARRELATIVEX - (m_fBarWidth + BAR_HORIZONTAL_PADDING) * WINDOWINDEX > m_fBarWidth) {
-        if (!g_pCompositor->isWindowActive(m_pWindow))
-            g_pCompositor->focusWindow(m_pWindow);
+        if (!g_pCompositor->isWindowActive(m_pWindow.lock()))
+            g_pCompositor->focusWindow(m_pWindow.lock());
         return true;
     }
 
-    CWindow* pWindow = m_pWindow->getGroupWindowByIndex(WINDOWINDEX);
+    PHLWINDOW pWindow = m_pWindow.lock()->getGroupWindowByIndex(WINDOWINDEX);
 
-    if (pWindow != m_pWindow)
+    if (pWindow != m_pWindow.lock())
         pWindow->setGroupCurrent(pWindow);
 
     if (!g_pCompositor->isWindowActive(pWindow) && *PFOLLOWMOUSE != 3)
@@ -469,13 +469,13 @@ bool CHyprGroupBarDecoration::onMouseButtonOnDeco(const Vector2D& pos, wlr_point
 bool CHyprGroupBarDecoration::onScrollOnDeco(const Vector2D& pos, wlr_pointer_axis_event* e) {
     static auto PGROUPBARSCROLLING = CConfigValue<Hyprlang::INT>("group:groupbar:scrolling");
 
-    if (!*PGROUPBARSCROLLING || !m_pWindow->m_sGroupData.pNextWindow)
+    if (!*PGROUPBARSCROLLING || !m_pWindow.lock()->m_sGroupData.pNextWindow.lock())
         return false;
 
     if (e->delta > 0)
-        m_pWindow->setGroupCurrent(m_pWindow->m_sGroupData.pNextWindow);
+        m_pWindow.lock()->setGroupCurrent(m_pWindow.lock()->m_sGroupData.pNextWindow.lock());
     else
-        m_pWindow->setGroupCurrent(m_pWindow->getGroupPrevious());
+        m_pWindow.lock()->setGroupCurrent(m_pWindow.lock()->getGroupPrevious());
 
     return true;
 }
@@ -485,7 +485,7 @@ bool CHyprGroupBarDecoration::onInputOnDeco(const eInputType type, const Vector2
         case INPUT_TYPE_AXIS: return onScrollOnDeco(mouseCoords, std::any_cast<wlr_pointer_axis_event*>(data));
         case INPUT_TYPE_BUTTON: return onMouseButtonOnDeco(mouseCoords, std::any_cast<wlr_pointer_button_event*>(data));
         case INPUT_TYPE_DRAG_START: return onBeginWindowDragOnDeco(mouseCoords);
-        case INPUT_TYPE_DRAG_END: return onEndWindowDragOnDeco(mouseCoords, std::any_cast<CWindow*>(data));
+        case INPUT_TYPE_DRAG_END: return onEndWindowDragOnDeco(mouseCoords, std::any_cast<PHLWINDOW>(data));
         default: return false;
     }
 }
@@ -504,11 +504,11 @@ std::string CHyprGroupBarDecoration::getDisplayName() {
 
 CBox CHyprGroupBarDecoration::assignedBoxGlobal() {
     CBox box = m_bAssignedBox;
-    box.translate(g_pDecorationPositioner->getEdgeDefinedPoint(DECORATION_EDGE_TOP, m_pWindow));
+    box.translate(g_pDecorationPositioner->getEdgeDefinedPoint(DECORATION_EDGE_TOP, m_pWindow.lock()));
 
-    const auto PWORKSPACE = m_pWindow->m_pWorkspace;
+    const auto PWORKSPACE = m_pWindow.lock()->m_pWorkspace;
 
-    if (PWORKSPACE && !m_pWindow->m_bPinned)
+    if (PWORKSPACE && !m_pWindow.lock()->m_bPinned)
         box.translate(PWORKSPACE->m_vRenderOffset.value());
 
     return box;

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -8,19 +8,19 @@
 
 class CTitleTex {
   public:
-    CTitleTex(CWindow* pWindow, const Vector2D& bufferSize);
+    CTitleTex(PHLWINDOW pWindow, const Vector2D& bufferSize);
     ~CTitleTex();
 
-    CTexture    tex;
-    std::string szContent;
-    CWindow*    pWindowOwner = nullptr;
+    CTexture     tex;
+    std::string  szContent;
+    PHLWINDOWREF pWindowOwner;
 };
 
 void refreshGroupBarGradients();
 
 class CHyprGroupBarDecoration : public IHyprWindowDecoration {
   public:
-    CHyprGroupBarDecoration(CWindow*);
+    CHyprGroupBarDecoration(PHLWINDOW);
     virtual ~CHyprGroupBarDecoration();
 
     virtual SDecorationPositioningInfo getPositioningInfo();
@@ -31,7 +31,7 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
 
     virtual eDecorationType            getDecorationType();
 
-    virtual void                       updateWindow(CWindow*);
+    virtual void                       updateWindow(PHLWINDOW);
 
     virtual void                       damageEntire();
 
@@ -48,9 +48,9 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
 
     CBox                     m_bAssignedBox = {0};
 
-    CWindow*                 m_pWindow = nullptr;
+    PHLWINDOWREF             m_pWindow;
 
-    std::deque<CWindow*>     m_dwGroupMembers;
+    std::deque<PHLWINDOWREF> m_dwGroupMembers;
 
     float                    m_fBarWidth;
 
@@ -60,7 +60,7 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
     CBox                     assignedBoxGlobal();
 
     bool                     onBeginWindowDragOnDeco(const Vector2D&);
-    bool                     onEndWindowDragOnDeco(const Vector2D&, CWindow*);
+    bool                     onEndWindowDragOnDeco(const Vector2D&, PHLWINDOW);
     bool                     onMouseButtonOnDeco(const Vector2D&, wlr_pointer_button_event*);
     bool                     onScrollOnDeco(const Vector2D&, wlr_pointer_axis_event*);
 

--- a/src/render/decorations/DecorationPositioner.cpp
+++ b/src/render/decorations/DecorationPositioner.cpp
@@ -3,17 +3,17 @@
 
 CDecorationPositioner::CDecorationPositioner() {
     static auto P = g_pHookSystem->hookDynamic("closeWindow", [this](void* call, SCallbackInfo& info, std::any data) {
-        auto* const PWINDOW = std::any_cast<CWindow*>(data);
+        auto PWINDOW = std::any_cast<PHLWINDOW>(data);
         this->onWindowUnmap(PWINDOW);
     });
 
     static auto P2 = g_pHookSystem->hookDynamic("openWindow", [this](void* call, SCallbackInfo& info, std::any data) {
-        auto* const PWINDOW = std::any_cast<CWindow*>(data);
+        auto PWINDOW = std::any_cast<PHLWINDOW>(data);
         this->onWindowMap(PWINDOW);
     });
 }
 
-Vector2D CDecorationPositioner::getEdgeDefinedPoint(uint32_t edges, CWindow* pWindow) {
+Vector2D CDecorationPositioner::getEdgeDefinedPoint(uint32_t edges, PHLWINDOW pWindow) {
     const bool TOP    = edges & DECORATION_EDGE_TOP;
     const bool BOTTOM = edges & DECORATION_EDGE_BOTTOM;
     const bool LEFT   = edges & DECORATION_EDGE_LEFT;
@@ -57,9 +57,9 @@ Vector2D CDecorationPositioner::getEdgeDefinedPoint(uint32_t edges, CWindow* pWi
 }
 
 void CDecorationPositioner::uncacheDecoration(IHyprWindowDecoration* deco) {
-    std::erase_if(m_vWindowPositioningDatas, [&](const auto& data) { return data->pDecoration == deco; });
+    std::erase_if(m_vWindowPositioningDatas, [&](const auto& data) { return !data->pWindow.lock() || data->pDecoration == deco; });
 
-    const auto WIT = std::find_if(m_mWindowDatas.begin(), m_mWindowDatas.end(), [&](const auto& other) { return other.first == deco->m_pWindow; });
+    const auto WIT = std::find_if(m_mWindowDatas.begin(), m_mWindowDatas.end(), [&](const auto& other) { return other.first.lock() == deco->m_pWindow.lock(); });
     if (WIT == m_mWindowDatas.end())
         return;
 
@@ -68,10 +68,10 @@ void CDecorationPositioner::uncacheDecoration(IHyprWindowDecoration* deco) {
 
 void CDecorationPositioner::repositionDeco(IHyprWindowDecoration* deco) {
     uncacheDecoration(deco);
-    onWindowUpdate(deco->m_pWindow);
+    onWindowUpdate(deco->m_pWindow.lock());
 }
 
-CDecorationPositioner::SWindowPositioningData* CDecorationPositioner::getDataFor(IHyprWindowDecoration* pDecoration, CWindow* pWindow) {
+CDecorationPositioner::SWindowPositioningData* CDecorationPositioner::getDataFor(IHyprWindowDecoration* pDecoration, PHLWINDOW pWindow) {
     auto it = std::find_if(m_vWindowPositioningDatas.begin(), m_vWindowPositioningDatas.end(), [&](const auto& el) { return el->pDecoration == pDecoration; });
 
     if (it != m_vWindowPositioningDatas.end())
@@ -85,19 +85,19 @@ CDecorationPositioner::SWindowPositioningData* CDecorationPositioner::getDataFor
 }
 
 void CDecorationPositioner::sanitizeDatas() {
-    std::erase_if(m_mWindowDatas, [](const auto& other) { return !g_pCompositor->windowExists(other.first); });
+    std::erase_if(m_mWindowDatas, [](const auto& other) { return !valid(other.first); });
     std::erase_if(m_vWindowPositioningDatas, [](const auto& other) {
-        if (!g_pCompositor->windowExists(other->pWindow))
+        if (!validMapped(other->pWindow))
             return true;
-        if (std::find_if(other->pWindow->m_dWindowDecorations.begin(), other->pWindow->m_dWindowDecorations.end(),
-                         [&](const auto& el) { return el.get() == other->pDecoration; }) == other->pWindow->m_dWindowDecorations.end())
+        if (std::find_if(other->pWindow.lock()->m_dWindowDecorations.begin(), other->pWindow.lock()->m_dWindowDecorations.end(),
+                         [&](const auto& el) { return el.get() == other->pDecoration; }) == other->pWindow.lock()->m_dWindowDecorations.end())
             return true;
         return false;
     });
 }
 
-void CDecorationPositioner::forceRecalcFor(CWindow* pWindow) {
-    const auto WIT = std::find_if(m_mWindowDatas.begin(), m_mWindowDatas.end(), [&](const auto& other) { return other.first == pWindow; });
+void CDecorationPositioner::forceRecalcFor(PHLWINDOW pWindow) {
+    const auto WIT = std::find_if(m_mWindowDatas.begin(), m_mWindowDatas.end(), [&](const auto& other) { return other.first.lock() == pWindow; });
     if (WIT == m_mWindowDatas.end())
         return;
 
@@ -106,11 +106,11 @@ void CDecorationPositioner::forceRecalcFor(CWindow* pWindow) {
     WINDOWDATA->needsRecalc = true;
 }
 
-void CDecorationPositioner::onWindowUpdate(CWindow* pWindow) {
-    if (!g_pCompositor->windowExists(pWindow) || !pWindow->m_bIsMapped)
+void CDecorationPositioner::onWindowUpdate(PHLWINDOW pWindow) {
+    if (!validMapped(pWindow))
         return;
 
-    const auto WIT = std::find_if(m_mWindowDatas.begin(), m_mWindowDatas.end(), [&](const auto& other) { return other.first == pWindow; });
+    const auto WIT = std::find_if(m_mWindowDatas.begin(), m_mWindowDatas.end(), [&](const auto& other) { return other.first.lock() == pWindow; });
     if (WIT == m_mWindowDatas.end())
         return;
 
@@ -126,7 +126,7 @@ void CDecorationPositioner::onWindowUpdate(CWindow* pWindow) {
 
     if (WINDOWDATA->lastWindowSize == pWindow->m_vRealSize.value() /* position not changed */
         &&
-        std::all_of(m_vWindowPositioningDatas.begin(), m_vWindowPositioningDatas.end(), [pWindow](const auto& data) { return pWindow != data->pWindow || !data->needsReposition; })
+        std::all_of(m_vWindowPositioningDatas.begin(), m_vWindowPositioningDatas.end(), [pWindow](const auto& data) { return pWindow != data->pWindow.lock() || !data->needsReposition; })
         /* all window datas are either not for this window or don't need a reposition */
         && !WINDOWDATA->needsRecalc /* window doesn't need recalc */
     )
@@ -269,30 +269,30 @@ void CDecorationPositioner::onWindowUpdate(CWindow* pWindow) {
     WINDOWDATA->extents = {{stickyOffsetXL + reservedXL, stickyOffsetYT + reservedYT}, {stickyOffsetXR + reservedXR, stickyOffsetYB + reservedYB}};
 }
 
-void CDecorationPositioner::onWindowUnmap(CWindow* pWindow) {
-    std::erase_if(m_vWindowPositioningDatas, [&](const auto& data) { return data->pWindow == pWindow; });
+void CDecorationPositioner::onWindowUnmap(PHLWINDOW pWindow) {
+    std::erase_if(m_vWindowPositioningDatas, [&](const auto& data) { return data->pWindow.lock() == pWindow; });
     m_mWindowDatas.erase(pWindow);
 }
 
-void CDecorationPositioner::onWindowMap(CWindow* pWindow) {
+void CDecorationPositioner::onWindowMap(PHLWINDOW pWindow) {
     m_mWindowDatas[pWindow] = {};
 }
 
-SWindowDecorationExtents CDecorationPositioner::getWindowDecorationReserved(CWindow* pWindow) {
+SWindowDecorationExtents CDecorationPositioner::getWindowDecorationReserved(PHLWINDOW pWindow) {
     try {
         const auto E = m_mWindowDatas.at(pWindow);
         return E.reserved;
     } catch (std::out_of_range& e) { return {}; }
 }
 
-SWindowDecorationExtents CDecorationPositioner::getWindowDecorationExtents(CWindow* pWindow, bool inputOnly) {
+SWindowDecorationExtents CDecorationPositioner::getWindowDecorationExtents(PHLWINDOW pWindow, bool inputOnly) {
     CBox accum = pWindow->getWindowMainSurfaceBox();
 
     for (auto& data : m_vWindowPositioningDatas) {
-        if (data->pWindow != pWindow)
+        if (data->pWindow.lock() != pWindow)
             continue;
 
-        if (!data->pWindow || !data->pDecoration)
+        if (!data->pWindow.lock() || !data->pDecoration)
             continue;
 
         if (!(data->pDecoration->getDecorationFlags() & DECORATION_ALLOWS_MOUSE_INPUT) && inputOnly)
@@ -301,7 +301,7 @@ SWindowDecorationExtents CDecorationPositioner::getWindowDecorationExtents(CWind
         CBox decoBox;
 
         if (data->positioningInfo.policy == DECORATION_POSITION_ABSOLUTE) {
-            decoBox = data->pWindow->getWindowMainSurfaceBox();
+            decoBox = data->pWindow.lock()->getWindowMainSurfaceBox();
             decoBox.addExtents(data->positioningInfo.desiredExtents);
         } else {
             decoBox              = data->lastReply.assignedGeometry;
@@ -326,11 +326,11 @@ SWindowDecorationExtents CDecorationPositioner::getWindowDecorationExtents(CWind
     return accum.extentsFrom(pWindow->getWindowMainSurfaceBox());
 }
 
-CBox CDecorationPositioner::getBoxWithIncludedDecos(CWindow* pWindow) {
+CBox CDecorationPositioner::getBoxWithIncludedDecos(PHLWINDOW pWindow) {
     CBox accum = pWindow->getWindowMainSurfaceBox();
 
     for (auto& data : m_vWindowPositioningDatas) {
-        if (data->pWindow != pWindow)
+        if (data->pWindow.lock() != pWindow)
             continue;
 
         if (!(data->pDecoration->getDecorationFlags() & DECORATION_PART_OF_MAIN_WINDOW))
@@ -339,7 +339,7 @@ CBox CDecorationPositioner::getBoxWithIncludedDecos(CWindow* pWindow) {
         CBox decoBox;
 
         if (data->positioningInfo.policy == DECORATION_POSITION_ABSOLUTE) {
-            decoBox = data->pWindow->getWindowMainSurfaceBox();
+            decoBox = data->pWindow.lock()->getWindowMainSurfaceBox();
             decoBox.addExtents(data->positioningInfo.desiredExtents);
         } else {
             decoBox              = data->lastReply.assignedGeometry;
@@ -365,9 +365,9 @@ CBox CDecorationPositioner::getBoxWithIncludedDecos(CWindow* pWindow) {
 }
 
 CBox CDecorationPositioner::getWindowDecorationBox(IHyprWindowDecoration* deco) {
-    const auto DATA = getDataFor(deco, deco->m_pWindow);
+    const auto DATA = getDataFor(deco, deco->m_pWindow.lock());
 
     CBox       box = DATA->lastReply.assignedGeometry;
-    box.translate(getEdgeDefinedPoint(DATA->positioningInfo.edges, deco->m_pWindow));
+    box.translate(getEdgeDefinedPoint(DATA->positioningInfo.edges, deco->m_pWindow.lock()));
     return box;
 }

--- a/src/render/decorations/DecorationPositioner.cpp
+++ b/src/render/decorations/DecorationPositioner.cpp
@@ -125,8 +125,8 @@ void CDecorationPositioner::onWindowUpdate(PHLWINDOW pWindow) {
     }
 
     if (WINDOWDATA->lastWindowSize == pWindow->m_vRealSize.value() /* position not changed */
-        &&
-        std::all_of(m_vWindowPositioningDatas.begin(), m_vWindowPositioningDatas.end(), [pWindow](const auto& data) { return pWindow != data->pWindow.lock() || !data->needsReposition; })
+        && std::all_of(m_vWindowPositioningDatas.begin(), m_vWindowPositioningDatas.end(),
+                       [pWindow](const auto& data) { return pWindow != data->pWindow.lock() || !data->needsReposition; })
         /* all window datas are either not for this window or don't need a reposition */
         && !WINDOWDATA->needsRecalc /* window doesn't need recalc */
     )

--- a/src/render/decorations/DecorationPositioner.hpp
+++ b/src/render/decorations/DecorationPositioner.hpp
@@ -10,7 +10,7 @@ class CWindow;
 class IHyprWindowDecoration;
 
 typedef std::shared_ptr<CWindow> PHLWINDOW;
-typedef std::weak_ptr<CWindow> PHLWINDOWREF;
+typedef std::weak_ptr<CWindow>   PHLWINDOWREF;
 
 enum eDecorationPositioningPolicy {
     DECORATION_POSITION_ABSOLUTE = 0, /* Decoration wants absolute positioning */
@@ -90,13 +90,13 @@ class CDecorationPositioner {
         bool                     needsRecalc    = false;
     };
 
-    std::map<PHLWINDOWREF, SWindowData, std::owner_less<PHLWINDOWREF>>        m_mWindowDatas;
-    std::vector<std::unique_ptr<SWindowPositioningData>> m_vWindowPositioningDatas;
+    std::map<PHLWINDOWREF, SWindowData, std::owner_less<PHLWINDOWREF>> m_mWindowDatas;
+    std::vector<std::unique_ptr<SWindowPositioningData>>               m_vWindowPositioningDatas;
 
-    SWindowPositioningData*                              getDataFor(IHyprWindowDecoration* pDecoration, PHLWINDOW pWindow);
-    void                                                 onWindowUnmap(PHLWINDOW pWindow);
-    void                                                 onWindowMap(PHLWINDOW pWindow);
-    void                                                 sanitizeDatas();
+    SWindowPositioningData*                                            getDataFor(IHyprWindowDecoration* pDecoration, PHLWINDOW pWindow);
+    void                                                               onWindowUnmap(PHLWINDOW pWindow);
+    void                                                               onWindowMap(PHLWINDOW pWindow);
+    void                                                               sanitizeDatas();
 };
 
 inline std::unique_ptr<CDecorationPositioner> g_pDecorationPositioner;

--- a/src/render/decorations/DecorationPositioner.hpp
+++ b/src/render/decorations/DecorationPositioner.hpp
@@ -3,11 +3,14 @@
 #include <cstdint>
 #include <memory>
 #include <vector>
-#include <unordered_map>
+#include <map>
 #include "../../helpers/Box.hpp"
 
 class CWindow;
 class IHyprWindowDecoration;
+
+typedef std::shared_ptr<CWindow> PHLWINDOW;
+typedef std::weak_ptr<CWindow> PHLWINDOWREF;
 
 enum eDecorationPositioningPolicy {
     DECORATION_POSITION_ABSOLUTE = 0, /* Decoration wants absolute positioning */
@@ -59,21 +62,21 @@ class CDecorationPositioner {
   public:
     CDecorationPositioner();
 
-    Vector2D getEdgeDefinedPoint(uint32_t edges, CWindow* pWindow);
+    Vector2D getEdgeDefinedPoint(uint32_t edges, PHLWINDOW pWindow);
 
     // called on resize, or insert/removal of a new deco
-    void                     onWindowUpdate(CWindow* pWindow);
+    void                     onWindowUpdate(PHLWINDOW pWindow);
     void                     uncacheDecoration(IHyprWindowDecoration* deco);
-    SWindowDecorationExtents getWindowDecorationReserved(CWindow* pWindow);
-    SWindowDecorationExtents getWindowDecorationExtents(CWindow* pWindow, bool inputOnly = false);
-    CBox                     getBoxWithIncludedDecos(CWindow* pWindow);
+    SWindowDecorationExtents getWindowDecorationReserved(PHLWINDOW pWindow);
+    SWindowDecorationExtents getWindowDecorationExtents(PHLWINDOW pWindow, bool inputOnly = false);
+    CBox                     getBoxWithIncludedDecos(PHLWINDOW pWindow);
     void                     repositionDeco(IHyprWindowDecoration* deco);
     CBox                     getWindowDecorationBox(IHyprWindowDecoration* deco);
-    void                     forceRecalcFor(CWindow* pWindow);
+    void                     forceRecalcFor(PHLWINDOW pWindow);
 
   private:
     struct SWindowPositioningData {
-        CWindow*                    pWindow     = nullptr;
+        PHLWINDOWREF                pWindow;
         IHyprWindowDecoration*      pDecoration = nullptr;
         SDecorationPositioningInfo  positioningInfo;
         SDecorationPositioningReply lastReply;
@@ -87,12 +90,12 @@ class CDecorationPositioner {
         bool                     needsRecalc    = false;
     };
 
-    std::unordered_map<CWindow*, SWindowData>            m_mWindowDatas;
+    std::map<PHLWINDOWREF, SWindowData, std::owner_less<PHLWINDOWREF>>        m_mWindowDatas;
     std::vector<std::unique_ptr<SWindowPositioningData>> m_vWindowPositioningDatas;
 
-    SWindowPositioningData*                              getDataFor(IHyprWindowDecoration* pDecoration, CWindow* pWindow);
-    void                                                 onWindowUnmap(CWindow* pWindow);
-    void                                                 onWindowMap(CWindow* pWindow);
+    SWindowPositioningData*                              getDataFor(IHyprWindowDecoration* pDecoration, PHLWINDOW pWindow);
+    void                                                 onWindowUnmap(PHLWINDOW pWindow);
+    void                                                 onWindowMap(PHLWINDOW pWindow);
     void                                                 sanitizeDatas();
 };
 

--- a/src/render/decorations/IHyprWindowDecoration.cpp
+++ b/src/render/decorations/IHyprWindowDecoration.cpp
@@ -2,7 +2,7 @@
 
 class CWindow;
 
-IHyprWindowDecoration::IHyprWindowDecoration(CWindow* pWindow) {
+IHyprWindowDecoration::IHyprWindowDecoration(PHLWINDOW pWindow) {
     m_pWindow = pWindow;
 }
 

--- a/src/render/decorations/IHyprWindowDecoration.hpp
+++ b/src/render/decorations/IHyprWindowDecoration.hpp
@@ -32,7 +32,7 @@ class CDecorationPositioner;
 
 class IHyprWindowDecoration {
   public:
-    IHyprWindowDecoration(CWindow*);
+    IHyprWindowDecoration(PHLWINDOW);
     virtual ~IHyprWindowDecoration() = 0;
 
     virtual SDecorationPositioningInfo getPositioningInfo() = 0;
@@ -43,7 +43,7 @@ class IHyprWindowDecoration {
 
     virtual eDecorationType            getDecorationType() = 0;
 
-    virtual void                       updateWindow(CWindow*) = 0;
+    virtual void                       updateWindow(PHLWINDOW) = 0;
 
     virtual void                       damageEntire() = 0; // should be ignored by non-absolute decos
 
@@ -56,7 +56,7 @@ class IHyprWindowDecoration {
     virtual std::string                getDisplayName();
 
   private:
-    CWindow* m_pWindow = nullptr;
+    PHLWINDOWREF m_pWindow;
 
     friend class CDecorationPositioner;
 };


### PR DESCRIPTION
Makes the storage of CWindow and its pointers memory-safe.

Breaks all plugins

part 2 will be moving events/Windows.cpp to members of CWindow

TODO:
 - [ ] Testing
 - [ ] Wiki (some events' params changed)
 
 cc @fufexan (meson/nix)
 
 Leave a :+1: if everything is working well