### PR TITLE
few more marginal optimisations from profiling

### DIFF
--- a/src/desktop/Popup.cpp
+++ b/src/desktop/Popup.cpp
@@ -288,12 +288,13 @@ bool CPopup::visible() {
     return false;
 }
 
-void CPopup::bfHelper(std::vector<CPopup*> nodes, std::function<void(CPopup*, void*)> fn, void* data) {
+void CPopup::bfHelper(std::vector<CPopup*> const& nodes, std::function<void(CPopup*, void*)> fn, void* data) {
     for (auto const& n : nodes) {
         fn(n, data);
     }
 
     std::vector<CPopup*> nodes2;
+    nodes2.reserve(nodes.size() * 2);
 
     for (auto const& n : nodes) {
         for (auto const& c : n->m_vChildren) {

--- a/src/desktop/Popup.hpp
+++ b/src/desktop/Popup.hpp
@@ -81,5 +81,5 @@ class CPopup {
 
     Vector2D    localToGlobal(const Vector2D& rel);
     Vector2D    t1ParentCoords();
-    static void bfHelper(std::vector<CPopup*> nodes, std::function<void(CPopup*, void*)> fn, void* data);
+    static void bfHelper(std::vector<CPopup*> const& nodes, std::function<void(CPopup*, void*)> fn, void* data);
 };

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -252,9 +252,10 @@ void CWLSurfaceResource::resetRole() {
     role = makeShared<CDefaultSurfaceRole>();
 }
 
-void CWLSurfaceResource::bfHelper(std::vector<SP<CWLSurfaceResource>> nodes, std::function<void(SP<CWLSurfaceResource>, const Vector2D&, void*)> fn, void* data) {
+void CWLSurfaceResource::bfHelper(std::vector<SP<CWLSurfaceResource>> const& nodes, std::function<void(SP<CWLSurfaceResource>, const Vector2D&, void*)> fn, void* data) {
 
     std::vector<SP<CWLSurfaceResource>> nodes2;
+    nodes2.reserve(nodes.size() * 2);
 
     // first, gather all nodes below
     for (auto const& n : nodes) {

--- a/src/protocols/core/Compositor.hpp
+++ b/src/protocols/core/Compositor.hpp
@@ -147,7 +147,7 @@ class CWLSurfaceResource {
     void          dropPendingBuffer();
     void          dropCurrentBuffer();
     void          commitPendingState();
-    void          bfHelper(std::vector<SP<CWLSurfaceResource>> nodes, std::function<void(SP<CWLSurfaceResource>, const Vector2D&, void*)> fn, void* data);
+    void          bfHelper(std::vector<SP<CWLSurfaceResource>> const& nodes, std::function<void(SP<CWLSurfaceResource>, const Vector2D&, void*)> fn, void* data);
     void          updateCursorShm();
 
     friend class CWLPointerResource;


### PR DESCRIPTION
found a few more marginal gains that could be had on high frequently called functions.

reserve the vector sizes to reduce the amount of reallocations that could happend, most of the time it doesnt.
use const ref in the function parameters and reduce function calls and temporar copies in getWindowDecorationExtents
and check if there is even extents to add before adding
