### PR TITLE
xdg-shell: fix xdg-positioner y-flip

### DIFF
--- a/src/protocols/XDGShell.cpp
+++ b/src/protocols/XDGShell.cpp
@@ -567,7 +567,7 @@ CBox CXDGPositionerRules::getPosition(CBox constraint, const Vector2D& parentCoo
         if (flip) {
             state.gravity ^= CEdges::TOP | CEdges::BOTTOM;
             anchorY    = state.anchor.top() ? anchorRect.extent().y : state.anchor.bottom() ? anchorRect.y : anchorY;
-            effectiveX = calcEffectiveX();
+            effectiveY = calcEffectiveY();
         }
     }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes a copypaste typo in https://github.com/hyprwm/Hyprland/pull/7067 which caused flip_y to be skipped.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready
