### PR TITLE
input: kb focus mouse focused window if unset

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -508,6 +508,9 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool silent) {
             }
         }
 
+        if (g_pSeatManager->state.keyboardFocus == nullptr)
+            g_pCompositor->focusWindow(pFoundWindow, foundSurface);
+
         m_bLastFocusOnLS = false;
     } else {
         if (*PRESIZEONBORDER && *PRESIZECURSORICON && m_eBorderIconDirection != BORDERICON_NONE) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Normally it shouldn't be possible to have mouse focus with no kb focus, but it does happen, and when it does this makes it considerably less annoying.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Not sure if this would work/feel right for focus mode != 1, so this only affects focus mode == 1

#### Is it ready for merging, or does it need work?
Ready to merge

