### PR TITLE
New shared_ptr implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,8 @@ if(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES DEBUG)
         message(STATUS "Enabling ASan")
 
         target_link_libraries(Hyprland asan)
+        pkg_check_modules(ffidep REQUIRED IMPORTED_TARGET libffi)
+        target_link_libraries(Hyprland ${CMAKE_SOURCE_DIR}/libwayland-server.a PkgConfig::ffidep)
         target_compile_options(Hyprland PUBLIC -fsanitize=address)
     endif()
 

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1183,7 +1183,7 @@ void CCompositor::sanityCheckWorkspaces() {
         const auto& WORKSPACE = *it;
 
         // If ref == 1, only the compositor holds a ref, which means it's inactive and has no mapped windows.
-        if (!WORKSPACE->m_bPersistent && WORKSPACE.use_count() == 1) {
+        if (!WORKSPACE->m_bPersistent && WORKSPACE.strongRef() == 1) {
             it = m_vWorkspaces.erase(it);
             continue;
         }
@@ -1823,7 +1823,7 @@ void CCompositor::updateWindowAnimatedDecorationValues(PHLWINDOW pWindow) {
         setBorderColor(*RENDERDATA.borderGradient);
     else {
         const bool GROUPLOCKED = pWindow->m_sGroupData.pNextWindow.lock() ? pWindow->getGroupHead()->m_sGroupData.locked : false;
-        if (pWindow == m_pLastWindow.lock()) {
+        if (pWindow == m_pLastWindow) {
             const auto* const ACTIVECOLOR =
                 !pWindow->m_sGroupData.pNextWindow.lock() ? (!pWindow->m_sGroupData.deny ? ACTIVECOL : NOGROUPACTIVECOL) : (GROUPLOCKED ? GROUPACTIVELOCKEDCOL : GROUPACTIVECOL);
             setBorderColor(pWindow->m_sSpecialRenderData.activeBorderColor.toUnderlying().m_vColors.empty() ? *ACTIVECOLOR :
@@ -1848,7 +1848,7 @@ void CCompositor::updateWindowAnimatedDecorationValues(PHLWINDOW pWindow) {
                                                                                     pWindow->m_sSpecialRenderData.alphaFullscreen.toUnderlying() * *PFULLSCREENALPHA) :
             *PFULLSCREENALPHA;
     } else {
-        if (pWindow == m_pLastWindow.lock())
+        if (pWindow == m_pLastWindow)
             pWindow->m_fActiveInactiveAlpha = pWindow->m_sSpecialRenderData.alphaOverride.toUnderlying() ? pWindow->m_sSpecialRenderData.alpha.toUnderlying() :
                                                                                                            pWindow->m_sSpecialRenderData.alpha.toUnderlying() * *PACTIVEALPHA;
         else
@@ -1867,7 +1867,7 @@ void CCompositor::updateWindowAnimatedDecorationValues(PHLWINDOW pWindow) {
 
     // shadow
     if (pWindow->m_iX11Type != 2 && !pWindow->m_bX11DoesntWantBorders) {
-        if (pWindow == m_pLastWindow.lock()) {
+        if (pWindow == m_pLastWindow) {
             pWindow->m_cRealShadowColor = CColor(*PSHADOWCOL);
         } else {
             pWindow->m_cRealShadowColor = CColor(*PSHADOWCOLINACTIVE != INT_MAX ? *PSHADOWCOLINACTIVE : *PSHADOWCOL);
@@ -2346,7 +2346,7 @@ PHLWINDOW CCompositor::getWindowByRegex(const std::string& regexp) {
         const bool FLOAT = regexp.starts_with("floating");
 
         for (auto& w : m_vWindows) {
-            if (!w->m_bIsMapped || w->m_bIsFloating != FLOAT || w->m_pWorkspace != m_pLastWindow.lock()->m_pWorkspace || w->isHidden())
+            if (!w->m_bIsMapped || w->m_bIsFloating != FLOAT || w->m_pWorkspace != m_pLastWindow->m_pWorkspace || w->isHidden())
                 continue;
 
             return w;

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1588,11 +1588,11 @@ CHyprCtl::CHyprCtl() {
     startHyprCtlSocket();
 }
 
-std::shared_ptr<SHyprCtlCommand> CHyprCtl::registerCommand(SHyprCtlCommand cmd) {
-    return m_vCommands.emplace_back(std::make_shared<SHyprCtlCommand>(cmd));
+SP<SHyprCtlCommand> CHyprCtl::registerCommand(SHyprCtlCommand cmd) {
+    return m_vCommands.emplace_back(makeShared<SHyprCtlCommand>(cmd));
 }
 
-void CHyprCtl::unregisterCommand(const std::shared_ptr<SHyprCtlCommand>& cmd) {
+void CHyprCtl::unregisterCommand(const SP<SHyprCtlCommand>& cmd) {
     std::erase(m_vCommands, cmd);
 }
 

--- a/src/debug/HyprCtl.hpp
+++ b/src/debug/HyprCtl.hpp
@@ -9,21 +9,21 @@ class CHyprCtl {
   public:
     CHyprCtl();
 
-    std::string                      makeDynamicCall(const std::string& input);
-    std::shared_ptr<SHyprCtlCommand> registerCommand(SHyprCtlCommand cmd);
-    void                             unregisterCommand(const std::shared_ptr<SHyprCtlCommand>& cmd);
-    std::string                      getReply(std::string);
+    std::string         makeDynamicCall(const std::string& input);
+    SP<SHyprCtlCommand> registerCommand(SHyprCtlCommand cmd);
+    void                unregisterCommand(const SP<SHyprCtlCommand>& cmd);
+    std::string         getReply(std::string);
 
-    int                              m_iSocketFD = -1;
+    int                 m_iSocketFD = -1;
 
     struct {
         bool all = false;
     } m_sCurrentRequestParams;
 
   private:
-    void                                          startHyprCtlSocket();
+    void                             startHyprCtlSocket();
 
-    std::vector<std::shared_ptr<SHyprCtlCommand>> m_vCommands;
+    std::vector<SP<SHyprCtlCommand>> m_vCommands;
 };
 
 inline std::unique_ptr<CHyprCtl> g_pHyprCtl;

--- a/src/defines.hpp
+++ b/src/defines.hpp
@@ -3,16 +3,4 @@
 #include "helpers/WLListener.hpp"
 #include "helpers/Color.hpp"
 #include "macros.hpp"
-
-class CWindow;
-class CLayerSurface;
-
-/* Shared pointer to a window */
-typedef SP<CWindow> PHLWINDOW;
-/* Weak pointer to a window */
-typedef WP<CWindow> PHLWINDOWREF;
-
-/* Shared pointer to a layer surface */
-typedef SP<CLayerSurface> PHLLS;
-/* Weak pointer to a layer surface */
-typedef WP<CLayerSurface> PHLLSREF;
+#include "desktop/DesktopTypes.hpp"

--- a/src/desktop/DesktopTypes.hpp
+++ b/src/desktop/DesktopTypes.hpp
@@ -1,6 +1,20 @@
 #pragma once
-#include <memory>
-
+#include "../macros.hpp"
 class CWorkspace;
+class CWindow;
+class CLayerSurface;
 
-typedef std::shared_ptr<CWorkspace> PHLWORKSPACE;
+/* Shared pointer to a workspace */
+typedef SP<CWorkspace> PHLWORKSPACE;
+/* Weak pointer to a workspace */
+typedef WP<CWorkspace> PHLWORKSPACEREF;
+
+/* Shared pointer to a window */
+typedef SP<CWindow> PHLWINDOW;
+/* Weak pointer to a window */
+typedef WP<CWindow> PHLWINDOWREF;
+
+/* Shared pointer to a layer surface */
+typedef SP<CLayerSurface> PHLLS;
+/* Weak pointer to a layer surface */
+typedef WP<CLayerSurface> PHLLSREF;

--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -58,7 +58,7 @@ static void onDestroy(void* owner, void* data) {
 // IMPL
 
 PHLLS CLayerSurface::create(wlr_layer_surface_v1* pWLRLS) {
-    PHLLS pLS = std::shared_ptr<CLayerSurface>(new CLayerSurface);
+    PHLLS pLS = SP<CLayerSurface>(new CLayerSurface);
 
     auto  PMONITOR = g_pCompositor->getMonitorFromOutput(pWLRLS->output);
 
@@ -176,7 +176,7 @@ void CLayerSurface::onMap() {
     if ((uint64_t)monitorID != PMONITOR->ID) {
         const auto POLDMON = g_pCompositor->getMonitorFromID(monitorID);
         for (auto it = POLDMON->m_aLayerSurfaceLayers[layer].begin(); it != POLDMON->m_aLayerSurfaceLayers[layer].end(); it++) {
-            if (*it == self.lock()) {
+            if (*it == self) {
                 PMONITOR->m_aLayerSurfaceLayers[layer].emplace_back(std::move(*it));
                 POLDMON->m_aLayerSurfaceLayers[layer].erase(it);
                 break;
@@ -235,7 +235,7 @@ void CLayerSurface::onUnmap() {
     std::erase_if(g_pInputManager->m_dExclusiveLSes, [this](const auto& other) { return !other.lock() || other.lock() == self.lock(); });
 
     if (!g_pInputManager->m_dExclusiveLSes.empty())
-        g_pCompositor->focusSurface(g_pInputManager->m_dExclusiveLSes[0].lock()->layerSurface->surface);
+        g_pCompositor->focusSurface(g_pInputManager->m_dExclusiveLSes[0]->layerSurface->surface);
 
     if (!g_pCompositor->getMonitorFromID(monitorID) || g_pCompositor->m_bUnsafeState) {
         Debug::log(WARN, "Layersurface unmapping on invalid monitor (removed?) ignoring.");
@@ -284,7 +284,7 @@ void CLayerSurface::onUnmap() {
             foundSurface = g_pCompositor->vectorToLayerSurface(g_pInputManager->getMouseCoordsInternal(), &PMONITOR->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP],
                                                                &surfaceCoords, &pFoundLayerSurface);
 
-        if (!foundSurface && g_pCompositor->m_pLastWindow.lock() && g_pCompositor->isWorkspaceVisible(g_pCompositor->m_pLastWindow.lock()->m_pWorkspace)) {
+        if (!foundSurface && g_pCompositor->m_pLastWindow.lock() && g_pCompositor->isWorkspaceVisible(g_pCompositor->m_pLastWindow->m_pWorkspace)) {
             // if there isn't any, focus the last window
             const auto PLASTWINDOW = g_pCompositor->m_pLastWindow.lock();
             g_pCompositor->focusWindow(nullptr);
@@ -325,7 +325,7 @@ void CLayerSurface::onCommit() {
         const auto POLDMON = g_pCompositor->getMonitorFromID(monitorID);
 
         for (auto it = POLDMON->m_aLayerSurfaceLayers[layer].begin(); it != POLDMON->m_aLayerSurfaceLayers[layer].end(); it++) {
-            if (*it == self.lock()) {
+            if (*it == self) {
                 PMONITOR->m_aLayerSurfaceLayers[layer].emplace_back(std::move(*it));
                 POLDMON->m_aLayerSurfaceLayers[layer].erase(it);
                 break;
@@ -341,7 +341,7 @@ void CLayerSurface::onCommit() {
         if (layer != layerSurface->current.layer) {
 
             for (auto it = PMONITOR->m_aLayerSurfaceLayers[layer].begin(); it != PMONITOR->m_aLayerSurfaceLayers[layer].end(); it++) {
-                if (*it == self.lock()) {
+                if (*it == self) {
                     PMONITOR->m_aLayerSurfaceLayers[layerSurface->current.layer].emplace_back(std::move(*it));
                     PMONITOR->m_aLayerSurfaceLayers[layer].erase(it);
                     break;

--- a/src/desktop/Popup.cpp
+++ b/src/desktop/Popup.cpp
@@ -70,9 +70,9 @@ void CPopup::initAllSignals() {
 
     if (!m_pWLR) {
         if (!m_pWindowOwner.expired())
-            hyprListener_newPopup.initCallback(&m_pWindowOwner.lock()->m_uSurface.xdg->events.new_popup, ::onNewPopup, this, "CPopup Head");
+            hyprListener_newPopup.initCallback(&m_pWindowOwner->m_uSurface.xdg->events.new_popup, ::onNewPopup, this, "CPopup Head");
         else if (!m_pLayerOwner.expired())
-            hyprListener_newPopup.initCallback(&m_pLayerOwner.lock()->layerSurface->events.new_popup, ::onNewPopup, this, "CPopup Head");
+            hyprListener_newPopup.initCallback(&m_pLayerOwner->layerSurface->events.new_popup, ::onNewPopup, this, "CPopup Head");
         else
             ASSERT(false);
 
@@ -119,8 +119,8 @@ void CPopup::onMap() {
     unconstrain();
     sendScale();
 
-    if (!m_pLayerOwner.expired() && m_pLayerOwner.lock()->layer < ZWLR_LAYER_SHELL_V1_LAYER_TOP)
-        g_pHyprOpenGL->markBlurDirtyForMonitor(g_pCompositor->getMonitorFromID(m_pLayerOwner.lock()->layer));
+    if (!m_pLayerOwner.expired() && m_pLayerOwner->layer < ZWLR_LAYER_SHELL_V1_LAYER_TOP)
+        g_pHyprOpenGL->markBlurDirtyForMonitor(g_pCompositor->getMonitorFromID(m_pLayerOwner->layer));
 }
 
 void CPopup::onUnmap() {
@@ -136,8 +136,8 @@ void CPopup::onUnmap() {
 
     g_pInputManager->simulateMouseMovement();
 
-    if (!m_pLayerOwner.expired() && m_pLayerOwner.lock()->layer < ZWLR_LAYER_SHELL_V1_LAYER_TOP)
-        g_pHyprOpenGL->markBlurDirtyForMonitor(g_pCompositor->getMonitorFromID(m_pLayerOwner.lock()->layer));
+    if (!m_pLayerOwner.expired() && m_pLayerOwner->layer < ZWLR_LAYER_SHELL_V1_LAYER_TOP)
+        g_pHyprOpenGL->markBlurDirtyForMonitor(g_pCompositor->getMonitorFromID(m_pLayerOwner->layer));
 }
 
 void CPopup::onCommit(bool ignoreSiblings) {
@@ -146,7 +146,7 @@ void CPopup::onCommit(bool ignoreSiblings) {
         return;
     }
 
-    if (!m_pWindowOwner.expired() && (!m_pWindowOwner.lock()->m_bIsMapped || !m_pWindowOwner.lock()->m_pWorkspace->m_bVisible)) {
+    if (!m_pWindowOwner.expired() && (!m_pWindowOwner->m_bIsMapped || !m_pWindowOwner->m_pWorkspace->m_bVisible)) {
         m_vLastSize = {m_pWLR->base->current.geometry.width, m_pWLR->base->current.geometry.height};
 
         static auto PLOGDAMAGE = CConfigValue<Hyprlang::INT>("debug:log_damage");
@@ -178,8 +178,8 @@ void CPopup::onCommit(bool ignoreSiblings) {
 
     m_bRequestedReposition = false;
 
-    if (!m_pLayerOwner.expired() && m_pLayerOwner.lock()->layer < ZWLR_LAYER_SHELL_V1_LAYER_TOP)
-        g_pHyprOpenGL->markBlurDirtyForMonitor(g_pCompositor->getMonitorFromID(m_pLayerOwner.lock()->layer));
+    if (!m_pLayerOwner.expired() && m_pLayerOwner->layer < ZWLR_LAYER_SHELL_V1_LAYER_TOP)
+        g_pHyprOpenGL->markBlurDirtyForMonitor(g_pCompositor->getMonitorFromID(m_pLayerOwner->layer));
 }
 
 void CPopup::onReposition() {
@@ -231,9 +231,9 @@ Vector2D CPopup::localToGlobal(const Vector2D& rel) {
 
 Vector2D CPopup::t1ParentCoords() {
     if (!m_pWindowOwner.expired())
-        return m_pWindowOwner.lock()->m_vRealPosition.value();
+        return m_pWindowOwner->m_vRealPosition.value();
     if (!m_pLayerOwner.expired())
-        return m_pLayerOwner.lock()->realPosition.value();
+        return m_pLayerOwner->realPosition.value();
 
     ASSERT(false);
     return {};
@@ -261,9 +261,9 @@ Vector2D CPopup::size() {
 
 void CPopup::sendScale() {
     if (!m_pWindowOwner.expired())
-        g_pCompositor->setPreferredScaleForSurface(m_sWLSurface.wlr(), m_pWindowOwner.lock()->m_pWLSurface.m_fLastScale);
+        g_pCompositor->setPreferredScaleForSurface(m_sWLSurface.wlr(), m_pWindowOwner->m_pWLSurface.m_fLastScale);
     else if (!m_pLayerOwner.expired())
-        g_pCompositor->setPreferredScaleForSurface(m_sWLSurface.wlr(), m_pLayerOwner.lock()->surface.m_fLastScale);
+        g_pCompositor->setPreferredScaleForSurface(m_sWLSurface.wlr(), m_pLayerOwner->surface.m_fLastScale);
     else
         UNREACHABLE();
 }

--- a/src/desktop/Subsurface.cpp
+++ b/src/desktop/Subsurface.cpp
@@ -74,7 +74,7 @@ void CSubsurface::initSignals() {
         hyprListener_unmapSubsurface.initCallback(&m_pSubsurface->surface->events.unmap, &onUnmapSubsurface, this, "CSubsurface");
     } else {
         if (!m_pWindowParent.expired())
-            hyprListener_newSubsurface.initCallback(&m_pWindowParent.lock()->m_pWLSurface.wlr()->events.new_subsurface, &::onNewSubsurface, this, "CSubsurface Head");
+            hyprListener_newSubsurface.initCallback(&m_pWindowParent->m_pWLSurface.wlr()->events.new_subsurface, &::onNewSubsurface, this, "CSubsurface Head");
         else if (m_pPopupParent)
             hyprListener_newSubsurface.initCallback(&m_pPopupParent->m_sWLSurface.wlr()->events.new_subsurface, &::onNewSubsurface, this, "CSubsurface Head");
         else
@@ -86,7 +86,7 @@ void CSubsurface::checkSiblingDamage() {
     if (!m_pParent)
         return; // ??????????
 
-    const double SCALE = m_pWindowParent.lock() && m_pWindowParent.lock()->m_bIsX11 ? 1.0 / m_pWindowParent.lock()->m_fX11SurfaceScaledBy : 1.0;
+    const double SCALE = m_pWindowParent.lock() && m_pWindowParent->m_bIsX11 ? 1.0 / m_pWindowParent->m_fX11SurfaceScaledBy : 1.0;
 
     for (auto& n : m_pParent->m_vChildren) {
         if (n.get() == this)
@@ -106,7 +106,7 @@ void CSubsurface::recheckDamageForSubsurfaces() {
 
 void CSubsurface::onCommit() {
     // no damaging if it's not visible
-    if (!m_pWindowParent.expired() && (!m_pWindowParent.lock()->m_bIsMapped || !m_pWindowParent.lock()->m_pWorkspace->m_bVisible)) {
+    if (!m_pWindowParent.expired() && (!m_pWindowParent->m_bIsMapped || !m_pWindowParent->m_pWorkspace->m_bVisible)) {
         m_vLastSize = Vector2D{m_sWLSurface.wlr()->current.width, m_sWLSurface.wlr()->current.height};
 
         static auto PLOGDAMAGE = CConfigValue<Hyprlang::INT>("debug:log_damage");
@@ -122,7 +122,7 @@ void CSubsurface::onCommit() {
     if (m_pPopupParent)
         m_pPopupParent->recheckTree();
     if (!m_pWindowParent.expired()) // I hate you firefox why are you doing this
-        m_pWindowParent.lock()->m_pPopupHead->recheckTree();
+        m_pWindowParent->m_pPopupHead->recheckTree();
 
     // I do not think this is correct, but it solves a lot of issues with some apps (e.g. firefox)
     checkSiblingDamage();
@@ -170,7 +170,7 @@ void CSubsurface::onMap() {
     g_pHyprRenderer->damageBox(&box);
 
     if (!m_pWindowParent.expired())
-        m_pWindowParent.lock()->updateSurfaceScaleTransformDetails();
+        m_pWindowParent->updateSurfaceScaleTransformDetails();
 }
 
 void CSubsurface::onUnmap() {
@@ -207,7 +207,7 @@ Vector2D CSubsurface::coordsGlobal() {
     Vector2D coords = coordsRelativeToParent();
 
     if (!m_pWindowParent.expired())
-        coords += m_pWindowParent.lock()->m_vRealPosition.value();
+        coords += m_pWindowParent->m_vRealPosition.value();
     else if (m_pPopupParent)
         coords += m_pPopupParent->coordsGlobal();
 

--- a/src/desktop/WLSurface.cpp
+++ b/src/desktop/WLSurface.cpp
@@ -175,9 +175,9 @@ std::optional<CBox> CWLSurface::getSurfaceBoxGlobal() {
         return {};
 
     if (!m_pWindowOwner.expired())
-        return m_pWindowOwner.lock()->getWindowMainSurfaceBox();
+        return m_pWindowOwner->getWindowMainSurfaceBox();
     if (!m_pLayerOwner.expired())
-        return m_pLayerOwner.lock()->geometry;
+        return m_pLayerOwner->geometry;
     if (m_pPopupOwner)
         return CBox{m_pPopupOwner->coordsGlobal(), m_pPopupOwner->size()};
     if (m_pSubsurfaceOwner)
@@ -186,7 +186,7 @@ std::optional<CBox> CWLSurface::getSurfaceBoxGlobal() {
     return {};
 }
 
-void CWLSurface::appendConstraint(std::weak_ptr<CPointerConstraint> constraint) {
+void CWLSurface::appendConstraint(WP<CPointerConstraint> constraint) {
     m_pConstraint = constraint;
 }
 
@@ -194,7 +194,7 @@ void CWLSurface::onCommit() {
     ;
 }
 
-std::shared_ptr<CPointerConstraint> CWLSurface::constraint() {
+SP<CPointerConstraint> CWLSurface::constraint() {
     return m_pConstraint.lock();
 }
 

--- a/src/desktop/WLSurface.hpp
+++ b/src/desktop/WLSurface.hpp
@@ -42,9 +42,9 @@ class CWLSurface {
     CSubsurface* getSubsurface();
 
     // desktop components misc utils
-    std::optional<CBox>                 getSurfaceBoxGlobal();
-    void                                appendConstraint(std::weak_ptr<CPointerConstraint> constraint);
-    std::shared_ptr<CPointerConstraint> constraint();
+    std::optional<CBox>    getSurfaceBoxGlobal();
+    void                   appendConstraint(WP<CPointerConstraint> constraint);
+    SP<CPointerConstraint> constraint();
 
     // allow stretching. Useful for plugins.
     bool m_bFillIgnoreSmall = false;
@@ -99,11 +99,11 @@ class CWLSurface {
     CSubsurface* m_pSubsurfaceOwner = nullptr;
 
     //
-    std::weak_ptr<CPointerConstraint> m_pConstraint;
+    WP<CPointerConstraint> m_pConstraint;
 
-    void                              destroy();
-    void                              init();
-    bool                              desktopComponent();
+    void                   destroy();
+    void                   init();
+    bool                   desktopComponent();
 
     DYNLISTENER(destroy);
     DYNLISTENER(commit);

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -8,7 +8,7 @@
 #include "../managers/TokenManager.hpp"
 
 PHLWINDOW CWindow::create() {
-    PHLWINDOW pWindow = std::shared_ptr<CWindow>(new CWindow);
+    PHLWINDOW pWindow = SP<CWindow>(new CWindow);
 
     pWindow->m_pSelf = pWindow;
 
@@ -894,7 +894,7 @@ PHLWINDOW CWindow::getGroupHead() {
 
 PHLWINDOW CWindow::getGroupTail() {
     PHLWINDOW curr = m_pSelf.lock();
-    while (!curr->m_sGroupData.pNextWindow.lock()->m_sGroupData.head)
+    while (!curr->m_sGroupData.pNextWindow->m_sGroupData.head)
         curr = curr->m_sGroupData.pNextWindow.lock();
     return curr;
 }

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -467,7 +467,7 @@ inline bool valid(PHLWINDOW w) {
 }
 
 inline bool valid(PHLWINDOWREF w) {
-    return w.lock().get();
+    return !w.expired();
 }
 
 inline bool validMapped(PHLWINDOW w) {
@@ -479,7 +479,7 @@ inline bool validMapped(PHLWINDOW w) {
 inline bool validMapped(PHLWINDOWREF w) {
     if (!valid(w))
         return false;
-    return w.lock()->m_bIsMapped;
+    return w->m_bIsMapped;
 }
 
 /**

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -3,7 +3,7 @@
 #include "../config/ConfigValue.hpp"
 
 PHLWORKSPACE CWorkspace::create(int id, int monitorID, std::string name, bool special) {
-    PHLWORKSPACE workspace = std::make_shared<CWorkspace>(id, monitorID, name, special);
+    PHLWORKSPACE workspace = makeShared<CWorkspace>(id, monitorID, name, special);
     workspace->init(workspace);
     return workspace;
 }
@@ -183,7 +183,7 @@ void CWorkspace::moveToMonitor(const int& id) {
 }
 
 PHLWINDOW CWorkspace::getLastFocusedWindow() {
-    if (!validMapped(m_pLastFocusedWindow) || m_pLastFocusedWindow.lock()->workspaceID() != m_iID)
+    if (!validMapped(m_pLastFocusedWindow) || m_pLastFocusedWindow->workspaceID() != m_iID)
         return nullptr;
 
     return m_pLastFocusedWindow.lock();

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -78,11 +78,11 @@ class CWorkspace {
     void        markInert();
 
   private:
-    void                              init(PHLWORKSPACE self);
+    void                 init(PHLWORKSPACE self);
 
-    std::shared_ptr<HOOK_CALLBACK_FN> m_pFocusedWindowHook;
-    bool                              m_bInert = true;
-    std::weak_ptr<CWorkspace>         m_pSelf;
+    SP<HOOK_CALLBACK_FN> m_pFocusedWindowHook;
+    bool                 m_bInert = true;
+    WP<CWorkspace>       m_pSelf;
 };
 
 inline bool valid(const PHLWORKSPACE& ref) {

--- a/src/devices/VirtualKeyboard.cpp
+++ b/src/devices/VirtualKeyboard.cpp
@@ -57,7 +57,7 @@ bool CVirtualKeyboard::isVirtual() {
 wlr_keyboard* CVirtualKeyboard::wlr() {
     if (keyboard.expired())
         return nullptr;
-    return keyboard.lock()->wlr();
+    return keyboard->wlr();
 }
 
 void CVirtualKeyboard::disconnectCallbacks() {
@@ -71,5 +71,5 @@ void CVirtualKeyboard::disconnectCallbacks() {
 wl_client* CVirtualKeyboard::getClient() {
     if (keyboard.expired())
         return nullptr;
-    return keyboard.lock()->client();
+    return keyboard->client();
 }

--- a/src/devices/VirtualPointer.cpp
+++ b/src/devices/VirtualPointer.cpp
@@ -168,5 +168,5 @@ void CVirtualPointer::disconnectCallbacks() {
 wlr_pointer* CVirtualPointer::wlr() {
     if (pointer.expired())
         return nullptr;
-    return pointer.lock()->wlr();
+    return pointer->wlr();
 }

--- a/src/events/Monitors.cpp
+++ b/src/events/Monitors.cpp
@@ -16,7 +16,7 @@
 //                                                           //
 // --------------------------------------------------------- //
 
-static void checkDefaultCursorWarp(std::shared_ptr<CMonitor>* PNEWMONITORWRAP, std::string monitorName) {
+static void checkDefaultCursorWarp(SP<CMonitor>* PNEWMONITORWRAP, std::string monitorName) {
     const auto  PNEWMONITOR = PNEWMONITORWRAP->get();
 
     static auto PCURSORMONITOR    = CConfigValue<std::string>("general:default_cursor_monitor");
@@ -61,9 +61,9 @@ void Events::listener_newOutput(wl_listener* listener, void* data) {
     }
 
     // add it to real
-    std::shared_ptr<CMonitor>* PNEWMONITORWRAP = nullptr;
+    SP<CMonitor>* PNEWMONITORWRAP = nullptr;
 
-    PNEWMONITORWRAP = &g_pCompositor->m_vRealMonitors.emplace_back(std::make_shared<CMonitor>());
+    PNEWMONITORWRAP = &g_pCompositor->m_vRealMonitors.emplace_back(makeShared<CMonitor>());
     if (std::string("HEADLESS-1") == OUTPUT->name)
         g_pCompositor->m_pUnsafeOutput = PNEWMONITORWRAP->get();
 
@@ -196,7 +196,7 @@ void Events::listener_monitorDestroy(void* owner, void* data) {
 
     Debug::log(LOG, "Removing monitor {} from realMonitors", pMonitor->szName);
 
-    std::erase_if(g_pCompositor->m_vRealMonitors, [&](std::shared_ptr<CMonitor>& el) { return el.get() == pMonitor; });
+    std::erase_if(g_pCompositor->m_vRealMonitors, [&](SP<CMonitor>& el) { return el.get() == pMonitor; });
 }
 
 void Events::listener_monitorStateRequest(void* owner, void* data) {

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -729,7 +729,7 @@ void Events::listener_unmapWindow(void* owner, void* data) {
 
     // swallowing
     if (valid(PWINDOW->m_pSwallowed)) {
-        PWINDOW->m_pSwallowed.lock()->setHidden(false);
+        PWINDOW->m_pSwallowed->setHidden(false);
         g_pLayoutManager->getCurrentLayout()->onWindowCreated(PWINDOW->m_pSwallowed.lock());
         PWINDOW->m_pSwallowed.reset();
     }
@@ -1024,7 +1024,7 @@ void Events::listener_activateX11(void* owner, void* data) {
 
         Debug::log(LOG, "Unmanaged X11 {} requests activate", PWINDOW);
 
-        if (g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow.lock()->getPID() != PWINDOW->getPID())
+        if (g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->getPID() != PWINDOW->getPID())
             return;
 
         if (!wlr_xwayland_or_surface_wants_focus(PWINDOW->m_uSurface.xwayland))

--- a/src/helpers/AnimatedVariable.hpp
+++ b/src/helpers/AnimatedVariable.hpp
@@ -146,7 +146,7 @@ class CBaseAnimatedVariable {
 
   protected:
     PHLWINDOWREF                          m_pWindow;
-    std::weak_ptr<CWorkspace>             m_pWorkspace;
+    PHLWORKSPACEREF                       m_pWorkspace;
     PHLLSREF                              m_pLayer;
 
     SAnimationPropertyConfig*             m_pConfig = nullptr;

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -123,7 +123,7 @@ void CMonitor::onConnect(bool noRule) {
         m_bRenderingInitPassed = true;
     }
 
-    std::shared_ptr<CMonitor>* thisWrapper = nullptr;
+    SP<CMonitor>* thisWrapper = nullptr;
 
     // find the wrap
     for (auto& m : g_pCompositor->m_vRealMonitors) {
@@ -337,7 +337,7 @@ void CMonitor::onDisconnect(bool destroy) {
 
         g_pHyprRenderer->m_pMostHzMonitor = pMonitorMostHz;
     }
-    std::erase_if(g_pCompositor->m_vMonitors, [&](std::shared_ptr<CMonitor>& el) { return el.get() == this; });
+    std::erase_if(g_pCompositor->m_vMonitors, [&](SP<CMonitor>& el) { return el.get() == this; });
 }
 
 void CMonitor::addDamage(const pixman_region32_t* rg) {
@@ -464,7 +464,7 @@ void CMonitor::setMirror(const std::string& mirrorOf) {
 
         // push to mvmonitors
 
-        std::shared_ptr<CMonitor>* thisWrapper = nullptr;
+        SP<CMonitor>* thisWrapper = nullptr;
 
         // find the wrap
         for (auto& m : g_pCompositor->m_vRealMonitors) {
@@ -578,7 +578,7 @@ void CMonitor::changeWorkspace(const PHLWORKSPACE& pWorkspace, bool internal, bo
         }
 
         if (!noFocus && !g_pCompositor->m_pLastMonitor->activeSpecialWorkspace &&
-            !(g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow.lock()->m_bPinned && g_pCompositor->m_pLastWindow.lock()->m_iMonitorID == ID)) {
+            !(g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->m_bPinned && g_pCompositor->m_pLastWindow->m_iMonitorID == ID)) {
             static auto PFOLLOWMOUSE = CConfigValue<Hyprlang::INT>("input:follow_mouse");
             auto        pWindow      = pWorkspace->getLastFocusedWindow();
 
@@ -636,7 +636,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
 
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(ID);
 
-        if (!(g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow.lock()->m_bPinned && g_pCompositor->m_pLastWindow.lock()->m_iMonitorID == ID)) {
+        if (!(g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->m_bPinned && g_pCompositor->m_pLastWindow->m_iMonitorID == ID)) {
             if (const auto PLAST = activeWorkspace->getLastFocusedWindow(); PLAST)
                 g_pCompositor->focusWindow(PLAST);
             else
@@ -704,7 +704,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
 
     g_pLayoutManager->getCurrentLayout()->recalculateMonitor(ID);
 
-    if (!(g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow.lock()->m_bPinned && g_pCompositor->m_pLastWindow.lock()->m_iMonitorID == ID)) {
+    if (!(g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->m_bPinned && g_pCompositor->m_pLastWindow->m_iMonitorID == ID)) {
         if (const auto PLAST = pWorkspace->getLastFocusedWindow(); PLAST)
             g_pCompositor->focusWindow(PLAST);
         else

--- a/src/helpers/memory/SharedPtr.hpp
+++ b/src/helpers/memory/SharedPtr.hpp
@@ -1,0 +1,300 @@
+#pragma once
+
+#include <typeinfo>
+#include <typeindex>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#define SP CSharedPointer
+
+/*
+    This is a custom impl of std::shared_ptr.
+    It is not thread-safe like the STL one,
+    but Hyprland is single-threaded anyways.
+
+    It differs a bit from how the STL one works,
+    namely in the fact that it keeps the T* inside the
+    control block, and that you can still make a CWeakPtr
+    or deref an existing one inside the destructor.
+*/
+namespace CSharedPointer_ {
+
+    class impl_base {
+      public:
+        virtual ~impl_base(){};
+
+        virtual void         inc() noexcept         = 0;
+        virtual void         dec() noexcept         = 0;
+        virtual void         incWeak() noexcept     = 0;
+        virtual void         decWeak() noexcept     = 0;
+        virtual unsigned int ref() noexcept         = 0;
+        virtual unsigned int wref() noexcept        = 0;
+        virtual void         destroy() noexcept     = 0;
+        virtual bool         destroying() noexcept  = 0;
+        virtual bool         dataNonNull() noexcept = 0;
+    };
+
+    template <typename T>
+    class impl : public impl_base {
+      public:
+        impl(T* data) noexcept : _data(data) {
+            ;
+        }
+
+        /* strong refcount */
+        unsigned int _ref = 0;
+        /* weak refcount */
+        unsigned int _weak = 0;
+
+        T*           _data = nullptr;
+
+        friend void  swap(impl*& a, impl*& b) {
+            impl* tmp = a;
+            a         = b;
+            b         = tmp;
+        }
+
+        /* if the destructor was called, 
+           creating shared_ptrs is no longer valid */
+        bool _destroying = false;
+
+        void _destroy() {
+            if (!_data)
+                return;
+
+            // first, we destroy the data, but keep the pointer.
+            // this way, weak pointers will still be able to
+            // reference and use, but no longer create shared ones.
+            _destroying = true;
+            __deleter(_data);
+            // now, we can reset the data and call it a day.
+            _data       = nullptr;
+            _destroying = false;
+        }
+
+        std::default_delete<T> __deleter{};
+
+        //
+        virtual void inc() noexcept {
+            _ref++;
+        }
+
+        virtual void dec() noexcept {
+            _ref--;
+        }
+
+        virtual void incWeak() noexcept {
+            _weak++;
+        }
+
+        virtual void decWeak() noexcept {
+            _weak--;
+        }
+
+        virtual unsigned int ref() noexcept {
+            return _ref;
+        }
+
+        virtual unsigned int wref() noexcept {
+            return _weak;
+        }
+
+        virtual void destroy() noexcept {
+            _destroy();
+        }
+
+        virtual bool destroying() noexcept {
+            return _destroying;
+        }
+
+        virtual bool dataNonNull() noexcept {
+            return _data;
+        }
+
+        virtual ~impl() {
+            destroy();
+        }
+    };
+};
+
+template <typename T>
+class CSharedPointer {
+  public:
+    template <typename X>
+    using validHierarchy = typename std::enable_if<std::is_assignable<T*, X*>::value>;
+
+    /* creates a new shared pointer managing a resource
+       avoid calling. Could duplicate ownership. Prefer makeShared */
+    explicit CSharedPointer(T* object) noexcept {
+        impl_ = new CSharedPointer_::impl<T>(object);
+        increment();
+    }
+
+    /* creates a shared pointer from a reference */
+    template <typename U, typename = validHierarchy<U>>
+    CSharedPointer(const CSharedPointer<U>& ref) noexcept {
+        impl_ = ref.impl_;
+        increment();
+    }
+
+    CSharedPointer(const CSharedPointer& ref) noexcept {
+        impl_ = ref.impl_;
+        increment();
+    }
+
+    template <typename U, typename = validHierarchy<U>>
+    CSharedPointer(CSharedPointer<U>&& ref) noexcept {
+        std::swap(impl_, ref.impl_);
+    }
+
+    CSharedPointer(CSharedPointer&& ref) noexcept {
+        std::swap(impl_, ref.impl_);
+    }
+
+    /* allows weakPointer to create from an impl */
+    CSharedPointer(CSharedPointer_::impl_base* implementation) noexcept {
+        impl_ = implementation;
+        increment();
+    }
+
+    /* creates an empty shared pointer with no implementation */
+    CSharedPointer() noexcept {
+        ; // empty
+    }
+
+    /* creates an empty shared pointer with no implementation */
+    CSharedPointer(std::nullptr_t) noexcept {
+        ; // empty
+    }
+
+    ~CSharedPointer() {
+        // we do not decrement here,
+        // because we want to preserve the pointer
+        // in case this is the last owner.
+        if (impl_ && impl_->ref() == 1)
+            destroyImpl();
+        else
+            decrement();
+    }
+
+    template <typename U, typename = validHierarchy<U>>
+    CSharedPointer<T>& operator=(const CSharedPointer<U>& rhs) {
+        if (impl_ == rhs.impl_)
+            return *this;
+
+        decrement();
+        impl_ = rhs.impl_;
+        increment();
+        return *this;
+    }
+
+    CSharedPointer& operator=(const CSharedPointer& rhs) {
+        if (impl_ == rhs.impl_)
+            return *this;
+
+        decrement();
+        impl_ = rhs.impl_;
+        increment();
+        return *this;
+    }
+
+    template <typename U, typename = validHierarchy<U>>
+    CSharedPointer<T>& operator=(CSharedPointer<U>&& rhs) {
+        std::swap(impl_, rhs.impl_);
+        return *this;
+    }
+
+    CSharedPointer& operator=(CSharedPointer&& rhs) {
+        std::swap(impl_, rhs.impl_);
+        return *this;
+    }
+
+    operator bool() const {
+        return impl_ && impl_->dataNonNull();
+    }
+
+    bool operator==(const CSharedPointer& rhs) const {
+        return impl_ == rhs.impl_;
+    }
+
+    bool operator()(const CSharedPointer& lhs, const CSharedPointer& rhs) const {
+        return (uintptr_t)lhs.impl_ < (uintptr_t)rhs.impl_;
+    }
+
+    bool operator<(const CSharedPointer& rhs) const {
+        return (uintptr_t)impl_ < (uintptr_t)rhs.impl_;
+    }
+
+    T* operator->() const {
+        return get();
+    }
+
+    T& operator*() const {
+        return *get();
+    }
+
+    void reset() {
+        decrement();
+        impl_ = nullptr;
+    }
+
+    T* get() const {
+        return (T*)(impl_ ? static_cast<CSharedPointer_::impl<T>*>(impl_)->_data : nullptr);
+    }
+
+    unsigned int strongRef() const {
+        return impl_ ? impl_->ref() : 0;
+    }
+
+    CSharedPointer_::impl_base* impl_ = nullptr;
+
+  private:
+    /* 
+       no-op if there is no impl_
+       may delete the stored object if ref == 0
+       may delete and reset impl_ if ref == 0 and weak == 0
+    */
+    void decrement() {
+        if (!impl_)
+            return;
+
+        impl_->dec();
+
+        // if ref == 0, we can destroy impl
+        if (impl_->ref() == 0)
+            destroyImpl();
+    }
+    /* no-op if there is no impl_ */
+    void increment() {
+        if (!impl_)
+            return;
+
+        impl_->inc();
+    }
+
+    /* destroy the pointed-to object 
+       if able, will also destroy impl */
+    void destroyImpl() {
+        // destroy the impl contents
+        impl_->destroy();
+
+        // check for weak refs, if zero, we can also delete impl_
+        if (impl_->wref() == 0) {
+            delete impl_;
+            impl_ = nullptr;
+        }
+    }
+};
+
+template <typename U, typename... Args>
+static CSharedPointer<U> makeShared(Args&&... args) {
+    return CSharedPointer<U>(new U(std::forward<Args>(args)...));
+}
+
+template <typename T>
+struct std::hash<CSharedPointer<T>> {
+    std::size_t operator()(const CSharedPointer<T>& p) const noexcept {
+        return std::hash<void*>{}(p->impl_);
+    }
+};

--- a/src/helpers/memory/WeakPtr.hpp
+++ b/src/helpers/memory/WeakPtr.hpp
@@ -1,0 +1,188 @@
+#pragma once
+
+#include "SharedPtr.hpp"
+
+#define WP CWeakPointer
+
+/*
+    This is a Hyprland implementation of std::weak_ptr.
+
+    See SharedPtr.hpp for more info on how it's different.
+*/
+
+template <typename T>
+class CWeakPointer {
+  public:
+    template <typename X>
+    using validHierarchy = typename std::enable_if<std::is_assignable<T*, X*>::value>;
+
+    /* create a weak ptr from a reference */
+    template <typename U, typename = validHierarchy<U>>
+    CWeakPointer(const CSharedPointer<U>& ref) noexcept {
+        if (!ref.impl_)
+            return;
+
+        impl_ = ref.impl_;
+        incrementWeak();
+    }
+
+    /* create a weak ptr from another weak ptr */
+    template <typename U, typename = validHierarchy<U>>
+    CWeakPointer(const CWeakPointer<U>& ref) noexcept {
+        if (!ref.impl_)
+            return;
+
+        impl_ = ref.impl_;
+        incrementWeak();
+    }
+
+    CWeakPointer(const CWeakPointer& ref) noexcept {
+        if (!ref.impl_)
+            return;
+
+        impl_ = ref.impl_;
+        incrementWeak();
+    }
+
+    template <typename U, typename = validHierarchy<U>>
+    CWeakPointer(CWeakPointer<U>&& ref) noexcept {
+        std::swap(impl_, ref.impl_);
+    }
+
+    CWeakPointer(CWeakPointer&& ref) noexcept {
+        std::swap(impl_, ref.impl_);
+    }
+
+    /* create a weak ptr from another weak ptr with assignment */
+    template <typename U, typename = validHierarchy<U>>
+    CWeakPointer<T>& operator=(const CWeakPointer<U>& rhs) {
+        if (impl_ == rhs.impl_)
+            return *this;
+
+        decrementWeak();
+        impl_ = rhs.impl_;
+        incrementWeak();
+        return *this;
+    }
+
+    CWeakPointer<T>& operator=(const CWeakPointer& rhs) {
+        if (impl_ == rhs.impl_)
+            return *this;
+
+        decrementWeak();
+        impl_ = rhs.impl_;
+        incrementWeak();
+        return *this;
+    }
+
+    /* create a weak ptr from a shared ptr with assignment */
+    template <typename U, typename = validHierarchy<U>>
+    CWeakPointer<T>& operator=(const CSharedPointer<U>& rhs) {
+        if ((uintptr_t)impl_ == (uintptr_t)rhs.impl_)
+            return *this;
+
+        decrementWeak();
+        impl_ = rhs.impl_;
+        incrementWeak();
+        return *this;
+    }
+
+    /* create an empty weak ptr */
+    CWeakPointer() {
+        ;
+    }
+
+    ~CWeakPointer() {
+        decrementWeak();
+    }
+
+    /* expired MAY return true even if the pointer is still stored.
+       the situation would be e.g. self-weak pointer in a destructor.
+       for pointer validity, use valid() */
+    bool expired() const {
+        return !impl_ || !impl_->dataNonNull() || impl_->destroying();
+    }
+
+    /* this means the pointed-to object is not yet deleted and can still be
+       referenced, but it might be in the process of being deleted. 
+       check !expired() if you want to check whether it's valid and
+       assignable to a SP. */
+    bool valid() const {
+        return impl_ && impl_->dataNonNull();
+    }
+
+    void reset() {
+        decrementWeak();
+        impl_ = nullptr;
+    }
+
+    CSharedPointer<T> lock() const {
+        if (!impl_ || !impl_->dataNonNull() || impl_->destroying())
+            return {};
+
+        return CSharedPointer<T>(impl_);
+    }
+
+    /* this returns valid() */
+    operator bool() const {
+        return valid();
+    }
+
+    bool operator==(const CWeakPointer<T>& rhs) const {
+        return impl_ == rhs.impl_;
+    }
+
+    bool operator==(const CSharedPointer<T>& rhs) const {
+        return impl_ == rhs.impl_;
+    }
+
+    bool operator()(const CWeakPointer& lhs, const CWeakPointer& rhs) const {
+        return (uintptr_t)lhs.impl_ < (uintptr_t)rhs.impl_;
+    }
+
+    bool operator<(const CWeakPointer& rhs) const {
+        return (uintptr_t)impl_ < (uintptr_t)rhs.impl_;
+    }
+
+    T* get() const {
+        return (T*)(impl_ ? static_cast<CSharedPointer_::impl<T>*>(impl_)->_data : nullptr);
+    }
+
+    T* operator->() const {
+        return get();
+    }
+
+    CSharedPointer_::impl_base* impl_ = nullptr;
+
+  private:
+    /* no-op if there is no impl_ */
+    void decrementWeak() {
+        if (!impl_)
+            return;
+
+        impl_->decWeak();
+
+        // we need to check for ->destroying,
+        // because otherwise we could destroy here
+        // and have a shared_ptr destroy the same thing
+        // later (in situations where we have a weak_ptr to self)
+        if (impl_->wref() == 0 && impl_->ref() == 0 && !impl_->destroying()) {
+            delete impl_;
+            impl_ = nullptr;
+        }
+    }
+    /* no-op if there is no impl_ */
+    void incrementWeak() {
+        if (!impl_)
+            return;
+
+        impl_->incWeak();
+    }
+};
+
+template <typename T>
+struct std::hash<CWeakPointer<T>> {
+    std::size_t operator()(const CWeakPointer<T>& p) const noexcept {
+        return std::hash<void*>{}(p->impl_);
+    }
+};

--- a/src/helpers/signal/Listener.hpp
+++ b/src/helpers/signal/Listener.hpp
@@ -3,6 +3,7 @@
 #include <any>
 #include <memory>
 #include <functional>
+#include "../../macros.hpp"
 
 class CSignal;
 
@@ -21,7 +22,7 @@ class CSignalListener {
     std::function<void(std::any)> m_fHandler;
 };
 
-typedef std::shared_ptr<CSignalListener> CHyprSignalListener;
+typedef SP<CSignalListener> CHyprSignalListener;
 
 class CStaticSignalListener {
   public:

--- a/src/helpers/signal/Signal.cpp
+++ b/src/helpers/signal/Signal.cpp
@@ -20,8 +20,8 @@ void CSignal::emit(std::any data) {
 }
 
 CHyprSignalListener CSignal::registerListener(std::function<void(std::any)> handler) {
-    CHyprSignalListener listener = std::make_shared<CSignalListener>(handler);
-    m_vListeners.emplace_back(std::weak_ptr<CSignalListener>(listener));
+    CHyprSignalListener listener = makeShared<CSignalListener>(handler);
+    m_vListeners.emplace_back(WP<CSignalListener>(listener));
     return listener;
 }
 

--- a/src/helpers/signal/Signal.hpp
+++ b/src/helpers/signal/Signal.hpp
@@ -19,6 +19,6 @@ class CSignal {
     void registerStaticListener(std::function<void(void*, std::any)> handler, void* owner);
 
   private:
-    std::vector<std::weak_ptr<CSignalListener>>         m_vListeners;
+    std::vector<WP<CSignalListener>>                    m_vListeners;
     std::vector<std::unique_ptr<CStaticSignalListener>> m_vStaticListeners;
 };

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -282,8 +282,8 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
             OPENINGON = getClosestNodeOnWorkspace(PNODE->workspaceID, MOUSECOORDS);
 
     } else if (*PUSEACTIVE) {
-        if (g_pCompositor->m_pLastWindow.lock() && !g_pCompositor->m_pLastWindow.lock()->m_bIsFloating && g_pCompositor->m_pLastWindow.lock() != pWindow &&
-            g_pCompositor->m_pLastWindow.lock()->m_pWorkspace == pWindow->m_pWorkspace && g_pCompositor->m_pLastWindow.lock()->m_bIsMapped) {
+        if (g_pCompositor->m_pLastWindow.lock() && !g_pCompositor->m_pLastWindow->m_bIsFloating && g_pCompositor->m_pLastWindow.lock() != pWindow &&
+            g_pCompositor->m_pLastWindow->m_pWorkspace == pWindow->m_pWorkspace && g_pCompositor->m_pLastWindow->m_bIsMapped) {
             OPENINGON = getNodeFromWindow(g_pCompositor->m_pLastWindow.lock());
         } else {
             OPENINGON = getNodeFromWindow(g_pCompositor->vectorToWindowUnified(MOUSECOORDS, RESERVED_EXTENTS | INPUT_EXTENTS));
@@ -334,19 +334,19 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
     }
 
     if (!m_vOverrideFocalPoint && g_pInputManager->m_bWasDraggingWindow) {
-        if (OPENINGON->pWindow.lock()->checkInputOnDecos(INPUT_TYPE_DRAG_END, MOUSECOORDS, pWindow))
+        if (OPENINGON->pWindow->checkInputOnDecos(INPUT_TYPE_DRAG_END, MOUSECOORDS, pWindow))
             return;
     }
 
     // if it's a group, add the window
-    if (OPENINGON->pWindow.lock()->m_sGroupData.pNextWindow.lock()                           // target is group
+    if (OPENINGON->pWindow->m_sGroupData.pNextWindow.lock()                                  // target is group
         && pWindow->canBeGroupedInto(OPENINGON->pWindow.lock()) && !m_vOverrideFocalPoint) { // we are not moving window
         m_lDwindleNodesData.remove(*PNODE);
 
         static auto USECURRPOS = CConfigValue<Hyprlang::INT>("group:insert_after_current");
-        (*USECURRPOS ? OPENINGON->pWindow.lock() : OPENINGON->pWindow.lock()->getGroupTail())->insertWindowToGroup(pWindow);
+        (*USECURRPOS ? OPENINGON->pWindow.lock() : OPENINGON->pWindow->getGroupTail())->insertWindowToGroup(pWindow);
 
-        OPENINGON->pWindow.lock()->setGroupCurrent(pWindow);
+        OPENINGON->pWindow->setGroupCurrent(pWindow);
         pWindow->applyGroupRules();
         pWindow->updateWindowDecos();
         recalculateWindow(pWindow);
@@ -984,15 +984,15 @@ void CHyprDwindleLayout::switchWindows(PHLWINDOW pWindow, PHLWINDOW pWindow2) {
         getMasterNodeOnWorkspace(PNODE2->workspaceID)->recalcSizePosRecursive();
 
     if (ACTIVE1) {
-        ACTIVE1->box                         = PNODE->box;
-        ACTIVE1->pWindow.lock()->m_vPosition = ACTIVE1->box.pos();
-        ACTIVE1->pWindow.lock()->m_vSize     = ACTIVE1->box.size();
+        ACTIVE1->box                  = PNODE->box;
+        ACTIVE1->pWindow->m_vPosition = ACTIVE1->box.pos();
+        ACTIVE1->pWindow->m_vSize     = ACTIVE1->box.size();
     }
 
     if (ACTIVE2) {
-        ACTIVE2->box                         = PNODE2->box;
-        ACTIVE2->pWindow.lock()->m_vPosition = ACTIVE2->box.pos();
-        ACTIVE2->pWindow.lock()->m_vSize     = ACTIVE2->box.size();
+        ACTIVE2->box                  = PNODE2->box;
+        ACTIVE2->pWindow->m_vPosition = ACTIVE2->box.pos();
+        ACTIVE2->pWindow->m_vSize     = ACTIVE2->box.size();
     }
 
     g_pHyprRenderer->damageWindow(pWindow);

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -45,11 +45,11 @@ void IHyprLayout::onWindowRemoved(PHLWINDOW pWindow) {
             pWindow->m_sGroupData.pNextWindow.reset();
 
             if (pWindow->m_sGroupData.head) {
-                std::swap(PWINDOWPREV->m_sGroupData.pNextWindow.lock()->m_sGroupData.head, pWindow->m_sGroupData.head);
-                std::swap(PWINDOWPREV->m_sGroupData.pNextWindow.lock()->m_sGroupData.locked, pWindow->m_sGroupData.locked);
+                std::swap(PWINDOWPREV->m_sGroupData.pNextWindow->m_sGroupData.head, pWindow->m_sGroupData.head);
+                std::swap(PWINDOWPREV->m_sGroupData.pNextWindow->m_sGroupData.locked, pWindow->m_sGroupData.locked);
             }
 
-            if (pWindow == m_pLastTiledWindow.lock())
+            if (pWindow == m_pLastTiledWindow)
                 m_pLastTiledWindow.reset();
 
             pWindow->setHidden(false);
@@ -68,7 +68,7 @@ void IHyprLayout::onWindowRemoved(PHLWINDOW pWindow) {
         onWindowRemovedTiling(pWindow);
     }
 
-    if (pWindow == m_pLastTiledWindow.lock())
+    if (pWindow == m_pLastTiledWindow)
         m_pLastTiledWindow.reset();
 }
 
@@ -508,7 +508,7 @@ void IHyprLayout::changeWindowFloatingMode(PHLWINDOW pWindow) {
         // fix pseudo leaving artifacts
         g_pHyprRenderer->damageMonitor(g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID));
 
-        if (pWindow == g_pCompositor->m_pLastWindow.lock())
+        if (pWindow == g_pCompositor->m_pLastWindow)
             m_pLastTiledWindow = pWindow;
     } else {
         onWindowRemovedTiling(pWindow);
@@ -533,7 +533,7 @@ void IHyprLayout::changeWindowFloatingMode(PHLWINDOW pWindow) {
 
         pWindow->updateSpecialRenderData();
 
-        if (pWindow == m_pLastTiledWindow.lock())
+        if (pWindow == m_pLastTiledWindow)
             m_pLastTiledWindow.reset();
     }
 
@@ -589,7 +589,7 @@ PHLWINDOW IHyprLayout::getNextWindowCandidate(PHLWINDOW pWindow) {
         }
 
         // let's try the last tiled window.
-        if (m_pLastTiledWindow.lock() && m_pLastTiledWindow.lock()->m_pWorkspace == pWindow->m_pWorkspace)
+        if (m_pLastTiledWindow.lock() && m_pLastTiledWindow->m_pWorkspace == pWindow->m_pWorkspace)
             return m_pLastTiledWindow.lock();
 
         // if we don't, let's try to find any window that is in the middle
@@ -625,14 +625,14 @@ PHLWINDOW IHyprLayout::getNextWindowCandidate(PHLWINDOW pWindow) {
 }
 
 bool IHyprLayout::isWindowReachable(PHLWINDOW pWindow) {
-    return pWindow && (!pWindow->isHidden() || pWindow->m_sGroupData.pNextWindow.lock());
+    return pWindow && (!pWindow->isHidden() || pWindow->m_sGroupData.pNextWindow);
 }
 
 void IHyprLayout::bringWindowToTop(PHLWINDOW pWindow) {
     if (pWindow == nullptr)
         return;
 
-    if (pWindow->isHidden() && pWindow->m_sGroupData.pNextWindow.lock()) {
+    if (pWindow->isHidden() && pWindow->m_sGroupData.pNextWindow) {
         // grouped, change the current to this window
         pWindow->setGroupCurrent(pWindow);
     }

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -91,27 +91,27 @@ void CHyprMasterLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dire
     static auto PMFACT             = CConfigValue<Hyprlang::FLOAT>("master:mfact");
     float       lastSplitPercent   = *PMFACT;
 
-    auto        OPENINGON = isWindowTiled(g_pCompositor->m_pLastWindow.lock()) && g_pCompositor->m_pLastWindow.lock()->m_pWorkspace == pWindow->m_pWorkspace ?
+    auto        OPENINGON = isWindowTiled(g_pCompositor->m_pLastWindow.lock()) && g_pCompositor->m_pLastWindow->m_pWorkspace == pWindow->m_pWorkspace ?
                getNodeFromWindow(g_pCompositor->m_pLastWindow.lock()) :
                getMasterNodeOnWorkspace(pWindow->workspaceID());
 
     const auto  MOUSECOORDS = g_pInputManager->getMouseCoordsInternal();
 
     if (g_pInputManager->m_bWasDraggingWindow && OPENINGON) {
-        if (OPENINGON->pWindow.lock()->checkInputOnDecos(INPUT_TYPE_DRAG_END, MOUSECOORDS, pWindow))
+        if (OPENINGON->pWindow->checkInputOnDecos(INPUT_TYPE_DRAG_END, MOUSECOORDS, pWindow))
             return;
     }
 
     // if it's a group, add the window
-    if (OPENINGON && OPENINGON != PNODE && OPENINGON->pWindow.lock()->m_sGroupData.pNextWindow.lock() // target is group
+    if (OPENINGON && OPENINGON != PNODE && OPENINGON->pWindow->m_sGroupData.pNextWindow.lock() // target is group
         && pWindow->canBeGroupedInto(OPENINGON->pWindow.lock())) {
 
         m_lMasterNodesData.remove(*PNODE);
 
         static auto USECURRPOS = CConfigValue<Hyprlang::INT>("group:insert_after_current");
-        (*USECURRPOS ? OPENINGON->pWindow.lock() : OPENINGON->pWindow.lock()->getGroupTail())->insertWindowToGroup(pWindow);
+        (*USECURRPOS ? OPENINGON->pWindow.lock() : OPENINGON->pWindow->getGroupTail())->insertWindowToGroup(pWindow);
 
-        OPENINGON->pWindow.lock()->setGroupCurrent(pWindow);
+        OPENINGON->pWindow->setGroupCurrent(pWindow);
         pWindow->applyGroupRules();
         pWindow->updateWindowDecos();
         recalculateWindow(pWindow);
@@ -135,17 +135,17 @@ void CHyprMasterLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dire
             for (auto it = m_lMasterNodesData.begin(); it != m_lMasterNodesData.end(); ++it) {
                 if (it->workspaceID != pWindow->workspaceID())
                     continue;
-                const CBox box = it->pWindow.lock()->getWindowIdealBoundingBoxIgnoreReserved();
+                const CBox box = it->pWindow->getWindowIdealBoundingBoxIgnoreReserved();
                 if (box.containsPoint(MOUSECOORDS)) {
                     switch (orientation) {
                         case ORIENTATION_LEFT:
                         case ORIENTATION_RIGHT:
-                            if (MOUSECOORDS.y > it->pWindow.lock()->middle().y)
+                            if (MOUSECOORDS.y > it->pWindow->middle().y)
                                 ++it;
                             break;
                         case ORIENTATION_TOP:
                         case ORIENTATION_BOTTOM:
-                            if (MOUSECOORDS.x > it->pWindow.lock()->middle().x)
+                            if (MOUSECOORDS.x > it->pWindow->middle().x)
                                 ++it;
                             break;
                         case ORIENTATION_CENTER: break;
@@ -163,19 +163,19 @@ void CHyprMasterLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dire
                     switch (orientation) {
                         case ORIENTATION_LEFT:
                         case ORIENTATION_CENTER:
-                            if (MOUSECOORDS.x < nd.pWindow.lock()->middle().x)
+                            if (MOUSECOORDS.x < nd.pWindow->middle().x)
                                 forceDropAsMaster = true;
                             break;
                         case ORIENTATION_RIGHT:
-                            if (MOUSECOORDS.x > nd.pWindow.lock()->middle().x)
+                            if (MOUSECOORDS.x > nd.pWindow->middle().x)
                                 forceDropAsMaster = true;
                             break;
                         case ORIENTATION_TOP:
-                            if (MOUSECOORDS.y < nd.pWindow.lock()->middle().y)
+                            if (MOUSECOORDS.y < nd.pWindow->middle().y)
                                 forceDropAsMaster = true;
                             break;
                         case ORIENTATION_BOTTOM:
-                            if (MOUSECOORDS.y > nd.pWindow.lock()->middle().y)
+                            if (MOUSECOORDS.y > nd.pWindow->middle().y)
                                 forceDropAsMaster = true;
                             break;
                         default: UNREACHABLE();

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -4,9 +4,9 @@
 #include <csignal>
 #include <utility>
 
-#define SP std::shared_ptr
+#include "helpers/memory/WeakPtr.hpp"
+
 #define UP std::unique_ptr
-#define WP std::weak_ptr
 
 #ifndef NDEBUG
 #ifdef HYPRLAND_DEBUG

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -7,7 +7,7 @@
 #include "../desktop/LayerSurface.hpp"
 #include "eventLoop/EventLoopManager.hpp"
 
-int wlTick(std::shared_ptr<CEventLoopTimer> self, void* data) {
+int wlTick(SP<CEventLoopTimer> self, void* data) {
     if (g_pAnimationManager)
         g_pAnimationManager->onTicked();
 
@@ -27,7 +27,7 @@ CAnimationManager::CAnimationManager() {
     std::vector<Vector2D> points = {Vector2D(0, 0.75f), Vector2D(0.15f, 1.f)};
     m_mBezierCurves["default"].setup(&points);
 
-    m_pAnimationTimer = std::make_unique<CEventLoopTimer>(std::chrono::microseconds(500), wlTick, nullptr);
+    m_pAnimationTimer = SP<CEventLoopTimer>(new CEventLoopTimer(std::chrono::microseconds(500), wlTick, nullptr));
     g_pEventLoopManager->addTimer(m_pAnimationTimer);
 }
 

--- a/src/managers/AnimationManager.hpp
+++ b/src/managers/AnimationManager.hpp
@@ -33,7 +33,7 @@ class CAnimationManager {
     std::vector<CBaseAnimatedVariable*>           m_vAnimatedVariables;
     std::vector<CBaseAnimatedVariable*>           m_vActiveAnimatedVariables;
 
-    std::shared_ptr<CEventLoopTimer>              m_pAnimationTimer;
+    SP<CEventLoopTimer>                           m_pAnimationTimer;
 
     float                                         m_fLastTickTime; // in ms
 

--- a/src/managers/HookSystemManager.cpp
+++ b/src/managers/HookSystemManager.cpp
@@ -7,16 +7,16 @@ CHookSystemManager::CHookSystemManager() {
 }
 
 // returns the pointer to the function
-std::shared_ptr<HOOK_CALLBACK_FN> CHookSystemManager::hookDynamic(const std::string& event, HOOK_CALLBACK_FN fn, HANDLE handle) {
-    std::shared_ptr<HOOK_CALLBACK_FN> hookFN = std::make_shared<HOOK_CALLBACK_FN>(fn);
+SP<HOOK_CALLBACK_FN> CHookSystemManager::hookDynamic(const std::string& event, HOOK_CALLBACK_FN fn, HANDLE handle) {
+    SP<HOOK_CALLBACK_FN> hookFN = makeShared<HOOK_CALLBACK_FN>(fn);
     m_mRegisteredHooks[event].emplace_back(SCallbackFNPtr{.fn = hookFN, .handle = handle});
     return hookFN;
 }
 
-void CHookSystemManager::unhook(std::shared_ptr<HOOK_CALLBACK_FN> fn) {
+void CHookSystemManager::unhook(SP<HOOK_CALLBACK_FN> fn) {
     for (auto& [k, v] : m_mRegisteredHooks) {
         std::erase_if(v, [&](const auto& other) {
-            std::shared_ptr<HOOK_CALLBACK_FN> fn_ = other.fn.lock();
+            SP<HOOK_CALLBACK_FN> fn_ = other.fn.lock();
 
             return fn_.get() == fn.get();
         });
@@ -37,7 +37,7 @@ void CHookSystemManager::emit(std::vector<SCallbackFNPtr>* const callbacks, SCal
         if (!cb.handle) {
             // we don't guard hl hooks
 
-            if (std::shared_ptr<HOOK_CALLBACK_FN> fn = cb.fn.lock())
+            if (SP<HOOK_CALLBACK_FN> fn = cb.fn.lock())
                 (*fn)(fn.get(), info, data);
             else
                 needsDeadCleanup = true;
@@ -51,7 +51,7 @@ void CHookSystemManager::emit(std::vector<SCallbackFNPtr>* const callbacks, SCal
 
         try {
             if (!setjmp(m_jbHookFaultJumpBuf)) {
-                if (std::shared_ptr<HOOK_CALLBACK_FN> fn = cb.fn.lock())
+                if (SP<HOOK_CALLBACK_FN> fn = cb.fn.lock())
                     (*fn)(fn.get(), info, data);
                 else
                     needsDeadCleanup = true;

--- a/src/managers/HookSystemManager.hpp
+++ b/src/managers/HookSystemManager.hpp
@@ -16,8 +16,8 @@
 typedef std::function<void(void*, SCallbackInfo& info, std::any data)> HOOK_CALLBACK_FN;
 
 struct SCallbackFNPtr {
-    std::weak_ptr<HOOK_CALLBACK_FN> fn;
-    HANDLE                          handle = nullptr;
+    WP<HOOK_CALLBACK_FN> fn;
+    HANDLE               handle = nullptr;
 };
 
 #define EMIT_HOOK_EVENT(name, param)                                                                                                                                               \
@@ -43,9 +43,9 @@ class CHookSystemManager {
     // returns the pointer to the function.
     // losing this pointer (letting it get destroyed)
     // will equal to unregistering the callback.
-    [[nodiscard("Losing this pointer instantly unregisters the callback")]] std::shared_ptr<HOOK_CALLBACK_FN> hookDynamic(const std::string& event, HOOK_CALLBACK_FN fn,
-                                                                                                                          HANDLE handle = nullptr);
-    void                                                                                                      unhook(std::shared_ptr<HOOK_CALLBACK_FN> fn);
+    [[nodiscard("Losing this pointer instantly unregisters the callback")]] SP<HOOK_CALLBACK_FN> hookDynamic(const std::string& event, HOOK_CALLBACK_FN fn,
+                                                                                                             HANDLE handle = nullptr);
+    void                                                                                         unhook(SP<HOOK_CALLBACK_FN> fn);
 
     void                         emit(std::vector<SCallbackFNPtr>* const callbacks, SCallbackInfo& info, std::any data = 0);
     std::vector<SCallbackFNPtr>* getVecForEvent(const std::string& event);

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -5,12 +5,12 @@
 #include "../protocols/SessionLock.hpp"
 
 SSessionLockSurface::SSessionLockSurface(SP<CSessionLockSurface> surface_) : surface(surface_) {
-    pWlrSurface = surface.lock()->surface();
+    pWlrSurface = surface->surface();
 
     listeners.map = surface_->events.map.registerListener([this](std::any data) {
         mapped = true;
 
-        g_pCompositor->focusSurface(surface.lock()->surface());
+        g_pCompositor->focusSurface(surface->surface());
 
         const auto PMONITOR = g_pCompositor->getMonitorFromID(iMonitorID);
 
@@ -124,7 +124,7 @@ bool CSessionLockManager::isSurfaceSessionLock(wlr_surface* pSurface) {
         return false;
 
     for (auto& sls : m_pSessionLock->vSessionLockSurfaces) {
-        if (sls->surface.lock()->surface() == pSurface)
+        if (sls->surface->surface() == pSurface)
             return true;
     }
 
@@ -144,7 +144,7 @@ void CSessionLockManager::removeSessionLockSurface(SSessionLockSurface* pSLS) {
         if (!sls->mapped)
             continue;
 
-        g_pCompositor->focusSurface(sls->surface.lock()->surface());
+        g_pCompositor->focusSurface(sls->surface->surface());
         break;
     }
 }

--- a/src/managers/TokenManager.cpp
+++ b/src/managers/TokenManager.cpp
@@ -26,11 +26,11 @@ std::string CTokenManager::getRandomUUID() {
 std::string CTokenManager::registerNewToken(std::any data, std::chrono::system_clock::duration expires) {
     std::string uuid = getRandomUUID();
 
-    m_mTokens[uuid] = std::make_shared<CUUIDToken>(uuid, data, expires);
+    m_mTokens[uuid] = makeShared<CUUIDToken>(uuid, data, expires);
     return uuid;
 }
 
-std::shared_ptr<CUUIDToken> CTokenManager::getToken(const std::string& uuid) {
+SP<CUUIDToken> CTokenManager::getToken(const std::string& uuid) {
 
     // cleanup expired tokens
     const auto NOW = std::chrono::system_clock::now();
@@ -42,7 +42,7 @@ std::shared_ptr<CUUIDToken> CTokenManager::getToken(const std::string& uuid) {
     return m_mTokens.at(uuid);
 }
 
-void CTokenManager::removeToken(std::shared_ptr<CUUIDToken> token) {
+void CTokenManager::removeToken(SP<CUUIDToken> token) {
     if (!token)
         return;
     m_mTokens.erase(token->uuid);

--- a/src/managers/TokenManager.hpp
+++ b/src/managers/TokenManager.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <memory>
 #include <chrono>
 #include <any>
 #include <unordered_map>
 #include <string>
+
+#include "../helpers/memory/SharedPtr.hpp"
 
 class CUUIDToken {
   public:
@@ -24,14 +25,14 @@ class CUUIDToken {
 
 class CTokenManager {
   public:
-    std::string                 registerNewToken(std::any data, std::chrono::system_clock::duration expires);
-    std::string                 getRandomUUID();
+    std::string    registerNewToken(std::any data, std::chrono::system_clock::duration expires);
+    std::string    getRandomUUID();
 
-    std::shared_ptr<CUUIDToken> getToken(const std::string& uuid);
-    void                        removeToken(std::shared_ptr<CUUIDToken> token);
+    SP<CUUIDToken> getToken(const std::string& uuid);
+    void           removeToken(SP<CUUIDToken> token);
 
   private:
-    std::unordered_map<std::string, std::shared_ptr<CUUIDToken>> m_mTokens;
+    std::unordered_map<std::string, SP<CUUIDToken>> m_mTokens;
 };
 
 inline std::unique_ptr<CTokenManager> g_pTokenManager;

--- a/src/managers/eventLoop/EventLoopManager.cpp
+++ b/src/managers/eventLoop/EventLoopManager.cpp
@@ -38,12 +38,12 @@ void CEventLoopManager::onTimerFire() {
     nudgeTimers();
 }
 
-void CEventLoopManager::addTimer(std::shared_ptr<CEventLoopTimer> timer) {
+void CEventLoopManager::addTimer(SP<CEventLoopTimer> timer) {
     m_sTimers.timers.push_back(timer);
     nudgeTimers();
 }
 
-void CEventLoopManager::removeTimer(std::shared_ptr<CEventLoopTimer> timer) {
+void CEventLoopManager::removeTimer(SP<CEventLoopTimer> timer) {
     std::erase_if(m_sTimers.timers, [timer](const auto& t) { return timer == t; });
     nudgeTimers();
 }

--- a/src/managers/eventLoop/EventLoopManager.hpp
+++ b/src/managers/eventLoop/EventLoopManager.hpp
@@ -2,7 +2,6 @@
 
 #include <condition_variable>
 #include <mutex>
-#include <memory>
 #include <thread>
 #include <wayland-server.h>
 
@@ -13,8 +12,8 @@ class CEventLoopManager {
     CEventLoopManager();
 
     void enterLoop(wl_display* display, wl_event_loop* wlEventLoop);
-    void addTimer(std::shared_ptr<CEventLoopTimer> timer);
-    void removeTimer(std::shared_ptr<CEventLoopTimer> timer);
+    void addTimer(SP<CEventLoopTimer> timer);
+    void removeTimer(SP<CEventLoopTimer> timer);
 
     void onTimerFire();
 
@@ -28,8 +27,8 @@ class CEventLoopManager {
     } m_sWayland;
 
     struct {
-        std::vector<std::shared_ptr<CEventLoopTimer>> timers;
-        int                                           timerfd = -1;
+        std::vector<SP<CEventLoopTimer>> timers;
+        int                              timerfd = -1;
     } m_sTimers;
 };
 

--- a/src/managers/eventLoop/EventLoopTimer.cpp
+++ b/src/managers/eventLoop/EventLoopTimer.cpp
@@ -2,10 +2,8 @@
 #include <limits>
 #include "EventLoopManager.hpp"
 
-CEventLoopTimer::CEventLoopTimer(std::optional<std::chrono::system_clock::duration> timeout, std::function<void(std::shared_ptr<CEventLoopTimer> self, void* data)> cb_,
-                                 void* data_) :
-    cb(cb_),
-    data(data_) {
+CEventLoopTimer::CEventLoopTimer(std::optional<std::chrono::system_clock::duration> timeout, std::function<void(SP<CEventLoopTimer> self, void* data)> cb_, void* data_) :
+    cb(cb_), data(data_) {
 
     if (!timeout.has_value())
         expires.reset();
@@ -40,7 +38,7 @@ bool CEventLoopTimer::cancelled() {
     return wasCancelled;
 }
 
-void CEventLoopTimer::call(std::shared_ptr<CEventLoopTimer> self) {
+void CEventLoopTimer::call(SP<CEventLoopTimer> self) {
     expires.reset();
     cb(self, data);
 }

--- a/src/managers/eventLoop/EventLoopTimer.hpp
+++ b/src/managers/eventLoop/EventLoopTimer.hpp
@@ -4,9 +4,11 @@
 #include <functional>
 #include <optional>
 
+#include "../../helpers/memory/SharedPtr.hpp"
+
 class CEventLoopTimer {
   public:
-    CEventLoopTimer(std::optional<std::chrono::system_clock::duration> timeout, std::function<void(std::shared_ptr<CEventLoopTimer> self, void* data)> cb_, void* data_);
+    CEventLoopTimer(std::optional<std::chrono::system_clock::duration> timeout, std::function<void(SP<CEventLoopTimer> self, void* data)> cb_, void* data_);
 
     // if not specified, disarms.
     // if specified, arms.
@@ -19,11 +21,11 @@ class CEventLoopTimer {
 
     bool  cancelled();
     // resets expires
-    void call(std::shared_ptr<CEventLoopTimer> self);
+    void call(SP<CEventLoopTimer> self);
 
   private:
-    std::function<void(std::shared_ptr<CEventLoopTimer> self, void* data)> cb;
-    void*                                                                  data = nullptr;
-    std::optional<std::chrono::system_clock::time_point>                   expires;
-    bool                                                                   wasCancelled = false;
+    std::function<void(SP<CEventLoopTimer> self, void* data)> cb;
+    void*                                                     data = nullptr;
+    std::optional<std::chrono::system_clock::time_point>      expires;
+    bool                                                      wasCancelled = false;
 };

--- a/src/managers/input/IdleInhibitor.cpp
+++ b/src/managers/input/IdleInhibitor.cpp
@@ -5,11 +5,11 @@
 
 void CInputManager::newIdleInhibitor(std::any inhibitor) {
     const auto PINHIBIT = m_vIdleInhibitors.emplace_back(std::make_unique<SIdleInhibitor>()).get();
-    PINHIBIT->inhibitor = std::any_cast<std::shared_ptr<CIdleInhibitor>>(inhibitor);
+    PINHIBIT->inhibitor = std::any_cast<SP<CIdleInhibitor>>(inhibitor);
 
     Debug::log(LOG, "New idle inhibitor registered for surface {:x}", (uintptr_t)PINHIBIT->inhibitor->surface);
 
-    PINHIBIT->inhibitor->listeners.destroy = PINHIBIT->inhibitor->resource.lock()->events.destroy.registerListener([this, PINHIBIT](std::any data) {
+    PINHIBIT->inhibitor->listeners.destroy = PINHIBIT->inhibitor->resource->events.destroy.registerListener([this, PINHIBIT](std::any data) {
         std::erase_if(m_vIdleInhibitors, [PINHIBIT](const auto& other) { return other.get() == PINHIBIT; });
         recheckIdleInhibitorStatus();
     });

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -250,7 +250,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
         if (!PSLS)
             return;
 
-        foundSurface = PSLS->surface.lock()->surface();
+        foundSurface = PSLS->surface->surface();
         surfacePos   = PMONITOR->vecPosition;
     }
 
@@ -408,7 +408,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
         m_pFoundSurfaceToFocus = foundSurface;
     }
 
-    if (currentlyDraggedWindow.lock() && pFoundWindow != currentlyDraggedWindow.lock()) {
+    if (currentlyDraggedWindow.lock() && pFoundWindow != currentlyDraggedWindow) {
         wlr_seat_pointer_notify_enter(g_pCompositor->m_sSeat.seat, foundSurface, surfaceLocal.x, surfaceLocal.y);
         wlr_seat_pointer_notify_motion(g_pCompositor->m_sSeat.seat, time, surfaceLocal.x, surfaceLocal.y);
         return;
@@ -434,8 +434,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
 
         if (FOLLOWMOUSE != 1 && !refocus) {
             if (pFoundWindow != g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow.lock() &&
-                ((pFoundWindow->m_bIsFloating && *PFLOATBEHAVIOR == 2) ||
-                 (g_pCompositor->m_pLastWindow.lock()->m_bIsFloating != pFoundWindow->m_bIsFloating && *PFLOATBEHAVIOR != 0))) {
+                ((pFoundWindow->m_bIsFloating && *PFLOATBEHAVIOR == 2) || (g_pCompositor->m_pLastWindow->m_bIsFloating != pFoundWindow->m_bIsFloating && *PFLOATBEHAVIOR != 0))) {
                 // enter if change floating style
                 if (FOLLOWMOUSE != 3 && allowKeyboardRefocus)
                     g_pCompositor->focusWindow(pFoundWindow, foundSurface);
@@ -446,12 +445,12 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
                 wlr_seat_pointer_notify_enter(g_pCompositor->m_sSeat.seat, foundSurface, surfaceLocal.x, surfaceLocal.y);
             }
 
-            if (pFoundWindow == g_pCompositor->m_pLastWindow.lock()) {
+            if (pFoundWindow == g_pCompositor->m_pLastWindow) {
                 m_pLastMouseSurface = foundSurface;
                 wlr_seat_pointer_notify_enter(g_pCompositor->m_sSeat.seat, foundSurface, surfaceLocal.x, surfaceLocal.y);
             }
 
-            if (FOLLOWMOUSE != 0 || pFoundWindow == g_pCompositor->m_pLastWindow.lock())
+            if (FOLLOWMOUSE != 0 || pFoundWindow == g_pCompositor->m_pLastWindow)
                 wlr_seat_pointer_notify_motion(g_pCompositor->m_sSeat.seat, time, surfaceLocal.x, surfaceLocal.y);
 
             m_bLastFocusOnLS = false;
@@ -671,7 +670,7 @@ void CInputManager::processMouseDownNormal(wlr_pointer_button_event* e) {
             }
 
             // if clicked on a floating window make it top
-            if (g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow.lock()->m_bIsFloating)
+            if (g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->m_bIsFloating)
                 g_pCompositor->changeWindowZOrder(g_pCompositor->m_pLastWindow.lock(), true);
 
             break;
@@ -1172,9 +1171,9 @@ void CInputManager::destroyKeyboard(SP<IKeyboard> pKeyboard) {
     std::erase_if(m_vKeyboards, [pKeyboard](const auto& other) { return other == pKeyboard; });
 
     if (m_vKeyboards.size() > 0) {
-        g_pCompositor->m_sSeat.keyboard                = m_vKeyboards.back();
-        g_pCompositor->m_sSeat.keyboard.lock()->active = true;
-        wlr_seat_set_keyboard(g_pCompositor->m_sSeat.seat, g_pCompositor->m_sSeat.keyboard.lock()->wlr());
+        g_pCompositor->m_sSeat.keyboard         = m_vKeyboards.back();
+        g_pCompositor->m_sSeat.keyboard->active = true;
+        wlr_seat_set_keyboard(g_pCompositor->m_sSeat.seat, g_pCompositor->m_sSeat.keyboard->wlr());
     } else {
         g_pCompositor->m_sSeat.keyboard.reset();
         wlr_seat_set_keyboard(g_pCompositor->m_sSeat.seat, nullptr);
@@ -1278,7 +1277,7 @@ bool CInputManager::shouldIgnoreVirtualKeyboard(SP<IKeyboard> pKeyboard) {
 
     CVirtualKeyboard* vk = (CVirtualKeyboard*)pKeyboard.get();
 
-    return !pKeyboard || (!m_sIMERelay.m_pIME.expired() && m_sIMERelay.m_pIME.lock()->grabClient() == vk->getClient());
+    return !pKeyboard || (!m_sIMERelay.m_pIME.expired() && m_sIMERelay.m_pIME->grabClient() == vk->getClient());
 }
 
 void CInputManager::refocus() {

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -144,7 +144,7 @@ class CInputManager {
     std::deque<PHLLSREF> m_dExclusiveLSes;
 
     // constraints
-    std::vector<std::weak_ptr<CPointerConstraint>> m_vConstraints;
+    std::vector<WP<CPointerConstraint>> m_vConstraints;
 
     //
     void              newTabletTool(wlr_input_device*);
@@ -241,9 +241,9 @@ class CInputManager {
 
     // idle inhibitors
     struct SIdleInhibitor {
-        std::shared_ptr<CIdleInhibitor> inhibitor;
-        bool                            nonDesktop = false;
-        CHyprSignalListener             surfaceDestroyListener;
+        SP<CIdleInhibitor>  inhibitor;
+        bool                nonDesktop = false;
+        CHyprSignalListener surfaceDestroyListener;
     };
     std::vector<std::unique_ptr<SIdleInhibitor>> m_vIdleInhibitors;
 

--- a/src/managers/input/InputMethodPopup.cpp
+++ b/src/managers/input/InputMethodPopup.cpp
@@ -73,7 +73,7 @@ void CInputPopup::damageSurface() {
 }
 
 void CInputPopup::updateBox() {
-    if (!popup.lock()->mapped)
+    if (!popup->mapped)
         return;
 
     const auto OWNER      = queryOwner();
@@ -114,7 +114,7 @@ void CInputPopup::updateBox() {
         popupOffset.x -= popupOverflow;
 
     CBox cursorBoxLocal({-popupOffset.x, -popupOffset.y}, cursorBoxParent.size());
-    popup.lock()->sendInputRectangle(cursorBoxLocal);
+    popup->sendInputRectangle(cursorBoxLocal);
 
     CBox popupBoxParent(cursorBoxParent.pos() + popupOffset, currentPopupSize);
     if (popupBoxParent != lastBoxLocal) {

--- a/src/managers/input/InputMethodRelay.cpp
+++ b/src/managers/input/InputMethodRelay.cpp
@@ -85,7 +85,7 @@ CTextInput* CInputMethodRelay::getFocusedTextInput() {
 }
 
 void CInputMethodRelay::onNewTextInput(std::any tiv3) {
-    m_vTextInputs.emplace_back(std::make_unique<CTextInput>(std::any_cast<std::weak_ptr<CTextInputV3>>(tiv3)));
+    m_vTextInputs.emplace_back(std::make_unique<CTextInput>(std::any_cast<WP<CTextInputV3>>(tiv3)));
 }
 
 void CInputMethodRelay::onNewTextInput(STextInputV1* pTIV1) {
@@ -106,7 +106,7 @@ void CInputMethodRelay::activateIME(CTextInput* pInput) {
     if (m_pIME.expired())
         return;
 
-    m_pIME.lock()->activate();
+    m_pIME->activate();
     commitIMEState(pInput);
 }
 
@@ -114,7 +114,7 @@ void CInputMethodRelay::deactivateIME(CTextInput* pInput) {
     if (m_pIME.expired())
         return;
 
-    m_pIME.lock()->deactivate();
+    m_pIME->deactivate();
     commitIMEState(pInput);
 }
 

--- a/src/managers/input/TextInput.cpp
+++ b/src/managers/input/TextInput.cpp
@@ -11,7 +11,7 @@ CTextInput::CTextInput(STextInputV1* ti) : pV1Input(ti) {
     initCallbacks();
 }
 
-CTextInput::CTextInput(std::weak_ptr<CTextInputV3> ti) : pV3Input(ti) {
+CTextInput::CTextInput(WP<CTextInputV3> ti) : pV3Input(ti) {
     initCallbacks();
 }
 
@@ -109,7 +109,7 @@ void CTextInput::onCommit() {
         return;
     }
 
-    if (!(isV3() ? pV3Input.lock()->current.enabled : pV1Input->active)) {
+    if (!(isV3() ? pV3Input->current.enabled : pV1Input->active)) {
         Debug::log(WARN, "Disabled TextInput commit?");
         return;
     }
@@ -180,7 +180,7 @@ void CTextInput::enter(wlr_surface* pSurface) {
     }
 
     if (isV3())
-        pV3Input.lock()->enter(pSurface);
+        pV3Input->enter(pSurface);
     else {
         zwp_text_input_v1_send_enter(pV1Input->resourceImpl, pSurface->resource);
         pV1Input->active = true;
@@ -200,7 +200,7 @@ void CTextInput::leave() {
     }
 
     if (isV3() && focusedSurface())
-        pV3Input.lock()->leave(focusedSurface());
+        pV3Input->leave(focusedSurface());
     else if (focusedSurface() && pV1Input) {
         zwp_text_input_v1_send_leave(pV1Input->resourceImpl);
         pV1Input->active = false;
@@ -216,7 +216,7 @@ wlr_surface* CTextInput::focusedSurface() {
 }
 
 wl_client* CTextInput::client() {
-    return isV3() ? pV3Input.lock()->client() : pV1Input->client;
+    return isV3() ? pV3Input->client() : pV1Input->client;
 }
 
 void CTextInput::commitStateToIME(SP<CInputMethodV2> ime) {
@@ -284,9 +284,9 @@ void CTextInput::updateIMEState(SP<CInputMethodV2> ime) {
 }
 
 bool CTextInput::hasCursorRectangle() {
-    return !isV3() || pV3Input.lock()->current.box.updated;
+    return !isV3() || pV3Input->current.box.updated;
 }
 
 CBox CTextInput::cursorBox() {
-    return CBox{isV3() ? pV3Input.lock()->current.box.cursorBox : pV1Input->cursorRectangle};
+    return CBox{isV3() ? pV3Input->current.box.cursorBox : pV1Input->cursorRectangle};
 }

--- a/src/managers/input/TextInput.hpp
+++ b/src/managers/input/TextInput.hpp
@@ -15,7 +15,7 @@ class CInputMethodV2;
 
 class CTextInput {
   public:
-    CTextInput(std::weak_ptr<CTextInputV3> ti);
+    CTextInput(WP<CTextInputV3> ti);
     CTextInput(STextInputV1* ti);
     ~CTextInput();
 
@@ -37,13 +37,13 @@ class CTextInput {
     wlr_surface* focusedSurface();
 
   private:
-    void                        setFocusedSurface(wlr_surface* pSurface);
-    void                        initCallbacks();
+    void             setFocusedSurface(wlr_surface* pSurface);
+    void             initCallbacks();
 
-    wlr_surface*                pFocusedSurface = nullptr;
-    int                         enterLocks      = 0;
-    std::weak_ptr<CTextInputV3> pV3Input;
-    STextInputV1*               pV1Input = nullptr;
+    wlr_surface*     pFocusedSurface = nullptr;
+    int              enterLocks      = 0;
+    WP<CTextInputV3> pV3Input;
+    STextInputV1*    pV1Input = nullptr;
 
     DYNLISTENER(textInputEnable);
     DYNLISTENER(textInputDisable);

--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -38,7 +38,7 @@ void CInputManager::onTouchDown(wlr_touch_down_event* e) {
     if (m_sActiveSwipe.pWorkspaceBegin) {
         return;
         // TODO: Don't swipe if you touched a floating window.
-    } else if (*PSWIPETOUCH && (m_pFoundLSToFocus.expired() || m_pFoundLSToFocus.lock()->layer <= ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM)) {
+    } else if (*PSWIPETOUCH && (m_pFoundLSToFocus.expired() || m_pFoundLSToFocus->layer <= ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM)) {
         const auto PWORKSPACE = PMONITOR->activeWorkspace;
         const bool VERTANIMS  = PWORKSPACE->m_vRenderOffset.getConfig()->pValues->internalStyle == "slidevert" ||
             PWORKSPACE->m_vRenderOffset.getConfig()->pValues->internalStyle.starts_with("slidefadevert");
@@ -67,16 +67,15 @@ void CInputManager::onTouchDown(wlr_touch_down_event* e) {
     Vector2D local;
 
     if (!m_sTouchData.touchFocusWindow.expired()) {
-        if (m_sTouchData.touchFocusWindow.lock()->m_bIsX11) {
-            local = (g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchFocusWindow.lock()->m_vRealPosition.goal()) *
-                m_sTouchData.touchFocusWindow.lock()->m_fX11SurfaceScaledBy;
-            m_sTouchData.touchSurfaceOrigin = m_sTouchData.touchFocusWindow.lock()->m_vRealPosition.goal();
+        if (m_sTouchData.touchFocusWindow->m_bIsX11) {
+            local = (g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchFocusWindow->m_vRealPosition.goal()) * m_sTouchData.touchFocusWindow->m_fX11SurfaceScaledBy;
+            m_sTouchData.touchSurfaceOrigin = m_sTouchData.touchFocusWindow->m_vRealPosition.goal();
         } else {
             g_pCompositor->vectorWindowToSurface(g_pInputManager->getMouseCoordsInternal(), m_sTouchData.touchFocusWindow.lock(), local);
             m_sTouchData.touchSurfaceOrigin = g_pInputManager->getMouseCoordsInternal() - local;
         }
     } else if (!m_sTouchData.touchFocusLS.expired()) {
-        local = g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchFocusLS.lock()->geometry.pos();
+        local = g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchFocusLS->geometry.pos();
 
         m_sTouchData.touchSurfaceOrigin = g_pInputManager->getMouseCoordsInternal() - local;
     } else {
@@ -130,18 +129,18 @@ void CInputManager::onTouchMove(wlr_touch_motion_event* e) {
         return;
     }
     if (validMapped(m_sTouchData.touchFocusWindow)) {
-        const auto PMONITOR = g_pCompositor->getMonitorFromID(m_sTouchData.touchFocusWindow.lock()->m_iMonitorID);
+        const auto PMONITOR = g_pCompositor->getMonitorFromID(m_sTouchData.touchFocusWindow->m_iMonitorID);
 
         wlr_cursor_warp(g_pCompositor->m_sWLRCursor, nullptr, PMONITOR->vecPosition.x + e->x * PMONITOR->vecSize.x, PMONITOR->vecPosition.y + e->y * PMONITOR->vecSize.y);
 
         auto local = g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchSurfaceOrigin;
-        if (m_sTouchData.touchFocusWindow.lock()->m_bIsX11)
-            local = local * m_sTouchData.touchFocusWindow.lock()->m_fX11SurfaceScaledBy;
+        if (m_sTouchData.touchFocusWindow->m_bIsX11)
+            local = local * m_sTouchData.touchFocusWindow->m_fX11SurfaceScaledBy;
 
         wlr_seat_touch_notify_motion(g_pCompositor->m_sSeat.seat, e->time_msec, e->touch_id, local.x, local.y);
         // wlr_seat_pointer_notify_motion(g_pCompositor->m_sSeat.seat, e->time_msec, local.x, local.y);
     } else if (!m_sTouchData.touchFocusLS.expired()) {
-        const auto PMONITOR = g_pCompositor->getMonitorFromID(m_sTouchData.touchFocusLS.lock()->monitorID);
+        const auto PMONITOR = g_pCompositor->getMonitorFromID(m_sTouchData.touchFocusLS->monitorID);
 
         wlr_cursor_warp(g_pCompositor->m_sWLRCursor, nullptr, PMONITOR->vecPosition.x + e->x * PMONITOR->vecSize.x, PMONITOR->vecPosition.y + e->y * PMONITOR->vecSize.y);
 

--- a/src/plugins/PluginAPI.cpp
+++ b/src/plugins/PluginAPI.cpp
@@ -13,18 +13,18 @@ APICALL const char* __hyprland_api_get_hash() {
     return GIT_COMMIT_HASH;
 }
 
-APICALL std::shared_ptr<HOOK_CALLBACK_FN> HyprlandAPI::registerCallbackDynamic(HANDLE handle, const std::string& event, HOOK_CALLBACK_FN fn) {
+APICALL SP<HOOK_CALLBACK_FN> HyprlandAPI::registerCallbackDynamic(HANDLE handle, const std::string& event, HOOK_CALLBACK_FN fn) {
     auto* const PLUGIN = g_pPluginSystem->getPluginByHandle(handle);
 
     if (!PLUGIN)
         return nullptr;
 
     auto PFN = g_pHookSystem->hookDynamic(event, fn, handle);
-    PLUGIN->registeredCallbacks.emplace_back(std::make_pair<>(event, std::weak_ptr<HOOK_CALLBACK_FN>(PFN)));
+    PLUGIN->registeredCallbacks.emplace_back(std::make_pair<>(event, WP<HOOK_CALLBACK_FN>(PFN)));
     return PFN;
 }
 
-APICALL bool HyprlandAPI::unregisterCallback(HANDLE handle, std::shared_ptr<HOOK_CALLBACK_FN> fn) {
+APICALL bool HyprlandAPI::unregisterCallback(HANDLE handle, SP<HOOK_CALLBACK_FN> fn) {
     auto* const PLUGIN = g_pPluginSystem->getPluginByHandle(handle);
 
     if (!PLUGIN)
@@ -355,7 +355,7 @@ APICALL SVersionInfo HyprlandAPI::getHyprlandVersion(HANDLE handle) {
     return {GIT_COMMIT_HASH, GIT_TAG, GIT_DIRTY != std::string(""), GIT_BRANCH, GIT_COMMIT_MESSAGE, GIT_COMMITS};
 }
 
-APICALL std::shared_ptr<SHyprCtlCommand> HyprlandAPI::registerHyprCtlCommand(HANDLE handle, SHyprCtlCommand cmd) {
+APICALL SP<SHyprCtlCommand> HyprlandAPI::registerHyprCtlCommand(HANDLE handle, SHyprCtlCommand cmd) {
     auto* const PLUGIN = g_pPluginSystem->getPluginByHandle(handle);
 
     if (!PLUGIN)
@@ -366,7 +366,7 @@ APICALL std::shared_ptr<SHyprCtlCommand> HyprlandAPI::registerHyprCtlCommand(HAN
     return PTR;
 }
 
-APICALL bool HyprlandAPI::unregisterHyprCtlCommand(HANDLE handle, std::shared_ptr<SHyprCtlCommand> cmd) {
+APICALL bool HyprlandAPI::unregisterHyprCtlCommand(HANDLE handle, SP<SHyprCtlCommand> cmd) {
 
     auto* const PLUGIN = g_pPluginSystem->getPluginByHandle(handle);
 

--- a/src/plugins/PluginAPI.hpp
+++ b/src/plugins/PluginAPI.hpp
@@ -23,6 +23,7 @@ Feel like the API is missing something you'd like to use in your plugin? Open an
 #include "../helpers/Color.hpp"
 #include "HookSystem.hpp"
 #include "../SharedDefs.hpp"
+#include "../defines.hpp"
 #include "../version.h"
 
 #include <any>
@@ -62,9 +63,6 @@ class CWindow;
 class IHyprWindowDecoration;
 struct SConfigValue;
 class CWindow;
-
-typedef std::shared_ptr<CWindow> PHLWINDOW;
-typedef std::weak_ptr<CWindow>   PHLWINDOWREF;
 
 /*
     These methods are for the plugin to implement
@@ -144,7 +142,7 @@ namespace HyprlandAPI {
 
         WARNING: Losing this pointer will unregister the callback!
     */
-    APICALL [[nodiscard]] std::shared_ptr<HOOK_CALLBACK_FN> registerCallbackDynamic(HANDLE handle, const std::string& event, HOOK_CALLBACK_FN fn);
+    APICALL [[nodiscard]] SP<HOOK_CALLBACK_FN> registerCallbackDynamic(HANDLE handle, const std::string& event, HOOK_CALLBACK_FN fn);
 
     /*
         Unregisters a callback. If the callback was dynamic, frees the memory.
@@ -153,7 +151,7 @@ namespace HyprlandAPI {
 
         Deprecated: just reset the pointer you received with registerCallbackDynamic
     */
-    APICALL [[deprecated]] bool unregisterCallback(HANDLE handle, std::shared_ptr<HOOK_CALLBACK_FN> fn);
+    APICALL [[deprecated]] bool unregisterCallback(HANDLE handle, SP<HOOK_CALLBACK_FN> fn);
 
     /*
         Calls a hyprctl command.
@@ -281,14 +279,14 @@ namespace HyprlandAPI {
 
         returns: Pointer. Nullptr on fail.
     */
-    APICALL std::shared_ptr<SHyprCtlCommand> registerHyprCtlCommand(HANDLE handle, SHyprCtlCommand cmd);
+    APICALL SP<SHyprCtlCommand> registerHyprCtlCommand(HANDLE handle, SHyprCtlCommand cmd);
 
     /*
         Unregisters a hyprctl command
 
         returns: true on success. False otherwise.
     */
-    APICALL bool unregisterHyprCtlCommand(HANDLE handle, std::shared_ptr<SHyprCtlCommand> cmd);
+    APICALL bool unregisterHyprCtlCommand(HANDLE handle, SP<SHyprCtlCommand> cmd);
 };
 
 /*

--- a/src/plugins/PluginSystem.hpp
+++ b/src/plugins/PluginSystem.hpp
@@ -8,22 +8,22 @@ class IHyprWindowDecoration;
 
 class CPlugin {
   public:
-    std::string                                                          name        = "";
-    std::string                                                          description = "";
-    std::string                                                          author      = "";
-    std::string                                                          version     = "";
+    std::string                                               name        = "";
+    std::string                                               description = "";
+    std::string                                               author      = "";
+    std::string                                               version     = "";
 
-    std::string                                                          path = "";
+    std::string                                               path = "";
 
-    bool                                                                 m_bLoadedWithConfig = false;
+    bool                                                      m_bLoadedWithConfig = false;
 
-    HANDLE                                                               m_pHandle = nullptr;
+    HANDLE                                                    m_pHandle = nullptr;
 
-    std::vector<IHyprLayout*>                                            registeredLayouts;
-    std::vector<IHyprWindowDecoration*>                                  registeredDecorations;
-    std::vector<std::pair<std::string, std::weak_ptr<HOOK_CALLBACK_FN>>> registeredCallbacks;
-    std::vector<std::string>                                             registeredDispatchers;
-    std::vector<std::shared_ptr<SHyprCtlCommand>>                        registeredHyprctlCommands;
+    std::vector<IHyprLayout*>                                 registeredLayouts;
+    std::vector<IHyprWindowDecoration*>                       registeredDecorations;
+    std::vector<std::pair<std::string, WP<HOOK_CALLBACK_FN>>> registeredCallbacks;
+    std::vector<std::string>                                  registeredDispatchers;
+    std::vector<SP<SHyprCtlCommand>>                          registeredHyprctlCommands;
 };
 
 class CPluginSystem {

--- a/src/protocols/AlphaModifier.cpp
+++ b/src/protocols/AlphaModifier.cpp
@@ -111,9 +111,8 @@ void CAlphaModifierProtocol::onGetSurface(CWpAlphaModifierV1* pMgr, uint32_t id,
         return;
     }
 
-    const auto RESOURCE =
-        m_mAlphaModifiers.emplace(surface, std::make_unique<CAlphaModifier>(std::make_shared<CWpAlphaModifierSurfaceV1>(pMgr->client(), pMgr->version(), id), surface))
-            .first->second.get();
+    const auto RESOURCE = m_mAlphaModifiers.emplace(surface, std::make_unique<CAlphaModifier>(makeShared<CWpAlphaModifierSurfaceV1>(pMgr->client(), pMgr->version(), id), surface))
+                              .first->second.get();
 
     if (!RESOURCE->good()) {
         pMgr->noMemory();

--- a/src/protocols/CursorShape.cpp
+++ b/src/protocols/CursorShape.cpp
@@ -74,7 +74,7 @@ void CCursorShapeProtocol::onGetTabletToolV2(CWpCursorShapeManagerV1* pMgr, uint
 
 void CCursorShapeProtocol::createCursorShapeDevice(CWpCursorShapeManagerV1* pMgr, uint32_t id, wl_resource* resource) {
     const auto CLIENT   = pMgr->client();
-    const auto RESOURCE = m_vDevices.emplace_back(std::make_shared<CWpCursorShapeDeviceV1>(CLIENT, pMgr->version(), id));
+    const auto RESOURCE = m_vDevices.emplace_back(makeShared<CWpCursorShapeDeviceV1>(CLIENT, pMgr->version(), id));
     RESOURCE->setOnDestroy([this](CWpCursorShapeDeviceV1* p) { this->onDeviceResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CWpCursorShapeDeviceV1* p) { this->onDeviceResourceDestroy(p->resource()); });

--- a/src/protocols/FocusGrab.cpp
+++ b/src/protocols/FocusGrab.cpp
@@ -315,7 +315,7 @@ void CFocusGrabProtocol::destroyGrab(CFocusGrab* grab) {
 }
 
 void CFocusGrabProtocol::onCreateGrab(CHyprlandFocusGrabManagerV1* pMgr, uint32_t id) {
-    m_vGrabs.push_back(std::make_unique<CFocusGrab>(std::make_shared<CHyprlandFocusGrabV1>(pMgr->client(), pMgr->version(), id)));
+    m_vGrabs.push_back(std::make_unique<CFocusGrab>(makeShared<CHyprlandFocusGrabV1>(pMgr->client(), pMgr->version(), id)));
     const auto RESOURCE = m_vGrabs.back().get();
 
     if (!RESOURCE->good()) {

--- a/src/protocols/ForeignToplevel.cpp
+++ b/src/protocols/ForeignToplevel.cpp
@@ -45,7 +45,7 @@ void CForeignToplevelList::onMap(PHLWINDOW pWindow) {
         return;
 
     const auto NEWHANDLE = PROTO::foreignToplevel->m_vHandles.emplace_back(
-        std::make_shared<CForeignToplevelHandle>(std::make_shared<CExtForeignToplevelHandleV1>(resource->client(), resource->version(), 0), pWindow));
+        makeShared<CForeignToplevelHandle>(makeShared<CExtForeignToplevelHandleV1>(resource->client(), resource->version(), 0), pWindow));
 
     if (!NEWHANDLE->good()) {
         LOGM(ERR, "Couldn't create a foreign handle");
@@ -68,7 +68,7 @@ void CForeignToplevelList::onMap(PHLWINDOW pWindow) {
 
 SP<CForeignToplevelHandle> CForeignToplevelList::handleForWindow(PHLWINDOW pWindow) {
     std::erase_if(handles, [](const auto& wp) { return wp.expired(); });
-    const auto IT = std::find_if(handles.begin(), handles.end(), [pWindow](const auto& h) { return h.lock()->window() == pWindow; });
+    const auto IT = std::find_if(handles.begin(), handles.end(), [pWindow](const auto& h) { return h->window() == pWindow; });
     return IT == handles.end() ? SP<CForeignToplevelHandle>{} : IT->lock();
 }
 
@@ -131,7 +131,7 @@ CForeignToplevelProtocol::CForeignToplevelProtocol(const wl_interface* iface, co
 }
 
 void CForeignToplevelProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CForeignToplevelList>(std::make_shared<CExtForeignToplevelListV1>(client, ver, id))).get();
+    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CForeignToplevelList>(makeShared<CExtForeignToplevelListV1>(client, ver, id))).get();
 
     if (!RESOURCE->good()) {
         LOGM(ERR, "Couldn't create a foreign list");

--- a/src/protocols/FractionalScale.cpp
+++ b/src/protocols/FractionalScale.cpp
@@ -36,8 +36,8 @@ void CFractionalScaleProtocol::onGetFractionalScale(CWpFractionalScaleManagerV1*
         return;
     }
 
-    const auto PADDON = m_mAddons.emplace(surface, std::make_unique<CFractionalScaleAddon>(std::make_shared<CWpFractionalScaleV1>(pMgr->client(), pMgr->version(), id), surface))
-                            .first->second.get();
+    const auto PADDON =
+        m_mAddons.emplace(surface, std::make_unique<CFractionalScaleAddon>(makeShared<CWpFractionalScaleV1>(pMgr->client(), pMgr->version(), id), surface)).first->second.get();
 
     if (!PADDON->good()) {
         m_mAddons.erase(surface);

--- a/src/protocols/GammaControl.cpp
+++ b/src/protocols/GammaControl.cpp
@@ -157,7 +157,7 @@ void CGammaControlProtocol::destroyGammaControl(CGammaControl* gamma) {
 
 void CGammaControlProtocol::onGetGammaControl(CZwlrGammaControlManagerV1* pMgr, uint32_t id, wl_resource* output) {
     const auto CLIENT   = pMgr->client();
-    const auto RESOURCE = m_vGammaControllers.emplace_back(std::make_unique<CGammaControl>(std::make_shared<CZwlrGammaControlV1>(CLIENT, pMgr->version(), id), output)).get();
+    const auto RESOURCE = m_vGammaControllers.emplace_back(std::make_unique<CGammaControl>(makeShared<CZwlrGammaControlV1>(CLIENT, pMgr->version(), id), output)).get();
 
     if (!RESOURCE->good()) {
         pMgr->noMemory();

--- a/src/protocols/IdleInhibit.cpp
+++ b/src/protocols/IdleInhibit.cpp
@@ -48,8 +48,8 @@ void CIdleInhibitProtocol::removeInhibitor(CIdleInhibitorResource* resource) {
 
 void CIdleInhibitProtocol::onCreateInhibitor(CZwpIdleInhibitManagerV1* pMgr, uint32_t id, wlr_surface* surface) {
     const auto CLIENT   = pMgr->client();
-    const auto RESOURCE = m_vInhibitors.emplace_back(std::make_shared<CIdleInhibitorResource>(std::make_shared<CZwpIdleInhibitorV1>(CLIENT, pMgr->version(), id), surface));
+    const auto RESOURCE = m_vInhibitors.emplace_back(makeShared<CIdleInhibitorResource>(makeShared<CZwpIdleInhibitorV1>(CLIENT, pMgr->version(), id), surface));
 
-    RESOURCE->inhibitor = std::make_shared<CIdleInhibitor>(RESOURCE, surface);
+    RESOURCE->inhibitor = makeShared<CIdleInhibitor>(RESOURCE, surface);
     events.newIdleInhibitor.emit(RESOURCE->inhibitor);
 }

--- a/src/protocols/IdleNotify.cpp
+++ b/src/protocols/IdleNotify.cpp
@@ -3,7 +3,7 @@
 
 #define LOGM PROTO::idle->protoLog
 
-static int onTimer(std::shared_ptr<CEventLoopTimer> self, void* data) {
+static int onTimer(SP<CEventLoopTimer> self, void* data) {
 
     const auto NOTIF = (CExtIdleNotification*)data;
 
@@ -19,7 +19,7 @@ CExtIdleNotification::CExtIdleNotification(SP<CExtIdleNotificationV1> resource_,
     resource->setDestroy([this](CExtIdleNotificationV1* r) { PROTO::idle->destroyNotification(this); });
     resource->setOnDestroy([this](CExtIdleNotificationV1* r) { PROTO::idle->destroyNotification(this); });
 
-    timer = std::make_shared<CEventLoopTimer>(std::nullopt, onTimer, this);
+    timer = makeShared<CEventLoopTimer>(std::nullopt, onTimer, this);
     g_pEventLoopManager->addTimer(timer);
 
     updateTimer();
@@ -77,9 +77,8 @@ void CIdleNotifyProtocol::destroyNotification(CExtIdleNotification* notif) {
 }
 
 void CIdleNotifyProtocol::onGetNotification(CExtIdleNotifierV1* pMgr, uint32_t id, uint32_t timeout, wl_resource* seat) {
-    const auto CLIENT = pMgr->client();
-    const auto RESOURCE =
-        m_vNotifications.emplace_back(std::make_unique<CExtIdleNotification>(std::make_shared<CExtIdleNotificationV1>(CLIENT, pMgr->version(), id), timeout)).get();
+    const auto CLIENT   = pMgr->client();
+    const auto RESOURCE = m_vNotifications.emplace_back(makeShared<CExtIdleNotification>(makeShared<CExtIdleNotificationV1>(CLIENT, pMgr->version(), id), timeout)).get();
 
     if (!RESOURCE->good()) {
         pMgr->noMemory();

--- a/src/protocols/IdleNotify.hpp
+++ b/src/protocols/IdleNotify.hpp
@@ -18,13 +18,13 @@ class CExtIdleNotification {
     void onActivity();
 
   private:
-    SP<CExtIdleNotificationV1>       resource;
-    uint32_t                         timeoutMs = 0;
-    std::shared_ptr<CEventLoopTimer> timer;
+    SP<CExtIdleNotificationV1> resource;
+    uint32_t                   timeoutMs = 0;
+    SP<CEventLoopTimer>        timer;
 
-    bool                             idled = false;
+    bool                       idled = false;
 
-    void                             updateTimer();
+    void                       updateTimer();
 };
 
 class CIdleNotifyProtocol : public IWaylandProtocol {

--- a/src/protocols/InputMethodV2.cpp
+++ b/src/protocols/InputMethodV2.cpp
@@ -23,7 +23,7 @@ CInputMethodKeyboardGrabV2::CInputMethodKeyboardGrabV2(SP<CZwpInputMethodKeyboar
 
 CInputMethodKeyboardGrabV2::~CInputMethodKeyboardGrabV2() {
     if (!owner.expired())
-        std::erase_if(owner.lock()->grabs, [](const auto& g) { return g.expired(); });
+        std::erase_if(owner->grabs, [](const auto& g) { return g.expired(); });
 }
 
 void CInputMethodKeyboardGrabV2::sendKeyboardData(wlr_keyboard* keyboard) {
@@ -131,7 +131,7 @@ CInputMethodPopupV2::CInputMethodPopupV2(SP<CZwpInputPopupSurfaceV2> resource_, 
 
 CInputMethodPopupV2::~CInputMethodPopupV2() {
     if (!owner.expired())
-        std::erase_if(owner.lock()->popups, [](const auto& p) { return p.expired(); });
+        std::erase_if(owner->popups, [](const auto& p) { return p.expired(); });
 
     events.destroy.emit();
 }
@@ -193,7 +193,7 @@ CInputMethodV2::CInputMethodV2(SP<CZwpInputMethodV2> resource_) : resource(resou
 
     resource->setGetInputPopupSurface([this](CZwpInputMethodV2* r, uint32_t id, wl_resource* surface) {
         const auto RESOURCE = PROTO::ime->m_vPopups.emplace_back(
-            std::make_shared<CInputMethodPopupV2>(std::make_shared<CZwpInputPopupSurfaceV2>(r->client(), r->version(), id), self.lock(), wlr_surface_from_resource(surface)));
+            makeShared<CInputMethodPopupV2>(makeShared<CZwpInputPopupSurfaceV2>(r->client(), r->version(), id), self.lock(), wlr_surface_from_resource(surface)));
 
         if (!RESOURCE->good()) {
             r->noMemory();
@@ -209,8 +209,8 @@ CInputMethodV2::CInputMethodV2(SP<CZwpInputMethodV2> resource_) : resource(resou
     });
 
     resource->setGrabKeyboard([this](CZwpInputMethodV2* r, uint32_t id) {
-        const auto RESOURCE = PROTO::ime->m_vGrabs.emplace_back(
-            std::make_shared<CInputMethodKeyboardGrabV2>(std::make_shared<CZwpInputMethodKeyboardGrabV2>(r->client(), r->version(), id), self.lock()));
+        const auto RESOURCE =
+            PROTO::ime->m_vGrabs.emplace_back(makeShared<CInputMethodKeyboardGrabV2>(makeShared<CZwpInputMethodKeyboardGrabV2>(r->client(), r->version(), id), self.lock()));
 
         if (!RESOURCE->good()) {
             r->noMemory();
@@ -364,7 +364,7 @@ void CInputMethodV2Protocol::destroyResource(CInputMethodV2* ime) {
 }
 
 void CInputMethodV2Protocol::onGetIME(CZwpInputMethodManagerV2* mgr, wl_resource* seat, uint32_t id) {
-    const auto RESOURCE = m_vIMEs.emplace_back(std::make_shared<CInputMethodV2>(std::make_shared<CZwpInputMethodV2>(mgr->client(), mgr->version(), id)));
+    const auto RESOURCE = m_vIMEs.emplace_back(makeShared<CInputMethodV2>(makeShared<CZwpInputMethodV2>(mgr->client(), mgr->version(), id)));
 
     if (!RESOURCE->good()) {
         mgr->noMemory();

--- a/src/protocols/OutputManagement.cpp
+++ b/src/protocols/OutputManagement.cpp
@@ -18,7 +18,7 @@ COutputManager::COutputManager(SP<CZwlrOutputManagerV1> resource_) : resource(re
         LOGM(LOG, "Creating new configuration");
 
         const auto RESOURCE = PROTO::outputManagement->m_vConfigurations.emplace_back(
-            std::make_shared<COutputConfiguration>(std::make_shared<CZwlrOutputConfigurationV1>(resource->client(), resource->version(), id), self.lock()));
+            makeShared<COutputConfiguration>(makeShared<CZwlrOutputConfigurationV1>(resource->client(), resource->version(), id), self.lock()));
 
         if (!RESOURCE->good()) {
             resource->noMemory();
@@ -49,7 +49,7 @@ void COutputManager::makeAndSendNewHead(CMonitor* pMonitor) {
         return;
 
     const auto RESOURCE =
-        PROTO::outputManagement->m_vHeads.emplace_back(std::make_shared<COutputHead>(std::make_shared<CZwlrOutputHeadV1>(resource->client(), resource->version(), 0), pMonitor));
+        PROTO::outputManagement->m_vHeads.emplace_back(makeShared<COutputHead>(makeShared<CZwlrOutputHeadV1>(resource->client(), resource->version(), 0), pMonitor));
 
     if (!RESOURCE->good()) {
         resource->noMemory();
@@ -205,8 +205,7 @@ void COutputHead::updateMode() {
 }
 
 void COutputHead::makeAndSendNewMode(wlr_output_mode* mode) {
-    const auto RESOURCE =
-        PROTO::outputManagement->m_vModes.emplace_back(std::make_shared<COutputMode>(std::make_shared<CZwlrOutputModeV1>(resource->client(), resource->version(), 0), mode));
+    const auto RESOURCE = PROTO::outputManagement->m_vModes.emplace_back(makeShared<COutputMode>(makeShared<CZwlrOutputModeV1>(resource->client(), resource->version(), 0), mode));
 
     if (!RESOURCE->good()) {
         resource->noMemory();
@@ -275,7 +274,7 @@ COutputConfiguration::COutputConfiguration(SP<CZwlrOutputConfigurationV1> resour
         }
 
         const auto RESOURCE = PROTO::outputManagement->m_vConfigurationHeads.emplace_back(
-            std::make_shared<COutputConfigurationHead>(std::make_shared<CZwlrOutputConfigurationHeadV1>(resource->client(), resource->version(), id), PMONITOR));
+            makeShared<COutputConfigurationHead>(makeShared<CZwlrOutputConfigurationHeadV1>(resource->client(), resource->version(), id), PMONITOR));
 
         if (!RESOURCE->good()) {
             resource->noMemory();
@@ -326,7 +325,7 @@ COutputConfiguration::COutputConfiguration(SP<CZwlrOutputConfigurationV1> resour
         else
             resource->sendFailed();
 
-        owner.lock()->sendDone();
+        owner->sendDone();
     });
 }
 
@@ -359,8 +358,8 @@ bool COutputConfiguration::applyTestConfiguration(bool test) {
         newRule.name         = PMONITOR->szName;
 
         if (head->committedProperties & COutputConfigurationHead::eCommittedProperties::OUTPUT_HEAD_COMMITTED_MODE) {
-            newRule.resolution  = {head->state.mode.lock()->getMode()->width, head->state.mode.lock()->getMode()->height};
-            newRule.refreshRate = head->state.mode.lock()->getMode()->refresh / 1000.F;
+            newRule.resolution  = {head->state.mode->getMode()->width, head->state.mode->getMode()->height};
+            newRule.refreshRate = head->state.mode->getMode()->refresh / 1000.F;
         } else if (head->committedProperties & COutputConfigurationHead::eCommittedProperties::OUTPUT_HEAD_COMMITTED_CUSTOM_MODE) {
             newRule.resolution  = head->state.customMode.size;
             newRule.refreshRate = head->state.customMode.refresh / 1000.F;
@@ -539,7 +538,7 @@ COutputManagementProtocol::COutputManagementProtocol(const wl_interface* iface, 
 }
 
 void COutputManagementProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_shared<COutputManager>(std::make_shared<CZwlrOutputManagerV1>(client, ver, id)));
+    const auto RESOURCE = m_vManagers.emplace_back(makeShared<COutputManager>(makeShared<CZwlrOutputManagerV1>(client, ver, id)));
 
     if (!RESOURCE->good()) {
         wl_client_post_no_memory(client);

--- a/src/protocols/OutputPower.cpp
+++ b/src/protocols/OutputPower.cpp
@@ -69,7 +69,7 @@ void COutputPowerProtocol::onGetOutputPower(CZwlrOutputPowerManagerV1* pMgr, uin
     }
 
     const auto CLIENT   = pMgr->client();
-    const auto RESOURCE = m_vOutputPowers.emplace_back(std::make_unique<COutputPower>(std::make_shared<CZwlrOutputPowerV1>(CLIENT, pMgr->version(), id), PMONITOR)).get();
+    const auto RESOURCE = m_vOutputPowers.emplace_back(std::make_unique<COutputPower>(makeShared<CZwlrOutputPowerV1>(CLIENT, pMgr->version(), id), PMONITOR)).get();
 
     if (!RESOURCE->good()) {
         pMgr->noMemory();

--- a/src/protocols/PointerConstraints.cpp
+++ b/src/protocols/PointerConstraints.cpp
@@ -246,7 +246,7 @@ void CPointerConstraintsProtocol::onLockPointer(CZwpPointerConstraintsV1* pMgr, 
                                                 zwpPointerConstraintsV1Lifetime lifetime) {
     const auto CLIENT   = pMgr->client();
     const auto RESOURCE = m_vConstraints.emplace_back(
-        std::make_shared<CPointerConstraint>(std::make_shared<CZwpLockedPointerV1>(CLIENT, pMgr->version(), id), wlr_surface_from_resource(surface), region, lifetime));
+        makeShared<CPointerConstraint>(makeShared<CZwpLockedPointerV1>(CLIENT, pMgr->version(), id), wlr_surface_from_resource(surface), region, lifetime));
 
     onNewConstraint(RESOURCE, pMgr);
 }
@@ -255,7 +255,7 @@ void CPointerConstraintsProtocol::onConfinePointer(CZwpPointerConstraintsV1* pMg
                                                    zwpPointerConstraintsV1Lifetime lifetime) {
     const auto CLIENT   = pMgr->client();
     const auto RESOURCE = m_vConstraints.emplace_back(
-        std::make_shared<CPointerConstraint>(std::make_shared<CZwpConfinedPointerV1>(CLIENT, pMgr->version(), id), wlr_surface_from_resource(surface), region, lifetime));
+        makeShared<CPointerConstraint>(makeShared<CZwpConfinedPointerV1>(CLIENT, pMgr->version(), id), wlr_surface_from_resource(surface), region, lifetime));
 
     onNewConstraint(RESOURCE, pMgr);
 }

--- a/src/protocols/PointerGestures.cpp
+++ b/src/protocols/PointerGestures.cpp
@@ -71,7 +71,7 @@ void CPointerGesturesProtocol::onGestureDestroy(CPointerGestureHold* gesture) {
 
 void CPointerGesturesProtocol::onGetPinchGesture(CZwpPointerGesturesV1* pMgr, uint32_t id, wl_resource* pointer) {
     const auto CLIENT   = pMgr->client();
-    const auto RESOURCE = m_vPinches.emplace_back(std::make_unique<CPointerGesturePinch>(std::make_shared<CZwpPointerGesturePinchV1>(CLIENT, pMgr->version(), id))).get();
+    const auto RESOURCE = m_vPinches.emplace_back(std::make_unique<CPointerGesturePinch>(makeShared<CZwpPointerGesturePinchV1>(CLIENT, pMgr->version(), id))).get();
 
     if (!RESOURCE->good()) {
         pMgr->noMemory();
@@ -82,7 +82,7 @@ void CPointerGesturesProtocol::onGetPinchGesture(CZwpPointerGesturesV1* pMgr, ui
 
 void CPointerGesturesProtocol::onGetSwipeGesture(CZwpPointerGesturesV1* pMgr, uint32_t id, wl_resource* pointer) {
     const auto CLIENT   = pMgr->client();
-    const auto RESOURCE = m_vSwipes.emplace_back(std::make_unique<CPointerGestureSwipe>(std::make_shared<CZwpPointerGestureSwipeV1>(CLIENT, pMgr->version(), id))).get();
+    const auto RESOURCE = m_vSwipes.emplace_back(std::make_unique<CPointerGestureSwipe>(makeShared<CZwpPointerGestureSwipeV1>(CLIENT, pMgr->version(), id))).get();
 
     if (!RESOURCE->good()) {
         pMgr->noMemory();
@@ -93,7 +93,7 @@ void CPointerGesturesProtocol::onGetSwipeGesture(CZwpPointerGesturesV1* pMgr, ui
 
 void CPointerGesturesProtocol::onGetHoldGesture(CZwpPointerGesturesV1* pMgr, uint32_t id, wl_resource* pointer) {
     const auto CLIENT   = pMgr->client();
-    const auto RESOURCE = m_vHolds.emplace_back(std::make_unique<CPointerGestureHold>(std::make_shared<CZwpPointerGestureHoldV1>(CLIENT, pMgr->version(), id))).get();
+    const auto RESOURCE = m_vHolds.emplace_back(std::make_unique<CPointerGestureHold>(makeShared<CZwpPointerGestureHoldV1>(CLIENT, pMgr->version(), id))).get();
 
     if (!RESOURCE->good()) {
         pMgr->noMemory();

--- a/src/protocols/RelativePointer.cpp
+++ b/src/protocols/RelativePointer.cpp
@@ -47,7 +47,7 @@ void CRelativePointerProtocol::destroyRelativePointer(CRelativePointer* pointer)
 
 void CRelativePointerProtocol::onGetRelativePointer(CZwpRelativePointerManagerV1* pMgr, uint32_t id, wl_resource* pointer) {
     const auto CLIENT   = pMgr->client();
-    const auto RESOURCE = m_vRelativePointers.emplace_back(std::make_unique<CRelativePointer>(std::make_shared<CZwpRelativePointerV1>(CLIENT, pMgr->version(), id))).get();
+    const auto RESOURCE = m_vRelativePointers.emplace_back(std::make_unique<CRelativePointer>(makeShared<CZwpRelativePointerV1>(CLIENT, pMgr->version(), id))).get();
 
     if (!RESOURCE->good()) {
         pMgr->noMemory();

--- a/src/protocols/Screencopy.hpp
+++ b/src/protocols/Screencopy.hpp
@@ -20,21 +20,21 @@ class CScreencopyClient {
     CScreencopyClient();
     ~CScreencopyClient();
 
-    int                               ref      = 0;
-    wl_resource*                      resource = nullptr;
+    int                  ref      = 0;
+    wl_resource*         resource = nullptr;
 
-    eClientOwners                     clientOwner = CLIENT_SCREENCOPY;
+    eClientOwners        clientOwner = CLIENT_SCREENCOPY;
 
-    int                               frameCounter           = 0;
-    int                               framesInLastHalfSecond = 0;
-    CTimer                            lastMeasure;
-    CTimer                            lastFrame;
-    bool                              sentScreencast = false;
+    int                  frameCounter           = 0;
+    int                  framesInLastHalfSecond = 0;
+    CTimer               lastMeasure;
+    CTimer               lastFrame;
+    bool                 sentScreencast = false;
 
-    void                              onTick();
-    std::shared_ptr<HOOK_CALLBACK_FN> tickCallback;
+    void                 onTick();
+    SP<HOOK_CALLBACK_FN> tickCallback;
 
-    bool                              operator==(const CScreencopyClient& other) const {
+    bool                 operator==(const CScreencopyClient& other) const {
         return resource == other.resource;
     }
 };

--- a/src/protocols/ServerDecorationKDE.cpp
+++ b/src/protocols/ServerDecorationKDE.cpp
@@ -42,8 +42,7 @@ void CServerDecorationKDEProtocol::destroyResource(CServerDecorationKDE* hayperl
 void CServerDecorationKDEProtocol::createDecoration(COrgKdeKwinServerDecorationManager* pMgr, uint32_t id, wl_resource* surf) {
     const auto CLIENT = pMgr->client();
     const auto RESOURCE =
-        m_vDecos.emplace_back(std::make_unique<CServerDecorationKDE>(std::make_shared<COrgKdeKwinServerDecoration>(CLIENT, pMgr->version(), id), wlr_surface_from_resource(surf)))
-            .get();
+        m_vDecos.emplace_back(std::make_unique<CServerDecorationKDE>(makeShared<COrgKdeKwinServerDecoration>(CLIENT, pMgr->version(), id), wlr_surface_from_resource(surf))).get();
 
     if (!RESOURCE->good()) {
         pMgr->noMemory();

--- a/src/protocols/SessionLock.cpp
+++ b/src/protocols/SessionLock.cpp
@@ -161,7 +161,7 @@ void CSessionLockProtocol::onLock(CExtSessionLockManagerV1* pMgr, uint32_t id) {
     LOGM(LOG, "New sessionLock with id {}", id);
 
     const auto CLIENT   = pMgr->client();
-    const auto RESOURCE = m_vLocks.emplace_back(std::make_unique<CSessionLock>(std::make_shared<CExtSessionLockV1>(CLIENT, pMgr->version(), id)));
+    const auto RESOURCE = m_vLocks.emplace_back(makeShared<CSessionLock>(makeShared<CExtSessionLockV1>(CLIENT, pMgr->version(), id)));
 
     if (!RESOURCE->good()) {
         pMgr->noMemory();
@@ -195,8 +195,8 @@ void CSessionLockProtocol::onGetLockSurface(CExtSessionLockV1* lock, uint32_t id
         }
     }
 
-    const auto RESOURCE = m_vLockSurfaces.emplace_back(
-        std::make_unique<CSessionLockSurface>(std::make_shared<CExtSessionLockSurfaceV1>(lock->client(), lock->version(), id), PSURFACE, PMONITOR, sessionLock));
+    const auto RESOURCE =
+        m_vLockSurfaces.emplace_back(makeShared<CSessionLockSurface>(makeShared<CExtSessionLockSurfaceV1>(lock->client(), lock->version(), id), PSURFACE, PMONITOR, sessionLock));
 
     if (!RESOURCE->good()) {
         lock->noMemory();

--- a/src/protocols/ShortcutsInhibit.cpp
+++ b/src/protocols/ShortcutsInhibit.cpp
@@ -58,7 +58,7 @@ void CKeyboardShortcutsInhibitProtocol::onInhibit(CZwpKeyboardShortcutsInhibitMa
     }
 
     const auto RESOURCE =
-        m_vInhibitors.emplace_back(std::make_unique<CKeyboardShortcutsInhibitor>(std::make_shared<CZwpKeyboardShortcutsInhibitorV1>(CLIENT, pMgr->version(), id), surf)).get();
+        m_vInhibitors.emplace_back(std::make_unique<CKeyboardShortcutsInhibitor>(makeShared<CZwpKeyboardShortcutsInhibitorV1>(CLIENT, pMgr->version(), id), surf)).get();
 
     if (!RESOURCE->good()) {
         pMgr->noMemory();

--- a/src/protocols/TearingControl.cpp
+++ b/src/protocols/TearingControl.cpp
@@ -22,7 +22,7 @@ void CTearingControlProtocol::onManagerResourceDestroy(wl_resource* res) {
 }
 
 void CTearingControlProtocol::onGetController(wl_client* client, CWpTearingControlManagerV1* pMgr, uint32_t id, wlr_surface* surf) {
-    const auto CONTROLLER = m_vTearingControllers.emplace_back(std::make_unique<CTearingControl>(std::make_shared<CWpTearingControlV1>(client, pMgr->version(), id), surf)).get();
+    const auto CONTROLLER = m_vTearingControllers.emplace_back(std::make_unique<CTearingControl>(makeShared<CWpTearingControlV1>(client, pMgr->version(), id), surf)).get();
 
     if (!CONTROLLER->good()) {
         pMgr->noMemory();
@@ -67,7 +67,7 @@ void CTearingControl::updateWindow() {
     if (pWindow.expired())
         return;
 
-    pWindow.lock()->m_bTearingHint = hint == WP_TEARING_CONTROL_V1_PRESENTATION_HINT_ASYNC;
+    pWindow->m_bTearingHint = hint == WP_TEARING_CONTROL_V1_PRESENTATION_HINT_ASYNC;
 }
 
 bool CTearingControl::good() {

--- a/src/protocols/TextInputV3.cpp
+++ b/src/protocols/TextInputV3.cpp
@@ -116,7 +116,7 @@ void CTextInputV3Protocol::destroyTextInput(CTextInputV3* input) {
 
 void CTextInputV3Protocol::onGetTextInput(CZwpTextInputManagerV3* pMgr, uint32_t id, wl_resource* seat) {
     const auto CLIENT   = pMgr->client();
-    const auto RESOURCE = m_vTextInputs.emplace_back(std::make_shared<CTextInputV3>(std::make_shared<CZwpTextInputV3>(CLIENT, pMgr->version(), id)));
+    const auto RESOURCE = m_vTextInputs.emplace_back(makeShared<CTextInputV3>(makeShared<CZwpTextInputV3>(CLIENT, pMgr->version(), id)));
 
     if (!RESOURCE->good()) {
         pMgr->noMemory();
@@ -125,5 +125,5 @@ void CTextInputV3Protocol::onGetTextInput(CZwpTextInputManagerV3* pMgr, uint32_t
         return;
     }
 
-    events.newTextInput.emit(std::weak_ptr<CTextInputV3>(RESOURCE));
+    events.newTextInput.emit(WP<CTextInputV3>(RESOURCE));
 }

--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -369,7 +369,7 @@ bool CToplevelExportProtocolManager::copyFrameShm(SScreencopyFrame* frame, times
         return false;
 
     // render the client
-    const auto PMONITOR = g_pCompositor->getMonitorFromID(frame->pWindow.lock()->m_iMonitorID);
+    const auto PMONITOR = g_pCompositor->getMonitorFromID(frame->pWindow->m_iMonitorID);
     CRegion    fakeDamage{0, 0, PMONITOR->vecPixelSize.x * 10, PMONITOR->vecPixelSize.y * 10};
 
     g_pHyprRenderer->makeEGLCurrent();
@@ -393,7 +393,7 @@ bool CToplevelExportProtocolManager::copyFrameShm(SScreencopyFrame* frame, times
     g_pHyprRenderer->m_bBlockSurfaceFeedback = false;
 
     if (frame->overlayCursor)
-        g_pHyprRenderer->renderSoftwareCursors(PMONITOR, fakeDamage, g_pInputManager->getMouseCoordsInternal() - frame->pWindow.lock()->m_vRealPosition.value());
+        g_pHyprRenderer->renderSoftwareCursors(PMONITOR, fakeDamage, g_pInputManager->getMouseCoordsInternal() - frame->pWindow->m_vRealPosition.value());
 
     const auto PFORMAT = g_pHyprOpenGL->getPixelFormatFromDRM(format);
     if (!PFORMAT) {
@@ -426,7 +426,7 @@ bool CToplevelExportProtocolManager::copyFrameShm(SScreencopyFrame* frame, times
 }
 
 bool CToplevelExportProtocolManager::copyFrameDmabuf(SScreencopyFrame* frame, timespec* now) {
-    const auto PMONITOR = g_pCompositor->getMonitorFromID(frame->pWindow.lock()->m_iMonitorID);
+    const auto PMONITOR = g_pCompositor->getMonitorFromID(frame->pWindow->m_iMonitorID);
 
     CRegion    fakeDamage{0, 0, INT16_MAX, INT16_MAX};
 
@@ -440,7 +440,7 @@ bool CToplevelExportProtocolManager::copyFrameDmabuf(SScreencopyFrame* frame, ti
     g_pHyprRenderer->m_bBlockSurfaceFeedback = false;
 
     if (frame->overlayCursor)
-        g_pHyprRenderer->renderSoftwareCursors(PMONITOR, fakeDamage, g_pInputManager->getMouseCoordsInternal() - frame->pWindow.lock()->m_vRealPosition.value());
+        g_pHyprRenderer->renderSoftwareCursors(PMONITOR, fakeDamage, g_pInputManager->getMouseCoordsInternal() - frame->pWindow->m_vRealPosition.value());
 
     g_pHyprOpenGL->m_RenderData.blockScreenShader = true;
     g_pHyprRenderer->endRender();

--- a/src/protocols/VirtualKeyboard.cpp
+++ b/src/protocols/VirtualKeyboard.cpp
@@ -122,7 +122,7 @@ void CVirtualKeyboardProtocol::destroyResource(CVirtualKeyboardV1Resource* keeb)
 
 void CVirtualKeyboardProtocol::onCreateKeeb(CZwpVirtualKeyboardManagerV1* pMgr, wl_resource* seat, uint32_t id) {
 
-    const auto RESOURCE = m_vKeyboards.emplace_back(std::make_shared<CVirtualKeyboardV1Resource>(std::make_shared<CZwpVirtualKeyboardV1>(pMgr->client(), pMgr->version(), id)));
+    const auto RESOURCE = m_vKeyboards.emplace_back(makeShared<CVirtualKeyboardV1Resource>(makeShared<CZwpVirtualKeyboardV1>(pMgr->client(), pMgr->version(), id)));
 
     if (!RESOURCE->good()) {
         pMgr->noMemory();

--- a/src/protocols/VirtualPointer.cpp
+++ b/src/protocols/VirtualPointer.cpp
@@ -151,7 +151,7 @@ void CVirtualPointerProtocol::destroyResource(CVirtualPointerV1Resource* pointer
 
 void CVirtualPointerProtocol::onCreatePointer(CZwlrVirtualPointerManagerV1* pMgr, wl_resource* seat, uint32_t id) {
 
-    const auto RESOURCE = m_vPointers.emplace_back(std::make_shared<CVirtualPointerV1Resource>(std::make_shared<CZwlrVirtualPointerV1>(pMgr->client(), pMgr->version(), id)));
+    const auto RESOURCE = m_vPointers.emplace_back(makeShared<CVirtualPointerV1Resource>(makeShared<CZwlrVirtualPointerV1>(pMgr->client(), pMgr->version(), id)));
 
     if (!RESOURCE->good()) {
         pMgr->noMemory();

--- a/src/protocols/XDGActivation.cpp
+++ b/src/protocols/XDGActivation.cpp
@@ -92,7 +92,7 @@ void CXDGActivationProtocol::destroyToken(CXDGActivationToken* token) {
 
 void CXDGActivationProtocol::onGetToken(CXdgActivationV1* pMgr, uint32_t id) {
     const auto CLIENT   = pMgr->client();
-    const auto RESOURCE = m_vTokens.emplace_back(std::make_unique<CXDGActivationToken>(std::make_shared<CXdgActivationTokenV1>(CLIENT, pMgr->version(), id))).get();
+    const auto RESOURCE = m_vTokens.emplace_back(std::make_unique<CXDGActivationToken>(makeShared<CXdgActivationTokenV1>(CLIENT, pMgr->version(), id))).get();
 
     if (!RESOURCE->good()) {
         pMgr->noMemory();

--- a/src/protocols/XDGDecoration.cpp
+++ b/src/protocols/XDGDecoration.cpp
@@ -64,8 +64,7 @@ void CXDGDecorationProtocol::onGetDecoration(CZxdgDecorationManagerV1* pMgr, uin
 
     const auto CLIENT = pMgr->client();
     const auto RESOURCE =
-        m_mDecorations.emplace(xdgToplevel, std::make_unique<CXDGDecoration>(std::make_shared<CZxdgToplevelDecorationV1>(CLIENT, pMgr->version(), id), xdgToplevel))
-            .first->second.get();
+        m_mDecorations.emplace(xdgToplevel, std::make_unique<CXDGDecoration>(makeShared<CZxdgToplevelDecorationV1>(CLIENT, pMgr->version(), id), xdgToplevel)).first->second.get();
 
     if (!RESOURCE->good()) {
         pMgr->noMemory();

--- a/src/protocols/XDGOutput.cpp
+++ b/src/protocols/XDGOutput.cpp
@@ -53,7 +53,7 @@ void CXDGOutputProtocol::onManagerGetXDGOutput(CZxdgOutputManagerV1* mgr, uint32
 
     const auto  CLIENT = mgr->client();
 
-    CXDGOutput* pXDGOutput = m_vXDGOutputs.emplace_back(std::make_unique<CXDGOutput>(std::make_shared<CZxdgOutputV1>(CLIENT, mgr->version(), id), PMONITOR)).get();
+    CXDGOutput* pXDGOutput = m_vXDGOutputs.emplace_back(std::make_unique<CXDGOutput>(makeShared<CZxdgOutputV1>(CLIENT, mgr->version(), id), PMONITOR)).get();
 #ifndef NO_XWAYLAND
     if (g_pXWaylandManager->m_sWLRXWayland && g_pXWaylandManager->m_sWLRXWayland->server && g_pXWaylandManager->m_sWLRXWayland->server->client == CLIENT)
         pXDGOutput->isXWayland = true;

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -874,7 +874,7 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(const CTexture& tex, CBox*
         }
     }
 
-    if (m_pCurrentWindow.lock() && m_pCurrentWindow.lock()->m_sAdditionalConfigData.forceRGBX)
+    if (m_pCurrentWindow.lock() && m_pCurrentWindow->m_sAdditionalConfigData.forceRGBX)
         shader = &m_RenderData.pCurrentMonData->m_shRGBX;
 
     glActiveTexture(GL_TEXTURE0);
@@ -943,7 +943,7 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(const CTexture& tex, CBox*
 
         if (allowDim && m_pCurrentWindow.lock() && *PDIMINACTIVE) {
             glUniform1i(shader->applyTint, 1);
-            const auto DIM = m_pCurrentWindow.lock()->m_fDimPercent.value();
+            const auto DIM = m_pCurrentWindow->m_fDimPercent.value();
             glUniform3f(shader->tint, 1.f - DIM, 1.f - DIM, 1.f - DIM);
         } else {
             glUniform1i(shader->applyTint, 0);
@@ -1494,7 +1494,7 @@ void CHyprOpenGLImpl::renderTextureWithBlur(const CTexture& tex, CBox* pBox, flo
     m_RenderData.renderModif.applyToRegion(texDamage);
 
     if (*PBLURENABLED == 0 || (*PNOBLUROVERSIZED && m_RenderData.primarySurfaceUVTopLeft != Vector2D(-1, -1)) ||
-        (m_pCurrentWindow.lock() && (m_pCurrentWindow.lock()->m_sAdditionalConfigData.forceNoBlur || m_pCurrentWindow.lock()->m_sAdditionalConfigData.forceRGBX))) {
+        (m_pCurrentWindow.lock() && (m_pCurrentWindow->m_sAdditionalConfigData.forceNoBlur || m_pCurrentWindow->m_sAdditionalConfigData.forceRGBX))) {
         renderTexture(tex, pBox, a, round, false, true);
         return;
     }
@@ -1591,7 +1591,7 @@ void CHyprOpenGLImpl::renderBorder(CBox* box, const CGradientValueData& grad, in
 
     TRACY_GPU_ZONE("RenderBorder");
 
-    if (m_RenderData.damage.empty() || (m_pCurrentWindow.lock() && m_pCurrentWindow.lock()->m_sAdditionalConfigData.forceNoBorder))
+    if (m_RenderData.damage.empty() || (m_pCurrentWindow.lock() && m_pCurrentWindow->m_sAdditionalConfigData.forceNoBorder))
         return;
 
     CBox newBox = *box;

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -196,10 +196,10 @@ class CHyprOpenGLImpl {
     PHLWINDOWREF          m_pCurrentWindow; // hack to get the current rendered window
     PHLLS                 m_pCurrentLayer;  // hack to get the current rendered layer
 
-    std::map<PHLWINDOWREF, CFramebuffer, std::owner_less<PHLWINDOWREF>> m_mWindowFramebuffers;
-    std::map<PHLLSREF, CFramebuffer, std::owner_less<PHLLSREF>>         m_mLayerFramebuffers;
-    std::unordered_map<CMonitor*, SMonitorRenderData>                   m_mMonitorRenderResources;
-    std::unordered_map<CMonitor*, CFramebuffer>                         m_mMonitorBGFBs;
+    std::map<PHLWINDOWREF, CFramebuffer>              m_mWindowFramebuffers;
+    std::map<PHLLSREF, CFramebuffer>                  m_mLayerFramebuffers;
+    std::unordered_map<CMonitor*, SMonitorRenderData> m_mMonitorRenderResources;
+    std::unordered_map<CMonitor*, CFramebuffer>       m_mMonitorBGFBs;
 
     struct {
         PFNGLEGLIMAGETARGETRENDERBUFFERSTORAGEOESPROC glEGLImageTargetRenderbufferStorageOES = nullptr;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -417,7 +417,7 @@ void CHyprRenderer::renderWorkspaceWindows(CMonitor* pMonitor, PHLWORKSPACE pWor
             continue;
 
         // render active window after all others of this pass
-        if (w == g_pCompositor->m_pLastWindow.lock()) {
+        if (w == g_pCompositor->m_pLastWindow) {
             lastWindow = w;
             continue;
         }
@@ -740,12 +740,12 @@ void CHyprRenderer::renderSessionLockSurface(SSessionLockSurface* pSurface, CMon
     SRenderData renderdata = {pMonitor, time, pMonitor->vecPosition.x, pMonitor->vecPosition.y};
 
     renderdata.blur     = false;
-    renderdata.surface  = pSurface->surface.lock()->surface();
+    renderdata.surface  = pSurface->surface->surface();
     renderdata.decorate = false;
     renderdata.w        = pMonitor->vecSize.x;
     renderdata.h        = pMonitor->vecSize.y;
 
-    wlr_surface_for_each_surface(pSurface->surface.lock()->surface(), renderSurface, &renderdata);
+    wlr_surface_for_each_surface(pSurface->surface->surface(), renderSurface, &renderdata);
 }
 
 void CHyprRenderer::renderAllClientsForWorkspace(CMonitor* pMonitor, PHLWORKSPACE pWorkspace, timespec* time, const Vector2D& translate, const float& scale) {

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -11,7 +11,7 @@ CHyprBorderDecoration::~CHyprBorderDecoration() {
 }
 
 SDecorationPositioningInfo CHyprBorderDecoration::getPositioningInfo() {
-    const auto BORDERSIZE = m_pWindow.lock()->getRealBorderSize();
+    const auto BORDERSIZE = m_pWindow->getRealBorderSize();
     m_seExtents           = {{BORDERSIZE, BORDERSIZE}, {BORDERSIZE, BORDERSIZE}};
 
     if (doesntWantBorders())
@@ -36,12 +36,12 @@ CBox CHyprBorderDecoration::assignedBoxGlobal() {
     CBox box = m_bAssignedGeometry;
     box.translate(g_pDecorationPositioner->getEdgeDefinedPoint(DECORATION_EDGE_BOTTOM | DECORATION_EDGE_LEFT | DECORATION_EDGE_RIGHT | DECORATION_EDGE_TOP, m_pWindow.lock()));
 
-    const auto PWORKSPACE = m_pWindow.lock()->m_pWorkspace;
+    const auto PWORKSPACE = m_pWindow->m_pWorkspace;
 
     if (!PWORKSPACE)
         return box;
 
-    const auto WORKSPACEOFFSET = PWORKSPACE && !m_pWindow.lock()->m_bPinned ? PWORKSPACE->m_vRenderOffset.value() : Vector2D();
+    const auto WORKSPACEOFFSET = PWORKSPACE && !m_pWindow->m_bPinned ? PWORKSPACE->m_vRenderOffset.value() : Vector2D();
     return box.translate(WORKSPACEOFFSET);
 }
 
@@ -52,29 +52,28 @@ void CHyprBorderDecoration::draw(CMonitor* pMonitor, float a) {
     if (m_bAssignedGeometry.width < m_seExtents.topLeft.x + 1 || m_bAssignedGeometry.height < m_seExtents.topLeft.y + 1)
         return;
 
-    CBox windowBox =
-        assignedBoxGlobal().translate(-pMonitor->vecPosition + m_pWindow.lock()->m_vFloatingOffset).expand(-m_pWindow.lock()->getRealBorderSize()).scale(pMonitor->scale).round();
+    CBox windowBox = assignedBoxGlobal().translate(-pMonitor->vecPosition + m_pWindow->m_vFloatingOffset).expand(-m_pWindow->getRealBorderSize()).scale(pMonitor->scale).round();
 
     if (windowBox.width < 1 || windowBox.height < 1)
         return;
 
-    auto       grad     = m_pWindow.lock()->m_cRealBorderColor;
-    const bool ANIMATED = m_pWindow.lock()->m_fBorderFadeAnimationProgress.isBeingAnimated();
-    float      a1       = a * (ANIMATED ? m_pWindow.lock()->m_fBorderFadeAnimationProgress.value() : 1.f);
+    auto       grad     = m_pWindow->m_cRealBorderColor;
+    const bool ANIMATED = m_pWindow->m_fBorderFadeAnimationProgress.isBeingAnimated();
+    float      a1       = a * (ANIMATED ? m_pWindow->m_fBorderFadeAnimationProgress.value() : 1.f);
 
-    if (m_pWindow.lock()->m_fBorderAngleAnimationProgress.getConfig()->pValues->internalEnabled) {
-        grad.m_fAngle += m_pWindow.lock()->m_fBorderAngleAnimationProgress.value() * M_PI * 2;
+    if (m_pWindow->m_fBorderAngleAnimationProgress.getConfig()->pValues->internalEnabled) {
+        grad.m_fAngle += m_pWindow->m_fBorderAngleAnimationProgress.value() * M_PI * 2;
         grad.m_fAngle = normalizeAngleRad(grad.m_fAngle);
     }
 
-    int        borderSize = m_pWindow.lock()->getRealBorderSize();
-    const auto ROUNDING   = m_pWindow.lock()->rounding() * pMonitor->scale;
+    int        borderSize = m_pWindow->getRealBorderSize();
+    const auto ROUNDING   = m_pWindow->rounding() * pMonitor->scale;
 
     g_pHyprOpenGL->renderBorder(&windowBox, grad, ROUNDING, borderSize, a1);
 
     if (ANIMATED) {
-        float a2 = a * (1.f - m_pWindow.lock()->m_fBorderFadeAnimationProgress.value());
-        g_pHyprOpenGL->renderBorder(&windowBox, m_pWindow.lock()->m_cRealBorderColorPrevious, ROUNDING, borderSize, a2);
+        float a2 = a * (1.f - m_pWindow->m_fBorderFadeAnimationProgress.value());
+        g_pHyprOpenGL->renderBorder(&windowBox, m_pWindow->m_cRealBorderColorPrevious, ROUNDING, borderSize, a2);
     }
 }
 
@@ -83,7 +82,7 @@ eDecorationType CHyprBorderDecoration::getDecorationType() {
 }
 
 void CHyprBorderDecoration::updateWindow(PHLWINDOW) {
-    if (m_pWindow.lock()->getRealBorderSize() != m_seExtents.topLeft.x)
+    if (m_pWindow->getRealBorderSize() != m_seExtents.topLeft.x)
         g_pDecorationPositioner->repositionDeco(this);
 }
 
@@ -91,15 +90,15 @@ void CHyprBorderDecoration::damageEntire() {
     if (!validMapped(m_pWindow))
         return;
 
-    auto       surfaceBox   = m_pWindow.lock()->getWindowMainSurfaceBox();
-    const auto ROUNDING     = m_pWindow.lock()->rounding();
+    auto       surfaceBox   = m_pWindow->getWindowMainSurfaceBox();
+    const auto ROUNDING     = m_pWindow->rounding();
     const auto ROUNDINGSIZE = ROUNDING - M_SQRT1_2 * ROUNDING + 2;
-    const auto BORDERSIZE   = m_pWindow.lock()->getRealBorderSize() + 1;
+    const auto BORDERSIZE   = m_pWindow->getRealBorderSize() + 1;
 
-    const auto PWINDOWWORKSPACE = m_pWindow.lock()->m_pWorkspace;
-    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_vRenderOffset.isBeingAnimated() && !m_pWindow.lock()->m_bPinned)
+    const auto PWINDOWWORKSPACE = m_pWindow->m_pWorkspace;
+    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_vRenderOffset.isBeingAnimated() && !m_pWindow->m_bPinned)
         surfaceBox.translate(PWINDOWWORKSPACE->m_vRenderOffset.value());
-    surfaceBox.translate(m_pWindow.lock()->m_vFloatingOffset);
+    surfaceBox.translate(m_pWindow->m_vFloatingOffset);
 
     CBox surfaceBoxExpandedBorder = surfaceBox;
     surfaceBoxExpandedBorder.expand(BORDERSIZE);
@@ -134,5 +133,5 @@ std::string CHyprBorderDecoration::getDisplayName() {
 }
 
 bool CHyprBorderDecoration::doesntWantBorders() {
-    return !m_pWindow.lock()->m_sSpecialRenderData.border || m_pWindow.lock()->m_bX11DoesntWantBorders || m_pWindow.lock()->getRealBorderSize() == 0;
+    return !m_pWindow->m_sSpecialRenderData.border || m_pWindow->m_bX11DoesntWantBorders || m_pWindow->getRealBorderSize() == 0;
 }

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -39,7 +39,7 @@ SDecorationPositioningInfo CHyprGroupBarDecoration::getPositioningInfo() {
     info.priority = *PPRIORITY;
     info.reserved = true;
 
-    if (*PENABLED && m_pWindow.lock()->m_sSpecialRenderData.decorate)
+    if (*PENABLED && m_pWindow->m_sSpecialRenderData.decorate)
         info.desiredExtents = {{0, BAR_PADDING_OUTER_VERT * 2 + BAR_INDICATOR_HEIGHT + (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0) + 2}, {0, 0}};
     else
         info.desiredExtents = {{0, 0}, {0, 0}};
@@ -58,8 +58,8 @@ eDecorationType CHyprGroupBarDecoration::getDecorationType() {
 //
 
 void CHyprGroupBarDecoration::updateWindow(PHLWINDOW pWindow) {
-    if (m_pWindow.lock()->m_sGroupData.pNextWindow.expired()) {
-        m_pWindow.lock()->removeWindowDeco(this);
+    if (m_pWindow->m_sGroupData.pNextWindow.expired()) {
+        m_pWindow->removeWindowDeco(this);
         return;
     }
 
@@ -76,14 +76,14 @@ void CHyprGroupBarDecoration::updateWindow(PHLWINDOW pWindow) {
     damageEntire();
 
     if (m_dwGroupMembers.size() == 0) {
-        m_pWindow.lock()->removeWindowDeco(this);
+        m_pWindow->removeWindowDeco(this);
         return;
     }
 }
 
 void CHyprGroupBarDecoration::damageEntire() {
     auto box = assignedBoxGlobal();
-    box.translate(m_pWindow.lock()->m_vFloatingOffset);
+    box.translate(m_pWindow->m_vFloatingOffset);
     g_pHyprRenderer->damageBox(&box);
 }
 
@@ -97,7 +97,7 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a) {
     static auto PHEIGHT        = CConfigValue<Hyprlang::INT>("group:groupbar:height");
     static auto PGRADIENTS     = CConfigValue<Hyprlang::INT>("group:groupbar:gradients");
 
-    if (!*PENABLED || !m_pWindow.lock()->m_sSpecialRenderData.decorate)
+    if (!*PENABLED || !m_pWindow->m_sSpecialRenderData.decorate)
         return;
 
     const auto ASSIGNEDBOX = assignedBoxGlobal();
@@ -111,8 +111,8 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a) {
     int xoff = 0;
 
     for (int i = 0; i < barsToDraw; ++i) {
-        CBox rect = {ASSIGNEDBOX.x + xoff - pMonitor->vecPosition.x + m_pWindow.lock()->m_vFloatingOffset.x,
-                     ASSIGNEDBOX.y + ASSIGNEDBOX.h - BAR_INDICATOR_HEIGHT - BAR_PADDING_OUTER_VERT - pMonitor->vecPosition.y + m_pWindow.lock()->m_vFloatingOffset.y, m_fBarWidth,
+        CBox rect = {ASSIGNEDBOX.x + xoff - pMonitor->vecPosition.x + m_pWindow->m_vFloatingOffset.x,
+                     ASSIGNEDBOX.y + ASSIGNEDBOX.h - BAR_INDICATOR_HEIGHT - BAR_PADDING_OUTER_VERT - pMonitor->vecPosition.y + m_pWindow->m_vFloatingOffset.y, m_fBarWidth,
                      BAR_INDICATOR_HEIGHT};
 
         if (rect.width <= 0 || rect.height <= 0)
@@ -129,7 +129,7 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a) {
         auto* const       GROUPCOLACTIVELOCKED    = (CGradientValueData*)(PGROUPCOLACTIVELOCKED.ptr())->getData();
         auto* const       GROUPCOLINACTIVELOCKED  = (CGradientValueData*)(PGROUPCOLINACTIVELOCKED.ptr())->getData();
 
-        const bool        GROUPLOCKED  = m_pWindow.lock()->getGroupHead()->m_sGroupData.locked;
+        const bool        GROUPLOCKED  = m_pWindow->getGroupHead()->m_sGroupData.locked;
         const auto* const PCOLACTIVE   = GROUPLOCKED ? GROUPCOLACTIVELOCKED : GROUPCOLACTIVE;
         const auto* const PCOLINACTIVE = GROUPLOCKED ? GROUPCOLINACTIVELOCKED : GROUPCOLINACTIVE;
 
@@ -137,8 +137,8 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a) {
         color.a *= a;
         g_pHyprOpenGL->renderRect(&rect, color);
 
-        rect = {ASSIGNEDBOX.x + xoff - pMonitor->vecPosition.x + m_pWindow.lock()->m_vFloatingOffset.x,
-                ASSIGNEDBOX.y - pMonitor->vecPosition.y + m_pWindow.lock()->m_vFloatingOffset.y + BAR_PADDING_OUTER_VERT, m_fBarWidth,
+        rect = {ASSIGNEDBOX.x + xoff - pMonitor->vecPosition.x + m_pWindow->m_vFloatingOffset.x,
+                ASSIGNEDBOX.y - pMonitor->vecPosition.y + m_pWindow->m_vFloatingOffset.y + BAR_PADDING_OUTER_VERT, m_fBarWidth,
                 ASSIGNEDBOX.h - BAR_INDICATOR_HEIGHT - BAR_PADDING_OUTER_VERT * 2};
         rect.scale(pMonitor->scale);
 
@@ -150,7 +150,7 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a) {
         }
 
         if (*PRENDERTITLES) {
-            CTitleTex* pTitleTex = textureFromTitle(m_dwGroupMembers[i].lock()->m_szTitle);
+            CTitleTex* pTitleTex = textureFromTitle(m_dwGroupMembers[i]->m_szTitle);
 
             if (!pTitleTex)
                 pTitleTex = m_sTitleTexs.titleTexs
@@ -335,7 +335,7 @@ void refreshGroupBarGradients() {
 }
 
 bool CHyprGroupBarDecoration::onBeginWindowDragOnDeco(const Vector2D& pos) {
-    if (m_pWindow.lock() == m_pWindow.lock()->m_sGroupData.pNextWindow.lock())
+    if (m_pWindow.lock() == m_pWindow->m_sGroupData.pNextWindow.lock())
         return false;
 
     const float BARRELATIVEX = pos.x - assignedBoxGlobal().x;
@@ -344,7 +344,7 @@ bool CHyprGroupBarDecoration::onBeginWindowDragOnDeco(const Vector2D& pos) {
     if (BARRELATIVEX - (m_fBarWidth + BAR_HORIZONTAL_PADDING) * WINDOWINDEX > m_fBarWidth)
         return false;
 
-    PHLWINDOW pWindow = m_pWindow.lock()->getGroupWindowByIndex(WINDOWINDEX);
+    PHLWINDOW pWindow = m_pWindow->getGroupWindowByIndex(WINDOWINDEX);
 
     // hack
     g_pLayoutManager->getCurrentLayout()->onWindowRemoved(pWindow);
@@ -370,7 +370,7 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, PHLWIND
     const float BARRELATIVEX = pos.x - assignedBoxGlobal().x - m_fBarWidth / 2;
     const int   WINDOWINDEX  = BARRELATIVEX < 0 ? -1 : (BARRELATIVEX) / (m_fBarWidth + BAR_HORIZONTAL_PADDING);
 
-    PHLWINDOW   pWindowInsertAfter = m_pWindow.lock()->getGroupWindowByIndex(WINDOWINDEX);
+    PHLWINDOW   pWindowInsertAfter = m_pWindow->getGroupWindowByIndex(WINDOWINDEX);
     PHLWINDOW   pWindowInsertEnd   = pWindowInsertAfter->m_sGroupData.pNextWindow.lock();
     PHLWINDOW   pDraggedHead       = pDraggedWindow->m_sGroupData.pNextWindow.lock() ? pDraggedWindow->getGroupHead() : pDraggedWindow;
 
@@ -411,7 +411,7 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, PHLWIND
     if (WINDOWINDEX == -1)
         std::swap(pDraggedHead->m_sGroupData.head, pWindowInsertEnd->m_sGroupData.head);
 
-    m_pWindow.lock()->setGroupCurrent(pDraggedWindow);
+    m_pWindow->setGroupCurrent(pDraggedWindow);
     pDraggedWindow->applyGroupRules();
     pDraggedWindow->updateWindowDecos();
     g_pLayoutManager->getCurrentLayout()->recalculateWindow(pDraggedWindow);
@@ -423,7 +423,7 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, PHLWIND
 }
 
 bool CHyprGroupBarDecoration::onMouseButtonOnDeco(const Vector2D& pos, wlr_pointer_button_event* e) {
-    if (m_pWindow.lock()->m_bIsFullscreen && m_pWindow.lock()->m_pWorkspace->m_efFullscreenMode == FULLSCREEN_FULL)
+    if (m_pWindow->m_bIsFullscreen && m_pWindow->m_pWorkspace->m_efFullscreenMode == FULLSCREEN_FULL)
         return true;
 
     const float BARRELATIVEX = pos.x - assignedBoxGlobal().x;
@@ -437,7 +437,7 @@ bool CHyprGroupBarDecoration::onMouseButtonOnDeco(const Vector2D& pos, wlr_point
         if (e->state == WL_POINTER_BUTTON_STATE_PRESSED)
             pressedCursorPos = pos;
         else if (e->state == WL_POINTER_BUTTON_STATE_RELEASED && pressedCursorPos == pos)
-            g_pXWaylandManager->sendCloseWindow(m_pWindow.lock()->getGroupWindowByIndex(WINDOWINDEX));
+            g_pXWaylandManager->sendCloseWindow(m_pWindow->getGroupWindowByIndex(WINDOWINDEX));
 
         return true;
     }
@@ -452,9 +452,9 @@ bool CHyprGroupBarDecoration::onMouseButtonOnDeco(const Vector2D& pos, wlr_point
         return true;
     }
 
-    PHLWINDOW pWindow = m_pWindow.lock()->getGroupWindowByIndex(WINDOWINDEX);
+    PHLWINDOW pWindow = m_pWindow->getGroupWindowByIndex(WINDOWINDEX);
 
-    if (pWindow != m_pWindow.lock())
+    if (pWindow != m_pWindow)
         pWindow->setGroupCurrent(pWindow);
 
     if (!g_pCompositor->isWindowActive(pWindow) && *PFOLLOWMOUSE != 3)
@@ -469,13 +469,13 @@ bool CHyprGroupBarDecoration::onMouseButtonOnDeco(const Vector2D& pos, wlr_point
 bool CHyprGroupBarDecoration::onScrollOnDeco(const Vector2D& pos, wlr_pointer_axis_event* e) {
     static auto PGROUPBARSCROLLING = CConfigValue<Hyprlang::INT>("group:groupbar:scrolling");
 
-    if (!*PGROUPBARSCROLLING || m_pWindow.lock()->m_sGroupData.pNextWindow.expired())
+    if (!*PGROUPBARSCROLLING || m_pWindow->m_sGroupData.pNextWindow.expired())
         return false;
 
     if (e->delta > 0)
-        m_pWindow.lock()->setGroupCurrent(m_pWindow.lock()->m_sGroupData.pNextWindow.lock());
+        m_pWindow->setGroupCurrent(m_pWindow->m_sGroupData.pNextWindow.lock());
     else
-        m_pWindow.lock()->setGroupCurrent(m_pWindow.lock()->getGroupPrevious());
+        m_pWindow->setGroupCurrent(m_pWindow->getGroupPrevious());
 
     return true;
 }
@@ -506,9 +506,9 @@ CBox CHyprGroupBarDecoration::assignedBoxGlobal() {
     CBox box = m_bAssignedBox;
     box.translate(g_pDecorationPositioner->getEdgeDefinedPoint(DECORATION_EDGE_TOP, m_pWindow.lock()));
 
-    const auto PWORKSPACE = m_pWindow.lock()->m_pWorkspace;
+    const auto PWORKSPACE = m_pWindow->m_pWorkspace;
 
-    if (PWORKSPACE && !m_pWindow.lock()->m_bPinned)
+    if (PWORKSPACE && !m_pWindow->m_bPinned)
         box.translate(PWORKSPACE->m_vRenderOffset.value());
 
     return box;

--- a/src/render/decorations/DecorationPositioner.cpp
+++ b/src/render/decorations/DecorationPositioner.cpp
@@ -85,12 +85,17 @@ CDecorationPositioner::SWindowPositioningData* CDecorationPositioner::getDataFor
 }
 
 void CDecorationPositioner::sanitizeDatas() {
-    std::erase_if(m_mWindowDatas, [](const auto& other) { return !valid(other.first); });
+    std::erase_if(m_mWindowDatas, [](const auto& other) {
+        if (!valid(other.first))
+            return true;
+
+        return false;
+    });
     std::erase_if(m_vWindowPositioningDatas, [](const auto& other) {
         if (!validMapped(other->pWindow))
             return true;
-        if (std::find_if(other->pWindow.lock()->m_dWindowDecorations.begin(), other->pWindow.lock()->m_dWindowDecorations.end(),
-                         [&](const auto& el) { return el.get() == other->pDecoration; }) == other->pWindow.lock()->m_dWindowDecorations.end())
+        if (std::find_if(other->pWindow->m_dWindowDecorations.begin(), other->pWindow->m_dWindowDecorations.end(),
+                         [&](const auto& el) { return el.get() == other->pDecoration; }) == other->pWindow->m_dWindowDecorations.end())
             return true;
         return false;
     });
@@ -302,7 +307,7 @@ SWindowDecorationExtents CDecorationPositioner::getWindowDecorationExtents(PHLWI
         CBox decoBox;
 
         if (data->positioningInfo.policy == DECORATION_POSITION_ABSOLUTE) {
-            decoBox = data->pWindow.lock()->getWindowMainSurfaceBox();
+            decoBox = data->pWindow->getWindowMainSurfaceBox();
             decoBox.addExtents(data->positioningInfo.desiredExtents);
         } else {
             decoBox              = data->lastReply.assignedGeometry;
@@ -340,7 +345,7 @@ CBox CDecorationPositioner::getBoxWithIncludedDecos(PHLWINDOW pWindow) {
         CBox decoBox;
 
         if (data->positioningInfo.policy == DECORATION_POSITION_ABSOLUTE) {
-            decoBox = data->pWindow.lock()->getWindowMainSurfaceBox();
+            decoBox = data->pWindow->getWindowMainSurfaceBox();
             decoBox.addExtents(data->positioningInfo.desiredExtents);
         } else {
             decoBox              = data->lastReply.assignedGeometry;

--- a/src/render/decorations/DecorationPositioner.hpp
+++ b/src/render/decorations/DecorationPositioner.hpp
@@ -1,16 +1,13 @@
 #pragma once
 
 #include <cstdint>
-#include <memory>
 #include <vector>
 #include <map>
 #include "../../helpers/Box.hpp"
+#include "../../desktop/DesktopTypes.hpp"
 
 class CWindow;
 class IHyprWindowDecoration;
-
-typedef std::shared_ptr<CWindow> PHLWINDOW;
-typedef std::weak_ptr<CWindow>   PHLWINDOWREF;
 
 enum eDecorationPositioningPolicy {
     DECORATION_POSITION_ABSOLUTE = 0, /* Decoration wants absolute positioning */
@@ -90,13 +87,13 @@ class CDecorationPositioner {
         bool                     needsRecalc    = false;
     };
 
-    std::map<PHLWINDOWREF, SWindowData, std::owner_less<PHLWINDOWREF>> m_mWindowDatas;
-    std::vector<std::unique_ptr<SWindowPositioningData>>               m_vWindowPositioningDatas;
+    std::map<PHLWINDOWREF, SWindowData>                  m_mWindowDatas;
+    std::vector<std::unique_ptr<SWindowPositioningData>> m_vWindowPositioningDatas;
 
-    SWindowPositioningData*                                            getDataFor(IHyprWindowDecoration* pDecoration, PHLWINDOW pWindow);
-    void                                                               onWindowUnmap(PHLWINDOW pWindow);
-    void                                                               onWindowMap(PHLWINDOW pWindow);
-    void                                                               sanitizeDatas();
+    SWindowPositioningData*                              getDataFor(IHyprWindowDecoration* pDecoration, PHLWINDOW pWindow);
+    void                                                 onWindowUnmap(PHLWINDOW pWindow);
+    void                                                 onWindowMap(PHLWINDOW pWindow);
+    void                                                 sanitizeDatas();
 };
 
 inline std::unique_ptr<CDecorationPositioner> g_pDecorationPositioner;


### PR DESCRIPTION
The reasoning is quite simple - this is a more useful shared_ptr implementation. Whether the impl itself is better - God knows.

I am not sure if this is a great idea either, but:

weak_ptrs got two new superpowers that the stl ones dont have:

- you can dereference a weak_ptr directly. This will obviously segfault on a nullptr deref if it's expired.
   - this is useful to avoid the .lock() hell where we are 100% sure the pointer _should_ be valid. (and if it isn't, it should throw.)
- weak_ptrs are still valid while the SP is being destroyed.
   - reasoning: while an object (e.g. CWindow) is being destroyed, its `weak_ptr self` should be accessible (the sp is still alive, and so is CWindow), but it's not because by stl it's already expired (to prevent resurrection)
   - this impl solves it differently. w_p is expired, but can still be dereferenced and used. Creating `s_p`s is not possible anymore, though.
   - this is useful in destructors and callbacks.
   
review pls @outfoxxed @fufexan and everyone else.

TODO:
 - [x] Battle testing.
 - [x] Fix invalid delete