### PR TITLE
[Scroll Wheel] Emulate discrete scrolling from v120 events

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -472,6 +472,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("input:scroll_button_lock", Hyprlang::INT{0});
     m_pConfig->addConfigValue("input:scroll_factor", {1.f});
     m_pConfig->addConfigValue("input:scroll_points", {STRVAL_EMPTY});
+    m_pConfig->addConfigValue("input:emulate_discrete_scroll", Hyprlang::INT{1});
     m_pConfig->addConfigValue("input:touchpad:natural_scroll", Hyprlang::INT{0});
     m_pConfig->addConfigValue("input:touchpad:disable_while_typing", Hyprlang::INT{1});
     m_pConfig->addConfigValue("input:touchpad:clickfinger_behavior", Hyprlang::INT{0});

--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -333,9 +333,7 @@ void CSeatManager::sendPointerAxis(uint32_t timeMs, wl_pointer_axis axis, double
             if (source == 0) {
                 p->sendAxisValue120(axis, value120);
                 p->sendAxisDiscrete(axis, discrete);
-            }
-
-            if (value == 0)
+            } else if (value == 0)
                 p->sendAxisStop(timeMs, axis);
         }
     }

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -278,6 +278,14 @@ class CInputManager {
 
     void restoreCursorIconToApp(); // no-op if restored
 
+    // discrete scrolling emulation using v120 data
+    struct {
+        bool     lastEventSign     = 0;
+        bool     lastEventAxis     = 0;
+        uint32_t lastEventTime     = 0;
+        uint32_t accumulatedScroll = 0;
+    } m_ScrollWheelState;
+
     friend class CKeybindManager;
     friend class CWLSurface;
 };


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes #6681. Adds an accurate emulation of discrete scrolling when given scroll wheel events that are fractions of 120. It is configurable to be force enabled (`2`) / disabled (`0`) but it defaults to automatic detection (`input:emulate_discrete_scroll` `1`)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No clue how this will interact with horizontal scroll wheels because I don't have a mouse that can do that. Should not affect normal, non-highres, scroll wheel behaviour.

#### Is it ready for merging, or does it need work?
Needs some more testing and could use some touch-ups. Tested with an old wireless mouse that does scrolling in multiples of 30 degrees and a normal wired mouse.

