### PR TITLE
Fix initial xdg-decoration toplevel decoration mode negotiation

### DIFF
--- a/src/protocols/XDGDecoration.cpp
+++ b/src/protocols/XDGDecoration.cpp
@@ -26,6 +26,8 @@ CXDGDecoration::CXDGDecoration(SP<CZxdgToplevelDecorationV1> resource_, wl_resou
         LOGM(LOG, "unsetMode. Sending MODE_SERVER_SIDE.");
         resource->sendConfigure(ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE);
     });
+
+    resource->sendConfigure(ZXDG_TOPLEVEL_DECORATION_V1_MODE_SERVER_SIDE);
 }
 
 bool CXDGDecoration::good() {


### PR DESCRIPTION
Clients using zxdg_decoration_manager_v1::get_toplevel_decoration may expect a receiving a zxdg_toplevel_decoration_v1::configure event to determine the initial decoration mode, without having to go through a zxdg_toplevel_decoration_v1::set_mode request. Hyprland was not sending this event, resulting in unwanted decorations being drawn.

Specifically, clients using libdecor, e.g. applications using recent GLFW, would draw GTK decorations with artefacts. This change fixes these.

This fixes #5861 but may not be the right place from which to send this event,  so please review

