### PR TITLE
fix: prevent potential crash in handleBezier and in refreshRate due to invalid input

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1821,26 +1821,20 @@ std::optional<std::string> CConfigManager::handleBezier(const std::string& comma
     const auto  ARGS = CVarList(args);
 
     std::string bezierName = ARGS[0];
+        if (ARGS[1] == "" || ARGS[2] == "" || ARGS[3] == "" || ARGS[4] == "")
+            return "too few arguments";
+        if (ARGS[5]!= "")
+            return "too many arguments";
 
-    if (ARGS[1] == "")
-        return "too few arguments";
-    float p1x = std::stof(ARGS[1]);
-
-    if (ARGS[2] == "")
-        return "too few arguments";
-    float p1y = std::stof(ARGS[2]);
-
-    if (ARGS[3] == "")
-        return "too few arguments";
-    float p2x = std::stof(ARGS[3]);
-
-    if (ARGS[4] == "")
-        return "too few arguments";
-    float p2y = std::stof(ARGS[4]);
-
-    if (ARGS[5] != "")
-        return "too many arguments";
-
+    float p1x = 0, p1y = 0, p2x = 0, p2y = 0;
+    try {
+        p1x = std::stof(ARGS[1]);
+        p1y = std::stof(ARGS[2]);
+        p2x = std::stof(ARGS[3]);
+        p2y = std::stof(ARGS[4]);
+    } catch (const std::invalid_argument&) {
+        return "invalid argument";
+    }
     g_pAnimationManager->addBezierWithName(bezierName, Vector2D(p1x, p1y), Vector2D(p2x, p2y));
 
     return {};

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1706,8 +1706,13 @@ std::optional<std::string> CConfigManager::handleMonitor(const std::string& comm
             newrule.resolution.x = stoi(ARGS[1].substr(0, ARGS[1].find_first_of('x')));
             newrule.resolution.y = stoi(ARGS[1].substr(ARGS[1].find_first_of('x') + 1, ARGS[1].find_first_of('@')));
 
-            if (ARGS[1].contains("@"))
-                newrule.refreshRate = stof(ARGS[1].substr(ARGS[1].find_first_of('@') + 1));
+            if (ARGS[1].contains("@")) {
+                try {
+                    newrule.refreshRate = stof(ARGS[1].substr(ARGS[1].find_first_of('@') + 1));
+                } catch (...) {
+                    return "invalid argument for framerate";
+                }
+            }
         }
     }
 
@@ -1821,10 +1826,11 @@ std::optional<std::string> CConfigManager::handleBezier(const std::string& comma
     const auto  ARGS = CVarList(args);
 
     std::string bezierName = ARGS[0];
-        if (ARGS[1] == "" || ARGS[2] == "" || ARGS[3] == "" || ARGS[4] == "")
-            return "too few arguments";
-        if (ARGS[5]!= "")
-            return "too many arguments";
+
+    if (ARGS.size() < 5)
+        return "too few arguments";
+    if (ARGS[5]!= "")
+        return "too many arguments";
 
     float p1x = 0, p1y = 0, p2x = 0, p2y = 0;
     try {


### PR DESCRIPTION


#### Describe your PR, what does it fix/add?

before, when the conf file contained anything other than a float in the 4 bezier curve generation points for annimations, it crashed Hyprland, which now returns an error message.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This is my first PR, so please check that I haven't done anything wrong. 

#### Is it ready for merging, or does it need work?

It's ready
