### PR TITLE
hyprctl devices: Get caps/num lock state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PREFIX = /usr/local
 
 legacyrenderer:
-	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX:STRING=${PREFIX} -DLEGACY_RENDERER:BOOL=true -S . -B ./buildZ
+	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX:STRING=${PREFIX} -DLEGACY_RENDERER:BOOL=true -S . -B ./build
 	cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
 legacyrendererdebug:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PREFIX = /usr/local
 
 legacyrenderer:
-	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX:STRING=${PREFIX} -DLEGACY_RENDERER:BOOL=true -S . -B ./build
+	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX:STRING=${PREFIX} -DLEGACY_RENDERER:BOOL=true -S . -B ./buildZ
 	cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
 
 legacyrendererdebug:

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -586,7 +586,7 @@ std::string devicesRequest(eHyprCtlOutputFormat format, std::string request) {
     }},)#",
                 (uintptr_t)k.get(), escapeJSONStrings(k->hlName), escapeJSONStrings(k->currentRules.rules), escapeJSONStrings(k->currentRules.model),
                 escapeJSONStrings(k->currentRules.layout), escapeJSONStrings(k->currentRules.variant), escapeJSONStrings(k->currentRules.options), escapeJSONStrings(KM),
-                (k->modifiersState.locked & (1 << 1) : "true" ? "false"), (k->modifiersState.locked & (1 << 4) : "true" ? "false"), (k->active ? "true" : "false"));
+                ((k->modifiersState.locked & (1 << 1)) == 2 ? "true" : "false"), ((k->modifiersState.locked & (1 << 4)) == 16 ? "true" : "false"), (k->active ? "true" : "false"));
         }
 
         trimTrailingComma(result);

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -580,13 +580,13 @@ std::string devicesRequest(eHyprCtlOutputFormat format, std::string request) {
         "variant": "{}",
         "options": "{}",
         "active_keymap": "{}",
-        "capsLock: {}",
-        "numLock: {}",
+        "capsLock": {},
+        "numLock": {},
         "main": {}
     }},)#",
                 (uintptr_t)k.get(), escapeJSONStrings(k->hlName), escapeJSONStrings(k->currentRules.rules), escapeJSONStrings(k->currentRules.model),
                 escapeJSONStrings(k->currentRules.layout), escapeJSONStrings(k->currentRules.variant), escapeJSONStrings(k->currentRules.options), escapeJSONStrings(KM),
-                ((k->getLEDs().value_or(0) & (1 << 1)) == 2 ? "On" : "Off"), ((k->getLEDs().value_or(0) & (1 << 0)) ? "On" : "Off"), (k->active ? "true" : "false"));
+                ((k->getLEDs().value_or(0) & (1 << 1)) == 2 ? "true" : "false"), ((k->getLEDs().value_or(0) & (1 << 0)) ? "true" : "false"), (k->active ? "true" : "false"));
         }
 
         trimTrailingComma(result);

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -549,6 +549,15 @@ std::string configErrorsRequest(eHyprCtlOutputFormat format, std::string request
 std::string devicesRequest(eHyprCtlOutputFormat format, std::string request) {
     std::string result = "";
 
+    auto        getModState = [](SP<IKeyboard> keyboard, const char* xkbModName) -> bool {
+        auto IDX = xkb_keymap_mod_get_index(keyboard->xkbKeymap, xkbModName);
+
+        if (IDX == XKB_MOD_INVALID)
+            return false;
+
+        return (keyboard->modifiersState.locked & (1 << IDX)) > 0;
+    };
+
     if (format == eHyprCtlOutputFormat::FORMAT_JSON) {
         result += "{\n";
         result += "\"mice\": [\n";
@@ -586,15 +595,7 @@ std::string devicesRequest(eHyprCtlOutputFormat format, std::string request) {
     }},)#",
                 (uintptr_t)k.get(), escapeJSONStrings(k->hlName), escapeJSONStrings(k->currentRules.rules), escapeJSONStrings(k->currentRules.model),
                 escapeJSONStrings(k->currentRules.layout), escapeJSONStrings(k->currentRules.variant), escapeJSONStrings(k->currentRules.options), escapeJSONStrings(KM),
-                (((xkb_keymap_mod_get_index(k->xkbKeymap, XKB_MOD_NAME_CAPS)) != XKB_MOD_INVALID &&
-                  (k->modifiersState.locked & (1 << xkb_keymap_mod_get_index(k->xkbKeymap, XKB_MOD_NAME_CAPS))) > 0) ?
-                     "true" :
-                     "false"),
-                (((xkb_keymap_mod_get_index(k->xkbKeymap, XKB_MOD_NAME_NUM)) != XKB_MOD_INVALID &&
-                  (k->modifiersState.locked & (1 << xkb_keymap_mod_get_index(k->xkbKeymap, XKB_MOD_NAME_NUM))) > 0) ?
-                     "true" :
-                     "false"),
-                (k->active ? "true" : "false"));
+                (getModState(k, XKB_MOD_NAME_CAPS) ? "true" : "false"), (getModState(k, XKB_MOD_NAME_NUM) ? "true" : "false"), (k->active ? "true" : "false"));
         }
 
         trimTrailingComma(result);
@@ -678,19 +679,11 @@ std::string devicesRequest(eHyprCtlOutputFormat format, std::string request) {
 
         for (auto const& k : g_pInputManager->m_vKeyboards) {
             const auto KM = k->getActiveLayout();
-            result += std::format("\tKeyboard at {:x}:\n\t\t{}\n\t\t\trules: r \"{}\", m \"{}\", l \"{}\", v \"{}\", o \"{}\"\n\t\t\tactive keymap: {}\n\t\t\tcapsLock: "
-                                  "{}\n\t\t\tnumLock: {}\n\t\t\tmain: {}\n",
-                                  (uintptr_t)k.get(), k->hlName, k->currentRules.rules, k->currentRules.model, k->currentRules.layout, k->currentRules.variant,
-                                  k->currentRules.options, KM,
-                                  (((xkb_keymap_mod_get_index(k->xkbKeymap, XKB_MOD_NAME_CAPS)) != XKB_MOD_INVALID &&
-                                    (k->modifiersState.locked & (1 << xkb_keymap_mod_get_index(k->xkbKeymap, XKB_MOD_NAME_CAPS))) > 0) ?
-                                       "yes" :
-                                       "no"),
-                                  (((xkb_keymap_mod_get_index(k->xkbKeymap, XKB_MOD_NAME_NUM)) != XKB_MOD_INVALID &&
-                                    (k->modifiersState.locked & (1 << xkb_keymap_mod_get_index(k->xkbKeymap, XKB_MOD_NAME_NUM))) > 0) ?
-                                       "yes" :
-                                       "no"),
-                                  (k->active ? "yes" : "no"));
+            result +=
+                std::format("\tKeyboard at {:x}:\n\t\t{}\n\t\t\trules: r \"{}\", m \"{}\", l \"{}\", v \"{}\", o \"{}\"\n\t\t\tactive keymap: {}\n\t\t\tcapsLock: "
+                            "{}\n\t\t\tnumLock: {}\n\t\t\tmain: {}\n",
+                            (uintptr_t)k.get(), k->hlName, k->currentRules.rules, k->currentRules.model, k->currentRules.layout, k->currentRules.variant, k->currentRules.options,
+                            KM, (getModState(k, XKB_MOD_NAME_CAPS) ? "yes" : "no"), (getModState(k, XKB_MOD_NAME_NUM) ? "yes" : "no"), (k->active ? "yes" : "no"));
         }
 
         result += "\n\nTablets:\n";

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -586,7 +586,7 @@ std::string devicesRequest(eHyprCtlOutputFormat format, std::string request) {
     }},)#",
                 (uintptr_t)k.get(), escapeJSONStrings(k->hlName), escapeJSONStrings(k->currentRules.rules), escapeJSONStrings(k->currentRules.model),
                 escapeJSONStrings(k->currentRules.layout), escapeJSONStrings(k->currentRules.variant), escapeJSONStrings(k->currentRules.options), escapeJSONStrings(KM),
-                ((k->getLEDs().value_or(0) & (1 << 1)) == 2 ? "true" : "false"), ((k->getLEDs().value_or(0) & (1 << 0)) ? "true" : "false"), (k->active ? "true" : "false"));
+                (k->modifiersState.locked & (1 << 1) : "true" ? "false"), (k->modifiersState.locked & (1 << 4) : "true" ? "false"), (k->active ? "true" : "false"));
         }
 
         trimTrailingComma(result);

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -670,9 +670,11 @@ std::string devicesRequest(eHyprCtlOutputFormat format, std::string request) {
 
         for (auto const& k : g_pInputManager->m_vKeyboards) {
             const auto KM = k->getActiveLayout();
-            result += std::format("\tKeyboard at {:x}:\n\t\t{}\n\t\t\trules: r \"{}\", m \"{}\", l \"{}\", v \"{}\", o \"{}\"\n\t\t\tactive keymap: {}\n\t\t\tmain: {}\n",
+            result += std::format("\tKeyboard at {:x}:\n\t\t{}\n\t\t\trules: r \"{}\", m \"{}\", l \"{}\", v \"{}\", o \"{}\"\n\t\t\tactive keymap: {}\n\t\t\tcapsLock: "
+                                  "{}\n\t\t\tnumLock: {}\n\t\t\tmain: {}\n",
                                   (uintptr_t)k.get(), k->hlName, k->currentRules.rules, k->currentRules.model, k->currentRules.layout, k->currentRules.variant,
-                                  k->currentRules.options, KM, (k->active ? "yes" : "no"));
+                                  k->currentRules.options, KM, ((k->modifiersState.locked & (1 << 1)) == 2 ? "yes" : "no"),
+                                  ((k->modifiersState.locked & (1 << 4)) == 16 ? "yes" : "no"), (k->active ? "yes" : "no"));
         }
 
         result += "\n\nTablets:\n";

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -580,10 +580,13 @@ std::string devicesRequest(eHyprCtlOutputFormat format, std::string request) {
         "variant": "{}",
         "options": "{}",
         "active_keymap": "{}",
+        "capsLock: {}",
+        "numLock: {}",
         "main": {}
     }},)#",
                 (uintptr_t)k.get(), escapeJSONStrings(k->hlName), escapeJSONStrings(k->currentRules.rules), escapeJSONStrings(k->currentRules.model),
                 escapeJSONStrings(k->currentRules.layout), escapeJSONStrings(k->currentRules.variant), escapeJSONStrings(k->currentRules.options), escapeJSONStrings(KM),
+                ((k->getLEDs().value_or(0) & (1 << 1)) == 2 ? "On" : "Off"), ((k->getLEDs().value_or(0) & (1 << 0)) ? "On" : "Off"),
                 (k->active ? "true" : "false"));
         }
 

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -586,7 +586,15 @@ std::string devicesRequest(eHyprCtlOutputFormat format, std::string request) {
     }},)#",
                 (uintptr_t)k.get(), escapeJSONStrings(k->hlName), escapeJSONStrings(k->currentRules.rules), escapeJSONStrings(k->currentRules.model),
                 escapeJSONStrings(k->currentRules.layout), escapeJSONStrings(k->currentRules.variant), escapeJSONStrings(k->currentRules.options), escapeJSONStrings(KM),
-                ((k->modifiersState.locked & (1 << 1)) == 2 ? "true" : "false"), ((k->modifiersState.locked & (1 << 4)) == 16 ? "true" : "false"), (k->active ? "true" : "false"));
+                (((xkb_keymap_mod_get_index(k->xkbKeymap, XKB_MOD_NAME_CAPS)) != XKB_MOD_INVALID &&
+                  (k->modifiersState.locked & (1 << xkb_keymap_mod_get_index(k->xkbKeymap, XKB_MOD_NAME_CAPS))) > 0) ?
+                     "true" :
+                     "false"),
+                (((xkb_keymap_mod_get_index(k->xkbKeymap, XKB_MOD_NAME_NUM)) != XKB_MOD_INVALID &&
+                  (k->modifiersState.locked & (1 << xkb_keymap_mod_get_index(k->xkbKeymap, XKB_MOD_NAME_NUM))) > 0) ?
+                     "true" :
+                     "false"),
+                (k->active ? "true" : "false"));
         }
 
         trimTrailingComma(result);
@@ -673,8 +681,16 @@ std::string devicesRequest(eHyprCtlOutputFormat format, std::string request) {
             result += std::format("\tKeyboard at {:x}:\n\t\t{}\n\t\t\trules: r \"{}\", m \"{}\", l \"{}\", v \"{}\", o \"{}\"\n\t\t\tactive keymap: {}\n\t\t\tcapsLock: "
                                   "{}\n\t\t\tnumLock: {}\n\t\t\tmain: {}\n",
                                   (uintptr_t)k.get(), k->hlName, k->currentRules.rules, k->currentRules.model, k->currentRules.layout, k->currentRules.variant,
-                                  k->currentRules.options, KM, ((k->modifiersState.locked & (1 << 1)) == 2 ? "yes" : "no"),
-                                  ((k->modifiersState.locked & (1 << 4)) == 16 ? "yes" : "no"), (k->active ? "yes" : "no"));
+                                  k->currentRules.options, KM,
+                                  (((xkb_keymap_mod_get_index(k->xkbKeymap, XKB_MOD_NAME_CAPS)) != XKB_MOD_INVALID &&
+                                    (k->modifiersState.locked & (1 << xkb_keymap_mod_get_index(k->xkbKeymap, XKB_MOD_NAME_CAPS))) > 0) ?
+                                       "yes" :
+                                       "no"),
+                                  (((xkb_keymap_mod_get_index(k->xkbKeymap, XKB_MOD_NAME_NUM)) != XKB_MOD_INVALID &&
+                                    (k->modifiersState.locked & (1 << xkb_keymap_mod_get_index(k->xkbKeymap, XKB_MOD_NAME_NUM))) > 0) ?
+                                       "yes" :
+                                       "no"),
+                                  (k->active ? "yes" : "no"));
         }
 
         result += "\n\nTablets:\n";

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -586,8 +586,7 @@ std::string devicesRequest(eHyprCtlOutputFormat format, std::string request) {
     }},)#",
                 (uintptr_t)k.get(), escapeJSONStrings(k->hlName), escapeJSONStrings(k->currentRules.rules), escapeJSONStrings(k->currentRules.model),
                 escapeJSONStrings(k->currentRules.layout), escapeJSONStrings(k->currentRules.variant), escapeJSONStrings(k->currentRules.options), escapeJSONStrings(KM),
-                ((k->getLEDs().value_or(0) & (1 << 1)) == 2 ? "On" : "Off"), ((k->getLEDs().value_or(0) & (1 << 0)) ? "On" : "Off"),
-                (k->active ? "true" : "false"));
+                ((k->getLEDs().value_or(0) & (1 << 1)) == 2 ? "On" : "Off"), ((k->getLEDs().value_or(0) & (1 << 0)) ? "On" : "Off"), (k->active ? "true" : "false"));
         }
 
         trimTrailingComma(result);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
#7271 
Adds caps/num lock state to `hyprctl devices -j`

```
...
{
  "address": "0x<the address>",
  "name": "<the name>",
  "rules": "",
  "model": "",
  "layout": "us",
  "variant": "",
  "options": "",
  "active_keymap": "English (US)",
  "capsLock": true/false,
  "numLock": true/false,
  "main": true/false
}
...
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready
