### PR TITLE
Fix missing include needed by clang

### DIFF
--- a/src/managers/XCursorManager.cpp
+++ b/src/managers/XCursorManager.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cstring>
 #include <dirent.h>
 #include <filesystem>


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Hyprland was failing to build on Clang due to using std::copy_if, std::none_of, and std::any_of while algorithm wasn't included. This simply includes it allowing Hyprland to build with clang.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

#### Is it ready for merging, or does it need work?
If this is an acceptable solution for this issue and the commit name is acceptable it should be ready to merge.

