### PR TITLE
Add description do key binds

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -6,6 +6,7 @@
 #include "helpers/VarList.hpp"
 #include "../protocols/LayerShell.hpp"
 
+#include <cstddef>
 #include <cstdint>
 #include <string.h>
 #include <string>
@@ -1991,9 +1992,9 @@ std::optional<std::string> CConfigManager::handleBind(const std::string& command
     if (mouse && (repeat || release || locked))
         return "flag m is exclusive";
 
-    auto ARGS = CVarList(value, 4);
+    auto       ARGS = CVarList(value, 4);
 
-    const bool HAS_DESCRIPTION = ARGS[2].starts_with("\"") && ARGS[2].ends_with("\"");
+    const bool HAS_DESCRIPTION = ARGS[2].length() > 1 && ARGS[2].starts_with("\"") && ARGS[2].ends_with("\"");
 
     if (HAS_DESCRIPTION) {
         ARGS = CVarList(value, 5);
@@ -2001,7 +2002,7 @@ std::optional<std::string> CConfigManager::handleBind(const std::string& command
     const int DESCR_OFFSET = HAS_DESCRIPTION ? 1 : 0;
     if ((ARGS.size() < 3 && !mouse) || (ARGS.size() < 3 && mouse))
         return "bind: too few args";
-    else if ((ARGS.size() > 4 + DESCR_OFFSET && !mouse) || (ARGS.size() > 3 + DESCR_OFFSET && mouse))
+    else if ((ARGS.size() > (size_t)4 + DESCR_OFFSET && !mouse) || (ARGS.size() > (size_t)3 + DESCR_OFFSET && mouse))
         return "bind: too many args";
 
     std::set<xkb_keysym_t> KEYSYMS;
@@ -2020,7 +2021,7 @@ std::optional<std::string> CConfigManager::handleBind(const std::string& command
 
     const auto KEY = multiKey ? "" : ARGS[1];
 
-    const auto DESCRIPTION = HAS_DESCRIPTION ? ARGS[2] : "";
+    const auto DESCRIPTION = HAS_DESCRIPTION ? ARGS[2].substr(1, ARGS.size() - 1) : "";
 
     auto       HANDLER = ARGS[2 + DESCR_OFFSET];
 

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -24,6 +24,7 @@ struct SKeybind {
     std::string            arg          = "";
     bool                   locked       = false;
     std::string            submap       = "";
+    std::string            description  = "";
     bool                   release      = false;
     bool                   repeat       = false;
     bool                   mouse        = false;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
I'm bad at remembering key binds and was always a fan of nvim plugins like which key. For something like this, a way of describing your key binds is necessary.

My proposal would look something like this:
```conf
bind = SUPER, T, "open my terminal", exec, kitty
```
but obviously, it should be backward compatible so this should also be no problem:
```conf
bind = SUPER, T, exec, kitty
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
Feedback is wanted but it's merge ready from my end.

closes #6357 