### PR TITLE
add a destructor to CHyprOpenglImpl and avoid wl_container_of undefined behaviour

### DIFF
--- a/src/protocols/GlobalShortcuts.cpp
+++ b/src/protocols/GlobalShortcuts.cpp
@@ -8,13 +8,14 @@ static void bindManagerInt(wl_client* client, void* data, uint32_t version, uint
 }
 
 static void handleDisplayDestroy(struct wl_listener* listener, void* data) {
-    CGlobalShortcutsProtocolManager* proto = wl_container_of(listener, proto, m_liDisplayDestroy);
+    CGlobalShortcutsProtocolManagerDestroyWrapper* wrap  = wl_container_of(listener, wrap, listener);
+    CGlobalShortcutsProtocolManager*               proto = wrap->parent;
     proto->displayDestroy();
 }
 
 void CGlobalShortcutsProtocolManager::displayDestroy() {
-    wl_list_remove(&m_liDisplayDestroy.link);
-    wl_list_init(&m_liDisplayDestroy.link);
+    wl_list_remove(&m_liDisplayDestroy.listener.link);
+    wl_list_init(&m_liDisplayDestroy.listener.link);
     wl_global_destroy(m_pGlobal);
 }
 
@@ -30,8 +31,10 @@ CGlobalShortcutsProtocolManager::CGlobalShortcutsProtocolManager() {
         return;
     }
 
-    m_liDisplayDestroy.notify = handleDisplayDestroy;
-    wl_display_add_destroy_listener(g_pCompositor->m_sWLDisplay, &m_liDisplayDestroy);
+    wl_list_init(&m_liDisplayDestroy.listener.link);
+    m_liDisplayDestroy.listener.notify = handleDisplayDestroy;
+    m_liDisplayDestroy.parent          = this;
+    wl_display_add_destroy_listener(g_pCompositor->m_sWLDisplay, &m_liDisplayDestroy.listener);
 
     Debug::log(LOG, "GlobalShortcutsManager started successfully!");
 }

--- a/src/protocols/GlobalShortcuts.hpp
+++ b/src/protocols/GlobalShortcuts.hpp
@@ -14,6 +14,12 @@ struct SShortcutClient {
     std::vector<std::unique_ptr<SShortcut>> shortcuts;
 };
 
+class CGlobalShortcutsProtocolManager;
+struct CGlobalShortcutsProtocolManagerDestroyWrapper {
+    wl_listener                      listener;
+    CGlobalShortcutsProtocolManager* parent = nullptr;
+};
+
 class CGlobalShortcutsProtocolManager {
   public:
     CGlobalShortcutsProtocolManager();
@@ -31,7 +37,7 @@ class CGlobalShortcutsProtocolManager {
 
     std::vector<SShortcut> getAllShortcuts();
 
-    wl_listener            m_liDisplayDestroy;
+    CGlobalShortcutsProtocolManagerDestroyWrapper m_liDisplayDestroy;
 
   private:
     std::vector<std::unique_ptr<SShortcutClient>> m_vClients;

--- a/src/protocols/WaylandProtocol.hpp
+++ b/src/protocols/WaylandProtocol.hpp
@@ -11,6 +11,12 @@
 
 #define PROTO NProtocols
 
+class IWaylandProtocol;
+struct IWaylandProtocolDestroyWrapper {
+    wl_listener       listener;
+    IWaylandProtocol* parent = nullptr;
+};
+
 class IWaylandProtocol {
   public:
     IWaylandProtocol(const wl_interface* iface, const int& ver, const std::string& name);
@@ -26,7 +32,7 @@ class IWaylandProtocol {
         Debug::log(level, std::format("[{}] ", m_szName) + std::vformat(fmt.get(), std::make_format_args(args...)));
     };
 
-    wl_listener m_liDisplayDestroy;
+    IWaylandProtocolDestroyWrapper m_liDisplayDestroy;
 
   private:
     std::string m_szName;

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -345,6 +345,22 @@ CHyprOpenGLImpl::CHyprOpenGLImpl() {
     m_tGlobalTimer.reset();
 }
 
+CHyprOpenGLImpl::~CHyprOpenGLImpl() {
+    if (m_pEglDisplay && m_pEglContext != EGL_NO_CONTEXT)
+        eglDestroyContext(m_pEglDisplay, m_pEglContext);
+
+    if (m_pEglDisplay)
+        eglTerminate(m_pEglDisplay);
+
+    eglReleaseThread();
+
+    if (m_pGbmDevice)
+        gbm_device_destroy(m_pGbmDevice);
+
+    if (m_iGBMFD >= 0)
+        close(m_iGBMFD);
+}
+
 std::optional<std::vector<uint64_t>> CHyprOpenGLImpl::getModsForFormat(EGLint format) {
     // TODO: return std::expected when clang supports it
 

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -145,6 +145,7 @@ class CGradientValueData;
 class CHyprOpenGLImpl {
   public:
     CHyprOpenGLImpl();
+    ~CHyprOpenGLImpl();
 
     void     begin(CMonitor*, const CRegion& damage, CFramebuffer* fb = nullptr, std::optional<CRegion> finalDamage = {});
     void     beginSimple(CMonitor*, const CRegion& damage, SP<CRenderbuffer> rb = nullptr, CFramebuffer* fb = nullptr);


### PR DESCRIPTION
add a destructor to CHyprOpenglImpl to free allocated memory/fd/etc to make asan more happy on destruction. 

to safely use wl_container_of with a class the class has to be no virtual functions, no inheritance, and uniform access control (e.g all public)

work around this by putting this into a destroywrapper struct.

