### PR TITLE
Core: move internal structures from monitor IDs to pointers

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -242,7 +242,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             (uintptr_t)w.get(), (w->m_bIsMapped ? "true" : "false"), (w->isHidden() ? "true" : "false"), (int)w->m_vRealPosition.goal().x, (int)w->m_vRealPosition.goal().y,
             (int)w->m_vRealSize.goal().x, (int)w->m_vRealSize.goal().y, w->m_pWorkspace ? w->workspaceID() : WORKSPACE_INVALID,
             escapeJSONStrings(!w->m_pWorkspace ? "" : w->m_pWorkspace->m_szName), ((int)w->m_bIsFloating == 1 ? "true" : "false"), (w->m_bIsPseudotiled ? "true" : "false"),
-            (int64_t)w->m_iMonitorID, escapeJSONStrings(w->m_szClass), escapeJSONStrings(w->m_szTitle), escapeJSONStrings(w->m_szInitialClass),
+            (int64_t)w->monitorID(), escapeJSONStrings(w->m_szClass), escapeJSONStrings(w->m_szTitle), escapeJSONStrings(w->m_szInitialClass),
             escapeJSONStrings(w->m_szInitialTitle), w->getPID(), ((int)w->m_bIsX11 == 1 ? "true" : "false"), (w->m_bPinned ? "true" : "false"),
             (uint8_t)w->m_sFullscreenState.internal, (uint8_t)w->m_sFullscreenState.client, getGroupedData(w, format), getTagsData(w, format),
             (uintptr_t)w->m_pSwallowed.lock().get(), getFocusHistoryID(w));
@@ -254,7 +254,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             "{}\n\tfullscreen: {}\n\tfullscreenClient: {}\n\tgrouped: {}\n\ttags: {}\n\tswallowing: {:x}\n\tfocusHistoryID: {}\n\n",
             (uintptr_t)w.get(), w->m_szTitle, (int)w->m_bIsMapped, (int)w->isHidden(), (int)w->m_vRealPosition.goal().x, (int)w->m_vRealPosition.goal().y,
             (int)w->m_vRealSize.goal().x, (int)w->m_vRealSize.goal().y, w->m_pWorkspace ? w->workspaceID() : WORKSPACE_INVALID, (!w->m_pWorkspace ? "" : w->m_pWorkspace->m_szName),
-            (int)w->m_bIsFloating, (int)w->m_bIsPseudotiled, (int64_t)w->m_iMonitorID, w->m_szClass, w->m_szTitle, w->m_szInitialClass, w->m_szInitialTitle, w->getPID(),
+            (int)w->m_bIsFloating, (int)w->m_bIsPseudotiled, (int64_t)w->monitorID(), w->m_szClass, w->m_szTitle, w->m_szInitialClass, w->m_szInitialTitle, w->getPID(),
             (int)w->m_bIsX11, (int)w->m_bPinned, (uint8_t)w->m_sFullscreenState.internal, (uint8_t)w->m_sFullscreenState.client, getGroupedData(w, format), getTagsData(w, format),
             (uintptr_t)w->m_pSwallowed.lock().get(), getFocusHistoryID(w));
     }
@@ -288,7 +288,7 @@ std::string clientsRequest(eHyprCtlOutputFormat format, std::string request) {
 
 std::string CHyprCtl::getWorkspaceData(PHLWORKSPACE w, eHyprCtlOutputFormat format) {
     const auto PLASTW   = w->getLastFocusedWindow();
-    const auto PMONITOR = g_pCompositor->getMonitorFromID(w->m_iMonitorID);
+    const auto PMONITOR = w->m_pMonitor.lock();
     if (format == eHyprCtlOutputFormat::FORMAT_JSON) {
         return std::format(R"#({{
     "id": {},

--- a/src/desktop/LayerSurface.hpp
+++ b/src/desktop/LayerSurface.hpp
@@ -42,7 +42,7 @@ class CLayerSurface {
     bool                       mapped = false;
     uint32_t                   layer  = 0;
 
-    MONITORID                  monitorID = -1;
+    PHLMONITORREF              monitor;
 
     bool                       fadingOut     = false;
     bool                       readyToDelete = false;
@@ -70,6 +70,7 @@ class CLayerSurface {
     void                       onMap();
     void                       onUnmap();
     void                       onCommit();
+    MONITORID                  monitorID();
 
   private:
     struct {
@@ -83,6 +84,6 @@ class CLayerSurface {
 
     // For the list lookup
     bool operator==(const CLayerSurface& rhs) const {
-        return layerSurface == rhs.layerSurface && monitorID == rhs.monitorID;
+        return layerSurface == rhs.layerSurface && monitor == rhs.monitor;
     }
 };

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -272,12 +272,12 @@ class CWindow {
     bool             m_bDraggingTiled   = false; // for dragging around tiled windows
     bool             m_bWasMaximized    = false;
     sFullscreenState m_sFullscreenState = {.internal = FSMODE_NONE, .client = FSMODE_NONE};
-    MONITORID        m_iMonitorID       = -1;
     std::string      m_szTitle          = "";
     std::string      m_szClass          = "";
     std::string      m_szInitialTitle   = "";
     std::string      m_szInitialClass   = "";
     PHLWORKSPACE     m_pWorkspace;
+    PHLMONITORREF    m_pMonitor;
 
     bool             m_bIsMapped = false;
 
@@ -429,6 +429,7 @@ class CWindow {
     void                   setSuspended(bool suspend);
     bool                   visibleOnMonitor(PHLMONITOR pMonitor);
     WORKSPACEID            workspaceID();
+    MONITORID              monitorID();
     bool                   onSpecialWorkspace();
     void                   activate(bool force = false);
     int                    surfacesCount();
@@ -559,7 +560,7 @@ struct std::formatter<PHLWINDOW, CharT> : std::formatter<CharT> {
         if (formatWorkspace)
             std::format_to(out, ", workspace: {}", w->m_pWorkspace ? w->workspaceID() : WORKSPACE_INVALID);
         if (formatMonitor)
-            std::format_to(out, ", monitor: {}", w->m_iMonitorID);
+            std::format_to(out, ", monitor: {}", w->monitorID());
         if (formatClass)
             std::format_to(out, ", class: {}", w->m_szClass);
         return std::format_to(out, "]");

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -17,16 +17,16 @@ class CWindow;
 
 class CWorkspace {
   public:
-    static PHLWORKSPACE create(WORKSPACEID id, MONITORID monitorID, std::string name, bool special = false, bool isEmpty = true);
+    static PHLWORKSPACE create(WORKSPACEID id, PHLMONITOR monitor, std::string name, bool special = false, bool isEmpty = true);
     // use create() don't use this
-    CWorkspace(WORKSPACEID id, MONITORID monitorID, std::string name, bool special = false, bool isEmpty = true);
+    CWorkspace(WORKSPACEID id, PHLMONITOR monitor, std::string name, bool special = false, bool isEmpty = true);
     ~CWorkspace();
 
     // Workspaces ID-based have IDs > 0
     // and workspaces name-based have IDs starting with -1337
-    WORKSPACEID m_iID        = WORKSPACE_INVALID;
-    std::string m_szName     = "";
-    MONITORID   m_iMonitorID = MONITOR_INVALID;
+    WORKSPACEID   m_iID    = WORKSPACE_INVALID;
+    std::string   m_szName = "";
+    PHLMONITORREF m_pMonitor;
     // Previous workspace ID and name is stored during a workspace change, allowing travel
     // to the previous workspace.
     SWorkspaceIDName m_sPrevWorkspace, m_sPrevWorkspacePerMonitor;
@@ -68,6 +68,7 @@ class CWorkspace {
     void             setActive(bool on);
 
     void             moveToMonitor(const MONITORID&);
+    MONITORID        monitorID();
 
     PHLWINDOW        getLastFocusedWindow();
     void             rememberPrevWorkspace(const PHLWORKSPACE& prevWorkspace);

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -302,7 +302,7 @@ SWorkspaceIDName getWorkspaceIDNameFromString(const std::string& in) {
 
             // Collect all the workspaces we can't jump to.
             for (auto const& ws : g_pCompositor->m_vWorkspaces) {
-                if (ws->m_bIsSpecialWorkspace || (ws->m_iMonitorID != g_pCompositor->m_pLastMonitor->ID)) {
+                if (ws->m_bIsSpecialWorkspace || (ws->m_pMonitor != g_pCompositor->m_pLastMonitor)) {
                     // Can't jump to this workspace
                     invalidWSes.insert(ws->m_iID);
                 }
@@ -320,7 +320,7 @@ SWorkspaceIDName getWorkspaceIDNameFromString(const std::string& in) {
             // Prepare all named workspaces in case when we need them
             std::vector<WORKSPACEID> namedWSes;
             for (auto const& ws : g_pCompositor->m_vWorkspaces) {
-                if (ws->m_bIsSpecialWorkspace || (ws->m_iMonitorID != g_pCompositor->m_pLastMonitor->ID) || ws->m_iID >= 0)
+                if (ws->m_bIsSpecialWorkspace || (ws->m_pMonitor != g_pCompositor->m_pLastMonitor) || ws->m_iID >= 0)
                     continue;
 
                 namedWSes.push_back(ws->m_iID);
@@ -464,7 +464,7 @@ SWorkspaceIDName getWorkspaceIDNameFromString(const std::string& in) {
 
             std::vector<WORKSPACEID> validWSes;
             for (auto const& ws : g_pCompositor->m_vWorkspaces) {
-                if (ws->m_bIsSpecialWorkspace || (ws->m_iMonitorID != g_pCompositor->m_pLastMonitor->ID && !onAllMonitors))
+                if (ws->m_bIsSpecialWorkspace || (ws->m_pMonitor != g_pCompositor->m_pLastMonitor && !onAllMonitors))
                     continue;
 
                 validWSes.push_back(ws->m_iID);

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -99,12 +99,12 @@ void CAnimationManager::tick() {
                 PDECO->damageEntire();
             }
 
-            PMONITOR = g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID);
+            PMONITOR = PWINDOW->m_pMonitor.lock();
             if (!PMONITOR)
                 continue;
             animationsDisabled = PWINDOW->m_sWindowData.noAnim.valueOr(animationsDisabled);
         } else if (PWORKSPACE) {
-            PMONITOR = g_pCompositor->getMonitorFromID(PWORKSPACE->m_iMonitorID);
+            PMONITOR = PWORKSPACE->m_pMonitor.lock();
             if (!PMONITOR)
                 continue;
 
@@ -325,7 +325,7 @@ void CAnimationManager::animationSlide(PHLWINDOW pWindow, std::string force, boo
     const auto GOALPOS  = pWindow->m_vRealPosition.goal();
     const auto GOALSIZE = pWindow->m_vRealSize.goal();
 
-    const auto PMONITOR = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
+    const auto PMONITOR = pWindow->m_pMonitor.lock();
 
     if (!PMONITOR)
         return; // unsafe state most likely

--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -117,7 +117,7 @@ void CHyprXWaylandManager::setWindowSize(PHLWINDOW pWindow, Vector2D size, bool 
 
     static auto PXWLFORCESCALEZERO = CConfigValue<Hyprlang::INT>("xwayland:force_zero_scaling");
 
-    const auto  PMONITOR = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
+    const auto  PMONITOR = pWindow->m_pMonitor.lock();
 
     size = size.clamp(Vector2D{0, 0}, Vector2D{std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()});
 

--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -15,9 +15,8 @@ void CInputManager::onSwipeBegin(IPointer::SSwipeBeginEvent e) {
 
     int onMonitor = 0;
     for (auto const& w : g_pCompositor->m_vWorkspaces) {
-        if (w->m_iMonitorID == g_pCompositor->m_pLastMonitor->ID && !g_pCompositor->isWorkspaceSpecial(w->m_iID)) {
+        if (w->m_pMonitor == g_pCompositor->m_pLastMonitor && !g_pCompositor->isWorkspaceSpecial(w->m_iID))
             onMonitor++;
-        }
     }
 
     if (onMonitor < 2 && !*PSWIPENEW)

--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -123,7 +123,7 @@ void CInputManager::onTouchMove(ITouch::SMotionEvent e) {
         return;
     }
     if (validMapped(m_sTouchData.touchFocusWindow)) {
-        const auto PMONITOR = g_pCompositor->getMonitorFromID(m_sTouchData.touchFocusWindow->m_iMonitorID);
+        const auto PMONITOR = m_sTouchData.touchFocusWindow->m_pMonitor.lock();
 
         g_pCompositor->warpCursorTo({PMONITOR->vecPosition.x + e.pos.x * PMONITOR->vecSize.x, PMONITOR->vecPosition.y + e.pos.y * PMONITOR->vecSize.y}, true);
 
@@ -133,7 +133,7 @@ void CInputManager::onTouchMove(ITouch::SMotionEvent e) {
 
         g_pSeatManager->sendTouchMotion(e.timeMs, e.touchID, local);
     } else if (!m_sTouchData.touchFocusLS.expired()) {
-        const auto PMONITOR = g_pCompositor->getMonitorFromID(m_sTouchData.touchFocusLS->monitorID);
+        const auto PMONITOR = m_sTouchData.touchFocusLS->monitor.lock();
 
         g_pCompositor->warpCursorTo({PMONITOR->vecPosition.x + e.pos.x * PMONITOR->vecSize.x, PMONITOR->vecPosition.y + e.pos.y * PMONITOR->vecSize.y}, true);
 

--- a/src/protocols/ForeignToplevelWlr.cpp
+++ b/src/protocols/ForeignToplevelWlr.cpp
@@ -207,7 +207,7 @@ void CForeignToplevelWlrManager::onMap(PHLWINDOW pWindow) {
     resource->sendToplevel(NEWHANDLE->resource.get());
     NEWHANDLE->resource->sendAppId(pWindow->m_szClass.c_str());
     NEWHANDLE->resource->sendTitle(pWindow->m_szTitle.c_str());
-    if (const auto PMONITOR = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID); PMONITOR)
+    if (const auto PMONITOR = pWindow->m_pMonitor.lock(); PMONITOR)
         NEWHANDLE->sendMonitor(PMONITOR);
     NEWHANDLE->sendState();
     NEWHANDLE->resource->sendDone();
@@ -266,7 +266,7 @@ void CForeignToplevelWlrManager::onMoveMonitor(PHLWINDOW pWindow) {
     if (!H || H->closed)
         return;
 
-    const auto PMONITOR = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
+    const auto PMONITOR = pWindow->m_pMonitor.lock();
 
     if (!PMONITOR)
         return;

--- a/src/protocols/LinuxDMABUF.cpp
+++ b/src/protocols/LinuxDMABUF.cpp
@@ -509,7 +509,7 @@ void CLinuxDMABufV1Protocol::resetFormatTable() {
             PHLMONITOR mon;
             auto       HLSurface = CWLSurface::fromResource(feedback->surface);
             if (auto w = HLSurface->getWindow(); w)
-                if (auto m = g_pCompositor->getMonitorFromID(w->m_iMonitorID); m)
+                if (auto m = w->m_pMonitor.lock(); m)
                     mon = m->self.lock();
 
             if (!mon) {

--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -97,7 +97,7 @@ CToplevelExportFrame::CToplevelExportFrame(SP<CHyprlandToplevelExportFrameV1> re
     resource->setDestroy([this](CHyprlandToplevelExportFrameV1* pFrame) { PROTO::toplevelExport->destroyResource(this); });
     resource->setCopy([this](CHyprlandToplevelExportFrameV1* pFrame, wl_resource* res, int32_t ignoreDamage) { this->copy(pFrame, res, ignoreDamage); });
 
-    const auto PMONITOR = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
+    const auto PMONITOR = pWindow->m_pMonitor.lock();
 
     g_pHyprRenderer->makeEGLCurrent();
 
@@ -239,7 +239,7 @@ bool CToplevelExportFrame::copyShm(timespec* now) {
     auto [pixelData, fmt, bufLen] = buffer->beginDataPtr(0); // no need for end, cuz it's shm
 
     // render the client
-    const auto PMONITOR = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
+    const auto PMONITOR = pWindow->m_pMonitor.lock();
     CRegion    fakeDamage{0, 0, PMONITOR->vecPixelSize.x * 10, PMONITOR->vecPixelSize.y * 10};
 
     g_pHyprRenderer->makeEGLCurrent();
@@ -296,7 +296,7 @@ bool CToplevelExportFrame::copyShm(timespec* now) {
 }
 
 bool CToplevelExportFrame::copyDmabuf(timespec* now) {
-    const auto PMONITOR = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
+    const auto PMONITOR = pWindow->m_pMonitor.lock();
 
     CRegion    fakeDamage{0, 0, INT16_MAX, INT16_MAX};
 
@@ -383,7 +383,7 @@ void CToplevelExportProtocol::onOutputCommit(PHLMONITOR pMonitor) {
 
         const auto PWINDOW = f->pWindow;
 
-        if (pMonitor != g_pCompositor->getMonitorFromID(PWINDOW->m_iMonitorID))
+        if (pMonitor != PWINDOW->m_pMonitor.lock())
             continue;
 
         CBox geometry = {PWINDOW->m_vRealPosition.value().x, PWINDOW->m_vRealPosition.value().y, PWINDOW->m_vRealSize.value().x, PWINDOW->m_vRealSize.value().y};

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -693,7 +693,7 @@ bool CHyprOpenGLImpl::passRequiresIntrospection(PHLMONITOR pMonitor) {
 
     if (*PBLURSPECIAL) {
         for (auto const& ws : g_pCompositor->m_vWorkspaces) {
-            if (!ws->m_bIsSpecialWorkspace || ws->m_iMonitorID != pMonitor->ID)
+            if (!ws->m_bIsSpecialWorkspace || ws->m_pMonitor != pMonitor)
                 continue;
 
             if (ws->m_fAlpha.value() == 0)
@@ -2219,7 +2219,7 @@ void CHyprOpenGLImpl::renderBorder(CBox* box, const CGradientValueData& grad, in
 
 void CHyprOpenGLImpl::makeRawWindowSnapshot(PHLWINDOW pWindow, CFramebuffer* pFramebuffer) {
     // we trust the window is valid.
-    const auto PMONITOR = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
+    const auto PMONITOR = pWindow->m_pMonitor.lock();
 
     if (!PMONITOR || !PMONITOR->output || PMONITOR->vecPixelSize.x <= 0 || PMONITOR->vecPixelSize.y <= 0)
         return;
@@ -2267,7 +2267,7 @@ void CHyprOpenGLImpl::makeRawWindowSnapshot(PHLWINDOW pWindow, CFramebuffer* pFr
 
 void CHyprOpenGLImpl::makeWindowSnapshot(PHLWINDOW pWindow) {
     // we trust the window is valid.
-    const auto PMONITOR = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
+    const auto PMONITOR = pWindow->m_pMonitor.lock();
 
     if (!PMONITOR || !PMONITOR->output || PMONITOR->vecPixelSize.x <= 0 || PMONITOR->vecPixelSize.y <= 0)
         return;
@@ -2319,7 +2319,7 @@ void CHyprOpenGLImpl::makeWindowSnapshot(PHLWINDOW pWindow) {
 
 void CHyprOpenGLImpl::makeLayerSnapshot(PHLLS pLayer) {
     // we trust the window is valid.
-    const auto PMONITOR = g_pCompositor->getMonitorFromID(pLayer->monitorID);
+    const auto PMONITOR = pLayer->monitor.lock();
 
     if (!PMONITOR || !PMONITOR->output || PMONITOR->vecPixelSize.x <= 0 || PMONITOR->vecPixelSize.y <= 0)
         return;
@@ -2372,7 +2372,7 @@ void CHyprOpenGLImpl::renderSnapshot(PHLWINDOW pWindow) {
     if (!FBDATA->m_cTex->m_iTexID)
         return;
 
-    const auto PMONITOR = g_pCompositor->getMonitorFromID(pWindow->m_iMonitorID);
+    const auto PMONITOR = pWindow->m_pMonitor.lock();
 
     CBox       windowBox;
     // some mafs to figure out the correct box
@@ -2411,7 +2411,7 @@ void CHyprOpenGLImpl::renderSnapshot(PHLLS pLayer) {
     if (!FBDATA->m_cTex->m_iTexID)
         return;
 
-    const auto PMONITOR = g_pCompositor->getMonitorFromID(pLayer->monitorID);
+    const auto PMONITOR = pLayer->monitor.lock();
 
     CBox       layerBox;
     // some mafs to figure out the correct box


### PR DESCRIPTION
Needs some testing, should improve performance a tiny bit now that we can do this.