### PR TITLE
config: add 'force' option for 'cursor:warp_on_change_workspace'

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1339,7 +1339,7 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
     },
     SConfigOptionDescription{
         .value       = "cursor:warp_on_change_workspace",
-        .description = "Move the cursor to the last focused window after changing the workspace. Options: 0 (Disabled), 1 (Enabled), 2 (Force - ignores input:no_warps option)",
+        .description = "Move the cursor to the last focused window after changing the workspace. Options: 0 (Disabled), 1 (Enabled), 2 (Force - ignores cursor:no_warps option)",
         .type        = CONFIG_OPTION_CHOICE,
         .data        = SConfigOptionDescription::SChoiceData{0, "Disabled,Enabled,Force"},
     },

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1339,9 +1339,9 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
     },
     SConfigOptionDescription{
         .value       = "cursor:warp_on_change_workspace",
-        .description = "If true, move the cursor to the last focused window after changing the workspace.",
-        .type        = CONFIG_OPTION_BOOL,
-        .data        = SConfigOptionDescription::SBoolData{false},
+        .description = "Move the cursor to the last focused window after changing the workspace. Options: 0 (Disabled), 1 (Enabled), 2 (Force - ignores input:no_warps option)",
+        .type        = CONFIG_OPTION_CHOICE,
+        .data        = SConfigOptionDescription::SChoiceData{0, "Disabled,Enabled,Force"},
     },
     SConfigOptionDescription{
         .value       = "cursor:default_monitor",

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1529,15 +1529,15 @@ void CWindow::onX11Configure(CBox box) {
     g_pHyprRenderer->damageWindow(m_pSelf.lock());
 }
 
-void CWindow::warpCursor() {
+void CWindow::warpCursor(bool force) {
     static auto PERSISTENTWARPS         = CConfigValue<Hyprlang::INT>("cursor:persistent_warps");
     const auto  coords                  = m_vRelativeCursorCoordsOnLastWarp;
     m_vRelativeCursorCoordsOnLastWarp.x = -1; // reset m_vRelativeCursorCoordsOnLastWarp
 
     if (*PERSISTENTWARPS && coords.x > 0 && coords.y > 0 && coords < m_vSize) // don't warp cursor outside the window
-        g_pCompositor->warpCursorTo(m_vPosition + coords);
+        g_pCompositor->warpCursorTo(m_vPosition + coords, force);
     else
-        g_pCompositor->warpCursorTo(middle());
+        g_pCompositor->warpCursorTo(middle(), force);
 }
 
 PHLWINDOW CWindow::getSwallower() {

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -470,7 +470,7 @@ class CWindow {
     void                   onResourceChangeX11();
     std::string            fetchTitle();
     std::string            fetchClass();
-    void                   warpCursor();
+    void                   warpCursor(bool force = false);
     PHLWINDOW              getSwallower();
     void                   unsetWindowData(eOverridePriority priority);
     bool                   isX11OverrideRedirect();

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1202,12 +1202,13 @@ SDispatchResult CKeybindManager::changeworkspace(std::string args) {
 
     const static auto PWARPONWORKSPACECHANGE = CConfigValue<Hyprlang::INT>("cursor:warp_on_change_workspace");
 
-    if (*PWARPONWORKSPACECHANGE) {
+    if (*PWARPONWORKSPACECHANGE > 0) {
         auto PLAST     = pWorkspaceToChangeTo->getLastFocusedWindow();
         auto HLSurface = CWLSurface::fromResource(g_pSeatManager->state.pointerFocus.lock());
 
+        bool force = *PWARPONWORKSPACECHANGE == 2;
         if (PLAST && (!HLSurface || HLSurface->getWindow()))
-            PLAST->warpCursor();
+            PLAST->warpCursor(force);
     }
 
     return {};

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1206,9 +1206,8 @@ SDispatchResult CKeybindManager::changeworkspace(std::string args) {
         auto PLAST     = pWorkspaceToChangeTo->getLastFocusedWindow();
         auto HLSurface = CWLSurface::fromResource(g_pSeatManager->state.pointerFocus.lock());
 
-        bool force = *PWARPONWORKSPACECHANGE == 2;
         if (PLAST && (!HLSurface || HLSurface->getWindow()))
-            PLAST->warpCursor(force);
+            PLAST->warpCursor(*PWARPONWORKSPACECHANGE == 2);
     }
 
     return {};


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Add a new third option for `cursor:warp_on_change_workspace` which forces cursor warping (ignores the `cursor:no_warps` option).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Idk, is it breaks the backward compatibility when it turned from `bool` to `choice option` because I didn't dig deep into codebase. Anyway, I mentioned.

#### Is it ready for merging, or does it need work?

Ready.
