### PR TITLE
nix: fix build by deferring submodule fetching

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,4 +1,5 @@
 {
+  self,
   lib,
   stdenv,
   pkg-config,
@@ -68,7 +69,16 @@ assert lib.assertMsg (!hidpiXWayland) "The option `hidpiXWayland` has been remov
         baseName = baseNameOf (toString name);
       in
         ! (lib.hasSuffix ".nix" baseName);
-      src = lib.cleanSource ../.;
+      src = lib.cleanSource (
+        if self ? rev
+        then builtins.fetchGit {
+          url = "https://github.com/hyprwm/Hyprland";
+          inherit (self) rev;
+          submodules = true;
+          allRefs = true;
+        }
+        else ../.
+      );
     };
 
     postPatch = ''

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -36,6 +36,7 @@ in {
         version = "${props.version}+date=${date}_${self.shortRev or "dirty"}";
         commit = self.rev or "";
         inherit date;
+        inherit (inputs) self;
       };
       hyprland-unwrapped = final.hyprland.override {wrapRuntimeDeps = false;};
       hyprland-debug = final.hyprland.override {debug = true;};


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Currently, it isn't possible to fetch submodules on `inputs.self` of a Nix flake. As a workaround, use `builtins.fetchGit` with `self.rev` of the current checkout to include submodules.

This implementation defers submodule fetching to build time instead of before the flake evaluation begins, which would be the case if it were possible to specify submodule fetching in the `inputs` of `self` as with other inputs. This way, when interacting with the other outputs of the flake, the cost of fetching submodules is avoided.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Unfortunately, since the flake.lock format does not encode information about a canonical remote location for `inputs.self`, the url must be hardcoded.

#### Is it ready for merging, or does it need work?

I believe this is likely the best workaround, currently, to fix the  build. We could alternately use one of the nixpkgs fetchers to make the  source an FOD, however the benefit of the builtin is that we only need  specify a git `rev` as the integrity hash.