### PR TITLE
[aquamarine] try to fix direct scanout

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -812,6 +812,7 @@ bool CMonitor::attemptDirectScanout() {
     // and comes from the appropriate device. This may implode on multi-gpu!!
 
     output->state->setBuffer(PSURFACE->current.buffer);
+    output->state->setPresentationMode(Aquamarine::eOutputPresentationMode::AQ_OUTPUT_PRESENTATION_VSYNC);
 
     if (!state.test())
         return false;

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -133,6 +133,9 @@ class CMonitor {
     // for tearing
     PHLWINDOWREF solitaryClient;
 
+    // for direct scanout
+    PHLWINDOWREF lastScanout;
+
     struct {
         bool canTear         = false;
         bool nextRenderTorn  = false;
@@ -174,6 +177,7 @@ class CMonitor {
     int64_t  activeSpecialWorkspaceID();
     CBox     logicalBox();
     void     scheduleDone();
+    bool     attemptDirectScanout();
 
     bool     m_bEnabled             = false;
     bool     m_bRenderingInitPassed = false;

--- a/src/protocols/LinuxDMABUF.cpp
+++ b/src/protocols/LinuxDMABUF.cpp
@@ -441,7 +441,8 @@ CLinuxDMABufV1Protocol::CLinuxDMABufV1Protocol(const wl_interface* iface, const 
         std::vector<std::pair<SP<CMonitor>, SDMABUFTranche>> tches;
 
         if (g_pCompositor->m_pAqBackend->hasSession()) {
-            // this assumes there's 1 device used for scanout and each monitor never changes its primary plane
+            // this assumes there's only 1 device used for both scanout and rendering
+            // also that each monitor never changes its primary plane
 
             for (auto& mon : g_pCompositor->m_vMonitors) {
                 auto tranche = SDMABUFTranche{
@@ -594,10 +595,6 @@ void CLinuxDMABufV1Protocol::updateScanoutTranche(SP<CWLSurfaceResource> surface
 
     LOGM(LOG, "updateScanoutTranche: sending a scanout tranche");
 
-    // send a dedicated scanout tranche that contains formats that:
-    //  - match the format of the output
-    //  - are not linear or implicit
-
     struct wl_array deviceArr = {
         .size = sizeof(mainDevice),
         .data = (void*)&mainDevice,
@@ -605,7 +602,7 @@ void CLinuxDMABufV1Protocol::updateScanoutTranche(SP<CWLSurfaceResource> surface
     feedbackResource->resource->sendMainDevice(&deviceArr);
 
     // prioritize scnaout tranche but have renderer fallback tranche
-    // also yes flags can be duped here because different tranche flags (ds and no ds)
+    // also yes formats can be duped here because different tranche flags (ds and no ds)
     feedbackResource->sendTranche(monitorTranche);
     feedbackResource->sendTranche(formatTable->rendererTranche);
 

--- a/src/protocols/LinuxDMABUF.hpp
+++ b/src/protocols/LinuxDMABUF.hpp
@@ -32,7 +32,7 @@ class CLinuxDMABuffer {
 };
 
 #pragma pack(push, 1)
-struct SDMABUFFeedbackTableEntry {
+struct SDMABUFFormatTableEntry {
     uint32_t fmt = 0;
     char     pad[4];
     uint64_t modifier = 0;
@@ -84,7 +84,8 @@ class CLinuxDMABUFFeedbackResource {
     ~CLinuxDMABUFFeedbackResource();
 
     bool                   good();
-    void                   sendDefault();
+    void                   sendDefaultFeedback();
+    void                   sendTranche(SDMABUFTranche& tranche);
 
     SP<CWLSurfaceResource> surface; // optional, for surface feedbacks
 

--- a/src/protocols/LinuxDMABUF.hpp
+++ b/src/protocols/LinuxDMABUF.hpp
@@ -90,6 +90,7 @@ class CLinuxDMABUFFeedbackResource {
 
   private:
     SP<CZwpLinuxDmabufFeedbackV1> resource;
+    bool                          lastFeedbackWasScanout = false;
 
     friend class CLinuxDMABufV1Protocol;
 };
@@ -118,6 +119,8 @@ class CLinuxDMABufV1Protocol : public IWaylandProtocol {
     void destroyResource(CLinuxDMABUFFeedbackResource* resource);
     void destroyResource(CLinuxDMABBUFParamsResource* resource);
     void destroyResource(CLinuxDMABuffer* resource);
+
+    void resetFormatTable();
 
     //
     std::vector<SP<CLinuxDMABUFResource>>         m_vManagers;

--- a/src/protocols/LinuxDMABUF.hpp
+++ b/src/protocols/LinuxDMABUF.hpp
@@ -39,27 +39,24 @@ struct SDMABUFFeedbackTableEntry {
 };
 #pragma pack(pop)
 
-class SCompiledDMABUFTranche {
-    dev_t                 device = 0;
-    uint32_t              flags  = 0;
-    std::vector<uint16_t> indices;
-};
-
-struct SDMABufTranche {
-    dev_t                   device = 0;
-    uint32_t                flags  = 0;
+struct SDMABUFTranche {
+    dev_t                   device     = 0;
+    uint32_t                flags      = 0;
+    uint32_t                firstIndex = -1; // first index in format table for this tranche
+    uint32_t                lastIndex  = -1; // first index in format table NOT for this tranche
     std::vector<SDRMFormat> formats;
 };
 
-class CCompiledDMABUFFeedback {
+class CDMABUFFormatTable {
   public:
-    CCompiledDMABUFFeedback(dev_t device, std::vector<SDMABufTranche> tranches);
-    ~CCompiledDMABUFFeedback();
+    CDMABUFFormatTable(SDMABUFTranche rendererTranche, std::vector<std::pair<SP<CMonitor>, SDMABUFTranche>> tranches);
+    ~CDMABUFFormatTable();
 
-    dev_t                                      mainDevice = 0;
-    int                                        tableFD    = -1;
-    size_t                                     tableLen   = 0;
-    std::vector<std::pair<uint32_t, uint64_t>> formats;
+    int                                                  tableFD   = -1;
+    size_t                                               tableLen  = 0;
+    size_t                                               tableSize = 0;
+    SDMABUFTranche                                       rendererTranche;
+    std::vector<std::pair<SP<CMonitor>, SDMABUFTranche>> monitorTranches;
 };
 
 class CLinuxDMABBUFParamsResource {
@@ -128,7 +125,7 @@ class CLinuxDMABufV1Protocol : public IWaylandProtocol {
     std::vector<SP<CLinuxDMABBUFParamsResource>>  m_vParams;
     std::vector<SP<CLinuxDMABuffer>>              m_vBuffers;
 
-    UP<CCompiledDMABUFFeedback>                   defaultFeedback;
+    UP<CDMABUFFormatTable>                        formatTable;
     dev_t                                         mainDevice;
     int                                           mainDeviceFD = -1;
 

--- a/src/protocols/LinuxDMABUF.hpp
+++ b/src/protocols/LinuxDMABUF.hpp
@@ -40,11 +40,10 @@ struct SDMABUFFormatTableEntry {
 #pragma pack(pop)
 
 struct SDMABUFTranche {
-    dev_t                   device     = 0;
-    uint32_t                flags      = 0;
-    uint32_t                firstIndex = -1; // first index in format table for this tranche
-    uint32_t                lastIndex  = -1; // first index in format table NOT for this tranche
+    dev_t                   device = 0;
+    uint32_t                flags  = 0;
     std::vector<SDRMFormat> formats;
+    std::vector<uint16_t>   indicies;
 };
 
 class CDMABUFFormatTable {
@@ -53,7 +52,6 @@ class CDMABUFFormatTable {
     ~CDMABUFFormatTable();
 
     int                                                  tableFD   = -1;
-    size_t                                               tableLen  = 0;
     size_t                                               tableSize = 0;
     SDMABUFTranche                                       rendererTranche;
     std::vector<std::pair<SP<CMonitor>, SDMABUFTranche>> monitorTranches;

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -447,6 +447,7 @@ void CWLSurfaceResource::commitPendingState() {
             previousBuffer->hlEvents.backendRelease = previousBuffer->events.backendRelease.registerListener([this, previousBuffer](std::any data) {
                 previousBuffer->sendReleaseWithSurface(self.lock());
                 previousBuffer->hlEvents.backendRelease.reset();
+                bufferReleased = true;
             });
         } else
             previousBuffer->sendReleaseWithSurface(self.lock());

--- a/src/protocols/types/Buffer.cpp
+++ b/src/protocols/types/Buffer.cpp
@@ -5,5 +5,6 @@ void IHLBuffer::sendRelease() {
 }
 
 void IHLBuffer::sendReleaseWithSurface(SP<CWLSurfaceResource> surf) {
-    resource->sendReleaseWithSurface(surf);
+    if (resource && resource->good())
+        resource->sendReleaseWithSurface(surf);
 }

--- a/src/protocols/types/Buffer.hpp
+++ b/src/protocols/types/Buffer.hpp
@@ -22,4 +22,8 @@ class IHLBuffer : public Aquamarine::IBuffer {
     SP<CTexture>                          texture;
     bool                                  opaque = false;
     SP<CWLBufferResource>                 resource;
+
+    struct {
+        CHyprSignalListener backendRelease;
+    } hlEvents;
 };

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1167,6 +1167,9 @@ void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(pMonitor->ID);
     }
 
+    if (!pMonitor->output->needsFrame && pMonitor->forceFullFrames == 0)
+        return;
+
     // tearing and DS first
     bool shouldTear = false;
     if (pMonitor->tearingState.nextRenderTorn) {
@@ -1211,9 +1214,7 @@ void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
     clock_gettime(CLOCK_MONOTONIC, &now);
 
     // check the damage
-    bool hasChanged = pMonitor->output->needsFrame || pMonitor->damage.hasChanged();
-
-    if (!hasChanged && *PDAMAGETRACKINGMODE != DAMAGE_TRACKING_NONE && pMonitor->forceFullFrames == 0 && damageBlinkCleanup == 0)
+    if (!pMonitor->damage.hasChanged() && *PDAMAGETRACKINGMODE != DAMAGE_TRACKING_NONE && damageBlinkCleanup == 0)
         return;
 
     if (*PDAMAGETRACKINGMODE == -1) {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1214,7 +1214,9 @@ void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
     clock_gettime(CLOCK_MONOTONIC, &now);
 
     // check the damage
-    if (!pMonitor->damage.hasChanged() && *PDAMAGETRACKINGMODE != DAMAGE_TRACKING_NONE && damageBlinkCleanup == 0)
+    bool hasChanged = pMonitor->output->needsFrame || pMonitor->damage.hasChanged();
+
+    if (!hasChanged && *PDAMAGETRACKINGMODE != DAMAGE_TRACKING_NONE && pMonitor->forceFullFrames == 0 && damageBlinkCleanup == 0)
         return;
 
     if (*PDAMAGETRACKINGMODE == -1) {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1239,11 +1239,11 @@ void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
     }
 
     if (!*PNODIRECTSCANOUT && !shouldTear) {
-        if (attemptDirectScanout(pMonitor)) {
+        if (pMonitor->attemptDirectScanout()) {
             return;
-        } else if (!m_pLastScanout.expired()) {
+        } else if (!pMonitor->lastScanout.expired()) {
             Debug::log(LOG, "Left a direct scanout.");
-            m_pLastScanout.reset();
+            pMonitor->lastScanout.reset();
         }
     }
 

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -76,19 +76,17 @@ class CHyprRenderer {
 
     // if RENDER_MODE_NORMAL, provided damage will be written to.
     // otherwise, it will be the one used.
-    bool beginRender(CMonitor* pMonitor, CRegion& damage, eRenderMode mode = RENDER_MODE_NORMAL, SP<IHLBuffer> buffer = {}, CFramebuffer* fb = nullptr, bool simple = false);
-    void endRender();
+    bool      beginRender(CMonitor* pMonitor, CRegion& damage, eRenderMode mode = RENDER_MODE_NORMAL, SP<IHLBuffer> buffer = {}, CFramebuffer* fb = nullptr, bool simple = false);
+    void      endRender();
 
-    bool m_bBlockSurfaceFeedback = false;
-    bool m_bRenderingSnapshot    = false;
-    PHLWINDOWREF m_pLastScanout;
-    CMonitor*    m_pMostHzMonitor        = nullptr;
-    bool         m_bDirectScanoutBlocked = false;
+    bool      m_bBlockSurfaceFeedback = false;
+    bool      m_bRenderingSnapshot    = false;
+    CMonitor* m_pMostHzMonitor        = nullptr;
+    bool      m_bDirectScanoutBlocked = false;
 
     DAMAGETRACKINGMODES
     damageTrackingModeFromStr(const std::string&);
 
-    bool                                attemptDirectScanout(CMonitor*);
     void                                setSurfaceScanoutMode(SP<CWLSurfaceResource> surface, SP<CMonitor> monitor); // nullptr monitor resets
     void                                initiateManualCrash();
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
will try to fix direct scanout and linux-dmabuf protocol for #6608

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

#### Is it ready for merging, or does it need work?
 - [x] use monitor primary plane formats for ds (hyprwm/aquamarine#13)
 - [x] support monitor connect/disconnect for format_table (hyprwm/aquamarine#14)
 - [x] fix weird bug that disables ds randomly
 - [x] fix weird artifacts that happen randomly when ds [^1] **(thanks vaxry!!!)**
 - [x] <s> only send formats than can fallback to renderer even in scanout tranches</s> \
    add renderer fallback tranche when attempting ds [^2]
 - [x] maybe use sets in format table to conserve memory, would be hard to keep track of indicies tho
 - [ ] <s>maybe create seperate format_tables to mitigate bad clients [^3]</s>

[^1]:  after reading some of weston's code this might be related to plane damaging (drm.c@470)? this is a guess so far tho
[^2]: https://gitlab.freedesktop.org/wayland/wayland-protocols/-/blob/main/stable/linux-dmabuf/feedback.rst
    >Compositors should not send feedback parameters if they don't have a fallback path. For instance, compositors shouldn't send a format/modifier supported for direct scan-out but not supported by the rendering API for texturing.

    after some more reading the ds tranche is allowed to have formats that the egl doesnt support as long as there is a fallback tranche that the renderer does support
[^3]: the format_table contains all the formats from egl and planes but some wl clients only use format_table to find formats instead of tranches
    only "bad" client i could find was mpv so I just bug reported there