### PR TITLE
inputmgr ensure we dont divide by zero

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -798,7 +798,7 @@ void CInputManager::onMouseWheel(IPointer::SAxisEvent e) {
             }
         }
     }
-    double deltaDiscrete = factor * e.deltaDiscrete / std::abs(e.deltaDiscrete);
+    double deltaDiscrete = (e.deltaDiscrete != 0) ? (factor * e.deltaDiscrete / std::abs(e.deltaDiscrete)) : 0;
     g_pSeatManager->sendPointerAxis(e.timeMs, e.axis, factor * e.delta, deltaDiscrete > 0 ? std::ceil(deltaDiscrete) : std::floor(deltaDiscrete),
                                     std::round(factor * e.deltaDiscrete), e.source, WL_POINTER_AXIS_RELATIVE_DIRECTION_IDENTICAL);
 }


### PR DESCRIPTION
some weird combination of scrolling/nesting hyprland and closing a window i managed to divide by zero here, reported by ubsan. add a check to ensure we dont hit UB.

report from ubsan when it triggered.

```
/home/tom/dev/Hyprland/src/managers/input/InputManager.cpp:802:73: runtime error: -nan is outside the range of representable values of type 'int'
    #0 0x55555a764b94 in CInputManager::onMouseWheel(IPointer::SAxisEvent) /home/tom/dev/Hyprland/src/managers/input/InputManager.cpp:802:73
    #1 0x55555a60222e in CPointerManager::attachPointer(Hyprutils::Memory::CSharedPointer<IPointer>)::$_4::operator()(std::any) const /home/tom/dev/Hyprland/src/managers/PointerManager.cpp:846:26
    #2 0x55555a602011 in void std::__invoke_impl<void, CPointerManager::attachPointer(Hyprutils::Memory::CSharedPointer<IPointer>)::$_4&, std::any>(std::__invoke_other, CPointerManager::attachPointer(Hyprutils::Memory::CSharedPointer<IPointer>)::$_4&, std::any&&) /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/invoke.h:61:14
    #3 0x55555a601dec in std::enable_if<is_invocable_r_v<void, CPointerManager::attachPointer(Hyprutils::Memory::CSharedPointer<IPointer>)::$_4&, std::any>, void>::type std::__invoke_r<void, CPointerManager::attachPointer(Hyprutils::Memory::CSharedPointer<IPointer>)::$_4&, std::any>(CPointerManager::attachPointer(Hyprutils::Memory::CSharedPointer<IPointer>)::$_4&, std::any&&) /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/invoke.h:111:2
    #4 0x55555a601a38 in std::_Function_handler<void (std::any), CPointerManager::attachPointer(Hyprutils::Memory::CSharedPointer<IPointer>)::$_4>::_M_invoke(std::_Any_data const&, std::any&&) /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/std_function.h:290:9
    #5 0x7ffff74c600a in Hyprutils::Signal::CSignalListener::emit(std::any) (/usr/lib64/libhyprutils.so.0+0x600a)
    #6 0x7ffff74c65a3 in Hyprutils::Signal::CSignal::emit(std::any) (/usr/lib64/libhyprutils.so.0+0x65a3)
```

ubsan hints at the line below, but the "-nan" is outside of range seems to me to suggest its a division by zero.
in any rate safeguard against it anyways.


