### PR TITLE
Add DesktopNames to hyprland.desktop

### DIFF
--- a/example/hyprland.desktop
+++ b/example/hyprland.desktop
@@ -3,3 +3,4 @@ Name=Hyprland
 Comment=An intelligent dynamic tiling Wayland compositor
 Exec=Hyprland
 Type=Application
+DesktopNames=Hyprland;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Adds `DesktopNames` with canonical `Hyprland` name to `hyprland.desktop`. DMs or SMs would use this to set `$XDG_CURRENT_DESKTOP`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Yes.