### PR TITLE
Fix layershell keyboard focus grabs (#4968)

### DIFF
--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -180,9 +180,6 @@ void CLayerSurface::onUnmap() {
 
     std::erase_if(g_pInputManager->m_dExclusiveLSes, [this](const auto& other) { return !other.lock() || other.lock() == self.lock(); });
 
-    if (!g_pInputManager->m_dExclusiveLSes.empty())
-        g_pCompositor->focusSurface(g_pInputManager->m_dExclusiveLSes[0]->surface->resource());
-
     if (!g_pCompositor->getMonitorFromID(monitorID) || g_pCompositor->m_bUnsafeState) {
         Debug::log(WARN, "Layersurface unmapping on invalid monitor (removed?) ignoring.");
 
@@ -221,6 +218,10 @@ void CLayerSurface::onUnmap() {
         SP<CWLSurfaceResource> foundSurface = nullptr;
 
         g_pCompositor->m_pLastFocus.reset();
+
+        // try to focus the last exclusive ls first
+        if (!g_pInputManager->m_dExclusiveLSes.empty())
+            g_pCompositor->focusSurface(g_pInputManager->m_dExclusiveLSes[g_pInputManager->m_dExclusiveLSes.size() - 1]->surface->resource());
 
         // find LS-es to focus
         foundSurface = g_pCompositor->vectorToLayerSurface(g_pInputManager->getMouseCoordsInternal(), &PMONITOR->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY],

--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -133,12 +133,15 @@ void CLayerSurface::onMap() {
 
     surface->resource()->enter(PMONITOR->self.lock());
 
-    if (layerSurface->current.interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE)
+    const bool isExclusive = layerSurface->current.interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE;
+
+    if (isExclusive)
         g_pInputManager->m_dExclusiveLSes.push_back(self);
 
-    const bool GRABSFOCUS = layerSurface->current.interactivity != ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE &&
-        // don't focus if constrained
-        (g_pSeatManager->mouse.expired() || !g_pInputManager->isConstrained());
+    const bool GRABSFOCUS = isExclusive ||
+        (layerSurface->current.interactivity != ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE &&
+         // don't focus if constrained
+         (g_pSeatManager->mouse.expired() || !g_pInputManager->isConstrained()));
 
     if (GRABSFOCUS) {
         // TODO: use the new superb really very cool grab

--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -297,9 +297,9 @@ void CLayerSurface::onCommit() {
             std::erase_if(g_pInputManager->m_dExclusiveLSes, [this](const auto& other) { return !other.lock() || other.lock() == self.lock(); });
 
         // if the surface was focused and interactive but now isn't, refocus
-        if (WASLASTFOCUS && !layerSurface->current.interactivity) {
+        if (WASLASTFOCUS && !layerSurface->current.interactivity)
             g_pInputManager->refocusLastWindow(g_pCompositor->getMonitorFromID(monitorID));
-        } else if (!WASLASTFOCUS && (ISEXCLUSIVE || (layerSurface->current.interactivity && (g_pSeatManager->mouse.expired() || !g_pInputManager->isConstrained())))) {
+        else if (!WASLASTFOCUS && (ISEXCLUSIVE || (layerSurface->current.interactivity && (g_pSeatManager->mouse.expired() || !g_pInputManager->isConstrained())))) {
             // if not focused last and exclusive or accepting input + unconstrained
             g_pSeatManager->setGrab(nullptr);
             g_pInputManager->releaseAllMouseButtons();

--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -299,7 +299,8 @@ void CLayerSurface::onCommit() {
         // if the surface was focused and interactive but now isn't, refocus
         if (WASLASTFOCUS && !layerSurface->current.interactivity)
             g_pInputManager->refocusLastWindow(g_pCompositor->getMonitorFromID(monitorID));
-        else if (!WASLASTFOCUS && (ISEXCLUSIVE || (layerSurface->current.interactivity && (g_pSeatManager->mouse.expired() || !g_pInputManager->isConstrained())))) {
+        else if (!WASEXCLUSIVE && !WASLASTFOCUS &&
+                 (ISEXCLUSIVE || (layerSurface->current.interactivity && (g_pSeatManager->mouse.expired() || !g_pInputManager->isConstrained())))) {
             // if not focused last and exclusive or accepting input + unconstrained
             g_pSeatManager->setGrab(nullptr);
             g_pInputManager->releaseAllMouseButtons();

--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -4,7 +4,6 @@
 #include "../protocols/LayerShell.hpp"
 #include "../protocols/core/Compositor.hpp"
 #include "../managers/SeatManager.hpp"
-#include "managers/input/InputManager.hpp"
 
 PHLLS CLayerSurface::create(SP<CLayerShellResource> resource) {
     PHLLS     pLS = SP<CLayerSurface>(new CLayerSurface(resource));
@@ -211,7 +210,8 @@ void CLayerSurface::onUnmap() {
         return;
 
     // refocus if needed
-    if (WASLASTFOCUS) g_pInputManager->refocusLastWindow(PMONITOR);
+    if (WASLASTFOCUS)
+        g_pInputManager->refocusLastWindow(PMONITOR);
 
     CBox geomFixed = {geometry.x + PMONITOR->vecPosition.x, geometry.y + PMONITOR->vecPosition.y, geometry.width, geometry.height};
     g_pHyprRenderer->damageBox(&geomFixed);
@@ -296,11 +296,11 @@ void CLayerSurface::onCommit() {
         else if (WASEXCLUSIVE && !ISEXCLUSIVE)
             std::erase_if(g_pInputManager->m_dExclusiveLSes, [this](const auto& other) { return !other.lock() || other.lock() == self.lock(); });
 
-				// if the surface was focused and interactive but now isn't, refocus
-				if (WASLASTFOCUS && !layerSurface->current.interactivity) {
-						g_pInputManager->refocusLastWindow(g_pCompositor->getMonitorFromID(monitorID));
-				} else if (!WASLASTFOCUS && (ISEXCLUSIVE || (layerSurface->current.interactivity && (g_pSeatManager->mouse.expired() || !g_pInputManager->isConstrained())))) {
-						// if not focused last and exclusive or accepting input + unconstrained
+        // if the surface was focused and interactive but now isn't, refocus
+        if (WASLASTFOCUS && !layerSurface->current.interactivity) {
+            g_pInputManager->refocusLastWindow(g_pCompositor->getMonitorFromID(monitorID));
+        } else if (!WASLASTFOCUS && (ISEXCLUSIVE || (layerSurface->current.interactivity && (g_pSeatManager->mouse.expired() || !g_pInputManager->isConstrained())))) {
+            // if not focused last and exclusive or accepting input + unconstrained
             g_pSeatManager->setGrab(nullptr);
             g_pInputManager->releaseAllMouseButtons();
             g_pCompositor->focusSurface(surface->resource());

--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -297,10 +297,13 @@ void CLayerSurface::onCommit() {
             std::erase_if(g_pInputManager->m_dExclusiveLSes, [this](const auto& other) { return !other.lock() || other.lock() == self.lock(); });
 
         // if the surface was focused and interactive but now isn't, refocus
-        if (WASLASTFOCUS && !layerSurface->current.interactivity)
+        if (WASLASTFOCUS && !layerSurface->current.interactivity) {
+            // moveMouseUnified won't focus non interactive layers but it won't unfocus them either,
+            // so unfocus the surface here.
+            g_pCompositor->focusSurface(nullptr);
             g_pInputManager->refocusLastWindow(g_pCompositor->getMonitorFromID(monitorID));
-        else if (!WASEXCLUSIVE && !WASLASTFOCUS &&
-                 (ISEXCLUSIVE || (layerSurface->current.interactivity && (g_pSeatManager->mouse.expired() || !g_pInputManager->isConstrained())))) {
+        } else if (!WASEXCLUSIVE && !WASLASTFOCUS &&
+                   (ISEXCLUSIVE || (layerSurface->current.interactivity && (g_pSeatManager->mouse.expired() || !g_pInputManager->isConstrained())))) {
             // if not focused last and exclusive or accepting input + unconstrained
             g_pSeatManager->setGrab(nullptr);
             g_pInputManager->releaseAllMouseButtons();

--- a/src/desktop/LayerSurface.hpp
+++ b/src/desktop/LayerSurface.hpp
@@ -35,40 +35,40 @@ class CLayerSurface {
     wl_list                     link;
 
     // the header providing the enum type cannot be imported here
-    int                         interactivity = 0;
+    int                        interactivity = 0;
 
-    SP<CWLSurface>              surface;
+    SP<CWLSurface>             surface;
 
-    bool                        mapped = false;
-    uint32_t                    layer  = 0;
+    bool                       mapped = false;
+    uint32_t                   layer  = 0;
 
-    int                         monitorID = -1;
+    int                        monitorID = -1;
 
-    bool                        fadingOut     = false;
-    bool                        readyToDelete = false;
-    bool                        noProcess     = false;
-    bool                        noAnimations  = false;
+    bool                       fadingOut     = false;
+    bool                       readyToDelete = false;
+    bool                       noProcess     = false;
+    bool                       noAnimations  = false;
 
-    bool                        forceBlur        = false;
-    bool                        forceBlurPopups  = false;
-    int                         xray             = -1;
-    bool                        ignoreAlpha      = false;
-    float                       ignoreAlphaValue = 0.f;
-    bool                        dimAround        = false;
+    bool                       forceBlur        = false;
+    bool                       forceBlurPopups  = false;
+    int                        xray             = -1;
+    bool                       ignoreAlpha      = false;
+    float                      ignoreAlphaValue = 0.f;
+    bool                       dimAround        = false;
 
-    std::optional<std::string>  animationStyle;
+    std::optional<std::string> animationStyle;
 
-    PHLLSREF                    self;
+    PHLLSREF                   self;
 
-    CBox                        geometry = {0, 0, 0, 0};
-    Vector2D                    position;
-    std::string                 szNamespace = "";
-    std::unique_ptr<CPopup>     popupHead;
+    CBox                       geometry = {0, 0, 0, 0};
+    Vector2D                   position;
+    std::string                szNamespace = "";
+    std::unique_ptr<CPopup>    popupHead;
 
-    void                        onDestroy();
-    void                        onMap();
-    void                        onUnmap();
-    void                        onCommit();
+    void                       onDestroy();
+    void                       onMap();
+    void                       onUnmap();
+    void                       onCommit();
 
   private:
     struct {

--- a/src/desktop/LayerSurface.hpp
+++ b/src/desktop/LayerSurface.hpp
@@ -34,7 +34,8 @@ class CLayerSurface {
     WP<CLayerShellResource>     layerSurface;
     wl_list                     link;
 
-    bool                        keyboardExclusive = false;
+    // the header providing the enum type cannot be imported here
+    int                         interactivity = 0;
 
     SP<CWLSurface>              surface;
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1381,6 +1381,43 @@ void CInputManager::refocus() {
     mouseMoveUnified(0, true);
 }
 
+void CInputManager::refocusLastWindow(CMonitor* pMonitor) {
+    if (!pMonitor) {
+        refocus();
+        return;
+    }
+
+    Vector2D               surfaceCoords;
+    PHLLS                  pFoundLayerSurface;
+    SP<CWLSurfaceResource> foundSurface = nullptr;
+
+    g_pInputManager->releaseAllMouseButtons();
+    g_pCompositor->m_pLastFocus.reset();
+
+    // first try for an exclusive layer
+    if (!m_dExclusiveLSes.empty())
+        foundSurface = m_dExclusiveLSes[m_dExclusiveLSes.size() - 1]->surface->resource();
+
+    // then any surfaces above windows on the same monitor
+    if (!foundSurface)
+        foundSurface = g_pCompositor->vectorToLayerSurface(g_pInputManager->getMouseCoordsInternal(), &pMonitor->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY],
+                                                           &surfaceCoords, &pFoundLayerSurface);
+
+    if (!foundSurface)
+        foundSurface = g_pCompositor->vectorToLayerSurface(g_pInputManager->getMouseCoordsInternal(), &pMonitor->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP],
+                                                           &surfaceCoords, &pFoundLayerSurface);
+
+    if (!foundSurface && g_pCompositor->m_pLastWindow.lock() && g_pCompositor->isWorkspaceVisible(g_pCompositor->m_pLastWindow->m_pWorkspace)) {
+        // then the last focused window if we're on the same workspace as it
+        const auto PLASTWINDOW = g_pCompositor->m_pLastWindow.lock();
+        g_pCompositor->focusWindow(nullptr);
+        g_pCompositor->focusWindow(PLASTWINDOW);
+    } else {
+        // otherwise fall back to a normal refocus.
+        refocus();
+    }
+}
+
 void CInputManager::unconstrainMouse() {
     if (g_pSeatManager->mouse.expired())
         return;

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -509,7 +509,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
         }
 
         if (pFoundLayerSurface && (pFoundLayerSurface->layerSurface->current.interactivity != ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE) && FOLLOWMOUSE != 3 &&
-            allowKeyboardRefocus) {
+            (allowKeyboardRefocus || pFoundLayerSurface->layerSurface->current.interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE)) {
             g_pCompositor->focusSurface(foundSurface);
         }
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1392,7 +1392,6 @@ void CInputManager::refocusLastWindow(CMonitor* pMonitor) {
     SP<CWLSurfaceResource> foundSurface = nullptr;
 
     g_pInputManager->releaseAllMouseButtons();
-    g_pCompositor->m_pLastFocus.reset();
 
     // first try for an exclusive layer
     if (!m_dExclusiveLSes.empty())

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1410,7 +1410,6 @@ void CInputManager::refocusLastWindow(CMonitor* pMonitor) {
     if (!foundSurface && g_pCompositor->m_pLastWindow.lock() && g_pCompositor->isWorkspaceVisible(g_pCompositor->m_pLastWindow->m_pWorkspace)) {
         // then the last focused window if we're on the same workspace as it
         const auto PLASTWINDOW = g_pCompositor->m_pLastWindow.lock();
-        g_pCompositor->focusWindow(nullptr);
         g_pCompositor->focusWindow(PLASTWINDOW);
     } else {
         // otherwise fall back to a normal refocus.

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -103,8 +103,9 @@ class CInputManager {
     bool               isConstrained();
 
     Vector2D           getMouseCoordsInternal();
-    void               refocus();
-    void               simulateMouseMovement();
+		void               refocus();
+		void               refocusLastWindow(CMonitor* pMonitor);
+		void               simulateMouseMovement();
     void               sendMotionEventsToFocused();
 
     void               setKeyboardLayout();

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -103,9 +103,9 @@ class CInputManager {
     bool               isConstrained();
 
     Vector2D           getMouseCoordsInternal();
-		void               refocus();
-		void               refocusLastWindow(CMonitor* pMonitor);
-		void               simulateMouseMovement();
+    void               refocus();
+    void               refocusLastWindow(CMonitor* pMonitor);
+    void               simulateMouseMovement();
     void               sendMotionEventsToFocused();
 
     void               setKeyboardLayout();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
- Fixes layershells not being able to steal focus from windows as described in #4968.
- Fixes use after free in m_dExclusiveLSes when exclusive state changes post-map.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
- Changing the keyboard focus mode to none will not kick the layer from the seat, even though refocus is called.

#### Is it ready for merging, or does it need work?
Ready to merge.
