### PR TITLE
free more memory on destruction

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -147,7 +147,7 @@ void CCompositor::initServer() {
     m_sWLEventLoop = wl_display_get_event_loop(m_sWLDisplay);
 
     // register crit signal handler
-    wl_event_loop_add_signal(m_sWLEventLoop, SIGTERM, handleCritSignal, nullptr);
+    m_critSigSource = wl_event_loop_add_signal(m_sWLEventLoop, SIGTERM, handleCritSignal, nullptr);
 
     if (!envEnabled("HYPRLAND_NO_CRASHREPORTER")) {
         signal(SIGSEGV, handleUnrecoverableSignal);
@@ -372,6 +372,9 @@ void CCompositor::cleanup() {
 
     if (m_sWLRBackend)
         wlr_backend_destroy(m_sWLRBackend);
+
+    if (m_critSigSource)
+        wl_event_source_remove(m_critSigSource);
 
     wl_display_terminate(m_sWLDisplay);
     m_sWLDisplay = nullptr;

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -178,14 +178,15 @@ class CCompositor {
     std::string  explicitConfigPath;
 
   private:
-    void     initAllSignals();
-    void     removeAllSignals();
-    void     cleanEnvironment();
-    void     setRandomSplash();
-    void     initManagers(eManagersInitStage stage);
-    void     prepareFallbackOutput();
+    void             initAllSignals();
+    void             removeAllSignals();
+    void             cleanEnvironment();
+    void             setRandomSplash();
+    void             initManagers(eManagersInitStage stage);
+    void             prepareFallbackOutput();
 
-    uint64_t m_iHyprlandPID = 0;
+    uint64_t         m_iHyprlandPID  = 0;
+    wl_event_source* m_critSigSource = nullptr;
 };
 
 inline std::unique_ptr<CCompositor> g_pCompositor;

--- a/src/desktop/Popup.cpp
+++ b/src/desktop/Popup.cpp
@@ -136,7 +136,7 @@ void CPopup::onCommit(bool ignoreSiblings) {
         onDestroy();
         return;
     }
-    
+
     if (m_pResource->surface->initialCommit) {
         m_pResource->surface->scheduleConfigure();
         return;

--- a/src/managers/CursorManager.cpp
+++ b/src/managers/CursorManager.cpp
@@ -58,6 +58,9 @@ CCursorManager::CCursorManager() {
 CCursorManager::~CCursorManager() {
     if (m_pWLRXCursorMgr)
         wlr_xcursor_manager_destroy(m_pWLRXCursorMgr);
+
+    if (m_pAnimationTimer)
+        wl_event_source_remove(m_pAnimationTimer);
 }
 
 void CCursorManager::dropBufferRef(CCursorManager::CCursorBuffer* ref) {

--- a/src/managers/PointerManager.hpp
+++ b/src/managers/PointerManager.hpp
@@ -146,6 +146,11 @@ class CPointerManager {
 
     struct SMonitorPointerState {
         SMonitorPointerState(SP<CMonitor> m) : monitor(m) {}
+        ~SMonitorPointerState() {
+            if (cursorFrontBuffer)
+                wlr_buffer_unlock(cursorFrontBuffer);
+        }
+
         WP<CMonitor> monitor;
 
         int          softwareLocks  = 0;


### PR DESCRIPTION
with these most direct leaks reported by asan should be handled, the only thing remaining is the shared/weakptr reports and a few indirect ones inside wlroots/libwayland which im not sure if its just false positives.


