### PR TITLE
renderbuffer ensure framebuffer gets deleted

### DIFF
--- a/src/render/Renderbuffer.cpp
+++ b/src/render/Renderbuffer.cpp
@@ -35,7 +35,8 @@ CRenderbuffer::CRenderbuffer(SP<Aquamarine::IBuffer> buffer, uint32_t format) : 
     glBindRenderbuffer(GL_RENDERBUFFER, 0);
 
     glGenFramebuffers(1, &m_sFramebuffer.m_iFb);
-    m_sFramebuffer.m_vSize = buffer->size;
+    m_sFramebuffer.m_iFbAllocated = true;
+    m_sFramebuffer.m_vSize        = buffer->size;
     m_sFramebuffer.bind();
     glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, m_iRBO);
 


### PR DESCRIPTION
after commit 4b4971c it uses m_iFbAllocated and deletes if upon calling release() but Renderbuffer generates directly on m_iFb without calling alloc() meaning it wont be deleted on release(), set m_iFbAllocated to true after generating the buffer.

