### PR TITLE
Nix: revert to using CMake, drop ninja

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,10 +216,13 @@ set(CPACK_PROJECT_NAME ${PROJECT_NAME})
 set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
 include(CPack)
 
-message(STATUS "Setting precompiled headers")
-
-target_precompile_headers(Hyprland PRIVATE
-                          $<$<COMPILE_LANGUAGE:CXX>:src/pch/pch.hpp>)
+if(CMAKE_DISABLE_PRECOMPILE_HEADERS)
+  message(STATUS "Not using precompiled headers")
+else()
+  message(STATUS "Setting precompiled headers")
+  target_precompile_headers(Hyprland PRIVATE
+                            $<$<COMPILE_LANGUAGE:CXX>:src/pch/pch.hpp>)
+endif()
 
 message(STATUS "Setting link libraries")
 

--- a/nix/cmake-version.patch
+++ b/nix/cmake-version.patch
@@ -1,0 +1,10 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 6fdf98db..d8424d91 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-cmake_minimum_required(VERSION 3.30)
++cmake_minimum_required(VERSION 3.27)
+ 
+ # Get version
+ file(READ "${CMAKE_SOURCE_DIR}/VERSION" VER_RAW)

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -6,7 +6,6 @@
   pkgconf,
   makeWrapper,
   cmake,
-  ninja,
   aquamarine,
   binutils,
   cairo,
@@ -105,7 +104,6 @@ in
         jq
         makeWrapper
         cmake
-        ninja
         pkg-config
         python3 # for udis86
         wayland-scanner

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -5,7 +5,6 @@
   pkg-config,
   pkgconf,
   makeWrapper,
-  meson,
   cmake,
   ninja,
   aquamarine,
@@ -105,7 +104,6 @@ in
         hyprwayland-scanner
         jq
         makeWrapper
-        meson
         cmake
         ninja
         pkg-config

--- a/nix/stdcxx.patch
+++ b/nix/stdcxx.patch
@@ -1,0 +1,12 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index cfbd431f..73e8e0c2 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -64,6 +64,7 @@ endif()
+ include_directories(. "src/" "subprojects/udis86/" "protocols/")
+ set(CMAKE_CXX_STANDARD 26)
+ add_compile_options(
++  -std=c++26
+   -Wall
+   -Wextra
+   -Wno-unused-parameter


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Revert https://github.com/hyprwm/Hyprland/pull/7774 and https://github.com/hyprwm/Hyprland/pull/7778.
Reason: CMake + Makefile + Mold builds the fastest out of the tested configurations. See https://github.com/hyprwm/Hyprland/pull/7774#issuecomment-2350092139 for an ugly graph.

~~Also use stdenvAdapters.keepDebugInfo when debug is enabled, and handle applying all configured adapters.~~ done on main

~~devShell now inherits the default package's stdenv so that it only needs to be set in `nix/overlays.nix`.~~ done on main

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

CC: @JohnRTitor @Diniamo @NotAShelf

#### Is it ready for merging, or does it need work?

Should be ready.
