### PR TITLE
type conversion to new types to avoid unsigned int rollover and signed int overflow

### DIFF
--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -113,7 +113,7 @@ int rollingRead(const int socket) {
 
     constexpr size_t              BUFFER_SIZE = 8192;
     std::array<char, BUFFER_SIZE> buffer      = {0};
-    int                           sizeWritten = 0;
+    long                          sizeWritten = 0;
     std::cout << "[hyprctl] reading from socket following up log:" << std::endl;
     while (!sigintReceived) {
         sizeWritten = read(socket, buffer.data(), BUFFER_SIZE);

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -683,9 +683,9 @@ void CCompositor::startCompositor() {
     g_pEventLoopManager->enterLoop();
 }
 
-CMonitor* CCompositor::getMonitorFromID(const int& id) {
+CMonitor* CCompositor::getMonitorFromID(const MONITORID& id) {
     for (auto& m : m_vMonitors) {
-        if (m->ID == (uint64_t)id) {
+        if (m->ID == id) {
             return m.get();
         }
     }
@@ -845,8 +845,8 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
         if (properties & FLOATING_ONLY)
             return floating(false);
 
-        const int64_t WORKSPACEID = special ? PMONITOR->activeSpecialWorkspaceID() : PMONITOR->activeWorkspaceID();
-        const auto    PWORKSPACE  = getWorkspaceByID(WORKSPACEID);
+        const WORKSPACEID WSPID      = special ? PMONITOR->activeSpecialWorkspaceID() : PMONITOR->activeWorkspaceID();
+        const auto        PWORKSPACE = getWorkspaceByID(WSPID);
 
         if (PWORKSPACE->m_bHasFullscreenWindow)
             return getFullscreenWindowOnWorkspace(PWORKSPACE->m_iID);
@@ -860,7 +860,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
             if (special != w->onSpecialWorkspace())
                 continue;
 
-            if (!w->m_bIsX11 && !w->m_bIsFloating && w->m_bIsMapped && w->workspaceID() == WORKSPACEID && !w->isHidden() && !w->m_bX11ShouldntFocus &&
+            if (!w->m_bIsX11 && !w->m_bIsFloating && w->m_bIsMapped && w->workspaceID() == WSPID && !w->isHidden() && !w->m_bX11ShouldntFocus &&
                 !w->m_sWindowData.noFocus.valueOrDefault() && w != pIgnoreWindow) {
                 if (w->hasPopupAt(pos))
                     return w;
@@ -872,7 +872,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
                 continue;
 
             CBox box = (properties & USE_PROP_TILED) ? w->getWindowBoxUnified(properties) : CBox{w->m_vPosition, w->m_vSize};
-            if (!w->m_bIsFloating && w->m_bIsMapped && box.containsPoint(pos) && w->workspaceID() == WORKSPACEID && !w->isHidden() && !w->m_bX11ShouldntFocus &&
+            if (!w->m_bIsFloating && w->m_bIsMapped && box.containsPoint(pos) && w->workspaceID() == WSPID && !w->isHidden() && !w->m_bX11ShouldntFocus &&
                 !w->m_sWindowData.noFocus.valueOrDefault() && w != pIgnoreWindow)
                 return w;
         }
@@ -1207,7 +1207,7 @@ PHLWINDOW CCompositor::getWindowFromHandle(uint32_t handle) {
     return nullptr;
 }
 
-PHLWINDOW CCompositor::getFullscreenWindowOnWorkspace(const int& ID) {
+PHLWINDOW CCompositor::getFullscreenWindowOnWorkspace(const WORKSPACEID& ID) {
     for (auto& w : m_vWindows) {
         if (w->workspaceID() == ID && w->isFullscreen())
             return w;
@@ -1231,7 +1231,7 @@ bool CCompositor::isWorkspaceVisibleNotCovered(PHLWORKSPACE w) {
     return PMONITOR->activeWorkspace->m_iID == w->m_iID;
 }
 
-PHLWORKSPACE CCompositor::getWorkspaceByID(const int& id) {
+PHLWORKSPACE CCompositor::getWorkspaceByID(const WORKSPACEID& id) {
     for (auto& w : m_vWorkspaces) {
         if (w->m_iID == id && !w->inert())
             return w;
@@ -1255,7 +1255,7 @@ void CCompositor::sanityCheckWorkspaces() {
     }
 }
 
-int CCompositor::getWindowsOnWorkspace(const int& id, std::optional<bool> onlyTiled, std::optional<bool> onlyVisible) {
+int CCompositor::getWindowsOnWorkspace(const WORKSPACEID& id, std::optional<bool> onlyTiled, std::optional<bool> onlyVisible) {
     int no = 0;
     for (auto& w : m_vWindows) {
         if (w->workspaceID() != id || !w->m_bIsMapped)
@@ -1270,7 +1270,7 @@ int CCompositor::getWindowsOnWorkspace(const int& id, std::optional<bool> onlyTi
     return no;
 }
 
-int CCompositor::getGroupsOnWorkspace(const int& id, std::optional<bool> onlyTiled, std::optional<bool> onlyVisible) {
+int CCompositor::getGroupsOnWorkspace(const WORKSPACEID& id, std::optional<bool> onlyTiled, std::optional<bool> onlyVisible) {
     int no = 0;
     for (auto& w : m_vWindows) {
         if (w->workspaceID() != id || !w->m_bIsMapped)
@@ -1295,7 +1295,7 @@ PHLWINDOW CCompositor::getUrgentWindow() {
     return nullptr;
 }
 
-bool CCompositor::hasUrgentWindowOnWorkspace(const int& id) {
+bool CCompositor::hasUrgentWindowOnWorkspace(const WORKSPACEID& id) {
     for (auto& w : m_vWindows) {
         if (w->workspaceID() == id && w->m_bIsMapped && w->m_bIsUrgent)
             return true;
@@ -1304,7 +1304,7 @@ bool CCompositor::hasUrgentWindowOnWorkspace(const int& id) {
     return false;
 }
 
-PHLWINDOW CCompositor::getFirstWindowOnWorkspace(const int& id) {
+PHLWINDOW CCompositor::getFirstWindowOnWorkspace(const WORKSPACEID& id) {
     for (auto& w : m_vWindows) {
         if (w->workspaceID() == id && w->m_bIsMapped && !w->isHidden())
             return w;
@@ -1313,7 +1313,7 @@ PHLWINDOW CCompositor::getFirstWindowOnWorkspace(const int& id) {
     return nullptr;
 }
 
-PHLWINDOW CCompositor::getTopLeftWindowOnWorkspace(const int& id) {
+PHLWINDOW CCompositor::getTopLeftWindowOnWorkspace(const WORKSPACEID& id) {
     const auto PWORKSPACE = getWorkspaceByID(id);
 
     if (!PWORKSPACE)
@@ -1401,12 +1401,12 @@ void CCompositor::changeWindowZOrder(PHLWINDOW pWindow, bool top) {
     }
 }
 
-void CCompositor::cleanupFadingOut(const int& monid) {
+void CCompositor::cleanupFadingOut(const MONITORID& monid) {
     for (auto& ww : m_vWindowsFadingOut) {
 
         auto w = ww.lock();
 
-        if (w->m_iMonitorID != (long unsigned int)monid)
+        if (w->m_iMonitorID != monid)
             continue;
 
         if (!w->m_bFadingOut || w->m_fAlpha.value() == 0.f) {
@@ -1702,8 +1702,8 @@ PHLWINDOW CCompositor::getPrevWindowOnWorkspace(PHLWINDOW pWindow, bool focusabl
     return nullptr;
 }
 
-int CCompositor::getNextAvailableNamedWorkspace() {
-    int lowest = -1337 + 1;
+WORKSPACEID CCompositor::getNextAvailableNamedWorkspace() {
+    WORKSPACEID lowest = -1337 + 1;
     for (auto& w : m_vWorkspaces) {
         if (w->m_iID < -1 && w->m_iID < lowest)
             lowest = w->m_iID;
@@ -1927,18 +1927,18 @@ void CCompositor::updateWindowAnimatedDecorationValues(PHLWINDOW pWindow) {
     pWindow->updateWindowDecos();
 }
 
-int CCompositor::getNextAvailableMonitorID(std::string const& name) {
+MONITORID CCompositor::getNextAvailableMonitorID(std::string const& name) {
     // reuse ID if it's already in the map, and the monitor with that ID is not being used by another monitor
     if (m_mMonitorIDMap.contains(name) && !std::any_of(m_vRealMonitors.begin(), m_vRealMonitors.end(), [&](auto m) { return m->ID == m_mMonitorIDMap[name]; }))
         return m_mMonitorIDMap[name];
 
     // otherwise, find minimum available ID that is not in the map
-    std::unordered_set<uint64_t> usedIDs;
+    std::unordered_set<MONITORID> usedIDs;
     for (auto const& monitor : m_vRealMonitors) {
         usedIDs.insert(monitor->ID);
     }
 
-    uint64_t nextID = 0;
+    MONITORID nextID = 0;
     while (usedIDs.count(nextID) > 0) {
         nextID++;
     }
@@ -2078,7 +2078,7 @@ CMonitor* CCompositor::getMonitorFromString(const std::string& name) {
         return m_vMonitors[currentPlace].get();
     } else if (isNumber(name)) {
         // change by ID
-        int monID = -1;
+        MONITORID monID = MONITOR_INVALID;
         try {
             monID = std::stoi(name);
         } catch (std::exception& e) {
@@ -2087,7 +2087,7 @@ CMonitor* CCompositor::getMonitorFromString(const std::string& name) {
             return nullptr;
         }
 
-        if (monID > -1 && monID < (int)m_vMonitors.size()) {
+        if (monID > -1 && monID < (MONITORID)m_vMonitors.size()) {
             return getMonitorFromID(monID);
         } else {
             Debug::log(ERR, "Error in getMonitorFromString: invalid arg 1");
@@ -2121,7 +2121,7 @@ void CCompositor::moveWorkspaceToMonitor(PHLWORKSPACE pWorkspace, CMonitor* pMon
     const bool SWITCHINGISACTIVE = POLDMON ? POLDMON->activeWorkspace == pWorkspace : false;
 
     // fix old mon
-    int nextWorkspaceOnMonitorID = -1;
+    WORKSPACEID nextWorkspaceOnMonitorID = WORKSPACE_INVALID;
     if (!SWITCHINGISACTIVE)
         nextWorkspaceOnMonitorID = pWorkspace->m_iID;
     else {
@@ -2132,7 +2132,7 @@ void CCompositor::moveWorkspaceToMonitor(PHLWORKSPACE pWorkspace, CMonitor* pMon
             }
         }
 
-        if (nextWorkspaceOnMonitorID == -1) {
+        if (nextWorkspaceOnMonitorID == WORKSPACE_INVALID) {
             nextWorkspaceOnMonitorID = 1;
 
             while (getWorkspaceByID(nextWorkspaceOnMonitorID) || [&]() -> bool {
@@ -2219,9 +2219,9 @@ void CCompositor::moveWorkspaceToMonitor(PHLWORKSPACE pWorkspace, CMonitor* pMon
     EMIT_HOOK_EVENT("moveWorkspace", (std::vector<std::any>{pWorkspace, pMonitor}));
 }
 
-bool CCompositor::workspaceIDOutOfBounds(const int64_t& id) {
-    int64_t lowestID  = INT64_MAX;
-    int64_t highestID = INT64_MIN;
+bool CCompositor::workspaceIDOutOfBounds(const WORKSPACEID& id) {
+    WORKSPACEID lowestID  = INT64_MAX;
+    WORKSPACEID highestID = INT64_MIN;
 
     for (auto& w : m_vWorkspaces) {
         if (w->m_bIsSpecialWorkspace)
@@ -2370,7 +2370,7 @@ PHLWINDOW CCompositor::getX11Parent(PHLWINDOW pWindow) {
     return nullptr;
 }
 
-void CCompositor::updateWorkspaceWindowDecos(const int& id) {
+void CCompositor::updateWorkspaceWindowDecos(const WORKSPACEID& id) {
     for (auto& w : m_vWindows) {
         if (w->workspaceID() != id)
             continue;
@@ -2379,7 +2379,7 @@ void CCompositor::updateWorkspaceWindowDecos(const int& id) {
     }
 }
 
-void CCompositor::updateWorkspaceWindowData(const int& id) {
+void CCompositor::updateWorkspaceWindowData(const WORKSPACEID& id) {
     const auto PWORKSPACE    = getWorkspaceByID(id);
     const auto WORKSPACERULE = PWORKSPACE ? g_pConfigManager->getWorkspaceRuleFor(PWORKSPACE) : SWorkspaceRule{};
 
@@ -2599,7 +2599,7 @@ Vector2D CCompositor::parseWindowVectorArgsRelative(const std::string& args, con
     return Vector2D(X, Y);
 }
 
-void CCompositor::forceReportSizesToWindowsOnWorkspace(const int& wid) {
+void CCompositor::forceReportSizesToWindowsOnWorkspace(const WORKSPACEID& wid) {
     for (auto& w : m_vWindows) {
         if (w->workspaceID() == wid && w->m_bIsMapped && !w->isHidden()) {
             g_pXWaylandManager->setWindowSize(w, w->m_vRealSize.value(), true);
@@ -2607,7 +2607,7 @@ void CCompositor::forceReportSizesToWindowsOnWorkspace(const int& wid) {
     }
 }
 
-PHLWORKSPACE CCompositor::createNewWorkspace(const int& id, const int& monid, const std::string& name, bool isEmtpy) {
+PHLWORKSPACE CCompositor::createNewWorkspace(const WORKSPACEID& id, const MONITORID& monid, const std::string& name, bool isEmtpy) {
     const auto NAME  = name == "" ? std::to_string(id) : name;
     auto       monID = monid;
 
@@ -2625,7 +2625,7 @@ PHLWORKSPACE CCompositor::createNewWorkspace(const int& id, const int& monid, co
     return PWORKSPACE;
 }
 
-void CCompositor::renameWorkspace(const int& id, const std::string& name) {
+void CCompositor::renameWorkspace(const WORKSPACEID& id, const std::string& name) {
     const auto PWORKSPACE = getWorkspaceByID(id);
 
     if (!PWORKSPACE)
@@ -2656,12 +2656,12 @@ void CCompositor::setActiveMonitor(CMonitor* pMonitor) {
     m_pLastMonitor = pMonitor->self;
 }
 
-bool CCompositor::isWorkspaceSpecial(const int& id) {
+bool CCompositor::isWorkspaceSpecial(const WORKSPACEID& id) {
     return id >= SPECIAL_WORKSPACE_START && id <= -2;
 }
 
-int CCompositor::getNewSpecialID() {
-    int highest = SPECIAL_WORKSPACE_START;
+WORKSPACEID CCompositor::getNewSpecialID() {
+    WORKSPACEID highest = SPECIAL_WORKSPACE_START;
     for (auto& ws : m_vWorkspaces) {
         if (ws->m_bIsSpecialWorkspace && ws->m_iID > highest) {
             highest = ws->m_iID;
@@ -2965,7 +2965,7 @@ void CCompositor::onNewMonitor(SP<Aquamarine::IOutput> output) {
     PNEWMONITOR->output           = output;
     PNEWMONITOR->self             = PNEWMONITOR;
     const bool FALLBACK           = g_pCompositor->m_pUnsafeOutput ? output == g_pCompositor->m_pUnsafeOutput->output : false;
-    PNEWMONITOR->ID               = FALLBACK ? -1 : g_pCompositor->getNextAvailableMonitorID(output->name);
+    PNEWMONITOR->ID               = FALLBACK ? MONITOR_INVALID : g_pCompositor->getNextAvailableMonitorID(output->name);
     PNEWMONITOR->isUnsafeFallback = FALLBACK;
 
     EMIT_HOOK_EVENT("newMonitor", PNEWMONITOR);
@@ -2990,7 +2990,7 @@ void CCompositor::onNewMonitor(SP<Aquamarine::IOutput> output) {
 
     for (auto& w : g_pCompositor->m_vWindows) {
         if (w->m_iMonitorID == PNEWMONITOR->ID) {
-            w->m_iLastSurfaceMonitorID = -1;
+            w->m_iLastSurfaceMonitorID = MONITOR_INVALID;
             w->updateSurfaceScaleTransformDetails();
         }
     }

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -46,55 +46,55 @@ class CCompositor {
     CCompositor();
     ~CCompositor();
 
-    wl_display*                               m_sWLDisplay;
-    wl_event_loop*                            m_sWLEventLoop;
-    int                                       m_iDRMFD       = -1;
-    bool                                      m_bInitialized = false;
-    SP<Aquamarine::CBackend>                  m_pAqBackend;
+    wl_display*                                m_sWLDisplay;
+    wl_event_loop*                             m_sWLEventLoop;
+    int                                        m_iDRMFD       = -1;
+    bool                                       m_bInitialized = false;
+    SP<Aquamarine::CBackend>                   m_pAqBackend;
 
-    std::string                               m_szHyprTempDataRoot = "";
+    std::string                                m_szHyprTempDataRoot = "";
 
-    std::string                               m_szWLDisplaySocket   = "";
-    std::string                               m_szInstanceSignature = "";
-    std::string                               m_szInstancePath      = "";
-    std::string                               m_szCurrentSplash     = "error";
+    std::string                                m_szWLDisplaySocket   = "";
+    std::string                                m_szInstanceSignature = "";
+    std::string                                m_szInstancePath      = "";
+    std::string                                m_szCurrentSplash     = "error";
 
-    std::vector<SP<CMonitor>>                 m_vMonitors;
-    std::vector<SP<CMonitor>>                 m_vRealMonitors; // for all monitors, even those turned off
-    std::vector<PHLWINDOW>                    m_vWindows;
-    std::vector<PHLLS>                        m_vLayers;
-    std::vector<PHLWORKSPACE>                 m_vWorkspaces;
-    std::vector<PHLWINDOWREF>                 m_vWindowsFadingOut;
-    std::vector<PHLLSREF>                     m_vSurfacesFadingOut;
+    std::vector<SP<CMonitor>>                  m_vMonitors;
+    std::vector<SP<CMonitor>>                  m_vRealMonitors; // for all monitors, even those turned off
+    std::vector<PHLWINDOW>                     m_vWindows;
+    std::vector<PHLLS>                         m_vLayers;
+    std::vector<PHLWORKSPACE>                  m_vWorkspaces;
+    std::vector<PHLWINDOWREF>                  m_vWindowsFadingOut;
+    std::vector<PHLLSREF>                      m_vSurfacesFadingOut;
 
-    std::unordered_map<std::string, uint64_t> m_mMonitorIDMap;
+    std::unordered_map<std::string, MONITORID> m_mMonitorIDMap;
 
-    void                                      initServer(std::string socketName, int socketFd);
-    void                                      startCompositor();
-    void                                      stopCompositor();
-    void                                      cleanup();
-    void                                      createLockFile();
-    void                                      removeLockFile();
-    void                                      bumpNofile();
-    void                                      restoreNofile();
+    void                                       initServer(std::string socketName, int socketFd);
+    void                                       startCompositor();
+    void                                       stopCompositor();
+    void                                       cleanup();
+    void                                       createLockFile();
+    void                                       removeLockFile();
+    void                                       bumpNofile();
+    void                                       restoreNofile();
 
-    WP<CWLSurfaceResource>                    m_pLastFocus;
-    PHLWINDOWREF                              m_pLastWindow;
-    WP<CMonitor>                              m_pLastMonitor;
+    WP<CWLSurfaceResource>                     m_pLastFocus;
+    PHLWINDOWREF                               m_pLastWindow;
+    WP<CMonitor>                               m_pLastMonitor;
 
-    std::vector<PHLWINDOWREF>                 m_vWindowFocusHistory; // first element is the most recently focused.
+    std::vector<PHLWINDOWREF>                  m_vWindowFocusHistory; // first element is the most recently focused.
 
-    bool                                      m_bReadyToProcess = false;
-    bool                                      m_bSessionActive  = true;
-    bool                                      m_bDPMSStateON    = true;
-    bool                                      m_bUnsafeState    = false; // unsafe state is when there is no monitors.
-    bool                                      m_bNextIsUnsafe   = false;
-    CMonitor*                                 m_pUnsafeOutput   = nullptr; // fallback output for the unsafe state
-    bool                                      m_bIsShuttingDown = false;
+    bool                                       m_bReadyToProcess = false;
+    bool                                       m_bSessionActive  = true;
+    bool                                       m_bDPMSStateON    = true;
+    bool                                       m_bUnsafeState    = false; // unsafe state is when there is no monitors.
+    bool                                       m_bNextIsUnsafe   = false;
+    CMonitor*                                  m_pUnsafeOutput   = nullptr; // fallback output for the unsafe state
+    bool                                       m_bIsShuttingDown = false;
 
     // ------------------------------------------------- //
 
-    CMonitor*              getMonitorFromID(const int&);
+    CMonitor*              getMonitorFromID(const MONITORID&);
     CMonitor*              getMonitorFromName(const std::string&);
     CMonitor*              getMonitorFromDesc(const std::string&);
     CMonitor*              getMonitorFromCursor();
@@ -114,38 +114,38 @@ class CCompositor {
     PHLWINDOW              getWindowFromHandle(uint32_t);
     bool                   isWorkspaceVisible(PHLWORKSPACE);
     bool                   isWorkspaceVisibleNotCovered(PHLWORKSPACE);
-    PHLWORKSPACE           getWorkspaceByID(const int&);
+    PHLWORKSPACE           getWorkspaceByID(const WORKSPACEID&);
     PHLWORKSPACE           getWorkspaceByName(const std::string&);
     PHLWORKSPACE           getWorkspaceByString(const std::string&);
     void                   sanityCheckWorkspaces();
-    void                   updateWorkspaceWindowDecos(const int&);
-    void                   updateWorkspaceWindowData(const int&);
-    int                    getWindowsOnWorkspace(const int& id, std::optional<bool> onlyTiled = {}, std::optional<bool> onlyVisible = {});
-    int                    getGroupsOnWorkspace(const int& id, std::optional<bool> onlyTiled = {}, std::optional<bool> onlyVisible = {});
+    void                   updateWorkspaceWindowDecos(const WORKSPACEID&);
+    void                   updateWorkspaceWindowData(const WORKSPACEID&);
+    int                    getWindowsOnWorkspace(const WORKSPACEID& id, std::optional<bool> onlyTiled = {}, std::optional<bool> onlyVisible = {});
+    int                    getGroupsOnWorkspace(const WORKSPACEID& id, std::optional<bool> onlyTiled = {}, std::optional<bool> onlyVisible = {});
     PHLWINDOW              getUrgentWindow();
-    bool                   hasUrgentWindowOnWorkspace(const int&);
-    PHLWINDOW              getFirstWindowOnWorkspace(const int&);
-    PHLWINDOW              getTopLeftWindowOnWorkspace(const int&);
-    PHLWINDOW              getFullscreenWindowOnWorkspace(const int&);
+    bool                   hasUrgentWindowOnWorkspace(const WORKSPACEID&);
+    PHLWINDOW              getFirstWindowOnWorkspace(const WORKSPACEID&);
+    PHLWINDOW              getTopLeftWindowOnWorkspace(const WORKSPACEID&);
+    PHLWINDOW              getFullscreenWindowOnWorkspace(const WORKSPACEID&);
     bool                   isWindowActive(PHLWINDOW);
     void                   changeWindowZOrder(PHLWINDOW, bool);
-    void                   cleanupFadingOut(const int& monid);
+    void                   cleanupFadingOut(const MONITORID& monid);
     PHLWINDOW              getWindowInDirection(PHLWINDOW, char);
     PHLWINDOW              getNextWindowOnWorkspace(PHLWINDOW, bool focusableOnly = false, std::optional<bool> floating = {});
     PHLWINDOW              getPrevWindowOnWorkspace(PHLWINDOW, bool focusableOnly = false, std::optional<bool> floating = {});
-    int                    getNextAvailableNamedWorkspace();
+    WORKSPACEID            getNextAvailableNamedWorkspace();
     bool                   isPointOnAnyMonitor(const Vector2D&);
     bool                   isPointOnReservedArea(const Vector2D& point, const CMonitor* monitor = nullptr);
     CMonitor*              getMonitorInDirection(const char&);
     CMonitor*              getMonitorInDirection(CMonitor*, const char&);
     void                   updateAllWindowsAnimatedDecorationValues();
-    void                   updateWorkspaceWindows(const int64_t& id);
+    void                   updateWorkspaceWindows(const WORKSPACEID& id);
     void                   updateWindowAnimatedDecorationValues(PHLWINDOW);
-    int                    getNextAvailableMonitorID(std::string const& name);
+    MONITORID              getNextAvailableMonitorID(std::string const& name);
     void                   moveWorkspaceToMonitor(PHLWORKSPACE, CMonitor*, bool noWarpCursor = false);
     void                   swapActiveWorkspaces(CMonitor*, CMonitor*);
     CMonitor*              getMonitorFromString(const std::string&);
-    bool                   workspaceIDOutOfBounds(const int64_t&);
+    bool                   workspaceIDOutOfBounds(const WORKSPACEID&);
     void                   setWindowFullscreenInternal(const PHLWINDOW PWINDOW, const eFullscreenMode MODE);
     void                   setWindowFullscreenClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE);
     void                   setWindowFullscreenState(const PHLWINDOW PWINDOW, const sFullscreenState state);
@@ -162,12 +162,13 @@ class CCompositor {
     PHLLS                  getLayerSurfaceFromSurface(SP<CWLSurfaceResource>);
     void                   closeWindow(PHLWINDOW);
     Vector2D               parseWindowVectorArgsRelative(const std::string&, const Vector2D&);
-    void                   forceReportSizesToWindowsOnWorkspace(const int&);
-    PHLWORKSPACE           createNewWorkspace(const int&, const int&, const std::string& name = "", bool isEmtpy = true); // will be deleted next frame if left empty and unfocused!
-    void                   renameWorkspace(const int&, const std::string& name = "");
+    void                   forceReportSizesToWindowsOnWorkspace(const WORKSPACEID&);
+    PHLWORKSPACE           createNewWorkspace(const WORKSPACEID&, const MONITORID&, const std::string& name = "",
+                                              bool isEmtpy = true); // will be deleted next frame if left empty and unfocused!
+    void                   renameWorkspace(const WORKSPACEID&, const std::string& name = "");
     void                   setActiveMonitor(CMonitor*);
-    bool                   isWorkspaceSpecial(const int&);
-    int                    getNewSpecialID();
+    bool                   isWorkspaceSpecial(const WORKSPACEID&);
+    WORKSPACEID            getNewSpecialID();
     void                   performUserChecks();
     void                   moveWindowToWorkspaceSafe(PHLWINDOW pWindow, PHLWORKSPACE pWorkspace);
     PHLWINDOW              getForceFocus();

--- a/src/SharedDefs.hpp
+++ b/src/SharedDefs.hpp
@@ -52,4 +52,8 @@ struct SHyprCtlCommand {
     std::function<std::string(eHyprCtlOutputFormat, std::string)> fn;
 };
 
+typedef int64_t                                              WINDOWID;
+typedef int64_t                                              MONITORID;
+typedef int64_t                                              WORKSPACEID;
+
 typedef std::function<void(void*, SCallbackInfo&, std::any)> HOOK_CALLBACK_FN;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2425,7 +2425,7 @@ std::optional<std::string> CConfigManager::handleWorkspaceRules(const std::strin
     // }
 
     const static std::string ruleOnCreatedEmpty    = "on-created-empty:";
-    const static int         ruleOnCreatedEmptyLen = ruleOnCreatedEmpty.length();
+    const static auto        ruleOnCreatedEmptyLen = ruleOnCreatedEmpty.length();
 
     auto                     assignRule = [&](std::string rule) -> std::optional<std::string> {
         size_t delim = std::string::npos;

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -33,7 +33,7 @@ struct SWorkspaceRule {
     std::string                        monitor         = "";
     std::string                        workspaceString = "";
     std::string                        workspaceName   = "";
-    int                                workspaceId     = -1;
+    WORKSPACEID                        workspaceId     = -1;
     bool                               isDefault       = false;
     bool                               isPersistent    = false;
     std::optional<CCssGapData>         gapsIn;

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -71,7 +71,7 @@ static std::string availableModesForOutput(CMonitor* pMonitor, eHyprCtlOutputFor
 
 std::string CHyprCtl::getMonitorData(Hyprutils::Memory::CSharedPointer<CMonitor> m, eHyprCtlOutputFormat format) {
     std::string result;
-    if (!m->output || m->ID == -1ull)
+    if (!m->output || m->ID == -1)
         return "";
 
     if (format == eHyprCtlOutputFormat::FORMAT_JSON) {
@@ -155,7 +155,7 @@ std::string monitorsRequest(eHyprCtlOutputFormat format, std::string request) {
         result += "]";
     } else {
         for (auto& m : allMonitors ? g_pCompositor->m_vRealMonitors : g_pCompositor->m_vMonitors) {
-            if (!m->output || m->ID == -1ull)
+            if (!m->output || m->ID == -1)
                 continue;
 
             result +=

--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -432,8 +432,8 @@ void CLayerSurface::startAnimation(bool in, bool instant) {
             PMONITOR->vecPosition + Vector2D{PMONITOR->vecSize.x, PMONITOR->vecSize.y / 2},
         };
 
-        float closest = std::numeric_limits<float>::max();
-        int   leader  = force;
+        float  closest = std::numeric_limits<float>::max();
+        size_t leader  = force;
         if (leader == -1) {
             for (size_t i = 0; i < 4; ++i) {
                 float dist = MIDDLE.distance(edgePoints[i]);

--- a/src/desktop/LayerSurface.hpp
+++ b/src/desktop/LayerSurface.hpp
@@ -42,7 +42,7 @@ class CLayerSurface {
     bool                       mapped = false;
     uint32_t                   layer  = 0;
 
-    int                        monitorID = -1;
+    MONITORID                  monitorID = -1;
 
     bool                       fadingOut     = false;
     bool                       readyToDelete = false;
@@ -51,7 +51,7 @@ class CLayerSurface {
 
     bool                       forceBlur        = false;
     bool                       forceBlurPopups  = false;
-    int                        xray             = -1;
+    int64_t                    xray             = -1;
     bool                       ignoreAlpha      = false;
     float                      ignoreAlphaValue = 0.f;
     bool                       dimAround        = false;

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1243,7 +1243,7 @@ bool CWindow::isEffectiveInternalFSMode(const eFullscreenMode MODE) {
     return (eFullscreenMode)std::bit_floor((uint8_t)m_sFullscreenState.internal) == MODE;
 }
 
-int CWindow::workspaceID() {
+WORKSPACEID CWindow::workspaceID() {
     return m_pWorkspace ? m_pWorkspace->m_iID : m_iLastWorkspace;
 }
 

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -270,7 +270,7 @@ class CWindow {
     bool             m_bDraggingTiled   = false; // for dragging around tiled windows
     bool             m_bWasMaximized    = false;
     sFullscreenState m_sFullscreenState = {.internal = FSMODE_NONE, .client = FSMODE_NONE};
-    uint64_t         m_iMonitorID       = -1;
+    MONITORID        m_iMonitorID       = -1;
     std::string      m_szTitle          = "";
     std::string      m_szClass          = "";
     std::string      m_szInitialTitle   = "";
@@ -358,8 +358,8 @@ class CWindow {
     bool m_bStayFocused = false;
 
     // for toplevel monitor events
-    uint64_t m_iLastToplevelMonitorID = -1;
-    uint64_t m_iLastSurfaceMonitorID  = -1;
+    MONITORID m_iLastToplevelMonitorID = -1;
+    MONITORID m_iLastSurfaceMonitorID  = -1;
 
     // for idle inhibiting windows
     eIdleInhibitMode m_eIdleInhibitMode = IDLEINHIBIT_NONE;
@@ -421,7 +421,7 @@ class CWindow {
     bool                   canBeTorn();
     void                   setSuspended(bool suspend);
     bool                   visibleOnMonitor(CMonitor* pMonitor);
-    int                    workspaceID();
+    WORKSPACEID            workspaceID();
     bool                   onSpecialWorkspace();
     void                   activate(bool force = false);
     int                    surfacesCount();
@@ -490,9 +490,9 @@ class CWindow {
 
   private:
     // For hidden windows and stuff
-    bool m_bHidden        = false;
-    bool m_bSuspended     = false;
-    int  m_iLastWorkspace = WORKSPACE_INVALID;
+    bool        m_bHidden        = false;
+    bool        m_bSuspended     = false;
+    WORKSPACEID m_iLastWorkspace = WORKSPACE_INVALID;
 };
 
 inline bool valid(PHLWINDOW w) {

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -5,13 +5,13 @@
 #include <hyprutils/string/String.hpp>
 using namespace Hyprutils::String;
 
-PHLWORKSPACE CWorkspace::create(int id, int monitorID, std::string name, bool special, bool isEmtpy) {
+PHLWORKSPACE CWorkspace::create(WORKSPACEID id, MONITORID monitorID, std::string name, bool special, bool isEmtpy) {
     PHLWORKSPACE workspace = makeShared<CWorkspace>(id, monitorID, name, special, isEmtpy);
     workspace->init(workspace);
     return workspace;
 }
 
-CWorkspace::CWorkspace(int id, int monitorID, std::string name, bool special, bool isEmtpy) {
+CWorkspace::CWorkspace(WORKSPACEID id, MONITORID monitorID, std::string name, bool special, bool isEmtpy) {
     m_iMonitorID          = monitorID;
     m_iID                 = id;
     m_szName              = name;
@@ -190,7 +190,7 @@ void CWorkspace::setActive(bool on) {
     ; // empty until https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/40
 }
 
-void CWorkspace::moveToMonitor(const int& id) {
+void CWorkspace::moveToMonitor(const MONITORID& id) {
     ; // empty until https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/40
 }
 
@@ -275,7 +275,7 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
             i                     = std::min(NEXTSPACE, std::string::npos - 1);
 
             if (cur == 'r') {
-                int from = 0, to = 0;
+                WORKSPACEID from = 0, to = 0;
                 if (!prop.starts_with("r[") || !prop.ends_with("]")) {
                     Debug::log(LOG, "Invalid selector {}", selector);
                     return false;
@@ -365,7 +365,7 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
             }
 
             if (cur == 'w') {
-                int from = 0, to = 0;
+                WORKSPACEID from = 0, to = 0;
                 if (!prop.starts_with("w[") || !prop.ends_with("]")) {
                     Debug::log(LOG, "Invalid selector {}", selector);
                     return false;
@@ -446,7 +446,7 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
                     return false;
                 }
 
-                int count;
+                WORKSPACEID count;
                 if (wantsCountGroup)
                     count = g_pCompositor->getGroupsOnWorkspace(m_iID, wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled),
                                                                 wantsCountVisible ? std::optional<bool>(wantsCountVisible) : std::nullopt);
@@ -506,7 +506,7 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
 void CWorkspace::markInert() {
     m_bInert     = true;
     m_iID        = WORKSPACE_INVALID;
-    m_iMonitorID = -1;
+    m_iMonitorID = MONITOR_INVALID;
     m_bVisible   = false;
 }
 

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -17,16 +17,16 @@ class CWindow;
 
 class CWorkspace {
   public:
-    static PHLWORKSPACE create(int id, int monitorID, std::string name, bool special = false, bool isEmtpy = true);
+    static PHLWORKSPACE create(WORKSPACEID id, MONITORID monitorID, std::string name, bool special = false, bool isEmtpy = true);
     // use create() don't use this
-    CWorkspace(int id, int monitorID, std::string name, bool special = false, bool isEmpty = true);
+    CWorkspace(WORKSPACEID id, MONITORID monitorID, std::string name, bool special = false, bool isEmpty = true);
     ~CWorkspace();
 
     // Workspaces ID-based have IDs > 0
     // and workspaces name-based have IDs starting with -1337
-    int         m_iID        = -1;
+    WORKSPACEID m_iID        = WORKSPACE_INVALID;
     std::string m_szName     = "";
-    uint64_t    m_iMonitorID = -1;
+    MONITORID   m_iMonitorID = MONITOR_INVALID;
     // Previous workspace ID and name is stored during a workspace change, allowing travel
     // to the previous workspace.
     SWorkspaceIDName m_sPrevWorkspace, m_sPrevWorkspacePerMonitor;
@@ -67,7 +67,7 @@ class CWorkspace {
     void             startAnim(bool in, bool left, bool instant = false);
     void             setActive(bool on);
 
-    void             moveToMonitor(const int&);
+    void             moveToMonitor(const MONITORID&);
 
     PHLWINDOW        getLastFocusedWindow();
     void             rememberPrevWorkspace(const PHLWORKSPACE& prevWorkspace);

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -148,7 +148,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                     PWINDOW->m_iMonitorID = PMONITOR->ID;
                 } else {
                     if (isNumber(MONITORSTR)) {
-                        const long int MONITOR = std::stoi(MONITORSTR);
+                        const MONITORID MONITOR = std::stoi(MONITORSTR);
                         if (!g_pCompositor->getMonitorFromID(MONITOR))
                             PWINDOW->m_iMonitorID = 0;
                         else

--- a/src/helpers/MiscFunctions.hpp
+++ b/src/helpers/MiscFunctions.hpp
@@ -6,6 +6,8 @@
 #include "math/Math.hpp"
 #include <vector>
 #include <format>
+#include "SharedDefs.hpp"
+#include "macros.hpp"
 
 struct SCallstackFrameInfo {
     void*       adr = nullptr;
@@ -13,7 +15,7 @@ struct SCallstackFrameInfo {
 };
 
 struct SWorkspaceIDName {
-    int         id = -1;
+    WORKSPACEID id = WORKSPACE_INVALID;
     std::string name;
 };
 

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -389,8 +389,8 @@ bool CMonitor::matchesStaticSelector(const std::string& selector) const {
     }
 }
 
-int CMonitor::findAvailableDefaultWS() {
-    for (size_t i = 1; i < INT32_MAX; ++i) {
+WORKSPACEID CMonitor::findAvailableDefaultWS() {
+    for (WORKSPACEID i = 1; i < LONG_MAX; ++i) {
         if (g_pCompositor->getWorkspaceByID(i))
             continue;
 
@@ -400,7 +400,7 @@ int CMonitor::findAvailableDefaultWS() {
         return i;
     }
 
-    return INT32_MAX; // shouldn't be reachable
+    return LONG_MAX; // shouldn't be reachable
 }
 
 void CMonitor::setupDefaultWS(const SMonitorRule& monitorRule) {
@@ -638,7 +638,7 @@ void CMonitor::changeWorkspace(const PHLWORKSPACE& pWorkspace, bool internal, bo
         g_pCompositor->updateFullscreenFadeOnWorkspace(activeSpecialWorkspace);
 }
 
-void CMonitor::changeWorkspace(const int& id, bool internal, bool noMouseMove, bool noFocus) {
+void CMonitor::changeWorkspace(const WORKSPACEID& id, bool internal, bool noMouseMove, bool noFocus) {
     changeWorkspace(g_pCompositor->getWorkspaceByID(id), internal, noMouseMove, noFocus);
 }
 
@@ -745,7 +745,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
     g_pCompositor->updateSuspendedStates();
 }
 
-void CMonitor::setSpecialWorkspace(const int& id) {
+void CMonitor::setSpecialWorkspace(const WORKSPACEID& id) {
     setSpecialWorkspace(g_pCompositor->getWorkspaceByID(id));
 }
 
@@ -766,11 +766,11 @@ void CMonitor::updateMatrix() {
     }
 }
 
-int64_t CMonitor::activeWorkspaceID() {
+WORKSPACEID CMonitor::activeWorkspaceID() {
     return activeWorkspace ? activeWorkspace->m_iID : 0;
 }
 
-int64_t CMonitor::activeSpecialWorkspaceID() {
+WORKSPACEID CMonitor::activeSpecialWorkspaceID() {
     return activeSpecialWorkspace ? activeSpecialWorkspace->m_iID : 0;
 }
 

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -70,7 +70,7 @@ class CMonitor {
 
     bool                        primary = false;
 
-    uint64_t                    ID                     = -1;
+    MONITORID                   ID                     = MONITOR_INVALID;
     PHLWORKSPACE                activeWorkspace        = nullptr;
     PHLWORKSPACE                activeSpecialWorkspace = nullptr;
     float                       setScale               = 1; // scale set by cfg
@@ -155,31 +155,31 @@ class CMonitor {
     std::array<std::vector<PHLLSREF>, 4> m_aLayerSurfaceLayers;
 
     // methods
-    void     onConnect(bool noRule);
-    void     onDisconnect(bool destroy = false);
-    void     addDamage(const pixman_region32_t* rg);
-    void     addDamage(const CRegion* rg);
-    void     addDamage(const CBox* box);
-    bool     shouldSkipScheduleFrameOnMouseEvent();
-    void     setMirror(const std::string&);
-    bool     isMirror();
-    bool     matchesStaticSelector(const std::string& selector) const;
-    float    getDefaultScale();
-    void     changeWorkspace(const PHLWORKSPACE& pWorkspace, bool internal = false, bool noMouseMove = false, bool noFocus = false);
-    void     changeWorkspace(const int& id, bool internal = false, bool noMouseMove = false, bool noFocus = false);
-    void     setSpecialWorkspace(const PHLWORKSPACE& pWorkspace);
-    void     setSpecialWorkspace(const int& id);
-    void     moveTo(const Vector2D& pos);
-    Vector2D middle();
-    void     updateMatrix();
-    int64_t  activeWorkspaceID();
-    int64_t  activeSpecialWorkspaceID();
-    CBox     logicalBox();
-    void     scheduleDone();
-    bool     attemptDirectScanout();
+    void        onConnect(bool noRule);
+    void        onDisconnect(bool destroy = false);
+    void        addDamage(const pixman_region32_t* rg);
+    void        addDamage(const CRegion* rg);
+    void        addDamage(const CBox* box);
+    bool        shouldSkipScheduleFrameOnMouseEvent();
+    void        setMirror(const std::string&);
+    bool        isMirror();
+    bool        matchesStaticSelector(const std::string& selector) const;
+    float       getDefaultScale();
+    void        changeWorkspace(const PHLWORKSPACE& pWorkspace, bool internal = false, bool noMouseMove = false, bool noFocus = false);
+    void        changeWorkspace(const WORKSPACEID& id, bool internal = false, bool noMouseMove = false, bool noFocus = false);
+    void        setSpecialWorkspace(const PHLWORKSPACE& pWorkspace);
+    void        setSpecialWorkspace(const WORKSPACEID& id);
+    void        moveTo(const Vector2D& pos);
+    Vector2D    middle();
+    void        updateMatrix();
+    WORKSPACEID activeWorkspaceID();
+    WORKSPACEID activeSpecialWorkspaceID();
+    CBox        logicalBox();
+    void        scheduleDone();
+    bool        attemptDirectScanout();
 
-    bool     m_bEnabled             = false;
-    bool     m_bRenderingInitPassed = false;
+    bool        m_bEnabled             = false;
+    bool        m_bRenderingInitPassed = false;
 
     // For the list lookup
 
@@ -189,7 +189,7 @@ class CMonitor {
 
   private:
     void             setupDefaultWS(const SMonitorRule&);
-    int              findAvailableDefaultWS();
+    WORKSPACEID      findAvailableDefaultWS();
 
     wl_event_source* doneSource = nullptr;
 

--- a/src/helpers/Timer.cpp
+++ b/src/helpers/Timer.cpp
@@ -8,7 +8,7 @@ std::chrono::steady_clock::duration CTimer::getDuration() {
     return std::chrono::steady_clock::now() - m_tpLastReset;
 }
 
-int CTimer::getMillis() {
+long CTimer::getMillis() {
     return std::chrono::duration_cast<std::chrono::milliseconds>(getDuration()).count();
 }
 

--- a/src/helpers/Timer.hpp
+++ b/src/helpers/Timer.hpp
@@ -6,7 +6,7 @@ class CTimer {
   public:
     void                                         reset();
     float                                        getSeconds();
-    int                                          getMillis();
+    long                                         getMillis();
     const std::chrono::steady_clock::time_point& chrono() const;
 
   private:

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -47,7 +47,7 @@ void SDwindleNodeData::getAllChildrenRecursive(std::deque<SDwindleNodeData*>* pD
     }
 }
 
-int CHyprDwindleLayout::getNodesOnWorkspace(const int& id) {
+int CHyprDwindleLayout::getNodesOnWorkspace(const WORKSPACEID& id) {
     int no = 0;
     for (auto& n : m_lDwindleNodesData) {
         if (n.workspaceID == id && n.valid)
@@ -56,7 +56,7 @@ int CHyprDwindleLayout::getNodesOnWorkspace(const int& id) {
     return no;
 }
 
-SDwindleNodeData* CHyprDwindleLayout::getFirstNodeOnWorkspace(const int& id) {
+SDwindleNodeData* CHyprDwindleLayout::getFirstNodeOnWorkspace(const WORKSPACEID& id) {
     for (auto& n : m_lDwindleNodesData) {
         if (n.workspaceID == id && validMapped(n.pWindow))
             return &n;
@@ -64,7 +64,7 @@ SDwindleNodeData* CHyprDwindleLayout::getFirstNodeOnWorkspace(const int& id) {
     return nullptr;
 }
 
-SDwindleNodeData* CHyprDwindleLayout::getClosestNodeOnWorkspace(const int& id, const Vector2D& point) {
+SDwindleNodeData* CHyprDwindleLayout::getClosestNodeOnWorkspace(const WORKSPACEID& id, const Vector2D& point) {
     SDwindleNodeData* res         = nullptr;
     double            distClosest = -1;
     for (auto& n : m_lDwindleNodesData) {
@@ -88,7 +88,7 @@ SDwindleNodeData* CHyprDwindleLayout::getNodeFromWindow(PHLWINDOW pWindow) {
     return nullptr;
 }
 
-SDwindleNodeData* CHyprDwindleLayout::getMasterNodeOnWorkspace(const int& id) {
+SDwindleNodeData* CHyprDwindleLayout::getMasterNodeOnWorkspace(const WORKSPACEID& id) {
     for (auto& n : m_lDwindleNodesData) {
         if (!n.pParent && n.workspaceID == id)
             return &n;
@@ -535,7 +535,7 @@ void CHyprDwindleLayout::onWindowRemovedTiling(PHLWINDOW pWindow) {
     m_lDwindleNodesData.remove(*PNODE);
 }
 
-void CHyprDwindleLayout::recalculateMonitor(const int& monid) {
+void CHyprDwindleLayout::recalculateMonitor(const MONITORID& monid) {
     const auto PMONITOR = g_pCompositor->getMonitorFromID(monid);
 
     if (!PMONITOR || !PMONITOR->activeWorkspace)
@@ -872,7 +872,7 @@ void CHyprDwindleLayout::moveWindowTo(PHLWINDOW pWindow, const std::string& dir,
         return;
 
     const auto     PNODE               = getNodeFromWindow(pWindow);
-    const int      originalWorkspaceID = pWindow->workspaceID();
+    const auto     originalWorkspaceID = pWindow->workspaceID();
     const Vector2D originalPos         = pWindow->middle();
 
     if (!PNODE)

--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -24,7 +24,7 @@ struct SDwindleNodeData {
 
     CBox                             box = {0};
 
-    int                              workspaceID = -1;
+    WORKSPACEID                      workspaceID = WORKSPACE_INVALID;
 
     float                            splitRatio = 1.f;
 
@@ -48,7 +48,7 @@ class CHyprDwindleLayout : public IHyprLayout {
     virtual void                     onWindowCreatedTiling(PHLWINDOW, eDirection direction = DIRECTION_DEFAULT);
     virtual void                     onWindowRemovedTiling(PHLWINDOW);
     virtual bool                     isWindowTiled(PHLWINDOW);
-    virtual void                     recalculateMonitor(const int&);
+    virtual void                     recalculateMonitor(const MONITORID&);
     virtual void                     recalculateWindow(PHLWINDOW);
     virtual void                     onBeginDragWindow();
     virtual void                     resizeActiveWindow(const Vector2D&, eRectCorner corner = CORNER_NONE, PHLWINDOW pWindow = nullptr);
@@ -77,13 +77,13 @@ class CHyprDwindleLayout : public IHyprLayout {
 
     std::optional<Vector2D> m_vOverrideFocalPoint; // for onWindowCreatedTiling.
 
-    int                     getNodesOnWorkspace(const int&);
+    int                     getNodesOnWorkspace(const WORKSPACEID&);
     void                    applyNodeDataToWindow(SDwindleNodeData*, bool force = false);
     void                    calculateWorkspace(const PHLWORKSPACE& pWorkspace);
     SDwindleNodeData*       getNodeFromWindow(PHLWINDOW);
-    SDwindleNodeData*       getFirstNodeOnWorkspace(const int&);
-    SDwindleNodeData*       getClosestNodeOnWorkspace(const int&, const Vector2D&);
-    SDwindleNodeData*       getMasterNodeOnWorkspace(const int&);
+    SDwindleNodeData*       getFirstNodeOnWorkspace(const WORKSPACEID&);
+    SDwindleNodeData*       getClosestNodeOnWorkspace(const WORKSPACEID&, const Vector2D&);
+    SDwindleNodeData*       getMasterNodeOnWorkspace(const WORKSPACEID&);
 
     void                    toggleSplit(PHLWINDOW);
     void                    swapSplit(PHLWINDOW);

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -63,7 +63,7 @@ class IHyprLayout {
         Called when the monitor requires a layout recalculation
         this usually means reserved area changes
     */
-    virtual void recalculateMonitor(const int&) = 0;
+    virtual void recalculateMonitor(const MONITORID&) = 0;
 
     /*
         Called when the compositor requests a window

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -14,7 +14,7 @@ SMasterNodeData* CHyprMasterLayout::getNodeFromWindow(PHLWINDOW pWindow) {
     return nullptr;
 }
 
-int CHyprMasterLayout::getNodesOnWorkspace(const int& ws) {
+int CHyprMasterLayout::getNodesOnWorkspace(const WORKSPACEID& ws) {
     int no = 0;
     for (auto& n : m_lMasterNodesData) {
         if (n.workspaceID == ws)
@@ -24,7 +24,7 @@ int CHyprMasterLayout::getNodesOnWorkspace(const int& ws) {
     return no;
 }
 
-int CHyprMasterLayout::getMastersOnWorkspace(const int& ws) {
+int CHyprMasterLayout::getMastersOnWorkspace(const WORKSPACEID& ws) {
     int no = 0;
     for (auto& n : m_lMasterNodesData) {
         if (n.workspaceID == ws && n.isMaster)
@@ -34,7 +34,7 @@ int CHyprMasterLayout::getMastersOnWorkspace(const int& ws) {
     return no;
 }
 
-SMasterWorkspaceData* CHyprMasterLayout::getMasterWorkspaceData(const int& ws) {
+SMasterWorkspaceData* CHyprMasterLayout::getMasterWorkspaceData(const WORKSPACEID& ws) {
     for (auto& n : m_lMasterWorkspacesData) {
         if (n.workspaceID == ws)
             return &n;
@@ -63,7 +63,7 @@ std::string CHyprMasterLayout::getLayoutName() {
     return "Master";
 }
 
-SMasterNodeData* CHyprMasterLayout::getMasterNodeOnWorkspace(const int& ws) {
+SMasterNodeData* CHyprMasterLayout::getMasterNodeOnWorkspace(const WORKSPACEID& ws) {
     for (auto& n : m_lMasterNodesData) {
         if (n.isMaster && n.workspaceID == ws)
             return &n;
@@ -304,7 +304,7 @@ void CHyprMasterLayout::onWindowRemovedTiling(PHLWINDOW pWindow) {
     recalculateMonitor(pWindow->m_iMonitorID);
 }
 
-void CHyprMasterLayout::recalculateMonitor(const int& monid) {
+void CHyprMasterLayout::recalculateMonitor(const MONITORID& monid) {
     const auto PMONITOR = g_pCompositor->getMonitorFromID(monid);
 
     if (!PMONITOR || !PMONITOR->activeWorkspace)

--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -30,7 +30,7 @@ struct SMasterNodeData {
 
     float        percSize = 1.f; // size multiplier for resizing children
 
-    int          workspaceID = -1;
+    WORKSPACEID  workspaceID = WORKSPACE_INVALID;
 
     bool         ignoreFullscreenChecks = false;
 
@@ -41,7 +41,7 @@ struct SMasterNodeData {
 };
 
 struct SMasterWorkspaceData {
-    int          workspaceID = -1;
+    WORKSPACEID  workspaceID = WORKSPACE_INVALID;
     eOrientation orientation = ORIENTATION_LEFT;
 
     //
@@ -55,7 +55,7 @@ class CHyprMasterLayout : public IHyprLayout {
     virtual void                     onWindowCreatedTiling(PHLWINDOW, eDirection direction = DIRECTION_DEFAULT);
     virtual void                     onWindowRemovedTiling(PHLWINDOW);
     virtual bool                     isWindowTiled(PHLWINDOW);
-    virtual void                     recalculateMonitor(const int&);
+    virtual void                     recalculateMonitor(const MONITORID&);
     virtual void                     recalculateWindow(PHLWINDOW);
     virtual void                     resizeActiveWindow(const Vector2D&, eRectCorner corner = CORNER_NONE, PHLWINDOW pWindow = nullptr);
     virtual void                     fullscreenRequestForWindow(PHLWINDOW pWindow, const eFullscreenMode CURRENT_EFFECTIVE_MODE, const eFullscreenMode EFFECTIVE_MODE);
@@ -81,14 +81,14 @@ class CHyprMasterLayout : public IHyprLayout {
     void                              buildOrientationCycleVectorFromEOperation(std::vector<eOrientation>& cycle);
     void                              runOrientationCycle(SLayoutMessageHeader& header, CVarList* vars, int next);
     eOrientation                      getDynamicOrientation(PHLWORKSPACE);
-    int                               getNodesOnWorkspace(const int&);
+    int                               getNodesOnWorkspace(const WORKSPACEID&);
     void                              applyNodeDataToWindow(SMasterNodeData*);
     SMasterNodeData*                  getNodeFromWindow(PHLWINDOW);
-    SMasterNodeData*                  getMasterNodeOnWorkspace(const int&);
-    SMasterWorkspaceData*             getMasterWorkspaceData(const int&);
+    SMasterNodeData*                  getMasterNodeOnWorkspace(const WORKSPACEID&);
+    SMasterWorkspaceData*             getMasterWorkspaceData(const WORKSPACEID&);
     void                              calculateWorkspace(PHLWORKSPACE);
     PHLWINDOW                         getNextWindow(PHLWINDOW, bool);
-    int                               getMastersOnWorkspace(const int&);
+    int                               getMastersOnWorkspace(const WORKSPACEID&);
 
     friend struct SMasterNodeData;
     friend struct SMasterWorkspaceData;

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -27,6 +27,8 @@
 #define WORKSPACE_INVALID     -1L
 #define WORKSPACE_NOT_CHANGED -101
 
+#define MONITOR_INVALID -1L
+
 #define LISTENER(name)                                                                                                                                                             \
     void               listener_##name(wl_listener*, void*);                                                                                                                       \
     inline wl_listener listen_##name = {.notify = listener_##name}

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1738,7 +1738,7 @@ void CKeybindManager::moveWorkspaceToMonitor(std::string args) {
         return;
     }
 
-    const int WORKSPACEID = getWorkspaceIDNameFromString(workspace).id;
+    const auto WORKSPACEID = getWorkspaceIDNameFromString(workspace).id;
 
     if (WORKSPACEID == WORKSPACE_INVALID) {
         Debug::log(ERR, "moveWorkspaceToMonitor invalid workspace!");
@@ -1756,7 +1756,7 @@ void CKeybindManager::moveWorkspaceToMonitor(std::string args) {
 }
 
 void CKeybindManager::focusWorkspaceOnCurrentMonitor(std::string args) {
-    int workspaceID = getWorkspaceIDNameFromString(args).id;
+    auto workspaceID = getWorkspaceIDNameFromString(args).id;
     if (workspaceID == WORKSPACE_INVALID) {
         Debug::log(ERR, "focusWorkspaceOnCurrentMonitor invalid workspace!");
         return;
@@ -1816,7 +1816,7 @@ void CKeybindManager::toggleSpecialWorkspace(std::string args) {
 
     bool       requestedWorkspaceIsAlreadyOpen = false;
     const auto PMONITOR                        = g_pCompositor->m_pLastMonitor;
-    int        specialOpenOnMonitor            = PMONITOR->activeSpecialWorkspaceID();
+    auto       specialOpenOnMonitor            = PMONITOR->activeSpecialWorkspaceID();
 
     for (auto& m : g_pCompositor->m_vMonitors) {
         if (m->activeSpecialWorkspaceID() == workspaceID) {

--- a/src/managers/eventLoop/EventLoopManager.cpp
+++ b/src/managers/eventLoop/EventLoopManager.cpp
@@ -76,8 +76,8 @@ void CEventLoopManager::removeTimer(SP<CEventLoopTimer> timer) {
 }
 
 static void timespecAddNs(timespec* pTimespec, int64_t delta) {
-    int delta_ns_low = delta % TIMESPEC_NSEC_PER_SEC;
-    int delta_s_high = delta / TIMESPEC_NSEC_PER_SEC;
+    auto delta_ns_low = delta % TIMESPEC_NSEC_PER_SEC;
+    auto delta_s_high = delta / TIMESPEC_NSEC_PER_SEC;
 
     pTimespec->tv_sec += delta_s_high;
 

--- a/src/managers/input/InputMethodPopup.hpp
+++ b/src/managers/input/InputMethodPopup.hpp
@@ -33,7 +33,7 @@ class CInputPopup {
     WP<CInputMethodPopupV2> popup;
     SP<CWLSurface>          surface;
     CBox                    lastBoxLocal;
-    uint64_t                lastMonitor = -1;
+    MONITORID               lastMonitor = MONITOR_INVALID;
 
     struct {
         CHyprSignalListener map;

--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -77,7 +77,7 @@ void CInputManager::endWorkspaceSwipe() {
     // left of where we started.  Instead, it's one more than the greatest
     // workspace ID that currently exists.
     if (workspaceIDRight <= m_sActiveSwipe.pWorkspaceBegin->m_iID && *PSWIPENEW) {
-        int maxWorkspace = 0;
+        WORKSPACEID maxWorkspace = 0;
         for (const auto& ws : g_pCompositor->m_vWorkspaces) {
             maxWorkspace = std::max(maxWorkspace, ws->m_iID);
         }

--- a/src/protocols/ForeignToplevelWlr.cpp
+++ b/src/protocols/ForeignToplevelWlr.cpp
@@ -119,7 +119,7 @@ wl_resource* CForeignToplevelHandleWlr::res() {
 }
 
 void CForeignToplevelHandleWlr::sendMonitor(CMonitor* pMonitor) {
-    if (lastMonitorID == (int64_t)pMonitor->ID)
+    if (lastMonitorID == pMonitor->ID)
         return;
 
     const auto CLIENT = resource->client();

--- a/src/protocols/ForeignToplevelWlr.hpp
+++ b/src/protocols/ForeignToplevelWlr.hpp
@@ -20,7 +20,7 @@ class CForeignToplevelHandleWlr {
     SP<CZwlrForeignToplevelHandleV1> resource;
     PHLWINDOWREF                     pWindow;
     bool                             closed        = false;
-    int64_t                          lastMonitorID = -1;
+    MONITORID                        lastMonitorID = MONITOR_INVALID;
 
     void                             sendMonitor(CMonitor* pMonitor);
     void                             sendState();

--- a/src/render/Framebuffer.cpp
+++ b/src/render/Framebuffer.cpp
@@ -12,9 +12,10 @@ bool CFramebuffer::alloc(int w, int h, uint32_t drmFormat) {
     uint32_t glFormat = FormatUtils::drmFormatToGL(drmFormat);
     uint32_t glType   = FormatUtils::glFormatToType(glFormat);
 
-    if (m_iFb == (uint32_t)-1) {
+    if (!m_iFbAllocated) {
         firstAlloc = true;
         glGenFramebuffers(1, &m_iFb);
+        m_iFbAllocated = true;
     }
 
     if (m_cTex->m_iTexID == 0) {
@@ -88,12 +89,12 @@ void CFramebuffer::bind() {
 }
 
 void CFramebuffer::release() {
-    if (m_iFb != (uint32_t)-1 && m_iFb)
+    if (m_iFbAllocated)
         glDeleteFramebuffers(1, &m_iFb);
 
     m_cTex->destroyTexture();
-    m_iFb   = -1;
-    m_vSize = Vector2D();
+    m_iFbAllocated = false;
+    m_vSize        = Vector2D();
 }
 
 CFramebuffer::~CFramebuffer() {
@@ -101,5 +102,5 @@ CFramebuffer::~CFramebuffer() {
 }
 
 bool CFramebuffer::isAllocated() {
-    return m_iFb != (GLuint)-1;
+    return m_iFbAllocated;
 }

--- a/src/render/Framebuffer.hpp
+++ b/src/render/Framebuffer.hpp
@@ -18,7 +18,8 @@ class CFramebuffer {
     Vector2D     m_vSize;
 
     SP<CTexture> m_cTex;
-    GLuint       m_iFb = -1;
+    GLuint       m_iFb;
+    bool         m_iFbAllocated{false};
 
     SP<CTexture> m_pStencilTex;
 };

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1802,12 +1802,12 @@ CFramebuffer* CHyprOpenGLImpl::blurMainFramebufferWithDamage(float a, CRegion* o
     CRegion tempDamage{damage};
 
     // and draw
-    for (int i = 1; i <= *PBLURPASSES; ++i) {
+    for (auto i = 1; i <= *PBLURPASSES; ++i) {
         tempDamage = damage.copy().scale(1.f / (1 << i));
         drawPass(&m_RenderData.pCurrentMonData->m_shBLUR1, &tempDamage); // down
     }
 
-    for (int i = *PBLURPASSES - 1; i >= 0; --i) {
+    for (auto i = *PBLURPASSES - 1; i >= 0; --i) {
         tempDamage = damage.copy().scale(1.f / (1 << i));                // when upsampling we make the region twice as big
         drawPass(&m_RenderData.pCurrentMonData->m_shBLUR2, &tempDamage); // up
     }

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1247,14 +1247,14 @@ void CHyprOpenGLImpl::renderRectWithBlur(CBox* box, const CColor& col, int round
 
     glEnable(GL_STENCIL_TEST);
 
-    glStencilFunc(GL_ALWAYS, 1, -1);
+    glStencilFunc(GL_ALWAYS, 1, 0xFF);
     glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
 
     glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
     renderRect(box, CColor(0, 0, 0, 0), round);
     glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 
-    glStencilFunc(GL_EQUAL, 1, -1);
+    glStencilFunc(GL_EQUAL, 1, 0xFF);
     glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
 
     scissor(box);
@@ -1269,7 +1269,7 @@ void CHyprOpenGLImpl::renderRectWithBlur(CBox* box, const CColor& col, int round
     glClearStencil(0);
     glClear(GL_STENCIL_BUFFER_BIT);
     glDisable(GL_STENCIL_TEST);
-    glStencilMask(-1);
+    glStencilMask(0xFF);
     glStencilFunc(GL_ALWAYS, 1, 0xFF);
     scissor((CBox*)nullptr);
 
@@ -2091,7 +2091,7 @@ void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, CBox* pBox, float 
 
     glEnable(GL_STENCIL_TEST);
 
-    glStencilFunc(GL_ALWAYS, 1, -1);
+    glStencilFunc(GL_ALWAYS, 1, 0xFF);
     glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
 
     glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
@@ -2101,7 +2101,7 @@ void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, CBox* pBox, float 
         renderTexture(tex, pBox, a, round, true, true); // discard opaque
     glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 
-    glStencilFunc(GL_EQUAL, 1, -1);
+    glStencilFunc(GL_EQUAL, 1, 0xFF);
     glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
 
     // stencil done. Render everything.
@@ -2124,7 +2124,7 @@ void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, CBox* pBox, float 
     glDisable(GL_STENCIL_TEST);
     renderTextureInternalWithDamage(tex, pBox, a, &texDamage, round, false, false, true, true);
 
-    glStencilMask(-1);
+    glStencilMask(0xFF);
     glStencilFunc(GL_ALWAYS, 1, 0xFF);
     scissor((CBox*)nullptr);
 }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1658,7 +1658,7 @@ void CHyprRenderer::arrangeLayerArray(CMonitor* pMonitor, const std::vector<PHLL
     }
 }
 
-void CHyprRenderer::arrangeLayersForMonitor(const int& monitor) {
+void CHyprRenderer::arrangeLayersForMonitor(const MONITORID& monitor) {
     const auto PMONITOR = g_pCompositor->getMonitorFromID(monitor);
 
     if (!PMONITOR)

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -49,7 +49,7 @@ class CHyprRenderer {
     ~CHyprRenderer();
 
     void                            renderMonitor(CMonitor* pMonitor);
-    void                            arrangeLayersForMonitor(const int&);
+    void                            arrangeLayersForMonitor(const MONITORID&);
     void                            damageSurface(SP<CWLSurfaceResource>, double, double, double scale = 1.0);
     void                            damageWindow(PHLWINDOW, bool forceFull = false);
     void                            damageBox(CBox*, bool skipFrameSchedule = false);

--- a/src/signal-safe.cpp
+++ b/src/signal-safe.cpp
@@ -10,7 +10,7 @@
 extern char** environ;
 
 char const*   sig_getenv(char const* name) {
-    int len = strlen(name);
+    size_t len = strlen(name);
     for (char** var = environ; *var != NULL; var++) {
         if (strncmp(*var, name, len) == 0 && (*var)[len] == '=') {
             return (*var) + len + 1;

--- a/src/signal-safe.hpp
+++ b/src/signal-safe.hpp
@@ -139,7 +139,7 @@ class BufFileWriter {
             abort();
         } else {
             close(pipefd[1]);
-            int  len;
+            long len;
             char readbuf[256];
             while ((len = read(pipefd[0], readbuf, 256)) > 0) {
                 write(readbuf, len);
@@ -155,7 +155,7 @@ class BufFileWriter {
     void flush() {
         size_t i = 0;
         while (i < m_writeBufPos) {
-            int written = ::write(m_fd, m_writeBuf + i, m_writeBufPos - i);
+            auto written = ::write(m_fd, m_writeBuf + i, m_writeBufPos - i);
             if (written <= 0) {
                 return;
             }


### PR DESCRIPTION
unsigned int = -1 rolls over to unsigned int max, avoid rolling over by using the new typedefs WORKSPACEID/MONITORID/WINDOWID where this occured and also since we were rolling over getmonitorid() was passed a unsigned int max value and overflowed causing UB.

as a consequence of this turning on -Wshorten-64-to-32 revealed a few other mismatches related or close to same place where i changed the type to the correct  one when refactoring. still remains a few in other places but thats for a future PR.

the opengl changes im not sure about if they are correct, requires a keen eye what the intention behind the stencil calls were but same deal there, -1 to gluint rolls over to uint max.


