### PR TITLE
hyprpm: target installed instead of running version

### DIFF
--- a/hyprpm/src/core/PluginManager.cpp
+++ b/hyprpm/src/core/PluginManager.cpp
@@ -50,7 +50,7 @@ static std::string getTempRoot() {
     return STR;
 }
 
-SHyprlandVersion CPluginManager::getHyprlandVersion(bool running = true) {
+SHyprlandVersion CPluginManager::getHyprlandVersion(bool running) {
     static bool             onceRunning   = false;
     static bool             onceInstalled = false;
     static SHyprlandVersion verRunning;
@@ -868,10 +868,12 @@ ePluginLoadStateReturn CPluginManager::ensurePluginsLoadState() {
             if (std::find_if(loadedPlugins.begin(), loadedPlugins.end(), [&](const auto& other) { return other == p.name; }) != loadedPlugins.end())
                 continue;
 
-            if (!loadUnloadPlugin(HYPRPMPATH + repoForName(p.name) + "/" + p.filename, true))
+            if (!loadUnloadPlugin(HYPRPMPATH + repoForName(p.name) + "/" + p.filename, true)) {
+                std::println("{}", infoString("{} will be loaded after restarting Hyprland", p.name));
                 hyprlandVersionMismatch = true;
-
-            std::println("{}", successString("Loaded {}", p.name));
+            } else {
+                std::println("{}", successString("Loaded {}", p.name));
+            }
         }
     }
 

--- a/hyprpm/src/core/PluginManager.cpp
+++ b/hyprpm/src/core/PluginManager.cpp
@@ -50,17 +50,26 @@ static std::string getTempRoot() {
     return STR;
 }
 
-SHyprlandVersion CPluginManager::getHyprlandVersion() {
-    static SHyprlandVersion ver;
-    static bool             once = false;
+SHyprlandVersion CPluginManager::getHyprlandVersion(bool running = true) {
+    static bool             once_running   = false;
+    static bool             once_installed = false;
+    static SHyprlandVersion ver_running;
+    static SHyprlandVersion ver_installed;
 
-    if (once)
-        return ver;
+    if (once_running && running)
+        return ver_running;
 
-    once                 = true;
-    const auto HLVERCALL = execAndGet("hyprctl version");
+    if (once_installed && !running)
+        return ver_installed;
+
+    if (running)
+        once_running = true;
+    else
+        once_installed = true;
+
+    const auto HLVERCALL = running ? execAndGet("hyprctl version") : execAndGet("Hyprland --version");
     if (m_bVerbose)
-        std::println("{}", verboseString("version returned: {}", HLVERCALL));
+        std::println("{}", verboseString("{} version returned: {}", running ? "running" : "installed", HLVERCALL));
 
     if (!HLVERCALL.contains("Tag:")) {
         std::println(stderr, "\n{}", failureString("You don't seem to be running Hyprland."));
@@ -91,7 +100,13 @@ SHyprlandVersion CPluginManager::getHyprlandVersion() {
     if (m_bVerbose)
         std::println("{}", verboseString("parsed commit {} at branch {} on {}, commits {}", hlcommit, hlbranch, hldate, commits));
 
-    ver = SHyprlandVersion{hlbranch, hlcommit, hldate, commits};
+    auto ver = SHyprlandVersion{hlbranch, hlcommit, hldate, commits};
+
+    if (running)
+        ver_running = ver;
+    else
+        ver_installed = ver;
+
     return ver;
 }
 
@@ -356,7 +371,7 @@ bool CPluginManager::removePluginRepo(const std::string& urlOrName) {
 }
 
 eHeadersErrors CPluginManager::headersValid() {
-    const auto HLVER = getHyprlandVersion();
+    const auto HLVER = getHyprlandVersion(false);
 
     if (!std::filesystem::exists(DataState::getHeadersPath() + "/share/pkgconfig/hyprland.pc"))
         return HEADERS_MISSING;
@@ -418,7 +433,7 @@ bool CPluginManager::updateHeaders(bool force) {
 
     DataState::ensureStateStoreExists();
 
-    const auto HLVER = getHyprlandVersion();
+    const auto HLVER = getHyprlandVersion(false);
 
     if (!hasDeps()) {
         std::println("\n{}", failureString("Could not update. Dependencies not satisfied. Hyprpm requires: cmake, meson, cpio, pkg-config"));
@@ -580,7 +595,7 @@ bool CPluginManager::updatePlugins(bool forceUpdateAll) {
         return true;
     }
 
-    const auto   HLVER = getHyprlandVersion();
+    const auto   HLVER = getHyprlandVersion(false);
 
     CProgressBar progress;
     progress.m_iMaxSteps        = REPOS.size() * 2 + 2;
@@ -829,11 +844,17 @@ ePluginLoadStateReturn CPluginManager::ensurePluginsLoadState() {
         return "";
     };
 
+    // if any of the loadUnloadPlugin calls return false, this is true
+    // bcs that means the header version doesn't match the running version
+    // (and Hyprland needs to restart)
+    bool hyprlandVersionMismatch = false;
+
     // unload disabled plugins
     for (auto const& p : loadedPlugins) {
         if (!enabled(p)) {
             // unload
-            loadUnloadPlugin(HYPRPMPATH + repoForName(p) + "/" + p + ".so", false);
+            if (!loadUnloadPlugin(HYPRPMPATH + repoForName(p) + "/" + p + ".so", false))
+                hyprlandVersionMismatch = true;
             std::println("{}", successString("Unloaded {}", p));
         }
     }
@@ -847,17 +868,27 @@ ePluginLoadStateReturn CPluginManager::ensurePluginsLoadState() {
             if (std::find_if(loadedPlugins.begin(), loadedPlugins.end(), [&](const auto& other) { return other == p.name; }) != loadedPlugins.end())
                 continue;
 
-            loadUnloadPlugin(HYPRPMPATH + repoForName(p.name) + "/" + p.filename, true);
+            if (!loadUnloadPlugin(HYPRPMPATH + repoForName(p.name) + "/" + p.filename, true))
+                hyprlandVersionMismatch = true;
+
             std::println("{}", successString("Loaded {}", p.name));
         }
     }
 
     std::println("{}", successString("Plugin load state ensured"));
 
-    return LOADSTATE_OK;
+    return hyprlandVersionMismatch ? LOADSTATE_HYPRLAND_UPDATED : LOADSTATE_OK;
 }
 
 bool CPluginManager::loadUnloadPlugin(const std::string& path, bool load) {
+    auto state = DataState::getGlobalState();
+    auto HLVER = getHyprlandVersion(true);
+
+    if (state.headersHashCompiled != HLVER.hash) {
+        std::println("{}", infoString("Running Hyprland version differs from plugin state, please restart Hyprland."));
+        return false;
+    }
+
     if (load)
         execAndGet("hyprctl plugin load " + path);
     else

--- a/hyprpm/src/core/PluginManager.cpp
+++ b/hyprpm/src/core/PluginManager.cpp
@@ -51,21 +51,21 @@ static std::string getTempRoot() {
 }
 
 SHyprlandVersion CPluginManager::getHyprlandVersion(bool running = true) {
-    static bool             once_running   = false;
-    static bool             once_installed = false;
-    static SHyprlandVersion ver_running;
-    static SHyprlandVersion ver_installed;
+    static bool             onceRunning   = false;
+    static bool             onceInstalled = false;
+    static SHyprlandVersion verRunning;
+    static SHyprlandVersion verInstalled;
 
-    if (once_running && running)
-        return ver_running;
+    if (onceRunning && running)
+        return verRunning;
 
-    if (once_installed && !running)
-        return ver_installed;
+    if (onceInstalled && !running)
+        return verInstalled;
 
     if (running)
-        once_running = true;
+        onceRunning = true;
     else
-        once_installed = true;
+        onceInstalled = true;
 
     const auto HLVERCALL = running ? execAndGet("hyprctl version") : execAndGet("Hyprland --version");
     if (m_bVerbose)
@@ -103,9 +103,9 @@ SHyprlandVersion CPluginManager::getHyprlandVersion(bool running = true) {
     auto ver = SHyprlandVersion{hlbranch, hlcommit, hldate, commits};
 
     if (running)
-        ver_running = ver;
+        verRunning = ver;
     else
-        ver_installed = ver;
+        verInstalled = ver;
 
     return ver;
 }

--- a/hyprpm/src/core/PluginManager.cpp
+++ b/hyprpm/src/core/PluginManager.cpp
@@ -853,9 +853,11 @@ ePluginLoadStateReturn CPluginManager::ensurePluginsLoadState() {
     for (auto const& p : loadedPlugins) {
         if (!enabled(p)) {
             // unload
-            if (!loadUnloadPlugin(HYPRPMPATH + repoForName(p) + "/" + p + ".so", false))
+            if (!loadUnloadPlugin(HYPRPMPATH + repoForName(p) + "/" + p + ".so", false)) {
+                std::println("{}", infoString("{} will be unloaded after restarting Hyprland", p));
                 hyprlandVersionMismatch = true;
-            std::println("{}", successString("Unloaded {}", p));
+            } else
+                std::println("{}", successString("Unloaded {}", p));
         }
     }
 
@@ -871,9 +873,8 @@ ePluginLoadStateReturn CPluginManager::ensurePluginsLoadState() {
             if (!loadUnloadPlugin(HYPRPMPATH + repoForName(p.name) + "/" + p.filename, true)) {
                 std::println("{}", infoString("{} will be loaded after restarting Hyprland", p.name));
                 hyprlandVersionMismatch = true;
-            } else {
+            } else
                 std::println("{}", successString("Loaded {}", p.name));
-            }
         }
     }
 

--- a/hyprpm/src/core/PluginManager.hpp
+++ b/hyprpm/src/core/PluginManager.hpp
@@ -54,7 +54,7 @@ class CPluginManager {
     ePluginLoadStateReturn ensurePluginsLoadState();
 
     bool                   loadUnloadPlugin(const std::string& path, bool load);
-    SHyprlandVersion       getHyprlandVersion(bool running);
+    SHyprlandVersion       getHyprlandVersion(bool running = true);
 
     void                   notify(const eNotifyIcons icon, uint32_t color, int durationMs, const std::string& message);
 

--- a/hyprpm/src/core/PluginManager.hpp
+++ b/hyprpm/src/core/PluginManager.hpp
@@ -27,7 +27,8 @@ enum ePluginLoadStateReturn {
     LOADSTATE_OK = 0,
     LOADSTATE_FAIL,
     LOADSTATE_PARTIAL_FAIL,
-    LOADSTATE_HEADERS_OUTDATED
+    LOADSTATE_HEADERS_OUTDATED,
+    LOADSTATE_HYPRLAND_UPDATED
 };
 
 struct SHyprlandVersion {
@@ -53,7 +54,7 @@ class CPluginManager {
     ePluginLoadStateReturn ensurePluginsLoadState();
 
     bool                   loadUnloadPlugin(const std::string& path, bool load);
-    SHyprlandVersion       getHyprlandVersion();
+    SHyprlandVersion       getHyprlandVersion(bool running);
 
     void                   notify(const eNotifyIcons icon, uint32_t color, int durationMs, const std::string& message);
 

--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -103,7 +103,7 @@ int                        main(int argc, char** argv, char** envp) {
         bool headersValid = g_pPluginManager->headersValid() == HEADERS_OK;
         bool headers      = g_pPluginManager->updateHeaders(force);
         if (headers) {
-            const auto HLVER            = g_pPluginManager->getHyprlandVersion();
+            const auto HLVER            = g_pPluginManager->getHyprlandVersion(false);
             auto       GLOBALSTATE      = DataState::getGlobalState();
             const auto COMPILEDOUTDATED = HLVER.hash != GLOBALSTATE.headersHashCompiled;
 
@@ -114,7 +114,10 @@ int                        main(int argc, char** argv, char** envp) {
 
             auto ret2 = g_pPluginManager->ensurePluginsLoadState();
 
-            if (ret2 != LOADSTATE_OK)
+            if (ret2 == LOADSTATE_HYPRLAND_UPDATED)
+                g_pPluginManager->notify(ICON_INFO, 0, 10000, "[hyprpm] Updated plugins, but Hyprland was updated. Please restart Hyprland.");
+
+            if (ret2 != LOADSTATE_OK && ret2 != LOADSTATE_HYPRLAND_UPDATED)
                 return 1;
         } else if (notify)
             g_pPluginManager->notify(ICON_ERROR, 0, 10000, "[hyprpm] Couldn't update headers");

--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -117,7 +117,7 @@ int                        main(int argc, char** argv, char** envp) {
             if (ret2 == LOADSTATE_HYPRLAND_UPDATED)
                 g_pPluginManager->notify(ICON_INFO, 0, 10000, "[hyprpm] Updated plugins, but Hyprland was updated. Please restart Hyprland.");
 
-            if (ret2 != LOADSTATE_OK || ret2 == LOADSTATE_HYPRLAND_UPDATED)
+            if (ret2 != LOADSTATE_OK)
                 return 1;
         } else if (notify)
             g_pPluginManager->notify(ICON_ERROR, 0, 10000, "[hyprpm] Couldn't update headers");
@@ -137,7 +137,7 @@ int                        main(int argc, char** argv, char** envp) {
         if (ret == LOADSTATE_HYPRLAND_UPDATED)
             g_pPluginManager->notify(ICON_INFO, 0, 10000, "[hyprpm] Enabled plugin, but Hyprland was updated. Please restart Hyprland.");
 
-        if (ret != LOADSTATE_OK || ret == LOADSTATE_HYPRLAND_UPDATED)
+        if (ret != LOADSTATE_OK)
             return 1;
     } else if (command[0] == "disable") {
         if (command.size() < 2) {

--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -133,7 +133,11 @@ int                        main(int argc, char** argv, char** envp) {
         }
 
         auto ret = g_pPluginManager->ensurePluginsLoadState();
-        if (ret != LOADSTATE_OK)
+
+        if (ret == LOADSTATE_HYPRLAND_UPDATED)
+            g_pPluginManager->notify(ICON_INFO, 0, 10000, "[hyprpm] Enabled plugin, but Hyprland was updated. Please restart Hyprland.");
+
+        if (ret != LOADSTATE_OK && ret != LOADSTATE_HYPRLAND_UPDATED)
             return 1;
     } else if (command[0] == "disable") {
         if (command.size() < 2) {

--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -117,7 +117,7 @@ int                        main(int argc, char** argv, char** envp) {
             if (ret2 == LOADSTATE_HYPRLAND_UPDATED)
                 g_pPluginManager->notify(ICON_INFO, 0, 10000, "[hyprpm] Updated plugins, but Hyprland was updated. Please restart Hyprland.");
 
-            if (ret2 != LOADSTATE_OK && ret2 != LOADSTATE_HYPRLAND_UPDATED)
+            if (ret2 != LOADSTATE_OK || ret2 == LOADSTATE_HYPRLAND_UPDATED)
                 return 1;
         } else if (notify)
             g_pPluginManager->notify(ICON_ERROR, 0, 10000, "[hyprpm] Couldn't update headers");
@@ -137,7 +137,7 @@ int                        main(int argc, char** argv, char** envp) {
         if (ret == LOADSTATE_HYPRLAND_UPDATED)
             g_pPluginManager->notify(ICON_INFO, 0, 10000, "[hyprpm] Enabled plugin, but Hyprland was updated. Please restart Hyprland.");
 
-        if (ret != LOADSTATE_OK && ret != LOADSTATE_HYPRLAND_UPDATED)
+        if (ret != LOADSTATE_OK || ret == LOADSTATE_HYPRLAND_UPDATED)
             return 1;
     } else if (command[0] == "disable") {
         if (command.size() < 2) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
After updating Hyprland, `hyprpm update` will still build plugins against the currently running version of Hyprland.
This is a little annoying, because you first have to restart Hyprland and *then* run `hyprpm update` for your plugins to be built for the correct version.
This PR makes `hyprpm` build against the *installed* version of Hyprland instead of the running version, and shows a popup notification if the running Hyprland version differs from the installed one after updating, telling users to restart Hyprland.
![example](https://github.com/user-attachments/assets/29443381-7b5e-491d-b245-e9fa4e36dcd3)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
When I tested it on my setup (Arch) everything worked fine, so no I don't think so. Not sure how Nix handles stuff, but it should work there too I suppose.
I did change the signature of hyprpm's `getHyprlandVersion` func, but gave it a default value of true that corresponds to the original behavior.

#### Is it ready for merging, or does it need work?
Should be ready for merging, although if you have any feedback (e.g. UX wise) go for it
