### PR TITLE
hyprctl: link to much less libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,12 @@ endif()
 find_package(OpenGL REQUIRED COMPONENTS ${GLES_VERSION})
 
 pkg_check_modules(
+  hyprctl_deps
+  REQUIRED
+  IMPORTED_TARGET
+  hyprutils>=0.2.1)
+
+pkg_check_modules(
   deps
   REQUIRED
   IMPORTED_TARGET

--- a/hyprctl/CMakeLists.txt
+++ b/hyprctl/CMakeLists.txt
@@ -9,7 +9,7 @@ pkg_check_modules(deps REQUIRED IMPORTED_TARGET hyprutils>=0.1.1)
 
 add_executable(hyprctl "main.cpp")
 
-target_link_libraries(hyprctl PUBLIC PkgConfig::deps)
+target_link_libraries(hyprctl PUBLIC PkgConfig::hyprctl_deps)
 
 # binary
 install(TARGETS hyprctl)


### PR DESCRIPTION
I got annoyed by latency caused by implementing some operations in shell scripts; particularly if the shell script needed to read some status using hyprctl and then decide to do more hyprctl executions.

#### Describe your PR, what does it fix/add?

This makes hyprctl start significantly faster.

`$ time for ((i=0; i<1000; i++)); do hyprctl/hyprctl -j activewindow >/dev/null; done`

Before: 12.269 s (about 12.3 ms/execution)
After: 2.142 s (about 2.1 ms/execution)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

The one thing I don't like is how this adds another mention (and version constraint) of `hyprutils>=0.2.1` in the top level `CMakeLists.txt`. I don't understand CMake well enough to tell if the `deps` could be made to somehow inherit `hyprctl_deps`.

#### Is it ready for merging, or does it need work?

I believe it is ready to merge as is, unless you know a way to only mention hyprutils once :)