### PR TITLE
Make shader time always count from zero

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -861,6 +861,9 @@ void CHyprOpenGLImpl::applyScreenShader(const std::string& path) {
     m_sFinalScreenShader.proj      = glGetUniformLocation(m_sFinalScreenShader.program, "proj");
     m_sFinalScreenShader.tex       = glGetUniformLocation(m_sFinalScreenShader.program, "tex");
     m_sFinalScreenShader.time      = glGetUniformLocation(m_sFinalScreenShader.program, "time");
+    m_sFinalScreenShader.initial_time = glGetUniformLocation(m_sFinalScreenShader.program, "initial_time");
+    if (m_sFinalScreenShader.initial_time != -1)
+        m_sFinalScreenShader.initialTime = m_tGlobalTimer.getSeconds();
     m_sFinalScreenShader.wl_output = glGetUniformLocation(m_sFinalScreenShader.program, "wl_output");
     m_sFinalScreenShader.fullSize  = glGetUniformLocation(m_sFinalScreenShader.program, "screen_size");
     if (m_sFinalScreenShader.fullSize == -1)
@@ -1160,6 +1163,9 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, CBox* pB
         // Don't let time be unitialised
         glUniform1f(shader->time, 0.f);
     }
+
+    if (usingFinalShader && shader->initial_time != -1)
+        glUniform1f(shader->initial_time, shader->initialTime);
 
     if (usingFinalShader && shader->wl_output != -1)
         glUniform1i(shader->wl_output, m_RenderData.pMonitor->ID);

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -861,8 +861,7 @@ void CHyprOpenGLImpl::applyScreenShader(const std::string& path) {
     m_sFinalScreenShader.proj      = glGetUniformLocation(m_sFinalScreenShader.program, "proj");
     m_sFinalScreenShader.tex       = glGetUniformLocation(m_sFinalScreenShader.program, "tex");
     m_sFinalScreenShader.time      = glGetUniformLocation(m_sFinalScreenShader.program, "time");
-    m_sFinalScreenShader.initial_time = glGetUniformLocation(m_sFinalScreenShader.program, "initial_time");
-    if (m_sFinalScreenShader.initial_time != -1)
+    if (m_sFinalScreenShader.time != -1)
         m_sFinalScreenShader.initialTime = m_tGlobalTimer.getSeconds();
     m_sFinalScreenShader.wl_output = glGetUniformLocation(m_sFinalScreenShader.program, "wl_output");
     m_sFinalScreenShader.fullSize  = glGetUniformLocation(m_sFinalScreenShader.program, "screen_size");
@@ -1158,14 +1157,11 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, CBox* pB
     glUniform1i(shader->tex, 0);
 
     if ((usingFinalShader && *PDT == 0) || CRASHING) {
-        glUniform1f(shader->time, m_tGlobalTimer.getSeconds());
+        glUniform1f(shader->time, m_tGlobalTimer.getSeconds() - shader->initialTime);
     } else if (usingFinalShader && shader->time != -1) {
         // Don't let time be unitialised
         glUniform1f(shader->time, 0.f);
     }
-
-    if (usingFinalShader && shader->initial_time != -1)
-        glUniform1f(shader->initial_time, shader->initialTime);
 
     if (usingFinalShader && shader->wl_output != -1)
         glUniform1i(shader->wl_output, m_RenderData.pMonitor->ID);

--- a/src/render/Shader.hpp
+++ b/src/render/Shader.hpp
@@ -43,7 +43,6 @@ class CShader {
     GLint   angle          = -1;
 
     float   initialTime  = 0;
-    GLint   initial_time = -1;
     GLint   time      = -1;
     GLint   distort   = -1;
     GLint   wl_output = -1;

--- a/src/render/Shader.hpp
+++ b/src/render/Shader.hpp
@@ -42,6 +42,8 @@ class CShader {
     GLint   gradientLength = -1;
     GLint   angle          = -1;
 
+    float   initialTime  = 0;
+    GLint   initial_time = -1;
     GLint   time      = -1;
     GLint   distort   = -1;
     GLint   wl_output = -1;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

At the moment, a shader's `time` uniform is initially set to whatever the current value of `m_tGlobalTimer` is. This means that any shaders that are enabled after hyprland starts have no way of knowing how long it has been since they were enabled (this only applies to the user defined screen shader as far as I can tell).

This PR fixes this by storing the initial time and setting the `time` uniform to `time - initialTime`, so a shader's first `time` value is zero (and then counts up normally from there).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This only sets the initial time value for the screen shader (everything else defaulting to zero), as I assume nothing else actually needs it. This does mean the initial time could just be stored outside of the `CShader`, but it's easier this way.

It means that whenever the config is edited and the user has a screen shader active it will reset the screen shader's time back to zero instead of continuing roughly from where they were. If this is a problem then it could instead just expose an `initial_time` uniform to the shader but the only thing you could possibly do with it is just `float timer = time-initial_time;` so I think it's best not to, for ease of use. (the first commit does it this way)

#### Is it ready for merging, or does it need work?

Should be ready to merge, it works fine on my machine.
