### PR TITLE
core: add HYPRLAND_CONFIG environment variable

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -684,7 +684,7 @@ std::string CConfigManager::getMainConfigPath() {
         return g_pCompositor->explicitConfigPath;
 
     if (const auto CFG_ENV = getenv("HYPRLAND_CONFIG"); CFG_ENV) {
-      return CFG_ENV;
+        return CFG_ENV;
     };
 
     Debug::log(TRACE, "Seems as if HYPRLAND_CONFIG isn't set, let's see what we can do with HOME.");

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -683,6 +683,12 @@ std::string CConfigManager::getMainConfigPath() {
     if (!g_pCompositor->explicitConfigPath.empty())
         return g_pCompositor->explicitConfigPath;
 
+    if (const char *cfg = getenv("HYPRLAND_CONFIG"); cfg != NULL) {
+        return cfg;
+    }
+
+    Debug::log(INFO, "Seems as if HYPRLAND_CONFIG isn't set, let's see what we can do with HOME.");
+
     static const auto paths = Hyprutils::Path::findConfig(ISDEBUG ? "hyprlandd" : "hyprland");
     if (paths.first.has_value()) {
         return paths.first.value();

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -683,10 +683,7 @@ std::string CConfigManager::getMainConfigPath() {
     if (!g_pCompositor->explicitConfigPath.empty())
         return g_pCompositor->explicitConfigPath;
 
-    if (const auto CFG_ENV = getenv("HYPRLAND_CONFIG"); CFG_ENV) {
-        return CFG_ENV;
-    };
-
+    if (const auto CFG_ENV = getenv("HYPRLAND_CONFIG"); CFG_ENV) return CFG_ENV;
     Debug::log(TRACE, "Seems as if HYPRLAND_CONFIG isn't set, let's see what we can do with HOME.");
 
     static const auto paths = Hyprutils::Path::findConfig(ISDEBUG ? "hyprlandd" : "hyprland");

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -683,11 +683,9 @@ std::string CConfigManager::getMainConfigPath() {
     if (!g_pCompositor->explicitConfigPath.empty())
         return g_pCompositor->explicitConfigPath;
 
-    if (const char *cfg = getenv("HYPRLAND_CONFIG"); cfg != NULL) {
-        return cfg;
-    }
+    if (const char *CFG_ENV = getenv("HYPRLAND_CONFIG"); CFG_ENV);
 
-    Debug::log(INFO, "Seems as if HYPRLAND_CONFIG isn't set, let's see what we can do with HOME.");
+    Debug::log(DEBUG, "Seems as if HYPRLAND_CONFIG isn't set, let's see what we can do with HOME.");
 
     static const auto paths = Hyprutils::Path::findConfig(ISDEBUG ? "hyprlandd" : "hyprland");
     if (paths.first.has_value()) {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -683,7 +683,8 @@ std::string CConfigManager::getMainConfigPath() {
     if (!g_pCompositor->explicitConfigPath.empty())
         return g_pCompositor->explicitConfigPath;
 
-    if (const auto CFG_ENV = getenv("HYPRLAND_CONFIG"); CFG_ENV) return CFG_ENV;
+    if (const auto CFG_ENV = getenv("HYPRLAND_CONFIG"); CFG_ENV)
+        return CFG_ENV;
     Debug::log(TRACE, "Seems as if HYPRLAND_CONFIG isn't set, let's see what we can do with HOME.");
 
     static const auto paths = Hyprutils::Path::findConfig(ISDEBUG ? "hyprlandd" : "hyprland");

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -683,7 +683,7 @@ std::string CConfigManager::getMainConfigPath() {
     if (!g_pCompositor->explicitConfigPath.empty())
         return g_pCompositor->explicitConfigPath;
 
-    if (const char *CFG_ENV = getenv("HYPRLAND_CONFIG"); CFG_ENV);
+    if (const auto CFG_ENV = getenv("HYPRLAND_CONFIG"); CFG_ENV);
 
     Debug::log(DEBUG, "Seems as if HYPRLAND_CONFIG isn't set, let's see what we can do with HOME.");
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -683,9 +683,11 @@ std::string CConfigManager::getMainConfigPath() {
     if (!g_pCompositor->explicitConfigPath.empty())
         return g_pCompositor->explicitConfigPath;
 
-    if (const auto CFG_ENV = getenv("HYPRLAND_CONFIG"); CFG_ENV);
+    if (const auto CFG_ENV = getenv("HYPRLAND_CONFIG"); CFG_ENV) {
+      return CFG_ENV;
+    };
 
-    Debug::log(DEBUG, "Seems as if HYPRLAND_CONFIG isn't set, let's see what we can do with HOME.");
+    Debug::log(TRACE, "Seems as if HYPRLAND_CONFIG isn't set, let's see what we can do with HOME.");
 
     static const auto paths = Hyprutils::Path::findConfig(ISDEBUG ? "hyprlandd" : "hyprland");
     if (paths.first.has_value()) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This adds a brand new environment variable named HYPRLAND_CONFIG to the table, this is another fallback config lookup that Hyprland uses in case --config fails.

There are benefits that come from this:

A) You can now just wrap Hyprland itself with your configuration, this solves any issues with wrapping that may come from systemd.

B) While the XDG directory spec cleans up your ~, at least clean up the XDG directories a bit too, god knows they need it...

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

There's a Debug::log call which may be unnecessary? Other than that nothing else is really notable.

I am also not amazing at C++ but I tried to make the code look C++ which may be a bit more enticing. /s

#### Is it ready for merging, or does it need work?

I have tested the necessary sections of code (trying to w/ & w/o HYPRLAND_CONFIG) with both doing as I expected.

I believe this is ready to be checked at least.

