### PR TITLE
dwindle: add config option `split_bias`

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -446,6 +446,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("dwindle:no_gaps_when_only", Hyprlang::INT{0});
     m_pConfig->addConfigValue("dwindle:use_active_for_splits", Hyprlang::INT{1});
     m_pConfig->addConfigValue("dwindle:default_split_ratio", {1.f});
+    m_pConfig->addConfigValue("dwindle:split_bias", Hyprlang::INT{0});
     m_pConfig->addConfigValue("dwindle:smart_split", Hyprlang::INT{0});
     m_pConfig->addConfigValue("dwindle:smart_resizing", Hyprlang::INT{1});
 

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -1,7 +1,7 @@
 #include "DwindleLayout.hpp"
-#include "../render/decorations/CHyprGroupBarDecoration.hpp"
 #include "../Compositor.hpp"
 #include "../config/ConfigValue.hpp"
+#include "../render/decorations/CHyprGroupBarDecoration.hpp"
 
 void SDwindleNodeData::recalcSizePosRecursive(bool force, bool horizontalOverride, bool verticalOverride) {
     if (children[0]) {
@@ -458,6 +458,12 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
             NEWPARENT->children[1] = PNODE;
         }
     }
+
+    // split in favor of a specific window
+    const auto  first      = NEWPARENT->children[0];
+    static auto PSPLITBIAS = CConfigValue<Hyprlang::INT>("dwindle:split_bias");
+    if ((*PSPLITBIAS == 1 && first == PNODE) || (*PSPLITBIAS == 2 && first == OPENINGON))
+        NEWPARENT->splitRatio = 2.f - NEWPARENT->splitRatio;
 
     // and update the previous parent if it exists
     if (OPENINGON->pParent) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

If `default_split_ratio` is greater than 1.0, `split_bias` will give the bigger half to a specific window:

0 - positional (default)
1 - current window
2 - opening window

For example, using these settings:
```ini
dwindle {
    default_split_ratio = 1.2360679775 # 2/phi
    split_bias = 1 # current window
}
```
We can create a golden spiral

https://github.com/user-attachments/assets/0c877c5b-a0c8-4225-983e-ec3c17199ea5

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Not that I can think of.

#### Is it ready for merging, or does it need work?

Ready for merging.
