### PR TITLE
build: include missing header: "debug/Log.hpp" in Format.cpp

### DIFF
--- a/src/helpers/Format.cpp
+++ b/src/helpers/Format.cpp
@@ -1,6 +1,7 @@
 #include "Format.hpp"
 #include <vector>
 #include "../includes.hpp"
+#include "debug/Log.hpp"
 
 /*
     DRM formats are LE, while OGL is BE. The two primary formats


### PR DESCRIPTION
Referenced here

https://github.com/hyprwm/Hyprland/blob/3fb079a2a365976b846644571322288d91a1ebc2/src/helpers/Format.cpp#L259

How come CI didn't report this?

https://github.com/hyprwm/Hyprland/blob/211353dc34b8f0fa17fc1e4d1d5f04d6fe1910e5/.github/workflows/ci.yaml#L66-L83
