### PR TITLE
Fix dpms toggle

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2399,9 +2399,7 @@ SDispatchResult CKeybindManager::dpms(std::string arg) {
     bool            enable = arg.starts_with("on");
     std::string     port   = "";
 
-    if (arg.starts_with("toggle"))
-        enable = !std::any_of(g_pCompositor->m_vMonitors.begin(), g_pCompositor->m_vMonitors.end(), [&](const auto& other) { return !other->dpmsStatus; }); // enable if any is off
-
+    bool            isToggle = arg.starts_with("toggle");
     if (arg.find_first_of(' ') != std::string::npos)
         port = arg.substr(arg.find_first_of(' ') + 1);
 
@@ -2409,6 +2407,9 @@ SDispatchResult CKeybindManager::dpms(std::string arg) {
 
         if (!port.empty() && m->szName != port)
             continue;
+
+        if (isToggle)
+            enable = !m->dpmsStatus;
 
         m->output->state->resetExplicitFences();
         m->output->state->setEnabled(enable);


### PR DESCRIPTION
Maybe I'm stupid, but I don't understand the logic behind the current implementation. It is input monitor agnostic and results in the following truth table:
```
+------+------+---------+
| Mon1 | Mon2 |  Enable |
+------+------+---------+
|  Off |  Off |   false |
|   On |  Off |   false |
|  Off |   On |   false |
|   On |   On |    true |
+------+------+---------+
```
This logic does not seem to make sense to me.
So this PR fixes that.
