### PR TITLE
Pointer constraints: Lock surface region when region is empty

### DIFF
--- a/src/protocols/PointerConstraints.cpp
+++ b/src/protocols/PointerConstraints.cpp
@@ -165,8 +165,8 @@ SP<CWLSurface> CPointerConstraint::owner() {
 }
 
 CRegion CPointerConstraint::logicConstraintRegion() {
-    CRegion    rg            = region;
-    const auto SURFBOX       = pHLSurface->getSurfaceBoxGlobal();
+    CRegion    rg      = region;
+    const auto SURFBOX = pHLSurface->getSurfaceBoxGlobal();
 
     // if region wasn't set in pointer-constraints request take surface region
     if (rg.empty() && SURFBOX.has_value()) {

--- a/src/protocols/PointerConstraints.cpp
+++ b/src/protocols/PointerConstraints.cpp
@@ -167,6 +167,13 @@ SP<CWLSurface> CPointerConstraint::owner() {
 CRegion CPointerConstraint::logicConstraintRegion() {
     CRegion    rg            = region;
     const auto SURFBOX       = pHLSurface->getSurfaceBoxGlobal();
+
+    // if region wasn't set in pointer-constraints request take surface region
+    if (rg.empty() && SURFBOX.has_value()) {
+        rg.set(SURFBOX.value());
+        return rg;
+    }
+
     const auto CONSTRAINTPOS = SURFBOX.has_value() ? SURFBOX->pos() : Vector2D{};
     rg.translate(CONSTRAINTPOS);
     return rg;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes https://github.com/hyprwm/Hyprland/issues/6292 and https://github.com/hyprwm/Hyprland/issues/5900
Currently Hyprland locks mouse cursor based on provided region and it does not work when it's not provided. The PR fallbacks to surface region in such cases.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This is my first PR, I am not familiar with the codebase and wayland protocol


#### Is it ready for merging, or does it need work?
Ready

