### PR TITLE
fix: make new_window_takes_over_fullscreen use the new window's workspace

### DIFF
--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -466,12 +466,12 @@ void Events::listener_mapWindow(void* owner, void* data) {
     const auto PLSFROMFOCUS = g_pCompositor->getLayerSurfaceFromSurface(g_pCompositor->m_pLastFocus);
     if (PLSFROMFOCUS && PLSFROMFOCUS->layerSurface->current.interactivity != ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE)
         PWINDOW->m_bNoInitialFocus = true;
-    if (PWORKSPACE->m_bHasFullscreenWindow && !requestsFullscreen && !PWINDOW->m_bIsFloating) {
+    if (PWINDOW->m_pWorkspace->m_bHasFullscreenWindow && !requestsFullscreen && !PWINDOW->m_bIsFloating) {
         if (*PNEWTAKESOVERFS == 0)
             PWINDOW->m_bNoInitialFocus = true;
         else if (*PNEWTAKESOVERFS == 2)
-            g_pCompositor->setWindowFullscreen(g_pCompositor->getFullscreenWindowOnWorkspace(PWORKSPACE->m_iID), false, FULLSCREEN_INVALID);
-        else if (PWORKSPACE->m_efFullscreenMode == FULLSCREEN_MAXIMIZED)
+            g_pCompositor->setWindowFullscreen(g_pCompositor->getFullscreenWindowOnWorkspace(PWINDOW->m_pWorkspace->m_iID), false, FULLSCREEN_INVALID);
+        else if (PWINDOW->m_pWorkspace->m_efFullscreenMode == FULLSCREEN_MAXIMIZED)
             requestsMaximize = true;
         else
             requestsFullscreen = true;

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -491,8 +491,8 @@ void Events::listener_mapWindow(void* owner, void* data) {
     if ((requestsFullscreen && (!(PWINDOW->m_eSuppressedEvents & SUPPRESS_FULLSCREEN) || overridingNoFullscreen)) ||
         (requestsMaximize && (!(PWINDOW->m_eSuppressedEvents & SUPPRESS_MAXIMIZE) || overridingNoMaximize)) || requestsFakeFullscreen) {
         // fix fullscreen on requested (basically do a switcheroo)
-        if (PWORKSPACE->m_bHasFullscreenWindow) {
-            const auto PFULLWINDOW = g_pCompositor->getFullscreenWindowOnWorkspace(PWORKSPACE->m_iID);
+        if (PWINDOW->m_pWorkspace->m_bHasFullscreenWindow) {
+            const auto PFULLWINDOW = g_pCompositor->getFullscreenWindowOnWorkspace(PWINDOW->m_pWorkspace->m_iID);
             g_pCompositor->setWindowFullscreen(PFULLWINDOW, false, FULLSCREEN_FULL);
         }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Currently the setting `new_window_takes_over_fullscreen` is applied to the currently focused workspace instead of the workspace the new window is appearing on.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Minimally tested but should be fine

#### Is it ready for merging, or does it need work?
I haven't run into issues regarding this so i think it's okay. Let me know if something isn't though.

