### PR TITLE
hyprpm: Add option to notify on fail and keep original notify

### DIFF
--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -23,7 +23,8 @@ constexpr std::string_view HELP = R"#(┏ hyprpm, a Hyprland Plugin Manager
 ┃
 ┣ Flags:
 ┃
-┣ --notify       | -n    → Send a hyprland notification for important events (e.g. load fail)
+┣ --notify       | -n    → Send a hyprland notification for important events (including both successes and fail events)
+┣ --notify-fail  | -nn   → Send a hyprland notification for fail events only
 ┣ --help         | -h    → Show this menu
 ┣ --verbose      | -v    → Enable too much logging
 ┣ --force        | -f    → Force an operation ignoring checks (e.g. update -f)
@@ -43,7 +44,7 @@ int                        main(int argc, char** argv, char** envp) {
     }
 
     std::vector<std::string> command;
-    bool                     notify = false, verbose = false, force = false, noShallow = false;
+    bool                     notify = false, notifyFail = false, verbose = false, force = false, noShallow = false;
 
     for (int i = 1; i < argc; ++i) {
         if (ARGS[i].starts_with("-")) {
@@ -52,6 +53,8 @@ int                        main(int argc, char** argv, char** envp) {
                 return 0;
             } else if (ARGS[i] == "--notify" || ARGS[i] == "-n") {
                 notify = true;
+            } else if (ARGS[i] == "--notify-fail" || ARGS[i] == "-nn") {
+                notifyFail = notify = true;
             } else if (ARGS[i] == "--verbose" || ARGS[i] == "-v") {
                 verbose = true;
             } else if (ARGS[i] == "--no-shallow" || ARGS[i] == "-s") {
@@ -155,6 +158,9 @@ int                        main(int argc, char** argv, char** envp) {
                     break;
                 default: break;
             }
+        } else if (notify && !notifyFail) {
+            g_pPluginManager->notify(ICON_OK, 0, 4000, "[hyprpm] Loaded plugins");
+        }
     } else if (command[0] == "list") {
         g_pPluginManager->listAllPlugins();
     } else {

--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -155,9 +155,6 @@ int                        main(int argc, char** argv, char** envp) {
                     break;
                 default: break;
             }
-        } else if (notify) {
-            g_pPluginManager->notify(ICON_OK, 0, 4000, "[hyprpm] Loaded plugins");
-        }
     } else if (command[0] == "list") {
         g_pPluginManager->listAllPlugins();
     } else {


### PR DESCRIPTION
Hyprpm fail/pass notification are mutually exclusive.

#### Describe your PR, what does it fix/add?
~~By only generating fail notifications, we reduce UI clutter.~~
Add additional `-nn` option to generate notification only on fail events.


#### Is it ready for merging, or does it need work?
Yes

