### PR TITLE
log: log with local timezone

### DIFF
--- a/src/debug/Log.hpp
+++ b/src/debug/Log.hpp
@@ -48,12 +48,9 @@ namespace Debug {
 
         // print date and time to the ofs
         if (disableTime && !**disableTime) {
-#ifndef _LIBCPP_VERSION
-            logMsg += std::format("[{:%T}] ", std::chrono::hh_mm_ss{std::chrono::system_clock::now() - std::chrono::floor<std::chrono::days>(std::chrono::system_clock::now())});
-#else
-            auto c = std::chrono::hh_mm_ss{std::chrono::system_clock::now() - std::chrono::floor<std::chrono::days>(std::chrono::system_clock::now())};
-            logMsg += std::format("{:%H}:{:%M}:{:%S}", c.hours(), c.minutes(), c.subseconds());
-#endif
+            auto zt  = std::chrono::zoned_time{std::chrono::current_zone(), std::chrono::system_clock::now()};
+            auto hms = std::chrono::hh_mm_ss{zt.get_local_time() - std::chrono::floor<std::chrono::days>(zt.get_local_time())};
+            logMsg += std::format("[{}] ", hms);
         }
 
         // no need for try {} catch {} because std::format_string<Args...> ensures that vformat never throw std::format_error

--- a/src/debug/Log.hpp
+++ b/src/debug/Log.hpp
@@ -48,8 +48,13 @@ namespace Debug {
 
         // print date and time to the ofs
         if (disableTime && !**disableTime) {
-            auto zt  = std::chrono::zoned_time{std::chrono::current_zone(), std::chrono::system_clock::now()};
-            auto hms = std::chrono::hh_mm_ss{zt.get_local_time() - std::chrono::floor<std::chrono::days>(zt.get_local_time())};
+#ifndef _LIBCPP_VERSION
+            const auto zt  = std::chrono::zoned_time{std::chrono::current_zone(), std::chrono::system_clock::now()};
+            const auto hms = std::chrono::hh_mm_ss{zt.get_local_time() - std::chrono::floor<std::chrono::days>(zt.get_local_time())};
+#else
+            // TODO: current clang 17 does not support `zoned_time`, remove this once clang 19 is ready
+            const auto hms = std::chrono::hh_mm_ss{std::chrono::system_clock::now() - std::chrono::floor<std::chrono::days>(std::chrono::system_clock::now())};
+#endif
             logMsg += std::format("[{}] ", hms);
         }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Now that local timezone is there, why not?

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

`libc++` seems to support the format of `std::chrono::hh_mm_ss`, so the conditional compilation statement was removed. Not for sure, please confirm

#### Is it ready for merging, or does it need work?

ready

