### PR TITLE
Warp cursor on openwindow/closewindow.

### DIFF
--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -668,7 +668,6 @@ void Events::listener_mapWindow(void* owner, void* data) {
     if (PMONITOR && PWINDOW->m_iX11Type == 2)
         PWINDOW->m_fX11SurfaceScaledBy = PMONITOR->scale;
 
-    // Move cursor to middle of new window if enabled.
     g_pCompositor->warpCursorTo(PWINDOW->middle());
 }
 

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -667,6 +667,9 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
     if (PMONITOR && PWINDOW->m_iX11Type == 2)
         PWINDOW->m_fX11SurfaceScaledBy = PMONITOR->scale;
+
+    // Move cursor to middle of new window if enabled.
+    g_pCompositor->warpCursorTo(PWINDOW->middle());
 }
 
 void Events::listener_unmapWindow(void* owner, void* data) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes/addresses https://github.com/hyprwm/Hyprland/issues/5745.

Currently when creating a new window, the cursor doesn't warp to the new window like it does on a window focus change. As such I used the same method (warpCursorTo) to warp the cursor. This will also be disabled with no_cursor_warps.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This is a very straightforward change. It's unlikely this will introduce unexpected behavior as new windows are already focused, this just moves mouse too.

#### Is it ready for merging, or does it need work?
Ready for merging.
