### PR TITLE
fix: new_window_takes_over_fullscreen=1, overridingNoMaximise (#6812)

### DIFF
--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -465,9 +465,11 @@ void Events::listener_mapWindow(void* owner, void* data) {
             PWINDOW->m_bNoInitialFocus = true;
         else if (*PNEWTAKESOVERFS == 2)
             g_pCompositor->setWindowFullscreen(g_pCompositor->getFullscreenWindowOnWorkspace(PWINDOW->m_pWorkspace->m_iID), false, FULLSCREEN_INVALID);
-        else if (PWINDOW->m_pWorkspace->m_efFullscreenMode == FULLSCREEN_MAXIMIZED)
+        else if (PWINDOW->m_pWorkspace->m_efFullscreenMode == FULLSCREEN_MAXIMIZED) {
             requestsMaximize = true;
-        else
+            if (*PNEWTAKESOVERFS == 1)
+                overridingNoMaximize = true;
+        } else
             requestsFullscreen = true;
     }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes #6812: `new_window_takes_over_fullscreen=1` behaves incorrectly for `maximise` in combination with the default hyprland.conf window rule:
```
windowrulev2 = suppressevent maximize, class:.* # You'll probably like this. 
```
In short, when we have an existing maximised window, spawning a new window gains focus, but is invisible behind the existing maximised window.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Main discussion point from #6812:

<details close>
<summary> CLICK TO VIEW </summary>

> https://github.com/hyprwm/Hyprland/blob/45c48984236d7a682a1941b147f8ae489ac9a1e6/example/hyprland.conf#L245
> 
> Not sure why this was here by default, but it lead to the odd behaviour (bug?) as shown in the video above.
> 
> Perhaps this line in the default config can be better documented for new users instead of simply:
> 
> > \# You'll probably like this.
> 
> Alternatively, the changes above can be applied to ignore this specific case.

</details>

#### Is it ready for merging, or does it need work?

It should be ready if the changes in this PR is the intended behaviour for the interaction between suppress event and maximise, although it does not appear intuitive (seems buggy).

Another alternative may be to spawn the new window in the background, but don't seize the focus (since there are few, if any, use cases where you would want focus on a hidden window).

Otherwise, I think better documentation/comments can be added to the default window rule for suppressing maximise events for all classes, or at least mention the caveat.
