### PR TITLE
Build with hyprland-session.service and hyprland-systemd.desktop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,7 +363,7 @@ install(FILES ${CMAKE_SOURCE_DIR}/example/hyprland-systemd.desktop
 
 # install systemd service
 install(FILES ${CMAKE_SOURCE_DIR}/example/hyprland-session.service
-       DESTINATION "lib/systemd/user")
+       DESTINATION "${CMAKE_INSTALL_LIBDIR}/systemd/user")
 
 # allow Hyprland to find assets
 add_compile_definitions(DATAROOTDIR="${CMAKE_INSTALL_FULL_DATAROOTDIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,6 +357,14 @@ install(
 install(FILES ${CMAKE_SOURCE_DIR}/example/hyprland.desktop
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/wayland-sessions)
 
+# session file - systemd support
+install(FILES ${CMAKE_SOURCE_DIR}/example/hyprland-systemd.desktop
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/wayland-sessions)
+
+# install systemd service
+install(FILES ${CMAKE_SOURCE_DIR}/example/hyprland-session.service
+       DESTINATION "lib/systemd/user")
+
 # allow Hyprland to find assets
 add_compile_definitions(DATAROOTDIR="${CMAKE_INSTALL_FULL_DATAROOTDIR}")
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Improved systemd support. Hyprland is built with hyprland-session.service and hyprland-systemd.desktop from https://github.com/hyprwm/Hyprland/pull/7409.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
First serious merge, so better to double-check.


#### Is it ready for merging, or does it need work?
hyprland-session.service works, tested with `[ "$(tty)" = "/dev/tty1" ] && exec systemctl --user start --wait hyprland-session.service` in `.zprofile`. hyprland-systemd.desktop should work too.

