### PR TITLE
CMake: drop unused dependencies (a la Meson)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,8 +99,6 @@ pkg_check_modules(
   xkbcommon
   uuid
   wayland-server
-  wayland-client
-  wayland-cursor
   wayland-protocols
   cairo
   pango
@@ -109,11 +107,6 @@ pkg_check_modules(
   xcursor
   libdrm
   libinput
-  hwdata
-  libseat
-  libdisplay-info
-  libliftoff
-  libudev
   gbm
   gio-2.0
   hyprlang>=0.3.2
@@ -200,14 +193,11 @@ else()
     REQUIRED
     IMPORTED_TARGET
     xcb
-    xwayland
-    xcb-util
     xcb-render
     xcb-xfixes
     xcb-icccm
     xcb-composite
     xcb-res
-    xcb-ewmh
     xcb-errors)
   target_link_libraries(Hyprland PkgConfig::xdeps)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,7 +266,7 @@ function(protocolWayland)
 endfunction()
 
 target_link_libraries(Hyprland OpenGL::EGL OpenGL::GL Threads::Threads
-                      libudis86 uuid)
+                      libudis86)
 
 protocolnew("subprojects/hyprland-protocols/protocols"
             "hyprland-global-shortcuts-v1" true)

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -9,33 +9,22 @@
   aquamarine,
   binutils,
   cairo,
-  expat,
-  fribidi,
   git,
-  hwdata,
   hyprcursor,
   hyprlang,
   hyprutils,
   hyprwayland-scanner,
   jq,
   libGL,
-  libdatrie,
-  libdisplay-info,
   libdrm,
   libexecinfo,
   libinput,
-  libliftoff,
-  libselinux,
-  libsepol,
-  libthai,
-  libuuid,
   libxkbcommon,
+  libuuid,
   mesa,
   pango,
   pciutils,
-  pcre2,
   python3,
-  seatd,
   systemd,
   tomlplusplus,
   wayland,
@@ -114,29 +103,25 @@ assert lib.assertMsg (!hidpiXWayland) "The option `hidpiXWayland` has been remov
       [
         aquamarine
         cairo
-        expat
-        fribidi
+        # expat
+        # fribidi
         git
-        hwdata
         hyprcursor
         hyprlang
         hyprutils
-        libdatrie
-        libdisplay-info
+        # libdatrie
         libdrm
         libGL
         libinput
-        libliftoff
-        libselinux
-        libsepol
-        libthai
+        # libselinux
+        # libsepol
+        # libthai
         libuuid
         libxkbcommon
         mesa
         pango
         pciutils
-        pcre2
-        seatd
+        # pcre2
         tomlplusplus
         wayland
         wayland-protocols
@@ -146,7 +131,6 @@ assert lib.assertMsg (!hidpiXWayland) "The option `hidpiXWayland` has been remov
       (lib.optionals enableXWayland [
         xorg.libxcb
         xorg.libXdmcp
-        xorg.xcbutil
         xorg.xcbutilerrors
         xorg.xcbutilrenderutil
         xorg.xcbutilwm


### PR DESCRIPTION
Parity for [downstream switch](https://github.com/freebsd/freebsd-ports/commit/5fed0aee8298) ([build log](https://github.com/user-attachments/files/16838927/hyprland-0.42.0_2.log)).