### PR TITLE
Improve output configuration via wlr-output-configuration

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -7,6 +7,7 @@
 #include "helpers/varlist/VarList.hpp"
 #include "../protocols/LayerShell.hpp"
 #include "../xwayland/XWayland.hpp"
+#include "../protocols/OutputManagement.hpp"
 
 #include <cstddef>
 #include <cstdint>
@@ -1079,28 +1080,66 @@ std::string CConfigManager::getDeviceString(const std::string& dev, const std::s
     return VAL;
 }
 
-SMonitorRule CConfigManager::getMonitorRuleFor(const CMonitor& PMONITOR) {
+SMonitorRule CConfigManager::getMonitorRuleFor(const SP<CMonitor> PMONITOR) {
+    auto applyWlrOutputConfig = [PMONITOR](SMonitorRule rule) -> SMonitorRule {
+        const auto CONFIG = PROTO::outputManagement->getOutputStateFor(PMONITOR);
+
+        if (!CONFIG)
+            return rule;
+
+        Debug::log(LOG, "CConfigManager::getMonitorRuleFor: found a wlr_output_manager override for {}", PMONITOR->szName);
+
+        if ((CONFIG->committedProperties & OUTPUT_HEAD_COMMITTED_MODE) || (CONFIG->committedProperties & OUTPUT_HEAD_COMMITTED_CUSTOM_MODE)) {
+            Debug::log(LOG, " > overriding mode: {:.0f}x{:.0f}@{:.2f}Hz -> {:.0f}x{:.0f}@{:.2f}Hz", rule.resolution.x, rule.resolution.y, rule.refreshRate, CONFIG->resolution.x,
+                       CONFIG->resolution.y, CONFIG->refresh / 1000.F);
+            rule.resolution  = CONFIG->resolution;
+            rule.refreshRate = CONFIG->refresh / 1000.F;
+        }
+
+        if (CONFIG->committedProperties & OUTPUT_HEAD_COMMITTED_POSITION) {
+            Debug::log(LOG, " > overriding offset: {:.0f}, {:.0f} -> {:.0f}, {:.0f}", rule.offset.x, rule.offset.y, CONFIG->position.x, CONFIG->position.y);
+            rule.offset = CONFIG->position;
+        }
+
+        if (CONFIG->committedProperties & OUTPUT_HEAD_COMMITTED_TRANSFORM) {
+            Debug::log(LOG, " > overriding transform: {} -> {}", (uint8_t)rule.transform, (uint8_t)CONFIG->transform);
+            rule.transform = CONFIG->transform;
+        }
+
+        if (CONFIG->committedProperties & OUTPUT_HEAD_COMMITTED_SCALE) {
+            Debug::log(LOG, " > overriding scale: {} -> {}", (uint8_t)rule.scale, (uint8_t)CONFIG->scale);
+            rule.scale = CONFIG->scale;
+        }
+
+        if (CONFIG->committedProperties & OUTPUT_HEAD_COMMITTED_ADAPTIVE_SYNC) {
+            Debug::log(LOG, " > overriding vrr: {} -> {}", rule.vrr.value_or(0), CONFIG->adaptiveSync);
+            rule.vrr = (int)CONFIG->adaptiveSync;
+        }
+
+        return rule;
+    };
+
     for (auto const& r : m_dMonitorRules | std::views::reverse) {
-        if (PMONITOR.matchesStaticSelector(r.name)) {
-            return r;
+        if (PMONITOR->matchesStaticSelector(r.name)) {
+            return applyWlrOutputConfig(r);
         }
     }
 
-    Debug::log(WARN, "No rule found for {}, trying to use the first.", PMONITOR.szName);
+    Debug::log(WARN, "No rule found for {}, trying to use the first.", PMONITOR->szName);
 
     for (auto const& r : m_dMonitorRules) {
         if (r.name.empty()) {
-            return r;
+            return applyWlrOutputConfig(r);
         }
     }
 
     Debug::log(WARN, "No rules configured. Using the default hardcoded one.");
 
-    return SMonitorRule{.autoDir    = eAutoDirs::DIR_AUTO_RIGHT,
-                        .name       = "",
-                        .resolution = Vector2D(0, 0),
-                        .offset     = Vector2D(-INT32_MAX, -INT32_MAX),
-                        .scale      = -1}; // 0, 0 is preferred and -1, -1 is auto
+    return applyWlrOutputConfig(SMonitorRule{.autoDir    = eAutoDirs::DIR_AUTO_RIGHT,
+                                             .name       = "",
+                                             .resolution = Vector2D(0, 0),
+                                             .offset     = Vector2D(-INT32_MAX, -INT32_MAX),
+                                             .scale      = -1}); // 0, 0 is preferred and -1, -1 is auto
 }
 
 SWorkspaceRule CConfigManager::getWorkspaceRuleFor(PHLWORKSPACE pWorkspace) {
@@ -1459,7 +1498,7 @@ void CConfigManager::performMonitorReload() {
         if (!m->output || m->isUnsafeFallback)
             continue;
 
-        auto rule = getMonitorRuleFor(*m);
+        auto rule = getMonitorRuleFor(m);
 
         if (!g_pHyprRenderer->applyMonitorRule(m.get(), &rule)) {
             overAgain = true;
@@ -1516,7 +1555,7 @@ void CConfigManager::ensureMonitorStatus() {
         if (!rm->output || rm->isUnsafeFallback)
             continue;
 
-        auto rule = getMonitorRuleFor(*rm);
+        auto rule = getMonitorRuleFor(rm);
 
         if (rule.disabled == rm->m_bEnabled)
             g_pHyprRenderer->applyMonitorRule(rm.get(), &rule);

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1089,6 +1089,9 @@ SMonitorRule CConfigManager::getMonitorRuleFor(const SP<CMonitor> PMONITOR) {
 
         Debug::log(LOG, "CConfigManager::getMonitorRuleFor: found a wlr_output_manager override for {}", PMONITOR->szName);
 
+        Debug::log(LOG, " > overriding enabled: {} -> {}", !rule.disabled, !CONFIG->enabled);
+        rule.disabled = !CONFIG->enabled;
+
         if ((CONFIG->committedProperties & OUTPUT_HEAD_COMMITTED_MODE) || (CONFIG->committedProperties & OUTPUT_HEAD_COMMITTED_CUSTOM_MODE)) {
             Debug::log(LOG, " > overriding mode: {:.0f}x{:.0f}@{:.2f}Hz -> {:.0f}x{:.0f}@{:.2f}Hz", rule.resolution.x, rule.resolution.y, rule.refreshRate, CONFIG->resolution.x,
                        CONFIG->resolution.y, CONFIG->refresh / 1000.F);

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -169,7 +169,7 @@ class CConfigManager {
     static std::string                                              getMainConfigPath();
     const std::string                                               getConfigString();
 
-    SMonitorRule                                                    getMonitorRuleFor(const CMonitor&);
+    SMonitorRule                                                    getMonitorRuleFor(const SP<CMonitor>);
     SWorkspaceRule                                                  getWorkspaceRuleFor(PHLWORKSPACE workspace);
     std::string                                                     getDefaultWorkspaceFor(const std::string&);
 

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -114,7 +114,7 @@ void CMonitor::onConnect(bool noRule) {
         createdByUser = true; // should be true. WL and Headless backends should be addable / removable
 
     // get monitor rule that matches
-    SMonitorRule monitorRule = g_pConfigManager->getMonitorRuleFor(*this);
+    SMonitorRule monitorRule = g_pConfigManager->getMonitorRuleFor(self.lock());
 
     // if it's disabled, disable and ignore
     if (monitorRule.disabled) {
@@ -489,7 +489,7 @@ void CMonitor::setMirror(const std::string& mirrorOf) {
         pMirrorOf = nullptr;
 
         // set rule
-        const auto RULE = g_pConfigManager->getMonitorRuleFor(*this);
+        const auto RULE = g_pConfigManager->getMonitorRuleFor(self.lock());
 
         vecPosition = RULE.offset;
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1943,7 +1943,7 @@ SDispatchResult CKeybindManager::forceRendererReload(std::string args) {
         if (!m->output)
             continue;
 
-        auto rule = g_pConfigManager->getMonitorRuleFor(*m);
+        auto rule = g_pConfigManager->getMonitorRuleFor(m);
         if (!g_pHyprRenderer->applyMonitorRule(m.get(), &rule, true)) {
             overAgain = true;
             break;


### PR DESCRIPTION
Improves the handling of wlr-output-configuration (e.g. wdisplays, kanshi)

Notable changes:
 - Output configuration will be valid for as long as the client has the global bound (so likely for as long as it's running)
 - Wlr output configuration will no longer be a rule, it will be treated as a hard override of whatever the user sets in the cfg (for as long as point 1)
 - Older clients have precedence (but who runs 2 monitor managers?)
 
Ref #7059