### PR TITLE
feat: cursor warps maintain relative position within a window

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -521,6 +521,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("cursor:hotspot_padding", Hyprlang::INT{1});
     m_pConfig->addConfigValue("cursor:inactive_timeout", Hyprlang::INT{0});
     m_pConfig->addConfigValue("cursor:no_warps", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("cursor:persistent_warps", Hyprlang::INT{0});
     m_pConfig->addConfigValue("cursor:default_monitor", {STRVAL_EMPTY});
     m_pConfig->addConfigValue("cursor:zoom_factor", {1.f});
     m_pConfig->addConfigValue("cursor:zoom_rigid", Hyprlang::INT{0});

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1356,7 +1356,7 @@ void CWindow::activate(bool force) {
         g_pCompositor->changeWindowZOrder(m_pSelf.lock(), true);
 
     g_pCompositor->focusWindow(m_pSelf.lock());
-    g_pCompositor->warpCursorTo(middle());
+    warpCursor();
 }
 
 void CWindow::onUpdateState() {
@@ -1529,4 +1529,17 @@ void CWindow::onX11Configure(CBox box) {
         g_pInputManager->refocus();
 
     g_pHyprRenderer->damageWindow(m_pSelf.lock());
+}
+
+void CWindow::warpCursor() {
+    const auto coords = m_vRelativeCursorCoordsOnLastWarp;
+
+    // effectivly reset m_vRelativeCursorCoordsOnLastWarp
+    m_vRelativeCursorCoordsOnLastWarp.x = -1;
+
+    // we don't wanna warp cursor outside the window
+    if (true && coords.x >= 0 && coords.y >= 0 && coords < m_vSize) {
+        g_pCompositor->warpCursorTo(m_vPosition + coords);
+    } else
+        g_pCompositor->warpCursorTo(middle());
 }

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1532,13 +1532,11 @@ void CWindow::onX11Configure(CBox box) {
 }
 
 void CWindow::warpCursor() {
-    const auto coords = m_vRelativeCursorCoordsOnLastWarp;
+    static auto PERSISTENTWARPS         = CConfigValue<Hyprlang::INT>("cursor:persistent_warps");
+    const auto  coords                  = m_vRelativeCursorCoordsOnLastWarp;
+    m_vRelativeCursorCoordsOnLastWarp.x = -1; // reset m_vRelativeCursorCoordsOnLastWarp
 
-    // effectivly reset m_vRelativeCursorCoordsOnLastWarp
-    m_vRelativeCursorCoordsOnLastWarp.x = -1;
-
-    // we don't wanna warp cursor outside the window
-    if (true && coords.x > 0 && coords.y > 0 && coords < m_vSize) {
+    if (*PERSISTENTWARPS && coords.x > 0 && coords.y > 0 && coords < m_vSize) { // don't warp cursor outside the window
         g_pCompositor->warpCursorTo(m_vPosition + coords);
     } else
         g_pCompositor->warpCursorTo(middle());

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1538,7 +1538,7 @@ void CWindow::warpCursor() {
     m_vRelativeCursorCoordsOnLastWarp.x = -1;
 
     // we don't wanna warp cursor outside the window
-    if (true && coords.x >= 0 && coords.y >= 0 && coords < m_vSize) {
+    if (true && coords.x > 0 && coords.y > 0 && coords < m_vSize) {
         g_pCompositor->warpCursorTo(m_vPosition + coords);
     } else
         g_pCompositor->warpCursorTo(middle());

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1536,8 +1536,8 @@ void CWindow::warpCursor() {
     const auto  coords                  = m_vRelativeCursorCoordsOnLastWarp;
     m_vRelativeCursorCoordsOnLastWarp.x = -1; // reset m_vRelativeCursorCoordsOnLastWarp
 
-    if (*PERSISTENTWARPS && coords.x > 0 && coords.y > 0 && coords < m_vSize) { // don't warp cursor outside the window
+    if (*PERSISTENTWARPS && coords.x > 0 && coords.y > 0 && coords < m_vSize) // don't warp cursor outside the window
         g_pCompositor->warpCursorTo(m_vPosition + coords);
-    } else
+    else
         g_pCompositor->warpCursorTo(middle());
 }

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -245,8 +245,11 @@ class CWindow {
     Vector2D m_vFloatingOffset = Vector2D(0, 0);
 
     // this is used for pseudotiling
-    bool         m_bIsPseudotiled = false;
-    Vector2D     m_vPseudoSize    = Vector2D(1280, 720);
+    bool     m_bIsPseudotiled = false;
+    Vector2D m_vPseudoSize    = Vector2D(1280, 720);
+
+    // for recovering relative cursor position
+    Vector2D     m_vRelativeCursorCoordsOnLastWarp;
 
     bool         m_bFirstMap           = false; // for layouts
     bool         m_bIsFloating         = false;
@@ -446,6 +449,7 @@ class CWindow {
     void                     onResourceChangeX11();
     std::string              fetchTitle();
     std::string              fetchClass();
+    void                     warpCursor();
 
     // listeners
     void onAck(uint32_t serial);

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -249,7 +249,7 @@ class CWindow {
     Vector2D m_vPseudoSize    = Vector2D(1280, 720);
 
     // for recovering relative cursor position
-    Vector2D     m_vRelativeCursorCoordsOnLastWarp;
+    Vector2D     m_vRelativeCursorCoordsOnLastWarp = Vector2D(-1, -1);
 
     bool         m_bFirstMap           = false; // for layouts
     bool         m_bIsFloating         = false;

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -278,7 +278,7 @@ bool CKeybindManager::tryMoveFocusToMonitor(CMonitor* monitor) {
     const auto PNEWWINDOW = PNEWWORKSPACE->getLastFocusedWindow();
     if (PNEWWINDOW) {
         g_pCompositor->focusWindow(PNEWWINDOW);
-        g_pCompositor->warpCursorTo(PNEWWINDOW->middle());
+        PNEWWINDOW->warpCursor();
 
         g_pInputManager->m_pForcedFocus = PNEWWINDOW;
         g_pInputManager->simulateMouseMovement();
@@ -314,7 +314,7 @@ void CKeybindManager::switchToWindow(PHLWINDOW PWINDOWTOCHANGETO) {
             g_pCompositor->setWindowFullscreen(PWINDOWTOCHANGETO, true, FSMODE);
     } else {
         g_pCompositor->focusWindow(PWINDOWTOCHANGETO);
-        g_pCompositor->warpCursorTo(PWINDOWTOCHANGETO->middle());
+        PWINDOWTOCHANGETO->warpCursor();
 
         g_pInputManager->m_pForcedFocus = PWINDOWTOCHANGETO;
         g_pInputManager->simulateMouseMovement();
@@ -1171,7 +1171,7 @@ void CKeybindManager::moveActiveToWorkspace(std::string args) {
     pMonitor->changeWorkspace(pWorkspace);
 
     g_pCompositor->focusWindow(PWINDOW);
-    g_pCompositor->warpCursorTo(PWINDOW->middle());
+    PWINDOW->warpCursor();
 }
 
 void CKeybindManager::moveActiveToWorkspaceSilent(std::string args) {
@@ -1304,7 +1304,7 @@ void CKeybindManager::swapActive(std::string args) {
         return;
 
     g_pLayoutManager->getCurrentLayout()->switchWindows(PLASTWINDOW, PWINDOWTOCHANGETO);
-    g_pCompositor->warpCursorTo(PLASTWINDOW->middle());
+    PLASTWINDOW->warpCursor();
 }
 
 void CKeybindManager::moveActiveTo(std::string args) {
@@ -1359,7 +1359,7 @@ void CKeybindManager::moveActiveTo(std::string args) {
     if (PWINDOWTOCHANGETO) {
         g_pLayoutManager->getCurrentLayout()->moveWindowTo(PLASTWINDOW, args, silent);
         if (!silent)
-            g_pCompositor->warpCursorTo(PLASTWINDOW->middle());
+            PLASTWINDOW->warpCursor();
         return;
     }
 
@@ -1926,7 +1926,7 @@ void CKeybindManager::focusWindow(std::string regexp) {
     } else
         g_pCompositor->focusWindow(PWINDOW);
 
-    g_pCompositor->warpCursorTo(PWINDOW->middle());
+    PWINDOW->warpCursor();
 }
 
 void CKeybindManager::tagWindow(std::string args) {
@@ -2455,7 +2455,7 @@ void CKeybindManager::moveWindowIntoGroup(PHLWINDOW pWindow, PHLWINDOW pWindowIn
     pWindow->updateWindowDecos();
     g_pLayoutManager->getCurrentLayout()->recalculateWindow(pWindow);
     g_pCompositor->focusWindow(pWindow);
-    g_pCompositor->warpCursorTo(pWindow->middle());
+    pWindow->warpCursor();
 
     if (!pWindow->getDecorationByType(DECORATION_GROUPBAR))
         pWindow->addWindowDeco(std::make_unique<CHyprGroupBarDecoration>(pWindow));
@@ -2493,10 +2493,10 @@ void CKeybindManager::moveWindowOutOfGroup(PHLWINDOW pWindow, const std::string&
 
     if (*BFOCUSREMOVEDWINDOW) {
         g_pCompositor->focusWindow(pWindow);
-        g_pCompositor->warpCursorTo(pWindow->middle());
+        pWindow->warpCursor();
     } else {
         g_pCompositor->focusWindow(PWINDOWPREV);
-        g_pCompositor->warpCursorTo(PWINDOWPREV->middle());
+        PWINDOWPREV->warpCursor();
     }
 
     g_pEventManager->postEvent(SHyprIPCEvent{"moveoutofgroup", std::format("{:x}", (uintptr_t)pWindow.get())});
@@ -2580,20 +2580,20 @@ void CKeybindManager::moveWindowOrGroup(std::string args) {
     if (PWINDOWINDIR && PWINDOWINDIR->m_sGroupData.pNextWindow) { // target is group
         if (!*PIGNOREGROUPLOCK && (PWINDOWINDIR->getGroupHead()->m_sGroupData.locked || ISWINDOWGROUPLOCKED || PWINDOW->m_sGroupData.deny)) {
             g_pLayoutManager->getCurrentLayout()->moveWindowTo(PWINDOW, args);
-            g_pCompositor->warpCursorTo(PWINDOW->middle());
+            PWINDOW->warpCursor();
         } else
             moveWindowIntoGroup(PWINDOW, PWINDOWINDIR);
     } else if (PWINDOWINDIR) { // target is regular window
         if ((!*PIGNOREGROUPLOCK && ISWINDOWGROUPLOCKED) || !ISWINDOWGROUP || (ISWINDOWGROUPSINGLE && PWINDOW->m_eGroupRules & GROUP_SET_ALWAYS)) {
             g_pLayoutManager->getCurrentLayout()->moveWindowTo(PWINDOW, args);
-            g_pCompositor->warpCursorTo(PWINDOW->middle());
+            PWINDOW->warpCursor();
         } else
             moveWindowOutOfGroup(PWINDOW, args);
     } else if ((*PIGNOREGROUPLOCK || !ISWINDOWGROUPLOCKED) && ISWINDOWGROUP) { // no target window
         moveWindowOutOfGroup(PWINDOW, args);
     } else if (!PWINDOWINDIR && !ISWINDOWGROUP) { // no target in dir and not in group
         g_pLayoutManager->getCurrentLayout()->moveWindowTo(PWINDOW, args);
-        g_pCompositor->warpCursorTo(PWINDOW->middle());
+        PWINDOW->warpCursor();
     }
 
     g_pCompositor->updateWindowAnimatedDecorationValues(PWINDOW);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -263,8 +263,8 @@ void updateRelativeCursorCoords() {
     if (*PNOWARPS)
         return;
 
-    if (const auto PLASTWINDOW = g_pCompositor->m_pLastWindow.lock(); PLASTWINDOW)
-        PLASTWINDOW->m_vRelativeCursorCoordsOnLastWarp = g_pInputManager->getMouseCoordsInternal() - PLASTWINDOW->m_vPosition;
+    if (g_pCompositor->m_pLastWindow)
+        g_pCompositor->m_pLastWindow->m_vRelativeCursorCoordsOnLastWarp = g_pInputManager->getMouseCoordsInternal() - g_pCompositor->m_pLastWindow->m_vPosition;
 }
 
 bool CKeybindManager::tryMoveFocusToMonitor(CMonitor* monitor) {


### PR DESCRIPTION
Enables hyprland to remember the position of the cursor relative to a window when the window is unfocused (unless caused by **continuous** cursor movement). later, when the window is refocused, the cursor will be warped back to its previously remembered position within that window, rather than to the centre of the window.

in addition, when moving a focused window, the relative cursor position would also be maintained instead of jumping to the centre. this includes
- swap windows
- moving windows
- adding or removing windows from groups
- moving windows to different workspaces 


as a fallback, the cursor is still moved to the centre of the window when 
- the cursor is outside the window when it is unfocused
- the cursor would be distorted outside the window if the relative position is remembered.

this behaviour is controlled by `cursor:persistent_warps`.

## use case

improves usability for workflows where it is beneficial to maintain the cursor position within a window context, such as when frequently switching between multiple windows, e.g. between a browser and an ide.

this should be more noticeable to laptop users with trackpads, as these devices are relatively close to the keyboard and tend to be imprecise and require a lot of finger movement.

## mechanism

### terms

- *warp*: a **discontinuous** cursor movement.
- *discontinuous unfocus*: losing focus of a window that is **not** caused by moving the mouse continuously. currently it is usually caused by the movefocus dispatcher.
- *relative cursor position*: the coordination of the cursor relative to the upper left corner of a window.

### cursor position tracking

`vector2d cwindow::m_vrelativecursorcoordsonlastwarp` stores the cursor position relative to the window. it was updated whenever the window was about to lose focus discontinuously.

### cursor warpping

`void cwindow::warpcursor()` handles the logic for warping the cursor.
- if presistent_warps is disabled or the saved position is invalid, it behaves identically to `g_pcompositor->warpcursorto(window->middle())`, i.e. warp the cursor to the middle of the window;
- otherwise it warps the cursor to the previously stored relative position.

### integration with keybindings

- `updaterelativecursorcoords` will update the relative cursor position before the last focused window is about to discontinuously lose focus. 
- several dispatchers are updated to call `updaterelativecursorcoords` before change of window position and to use the `cwindow::warpcursor()` method instead of warping the cursor to the centre of the window directly.
