### PR TITLE
Renderer: rewrite render scheduling

### DIFF
--- a/src/helpers/WLClasses.hpp
+++ b/src/helpers/WLClasses.hpp
@@ -17,47 +17,6 @@ class CWLSurfaceResource;
 
 AQUAMARINE_FORWARD(ISwitch);
 
-struct SRenderData {
-    PHLMONITORREF pMonitor;
-    timespec*     when;
-    double        x, y;
-
-    // for iters
-    void*                  data    = nullptr;
-    SP<CWLSurfaceResource> surface = nullptr;
-    double                 w, h;
-
-    // for rounding
-    bool dontRound = true;
-
-    // for fade
-    float fadeAlpha = 1.f;
-
-    // for alpha settings
-    float alpha = 1.f;
-
-    // for decorations (border)
-    bool decorate = false;
-
-    // for custom round values
-    int rounding = -1; // -1 means not set
-
-    // for blurring
-    bool blur                  = false;
-    bool blockBlurOptimization = false;
-
-    // only for windows, not popups
-    bool squishOversized = true;
-
-    // for calculating UV
-    PHLWINDOW pWindow;
-
-    bool      popup = false;
-
-    // counts how many surfaces this pass has rendered
-    int surfaceCounter = 0;
-};
-
 struct SSwipeGesture {
     PHLWORKSPACE  pWorkspaceBegin = nullptr;
 

--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -551,7 +551,7 @@ void CPointerManager::renderSoftwareCursorsFor(PHLMONITOR pMonitor, timespec* no
     box.x = std::round(box.x);
     box.y = std::round(box.y);
 
-    g_pHyprOpenGL->renderTextureWithDamage(texture, &box, &damage, 1.F, 0, false, false, currentCursorImage.waitTimeline, currentCursorImage.waitPoint);
+    g_pHyprOpenGL->renderTextureWithDamage(texture, &box, damage, 1.F, 0, false, false, currentCursorImage.waitTimeline, currentCursorImage.waitPoint);
 
     if (currentCursorImage.surface)
         currentCursorImage.surface->resource()->frame(now);

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -19,6 +19,7 @@
 #include "Framebuffer.hpp"
 #include "Transformer.hpp"
 #include "Renderbuffer.hpp"
+#include "pass/Pass.hpp"
 
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
@@ -61,17 +62,31 @@ struct SRenderModifData {
     bool                                               enabled = true;
 };
 
+enum eMonitorRenderFBs : uint8_t {
+    FB_MONITOR_RENDER_MAIN    = 0,
+    FB_MONITOR_RENDER_CURRENT = 1,
+    FB_MONITOR_RENDER_OUT     = 2,
+};
+
+enum eMonitorExtraRenderFBs : uint8_t {
+    FB_MONITOR_RENDER_EXTRA_OFFLOAD = 0,
+    FB_MONITOR_RENDER_EXTRA_MIRROR,
+    FB_MONITOR_RENDER_EXTRA_MIRROR_SWAP,
+    FB_MONITOR_RENDER_EXTRA_OFF_MAIN,
+    FB_MONITOR_RENDER_EXTRA_MONITOR_MIRROR,
+    FB_MONITOR_RENDER_EXTRA_BLUR,
+};
+
 struct SMonitorRenderData {
     CFramebuffer offloadFB;
     CFramebuffer mirrorFB;     // these are used for some effects,
     CFramebuffer mirrorSwapFB; // etc
     CFramebuffer offMainFB;
-
     CFramebuffer monitorMirrorFB; // used for mirroring outputs, does not contain artifacts like offloadFB
+    CFramebuffer blurFB;
 
     SP<CTexture> stencilTex = makeShared<CTexture>();
 
-    CFramebuffer blurFB;
     bool         blurFBDirty        = true;
     bool         blurFBShouldRender = false;
 
@@ -123,6 +138,9 @@ struct SCurrentRenderData {
 
     uint32_t            discardMode    = DISCARD_OPAQUE;
     float               discardOpacity = 0.f;
+
+    PHLLSREF            currentLS;
+    PHLWINDOWREF        currentWindow;
 };
 
 class CEGLSync {
@@ -155,9 +173,9 @@ class CHyprOpenGLImpl {
 
     void     renderRect(CBox*, const CHyprColor&, int round = 0);
     void     renderRectWithBlur(CBox*, const CHyprColor&, int round = 0, float blurA = 1.f, bool xray = false);
-    void     renderRectWithDamage(CBox*, const CHyprColor&, CRegion* damage, int round = 0);
+    void     renderRectWithDamage(CBox*, const CHyprColor&, const CRegion& damage, int round = 0);
     void     renderTexture(SP<CTexture>, CBox*, float a, int round = 0, bool discardActive = false, bool allowCustomUV = false);
-    void     renderTextureWithDamage(SP<CTexture>, CBox*, CRegion* damage, float a, int round = 0, bool discardActive = false, bool allowCustomUV = false,
+    void     renderTextureWithDamage(SP<CTexture>, CBox*, const CRegion& damage, float a, int round = 0, bool discardActive = false, bool allowCustomUV = false,
                                      SP<CSyncTimeline> waitTimeline = nullptr, uint64_t waitPoint = 0);
     void     renderTextureWithBlur(SP<CTexture>, CBox*, float a, SP<CWLSurfaceResource> pSurface, int round = 0, bool blockBlurOptimization = false, float blurA = 1.f);
     void     renderRoundedShadow(CBox*, int round, int range, const CHyprColor& color, float a = 1.0);
@@ -224,9 +242,6 @@ class CHyprOpenGLImpl {
     uint                                        failedAssetsNo = 0;
 
     bool                                        m_bReloadScreenShader = true; // at launch it can be set
-
-    PHLWINDOWREF                                m_pCurrentWindow; // hack to get the current rendered window
-    PHLLS                                       m_pCurrentLayer;  // hack to get the current rendered layer
 
     std::map<PHLWINDOWREF, CFramebuffer>        m_mWindowFramebuffers;
     std::map<PHLLSREF, CFramebuffer>            m_mLayerFramebuffers;
@@ -300,7 +315,7 @@ class CHyprOpenGLImpl {
     // returns the out FB, can be either Mirror or MirrorSwap
     CFramebuffer* blurMainFramebufferWithDamage(float a, CRegion* damage);
 
-    void          renderTextureInternalWithDamage(SP<CTexture>, CBox* pBox, float a, CRegion* damage, int round = 0, bool discardOpaque = false, bool noAA = false,
+    void          renderTextureInternalWithDamage(SP<CTexture>, CBox* pBox, float a, const CRegion& damage, int round = 0, bool discardOpaque = false, bool noAA = false,
                                                   bool allowCustomUV = false, bool allowDim = false, SP<CSyncTimeline> = nullptr, uint64_t waitPoint = 0);
     void          renderTexturePrimitive(SP<CTexture> tex, CBox* pBox);
     void          renderSplash(cairo_t* const, cairo_surface_t* const, double offset, const Vector2D& size);
@@ -310,6 +325,7 @@ class CHyprOpenGLImpl {
     bool          passRequiresIntrospection(PHLMONITOR pMonitor);
 
     friend class CHyprRenderer;
+    friend class CTexPassElement;
 };
 
 inline std::unique_ptr<CHyprOpenGLImpl> g_pHyprOpenGL;

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -110,6 +110,8 @@ class CHyprRenderer {
         std::string                   name;
     } m_sLastCursorData;
 
+    CRenderPass m_sRenderPass = {};
+
   private:
     void              arrangeLayerArray(PHLMONITOR, const std::vector<PHLLSREF>&, bool, CBox*);
     void              renderWorkspaceWindowsFullscreen(PHLMONITOR, PHLWORKSPACE, timespec*); // renders workspace windows (fullscreen) (tiled, floating, pinned, but no special)
@@ -129,10 +131,9 @@ class CHyprRenderer {
     bool              m_bCursorHidden        = false;
     bool              m_bCursorHasSurface    = false;
     SP<CRenderbuffer> m_pCurrentRenderbuffer = nullptr;
-    SP<Aquamarine::IBuffer> m_pCurrentBuffer;
-    eRenderMode             m_eRenderMode = RENDER_MODE_NORMAL;
-
-    bool                    m_bNvidia = false;
+    SP<Aquamarine::IBuffer> m_pCurrentBuffer = nullptr;
+    eRenderMode             m_eRenderMode    = RENDER_MODE_NORMAL;
+    bool                    m_bNvidia        = false;
 
     struct {
         bool hiddenOnTouch    = false;

--- a/src/render/Transformer.cpp
+++ b/src/render/Transformer.cpp
@@ -1,5 +1,5 @@
 #include "Transformer.hpp"
 
-void IWindowTransformer::preWindowRender(SRenderData* pRenderData) {
+void IWindowTransformer::preWindowRender(CTexPassElement::SRenderData* pRenderData) {
     ;
 }

--- a/src/render/Transformer.hpp
+++ b/src/render/Transformer.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "Framebuffer.hpp"
-
-struct SRenderData;
+#include "pass/TexPassElement.hpp"
 
 // A window transformer can be attached to a window.
 // If any is attached, Hyprland will render the window to a separate fb, then call the transform() func with it,
@@ -18,5 +17,5 @@ class IWindowTransformer {
     virtual CFramebuffer* transform(CFramebuffer* in) = 0;
 
     // called by Hyprland before a window main pass is started.
-    virtual void preWindowRender(SRenderData* pRenderData);
+    virtual void preWindowRender(CTexPassElement::SRenderData* pRenderData);
 };

--- a/src/render/decorations/CHyprDropShadowDecoration.hpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.hpp
@@ -25,6 +25,8 @@ class CHyprDropShadowDecoration : public IHyprWindowDecoration {
 
     virtual std::string                getDisplayName();
 
+    void render(PHLMONITOR, float const& a);
+
   private:
     SBoxExtents  m_seExtents;
     SBoxExtents  m_seReportedExtents;

--- a/src/render/pass/BorderPassElement.cpp
+++ b/src/render/pass/BorderPassElement.cpp
@@ -1,0 +1,21 @@
+#include "BorderPassElement.hpp"
+#include "../OpenGL.hpp"
+
+CBorderPassElement::CBorderPassElement(const CBorderPassElement::SBorderData& data_) : data(data_) {
+    ;
+}
+
+void CBorderPassElement::draw(const CRegion& damage) {
+    if (data.hasGrad2)
+        g_pHyprOpenGL->renderBorder(&data.box, data.grad1, data.grad2, data.lerp, data.round, data.borderSize, data.a, data.outerRound);
+    else
+        g_pHyprOpenGL->renderBorder(&data.box, data.grad1, data.round, data.borderSize, data.a, data.outerRound);
+}
+
+bool CBorderPassElement::needsLiveBlur() {
+    return false;
+}
+
+bool CBorderPassElement::needsPrecomputeBlur() {
+    return false;
+}

--- a/src/render/pass/BorderPassElement.hpp
+++ b/src/render/pass/BorderPassElement.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include "PassElement.hpp"
+
+class CBorderPassElement : public IPassElement {
+  public:
+    struct SBorderData {
+        CBox               box;
+        CGradientValueData grad1, grad2;
+        bool               hasGrad2 = false;
+        float              lerp = 0.F, a = 1.F;
+        int                round = 0, borderSize = 1, outerRound = -1;
+    };
+
+    CBorderPassElement(const SBorderData& data_);
+    virtual ~CBorderPassElement() = default;
+
+    virtual void draw(const CRegion& damage);
+    virtual bool needsLiveBlur();
+    virtual bool needsPrecomputeBlur();
+
+  private:
+    SBorderData data;
+};

--- a/src/render/pass/FramebufferElement.cpp
+++ b/src/render/pass/FramebufferElement.cpp
@@ -1,0 +1,66 @@
+#include "FramebufferElement.hpp"
+#include "../OpenGL.hpp"
+
+CFramebufferElement::CFramebufferElement(const CFramebufferElement::SFramebufferElementData& data_) : data(data_) {
+    ;
+}
+
+void CFramebufferElement::draw(const CRegion& damage) {
+    CFramebuffer* fb = nullptr;
+
+    if (data.main) {
+        switch (data.framebufferID) {
+            case FB_MONITOR_RENDER_MAIN:
+                fb = g_pHyprOpenGL->m_RenderData.mainFB;
+                break;
+            case FB_MONITOR_RENDER_CURRENT:
+                fb = g_pHyprOpenGL->m_RenderData.currentFB;
+                break;
+            case FB_MONITOR_RENDER_OUT:
+                fb = g_pHyprOpenGL->m_RenderData.outFB;
+                break;
+        }
+
+        if (!fb) {
+            Debug::log(ERR, "BUG THIS: CFramebufferElement::draw: main but null");
+            return;
+        }
+
+    } else {
+        switch (data.framebufferID) {
+            case FB_MONITOR_RENDER_EXTRA_OFFLOAD:
+                fb = &g_pHyprOpenGL->m_RenderData.pCurrentMonData->offloadFB;
+                break;
+            case FB_MONITOR_RENDER_EXTRA_MIRROR:
+                fb = &g_pHyprOpenGL->m_RenderData.pCurrentMonData->mirrorFB;
+                break;
+            case FB_MONITOR_RENDER_EXTRA_MIRROR_SWAP:
+                fb = &g_pHyprOpenGL->m_RenderData.pCurrentMonData->mirrorSwapFB;
+                break;
+            case FB_MONITOR_RENDER_EXTRA_OFF_MAIN:
+                fb = &g_pHyprOpenGL->m_RenderData.pCurrentMonData->offMainFB;
+                break;
+            case FB_MONITOR_RENDER_EXTRA_MONITOR_MIRROR:
+                fb = &g_pHyprOpenGL->m_RenderData.pCurrentMonData->monitorMirrorFB;
+                break;
+            case FB_MONITOR_RENDER_EXTRA_BLUR:
+                fb = &g_pHyprOpenGL->m_RenderData.pCurrentMonData->blurFB;
+                break;
+        }
+
+        if (!fb) {
+            Debug::log(ERR, "BUG THIS: CFramebufferElement::draw: not main but null");
+            return;
+        }
+    }
+
+    fb->bind();
+}
+
+bool CFramebufferElement::needsLiveBlur() {
+    return false;
+}
+
+bool CFramebufferElement::needsPrecomputeBlur() {
+    return false;
+}

--- a/src/render/pass/FramebufferElement.hpp
+++ b/src/render/pass/FramebufferElement.hpp
@@ -1,0 +1,20 @@
+#pragma once
+#include "PassElement.hpp"
+
+class CFramebufferElement : public IPassElement {
+  public:
+    struct SFramebufferElementData {
+        bool    main          = true;
+        uint8_t framebufferID = 0;
+    };
+
+    CFramebufferElement(const SFramebufferElementData& data_);
+    virtual ~CFramebufferElement() = default;
+
+    virtual void draw(const CRegion& damage);
+    virtual bool needsLiveBlur();
+    virtual bool needsPrecomputeBlur();
+
+  private:
+    SFramebufferElementData data;
+};

--- a/src/render/pass/Pass.cpp
+++ b/src/render/pass/Pass.cpp
@@ -1,0 +1,32 @@
+#include "Pass.hpp"
+#include "../OpenGL.hpp"
+
+bool CRenderPass::empty() const {
+    return false;
+}
+
+bool CRenderPass::single() const {
+    return m_vPassElements.size() == 1;
+}
+
+bool CRenderPass::needsIntrospection() const {
+    return true;
+}
+
+void CRenderPass::add(SP<IPassElement> el) {
+    m_vPassElements.emplace_back(el);
+}
+
+void CRenderPass::simplify() {}
+
+void CRenderPass::clear() {
+    m_vPassElements.clear();
+}
+
+void CRenderPass::render() {
+    g_pHyprOpenGL->m_RenderData.pCurrentMonData->blurFBShouldRender = false; // TODO:
+
+    for (auto& el : m_vPassElements) {
+        el->draw(g_pHyprOpenGL->m_RenderData.damage);
+    }
+}

--- a/src/render/pass/Pass.hpp
+++ b/src/render/pass/Pass.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "../../defines.hpp"
+#include "PassElement.hpp"
+
+class CRenderPass {
+  public:
+    bool empty() const;
+    bool single() const;
+    bool needsIntrospection() const;
+
+    void add(SP<IPassElement> elem);
+    void simplify();
+    void clear();
+
+    void render();
+
+  private:
+    std::vector<SP<IPassElement>> m_vPassElements;
+
+    SP<IPassElement>             currentPassInfo = nullptr;
+
+    friend class CHyprOpenGLImpl;
+};

--- a/src/render/pass/PassElement.hpp
+++ b/src/render/pass/PassElement.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "../../defines.hpp"
+
+class IPassElement {
+  public:
+    virtual ~IPassElement() = default;
+
+    virtual void draw(const CRegion& damage) = 0;
+    virtual bool needsLiveBlur()             = 0;
+    virtual bool needsPrecomputeBlur()       = 0;
+};

--- a/src/render/pass/RectPassElement.cpp
+++ b/src/render/pass/RectPassElement.cpp
@@ -1,0 +1,21 @@
+#include "RectPassElement.hpp"
+#include "../OpenGL.hpp"
+
+CRectPassElement::CRectPassElement(const CRectPassElement::SRectData& data_) : data(data_) {
+    ;
+}
+
+void CRectPassElement::draw(const CRegion& damage) {
+    if (data.color.a == 1.F)
+        g_pHyprOpenGL->renderRectWithDamage(&data.box, data.color, damage, data.round);
+    else
+        g_pHyprOpenGL->renderRectWithBlur(&data.box, data.color, data.round, data.blurA, data.xray);
+}
+
+bool CRectPassElement::needsLiveBlur() {
+    return data.color.a < 1.F && !data.xray;
+}
+
+bool CRectPassElement::needsPrecomputeBlur() {
+    return data.color.a < 1.F && data.xray;
+}

--- a/src/render/pass/RectPassElement.hpp
+++ b/src/render/pass/RectPassElement.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include "PassElement.hpp"
+
+class CRectPassElement : public IPassElement {
+  public:
+    struct SRectData {
+        CBox       box;
+        CHyprColor color;
+        int        round = 0;
+        bool       blur = false, xray = false;
+        float      blurA = 1.F;
+    };
+
+    CRectPassElement(const SRectData& data);
+    virtual ~CRectPassElement() = default;
+
+    virtual void draw(const CRegion& damage);
+    virtual bool needsLiveBlur();
+    virtual bool needsPrecomputeBlur();
+
+  private:
+    SRectData data;
+};

--- a/src/render/pass/ShadowPassElement.cpp
+++ b/src/render/pass/ShadowPassElement.cpp
@@ -1,0 +1,19 @@
+#include "ShadowPassElement.hpp"
+#include "../OpenGL.hpp"
+#include "../decorations/CHyprDropShadowDecoration.hpp"
+
+CShadowPassElement::CShadowPassElement(const CShadowPassElement::SShadowData& data_) : data(data_) {
+    ;
+}
+
+void CShadowPassElement::draw(const CRegion& damage) {
+    data.deco->render(g_pHyprOpenGL->m_RenderData.pMonitor.lock(), data.a);
+}
+
+bool CShadowPassElement::needsLiveBlur() {
+    return false;
+}
+
+bool CShadowPassElement::needsPrecomputeBlur() {
+    return false;
+}

--- a/src/render/pass/ShadowPassElement.hpp
+++ b/src/render/pass/ShadowPassElement.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include "PassElement.hpp"
+
+class CHyprDropShadowDecoration;
+
+class CShadowPassElement : public IPassElement {
+  public:
+    struct SShadowData {
+        CHyprDropShadowDecoration* deco = nullptr;
+        float a = 1.F;
+    };
+
+    CShadowPassElement(const SShadowData& data_);
+    virtual ~CShadowPassElement() = default;
+
+    virtual void draw(const CRegion& damage);
+    virtual bool needsLiveBlur();
+    virtual bool needsPrecomputeBlur();
+
+  private:
+    SShadowData data;
+};

--- a/src/render/pass/TexPassElement.cpp
+++ b/src/render/pass/TexPassElement.cpp
@@ -1,0 +1,183 @@
+#include "TexPassElement.hpp"
+#include "../OpenGL.hpp"
+#include "../../desktop/WLSurface.hpp"
+#include "../../protocols/core/Compositor.hpp"
+#include "../../protocols/DRMSyncobj.hpp"
+
+#include <hyprutils/utils/ScopeGuard.hpp>
+using namespace Hyprutils::Utils;
+
+CTexPassElement::CTexPassElement(const CTexPassElement::SRenderData& data_) : data(data_) {
+    ;
+}
+
+CTexPassElement::CTexPassElement(const CTexPassElement::SSimpleRenderData& data_) : simple(data_) {
+    ;
+}
+
+void CTexPassElement::draw(const CRegion& damage) {
+    g_pHyprOpenGL->m_RenderData.currentWindow      = data.pWindow;
+    g_pHyprOpenGL->m_RenderData.currentLS          = data.pLS;
+    g_pHyprOpenGL->m_RenderData.clipBox            = data.clipBox;
+    g_pHyprOpenGL->m_RenderData.discardMode        = data.discardMode;
+    g_pHyprOpenGL->m_RenderData.discardOpacity     = data.discardOpacity;
+    g_pHyprOpenGL->m_RenderData.useNearestNeighbor = data.useNearestNeighbor;
+    g_pHyprOpenGL->m_bEndFrame                     = data.flipEndFrame;
+
+    CScopeGuard x = {[]() {
+        g_pHyprOpenGL->m_RenderData.primarySurfaceUVTopLeft     = Vector2D(-1, -1);
+        g_pHyprOpenGL->m_RenderData.primarySurfaceUVBottomRight = Vector2D(-1, -1);
+        g_pHyprOpenGL->m_RenderData.useNearestNeighbor          = false;
+        g_pHyprOpenGL->m_RenderData.clipBox                     = {};
+        g_pHyprOpenGL->m_RenderData.discardMode                 = 0;
+        g_pHyprOpenGL->m_RenderData.discardOpacity              = 0;
+        g_pHyprOpenGL->m_RenderData.useNearestNeighbor          = false;
+        g_pHyprOpenGL->m_bEndFrame                              = false;
+        g_pHyprOpenGL->m_RenderData.currentWindow.reset();
+        g_pHyprOpenGL->m_RenderData.currentLS.reset();
+    }};
+
+    if (simple) {
+        g_pHyprOpenGL->renderTextureInternalWithDamage(simple->tex, &simple->box, simple->a, simple->damage, simple->round);
+        return;
+    }
+
+    if (!data.texture)
+        return;
+
+    const auto& TEXTURE = data.texture;
+
+    // this is bad, probably has been logged elsewhere. Means the texture failed
+    // uploading to the GPU.
+    if (!TEXTURE->m_iTexID)
+        return;
+
+    // explicit sync: wait for the timeline, if any
+    if (data.surface->syncobj && data.surface->syncobj->current.acquireTimeline) {
+        if (!g_pHyprOpenGL->waitForTimelinePoint(data.surface->syncobj->current.acquireTimeline->timeline, data.surface->syncobj->current.acquirePoint)) {
+            Debug::log(ERR, "Renderer: failed to wait for explicit timeline");
+            return;
+        }
+    }
+
+    const auto INTERACTIVERESIZEINPROGRESS = data.pWindow && g_pInputManager->currentlyDraggedWindow && g_pInputManager->dragMode == MBIND_RESIZE;
+    TRACY_GPU_ZONE("RenderSurface");
+
+    double      outputX = -data.pMonitor->vecPosition.x, outputY = -data.pMonitor->vecPosition.y;
+
+    auto        PSURFACE = CWLSurface::fromResource(data.surface);
+
+    const float ALPHA = data.alpha * data.fadeAlpha * (PSURFACE ? PSURFACE->m_pAlphaModifier : 1.F);
+    const bool  BLUR  = data.blur && (!TEXTURE->m_bOpaque || ALPHA < 1.F);
+
+    CBox        windowBox;
+    if (data.surface && data.surface == data.surface) {
+        windowBox = {(int)outputX + data.pos.x + data.localPos.x, (int)outputY + data.pos.y + data.localPos.y, data.w, data.h};
+
+        // however, if surface buffer w / h < box, we need to adjust them
+        const auto PWINDOW = PSURFACE ? PSURFACE->getWindow() : nullptr;
+
+        // center the surface if it's smaller than the viewport we assign it
+        if (PSURFACE && !PSURFACE->m_bFillIgnoreSmall && PSURFACE->small() /* guarantees PWINDOW */) {
+            const auto CORRECT = PSURFACE->correctSmallVec();
+            const auto SIZE    = PSURFACE->getViewporterCorrectedSize();
+
+            if (!INTERACTIVERESIZEINPROGRESS) {
+                windowBox.translate(CORRECT);
+
+                windowBox.width  = SIZE.x * (PWINDOW->m_vRealSize.value().x / PWINDOW->m_vReportedSize.x);
+                windowBox.height = SIZE.y * (PWINDOW->m_vRealSize.value().y / PWINDOW->m_vReportedSize.y);
+            } else {
+                windowBox.width  = SIZE.x;
+                windowBox.height = SIZE.y;
+            }
+        }
+
+    } else { //  here we clamp to 2, these might be some tiny specks
+        windowBox = {(int)outputX + data.pos.x + data.localPos.x, (int)outputY + data.pos.y + data.localPos.y, std::max((float)data.surface->current.size.x, 2.F),
+                     std::max((float)data.surface->current.size.y, 2.F)};
+        if (data.pWindow && data.pWindow->m_vRealSize.isBeingAnimated() && data.surface && !data.mainSurface && data.squishOversized /* subsurface */) {
+            // adjust subsurfaces to the window
+            windowBox.width  = (windowBox.width / data.pWindow->m_vReportedSize.x) * data.pWindow->m_vRealSize.value().x;
+            windowBox.height = (windowBox.height / data.pWindow->m_vReportedSize.y) * data.pWindow->m_vRealSize.value().y;
+        }
+    }
+
+    if (data.squishOversized) {
+        if (data.localPos.x + windowBox.width > data.w)
+            windowBox.width = data.w - data.localPos.x;
+        if (data.localPos.y + windowBox.height > data.h)
+            windowBox.height = data.h - data.localPos.y;
+    }
+
+    const auto PROJSIZEUNSCALED = windowBox.size();
+
+    windowBox.scale(data.pMonitor->scale);
+    windowBox.round();
+
+    if (windowBox.width <= 1 || windowBox.height <= 1) {
+        if (!g_pHyprRenderer->m_bBlockSurfaceFeedback) {
+            Debug::log(TRACE, "presentFeedback for invisible surface");
+            data.surface->presentFeedback(data.when, data.pMonitor->self.lock());
+        }
+
+        return; // invisible
+    }
+
+    const bool MISALIGNEDFSV1 = std::floor(data.pMonitor->scale) != data.pMonitor->scale /* Fractional */ && data.surface->current.scale == 1 /* fs protocol */ &&
+        windowBox.size() != data.surface->current.bufferSize /* misaligned */ && DELTALESSTHAN(windowBox.width, data.surface->current.bufferSize.x, 3) &&
+        DELTALESSTHAN(windowBox.height, data.surface->current.bufferSize.y, 3) /* off by one-or-two */ &&
+        (!data.pWindow || (!data.pWindow->m_vRealSize.isBeingAnimated() && !INTERACTIVERESIZEINPROGRESS)) /* not window or not animated/resizing */;
+
+    g_pHyprRenderer->calculateUVForSurface(data.pWindow, data.surface, data.pMonitor->self.lock(), data.mainSurface, windowBox.size(), PROJSIZEUNSCALED, MISALIGNEDFSV1);
+
+    // check for fractional scale surfaces misaligning the buffer size
+    // in those cases it's better to just force nearest neighbor
+    // as long as the window is not animated. During those it'd look weird.
+    // UV will fixup it as well
+    if (MISALIGNEDFSV1)
+        g_pHyprOpenGL->m_RenderData.useNearestNeighbor = true;
+
+    float rounding = data.rounding;
+
+    rounding -= 1; // to fix a border issue
+
+    if (data.dontRound)
+        rounding = 0;
+
+    const bool WINDOWOPAQUE    = data.pWindow && data.pWindow->m_pWLSurface->resource() == data.surface ? data.pWindow->opaque() : false;
+    const bool CANDISABLEBLEND = ALPHA >= 1.f && rounding == 0 && WINDOWOPAQUE;
+
+    if (CANDISABLEBLEND)
+        g_pHyprOpenGL->blend(false);
+    else
+        g_pHyprOpenGL->blend(true);
+
+    // FIXME: This is wrong and will bug the blur out as shit if the first surface
+    // is a subsurface that does NOT cover the entire frame. In such cases, we probably should fall back
+    // to what we do for misaligned surfaces (blur the entire thing and then render shit without blur)
+    if (data.surfaceCounter == 0 && !data.popup) {
+        if (BLUR)
+            g_pHyprOpenGL->renderTextureWithBlur(TEXTURE, &windowBox, ALPHA, data.surface, rounding, data.blockBlurOptimization, data.fadeAlpha);
+        else
+            g_pHyprOpenGL->renderTexture(TEXTURE, &windowBox, ALPHA, rounding, false, true);
+    } else {
+        if (BLUR && data.popup)
+            g_pHyprOpenGL->renderTextureWithBlur(TEXTURE, &windowBox, ALPHA, data.surface, rounding, true, data.fadeAlpha);
+        else
+            g_pHyprOpenGL->renderTexture(TEXTURE, &windowBox, ALPHA, rounding, false, true);
+    }
+
+    if (!g_pHyprRenderer->m_bBlockSurfaceFeedback)
+        data.surface->presentFeedback(data.when, data.pMonitor->self.lock());
+
+    g_pHyprOpenGL->blend(true);
+}
+
+bool CTexPassElement::needsLiveBlur() {
+    return false; // FIXME:
+}
+
+bool CTexPassElement::needsPrecomputeBlur() {
+    return false;
+}

--- a/src/render/pass/TexPassElement.hpp
+++ b/src/render/pass/TexPassElement.hpp
@@ -1,0 +1,80 @@
+#pragma once
+#include "PassElement.hpp"
+#include <optional>
+
+class CTexPassElement : public IPassElement {
+  public:
+    struct SRenderData {
+        PHLMONITORREF pMonitor;
+        timespec*     when = nullptr;
+        Vector2D      pos, localPos;
+
+        // for iters
+        void*                  data        = nullptr;
+        SP<CWLSurfaceResource> surface     = nullptr;
+        SP<CTexture>           texture     = nullptr;
+        bool                   mainSurface = false;
+        double                 w = 0, h = 0;
+
+        // for rounding
+        bool dontRound = true;
+
+        // for fade
+        float fadeAlpha = 1.f;
+
+        // for alpha settings
+        float alpha = 1.f;
+
+        // for decorations (border)
+        bool decorate = false;
+
+        // for custom round values
+        int rounding = -1; // -1 means not set
+
+        // for blurring
+        bool blur                  = false;
+        bool blockBlurOptimization = false;
+
+        // only for windows, not popups
+        bool squishOversized = true;
+
+        // for calculating UV
+        PHLWINDOW pWindow;
+        PHLLS     pLS;
+
+        bool      popup = false;
+
+        // counts how many surfaces this pass has rendered
+        int      surfaceCounter = 0;
+
+        CBox     clipBox = {}; // scaled coordinates
+
+        uint32_t discardMode    = 0;
+        float    discardOpacity = 0.f;
+
+        bool     useNearestNeighbor = false;
+
+        bool     flipEndFrame = false;
+    };
+
+    struct SSimpleRenderData {
+        SP<CTexture> tex;
+        CBox         box;
+        float        a = 1.F;
+        CRegion      damage;
+        int          round = 0;
+        bool     flipEndFrame = false;
+    };
+
+    CTexPassElement(const SSimpleRenderData& data);
+    CTexPassElement(const SRenderData& data);
+    virtual ~CTexPassElement() = default;
+
+    virtual void draw(const CRegion& damage);
+    virtual bool needsLiveBlur();
+    virtual bool needsPrecomputeBlur();
+
+  private:
+    SRenderData                      data;
+    std::optional<SSimpleRenderData> simple;
+};

--- a/src/render/pass/TextureMatteElement.cpp
+++ b/src/render/pass/TextureMatteElement.cpp
@@ -1,0 +1,25 @@
+#include "TextureMatteElement.hpp"
+#include "../OpenGL.hpp"
+
+CTextureMatteElement::CTextureMatteElement(const CTextureMatteElement::STextureMatteData& data_) : data(data_) {
+    ;
+}
+
+void CTextureMatteElement::draw(const CRegion& damage) {
+    if (data.disableTransformAndModify) {
+        g_pHyprOpenGL->setMonitorTransformEnabled(true);
+        g_pHyprOpenGL->setRenderModifEnabled(false);
+        g_pHyprOpenGL->renderTextureMatte(data.tex, &data.box, *data.fb);
+        g_pHyprOpenGL->setRenderModifEnabled(true);
+        g_pHyprOpenGL->setMonitorTransformEnabled(false);
+    } else
+        g_pHyprOpenGL->renderTextureMatte(data.tex, &data.box, *data.fb);
+}
+
+bool CTextureMatteElement::needsLiveBlur() {
+    return false;
+}
+
+bool CTextureMatteElement::needsPrecomputeBlur() {
+    return false;
+}

--- a/src/render/pass/TextureMatteElement.hpp
+++ b/src/render/pass/TextureMatteElement.hpp
@@ -1,0 +1,22 @@
+#pragma once
+#include "PassElement.hpp"
+
+class CTextureMatteElement : public IPassElement {
+  public:
+    struct STextureMatteData {
+        CBox             box;
+        SP<CTexture>     tex;
+        SP<CFramebuffer> fb;
+        bool             disableTransformAndModify = false;
+    };
+
+    CTextureMatteElement(const STextureMatteData& data_);
+    virtual ~CTextureMatteElement() = default;
+
+    virtual void draw(const CRegion& damage);
+    virtual bool needsLiveBlur();
+    virtual bool needsPrecomputeBlur();
+
+  private:
+    STextureMatteData data;
+};


### PR DESCRIPTION
This MR rewrites the rendering scheduling internally.

Instead of rendering everything as-is, we queue the rendering then we can simplify it and do math.

Very wip, many things broken. Feel free to try and report if anything not on the list is broken.

Needs work:
 - [ ] Blur optimizations dont work
 - [ ] Fade out doesnt work
 - [ ] Weird damage glitches when opening window tho I might just be schizophrenic