### PR TITLE
CI: disable stale workflow on forks

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,22 +7,22 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: '7 */4 * * *'
+    - cron: "7 */4 * * *"
   workflow_dispatch:
 
 jobs:
   stale:
-
+    if: github.repository == 'hyprwm/Hyprland'
     runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v5
-      with:
-        repo-token: ${{ secrets.STALEBOT_PAT }}
-        stale-issue-label: 'stale'
-        stale-pr-label: 'stale'
-        operations-per-run: 40
-        days-before-close: -1
+      - uses: actions/stale@v5
+        with:
+          repo-token: ${{ secrets.STALEBOT_PAT }}
+          stale-issue-label: "stale"
+          stale-pr-label: "stale"
+          operations-per-run: 40
+          days-before-close: -1


### PR DESCRIPTION
The stale workflow will run unconditionally, but will fail on forks due to
`STALEBOT_PAT` not being set.

Trigger the workflow _only_ if we are on the main repo, where we can guarantee
the PAT. Also formats the YML syntax to be slightly more readable.

Suppresses annoying notifications if you have a longstanding fork of Hyprland on
your personal account.

_P.S. Please don't nit the formatting or else I will cry._
