### PR TITLE
Improve GPU debug reports

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -932,9 +932,9 @@ std::string systemInfoRequest(eHyprCtlOutputFormat format, std::string request) 
         close(fd);
         throw std::runtime_error("Failed to get DRM version");
     }
-    const std::string name = version->name ? version->name : "Unknown";
+    const std::string name        = version->name ? version->name : "Unknown";
     const std::string description = version->desc ? version->desc : "Unknown";
-    std::string GPUINFO = "GPU information:\n";
+    std::string       GPUINFO     = "GPU information:\n";
     GPUINFO += "GPU Type: " + name + "\n";
     GPUINFO += "Driver Description: " + description + "\n";
 

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -939,7 +939,8 @@ std::string systemInfoRequest(eHyprCtlOutputFormat format, std::string request) 
     GPUINFO += "Driver Description: " + description + "\n";
 
     result += GPUINFO;
-
+    drmFreeVersion(version);
+    close(fd);
 
     if (GPUINFO.contains("NVIDIA") && std::filesystem::exists("/proc/driver/nvidia/version"))
         result += execAndGet("cat /proc/driver/nvidia/version | grep NVRM");

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -620,9 +620,9 @@ void logSystemInfo() {
         close(fd);
         throw std::runtime_error("Failed to get DRM version");
     }
-    const std::string name = version->name ? version->name : "Unknown";
+    const std::string name        = version->name ? version->name : "Unknown";
     const std::string description = version->desc ? version->desc : "Unknown";
-    std::string GPUINFO;
+    std::string       GPUINFO;
     GPUINFO += "GPU Type: " + name + "\n";
     GPUINFO += "Driver Description: " + description + "\n";
 

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -627,6 +627,8 @@ void logSystemInfo() {
     GPUINFO += "Driver Description: " + description + "\n";
 
     Debug::log(LOG, "GPU information:\n{}\n", GPUINFO);
+    drmFreeVersion(version);
+    close(fd);
 
     if (GPUINFO.contains("NVIDIA")) {
         Debug::log(WARN, "Warning: you're using an NVIDIA GPU. Make sure you follow the instructions on the wiki if anything is amiss.\n");

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -612,26 +612,22 @@ void logSystemInfo() {
     Debug::log(NONE, "\n");
 
     int fd = open("/dev/dri/card0", O_RDONLY | O_CLOEXEC);
-    if (fd < 0) {
-        throw std::runtime_error("Failed to open /dev/dri/card0");
-    }
-    drmVersion* version = drmGetVersion(fd);
-    if (!version) {
+    if (fd > 0) {
+        drmVersion* version = drmGetVersion(fd);
+
+        const std::string name        = version->name ? version->name : "Unknown";
+        const std::string description = version->desc ? version->desc : "Unknown";
+        std::string       GPUINFO     = "GPU information:\n";
+        GPUINFO += "GPU Type: " + name + "\n";
+        GPUINFO += "Driver Description: " + description + "\n";
+
+        Debug::log(LOG, "{}\n", GPUINFO);
+        drmFreeVersion(version);
         close(fd);
-        throw std::runtime_error("Failed to get DRM version");
-    }
-    const std::string name        = version->name ? version->name : "Unknown";
-    const std::string description = version->desc ? version->desc : "Unknown";
-    std::string       GPUINFO;
-    GPUINFO += "GPU Type: " + name + "\n";
-    GPUINFO += "Driver Description: " + description + "\n";
 
-    Debug::log(LOG, "GPU information:\n{}\n", GPUINFO);
-    drmFreeVersion(version);
-    close(fd);
-
-    if (GPUINFO.contains("NVIDIA")) {
-        Debug::log(WARN, "Warning: you're using an NVIDIA GPU. Make sure you follow the instructions on the wiki if anything is amiss.\n");
+        if (GPUINFO.contains("NVIDIA")) {
+            Debug::log(WARN, "Warning: you're using an NVIDIA GPU. Make sure you follow the instructions on the wiki if anything is amiss.\n");
+        }
     }
 
     // log etc


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Instead of using weird "hacks" to get GPU information, Just get whatever libdrm reports.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
At the moment this uses /dev/dri/card0.
This implementation is not as verbose as before, Card model is not shown, unaware of a way to show it.

#### Is it ready for merging, or does it need work?
I'd say it's ready i guess.

