### PR TITLE
Add option to change position of HyprError bar (#3241)

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -374,6 +374,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("debug:manual_crash", Hyprlang::INT{0});
     m_pConfig->addConfigValue("debug:suppress_errors", Hyprlang::INT{0});
     m_pConfig->addConfigValue("debug:error_limit", Hyprlang::INT{5});
+    m_pConfig->addConfigValue("debug:error_position", Hyprlang::INT{0});
     m_pConfig->addConfigValue("debug:watchdog_timeout", Hyprlang::INT{5});
     m_pConfig->addConfigValue("debug:disable_scale_checks", Hyprlang::INT{0});
     m_pConfig->addConfigValue("debug:colored_stdout_logs", Hyprlang::INT{1});

--- a/src/hyprerror/HyprError.cpp
+++ b/src/hyprerror/HyprError.cpp
@@ -58,8 +58,11 @@ void CHyprError::createQueued() {
     cairo_paint(CAIRO);
     cairo_restore(CAIRO);
 
-    const auto   LINECOUNT = Hyprlang::INT{1} + std::count(m_szQueued.begin(), m_szQueued.end(), '\n');
-    static auto  LINELIMIT = CConfigValue<Hyprlang::INT>("debug:error_limit");
+    const auto   LINECOUNT    = Hyprlang::INT{1} + std::count(m_szQueued.begin(), m_szQueued.end(), '\n');
+    static auto  LINELIMIT    = CConfigValue<Hyprlang::INT>("debug:error_limit");
+    static auto  BAR_POSITION = CConfigValue<Hyprlang::INT>("debug:error_position");
+
+    const bool   TOPBAR = *BAR_POSITION == 0;
 
     const auto   VISLINECOUNT = std::min(LINECOUNT, *LINELIMIT);
     const auto   EXTRALINES   = (VISLINECOUNT < LINECOUNT) ? 1 : 0;
@@ -68,11 +71,11 @@ void CHyprError::createQueued() {
 
     const double PAD = 10 * SCALE;
 
-    const double X      = PAD;
-    const double Y      = PAD;
     const double WIDTH  = PMONITOR->vecPixelSize.x - PAD * 2;
     const double HEIGHT = (FONTSIZE + 2 * (FONTSIZE / 10.0)) * (VISLINECOUNT + EXTRALINES) + 3;
     const double RADIUS = PAD > HEIGHT / 2 ? HEIGHT / 2 - 1 : PAD;
+    const double X      = PAD;
+    const double Y      = TOPBAR ? PAD : PMONITOR->vecPixelSize.y - HEIGHT - PAD;
 
     m_bDamageBox = {0, 0, (int)PMONITOR->vecPixelSize.x, (int)HEIGHT + (int)PAD * 2};
 
@@ -96,9 +99,9 @@ void CHyprError::createQueued() {
     cairo_set_font_size(CAIRO, FONTSIZE);
     cairo_set_source_rgba(CAIRO, textColor.r, textColor.g, textColor.b, textColor.a);
 
-    float yoffset     = FONTSIZE;
+    float yoffset     = TOPBAR ? FONTSIZE : Y - PAD + FONTSIZE;
     int   renderedcnt = 0;
-    while (m_szQueued != "" && renderedcnt < VISLINECOUNT) {
+    while (!m_szQueued.empty() && renderedcnt < VISLINECOUNT) {
         std::string current = m_szQueued.substr(0, m_szQueued.find('\n'));
         if (const auto NEWLPOS = m_szQueued.find('\n'); NEWLPOS != std::string::npos)
             m_szQueued = m_szQueued.substr(NEWLPOS + 1);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Implements my own feature request: #3241.

Many people have their system bar up top. This means that when they have a config error, the error goes above the bar. 
Depending on your set `error_limit`, the errors might also cover up things like the top of your browser (which you might want to use to search for help), or the top of your terminal (which is where your prompt, and you'll use that to fix the error).

This PR makes the position configurable: 

* top bar (current): `debug:error_position = 0` (default)
* bottom bar: `debug:error_position = 1` (or I guess it would work with any non-zero value).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Tested in a nested debug instance. No problems found.

I would actually argue the default should be bottom, as I think more people have their bar up top than at the bottom. I assume the top is default for a reason?

#### Is it ready for merging, or does it need work?

Before merging this, I need to create a wiki PR to explain the new option. I'll create that after I get approval for this PR.
