### PR TITLE
build: update meson, cmake setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ project(Hyprland
 set(HYPRLAND_VERSION ${VER})
 set(PREFIX ${CMAKE_INSTALL_PREFIX})
 set(INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR})
-configure_file(hyprland.pc.in hyprland.pc @ONLY) 
+configure_file(hyprland.pc.in hyprland.pc @ONLY)
 
 set(CMAKE_MESSAGE_LOG_LEVEL "STATUS")
 
@@ -90,9 +90,12 @@ include_directories(
   "protocols/")
 set(CMAKE_CXX_STANDARD 23)
 add_compile_definitions(WLR_USE_UNSTABLE)
-add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wno-narrowing -Wno-pointer-arith)
+add_compile_options(-Wall -Wextra -Wno-unused-parameter -Wno-unused-value
+    -Wno-missing-field-initializers -Wno-narrowing -Wno-pointer-arith
+    -fmacro-prefix-map=${CMAKE_SOURCE_DIR}/=)
 
 set(CMAKE_EXECUTABLE_ENABLE_EXPORTS TRUE)
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 message(STATUS "Checking deps...")
 

--- a/meson.build
+++ b/meson.build
@@ -5,20 +5,9 @@ project('Hyprland', 'cpp', 'c',
     'default_library=static',
     'optimization=3',
     'buildtype=release',
-    'debug=false'
-    # 'cpp_std=c++23' # not yet supported by meson, as of version 0.63.0
-    ])
-
-# clang v14.0.6 uses C++2b instead of C++23, so we've gotta account for that
-# replace the following with a project default option once meson gets support for C++23
-cpp_compiler = meson.get_compiler('cpp')
-if cpp_compiler.has_argument('-std=c++23')
-  add_global_arguments('-std=c++23', language: 'cpp')
-elif cpp_compiler.has_argument('-std=c++2b')
-  add_global_arguments('-std=c++2b', language: 'cpp')
-else
-  error('Could not configure current C++ compiler (' + cpp_compiler.get_id() + ' ' + cpp_compiler.version() + ') with required C++ standard (C++23)')
-endif
+    'debug=false',
+    'cpp_std=c++23',
+  ])
 
 add_project_arguments(
   [
@@ -26,9 +15,11 @@ add_project_arguments(
     '-Wno-unused-value',
     '-Wno-missing-field-initializers',
     '-Wno-narrowing',
+    '-Wno-pointer-arith',
   ],
   language: 'cpp')
 
+cpp_compiler = meson.get_compiler('cpp')
 if cpp_compiler.check_header('execinfo.h')
   add_project_arguments('-DHAS_EXECINFO', language: 'cpp')
 endif
@@ -65,7 +56,7 @@ if get_option('buildtype') == 'debug'
   add_project_arguments('-DHYPRLAND_DEBUG', language: 'cpp')
 endif
 
-version_h = run_command('sh', '-c', 'scripts/generateVersion.sh')
+version_h = run_command('sh', '-c', 'scripts/generateVersion.sh', check: true)
 
 globber = run_command('find', 'src', '-name', '*.h*', check: true)
 headers = globber.stdout().strip().split('\n')


### PR DESCRIPTION
- meson
. Fix `run_command()` check warning
. Drop lines for compatibility, as it's already using c++23

- cmake
. Generate `compile_commands.json` by default, coder-friendly
. Position independent build for `__FILE__`

#### Describe your PR, what does it fix/add?


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?

ready
