### PR TITLE
Explicit sync fixes

### DIFF
--- a/src/helpers/sync/SyncTimeline.cpp
+++ b/src/helpers/sync/SyncTimeline.cpp
@@ -162,13 +162,13 @@ bool CSyncTimeline::importFromSyncFileFD(uint64_t dst, int fd) {
     if (drmSyncobjImportSyncFile(drmFD, syncHandle, fd)) {
         Debug::log(ERR, "importFromSyncFileFD: drmSyncobjImportSyncFile failed");
         drmSyncobjDestroy(drmFD, syncHandle);
-        return -1;
+        return false;
     }
 
     if (drmSyncobjTransfer(drmFD, handle, dst, syncHandle, 0, 0)) {
         Debug::log(ERR, "importFromSyncFileFD: drmSyncobjTransfer failed");
         drmSyncobjDestroy(drmFD, syncHandle);
-        return -1;
+        return false;
     }
 
     drmSyncobjDestroy(drmFD, syncHandle);

--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -448,7 +448,7 @@ void CPointerManager::renderSoftwareCursorsFor(SP<CMonitor> pMonitor, timespec* 
     box.x = std::round(box.x);
     box.y = std::round(box.y);
 
-    g_pHyprOpenGL->renderTextureWithDamage(texture, &box, &damage, 1.F);
+    g_pHyprOpenGL->renderTextureWithDamage(texture, &box, &damage, 1.F, 0, false, false, currentCursorImage.waitTimeline, currentCursorImage.waitPoint);
 
     if (currentCursorImage.surface)
         currentCursorImage.surface->resource()->frame(now);

--- a/src/managers/PointerManager.hpp
+++ b/src/managers/PointerManager.hpp
@@ -147,6 +147,8 @@ class CPointerManager {
 
         CHyprSignalListener     destroySurface;
         CHyprSignalListener     commitSurface;
+        SP<CSyncTimeline>       waitTimeline = nullptr;
+        uint64_t                waitPoint    = 0;
     } currentCursorImage; // TODO: support various sizes per-output so we can have pixel-perfect cursors
 
     Vector2D pointerPos = {0, 0};

--- a/src/protocols/core/Compositor.hpp
+++ b/src/protocols/core/Compositor.hpp
@@ -122,7 +122,7 @@ class CWLSurfaceResource {
 
     void                                   breadthfirst(std::function<void(SP<CWLSurfaceResource>, const Vector2D&, void*)> fn, void* data);
     CRegion                                accumulateCurrentBufferDamage();
-    void                                   presentFeedback(timespec* when, CMonitor* pMonitor);
+    void                                   presentFeedback(timespec* when, CMonitor* pMonitor, bool needsExplicitSync = false);
     void                                   lockPendingState();
     void                                   unlockPendingState();
 

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1253,10 +1253,11 @@ void CHyprOpenGLImpl::renderTexture(SP<CTexture> tex, CBox* pBox, float alpha, i
     scissor((CBox*)nullptr);
 }
 
-void CHyprOpenGLImpl::renderTextureWithDamage(SP<CTexture> tex, CBox* pBox, CRegion* damage, float alpha, int round, bool discardActive, bool allowCustomUV) {
+void CHyprOpenGLImpl::renderTextureWithDamage(SP<CTexture> tex, CBox* pBox, CRegion* damage, float alpha, int round, bool discardActive, bool allowCustomUV,
+                                              SP<CSyncTimeline> waitTimeline, uint64_t waitPoint) {
     RASSERT(m_RenderData.pMonitor, "Tried to render texture without begin()!");
 
-    renderTextureInternalWithDamage(tex, pBox, alpha, damage, round, discardActive, false, allowCustomUV, true);
+    renderTextureInternalWithDamage(tex, pBox, alpha, damage, round, discardActive, false, allowCustomUV, true, waitTimeline, waitPoint);
 
     scissor((CBox*)nullptr);
 }

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -2742,20 +2742,24 @@ std::vector<SDRMFormat> CHyprOpenGLImpl::getDRMFormats() {
 
 SP<CEGLSync> CHyprOpenGLImpl::createEGLSync(int fenceFD) {
     std::vector<EGLint> attribs;
-    int                 dupFd = fcntl(fenceFD, F_DUPFD_CLOEXEC, 0);
-    if (dupFd < 0) {
-        Debug::log(ERR, "createEGLSync: dup failed");
-        return nullptr;
-    }
+    int                 dupFd = -1;
+    if (fenceFD > 0) {
+        int dupFd = fcntl(fenceFD, F_DUPFD_CLOEXEC, 0);
+        if (dupFd < 0) {
+            Debug::log(ERR, "createEGLSync: dup failed");
+            return nullptr;
+        }
 
-    attribs.push_back(EGL_SYNC_NATIVE_FENCE_FD_ANDROID);
-    attribs.push_back(dupFd);
-    attribs.push_back(EGL_NONE);
+        attribs.push_back(EGL_SYNC_NATIVE_FENCE_FD_ANDROID);
+        attribs.push_back(dupFd);
+        attribs.push_back(EGL_NONE);
+    }
 
     EGLSyncKHR sync = m_sProc.eglCreateSyncKHR(m_pEglDisplay, EGL_SYNC_NATIVE_FENCE_ANDROID, attribs.data());
     if (sync == EGL_NO_SYNC_KHR) {
         Debug::log(ERR, "eglCreateSyncKHR failed");
-        close(dupFd);
+        if (dupFd >= 0)
+            close(dupFd);
         return nullptr;
     }
 

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -7,6 +7,7 @@
 #include "../helpers/math/Math.hpp"
 #include "../helpers/Format.hpp"
 #include "../helpers/sync/SyncTimeline.hpp"
+#include <cstdint>
 #include <list>
 #include <unordered_map>
 #include <map>
@@ -205,6 +206,7 @@ class CHyprOpenGLImpl {
     std::vector<SDRMFormat>                           getDRMFormats();
     EGLImageKHR                                       createEGLImage(const Aquamarine::SDMABUFAttrs& attrs);
     SP<CEGLSync>                                      createEGLSync(int fenceFD);
+    bool                                              waitForTimelinePoint(SP<CSyncTimeline> timeline, uint64_t point);
 
     SCurrentRenderData                                m_RenderData;
 

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -153,7 +153,8 @@ class CHyprOpenGLImpl {
     void     renderRectWithBlur(CBox*, const CColor&, int round = 0, float blurA = 1.f, bool xray = false);
     void     renderRectWithDamage(CBox*, const CColor&, CRegion* damage, int round = 0);
     void     renderTexture(SP<CTexture>, CBox*, float a, int round = 0, bool discardActive = false, bool allowCustomUV = false);
-    void     renderTextureWithDamage(SP<CTexture>, CBox*, CRegion* damage, float a, int round = 0, bool discardActive = false, bool allowCustomUV = false);
+    void     renderTextureWithDamage(SP<CTexture>, CBox*, CRegion* damage, float a, int round = 0, bool discardActive = false, bool allowCustomUV = false,
+                                     SP<CSyncTimeline> waitTimeline = nullptr, uint64_t waitPoint = 0);
     void     renderTextureWithBlur(SP<CTexture>, CBox*, float a, SP<CWLSurfaceResource> pSurface, int round = 0, bool blockBlurOptimization = false, float blurA = 1.f);
     void     renderRoundedShadow(CBox*, int round, int range, const CColor& color, float a = 1.0);
     void     renderBorder(CBox*, const CGradientValueData&, int round, int borderSize, float a = 1.0, int outerRound = -1 /* use round */);

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -6,6 +6,7 @@
 #include "../helpers/Timer.hpp"
 #include "../helpers/math/Math.hpp"
 #include "../helpers/Format.hpp"
+#include "../helpers/sync/SyncTimeline.hpp"
 #include <list>
 #include <unordered_map>
 #include <map>
@@ -284,7 +285,7 @@ class CHyprOpenGLImpl {
     CFramebuffer* blurMainFramebufferWithDamage(float a, CRegion* damage);
 
     void          renderTextureInternalWithDamage(SP<CTexture>, CBox* pBox, float a, CRegion* damage, int round = 0, bool discardOpaque = false, bool noAA = false,
-                                                  bool allowCustomUV = false, bool allowDim = false);
+                                                  bool allowCustomUV = false, bool allowDim = false, SP<CSyncTimeline> = nullptr, uint64_t waitPoint = 0);
     void          renderTexturePrimitive(SP<CTexture> tex, CBox* pBox);
     void          renderSplash(cairo_t* const, cairo_surface_t* const, double offset, const Vector2D& size);
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1452,9 +1452,9 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(CMonitor* pMonitor) {
     if (anyExplicit) {
         Debug::log(TRACE, "Explicit sync presented begin");
         auto inFence = pMonitor->inTimeline->exportAsSyncFileFD(pMonitor->lastWaitPoint);
-        if (inFence < 0) {
+        if (inFence < 0)
             Debug::log(ERR, "Export lastWaitPoint {} as sync explicitInFence failed", pMonitor->lastWaitPoint);
-        }
+
         pMonitor->output->state->setExplicitInFence(inFence);
 
         for (auto& e : explicitPresented) {
@@ -1466,9 +1466,9 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(CMonitor* pMonitor) {
 
         explicitPresented.clear();
         auto outFence = pMonitor->outTimeline->exportAsSyncFileFD(pMonitor->commitSeq);
-        if (outFence < 0) {
+        if (outFence < 0)
             Debug::log(ERR, "Export commitSeq {} as sync explicitOutFence failed", pMonitor->commitSeq);
-        }
+
         pMonitor->output->state->setExplicitOutFence(outFence);
         Debug::log(TRACE, "Explicit sync presented end");
     }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -115,21 +115,8 @@ static void renderSurface(SP<CWLSurfaceResource> surface, int x, int y, void* da
 
     // explicit sync: wait for the timeline, if any
     if (surface->syncobj && surface->syncobj->acquireTimeline) {
-        int fd = surface->syncobj->acquireTimeline->timeline->exportAsSyncFileFD(surface->syncobj->acquirePoint);
-        if (fd < 0) {
-            Debug::log(ERR, "Renderer: failed to get a fd from explicit timeline");
-            return;
-        }
-
-        auto sync = g_pHyprOpenGL->createEGLSync(fd);
-        close(fd);
-        if (!sync) {
-            Debug::log(ERR, "Renderer: failed to get an eglsync from explicit timeline");
-            return;
-        }
-
-        if (!sync->wait()) {
-            Debug::log(ERR, "Renderer: failed to wait on an eglsync from explicit timeline");
+        if (!g_pHyprOpenGL->waitForTimelinePoint(surface->syncobj->acquireTimeline->timeline, surface->syncobj->acquirePoint)) {
+            Debug::log(ERR, "Renderer: failed to wait for explicit timeline");
             return;
         }
     }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Somewhat fixes new explicit sync code. At least it runs and doesn't output any errors to the logs.
Also fixes part of `explicitPresented` for xwayland apps. `setExplicitInFence` still fails but the other two transfers work. These fixes result in a screen freeze when xwayland app is started:
```
[TRACE] Explicit sync presented begin
[ERR] exportAsSyncFileFD: drmSyncobjTransfer failed
[ERR] Export lastWaitPoint 91 as sync explicitInFence failed
[TRACE] Explicit sync presented releasePoint 18446744073709551615
[TRACE] Explicit sync presented end
[ERR] [AQ] atomic drm request: failed to commit: Bad address, flags: ATOMIC_NONBLOCK PAGE_FLIP_EVENT 
[TRACE] Monitor state commit failed
```
[explicit.log](https://github.com/user-attachments/files/16150969/explicit.log)

Either some parts of code are still missing or there is some mixup between `inTimeline`, `outTimeline` and fences. wlroots code and naming is confusing, hard to track what's happening and how it corresponds to hl code.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?

- [ ] general signal and wait timelines handling
- [ ] textures
- [ ] set cursor waitTimeline
- [ ] direct scanout
- [ ] xwayland surfaces