### PR TITLE
fix cursor gsettings on session change

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -393,6 +393,7 @@ void CCompositor::initAllSignals() {
                     }
 
                     g_pConfigManager->m_bWantsMonitorReload = true;
+                    g_pCursorManager->syncGsettings();
                 } else {
                     Debug::log(LOG, "Session got deactivated!");
 

--- a/src/managers/CursorManager.cpp
+++ b/src/managers/CursorManager.cpp
@@ -338,3 +338,7 @@ bool CCursorManager::changeTheme(const std::string& name, const int size) {
 
     return true;
 }
+
+void CCursorManager::syncGsettings() {
+    m_pXcursor->syncGsettings();
+}

--- a/src/managers/CursorManager.hpp
+++ b/src/managers/CursorManager.hpp
@@ -53,6 +53,7 @@ class CCursorManager {
     void                    updateTheme();
     SCursorImageData        dataFor(const std::string& name); // for xwayland
     void                    setXWaylandCursor();
+    void                    syncGsettings();
 
     void                    tickAnimatedCursor();
 

--- a/src/managers/XCursorManager.cpp
+++ b/src/managers/XCursorManager.cpp
@@ -5,6 +5,7 @@
 #include <gio/gsettingsschema.h>
 #include "config/ConfigValue.hpp"
 #include "helpers/CursorShapes.hpp"
+#include "../managers/CursorManager.hpp"
 #include "debug/Log.hpp"
 #include "XCursorManager.hpp"
 

--- a/src/managers/XCursorManager.hpp
+++ b/src/managers/XCursorManager.hpp
@@ -31,6 +31,7 @@ class CXCursorManager {
 
     void          loadTheme(const std::string& name, int size);
     SP<SXCursors> getShape(std::string const& shape, int size);
+    void          syncGsettings();
 
   private:
     SP<SXCursors>                   createCursor(std::string const& shape, XcursorImages* xImages);
@@ -38,7 +39,6 @@ class CXCursorManager {
     std::string                     getLegacyShapeName(std::string const& shape);
     std::vector<SP<SXCursors>>      loadStandardCursors(std::string const& name, int size);
     std::vector<SP<SXCursors>>      loadAllFromDir(std::string const& path, int size);
-    void                            syncGsettings();
 
     int                             lastLoadSize = 0;
     std::string                     themeName    = "";


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
when changing session gsettings cursor-theme can be changed
this resets it to what we want when switching back

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

#### Is it ready for merging, or does it need work?
yes