### PR TITLE
also test cross build

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         package:
           - hyprland
+          - hyprland-cross
           - xdg-desktop-portal-hyprland
 
     runs-on: ubuntu-latest

--- a/flake.lock
+++ b/flake.lock
@@ -154,11 +154,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1726755586,
-        "narHash": "sha256-PmUr/2GQGvFTIJ6/Tvsins7Q43KTMvMFhvG6oaYK+Wk=",
+        "lastModified": 1727122398,
+        "narHash": "sha256-o8VBeCWHBxGd4kVMceIayf5GApqTavJbTa44Xcg5Rrk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c04d5652cfa9742b1d519688f65d1bbccea9eb7e",
+        "rev": "30439d93eb8b19861ccbe3e581abf97bdc91b093",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,15 @@
           hyprland-extras
         ];
       });
+    pkgsCrossFor = eachSystem (system: crossSystem:
+      import nixpkgs {
+        localSystem = system;
+        crossSystem = crossSystem;
+        overlays = with self.overlays; [
+          hyprland-packages
+          hyprland-extras
+        ];
+      });
   in {
     overlays = import ./nix/overlays.nix {inherit self lib inputs;};
 
@@ -92,6 +101,7 @@
         
         xdg-desktop-portal-hyprland
         ;
+      hyprland-cross = (pkgsCrossFor.${system} "aarch64-linux").hyprland;
     });
 
     devShells = eachSystem (system: {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -102,7 +102,6 @@ in
         ninja
         pkg-config
         python3 # for udis86
-        wayland-scanner
       ];
 
       outputs = [
@@ -130,6 +129,7 @@ in
           tomlplusplus
           wayland
           wayland-protocols
+          wayland-scanner
           xorg.libXcursor
         ]
         (optionals customStdenv.hostPlatform.isMusl [libexecinfo])


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

We noticed that a recent update broken cross compilation in nixpkgs and therefore added tests for this upstream - I saw that this project uses the magic-nix-cache so hopefully all cross-build dependencies will be cached.

CMake Error at /nix/store/q1nssraba326p2kp6627hldd2bhg254c-cmake-3.29.2/share/cmake-3.29/Modules/FindPkgConfig.cmake:634 (message):
  The following required packages were not found:

   - hwdata

Adding `hwdata` and `hyprwayland-scanner` seems to make the pkg-config happy, but than it looks like it's pulling `hyprwayland-scanner` for the wrong architecture. I saw that your meson build seems to be somewhat cross-compiling aware, so I am not quite sure what is going on here. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?


