### PR TITLE
IME: Fixup IME popup candidate windows position when scale is not 1.0

### DIFF
--- a/src/managers/input/InputMethodPopup.cpp
+++ b/src/managers/input/InputMethodPopup.cpp
@@ -100,14 +100,14 @@ void CInputPopup::updateBox() {
         cursorBoxParent = {0, 0, (int)parentBox.w, (int)parentBox.h};
     }
 
-    Vector2D  currentPopupSize = surface->getViewporterCorrectedSize();
+    Vector2D  currentPopupSize = surface->getViewporterCorrectedSize() / surface->resource()->current.scale;
 
     CMonitor* pMonitor = g_pCompositor->getMonitorFromVector(parentBox.middle());
 
     Vector2D  popupOffset(0, 0);
 
     if (parentBox.y + cursorBoxParent.y + cursorBoxParent.height + currentPopupSize.y > pMonitor->vecPosition.y + pMonitor->vecSize.y)
-        popupOffset.y = -currentPopupSize.y;
+        popupOffset.y -= currentPopupSize.y;
     else
         popupOffset.y = cursorBoxParent.height;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixup this issue #7878 , making the IME pop up windows show in correct position when they touch the bottom or right edge of monitors.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Yes, it works well on my local machine. Here are the testing images,

![image_2024-10-14_20-08-04](https://github.com/user-attachments/assets/1dffa489-4075-408f-bcbf-5f3d18bb665a)

![image_2024-10-14_20-25-08](https://github.com/user-attachments/assets/6761b92a-a360-44ea-9a6a-a80f73a05884)

![image_2024-10-14_20-26-58](https://github.com/user-attachments/assets/901266bc-bce9-40f7-a3af-0764d1204dd1)


