### PR TITLE
more profiling less calls and local copies

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -811,10 +811,10 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
     // pinned windows on top of floating regardless
     if (properties & ALLOW_FLOATING) {
         for (auto const& w : m_vWindows | std::views::reverse) {
-            const auto BB  = w->getWindowBoxUnified(properties);
-            CBox       box = BB.copy().expand(!w->isX11OverrideRedirect() ? BORDER_GRAB_AREA : 0);
             if (w->m_bIsFloating && w->m_bIsMapped && !w->isHidden() && !w->m_bX11ShouldntFocus && w->m_bPinned && !w->m_sWindowData.noFocus.valueOrDefault() &&
                 w != pIgnoreWindow) {
+                const auto BB  = w->getWindowBoxUnified(properties);
+                CBox       box = BB.copy().expand(!w->isX11OverrideRedirect() ? BORDER_GRAB_AREA : 0);
                 if (box.containsPoint(g_pPointerManager->position()))
                     return w;
 
@@ -833,22 +833,25 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
                 if (special && !w->onSpecialWorkspace()) // because special floating may creep up into regular
                     continue;
 
-                const auto BB             = w->getWindowBoxUnified(properties);
                 const auto PWINDOWMONITOR = w->m_pMonitor.lock();
 
                 // to avoid focusing windows behind special workspaces from other monitors
-                if (!*PSPECIALFALLTHRU && PWINDOWMONITOR && PWINDOWMONITOR->activeSpecialWorkspace && w->m_pWorkspace != PWINDOWMONITOR->activeSpecialWorkspace &&
-                    BB.x >= PWINDOWMONITOR->vecPosition.x && BB.y >= PWINDOWMONITOR->vecPosition.y &&
-                    BB.x + BB.width <= PWINDOWMONITOR->vecPosition.x + PWINDOWMONITOR->vecSize.x && BB.y + BB.height <= PWINDOWMONITOR->vecPosition.y + PWINDOWMONITOR->vecSize.y)
-                    continue;
+                if (!*PSPECIALFALLTHRU && PWINDOWMONITOR && PWINDOWMONITOR->activeSpecialWorkspace && w->m_pWorkspace != PWINDOWMONITOR->activeSpecialWorkspace) {
+                    const auto BB = w->getWindowBoxUnified(properties);
+                    if (BB.x >= PWINDOWMONITOR->vecPosition.x && BB.y >= PWINDOWMONITOR->vecPosition.y &&
+                        BB.x + BB.width <= PWINDOWMONITOR->vecPosition.x + PWINDOWMONITOR->vecSize.x &&
+                        BB.y + BB.height <= PWINDOWMONITOR->vecPosition.y + PWINDOWMONITOR->vecSize.y)
+                        continue;
+                }
 
-                CBox box = BB.copy().expand(!w->isX11OverrideRedirect() ? BORDER_GRAB_AREA : 0);
                 if (w->m_bIsFloating && w->m_bIsMapped && isWorkspaceVisible(w->m_pWorkspace) && !w->isHidden() && !w->m_bPinned && !w->m_sWindowData.noFocus.valueOrDefault() &&
                     w != pIgnoreWindow && (!aboveFullscreen || w->m_bCreatedOverFullscreen)) {
                     // OR windows should add focus to parent
                     if (w->m_bX11ShouldntFocus && !w->isX11OverrideRedirect())
                         continue;
 
+                    const auto BB  = w->getWindowBoxUnified(properties);
+                    CBox       box = BB.copy().expand(!w->isX11OverrideRedirect() ? BORDER_GRAB_AREA : 0);
                     if (box.containsPoint(g_pPointerManager->position())) {
 
                         if (w->m_bIsX11 && w->isX11OverrideRedirect() && !w->m_pXWaylandSurface->wantsFocus()) {
@@ -906,10 +909,12 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
             if (special != w->onSpecialWorkspace())
                 continue;
 
-            CBox box = (properties & USE_PROP_TILED) ? w->getWindowBoxUnified(properties) : CBox{w->m_vPosition, w->m_vSize};
-            if (!w->m_bIsFloating && w->m_bIsMapped && box.containsPoint(pos) && w->workspaceID() == WSPID && !w->isHidden() && !w->m_bX11ShouldntFocus &&
-                !w->m_sWindowData.noFocus.valueOrDefault() && w != pIgnoreWindow)
-                return w;
+            if (!w->m_bIsFloating && w->m_bIsMapped && w->workspaceID() == WSPID && !w->isHidden() && !w->m_bX11ShouldntFocus && !w->m_sWindowData.noFocus.valueOrDefault() &&
+                w != pIgnoreWindow) {
+                CBox box = (properties & USE_PROP_TILED) ? w->getWindowBoxUnified(properties) : CBox{w->m_vPosition, w->m_vSize};
+                if (box.containsPoint(pos))
+                    return w;
+            }
         }
 
         return nullptr;

--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -372,10 +372,8 @@ bool CPointerManager::setHWCursorBuffer(SP<SMonitorPointerState> state, SP<Aquam
 }
 
 SP<Aquamarine::IBuffer> CPointerManager::renderHWCursorBuffer(SP<CPointerManager::SMonitorPointerState> state, SP<CTexture> texture) {
-    auto output = state->monitor->output;
-
-    auto maxSize    = output->cursorPlaneSize();
-    auto cursorSize = currentCursorImage.size;
+    auto        maxSize    = state->monitor->output->cursorPlaneSize();
+    auto const& cursorSize = currentCursorImage.size;
 
     if (maxSize == Vector2D{})
         return nullptr;
@@ -421,8 +419,6 @@ SP<Aquamarine::IBuffer> CPointerManager::renderHWCursorBuffer(SP<CPointerManager
         Debug::log(TRACE, "Failed to acquire a buffer from the cursor swapchain");
         return nullptr;
     }
-
-    CRegion damage = {0, 0, INT16_MAX, INT16_MAX};
 
     g_pHyprRenderer->makeEGLCurrent();
     g_pHyprOpenGL->m_RenderData.pMonitor = state->monitor;
@@ -482,7 +478,7 @@ SP<Aquamarine::IBuffer> CPointerManager::renderHWCursorBuffer(SP<CPointerManager
 
     RBO->bind();
 
-    g_pHyprOpenGL->beginSimple(state->monitor.lock(), damage, RBO);
+    g_pHyprOpenGL->beginSimple(state->monitor.lock(), {0, 0, INT16_MAX, INT16_MAX}, RBO);
     g_pHyprOpenGL->clear(CColor{0.F, 0.F, 0.F, 0.F});
 
     CBox xbox = {{}, Vector2D{currentCursorImage.size / currentCursorImage.scale * state->monitor->scale}.round()};

--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -52,7 +52,7 @@ void CPointerManager::unlockSoftwareAll() {
 }
 
 void CPointerManager::lockSoftwareForMonitor(PHLMONITOR mon) {
-    auto state = stateFor(mon);
+    auto const state = stateFor(mon);
     state->softwareLocks++;
 
     if (state->softwareLocks == 1)
@@ -60,7 +60,7 @@ void CPointerManager::lockSoftwareForMonitor(PHLMONITOR mon) {
 }
 
 void CPointerManager::unlockSoftwareForMonitor(PHLMONITOR mon) {
-    auto state = stateFor(mon);
+    auto const state = stateFor(mon);
     state->softwareLocks--;
     if (state->softwareLocks < 0)
         state->softwareLocks = 0;
@@ -70,7 +70,7 @@ void CPointerManager::unlockSoftwareForMonitor(PHLMONITOR mon) {
 }
 
 bool CPointerManager::softwareLockedFor(PHLMONITOR mon) {
-    auto state = stateFor(mon);
+    auto const state = stateFor(mon);
     return state->softwareLocks > 0 || state->hardwareFailed;
 }
 
@@ -250,14 +250,13 @@ void CPointerManager::updateCursorBackend() {
     const auto CURSORBOX = getCursorBoxGlobal();
 
     for (auto const& m : g_pCompositor->m_vMonitors) {
-        auto state = stateFor(m);
-
         if (!m->m_bEnabled || !m->dpmsStatus) {
             Debug::log(TRACE, "Not updating hw cursors: disabled / dpms off display");
             continue;
         }
 
         auto CROSSES = !m->logicalBox().intersection(CURSORBOX).empty();
+        auto state   = stateFor(m);
 
         if (!CROSSES) {
             if (state->cursorFrontBuffer)

--- a/src/managers/eventLoop/EventLoopManager.cpp
+++ b/src/managers/eventLoop/EventLoopManager.cpp
@@ -98,7 +98,7 @@ void CEventLoopManager::nudgeTimers() {
     long nextTimerUs = 10 * 1000 * 1000; // 10s
 
     for (auto const& t : m_sTimers.timers) {
-        if (const auto µs = t->leftUs(); µs < nextTimerUs)
+        if (auto const& µs = t->leftUs(); µs < nextTimerUs)
             nextTimerUs = µs;
     }
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -291,7 +291,8 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
         foundSurface = g_pCompositor->vectorToLayerSurface(mouseCoords, &PMONITOR->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP], &surfaceCoords, &pFoundLayerSurface);
 
     // then, we check if the workspace doesnt have a fullscreen window
-    const auto PWORKSPACE = PMONITOR->activeWorkspace;
+    const auto PWORKSPACE   = PMONITOR->activeWorkspace;
+    const auto PWINDOWIDEAL = g_pCompositor->vectorToWindowUnified(mouseCoords, RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING);
     if (PWORKSPACE->m_bHasFullscreenWindow && !foundSurface && PWORKSPACE->m_efFullscreenMode == FSMODE_FULLSCREEN) {
         pFoundWindow = g_pCompositor->getFullscreenWindowOnWorkspace(PWORKSPACE->m_iID);
 
@@ -300,8 +301,6 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
             PWORKSPACE->m_bHasFullscreenWindow = false;
             return;
         }
-
-        const auto PWINDOWIDEAL = g_pCompositor->vectorToWindowUnified(mouseCoords, RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING);
 
         if (PWINDOWIDEAL &&
             ((PWINDOWIDEAL->m_bIsFloating && PWINDOWIDEAL->m_bCreatedOverFullscreen) /* floating over fullscreen */
@@ -322,7 +321,8 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
         if (PWORKSPACE->m_bHasFullscreenWindow && PWORKSPACE->m_efFullscreenMode == FSMODE_MAXIMIZED) {
             if (!foundSurface) {
                 if (PMONITOR->activeSpecialWorkspace) {
-                    pFoundWindow = g_pCompositor->vectorToWindowUnified(mouseCoords, RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING);
+                    if (pFoundWindow != PWINDOWIDEAL)
+                        pFoundWindow = g_pCompositor->vectorToWindowUnified(mouseCoords, RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING);
 
                     if (pFoundWindow && !pFoundWindow->onSpecialWorkspace()) {
                         pFoundWindow = g_pCompositor->getFullscreenWindowOnWorkspace(PWORKSPACE->m_iID);
@@ -335,7 +335,8 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
                     }
 
                     if (!foundSurface) {
-                        pFoundWindow = g_pCompositor->vectorToWindowUnified(mouseCoords, RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING);
+                        if (pFoundWindow != PWINDOWIDEAL)
+                            pFoundWindow = g_pCompositor->vectorToWindowUnified(mouseCoords, RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING);
 
                         if (!(pFoundWindow && pFoundWindow->m_bIsFloating && pFoundWindow->m_bCreatedOverFullscreen))
                             pFoundWindow = g_pCompositor->getFullscreenWindowOnWorkspace(PWORKSPACE->m_iID);
@@ -344,7 +345,8 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
             }
 
         } else {
-            pFoundWindow = g_pCompositor->vectorToWindowUnified(mouseCoords, RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING);
+            if (pFoundWindow != PWINDOWIDEAL)
+                pFoundWindow = g_pCompositor->vectorToWindowUnified(mouseCoords, RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING);
         }
 
         if (pFoundWindow) {

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -422,10 +422,8 @@ void CWLSurfaceResource::unlockPendingState() {
 }
 
 void CWLSurfaceResource::commitPendingState() {
-    auto    previousBuffer       = current.buffer;
-    CRegion previousBufferDamage = accumulateCurrentBufferDamage();
-
-    current = pending;
+    auto const previousBuffer = current.buffer;
+    current                   = pending;
     pending.damage.clear();
     pending.bufferDamage.clear();
     pending.newBuffer = false;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -158,9 +158,7 @@ static void renderSurface(SP<CWLSurfaceResource> surface, int x, int y, void* da
     if (!surface->current.texture)
         return;
 
-    const auto& TEXTURE                     = surface->current.texture;
-    const auto  RDATA                       = (SRenderData*)data;
-    const auto  INTERACTIVERESIZEINPROGRESS = RDATA->pWindow && g_pInputManager->currentlyDraggedWindow && g_pInputManager->dragMode == MBIND_RESIZE;
+    const auto& TEXTURE = surface->current.texture;
 
     // this is bad, probably has been logged elsewhere. Means the texture failed
     // uploading to the GPU.
@@ -175,6 +173,8 @@ static void renderSurface(SP<CWLSurfaceResource> surface, int x, int y, void* da
         }
     }
 
+    const auto RDATA                       = (SRenderData*)data;
+    const auto INTERACTIVERESIZEINPROGRESS = RDATA->pWindow && g_pInputManager->currentlyDraggedWindow && g_pInputManager->dragMode == MBIND_RESIZE;
     TRACY_GPU_ZONE("RenderSurface");
 
     double      outputX = -RDATA->pMonitor->vecPosition.x, outputY = -RDATA->pMonitor->vecPosition.y;
@@ -484,36 +484,43 @@ void CHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
 
     EMIT_HOOK_EVENT("render", RENDER_PRE_WINDOWS);
 
-    // Non-floating main
+    std::vector<PHLWINDOWREF> windows;
+    windows.reserve(g_pCompositor->m_vWindows.size());
+
     for (auto const& w : g_pCompositor->m_vWindows) {
         if (w->isHidden() || (!w->m_bIsMapped && !w->m_bFadingOut))
             continue;
 
-        if (w->m_bIsFloating)
-            continue; // floating are in the second pass
-
         if (!shouldRenderWindow(w, pMonitor))
             continue;
+
+        windows.push_back(w);
+    }
+
+    // Non-floating main
+    for (auto& w : windows) {
+        if (w->m_bIsFloating)
+            continue; // floating are in the second pass
 
         if (pWorkspace->m_bIsSpecialWorkspace != w->onSpecialWorkspace())
             continue;
 
         // render active window after all others of this pass
         if (w == g_pCompositor->m_pLastWindow) {
-            lastWindow = w;
+            lastWindow = w.lock();
             continue;
         }
 
         // render the bad boy
-        renderWindow(w, pMonitor, time, true, RENDER_PASS_MAIN);
+        renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_MAIN);
     }
 
     if (lastWindow)
         renderWindow(lastWindow, pMonitor, time, true, RENDER_PASS_MAIN);
 
     // Non-floating popup
-    for (auto const& w : g_pCompositor->m_vWindows) {
-        if (w->isHidden() || (!w->m_bIsMapped && !w->m_bFadingOut))
+    for (auto& w : windows) {
+        if (!w)
             continue;
 
         if (w->m_bIsFloating)
@@ -522,22 +529,17 @@ void CHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
         if (pWorkspace->m_bIsSpecialWorkspace != w->onSpecialWorkspace())
             continue;
 
-        if (!shouldRenderWindow(w, pMonitor))
-            continue;
-
         // render the bad boy
-        renderWindow(w, pMonitor, time, true, RENDER_PASS_POPUP);
+        renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_POPUP);
+        w.reset();
     }
 
     // floating on top
-    for (auto const& w : g_pCompositor->m_vWindows) {
-        if (w->isHidden() || (!w->m_bIsMapped && !w->m_bFadingOut))
+    for (auto& w : windows) {
+        if (!w)
             continue;
 
         if (!w->m_bIsFloating || w->m_bPinned)
-            continue;
-
-        if (!shouldRenderWindow(w, pMonitor))
             continue;
 
         if (pWorkspace->m_bIsSpecialWorkspace != w->onSpecialWorkspace())
@@ -547,7 +549,7 @@ void CHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
             continue; // special on another are rendered as a part of the base pass
 
         // render the bad boy
-        renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
+        renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_ALL);
     }
 }
 
@@ -1093,8 +1095,8 @@ void CHyprRenderer::calculateUVForSurface(PHLWINDOW pWindow, SP<CWLSurfaceResour
 
         if (pSurface->current.viewport.hasSource) {
             // we stretch it to dest. if no dest, to 1,1
-            Vector2D bufferSize   = pSurface->current.bufferSize;
-            auto     bufferSource = pSurface->current.viewport.source;
+            Vector2D const& bufferSize   = pSurface->current.bufferSize;
+            auto const&     bufferSource = pSurface->current.viewport.source;
 
             // calculate UV for the basic src_box. Assume dest == size. Scale to dest later
             uvTL = Vector2D(bufferSource.x / bufferSize.x, bufferSource.y / bufferSize.y);
@@ -1904,10 +1906,11 @@ void CHyprRenderer::damageBox(CBox* pBox, bool skipFrameSchedule) {
         if (m->isMirror())
             continue; // don't damage mirrors traditionally
 
-        CBox damageBox = {pBox->x - m->vecPosition.x, pBox->y - m->vecPosition.y, pBox->width, pBox->height};
-        damageBox.scale(m->scale);
-        if (!skipFrameSchedule)
+        if (!skipFrameSchedule) {
+            CBox damageBox = {pBox->x - m->vecPosition.x, pBox->y - m->vecPosition.y, pBox->width, pBox->height};
+            damageBox.scale(m->scale);
             m->addDamage(&damageBox);
+        }
     }
 
     static auto PLOGDAMAGE = CConfigValue<Hyprlang::INT>("debug:log_damage");

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -46,7 +46,7 @@ CBox CHyprBorderDecoration::assignedBoxGlobal() {
     return box.translate(WORKSPACEOFFSET);
 }
 
-void CHyprBorderDecoration::draw(PHLMONITOR pMonitor, float a) {
+void CHyprBorderDecoration::draw(PHLMONITOR pMonitor, float const& a) {
     if (doesntWantBorders())
         return;
 

--- a/src/render/decorations/CHyprBorderDecoration.hpp
+++ b/src/render/decorations/CHyprBorderDecoration.hpp
@@ -11,7 +11,7 @@ class CHyprBorderDecoration : public IHyprWindowDecoration {
 
     virtual void                       onPositioningReply(const SDecorationPositioningReply& reply);
 
-    virtual void                       draw(PHLMONITOR, float a);
+    virtual void                       draw(PHLMONITOR, float const& a);
 
     virtual eDecorationType            getDecorationType();
 

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -86,7 +86,7 @@ void CHyprDropShadowDecoration::updateWindow(PHLWINDOW pWindow) {
     m_bLastWindowBoxWithDecos = g_pDecorationPositioner->getBoxWithIncludedDecos(pWindow);
 }
 
-void CHyprDropShadowDecoration::draw(PHLMONITOR pMonitor, float a) {
+void CHyprDropShadowDecoration::draw(PHLMONITOR pMonitor, float const& a) {
 
     const auto PWINDOW = m_pWindow.lock();
 

--- a/src/render/decorations/CHyprDropShadowDecoration.hpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.hpp
@@ -11,7 +11,7 @@ class CHyprDropShadowDecoration : public IHyprWindowDecoration {
 
     virtual void                       onPositioningReply(const SDecorationPositioningReply& reply);
 
-    virtual void                       draw(PHLMONITOR, float a);
+    virtual void                       draw(PHLMONITOR, float const& a);
 
     virtual eDecorationType            getDecorationType();
 

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -94,7 +94,7 @@ void CHyprGroupBarDecoration::damageEntire() {
     g_pHyprRenderer->damageBox(&box);
 }
 
-void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float a) {
+void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
     // get how many bars we will draw
     int         barsToDraw = m_dwGroupMembers.size();
 

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -31,7 +31,7 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
 
     virtual void                       onPositioningReply(const SDecorationPositioningReply& reply);
 
-    virtual void                       draw(PHLMONITOR, float a);
+    virtual void                       draw(PHLMONITOR, float const& a);
 
     virtual eDecorationType            getDecorationType();
 

--- a/src/render/decorations/IHyprWindowDecoration.hpp
+++ b/src/render/decorations/IHyprWindowDecoration.hpp
@@ -39,7 +39,7 @@ class IHyprWindowDecoration {
 
     virtual void                       onPositioningReply(const SDecorationPositioningReply& reply) = 0;
 
-    virtual void                       draw(PHLMONITOR, float a) = 0;
+    virtual void                       draw(PHLMONITOR, float const& a) = 0;
 
     virtual eDecorationType            getDecorationType() = 0;
 


### PR DESCRIPTION
more profiling of erraticly moving mouse and generally looking at the most cpu demanding functions appearing doing so.

const ref the things we can, move various objects and variables down in scope to where its actually being used, reduce amount of calls to functions and try reuse already looped and fetched object. mousemoveunified itself could use a refactor but its scary big and i will eventually break something, maybe il attempt it in the future.

add one more for loop in renderWorkspaceWindows and store the windows in a vector with reference wrappers that should be  rendered, this adds a loop but reduces the amount of repeated calls to shouldRenderWindow and also makes the rest of the loops go over way smaller vector when many windows exist.


this could use some testing so i didnt actually break something non obvious, works here locally so far. and made marginal gains in the profiling.