### PR TITLE
swallow: check if swallow_regex doesn't exist in the user's config file

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1531,7 +1531,7 @@ PHLWINDOW CWindow::getSwallower() {
     static auto PSWALLOWEXREGEX = CConfigValue<std::string>("misc:swallow_exception_regex");
     static auto PSWALLOW        = CConfigValue<Hyprlang::INT>("misc:enable_swallow");
 
-    if (!*PSWALLOW || (*PSWALLOWREGEX).empty())
+    if (!*PSWALLOW || std::string{*PSWALLOWREGEX} == STRVAL_EMPTY || (*PSWALLOWREGEX).empty())
         return nullptr;
 
     // check parent


### PR DESCRIPTION
Avoid to run CWindow::getSwallower() when `swallow_regex` doesn't exist in the user's config file.

One little grain of sand, but one by one, together they make a beautiful beach :-D
Cheers