### PR TITLE
compositor: fix getMonitorFromVector returning wrong monitor

### DIFF
--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -35,7 +35,7 @@
 #define DYNLISTENER(name)      CHyprWLListener hyprListener_##name
 #define DYNMULTILISTENER(name) wl_listener listen_##name
 
-#define VECINRECT(vec, x1, y1, x2, y2) ((vec).x >= (x1) && (vec).x <= (x2) && (vec).y >= (y1) && (vec).y <= (y2))
+#define VECINRECT(vec, x1, y1, x2, y2) ((vec).x >= (x1) && (vec).x < (x2) && (vec).y >= (y1) && (vec).y < (y2))
 
 #define DELTALESSTHAN(a, b, delta) (abs((a) - (b)) < (delta))
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes #5977
Related #5973 (This fixes my issues with firefox, but not sure if the OP's issue is same as mine)

When the second monitor is placed right next to the main monitor, `getMonitorFromVector()` will return the main monitor when it is supplied with the pos of the top left corner of the second monitor.

For example,
main monitor pos: 0x0, size: 1920x1080
second monitor pos:1920x0, size 1920x1080

In this case when you try to get the monitor with a vector (1920, 0)(e.g. fullscreened firefox, layershell anchored to top left), it will get the main monitor instead of the second monitor.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I don't know if changing the VECINRECT macro like this would break other parts of the code that uses this macro.

#### Is it ready for merging, or does it need work?
Ready if this change isn't a wrong approach

