### PR TITLE
Improve handling of window properties

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -702,7 +702,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
         for (auto& w : m_vWindows | std::views::reverse) {
             const auto BB  = w->getWindowBoxUnified(properties);
             CBox       box = BB.copy().expand(w->m_iX11Type == 2 ? BORDER_GRAB_AREA : 0);
-            if (w->m_bIsFloating && w->m_bIsMapped && !w->isHidden() && !w->m_bX11ShouldntFocus && w->m_bPinned && !w->m_sWindowData.noFocus.value_or(false) && w != pIgnoreWindow) {
+            if (w->m_bIsFloating && w->m_bIsMapped && !w->isHidden() && !w->m_bX11ShouldntFocus && w->m_bPinned && !w->m_sWindowData.noFocus.value_or_default() && w != pIgnoreWindow) {
                 if (box.containsPoint(g_pPointerManager->position()))
                     return w;
 
@@ -731,7 +731,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
                     continue;
 
                 CBox box = BB.copy().expand(w->m_iX11Type == 2 ? BORDER_GRAB_AREA : 0);
-                if (w->m_bIsFloating && w->m_bIsMapped && isWorkspaceVisible(w->m_pWorkspace) && !w->isHidden() && !w->m_bPinned && !w->m_sWindowData.noFocus.value_or(false) &&
+                if (w->m_bIsFloating && w->m_bIsMapped && isWorkspaceVisible(w->m_pWorkspace) && !w->isHidden() && !w->m_bPinned && !w->m_sWindowData.noFocus.value_or_default() &&
                     w != pIgnoreWindow && (!aboveFullscreen || w->m_bCreatedOverFullscreen)) {
                     // OR windows should add focus to parent
                     if (w->m_bX11ShouldntFocus && w->m_iX11Type != 2)
@@ -784,7 +784,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
                 continue;
 
             if (!w->m_bIsX11 && !w->m_bIsFloating && w->m_bIsMapped && w->workspaceID() == WORKSPACEID && !w->isHidden() && !w->m_bX11ShouldntFocus &&
-                !w->m_sWindowData.noFocus.value_or(false) && w != pIgnoreWindow) {
+                !w->m_sWindowData.noFocus.value_or_default() && w != pIgnoreWindow) {
                 if (w->hasPopupAt(pos))
                     return w;
             }
@@ -796,7 +796,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
 
             CBox box = (properties & USE_PROP_TILED) ? w->getWindowBoxUnified(properties) : CBox{w->m_vPosition, w->m_vSize};
             if (!w->m_bIsFloating && w->m_bIsMapped && box.containsPoint(pos) && w->workspaceID() == WORKSPACEID && !w->isHidden() && !w->m_bX11ShouldntFocus &&
-                !w->m_sWindowData.noFocus.value_or(false) && w != pIgnoreWindow)
+                !w->m_sWindowData.noFocus.value_or_default() && w != pIgnoreWindow)
                 return w;
         }
 
@@ -940,7 +940,7 @@ void CCompositor::focusWindow(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface
         return;
     }
 
-    if (pWindow->m_sWindowData.noFocus.value_or(false)) {
+    if (pWindow->m_sWindowData.noFocus.value_or_default()) {
         Debug::log(LOG, "Ignoring focus to nofocus window!");
         return;
     }
@@ -1579,7 +1579,7 @@ PHLWINDOW CCompositor::getNextWindowOnWorkspace(PHLWINDOW pWindow, bool focusabl
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus.value_or(false)))
+        if (w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus.value_or_default()))
             return w;
     }
 
@@ -1587,7 +1587,7 @@ PHLWINDOW CCompositor::getNextWindowOnWorkspace(PHLWINDOW pWindow, bool focusabl
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus.value_or(false)))
+        if (w != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus.value_or_default()))
             return w;
     }
 
@@ -1608,7 +1608,7 @@ PHLWINDOW CCompositor::getPrevWindowOnWorkspace(PHLWINDOW pWindow, bool focusabl
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus.value_or(false)))
+        if (w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus.value_or_default()))
             return w;
     }
 
@@ -1616,7 +1616,7 @@ PHLWINDOW CCompositor::getPrevWindowOnWorkspace(PHLWINDOW pWindow, bool focusabl
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus.value_or(false)))
+        if (w != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus.value_or_default()))
             return w;
     }
 
@@ -1828,7 +1828,7 @@ void CCompositor::updateWindowAnimatedDecorationValues(PHLWINDOW pWindow) {
     }
 
     // dim
-    if (pWindow == m_pLastWindow.lock() || pWindow->m_sWindowData.noDim.value_or(false) || !*PDIMENABLED) {
+    if (pWindow == m_pLastWindow.lock() || pWindow->m_sWindowData.noDim.value_or_default() || !*PDIMENABLED) {
         pWindow->m_fDimPercent = 0;
     } else {
         pWindow->m_fDimPercent = *PDIMSTRENGTH;

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -702,7 +702,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
         for (auto& w : m_vWindows | std::views::reverse) {
             const auto BB  = w->getWindowBoxUnified(properties);
             CBox       box = BB.copy().expand(w->m_iX11Type == 2 ? BORDER_GRAB_AREA : 0);
-            if (w->m_bIsFloating && w->m_bIsMapped && !w->isHidden() && !w->m_bX11ShouldntFocus && w->m_bPinned && !w->m_sWindowData.noFocus.value_or_default() && w != pIgnoreWindow) {
+            if (w->m_bIsFloating && w->m_bIsMapped && !w->isHidden() && !w->m_bX11ShouldntFocus && w->m_bPinned && !w->m_sWindowData.noFocus.valueOrDefault() && w != pIgnoreWindow) {
                 if (box.containsPoint(g_pPointerManager->position()))
                     return w;
 
@@ -731,7 +731,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
                     continue;
 
                 CBox box = BB.copy().expand(w->m_iX11Type == 2 ? BORDER_GRAB_AREA : 0);
-                if (w->m_bIsFloating && w->m_bIsMapped && isWorkspaceVisible(w->m_pWorkspace) && !w->isHidden() && !w->m_bPinned && !w->m_sWindowData.noFocus.value_or_default() &&
+                if (w->m_bIsFloating && w->m_bIsMapped && isWorkspaceVisible(w->m_pWorkspace) && !w->isHidden() && !w->m_bPinned && !w->m_sWindowData.noFocus.valueOrDefault() &&
                     w != pIgnoreWindow && (!aboveFullscreen || w->m_bCreatedOverFullscreen)) {
                     // OR windows should add focus to parent
                     if (w->m_bX11ShouldntFocus && w->m_iX11Type != 2)
@@ -784,7 +784,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
                 continue;
 
             if (!w->m_bIsX11 && !w->m_bIsFloating && w->m_bIsMapped && w->workspaceID() == WORKSPACEID && !w->isHidden() && !w->m_bX11ShouldntFocus &&
-                !w->m_sWindowData.noFocus.value_or_default() && w != pIgnoreWindow) {
+                !w->m_sWindowData.noFocus.valueOrDefault() && w != pIgnoreWindow) {
                 if (w->hasPopupAt(pos))
                     return w;
             }
@@ -796,7 +796,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
 
             CBox box = (properties & USE_PROP_TILED) ? w->getWindowBoxUnified(properties) : CBox{w->m_vPosition, w->m_vSize};
             if (!w->m_bIsFloating && w->m_bIsMapped && box.containsPoint(pos) && w->workspaceID() == WORKSPACEID && !w->isHidden() && !w->m_bX11ShouldntFocus &&
-                !w->m_sWindowData.noFocus.value_or_default() && w != pIgnoreWindow)
+                !w->m_sWindowData.noFocus.valueOrDefault() && w != pIgnoreWindow)
                 return w;
         }
 
@@ -940,7 +940,7 @@ void CCompositor::focusWindow(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface
         return;
     }
 
-    if (pWindow->m_sWindowData.noFocus.value_or_default()) {
+    if (pWindow->m_sWindowData.noFocus.valueOrDefault()) {
         Debug::log(LOG, "Ignoring focus to nofocus window!");
         return;
     }
@@ -1579,7 +1579,7 @@ PHLWINDOW CCompositor::getNextWindowOnWorkspace(PHLWINDOW pWindow, bool focusabl
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus.value_or_default()))
+        if (w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus.valueOrDefault()))
             return w;
     }
 
@@ -1587,7 +1587,7 @@ PHLWINDOW CCompositor::getNextWindowOnWorkspace(PHLWINDOW pWindow, bool focusabl
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus.value_or_default()))
+        if (w != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus.valueOrDefault()))
             return w;
     }
 
@@ -1608,7 +1608,7 @@ PHLWINDOW CCompositor::getPrevWindowOnWorkspace(PHLWINDOW pWindow, bool focusabl
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus.value_or_default()))
+        if (w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus.valueOrDefault()))
             return w;
     }
 
@@ -1616,7 +1616,7 @@ PHLWINDOW CCompositor::getPrevWindowOnWorkspace(PHLWINDOW pWindow, bool focusabl
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus.value_or_default()))
+        if (w != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus.valueOrDefault()))
             return w;
     }
 
@@ -1804,11 +1804,11 @@ void CCompositor::updateWindowAnimatedDecorationValues(PHLWINDOW pWindow) {
         if (pWindow == m_pLastWindow) {
             const auto* const ACTIVECOLOR =
                 !pWindow->m_sGroupData.pNextWindow.lock() ? (!pWindow->m_sGroupData.deny ? ACTIVECOL : NOGROUPACTIVECOL) : (GROUPLOCKED ? GROUPACTIVELOCKEDCOL : GROUPACTIVECOL);
-            setBorderColor(pWindow->m_sWindowData.activeBorderColor.value_or(*ACTIVECOLOR));
+            setBorderColor(pWindow->m_sWindowData.activeBorderColor.valueOr(*ACTIVECOLOR));
         } else {
             const auto* const INACTIVECOLOR = !pWindow->m_sGroupData.pNextWindow.lock() ? (!pWindow->m_sGroupData.deny ? INACTIVECOL : NOGROUPINACTIVECOL) :
                                                                                           (GROUPLOCKED ? GROUPINACTIVELOCKEDCOL : GROUPINACTIVECOL);
-            setBorderColor(pWindow->m_sWindowData.inactiveBorderColor.value_or(*INACTIVECOLOR));
+            setBorderColor(pWindow->m_sWindowData.inactiveBorderColor.valueOr(*INACTIVECOLOR));
         }
     }
 
@@ -1819,16 +1819,16 @@ void CCompositor::updateWindowAnimatedDecorationValues(PHLWINDOW pWindow) {
     // opacity
     const auto PWORKSPACE = pWindow->m_pWorkspace;
     if (pWindow->m_bIsFullscreen && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL) {
-        pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaFullscreen.value_or_default().applyAlpha(*PFULLSCREENALPHA);
+        pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaFullscreen.valueOrDefault().applyAlpha(*PFULLSCREENALPHA);
     } else {
         if (pWindow == m_pLastWindow)
-            pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alpha.value_or_default().applyAlpha(*PACTIVEALPHA);
+            pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alpha.valueOrDefault().applyAlpha(*PACTIVEALPHA);
         else
-            pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaInactive.value_or_default().applyAlpha(*PINACTIVEALPHA);
+            pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaInactive.valueOrDefault().applyAlpha(*PINACTIVEALPHA);
     }
 
     // dim
-    if (pWindow == m_pLastWindow.lock() || pWindow->m_sWindowData.noDim.value_or_default() || !*PDIMENABLED) {
+    if (pWindow == m_pLastWindow.lock() || pWindow->m_sWindowData.noDim.valueOrDefault() || !*PDIMENABLED) {
         pWindow->m_fDimPercent = 0;
     } else {
         pWindow->m_fDimPercent = *PDIMSTRENGTH;

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -702,7 +702,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
         for (auto& w : m_vWindows | std::views::reverse) {
             const auto BB  = w->getWindowBoxUnified(properties);
             CBox       box = BB.copy().expand(w->m_iX11Type == 2 ? BORDER_GRAB_AREA : 0);
-            if (w->m_bIsFloating && w->m_bIsMapped && !w->isHidden() && !w->m_bX11ShouldntFocus && w->m_bPinned && !w->m_sWindowData.noFocus && w != pIgnoreWindow) {
+            if (w->m_bIsFloating && w->m_bIsMapped && !w->isHidden() && !w->m_bX11ShouldntFocus && w->m_bPinned && !w->m_sWindowData.noFocus.value_or(false) && w != pIgnoreWindow) {
                 if (box.containsPoint(g_pPointerManager->position()))
                     return w;
 
@@ -731,7 +731,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
                     continue;
 
                 CBox box = BB.copy().expand(w->m_iX11Type == 2 ? BORDER_GRAB_AREA : 0);
-                if (w->m_bIsFloating && w->m_bIsMapped && isWorkspaceVisible(w->m_pWorkspace) && !w->isHidden() && !w->m_bPinned && !w->m_sWindowData.noFocus &&
+                if (w->m_bIsFloating && w->m_bIsMapped && isWorkspaceVisible(w->m_pWorkspace) && !w->isHidden() && !w->m_bPinned && !w->m_sWindowData.noFocus.value_or(false) &&
                     w != pIgnoreWindow && (!aboveFullscreen || w->m_bCreatedOverFullscreen)) {
                     // OR windows should add focus to parent
                     if (w->m_bX11ShouldntFocus && w->m_iX11Type != 2)
@@ -784,7 +784,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
                 continue;
 
             if (!w->m_bIsX11 && !w->m_bIsFloating && w->m_bIsMapped && w->workspaceID() == WORKSPACEID && !w->isHidden() && !w->m_bX11ShouldntFocus &&
-                !w->m_sWindowData.noFocus && w != pIgnoreWindow) {
+                !w->m_sWindowData.noFocus.value_or(false) && w != pIgnoreWindow) {
                 if (w->hasPopupAt(pos))
                     return w;
             }
@@ -796,7 +796,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
 
             CBox box = (properties & USE_PROP_TILED) ? w->getWindowBoxUnified(properties) : CBox{w->m_vPosition, w->m_vSize};
             if (!w->m_bIsFloating && w->m_bIsMapped && box.containsPoint(pos) && w->workspaceID() == WORKSPACEID && !w->isHidden() && !w->m_bX11ShouldntFocus &&
-                !w->m_sWindowData.noFocus && w != pIgnoreWindow)
+                !w->m_sWindowData.noFocus.value_or(false) && w != pIgnoreWindow)
                 return w;
         }
 
@@ -940,7 +940,7 @@ void CCompositor::focusWindow(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface
         return;
     }
 
-    if (pWindow->m_sWindowData.noFocus) {
+    if (pWindow->m_sWindowData.noFocus.value_or(false)) {
         Debug::log(LOG, "Ignoring focus to nofocus window!");
         return;
     }
@@ -1579,7 +1579,7 @@ PHLWINDOW CCompositor::getNextWindowOnWorkspace(PHLWINDOW pWindow, bool focusabl
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus))
+        if (w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus.value_or(false)))
             return w;
     }
 
@@ -1587,7 +1587,7 @@ PHLWINDOW CCompositor::getNextWindowOnWorkspace(PHLWINDOW pWindow, bool focusabl
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus))
+        if (w != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus.value_or(false)))
             return w;
     }
 
@@ -1608,7 +1608,7 @@ PHLWINDOW CCompositor::getPrevWindowOnWorkspace(PHLWINDOW pWindow, bool focusabl
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus))
+        if (w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus.value_or(false)))
             return w;
     }
 
@@ -1616,7 +1616,7 @@ PHLWINDOW CCompositor::getPrevWindowOnWorkspace(PHLWINDOW pWindow, bool focusabl
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus))
+        if (w != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus.value_or(false)))
             return w;
     }
 
@@ -1804,13 +1804,11 @@ void CCompositor::updateWindowAnimatedDecorationValues(PHLWINDOW pWindow) {
         if (pWindow == m_pLastWindow) {
             const auto* const ACTIVECOLOR =
                 !pWindow->m_sGroupData.pNextWindow.lock() ? (!pWindow->m_sGroupData.deny ? ACTIVECOL : NOGROUPACTIVECOL) : (GROUPLOCKED ? GROUPACTIVELOCKEDCOL : GROUPACTIVECOL);
-            setBorderColor(pWindow->m_sWindowData.activeBorderColor.toUnderlying().m_vColors.empty() ? *ACTIVECOLOR :
-                                                                                                              pWindow->m_sWindowData.activeBorderColor.toUnderlying());
+            setBorderColor(pWindow->m_sWindowData.activeBorderColor.value_or(*ACTIVECOLOR));
         } else {
             const auto* const INACTIVECOLOR = !pWindow->m_sGroupData.pNextWindow.lock() ? (!pWindow->m_sGroupData.deny ? INACTIVECOL : NOGROUPINACTIVECOL) :
                                                                                           (GROUPLOCKED ? GROUPINACTIVELOCKEDCOL : GROUPINACTIVECOL);
-            setBorderColor(pWindow->m_sWindowData.inactiveBorderColor.toUnderlying().m_vColors.empty() ? *INACTIVECOLOR :
-                                                                                                                pWindow->m_sWindowData.inactiveBorderColor.toUnderlying());
+            setBorderColor(pWindow->m_sWindowData.inactiveBorderColor.value_or(*INACTIVECOLOR));
         }
     }
 
@@ -1821,16 +1819,16 @@ void CCompositor::updateWindowAnimatedDecorationValues(PHLWINDOW pWindow) {
     // opacity
     const auto PWORKSPACE = pWindow->m_pWorkspace;
     if (pWindow->m_bIsFullscreen && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL) {
-        pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaFullscreen.toUnderlying().applyAlpha(*PFULLSCREENALPHA);
+        pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaFullscreen.value_or(sAlphaValue{1.f, false}).applyAlpha(*PFULLSCREENALPHA);
     } else {
         if (pWindow == m_pLastWindow)
-            pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alpha.toUnderlying().applyAlpha(*PACTIVEALPHA);
+            pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alpha.value_or(sAlphaValue{1.f, false}).applyAlpha(*PACTIVEALPHA);
         else
-            pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaInactive.toUnderlying().applyAlpha(*PINACTIVEALPHA);
+            pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaInactive.value_or(sAlphaValue{1.f, false}).applyAlpha(*PINACTIVEALPHA);
     }
 
     // dim
-    if (pWindow == m_pLastWindow.lock() || pWindow->m_sWindowData.noDim || !*PDIMENABLED) {
+    if (pWindow == m_pLastWindow.lock() || pWindow->m_sWindowData.noDim.value_or(false) || !*PDIMENABLED) {
         pWindow->m_fDimPercent = 0;
     } else {
         pWindow->m_fDimPercent = *PDIMSTRENGTH;

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1821,19 +1821,12 @@ void CCompositor::updateWindowAnimatedDecorationValues(PHLWINDOW pWindow) {
     // opacity
     const auto PWORKSPACE = pWindow->m_pWorkspace;
     if (pWindow->m_bIsFullscreen && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL) {
-        pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaFullscreen.toUnderlying() != -1 ?
-            (pWindow->m_sWindowData.alphaFullscreenOverride.toUnderlying() ? pWindow->m_sWindowData.alphaFullscreen.toUnderlying() :
-                                                                                    pWindow->m_sWindowData.alphaFullscreen.toUnderlying() * *PFULLSCREENALPHA) :
-            *PFULLSCREENALPHA;
+        pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaFullscreen.toUnderlying().applyAlpha(*PFULLSCREENALPHA);
     } else {
         if (pWindow == m_pLastWindow)
-            pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaOverride.toUnderlying() ? pWindow->m_sWindowData.alpha.toUnderlying() :
-                                                                                                           pWindow->m_sWindowData.alpha.toUnderlying() * *PACTIVEALPHA;
+            pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alpha.toUnderlying().applyAlpha(*PACTIVEALPHA);
         else
-            pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaInactive.toUnderlying() != -1 ?
-                (pWindow->m_sWindowData.alphaInactiveOverride.toUnderlying() ? pWindow->m_sWindowData.alphaInactive.toUnderlying() :
-                                                                                      pWindow->m_sWindowData.alphaInactive.toUnderlying() * *PINACTIVEALPHA) :
-                *PINACTIVEALPHA;
+            pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaInactive.toUnderlying().applyAlpha(*PINACTIVEALPHA);
     }
 
     // dim

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1819,12 +1819,12 @@ void CCompositor::updateWindowAnimatedDecorationValues(PHLWINDOW pWindow) {
     // opacity
     const auto PWORKSPACE = pWindow->m_pWorkspace;
     if (pWindow->m_bIsFullscreen && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL) {
-        pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaFullscreen.value_or(sAlphaValue{1.f, false}).applyAlpha(*PFULLSCREENALPHA);
+        pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaFullscreen.value_or_default().applyAlpha(*PFULLSCREENALPHA);
     } else {
         if (pWindow == m_pLastWindow)
-            pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alpha.value_or(sAlphaValue{1.f, false}).applyAlpha(*PACTIVEALPHA);
+            pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alpha.value_or_default().applyAlpha(*PACTIVEALPHA);
         else
-            pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaInactive.value_or(sAlphaValue{1.f, false}).applyAlpha(*PINACTIVEALPHA);
+            pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaInactive.value_or_default().applyAlpha(*PINACTIVEALPHA);
     }
 
     // dim

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2259,7 +2259,7 @@ void CCompositor::updateWorkspaceWindowDecos(const int& id) {
     }
 }
 
-void CCompositor::updateWorkspaceSpecialRenderData(const int& id) {
+void CCompositor::updateWorkspaceWindowData(const int& id) {
     const auto PWORKSPACE    = getWorkspaceByID(id);
     const auto WORKSPACERULE = PWORKSPACE ? g_pConfigManager->getWorkspaceRuleFor(PWORKSPACE) : SWorkspaceRule{};
 
@@ -2267,7 +2267,7 @@ void CCompositor::updateWorkspaceSpecialRenderData(const int& id) {
         if (w->workspaceID() != id)
             continue;
 
-        w->updateSpecialRenderData(WORKSPACERULE);
+        w->updateWindowData(WORKSPACERULE);
     }
 }
 

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -702,7 +702,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
         for (auto& w : m_vWindows | std::views::reverse) {
             const auto BB  = w->getWindowBoxUnified(properties);
             CBox       box = BB.copy().expand(w->m_iX11Type == 2 ? BORDER_GRAB_AREA : 0);
-            if (w->m_bIsFloating && w->m_bIsMapped && !w->isHidden() && !w->m_bX11ShouldntFocus && w->m_bPinned && !w->m_sAdditionalConfigData.noFocus && w != pIgnoreWindow) {
+            if (w->m_bIsFloating && w->m_bIsMapped && !w->isHidden() && !w->m_bX11ShouldntFocus && w->m_bPinned && !w->m_sWindowData.noFocus && w != pIgnoreWindow) {
                 if (box.containsPoint(g_pPointerManager->position()))
                     return w;
 
@@ -731,7 +731,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
                     continue;
 
                 CBox box = BB.copy().expand(w->m_iX11Type == 2 ? BORDER_GRAB_AREA : 0);
-                if (w->m_bIsFloating && w->m_bIsMapped && isWorkspaceVisible(w->m_pWorkspace) && !w->isHidden() && !w->m_bPinned && !w->m_sAdditionalConfigData.noFocus &&
+                if (w->m_bIsFloating && w->m_bIsMapped && isWorkspaceVisible(w->m_pWorkspace) && !w->isHidden() && !w->m_bPinned && !w->m_sWindowData.noFocus &&
                     w != pIgnoreWindow && (!aboveFullscreen || w->m_bCreatedOverFullscreen)) {
                     // OR windows should add focus to parent
                     if (w->m_bX11ShouldntFocus && w->m_iX11Type != 2)
@@ -784,7 +784,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
                 continue;
 
             if (!w->m_bIsX11 && !w->m_bIsFloating && w->m_bIsMapped && w->workspaceID() == WORKSPACEID && !w->isHidden() && !w->m_bX11ShouldntFocus &&
-                !w->m_sAdditionalConfigData.noFocus && w != pIgnoreWindow) {
+                !w->m_sWindowData.noFocus && w != pIgnoreWindow) {
                 if (w->hasPopupAt(pos))
                     return w;
             }
@@ -796,7 +796,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
 
             CBox box = (properties & USE_PROP_TILED) ? w->getWindowBoxUnified(properties) : CBox{w->m_vPosition, w->m_vSize};
             if (!w->m_bIsFloating && w->m_bIsMapped && box.containsPoint(pos) && w->workspaceID() == WORKSPACEID && !w->isHidden() && !w->m_bX11ShouldntFocus &&
-                !w->m_sAdditionalConfigData.noFocus && w != pIgnoreWindow)
+                !w->m_sWindowData.noFocus && w != pIgnoreWindow)
                 return w;
         }
 
@@ -940,7 +940,7 @@ void CCompositor::focusWindow(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface
         return;
     }
 
-    if (pWindow->m_sAdditionalConfigData.noFocus) {
+    if (pWindow->m_sWindowData.noFocus) {
         Debug::log(LOG, "Ignoring focus to nofocus window!");
         return;
     }
@@ -1579,7 +1579,7 @@ PHLWINDOW CCompositor::getNextWindowOnWorkspace(PHLWINDOW pWindow, bool focusabl
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sAdditionalConfigData.noFocus))
+        if (w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus))
             return w;
     }
 
@@ -1587,7 +1587,7 @@ PHLWINDOW CCompositor::getNextWindowOnWorkspace(PHLWINDOW pWindow, bool focusabl
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sAdditionalConfigData.noFocus))
+        if (w != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus))
             return w;
     }
 
@@ -1608,7 +1608,7 @@ PHLWINDOW CCompositor::getPrevWindowOnWorkspace(PHLWINDOW pWindow, bool focusabl
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sAdditionalConfigData.noFocus))
+        if (w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus))
             return w;
     }
 
@@ -1616,7 +1616,7 @@ PHLWINDOW CCompositor::getPrevWindowOnWorkspace(PHLWINDOW pWindow, bool focusabl
         if (floating.has_value() && w->m_bIsFloating != floating.value())
             continue;
 
-        if (w != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sAdditionalConfigData.noFocus))
+        if (w != pWindow && w->m_pWorkspace == pWindow->m_pWorkspace && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus))
             return w;
     }
 
@@ -1804,13 +1804,13 @@ void CCompositor::updateWindowAnimatedDecorationValues(PHLWINDOW pWindow) {
         if (pWindow == m_pLastWindow) {
             const auto* const ACTIVECOLOR =
                 !pWindow->m_sGroupData.pNextWindow.lock() ? (!pWindow->m_sGroupData.deny ? ACTIVECOL : NOGROUPACTIVECOL) : (GROUPLOCKED ? GROUPACTIVELOCKEDCOL : GROUPACTIVECOL);
-            setBorderColor(pWindow->m_sSpecialRenderData.activeBorderColor.toUnderlying().m_vColors.empty() ? *ACTIVECOLOR :
-                                                                                                              pWindow->m_sSpecialRenderData.activeBorderColor.toUnderlying());
+            setBorderColor(pWindow->m_sWindowData.activeBorderColor.toUnderlying().m_vColors.empty() ? *ACTIVECOLOR :
+                                                                                                              pWindow->m_sWindowData.activeBorderColor.toUnderlying());
         } else {
             const auto* const INACTIVECOLOR = !pWindow->m_sGroupData.pNextWindow.lock() ? (!pWindow->m_sGroupData.deny ? INACTIVECOL : NOGROUPINACTIVECOL) :
                                                                                           (GROUPLOCKED ? GROUPINACTIVELOCKEDCOL : GROUPINACTIVECOL);
-            setBorderColor(pWindow->m_sSpecialRenderData.inactiveBorderColor.toUnderlying().m_vColors.empty() ? *INACTIVECOLOR :
-                                                                                                                pWindow->m_sSpecialRenderData.inactiveBorderColor.toUnderlying());
+            setBorderColor(pWindow->m_sWindowData.inactiveBorderColor.toUnderlying().m_vColors.empty() ? *INACTIVECOLOR :
+                                                                                                                pWindow->m_sWindowData.inactiveBorderColor.toUnderlying());
         }
     }
 
@@ -1821,23 +1821,23 @@ void CCompositor::updateWindowAnimatedDecorationValues(PHLWINDOW pWindow) {
     // opacity
     const auto PWORKSPACE = pWindow->m_pWorkspace;
     if (pWindow->m_bIsFullscreen && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL) {
-        pWindow->m_fActiveInactiveAlpha = pWindow->m_sSpecialRenderData.alphaFullscreen.toUnderlying() != -1 ?
-            (pWindow->m_sSpecialRenderData.alphaFullscreenOverride.toUnderlying() ? pWindow->m_sSpecialRenderData.alphaFullscreen.toUnderlying() :
-                                                                                    pWindow->m_sSpecialRenderData.alphaFullscreen.toUnderlying() * *PFULLSCREENALPHA) :
+        pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaFullscreen.toUnderlying() != -1 ?
+            (pWindow->m_sWindowData.alphaFullscreenOverride.toUnderlying() ? pWindow->m_sWindowData.alphaFullscreen.toUnderlying() :
+                                                                                    pWindow->m_sWindowData.alphaFullscreen.toUnderlying() * *PFULLSCREENALPHA) :
             *PFULLSCREENALPHA;
     } else {
         if (pWindow == m_pLastWindow)
-            pWindow->m_fActiveInactiveAlpha = pWindow->m_sSpecialRenderData.alphaOverride.toUnderlying() ? pWindow->m_sSpecialRenderData.alpha.toUnderlying() :
-                                                                                                           pWindow->m_sSpecialRenderData.alpha.toUnderlying() * *PACTIVEALPHA;
+            pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaOverride.toUnderlying() ? pWindow->m_sWindowData.alpha.toUnderlying() :
+                                                                                                           pWindow->m_sWindowData.alpha.toUnderlying() * *PACTIVEALPHA;
         else
-            pWindow->m_fActiveInactiveAlpha = pWindow->m_sSpecialRenderData.alphaInactive.toUnderlying() != -1 ?
-                (pWindow->m_sSpecialRenderData.alphaInactiveOverride.toUnderlying() ? pWindow->m_sSpecialRenderData.alphaInactive.toUnderlying() :
-                                                                                      pWindow->m_sSpecialRenderData.alphaInactive.toUnderlying() * *PINACTIVEALPHA) :
+            pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaInactive.toUnderlying() != -1 ?
+                (pWindow->m_sWindowData.alphaInactiveOverride.toUnderlying() ? pWindow->m_sWindowData.alphaInactive.toUnderlying() :
+                                                                                      pWindow->m_sWindowData.alphaInactive.toUnderlying() * *PINACTIVEALPHA) :
                 *PINACTIVEALPHA;
     }
 
     // dim
-    if (pWindow == m_pLastWindow.lock() || pWindow->m_sAdditionalConfigData.forceNoDim || !*PDIMENABLED) {
+    if (pWindow == m_pLastWindow.lock() || pWindow->m_sWindowData.noDim || !*PDIMENABLED) {
         pWindow->m_fDimPercent = 0;
     } else {
         pWindow->m_fDimPercent = *PDIMSTRENGTH;

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -127,7 +127,7 @@ class CCompositor {
     PHLWORKSPACE           getWorkspaceByString(const std::string&);
     void                   sanityCheckWorkspaces();
     void                   updateWorkspaceWindowDecos(const int&);
-    void                   updateWorkspaceSpecialRenderData(const int&);
+    void                   updateWorkspaceWindowData(const int&);
     int                    getWindowsOnWorkspace(const int& id, std::optional<bool> onlyTiled = {}, std::optional<bool> onlyVisible = {});
     int                    getGroupsOnWorkspace(const int& id, std::optional<bool> onlyTiled = {}, std::optional<bool> onlyVisible = {});
     PHLWINDOW              getUrgentWindow();

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -839,7 +839,7 @@ void CConfigManager::postConfigReload(const Hyprlang::CParseResult& result) {
         if (w->inert())
             continue;
         g_pCompositor->updateWorkspaceWindows(w->m_iID);
-        g_pCompositor->updateWorkspaceSpecialRenderData(w->m_iID);
+        g_pCompositor->updateWorkspaceWindowData(w->m_iID);
     }
 
     // Update window border colors
@@ -1053,14 +1053,14 @@ SWorkspaceRule CConfigManager::mergeWorkspaceRules(const SWorkspaceRule& rule1, 
         mergedRule.gapsOut = rule2.gapsOut;
     if (rule2.borderSize.has_value())
         mergedRule.borderSize = rule2.borderSize;
-    if (rule2.border.has_value())
-        mergedRule.border = rule2.border;
-    if (rule2.rounding.has_value())
-        mergedRule.rounding = rule2.rounding;
+    if (rule2.noBorder.has_value())
+        mergedRule.noBorder = rule2.noBorder;
+    if (rule2.noRounding.has_value())
+        mergedRule.noRounding = rule2.noRounding;
     if (rule2.decorate.has_value())
         mergedRule.decorate = rule2.decorate;
-    if (rule2.shadow.has_value())
-        mergedRule.shadow = rule2.shadow;
+    if (rule2.noShadow.has_value())
+        mergedRule.noShadow = rule2.noShadow;
     if (rule2.onCreatedEmptyRunCmd.has_value())
         mergedRule.onCreatedEmptyRunCmd = rule2.onCreatedEmptyRunCmd;
     if (rule2.defaultName.has_value())
@@ -2416,11 +2416,11 @@ std::optional<std::string> CConfigManager::handleWorkspaceRules(const std::strin
                 wsRule.borderSize = std::stoi(rule.substr(delim + 11));
             } catch (...) { return "Error parsing workspace rule bordersize: {}", rule.substr(delim + 11); }
         else if ((delim = rule.find("border:")) != std::string::npos)
-            wsRule.border = configStringToInt(rule.substr(delim + 7));
+            wsRule.noBorder = !configStringToInt(rule.substr(delim + 7));
         else if ((delim = rule.find("shadow:")) != std::string::npos)
-            wsRule.shadow = configStringToInt(rule.substr(delim + 7));
+            wsRule.noShadow = !configStringToInt(rule.substr(delim + 7));
         else if ((delim = rule.find("rounding:")) != std::string::npos)
-            wsRule.rounding = configStringToInt(rule.substr(delim + 9));
+            wsRule.noRounding = !configStringToInt(rule.substr(delim + 9));
         else if ((delim = rule.find("decorate:")) != std::string::npos)
             wsRule.decorate = configStringToInt(rule.substr(delim + 9));
         else if ((delim = rule.find("monitor:")) != std::string::npos)

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2081,16 +2081,17 @@ std::optional<std::string> CConfigManager::handleUnbind(const std::string& comma
 
 bool windowRuleValid(const std::string& RULE) {
     static const auto rules = std::unordered_set<std::string>{
-        "dimaround",       "fakefullscreen", "float",           "focusonactivate", "forceinput", "forcergbx",   "fullscreen", "immediate",
-        "keepaspectratio", "maximize",       "nearestneighbor", "noanim",          "noblur",     "noborder",    "nodim",      "nofocus",
-        "noinitialfocus",  "nomaxsize",      "noshadow",        "opaque",          "pin",        "stayfocused", "tile",       "windowdance",
+        "fakefullscreen", "float", "fullscreen", "maximize", "noinitialfocus", "pin", "stayfocused", "tile",
     };
     static const auto rulesPrefix = std::vector<std::string>{
         "animation", "bordercolor", "bordersize", "center",   "group", "idleinhibit",   "maxsize", "minsize",   "monitor", "move",
         "opacity",   "plugin:",     "pseudo",     "rounding", "size",  "suppressevent", "tag",     "workspace", "xray",
     };
 
-    return rules.contains(RULE) || std::any_of(rulesPrefix.begin(), rulesPrefix.end(), [&RULE](auto prefix) { return RULE.starts_with(prefix); });
+    const auto VALS = CVarList(RULE, 2, ' ');
+    return rules.contains(RULE) || std::any_of(rulesPrefix.begin(), rulesPrefix.end(), [&RULE](auto prefix) { return RULE.starts_with(prefix); }) ||
+        (g_pConfigManager->mbWindowProperties.find(VALS[0]) != g_pConfigManager->mbWindowProperties.end()) ||
+        (g_pConfigManager->miWindowProperties.find(VALS[0]) != g_pConfigManager->miWindowProperties.end());
 }
 
 bool layerRuleValid(const std::string& RULE) {

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -169,12 +169,10 @@ class CConfigManager {
     std::string                                                                             configCurrentPath;
 
     std::unordered_map<std::string, std::function<CWindowOverridableVar<bool>*(PHLWINDOW)>> mbWindowProperties = {
-        {"dimaround", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.dimAround; }},
+        {"allowsinput", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.allowsInput; }},
+        {"dimaround", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.dimAround; }},
+        {"decorate", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.decorate; }},
         {"focusonactivate", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.focusOnActivate; }},
-        {"forceinput", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.allowsInput; }},
-        {"forceopaque", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.opaque; }},
-        {"forcergbx", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.RGBX; }},
-        {"immediate", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.tearing; }},
         {"keepaspectratio", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.keepAspectRatio; }},
         {"nearestneighbor", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.nearestNeighbor; }},
         {"noanim", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noAnim; }},
@@ -183,7 +181,12 @@ class CConfigManager {
         {"nodim", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noDim; }},
         {"nofocus", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noFocus; }},
         {"nomaxsize", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noMaxSize; }},
+        {"norounding", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noRounding; }},
         {"noshadow", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noShadow; }},
+        {"opaque", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.opaque; }},
+        {"forcergbx", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.RGBX; }},
+        {"immediate", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.tearing; }},
+        // {"xray", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.xray; }},
         {"windowdance", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.windowDanceCompat; }},
     };
 

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -39,10 +39,10 @@ struct SWorkspaceRule {
     std::optional<CCssGapData>         gapsIn;
     std::optional<CCssGapData>         gapsOut;
     std::optional<int64_t>             borderSize;
-    std::optional<int>                 border;
-    std::optional<int>                 rounding;
-    std::optional<int>                 decorate;
-    std::optional<int>                 shadow;
+    std::optional<bool>                decorate;
+    std::optional<bool>                noRounding;
+    std::optional<bool>                noBorder;
+    std::optional<bool>                noShadow;
     std::optional<std::string>         onCreatedEmptyRunCmd;
     std::optional<std::string>         defaultName;
     std::map<std::string, std::string> layoutopts;
@@ -148,25 +148,47 @@ class CConfigManager {
     std::string               getErrors();
 
     // keywords
-    std::optional<std::string> handleRawExec(const std::string&, const std::string&);
-    std::optional<std::string> handleExecOnce(const std::string&, const std::string&);
-    std::optional<std::string> handleMonitor(const std::string&, const std::string&);
-    std::optional<std::string> handleBind(const std::string&, const std::string&);
-    std::optional<std::string> handleUnbind(const std::string&, const std::string&);
-    std::optional<std::string> handleWindowRule(const std::string&, const std::string&);
-    std::optional<std::string> handleLayerRule(const std::string&, const std::string&);
-    std::optional<std::string> handleWindowRuleV2(const std::string&, const std::string&);
-    std::optional<std::string> handleWorkspaceRules(const std::string&, const std::string&);
-    std::optional<std::string> handleBezier(const std::string&, const std::string&);
-    std::optional<std::string> handleAnimation(const std::string&, const std::string&);
-    std::optional<std::string> handleSource(const std::string&, const std::string&);
-    std::optional<std::string> handleSubmap(const std::string&, const std::string&);
-    std::optional<std::string> handleBlurLS(const std::string&, const std::string&);
-    std::optional<std::string> handleBindWS(const std::string&, const std::string&);
-    std::optional<std::string> handleEnv(const std::string&, const std::string&);
-    std::optional<std::string> handlePlugin(const std::string&, const std::string&);
+    std::optional<std::string>                                                              handleRawExec(const std::string&, const std::string&);
+    std::optional<std::string>                                                              handleExecOnce(const std::string&, const std::string&);
+    std::optional<std::string>                                                              handleMonitor(const std::string&, const std::string&);
+    std::optional<std::string>                                                              handleBind(const std::string&, const std::string&);
+    std::optional<std::string>                                                              handleUnbind(const std::string&, const std::string&);
+    std::optional<std::string>                                                              handleWindowRule(const std::string&, const std::string&);
+    std::optional<std::string>                                                              handleLayerRule(const std::string&, const std::string&);
+    std::optional<std::string>                                                              handleWindowRuleV2(const std::string&, const std::string&);
+    std::optional<std::string>                                                              handleWorkspaceRules(const std::string&, const std::string&);
+    std::optional<std::string>                                                              handleBezier(const std::string&, const std::string&);
+    std::optional<std::string>                                                              handleAnimation(const std::string&, const std::string&);
+    std::optional<std::string>                                                              handleSource(const std::string&, const std::string&);
+    std::optional<std::string>                                                              handleSubmap(const std::string&, const std::string&);
+    std::optional<std::string>                                                              handleBlurLS(const std::string&, const std::string&);
+    std::optional<std::string>                                                              handleBindWS(const std::string&, const std::string&);
+    std::optional<std::string>                                                              handleEnv(const std::string&, const std::string&);
+    std::optional<std::string>                                                              handlePlugin(const std::string&, const std::string&);
 
-    std::string                configCurrentPath;
+    std::string                                                                             configCurrentPath;
+
+    std::unordered_map<std::string, std::function<CWindowOverridableVar<bool>*(PHLWINDOW)>> mbWindowProperties = {
+        {"dimaround", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.dimAround; }},
+        {"focusonactivate", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.focusOnActivate; }},
+        {"forceinput", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.allowsInput; }},
+        {"forceopaque", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.opaque; }},
+        {"forcergbx", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.RGBX; }},
+        {"immediate", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.tearing; }},
+        {"keepaspectratio", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.keepAspectRatio; }},
+        {"nearestneighbor", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.nearestNeighbor; }},
+        {"noanim", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noAnim; }},
+        {"noblur", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noBlur; }},
+        {"noborder", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noBorder; }},
+        {"nodim", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noDim; }},
+        {"nofocus", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noFocus; }},
+        {"nomaxsize", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noMaxSize; }},
+        {"noshadow", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noShadow; }},
+        {"windowdance", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.windowDanceCompat; }},
+    };
+
+    std::unordered_map<std::string, std::function<CWindowOverridableVar<int>*(PHLWINDOW)>> miWindowProperties = {
+        {"rounding", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.rounding; }}, {"bordersize", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.borderSize; }}};
 
   private:
     std::unique_ptr<Hyprlang::CConfig>                        m_pConfig;

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -187,7 +187,6 @@ class CConfigManager {
         {"forcergbx", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.RGBX; }},
         {"immediate", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.tearing; }},
         {"xray", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.xray; }},
-        {"windowdance", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.windowDanceCompat; }},
     };
 
     std::unordered_map<std::string, std::function<CWindowOverridableVar<int>*(PHLWINDOW)>> miWindowProperties = {

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -186,7 +186,7 @@ class CConfigManager {
         {"opaque", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.opaque; }},
         {"forcergbx", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.RGBX; }},
         {"immediate", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.tearing; }},
-        // {"xray", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.xray; }},
+        {"xray", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.xray; }},
         {"windowdance", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.windowDanceCompat; }},
     };
 

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1206,8 +1206,6 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
     try {
         if (PROP == "animationstyle") {
             PWINDOW->m_sAdditionalConfigData.animationStyle = VAL;
-        } else if (PROP == "rounding") {
-            PWINDOW->m_sAdditionalConfigData.rounding.forceSetIgnoreLocked(configStringToInt(VAL), lock);
         } else if (PROP == "maxsize") {
             PWINDOW->m_sAdditionalConfigData.maxSize.forceSetIgnoreLocked(configStringToVector2D(VAL + " " + vars[4]), lock);
             if (lock) {
@@ -1253,9 +1251,9 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
                 PWINDOW->m_sSpecialRenderData.activeBorderColor.forceSetIgnoreLocked(colorData, lock);
             else
                 PWINDOW->m_sSpecialRenderData.inactiveBorderColor.forceSetIgnoreLocked(colorData, lock);
-        } else if (PROP == "bordersize") {
-            PWINDOW->m_sSpecialRenderData.borderSize.forceSetIgnoreLocked(configStringToInt(VAL), lock);
-        } else if (auto search = PWINDOW->mWindowProperties.find(PROP); search != PWINDOW->mWindowProperties.end()) {
+        } else if (auto search = PWINDOW->mbWindowProperties.find(PROP); search != PWINDOW->mbWindowProperties.end()) {
+            search->second->forceSetIgnoreLocked(configStringToInt(VAL), lock);
+        } else if (auto search = PWINDOW->miWindowProperties.find(PROP); search != PWINDOW->miWindowProperties.end()) {
             search->second->forceSetIgnoreLocked(configStringToInt(VAL), lock);
         } else {
             return "prop not found";

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1196,52 +1196,45 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
     const auto PROP = vars[2];
     const auto VAL  = vars[3];
 
-    bool       noFocus = PWINDOW->m_sWindowData.noFocus.toUnderlying();
-    bool       lock    = false;
-
-    if (request.ends_with("lock"))
-        lock = true;
+    bool       noFocus = PWINDOW->m_sWindowData.noFocus.value_or(false);
 
     try {
         if (PROP == "animationstyle") {
             PWINDOW->m_sWindowData.animationStyle = CWindowOverridableVar(VAL, PRIORITY_SET_PROP);
         } else if (PROP == "maxsize") {
             PWINDOW->m_sWindowData.maxSize = CWindowOverridableVar(configStringToVector2D(VAL + " " + vars[4]), PRIORITY_SET_PROP);
-            if (lock) {
-                PWINDOW->m_vRealSize = Vector2D(std::min((double)PWINDOW->m_sWindowData.maxSize.toUnderlying().x, PWINDOW->m_vRealSize.goal().x),
-                                                std::min((double)PWINDOW->m_sWindowData.maxSize.toUnderlying().y, PWINDOW->m_vRealSize.goal().y));
-                g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal());
-                PWINDOW->setHidden(false);
-            }
+            PWINDOW->m_vRealSize           = Vector2D(std::min((double)PWINDOW->m_sWindowData.maxSize.value().x, PWINDOW->m_vRealSize.goal().x),
+                                                      std::min((double)PWINDOW->m_sWindowData.maxSize.value().y, PWINDOW->m_vRealSize.goal().y));
+            g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal());
+            PWINDOW->setHidden(false);
         } else if (PROP == "minsize") {
             PWINDOW->m_sWindowData.minSize = CWindowOverridableVar(configStringToVector2D(VAL + " " + vars[4]), PRIORITY_SET_PROP);
-            if (lock) {
-                PWINDOW->m_vRealSize = Vector2D(std::max((double)PWINDOW->m_sWindowData.minSize.toUnderlying().x, PWINDOW->m_vRealSize.goal().x),
-                                                std::max((double)PWINDOW->m_sWindowData.minSize.toUnderlying().y, PWINDOW->m_vRealSize.goal().y));
-                g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal());
-                PWINDOW->setHidden(false);
-            }
+            PWINDOW->m_vRealSize           = Vector2D(std::max((double)PWINDOW->m_sWindowData.minSize.value().x, PWINDOW->m_vRealSize.goal().x),
+                                                      std::max((double)PWINDOW->m_sWindowData.minSize.value().y, PWINDOW->m_vRealSize.goal().y));
+            g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal());
+            PWINDOW->setHidden(false);
         } else if (PROP == "alpha") {
-            PWINDOW->m_sWindowData.alpha = CWindowOverridableVar(sAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alpha.toUnderlying().m_bOverride}, PRIORITY_SET_PROP);
+            PWINDOW->m_sWindowData.alpha =
+                CWindowOverridableVar(sAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alpha.value_or(sAlphaValue{1.f, false}).m_bOverride}, PRIORITY_SET_PROP);
         } else if (PROP == "alphainactive") {
             PWINDOW->m_sWindowData.alphaInactive =
-                CWindowOverridableVar(sAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alphaInactive.toUnderlying().m_bOverride}, PRIORITY_SET_PROP);
+                CWindowOverridableVar(sAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alphaInactive.value_or(sAlphaValue{1.f, false}).m_bOverride}, PRIORITY_SET_PROP);
         } else if (PROP == "alphafullscreen") {
             PWINDOW->m_sWindowData.alphaFullscreen =
-                CWindowOverridableVar(sAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alphaFullscreen.toUnderlying().m_bOverride}, PRIORITY_SET_PROP);
+                CWindowOverridableVar(sAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alphaFullscreen.value_or(sAlphaValue{1.f, false}).m_bOverride}, PRIORITY_SET_PROP);
         } else if (PROP == "alphaoverride") {
             PWINDOW->m_sWindowData.alpha =
-                CWindowOverridableVar(sAlphaValue{PWINDOW->m_sWindowData.alpha.toUnderlying().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
+                CWindowOverridableVar(sAlphaValue{PWINDOW->m_sWindowData.alpha.value_or(sAlphaValue{1.f, false}).m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
         } else if (PROP == "alphainactiveoverride") {
-            PWINDOW->m_sWindowData.alphaInactive =
-                CWindowOverridableVar(sAlphaValue{PWINDOW->m_sWindowData.alphaInactive.toUnderlying().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
+            PWINDOW->m_sWindowData.alphaInactive = CWindowOverridableVar(
+                sAlphaValue{PWINDOW->m_sWindowData.alphaInactive.value_or(sAlphaValue{1.f, false}).m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
         } else if (PROP == "alphafullscreenoverride") {
-            PWINDOW->m_sWindowData.alphaFullscreen =
-                CWindowOverridableVar(sAlphaValue{PWINDOW->m_sWindowData.alphaFullscreen.toUnderlying().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
+            PWINDOW->m_sWindowData.alphaFullscreen = CWindowOverridableVar(
+                sAlphaValue{PWINDOW->m_sWindowData.alphaFullscreen.value_or(sAlphaValue{1.f, false}).m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
         } else if (PROP == "activebordercolor" || PROP == "inactivebordercolor") {
             CGradientValueData colorData = {};
             if (vars.size() > 4) {
-                for (int i = 3; i < static_cast<int>(lock ? vars.size() - 1 : vars.size()); ++i) {
+                for (int i = 3; i < static_cast<int>(vars.size()); ++i) {
                     const auto TOKEN = vars[i];
                     if (TOKEN.ends_with("deg"))
                         colorData.m_fAngle = std::stoi(TOKEN.substr(0, TOKEN.size() - 3)) * (PI / 180.0);
@@ -1266,7 +1259,7 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
 
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 
-    if (!(PWINDOW->m_sWindowData.noFocus.toUnderlying() == noFocus)) {
+    if (!(PWINDOW->m_sWindowData.noFocus.value_or(false) == noFocus)) {
         g_pCompositor->focusWindow(nullptr);
         g_pCompositor->focusWindow(PWINDOW);
         g_pCompositor->focusWindow(PLASTWINDOW);

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1196,7 +1196,7 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
     const auto PROP = vars[2];
     const auto VAL  = vars[3];
 
-    bool       noFocus = PWINDOW->m_sWindowData.noFocus.value_or_default();
+    bool       noFocus = PWINDOW->m_sWindowData.noFocus.valueOrDefault();
 
     try {
         if (PROP == "animationstyle") {
@@ -1214,22 +1214,22 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
             g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal());
             PWINDOW->setHidden(false);
         } else if (PROP == "alpha") {
-            PWINDOW->m_sWindowData.alpha = CWindowOverridableVar(SAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alpha.value_or_default().m_bOverride}, PRIORITY_SET_PROP);
+            PWINDOW->m_sWindowData.alpha = CWindowOverridableVar(SAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alpha.valueOrDefault().m_bOverride}, PRIORITY_SET_PROP);
         } else if (PROP == "alphainactive") {
             PWINDOW->m_sWindowData.alphaInactive =
-                CWindowOverridableVar(SAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alphaInactive.value_or_default().m_bOverride}, PRIORITY_SET_PROP);
+                CWindowOverridableVar(SAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alphaInactive.valueOrDefault().m_bOverride}, PRIORITY_SET_PROP);
         } else if (PROP == "alphafullscreen") {
             PWINDOW->m_sWindowData.alphaFullscreen =
-                CWindowOverridableVar(SAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alphaFullscreen.value_or_default().m_bOverride}, PRIORITY_SET_PROP);
+                CWindowOverridableVar(SAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alphaFullscreen.valueOrDefault().m_bOverride}, PRIORITY_SET_PROP);
         } else if (PROP == "alphaoverride") {
             PWINDOW->m_sWindowData.alpha =
-                CWindowOverridableVar(SAlphaValue{PWINDOW->m_sWindowData.alpha.value_or_default().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
+                CWindowOverridableVar(SAlphaValue{PWINDOW->m_sWindowData.alpha.valueOrDefault().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
         } else if (PROP == "alphainactiveoverride") {
             PWINDOW->m_sWindowData.alphaInactive =
-                CWindowOverridableVar(SAlphaValue{PWINDOW->m_sWindowData.alphaInactive.value_or_default().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
+                CWindowOverridableVar(SAlphaValue{PWINDOW->m_sWindowData.alphaInactive.valueOrDefault().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
         } else if (PROP == "alphafullscreenoverride") {
             PWINDOW->m_sWindowData.alphaFullscreen =
-                CWindowOverridableVar(SAlphaValue{PWINDOW->m_sWindowData.alphaFullscreen.value_or_default().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
+                CWindowOverridableVar(SAlphaValue{PWINDOW->m_sWindowData.alphaFullscreen.valueOrDefault().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
         } else if (PROP == "activebordercolor" || PROP == "inactivebordercolor") {
             CGradientValueData colorData = {};
             if (vars.size() > 4) {
@@ -1250,7 +1250,7 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
         } else if (auto search = g_pConfigManager->mbWindowProperties.find(PROP); search != g_pConfigManager->mbWindowProperties.end()) {
             auto pWindowDataElement = search->second(PWINDOW);
             if (VAL == "toggle")
-                *pWindowDataElement = CWindowOverridableVar(!pWindowDataElement->value_or_default(), PRIORITY_SET_PROP);
+                *pWindowDataElement = CWindowOverridableVar(!pWindowDataElement->valueOrDefault(), PRIORITY_SET_PROP);
             else if (VAL == "unset")
                 pWindowDataElement->unset(PRIORITY_SET_PROP);
             else
@@ -1267,7 +1267,7 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
 
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 
-    if (!(PWINDOW->m_sWindowData.noFocus.value_or_default() == noFocus)) {
+    if (!(PWINDOW->m_sWindowData.noFocus.valueOrDefault() == noFocus)) {
         g_pCompositor->focusWindow(nullptr);
         g_pCompositor->focusWindow(PWINDOW);
         g_pCompositor->focusWindow(PLASTWINDOW);

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1250,13 +1250,17 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
                 PWINDOW->m_sWindowData.inactiveBorderColor = CWindowOverridableVar(colorData, PRIORITY_SET_PROP);
         } else if (auto search = g_pConfigManager->mbWindowProperties.find(PROP); search != g_pConfigManager->mbWindowProperties.end()) {
             auto pWindowDataElement = search->second(PWINDOW);
-            if (VAL == "toggle") {
+            if (VAL == "toggle")
                 *pWindowDataElement = CWindowOverridableVar(!pWindowDataElement->value_or_default(), PRIORITY_SET_PROP);
-            } else {
+            else if (VAL == "unset")
+                pWindowDataElement->unset(PRIORITY_SET_PROP);
+            else
                 *pWindowDataElement = CWindowOverridableVar((bool)configStringToInt(VAL), PRIORITY_SET_PROP);
-            }
         } else if (auto search = g_pConfigManager->miWindowProperties.find(PROP); search != g_pConfigManager->miWindowProperties.end()) {
-            *(search->second(PWINDOW)) = CWindowOverridableVar((int)configStringToInt(VAL), PRIORITY_SET_PROP);
+            if (VAL == "unset")
+                search->second(PWINDOW)->unset(PRIORITY_SET_PROP);
+            else
+                *(search->second(PWINDOW)) = CWindowOverridableVar((int)configStringToInt(VAL), PRIORITY_SET_PROP);
         } else {
             return "prop not found";
         }

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1196,44 +1196,43 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
     const auto PROP = vars[2];
     const auto VAL  = vars[3];
 
-    auto       noFocus = PWINDOW->m_sAdditionalConfigData.noFocus;
-
-    bool       lock = false;
+    bool       noFocus = PWINDOW->m_sWindowData.noFocus.toUnderlying();
+    bool       lock    = false;
 
     if (request.ends_with("lock"))
         lock = true;
 
     try {
         if (PROP == "animationstyle") {
-            PWINDOW->m_sAdditionalConfigData.animationStyle = VAL;
+            PWINDOW->m_sWindowData.animationStyle = CWindowOverridableVar(VAL, PRIORITY_SET_PROP);
         } else if (PROP == "maxsize") {
-            PWINDOW->m_sAdditionalConfigData.maxSize.forceSetIgnoreLocked(configStringToVector2D(VAL + " " + vars[4]), lock);
+            PWINDOW->m_sWindowData.maxSize = CWindowOverridableVar(configStringToVector2D(VAL + " " + vars[4]), PRIORITY_SET_PROP);
             if (lock) {
-                PWINDOW->m_vRealSize = Vector2D(std::min((double)PWINDOW->m_sAdditionalConfigData.maxSize.toUnderlying().x, PWINDOW->m_vRealSize.goal().x),
-                                                std::min((double)PWINDOW->m_sAdditionalConfigData.maxSize.toUnderlying().y, PWINDOW->m_vRealSize.goal().y));
+                PWINDOW->m_vRealSize = Vector2D(std::min((double)PWINDOW->m_sWindowData.maxSize.toUnderlying().x, PWINDOW->m_vRealSize.goal().x),
+                                                std::min((double)PWINDOW->m_sWindowData.maxSize.toUnderlying().y, PWINDOW->m_vRealSize.goal().y));
                 g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal());
                 PWINDOW->setHidden(false);
             }
         } else if (PROP == "minsize") {
-            PWINDOW->m_sAdditionalConfigData.minSize.forceSetIgnoreLocked(configStringToVector2D(VAL + " " + vars[4]), lock);
+            PWINDOW->m_sWindowData.minSize = CWindowOverridableVar(configStringToVector2D(VAL + " " + vars[4]), PRIORITY_SET_PROP);
             if (lock) {
-                PWINDOW->m_vRealSize = Vector2D(std::max((double)PWINDOW->m_sAdditionalConfigData.minSize.toUnderlying().x, PWINDOW->m_vRealSize.goal().x),
-                                                std::max((double)PWINDOW->m_sAdditionalConfigData.minSize.toUnderlying().y, PWINDOW->m_vRealSize.goal().y));
+                PWINDOW->m_vRealSize = Vector2D(std::max((double)PWINDOW->m_sWindowData.minSize.toUnderlying().x, PWINDOW->m_vRealSize.goal().x),
+                                                std::max((double)PWINDOW->m_sWindowData.minSize.toUnderlying().y, PWINDOW->m_vRealSize.goal().y));
                 g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal());
                 PWINDOW->setHidden(false);
             }
         } else if (PROP == "alphaoverride") {
-            PWINDOW->m_sSpecialRenderData.alphaOverride.forceSetIgnoreLocked(configStringToInt(VAL), lock);
+            PWINDOW->m_sWindowData.alphaOverride = CWindowOverridableVar((bool)configStringToInt(VAL), PRIORITY_SET_PROP);
         } else if (PROP == "alpha") {
-            PWINDOW->m_sSpecialRenderData.alpha.forceSetIgnoreLocked(std::stof(VAL), lock);
+            PWINDOW->m_sWindowData.alpha = CWindowOverridableVar(std::stof(VAL), PRIORITY_SET_PROP);
         } else if (PROP == "alphainactiveoverride") {
-            PWINDOW->m_sSpecialRenderData.alphaInactiveOverride.forceSetIgnoreLocked(configStringToInt(VAL), lock);
+            PWINDOW->m_sWindowData.alphaInactiveOverride = CWindowOverridableVar((bool)configStringToInt(VAL), PRIORITY_SET_PROP);
         } else if (PROP == "alphainactive") {
-            PWINDOW->m_sSpecialRenderData.alphaInactive.forceSetIgnoreLocked(std::stof(VAL), lock);
+            PWINDOW->m_sWindowData.alphaInactive = CWindowOverridableVar(std::stof(VAL), PRIORITY_SET_PROP);
         } else if (PROP == "alphafullscreenoverride") {
-            PWINDOW->m_sSpecialRenderData.alphaFullscreenOverride.forceSetIgnoreLocked(configStringToInt(VAL), lock);
+            PWINDOW->m_sWindowData.alphaFullscreenOverride = CWindowOverridableVar((bool)configStringToInt(VAL), PRIORITY_SET_PROP);
         } else if (PROP == "alphafullscreen") {
-            PWINDOW->m_sSpecialRenderData.alphaFullscreen.forceSetIgnoreLocked(std::stof(VAL), lock);
+            PWINDOW->m_sWindowData.alphaFullscreen = CWindowOverridableVar(std::stof(VAL), PRIORITY_SET_PROP);
         } else if (PROP == "activebordercolor" || PROP == "inactivebordercolor") {
             CGradientValueData colorData = {};
             if (vars.size() > 4) {
@@ -1248,13 +1247,13 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
                 colorData.m_vColors.push_back(configStringToInt(VAL));
 
             if (PROP == "activebordercolor")
-                PWINDOW->m_sSpecialRenderData.activeBorderColor.forceSetIgnoreLocked(colorData, lock);
+                PWINDOW->m_sWindowData.activeBorderColor = CWindowOverridableVar(colorData, PRIORITY_SET_PROP);
             else
-                PWINDOW->m_sSpecialRenderData.inactiveBorderColor.forceSetIgnoreLocked(colorData, lock);
+                PWINDOW->m_sWindowData.inactiveBorderColor = CWindowOverridableVar(colorData, PRIORITY_SET_PROP);
         } else if (auto search = PWINDOW->mbWindowProperties.find(PROP); search != PWINDOW->mbWindowProperties.end()) {
-            search->second->forceSetIgnoreLocked(configStringToInt(VAL), lock);
+            *(search->second) = CWindowOverridableVar((bool)configStringToInt(VAL), PRIORITY_SET_PROP);
         } else if (auto search = PWINDOW->miWindowProperties.find(PROP); search != PWINDOW->miWindowProperties.end()) {
-            search->second->forceSetIgnoreLocked(configStringToInt(VAL), lock);
+            *(search->second) = CWindowOverridableVar((int)configStringToInt(VAL), PRIORITY_SET_PROP);
         } else {
             return "prop not found";
         }
@@ -1262,7 +1261,7 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
 
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 
-    if (!(PWINDOW->m_sAdditionalConfigData.noFocus.toUnderlying() == noFocus.toUnderlying())) {
+    if (!(PWINDOW->m_sWindowData.noFocus.toUnderlying() == noFocus)) {
         g_pCompositor->focusWindow(nullptr);
         g_pCompositor->focusWindow(PWINDOW);
         g_pCompositor->focusWindow(PLASTWINDOW);

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1221,18 +1221,23 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
                 g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal());
                 PWINDOW->setHidden(false);
             }
-        } else if (PROP == "alphaoverride") {
-            PWINDOW->m_sWindowData.alphaOverride = CWindowOverridableVar((bool)configStringToInt(VAL), PRIORITY_SET_PROP);
         } else if (PROP == "alpha") {
-            PWINDOW->m_sWindowData.alpha = CWindowOverridableVar(std::stof(VAL), PRIORITY_SET_PROP);
-        } else if (PROP == "alphainactiveoverride") {
-            PWINDOW->m_sWindowData.alphaInactiveOverride = CWindowOverridableVar((bool)configStringToInt(VAL), PRIORITY_SET_PROP);
+            PWINDOW->m_sWindowData.alpha = CWindowOverridableVar(sAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alpha.toUnderlying().m_bOverride}, PRIORITY_SET_PROP);
         } else if (PROP == "alphainactive") {
-            PWINDOW->m_sWindowData.alphaInactive = CWindowOverridableVar(std::stof(VAL), PRIORITY_SET_PROP);
-        } else if (PROP == "alphafullscreenoverride") {
-            PWINDOW->m_sWindowData.alphaFullscreenOverride = CWindowOverridableVar((bool)configStringToInt(VAL), PRIORITY_SET_PROP);
+            PWINDOW->m_sWindowData.alphaInactive =
+                CWindowOverridableVar(sAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alphaInactive.toUnderlying().m_bOverride}, PRIORITY_SET_PROP);
         } else if (PROP == "alphafullscreen") {
-            PWINDOW->m_sWindowData.alphaFullscreen = CWindowOverridableVar(std::stof(VAL), PRIORITY_SET_PROP);
+            PWINDOW->m_sWindowData.alphaFullscreen =
+                CWindowOverridableVar(sAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alphaFullscreen.toUnderlying().m_bOverride}, PRIORITY_SET_PROP);
+        } else if (PROP == "alphaoverride") {
+            PWINDOW->m_sWindowData.alpha =
+                CWindowOverridableVar(sAlphaValue{PWINDOW->m_sWindowData.alpha.toUnderlying().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
+        } else if (PROP == "alphainactiveoverride") {
+            PWINDOW->m_sWindowData.alphaInactive =
+                CWindowOverridableVar(sAlphaValue{PWINDOW->m_sWindowData.alphaInactive.toUnderlying().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
+        } else if (PROP == "alphafullscreenoverride") {
+            PWINDOW->m_sWindowData.alphaFullscreen =
+                CWindowOverridableVar(sAlphaValue{PWINDOW->m_sWindowData.alphaFullscreen.toUnderlying().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
         } else if (PROP == "activebordercolor" || PROP == "inactivebordercolor") {
             CGradientValueData colorData = {};
             if (vars.size() > 4) {
@@ -1809,7 +1814,6 @@ int hyprCtlFDTick(int fd, uint32_t mask, void* data) {
 }
 
 void CHyprCtl::startHyprCtlSocket() {
-
     m_iSocketFD = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
 
     if (m_iSocketFD < 0) {

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1208,28 +1208,6 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
             PWINDOW->m_sAdditionalConfigData.animationStyle = VAL;
         } else if (PROP == "rounding") {
             PWINDOW->m_sAdditionalConfigData.rounding.forceSetIgnoreLocked(configStringToInt(VAL), lock);
-        } else if (PROP == "forcenoblur") {
-            PWINDOW->m_sAdditionalConfigData.forceNoBlur.forceSetIgnoreLocked(configStringToInt(VAL), lock);
-        } else if (PROP == "forceopaque") {
-            PWINDOW->m_sAdditionalConfigData.forceOpaque.forceSetIgnoreLocked(configStringToInt(VAL), lock);
-        } else if (PROP == "forceopaqueoverriden") {
-            PWINDOW->m_sAdditionalConfigData.forceOpaqueOverridden.forceSetIgnoreLocked(configStringToInt(VAL), lock);
-        } else if (PROP == "forceallowsinput") {
-            PWINDOW->m_sAdditionalConfigData.forceAllowsInput.forceSetIgnoreLocked(configStringToInt(VAL), lock);
-        } else if (PROP == "forcenoanims") {
-            PWINDOW->m_sAdditionalConfigData.forceNoAnims.forceSetIgnoreLocked(configStringToInt(VAL), lock);
-        } else if (PROP == "forcenoborder") {
-            PWINDOW->m_sAdditionalConfigData.forceNoBorder.forceSetIgnoreLocked(configStringToInt(VAL), lock);
-        } else if (PROP == "forcenoshadow") {
-            PWINDOW->m_sAdditionalConfigData.forceNoShadow.forceSetIgnoreLocked(configStringToInt(VAL), lock);
-        } else if (PROP == "forcenodim") {
-            PWINDOW->m_sAdditionalConfigData.forceNoDim.forceSetIgnoreLocked(configStringToInt(VAL), lock);
-        } else if (PROP == "nofocus") {
-            PWINDOW->m_sAdditionalConfigData.noFocus.forceSetIgnoreLocked(configStringToInt(VAL), lock);
-        } else if (PROP == "windowdancecompat") {
-            PWINDOW->m_sAdditionalConfigData.windowDanceCompat.forceSetIgnoreLocked(configStringToInt(VAL), lock);
-        } else if (PROP == "nomaxsize") {
-            PWINDOW->m_sAdditionalConfigData.noMaxSize.forceSetIgnoreLocked(configStringToInt(VAL), lock);
         } else if (PROP == "maxsize") {
             PWINDOW->m_sAdditionalConfigData.maxSize.forceSetIgnoreLocked(configStringToVector2D(VAL + " " + vars[4]), lock);
             if (lock) {
@@ -1246,8 +1224,6 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
                 g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal());
                 PWINDOW->setHidden(false);
             }
-        } else if (PROP == "dimaround") {
-            PWINDOW->m_sAdditionalConfigData.dimAround.forceSetIgnoreLocked(configStringToInt(VAL), lock);
         } else if (PROP == "alphaoverride") {
             PWINDOW->m_sSpecialRenderData.alphaOverride.forceSetIgnoreLocked(configStringToInt(VAL), lock);
         } else if (PROP == "alpha") {
@@ -1277,16 +1253,10 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
                 PWINDOW->m_sSpecialRenderData.activeBorderColor.forceSetIgnoreLocked(colorData, lock);
             else
                 PWINDOW->m_sSpecialRenderData.inactiveBorderColor.forceSetIgnoreLocked(colorData, lock);
-        } else if (PROP == "forcergbx") {
-            PWINDOW->m_sAdditionalConfigData.forceRGBX.forceSetIgnoreLocked(configStringToInt(VAL), lock);
         } else if (PROP == "bordersize") {
             PWINDOW->m_sSpecialRenderData.borderSize.forceSetIgnoreLocked(configStringToInt(VAL), lock);
-        } else if (PROP == "keepaspectratio") {
-            PWINDOW->m_sAdditionalConfigData.keepAspectRatio.forceSetIgnoreLocked(configStringToInt(VAL), lock);
-        } else if (PROP == "immediate") {
-            PWINDOW->m_sAdditionalConfigData.forceTearing.forceSetIgnoreLocked(configStringToInt(VAL), lock);
-        } else if (PROP == "nearestneighbor") {
-            PWINDOW->m_sAdditionalConfigData.nearestNeighbor.forceSetIgnoreLocked(configStringToInt(VAL), lock);
+        } else if (auto search = PWINDOW->mWindowProperties.find(PROP); search != PWINDOW->mWindowProperties.end()) {
+            search->second->forceSetIgnoreLocked(configStringToInt(VAL), lock);
         } else {
             return "prop not found";
         }

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -312,8 +312,8 @@ static std::string getWorkspaceRuleData(const SWorkspaceRule& r, eHyprCtlOutputF
                "";
         const std::string borderSize = (bool)(r.borderSize) ? std::format(",\n    \"borderSize\": {}", r.borderSize.value()) : "";
         const std::string border     = (bool)(r.noBorder) ? std::format(",\n    \"border\": {}", boolToString(!r.noBorder.value())) : "";
-        const std::string rounding   = (bool)(r.noRounding) ? std::format(",\n    \"rounding\": {}", boolToString(r.noRounding.value())) : "";
-        const std::string decorate   = (bool)(r.decorate) ? std::format(",\n    \"decorate\": {}", boolToString(!r.decorate.value())) : "";
+        const std::string rounding   = (bool)(r.noRounding) ? std::format(",\n    \"rounding\": {}", boolToString(!r.noRounding.value())) : "";
+        const std::string decorate   = (bool)(r.decorate) ? std::format(",\n    \"decorate\": {}", boolToString(r.decorate.value())) : "";
         const std::string shadow     = (bool)(r.noShadow) ? std::format(",\n    \"shadow\": {}", boolToString(!r.noShadow.value())) : "";
 
         std::string       result = std::format(R"#({{
@@ -1214,23 +1214,22 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
             g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal());
             PWINDOW->setHidden(false);
         } else if (PROP == "alpha") {
-            PWINDOW->m_sWindowData.alpha =
-                CWindowOverridableVar(sAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alpha.value_or(sAlphaValue{1.f, false}).m_bOverride}, PRIORITY_SET_PROP);
+            PWINDOW->m_sWindowData.alpha = CWindowOverridableVar(sAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alpha.value_or_default().m_bOverride}, PRIORITY_SET_PROP);
         } else if (PROP == "alphainactive") {
             PWINDOW->m_sWindowData.alphaInactive =
-                CWindowOverridableVar(sAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alphaInactive.value_or(sAlphaValue{1.f, false}).m_bOverride}, PRIORITY_SET_PROP);
+                CWindowOverridableVar(sAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alphaInactive.value_or_default().m_bOverride}, PRIORITY_SET_PROP);
         } else if (PROP == "alphafullscreen") {
             PWINDOW->m_sWindowData.alphaFullscreen =
-                CWindowOverridableVar(sAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alphaFullscreen.value_or(sAlphaValue{1.f, false}).m_bOverride}, PRIORITY_SET_PROP);
+                CWindowOverridableVar(sAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alphaFullscreen.value_or_default().m_bOverride}, PRIORITY_SET_PROP);
         } else if (PROP == "alphaoverride") {
             PWINDOW->m_sWindowData.alpha =
-                CWindowOverridableVar(sAlphaValue{PWINDOW->m_sWindowData.alpha.value_or(sAlphaValue{1.f, false}).m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
+                CWindowOverridableVar(sAlphaValue{PWINDOW->m_sWindowData.alpha.value_or_default().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
         } else if (PROP == "alphainactiveoverride") {
-            PWINDOW->m_sWindowData.alphaInactive = CWindowOverridableVar(
-                sAlphaValue{PWINDOW->m_sWindowData.alphaInactive.value_or(sAlphaValue{1.f, false}).m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
+            PWINDOW->m_sWindowData.alphaInactive =
+                CWindowOverridableVar(sAlphaValue{PWINDOW->m_sWindowData.alphaInactive.value_or_default().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
         } else if (PROP == "alphafullscreenoverride") {
-            PWINDOW->m_sWindowData.alphaFullscreen = CWindowOverridableVar(
-                sAlphaValue{PWINDOW->m_sWindowData.alphaFullscreen.value_or(sAlphaValue{1.f, false}).m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
+            PWINDOW->m_sWindowData.alphaFullscreen =
+                CWindowOverridableVar(sAlphaValue{PWINDOW->m_sWindowData.alphaFullscreen.value_or_default().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
         } else if (PROP == "activebordercolor" || PROP == "inactivebordercolor") {
             CGradientValueData colorData = {};
             if (vars.size() > 4) {

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1249,7 +1249,12 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
             else
                 PWINDOW->m_sWindowData.inactiveBorderColor = CWindowOverridableVar(colorData, PRIORITY_SET_PROP);
         } else if (auto search = g_pConfigManager->mbWindowProperties.find(PROP); search != g_pConfigManager->mbWindowProperties.end()) {
-            *(search->second(PWINDOW)) = CWindowOverridableVar((bool)configStringToInt(VAL), PRIORITY_SET_PROP);
+            auto pWindowDataElement = search->second(PWINDOW);
+            if (VAL == "toggle") {
+                *pWindowDataElement = CWindowOverridableVar(!pWindowDataElement->value_or_default(), PRIORITY_SET_PROP);
+            } else {
+                *pWindowDataElement = CWindowOverridableVar((bool)configStringToInt(VAL), PRIORITY_SET_PROP);
+            }
         } else if (auto search = g_pConfigManager->miWindowProperties.find(PROP); search != g_pConfigManager->miWindowProperties.end()) {
             *(search->second(PWINDOW)) = CWindowOverridableVar((int)configStringToInt(VAL), PRIORITY_SET_PROP);
         } else {

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -311,10 +311,10 @@ static std::string getWorkspaceRuleData(const SWorkspaceRule& r, eHyprCtlOutputF
                std::format(",\n    \"gapsOut\": [{}, {}, {}, {}]", r.gapsOut.value().top, r.gapsOut.value().right, r.gapsOut.value().bottom, r.gapsOut.value().left) :
                "";
         const std::string borderSize = (bool)(r.borderSize) ? std::format(",\n    \"borderSize\": {}", r.borderSize.value()) : "";
-        const std::string border     = (bool)(r.border) ? std::format(",\n    \"border\": {}", boolToString(r.border.value())) : "";
-        const std::string rounding   = (bool)(r.rounding) ? std::format(",\n    \"rounding\": {}", boolToString(r.rounding.value())) : "";
-        const std::string decorate   = (bool)(r.decorate) ? std::format(",\n    \"decorate\": {}", boolToString(r.decorate.value())) : "";
-        const std::string shadow     = (bool)(r.shadow) ? std::format(",\n    \"shadow\": {}", boolToString(r.shadow.value())) : "";
+        const std::string border     = (bool)(r.noBorder) ? std::format(",\n    \"border\": {}", boolToString(!r.noBorder.value())) : "";
+        const std::string rounding   = (bool)(r.noRounding) ? std::format(",\n    \"rounding\": {}", boolToString(r.noRounding.value())) : "";
+        const std::string decorate   = (bool)(r.decorate) ? std::format(",\n    \"decorate\": {}", boolToString(!r.decorate.value())) : "";
+        const std::string shadow     = (bool)(r.noShadow) ? std::format(",\n    \"shadow\": {}", boolToString(!r.noShadow.value())) : "";
 
         std::string       result = std::format(R"#({{
     "workspaceString": "{}"{}{}{}{}{}{}{}{}
@@ -333,10 +333,10 @@ static std::string getWorkspaceRuleData(const SWorkspaceRule& r, eHyprCtlOutputF
                                                                        std::to_string(r.gapsOut.value().bottom), std::to_string(r.gapsOut.value().left)) :
                                                            std::format("\tgapsOut: <unset>\n");
         const std::string borderSize = std::format("\tborderSize: {}\n", (bool)(r.borderSize) ? std::to_string(r.borderSize.value()) : "<unset>");
-        const std::string border     = std::format("\tborder: {}\n", (bool)(r.border) ? boolToString(r.border.value()) : "<unset>");
-        const std::string rounding   = std::format("\trounding: {}\n", (bool)(r.rounding) ? boolToString(r.rounding.value()) : "<unset>");
+        const std::string border     = std::format("\tborder: {}\n", (bool)(r.noBorder) ? boolToString(!r.noBorder.value()) : "<unset>");
+        const std::string rounding   = std::format("\trounding: {}\n", (bool)(r.noRounding) ? boolToString(!r.noRounding.value()) : "<unset>");
         const std::string decorate   = std::format("\tdecorate: {}\n", (bool)(r.decorate) ? boolToString(r.decorate.value()) : "<unset>");
-        const std::string shadow     = std::format("\tshadow: {}\n", (bool)(r.shadow) ? boolToString(r.shadow.value()) : "<unset>");
+        const std::string shadow     = std::format("\tshadow: {}\n", (bool)(r.noShadow) ? boolToString(!r.noShadow.value()) : "<unset>");
 
         std::string       result = std::format("Workspace rule {}:\n{}{}{}{}{}{}{}{}{}{}\n", escapeJSONStrings(r.workspaceString), monitor, default_, persistent, gapsIn, gapsOut,
                                                borderSize, border, rounding, decorate, shadow);
@@ -1248,10 +1248,10 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
                 PWINDOW->m_sWindowData.activeBorderColor = CWindowOverridableVar(colorData, PRIORITY_SET_PROP);
             else
                 PWINDOW->m_sWindowData.inactiveBorderColor = CWindowOverridableVar(colorData, PRIORITY_SET_PROP);
-        } else if (auto search = PWINDOW->mbWindowProperties.find(PROP); search != PWINDOW->mbWindowProperties.end()) {
-            *(search->second) = CWindowOverridableVar((bool)configStringToInt(VAL), PRIORITY_SET_PROP);
-        } else if (auto search = PWINDOW->miWindowProperties.find(PROP); search != PWINDOW->miWindowProperties.end()) {
-            *(search->second) = CWindowOverridableVar((int)configStringToInt(VAL), PRIORITY_SET_PROP);
+        } else if (auto search = g_pConfigManager->mbWindowProperties.find(PROP); search != g_pConfigManager->mbWindowProperties.end()) {
+            *(search->second(PWINDOW)) = CWindowOverridableVar((bool)configStringToInt(VAL), PRIORITY_SET_PROP);
+        } else if (auto search = g_pConfigManager->miWindowProperties.find(PROP); search != g_pConfigManager->miWindowProperties.end()) {
+            *(search->second(PWINDOW)) = CWindowOverridableVar((int)configStringToInt(VAL), PRIORITY_SET_PROP);
         } else {
             return "prop not found";
         }

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1214,22 +1214,22 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
             g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal());
             PWINDOW->setHidden(false);
         } else if (PROP == "alpha") {
-            PWINDOW->m_sWindowData.alpha = CWindowOverridableVar(sAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alpha.value_or_default().m_bOverride}, PRIORITY_SET_PROP);
+            PWINDOW->m_sWindowData.alpha = CWindowOverridableVar(SAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alpha.value_or_default().m_bOverride}, PRIORITY_SET_PROP);
         } else if (PROP == "alphainactive") {
             PWINDOW->m_sWindowData.alphaInactive =
-                CWindowOverridableVar(sAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alphaInactive.value_or_default().m_bOverride}, PRIORITY_SET_PROP);
+                CWindowOverridableVar(SAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alphaInactive.value_or_default().m_bOverride}, PRIORITY_SET_PROP);
         } else if (PROP == "alphafullscreen") {
             PWINDOW->m_sWindowData.alphaFullscreen =
-                CWindowOverridableVar(sAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alphaFullscreen.value_or_default().m_bOverride}, PRIORITY_SET_PROP);
+                CWindowOverridableVar(SAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alphaFullscreen.value_or_default().m_bOverride}, PRIORITY_SET_PROP);
         } else if (PROP == "alphaoverride") {
             PWINDOW->m_sWindowData.alpha =
-                CWindowOverridableVar(sAlphaValue{PWINDOW->m_sWindowData.alpha.value_or_default().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
+                CWindowOverridableVar(SAlphaValue{PWINDOW->m_sWindowData.alpha.value_or_default().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
         } else if (PROP == "alphainactiveoverride") {
             PWINDOW->m_sWindowData.alphaInactive =
-                CWindowOverridableVar(sAlphaValue{PWINDOW->m_sWindowData.alphaInactive.value_or_default().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
+                CWindowOverridableVar(SAlphaValue{PWINDOW->m_sWindowData.alphaInactive.value_or_default().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
         } else if (PROP == "alphafullscreenoverride") {
             PWINDOW->m_sWindowData.alphaFullscreen =
-                CWindowOverridableVar(sAlphaValue{PWINDOW->m_sWindowData.alphaFullscreen.value_or_default().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
+                CWindowOverridableVar(SAlphaValue{PWINDOW->m_sWindowData.alphaFullscreen.value_or_default().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
         } else if (PROP == "activebordercolor" || PROP == "inactivebordercolor") {
             CGradientValueData colorData = {};
             if (vars.size() > 4) {

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1196,7 +1196,7 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
     const auto PROP = vars[2];
     const auto VAL  = vars[3];
 
-    bool       noFocus = PWINDOW->m_sWindowData.noFocus.value_or(false);
+    bool       noFocus = PWINDOW->m_sWindowData.noFocus.value_or_default();
 
     try {
         if (PROP == "animationstyle") {
@@ -1259,7 +1259,7 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
 
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 
-    if (!(PWINDOW->m_sWindowData.noFocus.value_or(false) == noFocus)) {
+    if (!(PWINDOW->m_sWindowData.noFocus.value_or_default() == noFocus)) {
         g_pCompositor->focusWindow(nullptr);
         g_pCompositor->focusWindow(PWINDOW);
         g_pCompositor->focusWindow(PLASTWINDOW);

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -110,7 +110,7 @@ SBoxExtents CWindow::getFullWindowExtents() {
 
     const int BORDERSIZE = getRealBorderSize();
 
-    if (m_sWindowData.dimAround.value_or(false)) {
+    if (m_sWindowData.dimAround.value_or_default()) {
         if (const auto PMONITOR = g_pCompositor->getMonitorFromID(m_iMonitorID); PMONITOR)
             return {{m_vRealPosition.value().x - PMONITOR->vecPosition.x, m_vRealPosition.value().y - PMONITOR->vecPosition.y},
                     {PMONITOR->vecSize.x - (m_vRealPosition.value().x - PMONITOR->vecPosition.x), PMONITOR->vecSize.y - (m_vRealPosition.value().y - PMONITOR->vecPosition.y)}};
@@ -170,7 +170,7 @@ SBoxExtents CWindow::getFullWindowExtents() {
 }
 
 CBox CWindow::getFullWindowBoundingBox() {
-    if (m_sWindowData.dimAround.value_or(false)) {
+    if (m_sWindowData.dimAround.value_or_default()) {
         if (const auto PMONITOR = g_pCompositor->getMonitorFromID(m_iMonitorID); PMONITOR)
             return {PMONITOR->vecPosition.x, PMONITOR->vecPosition.y, PMONITOR->vecSize.x, PMONITOR->vecSize.y};
     }
@@ -218,7 +218,7 @@ CBox CWindow::getWindowIdealBoundingBoxIgnoreReserved() {
 }
 
 CBox CWindow::getWindowBoxUnified(uint64_t properties) {
-    if (m_sWindowData.dimAround.value_or(false)) {
+    if (m_sWindowData.dimAround.value_or_default()) {
         const auto PMONITOR = g_pCompositor->getMonitorFromID(m_iMonitorID);
         if (PMONITOR)
             return {PMONITOR->vecPosition.x, PMONITOR->vecPosition.y, PMONITOR->vecSize.x, PMONITOR->vecSize.y};
@@ -1135,7 +1135,7 @@ float CWindow::rounding() {
 
     float       rounding = m_sWindowData.rounding.value_or(*PROUNDING);
 
-    return m_sWindowData.noRounding.value_or(false) ? 0 : rounding;
+    return m_sWindowData.noRounding.value_or_default() ? 0 : rounding;
 }
 
 void CWindow::updateWindowData() {
@@ -1160,7 +1160,7 @@ void CWindow::updateWindowData(const SWorkspaceRule& workspaceRule) {
 }
 
 int CWindow::getRealBorderSize() {
-    if (m_sWindowData.noBorder.value_or(false) || (m_pWorkspace && m_bIsFullscreen && (m_pWorkspace->m_efFullscreenMode == FULLSCREEN_FULL)))
+    if (m_sWindowData.noBorder.value_or_default() || (m_pWorkspace && m_bIsFullscreen && (m_pWorkspace->m_efFullscreenMode == FULLSCREEN_FULL)))
         return 0;
 
     static auto PBORDERSIZE = CConfigValue<Hyprlang::INT>("general:border_size");
@@ -1494,7 +1494,7 @@ void CWindow::onX11Configure(CBox box) {
 
     m_bCreatedOverFullscreen = true;
 
-    if (!m_sWindowData.windowDanceCompat.value_or(false))
+    if (!m_sWindowData.windowDanceCompat.value_or_default())
         g_pInputManager->refocus();
 
     g_pHyprRenderer->damageWindow(m_pSelf.lock());

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -757,33 +757,18 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
 }
 
 void CWindow::updateDynamicRules() {
-    m_sWindowData.activeBorderColor.unset(PRIORITY_WINDOW_RULE);
-    m_sWindowData.inactiveBorderColor.unset(PRIORITY_WINDOW_RULE);
     m_sWindowData.alpha.unset(PRIORITY_WINDOW_RULE);
     m_sWindowData.alphaInactive.unset(PRIORITY_WINDOW_RULE);
     m_sWindowData.alphaFullscreen.unset(PRIORITY_WINDOW_RULE);
 
-    m_sWindowData.opaque.unset(PRIORITY_WINDOW_RULE);
+    unsetWindowData(PRIORITY_WINDOW_RULE);
 
     m_sWindowData.animationStyle.unset(PRIORITY_WINDOW_RULE);
     m_sWindowData.maxSize.unset(PRIORITY_WINDOW_RULE);
     m_sWindowData.minSize.unset(PRIORITY_WINDOW_RULE);
 
-    m_sWindowData.dimAround.unset(PRIORITY_WINDOW_RULE);
-    m_sWindowData.noAnim.unset(PRIORITY_WINDOW_RULE);
-    m_sWindowData.noBlur.unset(PRIORITY_WINDOW_RULE);
-    m_sWindowData.noDim.unset(PRIORITY_WINDOW_RULE);
-    m_sWindowData.noBorder.unset(PRIORITY_WINDOW_RULE);
-    m_sWindowData.noShadow.unset(PRIORITY_WINDOW_RULE);
-    m_sWindowData.focusOnActivate.unset(PRIORITY_WINDOW_RULE);
-    m_sWindowData.RGBX.unset(PRIORITY_WINDOW_RULE);
-    m_sWindowData.tearing.unset(PRIORITY_WINDOW_RULE);
-    m_sWindowData.keepAspectRatio.unset(PRIORITY_WINDOW_RULE);
-    m_sWindowData.nearestNeighbor.unset(PRIORITY_WINDOW_RULE);
-    m_sWindowData.xray.unset(PRIORITY_WINDOW_RULE);
-
-    m_sWindowData.borderSize.unset(PRIORITY_WINDOW_RULE);
-    m_sWindowData.rounding.unset(PRIORITY_WINDOW_RULE);
+    m_sWindowData.activeBorderColor.unset(PRIORITY_WINDOW_RULE);
+    m_sWindowData.inactiveBorderColor.unset(PRIORITY_WINDOW_RULE);
 
     m_eIdleInhibitMode = IDLEINHIBIT_NONE;
 
@@ -1565,4 +1550,13 @@ PHLWINDOW CWindow::getSwallower() {
 
     // if none are found (??) then just return the first one
     return candidates.at(0);
+}
+
+void CWindow::unsetWindowData(eOverridePriority priority) {
+    for (auto const& element : g_pConfigManager->mbWindowProperties) {
+        element.second(m_pSelf.lock())->unset(priority);
+    }
+    for (auto const& element : g_pConfigManager->miWindowProperties) {
+        element.second(m_pSelf.lock())->unset(priority);
+    }
 }

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -281,23 +281,22 @@ void CWindow::updateWindowDecos() {
 }
 
 void CWindow::createWindowProperties() {
-    mbWindowProperties["dimaround"]            = &m_sWindowData.dimAround;
-    mbWindowProperties["focusonactivate"]      = &m_sWindowData.focusOnActivate;
-    mbWindowProperties["forceinput"]           = &m_sWindowData.allowsInput;
-    mbWindowProperties["forceopaque"]          = &m_sWindowData.opaque;
-    mbWindowProperties["forceopaqueoverriden"] = &m_sWindowData.opaqueOverridden;
-    mbWindowProperties["forcergbx"]            = &m_sWindowData.RGBX;
-    mbWindowProperties["immediate"]            = &m_sWindowData.tearing;
-    mbWindowProperties["keepaspectratio"]      = &m_sWindowData.keepAspectRatio;
-    mbWindowProperties["nearestneighbor"]      = &m_sWindowData.nearestNeighbor;
-    mbWindowProperties["noanim"]               = &m_sWindowData.noAnim;
-    mbWindowProperties["noblur"]               = &m_sWindowData.noBlur;
-    mbWindowProperties["noborder"]             = &m_sWindowData.noBorder;
-    mbWindowProperties["nodim"]                = &m_sWindowData.noDim;
-    mbWindowProperties["nofocus"]              = &m_sWindowData.noFocus;
-    mbWindowProperties["nomaxsize"]            = &m_sWindowData.noMaxSize;
-    mbWindowProperties["noshadow"]             = &m_sWindowData.noShadow;
-    mbWindowProperties["windowdance"]          = &m_sWindowData.windowDanceCompat;
+    mbWindowProperties["dimaround"]       = &m_sWindowData.dimAround;
+    mbWindowProperties["focusonactivate"] = &m_sWindowData.focusOnActivate;
+    mbWindowProperties["forceinput"]      = &m_sWindowData.allowsInput;
+    mbWindowProperties["forceopaque"]     = &m_sWindowData.opaque;
+    mbWindowProperties["forcergbx"]       = &m_sWindowData.RGBX;
+    mbWindowProperties["immediate"]       = &m_sWindowData.tearing;
+    mbWindowProperties["keepaspectratio"] = &m_sWindowData.keepAspectRatio;
+    mbWindowProperties["nearestneighbor"] = &m_sWindowData.nearestNeighbor;
+    mbWindowProperties["noanim"]          = &m_sWindowData.noAnim;
+    mbWindowProperties["noblur"]          = &m_sWindowData.noBlur;
+    mbWindowProperties["noborder"]        = &m_sWindowData.noBorder;
+    mbWindowProperties["nodim"]           = &m_sWindowData.noDim;
+    mbWindowProperties["nofocus"]         = &m_sWindowData.noFocus;
+    mbWindowProperties["nomaxsize"]       = &m_sWindowData.noMaxSize;
+    mbWindowProperties["noshadow"]        = &m_sWindowData.noShadow;
+    mbWindowProperties["windowdance"]     = &m_sWindowData.windowDanceCompat;
 
     miWindowProperties["rounding"]   = &m_sWindowData.rounding;
     miWindowProperties["bordersize"] = &m_sWindowData.borderSize;
@@ -631,8 +630,7 @@ bool CWindow::isHidden() {
 
 void CWindow::applyDynamicRule(const SWindowRule& r) {
     if (r.szRule == "opaque") {
-        if (!m_sWindowData.opaqueOverridden)
-            m_sWindowData.opaque = CWindowOverridableVar(true, PRIORITY_WINDOW_RULE);
+        m_sWindowData.opaque = CWindowOverridableVar(true, PRIORITY_WINDOW_RULE);
     } else if (r.szRule.starts_with("tag")) {
         CVarList vars{r.szRule, 0, 's', true};
 
@@ -652,21 +650,18 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
 
                 if (r == "override") {
                     if (opacityIDX == 1)
-                        m_sWindowData.alphaOverride = CWindowOverridableVar(true, PRIORITY_WINDOW_RULE);
+                        m_sWindowData.alpha = CWindowOverridableVar(sAlphaValue{m_sWindowData.alpha.toUnderlying().m_fAlpha, true}, PRIORITY_WINDOW_RULE);
                     else if (opacityIDX == 2)
-                        m_sWindowData.alphaInactiveOverride = CWindowOverridableVar(true, PRIORITY_WINDOW_RULE);
+                        m_sWindowData.alphaInactive = CWindowOverridableVar(sAlphaValue{m_sWindowData.alphaInactive.toUnderlying().m_fAlpha, true}, PRIORITY_WINDOW_RULE);
                     else if (opacityIDX == 3)
-                        m_sWindowData.alphaFullscreenOverride = CWindowOverridableVar(true, PRIORITY_WINDOW_RULE);
+                        m_sWindowData.alphaFullscreen = CWindowOverridableVar(sAlphaValue{m_sWindowData.alphaFullscreen.toUnderlying().m_fAlpha, true}, PRIORITY_WINDOW_RULE);
                 } else {
                     if (opacityIDX == 0) {
-                        m_sWindowData.alpha         = CWindowOverridableVar(std::stof(r), PRIORITY_WINDOW_RULE);
-                        m_sWindowData.alphaOverride = CWindowOverridableVar(false, PRIORITY_WINDOW_RULE);
+                        m_sWindowData.alpha = CWindowOverridableVar(sAlphaValue{std::stof(r), false}, PRIORITY_WINDOW_RULE);
                     } else if (opacityIDX == 1) {
-                        m_sWindowData.alphaInactive         = CWindowOverridableVar(std::stof(r), PRIORITY_WINDOW_RULE);
-                        m_sWindowData.alphaInactiveOverride = CWindowOverridableVar(false, PRIORITY_WINDOW_RULE);
+                        m_sWindowData.alphaInactive = CWindowOverridableVar(sAlphaValue{std::stof(r), false}, PRIORITY_WINDOW_RULE);
                     } else if (opacityIDX == 2) {
-                        m_sWindowData.alphaFullscreen         = CWindowOverridableVar(std::stof(r), PRIORITY_WINDOW_RULE);
-                        m_sWindowData.alphaFullscreenOverride = CWindowOverridableVar(false, PRIORITY_WINDOW_RULE);
+                        m_sWindowData.alphaFullscreen = CWindowOverridableVar(sAlphaValue{std::stof(r), false}, PRIORITY_WINDOW_RULE);
                     } else {
                         throw std::runtime_error("more than 3 alpha values");
                     }
@@ -676,10 +671,8 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
             }
 
             if (opacityIDX == 1) {
-                m_sWindowData.alphaInactiveOverride   = m_sWindowData.alphaOverride;
-                m_sWindowData.alphaInactive           = m_sWindowData.alpha;
-                m_sWindowData.alphaFullscreenOverride = m_sWindowData.alphaOverride;
-                m_sWindowData.alphaFullscreen         = m_sWindowData.alpha;
+                m_sWindowData.alphaInactive   = m_sWindowData.alpha;
+                m_sWindowData.alphaFullscreen = m_sWindowData.alpha;
             }
         } catch (std::exception& e) { Debug::log(ERR, "Opacity rule \"{}\" failed with: {}", r.szRule, e.what()); }
     } else if (r.szRule.starts_with("animation")) {
@@ -788,11 +781,11 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
 void CWindow::updateDynamicRules() {
     m_sWindowData.activeBorderColor   = CWindowOverridableVar(CGradientValueData(), PRIORITY_NONE);
     m_sWindowData.inactiveBorderColor = CWindowOverridableVar(CGradientValueData(), PRIORITY_NONE);
-    m_sWindowData.alpha               = CWindowOverridableVar(1.f, PRIORITY_NONE);
-    m_sWindowData.alphaInactive       = CWindowOverridableVar(-1.f, PRIORITY_NONE);
+    m_sWindowData.alpha               = CWindowOverridableVar(sAlphaValue{1.f, false}, PRIORITY_NONE);
+    m_sWindowData.alphaInactive       = CWindowOverridableVar(sAlphaValue{1.f, false}, PRIORITY_NONE);
+    m_sWindowData.alphaFullscreen     = CWindowOverridableVar(sAlphaValue{1.f, false}, PRIORITY_NONE);
 
-    if (!m_sWindowData.opaqueOverridden)
-        m_sWindowData.opaque = CWindowOverridableVar(false, PRIORITY_NONE);
+    m_sWindowData.opaque = CWindowOverridableVar(false, PRIORITY_NONE);
 
     m_sWindowData.animationStyle = CWindowOverridableVar(std::string(""), PRIORITY_NONE);
     m_sWindowData.maxSize        = CWindowOverridableVar(Vector2D(std::numeric_limits<double>::max(), std::numeric_limits<double>::max()), PRIORITY_NONE);

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -695,14 +695,11 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
                 m_sWindowData.inactiveBorderColor = CWindowOverridableVar(inactiveBorderGradient, priority);
             }
         } catch (std::exception& e) { Debug::log(ERR, "BorderColor rule \"{}\" failed with: {}", r.szRule, e.what()); }
-    } else if (r.szRule.starts_with("xray")) {
-        CVarList vars(r.szRule, 0, ' ');
-
-        try {
-            m_sWindowData.xray = CWindowOverridableVar((bool)configStringToInt(vars[1]), priority);
-        } catch (...) {}
     } else if (auto search = g_pConfigManager->mbWindowProperties.find(r.szRule); search != g_pConfigManager->mbWindowProperties.end()) {
-        *(search->second(m_pSelf.lock())) = CWindowOverridableVar(true, priority);
+        CVarList vars(r.szRule, 0, ' ');
+        try {
+            *(search->second(m_pSelf.lock())) = CWindowOverridableVar((bool)configStringToInt(vars[1]), priority);
+        } catch (...) {}
     } else if (auto search = g_pConfigManager->miWindowProperties.find(r.szRule.substr(0, r.szRule.find_first_of(' '))); search != g_pConfigManager->miWindowProperties.end()) {
         try {
             *(search->second(m_pSelf.lock())) = CWindowOverridableVar(std::stoi(r.szRule.substr(r.szRule.find_first_of(' ') + 1)), priority);

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -628,18 +628,18 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
 
                 if (r == "override") {
                     if (opacityIDX == 1)
-                        m_sWindowData.alpha = CWindowOverridableVar(sAlphaValue{m_sWindowData.alpha.value().m_fAlpha, true}, priority);
+                        m_sWindowData.alpha = CWindowOverridableVar(SAlphaValue{m_sWindowData.alpha.value().m_fAlpha, true}, priority);
                     else if (opacityIDX == 2)
-                        m_sWindowData.alphaInactive = CWindowOverridableVar(sAlphaValue{m_sWindowData.alphaInactive.value().m_fAlpha, true}, priority);
+                        m_sWindowData.alphaInactive = CWindowOverridableVar(SAlphaValue{m_sWindowData.alphaInactive.value().m_fAlpha, true}, priority);
                     else if (opacityIDX == 3)
-                        m_sWindowData.alphaFullscreen = CWindowOverridableVar(sAlphaValue{m_sWindowData.alphaFullscreen.value().m_fAlpha, true}, priority);
+                        m_sWindowData.alphaFullscreen = CWindowOverridableVar(SAlphaValue{m_sWindowData.alphaFullscreen.value().m_fAlpha, true}, priority);
                 } else {
                     if (opacityIDX == 0) {
-                        m_sWindowData.alpha = CWindowOverridableVar(sAlphaValue{std::stof(r), false}, priority);
+                        m_sWindowData.alpha = CWindowOverridableVar(SAlphaValue{std::stof(r), false}, priority);
                     } else if (opacityIDX == 1) {
-                        m_sWindowData.alphaInactive = CWindowOverridableVar(sAlphaValue{std::stof(r), false}, priority);
+                        m_sWindowData.alphaInactive = CWindowOverridableVar(SAlphaValue{std::stof(r), false}, priority);
                     } else if (opacityIDX == 2) {
-                        m_sWindowData.alphaFullscreen = CWindowOverridableVar(sAlphaValue{std::stof(r), false}, priority);
+                        m_sWindowData.alphaFullscreen = CWindowOverridableVar(SAlphaValue{std::stof(r), false}, priority);
                     } else {
                         throw std::runtime_error("more than 3 alpha values");
                     }
@@ -1479,9 +1479,6 @@ void CWindow::onX11Configure(CBox box) {
     g_pCompositor->changeWindowZOrder(m_pSelf.lock(), true);
 
     m_bCreatedOverFullscreen = true;
-
-    if (!m_sWindowData.windowDanceCompat.value_or_default())
-        g_pInputManager->refocus();
 
     g_pHyprRenderer->damageWindow(m_pSelf.lock());
 }

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -110,7 +110,7 @@ SBoxExtents CWindow::getFullWindowExtents() {
 
     const int BORDERSIZE = getRealBorderSize();
 
-    if (m_sWindowData.dimAround.value_or_default()) {
+    if (m_sWindowData.dimAround.valueOrDefault()) {
         if (const auto PMONITOR = g_pCompositor->getMonitorFromID(m_iMonitorID); PMONITOR)
             return {{m_vRealPosition.value().x - PMONITOR->vecPosition.x, m_vRealPosition.value().y - PMONITOR->vecPosition.y},
                     {PMONITOR->vecSize.x - (m_vRealPosition.value().x - PMONITOR->vecPosition.x), PMONITOR->vecSize.y - (m_vRealPosition.value().y - PMONITOR->vecPosition.y)}};
@@ -170,7 +170,7 @@ SBoxExtents CWindow::getFullWindowExtents() {
 }
 
 CBox CWindow::getFullWindowBoundingBox() {
-    if (m_sWindowData.dimAround.value_or_default()) {
+    if (m_sWindowData.dimAround.valueOrDefault()) {
         if (const auto PMONITOR = g_pCompositor->getMonitorFromID(m_iMonitorID); PMONITOR)
             return {PMONITOR->vecPosition.x, PMONITOR->vecPosition.y, PMONITOR->vecSize.x, PMONITOR->vecSize.y};
     }
@@ -218,7 +218,7 @@ CBox CWindow::getWindowIdealBoundingBoxIgnoreReserved() {
 }
 
 CBox CWindow::getWindowBoxUnified(uint64_t properties) {
-    if (m_sWindowData.dimAround.value_or_default()) {
+    if (m_sWindowData.dimAround.valueOrDefault()) {
         const auto PMONITOR = g_pCompositor->getMonitorFromID(m_iMonitorID);
         if (PMONITOR)
             return {PMONITOR->vecPosition.x, PMONITOR->vecPosition.y, PMONITOR->vecSize.x, PMONITOR->vecSize.y};
@@ -1119,9 +1119,9 @@ bool CWindow::opaque() {
 float CWindow::rounding() {
     static auto PROUNDING = CConfigValue<Hyprlang::INT>("decoration:rounding");
 
-    float       rounding = m_sWindowData.rounding.value_or(*PROUNDING);
+    float       rounding = m_sWindowData.rounding.valueOr(*PROUNDING);
 
-    return m_sWindowData.noRounding.value_or_default() ? 0 : rounding;
+    return m_sWindowData.noRounding.valueOrDefault() ? 0 : rounding;
 }
 
 void CWindow::updateWindowData() {
@@ -1146,16 +1146,16 @@ void CWindow::updateWindowData(const SWorkspaceRule& workspaceRule) {
 }
 
 int CWindow::getRealBorderSize() {
-    if (m_sWindowData.noBorder.value_or_default() || (m_pWorkspace && m_bIsFullscreen && (m_pWorkspace->m_efFullscreenMode == FULLSCREEN_FULL)))
+    if (m_sWindowData.noBorder.valueOrDefault() || (m_pWorkspace && m_bIsFullscreen && (m_pWorkspace->m_efFullscreenMode == FULLSCREEN_FULL)))
         return 0;
 
     static auto PBORDERSIZE = CConfigValue<Hyprlang::INT>("general:border_size");
 
-    return m_sWindowData.borderSize.value_or(*PBORDERSIZE);
+    return m_sWindowData.borderSize.valueOr(*PBORDERSIZE);
 }
 
 bool CWindow::canBeTorn() {
-    return m_sWindowData.tearing.value_or(m_bTearingHint);
+    return m_sWindowData.tearing.valueOr(m_bTearingHint);
 }
 
 bool CWindow::shouldSendFullscreenState() {
@@ -1304,7 +1304,7 @@ void CWindow::activate(bool force) {
 
     m_bIsUrgent = true;
 
-    if (!force && (!m_sWindowData.focusOnActivate.value_or(*PFOCUSONACTIVATE) || (m_eSuppressedEvents & SUPPRESS_ACTIVATE_FOCUSONLY) || (m_eSuppressedEvents & SUPPRESS_ACTIVATE)))
+    if (!force && (!m_sWindowData.focusOnActivate.valueOr(*PFOCUSONACTIVATE) || (m_eSuppressedEvents & SUPPRESS_ACTIVATE_FOCUSONLY) || (m_eSuppressedEvents & SUPPRESS_ACTIVATE)))
         return;
 
     if (m_bIsFloating)

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -281,23 +281,26 @@ void CWindow::updateWindowDecos() {
 }
 
 void CWindow::createWindowProperties() {
-    mWindowProperties["dimaround"]            = &m_sAdditionalConfigData.dimAround;
-    mWindowProperties["focusonactivate"]      = &m_sAdditionalConfigData.focusOnActivate;
-    mWindowProperties["forceinput"]           = &m_sAdditionalConfigData.forceAllowsInput;
-    mWindowProperties["forceopaque"]          = &m_sAdditionalConfigData.forceOpaque;
-    mWindowProperties["forceopaqueoverriden"] = &m_sAdditionalConfigData.forceOpaqueOverridden;
-    mWindowProperties["forcergbx"]            = &m_sAdditionalConfigData.forceRGBX;
-    mWindowProperties["immediate"]            = &m_sAdditionalConfigData.forceTearing;
-    mWindowProperties["keepaspectratio"]      = &m_sAdditionalConfigData.keepAspectRatio;
-    mWindowProperties["nearestneighbor"]      = &m_sAdditionalConfigData.nearestNeighbor;
-    mWindowProperties["noanim"]               = &m_sAdditionalConfigData.forceNoAnims;
-    mWindowProperties["noblur"]               = &m_sAdditionalConfigData.forceNoBlur;
-    mWindowProperties["noborder"]             = &m_sAdditionalConfigData.forceNoBorder;
-    mWindowProperties["nodim"]                = &m_sAdditionalConfigData.forceNoDim;
-    mWindowProperties["nofocus"]              = &m_sAdditionalConfigData.noFocus;
-    mWindowProperties["nomaxsize"]            = &m_sAdditionalConfigData.noMaxSize;
-    mWindowProperties["noshadow"]             = &m_sAdditionalConfigData.forceNoShadow;
-    mWindowProperties["windowdance"]          = &m_sAdditionalConfigData.windowDanceCompat;
+    mbWindowProperties["dimaround"]            = &m_sAdditionalConfigData.dimAround;
+    mbWindowProperties["focusonactivate"]      = &m_sAdditionalConfigData.focusOnActivate;
+    mbWindowProperties["forceinput"]           = &m_sAdditionalConfigData.forceAllowsInput;
+    mbWindowProperties["forceopaque"]          = &m_sAdditionalConfigData.forceOpaque;
+    mbWindowProperties["forceopaqueoverriden"] = &m_sAdditionalConfigData.forceOpaqueOverridden;
+    mbWindowProperties["forcergbx"]            = &m_sAdditionalConfigData.forceRGBX;
+    mbWindowProperties["immediate"]            = &m_sAdditionalConfigData.forceTearing;
+    mbWindowProperties["keepaspectratio"]      = &m_sAdditionalConfigData.keepAspectRatio;
+    mbWindowProperties["nearestneighbor"]      = &m_sAdditionalConfigData.nearestNeighbor;
+    mbWindowProperties["noanim"]               = &m_sAdditionalConfigData.forceNoAnims;
+    mbWindowProperties["noblur"]               = &m_sAdditionalConfigData.forceNoBlur;
+    mbWindowProperties["noborder"]             = &m_sAdditionalConfigData.forceNoBorder;
+    mbWindowProperties["nodim"]                = &m_sAdditionalConfigData.forceNoDim;
+    mbWindowProperties["nofocus"]              = &m_sAdditionalConfigData.noFocus;
+    mbWindowProperties["nomaxsize"]            = &m_sAdditionalConfigData.noMaxSize;
+    mbWindowProperties["noshadow"]             = &m_sAdditionalConfigData.forceNoShadow;
+    mbWindowProperties["windowdance"]          = &m_sAdditionalConfigData.windowDanceCompat;
+
+    miWindowProperties["rounding"]   = &m_sAdditionalConfigData.rounding;
+    miWindowProperties["bordersize"] = &m_sAdditionalConfigData.borderSize;
 }
 
 void CWindow::addWindowDeco(std::unique_ptr<IHyprWindowDecoration> deco) {
@@ -637,14 +640,6 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
             m_tags.applyTag(vars[1], true);
         else
             Debug::log(ERR, "Tag rule invalid: {}", r.szRule);
-    } else if (r.szRule.starts_with("rounding")) {
-        try {
-            m_sAdditionalConfigData.rounding = std::stoi(r.szRule.substr(r.szRule.find_first_of(' ') + 1));
-        } catch (std::exception& e) { Debug::log(ERR, "Rounding rule \"{}\" failed with: {}", r.szRule, e.what()); }
-    } else if (r.szRule.starts_with("bordersize")) {
-        try {
-            m_sAdditionalConfigData.borderSize = std::stoi(r.szRule.substr(r.szRule.find_first_of(' ') + 1));
-        } catch (std::exception& e) { Debug::log(ERR, "Bordersize rule \"{}\" failed with: {}", r.szRule, e.what()); }
     } else if (r.szRule.starts_with("opacity")) {
         try {
             CVarList vars(r.szRule, 0, ' ');
@@ -736,8 +731,12 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
         try {
             m_sAdditionalConfigData.xray = configStringToInt(vars[1]);
         } catch (...) {}
-    } else if (auto search = mWindowProperties.find(r.szRule); search != mWindowProperties.end()) {
+    } else if (auto search = mbWindowProperties.find(r.szRule); search != mbWindowProperties.end()) {
         *(search->second) = true;
+    } else if (auto search = miWindowProperties.find(r.szRule.substr(0, r.szRule.find_first_of(' '))); search != miWindowProperties.end()) {
+        try {
+            *(search->second) = std::stoi(r.szRule.substr(r.szRule.find_first_of(' ') + 1));
+        } catch (std::exception& e) { Debug::log(ERR, "Rule \"{}\" failed with: {}", r.szRule, e.what()); }
     } else if (r.szRule.starts_with("idleinhibit")) {
         auto IDLERULE = r.szRule.substr(r.szRule.find_first_of(' ') + 1);
 

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -457,6 +457,7 @@ class CWindow {
     std::string            fetchClass();
     void                   warpCursor();
     PHLWINDOW              getSwallower();
+    void                   unsetWindowData(eOverridePriority priority);
 
     // listeners
     void onAck(uint32_t serial);

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -59,7 +59,7 @@ enum eSuppressEvents {
 
 class IWindowTransformer;
 
-struct sAlphaValue {
+struct SAlphaValue {
     float m_fAlpha;
     bool  m_bOverride;
 
@@ -118,7 +118,7 @@ class CWindowOverridableVar {
             throw std::bad_optional_access();
     }
 
-    T value_or(T const& other) {
+    T value_or(T const other) {
         if (has_value())
             return value();
         else
@@ -149,29 +149,28 @@ class CWindowOverridableVar {
 };
 
 struct SWindowData {
-    CWindowOverridableVar<sAlphaValue>        alpha           = sAlphaValue{1.f, false};
-    CWindowOverridableVar<sAlphaValue>        alphaInactive   = sAlphaValue{1.f, false};
-    CWindowOverridableVar<sAlphaValue>        alphaFullscreen = sAlphaValue{1.f, false};
+    CWindowOverridableVar<SAlphaValue>        alpha           = SAlphaValue{1.f, false};
+    CWindowOverridableVar<SAlphaValue>        alphaInactive   = SAlphaValue{1.f, false};
+    CWindowOverridableVar<SAlphaValue>        alphaFullscreen = SAlphaValue{1.f, false};
 
-    CWindowOverridableVar<bool>               allowsInput       = false;
-    CWindowOverridableVar<bool>               dimAround         = false;
-    CWindowOverridableVar<bool>               decorate          = true;
-    CWindowOverridableVar<bool>               focusOnActivate   = false;
-    CWindowOverridableVar<bool>               keepAspectRatio   = false;
-    CWindowOverridableVar<bool>               nearestNeighbor   = false;
-    CWindowOverridableVar<bool>               noAnim            = false;
-    CWindowOverridableVar<bool>               noBorder          = false;
-    CWindowOverridableVar<bool>               noBlur            = false;
-    CWindowOverridableVar<bool>               noDim             = false;
-    CWindowOverridableVar<bool>               noFocus           = false;
-    CWindowOverridableVar<bool>               noMaxSize         = false;
-    CWindowOverridableVar<bool>               noRounding        = false;
-    CWindowOverridableVar<bool>               noShadow          = false;
-    CWindowOverridableVar<bool>               opaque            = false;
-    CWindowOverridableVar<bool>               RGBX              = false;
-    CWindowOverridableVar<bool>               tearing           = false;
-    CWindowOverridableVar<bool>               xray              = false;
-    CWindowOverridableVar<bool>               windowDanceCompat = false;
+    CWindowOverridableVar<bool>               allowsInput     = false;
+    CWindowOverridableVar<bool>               dimAround       = false;
+    CWindowOverridableVar<bool>               decorate        = true;
+    CWindowOverridableVar<bool>               focusOnActivate = false;
+    CWindowOverridableVar<bool>               keepAspectRatio = false;
+    CWindowOverridableVar<bool>               nearestNeighbor = false;
+    CWindowOverridableVar<bool>               noAnim          = false;
+    CWindowOverridableVar<bool>               noBorder        = false;
+    CWindowOverridableVar<bool>               noBlur          = false;
+    CWindowOverridableVar<bool>               noDim           = false;
+    CWindowOverridableVar<bool>               noFocus         = false;
+    CWindowOverridableVar<bool>               noMaxSize       = false;
+    CWindowOverridableVar<bool>               noRounding      = false;
+    CWindowOverridableVar<bool>               noShadow        = false;
+    CWindowOverridableVar<bool>               opaque          = false;
+    CWindowOverridableVar<bool>               RGBX            = false;
+    CWindowOverridableVar<bool>               tearing         = false;
+    CWindowOverridableVar<bool>               xray            = false;
 
     CWindowOverridableVar<int>                rounding;
     CWindowOverridableVar<int>                borderSize;

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -334,7 +334,8 @@ class CWindow {
     SWindowSpecialRenderData                                      m_sSpecialRenderData;
     SWindowAdditionalConfigData                                   m_sAdditionalConfigData;
 
-    std::unordered_map<std::string, CWindowOverridableVar<bool>*> mWindowProperties;
+    std::unordered_map<std::string, CWindowOverridableVar<bool>*> mbWindowProperties;
+    std::unordered_map<std::string, CWindowOverridableVar<int>*>  miWindowProperties;
 
     // Transformers
     std::vector<std::unique_ptr<IWindowTransformer>> m_vTransformers;

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -59,6 +59,18 @@ enum eSuppressEvents {
 
 class IWindowTransformer;
 
+struct sAlphaValue {
+    float m_fAlpha;
+    bool  m_bOverride;
+
+    float applyAlpha(float alpha) {
+        if (m_bOverride)
+            return m_fAlpha;
+        else
+            return m_fAlpha * alpha;
+    };
+};
+
 enum eOverridePriority {
     PRIORITY_NONE,
     PRIORITY_LAYOUT,
@@ -152,12 +164,9 @@ class CWindowOverridableVar {
 };
 
 struct SWindowData {
-    CWindowOverridableVar<bool>               alphaOverride           = false;
-    CWindowOverridableVar<float>              alpha                   = 1.f;
-    CWindowOverridableVar<bool>               alphaInactiveOverride   = false;
-    CWindowOverridableVar<float>              alphaInactive           = -1.f; // -1 means unset
-    CWindowOverridableVar<bool>               alphaFullscreenOverride = false;
-    CWindowOverridableVar<float>              alphaFullscreen         = -1.f; // -1 means unset
+    CWindowOverridableVar<sAlphaValue>        alpha           = sAlphaValue{1.f, false};
+    CWindowOverridableVar<sAlphaValue>        alphaInactive   = sAlphaValue{1.f, false};
+    CWindowOverridableVar<sAlphaValue>        alphaFullscreen = sAlphaValue{1.f, false};
 
     CWindowOverridableVar<bool>               allowsInput       = false;
     CWindowOverridableVar<bool>               dimAround         = false;
@@ -174,7 +183,6 @@ struct SWindowData {
     CWindowOverridableVar<bool>               noRounding        = false;
     CWindowOverridableVar<bool>               noShadow          = false;
     CWindowOverridableVar<bool>               opaque            = false;
-    CWindowOverridableVar<bool>               opaqueOverridden  = false; // if true, a rule will not change the forceOpaque state. This is for the force opaque dispatcher.
     CWindowOverridableVar<bool>               RGBX              = false;
     CWindowOverridableVar<bool>               tearing           = false;
     CWindowOverridableVar<bool>               windowDanceCompat = false;

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -129,6 +129,13 @@ class CWindowOverridableVar {
             throw std::bad_optional_access();
     }
 
+    void matchOptional(std::optional<T> const& optValue, eOverridePriority priority) {
+        if (optValue.has_value())
+            values[priority] = optValue.value();
+        else
+            unset(priority);
+    }
+
   private:
     std::map<eOverridePriority, T> values;
 };
@@ -319,10 +326,7 @@ class CWindow {
     std::vector<IHyprWindowDecoration*>                m_vDecosToRemove;
 
     // Special render data, rules, etc
-    SWindowData                                                   m_sWindowData;
-
-    std::unordered_map<std::string, CWindowOverridableVar<bool>*> mbWindowProperties;
-    std::unordered_map<std::string, CWindowOverridableVar<int>*>  miWindowProperties;
+    SWindowData m_sWindowData;
 
     // Transformers
     std::vector<std::unique_ptr<IWindowTransformer>> m_vTransformers;
@@ -397,7 +401,6 @@ class CWindow {
     void                   onMap();
     void                   setHidden(bool hidden);
     bool                   isHidden();
-    void                   createWindowProperties();
     void                   applyDynamicRule(const SWindowRule& r);
     void                   updateDynamicRules();
     SBoxExtents            getFullWindowReservedArea();
@@ -414,8 +417,8 @@ class CWindow {
     int                    surfacesCount();
 
     int                    getRealBorderSize();
-    void                   updateSpecialRenderData();
-    void                   updateSpecialRenderData(const struct SWorkspaceRule&);
+    void                   updateWindowData();
+    void                   updateWindowData(const struct SWorkspaceRule&);
 
     void                   onBorderAngleAnimEnd(void* ptr);
     bool                   isInCurvedCorner(double x, double y);

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -149,9 +149,9 @@ class CWindowOverridableVar {
 };
 
 struct SWindowData {
-    CWindowOverridableVar<sAlphaValue>        alpha;
-    CWindowOverridableVar<sAlphaValue>        alphaInactive;
-    CWindowOverridableVar<sAlphaValue>        alphaFullscreen;
+    CWindowOverridableVar<sAlphaValue>        alpha           = sAlphaValue{1.f, false};
+    CWindowOverridableVar<sAlphaValue>        alphaInactive   = sAlphaValue{1.f, false};
+    CWindowOverridableVar<sAlphaValue>        alphaFullscreen = sAlphaValue{1.f, false};
 
     CWindowOverridableVar<bool>               allowsInput       = false;
     CWindowOverridableVar<bool>               dimAround         = false;

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -84,6 +84,9 @@ class CWindowOverridableVar {
     CWindowOverridableVar(T const& value, eOverridePriority priority) {
         values[priority] = value;
     }
+    CWindowOverridableVar(T const& value) {
+        defaultValue = value;
+    }
 
     CWindowOverridableVar()  = default;
     ~CWindowOverridableVar() = default;
@@ -122,6 +125,10 @@ class CWindowOverridableVar {
             return other;
     }
 
+    T value_or_default() {
+        return value_or(defaultValue);
+    }
+
     eOverridePriority getPriority() {
         if (!values.empty())
             return std::prev(values.end())->first;
@@ -138,6 +145,7 @@ class CWindowOverridableVar {
 
   private:
     std::map<eOverridePriority, T> values;
+    T                              defaultValue; // used for toggling, so required for bool
 };
 
 struct SWindowData {
@@ -145,25 +153,25 @@ struct SWindowData {
     CWindowOverridableVar<sAlphaValue>        alphaInactive;
     CWindowOverridableVar<sAlphaValue>        alphaFullscreen;
 
-    CWindowOverridableVar<bool>               allowsInput;
-    CWindowOverridableVar<bool>               dimAround;
-    CWindowOverridableVar<bool>               decorate;
-    CWindowOverridableVar<bool>               focusOnActivate;
-    CWindowOverridableVar<bool>               keepAspectRatio;
-    CWindowOverridableVar<bool>               nearestNeighbor;
-    CWindowOverridableVar<bool>               noAnim;
-    CWindowOverridableVar<bool>               noBorder;
-    CWindowOverridableVar<bool>               noBlur;
-    CWindowOverridableVar<bool>               noDim;
-    CWindowOverridableVar<bool>               noFocus;
-    CWindowOverridableVar<bool>               noMaxSize;
-    CWindowOverridableVar<bool>               noRounding;
-    CWindowOverridableVar<bool>               noShadow;
-    CWindowOverridableVar<bool>               opaque;
-    CWindowOverridableVar<bool>               RGBX;
-    CWindowOverridableVar<bool>               tearing;
-    CWindowOverridableVar<bool>               xray;
-    CWindowOverridableVar<bool>               windowDanceCompat;
+    CWindowOverridableVar<bool>               allowsInput       = false;
+    CWindowOverridableVar<bool>               dimAround         = false;
+    CWindowOverridableVar<bool>               decorate          = true;
+    CWindowOverridableVar<bool>               focusOnActivate   = false;
+    CWindowOverridableVar<bool>               keepAspectRatio   = false;
+    CWindowOverridableVar<bool>               nearestNeighbor   = false;
+    CWindowOverridableVar<bool>               noAnim            = false;
+    CWindowOverridableVar<bool>               noBorder          = false;
+    CWindowOverridableVar<bool>               noBlur            = false;
+    CWindowOverridableVar<bool>               noDim             = false;
+    CWindowOverridableVar<bool>               noFocus           = false;
+    CWindowOverridableVar<bool>               noMaxSize         = false;
+    CWindowOverridableVar<bool>               noRounding        = false;
+    CWindowOverridableVar<bool>               noShadow          = false;
+    CWindowOverridableVar<bool>               opaque            = false;
+    CWindowOverridableVar<bool>               RGBX              = false;
+    CWindowOverridableVar<bool>               tearing           = false;
+    CWindowOverridableVar<bool>               xray              = false;
+    CWindowOverridableVar<bool>               windowDanceCompat = false;
 
     CWindowOverridableVar<int>                rounding;
     CWindowOverridableVar<int>                borderSize;

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -331,8 +331,10 @@ class CWindow {
     std::vector<IHyprWindowDecoration*>                m_vDecosToRemove;
 
     // Special render data, rules, etc
-    SWindowSpecialRenderData    m_sSpecialRenderData;
-    SWindowAdditionalConfigData m_sAdditionalConfigData;
+    SWindowSpecialRenderData                                      m_sSpecialRenderData;
+    SWindowAdditionalConfigData                                   m_sAdditionalConfigData;
+
+    std::unordered_map<std::string, CWindowOverridableVar<bool>*> mWindowProperties;
 
     // Transformers
     std::vector<std::unique_ptr<IWindowTransformer>> m_vTransformers;
@@ -407,6 +409,7 @@ class CWindow {
     void                   onMap();
     void                   setHidden(bool hidden);
     bool                   isHidden();
+    void                   createWindowProperties();
     void                   applyDynamicRule(const SWindowRule& r);
     void                   updateDynamicRules();
     SBoxExtents            getFullWindowReservedArea();

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -107,7 +107,7 @@ class CWindowOverridableVar {
         values.erase(priority);
     }
 
-    bool has_value() {
+    bool hasValue() {
         return !values.empty();
     }
 
@@ -118,15 +118,15 @@ class CWindowOverridableVar {
             throw std::bad_optional_access();
     }
 
-    T value_or(T const other) {
-        if (has_value())
+    T valueOr(T const& other) {
+        if (hasValue())
             return value();
         else
             return other;
     }
 
-    T value_or_default() {
-        return value_or(defaultValue);
+    T valueOrDefault() {
+        return valueOr(defaultValue);
     }
 
     eOverridePriority getPriority() {

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -452,7 +452,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
     const auto PFOCUSEDWINDOWPREV = g_pCompositor->m_pLastWindow.lock();
 
-    if (PWINDOW->m_sWindowData.allowsInput) {
+    if (PWINDOW->m_sWindowData.allowsInput.value_or(false)) {
         PWINDOW->m_sWindowData.noFocus = CWindowOverridableVar(false, PWINDOW->m_sWindowData.allowsInput.getPriority());
         PWINDOW->m_bNoInitialFocus     = false;
         PWINDOW->m_bX11ShouldntFocus   = false;
@@ -474,11 +474,12 @@ void Events::listener_mapWindow(void* owner, void* data) {
             requestsFullscreen = true;
     }
 
-    if (!PWINDOW->m_sWindowData.noFocus && !PWINDOW->m_bNoInitialFocus && (PWINDOW->m_iX11Type != 2 || (PWINDOW->m_bIsX11 && PWINDOW->m_pXWaylandSurface->wantsFocus())) &&
-        !workspaceSilent && (!PFORCEFOCUS || PFORCEFOCUS == PWINDOW) && !g_pInputManager->isConstrained()) {
+    if (!PWINDOW->m_sWindowData.noFocus.value_or(false) && !PWINDOW->m_bNoInitialFocus &&
+        (PWINDOW->m_iX11Type != 2 || (PWINDOW->m_bIsX11 && PWINDOW->m_pXWaylandSurface->wantsFocus())) && !workspaceSilent && (!PFORCEFOCUS || PFORCEFOCUS == PWINDOW) &&
+        !g_pInputManager->isConstrained()) {
         g_pCompositor->focusWindow(PWINDOW);
         PWINDOW->m_fActiveInactiveAlpha.setValueAndWarp(*PACTIVEALPHA);
-        PWINDOW->m_fDimPercent.setValueAndWarp(PWINDOW->m_sWindowData.noDim ? 0.f : *PDIMSTRENGTH);
+        PWINDOW->m_fDimPercent.setValueAndWarp(PWINDOW->m_sWindowData.noDim.value_or(false) ? 0.f : *PDIMSTRENGTH);
     } else {
         PWINDOW->m_fActiveInactiveAlpha.setValueAndWarp(*PINACTIVEALPHA);
         PWINDOW->m_fDimPercent.setValueAndWarp(0);

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -139,8 +139,6 @@ void Events::listener_mapWindow(void* owner, void* data) {
     bool overridingNoFullscreen = false;
     bool overridingNoMaximize   = false;
 
-    PWINDOW->createWindowProperties();
-
     for (auto& r : PWINDOW->m_vMatchedRules) {
         if (r.szRule.starts_with("monitor")) {
             try {
@@ -316,7 +314,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
             workspaceSilent = false;
     }
 
-    PWINDOW->updateSpecialRenderData();
+    g_pLayoutManager->getCurrentLayout()->unsetLayoutWindowData(PWINDOW);
 
     if (PWINDOW->m_bIsFloating) {
         g_pLayoutManager->getCurrentLayout()->onWindowCreatedFloating(PWINDOW);

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -196,7 +196,6 @@ void Events::listener_mapWindow(void* owner, void* data) {
             PWINDOW->m_bIsFloating = false;
         } else if (r.szRule.starts_with("pseudo")) {
             PWINDOW->m_bIsPseudotiled = true;
-
         } else if (r.szRule.starts_with("noinitialfocus")) {
             PWINDOW->m_bNoInitialFocus = true;
         } else if (r.szRule.starts_with("suppressevent")) {

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -452,10 +452,10 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
     const auto PFOCUSEDWINDOWPREV = g_pCompositor->m_pLastWindow.lock();
 
-    if (PWINDOW->m_sAdditionalConfigData.forceAllowsInput) {
-        PWINDOW->m_sAdditionalConfigData.noFocus = false;
-        PWINDOW->m_bNoInitialFocus               = false;
-        PWINDOW->m_bX11ShouldntFocus             = false;
+    if (PWINDOW->m_sWindowData.allowsInput) {
+        PWINDOW->m_sWindowData.noFocus = CWindowOverridableVar(false, PWINDOW->m_sWindowData.allowsInput.getPriority());
+        PWINDOW->m_bNoInitialFocus     = false;
+        PWINDOW->m_bX11ShouldntFocus   = false;
     }
 
     // check LS focus grab
@@ -474,12 +474,11 @@ void Events::listener_mapWindow(void* owner, void* data) {
             requestsFullscreen = true;
     }
 
-    if (!PWINDOW->m_sAdditionalConfigData.noFocus && !PWINDOW->m_bNoInitialFocus &&
-        (PWINDOW->m_iX11Type != 2 || (PWINDOW->m_bIsX11 && PWINDOW->m_pXWaylandSurface->wantsFocus())) && !workspaceSilent && (!PFORCEFOCUS || PFORCEFOCUS == PWINDOW) &&
-        !g_pInputManager->isConstrained()) {
+    if (!PWINDOW->m_sWindowData.noFocus && !PWINDOW->m_bNoInitialFocus && (PWINDOW->m_iX11Type != 2 || (PWINDOW->m_bIsX11 && PWINDOW->m_pXWaylandSurface->wantsFocus())) &&
+        !workspaceSilent && (!PFORCEFOCUS || PFORCEFOCUS == PWINDOW) && !g_pInputManager->isConstrained()) {
         g_pCompositor->focusWindow(PWINDOW);
         PWINDOW->m_fActiveInactiveAlpha.setValueAndWarp(*PACTIVEALPHA);
-        PWINDOW->m_fDimPercent.setValueAndWarp(PWINDOW->m_sAdditionalConfigData.forceNoDim ? 0.f : *PDIMSTRENGTH);
+        PWINDOW->m_fDimPercent.setValueAndWarp(PWINDOW->m_sWindowData.noDim ? 0.f : *PDIMSTRENGTH);
     } else {
         PWINDOW->m_fActiveInactiveAlpha.setValueAndWarp(*PINACTIVEALPHA);
         PWINDOW->m_fDimPercent.setValueAndWarp(0);

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -450,7 +450,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
     const auto PFOCUSEDWINDOWPREV = g_pCompositor->m_pLastWindow.lock();
 
-    if (PWINDOW->m_sWindowData.allowsInput.value_or(false)) {
+    if (PWINDOW->m_sWindowData.allowsInput.value_or_default()) {
         PWINDOW->m_sWindowData.noFocus = CWindowOverridableVar(false, PWINDOW->m_sWindowData.allowsInput.getPriority());
         PWINDOW->m_bNoInitialFocus     = false;
         PWINDOW->m_bX11ShouldntFocus   = false;
@@ -472,12 +472,12 @@ void Events::listener_mapWindow(void* owner, void* data) {
             requestsFullscreen = true;
     }
 
-    if (!PWINDOW->m_sWindowData.noFocus.value_or(false) && !PWINDOW->m_bNoInitialFocus &&
+    if (!PWINDOW->m_sWindowData.noFocus.value_or_default() && !PWINDOW->m_bNoInitialFocus &&
         (PWINDOW->m_iX11Type != 2 || (PWINDOW->m_bIsX11 && PWINDOW->m_pXWaylandSurface->wantsFocus())) && !workspaceSilent && (!PFORCEFOCUS || PFORCEFOCUS == PWINDOW) &&
         !g_pInputManager->isConstrained()) {
         g_pCompositor->focusWindow(PWINDOW);
         PWINDOW->m_fActiveInactiveAlpha.setValueAndWarp(*PACTIVEALPHA);
-        PWINDOW->m_fDimPercent.setValueAndWarp(PWINDOW->m_sWindowData.noDim.value_or(false) ? 0.f : *PDIMSTRENGTH);
+        PWINDOW->m_fDimPercent.setValueAndWarp(PWINDOW->m_sWindowData.noDim.value_or_default() ? 0.f : *PDIMSTRENGTH);
     } else {
         PWINDOW->m_fActiveInactiveAlpha.setValueAndWarp(*PINACTIVEALPHA);
         PWINDOW->m_fDimPercent.setValueAndWarp(0);

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -314,7 +314,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
             workspaceSilent = false;
     }
 
-    g_pLayoutManager->getCurrentLayout()->unsetLayoutWindowData(PWINDOW);
+    PWINDOW->updateWindowData();
 
     if (PWINDOW->m_bIsFloating) {
         g_pLayoutManager->getCurrentLayout()->onWindowCreatedFloating(PWINDOW);
@@ -450,7 +450,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
     const auto PFOCUSEDWINDOWPREV = g_pCompositor->m_pLastWindow.lock();
 
-    if (PWINDOW->m_sWindowData.allowsInput.value_or_default()) {
+    if (PWINDOW->m_sWindowData.allowsInput.value_or_default()) { // if default value wasn't set to false getPriority() would throw an exception
         PWINDOW->m_sWindowData.noFocus = CWindowOverridableVar(false, PWINDOW->m_sWindowData.allowsInput.getPriority());
         PWINDOW->m_bNoInitialFocus     = false;
         PWINDOW->m_bX11ShouldntFocus   = false;

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -449,7 +449,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
     const auto PFOCUSEDWINDOWPREV = g_pCompositor->m_pLastWindow.lock();
 
-    if (PWINDOW->m_sWindowData.allowsInput.value_or_default()) { // if default value wasn't set to false getPriority() would throw an exception
+    if (PWINDOW->m_sWindowData.allowsInput.valueOrDefault()) { // if default value wasn't set to false getPriority() would throw an exception
         PWINDOW->m_sWindowData.noFocus = CWindowOverridableVar(false, PWINDOW->m_sWindowData.allowsInput.getPriority());
         PWINDOW->m_bNoInitialFocus     = false;
         PWINDOW->m_bX11ShouldntFocus   = false;
@@ -471,12 +471,12 @@ void Events::listener_mapWindow(void* owner, void* data) {
             requestsFullscreen = true;
     }
 
-    if (!PWINDOW->m_sWindowData.noFocus.value_or_default() && !PWINDOW->m_bNoInitialFocus &&
+    if (!PWINDOW->m_sWindowData.noFocus.valueOrDefault() && !PWINDOW->m_bNoInitialFocus &&
         (PWINDOW->m_iX11Type != 2 || (PWINDOW->m_bIsX11 && PWINDOW->m_pXWaylandSurface->wantsFocus())) && !workspaceSilent && (!PFORCEFOCUS || PFORCEFOCUS == PWINDOW) &&
         !g_pInputManager->isConstrained()) {
         g_pCompositor->focusWindow(PWINDOW);
         PWINDOW->m_fActiveInactiveAlpha.setValueAndWarp(*PACTIVEALPHA);
-        PWINDOW->m_fDimPercent.setValueAndWarp(PWINDOW->m_sWindowData.noDim.value_or_default() ? 0.f : *PDIMSTRENGTH);
+        PWINDOW->m_fDimPercent.setValueAndWarp(PWINDOW->m_sWindowData.noDim.valueOrDefault() ? 0.f : *PDIMSTRENGTH);
     } else {
         PWINDOW->m_fActiveInactiveAlpha.setValueAndWarp(*PINACTIVEALPHA);
         PWINDOW->m_fDimPercent.setValueAndWarp(0);

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -139,6 +139,8 @@ void Events::listener_mapWindow(void* owner, void* data) {
     bool overridingNoFullscreen = false;
     bool overridingNoMaximize   = false;
 
+    PWINDOW->createWindowProperties();
+
     for (auto& r : PWINDOW->m_vMatchedRules) {
         if (r.szRule.starts_with("monitor")) {
             try {
@@ -196,8 +198,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
             PWINDOW->m_bIsFloating = false;
         } else if (r.szRule.starts_with("pseudo")) {
             PWINDOW->m_bIsPseudotiled = true;
-        } else if (r.szRule.starts_with("nofocus")) {
-            PWINDOW->m_sAdditionalConfigData.noFocus = true;
+
         } else if (r.szRule.starts_with("noinitialfocus")) {
             PWINDOW->m_bNoInitialFocus = true;
         } else if (r.szRule.starts_with("suppressevent")) {
@@ -219,12 +220,6 @@ void Events::listener_mapWindow(void* owner, void* data) {
             overridingNoFullscreen = true;
         } else if (r.szRule == "fakefullscreen") {
             requestsFakeFullscreen = true;
-        } else if (r.szRule == "windowdance") {
-            PWINDOW->m_sAdditionalConfigData.windowDanceCompat = true;
-        } else if (r.szRule == "nomaxsize") {
-            PWINDOW->m_sAdditionalConfigData.noMaxSize = true;
-        } else if (r.szRule == "forceinput") {
-            PWINDOW->m_sAdditionalConfigData.forceAllowsInput = true;
         } else if (r.szRule == "pin") {
             PWINDOW->m_bPinned = true;
         } else if (r.szRule == "maximize") {

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -139,7 +139,7 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
     if (PWINDOW->m_bIsFullscreen && !pNode->ignoreFullscreenChecks)
         return;
 
-    PWINDOW->updateSpecialRenderData();
+    unsetLayoutWindowData(PWINDOW);
 
     static auto PNOGAPSWHENONLY = CConfigValue<Hyprlang::INT>("dwindle:no_gaps_when_only");
     static auto PGAPSINDATA     = CConfigValue<Hyprlang::CUSTOMTYPE>("general:gaps_in");
@@ -496,7 +496,7 @@ void CHyprDwindleLayout::onWindowRemovedTiling(PHLWINDOW pWindow) {
         return;
     }
 
-    pWindow->updateSpecialRenderData();
+    unsetLayoutWindowData(pWindow);
 
     if (pWindow->m_bIsFullscreen)
         g_pCompositor->setWindowFullscreen(pWindow, false, FULLSCREEN_FULL);
@@ -830,7 +830,7 @@ void CHyprDwindleLayout::fullscreenRequestForWindow(PHLWINDOW pWindow, eFullscre
             pWindow->m_vRealPosition = pWindow->m_vLastFloatingPosition;
             pWindow->m_vRealSize     = pWindow->m_vLastFloatingSize;
 
-            pWindow->updateSpecialRenderData();
+            unsetLayoutWindowData(pWindow);
         }
     } else {
         // if it now got fullscreen, make it fullscreen

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -139,7 +139,7 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
     if (PWINDOW->m_bIsFullscreen && !pNode->ignoreFullscreenChecks)
         return;
 
-    unsetLayoutWindowData(PWINDOW);
+    PWINDOW->unsetWindowData(PRIORITY_LAYOUT);
 
     static auto PNOGAPSWHENONLY = CConfigValue<Hyprlang::INT>("dwindle:no_gaps_when_only");
     static auto PGAPSINDATA     = CConfigValue<Hyprlang::CUSTOMTYPE>("general:gaps_in");
@@ -496,7 +496,7 @@ void CHyprDwindleLayout::onWindowRemovedTiling(PHLWINDOW pWindow) {
         return;
     }
 
-    unsetLayoutWindowData(pWindow);
+    pWindow->unsetWindowData(PRIORITY_LAYOUT);
 
     if (pWindow->m_bIsFullscreen)
         g_pCompositor->setWindowFullscreen(pWindow, false, FULLSCREEN_FULL);
@@ -830,7 +830,7 @@ void CHyprDwindleLayout::fullscreenRequestForWindow(PHLWINDOW pWindow, eFullscre
             pWindow->m_vRealPosition = pWindow->m_vLastFloatingPosition;
             pWindow->m_vRealSize     = pWindow->m_vLastFloatingSize;
 
-            unsetLayoutWindowData(pWindow);
+            pWindow->unsetWindowData(PRIORITY_LAYOUT);
         }
     } else {
         // if it now got fullscreen, make it fullscreen

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -160,10 +160,10 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
     if (*PNOGAPSWHENONLY && !PWINDOW->onSpecialWorkspace() &&
         (NODESONWORKSPACE == 1 || (PWINDOW->m_bIsFullscreen && PWINDOW->m_pWorkspace->m_efFullscreenMode == FULLSCREEN_MAXIMIZED))) {
 
-        PWINDOW->m_sSpecialRenderData.border   = WORKSPACERULE.border.value_or(*PNOGAPSWHENONLY == 2);
-        PWINDOW->m_sSpecialRenderData.decorate = WORKSPACERULE.decorate.value_or(true);
-        PWINDOW->m_sSpecialRenderData.rounding = false;
-        PWINDOW->m_sSpecialRenderData.shadow   = false;
+        PWINDOW->m_sWindowData.decorate   = CWindowOverridableVar(true, PRIORITY_LAYOUT);
+        PWINDOW->m_sWindowData.noBorder   = CWindowOverridableVar(*PNOGAPSWHENONLY != 2, PRIORITY_LAYOUT);
+        PWINDOW->m_sWindowData.noRounding = CWindowOverridableVar(true, PRIORITY_LAYOUT);
+        PWINDOW->m_sWindowData.noShadow   = CWindowOverridableVar(true, PRIORITY_LAYOUT);
 
         PWINDOW->updateWindowDecos();
 

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -542,7 +542,7 @@ void IHyprLayout::changeWindowFloatingMode(PHLWINDOW pWindow) {
 
         g_pHyprRenderer->damageMonitor(g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID));
 
-        pWindow->updateSpecialRenderData();
+        g_pLayoutManager->getCurrentLayout()->unsetLayoutWindowData(pWindow);
 
         if (pWindow == m_pLastTiledWindow)
             m_pLastTiledWindow.reset();
@@ -710,6 +710,14 @@ Vector2D IHyprLayout::predictSizeForNewWindow(PHLWINDOW pWindow) {
         sizePredicted = {};
 
     return sizePredicted;
+}
+
+void IHyprLayout::unsetLayoutWindowData(PHLWINDOW pWindow) {
+    // not finished
+    pWindow->m_sWindowData.decorate.unset(PRIORITY_LAYOUT);
+    pWindow->m_sWindowData.noBorder.unset(PRIORITY_LAYOUT);
+    pWindow->m_sWindowData.noRounding.unset(PRIORITY_LAYOUT);
+    pWindow->m_sWindowData.noShadow.unset(PRIORITY_LAYOUT);
 }
 
 IHyprLayout::~IHyprLayout() {}

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -542,7 +542,7 @@ void IHyprLayout::changeWindowFloatingMode(PHLWINDOW pWindow) {
 
         g_pHyprRenderer->damageMonitor(g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID));
 
-        g_pLayoutManager->getCurrentLayout()->unsetLayoutWindowData(pWindow);
+        pWindow->unsetWindowData(PRIORITY_LAYOUT);
 
         if (pWindow == m_pLastTiledWindow)
             m_pLastTiledWindow.reset();
@@ -710,14 +710,6 @@ Vector2D IHyprLayout::predictSizeForNewWindow(PHLWINDOW pWindow) {
         sizePredicted = {};
 
     return sizePredicted;
-}
-
-void IHyprLayout::unsetLayoutWindowData(PHLWINDOW pWindow) {
-    // not finished
-    pWindow->m_sWindowData.decorate.unset(PRIORITY_LAYOUT);
-    pWindow->m_sWindowData.noBorder.unset(PRIORITY_LAYOUT);
-    pWindow->m_sWindowData.noRounding.unset(PRIORITY_LAYOUT);
-    pWindow->m_sWindowData.noShadow.unset(PRIORITY_LAYOUT);
 }
 
 IHyprLayout::~IHyprLayout() {}

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -386,8 +386,8 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
     } else if (g_pInputManager->dragMode == MBIND_RESIZE || g_pInputManager->dragMode == MBIND_RESIZE_FORCE_RATIO || g_pInputManager->dragMode == MBIND_RESIZE_BLOCK_RATIO) {
         if (DRAGGINGWINDOW->m_bIsFloating) {
 
-            Vector2D MINSIZE = g_pXWaylandManager->getMinSizeForWindow(DRAGGINGWINDOW).clamp(DRAGGINGWINDOW->m_sAdditionalConfigData.minSize.toUnderlying());
-            Vector2D MAXSIZE = g_pXWaylandManager->getMaxSizeForWindow(DRAGGINGWINDOW).clamp({}, DRAGGINGWINDOW->m_sAdditionalConfigData.maxSize.toUnderlying());
+            Vector2D MINSIZE = g_pXWaylandManager->getMinSizeForWindow(DRAGGINGWINDOW).clamp(DRAGGINGWINDOW->m_sWindowData.minSize.toUnderlying());
+            Vector2D MAXSIZE = g_pXWaylandManager->getMaxSizeForWindow(DRAGGINGWINDOW).clamp({}, DRAGGINGWINDOW->m_sWindowData.maxSize.toUnderlying());
 
             Vector2D newSize = m_vBeginDragSizeXY;
             Vector2D newPos  = m_vBeginDragPositionXY;
@@ -403,7 +403,7 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
 
             if ((m_vBeginDragSizeXY.x >= 1 && m_vBeginDragSizeXY.y >= 1) &&
                 (g_pInputManager->dragMode == MBIND_RESIZE_FORCE_RATIO ||
-                 (!(g_pInputManager->dragMode == MBIND_RESIZE_BLOCK_RATIO) && DRAGGINGWINDOW->m_sAdditionalConfigData.keepAspectRatio))) {
+                 (!(g_pInputManager->dragMode == MBIND_RESIZE_BLOCK_RATIO) && DRAGGINGWINDOW->m_sWindowData.keepAspectRatio))) {
 
                 const float RATIO = m_vBeginDragSizeXY.y / m_vBeginDragSizeXY.x;
 
@@ -587,7 +587,7 @@ PHLWINDOW IHyprLayout::getNextWindowCandidate(PHLWINDOW pWindow) {
         // find whether there is a floating window below this one
         for (auto& w : g_pCompositor->m_vWindows) {
             if (w->m_bIsMapped && !w->isHidden() && w->m_bIsFloating && w->m_iX11Type != 2 && w->m_pWorkspace == pWindow->m_pWorkspace && !w->m_bX11ShouldntFocus &&
-                !w->m_sAdditionalConfigData.noFocus && w != pWindow) {
+                !w->m_sWindowData.noFocus && w != pWindow) {
                 if (VECINRECT((pWindow->m_vSize / 2.f + pWindow->m_vPosition), w->m_vPosition.x, w->m_vPosition.y, w->m_vPosition.x + w->m_vSize.x,
                               w->m_vPosition.y + w->m_vSize.y)) {
                     return w;
@@ -607,7 +607,7 @@ PHLWINDOW IHyprLayout::getNextWindowCandidate(PHLWINDOW pWindow) {
         // if not, floating window
         for (auto& w : g_pCompositor->m_vWindows) {
             if (w->m_bIsMapped && !w->isHidden() && w->m_bIsFloating && w->m_iX11Type != 2 && w->m_pWorkspace == pWindow->m_pWorkspace && !w->m_bX11ShouldntFocus &&
-                !w->m_sAdditionalConfigData.noFocus && w != pWindow)
+                !w->m_sWindowData.noFocus && w != pWindow)
                 return w;
         }
 

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -386,8 +386,12 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
     } else if (g_pInputManager->dragMode == MBIND_RESIZE || g_pInputManager->dragMode == MBIND_RESIZE_FORCE_RATIO || g_pInputManager->dragMode == MBIND_RESIZE_BLOCK_RATIO) {
         if (DRAGGINGWINDOW->m_bIsFloating) {
 
-            Vector2D MINSIZE = g_pXWaylandManager->getMinSizeForWindow(DRAGGINGWINDOW).clamp(DRAGGINGWINDOW->m_sWindowData.minSize.toUnderlying());
-            Vector2D MAXSIZE = g_pXWaylandManager->getMaxSizeForWindow(DRAGGINGWINDOW).clamp({}, DRAGGINGWINDOW->m_sWindowData.maxSize.toUnderlying());
+            Vector2D MINSIZE = g_pXWaylandManager->getMinSizeForWindow(DRAGGINGWINDOW).clamp(DRAGGINGWINDOW->m_sWindowData.minSize.value_or(Vector2D(20, 20)));
+            Vector2D MAXSIZE;
+            if (DRAGGINGWINDOW->m_sWindowData.maxSize.has_value())
+                MAXSIZE = g_pXWaylandManager->getMaxSizeForWindow(DRAGGINGWINDOW).clamp({}, DRAGGINGWINDOW->m_sWindowData.maxSize.value());
+            else
+                MAXSIZE = g_pXWaylandManager->getMaxSizeForWindow(DRAGGINGWINDOW).clamp({}, Vector2D(std::numeric_limits<double>::max(), std::numeric_limits<double>::max()));
 
             Vector2D newSize = m_vBeginDragSizeXY;
             Vector2D newPos  = m_vBeginDragPositionXY;
@@ -403,7 +407,7 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
 
             if ((m_vBeginDragSizeXY.x >= 1 && m_vBeginDragSizeXY.y >= 1) &&
                 (g_pInputManager->dragMode == MBIND_RESIZE_FORCE_RATIO ||
-                 (!(g_pInputManager->dragMode == MBIND_RESIZE_BLOCK_RATIO) && DRAGGINGWINDOW->m_sWindowData.keepAspectRatio))) {
+                 (!(g_pInputManager->dragMode == MBIND_RESIZE_BLOCK_RATIO) && DRAGGINGWINDOW->m_sWindowData.keepAspectRatio.value_or(false)))) {
 
                 const float RATIO = m_vBeginDragSizeXY.y / m_vBeginDragSizeXY.x;
 
@@ -587,7 +591,7 @@ PHLWINDOW IHyprLayout::getNextWindowCandidate(PHLWINDOW pWindow) {
         // find whether there is a floating window below this one
         for (auto& w : g_pCompositor->m_vWindows) {
             if (w->m_bIsMapped && !w->isHidden() && w->m_bIsFloating && w->m_iX11Type != 2 && w->m_pWorkspace == pWindow->m_pWorkspace && !w->m_bX11ShouldntFocus &&
-                !w->m_sWindowData.noFocus && w != pWindow) {
+                !w->m_sWindowData.noFocus.value_or(false) && w != pWindow) {
                 if (VECINRECT((pWindow->m_vSize / 2.f + pWindow->m_vPosition), w->m_vPosition.x, w->m_vPosition.y, w->m_vPosition.x + w->m_vSize.x,
                               w->m_vPosition.y + w->m_vSize.y)) {
                     return w;
@@ -607,7 +611,7 @@ PHLWINDOW IHyprLayout::getNextWindowCandidate(PHLWINDOW pWindow) {
         // if not, floating window
         for (auto& w : g_pCompositor->m_vWindows) {
             if (w->m_bIsMapped && !w->isHidden() && w->m_bIsFloating && w->m_iX11Type != 2 && w->m_pWorkspace == pWindow->m_pWorkspace && !w->m_bX11ShouldntFocus &&
-                !w->m_sWindowData.noFocus && w != pWindow)
+                !w->m_sWindowData.noFocus.value_or(false) && w != pWindow)
                 return w;
         }
 

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -407,7 +407,7 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
 
             if ((m_vBeginDragSizeXY.x >= 1 && m_vBeginDragSizeXY.y >= 1) &&
                 (g_pInputManager->dragMode == MBIND_RESIZE_FORCE_RATIO ||
-                 (!(g_pInputManager->dragMode == MBIND_RESIZE_BLOCK_RATIO) && DRAGGINGWINDOW->m_sWindowData.keepAspectRatio.value_or(false)))) {
+                 (!(g_pInputManager->dragMode == MBIND_RESIZE_BLOCK_RATIO) && DRAGGINGWINDOW->m_sWindowData.keepAspectRatio.value_or_default()))) {
 
                 const float RATIO = m_vBeginDragSizeXY.y / m_vBeginDragSizeXY.x;
 
@@ -591,7 +591,7 @@ PHLWINDOW IHyprLayout::getNextWindowCandidate(PHLWINDOW pWindow) {
         // find whether there is a floating window below this one
         for (auto& w : g_pCompositor->m_vWindows) {
             if (w->m_bIsMapped && !w->isHidden() && w->m_bIsFloating && w->m_iX11Type != 2 && w->m_pWorkspace == pWindow->m_pWorkspace && !w->m_bX11ShouldntFocus &&
-                !w->m_sWindowData.noFocus.value_or(false) && w != pWindow) {
+                !w->m_sWindowData.noFocus.value_or_default() && w != pWindow) {
                 if (VECINRECT((pWindow->m_vSize / 2.f + pWindow->m_vPosition), w->m_vPosition.x, w->m_vPosition.y, w->m_vPosition.x + w->m_vSize.x,
                               w->m_vPosition.y + w->m_vSize.y)) {
                     return w;
@@ -611,7 +611,7 @@ PHLWINDOW IHyprLayout::getNextWindowCandidate(PHLWINDOW pWindow) {
         // if not, floating window
         for (auto& w : g_pCompositor->m_vWindows) {
             if (w->m_bIsMapped && !w->isHidden() && w->m_bIsFloating && w->m_iX11Type != 2 && w->m_pWorkspace == pWindow->m_pWorkspace && !w->m_bX11ShouldntFocus &&
-                !w->m_sWindowData.noFocus.value_or(false) && w != pWindow)
+                !w->m_sWindowData.noFocus.value_or_default() && w != pWindow)
                 return w;
         }
 

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -386,9 +386,9 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
     } else if (g_pInputManager->dragMode == MBIND_RESIZE || g_pInputManager->dragMode == MBIND_RESIZE_FORCE_RATIO || g_pInputManager->dragMode == MBIND_RESIZE_BLOCK_RATIO) {
         if (DRAGGINGWINDOW->m_bIsFloating) {
 
-            Vector2D MINSIZE = g_pXWaylandManager->getMinSizeForWindow(DRAGGINGWINDOW).clamp(DRAGGINGWINDOW->m_sWindowData.minSize.value_or(Vector2D(20, 20)));
+            Vector2D MINSIZE = g_pXWaylandManager->getMinSizeForWindow(DRAGGINGWINDOW).clamp(DRAGGINGWINDOW->m_sWindowData.minSize.valueOr(Vector2D(20, 20)));
             Vector2D MAXSIZE;
-            if (DRAGGINGWINDOW->m_sWindowData.maxSize.has_value())
+            if (DRAGGINGWINDOW->m_sWindowData.maxSize.hasValue())
                 MAXSIZE = g_pXWaylandManager->getMaxSizeForWindow(DRAGGINGWINDOW).clamp({}, DRAGGINGWINDOW->m_sWindowData.maxSize.value());
             else
                 MAXSIZE = g_pXWaylandManager->getMaxSizeForWindow(DRAGGINGWINDOW).clamp({}, Vector2D(std::numeric_limits<double>::max(), std::numeric_limits<double>::max()));
@@ -407,7 +407,7 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
 
             if ((m_vBeginDragSizeXY.x >= 1 && m_vBeginDragSizeXY.y >= 1) &&
                 (g_pInputManager->dragMode == MBIND_RESIZE_FORCE_RATIO ||
-                 (!(g_pInputManager->dragMode == MBIND_RESIZE_BLOCK_RATIO) && DRAGGINGWINDOW->m_sWindowData.keepAspectRatio.value_or_default()))) {
+                 (!(g_pInputManager->dragMode == MBIND_RESIZE_BLOCK_RATIO) && DRAGGINGWINDOW->m_sWindowData.keepAspectRatio.valueOrDefault()))) {
 
                 const float RATIO = m_vBeginDragSizeXY.y / m_vBeginDragSizeXY.x;
 
@@ -591,7 +591,7 @@ PHLWINDOW IHyprLayout::getNextWindowCandidate(PHLWINDOW pWindow) {
         // find whether there is a floating window below this one
         for (auto& w : g_pCompositor->m_vWindows) {
             if (w->m_bIsMapped && !w->isHidden() && w->m_bIsFloating && w->m_iX11Type != 2 && w->m_pWorkspace == pWindow->m_pWorkspace && !w->m_bX11ShouldntFocus &&
-                !w->m_sWindowData.noFocus.value_or_default() && w != pWindow) {
+                !w->m_sWindowData.noFocus.valueOrDefault() && w != pWindow) {
                 if (VECINRECT((pWindow->m_vSize / 2.f + pWindow->m_vPosition), w->m_vPosition.x, w->m_vPosition.y, w->m_vPosition.x + w->m_vSize.x,
                               w->m_vPosition.y + w->m_vSize.y)) {
                     return w;
@@ -611,7 +611,7 @@ PHLWINDOW IHyprLayout::getNextWindowCandidate(PHLWINDOW pWindow) {
         // if not, floating window
         for (auto& w : g_pCompositor->m_vWindows) {
             if (w->m_bIsMapped && !w->isHidden() && w->m_bIsFloating && w->m_iX11Type != 2 && w->m_pWorkspace == pWindow->m_pWorkspace && !w->m_bX11ShouldntFocus &&
-                !w->m_sWindowData.noFocus.value_or_default() && w != pWindow)
+                !w->m_sWindowData.noFocus.valueOrDefault() && w != pWindow)
                 return w;
         }
 

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -195,8 +195,6 @@ class IHyprLayout {
     virtual Vector2D predictSizeForNewWindow(PHLWINDOW pWindow);
     virtual Vector2D predictSizeForNewWindowFloating(PHLWINDOW pWindow);
 
-    virtual void     unsetLayoutWindowData(PHLWINDOW);
-
   private:
     int          m_iMouseMoveEventCount;
     Vector2D     m_vBeginDragXY;

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -195,6 +195,8 @@ class IHyprLayout {
     virtual Vector2D predictSizeForNewWindow(PHLWINDOW pWindow);
     virtual Vector2D predictSizeForNewWindowFloating(PHLWINDOW pWindow);
 
+    virtual void     unsetLayoutWindowData(PHLWINDOW);
+
   private:
     int          m_iMouseMoveEventCount;
     Vector2D     m_vBeginDragXY;

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -264,7 +264,7 @@ void CHyprMasterLayout::onWindowRemovedTiling(PHLWINDOW pWindow) {
     const auto  MASTERSLEFT = getMastersOnWorkspace(WORKSPACEID);
     static auto SMALLSPLIT  = CConfigValue<Hyprlang::INT>("master:allow_small_split");
 
-    pWindow->updateSpecialRenderData();
+    unsetLayoutWindowData(pWindow);
 
     g_pCompositor->setWindowFullscreen(pWindow, false, FULLSCREEN_FULL);
 
@@ -646,7 +646,7 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
     if (PWINDOW->m_bIsFullscreen && !pNode->ignoreFullscreenChecks)
         return;
 
-    PWINDOW->updateSpecialRenderData();
+    unsetLayoutWindowData(PWINDOW);
 
     static auto PNOGAPSWHENONLY = CConfigValue<Hyprlang::INT>("master:no_gaps_when_only");
     static auto PANIMATE        = CConfigValue<Hyprlang::INT>("misc:animate_manual_resizes");
@@ -922,7 +922,7 @@ void CHyprMasterLayout::fullscreenRequestForWindow(PHLWINDOW pWindow, eFullscree
             pWindow->m_vRealPosition = pWindow->m_vLastFloatingPosition;
             pWindow->m_vRealSize     = pWindow->m_vLastFloatingSize;
 
-            pWindow->updateSpecialRenderData();
+            unsetLayoutWindowData(pWindow);
         }
     } else {
         // if it now got fullscreen, make it fullscreen

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -264,7 +264,7 @@ void CHyprMasterLayout::onWindowRemovedTiling(PHLWINDOW pWindow) {
     const auto  MASTERSLEFT = getMastersOnWorkspace(WORKSPACEID);
     static auto SMALLSPLIT  = CConfigValue<Hyprlang::INT>("master:allow_small_split");
 
-    unsetLayoutWindowData(pWindow);
+    pWindow->unsetWindowData(PRIORITY_LAYOUT);
 
     g_pCompositor->setWindowFullscreen(pWindow, false, FULLSCREEN_FULL);
 
@@ -646,7 +646,7 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
     if (PWINDOW->m_bIsFullscreen && !pNode->ignoreFullscreenChecks)
         return;
 
-    unsetLayoutWindowData(PWINDOW);
+    PWINDOW->unsetWindowData(PRIORITY_LAYOUT);
 
     static auto PNOGAPSWHENONLY = CConfigValue<Hyprlang::INT>("master:no_gaps_when_only");
     static auto PANIMATE        = CConfigValue<Hyprlang::INT>("misc:animate_manual_resizes");
@@ -922,7 +922,7 @@ void CHyprMasterLayout::fullscreenRequestForWindow(PHLWINDOW pWindow, eFullscree
             pWindow->m_vRealPosition = pWindow->m_vLastFloatingPosition;
             pWindow->m_vRealSize     = pWindow->m_vLastFloatingSize;
 
-            unsetLayoutWindowData(pWindow);
+            pWindow->unsetWindowData(PRIORITY_LAYOUT);
         }
     } else {
         // if it now got fullscreen, make it fullscreen

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -669,10 +669,10 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
     if (*PNOGAPSWHENONLY && !PWINDOW->onSpecialWorkspace() &&
         (getNodesOnWorkspace(PWINDOW->workspaceID()) == 1 || (PWINDOW->m_bIsFullscreen && PWINDOW->m_pWorkspace->m_efFullscreenMode == FULLSCREEN_MAXIMIZED))) {
 
-        PWINDOW->m_sSpecialRenderData.border   = WORKSPACERULE.border.value_or(*PNOGAPSWHENONLY == 2);
-        PWINDOW->m_sSpecialRenderData.decorate = WORKSPACERULE.decorate.value_or(true);
-        PWINDOW->m_sSpecialRenderData.rounding = false;
-        PWINDOW->m_sSpecialRenderData.shadow   = false;
+        PWINDOW->m_sWindowData.decorate   = CWindowOverridableVar(true, PRIORITY_LAYOUT);
+        PWINDOW->m_sWindowData.noBorder   = CWindowOverridableVar(*PNOGAPSWHENONLY != 2, PRIORITY_LAYOUT);
+        PWINDOW->m_sWindowData.noRounding = CWindowOverridableVar(true, PRIORITY_LAYOUT);
+        PWINDOW->m_sWindowData.noShadow   = CWindowOverridableVar(true, PRIORITY_LAYOUT);
 
         PWINDOW->updateWindowDecos();
 

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -102,7 +102,7 @@ void CAnimationManager::tick() {
             PMONITOR = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID);
             if (!PMONITOR)
                 continue;
-            animationsDisabled = animationsDisabled || PWINDOW->m_sWindowData.noAnim;
+            animationsDisabled = PWINDOW->m_sWindowData.noAnim.value_or(animationsDisabled);
         } else if (PWORKSPACE) {
             PMONITOR = g_pCompositor->getMonitorFromID(PWORKSPACE->m_iMonitorID);
             if (!PMONITOR)
@@ -407,18 +407,19 @@ void CAnimationManager::onWindowPostCreateClose(PHLWINDOW pWindow, bool close) {
     if (!pWindow->m_vRealPosition.m_pConfig->pValues->internalEnabled)
         return;
 
-    if (pWindow->m_sWindowData.animationStyle.toUnderlying() != "") {
+    if (pWindow->m_sWindowData.animationStyle.has_value()) {
+        const auto STYLE = pWindow->m_sWindowData.animationStyle.value();
         // the window has config'd special anim
-        if (pWindow->m_sWindowData.animationStyle.toUnderlying().starts_with("slide")) {
-            CVarList animList2(pWindow->m_sWindowData.animationStyle.toUnderlying(), 0, 's');
+        if (STYLE.starts_with("slide")) {
+            CVarList animList2(STYLE, 0, 's');
             animationSlide(pWindow, animList2[1], close);
         } else {
             // anim popin, fallback
 
             float minPerc = 0.f;
-            if (pWindow->m_sWindowData.animationStyle.toUnderlying().find("%") != std::string::npos) {
+            if (STYLE.find("%") != std::string::npos) {
                 try {
-                    auto percstr = pWindow->m_sWindowData.animationStyle.toUnderlying().substr(pWindow->m_sWindowData.animationStyle.toUnderlying().find_last_of(' '));
+                    auto percstr = STYLE.substr(STYLE.find_last_of(' '));
                     minPerc      = std::stoi(percstr.substr(0, percstr.length() - 1));
                 } catch (std::exception& e) {
                     ; // oops

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -102,7 +102,7 @@ void CAnimationManager::tick() {
             PMONITOR = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID);
             if (!PMONITOR)
                 continue;
-            animationsDisabled = animationsDisabled || PWINDOW->m_sAdditionalConfigData.forceNoAnims;
+            animationsDisabled = animationsDisabled || PWINDOW->m_sWindowData.noAnim;
         } else if (PWORKSPACE) {
             PMONITOR = g_pCompositor->getMonitorFromID(PWORKSPACE->m_iMonitorID);
             if (!PMONITOR)
@@ -407,18 +407,18 @@ void CAnimationManager::onWindowPostCreateClose(PHLWINDOW pWindow, bool close) {
     if (!pWindow->m_vRealPosition.m_pConfig->pValues->internalEnabled)
         return;
 
-    if (pWindow->m_sAdditionalConfigData.animationStyle != "") {
+    if (pWindow->m_sWindowData.animationStyle.toUnderlying() != "") {
         // the window has config'd special anim
-        if (pWindow->m_sAdditionalConfigData.animationStyle.starts_with("slide")) {
-            CVarList animList2(pWindow->m_sAdditionalConfigData.animationStyle, 0, 's');
+        if (pWindow->m_sWindowData.animationStyle.toUnderlying().starts_with("slide")) {
+            CVarList animList2(pWindow->m_sWindowData.animationStyle.toUnderlying(), 0, 's');
             animationSlide(pWindow, animList2[1], close);
         } else {
             // anim popin, fallback
 
             float minPerc = 0.f;
-            if (pWindow->m_sAdditionalConfigData.animationStyle.find("%") != std::string::npos) {
+            if (pWindow->m_sWindowData.animationStyle.toUnderlying().find("%") != std::string::npos) {
                 try {
-                    auto percstr = pWindow->m_sAdditionalConfigData.animationStyle.substr(pWindow->m_sAdditionalConfigData.animationStyle.find_last_of(' '));
+                    auto percstr = pWindow->m_sWindowData.animationStyle.toUnderlying().substr(pWindow->m_sWindowData.animationStyle.toUnderlying().find_last_of(' '));
                     minPerc      = std::stoi(percstr.substr(0, percstr.length() - 1));
                 } catch (std::exception& e) {
                     ; // oops

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -102,7 +102,7 @@ void CAnimationManager::tick() {
             PMONITOR = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID);
             if (!PMONITOR)
                 continue;
-            animationsDisabled = PWINDOW->m_sWindowData.noAnim.value_or(animationsDisabled);
+            animationsDisabled = PWINDOW->m_sWindowData.noAnim.valueOr(animationsDisabled);
         } else if (PWORKSPACE) {
             PMONITOR = g_pCompositor->getMonitorFromID(PWORKSPACE->m_iMonitorID);
             if (!PMONITOR)
@@ -407,7 +407,7 @@ void CAnimationManager::onWindowPostCreateClose(PHLWINDOW pWindow, bool close) {
     if (!pWindow->m_vRealPosition.m_pConfig->pValues->internalEnabled)
         return;
 
-    if (pWindow->m_sWindowData.animationStyle.has_value()) {
+    if (pWindow->m_sWindowData.animationStyle.hasValue()) {
         const auto STYLE = pWindow->m_sWindowData.animationStyle.value();
         // the window has config'd special anim
         if (STYLE.starts_with("slide")) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -252,7 +252,7 @@ bool CKeybindManager::ensureMouseBindState() {
         g_pInputManager->dragMode = MBIND_INVALID;
 
         g_pCompositor->updateWorkspaceWindows(lastDraggedWindow->workspaceID());
-        g_pCompositor->updateWorkspaceSpecialRenderData(lastDraggedWindow->workspaceID());
+        g_pCompositor->updateWorkspaceWindowData(lastDraggedWindow->workspaceID());
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(lastDraggedWindow->m_iMonitorID);
         g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 
@@ -974,7 +974,7 @@ static void toggleActiveFloatingCore(std::string args, std::optional<bool> float
         g_pLayoutManager->getCurrentLayout()->changeWindowFloatingMode(PWINDOW);
     }
     g_pCompositor->updateWorkspaceWindows(PWINDOW->workspaceID());
-    g_pCompositor->updateWorkspaceSpecialRenderData(PWINDOW->workspaceID());
+    g_pCompositor->updateWorkspaceWindowData(PWINDOW->workspaceID());
     g_pLayoutManager->getCurrentLayout()->recalculateMonitor(PWINDOW->m_iMonitorID);
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2238,7 +2238,7 @@ void CKeybindManager::toggleOpaque(std::string unused) {
     if (!PWINDOW)
         return;
 
-    PWINDOW->m_sWindowData.opaque = CWindowOverridableVar(!PWINDOW->m_sWindowData.opaque, PRIORITY_SET_PROP);
+    PWINDOW->m_sWindowData.opaque = CWindowOverridableVar(!PWINDOW->m_sWindowData.opaque.value_or(false), PRIORITY_SET_PROP);
 
     g_pHyprRenderer->damageWindow(PWINDOW);
 }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2238,8 +2238,8 @@ void CKeybindManager::toggleOpaque(std::string unused) {
     if (!PWINDOW)
         return;
 
-    PWINDOW->m_sAdditionalConfigData.forceOpaque           = !PWINDOW->m_sAdditionalConfigData.forceOpaque;
-    PWINDOW->m_sAdditionalConfigData.forceOpaqueOverridden = true;
+    PWINDOW->m_sWindowData.opaque           = CWindowOverridableVar(!PWINDOW->m_sWindowData.opaque, PRIORITY_SET_PROP);
+    PWINDOW->m_sWindowData.opaqueOverridden = CWindowOverridableVar(true, PRIORITY_SET_PROP);
 
     g_pHyprRenderer->damageWindow(PWINDOW);
 }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2238,7 +2238,7 @@ void CKeybindManager::toggleOpaque(std::string unused) {
     if (!PWINDOW)
         return;
 
-    PWINDOW->m_sWindowData.opaque = CWindowOverridableVar(!PWINDOW->m_sWindowData.opaque.value_or(false), PRIORITY_SET_PROP);
+    PWINDOW->m_sWindowData.opaque = CWindowOverridableVar(!PWINDOW->m_sWindowData.opaque.value_or_default(), PRIORITY_SET_PROP);
 
     g_pHyprRenderer->damageWindow(PWINDOW);
 }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2238,7 +2238,7 @@ void CKeybindManager::toggleOpaque(std::string unused) {
     if (!PWINDOW)
         return;
 
-    PWINDOW->m_sWindowData.opaque = CWindowOverridableVar(!PWINDOW->m_sWindowData.opaque.value_or_default(), PRIORITY_SET_PROP);
+    PWINDOW->m_sWindowData.opaque = CWindowOverridableVar(!PWINDOW->m_sWindowData.opaque.valueOrDefault(), PRIORITY_SET_PROP);
 
     g_pHyprRenderer->damageWindow(PWINDOW);
 }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2238,8 +2238,7 @@ void CKeybindManager::toggleOpaque(std::string unused) {
     if (!PWINDOW)
         return;
 
-    PWINDOW->m_sWindowData.opaque           = CWindowOverridableVar(!PWINDOW->m_sWindowData.opaque, PRIORITY_SET_PROP);
-    PWINDOW->m_sWindowData.opaqueOverridden = CWindowOverridableVar(true, PRIORITY_SET_PROP);
+    PWINDOW->m_sWindowData.opaque = CWindowOverridableVar(!PWINDOW->m_sWindowData.opaque, PRIORITY_SET_PROP);
 
     g_pHyprRenderer->damageWindow(PWINDOW);
 }

--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -207,7 +207,7 @@ Vector2D CHyprXWaylandManager::getMaxSizeForWindow(PHLWINDOW pWindow) {
         return Vector2D(99999, 99999);
 
     if ((pWindow->m_bIsX11 && !pWindow->m_pXWaylandSurface->sizeHints) || (!pWindow->m_bIsX11 && !pWindow->m_pXDGSurface->toplevel) ||
-        pWindow->m_sWindowData.noMaxSize.value_or_default())
+        pWindow->m_sWindowData.noMaxSize.valueOrDefault())
         return Vector2D(99999, 99999);
 
     auto MAXSIZE = pWindow->m_bIsX11 ? Vector2D(pWindow->m_pXWaylandSurface->sizeHints->max_width, pWindow->m_pXWaylandSurface->sizeHints->max_height) :

--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -206,7 +206,8 @@ Vector2D CHyprXWaylandManager::getMaxSizeForWindow(PHLWINDOW pWindow) {
     if (!validMapped(pWindow))
         return Vector2D(99999, 99999);
 
-    if ((pWindow->m_bIsX11 && !pWindow->m_pXWaylandSurface->sizeHints) || (!pWindow->m_bIsX11 && !pWindow->m_pXDGSurface->toplevel) || pWindow->m_sWindowData.noMaxSize)
+    if ((pWindow->m_bIsX11 && !pWindow->m_pXWaylandSurface->sizeHints) || (!pWindow->m_bIsX11 && !pWindow->m_pXDGSurface->toplevel) ||
+        pWindow->m_sWindowData.noMaxSize.value_or(false))
         return Vector2D(99999, 99999);
 
     auto MAXSIZE = pWindow->m_bIsX11 ? Vector2D(pWindow->m_pXWaylandSurface->sizeHints->max_width, pWindow->m_pXWaylandSurface->sizeHints->max_height) :

--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -207,7 +207,7 @@ Vector2D CHyprXWaylandManager::getMaxSizeForWindow(PHLWINDOW pWindow) {
         return Vector2D(99999, 99999);
 
     if ((pWindow->m_bIsX11 && !pWindow->m_pXWaylandSurface->sizeHints) || (!pWindow->m_bIsX11 && !pWindow->m_pXDGSurface->toplevel) ||
-        pWindow->m_sWindowData.noMaxSize.value_or(false))
+        pWindow->m_sWindowData.noMaxSize.value_or_default())
         return Vector2D(99999, 99999);
 
     auto MAXSIZE = pWindow->m_bIsX11 ? Vector2D(pWindow->m_pXWaylandSurface->sizeHints->max_width, pWindow->m_pXWaylandSurface->sizeHints->max_height) :

--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -206,7 +206,7 @@ Vector2D CHyprXWaylandManager::getMaxSizeForWindow(PHLWINDOW pWindow) {
     if (!validMapped(pWindow))
         return Vector2D(99999, 99999);
 
-    if ((pWindow->m_bIsX11 && !pWindow->m_pXWaylandSurface->sizeHints) || (!pWindow->m_bIsX11 && !pWindow->m_pXDGSurface->toplevel) || pWindow->m_sAdditionalConfigData.noMaxSize)
+    if ((pWindow->m_bIsX11 && !pWindow->m_pXWaylandSurface->sizeHints) || (!pWindow->m_bIsX11 && !pWindow->m_pXDGSurface->toplevel) || pWindow->m_sWindowData.noMaxSize)
         return Vector2D(99999, 99999);
 
     auto MAXSIZE = pWindow->m_bIsX11 ? Vector2D(pWindow->m_pXWaylandSurface->sizeHints->max_width, pWindow->m_pXWaylandSurface->sizeHints->max_height) :

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -434,7 +434,7 @@ bool CHyprOpenGLImpl::passRequiresIntrospection(CMonitor* pMonitor) {
         if (!w->m_bIsFloating && *POPTIM && !w->onSpecialWorkspace())
             continue;
 
-        if (w->m_sWindowData.noBlur.value_or(false) || w->m_sWindowData.xray.value_or(false) == true)
+        if (w->m_sWindowData.noBlur.value_or_default() || w->m_sWindowData.xray.value_or_default() == true)
             continue;
 
         if (w->opaque())
@@ -1130,7 +1130,7 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, CBox* pB
         }
     }
 
-    if (m_pCurrentWindow.lock() && m_pCurrentWindow->m_sWindowData.RGBX.value_or(false))
+    if (m_pCurrentWindow.lock() && m_pCurrentWindow->m_sWindowData.RGBX.value_or_default())
         shader = &m_RenderData.pCurrentMonData->m_shRGBX;
 
     glActiveTexture(GL_TEXTURE0);
@@ -1601,7 +1601,7 @@ void CHyprOpenGLImpl::preRender(CMonitor* pMonitor) {
         if (!pWindow)
             return false;
 
-        if (pWindow->m_sWindowData.noBlur.value_or(false))
+        if (pWindow->m_sWindowData.noBlur.value_or_default())
             return false;
 
         if (pWindow->m_pWLSurface->small() && !pWindow->m_pWLSurface->m_bFillIgnoreSmall)
@@ -1717,7 +1717,7 @@ bool CHyprOpenGLImpl::shouldUseNewBlurOptimizations(PHLLS pLayer, PHLWINDOW pWin
     if (!m_RenderData.pCurrentMonData->blurFB.m_cTex->m_iTexID)
         return false;
 
-    if (pWindow && !pWindow->m_sWindowData.xray.value_or(false))
+    if (pWindow && !pWindow->m_sWindowData.xray.value_or_default())
         return false;
 
     if (pLayer && pLayer->xray == 0)
@@ -1726,7 +1726,7 @@ bool CHyprOpenGLImpl::shouldUseNewBlurOptimizations(PHLLS pLayer, PHLWINDOW pWin
     if ((*PBLURNEWOPTIMIZE && pWindow && !pWindow->m_bIsFloating && !pWindow->onSpecialWorkspace()) || *PBLURXRAY)
         return true;
 
-    if ((pLayer && pLayer->xray == 1) || (pWindow && pWindow->m_sWindowData.xray.value_or(false)))
+    if ((pLayer && pLayer->xray == 1) || (pWindow && pWindow->m_sWindowData.xray.value_or_default()))
         return true;
 
     return false;
@@ -1750,7 +1750,7 @@ void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, CBox* pBox, float 
     m_RenderData.renderModif.applyToRegion(texDamage);
 
     if (*PBLURENABLED == 0 || (*PNOBLUROVERSIZED && m_RenderData.primarySurfaceUVTopLeft != Vector2D(-1, -1)) ||
-        (m_pCurrentWindow.lock() && (m_pCurrentWindow->m_sWindowData.noBlur.value_or(false) || m_pCurrentWindow->m_sWindowData.RGBX.value_or(false)))) {
+        (m_pCurrentWindow.lock() && (m_pCurrentWindow->m_sWindowData.noBlur.value_or_default() || m_pCurrentWindow->m_sWindowData.RGBX.value_or_default()))) {
         renderTexture(tex, pBox, a, round, false, true);
         return;
     }
@@ -1847,7 +1847,7 @@ void CHyprOpenGLImpl::renderBorder(CBox* box, const CGradientValueData& grad, in
 
     TRACY_GPU_ZONE("RenderBorder");
 
-    if (m_RenderData.damage.empty() || (m_pCurrentWindow.lock() && m_pCurrentWindow->m_sWindowData.noBorder.value_or(false)))
+    if (m_RenderData.damage.empty() || (m_pCurrentWindow.lock() && m_pCurrentWindow->m_sWindowData.noBorder.value_or_default()))
         return;
 
     CBox newBox = *box;
@@ -2108,7 +2108,7 @@ void CHyprOpenGLImpl::renderSnapshot(PHLWINDOW pWindow) {
 
     CRegion fakeDamage{0, 0, PMONITOR->vecTransformedSize.x, PMONITOR->vecTransformedSize.y};
 
-    if (*PDIMAROUND && pWindow->m_sWindowData.dimAround.value_or(false)) {
+    if (*PDIMAROUND && pWindow->m_sWindowData.dimAround.value_or_default()) {
         CBox monbox = {0, 0, g_pHyprOpenGL->m_RenderData.pMonitor->vecPixelSize.x, g_pHyprOpenGL->m_RenderData.pMonitor->vecPixelSize.y};
         g_pHyprOpenGL->renderRect(&monbox, CColor(0, 0, 0, *PDIMAROUND * pWindow->m_fAlpha.value()));
         g_pHyprRenderer->damageMonitor(PMONITOR);

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -434,7 +434,7 @@ bool CHyprOpenGLImpl::passRequiresIntrospection(CMonitor* pMonitor) {
         if (!w->m_bIsFloating && *POPTIM && !w->onSpecialWorkspace())
             continue;
 
-        if (w->m_sAdditionalConfigData.forceNoBlur.toUnderlying() == true || w->m_sAdditionalConfigData.xray.toUnderlying() == true)
+        if (w->m_sWindowData.noBlur.toUnderlying() == true || w->m_sWindowData.xray.toUnderlying() == true)
             continue;
 
         if (w->opaque())
@@ -1130,7 +1130,7 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, CBox* pB
         }
     }
 
-    if (m_pCurrentWindow.lock() && m_pCurrentWindow->m_sAdditionalConfigData.forceRGBX)
+    if (m_pCurrentWindow.lock() && m_pCurrentWindow->m_sWindowData.RGBX)
         shader = &m_RenderData.pCurrentMonData->m_shRGBX;
 
     glActiveTexture(GL_TEXTURE0);
@@ -1601,7 +1601,7 @@ void CHyprOpenGLImpl::preRender(CMonitor* pMonitor) {
         if (!pWindow)
             return false;
 
-        if (pWindow->m_sAdditionalConfigData.forceNoBlur)
+        if (pWindow->m_sWindowData.noBlur)
             return false;
 
         if (pWindow->m_pWLSurface->small() && !pWindow->m_pWLSurface->m_bFillIgnoreSmall)
@@ -1717,7 +1717,7 @@ bool CHyprOpenGLImpl::shouldUseNewBlurOptimizations(PHLLS pLayer, PHLWINDOW pWin
     if (!m_RenderData.pCurrentMonData->blurFB.m_cTex->m_iTexID)
         return false;
 
-    if (pWindow && pWindow->m_sAdditionalConfigData.xray.toUnderlying() == 0)
+    if (pWindow && pWindow->m_sWindowData.xray.toUnderlying() == 0)
         return false;
 
     if (pLayer && pLayer->xray == 0)
@@ -1726,7 +1726,7 @@ bool CHyprOpenGLImpl::shouldUseNewBlurOptimizations(PHLLS pLayer, PHLWINDOW pWin
     if ((*PBLURNEWOPTIMIZE && pWindow && !pWindow->m_bIsFloating && !pWindow->onSpecialWorkspace()) || *PBLURXRAY)
         return true;
 
-    if ((pLayer && pLayer->xray == 1) || (pWindow && pWindow->m_sAdditionalConfigData.xray.toUnderlying() == 1))
+    if ((pLayer && pLayer->xray == 1) || (pWindow && pWindow->m_sWindowData.xray.toUnderlying() == 1))
         return true;
 
     return false;
@@ -1750,7 +1750,7 @@ void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, CBox* pBox, float 
     m_RenderData.renderModif.applyToRegion(texDamage);
 
     if (*PBLURENABLED == 0 || (*PNOBLUROVERSIZED && m_RenderData.primarySurfaceUVTopLeft != Vector2D(-1, -1)) ||
-        (m_pCurrentWindow.lock() && (m_pCurrentWindow->m_sAdditionalConfigData.forceNoBlur || m_pCurrentWindow->m_sAdditionalConfigData.forceRGBX))) {
+        (m_pCurrentWindow.lock() && (m_pCurrentWindow->m_sWindowData.noBlur || m_pCurrentWindow->m_sWindowData.RGBX))) {
         renderTexture(tex, pBox, a, round, false, true);
         return;
     }
@@ -1847,7 +1847,7 @@ void CHyprOpenGLImpl::renderBorder(CBox* box, const CGradientValueData& grad, in
 
     TRACY_GPU_ZONE("RenderBorder");
 
-    if (m_RenderData.damage.empty() || (m_pCurrentWindow.lock() && m_pCurrentWindow->m_sAdditionalConfigData.forceNoBorder))
+    if (m_RenderData.damage.empty() || (m_pCurrentWindow.lock() && m_pCurrentWindow->m_sWindowData.noBorder))
         return;
 
     CBox newBox = *box;
@@ -2108,7 +2108,7 @@ void CHyprOpenGLImpl::renderSnapshot(PHLWINDOW pWindow) {
 
     CRegion fakeDamage{0, 0, PMONITOR->vecTransformedSize.x, PMONITOR->vecTransformedSize.y};
 
-    if (*PDIMAROUND && pWindow->m_sAdditionalConfigData.dimAround) {
+    if (*PDIMAROUND && pWindow->m_sWindowData.dimAround) {
         CBox monbox = {0, 0, g_pHyprOpenGL->m_RenderData.pMonitor->vecPixelSize.x, g_pHyprOpenGL->m_RenderData.pMonitor->vecPixelSize.y};
         g_pHyprOpenGL->renderRect(&monbox, CColor(0, 0, 0, *PDIMAROUND * pWindow->m_fAlpha.value()));
         g_pHyprRenderer->damageMonitor(PMONITOR);

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -434,7 +434,7 @@ bool CHyprOpenGLImpl::passRequiresIntrospection(CMonitor* pMonitor) {
         if (!w->m_bIsFloating && *POPTIM && !w->onSpecialWorkspace())
             continue;
 
-        if (w->m_sWindowData.noBlur.value_or_default() || w->m_sWindowData.xray.value_or_default() == true)
+        if (w->m_sWindowData.noBlur.valueOrDefault() || w->m_sWindowData.xray.valueOrDefault() == true)
             continue;
 
         if (w->opaque())
@@ -1130,7 +1130,7 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, CBox* pB
         }
     }
 
-    if (m_pCurrentWindow.lock() && m_pCurrentWindow->m_sWindowData.RGBX.value_or_default())
+    if (m_pCurrentWindow.lock() && m_pCurrentWindow->m_sWindowData.RGBX.valueOrDefault())
         shader = &m_RenderData.pCurrentMonData->m_shRGBX;
 
     glActiveTexture(GL_TEXTURE0);
@@ -1601,7 +1601,7 @@ void CHyprOpenGLImpl::preRender(CMonitor* pMonitor) {
         if (!pWindow)
             return false;
 
-        if (pWindow->m_sWindowData.noBlur.value_or_default())
+        if (pWindow->m_sWindowData.noBlur.valueOrDefault())
             return false;
 
         if (pWindow->m_pWLSurface->small() && !pWindow->m_pWLSurface->m_bFillIgnoreSmall)
@@ -1717,7 +1717,7 @@ bool CHyprOpenGLImpl::shouldUseNewBlurOptimizations(PHLLS pLayer, PHLWINDOW pWin
     if (!m_RenderData.pCurrentMonData->blurFB.m_cTex->m_iTexID)
         return false;
 
-    if (pWindow && !pWindow->m_sWindowData.xray.value_or_default())
+    if (pWindow && !pWindow->m_sWindowData.xray.valueOrDefault())
         return false;
 
     if (pLayer && pLayer->xray == 0)
@@ -1726,7 +1726,7 @@ bool CHyprOpenGLImpl::shouldUseNewBlurOptimizations(PHLLS pLayer, PHLWINDOW pWin
     if ((*PBLURNEWOPTIMIZE && pWindow && !pWindow->m_bIsFloating && !pWindow->onSpecialWorkspace()) || *PBLURXRAY)
         return true;
 
-    if ((pLayer && pLayer->xray == 1) || (pWindow && pWindow->m_sWindowData.xray.value_or_default()))
+    if ((pLayer && pLayer->xray == 1) || (pWindow && pWindow->m_sWindowData.xray.valueOrDefault()))
         return true;
 
     return false;
@@ -1750,7 +1750,7 @@ void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, CBox* pBox, float 
     m_RenderData.renderModif.applyToRegion(texDamage);
 
     if (*PBLURENABLED == 0 || (*PNOBLUROVERSIZED && m_RenderData.primarySurfaceUVTopLeft != Vector2D(-1, -1)) ||
-        (m_pCurrentWindow.lock() && (m_pCurrentWindow->m_sWindowData.noBlur.value_or_default() || m_pCurrentWindow->m_sWindowData.RGBX.value_or_default()))) {
+        (m_pCurrentWindow.lock() && (m_pCurrentWindow->m_sWindowData.noBlur.valueOrDefault() || m_pCurrentWindow->m_sWindowData.RGBX.valueOrDefault()))) {
         renderTexture(tex, pBox, a, round, false, true);
         return;
     }
@@ -1847,7 +1847,7 @@ void CHyprOpenGLImpl::renderBorder(CBox* box, const CGradientValueData& grad, in
 
     TRACY_GPU_ZONE("RenderBorder");
 
-    if (m_RenderData.damage.empty() || (m_pCurrentWindow.lock() && m_pCurrentWindow->m_sWindowData.noBorder.value_or_default()))
+    if (m_RenderData.damage.empty() || (m_pCurrentWindow.lock() && m_pCurrentWindow->m_sWindowData.noBorder.valueOrDefault()))
         return;
 
     CBox newBox = *box;
@@ -2108,7 +2108,7 @@ void CHyprOpenGLImpl::renderSnapshot(PHLWINDOW pWindow) {
 
     CRegion fakeDamage{0, 0, PMONITOR->vecTransformedSize.x, PMONITOR->vecTransformedSize.y};
 
-    if (*PDIMAROUND && pWindow->m_sWindowData.dimAround.value_or_default()) {
+    if (*PDIMAROUND && pWindow->m_sWindowData.dimAround.valueOrDefault()) {
         CBox monbox = {0, 0, g_pHyprOpenGL->m_RenderData.pMonitor->vecPixelSize.x, g_pHyprOpenGL->m_RenderData.pMonitor->vecPixelSize.y};
         g_pHyprOpenGL->renderRect(&monbox, CColor(0, 0, 0, *PDIMAROUND * pWindow->m_fAlpha.value()));
         g_pHyprRenderer->damageMonitor(PMONITOR);

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -434,7 +434,7 @@ bool CHyprOpenGLImpl::passRequiresIntrospection(CMonitor* pMonitor) {
         if (!w->m_bIsFloating && *POPTIM && !w->onSpecialWorkspace())
             continue;
 
-        if (w->m_sWindowData.noBlur.toUnderlying() == true || w->m_sWindowData.xray.toUnderlying() == true)
+        if (w->m_sWindowData.noBlur.value_or(false) || w->m_sWindowData.xray.value_or(false) == true)
             continue;
 
         if (w->opaque())
@@ -1130,7 +1130,7 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, CBox* pB
         }
     }
 
-    if (m_pCurrentWindow.lock() && m_pCurrentWindow->m_sWindowData.RGBX)
+    if (m_pCurrentWindow.lock() && m_pCurrentWindow->m_sWindowData.RGBX.value_or(false))
         shader = &m_RenderData.pCurrentMonData->m_shRGBX;
 
     glActiveTexture(GL_TEXTURE0);
@@ -1601,7 +1601,7 @@ void CHyprOpenGLImpl::preRender(CMonitor* pMonitor) {
         if (!pWindow)
             return false;
 
-        if (pWindow->m_sWindowData.noBlur)
+        if (pWindow->m_sWindowData.noBlur.value_or(false))
             return false;
 
         if (pWindow->m_pWLSurface->small() && !pWindow->m_pWLSurface->m_bFillIgnoreSmall)
@@ -1717,7 +1717,7 @@ bool CHyprOpenGLImpl::shouldUseNewBlurOptimizations(PHLLS pLayer, PHLWINDOW pWin
     if (!m_RenderData.pCurrentMonData->blurFB.m_cTex->m_iTexID)
         return false;
 
-    if (pWindow && pWindow->m_sWindowData.xray.toUnderlying() == 0)
+    if (pWindow && !pWindow->m_sWindowData.xray.value_or(false))
         return false;
 
     if (pLayer && pLayer->xray == 0)
@@ -1726,7 +1726,7 @@ bool CHyprOpenGLImpl::shouldUseNewBlurOptimizations(PHLLS pLayer, PHLWINDOW pWin
     if ((*PBLURNEWOPTIMIZE && pWindow && !pWindow->m_bIsFloating && !pWindow->onSpecialWorkspace()) || *PBLURXRAY)
         return true;
 
-    if ((pLayer && pLayer->xray == 1) || (pWindow && pWindow->m_sWindowData.xray.toUnderlying() == 1))
+    if ((pLayer && pLayer->xray == 1) || (pWindow && pWindow->m_sWindowData.xray.value_or(false)))
         return true;
 
     return false;
@@ -1750,7 +1750,7 @@ void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, CBox* pBox, float 
     m_RenderData.renderModif.applyToRegion(texDamage);
 
     if (*PBLURENABLED == 0 || (*PNOBLUROVERSIZED && m_RenderData.primarySurfaceUVTopLeft != Vector2D(-1, -1)) ||
-        (m_pCurrentWindow.lock() && (m_pCurrentWindow->m_sWindowData.noBlur || m_pCurrentWindow->m_sWindowData.RGBX))) {
+        (m_pCurrentWindow.lock() && (m_pCurrentWindow->m_sWindowData.noBlur.value_or(false) || m_pCurrentWindow->m_sWindowData.RGBX.value_or(false)))) {
         renderTexture(tex, pBox, a, round, false, true);
         return;
     }
@@ -1847,7 +1847,7 @@ void CHyprOpenGLImpl::renderBorder(CBox* box, const CGradientValueData& grad, in
 
     TRACY_GPU_ZONE("RenderBorder");
 
-    if (m_RenderData.damage.empty() || (m_pCurrentWindow.lock() && m_pCurrentWindow->m_sWindowData.noBorder))
+    if (m_RenderData.damage.empty() || (m_pCurrentWindow.lock() && m_pCurrentWindow->m_sWindowData.noBorder.value_or(false)))
         return;
 
     CBox newBox = *box;
@@ -2108,7 +2108,7 @@ void CHyprOpenGLImpl::renderSnapshot(PHLWINDOW pWindow) {
 
     CRegion fakeDamage{0, 0, PMONITOR->vecTransformedSize.x, PMONITOR->vecTransformedSize.y};
 
-    if (*PDIMAROUND && pWindow->m_sWindowData.dimAround) {
+    if (*PDIMAROUND && pWindow->m_sWindowData.dimAround.value_or(false)) {
         CBox monbox = {0, 0, g_pHyprOpenGL->m_RenderData.pMonitor->vecPixelSize.x, g_pHyprOpenGL->m_RenderData.pMonitor->vecPixelSize.y};
         g_pHyprOpenGL->renderRect(&monbox, CColor(0, 0, 0, *PDIMAROUND * pWindow->m_fAlpha.value()));
         g_pHyprRenderer->damageMonitor(PMONITOR);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -531,7 +531,7 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, CMonitor* pMonitor, timespec
         decorate = false;
 
     renderdata.surface   = pWindow->m_pWLSurface->resource();
-    renderdata.dontRound = (pWindow->m_bIsFullscreen && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL) || pWindow->m_sWindowData.noRounding;
+    renderdata.dontRound = (pWindow->m_bIsFullscreen && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL) || pWindow->m_sWindowData.noRounding.value_or(false);
     renderdata.fadeAlpha = pWindow->m_fAlpha.value() * (pWindow->m_bPinned ? 1.f : PWORKSPACE->m_fAlpha.value());
     renderdata.alpha     = pWindow->m_fActiveInactiveAlpha.value();
     renderdata.decorate  = decorate && !pWindow->m_bX11DoesntWantBorders && (!pWindow->m_bIsFullscreen || PWORKSPACE->m_efFullscreenMode != FULLSCREEN_FULL);
@@ -545,14 +545,14 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, CMonitor* pMonitor, timespec
     }
 
     // apply opaque
-    if (pWindow->m_sWindowData.opaque)
+    if (pWindow->m_sWindowData.opaque.value_or(false))
         renderdata.alpha = 1.f;
 
     g_pHyprOpenGL->m_pCurrentWindow = pWindow;
 
     EMIT_HOOK_EVENT("render", RENDER_PRE_WINDOW);
 
-    if (*PDIMAROUND && pWindow->m_sWindowData.dimAround && !m_bRenderingSnapshot && mode != RENDER_PASS_POPUP) {
+    if (*PDIMAROUND && pWindow->m_sWindowData.dimAround.value_or(false) && !m_bRenderingSnapshot && mode != RENDER_PASS_POPUP) {
         CBox monbox = {0, 0, g_pHyprOpenGL->m_RenderData.pMonitor->vecTransformedSize.x, g_pHyprOpenGL->m_RenderData.pMonitor->vecTransformedSize.y};
         g_pHyprOpenGL->renderRect(&monbox, CColor(0, 0, 0, *PDIMAROUND * renderdata.alpha * renderdata.fadeAlpha));
     }
@@ -597,10 +597,10 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, CMonitor* pMonitor, timespec
         }
 
         static auto PXWLUSENN = CConfigValue<Hyprlang::INT>("xwayland:use_nearest_neighbor");
-        if ((pWindow->m_bIsX11 && *PXWLUSENN) || pWindow->m_sWindowData.nearestNeighbor.toUnderlying())
+        if ((pWindow->m_bIsX11 && *PXWLUSENN) || pWindow->m_sWindowData.nearestNeighbor.value_or(false))
             g_pHyprOpenGL->m_RenderData.useNearestNeighbor = true;
 
-        if (!pWindow->m_sWindowData.noBlur && pWindow->m_pWLSurface->small() && !pWindow->m_pWLSurface->m_bFillIgnoreSmall && renderdata.blur && *PBLUR) {
+        if (!pWindow->m_sWindowData.noBlur.value_or(false) && pWindow->m_pWLSurface->small() && !pWindow->m_pWLSurface->m_bFillIgnoreSmall && renderdata.blur && *PBLUR) {
             CBox wb = {renderdata.x - pMonitor->vecPosition.x, renderdata.y - pMonitor->vecPosition.y, renderdata.w, renderdata.h};
             wb.scale(pMonitor->scale).round();
             g_pHyprOpenGL->renderRectWithBlur(&wb, CColor(0, 0, 0, 0), renderdata.dontRound ? 0 : renderdata.rounding - 1, renderdata.fadeAlpha,
@@ -662,7 +662,7 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, CMonitor* pMonitor, timespec
                 g_pHyprOpenGL->m_RenderData.discardOpacity = *PBLURIGNOREA;
             }
 
-            if (pWindow->m_sWindowData.nearestNeighbor.toUnderlying())
+            if (pWindow->m_sWindowData.nearestNeighbor.value_or(false))
                 g_pHyprOpenGL->m_RenderData.useNearestNeighbor = true;
 
             renderdata.surfaceCounter = 0;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -531,7 +531,7 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, CMonitor* pMonitor, timespec
         decorate = false;
 
     renderdata.surface   = pWindow->m_pWLSurface->resource();
-    renderdata.dontRound = (pWindow->m_bIsFullscreen && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL) || pWindow->m_sWindowData.noRounding.value_or(false);
+    renderdata.dontRound = (pWindow->m_bIsFullscreen && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL) || pWindow->m_sWindowData.noRounding.value_or_default();
     renderdata.fadeAlpha = pWindow->m_fAlpha.value() * (pWindow->m_bPinned ? 1.f : PWORKSPACE->m_fAlpha.value());
     renderdata.alpha     = pWindow->m_fActiveInactiveAlpha.value();
     renderdata.decorate  = decorate && !pWindow->m_bX11DoesntWantBorders && (!pWindow->m_bIsFullscreen || PWORKSPACE->m_efFullscreenMode != FULLSCREEN_FULL);
@@ -545,14 +545,14 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, CMonitor* pMonitor, timespec
     }
 
     // apply opaque
-    if (pWindow->m_sWindowData.opaque.value_or(false))
+    if (pWindow->m_sWindowData.opaque.value_or_default())
         renderdata.alpha = 1.f;
 
     g_pHyprOpenGL->m_pCurrentWindow = pWindow;
 
     EMIT_HOOK_EVENT("render", RENDER_PRE_WINDOW);
 
-    if (*PDIMAROUND && pWindow->m_sWindowData.dimAround.value_or(false) && !m_bRenderingSnapshot && mode != RENDER_PASS_POPUP) {
+    if (*PDIMAROUND && pWindow->m_sWindowData.dimAround.value_or_default() && !m_bRenderingSnapshot && mode != RENDER_PASS_POPUP) {
         CBox monbox = {0, 0, g_pHyprOpenGL->m_RenderData.pMonitor->vecTransformedSize.x, g_pHyprOpenGL->m_RenderData.pMonitor->vecTransformedSize.y};
         g_pHyprOpenGL->renderRect(&monbox, CColor(0, 0, 0, *PDIMAROUND * renderdata.alpha * renderdata.fadeAlpha));
     }
@@ -597,10 +597,10 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, CMonitor* pMonitor, timespec
         }
 
         static auto PXWLUSENN = CConfigValue<Hyprlang::INT>("xwayland:use_nearest_neighbor");
-        if ((pWindow->m_bIsX11 && *PXWLUSENN) || pWindow->m_sWindowData.nearestNeighbor.value_or(false))
+        if ((pWindow->m_bIsX11 && *PXWLUSENN) || pWindow->m_sWindowData.nearestNeighbor.value_or_default())
             g_pHyprOpenGL->m_RenderData.useNearestNeighbor = true;
 
-        if (!pWindow->m_sWindowData.noBlur.value_or(false) && pWindow->m_pWLSurface->small() && !pWindow->m_pWLSurface->m_bFillIgnoreSmall && renderdata.blur && *PBLUR) {
+        if (!pWindow->m_sWindowData.noBlur.value_or_default() && pWindow->m_pWLSurface->small() && !pWindow->m_pWLSurface->m_bFillIgnoreSmall && renderdata.blur && *PBLUR) {
             CBox wb = {renderdata.x - pMonitor->vecPosition.x, renderdata.y - pMonitor->vecPosition.y, renderdata.w, renderdata.h};
             wb.scale(pMonitor->scale).round();
             g_pHyprOpenGL->renderRectWithBlur(&wb, CColor(0, 0, 0, 0), renderdata.dontRound ? 0 : renderdata.rounding - 1, renderdata.fadeAlpha,
@@ -662,7 +662,7 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, CMonitor* pMonitor, timespec
                 g_pHyprOpenGL->m_RenderData.discardOpacity = *PBLURIGNOREA;
             }
 
-            if (pWindow->m_sWindowData.nearestNeighbor.value_or(false))
+            if (pWindow->m_sWindowData.nearestNeighbor.value_or_default())
                 g_pHyprOpenGL->m_RenderData.useNearestNeighbor = true;
 
             renderdata.surfaceCounter = 0;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -531,7 +531,7 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, CMonitor* pMonitor, timespec
         decorate = false;
 
     renderdata.surface   = pWindow->m_pWLSurface->resource();
-    renderdata.dontRound = (pWindow->m_bIsFullscreen && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL) || pWindow->m_sWindowData.noRounding.value_or_default();
+    renderdata.dontRound = (pWindow->m_bIsFullscreen && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL) || pWindow->m_sWindowData.noRounding.valueOrDefault();
     renderdata.fadeAlpha = pWindow->m_fAlpha.value() * (pWindow->m_bPinned ? 1.f : PWORKSPACE->m_fAlpha.value());
     renderdata.alpha     = pWindow->m_fActiveInactiveAlpha.value();
     renderdata.decorate  = decorate && !pWindow->m_bX11DoesntWantBorders && (!pWindow->m_bIsFullscreen || PWORKSPACE->m_efFullscreenMode != FULLSCREEN_FULL);
@@ -545,14 +545,14 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, CMonitor* pMonitor, timespec
     }
 
     // apply opaque
-    if (pWindow->m_sWindowData.opaque.value_or_default())
+    if (pWindow->m_sWindowData.opaque.valueOrDefault())
         renderdata.alpha = 1.f;
 
     g_pHyprOpenGL->m_pCurrentWindow = pWindow;
 
     EMIT_HOOK_EVENT("render", RENDER_PRE_WINDOW);
 
-    if (*PDIMAROUND && pWindow->m_sWindowData.dimAround.value_or_default() && !m_bRenderingSnapshot && mode != RENDER_PASS_POPUP) {
+    if (*PDIMAROUND && pWindow->m_sWindowData.dimAround.valueOrDefault() && !m_bRenderingSnapshot && mode != RENDER_PASS_POPUP) {
         CBox monbox = {0, 0, g_pHyprOpenGL->m_RenderData.pMonitor->vecTransformedSize.x, g_pHyprOpenGL->m_RenderData.pMonitor->vecTransformedSize.y};
         g_pHyprOpenGL->renderRect(&monbox, CColor(0, 0, 0, *PDIMAROUND * renderdata.alpha * renderdata.fadeAlpha));
     }
@@ -597,10 +597,10 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, CMonitor* pMonitor, timespec
         }
 
         static auto PXWLUSENN = CConfigValue<Hyprlang::INT>("xwayland:use_nearest_neighbor");
-        if ((pWindow->m_bIsX11 && *PXWLUSENN) || pWindow->m_sWindowData.nearestNeighbor.value_or_default())
+        if ((pWindow->m_bIsX11 && *PXWLUSENN) || pWindow->m_sWindowData.nearestNeighbor.valueOrDefault())
             g_pHyprOpenGL->m_RenderData.useNearestNeighbor = true;
 
-        if (!pWindow->m_sWindowData.noBlur.value_or_default() && pWindow->m_pWLSurface->small() && !pWindow->m_pWLSurface->m_bFillIgnoreSmall && renderdata.blur && *PBLUR) {
+        if (!pWindow->m_sWindowData.noBlur.valueOrDefault() && pWindow->m_pWLSurface->small() && !pWindow->m_pWLSurface->m_bFillIgnoreSmall && renderdata.blur && *PBLUR) {
             CBox wb = {renderdata.x - pMonitor->vecPosition.x, renderdata.y - pMonitor->vecPosition.y, renderdata.w, renderdata.h};
             wb.scale(pMonitor->scale).round();
             g_pHyprOpenGL->renderRectWithBlur(&wb, CColor(0, 0, 0, 0), renderdata.dontRound ? 0 : renderdata.rounding - 1, renderdata.fadeAlpha,
@@ -662,7 +662,7 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, CMonitor* pMonitor, timespec
                 g_pHyprOpenGL->m_RenderData.discardOpacity = *PBLURIGNOREA;
             }
 
-            if (pWindow->m_sWindowData.nearestNeighbor.value_or_default())
+            if (pWindow->m_sWindowData.nearestNeighbor.valueOrDefault())
                 g_pHyprOpenGL->m_RenderData.useNearestNeighbor = true;
 
             renderdata.surfaceCounter = 0;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -531,7 +531,7 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, CMonitor* pMonitor, timespec
         decorate = false;
 
     renderdata.surface   = pWindow->m_pWLSurface->resource();
-    renderdata.dontRound = (pWindow->m_bIsFullscreen && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL) || (!pWindow->m_sSpecialRenderData.rounding);
+    renderdata.dontRound = (pWindow->m_bIsFullscreen && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL) || pWindow->m_sWindowData.noRounding;
     renderdata.fadeAlpha = pWindow->m_fAlpha.value() * (pWindow->m_bPinned ? 1.f : PWORKSPACE->m_fAlpha.value());
     renderdata.alpha     = pWindow->m_fActiveInactiveAlpha.value();
     renderdata.decorate  = decorate && !pWindow->m_bX11DoesntWantBorders && (!pWindow->m_bIsFullscreen || PWORKSPACE->m_efFullscreenMode != FULLSCREEN_FULL);
@@ -545,14 +545,14 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, CMonitor* pMonitor, timespec
     }
 
     // apply opaque
-    if (pWindow->m_sAdditionalConfigData.forceOpaque)
+    if (pWindow->m_sWindowData.opaque)
         renderdata.alpha = 1.f;
 
     g_pHyprOpenGL->m_pCurrentWindow = pWindow;
 
     EMIT_HOOK_EVENT("render", RENDER_PRE_WINDOW);
 
-    if (*PDIMAROUND && pWindow->m_sAdditionalConfigData.dimAround && !m_bRenderingSnapshot && mode != RENDER_PASS_POPUP) {
+    if (*PDIMAROUND && pWindow->m_sWindowData.dimAround && !m_bRenderingSnapshot && mode != RENDER_PASS_POPUP) {
         CBox monbox = {0, 0, g_pHyprOpenGL->m_RenderData.pMonitor->vecTransformedSize.x, g_pHyprOpenGL->m_RenderData.pMonitor->vecTransformedSize.y};
         g_pHyprOpenGL->renderRect(&monbox, CColor(0, 0, 0, *PDIMAROUND * renderdata.alpha * renderdata.fadeAlpha));
     }
@@ -597,10 +597,10 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, CMonitor* pMonitor, timespec
         }
 
         static auto PXWLUSENN = CConfigValue<Hyprlang::INT>("xwayland:use_nearest_neighbor");
-        if ((pWindow->m_bIsX11 && *PXWLUSENN) || pWindow->m_sAdditionalConfigData.nearestNeighbor.toUnderlying())
+        if ((pWindow->m_bIsX11 && *PXWLUSENN) || pWindow->m_sWindowData.nearestNeighbor.toUnderlying())
             g_pHyprOpenGL->m_RenderData.useNearestNeighbor = true;
 
-        if (!pWindow->m_sAdditionalConfigData.forceNoBlur && pWindow->m_pWLSurface->small() && !pWindow->m_pWLSurface->m_bFillIgnoreSmall && renderdata.blur && *PBLUR) {
+        if (!pWindow->m_sWindowData.noBlur && pWindow->m_pWLSurface->small() && !pWindow->m_pWLSurface->m_bFillIgnoreSmall && renderdata.blur && *PBLUR) {
             CBox wb = {renderdata.x - pMonitor->vecPosition.x, renderdata.y - pMonitor->vecPosition.y, renderdata.w, renderdata.h};
             wb.scale(pMonitor->scale).round();
             g_pHyprOpenGL->renderRectWithBlur(&wb, CColor(0, 0, 0, 0), renderdata.dontRound ? 0 : renderdata.rounding - 1, renderdata.fadeAlpha,
@@ -662,7 +662,7 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, CMonitor* pMonitor, timespec
                 g_pHyprOpenGL->m_RenderData.discardOpacity = *PBLURIGNOREA;
             }
 
-            if (pWindow->m_sAdditionalConfigData.nearestNeighbor.toUnderlying())
+            if (pWindow->m_sWindowData.nearestNeighbor.toUnderlying())
                 g_pHyprOpenGL->m_RenderData.useNearestNeighbor = true;
 
             renderdata.surfaceCounter = 0;

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -133,5 +133,5 @@ std::string CHyprBorderDecoration::getDisplayName() {
 }
 
 bool CHyprBorderDecoration::doesntWantBorders() {
-    return !m_pWindow->m_sSpecialRenderData.border || m_pWindow->m_bX11DoesntWantBorders || m_pWindow->getRealBorderSize() == 0;
+    return m_pWindow->m_sWindowData.noBorder || m_pWindow->m_bX11DoesntWantBorders || m_pWindow->getRealBorderSize() == 0;
 }

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -133,5 +133,5 @@ std::string CHyprBorderDecoration::getDisplayName() {
 }
 
 bool CHyprBorderDecoration::doesntWantBorders() {
-    return m_pWindow->m_sWindowData.noBorder.value_or_default() || m_pWindow->m_bX11DoesntWantBorders || m_pWindow->getRealBorderSize() == 0;
+    return m_pWindow->m_sWindowData.noBorder.valueOrDefault() || m_pWindow->m_bX11DoesntWantBorders || m_pWindow->getRealBorderSize() == 0;
 }

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -133,5 +133,5 @@ std::string CHyprBorderDecoration::getDisplayName() {
 }
 
 bool CHyprBorderDecoration::doesntWantBorders() {
-    return m_pWindow->m_sWindowData.noBorder.value_or(false) || m_pWindow->m_bX11DoesntWantBorders || m_pWindow->getRealBorderSize() == 0;
+    return m_pWindow->m_sWindowData.noBorder.value_or_default() || m_pWindow->m_bX11DoesntWantBorders || m_pWindow->getRealBorderSize() == 0;
 }

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -133,5 +133,5 @@ std::string CHyprBorderDecoration::getDisplayName() {
 }
 
 bool CHyprBorderDecoration::doesntWantBorders() {
-    return m_pWindow->m_sWindowData.noBorder || m_pWindow->m_bX11DoesntWantBorders || m_pWindow->getRealBorderSize() == 0;
+    return m_pWindow->m_sWindowData.noBorder.value_or(false) || m_pWindow->m_bX11DoesntWantBorders || m_pWindow->getRealBorderSize() == 0;
 }

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -96,10 +96,10 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a) {
     if (PWINDOW->m_cRealShadowColor.value() == CColor(0, 0, 0, 0))
         return; // don't draw invisible shadows
 
-    if (!PWINDOW->m_sWindowData.decorate.value_or_default())
+    if (!PWINDOW->m_sWindowData.decorate.valueOrDefault())
         return;
 
-    if (PWINDOW->m_sWindowData.noShadow.value_or_default())
+    if (PWINDOW->m_sWindowData.noShadow.valueOrDefault())
         return;
 
     static auto PSHADOWS            = CConfigValue<Hyprlang::INT>("decoration:drop_shadow");

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -96,10 +96,10 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a) {
     if (PWINDOW->m_cRealShadowColor.value() == CColor(0, 0, 0, 0))
         return; // don't draw invisible shadows
 
-    if (!PWINDOW->m_sWindowData.decorate.value_or(true))
+    if (!PWINDOW->m_sWindowData.decorate.value_or_default())
         return;
 
-    if (PWINDOW->m_sWindowData.noShadow.value_or(false))
+    if (PWINDOW->m_sWindowData.noShadow.value_or_default())
         return;
 
     static auto PSHADOWS            = CConfigValue<Hyprlang::INT>("decoration:drop_shadow");

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -96,10 +96,10 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a) {
     if (PWINDOW->m_cRealShadowColor.value() == CColor(0, 0, 0, 0))
         return; // don't draw invisible shadows
 
-    if (!PWINDOW->m_sWindowData.decorate)
+    if (!PWINDOW->m_sWindowData.decorate.value_or(true))
         return;
 
-    if (PWINDOW->m_sWindowData.noShadow)
+    if (PWINDOW->m_sWindowData.noShadow.value_or(false))
         return;
 
     static auto PSHADOWS            = CConfigValue<Hyprlang::INT>("decoration:drop_shadow");

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -96,13 +96,10 @@ void CHyprDropShadowDecoration::draw(CMonitor* pMonitor, float a) {
     if (PWINDOW->m_cRealShadowColor.value() == CColor(0, 0, 0, 0))
         return; // don't draw invisible shadows
 
-    if (!PWINDOW->m_sSpecialRenderData.decorate)
+    if (!PWINDOW->m_sWindowData.decorate)
         return;
 
-    if (!PWINDOW->m_sSpecialRenderData.shadow)
-        return;
-
-    if (PWINDOW->m_sAdditionalConfigData.forceNoShadow)
+    if (PWINDOW->m_sWindowData.noShadow)
         return;
 
     static auto PSHADOWS            = CConfigValue<Hyprlang::INT>("decoration:drop_shadow");

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -42,7 +42,7 @@ SDecorationPositioningInfo CHyprGroupBarDecoration::getPositioningInfo() {
     info.priority = *PPRIORITY;
     info.reserved = true;
 
-    if (*PENABLED && m_pWindow->m_sWindowData.decorate.value_or(true)) {
+    if (*PENABLED && m_pWindow->m_sWindowData.decorate.value_or_default()) {
         if (*PSTACKED) {
             const auto ONEBARHEIGHT = BAR_PADDING_OUTER_VERT + BAR_INDICATOR_HEIGHT + (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0);
             info.desiredExtents     = {{0, (ONEBARHEIGHT * m_dwGroupMembers.size()) + 2 + BAR_PADDING_OUTER_VERT}, {0, 0}};
@@ -105,7 +105,7 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a) {
     static auto PGRADIENTS     = CConfigValue<Hyprlang::INT>("group:groupbar:gradients");
     static auto PSTACKED       = CConfigValue<Hyprlang::INT>("group:groupbar:stacked");
 
-    if (!*PENABLED || !m_pWindow->m_sWindowData.decorate.value_or(true))
+    if (!*PENABLED || !m_pWindow->m_sWindowData.decorate.value_or_default())
         return;
 
     const auto ASSIGNEDBOX = assignedBoxGlobal();

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -42,7 +42,7 @@ SDecorationPositioningInfo CHyprGroupBarDecoration::getPositioningInfo() {
     info.priority = *PPRIORITY;
     info.reserved = true;
 
-    if (*PENABLED && m_pWindow->m_sSpecialRenderData.decorate) {
+    if (*PENABLED && m_pWindow->m_sWindowData.decorate) {
         if (*PSTACKED) {
             const auto ONEBARHEIGHT = BAR_PADDING_OUTER_VERT + BAR_INDICATOR_HEIGHT + (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0);
             info.desiredExtents     = {{0, (ONEBARHEIGHT * m_dwGroupMembers.size()) + 2 + BAR_PADDING_OUTER_VERT}, {0, 0}};
@@ -105,7 +105,7 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a) {
     static auto PGRADIENTS     = CConfigValue<Hyprlang::INT>("group:groupbar:gradients");
     static auto PSTACKED       = CConfigValue<Hyprlang::INT>("group:groupbar:stacked");
 
-    if (!*PENABLED || !m_pWindow->m_sSpecialRenderData.decorate)
+    if (!*PENABLED || !m_pWindow->m_sWindowData.decorate)
         return;
 
     const auto ASSIGNEDBOX = assignedBoxGlobal();

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -42,7 +42,7 @@ SDecorationPositioningInfo CHyprGroupBarDecoration::getPositioningInfo() {
     info.priority = *PPRIORITY;
     info.reserved = true;
 
-    if (*PENABLED && m_pWindow->m_sWindowData.decorate) {
+    if (*PENABLED && m_pWindow->m_sWindowData.decorate.value_or(true)) {
         if (*PSTACKED) {
             const auto ONEBARHEIGHT = BAR_PADDING_OUTER_VERT + BAR_INDICATOR_HEIGHT + (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0);
             info.desiredExtents     = {{0, (ONEBARHEIGHT * m_dwGroupMembers.size()) + 2 + BAR_PADDING_OUTER_VERT}, {0, 0}};
@@ -105,7 +105,7 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a) {
     static auto PGRADIENTS     = CConfigValue<Hyprlang::INT>("group:groupbar:gradients");
     static auto PSTACKED       = CConfigValue<Hyprlang::INT>("group:groupbar:stacked");
 
-    if (!*PENABLED || !m_pWindow->m_sWindowData.decorate)
+    if (!*PENABLED || !m_pWindow->m_sWindowData.decorate.value_or(true))
         return;
 
     const auto ASSIGNEDBOX = assignedBoxGlobal();

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -42,7 +42,7 @@ SDecorationPositioningInfo CHyprGroupBarDecoration::getPositioningInfo() {
     info.priority = *PPRIORITY;
     info.reserved = true;
 
-    if (*PENABLED && m_pWindow->m_sWindowData.decorate.value_or_default()) {
+    if (*PENABLED && m_pWindow->m_sWindowData.decorate.valueOrDefault()) {
         if (*PSTACKED) {
             const auto ONEBARHEIGHT = BAR_PADDING_OUTER_VERT + BAR_INDICATOR_HEIGHT + (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0);
             info.desiredExtents     = {{0, (ONEBARHEIGHT * m_dwGroupMembers.size()) + 2 + BAR_PADDING_OUTER_VERT}, {0, 0}};
@@ -105,7 +105,7 @@ void CHyprGroupBarDecoration::draw(CMonitor* pMonitor, float a) {
     static auto PGRADIENTS     = CConfigValue<Hyprlang::INT>("group:groupbar:gradients");
     static auto PSTACKED       = CConfigValue<Hyprlang::INT>("group:groupbar:stacked");
 
-    if (!*PENABLED || !m_pWindow->m_sWindowData.decorate.value_or_default())
+    if (!*PENABLED || !m_pWindow->m_sWindowData.decorate.valueOrDefault())
         return;
 
     const auto ASSIGNEDBOX = assignedBoxGlobal();


### PR DESCRIPTION
In this PR, `CWindowOverridableVar` allows setting different priorities for each value to fix issues where the layout, the workspace/window rules and `setprop` want different things.
Most properties have become window rules as well, and vice versa.
`SWindowAdditionalConfigData` and `SWindowSpecialRenderData` have been unified into SWindowData
`mbWindowProperties` and `miWindowProperties` have been created to avoid having to specify window rules / `setprop` in multiple places (ideally there would be a global struct for all types but I'm not sure how to do that without using `void*`)

Details:
`allowsinput`, `dimaround`, `decorate`, `focusonactivate`, `keepaspectratio`, `nearestneighbor`, `noanim`, `noblur`
`noborder`, `nodim`, `nofocus`, `nomaxsize`, `norounding`, `noshadow`, `opaque`, `forcergbx`, `immediate`, `xray`, `windowdance` can now be set with both windowrules and `setprop`
windowrule: `allowsinput` (set as true for backwards compatibility), `allowsinput 0` or `allowsinput 1`
`setprop`: `allowsinput 0` or `allowsinput 1`, `allowsinput toggle` and `allowsinput unset` (to unset value previously set with `set prop` or exec rules)
setprop also allows `bordersize unset` and `rounding toggle`

some workspace rule values have been flipped internally to match the negative nature of the window properties
`forceinput` has been removed because it wasn't used anywhere in the codebase (???)
exec rules now have the same priority as `setprop` so they won't disappear when the window rules get reloaded neither get overridden by a window rule that would match the same window

and I think that's mostly it
seems to work fine for some rules and cases I've tested but still haven't tested all case
also needs a wiki MR, but should be ready for review
