### PR TITLE
readme: Change image sources from vaxerski/Hyprland to hyprwm/Hyprland

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align = center>
 
-<img src="https://raw.githubusercontent.com/vaxerski/Hyprland/main/assets/header.svg" width="750" height="300" alt="banner">
+<img src="https://raw.githubusercontent.com/hyprwm/Hyprland/main/assets/header.svg" width="750" height="300" alt="banner">
 
 <br>
 
@@ -125,7 +125,7 @@ easy IPC, much more QoL stuff than other compositors and more...
 
 <!----------------------------------{ Images }--------------------------------->
 
-[Stars Preview]: https://starchart.cc/vaxerski/Hyprland.svg
+[Stars Preview]: https://starchart.cc/hyprwm/Hyprland.svg
 [Preview A]: https://i.ibb.co/C1yTb0r/falf.png
 [Preview B]: https://linfindel.github.io/cdn/hyprland-preview-b.png
 [Preview C]: https://i.ibb.co/B3GJg28/20221126-20h53m26s-grim.png

--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ easy IPC, much more QoL stuff than other compositors and more...
 
 <!----------------------------------{ Images }--------------------------------->
 
-[Stars Preview]: https://starchart.cc/hyprwm/Hyprland.svg
 [Preview A]: https://i.ibb.co/C1yTb0r/falf.png
 [Preview B]: https://linfindel.github.io/cdn/hyprland-preview-b.png
 [Preview C]: https://i.ibb.co/B3GJg28/20221126-20h53m26s-grim.png


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This PR changes a references from vaxerski/Hyprland used in image embeds to the `hyprwm` organization. Because of the repo transfer, Github still correctly handles the requests , but it's better to change it. It also removes an unused image link.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.

#### Is it ready for merging, or does it need work?
It's ready.

