### PR TITLE
Add scheduleFrame and scheduleFrameForMonitor reasons

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -6,6 +6,7 @@
 #include "managers/PointerManager.hpp"
 #include "managers/SeatManager.hpp"
 #include "managers/eventLoop/EventLoopManager.hpp"
+#include <aquamarine/output/Output.hpp>
 #include <random>
 #include <cstring>
 #include <unordered_set>
@@ -2341,7 +2342,7 @@ void CCompositor::updateWorkspaceSpecialRenderData(const int& id) {
     }
 }
 
-void CCompositor::scheduleFrameForMonitor(CMonitor* pMonitor) {
+void CCompositor::scheduleFrameForMonitor(CMonitor* pMonitor, IOutput::scheduleFrameReason reason) {
     if ((m_pAqBackend->hasSession() && !m_pAqBackend->session->active) || !m_bSessionActive)
         return;
 
@@ -2351,7 +2352,7 @@ void CCompositor::scheduleFrameForMonitor(CMonitor* pMonitor) {
     if (pMonitor->renderingActive)
         pMonitor->pendingFrame = true;
 
-    pMonitor->output->scheduleFrame();
+    pMonitor->output->scheduleFrame(reason);
 }
 
 PHLWINDOW CCompositor::getWindowByRegex(const std::string& regexp) {
@@ -2934,7 +2935,7 @@ void CCompositor::onNewMonitor(SP<Aquamarine::IOutput> output) {
     g_pCompositor->m_bReadyToProcess = true;
 
     g_pConfigManager->m_bWantsMonitorReload = true;
-    g_pCompositor->scheduleFrameForMonitor(PNEWMONITOR.get());
+    g_pCompositor->scheduleFrameForMonitor(PNEWMONITOR.get(), IOutput::AQ_SCHEDULE_NEW_MONITOR);
 
     checkDefaultCursorWarp(PNEWMONITOR, output->name);
 

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -148,7 +148,7 @@ class CCompositor {
     void                   setWindowFullscreen(PHLWINDOW, bool, eFullscreenMode mode = FULLSCREEN_INVALID);
     void                   updateFullscreenFadeOnWorkspace(PHLWORKSPACE);
     PHLWINDOW              getX11Parent(PHLWINDOW);
-    void                   scheduleFrameForMonitor(CMonitor*);
+    void                   scheduleFrameForMonitor(CMonitor*, Aquamarine::IOutput::scheduleFrameReason reason = Aquamarine::IOutput::AQ_SCHEDULE_CLIENT_UNKNOWN);
     void                   addToFadingOutSafe(PHLLS);
     void                   removeFromFadingOutSafe(PHLLS);
     void                   addToFadingOutSafe(PHLWINDOW);

--- a/src/events/Monitors.cpp
+++ b/src/events/Monitors.cpp
@@ -5,6 +5,7 @@
 #include "Events.hpp"
 #include "../debug/HyprCtl.hpp"
 #include "../config/ConfigValue.hpp"
+#include <aquamarine/output/Output.hpp>
 
 // --------------------------------------------------------- //
 //   __  __  ____  _   _ _____ _______ ____  _____   _____   //
@@ -110,7 +111,7 @@ void Events::listener_monitorDestroy(void* owner, void* data) {
 void Events::listener_monitorNeedsFrame(void* owner, void* data) {
     const auto PMONITOR = (CMonitor*)owner;
 
-    g_pCompositor->scheduleFrameForMonitor(PMONITOR);
+    g_pCompositor->scheduleFrameForMonitor(PMONITOR, Aquamarine::IOutput::AQ_SCHEDULE_NEEDS_FRAME);
 }
 
 void Events::listener_monitorCommit(void* owner, void* data) {

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -259,7 +259,7 @@ void CAnimationManager::tick() {
 
         // manually schedule a frame
         if (PMONITOR)
-            g_pCompositor->scheduleFrameForMonitor(PMONITOR);
+            g_pCompositor->scheduleFrameForMonitor(PMONITOR, Aquamarine::IOutput::AQ_SCHEDULE_CURSOR_SHAPE);
     }
 
     // do it here, because if this alters the animation vars deque we would be in trouble above.

--- a/src/managers/CursorManager.cpp
+++ b/src/managers/CursorManager.cpp
@@ -277,7 +277,7 @@ void CCursorManager::updateTheme() {
 
     for (auto& m : g_pCompositor->m_vMonitors) {
         m->forceFullFrames = 5;
-        g_pCompositor->scheduleFrameForMonitor(m.get());
+        g_pCompositor->scheduleFrameForMonitor(m.get(), Aquamarine::IOutput::AQ_SCHEDULE_CURSOR_SHAPE);
     }
 }
 

--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -342,7 +342,7 @@ bool CPointerManager::setHWCursorBuffer(SP<SMonitorPointerState> state, SP<Aquam
 
     state->cursorFrontBuffer = buf;
 
-    g_pCompositor->scheduleFrameForMonitor(state->monitor.get());
+    g_pCompositor->scheduleFrameForMonitor(state->monitor.get(), Aquamarine::IOutput::AQ_SCHEDULE_CURSOR_SHAPE);
 
     return true;
 }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1,5 +1,6 @@
 #include "InputManager.hpp"
 #include "../../Compositor.hpp"
+#include <aquamarine/output/Output.hpp>
 #include <cstdint>
 #include <ranges>
 #include "../../config/ConfigValue.hpp"
@@ -191,7 +192,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
     bool skipFrameSchedule = PMONITOR->shouldSkipScheduleFrameOnMouseEvent();
 
     if (!PMONITOR->solitaryClient.lock() && g_pHyprRenderer->shouldRenderCursor() && g_pPointerManager->softwareLockedFor(PMONITOR->self.lock()) && !skipFrameSchedule)
-        g_pCompositor->scheduleFrameForMonitor(PMONITOR);
+        g_pCompositor->scheduleFrameForMonitor(PMONITOR, Aquamarine::IOutput::AQ_SCHEDULE_CURSOR_MOVE);
 
     PHLWINDOW forcedFocus = m_pForcedFocus.lock();
 
@@ -374,7 +375,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
             g_pCompositor->vectorToLayerSurface(mouseCoords, &PMONITOR->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND], &surfaceCoords, &pFoundLayerSurface);
 
     if (g_pPointerManager->softwareLockedFor(PMONITOR->self.lock()) > 0 && !skipFrameSchedule)
-        g_pCompositor->scheduleFrameForMonitor(g_pCompositor->m_pLastMonitor.get());
+        g_pCompositor->scheduleFrameForMonitor(g_pCompositor->m_pLastMonitor.get(), Aquamarine::IOutput::AQ_SCHEDULE_CURSOR_MOVE);
 
     // grabs
     if (g_pSeatManager->seatGrab && !g_pSeatManager->seatGrab->accepts(foundSurface)) {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2,6 +2,7 @@
 #include "../Compositor.hpp"
 #include "../helpers/math/Math.hpp"
 #include <algorithm>
+#include <aquamarine/output/Output.hpp>
 #include <cstring>
 #include "../config/ConfigValue.hpp"
 #include "../managers/CursorManager.hpp"
@@ -1184,7 +1185,7 @@ void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
         pMonitor->framesToSkip -= 1;
 
         if (!pMonitor->noFrameSchedule)
-            g_pCompositor->scheduleFrameForMonitor(pMonitor);
+            g_pCompositor->scheduleFrameForMonitor(pMonitor, Aquamarine::IOutput::AQ_SCHEDULE_RENDER_MONITOR);
         else
             Debug::log(LOG, "NoFrameSchedule hit for {}.", pMonitor->szName);
 
@@ -1429,7 +1430,7 @@ void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
         pMonitor->tearingState.busy = true;
 
     if (*PDAMAGEBLINK || *PVFR == 0 || pMonitor->pendingFrame)
-        g_pCompositor->scheduleFrameForMonitor(pMonitor);
+        g_pCompositor->scheduleFrameForMonitor(pMonitor, Aquamarine::IOutput::AQ_SCHEDULE_RENDER_MONITOR);
 
     pMonitor->pendingFrame = false;
 
@@ -1747,7 +1748,7 @@ void CHyprRenderer::damageSurface(SP<CWLSurfaceResource> pSurface, double x, dou
         damageBox.scale(scale);
 
     // schedule frame events
-    g_pCompositor->scheduleFrameForMonitor(g_pCompositor->getMonitorFromVector(Vector2D(x, y)));
+    g_pCompositor->scheduleFrameForMonitor(g_pCompositor->getMonitorFromVector(Vector2D(x, y)), Aquamarine::IOutput::AQ_SCHEDULE_DAMAGE);
 
     if (damageBox.empty())
         return;
@@ -1865,7 +1866,7 @@ void CHyprRenderer::damageMirrorsWith(CMonitor* pMonitor, const CRegion& pRegion
 
         mirror->addDamage(&transformed);
 
-        g_pCompositor->scheduleFrameForMonitor(mirror);
+        g_pCompositor->scheduleFrameForMonitor(mirror, Aquamarine::IOutput::AQ_SCHEDULE_DAMAGE);
     }
 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds an optional argument `Aquamarine::IOutput::scheduleFrameReason` to `scheduleFrameForMonitor` and passes it to `Aquamarine::IOutput::scheduleFrame`. Used only for logging now. Can be used for stuff like `cursor:no_break_fs_vrr`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Not every `scheduleFrameReason` call updated to pass an additional argument. Those calls will default to `AQ_SCHEDULE_CLIENT_UNKNOWN`

#### Is it ready for merging, or does it need work?
Requires https://github.com/hyprwm/aquamarine/pull/7

