### PR TITLE
fix leds on kb creation

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -919,6 +919,8 @@ void CInputManager::setupKeyboard(SP<IKeyboard> keeb) {
     applyConfigToKeyboard(keeb);
 
     g_pSeatManager->setKeyboard(keeb);
+
+    keeb->updateLEDs();
 }
 
 void CInputManager::setKeyboardLayout() {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
when starting or vt switching, numlock led isnt set until a key is pressed
this fixes that

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
yes

