### PR TITLE
Fixed selection mismatch during 'wlr reset primary selection'.

### DIFF
--- a/src/protocols/DataDeviceWlr.cpp
+++ b/src/protocols/DataDeviceWlr.cpp
@@ -133,7 +133,7 @@ CWLRDataDevice::CWLRDataDevice(SP<CZwlrDataControlDeviceV1> resource_) : resourc
         auto source = sourceR ? CWLRDataSource::fromResource(sourceR) : CSharedPointer<CWLRDataSource>{};
         if (!source) {
             LOGM(LOG, "wlr reset primary selection received");
-            g_pSeatManager->setCurrentSelection(nullptr);
+            g_pSeatManager->setCurrentPrimarySelection(nullptr);
             return;
         }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes a copy-paste error from the regular selection handler. It should call setCurrentPrimarySelection(), but it's setCurrentSelection() in the nil branch. This causes wl-clipboard to be unable to clear primary selection.

View this issue for more context:
https://github.com/bugaevc/wl-clipboard/issues/235
