### PR TITLE
feat: add a config to control which window to focus on when closing window

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -454,6 +454,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SRangeData{1, 0, 3},
     },
     SConfigOptionDescription{
+        .value       = "input:focus_on_close",
+        .description = "Controls the window focus behavior when a window is closed. When set to 0, focus will shift to the next window candidate. When set to 1, focus will shift to the window under the cursor. [0/1]",
+        .type        = CONFIG_OPTION_INT,
+        .data        = SConfigOptionDescription::SRangeData{0, 0, 1},
+    },
+    SConfigOptionDescription{
         .value       = "input:mouse_refocus",
         .description = "if disabled, mouse focus won't switch to the hovered window unless the mouse crosses a window boundary when follow_mouse=1.",
         .type        = CONFIG_OPTION_BOOL,

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -455,8 +455,8 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
     },
     SConfigOptionDescription{
         .value       = "input:focus_on_close",
-        .description = "Controls the window focus behavior when a window is closed. When set to 0, focus will shift to the next window candidate. When set to 1, focus will shift to the window under the cursor. [0/1]",
-        .type        = CONFIG_OPTION_INT,
+        .description = "Controls the window focus behavior when a window is closed. When set to 0, focus will shift to the next window candidate. When set to 1, focus will shift to the window under the cursor.",
+        .type        = CONFIG_OPTION_CHOICE,
         .data        = SConfigOptionDescription::SRangeData{0, 0, 1},
     },
     SConfigOptionDescription{

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -455,7 +455,8 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
     },
     SConfigOptionDescription{
         .value       = "input:focus_on_close",
-        .description = "Controls the window focus behavior when a window is closed. When set to 0, focus will shift to the next window candidate. When set to 1, focus will shift to the window under the cursor.",
+        .description = "Controls the window focus behavior when a window is closed. When set to 0, focus will shift to the next window candidate. When set to 1, focus will shift "
+                       "to the window under the cursor.",
         .type        = CONFIG_OPTION_CHOICE,
         .data        = SConfigOptionDescription::SChoiceData{0, "next,cursor"},
     },

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -457,7 +457,7 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .value       = "input:focus_on_close",
         .description = "Controls the window focus behavior when a window is closed. When set to 0, focus will shift to the next window candidate. When set to 1, focus will shift to the window under the cursor.",
         .type        = CONFIG_OPTION_CHOICE,
-        .data        = SConfigOptionDescription::SRangeData{0, 0, 1},
+        .data        = SConfigOptionDescription::SChoiceData{0, "next,cursor"},
     },
     SConfigOptionDescription{
         .value       = "input:mouse_refocus",

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -449,7 +449,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("animations:first_launch_animation", Hyprlang::INT{1});
 
     m_pConfig->addConfigValue("input:follow_mouse", Hyprlang::INT{1});
-    m_pConfig->addConfigValue("input:focus_on_close", Hyprlang::INT{ 0 });
+    m_pConfig->addConfigValue("input:focus_on_close", Hyprlang::INT{0});
     m_pConfig->addConfigValue("input:mouse_refocus", Hyprlang::INT{1});
     m_pConfig->addConfigValue("input:special_fallthrough", Hyprlang::INT{0});
     m_pConfig->addConfigValue("input:off_window_axis_events", Hyprlang::INT{1});

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -449,6 +449,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("animations:first_launch_animation", Hyprlang::INT{1});
 
     m_pConfig->addConfigValue("input:follow_mouse", Hyprlang::INT{1});
+    m_pConfig->addConfigValue("input:focus_on_close", Hyprlang::INT{ 0 });
     m_pConfig->addConfigValue("input:mouse_refocus", Hyprlang::INT{1});
     m_pConfig->addConfigValue("input:special_fallthrough", Hyprlang::INT{0});
     m_pConfig->addConfigValue("input:off_window_axis_events", Hyprlang::INT{1});

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -648,11 +648,11 @@ void Events::listener_unmapWindow(void* owner, void* data) {
 
     // refocus on a new window if needed
     if (wasLastWindow) {
-        static auto FOCUSONCLOSE = CConfigValue<Hyprlang::INT>("input:focus_on_close");
-        PHLWINDOW PWINDOWCANDIDATE = nullptr;
-        if(*FOCUSONCLOSE)
+        static auto FOCUSONCLOSE     = CConfigValue<Hyprlang::INT>("input:focus_on_close");
+        PHLWINDOW   PWINDOWCANDIDATE = nullptr;
+        if (*FOCUSONCLOSE)
             PWINDOWCANDIDATE = (g_pCompositor->vectorToWindowUnified(g_pInputManager->getMouseCoordsInternal(), RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING));
-        else 
+        else
             PWINDOWCANDIDATE = g_pLayoutManager->getCurrentLayout()->getNextWindowCandidate(PWINDOW);
 
         Debug::log(LOG, "On closed window, new focused candidate is {}", PWINDOWCANDIDATE);

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -648,7 +648,12 @@ void Events::listener_unmapWindow(void* owner, void* data) {
 
     // refocus on a new window if needed
     if (wasLastWindow) {
-        const auto PWINDOWCANDIDATE = g_pLayoutManager->getCurrentLayout()->getNextWindowCandidate(PWINDOW);
+        static auto FOCUSONCLOSE = CConfigValue<Hyprlang::INT>("input:focus_on_close");
+        PHLWINDOW PWINDOWCANDIDATE = nullptr;
+        if(*FOCUSONCLOSE)
+            PWINDOWCANDIDATE = (g_pCompositor->vectorToWindowUnified(g_pInputManager->getMouseCoordsInternal(), RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING));
+        else 
+            PWINDOWCANDIDATE = g_pLayoutManager->getCurrentLayout()->getNextWindowCandidate(PWINDOW);
 
         Debug::log(LOG, "On closed window, new focused candidate is {}", PWINDOWCANDIDATE);
 


### PR DESCRIPTION

#### Describe your PR, what does it fix/add?

This PR introduces a new configuration option, `input::focus_on_close`, which controls the window focus behavior after a window is closed.

Given the existing focus-related settings within the `input` category, I have placed this configuration there as well.

`input::focus_on_close` is an integer, and currently supports two values:
- **0**: Maintains the current behavior, where focus shifts to the next window candidate as determined by `getNextWindowCandidate`.
- **1**: Changes focus to the window under the cursor, which I believe offers a more intuitive user experience.

The reason for using an integer instead of a boolean is to allow for future extensibility. For example, the option could be extended to focus on the previously focused window, or implement other behaviors, depending on user needs or future contributions.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No known issues.

#### Is it ready for merging, or does it need work?

Yes, it is ready for merging.
