### PR TITLE
toplevelexport: fix flipped r/b channels when sharing windows

### DIFF
--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -409,7 +409,8 @@ bool CToplevelExportProtocolManager::copyFrameShm(SScreencopyFrame* frame, times
 
     glPixelStorei(GL_PACK_ALIGNMENT, 1);
 
-    glReadPixels(0, 0, frame->box.width, frame->box.height, PFORMAT->glFormat, PFORMAT->glType, pixelData);
+    auto glFormat = PFORMAT->flipRB ? GL_BGRA_EXT : GL_RGBA;
+    glReadPixels(0, 0, frame->box.width, frame->box.height, glFormat, PFORMAT->glType, pixelData);
 
     if (frame->overlayCursor) {
         g_pPointerManager->unlockSoftwareForMonitor(PMONITOR->self.lock());


### PR DESCRIPTION
fixes #6823

#### Describe your PR, what does it fix/add?

When sharing windows the r/b channels are flipped under some circumstances.

#### Is it ready for merging, or does it need work?

I think it's ready to merge according to the discussion in the issue.
