### PR TITLE
CrashReporter: unbreak build on FreeBSD

### DIFF
--- a/hyprpm/src/core/PluginManager.cpp
+++ b/hyprpm/src/core/PluginManager.cpp
@@ -15,6 +15,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <pwd.h>
+#include <unistd.h>
 
 #include <toml++/toml.hpp>
 

--- a/src/signal-safe.hpp
+++ b/src/signal-safe.hpp
@@ -109,8 +109,10 @@ class BufFileWriter {
             struct sigaction act;
             act.sa_handler = SIG_DFL;
             sigemptyset(&act.sa_mask);
-            act.sa_flags    = SA_NOCLDWAIT;
+            act.sa_flags = SA_NOCLDWAIT;
+#ifdef SA_RESTORER
             act.sa_restorer = NULL;
+#endif
             sigaction(SIGCHLD, &act, NULL);
         }
         pid_t pid = fork();

--- a/src/signal-safe.hpp
+++ b/src/signal-safe.hpp
@@ -125,7 +125,7 @@ class BufFileWriter {
         if (pid == 0) {
             close(pipefd[0]);
             dup2(pipefd[1], STDOUT_FILENO);
-            char const* const argv[] = {"/bin/sh", "-c", cmd};
+            char const* const argv[] = {"/bin/sh", "-c", cmd, NULL};
             execv("/bin/sh", (char* const*)argv);
 
             BufFileWriter<64> failmsg(pipefd[1]);


### PR DESCRIPTION
Regressed by #5771. [POSIX.1-2017](https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigaction.html) and [FreeBSD](https://man.freebsd.org/sigaction/2) don't define `sa_restorer` while [Linux](https://man7.org/linux/man-pages/man2/sigaction.2.html) discourages usage in applications. As Hyprland just want to zero-init check for a related macro in order to catch all platforms that may have the field.

`writeCmdOutput` appears broken:
```diff
--- /home/test/.cache/hyprland/hyprlandCrashReport1111.txt	before
+++ /home/test/.cache/hyprland/hyprlandCrashReport2222.txt	after
@@ -1,13 +1,12 @@ --------------------------------------------
 --------------------------------------------
    Hyprland Crash Report
 --------------------------------------------
-Calm down, it was a misinput! MISINPUT!
+Oops
 
-Hyprland received signal 11 (Segmentation fault)
+Hyprland received signal 11(SEGV)
+Version: 2e763764bfdaee2039961c6c220b5d6af31712d4
+Tag: v0.39.1-91-g2e763764
 
-Version: e400a288d0f8ef75672cb201203b857b65b782bb
-Tag: v0.39.1-88-ge400a288
-
 System info:
 	System name: FreeBSD
 	Node name: foo.bar
@@ -16,22 +15,7 @@
 
 GPU:
-	vgapci0@pci0:0:2:0:	class=0x030000 rev=0x06 hdr=0x00 vendor=0x8086 device=0x1912 subvendor=0x1462 subdevice=0x7968
-    vendor     = 'Intel Corporation'
-    device     = 'HD Graphics 530'
-    class      = display
-    subclass   = VGA
-
-os-release:
-	NAME=FreeBSD
-	VERSION="15.0-CURRENT"
-	VERSION_ID="15.0"
-	ID=freebsd
-	ANSI_COLOR="0;31"
-	PRETTY_NAME="FreeBSD 15.0-CURRENT"
-	CPE_NAME="cpe:/o:freebsd:freebsd:15.0"
-	HOME_URL="https://FreeBSD.org/"
-	BUG_REPORT_URL="https://bugs.FreeBSD.org/"
 	
 
-
+os-release:
+<execv(cat /etc/os-release | sed 's/^/	/') resulted in errno >
 Backtrace:
```
