### PR TITLE
validate exclusiveEdge and don't set it as top by default

### DIFF
--- a/src/protocols/LayerShell.cpp
+++ b/src/protocols/LayerShell.cpp
@@ -11,7 +11,7 @@ void CLayerShellResource::SState::reset() {
     exclusive     = 0;
     interactivity = ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE;
     layer         = ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM;
-    exclusiveEdge = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP;
+    exclusiveEdge = (zwlrLayerSurfaceV1Anchor)0;
     desiredSize   = {};
     margin        = {0, 0, 0, 0};
 }
@@ -152,7 +152,10 @@ CLayerShellResource::CLayerShellResource(SP<CZwlrLayerSurfaceV1> resource_, SP<C
     });
 
     resource->setSetExclusiveEdge([this](CZwlrLayerSurfaceV1* r, zwlrLayerSurfaceV1Anchor anchor) {
-        // TODO: validate anchor
+        if (!pending.anchor || !(pending.anchor & anchor)) {
+            r->error(ZWLR_LAYER_SURFACE_V1_ERROR_INVALID_EXCLUSIVE_EDGE, "Exclusive edge doesn't align with anchor");
+            return;
+        }
 
         pending.committed |= STATE_EDGE;
         pending.exclusiveEdge = anchor;

--- a/src/protocols/LayerShell.cpp
+++ b/src/protocols/LayerShell.cpp
@@ -152,6 +152,11 @@ CLayerShellResource::CLayerShellResource(SP<CZwlrLayerSurfaceV1> resource_, SP<C
     });
 
     resource->setSetExclusiveEdge([this](CZwlrLayerSurfaceV1* r, zwlrLayerSurfaceV1Anchor anchor) {
+        if (anchor > (ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP | ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM | ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT | ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT)) {
+            r->error(ZWLR_LAYER_SURFACE_V1_ERROR_INVALID_EXCLUSIVE_EDGE, "Invalid exclusive edge");
+            return;
+        }
+
         if (!pending.anchor || !(pending.anchor & anchor)) {
             r->error(ZWLR_LAYER_SURFACE_V1_ERROR_INVALID_EXCLUSIVE_EDGE, "Exclusive edge doesn't align with anchor");
             return;

--- a/src/protocols/LayerShell.hpp
+++ b/src/protocols/LayerShell.hpp
@@ -47,7 +47,7 @@ class CLayerShellResource : public ISurfaceRole {
         Vector2D                                desiredSize;
         zwlrLayerSurfaceV1KeyboardInteractivity interactivity = ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE;
         zwlrLayerShellV1Layer                   layer         = ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM;
-        zwlrLayerSurfaceV1Anchor                exclusiveEdge = ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP;
+        zwlrLayerSurfaceV1Anchor                exclusiveEdge = (zwlrLayerSurfaceV1Anchor)0;
         uint32_t                                committed     = 0;
 
         struct {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
resolves #6987

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
anchor is defined as a enum bitfield so 0 is valid
>```xml
><enum name="anchor" bitfield="true">
>  <entry name="top" value="1" summary="the top edge of the anchor rectangle"/>
>  <entry name="bottom" value="2" summary="the bottom edge of the anchor rectangle"/>
>  <entry name="left" value="4" summary="the left edge of the anchor rectangle"/>
>  <entry name="right" value="8" summary="the right edge of the anchor rectangle"/>
></enum>
>```

#### Is it ready for merging, or does it need work?
yes

