### PR TITLE
log on watchdog activation

### DIFF
--- a/src/helpers/Watchdog.cpp
+++ b/src/helpers/Watchdog.cpp
@@ -22,8 +22,10 @@ CWatchdog::CWatchdog() {
             if (!m_bWillWatch)
                 m_cvWatchdogCondition.wait(lk, [this] { return m_bNotified; });
             else {
-                if (m_cvWatchdogCondition.wait_for(lk, std::chrono::milliseconds((int)(*PTIMEOUT * 1000.0)), [this] { return m_bNotified; }) == false)
+                if (m_cvWatchdogCondition.wait_for(lk, std::chrono::milliseconds((int)(*PTIMEOUT * 1000.0)), [this] { return m_bNotified; }) == false) {
+                    Debug::log(LogLevel::CRIT, "Watchdog timeout met: killing main thread!");
                     pthread_kill(m_iMainThreadPID, SIGUSR1);
+                }
             }
 
             if (m_bExitThread)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

When watchdog is triggered, log something so that users that are debugging / working on Hyprland don't get confused when a simple breakpoint crashes their program. Context: [this discord message](https://discord.com/channels/961691461554950145/1070436481912549497/1234261662081744916).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Thinking about the new user experience, `debug:enable_stdout_logs` is still disabled by default, meaning this won't take effect unless users have already looked through all the debugging variables and happened to set this. Maybe it makes sense to set the default value of disable_logs/enable_stdout_logs based on whether it's a debug build or not?

#### Is it ready for merging, or does it need work?

Should be ready, though feel free to reword the message
