### PR TITLE
Delay monitor messages

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -192,7 +192,6 @@ void CMonitor::onConnect(bool noRule) {
     if (!activeMonitorRule.mirrorOf.empty())
         setMirror(activeMonitorRule.mirrorOf);
 
-
     if (!g_pCompositor->m_pLastMonitor) // set the last monitor if it isnt set yet
         g_pCompositor->setActiveMonitor(this);
 
@@ -281,7 +280,6 @@ void CMonitor::onDisconnect(bool destroy) {
     }
 
     Debug::log(LOG, "Removed monitor {}!", szName);
-
 
     if (!BACKUPMON) {
         Debug::log(WARN, "Unplugged last monitor, entering an unsafe state. Good luck my friend.");

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -192,9 +192,6 @@ void CMonitor::onConnect(bool noRule) {
     if (!activeMonitorRule.mirrorOf.empty())
         setMirror(activeMonitorRule.mirrorOf);
 
-    g_pEventManager->postEvent(SHyprIPCEvent{"monitoradded", szName});
-    g_pEventManager->postEvent(SHyprIPCEvent{"monitoraddedv2", std::format("{},{},{}", ID, szName, szShortDescription)});
-    EMIT_HOOK_EVENT("monitorAdded", this);
 
     if (!g_pCompositor->m_pLastMonitor) // set the last monitor if it isnt set yet
         g_pCompositor->setActiveMonitor(this);
@@ -224,6 +221,10 @@ void CMonitor::onConnect(bool noRule) {
     PROTO::gamma->applyGammaToState(this);
 
     events.connect.emit();
+
+    g_pEventManager->postEvent(SHyprIPCEvent{"monitoradded", szName});
+    g_pEventManager->postEvent(SHyprIPCEvent{"monitoraddedv2", std::format("{},{},{}", ID, szName, szShortDescription)});
+    EMIT_HOOK_EVENT("monitorAdded", this);
 }
 
 void CMonitor::onDisconnect(bool destroy) {
@@ -281,8 +282,6 @@ void CMonitor::onDisconnect(bool destroy) {
 
     Debug::log(LOG, "Removed monitor {}!", szName);
 
-    g_pEventManager->postEvent(SHyprIPCEvent{"monitorremoved", szName});
-    EMIT_HOOK_EVENT("monitorRemoved", this);
 
     if (!BACKUPMON) {
         Debug::log(WARN, "Unplugged last monitor, entering an unsafe state. Good luck my friend.");
@@ -342,6 +341,9 @@ void CMonitor::onDisconnect(bool destroy) {
         g_pHyprRenderer->m_pMostHzMonitor = pMonitorMostHz;
     }
     std::erase_if(g_pCompositor->m_vMonitors, [&](SP<CMonitor>& el) { return el.get() == this; });
+
+    g_pEventManager->postEvent(SHyprIPCEvent{"monitorremoved", szName});
+    EMIT_HOOK_EVENT("monitorRemoved", this);
 }
 
 void CMonitor::addDamage(const pixman_region32_t* rg) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This basically delays the notifications for new/removed monitors. The intention is to finish hyprland internal handling to avoid collision with external tools.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This may (at least) reduce the problems with kanshi. The only issue remaining to me is that the laptop monitor does not go back on, I remember that that worked fine before aquamarine.



#### Is it ready for merging, or does it need work?


