### PR TITLE
Fix syncFullscreen inconsistent with state when set by fullscreenState

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1196,6 +1196,9 @@ void CKeybindManager::fullscreenStateActive(std::string args) {
     }
 
     g_pCompositor->setWindowFullscreenState(PWINDOW, STATE);
+
+    if (internalMode == clientMode)
+        PWINDOW->m_sWindowData.syncFullscreen = CWindowOverridableVar(true, PRIORITY_SET_PROP);
 }
 
 void CKeybindManager::moveActiveToWorkspace(std::string args) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1179,26 +1179,16 @@ void CKeybindManager::fullscreenStateActive(std::string args) {
     const sFullscreenState STATE = sFullscreenState{.internal = (internalMode != -1 ? (eFullscreenMode)internalMode : PWINDOW->m_sFullscreenState.internal),
                                                     .client   = (clientMode != -1 ? (eFullscreenMode)clientMode : PWINDOW->m_sFullscreenState.client)};
 
-    if (internalMode != -1 && clientMode != -1 && PWINDOW->m_sFullscreenState.internal == STATE.internal && PWINDOW->m_sFullscreenState.client == STATE.client) {
+    if (internalMode != -1 && clientMode != -1 && PWINDOW->m_sFullscreenState.internal == STATE.internal && PWINDOW->m_sFullscreenState.client == STATE.client)
         g_pCompositor->setWindowFullscreenState(PWINDOW, sFullscreenState{.internal = FSMODE_NONE, .client = FSMODE_NONE});
-        PWINDOW->m_sWindowData.syncFullscreen = CWindowOverridableVar(true, PRIORITY_SET_PROP);
-        return;
-    }
-
-    if (internalMode != -1 && clientMode == -1 && PWINDOW->m_sFullscreenState.internal == STATE.internal) {
+    else if (internalMode != -1 && clientMode == -1 && PWINDOW->m_sFullscreenState.internal == STATE.internal)
         g_pCompositor->setWindowFullscreenState(PWINDOW, sFullscreenState{.internal = FSMODE_NONE, .client = PWINDOW->m_sFullscreenState.client});
-        return;
-    }
-
-    if (internalMode == -1 && clientMode != -1 && PWINDOW->m_sFullscreenState.client == STATE.client) {
+    else if (internalMode == -1 && clientMode != -1 && PWINDOW->m_sFullscreenState.client == STATE.client)
         g_pCompositor->setWindowFullscreenState(PWINDOW, sFullscreenState{.internal = PWINDOW->m_sFullscreenState.internal, .client = FSMODE_NONE});
-        return;
-    }
+    else
+        g_pCompositor->setWindowFullscreenState(PWINDOW, STATE);
 
-    g_pCompositor->setWindowFullscreenState(PWINDOW, STATE);
-
-    if (internalMode == clientMode)
-        PWINDOW->m_sWindowData.syncFullscreen = CWindowOverridableVar(true, PRIORITY_SET_PROP);
+    PWINDOW->m_sWindowData.syncFullscreen = CWindowOverridableVar(PWINDOW->m_sFullscreenState.internal == PWINDOW->m_sFullscreenState.client, PRIORITY_SET_PROP);
 }
 
 void CKeybindManager::moveActiveToWorkspace(std::string args) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Changes in this PR ensure that `fullscreenState` always sets `syncFulscreen` to the correct value after dispatch regardless of the requested `internal` and `client` states.

Starting with the state `1 0` and  `syncFullscreen = false`:
- Dispatch `1 0`, fullscreen state is set to `0 0`,  `syncFullscreen` remains true
- Dispatch `1 -1`, fullscreen state is set to `0 0`,  `syncFullscreen` was previously false
- Dispatch `-1 1`, fullscreen state is set to `1 1` and `syncFullscreen` was previously false
- Dispatch `2 2`, fullscreen state is set to `2 2` and `syncFullscreen` was previously false

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Ready for merge