### PR TITLE
keybinds: release mods after sendshortcut

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2349,6 +2349,8 @@ SDispatchResult CKeybindManager::sendshortcut(std::string args) {
         }
     }
 
+    g_pSeatManager->sendKeyboardMods(0, 0, 0, 0);
+
     if (!PWINDOW)
         return {};
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

`sendshortcut` presses mods, presses keys, releases keys, but doesnt release mods

this pr releases mods

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I checked this fixes my use case (three finger swipe -> alt+left/right arrow using hyprgrass) but idk if this is gonna break anything else

#### Is it ready for merging, or does it need work?

See above, someone should look if this is gonna break something else