### PR TITLE
Add ARM GPU info

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -883,6 +883,8 @@ std::string systemInfoRequest(eHyprCtlOutputFormat format, std::string request) 
 
 #if defined(__DragonFly__) || defined(__FreeBSD__)
     const std::string GPUINFO = execAndGet("pciconf -lv | fgrep -A4 vga");
+#elif defined(__arm__) || defined(__aarch64__)
+    const std::string GPUINFO = execAndGet("cat /proc/device-tree/soc*/gpu*/compatible");
 #else
     const std::string GPUINFO = execAndGet("lspci -vnn | grep VGA");
 #endif

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -649,6 +649,8 @@ void logSystemInfo() {
 
 #if defined(__DragonFly__) || defined(__FreeBSD__)
     const std::string GPUINFO = execAndGet("pciconf -lv | fgrep -A4 vga");
+#elif defined(__arm__) || defined(__aarch64__)
+    const std::string GPUINFO = execAndGet("cat /proc/device-tree/soc*/gpu*/compatible");
 #else
     const std::string GPUINFO = execAndGet("lspci -vnn | grep VGA");
 #endif


### PR DESCRIPTION
Added a simple way to get basic info about the GPU on ARM based systems

#### Describe your PR, what does it fix/add?
Added missing GPU info on ARM based systems

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This can also work for other device tree based architectures, If anyone wants to add support for that just reuse the code provided

#### Is it ready for merging, or does it need work?
It's ready
Here's a preview from my One plus 6T:
```
[LOG] Instance Signature: df80fbf70650dfb0d96381a1d86d30811cf516f4_1716251706_369982838
[LOG] Runtime directory: /run/user/1000/hypr/df80fbf70650dfb0d96381a1d86d30811cf516f4_1716251706_369982838
[LOG] Hyprland PID: 3098
[LOG] ===== SYSTEM INFO: =====
[LOG] System name: Linux
[LOG] Node name: icicle
[LOG] Release: 6.9.0-rc4-baka+
[LOG] Version: #1 SMP PREEMPT Thu Apr 18 09:30:50 IDT 2024


[LOG] GPU information:
qcom,adreno-630.2

[LOG] os-release:
NAME="Artix Linux"
PRETTY_NAME="Artix Linux"
ID=artix
BUILD_ID=rolling
ANSI_COLOR="0;36"
HOME_URL="https://www.artixlinux.org/"
DOCUMENTATION_URL="https://wiki.artixlinux.org/"
SUPPORT_URL="https://forum.artixlinux.org/"
BUG_REPORT_URL="https://bugs.artixlinux.org/"
PRIVACY_POLICY_URL="https://terms.artixlinux.org/docs/privacy-policy/"
LOGO=artixlinux-logo

[LOG] ========================
```

