### PR TITLE
Fix crash reports having execute permission

### DIFF
--- a/src/debug/CrashReporter.cpp
+++ b/src/debug/CrashReporter.cpp
@@ -86,7 +86,7 @@ void CrashReporter::createAndSaveCrash(int sig) {
             stderr.flush();
         }
 
-        reportFd = open(reportPath.get_str(), O_WRONLY | O_CREAT, S_IRWXU);
+        reportFd = open(reportPath.get_str(), O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
         if (reportFd < 0) {
             exit_with_error("Failed to open crash report path for writing");
         }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Crash reports are currently created with rwx permissions, but they shouldn't be executable.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Ready for merging