### PR TITLE
cmake: make gprof optional for debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,8 @@ endif()
 add_executable(Hyprland ${SRCFILES} ${TRACY_CPP_FILES})
 add_dependencies(Hyprland wlroots-hyprland)
 
+set(USE_GPROF ON)
+
 if(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES DEBUG)
     message(STATUS "Setting debug flags")
 
@@ -151,8 +153,12 @@ if(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES DEBUG)
         endif()
     endif()
 
-    add_compile_options(-pg -no-pie -fno-builtin)
-    add_link_options(-pg -no-pie -fno-builtin)
+    add_compile_options(-fno-pie -fno-builtin)
+    add_link_options(-no-pie -fno-builtin)
+    if(USE_GPROF)
+        add_compile_options(-pg)
+        add_link_options(-pg)
+    endif()
 endif()
 
 check_include_file("execinfo.h" EXECINFOH)


### PR DESCRIPTION
Hyprland can't be built with cmake in debug mode on musl systems, because musl doesn't support the `-pg` flag.

This PR fixes that by making this flag optional (enabled by default).

Also, fix PIE flags: it should be `-fno-pie` for [compilation](https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html), `-no-pie` for [linking](https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html).