### PR TITLE
Clean environment when exiting

### DIFF
--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -191,6 +191,7 @@ class CCompositor {
   private:
     void     initAllSignals();
     void     removeAllSignals();
+    void     cleanEnvironment();
     void     setRandomSplash();
     void     initManagers(eManagersInitStage stage);
     void     prepareFallbackOutput();

--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -27,7 +27,11 @@ CHyprXWaylandManager::CHyprXWaylandManager() {
 #endif
 }
 
-CHyprXWaylandManager::~CHyprXWaylandManager() {}
+CHyprXWaylandManager::~CHyprXWaylandManager() {
+#ifndef NO_XWAYLAND
+    unsetenv("DISPLAY");
+#endif
+}
 
 wlr_surface* CHyprXWaylandManager::getWindowSurface(PHLWINDOW pWindow) {
     if (pWindow->m_bIsX11)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
fixes
 hyprland doesn't clean up its Wayland sockets after exit #4226 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Whether we should unlink the wayland sockets is debatable.
Technically [`wl_display_destroy()`](https://wayland.freedesktop.org/docs/html/apc.html) should be called to clean up everything wayland.
>This function emits the wl_display destroy signal, **releases all the sockets added to this display**, free's all the globals associated with this display, free's memory of additional shared memory formats and destroy the display object.

I'm not sure why we don't (maybe wlroots manages this?), but when I tried it stalls Hyprland shutdown and just doesn't end up removing the sockets...

#### Is it ready for merging, or does it need work?
`CCompositor::cleanEnvironment` works as expected on my system
but also see above