### PR TITLE
Update XDGShell.cpp

### DIFF
--- a/src/protocols/XDGShell.cpp
+++ b/src/protocols/XDGShell.cpp
@@ -518,7 +518,7 @@ CXDGPositionerResource::CXDGPositionerResource(SP<CXdgPositioner> resource_, SP<
 
     resource->setSetGravity([this](CXdgPositioner* r, xdgPositionerGravity g) { state.setGravity(g); });
 
-    resource->setSetConstraintAdjustment([this](CXdgPositioner* r, xdgPositionerConstraintAdjustment a) { state.constraintAdjustment = (uint32_t)a; });
+    resource->setSetConstraintAdjustment([this](CXdgPositioner* r, uint32_t a) { state.constraintAdjustment = a; });
 
     // TODO: support this shit better. The current impl _works_, but is lacking and could be wrong in a few cases.
     // doesn't matter _that_ much for now, though.


### PR DESCRIPTION
Ubuntu 24.10 Build Issue

#### Describe your PR, what does it fix/add?

Hyprland ninja -C build now works after this change on the following system/specs

<img width="805" alt="Screenshot 2024-11-12 at 19 15 28" src="https://github.com/user-attachments/assets/1140d2a2-bf30-45f5-a8f7-81d863c10024">

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Before:

<img width="1160" alt="Screenshot_2024-11-12_at_19 05 51" src="https://github.com/user-attachments/assets/39faa485-a586-4dd6-b396-c9bab5d2a86e">

After:

<img width="1203" alt="Screenshot_2024-11-12_at_19 09 12" src="https://github.com/user-attachments/assets/558a1eeb-a4fd-4bf7-a5fe-83a50d69ef96">

what did I do: the issue i had was due to a type mismatch in a lambda function. The function setSetConstraintAdjustment needed a parameter of type uint32_t, but the lambda was using xdgPositionerConstraintAdjustment instead. The fix i made included explicitly casting xdgPositionerConstraintAdjustment to uint32_t to match the expected signature.

