### PR TITLE
CI: only run once for PRs with branches from original repo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,14 +1,13 @@
 name: Build Hyprland
 
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
-
 on: [push, pull_request, workflow_dispatch]
 jobs:
   gcc:
     name: "Build Hyprland (Arch)"
     runs-on: ubuntu-latest
+    concurrency:
+      group: gcc
+      cancel-in-progress: true
     container:
       image: archlinux
     steps:
@@ -50,6 +49,9 @@ jobs:
   meson:
     name: "Build Hyprland with Meson (Arch)"
     runs-on: ubuntu-latest
+    concurrency:
+      group: meson
+      cancel-in-progress: true
     container:
       image: archlinux
     steps:
@@ -70,6 +72,9 @@ jobs:
   no-pch:
     name: "Build Hyprland without precompiled headers (Arch)"
     runs-on: ubuntu-latest
+    concurrency:
+      group: nopch
+      cancel-in-progress: true
     container:
       image: archlinux
     steps:
@@ -89,6 +94,9 @@ jobs:
   noxwayland:
     name: "Build Hyprland in pure Wayland (Arch)"
     runs-on: ubuntu-latest
+    concurrency:
+      group: noxwayland
+      cancel-in-progress: true
     container:
       image: archlinux
     steps:
@@ -109,6 +117,9 @@ jobs:
   clang-format:
     name: "Code Style (Arch)"
     runs-on: ubuntu-latest
+    concurrency:
+      group: clangformat
+      cancel-in-progress: true
     container:
       image: archlinux
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,12 @@
 name: Build Hyprland
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on: [push, pull_request, workflow_dispatch]
 jobs:
   gcc:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: "Build Hyprland (Arch)"
     runs-on: ubuntu-latest
     container:
@@ -45,7 +48,6 @@ jobs:
           path: Hyprland.tar.xz
 
   meson:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: "Build Hyprland with Meson (Arch)"
     runs-on: ubuntu-latest
     container:
@@ -66,7 +68,6 @@ jobs:
         run: ninja -C build
 
   no-pch:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: "Build Hyprland without precompiled headers (Arch)"
     runs-on: ubuntu-latest
     container:
@@ -86,7 +87,6 @@ jobs:
         run: make nopch
 
   noxwayland:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: "Build Hyprland in pure Wayland (Arch)"
     runs-on: ubuntu-latest
     container:
@@ -107,7 +107,6 @@ jobs:
         run: make release
 
   clang-format:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: "Code Style (Arch)"
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,7 @@ name: Build Hyprland
 on: [push, pull_request, workflow_dispatch]
 jobs:
   gcc:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: "Build Hyprland (Arch)"
     runs-on: ubuntu-latest
     container:
@@ -44,6 +45,7 @@ jobs:
           path: Hyprland.tar.xz
 
   meson:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: "Build Hyprland with Meson (Arch)"
     runs-on: ubuntu-latest
     container:
@@ -64,6 +66,7 @@ jobs:
         run: ninja -C build
 
   no-pch:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: "Build Hyprland without precompiled headers (Arch)"
     runs-on: ubuntu-latest
     container:
@@ -83,6 +86,7 @@ jobs:
         run: make nopch
 
   noxwayland:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: "Build Hyprland in pure Wayland (Arch)"
     runs-on: ubuntu-latest
     container:
@@ -103,6 +107,7 @@ jobs:
         run: make release
 
   clang-format:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: "Code Style (Arch)"
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,11 +3,9 @@ name: Build Hyprland
 on: [push, pull_request, workflow_dispatch]
 jobs:
   gcc:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork
     name: "Build Hyprland (Arch)"
     runs-on: ubuntu-latest
-    concurrency:
-      group: gcc
-      cancel-in-progress: true
     container:
       image: archlinux
     steps:
@@ -47,11 +45,9 @@ jobs:
           path: Hyprland.tar.xz
 
   meson:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork
     name: "Build Hyprland with Meson (Arch)"
     runs-on: ubuntu-latest
-    concurrency:
-      group: meson
-      cancel-in-progress: true
     container:
       image: archlinux
     steps:
@@ -70,11 +66,9 @@ jobs:
         run: ninja -C build
 
   no-pch:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork
     name: "Build Hyprland without precompiled headers (Arch)"
     runs-on: ubuntu-latest
-    concurrency:
-      group: nopch
-      cancel-in-progress: true
     container:
       image: archlinux
     steps:
@@ -92,11 +86,9 @@ jobs:
         run: make nopch
 
   noxwayland:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork
     name: "Build Hyprland in pure Wayland (Arch)"
     runs-on: ubuntu-latest
-    concurrency:
-      group: noxwayland
-      cancel-in-progress: true
     container:
       image: archlinux
     steps:
@@ -115,11 +107,9 @@ jobs:
         run: make release
 
   clang-format:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork
     name: "Code Style (Arch)"
     runs-on: ubuntu-latest
-    concurrency:
-      group: clangformat
-      cancel-in-progress: true
     container:
       image: archlinux
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,7 @@
 name: Build Hyprland
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.ref }}
   cancel-in-progress: true
 
 on: [push, pull_request, workflow_dispatch]

--- a/.github/workflows/man-update.yaml
+++ b/.github/workflows/man-update.yaml
@@ -8,6 +8,10 @@ on:
     branches:
       - 'main'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   main:
     name: Build man pages

--- a/.github/workflows/man-update.yaml
+++ b/.github/workflows/man-update.yaml
@@ -9,7 +9,7 @@ on:
       - 'main'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/man-update.yaml
+++ b/.github/workflows/man-update.yaml
@@ -8,14 +8,13 @@ on:
     branches:
       - 'main'
 
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   main:
     name: Build man pages
     runs-on: ubuntu-latest
+    concurrency:
+      group: man
+      cancel-in-progress: true
     steps:
     - name: Install deps
       run: sudo apt install pandoc

--- a/.github/workflows/man-update.yaml
+++ b/.github/workflows/man-update.yaml
@@ -12,9 +12,6 @@ jobs:
   main:
     name: Build man pages
     runs-on: ubuntu-latest
-    concurrency:
-      group: man
-      cancel-in-progress: true
     steps:
     - name: Install deps
       run: sudo apt install pandoc

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -3,7 +3,7 @@ name: Nix
 on: [push, pull_request, workflow_dispatch]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -5,17 +5,11 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
   update-inputs:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    concurrency:
-      group: nixupdateinputs
-      cancel-in-progress: true
     uses: ./.github/workflows/nix-update-inputs.yml
     secrets: inherit
 
   build:
-    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
-    concurrency:
-      group: nixbuild
-      cancel-in-progress: true
+    if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork) && !contains(needs.*.result, 'failure')
     needs: update-inputs
     uses: ./.github/workflows/nix-build.yml
     secrets: inherit

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -2,18 +2,20 @@ name: Nix
 
 on: [push, pull_request, workflow_dispatch]
 
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   update-inputs:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    concurrency:
+      group: nixupdateinputs
+      cancel-in-progress: true
     uses: ./.github/workflows/nix-update-inputs.yml
     secrets: inherit
 
   build:
     if: always() && !cancelled() && !contains(needs.*.result, 'failure')
+    concurrency:
+      group: nixbuild
+      cancel-in-progress: true
     needs: update-inputs
     uses: ./.github/workflows/nix-build.yml
     secrets: inherit

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -2,14 +2,18 @@ name: Nix
 
 on: [push, pull_request, workflow_dispatch]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   update-inputs:
-    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/nix-update-inputs.yml
     secrets: inherit
 
   build:
-    if: (always() && !cancelled() && !contains(needs.*.result, 'failure')) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)
+    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
     needs: update-inputs
     uses: ./.github/workflows/nix-build.yml
     secrets: inherit

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -4,12 +4,12 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   update-inputs:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)
     uses: ./.github/workflows/nix-update-inputs.yml
     secrets: inherit
 
   build:
-    if: always() && !cancelled() && !contains(needs.*.result, 'failure')
+    if: (always() && !cancelled() && !contains(needs.*.result, 'failure')) && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)
     needs: update-inputs
     uses: ./.github/workflows/nix-build.yml
     secrets: inherit

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -2,9 +2,12 @@ name: Security Checks
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   flawfinder:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: Flawfinder Checks
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -3,7 +3,7 @@ name: Security Checks
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -2,14 +2,13 @@ name: Security Checks
 
 on: [push, pull_request]
 
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   flawfinder:
     name: Flawfinder Checks
     runs-on: ubuntu-latest
+    concurrency:
+      group: security
+      cancel-in-progress: true
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -4,11 +4,9 @@ on: [push, pull_request]
 
 jobs:
   flawfinder:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork
     name: Flawfinder Checks
     runs-on: ubuntu-latest
-    concurrency:
-      group: security
-      cancel-in-progress: true
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   flawfinder:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: Flawfinder Checks
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Currently, if vaxry or I make a PR with a branch in this repo, CI's checks will
run twice, labeled (push) and (pull_request). This is not ideal as we're wasting
resources and making CI take longer to finish, and potentially starves resources
for other PR's CI runs.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This PR serves both as the feature and the test.

#### Is it ready for merging, or does it need work?

Probably ready.
