### PR TITLE
Add locked cmd to requests

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1550,6 +1550,18 @@ std::string dispatchDismissNotify(eHyprCtlOutputFormat format, std::string reque
     return "ok";
 }
 
+std::string getIsLocked(eHyprCtlOutputFormat format, std::string request) {
+    std::string lockedStr = g_pSessionLockManager->isSessionLocked() ? "true" : "false";
+    if (format == eHyprCtlOutputFormat::FORMAT_JSON)
+        lockedStr = std::format(R"#(
+{{
+    "locked": {}
+}}
+)#",
+                                lockedStr);
+    return lockedStr;
+}
+
 CHyprCtl::CHyprCtl() {
     registerCommand(SHyprCtlCommand{"workspaces", true, workspacesRequest});
     registerCommand(SHyprCtlCommand{"workspacerules", true, workspaceRulesRequest});
@@ -1569,6 +1581,7 @@ CHyprCtl::CHyprCtl() {
     registerCommand(SHyprCtlCommand{"rollinglog", true, rollinglogRequest});
     registerCommand(SHyprCtlCommand{"layouts", true, layoutsRequest});
     registerCommand(SHyprCtlCommand{"configerrors", true, configErrorsRequest});
+    registerCommand(SHyprCtlCommand{"locked", true, getIsLocked});
 
     registerCommand(SHyprCtlCommand{"monitors", false, monitorsRequest});
     registerCommand(SHyprCtlCommand{"reload", false, reloadRequest});


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

It returns state from SessionLockManager to indicate whether the session is locked or not.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Well, I was thinking to include general (current) session info, but not sure whether this is wanted or will be needed in the future, so for now only "locked" is added. Later on, this can be reworked into smth like session info thing or whatever. 

#### Is it ready for merging, or does it need work?

Ready for merging
