### PR TITLE
unify removing currentlyDraggedWindow

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -477,13 +477,7 @@ void unregisterVar(void* ptr) {
 
 void CWindow::onUnmap() {
     static auto PCLOSEONLASTSPECIAL = CConfigValue<Hyprlang::INT>("misc:close_special_on_empty");
-
-    if (g_pCompositor->m_pLastWindow.lock().get() == this)
-        g_pCompositor->m_pLastWindow.reset();
-    if (g_pInputManager->currentlyDraggedWindow.lock().get() == this)
-        g_pInputManager->currentlyDraggedWindow.reset();
-
-    static auto PINITIALWSTRACKING = CConfigValue<Hyprlang::INT>("misc:initial_workspace_tracking");
+    static auto PINITIALWSTRACKING  = CConfigValue<Hyprlang::INT>("misc:initial_workspace_tracking");
 
     if (!m_szInitialWorkspaceToken.empty()) {
         const auto TOKEN = g_pTokenManager->getToken(m_szInitialWorkspaceToken);

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -626,6 +626,9 @@ void Events::listener_unmapWindow(void* owner, void* data) {
         g_pInputManager->releaseAllMouseButtons();
     }
 
+    if (PWINDOW == g_pInputManager->currentlyDraggedWindow.lock())
+        g_pKeybindManager->changeMouseBindMode(MBIND_INVALID);
+
     // remove the fullscreen window status from workspace if we closed it
     const auto PWORKSPACE = PWINDOW->m_pWorkspace;
 

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -105,6 +105,8 @@ class CKeybindManager {
     //we also store the keyboard pointer (in the string) to differentiate between different keyboard (layouts)
     std::unordered_map<std::string, xkb_keycode_t> m_mKeyToCodeCache;
 
+    static void                                    changeMouseBindMode(const eMouseBindMode mode);
+
   private:
     std::deque<SPressedKeyWithMods> m_dPressedKeys;
 
@@ -116,7 +118,6 @@ class CKeybindManager {
     uint32_t                        m_uLastCode      = 0;
     uint32_t                        m_uLastMouseCode = 0;
 
-    bool                            m_bIsMouseBindActive = false;
     std::vector<SKeybind*>          m_vPressedSpecialBinds;
 
     int                             m_iPassPressed = -1; // used for pass

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1670,7 +1670,7 @@ void CInputManager::releaseAllMouseButtons() {
 
 void CInputManager::setCursorIconOnBorder(PHLWINDOW w) {
     // do not override cursor icons set by mouse binds
-    if (g_pKeybindManager->m_bIsMouseBindActive) {
+    if (g_pInputManager->currentlyDraggedWindow.expired()) {
         m_eBorderIconDirection = BORDERICON_NONE;
         return;
     }


### PR DESCRIPTION
unifies removing `currentlyDraggedWindow` by using `changeMouseBindMode()` to try to remove some weird states where `g_pInputManager->dragMode` is set but  `currentlyDraggedWindow` is expired
seems to work fine from my testing

mouse drag/resize icons are broken on main for some reason, but will try to address in another PR