### PR TITLE
security-context: avoid UB in C macro

### DIFF
--- a/src/protocols/SecurityContext.hpp
+++ b/src/protocols/SecurityContext.hpp
@@ -37,14 +37,20 @@ class CSecurityContextManagerResource {
     SP<CWpSecurityContextManagerV1> resource;
 };
 
+class CSecurityContextSandboxedClient;
+struct CSecurityContextSandboxedClientDestroyWrapper {
+    wl_listener                      listener;
+    CSecurityContextSandboxedClient* parent = nullptr;
+};
+
 class CSecurityContextSandboxedClient {
   public:
     static SP<CSecurityContextSandboxedClient> create(int clientFD);
     ~CSecurityContextSandboxedClient();
 
-    void        onDestroy();
+    void                                          onDestroy();
 
-    wl_listener destroyListener;
+    CSecurityContextSandboxedClientDestroyWrapper destroyListener;
 
   private:
     CSecurityContextSandboxedClient(int clientFD_);


### PR DESCRIPTION
to safely use wl_container_of with a class the class has to be no virtual functions, no inheritance, and uniform access control (e.g all public)

work around this by putting this into a destroywrapper struct.

just like in https://github.com/hyprwm/hyprwayland-scanner/pull/8

however this warrants for some testing so it doesnt break something. not sure what uses this protocol besides static analyzers showing the issue.


