### PR TITLE
sessionLock: ensure sls focus in some edge cases

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1117,7 +1117,7 @@ void CCompositor::focusSurface(SP<CWLSurfaceResource> pSurface, PHLWINDOW pWindo
     if (g_pSeatManager->state.keyboardFocus == pSurface || (pWindowOwner && g_pSeatManager->state.keyboardFocus == pWindowOwner->m_pWLSurface->resource()))
         return; // Don't focus when already focused on this.
 
-    if (g_pSessionLockManager->isSessionLocked() && !g_pSessionLockManager->isSurfaceSessionLock(pSurface))
+    if (g_pSessionLockManager->isSessionLocked() && pSurface && !g_pSessionLockManager->isSurfaceSessionLock(pSurface))
         return;
 
     if (g_pSeatManager->seatGrab && !g_pSeatManager->seatGrab->accepts(pSurface)) {

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -30,6 +30,9 @@ SSessionLockSurface::SSessionLockSurface(SP<CSessionLockSurface> surface_) : sur
     listeners.commit = surface_->events.commit.registerListener([this](std::any data) {
         const auto PMONITOR = g_pCompositor->getMonitorFromID(iMonitorID);
 
+        if (mapped && pWlrSurface != g_pCompositor->m_pLastFocus)
+            g_pInputManager->simulateMouseMovement();
+
         if (PMONITOR)
             g_pHyprRenderer->damageMonitor(PMONITOR);
     });

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -257,10 +257,10 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
 
     g_pLayoutManager->getCurrentLayout()->onMouseMove(getMouseCoordsInternal());
 
-    if (PMONITOR && PMONITOR != g_pCompositor->m_pLastMonitor.get() && (*PMOUSEFOCUSMON || refocus) && m_pForcedFocus.expired())
+    if (PMONITOR != g_pCompositor->m_pLastMonitor.get() && (*PMOUSEFOCUSMON || refocus) && m_pForcedFocus.expired())
         g_pCompositor->setActiveMonitor(PMONITOR);
 
-    if (PMONITOR && g_pSessionLockManager->isSessionLocked()) {
+    if (g_pSessionLockManager->isSessionLocked()) {
         const auto PSESSIONLOCKSURFACE = g_pSessionLockManager->getSessionLockSurfaceForMonitor(PMONITOR->ID);
         surfacePos                     = PMONITOR->vecPosition;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes https://github.com/hyprwm/hyprlock/issues/460 
Fixes https://github.com/hyprwm/Hyprland/issues/7391

Similar bad behaviour is easily reproduced with "sleep 5 && hyprlock" followed by a switch to another tty. When switching back, hyprlock has no focus and mouse needs to be moved to be able to type.

I think this can happen in some hypridle situations as well.

I also thought it would be a good idea to make the code path in `mouseMoveUnified` a bit more straight forward when the session is locked. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Please double check the reordering in `mouseMoveUnified`.

#### Is it ready for merging, or does it need work?

Ready.


