### PR TITLE
fix initial cursorwarp

### DIFF
--- a/src/managers/PointerManager.hpp
+++ b/src/managers/PointerManager.hpp
@@ -26,6 +26,7 @@ class CPointerManager {
   public:
     CPointerManager();
 
+    void checkDefaultCursorWarp(SP<CMonitor> monitor, std::string monitorName);
     void attachPointer(SP<IPointer> pointer);
     void attachTouch(SP<ITouch> touch);
     void attachTablet(SP<CTablet> tablet);


### PR DESCRIPTION
change the hook to monitorAdded instead of newMonitor so its finalized in the compositor and added to vMonitors, move the checkDefaultCursorWarp to PointerManager and check for it upon mode change. and also ensure it doesnt go out of bounds by replacing it in the middle again on resolution changes.

this im a bit unsure of if its the right approach to the problem so il put up a PR for discussion.


fixes: #7270 


