### PR TITLE
add movetoroot method to dwindle layout

### DIFF
--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -994,7 +994,7 @@ std::any CHyprDwindleLayout::layoutMessage(SLayoutMessageHeader header, std::str
         swapSplit(header.pWindow);
     } else if (ARGS[0] == "movetoroot") {
         const auto WINDOW = ARGS[1].empty() ? header.pWindow : g_pCompositor->getWindowByRegex(ARGS[1]);
-        const auto STABLE = ARGS[2].empty() || std::stoi(ARGS[2]) != 0;
+        const auto STABLE = ARGS[2].empty() || ARGS[2] != "unstable";
         moveToRoot(WINDOW, STABLE);
     } else if (ARGS[0] == "preselect") {
         std::string direction = ARGS[1];

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -993,11 +993,9 @@ std::any CHyprDwindleLayout::layoutMessage(SLayoutMessageHeader header, std::str
     } else if (ARGS[0] == "swapsplit") {
         swapSplit(header.pWindow);
     } else if (ARGS[0] == "movetoroot") {
-        std::string stable = ARGS[1];
-        if (stable.empty() || std::stoi(ARGS[1]) != 0)
-            moveToRoot(header.pWindow);
-        else
-            moveToRoot(header.pWindow, false);
+        const auto WINDOW = ARGS[1].empty() ? header.pWindow : g_pCompositor->getWindowByRegex(ARGS[1]);
+        const auto STABLE = ARGS[2].empty() || std::stoi(ARGS[2]) != 0;
+        moveToRoot(WINDOW, STABLE);
     } else if (ARGS[0] == "preselect") {
         std::string direction = ARGS[1];
 
@@ -1098,7 +1096,9 @@ void CHyprDwindleLayout::moveToRoot(PHLWINDOW pWindow, bool stable) {
     if (stable)
         std::swap(pRoot->children[0], pRoot->children[1]);
 
-    pRoot->recalcSizePosRecursive();
+    // if the workspace is visible, recalculate layout
+    if (g_pCompositor->isWorkspaceVisible(pWindow->m_pWorkspace))
+        pRoot->recalcSizePosRecursive();
 }
 
 void CHyprDwindleLayout::replaceWindowDataWith(PHLWINDOW from, PHLWINDOW to) {

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -994,11 +994,10 @@ std::any CHyprDwindleLayout::layoutMessage(SLayoutMessageHeader header, std::str
         swapSplit(header.pWindow);
     } else if (ARGS[0] == "movetoroot") {
         std::string stable = ARGS[1];
-        if (stable.empty() || std::stoi(ARGS[1]) != 0) {
+        if (stable.empty() || std::stoi(ARGS[1]) != 0)
             moveToRoot(header.pWindow);
-        } else {
+        else
             moveToRoot(header.pWindow, false);
-        }
     } else if (ARGS[0] == "preselect") {
         std::string direction = ARGS[1];
 
@@ -1084,21 +1083,20 @@ void CHyprDwindleLayout::moveToRoot(PHLWINDOW pWindow, bool stable) {
     auto& pNode = PNODE->pParent->children[0] == PNODE ? PNODE->pParent->children[0] : PNODE->pParent->children[1];
 
     // instead of [getMasterNodeOnWorkspace], we walk back to root since we need
-    // to know which children of root is our ancester
-    auto pAncester = PNODE, pRoot = PNODE->pParent;
+    // to know which children of root is our ancestor
+    auto pAncestor = PNODE, pRoot = PNODE->pParent;
     while (pRoot->pParent) {
-        pAncester = pRoot;
+        pAncestor = pRoot;
         pRoot     = pRoot->pParent;
     }
 
-    auto& pSwap = pRoot->children[0] == pAncester ? pRoot->children[1] : pRoot->children[0];
+    auto& pSwap = pRoot->children[0] == pAncestor ? pRoot->children[1] : pRoot->children[0];
     std::swap(pNode, pSwap);
     std::swap(pNode->pParent, pSwap->pParent);
 
     // [stable] in that the focused window occupies same side of screen
-    if (stable) {
+    if (stable)
         std::swap(pRoot->children[0], pRoot->children[1]);
-    }
 
     pRoot->recalcSizePosRecursive();
 }

--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -87,6 +87,7 @@ class CHyprDwindleLayout : public IHyprLayout {
 
     void                    toggleSplit(PHLWINDOW);
     void                    swapSplit(PHLWINDOW);
+    void                    moveToRoot(PHLWINDOW, bool stable = true);
 
     eDirection              overrideDirection = DIRECTION_DEFAULT;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This pull request adds a `movetoroot` method to `layoutmsg` for dwindle layout. It "maximizes" the current window within the current workspace/layout by swapping it with the other sub-tree of the root node. In some sense, this is a replication of `swapwithmaster` method from the master layout.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This should not break anything. I used this [pull request](https://github.com/hyprwm/Hyprland/pull/4702) as a template, but I didn't bother adding another keybind seeing that `layoutmsg, movetoroot` just works. 

#### Is it ready for merging, or does it need work?

It is ready for merging as is.

Though I could imagine to optimize the implementation a bit by limit `recalcSizePosRescursive` to the active window and swapped sub-tree, but I'm not familiar with the codebase enough to make the judgement. I also don't think average user will have a layout tree big enough for the optimization to make a difference.