### PR TITLE
Fix Floating Grouped Windows Crash and Bug.

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -707,7 +707,7 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
             m_vRealSize                     = Vector2D(std::min((double)m_sAdditionalConfigData.maxSize.toUnderlying().x, m_vRealSize.goal().x),
                                                        std::min((double)m_sAdditionalConfigData.maxSize.toUnderlying().y, m_vRealSize.goal().y));
             g_pXWaylandManager->setWindowSize(m_pSelf.lock(), m_vRealSize.goal());
-            if (!m_sGroupData.pNextWindow.lock())
+            if (m_sGroupData.pNextWindow.expired())
                 setHidden(false);
         } catch (std::exception& e) { Debug::log(ERR, "maxsize rule \"{}\" failed with: {}", r.szRule, e.what()); }
     } else if (r.szRule.starts_with("minsize")) {
@@ -724,7 +724,7 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
             m_vRealSize                     = Vector2D(std::max((double)m_sAdditionalConfigData.minSize.toUnderlying().x, m_vRealSize.goal().x),
                                                        std::max((double)m_sAdditionalConfigData.minSize.toUnderlying().y, m_vRealSize.goal().y));
             g_pXWaylandManager->setWindowSize(m_pSelf.lock(), m_vRealSize.goal());
-            if (!m_sGroupData.pNextWindow.lock())
+            if (m_sGroupData.pNextWindow.expired())
                 setHidden(false);
         } catch (std::exception& e) { Debug::log(ERR, "minsize rule \"{}\" failed with: {}", r.szRule, e.what()); }
     }

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -707,8 +707,7 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
             m_vRealSize                     = Vector2D(std::min((double)m_sAdditionalConfigData.maxSize.toUnderlying().x, m_vRealSize.goal().x),
                                                        std::min((double)m_sAdditionalConfigData.maxSize.toUnderlying().y, m_vRealSize.goal().y));
             g_pXWaylandManager->setWindowSize(m_pSelf.lock(), m_vRealSize.goal());
-            // Do not unhide grouped items unless it is the visible window.
-            if (!m_sGroupData.pNextWindow.lock() || m_sGroupData.head)
+            if (!m_sGroupData.pNextWindow.lock())
                 setHidden(false);
         } catch (std::exception& e) { Debug::log(ERR, "maxsize rule \"{}\" failed with: {}", r.szRule, e.what()); }
     } else if (r.szRule.starts_with("minsize")) {
@@ -725,8 +724,7 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
             m_vRealSize                     = Vector2D(std::max((double)m_sAdditionalConfigData.minSize.toUnderlying().x, m_vRealSize.goal().x),
                                                        std::max((double)m_sAdditionalConfigData.minSize.toUnderlying().y, m_vRealSize.goal().y));
             g_pXWaylandManager->setWindowSize(m_pSelf.lock(), m_vRealSize.goal());
-            // Do not unhide grouped items unless it is the visible window.
-            if (!m_sGroupData.pNextWindow.lock() || m_sGroupData.head)
+            if (!m_sGroupData.pNextWindow.lock())
                 setHidden(false);
         } catch (std::exception& e) { Debug::log(ERR, "minsize rule \"{}\" failed with: {}", r.szRule, e.what()); }
     }

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -707,7 +707,9 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
             m_vRealSize                     = Vector2D(std::min((double)m_sAdditionalConfigData.maxSize.toUnderlying().x, m_vRealSize.goal().x),
                                                        std::min((double)m_sAdditionalConfigData.maxSize.toUnderlying().y, m_vRealSize.goal().y));
             g_pXWaylandManager->setWindowSize(m_pSelf.lock(), m_vRealSize.goal());
-            setHidden(false);
+            // Do not unhide grouped items unless it is the visible window.
+            if (!m_sGroupData.pNextWindow.lock() || m_sGroupData.head)
+                setHidden(false);
         } catch (std::exception& e) { Debug::log(ERR, "maxsize rule \"{}\" failed with: {}", r.szRule, e.what()); }
     } else if (r.szRule.starts_with("minsize")) {
         try {
@@ -723,7 +725,9 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
             m_vRealSize                     = Vector2D(std::max((double)m_sAdditionalConfigData.minSize.toUnderlying().x, m_vRealSize.goal().x),
                                                        std::max((double)m_sAdditionalConfigData.minSize.toUnderlying().y, m_vRealSize.goal().y));
             g_pXWaylandManager->setWindowSize(m_pSelf.lock(), m_vRealSize.goal());
-            setHidden(false);
+            // Do not unhide grouped items unless it is the visible window.
+            if (!m_sGroupData.pNextWindow.lock() || m_sGroupData.head)
+                setHidden(false);
         } catch (std::exception& e) { Debug::log(ERR, "minsize rule \"{}\" failed with: {}", r.szRule, e.what()); }
     }
 }

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -707,8 +707,6 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
             m_vRealSize                     = Vector2D(std::min((double)m_sAdditionalConfigData.maxSize.toUnderlying().x, m_vRealSize.goal().x),
                                                        std::min((double)m_sAdditionalConfigData.maxSize.toUnderlying().y, m_vRealSize.goal().y));
             g_pXWaylandManager->setWindowSize(m_pSelf.lock(), m_vRealSize.goal());
-            if (m_sGroupData.pNextWindow.expired())
-                setHidden(false);
         } catch (std::exception& e) { Debug::log(ERR, "maxsize rule \"{}\" failed with: {}", r.szRule, e.what()); }
     } else if (r.szRule.starts_with("minsize")) {
         try {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
It was reported here https://github.com/hyprwm/Hyprland/issues/5768 that floating groups would display as two separate windows then Hyprland would eventually hang after moving or resizing. After further testing this only happens with minsize, or maxsize set in config. This was due to the max/min size check forcing windows to unhide.

Since I'm not sure why this was done in the first place I only added a check verifying that its not unhiding grouped windows here (nextWindow will be a null pointer only if the window is not grouped).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I'm unsure why we force unhid windows in a size check so there could be a potential side effect. That said, I did test this and this only effects grouped windows.

#### Is it ready for merging, or does it need work?
I believe so, that said there may be a better way to do this.

