### PR TITLE
fix keyboard focus

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -781,7 +781,6 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
 }
 
 SP<CWLSurfaceResource> CCompositor::vectorWindowToSurface(const Vector2D& pos, PHLWINDOW pWindow, Vector2D& sl) {
-
     if (!validMapped(pWindow))
         return nullptr;
 
@@ -802,7 +801,12 @@ SP<CWLSurfaceResource> CCompositor::vectorWindowToSurface(const Vector2D& pos, P
         return surf;
     }
 
-    return nullptr;
+    sl = pos - pWindow->m_vRealPosition.value();
+
+    sl.x += pWindow->m_pXDGSurface->current.geometry.x;
+    sl.y += pWindow->m_pXDGSurface->current.geometry.y;
+
+    return pWindow->m_pWLSurface->resource();
 }
 
 Vector2D CCompositor::vectorToSurfaceLocal(const Vector2D& vec, PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
fixes #6421

before https://github.com/hyprwm/Hyprland/commit/6967a31450441fc5605c05db6f65505dace4b263 pWindow->m_pWLSurface was used if a surface wasn't found at the point, this restores that behavior.

basically vectorWindowToSurface was returning a nullptr when the mouse was over a gap/border so in mouseMoveUnified we would end up with a valid pFoundWindow, but a pFoundSurface associated with a layer on the bottom/background instead of the window.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
nope

#### Is it ready for merging, or does it need work?
ready

