### PR TITLE
inputmgr: dont double free on hotplug

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -181,7 +181,6 @@ uint32_t CKeybindManager::keycodeToModifier(xkb_keycode_t keycode) {
 
 void CKeybindManager::updateXKBTranslationState() {
     if (m_pXKBTranslationState) {
-        xkb_keymap_unref(xkb_state_get_keymap(m_pXKBTranslationState));
         xkb_state_unref(m_pXKBTranslationState);
 
         m_pXKBTranslationState = nullptr;

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1195,6 +1195,7 @@ void CInputManager::destroyKeyboard(SKeyboard* pKeyboard) {
     pKeyboard->hyprListener_keyboardKey.removeCallback();
 
     xkb_state_unref(pKeyboard->xkbTranslationState);
+    pKeyboard->xkbTranslationState = nullptr;
 
     m_lKeyboards.remove(*pKeyboard);
 


### PR DESCRIPTION
since we are also unrefing the state on hotplugging the keyboard set the state to nullptr so the destructor if case actually catches its been already freed.

#### Describe your PR, what does it fix/add?
#5852 got merged so fast it didnt feel right, im on a laptop so had to dig through the closet for an old logitech usb keyboard and lo and behold there was a missing nullptr here, without it double free occurs.
