### PR TITLE
config: add exec-shutdown for running commands on shutdown

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -460,8 +460,6 @@ void CCompositor::cleanup() {
     m_bIsShuttingDown   = true;
     Debug::shuttingDown = true;
 
-    g_pConfigManager->dispatchExecShutdown();
-
 #ifdef USES_SYSTEMD
     if (Systemd::SdBooted() > 0 && !envEnabled("HYPRLAND_NO_SD_NOTIFY"))
         Systemd::SdNotify(0, "STOPPING=1");

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -460,6 +460,8 @@ void CCompositor::cleanup() {
     m_bIsShuttingDown   = true;
     Debug::shuttingDown = true;
 
+    g_pConfigManager->dispatchExecShutdown();
+
 #ifdef USES_SYSTEMD
     if (Systemd::SdBooted() > 0 && !envEnabled("HYPRLAND_NO_SD_NOTIFY"))
         Systemd::SdNotify(0, "STOPPING=1");

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -91,6 +91,7 @@ class CCompositor {
     bool                                       m_bNextIsUnsafe   = false;
     CMonitor*                                  m_pUnsafeOutput   = nullptr; // fallback output for the unsafe state
     bool                                       m_bIsShuttingDown = false;
+    bool                                       m_bFinalRequests  = false;
     bool                                       m_bDesktopEnvSet  = false;
     bool                                       m_bEnableXwayland = true;
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -141,6 +141,18 @@ static Hyprlang::CParseResult handleExecOnce(const char* c, const char* v) {
     return result;
 }
 
+static Hyprlang::CParseResult handleExecShutdown(const char* c, const char* v) {
+    const std::string      VALUE   = v;
+    const std::string      COMMAND = c;
+
+    const auto             RESULT = g_pConfigManager->handleExecShutdown(COMMAND, VALUE);
+
+    Hyprlang::CParseResult result;
+    if (RESULT.has_value())
+        result.setError(RESULT.value().c_str());
+    return result;
+}
+
 static Hyprlang::CParseResult handleMonitor(const char* c, const char* v) {
     const std::string      VALUE   = v;
     const std::string      COMMAND = c;
@@ -609,6 +621,7 @@ CConfigManager::CConfigManager() {
     // keywords
     m_pConfig->registerHandler(&::handleRawExec, "exec", {false});
     m_pConfig->registerHandler(&::handleExecOnce, "exec-once", {false});
+    m_pConfig->registerHandler(&::handleExecShutdown, "exec-shutdown", {false});
     m_pConfig->registerHandler(&::handleMonitor, "monitor", {false});
     m_pConfig->registerHandler(&::handleBind, "bind", {true});
     m_pConfig->registerHandler(&::handleUnbind, "unbind", {false});
@@ -801,6 +814,7 @@ std::optional<std::string> CConfigManager::resetHLConfig() {
     m_vDeclaredPlugins.clear();
     m_dLayerRules.clear();
     m_vFailedPluginConfigValues.clear();
+    finalExecRequests.clear();
 
     // paths
     configPaths.clear();
@@ -1398,6 +1412,15 @@ void CConfigManager::dispatchExecOnce() {
     g_pCompositor->performUserChecks();
 }
 
+void CConfigManager::dispatchExecShutdown() {
+    if (!g_pCompositor->m_bIsShuttingDown)
+        return;
+
+    for (auto const& c : finalExecRequests) {
+        handleExecShutdown("", c);
+    }
+}
+
 void CConfigManager::appendMonitorRule(const SMonitorRule& r) {
     m_dMonitorRules.emplace_back(r);
 }
@@ -1697,6 +1720,16 @@ std::optional<std::string> CConfigManager::handleExecOnce(const std::string& com
     if (isFirstLaunch)
         firstExecRequests.push_back(args);
 
+    return {};
+}
+
+std::optional<std::string> CConfigManager::handleExecShutdown(const std::string& command, const std::string& args) {
+    if (g_pCompositor->m_bIsShuttingDown) {
+        g_pKeybindManager->spawn(args);
+        return {};
+    }
+
+    finalExecRequests.push_back(args);
     return {};
 }
 

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -192,6 +192,7 @@ class CConfigManager {
 
     // no-op when done.
     void                      dispatchExecOnce();
+    void                      dispatchExecShutdown();
 
     void                      performMonitorReload();
     void                      appendMonitorRule(const SMonitorRule&);
@@ -213,6 +214,7 @@ class CConfigManager {
     // keywords
     std::optional<std::string>                                                              handleRawExec(const std::string&, const std::string&);
     std::optional<std::string>                                                              handleExecOnce(const std::string&, const std::string&);
+    std::optional<std::string>                                                              handleExecShutdown(const std::string&, const std::string&);
     std::optional<std::string>                                                              handleMonitor(const std::string&, const std::string&);
     std::optional<std::string>                                                              handleBind(const std::string&, const std::string&);
     std::optional<std::string>                                                              handleUnbind(const std::string&, const std::string&);
@@ -289,6 +291,7 @@ class CConfigManager {
     bool                                                      firstExecDispatched     = false;
     bool                                                      m_bManualCrashInitiated = false;
     std::deque<std::string>                                   firstExecRequests;
+    std::deque<std::string>                                   finalExecRequests;
 
     std::vector<std::pair<std::string, std::string>>          m_vFailedPluginConfigValues; // for plugin values of unloaded plugins
     std::string                                               m_szConfigErrors = "";

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1781,6 +1781,11 @@ SDispatchResult CKeybindManager::renameWorkspace(std::string args) {
 }
 
 SDispatchResult CKeybindManager::exitHyprland(std::string argz) {
+    g_pConfigManager->dispatchExecShutdown();
+
+    if (g_pCompositor->m_bFinalRequests)
+        return {}; // Exiting deferred until requests complete
+
     g_pCompositor->stopCompositor();
     return {};
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds a config option for executing programs on shutdown.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nothing that could crash Hyprland while running immediately found.

#### Is it ready for merging, or does it need work?
Ready, but want tested by #7671 for any edge cases I might be able to fix
