### PR TITLE
input: don't emit idle activity when calling simulateMouseMovement

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -111,7 +111,7 @@ void CInputManager::simulateMouseMovement() {
     timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);
     m_vLastCursorPosFloored = m_vLastCursorPosFloored - Vector2D(1, 1); // hack: force the mouseMoveUnified to report without making this a refocus.
-    mouseMoveUnified(now.tv_sec * 1000 + now.tv_nsec / 10000000);
+    mouseMoveUnified(now.tv_sec * 1000 + now.tv_nsec / 10000000, false, true);
 }
 
 void CInputManager::sendMotionEventsToFocused() {
@@ -132,7 +132,7 @@ void CInputManager::sendMotionEventsToFocused() {
     g_pSeatManager->setPointerFocus(g_pCompositor->m_pLastFocus.lock(), LOCAL);
 }
 
-void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
+void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool silent) {
     static auto PFOLLOWMOUSE      = CConfigValue<Hyprlang::INT>("input:follow_mouse");
     static auto PMOUSEREFOCUS     = CConfigValue<Hyprlang::INT>("input:mouse_refocus");
     static auto PMOUSEDPMS        = CConfigValue<Hyprlang::INT>("misc:mouse_move_enables_dpms");
@@ -171,7 +171,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
 
     EMIT_HOOK_EVENT_CANCELLABLE("mouseMove", MOUSECOORDSFLOORED);
 
-    if (time)
+    if (time && !silent)
         PROTO::idle->onActivity();
 
     m_vLastCursorPosFloored = MOUSECOORDSFLOORED;

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -237,7 +237,7 @@ class CInputManager {
 
     uint32_t           m_uiCapabilities = 0;
 
-    void               mouseMoveUnified(uint32_t, bool refocus = false);
+    void               mouseMoveUnified(uint32_t, bool refocus = false, bool silent = false);
 
     SP<CTabletTool>    ensureTabletToolPresent(SP<Aquamarine::ITabletTool>);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes https://github.com/hyprwm/hyprlock/issues/430

Now `simulateMouseMovement` does not lead to idle activity any more.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Idk if there are cases where `simulateMouseMovement` should post idle activity but I don't think so.

#### Is it ready for merging, or does it need work?

Ready.


