### PR TITLE
compositor: update suspendstate on window move

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2737,6 +2737,7 @@ void CCompositor::moveWindowToWorkspaceSafe(PHLWINDOW pWindow, PHLWORKSPACE pWor
 
     g_pCompositor->updateWorkspaceWindows(pWorkspace->m_iID);
     g_pCompositor->updateWorkspaceWindows(pWindow->workspaceID());
+    g_pCompositor->updateSuspendedStates();
 }
 
 PHLWINDOW CCompositor::getForceFocus() {


### PR DESCRIPTION
hyprctl dispatch -- movetoworkspacesilent x,"^kitty$" where X is the current workspace makes kitty stops updating until current workspace is changed while it is on the screen. update the suspend state after it has been moved.

fixes: #7191


