### PR TITLE
hyprctl completions: Use only awk rather than grep + awk

### DIFF
--- a/hyprctl/hyprctl.bash
+++ b/hyprctl/hyprctl.bash
@@ -1,13 +1,13 @@
 _hyprctl_cmd_2 () {
-    hyprctl monitors | grep Monitor | awk '{ print $2 }'
+    hyprctl monitors | awk '/Monitor/{ print $2 }'
 }
 
 _hyprctl_cmd_3 () {
-    hyprpm list | grep "Plugin" | awk '{print $4}'
+    hyprpm list | awk '/Plugin/{ print $4 }'
 }
 
 _hyprctl_cmd_0 () {
-    hyprctl clients | grep class | awk '{print $2}'
+    hyprctl clients | awk '/class/{ print $2 }'
 }
 
 _hyprctl_cmd_1 () {

--- a/hyprctl/hyprctl.fish
+++ b/hyprctl/hyprctl.fish
@@ -1,16 +1,16 @@
 function _hyprctl_3
     set 1 $argv[1]
-    hyprctl monitors | grep Monitor | awk '{ print $2 }'
+    hyprctl monitors | awk '/Monitor/{ print $2 }'
 end
 
 function _hyprctl_4
     set 1 $argv[1]
-    hyprpm list | grep "Plugin" | awk '{print $4}'
+    hyprpm list | awk '/Plugin/{ print $4 }'
 end
 
 function _hyprctl_1
     set 1 $argv[1]
-    hyprctl clients | grep class | awk '{print $2}'
+    hyprctl clients | awk '/class/{ print $2 }'
 end
 
 function _hyprctl_2

--- a/hyprctl/hyprctl.zsh
+++ b/hyprctl/hyprctl.zsh
@@ -1,15 +1,15 @@
 #compdef hyprctl
 
 _hyprctl_cmd_2 () {
-    hyprctl monitors | grep Monitor | awk '{ print $2 }'
+    hyprctl monitors | awk '/Monitor/{ print $2 }'
 }
 
 _hyprctl_cmd_3 () {
-    hyprpm list | grep "Plugin" | awk '{print $4}'
+    hyprpm list | awk '/Plugin/{ print $4 }'
 }
 
 _hyprctl_cmd_0 () {
-    hyprctl clients | grep class | awk '{print $2}'
+    hyprctl clients | awk '/class/{ print $2 }'
 }
 
 _hyprctl_cmd_1 () {


### PR DESCRIPTION
### Describe your PR, what does it fix/add?
Using `awk '/<exp>/{ print $n }'` is more minimal and slightly faster than using `grep '<exp>' | awk '{ print $n }'`.

### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.

### Is it ready for merging, or does it need work?

Ready to merge.