### PR TITLE
Build: fix include dirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,17 +46,17 @@ pluginenv:
 installheaders:
 	@if [ ! -f ./src/version.h ]; then echo -en "You need to run $(MAKE) all first.\n" && exit 1; fi
 
+	# remove previous headers from hyprpm's dir
 	rm -fr ${PREFIX}/include/hyprland
 	mkdir -p ${PREFIX}/include/hyprland
 	mkdir -p ${PREFIX}/include/hyprland/protocols
-	mkdir -p ${PREFIX}/include/hyprland/wlroots-hyprland
+	mkdir -p ${PREFIX}/include/hyprland/wlr
 	mkdir -p ${PREFIX}/share/pkgconfig
 
 	find src -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland
-	cd subprojects/wlroots-hyprland/include && find . -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland/wlroots-hyprland && cd ../../..
-	cd subprojects/wlroots-hyprland/build/include && find . -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland/wlroots-hyprland && cd ../../../..
-	cp ./protocols/*.h ${PREFIX}/include/hyprland/protocols
-	cp ./protocols/*.hpp ${PREFIX}/include/hyprland/protocols
+	cd subprojects/wlroots-hyprland/include && find . -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland/wlr && cd ../../..
+	cd subprojects/wlroots-hyprland/build/include && find . -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland/wlr && cd ../../../..
+	cp ./protocols/*.h* ${PREFIX}/include/hyprland/protocols
 	cp ./build/hyprland.pc ${PREFIX}/share/pkgconfig
 	if [ -d /usr/share/pkgconfig ]; then cp ./build/hyprland.pc /usr/share/pkgconfig 2>/dev/null || true; fi
 

--- a/hyprland.pc.in
+++ b/hyprland.pc.in
@@ -4,4 +4,4 @@ Name: Hyprland
 URL: https://github.com/hyprwm/Hyprland
 Description: Hyprland header files
 Version: @HYPRLAND_VERSION@
-Cflags: -I${prefix} -I${prefix}/hyprland/protocols -I${prefix}/hyprland -I${prefix}/hyprland/wlroots-hyprland
+Cflags: -I${prefix} -I${prefix}/hyprland/protocols -I${prefix}/hyprland -I${prefix}/hyprland/wlr

--- a/hyprpm/src/core/PluginManager.cpp
+++ b/hyprpm/src/core/PluginManager.cpp
@@ -442,14 +442,18 @@ bool CPluginManager::updateHeaders(bool force) {
 
     progress.printMessageAbove(std::string{Colors::YELLOW} + "!" + Colors::RESET + " Cloning https://github.com/hyprwm/hyprland, this might take a moment.");
 
+    const bool bShallow = HLVER.branch == "main" || HLVER.branch == "";
+
     // let us give a bit of leg-room for shallowing
     // due to timezones, etc.
-    const std::string SHALLOW_DATE = removeBeginEndSpacesTabs(HLVER.date).empty() ? "" : execAndGet("LC_TIME=\"en_US.UTF-8\" date --date='" + HLVER.date + " - 1 weeks' '+\%a \%b \%d \%H:\%M:\%S \%Y'");
+    const std::string SHALLOW_DATE =
+        removeBeginEndSpacesTabs(HLVER.date).empty() ? "" : execAndGet("LC_TIME=\"en_US.UTF-8\" date --date='" + HLVER.date + " - 1 weeks' '+\%a \%b \%d \%H:\%M:\%S \%Y'");
 
-    if (m_bVerbose)
+    if (m_bVerbose && bShallow)
         progress.printMessageAbove(std::string{Colors::BLUE} + "[v] " + Colors::RESET + "will shallow since: " + SHALLOW_DATE);
 
-    std::string ret = execAndGet("cd /tmp/hyprpm && git clone --recursive https://github.com/hyprwm/hyprland hyprland-" + USERNAME + " --shallow-since='" + SHALLOW_DATE + "'");
+    std::string ret =
+        execAndGet("cd /tmp/hyprpm && git clone --recursive https://github.com/hyprwm/hyprland hyprland-" + USERNAME + (bShallow ? " --shallow-since='" + SHALLOW_DATE + "'" : ""));
 
     if (!std::filesystem::exists(WORKINGDIR)) {
         progress.printMessageAbove(std::string{Colors::RED} + "✖" + Colors::RESET + " Clone failed. Retrying without shallow.");

--- a/meson.build
+++ b/meson.build
@@ -89,5 +89,5 @@ import('pkgconfig').generate(
   url: 'https://github.com/hyprwm/Hyprland',
   description: 'Hyprland header files',
   install_dir: pkg_install_dir,
-  subdirs: ['', 'hyprland/protocols', 'hyprland/wlroots'],
+  subdirs: ['', 'hyprland/protocols', 'hyprland', 'hyprland/wlr'],
 )

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -70,6 +70,9 @@ assert lib.assertMsg (!hidpiXWayland) "The option `hidpiXWayland` has been remov
     postPatch = ''
       # Fix hardcoded paths to /usr installation
       sed -i "s#/usr#$out#" src/render/OpenGL.cpp
+
+      # Remove extra @PREFIX@ to fix pkg-config paths
+      sed -i "s#@PREFIX@/##g" hyprland.pc.in
     '';
 
     DATE = date;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

- Nix: fix pkgconfig prefix to point to the right include dir
- pkg-config: fix wlroots dir, so that plugins can build again
- Meson: fix Cflags, to be on par with the CMake build

After we merge this PR, we can cut a new release so that https://github.com/NixOS/nixpkgs/pull/309075 can be updated.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Tested only by me. Please test it.

#### Is it ready for merging, or does it need work?

Needs a wlr bump.
