### PR TITLE
fix non-pch build

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -9,6 +9,7 @@
 #include "helpers/VarList.hpp"
 
 #include <optional>
+#include <iterator>
 #include <string>
 #include <string_view>
 


### PR DESCRIPTION
src/managers/KeybindManager.cpp is missing `#include <iterator>`.
