### PR TITLE
feat: more systemd examples

### DIFF
--- a/example/hyprland-session.service
+++ b/example/hyprland-session.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Hyprland - Tiling compositor with the looks
+Documentation=man:Hyprland(1)
+BindsTo=graphical-session.target
+Before=graphical-session.target
+Wants=graphical-session-pre.target
+After=graphical-session-pre.target
+
+[Service]
+Type=notify
+ExecStart=/usr/bin/Hyprland
+ExecStop=/usr/bin/hyprctl dispatch exit
+Restart=on-failure
+Slice=session.slice

--- a/example/hyprland-systemd.desktop
+++ b/example/hyprland-systemd.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Hyprland
+Comment=An intelligent dynamic tiling Wayland compositor
+Exec=systemctl --user start --wait hyprland-session
+Type=Application


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
These allow launching hyprland with a systemd service. They provide `graphical-session.target` which allows enabling services such as the ones for Waybar and Mako.

The existing examples are more examples than actually being usable. For example the load ordering that waybar and mako expect for `graphical-session.target` is not upheld with them.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
They are rather flaky if modified. In particular:
* If `Before=graphical-session.target` is removed then services part of `graphical-session.target` will be launched before hyprland has time to update the user environment variables.
* If `--wait` is removed, the service will exit and immediately put you back into your display manager (e.g. regreet, sddm).

#### Is it ready for merging, or does it need work?
Ready for merging as far as I'm concerned. I would even consider installing these by default on systemd systems.