### PR TITLE
xcursormgr dont apply scale on gsettings

### DIFF
--- a/src/managers/CursorManager.cpp
+++ b/src/managers/CursorManager.cpp
@@ -102,7 +102,7 @@ CCursorManager::CCursorManager() {
 
     // since we fallback to xcursor always load it on startup. otherwise we end up with a empty theme if hyprcursor is enabled in the config
     // and then later is disabled.
-    m_pXcursor->loadTheme(getenv("XCURSOR_THEME") ? getenv("XCURSOR_THEME") : "default", m_iSize * std::ceil(m_fCursorScale));
+    m_pXcursor->loadTheme(getenv("XCURSOR_THEME") ? getenv("XCURSOR_THEME") : "default", m_iSize, m_fCursorScale);
 
     m_pAnimationTimer = makeShared<CEventLoopTimer>(std::nullopt, cursorAnimTimer, this);
     g_pEventLoopManager->addTimer(m_pAnimationTimer);
@@ -163,7 +163,7 @@ void CCursorManager::setCursorFromName(const std::string& name) {
     auto        setXCursor = [this](auto const& name) {
         float scale = std::ceil(m_fCursorScale);
 
-        auto  xcursor = m_pXcursor->getShape(name, m_iSize * scale);
+        auto  xcursor = m_pXcursor->getShape(name, m_iSize, m_fCursorScale);
         auto& icon    = xcursor->images.front();
         auto  buf     = makeShared<CCursorBuffer>((uint8_t*)icon.pixels.data(), icon.size, icon.hotspot);
         setCursorBuffer(buf, icon.hotspot / scale, scale);
@@ -277,7 +277,7 @@ void CCursorManager::setXWaylandCursor() {
         g_pXWayland->setCursor(cairo_image_surface_get_data(CURSOR.surface), cairo_image_surface_get_stride(CURSOR.surface), {CURSOR.size, CURSOR.size},
                                {CURSOR.hotspotX, CURSOR.hotspotY});
     else {
-        auto  xcursor = m_pXcursor->getShape("left_ptr", m_iSize * std::ceil(m_fCursorScale));
+        auto  xcursor = m_pXcursor->getShape("left_ptr", m_iSize, 1);
         auto& icon    = xcursor->images.front();
 
         g_pXWayland->setCursor((uint8_t*)icon.pixels.data(), icon.size.x * 4, icon.size, icon.hotspot);
@@ -329,10 +329,10 @@ bool CCursorManager::changeTheme(const std::string& name, const int size) {
         m_pHyprcursor = std::make_unique<Hyprcursor::CHyprcursorManager>(m_szTheme.empty() ? nullptr : m_szTheme.c_str(), options);
         if (!m_pHyprcursor->valid()) {
             Debug::log(ERR, "Hyprcursor failed loading theme \"{}\", falling back to XCursor.", m_szTheme);
-            m_pXcursor->loadTheme(m_szTheme.empty() ? xcursor_theme : m_szTheme, m_iSize);
+            m_pXcursor->loadTheme(m_szTheme.empty() ? xcursor_theme : m_szTheme, m_iSize, m_fCursorScale);
         }
     } else
-        m_pXcursor->loadTheme(m_szTheme.empty() ? xcursor_theme : m_szTheme, m_iSize);
+        m_pXcursor->loadTheme(m_szTheme.empty() ? xcursor_theme : m_szTheme, m_iSize, m_fCursorScale);
 
     updateTheme();
 

--- a/src/managers/XCursorManager.cpp
+++ b/src/managers/XCursorManager.cpp
@@ -100,12 +100,13 @@ CXCursorManager::CXCursorManager() {
     defaultCursor     = hyprCursor;
 }
 
-void CXCursorManager::loadTheme(std::string const& name, int size) {
-    if (lastLoadSize == size && themeName == name)
+void CXCursorManager::loadTheme(std::string const& name, int size, float scale) {
+    if (lastLoadSize == (size * std::ceil(scale)) && themeName == name && lastLoadScale == scale)
         return;
 
-    lastLoadSize = size;
-    themeName    = name.empty() ? "default" : name;
+    lastLoadSize  = size * std::ceil(scale);
+    lastLoadScale = scale;
+    themeName     = name.empty() ? "default" : name;
     defaultCursor.reset();
     cursors.clear();
 
@@ -156,10 +157,10 @@ void CXCursorManager::loadTheme(std::string const& name, int size) {
         syncGsettings();
 }
 
-SP<SXCursors> CXCursorManager::getShape(std::string const& shape, int size) {
+SP<SXCursors> CXCursorManager::getShape(std::string const& shape, int size, float scale) {
     // monitor scaling changed etc, so reload theme with new size.
-    if (size != lastLoadSize)
-        loadTheme(themeName, size);
+    if ((size * std::ceil(scale)) != lastLoadSize || scale != lastLoadScale)
+        loadTheme(themeName, size, scale);
 
     // try to get an icon we know if we have one
     for (auto const& c : cursors) {
@@ -599,6 +600,7 @@ void CXCursorManager::syncGsettings() {
         g_object_unref(gsettings);
     };
 
+    int unscaledSize = lastLoadSize / std::ceil(lastLoadScale);
     setValue("cursor-theme", themeName, "org.gnome.desktop.interface");
-    setValue("cursor-size", lastLoadSize, "org.gnome.desktop.interface");
+    setValue("cursor-size", unscaledSize, "org.gnome.desktop.interface");
 }

--- a/src/managers/XCursorManager.hpp
+++ b/src/managers/XCursorManager.hpp
@@ -29,8 +29,8 @@ class CXCursorManager {
     CXCursorManager();
     ~CXCursorManager() = default;
 
-    void          loadTheme(const std::string& name, int size);
-    SP<SXCursors> getShape(std::string const& shape, int size);
+    void          loadTheme(const std::string& name, int size, float scale);
+    SP<SXCursors> getShape(std::string const& shape, int size, float scale);
     void          syncGsettings();
 
   private:
@@ -40,8 +40,9 @@ class CXCursorManager {
     std::vector<SP<SXCursors>>      loadStandardCursors(std::string const& name, int size);
     std::vector<SP<SXCursors>>      loadAllFromDir(std::string const& path, int size);
 
-    int                             lastLoadSize = 0;
-    std::string                     themeName    = "";
+    int                             lastLoadSize  = 0;
+    float                           lastLoadScale = 0;
+    std::string                     themeName     = "";
     SP<SXCursors>                   defaultCursor;
     SP<SXCursors>                   hyprCursor;
     std::vector<SP<SXCursors>>      cursors;


### PR DESCRIPTION
gtk scales the cursor size itself since its CSD so if we scale the size its gonna get double scaled. incorporate the scale into xcursormanager to keep track of it.

also xwayland expects a scale of 1 for its cursor aswell.

see #7283