### PR TITLE
session-lock: send `locked` after the lock screen is properly rendered

### DIFF
--- a/src/managers/SessionLockManager.hpp
+++ b/src/managers/SessionLockManager.hpp
@@ -5,6 +5,7 @@
 #include "../helpers/signal/Signal.hpp"
 #include <cstdint>
 #include <unordered_map>
+#include <unordered_set>
 
 class CSessionLockSurface;
 class CSessionLock;
@@ -37,6 +38,9 @@ struct SSessionLock {
         CHyprSignalListener unlock;
         CHyprSignalListener destroy;
     } listeners;
+
+    bool                         m_hasSentLocked = false;
+    std::unordered_set<uint64_t> m_lockedMonitors;
 };
 
 class CSessionLockManager {
@@ -53,6 +57,8 @@ class CSessionLockManager {
     bool                 isSurfaceSessionLock(SP<CWLSurfaceResource>);
 
     void                 removeSessionLockSurface(SSessionLockSurface*);
+
+    void                 onLockscreenRenderedOnMonitor(uint64_t id);
 
   private:
     UP<SSessionLock> m_pSessionLock;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -990,8 +990,11 @@ void CHyprRenderer::renderLockscreen(CMonitor* pMonitor, timespec* now, const CB
 
             if (ALPHA < 1.f) /* animate */
                 damageMonitor(pMonitor);
+            else
+                g_pSessionLockManager->onLockscreenRenderedOnMonitor(pMonitor->ID);
         } else {
             renderSessionLockSurface(PSLS, pMonitor, now);
+            g_pSessionLockManager->onLockscreenRenderedOnMonitor(pMonitor->ID);
         }
     }
 }


### PR DESCRIPTION
The protocol says:
> The locked event "must not be sent until a new "locked" frame (either from a
> session lock surface or the compositor blanking the output) has been presented
> on all outputs and no security sensitive normal/unlocked content is possibly
> visible".

This helps users ensure the screen is properly locked before suspending the machine. (e.g. with swaylock --ready-fd)