### PR TITLE
fix wlroots-hyprland dep checks (for libliftoff patch to work)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ ExternalProject_Add(
     wlroots-hyprland
     PREFIX ${CMAKE_SOURCE_DIR}/subprojects/wlroots-hyprland
     SOURCE_DIR ${CMAKE_SOURCE_DIR}/subprojects/wlroots-hyprland
-    CONFIGURE_COMMAND meson setup --reconfigure build --buildtype=${BUILDTYPE_LOWER} -Dwerror=false -Dxwayland=$<IF:$<BOOL:${NO_XWAYLAND}>,disabled,enabled> -Dexamples=false -Drenderers=gles2 -Dbackends=drm,libinput $<IF:$<BOOL:${WITH_ASAN}>,-Db_sanitize=address,-Db_sanitize=none>
+    CONFIGURE_COMMAND meson setup --reconfigure --clearcache build --buildtype=${BUILDTYPE_LOWER} -Dwerror=false -Dxwayland=$<IF:$<BOOL:${NO_XWAYLAND}>,disabled,enabled> -Dexamples=false -Drenderers=gles2 -Dbackends=drm,libinput $<IF:$<BOOL:${WITH_ASAN}>,-Db_sanitize=address,-Db_sanitize=none>
     BUILD_COMMAND ninja -C build
     BUILD_ALWAYS true
     BUILD_IN_SOURCE true


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
fixes wlroots-hyprland building when libliftoff is v0.5.0

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
when building wlroots-hyprland the libliftoff patch isn't applied because meson caching thinks we have the older version of libliftoff sometimes

#### Is it ready for merging, or does it need work?

Yes
