### PR TITLE
renderer: add the lockdead_screen_delay

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1121,6 +1121,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .type        = CONFIG_OPTION_BOOL,
         .data        = SConfigOptionDescription::SBoolData{false},
     },
+    SConfigOptionDescription{
+        .value       = "misc:lockdead_screen_delay",
+        .description = "the delay in ms after the lockdead screen appears if the lock screen did not appear after a lock event occurred.",
+        .type        = CONFIG_OPTION_INT,
+        .data        = SConfigOptionDescription::SRangeData{1000, 0, 5000},
+    },
 
     /*
      * binds:

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -377,6 +377,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("misc:middle_click_paste", Hyprlang::INT{1});
     m_pConfig->addConfigValue("misc:render_unfocused_fps", Hyprlang::INT{15});
     m_pConfig->addConfigValue("misc:disable_xdg_env_checks", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("misc:lockdead_screen_delay", Hyprlang::INT{1000});
 
     m_pConfig->addConfigValue("group:insert_after_current", Hyprlang::INT{1});
     m_pConfig->addConfigValue("group:focus_removed_window", Hyprlang::INT{1});

--- a/src/managers/SessionLockManager.hpp
+++ b/src/managers/SessionLockManager.hpp
@@ -29,6 +29,7 @@ struct SSessionLockSurface {
 
 struct SSessionLock {
     WP<CSessionLock>                                  lock;
+    CTimer                                            mLockTimer;
 
     std::vector<std::unique_ptr<SSessionLockSurface>> vSessionLockSurfaces;
     std::unordered_map<uint64_t, CTimer>              mMonitorsWithoutMappedSurfaceTimers;
@@ -60,6 +61,8 @@ class CSessionLockManager {
     void                 removeSessionLockSurface(SSessionLockSurface*);
 
     void                 onLockscreenRenderedOnMonitor(uint64_t id);
+
+    bool                 shallConsiderLockMissing();
 
   private:
     UP<SSessionLock> m_pSessionLock;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1045,9 +1045,10 @@ void CHyprRenderer::renderLockscreen(PHLMONITOR pMonitor, timespec* now, const C
         Vector2D   translate = {geometry.x, geometry.y};
 
         const auto PSLS = g_pSessionLockManager->getSessionLockSurfaceForMonitor(pMonitor->ID);
-        if (!PSLS)
-            renderSessionLockMissing(pMonitor);
-        else {
+        if (!PSLS) {
+            if (g_pSessionLockManager->shallConsiderLockMissing())
+                renderSessionLockMissing(pMonitor);
+        } else {
             renderSessionLockSurface(PSLS, pMonitor, now);
             g_pSessionLockManager->onLockscreenRenderedOnMonitor(pMonitor->ID);
         }
@@ -2725,7 +2726,7 @@ bool CHyprRenderer::beginRender(PHLMONITOR pMonitor, CRegion& damage, eRenderMod
         return true;
     }
 
-    /* This is a constant expression, as we always use double-buffering in our swapchain 
+    /* This is a constant expression, as we always use double-buffering in our swapchain
         TODO: Rewrite the CDamageRing to take advantage of that maybe? It's made to support longer swapchains atm because we used to do wlroots */
     static constexpr const int HL_BUFFER_AGE = 2;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

When running on slow computer (in my case laptop in powersave mode), hyprland can display lockdead screen before the lockscreen has started. It results in seeing for 1 or 2 second before the lockscreen actually starts.

This PR add a config option to add a delay between the time the lock happens an the lockdead screen appears, 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This is linked to this PR #8427

#### Is it ready for merging, or does it need work?

It shall be mergeable


