### PR TITLE
Fix Musl builds

### DIFF
--- a/src/protocols/PresentationTime.cpp
+++ b/src/protocols/PresentationTime.cpp
@@ -58,8 +58,8 @@ void CPresentationFeedback::sendQueued(SP<CQueuedPresentationData> data, timespe
     if (reportedFlags & Aquamarine::IOutput::AQ_OUTPUT_PRESENT_HW_COMPLETION)
         flags |= WP_PRESENTATION_FEEDBACK_KIND_HW_COMPLETION;
 
-    __time_t tv_sec = 0;
-    if (sizeof(__time_t) > 4)
+    time_t tv_sec = 0;
+    if (sizeof(time_t) > 4)
         tv_sec = when->tv_sec >> 32;
 
     if (data->wasPresented)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Musl does not include the glibc internal type `__time_t`, causing builds on Musl systems to fail. Use `time_t` instead.
Fixes #7858 
```
../hyprland-source/src/protocols/PresentationTime.cpp:61:5: error: unknown type name '__time_t'; did you mean 'time_t'?
   61 |     __time_t tv_sec = 0;
      |     ^~~~~~~~
      |     time_t
/usr/include/bits/alltypes.h:85:16: note: 'time_t' declared here
   85 | typedef _Int64 time_t;
      |                ^
../hyprland-source/src/protocols/PresentationTime.cpp:62:16: error: unknown type name '__time_t'; did you mean 'time_t'?
   62 |     if (sizeof(__time_t) > 4)
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I'm not sure _why_ __time_t is being used here?  



