### PR TITLE
optimize cursor move a bit

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -240,10 +240,6 @@ CBox CWindow::getWindowBoxUnified(uint64_t properties) {
     return box;
 }
 
-CBox CWindow::getWindowMainSurfaceBox() {
-    return {m_vRealPosition.value().x, m_vRealPosition.value().y, m_vRealSize.value().x, m_vRealSize.value().y};
-}
-
 SBoxExtents CWindow::getFullWindowReservedArea() {
     return g_pDecorationPositioner->getWindowDecorationReserved(m_pSelf.lock());
 }

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -396,10 +396,12 @@ class CWindow {
     }
 
     // methods
-    CBox                   getFullWindowBoundingBox();
-    SBoxExtents            getFullWindowExtents();
-    CBox                   getWindowBoxUnified(uint64_t props);
-    CBox                   getWindowMainSurfaceBox();
+    CBox        getFullWindowBoundingBox();
+    SBoxExtents getFullWindowExtents();
+    CBox        getWindowBoxUnified(uint64_t props);
+    inline CBox getWindowMainSurfaceBox() const {
+        return {m_vRealPosition.value().x, m_vRealPosition.value().y, m_vRealSize.value().x, m_vRealSize.value().y};
+    }
     CBox                   getWindowIdealBoundingBoxIgnoreReserved();
     void                   addWindowDeco(std::unique_ptr<IHyprWindowDecoration> deco);
     void                   updateWindowDecos();

--- a/src/render/decorations/DecorationPositioner.cpp
+++ b/src/render/decorations/DecorationPositioner.cpp
@@ -297,13 +297,14 @@ SBoxExtents CDecorationPositioner::getWindowDecorationExtents(PHLWINDOW pWindow,
     CBox accum = pWindow->getWindowMainSurfaceBox();
 
     for (auto const& data : m_vWindowPositioningDatas) {
-        if (data->pWindow.lock() != pWindow)
-            continue;
-
-        if (!data->pWindow.lock() || !data->pDecoration)
+        if (!data->pDecoration)
             continue;
 
         if (!(data->pDecoration->getDecorationFlags() & DECORATION_ALLOWS_MOUSE_INPUT) && inputOnly)
+            continue;
+
+        auto const window = data->pWindow.lock();
+        if (!window || window != pWindow)
             continue;
 
         CBox decoBox;
@@ -373,9 +374,10 @@ CBox CDecorationPositioner::getBoxWithIncludedDecos(PHLWINDOW pWindow) {
 }
 
 CBox CDecorationPositioner::getWindowDecorationBox(IHyprWindowDecoration* deco) {
-    const auto DATA = getDataFor(deco, deco->m_pWindow.lock());
+    auto const window = deco->m_pWindow.lock();
+    const auto DATA   = getDataFor(deco, window);
 
     CBox       box = DATA->lastReply.assignedGeometry;
-    box.translate(getEdgeDefinedPoint(DATA->positioningInfo.edges, deco->m_pWindow.lock()));
+    box.translate(getEdgeDefinedPoint(DATA->positioningInfo.edges, window));
     return box;
 }


### PR DESCRIPTION
was profiling cpu usage while erraticly moving the mouse cursor
found a few things that could be improved without changing much of the code logic.

seems im getting a gazzilion calls to mouseMoveUnified, so even down to unnecessery temporary copies was showing up in the profiling.


