### PR TITLE
layout: add drag_into_group

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -778,6 +778,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .type        = CONFIG_OPTION_BOOL,
         .data        = SConfigOptionDescription::SBoolData{true},
     },
+    SConfigOptionDescription{
+        .value       = "group:drag_into_group",
+        .description = "whether dragging a window into a unlocked group will merge them. Options: 0 (disabled), 1 (enabled), 2 (only when dragging into the groupbar)",
+        .type        = CONFIG_OPTION_CHOICE,
+        .data        = SConfigOptionDescription::SChoiceData{0, "disabled,enabled,only when dragging into the groupbar"},
+    },
 
     /*
      * group:groupbar:

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -378,6 +378,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("group:focus_removed_window", Hyprlang::INT{1});
     m_pConfig->addConfigValue("group:merge_groups_on_drag", Hyprlang::INT{1});
     m_pConfig->addConfigValue("group:auto_group", Hyprlang::INT{1});
+    m_pConfig->addConfigValue("group:drag_into_group", Hyprlang::INT{1});
     m_pConfig->addConfigValue("group:groupbar:enabled", Hyprlang::INT{1});
     m_pConfig->addConfigValue("group:groupbar:font_family", {STRVAL_EMPTY});
     m_pConfig->addConfigValue("group:groupbar:font_size", Hyprlang::INT{8});


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This adds the config option drag_into_group to control whether dragging a window into a unlocked group will merge them. Options: 0 (disabled), 1 (enabled), 2 (only when dragging into the groupbar). [Wiki](https://github.com/hyprwm/hyprland-wiki/pull/796)

Also does (compared to main):
+ Unifies the dragging into a group logic into IHyprLayout::onEndDragWindow(), and detaches it from IHyprLayout::changeWindowFloatingMode().
+ Fixes grouping a tiling group into a floating group (float state fixed).
+ Fixes grouping a window into a floating group (size fixed).
+ Enables grouping a floating window into a tiled group **only when** dragging it into the groupbar.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I have tested every scenario I could imagine and everything is working fine.

#### Is it ready for merging, or does it need work?

It is ready.
