### PR TITLE
Fix `listener_sessionActive` to handle an event correctly when the session get inactivated

### DIFF
--- a/src/events/Misc.cpp
+++ b/src/events/Misc.cpp
@@ -30,14 +30,27 @@ void Events::listener_RendererDestroy(wl_listener* listener, void* data) {
 }
 
 void Events::listener_sessionActive(wl_listener* listener, void* data) {
-    Debug::log(LOG, "Session got activated!");
+    if (g_pCompositor->m_sWLRSession->active) {
+        Debug::log(LOG, "Session got activated!");
 
-    g_pCompositor->m_bSessionActive = true;
+        g_pCompositor->m_bSessionActive = true;
 
-    for (auto& m : g_pCompositor->m_vMonitors) {
-        g_pCompositor->scheduleFrameForMonitor(m.get());
-        g_pHyprRenderer->applyMonitorRule(m.get(), &m->activeMonitorRule, true);
+        for (auto& m : g_pCompositor->m_vMonitors) {
+            g_pCompositor->scheduleFrameForMonitor(m.get());
+            g_pHyprRenderer->applyMonitorRule(m.get(), &m->activeMonitorRule, true);
+        }
+
+        g_pConfigManager->m_bWantsMonitorReload = true;
+    } else {
+        Debug::log(LOG, "Session got inactivated!");
+
+        g_pCompositor->m_bSessionActive = false;
+
+        for (auto& m : g_pCompositor->m_vMonitors) {
+            m->noFrameSchedule = true;
+            m->framesToSkip    = 1;
+        }
+
+        Debug::log(LOG, "Destroyed all render data, frames to skip for each: 2");
     }
-
-    g_pConfigManager->m_bWantsMonitorReload = true;
 }

--- a/src/events/Misc.cpp
+++ b/src/events/Misc.cpp
@@ -50,7 +50,5 @@ void Events::listener_sessionActive(wl_listener* listener, void* data) {
             m->noFrameSchedule = true;
             m->framesToSkip    = 1;
         }
-
-        Debug::log(LOG, "Destroyed all render data, frames to skip for each: 2");
     }
 }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -810,18 +810,7 @@ bool CKeybindManager::handleVT(xkb_keysym_t keysym) {
 
         Debug::log(LOG, "Switching from VT {} to VT {}", ttynum, TTY);
 
-        if (!wlr_session_change_vt(g_pCompositor->m_sWLRSession, TTY))
-            return true; // probably same session
-
-        g_pCompositor->m_bSessionActive = false;
-
-        for (auto& m : g_pCompositor->m_vMonitors) {
-            m->noFrameSchedule = true;
-            m->framesToSkip    = 1;
-        }
-
-        Debug::log(LOG, "Switched to VT {}, destroyed all render data, frames to skip for each: 2", TTY);
-
+        wlr_session_change_vt(g_pCompositor->m_sWLRSession, TTY);
         return true;
     }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

I found that Hyprland handles `m_sWLRSession->events.active` signal by `listener_sessionActive`.

https://github.com/hyprwm/Hyprland/blob/b7f42a1e88a5b6c9d2dbdba31e0f35f6a02461e7/src/Compositor.cpp#L285

https://github.com/hyprwm/Hyprland/blob/b7f42a1e88a5b6c9d2dbdba31e0f35f6a02461e7/src/events/Misc.cpp#L32-L43

`listener_sessionActive` always does an activation process.

But I think `m_sWLRSession->events.active` is emitted whether the session get activated or inactivated.

https://github.com/hyprwm/wlroots-hyprland/blob/422207dbcf0949e28042403edab539159282885e/backend/session/session.c#L24-L35

That's why I made the following changes:

- Check `m_sWLRSession->active` in `listener_sessionActive`.
- Move the code for switching VTs into `listener_sessionActive`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I'm not sure that the second change (the code for VTs) works correctly.

#### Is it ready for merging, or does it need work?

It is ready.