### PR TITLE
helpers: fix misuse of syscalls in sd namespace

### DIFF
--- a/src/helpers/SdDaemon.cpp
+++ b/src/helpers/SdDaemon.cpp
@@ -21,8 +21,8 @@ namespace Systemd {
     }
 
     int SdNotify(int unsetEnvironment, const char* state) {
-        int fd = socket(AF_UNIX, SOCK_DGRAM, 0);
-        if (fd == -1)
+        int fd = socket(AF_UNIX, SOCK_DGRAM | SOCK_CLOEXEC, 0);
+        if (fd < 0)
             return -errno;
 
         constexpr char envVar[] = "NOTIFY_SOCKET";
@@ -47,12 +47,12 @@ namespace Systemd {
         if (unixAddr.sun_path[0] == '@')
             unixAddr.sun_path[0] = '\0';
 
-        if (!connect(fd, (const sockaddr*)&unixAddr, sizeof(struct sockaddr_un)))
-            return 1;
+        if (connect(fd, (const sockaddr*)&unixAddr, sizeof(struct sockaddr_un)) < 0)
+            return -errno;
 
         // arbitrary value which seems to be enough for s-d messages
-        size_t stateLen = strnlen(state, 128);
-        if (write(fd, state, stateLen) >= 0)
+        ssize_t stateLen = strnlen(state, 128);
+        if (write(fd, state, stateLen) == stateLen)
             return 1;
 
         return -errno;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes systemd notifications. Current implementation exits once "connect" syscall is succeeded (rc=0).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?

Tested and ready.