### PR TITLE
pointer: map devices across all outputs by default

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -620,15 +620,21 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
     },
     SConfigOptionDescription{
         .value       = "input:tablet:output",
-        .description = "the monitor to bind tablets. Empty means unbound..",
+        .description = "the monitor to bind tablets. Can be current or a monitor name. Leave empty to map across all monitors.",
         .type        = CONFIG_OPTION_STRING_SHORT,
         .data        = SConfigOptionDescription::SStringData{""}, //##TODO UNSET?
     },
     SConfigOptionDescription{
         .value       = "input:tablet:region_position",
-        .description = "position of the mapped region in monitor layout.",
+        .description = "position of the mapped region in monitor layout relative to the top left corner of the bound monitor or all monitors.",
         .type        = CONFIG_OPTION_VECTOR,
         .data        = SConfigOptionDescription::SVectorData{{}, {-20000, -20000}, {20000, 20000}},
+    },
+    SConfigOptionDescription{
+        .value       = "input:tablet:absolute_region_position",
+        .description = "whether to treat the region_position as an absolute position in monitor layout. Only applies when output is empty.",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{false},
     },
     SConfigOptionDescription{
         .value       = "input:tablet:region_size",

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -516,6 +516,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("input:tablet:transform", Hyprlang::INT{0});
     m_pConfig->addConfigValue("input:tablet:output", {STRVAL_EMPTY});
     m_pConfig->addConfigValue("input:tablet:region_position", Hyprlang::VEC2{0, 0});
+    m_pConfig->addConfigValue("input:tablet:absolute_region_position", Hyprlang::INT{0});
     m_pConfig->addConfigValue("input:tablet:region_size", Hyprlang::VEC2{0, 0});
     m_pConfig->addConfigValue("input:tablet:relative_input", Hyprlang::INT{0});
     m_pConfig->addConfigValue("input:tablet:left_handed", Hyprlang::INT{0});
@@ -625,6 +626,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addSpecialConfigValue("device", "output", {STRVAL_EMPTY});
     m_pConfig->addSpecialConfigValue("device", "enabled", Hyprlang::INT{1});                  // only for mice, touchpads, and touchdevices
     m_pConfig->addSpecialConfigValue("device", "region_position", Hyprlang::VEC2{0, 0});      // only for tablets
+    m_pConfig->addSpecialConfigValue("device", "absolute_region_position", Hyprlang::INT{0}); // only for tablets
     m_pConfig->addSpecialConfigValue("device", "region_size", Hyprlang::VEC2{0, 0});          // only for tablets
     m_pConfig->addSpecialConfigValue("device", "relative_input", Hyprlang::INT{0});           // only for tablets
     m_pConfig->addSpecialConfigValue("device", "active_area_position", Hyprlang::VEC2{0, 0}); // only for tablets

--- a/src/devices/Tablet.hpp
+++ b/src/devices/Tablet.hpp
@@ -92,9 +92,10 @@ class CTablet : public IHID {
     WP<CTablet> self;
 
     bool        relativeInput = false;
+    bool        absolutePos   = false;
     std::string boundOutput   = "";
     CBox        activeArea;
-    CBox        boundBox; // output-local
+    CBox        boundBox;
 
   private:
     CTablet(SP<Aquamarine::ITablet> tablet);

--- a/src/devices/VirtualPointer.cpp
+++ b/src/devices/VirtualPointer.cpp
@@ -38,7 +38,7 @@ CVirtualPointer::CVirtualPointer(SP<CVirtualPointerV1Resource> resource) : point
     listeners.holdBegin      = pointer->events.holdBegin.registerListener([this](std::any d) { pointerEvents.holdBegin.emit(d); });
     listeners.holdEnd        = pointer->events.holdEnd.registerListener([this](std::any d) { pointerEvents.holdEnd.emit(d); });
 
-    boundOutput = resource->boundOutput ? resource->boundOutput->szName : "entire";
+    boundOutput = resource->boundOutput ? resource->boundOutput->szName : "";
 
     deviceName = pointer->name;
 }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1595,6 +1595,9 @@ void CInputManager::setTabletConfigs() {
             const auto REGION_SIZE = g_pConfigManager->getDeviceVec(NAME, "region_size", "input:tablet:region_size");
             t->boundBox            = {REGION_POS, REGION_SIZE};
 
+            const auto ABSOLUTE_REGION_POS = g_pConfigManager->getDeviceInt(NAME, "absolute_region_position", "input:tablet:absolute_region_position");
+            t->absolutePos                 = ABSOLUTE_REGION_POS;
+
             const auto ACTIVE_AREA_SIZE = g_pConfigManager->getDeviceVec(NAME, "active_area_size", "input:tablet:active_area_size");
             const auto ACTIVE_AREA_POS  = g_pConfigManager->getDeviceVec(NAME, "active_area_position", "input:tablet:active_area_position");
             if (ACTIVE_AREA_SIZE.x != 0 || ACTIVE_AREA_SIZE.y != 0) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This fixes a problem with [wlx-overlay-s](https://github.com/galister/wlx-overlay-s?tab=readme-ov-file#mouse-is-not-where-it-should-be) where multi-monitor overlay pointer movement is broken. Somewhat related issues: #6023 #6889

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I'm not sure if it's correct to map across the entire space by default.

#### Is it ready for merging, or does it need work?
Ready