### PR TITLE
compositor: implement wayland socket handover

### DIFF
--- a/docs/Hyprland.1
+++ b/docs/Hyprland.1
@@ -32,6 +32,10 @@ Show command usage.
 .TP
 \f[B]-c\f[R], \f[B]--config\f[R]
 Specify config file to use.
+\f[B]--socket\f[R]
+Sets the Wayland socket name (for Wayland socket handover)
+\f[B]--wayland-fd\f[R]
+Sets the Wayland socket file descriptor (for Wayland socket handover)
 .SH BUGS
 .TP
 Submit bug reports and request features online at:

--- a/docs/Hyprland.1.rst
+++ b/docs/Hyprland.1.rst
@@ -41,6 +41,12 @@ OPTIONS
 **-c**, **--config**
     Specify config file to use.
 
+**--socket**
+    Sets the Wayland socket name (for Wayland socket handover)
+
+**--wayland-fd**
+    Sets the Wayland socket file descriptor (for Wayland socket handover)
+
 BUGS
 ====
 

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -78,7 +78,7 @@ class CCompositor {
     std::unordered_map<std::string, uint64_t> m_mMonitorIDMap;
 
     void                                      initServer();
-    void                                      startCompositor();
+    void                                      startCompositor(std::string socketName, int socketFd);
     void                                      cleanup();
     void                                      createLockFile();
     void                                      removeLockFile();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,8 @@ void help() {
     std::cout << "\nArguments:\n";
     std::cout << "  --help              -h       - Show this message again\n";
     std::cout << "  --config FILE       -c FILE  - Specify config file to use\n";
+    std::cout << "  --socket NAME                - Sets the Wayland socket name (for Wayland socket handover)\n";
+    std::cout << "  --wayland-fd FD              - Sets the Wayland socket fd (for Wayland socket handover)\n";
     std::cout << "  --i-am-really-stupid         - Omits root user privileges check (why would you do that?)\n";
 }
 
@@ -37,6 +39,8 @@ int main(int argc, char** argv) {
 
     // parse some args
     std::string              configPath;
+    std::string              socketName;
+    int                      socketFd   = -1;
     bool                     ignoreSudo = false;
 
     std::vector<std::string> args{argv + 1, argv + argc};
@@ -46,6 +50,24 @@ int main(int argc, char** argv) {
             std::cout << "[ WARNING ] Running Hyprland with superuser privileges might damage your system\n";
 
             ignoreSudo = true;
+        } else if (it->compare("--socket") == 0) {
+            if (std::next(it) == args.end()) {
+                help();
+
+                return 1;
+            }
+
+            socketName = *std::next(it);
+            it++;
+        } else if (it->compare("--wayland-fd") == 0) {
+            if (std::next(it) == args.end()) {
+                help();
+
+                return 1;
+            }
+
+            socketFd = std::atoi(std::next(it)->c_str());
+            it++;
         } else if (it->compare("-c") == 0 || it->compare("--config") == 0) {
             if (std::next(it) == args.end()) {
                 help();
@@ -113,7 +135,7 @@ int main(int argc, char** argv) {
     Debug::log(LOG, "Hyprland init finished.");
 
     // If all's good to go, start.
-    g_pCompositor->startCompositor();
+    g_pCompositor->startCompositor(socketName, socketFd);
 
     g_pCompositor->m_bIsShuttingDown = true;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,6 +128,13 @@ int main(int argc, char** argv) {
         std::cout << "Superuser privileges check is omitted. I hope you know what you're doing.\n";
     }
 
+    if (socketName.empty() ^ (socketFd == -1)) {
+        std::cerr << "[ ERROR ] Hyprland was launched with only one of --socket and --wayland-fd.\n";
+        std::cerr << "          Hint: Pass both --socket and --wayland-fd to perform Wayland socket handover.\n";
+
+        return 1;
+    }
+
     std::cout << "Welcome to Hyprland!\n";
 
     // let's init the compositor.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include "config/ConfigManager.hpp"
 #include "init/initHelpers.hpp"
 
+#include <fcntl.h>
 #include <iostream>
 #include <iterator>
 #include <vector>
@@ -66,7 +67,19 @@ int main(int argc, char** argv) {
                 return 1;
             }
 
-            socketFd = std::atoi(std::next(it)->c_str());
+            try {
+                socketFd = std::stoi(std::next(it)->c_str());
+
+                // check if socketFd is a valid file descriptor
+                if (fcntl(socketFd, F_GETFD) == -1)
+                    throw std::exception();
+            } catch (...) {
+                std::cerr << "[ ERROR ] Invalid Wayland FD!\n";
+                help();
+
+                return 1;
+            }
+
             it++;
         } else if (it->compare("-c") == 0 || it->compare("--config") == 0) {
             if (std::next(it) == args.end()) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This PR implements the compositor side of the Wayland socket handover protocol as described in the [KDE Wiki](https://invent.kde.org/plasma/kwin/-/wikis/Restarting). The CLI options are chosen so that they are compatible with Kwin:

Hyprland now accepts the CLI options `--socket NAME` and `--wayland-fd FD`, which pass the name of the Wayland display socket and the Wayland display socket fd number respectively. If given, Hyprland will use these instead of finding a free Wayland display socket name and creating it.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This allows for Hyprland to be used with a helper tool that automatically restarts the compositor on crashes, and allowing clients to reconnect after the compositor restart and survive the crash. The reconnecting clients look like new clients to Hyprland and perform all the same steps as a fresh Wayland client would. No additional handling is required on the side of Hyprland.

The helper tool finds and creates the Wayland socket and launches Hyprland with the new CLI options, restarting it when it exits with a non-zero exit code. Two such helper tools currently exist as far as I know:

- [`kwin_wayland_wrapper`](https://invent.kde.org/plasma/kwin/-/blob/master/src/helpers/wayland_wrapper/kwin_wrapper.cpp?ref_type=heads) (only for KDE)
- [`wl-restart`](https://github.com/ferdi265/wl-restart) (developed by me)

#### Is it ready for merging, or does it need work?

This PR works well from my personal testing.


