### PR TITLE
Move /tmp/hypr to XDG_RUNTIME_DIR

### DIFF
--- a/docs/ISSUE_GUIDELINES.md
+++ b/docs/ISSUE_GUIDELINES.md
@@ -34,16 +34,16 @@ If your bug crashes Hyprland, append additionally:
 ## Obtaining the Hyprland log
 If you are in a TTY, and the hyprland session that crashed was the last one you launched, the log will be printed with
 ```
-cat /tmp/hypr/$(ls -t /tmp/hypr/ | head -n 1)/hyprland.log
+cat $XDG_RUNTIME_DIR/hypr/$(ls -t $XDG_RUNTIME_DIR/hypr | head -n 1)/hyprland.log
 ```
 feel free to send it to a file, save, copy, etc.
 
 if you are in a Hyprland session, and you want the log of the last session, use
 ```
-cat /tmp/hypr/$(ls -t /tmp/hypr/ | head -n 2 | tail -n 1)/hyprland.log
+cat $XDG_RUNTIME_DIR/hypr/$(ls -t $XDG_RUNTIME_DIR/hypr | head -n 2 | tail -n 1)/hyprland.log
 ```
 
-basically, directories in /tmp/hypr are your sessions.
+basically, directories in $XDG_RUNTIME_DIR/hypr are your sessions.
 
 ## Obtaining the Hyprland Crash Report (v0.22.0beta and up)
 

--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -8,6 +8,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/un.h>
+#include <pwd.h>
 #include <unistd.h>
 #include <ranges>
 #include <algorithm>
@@ -41,21 +42,22 @@ struct SInstanceData {
 std::vector<SInstanceData> instances() {
     std::vector<SInstanceData> result;
 
-    for (const auto& el : std::filesystem::directory_iterator("/tmp/hypr")) {
-        if (el.is_directory() || !el.path().string().ends_with(".lock"))
+    const std::string USERID = std::to_string(getpwuid(getuid())->pw_uid);
+
+    for (const auto& el : std::filesystem::directory_iterator("/run/user/" + USERID + "/hypr")) {
+        if (!el.is_directory() || !std::filesystem::exists(el.path().string() + "/hyprland.lock"))
             continue;
 
         // read lock
         SInstanceData* data = &result.emplace_back();
         data->id            = el.path().string();
-        data->id            = data->id.substr(data->id.find_last_of('/') + 1, data->id.find(".lock") - data->id.find_last_of('/') - 1);
 
         try {
             data->time = std::stoull(data->id.substr(data->id.find_first_of('_') + 1, data->id.find_last_of('_') - (data->id.find_first_of('_') + 1)));
         } catch (std::exception& e) { continue; }
 
         // read file
-        std::ifstream ifs(el.path().string());
+        std::ifstream ifs(el.path().string() + "/hyprland.lock");
 
         int           i = 0;
         for (std::string line; std::getline(ifs, line); ++i) {
@@ -99,10 +101,12 @@ void request(std::string arg, int minArgs = 0) {
         return;
     }
 
-    sockaddr_un serverAddress = {0};
-    serverAddress.sun_family  = AF_UNIX;
+    const std::string USERID = std::to_string(getpwuid(getuid())->pw_uid);
 
-    std::string socketPath = "/tmp/hypr/" + instanceSignature + "/.socket.sock";
+    sockaddr_un       serverAddress = {0};
+    serverAddress.sun_family        = AF_UNIX;
+
+    std::string socketPath = "/run/user/" + USERID + "/hypr/" + instanceSignature + "/.socket.sock";
 
     strncpy(serverAddress.sun_path, socketPath.c_str(), sizeof(serverAddress.sun_path) - 1);
 
@@ -160,7 +164,9 @@ void requestHyprpaper(std::string arg) {
     sockaddr_un serverAddress = {0};
     serverAddress.sun_family  = AF_UNIX;
 
-    std::string socketPath = "/tmp/hypr/" + instanceSignature + "/.hyprpaper.sock";
+    const std::string USERID = std::to_string(getpwuid(getuid())->pw_uid);
+
+    std::string socketPath = "/run/user/" + USERID + "/hypr/" + instanceSignature + "/.hyprpaper.sock";
 
     strncpy(serverAddress.sun_path, socketPath.c_str(), sizeof(serverAddress.sun_path) - 1);
 

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -74,8 +74,11 @@ class CCompositor {
     wlr_session_lock_manager_v1*     m_sWLRSessionLockMgr;
     // ------------------------------------------------- //
 
+    std::string                               m_szHyprTempDataRoot = "";
+
     std::string                               m_szWLDisplaySocket   = "";
     std::string                               m_szInstanceSignature = "";
+    std::string                               m_szInstancePath      = "";
     std::string                               m_szCurrentSplash     = "error";
 
     std::vector<SP<CMonitor>>                 m_vMonitors;

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1746,7 +1746,7 @@ void CHyprCtl::startHyprCtlSocket() {
 
     sockaddr_un SERVERADDRESS = {.sun_family = AF_UNIX};
 
-    std::string socketPath = "/tmp/hypr/" + g_pCompositor->m_szInstanceSignature + "/.socket.sock";
+    std::string socketPath = g_pCompositor->m_szInstancePath + "/.socket.sock";
 
     strcpy(SERVERADDRESS.sun_path, socketPath.c_str());
 

--- a/src/debug/Log.cpp
+++ b/src/debug/Log.cpp
@@ -6,7 +6,7 @@
 #include <iostream>
 
 void Debug::init(const std::string& IS) {
-    logFile = "/tmp/hypr/" + IS + (ISDEBUG ? "/hyprlandd.log" : "/hyprland.log");
+    logFile = IS + (ISDEBUG ? "/hyprlandd.log" : "/hyprland.log");
 }
 
 void Debug::wlrLog(wlr_log_importance level, const char* fmt, va_list args) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,8 +97,13 @@ int main(int argc, char** argv) {
 
     // let's init the compositor.
     // it initializes basic Wayland stuff in the constructor.
-    g_pCompositor                     = std::make_unique<CCompositor>();
-    g_pCompositor->explicitConfigPath = configPath;
+    try {
+        g_pCompositor                     = std::make_unique<CCompositor>();
+        g_pCompositor->explicitConfigPath = configPath;
+    } catch (std::exception& e) {
+        std::cout << "Hyprland threw in ctor: " << e.what() << "\nCannot continue.\n";
+        return 1;
+    }
 
     g_pCompositor->initServer();
 

--- a/src/managers/EventManager.cpp
+++ b/src/managers/EventManager.cpp
@@ -39,7 +39,7 @@ void CEventManager::startThread() {
     }
 
     sockaddr_un SERVERADDRESS = {.sun_family = AF_UNIX};
-    std::string socketPath    = "/tmp/hypr/" + g_pCompositor->m_szInstanceSignature + "/.socket2.sock";
+    std::string socketPath    = g_pCompositor->m_szInstancePath + "/.socket2.sock";
     strncpy(SERVERADDRESS.sun_path, socketPath.c_str(), sizeof(SERVERADDRESS.sun_path) - 1);
 
     bind(m_iSocketFD, (sockaddr*)&SERVERADDRESS, SUN_LEN(&SERVERADDRESS));

--- a/src/plugins/HookSystem.cpp
+++ b/src/plugins/HookSystem.cpp
@@ -2,6 +2,7 @@
 #include "../debug/Log.hpp"
 #include "../helpers/VarList.hpp"
 #include "../managers/TokenManager.hpp"
+#include "../Compositor.hpp"
 
 #define register
 #include <udis86.h>
@@ -138,7 +139,7 @@ CFunctionHook::SAssembly CFunctionHook::fixInstructionProbeRIPCalls(const SInstr
         currentAddress += len;
     }
 
-    const auto RANDOMDIR = "/tmp/hypr/" + g_pTokenManager->getRandomUUID();
+    const auto RANDOMDIR = g_pCompositor->m_szInstancePath + "/" + g_pTokenManager->getRandomUUID();
 
     if (std::filesystem::exists(RANDOMDIR)) {
         Debug::log(ERR, "[hooksystem] random out dir exists??");


### PR DESCRIPTION
Moves `/tmp/hypr` to `$XDG_RUNTIME_DIR/hypr`, making it 700 as well.

Breaks direct consumers of socket and socket2

TODO:
 - [ ] Wiki