### PR TITLE
Add option to disable window direction monitor fallback

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1386,7 +1386,7 @@ PHLWINDOW CCompositor::getWindowInDirection(PHLWINDOW pWindow, char dir) {
         return nullptr;
 
     // 0 -> history, 1 -> shared length
-    static auto PMETHOD = CConfigValue<Hyprlang::INT>("binds:focus_preferred_method");
+    static auto PMETHOD          = CConfigValue<Hyprlang::INT>("binds:focus_preferred_method");
     static auto PMONITORFALLBACK = CConfigValue<Hyprlang::INT>("binds:window_direction_monitor_fallback");
 
     const auto  PMONITOR = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1387,6 +1387,7 @@ PHLWINDOW CCompositor::getWindowInDirection(PHLWINDOW pWindow, char dir) {
 
     // 0 -> history, 1 -> shared length
     static auto PMETHOD = CConfigValue<Hyprlang::INT>("binds:focus_preferred_method");
+    static auto PMONITORFALLBACK = CConfigValue<Hyprlang::INT>("binds:window_direction_monitor_fallback");
 
     const auto  PMONITOR = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
 
@@ -1414,6 +1415,9 @@ PHLWINDOW CCompositor::getWindowInDirection(PHLWINDOW pWindow, char dir) {
                 continue;
 
             if (PWORKSPACE->m_bHasFullscreenWindow && !w->m_bIsFullscreen && !w->m_bCreatedOverFullscreen)
+                continue;
+
+            if (!*PMONITORFALLBACK && pWindow->m_iMonitorID != w->m_iMonitorID)
                 continue;
 
             const auto BWINDOWIDEALBB = w->getWindowIdealBoundingBoxIgnoreReserved();
@@ -1503,6 +1507,9 @@ PHLWINDOW CCompositor::getWindowInDirection(PHLWINDOW pWindow, char dir) {
                 continue;
 
             if (PWORKSPACE->m_bHasFullscreenWindow && !w->m_bIsFullscreen && !w->m_bCreatedOverFullscreen)
+                continue;
+
+            if (!*PMONITORFALLBACK && pWindow->m_iMonitorID != w->m_iMonitorID)
                 continue;
 
             const auto DIST  = w->middle().distance(pWindow->middle());

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -494,6 +494,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("binds:ignore_group_lock", Hyprlang::INT{0});
     m_pConfig->addConfigValue("binds:movefocus_cycles_fullscreen", Hyprlang::INT{1});
     m_pConfig->addConfigValue("binds:disable_keybind_grabbing", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("binds:window_direction_monitor_fallback", Hyprlang::INT{1});
 
     m_pConfig->addConfigValue("gestures:workspace_swipe", Hyprlang::INT{0});
     m_pConfig->addConfigValue("gestures:workspace_swipe_fingers", Hyprlang::INT{3});


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds an option to disable monitor fallback when focusing or moving a window in a direction. A value of `0` will disable moving to an adjacent monitor when focusing/moving a window over the edge of a monitor. A value of `1` (default) will keep behavior as it is now.

With `window_direction_monitor_fallback = 0`:
`movefocus l` will do nothing if the focused window is on the left edge of the monitor (or focus the next window on the workspace depending on `no_focus_fallback`)

`movewindow l` will do nothing if the focused window is already on the left edge of the monitor

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This was a feature request for my plugin (https://github.com/shezdy/hyprsplit/issues/20), but I think it makes sense to implement it here.

I don't think the name `window_direction_monitor_fallback` is ideal but I can't think of anything better so please suggest a better name if you have one.

#### Is it ready for merging, or does it need work?
ready, needs wiki mr

