### PR TITLE
core: Move to C++26 and use native_handle to CLOEXEC the debug fd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ else()
 endif()
 
 include_directories(. "src/" "subprojects/udis86/" "protocols/")
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 26)
 add_compile_options(
   -Wall
   -Wextra

--- a/flake.nix
+++ b/flake.nix
@@ -95,7 +95,7 @@
     devShells = eachSystem (system: {
       default =
         pkgsFor.${system}.mkShell.override {
-          stdenv = pkgsFor.${system}.gcc13Stdenv;
+          stdenv = pkgsFor.${system}.gcc14Stdenv;
         } {
           name = "hyprland-shell";
           nativeBuildInputs = with pkgsFor.${system}; [

--- a/meson.build
+++ b/meson.build
@@ -6,7 +6,7 @@ project('Hyprland', 'cpp', 'c',
     'optimization=3',
     'buildtype=release',
     'debug=false',
-    'cpp_std=c++23',
+    'cpp_std=c++26',
   ])
 
 datarootdir = '-DDATAROOTDIR="' + get_option('prefix') / get_option('datadir') + '"'

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -71,6 +71,11 @@ assert lib.assertMsg (!hidpiXWayland) "The option `hidpiXWayland` has been remov
       src = lib.cleanSource ../.;
     };
 
+    patches = [
+      # forces GCC to use -std=c++26
+      ./stdcxx.patch
+    ];
+
     postPatch = ''
       # Fix hardcoded paths to /usr installation
       sed -i "s#/usr#$out#" src/render/OpenGL.cpp

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -31,7 +31,7 @@ in {
       date = mkDate (self.lastModifiedDate or "19700101");
     in {
       hyprland = final.callPackage ./default.nix {
-        stdenv = final.gcc13Stdenv;
+        stdenv = final.gcc14Stdenv;
         version = "${version}+date=${date}_${self.shortRev or "dirty"}";
         commit = self.rev or "";
         inherit date;

--- a/nix/stdcxx.patch
+++ b/nix/stdcxx.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cfbd431f..73e8e0c2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -64,6 +64,7 @@ endif()
+ include_directories(. "src/" "subprojects/udis86/" "protocols/")
+ set(CMAKE_CXX_STANDARD 26)
+ add_compile_options(
++  -std=c++26
+   -Wall
+   -Wextra
+   -Wno-unused-parameter

--- a/src/debug/Log.cpp
+++ b/src/debug/Log.cpp
@@ -5,10 +5,13 @@
 
 #include <fstream>
 #include <iostream>
+#include <fcntl.h>
 
 void Debug::init(const std::string& IS) {
     logFile = IS + (ISDEBUG ? "/hyprlandd.log" : "/hyprland.log");
     logOfs.open(logFile, std::ios::out | std::ios::app);
+    auto handle = logOfs.native_handle();
+    fcntl(handle, F_SETFD, FD_CLOEXEC);
 }
 
 void Debug::close() {


### PR DESCRIPTION
Moves hyprland to C++26 to use `native_handle` to CLOEXEC the debug fd and avoid it being passed to children (every process spawned...)

@fufexan CI
@jbeich will this work on BSD / clang / libc++? I can see it has support for it since clang18