### PR TITLE
config: add descriptions for dwindle and master layout options

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1372,4 +1372,164 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .type        = CONFIG_OPTION_BOOL,
         .data        = SConfigOptionDescription::SBoolData{true},
     },
+
+    /*
+     * dwindle:
+     */
+
+    SConfigOptionDescription{
+        .value       = "dwindle:pseudotile",
+        .description = "enable pseudotiling. Pseudotiled windows retain their floating size when tiled.",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{false},
+    },
+    SConfigOptionDescription{
+        .value       = "dwindle:force_split",
+        .description = "0 -> split follows mouse, 1 -> always split to the left (new = left or top) 2 -> always split to the right (new = right or bottom)",
+        .type        = CONFIG_OPTION_CHOICE,
+        .data        = SConfigOptionDescription::SChoiceData{0, "follow mouse,left or top,right or bottom"},
+    },
+    SConfigOptionDescription{
+        .value       = "dwindle:preserve_split",
+        .description = "if enabled, the split (side/top) will not change regardless of what happens to the container.",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{false},
+    },
+    SConfigOptionDescription{
+        .value       = "dwindle:smart_split",
+        .description = "if enabled, allows a more precise control over the window split direction based on the cursor's position. The window is conceptually divided into four "
+                       "triangles, and cursor's triangle determines the split direction. This feature also turns on preserve_split.",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{false},
+    },
+    SConfigOptionDescription{
+        .value = "dwindle:smart_resizing",
+        .description =
+            "if enabled, resizing direction will be determined by the mouse's position on the window (nearest to which corner). Else, it is based on the window's tiling position.",
+        .type = CONFIG_OPTION_BOOL,
+        .data = SConfigOptionDescription::SBoolData{true},
+    },
+    SConfigOptionDescription{
+        .value       = "dwindle:permanent_direction_override",
+        .description = "if enabled, makes the preselect direction persist until either this mode is turned off, another direction is specified, or a non-direction is specified "
+                       "(anything other than l,r,u/t,d/b)",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{false},
+    },
+    SConfigOptionDescription{
+        .value       = "dwindle:special_scale_factor",
+        .description = "specifies the scale factor of windows on the special workspace [0 - 1]",
+        .type        = CONFIG_OPTION_FLOAT,
+        .data        = SConfigOptionDescription::SFloatData{1, 0, 1},
+    },
+    SConfigOptionDescription{
+        .value       = "dwindle:split_width_multiplier",
+        .description = "specifies the auto-split width multiplier",
+        .type        = CONFIG_OPTION_FLOAT,
+        .data        = SConfigOptionDescription::SFloatData{1, 0.1, 3},
+    },
+    SConfigOptionDescription{
+        .value       = "dwindle:no_gaps_when_only",
+        .description = "whether to apply gaps when there is only one window on a workspace, aka. smart gaps. (default: disabled - 0) no border - 1, with border - 2 [0/1/2]",
+        .type        = CONFIG_OPTION_CHOICE,
+        .data        = SConfigOptionDescription::SChoiceData{0, "disabled,no border,with border"},
+    },
+    SConfigOptionDescription{
+        .value       = "dwindle:use_active_for_splits",
+        .description = "whether to prefer the active window or the mouse position for splits",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{true},
+    },
+    SConfigOptionDescription{
+        .value       = "dwindle:default_split_ratio",
+        .description = "the default split ratio on window open. 1 means even 50/50 split. [0.1 - 1.9]",
+        .type        = CONFIG_OPTION_FLOAT,
+        .data        = SConfigOptionDescription::SFloatData{1, 0.1, 1.9},
+    },
+    SConfigOptionDescription{
+        .value       = "dwindle:split_bias",
+        .description = "specifies which window will receive the larger half of a split. positional - 0, current window - 1, opening window - 2 [0/1/2]",
+        .type        = CONFIG_OPTION_CHOICE,
+        .data        = SConfigOptionDescription::SChoiceData{0, "positional,current,opening"},
+    },
+
+    /*
+     * master:
+     */
+
+    SConfigOptionDescription{
+        .value       = "master:allow_small_split",
+        .description = "enable adding additional master windows in a horizontal split style",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{false},
+    },
+    SConfigOptionDescription{
+        .value       = "master:special_scale_factor",
+        .description = "the scale of the special workspace windows. [0.0 - 1.0]",
+        .type        = CONFIG_OPTION_FLOAT,
+        .data        = SConfigOptionDescription::SFloatData{1, 0, 1},
+    },
+    SConfigOptionDescription{
+        .value = "master:mfact",
+        .description =
+            "the size as a percentage of the master window, for example `mfact = 0.70` would mean 70% of the screen will be the master window, and 30% the slave [0.0 - 1.0]",
+        .type = CONFIG_OPTION_FLOAT,
+        .data = SConfigOptionDescription::SFloatData{0.55, 0, 1},
+    },
+    SConfigOptionDescription{
+        .value       = "master:new_status",
+        .description = "`master`: new window becomes master; `slave`: new windows are added to slave stack; `inherit`: inherit from focused window",
+        .type        = CONFIG_OPTION_STRING_SHORT,
+        .data        = SConfigOptionDescription::SStringData{"slave"},
+    },
+    SConfigOptionDescription{
+        .value       = "master:new_on_top",
+        .description = "whether a newly open window should be on the top of the stack",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{false},
+    },
+    SConfigOptionDescription{
+        .value       = "master:new_on_active",
+        .description = "`before`, `after`: place new window relative to the focused window; `none`: place new window according to the value of `new_on_top`. ",
+        .type        = CONFIG_OPTION_STRING_SHORT,
+        .data        = SConfigOptionDescription::SStringData{"none"},
+    },
+    SConfigOptionDescription{
+        .value       = "master:no_gaps_when_only",
+        .description = "whether to apply gaps when there is only one window on a workspace, aka. smart gaps. (default: disabled - 0) no border - 1, with border - 2 [0/1/2]",
+        .type        = CONFIG_OPTION_CHOICE,
+        .data        = SConfigOptionDescription::SChoiceData{0, "disabled,no border,with border"},
+    },
+    SConfigOptionDescription{
+        .value       = "master:orientation",
+        .description = "default placement of the master area, can be left, right, top, bottom or center",
+        .type        = CONFIG_OPTION_STRING_SHORT,
+        .data        = SConfigOptionDescription::SStringData{"left"},
+    },
+    SConfigOptionDescription{
+        .value       = "master:inherit_fullscreen",
+        .description = "inherit fullscreen status when cycling/swapping to another window (e.g. monocle layout)",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{true},
+    },
+    SConfigOptionDescription{
+        .value       = "master:always_center_master",
+        .description = "when using orientation=center, keep the master window centered, even when it is the only window in the workspace.",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{false},
+    },
+    SConfigOptionDescription{
+        .value = "master:smart_resizing",
+        .description =
+            "if enabled, resizing direction will be determined by the mouse's position on the window (nearest to which corner). Else, it is based on the window's tiling position.",
+        .type = CONFIG_OPTION_BOOL,
+        .data = SConfigOptionDescription::SBoolData{true},
+    },
+    SConfigOptionDescription{
+        .value       = "master:drop_at_cursor",
+        .description = "when enabled, dragging and dropping windows will put them at the cursor position. Otherwise, when dropped at the stack side, they will go to the "
+                       "top/bottom of the stack depending on new_on_top.",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{true},
+    },
 };


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Config options for the dwindle and master layouts need to be added to `ConfigDescriptions.hpp` as discussed here: https://github.com/hyprwm/Hyprland/pull/7920#issuecomment-2380281448

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

- `dwindle:split_width_multiplier` didn't specify an upper limit, so I gave it `std::numeric_limits<float>::max()`
- backticks from the wiki descriptions were left in, but I didn't see them in any of the other descriptions, so they might still need to be taken out.

#### Is it ready for merging, or does it need work?

Aside from what was mentioned, it's ready for merging.