### PR TITLE
dwindle: split windows horizontally if height becomes greater than width

### DIFF
--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -12,6 +12,10 @@ void SDwindleNodeData::recalcSizePosRecursive(bool force, bool horizontalOverrid
         if (*PPRESERVESPLIT == 0 && *PSMARTSPLIT == 0)
             splitTop = box.h * *PFLMULT > box.w;
 
+        const float FIRSTSIZE = box.w / 2.0 * splitRatio;
+        if (FIRSTSIZE < box.h && box.w - FIRSTSIZE < box.h)
+            splitTop = true;
+
         if (verticalOverride == true)
             splitTop = true;
         else if (horizontalOverride == true)
@@ -423,6 +427,11 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
         } else {
             OPENINGON->pParent->children[1] = NEWPARENT;
         }
+    }
+
+    const auto WH = Vector2D(NEWPARENT->box.w / 2.f, NEWPARENT->box.h);
+    if (WH.y > WH.x) {
+        verticalOverride = true;
     }
 
     // Update the children


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Changes dwindle layout to split horizontally when the new windows height would become greater than its width.
Addresses #8434 


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
The issue mentions changing the default value of dwindle:split_width_multiplier.
This PR does not do that.

#### Is it ready for merging, or does it need work?
Ready

