### PR TITLE
textinput: don't deactivate ime if another ti is focused

### DIFF
--- a/src/managers/input/TextInput.cpp
+++ b/src/managers/input/TextInput.cpp
@@ -23,8 +23,9 @@ void CTextInput::initCallbacks() {
         listeners.disable = INPUT->events.disable.registerListener([this](std::any p) { onDisabled(); });
         listeners.commit  = INPUT->events.onCommit.registerListener([this](std::any p) { onCommit(); });
         listeners.destroy = INPUT->events.destroy.registerListener([this](std::any p) {
-            g_pInputManager->m_sIMERelay.deactivateIME(this);
             g_pInputManager->m_sIMERelay.removeTextInput(this);
+            if (!g_pInputManager->m_sIMERelay.getFocusedTextInput())
+                g_pInputManager->m_sIMERelay.deactivateIME(this);
         });
     } else {
         const auto INPUT = pV1Input.lock();
@@ -38,8 +39,9 @@ void CTextInput::initCallbacks() {
         listeners.destroy = INPUT->events.destroy.registerListener([this](std::any p) {
             listeners.surfaceUnmap.reset();
             listeners.surfaceDestroy.reset();
-            g_pInputManager->m_sIMERelay.deactivateIME(this);
             g_pInputManager->m_sIMERelay.removeTextInput(this);
+            if (!g_pInputManager->m_sIMERelay.getFocusedTextInput())
+                g_pInputManager->m_sIMERelay.deactivateIME(this);
         });
     }
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fix ime getting deactivated when closing a window on certain applications.

Some applications like alacritty, doesn't explicitly `destroy` text input object when closing the application.
This results in ime getting deactivated when it's already focused on another window, due to the destory event getting emitted after the keyboard focus event.

This is a follow up MR of #7614. Because the original fix (#5455) was broken, I've split it into a separate MR.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nope.

#### Is it ready for merging, or does it need work?
Ready for merging.

