### PR TITLE
layout: fix auto_group when opening a new window in a non-focused workspace using window rules

### DIFF
--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -181,33 +181,34 @@ void IHyprLayout::onWindowCreatedFloating(PHLWINDOW pWindow) {
 }
 
 bool IHyprLayout::onWindowCreatedAutoGroup(PHLWINDOW pWindow) {
-    static auto AUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
-    if ((*AUTOGROUP || g_pInputManager->m_bWasDraggingWindow) // check if auto_group is enabled, or, if the user is manually dragging the window into the group.
-        && g_pCompositor->m_pLastWindow.lock()                // check if a focused window exists.
-        && g_pCompositor->m_pLastWindow != pWindow            // fixes a freeze when activating togglefloat to transform a floating group into a tiled group.
-        && g_pCompositor->m_pLastWindow->m_pWorkspace ==
-            pWindow
-                ->m_pWorkspace // fix for multimonitor: when there is a focused group in monitor 1 and monitor 2 is empty, this enables adding the first window of monitor 2 when using the mouse to focus it.
-        && g_pCompositor->m_pLastWindow->m_sGroupData.pNextWindow.lock()  // check if the focused window is a group
-        && pWindow->canBeGroupedInto(g_pCompositor->m_pLastWindow.lock()) // check if the new window can be grouped into the focused group
-        && !g_pXWaylandManager->shouldBeFloated(pWindow)) {               // don't group XWayland windows that should be floated.
+    static auto PAUTOGROUP = CConfigValue<Hyprlang::INT>("group:auto_group");
+    PHLWINDOW   OPENINGON  = g_pCompositor->m_pLastWindow.lock() && g_pCompositor->m_pLastWindow->m_pWorkspace == pWindow->m_pWorkspace ?
+           g_pCompositor->m_pLastWindow.lock() :
+           g_pCompositor->getFirstWindowOnWorkspace(pWindow->workspaceID());
 
-        switch (pWindow->m_bIsFloating) {
+    if ((*PAUTOGROUP || g_pInputManager->m_bWasDraggingWindow) // check if auto_group is enabled, or, if the user is manually dragging the window into the group.
+        && OPENINGON                                           // check if a focused window exists.
+        && OPENINGON != pWindow                                // fixes a freeze when activating togglefloat to transform a floating group into a tiled group.
+        && OPENINGON->m_sGroupData.pNextWindow.lock()          // check if the focused window is a group
+        && pWindow->canBeGroupedInto(OPENINGON)                // check if the new window can be grouped into the focused group
+        && !g_pXWaylandManager->shouldBeFloated(pWindow)) {    // don't group XWayland windows that should be floated.
+
+        switch (OPENINGON->m_bIsFloating) {
             case false:
-                if (g_pCompositor->m_pLastWindow->m_bIsFloating)
-                    pWindow->m_bIsFloating = true;
+                if (pWindow->m_bIsFloating)
+                    OPENINGON->m_bIsFloating = true;
                 break;
 
             case true:
-                if (!g_pCompositor->m_pLastWindow->m_bIsFloating)
-                    pWindow->m_bIsFloating = false;
+                if (!pWindow->m_bIsFloating)
+                    OPENINGON->m_bIsFloating = false;
                 break;
         }
 
         static auto USECURRPOS = CConfigValue<Hyprlang::INT>("group:insert_after_current");
-        (*USECURRPOS ? g_pCompositor->m_pLastWindow : g_pCompositor->m_pLastWindow->getGroupTail())->insertWindowToGroup(pWindow);
+        (*USECURRPOS ? OPENINGON : OPENINGON->getGroupTail())->insertWindowToGroup(pWindow);
 
-        g_pCompositor->m_pLastWindow->setGroupCurrent(pWindow);
+        OPENINGON->setGroupCurrent(pWindow);
         pWindow->applyGroupRules();
         pWindow->updateWindowDecos();
         recalculateWindow(pWindow);


### PR DESCRIPTION
Fixes auto grouping when using for example these window rules:
```
windowrulev2 = group set,class:discord
windowrulev2 = workspace special:chat silent,class:discord

windowrulev2 = group set,class:telegram
windowrulev2 = workspace special:chat silent,class:telegram
```