### PR TITLE
make most for loops use const references

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -314,7 +314,7 @@ void CCompositor::initServer(std::string socketName, int socketFd) {
 
     initManagers(STAGE_LATE);
 
-    for (auto& o : pendingOutputs) {
+    for (auto const& o : pendingOutputs) {
         onNewMonitor(o);
     }
     pendingOutputs.clear();
@@ -403,7 +403,7 @@ void CCompositor::initAllSignals() {
 
                     m_bSessionActive = false;
 
-                    for (auto& m : m_vMonitors) {
+                    for (auto const& m : m_vMonitors) {
                         m->noFrameSchedule = true;
                         m->framesToSkip    = 1;
                     }
@@ -741,7 +741,7 @@ CMonitor* CCompositor::getMonitorFromVector(const Vector2D& point) {
         float        bestDistance = 0.f;
         SP<CMonitor> pBestMon;
 
-        for (auto& m : m_vMonitors) {
+        for (auto const& m : m_vMonitors) {
             float dist = vecToRectDistanceSquared(point, m->vecPosition, m->vecPosition + m->vecSize);
 
             if (dist < bestDistance || !pBestMon) {
@@ -1164,8 +1164,8 @@ void CCompositor::focusSurface(SP<CWLSurfaceResource> pSurface, PHLWINDOW pWindo
 }
 
 SP<CWLSurfaceResource> CCompositor::vectorToLayerPopupSurface(const Vector2D& pos, CMonitor* monitor, Vector2D* sCoords, PHLLS* ppLayerSurfaceFound) {
-    for (auto& lsl : monitor->m_aLayerSurfaceLayers | std::views::reverse) {
-        for (auto& ls : lsl | std::views::reverse) {
+    for (auto const& lsl : monitor->m_aLayerSurfaceLayers | std::views::reverse) {
+        for (auto const& ls : lsl | std::views::reverse) {
             if (ls->fadingOut || !ls->layerSurface || (ls->layerSurface && !ls->layerSurface->mapped) || ls->alpha.value() == 0.f)
                 continue;
 
@@ -1183,7 +1183,7 @@ SP<CWLSurfaceResource> CCompositor::vectorToLayerPopupSurface(const Vector2D& po
 }
 
 SP<CWLSurfaceResource> CCompositor::vectorToLayerSurface(const Vector2D& pos, std::vector<PHLLSREF>* layerSurfaces, Vector2D* sCoords, PHLLS* ppLayerSurfaceFound) {
-    for (auto& ls : *layerSurfaces | std::views::reverse) {
+    for (auto const& ls : *layerSurfaces | std::views::reverse) {
         if (ls->fadingOut || !ls->layerSurface || (ls->layerSurface && !ls->layerSurface->surface->mapped) || ls->alpha.value() == 0.f)
             continue;
 
@@ -1458,7 +1458,7 @@ void CCompositor::cleanupFadingOut(const MONITORID& monid) {
             g_pHyprOpenGL->markBlurDirtyForMonitor(getMonitorFromID(monid));
 
         if (ls->fadingOut && ls->readyToDelete && ls->isFadedOut()) {
-            for (auto& m : m_vMonitors) {
+            for (auto const& m : m_vMonitors) {
                 for (auto& lsl : m->m_aLayerSurfaceLayers) {
                     if (!lsl.empty() && std::find_if(lsl.begin(), lsl.end(), [&](auto& other) { return other == ls; }) != lsl.end()) {
                         std::erase_if(lsl, [&](auto& other) { return other == ls || !other; });
@@ -1718,7 +1718,7 @@ PHLWINDOW CCompositor::getPrevWindowOnWorkspace(PHLWINDOW pWindow, bool focusabl
 
 WORKSPACEID CCompositor::getNextAvailableNamedWorkspace() {
     WORKSPACEID lowest = -1337 + 1;
-    for (auto& w : m_vWorkspaces) {
+    for (auto const& w : m_vWorkspaces) {
         if (w->m_iID < -1 && w->m_iID < lowest)
             lowest = w->m_iID;
     }
@@ -1748,7 +1748,7 @@ PHLWORKSPACE CCompositor::getWorkspaceByString(const std::string& str) {
 }
 
 bool CCompositor::isPointOnAnyMonitor(const Vector2D& point) {
-    for (auto& m : m_vMonitors) {
+    for (auto const& m : m_vMonitors) {
         if (VECINRECT(point, m->vecPosition.x, m->vecPosition.y, m->vecSize.x + m->vecPosition.x, m->vecSize.y + m->vecPosition.y))
             return true;
     }
@@ -1834,7 +1834,7 @@ CMonitor* CCompositor::getMonitorInDirection(CMonitor* pSourceMonitor, const cha
 }
 
 void CCompositor::updateAllWindowsAnimatedDecorationValues() {
-    for (auto& w : m_vWindows) {
+    for (auto const& w : m_vWindows) {
         if (!w->m_bIsMapped)
             continue;
 
@@ -2139,7 +2139,7 @@ void CCompositor::moveWorkspaceToMonitor(PHLWORKSPACE pWorkspace, CMonitor* pMon
     if (!SWITCHINGISACTIVE)
         nextWorkspaceOnMonitorID = pWorkspace->m_iID;
     else {
-        for (auto& w : m_vWorkspaces) {
+        for (auto const& w : m_vWorkspaces) {
             if (w->m_iMonitorID == POLDMON->ID && w->m_iID != pWorkspace->m_iID && !w->m_bIsSpecialWorkspace) {
                 nextWorkspaceOnMonitorID = w->m_iID;
                 break;
@@ -2237,7 +2237,7 @@ bool CCompositor::workspaceIDOutOfBounds(const WORKSPACEID& id) {
     WORKSPACEID lowestID  = INT64_MAX;
     WORKSPACEID highestID = INT64_MIN;
 
-    for (auto& w : m_vWorkspaces) {
+    for (auto const& w : m_vWorkspaces) {
         if (w->m_bIsSpecialWorkspace)
             continue;
 
@@ -2271,7 +2271,7 @@ void CCompositor::updateFullscreenFadeOnWorkspace(PHLWORKSPACE pWorkspace) {
     const auto PMONITOR = getMonitorFromID(pWorkspace->m_iMonitorID);
 
     if (pWorkspace->m_iID == PMONITOR->activeWorkspaceID() || pWorkspace->m_iID == PMONITOR->activeSpecialWorkspaceID()) {
-        for (auto& ls : PMONITOR->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]) {
+        for (auto const& ls : PMONITOR->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]) {
             if (!ls->fadingOut)
                 ls->alpha = FULLSCREEN && pWorkspace->m_efFullscreenMode == FSMODE_FULLSCREEN ? 0.f : 1.f;
         }
@@ -2376,7 +2376,7 @@ PHLWINDOW CCompositor::getX11Parent(PHLWINDOW pWindow) {
     if (!pWindow->m_bIsX11)
         return nullptr;
 
-    for (auto& w : m_vWindows) {
+    for (auto const& w : m_vWindows) {
         if (!w->m_bIsX11)
             continue;
 
@@ -2543,7 +2543,7 @@ void CCompositor::closeWindow(PHLWINDOW pWindow) {
 PHLLS CCompositor::getLayerSurfaceFromSurface(SP<CWLSurfaceResource> pSurface) {
     std::pair<SP<CWLSurfaceResource>, bool> result = {pSurface, false};
 
-    for (auto& ls : m_vLayers) {
+    for (auto const& ls : m_vLayers) {
         if (ls->layerSurface && ls->layerSurface->surface == pSurface)
             return ls;
 
@@ -2679,7 +2679,7 @@ bool CCompositor::isWorkspaceSpecial(const WORKSPACEID& id) {
 
 WORKSPACEID CCompositor::getNewSpecialID() {
     WORKSPACEID highest = SPECIAL_WORKSPACE_START;
-    for (auto& ws : m_vWorkspaces) {
+    for (auto const& ws : m_vWorkspaces) {
         if (ws->m_bIsSpecialWorkspace && ws->m_iID > highest) {
             highest = ws->m_iID;
         }

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -813,11 +813,11 @@ void CConfigManager::postConfigReload(const Hyprlang::CParseResult& result) {
     static const auto PENABLEEXPLICIT     = CConfigValue<Hyprlang::INT>("render:explicit_sync");
     static int        prevEnabledExplicit = *PENABLEEXPLICIT;
 
-    for (auto& w : g_pCompositor->m_vWindows) {
+    for (auto const& w : g_pCompositor->m_vWindows) {
         w->uncacheWindowDecos();
     }
 
-    for (auto& m : g_pCompositor->m_vMonitors)
+    for (auto const& m : g_pCompositor->m_vMonitors)
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m->ID);
 
     // Update the keyboard layout to the cfg'd one if this is not the first launch
@@ -901,7 +901,7 @@ void CConfigManager::postConfigReload(const Hyprlang::CParseResult& result) {
         m->forceFullFrames = 2;
 
         // also force mirrors, as the aspect ratio could've changed
-        for (auto& mirror : m->mirrors)
+        for (auto const& mirror : m->mirrors)
             mirror->forceFullFrames = 3;
     }
 
@@ -940,7 +940,7 @@ std::string CConfigManager::parseKeyword(const std::string& COMMAND, const std::
 
     // invalidate layouts if they changed
     if (COMMAND == "monitor" || COMMAND.contains("gaps_") || COMMAND.starts_with("dwindle:") || COMMAND.starts_with("master:")) {
-        for (auto& m : g_pCompositor->m_vMonitors)
+        for (auto const& m : g_pCompositor->m_vMonitors)
             g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m->ID);
     }
 
@@ -1034,7 +1034,7 @@ std::string CConfigManager::getDeviceString(const std::string& dev, const std::s
 }
 
 SMonitorRule CConfigManager::getMonitorRuleFor(const CMonitor& PMONITOR) {
-    for (auto& r : m_dMonitorRules | std::views::reverse) {
+    for (auto const& r : m_dMonitorRules | std::views::reverse) {
         if (PMONITOR.matchesStaticSelector(r.name)) {
             return r;
         }
@@ -1042,7 +1042,7 @@ SMonitorRule CConfigManager::getMonitorRuleFor(const CMonitor& PMONITOR) {
 
     Debug::log(WARN, "No rule found for {}, trying to use the first.", PMONITOR.szName);
 
-    for (auto& r : m_dMonitorRules) {
+    for (auto const& r : m_dMonitorRules) {
         if (r.name.empty()) {
             return r;
         }
@@ -1354,7 +1354,7 @@ void CConfigManager::dispatchExecOnce() {
     firstExecDispatched = true;
     isLaunchingExecOnce = true;
 
-    for (auto& c : firstExecRequests) {
+    for (auto const& c : firstExecRequests) {
         handleRawExec("", c);
     }
 
@@ -1438,7 +1438,7 @@ bool CConfigManager::deviceConfigExists(const std::string& dev) {
 }
 
 bool CConfigManager::shouldBlurLS(const std::string& ns) {
-    for (auto& bls : m_dBlurLSNamespaces) {
+    for (auto const& bls : m_dBlurLSNamespaces) {
         if (bls == ns) {
             return true;
         }
@@ -1553,7 +1553,7 @@ CMonitor* CConfigManager::getBoundMonitorForWS(const std::string& wsname) {
 }
 
 std::string CConfigManager::getBoundMonitorStringForWS(const std::string& wsname) {
-    for (auto& wr : m_dWorkspaceRules) {
+    for (auto const& wr : m_dWorkspaceRules) {
         const auto WSNAME = wr.workspaceName.starts_with("name:") ? wr.workspaceName.substr(5) : wr.workspaceName;
 
         if (WSNAME == wsname)
@@ -1624,7 +1624,7 @@ void CConfigManager::addPluginKeyword(HANDLE handle, const std::string& name, Hy
 }
 
 void CConfigManager::removePluginConfig(HANDLE handle) {
-    for (auto& k : pluginKeywords) {
+    for (auto const& k : pluginKeywords) {
         if (k.handle != handle)
             continue;
 
@@ -1647,7 +1647,7 @@ std::string CConfigManager::getDefaultWorkspaceFor(const std::string& name) {
             if (other->monitor == name)
                 return other->workspaceString;
             if (other->monitor.substr(0, 5) == "desc:") {
-                auto monitor = g_pCompositor->getMonitorFromDesc(other->monitor.substr(5));
+                auto const monitor = g_pCompositor->getMonitorFromDesc(other->monitor.substr(5));
                 if (monitor && monitor->szName == name)
                     return other->workspaceString;
             }
@@ -2044,7 +2044,7 @@ std::optional<std::string> CConfigManager::handleBind(const std::string& command
     bool       dontInhibit    = false;
     const auto BINDARGS       = command.substr(4);
 
-    for (auto& arg : BINDARGS) {
+    for (auto const& arg : BINDARGS) {
         if (arg == 'l') {
             locked = true;
         } else if (arg == 'r') {
@@ -2222,9 +2222,9 @@ std::optional<std::string> CConfigManager::handleLayerRule(const std::string& co
 
     m_dLayerRules.push_back({VALUE, RULE});
 
-    for (auto& m : g_pCompositor->m_vMonitors)
-        for (auto& lsl : m->m_aLayerSurfaceLayers)
-            for (auto& ls : lsl)
+    for (auto const& m : g_pCompositor->m_vMonitors)
+        for (auto const& lsl : m->m_aLayerSurfaceLayers)
+            for (auto const& ls : lsl)
                 ls->applyRules();
 
     return {};
@@ -2423,9 +2423,9 @@ void CConfigManager::updateBlurredLS(const std::string& name, const bool forceBl
         matchName = matchName.substr(8);
     }
 
-    for (auto& m : g_pCompositor->m_vMonitors) {
-        for (auto& lsl : m->m_aLayerSurfaceLayers) {
-            for (auto& ls : lsl) {
+    for (auto const& m : g_pCompositor->m_vMonitors) {
+        for (auto const& lsl : m->m_aLayerSurfaceLayers) {
+            for (auto const& ls : lsl) {
                 if (BYADDRESS) {
                     if (std::format("0x{:x}", (uintptr_t)ls.get()) == matchName)
                         ls->forceBlur = forceBlur;

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -146,7 +146,7 @@ std::string monitorsRequest(eHyprCtlOutputFormat format, std::string request) {
     if (format == eHyprCtlOutputFormat::FORMAT_JSON) {
         result += "[";
 
-        for (auto& m : allMonitors ? g_pCompositor->m_vRealMonitors : g_pCompositor->m_vMonitors) {
+        for (auto const& m : allMonitors ? g_pCompositor->m_vRealMonitors : g_pCompositor->m_vMonitors) {
             result += CHyprCtl::getMonitorData(m, format);
         }
 
@@ -154,7 +154,7 @@ std::string monitorsRequest(eHyprCtlOutputFormat format, std::string request) {
 
         result += "]";
     } else {
-        for (auto& m : allMonitors ? g_pCompositor->m_vRealMonitors : g_pCompositor->m_vMonitors) {
+        for (auto const& m : allMonitors ? g_pCompositor->m_vRealMonitors : g_pCompositor->m_vMonitors) {
             if (!m->output || m->ID == -1)
                 continue;
 
@@ -272,7 +272,7 @@ std::string clientsRequest(eHyprCtlOutputFormat format, std::string request) {
     if (format == eHyprCtlOutputFormat::FORMAT_JSON) {
         result += "[";
 
-        for (auto& w : g_pCompositor->m_vWindows) {
+        for (auto const& w : g_pCompositor->m_vWindows) {
             if (!w->m_bIsMapped && !g_pHyprCtl->m_sCurrentRequestParams.all)
                 continue;
 
@@ -283,7 +283,7 @@ std::string clientsRequest(eHyprCtlOutputFormat format, std::string request) {
 
         result += "]";
     } else {
-        for (auto& w : g_pCompositor->m_vWindows) {
+        for (auto const& w : g_pCompositor->m_vWindows) {
             if (!w->m_bIsMapped && !g_pHyprCtl->m_sCurrentRequestParams.all)
                 continue;
 
@@ -381,7 +381,7 @@ std::string workspacesRequest(eHyprCtlOutputFormat format, std::string request) 
 
     if (format == eHyprCtlOutputFormat::FORMAT_JSON) {
         result += "[";
-        for (auto& w : g_pCompositor->m_vWorkspaces) {
+        for (auto const& w : g_pCompositor->m_vWorkspaces) {
             result += CHyprCtl::getWorkspaceData(w, format);
             result += ",";
         }
@@ -389,7 +389,7 @@ std::string workspacesRequest(eHyprCtlOutputFormat format, std::string request) 
         trimTrailingComma(result);
         result += "]";
     } else {
-        for (auto& w : g_pCompositor->m_vWorkspaces) {
+        for (auto const& w : g_pCompositor->m_vWorkspaces) {
             result += CHyprCtl::getWorkspaceData(w, format);
         }
     }
@@ -401,7 +401,7 @@ std::string workspaceRulesRequest(eHyprCtlOutputFormat format, std::string reque
     std::string result = "";
     if (format == eHyprCtlOutputFormat::FORMAT_JSON) {
         result += "[";
-        for (auto& r : g_pConfigManager->getAllWorkspaceRules()) {
+        for (auto const& r : g_pConfigManager->getAllWorkspaceRules()) {
             result += getWorkspaceRuleData(r, format);
             result += ",";
         }
@@ -409,7 +409,7 @@ std::string workspaceRulesRequest(eHyprCtlOutputFormat format, std::string reque
         trimTrailingComma(result);
         result += "]";
     } else {
-        for (auto& r : g_pConfigManager->getAllWorkspaceRules()) {
+        for (auto const& r : g_pConfigManager->getAllWorkspaceRules()) {
             result += getWorkspaceRuleData(r, format);
         }
     }
@@ -437,7 +437,7 @@ std::string layersRequest(eHyprCtlOutputFormat format, std::string request) {
     if (format == eHyprCtlOutputFormat::FORMAT_JSON) {
         result += "{\n";
 
-        for (auto& mon : g_pCompositor->m_vMonitors) {
+        for (auto const& mon : g_pCompositor->m_vMonitors) {
             result += std::format(
                 R"#("{}": {{
     "levels": {{
@@ -744,7 +744,7 @@ std::string animationsRequest(eHyprCtlOutputFormat format, std::string request) 
 
         ret += ",\n[";
 
-        for (auto& bz : g_pAnimationManager->getAllBeziers()) {
+        for (auto const& bz : g_pAnimationManager->getAllBeziers()) {
             ret += std::format(R"#(
 {{
     "name": "{}"
@@ -782,7 +782,7 @@ std::string globalShortcutsRequest(eHyprCtlOutputFormat format, std::string requ
             ret += std::format("{}:{} -> {}\n", sh.appid, sh.id, sh.description);
     } else {
         ret += "[";
-        for (auto& sh : SHORTCUTS) {
+        for (auto const& sh : SHORTCUTS) {
             ret += std::format(R"#(
 {{
     "name": "{}",
@@ -1286,7 +1286,7 @@ std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
         g_pCompositor->focusWindow(PLASTWINDOW);
     }
 
-    for (auto& m : g_pCompositor->m_vMonitors)
+    for (auto const& m : g_pCompositor->m_vMonitors)
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m->ID);
 
     return "ok";
@@ -1386,7 +1386,7 @@ std::string dispatchOutput(eHyprCtlOutputFormat format, std::string request) {
     bool       added = false;
 
     if (!vars[3].empty()) {
-        for (auto& m : g_pCompositor->m_vRealMonitors) {
+        for (auto const& m : g_pCompositor->m_vRealMonitors) {
             if (m->szName == vars[3])
                 return "Name already taken";
         }

--- a/src/debug/HyprDebugOverlay.cpp
+++ b/src/debug/HyprDebugOverlay.cpp
@@ -57,7 +57,7 @@ int CHyprMonitorDebugOverlay::draw(int offset) {
     float avgFrametime = 0;
     float maxFrametime = 0;
     float minFrametime = 9999;
-    for (auto& ft : m_dLastFrametimes) {
+    for (auto const& ft : m_dLastFrametimes) {
         if (ft > maxFrametime)
             maxFrametime = ft;
         if (ft < minFrametime)
@@ -70,7 +70,7 @@ int CHyprMonitorDebugOverlay::draw(int offset) {
     float avgRenderTime = 0;
     float maxRenderTime = 0;
     float minRenderTime = 9999;
-    for (auto& rt : m_dLastRenderTimes) {
+    for (auto const& rt : m_dLastRenderTimes) {
         if (rt > maxRenderTime)
             maxRenderTime = rt;
         if (rt < minRenderTime)
@@ -83,7 +83,7 @@ int CHyprMonitorDebugOverlay::draw(int offset) {
     float avgRenderTimeNoOverlay = 0;
     float maxRenderTimeNoOverlay = 0;
     float minRenderTimeNoOverlay = 9999;
-    for (auto& rt : m_dLastRenderTimesNoOverlay) {
+    for (auto const& rt : m_dLastRenderTimesNoOverlay) {
         if (rt > maxRenderTimeNoOverlay)
             maxRenderTimeNoOverlay = rt;
         if (rt < minRenderTimeNoOverlay)
@@ -96,7 +96,7 @@ int CHyprMonitorDebugOverlay::draw(int offset) {
     float avgAnimMgrTick = 0;
     float maxAnimMgrTick = 0;
     float minAnimMgrTick = 9999;
-    for (auto& at : m_dLastAnimationTicks) {
+    for (auto const& at : m_dLastAnimationTicks) {
         if (at > maxAnimMgrTick)
             maxAnimMgrTick = at;
         if (at < minAnimMgrTick)

--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -72,7 +72,7 @@ CLayerSurface::~CLayerSurface() {
     g_pHyprRenderer->makeEGLCurrent();
     std::erase_if(g_pHyprOpenGL->m_mLayerFramebuffers, [&](const auto& other) { return other.first.expired() || other.first.lock() == self.lock(); });
 
-    for (auto& mon : g_pCompositor->m_vRealMonitors) {
+    for (auto const& mon : g_pCompositor->m_vRealMonitors) {
         for (auto& lsl : mon->m_aLayerSurfaceLayers) {
             std::erase_if(lsl, [this](auto& ls) { return ls.expired() || ls.get() == this; });
         }

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -252,7 +252,7 @@ void CWindow::updateWindowDecos() {
     if (!m_bIsMapped || isHidden())
         return;
 
-    for (auto& wd : m_vDecosToRemove) {
+    for (auto const& wd : m_vDecosToRemove) {
         for (auto it = m_dWindowDecorations.begin(); it != m_dWindowDecorations.end(); it++) {
             if (it->get() == wd) {
                 g_pDecorationPositioner->uncacheDecoration(it->get());
@@ -270,11 +270,11 @@ void CWindow::updateWindowDecos() {
     // make a copy because updateWindow can remove decos.
     std::vector<IHyprWindowDecoration*> decos;
 
-    for (auto& wd : m_dWindowDecorations) {
+    for (auto const& wd : m_dWindowDecorations) {
         decos.push_back(wd.get());
     }
 
-    for (auto& wd : decos) {
+    for (auto const& wd : decos) {
         if (std::find_if(m_dWindowDecorations.begin(), m_dWindowDecorations.end(), [wd](const auto& other) { return other.get() == wd; }) == m_dWindowDecorations.end())
             continue;
         wd->updateWindow(m_pSelf.lock());
@@ -454,7 +454,7 @@ PHLWINDOW CWindow::X11TransientFor() {
         s = s->parent;
     }
 
-    for (auto& w : g_pCompositor->m_vWindows) {
+    for (auto const& w : g_pCompositor->m_vWindows) {
         if (w->m_pXWaylandSurface != s)
             continue;
         return w;
@@ -464,7 +464,7 @@ PHLWINDOW CWindow::X11TransientFor() {
 }
 
 void CWindow::removeDecorationByType(eDecorationType type) {
-    for (auto& wd : m_dWindowDecorations) {
+    for (auto const& wd : m_dWindowDecorations) {
         if (wd->getDecorationType() == type)
             m_vDecosToRemove.push_back(wd.get());
     }
@@ -617,7 +617,7 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
 
             int      opacityIDX = 0;
 
-            for (auto& r : vars) {
+            for (auto const& r : vars) {
                 if (r == "opacity")
                     continue;
 
@@ -770,7 +770,7 @@ void CWindow::updateDynamicRules() {
     m_tags.removeDynamicTags();
 
     m_vMatchedRules = g_pConfigManager->getMatchingRules(m_pSelf.lock());
-    for (auto& r : m_vMatchedRules) {
+    for (auto const& r : m_vMatchedRules) {
         applyDynamicRule(r);
     }
 
@@ -881,7 +881,7 @@ void CWindow::destroyGroup() {
         addresses += std::format("{:x},", (uintptr_t)curr.get());
     } while (curr.get() != this);
 
-    for (auto& w : members) {
+    for (auto const& w : members) {
         if (w->m_sGroupData.head)
             g_pLayoutManager->getCurrentLayout()->onWindowRemoved(curr);
         w->m_sGroupData.head = false;

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -207,7 +207,7 @@ void CMonitor::onConnect(bool noRule) {
 
     // verify last mon valid
     bool found = false;
-    for (auto& m : g_pCompositor->m_vMonitors) {
+    for (auto const& m : g_pCompositor->m_vMonitors) {
         if (m == g_pCompositor->m_pLastMonitor) {
             found = true;
             break;
@@ -272,7 +272,7 @@ void CMonitor::onDisconnect(bool destroy) {
     listeners.commit.reset();
 
     for (size_t i = 0; i < 4; ++i) {
-        for (auto& ls : m_aLayerSurfaceLayers[i]) {
+        for (auto const& ls : m_aLayerSurfaceLayers[i]) {
             if (ls->layerSurface && !ls->fadingOut)
                 ls->layerSurface->sendClosed();
         }

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -49,7 +49,7 @@ void SDwindleNodeData::getAllChildrenRecursive(std::deque<SDwindleNodeData*>* pD
 
 int CHyprDwindleLayout::getNodesOnWorkspace(const WORKSPACEID& id) {
     int no = 0;
-    for (auto& n : m_lDwindleNodesData) {
+    for (auto const& n : m_lDwindleNodesData) {
         if (n.workspaceID == id && n.valid)
             ++no;
     }

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -691,7 +691,7 @@ Vector2D IHyprLayout::predictSizeForNewWindow(PHLWINDOW pWindow) {
     bool shouldBeFloated = g_pXWaylandManager->shouldBeFloated(pWindow, true);
 
     if (!shouldBeFloated) {
-        for (auto& r : g_pConfigManager->getMatchingRules(pWindow, true, true)) {
+        for (auto const& r : g_pConfigManager->getMatchingRules(pWindow, true, true)) {
             if (r.szRule.starts_with("float")) {
                 shouldBeFloated = true;
                 break;

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -16,7 +16,7 @@ SMasterNodeData* CHyprMasterLayout::getNodeFromWindow(PHLWINDOW pWindow) {
 
 int CHyprMasterLayout::getNodesOnWorkspace(const WORKSPACEID& ws) {
     int no = 0;
-    for (auto& n : m_lMasterNodesData) {
+    for (auto const& n : m_lMasterNodesData) {
         if (n.workspaceID == ws)
             no++;
     }
@@ -26,7 +26,7 @@ int CHyprMasterLayout::getNodesOnWorkspace(const WORKSPACEID& ws) {
 
 int CHyprMasterLayout::getMastersOnWorkspace(const WORKSPACEID& ws) {
     int no = 0;
-    for (auto& n : m_lMasterNodesData) {
+    for (auto const& n : m_lMasterNodesData) {
         if (n.workspaceID == ws && n.isMaster)
             no++;
     }
@@ -381,7 +381,7 @@ void CHyprMasterLayout::calculateWorkspace(PHLWORKSPACE pWorkspace) {
     if (*PSMARTRESIZING) {
         // check the total width and height so that later
         // if larger/smaller than screen size them down/up
-        for (auto& nd : m_lMasterNodesData) {
+        for (auto const& nd : m_lMasterNodesData) {
             if (nd.workspaceID == pWorkspace->m_iID) {
                 if (nd.isMaster)
                     masterAccumulatedSize += totalSize / MASTERS * nd.percSize;
@@ -552,7 +552,7 @@ void CHyprMasterLayout::calculateWorkspace(PHLWORKSPACE pWorkspace) {
         float       slaveAccumulatedHeightL = 0;
         float       slaveAccumulatedHeightR = 0;
         if (*PSMARTRESIZING) {
-            for (auto& nd : m_lMasterNodesData) {
+            for (auto const& nd : m_lMasterNodesData) {
                 if (nd.workspaceID != pWorkspace->m_iID || nd.isMaster)
                     continue;
 

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -131,7 +131,7 @@ void CAnimationManager::tick() {
             }
 
             // damage any workspace window that is on any monitor
-            for (auto& w : g_pCompositor->m_vWindows) {
+            for (auto const& w : g_pCompositor->m_vWindows) {
                 if (!validMapped(w) || w->m_pWorkspace != PWORKSPACE || w->m_bPinned)
                     continue;
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -765,7 +765,7 @@ void CKeybindManager::shadowKeybinds(const xkb_keysym_t& doesntHave, const uint3
             const auto KBKEY      = xkb_keysym_from_name(k.key.c_str(), XKB_KEYSYM_CASE_INSENSITIVE);
             const auto KBKEYUPPER = xkb_keysym_to_upper(KBKEY);
 
-            for (auto& pk : m_dPressedKeys) {
+            for (auto const& pk : m_dPressedKeys) {
                 if ((pk.keysym != 0 && (pk.keysym == KBKEY || pk.keysym == KBKEYUPPER))) {
                     shadow = true;
 
@@ -864,7 +864,7 @@ SDispatchResult CKeybindManager::spawn(std::string args) {
     if (!RULES.empty()) {
         const auto RULESLIST = CVarList(RULES, 0, ';');
 
-        for (auto& r : RULESLIST) {
+        for (auto const& r : RULESLIST) {
             g_pConfigManager->addExecRule({r, (unsigned long)PROC});
         }
 
@@ -1708,7 +1708,7 @@ SDispatchResult CKeybindManager::workspaceOpt(std::string args) {
         PWORKSPACE->m_bDefaultPseudo = !PWORKSPACE->m_bDefaultPseudo;
 
         // apply
-        for (auto& w : g_pCompositor->m_vWindows) {
+        for (auto const& w : g_pCompositor->m_vWindows) {
             if (!w->m_bIsMapped || w->m_pWorkspace != PWORKSPACE)
                 continue;
 
@@ -2129,7 +2129,7 @@ SDispatchResult CKeybindManager::setSubmap(std::string submap) {
         return {};
     }
 
-    for (auto& k : g_pKeybindManager->m_lKeybinds) {
+    for (auto const& k : g_pKeybindManager->m_lKeybinds) {
         if (k.submap == submap) {
             m_szCurrentSelectedSubmap = submap;
             Debug::log(LOG, "Changed keybind submap to {}", submap);

--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -90,7 +90,7 @@ void CPointerManager::unlockSoftwareAll() {
 }
 
 void CPointerManager::lockSoftwareForMonitor(CMonitor* Monitor) {
-    for (auto& m : g_pCompositor->m_vMonitors) {
+    for (auto const& m : g_pCompositor->m_vMonitors) {
         if (m->ID == Monitor->ID) {
             lockSoftwareForMonitor(m);
             return;
@@ -107,7 +107,7 @@ void CPointerManager::lockSoftwareForMonitor(SP<CMonitor> mon) {
 }
 
 void CPointerManager::unlockSoftwareForMonitor(CMonitor* Monitor) {
-    for (auto& m : g_pCompositor->m_vMonitors) {
+    for (auto const& m : g_pCompositor->m_vMonitors) {
         if (m->ID == Monitor->ID) {
             unlockSoftwareForMonitor(m);
             return;
@@ -225,7 +225,7 @@ void CPointerManager::recheckEnteredOutputs() {
 
     auto box = getCursorBoxGlobal();
 
-    for (auto& s : monitorStates) {
+    for (auto const& s : monitorStates) {
         if (s->monitor.expired() || s->monitor->isMirror() || !s->monitor->m_bEnabled)
             continue;
 
@@ -279,7 +279,7 @@ void CPointerManager::resetCursorImage(bool apply) {
     currentCursorImage.scale   = 1.F;
     currentCursorImage.hotspot = {0, 0};
 
-    for (auto& s : monitorStates) {
+    for (auto const& s : monitorStates) {
         if (s->monitor.expired() || s->monitor->isMirror() || !s->monitor->m_bEnabled)
             continue;
 
@@ -289,7 +289,7 @@ void CPointerManager::resetCursorImage(bool apply) {
     if (!apply)
         return;
 
-    for (auto& ms : monitorStates) {
+    for (auto const& ms : monitorStates) {
         if (!ms->monitor || !ms->monitor->m_bEnabled || !ms->monitor->dpmsStatus) {
             Debug::log(TRACE, "Not updating hw cursors: disabled / dpms off display");
             continue;
@@ -334,7 +334,7 @@ void CPointerManager::onCursorMoved() {
     if (!hasCursor())
         return;
 
-    for (auto& m : g_pCompositor->m_vMonitors) {
+    for (auto const& m : g_pCompositor->m_vMonitors) {
         auto state = stateFor(m);
 
         state->box = getCursorBoxLogicalForMonitor(state->monitor.lock());
@@ -1006,7 +1006,7 @@ void CPointerManager::detachTablet(SP<CTablet> tablet) {
 }
 
 void CPointerManager::damageCursor(SP<CMonitor> pMonitor) {
-    for (auto& mw : monitorStates) {
+    for (auto const& mw : monitorStates) {
         if (mw->monitor != pMonitor)
             continue;
 

--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -24,7 +24,7 @@ void CSeatManager::onNewSeatResource(SP<CWLSeatResource> resource) {
 }
 
 SP<CSeatManager::SSeatResourceContainer> CSeatManager::containerForResource(SP<CWLSeatResource> seatResource) {
-    for (auto& c : seatResources) {
+    for (auto const& c : seatResources) {
         if (c->resource == seatResource)
             return c;
     }
@@ -112,11 +112,11 @@ void CSeatManager::setKeyboardFocus(SP<CWLSurfaceResource> surf) {
 
     if (state.keyboardFocusResource) {
         auto client = state.keyboardFocusResource->client();
-        for (auto& s : seatResources) {
+        for (auto const& s : seatResources) {
             if (s->resource->client() != client)
                 continue;
 
-            for (auto& k : s->resource->keyboards) {
+            for (auto const& k : s->resource->keyboards) {
                 if (!k)
                     continue;
 
@@ -134,12 +134,12 @@ void CSeatManager::setKeyboardFocus(SP<CWLSurfaceResource> surf) {
     }
 
     auto client = surf->client();
-    for (auto& r : seatResources | std::views::reverse) {
+    for (auto const& r : seatResources | std::views::reverse) {
         if (r->resource->client() != client)
             continue;
 
         state.keyboardFocusResource = r->resource;
-        for (auto& k : r->resource->keyboards) {
+        for (auto const& k : r->resource->keyboards) {
             if (!k)
                 continue;
 
@@ -157,11 +157,11 @@ void CSeatManager::sendKeyboardKey(uint32_t timeMs, uint32_t key, wl_keyboard_ke
     if (!state.keyboardFocusResource)
         return;
 
-    for (auto& s : seatResources) {
+    for (auto const& s : seatResources) {
         if (s->resource->client() != state.keyboardFocusResource->client())
             continue;
 
-        for (auto& k : s->resource->keyboards) {
+        for (auto const& k : s->resource->keyboards) {
             if (!k)
                 continue;
 
@@ -174,11 +174,11 @@ void CSeatManager::sendKeyboardMods(uint32_t depressed, uint32_t latched, uint32
     if (!state.keyboardFocusResource)
         return;
 
-    for (auto& s : seatResources) {
+    for (auto const& s : seatResources) {
         if (s->resource->client() != state.keyboardFocusResource->client())
             continue;
 
-        for (auto& k : s->resource->keyboards) {
+        for (auto const& k : s->resource->keyboards) {
             if (!k)
                 continue;
 
@@ -205,11 +205,11 @@ void CSeatManager::setPointerFocus(SP<CWLSurfaceResource> surf, const Vector2D& 
 
     if (state.pointerFocusResource) {
         auto client = state.pointerFocusResource->client();
-        for (auto& s : seatResources) {
+        for (auto const& s : seatResources) {
             if (s->resource->client() != client)
                 continue;
 
-            for (auto& p : s->resource->pointers) {
+            for (auto const& p : s->resource->pointers) {
                 if (!p)
                     continue;
 
@@ -230,12 +230,12 @@ void CSeatManager::setPointerFocus(SP<CWLSurfaceResource> surf, const Vector2D& 
     }
 
     auto client = surf->client();
-    for (auto& r : seatResources | std::views::reverse) {
+    for (auto const& r : seatResources | std::views::reverse) {
         if (r->resource->client() != client)
             continue;
 
         state.pointerFocusResource = r->resource;
-        for (auto& p : r->resource->pointers) {
+        for (auto const& p : r->resource->pointers) {
             if (!p)
                 continue;
 
@@ -257,11 +257,11 @@ void CSeatManager::sendPointerMotion(uint32_t timeMs, const Vector2D& local) {
     if (!state.pointerFocusResource)
         return;
 
-    for (auto& s : seatResources) {
+    for (auto const& s : seatResources) {
         if (s->resource->client() != state.pointerFocusResource->client())
             continue;
 
-        for (auto& p : s->resource->pointers) {
+        for (auto const& p : s->resource->pointers) {
             if (!p)
                 continue;
 
@@ -276,11 +276,11 @@ void CSeatManager::sendPointerButton(uint32_t timeMs, uint32_t key, wl_pointer_b
     if (!state.pointerFocusResource)
         return;
 
-    for (auto& s : seatResources) {
+    for (auto const& s : seatResources) {
         if (s->resource->client() != state.pointerFocusResource->client())
             continue;
 
-        for (auto& p : s->resource->pointers) {
+        for (auto const& p : s->resource->pointers) {
             if (!p)
                 continue;
 
@@ -300,11 +300,11 @@ void CSeatManager::sendPointerFrame(WP<CWLSeatResource> pResource) {
     if (!pResource)
         return;
 
-    for (auto& s : seatResources) {
+    for (auto const& s : seatResources) {
         if (s->resource->client() != pResource->client())
             continue;
 
-        for (auto& p : s->resource->pointers) {
+        for (auto const& p : s->resource->pointers) {
             if (!p)
                 continue;
 
@@ -318,11 +318,11 @@ void CSeatManager::sendPointerAxis(uint32_t timeMs, wl_pointer_axis axis, double
     if (!state.pointerFocusResource)
         return;
 
-    for (auto& s : seatResources) {
+    for (auto const& s : seatResources) {
         if (s->resource->client() != state.pointerFocusResource->client())
             continue;
 
-        for (auto& p : s->resource->pointers) {
+        for (auto const& p : s->resource->pointers) {
             if (!p)
                 continue;
 
@@ -346,12 +346,12 @@ void CSeatManager::sendTouchDown(SP<CWLSurfaceResource> surf, uint32_t timeMs, i
     state.touchFocus = surf;
 
     auto client = surf->client();
-    for (auto& r : seatResources | std::views::reverse) {
+    for (auto const& r : seatResources | std::views::reverse) {
         if (r->resource->client() != client)
             continue;
 
         state.touchFocusResource = r->resource;
-        for (auto& t : r->resource->touches) {
+        for (auto const& t : r->resource->touches) {
             if (!t)
                 continue;
 
@@ -372,12 +372,12 @@ void CSeatManager::sendTouchUp(uint32_t timeMs, int32_t id) {
         return;
 
     auto client = state.touchFocusResource->client();
-    for (auto& r : seatResources | std::views::reverse) {
+    for (auto const& r : seatResources | std::views::reverse) {
         if (r->resource->client() != client)
             continue;
 
         state.touchFocusResource = r->resource;
-        for (auto& t : r->resource->touches) {
+        for (auto const& t : r->resource->touches) {
             if (!t)
                 continue;
 
@@ -395,11 +395,11 @@ void CSeatManager::sendTouchMotion(uint32_t timeMs, int32_t id, const Vector2D& 
     if (!state.touchFocusResource)
         return;
 
-    for (auto& s : seatResources) {
+    for (auto const& s : seatResources) {
         if (s->resource->client() != state.touchFocusResource->client())
             continue;
 
-        for (auto& t : s->resource->touches) {
+        for (auto const& t : s->resource->touches) {
             if (!t)
                 continue;
 
@@ -412,11 +412,11 @@ void CSeatManager::sendTouchFrame() {
     if (!state.touchFocusResource)
         return;
 
-    for (auto& s : seatResources) {
+    for (auto const& s : seatResources) {
         if (s->resource->client() != state.touchFocusResource->client())
             continue;
 
-        for (auto& t : s->resource->touches) {
+        for (auto const& t : s->resource->touches) {
             if (!t)
                 continue;
 
@@ -429,11 +429,11 @@ void CSeatManager::sendTouchCancel() {
     if (!state.touchFocusResource)
         return;
 
-    for (auto& s : seatResources) {
+    for (auto const& s : seatResources) {
         if (s->resource->client() != state.touchFocusResource->client())
             continue;
 
-        for (auto& t : s->resource->touches) {
+        for (auto const& t : s->resource->touches) {
             if (!t)
                 continue;
 
@@ -446,11 +446,11 @@ void CSeatManager::sendTouchShape(int32_t id, const Vector2D& shape) {
     if (!state.touchFocusResource)
         return;
 
-    for (auto& s : seatResources) {
+    for (auto const& s : seatResources) {
         if (s->resource->client() != state.touchFocusResource->client())
             continue;
 
-        for (auto& t : s->resource->touches) {
+        for (auto const& t : s->resource->touches) {
             if (!t)
                 continue;
 
@@ -463,11 +463,11 @@ void CSeatManager::sendTouchOrientation(int32_t id, double angle) {
     if (!state.touchFocusResource)
         return;
 
-    for (auto& s : seatResources) {
+    for (auto const& s : seatResources) {
         if (s->resource->client() != state.touchFocusResource->client())
             continue;
 
-        for (auto& t : s->resource->touches) {
+        for (auto const& t : s->resource->touches) {
             if (!t)
                 continue;
 

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -137,7 +137,7 @@ bool CSessionLockManager::isSurfaceSessionLock(SP<CWLSurfaceResource> pSurface) 
     if (!m_pSessionLock)
         return false;
 
-    for (auto& sls : m_pSessionLock->vSessionLockSurfaces) {
+    for (auto const& sls : m_pSessionLock->vSessionLockSurfaces) {
         if (sls->surface->surface() == pSurface)
             return true;
     }
@@ -154,7 +154,7 @@ void CSessionLockManager::removeSessionLockSurface(SSessionLockSurface* pSLS) {
     if (g_pCompositor->m_pLastFocus)
         return;
 
-    for (auto& sls : m_pSessionLock->vSessionLockSurfaces) {
+    for (auto const& sls : m_pSessionLock->vSessionLockSurfaces) {
         if (!sls->mapped)
             continue;
 

--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -147,7 +147,7 @@ void CHyprXWaylandManager::setWindowSize(PHLWINDOW pWindow, Vector2D size, bool 
 
 bool CHyprXWaylandManager::shouldBeFloated(PHLWINDOW pWindow, bool pending) {
     if (pWindow->m_bIsX11) {
-        for (auto& a : pWindow->m_pXWaylandSurface->atoms)
+        for (auto const& a : pWindow->m_pXWaylandSurface->atoms)
             if (a == HYPRATOMS["_NET_WM_WINDOW_TYPE_DIALOG"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_SPLASH"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_TOOLBAR"] ||
                 a == HYPRATOMS["_NET_WM_WINDOW_TYPE_UTILITY"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_TOOLTIP"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_POPUP_MENU"] ||
                 a == HYPRATOMS["_NET_WM_WINDOW_TYPE_DOCK"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_DROPDOWN_MENU"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_MENU"] ||
@@ -193,7 +193,7 @@ void CHyprXWaylandManager::checkBorders(PHLWINDOW pWindow) {
     if (!pWindow->m_bIsX11)
         return;
 
-    for (auto& a : pWindow->m_pXWaylandSurface->atoms) {
+    for (auto const& a : pWindow->m_pXWaylandSurface->atoms) {
         if (a == HYPRATOMS["_NET_WM_WINDOW_TYPE_POPUP_MENU"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_NOTIFICATION"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_DROPDOWN_MENU"] ||
             a == HYPRATOMS["_NET_WM_WINDOW_TYPE_COMBO"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_MENU"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_SPLASH"] ||
             a == HYPRATOMS["_NET_WM_WINDOW_TYPE_TOOLTIP"]) {

--- a/src/managers/input/IdleInhibitor.cpp
+++ b/src/managers/input/IdleInhibitor.cpp
@@ -31,7 +31,7 @@ void CInputManager::newIdleInhibitor(std::any inhibitor) {
 
 void CInputManager::recheckIdleInhibitorStatus() {
 
-    for (auto& ii : m_vIdleInhibitors) {
+    for (auto const& ii : m_vIdleInhibitors) {
         if (ii->nonDesktop) {
             PROTO::idle->setInhibit(true);
             return;

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -919,7 +919,7 @@ void CInputManager::setupKeyboard(SP<IKeyboard> keeb) {
 }
 
 void CInputManager::setKeyboardLayout() {
-    for (auto& k : m_vKeyboards)
+    for (auto const& k : m_vKeyboards)
         applyConfigToKeyboard(k);
 
     g_pKeybindManager->updateXKBTranslationState();
@@ -1197,7 +1197,7 @@ void CInputManager::destroyKeyboard(SP<IKeyboard> pKeyboard) {
 
     if (m_vKeyboards.size() > 0) {
         bool found = false;
-        for (auto& k : m_vKeyboards | std::views::reverse) {
+        for (auto const& k : m_vKeyboards | std::views::reverse) {
             if (!k)
                 continue;
 
@@ -1673,7 +1673,7 @@ void CInputManager::releaseAllMouseButtons() {
     if (PROTO::data->dndActive())
         return;
 
-    for (auto& mb : buttonsCopy) {
+    for (auto const& mb : buttonsCopy) {
         g_pSeatManager->sendPointerButton(0, mb, WL_POINTER_BUTTON_STATE_RELEASED);
     }
 

--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -14,7 +14,7 @@ void CInputManager::onSwipeBegin(IPointer::SSwipeBeginEvent e) {
         return;
 
     int onMonitor = 0;
-    for (auto& w : g_pCompositor->m_vWorkspaces) {
+    for (auto const& w : g_pCompositor->m_vWorkspaces) {
         if (w->m_iMonitorID == g_pCompositor->m_pLastMonitor->ID && !g_pCompositor->isWorkspaceSpecial(w->m_iID)) {
             onMonitor++;
         }
@@ -38,7 +38,7 @@ void CInputManager::beginWorkspaceSwipe() {
     m_sActiveSwipe.speedPoints     = 0;
 
     if (PWORKSPACE->m_bHasFullscreenWindow) {
-        for (auto& ls : g_pCompositor->m_pLastMonitor->m_aLayerSurfaceLayers[2]) {
+        for (auto const& ls : g_pCompositor->m_pLastMonitor->m_aLayerSurfaceLayers[2]) {
             ls->alpha = 1.f;
         }
     }
@@ -193,7 +193,7 @@ void CInputManager::endWorkspaceSwipe() {
     g_pInputManager->refocus();
 
     // apply alpha
-    for (auto& ls : g_pCompositor->m_pLastMonitor->m_aLayerSurfaceLayers[2]) {
+    for (auto const& ls : g_pCompositor->m_pLastMonitor->m_aLayerSurfaceLayers[2]) {
         ls->alpha = pSwitchedTo->m_bHasFullscreenWindow && pSwitchedTo->m_efFullscreenMode == FSMODE_FULLSCREEN ? 0.f : 1.f;
     }
 }

--- a/src/managers/input/Tablets.cpp
+++ b/src/managers/input/Tablets.cpp
@@ -14,7 +14,7 @@ static void unfocusTool(SP<CTabletTool> tool) {
     tool->setSurface(nullptr);
     if (tool->isDown)
         PROTO::tablet->up(tool);
-    for (auto& b : tool->buttonsDown) {
+    for (auto const& b : tool->buttonsDown) {
         PROTO::tablet->buttonTool(tool, b, false);
     }
     PROTO::tablet->proximityOut(tool);
@@ -31,7 +31,7 @@ static void focusTool(SP<CTabletTool> tool, SP<CTablet> tablet, SP<CWLSurfaceRes
     PROTO::tablet->proximityIn(tool, tablet, surf);
     if (tool->isDown)
         PROTO::tablet->down(tool);
-    for (auto& b : tool->buttonsDown) {
+    for (auto const& b : tool->buttonsDown) {
         PROTO::tablet->buttonTool(tool, b, true);
     }
 }

--- a/src/plugins/HookSystem.cpp
+++ b/src/plugins/HookSystem.cpp
@@ -81,7 +81,7 @@ CFunctionHook::SAssembly CFunctionHook::fixInstructionProbeRIPCalls(const SInstr
     std::vector<char> finalBytes;
     finalBytes.resize(probe.len);
 
-    for (auto& len : probe.insSizes) {
+    for (auto const& len : probe.insSizes) {
 
         // copy original bytes to our finalBytes
         for (size_t i = 0; i < len; ++i) {

--- a/src/protocols/DRMLease.cpp
+++ b/src/protocols/DRMLease.cpp
@@ -50,12 +50,12 @@ CDRMLeaseResource::CDRMLeaseResource(SP<CWpDrmLeaseV1> resource_, SP<CDRMLeaseRe
 
     lease = aqlease;
 
-    for (auto& m : requested) {
+    for (auto const& m : requested) {
         m->monitor->isBeingLeased = true;
     }
 
     listeners.destroyLease = lease->events.destroy.registerListener([this](std::any d) {
-        for (auto& m : requested) {
+        for (auto const& m : requested) {
             if (m && m->monitor)
                 m->monitor->isBeingLeased = false;
         }

--- a/src/protocols/DataDeviceWlr.cpp
+++ b/src/protocols/DataDeviceWlr.cpp
@@ -291,7 +291,7 @@ void CDataDeviceWLRProtocol::sendSelectionToDevice(SP<CWLRDataDevice> dev, SP<ID
 }
 
 void CDataDeviceWLRProtocol::setSelection(SP<IDataSource> source, bool primary) {
-    for (auto& o : m_vOffers) {
+    for (auto const& o : m_vOffers) {
         if (o->source && o->source->hasDnd())
             continue;
         if (o->primary != primary)
@@ -302,7 +302,7 @@ void CDataDeviceWLRProtocol::setSelection(SP<IDataSource> source, bool primary) 
     if (!source) {
         LOGM(LOG, "resetting {}selection", primary ? "primary " : " ");
 
-        for (auto& d : m_vDevices) {
+        for (auto const& d : m_vDevices) {
             sendSelectionToDevice(d, nullptr, primary);
         }
 
@@ -311,7 +311,7 @@ void CDataDeviceWLRProtocol::setSelection(SP<IDataSource> source, bool primary) 
 
     LOGM(LOG, "New {}selection for data source {:x}", primary ? "primary" : "", (uintptr_t)source.get());
 
-    for (auto& d : m_vDevices) {
+    for (auto const& d : m_vDevices) {
         sendSelectionToDevice(d, source, primary);
     }
 }

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -260,7 +260,7 @@ void CWLSurfaceResource::bfHelper(std::vector<SP<CWLSurfaceResource>> nodes, std
     for (auto& n : nodes) {
         std::erase_if(n->subsurfaces, [](const auto& e) { return e.expired(); });
         // subsurfaces is sorted lowest -> highest
-        for (auto& c : n->subsurfaces) {
+        for (auto const& c : n->subsurfaces) {
             if (c->zIndex >= 0)
                 break;
             if (c->surface.expired())
@@ -274,7 +274,7 @@ void CWLSurfaceResource::bfHelper(std::vector<SP<CWLSurfaceResource>> nodes, std
 
     nodes2.clear();
 
-    for (auto& n : nodes) {
+    for (auto const& n : nodes) {
         Vector2D offset = {};
         if (n->role->role() == SURFACE_ROLE_SUBSURFACE) {
             auto subsurface = ((CSubsurfaceRole*)n->role.get())->subsurface.lock();
@@ -284,8 +284,8 @@ void CWLSurfaceResource::bfHelper(std::vector<SP<CWLSurfaceResource>> nodes, std
         fn(n, offset, data);
     }
 
-    for (auto& n : nodes) {
-        for (auto& c : n->subsurfaces) {
+    for (auto const& n : nodes) {
+        for (auto const& c : n->subsurfaces) {
             if (c->zIndex < 0)
                 continue;
             if (c->surface.expired())

--- a/src/protocols/core/DataDevice.cpp
+++ b/src/protocols/core/DataDevice.cpp
@@ -306,7 +306,7 @@ CWLDataDeviceManagerResource::CWLDataDeviceManagerResource(SP<CWlDataDeviceManag
 
         RESOURCE->self = RESOURCE;
 
-        for (auto& s : sources) {
+        for (auto const& s : sources) {
             if (!s)
                 continue;
             s->device = RESOURCE;
@@ -390,7 +390,7 @@ void CWLDataDeviceProtocol::onDestroyDataSource(WP<CWLDataSourceResource> source
 }
 
 void CWLDataDeviceProtocol::setSelection(SP<IDataSource> source) {
-    for (auto& o : m_vOffers) {
+    for (auto const& o : m_vOffers) {
         if (o->source && o->source->hasDnd())
             continue;
         o->dead = true;
@@ -439,7 +439,7 @@ void CWLDataDeviceProtocol::updateSelection() {
 }
 
 void CWLDataDeviceProtocol::onKeyboardFocus() {
-    for (auto& o : m_vOffers) {
+    for (auto const& o : m_vOffers) {
         o->dead = true;
     }
 
@@ -606,7 +606,7 @@ bool CWLDataDeviceProtocol::wasDragSuccessful() {
     if (!dnd.focusedDevice || !dnd.currentSource)
         return false;
 
-    for (auto& o : m_vOffers) {
+    for (auto const& o : m_vOffers) {
         if (o->dead || !o->source || !o->source->hasDnd())
             continue;
 

--- a/src/protocols/core/Output.cpp
+++ b/src/protocols/core/Output.cpp
@@ -118,7 +118,7 @@ bool CWLOutputProtocol::isDefunct() {
 }
 
 void CWLOutputProtocol::sendDone() {
-    for (auto& r : m_vOutputs) {
+    for (auto const& r : m_vOutputs) {
         r->resource->sendDone();
     }
 }

--- a/src/protocols/core/Seat.cpp
+++ b/src/protocols/core/Seat.cpp
@@ -172,7 +172,7 @@ void CWLPointerResource::sendLeave() {
     if (!PROTO::data->dndActive()) {
         timespec now;
         clock_gettime(CLOCK_MONOTONIC, &now);
-        for (auto& b : pressedButtons) {
+        for (auto const& b : pressedButtons) {
             sendButton(now.tv_sec * 1000 + now.tv_nsec / 1000000, b, WL_POINTER_BUTTON_STATE_RELEASED);
         }
     }

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -690,7 +690,7 @@ bool CHyprOpenGLImpl::passRequiresIntrospection(CMonitor* pMonitor) {
     }
 
     if (*PBLURSPECIAL) {
-        for (auto& ws : g_pCompositor->m_vWorkspaces) {
+        for (auto const& ws : g_pCompositor->m_vWorkspaces) {
             if (!ws->m_bIsSpecialWorkspace || ws->m_iMonitorID != pMonitor->ID)
                 continue;
 
@@ -1936,9 +1936,9 @@ void CHyprOpenGLImpl::preRender(CMonitor* pMonitor) {
         }
     }
 
-    for (auto& m : g_pCompositor->m_vMonitors) {
-        for (auto& lsl : m->m_aLayerSurfaceLayers) {
-            for (auto& ls : lsl) {
+    for (auto const& m : g_pCompositor->m_vMonitors) {
+        for (auto const& lsl : m->m_aLayerSurfaceLayers) {
+            for (auto const& ls : lsl) {
                 if (!ls->layerSurface || ls->xray != 1)
                     continue;
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -331,7 +331,7 @@ bool CHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow) {
     if (g_pCompositor->isWorkspaceVisible(pWindow->m_pWorkspace))
         return true;
 
-    for (auto& m : g_pCompositor->m_vMonitors) {
+    for (auto const& m : g_pCompositor->m_vMonitors) {
         if (PWORKSPACE && PWORKSPACE->m_iMonitorID == m->ID && (PWORKSPACE->m_vRenderOffset.isBeingAnimated() || PWORKSPACE->m_fAlpha.isBeingAnimated()))
             return true;
 
@@ -915,7 +915,7 @@ void CHyprRenderer::renderAllClientsForWorkspace(CMonitor* pMonitor, PHLWORKSPAC
     g_pHyprOpenGL->m_RenderData.damage = preOccludedDamage;
 
     // and then special
-    for (auto& ws : g_pCompositor->m_vWorkspaces) {
+    for (auto const& ws : g_pCompositor->m_vWorkspaces) {
         if (ws->m_iMonitorID == pMonitor->ID && ws->m_fAlpha.value() > 0.f && ws->m_bIsSpecialWorkspace) {
             const auto SPECIALANIMPROGRS = ws->m_vRenderOffset.isBeingAnimated() ? ws->m_vRenderOffset.getCurveValue() : ws->m_fAlpha.getCurveValue();
             const bool ANIMOUT           = !pMonitor->activeSpecialWorkspace;
@@ -935,7 +935,7 @@ void CHyprRenderer::renderAllClientsForWorkspace(CMonitor* pMonitor, PHLWORKSPAC
     }
 
     // special
-    for (auto& ws : g_pCompositor->m_vWorkspaces) {
+    for (auto const& ws : g_pCompositor->m_vWorkspaces) {
         if (ws->m_fAlpha.value() > 0.f && ws->m_bIsSpecialWorkspace) {
             if (ws->m_bHasFullscreenWindow)
                 renderWorkspaceWindowsFullscreen(pMonitor, ws, time);
@@ -1489,7 +1489,7 @@ void CHyprRenderer::renderWorkspace(CMonitor* pMonitor, PHLWORKSPACE pWorkspace,
 }
 
 void CHyprRenderer::sendFrameEventsToWorkspace(CMonitor* pMonitor, PHLWORKSPACE pWorkspace, timespec* now) {
-    for (auto& w : g_pCompositor->m_vWindows) {
+    for (auto const& w : g_pCompositor->m_vWindows) {
         if (w->isHidden() || !w->m_bIsMapped || w->m_bFadingOut || !w->m_pWLSurface->resource())
             continue;
 
@@ -1499,8 +1499,8 @@ void CHyprRenderer::sendFrameEventsToWorkspace(CMonitor* pMonitor, PHLWORKSPACE 
         w->m_pWLSurface->resource()->breadthfirst([now](SP<CWLSurfaceResource> r, const Vector2D& offset, void* d) { r->frame(now); }, nullptr);
     }
 
-    for (auto& lsl : pMonitor->m_aLayerSurfaceLayers) {
-        for (auto& ls : lsl) {
+    for (auto const& lsl : pMonitor->m_aLayerSurfaceLayers) {
+        for (auto const& ls : lsl) {
             if (ls->fadingOut || !ls->surface->resource())
                 continue;
 
@@ -1673,10 +1673,10 @@ void CHyprRenderer::arrangeLayersForMonitor(const MONITORID& monitor) {
 
     CBox usableArea = {PMONITOR->vecPosition.x, PMONITOR->vecPosition.y, PMONITOR->vecSize.x, PMONITOR->vecSize.y};
 
-    for (auto& la : PMONITOR->m_aLayerSurfaceLayers)
+    for (auto const& la : PMONITOR->m_aLayerSurfaceLayers)
         arrangeLayerArray(PMONITOR, la, true, &usableArea);
 
-    for (auto& la : PMONITOR->m_aLayerSurfaceLayers)
+    for (auto const& la : PMONITOR->m_aLayerSurfaceLayers)
         arrangeLayerArray(PMONITOR, la, false, &usableArea);
 
     PMONITOR->vecReservedTopLeft     = Vector2D(usableArea.x, usableArea.y) - PMONITOR->vecPosition;
@@ -1808,7 +1808,7 @@ void CHyprRenderer::damageBox(const int& x, const int& y, const int& w, const in
 }
 
 void CHyprRenderer::damageRegion(const CRegion& rg) {
-    for (auto& RECT : rg.getRects()) {
+    for (auto const& RECT : rg.getRects()) {
         damageBox(RECT.x1, RECT.y1, RECT.x2 - RECT.x1, RECT.y2 - RECT.y1);
     }
 }
@@ -2370,7 +2370,7 @@ std::tuple<float, float, float> CHyprRenderer::getRenderTimes(CMonitor* pMonitor
     float      avgRenderTime = 0;
     float      maxRenderTime = 0;
     float      minRenderTime = 9999;
-    for (auto& rt : POVERLAY->m_dLastRenderTimes) {
+    for (auto const& rt : POVERLAY->m_dLastRenderTimes) {
         if (rt > maxRenderTime)
             maxRenderTime = rt;
         if (rt < minRenderTime)
@@ -2528,12 +2528,12 @@ void CHyprRenderer::recheckSolitaryForMonitor(CMonitor* pMonitor) {
     if (!pMonitor->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY].empty())
         return;
 
-    for (auto& topls : pMonitor->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]) {
+    for (auto const& topls : pMonitor->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]) {
         if (topls->alpha.value() != 0.f)
             return;
     }
 
-    for (auto& w : g_pCompositor->m_vWindows) {
+    for (auto const& w : g_pCompositor->m_vWindows) {
         if (w == PCANDIDATE || (!w->m_bIsMapped && !w->m_bFadingOut) || w->isHidden())
             continue;
 

--- a/src/xwayland/XSurface.cpp
+++ b/src/xwayland/XSurface.cpp
@@ -151,8 +151,8 @@ bool CXWaylandSurface::wantsFocus() {
         HYPRATOMS["_NET_WM_WINDOW_TYPE_UTILITY"],
     };
 
-    for (auto& searched : search) {
-        for (auto& a : atoms) {
+    for (auto const& searched : search) {
+        for (auto const& a : atoms) {
             if (a == searched)
                 return false;
         }

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -24,7 +24,7 @@ static int onX11Event(int fd, uint32_t mask, void* data) {
 }
 
 SP<CXWaylandSurface> CXWM::windowForXID(xcb_window_t wid) {
-    for (auto& s : surfaces) {
+    for (auto const& s : surfaces) {
         if (s->xID == wid)
             return s;
     }
@@ -156,7 +156,7 @@ void CXWM::readProp(SP<CXWaylandSurface> XSURF, uint32_t atom, xcb_get_property_
     std::string propName;
     if (Debug::trace) {
         propName = std::format("{}?", atom);
-        for (auto& ha : HYPRATOMS) {
+        for (auto const& ha : HYPRATOMS) {
             if (ha.second != atom)
                 continue;
 
@@ -285,7 +285,7 @@ void CXWM::handleClientMessage(xcb_client_message_event_t* e) {
         return;
 
     std::string propName = "?";
-    for (auto& ha : HYPRATOMS) {
+    for (auto const& ha : HYPRATOMS) {
         if (ha.second != e->type)
             continue;
 
@@ -317,7 +317,7 @@ void CXWM::handleClientMessage(xcb_client_message_event_t* e) {
 
         Debug::log(LOG, "[xwm] surface {:x} requests serial {:x}", (uintptr_t)XSURF.get(), XSURF->wlSerial);
 
-        for (auto& res : shellResources) {
+        for (auto const& res : shellResources) {
             if (!res)
                 continue;
 
@@ -579,7 +579,7 @@ void CXWM::handleSelectionRequest(xcb_selection_request_event_t* e) {
         atoms.push_back(HYPRATOMS["TIMESTAMP"]);
         atoms.push_back(HYPRATOMS["TARGETS"]);
 
-        for (auto& m : mimes) {
+        for (auto const& m : mimes) {
             atoms.push_back(mimeToAtom(m));
         }
 
@@ -944,7 +944,7 @@ void CXWM::onNewSurface(SP<CWLSurfaceResource> surf) {
 
     const auto WLID = surf->id();
 
-    for (auto& sr : surfaces) {
+    for (auto const& sr : surfaces) {
         if (sr->surface || sr->wlID != WLID)
             continue;
 
@@ -961,7 +961,7 @@ void CXWM::onNewResource(SP<CXWaylandSurfaceResource> resource) {
     std::erase_if(shellResources, [](const auto& e) { return e.expired(); });
     shellResources.push_back(resource);
 
-    for (auto& surf : surfaces) {
+    for (auto const& surf : surfaces) {
         if (surf->resource || surf->wlSerial != resource->serial)
             continue;
 


### PR DESCRIPTION
why not let the compiler optimise things for us at hyprspeeds when we can.

makes most for loops use const where applicable, didnt change any reference/pointer/copy so shouldnt change anything besides the compilers ability to optimize.


