### PR TITLE
Fixes shrinking pseudotile windows.

### DIFF
--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -523,7 +523,7 @@ void IHyprLayout::changeWindowFloatingMode(PHLWINDOW pWindow) {
         CBox wb = {pWindow->m_vRealPosition.goal() + (pWindow->m_vRealSize.goal() - pWindow->m_vLastFloatingSize) / 2.f, pWindow->m_vLastFloatingSize};
         wb.round();
 
-        if (DELTALESSTHAN(pWindow->m_vRealSize.value().x, pWindow->m_vLastFloatingSize.x, 10) &&
+        if (!(pWindow->m_bIsFloating && pWindow->m_bIsPseudotiled) && DELTALESSTHAN(pWindow->m_vRealSize.value().x, pWindow->m_vLastFloatingSize.x, 10) &&
             DELTALESSTHAN(pWindow->m_vRealSize.value().y, pWindow->m_vLastFloatingSize.y, 10)) {
             wb = {wb.pos() + Vector2D{10, 10}, wb.size() - Vector2D{20, 20}};
         }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
https://github.com/hyprwm/Hyprland/issues/6051
There is a problem described [here](https://github.com/hyprwm/Hyprland/issues/6051) where a window shrinks to nothingness by floating and unfloating a pseudo-tiled window. The reason for this is for some reason if a window isn't tiled and the difference of real size and floating size is less than 10 px on x and y, then the window is shrunk to by 20 pixels in each direction?

I have no idea what the point of this shrinking is so I didn't modify any cases besides when a window is floating and pseudotiled. This fixes it however and shouldn't break anything else.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This should be a small non-breaking change but I am curious why we would have this hardcoded shrink when going to floating?

#### Is it ready for merging, or does it need work?
Should be ready for merging.

