### PR TITLE
Replace monitor rule when disabling head. Closes #5978

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1262,6 +1262,18 @@ void CConfigManager::appendMonitorRule(const SMonitorRule& r) {
     m_dMonitorRules.emplace_back(r);
 }
 
+bool CConfigManager::replaceMonitorRule(const SMonitorRule& newrule) {
+    // Looks for an existing monitor rule (compared by name).
+    // If the rule exists, it is replaced with the input rule.
+    for (auto& r : m_dMonitorRules) {
+        if (r.name == newrule.name) {
+            r = newrule;
+            return true;
+        }
+    }
+    return false;
+}
+
 void CConfigManager::performMonitorReload() {
 
     bool overAgain = false;

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -128,6 +128,7 @@ class CConfigManager {
 
     void                      performMonitorReload();
     void                      appendMonitorRule(const SMonitorRule&);
+    bool                      replaceMonitorRule(const SMonitorRule&);
     bool                      m_bWantsMonitorReload = false;
     bool                      m_bForceReload        = false;
     bool                      m_bNoMonitorReload    = false;

--- a/src/protocols/OutputManagement.cpp
+++ b/src/protocols/OutputManagement.cpp
@@ -305,8 +305,8 @@ COutputConfiguration::COutputConfiguration(SP<CZwlrOutputConfigurationV1> resour
         LOGM(LOG, "disableHead on {}", PMONITOR->szName);
 
         PMONITOR->activeMonitorRule.disabled = true;
-        g_pHyprRenderer->applyMonitorRule(PMONITOR, &PMONITOR->activeMonitorRule, false);
         g_pConfigManager->replaceMonitorRule(PMONITOR->activeMonitorRule);
+        g_pHyprRenderer->applyMonitorRule(PMONITOR, &PMONITOR->activeMonitorRule, false);
     });
 
     resource->setTest([this](CZwlrOutputConfigurationV1* r) {

--- a/src/protocols/OutputManagement.cpp
+++ b/src/protocols/OutputManagement.cpp
@@ -357,6 +357,7 @@ bool COutputConfiguration::applyTestConfiguration(bool test) {
 
         SMonitorRule newRule = PMONITOR->activeMonitorRule;
         newRule.name         = PMONITOR->szName;
+        newRule.disabled     = false;
 
         if (head->committedProperties & COutputConfigurationHead::eCommittedProperties::OUTPUT_HEAD_COMMITTED_MODE) {
             newRule.resolution  = {head->state.mode->getMode()->width, head->state.mode->getMode()->height};
@@ -381,7 +382,8 @@ bool COutputConfiguration::applyTestConfiguration(bool test) {
         // reset properties for next set.
         head->committedProperties = 0;
 
-        g_pConfigManager->appendMonitorRule(newRule);
+        if (!g_pConfigManager->replaceMonitorRule(newRule))
+            g_pConfigManager->appendMonitorRule(newRule);
         g_pConfigManager->m_bWantsMonitorReload = true;
     }
 

--- a/src/protocols/OutputManagement.cpp
+++ b/src/protocols/OutputManagement.cpp
@@ -106,6 +106,9 @@ COutputHead::COutputHead(SP<CZwlrOutputHeadV1> resource_, CMonitor* pMonitor_) :
         }
 
         pMonitor = nullptr;
+        for (auto& m : PROTO::outputManagement->m_vManagers) {
+            m->sendDone();
+        }
     });
 
     listeners.monitorModeChange = pMonitor->events.modeChanged.registerListener([this](std::any d) { updateMode(); });

--- a/src/protocols/OutputManagement.cpp
+++ b/src/protocols/OutputManagement.cpp
@@ -306,6 +306,7 @@ COutputConfiguration::COutputConfiguration(SP<CZwlrOutputConfigurationV1> resour
 
         PMONITOR->activeMonitorRule.disabled = true;
         g_pHyprRenderer->applyMonitorRule(PMONITOR, &PMONITOR->activeMonitorRule, false);
+        g_pConfigManager->replaceMonitorRule(PMONITOR->activeMonitorRule);
     });
 
     resource->setTest([this](CZwlrOutputConfigurationV1* r) {

--- a/src/protocols/OutputManagement.cpp
+++ b/src/protocols/OutputManagement.cpp
@@ -308,7 +308,8 @@ COutputConfiguration::COutputConfiguration(SP<CZwlrOutputConfigurationV1> resour
         LOGM(LOG, "disableHead on {}", PMONITOR->szName);
 
         PMONITOR->activeMonitorRule.disabled = true;
-        g_pConfigManager->replaceMonitorRule(PMONITOR->activeMonitorRule);
+        if (!g_pConfigManager->replaceMonitorRule(PMONITOR->activeMonitorRule))
+            g_pConfigManager->appendMonitorRule(PMONITOR->activeMonitorRule);
         g_pHyprRenderer->applyMonitorRule(PMONITOR, &PMONITOR->activeMonitorRule, false);
     });
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes Issue #5978. The main reason was that the monitor rule was not updated, and thus the head would get re-enabled when calling `performMonitorReload`

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I'm not sure this is the best way of doing it. Would it be a better idea to make `Monitor.activeMonitorRule` a pointer to the actual rule?

#### Is it ready for merging, or does it need work?
See above.

