### PR TITLE
option to fix mouse breaking vrr

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -522,6 +522,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("opengl:force_introspection", Hyprlang::INT{2});
 
     m_pConfig->addConfigValue("cursor:no_hardware_cursors", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("cursor:no_break_fs_vrr", Hyprlang::INT{0});
     m_pConfig->addConfigValue("cursor:hotspot_padding", Hyprlang::INT{1});
     m_pConfig->addConfigValue("cursor:inactive_timeout", Hyprlang::INT{0});
     m_pConfig->addConfigValue("cursor:no_warps", Hyprlang::INT{0});

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -523,6 +523,7 @@ CConfigManager::CConfigManager() {
 
     m_pConfig->addConfigValue("cursor:no_hardware_cursors", Hyprlang::INT{0});
     m_pConfig->addConfigValue("cursor:no_break_fs_vrr", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("cursor:min_refresh_rate", Hyprlang::INT{24});
     m_pConfig->addConfigValue("cursor:hotspot_padding", Hyprlang::INT{1});
     m_pConfig->addConfigValue("cursor:inactive_timeout", Hyprlang::INT{0});
     m_pConfig->addConfigValue("cursor:no_warps", Hyprlang::INT{0});

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -363,12 +363,22 @@ void CMonitor::addDamage(const CBox* box) {
 }
 
 bool CMonitor::shouldSkipScheduleFrameOnMouseEvent() {
-    static auto PNOBREAK = CConfigValue<Hyprlang::INT>("cursor:no_break_fs_vrr");    
-    
+    static auto PNOBREAK = CConfigValue<Hyprlang::INT>("cursor:no_break_fs_vrr");
+    static auto PMINRR = CConfigValue<Hyprlang::INT>("cursor:min_refresh_rate");
+
     // skip scheduling extra frames for fullsreen apps with vrr
-    return *PNOBREAK
+    bool shouldSkip = *PNOBREAK
         && output->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED
         && activeWorkspace && activeWorkspace->m_bHasFullscreenWindow && activeWorkspace->m_efFullscreenMode == FULLSCREEN_FULL;
+
+    // keep requested minimum refresh rate
+    if (shouldSkip && *PMINRR && lastPresentationTimer.getMillis() > 1000 / *PMINRR) {
+        // damage whole screen because some previous cursor box damages were skipped
+        wlr_damage_ring_add_whole(&damage);
+        return false;
+    }
+
+    return shouldSkip;
 }
 
 bool CMonitor::isMirror() {

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -364,12 +364,11 @@ void CMonitor::addDamage(const CBox* box) {
 
 bool CMonitor::shouldSkipScheduleFrameOnMouseEvent() {
     static auto PNOBREAK = CConfigValue<Hyprlang::INT>("cursor:no_break_fs_vrr");
-    static auto PMINRR = CConfigValue<Hyprlang::INT>("cursor:min_refresh_rate");
+    static auto PMINRR   = CConfigValue<Hyprlang::INT>("cursor:min_refresh_rate");
 
     // skip scheduling extra frames for fullsreen apps with vrr
-    bool shouldSkip = *PNOBREAK
-        && output->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED
-        && activeWorkspace && activeWorkspace->m_bHasFullscreenWindow && activeWorkspace->m_efFullscreenMode == FULLSCREEN_FULL;
+    bool shouldSkip = *PNOBREAK && output->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED && activeWorkspace && activeWorkspace->m_bHasFullscreenWindow &&
+        activeWorkspace->m_efFullscreenMode == FULLSCREEN_FULL;
 
     // keep requested minimum refresh rate
     if (shouldSkip && *PMINRR && lastPresentationTimer.getMillis() > 1000 / *PMINRR) {

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -363,15 +363,12 @@ void CMonitor::addDamage(const CBox* box) {
 }
 
 bool CMonitor::shouldSkipScheduleFrameOnMouseEvent() {
-    static auto PNOBREAK = CConfigValue<Hyprlang::INT>("cursor:no_break_fs_vrr");
+    static auto PNOBREAK = CConfigValue<Hyprlang::INT>("cursor:no_break_fs_vrr");    
     
     // skip scheduling extra frames for fullsreen apps with vrr
-    if (*PNOBREAK && this->output->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED) {
-        const auto PWORKSPACE = this->activeWorkspace;
-        return PWORKSPACE && PWORKSPACE->m_bHasFullscreenWindow && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL;
-    }
-
-    return false;
+    return *PNOBREAK
+        && output->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED
+        && activeWorkspace && activeWorkspace->m_bHasFullscreenWindow && activeWorkspace->m_efFullscreenMode == FULLSCREEN_FULL;
 }
 
 bool CMonitor::isMirror() {

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -351,17 +351,15 @@ void CMonitor::addDamage(const CRegion* rg) {
     addDamage(const_cast<CRegion*>(rg)->pixman());
 }
 
-void CMonitor::addDamage(const CBox* box, bool skipFrameSchedule) {
+void CMonitor::addDamage(const CBox* box) {
     static auto PZOOMFACTOR = CConfigValue<Hyprlang::FLOAT>("cursor:zoom_factor");
     if (*PZOOMFACTOR != 1.f && g_pCompositor->getMonitorFromCursor() == this) {
         wlr_damage_ring_add_whole(&damage);
-        if (!skipFrameSchedule)
-            g_pCompositor->scheduleFrameForMonitor(this);
+        g_pCompositor->scheduleFrameForMonitor(this);
     }
 
     if (wlr_damage_ring_add_box(&damage, const_cast<CBox*>(box)->pWlr()))
-        if (!skipFrameSchedule)
-            g_pCompositor->scheduleFrameForMonitor(this);
+        g_pCompositor->scheduleFrameForMonitor(this);
 }
 
 bool CMonitor::shouldSkipScheduleFrameOnMouseEvent() {

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -157,7 +157,7 @@ class CMonitor {
     void     onDisconnect(bool destroy = false);
     void     addDamage(const pixman_region32_t* rg);
     void     addDamage(const CRegion* rg);
-    void     addDamage(const CBox* box, bool skipFrameSchedule = false);
+    void     addDamage(const CBox* box);
     bool     shouldSkipScheduleFrameOnMouseEvent();
     void     setMirror(const std::string&);
     bool     isMirror();

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -157,7 +157,8 @@ class CMonitor {
     void     onDisconnect(bool destroy = false);
     void     addDamage(const pixman_region32_t* rg);
     void     addDamage(const CRegion* rg);
-    void     addDamage(const CBox* box);
+    void     addDamage(const CBox* box, bool skipFrameSchedule = false);
+    bool     shouldSkipScheduleFrameOnMouseEvent();
     void     setMirror(const std::string&);
     bool     isMirror();
     bool     matchesStaticSelector(const std::string& selector) const;

--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -675,7 +675,7 @@ void CPointerManager::damageIfSoftware() {
             continue;
 
         if ((mw->softwareLocks > 0 || mw->hardwareFailed || *PNOHW) && b.overlaps({mw->monitor->vecPosition, mw->monitor->vecSize})) {
-            g_pHyprRenderer->damageBox(&b);
+            g_pHyprRenderer->damageBox(&b, mw->monitor->shouldSkipScheduleFrameOnMouseEvent());
             break;
         }
     }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -187,7 +187,9 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
     if (*PZOOMFACTOR != 1.f)
         g_pHyprRenderer->damageMonitor(PMONITOR);
 
-    if (!PMONITOR->solitaryClient.lock() && g_pHyprRenderer->shouldRenderCursor() && PMONITOR->output->software_cursor_locks > 0)
+    bool skipFrameSchedule = PMONITOR->shouldSkipScheduleFrameOnMouseEvent();
+
+    if (!PMONITOR->solitaryClient.lock() && g_pHyprRenderer->shouldRenderCursor() && PMONITOR->output->software_cursor_locks > 0 && !skipFrameSchedule)
         g_pCompositor->scheduleFrameForMonitor(PMONITOR);
 
     PHLWINDOW forcedFocus = m_pForcedFocus.lock();
@@ -370,7 +372,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
         foundSurface =
             g_pCompositor->vectorToLayerSurface(mouseCoords, &PMONITOR->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND], &surfaceCoords, &pFoundLayerSurface);
 
-    if (g_pCompositor->m_pLastMonitor->output->software_cursor_locks > 0)
+    if (g_pCompositor->m_pLastMonitor->output->software_cursor_locks > 0 && !skipFrameSchedule)
         g_pCompositor->scheduleFrameForMonitor(g_pCompositor->m_pLastMonitor.get());
 
     // grabs

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1773,7 +1773,8 @@ void CHyprRenderer::damageBox(CBox* pBox, bool skipFrameSchedule) {
 
         CBox damageBox = {pBox->x - m->vecPosition.x, pBox->y - m->vecPosition.y, pBox->width, pBox->height};
         damageBox.scale(m->scale);
-        m->addDamage(&damageBox, skipFrameSchedule);
+        if (!skipFrameSchedule)
+            m->addDamage(&damageBox);
     }
 
     static auto PLOGDAMAGE = CConfigValue<Hyprlang::INT>("debug:log_damage");

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1763,7 +1763,7 @@ void CHyprRenderer::damageMonitor(CMonitor* pMonitor) {
         Debug::log(LOG, "Damage: Monitor {}", pMonitor->szName);
 }
 
-void CHyprRenderer::damageBox(CBox* pBox) {
+void CHyprRenderer::damageBox(CBox* pBox, bool skipFrameSchedule) {
     if (g_pCompositor->m_bUnsafeState)
         return;
 
@@ -1773,7 +1773,7 @@ void CHyprRenderer::damageBox(CBox* pBox) {
 
         CBox damageBox = {pBox->x - m->vecPosition.x, pBox->y - m->vecPosition.y, pBox->width, pBox->height};
         damageBox.scale(m->scale);
-        m->addDamage(&damageBox);
+        m->addDamage(&damageBox, skipFrameSchedule);
     }
 
     static auto PLOGDAMAGE = CConfigValue<Hyprlang::INT>("debug:log_damage");

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -48,7 +48,7 @@ class CHyprRenderer {
     void                            arrangeLayersForMonitor(const int&);
     void                            damageSurface(SP<CWLSurfaceResource>, double, double, double scale = 1.0);
     void                            damageWindow(PHLWINDOW, bool forceFull = false);
-    void                            damageBox(CBox*);
+    void                            damageBox(CBox*, bool skipFrameSchedule = false);
     void                            damageBox(const int& x, const int& y, const int& w, const int& h);
     void                            damageRegion(const CRegion&);
     void                            damageMonitor(CMonitor*);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Added an option `cursor:no_break_fs_vrr` which allows skipping `scheduleFrameForMonitor` triggered by mouse events for fullscreen apps with VRR enabled. It fixes https://github.com/hyprwm/Hyprland/issues/6222, https://github.com/hyprwm/Hyprland/issues/5918

Added option `cursor:min_refresh_rate` to keep minimum refresh rate for cursor movement. Should be set to at least the minimum vrr supported by monitor since there is no point in keeping it lower. The default is 24.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This option fixes VRR in games and other apps with high enough fps but causes mouse cursor freeze or stutter for others (e.g. fullscreen terminal or browser). `cursor:min_refresh_rate` should help with this issue.

#### Is it ready for merging, or does it need work?
Ready for merging.

