### PR TITLE
add subtract window size option to move rule

### DIFF
--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -387,9 +387,13 @@ void Events::listener_mapWindow(void* owner, void* data) {
                     int        posY = 0;
 
                     if (POSXSTR.starts_with("100%-")) {
-                        const auto POSXRAW = POSXSTR.substr(5);
+                        const bool subtractWindow = POSXSTR.starts_with("100%-w-");
+                        const auto POSXRAW        = (subtractWindow) ? POSXSTR.substr(7) : POSXSTR.substr(5);
                         posX =
                             PMONITOR->vecSize.x - (!POSXRAW.contains('%') ? std::stoi(POSXRAW) : std::stof(POSXRAW.substr(0, POSXRAW.length() - 1)) * 0.01 * PMONITOR->vecSize.x);
+
+                        if (subtractWindow)
+                            posX -= PWINDOW->m_vRealSize.goal().x;
 
                         if (CURSOR)
                             Debug::log(ERR, "Cursor is not compatible with 100%-, ignoring cursor!");
@@ -406,9 +410,13 @@ void Events::listener_mapWindow(void* owner, void* data) {
                     }
 
                     if (POSYSTR.starts_with("100%-")) {
-                        const auto POSYRAW = POSYSTR.substr(5);
+                        const bool subtractWindow = POSYSTR.starts_with("100%-w-");
+                        const auto POSYRAW        = (subtractWindow) ? POSYSTR.substr(7) : POSYSTR.substr(5);
                         posY =
                             PMONITOR->vecSize.y - (!POSYRAW.contains('%') ? std::stoi(POSYRAW) : std::stof(POSYRAW.substr(0, POSYRAW.length() - 1)) * 0.01 * PMONITOR->vecSize.y);
+
+                        if (subtractWindow)
+                            posY -= PWINDOW->m_vRealSize.goal().y;
 
                         if (CURSOR)
                             Debug::log(ERR, "Cursor is not compatible with 100%-, ignoring cursor!");


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Implement #1075 

Allows to place a window with unknown size at the bottom right of the screen with `100%-w-0` or e.g. with gap `100%-w-10`. Especially useful for mpv window with `autofit` configuration.

If you accept the pull request i can also make one for the wiki with the new option.

#### Is it ready for merging, or does it need work?

Ready for merging

