### PR TITLE
dispatcher: allow moveintogroup when windows are floating

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2730,7 +2730,7 @@ SDispatchResult CKeybindManager::moveIntoGroup(std::string args) {
 
     const auto PWINDOW = g_pCompositor->m_pLastWindow.lock();
 
-    if (!PWINDOW || PWINDOW->m_bIsFloating || PWINDOW->m_sGroupData.deny)
+    if (!PWINDOW || PWINDOW->m_sGroupData.deny)
         return {};
 
     auto PWINDOWINDIR = g_pCompositor->getWindowInDirection(PWINDOW, arg);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This allows to use the moveintogroup dispatcher when windows are floating. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I don't know why was this disabled in the first place though.

#### Is it ready for merging, or does it need work?

Yes
