### PR TITLE
always render lock screen above other stuff

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1322,8 +1322,11 @@ void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
                         damageBlinkCleanup = 0;
                 }
             }
-        } else
+        } else {
+            CBox renderBox = {0, 0, (int)pMonitor->vecPixelSize.x, (int)pMonitor->vecPixelSize.y};
             g_pHyprRenderer->renderWindow(pMonitor->solitaryClient.lock(), pMonitor, &now, false, RENDER_PASS_MAIN /* solitary = no popups */);
+            renderLockscreen(pMonitor, &now, renderBox);
+        }
     } else {
         sendFrameEventsToWorkspace(pMonitor, pMonitor->activeWorkspace, &now);
         if (pMonitor->activeSpecialWorkspace)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
trying to fix
lockscreen is not rendered above floating wine games #5899 

This isn't only wine btw, this affects all fullscreen xwayland clients
#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
the real problem is that we're still rendering the fullscreen xwayland clients
and that doesn't follow the [session lock protocol](https://wayland.app/protocols/ext-session-lock-v1)
> This means that the compositor must stop rendering and providing input to normal clients.

Currently, I believe that Hyprland allows fullscreen xwayland clients use a dmabuf and direct scanout to render more efficiently
The question is... how do we make those clients stop rendering (through the dmabuf) when the session is locked?

rn I just always render the session locker, which works, but its a hack

#### Is it ready for merging, or does it need work?
if you are ok with the current solution

I'm going to **try** to actually fix it