### PR TITLE
use add_custom_command for generating protocols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,8 +110,10 @@ pkg_check_modules(deps REQUIRED IMPORTED_TARGET
     wayland-server wayland-client wayland-cursor wayland-protocols
     cairo pango pangocairo pixman-1
     libdrm libinput hwdata libseat libdisplay-info libliftoff libudev gbm
-    hyprwayland-scanner>=0.3.7 hyprlang>=0.3.2 hyprcursor>=0.1.7
+    hyprlang>=0.3.2 hyprcursor>=0.1.7
 )
+
+find_package(hyprwayland-scanner 0.3.7 REQUIRED)
 
 file(GLOB_RECURSE SRCFILES "src/*.cpp")
 
@@ -210,42 +212,41 @@ target_link_libraries(Hyprland rt PkgConfig::deps)
 
 function(protocol protoPath protoName external)
     if (external)
-        execute_process(
-            COMMAND ${WaylandScanner} server-header ${protoPath} protocols/${protoName}-protocol.h
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-        execute_process(
-            COMMAND ${WaylandScanner} private-code ${protoPath} protocols/${protoName}-protocol.c
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})  
-        target_sources(Hyprland PRIVATE protocols/${protoName}-protocol.c)
+        set(path ${CMAKE_SOURCE_DIR}/${protoPath})
     else()
-        execute_process(
-            COMMAND ${WaylandScanner} server-header ${WAYLAND_PROTOCOLS_DIR}/${protoPath} protocols/${protoName}-protocol.h
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-        execute_process(
-            COMMAND ${WaylandScanner} private-code ${WAYLAND_PROTOCOLS_DIR}/${protoPath} protocols/${protoName}-protocol.c
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})  
-        target_sources(Hyprland PRIVATE protocols/${protoName}-protocol.c)
+        set(path ${WAYLAND_PROTOCOLS_DIR}/${protoPath})
     endif()
+
+    add_custom_command(
+        OUTPUT ${CMAKE_SOURCE_DIR}/protocols/${protoName}-protocol.h
+        COMMAND ${WaylandScanner} server-header ${path} protocols/${protoName}-protocol.h
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    )
+    add_custom_command(
+        OUTPUT ${CMAKE_SOURCE_DIR}/protocols/${protoName}-protocol.c
+        COMMAND ${WaylandScanner} private-code ${path} protocols/${protoName}-protocol.c
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    )
+    target_sources(Hyprland PRIVATE ${CMAKE_SOURCE_DIR}/protocols/${protoName}-protocol.h)
+    target_sources(Hyprland PRIVATE ${CMAKE_SOURCE_DIR}/protocols/${protoName}-protocol.c)
 endfunction()
 function(protocolNew protoPath protoName external)
     if (external)
-        execute_process(
-            COMMAND hyprwayland-scanner ${protoPath} ${CMAKE_SOURCE_DIR}/protocols/
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-        target_sources(Hyprland PRIVATE protocols/${protoName}.cpp)
+        set(path ${CMAKE_SOURCE_DIR}/${protoPath})
     else()
-        execute_process(
-            COMMAND hyprwayland-scanner ${WAYLAND_PROTOCOLS_DIR}/${protoPath} ${CMAKE_SOURCE_DIR}/protocols/
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-        target_sources(Hyprland PRIVATE protocols/${protoName}.cpp)
+        set(path ${WAYLAND_PROTOCOLS_DIR}/${protoPath})
     endif()
+    hyprwayland_protocol(Hyprland ${protoName} ${path} ${CMAKE_SOURCE_DIR}/protocols)
 endfunction()
 function(protocolWayland)
-    execute_process(
+    add_custom_command(
+        OUTPUT ${CMAKE_SOURCE_DIR}/protocols/wayland.cpp
+               ${CMAKE_SOURCE_DIR}/protocols/wayland.hpp
         COMMAND hyprwayland-scanner --wayland-enums ${WAYLAND_SERVER_DIR}/wayland.xml ${CMAKE_SOURCE_DIR}/protocols/
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
     target_sources(Hyprland PRIVATE protocols/wayland.cpp)
+    target_sources(Hyprland PRIVATE protocols/wayland.hpp)
 endfunction()
 
 target_link_libraries(Hyprland
@@ -263,37 +264,37 @@ protocol("subprojects/hyprland-protocols/protocols/hyprland-toplevel-export-v1.x
 protocol("unstable/linux-dmabuf/linux-dmabuf-unstable-v1.xml" "linux-dmabuf-unstable-v1" false)
 protocol("unstable/text-input/text-input-unstable-v1.xml" "text-input-unstable-v1" false)
 
-protocolNew("protocols/wlr-gamma-control-unstable-v1.xml" "wlr-gamma-control-unstable-v1" true)
-protocolNew("protocols/wlr-foreign-toplevel-management-unstable-v1.xml" "wlr-foreign-toplevel-management-unstable-v1" true)
-protocolNew("protocols/wlr-output-power-management-unstable-v1.xml" "wlr-output-power-management-unstable-v1" true)
-protocolNew("protocols/virtual-keyboard-unstable-v1.xml" "virtual-keyboard-unstable-v1" true)
-protocolNew("protocols/wlr-virtual-pointer-unstable-v1.xml" "wlr-virtual-pointer-unstable-v1" true)
-protocolNew("protocols/input-method-unstable-v2.xml" "input-method-unstable-v2" true)
-protocolNew("protocols/wlr-output-management-unstable-v1.xml" "wlr-output-management-unstable-v1" true)
-protocolNew("protocols/kde-server-decoration.xml" "kde-server-decoration" true)
-protocolNew("protocols/wlr-data-control-unstable-v1.xml" "wlr-data-control-unstable-v1" true)
-protocolNew("subprojects/hyprland-protocols/protocols/hyprland-focus-grab-v1.xml" "hyprland-focus-grab-v1" true)
-protocolNew("protocols/wlr-layer-shell-unstable-v1.xml" "wlr-layer-shell-unstable-v1" true)
-protocolNew("staging/tearing-control/tearing-control-v1.xml" "tearing-control-v1" false)
-protocolNew("staging/fractional-scale/fractional-scale-v1.xml" "fractional-scale-v1" false)
-protocolNew("unstable/xdg-output/xdg-output-unstable-v1.xml" "xdg-output-unstable-v1" false)
-protocolNew("staging/cursor-shape/cursor-shape-v1.xml" "cursor-shape-v1" false)
-protocolNew("unstable/idle-inhibit/idle-inhibit-unstable-v1.xml" "idle-inhibit-unstable-v1" false)
-protocolNew("unstable/relative-pointer/relative-pointer-unstable-v1.xml" "relative-pointer-unstable-v1" false)
-protocolNew("unstable/xdg-decoration/xdg-decoration-unstable-v1.xml" "xdg-decoration-unstable-v1" false)
-protocolNew("staging/alpha-modifier/alpha-modifier-v1.xml" "alpha-modifier-v1" false)
-protocolNew("staging/ext-foreign-toplevel-list/ext-foreign-toplevel-list-v1.xml" "ext-foreign-toplevel-list-v1" false)
-protocolNew("unstable/pointer-gestures/pointer-gestures-unstable-v1.xml" "pointer-gestures-unstable-v1" false)
-protocolNew("unstable/keyboard-shortcuts-inhibit/keyboard-shortcuts-inhibit-unstable-v1.xml" "keyboard-shortcuts-inhibit-unstable-v1" false)
-protocolNew("unstable/text-input/text-input-unstable-v3.xml" "text-input-unstable-v3" false)
-protocolNew("unstable/pointer-constraints/pointer-constraints-unstable-v1.xml" "pointer-constraints-unstable-v1" false)
-protocolNew("staging/xdg-activation/xdg-activation-v1.xml" "xdg-activation-v1" false)
-protocolNew("staging/ext-idle-notify/ext-idle-notify-v1.xml" "ext-idle-notify-v1" false)
-protocolNew("staging/ext-session-lock/ext-session-lock-v1.xml" "ext-session-lock-v1" false)
-protocolNew("stable/tablet/tablet-v2.xml" "tablet-v2" false)
-protocolNew("stable/presentation-time/presentation-time.xml" "presentation-time" false)
-protocolNew("stable/xdg-shell/xdg-shell.xml" "xdg-shell" false)
-protocolNew("unstable/primary-selection/primary-selection-unstable-v1.xml" "primary-selection-unstable-v1" false)
+protocolNew("protocols" "wlr-gamma-control-unstable-v1" true)
+protocolNew("protocols" "wlr-foreign-toplevel-management-unstable-v1" true)
+protocolNew("protocols" "wlr-output-power-management-unstable-v1" true)
+protocolNew("protocols" "virtual-keyboard-unstable-v1" true)
+protocolNew("protocols" "wlr-virtual-pointer-unstable-v1" true)
+protocolNew("protocols" "input-method-unstable-v2" true)
+protocolNew("protocols" "wlr-output-management-unstable-v1" true)
+protocolNew("protocols" "kde-server-decoration" true)
+protocolNew("protocols" "wlr-data-control-unstable-v1" true)
+protocolNew("subprojects/hyprland-protocols/protocols" "hyprland-focus-grab-v1" true)
+protocolNew("protocols" "wlr-layer-shell-unstable-v1" true)
+protocolNew("staging/tearing-control" "tearing-control-v1" false)
+protocolNew("staging/fractional-scale" "fractional-scale-v1" false)
+protocolNew("unstable/xdg-output" "xdg-output-unstable-v1" false)
+protocolNew("staging/cursor-shape" "cursor-shape-v1" false)
+protocolNew("unstable/idle-inhibit" "idle-inhibit-unstable-v1" false)
+protocolNew("unstable/relative-pointer" "relative-pointer-unstable-v1" false)
+protocolNew("unstable/xdg-decoration" "xdg-decoration-unstable-v1" false)
+protocolNew("staging/alpha-modifier" "alpha-modifier-v1" false)
+protocolNew("staging/ext-foreign-toplevel-list" "ext-foreign-toplevel-list-v1" false)
+protocolNew("unstable/pointer-gestures" "pointer-gestures-unstable-v1" false)
+protocolNew("unstable/keyboard-shortcuts-inhibit" "keyboard-shortcuts-inhibit-unstable-v1" false)
+protocolNew("unstable/text-input" "text-input-unstable-v3" false)
+protocolNew("unstable/pointer-constraints" "pointer-constraints-unstable-v1" false)
+protocolNew("staging/xdg-activation" "xdg-activation-v1" false)
+protocolNew("staging/ext-idle-notify" "ext-idle-notify-v1" false)
+protocolNew("staging/ext-session-lock" "ext-session-lock-v1" false)
+protocolNew("stable/tablet" "tablet-v2" false)
+protocolNew("stable/presentation-time" "presentation-time" false)
+protocolNew("stable/xdg-shell" "xdg-shell" false)
+protocolNew("unstable/primary-selection" "primary-selection-unstable-v1" false)
 
 protocolWayland()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,7 +236,14 @@ function(protocolNew protoPath protoName external)
     else()
         set(path ${WAYLAND_PROTOCOLS_DIR}/${protoPath})
     endif()
-    hyprwayland_protocol(Hyprland ${protoName} ${path} ${CMAKE_SOURCE_DIR}/protocols)
+    add_custom_command(
+        OUTPUT ${CMAKE_SOURCE_DIR}/protocols/${protoName}.cpp
+               ${CMAKE_SOURCE_DIR}/protocols/${protoName}.hpp
+        COMMAND hyprwayland-scanner ${path}/${protoName}.xml ${CMAKE_SOURCE_DIR}/protocols/
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    )
+    target_sources(Hyprland PRIVATE protocols/${protoName}.cpp)
+    target_sources(Hyprland PRIVATE protocols/${protoName}.hpp)
 endfunction()
 function(protocolWayland)
     add_custom_command(

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -359,6 +359,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("group:groupbar:render_titles", Hyprlang::INT{1});
     m_pConfig->addConfigValue("group:groupbar:scrolling", Hyprlang::INT{1});
     m_pConfig->addConfigValue("group:groupbar:text_color", Hyprlang::INT{0xffffffff});
+    m_pConfig->addConfigValue("group:groupbar:stacked", Hyprlang::INT{0});
 
     m_pConfig->addConfigValue("debug:int", Hyprlang::INT{0});
     m_pConfig->addConfigValue("debug:log_damage", Hyprlang::INT{0});

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1041,6 +1041,9 @@ std::vector<SWindowRule> CConfigManager::getMatchingRules(PHLWINDOW pWindow, boo
     if (!valid(pWindow))
         return std::vector<SWindowRule>();
 
+    // if the window is unmapped, don't process exec rules yet.
+    shadowExec = shadowExec || !pWindow->m_bIsMapped;
+
     std::vector<SWindowRule> returns;
 
     std::string              title      = pWindow->m_szTitle;

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -284,16 +284,24 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
     } else if (in.starts_with("empty")) {
         const bool same_mon = in.substr(5).contains("m");
         const bool next     = in.substr(5).contains("n");
-        if (same_mon || next) {
-            if (!g_pCompositor->m_pLastMonitor) {
-                Debug::log(ERR, "Empty monitor workspace on monitor null!");
-                return WORKSPACE_INVALID;
+        if ((same_mon || next) && !g_pCompositor->m_pLastMonitor) {
+            Debug::log(ERR, "Empty monitor workspace on monitor null!");
+            return WORKSPACE_INVALID;
+        }
+
+        std::set<int> invalidWSes;
+        if (same_mon) {
+            for (auto& rule : g_pConfigManager->getAllWorkspaceRules()) {
+                const auto PMONITOR = g_pCompositor->getMonitorFromName(rule.monitor);
+                if (PMONITOR && (PMONITOR->ID != g_pCompositor->m_pLastMonitor->ID))
+                    invalidWSes.insert(rule.workspaceId);
             }
         }
+
         int id = next ? g_pCompositor->m_pLastMonitor->activeWorkspaceID() : 0;
         while (++id < INT_MAX) {
             const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(id);
-            if (!PWORKSPACE || (g_pCompositor->getWindowsOnWorkspace(id) == 0 && (!same_mon || PWORKSPACE->m_iMonitorID == g_pCompositor->m_pLastMonitor->ID)))
+            if (!invalidWSes.contains(id) && (!PWORKSPACE || g_pCompositor->getWindowsOnWorkspace(id) == 0))
                 return id;
         }
     } else if (in.starts_with("prev")) {

--- a/src/helpers/SdDaemon.cpp
+++ b/src/helpers/SdDaemon.cpp
@@ -7,6 +7,7 @@
 #include <errno.h>
 #include <sys/socket.h>
 #include <sys/un.h>
+#include <string.h>
 
 namespace Systemd {
     int SdBooted(void) {

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -2,6 +2,7 @@
 
 #include "../defines.hpp"
 #include <deque>
+#include <set>
 #include "../Compositor.hpp"
 #include <unordered_map>
 #include <functional>
@@ -13,20 +14,23 @@ class CPluginSystem;
 class IKeyboard;
 
 struct SKeybind {
-    std::string key          = "";
-    uint32_t    keycode      = 0;
-    bool        catchAll     = false;
-    uint32_t    modmask      = 0;
-    std::string handler      = "";
-    std::string arg          = "";
-    bool        locked       = false;
-    std::string submap       = "";
-    bool        release      = false;
-    bool        repeat       = false;
-    bool        mouse        = false;
-    bool        nonConsuming = false;
-    bool        transparent  = false;
-    bool        ignoreMods   = false;
+    std::string            key          = "";
+    std::set<xkb_keysym_t> sMkKeys      = {};
+    uint32_t               keycode      = 0;
+    bool                   catchAll     = false;
+    uint32_t               modmask      = 0;
+    std::set<xkb_keysym_t> sMkMods      = {};
+    std::string            handler      = "";
+    std::string            arg          = "";
+    bool                   locked       = false;
+    std::string            submap       = "";
+    bool                   release      = false;
+    bool                   repeat       = false;
+    bool                   mouse        = false;
+    bool                   nonConsuming = false;
+    bool                   transparent  = false;
+    bool                   ignoreMods   = false;
+    bool                   multiKey     = false;
 
     // DO NOT INITIALIZE
     bool shadowed = false;
@@ -55,6 +59,12 @@ struct SParsedKey {
     std::string key      = "";
     uint32_t    keycode  = 0;
     bool        catchAll = false;
+};
+
+enum eMultiKeyCase {
+    MK_NO_MATCH = 0,
+    MK_PARTIAL_MATCH,
+    MK_FULL_MATCH
 };
 
 class CKeybindManager {
@@ -104,6 +114,11 @@ class CKeybindManager {
     CTimer                          m_tScrollTimer;
 
     bool                            handleKeybinds(const uint32_t, const SPressedKeyWithMods&, bool);
+
+    std::set<xkb_keysym_t>          m_sMkKeys = {};
+    std::set<xkb_keysym_t>          m_sMkMods = {};
+    eMultiKeyCase                   mkBindMatches(const SKeybind);
+    eMultiKeyCase                   mkKeysymSetMatches(const std::set<xkb_keysym_t>, const std::set<xkb_keysym_t>);
 
     bool                            handleInternalKeybinds(xkb_keysym_t);
     bool                            handleVT(xkb_keysym_t);

--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -298,6 +298,9 @@ void CSeatManager::sendPointerAxis(uint32_t timeMs, wl_pointer_axis axis, double
         p->sendAxisSource(source);
         p->sendAxisRelativeDirection(axis, relative);
 
+        if (source == 0)
+            p->sendAxisDiscrete(axis, discrete);
+
         if (value == 0)
             p->sendAxisStop(timeMs, axis);
     }

--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -297,6 +297,9 @@ void CSeatManager::sendPointerAxis(uint32_t timeMs, wl_pointer_axis axis, double
         p->sendAxis(timeMs, axis, value);
         p->sendAxisSource(source);
         p->sendAxisRelativeDirection(axis, relative);
+
+        if (value == 0)
+            p->sendAxisStop(timeMs, axis);
     }
 }
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -774,7 +774,7 @@ void CInputManager::onMouseWheel(IPointer::SAxisEvent e) {
         }
     }
 
-    g_pSeatManager->sendPointerAxis(e.timeMs, e.axis, factor * e.delta, std::round(factor * e.deltaDiscrete), e.source, WL_POINTER_AXIS_RELATIVE_DIRECTION_IDENTICAL);
+    g_pSeatManager->sendPointerAxis(e.timeMs, e.axis, factor * e.delta, std::round(factor * e.deltaDiscrete / 120), e.source, WL_POINTER_AXIS_RELATIVE_DIRECTION_IDENTICAL);
 }
 
 Vector2D CInputManager::getMouseCoordsInternal() {

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -1,6 +1,7 @@
 #include "CHyprGroupBarDecoration.hpp"
 #include "../../Compositor.hpp"
 #include "../../config/ConfigValue.hpp"
+#include "managers/LayoutManager.hpp"
 #include <ranges>
 #include <pango/pangocairo.h>
 
@@ -12,6 +13,7 @@ static CTexture m_tGradientLockedInactive;
 
 constexpr int   BAR_INDICATOR_HEIGHT   = 3;
 constexpr int   BAR_PADDING_OUTER_VERT = 2;
+constexpr int   BAR_PADDING_OUTER_HORZ = 2;
 constexpr int   BAR_TEXT_PAD           = 2;
 constexpr int   BAR_HORIZONTAL_PADDING = 2;
 
@@ -32,6 +34,7 @@ SDecorationPositioningInfo CHyprGroupBarDecoration::getPositioningInfo() {
     static auto                PRENDERTITLES = CConfigValue<Hyprlang::INT>("group:groupbar:render_titles");
     static auto                PGRADIENTS    = CConfigValue<Hyprlang::INT>("group:groupbar:gradients");
     static auto                PPRIORITY     = CConfigValue<Hyprlang::INT>("group:groupbar:priority");
+    static auto                PSTACKED      = CConfigValue<Hyprlang::INT>("group:groupbar:stacked");
 
     SDecorationPositioningInfo info;
     info.policy   = DECORATION_POSITION_STICKY;
@@ -39,16 +42,20 @@ SDecorationPositioningInfo CHyprGroupBarDecoration::getPositioningInfo() {
     info.priority = *PPRIORITY;
     info.reserved = true;
 
-    if (*PENABLED && m_pWindow->m_sSpecialRenderData.decorate)
-        info.desiredExtents = {{0, BAR_PADDING_OUTER_VERT * 2 + BAR_INDICATOR_HEIGHT + (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0) + 2}, {0, 0}};
-    else
+    if (*PENABLED && m_pWindow->m_sSpecialRenderData.decorate) {
+        if (*PSTACKED) {
+            const auto ONEBARHEIGHT = BAR_PADDING_OUTER_VERT + BAR_INDICATOR_HEIGHT + (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0);
+            info.desiredExtents     = {{0, (ONEBARHEIGHT * m_dwGroupMembers.size()) + 2 + BAR_PADDING_OUTER_VERT}, {0, 0}};
+        } else
+            info.desiredExtents = {{0, BAR_PADDING_OUTER_VERT * 2 + BAR_INDICATOR_HEIGHT + (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0) + 2}, {0, 0}};
+    } else
         info.desiredExtents = {{0, 0}, {0, 0}};
-
     return info;
 }
 
 void CHyprGroupBarDecoration::onPositioningReply(const SDecorationPositioningReply& reply) {
     m_bAssignedBox = reply.assignedGeometry;
+    g_pLayoutManager->getCurrentLayout()->recalculateWindow(m_pWindow.lock());
 }
 
 eDecorationType CHyprGroupBarDecoration::getDecorationType() {
@@ -96,24 +103,31 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a) {
     static auto PTITLEFONTSIZE = CConfigValue<Hyprlang::INT>("group:groupbar:font_size");
     static auto PHEIGHT        = CConfigValue<Hyprlang::INT>("group:groupbar:height");
     static auto PGRADIENTS     = CConfigValue<Hyprlang::INT>("group:groupbar:gradients");
+    static auto PSTACKED       = CConfigValue<Hyprlang::INT>("group:groupbar:stacked");
 
     if (!*PENABLED || !m_pWindow->m_sSpecialRenderData.decorate)
         return;
 
     const auto ASSIGNEDBOX = assignedBoxGlobal();
 
-    m_fBarWidth = (ASSIGNEDBOX.w - BAR_HORIZONTAL_PADDING * (barsToDraw - 1)) / barsToDraw;
+    const auto ONEBARHEIGHT = BAR_PADDING_OUTER_VERT + BAR_INDICATOR_HEIGHT + (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0);
+    m_fBarWidth             = *PSTACKED ? ASSIGNEDBOX.w : (ASSIGNEDBOX.w - BAR_HORIZONTAL_PADDING * (barsToDraw - 1)) / barsToDraw;
+    m_fBarHeight = *PSTACKED ? ((ASSIGNEDBOX.h - 2 - BAR_PADDING_OUTER_VERT) - BAR_PADDING_OUTER_VERT * (barsToDraw)) / barsToDraw : ASSIGNEDBOX.h - BAR_PADDING_OUTER_VERT;
 
-    const auto DESIREDHEIGHT = BAR_PADDING_OUTER_VERT * 2 + BAR_INDICATOR_HEIGHT + (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0) + 2;
-    if (DESIREDHEIGHT != ASSIGNEDBOX.h)
+    const auto DESIREDHEIGHT = *PSTACKED ? (ONEBARHEIGHT * m_dwGroupMembers.size()) + 2 + BAR_PADDING_OUTER_VERT : BAR_PADDING_OUTER_VERT * 2 + ONEBARHEIGHT;
+    if (DESIREDHEIGHT != ASSIGNEDBOX.h) {
         g_pDecorationPositioner->repositionDeco(this);
+    }
 
     int xoff = 0;
+    int yoff = 0;
 
     for (int i = 0; i < barsToDraw; ++i) {
-        CBox rect = {ASSIGNEDBOX.x + xoff - pMonitor->vecPosition.x + m_pWindow->m_vFloatingOffset.x,
-                     ASSIGNEDBOX.y + ASSIGNEDBOX.h - BAR_INDICATOR_HEIGHT - BAR_PADDING_OUTER_VERT - pMonitor->vecPosition.y + m_pWindow->m_vFloatingOffset.y, m_fBarWidth,
-                     BAR_INDICATOR_HEIGHT};
+        const auto WINDOWINDEX = *PSTACKED ? m_dwGroupMembers.size() - i - 1 : i;
+
+        CBox       rect = {ASSIGNEDBOX.x + xoff - pMonitor->vecPosition.x + m_pWindow->m_vFloatingOffset.x,
+                           ASSIGNEDBOX.y + ASSIGNEDBOX.h - yoff - BAR_INDICATOR_HEIGHT - BAR_PADDING_OUTER_VERT - pMonitor->vecPosition.y + m_pWindow->m_vFloatingOffset.y, m_fBarWidth,
+                           BAR_INDICATOR_HEIGHT};
 
         if (rect.width <= 0 || rect.height <= 0)
             break;
@@ -133,38 +147,43 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a) {
         const auto* const PCOLACTIVE   = GROUPLOCKED ? GROUPCOLACTIVELOCKED : GROUPCOLACTIVE;
         const auto* const PCOLINACTIVE = GROUPLOCKED ? GROUPCOLINACTIVELOCKED : GROUPCOLINACTIVE;
 
-        CColor            color = m_dwGroupMembers[i].lock() == g_pCompositor->m_pLastWindow.lock() ? PCOLACTIVE->m_vColors[0] : PCOLINACTIVE->m_vColors[0];
+        CColor            color = m_dwGroupMembers[WINDOWINDEX].lock() == g_pCompositor->m_pLastWindow.lock() ? PCOLACTIVE->m_vColors[0] : PCOLINACTIVE->m_vColors[0];
         color.a *= a;
         g_pHyprOpenGL->renderRect(&rect, color);
 
         rect = {ASSIGNEDBOX.x + xoff - pMonitor->vecPosition.x + m_pWindow->m_vFloatingOffset.x,
-                ASSIGNEDBOX.y - pMonitor->vecPosition.y + m_pWindow->m_vFloatingOffset.y + BAR_PADDING_OUTER_VERT, m_fBarWidth,
-                ASSIGNEDBOX.h - BAR_INDICATOR_HEIGHT - BAR_PADDING_OUTER_VERT * 2};
+                ASSIGNEDBOX.y + ASSIGNEDBOX.h - yoff - ONEBARHEIGHT - pMonitor->vecPosition.y + m_pWindow->m_vFloatingOffset.y, m_fBarWidth,
+                (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0)};
         rect.scale(pMonitor->scale);
 
         if (*PGRADIENTS) {
-            const auto& GRADIENTTEX = (m_dwGroupMembers[i].lock() == g_pCompositor->m_pLastWindow.lock() ? (GROUPLOCKED ? m_tGradientLockedActive : m_tGradientActive) :
-                                                                                                           (GROUPLOCKED ? m_tGradientLockedInactive : m_tGradientInactive));
+            const auto& GRADIENTTEX =
+                (m_dwGroupMembers[WINDOWINDEX].lock() == g_pCompositor->m_pLastWindow.lock() ? (GROUPLOCKED ? m_tGradientLockedActive : m_tGradientActive) :
+                                                                                               (GROUPLOCKED ? m_tGradientLockedInactive : m_tGradientInactive));
             if (GRADIENTTEX.m_iTexID != 0)
                 g_pHyprOpenGL->renderTexture(GRADIENTTEX, &rect, 1.0);
         }
 
         if (*PRENDERTITLES) {
-            CTitleTex* pTitleTex = textureFromTitle(m_dwGroupMembers[i]->m_szTitle);
+            CTitleTex* pTitleTex = textureFromTitle(m_dwGroupMembers[WINDOWINDEX]->m_szTitle);
 
             if (!pTitleTex)
-                pTitleTex = m_sTitleTexs.titleTexs
-                                .emplace_back(std::make_unique<CTitleTex>(
-                                    m_dwGroupMembers[i].lock(), Vector2D{m_fBarWidth * pMonitor->scale, (*PTITLEFONTSIZE + 2 * BAR_TEXT_PAD) * pMonitor->scale}, pMonitor->scale))
-                                .get();
+                pTitleTex =
+                    m_sTitleTexs.titleTexs
+                        .emplace_back(std::make_unique<CTitleTex>(m_dwGroupMembers[WINDOWINDEX].lock(),
+                                                                  Vector2D{m_fBarWidth * pMonitor->scale, (*PTITLEFONTSIZE + 2 * BAR_TEXT_PAD) * pMonitor->scale}, pMonitor->scale))
+                        .get();
 
-            rect.y += (ASSIGNEDBOX.h / 2.0 - (*PTITLEFONTSIZE + 2 * BAR_TEXT_PAD) / 2.0) * pMonitor->scale;
+            rect.y += (*PHEIGHT / 2.0 - (*PTITLEFONTSIZE + 2 * BAR_TEXT_PAD) / 2.0) * pMonitor->scale;
             rect.height = (*PTITLEFONTSIZE + 2 * BAR_TEXT_PAD) * pMonitor->scale;
 
             g_pHyprOpenGL->renderTexture(pTitleTex->tex, &rect, 1.f);
         }
 
-        xoff += BAR_HORIZONTAL_PADDING + m_fBarWidth;
+        if (*PSTACKED)
+            yoff += ONEBARHEIGHT;
+        else
+            xoff += BAR_HORIZONTAL_PADDING + m_fBarWidth;
     }
 
     if (*PRENDERTITLES)
@@ -335,13 +354,18 @@ void refreshGroupBarGradients() {
 }
 
 bool CHyprGroupBarDecoration::onBeginWindowDragOnDeco(const Vector2D& pos) {
+    static auto PSTACKED = CConfigValue<Hyprlang::INT>("group:groupbar:stacked");
     if (m_pWindow.lock() == m_pWindow->m_sGroupData.pNextWindow.lock())
         return false;
 
     const float BARRELATIVEX = pos.x - assignedBoxGlobal().x;
-    const int   WINDOWINDEX  = (BARRELATIVEX) / (m_fBarWidth + BAR_HORIZONTAL_PADDING);
+    const float BARRELATIVEY = pos.y - assignedBoxGlobal().y;
+    const int   WINDOWINDEX  = *PSTACKED ? (BARRELATIVEY / (m_fBarHeight + BAR_PADDING_OUTER_VERT)) : (BARRELATIVEX) / (m_fBarWidth + BAR_HORIZONTAL_PADDING);
 
-    if (BARRELATIVEX - (m_fBarWidth + BAR_HORIZONTAL_PADDING) * WINDOWINDEX > m_fBarWidth)
+    if (!*PSTACKED && (BARRELATIVEX - (m_fBarWidth + BAR_HORIZONTAL_PADDING) * WINDOWINDEX > m_fBarWidth))
+        return false;
+
+    if (*PSTACKED && (BARRELATIVEY - (m_fBarHeight + BAR_PADDING_OUTER_VERT) * WINDOWINDEX < BAR_PADDING_OUTER_VERT))
         return false;
 
     PHLWINDOW pWindow = m_pWindow->getGroupWindowByIndex(WINDOWINDEX);
@@ -364,11 +388,13 @@ bool CHyprGroupBarDecoration::onBeginWindowDragOnDeco(const Vector2D& pos) {
 }
 
 bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, PHLWINDOW pDraggedWindow) {
+    static auto PSTACKED = CConfigValue<Hyprlang::INT>("group:groupbar:stacked");
     if (!pDraggedWindow->canBeGroupedInto(m_pWindow.lock()))
         return false;
 
-    const float BARRELATIVEX = pos.x - assignedBoxGlobal().x - m_fBarWidth / 2;
-    const int   WINDOWINDEX  = BARRELATIVEX < 0 ? -1 : (BARRELATIVEX) / (m_fBarWidth + BAR_HORIZONTAL_PADDING);
+    const float BARRELATIVE = *PSTACKED ? pos.y - assignedBoxGlobal().y - (m_fBarHeight + BAR_PADDING_OUTER_VERT) / 2 : pos.x - assignedBoxGlobal().x - m_fBarWidth / 2;
+    const float BARSIZE     = *PSTACKED ? m_fBarHeight + BAR_PADDING_OUTER_VERT : m_fBarWidth + BAR_HORIZONTAL_PADDING;
+    const int   WINDOWINDEX = BARRELATIVE < 0 ? -1 : BARRELATIVE / BARSIZE;
 
     PHLWINDOW   pWindowInsertAfter = m_pWindow->getGroupWindowByIndex(WINDOWINDEX);
     PHLWINDOW   pWindowInsertEnd   = pWindowInsertAfter->m_sGroupData.pNextWindow.lock();
@@ -423,11 +449,13 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, PHLWIND
 }
 
 bool CHyprGroupBarDecoration::onMouseButtonOnDeco(const Vector2D& pos, const IPointer::SButtonEvent& e) {
+    static auto PSTACKED = CConfigValue<Hyprlang::INT>("group:groupbar:stacked");
     if (m_pWindow->m_bIsFullscreen && m_pWindow->m_pWorkspace->m_efFullscreenMode == FULLSCREEN_FULL)
         return true;
 
     const float BARRELATIVEX = pos.x - assignedBoxGlobal().x;
-    const int   WINDOWINDEX  = (BARRELATIVEX) / (m_fBarWidth + BAR_HORIZONTAL_PADDING);
+    const float BARRELATIVEY = pos.y - assignedBoxGlobal().y;
+    const int   WINDOWINDEX  = *PSTACKED ? (BARRELATIVEY / (m_fBarHeight + BAR_PADDING_OUTER_VERT)) : (BARRELATIVEX) / (m_fBarWidth + BAR_HORIZONTAL_PADDING);
     static auto PFOLLOWMOUSE = CConfigValue<Hyprlang::INT>("input:follow_mouse");
 
     // close window on middle click
@@ -446,7 +474,9 @@ bool CHyprGroupBarDecoration::onMouseButtonOnDeco(const Vector2D& pos, const IPo
         return true;
 
     // click on padding
-    if (BARRELATIVEX - (m_fBarWidth + BAR_HORIZONTAL_PADDING) * WINDOWINDEX > m_fBarWidth) {
+    const auto TABPAD   = !*PSTACKED && (BARRELATIVEX - (m_fBarWidth + BAR_HORIZONTAL_PADDING) * WINDOWINDEX > m_fBarWidth);
+    const auto STACKPAD = *PSTACKED && (BARRELATIVEY - (m_fBarHeight + BAR_PADDING_OUTER_VERT) * WINDOWINDEX < BAR_PADDING_OUTER_VERT);
+    if (TABPAD || STACKPAD) {
         if (!g_pCompositor->isWindowActive(m_pWindow.lock()))
             g_pCompositor->focusWindow(m_pWindow.lock());
         return true;

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -54,6 +54,7 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
     std::deque<PHLWINDOWREF> m_dwGroupMembers;
 
     float                    m_fBarWidth;
+    float                    m_fBarHeight;
 
     CTitleTex*               textureFromTitle(const std::string&);
     void                     invalidateTextures();


### PR DESCRIPTION
This fixes an issue with build error in case of e.g.

```bash
$ rm protocols/*.h
$ cmake --build build
```

The workaround was to 
```bash
$ touch CMakeLists.txt
``` 
With this PR, protocol files are properly regenerated with no extra efforts.

Also, resolve hyprwayland-scanner dependency via cmake instead of pkg-config.
