### PR TITLE
config: fix generateConfig loop

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -688,14 +688,13 @@ std::string CConfigManager::getMainConfigPath() {
 
     if (const auto CFG_ENV = getenv("HYPRLAND_CONFIG"); CFG_ENV)
         return CFG_ENV;
-    Debug::log(TRACE, "Seems as if HYPRLAND_CONFIG isn't set, let's see what we can do with HOME.");
 
-    const auto paths = Hyprutils::Path::findConfig(ISDEBUG ? "hyprlandd" : "hyprland");
-    if (paths.first.has_value()) {
-        return paths.first.value();
-    } else if (paths.second.has_value()) {
-        auto configPath = Hyprutils::Path::fullConfigPath(paths.second.value(), ISDEBUG ? "hyprlandd" : "hyprland");
-        return generateConfig(configPath).value();
+    const auto PATHS = Hyprutils::Path::findConfig(ISDEBUG ? "hyprlandd" : "hyprland");
+    if (PATHS.first.has_value()) {
+        return PATHS.first.value();
+    } else if (PATHS.second.has_value()) {
+        const auto CONFIGPATH = Hyprutils::Path::fullConfigPath(PATHS.second.value(), ISDEBUG ? "hyprlandd" : "hyprland");
+        return generateConfig(CONFIGPATH).value();
     } else
         throw std::runtime_error("Neither HOME nor XDG_CONFIG_HOME are set in the environment. Could not find config in XDG_CONFIG_DIRS or /etc/xdg.");
 }

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -690,7 +690,7 @@ std::string CConfigManager::getMainConfigPath() {
         return CFG_ENV;
     Debug::log(TRACE, "Seems as if HYPRLAND_CONFIG isn't set, let's see what we can do with HOME.");
 
-    static const auto paths = Hyprutils::Path::findConfig(ISDEBUG ? "hyprlandd" : "hyprland");
+    const auto paths = Hyprutils::Path::findConfig(ISDEBUG ? "hyprlandd" : "hyprland");
     if (paths.first.has_value()) {
         return paths.first.value();
     } else if (paths.second.has_value()) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Two of my friends tried out hyprland recently and got into a infinite loop, where it would write the autogenerated config, trigger the hot reload and write the autogenerated config again.

I struggled quite a bit to find out why that happens, but it turns out that it is because this paths var was declared static. So there weren't any subsequent calls to `findConfig` at all.

I did search for issues but did not find one, although i vaguely remember that someone described this problem somewhere.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Yes
