### PR TITLE
Remove setenv("MOZ_ENABLE_WAYLAND", 1, 1)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,7 +35,6 @@ int main(int argc, char** argv) {
     setenv("HYPRLAND_CMD", cmd.c_str(), 1);
     setenv("XDG_BACKEND", "wayland", 1);
     setenv("_JAVA_AWT_WM_NONREPARENTING", "1", 1);
-    setenv("MOZ_ENABLE_WAYLAND", "1", 1);
 
     // parse some args
     std::string              configPath;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Firefox don't need this now from version 121, according to arch wiki. 

Keep it will prevent from user overriding MOZ_ENABLE_WAYLAND.
Like: "MOZ_ENABLE_WAYLAND=0 firefox" won't really change to 0
It still being forced to 1.

Which in some case, might lead to confusion for user who wish to run Firefox
under XWayland.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Not really sure if only Firefox depends on this env.
And I am not really sure if setenv() is intended to stop anything from changing it.

#### Is it ready for merging, or does it need work?

Yes, or just move this to default hyprland.conf.
