### PR TITLE
workspacerules: fix on-created-empty window focus

### DIFF
--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -51,7 +51,7 @@ void CWorkspace::init(PHLWORKSPACE self) {
 
     if (self->m_bWasCreatedEmpty)
         if (auto cmd = WORKSPACERULE.onCreatedEmptyRunCmd)
-            g_pKeybindManager->spawn(*cmd);
+            g_pKeybindManager->spawnWithRules(*cmd, self);
 
     g_pEventManager->postEvent({"createworkspace", m_szName});
     g_pEventManager->postEvent({"createworkspacev2", std::format("{},{}", m_iID, m_szName)});

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -149,7 +149,8 @@ class CKeybindManager {
     static void                     moveWindowOutOfGroup(PHLWINDOW pWindow, const std::string& dir = "");
     static void                     moveWindowIntoGroup(PHLWINDOW pWindow, PHLWINDOW pWindowInDirection);
     static void                     switchToWindow(PHLWINDOW PWINDOWTOCHANGETO);
-    static uint64_t                 spawnRawProc(std::string);
+    static uint64_t                 spawnRawProc(std::string, PHLWORKSPACE pInitialWorkspace);
+    static uint64_t                 spawnWithRules(std::string, PHLWORKSPACE pInitialWorkspace);
 
     // -------------- Dispatchers -------------- //
     static SDispatchResult killActive(std::string);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fix #6237

Because windows are technically spawned on the previous workspace, initial workspace token adds silent to the window. Thus the window created by on-created-empty doesn't get focused.

This MR fixes the issue by setting the window's initial workspace token to point to the newly created workspace.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nope

#### Is it ready for merging, or does it need work?
Ready

