### PR TITLE
sessionLock: don't send motion events on every surface commit

### DIFF
--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -31,7 +31,7 @@ SSessionLockSurface::SSessionLockSurface(SP<CSessionLockSurface> surface_) : sur
     listeners.commit = surface_->events.commit.registerListener([this](std::any data) {
         const auto PMONITOR = g_pCompositor->getMonitorFromID(iMonitorID);
 
-        if (mapped && pWlrSurface != g_pCompositor->m_pLastFocus)
+        if (mapped && !g_pCompositor->m_pLastFocus)
             g_pInputManager->simulateMouseMovement();
 
         if (PMONITOR)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This fixes two bugs that cause https://github.com/jirutka/swaylock-effects/issues/68:
- In a multi-monitor setup, the `pWlrSurface != g_pCompositor->m_pLastFocus` check (added in #7647) will always be false for all but the currently focused surface, meaning that a motion event is sent (through the `simulateMouseMovement()` call) after a commit to any non-focused surface. In the case of swaylock, this results in a motion event around once every second, which is treated as a mouse movement thus preventing `--grace` from working properly. The fix is to only call `simulateMouseMovement()` from the surface map/commit listeners if there is no currently focused surface.
- When the session lock surface is first mapped, it unconditionally receives a pointer motion event, due to #6658. Swaylock again treats this as a normal mouse movement, and therefore unlocks itself immediately after locking if `--grace` is specified. The fix here is to not call `sendPointerMotion()` when the first surface is focused.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

As mentioned in https://github.com/jirutka/swaylock-effects/issues/68, the actual issue can be easily solved by just ignoring the motion event if the cursor didn't actually move - I believe this is what hyprlock does. However, it doesn't really make sense to send a motion event after the pointer enter event because the pointer didn't actually move. I think it could be useful to combine `setPointerFocus` and `sendPointerMotion` into one method that either sends exit/enter events if the surface is not focused, or just sends a motion event if it is.

#### Is it ready for merging, or does it need work?

Ready
