### PR TITLE
xdg-shell: Continue transform of popup until size fits

### DIFF
--- a/src/protocols/XDGShell.cpp
+++ b/src/protocols/XDGShell.cpp
@@ -534,29 +534,25 @@ CBox CXDGPositionerRules::getPosition(const CBox& constraint, const Vector2D& pa
     if (success)
         return predictedBox.translate(-parentCoord - constraint.pos());
 
+    CBox test = predictedBox;
+
     if (state.constraintAdjustment & (XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_X | XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_Y)) {
         // attempt to flip
         const bool flipX = state.constraintAdjustment & XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_X;
         const bool flipY = state.constraintAdjustment & XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_Y;
 
-        CBox       test = predictedBox;
-        success         = true;
-        if (flipX && test.copy().translate(Vector2D{-predictedBox.w - state.anchorRect.w, 0}).expand(-1).inside(constraint))
-            test.translate(Vector2D{-predictedBox.w - state.anchorRect.w, 0});
-        else if (flipY && test.copy().translate(Vector2D{0, -predictedBox.h - state.anchorRect.h}).expand(-1).inside(constraint))
-            test.translate(Vector2D{0, -predictedBox.h - state.anchorRect.h});
-        else if (flipX && flipY && test.copy().translate(Vector2D{-predictedBox.w - state.anchorRect.w, -predictedBox.h - state.anchorRect.h}).expand(-1).inside(constraint))
+        if (flipX && flipY)
             test.translate(Vector2D{-predictedBox.w - state.anchorRect.w, -predictedBox.h - state.anchorRect.h});
-        else
-            success = false;
+        else if (flipX)
+            test.translate(Vector2D{-predictedBox.w - state.anchorRect.w, 0});
+        else if (flipY)
+            test.translate(Vector2D{0, -predictedBox.h - state.anchorRect.h});
+
+        success = test.copy().expand(-1).inside(constraint);
 
         if (success)
             return test.translate(-parentCoord - constraint.pos());
     }
-
-    // if flips fail, we will slide and remember.
-    // if the positioner is allowed to resize, then resize the slid thing.
-    CBox test = predictedBox;
 
     // for slide and resize, defines the padding around the edge for the positioned
     // surface.
@@ -570,10 +566,10 @@ CBox CXDGPositionerRules::getPosition(const CBox& constraint, const Vector2D& pa
         //const bool gravityLeft = state.gravity == XDG_POSITIONER_GRAVITY_NONE || state.gravity == XDG_POSITIONER_GRAVITY_LEFT || state.gravity == XDG_POSITIONER_GRAVITY_TOP_LEFT || state.gravity == XDG_POSITIONER_GRAVITY_BOTTOM_LEFT;
         //const bool gravityTop = state.gravity == XDG_POSITIONER_GRAVITY_NONE || state.gravity == XDG_POSITIONER_GRAVITY_TOP || state.gravity == XDG_POSITIONER_GRAVITY_TOP_LEFT || state.gravity == XDG_POSITIONER_GRAVITY_TOP_RIGHT;
 
-        const bool leftEdgeOut   = predictedBox.x < constraint.x;
-        const bool topEdgeOut    = predictedBox.y < constraint.y;
-        const bool rightEdgeOut  = predictedBox.x + predictedBox.w > constraint.x + constraint.w;
-        const bool bottomEdgeOut = predictedBox.y + predictedBox.h > constraint.y + constraint.h;
+        const bool leftEdgeOut   = test.x < constraint.x;
+        const bool topEdgeOut    = test.y < constraint.y;
+        const bool rightEdgeOut  = test.x + test.w > constraint.x + constraint.w;
+        const bool bottomEdgeOut = test.y + test.h > constraint.y + constraint.h;
 
         // TODO: this isn't truly conformant.
         if (leftEdgeOut && slideX)
@@ -595,10 +591,10 @@ CBox CXDGPositionerRules::getPosition(const CBox& constraint, const Vector2D& pa
         const bool resizeX = state.constraintAdjustment & XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_RESIZE_X;
         const bool resizeY = state.constraintAdjustment & XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_RESIZE_Y;
 
-        const bool leftEdgeOut   = predictedBox.x < constraint.x;
-        const bool topEdgeOut    = predictedBox.y < constraint.y;
-        const bool rightEdgeOut  = predictedBox.x + predictedBox.w > constraint.x + constraint.w;
-        const bool bottomEdgeOut = predictedBox.y + predictedBox.h > constraint.y + constraint.h;
+        const bool leftEdgeOut   = test.x < constraint.x;
+        const bool topEdgeOut    = test.y < constraint.y;
+        const bool rightEdgeOut  = test.x + test.w > constraint.x + constraint.w;
+        const bool bottomEdgeOut = test.y + test.h > constraint.y + constraint.h;
 
         // TODO: this isn't truly conformant.
         if (leftEdgeOut && resizeX) {

--- a/src/protocols/XDGShell.cpp
+++ b/src/protocols/XDGShell.cpp
@@ -550,12 +550,9 @@ CBox CXDGPositionerRules::getPosition(const CBox& constraint, const Vector2D& pa
         };
         int edgeCount = countEdges(test);
 
-        // -1 as we want 2 edges to be resolved with the flip, otherwise move on to only x or only y
-        if (flipX && flipY && edgeCount - 1 > countEdges(test.copy().translate(Vector2D{-predictedBox.w - state.anchorRect.w, -predictedBox.h - state.anchorRect.h})))
-            test.translate(Vector2D{-predictedBox.w - state.anchorRect.w, -predictedBox.h - state.anchorRect.h});
-        else if (flipX && edgeCount > countEdges(test.copy().translate(Vector2D{-predictedBox.w - state.anchorRect.w, 0})))
+        if (flipX && edgeCount > countEdges(test.copy().translate(Vector2D{-predictedBox.w - state.anchorRect.w, 0})))
             test.translate(Vector2D{-predictedBox.w - state.anchorRect.w, 0});
-        else if (flipY && edgeCount > countEdges(test.copy().translate(Vector2D{0, -predictedBox.h - state.anchorRect.h})))
+        if (flipY && edgeCount > countEdges(test.copy().translate(Vector2D{0, -predictedBox.h - state.anchorRect.h})))
             test.translate(Vector2D{0, -predictedBox.h - state.anchorRect.h});
 
         success = test.copy().expand(-1).inside(constraint);

--- a/src/protocols/XDGShell.cpp
+++ b/src/protocols/XDGShell.cpp
@@ -541,11 +541,14 @@ CBox CXDGPositionerRules::getPosition(const CBox& constraint, const Vector2D& pa
         const bool flipX = state.constraintAdjustment & XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_X;
         const bool flipY = state.constraintAdjustment & XDG_POSITIONER_CONSTRAINT_ADJUSTMENT_FLIP_Y;
 
-        if (flipX && flipY)
+        const bool horizontalEdgeOut = test.x < constraint.x || test.x + test.w > constraint.x + constraint.w;
+        const bool verticalEdgeOut   = test.y < constraint.y || test.y + test.h > constraint.y + constraint.h;
+
+        if (flipX && horizontalEdgeOut && flipY && verticalEdgeOut)
             test.translate(Vector2D{-predictedBox.w - state.anchorRect.w, -predictedBox.h - state.anchorRect.h});
-        else if (flipX)
+        else if (flipX && horizontalEdgeOut)
             test.translate(Vector2D{-predictedBox.w - state.anchorRect.w, 0});
-        else if (flipY)
+        else if (flipY && verticalEdgeOut)
             test.translate(Vector2D{0, -predictedBox.h - state.anchorRect.h});
 
         success = test.copy().expand(-1).inside(constraint);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
- applies all 3 steps of the protocol until it fits or doesn't find a suitable position
This is before this change:

https://github.com/hyprwm/Hyprland/assets/72016555/d4a4efb2-da65-48fd-b4d6-1efff0859be4



#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
There is an issue with opening the popup at the exact point where it should flip upwards -> it pops up, and then flips (this also exists in main)

#### Is it ready for merging, or does it need work?
Should be ready other than what's above

