### PR TITLE
hyprerror: fix height calc with bottom bar

### DIFF
--- a/src/hyprerror/HyprError.cpp
+++ b/src/hyprerror/HyprError.cpp
@@ -133,7 +133,7 @@ void CHyprError::createQueued() {
     }
     m_szQueued = "";
 
-    m_fLastHeight = yoffset + PAD + 1;
+    m_fLastHeight = yoffset + PAD + 1 - (TOPBAR ? 0 : Y - PAD);
 
     pango_font_description_free(pangoFD);
     g_object_unref(layoutText);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes the entire monitor becoming a reserved area when `error_position=1`

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready

