### PR TITLE
Fix: Workspace name not assigned via hyprctl dispatch focusworkspaceoncurrentmonitor

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1853,7 +1853,7 @@ SDispatchResult CKeybindManager::moveWorkspaceToMonitor(std::string args) {
 }
 
 SDispatchResult CKeybindManager::focusWorkspaceOnCurrentMonitor(std::string args) {
-    auto workspaceID = getWorkspaceIDNameFromString(args).id;
+    auto [workspaceID, workspaceName] = getWorkspaceIDNameFromString(args);
     if (workspaceID == WORKSPACE_INVALID) {
         Debug::log(ERR, "focusWorkspaceOnCurrentMonitor invalid workspace!");
         return {.success = false, .error = "focusWorkspaceOnCurrentMonitor invalid workspace!"};
@@ -1869,7 +1869,7 @@ SDispatchResult CKeybindManager::focusWorkspaceOnCurrentMonitor(std::string args
     auto pWorkspace = g_pCompositor->getWorkspaceByID(workspaceID);
 
     if (!pWorkspace) {
-        pWorkspace = g_pCompositor->createNewWorkspace(workspaceID, PCURRMONITOR->ID);
+        pWorkspace = g_pCompositor->createNewWorkspace(workspaceID, PCURRMONITOR->ID, workspaceName);
         // we can skip the moving, since it's already on the current monitor
         changeworkspace(pWorkspace->getConfigName());
         return {};


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Hello, the workspace name is not set when we use hyprctl, instead it names it -1337.
You can test it with this command
`hyprctl dispatch focusworkspaceoncurrentmonitor name:"plop"`

A really small PR to get the workspace name that's already been passed, and pass it along to createNewWorkspace().

Here's an example showing that hyprctl gives the new workspace a name of "-1337" and an id  of -1337 
```
$> hyprctl dispatch focusworkspaceoncurrentmonitor name:"plop"
$> hyprctl workspaces
workspace ID -1337 (-1337) on monitor eDP-1:
	monitorID: 0
	windows: 1
	hasfullscreen: 0
	lastwindow: 0x5fdab5f4f6e0
	lastwindowtitle: hyprctl workspaces ~`


$> hyprctl dispatch renameworkspace -1337 plopped
$> hyprctl workspaces
workspace ID -1337 (plopped) on monitor eDP-1:
	monitorID: 0
	windows: 2
	hasfullscreen: 0
	lastwindow: 0x5fdab5f4f6e0
	lastwindowtitle: hyprctl workspaces ~
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
Yes, it is ready for merging, I've been using this code for a while now and not noticed any issues.

I use this a lot as I wrote a script(uses rofi) to manage workspaces in Hyprland.
Create a workspace, rename, move windows to and from each workspace, and switch to any window quickly.
https://github.com/sslater11/hyprland-dynamic-workspaces-manager