### PR TITLE
systemd,dbus: import PATH XDG_DATA_DIRS variables into systemd and dbus session

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -311,10 +311,10 @@ void CCompositor::cleanEnvironment() {
     if (m_sWLRSession) {
         const auto CMD =
 #ifdef USES_SYSTEMD
-            "systemctl --user unset-environment DISPLAY WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP QT_QPA_PLATFORMTHEME && hash "
+            "systemctl --user unset-environment DISPLAY WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP QT_QPA_PLATFORMTHEME PATH XDG_DATA_DIRS && hash "
             "dbus-update-activation-environment 2>/dev/null && "
 #endif
-            "dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP HYPRLAND_INSTANCE_SIGNATURE QT_QPA_PLATFORMTHEME";
+            "dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP HYPRLAND_INSTANCE_SIGNATURE QT_QPA_PLATFORMTHEME PATH XDG_DATA_DIRS";
         g_pKeybindManager->spawn(CMD);
     }
 }
@@ -569,10 +569,10 @@ void CCompositor::startCompositor() {
     if (m_sWLRSession /* Session-less Hyprland usually means a nest, don't update the env in that case */) {
         const auto CMD =
 #ifdef USES_SYSTEMD
-            "systemctl --user import-environment DISPLAY WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP QT_QPA_PLATFORMTHEME && hash "
+            "systemctl --user import-environment DISPLAY WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP QT_QPA_PLATFORMTHEME PATH XDG_DATA_DIRS && hash "
             "dbus-update-activation-environment 2>/dev/null && "
 #endif
-            "dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP HYPRLAND_INSTANCE_SIGNATURE QT_QPA_PLATFORMTHEME";
+            "dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP HYPRLAND_INSTANCE_SIGNATURE QT_QPA_PLATFORMTHEME PATH XDG_DATA_DIRS";
         g_pKeybindManager->spawn(CMD);
     }
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1282,10 +1282,10 @@ void CConfigManager::dispatchExecOnce() {
     if (g_pCompositor->m_sWLRSession)
         handleRawExec("",
 #ifdef USES_SYSTEMD
-                      "systemctl --user import-environment DISPLAY WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP QT_QPA_PLATFORMTHEME && hash "
+                      "systemctl --user import-environment DISPLAY WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP QT_QPA_PLATFORMTHEME PATH XDG_DATA_DIRS && hash "
                       "dbus-update-activation-environment 2>/dev/null && "
 #endif
-                      "dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP HYPRLAND_INSTANCE_SIGNATURE QT_QPA_PLATFORMTHEME");
+                      "dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP HYPRLAND_INSTANCE_SIGNATURE QT_QPA_PLATFORMTHEME PATH XDG_DATA_DIRS");
 
     firstExecDispatched = true;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

When opening links from a browser that would otherwise open in another app present in the system, it fails to find the app. This is because PATH is not imported into systemd/dbus.

We are currently using a [workaround in NixOS](https://github.com/NixOS/nixpkgs/blob/d603719ec6e294f034936c0d0dc06f689d91b6c3/nixos/modules/programs/wayland/hyprland.nix#L66) to explicitly define the systemd environment PATH, but ideally it should be set by the Window manager/DE at login.

An open issue highlighted this for the past one year #2800 and several threads (ie. [on discourse](https://discourse.nixos.org/t/nautilus-not-working-properly-due-to-missing-path-in-dbus/38824)) on the internet have popped up asking the user to manually import PATH. Lets not hold this any longer and let this issue die in peace.   

In addition to `PATH`, `XDG_DATA_DIRS` should be imported as well, due to it containing useful things like desktop files.

This issue affects flatpak apps as well.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This is backwards compatible.

#### Is it ready for merging, or does it need work?

Ready. I am using the [patch on NixOS](https://github.com/JohnRTitor/nix-conf/commit/04c0d2b6feb2aaecfa4db0ca2e9658b47d394e88) and it works.
