### PR TITLE
add snapping to floating windows

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -104,6 +104,24 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .type        = CONFIG_OPTION_INT,
         .data        = SConfigOptionDescription::SRangeData{0, 0, 4},
     },
+    SConfigOptionDescription{
+        .value       = "general:snap:enabled",
+        .description = "enable snapping for floating windows",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{false},
+    },
+    SConfigOptionDescription{
+        .value       = "general:snap:window_gap",
+        .description = "minimum gap in pixels between windows before snapping",
+        .type        = CONFIG_OPTION_INT,
+        .data        = SConfigOptionDescription::SRangeData{10, 0, 100},
+    },
+    SConfigOptionDescription{
+        .value       = "general:snap:monitor_gap",
+        .description = "minimum gap in pixels between window and monitor edges before snapping",
+        .type        = CONFIG_OPTION_INT,
+        .data        = SConfigOptionDescription::SRangeData{10, 0, 100},
+    },
 
     /*
      * decoration:

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -341,6 +341,9 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("general:layout", {"dwindle"});
     m_pConfig->addConfigValue("general:allow_tearing", Hyprlang::INT{0});
     m_pConfig->addConfigValue("general:resize_corner", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("general:snap:enabled", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("general:snap:window_gap", Hyprlang::INT{10});
+    m_pConfig->addConfigValue("general:snap:monitor_gap", Hyprlang::INT{10});
 
     m_pConfig->addConfigValue("misc:disable_hyprland_logo", Hyprlang::INT{0});
     m_pConfig->addConfigValue("misc:disable_splash_rendering", Hyprlang::INT{0});

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -464,41 +464,42 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
                 const auto WSID = DRAGGINGWINDOW->workspaceID();
 
                 for (auto& other : g_pCompositor->m_vWindows) {
-                    if (other->workspaceID() == WSID && other->getPID() != PID) {
-                        const CBox     ob = other->getWindowMainSurfaceBox();
-                        const Vector2D ov = ob.extent();
-                        Vector2D       wv = wb.extent();
+                    if (other->workspaceID() != WSID || other->getPID() == PID || !other->m_bIsMapped || other->m_bFadingOut || other->m_bIsX11)
+                        continue;
 
-                        // only snap windows if their ranges intersect in the opposite axis
-                        if (wb.y <= ov.y && ob.y <= wv.y) {
-                            if (isInSnappingDistance(wb.x, ov.x, gap))
-                                wb.x = ov.x;
-                            else if (isInSnappingDistance(wv.x, ob.x, gap))
-                                wb.x = ob.x - wb.w;
-                        }
+                    const CBox     ob = other->getWindowMainSurfaceBox();
+                    const Vector2D ov = ob.extent();
+                    Vector2D       wv = wb.extent();
 
-                        if (wb.x <= ov.x && ob.x <= wv.x) {
-                            if (isInSnappingDistance(wb.y, ov.y, gap))
-                                wb.y = ov.y;
-                            else if (isInSnappingDistance(wv.y, ob.y, gap))
-                                wb.y = ob.y - wb.h;
-                        }
+                    // only snap windows if their ranges intersect in the opposite axis
+                    if (wb.y <= ov.y && ob.y <= wv.y) {
+                        if (isInSnappingDistance(wb.x, ov.x, gap))
+                            wb.x = ov.x;
+                        else if (isInSnappingDistance(wv.x, ob.x, gap))
+                            wb.x = ob.x - wb.w;
+                    }
 
-                        // corner snapping
-                        wv = wb.extent(); // refresh offset coordinates
-                        if (wb.x == ov.x || wv.x == ob.x) {
-                            if (isInSnappingDistance(wb.y, ob.y, gap))
-                                wb.y = ob.y;
-                            else if (isInSnappingDistance(wv.y, ov.y, gap))
-                                wb.y = ov.y - wb.h;
-                        }
+                    if (wb.x <= ov.x && ob.x <= wv.x) {
+                        if (isInSnappingDistance(wb.y, ov.y, gap))
+                            wb.y = ov.y;
+                        else if (isInSnappingDistance(wv.y, ob.y, gap))
+                            wb.y = ob.y - wb.h;
+                    }
 
-                        if (wb.y == ov.y || wv.y == ob.y) {
-                            if (isInSnappingDistance(wb.x, ob.x, gap))
-                                wb.x = ob.x;
-                            else if (isInSnappingDistance(wv.x, ov.x, gap))
-                                wb.x = ov.x - wb.w;
-                        }
+                    // corner snapping
+                    wv = wb.extent(); // refresh offset coordinates
+                    if (wb.x == ov.x || wv.x == ob.x) {
+                        if (isInSnappingDistance(wb.y, ob.y, gap))
+                            wb.y = ob.y;
+                        else if (isInSnappingDistance(wv.y, ov.y, gap))
+                            wb.y = ov.y - wb.h;
+                    }
+
+                    if (wb.y == ov.y || wv.y == ob.y) {
+                        if (isInSnappingDistance(wb.x, ob.x, gap))
+                            wb.x = ob.x;
+                        else if (isInSnappingDistance(wv.x, ov.x, gap))
+                            wb.x = ov.x - wb.w;
                     }
                 }
             }
@@ -587,45 +588,46 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
                     const auto WSID = DRAGGINGWINDOW->workspaceID();
 
                     for (auto& other : g_pCompositor->m_vWindows) {
-                        if (other->workspaceID() == WSID && other->getPID() != PID) {
-                            const CBox     ob = other->getWindowMainSurfaceBox();
-                            const Vector2D ov = ob.extent();
-                            Vector2D       wv = wb.extent();
+                        if (other->workspaceID() != WSID || other->getPID() == PID || !other->m_bIsMapped || other->m_bFadingOut || other->m_bIsX11)
+                            continue;
 
-                            // only snap windows if their ranges intersect in the opposite axis
-                            if (wb.y <= ov.y && ob.y <= wv.y) {
-                                if (isInSnappingDistance(wb.x, ov.x, gap)) {
-                                    wb.w += wb.x - ov.x;
-                                    wb.x = ov.x;
-                                } else if (isInSnappingDistance(wv.x, ob.x, gap))
-                                    wb.w = ob.x - wb.x;
-                            }
+                        const CBox     ob = other->getWindowMainSurfaceBox();
+                        const Vector2D ov = ob.extent();
+                        Vector2D       wv = wb.extent();
 
-                            if (wb.x <= ov.x && ob.x <= wv.x) {
-                                if (isInSnappingDistance(wb.y, ov.y, gap)) {
-                                    wb.h += wb.y - ov.y;
-                                    wb.y = ov.y;
-                                } else if (isInSnappingDistance(wv.y, ob.y, gap))
-                                    wb.h = ob.y - wb.y;
-                            }
+                        // only snap windows if their ranges intersect in the opposite axis
+                        if (wb.y <= ov.y && ob.y <= wv.y) {
+                            if (isInSnappingDistance(wb.x, ov.x, gap)) {
+                                wb.w += wb.x - ov.x;
+                                wb.x = ov.x;
+                            } else if (isInSnappingDistance(wv.x, ob.x, gap))
+                                wb.w = ob.x - wb.x;
+                        }
 
-                            // corner snapping
-                            wv = wb.extent(); // refresh offset coordinates
-                            if (wb.x == ov.x || wv.x == ob.x) {
-                                if ((m_eGrabbedCorner == CORNER_TOPLEFT || m_eGrabbedCorner == CORNER_TOPRIGHT) && isInSnappingDistance(wb.y, ob.y, gap)) {
-                                    wb.h += wb.y - ob.y;
-                                    wb.y = ob.y;
-                                } else if ((m_eGrabbedCorner == CORNER_BOTTOMLEFT || m_eGrabbedCorner == CORNER_BOTTOMRIGHT) && isInSnappingDistance(wv.y, ov.y, gap))
-                                    wb.h = ov.y - wb.y;
-                            }
+                        if (wb.x <= ov.x && ob.x <= wv.x) {
+                            if (isInSnappingDistance(wb.y, ov.y, gap)) {
+                                wb.h += wb.y - ov.y;
+                                wb.y = ov.y;
+                            } else if (isInSnappingDistance(wv.y, ob.y, gap))
+                                wb.h = ob.y - wb.y;
+                        }
 
-                            if (wb.y == ov.y || wv.y == ob.y) {
-                                if ((m_eGrabbedCorner == CORNER_TOPLEFT || m_eGrabbedCorner == CORNER_BOTTOMLEFT) && isInSnappingDistance(wb.x, ob.x, gap)) {
-                                    wb.w += wb.x - ob.x;
-                                    wb.x = ob.x;
-                                } else if ((m_eGrabbedCorner == CORNER_TOPRIGHT || m_eGrabbedCorner == CORNER_BOTTOMRIGHT) && isInSnappingDistance(wv.x, ov.x, gap))
-                                    wb.w = ov.x - wb.x;
-                            }
+                        // corner snapping
+                        wv = wb.extent(); // refresh offset coordinates
+                        if (wb.x == ov.x || wv.x == ob.x) {
+                            if ((m_eGrabbedCorner == CORNER_TOPLEFT || m_eGrabbedCorner == CORNER_TOPRIGHT) && isInSnappingDistance(wb.y, ob.y, gap)) {
+                                wb.h += wb.y - ob.y;
+                                wb.y = ob.y;
+                            } else if ((m_eGrabbedCorner == CORNER_BOTTOMLEFT || m_eGrabbedCorner == CORNER_BOTTOMRIGHT) && isInSnappingDistance(wv.y, ov.y, gap))
+                                wb.h = ov.y - wb.y;
+                        }
+
+                        if (wb.y == ov.y || wv.y == ob.y) {
+                            if ((m_eGrabbedCorner == CORNER_TOPLEFT || m_eGrabbedCorner == CORNER_BOTTOMLEFT) && isInSnappingDistance(wb.x, ob.x, gap)) {
+                                wb.w += wb.x - ob.x;
+                                wb.x = ob.x;
+                            } else if ((m_eGrabbedCorner == CORNER_TOPRIGHT || m_eGrabbedCorner == CORNER_BOTTOMRIGHT) && isInSnappingDistance(wv.x, ov.x, gap))
+                                wb.w = ov.x - wb.x;
                         }
                     }
                 }

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -419,15 +419,12 @@ typedef void (*SnapFn)(double& pos, double& len, const double p);
 
 void snapWindows(CBox& wb, PHLWINDOW DRAGGINGWINDOW, const double oldGap, const eMouseBindMode mode, const eRectCorner c) {
     SnapFn snapUp, snapDown, snapLeft, snapRight;
-    switch (mode) {
-        case MBIND_RESIZE:
-            snapUp = snapLeft = snapResizeLeft;
-            snapDown = snapRight = snapResizeRight;
-            break;
-        default:
-            snapUp = snapLeft = snapMoveLeft;
-            snapDown = snapRight = snapMoveRight;
-            break;
+    if (mode == MBIND_RESIZE) {
+        snapUp = snapLeft = snapResizeLeft;
+        snapDown = snapRight = snapResizeRight;
+    } else {
+        snapUp = snapLeft = snapMoveLeft;
+        snapDown = snapRight = snapMoveRight;
     }
 
     static auto  BORDERSIZE = CConfigValue<Hyprlang::INT>("general:border_size");
@@ -447,51 +444,42 @@ void snapWindows(CBox& wb, PHLWINDOW DRAGGINGWINDOW, const double oldGap, const 
 
         // only snap windows if their ranges intersect in the opposite axis
         if (wb.y <= bb.h && bb.y <= wv.y) {
-            if (c & (CORNER_TOPLEFT | CORNER_BOTTOMLEFT) && canSnap(wb.x, bb.w, gap)) {
+            if (c & (CORNER_TOPLEFT | CORNER_BOTTOMLEFT) && canSnap(wb.x, bb.w, gap))
                 snapLeft(wb.x, wb.w, bb.w);
-                // now check corners
-                if (c & CORNER_TOPLEFT && canSnap(wb.y, ob.y, gap))
-                    snapUp(wb.y, wb.h, ob.y);
-                else if (c & CORNER_BOTTOMLEFT && canSnap(wv.y, ob.h, gap))
-                    snapDown(wb.y, wb.h, ob.h);
-            } else if (c & (CORNER_TOPRIGHT | CORNER_BOTTOMRIGHT) && canSnap(wv.x, bb.x, gap)) {
+            else if (c & (CORNER_TOPRIGHT | CORNER_BOTTOMRIGHT) && canSnap(wv.x, bb.x, gap))
                 snapRight(wb.x, wb.w, bb.x);
-                if (c & CORNER_TOPRIGHT && canSnap(wb.y, ob.y, gap))
-                    snapUp(wb.y, wb.h, ob.y);
-                else if (c & CORNER_BOTTOMRIGHT && canSnap(wv.y, ob.h, gap))
-                    snapDown(wb.y, wb.h, ob.h);
-            }
+        }
+        if (wb.x <= bb.w && bb.x <= wv.x) {
+            if (c & (CORNER_TOPLEFT | CORNER_TOPRIGHT) && canSnap(wb.y, bb.h, gap))
+                snapUp(wb.y, wb.h, bb.h);
+            else if (c & (CORNER_BOTTOMLEFT | CORNER_BOTTOMRIGHT) && canSnap(wv.y, bb.y, gap))
+                snapDown(wb.y, wb.h, bb.y);
         }
 
-        if (wb.x <= bb.w && bb.x <= wv.x) {
-            if (c & (CORNER_TOPLEFT | CORNER_TOPRIGHT) && canSnap(wb.y, bb.h, gap)) {
-                snapUp(wb.y, wb.h, bb.h);
-                if (c & CORNER_TOPLEFT && canSnap(wb.x, ob.x, gap))
-                    snapLeft(wb.x, wb.w, ob.x);
-                else if (c & CORNER_TOPRIGHT && canSnap(wv.x, ob.w, gap))
-                    snapRight(wb.x, wb.w, ob.w);
-            } else if (c & (CORNER_BOTTOMLEFT | CORNER_BOTTOMRIGHT) && canSnap(wv.y, bb.y, gap)) {
-                snapDown(wb.y, wb.h, bb.y);
-                if (c & CORNER_BOTTOMLEFT && canSnap(wb.x, ob.x, gap))
-                    snapLeft(wb.x, wb.w, ob.x);
-                else if (c & CORNER_BOTTOMRIGHT && canSnap(wv.x, ob.w, gap))
-                    snapRight(wb.x, wb.w, ob.w);
-            }
+        // corner snapping
+        if (wb.x == bb.w || bb.x == wb.x + wb.w) {
+            if (c & (CORNER_TOPLEFT | CORNER_TOPRIGHT) && canSnap(wb.y, ob.y, gap))
+                snapUp(wb.y, wb.h, ob.y);
+            else if (c & (CORNER_BOTTOMLEFT | CORNER_BOTTOMRIGHT) && canSnap(wv.y, ob.h, gap))
+                snapDown(wb.y, wb.h, ob.h);
+        }
+        if (wb.y == bb.h || bb.y == wb.y + wb.h) {
+            if (c & (CORNER_TOPLEFT | CORNER_BOTTOMLEFT) && canSnap(wb.x, ob.x, gap))
+                snapLeft(wb.x, wb.w, ob.x);
+            else if (c & (CORNER_TOPRIGHT | CORNER_BOTTOMRIGHT) && canSnap(wv.x, ob.w, gap))
+                snapRight(wb.x, wb.w, ob.w);
         }
     }
 }
 
 void snapMonitor(CBox& wb, PHLWINDOW DRAGGINGWINDOW, const double gap, const eMouseBindMode mode) {
     SnapFn snapUp, snapDown, snapLeft, snapRight;
-    switch (mode) {
-        case MBIND_RESIZE:
-            snapUp = snapLeft = snapResizeLeft;
-            snapDown = snapRight = snapResizeRight;
-            break;
-        default:
-            snapUp = snapLeft = snapMoveLeft;
-            snapDown = snapRight = snapMoveRight;
-            break;
+    if (mode == MBIND_RESIZE) {
+        snapUp = snapLeft = snapResizeLeft;
+        snapDown = snapRight = snapResizeRight;
+    } else {
+        snapUp = snapLeft = snapMoveLeft;
+        snapDown = snapRight = snapMoveRight;
     }
 
     const auto MON = g_pCompositor->getMonitorFromID(DRAGGINGWINDOW->m_iMonitorID);

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -466,21 +466,24 @@ static void performSnap(Vector2D& pos, Vector2D& size, PHLWINDOW DRAGGINGWINDOW,
                 }
             }
 
-            if (mode == MBIND_RESIZE_FORCE_RATIO)
-                continue;
-
             // corner snapping
             if (pos.x == bb.w || bb.x == pos.x + size.x) {
-                if (corner & (CORNER_TOPLEFT | CORNER_TOPRIGHT) && canSnap(pos.y, ob.y, gap))
+                if (corner & (CORNER_TOPLEFT | CORNER_TOPRIGHT) && canSnap(pos.y, ob.y, gap)) {
                     snapUp(pos.y, size.y, ob.y);
-                else if (corner & (CORNER_BOTTOMLEFT | CORNER_BOTTOMRIGHT) && canSnap(end.y, ob.h, gap))
+                    snaps |= SNAP_UP;
+                } else if (corner & (CORNER_BOTTOMLEFT | CORNER_BOTTOMRIGHT) && canSnap(end.y, ob.h, gap)) {
                     snapDown(pos.y, size.y, ob.h);
+                    snaps |= SNAP_DOWN;
+                }
             }
             if (pos.y == bb.h || bb.y == pos.y + size.y) {
-                if (corner & (CORNER_TOPLEFT | CORNER_BOTTOMLEFT) && canSnap(pos.x, ob.x, gap))
+                if (corner & (CORNER_TOPLEFT | CORNER_BOTTOMLEFT) && canSnap(pos.x, ob.x, gap)) {
                     snapLeft(pos.x, size.x, ob.x);
-                else if (corner & (CORNER_TOPRIGHT | CORNER_BOTTOMRIGHT) && canSnap(end.x, ob.w, gap))
+                    snaps |= SNAP_LEFT;
+                } else if (corner & (CORNER_TOPRIGHT | CORNER_BOTTOMRIGHT) && canSnap(end.x, ob.w, gap)) {
                     snapRight(pos.x, size.x, ob.w);
+                    snaps |= SNAP_RIGHT;
+                }
             }
         }
     }

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -418,7 +418,6 @@ void snapResizeRight(double& pos, double& len, const double p) {
 typedef void (*SnapFn)(double& pos, double& len, const double p);
 
 void IHyprLayout::performSnap(Vector2D& pos, Vector2D& size, PHLWINDOW DRAGGINGWINDOW, const eMouseBindMode mode) {
-    static auto BORDERSIZE     = CConfigValue<Hyprlang::INT>("general:border_size");
     static auto SNAPWINDOWGAP  = CConfigValue<Hyprlang::INT>("general:snap:window_gap");
     static auto SNAPMONITORGAP = CConfigValue<Hyprlang::INT>("general:snap:monitor_gap");
 
@@ -435,14 +434,16 @@ void IHyprLayout::performSnap(Vector2D& pos, Vector2D& size, PHLWINDOW DRAGGINGW
     }
 
     if (*SNAPWINDOWGAP) {
-        const int    bord = *BORDERSIZE;
-        const double gap  = *SNAPWINDOWGAP + bord;
-        const auto   PID  = DRAGGINGWINDOW->getPID();
-        const auto   WSID = DRAGGINGWINDOW->workspaceID();
+        const auto PID  = DRAGGINGWINDOW->getPID();
+        const auto WSID = DRAGGINGWINDOW->workspaceID();
+        const int  BORD = DRAGGINGWINDOW->getRealBorderSize();
 
         for (auto& other : g_pCompositor->m_vWindows) {
             if (other->workspaceID() != WSID || other->getPID() == PID || !other->m_bIsMapped || other->m_bFadingOut || other->m_bIsX11)
                 continue;
+
+            const int      bord = std::max(BORD, other->getRealBorderSize());
+            const double   gap  = *SNAPWINDOWGAP + bord;
 
             const CBox     box = other->getWindowMainSurfaceBox();
             const CBox     ob(box.x, box.y, box.x + box.w, box.y + box.h);

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../defines.hpp"
-#include "../managers/input/InputManager.hpp"
 #include <any>
 
 class CWindow;
@@ -20,17 +19,18 @@ enum eFullscreenMode : int8_t;
 
 enum eRectCorner {
     CORNER_NONE        = 0,
-    CORNER_TOPLEFT     = 1,
-    CORNER_TOPRIGHT    = 2,
-    CORNER_BOTTOMRIGHT = 4,
-    CORNER_BOTTOMLEFT  = 8,
+    CORNER_TOPLEFT     = (1 << 0),
+    CORNER_TOPRIGHT    = (1 << 1),
+    CORNER_BOTTOMRIGHT = (1 << 2),
+    CORNER_BOTTOMLEFT  = (1 << 3),
 };
 
 enum eSnapEdge {
-    SNAP_UP    = 1,
-    SNAP_DOWN  = 2,
-    SNAP_LEFT  = 4,
-    SNAP_RIGHT = 8,
+    SNAP_INVALID = 0,
+    SNAP_UP      = (1 << 0),
+    SNAP_DOWN    = (1 << 1),
+    SNAP_LEFT    = (1 << 2),
+    SNAP_RIGHT   = (1 << 3),
 };
 
 enum eDirection {
@@ -214,6 +214,4 @@ class IHyprLayout {
     eRectCorner  m_eGrabbedCorner = CORNER_TOPLEFT;
 
     PHLWINDOWREF m_pLastTiledWindow;
-
-    void         performSnap(Vector2D& pos, Vector2D& size, PHLWINDOW DRAGGINGWINDOW, const eMouseBindMode mode);
 };

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -18,7 +18,6 @@ struct SLayoutMessageHeader {
 enum eFullscreenMode : int8_t;
 
 enum eRectCorner {
-    CORNER_ANY         = -1,
     CORNER_NONE        = 0,
     CORNER_TOPLEFT     = 1,
     CORNER_TOPRIGHT    = 2,
@@ -207,4 +206,6 @@ class IHyprLayout {
     eRectCorner  m_eGrabbedCorner = CORNER_TOPLEFT;
 
     PHLWINDOWREF m_pLastTiledWindow;
+
+    void         performSnap(Vector2D& pos, Vector2D& size, PHLWINDOW DRAGGINGWINDOW, const int mode);
 };

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -18,11 +18,12 @@ struct SLayoutMessageHeader {
 enum eFullscreenMode : int8_t;
 
 enum eRectCorner {
-    CORNER_NONE = 0,
-    CORNER_TOPLEFT,
-    CORNER_TOPRIGHT,
-    CORNER_BOTTOMRIGHT,
-    CORNER_BOTTOMLEFT
+    CORNER_ANY         = -1,
+    CORNER_NONE        = 0,
+    CORNER_TOPLEFT     = 1,
+    CORNER_TOPRIGHT    = 2,
+    CORNER_BOTTOMRIGHT = 4,
+    CORNER_BOTTOMLEFT  = 8,
 };
 
 enum eDirection {

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../defines.hpp"
+#include "../managers/input/InputManager.hpp"
 #include <any>
 
 class CWindow;
@@ -23,6 +24,13 @@ enum eRectCorner {
     CORNER_TOPRIGHT    = 2,
     CORNER_BOTTOMRIGHT = 4,
     CORNER_BOTTOMLEFT  = 8,
+};
+
+enum eSnapEdge {
+    SNAP_UP    = 1,
+    SNAP_DOWN  = 2,
+    SNAP_LEFT  = 4,
+    SNAP_RIGHT = 8,
 };
 
 enum eDirection {
@@ -207,5 +215,5 @@ class IHyprLayout {
 
     PHLWINDOWREF m_pLastTiledWindow;
 
-    void         performSnap(Vector2D& pos, Vector2D& size, PHLWINDOW DRAGGINGWINDOW, const int mode);
+    void         performSnap(Vector2D& pos, Vector2D& size, PHLWINDOW DRAGGINGWINDOW, const eMouseBindMode mode);
 };


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

While moving and resizing floating windows, edges and corners will snap to the edges/corners of the monitor or other windows when they get close enough to each other.

It started as an update to @shadowmax31 's PR #3236 , but was eventually changed to behave more similarly to KWin's snapping feature.

It comes with 3 options:

`general:snap:enabled` - whether it's enabled, off by default

`general:snap:window_gap` - minimum gap in pixels between windows before snapping. Setting to 0 effectively turns off this method of snapping.

`general:snap:monitor_gap` - minimum gap in pixels between window and monitor edges before snapping. Again, setting it to 0 effectively turns it off.

Here's a video of it with these settings:
```sh
general:snap {
    enabled = true
    window_gap = 25 # pixels
    monitor_gap = 10 # pixels
}
```

https://github.com/user-attachments/assets/8245a2bf-ff50-4722-b267-e20dfa77c519

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Not that I can think of.

#### Is it ready for merging, or does it need work?

Ready to merge.