### PR TITLE
renderer: use explicitly set exclusiveEdge

### DIFF
--- a/src/protocols/LayerShell.cpp
+++ b/src/protocols/LayerShell.cpp
@@ -152,6 +152,8 @@ CLayerShellResource::CLayerShellResource(SP<CZwlrLayerSurfaceV1> resource_, SP<C
     });
 
     resource->setSetExclusiveEdge([this](CZwlrLayerSurfaceV1* r, zwlrLayerSurfaceV1Anchor anchor) {
+        // TODO: validate anchor
+
         pending.committed |= STATE_EDGE;
         pending.exclusiveEdge = anchor;
     });

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1506,7 +1506,8 @@ void CHyprRenderer::setSurfaceScanoutMode(SP<CWLSurfaceResource> surface, SP<CMo
 
 // taken from Sway.
 // this is just too much of a spaghetti for me to understand
-static void applyExclusive(CBox& usableArea, uint32_t anchor, int32_t exclusive, int32_t marginTop, int32_t marginRight, int32_t marginBottom, int32_t marginLeft) {
+static void applyExclusive(CBox& usableArea, uint32_t anchor, int32_t exclusive, uint32_t exclusiveEdge, int32_t marginTop, int32_t marginRight, int32_t marginBottom,
+                           int32_t marginLeft) {
     if (exclusive <= 0) {
         return;
     }
@@ -1551,7 +1552,7 @@ static void applyExclusive(CBox& usableArea, uint32_t anchor, int32_t exclusive,
         },
     };
     for (size_t i = 0; i < sizeof(edges) / sizeof(edges[0]); ++i) {
-        if ((anchor == edges[i].singular_anchor || anchor == edges[i].anchor_triplet) && exclusive + edges[i].margin > 0) {
+        if ((exclusiveEdge == edges[i].singular_anchor || anchor == edges[i].singular_anchor || anchor == edges[i].anchor_triplet) && exclusive + edges[i].margin > 0) {
             if (edges[i].positive_axis) {
                 *edges[i].positive_axis += exclusive + edges[i].margin;
             }
@@ -1638,7 +1639,7 @@ void CHyprRenderer::arrangeLayerArray(CMonitor* pMonitor, const std::vector<PHLL
         // Apply
         ls->geometry = box;
 
-        applyExclusive(*usableArea, PSTATE->anchor, PSTATE->exclusive, PSTATE->margin.top, PSTATE->margin.right, PSTATE->margin.bottom, PSTATE->margin.left);
+        applyExclusive(*usableArea, PSTATE->anchor, PSTATE->exclusive, PSTATE->exclusiveEdge, PSTATE->margin.top, PSTATE->margin.right, PSTATE->margin.bottom, PSTATE->margin.left);
 
         if (Vector2D{box.width, box.height} != OLDSIZE)
             ls->layerSurface->configure(box.size());


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Hyprland advertises layer-shell v5, and does store the exclusiveEdge that it adds, but doesn't actually use it in the renderer. This fixes that.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I checked that this works with the bar I'm working on, but I haven't checked for edge cases or any other possible issues. Also, I'm not used to C++ at all so I might have missed things.

#### Is it ready for merging, or does it need work?

If I haven't missed anything, guess it's ok to merge?