### PR TITLE
use clampWindowSize to unify min/maxsize handling

### DIFF
--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -429,6 +429,7 @@ class CWindow {
     bool                   onSpecialWorkspace();
     void                   activate(bool force = false);
     int                    surfacesCount();
+    void                   clampWindowSize(const std::optional<Vector2D> minSize, const std::optional<Vector2D> maxSize);
 
     bool                   isFullscreen();
     bool                   isEffectiveInternalFSMode(const eFullscreenMode);

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -751,26 +751,8 @@ void Events::listener_commitWindow(void* owner, void* data) {
         const auto MINSIZE = PWINDOW->m_pXDGSurface->toplevel->current.minSize;
         const auto MAXSIZE = PWINDOW->m_pXDGSurface->toplevel->current.maxSize;
 
-        if (MAXSIZE > Vector2D{1, 1}) {
-            const auto REALSIZE = PWINDOW->m_vRealSize.goal();
-            Vector2D   newSize  = REALSIZE;
-
-            if (MAXSIZE.x < newSize.x)
-                newSize.x = MAXSIZE.x;
-            if (MAXSIZE.y < newSize.y)
-                newSize.y = MAXSIZE.y;
-            if (MINSIZE.x > newSize.x)
-                newSize.x = MINSIZE.x;
-            if (MINSIZE.y > newSize.y)
-                newSize.y = MINSIZE.y;
-
-            const Vector2D DELTA = REALSIZE - newSize;
-
-            PWINDOW->m_vRealPosition = PWINDOW->m_vRealPosition.goal() + DELTA / 2.0;
-            PWINDOW->m_vRealSize     = newSize;
-            g_pXWaylandManager->setWindowSize(PWINDOW, newSize);
-            g_pHyprRenderer->damageWindow(PWINDOW);
-        }
+        PWINDOW->clampWindowSize(MINSIZE, MAXSIZE > Vector2D{1, 1} ? std::optional<Vector2D>{MAXSIZE} : std::nullopt);
+        g_pHyprRenderer->damageWindow(PWINDOW);
     }
 
     if (!PWINDOW->m_pWorkspace->m_bVisible)


### PR DESCRIPTION
Creates  `clampWindowSize` to unify handling of `minsize` and `maxsize`.
Fixes window position not changing when using `minsize`/`maxsize` (causing window to be placed out of screen for large initial size values).
Seems to work without issues.