### PR TITLE
layer-shell: avoid crashes on unmap

### DIFF
--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -217,7 +217,7 @@ void CLayerSurface::onUnmap() {
 
     // refocus if needed
     //                                vvvvvvvvvvvvv if there is a last focus and the last focus is not keyboard focusable, fallback to window
-    if (WASLASTFOCUS || (g_pCompositor->m_pLastFocus && !g_pCompositor->m_pLastFocus->hlSurface->keyboardFocusable()))
+    if (WASLASTFOCUS || (g_pCompositor->m_pLastFocus && g_pCompositor->m_pLastFocus->hlSurface && !g_pCompositor->m_pLastFocus->hlSurface->keyboardFocusable()))
         g_pInputManager->refocusLastWindow(PMONITOR);
     else if (g_pCompositor->m_pLastFocus)
         g_pSeatManager->setKeyboardFocus(g_pCompositor->m_pLastFocus.lock());


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes a crash I had since today, where I would lock my PC, walk away, and come back to a crash in the tty. Turns out the crash is caused if a layer surface is unmapped while hyprland is locked. So if I was receiving notifications, whilst being on the lockscreen, it would crash. 

The problem is that the `LastFocus` would contain the session-lock surface, which for some reason doesn't have an associated `hlSurface`, which would however still be accessed and thus segfault. So it seems to be introduced by https://github.com/hyprwm/Hyprland/commit/963816b9a6524a99a6716fa1aa30b2c4f369d2f0, and  a null check does the trick.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Didn't look in too deeply, as I don't have too much time currently, so I don't really know why `hlSurface` is null for the session-lock surface in the first place. But from looking around other code it seems to be expected.

#### Is it ready for merging, or does it need work?
Yes


