### PR TITLE
debug: dont manually unlock the lock_guard

### DIFF
--- a/src/debug/Log.hpp
+++ b/src/debug/Log.hpp
@@ -72,6 +72,5 @@ namespace Debug {
         logMsg += std::vformat(fmt.get(), std::make_format_args(args...));
 
         log(level, logMsg);
-        logMutex.unlock();
     }
 };


### PR DESCRIPTION
when lock_guard goes out of scope it RAII itself and calls unlock. causes crashes on freebsd/libc++ and double unlocking a mutex is UB.

Fixes: #7203


seems i introduced UB that neither my eye nor ubsan has catched. interesting how nothing but freebsd/libc++ catched this.