### PR TITLE
snap: account for position of multiple monitors

### DIFF
--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -484,8 +484,8 @@ static void performSnap(Vector2D& sourcePos, Vector2D& sourceSize, PHLWINDOW DRA
         const double BORDERDIFF = DRAGGINGBORDERSIZE - BORDERSIZE;
         const auto   MON        = DRAGGINGWINDOW->m_pMonitor.lock();
 
-        SRange       monX = {MON->vecPosition.x + BORDERSIZE, MON->vecSize.x - BORDERSIZE};
-        SRange       monY = {MON->vecPosition.y + BORDERSIZE, MON->vecSize.y - BORDERSIZE};
+        SRange       monX = {MON->vecPosition.x + BORDERSIZE, MON->vecPosition.x + MON->vecSize.x - BORDERSIZE};
+        SRange       monY = {MON->vecPosition.y + BORDERSIZE, MON->vecPosition.y + MON->vecSize.y - BORDERSIZE};
 
         if (canSnap(sourceX.start, monX.start, GAPSIZE) || canSnap(sourceX.start, (monX.start += MON->vecReservedTopLeft.x + BORDERDIFF), GAPSIZE)) {
             SNAP(sourceX.start, sourceX.end, monX.start);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Floating windows weren't snapping to all of the edges of multiple monitors because monitor position wasn't being properly taken into account.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Nope

#### Is it ready for merging, or does it need work?

Ready to merge