### PR TITLE
Add windowtitlev2 event for the socket which includes the window title

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1343,6 +1343,7 @@ void CWindow::onUpdateMeta() {
     if (m_szTitle != NEWTITLE) {
         m_szTitle = NEWTITLE;
         g_pEventManager->postEvent(SHyprIPCEvent{"windowtitle", std::format("{:x}", (uintptr_t)this)});
+        g_pEventManager->postEvent(SHyprIPCEvent{"windowtitlev2", std::format("{:x},{}", (uintptr_t)this, m_szTitle)});
         EMIT_HOOK_EVENT("windowTitle", m_pSelf.lock());
 
         if (m_pSelf == g_pCompositor->m_pLastWindow) { // if it's the active, let's post an event to update others


### PR DESCRIPTION
Fixes #5393

#### Describe your PR, what does it fix/add?
Adds a new windowtitlev2 event which includes the new window title. The current windowtitle event only includes the window address which is not particularly useful for clients listening to these events.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Verified the change by building and running locally. Will include the PR to the wiki once it is created.

#### Is it ready for merging, or does it need work?
Ready for merging

