### PR TITLE
seat: avoid sending pointless 'keymap' and 'repeat_info' events

### DIFF
--- a/src/protocols/core/Seat.hpp
+++ b/src/protocols/core/Seat.hpp
@@ -119,6 +119,10 @@ class CWLKeyboardResource {
     struct {
         CHyprSignalListener destroySurface;
     } listeners;
+
+    std::string lastKeymap  = "<none>";
+    uint32_t    lastRate    = 0;
+    uint32_t    lastDelayMs = 0;
 };
 
 class CWLSeatResource {


### PR DESCRIPTION
 #### Describe your PR, what does it fix/add?

Fix lag spikes when pressing more than 6 keys at the same time.

 #### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Debugging process:
<details>
This is triggered by typing some applications, like CopyQ or XWayland. Typing in Firefox doesn't lead to lag, however it itself does lag handling these events.

Profiling CopyQ shows that paths leading to
`QtWaylandClient::QWaylandInputDevice::Keyboard::keyboard` take over 80% of processing time of an otherwise idle program.

Looking at output of 'wev' even when it's not focused shows same events received over and over again.

```
[14:     wl_keyboard] repeat_info: rate: 25 keys/sec; delay: 300 ms
[14:     wl_keyboard] keymap: format: 1 (xkb v1), size: 64754
```

Looking at what passes through CInputManager::onKeyboardKey() -> CSeatManager::setKeyboard() shows Hyprland 'switching' between endpoints of the same keyboard, one of them being named like the other but with '-1' suffix.
</details>

Tested changing layouts in Fcitx5 and with following config.

```
input:kb_layout = us,cz
input:kb_variant = ,qwerty
input:kb_options = grp:alt_shift_toggle
```

Also tested changing 'input:repeat_delay' while running.

Curiously, now these events appear in the output of 'wev' only once. Changing layouts still seems to work fine though.

 #### Is it ready for merging, or does it need work?

Ready for merging.
