### PR TITLE
Add custom cmake target to generate protocol headers during `make installheaders`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,9 @@ message(STATUS "Setting link libraries")
 
 target_link_libraries(Hyprland rt PkgConfig::deps)
 
+# used by `make installheaders`, to ensure the headers are generated
+add_custom_target(generate-protocol-headers)
+
 function(protocol protoPath protoName external)
     if (external)
         set(path ${CMAKE_SOURCE_DIR}/${protoPath})
@@ -236,9 +239,10 @@ function(protocol protoPath protoName external)
         COMMAND ${WaylandScanner} private-code ${path} protocols/${protoName}-protocol.c
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
-    target_sources(Hyprland PRIVATE ${CMAKE_SOURCE_DIR}/protocols/${protoName}-protocol.h)
-    target_sources(Hyprland PRIVATE ${CMAKE_SOURCE_DIR}/protocols/${protoName}-protocol.c)
+    target_sources(Hyprland PRIVATE ${CMAKE_SOURCE_DIR}/protocols/${protoName}-protocol.h ${CMAKE_SOURCE_DIR}/protocols/${protoName}-protocol.c)
+    target_sources(generate-protocol-headers PRIVATE ${CMAKE_SOURCE_DIR}/protocols/${protoName}-protocol.h)
 endfunction()
+
 function(protocolNew protoPath protoName external)
     if (external)
         set(path ${CMAKE_SOURCE_DIR}/${protoPath})
@@ -251,8 +255,8 @@ function(protocolNew protoPath protoName external)
         COMMAND hyprwayland-scanner ${path}/${protoName}.xml ${CMAKE_SOURCE_DIR}/protocols/
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
-    target_sources(Hyprland PRIVATE protocols/${protoName}.cpp)
-    target_sources(Hyprland PRIVATE protocols/${protoName}.hpp)
+    target_sources(Hyprland PRIVATE protocols/${protoName}.cpp protocols/${protoName}.hpp)
+    target_sources(generate-protocol-headers PRIVATE ${CMAKE_SOURCE_DIR}/protocols/${protoName}.hpp)
 endfunction()
 function(protocolWayland)
     add_custom_command(
@@ -261,8 +265,8 @@ function(protocolWayland)
         COMMAND hyprwayland-scanner --wayland-enums ${WAYLAND_SERVER_DIR}/wayland.xml ${CMAKE_SOURCE_DIR}/protocols/
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
-    target_sources(Hyprland PRIVATE protocols/wayland.cpp)
-    target_sources(Hyprland PRIVATE protocols/wayland.hpp)
+    target_sources(Hyprland PRIVATE protocols/wayland.cpp protocols/wayland.hpp)
+    target_sources(generate-protocol-headers PRIVATE ${CMAKE_SOURCE_DIR}/protocols/wayland.hpp)
 endfunction()
 
 target_link_libraries(Hyprland

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,8 +113,10 @@ pkg_check_modules(deps REQUIRED IMPORTED_TARGET
     wayland-server wayland-client wayland-cursor wayland-protocols
     cairo pango pangocairo pixman-1
     libdrm libinput hwdata libseat libdisplay-info libliftoff libudev gbm
-    hyprwayland-scanner>=0.3.8 hyprlang>=0.3.2 hyprcursor>=0.1.7
+    hyprlang>=0.3.2 hyprcursor>=0.1.7
 )
+
+find_package(hyprwayland-scanner 0.3.8 REQUIRED)
 
 file(GLOB_RECURSE SRCFILES "src/*.cpp")
 
@@ -219,42 +221,48 @@ target_link_libraries(Hyprland rt PkgConfig::deps)
 
 function(protocol protoPath protoName external)
     if (external)
-        execute_process(
-            COMMAND ${WaylandScanner} server-header ${protoPath} protocols/${protoName}-protocol.h
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-        execute_process(
-            COMMAND ${WaylandScanner} private-code ${protoPath} protocols/${protoName}-protocol.c
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})  
-        target_sources(Hyprland PRIVATE protocols/${protoName}-protocol.c)
+        set(path ${CMAKE_SOURCE_DIR}/${protoPath})
     else()
-        execute_process(
-            COMMAND ${WaylandScanner} server-header ${WAYLAND_PROTOCOLS_DIR}/${protoPath} protocols/${protoName}-protocol.h
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-        execute_process(
-            COMMAND ${WaylandScanner} private-code ${WAYLAND_PROTOCOLS_DIR}/${protoPath} protocols/${protoName}-protocol.c
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})  
-        target_sources(Hyprland PRIVATE protocols/${protoName}-protocol.c)
+        set(path ${WAYLAND_PROTOCOLS_DIR}/${protoPath})
     endif()
+
+    add_custom_command(
+        OUTPUT ${CMAKE_SOURCE_DIR}/protocols/${protoName}-protocol.h
+        COMMAND ${WaylandScanner} server-header ${path} protocols/${protoName}-protocol.h
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    )
+    add_custom_command(
+        OUTPUT ${CMAKE_SOURCE_DIR}/protocols/${protoName}-protocol.c
+        COMMAND ${WaylandScanner} private-code ${path} protocols/${protoName}-protocol.c
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    )
+    target_sources(Hyprland PRIVATE ${CMAKE_SOURCE_DIR}/protocols/${protoName}-protocol.h)
+    target_sources(Hyprland PRIVATE ${CMAKE_SOURCE_DIR}/protocols/${protoName}-protocol.c)
 endfunction()
 function(protocolNew protoPath protoName external)
     if (external)
-        execute_process(
-            COMMAND hyprwayland-scanner ${protoPath} ${CMAKE_SOURCE_DIR}/protocols/
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-        target_sources(Hyprland PRIVATE protocols/${protoName}.cpp)
+        set(path ${CMAKE_SOURCE_DIR}/${protoPath})
     else()
-        execute_process(
-            COMMAND hyprwayland-scanner ${WAYLAND_PROTOCOLS_DIR}/${protoPath} ${CMAKE_SOURCE_DIR}/protocols/
-            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-        target_sources(Hyprland PRIVATE protocols/${protoName}.cpp)
+        set(path ${WAYLAND_PROTOCOLS_DIR}/${protoPath})
     endif()
+    add_custom_command(
+        OUTPUT ${CMAKE_SOURCE_DIR}/protocols/${protoName}.cpp
+               ${CMAKE_SOURCE_DIR}/protocols/${protoName}.hpp
+        COMMAND hyprwayland-scanner ${path}/${protoName}.xml ${CMAKE_SOURCE_DIR}/protocols/
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    )
+    target_sources(Hyprland PRIVATE protocols/${protoName}.cpp)
+    target_sources(Hyprland PRIVATE protocols/${protoName}.hpp)
 endfunction()
 function(protocolWayland)
-    execute_process(
+    add_custom_command(
+        OUTPUT ${CMAKE_SOURCE_DIR}/protocols/wayland.cpp
+               ${CMAKE_SOURCE_DIR}/protocols/wayland.hpp
         COMMAND hyprwayland-scanner --wayland-enums ${WAYLAND_SERVER_DIR}/wayland.xml ${CMAKE_SOURCE_DIR}/protocols/
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
     target_sources(Hyprland PRIVATE protocols/wayland.cpp)
+    target_sources(Hyprland PRIVATE protocols/wayland.hpp)
 endfunction()
 
 target_link_libraries(Hyprland
@@ -272,37 +280,37 @@ protocol("subprojects/hyprland-protocols/protocols/hyprland-toplevel-export-v1.x
 protocol("unstable/linux-dmabuf/linux-dmabuf-unstable-v1.xml" "linux-dmabuf-unstable-v1" false)
 protocol("unstable/text-input/text-input-unstable-v1.xml" "text-input-unstable-v1" false)
 
-protocolNew("protocols/wlr-gamma-control-unstable-v1.xml" "wlr-gamma-control-unstable-v1" true)
-protocolNew("protocols/wlr-foreign-toplevel-management-unstable-v1.xml" "wlr-foreign-toplevel-management-unstable-v1" true)
-protocolNew("protocols/wlr-output-power-management-unstable-v1.xml" "wlr-output-power-management-unstable-v1" true)
-protocolNew("protocols/virtual-keyboard-unstable-v1.xml" "virtual-keyboard-unstable-v1" true)
-protocolNew("protocols/wlr-virtual-pointer-unstable-v1.xml" "wlr-virtual-pointer-unstable-v1" true)
-protocolNew("protocols/input-method-unstable-v2.xml" "input-method-unstable-v2" true)
-protocolNew("protocols/wlr-output-management-unstable-v1.xml" "wlr-output-management-unstable-v1" true)
-protocolNew("protocols/kde-server-decoration.xml" "kde-server-decoration" true)
-protocolNew("protocols/wlr-data-control-unstable-v1.xml" "wlr-data-control-unstable-v1" true)
-protocolNew("subprojects/hyprland-protocols/protocols/hyprland-focus-grab-v1.xml" "hyprland-focus-grab-v1" true)
-protocolNew("protocols/wlr-layer-shell-unstable-v1.xml" "wlr-layer-shell-unstable-v1" true)
-protocolNew("staging/tearing-control/tearing-control-v1.xml" "tearing-control-v1" false)
-protocolNew("staging/fractional-scale/fractional-scale-v1.xml" "fractional-scale-v1" false)
-protocolNew("unstable/xdg-output/xdg-output-unstable-v1.xml" "xdg-output-unstable-v1" false)
-protocolNew("staging/cursor-shape/cursor-shape-v1.xml" "cursor-shape-v1" false)
-protocolNew("unstable/idle-inhibit/idle-inhibit-unstable-v1.xml" "idle-inhibit-unstable-v1" false)
-protocolNew("unstable/relative-pointer/relative-pointer-unstable-v1.xml" "relative-pointer-unstable-v1" false)
-protocolNew("unstable/xdg-decoration/xdg-decoration-unstable-v1.xml" "xdg-decoration-unstable-v1" false)
-protocolNew("staging/alpha-modifier/alpha-modifier-v1.xml" "alpha-modifier-v1" false)
-protocolNew("staging/ext-foreign-toplevel-list/ext-foreign-toplevel-list-v1.xml" "ext-foreign-toplevel-list-v1" false)
-protocolNew("unstable/pointer-gestures/pointer-gestures-unstable-v1.xml" "pointer-gestures-unstable-v1" false)
-protocolNew("unstable/keyboard-shortcuts-inhibit/keyboard-shortcuts-inhibit-unstable-v1.xml" "keyboard-shortcuts-inhibit-unstable-v1" false)
-protocolNew("unstable/text-input/text-input-unstable-v3.xml" "text-input-unstable-v3" false)
-protocolNew("unstable/pointer-constraints/pointer-constraints-unstable-v1.xml" "pointer-constraints-unstable-v1" false)
-protocolNew("staging/xdg-activation/xdg-activation-v1.xml" "xdg-activation-v1" false)
-protocolNew("staging/ext-idle-notify/ext-idle-notify-v1.xml" "ext-idle-notify-v1" false)
-protocolNew("staging/ext-session-lock/ext-session-lock-v1.xml" "ext-session-lock-v1" false)
-protocolNew("stable/tablet/tablet-v2.xml" "tablet-v2" false)
-protocolNew("stable/presentation-time/presentation-time.xml" "presentation-time" false)
-protocolNew("stable/xdg-shell/xdg-shell.xml" "xdg-shell" false)
-protocolNew("unstable/primary-selection/primary-selection-unstable-v1.xml" "primary-selection-unstable-v1" false)
+protocolNew("protocols" "wlr-gamma-control-unstable-v1" true)
+protocolNew("protocols" "wlr-foreign-toplevel-management-unstable-v1" true)
+protocolNew("protocols" "wlr-output-power-management-unstable-v1" true)
+protocolNew("protocols" "virtual-keyboard-unstable-v1" true)
+protocolNew("protocols" "wlr-virtual-pointer-unstable-v1" true)
+protocolNew("protocols" "input-method-unstable-v2" true)
+protocolNew("protocols" "wlr-output-management-unstable-v1" true)
+protocolNew("protocols" "kde-server-decoration" true)
+protocolNew("protocols" "wlr-data-control-unstable-v1" true)
+protocolNew("subprojects/hyprland-protocols/protocols" "hyprland-focus-grab-v1" true)
+protocolNew("protocols" "wlr-layer-shell-unstable-v1" true)
+protocolNew("staging/tearing-control" "tearing-control-v1" false)
+protocolNew("staging/fractional-scale" "fractional-scale-v1" false)
+protocolNew("unstable/xdg-output" "xdg-output-unstable-v1" false)
+protocolNew("staging/cursor-shape" "cursor-shape-v1" false)
+protocolNew("unstable/idle-inhibit" "idle-inhibit-unstable-v1" false)
+protocolNew("unstable/relative-pointer" "relative-pointer-unstable-v1" false)
+protocolNew("unstable/xdg-decoration" "xdg-decoration-unstable-v1" false)
+protocolNew("staging/alpha-modifier" "alpha-modifier-v1" false)
+protocolNew("staging/ext-foreign-toplevel-list" "ext-foreign-toplevel-list-v1" false)
+protocolNew("unstable/pointer-gestures" "pointer-gestures-unstable-v1" false)
+protocolNew("unstable/keyboard-shortcuts-inhibit" "keyboard-shortcuts-inhibit-unstable-v1" false)
+protocolNew("unstable/text-input" "text-input-unstable-v3" false)
+protocolNew("unstable/pointer-constraints" "pointer-constraints-unstable-v1" false)
+protocolNew("staging/xdg-activation" "xdg-activation-v1" false)
+protocolNew("staging/ext-idle-notify" "ext-idle-notify-v1" false)
+protocolNew("staging/ext-session-lock" "ext-session-lock-v1" false)
+protocolNew("stable/tablet" "tablet-v2" false)
+protocolNew("stable/presentation-time" "presentation-time" false)
+protocolNew("stable/xdg-shell" "xdg-shell" false)
+protocolNew("unstable/primary-selection" "primary-selection-unstable-v1" false)
 
 protocolWayland()
 

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ installheaders:
 	mkdir -p ${PREFIX}/include/hyprland/wlr
 	mkdir -p ${PREFIX}/share/pkgconfig
 
+	cmake --build ./build --config Release --target generate-protocol-headers
+
 	find src -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland
 	cd subprojects/wlroots-hyprland/include/wlr && find . -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland/wlr && cd ../../../..
 	cd subprojects/wlroots-hyprland/build/include && find . -name '*.h*' -print0 | cpio --quiet -0dump ${PREFIX}/include/hyprland/wlr && cd ../../../..


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

As discussed in https://github.com/hyprwm/Hyprland/issues/6115, I think this is how we should do the protocol header generation: add a custom target that simply depends on the `OUTPUT`s of the `add_custom_command`s, and then execute that target in the installheaders step in the Makefile.

This way, the headers will only be generated if necessary, and if they are already there, they won't be overridden.

I reapplied the reverted commit and added my changes in the second commit.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)



#### Is it ready for merging, or does it need work?

ready to merge

CC @fufexan @cnt0 
