### PR TITLE
feat: add delimiter to hyprctl batch command

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1045,13 +1045,15 @@ std::string dispatchBatch(eHyprCtlOutputFormat format, std::string request) {
 
     nextItem();
 
+    const std::string DELIMITER = "\n\n\n";
+
     while (curitem != "" || request != "") {
-        reply += g_pHyprCtl->getReply(curitem);
+        reply += g_pHyprCtl->getReply(curitem) + DELIMITER;
 
         nextItem();
     }
 
-    return reply;
+    return reply.substr(0, std::max(static_cast<int>(reply.size() - DELIMITER.size()), 0));
 }
 
 std::string dispatchSetCursor(eHyprCtlOutputFormat format, std::string request) {


### PR DESCRIPTION


#### Describe your PR, what does it fix/add?

- adds a delimiter of 3 newlines to separate different command outputs

- fixes #6256

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

- Tested and seems to work fine.
- Not sure if this is the best solution to the issue this is trying to fix: #6256. 
  Look at the "Possible Solutions" I listed there and suggest one if you have a better solution than this.

#### Is it ready for merging, or does it need work?

Ready for merging.

