### PR TITLE
Changed the default value of decoration:blur:ignore_opacity to true

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -268,7 +268,7 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .value       = "blur:ignore_opacity",
         .description = "make the blur layer ignore the opacity of the window",
         .type        = CONFIG_OPTION_BOOL,
-        .data        = SConfigOptionDescription::SBoolData{false},
+        .data        = SConfigOptionDescription::SBoolData{true},
     },
     SConfigOptionDescription{
         .value       = "blur:new_optimizations",

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -417,7 +417,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("decoration:blur:enabled", Hyprlang::INT{1});
     m_pConfig->addConfigValue("decoration:blur:size", Hyprlang::INT{8});
     m_pConfig->addConfigValue("decoration:blur:passes", Hyprlang::INT{1});
-    m_pConfig->addConfigValue("decoration:blur:ignore_opacity", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("decoration:blur:ignore_opacity", Hyprlang::INT{1});
     m_pConfig->addConfigValue("decoration:blur:new_optimizations", Hyprlang::INT{1});
     m_pConfig->addConfigValue("decoration:blur:xray", Hyprlang::INT{0});
     m_pConfig->addConfigValue("decoration:blur:contrast", {0.8916F});


### PR DESCRIPTION
This change is made in order to deliver the blur look majority of people expect by default.

#### Describe your PR, what does it fix/add?
It changes the default value of the `decoration:blur:ignore_opacity` to `true` in order to provide the expected blur appearance by default.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I changed all instances of the default value I managed to find in the repo, let me know if I missed a spot.
It should be fine because it works as expected on my end.

#### Is it ready for merging, or does it need work?
It is ready for merging, however, I still have to edit the default value displayed in Hyprland wiki.

### Old
![Old](https://github.com/user-attachments/assets/19e3e20f-f913-4491-94ae-40c25529a446)

### New
![New](https://github.com/user-attachments/assets/f0c0efb1-261a-4dfa-b929-7d51d3ebd471)
