### PR TITLE
xwayland: break cyclic loop of parents

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -444,9 +444,11 @@ PHLWINDOW CWindow::X11TransientFor() {
     if (!m_pXWaylandSurface || !m_pXWaylandSurface->parent)
         return nullptr;
 
-    auto s = m_pXWaylandSurface->parent;
+    auto s         = m_pXWaylandSurface->parent;
+    auto oldParent = s;
     while (s) {
-        if (!s->parent)
+        // break cyclic loop of m_pXWaylandSurface being parent of itself, #TODO reject this from even being created?
+        if (!s->parent || s->parent == oldParent)
             break;
         s = s->parent;
     }


### PR DESCRIPTION
in X11 some surfaces is a parent of itself and creates a cyclic loop when trying to find its parent. check for old parent and break if its beginning to roll over.

perhaps should be rejected from created at all?

fixes #6711 


