### PR TITLE
fix a few asan reported issues and a coredump on exit

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1625,6 +1625,11 @@ CHyprCtl::CHyprCtl() {
     startHyprCtlSocket();
 }
 
+CHyprCtl::~CHyprCtl() {
+    if (m_eventSource)
+        wl_event_source_remove(m_eventSource);
+}
+
 SP<SHyprCtlCommand> CHyprCtl::registerCommand(SHyprCtlCommand cmd) {
     return m_vCommands.emplace_back(makeShared<SHyprCtlCommand>(cmd));
 }
@@ -1805,5 +1810,5 @@ void CHyprCtl::startHyprCtlSocket() {
 
     Debug::log(LOG, "Hypr socket started at {}", socketPath);
 
-    wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, m_iSocketFD, WL_EVENT_READABLE, hyprCtlFDTick, nullptr);
+    m_eventSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, m_iSocketFD, WL_EVENT_READABLE, hyprCtlFDTick, nullptr);
 }

--- a/src/debug/HyprCtl.hpp
+++ b/src/debug/HyprCtl.hpp
@@ -8,6 +8,7 @@
 class CHyprCtl {
   public:
     CHyprCtl();
+    ~CHyprCtl();
 
     std::string         makeDynamicCall(const std::string& input);
     SP<SHyprCtlCommand> registerCommand(SHyprCtlCommand cmd);
@@ -25,6 +26,7 @@ class CHyprCtl {
     void                             startHyprCtlSocket();
 
     std::vector<SP<SHyprCtlCommand>> m_vCommands;
+    wl_event_source*                 m_eventSource = nullptr;
 };
 
 inline std::unique_ptr<CHyprCtl> g_pHyprCtl;

--- a/src/managers/eventLoop/EventLoopManager.cpp
+++ b/src/managers/eventLoop/EventLoopManager.cpp
@@ -13,6 +13,11 @@ CEventLoopManager::CEventLoopManager() {
     m_sTimers.timerfd = timerfd_create(CLOCK_MONOTONIC, TFD_CLOEXEC);
 }
 
+CEventLoopManager::~CEventLoopManager() {
+    if (m_sWayland.eventSource)
+        wl_event_source_remove(m_sWayland.eventSource);
+}
+
 static int timerWrite(int fd, uint32_t mask, void* data) {
     g_pEventLoopManager->onTimerFire();
     return 1;
@@ -22,7 +27,7 @@ void CEventLoopManager::enterLoop(wl_display* display, wl_event_loop* wlEventLoo
     m_sWayland.loop    = wlEventLoop;
     m_sWayland.display = display;
 
-    wl_event_loop_add_fd(wlEventLoop, m_sTimers.timerfd, WL_EVENT_READABLE, timerWrite, nullptr);
+    m_sWayland.eventSource = wl_event_loop_add_fd(wlEventLoop, m_sTimers.timerfd, WL_EVENT_READABLE, timerWrite, nullptr);
 
     wl_display_run(display);
 

--- a/src/managers/eventLoop/EventLoopManager.hpp
+++ b/src/managers/eventLoop/EventLoopManager.hpp
@@ -10,6 +10,7 @@
 class CEventLoopManager {
   public:
     CEventLoopManager();
+    ~CEventLoopManager();
 
     void enterLoop(wl_display* display, wl_event_loop* wlEventLoop);
 
@@ -24,8 +25,9 @@ class CEventLoopManager {
 
   private:
     struct {
-        wl_event_loop* loop    = nullptr;
-        wl_display*    display = nullptr;
+        wl_event_loop*   loop        = nullptr;
+        wl_display*      display     = nullptr;
+        wl_event_source* eventSource = nullptr;
     } m_sWayland;
 
     struct {

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -837,6 +837,17 @@ CXWM::CXWM() {
     xcb_flush(connection);
 }
 
+CXWM::~CXWM() {
+    if (errors)
+        xcb_errors_context_free(errors);
+
+    if (connection)
+        xcb_disconnect(connection);
+
+    if (eventSource)
+        wl_event_source_remove(eventSource);
+}
+
 void CXWM::setActiveWindow(xcb_window_t window) {
     xcb_change_property(connection, XCB_PROP_MODE_REPLACE, screen->root, HYPRATOMS["_NET_ACTIVE_WINDOW"], HYPRATOMS["WINDOW"], 32, 1, &window);
 }

--- a/src/xwayland/XWM.hpp
+++ b/src/xwayland/XWM.hpp
@@ -60,6 +60,7 @@ struct SXSelection {
 class CXWM {
   public:
     CXWM();
+    ~CXWM();
 
     int onEvent(int fd, uint32_t mask);
 


### PR DESCRIPTION
the wl_event_resource was running upon destruction of the compositor causing a null pointer segfault in onX11Event so ensure the event is removed upon destruction, also free the memory allocated by xcb_errors_context_new and finally call xcb_disconnect on the connection to free the fd and its memory.

also free the eventsources in hyprctl and eventloopmanager.
