### PR TITLE
config: don't crash when getenv HOME returns null

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -633,7 +633,12 @@ std::string CConfigManager::getConfigDir() {
     if (xdgConfigHome && std::filesystem::path(xdgConfigHome).is_absolute())
         return xdgConfigHome;
 
-    return getenv("HOME") + std::string("/.config");
+    static const char* home = getenv("HOME");
+
+    if (!home)
+        throw std::runtime_error("Neither HOME nor XDG_CONFIG_HOME is set in the environment. Cannot determine config directory.");
+
+    return home + std::string("/.config");
 }
 
 std::string CConfigManager::getMainConfigPath() {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

No crash when homeless.
Same as https://github.com/hyprwm/hyprlock/pull/398

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Ready.