### PR TITLE
fix buffer crash with cursors

### DIFF
--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -480,14 +480,14 @@ void CWLSurfaceResource::commitPendingState() {
 }
 
 void CWLSurfaceResource::updateCursorShm() {
-    auto buf = current.buffer ? current.buffer : lastBuffer;
+    auto buf = current.buffer ? current.buffer->buffer : lastBuffer;
 
     if (!buf)
         return;
 
     // TODO: actually use damage
     auto& shmData  = CCursorSurfaceRole::cursorPixelData(self.lock());
-    auto  shmAttrs = current.buffer->buffer->shm();
+    auto  shmAttrs = buf->shm();
 
     if (!shmAttrs.success) {
         LOGM(TRACE, "updateCursorShm: ignoring, not a shm buffer");
@@ -495,7 +495,7 @@ void CWLSurfaceResource::updateCursorShm() {
     }
 
     // no need to end, shm.
-    auto [pixelData, fmt, bufLen] = current.buffer->buffer->beginDataPtr(0);
+    auto [pixelData, fmt, bufLen] = buf->beginDataPtr(0);
 
     shmData.resize(bufLen);
     memcpy(shmData.data(), pixelData, bufLen);


### PR DESCRIPTION
current buffer->buffer can turn out to be null actually check for its existence or use the lastbuffer when calling updateCursorShm()


was hitting crashes at `auto shmAttrs = current.buffer->buffer->shm();`  when running nested session, was this how its supposed to be?