### PR TITLE
fix infinite recursion on no_gaps when only

### DIFF
--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -141,7 +141,6 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
 
     PWINDOW->unsetWindowData(PRIORITY_LAYOUT);
     PWINDOW->updateWindowData();
-    PWINDOW->updateWindowDecos();
 
     static auto PNOGAPSWHENONLY = CConfigValue<Hyprlang::INT>("dwindle:no_gaps_when_only");
     static auto PGAPSINDATA     = CConfigValue<Hyprlang::CUSTOMTYPE>("general:gaps_in");
@@ -177,6 +176,8 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
 
         return;
     }
+
+    PWINDOW->updateWindowDecos();
 
     auto       calcPos  = PWINDOW->m_vPosition;
     auto       calcSize = PWINDOW->m_vSize;
@@ -245,8 +246,6 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
 
         g_pHyprRenderer->damageWindow(PWINDOW);
     }
-
-    PWINDOW->updateWindowDecos();
 }
 
 void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection direction) {

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -650,7 +650,6 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
 
     PWINDOW->unsetWindowData(PRIORITY_LAYOUT);
     PWINDOW->updateWindowData();
-    PWINDOW->updateWindowDecos();
 
     static auto PNOGAPSWHENONLY = CConfigValue<Hyprlang::INT>("master:no_gaps_when_only");
     static auto PANIMATE        = CConfigValue<Hyprlang::INT>("misc:animate_manual_resizes");
@@ -688,6 +687,8 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
 
         return;
     }
+
+    PWINDOW->updateWindowDecos();
 
     auto       calcPos  = PWINDOW->m_vPosition;
     auto       calcSize = PWINDOW->m_vSize;
@@ -731,8 +732,6 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
 
         g_pHyprRenderer->damageWindow(PWINDOW);
     }
-
-    PWINDOW->updateWindowDecos();
 }
 
 bool CHyprMasterLayout::isWindowTiled(PHLWINDOW pWindow) {

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -93,7 +93,7 @@ void CHyprBorderDecoration::updateWindow(PHLWINDOW) {
 
     m_iLastBorderSize = borderSize;
 
-    g_pEventLoopManager->doLater([this]() { g_pDecorationPositioner->repositionDeco(this); });
+    g_pDecorationPositioner->repositionDeco(this);
 }
 
 void CHyprBorderDecoration::damageEntire() {


### PR DESCRIPTION
fixes infinite recursion when using `no_gaps_when_only`
partially reverts https://github.com/hyprwm/Hyprland/commit/60571cd5ccc76f91209ef2faac93ecea542de221

closes: #7138 and closes: #7167 