### PR TITLE
fix: add missing include directive

### DIFF
--- a/src/helpers/SdDaemon.cpp
+++ b/src/helpers/SdDaemon.cpp
@@ -8,6 +8,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <string.h>
+#include <stdlib.h>
 #include <cstring>
 
 namespace Systemd {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This should fix building with clang. See https://github.com/hyprwm/Hyprland/discussions/7983

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

If it is better to use cstdio or cstdlib instead of stdlib.h please let me know.

#### Is it ready for merging, or does it need work?
