### PR TITLE
CMakeLists: wayland.xml is in wayland-scanner pkgdatadir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ find_package(PkgConfig REQUIRED)
 
 pkg_get_variable(WAYLAND_PROTOCOLS_DIR wayland-protocols pkgdatadir)
 message(STATUS "Found wayland-protocols at ${WAYLAND_PROTOCOLS_DIR}")
-pkg_get_variable(WAYLAND_SERVER_DIR wayland-server pkgdatadir)
+pkg_get_variable(WAYLAND_SCANNER_PKGDATA_DIR wayland-scanner pkgdatadir)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES DEBUG)
   message(STATUS "Configuring Hyprland in Debug with CMake")
@@ -259,7 +259,7 @@ function(protocolWayland)
     OUTPUT ${CMAKE_SOURCE_DIR}/protocols/wayland.cpp
            ${CMAKE_SOURCE_DIR}/protocols/wayland.hpp
     COMMAND hyprwayland-scanner --wayland-enums
-            ${WAYLAND_SERVER_DIR}/wayland.xml ${CMAKE_SOURCE_DIR}/protocols/
+            ${WAYLAND_SCANNER_PKGDATA_DIR}/wayland.xml ${CMAKE_SOURCE_DIR}/protocols/
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
   target_sources(Hyprland PRIVATE protocols/wayland.cpp protocols/wayland.hpp)
   target_sources(generate-protocol-headers


### PR DESCRIPTION
See https://gitlab.freedesktop.org/wayland/wayland/-/blob/6c4a695045155583a99f3fbce7bb745f79c2e726/meson.build#L129-136

Similar fix as https://github.com/hyprwm/aquamarine/pull/55.

#### Is it ready for merging, or does it need work?
Ready for merge :-)
