### PR TITLE
textinput: handle reset

### DIFF
--- a/src/managers/input/InputMethodRelay.cpp
+++ b/src/managers/input/InputMethodRelay.cpp
@@ -106,20 +106,22 @@ void CInputMethodRelay::updateAllPopups() {
     }
 }
 
-void CInputMethodRelay::activateIME(CTextInput* pInput) {
+void CInputMethodRelay::activateIME(CTextInput* pInput, bool shouldCommit) {
     if (m_pIME.expired())
         return;
 
     m_pIME->activate();
-    commitIMEState(pInput);
+    if (shouldCommit)
+        commitIMEState(pInput);
 }
 
-void CInputMethodRelay::deactivateIME(CTextInput* pInput) {
+void CInputMethodRelay::deactivateIME(CTextInput* pInput, bool shouldCommit) {
     if (m_pIME.expired())
         return;
 
     m_pIME->deactivate();
-    commitIMEState(pInput);
+    if (shouldCommit)
+        commitIMEState(pInput);
 }
 
 void CInputMethodRelay::commitIMEState(CTextInput* pInput) {

--- a/src/managers/input/InputMethodRelay.hpp
+++ b/src/managers/input/InputMethodRelay.hpp
@@ -21,8 +21,8 @@ class CInputMethodRelay {
     void               onNewTextInput(WP<CTextInputV3> tiv3);
     void               onNewTextInput(WP<CTextInputV1> pTIV1);
 
-    void               activateIME(CTextInput* pInput);
-    void               deactivateIME(CTextInput* pInput);
+    void               activateIME(CTextInput* pInput, bool shouldCommit = true);
+    void               deactivateIME(CTextInput* pInput, bool shouldCommit = true);
     void               commitIMEState(CTextInput* pInput);
     void               removeTextInput(CTextInput* pInput);
 

--- a/src/managers/input/TextInput.cpp
+++ b/src/managers/input/TextInput.cpp
@@ -22,6 +22,7 @@ void CTextInput::initCallbacks() {
         listeners.enable  = INPUT->events.enable.registerListener([this](std::any p) { onEnabled(); });
         listeners.disable = INPUT->events.disable.registerListener([this](std::any p) { onDisabled(); });
         listeners.commit  = INPUT->events.onCommit.registerListener([this](std::any p) { onCommit(); });
+        listeners.reset   = INPUT->events.reset.registerListener([this](std::any p) { onReset(); });
         listeners.destroy = INPUT->events.destroy.registerListener([this](std::any p) {
             listeners.surfaceUnmap.reset();
             listeners.surfaceDestroy.reset();
@@ -41,6 +42,7 @@ void CTextInput::initCallbacks() {
         });
         listeners.disable = INPUT->events.disable.registerListener([this](std::any p) { onDisabled(); });
         listeners.commit  = INPUT->events.onCommit.registerListener([this](std::any p) { onCommit(); });
+        listeners.reset   = INPUT->events.reset.registerListener([this](std::any p) { onReset(); });
         listeners.destroy = INPUT->events.destroy.registerListener([this](std::any p) {
             listeners.surfaceUnmap.reset();
             listeners.surfaceDestroy.reset();
@@ -93,13 +95,21 @@ void CTextInput::onDisabled() {
     g_pInputManager->m_sIMERelay.deactivateIME(this);
 }
 
+void CTextInput::onReset() {
+    if (g_pInputManager->m_sIMERelay.m_pIME.expired())
+        return;
+
+    g_pInputManager->m_sIMERelay.deactivateIME(this, false);
+    g_pInputManager->m_sIMERelay.activateIME(this);
+}
+
 void CTextInput::onCommit() {
     if (g_pInputManager->m_sIMERelay.m_pIME.expired()) {
         //   Debug::log(WARN, "Committing TextInput on no IME!");
         return;
     }
 
-    if (!(isV3() ? pV3Input->current.enabled : pV1Input->active)) {
+    if (!(isV3() ? pV3Input->current.enabled.value : pV1Input->active)) {
         Debug::log(WARN, "Disabled TextInput commit?");
         return;
     }
@@ -128,8 +138,8 @@ void CTextInput::setFocusedSurface(SP<CWLSurfaceResource> pSurface) {
         listeners.surfaceUnmap.reset();
         listeners.surfaceDestroy.reset();
 
-        if (isV3() && !pV3Input.expired() && pV3Input->current.enabled)
-            pV3Input->current.enabled = false;
+        if (isV3() && !pV3Input.expired() && pV3Input->current.enabled.value)
+            pV3Input->current.enabled.value = false;
 
         if (!g_pInputManager->m_sIMERelay.getFocusedTextInput())
             g_pInputManager->m_sIMERelay.deactivateIME(this);
@@ -144,8 +154,8 @@ void CTextInput::setFocusedSurface(SP<CWLSurfaceResource> pSurface) {
         listeners.surfaceUnmap.reset();
         listeners.surfaceDestroy.reset();
 
-        if (isV3() && !pV3Input.expired() && pV3Input->current.enabled)
-            pV3Input->current.enabled = false;
+        if (isV3() && !pV3Input.expired() && pV3Input->current.enabled.value)
+            pV3Input->current.enabled.value = false;
 
         if (!g_pInputManager->m_sIMERelay.getFocusedTextInput())
             g_pInputManager->m_sIMERelay.deactivateIME(this);
@@ -194,8 +204,8 @@ void CTextInput::leave() {
 
     if (isV3()) {
         pV3Input->leave(focusedSurface());
-        if (pV3Input->current.enabled) {
-            pV3Input->current.enabled = false;
+        if (pV3Input->current.enabled.value) {
+            pV3Input->current.enabled.value = false;
             onDisabled();
         }
     } else

--- a/src/managers/input/TextInput.hpp
+++ b/src/managers/input/TextInput.hpp
@@ -29,6 +29,7 @@ class CTextInput {
     void                   onEnabled(SP<CWLSurfaceResource> surfV1 = nullptr);
     void                   onDisabled();
     void                   onCommit();
+    void                   onReset();
 
     bool                   hasCursorRectangle();
     CBox                   cursorBox();
@@ -47,6 +48,7 @@ class CTextInput {
     struct {
         CHyprSignalListener enable;
         CHyprSignalListener disable;
+        CHyprSignalListener reset;
         CHyprSignalListener commit;
         CHyprSignalListener destroy;
         CHyprSignalListener surfaceUnmap;

--- a/src/protocols/TextInputV1.cpp
+++ b/src/protocols/TextInputV1.cpp
@@ -31,6 +31,7 @@ CTextInputV1::CTextInputV1(SP<CZwpTextInputV1> resource_) : resource(resource_) 
     resource->setReset([this](CZwpTextInputV1* pMgr) {
         pendingSurrounding.isPending = false;
         pendingContentType.isPending = false;
+        events.reset.emit();
     });
 
     resource->setSetSurroundingText(

--- a/src/protocols/TextInputV1.hpp
+++ b/src/protocols/TextInputV1.hpp
@@ -37,6 +37,7 @@ class CTextInputV1 {
         CSignal onCommit;
         CSignal enable;
         CSignal disable;
+        CSignal reset;
         CSignal destroy;
     } events;
 

--- a/src/protocols/TextInputV3.hpp
+++ b/src/protocols/TextInputV3.hpp
@@ -31,6 +31,7 @@ class CTextInputV3 {
         CSignal onCommit;
         CSignal enable;
         CSignal disable;
+        CSignal reset;
         CSignal destroy;
     } events;
 
@@ -53,7 +54,11 @@ class CTextInputV3 {
             CBox cursorBox;
         } box;
 
-        bool                      enabled = false;
+        struct {
+            bool isEnablePending  = false;
+            bool isDisablePending = false;
+            bool value            = false;
+        } enabled;
 
         zwpTextInputV3ChangeCause cause = ZWP_TEXT_INPUT_V3_CHANGE_CAUSE_INPUT_METHOD;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Forward tiv1's reset request to IME.
Reset IME when tiv3's disable and enable request are in a single commit.

Resetting the IME is done by deactivating and reactivating IME.

The reason for this change is to reset the IME's internal preedit state when a reset is requested by tiv1 (e.g. when moving the cursor by clicking).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nope

#### Is it ready for merging, or does it need work?
Should be ready
