### PR TITLE
HookSystemManager: Make needsDeadCleanup volatile

### DIFF
--- a/src/managers/HookSystemManager.cpp
+++ b/src/managers/HookSystemManager.cpp
@@ -28,7 +28,7 @@ void CHookSystemManager::emit(std::vector<SCallbackFNPtr>* const callbacks, SCal
         return;
 
     std::vector<HANDLE> faultyHandles;
-    bool                needsDeadCleanup = false;
+    volatile bool       needsDeadCleanup = false;
 
     for (auto& cb : *callbacks) {
 


### PR DESCRIPTION
The value of needsDeadCleanup would be clobbered after longjmp, having an undefined value.

By making this variable volatile, it will always be read/written in memory instead of being stored in a register.