### PR TITLE
Aquamarine headers for no pch build and a heap use after free

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -9,6 +9,7 @@
 #include <aquamarine/output/Output.hpp>
 #include <random>
 #include <cstring>
+#include <filesystem>
 #include <unordered_set>
 #include "debug/HyprCtl.hpp"
 #include "debug/CrashReporter.hpp"
@@ -24,6 +25,7 @@
 #include "protocols/core/Compositor.hpp"
 #include "protocols/core/Subcompositor.hpp"
 #include "desktop/LayerSurface.hpp"
+#include "render/Renderer.hpp"
 #include "xwayland/XWayland.hpp"
 
 #include <hyprutils/string/String.hpp>

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -23,6 +23,7 @@
 #include <ranges>
 #include <unordered_set>
 #include <hyprutils/string/String.hpp>
+#include <filesystem>
 using namespace Hyprutils::String;
 
 extern "C" char**             environ;

--- a/src/debug/CrashReporter.cpp
+++ b/src/debug/CrashReporter.cpp
@@ -5,6 +5,7 @@
 #include <time.h>
 #include <errno.h>
 #include <sys/stat.h>
+#include <filesystem>
 
 #include "../plugins/PluginSystem.hpp"
 #include "../signal-safe.hpp"

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -12,6 +12,8 @@
 #include <sys/un.h>
 #include <unistd.h>
 #include <sys/poll.h>
+#include <filesystem>
+#include <ranges>
 
 #include <sstream>
 #include <string>

--- a/src/devices/IKeyboard.cpp
+++ b/src/devices/IKeyboard.cpp
@@ -3,6 +3,7 @@
 #include "../helpers/varlist/VarList.hpp"
 #include "../managers/input/InputManager.hpp"
 #include "../managers/SeatManager.hpp"
+#include "../config/ConfigManager.hpp"
 #include <sys/mman.h>
 #include <aquamarine/input/Input.hpp>
 #include <cstring>

--- a/src/helpers/Format.cpp
+++ b/src/helpers/Format.cpp
@@ -4,6 +4,7 @@
 #include "debug/Log.hpp"
 #include "../macros.hpp"
 #include <xf86drm.h>
+#include <drm_fourcc.h>
 
 /*
     DRM formats are LE, while OGL is BE. The two primary formats

--- a/src/helpers/math/Math.cpp
+++ b/src/helpers/math/Math.cpp
@@ -70,113 +70,28 @@ void matrixRotate(float mat[9], float rad) {
     matrixMultiply(mat, mat, rotate);
 }
 
-std::unordered_map<eTransform, std::array<float, 9>> transforms = {
-    {HYPRUTILS_TRANSFORM_NORMAL,
-     {
-         1.0f,
-         0.0f,
-         0.0f,
-         0.0f,
-         1.0f,
-         0.0f,
-         0.0f,
-         0.0f,
-         1.0f,
-     }},
-    {HYPRUTILS_TRANSFORM_90,
-     {
-         0.0f,
-         1.0f,
-         0.0f,
-         -1.0f,
-         0.0f,
-         0.0f,
-         0.0f,
-         0.0f,
-         1.0f,
-     }},
-    {HYPRUTILS_TRANSFORM_180,
-     {
-         -1.0f,
-         0.0f,
-         0.0f,
-         0.0f,
-         -1.0f,
-         0.0f,
-         0.0f,
-         0.0f,
-         1.0f,
-     }},
-    {HYPRUTILS_TRANSFORM_270,
-     {
-         0.0f,
-         -1.0f,
-         0.0f,
-         1.0f,
-         0.0f,
-         0.0f,
-         0.0f,
-         0.0f,
-         1.0f,
-     }},
-    {HYPRUTILS_TRANSFORM_FLIPPED,
-     {
-         -1.0f,
-         0.0f,
-         0.0f,
-         0.0f,
-         1.0f,
-         0.0f,
-         0.0f,
-         0.0f,
-         1.0f,
-     }},
-    {HYPRUTILS_TRANSFORM_FLIPPED_90,
-     {
-         0.0f,
-         1.0f,
-         0.0f,
-         1.0f,
-         0.0f,
-         0.0f,
-         0.0f,
-         0.0f,
-         1.0f,
-     }},
-    {HYPRUTILS_TRANSFORM_FLIPPED_180,
-     {
-         1.0f,
-         0.0f,
-         0.0f,
-         0.0f,
-         -1.0f,
-         0.0f,
-         0.0f,
-         0.0f,
-         1.0f,
-     }},
-    {HYPRUTILS_TRANSFORM_FLIPPED_270,
-     {
-         0.0f,
-         -1.0f,
-         0.0f,
-         -1.0f,
-         0.0f,
-         0.0f,
-         0.0f,
-         0.0f,
-         1.0f,
-     }},
-};
+const std::unordered_map<eTransform, std::array<float, 9>>& getTransforms() {
+    static std::unordered_map<eTransform, std::array<float, 9>> transforms = {
+        {HYPRUTILS_TRANSFORM_NORMAL, {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f}},
+        {HYPRUTILS_TRANSFORM_90, {0.0f, 1.0f, 0.0f, -1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f}},
+        {HYPRUTILS_TRANSFORM_180, {-1.0f, 0.0f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f, 0.0f, 1.0f}},
+        {HYPRUTILS_TRANSFORM_270, {0.0f, -1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f}},
+        {HYPRUTILS_TRANSFORM_FLIPPED, {-1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 1.0f}},
+        {HYPRUTILS_TRANSFORM_FLIPPED_90, {0.0f, 1.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f}},
+        {HYPRUTILS_TRANSFORM_FLIPPED_180, {1.0f, 0.0f, 0.0f, 0.0f, -1.0f, 0.0f, 0.0f, 0.0f, 1.0f}},
+        {HYPRUTILS_TRANSFORM_FLIPPED_270, {0.0f, -1.0f, 0.0f, -1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f}},
+    };
+    return transforms;
+}
 
 void matrixTransform(float mat[9], eTransform transform) {
-    matrixMultiply(mat, mat, transforms.at(transform).data());
+    matrixMultiply(mat, mat, getTransforms().at(transform).data());
 }
 
 void matrixProjection(float mat[9], int width, int height, eTransform transform) {
     memset(mat, 0, sizeof(*mat) * 9);
 
-    const float* t = transforms.at(transform).data();
+    const float* t = getTransforms().at(transform).data();
     float        x = 2.0f / width;
     float        y = 2.0f / height;
 

--- a/src/helpers/sync/SyncTimeline.hpp
+++ b/src/helpers/sync/SyncTimeline.hpp
@@ -4,6 +4,7 @@
 #include <optional>
 #include <vector>
 #include <functional>
+#include "../memory/Memory.hpp"
 
 /*
     Hyprland synchronization timelines are based on the wlroots' ones, which

--- a/src/managers/CursorManager.hpp
+++ b/src/managers/CursorManager.hpp
@@ -6,6 +6,8 @@
 #include "../includes.hpp"
 #include "../helpers/math/Math.hpp"
 #include "../helpers/memory/Memory.hpp"
+#include "../macros.hpp"
+#include <aquamarine/buffer/Buffer.hpp>
 
 class CWLSurface;
 

--- a/src/managers/PointerManager.hpp
+++ b/src/managers/PointerManager.hpp
@@ -6,6 +6,7 @@
 #include "../helpers/math/Math.hpp"
 #include "../helpers/math/Math.hpp"
 #include "../desktop/WLSurface.hpp"
+#include "../helpers/sync/SyncTimeline.hpp"
 #include <tuple>
 
 class CMonitor;

--- a/src/managers/ProtocolManager.cpp
+++ b/src/managers/ProtocolManager.cpp
@@ -49,6 +49,10 @@
 
 #include "../helpers/Monitor.hpp"
 #include "../render/Renderer.hpp"
+#include "../Compositor.hpp"
+
+#include <aquamarine/buffer/Buffer.hpp>
+#include <aquamarine/backend/Backend.hpp>
 
 void CProtocolManager::onMonitorModeChange(CMonitor* pMonitor) {
     const bool ISMIRROR = pMonitor->isMirror();

--- a/src/plugins/PluginAPI.cpp
+++ b/src/plugins/PluginAPI.cpp
@@ -2,6 +2,7 @@
 #include "../Compositor.hpp"
 #include "../debug/HyprCtl.hpp"
 #include <dlfcn.h>
+#include <filesystem>
 
 #if defined(__DragonFly__) || defined(__FreeBSD__) || defined(__NetBSD__)
 #include <sys/sysctl.h>

--- a/src/protocols/LinuxDMABUF.hpp
+++ b/src/protocols/LinuxDMABUF.hpp
@@ -7,6 +7,8 @@
 #include "wayland.hpp"
 #include "linux-dmabuf-v1.hpp"
 #include "../helpers/signal/Signal.hpp"
+#include "../helpers/Format.hpp"
+#include "../helpers/Monitor.hpp"
 #include <aquamarine/buffer/Buffer.hpp>
 
 class CDMABuffer;

--- a/src/protocols/Screencopy.hpp
+++ b/src/protocols/Screencopy.hpp
@@ -8,6 +8,7 @@
 #include "../managers/HookSystemManager.hpp"
 #include "../helpers/Timer.hpp"
 #include "../managers/eventLoop/EventLoopTimer.hpp"
+#include <aquamarine/buffer/Buffer.hpp>
 
 class CMonitor;
 class IHLBuffer;

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -8,6 +8,7 @@
 #include "../../helpers/Monitor.hpp"
 #include "../PresentationTime.hpp"
 #include "../DRMSyncobj.hpp"
+#include "../../render/Renderer.hpp"
 
 #define LOGM PROTO::compositor->protoLog
 

--- a/src/protocols/types/WLBuffer.cpp
+++ b/src/protocols/types/WLBuffer.cpp
@@ -3,6 +3,7 @@
 #include "../core/Compositor.hpp"
 #include "../DRMSyncobj.hpp"
 #include "../../helpers/sync/SyncTimeline.hpp"
+#include "../../Compositor.hpp"
 #include <xf86drm.h>
 
 CWLBufferResource::CWLBufferResource(SP<CWlBuffer> resource_) : resource(resource_) {

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -11,6 +11,7 @@
 #include <xf86drm.h>
 #include <fcntl.h>
 #include <gbm.h>
+#include <filesystem>
 
 inline void loadGLProc(void* pProc, const char* name) {
     void* proc = (void*)eglGetProcAddress(name);

--- a/src/render/Renderbuffer.cpp
+++ b/src/render/Renderbuffer.cpp
@@ -2,6 +2,8 @@
 #include "OpenGL.hpp"
 #include "../Compositor.hpp"
 #include "../protocols/types/Buffer.hpp"
+#include <hyprutils/signal/Listener.hpp>
+#include <hyprutils/signal/Signal.hpp>
 
 #include <dlfcn.h>
 

--- a/src/render/Renderbuffer.hpp
+++ b/src/render/Renderbuffer.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+#include "../helpers/signal/Signal.hpp"
+#include "../helpers/memory/Memory.hpp"
+#include "../helpers/WLListener.hpp"
 #include "Framebuffer.hpp"
 #include <aquamarine/buffer/Buffer.hpp>
 

--- a/src/xwayland/Server.cpp
+++ b/src/xwayland/Server.cpp
@@ -18,6 +18,7 @@
 #include <sys/types.h>
 #include <sys/un.h>
 #include <unistd.h>
+#include <filesystem>
 
 // TODO: cleanup
 static bool set_cloexec(int fd, bool cloexec) {


### PR DESCRIPTION
added includes one by one when hitting build errors when trying to build it with emerge as a package, so combination of no precompiled headers and lto found these missing.

the heap use after free shows with asan at exit of hyprland

```
==9206==ERROR: AddressSanitizer: heap-use-after-free on address 0x50b0000003b0 at pc 0x555559d1c922 bp 0x7fffffffc9a0 sp 0x7fffffffc168
WRITE of size 104 at 0x50b0000003b0 thread T0
    #0 0x555559d1c921 in memset (/home/tom/dev/Hyprland/build/Desktop-Debug/Hyprland+0x47c8921)
    #1 0x7ffff7ea136a  (/usr/lib64/libaquamarine.so.0+0x9e36a)
    #2 0x7ffff6e46201 in __cxa_finalize (/usr/lib64/libc.so.6+0x46201)
    #3 0x7ffff7e4fbc2  (/usr/lib64/libaquamarine.so.0+0x4cbc2)

0x50b0000003b0 is located 0 bytes inside of 104-byte region [0x50b0000003b0,0x50b000000418)
freed by thread T0 here:
    #0 0x555559d60a68 in operator delete(void*) (/home/tom/dev/Hyprland/build/Desktop-Debug/Hyprland+0x480ca68)
    #1 0x555559e4d68e in std::__new_allocator<std::__detail::_Hash_node_base*>::deallocate(std::__detail::_Hash_node_base**, unsigned long) /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/new_allocator.h:172:2
    #2 0x55555a66eb82 in std::allocator<std::__detail::_Hash_node_base*>::deallocate(std::__detail::_Hash_node_base**, unsigned long) /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/allocator.h:208:25
    #3 0x55555a66eb82 in std::allocator_traits<std::allocator<std::__detail::_Hash_node_base*>>::deallocate(std::allocator<std::__detail::_Hash_node_base*>&, std::__detail::_Hash_node_base**, unsigned long) /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/alloc_traits.h:513:13
    #4 0x55555a66eb82 in std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<Hyprutils::Math::eTransform const, std::array<float, 9ul>>, false>>>::_M_deallocate_buckets(std::__detail::_Hash_node_base**, unsigned long) /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/hashtable_policy.h:2088:7
    #5 0x55555a66e859 in std::_Hashtable<Hyprutils::Math::eTransform, std::pair<Hyprutils::Math::eTransform const, std::array<float, 9ul>>, std::allocator<std::pair<Hyprutils::Math::eTransform const, std::array<float, 9ul>>>, std::__detail::_Select1st, std::equal_to<Hyprutils::Math::eTransform>, std::hash<Hyprutils::Math::eTransform>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true>>::_M_deallocate_buckets(std::__detail::_Hash_node_base**, unsigned long) /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/hashtable.h:456:21
    #6 0x55555a66e09e in std::_Hashtable<Hyprutils::Math::eTransform, std::pair<Hyprutils::Math::eTransform const, std::array<float, 9ul>>, std::allocator<std::pair<Hyprutils::Math::eTransform const, std::array<float, 9ul>>>, std::__detail::_Select1st, std::equal_to<Hyprutils::Math::eTransform>, std::hash<Hyprutils::Math::eTransform>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true>>::_M_deallocate_buckets() /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/hashtable.h:461:9
    #7 0x55555a66de31 in std::_Hashtable<Hyprutils::Math::eTransform, std::pair<Hyprutils::Math::eTransform const, std::array<float, 9ul>>, std::allocator<std::pair<Hyprutils::Math::eTransform const, std::array<float, 9ul>>>, std::__detail::_Select1st, std::equal_to<Hyprutils::Math::eTransform>, std::hash<Hyprutils::Math::eTransform>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true>>::~_Hashtable() /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/hashtable.h:1668:7
    #8 0x55555a66dcc8 in std::unordered_map<Hyprutils::Math::eTransform, std::array<float, 9ul>, std::hash<Hyprutils::Math::eTransform>, std::equal_to<Hyprutils::Math::eTransform>, std::allocator<std::pair<Hyprutils::Math::eTransform const, std::array<float, 9ul>>>>::~unordered_map() /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/unordered_map.h:109:11
    #9 0x7ffff6e468ff  (/usr/lib64/libc.so.6+0x468ff)
    #10 0x7ffff6e469c9 in exit (/usr/lib64/libc.so.6+0x469c9)
    #11 0x7ffff6e29e7d  (/usr/lib64/libc.so.6+0x29e7d)
    #12 0x7ffff6e29f36 in __libc_start_main (/usr/lib64/libc.so.6+0x29f36)
    #13 0x555559bb1f20 in _start (/home/tom/dev/Hyprland/build/Desktop-Debug/Hyprland+0x465df20)

``


