### PR TITLE
pointer constraints: don't warp pointer position on release

### DIFF
--- a/src/protocols/PointerConstraints.cpp
+++ b/src/protocols/PointerConstraints.cpp
@@ -188,7 +188,7 @@ Vector2D CPointerConstraint::logicPositionHint() {
     const auto SURFBOX       = pHLSurface->getSurfaceBoxGlobal();
     const auto CONSTRAINTPOS = SURFBOX.has_value() ? SURFBOX->pos() : Vector2D{};
 
-    return hintSet ? CONSTRAINTPOS + positionHint : (locked ? CONSTRAINTPOS + SURFBOX->size() / 2.f : cursorPosOnActivate);
+    return hintSet ? CONSTRAINTPOS + positionHint : cursorPosOnActivate;
 }
 
 CPointerConstraintsProtocol::CPointerConstraintsProtocol(const wl_interface* iface, const int& ver, const std::string& name) : IWaylandProtocol(iface, ver, name) {


### PR DESCRIPTION

#### Describe your PR, what does it fix/add?

this was annoying for nuklear properties/ui slider elements that grab the pointer via GLFW_CURSOR_DISABLE to allow more range and finer control. upon mouse release, the pointer is reset to the middle of the window without this patch, making long mouse movements necessary to go back to the original position for re-adjustments. fwiw the new behaviour is consistent with x11 and weston.

can prepare a video for illustration if that's helpful.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?

this works for me, but i don't know the reason for warping the pointer position to the center of the window in the first place. might have been leftover logic from some initial implementation?
