### PR TITLE
last bits of asan output

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -352,6 +352,7 @@ void CCompositor::cleanup() {
     g_pPointerManager.reset();
     g_pSeatManager.reset();
     g_pHyprCtl.reset();
+    g_pEventLoopManager.reset();
 
     if (m_sWLRRenderer)
         wlr_renderer_destroy(m_sWLRRenderer);

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -351,6 +351,7 @@ void CCompositor::cleanup() {
     g_pXWaylandManager.reset();
     g_pPointerManager.reset();
     g_pSeatManager.reset();
+    g_pHyprCtl.reset();
 
     if (m_sWLRRenderer)
         wlr_renderer_destroy(m_sWLRRenderer);
@@ -364,6 +365,7 @@ void CCompositor::cleanup() {
     if (m_critSigSource)
         wl_event_source_remove(m_critSigSource);
 
+    wl_event_loop_destroy(m_sWLEventLoop);
     wl_display_terminate(m_sWLDisplay);
     m_sWLDisplay = nullptr;
 

--- a/src/events/Monitors.cpp
+++ b/src/events/Monitors.cpp
@@ -188,6 +188,9 @@ void Events::listener_monitorDestroy(void* owner, void* data) {
 
     Debug::log(LOG, "Destroy called for monitor {}", pMonitor->output->name);
 
+    if (pMonitor->output->idle_frame)
+        wl_event_source_remove(pMonitor->output->idle_frame);
+
     pMonitor->onDisconnect(true);
 
     pMonitor->output                 = nullptr;

--- a/src/managers/ThreadManager.cpp
+++ b/src/managers/ThreadManager.cpp
@@ -25,5 +25,6 @@ CThreadManager::CThreadManager() {
 }
 
 CThreadManager::~CThreadManager() {
-    //
+    if (m_esConfigTimer)
+        wl_event_source_remove(m_esConfigTimer);
 }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -90,6 +90,11 @@ CHyprRenderer::CHyprRenderer() {
     wl_event_source_timer_update(m_pCursorTicker, 500);
 }
 
+CHyprRenderer::~CHyprRenderer() {
+    if (m_pCursorTicker)
+        wl_event_source_remove(m_pCursorTicker);
+}
+
 static void renderSurface(SP<CWLSurfaceResource> surface, int x, int y, void* data) {
     if (!surface->current.buffer || !surface->current.buffer->texture)
         return;

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -42,6 +42,7 @@ struct SSessionLockSurface;
 class CHyprRenderer {
   public:
     CHyprRenderer();
+    ~CHyprRenderer();
 
     void                            renderMonitor(CMonitor* pMonitor);
     void                            arrangeLayersForMonitor(const int&);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
with these commits and the [hyprutils PR](https://github.com/hyprwm/hyprutils/pull/1) im down to 

` SUMMARY: AddressSanitizer: 880 byte(s) leaked in 8 allocation(s).` of a nested run of opening a few windows/closing and exiting hyprland. making asan VERY silent :) not that these wouldnt have been harvested by the OS anyways but makes asan much more tolerable when trying to debug things. could use a test or two so the eventloopmanager doesnt have to be running at exit? and freeing the idle frame means some artifacting on some weird combination of display destroying.

the remaining leaks is gonna be solved when the 3 old protocols gets rewritten to the new way, and when the wlroots/wayland implentation proceeds.
