### PR TITLE
add focusonactivate window rule

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1997,8 +1997,8 @@ bool windowRuleValid(const std::string& RULE) {
         RULE.starts_with("maxsize") || RULE.starts_with("pseudo") || RULE.starts_with("monitor") || RULE.starts_with("idleinhibit") || RULE == "nofocus" || RULE == "noblur" ||
         RULE == "noshadow" || RULE == "nodim" || RULE == "noborder" || RULE == "opaque" || RULE == "forceinput" || RULE == "fullscreen" || RULE == "fakefullscreen" ||
         RULE == "nomaxsize" || RULE == "pin" || RULE == "noanim" || RULE == "dimaround" || RULE == "windowdance" || RULE == "maximize" || RULE == "keepaspectratio" ||
-        RULE.starts_with("animation") || RULE.starts_with("rounding") || RULE.starts_with("workspace") || RULE.starts_with("bordercolor") || RULE == "forcergbx" ||
-        RULE == "noinitialfocus" || RULE == "stayfocused" || RULE.starts_with("bordersize") || RULE.starts_with("xray") || RULE.starts_with("center") ||
+        RULE == "focusonactivate" || RULE.starts_with("animation") || RULE.starts_with("rounding") || RULE.starts_with("workspace") || RULE.starts_with("bordercolor") ||
+        RULE == "forcergbx" || RULE == "noinitialfocus" || RULE == "stayfocused" || RULE.starts_with("bordersize") || RULE.starts_with("xray") || RULE.starts_with("center") ||
         RULE.starts_with("group") || RULE == "immediate" || RULE == "nearestneighbor" || RULE.starts_with("suppressevent") || RULE.starts_with("plugin:");
 }
 

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -671,6 +671,8 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
         m_sAdditionalConfigData.dimAround = true;
     } else if (r.szRule == "keepaspectratio") {
         m_sAdditionalConfigData.keepAspectRatio = true;
+    } else if (r.szRule.starts_with("focusonactivate")) {
+        m_sAdditionalConfigData.focusOnActivate = true;
     } else if (r.szRule.starts_with("xray")) {
         CVarList vars(r.szRule, 0, ' ');
 
@@ -745,6 +747,7 @@ void CWindow::updateDynamicRules() {
     m_sAdditionalConfigData.forceRGBX       = false;
     m_sAdditionalConfigData.borderSize      = -1;
     m_sAdditionalConfigData.keepAspectRatio = false;
+    m_sAdditionalConfigData.focusOnActivate = false;
     m_sAdditionalConfigData.xray            = -1;
     m_sAdditionalConfigData.forceTearing    = false;
     m_sAdditionalConfigData.nearestNeighbor = false;
@@ -1282,7 +1285,8 @@ void CWindow::activate(bool force) {
 
     m_bIsUrgent = true;
 
-    if (!force && (!*PFOCUSONACTIVATE || (m_eSuppressedEvents & SUPPRESS_ACTIVATE_FOCUSONLY) || (m_eSuppressedEvents & SUPPRESS_ACTIVATE)))
+    if (!force &&
+        (!(*PFOCUSONACTIVATE || m_sAdditionalConfigData.focusOnActivate) || (m_eSuppressedEvents & SUPPRESS_ACTIVATE_FOCUSONLY) || (m_eSuppressedEvents & SUPPRESS_ACTIVATE)))
         return;
 
     if (m_bIsFloating)

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -164,6 +164,7 @@ struct SWindowAdditionalConfigData {
     CWindowOverridableVar<bool>     dimAround             = false;
     CWindowOverridableVar<bool>     forceRGBX             = false;
     CWindowOverridableVar<bool>     keepAspectRatio       = false;
+    CWindowOverridableVar<bool>     focusOnActivate       = false;
     CWindowOverridableVar<int>      xray                  = -1; // -1 means unset, takes precedence over the renderdata one
     CWindowOverridableVar<int>      borderSize            = -1; // -1 means unset, takes precedence over the renderdata one
     CWindowOverridableVar<bool>     forceTearing          = false;


### PR DESCRIPTION
adds `focusonactivate` window rule to allow finer control than the global variable
maybe the variable could be removed

https://github.com/hyprwm/hyprland-wiki/pull/643
