### PR TITLE
layout: simplify the conditions to autogroup

### DIFF
--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -191,14 +191,12 @@ bool IHyprLayout::onWindowCreatedAutoGroup(PHLWINDOW pWindow) {
         denied = true;
 
     if (*PAUTOGROUP                                      // check if auto_group is enabled.
-        && OPENINGON                                     // check if OPENINGON exists.
-        && OPENINGON != pWindow                          // fixes a freeze when activating togglefloat to transform a floating group into a tiled group.
         && OPENINGON->m_sGroupData.pNextWindow.lock()    // check if OPENINGON is a group.
         && pWindow->canBeGroupedInto(OPENINGON)          // check if the new window can be grouped into OPENINGON.
-        && !g_pXWaylandManager->shouldBeFloated(pWindow) // don't group a new window that should be floated.
-        && !denied) {                                    // don't group a new floated window into a tiled group.
+        && !g_pXWaylandManager->shouldBeFloated(pWindow) // fixes the popups of XWayland programs running in a floating group.
+        && !denied) {                                    // don't group a new floated window into a tiled group (for convenience).
 
-        pWindow->m_bIsFloating = OPENINGON->m_bIsFloating; // match the floating state
+        pWindow->m_bIsFloating = OPENINGON->m_bIsFloating; // match the floating state. Needed to autogroup a new tiled window into a floated group.
 
         static auto USECURRPOS = CConfigValue<Hyprlang::INT>("group:insert_after_current");
         (*USECURRPOS ? OPENINGON : OPENINGON->getGroupTail())->insertWindowToGroup(pWindow);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
`OPENINGON != pWindow`: is not necessary after the changes in https://github.com/hyprwm/Hyprland/commit/45e82199fb29f422ebbbfe06ce03022dfb6d645e

`OPENINGON`: now I realize that was not necessary since the beginning, because we are checking for `OPENINGON->m_sGroupData.pNextWindow.lock()` anyway.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I have tested and everything seems good.

#### Is it ready for merging, or does it need work?
Ready.

