### PR TITLE
fix some minor typos

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1720,7 +1720,7 @@ static bool parseModeLine(const std::string& modeline, drmModeModeInfo& mode) {
         if (it != flagsmap.end())
             mode.flags |= it->second;
         else
-            Debug::log(ERR, "invalid flag {} in modeline", it->first);
+            Debug::log(ERR, "invalid flag {} in modeline", key);
     }
 
     snprintf(mode.name, sizeof(mode.name), "%dx%d@%d", mode.hdisplay, mode.vdisplay, mode.vrefresh / 1000);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2441,7 +2441,7 @@ SDispatchResult CKeybindManager::swapnext(std::string arg) {
     // sometimes we may come back to ourselves.
     if (toSwap == PLASTWINDOW) {
         if (arg == "last" || arg == "l" || arg == "prev" || arg == "p")
-            toSwap = g_pCompositor->getPrevWindowOnWorkspace(PLASTWINDOW), true;
+            toSwap = g_pCompositor->getPrevWindowOnWorkspace(PLASTWINDOW, true);
         else
             toSwap = g_pCompositor->getNextWindowOnWorkspace(PLASTWINDOW, true);
     }


### PR DESCRIPTION
lets not potentially dereference an invalid iterator and seems swapnext getPrevWindowOnWorkspace had an extra errenous ) added.


