### PR TITLE
Add the disable_lockdead_screen option

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1121,6 +1121,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .type        = CONFIG_OPTION_BOOL,
         .data        = SConfigOptionDescription::SBoolData{false},
     },
+    SConfigOptionDescription{
+        .value       = "misc:disable_lockdead_screen",
+        .description = "disable the lockdead screen when lockscreen failed.",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{false},
+    },
 
     /*
      * binds:

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -377,6 +377,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("misc:middle_click_paste", Hyprlang::INT{1});
     m_pConfig->addConfigValue("misc:render_unfocused_fps", Hyprlang::INT{15});
     m_pConfig->addConfigValue("misc:disable_xdg_env_checks", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("misc:disable_lockdead_screen", Hyprlang::INT{0});
 
     m_pConfig->addConfigValue("group:insert_after_current", Hyprlang::INT{1});
     m_pConfig->addConfigValue("group:focus_removed_window", Hyprlang::INT{1});


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

When running on slow computer (in my case laptop in powersave mode), hyprland can display lockdead screen before the lockscreen has started. It results in seeing for 1 or 2 second before the lockscreen actually starts.

This PR add a config option to disable the lockdead screen, solving the issue at the same time. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Another solution would be to wait for a configurable delay before displaying it. If this solution is preferable, let me know.

#### Is it ready for merging, or does it need work?

It shall be mergeable

