### PR TITLE
CMonitor: move to sharedptr

### DIFF
--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -66,8 +66,8 @@ class CCompositor {
     std::string                               m_szInstancePath      = "";
     std::string                               m_szCurrentSplash     = "error";
 
-    std::vector<SP<CMonitor>>                 m_vMonitors;
-    std::vector<SP<CMonitor>>                 m_vRealMonitors; // for all monitors, even those turned off
+    std::vector<PHLMONITOR>                   m_vMonitors;
+    std::vector<PHLMONITOR>                   m_vRealMonitors; // for all monitors, even those turned off
     std::vector<PHLWINDOW>                    m_vWindows;
     std::vector<PHLLS>                        m_vLayers;
     std::vector<PHLWORKSPACE>                 m_vWorkspaces;
@@ -84,37 +84,36 @@ class CCompositor {
 
     WP<CWLSurfaceResource>                    m_pLastFocus;
     PHLWINDOWREF                              m_pLastWindow;
-    WP<CMonitor>                              m_pLastMonitor;
+    PHLMONITORREF                             m_pLastMonitor;
 
     std::vector<PHLWINDOWREF>                 m_vWindowFocusHistory; // first element is the most recently focused.
 
     bool                                      m_bReadyToProcess = false;
     bool                                      m_bSessionActive  = true;
     bool                                      m_bDPMSStateON    = true;
-    bool                                      m_bUnsafeState    = false;   // unsafe state is when there is no monitors.
-    bool                                      m_bNextIsUnsafe   = false;   // because wlroots
-    CMonitor*                                 m_pUnsafeOutput   = nullptr; // fallback output for the unsafe state
-    bool                                      m_bExitTriggered  = false;   // For exit dispatcher
+    bool                                      m_bUnsafeState    = false; // unsafe state is when there is no monitors.
+    bool                                      m_bNextIsUnsafe   = false; // because wlroots
+    PHLMONITORREF                             m_pUnsafeOutput;           // fallback output for the unsafe state
+    bool                                      m_bExitTriggered  = false; // For exit dispatcher
     bool                                      m_bIsShuttingDown = false;
 
     // ------------------------------------------------- //
 
-    CMonitor*              getMonitorFromID(const int&);
-    CMonitor*              getMonitorFromName(const std::string&);
-    CMonitor*              getMonitorFromDesc(const std::string&);
-    CMonitor*              getMonitorFromCursor();
-    CMonitor*              getMonitorFromVector(const Vector2D&);
+    PHLMONITOR             getMonitorFromID(const int&);
+    PHLMONITOR             getMonitorFromName(const std::string&);
+    PHLMONITOR             getMonitorFromDesc(const std::string&);
+    PHLMONITOR             getMonitorFromCursor();
+    PHLMONITOR             getMonitorFromVector(const Vector2D&);
     void                   removeWindowFromVectorSafe(PHLWINDOW);
     void                   focusWindow(PHLWINDOW, SP<CWLSurfaceResource> pSurface = nullptr);
     void                   focusSurface(SP<CWLSurfaceResource>, PHLWINDOW pWindowOwner = nullptr);
-    bool                   monitorExists(CMonitor*);
     PHLWINDOW              vectorToWindowUnified(const Vector2D&, uint8_t properties, PHLWINDOW pIgnoreWindow = nullptr);
     SP<CWLSurfaceResource> vectorToLayerSurface(const Vector2D&, std::vector<PHLLSREF>*, Vector2D*, PHLLS*);
-    SP<CWLSurfaceResource> vectorToLayerPopupSurface(const Vector2D&, CMonitor* monitor, Vector2D*, PHLLS*);
+    SP<CWLSurfaceResource> vectorToLayerPopupSurface(const Vector2D&, PHLMONITOR monitor, Vector2D*, PHLLS*);
     SP<CWLSurfaceResource> vectorWindowToSurface(const Vector2D&, PHLWINDOW, Vector2D& sl);
     Vector2D               vectorToSurfaceLocal(const Vector2D&, PHLWINDOW, SP<CWLSurfaceResource>);
-    CMonitor*              getMonitorFromOutput(wlr_output*);
-    CMonitor*              getRealMonitorFromOutput(wlr_output*);
+    PHLMONITOR             getMonitorFromOutput(wlr_output*);
+    PHLMONITOR             getRealMonitorFromOutput(wlr_output*);
     PHLWINDOW              getWindowFromSurface(SP<CWLSurfaceResource>);
     PHLWINDOW              getWindowFromHandle(uint32_t);
     bool                   isWorkspaceVisible(PHLWORKSPACE);
@@ -140,21 +139,21 @@ class CCompositor {
     PHLWINDOW              getPrevWindowOnWorkspace(PHLWINDOW, bool focusableOnly = false, std::optional<bool> floating = {});
     int                    getNextAvailableNamedWorkspace();
     bool                   isPointOnAnyMonitor(const Vector2D&);
-    bool                   isPointOnReservedArea(const Vector2D& point, const CMonitor* monitor = nullptr);
-    CMonitor*              getMonitorInDirection(const char&);
-    CMonitor*              getMonitorInDirection(CMonitor*, const char&);
+    bool                   isPointOnReservedArea(const Vector2D& point, const PHLMONITOR monitor = nullptr);
+    PHLMONITOR             getMonitorInDirection(const char&);
+    PHLMONITOR             getMonitorInDirection(PHLMONITOR, const char&);
     void                   updateAllWindowsAnimatedDecorationValues();
     void                   updateWorkspaceWindows(const int64_t& id);
     void                   updateWindowAnimatedDecorationValues(PHLWINDOW);
     int                    getNextAvailableMonitorID(std::string const& name);
-    void                   moveWorkspaceToMonitor(PHLWORKSPACE, CMonitor*, bool noWarpCursor = false);
-    void                   swapActiveWorkspaces(CMonitor*, CMonitor*);
-    CMonitor*              getMonitorFromString(const std::string&);
+    void                   moveWorkspaceToMonitor(PHLWORKSPACE, PHLMONITOR, bool noWarpCursor = false);
+    void                   swapActiveWorkspaces(PHLMONITOR, PHLMONITOR);
+    PHLMONITOR             getMonitorFromString(const std::string&);
     bool                   workspaceIDOutOfBounds(const int64_t&);
     void                   setWindowFullscreen(PHLWINDOW, bool, eFullscreenMode mode = FULLSCREEN_INVALID);
     void                   updateFullscreenFadeOnWorkspace(PHLWORKSPACE);
     PHLWINDOW              getX11Parent(PHLWINDOW);
-    void                   scheduleFrameForMonitor(CMonitor*);
+    void                   scheduleFrameForMonitor(PHLMONITOR);
     void                   addToFadingOutSafe(PHLLS);
     void                   removeFromFadingOutSafe(PHLLS);
     void                   addToFadingOutSafe(PHLWINDOW);
@@ -166,7 +165,7 @@ class CCompositor {
     void                   forceReportSizesToWindowsOnWorkspace(const int&);
     PHLWORKSPACE           createNewWorkspace(const int&, const int&, const std::string& name = "", bool isEmtpy = true); // will be deleted next frame if left empty and unfocused!
     void                   renameWorkspace(const int&, const std::string& name = "");
-    void                   setActiveMonitor(CMonitor*);
+    void                   setActiveMonitor(PHLMONITOR);
     bool                   isWorkspaceSpecial(const int&);
     int                    getNewSpecialID();
     void                   performUserChecks();

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -861,9 +861,9 @@ void CConfigManager::postConfigReload(const Hyprlang::CParseResult& result) {
 
     for (auto& m : g_pCompositor->m_vMonitors) {
         // mark blur dirty
-        g_pHyprOpenGL->markBlurDirtyForMonitor(m.get());
+        g_pHyprOpenGL->markBlurDirtyForMonitor(m);
 
-        g_pCompositor->scheduleFrameForMonitor(m.get());
+        g_pCompositor->scheduleFrameForMonitor(m);
 
         // Force the compositor to fully re-render all monitors
         m->forceFullFrames = 2;
@@ -1326,7 +1326,7 @@ void CConfigManager::performMonitorReload() {
 
         auto rule = getMonitorRuleFor(*m);
 
-        if (!g_pHyprRenderer->applyMonitorRule(m.get(), &rule)) {
+        if (!g_pHyprRenderer->applyMonitorRule(m, &rule)) {
             overAgain = true;
             break;
         }
@@ -1384,14 +1384,14 @@ void CConfigManager::ensureMonitorStatus() {
         auto rule = getMonitorRuleFor(*rm);
 
         if (rule.disabled == rm->m_bEnabled)
-            g_pHyprRenderer->applyMonitorRule(rm.get(), &rule);
+            g_pHyprRenderer->applyMonitorRule(rm, &rule);
     }
 }
 
-void CConfigManager::ensureVRR(CMonitor* pMonitor) {
+void CConfigManager::ensureVRR(PHLMONITOR pMonitor) {
     static auto PVRR = reinterpret_cast<Hyprlang::INT* const*>(getConfigValuePtr("misc:vrr"));
 
-    static auto ensureVRRForDisplay = [&](CMonitor* m) -> void {
+    static auto ensureVRRForDisplay = [&](PHLMONITOR m) -> void {
         if (!m->output || m->createdByUser)
             return;
 
@@ -1457,7 +1457,7 @@ void CConfigManager::ensureVRR(CMonitor* pMonitor) {
     }
 
     for (auto& m : g_pCompositor->m_vMonitors) {
-        ensureVRRForDisplay(m.get());
+        ensureVRRForDisplay(m);
     }
 }
 
@@ -1469,7 +1469,7 @@ void CConfigManager::addParseError(const std::string& err) {
     g_pHyprError->queueCreate(err + "\nHyprland may not work correctly.", CColor(1.0, 50.0 / 255.0, 50.0 / 255.0, 1.0));
 }
 
-CMonitor* CConfigManager::getBoundMonitorForWS(const std::string& wsname) {
+PHLMONITOR CConfigManager::getBoundMonitorForWS(const std::string& wsname) {
     auto monitor = getBoundMonitorStringForWS(wsname);
     if (monitor.substr(0, 5) == "desc:")
         return g_pCompositor->getMonitorFromDesc(monitor.substr(5));

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -109,7 +109,7 @@ class CConfigManager {
     SWorkspaceRule                                                  getWorkspaceRuleFor(PHLWORKSPACE workspace);
     std::string                                                     getDefaultWorkspaceFor(const std::string&);
 
-    CMonitor*                                                       getBoundMonitorForWS(const std::string&);
+    PHLMONITOR                                                      getBoundMonitorForWS(const std::string&);
     std::string                                                     getBoundMonitorStringForWS(const std::string&);
     const std::deque<SWorkspaceRule>&                               getAllWorkspaceRules();
 
@@ -134,7 +134,7 @@ class CConfigManager {
     bool                      m_bForceReload        = false;
     bool                      m_bNoMonitorReload    = false;
     void                      ensureMonitorStatus();
-    void                      ensureVRR(CMonitor* pMonitor = nullptr);
+    void                      ensureVRR(PHLMONITOR pMonitor = nullptr);
 
     std::string               parseKeyword(const std::string&, const std::string&);
 

--- a/src/debug/HyprDebugOverlay.cpp
+++ b/src/debug/HyprDebugOverlay.cpp
@@ -7,7 +7,7 @@ CHyprDebugOverlay::CHyprDebugOverlay() {
     m_pTexture = makeShared<CTexture>();
 }
 
-void CHyprMonitorDebugOverlay::renderData(CMonitor* pMonitor, float µs) {
+void CHyprMonitorDebugOverlay::renderData(PHLMONITOR pMonitor, float µs) {
     m_dLastRenderTimes.push_back(µs / 1000.f);
 
     if (m_dLastRenderTimes.size() > (long unsigned int)pMonitor->refreshRate)
@@ -17,7 +17,7 @@ void CHyprMonitorDebugOverlay::renderData(CMonitor* pMonitor, float µs) {
         m_pMonitor = pMonitor;
 }
 
-void CHyprMonitorDebugOverlay::renderDataNoOverlay(CMonitor* pMonitor, float µs) {
+void CHyprMonitorDebugOverlay::renderDataNoOverlay(PHLMONITOR pMonitor, float µs) {
     m_dLastRenderTimesNoOverlay.push_back(µs / 1000.f);
 
     if (m_dLastRenderTimesNoOverlay.size() > (long unsigned int)pMonitor->refreshRate)
@@ -27,7 +27,7 @@ void CHyprMonitorDebugOverlay::renderDataNoOverlay(CMonitor* pMonitor, float µs
         m_pMonitor = pMonitor;
 }
 
-void CHyprMonitorDebugOverlay::frameData(CMonitor* pMonitor) {
+void CHyprMonitorDebugOverlay::frameData(PHLMONITOR pMonitor) {
     m_dLastFrametimes.push_back(std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - m_tpLastFrame).count() / 1000.f);
 
     if (m_dLastFrametimes.size() > (long unsigned int)pMonitor->refreshRate)
@@ -39,7 +39,7 @@ void CHyprMonitorDebugOverlay::frameData(CMonitor* pMonitor) {
         m_pMonitor = pMonitor;
 
     // anim data too
-    const auto PMONITORFORTICKS = g_pHyprRenderer->m_pMostHzMonitor ? g_pHyprRenderer->m_pMostHzMonitor : g_pCompositor->m_pLastMonitor.get();
+    const auto PMONITORFORTICKS = g_pHyprRenderer->m_pMostHzMonitor ? g_pHyprRenderer->m_pMostHzMonitor : g_pCompositor->m_pLastMonitor;
     if (PMONITORFORTICKS) {
         if (m_dLastAnimationTicks.size() > (long unsigned int)PMONITORFORTICKS->refreshRate)
             m_dLastAnimationTicks.pop_front();
@@ -188,15 +188,15 @@ int CHyprMonitorDebugOverlay::draw(int offset) {
     return posY - offset;
 }
 
-void CHyprDebugOverlay::renderData(CMonitor* pMonitor, float µs) {
+void CHyprDebugOverlay::renderData(PHLMONITOR pMonitor, float µs) {
     m_mMonitorOverlays[pMonitor].renderData(pMonitor, µs);
 }
 
-void CHyprDebugOverlay::renderDataNoOverlay(CMonitor* pMonitor, float µs) {
+void CHyprDebugOverlay::renderDataNoOverlay(PHLMONITOR pMonitor, float µs) {
     m_mMonitorOverlays[pMonitor].renderDataNoOverlay(pMonitor, µs);
 }
 
-void CHyprDebugOverlay::frameData(CMonitor* pMonitor) {
+void CHyprDebugOverlay::frameData(PHLMONITOR pMonitor) {
     m_mMonitorOverlays[pMonitor].frameData(pMonitor);
 }
 
@@ -218,7 +218,7 @@ void CHyprDebugOverlay::draw() {
     // draw the things
     int offsetY = 0;
     for (auto& m : g_pCompositor->m_vMonitors) {
-        offsetY += m_mMonitorOverlays[m.get()].draw(offsetY);
+        offsetY += m_mMonitorOverlays[m].draw(offsetY);
         offsetY += 5; // for padding between mons
     }
 

--- a/src/debug/HyprDebugOverlay.hpp
+++ b/src/debug/HyprDebugOverlay.hpp
@@ -13,9 +13,9 @@ class CHyprMonitorDebugOverlay {
   public:
     int  draw(int offset);
 
-    void renderData(CMonitor* pMonitor, float µs);
-    void renderDataNoOverlay(CMonitor* pMonitor, float µs);
-    void frameData(CMonitor* pMonitor);
+    void renderData(PHLMONITOR pMonitor, float µs);
+    void renderDataNoOverlay(PHLMONITOR pMonitor, float µs);
+    void frameData(PHLMONITOR pMonitor);
 
   private:
     std::deque<float>                              m_dLastFrametimes;
@@ -23,7 +23,7 @@ class CHyprMonitorDebugOverlay {
     std::deque<float>                              m_dLastRenderTimesNoOverlay;
     std::deque<float>                              m_dLastAnimationTicks;
     std::chrono::high_resolution_clock::time_point m_tpLastFrame;
-    CMonitor*                                      m_pMonitor = nullptr;
+    PHLMONITORREF                                  m_pMonitor;
     CBox                                           m_wbLastDrawnBox;
 
     friend class CHyprRenderer;
@@ -33,17 +33,17 @@ class CHyprDebugOverlay {
   public:
     CHyprDebugOverlay();
     void draw();
-    void renderData(CMonitor*, float µs);
-    void renderDataNoOverlay(CMonitor*, float µs);
-    void frameData(CMonitor*);
+    void renderData(PHLMONITOR, float µs);
+    void renderDataNoOverlay(PHLMONITOR, float µs);
+    void frameData(PHLMONITOR);
 
   private:
-    std::unordered_map<CMonitor*, CHyprMonitorDebugOverlay> m_mMonitorOverlays;
+    std::unordered_map<PHLMONITOR, CHyprMonitorDebugOverlay> m_mMonitorOverlays;
 
-    cairo_surface_t*                                        m_pCairoSurface = nullptr;
-    cairo_t*                                                m_pCairo        = nullptr;
+    cairo_surface_t*                                         m_pCairoSurface = nullptr;
+    cairo_t*                                                 m_pCairo        = nullptr;
 
-    SP<CTexture>                                            m_pTexture;
+    SP<CTexture>                                             m_pTexture;
 
     friend class CHyprMonitorDebugOverlay;
     friend class CHyprRenderer;

--- a/src/debug/HyprNotificationOverlay.cpp
+++ b/src/debug/HyprNotificationOverlay.cpp
@@ -45,7 +45,7 @@ void CHyprNotificationOverlay::addNotification(const std::string& text, const CC
     PNOTIF->fontSize = fontSize;
 
     for (auto& m : g_pCompositor->m_vMonitors) {
-        g_pCompositor->scheduleFrameForMonitor(m.get());
+        g_pCompositor->scheduleFrameForMonitor(m);
     }
 }
 
@@ -61,7 +61,7 @@ void CHyprNotificationOverlay::dismissNotifications(const int amount) {
     }
 }
 
-CBox CHyprNotificationOverlay::drawNotifications(CMonitor* pMonitor) {
+CBox CHyprNotificationOverlay::drawNotifications(PHLMONITOR pMonitor) {
     static constexpr auto ANIM_DURATION_MS   = 600.0;
     static constexpr auto ANIM_LAG_MS        = 100.0;
     static constexpr auto NOTIF_LEFTBAR_SIZE = 5.0;
@@ -187,7 +187,7 @@ CBox CHyprNotificationOverlay::drawNotifications(CMonitor* pMonitor) {
     return CBox{(int)(pMonitor->vecPosition.x + pMonitor->vecSize.x - maxWidth - 20), (int)pMonitor->vecPosition.y, (int)maxWidth + 20, (int)offsetY + 10};
 }
 
-void CHyprNotificationOverlay::draw(CMonitor* pMonitor) {
+void CHyprNotificationOverlay::draw(PHLMONITOR pMonitor) {
 
     const auto MONSIZE = pMonitor->vecTransformedSize;
 

--- a/src/debug/HyprNotificationOverlay.hpp
+++ b/src/debug/HyprNotificationOverlay.hpp
@@ -41,13 +41,13 @@ class CHyprNotificationOverlay {
     CHyprNotificationOverlay();
     ~CHyprNotificationOverlay();
 
-    void draw(CMonitor* pMonitor);
+    void draw(PHLMONITOR pMonitor);
     void addNotification(const std::string& text, const CColor& color, const float timeMs, const eIcons icon = ICON_NONE, const float fontSize = 13.f);
     void dismissNotifications(const int amount);
     bool hasAny();
 
   private:
-    CBox                                       drawNotifications(CMonitor* pMonitor);
+    CBox                                       drawNotifications(PHLMONITOR pMonitor);
     CBox                                       m_bLastDamage;
 
     std::deque<std::unique_ptr<SNotification>> m_dNotifications;
@@ -55,8 +55,8 @@ class CHyprNotificationOverlay {
     cairo_surface_t*                           m_pCairoSurface = nullptr;
     cairo_t*                                   m_pCairo        = nullptr;
 
-    CMonitor*                                  m_pLastMonitor = nullptr;
-    Vector2D                                   m_vecLastSize  = Vector2D(-1, -1);
+    PHLMONITORREF                              m_pLastMonitor;
+    Vector2D                                   m_vecLastSize = Vector2D(-1, -1);
 
     SP<CTexture>                               m_pTexture;
 };

--- a/src/desktop/DesktopTypes.hpp
+++ b/src/desktop/DesktopTypes.hpp
@@ -3,6 +3,7 @@
 class CWorkspace;
 class CWindow;
 class CLayerSurface;
+class CMonitor;
 
 /* Shared pointer to a workspace */
 typedef SP<CWorkspace> PHLWORKSPACE;
@@ -18,3 +19,8 @@ typedef WP<CWindow> PHLWINDOWREF;
 typedef SP<CLayerSurface> PHLLS;
 /* Weak pointer to a layer surface */
 typedef WP<CLayerSurface> PHLLSREF;
+
+/* Shared pointer to a monitor */
+typedef SP<CMonitor> PHLMONITOR;
+/* Weak pointer to a monitor */
+typedef WP<CMonitor> PHLMONITORREF;

--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -6,9 +6,9 @@
 #include "../managers/SeatManager.hpp"
 
 PHLLS CLayerSurface::create(SP<CLayerShellResource> resource) {
-    PHLLS     pLS = SP<CLayerSurface>(new CLayerSurface(resource));
+    PHLLS      pLS = SP<CLayerSurface>(new CLayerSurface(resource));
 
-    CMonitor* pMonitor = resource->monitor.empty() ? g_pCompositor->getMonitorFromCursor() : g_pCompositor->getMonitorFromName(resource->monitor);
+    PHLMONITOR pMonitor = resource->monitor.empty() ? g_pCompositor->getMonitorFromCursor() : g_pCompositor->getMonitorFromName(resource->monitor);
 
     pLS->surface->assign(resource->surface.lock(), pLS);
 
@@ -18,7 +18,7 @@ PHLLS CLayerSurface::create(SP<CLayerShellResource> resource) {
     }
 
     if (pMonitor->pMirrorOf)
-        pMonitor = g_pCompositor->m_vMonitors.front().get();
+        pMonitor = g_pCompositor->m_vMonitors.front();
 
     pLS->self = pLS;
 

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1217,7 +1217,7 @@ void CWindow::setSuspended(bool suspend) {
     m_bSuspended = suspend;
 }
 
-bool CWindow::visibleOnMonitor(CMonitor* pMonitor) {
+bool CWindow::visibleOnMonitor(PHLMONITOR pMonitor) {
     CBox wbox = {m_vRealPosition.value(), m_vRealSize.value()};
 
     return !wbox.intersection({pMonitor->vecPosition, pMonitor->vecSize}).empty();

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -412,7 +412,7 @@ class CWindow {
     bool                     canBeTorn();
     bool                     shouldSendFullscreenState();
     void                     setSuspended(bool suspend);
-    bool                     visibleOnMonitor(CMonitor* pMonitor);
+    bool                     visibleOnMonitor(PHLMONITOR pMonitor);
     int                      workspaceID();
     bool                     onSpecialWorkspace();
     void                     activate(bool force = false);

--- a/src/events/Misc.cpp
+++ b/src/events/Misc.cpp
@@ -35,8 +35,8 @@ void Events::listener_sessionActive(wl_listener* listener, void* data) {
     g_pCompositor->m_bSessionActive = true;
 
     for (auto& m : g_pCompositor->m_vMonitors) {
-        g_pCompositor->scheduleFrameForMonitor(m.get());
-        g_pHyprRenderer->applyMonitorRule(m.get(), &m->activeMonitorRule, true);
+        g_pCompositor->scheduleFrameForMonitor(m);
+        g_pHyprRenderer->applyMonitorRule(m, &m->activeMonitorRule, true);
     }
 
     g_pConfigManager->m_bWantsMonitorReload = true;

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -48,10 +48,10 @@ void Events::listener_mapWindow(void* owner, void* data) {
     static auto PNEWTAKESOVERFS    = CConfigValue<Hyprlang::INT>("misc:new_window_takes_over_fullscreen");
     static auto PINITIALWSTRACKING = CConfigValue<Hyprlang::INT>("misc:initial_workspace_tracking");
 
-    auto        PMONITOR = g_pCompositor->m_pLastMonitor.get();
+    auto        PMONITOR = g_pCompositor->m_pLastMonitor.lock();
     if (!g_pCompositor->m_pLastMonitor) {
         g_pCompositor->setActiveMonitor(g_pCompositor->getMonitorFromVector({}));
-        PMONITOR = g_pCompositor->m_pLastMonitor.get();
+        PMONITOR = g_pCompositor->m_pLastMonitor.lock();
     }
     auto PWORKSPACE           = PMONITOR->activeSpecialWorkspace ? PMONITOR->activeSpecialWorkspace : PMONITOR->activeWorkspace;
     PWINDOW->m_iMonitorID     = PMONITOR->ID;
@@ -317,7 +317,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                 else if (PMONITOR->activeWorkspaceID() != REQUESTEDWORKSPACEID)
                     g_pKeybindManager->m_mDispatchers["workspace"](requestedWorkspaceName);
 
-                PMONITOR = g_pCompositor->m_pLastMonitor.get();
+                PMONITOR = g_pCompositor->m_pLastMonitor.lock();
             }
         } else
             workspaceSilent = false;

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -115,11 +115,11 @@ class CMonitor {
 
     SMonitorRule            activeMonitorRule;
 
-    WP<CMonitor>            self;
+    PHLMONITORREF           self;
 
     // mirroring
-    CMonitor*              pMirrorOf = nullptr;
-    std::vector<CMonitor*> mirrors;
+    PHLMONITORREF              pMirrorOf;
+    std::vector<PHLMONITORREF> mirrors;
 
     // for tearing
     PHLWINDOWREF solitaryClient;
@@ -185,4 +185,13 @@ class CMonitor {
   private:
     void setupDefaultWS(const SMonitorRule&);
     int  findAvailableDefaultWS();
+
+    void onFrame(void* data);
+    void onStateRequest(void* data);
+    void onDamage(void* data);
+    void onCommit(void* data);
+    void onNeedsFrame(void* data);
+    void onBind(void* data);
+    void onDestroy(void* data);
+    void onPresented(void* data);
 };

--- a/src/helpers/WLClasses.hpp
+++ b/src/helpers/WLClasses.hpp
@@ -16,9 +16,9 @@ class IKeyboard;
 class CWLSurfaceResource;
 
 struct SRenderData {
-    CMonitor* pMonitor;
-    timespec* when;
-    double    x, y;
+    PHLMONITOR pMonitor;
+    timespec*  when;
+    double     x, y;
 
     // for iters
     void*                  data    = nullptr;
@@ -63,7 +63,7 @@ struct SSwipeGesture {
     int          speedPoints      = 0;
     int          touch_id         = 0;
 
-    CMonitor*    pMonitor = nullptr;
+    PHLMONITOR   pMonitor = nullptr;
 };
 
 struct SSwitchDevice {

--- a/src/hyprerror/HyprError.cpp
+++ b/src/hyprerror/HyprError.cpp
@@ -11,7 +11,7 @@ CHyprError::CHyprError() {
         if (!m_bIsCreated)
             return;
 
-        g_pHyprRenderer->damageMonitor(g_pCompositor->m_pLastMonitor.get());
+        g_pHyprRenderer->damageMonitor(g_pCompositor->m_pLastMonitor.lock());
         m_bMonitorChanged = true;
     });
 
@@ -44,7 +44,7 @@ void CHyprError::createQueued() {
     m_fFadeOpacity.setValueAndWarp(0.f);
     m_fFadeOpacity = 1.f;
 
-    const auto PMONITOR = g_pCompositor->m_vMonitors.front().get();
+    const auto PMONITOR = g_pCompositor->m_vMonitors.front();
 
     const auto SCALE = PMONITOR->scale;
 

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -101,12 +101,12 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
     if (pNode->isNode)
         return;
 
-    CMonitor* PMONITOR = nullptr;
+    PHLMONITOR PMONITOR = nullptr;
 
     if (g_pCompositor->isWorkspaceSpecial(pNode->workspaceID)) {
         for (auto& m : g_pCompositor->m_vMonitors) {
             if (m->activeSpecialWorkspaceID() == pNode->workspaceID) {
-                PMONITOR = m.get();
+                PMONITOR = m;
                 break;
             }
         }

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -586,12 +586,12 @@ void CHyprMasterLayout::calculateWorkspace(PHLWORKSPACE pWorkspace) {
 }
 
 void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
-    CMonitor* PMONITOR = nullptr;
+    PHLMONITOR PMONITOR = nullptr;
 
     if (g_pCompositor->isWorkspaceSpecial(pNode->workspaceID)) {
         for (auto& m : g_pCompositor->m_vMonitors) {
             if (m->activeSpecialWorkspaceID() == pNode->workspaceID) {
-                PMONITOR = m.get();
+                PMONITOR = m;
                 break;
             }
         }

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -84,7 +84,7 @@ void CAnimationManager::tick() {
         PHLWINDOW    PWINDOW            = av->m_pWindow.lock();
         PHLWORKSPACE PWORKSPACE         = av->m_pWorkspace.lock();
         PHLLS        PLAYER             = av->m_pLayer.lock();
-        CMonitor*    PMONITOR           = nullptr;
+        PHLMONITOR   PMONITOR           = nullptr;
         bool         animationsDisabled = animGlobalDisabled;
 
         if (PWINDOW) {

--- a/src/managers/CursorManager.cpp
+++ b/src/managers/CursorManager.cpp
@@ -283,7 +283,7 @@ void CCursorManager::updateTheme() {
 
     for (auto& m : g_pCompositor->m_vMonitors) {
         m->forceFullFrames = 5;
-        g_pCompositor->scheduleFrameForMonitor(m.get());
+        g_pCompositor->scheduleFrameForMonitor(m);
     }
 }
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -270,11 +270,11 @@ void updateRelativeCursorCoords() {
         g_pCompositor->m_pLastWindow->m_vRelativeCursorCoordsOnLastWarp = g_pInputManager->getMouseCoordsInternal() - g_pCompositor->m_pLastWindow->m_vPosition;
 }
 
-bool CKeybindManager::tryMoveFocusToMonitor(CMonitor* monitor) {
+bool CKeybindManager::tryMoveFocusToMonitor(PHLMONITOR monitor) {
     if (!monitor)
         return false;
 
-    const auto LASTMONITOR = g_pCompositor->m_pLastMonitor.get();
+    const auto LASTMONITOR = g_pCompositor->m_pLastMonitor.lock();
     if (LASTMONITOR == monitor) {
         Debug::log(LOG, "Tried to move to active monitor");
         return false;
@@ -1029,7 +1029,7 @@ void CKeybindManager::changeworkspace(std::string args) {
     static auto PALLOWWORKSPACECYCLES = CConfigValue<Hyprlang::INT>("binds:allow_workspace_cycles");
     static auto PWORKSPACECENTERON    = CConfigValue<Hyprlang::INT>("binds:workspace_center_on");
 
-    const auto  PMONITOR = g_pCompositor->m_pLastMonitor.get();
+    const auto  PMONITOR = g_pCompositor->m_pLastMonitor.lock();
 
     if (!PMONITOR)
         return;
@@ -1157,7 +1157,7 @@ void CKeybindManager::moveActiveToWorkspace(std::string args) {
     }
 
     auto        pWorkspace            = g_pCompositor->getWorkspaceByID(WORKSPACEID);
-    CMonitor*   pMonitor              = nullptr;
+    PHLMONITOR  pMonitor              = nullptr;
     const auto  POLDWS                = PWINDOW->m_pWorkspace;
     static auto PALLOWWORKSPACECYCLES = CConfigValue<Hyprlang::INT>("binds:allow_workspace_cycles");
 
@@ -1643,7 +1643,7 @@ void CKeybindManager::exitHyprland(std::string argz) {
 }
 
 void CKeybindManager::moveCurrentWorkspaceToMonitor(std::string args) {
-    CMonitor* PMONITOR = g_pCompositor->getMonitorFromString(args);
+    PHLMONITOR PMONITOR = g_pCompositor->getMonitorFromString(args);
 
     if (!PMONITOR) {
         Debug::log(ERR, "Ignoring moveCurrentWorkspaceToMonitor: monitor doesnt exist");
@@ -1702,7 +1702,7 @@ void CKeybindManager::focusWorkspaceOnCurrentMonitor(std::string args) {
         return;
     }
 
-    const auto PCURRMONITOR = g_pCompositor->m_pLastMonitor.get();
+    const auto PCURRMONITOR = g_pCompositor->m_pLastMonitor.lock();
 
     if (!PCURRMONITOR) {
         Debug::log(ERR, "focusWorkspaceOnCurrentMonitor monitor doesn't exist!");
@@ -1791,7 +1791,7 @@ void CKeybindManager::forceRendererReload(std::string args) {
             continue;
 
         auto rule = g_pConfigManager->getMonitorRuleFor(*m);
-        if (!g_pHyprRenderer->applyMonitorRule(m.get(), &rule, true)) {
+        if (!g_pHyprRenderer->applyMonitorRule(m, &rule, true)) {
             overAgain = true;
             break;
         }
@@ -2255,7 +2255,7 @@ void CKeybindManager::dpms(std::string arg) {
         }
 
         if (enable)
-            g_pHyprRenderer->damageMonitor(m.get());
+            g_pHyprRenderer->damageMonitor(m);
 
         m->events.dpmsChanged.emit();
     }

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -136,7 +136,7 @@ class CKeybindManager {
     void                            updateXKBTranslationState();
     bool                            ensureMouseBindState();
 
-    static bool                     tryMoveFocusToMonitor(CMonitor* monitor);
+    static bool                     tryMoveFocusToMonitor(PHLMONITOR monitor);
     static void                     moveWindowOutOfGroup(PHLWINDOW pWindow, const std::string& dir = "");
     static void                     moveWindowIntoGroup(PHLWINDOW pWindow, PHLWINDOW pWindowInDirection);
     static void                     switchToWindow(PHLWINDOW PWINDOWTOCHANGETO);

--- a/src/managers/PointerManager.hpp
+++ b/src/managers/PointerManager.hpp
@@ -41,17 +41,18 @@ class CPointerManager {
     void setCursorSurface(SP<CWLSurface> buf, const Vector2D& hotspot);
     void resetCursorImage(bool apply = true);
 
-    void lockSoftwareForMonitor(SP<CMonitor> pMonitor);
-    void unlockSoftwareForMonitor(SP<CMonitor> pMonitor);
+    void lockSoftwareForMonitor(PHLMONITOR pMonitor);
+    void unlockSoftwareForMonitor(PHLMONITOR pMonitor);
     void lockSoftwareAll();
     void unlockSoftwareAll();
+    bool isSoftwareLockedFor(PHLMONITOR pMonitor);
 
-    void renderSoftwareCursorsFor(SP<CMonitor> pMonitor, timespec* now, CRegion& damage /* logical */, std::optional<Vector2D> overridePos = {} /* monitor-local */);
+    void renderSoftwareCursorsFor(PHLMONITOR pMonitor, timespec* now, CRegion& damage /* logical */, std::optional<Vector2D> overridePos = {} /* monitor-local */);
 
     // this is needed e.g. during screensharing where
     // the software cursors aren't locked during the cursor move, but they
     // are rendered later.
-    void damageCursor(SP<CMonitor> pMonitor);
+    void damageCursor(PHLMONITOR pMonitor);
 
     //
     Vector2D position();
@@ -71,13 +72,13 @@ class CPointerManager {
     Vector2D closestValid(const Vector2D& pos);
 
     // returns the thing in device coordinates. Is NOT offset by the hotspot, relies on set_cursor with hotspot.
-    Vector2D getCursorPosForMonitor(SP<CMonitor> pMonitor);
+    Vector2D getCursorPosForMonitor(PHLMONITOR pMonitor);
     // returns the thing in logical coordinates of the monitor
-    CBox getCursorBoxLogicalForMonitor(SP<CMonitor> pMonitor);
+    CBox getCursorBoxLogicalForMonitor(PHLMONITOR pMonitor);
     // returns the thing in global coords
     CBox         getCursorBoxGlobal();
 
-    Vector2D     transformedHotspot(SP<CMonitor> pMonitor);
+    Vector2D     transformedHotspot(PHLMONITOR pMonitor);
 
     SP<CTexture> getCurrentCursorTexture();
 
@@ -149,25 +150,25 @@ class CPointerManager {
     Vector2D pointerPos = {0, 0};
 
     struct SMonitorPointerState {
-        SMonitorPointerState(SP<CMonitor> m) : monitor(m) {}
+        SMonitorPointerState(PHLMONITOR m) : monitor(m) {}
         ~SMonitorPointerState() {
             if (cursorFrontBuffer)
                 wlr_buffer_unlock(cursorFrontBuffer);
         }
 
-        WP<CMonitor> monitor;
+        PHLMONITORREF monitor;
 
-        int          softwareLocks  = 0;
-        bool         hardwareFailed = false;
-        CBox         box; // logical
-        bool         entered   = false;
-        bool         hwApplied = false;
+        int           softwareLocks  = 0;
+        bool          hardwareFailed = false;
+        CBox          box; // logical
+        bool          entered   = false;
+        bool          hwApplied = false;
 
-        wlr_buffer*  cursorFrontBuffer = nullptr;
+        wlr_buffer*   cursorFrontBuffer = nullptr;
     };
 
     std::vector<SP<SMonitorPointerState>> monitorStates;
-    SP<SMonitorPointerState>              stateFor(SP<CMonitor> mon);
+    SP<SMonitorPointerState>              stateFor(PHLMONITOR mon);
     bool                                  attemptHardwareCursor(SP<SMonitorPointerState> state);
     wlr_buffer*                           renderHWCursorBuffer(SP<SMonitorPointerState> state, SP<CTexture> texture);
     bool                                  setHWCursorBuffer(SP<SMonitorPointerState> state, wlr_buffer* buf);

--- a/src/managers/ProtocolManager.cpp
+++ b/src/managers/ProtocolManager.cpp
@@ -46,7 +46,7 @@
 #include "../helpers/Monitor.hpp"
 #include "../render/Renderer.hpp"
 
-void CProtocolManager::onMonitorModeChange(CMonitor* pMonitor) {
+void CProtocolManager::onMonitorModeChange(PHLMONITOR pMonitor) {
     const bool ISMIRROR = pMonitor->isMirror();
 
     // onModeChanged we check if the current mirror status matches the global.
@@ -67,7 +67,7 @@ CProtocolManager::CProtocolManager() {
 
     // Outputs are a bit dumb, we have to agree.
     static auto P = g_pHookSystem->hookDynamic("monitorAdded", [this](void* self, SCallbackInfo& info, std::any param) {
-        auto M = std::any_cast<CMonitor*>(param);
+        auto M = std::any_cast<PHLMONITOR>(param);
 
         // ignore mirrored outputs. I don't think this will ever be hit as mirrors are applied after
         // this event is emitted iirc.
@@ -82,7 +82,7 @@ CProtocolManager::CProtocolManager() {
     });
 
     static auto P2 = g_pHookSystem->hookDynamic("monitorRemoved", [this](void* self, SCallbackInfo& info, std::any param) {
-        auto M = std::any_cast<CMonitor*>(param);
+        auto M = std::any_cast<PHLMONITOR>(param);
         if (!PROTO::outputs.contains(M->szName))
             return;
         PROTO::outputs.at(M->szName)->remove();

--- a/src/managers/ProtocolManager.hpp
+++ b/src/managers/ProtocolManager.hpp
@@ -22,7 +22,7 @@ class CProtocolManager {
   private:
     std::unordered_map<std::string, CHyprSignalListener> m_mModeChangeListeners;
 
-    void                                                 onMonitorModeChange(CMonitor* pMonitor);
+    void                                                 onMonitorModeChange(PHLMONITOR pMonitor);
 };
 
 inline std::unique_ptr<CProtocolManager> g_pProtocolManager;

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -67,14 +67,14 @@ void CSessionLockManager::onNewSessionLock(SP<CSessionLock> pLock) {
         g_pInputManager->refocus();
 
         for (auto& m : g_pCompositor->m_vMonitors)
-            g_pHyprRenderer->damageMonitor(m.get());
+            g_pHyprRenderer->damageMonitor(m);
     });
 
     m_pSessionLock->listeners.destroy = pLock->events.destroyed.registerListener([](std::any data) {
         g_pCompositor->focusSurface(nullptr);
 
         for (auto& m : g_pCompositor->m_vMonitors)
-            g_pHyprRenderer->damageMonitor(m.get());
+            g_pHyprRenderer->damageMonitor(m);
     });
 
     pLock->sendLocked();

--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -239,7 +239,7 @@ Vector2D CHyprXWaylandManager::xwaylandToWaylandCoords(const Vector2D& coord) {
 
     static auto PXWLFORCESCALEZERO = CConfigValue<Hyprlang::INT>("xwayland:force_zero_scaling");
 
-    CMonitor*   pMonitor     = nullptr;
+    PHLMONITOR  pMonitor     = nullptr;
     double      bestDistance = __FLT_MAX__;
     for (auto& m : g_pCompositor->m_vMonitors) {
         const auto SIZ = *PXWLFORCESCALEZERO ? m->vecTransformedSize : m->vecSize;
@@ -249,7 +249,7 @@ Vector2D CHyprXWaylandManager::xwaylandToWaylandCoords(const Vector2D& coord) {
 
         if (distance < bestDistance) {
             bestDistance = distance;
-            pMonitor     = m.get();
+            pMonitor     = m;
         }
     }
 

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -104,7 +104,7 @@ class CInputManager {
 
     Vector2D           getMouseCoordsInternal();
     void               refocus();
-    void               refocusLastWindow(CMonitor* pMonitor);
+    void               refocusLastWindow(PHLMONITOR pMonitor);
     void               simulateMouseMovement();
     void               sendMotionEventsToFocused();
 

--- a/src/managers/input/InputMethodPopup.cpp
+++ b/src/managers/input/InputMethodPopup.cpp
@@ -100,11 +100,11 @@ void CInputPopup::updateBox() {
         cursorBoxParent = {0, 0, (int)parentBox.w, (int)parentBox.h};
     }
 
-    Vector2D  currentPopupSize = surface->getViewporterCorrectedSize();
+    Vector2D   currentPopupSize = surface->getViewporterCorrectedSize();
 
-    CMonitor* pMonitor = g_pCompositor->getMonitorFromVector(parentBox.middle());
+    PHLMONITOR pMonitor = g_pCompositor->getMonitorFromVector(parentBox.middle());
 
-    Vector2D  popupOffset(0, 0);
+    Vector2D   popupOffset(0, 0);
 
     if (parentBox.y + cursorBoxParent.y + cursorBoxParent.height + currentPopupSize.y > pMonitor->vecPosition.y + pMonitor->vecSize.y)
         popupOffset.y = -currentPopupSize.y;

--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -33,7 +33,7 @@ void CInputManager::beginWorkspaceSwipe() {
 
     m_sActiveSwipe.pWorkspaceBegin = PWORKSPACE;
     m_sActiveSwipe.delta           = 0;
-    m_sActiveSwipe.pMonitor        = g_pCompositor->m_pLastMonitor.get();
+    m_sActiveSwipe.pMonitor        = g_pCompositor->m_pLastMonitor.lock();
     m_sActiveSwipe.avgSpeed        = 0;
     m_sActiveSwipe.speedPoints     = 0;
 

--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -17,7 +17,7 @@ void CInputManager::onTouchDown(ITouch::SDownEvent e) {
 
     auto PMONITOR = g_pCompositor->getMonitorFromName(!e.device->boundOutput.empty() ? e.device->boundOutput : "");
 
-    PMONITOR = PMONITOR ? PMONITOR : g_pCompositor->m_pLastMonitor.get();
+    PMONITOR = PMONITOR ? PMONITOR : g_pCompositor->m_pLastMonitor.lock();
 
     g_pCompositor->warpCursorTo({PMONITOR->vecPosition.x + e.pos.x * PMONITOR->vecSize.x, PMONITOR->vecPosition.y + e.pos.y * PMONITOR->vecSize.y}, true);
 

--- a/src/protocols/ForeignToplevelWlr.cpp
+++ b/src/protocols/ForeignToplevelWlr.cpp
@@ -46,7 +46,7 @@ CForeignToplevelHandleWlr::CForeignToplevelHandleWlr(SP<CZwlrForeignToplevelHand
 
                 if (PWINDOW->m_pWorkspace != monitor->activeWorkspace) {
                     g_pCompositor->moveWindowToWorkspaceSafe(PWINDOW, monitor->activeWorkspace);
-                    g_pCompositor->setActiveMonitor(monitor.get());
+                    g_pCompositor->setActiveMonitor(monitor);
                 }
             }
         }
@@ -118,7 +118,7 @@ wl_resource* CForeignToplevelHandleWlr::res() {
     return resource->resource();
 }
 
-void CForeignToplevelHandleWlr::sendMonitor(CMonitor* pMonitor) {
+void CForeignToplevelHandleWlr::sendMonitor(PHLMONITOR pMonitor) {
     if (lastMonitorID == (int64_t)pMonitor->ID)
         return;
 

--- a/src/protocols/ForeignToplevelWlr.hpp
+++ b/src/protocols/ForeignToplevelWlr.hpp
@@ -22,7 +22,7 @@ class CForeignToplevelHandleWlr {
     bool                             closed        = false;
     int64_t                          lastMonitorID = -1;
 
-    void                             sendMonitor(CMonitor* pMonitor);
+    void                             sendMonitor(PHLMONITOR pMonitor);
     void                             sendState();
 
     friend class CForeignToplevelWlrManager;

--- a/src/protocols/GammaControl.hpp
+++ b/src/protocols/GammaControl.hpp
@@ -14,13 +14,13 @@ class CGammaControl {
     CGammaControl(SP<CZwlrGammaControlV1> resource_, wl_resource* output);
     ~CGammaControl();
 
-    bool      good();
-    void      applyToMonitor();
-    CMonitor* getMonitor();
+    bool       good();
+    void       applyToMonitor();
+    PHLMONITOR getMonitor();
 
   private:
     SP<CZwlrGammaControlV1> resource;
-    CMonitor*               pMonitor      = nullptr;
+    PHLMONITORREF           pMonitor;
     size_t                  gammaSize     = 0;
     bool                    gammaTableSet = false;
     std::vector<uint16_t>   gammaTable;
@@ -39,7 +39,7 @@ class CGammaControlProtocol : public IWaylandProtocol {
 
     virtual void bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id);
 
-    void         applyGammaToState(CMonitor* pMonitor);
+    void         applyGammaToState(PHLMONITOR pMonitor);
 
   private:
     void onManagerResourceDestroy(wl_resource* res);

--- a/src/protocols/LayerShell.cpp
+++ b/src/protocols/LayerShell.cpp
@@ -16,8 +16,10 @@ void CLayerShellResource::SState::reset() {
     margin        = {0, 0, 0, 0};
 }
 
-CLayerShellResource::CLayerShellResource(SP<CZwlrLayerSurfaceV1> resource_, SP<CWLSurfaceResource> surf_, std::string namespace_, CMonitor* pMonitor, zwlrLayerShellV1Layer layer) :
-    layerNamespace(namespace_), surface(surf_), resource(resource_) {
+CLayerShellResource::CLayerShellResource(SP<CZwlrLayerSurfaceV1> resource_, SP<CWLSurfaceResource> surf_, std::string namespace_, PHLMONITOR pMonitor,
+                                         zwlrLayerShellV1Layer layer) :
+    layerNamespace(namespace_),
+    surface(surf_), resource(resource_) {
     if (!good())
         return;
 
@@ -212,7 +214,7 @@ void CLayerShellProtocol::destroyResource(CLayerShellResource* surf) {
 
 void CLayerShellProtocol::onGetLayerSurface(CZwlrLayerShellV1* pMgr, uint32_t id, wl_resource* surface, wl_resource* output, zwlrLayerShellV1Layer layer, std::string namespace_) {
     const auto CLIENT   = pMgr->client();
-    const auto PMONITOR = output ? CWLOutputResource::fromResource(output)->monitor.get() : nullptr;
+    const auto PMONITOR = output ? CWLOutputResource::fromResource(output)->monitor.lock() : nullptr;
     auto       SURF     = CWLSurfaceResource::fromResource(surface);
 
     if (!SURF) {

--- a/src/protocols/LayerShell.hpp
+++ b/src/protocols/LayerShell.hpp
@@ -15,7 +15,7 @@ class CWLSurfaceResource;
 
 class CLayerShellResource : public ISurfaceRole {
   public:
-    CLayerShellResource(SP<CZwlrLayerSurfaceV1> resource_, SP<CWLSurfaceResource> surf_, std::string namespace_, CMonitor* pMonitor, zwlrLayerShellV1Layer layer);
+    CLayerShellResource(SP<CZwlrLayerSurfaceV1> resource_, SP<CWLSurfaceResource> surf_, std::string namespace_, PHLMONITOR pMonitor, zwlrLayerShellV1Layer layer);
     ~CLayerShellResource();
 
     bool                 good();

--- a/src/protocols/OutputManagement.hpp
+++ b/src/protocols/OutputManagement.hpp
@@ -17,7 +17,7 @@ class COutputManager {
     COutputManager(SP<CZwlrOutputManagerV1> resource_);
 
     bool good();
-    void ensureMonitorSent(CMonitor* pMonitor);
+    void ensureMonitorSent(PHLMONITOR pMonitor);
     void sendDone();
 
   private:
@@ -28,7 +28,7 @@ class COutputManager {
 
     std::vector<WP<COutputHead>> heads;
 
-    void                         makeAndSendNewHead(CMonitor* pMonitor);
+    void                         makeAndSendNewHead(PHLMONITOR pMonitor);
     friend class COutputManagementProtocol;
 };
 
@@ -50,16 +50,16 @@ class COutputMode {
 
 class COutputHead {
   public:
-    COutputHead(SP<CZwlrOutputHeadV1> resource_, CMonitor* pMonitor_);
+    COutputHead(SP<CZwlrOutputHeadV1> resource_, PHLMONITOR pMonitor_);
 
-    bool      good();
-    void      sendAllData(); // this has to be separate as we need to send the head first, then set the data
-    void      updateMode();
-    CMonitor* monitor();
+    bool       good();
+    void       sendAllData(); // this has to be separate as we need to send the head first, then set the data
+    void       updateMode();
+    PHLMONITOR monitor();
 
   private:
     SP<CZwlrOutputHeadV1>        resource;
-    CMonitor*                    pMonitor = nullptr;
+    PHLMONITORREF                pMonitor;
 
     void                         makeAndSendNewMode(wlr_output_mode* mode);
     void                         sendCurrentMode();
@@ -77,7 +77,7 @@ class COutputHead {
 
 class COutputConfigurationHead {
   public:
-    COutputConfigurationHead(SP<CZwlrOutputConfigurationHeadV1> resource_, CMonitor* pMonitor_);
+    COutputConfigurationHead(SP<CZwlrOutputConfigurationHeadV1> resource_, PHLMONITOR pMonitor_);
 
     bool good();
 
@@ -106,7 +106,7 @@ class COutputConfigurationHead {
 
   private:
     SP<CZwlrOutputConfigurationHeadV1> resource;
-    CMonitor*                          pMonitor = nullptr;
+    PHLMONITOR                         pMonitor = nullptr;
 
     struct {
         CHyprSignalListener monitorDestroy;

--- a/src/protocols/OutputPower.cpp
+++ b/src/protocols/OutputPower.cpp
@@ -4,7 +4,7 @@
 
 #define LOGM PROTO::outputPower->protoLog
 
-COutputPower::COutputPower(SP<CZwlrOutputPowerV1> resource_, CMonitor* pMonitor_) : resource(resource_), pMonitor(pMonitor_) {
+COutputPower::COutputPower(SP<CZwlrOutputPowerV1> resource_, PHLMONITOR pMonitor_) : resource(resource_), pMonitor(pMonitor_) {
     if (!resource->resource())
         return;
 
@@ -26,7 +26,7 @@ COutputPower::COutputPower(SP<CZwlrOutputPowerV1> resource_, CMonitor* pMonitor_
     resource->sendMode(pMonitor->dpmsStatus ? ZWLR_OUTPUT_POWER_V1_MODE_ON : ZWLR_OUTPUT_POWER_V1_MODE_OFF);
 
     listeners.monitorDestroy = pMonitor->events.destroy.registerListener([this](std::any v) {
-        pMonitor = nullptr;
+        pMonitor.reset();
         resource->sendFailed();
     });
 
@@ -70,7 +70,7 @@ void COutputPowerProtocol::onGetOutputPower(CZwlrOutputPowerManagerV1* pMgr, uin
     }
 
     const auto CLIENT   = pMgr->client();
-    const auto RESOURCE = m_vOutputPowers.emplace_back(std::make_unique<COutputPower>(makeShared<CZwlrOutputPowerV1>(CLIENT, pMgr->version(), id), OUTPUT->monitor.get())).get();
+    const auto RESOURCE = m_vOutputPowers.emplace_back(std::make_unique<COutputPower>(makeShared<CZwlrOutputPowerV1>(CLIENT, pMgr->version(), id), OUTPUT->monitor.lock())).get();
 
     if (!RESOURCE->good()) {
         pMgr->noMemory();

--- a/src/protocols/OutputPower.hpp
+++ b/src/protocols/OutputPower.hpp
@@ -11,14 +11,14 @@ class CMonitor;
 
 class COutputPower {
   public:
-    COutputPower(SP<CZwlrOutputPowerV1> resource_, CMonitor* pMonitor);
+    COutputPower(SP<CZwlrOutputPowerV1> resource_, PHLMONITOR pMonitor);
 
     bool good();
 
   private:
     SP<CZwlrOutputPowerV1> resource;
 
-    CMonitor*              pMonitor = nullptr;
+    PHLMONITORREF          pMonitor;
 
     struct {
         CHyprSignalListener monitorDestroy;

--- a/src/protocols/PresentationTime.cpp
+++ b/src/protocols/PresentationTime.cpp
@@ -14,7 +14,7 @@ void CQueuedPresentationData::setPresentationType(bool zeroCopy_) {
     zeroCopy = zeroCopy_;
 }
 
-void CQueuedPresentationData::attachMonitor(CMonitor* pMonitor_) {
+void CQueuedPresentationData::attachMonitor(PHLMONITOR pMonitor_) {
     pMonitor = pMonitor_;
 }
 
@@ -69,7 +69,7 @@ void CPresentationFeedback::sendQueued(SP<CQueuedPresentationData> data, timespe
 
 CPresentationProtocol::CPresentationProtocol(const wl_interface* iface, const int& ver, const std::string& name) : IWaylandProtocol(iface, ver, name) {
     static auto P = g_pHookSystem->hookDynamic("monitorRemoved", [this](void* self, SCallbackInfo& info, std::any param) {
-        const auto PMONITOR = std::any_cast<CMonitor*>(param);
+        const auto PMONITOR = std::any_cast<PHLMONITOR>(param);
         std::erase_if(m_vQueue, [PMONITOR](const auto& other) { return !other->surface || other->pMonitor == PMONITOR; });
     });
 }
@@ -103,7 +103,7 @@ void CPresentationProtocol::onGetFeedback(CWpPresentation* pMgr, wl_resource* su
     }
 }
 
-void CPresentationProtocol::onPresented(CMonitor* pMonitor, timespec* when, uint32_t untilRefreshNs, uint64_t seq, uint32_t reportedFlags) {
+void CPresentationProtocol::onPresented(PHLMONITOR pMonitor, timespec* when, uint32_t untilRefreshNs, uint64_t seq, uint32_t reportedFlags) {
     for (auto& feedback : m_vFeedbacks) {
         if (!feedback->surface)
             continue;

--- a/src/protocols/PresentationTime.hpp
+++ b/src/protocols/PresentationTime.hpp
@@ -14,7 +14,7 @@ class CQueuedPresentationData {
     CQueuedPresentationData(SP<CWLSurfaceResource> surf);
 
     void setPresentationType(bool zeroCopy);
-    void attachMonitor(CMonitor* pMonitor);
+    void attachMonitor(PHLMONITOR pMonitor);
 
     void presented();
     void discarded();
@@ -22,7 +22,7 @@ class CQueuedPresentationData {
   private:
     bool                   wasPresented = false;
     bool                   zeroCopy     = false;
-    CMonitor*              pMonitor     = nullptr;
+    PHLMONITORREF          pMonitor;
     WP<CWLSurfaceResource> surface;
 
     DYNLISTENER(destroySurface);
@@ -53,7 +53,7 @@ class CPresentationProtocol : public IWaylandProtocol {
 
     virtual void bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id);
 
-    void         onPresented(CMonitor* pMonitor, timespec* when, uint32_t untilRefreshNs, uint64_t seq, uint32_t reportedFlags);
+    void         onPresented(PHLMONITOR pMonitor, timespec* when, uint32_t untilRefreshNs, uint64_t seq, uint32_t reportedFlags);
     void         queueData(SP<CQueuedPresentationData> data);
 
   private:

--- a/src/protocols/Screencopy.hpp
+++ b/src/protocols/Screencopy.hpp
@@ -58,7 +58,7 @@ struct SScreencopyFrame {
 
     WP<IWLBuffer>      buffer;
 
-    CMonitor*          pMonitor = nullptr;
+    PHLMONITORREF      pMonitor;
     PHLWINDOWREF       pWindow;
 
     bool               operator==(const SScreencopyFrame& other) const {
@@ -79,7 +79,7 @@ class CScreencopyProtocolManager {
 
     void copyFrame(wl_client* client, wl_resource* resource, wl_resource* buffer);
 
-    void onOutputCommit(CMonitor* pMonitor, wlr_output_event_commit* e);
+    void onOutputCommit(PHLMONITOR pMonitor, wlr_output_event_commit* e);
 
   private:
     wl_global*                     m_pGlobal = nullptr;
@@ -95,7 +95,7 @@ class CScreencopyProtocolManager {
 
     wlr_buffer*                    m_pLastMonitorBackBuffer = nullptr;
 
-    void                           shareAllFrames(CMonitor* pMonitor);
+    void                           shareAllFrames(PHLMONITOR pMonitor);
     void                           shareFrame(SScreencopyFrame* frame);
     void                           sendFrameDamage(SScreencopyFrame* frame);
     bool                           copyFrameDmabuf(SScreencopyFrame* frame);

--- a/src/protocols/SessionLock.cpp
+++ b/src/protocols/SessionLock.cpp
@@ -7,7 +7,7 @@
 
 #define LOGM PROTO::sessionLock->protoLog
 
-CSessionLockSurface::CSessionLockSurface(SP<CExtSessionLockSurfaceV1> resource_, SP<CWLSurfaceResource> surface_, CMonitor* pMonitor_, WP<CSessionLock> owner_) :
+CSessionLockSurface::CSessionLockSurface(SP<CExtSessionLockSurfaceV1> resource_, SP<CWLSurfaceResource> surface_, PHLMONITOR pMonitor_, WP<CSessionLock> owner_) :
     resource(resource_), sessionLock(owner_), pSurface(surface_), pMonitor(pMonitor_) {
     if (!resource->resource())
         return;
@@ -84,8 +84,8 @@ bool CSessionLockSurface::inert() {
     return sessionLock.expired();
 }
 
-CMonitor* CSessionLockSurface::monitor() {
-    return pMonitor;
+PHLMONITOR CSessionLockSurface::monitor() {
+    return pMonitor.lock();
 }
 
 SP<CWLSurfaceResource> CSessionLockSurface::surface() {
@@ -193,7 +193,7 @@ void CSessionLockProtocol::onGetLockSurface(CExtSessionLockV1* lock, uint32_t id
     LOGM(LOG, "New sessionLockSurface with id {}", id);
 
     auto             PSURFACE = CWLSurfaceResource::fromResource(surface);
-    auto             PMONITOR = CWLOutputResource::fromResource(output)->monitor.get();
+    auto             PMONITOR = CWLOutputResource::fromResource(output)->monitor.lock();
 
     SP<CSessionLock> sessionLock;
     for (auto& l : m_vLocks) {

--- a/src/protocols/SessionLock.hpp
+++ b/src/protocols/SessionLock.hpp
@@ -13,12 +13,12 @@ class CWLSurfaceResource;
 
 class CSessionLockSurface {
   public:
-    CSessionLockSurface(SP<CExtSessionLockSurfaceV1> resource_, SP<CWLSurfaceResource> surface_, CMonitor* pMonitor_, WP<CSessionLock> owner_);
+    CSessionLockSurface(SP<CExtSessionLockSurfaceV1> resource_, SP<CWLSurfaceResource> surface_, PHLMONITOR pMonitor_, WP<CSessionLock> owner_);
     ~CSessionLockSurface();
 
     bool                   good();
     bool                   inert();
-    CMonitor*              monitor();
+    PHLMONITOR             monitor();
     SP<CWLSurfaceResource> surface();
 
     struct {
@@ -31,7 +31,7 @@ class CSessionLockSurface {
     SP<CExtSessionLockSurfaceV1> resource;
     WP<CSessionLock>             sessionLock;
     WP<CWLSurfaceResource>       pSurface;
-    CMonitor*                    pMonitor = nullptr;
+    PHLMONITORREF                pMonitor;
 
     bool                         ackdConfigure = false;
     bool                         committed     = false;

--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -289,7 +289,7 @@ void CToplevelExportProtocolManager::copyFrame(wl_client* client, wl_resource* r
     m_vFramesAwaitingWrite.emplace_back(PFRAME);
 }
 
-void CToplevelExportProtocolManager::onOutputCommit(CMonitor* pMonitor, wlr_output_event_commit* e) {
+void CToplevelExportProtocolManager::onOutputCommit(PHLMONITOR pMonitor, wlr_output_event_commit* e) {
     if (m_vFramesAwaitingWrite.empty())
         return; // nothing to share
 

--- a/src/protocols/ToplevelExport.hpp
+++ b/src/protocols/ToplevelExport.hpp
@@ -21,7 +21,7 @@ class CToplevelExportProtocolManager {
     void copyFrame(wl_client* client, wl_resource* resource, wl_resource* buffer, int32_t ignore_damage);
     void displayDestroy();
     void onWindowUnmap(PHLWINDOW pWindow);
-    void onOutputCommit(CMonitor* pMonitor, wlr_output_event_commit* e);
+    void onOutputCommit(PHLMONITOR pMonitor, wlr_output_event_commit* e);
 
   private:
     wl_global*                     m_pGlobal = nullptr;

--- a/src/protocols/XDGOutput.hpp
+++ b/src/protocols/XDGOutput.hpp
@@ -9,12 +9,12 @@ class CXDGOutputProtocol;
 
 class CXDGOutput {
   public:
-    CXDGOutput(SP<CZxdgOutputV1> resource, CMonitor* monitor_);
+    CXDGOutput(SP<CZxdgOutputV1> resource, PHLMONITOR monitor_);
 
     void sendDetails();
 
   private:
-    CMonitor*               monitor = nullptr;
+    PHLMONITORREF           monitor;
     SP<CZxdgOutputV1>       resource;
 
     std::optional<Vector2D> overridePosition;

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -211,7 +211,7 @@ wl_client* CWLSurfaceResource::client() {
     return pClient;
 }
 
-void CWLSurfaceResource::enter(SP<CMonitor> monitor) {
+void CWLSurfaceResource::enter(PHLMONITOR monitor) {
     if (std::find(enteredOutputs.begin(), enteredOutputs.end(), monitor) != enteredOutputs.end())
         return;
 
@@ -233,7 +233,7 @@ void CWLSurfaceResource::enter(SP<CMonitor> monitor) {
     resource->sendEnter(output->getResource().get());
 }
 
-void CWLSurfaceResource::leave(SP<CMonitor> monitor) {
+void CWLSurfaceResource::leave(PHLMONITOR monitor) {
     if (std::find(enteredOutputs.begin(), enteredOutputs.end(), monitor) == enteredOutputs.end())
         return;
 

--- a/src/protocols/core/Compositor.hpp
+++ b/src/protocols/core/Compositor.hpp
@@ -59,8 +59,8 @@ class CWLSurfaceResource {
 
     bool                          good();
     wl_client*                    client();
-    void                          enter(SP<CMonitor> monitor);
-    void                          leave(SP<CMonitor> monitor);
+    void                          enter(PHLMONITOR monitor);
+    void                          leave(PHLMONITOR monitor);
     void                          sendPreferredTransform(wl_output_transform t);
     void                          sendPreferredScale(int32_t scale);
     void                          frame(timespec* now);
@@ -110,7 +110,7 @@ class CWLSurfaceResource {
     std::vector<SP<CWLCallbackResource>>   callbacks;
     WP<CWLSurfaceResource>                 self;
     WP<CWLSurface>                         hlSurface;
-    std::vector<WP<CMonitor>>              enteredOutputs;
+    std::vector<PHLMONITORREF>             enteredOutputs;
     bool                                   mapped = false;
     std::vector<WP<CWLSubsurfaceResource>> subsurfaces;
     WP<ISurfaceRole>                       role;

--- a/src/protocols/core/DataDevice.cpp
+++ b/src/protocols/core/DataDevice.cpp
@@ -636,7 +636,7 @@ void CWLDataDeviceProtocol::abortDrag() {
     g_pSeatManager->resendEnterEvents();
 }
 
-void CWLDataDeviceProtocol::renderDND(CMonitor* pMonitor, timespec* when) {
+void CWLDataDeviceProtocol::renderDND(PHLMONITOR pMonitor, timespec* when) {
     if (!dnd.dndSurface || !dnd.dndSurface->current.buffer || !dnd.dndSurface->current.buffer->texture)
         return;
 

--- a/src/protocols/core/DataDevice.hpp
+++ b/src/protocols/core/DataDevice.hpp
@@ -128,7 +128,7 @@ class CWLDataDeviceProtocol : public IWaylandProtocol {
     virtual void bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id);
 
     // renders and damages the dnd icon, if present
-    void renderDND(CMonitor* pMonitor, timespec* when);
+    void renderDND(PHLMONITOR pMonitor, timespec* when);
     // for inputmgr to force refocus
     // TODO: move handling to seatmgr
     bool dndActive();

--- a/src/protocols/core/Output.cpp
+++ b/src/protocols/core/Output.cpp
@@ -1,7 +1,7 @@
 #include "Output.hpp"
 #include "../../helpers/Monitor.hpp"
 
-CWLOutputResource::CWLOutputResource(SP<CWlOutput> resource_, SP<CMonitor> pMonitor) : monitor(pMonitor), resource(resource_) {
+CWLOutputResource::CWLOutputResource(SP<CWlOutput> resource_, PHLMONITOR pMonitor) : monitor(pMonitor), resource(resource_) {
     if (!good())
         return;
 
@@ -58,7 +58,7 @@ void CWLOutputResource::updateState() {
         resource->sendDone();
 }
 
-CWLOutputProtocol::CWLOutputProtocol(const wl_interface* iface, const int& ver, const std::string& name, SP<CMonitor> pMonitor) :
+CWLOutputProtocol::CWLOutputProtocol(const wl_interface* iface, const int& ver, const std::string& name, PHLMONITOR pMonitor) :
     IWaylandProtocol(iface, ver, name), monitor(pMonitor), szName(pMonitor->szName) {
 
     listeners.modeChanged = monitor->events.modeChanged.registerListener([this](std::any d) {

--- a/src/protocols/core/Output.hpp
+++ b/src/protocols/core/Output.hpp
@@ -11,7 +11,7 @@ class CMonitor;
 
 class CWLOutputResource {
   public:
-    CWLOutputResource(SP<CWlOutput> resource_, SP<CMonitor> pMonitor);
+    CWLOutputResource(SP<CWlOutput> resource_, PHLMONITOR pMonitor);
     static SP<CWLOutputResource> fromResource(wl_resource*);
 
     bool                         good();
@@ -19,7 +19,7 @@ class CWLOutputResource {
     SP<CWlOutput>                getResource();
     void                         updateState();
 
-    WP<CMonitor>                 monitor;
+    PHLMONITORREF                monitor;
 
     WP<CWLOutputResource>        self;
 
@@ -30,13 +30,13 @@ class CWLOutputResource {
 
 class CWLOutputProtocol : public IWaylandProtocol {
   public:
-    CWLOutputProtocol(const wl_interface* iface, const int& ver, const std::string& name, SP<CMonitor> pMonitor);
+    CWLOutputProtocol(const wl_interface* iface, const int& ver, const std::string& name, PHLMONITOR pMonitor);
 
     virtual void          bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id);
 
     SP<CWLOutputResource> outputResourceFrom(wl_client* client);
 
-    WP<CMonitor>          monitor;
+    PHLMONITORREF         monitor;
 
     // will mark the protocol for removal, will be removed when no. of bound outputs is 0 (or when overwritten by a new global)
     void remove();

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -72,7 +72,7 @@ CHyprOpenGLImpl::CHyprOpenGLImpl() {
 
     initDRMFormats();
 
-    static auto P = g_pHookSystem->hookDynamic("preRender", [&](void* self, SCallbackInfo& info, std::any data) { preRender(std::any_cast<CMonitor*>(data)); });
+    static auto P = g_pHookSystem->hookDynamic("preRender", [&](void* self, SCallbackInfo& info, std::any data) { preRender(std::any_cast<PHLMONITOR>(data)); });
 
     RASSERT(eglMakeCurrent(wlr_egl_get_display(g_pCompositor->m_sWLREGL), EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT), "Couldn't unset current EGL!");
 
@@ -329,7 +329,7 @@ GLuint CHyprOpenGLImpl::compileShader(const GLuint& type, std::string src, bool 
     return shader;
 }
 
-bool CHyprOpenGLImpl::passRequiresIntrospection(CMonitor* pMonitor) {
+bool CHyprOpenGLImpl::passRequiresIntrospection(PHLMONITOR pMonitor) {
     // passes requiring introspection are the ones that need to render blur.
 
     static auto PBLUR        = CConfigValue<Hyprlang::INT>("decoration:blur:enabled");
@@ -434,7 +434,7 @@ bool CHyprOpenGLImpl::passRequiresIntrospection(CMonitor* pMonitor) {
     return false;
 }
 
-void CHyprOpenGLImpl::beginSimple(CMonitor* pMonitor, const CRegion& damage, CRenderbuffer* rb, CFramebuffer* fb) {
+void CHyprOpenGLImpl::beginSimple(PHLMONITOR pMonitor, const CRegion& damage, CRenderbuffer* rb, CFramebuffer* fb) {
     m_RenderData.pMonitor = pMonitor;
 
 #ifndef GLES2
@@ -488,7 +488,7 @@ void CHyprOpenGLImpl::beginSimple(CMonitor* pMonitor, const CRegion& damage, CRe
     m_RenderData.simplePass = true;
 }
 
-void CHyprOpenGLImpl::begin(CMonitor* pMonitor, const CRegion& damage_, CFramebuffer* fb, std::optional<CRegion> finalDamage) {
+void CHyprOpenGLImpl::begin(PHLMONITOR pMonitor, const CRegion& damage_, CFramebuffer* fb, std::optional<CRegion> finalDamage) {
     m_RenderData.pMonitor = pMonitor;
 
     static auto PFORCEINTROSPECTION = CConfigValue<Hyprlang::INT>("opengl:force_introspection");
@@ -634,7 +634,7 @@ void CHyprOpenGLImpl::end() {
     }
 
     // reset our data
-    m_RenderData.pMonitor           = nullptr;
+    m_RenderData.pMonitor.reset();
     m_RenderData.mouseZoomFactor    = 1.f;
     m_RenderData.mouseZoomUseMouse  = true;
     m_RenderData.forceIntrospection = false;
@@ -1565,11 +1565,11 @@ CFramebuffer* CHyprOpenGLImpl::blurMainFramebufferWithDamage(float a, CRegion* o
     return currentRenderToFB;
 }
 
-void CHyprOpenGLImpl::markBlurDirtyForMonitor(CMonitor* pMonitor) {
+void CHyprOpenGLImpl::markBlurDirtyForMonitor(PHLMONITOR pMonitor) {
     m_mMonitorRenderResources[pMonitor].blurFBDirty = true;
 }
 
-void CHyprOpenGLImpl::preRender(CMonitor* pMonitor) {
+void CHyprOpenGLImpl::preRender(PHLMONITOR pMonitor) {
     static auto PBLURNEWOPTIMIZE = CConfigValue<Hyprlang::INT>("decoration:blur:new_optimizations");
     static auto PBLURXRAY        = CConfigValue<Hyprlang::INT>("decoration:blur:xray");
     static auto PBLUR            = CConfigValue<Hyprlang::INT>("decoration:blur:enabled");
@@ -2306,7 +2306,7 @@ void CHyprOpenGLImpl::renderSplash(cairo_t* const CAIRO, cairo_surface_t* const 
     cairo_surface_flush(CAIROSURFACE);
 }
 
-void CHyprOpenGLImpl::createBGTextureForMonitor(CMonitor* pMonitor) {
+void CHyprOpenGLImpl::createBGTextureForMonitor(PHLMONITOR pMonitor) {
     RASSERT(m_RenderData.pMonitor, "Tried to createBGTex without begin()!");
 
     static auto        PRENDERTEX      = CConfigValue<Hyprlang::INT>("misc:disable_hyprland_logo");
@@ -2445,7 +2445,7 @@ void CHyprOpenGLImpl::clearWithTex() {
     auto TEXIT = m_mMonitorBGFBs.find(m_RenderData.pMonitor);
 
     if (TEXIT == m_mMonitorBGFBs.end()) {
-        createBGTextureForMonitor(m_RenderData.pMonitor);
+        createBGTextureForMonitor(m_RenderData.pMonitor.lock());
         TEXIT = m_mMonitorBGFBs.find(m_RenderData.pMonitor);
     }
 
@@ -2457,7 +2457,7 @@ void CHyprOpenGLImpl::clearWithTex() {
     }
 }
 
-void CHyprOpenGLImpl::destroyMonitorResources(CMonitor* pMonitor) {
+void CHyprOpenGLImpl::destroyMonitorResources(PHLMONITOR pMonitor) {
     g_pHyprRenderer->makeEGLCurrent();
 
     auto RESIT = g_pHyprOpenGL->m_mMonitorRenderResources.find(pMonitor);
@@ -2518,7 +2518,7 @@ void CHyprOpenGLImpl::setRenderModifEnabled(bool enabled) {
     m_RenderData.renderModif.enabled = enabled;
 }
 
-uint32_t CHyprOpenGLImpl::getPreferredReadFormat(CMonitor* pMonitor) {
+uint32_t CHyprOpenGLImpl::getPreferredReadFormat(PHLMONITOR pMonitor) {
     GLint glf = -1, glt = -1, as = 0;
     /*glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_FORMAT, &glf);
     glGetIntegerv(GL_IMPLEMENTATION_COLOR_READ_TYPE, &glt);

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -88,7 +88,7 @@ struct SMonitorRenderData {
 };
 
 struct SCurrentRenderData {
-    CMonitor*            pMonitor   = nullptr;
+    PHLMONITORREF        pMonitor;
     PHLWORKSPACE         pWorkspace = nullptr;
     float                projection[9];
     float                savedProjection[9];
@@ -125,8 +125,8 @@ class CHyprOpenGLImpl {
   public:
     CHyprOpenGLImpl();
 
-    void     begin(CMonitor*, const CRegion& damage, CFramebuffer* fb = nullptr, std::optional<CRegion> finalDamage = {});
-    void     beginSimple(CMonitor*, const CRegion& damage, CRenderbuffer* rb = nullptr, CFramebuffer* fb = nullptr);
+    void     begin(PHLMONITOR, const CRegion& damage, CFramebuffer* fb = nullptr, std::optional<CRegion> finalDamage = {});
+    void     beginSimple(PHLMONITOR, const CRegion& damage, CRenderbuffer* rb = nullptr, CFramebuffer* fb = nullptr);
     void     end();
 
     void     renderRect(CBox*, const CColor&, int round = 0);
@@ -161,13 +161,13 @@ class CHyprOpenGLImpl {
     void     scissor(const pixman_box32*, bool transform = true);
     void     scissor(const int x, const int y, const int w, const int h, bool transform = true);
 
-    void     destroyMonitorResources(CMonitor*);
+    void     destroyMonitorResources(PHLMONITOR);
 
-    void     markBlurDirtyForMonitor(CMonitor*);
+    void     markBlurDirtyForMonitor(PHLMONITOR);
 
     void     preWindowPass();
     bool     preBlurQueued();
-    void     preRender(CMonitor*);
+    void     preRender(PHLMONITOR);
 
     void     saveBufferForMirror(CBox*);
     void     renderMirrored();
@@ -180,23 +180,23 @@ class CHyprOpenGLImpl {
 
     void     setDamage(const CRegion& damage, std::optional<CRegion> finalDamage = {});
 
-    uint32_t getPreferredReadFormat(CMonitor* pMonitor);
-    std::vector<SDRMFormat>                           getDRMFormats();
-    EGLImageKHR                                       createEGLImage(const SDMABUFAttrs& attrs);
+    uint32_t getPreferredReadFormat(PHLMONITOR pMonitor);
+    std::vector<SDRMFormat>                     getDRMFormats();
+    EGLImageKHR                                 createEGLImage(const SDMABUFAttrs& attrs);
 
-    SCurrentRenderData                                m_RenderData;
+    SCurrentRenderData                          m_RenderData;
 
-    GLint                                             m_iCurrentOutputFb = 0;
+    GLint                                       m_iCurrentOutputFb = 0;
 
-    bool                                              m_bReloadScreenShader = true; // at launch it can be set
+    bool                                        m_bReloadScreenShader = true; // at launch it can be set
 
-    PHLWINDOWREF                                      m_pCurrentWindow; // hack to get the current rendered window
-    PHLLS                                             m_pCurrentLayer;  // hack to get the current rendered layer
+    PHLWINDOWREF                                m_pCurrentWindow; // hack to get the current rendered window
+    PHLLS                                       m_pCurrentLayer;  // hack to get the current rendered layer
 
-    std::map<PHLWINDOWREF, CFramebuffer>              m_mWindowFramebuffers;
-    std::map<PHLLSREF, CFramebuffer>                  m_mLayerFramebuffers;
-    std::unordered_map<CMonitor*, SMonitorRenderData> m_mMonitorRenderResources;
-    std::unordered_map<CMonitor*, CFramebuffer>       m_mMonitorBGFBs;
+    std::map<PHLWINDOWREF, CFramebuffer>        m_mWindowFramebuffers;
+    std::map<PHLLSREF, CFramebuffer>            m_mLayerFramebuffers;
+    std::map<PHLMONITORREF, SMonitorRenderData> m_mMonitorRenderResources;
+    std::map<PHLMONITORREF, CFramebuffer>       m_mMonitorBGFBs;
 
     struct {
         PFNGLEGLIMAGETARGETRENDERBUFFERSTORAGEOESPROC glEGLImageTargetRenderbufferStorageOES = nullptr;
@@ -235,7 +235,7 @@ class CHyprOpenGLImpl {
     void                    logShaderError(const GLuint&, bool program = false);
     GLuint                  createProgram(const std::string&, const std::string&, bool dynamic = false);
     GLuint                  compileShader(const GLuint&, std::string, bool dynamic = false);
-    void                    createBGTextureForMonitor(CMonitor*);
+    void                    createBGTextureForMonitor(PHLMONITOR);
     void                    initShaders();
     void                    initDRMFormats();
     std::vector<uint64_t>   getModsForFormat(EGLint format);
@@ -250,7 +250,7 @@ class CHyprOpenGLImpl {
 
     void          preBlurForCurrentMonitor();
 
-    bool          passRequiresIntrospection(CMonitor* pMonitor);
+    bool          passRequiresIntrospection(PHLMONITOR pMonitor);
 
     friend class CHyprRenderer;
 };

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -232,7 +232,7 @@ static void renderSurface(SP<CWLSurfaceResource> surface, int x, int y, void* da
     g_pHyprOpenGL->m_RenderData.useNearestNeighbor          = NEARESTNEIGHBORSET;
 }
 
-bool CHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, CMonitor* pMonitor) {
+bool CHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
     if (!pWindow->visibleOnMonitor(pMonitor))
         return false;
 
@@ -321,7 +321,7 @@ bool CHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow) {
     return false;
 }
 
-void CHyprRenderer::renderWorkspaceWindowsFullscreen(CMonitor* pMonitor, PHLWORKSPACE pWorkspace, timespec* time) {
+void CHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, timespec* time) {
     PHLWINDOW pWorkspaceWindow = nullptr;
 
     EMIT_HOOK_EVENT("render", RENDER_PRE_WINDOWS);
@@ -411,7 +411,7 @@ void CHyprRenderer::renderWorkspaceWindowsFullscreen(CMonitor* pMonitor, PHLWORK
     }
 }
 
-void CHyprRenderer::renderWorkspaceWindows(CMonitor* pMonitor, PHLWORKSPACE pWorkspace, timespec* time) {
+void CHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, timespec* time) {
     PHLWINDOW lastWindow;
 
     EMIT_HOOK_EVENT("render", RENDER_PRE_WINDOWS);
@@ -483,7 +483,7 @@ void CHyprRenderer::renderWorkspaceWindows(CMonitor* pMonitor, PHLWORKSPACE pWor
     }
 }
 
-void CHyprRenderer::renderWindow(PHLWINDOW pWindow, CMonitor* pMonitor, timespec* time, bool decorate, eRenderPassMode mode, bool ignorePosition, bool ignoreAllGeometry) {
+void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, timespec* time, bool decorate, eRenderPassMode mode, bool ignorePosition, bool ignoreAllGeometry) {
     if (pWindow->isHidden())
         return;
 
@@ -691,7 +691,7 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, CMonitor* pMonitor, timespec
     g_pHyprOpenGL->m_RenderData.clipBox = CBox();
 }
 
-void CHyprRenderer::renderLayer(PHLLS pLayer, CMonitor* pMonitor, timespec* time, bool popups) {
+void CHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, timespec* time, bool popups) {
     static auto PDIMAROUND = CConfigValue<Hyprlang::FLOAT>("decoration:dim_around");
 
     if (*PDIMAROUND && pLayer->dimAround && !m_bRenderingSnapshot && !popups) {
@@ -756,7 +756,7 @@ void CHyprRenderer::renderLayer(PHLLS pLayer, CMonitor* pMonitor, timespec* time
     g_pHyprOpenGL->m_RenderData.discardOpacity = DA;
 }
 
-void CHyprRenderer::renderIMEPopup(CInputPopup* pPopup, CMonitor* pMonitor, timespec* time) {
+void CHyprRenderer::renderIMEPopup(CInputPopup* pPopup, PHLMONITOR pMonitor, timespec* time) {
     const auto  POS = pPopup->globalBox().pos();
 
     SRenderData renderdata = {pMonitor, time, POS.x, POS.y};
@@ -772,7 +772,7 @@ void CHyprRenderer::renderIMEPopup(CInputPopup* pPopup, CMonitor* pMonitor, time
     SURF->breadthfirst([](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) { renderSurface(s, offset.x, offset.y, data); }, &renderdata);
 }
 
-void CHyprRenderer::renderSessionLockSurface(SSessionLockSurface* pSurface, CMonitor* pMonitor, timespec* time) {
+void CHyprRenderer::renderSessionLockSurface(SSessionLockSurface* pSurface, PHLMONITOR pMonitor, timespec* time) {
     SRenderData renderdata = {pMonitor, time, pMonitor->vecPosition.x, pMonitor->vecPosition.y};
 
     renderdata.blur     = false;
@@ -784,7 +784,7 @@ void CHyprRenderer::renderSessionLockSurface(SSessionLockSurface* pSurface, CMon
     renderdata.surface->breadthfirst([](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) { renderSurface(s, offset.x, offset.y, data); }, &renderdata);
 }
 
-void CHyprRenderer::renderAllClientsForWorkspace(CMonitor* pMonitor, PHLWORKSPACE pWorkspace, timespec* time, const Vector2D& translate, const float& scale) {
+void CHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, timespec* time, const Vector2D& translate, const float& scale) {
     static auto      PDIMSPECIAL      = CConfigValue<Hyprlang::FLOAT>("decoration:dim_special");
     static auto      PBLURSPECIAL     = CConfigValue<Hyprlang::INT>("decoration:blur:special");
     static auto      PBLUR            = CConfigValue<Hyprlang::INT>("decoration:blur:enabled");
@@ -958,7 +958,7 @@ void CHyprRenderer::renderAllClientsForWorkspace(CMonitor* pMonitor, PHLWORKSPAC
     g_pHyprOpenGL->m_RenderData.renderModif = {};
 }
 
-void CHyprRenderer::renderLockscreen(CMonitor* pMonitor, timespec* now, const CBox& geometry) {
+void CHyprRenderer::renderLockscreen(PHLMONITOR pMonitor, timespec* now, const CBox& geometry) {
     TRACY_GPU_ZONE("RenderLockscreen");
 
     if (g_pSessionLockManager->isSessionLocked()) {
@@ -1061,7 +1061,7 @@ void CHyprRenderer::calculateUVForSurface(PHLWINDOW pWindow, SP<CWLSurfaceResour
     }
 }
 
-bool CHyprRenderer::attemptDirectScanout(CMonitor* pMonitor) {
+bool CHyprRenderer::attemptDirectScanout(PHLMONITOR pMonitor) {
     return false; // FIXME: fix when we move to new lib for backend.
 
     // if (!pMonitor->mirrors.empty() || pMonitor->isMirror() || m_bDirectScanoutBlocked)
@@ -1108,7 +1108,7 @@ bool CHyprRenderer::attemptDirectScanout(CMonitor* pMonitor) {
     // return true;
 }
 
-void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
+void CHyprRenderer::renderMonitor(PHLMONITOR pMonitor) {
     static std::chrono::high_resolution_clock::time_point renderStart        = std::chrono::high_resolution_clock::now();
     static std::chrono::high_resolution_clock::time_point renderStartOverlay = std::chrono::high_resolution_clock::now();
     static std::chrono::high_resolution_clock::time_point endRenderOverlay   = std::chrono::high_resolution_clock::now();
@@ -1334,13 +1334,13 @@ void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
 
                 renderLockscreen(pMonitor, &now, renderBox);
 
-                if (pMonitor == g_pCompositor->m_pLastMonitor.get()) {
+                if (pMonitor == g_pCompositor->m_pLastMonitor.lock()) {
                     g_pHyprNotificationOverlay->draw(pMonitor);
                     g_pHyprError->draw();
                 }
 
                 // for drawing the debug overlay
-                if (pMonitor == g_pCompositor->m_vMonitors.front().get() && *PDEBUGOVERLAY == 1) {
+                if (pMonitor == g_pCompositor->m_vMonitors.front() && *PDEBUGOVERLAY == 1) {
                     renderStartOverlay = std::chrono::high_resolution_clock::now();
                     g_pDebugOverlay->draw();
                     endRenderOverlay = std::chrono::high_resolution_clock::now();
@@ -1415,7 +1415,7 @@ void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
     g_pDebugOverlay->renderData(pMonitor, µs);
 
     if (*PDEBUGOVERLAY == 1) {
-        if (pMonitor == g_pCompositor->m_vMonitors.front().get()) {
+        if (pMonitor == g_pCompositor->m_vMonitors.front()) {
             const float µsNoOverlay = µs - std::chrono::duration_cast<std::chrono::nanoseconds>(endRenderOverlay - renderStartOverlay).count() / 1000.f;
             g_pDebugOverlay->renderDataNoOverlay(pMonitor, µsNoOverlay);
         } else {
@@ -1424,7 +1424,7 @@ void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
     }
 }
 
-void CHyprRenderer::renderWorkspace(CMonitor* pMonitor, PHLWORKSPACE pWorkspace, timespec* now, const CBox& geometry) {
+void CHyprRenderer::renderWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, timespec* now, const CBox& geometry) {
     Vector2D translate = {geometry.x, geometry.y};
     float    scale     = (float)geometry.width / pMonitor->vecPixelSize.x;
 
@@ -1441,7 +1441,7 @@ void CHyprRenderer::renderWorkspace(CMonitor* pMonitor, PHLWORKSPACE pWorkspace,
     g_pHyprOpenGL->m_RenderData.pWorkspace = nullptr;
 }
 
-void CHyprRenderer::sendFrameEventsToWorkspace(CMonitor* pMonitor, PHLWORKSPACE pWorkspace, timespec* now) {
+void CHyprRenderer::sendFrameEventsToWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, timespec* now) {
     for (auto& w : g_pCompositor->m_vWindows) {
         if (w->isHidden() || !w->m_bIsMapped || w->m_bFadingOut || !w->m_pWLSurface->resource())
             continue;
@@ -1550,7 +1550,7 @@ static void applyExclusive(wlr_box& usableArea, uint32_t anchor, int32_t exclusi
     }
 }
 
-void CHyprRenderer::arrangeLayerArray(CMonitor* pMonitor, const std::vector<PHLLSREF>& layerSurfaces, bool exclusiveZone, CBox* usableArea) {
+void CHyprRenderer::arrangeLayerArray(PHLMONITOR pMonitor, const std::vector<PHLLSREF>& layerSurfaces, bool exclusiveZone, CBox* usableArea) {
     CBox full_area = {pMonitor->vecPosition.x, pMonitor->vecPosition.y, pMonitor->vecSize.x, pMonitor->vecSize.y};
 
     for (auto& ls : layerSurfaces) {
@@ -1729,7 +1729,7 @@ void CHyprRenderer::damageWindow(PHLWINDOW pWindow, bool forceFull) {
     windowBox.translate(pWindow->m_vFloatingOffset);
 
     for (auto& m : g_pCompositor->m_vMonitors) {
-        if (forceFull || g_pHyprRenderer->shouldRenderWindow(pWindow, m.get())) { // only damage if window is rendered on monitor
+        if (forceFull || g_pHyprRenderer->shouldRenderWindow(pWindow, m)) { // only damage if window is rendered on monitor
             CBox fixedDamageBox = {windowBox.x - m->vecPosition.x, windowBox.y - m->vecPosition.y, windowBox.width, windowBox.height};
             fixedDamageBox.scale(m->scale);
             m->addDamage(&fixedDamageBox);
@@ -1745,7 +1745,7 @@ void CHyprRenderer::damageWindow(PHLWINDOW pWindow, bool forceFull) {
         Debug::log(LOG, "Damage: Window ({}): xy: {}, {} wh: {}, {}", pWindow->m_szTitle, windowBox.x, windowBox.y, windowBox.width, windowBox.height);
 }
 
-void CHyprRenderer::damageMonitor(CMonitor* pMonitor) {
+void CHyprRenderer::damageMonitor(PHLMONITOR pMonitor) {
     if (g_pCompositor->m_bUnsafeState || pMonitor->isMirror())
         return;
 
@@ -1788,7 +1788,7 @@ void CHyprRenderer::damageRegion(const CRegion& rg) {
     }
 }
 
-void CHyprRenderer::damageMirrorsWith(CMonitor* pMonitor, const CRegion& pRegion) {
+void CHyprRenderer::damageMirrorsWith(PHLMONITOR pMonitor, const CRegion& pRegion) {
     for (auto& mirror : pMonitor->mirrors) {
 
         // transform the damage here, so it won't get clipped by the monitor damage ring
@@ -1809,11 +1809,11 @@ void CHyprRenderer::damageMirrorsWith(CMonitor* pMonitor, const CRegion& pRegion
 
         mirror->addDamage(&transformed);
 
-        g_pCompositor->scheduleFrameForMonitor(mirror);
+        g_pCompositor->scheduleFrameForMonitor(mirror.lock());
     }
 }
 
-void CHyprRenderer::renderDragIcon(CMonitor* pMonitor, timespec* time) {
+void CHyprRenderer::renderDragIcon(PHLMONITOR pMonitor, timespec* time) {
     PROTO::data->renderDND(pMonitor, time);
 }
 
@@ -1828,7 +1828,7 @@ DAMAGETRACKINGMODES CHyprRenderer::damageTrackingModeFromStr(const std::string& 
     return DAMAGE_TRACKING_INVALID;
 }
 
-bool CHyprRenderer::applyMonitorRule(CMonitor* pMonitor, SMonitorRule* pMonitorRule, bool force) {
+bool CHyprRenderer::applyMonitorRule(PHLMONITOR pMonitor, SMonitorRule* pMonitorRule, bool force) {
 
     static auto PDISABLESCALECHECKS = CConfigValue<Hyprlang::INT>("debug:disable_scale_checks");
 
@@ -2315,7 +2315,7 @@ void CHyprRenderer::ensureCursorRenderingMode() {
             if (m->output->software_cursor_locks == 0)
                 continue;
 
-            g_pHyprRenderer->damageMonitor(m.get()); // TODO: maybe just damage the cursor area?
+            g_pHyprRenderer->damageMonitor(m); // TODO: maybe just damage the cursor area?
         }
 
         setCursorHidden(true);
@@ -2327,7 +2327,7 @@ void CHyprRenderer::ensureCursorRenderingMode() {
             if (m->output->software_cursor_locks == 0)
                 continue;
 
-            g_pHyprRenderer->damageMonitor(m.get()); // TODO: maybe just damage the cursor area?
+            g_pHyprRenderer->damageMonitor(m); // TODO: maybe just damage the cursor area?
         }
 
         setCursorHidden(false);
@@ -2358,7 +2358,7 @@ bool CHyprRenderer::shouldRenderCursor() {
     return !m_bCursorHidden && m_bCursorHasSurface;
 }
 
-std::tuple<float, float, float> CHyprRenderer::getRenderTimes(CMonitor* pMonitor) {
+std::tuple<float, float, float> CHyprRenderer::getRenderTimes(PHLMONITOR pMonitor) {
     const auto POVERLAY = &g_pDebugOverlay->m_mMonitorOverlays[pMonitor];
 
     float      avgRenderTime = 0;
@@ -2463,7 +2463,7 @@ void CHyprRenderer::setOccludedForBackLayers(CRegion& region, PHLWORKSPACE pWork
     region.subtract(rg);
 }
 
-bool CHyprRenderer::canSkipBackBufferClear(CMonitor* pMonitor) {
+bool CHyprRenderer::canSkipBackBufferClear(PHLMONITOR pMonitor) {
     for (auto& ls : pMonitor->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]) {
         if (!ls->layerSurface)
             continue;
@@ -2489,7 +2489,7 @@ bool CHyprRenderer::canSkipBackBufferClear(CMonitor* pMonitor) {
     return false;
 }
 
-void CHyprRenderer::recheckSolitaryForMonitor(CMonitor* pMonitor) {
+void CHyprRenderer::recheckSolitaryForMonitor(PHLMONITOR pMonitor) {
     pMonitor->solitaryClient.reset(); // reset it, if we find one it will be set.
 
     if (g_pHyprNotificationOverlay->hasAny() || g_pSessionLockManager->isSessionLocked())
@@ -2577,7 +2577,7 @@ void CHyprRenderer::unsetEGL() {
     eglMakeCurrent(wlr_egl_get_display(g_pCompositor->m_sWLREGL), EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
 }
 
-bool CHyprRenderer::beginRender(CMonitor* pMonitor, CRegion& damage, eRenderMode mode, SP<IWLBuffer> buffer, CFramebuffer* fb, bool simple) {
+bool CHyprRenderer::beginRender(PHLMONITOR pMonitor, CRegion& damage, eRenderMode mode, SP<IWLBuffer> buffer, CFramebuffer* fb, bool simple) {
 
     makeEGLCurrent();
 
@@ -2639,7 +2639,7 @@ void CHyprRenderer::endRender() {
     if (m_eRenderMode != RENDER_MODE_TO_BUFFER_READ_ONLY)
         g_pHyprOpenGL->end();
     else {
-        g_pHyprOpenGL->m_RenderData.pMonitor          = nullptr;
+        g_pHyprOpenGL->m_RenderData.pMonitor.reset();
         g_pHyprOpenGL->m_RenderData.mouseZoomFactor   = 1.f;
         g_pHyprOpenGL->m_RenderData.mouseZoomUseMouse = true;
     }

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -43,28 +43,28 @@ class CHyprRenderer {
   public:
     CHyprRenderer();
 
-    void                            renderMonitor(CMonitor* pMonitor);
+    void                            renderMonitor(PHLMONITOR pMonitor);
     void                            arrangeLayersForMonitor(const int&);
     void                            damageSurface(SP<CWLSurfaceResource>, double, double, double scale = 1.0);
     void                            damageWindow(PHLWINDOW, bool forceFull = false);
     void                            damageBox(CBox*);
     void                            damageBox(const int& x, const int& y, const int& w, const int& h);
     void                            damageRegion(const CRegion&);
-    void                            damageMonitor(CMonitor*);
-    void                            damageMirrorsWith(CMonitor*, const CRegion&);
-    bool                            applyMonitorRule(CMonitor*, SMonitorRule*, bool force = false);
-    bool                            shouldRenderWindow(PHLWINDOW, CMonitor*);
+    void                            damageMonitor(PHLMONITOR);
+    void                            damageMirrorsWith(PHLMONITOR, const CRegion&);
+    bool                            applyMonitorRule(PHLMONITOR, SMonitorRule*, bool force = false);
+    bool                            shouldRenderWindow(PHLWINDOW, PHLMONITOR);
     bool                            shouldRenderWindow(PHLWINDOW);
     void                            ensureCursorRenderingMode();
     bool                            shouldRenderCursor();
     void                            setCursorHidden(bool hide);
     void                            calculateUVForSurface(PHLWINDOW, SP<CWLSurfaceResource>, bool main = false, const Vector2D& projSize = {}, bool fixMisalignedFSV1 = false);
-    std::tuple<float, float, float> getRenderTimes(CMonitor* pMonitor); // avg max min
-    void                            renderLockscreen(CMonitor* pMonitor, timespec* now, const CBox& geometry);
+    std::tuple<float, float, float> getRenderTimes(PHLMONITOR pMonitor); // avg max min
+    void                            renderLockscreen(PHLMONITOR pMonitor, timespec* now, const CBox& geometry);
     void                            setOccludedForBackLayers(CRegion& region, PHLWORKSPACE pWorkspace);
     void                            setOccludedForMainWorkspace(CRegion& region, PHLWORKSPACE pWorkspace); // TODO: merge occlusion methods
-    bool                            canSkipBackBufferClear(CMonitor* pMonitor);
-    void                            recheckSolitaryForMonitor(CMonitor* pMonitor);
+    bool                            canSkipBackBufferClear(PHLMONITOR pMonitor);
+    void                            recheckSolitaryForMonitor(PHLMONITOR pMonitor);
     void                            setCursorSurface(SP<CWLSurface> surf, int hotspotX, int hotspotY, bool force = false);
     void                            setCursorFromName(const std::string& name, bool force = false);
     void                            onRenderbufferDestroy(CRenderbuffer* rb);
@@ -75,19 +75,19 @@ class CHyprRenderer {
 
     // if RENDER_MODE_NORMAL, provided damage will be written to.
     // otherwise, it will be the one used.
-    bool beginRender(CMonitor* pMonitor, CRegion& damage, eRenderMode mode = RENDER_MODE_NORMAL, SP<IWLBuffer> buffer = {}, CFramebuffer* fb = nullptr, bool simple = false);
+    bool beginRender(PHLMONITOR pMonitor, CRegion& damage, eRenderMode mode = RENDER_MODE_NORMAL, SP<IWLBuffer> buffer = {}, CFramebuffer* fb = nullptr, bool simple = false);
     void endRender();
 
     bool m_bBlockSurfaceFeedback = false;
     bool m_bRenderingSnapshot    = false;
-    PHLWINDOWREF m_pLastScanout;
-    CMonitor*    m_pMostHzMonitor        = nullptr;
-    bool         m_bDirectScanoutBlocked = false;
+    PHLWINDOWREF  m_pLastScanout;
+    PHLMONITORREF m_pMostHzMonitor;
+    bool          m_bDirectScanoutBlocked = false;
 
     DAMAGETRACKINGMODES
     damageTrackingModeFromStr(const std::string&);
 
-    bool             attemptDirectScanout(CMonitor*);
+    bool             attemptDirectScanout(PHLMONITOR);
     void             setWindowScanoutMode(PHLWINDOW);
     void             initiateManualCrash();
 
@@ -106,17 +106,17 @@ class CHyprRenderer {
     } m_sLastCursorData;
 
   private:
-    void           arrangeLayerArray(CMonitor*, const std::vector<PHLLSREF>&, bool, CBox*);
-    void           renderWorkspaceWindowsFullscreen(CMonitor*, PHLWORKSPACE, timespec*); // renders workspace windows (fullscreen) (tiled, floating, pinned, but no special)
-    void           renderWorkspaceWindows(CMonitor*, PHLWORKSPACE, timespec*);           // renders workspace windows (no fullscreen) (tiled, floating, pinned, but no special)
-    void           renderWindow(PHLWINDOW, CMonitor*, timespec*, bool, eRenderPassMode, bool ignorePosition = false, bool ignoreAllGeometry = false);
-    void           renderLayer(PHLLS, CMonitor*, timespec*, bool popups = false);
-    void           renderSessionLockSurface(SSessionLockSurface*, CMonitor*, timespec*);
-    void           renderDragIcon(CMonitor*, timespec*);
-    void           renderIMEPopup(CInputPopup*, CMonitor*, timespec*);
-    void           renderWorkspace(CMonitor* pMonitor, PHLWORKSPACE pWorkspace, timespec* now, const CBox& geometry);
-    void           sendFrameEventsToWorkspace(CMonitor* pMonitor, PHLWORKSPACE pWorkspace, timespec* now); // sends frame displayed events but doesn't actually render anything
-    void           renderAllClientsForWorkspace(CMonitor* pMonitor, PHLWORKSPACE pWorkspace, timespec* now, const Vector2D& translate = {0, 0}, const float& scale = 1.f);
+    void           arrangeLayerArray(PHLMONITOR, const std::vector<PHLLSREF>&, bool, CBox*);
+    void           renderWorkspaceWindowsFullscreen(PHLMONITOR, PHLWORKSPACE, timespec*); // renders workspace windows (fullscreen) (tiled, floating, pinned, but no special)
+    void           renderWorkspaceWindows(PHLMONITOR, PHLWORKSPACE, timespec*);           // renders workspace windows (no fullscreen) (tiled, floating, pinned, but no special)
+    void           renderWindow(PHLWINDOW, PHLMONITOR, timespec*, bool, eRenderPassMode, bool ignorePosition = false, bool ignoreAllGeometry = false);
+    void           renderLayer(PHLLS, PHLMONITOR, timespec*, bool popups = false);
+    void           renderSessionLockSurface(SSessionLockSurface*, PHLMONITOR, timespec*);
+    void           renderDragIcon(PHLMONITOR, timespec*);
+    void           renderIMEPopup(CInputPopup*, PHLMONITOR, timespec*);
+    void           renderWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, timespec* now, const CBox& geometry);
+    void           sendFrameEventsToWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, timespec* now); // sends frame displayed events but doesn't actually render anything
+    void           renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, timespec* now, const Vector2D& translate = {0, 0}, const float& scale = 1.f);
 
     bool           m_bCursorHidden        = false;
     bool           m_bCursorHasSurface    = false;

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -45,7 +45,7 @@ CBox CHyprBorderDecoration::assignedBoxGlobal() {
     return box.translate(WORKSPACEOFFSET);
 }
 
-void CHyprBorderDecoration::draw(CMonitor* pMonitor, float a) {
+void CHyprBorderDecoration::draw(PHLMONITOR pMonitor, float a) {
     if (doesntWantBorders())
         return;
 
@@ -109,7 +109,7 @@ void CHyprBorderDecoration::damageEntire() {
     borderRegion.subtract(surfaceBoxShrunkRounding);
 
     for (auto& m : g_pCompositor->m_vMonitors) {
-        if (!g_pHyprRenderer->shouldRenderWindow(m_pWindow.lock(), m.get())) {
+        if (!g_pHyprRenderer->shouldRenderWindow(m_pWindow.lock(), m)) {
             const CRegion monitorRegion({m->vecPosition, m->vecSize});
             borderRegion.subtract(monitorRegion);
         }

--- a/src/render/decorations/CHyprBorderDecoration.hpp
+++ b/src/render/decorations/CHyprBorderDecoration.hpp
@@ -11,7 +11,7 @@ class CHyprBorderDecoration : public IHyprWindowDecoration {
 
     virtual void                       onPositioningReply(const SDecorationPositioningReply& reply);
 
-    virtual void                       draw(CMonitor*, float a);
+    virtual void                       draw(PHLMONITOR, float a);
 
     virtual eDecorationType            getDecorationType();
 

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -67,7 +67,7 @@ void CHyprDropShadowDecoration::damageEntire() {
     }
 
     for (auto& m : g_pCompositor->m_vMonitors) {
-        if (!g_pHyprRenderer->shouldRenderWindow(PWINDOW, m.get())) {
+        if (!g_pHyprRenderer->shouldRenderWindow(PWINDOW, m)) {
             const CRegion monitorRegion({m->vecPosition, m->vecSize});
             shadowRegion.subtract(monitorRegion);
         }
@@ -86,7 +86,7 @@ void CHyprDropShadowDecoration::updateWindow(PHLWINDOW pWindow) {
     m_bLastWindowBoxWithDecos = g_pDecorationPositioner->getBoxWithIncludedDecos(pWindow);
 }
 
-void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a) {
+void CHyprDropShadowDecoration::draw(PHLMONITOR pMonitor, float a) {
 
     const auto PWINDOW = m_pWindow.lock();
 

--- a/src/render/decorations/CHyprDropShadowDecoration.hpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.hpp
@@ -11,7 +11,7 @@ class CHyprDropShadowDecoration : public IHyprWindowDecoration {
 
     virtual void                       onPositioningReply(const SDecorationPositioningReply& reply);
 
-    virtual void                       draw(CMonitor*, float a);
+    virtual void                       draw(PHLMONITOR, float a);
 
     virtual eDecorationType            getDecorationType();
 

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -94,7 +94,7 @@ void CHyprGroupBarDecoration::damageEntire() {
     g_pHyprRenderer->damageBox(&box);
 }
 
-void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a) {
+void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float a) {
     // get how many bars we will draw
     int         barsToDraw = m_dwGroupMembers.size();
 

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -31,7 +31,7 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
 
     virtual void                       onPositioningReply(const SDecorationPositioningReply& reply);
 
-    virtual void                       draw(CMonitor*, float a);
+    virtual void                       draw(PHLMONITOR, float a);
 
     virtual eDecorationType            getDecorationType();
 

--- a/src/render/decorations/IHyprWindowDecoration.hpp
+++ b/src/render/decorations/IHyprWindowDecoration.hpp
@@ -39,7 +39,7 @@ class IHyprWindowDecoration {
 
     virtual void                       onPositioningReply(const SDecorationPositioningReply& reply) = 0;
 
-    virtual void                       draw(CMonitor*, float a) = 0;
+    virtual void                       draw(PHLMONITOR, float a) = 0;
 
     virtual eDecorationType            getDecorationType() = 0;
 


### PR DESCRIPTION
Moves CMonitor* to shared pointers, the same as we did with windows, workspaces, layers.

Needs testing.