### PR TITLE
input: move idle notify to input handlers

### DIFF
--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -3,6 +3,7 @@
 #include "../config/ConfigValue.hpp"
 #include "../protocols/PointerGestures.hpp"
 #include "../protocols/FractionalScale.hpp"
+#include "../protocols/IdleNotify.hpp"
 #include "../protocols/core/Compositor.hpp"
 #include "../protocols/core/Seat.hpp"
 #include "eventLoop/EventLoopManager.hpp"
@@ -833,24 +834,32 @@ void CPointerManager::attachPointer(SP<IPointer> pointer) {
         auto E = std::any_cast<IPointer::SMotionEvent>(e);
 
         g_pInputManager->onMouseMoved(E);
+
+        PROTO::idle->onActivity();
     });
 
     listener->motionAbsolute = pointer->pointerEvents.motionAbsolute.registerListener([this] (std::any e) {
         auto E = std::any_cast<IPointer::SMotionAbsoluteEvent>(e);
 
         g_pInputManager->onMouseWarp(E);
+
+        PROTO::idle->onActivity();
     });
 
     listener->button = pointer->pointerEvents.button.registerListener([this] (std::any e) {
         auto E = std::any_cast<IPointer::SButtonEvent>(e);
 
         g_pInputManager->onMouseButton(E);
+
+        PROTO::idle->onActivity();
     });
 
     listener->axis = pointer->pointerEvents.axis.registerListener([this] (std::any e) {
         auto E = std::any_cast<IPointer::SAxisEvent>(e);
 
         g_pInputManager->onMouseWheel(E);
+
+        PROTO::idle->onActivity();
     });
 
     listener->frame = pointer->pointerEvents.frame.registerListener([this] (std::any e) {
@@ -861,48 +870,64 @@ void CPointerManager::attachPointer(SP<IPointer> pointer) {
         auto E = std::any_cast<IPointer::SSwipeBeginEvent>(e);
 
         g_pInputManager->onSwipeBegin(E);
+
+        PROTO::idle->onActivity();
     });
 
     listener->swipeEnd = pointer->pointerEvents.swipeEnd.registerListener([this] (std::any e) {
         auto E = std::any_cast<IPointer::SSwipeEndEvent>(e);
 
         g_pInputManager->onSwipeEnd(E);
+
+        PROTO::idle->onActivity();
     });
 
     listener->swipeUpdate = pointer->pointerEvents.swipeUpdate.registerListener([this] (std::any e) {
         auto E = std::any_cast<IPointer::SSwipeUpdateEvent>(e);
 
         g_pInputManager->onSwipeUpdate(E);
+
+        PROTO::idle->onActivity();
     });
 
     listener->pinchBegin = pointer->pointerEvents.pinchBegin.registerListener([this] (std::any e) {
         auto E = std::any_cast<IPointer::SPinchBeginEvent>(e);
 
         PROTO::pointerGestures->pinchBegin(E.timeMs, E.fingers);
+
+        PROTO::idle->onActivity();
     });
 
     listener->pinchEnd = pointer->pointerEvents.pinchEnd.registerListener([this] (std::any e) {
         auto E = std::any_cast<IPointer::SPinchEndEvent>(e);
 
         PROTO::pointerGestures->pinchEnd(E.timeMs, E.cancelled);
+
+        PROTO::idle->onActivity();
     });
 
     listener->pinchUpdate = pointer->pointerEvents.pinchUpdate.registerListener([this] (std::any e) {
         auto E = std::any_cast<IPointer::SPinchUpdateEvent>(e);
 
         PROTO::pointerGestures->pinchUpdate(E.timeMs, E.delta, E.scale, E.rotation);
+
+        PROTO::idle->onActivity();
     });
 
     listener->holdBegin = pointer->pointerEvents.holdBegin.registerListener([this] (std::any e) {
         auto E = std::any_cast<IPointer::SHoldBeginEvent>(e);
 
         PROTO::pointerGestures->holdBegin(E.timeMs, E.fingers);
+
+        PROTO::idle->onActivity();
     });
 
     listener->holdEnd = pointer->pointerEvents.holdEnd.registerListener([this] (std::any e) {
         auto E = std::any_cast<IPointer::SHoldEndEvent>(e);
 
         PROTO::pointerGestures->holdEnd(E.timeMs, E.cancelled);
+
+        PROTO::idle->onActivity();
     });
     // clang-format on
 
@@ -926,18 +951,24 @@ void CPointerManager::attachTouch(SP<ITouch> touch) {
         auto E = std::any_cast<ITouch::SDownEvent>(e);
 
         g_pInputManager->onTouchDown(E);
+
+        PROTO::idle->onActivity();
     });
 
     listener->up = touch->touchEvents.up.registerListener([this] (std::any e) {
         auto E = std::any_cast<ITouch::SUpEvent>(e);
 
         g_pInputManager->onTouchUp(E);
+
+        PROTO::idle->onActivity();
     });
 
     listener->motion = touch->touchEvents.motion.registerListener([this] (std::any e) {
         auto E = std::any_cast<ITouch::SMotionEvent>(e);
 
         g_pInputManager->onTouchMove(E);
+
+        PROTO::idle->onActivity();
     });
 
     listener->cancel = touch->touchEvents.cancel.registerListener([this] (std::any e) {
@@ -969,24 +1000,32 @@ void CPointerManager::attachTablet(SP<CTablet> tablet) {
         auto E = std::any_cast<CTablet::SAxisEvent>(e);
 
         g_pInputManager->onTabletAxis(E);
+
+        PROTO::idle->onActivity();
     });
 
     listener->proximity = tablet->tabletEvents.proximity.registerListener([this] (std::any e) {
         auto E = std::any_cast<CTablet::SProximityEvent>(e);
 
         g_pInputManager->onTabletProximity(E);
+
+        PROTO::idle->onActivity();
     });
 
     listener->tip = tablet->tabletEvents.tip.registerListener([this] (std::any e) {
         auto E = std::any_cast<CTablet::STipEvent>(e);
 
         g_pInputManager->onTabletTip(E);
+
+        PROTO::idle->onActivity();
     });
 
     listener->button = tablet->tabletEvents.button.registerListener([this] (std::any e) {
         auto E = std::any_cast<CTablet::SButtonEvent>(e);
 
         g_pInputManager->onTabletButton(E);
+
+        PROTO::idle->onActivity();
     });
     // clang-format on
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -111,7 +111,7 @@ void CInputManager::simulateMouseMovement() {
     timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);
     m_vLastCursorPosFloored = m_vLastCursorPosFloored - Vector2D(1, 1); // hack: force the mouseMoveUnified to report without making this a refocus.
-    mouseMoveUnified(now.tv_sec * 1000 + now.tv_nsec / 10000000, false, true);
+    mouseMoveUnified(now.tv_sec * 1000 + now.tv_nsec / 10000000);
 }
 
 void CInputManager::sendMotionEventsToFocused() {
@@ -132,7 +132,7 @@ void CInputManager::sendMotionEventsToFocused() {
     g_pSeatManager->setPointerFocus(g_pCompositor->m_pLastFocus.lock(), LOCAL);
 }
 
-void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool silent) {
+void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
     static auto PFOLLOWMOUSE      = CConfigValue<Hyprlang::INT>("input:follow_mouse");
     static auto PMOUSEREFOCUS     = CConfigValue<Hyprlang::INT>("input:mouse_refocus");
     static auto PMOUSEDPMS        = CConfigValue<Hyprlang::INT>("misc:mouse_move_enables_dpms");
@@ -170,7 +170,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool silent) {
 
     EMIT_HOOK_EVENT_CANCELLABLE("mouseMove", MOUSECOORDSFLOORED);
 
-    if (time && !silent)
+    if (time)
         PROTO::idle->onActivity();
 
     m_vLastCursorPosFloored = MOUSECOORDSFLOORED;

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -170,9 +170,6 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
 
     EMIT_HOOK_EVENT_CANCELLABLE("mouseMove", MOUSECOORDSFLOORED);
 
-    if (time)
-        PROTO::idle->onActivity();
-
     m_vLastCursorPosFloored = MOUSECOORDSFLOORED;
 
     const auto PMONITOR = g_pCompositor->getMonitorFromCursor();
@@ -531,8 +528,6 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
 void CInputManager::onMouseButton(IPointer::SButtonEvent e) {
     EMIT_HOOK_EVENT_CANCELLABLE("mouseButton", e);
 
-    PROTO::idle->onActivity();
-
     m_tmrLastCursorMovement.reset();
 
     if (e.state == WL_POINTER_BUTTON_STATE_PRESSED) {
@@ -767,8 +762,6 @@ void CInputManager::onMouseWheel(IPointer::SAxisEvent e) {
 
     bool passEvent = g_pKeybindManager->onAxisEvent(e);
 
-    PROTO::idle->onActivity();
-
     if (!passEvent)
         return;
 
@@ -883,6 +876,8 @@ void CInputManager::setupKeyboard(SP<IKeyboard> keeb) {
             auto PKEEB = ((IKeyboard*)owner)->self.lock();
 
             onKeyboardKey(data, PKEEB);
+
+            PROTO::idle->onActivity();
         },
         keeb.get());
 
@@ -891,6 +886,8 @@ void CInputManager::setupKeyboard(SP<IKeyboard> keeb) {
             auto PKEEB = ((IKeyboard*)owner)->self.lock();
 
             onKeyboardMod(PKEEB);
+
+            PROTO::idle->onActivity();
         },
         keeb.get());
 
@@ -1291,8 +1288,6 @@ void CInputManager::onKeyboardKey(std::any event, SP<IKeyboard> pKeyboard) {
     bool passEvent = DISALLOWACTION || g_pKeybindManager->onKeyEvent(event, pKeyboard);
 
     auto e = std::any_cast<IKeyboard::SKeyEvent>(event);
-
-    PROTO::idle->onActivity();
 
     if (passEvent) {
         const auto IME = m_sIMERelay.m_pIME.lock();

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -877,7 +877,8 @@ void CInputManager::setupKeyboard(SP<IKeyboard> keeb) {
 
             onKeyboardKey(data, PKEEB);
 
-            PROTO::idle->onActivity();
+            if (PKEEB->enabled)
+                PROTO::idle->onActivity();
         },
         keeb.get());
 
@@ -887,7 +888,8 @@ void CInputManager::setupKeyboard(SP<IKeyboard> keeb) {
 
             onKeyboardMod(PKEEB);
 
-            PROTO::idle->onActivity();
+            if (PKEEB->enabled)
+                PROTO::idle->onActivity();
         },
         keeb.get());
 

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -237,7 +237,7 @@ class CInputManager {
 
     uint32_t           m_uiCapabilities = 0;
 
-    void               mouseMoveUnified(uint32_t, bool refocus = false, bool silent = false);
+    void               mouseMoveUnified(uint32_t, bool refocus = false);
 
     SP<CTabletTool>    ensureTabletToolPresent(SP<Aquamarine::ITabletTool>);
 

--- a/src/managers/input/Tablets.cpp
+++ b/src/managers/input/Tablets.cpp
@@ -1,6 +1,5 @@
 #include "InputManager.hpp"
 #include "../../Compositor.hpp"
-#include "../../protocols/IdleNotify.hpp"
 #include "../../protocols/Tablet.hpp"
 #include "../../devices/Tablet.hpp"
 #include "../../managers/PointerManager.hpp"
@@ -155,8 +154,6 @@ void CInputManager::onTabletAxis(CTablet::SAxisEvent e) {
 
     if (e.updatedAxes & (CTablet::eTabletToolAxes::HID_TABLET_TOOL_AXIS_TILT_X | CTablet::eTabletToolAxes::HID_TABLET_TOOL_AXIS_TILT_Y))
         PROTO::tablet->tilt(PTOOL, PTOOL->tilt);
-
-    PROTO::idle->onActivity();
 }
 
 void CInputManager::onTabletTip(CTablet::STipEvent e) {
@@ -171,8 +168,6 @@ void CInputManager::onTabletTip(CTablet::STipEvent e) {
         PROTO::tablet->up(PTOOL);
 
     PTOOL->isDown = e.in;
-
-    PROTO::idle->onActivity();
 }
 
 void CInputManager::onTabletButton(CTablet::SButtonEvent e) {
@@ -184,8 +179,6 @@ void CInputManager::onTabletButton(CTablet::SButtonEvent e) {
         PTOOL->buttonsDown.push_back(e.button);
     else
         std::erase(PTOOL->buttonsDown, e.button);
-
-    PROTO::idle->onActivity();
 }
 
 void CInputManager::onTabletProximity(CTablet::SProximityEvent e) {
@@ -201,8 +194,6 @@ void CInputManager::onTabletProximity(CTablet::SProximityEvent e) {
         simulateMouseMovement();
         refocusTablet(PTAB, PTOOL);
     }
-
-    PROTO::idle->onActivity();
 }
 
 void CInputManager::newTablet(SP<Aquamarine::ITablet> pDevice) {

--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -1,7 +1,6 @@
 #include "InputManager.hpp"
 #include "../../Compositor.hpp"
 #include "../../config/ConfigValue.hpp"
-#include "../../protocols/IdleNotify.hpp"
 #include "../../devices/ITouch.hpp"
 #include "../SeatManager.hpp"
 
@@ -78,8 +77,6 @@ void CInputManager::onTouchDown(ITouch::SDownEvent e) {
         return; // oops, nothing found.
 
     g_pSeatManager->sendTouchDown(m_sTouchData.touchFocusSurface.lock(), e.timeMs, e.touchID, local);
-
-    PROTO::idle->onActivity();
 }
 
 void CInputManager::onTouchUp(ITouch::SUpEvent e) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Followup to #7649

> tho in the future it'd be better to move the idle resetting stuff directly to stuff like IMouse and IKeyboard

I think the handlers are the correct place right?

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

idle for a keyboard key is here: 
https://github.com/hyprwm/Hyprland/blob/027140b7315efe3cd2e7b78fa608bd36da839894/src/managers/input/InputManager.cpp#L1295

idle for mouse move is now in `InputManager::onMouseMoved`.
idle for touch down is in `Touch::onTouchDown` and was moved up to not ignore it in some cases.

#### Is it ready for merging, or does it need work?

Ready

