### PR TITLE
flake: adding clang-tools to devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -90,9 +90,13 @@
           stdenv = pkgsFor.${system}.gcc13Stdenv;
         } {
           name = "hyprland-shell";
-          nativeBuildInputs = with pkgsFor.${system}; [expat libxml2];
+          nativeBuildInputs = with pkgsFor.${system}; [
+            expat
+            libxml2
+          ];
           hardeningDisable = ["fortify"];
           inputsFrom = [pkgsFor.${system}.hyprland];
+          packages = [pkgsFor.${system}.clang-tools];
         };
     });
 


### PR DESCRIPTION


#### Describe your PR, what does it fix/add?

It adds the `clang-tools` package to the devShell containing the `clangd` formatter used to format Hyprland's code apparently (`.clang-format` file exists)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I don't know how there can be so much diff, i just use the `nix fmt` command, the real change is line 101

#### Is it ready for merging, or does it need work?

It is ready for merging though i would like to propose to change the formatter from `alejandra` to `nixfmt-rfc-style`
I will add this change to this PR if wanted
