### PR TITLE
Update session desktop file to include DesktopNames, fixes empty XDG_CURRENT_DESKTOP in ly

### DIFF
--- a/example/hyprland.desktop
+++ b/example/hyprland.desktop
@@ -3,3 +3,5 @@ Name=Hyprland
 Comment=An intelligent dynamic tiling Wayland compositor
 Exec=Hyprland
 Type=Application
+DesktopNames=Hyprland
+Keywords=tiling;wayland;compositor;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Include `DesktopNames`, ~`X-LightDM-DesktopName`~ and `Keywords` in the example session desktop file. `DesktopNames` is set to provide a source of truth for the display managers, the other two are taken from i3's session file on Arch and seem like they could prove userful. (Do feel free to keep or remove them as you see fit.)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This was already requested in the past in PR #7345 and partially solved by PR #7347.  
This PR handles an edge case for when a display manager sets the `XDG_CURRENT_DESKTOP` value to an empty string due to a missing `DesktopNames` key.
This can lead to a warning about an unset `XDG_CURRENT_DESKTOP` as the current logic in [Compositor.cpp:328 ](https://github.com/hyprwm/Hyprland/blob/main/src/Compositor.cpp#L328) only handles a missing variable (not an empty one).

Not sure whenether this behaviour should be changed, however including `DesktopNames` in the session desktop file looks sensible enough as the spec seems to imply that `XDG_CURRENT_DESKTOP` should be set by the display manager.

See [desktop entry spec](https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html), impl in ly display manager: [auth.zig:35](https://github.com/fairyglade/ly/blob/e125d8f1aa1544a6a106047c0acd7a7d2e0ff16c/src/auth.zig#L35)

#### Is it ready for merging, or does it need work?
More or less, works fine with `ly`.
