### PR TITLE
keybinds: fix mouse pass

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2079,7 +2079,7 @@ void CKeybindManager::pass(std::string regexp) {
     if (g_pKeybindManager->m_uLastCode != 0)
         g_pSeatManager->setKeyboardFocus(LASTSRF);
     else
-        g_pSeatManager->setPointerFocus(PWINDOW->m_pWLSurface->resource(), SL);
+        g_pSeatManager->setPointerFocus(LASTSRF, SL);
 }
 
 void CKeybindManager::sendshortcut(std::string args) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2024,8 +2024,9 @@ void CKeybindManager::pass(std::string regexp) {
         return;
     }
 
-    const auto XWTOXW  = PWINDOW->m_bIsX11 && g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->m_bIsX11;
-    const auto LASTSRF = g_pCompositor->m_pLastFocus.lock();
+    const auto XWTOXW        = PWINDOW->m_bIsX11 && g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->m_bIsX11;
+    const auto LASTMOUSESURF = g_pSeatManager->state.pointerFocus.lock();
+    const auto LASTKBSURF    = g_pSeatManager->state.keyboardFocus.lock();
 
     // pass all mf shit
     if (!XWTOXW) {
@@ -2077,9 +2078,9 @@ void CKeybindManager::pass(std::string regexp) {
     const auto SL = PWINDOW->m_vRealPosition.goal() - g_pInputManager->getMouseCoordsInternal();
 
     if (g_pKeybindManager->m_uLastCode != 0)
-        g_pSeatManager->setKeyboardFocus(LASTSRF);
+        g_pSeatManager->setKeyboardFocus(LASTKBSURF);
     else
-        g_pSeatManager->setPointerFocus(LASTSRF, SL);
+        g_pSeatManager->setPointerFocus(LASTMOUSESURF, SL);
 }
 
 void CKeybindManager::sendshortcut(std::string args) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes mouse pass not refocusing active Wayland surface when passing to XWayland surface. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Couldn't find any reason for not using last surface for the mouse in old commits. Maybe I missed something I don't know about? Doesn't introduce any bugs from my testing.

#### Is it ready for merging, or does it need work?
Ready for merging

