### PR TITLE
Fix keybinds xkb names

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -576,9 +576,10 @@ bool CKeybindManager::handleKeybinds(const uint32_t modmask, const SPressedKeyWi
         } else {
             // oMg such performance hit!!11!
             // this little maneouver is gonna cost us 4µs
-            const auto KBKEY = xkb_keysym_from_name(k.key.c_str(), XKB_KEYSYM_CASE_INSENSITIVE);
+            const auto KBKEY      = xkb_keysym_from_name(k.key.c_str(), XKB_KEYSYM_NO_FLAGS);
+            const auto KBKEYLOWER = xkb_keysym_from_name(k.key.c_str(), XKB_KEYSYM_CASE_INSENSITIVE);
 
-            if (KBKEY == 0) {
+            if (KBKEY == 0 && KBKEYLOWER == 0) {
                 // Keysym failed to resolve from the key name of the currently iterated bind.
                 // This happens for names such as `switch:off:Lid Switch` as well as some keys
                 // (such as yen and ro).
@@ -589,9 +590,7 @@ bool CKeybindManager::handleKeybinds(const uint32_t modmask, const SPressedKeyWi
                 continue;
             }
 
-            const auto KBKEYUPPER = xkb_keysym_to_upper(KBKEY);
-
-            if (key.keysym != KBKEY && key.keysym != KBKEYUPPER)
+            if (key.keysym != KBKEY && key.keysym != KBKEYLOWER)
                 continue;
         }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
fixes
XF86ScreenSaver key not working #5892

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

docs from [xkbcommon.h](https://github.com/xkbcommon/libxkbcommon/blob/master/include/xkbcommon/xkbcommon.h) for `xkb_keysym_from_name`
> If you use the XKB_KEYSYM_CASE_INSENSITIVE flag and two keysym names
> differ only by case, then the lower-case keysym name is returned.  For
> instance, for KEY_a and KEY_A, this function would return KEY_a for the
> case-insensitive search.  If this functionality is needed, it is
> recommended to first call this function without this flag; and if that
> fails, only then to try with this flag, while possibly warning the user
> he had misspelled the name, and might get wrong results.

#### Is it ready for merging, or does it need work?
Yes