### PR TITLE
Don't render animating windows out of their monitor when they are not moving workspaces

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -355,7 +355,7 @@ bool CHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
         windowBox.translate(pWindow->m_vFloatingOffset);
 
         const CBox monitorBox = {pMonitor->vecPosition, pMonitor->vecSize};
-        if (!windowBox.intersection(monitorBox).empty())
+        if (!windowBox.intersection(monitorBox).empty() && (pWindow->workspaceID() == pMonitor->activeWorkspaceID() || pWindow->m_iMonitorMovedFrom != -1))
             return true;
     }
 


### PR DESCRIPTION
https://github.com/hyprwm/Hyprland/issues/8349

It seems this fixes [hyprscroller](https://github.com/dawsers/hyprscroller) and doesn't affect Hyprland in general.