### PR TITLE
Add back nvidia hardware cursor

### DIFF
--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -119,7 +119,17 @@ static bool output_pick_cursor_format(struct wlr_output* output, struct wlr_drm_
         }
     }
 
-    return output_pick_format(output, display_formats, format, DRM_FORMAT_ARGB8888);
+    // Note: taken from https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4596/diffs#diff-content-e3ea164da86650995728d70bd118f6aa8c386797
+    // If this fails to find a shared modifier try to use a linear
+    // modifier. This avoids a scenario where the hardware cannot render to
+    // linear textures but only linear textures are supported for cursors,
+    // as is the case with Nvidia and VmWare GPUs
+    if (!output_pick_format(output, display_formats, format, DRM_FORMAT_ARGB8888)) {
+        // Clear the format as output_pick_format doesn't zero it
+        memset(format, 0, sizeof(*format));
+        return output_pick_format(output, NULL, format, DRM_FORMAT_ARGB8888);
+    }
+    return true;
 }
 
 CPointerManager::CPointerManager() {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes the issue that nvidia hardware cursors no longer work after the new cursor implementation
Code is simply taken from https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4596/diffs#diff-content-e3ea164da86650995728d70bd118f6aa8c386797

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Don't know if it would break anything but this just restores the behavior from before the new cursor impl

#### Is it ready for merging, or does it need work?
Should be ready

