### PR TITLE
xwm: read atom name from xcb

### DIFF
--- a/src/xwayland/XWM.hpp
+++ b/src/xwayland/XWM.hpp
@@ -119,6 +119,7 @@ class CXWM {
     std::string mimeFromAtom(xcb_atom_t atom);
     void        setClipboardToWayland(SXSelection& sel);
     void        getTransferData(SXSelection& sel);
+    std::string getAtomName(uint32_t atom);
     void        readProp(SP<CXWaylandSurface> XSURF, uint32_t atom, xcb_get_property_reply_t* reply);
 
     //


### PR DESCRIPTION
expand the debug trace logging by actually reading the atom name from xcb, will also print the proper atom for xcb internal ones and not just the HYPRATOMS ones.

