### PR TITLE
input: add cursor:warp_on_changeworkspace

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -526,6 +526,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("cursor:inactive_timeout", Hyprlang::INT{0});
     m_pConfig->addConfigValue("cursor:no_warps", Hyprlang::INT{0});
     m_pConfig->addConfigValue("cursor:persistent_warps", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("cursor:warp_on_change_workspace", Hyprlang::INT{0});
     m_pConfig->addConfigValue("cursor:default_monitor", {STRVAL_EMPTY});
     m_pConfig->addConfigValue("cursor:zoom_factor", {1.f});
     m_pConfig->addConfigValue("cursor:zoom_rigid", Hyprlang::INT{0});

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1,6 +1,7 @@
 #include "../config/ConfigValue.hpp"
 #include "../devices/IKeyboard.hpp"
 #include "../managers/SeatManager.hpp"
+#include "../protocols/LayerShell.hpp"
 #include "../protocols/ShortcutsInhibit.hpp"
 #include "../render/decorations/CHyprGroupBarDecoration.hpp"
 #include "KeybindManager.hpp"
@@ -1086,6 +1087,8 @@ void CKeybindManager::changeworkspace(std::string args) {
     if (!PMONITORWORKSPACEOWNER)
         return;
 
+    updateRelativeCursorCoords();
+
     g_pCompositor->setActiveMonitor(PMONITORWORKSPACEOWNER);
 
     if (BISWORKSPACECURRENT) {
@@ -1113,6 +1116,19 @@ void CKeybindManager::changeworkspace(std::string args) {
             g_pInputManager->sendMotionEventsToFocused();
         else
             g_pInputManager->simulateMouseMovement();
+    }
+
+    const static auto PWARPONWORKSPACECHANGE = CConfigValue<Hyprlang::INT>("cursor:warp_on_change_workspace");
+
+    if (*PWARPONWORKSPACECHANGE) {
+        Vector2D surfaceCoords;
+        PHLLS    pFoundLayerSurface;
+        auto     PLAST = pWorkspaceToChangeTo->getLastFocusedWindow();
+
+        if (PLAST &&
+            !g_pCompositor->vectorToLayerSurface(g_pInputManager->getMouseCoordsInternal(), &PMONITOR->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP], &surfaceCoords,
+                                                 &pFoundLayerSurface))
+            PLAST->warpCursor();
     }
 }
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1121,13 +1121,10 @@ void CKeybindManager::changeworkspace(std::string args) {
     const static auto PWARPONWORKSPACECHANGE = CConfigValue<Hyprlang::INT>("cursor:warp_on_change_workspace");
 
     if (*PWARPONWORKSPACECHANGE) {
-        Vector2D surfaceCoords;
-        PHLLS    pFoundLayerSurface;
-        auto     PLAST = pWorkspaceToChangeTo->getLastFocusedWindow();
+        auto PLAST     = pWorkspaceToChangeTo->getLastFocusedWindow();
+        auto HLSurface = CWLSurface::fromResource(g_pSeatManager->state.pointerFocus.lock());
 
-        if (PLAST &&
-            !g_pCompositor->vectorToLayerSurface(g_pInputManager->getMouseCoordsInternal(), &PMONITOR->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP], &surfaceCoords,
-                                                 &pFoundLayerSurface))
+        if (PLAST && (!HLSurface || HLSurface->getWindow()))
             PLAST->warpCursor();
     }
 }


### PR DESCRIPTION
If enabled, warp the cursor to the last focused window on the workspace in the `changeworkspace' dispatcher, except if the cursor is currently on the WLR top layer.

Respect persistent warps.



