### PR TITLE
Hyprland-systemd.desktop fix

### DIFF
--- a/systemd/hyprland-systemd.desktop
+++ b/systemd/hyprland-systemd.desktop
@@ -3,5 +3,5 @@ Name=Hyprland (systemd session)
 Comment=An intelligent dynamic tiling Wayland compositor
 Exec=systemctl --user start --wait hyprland-session
 Type=Application
-DesktopNames=Hyprland (systemd session)
+DesktopNames=Hyprland
 Keywords=tiling;wayland;compositor;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Rename `DesktopNames=Hyprland (systemd session)` to` DesktopNames=Hyprland` for compatibility with  [uwsm](https://github.com/Vladimir-csp/uwsm) and, possibly, other display managers.

https://github.com/hyprwm/Hyprland/pull/8318#issuecomment-2455587253


#### Is there anything you want to mention? 

No


#### Is it ready for merging, or does it need work?

Yes
