### PR TITLE
Send done after title and app id events for ForeignTopLevel protocol

### DIFF
--- a/src/protocols/ForeignToplevel.cpp
+++ b/src/protocols/ForeignToplevel.cpp
@@ -81,6 +81,7 @@ void CForeignToplevelList::onTitle(PHLWINDOW pWindow) {
         return;
 
     H->resource->sendTitle(pWindow->m_szTitle.c_str());
+    H->resource->sendDone();
 }
 
 void CForeignToplevelList::onClass(PHLWINDOW pWindow) {
@@ -92,6 +93,7 @@ void CForeignToplevelList::onClass(PHLWINDOW pWindow) {
         return;
 
     H->resource->sendAppId(pWindow->m_szClass.c_str());
+    H->resource->sendDone();
 }
 
 void CForeignToplevelList::onUnmap(PHLWINDOW pWindow) {


### PR DESCRIPTION
According to the spec (https://wayland.app/protocols/ext-foreign-toplevel-list-v1#ext_foreign_toplevel_handle_v1:event:title), clients should wait for the done signal before applying updates

#### Describe your PR, what does it fix/add?
Adds the done event after the title event to comply with they Wayland spec.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I don't expect this to break any users unless they are expecting done only for new windows.


#### Is it ready for merging, or does it need work?
Ready for merging

