### PR TITLE
Add order rule for layers

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2239,7 +2239,7 @@ bool windowRuleValid(const std::string& RULE) {
 
 bool layerRuleValid(const std::string& RULE) {
     static const auto rules       = std::unordered_set<std::string>{"noanim", "blur", "blurpopups", "dimaround"};
-    static const auto rulesPrefix = std::vector<std::string>{"ignorealpha", "ignorezero", "xray", "animation"};
+    static const auto rulesPrefix = std::vector<std::string>{"ignorealpha", "ignorezero", "xray", "animation", "order"};
 
     return rules.contains(RULE) || std::any_of(rulesPrefix.begin(), rulesPrefix.end(), [&RULE](auto prefix) { return RULE.starts_with(prefix); });
 }

--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -394,6 +394,11 @@ void CLayerSurface::applyRules() {
         } else if (rule.rule.starts_with("animation")) {
             CVarList vars{rule.rule, 2, 's'};
             animationStyle = vars[1];
+        } else if (rule.rule.starts_with("order")) {
+            CVarList vars{rule.rule, 2, 's'};
+            try {
+                order = std::stoi(vars[1]);
+            } catch (...) { Debug::log(ERR, "Invalid value passed to order"); }
         }
     }
 }

--- a/src/desktop/LayerSurface.hpp
+++ b/src/desktop/LayerSurface.hpp
@@ -55,6 +55,7 @@ class CLayerSurface {
     bool                       ignoreAlpha      = false;
     float                      ignoreAlphaValue = 0.f;
     bool                       dimAround        = false;
+    int64_t                    order            = 0;
 
     std::optional<std::string> animationStyle;
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1742,6 +1742,10 @@ void CHyprRenderer::arrangeLayersForMonitor(const MONITORID& monitor) {
 
     CBox usableArea = {PMONITOR->vecPosition.x, PMONITOR->vecPosition.y, PMONITOR->vecSize.x, PMONITOR->vecSize.y};
 
+    for (auto& la : PMONITOR->m_aLayerSurfaceLayers) {
+        std::stable_sort(la.begin(), la.end(), [](const PHLLSREF& a, const PHLLSREF& b) { return a->order > b->order; });
+    }
+
     for (auto const& la : PMONITOR->m_aLayerSurfaceLayers)
         arrangeLayerArray(PMONITOR, la, true, &usableArea);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Adds an `order` rule for layers, like so:

```
layerrule = order 10, waybar
layerrule = order -5, fdls
layerrule = order 100, wvkbd
```

A higher order means the layer is closer to the edge of the monitor.

Closes #7476

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Idk where the best place to do the sorting is, I just put it somewhere where it works.

The best sorting algorithm to use would be insertion sort as usually there will be 0 or 1 elements out of order, idk what `std::stable_sort` does.

#### Is it ready for merging, or does it need work?

Fine to merge probably