### PR TITLE
Fix modifier keys getting stuck if depressed during config reload

### DIFF
--- a/src/devices/IKeyboard.cpp
+++ b/src/devices/IKeyboard.cpp
@@ -119,7 +119,8 @@ void IKeyboard::setKeymap(const SStringRuleNames& rules) {
         if (IDX != XKB_MOD_INVALID)
             modifiersState.locked |= (uint32_t)1 << IDX;
 
-        updateModifiers(modifiersState.depressed, modifiersState.latched, modifiersState.locked, modifiersState.group);
+        // 0 to avoid mods getting stuck if depressed during reload
+        updateModifiers(0, 0, modifiersState.locked, modifiersState.group);
     }
 
     for (size_t i = 0; i < LEDNAMES.size(); ++i) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

##### The problem

If `input:numlock_by_default = true`, depressed mods will get stuck on config reload; this takes effect after some **other** mod is pressed. Can be unstuck by pressing the stuck mod another time.

##### With patch

Mods won't be stuck

`modifiersState` is still updated to the correct values, but it's done inside `updateModifiersState()` after new `xkbState` takes effect. Thus `SModifiersEvent` is also emitted, which is what I suspect actually fixes it.

This restores 0.41.2 behavior

https://github.com/hyprwm/Hyprland/blob/918d8340afd652b011b937d29d5eea0be08467f5/src/managers/input/InputManager.cpp#L993-L1002

with the exception that selected keyboard layout is preserved.

Fixes https://github.com/hyprwm/Hyprland/issues/7069

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Someone [says](https://github.com/hyprwm/Hyprland/issues/7069#issuecomment-2303328558) that you could

> open hyprland config in micro editor, edit config, hold CTRL, press S then Q to save then quit

But even on 0.41.2, regardless of `numlock_by_default` value, I can't reproduce it **if** I wait for config autoreload before pressing Q.

But if you press it fast enough - then it works.

#### Is it ready for merging, or does it need work?

Yes
