### PR TITLE
refactor fullscreen

### DIFF
--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -146,7 +146,11 @@ class CCompositor {
     void                   swapActiveWorkspaces(CMonitor*, CMonitor*);
     CMonitor*              getMonitorFromString(const std::string&);
     bool                   workspaceIDOutOfBounds(const int64_t&);
-    void                   setWindowFullscreen(PHLWINDOW, bool, eFullscreenMode mode = FULLSCREEN_INVALID);
+    void                   setWindowFullscreenInternal(const PHLWINDOW PWINDOW, const eFullscreenMode MODE);
+    void                   setWindowFullscreenClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE);
+    void                   setWindowFullscreenState(const PHLWINDOW PWINDOW, const sFullscreenState state);
+    void                   changeWindowFullscreenModeInternal(const PHLWINDOW PWINDOW, const eFullscreenMode MODE, const bool ON);
+    void                   changeWindowFullscreenModeClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE, const bool ON);
     void                   updateFullscreenFadeOnWorkspace(PHLWORKSPACE);
     PHLWINDOW              getX11Parent(PHLWINDOW);
     void                   scheduleFrameForMonitor(CMonitor*, Aquamarine::IOutput::scheduleFrameReason reason = Aquamarine::IOutput::AQ_SCHEDULE_CLIENT_UNKNOWN);

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2099,7 +2099,7 @@ std::optional<std::string> CConfigManager::handleUnbind(const std::string& comma
 
 bool windowRuleValid(const std::string& RULE) {
     static const auto rules = std::unordered_set<std::string>{
-        "fakefullscreen", "float", "fullscreen", "maximize", "noinitialfocus", "pin", "stayfocused", "tile",
+        "float", "fullscreen", "maximize", "noinitialfocus", "pin", "stayfocused", "tile",
     };
     static const auto rulesPrefix = std::vector<std::string>{
         "animation", "bordercolor", "bordersize", "center",   "group", "idleinhibit",   "maxsize", "minsize",   "monitor", "move",

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1100,7 +1100,7 @@ std::vector<SWindowRule> CConfigManager::getMatchingRules(PHLWINDOW pWindow, boo
 
     // since some rules will be applied later, we need to store some flags
     bool hasFloating   = pWindow->m_bIsFloating;
-    bool hasFullscreen = pWindow->m_bIsFullscreen;
+    bool hasFullscreen = pWindow->isFullscreen();
 
     // local tags for dynamic tag rule match
     auto tags = pWindow->m_tags;
@@ -1448,7 +1448,7 @@ void CConfigManager::ensureVRR(CMonitor* pMonitor) {
             if (!PWORKSPACE)
                 return; // ???
 
-            const auto WORKSPACEFULL = PWORKSPACE->m_bHasFullscreenWindow && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL;
+            const auto WORKSPACEFULL = PWORKSPACE->m_bHasFullscreenWindow && (PWORKSPACE->m_efFullscreenMode & FSMODE_FULLSCREEN);
 
             if (WORKSPACEFULL) {
                 m->output->state->setAdaptiveSync(true);

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2102,8 +2102,8 @@ bool windowRuleValid(const std::string& RULE) {
         "float", "fullscreen", "maximize", "noinitialfocus", "pin", "stayfocused", "tile",
     };
     static const auto rulesPrefix = std::vector<std::string>{
-        "animation", "bordercolor", "bordersize", "center",   "group", "idleinhibit",   "maxsize", "minsize",   "monitor", "move",
-        "opacity",   "plugin:",     "pseudo",     "rounding", "size",  "suppressevent", "tag",     "workspace", "xray",
+        "animation", "bordercolor", "bordersize", "center", "fullscreenstate", "group", "idleinhibit",   "maxsize", "minsize",   "monitor",
+        "move",      "opacity",     "plugin:",    "pseudo", "rounding",        "size",  "suppressevent", "tag",     "workspace", "xray",
     };
 
     const auto VALS = CVarList(RULE, 2, ' ');

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -182,6 +182,7 @@ class CConfigManager {
         {"noshortcutsinhibit", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noShortcutsInhibit; }},
         {"opaque", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.opaque; }},
         {"forcergbx", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.RGBX; }},
+        {"syncFullscreen", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.syncFullscreen; }},
         {"immediate", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.tearing; }},
         {"xray", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.xray; }},
     };

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -182,7 +182,7 @@ class CConfigManager {
         {"noshortcutsinhibit", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noShortcutsInhibit; }},
         {"opaque", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.opaque; }},
         {"forcergbx", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.RGBX; }},
-        {"syncFullscreen", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.syncFullscreen; }},
+        {"syncfullscreen", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.syncFullscreen; }},
         {"immediate", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.tearing; }},
         {"xray", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.xray; }},
     };

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -239,8 +239,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
     "xwayland": {},
     "pinned": {},
     "fullscreen": {},
-    "fullscreenMode": {},
-    "fakeFullscreen": {},
+    "fullscreenClient": {},
     "grouped": [{}],
     "tags": [{}],
     "swallowing": "0x{:x}",
@@ -251,19 +250,19 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             escapeJSONStrings(!w->m_pWorkspace ? "" : w->m_pWorkspace->m_szName), ((int)w->m_bIsFloating == 1 ? "true" : "false"), (w->m_bIsPseudotiled ? "true" : "false"),
             (int64_t)w->m_iMonitorID, escapeJSONStrings(w->m_szClass), escapeJSONStrings(w->m_szTitle), escapeJSONStrings(w->m_szInitialClass),
             escapeJSONStrings(w->m_szInitialTitle), w->getPID(), ((int)w->m_bIsX11 == 1 ? "true" : "false"), (w->m_bPinned ? "true" : "false"),
-            (w->isFullscreen() ? "true" : "false"), (w->isFullscreen() ? (w->m_pWorkspace ? (int)w->m_pWorkspace->m_efFullscreenMode : 0) : 0),
-            w->m_bFakeFullscreenState ? "true" : "false", getGroupedData(w, format), getTagsData(w, format), (uintptr_t)w->m_pSwallowed.lock().get(), getFocusHistoryID(w));
+            (uint8_t)w->m_sFullscreenState.internal, (uint8_t)w->m_sFullscreenState.client, getGroupedData(w, format), getTagsData(w, format),
+            (uintptr_t)w->m_pSwallowed.lock().get(), getFocusHistoryID(w));
     } else {
         return std::format(
             "Window {:x} -> {}:\n\tmapped: {}\n\thidden: {}\n\tat: {},{}\n\tsize: {},{}\n\tworkspace: {} ({})\n\tfloating: {}\n\tpseudo: {}\n\tmonitor: {}\n\tclass: {}\n\ttitle: "
             "{}\n\tinitialClass: {}\n\tinitialTitle: {}\n\tpid: "
             "{}\n\txwayland: {}\n\tpinned: "
-            "{}\n\tfullscreen: {}\n\tfullscreenmode: {}\n\tfakefullscreen: {}\n\tgrouped: {}\n\ttags: {}\n\tswallowing: {:x}\n\tfocusHistoryID: {}\n\n",
+            "{}\n\tfullscreen: {}\n\tfullscreenClient: {}\n\tgrouped: {}\n\ttags: {}\n\tswallowing: {:x}\n\tfocusHistoryID: {}\n\n",
             (uintptr_t)w.get(), w->m_szTitle, (int)w->m_bIsMapped, (int)w->isHidden(), (int)w->m_vRealPosition.goal().x, (int)w->m_vRealPosition.goal().y,
             (int)w->m_vRealSize.goal().x, (int)w->m_vRealSize.goal().y, w->m_pWorkspace ? w->workspaceID() : WORKSPACE_INVALID, (!w->m_pWorkspace ? "" : w->m_pWorkspace->m_szName),
             (int)w->m_bIsFloating, (int)w->m_bIsPseudotiled, (int64_t)w->m_iMonitorID, w->m_szClass, w->m_szTitle, w->m_szInitialClass, w->m_szInitialTitle, w->getPID(),
-            (int)w->m_bIsX11, (int)w->m_bPinned, (int)w->isFullscreen(), (w->isFullscreen() ? (w->m_pWorkspace ? w->m_pWorkspace->m_efFullscreenMode : 0) : 0),
-            (int)w->m_bFakeFullscreenState, getGroupedData(w, format), getTagsData(w, format), (uintptr_t)w->m_pSwallowed.lock().get(), getFocusHistoryID(w));
+            (int)w->m_bIsX11, (int)w->m_bPinned, (uint8_t)w->m_sFullscreenState.internal, (uint8_t)w->m_sFullscreenState.client, getGroupedData(w, format), getTagsData(w, format),
+            (uintptr_t)w->m_pSwallowed.lock().get(), getFocusHistoryID(w));
     }
 }
 

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -251,7 +251,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             escapeJSONStrings(!w->m_pWorkspace ? "" : w->m_pWorkspace->m_szName), ((int)w->m_bIsFloating == 1 ? "true" : "false"), (w->m_bIsPseudotiled ? "true" : "false"),
             (int64_t)w->m_iMonitorID, escapeJSONStrings(w->m_szClass), escapeJSONStrings(w->m_szTitle), escapeJSONStrings(w->m_szInitialClass),
             escapeJSONStrings(w->m_szInitialTitle), w->getPID(), ((int)w->m_bIsX11 == 1 ? "true" : "false"), (w->m_bPinned ? "true" : "false"),
-            (w->m_bIsFullscreen ? "true" : "false"), (w->m_bIsFullscreen ? (w->m_pWorkspace ? (int)w->m_pWorkspace->m_efFullscreenMode : 0) : 0),
+            (w->isFullscreen() ? "true" : "false"), (w->isFullscreen() ? (w->m_pWorkspace ? (int)w->m_pWorkspace->m_efFullscreenMode : 0) : 0),
             w->m_bFakeFullscreenState ? "true" : "false", getGroupedData(w, format), getTagsData(w, format), (uintptr_t)w->m_pSwallowed.lock().get(), getFocusHistoryID(w));
     } else {
         return std::format(
@@ -262,7 +262,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             (uintptr_t)w.get(), w->m_szTitle, (int)w->m_bIsMapped, (int)w->isHidden(), (int)w->m_vRealPosition.goal().x, (int)w->m_vRealPosition.goal().y,
             (int)w->m_vRealSize.goal().x, (int)w->m_vRealSize.goal().y, w->m_pWorkspace ? w->workspaceID() : WORKSPACE_INVALID, (!w->m_pWorkspace ? "" : w->m_pWorkspace->m_szName),
             (int)w->m_bIsFloating, (int)w->m_bIsPseudotiled, (int64_t)w->m_iMonitorID, w->m_szClass, w->m_szTitle, w->m_szInitialClass, w->m_szInitialTitle, w->getPID(),
-            (int)w->m_bIsX11, (int)w->m_bPinned, (int)w->m_bIsFullscreen, (w->m_bIsFullscreen ? (w->m_pWorkspace ? w->m_pWorkspace->m_efFullscreenMode : 0) : 0),
+            (int)w->m_bIsX11, (int)w->m_bPinned, (int)w->isFullscreen(), (w->isFullscreen() ? (w->m_pWorkspace ? w->m_pWorkspace->m_efFullscreenMode : 0) : 0),
             (int)w->m_bFakeFullscreenState, getGroupedData(w, format), getTagsData(w, format), (uintptr_t)w->m_pSwallowed.lock().get(), getFocusHistoryID(w));
     }
 }

--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -165,7 +165,7 @@ void CLayerSurface::onMap() {
     CBox geomFixed = {geometry.x + PMONITOR->vecPosition.x, geometry.y + PMONITOR->vecPosition.y, geometry.width, geometry.height};
     g_pHyprRenderer->damageBox(&geomFixed);
     const auto WORKSPACE  = PMONITOR->activeWorkspace;
-    const bool FULLSCREEN = WORKSPACE->m_bHasFullscreenWindow && WORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL;
+    const bool FULLSCREEN = WORKSPACE->m_bHasFullscreenWindow && WORKSPACE->m_efFullscreenMode == FSMODE_FULLSCREEN;
 
     startAnimation(!(layer == ZWLR_LAYER_SHELL_V1_LAYER_TOP && FULLSCREEN && !GRABSFOCUS));
     readyToDelete = false;

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -211,8 +211,8 @@ struct SInitialWorkspaceToken {
 };
 
 struct sFullscreenState {
-    eFullscreenMode internal;
-    eFullscreenMode client;
+    eFullscreenMode internal = FSMODE_NONE;
+    eFullscreenMode client   = FSMODE_NONE;
 };
 
 class CWindow {

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -265,17 +265,16 @@ class CWindow {
     // for recovering relative cursor position
     Vector2D         m_vRelativeCursorCoordsOnLastWarp = Vector2D(-1, -1);
 
-    bool             m_bFirstMap           = false; // for layouts
-    bool             m_bIsFloating         = false;
-    bool             m_bDraggingTiled      = false; // for dragging around tiled windows
-    bool             m_bDontSendFullscreen = false;
-    bool             m_bWasMaximized       = false;
-    sFullscreenState m_sFullscreenState    = {.internal = FSMODE_NONE, .client = FSMODE_NONE};
-    uint64_t         m_iMonitorID          = -1;
-    std::string      m_szTitle             = "";
-    std::string      m_szClass             = "";
-    std::string      m_szInitialTitle      = "";
-    std::string      m_szInitialClass      = "";
+    bool             m_bFirstMap        = false; // for layouts
+    bool             m_bIsFloating      = false;
+    bool             m_bDraggingTiled   = false; // for dragging around tiled windows
+    bool             m_bWasMaximized    = false;
+    sFullscreenState m_sFullscreenState = {.internal = FSMODE_NONE, .client = FSMODE_NONE};
+    uint64_t         m_iMonitorID       = -1;
+    std::string      m_szTitle          = "";
+    std::string      m_szClass          = "";
+    std::string      m_szInitialTitle   = "";
+    std::string      m_szInitialClass   = "";
     PHLWORKSPACE     m_pWorkspace;
 
     bool             m_bIsMapped = false;
@@ -328,9 +327,6 @@ class CWindow {
 
     // urgency hint
     bool m_bIsUrgent = false;
-
-    // fakefullscreen
-    bool m_bFakeFullscreenState = false;
 
     // for proper cycling. While cycling we can't just move the pointers, so we need to keep track of the last cycled window.
     PHLWINDOWREF m_pLastCycledWindow;

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -16,6 +16,7 @@
 #include "Popup.hpp"
 #include "Subsurface.hpp"
 #include "WLSurface.hpp"
+#include "Workspace.hpp"
 
 class CXDGSurfaceResource;
 class CXWaylandSurface;
@@ -170,6 +171,7 @@ struct SWindowData {
     CWindowOverridableVar<bool>               noShortcutsInhibit = false;
     CWindowOverridableVar<bool>               opaque             = false;
     CWindowOverridableVar<bool>               RGBX               = false;
+    CWindowOverridableVar<bool>               syncFullscreen     = true;
     CWindowOverridableVar<bool>               tearing            = false;
     CWindowOverridableVar<bool>               xray               = false;
 
@@ -206,6 +208,11 @@ struct SWindowRule {
 struct SInitialWorkspaceToken {
     PHLWINDOWREF primaryOwner;
     std::string  workspace;
+};
+
+struct sFullscreenState {
+    eFullscreenMode internal;
+    eFullscreenMode client;
 };
 
 class CWindow {
@@ -256,24 +263,24 @@ class CWindow {
     Vector2D m_vPseudoSize    = Vector2D(1280, 720);
 
     // for recovering relative cursor position
-    Vector2D     m_vRelativeCursorCoordsOnLastWarp = Vector2D(-1, -1);
+    Vector2D         m_vRelativeCursorCoordsOnLastWarp = Vector2D(-1, -1);
 
-    bool         m_bFirstMap           = false; // for layouts
-    bool         m_bIsFloating         = false;
-    bool         m_bDraggingTiled      = false; // for dragging around tiled windows
-    bool         m_bIsFullscreen       = false;
-    bool         m_bDontSendFullscreen = false;
-    bool         m_bWasMaximized       = false;
-    uint64_t     m_iMonitorID          = -1;
-    std::string  m_szTitle             = "";
-    std::string  m_szClass             = "";
-    std::string  m_szInitialTitle      = "";
-    std::string  m_szInitialClass      = "";
-    PHLWORKSPACE m_pWorkspace;
+    bool             m_bFirstMap           = false; // for layouts
+    bool             m_bIsFloating         = false;
+    bool             m_bDraggingTiled      = false; // for dragging around tiled windows
+    bool             m_bDontSendFullscreen = false;
+    bool             m_bWasMaximized       = false;
+    sFullscreenState m_sFullscreenState    = {.internal = FSMODE_NONE, .client = FSMODE_NONE};
+    uint64_t         m_iMonitorID          = -1;
+    std::string      m_szTitle             = "";
+    std::string      m_szClass             = "";
+    std::string      m_szInitialTitle      = "";
+    std::string      m_szInitialClass      = "";
+    PHLWORKSPACE     m_pWorkspace;
 
-    bool         m_bIsMapped = false;
+    bool             m_bIsMapped = false;
 
-    bool         m_bRequestsFloat = false;
+    bool             m_bRequestsFloat = false;
 
     // This is for fullscreen apps
     bool m_bCreatedOverFullscreen = false;
@@ -416,13 +423,15 @@ class CWindow {
     bool                   opaque();
     float                  rounding();
     bool                   canBeTorn();
-    bool                   shouldSendFullscreenState();
     void                   setSuspended(bool suspend);
     bool                   visibleOnMonitor(CMonitor* pMonitor);
     int                    workspaceID();
     bool                   onSpecialWorkspace();
     void                   activate(bool force = false);
     int                    surfacesCount();
+
+    bool                   isFullscreen();
+    bool                   isEffectiveInternalFSMode(const eFullscreenMode);
 
     int                    getRealBorderSize();
     void                   updateWindowData();

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -480,15 +480,15 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
                             return false;
                         break;
                     case 0: // fullscreen full
-                        if (!m_bHasFullscreenWindow || m_efFullscreenMode != FULLSCREEN_FULL)
+                        if (!m_bHasFullscreenWindow || m_efFullscreenMode != FSMODE_FULLSCREEN)
                             return false;
                         break;
                     case 1: // maximized
-                        if (!m_bHasFullscreenWindow || m_efFullscreenMode != FULLSCREEN_MAXIMIZED)
+                        if (!m_bHasFullscreenWindow || m_efFullscreenMode != FSMODE_FULLSCREEN)
                             return false;
                         break;
                     case 2: // fullscreen without sending fullscreen state to window
-                        if (!m_bHasFullscreenWindow || m_efFullscreenMode != FULLSCREEN_FULL || !g_pCompositor->getFullscreenWindowOnWorkspace(m_iID) ||
+                        if (!m_bHasFullscreenWindow || m_efFullscreenMode != FSMODE_FULLSCREEN || !g_pCompositor->getFullscreenWindowOnWorkspace(m_iID) ||
                             !g_pCompositor->getFullscreenWindowOnWorkspace(m_iID)->m_bDontSendFullscreen)
                             return false;
                         break;

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -484,7 +484,7 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
                             return false;
                         break;
                     case 1: // maximized
-                        if (!m_bHasFullscreenWindow || m_efFullscreenMode != FSMODE_FULLSCREEN)
+                        if (!m_bHasFullscreenWindow || m_efFullscreenMode != FSMODE_MAXIMIZED)
                             return false;
                         break;
                     default: break;

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -487,11 +487,6 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
                         if (!m_bHasFullscreenWindow || m_efFullscreenMode != FSMODE_FULLSCREEN)
                             return false;
                         break;
-                    case 2: // fullscreen without sending fullscreen state to window
-                        if (!m_bHasFullscreenWindow || m_efFullscreenMode != FSMODE_FULLSCREEN || !g_pCompositor->getFullscreenWindowOnWorkspace(m_iID) ||
-                            !g_pCompositor->getFullscreenWindowOnWorkspace(m_iID)->m_bDontSendFullscreen)
-                            return false;
-                        break;
                     default: break;
                 }
                 continue;

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -7,9 +7,10 @@
 #include "../helpers/MiscFunctions.hpp"
 
 enum eFullscreenMode : int8_t {
-    FULLSCREEN_INVALID = -1,
-    FULLSCREEN_FULL    = 0,
-    FULLSCREEN_MAXIMIZED
+    FSMODE_NONE       = 0,
+    FSMODE_MAXIMIZED  = 1 << 0,
+    FSMODE_FULLSCREEN = 1 << 1,
+    FSMODE_MAX        = (1 << 2) - 1
 };
 
 class CWindow;
@@ -31,7 +32,7 @@ class CWorkspace {
     SWorkspaceIDName m_sPrevWorkspace, m_sPrevWorkspacePerMonitor;
 
     bool             m_bHasFullscreenWindow = false;
-    eFullscreenMode  m_efFullscreenMode     = FULLSCREEN_FULL;
+    eFullscreenMode  m_efFullscreenMode     = FSMODE_NONE;
 
     wl_array         m_wlrCoordinateArr;
 

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -354,7 +354,7 @@ bool CMonitor::shouldSkipScheduleFrameOnMouseEvent() {
 
     // skip scheduling extra frames for fullsreen apps with vrr
     bool shouldSkip =
-        *PNOBREAK && output->state->state().adaptiveSync && activeWorkspace && activeWorkspace->m_bHasFullscreenWindow && activeWorkspace->m_efFullscreenMode == FULLSCREEN_FULL;
+        *PNOBREAK && output->state->state().adaptiveSync && activeWorkspace && activeWorkspace->m_bHasFullscreenWindow && activeWorkspace->m_efFullscreenMode == FSMODE_FULLSCREEN;
 
     // keep requested minimum refresh rate
     if (shouldSkip && *PMINRR && lastPresentationTimer.getMillis() > 1000 / *PMINRR) {

--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -52,7 +52,7 @@ class CHyprDwindleLayout : public IHyprLayout {
     virtual void                     recalculateWindow(PHLWINDOW);
     virtual void                     onBeginDragWindow();
     virtual void                     resizeActiveWindow(const Vector2D&, eRectCorner corner = CORNER_NONE, PHLWINDOW pWindow = nullptr);
-    virtual void                     fullscreenRequestForWindow(PHLWINDOW, eFullscreenMode, bool);
+    virtual void                     fullscreenRequestForWindow(PHLWINDOW pWindow, const eFullscreenMode CURRENT_EFFECTIVE_MODE, const eFullscreenMode EFFECTIVE_MODE);
     virtual std::any                 layoutMessage(SLayoutMessageHeader, std::string);
     virtual SWindowRenderLayoutHints requestRenderHints(PHLWINDOW);
     virtual void                     switchWindows(PHLWINDOW, PHLWINDOW);

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -29,8 +29,8 @@ void IHyprLayout::onWindowCreated(PHLWINDOW pWindow, eDirection direction) {
 }
 
 void IHyprLayout::onWindowRemoved(PHLWINDOW pWindow) {
-    if (pWindow->m_bIsFullscreen)
-        g_pCompositor->setWindowFullscreen(pWindow, false, FULLSCREEN_FULL);
+    if (pWindow->isFullscreen())
+        g_pCompositor->setWindowFullscreenInternal(pWindow, FSMODE_NONE);
 
     if (!pWindow->m_sGroupData.pNextWindow.expired()) {
         if (pWindow->m_sGroupData.pNextWindow.lock() == pWindow)
@@ -191,9 +191,9 @@ void IHyprLayout::onBeginDragWindow() {
         return;
     }
 
-    if (DRAGGINGWINDOW->m_bIsFullscreen) {
+    if (DRAGGINGWINDOW->isFullscreen()) {
         Debug::log(LOG, "Dragging a fullscreen window");
-        g_pCompositor->setWindowFullscreen(DRAGGINGWINDOW, false, FULLSCREEN_FULL);
+        g_pCompositor->setWindowFullscreenInternal(DRAGGINGWINDOW, FSMODE_NONE);
     }
 
     const auto PWORKSPACE = DRAGGINGWINDOW->m_pWorkspace;
@@ -475,9 +475,9 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
 
 void IHyprLayout::changeWindowFloatingMode(PHLWINDOW pWindow) {
 
-    if (pWindow->m_bIsFullscreen) {
+    if (pWindow->isFullscreen()) {
         Debug::log(LOG, "changeWindowFloatingMode: fullscreen");
-        g_pCompositor->setWindowFullscreen(pWindow, false, FULLSCREEN_FULL);
+        g_pCompositor->setWindowFullscreenInternal(pWindow, FSMODE_NONE);
     }
 
     pWindow->m_bPinned = false;
@@ -497,7 +497,7 @@ void IHyprLayout::changeWindowFloatingMode(PHLWINDOW pWindow) {
         const auto PWORKSPACE = PNEWMON->activeSpecialWorkspace ? PNEWMON->activeSpecialWorkspace : PNEWMON->activeWorkspace;
 
         if (PWORKSPACE->m_bHasFullscreenWindow)
-            g_pCompositor->setWindowFullscreen(g_pCompositor->getFullscreenWindowOnWorkspace(PWORKSPACE->m_iID), false);
+            g_pCompositor->setWindowFullscreenInternal(g_pCompositor->getFullscreenWindowOnWorkspace(PWORKSPACE->m_iID), FSMODE_NONE);
 
         // save real pos cuz the func applies the default 5,5 mid
         const auto PSAVEDPOS  = pWindow->m_vRealPosition.goal();

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -110,7 +110,7 @@ class IHyprLayout {
         The layout sets all the fullscreen flags.
         It can either accept or ignore.
     */
-    virtual void fullscreenRequestForWindow(PHLWINDOW, eFullscreenMode, bool) = 0;
+    virtual void fullscreenRequestForWindow(PHLWINDOW pWindow, const eFullscreenMode CURRENT_EFFECTIVE_MODE, const eFullscreenMode EFFECTIVE_MODE) = 0;
 
     /*
         Called when a dispatcher requests a custom message

--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -58,7 +58,7 @@ class CHyprMasterLayout : public IHyprLayout {
     virtual void                     recalculateMonitor(const int&);
     virtual void                     recalculateWindow(PHLWINDOW);
     virtual void                     resizeActiveWindow(const Vector2D&, eRectCorner corner = CORNER_NONE, PHLWINDOW pWindow = nullptr);
-    virtual void                     fullscreenRequestForWindow(PHLWINDOW, eFullscreenMode, bool);
+    virtual void                     fullscreenRequestForWindow(PHLWINDOW pWindow, const eFullscreenMode CURRENT_EFFECTIVE_MODE, const eFullscreenMode EFFECTIVE_MODE);
     virtual std::any                 layoutMessage(SLayoutMessageHeader, std::string);
     virtual SWindowRenderLayoutHints requestRenderHints(PHLWINDOW);
     virtual void                     switchWindows(PHLWINDOW, PHLWINDOW);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1150,7 +1150,7 @@ void CKeybindManager::fullscreenActive(std::string args) {
 
     const eFullscreenMode MODE = args == "1" ? FSMODE_MAXIMIZED : FSMODE_FULLSCREEN;
 
-    if (PWINDOW->m_sFullscreenState.internal == MODE)
+    if (PWINDOW->isEffectiveInternalFSMode(MODE))
         g_pCompositor->setWindowFullscreenInternal(PWINDOW, FSMODE_NONE);
     else
         g_pCompositor->setWindowFullscreenInternal(PWINDOW, MODE);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -67,7 +67,7 @@ CKeybindManager::CKeybindManager() {
     m_mDispatchers["workspace"]                      = changeworkspace;
     m_mDispatchers["renameworkspace"]                = renameWorkspace;
     m_mDispatchers["fullscreen"]                     = fullscreenActive;
-    m_mDispatchers["fakefullscreen"]                 = fakeFullscreenActive;
+    m_mDispatchers["fullscreenstate"]                = fullscreenStateActive;
     m_mDispatchers["movetoworkspace"]                = moveActiveToWorkspace;
     m_mDispatchers["movetoworkspacesilent"]          = moveActiveToWorkspaceSilent;
     m_mDispatchers["pseudo"]                         = toggleActivePseudo;
@@ -318,17 +318,17 @@ void CKeybindManager::switchToWindow(PHLWINDOW PWINDOWTOCHANGETO) {
     // remove constraints
     g_pInputManager->unconstrainMouse();
 
-    if (PLASTWINDOW && PLASTWINDOW->m_pWorkspace == PWINDOWTOCHANGETO->m_pWorkspace && PLASTWINDOW->m_bIsFullscreen) {
+    if (PLASTWINDOW && PLASTWINDOW->m_pWorkspace == PWINDOWTOCHANGETO->m_pWorkspace && PLASTWINDOW->isFullscreen()) {
         const auto PWORKSPACE = PLASTWINDOW->m_pWorkspace;
-        const auto FSMODE     = PWORKSPACE->m_efFullscreenMode;
+        const auto MODE       = PWORKSPACE->m_efFullscreenMode;
 
         if (!PWINDOWTOCHANGETO->m_bPinned)
-            g_pCompositor->setWindowFullscreen(PLASTWINDOW, false, FULLSCREEN_FULL);
+            g_pCompositor->setWindowFullscreenInternal(PLASTWINDOW, FSMODE_NONE);
 
         g_pCompositor->focusWindow(PWINDOWTOCHANGETO);
 
         if (!PWINDOWTOCHANGETO->m_bPinned)
-            g_pCompositor->setWindowFullscreen(PWINDOWTOCHANGETO, true, FSMODE);
+            g_pCompositor->setWindowFullscreenInternal(PWINDOWTOCHANGETO, MODE);
     } else {
         updateRelativeCursorCoords();
         g_pCompositor->focusWindow(PWINDOWTOCHANGETO);
@@ -995,7 +995,7 @@ void CKeybindManager::setActiveTiled(std::string args) {
 void CKeybindManager::centerWindow(std::string args) {
     const auto PWINDOW = g_pCompositor->m_pLastWindow.lock();
 
-    if (!PWINDOW || !PWINDOW->m_bIsFloating || PWINDOW->m_bIsFullscreen)
+    if (!PWINDOW || !PWINDOW->m_bIsFloating || PWINDOW->isFullscreen())
         return;
 
     const auto PMONITOR = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID);
@@ -1021,7 +1021,7 @@ void CKeybindManager::toggleActivePseudo(std::string args) {
 
     PWINDOW->m_bIsPseudotiled = !PWINDOW->m_bIsPseudotiled;
 
-    if (!PWINDOW->m_bIsFullscreen)
+    if (!PWINDOW->isFullscreen())
         g_pLayoutManager->getCurrentLayout()->recalculateWindow(PWINDOW);
 }
 
@@ -1148,10 +1148,34 @@ void CKeybindManager::fullscreenActive(std::string args) {
     if (!PWINDOW)
         return;
 
-    PWINDOW->m_bDontSendFullscreen = false;
-    if (args == "2")
-        PWINDOW->m_bDontSendFullscreen = true;
-    g_pCompositor->setWindowFullscreen(PWINDOW, !PWINDOW->m_bIsFullscreen, args == "1" ? FULLSCREEN_MAXIMIZED : FULLSCREEN_FULL);
+    const eFullscreenMode MODE = args == "1" ? FSMODE_MAXIMIZED : FSMODE_FULLSCREEN;
+
+    if (PWINDOW->m_sFullscreenState.internal == MODE)
+        g_pCompositor->setWindowFullscreenInternal(PWINDOW, FSMODE_NONE);
+    else
+        g_pCompositor->setWindowFullscreenInternal(PWINDOW, MODE);
+}
+
+void CKeybindManager::fullscreenStateActive(std::string args) {
+    const auto PWINDOW = g_pCompositor->m_pLastWindow.lock();
+    const auto ARGS    = CVarList(args, 2, ' ');
+
+    if (!PWINDOW)
+        return;
+
+    PWINDOW->m_sWindowData.syncFullscreen = CWindowOverridableVar(false, PRIORITY_SET_PROP);
+
+    int internalMode, clientMode;
+    try {
+        internalMode = std::stoi(ARGS[0]);
+    } catch (std::exception& e) { internalMode = -1; }
+    try {
+        clientMode = std::stoi(ARGS[1]);
+    } catch (std::exception& e) { clientMode = -1; }
+
+    g_pCompositor->setWindowFullscreenState(PWINDOW,
+                                            sFullscreenState{.internal = (internalMode != -1 ? (eFullscreenMode)internalMode : PWINDOW->m_sFullscreenState.internal),
+                                                             .client   = (clientMode != -1 ? (eFullscreenMode)clientMode : PWINDOW->m_sFullscreenState.client)});
 }
 
 void CKeybindManager::moveActiveToWorkspace(std::string args) {
@@ -1276,7 +1300,7 @@ void CKeybindManager::moveFocusTo(std::string args) {
         return;
     }
 
-    const auto PWINDOWTOCHANGETO = *PFULLCYCLE && PLASTWINDOW->m_bIsFullscreen ?
+    const auto PWINDOWTOCHANGETO = *PFULLCYCLE && PLASTWINDOW->isFullscreen() ?
         (arg == 'd' || arg == 'b' || arg == 'r' ? g_pCompositor->getNextWindowOnWorkspace(PLASTWINDOW, true) : g_pCompositor->getPrevWindowOnWorkspace(PLASTWINDOW, true)) :
         g_pCompositor->getWindowInDirection(PLASTWINDOW, arg);
 
@@ -1333,7 +1357,7 @@ void CKeybindManager::swapActive(std::string args) {
 
     Debug::log(LOG, "Swapping active window in direction {}", arg);
     const auto PLASTWINDOW = g_pCompositor->m_pLastWindow.lock();
-    if (!PLASTWINDOW || PLASTWINDOW->m_bIsFullscreen)
+    if (!PLASTWINDOW || PLASTWINDOW->isFullscreen())
         return;
 
     const auto PWINDOWTOCHANGETO = g_pCompositor->getWindowInDirection(PLASTWINDOW, arg);
@@ -1371,7 +1395,7 @@ void CKeybindManager::moveActiveTo(std::string args) {
 
     const auto PLASTWINDOW = g_pCompositor->m_pLastWindow.lock();
 
-    if (!PLASTWINDOW || PLASTWINDOW->m_bIsFullscreen)
+    if (!PLASTWINDOW || PLASTWINDOW->isFullscreen())
         return;
 
     if (PLASTWINDOW->m_bIsFloating) {
@@ -1426,7 +1450,8 @@ void CKeybindManager::toggleGroup(std::string args) {
     if (!PWINDOW)
         return;
 
-    g_pCompositor->setWindowFullscreen(PWINDOW, false, FULLSCREEN_FULL);
+    if (PWINDOW->isFullscreen())
+        g_pCompositor->setWindowFullscreenInternal(PWINDOW, FSMODE_NONE);
 
     if (PWINDOW->m_sGroupData.pNextWindow.expired())
         PWINDOW->createGroup();
@@ -1818,7 +1843,7 @@ void CKeybindManager::forceRendererReload(std::string args) {
 void CKeybindManager::resizeActive(std::string args) {
     const auto PLASTWINDOW = g_pCompositor->m_pLastWindow.lock();
 
-    if (!PLASTWINDOW || PLASTWINDOW->m_bIsFullscreen)
+    if (!PLASTWINDOW || PLASTWINDOW->isFullscreen())
         return;
 
     const auto SIZ = g_pCompositor->parseWindowVectorArgsRelative(args, PLASTWINDOW->m_vRealSize.goal());
@@ -1835,7 +1860,7 @@ void CKeybindManager::resizeActive(std::string args) {
 void CKeybindManager::moveActive(std::string args) {
     const auto PLASTWINDOW = g_pCompositor->m_pLastWindow.lock();
 
-    if (!PLASTWINDOW || PLASTWINDOW->m_bIsFullscreen)
+    if (!PLASTWINDOW || PLASTWINDOW->isFullscreen())
         return;
 
     const auto POS = g_pCompositor->parseWindowVectorArgsRelative(args, PLASTWINDOW->m_vRealPosition.goal());
@@ -1855,7 +1880,7 @@ void CKeybindManager::moveWindow(std::string args) {
         return;
     }
 
-    if (PWINDOW->m_bIsFullscreen)
+    if (PWINDOW->isFullscreen())
         return;
 
     const auto POS = g_pCompositor->parseWindowVectorArgsRelative(MOVECMD, PWINDOW->m_vRealPosition.goal());
@@ -1875,7 +1900,7 @@ void CKeybindManager::resizeWindow(std::string args) {
         return;
     }
 
-    if (PWINDOW->m_bIsFullscreen)
+    if (PWINDOW->isFullscreen())
         return;
 
     const auto SIZ = g_pCompositor->parseWindowVectorArgsRelative(MOVECMD, PWINDOW->m_vRealSize.goal());
@@ -1952,12 +1977,12 @@ void CKeybindManager::focusWindow(std::string regexp) {
             g_pCompositor->focusWindow(PWINDOW);
         } else {
             if (FSWINDOW != PWINDOW && !PWINDOW->m_bPinned)
-                g_pCompositor->setWindowFullscreen(FSWINDOW, false, FULLSCREEN_FULL);
+                g_pCompositor->setWindowFullscreenClient(FSWINDOW, FSMODE_NONE);
 
             g_pCompositor->focusWindow(PWINDOW);
 
             if (FSWINDOW != PWINDOW && !PWINDOW->m_bPinned)
-                g_pCompositor->setWindowFullscreen(PWINDOW, true, FSMODE);
+                g_pCompositor->setWindowFullscreenClient(PWINDOW, FSMODE);
         }
     } else
         g_pCompositor->focusWindow(PWINDOW);
@@ -2329,7 +2354,7 @@ void CKeybindManager::pinActive(std::string args) {
         return;
     }
 
-    if (!PWINDOW->m_bIsFloating || PWINDOW->m_bIsFullscreen)
+    if (!PWINDOW->m_bIsFloating || PWINDOW->isFullscreen())
         return;
 
     PWINDOW->m_bPinned    = !PWINDOW->m_bPinned;
@@ -2379,7 +2404,7 @@ void CKeybindManager::changeMouseBindMode(const eMouseBindMode MODE) {
         if (!PWINDOW)
             return;
 
-        if (!PWINDOW->m_bIsFullscreen && MODE == MBIND_MOVE)
+        if (!PWINDOW->isFullscreen() && MODE == MBIND_MOVE)
             PWINDOW->checkInputOnDecos(INPUT_TYPE_DRAG_START, MOUSECOORDS);
 
         if (g_pInputManager->currentlyDraggedWindow.expired())
@@ -2425,14 +2450,6 @@ void CKeybindManager::alterZOrder(std::string args) {
     }
 
     g_pInputManager->simulateMouseMovement();
-}
-
-void CKeybindManager::fakeFullscreenActive(std::string args) {
-    if (!g_pCompositor->m_pLastWindow.expired()) {
-        // will also set the flag
-        g_pCompositor->m_pLastWindow->m_bFakeFullscreenState = !g_pCompositor->m_pLastWindow->m_bFakeFullscreenState;
-        g_pXWaylandManager->setWindowFullscreen(g_pCompositor->m_pLastWindow.lock(), g_pCompositor->m_pLastWindow->shouldSendFullscreenState());
-    }
 }
 
 void CKeybindManager::lockGroups(std::string args) {
@@ -2594,7 +2611,7 @@ void CKeybindManager::moveWindowOrGroup(std::string args) {
     }
 
     const auto PWINDOW = g_pCompositor->m_pLastWindow.lock();
-    if (!PWINDOW || PWINDOW->m_bIsFullscreen)
+    if (!PWINDOW || PWINDOW->isFullscreen())
         return;
 
     if (!*PIGNOREGROUPLOCK && g_pKeybindManager->m_bGroupsLocked) {

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -155,7 +155,7 @@ class CKeybindManager {
     static void     setActiveTiled(std::string);
     static void     changeworkspace(std::string);
     static void     fullscreenActive(std::string);
-    static void     fakeFullscreenActive(std::string);
+    static void     fullscreenStateActive(std::string args);
     static void     moveActiveToWorkspace(std::string);
     static void     moveActiveToWorkspaceSilent(std::string);
     static void     moveFocusTo(std::string);

--- a/src/managers/input/IdleInhibitor.cpp
+++ b/src/managers/input/IdleInhibitor.cpp
@@ -63,7 +63,7 @@ void CInputManager::recheckIdleInhibitorStatus() {
             return;
         }
 
-        if (w->m_eIdleInhibitMode == IDLEINHIBIT_FULLSCREEN && w->m_bIsFullscreen && g_pCompositor->isWorkspaceVisible(w->m_pWorkspace)) {
+        if (w->m_eIdleInhibitMode == IDLEINHIBIT_FULLSCREEN && w->isFullscreen() && g_pCompositor->isWorkspaceVisible(w->m_pWorkspace)) {
             PROTO::idle->setInhibit(true);
             return;
         }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -298,7 +298,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
 
     // then, we check if the workspace doesnt have a fullscreen window
     const auto PWORKSPACE = PMONITOR->activeWorkspace;
-    if (PWORKSPACE->m_bHasFullscreenWindow && !foundSurface && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL) {
+    if (PWORKSPACE->m_bHasFullscreenWindow && !foundSurface && PWORKSPACE->m_efFullscreenMode == FSMODE_FULLSCREEN) {
         pFoundWindow = g_pCompositor->getFullscreenWindowOnWorkspace(PWORKSPACE->m_iID);
 
         if (!pFoundWindow) {
@@ -325,7 +325,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
 
     // then windows
     if (!foundSurface) {
-        if (PWORKSPACE->m_bHasFullscreenWindow && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_MAXIMIZED) {
+        if (PWORKSPACE->m_bHasFullscreenWindow && PWORKSPACE->m_efFullscreenMode == FSMODE_MAXIMIZED) {
             if (!foundSurface) {
                 if (PMONITOR->activeSpecialWorkspace) {
                     pFoundWindow = g_pCompositor->vectorToWindowUnified(mouseCoords, RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING);
@@ -470,7 +470,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
     else if (pFoundWindow) {
         // change cursor icon if hovering over border
         if (*PRESIZEONBORDER && *PRESIZECURSORICON) {
-            if (!pFoundWindow->m_bIsFullscreen && !pFoundWindow->hasPopupAt(mouseCoords)) {
+            if (!pFoundWindow->isFullscreen() && !pFoundWindow->hasPopupAt(mouseCoords)) {
                 setCursorIconOnBorder(pFoundWindow);
             } else if (m_eBorderIconDirection != BORDERICON_NONE) {
                 unsetCursorImage();
@@ -681,7 +681,7 @@ void CInputManager::processMouseDownNormal(const IPointer::SButtonEvent& e) {
     // clicking on border triggers resize
     // TODO detect click on LS properly
     if (*PRESIZEONBORDER && !m_bLastFocusOnLS && e.state == WL_POINTER_BUTTON_STATE_PRESSED && (!w || w->m_iX11Type != 2)) {
-        if (w && !w->m_bIsFullscreen) {
+        if (w && !w->isFullscreen()) {
             const CBox real = {w->m_vRealPosition.value().x, w->m_vRealPosition.value().y, w->m_vRealSize.value().x, w->m_vRealSize.value().y};
             const CBox grab = {real.x - BORDER_GRAB_AREA, real.y - BORDER_GRAB_AREA, real.width + 2 * BORDER_GRAB_AREA, real.height + 2 * BORDER_GRAB_AREA};
 

--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -194,7 +194,7 @@ void CInputManager::endWorkspaceSwipe() {
 
     // apply alpha
     for (auto& ls : g_pCompositor->m_pLastMonitor->m_aLayerSurfaceLayers[2]) {
-        ls->alpha = pSwitchedTo->m_bHasFullscreenWindow && pSwitchedTo->m_efFullscreenMode == FULLSCREEN_FULL ? 0.f : 1.f;
+        ls->alpha = pSwitchedTo->m_bHasFullscreenWindow && pSwitchedTo->m_efFullscreenMode == FSMODE_FULLSCREEN? 0.f : 1.f;
     }
 }
 

--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -194,7 +194,7 @@ void CInputManager::endWorkspaceSwipe() {
 
     // apply alpha
     for (auto& ls : g_pCompositor->m_pLastMonitor->m_aLayerSurfaceLayers[2]) {
-        ls->alpha = pSwitchedTo->m_bHasFullscreenWindow && pSwitchedTo->m_efFullscreenMode == FSMODE_FULLSCREEN? 0.f : 1.f;
+        ls->alpha = pSwitchedTo->m_bHasFullscreenWindow && pSwitchedTo->m_efFullscreenMode == FSMODE_FULLSCREEN ? 0.f : 1.f;
     }
 }
 

--- a/src/protocols/ForeignToplevelWlr.cpp
+++ b/src/protocols/ForeignToplevelWlr.cpp
@@ -51,7 +51,7 @@ CForeignToplevelHandleWlr::CForeignToplevelHandleWlr(SP<CZwlrForeignToplevelHand
             }
         }
 
-        g_pCompositor->setWindowFullscreen(PWINDOW, true, FULLSCREEN_FULL);
+        g_pCompositor->changeWindowFullscreenModeClient(PWINDOW, FSMODE_FULLSCREEN, true);
         g_pHyprRenderer->damageWindow(PWINDOW);
     });
 
@@ -64,7 +64,7 @@ CForeignToplevelHandleWlr::CForeignToplevelHandleWlr(SP<CZwlrForeignToplevelHand
         if (PWINDOW->m_eSuppressedEvents & SUPPRESS_FULLSCREEN)
             return;
 
-        g_pCompositor->setWindowFullscreen(PWINDOW, false);
+        g_pCompositor->changeWindowFullscreenModeClient(PWINDOW, FSMODE_FULLSCREEN, false);
     });
 
     resource->setSetMaximized([this](CZwlrForeignToplevelHandleV1* p) {
@@ -81,7 +81,7 @@ CForeignToplevelHandleWlr::CForeignToplevelHandleWlr(SP<CZwlrForeignToplevelHand
             return;
         }
 
-        g_pCompositor->setWindowFullscreen(PWINDOW, true, FULLSCREEN_MAXIMIZED);
+        g_pCompositor->changeWindowFullscreenModeClient(PWINDOW, FSMODE_MAXIMIZED, true);
     });
 
     resource->setUnsetMaximized([this](CZwlrForeignToplevelHandleV1* p) {
@@ -93,7 +93,7 @@ CForeignToplevelHandleWlr::CForeignToplevelHandleWlr(SP<CZwlrForeignToplevelHand
         if (PWINDOW->m_eSuppressedEvents & SUPPRESS_MAXIMIZE)
             return;
 
-        g_pCompositor->setWindowFullscreen(PWINDOW, false);
+        g_pCompositor->changeWindowFullscreenModeClient(PWINDOW, FSMODE_MAXIMIZED, false);
     });
 
     resource->setClose([this](CZwlrForeignToplevelHandleV1* p) {
@@ -155,9 +155,9 @@ void CForeignToplevelHandleWlr::sendState() {
         *p     = ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_STATE_ACTIVATED;
     }
 
-    if (PWINDOW->m_bIsFullscreen) {
+    if (PWINDOW->isFullscreen()) {
         auto p = (uint32_t*)wl_array_add(&state, sizeof(uint32_t));
-        if (PWINDOW->m_pWorkspace->m_efFullscreenMode == FULLSCREEN_FULL)
+        if (PWINDOW->isEffectiveInternalFSMode(FSMODE_FULLSCREEN))
             *p = ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_STATE_FULLSCREEN;
         else
             *p = ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_STATE_MAXIMIZED;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -269,7 +269,7 @@ bool CHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, CMonitor* pMonitor) {
             return true;
 
         // if hidden behind fullscreen
-        if (PWINDOWWORKSPACE->m_bHasFullscreenWindow && !pWindow->m_bIsFullscreen && (!pWindow->m_bIsFloating || !pWindow->m_bCreatedOverFullscreen) &&
+        if (PWINDOWWORKSPACE->m_bHasFullscreenWindow && !pWindow->isFullscreen() && (!pWindow->m_bIsFloating || !pWindow->m_bCreatedOverFullscreen) &&
             pWindow->m_fAlpha.value() == 0)
             return false;
 
@@ -285,7 +285,7 @@ bool CHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, CMonitor* pMonitor) {
 
     // if not, check if it maybe is active on a different monitor.
     if (g_pCompositor->isWorkspaceVisible(pWindow->m_pWorkspace) && pWindow->m_bIsFloating /* tiled windows can't be multi-ws */)
-        return !pWindow->m_bIsFullscreen; // Do not draw fullscreen windows on other monitors
+        return !pWindow->isFullscreen(); // Do not draw fullscreen windows on other monitors
 
     if (pMonitor->activeSpecialWorkspace == pWindow->m_pWorkspace)
         return true;
@@ -352,7 +352,7 @@ void CHyprRenderer::renderWorkspaceWindowsFullscreen(CMonitor* pMonitor, PHLWORK
         if (w->m_fAlpha.value() == 0.f)
             continue;
 
-        if (w->m_bIsFullscreen || w->m_bIsFloating)
+        if (w->isFullscreen() || w->m_bIsFloating)
             continue;
 
         if (pWorkspace->m_bIsSpecialWorkspace != w->onSpecialWorkspace())
@@ -369,7 +369,7 @@ void CHyprRenderer::renderWorkspaceWindowsFullscreen(CMonitor* pMonitor, PHLWORK
         if (w->m_fAlpha.value() == 0.f)
             continue;
 
-        if (w->m_bIsFullscreen || !w->m_bIsFloating)
+        if (w->isFullscreen() || !w->m_bIsFloating)
             continue;
 
         if (w->m_iMonitorID == pWorkspace->m_iMonitorID && pWorkspace->m_bIsSpecialWorkspace != w->onSpecialWorkspace())
@@ -385,7 +385,7 @@ void CHyprRenderer::renderWorkspaceWindowsFullscreen(CMonitor* pMonitor, PHLWORK
     for (auto& w : g_pCompositor->m_vWindows) {
         const auto PWORKSPACE = w->m_pWorkspace;
 
-        if (w->m_pWorkspace != pWorkspace || !w->m_bIsFullscreen) {
+        if (w->m_pWorkspace != pWorkspace || !w->isFullscreen()) {
             if (!(PWORKSPACE && (PWORKSPACE->m_vRenderOffset.isBeingAnimated() || PWORKSPACE->m_fAlpha.isBeingAnimated() || PWORKSPACE->m_bForceRendering)))
                 continue;
 
@@ -393,14 +393,14 @@ void CHyprRenderer::renderWorkspaceWindowsFullscreen(CMonitor* pMonitor, PHLWORK
                 continue;
         }
 
-        if (!w->m_bIsFullscreen)
+        if (!w->isFullscreen())
             continue;
 
         if (w->m_iMonitorID == pWorkspace->m_iMonitorID && pWorkspace->m_bIsSpecialWorkspace != w->onSpecialWorkspace())
             continue;
 
         if (shouldRenderWindow(w, pMonitor))
-            renderWindow(w, pMonitor, time, pWorkspace->m_efFullscreenMode != FULLSCREEN_FULL, RENDER_PASS_ALL);
+            renderWindow(w, pMonitor, time, pWorkspace->m_efFullscreenMode != FSMODE_FULLSCREEN, RENDER_PASS_ALL);
 
         if (w->m_pWorkspace != pWorkspace)
             continue;
@@ -416,7 +416,7 @@ void CHyprRenderer::renderWorkspaceWindowsFullscreen(CMonitor* pMonitor, PHLWORK
 
     // then render windows over fullscreen.
     for (auto& w : g_pCompositor->m_vWindows) {
-        if (w->m_pWorkspace != pWorkspaceWindow->m_pWorkspace || (!w->m_bCreatedOverFullscreen && !w->m_bPinned) || (!w->m_bIsMapped && !w->m_bFadingOut) || w->m_bIsFullscreen)
+        if (w->m_pWorkspace != pWorkspaceWindow->m_pWorkspace || (!w->m_bCreatedOverFullscreen && !w->m_bPinned) || (!w->m_bIsMapped && !w->m_bFadingOut) || w->isFullscreen())
             continue;
 
         if (w->m_iMonitorID == pWorkspace->m_iMonitorID && pWorkspace->m_bIsSpecialWorkspace != w->onSpecialWorkspace())
@@ -538,10 +538,10 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, CMonitor* pMonitor, timespec
         decorate = false;
 
     renderdata.surface   = pWindow->m_pWLSurface->resource();
-    renderdata.dontRound = (pWindow->m_bIsFullscreen && PWORKSPACE->m_efFullscreenMode == FULLSCREEN_FULL) || pWindow->m_sWindowData.noRounding.valueOrDefault();
+    renderdata.dontRound = pWindow->isEffectiveInternalFSMode(FSMODE_FULLSCREEN) || pWindow->m_sWindowData.noRounding.valueOrDefault();
     renderdata.fadeAlpha = pWindow->m_fAlpha.value() * (pWindow->m_bPinned ? 1.f : PWORKSPACE->m_fAlpha.value());
     renderdata.alpha     = pWindow->m_fActiveInactiveAlpha.value();
-    renderdata.decorate  = decorate && !pWindow->m_bX11DoesntWantBorders && (!pWindow->m_bIsFullscreen || PWORKSPACE->m_efFullscreenMode != FULLSCREEN_FULL);
+    renderdata.decorate  = decorate && !pWindow->m_bX11DoesntWantBorders && !pWindow->isEffectiveInternalFSMode(FSMODE_FULLSCREEN);
     renderdata.rounding  = ignoreAllGeometry || renderdata.dontRound ? 0 : pWindow->rounding() * pMonitor->scale;
     renderdata.blur      = !ignoreAllGeometry; // if it shouldn't, it will be ignored later
     renderdata.pWindow   = pWindow;
@@ -568,7 +568,7 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, CMonitor* pMonitor, timespec
     renderdata.y += pWindow->m_vFloatingOffset.y;
 
     // if window is floating and we have a slide animation, clip it to its full bb
-    if (!ignorePosition && pWindow->m_bIsFloating && !pWindow->m_bIsFullscreen && PWORKSPACE->m_vRenderOffset.isBeingAnimated() && !pWindow->m_bPinned) {
+    if (!ignorePosition && pWindow->m_bIsFloating && !pWindow->isFullscreen() && PWORKSPACE->m_vRenderOffset.isBeingAnimated() && !pWindow->m_bPinned) {
         CRegion rg =
             pWindow->getFullWindowBoundingBox().translate(-pMonitor->vecPosition + PWORKSPACE->m_vRenderOffset.value() + pWindow->m_vFloatingOffset).scale(pMonitor->scale);
         g_pHyprOpenGL->m_RenderData.clipBox = rg.getExtents();
@@ -871,7 +871,7 @@ void CHyprRenderer::renderAllClientsForWorkspace(CMonitor* pMonitor, PHLWORKSPAC
     // if we have a fullscreen, opaque window that convers the screen, we can skip this.
     // TODO: check better with solitary after MR for tearing.
     const auto PFULLWINDOW = pWorkspace ? g_pCompositor->getFullscreenWindowOnWorkspace(pWorkspace->m_iID) : nullptr;
-    if (!pWorkspace->m_bHasFullscreenWindow || pWorkspace->m_efFullscreenMode != FULLSCREEN_FULL || !PFULLWINDOW || PFULLWINDOW->m_vRealSize.isBeingAnimated() ||
+    if (!pWorkspace->m_bHasFullscreenWindow || pWorkspace->m_efFullscreenMode != FSMODE_FULLSCREEN || !PFULLWINDOW || PFULLWINDOW->m_vRealSize.isBeingAnimated() ||
         !PFULLWINDOW->opaque() || pWorkspace->m_vRenderOffset.value() != Vector2D{} || g_pHyprOpenGL->preBlurQueued()) {
 
         if (!g_pHyprOpenGL->m_RenderData.pCurrentMonData->blurFBShouldRender)

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -464,7 +464,7 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, PHLWIND
 
 bool CHyprGroupBarDecoration::onMouseButtonOnDeco(const Vector2D& pos, const IPointer::SButtonEvent& e) {
     static auto PSTACKED = CConfigValue<Hyprlang::INT>("group:groupbar:stacked");
-    if (m_pWindow->m_bIsFullscreen && m_pWindow->m_pWorkspace->m_efFullscreenMode == FULLSCREEN_FULL)
+    if (m_pWindow->isEffectiveInternalFSMode(FSMODE_FULLSCREEN))
         return true;
 
     const float BARRELATIVEX = pos.x - assignedBoxGlobal().x;


### PR DESCRIPTION
Refactors fullscreen to:
- allow passing directly from any state to any other (e.g. maximized to fullscreen)
- allow fully separating the fullscreen mode hyprland uses and the client sees (e.g. to replace fakefullscreen)

Introduces `syncFullscreen` to allow enabling and disabling wether the internal and client's state should be the same.
Introduces new dispatcher `fullscreenState X Y` where `X` and `Y` set the internal and the client's fullscreen state respectively (`-1` to not alter, `0` for none, `1` for maximized, `2` for fullscreen, `3` for maximized and fullscreen) (using this dispatcher will set value above false).

It's ready for testing and should be fully functional, but still needs some clean up of unused stuff.

should fix #6562
closes #2662