### PR TITLE
make the keybind manager check for session lock

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -557,6 +557,9 @@ bool CKeybindManager::handleKeybinds(const uint32_t modmask, const SPressedKeyWi
         const bool IGNORECONDITIONS =
             SPECIALDISPATCHER && !pressed && SPECIALTRIGGERED; // ignore mods. Pass, global dispatchers should be released immediately once the key is released.
 
+        if (!k.locked && g_pSessionLockManager->isSessionLocked())
+            continue;
+
         if (!IGNORECONDITIONS &&
             ((modmask != k.modmask && !k.ignoreMods) || (g_pCompositor->m_sSeat.exclusiveClient && !k.locked) || k.submap != m_szCurrentSelectedSubmap || k.shadowed))
             continue;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes
 [bug] hyprland keybinds still response on hyprlock screen #5885 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I used these binds for testing

```
# a few simple test binds
# onSwitchEvent uses handleKeybinds directly it so should work correctly
# mouse binds (bindm) are exclusive so don't need to test
bind  = $mainMod, Q, exec, $terminal # normal bind (onKeyEvent) is ignored
bind  = $mainMod, mouse_down, exec, $terminal # mouse wheel bind (onAxisEvent) is ignored
bindl = $mainMod, T, exec, $terminal # bindl still works (onKeyEvent)
bindl = $mainMod, mouse_up, exec, $terminal # bindl still works (onAxisEvent)
```
<s>However the bindl for mouse_up did not work.
Maybe this is because the mouse is deleted somehow during lock?
Not sure how to make bindl for mouse_up (onAxisEvent) work if it doesn't get events
</s>
It seems that the scroll direction names are inversed...

#### Is it ready for merging, or does it need work?
<s>Probably except for above</s> Yes