### PR TITLE
Fixed window not taking focus on scroll after workspace switch

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -831,6 +831,7 @@ void CInputManager::onMouseWheel(IPointer::SAxisEvent e) {
     int32_t deltaDiscrete = std::abs(discrete) != 0 && std::abs(discrete) < 1 ? std::copysign(1, discrete) : std::round(discrete);
 
     g_pSeatManager->sendPointerAxis(e.timeMs, e.axis, delta, deltaDiscrete, value120, e.source, WL_POINTER_AXIS_RELATIVE_DIRECTION_IDENTICAL);
+    simulateMouseMovement();
 }
 
 Vector2D CInputManager::getMouseCoordsInternal() {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Refocus on the hovered window with the scroll wheel after you switched back to the workspace. This works on mouse movement and on button clicks but not with the scroll wheel. This fixes #8180 (Which describes it in detail).


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I tested it on my pc and it seems to work. But I have the feeling that this is to "simple" of a solution.

- Should I check if I'm not on the currently focused window to perform the `refocus()`?
- Is there a better place to perform the `refocus()`?

I would appreciate a more detailed guidance on how to improve it (I'm new to this codebase) when this is insufficient


#### Is it ready for merging, or does it need work?
From my side yes