### PR TITLE
actually suppress internal keybinds instead of passing them along

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -423,8 +423,10 @@ bool CKeybindManager::onKeyEvent(std::any event, SP<IKeyboard> pKeyboard) {
     const xkb_keysym_t keysym         = xkb_state_key_get_one_sym(pKeyboard->resolveBindsBySym ? pKeyboard->xkbSymState : m_pXKBTranslationState, KEYCODE);
     const xkb_keysym_t internalKeysym = xkb_state_key_get_one_sym(pKeyboard->xkbState, KEYCODE);
 
+    // handleInternalKeybinds returns true when the key should be suppressed,
+    // while this function returns true when the key event should be sent
     if (handleInternalKeybinds(internalKeysym))
-        return true;
+        return false;
 
     const auto MODS = g_pInputManager->accumulateModsFromAllKBs();
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

previously when switching vt hyprland would print bullshit to the terminal[^1], because it changes what a `true` boolean means somewhere in the middle without flipping one of them.

in [`CKeybindManager::handleVT`](https://github.com/hyprwm/Hyprland/blob/940f7aa990dbc99815bab8d355999d8277534b17/src/managers/KeybindManager.cpp#L831-L832) it returns a `true` when the key should be intercepted, which is passed up by [`CKeybindManager::handleInternalKeybinds`](https://github.com/hyprwm/Hyprland/blob/940f7aa990dbc99815bab8d355999d8277534b17/src/managers/KeybindManager.cpp#L864-L866), and then handled in [`CKeybindManager::onKeyEvent`](https://github.com/hyprwm/Hyprland/blob/940f7aa990dbc99815bab8d355999d8277534b17/src/managers/KeybindManager.cpp#L426-L427), where it also returns a `true`. but [`CInputManager::onKeyboardKey`](https://github.com/hyprwm/Hyprland/blob/940f7aa990dbc99815bab8d355999d8277534b17/src/managers/input/InputManager.cpp#L1307) interprets a `true` to mean that it should [pass the event along](https://github.com/hyprwm/Hyprland/blob/940f7aa990dbc99815bab8d355999d8277534b17/src/managers/input/InputManager.cpp#L1311-L1323), which is not what we want for internal keybinds.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

i didn't check if the boolean stuff was correct for everything else

#### Is it ready for merging, or does it need work?

ready

[^1]: ![image](https://github.com/user-attachments/assets/f55779e6-5b69-420a-867f-23f165e148b6) 
![image](https://github.com/user-attachments/assets/a8f845ff-c678-4040-a29f-17da600d83bd)


