### PR TITLE
Fix `hyprctl switchxkblayout` not actually changing layout

### DIFF
--- a/src/devices/IKeyboard.cpp
+++ b/src/devices/IKeyboard.cpp
@@ -325,6 +325,13 @@ void IKeyboard::updateModifiers(uint32_t depressed, uint32_t latched, uint32_t l
     if (!updateModifiersState())
         return;
 
+    keyboardEvents.modifiers.emit(SModifiersEvent{
+        .depressed = modifiersState.depressed,
+        .latched   = modifiersState.latched,
+        .locked    = modifiersState.locked,
+        .group     = modifiersState.group,
+    });
+
     updateLEDs();
 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This fixes https://github.com/hyprwm/Hyprland/issues/7044

Emits `SModifiersEvent` in `updateModifiers()`

Before the patch:

Changing layout with `hyprctl switchxkblayout ...` results in:
* active keymap in `hyprctl devices` is changed
* no ipc event
* no layout is actually changed **util** you press one of the mod keys (Alt | Shift | Super | Ctrl) - then event is emitted, and layout is changed for real 

After:
* active keymap in `hyprctl devices` is changed
* activelayout IPC event emitted
* layout is changed

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

It works for me and @coffebar , it doesn't seem to break anything.

Video demo https://github.com/hyprwm/Hyprland/issues/7044#issuecomment-2253725841

#### Is it ready for merging, or does it need work?

Ready
