### PR TITLE
check value correctly with xkb_state_layout_index_is_active()

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1084,7 +1084,7 @@ std::string switchXKBLayoutRequest(eHyprCtlOutputFormat format, std::string requ
     const auto         LAYOUTS      = xkb_keymap_num_layouts(PWLRKEYBOARD->keymap);
     xkb_layout_index_t activeLayout = 0;
     while (activeLayout < LAYOUTS) {
-        if (xkb_state_layout_index_is_active(PWLRKEYBOARD->xkb_state, activeLayout, XKB_STATE_LAYOUT_EFFECTIVE))
+        if (xkb_state_layout_index_is_active(PWLRKEYBOARD->xkb_state, activeLayout, XKB_STATE_LAYOUT_EFFECTIVE) == 1)
             break;
 
         activeLayout++;

--- a/src/devices/IKeyboard.cpp
+++ b/src/devices/IKeyboard.cpp
@@ -36,7 +36,7 @@ void IKeyboard::updateXKBTranslationState(xkb_keymap* const keymap) {
     const auto PCONTEXT = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
 
     for (uint32_t i = 0; i < LAYOUTSNUM; ++i) {
-        if (xkb_state_layout_index_is_active(STATE, i, XKB_STATE_LAYOUT_EFFECTIVE)) {
+        if (xkb_state_layout_index_is_active(STATE, i, XKB_STATE_LAYOUT_EFFECTIVE) == 1) {
             Debug::log(LOG, "Updating keyboard {:x}'s translation state from an active index {}", (uintptr_t)this, i);
 
             CVarList       keyboardLayouts(currentRules.layout, 0, ',');
@@ -103,7 +103,7 @@ std::string IKeyboard::getActiveLayout() {
     const auto LAYOUTSNUM = xkb_keymap_num_layouts(KEYMAP);
 
     for (uint32_t i = 0; i < LAYOUTSNUM; ++i) {
-        if (xkb_state_layout_index_is_active(STATE, i, XKB_STATE_LAYOUT_EFFECTIVE)) {
+        if (xkb_state_layout_index_is_active(STATE, i, XKB_STATE_LAYOUT_EFFECTIVE) == 1) {
             const auto LAYOUTNAME = xkb_keymap_layout_get_name(KEYMAP, i);
 
             if (LAYOUTNAME)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
fixes
language onevent with error #5923


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
>[xkb_state_layout_index_is_active()](https://xkbcommon.org/doc/current/group__state.html#ga4011df1f305b9167249d8ba217328f6c)
>Test whether a layout is active in a given keyboard state by index.
>
>Returns
>1 if the layout is active, 0 if it is not. **If the layout index is not valid in the keymap, returns -1.**

in cpp `-1` is truthy and Hyprland uses this
```cpp
std::string IKeyboard::getActiveLayout() {
    const auto WLRKB      = wlr();
    const auto KEYMAP     = WLRKB->keymap;
    const auto STATE      = WLRKB->xkb_state;
    const auto LAYOUTSNUM = xkb_keymap_num_layouts(KEYMAP);

    for (uint32_t i = 0; i < LAYOUTSNUM; ++i) {
        if (xkb_state_layout_index_is_active(STATE, i, XKB_STATE_LAYOUT_EFFECTIVE)) {
            const auto LAYOUTNAME = xkb_keymap_layout_get_name(KEYMAP, i);

            if (LAYOUTNAME)
                return std::string(LAYOUTNAME);
            return "error";
        }
    }

    return "none";
}
```

Not sure how it would get an invalid index though

#### Is it ready for merging, or does it need work?
Yes