### PR TITLE
tiv1: fix deleting first character

### DIFF
--- a/src/managers/input/TextInput.cpp
+++ b/src/managers/input/TextInput.cpp
@@ -264,7 +264,7 @@ void CTextInput::updateIMEState(SP<CInputMethodV2> ime) {
             INPUT->preeditStyling(0, std::string(ime->current.preeditString.string).length(), ZWP_TEXT_INPUT_V1_PREEDIT_STYLE_HIGHLIGHT);
             INPUT->preeditString(pV1Input->serial, ime->current.preeditString.string.c_str(), "");
         } else {
-            INPUT->preeditCursor(ime->current.preeditString.begin);
+            INPUT->preeditCursor(0);
             INPUT->preeditStyling(0, 0, ZWP_TEXT_INPUT_V1_PREEDIT_STYLE_HIGHLIGHT);
             INPUT->preeditString(pV1Input->serial, "", "");
         }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fix #6904

Because preeddit `cursor_begin` isn't updated when deleting first character, clients receive old and invalid cursor position in text input v1.

The issue could only be reproduced with certain input methods. Because some input methods like Mozc(Japanese), Rime(Chinese) always set `cursor_begin` to 0, they don't have this issue.
However, because input methods like Hangul(Korean) and Mcbopomofo(Chinese) set `cursor_begin` to a value greater than 0, they have this problem.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nothing that I can think of

#### Is it ready for merging, or does it need work?
Ready