### PR TITLE
some minor fd/socket cleanups and make logging thread safe

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -518,6 +518,8 @@ void CCompositor::cleanup() {
 
     // this frees all wayland resources, including sockets
     wl_display_destroy(m_sWLDisplay);
+
+    Debug::close();
 }
 
 void CCompositor::initManagers(eManagersInitStage stage) {

--- a/src/debug/HyprCtl.hpp
+++ b/src/debug/HyprCtl.hpp
@@ -31,6 +31,7 @@ class CHyprCtl {
 
     std::vector<SP<SHyprCtlCommand>> m_vCommands;
     wl_event_source*                 m_eventSource = nullptr;
+    std::string                      m_socketPath;
 };
 
 inline std::unique_ptr<CHyprCtl> g_pHyprCtl;

--- a/src/debug/Log.cpp
+++ b/src/debug/Log.cpp
@@ -8,6 +8,11 @@
 
 void Debug::init(const std::string& IS) {
     logFile = IS + (ISDEBUG ? "/hyprlandd.log" : "/hyprland.log");
+    logOfs.open(logFile, std::ios::out | std::ios::app);
+}
+
+void Debug::close() {
+    logOfs.close();
 }
 
 void Debug::log(LogLevel level, std::string str) {
@@ -55,11 +60,8 @@ void Debug::log(LogLevel level, std::string str) {
 
     if (!disableLogs || !**disableLogs) {
         // log to a file
-        std::ofstream ofs;
-        ofs.open(logFile, std::ios::out | std::ios::app);
-        ofs << str << "\n";
-
-        ofs.close();
+        logOfs << str << "\n";
+        logOfs.flush();
     }
 
     // log it to the stdout too.

--- a/src/helpers/BezierCurve.cpp
+++ b/src/helpers/BezierCurve.cpp
@@ -30,8 +30,10 @@ void CBezierCurve::setup(std::vector<Vector2D>* pVec) {
     const auto POINTSSIZE = m_aPointsBaked.size() * sizeof(m_aPointsBaked[0]) / 1000.f;
 
     const auto BEGINCALC = std::chrono::high_resolution_clock::now();
-    for (float i = 0.1f; i < 1.f; i += 0.1f)
+    for (int j = 1; j < 10; ++j) {
+        float i = j / 10.0f;
         getYForPoint(i);
+    }
     const auto ELAPSEDCALCAVG = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - BEGINCALC).count() / 1000.f / 10.f;
 
     Debug::log(LOG, "Created a bezier curve, baked {} points, mem usage: {:.2f}kB, time to bake: {:.2f}µs. Estimated average calc time: {:.2f}µs.", BAKEDPOINTS, POINTSSIZE,

--- a/src/managers/eventLoop/EventLoopManager.cpp
+++ b/src/managers/eventLoop/EventLoopManager.cpp
@@ -27,6 +27,8 @@ CEventLoopManager::~CEventLoopManager() {
         wl_event_source_remove(m_sWayland.eventSource);
     if (m_sIdle.eventSource)
         wl_event_source_remove(m_sIdle.eventSource);
+    if (m_sTimers.timerfd >= 0)
+        close(m_sTimers.timerfd);
 }
 
 static int timerWrite(int fd, uint32_t mask, void* data) {

--- a/src/xwayland/Server.cpp
+++ b/src/xwayland/Server.cpp
@@ -262,13 +262,16 @@ void CXWaylandServer::die() {
     if (pipeSource)
         wl_event_source_remove(pipeSource);
 
-    if (waylandFDs[0])
+    if (pipeFd >= 0)
+        close(pipeFd);
+
+    if (waylandFDs[0] >= 0)
         close(waylandFDs[0]);
-    if (waylandFDs[1])
+    if (waylandFDs[1] >= 0)
         close(waylandFDs[1]);
-    if (xwmFDs[0])
+    if (xwmFDs[0] >= 0)
         close(xwmFDs[0]);
-    if (xwmFDs[1])
+    if (xwmFDs[1] >= 0)
         close(xwmFDs[1]);
 
     // possible crash. Better to leak a bit.
@@ -364,6 +367,7 @@ bool CXWaylandServer::start() {
     }
 
     pipeSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, notify[0], WL_EVENT_READABLE, ::xwaylandReady, nullptr);
+    pipeFd     = notify[0];
 
     serverPID = fork();
     if (serverPID < 0) {

--- a/src/xwayland/Server.hpp
+++ b/src/xwayland/Server.hpp
@@ -41,6 +41,7 @@ class CXWaylandServer {
     std::array<wl_event_source*, 2> xFDReadEvents = {nullptr, nullptr};
     wl_event_source*                idleSource    = nullptr;
     wl_event_source*                pipeSource    = nullptr;
+    int                             pipeFd        = -1;
     std::array<int, 2>              xwmFDs        = {-1, -1};
     std::array<int, 2>              waylandFDs    = {-1, -1};
 


### PR DESCRIPTION
the logger change is something i kinda made apparent on my own by placing various Debug::log() in places to figure things out and suddenly i hit bad things, so make it thread safe and only open file once on start and close it on exit.

the rest is a few fd/socket leaks and closing already closed or closing -1 fd's making valgrind a bit spammy.

also change the way bezier loops over getYForPoint,

looping a float and incrementing it can cause subtle precision errors like looping 8 times or 10 times depending on how it turns out. god willing it does it right. so loop 9 iterations and get the float value from that instead