### PR TITLE
fix: dynamic rules not updating after setting fullscreen

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2316,9 +2316,10 @@ void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, sFullscreenS
     g_pEventManager->postEvent(SHyprIPCEvent{"fullscreen", std::to_string((int)EFFECTIVE_MODE != FSMODE_NONE)});
     EMIT_HOOK_EVENT("fullscreen", PWINDOW);
 
-    g_pLayoutManager->getCurrentLayout()->recalculateMonitor(PWINDOW->m_iMonitorID);
+    PWINDOW->updateDynamicRules();
     PWINDOW->updateWindowDecos();
     updateWindowAnimatedDecorationValues(PWINDOW);
+    g_pLayoutManager->getCurrentLayout()->recalculateMonitor(PWINDOW->m_iMonitorID);
 
     // make all windows on the same workspace under the fullscreen window
     for (auto& w : m_vWindows) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes window's dynamic rules not updating after changing the fullscreen state.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nope

#### Is it ready for merging, or does it need work?
Yes

