### PR TITLE
Fix change group current messing up fullscreen

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -991,7 +991,7 @@ void CWindow::setGroupCurrent(PHLWINDOW pWindow) {
     const auto PCURRENT   = getGroupCurrent();
     const bool FULLSCREEN = PCURRENT->isFullscreen();
     const auto WORKSPACE  = PCURRENT->m_pWorkspace;
-    const auto MODE       = PCURRENT->m_sFullscreenState.client;
+    const auto MODE       = PCURRENT->m_sFullscreenState.internal;
 
     const auto PWINDOWSIZE = PCURRENT->m_vRealSize.goal();
     const auto PWINDOWPOS  = PCURRENT->m_vRealPosition.goal();


### PR DESCRIPTION
In the current version of Hyprland if the focused window of a group is in client full-screen and you try to change the group's active window, the target window would become internally full-screened.
That seemed like a bug so I tried to fix it in this PR.
The problem is that in the change group current function, the client full-screen state is copied to the target window instead of the internal one.

I only changed variable assignment that is not used elsewhere. I think nothing should be broken.