### PR TITLE
empty on monitor and next empty flags

### DIFF
--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -282,14 +282,15 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
         }
         outName = WORKSPACENAME;
     } else if (in.starts_with("empty")) {
-            const bool same_mon = in.starts_with("emptym");
+            const bool same_mon = in.substr(5).contains("m");
+            const bool next = in.substr(5).contains("n");
             if (same_mon) {
                 if (!g_pCompositor->m_pLastMonitor) {
                     Debug::log(ERR, "Empty monitor workspace on monitor null!");
                     return WORKSPACE_INVALID;
                 }
             }
-            int id = 0;
+            int id = next ? g_pCompositor->m_pLastMonitor->activeWorkspaceID() : 0;
             while (++id < INT_MAX) {
                 const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(id);
                 if (!PWORKSPACE || (g_pCompositor->getWindowsOnWorkspace(id) == 0 && (!same_mon || PWORKSPACE->m_iMonitorID == g_pCompositor->m_pLastMonitor->ID)))

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -282,12 +282,19 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
         }
         outName = WORKSPACENAME;
     } else if (in.starts_with("empty")) {
-        int id = 0;
-        while (++id < INT_MAX) {
-            const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(id);
-            if (!PWORKSPACE || (g_pCompositor->getWindowsOnWorkspace(id) == 0))
-                return id;
-        }
+            const bool same_mon = in.starts_with("emptym");
+            if (same_mon) {
+                if (!g_pCompositor->m_pLastMonitor) {
+                    Debug::log(ERR, "Empty monitor workspace on monitor null!");
+                    return WORKSPACE_INVALID;
+                }
+            }
+            int id = 0;
+            while (++id < INT_MAX) {
+                const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(id);
+                if (!PWORKSPACE || (g_pCompositor->getWindowsOnWorkspace(id) == 0 && (!same_mon || PWORKSPACE->m_iMonitorID == g_pCompositor->m_pLastMonitor->ID)))
+                    return id;
+            }
     } else if (in.starts_with("prev")) {
         if (!g_pCompositor->m_pLastMonitor)
             return WORKSPACE_INVALID;

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -282,20 +282,20 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
         }
         outName = WORKSPACENAME;
     } else if (in.starts_with("empty")) {
-            const bool same_mon = in.substr(5).contains("m");
-            const bool next = in.substr(5).contains("n");
-            if (same_mon) {
-                if (!g_pCompositor->m_pLastMonitor) {
-                    Debug::log(ERR, "Empty monitor workspace on monitor null!");
-                    return WORKSPACE_INVALID;
-                }
+        const bool same_mon = in.substr(5).contains("m");
+        const bool next     = in.substr(5).contains("n");
+        if (same_mon) {
+            if (!g_pCompositor->m_pLastMonitor) {
+                Debug::log(ERR, "Empty monitor workspace on monitor null!");
+                return WORKSPACE_INVALID;
             }
-            int id = next ? g_pCompositor->m_pLastMonitor->activeWorkspaceID() : 0;
-            while (++id < INT_MAX) {
-                const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(id);
-                if (!PWORKSPACE || (g_pCompositor->getWindowsOnWorkspace(id) == 0 && (!same_mon || PWORKSPACE->m_iMonitorID == g_pCompositor->m_pLastMonitor->ID)))
-                    return id;
-            }
+        }
+        int id = next ? g_pCompositor->m_pLastMonitor->activeWorkspaceID() : 0;
+        while (++id < INT_MAX) {
+            const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(id);
+            if (!PWORKSPACE || (g_pCompositor->getWindowsOnWorkspace(id) == 0 && (!same_mon || PWORKSPACE->m_iMonitorID == g_pCompositor->m_pLastMonitor->ID)))
+                return id;
+        }
     } else if (in.starts_with("prev")) {
         if (!g_pCompositor->m_pLastMonitor)
             return WORKSPACE_INVALID;

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -284,7 +284,7 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
     } else if (in.starts_with("empty")) {
         const bool same_mon = in.substr(5).contains("m");
         const bool next     = in.substr(5).contains("n");
-        if (same_mon) {
+        if (same_mon || next) {
             if (!g_pCompositor->m_pLastMonitor) {
                 Debug::log(ERR, "Empty monitor workspace on monitor null!");
                 return WORKSPACE_INVALID;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

add a selector to select the first empty workspace on the monitor. and a flag to only select empty workspaces with a higher id.

flags work by suffix'ing empty
ie.
`emptynm` for next empty on the same monitor
`emptym` for first empty on same monitor

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

so basically, I want this so when I hit my fullscreen bind the current window moves to the next empty workspace on the same monitor, without my program just spamming `r+1` until it finds one.

#### Is it ready for merging, or does it need work?

yes.
