### PR TITLE
sessionLock: fix focus not being tied to mouse

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -155,6 +155,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
     Vector2D               surfacePos = Vector2D(-1337, -1337);
     PHLWINDOW              pFoundWindow;
     PHLLS                  pFoundLayerSurface;
+    SSessionLockSurface*   pSessionLock = nullptr;
 
     if (!g_pCompositor->m_bReadyToProcess || g_pCompositor->m_bIsShuttingDown || g_pCompositor->m_bUnsafeState)
         return;
@@ -261,12 +262,12 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
         g_pCompositor->setActiveMonitor(PMONITOR);
 
     if (g_pSessionLockManager->isSessionLocked()) {
-        const auto PSLS = PMONITOR ? g_pSessionLockManager->getSessionLockSurfaceForMonitor(PMONITOR->ID) : nullptr;
+        pSessionLock = PMONITOR ? g_pSessionLockManager->getSessionLockSurfaceForMonitor(PMONITOR->ID) : nullptr;
 
-        if (!PSLS)
+        if (!pSessionLock)
             return;
 
-        foundSurface = PSLS->surface->surface();
+        foundSurface = pSessionLock->surface->surface();
         surfacePos   = PMONITOR->vecPosition;
     }
 
@@ -455,7 +456,9 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
             restoreCursorIconToApp();
     }
 
-    if (pFoundWindow) {
+    if (pSessionLock != nullptr)
+        g_pCompositor->focusSurface(foundSurface);
+    else if (pFoundWindow) {
         // change cursor icon if hovering over border
         if (*PRESIZEONBORDER && *PRESIZECURSORICON) {
             if (!pFoundWindow->m_bIsFullscreen && !pFoundWindow->hasPopupAt(mouseCoords)) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes session lock focus not following the mouse between monitors. Previously focus would stay forever on a single surface.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
ready to merge
