### PR TITLE
keybinds: fix release binds in submaps

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -386,8 +386,7 @@ bool CKeybindManager::onKeyEvent(std::any event, SP<IKeyboard> pKeyboard) {
         bool foundInPressedKeys = false;
         for (auto it = m_dPressedKeys.begin(); it != m_dPressedKeys.end();) {
             if (it->keycode == KEYCODE) {
-                if (it->submapAtPress == m_szCurrentSelectedSubmap)
-                    handleKeybinds(MODS, *it, false);
+                handleKeybinds(MODS, *it, false);
                 foundInPressedKeys = true;
                 suppressEvent      = !it->sent;
                 it                 = m_dPressedKeys.erase(it);
@@ -570,7 +569,7 @@ bool CKeybindManager::handleKeybinds(const uint32_t modmask, const SPressedKeyWi
             if (key.keycode != k.keycode)
                 continue;
         } else if (k.catchAll) {
-            if (found)
+            if (found || key.submapAtPress != m_szCurrentSelectedSubmap)
                 continue;
         } else {
             // oMg such performance hit!!11!


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes #5292. Was a regression caused by https://github.com/hyprwm/Hyprland/commit/300d77edd9833db42c999a91271ae23a5be69ef2. I just moved the submapAtPress check so it only applies to catchall binds.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
ready

