### PR TITLE
Add check for conflicting acquire and release points

### DIFF
--- a/src/protocols/DRMSyncobj.cpp
+++ b/src/protocols/DRMSyncobj.cpp
@@ -55,8 +55,13 @@ CDRMSyncobjSurfaceResource::CDRMSyncobjSurfaceResource(SP<CWpLinuxDrmSyncobjSurf
             return;
         }
 
-        if (!pending.acquireTimeline)
-            return;
+        if (pending.acquireTimeline && pending.releaseTimeline && pending.acquireTimeline == pending.releaseTimeline) {
+            if (pending.acquirePoint >= pending.releasePoint) {
+                resource->error(WP_LINUX_DRM_SYNCOBJ_SURFACE_V1_ERROR_CONFLICTING_POINTS, "Acquire and release points are on the same timeline, and acquire >= release");
+                surface->pending.rejected = true;
+                return;
+            }
+        }
 
         // wait for the acquire timeline to materialize
         auto materialized = pending.acquireTimeline->timeline->check(pending.acquirePoint, DRM_SYNCOBJ_WAIT_FLAGS_WAIT_AVAILABLE);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
adds a check to prevent conflicts between acquire and release points when they are on the same timeline


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No known issues or breaking changes

#### Is it ready for merging, or does it need work?
It's ready for merging, I guess.

