### PR TITLE
github issues: improve the chances of the user specifying bug or regression

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -9,6 +9,17 @@ body:
 
         ---
 
+  - type: dropdown
+    id: type
+    attributes:
+      label: Bug or Regression?
+      description: Is this a bug or a regression?
+      options:
+        - Bug
+        - Regression
+    validations:
+      required: true
+
   - type: textarea
     id: ver
     attributes:
@@ -30,17 +41,6 @@ body:
 
 
         </details>"
-    validations:
-      required: true
-
-  - type: dropdown
-    id: type
-    attributes:
-      label: Bug or Regression?
-      description: Is this a bug or a regression?
-      options:
-        - Bug
-        - Regression
     validations:
       required: true
 


### PR DESCRIPTION
I believe this would do the trick, because currently when you expand the system info box; the bug/regression box is left in a weird spot between the huge system info box and the description box, making it harder to pay attention to it.

Cheers