### PR TITLE
Add window rules for mouse and touchpad scroll factors

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2309,14 +2309,15 @@ bool windowRuleValid(const std::string& RULE) {
         "float", "fullscreen", "maximize", "noinitialfocus", "pin", "stayfocused", "tile", "renderunfocused",
     };
     static const auto rulesPrefix = std::vector<std::string>{
-        "animation", "bordercolor", "bordersize", "center", "fullscreenstate", "group", "idleinhibit",   "maxsize", "minsize",   "monitor",
-        "move",      "opacity",     "plugin:",    "pseudo", "rounding",        "size",  "suppressevent", "tag",     "workspace", "xray",
+        "animation", "bordercolor", "bordersize", "center",   "fullscreenstate", "group",          "idleinhibit", "maxsize",       "minsize", "monitor",   "move",
+        "opacity",   "plugin:",     "pseudo",     "rounding", "scrollmouse",     "scrolltouchpad", "size",        "suppressevent", "tag",     "workspace", "xray",
     };
 
     const auto VALS = CVarList(RULE, 2, ' ');
     return rules.contains(RULE) || std::any_of(rulesPrefix.begin(), rulesPrefix.end(), [&RULE](auto prefix) { return RULE.starts_with(prefix); }) ||
         (g_pConfigManager->mbWindowProperties.find(VALS[0]) != g_pConfigManager->mbWindowProperties.end()) ||
-        (g_pConfigManager->miWindowProperties.find(VALS[0]) != g_pConfigManager->miWindowProperties.end());
+        (g_pConfigManager->miWindowProperties.find(VALS[0]) != g_pConfigManager->miWindowProperties.end()) ||
+        (g_pConfigManager->mfWindowProperties.find(VALS[0]) != g_pConfigManager->mfWindowProperties.end());
 }
 
 bool layerRuleValid(const std::string& RULE) {

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -263,6 +263,10 @@ class CConfigManager {
         {"bordersize", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.borderSize; }},
     };
 
+    std::unordered_map<std::string, std::function<CWindowOverridableVar<float>*(PHLWINDOW)>> mfWindowProperties = {
+        {"scrollmouse", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.scrollMouse; }},
+        {"scrolltouchpad", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.scrollTouchpad; }}};
+
     bool m_bWantsMonitorReload = false;
     bool m_bForceReload        = false;
     bool m_bNoMonitorReload    = false;

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -718,6 +718,10 @@ void CWindow::applyDynamicRule(const SWindowRule& r) {
         try {
             *(search->second(m_pSelf.lock())) = CWindowOverridableVar(std::stoi(VARS[1]), priority);
         } catch (std::exception& e) { Debug::log(ERR, "Rule \"{}\" failed with: {}", r.szRule, e.what()); }
+    } else if (auto search = g_pConfigManager->mfWindowProperties.find(VARS[0]); search != g_pConfigManager->mfWindowProperties.end()) {
+        try {
+            *(search->second(m_pSelf.lock())) = CWindowOverridableVar(std::stof(VARS[1]), priority);
+        } catch (std::exception& e) { Debug::log(ERR, "Rule \"{}\" failed with: {}", r.szRule, e.what()); }
     } else if (r.szRule.starts_with("idleinhibit")) {
         auto IDLERULE = r.szRule.substr(r.szRule.find_first_of(' ') + 1);
 
@@ -1178,6 +1182,16 @@ int CWindow::getRealBorderSize() {
     return m_sWindowData.borderSize.valueOr(*PBORDERSIZE);
 }
 
+float CWindow::getScrollMouse() {
+    static auto PINPUTSCROLLFACTOR = CConfigValue<Hyprlang::FLOAT>("input:scroll_factor");
+    return m_sWindowData.scrollMouse.valueOr(*PINPUTSCROLLFACTOR);
+}
+
+float CWindow::getScrollTouchpad() {
+    static auto PTOUCHPADSCROLLFACTOR = CConfigValue<Hyprlang::FLOAT>("input:touchpad:scroll_factor");
+    return m_sWindowData.scrollTouchpad.valueOr(*PTOUCHPADSCROLLFACTOR);
+}
+
 bool CWindow::canBeTorn() {
     static auto PTEARING = CConfigValue<Hyprlang::INT>("general:allow_tearing");
     return m_sWindowData.tearing.valueOr(m_bTearingHint) && *PTEARING;
@@ -1600,6 +1614,9 @@ void CWindow::unsetWindowData(eOverridePriority priority) {
         element.second(m_pSelf.lock())->unset(priority);
     }
     for (auto const& element : g_pConfigManager->miWindowProperties) {
+        element.second(m_pSelf.lock())->unset(priority);
+    }
+    for (auto const& element : g_pConfigManager->mfWindowProperties) {
         element.second(m_pSelf.lock())->unset(priority);
     }
 }

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -184,6 +184,9 @@ struct SWindowData {
     CWindowOverridableVar<int>                rounding;
     CWindowOverridableVar<int>                borderSize;
 
+    CWindowOverridableVar<float>              scrollMouse;
+    CWindowOverridableVar<float>              scrollTouchpad;
+
     CWindowOverridableVar<std::string>        animationStyle;
     CWindowOverridableVar<Vector2D>           maxSize;
     CWindowOverridableVar<Vector2D>           minSize;
@@ -442,6 +445,8 @@ class CWindow {
     bool                   isFullscreen();
     bool                   isEffectiveInternalFSMode(const eFullscreenMode);
     int                    getRealBorderSize();
+    float                  getScrollMouse();
+    float                  getScrollTouchpad();
     void                   updateWindowData();
     void                   updateWindowData(const struct SWorkspaceRule&);
     void                   onBorderAngleAnimEnd(void* ptr);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -3014,6 +3014,13 @@ SDispatchResult CKeybindManager::setProp(std::string args) {
                 search->second(PWINDOW)->unset(PRIORITY_SET_PROP);
             else if (const auto V = configStringToInt(VAL); V)
                 *(search->second(PWINDOW)) = CWindowOverridableVar((int)*V, PRIORITY_SET_PROP);
+        } else if (auto search = g_pConfigManager->mfWindowProperties.find(PROP); search != g_pConfigManager->mfWindowProperties.end()) {
+            if (VAL == "unset")
+                search->second(PWINDOW)->unset(PRIORITY_SET_PROP);
+            else {
+                const auto V               = std::stof(VAL);
+                *(search->second(PWINDOW)) = CWindowOverridableVar(V, PRIORITY_SET_PROP);
+            }
         } else
             return {.success = false, .error = "Prop not found"};
     } catch (std::exception& e) { return {.success = false, .error = std::format("Error parsing prop value: {}", std::string(e.what()))}; }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -761,7 +761,8 @@ void CInputManager::onMouseWheel(IPointer::SAxisEvent e) {
     static auto PEMULATEDISCRETE      = CConfigValue<Hyprlang::INT>("input:emulate_discrete_scroll");
     static auto PFOLLOWMOUSE          = CConfigValue<Hyprlang::INT>("input:follow_mouse");
 
-    auto        factor = (*PTOUCHPADSCROLLFACTOR <= 0.f || e.source == WL_POINTER_AXIS_SOURCE_FINGER ? *PTOUCHPADSCROLLFACTOR : *PINPUTSCROLLFACTOR);
+    const bool  ISTOUCHPADSCROLL = *PTOUCHPADSCROLLFACTOR <= 0.f || e.source == WL_POINTER_AXIS_SOURCE_FINGER;
+    auto        factor           = ISTOUCHPADSCROLL ? *PTOUCHPADSCROLLFACTOR : *PINPUTSCROLLFACTOR;
 
     const auto  EMAP = std::unordered_map<std::string, std::any>{{"event", e}};
     EMIT_HOOK_EVENT_CANCELLABLE("mouseAxis", EMAP);
@@ -803,6 +804,7 @@ void CInputManager::onMouseWheel(IPointer::SAxisEvent e) {
                 if (*PFOLLOWMOUSE == 1 && PCURRWINDOW && PWINDOW != PCURRWINDOW)
                     simulateMouseMovement();
             }
+            factor = ISTOUCHPADSCROLL ? PWINDOW->getScrollTouchpad() : PWINDOW->getScrollMouse();
         }
     }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

There are scenarios where I want the scroll factor to be different on a per-window/application basis. This change adds window rules for overriding the global scroll factors. There is one for the mouse scroll factor (`scrollmouse`) and one for the touchpad (`scrolltouchpad`)

Example:

`hyprland.conf`:
```ini
# Faster scrolling in Dolphin
windowrulev2 = scrollmouse 3, class:org.kde.dolphin

# Even faster scrolling in Sublime Text
windowrulev2 = scrollmouse 5, class:sublime_text
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Not that I can think of.

#### Is it ready for merging, or does it need work?

Ready for merging.