### PR TITLE
session-lock: reset seat grab on a new session lock

### DIFF
--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -3,6 +3,7 @@
 #include "../config/ConfigValue.hpp"
 #include "../protocols/FractionalScale.hpp"
 #include "../protocols/SessionLock.hpp"
+#include "../managers/SeatManager.hpp"
 #include <algorithm>
 #include <ranges>
 
@@ -84,6 +85,7 @@ void CSessionLockManager::onNewSessionLock(SP<CSessionLock> pLock) {
     });
 
     g_pCompositor->focusSurface(nullptr);
+    g_pSeatManager->setGrab(nullptr);
 }
 
 bool CSessionLockManager::isSessionLocked() {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes freeze and subsequent crash when launching hyprlock and a grab is active (reproduced via a popup on waybar)
```
#0  0x00007effc3bb57dc in __pthread_kill_implementation ()
   from /nix/store/3dyw8dzj9ab4m8hv5dpyx7zii8d0w6fi-glibc-2.39-52/lib/libc.so.6
#1  0x00007effc3b63516 in raise ()
   from /nix/store/3dyw8dzj9ab4m8hv5dpyx7zii8d0w6fi-glibc-2.39-52/lib/libc.so.6
#2  0x00007effc3b4b935 in abort ()
   from /nix/store/3dyw8dzj9ab4m8hv5dpyx7zii8d0w6fi-glibc-2.39-52/lib/libc.so.6
#3  0x00000000005113d4 in handleUnrecoverableSignal(int) ()
#4  <signal handler called>
#5  0x0000000000619799 in CWLSurface::getLayer() const ()
#6  0x0000000000753384 in CSeatManager::setGrab(Hyprutils::Memory::CSharedPointer<CSeatGrab>)()
#7  0x00000000008f1d65 in CXDGShellProtocol::onPopupDestroy(Hyprutils::Memory::CWeakPointer<C
XDGPopupResource>) ()
#8  0x00000000008f2381 in std::_Function_handler<void (CXdgPopup*), CXDGPopupResource::CXDGPo
pupResource(Hyprutils::Memory::CSharedPointer<CXdgPopup>, Hyprutils::Memory::CSharedPointer<C
XDGSurfaceResource>, Hyprutils::Memory::CSharedPointer<CXDGSurfaceResource>, Hyprutils::Memor
y::CSharedPointer<CXDGPositionerResource>)::{lambda(CXdgPopup*)#1}>::_M_invoke(std::_Any_data
 const&, CXdgPopup*&&) ()
#9  0x00000000004f9403 in _CXdgPopupDestroy(wl_client*, wl_resource*) ()
#10 0x00007effc3a1e052 in ffi_call_unix64 ()
   from /nix/store/4ybgqxv43z9sk9lccwq6dgmz6j32syr1-libffi-3.4.6/lib/libffi.so.8
#11 0x00007effc3a1c125 in ffi_call_int ()
   from /nix/store/4ybgqxv43z9sk9lccwq6dgmz6j32syr1-libffi-3.4.6/lib/libffi.so.8
#12 0x00007effc3a1cd38 in ffi_call ()
   from /nix/store/4ybgqxv43z9sk9lccwq6dgmz6j32syr1-libffi-3.4.6/lib/libffi.so.8
#13 0x00007effc4c06351 in wl_closure_invoke ()
   from /nix/store/cdnwvy5zyh6la8x1cal00xmvsj8x3dai-wayland-1.23.1/lib/libwayland-server.so.0
#14 0x00007effc4c00d6a in wl_client_connection_data ()
   from /nix/store/cdnwvy5zyh6la8x1cal00xmvsj8x3dai-wayland-1.23.1/lib/libwayland-server.so.0
#15 0x00007effc4c03ed2 in wl_event_loop_dispatch ()
   from /nix/store/cdnwvy5zyh6la8x1cal00xmvsj8x3dai-wayland-1.23.1/lib/libwayland-server.so.0
#16 0x00007effc4c015d5 in wl_display_run ()
   from /nix/store/cdnwvy5zyh6la8x1cal00xmvsj8x3dai-wayland-1.23.1/lib/libwayland-server.so.0
#17 0x0000000000775f5f in CEventLoopManager::enterLoop() ()

```

Closes #https://github.com/hyprwm/hyprlock/issues/210
Did not find a matching Hyprland issue.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Yes
