### PR TITLE
xwayland: support HiDPI scale

### DIFF
--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -16,6 +16,7 @@
 #include "config/ConfigValue.hpp"
 #include "../../managers/eventLoop/EventLoopManager.hpp"
 #include "../../state/MonitorState.hpp"
+#include "../../xwayland/XWayland.hpp"
 #include "protocols/types/SurfaceRole.hpp"
 #include "render/Texture.hpp"
 #include <cstring>
@@ -145,7 +146,13 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
             // that's not the case, an invalid_size error is sent.
             // https://gitlab.freedesktop.org/wayland/wayland/-/issues/194
             // https://github.com/hyprwm/Hyprland/discussions/15673
-            if (m_role->role() != SURFACE_ROLE_CURSOR && m_role->role() != SURFACE_ROLE_UNASSIGNED) {
+            const bool ISXWAYLAND =
+#ifndef NO_XWAYLAND
+                g_pXWayland && g_pXWayland->m_server && m_client == g_pXWayland->m_server->m_xwaylandClient;
+#else
+                false;
+#endif
+            if (!ISXWAYLAND && m_role->role() != SURFACE_ROLE_CURSOR && m_role->role() != SURFACE_ROLE_UNASSIGNED) {
                 if (sc<int>(m_pending.bufferSize.x) % m_pending.scale != 0 || sc<int>(m_pending.bufferSize.y) % m_pending.scale != 0) {
                     r->error(WL_SURFACE_ERROR_INVALID_SIZE, "buffer size is not an integer multiple of the buffer scale");
                     dropPendingBuffer();

--- a/src/xwayland/XSurface.cpp
+++ b/src/xwayland/XSurface.cpp
@@ -200,7 +200,8 @@ void CXWaylandSurface::configure(const CBox& box) {
     m_geometry = box;
 
     uint32_t mask     = XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y | XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT | XCB_CONFIG_WINDOW_BORDER_WIDTH;
-    uint32_t values[] = {box.x, box.y, box.width, box.height, 0};
+    uint32_t values[] = {sc<uint32_t>(g_pXWayland->m_wm->applyScale(box.x)), sc<uint32_t>(g_pXWayland->m_wm->applyScale(box.y)),
+                         sc<uint32_t>(g_pXWayland->m_wm->applyScale(box.width)), sc<uint32_t>(g_pXWayland->m_wm->applyScale(box.height)), 0};
     xcb_configure_window(g_pXWayland->m_wm->getConnection(), m_xID, mask, values);
 
     if (box.width == oldSize.x && box.height == oldSize.y) {
@@ -209,10 +210,10 @@ void CXWaylandSurface::configure(const CBox& box) {
         e.response_type     = XCB_CONFIGURE_NOTIFY;
         e.event             = m_xID;
         e.window            = m_xID;
-        e.x                 = box.x;
-        e.y                 = box.y;
-        e.width             = box.width;
-        e.height            = box.height;
+        e.x                 = g_pXWayland->m_wm->applyScale(box.x);
+        e.y                 = g_pXWayland->m_wm->applyScale(box.y);
+        e.width             = g_pXWayland->m_wm->applyScale(box.width);
+        e.height            = g_pXWayland->m_wm->applyScale(box.height);
         e.border_width      = 0;
         e.above_sibling     = XCB_NONE;
         e.override_redirect = m_overrideRedirect;

--- a/src/xwayland/XSurface.cpp
+++ b/src/xwayland/XSurface.cpp
@@ -199,7 +199,8 @@ void CXWaylandSurface::configure(const CBox& box) {
     m_geometry = box;
 
     uint32_t mask     = XCB_CONFIG_WINDOW_X | XCB_CONFIG_WINDOW_Y | XCB_CONFIG_WINDOW_WIDTH | XCB_CONFIG_WINDOW_HEIGHT | XCB_CONFIG_WINDOW_BORDER_WIDTH;
-    uint32_t values[] = {box.x, box.y, box.width, box.height, 0};
+    uint32_t values[] = {sc<uint32_t>(g_pXWayland->m_wm->applyScale(box.x)), sc<uint32_t>(g_pXWayland->m_wm->applyScale(box.y)),
+                         sc<uint32_t>(g_pXWayland->m_wm->applyScale(box.width)), sc<uint32_t>(g_pXWayland->m_wm->applyScale(box.height)), 0};
     xcb_configure_window(g_pXWayland->m_wm->getConnection(), m_xID, mask, values);
 
     if (box.width == oldSize.x && box.height == oldSize.y) {
@@ -208,10 +209,10 @@ void CXWaylandSurface::configure(const CBox& box) {
         e.response_type     = XCB_CONFIGURE_NOTIFY;
         e.event             = m_xID;
         e.window            = m_xID;
-        e.x                 = box.x;
-        e.y                 = box.y;
-        e.width             = box.width;
-        e.height            = box.height;
+        e.x                 = g_pXWayland->m_wm->applyScale(box.x);
+        e.y                 = g_pXWayland->m_wm->applyScale(box.y);
+        e.width             = g_pXWayland->m_wm->applyScale(box.width);
+        e.height            = g_pXWayland->m_wm->applyScale(box.height);
         e.border_width      = 0;
         e.above_sibling     = XCB_NONE;
         e.override_redirect = m_overrideRedirect;

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -57,8 +57,9 @@ void CXWM::handleCreate(xcb_create_notify_event_t* e) {
     if (isWMWindow(e->window))
         return;
 
-    const auto XSURF = m_surfaces.emplace_back(SP<CXWaylandSurface>(new CXWaylandSurface(e->window, CBox{e->x, e->y, e->width, e->height}, e->override_redirect)));
-    XSURF->m_self    = XSURF;
+    const auto XSURF = m_surfaces.emplace_back(
+        SP<CXWaylandSurface>(new CXWaylandSurface(e->window, CBox{applyUnScale(e->x), applyUnScale(e->y), applyUnScale(e->width), applyUnScale(e->height)}, e->override_redirect)));
+    XSURF->m_self = XSURF;
     Log::logger->log(Log::DEBUG, "[xwm] New XSurface at {:x} with xid of {}", rc<uintptr_t>(XSURF.get()), e->window);
 
     const auto WINDOW = Desktop::View::CWindow::create(XSURF);
@@ -89,9 +90,9 @@ void CXWM::handleConfigureRequest(xcb_configure_request_event_t* e) {
     if (!(MASK & GEOMETRY))
         return;
 
-    XSURF->m_events.configureRequest.emit(CBox{MASK & XCB_CONFIG_WINDOW_X ? e->x : XSURF->m_geometry.x, MASK & XCB_CONFIG_WINDOW_Y ? e->y : XSURF->m_geometry.y,
-                                               MASK & XCB_CONFIG_WINDOW_WIDTH ? e->width : XSURF->m_geometry.width,
-                                               MASK & XCB_CONFIG_WINDOW_HEIGHT ? e->height : XSURF->m_geometry.height});
+    XSURF->m_events.configureRequest.emit(CBox{
+        MASK & XCB_CONFIG_WINDOW_X ? applyUnScale(e->x) : XSURF->m_geometry.x, MASK & XCB_CONFIG_WINDOW_Y ? applyUnScale(e->y) : XSURF->m_geometry.y,
+        MASK & XCB_CONFIG_WINDOW_WIDTH ? applyUnScale(e->width) : XSURF->m_geometry.width, MASK & XCB_CONFIG_WINDOW_HEIGHT ? applyUnScale(e->height) : XSURF->m_geometry.height});
 }
 
 void CXWM::handleConfigureNotify(xcb_configure_notify_event_t* e) {
@@ -100,10 +101,11 @@ void CXWM::handleConfigureNotify(xcb_configure_notify_event_t* e) {
     if (!XSURF)
         return;
 
-    if (XSURF->m_geometry == CBox{e->x, e->y, e->width, e->height})
+    const auto GEOM = CBox{applyUnScale(e->x), applyUnScale(e->y), applyUnScale(e->width), applyUnScale(e->height)};
+    if (XSURF->m_geometry == GEOM)
         return;
 
-    XSURF->m_geometry = {e->x, e->y, e->width, e->height};
+    XSURF->m_geometry = GEOM;
     updateOverrideRedirect(XSURF, e->override_redirect);
     XSURF->m_events.setGeometry.emit();
 }
@@ -314,6 +316,27 @@ void CXWM::readProp(SP<CXWaylandSurface> XSURF, uint32_t atom, xcb_get_property_
         const bool    HASMIN  = FLAGS & XCB_ICCCM_SIZE_HINT_P_MIN_SIZE;
         const bool    HASBASE = FLAGS & XCB_ICCCM_SIZE_HINT_BASE_SIZE;
 
+        if (FLAGS & XCB_ICCCM_SIZE_HINT_US_POSITION || FLAGS & XCB_ICCCM_SIZE_HINT_P_POSITION) {
+            XSURF->m_sizeHints->x = applyUnScale(XSURF->m_sizeHints->x);
+            XSURF->m_sizeHints->y = applyUnScale(XSURF->m_sizeHints->y);
+        }
+        if (FLAGS & XCB_ICCCM_SIZE_HINT_US_SIZE || FLAGS & XCB_ICCCM_SIZE_HINT_P_SIZE) {
+            XSURF->m_sizeHints->width  = applyUnScale(XSURF->m_sizeHints->width);
+            XSURF->m_sizeHints->height = applyUnScale(XSURF->m_sizeHints->height);
+        }
+        if (HASMIN) {
+            XSURF->m_sizeHints->min_width  = applyUnScale(XSURF->m_sizeHints->min_width);
+            XSURF->m_sizeHints->min_height = applyUnScale(XSURF->m_sizeHints->min_height);
+        }
+        if (FLAGS & XCB_ICCCM_SIZE_HINT_P_MAX_SIZE) {
+            XSURF->m_sizeHints->max_width  = applyUnScale(XSURF->m_sizeHints->max_width);
+            XSURF->m_sizeHints->max_height = applyUnScale(XSURF->m_sizeHints->max_height);
+        }
+        if (HASBASE) {
+            XSURF->m_sizeHints->base_width  = applyUnScale(XSURF->m_sizeHints->base_width);
+            XSURF->m_sizeHints->base_height = applyUnScale(XSURF->m_sizeHints->base_height);
+        }
+
         if (!HASMIN && !HASBASE) {
             XSURF->m_sizeHints->min_width = XSURF->m_sizeHints->min_height = -1;
             XSURF->m_sizeHints->base_width = XSURF->m_sizeHints->base_height = -1;
@@ -367,6 +390,15 @@ void CXWM::handlePropertyNotify(xcb_property_notify_event_t* e) {
 
     if (!XSURF) {
         removeTransfersForWindow(e->window);
+        if (e->atom == HYPRATOMS["_XWAYLAND_GLOBAL_OUTPUT_SCALE"]) {
+            xcb_get_property_cookie_t             cookie = xcb_get_property(getConnection(), 0, e->window, e->atom, XCB_ATOM_ANY, 0, 1);
+            XCBReplyPtr<xcb_get_property_reply_t> reply(xcb_get_property_reply(getConnection(), cookie, nullptr));
+            if (!reply)
+                return;
+
+            if (reply->type == XCB_ATOM_CARDINAL && xcb_get_property_value_length(reply.get()) >= sc<int>(sizeof(uint32_t)))
+                m_scale = *rc<uint32_t*>(xcb_get_property_value(reply.get()));
+        }
         return;
     }
 
@@ -1257,6 +1289,11 @@ void CXWM::updateWorkArea(int x, int y, int w, int h) {
         return;
     }
 
+    x = applyScale(x);
+    y = applyScale(y);
+    w = applyScale(w);
+    h = applyScale(h);
+
     uint32_t values[4] = {sc<uint32_t>(x), sc<uint32_t>(y), sc<uint32_t>(w), sc<uint32_t>(h)};
     xcb_change_property(connection, XCB_PROP_MODE_REPLACE, m_screen->root, HYPRATOMS["_NET_WORKAREA"], XCB_ATOM_CARDINAL, 32, 4, values);
     xcb_flush(connection);
@@ -1442,6 +1479,14 @@ SP<IDataOffer> CXWM::createX11DataOffer(SP<CWLSurfaceResource> surf, SP<IDataSou
     offer->m_source          = source;
 
     return offer;
+}
+
+int32_t CXWM::applyScale(double val) {
+    return sc<int32_t>(std::floor(val * m_scale));
+}
+
+int32_t CXWM::applyUnScale(double val) {
+    return sc<int32_t>(std::ceil(val / m_scale));
 }
 
 void SXSelection::onSelection() {

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -57,8 +57,9 @@ void CXWM::handleCreate(xcb_create_notify_event_t* e) {
     if (isWMWindow(e->window))
         return;
 
-    const auto XSURF = m_surfaces.emplace_back(SP<CXWaylandSurface>(new CXWaylandSurface(e->window, CBox{e->x, e->y, e->width, e->height}, e->override_redirect)));
-    XSURF->m_self    = XSURF;
+    const auto XSURF = m_surfaces.emplace_back(
+        SP<CXWaylandSurface>(new CXWaylandSurface(e->window, CBox{applyUnScale(e->x), applyUnScale(e->y), applyUnScale(e->width), applyUnScale(e->height)}, e->override_redirect)));
+    XSURF->m_self = XSURF;
     LOG(Log::DEBUG, "[xwm] New XSurface at {:x} with xid of {}", rc<uintptr_t>(XSURF.get()), e->window);
 
     const auto WINDOW = Desktop::View::CWindow::create(makeUnique<Desktop::View::CX11Backend>(XSURF));
@@ -88,9 +89,9 @@ void CXWM::handleConfigureRequest(xcb_configure_request_event_t* e) {
     if (!(MASK & GEOMETRY))
         return;
 
-    XSURF->m_events.configureRequest.emit(CBox{MASK & XCB_CONFIG_WINDOW_X ? e->x : XSURF->m_geometry.x, MASK & XCB_CONFIG_WINDOW_Y ? e->y : XSURF->m_geometry.y,
-                                               MASK & XCB_CONFIG_WINDOW_WIDTH ? e->width : XSURF->m_geometry.width,
-                                               MASK & XCB_CONFIG_WINDOW_HEIGHT ? e->height : XSURF->m_geometry.height});
+    XSURF->m_events.configureRequest.emit(CBox{
+        MASK & XCB_CONFIG_WINDOW_X ? applyUnScale(e->x) : XSURF->m_geometry.x, MASK & XCB_CONFIG_WINDOW_Y ? applyUnScale(e->y) : XSURF->m_geometry.y,
+        MASK & XCB_CONFIG_WINDOW_WIDTH ? applyUnScale(e->width) : XSURF->m_geometry.width, MASK & XCB_CONFIG_WINDOW_HEIGHT ? applyUnScale(e->height) : XSURF->m_geometry.height});
 }
 
 void CXWM::handleConfigureNotify(xcb_configure_notify_event_t* e) {
@@ -99,10 +100,11 @@ void CXWM::handleConfigureNotify(xcb_configure_notify_event_t* e) {
     if (!XSURF)
         return;
 
-    if (XSURF->m_geometry == CBox{e->x, e->y, e->width, e->height})
+    const auto GEOM = CBox{applyUnScale(e->x), applyUnScale(e->y), applyUnScale(e->width), applyUnScale(e->height)};
+    if (XSURF->m_geometry == GEOM)
         return;
 
-    XSURF->m_geometry = {e->x, e->y, e->width, e->height};
+    XSURF->m_geometry = GEOM;
     updateOverrideRedirect(XSURF, e->override_redirect);
     XSURF->m_events.setGeometry.emit();
 }
@@ -313,6 +315,27 @@ void CXWM::readProp(SP<CXWaylandSurface> XSURF, uint32_t atom, xcb_get_property_
         const bool    HASMIN  = FLAGS & XCB_ICCCM_SIZE_HINT_P_MIN_SIZE;
         const bool    HASBASE = FLAGS & XCB_ICCCM_SIZE_HINT_BASE_SIZE;
 
+        if (FLAGS & XCB_ICCCM_SIZE_HINT_US_POSITION || FLAGS & XCB_ICCCM_SIZE_HINT_P_POSITION) {
+            XSURF->m_sizeHints->x = applyUnScale(XSURF->m_sizeHints->x);
+            XSURF->m_sizeHints->y = applyUnScale(XSURF->m_sizeHints->y);
+        }
+        if (FLAGS & XCB_ICCCM_SIZE_HINT_US_SIZE || FLAGS & XCB_ICCCM_SIZE_HINT_P_SIZE) {
+            XSURF->m_sizeHints->width  = applyUnScale(XSURF->m_sizeHints->width);
+            XSURF->m_sizeHints->height = applyUnScale(XSURF->m_sizeHints->height);
+        }
+        if (HASMIN) {
+            XSURF->m_sizeHints->min_width  = applyUnScale(XSURF->m_sizeHints->min_width);
+            XSURF->m_sizeHints->min_height = applyUnScale(XSURF->m_sizeHints->min_height);
+        }
+        if (FLAGS & XCB_ICCCM_SIZE_HINT_P_MAX_SIZE) {
+            XSURF->m_sizeHints->max_width  = applyUnScale(XSURF->m_sizeHints->max_width);
+            XSURF->m_sizeHints->max_height = applyUnScale(XSURF->m_sizeHints->max_height);
+        }
+        if (HASBASE) {
+            XSURF->m_sizeHints->base_width  = applyUnScale(XSURF->m_sizeHints->base_width);
+            XSURF->m_sizeHints->base_height = applyUnScale(XSURF->m_sizeHints->base_height);
+        }
+
         if (!HASMIN && !HASBASE) {
             XSURF->m_sizeHints->min_width = XSURF->m_sizeHints->min_height = -1;
             XSURF->m_sizeHints->base_width = XSURF->m_sizeHints->base_height = -1;
@@ -366,6 +389,15 @@ void CXWM::handlePropertyNotify(xcb_property_notify_event_t* e) {
 
     if (!XSURF) {
         removeTransfersForWindow(e->window);
+        if (e->atom == HYPRATOMS["_XWAYLAND_GLOBAL_OUTPUT_SCALE"]) {
+            xcb_get_property_cookie_t             cookie = xcb_get_property(getConnection(), 0, e->window, e->atom, XCB_ATOM_ANY, 0, 1);
+            XCBReplyPtr<xcb_get_property_reply_t> reply(xcb_get_property_reply(getConnection(), cookie, nullptr));
+            if (!reply)
+                return;
+
+            if (reply->type == XCB_ATOM_CARDINAL && xcb_get_property_value_length(reply.get()) >= sc<int>(sizeof(uint32_t)))
+                m_scale = *rc<uint32_t*>(xcb_get_property_value(reply.get()));
+        }
         return;
     }
 
@@ -1256,6 +1288,11 @@ void CXWM::updateWorkArea(int x, int y, int w, int h) {
         return;
     }
 
+    x = applyScale(x);
+    y = applyScale(y);
+    w = applyScale(w);
+    h = applyScale(h);
+
     uint32_t values[4] = {sc<uint32_t>(x), sc<uint32_t>(y), sc<uint32_t>(w), sc<uint32_t>(h)};
     xcb_change_property(connection, XCB_PROP_MODE_REPLACE, m_screen->root, HYPRATOMS["_NET_WORKAREA"], XCB_ATOM_CARDINAL, 32, 4, values);
     xcb_flush(connection);
@@ -1441,6 +1478,14 @@ SP<IDataOffer> CXWM::createX11DataOffer(SP<CWLSurfaceResource> surf, SP<IDataSou
     offer->m_source          = source;
 
     return offer;
+}
+
+int32_t CXWM::applyScale(double val) {
+    return sc<int32_t>(std::floor(val * m_scale));
+}
+
+int32_t CXWM::applyUnScale(double val) {
+    return sc<int32_t>(std::ceil(val / m_scale));
 }
 
 void SXSelection::onSelection() {

--- a/src/xwayland/XWM.hpp
+++ b/src/xwayland/XWM.hpp
@@ -119,6 +119,7 @@ class CXWM {
     SP<CX11DataDevice> getDataDevice();
     SP<IDataOffer>     createX11DataOffer(SP<CWLSurfaceResource> surf, SP<IDataSource> source);
     void               updateWorkArea(int x, int y, int w, int h);
+    int32_t            applyScale(double val);
 
   private:
     void                 setCursor(unsigned char* pixData, uint32_t stride, const Vector2D& size, const Vector2D& hotspot);
@@ -182,12 +183,15 @@ class CXWM {
 
     SXSelection* getSelection(xcb_atom_t atom);
 
+    int32_t      applyUnScale(double val);
+
     //
     UP<CXCBConnection>                        m_connection;
     xcb_errors_context_t*                     m_errors = nullptr;
     xcb_screen_t*                             m_screen = nullptr;
 
     xcb_window_t                              m_wmWindow;
+    double                                    m_scale = 1.0;
 
     wl_event_source*                          m_eventSource = nullptr;
 

--- a/src/xwayland/XWayland.hpp
+++ b/src/xwayland/XWayland.hpp
@@ -127,5 +127,6 @@ inline std::unordered_map<std::string, uint32_t> HYPRATOMS = {
     HYPRATOM("DELETE"),
     HYPRATOM("TEXT"),
     HYPRATOM("INCR"),
+    HYPRATOM("_XWAYLAND_GLOBAL_OUTPUT_SCALE"),
 #endif
 };


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This supports the xorg-xwayland patch at https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/733

Ported from https://gitlab.freedesktop.org/lilydjwg/wlroots/-/commit/5a7c65cab11c9f3c3dc79f9c4cfb8a6acf6cbaae

See #6281 for motivation.

AUR package [`hyprland-hidpi-xprop-git`](https://aur.archlinux.org/packages/hyprland-hidpi-xprop-git) applies this patch on top of hyprland mainline. After installing, do the following to enable (scaling factor 2 in this example):
1. Add `exec-once = systemctl --user start xsettingsd.service && echo "Xft.dpi: 192" | xrdb -merge && xprop -root -format _XWAYLAND_GLOBAL_OUTPUT_SCALE 32c -set _XWAYLAND_GLOBAL_OUTPUT_SCALE 2` to hyprland configuration.
2. Add the following to `~/.config/xsettingsd/xsettingsd.conf`
    ```
    Gdk/UnscaledDPI 98304
    Gdk/WindowScalingFactor 2
    ```
3. Remove `GDK_SCALE`, `QT_SCALE_FACTOR`, and other per-application scaling options.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

N/A

#### Is it ready for merging, or does it need work?

No, for cherry-pick only