### PR TITLE
sessionLock: don't sendLocked when session lock has already been destoyed

### DIFF
--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -124,7 +124,7 @@ void CSessionLockManager::onLockscreenRenderedOnMonitor(uint64_t id) {
     m_pSessionLock->m_lockedMonitors.emplace(id);
     const auto MONITORS = g_pCompositor->m_vMonitors;
     const bool LOCKED   = std::all_of(MONITORS.begin(), MONITORS.end(), [this](auto m) { return m_pSessionLock->m_lockedMonitors.contains(m->ID); });
-    if (LOCKED) {
+    if (LOCKED && m_pSessionLock->lock->good()) {
         m_pSessionLock->lock->sendLocked();
         m_pSessionLock->m_hasSentLocked = true;
     }

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -71,7 +71,8 @@ void CSessionLockManager::onNewSessionLock(SP<CSessionLock> pLock) {
             g_pHyprRenderer->damageMonitor(m.get());
     });
 
-    m_pSessionLock->listeners.destroy = pLock->events.destroyed.registerListener([](std::any data) {
+    m_pSessionLock->listeners.destroy = pLock->events.destroyed.registerListener([this](std::any data) {
+        m_pSessionLock.reset();
         g_pCompositor->focusSurface(nullptr);
 
         for (auto& m : g_pCompositor->m_vMonitors)
@@ -104,7 +105,7 @@ SSessionLockSurface* CSessionLockManager::getSessionLockSurfaceForMonitor(uint64
 // We don't want the red screen to flash.
 float CSessionLockManager::getRedScreenAlphaForMonitor(uint64_t id) {
     if (!m_pSessionLock)
-        return 0.F;
+        return 1.F;
 
     const auto& NOMAPPEDSURFACETIMER = m_pSessionLock->mMonitorsWithoutMappedSurfaceTimers.find(id);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes the following crash that can happen when the lock object is destroyed, but the session is still locked:
```
#0  0x00007fd7752767dc in __pthread_kill_implementation () from /nix/store/m71p7f0nymb19yn1dascklyya2i96jfw-glibc-2.39-52/lib/libc.so.6
#1  0x00007fd775224516 in raise () from /nix/store/m71p7f0nymb19yn1dascklyya2i96jfw-glibc-2.39-52/lib/libc.so.6
#2  0x00007fd77520c935 in abort () from /nix/store/m71p7f0nymb19yn1dascklyya2i96jfw-glibc-2.39-52/lib/libc.so.6
#3  0x00000000005e9b04 in handleUnrecoverableSignal(int) ()
#4  <signal handler called>
#5  0x00000000008aa750 in CSessionLock::sendLocked() ()
#6  0x00000000007cd21f in CSessionLockManager::onLockscreenRenderedOnMonitor(unsigned long) ()
#7  0x00000000009698d7 in CHyprRenderer::renderLockscreen(CMonitor*, timespec*, Hyprutils::Math::CBox const&) ()
#8  0x0000000000971a0c in CHyprRenderer::renderMonitor(CMonitor*) ()
```

Second commit (checking for `m_pSessionLock->lock->good()`) would fix it alone as well, but resetting `m_pSessionLock` on `destroy` seems the right thing to do and i did not find any problems with it.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

When Hyprland is in the state where no lock screen client is present but the session is locked, `m_pSessionLock` will be a `nullptr`. The code already handles that by checking `m_pSessionLock` in the relevant places.

#### Is it ready for merging, or does it need work?

Ready.

