### PR TITLE
windows: set fullscreen border size to 0

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1119,7 +1119,7 @@ void CWindow::updateSpecialRenderData(const SWorkspaceRule& workspaceRule) {
 }
 
 int CWindow::getRealBorderSize() {
-    if (!m_sSpecialRenderData.border || m_sAdditionalConfigData.forceNoBorder)
+    if (!m_sSpecialRenderData.border || m_sAdditionalConfigData.forceNoBorder || (m_pWorkspace && m_bIsFullscreen && (m_pWorkspace->m_efFullscreenMode == FULLSCREEN_FULL)))
         return 0;
 
     if (m_sAdditionalConfigData.borderSize.toUnderlying() != -1)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
The border size meant that fullscreen windows behind special workspaces would get focus as the cursor moved between monitors. If the fullscreen application was a game that captures the cursor, this caused the game to focus, and the special workspace to unexpectedly close.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready

