### PR TITLE
sessionLock: fix the check for locking a locked session

### DIFF
--- a/src/protocols/SessionLock.cpp
+++ b/src/protocols/SessionLock.cpp
@@ -177,7 +177,7 @@ void CSessionLockProtocol::onLock(CExtSessionLockManagerV1* pMgr, uint32_t id) {
         return;
     }
 
-    if (m_vLocks.size() > 1) {
+    if (locked) {
         LOGM(ERR, "Tried to lock a locked session");
         RESOURCE->inert = true;
         RESOURCE->resource->sendFinished();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
It fixes the following misbehavior:

When a client holds a locked session lock object and another client tries to lock the session as well, the second client will receive `finished`. When the second client never calls `destroy` or `unlock_and_destroy` it effectively blocks the user from locking the session, because `m_vLocks` still contains the lock object that was not destroyed.

I think this is the correct behavior. Since `RESOURCE->inert` is set whenever `sendFinished` is called anyways, it should also be safe for the left over lock object to send `unlock_and_destroy` at some point. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Please check if i am correct, but should be fine.

#### Is it ready for merging, or does it need work?

Ready.
