### PR TITLE
add virtual destructor to surfacerole to avoid undefined behaviour

### DIFF
--- a/src/managers/CursorManager.hpp
+++ b/src/managers/CursorManager.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include "../includes.hpp"
 #include "../helpers/math/Math.hpp"
+#include "../helpers/memory/Memory.hpp"
 
 struct wlr_buffer;
 struct wlr_xcursor_manager;

--- a/src/protocols/types/SurfaceRole.hpp
+++ b/src/protocols/types/SurfaceRole.hpp
@@ -11,4 +11,5 @@ enum eSurfaceRole {
 class ISurfaceRole {
   public:
     virtual eSurfaceRole role() = 0;
+    virtual ~ISurfaceRole()     = default;
 };

--- a/src/xwayland/XSurface.hpp
+++ b/src/xwayland/XSurface.hpp
@@ -2,6 +2,7 @@
 
 #include "../helpers/WLListener.hpp"
 #include "../helpers/signal/Signal.hpp"
+#include "../helpers/memory/Memory.hpp"
 #include "../helpers/math/Math.hpp"
 #include <vector>
 

--- a/src/xwayland/XWM.hpp
+++ b/src/xwayland/XWM.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../helpers/signal/Signal.hpp"
+#include "../helpers/memory/Memory.hpp"
 #include "../helpers/WLListener.hpp"
 #include "../macros.hpp"
 

--- a/src/xwayland/XWayland.hpp
+++ b/src/xwayland/XWayland.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include "../helpers/signal/Signal.hpp"
+#include "../helpers/memory/Memory.hpp"
 
 #include "XSurface.hpp"
 
@@ -29,10 +30,8 @@ class CXWayland {
     } events;
 };
 
-inline std::unique_ptr<CXWayland> g_pXWayland;
+inline std::unique_ptr<CXWayland>                g_pXWayland;
 
-#define HYPRATOM(name)                                                                                                                                                             \
-    { name, 0 }
 inline std::unordered_map<std::string, uint32_t> HYPRATOMS = {
     HYPRATOM("_NET_SUPPORTED"),
     HYPRATOM("_NET_SUPPORTING_WM_CHECK"),


### PR DESCRIPTION
all classes that will be derived from should have a virtual destructor otherwise deleting an instance via pointer to a base class is undefined behaviour, CLayerShellResource/CXDGSurfaceResource hits this with std::default_delete in the new sharedptr implentation.


