### PR TITLE
config: Add a variable to prevent groups from merging after being dragged

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -743,6 +743,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SBoolData{true},
     },
     SConfigOptionDescription{
+        .value       = "group:merge_groups_on_drag",
+        .description = "whether window groups can be dragged into other groups",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{true},
+    },
+    SConfigOptionDescription{
         .value       = "general:col.border_active",
         .description = "border color for inactive windows",
         .type        = CONFIG_OPTION_GRADIENT,

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -361,6 +361,7 @@ CConfigManager::CConfigManager() {
 
     m_pConfig->addConfigValue("group:insert_after_current", Hyprlang::INT{1});
     m_pConfig->addConfigValue("group:focus_removed_window", Hyprlang::INT{1});
+    m_pConfig->addConfigValue("group:merge_groups_on_drag", Hyprlang::INT{1});
     m_pConfig->addConfigValue("group:groupbar:enabled", Hyprlang::INT{1});
     m_pConfig->addConfigValue("group:groupbar:font_family", {STRVAL_EMPTY});
     m_pConfig->addConfigValue("group:groupbar:font_size", Hyprlang::INT{8});

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -951,12 +951,16 @@ int CWindow::getGroupSize() {
 }
 
 bool CWindow::canBeGroupedInto(PHLWINDOW pWindow) {
+    static auto ALLOWGROUPMERGE = CConfigValue<Hyprlang::INT>("group:merge_groups_on_drag");
+    bool isGroup = m_sGroupData.pNextWindow;
+    bool disallowDragIntoGroup = g_pInputManager->m_bWasDraggingWindow && isGroup && !bool(*ALLOWGROUPMERGE);
     return !g_pKeybindManager->m_bGroupsLocked                                                 // global group lock disengaged
         && ((m_eGroupRules & GROUP_INVADE && m_bFirstMap)                                      // window ignore local group locks, or
             || (!pWindow->getGroupHead()->m_sGroupData.locked                                  //      target unlocked
                 && !(m_sGroupData.pNextWindow.lock() && getGroupHead()->m_sGroupData.locked))) //      source unlocked or isn't group
         && !m_sGroupData.deny                                                                  // source is not denied entry
-        && !(m_eGroupRules & GROUP_BARRED && m_bFirstMap);                                     // group rule doesn't prevent adding window
+        && !(m_eGroupRules & GROUP_BARRED && m_bFirstMap)                                      // group rule doesn't prevent adding window
+        && !disallowDragIntoGroup;                                                             // config allows groups to be merged
 }
 
 PHLWINDOW CWindow::getGroupWindowByIndex(int index) {

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -951,9 +951,9 @@ int CWindow::getGroupSize() {
 }
 
 bool CWindow::canBeGroupedInto(PHLWINDOW pWindow) {
-    static auto ALLOWGROUPMERGE = CConfigValue<Hyprlang::INT>("group:merge_groups_on_drag");
-    bool isGroup = m_sGroupData.pNextWindow;
-    bool disallowDragIntoGroup = g_pInputManager->m_bWasDraggingWindow && isGroup && !bool(*ALLOWGROUPMERGE);
+    static auto ALLOWGROUPMERGE       = CConfigValue<Hyprlang::INT>("group:merge_groups_on_drag");
+    bool        isGroup               = m_sGroupData.pNextWindow;
+    bool        disallowDragIntoGroup = g_pInputManager->m_bWasDraggingWindow && isGroup && !bool(*ALLOWGROUPMERGE);
     return !g_pKeybindManager->m_bGroupsLocked                                                 // global group lock disengaged
         && ((m_eGroupRules & GROUP_INVADE && m_bFirstMap)                                      // window ignore local group locks, or
             || (!pWindow->getGroupHead()->m_sGroupData.locked                                  //      target unlocked


### PR DESCRIPTION
### Describe your PR, what does it fix/add?

The PR adds a config variable that (dis)allows window groups from being "swallowed" into other groups when being dragged over them.  
This setting does **not** prevent _ungrouped_ windows from being dragged into groups.

The default value of the variable (`merge_groups_on_drag`) is `true`, which reflects the behavior of Hyprland prior to this change.


### Is it ready for merging, or does it need work?

It is ready for merging.


### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

#### Code Style

I tried to follow the code style as seen, but the [PR Guidelines page on the wiki](https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/) only mentions the `/.clang-format` file and I'm not sure I got VSCode to use it; still, I did my best to follow it.

#### Implementation

I implemented the check in `CWindow::canBeGroupedInto` (`/src/desktop/Window.cpp`), but I am not familiar with the codebase so I'm not entirely sure that's the correct place for it.


#### Rationale

My usual workflow has two window groups, with one being the "master" (despite using the dwindle layout); I also use a mouse binding to to drag windows.  
When I want to move a window from one group to the other, my muscle memory has me `moveoutofgroup`ing the window, then swiftly dragging it to its target.

However, occasionally I accidentally press the wrong keys, _forget_ to press the right keys, or even simply twitch and click twice.  
This means that the window group, often containing up to ~8 windows, "hovers" above the other group for a split second, and I end up with one big group containing everything;  
consequently, I need to _manually_ sort the windows back to the previous layout if I can even remember it.

You could prevent this from happening by locking groups or preventing ungrouped windows from joining them, but doing so is still either prone to whoopsies or much slower than having this PR's config variable set to `false`.  
Still, as far as I could gather from social media, I seem to be the only person to have ever had this issue; **someone suggested doing this was already possible**, but when I asked for clarification, silence followed.