### PR TITLE
dont rollover in layersurface

### DIFF
--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -432,8 +432,8 @@ void CLayerSurface::startAnimation(bool in, bool instant) {
             PMONITOR->vecPosition + Vector2D{PMONITOR->vecSize.x, PMONITOR->vecSize.y / 2},
         };
 
-        float  closest = std::numeric_limits<float>::max();
-        size_t leader  = force;
+        float closest = std::numeric_limits<float>::max();
+        int   leader  = force;
         if (leader == -1) {
             for (size_t i = 0; i < 4; ++i) {
                 float dist = MIDDLE.distance(edgePoints[i]);


### PR DESCRIPTION
dont rollover in layersurface when assigning leader, a bit unnecessery.


