### PR TITLE
xcursors store themes in a std:set to order it

### DIFF
--- a/src/managers/XCursorManager.cpp
+++ b/src/managers/XCursorManager.cpp
@@ -197,7 +197,7 @@ SP<SXCursors> CXCursorManager::createCursor(std::string const& shape, XcursorIma
     return xcursor;
 }
 
-std::unordered_set<std::string> CXCursorManager::themePaths(std::string const& theme) {
+std::set<std::string> CXCursorManager::themePaths(std::string const& theme) {
     auto const* path = XcursorLibraryPath();
 
     auto        expandTilde = [](std::string const& path) {
@@ -276,10 +276,10 @@ std::unordered_set<std::string> CXCursorManager::themePaths(std::string const& t
         return themes;
     };
 
-    std::unordered_set<std::string> paths;
-    std::unordered_set<std::string> inherits;
+    std::set<std::string> paths;
+    std::set<std::string> inherits;
 
-    auto                            scanTheme = [&path, &paths, &expandTilde, &inherits, &getInheritThemes](auto const& t) {
+    auto                  scanTheme = [&path, &paths, &expandTilde, &inherits, &getInheritThemes](auto const& t) {
         std::stringstream ss(path);
         std::string       line;
 

--- a/src/managers/XCursorManager.hpp
+++ b/src/managers/XCursorManager.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <string>
 #include <vector>
-#include <unordered_set>
+#include <set>
 #include <array>
 #include <cstdint>
 #include <hyprutils/math/Vector2D.hpp>
@@ -34,16 +34,16 @@ class CXCursorManager {
     void          syncGsettings();
 
   private:
-    SP<SXCursors>                   createCursor(std::string const& shape, XcursorImages* xImages);
-    std::unordered_set<std::string> themePaths(std::string const& theme);
-    std::string                     getLegacyShapeName(std::string const& shape);
-    std::vector<SP<SXCursors>>      loadStandardCursors(std::string const& name, int size);
-    std::vector<SP<SXCursors>>      loadAllFromDir(std::string const& path, int size);
+    SP<SXCursors>              createCursor(std::string const& shape, XcursorImages* xImages);
+    std::set<std::string>      themePaths(std::string const& theme);
+    std::string                getLegacyShapeName(std::string const& shape);
+    std::vector<SP<SXCursors>> loadStandardCursors(std::string const& name, int size);
+    std::vector<SP<SXCursors>> loadAllFromDir(std::string const& path, int size);
 
-    int                             lastLoadSize  = 0;
-    float                           lastLoadScale = 0;
-    std::string                     themeName     = "";
-    SP<SXCursors>                   defaultCursor;
-    SP<SXCursors>                   hyprCursor;
-    std::vector<SP<SXCursors>>      cursors;
+    int                        lastLoadSize  = 0;
+    float                      lastLoadScale = 0;
+    std::string                themeName     = "";
+    SP<SXCursors>              defaultCursor;
+    SP<SXCursors>              hyprCursor;
+    std::vector<SP<SXCursors>> cursors;
 };


### PR DESCRIPTION
using a unordered_set means its store based on a hash_value meaning currently it can end up loading inherited themes before the actual theme itself depending on the hash of the theme name used, reason for using set at all over vector is to keep unique members and not foreverever looping broken inherit themeing.

fixes #8460 
