### PR TITLE
increase hyprctl timeout to 5s to fix #6801

### DIFF
--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -141,7 +141,7 @@ int rollingRead(const int socket) {
 int request(std::string arg, int minArgs = 0, bool needRoll = false) {
     const auto SERVERSOCKET = socket(AF_UNIX, SOCK_STREAM, 0);
 
-    auto       t = timeval{.tv_sec = 1, .tv_usec = 0};
+    auto       t = timeval{.tv_sec = 5, .tv_usec = 0};
     setsockopt(SERVERSOCKET, SOL_SOCKET, SO_RCVTIMEO, &t, sizeof(struct timeval));
 
     const auto ARGS = std::count(arg.begin(), arg.end(), ' ');


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

In b2590b58c51094424a9651d8df37dfab838b5bbb, a timeout of 1s was added to hyprctl, which caused the bug described in #6801. Increasing the timout to 5s fixes it. More info on what the actual bug is in this comment: https://github.com/hyprwm/Hyprland/issues/6801#issuecomment-2248973724

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I think this is a pretty patchy solution, the current timeout is 1s and I feel like that should be enough for hyprctl to get the version. The reason why it takes longer than 1s (only at boot!) to get the version should be investigated.

While investigating this bug, I noticed some potential improvements that I would also like to propose (for different PRs):
* We currently have 2 `execAndGet` methods: one in [MiscFunctions.cpp](https://github.com/hyprwm/Hyprland/blob/1fa4b7d79baaad47fde8e72221cd77f569fbfe35/src/helpers/MiscFunctions.cpp#L585) and one in [PluginManager.cpp](https://github.com/hyprwm/Hyprland/blob/1fa4b7d79baaad47fde8e72221cd77f569fbfe35/hyprpm/src/core/PluginManager.cpp#L25). I feel like these could be merged?
* We should check the exit code in `execAndGet`. I propose we return either a tuple of std::string and int, or a struct containing these two (a struct might be more readable to the caller). This way, we can better handle errors like the one described in the issue. 
* To get the version from hyprpm, we currently use `execAndGet("hyprctl version")` [here](https://github.com/hyprwm/Hyprland/blob/1fa4b7d79baaad47fde8e72221cd77f569fbfe35/hyprpm/src/core/PluginManager.cpp#L48), and then we use a combination of `find` and `substring` to get the version, git tag, branch name, etc. Why not use the output of `hyprctl version -j`, and parse it as json?
* And this leads me into my last point: do we not have a json parser in the repo?

#### Is it ready for merging, or does it need work?

ready to merge