### PR TITLE
hyprctl: add listmonitors to hyprpaper's help page

### DIFF
--- a/hyprctl/Strings.hpp
+++ b/hyprctl/Strings.hpp
@@ -70,6 +70,7 @@ const std::string_view HYPRPAPER_HELP = R"#(usage: hyprctl [flags] hyprpaper <re
 requests:
     listactive      → Lists all active images
     listloaded      → Lists all loaded images
+    listmonitors    → Lists all monitors
     preload <path>  → Preloads image
     unload <path>   → Unloads image. Pass 'all' as path to unload all images
     wallpaper       → Issue a wallpaper to call a config wallpaper dynamically
@@ -111,7 +112,7 @@ create <backend>:
 remove <name>:
     Removes virtual output. Pass the output's name, as found in
     'hyprctl monitors'
-    
+
 flags:
     See 'hyprctl --help')#";
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Update to `hyprctl`'s help page, if https://github.com/hyprwm/hyprpaper/pull/174 is merged.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Yes, it is ready.
