### PR TITLE
Explicit sync fixes

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2282,7 +2282,7 @@ void CCompositor::setWindowFullscreenClient(const PHLWINDOW PWINDOW, const eFull
 }
 
 void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, sFullscreenState state) {
-    static auto PNODIRECTSCANOUT = CConfigValue<Hyprlang::INT>("misc:no_direct_scanout");
+    static auto PDIRECTSCANOUT = CConfigValue<Hyprlang::INT>("render:direct_scanout");
 
     if (!validMapped(PWINDOW) || g_pCompositor->m_bUnsafeState)
         return;
@@ -2342,7 +2342,7 @@ void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, sFullscreenS
 
     // send a scanout tranche if we are entering fullscreen, and send a regular one if we aren't.
     // ignore if DS is disabled.
-    if (!*PNODIRECTSCANOUT)
+    if (*PDIRECTSCANOUT)
         g_pHyprRenderer->setSurfaceScanoutMode(PWINDOW->m_pWLSurface->resource(), EFFECTIVE_MODE != FSMODE_NONE ? PMONITOR->self.lock() : nullptr);
 
     g_pConfigManager->ensureVRR(PMONITOR);

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -801,7 +801,7 @@ std::optional<std::string> CConfigManager::resetHLConfig() {
 
 void CConfigManager::postConfigReload(const Hyprlang::CParseResult& result) {
     static const auto PENABLEEXPLICIT     = CConfigValue<Hyprlang::INT>("render:explicit_sync");
-    static bool       prevEnabledExplicit = *PENABLEEXPLICIT;
+    static int        prevEnabledExplicit = *PENABLEEXPLICIT;
 
     for (auto& w : g_pCompositor->m_vWindows) {
         w->uncacheWindowDecos();

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -562,6 +562,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("group:groupbar:col.locked_inactive", Hyprlang::CConfigCustomValueType{&configHandleGradientSet, configHandleGradientDestroy, "0x66775500"});
 
     m_pConfig->addConfigValue("render:explicit_sync", Hyprlang::INT{1});
+    m_pConfig->addConfigValue("render:explicit_sync_kms", Hyprlang::INT{1});
 
     // devices
     m_pConfig->addSpecialCategory("device", {"name"});

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -3,6 +3,7 @@
 
 #include "../render/decorations/CHyprGroupBarDecoration.hpp"
 #include "config/ConfigDataValues.hpp"
+#include "config/ConfigValue.hpp"
 #include "helpers/varlist/VarList.hpp"
 #include "../protocols/LayerShell.hpp"
 
@@ -798,6 +799,9 @@ std::optional<std::string> CConfigManager::resetHLConfig() {
 }
 
 void CConfigManager::postConfigReload(const Hyprlang::CParseResult& result) {
+    static const auto PENABLEEXPLICIT     = CConfigValue<Hyprlang::INT>("render:explicit_sync");
+    static bool       prevEnabledExplicit = *PENABLEEXPLICIT;
+
     for (auto& w : g_pCompositor->m_vWindows) {
         w->uncacheWindowDecos();
     }
@@ -815,6 +819,9 @@ void CConfigManager::postConfigReload(const Hyprlang::CParseResult& result) {
 
     if (!isFirstLaunch)
         g_pHyprOpenGL->m_bReloadScreenShader = true;
+
+    if (!isFirstLaunch && *PENABLEEXPLICIT != prevEnabledExplicit)
+        g_pHyprError->queueCreate("Warning: You changed the render:explicit_sync option, this requires you to restart Hyprland.", CColor(0.9, 0.76, 0.221, 1.0));
 
     // parseError will be displayed next frame
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -560,7 +560,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("group:groupbar:col.locked_active", Hyprlang::CConfigCustomValueType{&configHandleGradientSet, configHandleGradientDestroy, "0x66ff5500"});
     m_pConfig->addConfigValue("group:groupbar:col.locked_inactive", Hyprlang::CConfigCustomValueType{&configHandleGradientSet, configHandleGradientDestroy, "0x66775500"});
 
-    m_pConfig->addConfigValue("experimental:explicit_sync", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("render:explicit_sync", Hyprlang::INT{1});
 
     // devices
     m_pConfig->addSpecialCategory("device", {"name"});

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1424,7 +1424,7 @@ void CConfigManager::ensureVRR(CMonitor* pMonitor) {
 
         if (USEVRR == 0) {
             if (m->vrrActive) {
-
+                m->output->state->resetExplicitFences();
                 m->output->state->setAdaptiveSync(false);
 
                 if (!m->state.commit())
@@ -1434,6 +1434,7 @@ void CConfigManager::ensureVRR(CMonitor* pMonitor) {
             return;
         } else if (USEVRR == 1) {
             if (!m->vrrActive) {
+                m->output->state->resetExplicitFences();
                 m->output->state->setAdaptiveSync(true);
 
                 if (!m->state.test()) {
@@ -1458,6 +1459,7 @@ void CConfigManager::ensureVRR(CMonitor* pMonitor) {
             const auto WORKSPACEFULL = PWORKSPACE->m_bHasFullscreenWindow && (PWORKSPACE->m_efFullscreenMode & FSMODE_FULLSCREEN);
 
             if (WORKSPACEFULL) {
+                m->output->state->resetExplicitFences();
                 m->output->state->setAdaptiveSync(true);
 
                 if (!m->state.test()) {
@@ -1469,6 +1471,7 @@ void CConfigManager::ensureVRR(CMonitor* pMonitor) {
                     Debug::log(ERR, "Couldn't commit output {} in ensureVRR -> true", m->output->name);
 
             } else if (!WORKSPACEFULL) {
+                m->output->state->resetExplicitFences();
                 m->output->state->setAdaptiveSync(false);
 
                 if (!m->state.commit())

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -561,8 +561,8 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("group:groupbar:col.locked_active", Hyprlang::CConfigCustomValueType{&configHandleGradientSet, configHandleGradientDestroy, "0x66ff5500"});
     m_pConfig->addConfigValue("group:groupbar:col.locked_inactive", Hyprlang::CConfigCustomValueType{&configHandleGradientSet, configHandleGradientDestroy, "0x66775500"});
 
-    m_pConfig->addConfigValue("render:explicit_sync", Hyprlang::INT{1});
-    m_pConfig->addConfigValue("render:explicit_sync_kms", Hyprlang::INT{1});
+    m_pConfig->addConfigValue("render:explicit_sync", Hyprlang::INT{2});
+    m_pConfig->addConfigValue("render:explicit_sync_kms", Hyprlang::INT{2});
 
     // devices
     m_pConfig->addSpecialCategory("device", {"name"});

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -347,7 +347,6 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("misc:swallow_regex", {STRVAL_EMPTY});
     m_pConfig->addConfigValue("misc:swallow_exception_regex", {STRVAL_EMPTY});
     m_pConfig->addConfigValue("misc:focus_on_activate", Hyprlang::INT{0});
-    m_pConfig->addConfigValue("misc:no_direct_scanout", Hyprlang::INT{1});
     m_pConfig->addConfigValue("misc:mouse_move_focuses_monitor", Hyprlang::INT{1});
     m_pConfig->addConfigValue("misc:render_ahead_of_time", Hyprlang::INT{0});
     m_pConfig->addConfigValue("misc:render_ahead_safezone", Hyprlang::INT{1});
@@ -563,6 +562,7 @@ CConfigManager::CConfigManager() {
 
     m_pConfig->addConfigValue("render:explicit_sync", Hyprlang::INT{2});
     m_pConfig->addConfigValue("render:explicit_sync_kms", Hyprlang::INT{2});
+    m_pConfig->addConfigValue("render:direct_scanout", Hyprlang::INT{0});
 
     // devices
     m_pConfig->addSpecialCategory("device", {"name"});

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1,6 +1,7 @@
 #include "Monitor.hpp"
 #include "MiscFunctions.hpp"
 #include "math/Math.hpp"
+#include "sync/SyncReleaser.hpp"
 #include "../Compositor.hpp"
 #include "../config/ConfigValue.hpp"
 #include "../protocols/GammaControl.hpp"
@@ -838,6 +839,9 @@ bool CMonitor::attemptDirectScanout() {
 
         // delay explicit sync feedback until kms release of the buffer
         if (DOEXPLICIT) {
+            Debug::log(TRACE, "Delaying explicit sync release feedback until kms release");
+            PSURFACE->current.buffer->releaser->drop();
+
             PSURFACE->current.buffer->buffer->hlEvents.backendRelease2 = PSURFACE->current.buffer->buffer->events.backendRelease.registerListener([PSURFACE](std::any d) {
                 const bool DOEXPLICIT = PSURFACE->syncobj && PSURFACE->syncobj->releaseTimeline && PSURFACE->syncobj->releaseTimeline->timeline;
                 if (DOEXPLICIT)

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -795,8 +795,6 @@ void CMonitor::scheduleDone() {
 }
 
 bool CMonitor::attemptDirectScanout() {
-    static auto PENABLEEXPLICITKMS = CConfigValue<Hyprlang::INT>("render:explicit_sync_kms");
-
     if (!mirrors.empty() || isMirror() || g_pHyprRenderer->m_bDirectScanoutBlocked)
         return false; // do not DS if this monitor is being mirrored. Will break the functionality.
 
@@ -830,8 +828,10 @@ bool CMonitor::attemptDirectScanout() {
         return false;
     }
 
+    auto explicitOptions = g_pHyprRenderer->getExplicitSyncSettings();
+
     // wait for the explicit fence if present, and if kms explicit is allowed
-    bool DOEXPLICIT     = PSURFACE->syncobj && PSURFACE->syncobj->acquireTimeline && PSURFACE->syncobj->acquireTimeline->timeline && *PENABLEEXPLICITKMS;
+    bool DOEXPLICIT     = PSURFACE->syncobj && PSURFACE->syncobj->acquireTimeline && PSURFACE->syncobj->acquireTimeline->timeline && explicitOptions.explicitKMSEnabled;
     int  explicitWaitFD = -1;
     if (DOEXPLICIT) {
         explicitWaitFD = PSURFACE->syncobj->acquireTimeline->timeline->exportAsSyncFileFD(PSURFACE->syncobj->acquirePoint);

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -831,8 +831,11 @@ bool CMonitor::attemptDirectScanout() {
     // wait for the implicit fence if present
     bool DOEXPLICIT     = PSURFACE->syncobj && PSURFACE->syncobj->acquireTimeline && PSURFACE->syncobj->acquireTimeline->timeline;
     int  explicitWaitFD = -1;
-    if (DOEXPLICIT)
+    if (DOEXPLICIT) {
         explicitWaitFD = PSURFACE->syncobj->acquireTimeline->timeline->exportAsSyncFileFD(PSURFACE->syncobj->acquirePoint);
+        if (explicitWaitFD < 0)
+            Debug::log(TRACE, "attemptDirectScanout: failed to acquire an explicit wait fd");
+    }
     DOEXPLICIT = DOEXPLICIT && explicitWaitFD >= 0;
 
     auto     cleanup = CScopeGuard([explicitWaitFD, this]() {

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -795,6 +795,8 @@ void CMonitor::scheduleDone() {
 }
 
 bool CMonitor::attemptDirectScanout() {
+    static auto PENABLEEXPLICITKMS = CConfigValue<Hyprlang::INT>("render:render:explicit_sync_kms");
+
     if (!mirrors.empty() || isMirror() || g_pHyprRenderer->m_bDirectScanoutBlocked)
         return false; // do not DS if this monitor is being mirrored. Will break the functionality.
 
@@ -828,8 +830,8 @@ bool CMonitor::attemptDirectScanout() {
         return false;
     }
 
-    // wait for the implicit fence if present
-    bool DOEXPLICIT     = PSURFACE->syncobj && PSURFACE->syncobj->acquireTimeline && PSURFACE->syncobj->acquireTimeline->timeline;
+    // wait for the explicit fence if present, and if kms explicit is allowed
+    bool DOEXPLICIT     = PSURFACE->syncobj && PSURFACE->syncobj->acquireTimeline && PSURFACE->syncobj->acquireTimeline->timeline && *PENABLEEXPLICITKMS;
     int  explicitWaitFD = -1;
     if (DOEXPLICIT) {
         explicitWaitFD = PSURFACE->syncobj->acquireTimeline->timeline->exportAsSyncFileFD(PSURFACE->syncobj->acquirePoint);

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -795,7 +795,7 @@ void CMonitor::scheduleDone() {
 }
 
 bool CMonitor::attemptDirectScanout() {
-    static auto PENABLEEXPLICITKMS = CConfigValue<Hyprlang::INT>("render:render:explicit_sync_kms");
+    static auto PENABLEEXPLICITKMS = CConfigValue<Hyprlang::INT>("render:explicit_sync_kms");
 
     if (!mirrors.empty() || isMirror() || g_pHyprRenderer->m_bDirectScanoutBlocked)
         return false; // do not DS if this monitor is being mirrored. Will break the functionality.

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -831,10 +831,10 @@ bool CMonitor::attemptDirectScanout() {
     auto explicitOptions = g_pHyprRenderer->getExplicitSyncSettings();
 
     // wait for the explicit fence if present, and if kms explicit is allowed
-    bool DOEXPLICIT     = PSURFACE->syncobj && PSURFACE->syncobj->acquireTimeline && PSURFACE->syncobj->acquireTimeline->timeline && explicitOptions.explicitKMSEnabled;
+    bool DOEXPLICIT = PSURFACE->syncobj && PSURFACE->syncobj->current.acquireTimeline && PSURFACE->syncobj->current.acquireTimeline->timeline && explicitOptions.explicitKMSEnabled;
     int  explicitWaitFD = -1;
     if (DOEXPLICIT) {
-        explicitWaitFD = PSURFACE->syncobj->acquireTimeline->timeline->exportAsSyncFileFD(PSURFACE->syncobj->acquirePoint);
+        explicitWaitFD = PSURFACE->syncobj->current.acquireTimeline->timeline->exportAsSyncFileFD(PSURFACE->syncobj->current.acquirePoint);
         if (explicitWaitFD < 0)
             Debug::log(TRACE, "attemptDirectScanout: failed to acquire an explicit wait fd");
     }
@@ -879,9 +879,9 @@ bool CMonitor::attemptDirectScanout() {
             PSURFACE->current.buffer->releaser->drop();
 
             PSURFACE->current.buffer->buffer->hlEvents.backendRelease2 = PSURFACE->current.buffer->buffer->events.backendRelease.registerListener([PSURFACE](std::any d) {
-                const bool DOEXPLICIT = PSURFACE->syncobj && PSURFACE->syncobj->releaseTimeline && PSURFACE->syncobj->releaseTimeline->timeline;
+                const bool DOEXPLICIT = PSURFACE->syncobj && PSURFACE->syncobj->current.releaseTimeline && PSURFACE->syncobj->current.releaseTimeline->timeline;
                 if (DOEXPLICIT)
-                    PSURFACE->syncobj->releaseTimeline->timeline->signal(PSURFACE->syncobj->releasePoint);
+                    PSURFACE->syncobj->current.releaseTimeline->timeline->signal(PSURFACE->syncobj->current.releasePoint);
             });
         }
     } else {

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -820,7 +820,7 @@ bool CMonitor::attemptDirectScanout() {
     timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);
     Debug::log(TRACE, "presentFeedback for DS");
-    PSURFACE->presentFeedback(&now, this, true);
+    PSURFACE->presentFeedback(&now, this);
 
     output->state->addDamage(CBox{{}, vecPixelSize});
 

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -830,7 +830,8 @@ bool CMonitor::attemptDirectScanout() {
     if (DOEXPLICIT)
         explicitWaitFD = PSURFACE->syncobj->acquireTimeline->timeline->exportAsSyncFileFD(PSURFACE->syncobj->acquirePoint);
 
-    auto     closeExplicitFD = CScopeGuard([explicitWaitFD]() {
+    auto     cleanup = CScopeGuard([explicitWaitFD, this]() {
+        output->state->resetExplicitFences();
         if (explicitWaitFD >= 0)
             close(explicitWaitFD);
     });

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -121,8 +121,7 @@ class CMonitor {
     // explicit sync
     SP<CSyncTimeline> inTimeline;
     SP<CSyncTimeline> outTimeline;
-    uint64_t          lastWaitPoint = 0;
-    uint64_t          commitSeq     = 0;
+    uint64_t          commitSeq = 0;
 
     WP<CMonitor>      self;
 

--- a/src/helpers/ScopeGuard.cpp
+++ b/src/helpers/ScopeGuard.cpp
@@ -1,0 +1,10 @@
+#include "ScopeGuard.hpp"
+
+CScopeGuard::CScopeGuard(const std::function<void()>& fn_) : fn(fn_) {
+    ;
+}
+
+CScopeGuard::~CScopeGuard() {
+    if (fn)
+        fn();
+}

--- a/src/helpers/ScopeGuard.hpp
+++ b/src/helpers/ScopeGuard.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <functional>
+
+// calls a function when it goes out of scope
+class CScopeGuard {
+  public:
+    CScopeGuard(const std::function<void()>& fn_);
+    ~CScopeGuard();
+
+  private:
+    std::function<void()> fn;
+};

--- a/src/helpers/sync/SyncReleaser.cpp
+++ b/src/helpers/sync/SyncReleaser.cpp
@@ -14,8 +14,8 @@ CSyncReleaser::~CSyncReleaser() {
         timeline->signal(point);
 }
 
-void CSyncReleaser::addReleaseSyncFD(int syncFD) {
-    fd = syncFD;
+void CSyncReleaser::addReleaseSync(SP<CEGLSync> sync_) {
+    sync = sync_;
 }
 
 void CSyncReleaser::drop() {

--- a/src/helpers/sync/SyncReleaser.cpp
+++ b/src/helpers/sync/SyncReleaser.cpp
@@ -1,4 +1,6 @@
 #include "SyncReleaser.hpp"
+#include "SyncTimeline.hpp"
+#include "../../render/OpenGL.hpp"
 
 CSyncReleaser::CSyncReleaser(WP<CSyncTimeline> timeline_, uint64_t point_) : timeline(timeline_), point(point_) {
     ;

--- a/src/helpers/sync/SyncReleaser.cpp
+++ b/src/helpers/sync/SyncReleaser.cpp
@@ -1,0 +1,23 @@
+#include "SyncReleaser.hpp"
+
+CSyncReleaser::CSyncReleaser(WP<CSyncTimeline> timeline_, uint64_t point_) : timeline(timeline_), point(point_) {
+    ;
+}
+
+CSyncReleaser::~CSyncReleaser() {
+    if (timeline.expired())
+        return;
+
+    if (fd >= 0)
+        timeline->importFromSyncFileFD(point, fd);
+    else
+        timeline->signal(point);
+}
+
+void CSyncReleaser::addReleaseSyncFD(int syncFD) {
+    fd = syncFD;
+}
+
+void CSyncReleaser::drop() {
+    timeline.reset();
+}

--- a/src/helpers/sync/SyncReleaser.cpp
+++ b/src/helpers/sync/SyncReleaser.cpp
@@ -8,8 +8,8 @@ CSyncReleaser::~CSyncReleaser() {
     if (timeline.expired())
         return;
 
-    if (fd >= 0)
-        timeline->importFromSyncFileFD(point, fd);
+    if (sync)
+        timeline->importFromSyncFileFD(point, sync->fd());
     else
         timeline->signal(point);
 }

--- a/src/helpers/sync/SyncReleaser.hpp
+++ b/src/helpers/sync/SyncReleaser.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+#include <functional>
+#include "../memory/Memory.hpp"
+
+/*
+    A helper (inspired by KDE's KWin) that will release the timeline point in the dtor
+*/
+
+class CSyncTimeline;
+
+class CSyncReleaser {
+  public:
+    CSyncReleaser(WP<CSyncTimeline> timeline_, uint64_t point_);
+    ~CSyncReleaser();
+
+    // drops the releaser, will never signal anymore
+    void drop();
+
+    // wait for this gpu job to finish before releasing
+    void addReleaseSyncFD(int syncFD);
+
+  private:
+    WP<CSyncTimeline> timeline;
+    uint64_t          point = 0;
+    int               fd    = -1;
+};

--- a/src/helpers/sync/SyncReleaser.hpp
+++ b/src/helpers/sync/SyncReleaser.hpp
@@ -11,6 +11,7 @@
 */
 
 class CSyncTimeline;
+class CEGLSync;
 
 class CSyncReleaser {
   public:
@@ -21,10 +22,11 @@ class CSyncReleaser {
     void drop();
 
     // wait for this gpu job to finish before releasing
-    void addReleaseSyncFD(int syncFD);
+    void addReleaseSync(SP<CEGLSync> sync);
 
   private:
     WP<CSyncTimeline> timeline;
     uint64_t          point = 0;
     int               fd    = -1;
+    SP<CEGLSync>      sync;
 };

--- a/src/helpers/sync/SyncReleaser.hpp
+++ b/src/helpers/sync/SyncReleaser.hpp
@@ -27,6 +27,5 @@ class CSyncReleaser {
   private:
     WP<CSyncTimeline> timeline;
     uint64_t          point = 0;
-    int               fd    = -1;
     SP<CEGLSync>      sync;
 };

--- a/src/helpers/sync/SyncTimeline.cpp
+++ b/src/helpers/sync/SyncTimeline.cpp
@@ -188,3 +188,8 @@ bool CSyncTimeline::transfer(SP<CSyncTimeline> from, uint64_t fromPoint, uint64_
 
     return true;
 }
+
+void CSyncTimeline::signal(uint64_t point) {
+    if (drmSyncobjTimelineSignal(drmFD, &handle, &point, 1))
+        Debug::log(ERR, "CSyncTimeline::signal: drmSyncobjTimelineSignal failed");
+}

--- a/src/helpers/sync/SyncTimeline.hpp
+++ b/src/helpers/sync/SyncTimeline.hpp
@@ -35,6 +35,7 @@ class CSyncTimeline {
     int                 exportAsSyncFileFD(uint64_t src);
     bool                importFromSyncFileFD(uint64_t dst, int fd);
     bool                transfer(SP<CSyncTimeline> from, uint64_t fromPoint, uint64_t toPoint);
+    void                signal(uint64_t point);
 
     int                 drmFD  = -1;
     uint32_t            handle = 0;

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2279,6 +2279,7 @@ void CKeybindManager::dpms(std::string arg) {
         if (!port.empty() && m->szName != port)
             continue;
 
+        m->output->state->resetExplicitFences();
         m->output->state->setEnabled(enable);
 
         m->dpmsStatus = enable;

--- a/src/managers/ProtocolManager.cpp
+++ b/src/managers/ProtocolManager.cpp
@@ -76,7 +76,7 @@ void CProtocolManager::onMonitorModeChange(CMonitor* pMonitor) {
 
 CProtocolManager::CProtocolManager() {
 
-    static const auto PENABLEEXPLICIT = CConfigValue<Hyprlang::INT>("experimental:explicit_sync");
+    static const auto PENABLEEXPLICIT = CConfigValue<Hyprlang::INT>("render:explicit_sync");
 
     // Outputs are a bit dumb, we have to agree.
     static auto P = g_pHookSystem->hookDynamic("monitorAdded", [this](void* self, SCallbackInfo& info, std::any param) {

--- a/src/protocols/DRMSyncobj.cpp
+++ b/src/protocols/DRMSyncobj.cpp
@@ -24,9 +24,9 @@ CDRMSyncobjSurfaceResource::CDRMSyncobjSurfaceResource(SP<CWpLinuxDrmSyncobjSurf
             return;
         }
 
-        auto timeline   = CDRMSyncobjTimelineResource::fromResource(timeline_);
-        acquireTimeline = timeline;
-        acquirePoint    = ((uint64_t)hi << 32) | (uint64_t)lo;
+        auto timeline           = CDRMSyncobjTimelineResource::fromResource(timeline_);
+        pending.acquireTimeline = timeline;
+        pending.acquirePoint    = ((uint64_t)hi << 32) | (uint64_t)lo;
     });
 
     resource->setSetReleasePoint([this](CWpLinuxDrmSyncobjSurfaceV1* r, wl_resource* timeline_, uint32_t hi, uint32_t lo) {
@@ -35,29 +35,30 @@ CDRMSyncobjSurfaceResource::CDRMSyncobjSurfaceResource(SP<CWpLinuxDrmSyncobjSurf
             return;
         }
 
-        auto timeline   = CDRMSyncobjTimelineResource::fromResource(timeline_);
-        releaseTimeline = timeline;
-        releasePoint    = ((uint64_t)hi << 32) | (uint64_t)lo;
+        auto timeline           = CDRMSyncobjTimelineResource::fromResource(timeline_);
+        pending.releaseTimeline = timeline;
+        pending.releasePoint    = ((uint64_t)hi << 32) | (uint64_t)lo;
     });
 
     listeners.surfacePrecommit = surface->events.precommit.registerListener([this](std::any d) {
-        if ((acquireTimeline || releaseTimeline) && !surface->pending.texture) {
+        if ((pending.acquireTimeline || pending.releaseTimeline) && !surface->pending.texture) {
             resource->error(WP_LINUX_DRM_SYNCOBJ_SURFACE_V1_ERROR_NO_BUFFER, "Missing buffer");
             surface->pending.rejected = true;
             return;
         }
 
-        if (!!acquireTimeline != !!releaseTimeline) {
-            resource->error(acquireTimeline ? WP_LINUX_DRM_SYNCOBJ_SURFACE_V1_ERROR_NO_RELEASE_POINT : WP_LINUX_DRM_SYNCOBJ_SURFACE_V1_ERROR_NO_ACQUIRE_POINT, "Missing timeline");
+        if (!!pending.acquireTimeline != !!pending.releaseTimeline) {
+            resource->error(pending.acquireTimeline ? WP_LINUX_DRM_SYNCOBJ_SURFACE_V1_ERROR_NO_RELEASE_POINT : WP_LINUX_DRM_SYNCOBJ_SURFACE_V1_ERROR_NO_ACQUIRE_POINT,
+                            "Missing timeline");
             surface->pending.rejected = true;
             return;
         }
 
-        if (!acquireTimeline)
+        if (!pending.acquireTimeline)
             return;
 
         // wait for the acquire timeline to materialize
-        auto materialized = acquireTimeline->timeline->check(acquirePoint, DRM_SYNCOBJ_WAIT_FLAGS_WAIT_AVAILABLE);
+        auto materialized = pending.acquireTimeline->timeline->check(pending.acquirePoint, DRM_SYNCOBJ_WAIT_FLAGS_WAIT_AVAILABLE);
         if (!materialized.has_value()) {
             LOGM(ERR, "Failed to check the acquire timeline");
             resource->noMemory();
@@ -68,7 +69,24 @@ CDRMSyncobjSurfaceResource::CDRMSyncobjSurfaceResource(SP<CWpLinuxDrmSyncobjSurf
             return;
 
         surface->lockPendingState();
-        acquireTimeline->timeline->addWaiter([this]() { surface->unlockPendingState(); }, acquirePoint, DRM_SYNCOBJ_WAIT_FLAGS_WAIT_AVAILABLE);
+        pending.acquireTimeline->timeline->addWaiter([this]() { surface->unlockPendingState(); }, pending.acquirePoint, DRM_SYNCOBJ_WAIT_FLAGS_WAIT_AVAILABLE);
+    });
+
+    listeners.surfaceCommit = surface->events.commit.registerListener([this](std::any d) {
+        // apply timelines if new ones have been attached, otherwise don't touch
+        // the current ones
+        if (pending.releaseTimeline) {
+            current.releaseTimeline = pending.releaseTimeline;
+            current.releasePoint    = pending.releasePoint;
+        }
+
+        if (pending.acquireTimeline) {
+            current.acquireTimeline = pending.acquireTimeline;
+            current.acquirePoint    = pending.acquirePoint;
+        }
+
+        pending.releaseTimeline.reset();
+        pending.acquireTimeline.reset();
     });
 }
 

--- a/src/protocols/DRMSyncobj.cpp
+++ b/src/protocols/DRMSyncobj.cpp
@@ -47,6 +47,9 @@ CDRMSyncobjSurfaceResource::CDRMSyncobjSurfaceResource(SP<CWpLinuxDrmSyncobjSurf
             return;
         }
 
+        if (!surface->pending.texture)
+            return; // this commit does not change the state here
+
         if (!!pending.acquireTimeline != !!pending.releaseTimeline) {
             resource->error(pending.acquireTimeline ? WP_LINUX_DRM_SYNCOBJ_SURFACE_V1_ERROR_NO_RELEASE_POINT : WP_LINUX_DRM_SYNCOBJ_SURFACE_V1_ERROR_NO_ACQUIRE_POINT,
                             "Missing timeline");

--- a/src/protocols/DRMSyncobj.cpp
+++ b/src/protocols/DRMSyncobj.cpp
@@ -41,14 +41,14 @@ CDRMSyncobjSurfaceResource::CDRMSyncobjSurfaceResource(SP<CWpLinuxDrmSyncobjSurf
     });
 
     listeners.surfacePrecommit = surface->events.precommit.registerListener([this](std::any d) {
-        if (!!acquireTimeline != !!releaseTimeline) {
-            resource->error(acquireTimeline ? WP_LINUX_DRM_SYNCOBJ_SURFACE_V1_ERROR_NO_RELEASE_POINT : WP_LINUX_DRM_SYNCOBJ_SURFACE_V1_ERROR_NO_ACQUIRE_POINT, "Missing timeline");
+        if ((acquireTimeline || releaseTimeline) && !surface->pending.texture) {
+            resource->error(WP_LINUX_DRM_SYNCOBJ_SURFACE_V1_ERROR_NO_BUFFER, "Missing buffer");
             surface->pending.rejected = true;
             return;
         }
 
-        if ((acquireTimeline || releaseTimeline) && !surface->pending.texture) {
-            resource->error(WP_LINUX_DRM_SYNCOBJ_SURFACE_V1_ERROR_NO_BUFFER, "Missing buffer");
+        if (!!acquireTimeline != !!releaseTimeline) {
+            resource->error(acquireTimeline ? WP_LINUX_DRM_SYNCOBJ_SURFACE_V1_ERROR_NO_RELEASE_POINT : WP_LINUX_DRM_SYNCOBJ_SURFACE_V1_ERROR_NO_ACQUIRE_POINT, "Missing timeline");
             surface->pending.rejected = true;
             return;
         }

--- a/src/protocols/DRMSyncobj.cpp
+++ b/src/protocols/DRMSyncobj.cpp
@@ -47,7 +47,7 @@ CDRMSyncobjSurfaceResource::CDRMSyncobjSurfaceResource(SP<CWpLinuxDrmSyncobjSurf
             return;
         }
 
-        if (!surface->pending.texture)
+        if (!surface->pending.newBuffer)
             return; // this commit does not change the state here
 
         if (!!pending.acquireTimeline != !!pending.releaseTimeline) {

--- a/src/protocols/DRMSyncobj.hpp
+++ b/src/protocols/DRMSyncobj.hpp
@@ -14,17 +14,20 @@ class CDRMSyncobjSurfaceResource {
   public:
     CDRMSyncobjSurfaceResource(SP<CWpLinuxDrmSyncobjSurfaceV1> resource_, SP<CWLSurfaceResource> surface_);
 
-    bool                            good();
+    bool                   good();
 
-    WP<CWLSurfaceResource>          surface;
-    WP<CDRMSyncobjTimelineResource> acquireTimeline, releaseTimeline;
-    uint64_t                        acquirePoint = 0, releasePoint = 0;
+    WP<CWLSurfaceResource> surface;
+    struct {
+        WP<CDRMSyncobjTimelineResource> acquireTimeline, releaseTimeline;
+        uint64_t                        acquirePoint = 0, releasePoint = 0;
+    } current, pending;
 
   private:
     SP<CWpLinuxDrmSyncobjSurfaceV1> resource;
 
     struct {
         CHyprSignalListener surfacePrecommit;
+        CHyprSignalListener surfaceCommit;
     } listeners;
 };
 

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -501,23 +501,18 @@ void CWLSurfaceResource::updateCursorShm() {
     memcpy(shmData.data(), pixelData, bufLen);
 }
 
-void CWLSurfaceResource::presentFeedback(timespec* when, CMonitor* pMonitor, bool needsExplicitSync) {
+void CWLSurfaceResource::presentFeedback(timespec* when, CMonitor* pMonitor) {
     frame(when);
     auto FEEDBACK = makeShared<CQueuedPresentationData>(self.lock());
     FEEDBACK->attachMonitor(pMonitor);
     FEEDBACK->presented();
     PROTO::presentation->queueData(FEEDBACK);
 
-    if (!pMonitor || !pMonitor->outTimeline || !syncobj || !needsExplicitSync)
+    if (!pMonitor || !pMonitor->outTimeline || !syncobj)
         return;
 
     // attach explicit sync
     g_pHyprRenderer->explicitPresented.emplace_back(self.lock());
-
-    if (syncobj->acquirePoint > pMonitor->lastWaitPoint) {
-        Debug::log(TRACE, "presentFeedback lastWaitPoint {} -> {}", pMonitor->lastWaitPoint, syncobj->acquirePoint);
-        pMonitor->lastWaitPoint = syncobj->acquirePoint;
-    }
 }
 
 CWLCompositorResource::CWLCompositorResource(SP<CWlCompositor> resource_) : resource(resource_) {

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -70,7 +70,8 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : resource(reso
     resource->setOnDestroy([this](CWlSurface* r) { destroy(); });
 
     resource->setAttach([this](CWlSurface* r, wl_resource* buffer, int32_t x, int32_t y) {
-        pending.offset = {x, y};
+        pending.offset    = {x, y};
+        pending.newBuffer = true;
 
         if (!buffer) {
             pending.buffer.reset();
@@ -429,8 +430,7 @@ void CWLSurfaceResource::commitPendingState() {
     current = pending;
     pending.damage.clear();
     pending.bufferDamage.clear();
-    pending.texture.reset();
-    pending.buffer.reset();
+    pending.newBuffer = false;
 
     if (syncobj && syncobj->current.releaseTimeline && syncobj->current.releaseTimeline->timeline && current.buffer && current.buffer->buffer)
         current.buffer->releaser = makeShared<CSyncReleaser>(syncobj->current.releaseTimeline->timeline, syncobj->current.releasePoint);

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -429,6 +429,8 @@ void CWLSurfaceResource::commitPendingState() {
     current = pending;
     pending.damage.clear();
     pending.bufferDamage.clear();
+    pending.texture.reset();
+    pending.buffer.reset();
 
     if (syncobj && syncobj->current.releaseTimeline && syncobj->current.releaseTimeline->timeline && current.buffer && current.buffer->buffer)
         current.buffer->releaser = makeShared<CSyncReleaser>(syncobj->current.releaseTimeline->timeline, syncobj->current.releasePoint);

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -7,6 +7,7 @@
 #include "Subcompositor.hpp"
 #include "../Viewporter.hpp"
 #include "../../helpers/Monitor.hpp"
+#include "../../helpers/sync/SyncReleaser.hpp"
 #include "../PresentationTime.hpp"
 #include "../DRMSyncobj.hpp"
 #include "../../render/Renderer.hpp"
@@ -428,6 +429,9 @@ void CWLSurfaceResource::commitPendingState() {
     current = pending;
     pending.damage.clear();
     pending.bufferDamage.clear();
+
+    if (syncobj && syncobj->releaseTimeline && syncobj->releaseTimeline->timeline && current.buffer && current.buffer->buffer)
+        current.buffer->releaser = makeShared<CSyncReleaser>(syncobj->releaseTimeline->timeline, syncobj->releasePoint);
 
     if (current.texture)
         current.texture->m_eTransform = wlTransformToHyprutils(current.transform);

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -430,8 +430,8 @@ void CWLSurfaceResource::commitPendingState() {
     pending.damage.clear();
     pending.bufferDamage.clear();
 
-    if (syncobj && syncobj->releaseTimeline && syncobj->releaseTimeline->timeline && current.buffer && current.buffer->buffer)
-        current.buffer->releaser = makeShared<CSyncReleaser>(syncobj->releaseTimeline->timeline, syncobj->releasePoint);
+    if (syncobj && syncobj->current.releaseTimeline && syncobj->current.releaseTimeline->timeline && current.buffer && current.buffer->buffer)
+        current.buffer->releaser = makeShared<CSyncReleaser>(syncobj->current.releaseTimeline->timeline, syncobj->current.releasePoint);
 
     if (current.texture)
         current.texture->m_eTransform = wlTransformToHyprutils(current.transform);

--- a/src/protocols/core/Compositor.hpp
+++ b/src/protocols/core/Compositor.hpp
@@ -97,7 +97,8 @@ class CWLSurfaceResource {
             Vector2D destination;
             CBox     source;
         } viewport;
-        bool rejected = false;
+        bool rejected  = false;
+        bool newBuffer = false;
 
         //
         void reset() {

--- a/src/protocols/core/Compositor.hpp
+++ b/src/protocols/core/Compositor.hpp
@@ -122,7 +122,7 @@ class CWLSurfaceResource {
 
     void                                   breadthfirst(std::function<void(SP<CWLSurfaceResource>, const Vector2D&, void*)> fn, void* data);
     CRegion                                accumulateCurrentBufferDamage();
-    void                                   presentFeedback(timespec* when, CMonitor* pMonitor, bool needsExplicitSync = false);
+    void                                   presentFeedback(timespec* when, CMonitor* pMonitor);
     void                                   lockPendingState();
     void                                   unlockPendingState();
 

--- a/src/protocols/types/Buffer.hpp
+++ b/src/protocols/types/Buffer.hpp
@@ -15,10 +15,8 @@ class IHLBuffer : public Aquamarine::IBuffer {
     virtual bool                          isSynchronous()               = 0; // whether the updates to this buffer are synchronous, aka happen over cpu
     virtual bool                          good()                        = 0;
     virtual void                          sendRelease();
-    virtual void                          sendReleaseWithSurface(SP<CWLSurfaceResource>);
     virtual void                          lock();
     virtual void                          unlock();
-    virtual void                          unlockWithSurface(SP<CWLSurfaceResource> surf);
     virtual bool                          locked();
 
     void                                  unlockOnBufferRelease(WP<CWLSurfaceResource> surf /* optional */);
@@ -29,12 +27,11 @@ class IHLBuffer : public Aquamarine::IBuffer {
 
     struct {
         CHyprSignalListener backendRelease;
+        CHyprSignalListener backendRelease2; // for explicit ds
     } hlEvents;
 
   private:
-    int                    nLocks = 0;
-
-    WP<CWLSurfaceResource> unlockSurface;
+    int nLocks = 0;
 };
 
 // for ref-counting. Releases in ~dtor

--- a/src/protocols/types/Buffer.hpp
+++ b/src/protocols/types/Buffer.hpp
@@ -6,6 +6,8 @@
 
 #include <aquamarine/buffer/Buffer.hpp>
 
+class CSyncReleaser;
+
 class IHLBuffer : public Aquamarine::IBuffer {
   public:
     virtual ~IHLBuffer();
@@ -41,7 +43,8 @@ class CHLBufferReference {
     CHLBufferReference(SP<IHLBuffer> buffer, SP<CWLSurfaceResource> surface);
     ~CHLBufferReference();
 
-    WP<IHLBuffer> buffer;
+    WP<IHLBuffer>     buffer;
+    SP<CSyncReleaser> releaser;
 
   private:
     WP<CWLSurfaceResource> surface;

--- a/src/protocols/types/WLBuffer.cpp
+++ b/src/protocols/types/WLBuffer.cpp
@@ -32,10 +32,6 @@ void CWLBufferResource::sendRelease() {
     resource->sendRelease();
 }
 
-void CWLBufferResource::sendReleaseWithSurface(SP<CWLSurfaceResource> surf) {
-    sendRelease();
-}
-
 wl_resource* CWLBufferResource::getResource() {
     return resource->resource();
 }

--- a/src/protocols/types/WLBuffer.cpp
+++ b/src/protocols/types/WLBuffer.cpp
@@ -34,12 +34,6 @@ void CWLBufferResource::sendRelease() {
 
 void CWLBufferResource::sendReleaseWithSurface(SP<CWLSurfaceResource> surf) {
     sendRelease();
-
-    if (!surf || !surf->syncobj)
-        return;
-
-    if (drmSyncobjTimelineSignal(g_pCompositor->m_iDRMFD, &surf->syncobj->releaseTimeline->timeline->handle, &surf->syncobj->releasePoint, 1))
-        Debug::log(ERR, "sendReleaseWithSurface: drmSyncobjTimelineSignal failed");
 }
 
 wl_resource* CWLBufferResource::getResource() {

--- a/src/protocols/types/WLBuffer.hpp
+++ b/src/protocols/types/WLBuffer.hpp
@@ -17,7 +17,6 @@ class CWLBufferResource {
 
     bool                         good();
     void                         sendRelease();
-    void                         sendReleaseWithSurface(SP<CWLSurfaceResource>);
     wl_resource*                 getResource();
 
     WP<IHLBuffer>                buffer;

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -2986,14 +2986,14 @@ float SRenderModifData::combinedScale() {
 }
 
 CEGLSync::~CEGLSync() {
+    if (m_iFd >= 0)
+        close(m_iFd);
+
     if (sync == EGL_NO_SYNC_KHR)
         return;
 
     if (g_pHyprOpenGL->m_sProc.eglDestroySyncKHR(g_pHyprOpenGL->m_pEglDisplay, sync) != EGL_TRUE)
         Debug::log(ERR, "eglDestroySyncKHR failed");
-
-    if (m_iFd >= 0)
-        close(m_iFd);
 }
 
 int CEGLSync::fd() {

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -2868,7 +2868,7 @@ SP<CEGLSync> CHyprOpenGLImpl::createEGLSync(int fenceFD) {
     std::vector<EGLint> attribs;
     int                 dupFd = -1;
     if (fenceFD > 0) {
-        int dupFd = fcntl(fenceFD, F_DUPFD_CLOEXEC, 0);
+        dupFd = fcntl(fenceFD, F_DUPFD_CLOEXEC, 0);
         if (dupFd < 0) {
             Debug::log(ERR, "createEGLSync: dup failed");
             return nullptr;

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -2887,6 +2887,9 @@ SP<CEGLSync> CHyprOpenGLImpl::createEGLSync(int fenceFD) {
         return nullptr;
     }
 
+    // we need to flush otherwise we might not get a valid fd later
+    glFlush();
+
     auto eglsync  = SP<CEGLSync>(new CEGLSync);
     eglsync->sync = sync;
     return eglsync;

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -2986,14 +2986,14 @@ float SRenderModifData::combinedScale() {
 }
 
 CEGLSync::~CEGLSync() {
-    if (m_iFd >= 0)
-        close(m_iFd);
-
     if (sync == EGL_NO_SYNC_KHR)
         return;
 
     if (g_pHyprOpenGL->m_sProc.eglDestroySyncKHR(g_pHyprOpenGL->m_pEglDisplay, sync) != EGL_TRUE)
         Debug::log(ERR, "eglDestroySyncKHR failed");
+
+    if (m_iFd >= 0)
+        close(m_iFd);
 }
 
 int CEGLSync::fd() {

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -131,11 +131,13 @@ class CEGLSync {
 
     EGLSyncKHR sync = nullptr;
 
-    int        dupFenceFD();
+    int        fd();
     bool       wait();
 
   private:
     CEGLSync() = default;
+
+    int m_iFd = -1;
 
     friend class CHyprOpenGLImpl;
 };

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1407,7 +1407,10 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(CMonitor* pMonitor) {
     static auto PENABLEEXPLICIT = CConfigValue<Hyprlang::INT>("render:explicit_sync");
 
     // apply timelines for explicit sync
+    // save inFD otherwise reset will reset it
+    auto inFD = pMonitor->output->state->state().explicitInFence;
     pMonitor->output->state->resetExplicitFences();
+    pMonitor->output->state->setExplicitInFence(inFD);
 
     bool ok = pMonitor->state.commit();
     if (!ok) {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2650,7 +2650,7 @@ void CHyprRenderer::endRender() {
     const auto  PMONITOR           = g_pHyprOpenGL->m_RenderData.pMonitor;
     static auto PNVIDIAANTIFLICKER = CConfigValue<Hyprlang::INT>("opengl:nvidia_anti_flicker");
     static auto PENABLEEXPLICIT    = CConfigValue<Hyprlang::INT>("render:explicit_sync");
-    static auto PENABLEEXPLICITKMS = CConfigValue<Hyprlang::INT>("render:render:explicit_sync_kms");
+    static auto PENABLEEXPLICITKMS = CConfigValue<Hyprlang::INT>("render:explicit_sync_kms");
 
     PMONITOR->commitSeq++;
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <aquamarine/output/Output.hpp>
 #include <cstring>
+#include <filesystem>
 #include "../config/ConfigValue.hpp"
 #include "../managers/CursorManager.hpp"
 #include "../managers/PointerManager.hpp"

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1410,7 +1410,8 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(CMonitor* pMonitor) {
     // save inFD otherwise reset will reset it
     auto inFD = pMonitor->output->state->state().explicitInFence;
     pMonitor->output->state->resetExplicitFences();
-    pMonitor->output->state->setExplicitInFence(inFD);
+    if (inFD >= 0)
+        pMonitor->output->state->setExplicitInFence(inFD);
 
     bool ok = pMonitor->state.commit();
     if (!ok) {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1425,12 +1425,6 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(CMonitor* pMonitor) {
         }
 
         explicitPresented.clear();
-        auto outFence = pMonitor->outTimeline->exportAsSyncFileFD(pMonitor->commitSeq);
-        if (outFence < 0)
-            Debug::log(ERR, "Export commitSeq {} as sync explicitOutFence failed", pMonitor->commitSeq);
-
-        pMonitor->output->state->setExplicitOutFence(outFence);
-        Debug::log(TRACE, "Explicit sync presented end");
     }
 
     pMonitor->lastWaitPoint = 0;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2650,6 +2650,7 @@ void CHyprRenderer::endRender() {
     const auto  PMONITOR           = g_pHyprOpenGL->m_RenderData.pMonitor;
     static auto PNVIDIAANTIFLICKER = CConfigValue<Hyprlang::INT>("opengl:nvidia_anti_flicker");
     static auto PENABLEEXPLICIT    = CConfigValue<Hyprlang::INT>("render:explicit_sync");
+    static auto PENABLEEXPLICITKMS = CConfigValue<Hyprlang::INT>("render:render:explicit_sync_kms");
 
     PMONITOR->commitSeq++;
 
@@ -2673,7 +2674,7 @@ void CHyprRenderer::endRender() {
     if (m_eRenderMode == RENDER_MODE_NORMAL) {
         PMONITOR->output->state->setBuffer(m_pCurrentBuffer);
 
-        if (PMONITOR->inTimeline && *PENABLEEXPLICIT) {
+        if (PMONITOR->inTimeline && *PENABLEEXPLICIT && *PENABLEEXPLICITKMS) {
             auto sync = g_pHyprOpenGL->createEGLSync(-1);
             if (!sync) {
                 Debug::log(ERR, "renderer: couldn't create an EGLSync for out in endRender");

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1445,8 +1445,10 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(CMonitor* pMonitor) {
         close(pMonitor->output->state->state().explicitInFence);
 
     if (pMonitor->output->state->state().explicitOutFence >= 0) {
-        if (ok)
+        if (ok) {
             pMonitor->outTimeline->importFromSyncFileFD(pMonitor->commitSeq, pMonitor->output->state->state().explicitOutFence);
+            pMonitor->outTimeline->signal(pMonitor->commitSeq);
+        }
         close(pMonitor->output->state->state().explicitOutFence);
     }
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1403,7 +1403,7 @@ void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
 }
 
 bool CHyprRenderer::commitPendingAndDoExplicitSync(CMonitor* pMonitor) {
-    static auto PENABLEEXPLICIT = CConfigValue<Hyprlang::INT>("experimental:explicit_sync");
+    static auto PENABLEEXPLICIT = CConfigValue<Hyprlang::INT>("render:explicit_sync");
 
     // apply timelines for explicit sync
     pMonitor->output->state->resetExplicitFences();
@@ -2636,7 +2636,7 @@ bool CHyprRenderer::beginRender(CMonitor* pMonitor, CRegion& damage, eRenderMode
 void CHyprRenderer::endRender() {
     const auto  PMONITOR           = g_pHyprOpenGL->m_RenderData.pMonitor;
     static auto PNVIDIAANTIFLICKER = CConfigValue<Hyprlang::INT>("opengl:nvidia_anti_flicker");
-    static auto PENABLEEXPLICIT    = CConfigValue<Hyprlang::INT>("experimental:explicit_sync");
+    static auto PENABLEEXPLICIT    = CConfigValue<Hyprlang::INT>("render:explicit_sync");
 
     PMONITOR->commitSeq++;
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1436,12 +1436,11 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(CMonitor* pMonitor) {
     if (!sync)
         Debug::log(TRACE, "Explicit: can't add sync, EGLSync failed");
     else {
-        int fd = sync->dupFenceFD();
         for (auto& e : explicitPresented) {
             if (!e->current.buffer || !e->current.buffer->releaser)
                 continue;
 
-            e->current.buffer->releaser->addReleaseSyncFD(fd);
+            e->current.buffer->releaser->addReleaseSync(sync);
         }
     }
 
@@ -2662,7 +2661,7 @@ void CHyprRenderer::endRender() {
                 return;
             }
 
-            auto dupedfd = sync->dupFenceFD();
+            auto dupedfd = sync->fd();
             sync.reset();
             if (dupedfd < 0) {
                 m_pCurrentRenderbuffer->unbind();

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2651,36 +2651,7 @@ void CHyprRenderer::endRender() {
     if (m_eRenderMode == RENDER_MODE_NORMAL) {
         PMONITOR->output->state->setBuffer(m_pCurrentBuffer);
 
-        if (PMONITOR->inTimeline && *PENABLEEXPLICIT) {
-            auto sync = g_pHyprOpenGL->createEGLSync(-1);
-            if (!sync) {
-                m_pCurrentRenderbuffer->unbind();
-                m_pCurrentRenderbuffer = nullptr;
-                m_pCurrentBuffer       = nullptr;
-                Debug::log(ERR, "renderer: couldn't create an EGLSync for out in endRender");
-                return;
-            }
-
-            auto dupedfd = sync->fd();
-            sync.reset();
-            if (dupedfd < 0) {
-                m_pCurrentRenderbuffer->unbind();
-                m_pCurrentRenderbuffer = nullptr;
-                m_pCurrentBuffer       = nullptr;
-                Debug::log(ERR, "renderer: couldn't dup an EGLSync fence for out in endRender");
-                return;
-            }
-
-            bool ok = PMONITOR->inTimeline->importFromSyncFileFD(PMONITOR->commitSeq, dupedfd);
-            close(dupedfd);
-            if (!ok) {
-                m_pCurrentRenderbuffer->unbind();
-                m_pCurrentRenderbuffer = nullptr;
-                m_pCurrentBuffer       = nullptr;
-                Debug::log(ERR, "renderer: couldn't import from sync file fd in endRender");
-                return;
-            }
-        } else {
+        if (!PMONITOR->inTimeline || !*PENABLEEXPLICIT) {
             if (isNvidia() && *PNVIDIAANTIFLICKER)
                 glFinish();
             else

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1459,6 +1459,8 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(CMonitor* pMonitor) {
 
     explicitPresented.clear();
 
+    pMonitor->output->state->resetExplicitFences();
+
     return ok;
 }
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -118,8 +118,8 @@ static void renderSurface(SP<CWLSurfaceResource> surface, int x, int y, void* da
         return;
 
     // explicit sync: wait for the timeline, if any
-    if (surface->syncobj && surface->syncobj->acquireTimeline) {
-        if (!g_pHyprOpenGL->waitForTimelinePoint(surface->syncobj->acquireTimeline->timeline, surface->syncobj->acquirePoint)) {
+    if (surface->syncobj && surface->syncobj->current.acquireTimeline) {
+        if (!g_pHyprOpenGL->waitForTimelinePoint(surface->syncobj->current.acquireTimeline->timeline, surface->syncobj->current.acquirePoint)) {
             Debug::log(ERR, "Renderer: failed to wait for explicit timeline");
             return;
         }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2732,13 +2732,15 @@ SExplicitSyncSettings CHyprRenderer::getExplicitSyncSettings() {
             if (!std::filesystem::exists("/proc/driver/nvidia/version"))
                 settings.explicitKMSEnabled = false;
             else {
-                // check nvidia version. Explicit KMS is supported in 560+
+                // check nvidia version. Explicit KMS is supported in >=560
                 std::ifstream ifs("/proc/driver/nvidia/version");
                 if (!ifs.good())
                     settings.explicitKMSEnabled = false;
                 else {
                     std::string driverInfo((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
-                    if (driverInfo.contains("550.") || driverInfo.contains("555."))
+                    if (driverInfo.contains("550.") || driverInfo.contains("555.") || driverInfo.contains("545.") || driverInfo.contains("540.") || driverInfo.contains("535.") ||
+                        driverInfo.contains("530.") || driverInfo.contains("525.") || driverInfo.contains("520.") || driverInfo.contains("515.") || driverInfo.contains("510.") ||
+                        driverInfo.contains("505.") || driverInfo.contains("500.") || driverInfo.contains("470."))
                         settings.explicitKMSEnabled = false;
                     else
                         settings.explicitKMSEnabled = true;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2654,7 +2654,8 @@ void CHyprRenderer::endRender() {
     PMONITOR->commitSeq++;
 
     auto cleanup = CScopeGuard([this]() {
-        m_pCurrentRenderbuffer->unbind();
+        if (m_pCurrentRenderbuffer)
+            m_pCurrentRenderbuffer->unbind();
         m_pCurrentRenderbuffer = nullptr;
         m_pCurrentBuffer       = nullptr;
     });

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1097,7 +1097,7 @@ void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
     static auto                                           PDEBUGOVERLAY       = CConfigValue<Hyprlang::INT>("debug:overlay");
     static auto                                           PDAMAGETRACKINGMODE = CConfigValue<Hyprlang::INT>("debug:damage_tracking");
     static auto                                           PDAMAGEBLINK        = CConfigValue<Hyprlang::INT>("debug:damage_blink");
-    static auto                                           PNODIRECTSCANOUT    = CConfigValue<Hyprlang::INT>("misc:no_direct_scanout");
+    static auto                                           PDIRECTSCANOUT      = CConfigValue<Hyprlang::INT>("render:direct_scanout");
     static auto                                           PVFR                = CConfigValue<Hyprlang::INT>("misc:vfr");
     static auto                                           PZOOMFACTOR         = CConfigValue<Hyprlang::FLOAT>("cursor:zoom_factor");
     static auto                                           PANIMENABLED        = CConfigValue<Hyprlang::INT>("animations:enabled");
@@ -1197,7 +1197,7 @@ void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
 
     pMonitor->tearingState.activelyTearing = shouldTear;
 
-    if (!*PNODIRECTSCANOUT && !shouldTear) {
+    if (*PDIRECTSCANOUT && !shouldTear) {
         if (pMonitor->attemptDirectScanout()) {
             return;
         } else if (!pMonitor->lastScanout.expired()) {

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -142,6 +142,7 @@ class CHyprRenderer {
     friend class CToplevelExportFrame;
     friend class CInputManager;
     friend class CPointerManager;
+    friend class CMonitor;
 };
 
 inline std::unique_ptr<CHyprRenderer> g_pHyprRenderer;

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -39,6 +39,10 @@ class CToplevelExportProtocolManager;
 class CInputManager;
 struct SSessionLockSurface;
 
+struct SExplicitSyncSettings {
+    bool explicitEnabled = false, explicitKMSEnabled = false;
+};
+
 class CHyprRenderer {
   public:
     CHyprRenderer();
@@ -73,6 +77,7 @@ class CHyprRenderer {
     bool                            isNvidia();
     void                            makeEGLCurrent();
     void                            unsetEGL();
+    SExplicitSyncSettings           getExplicitSyncSettings();
 
     // if RENDER_MODE_NORMAL, provided damage will be written to.
     // otherwise, it will be the one used.


### PR DESCRIPTION
Drops explicit sync from being experimental into being always on™, you can still disable it though with `render:explicit_sync = false`

TODO:
 - [ ] Testing
 - [x] DS might be brok
 - [x] cleanup
 - [x] DS glitches at high fps
 - [x] cs2 fps are halved

Fixes #6964
Closes #4857

Maybe #6980

Breaking:
 - `misc:no_direct_scanout` -> `render:direct_scanout`

Config:
 - `render:explicit_sync` -> default 2 (auto)
 - `render:explicit_sync_kms` -> default 2 (auto)

cc @ikalco @UjinT34 @fufexan @romanstingler 