### PR TITLE
cursor: make inactive_timeout setting a float

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -531,7 +531,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("cursor:no_break_fs_vrr", Hyprlang::INT{0});
     m_pConfig->addConfigValue("cursor:min_refresh_rate", Hyprlang::INT{24});
     m_pConfig->addConfigValue("cursor:hotspot_padding", Hyprlang::INT{0});
-    m_pConfig->addConfigValue("cursor:inactive_timeout", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("cursor:inactive_timeout", {0.f});
     m_pConfig->addConfigValue("cursor:no_warps", Hyprlang::INT{0});
     m_pConfig->addConfigValue("cursor:persistent_warps", Hyprlang::INT{0});
     m_pConfig->addConfigValue("cursor:warp_on_change_workspace", Hyprlang::INT{0});

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2299,7 +2299,7 @@ void CHyprRenderer::setCursorFromName(const std::string& name, bool force) {
 }
 
 void CHyprRenderer::ensureCursorRenderingMode() {
-    static auto PCURSORTIMEOUT = CConfigValue<Hyprlang::INT>("cursor:inactive_timeout");
+    static auto PCURSORTIMEOUT = CConfigValue<Hyprlang::FLOAT>("cursor:inactive_timeout");
     static auto PHIDEONTOUCH   = CConfigValue<Hyprlang::INT>("cursor:hide_on_touch");
     static auto PHIDEONKEY     = CConfigValue<Hyprlang::INT>("cursor:hide_on_key_press");
 


### PR DESCRIPTION
Implements [#7265](https://github.com/hyprwm/Hyprland/issues/7265) to give users full control over the length of the cursor timeout delay by making this setting a float.

Accompanying wiki PR: [#744](https://github.com/hyprwm/hyprland-wiki/pull/744).