### PR TITLE
sessionLock: focus lock on creation based on mouse position

### DIFF
--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -78,6 +78,7 @@ void CSessionLockManager::onNewSessionLock(SP<CSessionLock> pLock) {
     });
 
     pLock->sendLocked();
+    g_pCompositor->focusSurface(nullptr);
 }
 
 bool CSessionLockManager::isSessionLocked() {

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -10,7 +10,7 @@ SSessionLockSurface::SSessionLockSurface(SP<CSessionLockSurface> surface_) : sur
     listeners.map = surface_->events.map.registerListener([this](std::any data) {
         mapped = true;
 
-        g_pCompositor->focusSurface(surface->surface());
+        g_pInputManager->simulateMouseMovement();
 
         const auto PMONITOR = g_pCompositor->getMonitorFromID(iMonitorID);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Causes created lock surfaces to be focused only if they would be focused by mouse movement. This makes it so on lock, the focused surface is the one the mouse is on instead of the last surface created by the locker.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?


