### PR TITLE
xwayland: update overrideRedirect on map and configure

### DIFF
--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -81,6 +81,7 @@ void CXWM::handleConfigureNotify(xcb_configure_notify_event_t* e) {
         return;
 
     XSURF->geometry = {e->x, e->y, e->width, e->height};
+    updateOverrideRedirect(XSURF, e->override_redirect);
     XSURF->events.setGeometry.emit();
 }
 
@@ -115,7 +116,12 @@ void CXWM::handleMapRequest(xcb_map_request_event_t* e) {
 void CXWM::handleMapNotify(xcb_map_notify_event_t* e) {
     const auto XSURF = windowForXID(e->window);
 
-    if (!XSURF || XSURF->overrideRedirect)
+    if (!XSURF)
+        return;
+
+    updateOverrideRedirect(XSURF, e->override_redirect);
+
+    if (XSURF->overrideRedirect)
         return;
 
     XSURF->setWithdrawn(false);
@@ -1042,6 +1048,13 @@ void CXWM::updateClientList() {
 
 bool CXWM::isWMWindow(xcb_window_t w) {
     return w == wmWindow || w == clipboard.window;
+}
+
+void CXWM::updateOverrideRedirect(SP<CXWaylandSurface> surf, bool overrideRedirect) {
+    if (!surf || surf->overrideRedirect == overrideRedirect)
+        return;
+
+    surf->overrideRedirect = overrideRedirect;
 }
 
 void CXWM::initSelection() {

--- a/src/xwayland/XWM.hpp
+++ b/src/xwayland/XWM.hpp
@@ -82,6 +82,7 @@ class CXWM {
     void                 focusWindow(SP<CXWaylandSurface> surf);
     void                 activateSurface(SP<CXWaylandSurface> surf, bool activate);
     bool                 isWMWindow(xcb_window_t w);
+    void                 updateOverrideRedirect(SP<CXWaylandSurface> surf, bool overrideRedirect);
 
     void                 sendWMMessage(SP<CXWaylandSurface> surf, xcb_client_message_data_t* data, uint32_t mask);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes surfaces that are originally starting with `overrideRedirect = true` not being updated on configure and map notifies.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I kept the update logic in the function in case the other pieces from wlroots needs to be added back in, but I think these already get handled? Might want to double check that.

#### Is it ready for merging, or does it need work?
Works on my end for account creation typing, but want to confirm #7507 works as I don't actually play the game anymore.

