### PR TITLE
minor XWM fix

### DIFF
--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -920,15 +920,28 @@ void CXWM::createWMWindow() {
 void CXWM::activateSurface(SP<CXWaylandSurface> surf, bool activate) {
     if ((surf == focusedSurface && activate) || (surf && surf->overrideRedirect))
         return;
-
-    if (!surf || (!activate && g_pCompositor->m_pLastWindow && !g_pCompositor->m_pLastWindow->m_bIsX11)) {
+    if (!surf){
         setActiveWindow((uint32_t)XCB_WINDOW_NONE);
         focusWindow(nullptr);
-    } else {
-        setActiveWindow(surf ? surf->xID : (uint32_t)XCB_WINDOW_NONE);
-        focusWindow(surf);
+    }else{
+        if(activate){
+            setActiveWindow(surf->xID);
+            focusWindow(surf);
+        } else {
+            if(g_pCompositor->m_pLastWindow){
+                if(!g_pCompositor->m_pLastWindow->m_bIsX11){
+                    setActiveWindow(surf->wlID);
+                    focusWindow(surf);
+                }else{
+                    setActiveWindow(surf->xID);
+                    focusWindow(surf);
+                }
+            }else{
+                setActiveWindow((uint32_t)XCB_WINDOW_NONE);
+                focusWindow(nullptr);
+            }      
+        }
     }
-
     xcb_flush(connection);
 }
 

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -920,26 +920,26 @@ void CXWM::createWMWindow() {
 void CXWM::activateSurface(SP<CXWaylandSurface> surf, bool activate) {
     if ((surf == focusedSurface && activate) || (surf && surf->overrideRedirect))
         return;
-    if (!surf){
+    if (!surf) {
         setActiveWindow((uint32_t)XCB_WINDOW_NONE);
         focusWindow(nullptr);
-    }else{
-        if(activate){
+    } else {
+        if (activate) {
             setActiveWindow(surf->xID);
             focusWindow(surf);
         } else {
-            if(g_pCompositor->m_pLastWindow){
-                if(!g_pCompositor->m_pLastWindow->m_bIsX11){
+            if (g_pCompositor->m_pLastWindow) {
+                if (!g_pCompositor->m_pLastWindow->m_bIsX11) {
                     setActiveWindow(surf->wlID);
                     focusWindow(surf);
-                }else{
+                } else {
                     setActiveWindow(surf->xID);
                     focusWindow(surf);
                 }
-            }else{
+            } else {
                 setActiveWindow((uint32_t)XCB_WINDOW_NONE);
                 focusWindow(nullptr);
-            }      
+            }
         }
     }
     xcb_flush(connection);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Partially fixes an issue in hyprland where some games FPS get throttled when you change windows focus while in game (pretty annoying when playing First Person Shooters). Now the FPS stays stable if you change focus from game to a Wayland surface, but still get throttled if you change focus to another xwayland surface. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
only Tested with Apex Legends on steam.


#### Is it ready for merging, or does it need work?
Well I would say is not since the issue still happens when the focus changes from an xwayland to another xwayland window. But I doubt I'll have time to continue working on it this week so maybe someone else can finish it.

