### PR TITLE
Ignore reserved areas when centering master window

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1579,6 +1579,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SBoolData{false},
     },
     SConfigOptionDescription{
+        .value       = "master:center_ignores_reserved",
+        .description = "centers the master window on monitor ignoring reserved areas",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{false},
+    },
+    SConfigOptionDescription{
         .value = "master:smart_resizing",
         .description =
             "if enabled, resizing direction will be determined by the mouse's position on the window (nearest to which corner). Else, it is based on the window's tiling position.",

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -464,6 +464,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("master:mfact", {0.55f});
     m_pConfig->addConfigValue("master:new_status", {"slave"});
     m_pConfig->addConfigValue("master:always_center_master", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("master:center_ignores_reserved", Hyprlang::INT{0});
     m_pConfig->addConfigValue("master:new_on_active", {"none"});
     m_pConfig->addConfigValue("master:new_on_top", Hyprlang::INT{0});
     m_pConfig->addConfigValue("master:orientation", {"left"});


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds an option `master:center_ignores_reserved` to ignore reserved areas while calculating master window size and position. Makes master window always centered on monitor. Reserved areas on left and right will affect slave columns only.
Needs `master:orientation = center`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
With very high `master:mfact` and large reserved areas the master window size and position might overlap with reserved areas. I don't think that such a situation can happen in any usable setup.

#### Is it ready for merging, or does it need work?
Ready

