### PR TITLE
fix a few ubsan issues reported at exit of hyprland

### DIFF
--- a/src/helpers/Watchdog.cpp
+++ b/src/helpers/Watchdog.cpp
@@ -7,7 +7,9 @@ CWatchdog::~CWatchdog() {
     m_bExitThread = true;
     m_bNotified   = true;
     m_cvWatchdogCondition.notify_all();
-    m_pWatchdog.reset();
+
+    if (m_pWatchdog && m_pWatchdog->joinable())
+        m_pWatchdog->join();
 }
 
 CWatchdog::CWatchdog() {
@@ -33,8 +35,6 @@ CWatchdog::CWatchdog() {
             m_bNotified = false;
         }
     });
-
-    m_pWatchdog->detach();
 }
 
 void CWatchdog::startWatching() {

--- a/src/render/Renderbuffer.cpp
+++ b/src/render/Renderbuffer.cpp
@@ -6,7 +6,7 @@
 #include <dlfcn.h>
 
 CRenderbuffer::~CRenderbuffer() {
-    if (!g_pCompositor)
+    if (!g_pCompositor || g_pCompositor->m_bIsShuttingDown || !g_pHyprRenderer)
         return;
 
     g_pHyprRenderer->makeEGLCurrent();

--- a/src/render/Texture.cpp
+++ b/src/render/Texture.cpp
@@ -9,7 +9,7 @@ CTexture::CTexture() {
 }
 
 CTexture::~CTexture() {
-    if (m_bNonOwning)
+    if (m_bNonOwning || !g_pCompositor || g_pCompositor->m_bIsShuttingDown || !g_pHyprRenderer)
         return;
 
     g_pHyprRenderer->makeEGLCurrent();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
dont detach the cwatchdog and cause it to have a race condition where it eventually runs into heap use after free on destruction.

add checks in renderbuffer and texture if the compositor is shutting down and if hypr renderer is destroyed already which happends on destruction of the compositor, causing member call on null pointer.  `g_pHyprRenderer->makeEGLCurrent();`


