### PR TITLE
gamma-control: fix crash on monitor disconnect

### DIFF
--- a/src/protocols/GammaControl.cpp
+++ b/src/protocols/GammaControl.cpp
@@ -109,7 +109,7 @@ CGammaControl::CGammaControl(SP<CZwlrGammaControlV1> resource_, wl_resource* out
 }
 
 CGammaControl::~CGammaControl() {
-    if (!gammaTableSet || !pMonitor)
+    if (!gammaTableSet || !pMonitor || !pMonitor->output)
         return;
 
     // reset the LUT if the client dies for whatever reason and doesn't unset the gamma


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes this crash i get when unplugging and external monitor from my laptop:
```
#0  0x00007fcdba89b7dc in __pthread_kill_implementation () from /nix/store/5adwdl39g3k9a2j0qadvirnliv4r7pwd-glibc-2.39-52/lib/libc.so.6
#1  0x00007fcdba849516 in raise () from /nix/store/5adwdl39g3k9a2j0qadvirnliv4r7pwd-glibc-2.39-52/lib/libc.so.6
#2  0x00007fcdba831935 in abort () from /nix/store/5adwdl39g3k9a2j0qadvirnliv4r7pwd-glibc-2.39-52/lib/libc.so.6
#3  0x00000000005f6ecf in operator() (__closure=0x0, _=<optimized out>) at /build/source/src/Compositor.cpp:67
#4  _FUN () at /build/source/src/Compositor.cpp:68
#5  <signal handler called>
#6  0x00007fcdba90b3da in read () from /nix/store/5adwdl39g3k9a2j0qadvirnliv4r7pwd-glibc-2.39-52/lib/libc.so.6
#7  0x00007fcdba890753 in __GI__IO_file_underflow () from /nix/store/5adwdl39g3k9a2j0qadvirnliv4r7pwd-glibc-2.39-52/lib/libc.so.6
#8  0x00007fcdba892bef in _IO_default_uflow () from /nix/store/5adwdl39g3k9a2j0qadvirnliv4r7pwd-glibc-2.39-52/lib/libc.so.6
#9  0x00007fcdba88516e in _IO_getline_info () from /nix/store/5adwdl39g3k9a2j0qadvirnliv4r7pwd-glibc-2.39-52/lib/libc.so.6
#10 0x00007fcdba883e30 in fgets () from /nix/store/5adwdl39g3k9a2j0qadvirnliv4r7pwd-glibc-2.39-52/lib/libc.so.6
#11 0x0000000000717370 in fgets (__s=0x7ffd93108560 "??:0\n", __n=128, __stream=0x3f4afc90)
    at /nix/store/nv84272fps7vc62w42c55hw6cyy9qh3h-glibc-2.39-52-dev/include/bits/stdio2.h:200
#12 execAndGet[abi:cxx11](char const*) (cmd=<optimized out>) at /build/source/src/helpers/MiscFunctions.cpp:594
#13 0x000000000067e102 in CrashReporter::createAndSaveCrash (sig=sig@entry=11)
    at /nix/store/y3cs50f7210gapx8lxm648mh309y6rmw-gcc-14.1.0/include/c++/14.1.0/bits/basic_string.h:227
#14 0x00000000005f6e9f in handleUnrecoverableSignal (sig=11) at /build/source/src/Compositor.cpp:71
#15 handleUnrecoverableSignal (sig=11) at /build/source/src/Compositor.cpp:52
#16 <signal handler called>
#17 Hyprutils::Memory::CSharedPointer<Aquamarine::COutputState>::operator-> (this=0xe0)
    at /nix/store/vvvxs2m2ibrppqq3ffkjh195ipkb0xvs-hyprutils-0.2.1+date=2024-08-05_0252fd1-dev/include/hyprutils/memory/SharedPtr.hpp:228
#18 CGammaControl::~CGammaControl (this=0x37b73f40, __in_chrg=<optimized out>) at /build/source/src/protocols/GammaControl.cpp:116
#19 0x0000000000832298 in std::default_delete<CGammaControl>::operator() (this=<optimized out>, __ptr=0x37b73f40)
    at /nix/store/y3cs50f7210gapx8lxm648mh309y6rmw-gcc-14.1.0/include/c++/14.1.0/bits/unique_ptr.h:87
#20 std::default_delete<CGammaControl>::operator() (this=<optimized out>, __ptr=0x37b73f40)
    at /nix/store/y3cs50f7210gapx8lxm648mh309y6rmw-gcc-14.1.0/include/c++/14.1.0/bits/unique_ptr.h:87
#21 std::unique_ptr<CGammaControl, std::default_delete<CGammaControl> >::~unique_ptr (this=0x37da6768, __in_chrg=<optimized out>)
    at /nix/store/y3cs50f7210gapx8lxm648mh309y6rmw-gcc-14.1.0/include/c++/14.1.0/bits/unique_ptr.h:398
#22 std::destroy_at<std::unique_ptr<CGammaControl, std::default_delete<CGammaControl> > > (__location=0x37da6768)
    at /nix/store/y3cs50f7210gapx8lxm648mh309y6rmw-gcc-14.1.0/include/c++/14.1.0/bits/stl_construct.h:88
#23 std::_Destroy<std::unique_ptr<CGammaControl, std::default_delete<CGammaControl> > > (__pointer=0x37da6768)
    at /nix/store/y3cs50f7210gapx8lxm648mh309y6rmw-gcc-14.1.0/include/c++/14.1.0/bits/stl_construct.h:149
#24 std::_Destroy_aux<false>::__destroy<std::unique_ptr<CGammaControl, std::default_delete<CGammaControl> >*> (__first=0x37da6768, __last=<optimized out>)
    at /nix/store/y3cs50f7210gapx8lxm648mh309y6rmw-gcc-14.1.0/include/c++/14.1.0/bits/stl_construct.h:163
#25 std::_Destroy<std::unique_ptr<CGammaControl, std::default_delete<CGammaControl> >*> (__first=<optimized out>, __last=<optimized out>)
    at /nix/store/y3cs50f7210gapx8lxm648mh309y6rmw-gcc-14.1.0/include/c++/14.1.0/bits/stl_construct.h:196
#26 std::_Destroy<std::unique_ptr<CGammaControl, std::default_delete<CGammaControl> >*, std::unique_ptr<CGammaControl, std::default_delete<CGammaControl> > > (
    __first=<optimized out>, __last=<optimized out>) at /nix/store/y3cs50f7210gapx8lxm648mh309y6rmw-gcc-14.1.0/include/c++/14.1.0/bits/alloc_traits.h:944
#27 std::vector<std::unique_ptr<CGammaControl, std::default_delete<CGammaControl> >, std::allocator<std::unique_ptr<CGammaControl, std::default_delete<CGammaControl> > > >::_M_erase_at_end (this=<optimized out>, __pos=<optimized out>) at /nix/store/y3cs50f7210gapx8lxm648mh309y6rmw-gcc-14.1.0/include/c++/14.1.0/bits/stl_vector.h:1947
#28 std::vector<std::unique_ptr<CGammaControl, std::default_delete<CGammaControl> >, std::allocator<std::unique_ptr<CGammaControl, std::default_delete<CGammaControl> > > >::_M_erase (this=0x2f744708, __first=..., __last=...) at /nix/store/y3cs50f7210gapx8lxm648mh309y6rmw-gcc-14.1.0/include/c++/14.1.0/bits/vector.tcc:202
#29 std::vector<std::unique_ptr<CGammaControl, std::default_delete<CGammaControl> >, std::allocator<std::unique_ptr<CGammaControl, std::default_delete<CGammaControl> > > >::erase (this=0x2f744708, __first=..., __last=...) at /nix/store/y3cs50f7210gapx8lxm648mh309y6rmw-gcc-14.1.0/include/c++/14.1.0/bits/stl_vector.h:1568
#30 std::erase_if<std::unique_ptr<CGammaControl>, std::allocator<std::unique_ptr<CGammaControl> >, CGammaControlProtocol::destroyGammaControl(CGammaControl*)::<lambda(const auto:58&)> > (__cont=..., __pred=...) at /nix/store/y3cs50f7210gapx8lxm648mh309y6rmw-gcc-14.1.0/include/c++/14.1.0/vector:123
#31 CGammaControlProtocol::destroyGammaControl (this=0x2f7446a0, gamma=<optimized out>) at /build/source/src/protocols/GammaControl.cpp:170
#32 0x00000000009805a4 in std::function<void(CZwlrGammaControlV1*)>::operator() (this=<optimized out>, __args#0=<optimized out>)
    at /nix/store/y3cs50f7210gapx8lxm648mh309y6rmw-gcc-14.1.0/include/c++/14.1.0/bits/std_function.h:591
#33 _CZwlrGammaControlV1Destroy (client=<optimized out>, resource=<optimized out>) at /build/source/protocols/wlr-gamma-control-unstable-v1.cpp:146
#34 0x00007fcdbaca2052 in ffi_call_unix64 () from /nix/store/sxrwnsyznfirkcycynqj81gb78dih7ch-libffi-3.4.6/lib/libffi.so.8
#35 0x00007fcdbaca0125 in ffi_call_int () from /nix/store/sxrwnsyznfirkcycynqj81gb78dih7ch-libffi-3.4.6/lib/libffi.so.8
#36 0x00007fcdbaca0d38 in ffi_call () from /nix/store/sxrwnsyznfirkcycynqj81gb78dih7ch-libffi-3.4.6/lib/libffi.so.8
#37 0x00007fcdbb7d0351 in wl_closure_invoke () from /nix/store/gvqs9hrmw50gi9ipww1vf5lh1qx904qi-wayland-1.23.0/lib/libwayland-server.so.0
#38 0x00007fcdbb7cad6a in wl_client_connection_data () from /nix/store/gvqs9hrmw50gi9ipww1vf5lh1qx904qi-wayland-1.23.0/lib/libwayland-server.so.0
#39 0x00007fcdbb7cded2 in wl_event_loop_dispatch () from /nix/store/gvqs9hrmw50gi9ipww1vf5lh1qx904qi-wayland-1.23.0/lib/libwayland-server.so.0
#40 0x00007fcdbb7cb5d5 in wl_display_run () from /nix/store/gvqs9hrmw50gi9ipww1vf5lh1qx904qi-wayland-1.23.0/lib/libwayland-server.so.0
#41 0x00000000007c2183 in CEventLoopManager::enterLoop (this=<optimized out>) at /build/source/src/managers/eventLoop/EventLoopManager.cpp:53
#42 0x00000000006018d0 in CCompositor::startCompositor (this=<optimized out>) at /build/source/src/Compositor.cpp:688
#43 0x00000000005b5bf9 in main (argc=<optimized out>, argv=<optimized out>)
    at /nix/store/y3cs50f7210gapx8lxm648mh309y6rmw-gcc-14.1.0/include/c++/14.1.0/bits/unique_ptr.h:193
#44 0x00007fcdba83314e in __libc_start_call_main () from /nix/store/5adwdl39g3k9a2j0qadvirnliv4r7pwd-glibc-2.39-52/lib/libc.so.6
#45 0x00007fcdba833209 in __libc_start_main_impl () from /nix/store/5adwdl39g3k9a2j0qadvirnliv4r7pwd-glibc-2.39-52/lib/libc.so.6
#46 0x00000000005f6b55 in _start ()
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Ready
