### PR TITLE
meson: install wayland.hpp header

### DIFF
--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -113,7 +113,8 @@ foreach p : wl_server_protos
 	wl_server_protos_gen += custom_target(
 		p.underscorify(),
 		input: p,
-		install: false,
+		install: true,
+		install_dir: [false, join_paths(get_option('includedir'), 'hyprland/protocols')],
 		output: ['@BASENAME@.cpp', '@BASENAME@.hpp'],
 		command: [hyprwayland_scanner, '--wayland-enums', '@INPUT@', '@OUTDIR@'],
 	)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Changes the `meson` build to also install the `wayland.hpp` header like all other protocol headers.

Currently, the Meson build does not install this header, but CMake does. This means that this header is available when building plugins through hyprpm, but is not installed on the system (at least with arch packages), so you can't build the plugin with your system headers.

It would be nice if this header was also installed through meson, as this would be more consistent with CMake and also allow people to build plugins using `wayland.hpp` with either headers.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I don't know why the header was not installed from the start. Was this intentional? If so, why?

#### Is it ready for merging, or does it need work?
Yes

