### PR TITLE
check if VirtualKeyboard is valid before accessing.

### DIFF
--- a/src/protocols/InputMethodV2.cpp
+++ b/src/protocols/InputMethodV2.cpp
@@ -81,7 +81,7 @@ SP<CInputMethodV2> CInputMethodKeyboardGrabV2::getOwner() {
 }
 
 wl_client* CInputMethodKeyboardGrabV2::client() {
-    return resource->client();
+    return resource->resource() ? resource->client() : nullptr;
 }
 
 CInputMethodPopupV2::CInputMethodPopupV2(SP<CZwpInputPopupSurfaceV2> resource_, SP<CInputMethodV2> owner_, SP<CWLSurfaceResource> surface) : resource(resource_), owner(owner_) {

--- a/src/protocols/VirtualKeyboard.cpp
+++ b/src/protocols/VirtualKeyboard.cpp
@@ -100,7 +100,7 @@ wlr_keyboard* CVirtualKeyboardV1Resource::wlr() {
 }
 
 wl_client* CVirtualKeyboardV1Resource::client() {
-    return resource->client();
+    return resource->resource() ? resource->client() : nullptr;
 }
 
 void CVirtualKeyboardV1Resource::releasePressed() {


### PR DESCRIPTION
This fixes a crash when restarting fcitx (#6378).

An extra newline is added by the editor automatically, as mentioned in https://stackoverflow.com/questions/729692/why-should-text-files-end-with-a-newline.


