### PR TITLE
Fix odd window animation effect that causes the bottom left corner to bounce.

### DIFF
--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -36,10 +36,10 @@ void setAnimToMove(void* data) {
 
     CBaseAnimatedVariable* animvar = (CBaseAnimatedVariable*)data;
 
-    if (animvar->getWindow() && !animvar->getWindow()->m_vRealPosition.isBeingAnimated() && !animvar->getWindow()->m_vRealSize.isBeingAnimated()) {
-        animvar->setConfig(PANIMCFG);
+    animvar->setConfig(PANIMCFG);
+
+    if (animvar->getWindow() && !animvar->getWindow()->m_vRealPosition.isBeingAnimated() && !animvar->getWindow()->m_vRealSize.isBeingAnimated())
         animvar->getWindow()->m_bAnimatingIn = false;
-    }
 }
 
 void Events::listener_mapWindow(void* owner, void* data) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This reverts commit 7617c03dfd0073654ca8c4d9a6f5db278d14cd28, fixing a bug that caused the bottom right corner of windows to animate oddly.

pre revert:

https://github.com/hyprwm/Hyprland/assets/83010835/592568ea-2e96-44ca-8bfa-3d1dc9d6f1bb

post revert:

https://github.com/hyprwm/Hyprland/assets/83010835/0140d63b-4942-4009-be35-de82a19411fc

Animations in use:
```
    bezier = windowResize, 0.04, 0.67, 0.38, 1
    animation = windowsMove, 1, 2.5, windowResize
```

Note that after the revert it still glitches slightly, but its far better:

https://github.com/hyprwm/Hyprland/assets/83010835/ec06efd0-52f2-4f95-8a02-04cd2e0e4cac


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.

#### Is it ready for merging, or does it need work?
Ready to merge.