### PR TITLE
feat: [compositor, misc] ability to select previous workspace per monitor

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1648,8 +1648,7 @@ PHLWORKSPACE CCompositor::getWorkspaceByString(const std::string& str) {
     }
 
     try {
-        std::string name = "";
-        return getWorkspaceByID(getWorkspaceIDFromString(str, name));
+        return getWorkspaceByID(getWorkspaceIDNameFromString(str).id);
     } catch (std::exception& e) { Debug::log(ERR, "Error in getWorkspaceByString, invalid id"); }
 
     return nullptr;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1815,14 +1815,13 @@ std::optional<std::string> CConfigManager::handleMonitor(const std::string& comm
             newrule.vrr = std::stoi(ARGS[argno + 1]);
             argno++;
         } else if (ARGS[argno] == "workspace") {
-            std::string    name = "";
-            int            wsId = getWorkspaceIDFromString(ARGS[argno + 1], name);
+            const auto& [id, name] = getWorkspaceIDNameFromString(ARGS[argno + 1]);
 
             SWorkspaceRule wsRule;
             wsRule.monitor         = newrule.name;
             wsRule.workspaceString = ARGS[argno + 1];
+            wsRule.workspaceId     = id;
             wsRule.workspaceName   = name;
-            wsRule.workspaceId     = wsId;
 
             m_dWorkspaceRules.emplace_back(wsRule);
             argno++;
@@ -2370,11 +2369,11 @@ std::optional<std::string> CConfigManager::handleBlurLS(const std::string& comma
 
 std::optional<std::string> CConfigManager::handleWorkspaceRules(const std::string& command, const std::string& value) {
     // This can either be the monitor or the workspace identifier
-    const auto     FIRST_DELIM = value.find_first_of(',');
+    const auto FIRST_DELIM = value.find_first_of(',');
 
-    std::string    name        = "";
-    auto           first_ident = trim(value.substr(0, FIRST_DELIM));
-    int            id          = getWorkspaceIDFromString(first_ident, name);
+    auto       first_ident = trim(value.substr(0, FIRST_DELIM));
+
+    const auto& [id, name] = getWorkspaceIDNameFromString(first_ident);
 
     auto           rules = value.substr(FIRST_DELIM + 1);
     SWorkspaceRule wsRule;

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -57,6 +57,13 @@ void CWorkspace::init(PHLWORKSPACE self) {
     EMIT_HOOK_EVENT("createWorkspace", this);
 }
 
+SWorkspaceIDName CWorkspace::getPrevWorkspaceIDName(bool perMonitor) const {
+    if (perMonitor)
+        return m_sPrevWorkspacePerMonitor;
+
+    return m_sPrevWorkspace;
+}
+
 CWorkspace::~CWorkspace() {
     m_vRenderOffset.unregister();
 
@@ -196,7 +203,7 @@ PHLWINDOW CWorkspace::getLastFocusedWindow() {
 
 void CWorkspace::rememberPrevWorkspace(const PHLWORKSPACE& prev) {
     if (!prev) {
-        m_sPrevWorkspace.iID  = -1;
+        m_sPrevWorkspace.id   = -1;
         m_sPrevWorkspace.name = "";
         return;
     }
@@ -206,8 +213,13 @@ void CWorkspace::rememberPrevWorkspace(const PHLWORKSPACE& prev) {
         return;
     }
 
-    m_sPrevWorkspace.iID  = prev->m_iID;
+    m_sPrevWorkspace.id   = prev->m_iID;
     m_sPrevWorkspace.name = prev->m_szName;
+
+    if (prev->m_iMonitorID == m_iMonitorID) {
+        m_sPrevWorkspacePerMonitor.id   = prev->m_iID;
+        m_sPrevWorkspacePerMonitor.name = prev->m_szName;
+    }
 }
 
 std::string CWorkspace::getConfigName() {
@@ -228,9 +240,7 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
         return true;
 
     if (isNumber(selector)) {
-
-        std::string wsname = "";
-        int         wsid   = getWorkspaceIDFromString(selector, wsname);
+        const auto& [wsid, wsname] = getWorkspaceIDNameFromString(selector);
 
         if (wsid == WORKSPACE_INVALID)
             return false;

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include "../defines.hpp"
 #include "DesktopTypes.hpp"
+#include "helpers/MiscFunctions.hpp"
 
 enum eFullscreenMode : int8_t {
     FULLSCREEN_INVALID = -1,
@@ -25,17 +26,14 @@ class CWorkspace {
     int         m_iID        = -1;
     std::string m_szName     = "";
     uint64_t    m_iMonitorID = -1;
-    // Previous workspace ID is stored during a workspace change, allowing travel
+    // Previous workspace ID and name is stored during a workspace change, allowing travel
     // to the previous workspace.
-    struct SPrevWorkspaceData {
-        int         iID  = -1;
-        std::string name = "";
-    } m_sPrevWorkspace;
+    SWorkspaceIDName m_sPrevWorkspace, m_sPrevWorkspacePerMonitor;
 
-    bool            m_bHasFullscreenWindow = false;
-    eFullscreenMode m_efFullscreenMode     = FULLSCREEN_FULL;
+    bool             m_bHasFullscreenWindow = false;
+    eFullscreenMode  m_efFullscreenMode     = FULLSCREEN_FULL;
 
-    wl_array        m_wlrCoordinateArr;
+    wl_array         m_wlrCoordinateArr;
 
     // for animations
     CAnimatedVariable<Vector2D> m_vRenderOffset;
@@ -63,21 +61,23 @@ class CWorkspace {
     bool        m_bPersistent = false;
 
     // Inert: destroyed and invalid. If this is true, release the ptr you have.
-    bool        inert();
+    bool             inert();
 
-    void        startAnim(bool in, bool left, bool instant = false);
-    void        setActive(bool on);
+    void             startAnim(bool in, bool left, bool instant = false);
+    void             setActive(bool on);
 
-    void        moveToMonitor(const int&);
+    void             moveToMonitor(const int&);
 
-    PHLWINDOW   getLastFocusedWindow();
-    void        rememberPrevWorkspace(const PHLWORKSPACE& prevWorkspace);
+    PHLWINDOW        getLastFocusedWindow();
+    void             rememberPrevWorkspace(const PHLWORKSPACE& prevWorkspace);
 
-    std::string getConfigName();
+    std::string      getConfigName();
 
-    bool        matchesStaticSelector(const std::string& selector);
+    bool             matchesStaticSelector(const std::string& selector);
 
-    void        markInert();
+    void             markInert();
+
+    SWorkspaceIDName getPrevWorkspaceIDName(bool perMonitor) const;
 
   private:
     void                 init(PHLWORKSPACE self);

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -293,8 +293,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
         if (WORKSPACEARGS[WORKSPACEARGS.size() - 1].starts_with("silent"))
             workspaceSilent = true;
 
-        std::string requestedWorkspaceName;
-        const int   REQUESTEDWORKSPACEID = getWorkspaceIDFromString(WORKSPACEARGS.join(" ", 0, workspaceSilent ? WORKSPACEARGS.size() - 1 : 0), requestedWorkspaceName);
+        const auto& [REQUESTEDWORKSPACEID, requestedWorkspaceName] = getWorkspaceIDNameFromString(WORKSPACEARGS.join(" ", 0, workspaceSilent ? WORKSPACEARGS.size() - 1 : 0));
 
         if (REQUESTEDWORKSPACEID != WORKSPACE_INVALID) {
             auto pWorkspace = g_pCompositor->getWorkspaceByID(REQUESTEDWORKSPACEID);

--- a/src/helpers/MiscFunctions.hpp
+++ b/src/helpers/MiscFunctions.hpp
@@ -13,13 +13,18 @@ struct SCallstackFrameInfo {
     std::string desc;
 };
 
+struct SWorkspaceIDName {
+    int         id = -1;
+    std::string name;
+};
+
 std::string                      absolutePath(const std::string&, const std::string&);
 void                             addWLSignal(wl_signal*, wl_listener*, void* pOwner, const std::string& ownerString);
 void                             removeWLSignal(wl_listener*);
 std::string                      escapeJSONStrings(const std::string& str);
 bool                             isDirection(const std::string&);
 bool                             isDirection(const char&);
-int                              getWorkspaceIDFromString(const std::string&, std::string&);
+SWorkspaceIDName                 getWorkspaceIDNameFromString(const std::string&);
 std::optional<std::string>       cleanCmdForWorkspace(const std::string&, std::string);
 float                            vecToRectDistanceSquared(const Vector2D& vec, const Vector2D& p1, const Vector2D& p2);
 void                             logSystemInfo();

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -24,7 +24,8 @@
 
 #define STRVAL_EMPTY "[[EMPTY]]"
 
-#define WORKSPACE_INVALID -1L
+#define WORKSPACE_INVALID     -1L
+#define WORKSPACE_NOT_CHANGED -101
 
 #define LISTENER(name)                                                                                                                                                             \
     void               listener_##name(wl_listener*, void*);                                                                                                                       \

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1034,10 +1034,26 @@ void CKeybindManager::toggleActivePseudo(std::string args) {
         g_pLayoutManager->getCurrentLayout()->recalculateWindow(PWINDOW);
 }
 
-void CKeybindManager::changeworkspace(std::string args) {
-    int         workspaceToChangeTo = 0;
-    std::string workspaceName       = "";
+SWorkspaceIDName getWorkspaceToChangeFromArgs(std::string args, PHLWORKSPACE PCURRENTWORKSPACE) {
+    if (!args.starts_with("previous")) {
+        return getWorkspaceIDNameFromString(args);
+    }
 
+    const SWorkspaceIDName PPREVWS = PCURRENTWORKSPACE->getPrevWorkspaceIDName(args.contains("_per_monitor"));
+    // Do nothing if there's no previous workspace, otherwise switch to it.
+    if (PPREVWS.id == -1) {
+        Debug::log(LOG, "No previous workspace to change to");
+        return {WORKSPACE_NOT_CHANGED, ""};
+    }
+
+    const auto ID = PCURRENTWORKSPACE->m_iID;
+    if (const auto PWORKSPACETOCHANGETO = g_pCompositor->getWorkspaceByID(PPREVWS.id); PWORKSPACETOCHANGETO)
+        return {ID, PWORKSPACETOCHANGETO->m_szName};
+
+    return {ID, PPREVWS.name.empty() ? std::to_string(PPREVWS.id) : PPREVWS.name};
+}
+
+void CKeybindManager::changeworkspace(std::string args) {
     // Workspace_back_and_forth being enabled means that an attempt to switch to
     // the current workspace will instead switch to the previous.
     static auto PBACKANDFORTH         = CConfigValue<Hyprlang::INT>("binds:workspace_back_and_forth");
@@ -1050,43 +1066,31 @@ void CKeybindManager::changeworkspace(std::string args) {
         return;
 
     const auto PCURRENTWORKSPACE = PMONITOR->activeWorkspace;
-    const bool EXPLICITPREVIOUS  = args.starts_with("previous");
+    const bool EXPLICITPREVIOUS  = args.contains("previous");
 
-    if (args.starts_with("previous")) {
-        // Do nothing if there's no previous workspace, otherwise switch to it.
-        if (PCURRENTWORKSPACE->m_sPrevWorkspace.iID == -1) {
-            Debug::log(LOG, "No previous workspace to change to");
-            return;
-        } else {
-            workspaceToChangeTo = PCURRENTWORKSPACE->m_iID;
-
-            if (const auto PWORKSPACETOCHANGETO = g_pCompositor->getWorkspaceByID(PCURRENTWORKSPACE->m_sPrevWorkspace.iID); PWORKSPACETOCHANGETO)
-                workspaceName = PWORKSPACETOCHANGETO->m_szName;
-            else
-                workspaceName =
-                    PCURRENTWORKSPACE->m_sPrevWorkspace.name.empty() ? std::to_string(PCURRENTWORKSPACE->m_sPrevWorkspace.iID) : PCURRENTWORKSPACE->m_sPrevWorkspace.name;
-        }
-    } else {
-        workspaceToChangeTo = getWorkspaceIDFromString(args, workspaceName);
-    }
-
+    const auto& [workspaceToChangeTo, workspaceName] = getWorkspaceToChangeFromArgs(args, PCURRENTWORKSPACE);
     if (workspaceToChangeTo == WORKSPACE_INVALID) {
         Debug::log(ERR, "Error in changeworkspace, invalid value");
         return;
     }
 
-    const bool BISWORKSPACECURRENT = workspaceToChangeTo == PCURRENTWORKSPACE->m_iID;
+    if (workspaceToChangeTo == WORKSPACE_NOT_CHANGED) {
+        return;
+    }
 
-    if (BISWORKSPACECURRENT && (!(*PBACKANDFORTH || EXPLICITPREVIOUS) || PCURRENTWORKSPACE->m_sPrevWorkspace.iID == -1))
+    const auto PREVWS = PCURRENTWORKSPACE->getPrevWorkspaceIDName(args.contains("_per_monitor"));
+
+    const bool BISWORKSPACECURRENT = workspaceToChangeTo == PCURRENTWORKSPACE->m_iID;
+    if (BISWORKSPACECURRENT && (!(*PBACKANDFORTH || EXPLICITPREVIOUS) || PREVWS.id == -1))
         return;
 
     g_pInputManager->unconstrainMouse();
     g_pInputManager->m_bEmptyFocusCursorSet = false;
 
-    auto pWorkspaceToChangeTo = g_pCompositor->getWorkspaceByID(BISWORKSPACECURRENT ? PCURRENTWORKSPACE->m_sPrevWorkspace.iID : workspaceToChangeTo);
+    auto pWorkspaceToChangeTo = g_pCompositor->getWorkspaceByID(BISWORKSPACECURRENT ? PREVWS.id : workspaceToChangeTo);
     if (!pWorkspaceToChangeTo)
-        pWorkspaceToChangeTo = g_pCompositor->createNewWorkspace(BISWORKSPACECURRENT ? PCURRENTWORKSPACE->m_sPrevWorkspace.iID : workspaceToChangeTo, PMONITOR->ID,
-                                                                 BISWORKSPACECURRENT ? PCURRENTWORKSPACE->m_sPrevWorkspace.name : workspaceName);
+        pWorkspaceToChangeTo =
+            g_pCompositor->createNewWorkspace(BISWORKSPACECURRENT ? PREVWS.id : workspaceToChangeTo, PMONITOR->ID, BISWORKSPACECURRENT ? PREVWS.name : workspaceName);
 
     if (!BISWORKSPACECURRENT && pWorkspaceToChangeTo->m_bIsSpecialWorkspace) {
         PMONITOR->setSpecialWorkspace(pWorkspaceToChangeTo);
@@ -1169,10 +1173,7 @@ void CKeybindManager::moveActiveToWorkspace(std::string args) {
     if (!PWINDOW)
         return;
 
-    // hack
-    std::string workspaceName;
-    const auto  WORKSPACEID = getWorkspaceIDFromString(args, workspaceName);
-
+    const auto& [WORKSPACEID, workspaceName] = getWorkspaceIDNameFromString(args);
     if (WORKSPACEID == WORKSPACE_INVALID) {
         Debug::log(LOG, "Invalid workspace in moveActiveToWorkspace");
         return;
@@ -1233,10 +1234,7 @@ void CKeybindManager::moveActiveToWorkspaceSilent(std::string args) {
     if (!PWINDOW)
         return;
 
-    std::string workspaceName = "";
-
-    const int   WORKSPACEID = getWorkspaceIDFromString(args, workspaceName);
-
+    const auto& [WORKSPACEID, workspaceName] = getWorkspaceIDNameFromString(args);
     if (WORKSPACEID == WORKSPACE_INVALID) {
         Debug::log(ERR, "Error in moveActiveToWorkspaceSilent, invalid value");
         return;
@@ -1702,8 +1700,7 @@ void CKeybindManager::moveWorkspaceToMonitor(std::string args) {
         return;
     }
 
-    std::string workspaceName;
-    const int   WORKSPACEID = getWorkspaceIDFromString(workspace, workspaceName);
+    const int WORKSPACEID = getWorkspaceIDNameFromString(workspace).id;
 
     if (WORKSPACEID == WORKSPACE_INVALID) {
         Debug::log(ERR, "moveWorkspaceToMonitor invalid workspace!");
@@ -1721,9 +1718,7 @@ void CKeybindManager::moveWorkspaceToMonitor(std::string args) {
 }
 
 void CKeybindManager::focusWorkspaceOnCurrentMonitor(std::string args) {
-    std::string workspaceName;
-    int         workspaceID = getWorkspaceIDFromString(args, workspaceName);
-
+    int workspaceID = getWorkspaceIDNameFromString(args).id;
     if (workspaceID == WORKSPACE_INVALID) {
         Debug::log(ERR, "focusWorkspaceOnCurrentMonitor invalid workspace!");
         return;
@@ -1746,14 +1741,13 @@ void CKeybindManager::focusWorkspaceOnCurrentMonitor(std::string args) {
     }
 
     static auto PBACKANDFORTH = CConfigValue<Hyprlang::INT>("binds:workspace_back_and_forth");
+    const auto  PREVWS        = pWorkspace->getPrevWorkspaceIDName(false);
 
-    if (*PBACKANDFORTH && PCURRMONITOR->activeWorkspaceID() == workspaceID && pWorkspace->m_sPrevWorkspace.iID != -1) {
-        const int  PREVWORKSPACEID   = pWorkspace->m_sPrevWorkspace.iID;
-        const auto PREVWORKSPACENAME = pWorkspace->m_sPrevWorkspace.name;
+    if (*PBACKANDFORTH && PCURRMONITOR->activeWorkspaceID() == workspaceID && PREVWS.id != -1) {
         // Workspace to focus is previous workspace
-        pWorkspace = g_pCompositor->getWorkspaceByID(PREVWORKSPACEID);
+        pWorkspace = g_pCompositor->getWorkspaceByID(PREVWS.id);
         if (!pWorkspace)
-            pWorkspace = g_pCompositor->createNewWorkspace(PREVWORKSPACEID, PCURRMONITOR->ID, PREVWORKSPACENAME);
+            pWorkspace = g_pCompositor->createNewWorkspace(PREVWS.id, PCURRMONITOR->ID, PREVWS.name);
 
         workspaceID = pWorkspace->m_iID;
     }
@@ -1776,9 +1770,7 @@ void CKeybindManager::focusWorkspaceOnCurrentMonitor(std::string args) {
 }
 
 void CKeybindManager::toggleSpecialWorkspace(std::string args) {
-    std::string workspaceName = "";
-    int         workspaceID   = getWorkspaceIDFromString("special:" + args, workspaceName);
-
+    const auto& [workspaceID, workspaceName] = getWorkspaceIDNameFromString("special:" + args);
     if (workspaceID == WORKSPACE_INVALID || !g_pCompositor->isWorkspaceSpecial(workspaceID)) {
         Debug::log(ERR, "Invalid workspace passed to special");
         return;

--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -63,10 +63,9 @@ void CInputManager::endWorkspaceSwipe() {
         m_sActiveSwipe.pWorkspaceBegin->m_vRenderOffset.getConfig()->pValues->internalStyle.starts_with("slidefadevert");
 
     // commit
-    std::string wsname           = "";
-    auto        workspaceIDLeft  = getWorkspaceIDFromString((*PSWIPEUSER ? "r-1" : "m-1"), wsname);
-    auto        workspaceIDRight = getWorkspaceIDFromString((*PSWIPEUSER ? "r+1" : "m+1"), wsname);
-    const auto  SWIPEDISTANCE    = std::clamp(*PSWIPEDIST, (int64_t)1LL, (int64_t)UINT32_MAX);
+    auto       workspaceIDLeft  = getWorkspaceIDNameFromString((*PSWIPEUSER ? "r-1" : "m-1")).id;
+    auto       workspaceIDRight = getWorkspaceIDNameFromString((*PSWIPEUSER ? "r+1" : "m+1")).id;
+    const auto SWIPEDISTANCE    = std::clamp(*PSWIPEDIST, (int64_t)1LL, (int64_t)UINT32_MAX);
 
     // If we've been swiping off the right end with PSWIPENEW enabled, there is
     // no workspace there yet, and we need to choose an ID for a new one now.
@@ -232,9 +231,8 @@ void CInputManager::updateWorkspaceSwipe(double delta) {
     m_sActiveSwipe.avgSpeed = (m_sActiveSwipe.avgSpeed * m_sActiveSwipe.speedPoints + abs(d)) / (m_sActiveSwipe.speedPoints + 1);
     m_sActiveSwipe.speedPoints++;
 
-    std::string wsname           = "";
-    auto        workspaceIDLeft  = getWorkspaceIDFromString((*PSWIPEUSER ? "r-1" : "m-1"), wsname);
-    auto        workspaceIDRight = getWorkspaceIDFromString((*PSWIPEUSER ? "r+1" : "m+1"), wsname);
+    auto workspaceIDLeft  = getWorkspaceIDNameFromString((*PSWIPEUSER ? "r-1" : "m-1")).id;
+    auto workspaceIDRight = getWorkspaceIDNameFromString((*PSWIPEUSER ? "r+1" : "m+1")).id;
 
     if ((workspaceIDLeft == WORKSPACE_INVALID || workspaceIDRight == WORKSPACE_INVALID || workspaceIDLeft == m_sActiveSwipe.pWorkspaceBegin->m_iID) && !*PSWIPENEW) {
         m_sActiveSwipe.pWorkspaceBegin = nullptr; // invalidate the swipe


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
added `previous_per_monitor` parameter that selects the previously focused workspace on the currently focused monitor
https://github.com/hyprwm/Hyprland/issues/6545

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
ready


