### PR TITLE
pointer: use software rendering when monitor is mirrored

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -6,6 +6,7 @@
 #include "../devices/ITouch.hpp"
 #include "../protocols/LayerShell.hpp"
 #include "../protocols/PresentationTime.hpp"
+#include "managers/PointerManager.hpp"
 #include <hyprutils/string/String.hpp>
 using namespace Hyprutils::String;
 
@@ -248,6 +249,9 @@ void CMonitor::onDisconnect(bool destroy) {
     // remove mirror
     if (pMirrorOf) {
         pMirrorOf->mirrors.erase(std::find_if(pMirrorOf->mirrors.begin(), pMirrorOf->mirrors.end(), [&](const auto& other) { return other == this; }));
+
+        // unlock software for mirrored monitor
+        g_pPointerManager->unlockSoftwareForMonitor(pMirrorOf);
         pMirrorOf = nullptr;
     }
 
@@ -469,6 +473,9 @@ void CMonitor::setMirror(const std::string& mirrorOf) {
 
         if (pMirrorOf) {
             pMirrorOf->mirrors.erase(std::find_if(pMirrorOf->mirrors.begin(), pMirrorOf->mirrors.end(), [&](const auto& other) { return other == this; }));
+
+            // unlock software for mirrored monitor
+            g_pPointerManager->unlockSoftwareForMonitor(pMirrorOf);
         }
 
         pMirrorOf = nullptr;
@@ -538,6 +545,9 @@ void CMonitor::setMirror(const std::string& mirrorOf) {
         g_pCompositor->setActiveMonitor(g_pCompositor->m_vMonitors.front().get());
 
         g_pCompositor->sanityCheckWorkspaces();
+
+        // Software lock mirrored monitor
+        g_pPointerManager->lockSoftwareForMonitor(PMIRRORMON);
     }
 
     events.modeChanged.emit();

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -6,7 +6,7 @@
 #include "../devices/ITouch.hpp"
 #include "../protocols/LayerShell.hpp"
 #include "../protocols/PresentationTime.hpp"
-#include "managers/PointerManager.hpp"
+#include "../managers/PointerManager.hpp"
 #include <hyprutils/string/String.hpp>
 using namespace Hyprutils::String;
 

--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -164,12 +164,30 @@ void CPointerManager::unlockSoftwareAll() {
     updateCursorBackend();
 }
 
+void CPointerManager::lockSoftwareForMonitor(CMonitor* Monitor) {
+    for (auto& m : g_pCompositor->m_vMonitors) {
+        if (m->ID == Monitor->ID) {
+            lockSoftwareForMonitor(m);
+            return;
+        }
+    }
+}
+
 void CPointerManager::lockSoftwareForMonitor(SP<CMonitor> mon) {
     auto state = stateFor(mon);
     state->softwareLocks++;
 
     if (state->softwareLocks == 1)
         updateCursorBackend();
+}
+
+void CPointerManager::unlockSoftwareForMonitor(CMonitor* Monitor) {
+    for (auto& m : g_pCompositor->m_vMonitors) {
+        if (m->ID == Monitor->ID) {
+            unlockSoftwareForMonitor(m);
+            return;
+        }
+    }
 }
 
 void CPointerManager::unlockSoftwareForMonitor(SP<CMonitor> mon) {

--- a/src/managers/PointerManager.hpp
+++ b/src/managers/PointerManager.hpp
@@ -43,6 +43,8 @@ class CPointerManager {
 
     void lockSoftwareForMonitor(SP<CMonitor> pMonitor);
     void unlockSoftwareForMonitor(SP<CMonitor> pMonitor);
+    void lockSoftwareForMonitor(CMonitor* pMonitor);
+    void unlockSoftwareForMonitor(CMonitor* pMonitor);
     void lockSoftwareAll();
     void unlockSoftwareAll();
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Force software locks to monitors when they are being mirrored to another screen, so we can render the pointer properly in mirror monitors. Fixes #6455 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I'm incrementing the lock counter for each new mirror. Maybe we could just increment/decrement it once if mirror list isn't/is empty, but I found it more concise this way.

#### Is it ready for merging, or does it need work?
Ready.

