### PR TITLE
CMake: Suppress CMake warning about GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.27)
 
-include(CheckIncludeFile)
-include(GNUInstallDirs)
-
 # Get version
 file(READ "${CMAKE_SOURCE_DIR}/VERSION" VER_RAW)
 string(STRIP ${VER_RAW} VER)
@@ -11,6 +8,9 @@ project(
   Hyprland
   DESCRIPTION "A Modern C++ Wayland Compositor"
   VERSION ${VER})
+
+include(CheckIncludeFile)
+include(GNUInstallDirs)
 
 set(HYPRLAND_VERSION ${VER})
 set(PREFIX ${CMAKE_INSTALL_PREFIX})


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
CMake no longer warns about `Unable to determine default CMAKE_INSTALL_LIBDIR directory`

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Generally speaking, it is recommended to place project() as close to the beginning of top-level CMakeLists.txt as possible, but after calling cmake_minimum_required(), which is what was done.

When building, cmake gave the following warning:
```
CMake Warning (dev) at /usr/share/cmake/Modules/GNUInstallDirs.cmake:253 (message):
Not searching for unused variables given on the command line.
  Unable to determine default CMAKE_INSTALL_LIBDIR directory because no
  target architecture is known.  Please enable at least one language before
  including GNUInstallDirs.
Call Stack (most recent call first):
  CMakeLists.txt:4 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```
It is related to the fact that include(GNUInstallDirs) is located before the project() command.

#### Is it ready for merging, or does it need work?

Ready.
