### PR TITLE
fix data race and a unsigned int rollover

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -552,6 +552,10 @@ void CCompositor::initManagers(eManagersInitStage stage) {
 
             g_pConfigManager->init();
             g_pWatchdog = std::make_unique<CWatchdog>(); // requires config
+            // wait for watchdog to initialize to not hit data races in reading config values.
+            while (!g_pWatchdog->m_bWatchdogInitialized) {
+                std::this_thread::yield();
+            }
 
             Debug::log(LOG, "Creating the PointerManager!");
             g_pPointerManager = std::make_unique<CPointerManager>();

--- a/src/debug/HyprDebugOverlay.cpp
+++ b/src/debug/HyprDebugOverlay.cpp
@@ -7,8 +7,8 @@ CHyprDebugOverlay::CHyprDebugOverlay() {
     m_pTexture = makeShared<CTexture>();
 }
 
-void CHyprMonitorDebugOverlay::renderData(CMonitor* pMonitor, float µs) {
-    m_dLastRenderTimes.push_back(µs / 1000.f);
+void CHyprMonitorDebugOverlay::renderData(CMonitor* pMonitor, float durationUs) {
+    m_dLastRenderTimes.push_back(durationUs / 1000.f);
 
     if (m_dLastRenderTimes.size() > (long unsigned int)pMonitor->refreshRate)
         m_dLastRenderTimes.pop_front();
@@ -17,8 +17,8 @@ void CHyprMonitorDebugOverlay::renderData(CMonitor* pMonitor, float µs) {
         m_pMonitor = pMonitor;
 }
 
-void CHyprMonitorDebugOverlay::renderDataNoOverlay(CMonitor* pMonitor, float µs) {
-    m_dLastRenderTimesNoOverlay.push_back(µs / 1000.f);
+void CHyprMonitorDebugOverlay::renderDataNoOverlay(CMonitor* pMonitor, float durationUs) {
+    m_dLastRenderTimesNoOverlay.push_back(durationUs / 1000.f);
 
     if (m_dLastRenderTimesNoOverlay.size() > (long unsigned int)pMonitor->refreshRate)
         m_dLastRenderTimesNoOverlay.pop_front();
@@ -188,12 +188,12 @@ int CHyprMonitorDebugOverlay::draw(int offset) {
     return posY - offset;
 }
 
-void CHyprDebugOverlay::renderData(CMonitor* pMonitor, float µs) {
-    m_mMonitorOverlays[pMonitor].renderData(pMonitor, µs);
+void CHyprDebugOverlay::renderData(CMonitor* pMonitor, float durationUs) {
+    m_mMonitorOverlays[pMonitor].renderData(pMonitor, durationUs);
 }
 
-void CHyprDebugOverlay::renderDataNoOverlay(CMonitor* pMonitor, float µs) {
-    m_mMonitorOverlays[pMonitor].renderDataNoOverlay(pMonitor, µs);
+void CHyprDebugOverlay::renderDataNoOverlay(CMonitor* pMonitor, float durationUs) {
+    m_mMonitorOverlays[pMonitor].renderDataNoOverlay(pMonitor, durationUs);
 }
 
 void CHyprDebugOverlay::frameData(CMonitor* pMonitor) {

--- a/src/debug/HyprDebugOverlay.hpp
+++ b/src/debug/HyprDebugOverlay.hpp
@@ -13,8 +13,8 @@ class CHyprMonitorDebugOverlay {
   public:
     int  draw(int offset);
 
-    void renderData(CMonitor* pMonitor, float µs);
-    void renderDataNoOverlay(CMonitor* pMonitor, float µs);
+    void renderData(CMonitor* pMonitor, float durationUs);
+    void renderDataNoOverlay(CMonitor* pMonitor, float durationUs);
     void frameData(CMonitor* pMonitor);
 
   private:
@@ -33,8 +33,8 @@ class CHyprDebugOverlay {
   public:
     CHyprDebugOverlay();
     void draw();
-    void renderData(CMonitor*, float µs);
-    void renderDataNoOverlay(CMonitor*, float µs);
+    void renderData(CMonitor*, float durationUs);
+    void renderDataNoOverlay(CMonitor*, float durationUs);
     void frameData(CMonitor*);
 
   private:

--- a/src/helpers/Watchdog.hpp
+++ b/src/helpers/Watchdog.hpp
@@ -11,21 +11,23 @@ class CWatchdog {
     CWatchdog();
     ~CWatchdog();
 
-    void startWatching();
-    void endWatching();
+    void              startWatching();
+    void              endWatching();
+
+    std::atomic<bool> m_bWatchdogInitialized{false};
 
   private:
     std::chrono::high_resolution_clock::time_point m_tTriggered;
 
     pthread_t                                      m_iMainThreadPID = 0;
 
-    bool                                           m_bWatching  = false;
-    bool                                           m_bWillWatch = false;
+    std::atomic<bool>                              m_bWatching  = false;
+    std::atomic<bool>                              m_bWillWatch = false;
 
     std::unique_ptr<std::thread>                   m_pWatchdog;
     std::mutex                                     m_mWatchdogMutex;
-    bool                                           m_bNotified   = false;
-    bool                                           m_bExitThread = false;
+    std::atomic<bool>                              m_bNotified   = false;
+    std::atomic<bool>                              m_bExitThread = false;
     std::condition_variable                        m_cvWatchdogCondition;
 };
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -180,6 +180,9 @@ uint32_t CKeybindManager::stringToModMask(std::string mods) {
 }
 
 uint32_t CKeybindManager::keycodeToModifier(xkb_keycode_t keycode) {
+    if (keycode == 0)
+        return 0;
+
     switch (keycode - 8) {
         case KEY_LEFTMETA: return HL_MODIFIER_META;
         case KEY_RIGHTMETA: return HL_MODIFIER_META;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1395,15 +1395,15 @@ void CHyprRenderer::renderMonitor(CMonitor* pMonitor) {
 
     pMonitor->pendingFrame = false;
 
-    const float µs = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - renderStart).count() / 1000.f;
-    g_pDebugOverlay->renderData(pMonitor, µs);
+    const float durationUs = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - renderStart).count() / 1000.f;
+    g_pDebugOverlay->renderData(pMonitor, durationUs);
 
     if (*PDEBUGOVERLAY == 1) {
         if (pMonitor == g_pCompositor->m_vMonitors.front().get()) {
-            const float µsNoOverlay = µs - std::chrono::duration_cast<std::chrono::nanoseconds>(endRenderOverlay - renderStartOverlay).count() / 1000.f;
-            g_pDebugOverlay->renderDataNoOverlay(pMonitor, µsNoOverlay);
+            const float noOverlayUs = durationUs - std::chrono::duration_cast<std::chrono::nanoseconds>(endRenderOverlay - renderStartOverlay).count() / 1000.f;
+            g_pDebugOverlay->renderDataNoOverlay(pMonitor, noOverlayUs);
         } else {
-            g_pDebugOverlay->renderDataNoOverlay(pMonitor, µs);
+            g_pDebugOverlay->renderDataNoOverlay(pMonitor, durationUs);
         }
     }
 }


### PR DESCRIPTION
just some minor ubsan finds, keycodeToModifier was called with a 0 keycode on mouse keys, and the switch case rolled it over on 0 - 8, no harm but unnecessery.

the watchdog is a seperate thread and hit data races in both reading the config values and reading the bools with the main thread, add a atomic bool for the main thread to wait until the watchdog has read its configvalues so it doesnt hit races in reading the config values with main thread. and change the members to atomic aswell.

also with enabling various ubsan/threadsanitizer/asan flags it gave a few false positives from the non unicode characters in hyprdebug, just change them to a unicode name.
