### PR TITLE
Fix: `on-created-empty` runs even if workspace is not created empty

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2492,7 +2492,7 @@ void CCompositor::forceReportSizesToWindowsOnWorkspace(const int& wid) {
     }
 }
 
-PHLWORKSPACE CCompositor::createNewWorkspace(const int& id, const int& monid, const std::string& name) {
+PHLWORKSPACE CCompositor::createNewWorkspace(const int& id, const int& monid, const std::string& name, bool isEmtpy) {
     const auto NAME  = name == "" ? std::to_string(id) : name;
     auto       monID = monid;
 
@@ -2503,7 +2503,7 @@ PHLWORKSPACE CCompositor::createNewWorkspace(const int& id, const int& monid, co
 
     const bool SPECIAL = id >= SPECIAL_WORKSPACE_START && id <= -2;
 
-    const auto PWORKSPACE = m_vWorkspaces.emplace_back(CWorkspace::create(id, monID, NAME, SPECIAL));
+    const auto PWORKSPACE = m_vWorkspaces.emplace_back(CWorkspace::create(id, monID, NAME, SPECIAL, isEmtpy));
 
     PWORKSPACE->m_fAlpha.setValueAndWarp(0);
 

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -164,7 +164,7 @@ class CCompositor {
     void         closeWindow(PHLWINDOW);
     Vector2D     parseWindowVectorArgsRelative(const std::string&, const Vector2D&);
     void         forceReportSizesToWindowsOnWorkspace(const int&);
-    PHLWORKSPACE createNewWorkspace(const int&, const int&, const std::string& name = ""); // will be deleted next frame if left empty and unfocused!
+    PHLWORKSPACE createNewWorkspace(const int&, const int&, const std::string& name = "", bool isEmtpy = true); // will be deleted next frame if left empty and unfocused!
     void         renameWorkspace(const int&, const std::string& name = "");
     void         setActiveMonitor(CMonitor*);
     bool         isWorkspaceSpecial(const int&);

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -2,17 +2,18 @@
 #include "../Compositor.hpp"
 #include "../config/ConfigValue.hpp"
 
-PHLWORKSPACE CWorkspace::create(int id, int monitorID, std::string name, bool special) {
-    PHLWORKSPACE workspace = makeShared<CWorkspace>(id, monitorID, name, special);
+PHLWORKSPACE CWorkspace::create(int id, int monitorID, std::string name, bool special, bool isEmtpy) {
+    PHLWORKSPACE workspace = makeShared<CWorkspace>(id, monitorID, name, special, isEmtpy);
     workspace->init(workspace);
     return workspace;
 }
 
-CWorkspace::CWorkspace(int id, int monitorID, std::string name, bool special) {
+CWorkspace::CWorkspace(int id, int monitorID, std::string name, bool special, bool isEmtpy) {
     m_iMonitorID          = monitorID;
     m_iID                 = id;
     m_szName              = name;
     m_bIsSpecialWorkspace = special;
+    m_bWasCreatedEmtpy    = isEmtpy;
 }
 
 void CWorkspace::init(PHLWORKSPACE self) {
@@ -44,8 +45,9 @@ void CWorkspace::init(PHLWORKSPACE self) {
     const auto WORKSPACERULE = g_pConfigManager->getWorkspaceRuleFor(self);
     m_bPersistent            = WORKSPACERULE.isPersistent;
 
-    if (auto cmd = WORKSPACERULE.onCreatedEmptyRunCmd)
-        g_pKeybindManager->spawn(*cmd);
+    if (self->m_bWasCreatedEmtpy)
+        if (auto cmd = WORKSPACERULE.onCreatedEmptyRunCmd)
+            g_pKeybindManager->spawn(*cmd);
 
     g_pEventManager->postEvent({"createworkspace", m_szName});
     g_pEventManager->postEvent({"createworkspacev2", std::format("{},{}", m_iID, m_szName)});

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -15,9 +15,9 @@ class CWindow;
 
 class CWorkspace {
   public:
-    static PHLWORKSPACE create(int id, int monitorID, std::string name, bool special = false);
+    static PHLWORKSPACE create(int id, int monitorID, std::string name, bool special = false, bool isEmtpy = true);
     // use create() don't use this
-    CWorkspace(int id, int monitorID, std::string name, bool special = false);
+    CWorkspace(int id, int monitorID, std::string name, bool special = false, bool isEmpty = true);
     ~CWorkspace();
 
     // Workspaces ID-based have IDs > 0
@@ -57,6 +57,8 @@ class CWorkspace {
 
     // last monitor (used on reconnect)
     std::string m_szLastMonitor = "";
+
+    bool        m_bWasCreatedEmtpy = true;
 
     bool        m_bPersistent = false;
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1103,7 +1103,7 @@ void CKeybindManager::moveActiveToWorkspace(std::string args) {
         pMonitor = g_pCompositor->getMonitorFromID(pWorkspace->m_iMonitorID);
         g_pCompositor->setActiveMonitor(pMonitor);
     } else {
-        pWorkspace = g_pCompositor->createNewWorkspace(WORKSPACEID, PWINDOW->m_iMonitorID, workspaceName);
+        pWorkspace = g_pCompositor->createNewWorkspace(WORKSPACEID, PWINDOW->m_iMonitorID, workspaceName, false);
         pMonitor   = g_pCompositor->getMonitorFromID(pWorkspace->m_iMonitorID);
         g_pCompositor->moveWindowToWorkspaceSafe(PWINDOW, pWorkspace);
     }
@@ -1159,7 +1159,7 @@ void CKeybindManager::moveActiveToWorkspaceSilent(std::string args) {
     if (pWorkspace) {
         g_pCompositor->moveWindowToWorkspaceSafe(PWINDOW, pWorkspace);
     } else {
-        pWorkspace = g_pCompositor->createNewWorkspace(WORKSPACEID, PWINDOW->m_iMonitorID, workspaceName);
+        pWorkspace = g_pCompositor->createNewWorkspace(WORKSPACEID, PWINDOW->m_iMonitorID, workspaceName, false);
         g_pCompositor->moveWindowToWorkspaceSafe(PWINDOW, pWorkspace);
     }
 


### PR DESCRIPTION
Resolves #5663

## About the PR

This PR fixes the `on-created-empty` workspace rule, which has unintentionally removed in 094bce811831675b03939e4a2d527998850c906d (april 5th) and re-added back in #5452 (april 6th).

The PR originally reused the same code as the original implementation (#3559), but changed to execute the command in `CWorkspace`'s constructor, [as requested](https://github.com/hyprwm/Hyprland/pull/5452#pullrequestreview-1984489883).

However, when doing so no additional logic was added to guarantee that it would only execute commands when the workspace was, in fact, created empty.

The side-effect is that moving windows to new workspaces trigger the rule just the same.

## About the implementation

The implementation tries not to revert the changes from `CWorkspace`'s constructor back to `sanityCheckWorkspaces`, and instead works within the new implementation to guarantee that the workspace is, in fact, being created empty by relying on the rule that created it to say so.
