### PR TITLE
keybinds: fix empty on monitor for new workspaces

### DIFF
--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -284,16 +284,24 @@ int getWorkspaceIDFromString(const std::string& in, std::string& outName) {
     } else if (in.starts_with("empty")) {
         const bool same_mon = in.substr(5).contains("m");
         const bool next     = in.substr(5).contains("n");
-        if (same_mon || next) {
-            if (!g_pCompositor->m_pLastMonitor) {
-                Debug::log(ERR, "Empty monitor workspace on monitor null!");
-                return WORKSPACE_INVALID;
+        if ((same_mon || next) && !g_pCompositor->m_pLastMonitor) {
+            Debug::log(ERR, "Empty monitor workspace on monitor null!");
+            return WORKSPACE_INVALID;
+        }
+
+        std::set<int> invalidWSes;
+        if (same_mon) {
+            for (auto& rule : g_pConfigManager->getAllWorkspaceRules()) {
+                const auto PMONITOR = g_pCompositor->getMonitorFromName(rule.monitor);
+                if (PMONITOR && (PMONITOR->ID != g_pCompositor->m_pLastMonitor->ID))
+                    invalidWSes.insert(rule.workspaceId);
             }
         }
+
         int id = next ? g_pCompositor->m_pLastMonitor->activeWorkspaceID() : 0;
         while (++id < INT_MAX) {
             const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(id);
-            if (!PWORKSPACE || (g_pCompositor->getWindowsOnWorkspace(id) == 0 && (!same_mon || PWORKSPACE->m_iMonitorID == g_pCompositor->m_pLastMonitor->ID)))
+            if (!invalidWSes.contains(id) && (!PWORKSPACE || g_pCompositor->getWindowsOnWorkspace(id) == 0))
                 return id;
         }
     } else if (in.starts_with("prev")) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Currently, when the next workspace does not yet exist (but has been defined in config), the `emptym` selector opens the next workspace on the wrong monitor. This fixes that by checking the workspace rules to make sure the next new workspace is on the same monitor.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready

