### PR TITLE
Fix workspace selector parsing

### DIFF
--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -275,9 +275,9 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
             // f - fullscreen state : f[-1], f[0], f[1], or f[2] for different fullscreen states
             //                        -1: no fullscreen, 0: fullscreen, 1: maximized, 2: fullscreen without sending fs state to window
 
-            const auto  NEXTSPACE = selector.find_first_of(' ', i);
-            std::string prop      = selector.substr(i, NEXTSPACE == std::string::npos ? std::string::npos : NEXTSPACE - i);
-            i                     = std::min(NEXTSPACE, std::string::npos - 1);
+            const auto  CLOSING_BRACKET = selector.find_first_of(']', i);
+            std::string prop            = selector.substr(i, CLOSING_BRACKET == std::string::npos ? std::string::npos : CLOSING_BRACKET + 1 - i);
+            i                           = std::min(CLOSING_BRACKET, std::string::npos - 1);
 
             if (cur == 'r') {
                 WORKSPACEID from = 0, to = 0;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Search for the closing bracket when parsing a workspace selector. This is needed when the `m[desc:<monitor description>]` selector is used, as the monitor description always contains spaces.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

--

#### Is it ready for merging, or does it need work?

Should be ready.


