### PR TITLE
feat: auto_group

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -772,6 +772,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .type        = CONFIG_OPTION_GRADIENT,
         .data        = SConfigOptionDescription::SGradientData{"0x66775500"},
     },
+    SConfigOptionDescription{
+        .value       = "group:auto_group",
+        .description = "automatically group new windows",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{true},
+    },
 
     /*
      * group:groupbar:

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -376,6 +376,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("group:insert_after_current", Hyprlang::INT{1});
     m_pConfig->addConfigValue("group:focus_removed_window", Hyprlang::INT{1});
     m_pConfig->addConfigValue("group:merge_groups_on_drag", Hyprlang::INT{1});
+    m_pConfig->addConfigValue("group:auto_group", Hyprlang::INT{1});
     m_pConfig->addConfigValue("group:groupbar:enabled", Hyprlang::INT{1});
     m_pConfig->addConfigValue("group:groupbar:font_family", {STRVAL_EMPTY});
     m_pConfig->addConfigValue("group:groupbar:font_size", Hyprlang::INT{8});

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -322,7 +322,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
     PWINDOW->updateWindowData();
 
     if (PWINDOW->m_bIsFloating) {
-        g_pLayoutManager->getCurrentLayout()->onWindowCreatedFloating(PWINDOW);
+        g_pLayoutManager->getCurrentLayout()->onWindowCreated(PWINDOW);
         PWINDOW->m_bCreatedOverFullscreen = true;
 
         // size and move rules

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -327,8 +327,8 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
     static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
     // Auto group the new tiling window if the focused window is a open group
     if ((*AUTOGROUP || g_pInputManager->m_bWasDraggingWindow) && g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->m_pWorkspace == pWindow->m_pWorkspace &&
-        getNodeFromWindow(g_pCompositor->m_pLastWindow.lock()) != PNODE && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
-        && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock()) && !m_vOverrideFocalPoint) {                            // we are not moving window
+        getNodeFromWindow(g_pCompositor->m_pLastWindow.lock()) != PNODE && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow.lock() // target: active group
+        && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock()) && !m_vOverrideFocalPoint) {                                   // we are not moving window
 
         m_lDwindleNodesData.remove(*PNODE);
 

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -254,10 +254,6 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
     if (pWindow->m_bIsFloating)
         return;
 
-    bool autoGrouped = IHyprLayout::onWindowCreatedAutoGroup(pWindow);
-    if (autoGrouped)
-        return;
-
     m_lDwindleNodesData.push_back(SDwindleNodeData());
     const auto  PNODE = &m_lDwindleNodesData.back();
 

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -359,7 +359,8 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
 
         return;
     }
-    // auto group the window if the last window is a floating group
+
+    // auto group the new tiling window if the focused window is a floating group
     const auto PLASTWINDOW = g_pCompositor->m_pLastWindow;
     if (*AUTOGROUP && PLASTWINDOW && PLASTWINDOW->m_bIsFloating && PLASTWINDOW->m_sGroupData.pNextWindow // target is a floating group
         && pWindow->canBeGroupedInto(PLASTWINDOW.lock())) {

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -326,7 +326,8 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
 
     static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
     // Auto group the new tiling window if the focused window is a open group
-    if ((*AUTOGROUP || g_pInputManager->m_bWasDraggingWindow) && getNodeFromWindow(g_pCompositor->m_pLastWindow.lock()) != PNODE && g_pCompositor->m_pLastWindow &&
+    if ((*AUTOGROUP || g_pInputManager->m_bWasDraggingWindow) && g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->m_pWorkspace == pWindow->m_pWorkspace &&
+        getNodeFromWindow(g_pCompositor->m_pLastWindow.lock()) != PNODE && g_pCompositor->m_pLastWindow &&
         g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow                                         // target: active group
         && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock()) && !m_vOverrideFocalPoint) { // we are not moving window
 

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -364,8 +364,10 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
     if (*AUTOGROUP && PLASTWINDOW && PLASTWINDOW->m_bIsFloating && PLASTWINDOW->m_sGroupData.pNextWindow // target is a floating group
         && pWindow->canBeGroupedInto(PLASTWINDOW.lock())) {
 
-        static auto USECURRPOS = CConfigValue<Hyprlang::INT>("group:insert_after_current");
-        (*USECURRPOS ? PLASTWINDOW : PLASTWINDOW->getGroupTail())->insertWindowToGroup(pWindow);
+        // make the new window floating before merging into the focused floating group
+        pWindow->m_bIsFloating = true;
+        m_lDwindleNodesData.remove(*PNODE);
+        g_pLayoutManager->getCurrentLayout()->onWindowCreatedFloating(pWindow);
 
         PLASTWINDOW->setGroupCurrent(pWindow);
         pWindow->applyGroupRules();

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -325,26 +325,25 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
     }
 
     // If the active window is a group and auto_group = true:
-    static auto AUTOGROUP   = CConfigValue<Hyprlang::INT>("group:auto_group");
-    const auto  PLASTWINDOW = g_pCompositor->m_pLastWindow;
+    static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
     // Auto group the new tiling window if the focused window is a group
-    if (*AUTOGROUP && PLASTWINDOW && PLASTWINDOW->m_sGroupData.pNextWindow            // target: active group
-        && pWindow->canBeGroupedInto(PLASTWINDOW.lock()) && !m_vOverrideFocalPoint) { // we are not moving window
+    if (*AUTOGROUP && g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
+        && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock()) && !m_vOverrideFocalPoint) {       // we are not moving window
 
         m_lDwindleNodesData.remove(*PNODE);
 
-        if (!PLASTWINDOW->m_bIsFloating) { // target: focused tiled group
+        if (!g_pCompositor->m_pLastWindow->m_bIsFloating) { // target: focused tiled group
             static auto USECURRPOS = CConfigValue<Hyprlang::INT>("group:insert_after_current");
-            (*USECURRPOS ? PLASTWINDOW : PLASTWINDOW->getGroupTail())->insertWindowToGroup(pWindow);
+            (*USECURRPOS ? g_pCompositor->m_pLastWindow : g_pCompositor->m_pLastWindow->getGroupTail())->insertWindowToGroup(pWindow);
         }
 
-        if (PLASTWINDOW->m_bIsFloating) { // target: focused floating group
+        if (g_pCompositor->m_pLastWindow->m_bIsFloating) { // target: focused floating group
             // make the new tiling window to float before merging it into the focused floating group
             pWindow->m_bIsFloating = true;
             g_pLayoutManager->getCurrentLayout()->onWindowCreatedFloating(pWindow);
         }
 
-        PLASTWINDOW->setGroupCurrent(pWindow);
+        g_pCompositor->m_pLastWindow->setGroupCurrent(pWindow);
         pWindow->applyGroupRules();
         pWindow->updateWindowDecos();
         recalculateWindow(pWindow);

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -254,6 +254,10 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
     if (pWindow->m_bIsFloating)
         return;
 
+    bool autoGrouped = IHyprLayout::onWindowCreatedAutoGroup(pWindow);
+    if (autoGrouped)
+        return;
+
     m_lDwindleNodesData.push_back(SDwindleNodeData());
     const auto  PNODE = &m_lDwindleNodesData.back();
 
@@ -322,36 +326,6 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
                 break;
             }
         }
-    }
-
-    static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
-    // Auto group the new tiling window if the focused window is a open group
-    if ((*AUTOGROUP || g_pInputManager->m_bWasDraggingWindow) && g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->m_pWorkspace == pWindow->m_pWorkspace &&
-        getNodeFromWindow(g_pCompositor->m_pLastWindow.lock()) != PNODE && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow.lock() // target: active group
-        && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock())) {
-
-        m_lDwindleNodesData.remove(*PNODE);
-
-        if (!g_pCompositor->m_pLastWindow->m_bIsFloating) { // target: focused tiled group
-            static auto USECURRPOS = CConfigValue<Hyprlang::INT>("group:insert_after_current");
-            (*USECURRPOS ? g_pCompositor->m_pLastWindow : g_pCompositor->m_pLastWindow->getGroupTail())->insertWindowToGroup(pWindow);
-        }
-
-        if (g_pCompositor->m_pLastWindow->m_bIsFloating) { // target: focused floating group
-            // make the new tiling window to float before merging it into the focused floating group
-            pWindow->m_bIsFloating = true;
-            g_pLayoutManager->getCurrentLayout()->onWindowCreated(pWindow);
-        }
-
-        g_pCompositor->m_pLastWindow->setGroupCurrent(pWindow);
-        pWindow->applyGroupRules();
-        pWindow->updateWindowDecos();
-        recalculateWindow(pWindow);
-
-        if (!pWindow->getDecorationByType(DECORATION_GROUPBAR))
-            pWindow->addWindowDeco(std::make_unique<CHyprGroupBarDecoration>(pWindow));
-
-        return;
     }
 
     // if it's the first, it's easy. Make it fullscreen.

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -327,9 +327,8 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
     static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
     // Auto group the new tiling window if the focused window is a open group
     if ((*AUTOGROUP || g_pInputManager->m_bWasDraggingWindow) && g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->m_pWorkspace == pWindow->m_pWorkspace &&
-        getNodeFromWindow(g_pCompositor->m_pLastWindow.lock()) != PNODE && g_pCompositor->m_pLastWindow &&
-        g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow                                         // target: active group
-        && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock()) && !m_vOverrideFocalPoint) { // we are not moving window
+        getNodeFromWindow(g_pCompositor->m_pLastWindow.lock()) != PNODE && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
+        && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock()) && !m_vOverrideFocalPoint) {                            // we are not moving window
 
         m_lDwindleNodesData.remove(*PNODE);
 

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -340,7 +340,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
         if (g_pCompositor->m_pLastWindow->m_bIsFloating) { // target: focused floating group
             // make the new tiling window to float before merging it into the focused floating group
             pWindow->m_bIsFloating = true;
-            g_pLayoutManager->getCurrentLayout()->onWindowCreatedFloating(pWindow);
+            g_pLayoutManager->getCurrentLayout()->onWindowCreated(pWindow);
         }
 
         g_pCompositor->m_pLastWindow->setGroupCurrent(pWindow);

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -340,8 +340,9 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
             return;
     }
 
-    // if it's a group, add the window
-    if (OPENINGON->pWindow->m_sGroupData.pNextWindow.lock()                                  // target is group
+    static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
+    // auto group the window if OPENINGON is a tiled group
+    if (*AUTOGROUP && OPENINGON->pWindow->m_sGroupData.pNextWindow.lock()                    // target is a tiled group
         && pWindow->canBeGroupedInto(OPENINGON->pWindow.lock()) && !m_vOverrideFocalPoint) { // we are not moving window
         m_lDwindleNodesData.remove(*PNODE);
 
@@ -349,6 +350,24 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
         (*USECURRPOS ? OPENINGON->pWindow.lock() : OPENINGON->pWindow->getGroupTail())->insertWindowToGroup(pWindow);
 
         OPENINGON->pWindow->setGroupCurrent(pWindow);
+        pWindow->applyGroupRules();
+        pWindow->updateWindowDecos();
+        recalculateWindow(pWindow);
+
+        if (!pWindow->getDecorationByType(DECORATION_GROUPBAR))
+            pWindow->addWindowDeco(std::make_unique<CHyprGroupBarDecoration>(pWindow));
+
+        return;
+    }
+    // auto group the window if the last window is a floating group
+    const auto PLASTWINDOW = g_pCompositor->m_pLastWindow;
+    if (*AUTOGROUP && PLASTWINDOW && PLASTWINDOW->m_bIsFloating && PLASTWINDOW->m_sGroupData.pNextWindow // target is a floating group
+        && pWindow->canBeGroupedInto(PLASTWINDOW.lock())) {
+
+        static auto USECURRPOS = CConfigValue<Hyprlang::INT>("group:insert_after_current");
+        (*USECURRPOS ? PLASTWINDOW : PLASTWINDOW->getGroupTail())->insertWindowToGroup(pWindow);
+
+        PLASTWINDOW->setGroupCurrent(pWindow);
         pWindow->applyGroupRules();
         pWindow->updateWindowDecos();
         recalculateWindow(pWindow);

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -340,8 +340,10 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
             return;
     }
 
+    // If the active window is a group and auto_group = true:
     static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
-    // auto group the window if OPENINGON is a tiled group
+
+    // auto group the new tiling window if OPENINGON is a tiled group
     if (*AUTOGROUP && OPENINGON->pWindow->m_sGroupData.pNextWindow.lock()                    // target is a tiled group
         && pWindow->canBeGroupedInto(OPENINGON->pWindow.lock()) && !m_vOverrideFocalPoint) { // we are not moving window
         m_lDwindleNodesData.remove(*PNODE);
@@ -362,10 +364,10 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
 
     // auto group the new tiling window if the focused window is a floating group
     const auto PLASTWINDOW = g_pCompositor->m_pLastWindow;
-    if (*AUTOGROUP && PLASTWINDOW && PLASTWINDOW->m_bIsFloating && PLASTWINDOW->m_sGroupData.pNextWindow // target is a floating group
+    if (*AUTOGROUP && PLASTWINDOW && PLASTWINDOW->m_bIsFloating && PLASTWINDOW->m_sGroupData.pNextWindow // target is the focused floating group
         && pWindow->canBeGroupedInto(PLASTWINDOW.lock())) {
 
-        // make the new window floating before merging into the focused floating group
+        // make the new tiling window to float before merging it into the focused floating group
         pWindow->m_bIsFloating = true;
         m_lDwindleNodesData.remove(*PNODE);
         g_pLayoutManager->getCurrentLayout()->onWindowCreatedFloating(pWindow);

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -327,8 +327,9 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
     // If the active window is a group and auto_group = true:
     static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
     // Auto group the new tiling window if the focused window is a group
-    if (*AUTOGROUP && g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
-        && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock()) && !m_vOverrideFocalPoint) {       // we are not moving window
+    if (*AUTOGROUP && getNodeFromWindow(g_pCompositor->m_pLastWindow.lock()) != PNODE && g_pCompositor->m_pLastWindow &&
+        g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow                                         // target: active group
+        && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock()) && !m_vOverrideFocalPoint) { // we are not moving window
 
         m_lDwindleNodesData.remove(*PNODE);
 

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -341,36 +341,24 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
     }
 
     // If the active window is a group and auto_group = true:
-    static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
+    static auto AUTOGROUP   = CConfigValue<Hyprlang::INT>("group:auto_group");
+    const auto  PLASTWINDOW = g_pCompositor->m_pLastWindow;
+    // Auto group the new tiling window if the focused window is a group
+    if (*AUTOGROUP && PLASTWINDOW && PLASTWINDOW->m_sGroupData.pNextWindow            // target: active group
+        && pWindow->canBeGroupedInto(PLASTWINDOW.lock()) && !m_vOverrideFocalPoint) { // we are not moving window
 
-    // auto group the new tiling window if OPENINGON is a tiled group
-    if (*AUTOGROUP && OPENINGON->pWindow->m_sGroupData.pNextWindow.lock()                    // target is a tiled group
-        && pWindow->canBeGroupedInto(OPENINGON->pWindow.lock()) && !m_vOverrideFocalPoint) { // we are not moving window
         m_lDwindleNodesData.remove(*PNODE);
 
-        static auto USECURRPOS = CConfigValue<Hyprlang::INT>("group:insert_after_current");
-        (*USECURRPOS ? OPENINGON->pWindow.lock() : OPENINGON->pWindow->getGroupTail())->insertWindowToGroup(pWindow);
+        if (!PLASTWINDOW->m_bIsFloating) { // target: focused tiled group
+            static auto USECURRPOS = CConfigValue<Hyprlang::INT>("group:insert_after_current");
+            (*USECURRPOS ? PLASTWINDOW : PLASTWINDOW->getGroupTail())->insertWindowToGroup(pWindow);
+        }
 
-        OPENINGON->pWindow->setGroupCurrent(pWindow);
-        pWindow->applyGroupRules();
-        pWindow->updateWindowDecos();
-        recalculateWindow(pWindow);
-
-        if (!pWindow->getDecorationByType(DECORATION_GROUPBAR))
-            pWindow->addWindowDeco(std::make_unique<CHyprGroupBarDecoration>(pWindow));
-
-        return;
-    }
-
-    // auto group the new tiling window if the focused window is a floating group
-    const auto PLASTWINDOW = g_pCompositor->m_pLastWindow;
-    if (*AUTOGROUP && PLASTWINDOW && PLASTWINDOW->m_bIsFloating && PLASTWINDOW->m_sGroupData.pNextWindow // target is the focused floating group
-        && pWindow->canBeGroupedInto(PLASTWINDOW.lock())) {
-
-        // make the new tiling window to float before merging it into the focused floating group
-        pWindow->m_bIsFloating = true;
-        m_lDwindleNodesData.remove(*PNODE);
-        g_pLayoutManager->getCurrentLayout()->onWindowCreatedFloating(pWindow);
+        if (PLASTWINDOW->m_bIsFloating) { // target: focused floating group
+            // make the new tiling window to float before merging it into the focused floating group
+            pWindow->m_bIsFloating = true;
+            g_pLayoutManager->getCurrentLayout()->onWindowCreatedFloating(pWindow);
+        }
 
         PLASTWINDOW->setGroupCurrent(pWindow);
         pWindow->applyGroupRules();

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -324,10 +324,9 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
         }
     }
 
-    // If the active window is a group and auto_group = true:
     static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
-    // Auto group the new tiling window if the focused window is a group
-    if (*AUTOGROUP && getNodeFromWindow(g_pCompositor->m_pLastWindow.lock()) != PNODE && g_pCompositor->m_pLastWindow &&
+    // Auto group the new tiling window if the focused window is a open group
+    if ((*AUTOGROUP || g_pInputManager->m_bWasDraggingWindow) && getNodeFromWindow(g_pCompositor->m_pLastWindow.lock()) != PNODE && g_pCompositor->m_pLastWindow &&
         g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow                                         // target: active group
         && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock()) && !m_vOverrideFocalPoint) { // we are not moving window
 

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -328,7 +328,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
     // Auto group the new tiling window if the focused window is a open group
     if ((*AUTOGROUP || g_pInputManager->m_bWasDraggingWindow) && g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->m_pWorkspace == pWindow->m_pWorkspace &&
         getNodeFromWindow(g_pCompositor->m_pLastWindow.lock()) != PNODE && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow.lock() // target: active group
-        && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock()) && !m_vOverrideFocalPoint) {                                   // we are not moving window
+        && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock())) {
 
         m_lDwindleNodesData.remove(*PNODE);
 

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -324,22 +324,6 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
         }
     }
 
-    // if it's the first, it's easy. Make it fullscreen.
-    if (!OPENINGON || OPENINGON->pWindow.lock() == pWindow) {
-        PNODE->box = CBox{PMONITOR->vecPosition + PMONITOR->vecReservedTopLeft, PMONITOR->vecSize - PMONITOR->vecReservedTopLeft - PMONITOR->vecReservedBottomRight};
-
-        applyNodeDataToWindow(PNODE);
-
-        pWindow->applyGroupRules();
-
-        return;
-    }
-
-    if (!m_vOverrideFocalPoint && g_pInputManager->m_bWasDraggingWindow) {
-        if (OPENINGON->pWindow->checkInputOnDecos(INPUT_TYPE_DRAG_END, MOUSECOORDS, pWindow))
-            return;
-    }
-
     // If the active window is a group and auto_group = true:
     static auto AUTOGROUP   = CConfigValue<Hyprlang::INT>("group:auto_group");
     const auto  PLASTWINDOW = g_pCompositor->m_pLastWindow;
@@ -371,7 +355,23 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
         return;
     }
 
-    // If it's not, get the node under our cursor
+    // if it's the first, it's easy. Make it fullscreen.
+    if (!OPENINGON || OPENINGON->pWindow.lock() == pWindow) {
+        PNODE->box = CBox{PMONITOR->vecPosition + PMONITOR->vecReservedTopLeft, PMONITOR->vecSize - PMONITOR->vecReservedTopLeft - PMONITOR->vecReservedBottomRight};
+
+        applyNodeDataToWindow(PNODE);
+
+        pWindow->applyGroupRules();
+
+        return;
+    }
+
+    if (!m_vOverrideFocalPoint && g_pInputManager->m_bWasDraggingWindow) {
+        if (OPENINGON->pWindow->checkInputOnDecos(INPUT_TYPE_DRAG_END, MOUSECOORDS, pWindow))
+            return;
+    }
+
+    // get the node under our cursor
 
     m_lDwindleNodesData.push_back(SDwindleNodeData());
     const auto NEWPARENT = &m_lDwindleNodesData.back();

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -82,23 +82,22 @@ void IHyprLayout::onWindowRemovedFloating(PHLWINDOW pWindow) {
 void IHyprLayout::onWindowCreatedFloating(PHLWINDOW pWindow) {
 
     // Auto group the new floating window if the focused window is a group
-    static auto AUTOGROUP   = CConfigValue<Hyprlang::INT>("group:auto_group");
-    const auto  PLASTWINDOW = g_pCompositor->m_pLastWindow;
-    if (*AUTOGROUP && PLASTWINDOW && PLASTWINDOW->m_sGroupData.pNextWindow // target: active group
-        && pWindow->canBeGroupedInto(PLASTWINDOW.lock())) {
+    static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
+    if (*AUTOGROUP && g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
+        && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock())) {
 
-        if (!PLASTWINDOW->m_bIsFloating) { // target: focused tiled group
+        if (!g_pCompositor->m_pLastWindow->m_bIsFloating) { // target: focused tiled group
             // make the new floating window to tile before merging it into the focused tiled group
             pWindow->m_bIsFloating = false;
             g_pLayoutManager->getCurrentLayout()->onWindowCreatedTiling(pWindow);
         }
 
-        if (PLASTWINDOW->m_bIsFloating) { // target: focused floating group
+        if (g_pCompositor->m_pLastWindow->m_bIsFloating) { // target: focused floating group
             static auto USECURRPOS = CConfigValue<Hyprlang::INT>("group:insert_after_current");
-            (*USECURRPOS ? PLASTWINDOW : PLASTWINDOW->getGroupTail())->insertWindowToGroup(pWindow);
+            (*USECURRPOS ? g_pCompositor->m_pLastWindow : g_pCompositor->m_pLastWindow->getGroupTail())->insertWindowToGroup(pWindow);
         }
 
-        PLASTWINDOW->setGroupCurrent(pWindow);
+        g_pCompositor->m_pLastWindow->setGroupCurrent(pWindow);
         pWindow->applyGroupRules();
         pWindow->updateWindowDecos();
         recalculateWindow(pWindow);

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -90,7 +90,7 @@ void IHyprLayout::onWindowCreatedFloating(PHLWINDOW pWindow) {
         if (!g_pCompositor->m_pLastWindow->m_bIsFloating) { // target: focused tiled group
             // make the new floating window to tile before merging it into the focused tiled group
             pWindow->m_bIsFloating = false;
-            g_pLayoutManager->getCurrentLayout()->onWindowCreatedTiling(pWindow);
+            g_pLayoutManager->getCurrentLayout()->onWindowCreated(pWindow);
         }
 
         if (g_pCompositor->m_pLastWindow->m_bIsFloating) { // target: focused floating group

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -81,14 +81,22 @@ void IHyprLayout::onWindowRemovedFloating(PHLWINDOW pWindow) {
 
 void IHyprLayout::onWindowCreatedFloating(PHLWINDOW pWindow) {
 
-    // auto group the new floating window if the focused window is a floating group
+    // Auto group the new floating window if the focused window is a group
     static auto AUTOGROUP   = CConfigValue<Hyprlang::INT>("group:auto_group");
     const auto  PLASTWINDOW = g_pCompositor->m_pLastWindow;
-    if (*AUTOGROUP && PLASTWINDOW && PLASTWINDOW->m_bIsFloating && PLASTWINDOW->m_sGroupData.pNextWindow // target is the focused floating group
+    if (*AUTOGROUP && PLASTWINDOW && PLASTWINDOW->m_sGroupData.pNextWindow // target: active group
         && pWindow->canBeGroupedInto(PLASTWINDOW.lock())) {
 
-        static auto USECURRPOS = CConfigValue<Hyprlang::INT>("group:insert_after_current");
-        (*USECURRPOS ? PLASTWINDOW : PLASTWINDOW->getGroupTail())->insertWindowToGroup(pWindow);
+        if (!PLASTWINDOW->m_bIsFloating) { // target: focused tiled group
+            // make the new floating window to tile before merging it into the focused tiled group
+            pWindow->m_bIsFloating = false;
+            g_pLayoutManager->getCurrentLayout()->onWindowCreatedTiling(pWindow);
+        }
+
+        if (PLASTWINDOW->m_bIsFloating) { // target: focused floating group
+            static auto USECURRPOS = CConfigValue<Hyprlang::INT>("group:insert_after_current");
+            (*USECURRPOS ? PLASTWINDOW : PLASTWINDOW->getGroupTail())->insertWindowToGroup(pWindow);
+        }
 
         PLASTWINDOW->setGroupCurrent(pWindow);
         pWindow->applyGroupRules();

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -9,29 +9,26 @@
 #include "../xwayland/XSurface.hpp"
 
 void IHyprLayout::onWindowCreated(PHLWINDOW pWindow, eDirection direction) {
+    CBox desiredGeometry = {};
+    g_pXWaylandManager->getGeometryForWindow(pWindow, &desiredGeometry);
+
+    if (desiredGeometry.width <= 5 || desiredGeometry.height <= 5) {
+        const auto PMONITOR          = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
+        pWindow->m_vLastFloatingSize = PMONITOR->vecSize / 2.f;
+    } else {
+        pWindow->m_vLastFloatingSize = Vector2D(desiredGeometry.width, desiredGeometry.height);
+    }
+
+    pWindow->m_vPseudoSize = pWindow->m_vLastFloatingSize;
 
     bool autoGrouped = IHyprLayout::onWindowCreatedAutoGroup(pWindow);
     if (autoGrouped)
         return;
 
-    if (pWindow->m_bIsFloating) {
+    if (pWindow->m_bIsFloating)
         onWindowCreatedFloating(pWindow);
-
-    } else {
-        CBox desiredGeometry = {};
-        g_pXWaylandManager->getGeometryForWindow(pWindow, &desiredGeometry);
-
-        if (desiredGeometry.width <= 5 || desiredGeometry.height <= 5) {
-            const auto PMONITOR          = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
-            pWindow->m_vLastFloatingSize = PMONITOR->vecSize / 2.f;
-        } else {
-            pWindow->m_vLastFloatingSize = Vector2D(desiredGeometry.width, desiredGeometry.height);
-        }
-
-        pWindow->m_vPseudoSize = pWindow->m_vLastFloatingSize;
-
+    else
         onWindowCreatedTiling(pWindow, direction);
-    }
 }
 
 void IHyprLayout::onWindowRemoved(PHLWINDOW pWindow) {

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -84,7 +84,7 @@ void IHyprLayout::onWindowCreatedFloating(PHLWINDOW pWindow) {
     // Auto group the new floating window if the focused window is a open group
     static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
     if ((*AUTOGROUP || g_pInputManager->m_bWasDraggingWindow) && g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->m_pWorkspace == pWindow->m_pWorkspace &&
-        g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
+        g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
         && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock())) {
 
         if (!g_pCompositor->m_pLastWindow->m_bIsFloating) { // target: focused tiled group

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -84,7 +84,7 @@ void IHyprLayout::onWindowCreatedFloating(PHLWINDOW pWindow) {
     // Auto group the new floating window if the focused window is a open group
     static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
     if ((*AUTOGROUP || g_pInputManager->m_bWasDraggingWindow) && g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->m_pWorkspace == pWindow->m_pWorkspace &&
-        g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
+        g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow.lock() // target: active group
         && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock())) {
 
         if (!g_pCompositor->m_pLastWindow->m_bIsFloating) { // target: focused tiled group

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -85,7 +85,7 @@ void IHyprLayout::onWindowCreatedFloating(PHLWINDOW pWindow) {
     static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
     if ((*AUTOGROUP || g_pInputManager->m_bWasDraggingWindow) && g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->m_pWorkspace == pWindow->m_pWorkspace &&
         g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow.lock() // target: active group
-        && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock())) {
+        && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock()) && !g_pXWaylandManager->shouldBeFloated(pWindow)) {
 
         if (!g_pCompositor->m_pLastWindow->m_bIsFloating) { // target: focused tiled group
             // make the new floating window to tile before merging it into the focused tiled group

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -15,9 +15,8 @@ void IHyprLayout::onWindowCreated(PHLWINDOW pWindow, eDirection direction) {
     if (desiredGeometry.width <= 5 || desiredGeometry.height <= 5) {
         const auto PMONITOR          = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
         pWindow->m_vLastFloatingSize = PMONITOR->vecSize / 2.f;
-    } else {
+    } else
         pWindow->m_vLastFloatingSize = Vector2D(desiredGeometry.width, desiredGeometry.height);
-    }
 
     pWindow->m_vPseudoSize = pWindow->m_vLastFloatingSize;
 

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -81,10 +81,10 @@ void IHyprLayout::onWindowRemovedFloating(PHLWINDOW pWindow) {
 
 void IHyprLayout::onWindowCreatedFloating(PHLWINDOW pWindow) {
 
-    // auto group the window if the last window is a floating group
-    static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
-    const auto PLASTWINDOW = g_pCompositor->m_pLastWindow;
-    if (*AUTOGROUP && PLASTWINDOW && PLASTWINDOW->m_bIsFloating && PLASTWINDOW->m_sGroupData.pNextWindow // target is a floating group
+    // auto group the new floating window if the focused window is a floating group
+    static auto AUTOGROUP   = CConfigValue<Hyprlang::INT>("group:auto_group");
+    const auto  PLASTWINDOW = g_pCompositor->m_pLastWindow;
+    if (*AUTOGROUP && PLASTWINDOW && PLASTWINDOW->m_bIsFloating && PLASTWINDOW->m_sGroupData.pNextWindow // target is the focused floating group
         && pWindow->canBeGroupedInto(PLASTWINDOW.lock())) {
 
         static auto USECURRPOS = CConfigValue<Hyprlang::INT>("group:insert_after_current");

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -81,9 +81,9 @@ void IHyprLayout::onWindowRemovedFloating(PHLWINDOW pWindow) {
 
 void IHyprLayout::onWindowCreatedFloating(PHLWINDOW pWindow) {
 
-    // Auto group the new floating window if the focused window is a group
+    // Auto group the new floating window if the focused window is a open group
     static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
-    if (*AUTOGROUP && g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
+    if ((*AUTOGROUP || g_pInputManager->m_bWasDraggingWindow) && g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
         && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock())) {
 
         if (!g_pCompositor->m_pLastWindow->m_bIsFloating) { // target: focused tiled group

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -83,7 +83,8 @@ void IHyprLayout::onWindowCreatedFloating(PHLWINDOW pWindow) {
 
     // Auto group the new floating window if the focused window is a open group
     static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
-    if ((*AUTOGROUP || g_pInputManager->m_bWasDraggingWindow) && g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
+    if ((*AUTOGROUP || g_pInputManager->m_bWasDraggingWindow) && g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->m_pWorkspace == pWindow->m_pWorkspace &&
+        g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
         && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock())) {
 
         if (!g_pCompositor->m_pLastWindow->m_bIsFloating) { // target: focused tiled group

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -47,6 +47,7 @@ class IHyprLayout {
     virtual void onWindowCreated(PHLWINDOW, eDirection direction = DIRECTION_DEFAULT);
     virtual void onWindowCreatedTiling(PHLWINDOW, eDirection direction = DIRECTION_DEFAULT) = 0;
     virtual void onWindowCreatedFloating(PHLWINDOW);
+    virtual bool onWindowCreatedAutoGroup(PHLWINDOW);
 
     /*
         Return tiled status

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -116,8 +116,10 @@ void CHyprMasterLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dire
             return;
     }
 
+    // If the active window is a group and auto_group = true:
     static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
-    // auto group the window if OPENINGON is a tiled group
+
+    // auto group the new tiling window if OPENINGON is a tiled group
     if (*AUTOGROUP && OPENINGON && OPENINGON != PNODE && OPENINGON->pWindow->m_sGroupData.pNextWindow.lock() // target is a tiled group
         && pWindow->canBeGroupedInto(OPENINGON->pWindow.lock())) {
 
@@ -139,10 +141,10 @@ void CHyprMasterLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dire
 
     // auto group the new tiling window if the focused window is a floating group
     const auto PLASTWINDOW = g_pCompositor->m_pLastWindow;
-    if (*AUTOGROUP && PLASTWINDOW && PLASTWINDOW->m_bIsFloating && PLASTWINDOW->m_sGroupData.pNextWindow // target is a floating group
+    if (*AUTOGROUP && PLASTWINDOW && PLASTWINDOW->m_bIsFloating && PLASTWINDOW->m_sGroupData.pNextWindow // target is the focused floating group
         && pWindow->canBeGroupedInto(PLASTWINDOW.lock())) {
 
-        // make the new window floating before merging into the focused floating group
+        // make the new tiling window to float before merging it into the focused floating group
         pWindow->m_bIsFloating = true;
         m_lMasterNodesData.remove(*PNODE);
         g_pLayoutManager->getCurrentLayout()->onWindowCreatedFloating(pWindow);

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -119,7 +119,7 @@ void CHyprMasterLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dire
     static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
     // Auto group the new tiling window if the focused window is a open group
     if ((*AUTOGROUP || g_pInputManager->m_bWasDraggingWindow) && g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->m_pWorkspace == pWindow->m_pWorkspace &&
-        getNodeFromWindow(g_pCompositor->m_pLastWindow.lock()) != PNODE && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
+        getNodeFromWindow(g_pCompositor->m_pLastWindow.lock()) != PNODE && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow.lock() // target: active group
         && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock())) {
 
         m_lMasterNodesData.remove(*PNODE);

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -119,7 +119,7 @@ void CHyprMasterLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dire
     // If the active window is a group and auto_group = true:
     static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
     // Auto group the new tiling window if the focused window is a group
-    if (*AUTOGROUP && g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
+    if (*AUTOGROUP && OPENINGON != PNODE && g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
         && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock())) {
 
         m_lMasterNodesData.remove(*PNODE);

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -76,10 +76,6 @@ void CHyprMasterLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dire
     if (pWindow->m_bIsFloating)
         return;
 
-    bool autoGrouped = IHyprLayout::onWindowCreatedAutoGroup(pWindow);
-    if (autoGrouped)
-        return;
-
     static auto PNEWONACTIVE = CConfigValue<std::string>("master:new_on_active");
     static auto PNEWONTOP    = CConfigValue<Hyprlang::INT>("master:new_on_top");
     static auto PNEWSTATUS   = CConfigValue<std::string>("master:new_status");

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -136,7 +136,8 @@ void CHyprMasterLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dire
 
         return;
     }
-    // auto group the window if the last window is a floating group
+
+    // auto group the new tiling window if the focused window is a floating group
     const auto PLASTWINDOW = g_pCompositor->m_pLastWindow;
     if (*AUTOGROUP && PLASTWINDOW && PLASTWINDOW->m_bIsFloating && PLASTWINDOW->m_sGroupData.pNextWindow // target is a floating group
         && pWindow->canBeGroupedInto(PLASTWINDOW.lock())) {

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -140,10 +140,11 @@ void CHyprMasterLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dire
     const auto PLASTWINDOW = g_pCompositor->m_pLastWindow;
     if (*AUTOGROUP && PLASTWINDOW && PLASTWINDOW->m_bIsFloating && PLASTWINDOW->m_sGroupData.pNextWindow // target is a floating group
         && pWindow->canBeGroupedInto(PLASTWINDOW.lock())) {
-        m_lMasterNodesData.remove(*PNODE);
 
-        static auto USECURRPOS = CConfigValue<Hyprlang::INT>("group:insert_after_current");
-        (*USECURRPOS ? PLASTWINDOW : PLASTWINDOW->getGroupTail())->insertWindowToGroup(pWindow);
+        // make the new window floating before merging into the focused floating group
+        pWindow->m_bIsFloating = true;
+        m_lMasterNodesData.remove(*PNODE);
+        g_pLayoutManager->getCurrentLayout()->onWindowCreatedFloating(pWindow);
 
         PLASTWINDOW->setGroupCurrent(pWindow);
         pWindow->applyGroupRules();

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -119,8 +119,7 @@ void CHyprMasterLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dire
     static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
     // Auto group the new tiling window if the focused window is a open group
     if ((*AUTOGROUP || g_pInputManager->m_bWasDraggingWindow) && g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->m_pWorkspace == pWindow->m_pWorkspace &&
-        getNodeFromWindow(g_pCompositor->m_pLastWindow.lock()) != PNODE && g_pCompositor->m_pLastWindow &&
-        g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
+        getNodeFromWindow(g_pCompositor->m_pLastWindow.lock()) != PNODE && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
         && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock())) {
 
         m_lMasterNodesData.remove(*PNODE);

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -117,26 +117,25 @@ void CHyprMasterLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dire
     }
 
     // If the active window is a group and auto_group = true:
-    static auto AUTOGROUP   = CConfigValue<Hyprlang::INT>("group:auto_group");
-    const auto  PLASTWINDOW = g_pCompositor->m_pLastWindow;
+    static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
     // Auto group the new tiling window if the focused window is a group
-    if (*AUTOGROUP && PLASTWINDOW && PLASTWINDOW->m_sGroupData.pNextWindow // target: active group
-        && pWindow->canBeGroupedInto(PLASTWINDOW.lock())) {
+    if (*AUTOGROUP && g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
+        && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock())) {
 
         m_lMasterNodesData.remove(*PNODE);
 
-        if (!PLASTWINDOW->m_bIsFloating) { // target: focused tiled group
+        if (!g_pCompositor->m_pLastWindow->m_bIsFloating) { // target: focused tiled group
             static auto USECURRPOS = CConfigValue<Hyprlang::INT>("group:insert_after_current");
-            (*USECURRPOS ? PLASTWINDOW : PLASTWINDOW->getGroupTail())->insertWindowToGroup(pWindow);
+            (*USECURRPOS ? g_pCompositor->m_pLastWindow : g_pCompositor->m_pLastWindow->getGroupTail())->insertWindowToGroup(pWindow);
         }
 
-        if (PLASTWINDOW->m_bIsFloating) { // target: focused floating group
+        if (g_pCompositor->m_pLastWindow->m_bIsFloating) { // target: focused floating group
             // make the new tiling window to float before merging it into the focused floating group
             pWindow->m_bIsFloating = true;
             g_pLayoutManager->getCurrentLayout()->onWindowCreatedFloating(pWindow);
         }
 
-        PLASTWINDOW->setGroupCurrent(pWindow);
+        g_pCompositor->m_pLastWindow->setGroupCurrent(pWindow);
         pWindow->applyGroupRules();
         pWindow->updateWindowDecos();
         recalculateWindow(pWindow);

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -132,7 +132,7 @@ void CHyprMasterLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dire
         if (g_pCompositor->m_pLastWindow->m_bIsFloating) { // target: focused floating group
             // make the new tiling window to float before merging it into the focused floating group
             pWindow->m_bIsFloating = true;
-            g_pLayoutManager->getCurrentLayout()->onWindowCreatedFloating(pWindow);
+            g_pLayoutManager->getCurrentLayout()->onWindowCreated(pWindow);
         }
 
         g_pCompositor->m_pLastWindow->setGroupCurrent(pWindow);

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -118,7 +118,8 @@ void CHyprMasterLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dire
 
     static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
     // Auto group the new tiling window if the focused window is a open group
-    if ((*AUTOGROUP || g_pInputManager->m_bWasDraggingWindow) && getNodeFromWindow(g_pCompositor->m_pLastWindow.lock()) != PNODE && g_pCompositor->m_pLastWindow &&
+    if ((*AUTOGROUP || g_pInputManager->m_bWasDraggingWindow) && g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->m_pWorkspace == pWindow->m_pWorkspace &&
+        getNodeFromWindow(g_pCompositor->m_pLastWindow.lock()) != PNODE && g_pCompositor->m_pLastWindow &&
         g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
         && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock())) {
 

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -118,7 +118,7 @@ void CHyprMasterLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dire
 
     static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
     // Auto group the new tiling window if the focused window is a open group
-    if ((*AUTOGROUP || g_pInputManager->m_bWasDraggingWindow) && OPENINGON != PNODE && g_pCompositor->m_pLastWindow &&
+    if ((*AUTOGROUP || g_pInputManager->m_bWasDraggingWindow) && getNodeFromWindow(g_pCompositor->m_pLastWindow.lock()) != PNODE && g_pCompositor->m_pLastWindow &&
         g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
         && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock())) {
 

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -116,10 +116,10 @@ void CHyprMasterLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dire
             return;
     }
 
-    // If the active window is a group and auto_group = true:
     static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
-    // Auto group the new tiling window if the focused window is a group
-    if (*AUTOGROUP && OPENINGON != PNODE && g_pCompositor->m_pLastWindow && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
+    // Auto group the new tiling window if the focused window is a open group
+    if ((*AUTOGROUP || g_pInputManager->m_bWasDraggingWindow) && OPENINGON != PNODE && g_pCompositor->m_pLastWindow &&
+        g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow // target: active group
         && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock())) {
 
         m_lMasterNodesData.remove(*PNODE);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
The behavior before this was to auto group only tiled groups when the tiling mode was enabled (allfloat=false on the workspace). This PR gives you the auto group feature for tiled and floating groups when the tiling mode is enabled and also when the floating mode is enabled (allfloat=true on the workspace).

Furthermore, this gives you the freedom to configure whether new windows will be automatically grouped into the focused unlocked group. [Wiki](https://github.com/hyprwm/hyprland-wiki/pull/783/files)

Fixes: https://github.com/hyprwm/Hyprland/issues/7840

#### Is it ready for merging, or does it need work?
It is ready.