### PR TITLE
feat: option to exit window while retaining fullscreen (#516)

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -352,6 +352,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("misc:close_special_on_empty", Hyprlang::INT{1});
     m_pConfig->addConfigValue("misc:background_color", Hyprlang::INT{0xff111111});
     m_pConfig->addConfigValue("misc:new_window_takes_over_fullscreen", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("misc:exit_window_retains_fullscreen", Hyprlang::INT{0});
     m_pConfig->addConfigValue("misc:initial_workspace_tracking", Hyprlang::INT{1});
     m_pConfig->addConfigValue("misc:middle_click_paste", Hyprlang::INT{1});
 

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -582,8 +582,8 @@ void Events::listener_unmapWindow(void* owner, void* data) {
 
     static auto PEXITRETAINSFS = CConfigValue<Hyprlang::INT>("misc:exit_window_retains_fullscreen");
 
-    const auto  pwindowCurrentFullscreenState = PWINDOW->m_bIsFullscreen;
-    const auto  pwindowCurrentFullscreenMode  = PWINDOW->m_pWorkspace->m_efFullscreenMode;
+    const auto  CURRENTWINDOWFSSTATE = PWINDOW->m_bIsFullscreen;
+    const auto  CURRENTWINDOWFSMODE  = PWINDOW->m_pWorkspace->m_efFullscreenMode;
 
     if (!PWINDOW->m_pWLSurface->exists() || !PWINDOW->m_bIsMapped) {
         Debug::log(WARN, "{} unmapped without being mapped??", PWINDOW);
@@ -645,8 +645,8 @@ void Events::listener_unmapWindow(void* owner, void* data) {
 
         if (PWINDOWCANDIDATE != g_pCompositor->m_pLastWindow.lock() && PWINDOWCANDIDATE) {
             g_pCompositor->focusWindow(PWINDOWCANDIDATE);
-            if (*PEXITRETAINSFS && pwindowCurrentFullscreenState)
-                g_pCompositor->setWindowFullscreen(PWINDOWCANDIDATE, true, pwindowCurrentFullscreenMode);
+            if (*PEXITRETAINSFS && CURRENTWINDOWFSSTATE)
+                g_pCompositor->setWindowFullscreen(PWINDOWCANDIDATE, true, CURRENTWINDOWFSMODE);
         }
 
         if (!PWINDOWCANDIDATE && g_pCompositor->getWindowsOnWorkspace(PWINDOW->workspaceID()) == 0)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Resolves #516 by completing the second (final) point:
> *when a fullscreen window is being closed and it was not the only window on the current workspace, the next window that gains focus would become the new fullscreen window*

This PR introduces a new `misc` option:
```
misc { 
    exit_window_retains_fullscreen = true
}
```

The implementation makes a backup of the current window's fullscreen mode & state, which is then applied to the next window candidate that will gain focus (if any). 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I think `exit_window_retains_fullscreen` is a suitable name and belongs in `misc` as a new [variable](https://wiki.hyprland.org/Configuring/Variables/), although I'm not too familiar with the code base and all available options yet.


#### Is it ready for merging, or does it need work?

Code-wise, I think it's ready.

Will need to make another pull request for [hyprland-wiki](https://github.com/hyprwm/hyprland-wiki) if this PR is in the right direction (happy to write the documentation if this gets the green lights).

