### PR TITLE
Make hyprctl setcursor better (support XCursor themes, also give fail message)

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1063,7 +1063,8 @@ std::string dispatchSetCursor(eHyprCtlOutputFormat format, std::string request) 
     if (size <= 0)
         return "size not positive";
 
-    g_pCursorManager->changeTheme(theme, size);
+    if (!g_pCursorManager->changeTheme(theme, size))
+        return "failed to set cursor";
 
     return "ok";
 }

--- a/src/managers/CursorManager.cpp
+++ b/src/managers/CursorManager.cpp
@@ -266,9 +266,6 @@ void CCursorManager::updateTheme() {
             highestScale = m->scale;
     }
 
-    if (std::round(highestScale * m_iSize) == m_sCurrentStyleInfo.size)
-        return;
-
     if (m_sCurrentStyleInfo.size && m_pHyprcursor->valid())
         m_pHyprcursor->cursorSurfaceStyleDone(m_sCurrentStyleInfo);
 
@@ -286,13 +283,48 @@ void CCursorManager::updateTheme() {
     }
 }
 
-void CCursorManager::changeTheme(const std::string& name, const int size) {
-    m_pHyprcursor = std::make_unique<Hyprcursor::CHyprcursorManager>(name.empty() ? "" : name.c_str(), hcLogger);
-    m_szTheme     = name;
-    m_iSize       = size;
+bool CCursorManager::changeTheme(const std::string& name, const int size) {
+    m_pHyprcursor = std::make_unique<Hyprcursor::CHyprcursorManager>(name.empty() ? "" : name.c_str(), hcLogger, false);
+    if (m_pHyprcursor->valid()) {
+        m_szTheme = name;
+        m_iSize   = size;
+        updateTheme();
+        return true;
+    }
 
-    if (!m_pHyprcursor->valid())
-        Debug::log(ERR, "Hyprcursor failed loading theme \"{}\", falling back to X.", m_szTheme);
+    Debug::log(ERR, "Hyprcursor failed loading theme \"{}\", falling back to X.", name);
+
+    if (m_pWLRXCursorMgr)
+        wlr_xcursor_manager_destroy(m_pWLRXCursorMgr);
+
+    m_pWLRXCursorMgr = wlr_xcursor_manager_create(name.empty() ? "" : name.c_str(), size);
+    bool xSuccess    = wlr_xcursor_manager_load(m_pWLRXCursorMgr, 1.0) == 1;
+
+    // this basically checks if xcursor changed used theme to default but better
+    bool                              diffTheme = false;
+    struct wlr_xcursor_manager_theme* theme;
+    wl_list_for_each(theme, &m_pWLRXCursorMgr->scaled_themes, link) {
+        if (std::string{theme->theme->name} != name) {
+            diffTheme = true;
+            break;
+        }
+    }
+
+    if (xSuccess && !diffTheme) {
+        m_szTheme = name;
+        m_iSize   = size;
+        updateTheme();
+        return true;
+    }
+
+    Debug::log(ERR, "X also failed loading theme \"{}\", falling back to previous theme.", name);
+
+    m_pHyprcursor = std::make_unique<Hyprcursor::CHyprcursorManager>(m_szTheme.c_str(), hcLogger);
+
+    wlr_xcursor_manager_destroy(m_pWLRXCursorMgr);
+    m_pWLRXCursorMgr = wlr_xcursor_manager_create(m_szTheme.c_str(), m_iSize);
+    wlr_xcursor_manager_load(m_pWLRXCursorMgr, 1.0);
 
     updateTheme();
+    return false;
 }

--- a/src/managers/CursorManager.cpp
+++ b/src/managers/CursorManager.cpp
@@ -305,8 +305,8 @@ bool CCursorManager::changeTheme(const std::string& name, const int size) {
     bool xSuccess    = wlr_xcursor_manager_load(m_pWLRXCursorMgr, 1.0) == 1;
 
     // this basically checks if xcursor changed used theme to default but better
-    bool                              diffTheme = false;
-    struct wlr_xcursor_manager_theme* theme;
+    bool                       diffTheme = false;
+    wlr_xcursor_manager_theme* theme;
     wl_list_for_each(theme, &m_pWLRXCursorMgr->scaled_themes, link) {
         if (std::string{theme->theme->name} != name) {
             diffTheme = true;

--- a/src/managers/CursorManager.cpp
+++ b/src/managers/CursorManager.cpp
@@ -284,7 +284,11 @@ void CCursorManager::updateTheme() {
 }
 
 bool CCursorManager::changeTheme(const std::string& name, const int size) {
-    m_pHyprcursor = std::make_unique<Hyprcursor::CHyprcursorManager>(name.empty() ? "" : name.c_str(), hcLogger, false);
+    auto options                 = Hyprcursor::SManagerOptions();
+    options.logFn                = hcLogger;
+    options.allowDefaultFallback = false;
+
+    m_pHyprcursor = std::make_unique<Hyprcursor::CHyprcursorManager>(name.empty() ? "" : name.c_str(), options);
     if (m_pHyprcursor->valid()) {
         m_szTheme = name;
         m_iSize   = size;

--- a/src/managers/CursorManager.hpp
+++ b/src/managers/CursorManager.hpp
@@ -22,7 +22,7 @@ class CCursorManager {
     void             setCursorSurface(CWLSurface* surf, const Vector2D& hotspot);
     void             setXCursor(const std::string& name);
 
-    void             changeTheme(const std::string& name, const int size);
+    bool             changeTheme(const std::string& name, const int size);
     void             updateTheme();
     SCursorImageData dataFor(const std::string& name); // for xwayland
     void             setXWaylandCursor(wlr_xwayland* xwayland);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
makes it so that hyprctl setcursor can be used to change cursor theme between Hyprcursor and Xcursor

also addresses these issues
* #4221, by removing this code
  https://github.com/hyprwm/Hyprland/blob/de9798fcf9494eb082bd168175390c0d47b8478b/src/managers/CursorManager.cpp#L269-L270

* #5232, and adding this too
https://github.com/hyprwm/Hyprland/blob/deb7c4f9b07d358d4e01fe8726f72ce9bbc016a2/src/debug/HyprCtl.cpp#L1066-L1069

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
**_This PR also requires a change in hyprcursor, see hyprwm/hyprcursor#43_**

The git blame for these lines is for a bug fix, but I believe this was left over when CursorManager was later changed?
either way code should still work the same, just a little less efficient i guess
https://github.com/hyprwm/Hyprland/blob/de9798fcf9494eb082bd168175390c0d47b8478b/src/managers/CursorManager.cpp#L269-L270

#### Is it ready for merging, or does it need work?
No, I need to get hyprcursor PR merged first (hyprwm/hyprcursor#43)
tested on my machine
* switching between xcursor and hyprcursor 
* and between xcursor and xcursor
* and hyprcursor and hyprcursor
* and different sizes for both