### PR TITLE
Add file path to asset ERR log

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -2690,7 +2690,7 @@ void CHyprOpenGLImpl::createBGTextureForMonitor(CMonitor* pMonitor) {
         // check if wallpapers exist
         std::error_code err;
         if (!std::filesystem::exists(texPath, err)) {
-            Debug::log(ERR, "createBGTextureForMonitor: failed, file doesn't exist or access denied, ec: {}", err.message());
+            Debug::log(ERR, "createBGTextureForMonitor: failed, file \"{}\" doesn't exist or access denied, ec: {}", texPath, err.message());
             return; // the texture will be empty, oh well. We'll clear with a solid color anyways.
         }
 


### PR DESCRIPTION
See https://github.com/hyprwm/Hyprland/issues/7319.

Helps to quickly figure out assets directory in case of access failures.