### PR TITLE
textinput: don't reset if ti isn't enabled

### DIFF
--- a/src/managers/input/TextInput.cpp
+++ b/src/managers/input/TextInput.cpp
@@ -99,6 +99,13 @@ void CTextInput::onReset() {
     if (g_pInputManager->m_sIMERelay.m_pIME.expired())
         return;
 
+    if (!focusedSurface())
+        return;
+
+    const auto PFOCUSEDTI = g_pInputManager->m_sIMERelay.getFocusedTextInput();
+    if (!PFOCUSEDTI || PFOCUSEDTI != this)
+        return;
+
     g_pInputManager->m_sIMERelay.deactivateIME(this, false);
     g_pInputManager->m_sIMERelay.activateIME(this);
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fix #7775

Don't activate IME when textinput requesting reset is not enabled.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nope

#### Is it ready for merging, or does it need work?
Ready for merging

