### PR TITLE
core: Add clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,7 @@ Checks: >
   -bugprone-macro-parentheses,
   -bugprone-narrowing-conversions,
   -bugprone-branch-clone,
+  -bugprone-assignment-in-if-condition,
   concurrency-*,
   -concurrency-mt-unsafe,
   cppcoreguidelines-*,
@@ -34,6 +35,7 @@ Checks: >
   -cppcoreguidelines-init-variables,
   -cppcoreguidelines-pro-type-cstyle-cast,
   -cppcoreguidelines-pro-type-vararg,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
   google-global-names-in-headers,
   -google-readability-casting,
   google-runtime-operator,
@@ -78,6 +80,8 @@ Checks: >
   -readability-convert-member-functions-to-static,
   -readability-qualified-auto,
   -readability-make-member-function-const,
+  -readability-isolate-declaration,
+  -readability-inconsistent-declaration-parameter-name,
   -clang-diagnostic-error,
 
 CheckOptions:

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -57,6 +57,7 @@ Checks: >
   -modernize-use-auto,
   performance-*,
   -performance-avoid-endl,
+  -performance-unnecessary-value-param,
   portability-std-allocator-const,
   readability-*,
   -readability-function-cognitive-complexity,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,96 @@
+WarningsAsErrors: '*'
+HeaderFilterRegex: '.*\.hpp'
+FormatStyle: file
+Checks: >
+  -*,
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-forward-declararion-namespace,
+  -bugprone-forward-declararion-namespace,
+  -bugprone-macro-parentheses,
+  -bugprone-narrowing-conversions,
+  -bugprone-branch-clone,
+  concurrency-*,
+  -concurrency-mt-unsafe,
+  cppcoreguidelines-*,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-avoid-const-or-ref-data-members,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-avoid-goto,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-avoid-do-while,
+  -cppcoreguidelines-avoid-non-const-global-variables,
+  -cppcoreguidelines-special-member-functions,
+  -cppcoreguidelines-explicit-virtual-functions,
+  -cppcoreguidelines-avoid-c-arrays,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-narrowing-conversions,
+  -cppcoreguidelines-pro-type-union-access,
+  -cppcoreguidelines-pro-type-member-init,
+  -cppcoreguidelines-macro-usage,
+  -cppcoreguidelines-macro-to-enum,
+  -cppcoreguidelines-init-variables,
+  -cppcoreguidelines-pro-type-cstyle-cast,
+  -cppcoreguidelines-pro-type-vararg,
+  google-global-names-in-headers,
+  -google-readability-casting,
+  google-runtime-operator,
+  misc-*,
+  -misc-unused-parameters,
+  -misc-no-recursion,
+  -misc-non-private-member-variables-in-classes,
+  -misc-include-cleaner,
+  -misc-use-anonymous-namespace,
+  -misc-const-correctness,
+  modernize-*,
+  -modernize-return-braced-init-list,
+  -modernize-use-trailing-return-type,
+  -modernize-use-using,
+  -modernize-use-override,
+  -modernize-avoid-c-arrays,
+  -modernize-macro-to-enum,
+  -modernize-loop-convert,
+  -modernize-use-nodiscard,
+  -modernize-pass-by-value,
+  -modernize-use-auto,
+  performance-*,
+  -performance-avoid-endl,
+  portability-std-allocator-const,
+  readability-*,
+  -readability-function-cognitive-complexity,
+  -readability-function-size,
+  -readability-identifier-length,
+  -readability-magic-numbers,
+  -readability-uppercase-literal-suffix,
+  -readability-braces-around-statements,
+  -readability-redundant-access-specifiers,
+  -readability-else-after-return,
+  -readability-container-data-pointer,
+  -readability-implicit-bool-conversion,
+  -readability-avoid-nested-conditional-operator,
+  -readability-redundant-member-init,
+  -readability-redundant-string-init,
+  -readability-avoid-const-params-in-decls,
+  -readability-named-parameter,
+  -readability-convert-member-functions-to-static,
+  -readability-qualified-auto,
+  -readability-make-member-function-const,
+  -clang-diagnostic-error,
+
+CheckOptions:
+  performance-for-range-copy.WarnOnAllAutoCopies: true
+  performance-inefficient-string-concatenation.StrictMode: true
+  readability-braces-around-statements.ShortStatementLines: 0
+  readability-identifier-naming.ClassCase: CamelCase
+  readability-identifier-naming.ClassIgnoredRegexp: I.*
+  readability-identifier-naming.ClassPrefix: C # We can't use regex here?!?!?!?
+  readability-identifier-naming.EnumCase: CamelCase
+  readability-identifier-naming.EnumPrefix: e
+  readability-identifier-naming.EnumConstantCase: UPPER_CASE
+  readability-identifier-naming.FunctionCase: camelBack
+  readability-identifier-naming.NamespaceCase: CamelCase
+  readability-identifier-naming.NamespacePrefix: N
+  readability-identifier-naming.StructPrefix: S
+  readability-identifier-naming.StructCase: CamelCase

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2234,26 +2234,26 @@ void CCompositor::updateFullscreenFadeOnWorkspace(PHLWORKSPACE pWorkspace) {
 
 void CCompositor::changeWindowFullscreenModeInternal(const PHLWINDOW PWINDOW, const eFullscreenMode MODE, const bool ON) {
     setWindowFullscreenInternal(
-        PWINDOW, (eFullscreenMode)(ON ? (uint8_t)PWINDOW->m_SFullscreenState.internal | (uint8_t)MODE : ((uint8_t)PWINDOW->m_SFullscreenState.internal & (uint8_t)~MODE)));
+        PWINDOW, (eFullscreenMode)(ON ? (uint8_t)PWINDOW->m_sFullscreenState.internal | (uint8_t)MODE : ((uint8_t)PWINDOW->m_sFullscreenState.internal & (uint8_t)~MODE)));
 }
 
 void CCompositor::changeWindowFullscreenModeClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE, const bool ON) {
     setWindowFullscreenClient(PWINDOW,
-                              (eFullscreenMode)(ON ? (uint8_t)PWINDOW->m_SFullscreenState.client | (uint8_t)MODE : ((uint8_t)PWINDOW->m_SFullscreenState.client & (uint8_t)~MODE)));
+                              (eFullscreenMode)(ON ? (uint8_t)PWINDOW->m_sFullscreenState.client | (uint8_t)MODE : ((uint8_t)PWINDOW->m_sFullscreenState.client & (uint8_t)~MODE)));
 }
 
 void CCompositor::setWindowFullscreenInternal(const PHLWINDOW PWINDOW, const eFullscreenMode MODE) {
     if (PWINDOW->m_sWindowData.syncFullscreen.valueOrDefault())
         setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = MODE, .client = MODE});
     else
-        setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = MODE, .client = PWINDOW->m_SFullscreenState.client});
+        setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = MODE, .client = PWINDOW->m_sFullscreenState.client});
 }
 
 void CCompositor::setWindowFullscreenClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE) {
     if (PWINDOW->m_sWindowData.syncFullscreen.valueOrDefault())
         setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = MODE, .client = MODE});
     else
-        setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = PWINDOW->m_SFullscreenState.internal, .client = MODE});
+        setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = PWINDOW->m_sFullscreenState.internal, .client = MODE});
 }
 
 void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, SFullscreenState state) {
@@ -2269,7 +2269,7 @@ void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, SFullscreenS
     const auto            PMONITOR   = PWINDOW->m_pMonitor.lock();
     const auto            PWORKSPACE = PWINDOW->m_pWorkspace;
 
-    const eFullscreenMode CURRENT_EFFECTIVE_MODE = (eFullscreenMode)std::bit_floor((uint8_t)PWINDOW->m_SFullscreenState.internal);
+    const eFullscreenMode CURRENT_EFFECTIVE_MODE = (eFullscreenMode)std::bit_floor((uint8_t)PWINDOW->m_sFullscreenState.internal);
     const eFullscreenMode EFFECTIVE_MODE         = (eFullscreenMode)std::bit_floor((uint8_t)state.internal);
 
     if (*PALLOWPINFULLSCREEN && !PWINDOW->m_bPinFullscreened && !PWINDOW->isFullscreen() && PWINDOW->m_bPinned) {
@@ -2288,7 +2288,7 @@ void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, SFullscreenS
     if (!CHANGEINTERNAL && PWINDOW->m_sWindowData.syncFullscreen.valueOrDefault())
         return;
 
-    PWINDOW->m_SFullscreenState.client = state.client;
+    PWINDOW->m_sFullscreenState.client = state.client;
     g_pXWaylandManager->setWindowFullscreen(PWINDOW, state.client & FSMODE_FULLSCREEN);
 
     if (!CHANGEINTERNAL) {
@@ -2300,7 +2300,7 @@ void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, SFullscreenS
 
     g_pLayoutManager->getCurrentLayout()->fullscreenRequestForWindow(PWINDOW, CURRENT_EFFECTIVE_MODE, EFFECTIVE_MODE);
 
-    PWINDOW->m_SFullscreenState.internal = state.internal;
+    PWINDOW->m_sFullscreenState.internal = state.internal;
     PWORKSPACE->m_efFullscreenMode       = EFFECTIVE_MODE;
     PWORKSPACE->m_bHasFullscreenWindow   = EFFECTIVE_MODE != FSMODE_NONE;
 
@@ -2647,7 +2647,7 @@ void CCompositor::moveWindowToWorkspaceSafe(PHLWINDOW pWindow, PHLWORKSPACE pWor
         return;
 
     const bool FULLSCREEN     = pWindow->isFullscreen();
-    const auto FULLSCREENMODE = pWindow->m_SFullscreenState.internal;
+    const auto FULLSCREENMODE = pWindow->m_sFullscreenState.internal;
 
     if (FULLSCREEN)
         setWindowFullscreenInternal(pWindow, FSMODE_NONE);

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -76,7 +76,7 @@ void handleUnrecoverableSignal(int sig) {
     });
     alarm(15);
 
-    CrashReporter::createAndSaveCrash(sig);
+    NCrashReporter::createAndSaveCrash(sig);
 
     abort();
 }
@@ -88,7 +88,7 @@ void handleUserSignal(int sig) {
     }
 }
 
-static LogLevel aqLevelToHl(Aquamarine::eBackendLogLevel level) {
+static eLogLevel aqLevelToHl(Aquamarine::eBackendLogLevel level) {
     switch (level) {
         case Aquamarine::eBackendLogLevel::AQ_LOG_TRACE: return TRACE;
         case Aquamarine::eBackendLogLevel::AQ_LOG_DEBUG: return LOG;
@@ -136,9 +136,7 @@ void CCompositor::restoreNofile() {
         Debug::log(ERR, "Failed restoring NOFILE limits");
 }
 
-CCompositor::CCompositor() {
-    m_iHyprlandPID = getpid();
-
+CCompositor::CCompositor() : m_iHyprlandPID(getpid()) {
     m_szHyprTempDataRoot = std::string{getenv("XDG_RUNTIME_DIR")} + "/hypr";
 
     if (m_szHyprTempDataRoot.starts_with("/hypr")) {
@@ -153,7 +151,7 @@ CCompositor::CCompositor() {
     std::mt19937                    engine(dev());
     std::uniform_int_distribution<> distribution(0, INT32_MAX);
 
-    m_szInstanceSignature = std::format("{}_{}_{}", GIT_COMMIT_HASH, std::time(NULL), distribution(engine));
+    m_szInstanceSignature = std::format("{}_{}_{}", GIT_COMMIT_HASH, std::time(nullptr), distribution(engine));
 
     setenv("HYPRLAND_INSTANCE_SIGNATURE", m_szInstanceSignature.c_str(), true);
 
@@ -261,7 +259,7 @@ void CCompositor::initServer(std::string socketName, int socketFd) {
     // set the buffer size to 1MB to avoid disconnects due to an app hanging for a short while
     wl_display_set_default_max_buffer_size(m_sWLDisplay, 1_MB);
 
-    Aquamarine::SBackendOptions options;
+    Aquamarine::SBackendOptions options{};
     options.logFunction = aqLog;
 
     std::vector<Aquamarine::SBackendImplementationOptions> implementations;
@@ -1360,7 +1358,7 @@ void CCompositor::changeWindowZOrder(PHLWINDOW pWindow, bool top) {
                 toMove.emplace_front(pw);
 
             for (auto const& w : m_vWindows) {
-                if (w->m_bIsMapped && !w->isHidden() && w->m_bIsX11 && w->X11TransientFor() == pw && w != pw && std::find(toMove.begin(), toMove.end(), w) == toMove.end()) {
+                if (w->m_bIsMapped && !w->isHidden() && w->m_bIsX11 && w->x11TransientFor() == pw && w != pw && std::find(toMove.begin(), toMove.end(), w) == toMove.end()) {
                     x11Stack(w, top, x11Stack);
                 }
             }
@@ -1572,7 +1570,7 @@ PHLWINDOW CCompositor::getWindowInDirection(PHLWINDOW pWindow, char dir) {
         static const std::unordered_map<char, Vector2D> VECTORS = {{'r', {1, 0}}, {'t', {0, -1}}, {'b', {0, 1}}, {'l', {-1, 0}}};
 
         //
-        auto vectorAngles = [](Vector2D a, Vector2D b) -> double {
+        auto vectorAngles = [](const Vector2D& a, const Vector2D& b) -> double {
             double dot = a.x * b.x + a.y * b.y;
             double ang = std::acos(dot / (a.size() * b.size()));
             return ang;

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -491,8 +491,8 @@ void CCompositor::cleanup() {
     Debug::shuttingDown = true;
 
 #ifdef USES_SYSTEMD
-    if (Systemd::SdBooted() > 0 && !envEnabled("HYPRLAND_NO_SD_NOTIFY"))
-        Systemd::SdNotify(0, "STOPPING=1");
+    if (NSystemd::sdBooted() > 0 && !envEnabled("HYPRLAND_NO_SD_NOTIFY"))
+        NSystemd::sdNotify(0, "STOPPING=1");
 #endif
 
     cleanEnvironment();
@@ -713,10 +713,10 @@ void CCompositor::startCompositor() {
     g_pHyprRenderer->setCursorFromName("left_ptr");
 
 #ifdef USES_SYSTEMD
-    if (Systemd::SdBooted() > 0) {
+    if (NSystemd::sdBooted() > 0) {
         // tell systemd that we are ready so it can start other bond, following, related units
         if (!envEnabled("HYPRLAND_NO_SD_NOTIFY"))
-            Systemd::SdNotify(0, "READY=1");
+            NSystemd::sdNotify(0, "READY=1");
     } else
         Debug::log(LOG, "systemd integration is baked in but system itself is not booted à la systemd!");
 #endif
@@ -1366,7 +1366,7 @@ void CCompositor::changeWindowZOrder(PHLWINDOW pWindow, bool top) {
 
         x11Stack(pWindow, top, x11Stack);
 
-        for (auto it : toMove) {
+        for (const auto& it : toMove) {
             moveToZ(it, top);
         }
     }
@@ -2564,7 +2564,7 @@ Vector2D CCompositor::parseWindowVectorArgsRelative(const std::string& args, con
 }
 
 PHLWORKSPACE CCompositor::createNewWorkspace(const WORKSPACEID& id, const MONITORID& monid, const std::string& name, bool isEmpty) {
-    const auto NAME  = name == "" ? std::to_string(id) : name;
+    const auto NAME  = name.empty() ? std::to_string(id) : name;
     auto       monID = monid;
 
     // check if bound

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2236,29 +2236,29 @@ void CCompositor::updateFullscreenFadeOnWorkspace(PHLWORKSPACE pWorkspace) {
 
 void CCompositor::changeWindowFullscreenModeInternal(const PHLWINDOW PWINDOW, const eFullscreenMode MODE, const bool ON) {
     setWindowFullscreenInternal(
-        PWINDOW, (eFullscreenMode)(ON ? (uint8_t)PWINDOW->m_sFullscreenState.internal | (uint8_t)MODE : ((uint8_t)PWINDOW->m_sFullscreenState.internal & (uint8_t)~MODE)));
+        PWINDOW, (eFullscreenMode)(ON ? (uint8_t)PWINDOW->m_SFullscreenState.internal | (uint8_t)MODE : ((uint8_t)PWINDOW->m_SFullscreenState.internal & (uint8_t)~MODE)));
 }
 
 void CCompositor::changeWindowFullscreenModeClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE, const bool ON) {
     setWindowFullscreenClient(PWINDOW,
-                              (eFullscreenMode)(ON ? (uint8_t)PWINDOW->m_sFullscreenState.client | (uint8_t)MODE : ((uint8_t)PWINDOW->m_sFullscreenState.client & (uint8_t)~MODE)));
+                              (eFullscreenMode)(ON ? (uint8_t)PWINDOW->m_SFullscreenState.client | (uint8_t)MODE : ((uint8_t)PWINDOW->m_SFullscreenState.client & (uint8_t)~MODE)));
 }
 
 void CCompositor::setWindowFullscreenInternal(const PHLWINDOW PWINDOW, const eFullscreenMode MODE) {
     if (PWINDOW->m_sWindowData.syncFullscreen.valueOrDefault())
-        setWindowFullscreenState(PWINDOW, sFullscreenState{.internal = MODE, .client = MODE});
+        setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = MODE, .client = MODE});
     else
-        setWindowFullscreenState(PWINDOW, sFullscreenState{.internal = MODE, .client = PWINDOW->m_sFullscreenState.client});
+        setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = MODE, .client = PWINDOW->m_SFullscreenState.client});
 }
 
 void CCompositor::setWindowFullscreenClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE) {
     if (PWINDOW->m_sWindowData.syncFullscreen.valueOrDefault())
-        setWindowFullscreenState(PWINDOW, sFullscreenState{.internal = MODE, .client = MODE});
+        setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = MODE, .client = MODE});
     else
-        setWindowFullscreenState(PWINDOW, sFullscreenState{.internal = PWINDOW->m_sFullscreenState.internal, .client = MODE});
+        setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = PWINDOW->m_SFullscreenState.internal, .client = MODE});
 }
 
-void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, sFullscreenState state) {
+void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, SFullscreenState state) {
     static auto PDIRECTSCANOUT      = CConfigValue<Hyprlang::INT>("render:direct_scanout");
     static auto PALLOWPINFULLSCREEN = CConfigValue<Hyprlang::INT>("binds:allow_pin_fullscreen");
 
@@ -2271,7 +2271,7 @@ void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, sFullscreenS
     const auto            PMONITOR   = PWINDOW->m_pMonitor.lock();
     const auto            PWORKSPACE = PWINDOW->m_pWorkspace;
 
-    const eFullscreenMode CURRENT_EFFECTIVE_MODE = (eFullscreenMode)std::bit_floor((uint8_t)PWINDOW->m_sFullscreenState.internal);
+    const eFullscreenMode CURRENT_EFFECTIVE_MODE = (eFullscreenMode)std::bit_floor((uint8_t)PWINDOW->m_SFullscreenState.internal);
     const eFullscreenMode EFFECTIVE_MODE         = (eFullscreenMode)std::bit_floor((uint8_t)state.internal);
 
     if (*PALLOWPINFULLSCREEN && !PWINDOW->m_bPinFullscreened && !PWINDOW->isFullscreen() && PWINDOW->m_bPinned) {
@@ -2290,7 +2290,7 @@ void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, sFullscreenS
     if (!CHANGEINTERNAL && PWINDOW->m_sWindowData.syncFullscreen.valueOrDefault())
         return;
 
-    PWINDOW->m_sFullscreenState.client = state.client;
+    PWINDOW->m_SFullscreenState.client = state.client;
     g_pXWaylandManager->setWindowFullscreen(PWINDOW, state.client & FSMODE_FULLSCREEN);
 
     if (!CHANGEINTERNAL) {
@@ -2302,7 +2302,7 @@ void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, sFullscreenS
 
     g_pLayoutManager->getCurrentLayout()->fullscreenRequestForWindow(PWINDOW, CURRENT_EFFECTIVE_MODE, EFFECTIVE_MODE);
 
-    PWINDOW->m_sFullscreenState.internal = state.internal;
+    PWINDOW->m_SFullscreenState.internal = state.internal;
     PWORKSPACE->m_efFullscreenMode       = EFFECTIVE_MODE;
     PWORKSPACE->m_bHasFullscreenWindow   = EFFECTIVE_MODE != FSMODE_NONE;
 
@@ -2649,7 +2649,7 @@ void CCompositor::moveWindowToWorkspaceSafe(PHLWINDOW pWindow, PHLWORKSPACE pWor
         return;
 
     const bool FULLSCREEN     = pWindow->isFullscreen();
-    const auto FULLSCREENMODE = pWindow->m_sFullscreenState.internal;
+    const auto FULLSCREENMODE = pWindow->m_SFullscreenState.internal;
 
     if (FULLSCREEN)
         setWindowFullscreenInternal(pWindow, FSMODE_NONE);

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -35,7 +35,7 @@
 
 class CWLSurfaceResource;
 
-enum eManagersInitStage {
+enum eManagersInitStage : uint8_t {
     STAGE_PRIORITY = 0,
     STAGE_BASICINIT,
     STAGE_LATE

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -140,7 +140,7 @@ class CCompositor {
     bool                   workspaceIDOutOfBounds(const WORKSPACEID&);
     void                   setWindowFullscreenInternal(const PHLWINDOW PWINDOW, const eFullscreenMode MODE);
     void                   setWindowFullscreenClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE);
-    void                   setWindowFullscreenState(const PHLWINDOW PWINDOW, const sFullscreenState state);
+    void                   setWindowFullscreenState(const PHLWINDOW PWINDOW, const SFullscreenState state);
     void                   changeWindowFullscreenModeInternal(const PHLWINDOW PWINDOW, const eFullscreenMode MODE, const bool ON);
     void                   changeWindowFullscreenModeClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE, const bool ON);
     void                   updateFullscreenFadeOnWorkspace(PHLWORKSPACE);

--- a/src/SharedDefs.hpp
+++ b/src/SharedDefs.hpp
@@ -5,9 +5,7 @@
 #include <any>
 #include <hyprutils/math/Box.hpp>
 
-using namespace Hyprutils::Math;
-
-enum eIcons {
+enum eIcons : uint8_t {
     ICON_WARNING = 0,
     ICON_INFO,
     ICON_HINT,
@@ -17,7 +15,7 @@ enum eIcons {
     ICON_NONE
 };
 
-enum eRenderStage {
+enum eRenderStage : uint8_t {
     RENDER_PRE = 0,      /* Before binding the gl context */
     RENDER_BEGIN,        /* Just when the rendering begins, nothing has been rendered yet. Damage, current render data in opengl valid. */
     RENDER_PRE_WINDOWS,  /* Pre windows, post bottom and overlay layers */
@@ -29,7 +27,7 @@ enum eRenderStage {
     RENDER_POST_WINDOW,  /* After rendering a window (any pass) */
 };
 
-enum eInputType {
+enum eInputType : uint8_t {
     INPUT_TYPE_AXIS = 0,
     INPUT_TYPE_BUTTON,
     INPUT_TYPE_DRAG_START,
@@ -41,7 +39,7 @@ struct SCallbackInfo {
     bool cancelled = false; /* on cancellable events, will cancel the event. */
 };
 
-enum eHyprCtlOutputFormat {
+enum eHyprCtlOutputFormat : uint8_t {
     FORMAT_NORMAL = 0,
     FORMAT_JSON
 };

--- a/src/config/ConfigDataValues.hpp
+++ b/src/config/ConfigDataValues.hpp
@@ -3,7 +3,7 @@
 #include "../helpers/varlist/VarList.hpp"
 #include <vector>
 
-enum eConfigValueDataTypes {
+enum eConfigValueDataTypes : int8_t {
     CVD_TYPE_INVALID   = -1,
     CVD_TYPE_GRADIENT  = 0,
     CVD_TYPE_CSS_VALUE = 1
@@ -20,12 +20,12 @@ class ICustomConfigValueData {
 
 class CGradientValueData : public ICustomConfigValueData {
   public:
-    CGradientValueData() {};
+    CGradientValueData() = default;
     CGradientValueData(CHyprColor col) {
         m_vColors.push_back(col);
         updateColorsOk();
     };
-    virtual ~CGradientValueData() {};
+    virtual ~CGradientValueData() = default;
 
     virtual eConfigValueDataTypes getDataType() {
         return CVD_TYPE_GRADIENT;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -31,6 +31,7 @@
 #include <filesystem>
 using namespace Hyprutils::String;
 
+//NOLINTNEXTLINE
 extern "C" char** environ;
 
 #include "ConfigDescriptions.hpp"
@@ -71,7 +72,7 @@ static Hyprlang::CParseResult configHandleGradientSet(const char* VALUE, void** 
             const auto COL = configStringToInt(var);
             if (!COL)
                 throw std::runtime_error(std::format("failed to parse {} as a color", var));
-            DATA->m_vColors.push_back(CHyprColor(COL.value()));
+            DATA->m_vColors.emplace_back(COL.value());
         } catch (std::exception& e) {
             Debug::log(WARN, "Error parsing gradient {}", V);
             parseError = "Error parsing gradient " + V + ": " + e.what();
@@ -83,7 +84,7 @@ static Hyprlang::CParseResult configHandleGradientSet(const char* VALUE, void** 
         if (parseError.empty())
             parseError = "Error parsing gradient " + V + ": No colors?";
 
-        DATA->m_vColors.push_back(0); // transparent
+        DATA->m_vColors.emplace_back(0); // transparent
     }
 
     DATA->updateColorsOk();
@@ -737,7 +738,7 @@ const std::string CConfigManager::getConfigString() {
     std::string configString;
     std::string currFileContent;
 
-    for (auto path : configPaths) {
+    for (const auto& path : configPaths) {
         std::ifstream configFile(path);
         configString += ("\n\nConfig File: " + path + ": ");
         if (!configFile.is_open()) {
@@ -1101,7 +1102,7 @@ Vector2D CConfigManager::getDeviceVec(const std::string& dev, const std::string&
 }
 
 std::string CConfigManager::getDeviceString(const std::string& dev, const std::string& v, const std::string& fallback) {
-    const auto VAL = std::string{std::any_cast<Hyprlang::STRING>(getConfigValueSafeDevice(dev, v, fallback)->getValue())};
+    auto VAL = std::string{std::any_cast<Hyprlang::STRING>(getConfigValueSafeDevice(dev, v, fallback)->getValue())};
 
     if (VAL == STRVAL_EMPTY)
         return "";
@@ -1719,7 +1720,7 @@ void CConfigManager::handlePluginLoads() {
         std::stringstream error;
         error << "Failed to load the following plugins:";
 
-        for (auto path : failedPlugins) {
+        for (const auto& path : failedPlugins) {
             error << "\n" << path;
         }
 
@@ -2150,7 +2151,7 @@ std::optional<std::string> CConfigManager::handleAnimation(const std::string& co
         PANIM->second.internalStyle = ARGS[4];
 
         if (ARGS[4] != "") {
-            const auto ERR = g_pAnimationManager->styleValidInConfigVar(ANIMNAME, ARGS[4]);
+            auto ERR = g_pAnimationManager->styleValidInConfigVar(ANIMNAME, ARGS[4]);
 
             if (ERR != "")
                 return ERR;
@@ -2239,10 +2240,10 @@ std::optional<std::string> CConfigManager::handleBind(const std::string& command
     std::set<xkb_keysym_t> MODS;
 
     if (multiKey) {
-        for (auto splitKey : CVarList(ARGS[1], 8, '&')) {
+        for (const auto& splitKey : CVarList(ARGS[1], 8, '&')) {
             KEYSYMS.insert(xkb_keysym_from_name(splitKey.c_str(), XKB_KEYSYM_CASE_INSENSITIVE));
         }
-        for (auto splitMod : CVarList(ARGS[0], 8, '&')) {
+        for (const auto& splitMod : CVarList(ARGS[0], 8, '&')) {
             MODS.insert(xkb_keysym_from_name(splitMod.c_str(), XKB_KEYSYM_CASE_INSENSITIVE));
         }
     }
@@ -2688,8 +2689,8 @@ std::optional<std::string> CConfigManager::handleWorkspaceRules(const std::strin
                 return "Invalid workspace rule found: " + rule;
             }
 
-            std::string val = opt.substr(opt.find(":") + 1);
-            opt             = opt.substr(0, opt.find(":"));
+            std::string val = opt.substr(opt.find(':') + 1);
+            opt             = opt.substr(0, opt.find(':'));
 
             wsRule.layoutopts[opt] = val;
         }

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1,5 +1,6 @@
 #include "ConfigManager.hpp"
 #include "../managers/KeybindManager.hpp"
+#include "../Compositor.hpp"
 
 #include "../render/decorations/CHyprGroupBarDecoration.hpp"
 #include "config/ConfigDataValues.hpp"
@@ -12,7 +13,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <hyprutils/path/Path.hpp>
-#include <string.h>
+#include <cstring>
 #include <string>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1348,10 +1348,10 @@ std::vector<SWindowRule> CConfigManager::getMatchingRules(PHLWINDOW pWindow, boo
                     else
                         throw std::runtime_error("szFullscreenState client mode not valid");
 
-                    if (internalMode.has_value() && pWindow->m_SFullscreenState.internal != internalMode)
+                    if (internalMode.has_value() && pWindow->m_sFullscreenState.internal != internalMode)
                         continue;
 
-                    if (clientMode.has_value() && pWindow->m_SFullscreenState.client != clientMode)
+                    if (clientMode.has_value() && pWindow->m_sFullscreenState.client != clientMode)
                         continue;
                 }
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1347,10 +1347,10 @@ std::vector<SWindowRule> CConfigManager::getMatchingRules(PHLWINDOW pWindow, boo
                     else
                         throw std::runtime_error("szFullscreenState client mode not valid");
 
-                    if (internalMode.has_value() && pWindow->m_sFullscreenState.internal != internalMode)
+                    if (internalMode.has_value() && pWindow->m_SFullscreenState.internal != internalMode)
                         continue;
 
-                    if (clientMode.has_value() && pWindow->m_sFullscreenState.client != clientMode)
+                    if (clientMode.has_value() && pWindow->m_SFullscreenState.client != clientMode)
                         continue;
                 }
 

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -69,13 +69,13 @@ struct SAnimationPropertyConfig {
 };
 
 struct SPluginKeyword {
-    HANDLE                       handle = 0;
+    HANDLE                       handle = nullptr;
     std::string                  name   = "";
     Hyprlang::PCONFIGHANDLERFUNC fn     = nullptr;
 };
 
 struct SPluginVariable {
-    HANDLE      handle = 0;
+    HANDLE      handle = nullptr;
     std::string name   = "";
 };
 
@@ -84,7 +84,7 @@ struct SExecRequestedRule {
     uint64_t    iPid   = 0;
 };
 
-enum eConfigOptionType : uint16_t {
+enum eConfigOptionType : uint8_t {
     CONFIG_OPTION_BOOL         = 0,
     CONFIG_OPTION_INT          = 1, /* e.g. 0/1/2*/
     CONFIG_OPTION_FLOAT        = 2,
@@ -96,7 +96,7 @@ enum eConfigOptionType : uint16_t {
     CONFIG_OPTION_VECTOR       = 8,
 };
 
-enum eConfigOptionFlags : uint32_t {
+enum eConfigOptionFlags : uint8_t {
     CONFIG_OPTION_FLAG_PERCENTAGE = (1 << 0),
 };
 
@@ -214,52 +214,54 @@ class CConfigManager {
     std::string               getErrors();
 
     // keywords
-    std::optional<std::string>                                                              handleRawExec(const std::string&, const std::string&);
-    std::optional<std::string>                                                              handleExecOnce(const std::string&, const std::string&);
-    std::optional<std::string>                                                              handleExecShutdown(const std::string&, const std::string&);
-    std::optional<std::string>                                                              handleMonitor(const std::string&, const std::string&);
-    std::optional<std::string>                                                              handleBind(const std::string&, const std::string&);
-    std::optional<std::string>                                                              handleUnbind(const std::string&, const std::string&);
-    std::optional<std::string>                                                              handleWindowRule(const std::string&, const std::string&);
-    std::optional<std::string>                                                              handleLayerRule(const std::string&, const std::string&);
-    std::optional<std::string>                                                              handleWindowRuleV2(const std::string&, const std::string&);
-    std::optional<std::string>                                                              handleWorkspaceRules(const std::string&, const std::string&);
-    std::optional<std::string>                                                              handleBezier(const std::string&, const std::string&);
-    std::optional<std::string>                                                              handleAnimation(const std::string&, const std::string&);
-    std::optional<std::string>                                                              handleSource(const std::string&, const std::string&);
-    std::optional<std::string>                                                              handleSubmap(const std::string&, const std::string&);
-    std::optional<std::string>                                                              handleBlurLS(const std::string&, const std::string&);
-    std::optional<std::string>                                                              handleBindWS(const std::string&, const std::string&);
-    std::optional<std::string>                                                              handleEnv(const std::string&, const std::string&);
-    std::optional<std::string>                                                              handlePlugin(const std::string&, const std::string&);
+    std::optional<std::string>                                                                     handleRawExec(const std::string&, const std::string&);
+    std::optional<std::string>                                                                     handleExecOnce(const std::string&, const std::string&);
+    std::optional<std::string>                                                                     handleExecShutdown(const std::string&, const std::string&);
+    std::optional<std::string>                                                                     handleMonitor(const std::string&, const std::string&);
+    std::optional<std::string>                                                                     handleBind(const std::string&, const std::string&);
+    std::optional<std::string>                                                                     handleUnbind(const std::string&, const std::string&);
+    std::optional<std::string>                                                                     handleWindowRule(const std::string&, const std::string&);
+    std::optional<std::string>                                                                     handleLayerRule(const std::string&, const std::string&);
+    std::optional<std::string>                                                                     handleWindowRuleV2(const std::string&, const std::string&);
+    std::optional<std::string>                                                                     handleWorkspaceRules(const std::string&, const std::string&);
+    std::optional<std::string>                                                                     handleBezier(const std::string&, const std::string&);
+    std::optional<std::string>                                                                     handleAnimation(const std::string&, const std::string&);
+    std::optional<std::string>                                                                     handleSource(const std::string&, const std::string&);
+    std::optional<std::string>                                                                     handleSubmap(const std::string&, const std::string&);
+    std::optional<std::string>                                                                     handleBlurLS(const std::string&, const std::string&);
+    std::optional<std::string>                                                                     handleBindWS(const std::string&, const std::string&);
+    std::optional<std::string>                                                                     handleEnv(const std::string&, const std::string&);
+    std::optional<std::string>                                                                     handlePlugin(const std::string&, const std::string&);
 
-    std::string                                                                             configCurrentPath;
+    std::string                                                                                    configCurrentPath;
 
-    std::unordered_map<std::string, std::function<CWindowOverridableVar<bool>*(PHLWINDOW)>> mbWindowProperties = {
-        {"allowsinput", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.allowsInput; }},
-        {"dimaround", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.dimAround; }},
-        {"decorate", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.decorate; }},
-        {"focusonactivate", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.focusOnActivate; }},
-        {"keepaspectratio", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.keepAspectRatio; }},
-        {"nearestneighbor", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.nearestNeighbor; }},
-        {"noanim", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noAnim; }},
-        {"noblur", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noBlur; }},
-        {"noborder", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noBorder; }},
-        {"nodim", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noDim; }},
-        {"nofocus", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noFocus; }},
-        {"nomaxsize", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noMaxSize; }},
-        {"norounding", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noRounding; }},
-        {"noshadow", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noShadow; }},
-        {"noshortcutsinhibit", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.noShortcutsInhibit; }},
-        {"opaque", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.opaque; }},
-        {"forcergbx", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.RGBX; }},
-        {"syncfullscreen", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.syncFullscreen; }},
-        {"immediate", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.tearing; }},
-        {"xray", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.xray; }},
+    std::unordered_map<std::string, std::function<CWindowOverridableVar<bool>*(const PHLWINDOW&)>> mbWindowProperties = {
+        {"allowsinput", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.allowsInput; }},
+        {"dimaround", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.dimAround; }},
+        {"decorate", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.decorate; }},
+        {"focusonactivate", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.focusOnActivate; }},
+        {"keepaspectratio", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.keepAspectRatio; }},
+        {"nearestneighbor", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.nearestNeighbor; }},
+        {"noanim", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.noAnim; }},
+        {"noblur", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.noBlur; }},
+        {"noborder", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.noBorder; }},
+        {"nodim", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.noDim; }},
+        {"nofocus", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.noFocus; }},
+        {"nomaxsize", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.noMaxSize; }},
+        {"norounding", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.noRounding; }},
+        {"noshadow", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.noShadow; }},
+        {"noshortcutsinhibit", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.noShortcutsInhibit; }},
+        {"opaque", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.opaque; }},
+        {"forcergbx", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.RGBX; }},
+        {"syncfullscreen", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.syncFullscreen; }},
+        {"immediate", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.tearing; }},
+        {"xray", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.xray; }},
     };
 
-    std::unordered_map<std::string, std::function<CWindowOverridableVar<int>*(PHLWINDOW)>> miWindowProperties = {
-        {"rounding", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.rounding; }}, {"bordersize", [](PHLWINDOW pWindow) { return &pWindow->m_sWindowData.borderSize; }}};
+    std::unordered_map<std::string, std::function<CWindowOverridableVar<int>*(const PHLWINDOW&)>> miWindowProperties = {
+        {"rounding", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.rounding; }},
+        {"bordersize", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.borderSize; }},
+    };
 
     bool m_bWantsMonitorReload = false;
     bool m_bForceReload        = false;

--- a/src/config/ConfigValue.hpp
+++ b/src/config/ConfigValue.hpp
@@ -13,6 +13,7 @@ class CConfigValue {
     CConfigValue(const std::string& val) {
         const auto PVHYPRLANG = g_pConfigManager->getHyprlangConfigValuePtr(val);
 
+        // NOLINTNEXTLINE
         p_ = PVHYPRLANG->getDataStaticPtr();
 
 #ifdef HYPRLAND_DEBUG

--- a/src/debug/CrashReporter.cpp
+++ b/src/debug/CrashReporter.cpp
@@ -2,8 +2,8 @@
 #include <fcntl.h>
 #include <sys/utsname.h>
 #include <link.h>
-#include <time.h>
-#include <errno.h>
+#include <ctime>
+#include <cerrno>
 #include <sys/stat.h>
 #include <filesystem>
 
@@ -31,10 +31,10 @@ static char const* const MESSAGES[] = {"Sorry, didn't mean to...",
 
 // <random> is not async-signal-safe, fake it with time(NULL) instead
 char const* getRandomMessage() {
-    return MESSAGES[time(NULL) % (sizeof(MESSAGES) / sizeof(MESSAGES[0]))];
+    return MESSAGES[time(nullptr) % (sizeof(MESSAGES) / sizeof(MESSAGES[0]))];
 }
 
-[[noreturn]] inline void exit_with_error(char const* err) {
+[[noreturn]] inline void exitWithError(char const* err) {
     write(STDERR_FILENO, err, strlen(err));
     // perror() is not signal-safe, but we use it here
     // because if the crash-handler already crashed, it can't get any worse.
@@ -42,17 +42,17 @@ char const* getRandomMessage() {
     abort();
 }
 
-void CrashReporter::createAndSaveCrash(int sig) {
-    int reportFd;
+void NCrashReporter::createAndSaveCrash(int sig) {
+    int reportFd = -1;
 
     // We're in the signal handler, so we *only* have stack memory.
     // To save as much stack memory as possible,
     // destroy things as soon as possible.
     {
-        MaxLengthCString<255> reportPath;
+        CMaxLengthCString<255> reportPath;
 
-        const auto            HOME       = sig_getenv("HOME");
-        const auto            CACHE_HOME = sig_getenv("XDG_CACHE_HOME");
+        const auto             HOME       = sigGetenv("HOME");
+        const auto             CACHE_HOME = sigGetenv("XDG_CACHE_HOME");
 
         if (CACHE_HOME && CACHE_HOME[0] != '\0') {
             reportPath += CACHE_HOME;
@@ -61,24 +61,24 @@ void CrashReporter::createAndSaveCrash(int sig) {
             reportPath += HOME;
             reportPath += "/.cache/hyprland";
         } else {
-            exit_with_error("$CACHE_HOME and $HOME not set, nowhere to report crash\n");
+            exitWithError("$CACHE_HOME and $HOME not set, nowhere to report crash\n");
             return;
         }
 
-        int ret = mkdir(reportPath.get_str(), S_IRWXU);
+        int ret = mkdir(reportPath.getStr(), S_IRWXU);
         //__asm__("int $3");
         if (ret < 0 && errno != EEXIST) {
-            exit_with_error("failed to mkdir() crash report directory\n");
+            exitWithError("failed to mkdir() crash report directory\n");
         }
         reportPath += "/hyprlandCrashReport";
-        reportPath.write_num(getpid());
+        reportPath.writeNum(getpid());
         reportPath += ".txt";
 
         {
-            BufFileWriter<64> stderr(2);
+            CBufFileWriter<64> stderr(2);
             stderr += "Hyprland has crashed :( Consult the crash report at ";
             if (!reportPath.boundsExceeded()) {
-                stderr += reportPath.get_str();
+                stderr += reportPath.getStr();
             } else {
                 stderr += "[ERROR: Crash report path does not fit into memory! Check if your $CACHE_HOME/$HOME is too deeply nested. Max 255 characters.]";
             }
@@ -86,12 +86,12 @@ void CrashReporter::createAndSaveCrash(int sig) {
             stderr.flush();
         }
 
-        reportFd = open(reportPath.get_str(), O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
+        reportFd = open(reportPath.getStr(), O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);
         if (reportFd < 0) {
-            exit_with_error("Failed to open crash report path for writing");
+            exitWithError("Failed to open crash report path for writing");
         }
     }
-    BufFileWriter<512> finalCrashReport(reportFd);
+    CBufFileWriter<512> finalCrashReport(reportFd);
 
     finalCrashReport += "--------------------------------------------\n   Hyprland Crash Report\n--------------------------------------------\n";
     finalCrashReport += getRandomMessage();
@@ -100,7 +100,7 @@ void CrashReporter::createAndSaveCrash(int sig) {
     finalCrashReport += "Hyprland received signal ";
     finalCrashReport.writeNum(sig);
     finalCrashReport += '(';
-    finalCrashReport += sig_strsignal(sig);
+    finalCrashReport += sigStrsignal(sig);
     finalCrashReport += ")\nVersion: ";
     finalCrashReport += GIT_COMMIT_HASH;
     finalCrashReport += "\nTag: ";
@@ -122,9 +122,9 @@ void CrashReporter::createAndSaveCrash(int sig) {
     if (g_pPluginSystem && g_pPluginSystem->pluginCount() > 0) {
         finalCrashReport += "Hyprland seems to be running with plugins. This crash might not be Hyprland's fault.\nPlugins:\n";
 
-        size_t   count = g_pPluginSystem->pluginCount();
-        CPlugin* plugins[count];
-        g_pPluginSystem->sig_getPlugins(plugins, count);
+        size_t   count          = g_pPluginSystem->pluginCount();
+        CPlugin* plugins[count] = {nullptr};
+        g_pPluginSystem->sigGetPlugins(plugins, count);
 
         for (size_t i = 0; i < count; i++) {
             auto p = plugins[i];
@@ -241,5 +241,5 @@ void CrashReporter::createAndSaveCrash(int sig) {
 
     finalCrashReport += "\n\nLog tail:\n";
 
-    finalCrashReport += std::string_view(Debug::rollingLog).substr(Debug::rollingLog.find("\n") + 1);
+    finalCrashReport += std::string_view(Debug::rollingLog).substr(Debug::rollingLog.find('\n') + 1);
 }

--- a/src/debug/CrashReporter.hpp
+++ b/src/debug/CrashReporter.hpp
@@ -2,6 +2,6 @@
 
 #include "../defines.hpp"
 
-namespace CrashReporter {
+namespace NCrashReporter {
     void createAndSaveCrash(int sig);
 };

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -252,7 +252,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             escapeJSONStrings(!w->m_pWorkspace ? "" : w->m_pWorkspace->m_szName), ((int)w->m_bIsFloating == 1 ? "true" : "false"), (w->m_bIsPseudotiled ? "true" : "false"),
             (int64_t)w->monitorID(), escapeJSONStrings(w->m_szClass), escapeJSONStrings(w->m_szTitle), escapeJSONStrings(w->m_szInitialClass),
             escapeJSONStrings(w->m_szInitialTitle), w->getPID(), ((int)w->m_bIsX11 == 1 ? "true" : "false"), (w->m_bPinned ? "true" : "false"),
-            (uint8_t)w->m_sFullscreenState.internal, (uint8_t)w->m_sFullscreenState.client, getGroupedData(w, format), getTagsData(w, format),
+            (uint8_t)w->m_SFullscreenState.internal, (uint8_t)w->m_SFullscreenState.client, getGroupedData(w, format), getTagsData(w, format),
             (uintptr_t)w->m_pSwallowed.lock().get(), getFocusHistoryID(w));
     } else {
         return std::format(
@@ -263,7 +263,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             (uintptr_t)w.get(), w->m_szTitle, (int)w->m_bIsMapped, (int)w->isHidden(), (int)w->m_vRealPosition.goal().x, (int)w->m_vRealPosition.goal().y,
             (int)w->m_vRealSize.goal().x, (int)w->m_vRealSize.goal().y, w->m_pWorkspace ? w->workspaceID() : WORKSPACE_INVALID, (!w->m_pWorkspace ? "" : w->m_pWorkspace->m_szName),
             (int)w->m_bIsFloating, (int)w->m_bIsPseudotiled, (int64_t)w->monitorID(), w->m_szClass, w->m_szTitle, w->m_szInitialClass, w->m_szInitialTitle, w->getPID(),
-            (int)w->m_bIsX11, (int)w->m_bPinned, (uint8_t)w->m_sFullscreenState.internal, (uint8_t)w->m_sFullscreenState.client, getGroupedData(w, format), getTagsData(w, format),
+            (int)w->m_bIsX11, (int)w->m_bPinned, (uint8_t)w->m_SFullscreenState.internal, (uint8_t)w->m_SFullscreenState.client, getGroupedData(w, format), getTagsData(w, format),
             (uintptr_t)w->m_pSwallowed.lock().get(), getFocusHistoryID(w));
     }
 }

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -5,9 +5,9 @@
 #include <fstream>
 #include <iterator>
 #include <netinet/in.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -537,7 +537,7 @@ std::string configErrorsRequest(eHyprCtlOutputFormat format, std::string request
     CVarList    errLines(currErrors, 0, '\n');
     if (format == eHyprCtlOutputFormat::FORMAT_JSON) {
         result += "[";
-        for (auto line : errLines) {
+        for (const auto& line : errLines) {
             result += std::format(
                 R"#(
 	"{}",)#",
@@ -547,7 +547,7 @@ std::string configErrorsRequest(eHyprCtlOutputFormat format, std::string request
         trimTrailingComma(result);
         result += "\n]\n";
     } else {
-        for (auto line : errLines) {
+        for (const auto& line : errLines) {
             result += std::format("{}\n", line);
         }
     }
@@ -1355,17 +1355,16 @@ std::string dispatchGetOption(eHyprCtlOutputFormat format, std::string request) 
             return std::format("custom type: {}\nset: {}", ((ICustomConfigValueData*)std::any_cast<void*>(VAL))->toString(), VAR->m_bSetByUser);
     } else {
         if (TYPE == typeid(Hyprlang::INT))
-            return std::format("{{\"option\": \"{}\", \"int\": {}, \"set\": {} }}", curitem, std::any_cast<Hyprlang::INT>(VAL), VAR->m_bSetByUser);
+            return std::format(R"({{"option": "{}", "int": {}, "set": {} }})", curitem, std::any_cast<Hyprlang::INT>(VAL), VAR->m_bSetByUser);
         else if (TYPE == typeid(Hyprlang::FLOAT))
-            return std::format("{{\"option\": \"{}\", \"float\": {:2f}, \"set\": {} }}", curitem, std::any_cast<Hyprlang::FLOAT>(VAL), VAR->m_bSetByUser);
+            return std::format(R"({{"option": "{}", "float": {:2f}, "set": {} }})", curitem, std::any_cast<Hyprlang::FLOAT>(VAL), VAR->m_bSetByUser);
         else if (TYPE == typeid(Hyprlang::VEC2))
-            return std::format("{{\"option\": \"{}\", \"vec2\": [{},{}], \"set\": {} }}", curitem, std::any_cast<Hyprlang::VEC2>(VAL).x, std::any_cast<Hyprlang::VEC2>(VAL).y,
+            return std::format(R"({{"option": "{}", "vec2": [{},{}], "set": {} }})", curitem, std::any_cast<Hyprlang::VEC2>(VAL).x, std::any_cast<Hyprlang::VEC2>(VAL).y,
                                VAR->m_bSetByUser);
         else if (TYPE == typeid(Hyprlang::STRING))
-            return std::format("{{\"option\": \"{}\", \"str\": \"{}\", \"set\": {} }}", curitem, escapeJSONStrings(std::any_cast<Hyprlang::STRING>(VAL)), VAR->m_bSetByUser);
+            return std::format(R"({{"option": "{}", "str": "{}", "set": {} }})", curitem, escapeJSONStrings(std::any_cast<Hyprlang::STRING>(VAL)), VAR->m_bSetByUser);
         else if (TYPE == typeid(void*))
-            return std::format("{{\"option\": \"{}\", \"custom\": \"{}\", \"set\": {} }}", curitem, ((ICustomConfigValueData*)std::any_cast<void*>(VAL))->toString(),
-                               VAR->m_bSetByUser);
+            return std::format(R"({{"option": "{}", "custom": "{}", "set": {} }})", curitem, ((ICustomConfigValueData*)std::any_cast<void*>(VAL))->toString(), VAR->m_bSetByUser);
     }
 
     return "invalid type (internal error)";

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1810,13 +1810,13 @@ void runWritingDebugLogThread(const int conn) {
     Debug::log(LOG, "In followlog thread, got connection, start writing: {}", conn);
     //will be finished, when reading side close connection
     std::thread([conn]() {
-        while (Debug::RollingLogFollow::Get().IsRunning()) {
-            if (Debug::RollingLogFollow::Get().isEmpty(conn)) {
+        while (Debug::SRollingLogFollow::get().isRunning()) {
+            if (Debug::SRollingLogFollow::get().isEmpty(conn)) {
                 std::this_thread::sleep_for(1000ms);
                 continue;
             }
 
-            auto line = Debug::RollingLogFollow::Get().GetLog(conn);
+            auto line = Debug::SRollingLogFollow::get().getLog(conn);
             if (!successWrite(conn, line))
                 // We cannot write, when connection is closed. So thread will successfully exit by itself
                 break;
@@ -1824,7 +1824,7 @@ void runWritingDebugLogThread(const int conn) {
             std::this_thread::sleep_for(100ms);
         }
         close(conn);
-        Debug::RollingLogFollow::Get().StopFor(conn);
+        Debug::SRollingLogFollow::get().stopFor(conn);
     }).detach();
 }
 
@@ -1883,9 +1883,9 @@ int hyprCtlFDTick(int fd, uint32_t mask, void* data) {
 
     if (isFollowUpRollingLogRequest(request)) {
         Debug::log(LOG, "Followup rollinglog request received. Starting thread to write to socket.");
-        Debug::RollingLogFollow::Get().StartFor(ACCEPTEDCONNECTION);
+        Debug::SRollingLogFollow::get().startFor(ACCEPTEDCONNECTION);
         runWritingDebugLogThread(ACCEPTEDCONNECTION);
-        Debug::log(LOG, Debug::RollingLogFollow::Get().DebugInfo());
+        Debug::log(LOG, Debug::SRollingLogFollow::get().debugInfo());
     } else
         close(ACCEPTEDCONNECTION);
 

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -252,7 +252,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             escapeJSONStrings(!w->m_pWorkspace ? "" : w->m_pWorkspace->m_szName), ((int)w->m_bIsFloating == 1 ? "true" : "false"), (w->m_bIsPseudotiled ? "true" : "false"),
             (int64_t)w->monitorID(), escapeJSONStrings(w->m_szClass), escapeJSONStrings(w->m_szTitle), escapeJSONStrings(w->m_szInitialClass),
             escapeJSONStrings(w->m_szInitialTitle), w->getPID(), ((int)w->m_bIsX11 == 1 ? "true" : "false"), (w->m_bPinned ? "true" : "false"),
-            (uint8_t)w->m_SFullscreenState.internal, (uint8_t)w->m_SFullscreenState.client, getGroupedData(w, format), getTagsData(w, format),
+            (uint8_t)w->m_sFullscreenState.internal, (uint8_t)w->m_sFullscreenState.client, getGroupedData(w, format), getTagsData(w, format),
             (uintptr_t)w->m_pSwallowed.lock().get(), getFocusHistoryID(w));
     } else {
         return std::format(
@@ -263,7 +263,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             (uintptr_t)w.get(), w->m_szTitle, (int)w->m_bIsMapped, (int)w->isHidden(), (int)w->m_vRealPosition.goal().x, (int)w->m_vRealPosition.goal().y,
             (int)w->m_vRealSize.goal().x, (int)w->m_vRealSize.goal().y, w->m_pWorkspace ? w->workspaceID() : WORKSPACE_INVALID, (!w->m_pWorkspace ? "" : w->m_pWorkspace->m_szName),
             (int)w->m_bIsFloating, (int)w->m_bIsPseudotiled, (int64_t)w->monitorID(), w->m_szClass, w->m_szTitle, w->m_szInitialClass, w->m_szInitialTitle, w->getPID(),
-            (int)w->m_bIsX11, (int)w->m_bPinned, (uint8_t)w->m_SFullscreenState.internal, (uint8_t)w->m_SFullscreenState.client, getGroupedData(w, format), getTagsData(w, format),
+            (int)w->m_bIsX11, (int)w->m_bPinned, (uint8_t)w->m_sFullscreenState.internal, (uint8_t)w->m_sFullscreenState.client, getGroupedData(w, format), getTagsData(w, format),
             (uintptr_t)w->m_pSwallowed.lock().get(), getFocusHistoryID(w));
     }
 }

--- a/src/debug/HyprNotificationOverlay.hpp
+++ b/src/debug/HyprNotificationOverlay.hpp
@@ -10,7 +10,7 @@
 
 #include <cairo/cairo.h>
 
-enum eIconBackend {
+enum eIconBackend : uint8_t {
     ICONS_BACKEND_NONE = 0,
     ICONS_BACKEND_NF,
     ICONS_BACKEND_FA

--- a/src/debug/Log.cpp
+++ b/src/debug/Log.cpp
@@ -18,7 +18,7 @@ void Debug::close() {
     logOfs.close();
 }
 
-void Debug::log(LogLevel level, std::string str) {
+void Debug::log(eLogLevel level, std::string str) {
     if (level == TRACE && !trace)
         return;
 
@@ -26,6 +26,7 @@ void Debug::log(LogLevel level, std::string str) {
         return;
 
     std::string coloredStr = str;
+    //NOLINTBEGIN
     switch (level) {
         case LOG:
             str        = "[LOG] " + str;
@@ -53,13 +54,14 @@ void Debug::log(LogLevel level, std::string str) {
             break;
         default: break;
     }
+    //NOLINTEND
 
     rollingLog += str + "\n";
     if (rollingLog.size() > ROLLING_LOG_SIZE)
         rollingLog = rollingLog.substr(rollingLog.size() - ROLLING_LOG_SIZE);
 
-    if (RollingLogFollow::Get().IsRunning())
-        RollingLogFollow::Get().AddLog(str);
+    if (SRollingLogFollow::get().isRunning())
+        SRollingLogFollow::get().addLog(str);
 
     if (!disableLogs || !**disableLogs) {
         // log to a file

--- a/src/debug/Log.hpp
+++ b/src/debug/Log.hpp
@@ -11,7 +11,7 @@
 #define LOGMESSAGESIZE   1024
 #define ROLLING_LOG_SIZE 4096
 
-enum LogLevel {
+enum eLogLevel : int8_t {
     NONE = -1,
     LOG  = 0,
     WARN,
@@ -39,10 +39,11 @@ namespace Debug {
     void                   close();
 
     //
-    void log(LogLevel level, std::string str);
+    void log(eLogLevel level, std::string str);
 
     template <typename... Args>
-    void log(LogLevel level, std::format_string<Args...> fmt, Args&&... args) {
+    //NOLINTNEXTLINE
+    void log(eLogLevel level, std::format_string<Args...> fmt, Args&&... args) {
         std::lock_guard<std::mutex> guard(logMutex);
 
         if (level == TRACE && !trace)

--- a/src/debug/Log.hpp
+++ b/src/debug/Log.hpp
@@ -21,6 +21,7 @@ enum LogLevel {
     TRACE
 };
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 namespace Debug {
     inline std::string     logFile;
     inline std::ofstream   logOfs;

--- a/src/debug/RollingLogFollow.hpp
+++ b/src/debug/RollingLogFollow.hpp
@@ -2,8 +2,9 @@
 
 #include <shared_mutex>
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 namespace Debug {
-    struct RollingLogFollow {
+    struct SRollingLogFollow {
         std::unordered_map<int, std::string> socketToRollingLogFollowQueue;
         std::shared_mutex                    m;
         bool                                 running                    = false;
@@ -15,12 +16,12 @@ namespace Debug {
             return socketToRollingLogFollowQueue[socket].empty();
         }
 
-        std::string DebugInfo() {
+        std::string debugInfo() {
             std::shared_lock<std::shared_mutex> r(m);
             return std::format("RollingLogFollow, got {} connections", socketToRollingLogFollowQueue.size());
         }
 
-        std::string GetLog(int socket) {
+        std::string getLog(int socket) {
             std::unique_lock<std::shared_mutex> w(m);
 
             const std::string                   ret = socketToRollingLogFollowQueue[socket];
@@ -29,7 +30,7 @@ namespace Debug {
             return ret;
         };
 
-        void AddLog(std::string log) {
+        void addLog(const std::string& log) {
             std::unique_lock<std::shared_mutex> w(m);
             running = true;
             std::vector<int> to_erase;
@@ -37,26 +38,26 @@ namespace Debug {
                 socketToRollingLogFollowQueue[p.first] += log + "\n";
         }
 
-        bool IsRunning() {
+        bool isRunning() {
             std::shared_lock<std::shared_mutex> r(m);
             return running;
         }
 
-        void StopFor(int socket) {
+        void stopFor(int socket) {
             std::unique_lock<std::shared_mutex> w(m);
             socketToRollingLogFollowQueue.erase(socket);
             if (socketToRollingLogFollowQueue.empty())
                 running = false;
         }
 
-        void StartFor(int socket) {
+        void startFor(int socket) {
             std::unique_lock<std::shared_mutex> w(m);
             socketToRollingLogFollowQueue[socket] = std::format("[LOG] Following log to socket: {} started\n", socket);
             running                               = true;
         }
 
-        static RollingLogFollow& Get() {
-            static RollingLogFollow     instance;
+        static SRollingLogFollow& get() {
+            static SRollingLogFollow    instance;
             static std::mutex           gm;
             std::lock_guard<std::mutex> lock(gm);
             return instance;

--- a/src/desktop/Popup.cpp
+++ b/src/desktop/Popup.cpp
@@ -16,12 +16,9 @@ CPopup::CPopup(PHLLS pOwner) : m_pLayerOwner(pOwner) {
     initAllSignals();
 }
 
-CPopup::CPopup(SP<CXDGPopupResource> popup, CPopup* pOwner) : m_pParent(pOwner), m_pResource(popup) {
+CPopup::CPopup(SP<CXDGPopupResource> popup, CPopup* pOwner) : m_pWindowOwner(pOwner->m_pWindowOwner), m_pLayerOwner(pOwner->m_pLayerOwner), m_pParent(pOwner), m_pResource(popup) {
     m_pWLSurface = CWLSurface::create();
     m_pWLSurface->assign(popup->surface->surface.lock(), this);
-
-    m_pLayerOwner  = pOwner->m_pLayerOwner;
-    m_pWindowOwner = pOwner->m_pWindowOwner;
 
     m_vLastSize = popup->surface->current.geometry.size();
     reposition();

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1001,7 +1001,7 @@ void CWindow::setGroupCurrent(PHLWINDOW pWindow) {
     const auto PCURRENT   = getGroupCurrent();
     const bool FULLSCREEN = PCURRENT->isFullscreen();
     const auto WORKSPACE  = PCURRENT->m_pWorkspace;
-    const auto MODE       = PCURRENT->m_SFullscreenState.internal;
+    const auto MODE       = PCURRENT->m_sFullscreenState.internal;
 
     const auto PWINDOWSIZE = PCURRENT->m_vRealSize.goal();
     const auto PWINDOWPOS  = PCURRENT->m_vRealPosition.goal();
@@ -1274,11 +1274,11 @@ void CWindow::clampWindowSize(const std::optional<Vector2D> minSize, const std::
 }
 
 bool CWindow::isFullscreen() {
-    return m_SFullscreenState.internal != FSMODE_NONE;
+    return m_sFullscreenState.internal != FSMODE_NONE;
 }
 
 bool CWindow::isEffectiveInternalFSMode(const eFullscreenMode MODE) {
-    return (eFullscreenMode)std::bit_floor((uint8_t)m_SFullscreenState.internal) == MODE;
+    return (eFullscreenMode)std::bit_floor((uint8_t)m_sFullscreenState.internal) == MODE;
 }
 
 WORKSPACEID CWindow::workspaceID() {

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -443,7 +443,7 @@ void CWindow::moveToWorkspace(PHLWORKSPACE pWorkspace) {
     }
 }
 
-PHLWINDOW CWindow::X11TransientFor() {
+PHLWINDOW CWindow::x11TransientFor() {
     if (!m_pXWaylandSurface || !m_pXWaylandSurface->parent)
         return nullptr;
 

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1001,7 +1001,7 @@ void CWindow::setGroupCurrent(PHLWINDOW pWindow) {
     const auto PCURRENT   = getGroupCurrent();
     const bool FULLSCREEN = PCURRENT->isFullscreen();
     const auto WORKSPACE  = PCURRENT->m_pWorkspace;
-    const auto MODE       = PCURRENT->m_sFullscreenState.internal;
+    const auto MODE       = PCURRENT->m_SFullscreenState.internal;
 
     const auto PWINDOWSIZE = PCURRENT->m_vRealSize.goal();
     const auto PWINDOWPOS  = PCURRENT->m_vRealPosition.goal();
@@ -1274,11 +1274,11 @@ void CWindow::clampWindowSize(const std::optional<Vector2D> minSize, const std::
 }
 
 bool CWindow::isFullscreen() {
-    return m_sFullscreenState.internal != FSMODE_NONE;
+    return m_SFullscreenState.internal != FSMODE_NONE;
 }
 
 bool CWindow::isEffectiveInternalFSMode(const eFullscreenMode MODE) {
-    return (eFullscreenMode)std::bit_floor((uint8_t)m_sFullscreenState.internal) == MODE;
+    return (eFullscreenMode)std::bit_floor((uint8_t)m_SFullscreenState.internal) == MODE;
 }
 
 WORKSPACEID CWindow::workspaceID() {

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -219,7 +219,7 @@ struct SInitialWorkspaceToken {
     std::string  workspace;
 };
 
-struct sFullscreenState {
+struct SFullscreenState {
     eFullscreenMode internal = FSMODE_NONE;
     eFullscreenMode client   = FSMODE_NONE;
 };
@@ -278,7 +278,7 @@ class CWindow {
     bool             m_bIsFloating      = false;
     bool             m_bDraggingTiled   = false; // for dragging around tiled windows
     bool             m_bWasMaximized    = false;
-    sFullscreenState m_sFullscreenState = {.internal = FSMODE_NONE, .client = FSMODE_NONE};
+    SFullscreenState m_SFullscreenState = {.internal = FSMODE_NONE, .client = FSMODE_NONE};
     std::string      m_szTitle          = "";
     std::string      m_szClass          = "";
     std::string      m_szInitialTitle   = "";

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -276,7 +276,7 @@ class CWindow {
     bool             m_bIsFloating      = false;
     bool             m_bDraggingTiled   = false; // for dragging around tiled windows
     bool             m_bWasMaximized    = false;
-    SFullscreenState m_SFullscreenState = {.internal = FSMODE_NONE, .client = FSMODE_NONE};
+    SFullscreenState m_sFullscreenState = {.internal = FSMODE_NONE, .client = FSMODE_NONE};
     std::string      m_szTitle          = "";
     std::string      m_szClass          = "";
     std::string      m_szInitialTitle   = "";

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -21,14 +21,14 @@
 class CXDGSurfaceResource;
 class CXWaylandSurface;
 
-enum eIdleInhibitMode {
+enum eIdleInhibitMode : uint8_t {
     IDLEINHIBIT_NONE = 0,
     IDLEINHIBIT_ALWAYS,
     IDLEINHIBIT_FULLSCREEN,
     IDLEINHIBIT_FOCUS
 };
 
-enum eGroupRules {
+enum eGroupRules : uint8_t {
     // effective only during first map, except for _ALWAYS variant
     GROUP_NONE        = 0,
     GROUP_SET         = 1 << 0, // Open as new group or add to focused group
@@ -40,7 +40,7 @@ enum eGroupRules {
     GROUP_OVERRIDE    = 1 << 6, // Override other rules
 };
 
-enum eGetWindowProperties {
+enum eGetWindowProperties : uint8_t {
     WINDOW_ONLY      = 0,
     RESERVED_EXTENTS = 1 << 0,
     INPUT_EXTENTS    = 1 << 1,
@@ -50,7 +50,7 @@ enum eGetWindowProperties {
     USE_PROP_TILED   = 1 << 5,
 };
 
-enum eSuppressEvents {
+enum eSuppressEvents : uint8_t {
     SUPPRESS_NONE               = 0,
     SUPPRESS_FULLSCREEN         = 1 << 0,
     SUPPRESS_MAXIMIZE           = 1 << 1,
@@ -64,7 +64,7 @@ struct SAlphaValue {
     float m_fAlpha;
     bool  m_bOverride;
 
-    float applyAlpha(float alpha) {
+    float applyAlpha(float alpha) const {
         if (m_bOverride)
             return m_fAlpha;
         else
@@ -72,8 +72,8 @@ struct SAlphaValue {
     };
 };
 
-enum eOverridePriority {
-    PRIORITY_LAYOUT,
+enum eOverridePriority : uint8_t {
+    PRIORITY_LAYOUT = 0,
     PRIORITY_WORKSPACE_RULE,
     PRIORITY_WINDOW_RULE,
     PRIORITY_SET_PROP,
@@ -85,9 +85,7 @@ class CWindowOverridableVar {
     CWindowOverridableVar(T const& value, eOverridePriority priority) {
         values[priority] = value;
     }
-    CWindowOverridableVar(T const& value) {
-        defaultValue = value;
-    }
+    CWindowOverridableVar(T const& value) : defaultValue{value} {}
 
     CWindowOverridableVar()  = default;
     ~CWindowOverridableVar() = default;
@@ -400,7 +398,7 @@ class CWindow {
     CTagKeeper m_tags;
 
     // For the list lookup
-    bool operator==(const CWindow& rhs) {
+    bool operator==(const CWindow& rhs) const {
         return m_pXDGSurface == rhs.m_pXDGSurface && m_pXWaylandSurface == rhs.m_pXWaylandSurface && m_vPosition == rhs.m_vPosition && m_vSize == rhs.m_vSize &&
             m_bFadingOut == rhs.m_bFadingOut;
     }
@@ -421,7 +419,7 @@ class CWindow {
     void                   updateToplevel();
     void                   updateSurfaceScaleTransformDetails(bool force = false);
     void                   moveToWorkspace(PHLWORKSPACE);
-    PHLWINDOW              X11TransientFor();
+    PHLWINDOW              x11TransientFor();
     void                   onUnmap();
     void                   onMap();
     void                   setHidden(bool hidden);
@@ -480,7 +478,7 @@ class CWindow {
     Vector2D               requestedMinSize();
     Vector2D               requestedMaxSize();
 
-    inline CBox            getWindowMainSurfaceBox() const {
+    CBox                   getWindowMainSurfaceBox() const {
         return {m_vRealPosition.value().x, m_vRealPosition.value().y, m_vRealSize.value().x, m_vRealSize.value().y};
     }
 

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -11,12 +11,9 @@ PHLWORKSPACE CWorkspace::create(WORKSPACEID id, PHLMONITOR monitor, std::string 
     return workspace;
 }
 
-CWorkspace::CWorkspace(WORKSPACEID id, PHLMONITOR monitor, std::string name, bool special, bool isEmpty) {
-    m_pMonitor            = monitor;
-    m_iID                 = id;
-    m_szName              = name;
-    m_bIsSpecialWorkspace = special;
-    m_bWasCreatedEmpty    = isEmpty;
+CWorkspace::CWorkspace(WORKSPACEID id, PHLMONITOR monitor, std::string name, bool special, bool isEmpty) :
+    m_iID(id), m_szName(name), m_pMonitor(monitor), m_bIsSpecialWorkspace(special), m_bWasCreatedEmpty(isEmpty) {
+    ;
 }
 
 void CWorkspace::init(PHLWORKSPACE self) {
@@ -106,7 +103,7 @@ void CWorkspace::startAnim(bool in, bool left, bool instant) {
         const auto PMONITOR = m_pMonitor.lock();
         float      movePerc = 100.f;
 
-        if (ANIMSTYLE.find("%") != std::string::npos) {
+        if (ANIMSTYLE.find('%') != std::string::npos) {
             try {
                 auto percstr = ANIMSTYLE.substr(ANIMSTYLE.find_last_of(' ') + 1);
                 movePerc     = std::stoi(percstr.substr(0, percstr.length() - 1));
@@ -296,7 +293,7 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
                     return false;
                 }
 
-                const auto DASHPOS = prop.find("-");
+                const auto DASHPOS = prop.find('-');
                 const auto LHS = prop.substr(0, DASHPOS), RHS = prop.substr(DASHPOS + 1);
 
                 if (!isNumber(LHS) || !isNumber(RHS)) {
@@ -433,7 +430,7 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
                     continue;
                 }
 
-                const auto DASHPOS = prop.find("-");
+                const auto DASHPOS = prop.find('-');
                 const auto LHS = prop.substr(0, DASHPOS), RHS = prop.substr(DASHPOS + 1);
 
                 if (!isNumber(LHS) || !isNumber(RHS)) {

--- a/src/devices/IHID.hpp
+++ b/src/devices/IHID.hpp
@@ -4,14 +4,14 @@
 #include <string>
 #include "../helpers/signal/Signal.hpp"
 
-enum eHIDCapabilityType : uint32_t {
+enum eHIDCapabilityType : uint8_t {
     HID_INPUT_CAPABILITY_KEYBOARD = (1 << 0),
     HID_INPUT_CAPABILITY_POINTER  = (1 << 1),
     HID_INPUT_CAPABILITY_TOUCH    = (1 << 2),
     HID_INPUT_CAPABILITY_TABLET   = (1 << 3),
 };
 
-enum eHIDType {
+enum eHIDType : uint8_t {
     HID_TYPE_UNKNOWN = 0,
     HID_TYPE_POINTER,
     HID_TYPE_KEYBOARD,
@@ -27,7 +27,7 @@ enum eHIDType {
 */
 class IHID {
   public:
-    virtual ~IHID() {}
+    virtual ~IHID() = default;
 
     virtual uint32_t getCapabilities() = 0;
     virtual eHIDType getType();

--- a/src/devices/Tablet.hpp
+++ b/src/devices/Tablet.hpp
@@ -3,7 +3,6 @@
 #include "IHID.hpp"
 #include "../macros.hpp"
 #include "../helpers/math/Math.hpp"
-#include "../helpers/math/Math.hpp"
 
 AQUAMARINE_FORWARD(ITablet);
 AQUAMARINE_FORWARD(ITabletTool);
@@ -27,7 +26,7 @@ class CTablet : public IHID {
     virtual eHIDType        getType();
     SP<Aquamarine::ITablet> aq();
 
-    enum eTabletToolAxes {
+    enum eTabletToolAxes : uint16_t {
         HID_TABLET_TOOL_AXIS_X        = (1 << 0),
         HID_TABLET_TOOL_AXIS_Y        = (1 << 1),
         HID_TABLET_TOOL_AXIS_TILT_X   = (1 << 2),
@@ -173,7 +172,7 @@ class CTabletTool : public IHID {
     static SP<CTabletTool> create(SP<Aquamarine::ITabletTool> tool);
     ~CTabletTool();
 
-    enum eTabletToolType {
+    enum eTabletToolType : uint8_t {
         HID_TABLET_TOOL_TYPE_PEN = 1,
         HID_TABLET_TOOL_TYPE_ERASER,
         HID_TABLET_TOOL_TYPE_BRUSH,
@@ -184,7 +183,7 @@ class CTabletTool : public IHID {
         HID_TABLET_TOOL_TYPE_TOTEM,
     };
 
-    enum eTabletToolCapabilities {
+    enum eTabletToolCapabilities : uint8_t {
         HID_TABLET_TOOL_CAPABILITY_TILT     = (1 << 0),
         HID_TABLET_TOOL_CAPABILITY_PRESSURE = (1 << 1),
         HID_TABLET_TOOL_CAPABILITY_DISTANCE = (1 << 2),

--- a/src/events/Events.hpp
+++ b/src/events/Events.hpp
@@ -1,12 +1,7 @@
 #pragma once
 #include "../defines.hpp"
 
-//
-// LISTEN_NAME -> the wl_listener
-//
-// LISTENER_NAME -> the wl_listener.notify function
-//
-
+// NOLINTNEXTLINE(readability-identifier-naming)
 namespace Events {
     // Window events
     DYNLISTENFUNC(commitWindow);

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -134,7 +134,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
     // window rules
     PWINDOW->m_vMatchedRules = g_pConfigManager->getMatchingRules(PWINDOW, false);
     std::optional<eFullscreenMode>  requestedInternalFSMode, requestedClientFSMode;
-    std::optional<sFullscreenState> requestedFSState;
+    std::optional<SFullscreenState> requestedFSState;
     if (PWINDOW->m_bWantsInitialFullscreen || (PWINDOW->m_bIsX11 && PWINDOW->m_pXWaylandSurface->fullscreen))
         requestedClientFSMode = FSMODE_FULLSCREEN;
 
@@ -206,7 +206,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
             try {
                 clientMode = std::stoi(ARGS[1]);
             } catch (std::exception& e) { clientMode = 0; }
-            requestedFSState = sFullscreenState{.internal = (eFullscreenMode)internalMode, .client = (eFullscreenMode)clientMode};
+            requestedFSState = SFullscreenState{.internal = (eFullscreenMode)internalMode, .client = (eFullscreenMode)clientMode};
         } else if (r.szRule.starts_with("suppressevent")) {
             CVarList vars(r.szRule, 0, 's', true);
             for (size_t i = 1; i < vars.size(); ++i) {
@@ -539,7 +539,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
             PWINDOW->m_sWindowData.syncFullscreen = CWindowOverridableVar(false, PRIORITY_WINDOW_RULE);
             g_pCompositor->setWindowFullscreenState(PWINDOW, requestedFSState.value());
         } else if (requestedInternalFSMode.has_value() && requestedClientFSMode.has_value() && !PWINDOW->m_sWindowData.syncFullscreen.valueOrDefault())
-            g_pCompositor->setWindowFullscreenState(PWINDOW, sFullscreenState{.internal = requestedInternalFSMode.value(), .client = requestedClientFSMode.value()});
+            g_pCompositor->setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = requestedInternalFSMode.value(), .client = requestedClientFSMode.value()});
         else if (requestedInternalFSMode.has_value())
             g_pCompositor->setWindowFullscreenInternal(PWINDOW, requestedInternalFSMode.value());
         else if (requestedClientFSMode.has_value())
@@ -618,7 +618,7 @@ void Events::listener_unmapWindow(void* owner, void* data) {
     static auto PEXITRETAINSFS = CConfigValue<Hyprlang::INT>("misc:exit_window_retains_fullscreen");
 
     const auto  CURRENTWINDOWFSSTATE = PWINDOW->isFullscreen();
-    const auto  CURRENTFSMODE        = PWINDOW->m_sFullscreenState.internal;
+    const auto  CURRENTFSMODE        = PWINDOW->m_SFullscreenState.internal;
 
     if (!PWINDOW->m_pWLSurface->exists() || !PWINDOW->m_bIsMapped) {
         Debug::log(WARN, "{} unmapped without being mapped??", PWINDOW);

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -618,7 +618,7 @@ void Events::listener_unmapWindow(void* owner, void* data) {
     static auto PEXITRETAINSFS = CConfigValue<Hyprlang::INT>("misc:exit_window_retains_fullscreen");
 
     const auto  CURRENTWINDOWFSSTATE = PWINDOW->isFullscreen();
-    const auto  CURRENTFSMODE        = PWINDOW->m_SFullscreenState.internal;
+    const auto  CURRENTFSMODE        = PWINDOW->m_sFullscreenState.internal;
 
     if (!PWINDOW->m_pWLSurface->exists() || !PWINDOW->m_bIsMapped) {
         Debug::log(WARN, "{} unmapped without being mapped??", PWINDOW);

--- a/src/helpers/AnimatedVariable.cpp
+++ b/src/helpers/AnimatedVariable.cpp
@@ -2,11 +2,11 @@
 #include "../managers/AnimationManager.hpp"
 #include "../config/ConfigManager.hpp"
 
-CBaseAnimatedVariable::CBaseAnimatedVariable(ANIMATEDVARTYPE type) : m_Type(type) {
+CBaseAnimatedVariable::CBaseAnimatedVariable(eAnimatedVarType type) : m_Type(type) {
     ; // dummy var
 }
 
-void CBaseAnimatedVariable::create(SAnimationPropertyConfig* pAnimConfig, PHLWINDOW pWindow, AVARDAMAGEPOLICY policy) {
+void CBaseAnimatedVariable::create(SAnimationPropertyConfig* pAnimConfig, PHLWINDOW pWindow, eAVarDamagePolicy policy) {
     m_eDamagePolicy = policy;
     m_pConfig       = pAnimConfig;
     m_pWindow       = pWindow;
@@ -14,7 +14,7 @@ void CBaseAnimatedVariable::create(SAnimationPropertyConfig* pAnimConfig, PHLWIN
     m_bDummy = false;
 }
 
-void CBaseAnimatedVariable::create(SAnimationPropertyConfig* pAnimConfig, PHLLS pLayer, AVARDAMAGEPOLICY policy) {
+void CBaseAnimatedVariable::create(SAnimationPropertyConfig* pAnimConfig, PHLLS pLayer, eAVarDamagePolicy policy) {
     m_eDamagePolicy = policy;
     m_pConfig       = pAnimConfig;
     m_pLayer        = pLayer;
@@ -22,7 +22,7 @@ void CBaseAnimatedVariable::create(SAnimationPropertyConfig* pAnimConfig, PHLLS 
     m_bDummy = false;
 }
 
-void CBaseAnimatedVariable::create(SAnimationPropertyConfig* pAnimConfig, PHLWORKSPACE pWorkspace, AVARDAMAGEPOLICY policy) {
+void CBaseAnimatedVariable::create(SAnimationPropertyConfig* pAnimConfig, PHLWORKSPACE pWorkspace, eAVarDamagePolicy policy) {
     m_eDamagePolicy = policy;
     m_pConfig       = pAnimConfig;
     m_pWorkspace    = pWorkspace;
@@ -30,7 +30,7 @@ void CBaseAnimatedVariable::create(SAnimationPropertyConfig* pAnimConfig, PHLWOR
     m_bDummy = false;
 }
 
-void CBaseAnimatedVariable::create(SAnimationPropertyConfig* pAnimConfig, AVARDAMAGEPOLICY policy) {
+void CBaseAnimatedVariable::create(SAnimationPropertyConfig* pAnimConfig, eAVarDamagePolicy policy) {
     m_eDamagePolicy = policy;
     m_pConfig       = pAnimConfig;
 

--- a/src/helpers/AnimatedVariable.hpp
+++ b/src/helpers/AnimatedVariable.hpp
@@ -10,38 +10,39 @@
 #include "../debug/Log.hpp"
 #include "../desktop/DesktopTypes.hpp"
 
-enum ANIMATEDVARTYPE {
+enum eAnimatedVarType {
     AVARTYPE_INVALID = -1,
     AVARTYPE_FLOAT,
     AVARTYPE_VECTOR,
     AVARTYPE_COLOR
 };
 
-// Utility to bind a type with its corresponding ANIMATEDVARTYPE
+// Utility to bind a type with its corresponding eAnimatedVarType
 template <class T>
-struct typeToANIMATEDVARTYPE_t {
-    static constexpr ANIMATEDVARTYPE value = AVARTYPE_INVALID;
+// NOLINTNEXTLINE(readability-identifier-naming)
+struct STypeToAnimatedVarType_t {
+    static constexpr eAnimatedVarType value = AVARTYPE_INVALID;
 };
 
 template <>
-struct typeToANIMATEDVARTYPE_t<float> {
-    static constexpr ANIMATEDVARTYPE value = AVARTYPE_FLOAT;
+struct STypeToAnimatedVarType_t<float> {
+    static constexpr eAnimatedVarType value = AVARTYPE_FLOAT;
 };
 
 template <>
-struct typeToANIMATEDVARTYPE_t<Vector2D> {
-    static constexpr ANIMATEDVARTYPE value = AVARTYPE_VECTOR;
+struct STypeToAnimatedVarType_t<Vector2D> {
+    static constexpr eAnimatedVarType value = AVARTYPE_VECTOR;
 };
 
 template <>
-struct typeToANIMATEDVARTYPE_t<CHyprColor> {
-    static constexpr ANIMATEDVARTYPE value = AVARTYPE_COLOR;
+struct STypeToAnimatedVarType_t<CHyprColor> {
+    static constexpr eAnimatedVarType value = AVARTYPE_COLOR;
 };
 
 template <class T>
-inline constexpr ANIMATEDVARTYPE typeToANIMATEDVARTYPE = typeToANIMATEDVARTYPE_t<T>::value;
+inline constexpr eAnimatedVarType typeToeAnimatedVarType = STypeToAnimatedVarType_t<T>::value;
 
-enum AVARDAMAGEPOLICY {
+enum eAVarDamagePolicy {
     AVARDAMAGE_NONE   = -1,
     AVARDAMAGE_ENTIRE = 0,
     AVARDAMAGE_BORDER,
@@ -67,11 +68,11 @@ concept Animable = OneOf<T, Vector2D, float, CHyprColor>;
 
 class CBaseAnimatedVariable {
   public:
-    CBaseAnimatedVariable(ANIMATEDVARTYPE type);
-    void create(SAnimationPropertyConfig* pAnimConfig, PHLWINDOW pWindow, AVARDAMAGEPOLICY policy);
-    void create(SAnimationPropertyConfig* pAnimConfig, PHLLS pLayer, AVARDAMAGEPOLICY policy);
-    void create(SAnimationPropertyConfig* pAnimConfig, PHLWORKSPACE pWorkspace, AVARDAMAGEPOLICY policy);
-    void create(SAnimationPropertyConfig* pAnimConfig, AVARDAMAGEPOLICY policy);
+    CBaseAnimatedVariable(eAnimatedVarType type);
+    void create(SAnimationPropertyConfig* pAnimConfig, PHLWINDOW pWindow, eAVarDamagePolicy policy);
+    void create(SAnimationPropertyConfig* pAnimConfig, PHLLS pLayer, eAVarDamagePolicy policy);
+    void create(SAnimationPropertyConfig* pAnimConfig, PHLWORKSPACE pWorkspace, eAVarDamagePolicy policy);
+    void create(SAnimationPropertyConfig* pAnimConfig, eAVarDamagePolicy policy);
 
     CBaseAnimatedVariable(const CBaseAnimatedVariable&)            = delete;
     CBaseAnimatedVariable(CBaseAnimatedVariable&&)                 = delete;
@@ -157,8 +158,8 @@ class CBaseAnimatedVariable {
 
     std::chrono::steady_clock::time_point animationBegin;
 
-    AVARDAMAGEPOLICY                      m_eDamagePolicy = AVARDAMAGE_NONE;
-    ANIMATEDVARTYPE                       m_Type;
+    eAVarDamagePolicy                      m_eDamagePolicy = AVARDAMAGE_NONE;
+    eAnimatedVarType                       m_Type;
 
     bool                                  m_bRemoveEndAfterRan   = true;
     bool                                  m_bRemoveBeginAfterRan = true;
@@ -206,24 +207,24 @@ class CBaseAnimatedVariable {
 template <Animable VarType>
 class CAnimatedVariable : public CBaseAnimatedVariable {
   public:
-    CAnimatedVariable() : CBaseAnimatedVariable(typeToANIMATEDVARTYPE<VarType>) {} // dummy var
+    CAnimatedVariable() : CBaseAnimatedVariable(typeToeAnimatedVarType<VarType>) {} // dummy var
 
-    void create(const VarType& value, SAnimationPropertyConfig* pAnimConfig, PHLWINDOW pWindow, AVARDAMAGEPOLICY policy) {
+    void create(const VarType& value, SAnimationPropertyConfig* pAnimConfig, PHLWINDOW pWindow, eAVarDamagePolicy policy) {
         create(pAnimConfig, pWindow, policy);
         m_Value = value;
         m_Goal  = value;
     }
-    void create(const VarType& value, SAnimationPropertyConfig* pAnimConfig, PHLLS pLayer, AVARDAMAGEPOLICY policy) {
+    void create(const VarType& value, SAnimationPropertyConfig* pAnimConfig, PHLLS pLayer, eAVarDamagePolicy policy) {
         create(pAnimConfig, pLayer, policy);
         m_Value = value;
         m_Goal  = value;
     }
-    void create(const VarType& value, SAnimationPropertyConfig* pAnimConfig, PHLWORKSPACE pWorkspace, AVARDAMAGEPOLICY policy) {
+    void create(const VarType& value, SAnimationPropertyConfig* pAnimConfig, PHLWORKSPACE pWorkspace, eAVarDamagePolicy policy) {
         create(pAnimConfig, pWorkspace, policy);
         m_Value = value;
         m_Goal  = value;
     }
-    void create(const VarType& value, SAnimationPropertyConfig* pAnimConfig, AVARDAMAGEPOLICY policy) {
+    void create(const VarType& value, SAnimationPropertyConfig* pAnimConfig, eAVarDamagePolicy policy) {
         create(pAnimConfig, policy);
         m_Value = value;
         m_Goal  = value;

--- a/src/helpers/ByteOperations.hpp
+++ b/src/helpers/ByteOperations.hpp
@@ -30,25 +30,27 @@ constexpr LD operator""_TB(const LD BYTES) {
     return BYTES * 1024 * 1024 * 1024 * 1024;
 }
 
+//NOLINTBEGIN
 template <typename T>
-using __acceptable_byte_operation_type = typename std::enable_if<std::is_trivially_constructible<T, ULL>::value || std::is_trivially_constructible<T, LD>::value>::type;
+using internal_hl_acceptable_byte_operation_type = typename std::enable_if<std::is_trivially_constructible<T, ULL>::value || std::is_trivially_constructible<T, LD>::value>::type;
 
-template <typename X, typename = __acceptable_byte_operation_type<X>>
+template <typename X, typename = internal_hl_acceptable_byte_operation_type<X>>
 constexpr X kBtoBytes(const X kB) {
     return kB * 1024;
 }
-template <typename X, typename = __acceptable_byte_operation_type<X>>
+template <typename X, typename = internal_hl_acceptable_byte_operation_type<X>>
 constexpr X MBtoBytes(const X MB) {
     return MB * 1024 * 1024;
 }
-template <typename X, typename = __acceptable_byte_operation_type<X>>
+template <typename X, typename = internal_hl_acceptable_byte_operation_type<X>>
 constexpr X GBtoBytes(const X GB) {
     return GB * 1024 * 1024 * 1024;
 }
-template <typename X, typename = __acceptable_byte_operation_type<X>>
+template <typename X, typename = internal_hl_acceptable_byte_operation_type<X>>
 constexpr X TBtoBytes(const X TB) {
     return TB * 1024 * 1024 * 1024 * 1024;
 }
+//NOLINTEND
 
 #undef ULL
 #undef LD

--- a/src/helpers/Color.cpp
+++ b/src/helpers/Color.cpp
@@ -5,32 +5,21 @@
 #define GREEN(c) ((double)(((c) >> 8) & 0xff) / 255.0)
 #define BLUE(c)  ((double)(((c)) & 0xff) / 255.0)
 
-CHyprColor::CHyprColor() {}
+CHyprColor::CHyprColor() = default;
 
-CHyprColor::CHyprColor(float r_, float g_, float b_, float a_) {
-    r = r_;
-    g = g_;
-    b = b_;
-    a = a_;
-
+CHyprColor::CHyprColor(float r_, float g_, float b_, float a_) : r(r_), g(g_), b(b_), a(a_) {
     okLab = Hyprgraphics::CColor(Hyprgraphics::CColor::SSRGB{r, g, b}).asOkLab();
 }
 
-CHyprColor::CHyprColor(uint64_t hex) {
-    r = RED(hex);
-    g = GREEN(hex);
-    b = BLUE(hex);
-    a = ALPHA(hex);
-
+CHyprColor::CHyprColor(uint64_t hex) : r(RED(hex)), g(GREEN(hex)), b(BLUE(hex)), a(ALPHA(hex)) {
     okLab = Hyprgraphics::CColor(Hyprgraphics::CColor::SSRGB{r, g, b}).asOkLab();
 }
 
-CHyprColor::CHyprColor(const Hyprgraphics::CColor& color, float a_) {
+CHyprColor::CHyprColor(const Hyprgraphics::CColor& color, float a_) : a(a_) {
     const auto SRGB = color.asRgb();
     r               = SRGB.r;
     g               = SRGB.g;
     b               = SRGB.b;
-    a               = a_;
 
     okLab = color.asOkLab();
 }

--- a/src/helpers/Format.cpp
+++ b/src/helpers/Format.cpp
@@ -231,7 +231,7 @@ inline const std::vector<SPixelFormat> GLES3_FORMATS = {
     },
 };
 
-SHMFormat FormatUtils::drmToShm(DRMFormat drm) {
+SHMFormat NFormatUtils::drmToShm(DRMFormat drm) {
     switch (drm) {
         case DRM_FORMAT_XRGB8888: return WL_SHM_FORMAT_XRGB8888;
         case DRM_FORMAT_ARGB8888: return WL_SHM_FORMAT_ARGB8888;
@@ -241,7 +241,7 @@ SHMFormat FormatUtils::drmToShm(DRMFormat drm) {
     return drm;
 }
 
-DRMFormat FormatUtils::shmToDRM(SHMFormat shm) {
+DRMFormat NFormatUtils::shmToDRM(SHMFormat shm) {
     switch (shm) {
         case WL_SHM_FORMAT_XRGB8888: return DRM_FORMAT_XRGB8888;
         case WL_SHM_FORMAT_ARGB8888: return DRM_FORMAT_ARGB8888;
@@ -251,7 +251,7 @@ DRMFormat FormatUtils::shmToDRM(SHMFormat shm) {
     return shm;
 }
 
-const SPixelFormat* FormatUtils::getPixelFormatFromDRM(DRMFormat drm) {
+const SPixelFormat* NFormatUtils::getPixelFormatFromDRM(DRMFormat drm) {
     for (auto const& fmt : GLES3_FORMATS) {
         if (fmt.drmFormat == drm)
             return &fmt;
@@ -260,7 +260,7 @@ const SPixelFormat* FormatUtils::getPixelFormatFromDRM(DRMFormat drm) {
     return nullptr;
 }
 
-const SPixelFormat* FormatUtils::getPixelFormatFromGL(uint32_t glFormat, uint32_t glType, bool alpha) {
+const SPixelFormat* NFormatUtils::getPixelFormatFromGL(uint32_t glFormat, uint32_t glType, bool alpha) {
     for (auto const& fmt : GLES3_FORMATS) {
         if (fmt.glFormat == (int)glFormat && fmt.glType == (int)glType && fmt.withAlpha == alpha)
             return &fmt;
@@ -269,23 +269,23 @@ const SPixelFormat* FormatUtils::getPixelFormatFromGL(uint32_t glFormat, uint32_
     return nullptr;
 }
 
-bool FormatUtils::isFormatOpaque(DRMFormat drm) {
-    const auto FMT = FormatUtils::getPixelFormatFromDRM(drm);
+bool NFormatUtils::isFormatOpaque(DRMFormat drm) {
+    const auto FMT = NFormatUtils::getPixelFormatFromDRM(drm);
     if (!FMT)
         return false;
 
     return !FMT->withAlpha;
 }
 
-int FormatUtils::pixelsPerBlock(const SPixelFormat* const fmt) {
+int NFormatUtils::pixelsPerBlock(const SPixelFormat* const fmt) {
     return fmt->blockSize.x * fmt->blockSize.y > 0 ? fmt->blockSize.x * fmt->blockSize.y : 1;
 }
 
-int FormatUtils::minStride(const SPixelFormat* const fmt, int32_t width) {
+int NFormatUtils::minStride(const SPixelFormat* const fmt, int32_t width) {
     return std::ceil((width * fmt->bytesPerBlock) / pixelsPerBlock(fmt));
 }
 
-uint32_t FormatUtils::drmFormatToGL(DRMFormat drm) {
+uint32_t NFormatUtils::drmFormatToGL(DRMFormat drm) {
     switch (drm) {
         case DRM_FORMAT_XRGB8888:
         case DRM_FORMAT_XBGR8888: return GL_RGBA; // doesn't matter, opengl is gucci in this case.
@@ -302,7 +302,7 @@ uint32_t FormatUtils::drmFormatToGL(DRMFormat drm) {
     return GL_RGBA;
 }
 
-uint32_t FormatUtils::glFormatToType(uint32_t gl) {
+uint32_t NFormatUtils::glFormatToType(uint32_t gl) {
     return gl != GL_RGBA ?
 #ifdef GLES2
         GL_UNSIGNED_INT_2_10_10_10_REV_EXT :
@@ -312,14 +312,14 @@ uint32_t FormatUtils::glFormatToType(uint32_t gl) {
         GL_UNSIGNED_BYTE;
 }
 
-std::string FormatUtils::drmFormatName(DRMFormat drm) {
+std::string NFormatUtils::drmFormatName(DRMFormat drm) {
     auto        n    = drmGetFormatName(drm);
     std::string name = n;
     free(n);
     return name;
 }
 
-std::string FormatUtils::drmModifierName(uint64_t mod) {
+std::string NFormatUtils::drmModifierName(uint64_t mod) {
     auto        n    = drmGetFormatModifierName(mod);
     std::string name = n;
     free(n);

--- a/src/helpers/Format.hpp
+++ b/src/helpers/Format.hpp
@@ -22,7 +22,7 @@ struct SPixelFormat {
 
 typedef Aquamarine::SDRMFormat SDRMFormat;
 
-namespace FormatUtils {
+namespace NFormatUtils {
     SHMFormat           drmToShm(DRMFormat drm);
     DRMFormat           shmToDRM(SHMFormat shm);
 

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -953,10 +953,7 @@ bool executableExistsInPath(const std::string& exe) {
 
         auto perms = stat.permissions();
 
-        if (std::filesystem::perms::none == (perms & std::filesystem::perms::others_exec))
-            return false;
-
-        return true;
+        return std::filesystem::perms::none != (perms & std::filesystem::perms::others_exec);
     }
 
     return false;

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1010,8 +1010,8 @@ void CMonitor::onMonitorFrame() {
         g_pHyprRenderer->renderMonitor(self.lock());
 }
 
-CMonitorState::CMonitorState(CMonitor* owner) {
-    m_pOwner = owner;
+CMonitorState::CMonitorState(CMonitor* owner) : m_pOwner(owner) {
+    ;
 }
 
 CMonitorState::~CMonitorState() {

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -16,7 +16,7 @@
 #include <aquamarine/allocator/Swapchain.hpp>
 
 // Enum for the different types of auto directions, e.g. auto-left, auto-up.
-enum eAutoDirs {
+enum eAutoDirs : uint8_t {
     DIR_AUTO_NONE = 0, /* None will be treated as right. */
     DIR_AUTO_UP,
     DIR_AUTO_DOWN,

--- a/src/helpers/SdDaemon.cpp
+++ b/src/helpers/SdDaemon.cpp
@@ -10,52 +10,50 @@
 #include <cstdlib>
 #include <cstring>
 
-namespace Systemd {
-    int SdBooted() {
-        if (!faccessat(AT_FDCWD, "/run/systemd/system/", F_OK, AT_SYMLINK_NOFOLLOW))
-            return true;
+int NSystemd::sdBooted() {
+    if (!faccessat(AT_FDCWD, "/run/systemd/system/", F_OK, AT_SYMLINK_NOFOLLOW))
+        return true;
 
-        if (errno == ENOENT)
-            return false;
+    if (errno == ENOENT)
+        return false;
 
+    return -errno;
+}
+
+int NSystemd::sdNotify(int unsetEnvironment, const char* state) {
+    int fd = socket(AF_UNIX, SOCK_DGRAM | SOCK_CLOEXEC, 0);
+    if (fd < 0)
         return -errno;
-    }
 
-    int SdNotify(int unsetEnvironment, const char* state) {
-        int fd = socket(AF_UNIX, SOCK_DGRAM | SOCK_CLOEXEC, 0);
-        if (fd < 0)
-            return -errno;
+    constexpr char envVar[] = "NOTIFY_SOCKET";
 
-        constexpr char envVar[] = "NOTIFY_SOCKET";
+    auto           cleanup = [unsetEnvironment, envVar](const int* fd) {
+        if (unsetEnvironment)
+            unsetenv(envVar);
+        close(*fd);
+    };
+    std::unique_ptr<int, decltype(cleanup)> fdCleaup(&fd, cleanup);
 
-        auto           cleanup = [unsetEnvironment, envVar](const int* fd) {
-            if (unsetEnvironment)
-                unsetenv(envVar);
-            close(*fd);
-        };
-        std::unique_ptr<int, decltype(cleanup)> fdCleaup(&fd, cleanup);
+    const char*                             addr = getenv(envVar);
+    if (!addr)
+        return 0;
 
-        const char*                             addr = getenv(envVar);
-        if (!addr)
-            return 0;
+    // address length must be at most this; see man 7 unix
+    size_t             addrLen = strnlen(addr, 107);
 
-        // address length must be at most this; see man 7 unix
-        size_t             addrLen = strnlen(addr, 107);
+    struct sockaddr_un unixAddr;
+    unixAddr.sun_family = AF_UNIX;
+    strncpy(unixAddr.sun_path, addr, addrLen);
+    if (unixAddr.sun_path[0] == '@')
+        unixAddr.sun_path[0] = '\0';
 
-        struct sockaddr_un unixAddr;
-        unixAddr.sun_family = AF_UNIX;
-        strncpy(unixAddr.sun_path, addr, addrLen);
-        if (unixAddr.sun_path[0] == '@')
-            unixAddr.sun_path[0] = '\0';
-
-        if (connect(fd, (const sockaddr*)&unixAddr, sizeof(struct sockaddr_un)) < 0)
-            return -errno;
-
-        // arbitrary value which seems to be enough for s-d messages
-        ssize_t stateLen = strnlen(state, 128);
-        if (write(fd, state, stateLen) == stateLen)
-            return 1;
-
+    if (connect(fd, (const sockaddr*)&unixAddr, sizeof(struct sockaddr_un)) < 0)
         return -errno;
-    }
+
+    // arbitrary value which seems to be enough for s-d messages
+    ssize_t stateLen = strnlen(state, 128);
+    if (write(fd, state, stateLen) == stateLen)
+        return 1;
+
+    return -errno;
 }

--- a/src/helpers/SdDaemon.cpp
+++ b/src/helpers/SdDaemon.cpp
@@ -4,15 +4,14 @@
 
 #include <fcntl.h>
 #include <unistd.h>
-#include <errno.h>
+#include <cerrno>
 #include <sys/socket.h>
 #include <sys/un.h>
-#include <string.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include <cstring>
 
 namespace Systemd {
-    int SdBooted(void) {
+    int SdBooted() {
         if (!faccessat(AT_FDCWD, "/run/systemd/system/", F_OK, AT_SYMLINK_NOFOLLOW))
             return true;
 
@@ -29,7 +28,7 @@ namespace Systemd {
 
         constexpr char envVar[] = "NOTIFY_SOCKET";
 
-        auto           cleanup = [unsetEnvironment, envVar](int* fd) {
+        auto           cleanup = [unsetEnvironment, envVar](const int* fd) {
             if (unsetEnvironment)
                 unsetenv(envVar);
             close(*fd);

--- a/src/helpers/SdDaemon.hpp
+++ b/src/helpers/SdDaemon.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace Systemd {
-    int SdBooted(void);
-    int SdNotify(int unset_environment, const char* state);
+namespace NSystemd {
+    int sdBooted(void);
+    int sdNotify(int unset_environment, const char* state);
 }

--- a/src/helpers/TagKeeper.hpp
+++ b/src/helpers/TagKeeper.hpp
@@ -5,11 +5,11 @@
 
 class CTagKeeper {
   public:
-    bool               isTagged(const std::string& tag, bool strict = false);
-    bool               applyTag(const std::string& tag, bool dynamic = false);
-    bool               removeDynamicTags();
+    bool        isTagged(const std::string& tag, bool strict = false);
+    bool        applyTag(const std::string& tag, bool dynamic = false);
+    bool        removeDynamicTags();
 
-    inline const auto& getTags() {
+    const auto& getTags() const {
         return m_tags;
     };
 

--- a/src/helpers/math/Math.hpp
+++ b/src/helpers/math/Math.hpp
@@ -6,6 +6,7 @@
 #include <hyprutils/math/Region.hpp>
 #include <hyprutils/math/Mat3x3.hpp>
 
+// NOLINTNEXTLINE
 using namespace Hyprutils::Math;
 
 eTransform          wlTransformToHyprutils(wl_output_transform t);

--- a/src/helpers/memory/Memory.hpp
+++ b/src/helpers/memory/Memory.hpp
@@ -2,6 +2,7 @@
 
 #include <hyprutils/memory/WeakPtr.hpp>
 
+//NOLINTNEXTLINE
 using namespace Hyprutils::Memory;
 
 #define SP Hyprutils::Memory::CSharedPointer

--- a/src/helpers/signal/Signal.hpp
+++ b/src/helpers/signal/Signal.hpp
@@ -2,4 +2,5 @@
 
 #include <hyprutils/signal/Signal.hpp>
 
+//NOLINTNEXTLINE
 using namespace Hyprutils::Signal;

--- a/src/helpers/varlist/VarList.hpp
+++ b/src/helpers/varlist/VarList.hpp
@@ -2,4 +2,5 @@
 
 #include <hyprutils/string/VarList.hpp>
 
+//NOLINTNEXTLINE
 using namespace Hyprutils::String;

--- a/src/includes.hpp
+++ b/src/includes.hpp
@@ -9,11 +9,11 @@
 #include <getopt.h>
 #include <libinput.h>
 #include <linux/input-event-codes.h>
-#include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
 #include <sys/wait.h>
-#include <time.h>
+#include <ctime>
 #include <unistd.h>
 #include <wayland-server-core.h>
 

--- a/src/init/initHelpers.cpp
+++ b/src/init/initHelpers.cpp
@@ -1,10 +1,10 @@
 #include "initHelpers.hpp"
 
-bool Init::isSudo() {
+bool NInit::isSudo() {
     return getuid() != geteuid() || !geteuid();
 }
 
-void Init::gainRealTime() {
+void NInit::gainRealTime() {
     const int          minPrio = sched_get_priority_min(SCHED_RR);
     int                old_policy;
     struct sched_param param;
@@ -21,7 +21,7 @@ void Init::gainRealTime() {
         return;
     }
 
-    pthread_atfork(NULL, NULL, []() {
+    pthread_atfork(nullptr, nullptr, []() {
         const struct sched_param param = {.sched_priority = 0};
         if (pthread_setschedparam(pthread_self(), SCHED_OTHER, &param))
             Debug::log(WARN, "Failed to reset process scheduling strategy");

--- a/src/init/initHelpers.hpp
+++ b/src/init/initHelpers.hpp
@@ -2,7 +2,7 @@
 
 #include "../defines.hpp"
 
-namespace Init {
+namespace NInit {
     bool isSudo();
     void gainRealTime();
 };

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -883,8 +883,8 @@ void CHyprDwindleLayout::switchWindows(PHLWINDOW pWindow, PHLWINDOW pWindow2) {
     if (!PNODE2 || !PNODE)
         return;
 
-    const eFullscreenMode MODE1 = pWindow->m_SFullscreenState.internal;
-    const eFullscreenMode MODE2 = pWindow2->m_SFullscreenState.internal;
+    const eFullscreenMode MODE1 = pWindow->m_sFullscreenState.internal;
+    const eFullscreenMode MODE2 = pWindow2->m_sFullscreenState.internal;
 
     g_pCompositor->setWindowFullscreenInternal(pWindow, FSMODE_NONE);
     g_pCompositor->setWindowFullscreenInternal(pWindow2, FSMODE_NONE);

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -883,8 +883,8 @@ void CHyprDwindleLayout::switchWindows(PHLWINDOW pWindow, PHLWINDOW pWindow2) {
     if (!PNODE2 || !PNODE)
         return;
 
-    const eFullscreenMode MODE1 = pWindow->m_sFullscreenState.internal;
-    const eFullscreenMode MODE2 = pWindow2->m_sFullscreenState.internal;
+    const eFullscreenMode MODE1 = pWindow->m_SFullscreenState.internal;
+    const eFullscreenMode MODE2 = pWindow2->m_SFullscreenState.internal;
 
     g_pCompositor->setWindowFullscreenInternal(pWindow, FSMODE_NONE);
     g_pCompositor->setWindowFullscreenInternal(pWindow2, FSMODE_NONE);

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -12,9 +12,9 @@ void SDwindleNodeData::recalcSizePosRecursive(bool force, bool horizontalOverrid
         if (*PPRESERVESPLIT == 0 && *PSMARTSPLIT == 0)
             splitTop = box.h * *PFLMULT > box.w;
 
-        if (verticalOverride == true)
+        if (verticalOverride)
             splitTop = true;
-        else if (horizontalOverride == true)
+        else if (horizontalOverride)
             splitTop = false;
 
         const auto SPLITSIDE = !splitTop;
@@ -231,7 +231,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
     if (pWindow->m_bIsFloating)
         return;
 
-    m_lDwindleNodesData.push_back(SDwindleNodeData());
+    m_lDwindleNodesData.emplace_back();
     const auto  PNODE = &m_lDwindleNodesData.back();
 
     const auto  PMONITOR = pWindow->m_pMonitor.lock();
@@ -312,7 +312,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
 
     // get the node under our cursor
 
-    m_lDwindleNodesData.push_back(SDwindleNodeData());
+    m_lDwindleNodesData.emplace_back();
     const auto NEWPARENT = &m_lDwindleNodesData.back();
 
     // make the parent have the OPENINGON's stats

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -81,7 +81,7 @@ void IHyprLayout::onWindowRemoved(PHLWINDOW pWindow) {
 }
 
 void IHyprLayout::onWindowRemovedFloating(PHLWINDOW pWindow) {
-    return; // no-op
+    ; // no-op
 }
 
 void IHyprLayout::onWindowCreatedFloating(PHLWINDOW pWindow) {
@@ -934,4 +934,4 @@ Vector2D IHyprLayout::predictSizeForNewWindow(PHLWINDOW pWindow) {
     return sizePredicted;
 }
 
-IHyprLayout::~IHyprLayout() {}
+IHyprLayout::~IHyprLayout() = default;

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -17,7 +17,7 @@ struct SLayoutMessageHeader {
 
 enum eFullscreenMode : int8_t;
 
-enum eRectCorner {
+enum eRectCorner : uint8_t {
     CORNER_NONE        = 0,
     CORNER_TOPLEFT     = (1 << 0),
     CORNER_TOPRIGHT    = (1 << 1),
@@ -25,7 +25,7 @@ enum eRectCorner {
     CORNER_BOTTOMLEFT  = (1 << 3),
 };
 
-enum eSnapEdge {
+enum eSnapEdge : uint8_t {
     SNAP_INVALID = 0,
     SNAP_UP      = (1 << 0),
     SNAP_DOWN    = (1 << 1),
@@ -33,7 +33,7 @@ enum eSnapEdge {
     SNAP_RIGHT   = (1 << 3),
 };
 
-enum eDirection {
+enum eDirection : int8_t {
     DIRECTION_DEFAULT = -1,
     DIRECTION_UP      = 0,
     DIRECTION_RIGHT,

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -267,7 +267,7 @@ void CHyprMasterLayout::onWindowRemovedTiling(PHLWINDOW pWindow) {
     // the screen half bare, and make it difficult to select remaining window
     if (getNodesOnWorkspace(WORKSPACEID) == 1) {
         for (auto& nd : m_lMasterNodesData) {
-            if (nd.workspaceID == WORKSPACEID && nd.isMaster == false) {
+            if (nd.workspaceID == WORKSPACEID && !nd.isMaster) {
                 nd.isMaster = true;
                 break;
             }

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -1007,7 +1007,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
 
         if (header.pWindow->isFullscreen()) {
             const auto  PWORKSPACE        = header.pWindow->m_pWorkspace;
-            const auto  FSMODE            = header.pWindow->m_sFullscreenState.internal;
+            const auto  FSMODE            = header.pWindow->m_SFullscreenState.internal;
             static auto INHERITFULLSCREEN = CConfigValue<Hyprlang::INT>("master:inherit_fullscreen");
             g_pCompositor->setWindowFullscreenInternal(header.pWindow, FSMODE_NONE);
             g_pCompositor->focusWindow(PWINDOWTOCHANGETO);

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -1007,7 +1007,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
 
         if (header.pWindow->isFullscreen()) {
             const auto  PWORKSPACE        = header.pWindow->m_pWorkspace;
-            const auto  FSMODE            = header.pWindow->m_SFullscreenState.internal;
+            const auto  FSMODE            = header.pWindow->m_sFullscreenState.internal;
             static auto INHERITFULLSCREEN = CConfigValue<Hyprlang::INT>("master:inherit_fullscreen");
             g_pCompositor->setWindowFullscreenInternal(header.pWindow, FSMODE_NONE);
             g_pCompositor->focusWindow(PWINDOWTOCHANGETO);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,11 +54,11 @@ int main(int argc, char** argv) {
     std::vector<std::string> args{argv + 1, argv + argc};
 
     for (auto it = args.begin(); it != args.end(); it++) {
-        if (it->compare("--i-am-really-stupid") == 0 && !ignoreSudo) {
+        if (*it == "--i-am-really-stupid" && !ignoreSudo) {
             std::println("[ WARNING ] Running Hyprland with superuser privileges might damage your system");
 
             ignoreSudo = true;
-        } else if (it->compare("--socket") == 0) {
+        } else if (*it == "--socket") {
             if (std::next(it) == args.end()) {
                 help();
 
@@ -67,7 +67,7 @@ int main(int argc, char** argv) {
 
             socketName = *std::next(it);
             it++;
-        } else if (it->compare("--wayland-fd") == 0) {
+        } else if (*it == "--wayland-fd") {
             if (std::next(it) == args.end()) {
                 help();
 
@@ -75,7 +75,7 @@ int main(int argc, char** argv) {
             }
 
             try {
-                socketFd = std::stoi(std::next(it)->c_str());
+                socketFd = std::stoi(*std::next(it));
 
                 // check if socketFd is a valid file descriptor
                 if (fcntl(socketFd, F_GETFD) == -1)
@@ -88,13 +88,13 @@ int main(int argc, char** argv) {
             }
 
             it++;
-        } else if (it->compare("-c") == 0 || it->compare("--config") == 0) {
+        } else if (*it == "-c" || *it == "--config") {
             if (std::next(it) == args.end()) {
                 help();
 
                 return 1;
             }
-            configPath = std::next(it)->c_str();
+            configPath = *std::next(it);
 
             try {
                 configPath = std::filesystem::canonical(configPath);
@@ -114,31 +114,31 @@ int main(int argc, char** argv) {
             it++;
 
             continue;
-        } else if (it->compare("-h") == 0 || it->compare("--help") == 0) {
+        } else if (*it == "-h" || *it == "--help") {
             help();
 
             return 0;
-        } else if (it->compare("-v") == 0 || it->compare("--version") == 0) {
+        } else if (*it == "-v" || *it == "--version") {
             std::println("{}", versionRequest(eHyprCtlOutputFormat::FORMAT_NORMAL, ""));
             return 0;
-        } else if (it->compare("--systeminfo") == 0) {
+        } else if (*it == "--systeminfo") {
             std::println("{}", systemInfoRequest(eHyprCtlOutputFormat::FORMAT_NORMAL, ""));
             return 0;
         } else {
-            std::println(stderr, "[ ERROR ] Unknown option '{}' !", it->c_str());
+            std::println(stderr, "[ ERROR ] Unknown option '{}' !", *it);
             help();
 
             return 1;
         }
     }
 
-    if (!ignoreSudo && Init::isSudo()) {
+    if (!ignoreSudo && NInit::isSudo()) {
         std::println(stderr,
                      "[ ERROR ] Hyprland was launched with superuser privileges, but the privileges check is not omitted.\n"
                      "          Hint: Use the --i-am-really-stupid flag to omit that check.");
 
         return 1;
-    } else if (ignoreSudo && Init::isSudo()) {
+    } else if (ignoreSudo && NInit::isSudo()) {
         std::println("Superuser privileges check is omitted. I hope you know what you're doing.");
     }
 
@@ -165,7 +165,7 @@ int main(int argc, char** argv) {
     g_pCompositor->initServer(socketName, socketFd);
 
     if (!envEnabled("HYPRLAND_NO_RT"))
-        Init::gainRealTime();
+        NInit::gainRealTime();
 
     Debug::log(LOG, "Hyprland init finished.");
 

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -216,17 +216,17 @@ void CAnimationManager::tick() {
 
         switch (av->m_Type) {
             case AVARTYPE_FLOAT: {
-                auto typedAv = static_cast<CAnimatedVariable<float>*>(av);
+                auto typedAv = dynamic_cast<CAnimatedVariable<float>*>(av);
                 updateVariable(*typedAv);
                 break;
             }
             case AVARTYPE_VECTOR: {
-                auto typedAv = static_cast<CAnimatedVariable<Vector2D>*>(av);
+                auto typedAv = dynamic_cast<CAnimatedVariable<Vector2D>*>(av);
                 updateVariable(*typedAv);
                 break;
             }
             case AVARTYPE_COLOR: {
-                auto typedAv = static_cast<CAnimatedVariable<CHyprColor>*>(av);
+                auto typedAv = dynamic_cast<CAnimatedVariable<CHyprColor>*>(av);
                 updateColorVariable(*typedAv);
                 break;
             }
@@ -495,7 +495,7 @@ std::string CAnimationManager::styleValidInConfigVar(const std::string& config, 
         else if (style.starts_with("popin")) {
             // try parsing
             float minPerc = 0.f;
-            if (style.find("%") != std::string::npos) {
+            if (style.find('%') != std::string::npos) {
                 try {
                     auto percstr = style.substr(style.find_last_of(' '));
                     minPerc      = std::stoi(percstr.substr(0, percstr.length() - 1));
@@ -516,7 +516,7 @@ std::string CAnimationManager::styleValidInConfigVar(const std::string& config, 
         else if (style.starts_with("slidefade")) {
             // try parsing
             float movePerc = 0.f;
-            if (style.find("%") != std::string::npos) {
+            if (style.find('%') != std::string::npos) {
                 try {
                     auto percstr = style.substr(style.find_last_of(' ') + 1);
                     movePerc     = std::stoi(percstr.substr(0, percstr.length() - 1));
@@ -541,7 +541,7 @@ std::string CAnimationManager::styleValidInConfigVar(const std::string& config, 
         else if (style.starts_with("popin")) {
             // try parsing
             float minPerc = 0.f;
-            if (style.find("%") != std::string::npos) {
+            if (style.find('%') != std::string::npos) {
                 try {
                     auto percstr = style.substr(style.find_last_of(' '));
                     minPerc      = std::stoi(percstr.substr(0, percstr.length() - 1));

--- a/src/managers/CursorManager.cpp
+++ b/src/managers/CursorManager.cpp
@@ -17,16 +17,12 @@ static void hcLogger(enum eHyprcursorLogLevel level, char* message) {
     Debug::log(NONE, "[hc] {}", message);
 }
 
-CCursorBuffer::CCursorBuffer(cairo_surface_t* surf, const Vector2D& size_, const Vector2D& hot_) : hotspot(hot_) {
-    surface = surf;
-    size    = size_;
-    stride  = cairo_image_surface_get_stride(surf);
+CCursorBuffer::CCursorBuffer(cairo_surface_t* surf, const Vector2D& size_, const Vector2D& hot_) : hotspot(hot_), surface(surf), stride(cairo_image_surface_get_stride(surf)) {
+    size = size_;
 }
 
-CCursorBuffer::CCursorBuffer(uint8_t* pixelData_, const Vector2D& size_, const Vector2D& hot_) : hotspot(hot_) {
-    pixelData = pixelData_;
-    size      = size_;
-    stride    = 4 * size_.x;
+CCursorBuffer::CCursorBuffer(uint8_t* pixelData_, const Vector2D& size_, const Vector2D& hot_) : hotspot(hot_), pixelData(pixelData_), stride(4 * size_.x) {
+    size = size_;
 }
 
 Aquamarine::eBufferCapability CCursorBuffer::caps() {

--- a/src/managers/EventManager.cpp
+++ b/src/managers/EventManager.cpp
@@ -10,8 +10,7 @@
 #include <unistd.h>
 #include <cstring>
 
-CEventManager::CEventManager() {
-    m_iSocketFD = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0);
+CEventManager::CEventManager() : m_iSocketFD(socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0)) {
     if (m_iSocketFD < 0) {
         Debug::log(ERR, "Couldn't start the Hyprland Socket 2. (1) IPC will not work.");
         return;

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1248,19 +1248,19 @@ SDispatchResult CKeybindManager::fullscreenStateActive(std::string args) {
         clientMode = std::stoi(ARGS[1]);
     } catch (std::exception& e) { clientMode = -1; }
 
-    const SFullscreenState STATE = SFullscreenState{.internal = (internalMode != -1 ? (eFullscreenMode)internalMode : PWINDOW->m_SFullscreenState.internal),
-                                                    .client   = (clientMode != -1 ? (eFullscreenMode)clientMode : PWINDOW->m_SFullscreenState.client)};
+    const SFullscreenState STATE = SFullscreenState{.internal = (internalMode != -1 ? (eFullscreenMode)internalMode : PWINDOW->m_sFullscreenState.internal),
+                                                    .client   = (clientMode != -1 ? (eFullscreenMode)clientMode : PWINDOW->m_sFullscreenState.client)};
 
-    if (internalMode != -1 && clientMode != -1 && PWINDOW->m_SFullscreenState.internal == STATE.internal && PWINDOW->m_SFullscreenState.client == STATE.client)
+    if (internalMode != -1 && clientMode != -1 && PWINDOW->m_sFullscreenState.internal == STATE.internal && PWINDOW->m_sFullscreenState.client == STATE.client)
         g_pCompositor->setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = FSMODE_NONE, .client = FSMODE_NONE});
-    else if (internalMode != -1 && clientMode == -1 && PWINDOW->m_SFullscreenState.internal == STATE.internal)
-        g_pCompositor->setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = FSMODE_NONE, .client = PWINDOW->m_SFullscreenState.client});
-    else if (internalMode == -1 && clientMode != -1 && PWINDOW->m_SFullscreenState.client == STATE.client)
-        g_pCompositor->setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = PWINDOW->m_SFullscreenState.internal, .client = FSMODE_NONE});
+    else if (internalMode != -1 && clientMode == -1 && PWINDOW->m_sFullscreenState.internal == STATE.internal)
+        g_pCompositor->setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = FSMODE_NONE, .client = PWINDOW->m_sFullscreenState.client});
+    else if (internalMode == -1 && clientMode != -1 && PWINDOW->m_sFullscreenState.client == STATE.client)
+        g_pCompositor->setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = PWINDOW->m_sFullscreenState.internal, .client = FSMODE_NONE});
     else
         g_pCompositor->setWindowFullscreenState(PWINDOW, STATE);
 
-    PWINDOW->m_sWindowData.syncFullscreen = CWindowOverridableVar(PWINDOW->m_SFullscreenState.internal == PWINDOW->m_SFullscreenState.client, PRIORITY_SET_PROP);
+    PWINDOW->m_sWindowData.syncFullscreen = CWindowOverridableVar(PWINDOW->m_sFullscreenState.internal == PWINDOW->m_sFullscreenState.client, PRIORITY_SET_PROP);
 
     return {};
 }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1248,19 +1248,19 @@ SDispatchResult CKeybindManager::fullscreenStateActive(std::string args) {
         clientMode = std::stoi(ARGS[1]);
     } catch (std::exception& e) { clientMode = -1; }
 
-    const sFullscreenState STATE = sFullscreenState{.internal = (internalMode != -1 ? (eFullscreenMode)internalMode : PWINDOW->m_sFullscreenState.internal),
-                                                    .client   = (clientMode != -1 ? (eFullscreenMode)clientMode : PWINDOW->m_sFullscreenState.client)};
+    const SFullscreenState STATE = SFullscreenState{.internal = (internalMode != -1 ? (eFullscreenMode)internalMode : PWINDOW->m_SFullscreenState.internal),
+                                                    .client   = (clientMode != -1 ? (eFullscreenMode)clientMode : PWINDOW->m_SFullscreenState.client)};
 
-    if (internalMode != -1 && clientMode != -1 && PWINDOW->m_sFullscreenState.internal == STATE.internal && PWINDOW->m_sFullscreenState.client == STATE.client)
-        g_pCompositor->setWindowFullscreenState(PWINDOW, sFullscreenState{.internal = FSMODE_NONE, .client = FSMODE_NONE});
-    else if (internalMode != -1 && clientMode == -1 && PWINDOW->m_sFullscreenState.internal == STATE.internal)
-        g_pCompositor->setWindowFullscreenState(PWINDOW, sFullscreenState{.internal = FSMODE_NONE, .client = PWINDOW->m_sFullscreenState.client});
-    else if (internalMode == -1 && clientMode != -1 && PWINDOW->m_sFullscreenState.client == STATE.client)
-        g_pCompositor->setWindowFullscreenState(PWINDOW, sFullscreenState{.internal = PWINDOW->m_sFullscreenState.internal, .client = FSMODE_NONE});
+    if (internalMode != -1 && clientMode != -1 && PWINDOW->m_SFullscreenState.internal == STATE.internal && PWINDOW->m_SFullscreenState.client == STATE.client)
+        g_pCompositor->setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = FSMODE_NONE, .client = FSMODE_NONE});
+    else if (internalMode != -1 && clientMode == -1 && PWINDOW->m_SFullscreenState.internal == STATE.internal)
+        g_pCompositor->setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = FSMODE_NONE, .client = PWINDOW->m_SFullscreenState.client});
+    else if (internalMode == -1 && clientMode != -1 && PWINDOW->m_SFullscreenState.client == STATE.client)
+        g_pCompositor->setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = PWINDOW->m_SFullscreenState.internal, .client = FSMODE_NONE});
     else
         g_pCompositor->setWindowFullscreenState(PWINDOW, STATE);
 
-    PWINDOW->m_sWindowData.syncFullscreen = CWindowOverridableVar(PWINDOW->m_sFullscreenState.internal == PWINDOW->m_sFullscreenState.client, PRIORITY_SET_PROP);
+    PWINDOW->m_sWindowData.syncFullscreen = CWindowOverridableVar(PWINDOW->m_SFullscreenState.internal == PWINDOW->m_SFullscreenState.client, PRIORITY_SET_PROP);
 
     return {};
 }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -5,7 +5,6 @@
 #include "../protocols/ShortcutsInhibit.hpp"
 #include "../protocols/GlobalShortcuts.hpp"
 #include "../render/decorations/CHyprGroupBarDecoration.hpp"
-#include "../devices/IKeyboard.hpp"
 #include "KeybindManager.hpp"
 #include "PointerManager.hpp"
 #include "Compositor.hpp"
@@ -13,7 +12,6 @@
 #include "eventLoop/EventLoopManager.hpp"
 #include "debug/Log.hpp"
 #include "helpers/varlist/VarList.hpp"
-#include "eventLoop/EventLoopManager.hpp"
 
 #include <optional>
 #include <iterator>
@@ -265,7 +263,7 @@ void CKeybindManager::updateXKBTranslationState() {
 
     xkb_rule_names    rules      = {.rules = RULES.c_str(), .model = MODEL.c_str(), .layout = LAYOUT.c_str(), .variant = VARIANT.c_str(), .options = OPTIONS.c_str()};
     const auto        PCONTEXT   = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-    FILE* const       KEYMAPFILE = FILEPATH == "" ? NULL : fopen(absolutePath(FILEPATH, g_pConfigManager->configCurrentPath).c_str(), "r");
+    FILE* const       KEYMAPFILE = FILEPATH == "" ? nullptr : fopen(absolutePath(FILEPATH, g_pConfigManager->configCurrentPath).c_str(), "r");
 
     auto              PKEYMAP = KEYMAPFILE ? xkb_keymap_new_from_file(PCONTEXT, KEYMAPFILE, XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS) :
                                              xkb_keymap_new_from_names(PCONTEXT, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
@@ -409,7 +407,7 @@ bool CKeybindManager::onKeyEvent(std::any event, SP<IKeyboard> pKeyboard) {
     }
 
     if (!m_pXKBTranslationState) {
-        Debug::log(ERR, "BUG THIS: m_pXKBTranslationState NULL!");
+        Debug::log(ERR, "BUG THIS: m_pXKBTranslationState nullptr!");
         updateXKBTranslationState();
 
         if (!m_pXKBTranslationState)
@@ -734,7 +732,7 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
         if (SPECIALTRIGGERED && !pressed)
             std::erase_if(m_vPressedSpecialBinds, [&](const auto& other) { return other == k; });
         else if (SPECIALDISPATCHER && pressed)
-            m_vPressedSpecialBinds.push_back(k);
+            m_vPressedSpecialBinds.emplace_back(k);
 
         // Should never happen, as we check in the ConfigManager, but oh well
         if (DISPATCHER == m_mDispatchers.end()) {
@@ -762,7 +760,7 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
         if (k->repeat) {
             const auto PACTIVEKEEB = g_pSeatManager->keyboard.lock();
 
-            m_vActiveKeybinds.push_back(k);
+            m_vActiveKeybinds.emplace_back(k);
             m_pRepeatKeyTimer->updateTimeout(std::chrono::milliseconds(PACTIVEKEEB->repeatDelay));
         }
 
@@ -827,7 +825,7 @@ void CKeybindManager::shadowKeybinds(const xkb_keysym_t& doesntHave, const uint3
 
 bool CKeybindManager::handleVT(xkb_keysym_t keysym) {
     // Handles the CTRL+ALT+FX TTY keybinds
-    if (!(keysym >= XKB_KEY_XF86Switch_VT_1 && keysym <= XKB_KEY_XF86Switch_VT_12))
+    if (keysym < XKB_KEY_XF86Switch_VT_1 || keysym > XKB_KEY_XF86Switch_VT_12)
         return false;
 
     // beyond this point, return true to not handle anything else.
@@ -942,7 +940,7 @@ uint64_t CKeybindManager::spawnRawProc(std::string args, PHLWORKSPACE pInitialWo
 
         sigset_t set;
         sigemptyset(&set);
-        sigprocmask(SIG_SETMASK, &set, NULL);
+        sigprocmask(SIG_SETMASK, &set, nullptr);
 
         grandchild = fork();
         if (grandchild == 0) {
@@ -968,7 +966,7 @@ uint64_t CKeybindManager::spawnRawProc(std::string args, PHLWORKSPACE pInitialWo
     read(socket[0], &grandchild, sizeof(grandchild));
     close(socket[0]);
     // clear child and leave grandchild to init
-    waitpid(child, NULL, 0);
+    waitpid(child, nullptr, 0);
     if (grandchild < 0) {
         Debug::log(LOG, "Fail to create the second fork");
         return 0;
@@ -1812,8 +1810,8 @@ SDispatchResult CKeybindManager::renameWorkspace(std::string args) {
         else
             return {.success = false, .error = "No such workspace"};
     } catch (std::exception& e) {
-        Debug::log(ERR, "Invalid arg in renameWorkspace, expected numeric id only or a numeric id and string name. \"{}\": \"{}\"", args, e.what());
-        return {.success = false, .error = std::format("Invalid arg in renameWorkspace, expected numeric id only or a numeric id and string name. \"{}\": \"{}\"", args, e.what())};
+        Debug::log(ERR, R"(Invalid arg in renameWorkspace, expected numeric id only or a numeric id and string name. "{}": "{}")", args, e.what());
+        return {.success = false, .error = std::format(R"(Invalid arg in renameWorkspace, expected numeric id only or a numeric id and string name. "{}": "{}")", args, e.what())};
     }
 
     return {};
@@ -2286,7 +2284,7 @@ SDispatchResult CKeybindManager::sendshortcut(std::string args) {
     const auto MOD     = g_pKeybindManager->stringToModMask(ARGS[0]);
     const auto KEY     = ARGS[1];
     uint32_t   keycode = 0;
-    bool       isMouse = 0;
+    bool       isMouse = false;
 
     // similar to parseKey in ConfigManager
     if (isNumber(KEY) && std::stoi(KEY) > 9)
@@ -2295,7 +2293,7 @@ SDispatchResult CKeybindManager::sendshortcut(std::string args) {
         keycode = std::stoi(KEY.substr(5));
     else if (KEY.compare(0, 6, "mouse:") == 0 && isNumber(KEY.substr(6))) {
         keycode = std::stoi(KEY.substr(6));
-        isMouse = 1;
+        isMouse = true;
         if (keycode < 272) {
             Debug::log(ERR, "sendshortcut: invalid mouse button");
             return {.success = false, .error = "sendshortcut: invalid mouse button"};
@@ -2643,9 +2641,9 @@ SDispatchResult CKeybindManager::alterZOrder(std::string args) {
     }
 
     if (POSITION == "top")
-        g_pCompositor->changeWindowZOrder(PWINDOW, 1);
+        g_pCompositor->changeWindowZOrder(PWINDOW, true);
     else if (POSITION == "bottom")
-        g_pCompositor->changeWindowZOrder(PWINDOW, 0);
+        g_pCompositor->changeWindowZOrder(PWINDOW, false);
     else {
         Debug::log(ERR, "alterZOrder: bad position: {}", POSITION);
         return {.success = false, .error = "alterZOrder: bad position: {}"};

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -14,6 +14,8 @@ class CConfigManager;
 class CPluginSystem;
 class IKeyboard;
 
+enum eMouseBindMode : int8_t;
+
 struct SKeybind {
     std::string            key            = "";
     std::set<xkb_keysym_t> sMkKeys        = {};

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -3,7 +3,6 @@
 #include "../defines.hpp"
 #include <deque>
 #include <set>
-#include "../Compositor.hpp"
 #include <unordered_map>
 #include <functional>
 #include <xkbcommon/xkbcommon.h>
@@ -42,7 +41,7 @@ struct SKeybind {
     bool shadowed = false;
 };
 
-enum eFocusWindowMode {
+enum eFocusWindowMode : uint8_t {
     MODE_CLASS_REGEX = 0,
     MODE_INITIAL_CLASS_REGEX,
     MODE_TITLE_REGEX,
@@ -67,7 +66,7 @@ struct SParsedKey {
     bool        catchAll = false;
 };
 
-enum eMultiKeyCase {
+enum eMultiKeyCase : uint8_t {
     MK_NO_MATCH = 0,
     MK_PARTIAL_MATCH,
     MK_FULL_MATCH

--- a/src/managers/LayoutManager.hpp
+++ b/src/managers/LayoutManager.hpp
@@ -16,7 +16,7 @@ class CLayoutManager {
     std::vector<std::string> getAllLayoutNames();
 
   private:
-    enum eHyprLayouts {
+    enum eHyprLayouts : uint8_t {
         LAYOUT_DWINDLE = 0,
         LAYOUT_MASTER
     };

--- a/src/managers/LayoutManager.hpp
+++ b/src/managers/LayoutManager.hpp
@@ -16,7 +16,7 @@ class CLayoutManager {
     std::vector<std::string> getAllLayoutNames();
 
   private:
-    enum HYPRLAYOUTS {
+    enum eHyprLayouts {
         LAYOUT_DWINDLE = 0,
         LAYOUT_MASTER
     };

--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -448,7 +448,7 @@ SP<Aquamarine::IBuffer> CPointerManager::renderHWCursorBuffer(SP<CPointerManager
                 bool       flipRB = false;
 
                 if (SURFACE->current.texture) {
-                    Debug::log(TRACE, "Cursor CPU surface: format {}, expecting AR24", FormatUtils::drmFormatName(SURFACE->current.texture->m_iDrmFormat));
+                    Debug::log(TRACE, "Cursor CPU surface: format {}, expecting AR24", NFormatUtils::drmFormatName(SURFACE->current.texture->m_iDrmFormat));
                     if (SURFACE->current.texture->m_iDrmFormat == DRM_FORMAT_ABGR8888) {
                         Debug::log(TRACE, "Cursor CPU surface format AB24, will flip. WARNING: this will break on big endian!");
                         flipRB = true;

--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -781,7 +781,7 @@ void CPointerManager::onMonitorLayoutChange() {
         if (m->isMirror() || !m->m_bEnabled || !m->output)
             continue;
 
-        currentMonitorLayout.monitorBoxes.emplace_back(CBox{m->vecPosition, m->vecSize});
+        currentMonitorLayout.monitorBoxes.emplace_back(m->vecPosition, m->vecSize);
     }
 
     damageIfSoftware();
@@ -822,7 +822,7 @@ void CPointerManager::attachPointer(SP<IPointer> pointer) {
         detachPointer(nullptr);
     });
 
-    listener->motion = pointer->pointerEvents.motion.registerListener([this] (std::any e) {
+    listener->motion = pointer->pointerEvents.motion.registerListener([] (std::any e) {
         auto E = std::any_cast<IPointer::SMotionEvent>(e);
 
         g_pInputManager->onMouseMoved(E);
@@ -833,7 +833,7 @@ void CPointerManager::attachPointer(SP<IPointer> pointer) {
             g_pKeybindManager->dpms("on");
     });
 
-    listener->motionAbsolute = pointer->pointerEvents.motionAbsolute.registerListener([this] (std::any e) {
+    listener->motionAbsolute = pointer->pointerEvents.motionAbsolute.registerListener([] (std::any e) {
         auto E = std::any_cast<IPointer::SMotionAbsoluteEvent>(e);
 
         g_pInputManager->onMouseWarp(E);
@@ -844,7 +844,7 @@ void CPointerManager::attachPointer(SP<IPointer> pointer) {
             g_pKeybindManager->dpms("on");
     });
 
-    listener->button = pointer->pointerEvents.button.registerListener([this] (std::any e) {
+    listener->button = pointer->pointerEvents.button.registerListener([] (std::any e) {
         auto E = std::any_cast<IPointer::SButtonEvent>(e);
 
         g_pInputManager->onMouseButton(E);
@@ -852,7 +852,7 @@ void CPointerManager::attachPointer(SP<IPointer> pointer) {
         PROTO::idle->onActivity();
     });
 
-    listener->axis = pointer->pointerEvents.axis.registerListener([this] (std::any e) {
+    listener->axis = pointer->pointerEvents.axis.registerListener([] (std::any e) {
         auto E = std::any_cast<IPointer::SAxisEvent>(e);
 
         g_pInputManager->onMouseWheel(E);
@@ -860,7 +860,7 @@ void CPointerManager::attachPointer(SP<IPointer> pointer) {
         PROTO::idle->onActivity();
     });
 
-    listener->frame = pointer->pointerEvents.frame.registerListener([this] (std::any e) {
+    listener->frame = pointer->pointerEvents.frame.registerListener([] (std::any e) {
         bool shouldSkip = false;
         if (!g_pSeatManager->mouse.expired() && g_pInputManager->isLocked()) {
             auto PMONITOR = g_pCompositor->m_pLastMonitor.get();
@@ -871,7 +871,7 @@ void CPointerManager::attachPointer(SP<IPointer> pointer) {
             g_pSeatManager->sendPointerFrame();
     });
 
-    listener->swipeBegin = pointer->pointerEvents.swipeBegin.registerListener([this] (std::any e) {
+    listener->swipeBegin = pointer->pointerEvents.swipeBegin.registerListener([] (std::any e) {
         auto E = std::any_cast<IPointer::SSwipeBeginEvent>(e);
 
         g_pInputManager->onSwipeBegin(E);
@@ -882,7 +882,7 @@ void CPointerManager::attachPointer(SP<IPointer> pointer) {
             g_pKeybindManager->dpms("on");
     });
 
-    listener->swipeEnd = pointer->pointerEvents.swipeEnd.registerListener([this] (std::any e) {
+    listener->swipeEnd = pointer->pointerEvents.swipeEnd.registerListener([] (std::any e) {
         auto E = std::any_cast<IPointer::SSwipeEndEvent>(e);
 
         g_pInputManager->onSwipeEnd(E);
@@ -890,7 +890,7 @@ void CPointerManager::attachPointer(SP<IPointer> pointer) {
         PROTO::idle->onActivity();
     });
 
-    listener->swipeUpdate = pointer->pointerEvents.swipeUpdate.registerListener([this] (std::any e) {
+    listener->swipeUpdate = pointer->pointerEvents.swipeUpdate.registerListener([] (std::any e) {
         auto E = std::any_cast<IPointer::SSwipeUpdateEvent>(e);
 
         g_pInputManager->onSwipeUpdate(E);
@@ -898,7 +898,7 @@ void CPointerManager::attachPointer(SP<IPointer> pointer) {
         PROTO::idle->onActivity();
     });
 
-    listener->pinchBegin = pointer->pointerEvents.pinchBegin.registerListener([this] (std::any e) {
+    listener->pinchBegin = pointer->pointerEvents.pinchBegin.registerListener([] (std::any e) {
         auto E = std::any_cast<IPointer::SPinchBeginEvent>(e);
 
         PROTO::pointerGestures->pinchBegin(E.timeMs, E.fingers);
@@ -909,7 +909,7 @@ void CPointerManager::attachPointer(SP<IPointer> pointer) {
             g_pKeybindManager->dpms("on");
     });
 
-    listener->pinchEnd = pointer->pointerEvents.pinchEnd.registerListener([this] (std::any e) {
+    listener->pinchEnd = pointer->pointerEvents.pinchEnd.registerListener([] (std::any e) {
         auto E = std::any_cast<IPointer::SPinchEndEvent>(e);
 
         PROTO::pointerGestures->pinchEnd(E.timeMs, E.cancelled);
@@ -917,7 +917,7 @@ void CPointerManager::attachPointer(SP<IPointer> pointer) {
         PROTO::idle->onActivity();
     });
 
-    listener->pinchUpdate = pointer->pointerEvents.pinchUpdate.registerListener([this] (std::any e) {
+    listener->pinchUpdate = pointer->pointerEvents.pinchUpdate.registerListener([] (std::any e) {
         auto E = std::any_cast<IPointer::SPinchUpdateEvent>(e);
 
         PROTO::pointerGestures->pinchUpdate(E.timeMs, E.delta, E.scale, E.rotation);
@@ -925,7 +925,7 @@ void CPointerManager::attachPointer(SP<IPointer> pointer) {
         PROTO::idle->onActivity();
     });
 
-    listener->holdBegin = pointer->pointerEvents.holdBegin.registerListener([this] (std::any e) {
+    listener->holdBegin = pointer->pointerEvents.holdBegin.registerListener([] (std::any e) {
         auto E = std::any_cast<IPointer::SHoldBeginEvent>(e);
 
         PROTO::pointerGestures->holdBegin(E.timeMs, E.fingers);
@@ -933,7 +933,7 @@ void CPointerManager::attachPointer(SP<IPointer> pointer) {
         PROTO::idle->onActivity();
     });
 
-    listener->holdEnd = pointer->pointerEvents.holdEnd.registerListener([this] (std::any e) {
+    listener->holdEnd = pointer->pointerEvents.holdEnd.registerListener([] (std::any e) {
         auto E = std::any_cast<IPointer::SHoldEndEvent>(e);
 
         PROTO::pointerGestures->holdEnd(E.timeMs, E.cancelled);
@@ -961,7 +961,7 @@ void CPointerManager::attachTouch(SP<ITouch> touch) {
         detachTouch(nullptr);
     });
 
-    listener->down = touch->touchEvents.down.registerListener([this] (std::any e) {
+    listener->down = touch->touchEvents.down.registerListener([] (std::any e) {
         auto E = std::any_cast<ITouch::SDownEvent>(e);
 
         g_pInputManager->onTouchDown(E);
@@ -972,7 +972,7 @@ void CPointerManager::attachTouch(SP<ITouch> touch) {
             g_pKeybindManager->dpms("on");
     });
 
-    listener->up = touch->touchEvents.up.registerListener([this] (std::any e) {
+    listener->up = touch->touchEvents.up.registerListener([] (std::any e) {
         auto E = std::any_cast<ITouch::SUpEvent>(e);
 
         g_pInputManager->onTouchUp(E);
@@ -980,7 +980,7 @@ void CPointerManager::attachTouch(SP<ITouch> touch) {
         PROTO::idle->onActivity();
     });
 
-    listener->motion = touch->touchEvents.motion.registerListener([this] (std::any e) {
+    listener->motion = touch->touchEvents.motion.registerListener([] (std::any e) {
         auto E = std::any_cast<ITouch::SMotionEvent>(e);
 
         g_pInputManager->onTouchMove(E);
@@ -988,11 +988,11 @@ void CPointerManager::attachTouch(SP<ITouch> touch) {
         PROTO::idle->onActivity();
     });
 
-    listener->cancel = touch->touchEvents.cancel.registerListener([this] (std::any e) {
+    listener->cancel = touch->touchEvents.cancel.registerListener([] (std::any e) {
         //
     });
 
-    listener->frame = touch->touchEvents.frame.registerListener([this] (std::any e) {
+    listener->frame = touch->touchEvents.frame.registerListener([] (std::any e) {
         g_pSeatManager->sendTouchFrame();
     });
     // clang-format on
@@ -1016,7 +1016,7 @@ void CPointerManager::attachTablet(SP<CTablet> tablet) {
         detachTablet(nullptr);
     });
 
-    listener->axis = tablet->tabletEvents.axis.registerListener([this] (std::any e) {
+    listener->axis = tablet->tabletEvents.axis.registerListener([] (std::any e) {
         auto E = std::any_cast<CTablet::SAxisEvent>(e);
 
         g_pInputManager->onTabletAxis(E);
@@ -1027,7 +1027,7 @@ void CPointerManager::attachTablet(SP<CTablet> tablet) {
             g_pKeybindManager->dpms("on");
     });
 
-    listener->proximity = tablet->tabletEvents.proximity.registerListener([this] (std::any e) {
+    listener->proximity = tablet->tabletEvents.proximity.registerListener([] (std::any e) {
         auto E = std::any_cast<CTablet::SProximityEvent>(e);
 
         g_pInputManager->onTabletProximity(E);
@@ -1035,7 +1035,7 @@ void CPointerManager::attachTablet(SP<CTablet> tablet) {
         PROTO::idle->onActivity();
     });
 
-    listener->tip = tablet->tabletEvents.tip.registerListener([this] (std::any e) {
+    listener->tip = tablet->tabletEvents.tip.registerListener([] (std::any e) {
         auto E = std::any_cast<CTablet::STipEvent>(e);
 
         g_pInputManager->onTabletTip(E);
@@ -1046,7 +1046,7 @@ void CPointerManager::attachTablet(SP<CTablet> tablet) {
             g_pKeybindManager->dpms("on");
     });
 
-    listener->button = tablet->tabletEvents.button.registerListener([this] (std::any e) {
+    listener->button = tablet->tabletEvents.button.registerListener([] (std::any e) {
         auto E = std::any_cast<CTablet::SButtonEvent>(e);
 
         g_pInputManager->onTabletButton(E);

--- a/src/managers/PointerManager.hpp
+++ b/src/managers/PointerManager.hpp
@@ -4,7 +4,6 @@
 #include "../devices/ITouch.hpp"
 #include "../devices/Tablet.hpp"
 #include "../helpers/math/Math.hpp"
-#include "../helpers/math/Math.hpp"
 #include "../desktop/WLSurface.hpp"
 #include "../helpers/sync/SyncTimeline.hpp"
 #include <tuple>
@@ -160,8 +159,8 @@ class CPointerManager {
     Vector2D storedUnaccel = {0, 0};
 
     struct SMonitorPointerState {
-        SMonitorPointerState(PHLMONITOR m) : monitor(m) {}
-        ~SMonitorPointerState() {}
+        SMonitorPointerState(const PHLMONITOR& m) : monitor(m) {}
+        ~SMonitorPointerState() = default;
 
         PHLMONITORREF           monitor;
 

--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -647,7 +647,7 @@ bool CSeatGrab::accepts(SP<CWLSurfaceResource> surf) {
 }
 
 void CSeatGrab::add(SP<CWLSurfaceResource> surf) {
-    surfs.push_back(surf);
+    surfs.emplace_back(surf);
 }
 
 void CSeatGrab::remove(SP<CWLSurfaceResource> surf) {

--- a/src/managers/ThreadManager.cpp
+++ b/src/managers/ThreadManager.cpp
@@ -16,9 +16,7 @@ int handleTimer(void* data) {
     return 0;
 }
 
-CThreadManager::CThreadManager() {
-    m_esConfigTimer = wl_event_loop_add_timer(g_pCompositor->m_sWLEventLoop, handleTimer, this);
-
+CThreadManager::CThreadManager() : m_esConfigTimer(wl_event_loop_add_timer(g_pCompositor->m_sWLEventLoop, handleTimer, this)) {
     wl_event_source_timer_update(m_esConfigTimer, 1000);
 }
 

--- a/src/managers/ThreadManager.hpp
+++ b/src/managers/ThreadManager.hpp
@@ -1,15 +1,14 @@
 #pragma once
 
 #include "../defines.hpp"
-#include <thread>
-#include "../Compositor.hpp"
+struct wl_event_source;
 
 class CThreadManager {
   public:
     CThreadManager();
     ~CThreadManager();
 
-    wl_event_source* m_esConfigTimer;
+    wl_event_source* m_esConfigTimer = nullptr;
 
   private:
 };

--- a/src/managers/XCursorManager.cpp
+++ b/src/managers/XCursorManager.cpp
@@ -185,8 +185,8 @@ SP<SXCursors> CXCursorManager::createCursor(std::string const& shape, XcursorIma
         SXCursorImage image;
         image.size    = {(int)xImage->width, (int)xImage->height};
         image.hotspot = {(int)xImage->xhot, (int)xImage->yhot};
-        image.pixels.resize(xImage->width * xImage->height);
-        std::memcpy(image.pixels.data(), xImage->pixels, xImage->width * xImage->height * sizeof(uint32_t));
+        image.pixels.resize((size_t)xImage->width * xImage->height);
+        std::memcpy(image.pixels.data(), xImage->pixels, (size_t)xImage->width * xImage->height * sizeof(uint32_t));
         image.delay = xImage->delay;
 
         xcursor->images.emplace_back(image);
@@ -570,7 +570,7 @@ void CXCursorManager::syncGsettings() {
         auto* gSettingsSchema = g_settings_schema_source_lookup(gSettingsSchemaSource, category.c_str(), true);
         bool  hasParam        = false;
 
-        if (gSettingsSchema != NULL) {
+        if (gSettingsSchema) {
             hasParam = gSettingsSchema && g_settings_schema_has_key(gSettingsSchema, paramName.c_str());
             g_settings_schema_unref(gSettingsSchema);
         }

--- a/src/managers/eventLoop/EventLoopManager.cpp
+++ b/src/managers/eventLoop/EventLoopManager.cpp
@@ -6,7 +6,7 @@
 #include <limits>
 
 #include <sys/timerfd.h>
-#include <time.h>
+#include <ctime>
 
 #include <aquamarine/backend/Backend.hpp>
 
@@ -95,7 +95,7 @@ void CEventLoopManager::nudgeTimers() {
     // remove timers that have gone missing
     std::erase_if(m_sTimers.timers, [](const auto& t) { return t.strongRef() <= 1; });
 
-    long nextTimerUs = 10 * 1000 * 1000; // 10s
+    long nextTimerUs = 10L * 1000 * 1000; // 10s
 
     for (auto const& t : m_sTimers.timers) {
         if (auto const& µs = t->leftUs(); µs < nextTimerUs)

--- a/src/managers/input/IdleInhibitor.cpp
+++ b/src/managers/input/IdleInhibitor.cpp
@@ -70,5 +70,4 @@ void CInputManager::recheckIdleInhibitorStatus() {
     }
 
     PROTO::idle->setInhibit(false);
-    return;
 }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -868,7 +868,7 @@ void CInputManager::newVirtualKeyboard(SP<CVirtualKeyboardV1Resource> keyboard) 
 void CInputManager::setupKeyboard(SP<IKeyboard> keeb) {
     static auto PDPMS = CConfigValue<Hyprlang::INT>("misc:key_press_enables_dpms");
 
-    m_vHIDs.push_back(keeb);
+    m_vHIDs.emplace_back(keeb);
 
     try {
         keeb->hlName = getNameForNewDevice(keeb->deviceName);
@@ -1016,7 +1016,7 @@ void CInputManager::newMouse(SP<Aquamarine::IPointer> mouse) {
 }
 
 void CInputManager::setupMouse(SP<IPointer> mauz) {
-    m_vHIDs.push_back(mauz);
+    m_vHIDs.emplace_back(mauz);
 
     try {
         mauz->hlName = getNameForNewDevice(mauz->deviceName);
@@ -1495,7 +1495,7 @@ void CInputManager::disableAllKeyboards(bool virt) {
 
 void CInputManager::newTouchDevice(SP<Aquamarine::ITouch> pDevice) {
     const auto PNEWDEV = m_vTouches.emplace_back(CTouchDevice::create(pDevice));
-    m_vHIDs.push_back(PNEWDEV);
+    m_vHIDs.emplace_back(PNEWDEV);
 
     try {
         PNEWDEV->hlName = getNameForNewDevice(PNEWDEV->deviceName);

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -26,12 +26,12 @@ AQUAMARINE_FORWARD(ITablet);
 AQUAMARINE_FORWARD(ITabletTool);
 AQUAMARINE_FORWARD(ITabletPad);
 
-enum eClickBehaviorMode {
+enum eClickBehaviorMode : uint8_t {
     CLICKMODE_DEFAULT = 0,
     CLICKMODE_KILL
 };
 
-enum eMouseBindMode {
+enum eMouseBindMode : int8_t {
     MBIND_INVALID            = -1,
     MBIND_MOVE               = 0,
     MBIND_RESIZE             = 1,
@@ -39,8 +39,8 @@ enum eMouseBindMode {
     MBIND_RESIZE_FORCE_RATIO = 3
 };
 
-enum eBorderIconDirection {
-    BORDERICON_NONE,
+enum eBorderIconDirection : uint8_t {
+    BORDERICON_NONE = 0,
     BORDERICON_UP,
     BORDERICON_DOWN,
     BORDERICON_LEFT,
@@ -276,7 +276,7 @@ class CInputManager {
     void setCursorImageOverride(const std::string& name);
 
     // cursor surface
-    struct cursorSI {
+    struct {
         bool           hidden = false; // null surface = hidden
         SP<CWLSurface> wlSurface;
         Vector2D       vHotspot;
@@ -288,8 +288,8 @@ class CInputManager {
 
     // discrete scrolling emulation using v120 data
     struct {
-        bool     lastEventSign     = 0;
-        bool     lastEventAxis     = 0;
+        bool     lastEventSign     = false;
+        bool     lastEventAxis     = false;
         uint32_t lastEventTime     = 0;
         uint32_t accumulatedScroll = 0;
     } m_ScrollWheelState;

--- a/src/managers/input/Tablets.cpp
+++ b/src/managers/input/Tablets.cpp
@@ -198,7 +198,7 @@ void CInputManager::onTabletProximity(CTablet::SProximityEvent e) {
 
 void CInputManager::newTablet(SP<Aquamarine::ITablet> pDevice) {
     const auto PNEWTABLET = m_vTablets.emplace_back(CTablet::create(pDevice));
-    m_vHIDs.push_back(PNEWTABLET);
+    m_vHIDs.emplace_back(PNEWTABLET);
 
     try {
         PNEWTABLET->hlName = g_pInputManager->getNameForNewDevice(pDevice->getName());
@@ -226,7 +226,7 @@ SP<CTabletTool> CInputManager::ensureTabletToolPresent(SP<Aquamarine::ITabletToo
     }
 
     const auto PTOOL = m_vTabletTools.emplace_back(CTabletTool::create(pTool));
-    m_vHIDs.push_back(PTOOL);
+    m_vHIDs.emplace_back(PTOOL);
 
     try {
         PTOOL->hlName = g_pInputManager->getNameForNewDevice(pTool->getName());
@@ -246,7 +246,7 @@ SP<CTabletTool> CInputManager::ensureTabletToolPresent(SP<Aquamarine::ITabletToo
 
 void CInputManager::newTabletPad(SP<Aquamarine::ITabletPad> pDevice) {
     const auto PNEWPAD = m_vTabletPads.emplace_back(CTabletPad::create(pDevice));
-    m_vHIDs.push_back(PNEWPAD);
+    m_vHIDs.emplace_back(PNEWPAD);
 
     try {
         PNEWPAD->hlName = g_pInputManager->getNameForNewDevice(pDevice->getName());

--- a/src/managers/input/TextInput.cpp
+++ b/src/managers/input/TextInput.cpp
@@ -63,11 +63,10 @@ void CTextInput::onEnabled(SP<CWLSurfaceResource> surfV1) {
 
     // v1 only, map surface to PTI
     if (!isV3()) {
-        SP<CWLSurfaceResource> pSurface = surfV1;
-        if (g_pCompositor->m_pLastFocus != pSurface || !pV1Input->active)
+        if (g_pCompositor->m_pLastFocus != surfV1 || !pV1Input->active)
             return;
 
-        enter(pSurface);
+        enter(surfV1);
     }
 
     g_pInputManager->m_sIMERelay.activateIME(this);

--- a/src/plugins/HookSystem.cpp
+++ b/src/plugins/HookSystem.cpp
@@ -14,10 +14,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-CFunctionHook::CFunctionHook(HANDLE owner, void* source, void* destination) {
-    m_pSource      = source;
-    m_pDestination = destination;
-    m_pOwner       = owner;
+CFunctionHook::CFunctionHook(HANDLE owner, void* source, void* destination) : m_pSource(source), m_pDestination(destination), m_pOwner(owner) {
+    ;
 }
 
 CFunctionHook::~CFunctionHook() {
@@ -88,7 +86,7 @@ CFunctionHook::SAssembly CFunctionHook::fixInstructionProbeRIPCalls(const SInstr
             finalBytes[currentDestinationOffset + i] = *(char*)(currentAddress + i);
         }
 
-        std::string code = probe.assembly.substr(lastAsmNewline, probe.assembly.find("\n", lastAsmNewline) - lastAsmNewline);
+        std::string code = probe.assembly.substr(lastAsmNewline, probe.assembly.find('\n', lastAsmNewline) - lastAsmNewline);
         if (code.contains("%rip")) {
             CVarList    tokens{code, 0, 's'};
             size_t      plusPresent  = tokens[1][0] == '+' ? 1 : 0;
@@ -132,7 +130,7 @@ CFunctionHook::SAssembly CFunctionHook::fixInstructionProbeRIPCalls(const SInstr
             currentDestinationOffset += len;
         }
 
-        lastAsmNewline = probe.assembly.find("\n", lastAsmNewline) + 1;
+        lastAsmNewline = probe.assembly.find('\n', lastAsmNewline) + 1;
         currentAddress += len;
     }
 

--- a/src/plugins/PluginAPI.cpp
+++ b/src/plugins/PluginAPI.cpp
@@ -320,7 +320,7 @@ APICALL std::vector<SFunctionMatch> HyprlandAPI::findFunctionsByName(HANDLE hand
     };
 
     if (SYMBOLS.empty()) {
-        Debug::log(ERR, "Unable to search for function \"{}\": no symbols found in binary (is \"{}\" in path?)", name,
+        Debug::log(ERR, R"(Unable to search for function "{}": no symbols found in binary (is "{}" in path?))", name,
 #ifdef __clang__
                    "llvm-nm"
 #else

--- a/src/plugins/PluginAPI.hpp
+++ b/src/plugins/PluginAPI.hpp
@@ -104,6 +104,7 @@ typedef OPTIONAL void (*PPLUGIN_EXIT_FUNC)(void);
     End plugin methods
 */
 
+// NOLINTNEXTLINE(readability-identifier-naming)
 namespace HyprlandAPI {
 
     /*

--- a/src/plugins/PluginAPI.hpp
+++ b/src/plugins/PluginAPI.hpp
@@ -96,7 +96,7 @@ typedef REQUIRED PLUGIN_DESCRIPTION_INFO (*PPLUGIN_INIT_FUNC)(HANDLE);
 
     Hooks are unloaded after exit.
 */
-typedef OPTIONAL void (*PPLUGIN_EXIT_FUNC)(void);
+typedef OPTIONAL void (*PPLUGIN_EXIT_FUNC)();
 #define PLUGIN_EXIT          pluginExit
 #define PLUGIN_EXIT_FUNC_STR "pluginExit"
 
@@ -291,6 +291,7 @@ namespace HyprlandAPI {
     APICALL bool unregisterHyprCtlCommand(HANDLE handle, SP<SHyprCtlCommand> cmd);
 };
 
+// NOLINTBEGIN
 /*
     Get the hash this plugin/server was compiled with.
 
@@ -304,3 +305,4 @@ APICALL EXPORT const char*        __hyprland_api_get_hash();
 APICALL inline EXPORT const char* __hyprland_api_get_client_hash() {
     return GIT_COMMIT_HASH;
 }
+// NOLINTEND

--- a/src/plugins/PluginSystem.cpp
+++ b/src/plugins/PluginSystem.cpp
@@ -201,7 +201,7 @@ size_t CPluginSystem::pluginCount() {
     return m_vLoadedPlugins.size();
 }
 
-void CPluginSystem::sig_getPlugins(CPlugin** data, size_t len) {
+void CPluginSystem::sigGetPlugins(CPlugin** data, size_t len) {
     for (size_t i = 0; i < std::min(m_vLoadedPlugins.size(), len); i++) {
         data[i] = m_vLoadedPlugins[i].get();
     }

--- a/src/plugins/PluginSystem.cpp
+++ b/src/plugins/PluginSystem.cpp
@@ -82,7 +82,7 @@ CPlugin* CPluginSystem::loadPlugin(const std::string& path) {
 
     g_pConfigManager->m_bForceReload = true;
 
-    Debug::log(LOG, " [PluginSystem] Plugin {} loaded. Handle: {:x}, path: \"{}\", author: \"{}\", description: \"{}\", version: \"{}\"", PLUGINDATA.name, (uintptr_t)MODULE, path,
+    Debug::log(LOG, R"( [PluginSystem] Plugin {} loaded. Handle: {:x}, path: "{}", author: "{}", description: "{}", version: "{}")", PLUGINDATA.name, (uintptr_t)MODULE, path,
                PLUGINDATA.author, PLUGINDATA.description, PLUGINDATA.version);
 
     return PLUGIN;

--- a/src/plugins/PluginSystem.hpp
+++ b/src/plugins/PluginSystem.hpp
@@ -38,7 +38,7 @@ class CPluginSystem {
     CPlugin*                 getPluginByHandle(HANDLE handle);
     std::vector<CPlugin*>    getAllPlugins();
     size_t                   pluginCount();
-    void                     sig_getPlugins(CPlugin** data, size_t len);
+    void                     sigGetPlugins(CPlugin** data, size_t len);
 
     bool                     m_bAllowConfigVars = false;
     std::string              m_szLastError      = "";

--- a/src/protocols/DataDeviceWlr.cpp
+++ b/src/protocols/DataDeviceWlr.cpp
@@ -57,7 +57,7 @@ CWLRDataSource::CWLRDataSource(SP<CZwlrDataControlSourceV1> resource_, SP<CWLRDa
         PROTO::dataWlr->destroyResource(this);
     });
 
-    resource->setOffer([this](CZwlrDataControlSourceV1* r, const char* mime) { mimeTypes.push_back(mime); });
+    resource->setOffer([this](CZwlrDataControlSourceV1* r, const char* mime) { mimeTypes.emplace_back(mime); });
 }
 
 CWLRDataSource::~CWLRDataSource() {
@@ -219,7 +219,7 @@ CWLRDataControlManagerResource::CWLRDataControlManagerResource(SP<CZwlrDataContr
 
         RESOURCE->self = RESOURCE;
 
-        sources.push_back(RESOURCE);
+        sources.emplace_back(RESOURCE);
 
         LOGM(LOG, "New wlr data source bound at {:x}", (uintptr_t)RESOURCE.get());
     });

--- a/src/protocols/LayerShell.hpp
+++ b/src/protocols/LayerShell.hpp
@@ -33,7 +33,7 @@ class CLayerShellResource {
     void configure(const Vector2D& size);
     void sendClosed();
 
-    enum eCommittedState {
+    enum eCommittedState : uint8_t {
         STATE_SIZE          = (1 << 0),
         STATE_ANCHOR        = (1 << 1),
         STATE_EXCLUSIVE     = (1 << 2),

--- a/src/protocols/LinuxDMABUF.cpp
+++ b/src/protocols/LinuxDMABUF.cpp
@@ -219,7 +219,7 @@ void CLinuxDMABBUFParamsResource::create(uint32_t id) {
         return;
     }
 
-    LOGM(LOG, "Creating a dmabuf, with id {}: size {}, fmt {}, planes {}", id, attrs->size, FormatUtils::drmFormatName(attrs->format), attrs->planes);
+    LOGM(LOG, "Creating a dmabuf, with id {}: size {}, fmt {}, planes {}", id, attrs->size, NFormatUtils::drmFormatName(attrs->format), attrs->planes);
     for (int i = 0; i < attrs->planes; ++i) {
         LOGM(LOG, " | plane {}: mod {} fd {} stride {} offset {}", i, attrs->modifier, attrs->fds[i], attrs->strides[i], attrs->offsets[i]);
     }

--- a/src/protocols/LinuxDMABUF.cpp
+++ b/src/protocols/LinuxDMABUF.cpp
@@ -448,7 +448,7 @@ CLinuxDMABufV1Protocol::CLinuxDMABufV1Protocol(const wl_interface* iface, const 
                     .flags   = ZWP_LINUX_DMABUF_FEEDBACK_V1_TRANCHE_FLAGS_SCANOUT,
                     .formats = mon->output->getRenderFormats(),
                 };
-                tches.push_back(std::make_pair<>(mon, tranche));
+                tches.emplace_back(std::make_pair<>(mon, tranche));
             }
 
             static auto monitorAdded = g_pHookSystem->hookDynamic("monitorAdded", [this](void* self, SCallbackInfo& info, std::any param) {
@@ -458,7 +458,7 @@ CLinuxDMABufV1Protocol::CLinuxDMABufV1Protocol(const wl_interface* iface, const 
                      .flags   = ZWP_LINUX_DMABUF_FEEDBACK_V1_TRANCHE_FLAGS_SCANOUT,
                      .formats = pMonitor->output->getRenderFormats(),
                 };
-                formatTable->monitorTranches.push_back(std::make_pair<>(pMonitor, tranche));
+                formatTable->monitorTranches.emplace_back(std::make_pair<>(pMonitor, tranche));
                 resetFormatTable();
             });
 

--- a/src/protocols/OutputManagement.cpp
+++ b/src/protocols/OutputManagement.cpp
@@ -57,7 +57,7 @@ void COutputManager::makeAndSendNewHead(PHLMONITOR pMonitor) {
         return;
     }
 
-    heads.push_back(RESOURCE);
+    heads.emplace_back(RESOURCE);
 
     resource->sendHead(RESOURCE->resource.get());
     RESOURCE->sendAllData();
@@ -216,7 +216,7 @@ void COutputHead::makeAndSendNewMode(SP<Aquamarine::SOutputMode> mode) {
         return;
     }
 
-    modes.push_back(RESOURCE);
+    modes.emplace_back(RESOURCE);
     resource->sendMode(RESOURCE->resource.get());
     RESOURCE->sendAllData();
 }
@@ -285,7 +285,7 @@ COutputConfiguration::COutputConfiguration(SP<CZwlrOutputConfigurationV1> resour
             return;
         }
 
-        heads.push_back(RESOURCE);
+        heads.emplace_back(RESOURCE);
 
         LOGM(LOG, "enableHead on {}. For now, doing nothing. Waiting for apply().", PMONITOR->szName);
     });

--- a/src/protocols/PointerConstraints.cpp
+++ b/src/protocols/PointerConstraints.cpp
@@ -45,7 +45,7 @@ CPointerConstraint::CPointerConstraint(SP<CZwpLockedPointerV1> resource_, SP<CWL
 }
 
 CPointerConstraint::CPointerConstraint(SP<CZwpConfinedPointerV1> resource_, SP<CWLSurfaceResource> surf, wl_resource* region_, zwpPointerConstraintsV1Lifetime lifetime_) :
-    resourceC(resource_), locked(false), lifetime(lifetime_) {
+    resourceC(resource_), lifetime(lifetime_) {
     if (!resource_->resource())
         return;
 
@@ -240,7 +240,7 @@ void CPointerConstraintsProtocol::onNewConstraint(SP<CPointerConstraint> constra
 
     OWNER->appendConstraint(constraint);
 
-    g_pInputManager->m_vConstraints.push_back(constraint);
+    g_pInputManager->m_vConstraints.emplace_back(constraint);
 }
 
 void CPointerConstraintsProtocol::onLockPointer(CZwpPointerConstraintsV1* pMgr, uint32_t id, wl_resource* surface, wl_resource* pointer, wl_resource* region,

--- a/src/protocols/PointerConstraints.hpp
+++ b/src/protocols/PointerConstraints.hpp
@@ -8,7 +8,6 @@
 #include "WaylandProtocol.hpp"
 #include "pointer-constraints-unstable-v1.hpp"
 #include "../helpers/math/Math.hpp"
-#include "../helpers/math/Math.hpp"
 #include "../helpers/signal/Signal.hpp"
 
 class CWLSurface;

--- a/src/protocols/PrimarySelection.cpp
+++ b/src/protocols/PrimarySelection.cpp
@@ -58,7 +58,7 @@ CPrimarySelectionSource::CPrimarySelectionSource(SP<CZwpPrimarySelectionSourceV1
         PROTO::primarySelection->destroyResource(this);
     });
 
-    resource->setOffer([this](CZwpPrimarySelectionSourceV1* r, const char* mime) { mimeTypes.push_back(mime); });
+    resource->setOffer([this](CZwpPrimarySelectionSourceV1* r, const char* mime) { mimeTypes.emplace_back(mime); });
 }
 
 CPrimarySelectionSource::~CPrimarySelectionSource() {
@@ -203,7 +203,7 @@ CPrimarySelectionManager::CPrimarySelectionManager(SP<CZwpPrimarySelectionDevice
 
         RESOURCE->self = RESOURCE;
 
-        sources.push_back(RESOURCE);
+        sources.emplace_back(RESOURCE);
 
         LOGM(LOG, "New primary selection data source bound at {:x}", (uintptr_t)RESOURCE.get());
     });

--- a/src/protocols/Screencopy.cpp
+++ b/src/protocols/Screencopy.cpp
@@ -50,7 +50,7 @@ CScreencopyFrame::CScreencopyFrame(SP<CZwlrScreencopyFrameV1> resource_, int32_t
     if (shmFormat == DRM_FORMAT_XRGB2101010 || shmFormat == DRM_FORMAT_ARGB2101010)
         shmFormat = DRM_FORMAT_XBGR2101010;
 
-    const auto PSHMINFO = FormatUtils::getPixelFormatFromDRM(shmFormat);
+    const auto PSHMINFO = NFormatUtils::getPixelFormatFromDRM(shmFormat);
     if (!PSHMINFO) {
         LOGM(ERR, "No pixel format supported by renderer in capture output");
         resource->sendFailed();
@@ -68,9 +68,9 @@ CScreencopyFrame::CScreencopyFrame(SP<CZwlrScreencopyFrameV1> resource_, int32_t
 
     box.transform(wlTransformToHyprutils(pMonitor->transform), pMonitor->vecTransformedSize.x, pMonitor->vecTransformedSize.y).scale(pMonitor->scale).round();
 
-    shmStride = FormatUtils::minStride(PSHMINFO, box.w);
+    shmStride = NFormatUtils::minStride(PSHMINFO, box.w);
 
-    resource->sendBuffer(FormatUtils::drmToShm(shmFormat), box.width, box.height, shmStride);
+    resource->sendBuffer(NFormatUtils::drmToShm(shmFormat), box.width, box.height, shmStride);
 
     if (resource->version() >= 3) {
         if (dmabufFormat != DRM_FORMAT_INVALID) {
@@ -258,7 +258,7 @@ bool CScreencopyFrame::copyShm() {
     glBindFramebuffer(GL_FRAMEBUFFER, fb.getFBID());
 #endif
 
-    const auto PFORMAT = FormatUtils::getPixelFormatFromDRM(shm.format);
+    const auto PFORMAT = NFormatUtils::getPixelFormatFromDRM(shm.format);
     if (!PFORMAT) {
         LOGM(ERR, "Can't copy: failed to find a pixel format");
         g_pHyprRenderer->endRender();
@@ -276,8 +276,8 @@ bool CScreencopyFrame::copyShm() {
 
     glPixelStorei(GL_PACK_ALIGNMENT, 1);
 
-    const auto drmFmt     = FormatUtils::getPixelFormatFromDRM(shm.format);
-    uint32_t   packStride = FormatUtils::minStride(drmFmt, box.w);
+    const auto drmFmt     = NFormatUtils::getPixelFormatFromDRM(shm.format);
+    uint32_t   packStride = NFormatUtils::minStride(drmFmt, box.w);
 
     if (packStride == (uint32_t)shm.stride) {
         glReadPixels(0, 0, box.w, box.h, glFormat, PFORMAT->glType, pixelData);

--- a/src/protocols/SecurityContext.cpp
+++ b/src/protocols/SecurityContext.cpp
@@ -22,8 +22,8 @@ SP<CSecurityContextSandboxedClient> CSecurityContextSandboxedClient::create(int 
 }
 
 static void onSecurityContextClientDestroy(wl_listener* l, void* d) {
-    CSecurityContextSandboxedClientDestroyWrapper* wrap   = wl_container_of(l, wrap, listener);
-    CSecurityContextSandboxedClient*               client = wrap->parent;
+    SCSecurityContextSandboxedClientDestroyWrapper* wrap   = wl_container_of(l, wrap, listener);
+    CSecurityContextSandboxedClient*                client = wrap->parent;
     client->onDestroy();
 }
 

--- a/src/protocols/SecurityContext.hpp
+++ b/src/protocols/SecurityContext.hpp
@@ -38,7 +38,7 @@ class CSecurityContextManagerResource {
 };
 
 class CSecurityContextSandboxedClient;
-struct CSecurityContextSandboxedClientDestroyWrapper {
+struct SCSecurityContextSandboxedClientDestroyWrapper {
     wl_listener                      listener;
     CSecurityContextSandboxedClient* parent = nullptr;
 };
@@ -48,9 +48,9 @@ class CSecurityContextSandboxedClient {
     static SP<CSecurityContextSandboxedClient> create(int clientFD);
     ~CSecurityContextSandboxedClient();
 
-    void                                          onDestroy();
+    void                                           onDestroy();
 
-    CSecurityContextSandboxedClientDestroyWrapper destroyListener;
+    SCSecurityContextSandboxedClientDestroyWrapper destroyListener;
 
   private:
     CSecurityContextSandboxedClient(int clientFD_);

--- a/src/protocols/Tablet.cpp
+++ b/src/protocols/Tablet.cpp
@@ -251,7 +251,7 @@ void CTabletSeat::sendTool(SP<CTabletTool> tool) {
     resource->sendToolAdded(RESOURCE->resource.get());
 
     RESOURCE->sendData();
-    tools.push_back(RESOURCE);
+    tools.emplace_back(RESOURCE);
 }
 
 void CTabletSeat::sendPad(SP<CTabletPad> pad) {
@@ -267,7 +267,7 @@ void CTabletSeat::sendPad(SP<CTabletPad> pad) {
     resource->sendPadAdded(RESOURCE->resource.get());
 
     RESOURCE->sendData();
-    pads.push_back(RESOURCE);
+    pads.emplace_back(RESOURCE);
 }
 
 void CTabletSeat::sendTablet(SP<CTablet> tablet) {
@@ -283,7 +283,7 @@ void CTabletSeat::sendTablet(SP<CTablet> tablet) {
     resource->sendTabletAdded(RESOURCE->resource.get());
 
     RESOURCE->sendData();
-    tablets.push_back(RESOURCE);
+    tablets.emplace_back(RESOURCE);
 }
 
 void CTabletSeat::sendData() {
@@ -371,7 +371,7 @@ void CTabletV2Protocol::registerDevice(SP<CTablet> tablet) {
         s->sendTablet(tablet);
     }
 
-    tablets.push_back(tablet);
+    tablets.emplace_back(tablet);
 }
 
 void CTabletV2Protocol::registerDevice(SP<CTabletTool> tool) {
@@ -379,7 +379,7 @@ void CTabletV2Protocol::registerDevice(SP<CTabletTool> tool) {
         s->sendTool(tool);
     }
 
-    tools.push_back(tool);
+    tools.emplace_back(tool);
 }
 
 void CTabletV2Protocol::registerDevice(SP<CTabletPad> pad) {
@@ -387,7 +387,7 @@ void CTabletV2Protocol::registerDevice(SP<CTabletPad> pad) {
         s->sendPad(pad);
     }
 
-    pads.push_back(pad);
+    pads.emplace_back(pad);
 }
 
 void CTabletV2Protocol::unregisterDevice(SP<CTablet> tablet) {

--- a/src/protocols/TextInputV1.cpp
+++ b/src/protocols/TextInputV1.cpp
@@ -50,10 +50,10 @@ CTextInputV1::CTextInputV1(SP<CZwpTextInputV1> resource_) : resource(resource_) 
     });
 
     // nothing
-    resource->setShowInputPanel([this](CZwpTextInputV1* pMgr) {});
-    resource->setHideInputPanel([this](CZwpTextInputV1* pMgr) {});
-    resource->setSetPreferredLanguage([this](CZwpTextInputV1* pMgr, const char* language) {});
-    resource->setInvokeAction([this](CZwpTextInputV1* pMgr, uint32_t button, uint32_t index) {});
+    resource->setShowInputPanel([](CZwpTextInputV1* pMgr) {});
+    resource->setHideInputPanel([](CZwpTextInputV1* pMgr) {});
+    resource->setSetPreferredLanguage([](CZwpTextInputV1* pMgr, const char* language) {});
+    resource->setInvokeAction([](CZwpTextInputV1* pMgr, uint32_t button, uint32_t index) {});
 }
 
 bool CTextInputV1::good() {
@@ -101,7 +101,7 @@ CTextInputV1Protocol::CTextInputV1Protocol(const wl_interface* iface, const int&
 void CTextInputV1Protocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
     const auto RESOURCE = m_vManagers.emplace_back(makeShared<CZwpTextInputManagerV1>(client, ver, id));
 
-    RESOURCE->setOnDestroy([this](CZwpTextInputManagerV1* pMgr) { PROTO::textInputV1->destroyResource(pMgr); });
+    RESOURCE->setOnDestroy([](CZwpTextInputManagerV1* pMgr) { PROTO::textInputV1->destroyResource(pMgr); });
     RESOURCE->setCreateTextInput([this](CZwpTextInputManagerV1* pMgr, uint32_t id) {
         const auto PTI = m_vClients.emplace_back(makeShared<CTextInputV1>(makeShared<CZwpTextInputV1>(pMgr->client(), pMgr->version(), id)));
         LOGM(LOG, "New TI V1 at {:x}", (uintptr_t)PTI.get());

--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -109,7 +109,7 @@ CToplevelExportFrame::CToplevelExportFrame(SP<CHyprlandToplevelExportFrameV1> re
         return;
     }
 
-    const auto PSHMINFO = FormatUtils::getPixelFormatFromDRM(shmFormat);
+    const auto PSHMINFO = NFormatUtils::getPixelFormatFromDRM(shmFormat);
     if (!PSHMINFO) {
         LOGM(ERR, "No pixel format supported by renderer in capture toplevel");
         resource->sendFailed();
@@ -123,9 +123,9 @@ CToplevelExportFrame::CToplevelExportFrame(SP<CHyprlandToplevelExportFrameV1> re
 
     box.transform(wlTransformToHyprutils(PMONITOR->transform), PMONITOR->vecTransformedSize.x, PMONITOR->vecTransformedSize.y).round();
 
-    shmStride = FormatUtils::minStride(PSHMINFO, box.w);
+    shmStride = NFormatUtils::minStride(PSHMINFO, box.w);
 
-    resource->sendBuffer(FormatUtils::drmToShm(shmFormat), box.width, box.height, shmStride);
+    resource->sendBuffer(NFormatUtils::drmToShm(shmFormat), box.width, box.height, shmStride);
 
     if (dmabufFormat != DRM_FORMAT_INVALID) {
         resource->sendLinuxDmabuf(dmabufFormat, box.width, box.height);
@@ -265,7 +265,7 @@ bool CToplevelExportFrame::copyShm(timespec* now) {
     if (overlayCursor)
         g_pPointerManager->renderSoftwareCursorsFor(PMONITOR->self.lock(), now, fakeDamage, g_pInputManager->getMouseCoordsInternal() - pWindow->m_vRealPosition.value());
 
-    const auto PFORMAT = FormatUtils::getPixelFormatFromDRM(shm.format);
+    const auto PFORMAT = NFormatUtils::getPixelFormatFromDRM(shm.format);
     if (!PFORMAT) {
         g_pHyprRenderer->endRender();
         return false;

--- a/src/protocols/ToplevelExport.hpp
+++ b/src/protocols/ToplevelExport.hpp
@@ -5,7 +5,6 @@
 #include "WaylandProtocol.hpp"
 #include "Screencopy.hpp"
 
-#include <list>
 #include <vector>
 
 class CMonitor;

--- a/src/protocols/WaylandProtocol.cpp
+++ b/src/protocols/WaylandProtocol.cpp
@@ -6,8 +6,8 @@ static void bindManagerInternal(wl_client* client, void* data, uint32_t ver, uin
 }
 
 static void displayDestroyInternal(struct wl_listener* listener, void* data) {
-    IWaylandProtocolDestroyWrapper* wrap  = wl_container_of(listener, wrap, listener);
-    IWaylandProtocol*               proto = wrap->parent;
+    SIWaylandProtocolDestroyWrapper* wrap  = wl_container_of(listener, wrap, listener);
+    IWaylandProtocol*                proto = wrap->parent;
     proto->onDisplayDestroy();
 }
 
@@ -17,8 +17,8 @@ void IWaylandProtocol::onDisplayDestroy() {
     wl_global_destroy(m_pGlobal);
 }
 
-IWaylandProtocol::IWaylandProtocol(const wl_interface* iface, const int& ver, const std::string& name) : m_szName(name) {
-    m_pGlobal = wl_global_create(g_pCompositor->m_sWLDisplay, iface, ver, this, &bindManagerInternal);
+IWaylandProtocol::IWaylandProtocol(const wl_interface* iface, const int& ver, const std::string& name) :
+    m_szName(name), m_pGlobal(wl_global_create(g_pCompositor->m_sWLDisplay, iface, ver, this, &bindManagerInternal)) {
 
     if (!m_pGlobal) {
         LOGM(ERR, "could not create a global [{}]", m_szName);

--- a/src/protocols/WaylandProtocol.hpp
+++ b/src/protocols/WaylandProtocol.hpp
@@ -41,7 +41,7 @@
     } while (0)
 
 class IWaylandProtocol;
-struct IWaylandProtocolDestroyWrapper {
+struct SIWaylandProtocolDestroyWrapper {
     wl_listener       listener;
     IWaylandProtocol* parent = nullptr;
 };
@@ -51,13 +51,13 @@ class IWaylandProtocol {
     IWaylandProtocol(const wl_interface* iface, const int& ver, const std::string& name);
     virtual ~IWaylandProtocol();
 
-    virtual void                   onDisplayDestroy();
-    virtual void                   removeGlobal();
-    virtual wl_global*             getGlobal();
+    virtual void                    onDisplayDestroy();
+    virtual void                    removeGlobal();
+    virtual wl_global*              getGlobal();
 
-    virtual void                   bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) = 0;
+    virtual void                    bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) = 0;
 
-    IWaylandProtocolDestroyWrapper m_liDisplayDestroy;
+    SIWaylandProtocolDestroyWrapper m_liDisplayDestroy;
 
   private:
     std::string m_szName;

--- a/src/protocols/XDGDialog.cpp
+++ b/src/protocols/XDGDialog.cpp
@@ -44,7 +44,7 @@ CXDGWmDialogManagerResource::CXDGWmDialogManagerResource(SP<CXdgWmDialogV1> reso
     resource->setDestroy([this](CXdgWmDialogV1* r) { PROTO::xdgDialog->destroyResource(this); });
     resource->setOnDestroy([this](CXdgWmDialogV1* r) { PROTO::xdgDialog->destroyResource(this); });
 
-    resource->setGetXdgDialog([this](CXdgWmDialogV1* r, uint32_t id, wl_resource* toplevel) {
+    resource->setGetXdgDialog([](CXdgWmDialogV1* r, uint32_t id, wl_resource* toplevel) {
         auto tl = CXDGToplevelResource::fromResource(toplevel);
         if (!tl) {
             r->error(-1, "Toplevel inert");

--- a/src/protocols/XDGShell.cpp
+++ b/src/protocols/XDGShell.cpp
@@ -551,8 +551,8 @@ bool CXDGPositionerResource::good() {
     return resource->resource();
 }
 
-CXDGPositionerRules::CXDGPositionerRules(SP<CXDGPositionerResource> positioner) {
-    state = positioner->state;
+CXDGPositionerRules::CXDGPositionerRules(SP<CXDGPositionerResource> positioner) : state(positioner->state) {
+    ;
 }
 
 CBox CXDGPositionerRules::getPosition(CBox constraint, const Vector2D& parentCoord) {

--- a/src/protocols/XWaylandShell.cpp
+++ b/src/protocols/XWaylandShell.cpp
@@ -42,7 +42,7 @@ CXWaylandShellResource::CXWaylandShellResource(SP<CXwaylandShellV1> resource_) :
     resource->setDestroy([this](CXwaylandShellV1* r) { PROTO::xwaylandShell->destroyResource(this); });
     resource->setOnDestroy([this](CXwaylandShellV1* r) { PROTO::xwaylandShell->destroyResource(this); });
 
-    resource->setGetXwaylandSurface([this](CXwaylandShellV1* r, uint32_t id, wl_resource* surface) {
+    resource->setGetXwaylandSurface([](CXwaylandShellV1* r, uint32_t id, wl_resource* surface) {
         const auto RESOURCE = PROTO::xwaylandShell->m_vSurfaces.emplace_back(
             makeShared<CXWaylandSurfaceResource>(makeShared<CXwaylandSurfaceV1>(r->client(), r->version(), id), CWLSurfaceResource::fromResource(surface)));
 

--- a/src/protocols/core/DataDevice.cpp
+++ b/src/protocols/core/DataDevice.cpp
@@ -119,7 +119,7 @@ CWLDataSourceResource::CWLDataSourceResource(SP<CWlDataSource> resource_, SP<CWL
         PROTO::data->destroyResource(this);
     });
 
-    resource->setOffer([this](CWlDataSource* r, const char* mime) { mimeTypes.push_back(mime); });
+    resource->setOffer([this](CWlDataSource* r, const char* mime) { mimeTypes.emplace_back(mime); });
     resource->setSetActions([this](CWlDataSource* r, uint32_t a) {
         LOGM(LOG, "DataSource {:x} actions {}", (uintptr_t)this, a);
         supportedActions = a;
@@ -311,7 +311,7 @@ CWLDataDeviceManagerResource::CWLDataDeviceManagerResource(SP<CWlDataDeviceManag
 
         RESOURCE->self = RESOURCE;
 
-        sources.push_back(RESOURCE);
+        sources.emplace_back(RESOURCE);
 
         LOGM(LOG, "New data source bound at {:x}", (uintptr_t)RESOURCE.get());
     });

--- a/src/protocols/core/Seat.cpp
+++ b/src/protocols/core/Seat.cpp
@@ -442,7 +442,7 @@ CWLSeatResource::CWLSeatResource(SP<CWlSeat> resource_) : resource(resource_) {
             return;
         }
 
-        keyboards.push_back(RESOURCE);
+        keyboards.emplace_back(RESOURCE);
     });
 
     resource->setGetPointer([this](CWlSeat* r, uint32_t id) {
@@ -454,7 +454,7 @@ CWLSeatResource::CWLSeatResource(SP<CWlSeat> resource_) : resource(resource_) {
             return;
         }
 
-        pointers.push_back(RESOURCE);
+        pointers.emplace_back(RESOURCE);
     });
 
     resource->setGetTouch([this](CWlSeat* r, uint32_t id) {
@@ -466,7 +466,7 @@ CWLSeatResource::CWLSeatResource(SP<CWlSeat> resource_) : resource(resource_) {
             return;
         }
 
-        touches.push_back(RESOURCE);
+        touches.emplace_back(RESOURCE);
     });
 
     if (resource->version() >= 2)

--- a/src/protocols/core/Shm.cpp
+++ b/src/protocols/core/Shm.cpp
@@ -19,9 +19,9 @@ CWLSHMBuffer::CWLSHMBuffer(SP<CWLSHMPoolResource> pool_, uint32_t id, int32_t of
     stride = stride_;
     fmt    = fmt_;
     offset = offset_;
-    opaque = FormatUtils::isFormatOpaque(FormatUtils::shmToDRM(fmt_));
+    opaque = NFormatUtils::isFormatOpaque(NFormatUtils::shmToDRM(fmt_));
 
-    texture = makeShared<CTexture>(FormatUtils::shmToDRM(fmt), (uint8_t*)pool->data + offset, stride, size_);
+    texture = makeShared<CTexture>(NFormatUtils::shmToDRM(fmt), (uint8_t*)pool->data + offset, stride, size_);
 
     resource = CWLBufferResource::create(makeShared<CWlBuffer>(pool_->resource->client(), 1, id));
 
@@ -56,7 +56,7 @@ Aquamarine::SSHMAttrs CWLSHMBuffer::shm() {
     Aquamarine::SSHMAttrs attrs;
     attrs.success = true;
     attrs.fd      = pool->fd;
-    attrs.format  = FormatUtils::shmToDRM(fmt);
+    attrs.format  = NFormatUtils::shmToDRM(fmt);
     attrs.size    = size;
     attrs.stride  = stride;
     attrs.offset  = offset;
@@ -76,7 +76,7 @@ bool CWLSHMBuffer::good() {
 }
 
 void CWLSHMBuffer::update(const CRegion& damage) {
-    texture->update(FormatUtils::shmToDRM(fmt), (uint8_t*)pool->data + offset, stride, damage);
+    texture->update(NFormatUtils::shmToDRM(fmt), (uint8_t*)pool->data + offset, stride, damage);
 }
 
 CSHMPool::CSHMPool(int fd_, size_t size_) : fd(fd_), size(size_) {

--- a/src/protocols/core/Shm.cpp
+++ b/src/protocols/core/Shm.cpp
@@ -79,8 +79,8 @@ void CWLSHMBuffer::update(const CRegion& damage) {
     texture->update(NFormatUtils::shmToDRM(fmt), (uint8_t*)pool->data + offset, stride, damage);
 }
 
-CSHMPool::CSHMPool(int fd_, size_t size_) : fd(fd_), size(size_) {
-    data = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+CSHMPool::CSHMPool(int fd_, size_t size_) : fd(fd_), size(size_), data(mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0)) {
+    ;
 }
 
 CSHMPool::~CSHMPool() {

--- a/src/protocols/types/DMABuffer.cpp
+++ b/src/protocols/types/DMABuffer.cpp
@@ -27,7 +27,7 @@ CDMABuffer::CDMABuffer(uint32_t id, wl_client* client, Aquamarine::SDMABUFAttrs 
     }
 
     texture = makeShared<CTexture>(attrs, eglImage); // texture takes ownership of the eglImage
-    opaque  = FormatUtils::isFormatOpaque(attrs.format);
+    opaque  = NFormatUtils::isFormatOpaque(attrs.format);
     success = texture->m_iTexID;
 
     if (!success)

--- a/src/protocols/types/DataDevice.hpp
+++ b/src/protocols/types/DataDevice.hpp
@@ -5,15 +5,15 @@
 #include <cstdint>
 #include "../../helpers/signal/Signal.hpp"
 
-enum eDataSourceType {
+enum eDataSourceType : uint8_t {
     DATA_SOURCE_TYPE_WAYLAND = 0,
     DATA_SOURCE_TYPE_X11,
 };
 
 class IDataSource {
   public:
-    IDataSource() {}
-    virtual ~IDataSource() {}
+    IDataSource()          = default;
+    virtual ~IDataSource() = default;
 
     virtual std::vector<std::string> mimes()                                    = 0;
     virtual void                     send(const std::string& mime, uint32_t fd) = 0;

--- a/src/protocols/types/SurfaceRole.hpp
+++ b/src/protocols/types/SurfaceRole.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-enum eSurfaceRole {
+enum eSurfaceRole : uint8_t {
     SURFACE_ROLE_UNASSIGNED = 0,
     SURFACE_ROLE_XDG_SHELL,
     SURFACE_ROLE_LAYER_SHELL,

--- a/src/render/Framebuffer.cpp
+++ b/src/render/Framebuffer.cpp
@@ -9,8 +9,8 @@ bool CFramebuffer::alloc(int w, int h, uint32_t drmFormat) {
     bool firstAlloc = false;
     RASSERT((w > 1 && h > 1), "cannot alloc a FB with negative / zero size! (attempted {}x{})", w, h);
 
-    uint32_t glFormat = FormatUtils::drmFormatToGL(drmFormat);
-    uint32_t glType   = FormatUtils::glFormatToType(glFormat);
+    uint32_t glFormat = NFormatUtils::drmFormatToGL(drmFormat);
+    uint32_t glType   = NFormatUtils::glFormatToType(glFormat);
 
     if (!m_cTex)
         m_cTex = makeShared<CTexture>();

--- a/src/render/Framebuffer.cpp
+++ b/src/render/Framebuffer.cpp
@@ -33,7 +33,7 @@ bool CFramebuffer::alloc(int w, int h, uint32_t drmFormat) {
 
     if (firstAlloc || m_vSize != Vector2D(w, h)) {
         glBindTexture(GL_TEXTURE_2D, m_cTex->m_iTexID);
-        glTexImage2D(GL_TEXTURE_2D, 0, glFormat, w, h, 0, GL_RGBA, glType, 0);
+        glTexImage2D(GL_TEXTURE_2D, 0, glFormat, w, h, 0, GL_RGBA, glType, nullptr);
 
         glBindFramebuffer(GL_FRAMEBUFFER, m_iFb);
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_cTex->m_iTexID, 0);
@@ -42,7 +42,7 @@ bool CFramebuffer::alloc(int w, int h, uint32_t drmFormat) {
 #ifndef GLES2
         if (m_pStencilTex) {
             glBindTexture(GL_TEXTURE_2D, m_pStencilTex->m_iTexID);
-            glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH24_STENCIL8, w, h, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, 0);
+            glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH24_STENCIL8, w, h, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, nullptr);
 
             glBindFramebuffer(GL_FRAMEBUFFER, m_iFb);
 
@@ -70,7 +70,7 @@ void CFramebuffer::addStencil(SP<CTexture> tex) {
 #ifndef GLES2
     m_pStencilTex = tex;
     glBindTexture(GL_TEXTURE_2D, m_pStencilTex->m_iTexID);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH24_STENCIL8, m_vSize.x, m_vSize.y, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, 0);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH24_STENCIL8, m_vSize.x, m_vSize.y, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, nullptr);
 
     glBindFramebuffer(GL_FRAMEBUFFER, m_iFb);
 

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -30,7 +30,7 @@ inline void loadGLProc(void* pProc, const char* name) {
     *(void**)pProc = proc;
 }
 
-static enum LogLevel eglLogToLevel(EGLint type) {
+static enum eLogLevel eglLogToLevel(EGLint type) {
     switch (type) {
         case EGL_DEBUG_MSG_CRITICAL_KHR: return CRIT;
         case EGL_DEBUG_MSG_ERROR_KHR: return ERR;

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -23,7 +23,7 @@ const std::vector<const char*> ASSET_PATHS = {
 
 inline void loadGLProc(void* pProc, const char* name) {
     void* proc = (void*)eglGetProcAddress(name);
-    if (proc == NULL) {
+    if (proc == nullptr) {
         Debug::log(CRIT, "[Tracy GPU Profiling] eglGetProcAddress({}) failed", name);
         abort();
     }
@@ -238,12 +238,10 @@ EGLDeviceEXT CHyprOpenGLImpl::eglDeviceFromDRMFD(int drmFD) {
     return EGL_NO_DEVICE_EXT;
 }
 
-CHyprOpenGLImpl::CHyprOpenGLImpl() {
+CHyprOpenGLImpl::CHyprOpenGLImpl() : m_iDRMFD(g_pCompositor->m_iDRMFD) {
     const std::string EGLEXTENSIONS = (const char*)eglQueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS);
 
     Debug::log(LOG, "Supported EGL extensions: ({}) {}", std::count(EGLEXTENSIONS.begin(), EGLEXTENSIONS.end(), ' '), EGLEXTENSIONS);
-
-    m_iDRMFD = g_pCompositor->m_iDRMFD;
 
     m_sExts.KHR_display_reference = EGLEXTENSIONS.contains("KHR_display_reference");
 
@@ -578,16 +576,15 @@ GLuint CHyprOpenGLImpl::createProgram(const std::string& vert, const std::string
     if (dynamic) {
         if (vertCompiled == 0)
             return 0;
-    } else {
-        RASSERT(vertCompiled, "Compiling shader failed. VERTEX NULL! Shader source:\n\n{}", vert.c_str());
-    }
+    } else
+        RASSERT(vertCompiled, "Compiling shader failed. VERTEX nullptr! Shader source:\n\n{}", vert);
 
     auto fragCompiled = compileShader(GL_FRAGMENT_SHADER, frag, dynamic);
     if (dynamic) {
         if (fragCompiled == 0)
             return 0;
     } else {
-        RASSERT(fragCompiled, "Compiling shader failed. FRAGMENT NULL! Shader source:\n\n{}", frag.c_str());
+        RASSERT(fragCompiled, "Compiling shader failed. FRAGMENT nullptr! Shader source:\n\n{}", frag.c_str());
     }
 
     auto prog = glCreateProgram();
@@ -1380,7 +1377,7 @@ void CHyprOpenGLImpl::renderTextureWithDamage(SP<CTexture> tex, CBox* pBox, CReg
 void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, CBox* pBox, float alpha, CRegion* damage, int round, bool discardActive, bool noAA, bool allowCustomUV,
                                                       bool allowDim, SP<CSyncTimeline> waitTimeline, uint64_t waitPoint) {
     RASSERT(m_RenderData.pMonitor, "Tried to render texture without begin()!");
-    RASSERT((tex->m_iTexID > 0), "Attempted to draw NULL texture!");
+    RASSERT((tex->m_iTexID > 0), "Attempted to draw nullptr texture!");
 
     TRACY_GPU_ZONE("RenderTextureInternalWithDamage");
 
@@ -1558,7 +1555,7 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, CBox* pB
 
 void CHyprOpenGLImpl::renderTexturePrimitive(SP<CTexture> tex, CBox* pBox) {
     RASSERT(m_RenderData.pMonitor, "Tried to render texture without begin()!");
-    RASSERT((tex->m_iTexID > 0), "Attempted to draw NULL texture!");
+    RASSERT((tex->m_iTexID > 0), "Attempted to draw nullptr texture!");
 
     TRACY_GPU_ZONE("RenderTexturePrimitive");
 
@@ -1609,7 +1606,7 @@ void CHyprOpenGLImpl::renderTexturePrimitive(SP<CTexture> tex, CBox* pBox) {
 
 void CHyprOpenGLImpl::renderTextureMatte(SP<CTexture> tex, CBox* pBox, CFramebuffer& matte) {
     RASSERT(m_RenderData.pMonitor, "Tried to render texture without begin()!");
-    RASSERT((tex->m_iTexID > 0), "Attempted to draw NULL texture!");
+    RASSERT((tex->m_iTexID > 0), "Attempted to draw nullptr texture!");
 
     TRACY_GPU_ZONE("RenderTextureMatte");
 

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -38,13 +38,13 @@ inline const float fullVerts[] = {
 };
 inline const float fanVertsFull[] = {-1.0f, -1.0f, 1.0f, -1.0f, 1.0f, 1.0f, -1.0f, 1.0f};
 
-enum eDiscardMode {
+enum eDiscardMode : uint8_t {
     DISCARD_OPAQUE = 1,
     DISCARD_ALPHA  = 1 << 1
 };
 
 struct SRenderModifData {
-    enum eRenderModifType {
+    enum eRenderModifType : uint8_t {
         RMOD_TYPE_SCALE,        /* scale by a float */
         RMOD_TYPE_SCALECENTER,  /* scale by a float from the center */
         RMOD_TYPE_TRANSLATE,    /* translate by a Vector2D */

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1973,17 +1973,6 @@ void CHyprRenderer::renderDragIcon(PHLMONITOR pMonitor, timespec* time) {
     PROTO::data->renderDND(pMonitor, time);
 }
 
-DAMAGETRACKINGMODES CHyprRenderer::damageTrackingModeFromStr(const std::string& mode) {
-    if (mode == "full")
-        return DAMAGE_TRACKING_FULL;
-    if (mode == "monitor")
-        return DAMAGE_TRACKING_MONITOR;
-    if (mode == "none")
-        return DAMAGE_TRACKING_NONE;
-
-    return DAMAGE_TRACKING_INVALID;
-}
-
 bool CHyprRenderer::applyMonitorRule(PHLMONITOR pMonitor, SMonitorRule* pMonitorRule, bool force) {
 
     static auto PDISABLESCALECHECKS = CConfigValue<Hyprlang::INT>("debug:disable_scale_checks");

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -896,9 +896,9 @@ void CHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
 
     SRenderModifData RENDERMODIFDATA;
     if (translate != Vector2D{0, 0})
-        RENDERMODIFDATA.modifs.push_back({SRenderModifData::eRenderModifType::RMOD_TYPE_TRANSLATE, translate});
+        RENDERMODIFDATA.modifs.emplace_back(std::make_pair<>(SRenderModifData::eRenderModifType::RMOD_TYPE_TRANSLATE, translate));
     if (scale != 1.f)
-        RENDERMODIFDATA.modifs.push_back({SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, scale});
+        RENDERMODIFDATA.modifs.emplace_back(std::make_pair<>(SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, scale));
 
     if (!pMonitor)
         return;
@@ -1652,7 +1652,7 @@ static void applyExclusive(CBox& usableArea, uint32_t anchor, int32_t exclusive,
         {
             .singular_anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM,
             .anchor_triplet  = ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT | ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT | ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM,
-            .positive_axis   = NULL,
+            .positive_axis   = nullptr,
             .negative_axis   = &usableArea.height,
             .margin          = marginBottom,
         },
@@ -1668,7 +1668,7 @@ static void applyExclusive(CBox& usableArea, uint32_t anchor, int32_t exclusive,
         {
             .singular_anchor = ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT,
             .anchor_triplet  = ZWLR_LAYER_SURFACE_V1_ANCHOR_RIGHT | ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP | ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM,
-            .positive_axis   = NULL,
+            .positive_axis   = nullptr,
             .negative_axis   = &usableArea.width,
             .margin          = marginRight,
         },
@@ -1948,19 +1948,18 @@ void CHyprRenderer::damageMirrorsWith(PHLMONITOR pMonitor, const CRegion& pRegio
     for (auto const& mirror : pMonitor->mirrors) {
 
         // transform the damage here, so it won't get clipped by the monitor damage ring
-        auto    monitor  = mirror;
-        auto    mirrored = pMonitor;
+        auto    monitor = mirror;
 
         CRegion transformed{pRegion};
 
         // we want to transform to the same box as in CHyprOpenGLImpl::renderMirrored
-        double scale  = std::min(monitor->vecTransformedSize.x / mirrored->vecTransformedSize.x, monitor->vecTransformedSize.y / mirrored->vecTransformedSize.y);
-        CBox   monbox = {0, 0, mirrored->vecTransformedSize.x * scale, mirrored->vecTransformedSize.y * scale};
+        double scale  = std::min(monitor->vecTransformedSize.x / pMonitor->vecTransformedSize.x, monitor->vecTransformedSize.y / pMonitor->vecTransformedSize.y);
+        CBox   monbox = {0, 0, pMonitor->vecTransformedSize.x * scale, pMonitor->vecTransformedSize.y * scale};
         monbox.x      = (monitor->vecTransformedSize.x - monbox.w) / 2;
         monbox.y      = (monitor->vecTransformedSize.y - monbox.h) / 2;
 
         transformed.scale(scale);
-        transformed.transform(wlTransformToHyprutils(mirrored->transform), mirrored->vecPixelSize.x * scale, mirrored->vecPixelSize.y * scale);
+        transformed.transform(wlTransformToHyprutils(pMonitor->transform), pMonitor->vecPixelSize.x * scale, pMonitor->vecPixelSize.y * scale);
         transformed.translate(Vector2D(monbox.x, monbox.y));
 
         mirror->addDamage(&transformed);

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -15,13 +15,20 @@ class CInputPopup;
 class IHLBuffer;
 class CEventLoopTimer;
 
-enum eRenderPassMode {
+enum eDamageTrackingModes : int8_t {
+    DAMAGE_TRACKING_INVALID = -1,
+    DAMAGE_TRACKING_NONE    = 0,
+    DAMAGE_TRACKING_MONITOR,
+    DAMAGE_TRACKING_FULL,
+};
+
+enum eRenderPassMode : uint8_t {
     RENDER_PASS_ALL = 0,
     RENDER_PASS_MAIN,
     RENDER_PASS_POPUP
 };
 
-enum eRenderMode {
+enum eRenderMode : uint8_t {
     RENDER_MODE_NORMAL              = 0,
     RENDER_MODE_FULL_FAKE           = 1,
     RENDER_MODE_TO_BUFFER           = 2,
@@ -81,8 +88,8 @@ class CHyprRenderer {
 
     bool m_bBlockSurfaceFeedback = false;
     bool m_bRenderingSnapshot    = false;
-    PHLMONITORREF m_pMostHzMonitor;
-    bool          m_bDirectScanoutBlocked = false;
+    PHLMONITORREF                       m_pMostHzMonitor;
+    bool                                m_bDirectScanoutBlocked = false;
 
     void                                setSurfaceScanoutMode(SP<CWLSurfaceResource> surface, PHLMONITOR monitor); // nullptr monitor resets
     void                                initiateManualCrash();

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -15,14 +15,6 @@ class CInputPopup;
 class IHLBuffer;
 class CEventLoopTimer;
 
-// TODO: add fuller damage tracking for updating only parts of a window
-enum DAMAGETRACKINGMODES {
-    DAMAGE_TRACKING_INVALID = -1,
-    DAMAGE_TRACKING_NONE    = 0,
-    DAMAGE_TRACKING_MONITOR,
-    DAMAGE_TRACKING_FULL
-};
-
 enum eRenderPassMode {
     RENDER_PASS_ALL = 0,
     RENDER_PASS_MAIN,
@@ -92,9 +84,6 @@ class CHyprRenderer {
     PHLMONITORREF m_pMostHzMonitor;
     bool          m_bDirectScanoutBlocked = false;
 
-    DAMAGETRACKINGMODES
-    damageTrackingModeFromStr(const std::string&);
-
     void                                setSurfaceScanoutMode(SP<CWLSurfaceResource> surface, PHLMONITOR monitor); // nullptr monitor resets
     void                                initiateManualCrash();
 
@@ -108,8 +97,8 @@ class CHyprRenderer {
     std::vector<SP<CWLSurfaceResource>> explicitPresented;
 
     struct {
-        int                           hotspotX;
-        int                           hotspotY;
+        int                           hotspotX = 0;
+        int                           hotspotY = 0;
         std::optional<SP<CWLSurface>> surf;
         std::string                   name;
     } m_sLastCursorData;

--- a/src/render/Texture.cpp
+++ b/src/render/Texture.cpp
@@ -5,9 +5,7 @@
 #include "../helpers/Format.hpp"
 #include <cstring>
 
-CTexture::CTexture() {
-    // naffin'
-}
+CTexture::CTexture() = default;
 
 CTexture::~CTexture() {
     if (!g_pCompositor || g_pCompositor->m_bIsShuttingDown || !g_pHyprRenderer)
@@ -63,7 +61,7 @@ CTexture::CTexture(const SP<Aquamarine::IBuffer> buffer, bool keepDataCopy) : m_
 void CTexture::createFromShm(uint32_t drmFormat, uint8_t* pixels, uint32_t stride, const Vector2D& size_) {
     g_pHyprRenderer->makeEGLCurrent();
 
-    const auto format = FormatUtils::getPixelFormatFromDRM(drmFormat);
+    const auto format = NFormatUtils::getPixelFormatFromDRM(drmFormat);
     ASSERT(format);
 
     m_iType = format->withAlpha ? TEXTURE_RGBA : TEXTURE_RGBX;
@@ -96,11 +94,11 @@ void CTexture::createFromDma(const Aquamarine::SDMABUFAttrs& attrs, void* image)
         return;
     }
 
-    m_bOpaque = FormatUtils::isFormatOpaque(attrs.format);
+    m_bOpaque = NFormatUtils::isFormatOpaque(attrs.format);
     m_iTarget = GL_TEXTURE_2D;
     m_iType   = TEXTURE_RGBA;
     m_vSize   = attrs.size;
-    m_iType   = FormatUtils::isFormatOpaque(attrs.format) ? TEXTURE_RGBX : TEXTURE_RGBA;
+    m_iType   = NFormatUtils::isFormatOpaque(attrs.format) ? TEXTURE_RGBX : TEXTURE_RGBA;
     allocate();
     m_pEglImage = image;
 
@@ -114,7 +112,7 @@ void CTexture::createFromDma(const Aquamarine::SDMABUFAttrs& attrs, void* image)
 void CTexture::update(uint32_t drmFormat, uint8_t* pixels, uint32_t stride, const CRegion& damage) {
     g_pHyprRenderer->makeEGLCurrent();
 
-    const auto format = FormatUtils::getPixelFormatFromDRM(drmFormat);
+    const auto format = NFormatUtils::getPixelFormatFromDRM(drmFormat);
     ASSERT(format);
 
     glBindTexture(GL_TEXTURE_2D, m_iTexID);

--- a/src/render/Texture.hpp
+++ b/src/render/Texture.hpp
@@ -6,13 +6,12 @@
 
 class IHLBuffer;
 HYPRUTILS_FORWARD(Math, CRegion);
-using namespace Hyprutils::Math;
 
-enum eTextureType {
-    TEXTURE_INVALID,  // Invalid
-    TEXTURE_RGBA,     // 4 channels
-    TEXTURE_RGBX,     // discard A
-    TEXTURE_EXTERNAL, // EGLImage
+enum eTextureType : int8_t {
+    TEXTURE_INVALID = -1, // Invalid
+    TEXTURE_RGBA    = 0,  // 4 channels
+    TEXTURE_RGBX,         // discard A
+    TEXTURE_EXTERNAL,     // EGLImage
 };
 
 class CTexture {
@@ -36,7 +35,7 @@ class CTexture {
     void                        update(uint32_t drmFormat, uint8_t* pixels, uint32_t stride, const CRegion& damage);
     const std::vector<uint8_t>& dataCopy();
 
-    eTextureType                 m_iType      = TEXTURE_RGBA;
+    eTextureType                m_iType      = TEXTURE_RGBA;
     GLenum                      m_iTarget    = GL_TEXTURE_2D;
     GLuint                      m_iTexID     = 0;
     Vector2D                    m_vSize      = {};

--- a/src/render/Texture.hpp
+++ b/src/render/Texture.hpp
@@ -8,7 +8,7 @@ class IHLBuffer;
 HYPRUTILS_FORWARD(Math, CRegion);
 using namespace Hyprutils::Math;
 
-enum TEXTURETYPE {
+enum eTextureType {
     TEXTURE_INVALID,  // Invalid
     TEXTURE_RGBA,     // 4 channels
     TEXTURE_RGBX,     // discard A
@@ -36,7 +36,7 @@ class CTexture {
     void                        update(uint32_t drmFormat, uint8_t* pixels, uint32_t stride, const CRegion& damage);
     const std::vector<uint8_t>& dataCopy();
 
-    TEXTURETYPE                 m_iType      = TEXTURE_RGBA;
+    eTextureType                 m_iType      = TEXTURE_RGBA;
     GLenum                      m_iTarget    = GL_TEXTURE_2D;
     GLuint                      m_iTexID     = 0;
     Vector2D                    m_vSize      = {};

--- a/src/render/Transformer.hpp
+++ b/src/render/Transformer.hpp
@@ -11,6 +11,8 @@ struct SRenderData;
 // Worth noting transformers for now only affect the main pass (not popups)
 class IWindowTransformer {
   public:
+    virtual ~IWindowTransformer() = default;
+
     // called by Hyprland. For more data about what is being rendered, inspect render data.
     // returns the out fb.
     virtual CFramebuffer* transform(CFramebuffer* in) = 0;

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -3,8 +3,8 @@
 #include "../../config/ConfigValue.hpp"
 #include "../../managers/eventLoop/EventLoopManager.hpp"
 
-CHyprBorderDecoration::CHyprBorderDecoration(PHLWINDOW pWindow) : IHyprWindowDecoration(pWindow) {
-    m_pWindow = pWindow;
+CHyprBorderDecoration::CHyprBorderDecoration(PHLWINDOW pWindow) : IHyprWindowDecoration(pWindow), m_pWindow(pWindow) {
+    ;
 }
 
 CHyprBorderDecoration::~CHyprBorderDecoration() {

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -3,11 +3,11 @@
 #include "../../Compositor.hpp"
 #include "../../config/ConfigValue.hpp"
 
-CHyprDropShadowDecoration::CHyprDropShadowDecoration(PHLWINDOW pWindow) : IHyprWindowDecoration(pWindow) {
-    m_pWindow = pWindow;
+CHyprDropShadowDecoration::CHyprDropShadowDecoration(PHLWINDOW pWindow) : IHyprWindowDecoration(pWindow), m_pWindow(pWindow) {
+    ;
 }
 
-CHyprDropShadowDecoration::~CHyprDropShadowDecoration() {}
+CHyprDropShadowDecoration::~CHyprDropShadowDecoration() = default;
 
 eDecorationType CHyprDropShadowDecoration::getDecorationType() {
     return DECORATION_SHADOW;

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -17,16 +17,15 @@ constexpr int       BAR_PADDING_OUTER_HORZ = 2;
 constexpr int       BAR_TEXT_PAD           = 2;
 constexpr int       BAR_HORIZONTAL_PADDING = 2;
 
-CHyprGroupBarDecoration::CHyprGroupBarDecoration(PHLWINDOW pWindow) : IHyprWindowDecoration(pWindow) {
+CHyprGroupBarDecoration::CHyprGroupBarDecoration(PHLWINDOW pWindow) : IHyprWindowDecoration(pWindow), m_pWindow(pWindow) {
     static auto PGRADIENTS = CConfigValue<Hyprlang::INT>("group:groupbar:enabled");
     static auto PENABLED   = CConfigValue<Hyprlang::INT>("group:groupbar:gradients");
-    m_pWindow              = pWindow;
 
     if (m_tGradientActive->m_iTexID == 0 && *PENABLED && *PGRADIENTS)
         refreshGroupBarGradients();
 }
 
-CHyprGroupBarDecoration::~CHyprGroupBarDecoration() {}
+CHyprGroupBarDecoration::~CHyprGroupBarDecoration() = default;
 
 SDecorationPositioningInfo CHyprGroupBarDecoration::getPositioningInfo() {
     static auto                PHEIGHT       = CConfigValue<Hyprlang::INT>("group:groupbar:height");

--- a/src/render/decorations/DecorationPositioner.cpp
+++ b/src/render/decorations/DecorationPositioner.cpp
@@ -85,12 +85,7 @@ CDecorationPositioner::SWindowPositioningData* CDecorationPositioner::getDataFor
 }
 
 void CDecorationPositioner::sanitizeDatas() {
-    std::erase_if(m_mWindowDatas, [](const auto& other) {
-        if (!valid(other.first))
-            return true;
-
-        return false;
-    });
+    std::erase_if(m_mWindowDatas, [](const auto& other) { return !valid(other.first); });
     std::erase_if(m_vWindowPositioningDatas, [](const auto& other) {
         if (!validMapped(other->pWindow))
             return true;

--- a/src/render/decorations/DecorationPositioner.hpp
+++ b/src/render/decorations/DecorationPositioner.hpp
@@ -9,12 +9,12 @@
 class CWindow;
 class IHyprWindowDecoration;
 
-enum eDecorationPositioningPolicy {
+enum eDecorationPositioningPolicy : uint8_t {
     DECORATION_POSITION_ABSOLUTE = 0, /* Decoration wants absolute positioning */
     DECORATION_POSITION_STICKY,       /* Decoration is stuck to some edge of a window */
 };
 
-enum eDecorationEdges {
+enum eDecorationEdges : uint8_t {
     DECORATION_EDGE_TOP    = 1 << 0,
     DECORATION_EDGE_BOTTOM = 1 << 1,
     DECORATION_EDGE_LEFT   = 1 << 2,

--- a/src/render/decorations/IHyprWindowDecoration.cpp
+++ b/src/render/decorations/IHyprWindowDecoration.cpp
@@ -2,11 +2,11 @@
 
 class CWindow;
 
-IHyprWindowDecoration::IHyprWindowDecoration(PHLWINDOW pWindow) {
-    m_pWindow = pWindow;
+IHyprWindowDecoration::IHyprWindowDecoration(PHLWINDOW pWindow) : m_pWindow(pWindow) {
+    ;
 }
 
-IHyprWindowDecoration::~IHyprWindowDecoration() {}
+IHyprWindowDecoration::~IHyprWindowDecoration() = default;
 
 bool IHyprWindowDecoration::onInputOnDeco(const eInputType, const Vector2D&, std::any) {
     return false;

--- a/src/render/decorations/IHyprWindowDecoration.hpp
+++ b/src/render/decorations/IHyprWindowDecoration.hpp
@@ -5,7 +5,7 @@
 #include "../../helpers/math/Math.hpp"
 #include "DecorationPositioner.hpp"
 
-enum eDecorationType {
+enum eDecorationType : int8_t {
     DECORATION_NONE = -1,
     DECORATION_GROUPBAR,
     DECORATION_SHADOW,
@@ -13,14 +13,14 @@ enum eDecorationType {
     DECORATION_CUSTOM
 };
 
-enum eDecorationLayer {
+enum eDecorationLayer : uint8_t {
     DECORATION_LAYER_BOTTOM = 0, /* lowest. */
     DECORATION_LAYER_UNDER,      /* under the window, but above BOTTOM */
     DECORATION_LAYER_OVER,       /* above the window, but below its popups */
     DECORATION_LAYER_OVERLAY     /* above everything of the window, including popups */
 };
 
-enum eDecorationFlags {
+enum eDecorationFlags : uint8_t {
     DECORATION_ALLOWS_MOUSE_INPUT  = 1 << 0, /* this decoration accepts mouse input */
     DECORATION_PART_OF_MAIN_WINDOW = 1 << 1, /* this decoration is a *seamless* part of the main window, so stuff like shadows will include it */
     DECORATION_NON_SOLID           = 1 << 2, /* this decoration is not solid. Other decorations should draw on top of it. Example: shadow */

--- a/src/signal-safe.cpp
+++ b/src/signal-safe.cpp
@@ -5,21 +5,19 @@
 #endif
 #include <fcntl.h>
 #include <unistd.h>
-#include <string.h>
+#include <cstring>
 
-extern char** environ;
-
-char const*   sig_getenv(char const* name) {
-    size_t len = strlen(name);
-    for (char** var = environ; *var != NULL; var++) {
+char const* sigGetenv(char const* name) {
+    const size_t len = strlen(name);
+    for (char** var = environ; *var != nullptr; var++) {
         if (strncmp(*var, name, len) == 0 && (*var)[len] == '=') {
             return (*var) + len + 1;
         }
     }
-    return NULL;
+    return nullptr;
 }
 
-char const* sig_strsignal(int sig) {
+char const* sigStrsignal(int sig) {
 #ifdef __GLIBC__
     return sigabbrev_np(sig);
 #elif defined(__DragonFly__) || defined(__FreeBSD__)

--- a/src/xwayland/Server.cpp
+++ b/src/xwayland/Server.cpp
@@ -3,14 +3,13 @@
 
 #include <format>
 #include <string>
-#include <errno.h>
+#include <cerrno>
 #include <fcntl.h>
-#include <stdio.h>
+#include <cstdio>
 #include <cstring>
-#include <signal.h>
-#include <stddef.h>
-#include <stdint.h>
-#include <stdlib.h>
+#include <csignal>
+#include <cstddef>
+#include <cstdlib>
 #include <sys/un.h>
 #include <unistd.h>
 #include <exception>
@@ -94,7 +93,7 @@ static int createSocket(struct sockaddr_un* addr, size_t path_size) {
     return fd;
 }
 
-static bool checkPermissionsForSocketDir(void) {
+static bool checkPermissionsForSocketDir() {
     struct stat buf;
 
     if (lstat("/tmp/.X11-unix", &buf)) {
@@ -107,7 +106,7 @@ static bool checkPermissionsForSocketDir(void) {
         return false;
     }
 
-    if (!((buf.st_uid == 0) || (buf.st_uid == getuid()))) {
+    if ((buf.st_uid != 0) && (buf.st_uid != getuid())) {
         Debug::log(ERR, "X11 socket dir is not owned by root or current user");
         return false;
     }

--- a/src/xwayland/XDataSource.cpp
+++ b/src/xwayland/XDataSource.cpp
@@ -11,7 +11,7 @@ CXDataSource::CXDataSource(SXSelection& sel_) : selection(sel_) {
                                                         1, // delete
                                                         selection.window, HYPRATOMS["_WL_SELECTION"], XCB_GET_PROPERTY_TYPE_ANY, 0, 4096);
 
-    xcb_get_property_reply_t* reply = xcb_get_property_reply(g_pXWayland->pWM->connection, cookie, NULL);
+    xcb_get_property_reply_t* reply = xcb_get_property_reply(g_pXWayland->pWM->connection, cookie, nullptr);
     if (!reply)
         return;
 
@@ -23,9 +23,9 @@ CXDataSource::CXDataSource(SXSelection& sel_) : selection(sel_) {
     auto value = (xcb_atom_t*)xcb_get_property_value(reply);
     for (uint32_t i = 0; i < reply->value_len; i++) {
         if (value[i] == HYPRATOMS["UTF8_STRING"])
-            mimeTypes.push_back("text/plain;charset=utf-8");
+            mimeTypes.emplace_back("text/plain;charset=utf-8");
         else if (value[i] == HYPRATOMS["TEXT"])
-            mimeTypes.push_back("text/plain");
+            mimeTypes.emplace_back("text/plain");
         else if (value[i] != HYPRATOMS["TARGETS"] && value[i] != HYPRATOMS["TIMESTAMP"]) {
 
             auto type = g_pXWayland->pWM->mimeFromAtom(value[i]);

--- a/src/xwayland/XSurface.cpp
+++ b/src/xwayland/XSurface.cpp
@@ -33,7 +33,7 @@ CXWaylandSurface::CXWaylandSurface(uint32_t xID_, CBox geometry_, bool OR) : xID
             }
             xcb_res_client_id_value_next(&iter);
         }
-        if (ppid == NULL) {
+        if (!ppid) {
             free(reply);
             return;
         }
@@ -208,7 +208,7 @@ void CXWaylandSurface::restackToTop() {
 }
 
 void CXWaylandSurface::close() {
-    xcb_client_message_data_t msg = {0};
+    xcb_client_message_data_t msg = {};
     msg.data32[0]                 = HYPRATOMS["WM_DELETE_WINDOW"];
     msg.data32[1]                 = XCB_CURRENT_TIME;
     g_pXWayland->pWM->sendWMMessage(self.lock(), &msg, XCB_EVENT_MASK_NO_EVENT);

--- a/src/xwayland/XWM.hpp
+++ b/src/xwayland/XWM.hpp
@@ -58,8 +58,8 @@ struct SXSelection {
 
 class CXCBConnection {
   public:
-    CXCBConnection(int fd) {
-        connection = xcb_connect_to_fd(fd, nullptr);
+    CXCBConnection(int fd) : connection{xcb_connect_to_fd(fd, nullptr)} {
+        ;
     }
 
     ~CXCBConnection() {
@@ -67,7 +67,7 @@ class CXCBConnection {
             xcb_disconnect(connection);
     }
 
-    bool hasError() const {
+    [[nodiscard]] bool hasError() const {
         return xcb_connection_has_error(connection);
     }
 
@@ -91,7 +91,7 @@ class CXCBErrorContext {
             xcb_errors_context_free(errors);
     }
 
-    bool isValid() const {
+    [[nodiscard]] bool isValid() const {
         return errors != nullptr;
     }
 

--- a/src/xwayland/XWM.hpp
+++ b/src/xwayland/XWM.hpp
@@ -67,7 +67,7 @@ class CXCBConnection {
             xcb_disconnect(connection);
     }
 
-    [[nodiscard]] bool hasError() const {
+    bool hasError() const {
         return xcb_connection_has_error(connection);
     }
 
@@ -91,7 +91,7 @@ class CXCBErrorContext {
             xcb_errors_context_free(errors);
     }
 
-    [[nodiscard]] bool isValid() const {
+    bool isValid() const {
         return errors != nullptr;
     }
 


### PR DESCRIPTION
This adds a nice clang-tidy config. Partially stolen from @outfoxxed.

Also fixes a lot of style issues with old MRd code. There are still a bunch of "errors" in some files. These might be up to either ignoring or fixing.

Probably should be done gradually, a lot of work all at once.