### PR TITLE
PR: Fix VRAM Memory leak on NVIDIA cards on config reload

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2809,7 +2809,7 @@ SExplicitSyncSettings CHyprRenderer::getExplicitSyncSettings() {
 
             // check nvidia version. Explicit KMS is supported in >=560
             // in the case of an error, driverMajor will stay 0 and explicit KMS will be disabled
-            int driverMajor = 0;
+            int  driverMajor = 0;
 
             static bool once = true;
             if (once) {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2809,7 +2809,7 @@ SExplicitSyncSettings CHyprRenderer::getExplicitSyncSettings() {
 
             // check nvidia version. Explicit KMS is supported in >=560
             // in the case of an error, driverMajor will stay 0 and explicit KMS will be disabled
-            int  driverMajor = 0;
+            int driverMajor = 0;
 
             static bool once = true;
             if (once) {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2809,7 +2809,7 @@ SExplicitSyncSettings CHyprRenderer::getExplicitSyncSettings() {
 
             // check nvidia version. Explicit KMS is supported in >=560
             // in the case of an error, driverMajor will stay 0 and explicit KMS will be disabled
-            static int  driverMajor = 0;
+            int  driverMajor = 0;
 
             static bool once = true;
             if (once) {


### PR DESCRIPTION

#### Describe your PR, what does it fix/add?
Fixes VRAM Memory leak on NVIDIA cards on config reload. https://github.com/hyprwm/Hyprland/issues/7728
It simply changes the driverMajor value from a static int to a standard int.
Bug introduced in commit: [renderer: fixup nvidia driver version checks](https://github.com/hyprwm/Hyprland/commit/2d552fbaa25f1457c3819521a2750dd30820271b)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No additional mentions required, a simple change, cannot reproduce the bug/leak in any way after the fix. Hyprland works just as it does on the main branch.

#### Is it ready for merging, or does it need work?
Ready to merge!

