### PR TITLE
Plugins: add pre connected/disconnected monitor events

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -39,6 +39,7 @@ CMonitor::~CMonitor() {
 }
 
 void CMonitor::onConnect(bool noRule) {
+    EMIT_HOOK_EVENT("preMonitorAdded", self.lock());
     CScopeGuard x = {[]() { g_pCompositor->arrangeMonitors(); }};
 
     if (output->supportsExplicit) {
@@ -238,6 +239,7 @@ void CMonitor::onConnect(bool noRule) {
 }
 
 void CMonitor::onDisconnect(bool destroy) {
+    EMIT_HOOK_EVENT("preMonitorRemoved", self.lock());
     CScopeGuard x = {[this]() {
         if (g_pCompositor->m_bIsShuttingDown)
             return;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This is a very simple PR, it simply adds two events for plugins: `preMonitorAdded` and `preMonitorRemoved`. These events are fired when a monitor is connected/disconnected, but before Hyprland handles it. This can be useful for plugins such as [hyprland-virtual-desktops](https://github.com/levnikmyskin/hyprland-virtual-desktops), to avoid listening to `workspace` change events when monitors are being disconnected/connected

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
ready, but this probably needs to be documented in the hyprland wiki. I'll open a PR there once this is approved

