### PR TITLE
renderer: fix incorrect early return

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -331,7 +331,7 @@ bool CHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
     if (pWindow->m_pMonitor == pMonitor)
         return true;
 
-    if (!(!pWindow->m_pWorkspace || !pWindow->m_pWorkspace->isVisible()) && pWindow->m_pMonitor != pMonitor)
+    if ((!pWindow->m_pWorkspace || !pWindow->m_pWorkspace->isVisible()) && pWindow->m_pMonitor != pMonitor)
         return false;
 
     // if not, check if it maybe is active on a different monitor.


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes a logical mishap in 745a82c that causes the checks below from running due to early return.
fixes #8585 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No. 

#### Is it ready for merging, or does it need work?
Ready.