### PR TITLE
Fix NO_XWAYLAND build

### DIFF
--- a/src/xwayland/XWayland.hpp
+++ b/src/xwayland/XWayland.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include "../helpers/signal/Signal.hpp"
 #include "../helpers/memory/Memory.hpp"
+#include "../macros.hpp"
 
 #include "XSurface.hpp"
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This fixes building with NO_XWAYLAND (broken [here](https://github.com/hyprwm/Hyprland/commit/fa022901cf2c9acdae9e9a24a68b9148d44f8627#diff-aac53492fead4834693fc4912b73c739ffc98c6196f97c211e8218195ca6a364) by removing `HYPERATOMS` redefinition).
Related [gentoo bugreport](https://bugs.gentoo.org/935322).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

#### Is it ready for merging, or does it need work?
Ready for merging