### PR TITLE
Add HYPRLAND_NO_SD_VARS env condition

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -660,8 +660,10 @@ void CCompositor::startCompositor() {
     signal(SIGPIPE, SIG_IGN);
 
     if (
-        m_pAqBackend->hasSession() /* Session-less Hyprland usually means a nest, don't update the env in that case */
-        && !envEnabled("HYPRLAND_NO_SD_VARS") /* Activation environment management is not disabled */
+        /* Session-less Hyprland usually means a nest, don't update the env in that case */
+        m_pAqBackend->hasSession() &&
+        /* Activation environment management is not disabled */
+        !envEnabled("HYPRLAND_NO_SD_VARS")
     ) {
         const auto CMD =
 #ifdef USES_SYSTEMD

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -663,8 +663,7 @@ void CCompositor::startCompositor() {
         /* Session-less Hyprland usually means a nest, don't update the env in that case */
         m_pAqBackend->hasSession() &&
         /* Activation environment management is not disabled */
-        !envEnabled("HYPRLAND_NO_SD_VARS")
-    ) {
+        !envEnabled("HYPRLAND_NO_SD_VARS")) {
         const auto CMD =
 #ifdef USES_SYSTEMD
             "systemctl --user import-environment DISPLAY WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP QT_QPA_PLATFORMTHEME PATH XDG_DATA_DIRS && hash "

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -429,7 +429,7 @@ void CCompositor::cleanEnvironment() {
     if (m_bDesktopEnvSet)
         unsetenv("XDG_CURRENT_DESKTOP");
 
-    if (m_pAqBackend->hasSession()) {
+    if (m_pAqBackend->hasSession() && !envEnabled("HYPRLAND_NO_SD_VARS")) {
         const auto CMD =
 #ifdef USES_SYSTEMD
             "systemctl --user unset-environment DISPLAY WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP QT_QPA_PLATFORMTHEME PATH XDG_DATA_DIRS && hash "
@@ -659,7 +659,10 @@ void CCompositor::prepareFallbackOutput() {
 void CCompositor::startCompositor() {
     signal(SIGPIPE, SIG_IGN);
 
-    if (m_pAqBackend->hasSession() /* Session-less Hyprland usually means a nest, don't update the env in that case */) {
+    if (
+        m_pAqBackend->hasSession() /* Session-less Hyprland usually means a nest, don't update the env in that case */
+        && !envEnabled("HYPRLAND_NO_SD_VARS") /* Activation environment management is not disabled */
+    ) {
         const auto CMD =
 #ifdef USES_SYSTEMD
             "systemctl --user import-environment DISPLAY WAYLAND_DISPLAY HYPRLAND_INSTANCE_SIGNATURE XDG_CURRENT_DESKTOP QT_QPA_PLATFORMTHEME PATH XDG_DATA_DIRS && hash "


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Closes #7083. This was pretty simple.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Not sure if hardcoding `systemctl` & `dbus-update-activation-environment` stuff is really a good idea. Config would be more appropriate IMHO.

Especially the way `dbus-update-activation-environment` and the original dbus' environment works: it can not unset stuff.

Calling `dbus-update-activation-environment` with a bunch of already unset vars does literally nothing. From manpage:

> VAR
... If VAR is not present in the environment, this argument is silently ignored.

The only cleanup option with original dbus is to export empty strings, and execute without `--systemd`.

And with `dbus-broker` there is no need for `dbus-update-activation-environment` at all, which begs for special treatment.

#### Is it ready for merging, or does it need work?

Patched my debian's hyprland 0.41.2, seems to work.
