### PR TITLE
flake.nix: add xdph follows

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -78,31 +78,6 @@
         "type": "github"
       }
     },
-    "hyprland-protocols_2": {
-      "inputs": {
-        "nixpkgs": [
-          "xdph",
-          "nixpkgs"
-        ],
-        "systems": [
-          "xdph",
-          "systems"
-        ]
-      },
-      "locked": {
-        "lastModified": 1721326555,
-        "narHash": "sha256-zCu4R0CSHEactW9JqYki26gy8h9f6rHmSwj4XJmlHgg=",
-        "owner": "hyprwm",
-        "repo": "hyprland-protocols",
-        "rev": "5a11232266bf1a1f5952d5b179c3f4b2facaaa84",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprland-protocols",
-        "type": "github"
-      }
-    },
     "hyprlang": {
       "inputs": {
         "hyprutils": [
@@ -221,7 +196,9 @@
     },
     "xdph": {
       "inputs": {
-        "hyprland-protocols": "hyprland-protocols_2",
+        "hyprland-protocols": [
+          "hyprland-protocols"
+        ],
         "hyprlang": [
           "hyprlang"
         ],

--- a/flake.nix
+++ b/flake.nix
@@ -51,6 +51,7 @@
       url = "github:hyprwm/xdg-desktop-portal-hyprland";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.systems.follows = "systems";
+      inputs.hyprland-protocols.follows = "hyprland-protocols";
       inputs.hyprlang.follows = "hyprlang";
       inputs.hyprutils.follows = "hyprutils";
       inputs.hyprwayland-scanner.follows = "hyprwayland-scanner";
@@ -98,13 +99,13 @@
       inherit
         (pkgsFor.${system})
         # hyprland-packages
-        
+
         hyprland
         hyprland-debug
         hyprland-legacy-renderer
         hyprland-unwrapped
         # hyprland-extras
-        
+
         xdg-desktop-portal-hyprland
         ;
       hyprland-cross = (pkgsCrossFor.${system} "aarch64-linux").hyprland;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes a duplicate `hyprland-protocols` instance in flake.lock due to xdph not following hyprlands instance.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

The removal of the second `hyprland-protocols` instance `hyprland-protocols_2` in flake.lock could also be done in the next flake update.


#### Is it ready for merging, or does it need work?

I'm currently using this in my own NixOS configuration, and from what I can see, everything is functioning as expected. Ready for merging :)
