### PR TITLE
[Tablet] Allow mapping to entire monitor layout

### DIFF
--- a/src/managers/PointerManager.hpp
+++ b/src/managers/PointerManager.hpp
@@ -82,7 +82,9 @@ class CPointerManager {
     // returns the thing in logical coordinates of the monitor
     CBox getCursorBoxLogicalForMonitor(PHLMONITOR pMonitor);
     // returns the thing in global coords
-    CBox         getCursorBoxGlobal();
+    CBox getCursorBoxGlobal();
+    // returns the area covered by all monitors
+    CBox         getEntireMappableArea();
 
     Vector2D     transformedHotspot(PHLMONITOR pMonitor);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes #6023. 
Moves monitor layout entire area search to a function and enables tablets to map to the entire monitor layout. This allows OpenTabletDriver's monitor mapping settings to work on artist mode.

Optionally enabled via `input:tablet:output` = `entire`

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Tested working with OTD on artist mode. Does not work with OTD absolute mode (virtual device is listed alongside normal mice in `hyprctl devices`). Related: #6889 

#### Is it ready for merging, or does it need work?
Ready.

