### PR TITLE
handle monitor changes in moveWindowIntoGroup

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2486,6 +2486,11 @@ void CKeybindManager::moveWindowIntoGroup(PHLWINDOW pWindow, PHLWINDOW pWindowIn
 
     g_pLayoutManager->getCurrentLayout()->onWindowRemoved(pWindow); // This removes groupped property!
 
+    if (pWindow->m_iMonitorID != pWindowInDirection->m_iMonitorID) {
+        pWindow->moveToWorkspace(pWindowInDirection->m_pWorkspace);
+        pWindow->m_iMonitorID = pWindowInDirection->m_iMonitorID;
+    }
+
     static auto USECURRPOS = CConfigValue<Hyprlang::INT>("group:insert_after_current");
     pWindowInDirection     = *USECURRPOS ? pWindowInDirection : pWindowInDirection->getGroupTail();
 


### PR DESCRIPTION
handles monitor changes in `moveWindowIntoGroup()`

fixes:https://github.com/hyprwm/Hyprland/issues/6778
pretty sure there is another open issue that should also be fixed but can't find it