### PR TITLE
added option to choose the default monitor that the cursor will appea…

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -318,6 +318,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("general:layout", {"dwindle"});
     m_pConfig->addConfigValue("general:allow_tearing", Hyprlang::INT{0});
     m_pConfig->addConfigValue("general:resize_corner", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("general:default_cursor_monitor", {STRVAL_EMPTY});
 
     m_pConfig->addConfigValue("misc:disable_hyprland_logo", Hyprlang::INT{0});
     m_pConfig->addConfigValue("misc:disable_splash_rendering", Hyprlang::INT{0});

--- a/src/events/Monitors.cpp
+++ b/src/events/Monitors.cpp
@@ -60,12 +60,44 @@ void Events::listener_change(wl_listener* listener, void* data) {
     wlr_output_manager_v1_set_configuration(g_pCompositor->m_sWLROutputMgr, CONFIG);
 }
 
+static void checkDefaultCursorWarp(std::shared_ptr<CMonitor>* PNEWMONITORWRAP, std::string monitorName) {
+    const auto  PNEWMONITOR = PNEWMONITORWRAP->get();
+
+    static auto PCURSORMONITOR    = CConfigValue<std::string>("general:default_cursor_monitor");
+    static auto firstMonitorAdded = std::chrono::system_clock::now();
+    static bool cursorDefaultDone = false;
+    static bool firstLaunch       = true;
+
+    const auto  POS = PNEWMONITOR->middle();
+
+    // by default, cursor should be set to first monitor detected
+    // this is needed as a default if the monitor given in config above doesn't exist
+    if (firstLaunch) {
+        firstLaunch = false;
+        g_pCompositor->warpCursorTo(POS, true);
+        g_pInputManager->refocus();
+    }
+
+    if (cursorDefaultDone || *PCURSORMONITOR == STRVAL_EMPTY)
+        return;
+
+    // after 10s, don't set cursor to default monitor
+    auto timePassedSec = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now() - firstMonitorAdded);
+    if (timePassedSec.count() > 10) {
+        cursorDefaultDone = true;
+        return;
+    }
+
+    if (*PCURSORMONITOR == monitorName) {
+        cursorDefaultDone = true;
+        g_pCompositor->warpCursorTo(POS, true);
+        g_pInputManager->refocus();
+    }
+}
+
 void Events::listener_newOutput(wl_listener* listener, void* data) {
     // new monitor added, let's accommodate for that.
     const auto OUTPUT = (wlr_output*)data;
-
-    // for warping the cursor on launch
-    static bool firstLaunch = true;
 
     if (!OUTPUT->name) {
         Debug::log(ERR, "New monitor has no name?? Ignoring");
@@ -101,36 +133,13 @@ void Events::listener_newOutput(wl_listener* listener, void* data) {
     g_pConfigManager->m_bWantsMonitorReload = true;
     g_pCompositor->scheduleFrameForMonitor(PNEWMONITOR);
 
-    if (firstLaunch) {
-        firstLaunch    = false;
-        const auto POS = PNEWMONITOR->middle();
-        if (g_pCompositor->m_sSeat.mouse)
-            wlr_cursor_warp(g_pCompositor->m_sWLRCursor, g_pCompositor->m_sSeat.mouse->mouse, POS.x, POS.y);
-    } else {
-        for (auto& w : g_pCompositor->m_vWindows) {
-            if (w->m_iMonitorID == PNEWMONITOR->ID) {
-                w->m_iLastSurfaceMonitorID = -1;
-                w->updateSurfaceScaleTransformDetails();
-            }
+    checkDefaultCursorWarp(PNEWMONITORWRAP, OUTPUT->name);
+
+    for (auto& w : g_pCompositor->m_vWindows) {
+        if (w->m_iMonitorID == PNEWMONITOR->ID) {
+            w->m_iLastSurfaceMonitorID = -1;
+            w->updateSurfaceScaleTransformDetails();
         }
-    }
-
-    static auto PCURSORMONITOR    = CConfigValue<std::string>("general:default_cursor_monitor");
-    static auto firstMonitorAdded = std::chrono::system_clock::now();
-    static bool cursorDefaultDone = false;
-
-    if (cursorDefaultDone || *PCURSORMONITOR == STRVAL_EMPTY)
-        return;
-
-    auto timePassedSec = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now() - firstMonitorAdded);
-    if (timePassedSec.count() > 10)
-        cursorDefaultDone = true;
-
-    if (*PCURSORMONITOR == OUTPUT->name) {
-        cursorDefaultDone = true;
-        const auto POS    = PNEWMONITOR->middle();
-        if (g_pCompositor->m_sSeat.mouse != nullptr)
-            wlr_cursor_warp(g_pCompositor->m_sWLRCursor, g_pCompositor->m_sSeat.mouse->mouse, POS.x, POS.y);
     }
 }
 

--- a/src/events/Monitors.cpp
+++ b/src/events/Monitors.cpp
@@ -115,10 +115,20 @@ void Events::listener_newOutput(wl_listener* listener, void* data) {
         }
     }
 
-    static auto PCURSORMONITOR = *CConfigValue<std::string>("general:default_cursor_monitor");
+    static auto PCURSORMONITOR    = CConfigValue<std::string>("general:default_cursor_monitor");
+    static auto firstMonitorAdded = std::chrono::system_clock::now();
+    static bool cursorDefaultDone = false;
 
-    if (PCURSORMONITOR != STRVAL_EMPTY && PCURSORMONITOR == OUTPUT->name) {
-        const auto POS = PNEWMONITOR->middle();
+    if (cursorDefaultDone || *PCURSORMONITOR == STRVAL_EMPTY)
+        return;
+
+    auto timePassedSec = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now() - firstMonitorAdded);
+    if (timePassedSec.count() > 10)
+        cursorDefaultDone = true;
+
+    if (*PCURSORMONITOR == OUTPUT->name) {
+        cursorDefaultDone = true;
+        const auto POS    = PNEWMONITOR->middle();
         if (g_pCompositor->m_sSeat.mouse != nullptr)
             wlr_cursor_warp(g_pCompositor->m_sWLRCursor, g_pCompositor->m_sSeat.mouse->mouse, POS.x, POS.y);
     }

--- a/src/events/Monitors.cpp
+++ b/src/events/Monitors.cpp
@@ -114,6 +114,14 @@ void Events::listener_newOutput(wl_listener* listener, void* data) {
             }
         }
     }
+
+    static auto PCURSORMONITOR = *CConfigValue<std::string>("general:default_cursor_monitor");
+
+    if (PCURSORMONITOR != STRVAL_EMPTY && PCURSORMONITOR == OUTPUT->name) {
+        const auto POS = PNEWMONITOR->middle();
+        if (g_pCompositor->m_sSeat.mouse != nullptr)
+            wlr_cursor_warp(g_pCompositor->m_sWLRCursor, g_pCompositor->m_sSeat.mouse->mouse, POS.x, POS.y);
+    }
 }
 
 void Events::listener_monitorFrame(void* owner, void* data) {


### PR DESCRIPTION
 Default monitor for cursor #5803 

#### Describe your PR, what does it fix/add?
Adds an option (string) under general:default_cursor_monitor.
Then, whenever a new monitor is added, it checks whether it's name matches the above string.
If it does, then it will set the cursor to the middle of that monitor.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
If the option isn't set then it functions the same as before

Also, technically if a new monitor is added after startup and it matches the name, then the cursor will be set to there.
To fix this you would need to make the code stop checking after startup or after all the initial monitors have been added.
I don't know how you would do that though

#### Is it ready for merging, or does it need work?
Probably, I tested it on my PC and changing the option does change which monitor the mouse appears in on startup