### PR TITLE
build: fix 32bit builds

### DIFF
--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -353,13 +353,13 @@ SWorkspaceIDName getWorkspaceIDNameFromString(const std::string& in) {
                 char        walkDir       = in[1];
 
                 // sanitize. 0 means invalid oob in -
-                predictedWSID = std::max(predictedWSID, 0L);
+                predictedWSID = std::max(predictedWSID, static_cast<int64_t>(0));
 
                 // Count how many invalidWSes are in between (how bad the prediction was)
                 WORKSPACEID beginID = in[1] == '+' ? activeWSID + 1 : predictedWSID;
                 WORKSPACEID endID   = in[1] == '+' ? predictedWSID : activeWSID;
                 auto        begin   = invalidWSes.upper_bound(beginID - 1); // upper_bound is >, we want >=
-                for (auto it = begin; *it <= endID && it != invalidWSes.end(); it++) {
+                for (auto it = begin; it != invalidWSes.end() && *it <= endID; it++) {
                     remainingWSes++;
                 }
 
@@ -376,7 +376,7 @@ SWorkspaceIDName getWorkspaceIDNameFromString(const std::string& in) {
                     }
 
                     currentItem += remains;
-                    currentItem = std::max(currentItem, 0UL);
+                    currentItem = std::max(currentItem, static_cast<size_t>(0));
                     if (currentItem >= namedWSes.size()) {
                         // At the seam between namedWSes and normal WSes. Behave like r+[diff] at imaginary ws 0
                         size_t diff         = currentItem - (namedWSes.size() - 1);
@@ -384,7 +384,7 @@ SWorkspaceIDName getWorkspaceIDNameFromString(const std::string& in) {
                         WORKSPACEID beginID = 1;
                         WORKSPACEID endID   = predictedWSID;
                         auto        begin   = invalidWSes.upper_bound(beginID - 1); // upper_bound is >, we want >=
-                        for (auto it = begin; *it <= endID && it != invalidWSes.end(); it++) {
+                        for (auto it = begin; it != invalidWSes.end() && *it <= endID; it++) {
                             remainingWSes++;
                         }
                         walkDir = '+';
@@ -413,7 +413,7 @@ SWorkspaceIDName getWorkspaceIDNameFromString(const std::string& in) {
                             // Need remainingWSes more
                             auto namedWSIdx = namedWSes.size() - remainingWSes;
                             // Sanitze
-                            namedWSIdx = std::clamp(namedWSIdx, 0UL, namedWSes.size() - 1);
+                            namedWSIdx = std::clamp(namedWSIdx, static_cast<size_t>(0), namedWSes.size() - static_cast<size_t>(1));
                             finalWSID  = namedWSes[namedWSIdx];
                         } else {
                             // Couldn't find valid workspace in negative direction, search last first one back up positive direction

--- a/src/protocols/PresentationTime.cpp
+++ b/src/protocols/PresentationTime.cpp
@@ -58,8 +58,12 @@ void CPresentationFeedback::sendQueued(SP<CQueuedPresentationData> data, timespe
     if (reportedFlags & Aquamarine::IOutput::AQ_OUTPUT_PRESENT_HW_COMPLETION)
         flags |= WP_PRESENTATION_FEEDBACK_KIND_HW_COMPLETION;
 
+    __time_t tv_sec = 0;
+    if (sizeof(__time_t) > 4)
+        tv_sec = when->tv_sec >> 32;
+
     if (data->wasPresented)
-        resource->sendPresented((uint32_t)(when->tv_sec >> 32), (uint32_t)(when->tv_sec & 0xFFFFFFFF), (uint32_t)(when->tv_nsec), untilRefreshNs, (uint32_t)(seq >> 32),
+        resource->sendPresented((uint32_t)tv_sec, (uint32_t)(when->tv_sec & 0xFFFFFFFF), (uint32_t)(when->tv_nsec), untilRefreshNs, (uint32_t)(seq >> 32),
                                 (uint32_t)(seq & 0xFFFFFFFF), (wpPresentationFeedbackKind)flags);
     else
         resource->sendDiscarded();


### PR DESCRIPTION
ensure the correct type is passed to std::clamp and std::max int64_t is different on 64bit compared to 32bit, also in presentationtime tv_sec is __time_t and on 32bit its a 32bit type so right shift count >= width of type. so only bit shift on 64bit. and avoid potential nullptr deref in the for loops, check for .end() before *it <= endID.

fixes: #7422 

atleast it builds now, but since im not planning on installing a 32bit OS and properly test if we are overflowing/rolling over on other places i cant say if it fixes any runtime issues.
