### PR TITLE
pointer-constraints: keep constraint alive until actual destruction

### DIFF
--- a/src/protocols/PointerConstraints.cpp
+++ b/src/protocols/PointerConstraints.cpp
@@ -112,6 +112,7 @@ void CPointerConstraint::deactivate() {
 
     active = false;
 
+    /* Requires additional lifetime implementations
     if (lifetime == ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_ONESHOT) {
         dead = true;
         // remove from inputmgr
@@ -120,6 +121,7 @@ void CPointerConstraint::deactivate() {
             return !SHP || SHP.get() == this;
         });
     }
+    */
 }
 
 void CPointerConstraint::activate() {

--- a/src/protocols/PointerConstraints.cpp
+++ b/src/protocols/PointerConstraints.cpp
@@ -112,7 +112,6 @@ void CPointerConstraint::deactivate() {
 
     active = false;
 
-    /* Requires additional lifetime implementations
     if (lifetime == ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_ONESHOT) {
         dead = true;
         // remove from inputmgr
@@ -121,7 +120,6 @@ void CPointerConstraint::deactivate() {
             return !SHP || SHP.get() == this;
         });
     }
-    */
 }
 
 void CPointerConstraint::activate() {

--- a/src/protocols/PointerConstraints.hpp
+++ b/src/protocols/PointerConstraints.hpp
@@ -46,7 +46,7 @@ class CPointerConstraint {
     bool                            active              = false;
     bool                            locked              = false;
     bool                            dead                = false;
-    zwpPointerConstraintsV1Lifetime lifetime            = ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_ONESHOT;
+    zwpPointerConstraintsV1Lifetime lifetime            = ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_PERSISTENT;
 
     void                            sharedConstructions();
     void                            onSetRegion(wl_resource* region);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Current constraint deactivation kills the constraint even if it tries to reactivate due to lifetime check always being true. Removing this fixes refocusing of windows not actually restarting constraint, requiring a recreation of the constraints by the program.
- Ex: Minecraft will not recreate constraint until menu is opened in game, so swapping to another window and back rapidly will kill the constraint without recreation, leaving pointer to roam free.

Possible fix for #5900 but can not recreate issue myself to test.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No problems with usage as proper destruction gets called anyways later when actually necessary. Perhaps a better option is to change the default lifetime of the pointer constraint, but I'm not too knowledgeable the implications of that.

#### Is it ready for merging, or does it need work?
Ready for merging

