### PR TITLE
Add force reload of config at the end of plugin initialization

### DIFF
--- a/src/plugins/PluginSystem.cpp
+++ b/src/plugins/PluginSystem.cpp
@@ -1,7 +1,6 @@
 #include "PluginSystem.hpp"
 
 #include <dlfcn.h>
-#include <hyprland/src/config/ConfigManager.hpp>
 #include <ranges>
 #include "../Compositor.hpp"
 

--- a/src/plugins/PluginSystem.cpp
+++ b/src/plugins/PluginSystem.cpp
@@ -1,6 +1,7 @@
 #include "PluginSystem.hpp"
 
 #include <dlfcn.h>
+#include <hyprland/src/config/ConfigManager.hpp>
 #include <ranges>
 #include "../Compositor.hpp"
 
@@ -79,6 +80,8 @@ CPlugin* CPluginSystem::loadPlugin(const std::string& path) {
     PLUGIN->description = PLUGINDATA.description;
     PLUGIN->version     = PLUGINDATA.version;
     PLUGIN->name        = PLUGINDATA.name;
+
+    g_pConfigManager->m_bForceReload = true;
 
     Debug::log(LOG, " [PluginSystem] Plugin {} loaded. Handle: {:x}, path: \"{}\", author: \"{}\", description: \"{}\", version: \"{}\"", PLUGINDATA.name, (uintptr_t)MODULE, path,
                PLUGINDATA.author, PLUGINDATA.description, PLUGINDATA.version);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes an issue where the plugin accesses a config value after initialization but before the config is reloaded by some other thingy. Previously, this would cause the plugin to use the default value instead of the value set in the config file. Fixes hyprwm/hyprland-plugins#100 and possibly other issues.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I guess hyprland should reload the config (because of [this](https://discord.com/channels/961691461554950145/1236850208411877387/1251502554278527056)), but it never actually does that. It could be fixed on the plugin side, but I don't think it should be.

#### Is it ready for merging, or does it need work?
Maybe this can be done somewhere else, idk. I'm also not sure about the `CConfigManager::handlePluginLoads` function, which does not work after `hyprpm reload` (`pluginsChanged` is never true).
