### PR TITLE
Focus window on scrolling

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -831,6 +831,7 @@ void CInputManager::onMouseWheel(IPointer::SAxisEvent e) {
     int32_t deltaDiscrete = std::abs(discrete) != 0 && std::abs(discrete) < 1 ? std::copysign(1, discrete) : std::round(discrete);
 
     g_pSeatManager->sendPointerAxis(e.timeMs, e.axis, delta, deltaDiscrete, value120, e.source, WL_POINTER_AXIS_RELATIVE_DIRECTION_IDENTICAL);
+    simulateMouseMovement();
 }
 
 Vector2D CInputManager::getMouseCoordsInternal() {

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -776,9 +776,8 @@ void CInputManager::onMouseWheel(IPointer::SAxisEvent e) {
         const auto PWINDOW     = g_pCompositor->vectorToWindowUnified(MOUSECOORDS, RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING);
 
         if (PWINDOW) {
-            if (PWINDOW->checkInputOnDecos(INPUT_TYPE_AXIS, MOUSECOORDS, e)) {
+            if (PWINDOW->checkInputOnDecos(INPUT_TYPE_AXIS, MOUSECOORDS, e))
                 return;
-            }
 
             if (*POFFWINDOWAXIS != 1) {
                 const auto BOX = PWINDOW->getWindowMainSurfaceBox();
@@ -799,9 +798,8 @@ void CInputManager::onMouseWheel(IPointer::SAxisEvent e) {
             }
 
             const auto PCURRWINDOW = g_pCompositor->getWindowFromSurface(g_pCompositor->m_pLastFocus.lock());
-            if (*PFOLLOWMOUSE == 1 && PCURRWINDOW && PWINDOW != PCURRWINDOW) {
+            if (*PFOLLOWMOUSE == 1 && PCURRWINDOW && PWINDOW != PCURRWINDOW)
                 simulateMouseMovement();
-            }
         }
     }
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -759,6 +759,7 @@ void CInputManager::onMouseWheel(IPointer::SAxisEvent e) {
     static auto PINPUTSCROLLFACTOR    = CConfigValue<Hyprlang::FLOAT>("input:scroll_factor");
     static auto PTOUCHPADSCROLLFACTOR = CConfigValue<Hyprlang::FLOAT>("input:touchpad:scroll_factor");
     static auto PEMULATEDISCRETE      = CConfigValue<Hyprlang::INT>("input:emulate_discrete_scroll");
+    static auto PFOLLOWMOUSE          = CConfigValue<Hyprlang::INT>("input:follow_mouse");
 
     auto        factor = (*PTOUCHPADSCROLLFACTOR <= 0.f || e.source == WL_POINTER_AXIS_SOURCE_FINGER ? *PTOUCHPADSCROLLFACTOR : *PINPUTSCROLLFACTOR);
 
@@ -774,24 +775,32 @@ void CInputManager::onMouseWheel(IPointer::SAxisEvent e) {
         const auto MOUSECOORDS = g_pInputManager->getMouseCoordsInternal();
         const auto PWINDOW     = g_pCompositor->vectorToWindowUnified(MOUSECOORDS, RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING);
 
-        if (PWINDOW && PWINDOW->checkInputOnDecos(INPUT_TYPE_AXIS, MOUSECOORDS, e))
-            return;
+        if (PWINDOW) {
+            if (PWINDOW->checkInputOnDecos(INPUT_TYPE_AXIS, MOUSECOORDS, e)) {
+                return;
+            }
 
-        if (PWINDOW && *POFFWINDOWAXIS != 1) {
-            const auto BOX = PWINDOW->getWindowMainSurfaceBox();
+            if (*POFFWINDOWAXIS != 1) {
+                const auto BOX = PWINDOW->getWindowMainSurfaceBox();
 
-            if (!BOX.containsPoint(MOUSECOORDS) && !PWINDOW->hasPopupAt(MOUSECOORDS)) {
-                if (*POFFWINDOWAXIS == 0)
-                    return;
+                if (!BOX.containsPoint(MOUSECOORDS) && !PWINDOW->hasPopupAt(MOUSECOORDS)) {
+                    if (*POFFWINDOWAXIS == 0)
+                        return;
 
-                const auto TEMPCURX = std::clamp(MOUSECOORDS.x, BOX.x, BOX.x + BOX.w - 1);
-                const auto TEMPCURY = std::clamp(MOUSECOORDS.y, BOX.y, BOX.y + BOX.h - 1);
+                    const auto TEMPCURX = std::clamp(MOUSECOORDS.x, BOX.x, BOX.x + BOX.w - 1);
+                    const auto TEMPCURY = std::clamp(MOUSECOORDS.y, BOX.y, BOX.y + BOX.h - 1);
 
-                if (*POFFWINDOWAXIS == 3)
-                    g_pCompositor->warpCursorTo({TEMPCURX, TEMPCURY}, true);
+                    if (*POFFWINDOWAXIS == 3)
+                        g_pCompositor->warpCursorTo({TEMPCURX, TEMPCURY}, true);
 
-                g_pSeatManager->sendPointerMotion(e.timeMs, Vector2D{TEMPCURX, TEMPCURY} - BOX.pos());
-                g_pSeatManager->sendPointerFrame();
+                    g_pSeatManager->sendPointerMotion(e.timeMs, Vector2D{TEMPCURX, TEMPCURY} - BOX.pos());
+                    g_pSeatManager->sendPointerFrame();
+                }
+            }
+
+            const auto PCURRWINDOW = g_pCompositor->getWindowFromSurface(g_pCompositor->m_pLastFocus.lock());
+            if (*PFOLLOWMOUSE == 1 && PCURRWINDOW && PWINDOW != PCURRWINDOW) {
+                simulateMouseMovement();
             }
         }
     }
@@ -833,7 +842,6 @@ void CInputManager::onMouseWheel(IPointer::SAxisEvent e) {
     int32_t deltaDiscrete = std::abs(discrete) != 0 && std::abs(discrete) < 1 ? std::copysign(1, discrete) : std::round(discrete);
 
     g_pSeatManager->sendPointerAxis(e.timeMs, e.axis, delta, deltaDiscrete, value120, e.source, WL_POINTER_AXIS_RELATIVE_DIRECTION_IDENTICAL);
-    simulateMouseMovement();
 }
 
 Vector2D CInputManager::getMouseCoordsInternal() {

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -797,9 +797,12 @@ void CInputManager::onMouseWheel(IPointer::SAxisEvent e) {
                 }
             }
 
-            const auto PCURRWINDOW = g_pCompositor->getWindowFromSurface(g_pCompositor->m_pLastFocus.lock());
-            if (*PFOLLOWMOUSE == 1 && PCURRWINDOW && PWINDOW != PCURRWINDOW)
-                simulateMouseMovement();
+            if (g_pSeatManager->state.pointerFocus) {
+                const auto PCURRWINDOW = g_pCompositor->getWindowFromSurface(g_pSeatManager->state.pointerFocus.lock());
+
+                if (*PFOLLOWMOUSE == 1 && PCURRWINDOW && PWINDOW != PCURRWINDOW)
+                    simulateMouseMovement();
+            }
         }
     }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This is the new PR for #8279. The other PR introduced a regression on merge which this implementation addresses as well. 

**In short**: You are now able to focus a window on scroll (like with mouse-movement and button-clicks). This particularly happens, after you switched your workspace and returned back.

What does it better? It now calls the `simulateMouseMovement` only once when the window differ and also when mouse_follow event is set to 1. This should avoid weard touchpad behaviour happening in firefox when you constantly call `simulateMouseMovement`.

#### Is it ready for merging, or does it need work?

- Tested it locally with mouse and touchpad on my Surface Pro 8
- Scrolling in Firefox works also on touchpad (was the regression)

