### PR TITLE
xcursmgr add a new setting to sync gsettings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ pkg_check_modules(
   libliftoff
   libudev
   gbm
+  gio-2.0
   hyprlang>=0.3.2
   hyprcursor>=0.1.7
   hyprutils>=0.2.1)

--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,8 @@ xcb_render_dep = dependency('xcb-render', required: get_option('xwayland'))
 xcb_res_dep = dependency('xcb-res', required: get_option('xwayland'))
 xcb_xfixes_dep = dependency('xcb-xfixes', required: get_option('xwayland'))
 
+gio_dep = dependency('gio-2.0', required:true)
+
 cmake = import('cmake')
 udis = cmake.subproject('udis86')
 udis86 = udis.dependency('libudis86')

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -539,6 +539,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("cursor:zoom_factor", {1.f});
     m_pConfig->addConfigValue("cursor:zoom_rigid", Hyprlang::INT{0});
     m_pConfig->addConfigValue("cursor:enable_hyprcursor", Hyprlang::INT{1});
+    m_pConfig->addConfigValue("cursor:sync_gsettings_theme", Hyprlang::INT{1});
     m_pConfig->addConfigValue("cursor:hide_on_key_press", Hyprlang::INT{0});
     m_pConfig->addConfigValue("cursor:hide_on_touch", Hyprlang::INT{1});
     m_pConfig->addConfigValue("cursor:allow_dumb_copy", Hyprlang::INT{0});

--- a/src/managers/XCursorManager.hpp
+++ b/src/managers/XCursorManager.hpp
@@ -38,6 +38,7 @@ class CXCursorManager {
     std::string                     getLegacyShapeName(std::string const& shape);
     std::vector<SP<SXCursors>>      loadStandardCursors(std::string const& name, int size);
     std::vector<SP<SXCursors>>      loadAllFromDir(std::string const& path, int size);
+    void                            syncGsettings();
 
     int                             lastLoadSize = 0;
     std::string                     themeName    = "";

--- a/src/meson.build
+++ b/src/meson.build
@@ -28,6 +28,7 @@ executable('Hyprland', src,
     xcb_xfixes_dep,
     backtrace_dep,
     epoll_dep,
+    gio_dep,
     udis86,
 
     dependency('pixman-1'),


### PR DESCRIPTION
cursor:sync_gsettings_theme is set to default true and if enabled it will now sync xcursor theme loading with gsettings if it can, meaning CSD clients will now also change to the appropiate theme upon start and hyprctl setcursor THEME SIZE .

adds a new linking and dep to GIO


