### PR TITLE
CI: clarify Nix CI jobs; disable on forked repositories

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,3 +1,5 @@
+name: Nix (Build)
+
 on:
   workflow_call:
     secrets:
@@ -25,6 +27,6 @@ jobs:
       - uses: cachix/cachix-action@v15
         with:
           name: hyprland
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
       - run: nix build '.?submodules=1#${{ matrix.package }}' -L --extra-substituters "https://hyprland.cachix.org"

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -1,10 +1,10 @@
-name: Nix
+name: Nix (CI)
 
 on: [push, pull_request, workflow_dispatch]
 
 jobs:
   update-inputs:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/nix-update-inputs.yml
     secrets: inherit
 

--- a/.github/workflows/nix-update-inputs.yml
+++ b/.github/workflows/nix-update-inputs.yml
@@ -1,4 +1,4 @@
-name: Nix
+name: Nix (Update Inputs)
 
 on:
   workflow_call:
@@ -8,6 +8,7 @@ on:
 
 jobs:
   update:
+    if: github.repository == 'hyprwm/Hyprland'
     name: inputs
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Followup for #7535: clarifies Nix CI tasks & properly suppresses Nix CI on forks. Should silence notifications for workflows that fail due to missing token. 

My formatter added a few additional syntax changes, I can probably revert those but they are harmless.

---

CC @fufexan in case this breaks a very obscure piece of infrastructure

