### PR TITLE
sessionLock: fix misc:allow_session_lock_restore

### DIFF
--- a/src/protocols/SessionLock.cpp
+++ b/src/protocols/SessionLock.cpp
@@ -175,13 +175,6 @@ void CSessionLockProtocol::onLock(CExtSessionLockManagerV1* pMgr, uint32_t id) {
         return;
     }
 
-    if (m_vLocks.size() > 1) {
-        LOGM(ERR, "Tried to lock a locked session");
-        RESOURCE->inert = true;
-        RESOURCE->resource->sendFinished();
-        return;
-    }
-
     events.newLock.emit(RESOURCE);
 
     locked = true;

--- a/src/protocols/SessionLock.cpp
+++ b/src/protocols/SessionLock.cpp
@@ -175,7 +175,7 @@ void CSessionLockProtocol::onLock(CExtSessionLockManagerV1* pMgr, uint32_t id) {
         return;
     }
 
-    if (locked) {
+    if (m_vLocks.size() > 1) {
         LOGM(ERR, "Tried to lock a locked session");
         RESOURCE->inert = true;
         RESOURCE->resource->sendFinished();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

I broke `misc:allow_session_lock_restore` with #6843.
The session beeing locked is checked in the `onNewSessionLock` handler, which also respects the
`misc:allow_session_lock_restore` option. So i removed the check in `CSessionLockProtocol::onLock`.
 
Closes #7455

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

The `misc:allow_session_lock_restore` option is a bit dangerous when hyprlock is configured with grace is used.
For example when a idle deamon lanches hyprlock a second time without `--immediate` and then the session can sudently be unlocked via grace.

Maybe we should ad a disclaimer to the grace option in the wiki. 

#### Is it ready for merging, or does it need work?

Tested it, seems to behave as expected.

- crash handler of hyprlock can recover the session.
- when the option is disabled it does not work and new hyprlock instances recieve `finished`
- launching a second hyprlock instance with the option enabled results in two locks, which seems to work, except the grace problem mentioned above.
