### PR TITLE
Don't use explicit sync fences if we can tear

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1531,7 +1531,7 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
     if (inFD >= 0)
         pMonitor->output->state->setExplicitInFence(inFD);
     auto explicitOptions = getExplicitSyncSettings();
-    if (explicitOptions.explicitEnabled && explicitOptions.explicitKMSEnabled)
+    if (explicitOptions.explicitEnabled && explicitOptions.explicitKMSEnabled && !pMonitor->tearingState.canTear)
         pMonitor->output->state->enableExplicitOutFenceForNextCommit();
 
     if (pMonitor->ctmUpdated) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes https://github.com/hyprwm/Hyprland/issues/8482

This fixes the issue where with explicit sync on no tearing is possible even when the requirements for it are fully met.

This is similar to how KWIN handles it.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I am not 100% sure this is ultimately the correct fix but it retains fences and allows tearing to happen when requested. It also seems to be what other compositors are doing too.

Also been running this patch on my distro with a good number of users with no issues reported for around 3 weeks.

#### Is it ready for merging, or does it need work?
Yea do it.

