### PR TITLE
nix: add missing hwdata dependency

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -11,6 +11,7 @@
   cairo,
   expat,
   git,
+  hwdata,
   hyprcursor,
   hyprland-protocols,
   hyprlang,
@@ -107,6 +108,7 @@ assert lib.assertMsg (!hidpiXWayland) "The option `hidpiXWayland` has been remov
         cairo
         expat
         git
+        hwdata
         hyprcursor.dev
         hyprland-protocols
         hyprlang


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Adds missing hwdata to the nix build.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Yes
