### PR TITLE
renderer: scaled surfaces could have zero area

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -222,6 +222,11 @@ static void renderSurface(SP<CWLSurfaceResource> surface, int x, int y, void* da
             windowBox.height = RDATA->h - y;
     }
 
+    const auto PROJSIZEUNSCALED = windowBox.size();
+
+    windowBox.scale(RDATA->pMonitor->scale);
+    windowBox.round();
+
     if (windowBox.width <= 1 || windowBox.height <= 1) {
         if (!g_pHyprRenderer->m_bBlockSurfaceFeedback) {
             Debug::log(TRACE, "presentFeedback for invisible surface");
@@ -230,11 +235,6 @@ static void renderSurface(SP<CWLSurfaceResource> surface, int x, int y, void* da
 
         return; // invisible
     }
-
-    const auto PROJSIZEUNSCALED = windowBox.size();
-
-    windowBox.scale(RDATA->pMonitor->scale);
-    windowBox.round();
 
     const bool MISALIGNEDFSV1 = std::floor(RDATA->pMonitor->scale) != RDATA->pMonitor->scale /* Fractional */ && surface->current.scale == 1 /* fs protocol */ &&
         windowBox.size() != surface->current.bufferSize /* misaligned */ && DELTALESSTHAN(windowBox.width, surface->current.bufferSize.x, 3) &&


### PR DESCRIPTION
When a monitor has a scale value smaller than 1, some small rendering surfaces belonging to a window could have zero width or height, causing a crash in Hyprland.

I know monitors rarely have a scale smaller than one (they shouldn't). But this MR is not about being too picky. I am working on an overview mode where windows are scaled, and can become very, very  small. When I render those windows, I change the monitor scale instead of the size of the window, so their content is the original. As soon as windows are small enough, some of its parts become zero-area surfaces, and Hyprland crashes.

The change is minimal, just swaps the order of the check for width and height to happen after scaling.

Thank you!