### PR TITLE
move setprop into dispatchers

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1261,6 +1261,11 @@ std::string dispatchSeterror(eHyprCtlOutputFormat format, std::string request) {
     return "ok";
 }
 
+std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
+    auto result = g_pKeybindManager->m_mDispatchers["setprop"](request.substr(request.find_first_of(' ') + 1, -1));
+    return "DEPRECATED: use hyprctl dispatch setprop instead" + (result.success ? "" : "\n" + result.error);
+}
+
 std::string dispatchGetOption(eHyprCtlOutputFormat format, std::string request) {
     std::string curitem = "";
 
@@ -1581,6 +1586,7 @@ CHyprCtl::CHyprCtl() {
     registerCommand(SHyprCtlCommand{"plugin", false, dispatchPlugin});
     registerCommand(SHyprCtlCommand{"notify", false, dispatchNotify});
     registerCommand(SHyprCtlCommand{"dismissnotify", false, dispatchDismissNotify});
+    registerCommand(SHyprCtlCommand{"setprop", false, dispatchSetProp});
     registerCommand(SHyprCtlCommand{"seterror", false, dispatchSeterror});
     registerCommand(SHyprCtlCommand{"switchxkblayout", false, switchXKBLayoutRequest});
     registerCommand(SHyprCtlCommand{"output", false, dispatchOutput});

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1261,104 +1261,6 @@ std::string dispatchSeterror(eHyprCtlOutputFormat format, std::string request) {
     return "ok";
 }
 
-std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
-    CVarList vars(request, 0, ' ');
-
-    if (vars.size() < 4)
-        return "not enough args";
-
-    const auto PLASTWINDOW = g_pCompositor->m_pLastWindow.lock();
-    const auto PWINDOW     = g_pCompositor->getWindowByRegex(vars[1]);
-
-    if (!PWINDOW)
-        return "window not found";
-
-    const auto PROP = vars[2];
-    const auto VAL  = vars[3];
-
-    bool       noFocus = PWINDOW->m_sWindowData.noFocus.valueOrDefault();
-
-    try {
-        if (PROP == "animationstyle") {
-            PWINDOW->m_sWindowData.animationStyle = CWindowOverridableVar(VAL, PRIORITY_SET_PROP);
-        } else if (PROP == "maxsize") {
-            PWINDOW->m_sWindowData.maxSize = CWindowOverridableVar(configStringToVector2D(VAL + " " + vars[4]), PRIORITY_SET_PROP);
-            PWINDOW->m_vRealSize           = Vector2D(std::min((double)PWINDOW->m_sWindowData.maxSize.value().x, PWINDOW->m_vRealSize.goal().x),
-                                                      std::min((double)PWINDOW->m_sWindowData.maxSize.value().y, PWINDOW->m_vRealSize.goal().y));
-            g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal());
-            PWINDOW->setHidden(false);
-        } else if (PROP == "minsize") {
-            PWINDOW->m_sWindowData.minSize = CWindowOverridableVar(configStringToVector2D(VAL + " " + vars[4]), PRIORITY_SET_PROP);
-            PWINDOW->m_vRealSize           = Vector2D(std::max((double)PWINDOW->m_sWindowData.minSize.value().x, PWINDOW->m_vRealSize.goal().x),
-                                                      std::max((double)PWINDOW->m_sWindowData.minSize.value().y, PWINDOW->m_vRealSize.goal().y));
-            g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal());
-            PWINDOW->setHidden(false);
-        } else if (PROP == "alpha") {
-            PWINDOW->m_sWindowData.alpha = CWindowOverridableVar(SAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alpha.valueOrDefault().m_bOverride}, PRIORITY_SET_PROP);
-        } else if (PROP == "alphainactive") {
-            PWINDOW->m_sWindowData.alphaInactive =
-                CWindowOverridableVar(SAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alphaInactive.valueOrDefault().m_bOverride}, PRIORITY_SET_PROP);
-        } else if (PROP == "alphafullscreen") {
-            PWINDOW->m_sWindowData.alphaFullscreen =
-                CWindowOverridableVar(SAlphaValue{std::stof(VAL), PWINDOW->m_sWindowData.alphaFullscreen.valueOrDefault().m_bOverride}, PRIORITY_SET_PROP);
-        } else if (PROP == "alphaoverride") {
-            PWINDOW->m_sWindowData.alpha =
-                CWindowOverridableVar(SAlphaValue{PWINDOW->m_sWindowData.alpha.valueOrDefault().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
-        } else if (PROP == "alphainactiveoverride") {
-            PWINDOW->m_sWindowData.alphaInactive =
-                CWindowOverridableVar(SAlphaValue{PWINDOW->m_sWindowData.alphaInactive.valueOrDefault().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
-        } else if (PROP == "alphafullscreenoverride") {
-            PWINDOW->m_sWindowData.alphaFullscreen =
-                CWindowOverridableVar(SAlphaValue{PWINDOW->m_sWindowData.alphaFullscreen.valueOrDefault().m_fAlpha, (bool)configStringToInt(VAL)}, PRIORITY_SET_PROP);
-        } else if (PROP == "activebordercolor" || PROP == "inactivebordercolor") {
-            CGradientValueData colorData = {};
-            if (vars.size() > 4) {
-                for (int i = 3; i < static_cast<int>(vars.size()); ++i) {
-                    const auto TOKEN = vars[i];
-                    if (TOKEN.ends_with("deg"))
-                        colorData.m_fAngle = std::stoi(TOKEN.substr(0, TOKEN.size() - 3)) * (PI / 180.0);
-                    else
-                        colorData.m_vColors.push_back(configStringToInt(TOKEN));
-                }
-            } else if (VAL != "-1")
-                colorData.m_vColors.push_back(configStringToInt(VAL));
-
-            if (PROP == "activebordercolor")
-                PWINDOW->m_sWindowData.activeBorderColor = CWindowOverridableVar(colorData, PRIORITY_SET_PROP);
-            else
-                PWINDOW->m_sWindowData.inactiveBorderColor = CWindowOverridableVar(colorData, PRIORITY_SET_PROP);
-        } else if (auto search = g_pConfigManager->mbWindowProperties.find(PROP); search != g_pConfigManager->mbWindowProperties.end()) {
-            auto pWindowDataElement = search->second(PWINDOW);
-            if (VAL == "toggle")
-                *pWindowDataElement = CWindowOverridableVar(!pWindowDataElement->valueOrDefault(), PRIORITY_SET_PROP);
-            else if (VAL == "unset")
-                pWindowDataElement->unset(PRIORITY_SET_PROP);
-            else
-                *pWindowDataElement = CWindowOverridableVar((bool)configStringToInt(VAL), PRIORITY_SET_PROP);
-        } else if (auto search = g_pConfigManager->miWindowProperties.find(PROP); search != g_pConfigManager->miWindowProperties.end()) {
-            if (VAL == "unset")
-                search->second(PWINDOW)->unset(PRIORITY_SET_PROP);
-            else
-                *(search->second(PWINDOW)) = CWindowOverridableVar((int)configStringToInt(VAL), PRIORITY_SET_PROP);
-        } else {
-            return "prop not found";
-        }
-    } catch (std::exception& e) { return "error in parsing prop value: " + std::string(e.what()); }
-
-    g_pCompositor->updateAllWindowsAnimatedDecorationValues();
-
-    if (!(PWINDOW->m_sWindowData.noFocus.valueOrDefault() == noFocus)) {
-        g_pCompositor->focusWindow(nullptr);
-        g_pCompositor->focusWindow(PWINDOW);
-        g_pCompositor->focusWindow(PLASTWINDOW);
-    }
-
-    for (auto const& m : g_pCompositor->m_vMonitors)
-        g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m->ID);
-
-    return "ok";
-}
-
 std::string dispatchGetOption(eHyprCtlOutputFormat format, std::string request) {
     std::string curitem = "";
 
@@ -1679,7 +1581,6 @@ CHyprCtl::CHyprCtl() {
     registerCommand(SHyprCtlCommand{"plugin", false, dispatchPlugin});
     registerCommand(SHyprCtlCommand{"notify", false, dispatchNotify});
     registerCommand(SHyprCtlCommand{"dismissnotify", false, dispatchDismissNotify});
-    registerCommand(SHyprCtlCommand{"setprop", false, dispatchSetProp});
     registerCommand(SHyprCtlCommand{"seterror", false, dispatchSeterror});
     registerCommand(SHyprCtlCommand{"switchxkblayout", false, switchXKBLayoutRequest});
     registerCommand(SHyprCtlCommand{"output", false, dispatchOutput});

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -217,6 +217,7 @@ class CKeybindManager {
     static SDispatchResult denyWindowFromGroup(std::string);
     static SDispatchResult global(std::string);
     static SDispatchResult event(std::string);
+    static SDispatchResult setProp(std::string);
 
     friend class CCompositor;
     friend class CInputManager;


### PR DESCRIPTION
Moves `setprop` to dispatchers, mostly to allow calling it in keybinds without having to use hyprctl.
Didn't find any issues.

wiki: https://github.com/hyprwm/hyprland-wiki/pull/832