### PR TITLE
CMake, Meson: suproject improvements

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -25,4 +25,4 @@ jobs:
           name: hyprland
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
-      - run: nix build 'git+https://github.com/hyprwm/Hyprland?ref=${{ github.ref }}&submodules=1#${{ matrix.package }}' -L --extra-substituters "https://hyprland.cachix.org"
+      - run: nix build 'git+https://github.com/hyprwm/Hyprland?ref=${{ github.ref }}#${{ matrix.package }}' -L --extra-substituters "https://hyprland.cachix.org"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,7 @@ add_custom_target(generate-protocol-headers)
 
 function(protocolnew protoPath protoName external)
   if(external)
-    set(path ${CMAKE_SOURCE_DIR}/${protoPath})
+    set(path ${protoPath})
   else()
     set(path ${WAYLAND_PROTOCOLS_DIR}/${protoPath})
   endif()
@@ -261,11 +261,20 @@ endfunction()
 target_link_libraries(Hyprland OpenGL::EGL OpenGL::GL Threads::Threads
                       libudis86)
 
-protocolnew("subprojects/hyprland-protocols/protocols"
-            "hyprland-global-shortcuts-v1" true)
+pkg_check_modules(hyprland_protocols_dep hyprland-protocols>=0.2.0)
+if(hyprland_protocols_dep_FOUND)
+  pkg_get_variable(HYPRLAND_PROTOCOLS hyprland-protocols pkgdatadir)
+  message(STATUS "hyprland-protocols dependency set to ${HYPRLAND_PROTOCOLS}")
+else()
+  set(HYPRLAND_PROTOCOLS "subprojects/hyprland-protocols")
+  message(STATUS "hyprland-protocols subproject set to ${HYPRLAND_PROTOCOLS}")
+endif()
+
+protocolnew("${HYPRLAND_PROTOCOLS}/protocols" "hyprland-global-shortcuts-v1"
+            true)
 protocolnew("unstable/text-input" "text-input-unstable-v1" false)
-protocolnew("subprojects/hyprland-protocols/protocols"
-            "hyprland-toplevel-export-v1" true)
+protocolnew("${HYPRLAND_PROTOCOLS}/protocols" "hyprland-toplevel-export-v1"
+            true)
 protocolnew("protocols" "wlr-screencopy-unstable-v1" true)
 protocolnew("protocols" "wlr-gamma-control-unstable-v1" true)
 protocolnew("protocols" "wlr-foreign-toplevel-management-unstable-v1" true)
@@ -276,8 +285,7 @@ protocolnew("protocols" "input-method-unstable-v2" true)
 protocolnew("protocols" "wlr-output-management-unstable-v1" true)
 protocolnew("protocols" "kde-server-decoration" true)
 protocolnew("protocols" "wlr-data-control-unstable-v1" true)
-protocolnew("subprojects/hyprland-protocols/protocols" "hyprland-focus-grab-v1"
-            true)
+protocolnew("${HYPRLAND_PROTOCOLS}/protocols" "hyprland-focus-grab-v1" true)
 protocolnew("protocols" "wlr-layer-shell-unstable-v1" true)
 protocolnew("protocols" "wayland-drm" true)
 protocolnew("staging/tearing-control" "tearing-control-v1" false)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,8 +25,18 @@ message(STATUS "Gathering git info")
 execute_process(COMMAND ./scripts/generateVersion.sh
                 WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
-# udis
-add_subdirectory("subprojects/udis86")
+find_package(PkgConfig REQUIRED)
+
+# Try to find canihavesomecoffee's udis86 using pkgconfig vmd/udis86 does not
+# provide a .pc file and won't be detected this way
+pkg_check_modules(udis_dep IMPORTED_TARGET udis86>=1.7.2)
+
+# Fallback to subproject
+if(NOT udis_dep_FOUND)
+  add_subdirectory("subprojects/udis86")
+  include_directories("subprojects/udis86")
+  message(STATUS "udis86 dependency not found, falling back to subproject")
+endif()
 
 if(CMAKE_BUILD_TYPE)
   string(TOLOWER ${CMAKE_BUILD_TYPE} BUILDTYPE_LOWER)
@@ -47,8 +57,6 @@ else()
   set(BUILDTYPE_LOWER "release")
 endif()
 
-find_package(PkgConfig REQUIRED)
-
 pkg_get_variable(WAYLAND_PROTOCOLS_DIR wayland-protocols pkgdatadir)
 message(STATUS "Found wayland-protocols at ${WAYLAND_PROTOCOLS_DIR}")
 pkg_get_variable(WAYLAND_SCANNER_PKGDATA_DIR wayland-scanner pkgdatadir)
@@ -63,7 +71,8 @@ else()
   message(STATUS "Configuring Hyprland in Release with CMake")
 endif()
 
-include_directories(. "src/" "subprojects/udis86/" "protocols/")
+include_directories(. "src/" "protocols/")
+
 set(CMAKE_CXX_STANDARD 26)
 add_compile_options(
   -Wall
@@ -224,6 +233,11 @@ target_precompile_headers(Hyprland PRIVATE
 message(STATUS "Setting link libraries")
 
 target_link_libraries(Hyprland rt PkgConfig::aquamarine_dep PkgConfig::deps)
+if(udis_dep_FOUND)
+  target_link_libraries(Hyprland PkgConfig::udis_dep)
+else()
+  target_link_libraries(Hyprland libudis86)
+endif()
 
 # used by `make installheaders`, to ensure the headers are generated
 add_custom_target(generate-protocol-headers)
@@ -258,8 +272,7 @@ function(protocolWayland)
                  PRIVATE ${CMAKE_SOURCE_DIR}/protocols/wayland.hpp)
 endfunction()
 
-target_link_libraries(Hyprland OpenGL::EGL OpenGL::GL Threads::Threads
-                      libudis86)
+target_link_libraries(Hyprland OpenGL::EGL OpenGL::GL Threads::Threads)
 
 pkg_check_modules(hyprland_protocols_dep hyprland-protocols>=0.2.0)
 if(hyprland_protocols_dep_FOUND)

--- a/flake.lock
+++ b/flake.lock
@@ -58,6 +58,29 @@
     "hyprland-protocols": {
       "inputs": {
         "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": [
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1721326555,
+        "narHash": "sha256-zCu4R0CSHEactW9JqYki26gy8h9f6rHmSwj4XJmlHgg=",
+        "owner": "hyprwm",
+        "repo": "hyprland-protocols",
+        "rev": "5a11232266bf1a1f5952d5b179c3f4b2facaaa84",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprland-protocols",
+        "type": "github"
+      }
+    },
+    "hyprland-protocols_2": {
+      "inputs": {
+        "nixpkgs": [
           "xdph",
           "nixpkgs"
         ],
@@ -172,6 +195,7 @@
       "inputs": {
         "aquamarine": "aquamarine",
         "hyprcursor": "hyprcursor",
+        "hyprland-protocols": "hyprland-protocols",
         "hyprlang": "hyprlang",
         "hyprutils": "hyprutils",
         "hyprwayland-scanner": "hyprwayland-scanner",
@@ -197,7 +221,7 @@
     },
     "xdph": {
       "inputs": {
-        "hyprland-protocols": "hyprland-protocols",
+        "hyprland-protocols": "hyprland-protocols_2",
         "hyprlang": [
           "hyprlang"
         ],

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,12 @@
       inputs.hyprlang.follows = "hyprlang";
     };
 
+    hyprland-protocols = {
+      url = "github:hyprwm/hyprland-protocols";
+      inputs.nixpkgs.follows = "nixpkgs";
+      inputs.systems.follows = "systems";
+    };
+
     hyprlang = {
       url = "github:hyprwm/hyprlang";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/meson.build
+++ b/meson.build
@@ -43,10 +43,6 @@ xcb_xfixes_dep = dependency('xcb-xfixes', required: get_option('xwayland'))
 
 gio_dep = dependency('gio-2.0', required: true)
 
-cmake = import('cmake')
-udis = cmake.subproject('udis86')
-udis86 = udis.dependency('libudis86')
-
 if not xcb_dep.found()
   add_project_arguments('-DNO_XWAYLAND', language: 'cpp')
 endif

--- a/meson.build
+++ b/meson.build
@@ -73,6 +73,12 @@ foreach file : headers
   install_headers(file, subdir: 'hyprland', preserve_path: true)
 endforeach
 
+tracy = dependency('tracy', static: true, required: get_option('tracy_enable'))
+
+if get_option('tracy_enable') and get_option('buildtype') != 'debugoptimized'
+  warning('Profiling builds should set -- buildtype = debugoptimized')
+endif
+
 subdir('protocols')
 subdir('src')
 subdir('hyprctl')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('xwayland', type: 'feature', value: 'auto', description: 'Enable support for X11 applications')
 option('systemd', type: 'feature', value: 'auto', description: 'Enable systemd integration')
 option('legacy_renderer', type: 'feature', value: 'disabled', description: 'Enable legacy renderer')
+option('tracy_enable', type: 'boolean', value: false , description: 'Enable profiling')

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -13,6 +13,7 @@
   cairo,
   git,
   hyprcursor,
+  hyprland-protocols,
   hyprlang,
   hyprutils,
   hyprwayland-scanner,
@@ -116,6 +117,7 @@ in
           cairo
           git
           hyprcursor
+          hyprland-protocols
           hyprlang
           hyprutils
           libdrm

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -144,7 +144,7 @@ in
 
       mesonBuildType =
         if debug
-        then "debug"
+        then "debugoptimized"
         else "release";
 
       # we want as much debug info as possible
@@ -156,7 +156,10 @@ in
           "legacy_renderer" = legacyRenderer;
           "systemd" = withSystemd;
         })
-        (mesonBool "b_pch" false)
+        (mapAttrsToList mesonBool {
+          "b_pch" = false;
+          "tracy_enable" = false;
+        })
       ];
 
       postInstall = ''

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -6,7 +6,6 @@
   pkgconf,
   makeWrapper,
   meson,
-  cmake,
   ninja,
   aquamarine,
   binutils,
@@ -17,7 +16,6 @@
   hyprlang,
   hyprutils,
   hyprwayland-scanner,
-  jq,
   libGL,
   libdrm,
   libexecinfo,
@@ -27,9 +25,9 @@
   mesa,
   pango,
   pciutils,
-  python3,
   systemd,
   tomlplusplus,
+  udis86-hyprland,
   wayland,
   wayland-protocols,
   wayland-scanner,
@@ -96,13 +94,10 @@ in
 
       nativeBuildInputs = [
         hyprwayland-scanner
-        jq
         makeWrapper
         meson
-        cmake
         ninja
         pkg-config
-        python3 # for udis86
       ];
 
       outputs = [
@@ -129,6 +124,7 @@ in
           pango
           pciutils
           tomlplusplus
+          udis86-hyprland
           wayland
           wayland-protocols
           wayland-scanner

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -22,6 +22,7 @@ in {
     # Dependencies
     inputs.aquamarine.overlays.default
     inputs.hyprcursor.overlays.default
+    inputs.hyprland-protocols.overlays.default
     inputs.hyprlang.overlays.default
     inputs.hyprutils.overlays.default
     inputs.hyprwayland-scanner.overlays.default

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -26,6 +26,7 @@ in {
     inputs.hyprlang.overlays.default
     inputs.hyprutils.overlays.default
     inputs.hyprwayland-scanner.overlays.default
+    self.overlays.udis86
 
     # Hyprland packages themselves
     (final: prev: let
@@ -64,4 +65,20 @@ in {
   hyprland-extras = lib.composeManyExtensions [
     inputs.xdph.overlays.xdg-desktop-portal-hyprland
   ];
+
+  # udis86 from nixpkgs is too old, and also does not provide a .pc file
+  # this version is the one used in the git submodule, and allows us to
+  # fetch the source without '?submodules=1'
+  udis86 = final: prev: {
+    udis86-hyprland = prev.udis86.overrideAttrs (self: super: {
+      src = final.fetchFromGitHub {
+        owner = "canihavesomecoffee";
+        repo = "udis86";
+        rev = "5336633af70f3917760a6d441ff02d93477b0c86";
+        hash = "sha256-HifdUQPGsKQKQprByeIznvRLONdOXeolOsU5nkwIv3g=";
+      };
+
+      patches = [];
+    });
+  };
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -31,6 +31,7 @@ executable(
     backtrace_dep,
     epoll_dep,
     gio_dep,
+    tracy,
 
     # Try to find canihavesomecoffee's udis86 using pkgconfig
     # vmt/udis86 does not provide a .pc file and won't be detected this way

--- a/src/meson.build
+++ b/src/meson.build
@@ -31,7 +31,11 @@ executable(
     backtrace_dep,
     epoll_dep,
     gio_dep,
-    udis86,
+
+    # Try to find canihavesomecoffee's udis86 using pkgconfig
+    # vmt/udis86 does not provide a .pc file and won't be detected this way
+    # Falls back to using the subproject through udis86.wrap
+    dependency('udis86'),
 
     dependency('pixman-1'),
     dependency('gl', 'opengl'),

--- a/subprojects/tracy.wrap
+++ b/subprojects/tracy.wrap
@@ -1,0 +1,1 @@
+[wrap-file]

--- a/subprojects/udis86.wrap
+++ b/subprojects/udis86.wrap
@@ -1,0 +1,5 @@
+[wrap-file]
+method = cmake
+
+[provide]
+udis86 = libudis86_dep


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Meson: try to find udis86 through pkgconfig, fallback to subproject. Adds Nix overlay with udis86 fork -> 2 remaining subproject for Nix
Nix: re-add hyprland-protocols -> 1 remaining subprojects for nix
CMake: use hyprland-protocols from pkg-config, fallback to subproject
CMake: use udis86 from pkg-config, fallback to subproject
Meson: add tracy dependency -> no more subproject deps for nix, unless wanted

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Tested various toggles, subprojects/no subprojects. If anyone wants to test feel free.

#### Is it ready for merging, or does it need work?

Should be ready.
