### PR TITLE
socket2: fix events being reordered

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -389,9 +389,6 @@ void CCompositor::cleanup() {
     m_pLastFocus = nullptr;
     m_pLastWindow.reset();
 
-    // end threads
-    g_pEventManager->m_tThread = std::thread();
-
     m_vWorkspaces.clear();
     m_vWindows.clear();
 
@@ -510,7 +507,6 @@ void CCompositor::initManagers(eManagersInitStage stage) {
 
             Debug::log(LOG, "Creating the EventManager!");
             g_pEventManager = std::make_unique<CEventManager>();
-            g_pEventManager->startThread();
 
             Debug::log(LOG, "Creating the HyprDebugOverlay!");
             g_pDebugOverlay = std::make_unique<CHyprDebugOverlay>();

--- a/src/managers/EventManager.cpp
+++ b/src/managers/EventManager.cpp
@@ -36,7 +36,7 @@ CEventManager::CEventManager() {
         return;
     }
 
-    m_pEventSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, m_iSocketFD, WL_EVENT_READABLE, onClientEvent, this);
+    m_pEventSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, m_iSocketFD, WL_EVENT_READABLE, onClientEvent, nullptr);
 }
 
 CEventManager::~CEventManager() {
@@ -53,13 +53,11 @@ CEventManager::~CEventManager() {
 }
 
 int CEventManager::onServerEvent(int fd, uint32_t mask, void* data) {
-    auto* const PEVMGR = (CEventManager*)data;
-    return PEVMGR->onClientEvent(fd, mask);
+    return g_pEventManager->onClientEvent(fd, mask);
 }
 
 int CEventManager::onClientEvent(int fd, uint32_t mask, void* data) {
-    auto* const PEVMGR = (CEventManager*)data;
-    return PEVMGR->onServerEvent(fd, mask);
+    return g_pEventManager->onServerEvent(fd, mask);
 }
 
 int CEventManager::onServerEvent(int fd, uint32_t mask) {
@@ -92,7 +90,7 @@ int CEventManager::onServerEvent(int fd, uint32_t mask) {
     Debug::log(LOG, "Socket2 accepted a new client at FD {}", ACCEPTEDCONNECTION);
 
     // add to event loop so we can close it when we need to
-    auto* eventSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, ACCEPTEDCONNECTION, 0, onServerEvent, this);
+    auto* eventSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, ACCEPTEDCONNECTION, 0, onServerEvent, nullptr);
     m_vClients.emplace_back(SClient{
         ACCEPTEDCONNECTION,
         {},

--- a/src/managers/EventManager.cpp
+++ b/src/managers/EventManager.cpp
@@ -1,154 +1,184 @@
 #include "EventManager.hpp"
 #include "../Compositor.hpp"
 
-#include <errno.h>
-#include <fcntl.h>
 #include <netinet/in.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/un.h>
 #include <unistd.h>
-#include <sys/ioctl.h>
 
-#include <string>
-#include <algorithm>
-
-CEventManager::CEventManager() {}
-
-int fdHandleWrite(int fd, uint32_t mask, void* data) {
-    const auto PEVMGR = (CEventManager*)data;
-    return PEVMGR->onFDWrite(fd, mask);
-}
-
-int socket2HandleWrite(int fd, uint32_t mask, void* data) {
-    const auto PEVMGR = (CEventManager*)data;
-    return PEVMGR->onSocket2Write(fd, mask);
-}
-
-void CEventManager::startThread() {
-
-    m_iSocketFD = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
-
+CEventManager::CEventManager() {
+    m_iSocketFD = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0);
     if (m_iSocketFD < 0) {
         Debug::log(ERR, "Couldn't start the Hyprland Socket 2. (1) IPC will not work.");
         return;
     }
 
     sockaddr_un SERVERADDRESS = {.sun_family = AF_UNIX};
-    std::string socketPath    = g_pCompositor->m_szInstancePath + "/.socket2.sock";
-    strncpy(SERVERADDRESS.sun_path, socketPath.c_str(), sizeof(SERVERADDRESS.sun_path) - 1);
+    const auto  PATH          = g_pCompositor->m_szInstancePath + "/.socket2.sock";
+    if (PATH.length() > sizeof(SERVERADDRESS.sun_path) - 1) {
+        Debug::log(ERR, "Socket2 path is too long. (2) IPC will not work.");
+        return;
+    }
 
-    bind(m_iSocketFD, (sockaddr*)&SERVERADDRESS, SUN_LEN(&SERVERADDRESS));
+    strncpy(SERVERADDRESS.sun_path, PATH.c_str(), sizeof(SERVERADDRESS.sun_path) - 1);
+
+    if (bind(m_iSocketFD, (sockaddr*)&SERVERADDRESS, SUN_LEN(&SERVERADDRESS)) < 0) {
+        Debug::log(ERR, "Couldn't bind the Hyprland Socket 2. (3) IPC will not work.");
+        return;
+    }
 
     // 10 max queued.
-    listen(m_iSocketFD, 10);
+    if (listen(m_iSocketFD, 10) < 0) {
+        Debug::log(ERR, "Couldn't listen on the Hyprland Socket 2. (4) IPC will not work.");
+        return;
+    }
 
-    m_pEventSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, m_iSocketFD, WL_EVENT_READABLE, socket2HandleWrite, this);
+    m_pEventSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, m_iSocketFD, WL_EVENT_READABLE, onClientEvent, this);
 }
 
-int CEventManager::onSocket2Write(int fd, uint32_t mask) {
+CEventManager::~CEventManager() {
+    for (const auto& [fd, client] : m_mClients) {
+        wl_event_source_remove(client.eventSource);
+        close(fd);
+    }
 
+    if (m_pEventSource != nullptr)
+        wl_event_source_remove(m_pEventSource);
+
+    if (m_iSocketFD >= 0)
+        close(m_iSocketFD);
+}
+
+int CEventManager::onServerEvent(int fd, uint32_t mask, void* data) {
+    auto* const PEVMGR = (CEventManager*)data;
+    return PEVMGR->onClientEvent(fd, mask);
+}
+
+int CEventManager::onClientEvent(int fd, uint32_t mask, void* data) {
+    auto* const PEVMGR = (CEventManager*)data;
+    return PEVMGR->onServerEvent(fd, mask);
+}
+
+int CEventManager::onServerEvent(int fd, uint32_t mask) {
     if (mask & WL_EVENT_ERROR || mask & WL_EVENT_HANGUP) {
         Debug::log(ERR, "Socket2 hangup?? IPC broke");
+
         wl_event_source_remove(m_pEventSource);
+        m_pEventSource = nullptr;
         close(fd);
+        m_iSocketFD = -1;
+
         return 0;
     }
 
     sockaddr_in clientAddress;
     socklen_t   clientSize         = sizeof(clientAddress);
     const auto  ACCEPTEDCONNECTION = accept4(m_iSocketFD, (sockaddr*)&clientAddress, &clientSize, SOCK_CLOEXEC | SOCK_NONBLOCK);
-
-    if (ACCEPTEDCONNECTION > 0) {
-        Debug::log(LOG, "Socket2 accepted a new client at FD {}", ACCEPTEDCONNECTION);
-
-        // add to event loop so we can close it when we need to
-        m_dAcceptedSocketFDs.push_back(
-            std::make_pair<>(ACCEPTEDCONNECTION, wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, ACCEPTEDCONNECTION, WL_EVENT_READABLE, fdHandleWrite, this)));
-    } else {
+    if (ACCEPTEDCONNECTION < 0) {
         Debug::log(ERR, "Socket2 failed receiving connection, errno: {}", errno);
+        wl_event_source_remove(m_pEventSource);
         close(fd);
+        return 0;
     }
+
+    Debug::log(LOG, "Socket2 accepted a new client at FD {}", ACCEPTEDCONNECTION);
+
+    // add to event loop so we can close it when we need to
+    auto* eventSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, ACCEPTEDCONNECTION, WL_EVENT_READABLE, onServerEvent, this);
+    m_mClients.emplace(ACCEPTEDCONNECTION,
+                       SClient{
+                           {},
+                           eventSource,
+                       });
 
     return 0;
 }
 
-int CEventManager::onFDWrite(int fd, uint32_t mask) {
-    auto removeFD = [this](int fd) -> void {
-        for (auto it = m_dAcceptedSocketFDs.begin(); it != m_dAcceptedSocketFDs.end();) {
-            if (it->first == fd) {
-                wl_event_source_remove(it->second); // remove this fd listener
-                it = m_dAcceptedSocketFDs.erase(it);
-            } else {
-                it++;
-            }
-        }
-
-        close(fd);
-    };
-
+int CEventManager::onClientEvent(int fd, uint32_t mask) {
     if (mask & WL_EVENT_ERROR || mask & WL_EVENT_HANGUP) {
-        // remove, hanged up
-        removeFD(fd);
+        Debug::log(LOG, "Socket2 fd {} hung up", fd);
+        removeClientByFD(fd);
         return 0;
     }
 
-    int availableBytes;
-    if (ioctl(fd, FIONREAD, &availableBytes) == -1) {
-        Debug::log(ERR, "fd {} sent invalid data (1)", fd);
-        removeFD(fd);
-        return 0;
+    if (mask & WL_EVENT_READABLE) {
+        char       buf[1024];
+        const auto RECEIVED = recv(fd, buf, sizeof(buf), 0);
+        if (RECEIVED < 0) {
+            Debug::log(ERR, "Socket2 fd {} sent invalid data", fd);
+            removeClientByFD(fd);
+            return 0;
+        }
     }
 
-    char       buf[availableBytes];
-    const auto RECEIVED = recv(fd, buf, availableBytes, 0);
-    if (RECEIVED == -1) {
-        Debug::log(ERR, "fd {} sent invalid data (2)", fd);
-        removeFD(fd);
-        return 0;
+    if (mask & WL_EVENT_WRITABLE) {
+        const auto IT = m_mClients.find(fd);
+
+        // send all queued events
+        const auto& FD     = IT->first;
+        auto&       client = IT->second;
+        while (!client.events.empty()) {
+            const auto& event = client.events.front();
+            if (write(FD, event->c_str(), event->length()) < 0)
+                break;
+
+            client.events.pop_front();
+        }
+
+        // stop polling when we sent all events
+        if (client.events.empty())
+            wl_event_source_fd_update(client.eventSource, WL_EVENT_READABLE);
     }
 
     return 0;
 }
 
-void CEventManager::flushEvents() {
-    eventQueueMutex.lock();
+std::unordered_map<int, CEventManager::SClient>::iterator CEventManager::removeClientByFD(int fd) {
+    const auto IT = m_mClients.find(fd);
+    wl_event_source_remove(IT->second.eventSource);
+    close(fd);
 
-    for (auto& ev : m_dQueuedEvents) {
-        std::string eventString = (ev.event + ">>" + ev.data).substr(0, 1022) + "\n";
-        for (auto& fd : m_dAcceptedSocketFDs) {
-            try {
-                write(fd.first, eventString.c_str(), eventString.length());
-            } catch (...) {}
-        }
-    }
-
-    m_dQueuedEvents.clear();
-
-    eventQueueMutex.unlock();
+    return m_mClients.erase(IT);
 }
 
-void CEventManager::postEvent(const SHyprIPCEvent event) {
+std::string CEventManager::formatEvent(const SHyprIPCEvent& event) const {
+    std::string_view data        = event.data;
+    auto             eventString = std::format("{}>>{}\n", event.event, data.substr(0, 1024));
+    std::replace(eventString.begin() + event.event.length() + 2, eventString.end() - 1, '\n', ' ');
+    return eventString;
+}
 
+void CEventManager::postEvent(const SHyprIPCEvent& event) {
     if (g_pCompositor->m_bIsShuttingDown) {
-        Debug::log(WARN, "Suppressed (ignoreevents true / shutting down) event of type {}, content: {}", event.event, event.data);
+        Debug::log(WARN, "Suppressed (shutting down) event of type {}, content: {}", event.event, event.data);
         return;
     }
 
-    std::thread(
-        [this](SHyprIPCEvent ev) {
-            std::replace(ev.data.begin(), ev.data.end(), '\n', ' ');
+    const size_t MAX_QUEUED_EVENTS = 64;
+    auto         sharedEvent       = makeShared<std::string>(formatEvent(event));
+    for (auto it = m_mClients.begin(); it != m_mClients.end();) {
+        const auto FD     = it->first;
+        auto&      client = it->second;
 
-            eventQueueMutex.lock();
-            m_dQueuedEvents.push_back(ev);
-            eventQueueMutex.unlock();
+        // try to send the event immediately
+        if (write(FD, sharedEvent->c_str(), sharedEvent->length()) < 0) {
+            const auto QUEUESIZE = client.events.size();
+            if (QUEUESIZE >= MAX_QUEUED_EVENTS) {
+                // too many events queued, remove the client
+                it = removeClientByFD(FD);
+                continue;
+            }
 
-            flushEvents();
-        },
-        event)
-        .detach();
+            // queue it to send later if failed
+            client.events.push_back(sharedEvent);
+
+            // poll for write if queue was empty
+            if (QUEUESIZE == 0)
+                wl_event_source_fd_update(client.eventSource, WL_EVENT_READABLE | WL_EVENT_WRITABLE);
+        }
+
+        ++it;
+    }
 }

--- a/src/managers/EventManager.cpp
+++ b/src/managers/EventManager.cpp
@@ -152,9 +152,9 @@ void CEventManager::postEvent(const SHyprIPCEvent& event) {
     const size_t MAX_QUEUED_EVENTS = 64;
     auto         sharedEvent       = makeShared<std::string>(formatEvent(event));
     for (auto it = m_vClients.begin(); it != m_vClients.end();) {
-        // try to send the event immediately
-        if (write(it->fd, sharedEvent->c_str(), sharedEvent->length()) < 0) {
-            const auto QUEUESIZE = it->events.size();
+        // try to send the event immediately if the queue is empty
+        const auto QUEUESIZE = it->events.size();
+        if (QUEUESIZE > 0 || write(it->fd, sharedEvent->c_str(), sharedEvent->length()) < 0) {
             if (QUEUESIZE >= MAX_QUEUED_EVENTS) {
                 // too many events queued, remove the client
                 Debug::log(ERR, "Socket2 fd {} overflowed event queue, removing", it->fd);

--- a/src/managers/EventManager.cpp
+++ b/src/managers/EventManager.cpp
@@ -78,9 +78,14 @@ int CEventManager::onServerEvent(int fd, uint32_t mask) {
     socklen_t   clientSize         = sizeof(clientAddress);
     const auto  ACCEPTEDCONNECTION = accept4(m_iSocketFD, (sockaddr*)&clientAddress, &clientSize, SOCK_CLOEXEC | SOCK_NONBLOCK);
     if (ACCEPTEDCONNECTION < 0) {
-        Debug::log(ERR, "Socket2 failed receiving connection, errno: {}", errno);
-        wl_event_source_remove(m_pEventSource);
-        close(fd);
+        if (errno != EAGAIN) {
+            Debug::log(ERR, "Socket2 failed receiving connection, errno: {}", errno);
+            wl_event_source_remove(m_pEventSource);
+            m_pEventSource = nullptr;
+            close(fd);
+            m_iSocketFD = -1;
+        }
+
         return 0;
     }
 

--- a/src/managers/EventManager.cpp
+++ b/src/managers/EventManager.cpp
@@ -157,6 +157,7 @@ void CEventManager::postEvent(const SHyprIPCEvent& event) {
             const auto QUEUESIZE = client.events.size();
             if (QUEUESIZE >= MAX_QUEUED_EVENTS) {
                 // too many events queued, remove the client
+                Debug::log(ERR, "Socket2 fd {} overflowed event queue, removing", FD);
                 it = removeClientByFD(FD);
                 continue;
             }

--- a/src/managers/EventManager.hpp
+++ b/src/managers/EventManager.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include <deque>
-#include <unordered_map>
+#include <vector>
 
 #include "../defines.hpp"
 #include "../helpers/memory/SharedPtr.hpp"
@@ -27,17 +27,19 @@ class CEventManager {
     int         onClientEvent(int fd, uint32_t mask);
 
     struct SClient {
+        int                         fd = -1;
         std::deque<SP<std::string>> events;
         wl_event_source*            eventSource = nullptr;
     };
 
-    std::unordered_map<int, SClient>::iterator removeClientByFD(int fd);
+    std::vector<SClient>::iterator findClientByFD(int fd);
+    std::vector<SClient>::iterator removeClientByFD(int fd);
 
   private:
-    int                              m_iSocketFD    = -1;
-    wl_event_source*                 m_pEventSource = nullptr;
+    int                  m_iSocketFD    = -1;
+    wl_event_source*     m_pEventSource = nullptr;
 
-    std::unordered_map<int, SClient> m_mClients;
+    std::vector<SClient> m_vClients;
 };
 
 inline std::unique_ptr<CEventManager> g_pEventManager;

--- a/src/managers/EventManager.hpp
+++ b/src/managers/EventManager.hpp
@@ -1,10 +1,9 @@
 #pragma once
 #include <deque>
-#include <fstream>
-#include <mutex>
+#include <unordered_map>
 
 #include "../defines.hpp"
-#include "../helpers/MiscFunctions.hpp"
+#include "../helpers/memory/SharedPtr.hpp"
 
 struct SHyprIPCEvent {
     std::string event;
@@ -14,27 +13,31 @@ struct SHyprIPCEvent {
 class CEventManager {
   public:
     CEventManager();
+    ~CEventManager();
 
-    void        postEvent(const SHyprIPCEvent event);
-
-    void        startThread();
-
-    std::thread m_tThread;
-
-    int         m_iSocketFD = -1;
-
-    int         onSocket2Write(int fd, uint32_t mask);
-    int         onFDWrite(int fd, uint32_t mask);
+    void postEvent(const SHyprIPCEvent& event);
 
   private:
-    void                                         flushEvents();
+    std::string formatEvent(const SHyprIPCEvent& event) const;
 
-    std::mutex                                   eventQueueMutex;
-    std::deque<SHyprIPCEvent>                    m_dQueuedEvents;
+    static int  onServerEvent(int fd, uint32_t mask, void* data);
+    static int  onClientEvent(int fd, uint32_t mask, void* data);
 
-    std::deque<std::pair<int, wl_event_source*>> m_dAcceptedSocketFDs;
+    int         onServerEvent(int fd, uint32_t mask);
+    int         onClientEvent(int fd, uint32_t mask);
 
-    wl_event_source*                             m_pEventSource = nullptr;
+    struct SClient {
+        std::deque<SP<std::string>> events;
+        wl_event_source*            eventSource;
+    };
+
+    std::unordered_map<int, SClient>::iterator removeClientByFD(int fd);
+
+  private:
+    int                              m_iSocketFD    = -1;
+    wl_event_source*                 m_pEventSource = nullptr;
+
+    std::unordered_map<int, SClient> m_mClients;
 };
 
 inline std::unique_ptr<CEventManager> g_pEventManager;

--- a/src/managers/EventManager.hpp
+++ b/src/managers/EventManager.hpp
@@ -28,7 +28,7 @@ class CEventManager {
 
     struct SClient {
         std::deque<SP<std::string>> events;
-        wl_event_source*            eventSource;
+        wl_event_source*            eventSource = nullptr;
     };
 
     std::unordered_map<int, SClient>::iterator removeClientByFD(int fd);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
fixes socket2 events being reordered due to std::thread racing with other threads in `postEvent` while pushing multiple events.
drops connections that have too many (64) queued events

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
ready