### PR TITLE
renderer: add option to blur IME popups

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -331,6 +331,18 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .type        = CONFIG_OPTION_FLOAT,
         .data        = SConfigOptionDescription::SFloatData{0.2, 0, 1},
     },
+    SConfigOptionDescription{
+        .value       = "blur:input_methods",
+        .description = "whether to blur input methods (e.g. fcitx5)",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{false},
+    },
+    SConfigOptionDescription{
+        .value       = "blur:input_methods_ignorealpha",
+        .description = "works like ignorealpha in layer rules. If pixel opacity is below set value, will not blur. [0.0 - 1.0]",
+        .type        = CONFIG_OPTION_FLOAT,
+        .data        = SConfigOptionDescription::SFloatData{0.2, 0, 1},
+    },
 
     /*
      * animations:

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -429,6 +429,8 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("decoration:blur:special", Hyprlang::INT{0});
     m_pConfig->addConfigValue("decoration:blur:popups", Hyprlang::INT{0});
     m_pConfig->addConfigValue("decoration:blur:popups_ignorealpha", {0.2F});
+    m_pConfig->addConfigValue("decoration:blur:input_methods", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("decoration:blur:input_methods_ignorealpha", {0.2F});
     m_pConfig->addConfigValue("decoration:active_opacity", {1.F});
     m_pConfig->addConfigValue("decoration:inactive_opacity", {1.F});
     m_pConfig->addConfigValue("decoration:fullscreen_opacity", {1.F});

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -850,11 +850,20 @@ void CHyprRenderer::renderIMEPopup(CInputPopup* pPopup, PHLMONITOR pMonitor, tim
 
     const auto  SURF = pPopup->getSurface();
 
-    renderdata.blur     = false;
     renderdata.surface  = SURF;
     renderdata.decorate = false;
     renderdata.w        = SURF->current.size.x;
     renderdata.h        = SURF->current.size.y;
+
+    static auto PBLUR        = CConfigValue<Hyprlang::INT>("decoration:blur:enabled");
+    static auto PBLURIMES    = CConfigValue<Hyprlang::INT>("decoration:blur:input_methods");
+    static auto PBLURIGNOREA = CConfigValue<Hyprlang::FLOAT>("decoration:blur:input_methods_ignorealpha");
+
+    renderdata.blur = *PBLURIMES && *PBLUR;
+    if (renderdata.blur) {
+        g_pHyprOpenGL->m_RenderData.discardMode |= DISCARD_ALPHA;
+        g_pHyprOpenGL->m_RenderData.discardOpacity = *PBLURIGNOREA;
+    }
 
     SURF->breadthfirst([](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) { renderSurface(s, offset.x, offset.y, data); }, &renderdata);
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
make it so that IME popups will be blurred by `decoration:blur:enabled` && `decoration:blur:input_methods`
![image](https://github.com/user-attachments/assets/4b1f5653-609d-41eb-8507-e399732ad948)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
i have no idea if this will break anything

#### Is it ready for merging, or does it need work?
ready
