### PR TITLE
textinput: fix ime activation in some edge cases

### DIFF
--- a/src/managers/input/TextInput.cpp
+++ b/src/managers/input/TextInput.cpp
@@ -23,6 +23,8 @@ void CTextInput::initCallbacks() {
         listeners.disable = INPUT->events.disable.registerListener([this](std::any p) { onDisabled(); });
         listeners.commit  = INPUT->events.onCommit.registerListener([this](std::any p) { onCommit(); });
         listeners.destroy = INPUT->events.destroy.registerListener([this](std::any p) {
+            listeners.surfaceUnmap.reset();
+            listeners.surfaceDestroy.reset();
             g_pInputManager->m_sIMERelay.removeTextInput(this);
             if (!g_pInputManager->m_sIMERelay.getFocusedTextInput())
                 g_pInputManager->m_sIMERelay.deactivateIME(this);
@@ -72,14 +74,18 @@ void CTextInput::onDisabled() {
         return;
     }
 
-    if (!focusedSurface())
-        return;
-
     if (!isV3())
         leave();
 
     listeners.surfaceUnmap.reset();
     listeners.surfaceDestroy.reset();
+
+    if (!focusedSurface())
+        return;
+
+    const auto PFOCUSEDTI = g_pInputManager->m_sIMERelay.getFocusedTextInput();
+    if (!PFOCUSEDTI || PFOCUSEDTI != this)
+        return;
 
     g_pInputManager->m_sIMERelay.deactivateIME(this);
 }
@@ -104,11 +110,11 @@ void CTextInput::setFocusedSurface(SP<CWLSurfaceResource> pSurface) {
 
     pFocusedSurface = pSurface;
 
-    listeners.surfaceUnmap.reset();
-    listeners.surfaceDestroy.reset();
-
     if (!pSurface)
         return;
+
+    listeners.surfaceUnmap.reset();
+    listeners.surfaceDestroy.reset();
 
     listeners.surfaceUnmap = pSurface->events.unmap.registerListener([this](std::any d) {
         Debug::log(LOG, "Unmap TI owner1");
@@ -118,6 +124,12 @@ void CTextInput::setFocusedSurface(SP<CWLSurfaceResource> pSurface) {
         pFocusedSurface.reset();
         listeners.surfaceUnmap.reset();
         listeners.surfaceDestroy.reset();
+
+        if (isV3() && !pV3Input.expired() && pV3Input->current.enabled)
+            pV3Input->current.enabled = false;
+
+        if (!g_pInputManager->m_sIMERelay.getFocusedTextInput())
+            g_pInputManager->m_sIMERelay.deactivateIME(this);
     });
 
     listeners.surfaceDestroy = pSurface->events.destroy.registerListener([this](std::any d) {
@@ -128,6 +140,12 @@ void CTextInput::setFocusedSurface(SP<CWLSurfaceResource> pSurface) {
         pFocusedSurface.reset();
         listeners.surfaceUnmap.reset();
         listeners.surfaceDestroy.reset();
+
+        if (isV3() && !pV3Input.expired() && pV3Input->current.enabled)
+            pV3Input->current.enabled = false;
+
+        if (!g_pInputManager->m_sIMERelay.getFocusedTextInput())
+            g_pInputManager->m_sIMERelay.deactivateIME(this);
     });
 }
 
@@ -142,10 +160,8 @@ void CTextInput::enter(SP<CWLSurfaceResource> pSurface) {
     if (pSurface == focusedSurface())
         return;
 
-    if (focusedSurface()) {
+    if (focusedSurface())
         leave();
-        setFocusedSurface(nullptr);
-    }
 
     enterLocks++;
     if (enterLocks != 1) {
@@ -173,11 +189,14 @@ void CTextInput::leave() {
         enterLocks = 0;
     }
 
-    if (isV3() && focusedSurface())
+    if (isV3()) {
         pV3Input->leave(focusedSurface());
-    else if (focusedSurface() && pV1Input) {
+        if (pV3Input->current.enabled) {
+            pV3Input->current.enabled = false;
+            onDisabled();
+        }
+    } else
         pV1Input->leave();
-    }
 
     setFocusedSurface(nullptr);
 

--- a/src/managers/input/TextInput.cpp
+++ b/src/managers/input/TextInput.cpp
@@ -29,6 +29,9 @@ void CTextInput::initCallbacks() {
             if (!g_pInputManager->m_sIMERelay.getFocusedTextInput())
                 g_pInputManager->m_sIMERelay.deactivateIME(this);
         });
+
+        if (!g_pCompositor->m_pLastFocus.expired() && g_pCompositor->m_pLastFocus->client() == INPUT->client())
+            enter(g_pCompositor->m_pLastFocus.lock());
     } else {
         const auto INPUT = pV1Input.lock();
 

--- a/src/protocols/TextInputV3.cpp
+++ b/src/protocols/TextInputV3.cpp
@@ -24,10 +24,9 @@ CTextInputV3::CTextInputV3(SP<CZwpTextInputV3> resource_) : resource(resource_) 
         current = pending;
         serial++;
 
-        if (wasEnabled && !current.enabled) {
-            current.reset();
+        if (wasEnabled && !current.enabled)
             events.disable.emit();
-        } else if (!wasEnabled && current.enabled)
+        else if (!wasEnabled && current.enabled)
             events.enable.emit();
         else
             events.onCommit.emit();
@@ -53,12 +52,12 @@ CTextInputV3::CTextInputV3(SP<CZwpTextInputV3> resource_) : resource(resource_) 
         pending.box.cursorBox = {x, y, w, h};
     });
 
-    resource->setEnable([this](CZwpTextInputV3* r) { pending.enabled = true; });
-
-    resource->setDisable([this](CZwpTextInputV3* r) {
-        pending.enabled = false;
+    resource->setEnable([this](CZwpTextInputV3* r) {
         pending.reset();
+        pending.enabled = true;
     });
+
+    resource->setDisable([this](CZwpTextInputV3* r) { pending.enabled = false; });
 }
 
 CTextInputV3::~CTextInputV3() {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fix #7623

When telegram(QT using text input v3) closes to tray, it just destroys the focused surface without sending disable request. This resulted in text input v3 object's internal state not being resetted and when telegram tried to enable ti, hyprland thought it was already enabled.

`neteast-cloud-music-gtk4` didn't create text input until it was visible and didn't receive enter event even though it was in focus.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nothing

#### Is it ready for merging, or does it need work?
Ready

