### PR TITLE
Customizable directional window resize logic

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -701,7 +701,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
     if (properties & ALLOW_FLOATING) {
         for (auto& w : m_vWindows | std::views::reverse) {
             const auto BB  = w->getWindowBoxUnified(properties);
-            CBox       box = BB.copy().expand(w->m_iX11Type == 2 ? BORDER_GRAB_AREA : 0);
+            CBox       box = BB.copy().expand(w->m_iX11Type != 2 ? BORDER_GRAB_AREA : 0);
             if (w->m_bIsFloating && w->m_bIsMapped && !w->isHidden() && !w->m_bX11ShouldntFocus && w->m_bPinned && !w->m_sAdditionalConfigData.noFocus && w != pIgnoreWindow) {
                 if (box.containsPoint(g_pPointerManager->position()))
                     return w;
@@ -730,7 +730,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
                     BB.x + BB.width <= PWINDOWMONITOR->vecPosition.x + PWINDOWMONITOR->vecSize.x && BB.y + BB.height <= PWINDOWMONITOR->vecPosition.y + PWINDOWMONITOR->vecSize.y)
                     continue;
 
-                CBox box = BB.copy().expand(w->m_iX11Type == 2 ? BORDER_GRAB_AREA : 0);
+                CBox box = BB.copy().expand(w->m_iX11Type != 2 ? BORDER_GRAB_AREA : 0);
                 if (w->m_bIsFloating && w->m_bIsMapped && isWorkspaceVisible(w->m_pWorkspace) && !w->isHidden() && !w->m_bPinned && !w->m_sAdditionalConfigData.noFocus &&
                     w != pIgnoreWindow && (!aboveFullscreen || w->m_bCreatedOverFullscreen)) {
                     // OR windows should add focus to parent

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -324,6 +324,8 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("general:layout", {"dwindle"});
     m_pConfig->addConfigValue("general:allow_tearing", Hyprlang::INT{0});
     m_pConfig->addConfigValue("general:resize_corner", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("general:edge_depth", {0.0f});
+    m_pConfig->addConfigValue("general:resize_mouse_bind_pattern", Hyprlang::INT{0});
 
     m_pConfig->addConfigValue("misc:disable_hyprland_logo", Hyprlang::INT{0});
     m_pConfig->addConfigValue("misc:disable_splash_rendering", Hyprlang::INT{0});

--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -71,8 +71,8 @@ class CHyprDwindleLayout : public IHyprLayout {
     struct {
         bool started = false;
         bool pseudo  = false;
-        bool xExtent = false;
-        bool yExtent = false;
+        int  xExtent = 0;
+        int  yExtent = 0;
     } m_PseudoDragFlags;
 
     std::optional<Vector2D> m_vOverrideFocalPoint; // for onWindowCreatedTiling.

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
 #include "../defines.hpp"
+#include "hyprutils/math/Box.hpp"
+#include "hyprutils/math/Vector2D.hpp"
 #include <any>
+#include <cstdint>
 
 class CWindow;
 class CGradientValueData;
@@ -22,7 +25,11 @@ enum eRectCorner {
     CORNER_TOPLEFT,
     CORNER_TOPRIGHT,
     CORNER_BOTTOMRIGHT,
-    CORNER_BOTTOMLEFT
+    CORNER_BOTTOMLEFT,
+    EDGE_TOP,
+    EDGE_RIGHT,
+    EDGE_BOTTOM,
+    EDGE_LEFT
 };
 
 enum eDirection {
@@ -75,6 +82,13 @@ class IHyprLayout {
         Called when a window is requested to be floated
     */
     virtual void changeWindowFloatingMode(PHLWINDOW);
+
+    /*
+        Called when cursor position on a window is requested. Returns a value between from 0 to 23
+        depending on the parameters given or the raw uint8_t to be interpreted by its bit composition.
+    */
+    virtual int getWindowRegion(Vector2D cursor, CBox window, CBox edge = 0, bool raw = false);
+
     /*
         Called when a window is clicked on, beginning a drag
         this might be a resize, move, whatever the layout defines it
@@ -201,6 +215,8 @@ class IHyprLayout {
     Vector2D     m_vLastDragXY;
     Vector2D     m_vBeginDragPositionXY;
     Vector2D     m_vBeginDragSizeXY;
+    Vector2D     m_vBeginDragFullPosXY;
+    Vector2D     m_vBeginDragFullSizeXY;
     Vector2D     m_vDraggingWindowOriginalFloatSize;
     eRectCorner  m_eGrabbedCorner = CORNER_TOPLEFT;
 

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -763,8 +763,8 @@ void CHyprMasterLayout::resizeActiveWindow(const Vector2D& pixResize, eRectCorne
     const bool   DISPLAYTOP    = STICKS(PWINDOW->m_vPosition.y, PMONITOR->vecPosition.y + PMONITOR->vecReservedTopLeft.y);
     const bool   DISPLAYLEFT   = STICKS(PWINDOW->m_vPosition.x, PMONITOR->vecPosition.x + PMONITOR->vecReservedTopLeft.x);
 
-    const bool   LEFT = corner == CORNER_TOPLEFT || corner == CORNER_BOTTOMLEFT;
-    const bool   TOP  = corner == CORNER_TOPLEFT || corner == CORNER_TOPRIGHT;
+    const bool   LEFT = corner == EDGE_LEFT || corner == CORNER_TOPLEFT || corner == CORNER_BOTTOMLEFT;
+    const bool   TOP  = corner == EDGE_TOP || corner == CORNER_TOPLEFT || corner == CORNER_TOPRIGHT;
     const bool   NONE = corner == CORNER_NONE;
 
     const auto   MASTERS      = getMastersOnWorkspace(PNODE->workspaceID);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Closes #6152, adds a drop-in replacement (and configurable) window resizing logic. Also will fix a bug with pseudotiled windows + resize on border being unreliable (sometimes resizes the node box, sometimes resizes the inner window).

New function: `IHyprLayout::getWindowRegion()` determines where a point is on an arbitrary rectangle defined as a CBox with an optional CBox for edge size calculation (defaults to 0) and an optional `raw` boolean for the raw untranslated integer. Returns an integer between 0 and 23 (inclusive) when translated in-function.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Drop-in compatibility, no behavioural changes unless configured to be. Pseudotiled `general:resize_on_border` interaction now always resizes the inner window instead of the window node's box.

`general:edge_depth` float value that
 * acts as a % of the window's shortest side divided into two edges when between 0.0 and 1.0 (exclusive)
 * acts as a pixel count clamped between 1 and 1/2 of the window's shortest side when above 1.0 
 * disables the calculation of edges when 0 or under.
 
`general:resize_mouse_bind_pattern` integer value that sets the pattern of the window resize direction. 
 * 0 is the default, the 4 corners that we have now.
 * 1 makes the edges of the window single axis resize and the middle of the window is divided into 4 corners.
 * 2 is similar to the default with the exception that the edges are single axis resize
 * 3 corners do the dual axis resize and a 'cross' shape that connects the edges are single axis resize
 * 4 window is divided into 4 triangles for single axis resizes only
 * Any invalid value is considered default
 
#### Is it ready for merging, or does it need work?
It's presently in a working state for dwindle and for floating windows.

TODO:
- [x] floating windows don't update their reported size and position when resized (bug in main branch)
- [x] `general:extend_border_grab_area` no longer does anything (bug in main branch) (broken by addd3e7f1aeb670dd91d26005aaeccce3efb1ae7)
- [x] pseudotiled windows [dwindle] have a inconsistent `general:resize_on_border` interaction (bug in main branch)
- [x] pseudotiled windows [dwindle] don't respect single axis resize
- [ ] master layout does not respect single axis resize
- [ ] primary + alternate pattern ?
- [ ] settle on config variable names
- [ ] cleanup
- [ ] docs