### PR TITLE
xwayland: deactivate xwayland focus if wayland is focused

### DIFF
--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -43,8 +43,11 @@ void CHyprXWaylandManager::activateSurface(SP<CWLSurfaceResource> pSurface, bool
                 w->m_pXWaylandSurface->restackToTop();
             }
             w->m_pXWaylandSurface->activate(activate);
-        } else
+        } else {
             w->m_pXDGSurface->toplevel->setActive(activate);
+            if (g_pCompositor->m_pLastFocus && g_pCompositor->m_pLastWindow->m_bIsX11)
+                activateSurface(g_pCompositor->m_pLastFocus.lock(), false);
+        }
     }
 }
 

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -897,7 +897,7 @@ void CXWM::activateSurface(SP<CXWaylandSurface> surf, bool activate) {
     if ((surf == focusedSurface && activate) || (surf && surf->overrideRedirect))
         return;
 
-    if (!surf) {
+    if (!surf || !activate) {
         setActiveWindow((uint32_t)XCB_WINDOW_NONE);
         focusWindow(nullptr);
     } else {

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -897,7 +897,7 @@ void CXWM::activateSurface(SP<CXWaylandSurface> surf, bool activate) {
     if ((surf == focusedSurface && activate) || (surf && surf->overrideRedirect))
         return;
 
-    if (!surf || !activate) {
+    if (!surf || (!activate && g_pCompositor->m_pLastWindow && !g_pCompositor->m_pLastWindow->m_bIsX11)) {
         setActiveWindow((uint32_t)XCB_WINDOW_NONE);
         focusWindow(nullptr);
     } else {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
When going from XWayland -> Wayland the window doesn't actually unfocus until you activate another XWayland window. This removes the focus so the last XWayland window doesn't think its still focused. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nope

#### Is it ready for merging, or does it need work?
Ready for merging

