### PR TITLE
Fix classic global keybinds(pass dispatcher)

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1964,7 +1964,7 @@ void CKeybindManager::pass(std::string regexp) {
     }
 
     if (g_pKeybindManager->m_uLastCode != 0)
-        wlr_seat_keyboard_enter(g_pCompositor->m_sSeat.seat, PLASTSRF, KEYBOARD->keycodes, KEYBOARD->num_keycodes, &KEYBOARD->modifiers);
+        wlr_seat_keyboard_enter(g_pCompositor->m_sSeat.seat, PWINDOW->m_pWLSurface.wlr(), KEYBOARD->keycodes, KEYBOARD->num_keycodes, &KEYBOARD->modifiers);
     else
         wlr_seat_pointer_enter(g_pCompositor->m_sSeat.seat, PWINDOW->m_pWLSurface.wlr(), SL.x, SL.y);
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Sometimes something like this `bind = CONTROL,grave,pass,^(discord)$` doesn't work. After fixing it always works.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No problems found in 2 days of active use.

#### Is it ready for merging, or does it need work?

Perhaps you can remove the PLASTRF variable in CKeybindManager::pass(std::string regexp).