### PR TITLE
workspaces: don't try to reopen special workspaces

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -652,6 +652,9 @@ void CMonitor::changeWorkspace(const int& id, bool internal, bool noMouseMove, b
 }
 
 void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
+    if (activeSpecialWorkspace == pWorkspace)
+        return;
+
     g_pHyprRenderer->damageMonitor(this);
 
     if (!pWorkspace) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Currently, if a special workspace is set whilst already being open, the special workspace is put in a weird state where it is open, but not shown (possibly due to the fade-in and fade-out animations being ran concurrently).

This bug was bothering me for quite some time, but never came around to look into it. In my case it often happens because I have windowrules along these lines:
```
windowrulev2 = workspace special, class:^Alacritty$
```
This meant that when I tried to open such a window with the workspace already being open, it would enter this weird invisible state. Of course, this state could be overcome by just closing and reopening the special workspace, but it was annoying nonetheless.

The implemented fix is simple, just don't do anything if the workspace is already shown.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Yes


