### PR TITLE
meson: require hyprwayland-scanner >= 0.3.5

### DIFF
--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -17,7 +17,7 @@ wayland_scanner = find_program(
 	wayland_scanner_dep.get_variable('wayland_scanner'),
 	native: true,
 )
-hyprwayland_scanner_dep = dependency('hyprwayland-scanner', native: true)
+hyprwayland_scanner_dep = dependency('hyprwayland-scanner', version: '>=0.3.5', native: true)
 hyprwayland_scanner = find_program(
 	hyprwayland_scanner_dep.get_variable('hyprwayland_scanner'),
 	native: true,


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
hyprwayland-scanner version has been bumped to 0.3.5, cmake build system is present, however the meson build system is not synced

I'm using arch, with AUR, it's default using the meson build system, which I prefer, however the previous installed `hyprwayland-scanner` from AUR is v0.3.4, and the latest version requirement is not synced in `meson.build`, it fails on build process without explicit prompt.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I think it's better to keep only one single build system, and meson is definitely a more modern and tidy build system for developers, maintain duplicate settings for two build system is unnecessary.

#### Is it ready for merging, or does it need work?


