### PR TITLE
togglegroup ipc event added when create/destroy-ing window groups

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -836,6 +836,8 @@ void CWindow::createGroup() {
         g_pCompositor->updateWorkspaceSpecialRenderData(workspaceID());
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m_iMonitorID);
         g_pCompositor->updateAllWindowsAnimatedDecorationValues();
+
+        g_pEventManager->postEvent(SHyprIPCEvent{"togglegroup", std::format("1,{:x}", (uintptr_t)this)});
     }
 }
 
@@ -852,9 +854,12 @@ void CWindow::destroyGroup() {
         g_pCompositor->updateWorkspaceSpecialRenderData(workspaceID());
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m_iMonitorID);
         g_pCompositor->updateAllWindowsAnimatedDecorationValues();
+
+        g_pEventManager->postEvent(SHyprIPCEvent{"togglegroup", std::format("0,{:x}", (uintptr_t)this)});
         return;
     }
 
+    std::string            addresses;
     PHLWINDOW              curr = m_pSelf.lock();
     std::vector<PHLWINDOW> members;
     do {
@@ -863,6 +868,8 @@ void CWindow::destroyGroup() {
         PLASTWIN->m_sGroupData.pNextWindow.reset();
         curr->setHidden(false);
         members.push_back(curr);
+
+        addresses += std::format("{:x},", (uintptr_t)curr.get());
     } while (curr.get() != this);
 
     for (auto& w : members) {
@@ -883,6 +890,10 @@ void CWindow::destroyGroup() {
     g_pCompositor->updateWorkspaceSpecialRenderData(workspaceID());
     g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m_iMonitorID);
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
+
+    if (!addresses.empty())
+        addresses.pop_back();
+    g_pEventManager->postEvent(SHyprIPCEvent{"togglegroup", std::format("0,{}", addresses)});
 }
 
 PHLWINDOW CWindow::getGroupHead() {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2238,6 +2238,8 @@ void CKeybindManager::moveWindowIntoGroup(PHLWINDOW pWindow, PHLWINDOW pWindowIn
 
     if (!pWindow->getDecorationByType(DECORATION_GROUPBAR))
         pWindow->addWindowDeco(std::make_unique<CHyprGroupBarDecoration>(pWindow));
+
+    g_pEventManager->postEvent(SHyprIPCEvent{"moveintogroup", std::format("{:x}", (uintptr_t)pWindow.get())});
 }
 
 void CKeybindManager::moveWindowOutOfGroup(PHLWINDOW pWindow, const std::string& dir) {
@@ -2275,6 +2277,8 @@ void CKeybindManager::moveWindowOutOfGroup(PHLWINDOW pWindow, const std::string&
         g_pCompositor->focusWindow(PWINDOWPREV);
         g_pCompositor->warpCursorTo(PWINDOWPREV->middle());
     }
+
+    g_pEventManager->postEvent(SHyprIPCEvent{"moveoutofgroup", std::format("{:x}", (uintptr_t)pWindow.get())});
 }
 
 void CKeybindManager::moveIntoGroup(std::string args) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
I found myself in a need of a IPC event of creating or destroying window groups. I read the [ipc wiki article](https://wiki.hyprland.org/IPC/) and saw this feature was missing

This PR will add new `togglegroup` IPC event which will return 0/1 after creating or destroying [a window group](https://wiki.hyprland.org/0.18.0beta/Configuring/Dwindle-Layout/#grouped-tabbed-windows) 
#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nothing specifically mentioned in question but this PR resolves #5687 issue
#### Is it ready for merging, or does it need work?
Should be ready for merge without conflicts

