### PR TITLE
layerSurface: fix layer being refocused every commit with on_demand

### DIFF
--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -311,23 +311,14 @@ void CLayerSurface::onCommit() {
         else if (WASEXCLUSIVE && !ISEXCLUSIVE)
             std::erase_if(g_pInputManager->m_dExclusiveLSes, [this](const auto& other) { return !other.lock() || other.lock() == self.lock(); });
 
-        auto interactivityRank = [](int interactivity) {
-            switch (interactivity) {
-                case ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE: return 0;
-                case ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_ON_DEMAND: return 1;
-                case ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE: return 2;
-            }
-        };
-
         // if the surface was focused and interactive but now isn't, refocus
         if (WASLASTFOCUS && !layerSurface->current.interactivity) {
             // moveMouseUnified won't focus non interactive layers but it won't unfocus them either,
             // so unfocus the surface here.
             g_pCompositor->focusSurface(nullptr);
             g_pInputManager->refocusLastWindow(g_pCompositor->getMonitorFromID(monitorID));
-        } else if (!WASLASTFOCUS && interactivityRank(layerSurface->current.interactivity) > interactivityRank(interactivity) &&
-                   (ISEXCLUSIVE || (g_pSeatManager->mouse.expired() || !g_pInputManager->isConstrained()))) {
-            // if kb interactivity > last kb interactivity
+        } else if (!WASEXCLUSIVE && ISEXCLUSIVE) {
+            // if now exclusive and not previously
             g_pSeatManager->setGrab(nullptr);
             g_pInputManager->releaseAllMouseButtons();
             g_pCompositor->focusSurface(surface->resource());


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes #6477

~~The surface will now only receive focus when its keyboard interactivity is more than the previous keyboard interactivity in the order none -> on_demand -> exclusive.~~
The surface will now only receive focus when moving from a non exclusive to exclusive state.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
ready to merge