### PR TITLE
config: add option to enable/disable xwayland

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -615,7 +615,7 @@ void CCompositor::initManagers(eManagersInitStage stage) {
             g_pCursorManager = std::make_unique<CCursorManager>();
 
             Debug::log(LOG, "Starting XWayland");
-            g_pXWayland = std::make_unique<CXWayland>();
+            g_pXWayland = std::make_unique<CXWayland>(g_pCompositor->m_bEnableXwayland);
         } break;
         default: UNREACHABLE();
     }

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -92,6 +92,7 @@ class CCompositor {
     CMonitor*                                  m_pUnsafeOutput   = nullptr; // fallback output for the unsafe state
     bool                                       m_bIsShuttingDown = false;
     bool                                       m_bDesktopEnvSet  = false;
+    bool                                       m_bEnableXwayland = true;
 
     // ------------------------------------------------- //
 

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1117,7 +1117,7 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
 
     SConfigOptionDescription{
         .value       = "xwayland:enabled",
-        .description = "enables xwayland applications to exist",
+        .description = "allow running applications using X11",
         .type        = CONFIG_OPTION_BOOL,
         .data        = SConfigOptionDescription::SBoolData{true},
     },

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1116,6 +1116,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
      */
 
     SConfigOptionDescription{
+        .value       = "xwayland:enabled",
+        .description = "enables xwayland applications to exist",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{true},
+    },
+    SConfigOptionDescription{
         .value       = "xwayland:use_nearest_neighbor",
         .description = "uses the nearest neighbor filtering for xwayland apps, making them pixelated rather than blurry",
         .type        = CONFIG_OPTION_BOOL,

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -874,7 +874,7 @@ void CConfigManager::postConfigReload(const Hyprlang::CParseResult& result) {
             } else {
                 Debug::log(LOG, "xwayland has been disabled, cleaning up...");
                 for (auto& w : g_pCompositor->m_vWindows) {
-                    if (!w->m_bIsX11)
+                    if (w->m_pXDGSurface || !w->m_bIsX11)
                         continue;
                     g_pCompositor->closeWindow(w);
                 }

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -865,14 +865,18 @@ void CConfigManager::postConfigReload(const Hyprlang::CParseResult& result) {
 #ifndef NO_XWAYLAND
     const auto PENABLEXWAYLAND = std::any_cast<Hyprlang::INT>(m_pConfig->getConfigValue("xwayland:enabled"));
     // enable/disable xwayland usage
-    // TODO: Clean up xwayland when changing to false
     if (!isFirstLaunch) {
         bool prevEnabledXwayland = g_pCompositor->m_bEnableXwayland;
         if (PENABLEXWAYLAND != prevEnabledXwayland) {
             if (PENABLEXWAYLAND)
                 Debug::log(LOG, "xwayland has been enabled");
-            else
-                Debug::log(LOG, "xwayland has been disabled");
+            else {
+                Debug::log(LOG, "xwayland has been disabled, cleaning up...");
+                for (const auto& w : g_pCompositor->m_vWindows) {
+                    if (w->m_bIsX11)
+                        g_pCompositor->closeWindow(w);
+                }
+            }
             g_pCompositor->m_bEnableXwayland = PENABLEXWAYLAND;
             g_pXWayland->pServer->setDisplayEnv();
         }

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -871,7 +871,6 @@ void CConfigManager::postConfigReload(const Hyprlang::CParseResult& result) {
             g_pCompositor->m_bEnableXwayland = PENABLEXWAYLAND;
             if (PENABLEXWAYLAND) {
                 Debug::log(LOG, "xwayland has been enabled");
-                g_pXWayland = std::make_unique<CXWayland>();
             } else {
                 Debug::log(LOG, "xwayland has been disabled, cleaning up...");
                 for (auto& w : g_pCompositor->m_vWindows) {
@@ -879,10 +878,8 @@ void CConfigManager::postConfigReload(const Hyprlang::CParseResult& result) {
                         continue;
                     g_pCompositor->closeWindow(w);
                 }
-                g_pXWayland->pServer = std::make_unique<CXWaylandServer>();
-                g_pXWayland->pWM     = std::make_unique<CXWM>();
-                g_pXWayland->pServer->setDisplayEnv();
             }
+            g_pXWayland = std::make_unique<CXWayland>(g_pCompositor->m_bEnableXwayland);
         }
     } else
         g_pCompositor->m_bEnableXwayland = PENABLEXWAYLAND;

--- a/src/xwayland/Server.cpp
+++ b/src/xwayland/Server.cpp
@@ -288,13 +288,20 @@ bool CXWaylandServer::create() {
     if (!tryOpenSockets())
         return false;
 
-    setenv("DISPLAY", displayName.c_str(), true);
+    setDisplayEnv();
 
     // TODO: lazy mode
 
     idleSource = wl_event_loop_add_idle(g_pCompositor->m_sWLEventLoop, ::startServer, nullptr);
 
     return true;
+}
+
+void CXWaylandServer::setDisplayEnv(void) {
+    if (g_pCompositor->m_bEnableXwayland)
+        setenv("DISPLAY", displayName.c_str(), true);
+    else 
+        unsetenv("DISPLAY");
 }
 
 void CXWaylandServer::runXWayland(int notifyFD) {

--- a/src/xwayland/Server.cpp
+++ b/src/xwayland/Server.cpp
@@ -297,7 +297,7 @@ bool CXWaylandServer::create() {
     return true;
 }
 
-void CXWaylandServer::setDisplayEnv(void) {
+void CXWaylandServer::setDisplayEnv() {
     if (g_pCompositor->m_bEnableXwayland)
         setenv("DISPLAY", displayName.c_str(), true);
     else
@@ -439,7 +439,8 @@ int CXWaylandServer::ready(int fd, uint32_t mask) {
     pipeSource = nullptr;
 
     // start the wm
-    g_pXWayland->pWM = std::make_unique<CXWM>();
+    if (!g_pXWayland->pWM)
+        g_pXWayland->pWM = std::make_unique<CXWM>();
 
     g_pCursorManager->setXWaylandCursor();
 

--- a/src/xwayland/Server.cpp
+++ b/src/xwayland/Server.cpp
@@ -300,7 +300,7 @@ bool CXWaylandServer::create() {
 void CXWaylandServer::setDisplayEnv(void) {
     if (g_pCompositor->m_bEnableXwayland)
         setenv("DISPLAY", displayName.c_str(), true);
-    else 
+    else
         unsetenv("DISPLAY");
 }
 

--- a/src/xwayland/Server.cpp
+++ b/src/xwayland/Server.cpp
@@ -288,20 +288,13 @@ bool CXWaylandServer::create() {
     if (!tryOpenSockets())
         return false;
 
-    setDisplayEnv();
+    setenv("DISPLAY", displayName.c_str(), true);
 
     // TODO: lazy mode
 
     idleSource = wl_event_loop_add_idle(g_pCompositor->m_sWLEventLoop, ::startServer, nullptr);
 
     return true;
-}
-
-void CXWaylandServer::setDisplayEnv() {
-    if (g_pCompositor->m_bEnableXwayland)
-        setenv("DISPLAY", displayName.c_str(), true);
-    else
-        unsetenv("DISPLAY");
 }
 
 void CXWaylandServer::runXWayland(int notifyFD) {

--- a/src/xwayland/Server.hpp
+++ b/src/xwayland/Server.hpp
@@ -15,8 +15,6 @@ class CXWaylandServer {
     // create the server.
     bool create();
 
-    void setDisplayEnv(void);
-
     // starts the server, meant to be called by CXWaylandServer.
     bool start();
 

--- a/src/xwayland/Server.hpp
+++ b/src/xwayland/Server.hpp
@@ -15,6 +15,8 @@ class CXWaylandServer {
     // create the server.
     bool create();
 
+    void setDisplayEnv(void);
+
     // starts the server, meant to be called by CXWaylandServer.
     bool start();
 

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -890,6 +890,9 @@ CXWM::~CXWM() {
 
     if (eventSource)
         wl_event_source_remove(eventSource);
+
+    for (auto const& sr : surfaces)
+        sr->events.destroy.emit();
 }
 
 void CXWM::setActiveWindow(xcb_window_t window) {

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -891,8 +891,9 @@ CXWM::~CXWM() {
     if (eventSource)
         wl_event_source_remove(eventSource);
 
-    for (auto const& sr : surfaces)
+    for (auto const& sr : surfaces) {
         sr->events.destroy.emit();
+    }
 }
 
 void CXWM::setActiveWindow(xcb_window_t window) {

--- a/src/xwayland/XWayland.cpp
+++ b/src/xwayland/XWayland.cpp
@@ -7,6 +7,11 @@ CXWayland::CXWayland() {
 
     pServer = std::make_unique<CXWaylandServer>();
 
+    if (!g_pCompositor->m_bEnableXwayland) {
+        pServer->setDisplayEnv();
+        return;
+    }
+
     if (!pServer->create()) {
         Debug::log(ERR, "XWayland failed to start: it will not work.");
         return;

--- a/src/xwayland/XWayland.cpp
+++ b/src/xwayland/XWayland.cpp
@@ -1,14 +1,14 @@
 #include "XWayland.hpp"
 #include "../debug/Log.hpp"
 
-CXWayland::CXWayland() {
+CXWayland::CXWayland(const bool enabled) {
 #ifndef NO_XWAYLAND
     Debug::log(LOG, "Starting up the XWayland server");
 
     pServer = std::make_unique<CXWaylandServer>();
 
-    if (!g_pCompositor->m_bEnableXwayland) {
-        pServer->setDisplayEnv();
+    if (!enabled) {
+        unsetenv("DISPLAY");
         return;
     }
 

--- a/src/xwayland/XWayland.hpp
+++ b/src/xwayland/XWayland.hpp
@@ -17,7 +17,7 @@ class CXWM;
 
 class CXWayland {
   public:
-    CXWayland();
+    CXWayland(const bool enabled);
 
 #ifndef NO_XWAYLAND
     std::unique_ptr<CXWaylandServer> pServer;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Allows enabling and disabling XWayland during runtime. #3371 appears to be stale and not being worked on.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
1. Disables "DISPLAY" env variable to prevent X11 launches. Due to this, a pop up will occur notifying of this. Is this to be left alone or is there a better way of informing the user that XWayland is not enabled?
2. While it closes the windows, applications like Steam are still running in the background with a tray icon. Is it possible to close these or just ignore them?

#### Is it ready for merging, or does it need work?
Current state of commit works, but see above for things I would like to address first. Closes #7607

