### PR TITLE
Fix #6279: prevent sending keymap or repeat info events by keyboards without keyboard capability

### DIFF
--- a/src/protocols/core/Seat.cpp
+++ b/src/protocols/core/Seat.cpp
@@ -2,6 +2,7 @@
 #include "Compositor.hpp"
 #include "DataDevice.hpp"
 #include "../../devices/IKeyboard.hpp"
+#include "../../devices/IHID.hpp"
 #include "../../managers/SeatManager.hpp"
 #include "../../config/ConfigValue.hpp"
 #include <algorithm>
@@ -451,12 +452,20 @@ void CWLSeatProtocol::updateCapabilities(uint32_t caps) {
 }
 
 void CWLSeatProtocol::updateKeymap() {
+    if (!(currentCaps & eHIDCapabilityType::HID_INPUT_CAPABILITY_KEYBOARD)) {
+        return;
+    }
+
     for (auto& k : m_vKeyboards) {
         k->sendKeymap(g_pSeatManager->keyboard.lock());
     }
 }
 
 void CWLSeatProtocol::updateRepeatInfo(uint32_t rate, uint32_t delayMs) {
+    if (!(currentCaps & eHIDCapabilityType::HID_INPUT_CAPABILITY_KEYBOARD)) {
+        return;
+    }
+
     for (auto& k : m_vKeyboards) {
         k->repeatInfo(rate, delayMs);
     }

--- a/src/protocols/core/Seat.cpp
+++ b/src/protocols/core/Seat.cpp
@@ -452,9 +452,8 @@ void CWLSeatProtocol::updateCapabilities(uint32_t caps) {
 }
 
 void CWLSeatProtocol::updateKeymap() {
-    if (!(currentCaps & eHIDCapabilityType::HID_INPUT_CAPABILITY_KEYBOARD)) {
+    if (!(currentCaps & eHIDCapabilityType::HID_INPUT_CAPABILITY_KEYBOARD))
         return;
-    }
 
     for (auto& k : m_vKeyboards) {
         k->sendKeymap(g_pSeatManager->keyboard.lock());
@@ -462,9 +461,8 @@ void CWLSeatProtocol::updateKeymap() {
 }
 
 void CWLSeatProtocol::updateRepeatInfo(uint32_t rate, uint32_t delayMs) {
-    if (!(currentCaps & eHIDCapabilityType::HID_INPUT_CAPABILITY_KEYBOARD)) {
+    if (!(currentCaps & eHIDCapabilityType::HID_INPUT_CAPABILITY_KEYBOARD))
         return;
-    }
 
     for (auto& k : m_vKeyboards) {
         k->repeatInfo(rate, delayMs);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This PR fixes a part of #6279, crashing of some programs.
Since this bug is caused by keyboards without keyboard capability sending keymap events or repeat info events, I have made changes to prevent it.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

It may be an issue that such keyboards exist.

#### Is it ready for merging, or does it need work?

It is ready.
