### PR TITLE
Fix hardware cursor not showing on mirror displays

### DIFF
--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -388,11 +388,15 @@ void CPointerManager::updateCursorBackend() {
 
     for (auto& m : g_pCompositor->m_vMonitors) {
         updateCursorBackendForMonitor(m, *PNOHW);
-        for (auto& mirror : m->mirrors)
-            for (auto& M : g_pCompositor->m_vRealMonitors)
+        for (auto& mirror : m->mirrors) {
+            for (auto& M : g_pCompositor->m_vRealMonitors) {
                 // update backend for mirrors when using hardware cursor
-                if (M->ID == mirror->ID && !*PNOHW)
-                    updateCursorBackendForMonitor(M, *PNOHW);
+                if (M->ID == mirror->ID && !*PNOHW) {
+                    updateCursorBackendForMonitor(M, true);
+                    break;
+                }
+            }
+        }
     }
 }
 

--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -387,6 +387,17 @@ void CPointerManager::updateCursorBackend() {
     }
 }
 
+void CPointerManager::moveCursorOnMirrors(SP<CMonitor> pMonitor) {
+    if (!pMonitor->mirrors.size())
+        return;
+
+    const auto CURSORPOS = getCursorPosForMonitor(pMonitor);
+    for (auto& mirror : pMonitor->mirrors) {
+        const Vector2D MIRRORPOS = {CURSORPOS.x / pMonitor->vecSize.x * mirror->vecSize.x, CURSORPOS.y / pMonitor->vecSize.y * mirror->vecSize.y};
+        mirror->output->impl->move_cursor(mirror->output, MIRRORPOS.x, MIRRORPOS.y);
+    }
+}
+
 void CPointerManager::onCursorMoved() {
     if (!hasCursor())
         return;
@@ -401,6 +412,8 @@ void CPointerManager::onCursorMoved() {
 
         const auto CURSORPOS = getCursorPosForMonitor(m);
         m->output->impl->move_cursor(m->output, CURSORPOS.x, CURSORPOS.y);
+        // manifest the cursor on the mirrors
+        moveCursorOnMirrors(m);
     }
 }
 
@@ -412,6 +425,8 @@ bool CPointerManager::attemptHardwareCursor(SP<CPointerManager::SMonitorPointerS
 
     const auto CURSORPOS = getCursorPosForMonitor(state->monitor.lock());
     state->monitor->output->impl->move_cursor(state->monitor->output, CURSORPOS.x, CURSORPOS.y);
+    // manifest the cursor on the mirrors
+    moveCursorOnMirrors(state->monitor.lock());
 
     auto texture = getCurrentCursorTexture();
 

--- a/src/managers/PointerManager.hpp
+++ b/src/managers/PointerManager.hpp
@@ -61,6 +61,7 @@ class CPointerManager {
     void recheckPointerPosition();
     void onMonitorLayoutChange();
     void onMonitorDisconnect();
+    void updateCursorBackendForMonitor(CSharedPointer<CMonitor>& m, Hyprlang::INT PNOHW);
     void updateCursorBackend();
     void moveCursorOnMirrors(SP<CMonitor> monitor);
     void onCursorMoved();

--- a/src/managers/PointerManager.hpp
+++ b/src/managers/PointerManager.hpp
@@ -62,6 +62,7 @@ class CPointerManager {
     void onMonitorLayoutChange();
     void onMonitorDisconnect();
     void updateCursorBackend();
+    void moveCursorOnMirrors(SP<CMonitor> monitor);
     void onCursorMoved();
     bool hasCursor();
     void damageIfSoftware();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Ensure cursor is rendered on mirror displays when using hardware cursor. (Fixes #6455 )

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
AFAIK this is a hack but works well on my system (using nvidia :)).

#### Is it ready for merging, or does it need work?
I guess it is, but again it's a hack so there could be tons of better solutions for this

