### PR TITLE
Window/Workspace Rules: If workspace is created by a windowrule, don't create it as empty workspace

### DIFF
--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -296,7 +296,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
             auto pWorkspace = g_pCompositor->getWorkspaceByID(REQUESTEDWORKSPACEID);
 
             if (!pWorkspace)
-                pWorkspace = g_pCompositor->createNewWorkspace(REQUESTEDWORKSPACEID, PWINDOW->monitorID(), requestedWorkspaceName);
+                pWorkspace = g_pCompositor->createNewWorkspace(REQUESTEDWORKSPACEID, PWINDOW->monitorID(), requestedWorkspaceName, false);
 
             PWORKSPACE = pWorkspace;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Consider the config:

    windowrulev2 = workspace 2, class:^(Alacritty)$
    workspace = 2, on-created-empty: alacritty


Assume workspace 2 does not exist yet and alacritty is launched. The window rule will be applied and a new workspace will be created. That new workspace should not be created as an empty workspace because it has (or soon will have) a window in it.

If it is created as an empty workspace, the `on-created-empty` will launch alacritty and the workspace will end up with two windows.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.


#### Is it ready for merging, or does it need work?

Ready to merge.
