### PR TITLE
Implement workspace scale animations

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -741,8 +741,6 @@ void CConfigManager::setDefaultAnimationVars() {
         INITANIMCFG("fadeShadow");
         INITANIMCFG("fadeDim");
 
-        // border
-
         // workspaces
         INITANIMCFG("workspaces");
         INITANIMCFG("workspacesIn");
@@ -777,6 +775,12 @@ void CConfigManager::setDefaultAnimationVars() {
     CREATEANIMCFG("fadeLayers", "fade");
     CREATEANIMCFG("fadeLayersIn", "fadeLayers");
     CREATEANIMCFG("fadeLayersOut", "fadeLayers");
+    CREATEANIMCFG("fadeWorkspaces", "fade");
+    CREATEANIMCFG("fadeWorkspacesIn", "fadeWorkspaces");
+    CREATEANIMCFG("fadeWorkspacesOut", "fadeWorkspaces");
+    CREATEANIMCFG("fadeSpecialWorkspace", "fadeWorkspaces");
+    CREATEANIMCFG("fadeSpecialWorkspaceIn", "fadeSpecialWorkspace");
+    CREATEANIMCFG("fadeSpecialWorkspaceOut", "fadeSpecialWorkspace");
 
     CREATEANIMCFG("workspacesIn", "workspaces");
     CREATEANIMCFG("workspacesOut", "workspaces");

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -116,7 +116,7 @@ void CWorkspace::startAnim(bool in, bool left, bool instant) {
     // handle animation styles for the movement one
     if (ANIMSTYLE.starts_with("slide") && ANIMSTYLE.contains("%")) {
         const auto PMONITOR = g_pCompositor->getMonitorFromID(m_iMonitorID);
-        float      movePerc = 100.f;
+        float      movePerc = 0.F;
 
         try {
             auto percstr = ANIMSTYLE.substr(ANIMSTYLE.find_last_of(' ') + 1);
@@ -143,7 +143,7 @@ void CWorkspace::startAnim(bool in, bool left, bool instant) {
     } else if (ANIMSTYLE.starts_with("popin")) {
         m_vRenderOffset.setValueAndWarp(Vector2D(0, 0));
 
-        float startPerc = 100.f;
+        float startPerc = 0.F;
 
         try {
             auto percstr = ANIMSTYLE.substr(ANIMSTYLE.find_last_of(' ') + 1);

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -39,6 +39,7 @@ class CWorkspace {
     // for animations
     CAnimatedVariable<Vector2D> m_vRenderOffset;
     CAnimatedVariable<float>    m_fAlpha;
+    CAnimatedVariable<float>    m_fScaleClients;
     bool                        m_bForceRendering = false;
 
     // allows damage to propagate.

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -472,9 +472,9 @@ std::string CAnimationManager::styleValidInConfigVar(const std::string& config, 
 
         return "unknown style";
     } else if (config.starts_with("workspaces") || config.starts_with("specialWorkspace")) {
-        if (style == "slide" || style == "slidevert" || style == "fade")
+        if (style == "slide" || style == "slidevert")
             return "";
-        else if (style.starts_with("slidefade")) {
+        else if (style.starts_with("slide") || style.starts_with("popin")) {
             // try parsing
             float movePerc = 0.f;
             if (style.find("%") != std::string::npos) {


### PR DESCRIPTION
Breaks some animation configs, fade/anim got split:

- `fadeWorkspaces`, `fadeWorkspacesIn`, `fadeSpecialWorkspace` etc

new style: `popin` optionally % `popin 20%`

`slidefade` removed (fade + slide is possible separately)