### PR TITLE
Get current layout from workspace instead of g_pLayoutManager

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -791,7 +791,7 @@ void CConfigManager::postConfigReload(const Hyprlang::CParseResult& result) {
     }
 
     for (auto& m : g_pCompositor->m_vMonitors)
-        g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m->ID);
+        m->activeWorkspace->getCurrentLayout()->recalculateMonitor(m->ID);
 
     // Update the keyboard layout to the cfg'd one if this is not the first launch
     if (!isFirstLaunch) {
@@ -909,7 +909,7 @@ std::string CConfigManager::parseKeyword(const std::string& COMMAND, const std::
     // invalidate layouts if they changed
     if (COMMAND == "monitor" || COMMAND.contains("gaps_") || COMMAND.starts_with("dwindle:") || COMMAND.starts_with("master:")) {
         for (auto& m : g_pCompositor->m_vMonitors)
-            g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m->ID);
+            m->activeWorkspace->getCurrentLayout()->recalculateMonitor(m->ID);
     }
 
     // Update window border colors

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -988,7 +988,7 @@ std::string dispatchKeyword(eHyprCtlOutputFormat format, std::string in) {
     if (COMMAND.contains("decoration:") || COMMAND.contains("border") || COMMAND == "workspace" || COMMAND.contains("zoom_factor") || COMMAND == "source") {
         for (auto& m : g_pCompositor->m_vMonitors) {
             g_pHyprRenderer->damageMonitor(m.get());
-            g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m->ID);
+            m->activeWorkspace->getCurrentLayout()->recalculateMonitor(m->ID);
         }
     }
 
@@ -1296,7 +1296,7 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
     }
 
     for (auto& m : g_pCompositor->m_vMonitors)
-        g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m->ID);
+        m->activeWorkspace->getCurrentLayout()->recalculateMonitor(m->ID);
 
     return "ok";
 }
@@ -1722,7 +1722,7 @@ std::string CHyprCtl::getReply(std::string request) {
 
         for (auto& m : g_pCompositor->m_vMonitors) {
             g_pHyprRenderer->damageMonitor(m.get());
-            g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m->ID);
+            m->activeWorkspace->getCurrentLayout()->recalculateMonitor(m->ID);
         }
     }
 

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -284,14 +284,14 @@ void CWindow::addWindowDeco(std::unique_ptr<IHyprWindowDecoration> deco) {
     m_dWindowDecorations.emplace_back(std::move(deco));
     g_pDecorationPositioner->forceRecalcFor(m_pSelf.lock());
     updateWindowDecos();
-    g_pLayoutManager->getCurrentLayout()->recalculateWindow(m_pSelf.lock());
+    m_pWorkspace->getCurrentLayout()->recalculateWindow(m_pSelf.lock());
 }
 
 void CWindow::removeWindowDeco(IHyprWindowDecoration* deco) {
     m_vDecosToRemove.push_back(deco);
     g_pDecorationPositioner->forceRecalcFor(m_pSelf.lock());
     updateWindowDecos();
-    g_pLayoutManager->getCurrentLayout()->recalculateWindow(m_pSelf.lock());
+    m_pWorkspace->getCurrentLayout()->recalculateWindow(m_pSelf.lock());
 }
 
 void CWindow::uncacheWindowDecos() {
@@ -412,11 +412,11 @@ void CWindow::moveToWorkspace(PHLWORKSPACE pWorkspace) {
 
     g_pCompositor->updateWorkspaceWindows(OLDWORKSPACE->m_iID);
     g_pCompositor->updateWorkspaceSpecialRenderData(OLDWORKSPACE->m_iID);
-    g_pLayoutManager->getCurrentLayout()->recalculateMonitor(OLDWORKSPACE->m_iMonitorID);
+    OLDWORKSPACE->getCurrentLayout()->recalculateMonitor(OLDWORKSPACE->m_iMonitorID);
 
     g_pCompositor->updateWorkspaceWindows(workspaceID());
     g_pCompositor->updateWorkspaceSpecialRenderData(workspaceID());
-    g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m_iMonitorID);
+    m_pWorkspace->getCurrentLayout()->recalculateMonitor(m_iMonitorID);
 
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 
@@ -523,7 +523,7 @@ void CWindow::onUnmap() {
 
     g_pCompositor->updateWorkspaceWindows(workspaceID());
     g_pCompositor->updateWorkspaceSpecialRenderData(workspaceID());
-    g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m_iMonitorID);
+    m_pWorkspace->getCurrentLayout()->recalculateMonitor(m_iMonitorID);
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 
     m_pWorkspace.reset();
@@ -819,7 +819,7 @@ void CWindow::updateDynamicRules() {
 
     EMIT_HOOK_EVENT("windowUpdateRules", m_pSelf.lock());
 
-    g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m_iMonitorID);
+    m_pWorkspace->getCurrentLayout()->recalculateMonitor(m_iMonitorID);
 }
 
 // check if the point is "hidden" under a rounded corner of the window
@@ -886,7 +886,7 @@ void CWindow::createGroup() {
 
         g_pCompositor->updateWorkspaceWindows(workspaceID());
         g_pCompositor->updateWorkspaceSpecialRenderData(workspaceID());
-        g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m_iMonitorID);
+        m_pWorkspace->getCurrentLayout()->recalculateMonitor(m_iMonitorID);
         g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 
         g_pEventManager->postEvent(SHyprIPCEvent{"togglegroup", std::format("1,{:x}", (uintptr_t)this)});
@@ -904,7 +904,7 @@ void CWindow::destroyGroup() {
         updateWindowDecos();
         g_pCompositor->updateWorkspaceWindows(workspaceID());
         g_pCompositor->updateWorkspaceSpecialRenderData(workspaceID());
-        g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m_iMonitorID);
+        m_pWorkspace->getCurrentLayout()->recalculateMonitor(m_iMonitorID);
         g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 
         g_pEventManager->postEvent(SHyprIPCEvent{"togglegroup", std::format("0,{:x}", (uintptr_t)this)});
@@ -926,21 +926,21 @@ void CWindow::destroyGroup() {
 
     for (auto& w : members) {
         if (w->m_sGroupData.head)
-            g_pLayoutManager->getCurrentLayout()->onWindowRemoved(curr);
+            m_pWorkspace->getCurrentLayout()->onWindowRemoved(curr);
         w->m_sGroupData.head = false;
     }
 
     const bool GROUPSLOCKEDPREV        = g_pKeybindManager->m_bGroupsLocked;
     g_pKeybindManager->m_bGroupsLocked = true;
     for (auto& w : members) {
-        g_pLayoutManager->getCurrentLayout()->onWindowCreated(w);
+        m_pWorkspace->getCurrentLayout()->onWindowCreated(w);
         w->updateWindowDecos();
     }
     g_pKeybindManager->m_bGroupsLocked = GROUPSLOCKEDPREV;
 
     g_pCompositor->updateWorkspaceWindows(workspaceID());
     g_pCompositor->updateWorkspaceSpecialRenderData(workspaceID());
-    g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m_iMonitorID);
+    m_pWorkspace->getCurrentLayout()->recalculateMonitor(m_iMonitorID);
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 
     if (!addresses.empty())
@@ -1028,7 +1028,7 @@ void CWindow::setGroupCurrent(PHLWINDOW pWindow) {
     PCURRENT->setHidden(true);
     pWindow->setHidden(false); // can remove m_pLastWindow
 
-    g_pLayoutManager->getCurrentLayout()->replaceWindowDataWith(PCURRENT, pWindow);
+    m_pWorkspace->getCurrentLayout()->replaceWindowDataWith(PCURRENT, pWindow);
 
     if (PCURRENT->m_bIsFloating) {
         pWindow->m_vRealPosition.setValueAndWarp(PWINDOWPOS);

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -1,6 +1,7 @@
 #include "Workspace.hpp"
 #include "../Compositor.hpp"
 #include "../config/ConfigValue.hpp"
+#include "managers/LayoutManager.hpp"
 
 #include <hyprutils/string/String.hpp>
 using namespace Hyprutils::String;
@@ -507,4 +508,8 @@ void CWorkspace::markInert() {
 
 bool CWorkspace::inert() {
     return m_bInert;
+}
+
+IHyprLayout* CWorkspace::getCurrentLayout() {
+    return g_pLayoutManager->getCurrentLayout();
 }

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -511,5 +511,5 @@ bool CWorkspace::inert() {
 }
 
 IHyprLayout* CWorkspace::getCurrentLayout() {
-    return g_pLayoutManager->getCurrentLayout();
+    return g_pLayoutManager->getCurrentGlobalLayout();
 }

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include "../defines.hpp"
 #include "DesktopTypes.hpp"
+#include "../layout/IHyprLayout.hpp"
 
 enum eFullscreenMode : int8_t {
     FULLSCREEN_INVALID = -1,

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -63,21 +63,23 @@ class CWorkspace {
     bool        m_bPersistent = false;
 
     // Inert: destroyed and invalid. If this is true, release the ptr you have.
-    bool        inert();
+    bool         inert();
 
-    void        startAnim(bool in, bool left, bool instant = false);
-    void        setActive(bool on);
+    void         startAnim(bool in, bool left, bool instant = false);
+    void         setActive(bool on);
 
-    void        moveToMonitor(const int&);
+    void         moveToMonitor(const int&);
 
-    PHLWINDOW   getLastFocusedWindow();
-    void        rememberPrevWorkspace(const PHLWORKSPACE& prevWorkspace);
+    PHLWINDOW    getLastFocusedWindow();
+    void         rememberPrevWorkspace(const PHLWORKSPACE& prevWorkspace);
 
-    std::string getConfigName();
+    std::string  getConfigName();
 
-    bool        matchesStaticSelector(const std::string& selector);
+    bool         matchesStaticSelector(const std::string& selector);
 
-    void        markInert();
+    void         markInert();
+
+    IHyprLayout* getCurrentLayout();
 
   private:
     void                 init(PHLWORKSPACE self);

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -325,7 +325,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
     PWINDOW->updateSpecialRenderData();
 
     if (PWINDOW->m_bIsFloating) {
-        g_pLayoutManager->getCurrentLayout()->onWindowCreatedFloating(PWINDOW);
+        PWINDOW->m_pWorkspace->getCurrentLayout()->onWindowCreatedFloating(PWINDOW);
         PWINDOW->m_bCreatedOverFullscreen = true;
 
         // size and move rules
@@ -450,7 +450,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
         g_pCompositor->changeWindowZOrder(PWINDOW, true);
     } else {
-        g_pLayoutManager->getCurrentLayout()->onWindowCreated(PWINDOW);
+        PWINDOW->m_pWorkspace->getCurrentLayout()->onWindowCreated(PWINDOW);
 
         // Set the pseudo size here too so that it doesnt end up being 0x0
         PWINDOW->m_vPseudoSize = PWINDOW->m_vRealSize.goal() - Vector2D(10, 10);
@@ -532,11 +532,11 @@ void Events::listener_mapWindow(void* owner, void* data) {
             // swallow
             PWINDOW->m_pSwallowed = SWALLOWER;
 
-            g_pLayoutManager->getCurrentLayout()->onWindowRemoved(SWALLOWER);
+            SWALLOWER->m_pWorkspace->getCurrentLayout()->onWindowRemoved(SWALLOWER);
 
             SWALLOWER->setHidden(true);
 
-            g_pLayoutManager->getCurrentLayout()->recalculateMonitor(PWINDOW->m_iMonitorID);
+            PWINDOW->m_pWorkspace->getCurrentLayout()->recalculateMonitor(PWINDOW->m_iMonitorID);
         }
     }
 
@@ -551,7 +551,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
     // apply data from default decos. Borders, shadows.
     g_pDecorationPositioner->forceRecalcFor(PWINDOW);
     PWINDOW->updateWindowDecos();
-    g_pLayoutManager->getCurrentLayout()->recalculateWindow(PWINDOW);
+    PWINDOW->m_pWorkspace->getCurrentLayout()->recalculateWindow(PWINDOW);
 
     // do animations
     g_pAnimationManager->onWindowPostCreateClose(PWINDOW, false);
@@ -614,7 +614,7 @@ void Events::listener_unmapWindow(void* owner, void* data) {
     // swallowing
     if (valid(PWINDOW->m_pSwallowed)) {
         PWINDOW->m_pSwallowed->setHidden(false);
-        g_pLayoutManager->getCurrentLayout()->onWindowCreated(PWINDOW->m_pSwallowed.lock());
+        PWINDOW->m_pWorkspace->getCurrentLayout()->onWindowCreated(PWINDOW->m_pSwallowed.lock());
         PWINDOW->m_pSwallowed.reset();
     }
 
@@ -634,14 +634,14 @@ void Events::listener_unmapWindow(void* owner, void* data) {
     if (PWORKSPACE->m_bHasFullscreenWindow && PWINDOW->m_bIsFullscreen)
         PWORKSPACE->m_bHasFullscreenWindow = false;
 
-    g_pLayoutManager->getCurrentLayout()->onWindowRemoved(PWINDOW);
+    PWORKSPACE->getCurrentLayout()->onWindowRemoved(PWINDOW);
 
     // do this after onWindowRemoved because otherwise it'll think the window is invalid
     PWINDOW->m_bIsMapped = false;
 
     // refocus on a new window if needed
     if (wasLastWindow) {
-        const auto PWINDOWCANDIDATE = g_pLayoutManager->getCurrentLayout()->getNextWindowCandidate(PWINDOW);
+        const auto PWINDOWCANDIDATE = PWORKSPACE->getCurrentLayout()->getNextWindowCandidate(PWINDOW);
 
         Debug::log(LOG, "On closed window, new focused candidate is {}", PWINDOWCANDIDATE);
 
@@ -690,7 +690,7 @@ void Events::listener_commitWindow(void* owner, void* data) {
     PHLWINDOW PWINDOW = ((CWindow*)owner)->m_pSelf.lock();
 
     if (!PWINDOW->m_bIsX11 && PWINDOW->m_pXDGSurface->initialCommit) {
-        Vector2D predSize = g_pLayoutManager->getCurrentLayout()->predictSizeForNewWindow(PWINDOW);
+        Vector2D predSize = PWINDOW->m_pWorkspace->getCurrentLayout()->predictSizeForNewWindow(PWINDOW);
 
         Debug::log(LOG, "Layout predicts size {} for {}", predSize, PWINDOW);
 
@@ -775,7 +775,7 @@ void Events::listener_destroyWindow(void* owner, void* data) {
 
     PWINDOW->listeners = {};
 
-    g_pLayoutManager->getCurrentLayout()->onWindowRemoved(PWINDOW);
+    PWINDOW->m_pWorkspace->getCurrentLayout()->onWindowRemoved(PWINDOW);
 
     PWINDOW->m_bReadyToDelete = true;
 

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -196,7 +196,7 @@ void CMonitor::onConnect(bool noRule) {
         g_pCompositor->setActiveMonitor(this);
 
     g_pHyprRenderer->arrangeLayersForMonitor(ID);
-    g_pLayoutManager->getCurrentLayout()->recalculateMonitor(ID);
+    activeWorkspace->getCurrentLayout()->recalculateMonitor(ID);
 
     // ensure VRR (will enable if necessary)
     g_pConfigManager->ensureVRR(this);
@@ -432,7 +432,7 @@ void CMonitor::setupDefaultWS(const SMonitorRule& monitorRule) {
         // workspace exists, move it to the newly connected monitor
         g_pCompositor->moveWorkspaceToMonitor(PNEWWORKSPACE, this);
         activeWorkspace = PNEWWORKSPACE;
-        g_pLayoutManager->getCurrentLayout()->recalculateMonitor(ID);
+        activeWorkspace->getCurrentLayout()->recalculateMonitor(ID);
         PNEWWORKSPACE->startAnim(true, true, true);
     } else {
         if (newDefaultWorkspaceName == "")
@@ -615,7 +615,7 @@ void CMonitor::changeWorkspace(const PHLWORKSPACE& pWorkspace, bool internal, bo
         if (!noMouseMove)
             g_pInputManager->simulateMouseMovement();
 
-        g_pLayoutManager->getCurrentLayout()->recalculateMonitor(ID);
+        activeWorkspace->getCurrentLayout()->recalculateMonitor(ID);
 
         g_pEventManager->postEvent(SHyprIPCEvent{"workspace", pWorkspace->m_szName});
         g_pEventManager->postEvent(SHyprIPCEvent{"workspacev2", std::format("{},{}", pWorkspace->m_iID, pWorkspace->m_szName)});
@@ -650,7 +650,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
         }
         activeSpecialWorkspace.reset();
 
-        g_pLayoutManager->getCurrentLayout()->recalculateMonitor(ID);
+        activeWorkspace->getCurrentLayout()->recalculateMonitor(ID);
 
         if (!(g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->m_bPinned && g_pCompositor->m_pLastWindow->m_iMonitorID == ID)) {
             if (const auto PLAST = activeWorkspace->getLastFocusedWindow(); PLAST)
@@ -678,7 +678,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
     const auto PMONITORWORKSPACEOWNER = g_pCompositor->getMonitorFromID(pWorkspace->m_iMonitorID);
     if (PMONITORWORKSPACEOWNER->activeSpecialWorkspace == pWorkspace) {
         PMONITORWORKSPACEOWNER->activeSpecialWorkspace.reset();
-        g_pLayoutManager->getCurrentLayout()->recalculateMonitor(PMONITORWORKSPACEOWNER->ID);
+        PMONITORWORKSPACEOWNER->activeWorkspace->getCurrentLayout()->recalculateMonitor(PMONITORWORKSPACEOWNER->ID);
         g_pEventManager->postEvent(SHyprIPCEvent{"activespecial", "," + PMONITORWORKSPACEOWNER->szName});
 
         const auto PACTIVEWORKSPACE = PMONITORWORKSPACEOWNER->activeWorkspace;
@@ -718,7 +718,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
         }
     }
 
-    g_pLayoutManager->getCurrentLayout()->recalculateMonitor(ID);
+    activeWorkspace->getCurrentLayout()->recalculateMonitor(ID);
 
     if (!(g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->m_bPinned && g_pCompositor->m_pLastWindow->m_iMonitorID == ID)) {
         if (const auto PLAST = pWorkspace->getLastFocusedWindow(); PLAST)

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -308,7 +308,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
         // we can't continue. make it floating.
         pWindow->m_bIsFloating = true;
         m_lDwindleNodesData.remove(*PNODE);
-        g_pLayoutManager->getCurrentLayout()->onWindowCreatedFloating(pWindow);
+        onWindowCreatedFloating(pWindow);
         return;
     }
 

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -232,7 +232,7 @@ void CHyprMasterLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dire
             // we can't continue. make it floating.
             pWindow->m_bIsFloating = true;
             m_lMasterNodesData.remove(*PNODE);
-            g_pLayoutManager->getCurrentLayout()->onWindowCreatedFloating(pWindow);
+            onWindowCreatedFloating(pWindow);
             return;
         }
     } else {
@@ -245,7 +245,7 @@ void CHyprMasterLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dire
             // we can't continue. make it floating.
             pWindow->m_bIsFloating = true;
             m_lMasterNodesData.remove(*PNODE);
-            g_pLayoutManager->getCurrentLayout()->onWindowCreatedFloating(pWindow);
+            onWindowCreatedFloating(pWindow);
             return;
         }
     }

--- a/src/managers/LayoutManager.cpp
+++ b/src/managers/LayoutManager.cpp
@@ -5,7 +5,7 @@ CLayoutManager::CLayoutManager() {
     m_vLayouts.emplace_back(std::make_pair<>("master", &m_cMasterLayout));
 }
 
-IHyprLayout* CLayoutManager::getCurrentLayout() {
+IHyprLayout* CLayoutManager::getCurrentGlobalLayout() {
     return m_vLayouts[m_iCurrentLayoutID].second;
 }
 
@@ -15,9 +15,9 @@ void CLayoutManager::switchToLayout(std::string layout) {
             if (i == (size_t)m_iCurrentLayoutID)
                 return;
 
-            getCurrentLayout()->onDisable();
+            getCurrentGlobalLayout()->onDisable();
             m_iCurrentLayoutID = i;
-            getCurrentLayout()->onEnable();
+            getCurrentGlobalLayout()->onEnable();
             return;
         }
     }

--- a/src/managers/LayoutManager.hpp
+++ b/src/managers/LayoutManager.hpp
@@ -7,7 +7,7 @@ class CLayoutManager {
   public:
     CLayoutManager();
 
-    IHyprLayout*             getCurrentLayout();
+    IHyprLayout*             getCurrentGlobalLayout();
 
     void                     switchToLayout(std::string);
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -258,7 +258,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
         }
     }
 
-    g_pLayoutManager->getCurrentLayout()->onMouseMove(getMouseCoordsInternal());
+    PMONITOR->activeWorkspace->getCurrentLayout()->onMouseMove(getMouseCoordsInternal());
 
     if (PMONITOR && PMONITOR != g_pCompositor->m_pLastMonitor.get() && (*PMOUSEFOCUSMON || refocus) && m_pForcedFocus.expired())
         g_pCompositor->setActiveMonitor(PMONITOR);

--- a/src/plugins/PluginAPI.cpp
+++ b/src/plugins/PluginAPI.cpp
@@ -112,7 +112,7 @@ APICALL bool HyprlandAPI::addWindowDecoration(HANDLE handle, PHLWINDOW pWindow, 
 
     pWindow->addWindowDeco(std::move(pDecoration));
 
-    g_pLayoutManager->getCurrentLayout()->recalculateWindow(pWindow);
+    pWindow->m_pWorkspace->getCurrentLayout()->recalculateWindow(pWindow);
 
     return true;
 }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1168,7 +1168,7 @@ void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
         else
             Debug::log(LOG, "NoFrameSchedule hit for {}.", pMonitor->szName);
 
-        g_pLayoutManager->getCurrentLayout()->recalculateMonitor(pMonitor->ID);
+        pMonitor->activeWorkspace->getCurrentLayout()->recalculateMonitor(pMonitor->ID);
 
         if (pMonitor->framesToSkip > 10)
             pMonitor->framesToSkip = 0;
@@ -1189,7 +1189,7 @@ void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
 
     if (pMonitor->scheduledRecalc) {
         pMonitor->scheduledRecalc = false;
-        g_pLayoutManager->getCurrentLayout()->recalculateMonitor(pMonitor->ID);
+        pMonitor->activeWorkspace->getCurrentLayout()->recalculateMonitor(pMonitor->ID);
     }
 
     // tearing and DS first
@@ -1642,8 +1642,8 @@ void CHyprRenderer::arrangeLayerArray(CMonitor* pMonitor, const std::vector<PHLL
     }
 }
 
-void CHyprRenderer::arrangeLayersForMonitor(const int& monitor) {
-    const auto PMONITOR = g_pCompositor->getMonitorFromID(monitor);
+void CHyprRenderer::arrangeLayersForMonitor(const int& monitorID) {
+    const auto PMONITOR = g_pCompositor->getMonitorFromID(monitorID);
 
     if (!PMONITOR)
         return;
@@ -1676,7 +1676,7 @@ void CHyprRenderer::arrangeLayersForMonitor(const int& monitor) {
     // damage the monitor if can
     damageMonitor(PMONITOR);
 
-    g_pLayoutManager->getCurrentLayout()->recalculateMonitor(monitor);
+    PMONITOR->activeWorkspace->getCurrentLayout()->recalculateMonitor(monitorID);
 }
 
 void CHyprRenderer::damageSurface(SP<CWLSurfaceResource> pSurface, double x, double y, double scale) {

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -55,7 +55,7 @@ SDecorationPositioningInfo CHyprGroupBarDecoration::getPositioningInfo() {
 
 void CHyprGroupBarDecoration::onPositioningReply(const SDecorationPositioningReply& reply) {
     m_bAssignedBox = reply.assignedGeometry;
-    g_pLayoutManager->getCurrentLayout()->recalculateWindow(m_pWindow.lock());
+    m_pWindow->m_pWorkspace->getCurrentLayout()->recalculateWindow(m_pWindow.lock());
 }
 
 eDecorationType CHyprGroupBarDecoration::getDecorationType() {
@@ -385,11 +385,11 @@ bool CHyprGroupBarDecoration::onBeginWindowDragOnDeco(const Vector2D& pos) {
     PHLWINDOW pWindow = m_pWindow->getGroupWindowByIndex(WINDOWINDEX);
 
     // hack
-    g_pLayoutManager->getCurrentLayout()->onWindowRemoved(pWindow);
+    pWindow->m_pWorkspace->getCurrentLayout()->onWindowRemoved(pWindow);
     if (!pWindow->m_bIsFloating) {
         const bool GROUPSLOCKEDPREV        = g_pKeybindManager->m_bGroupsLocked;
         g_pKeybindManager->m_bGroupsLocked = true;
-        g_pLayoutManager->getCurrentLayout()->onWindowCreated(pWindow);
+        pWindow->m_pWorkspace->getCurrentLayout()->onWindowCreated(pWindow);
         g_pKeybindManager->m_bGroupsLocked = GROUPSLOCKEDPREV;
     }
 
@@ -430,7 +430,7 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, PHLWIND
             w->m_sGroupData.pNextWindow.reset();
             w->m_sGroupData.head   = false;
             w->m_sGroupData.locked = false;
-            g_pLayoutManager->getCurrentLayout()->onWindowRemoved(w);
+            w->m_pWorkspace->getCurrentLayout()->onWindowRemoved(w);
         }
 
         // restores the group
@@ -443,7 +443,7 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, PHLWIND
         members[0]->m_sGroupData.head   = true;
         members[0]->m_sGroupData.locked = WASLOCKED;
     } else {
-        g_pLayoutManager->getCurrentLayout()->onWindowRemoved(pDraggedWindow);
+        pDraggedWindow->m_pWorkspace->getCurrentLayout()->onWindowRemoved(pDraggedWindow);
     }
 
     pWindowInsertAfter->insertWindowToGroup(pDraggedWindow);
@@ -454,7 +454,7 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, PHLWIND
     m_pWindow->setGroupCurrent(pDraggedWindow);
     pDraggedWindow->applyGroupRules();
     pDraggedWindow->updateWindowDecos();
-    g_pLayoutManager->getCurrentLayout()->recalculateWindow(pDraggedWindow);
+    pDraggedWindow->m_pWorkspace->getCurrentLayout()->recalculateWindow(pDraggedWindow);
 
     if (!pDraggedWindow->getDecorationByType(DECORATION_GROUPBAR))
         pDraggedWindow->addWindowDeco(std::make_unique<CHyprGroupBarDecoration>(pDraggedWindow));

--- a/src/render/decorations/DecorationPositioner.cpp
+++ b/src/render/decorations/DecorationPositioner.cpp
@@ -273,7 +273,7 @@ void CDecorationPositioner::onWindowUpdate(PHLWINDOW pWindow) {
 
     if (WINDOWDATA->extents != SWindowDecorationExtents{{stickyOffsetXL + reservedXL, stickyOffsetYT + reservedYT}, {stickyOffsetXR + reservedXR, stickyOffsetYB + reservedYB}}) {
         WINDOWDATA->extents = {{stickyOffsetXL + reservedXL, stickyOffsetYT + reservedYT}, {stickyOffsetXR + reservedXR, stickyOffsetYB + reservedYB}};
-        g_pLayoutManager->getCurrentLayout()->recalculateWindow(pWindow);
+        pWindow->m_pWorkspace->getCurrentLayout()->recalculateWindow(pWindow);
     }
 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
* added CWorkspace::getCurrentLayout
* replaced g_pLayoutManager->getCurrentLayout with CWorkspace::getCurrentLayout
* renamed CLayoutManager::getCurrentLayout to CLayoutManager::getCurrentGlobalLayout
* removed calls to getCurrentLayout from layouts

Initial work on per workspace layouts. For now `CWorkspace::getCurrentLayout` just returns `g_pLayoutManager->getCurrentGlobalLayout()`. So any existing logic shouldn't be affected by these changes.
Renamed `CLayoutManager::getCurrentLayout` to break the api and get conflicts with other PRs which may add new calls to `g_pLayoutManager->getCurrentLayout`.
Also removed calls to `getCurrentLayout` from layouts since it should point to `this`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This code relies on `CWindow::m_pWorkspace` and `CMonitor::activeWorkspace` being set before the calls to `getCurrentLayout`.
In some cases `getCurrentLayout` might be called on an incorrect workspace. This should not be an issue for now since all workspaces will return the same layout.
When a window is moved to another workspace there are no checks that both workspaces have the same layout and only one of them gets updated. Again not an issue for now.

#### Is it ready for merging, or does it need work?
Ready for merging
