### PR TITLE
Fix tablet mapping when mapped region is specified

### DIFF
--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -674,8 +674,11 @@ void CPointerManager::warpAbsolute(Vector2D abs, SP<IHID> dev) {
                 }
             }
 
-            if (!TAB->boundBox.empty())
-                mappedArea = TAB->boundBox.translate(currentMonitor->vecPosition);
+            mappedArea.translate(TAB->boundBox.pos());
+            if (!TAB->boundBox.empty()) {
+                mappedArea.w = TAB->boundBox.w;
+                mappedArea.h = TAB->boundBox.h;
+            }
             break;
         }
         case HID_TYPE_TOUCH: {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

When `region_position` or `region_size` is set in the config (non-empty `boundBox`), cursor is mapped to wrong coordinate because `CBox::translate` mutates `TAB->boundBox`, making all subsequent coordinate calculations wrong.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

#### Is it ready for merging, or does it need work?

Ready
