### PR TITLE
fix: xray regressions

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1717,7 +1717,7 @@ bool CHyprOpenGLImpl::shouldUseNewBlurOptimizations(PHLLS pLayer, PHLWINDOW pWin
     if (!m_RenderData.pCurrentMonData->blurFB.m_cTex->m_iTexID)
         return false;
 
-    if (pWindow && !pWindow->m_sWindowData.xray.valueOrDefault())
+    if (pWindow && pWindow->m_sWindowData.xray.hasValue() && !pWindow->m_sWindowData.xray.valueOrDefault())
         return false;
 
     if (pLayer && pLayer->xray == 0)

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -434,7 +434,7 @@ bool CHyprOpenGLImpl::passRequiresIntrospection(CMonitor* pMonitor) {
         if (!w->m_bIsFloating && *POPTIM && !w->onSpecialWorkspace())
             continue;
 
-        if (w->m_sWindowData.noBlur.valueOrDefault() || w->m_sWindowData.xray.valueOrDefault() == true)
+        if (w->m_sWindowData.noBlur.valueOrDefault() || !w->m_sWindowData.xray.hasValue() || w->m_sWindowData.xray.valueOrDefault())
             continue;
 
         if (w->opaque())


### PR DESCRIPTION
fixes regression where `shouldUseNewBlurOptimizations` would return `false` where it shouldn't .
fixes regression where `passRequiresIntrospection` would ignore a window since `-1 == true` .

no idea how xray (windowrule/prop) works but seems to be making foot opaque when using it's config file

fixes: https://github.com/hyprwm/Hyprland/issues/6852