### PR TITLE
use doLater instead of using wayland idle event sources

### DIFF
--- a/src/protocols/Tablet.hpp
+++ b/src/protocols/Tablet.hpp
@@ -112,21 +112,20 @@ class CTabletV2Resource {
 class CTabletToolV2Resource {
   public:
     CTabletToolV2Resource(SP<CZwpTabletToolV2> resource_, SP<CTabletTool> tool_, SP<CTabletSeat> seat_);
-    ~CTabletToolV2Resource();
 
     bool                   good();
     void                   sendData();
     void                   queueFrame();
-    void                   sendFrame(bool removeSource = true);
+    void                   sendFrame();
 
     bool                   current = false;
     WP<CWLSurfaceResource> lastSurf;
 
     WP<CTabletTool>        tool;
     WP<CTabletSeat>        seat;
-    wl_event_source*       frameSource = nullptr;
 
-    bool                   inert = false; // removed was sent
+    bool                   frameQueued = false;
+    bool                   inert       = false; // removed was sent
 
   private:
     SP<CZwpTabletToolV2> resource;

--- a/src/protocols/XDGShell.hpp
+++ b/src/protocols/XDGShell.hpp
@@ -199,12 +199,12 @@ class CXDGSurfaceResource {
     void configure();
 
   private:
-    SP<CXdgSurface>  resource;
+    SP<CXdgSurface> resource;
 
-    uint32_t         lastConfigureSerial = 0;
-    uint32_t         scheduledSerial     = 0;
+    uint32_t        lastConfigureSerial = 0;
+    uint32_t        scheduledSerial     = 0;
 
-    wl_event_source* configureSource = nullptr;
+    bool            configureScheduled = false;
 
     //
     std::vector<WP<CXDGPopupResource>> popups;

--- a/src/xwayland/Server.cpp
+++ b/src/xwayland/Server.cpp
@@ -176,11 +176,6 @@ static bool openSockets(std::array<int, 2>& sockets, int display) {
     return true;
 }
 
-static void startServer(void* data) {
-    if (!g_pXWayland->pServer->start())
-        Debug::log(ERR, "The XWayland server could not start! XWayland will not work...");
-}
-
 static int xwaylandReady(int fd, uint32_t mask, void* data) {
     return g_pXWayland->pServer->ready(fd, mask);
 }
@@ -308,9 +303,10 @@ bool CXWaylandServer::create() {
 
     setenv("DISPLAY", displayName.c_str(), true);
 
-    // TODO: lazy mode
-
-    idleSource = wl_event_loop_add_idle(g_pCompositor->m_sWLEventLoop, ::startServer, nullptr);
+    g_pEventLoopManager->doLater([this]() {
+        if (!start())
+            Debug::log(ERR, "The XWayland server could not start! XWayland will not work...");
+    });
 
     return true;
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
consolidates usage of dolater instead of multiple wayland idle sources

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
removing `removeSource` param from `void CTabletToolV2Resource::sendFrame(bool removeSource)` might cause issues
depends on why it was there in the first place

#### Is it ready for merging, or does it need work?
yes, probably