### PR TITLE
session-lock: fix refocus after unlocking

### DIFF
--- a/src/protocols/SessionLock.cpp
+++ b/src/protocols/SessionLock.cpp
@@ -114,9 +114,11 @@ CSessionLock::CSessionLock(SP<CExtSessionLockV1> resource_) : resource(resource_
             return;
         }
 
-        events.unlockAndDestroy.emit();
-        inert                      = true;
         PROTO::sessionLock->locked = false;
+
+        events.unlockAndDestroy.emit();
+
+        inert = true;
         PROTO::sessionLock->destroyResource(this);
     });
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes #5884

Sets `PROTO::sessionLock->locked = false;` before sending unlockAndDestroy.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Not really

#### Is it ready for merging, or does it need work?

ready
