### PR TITLE
core/data: Use pointer focus for DnD operations

### DIFF
--- a/src/managers/SeatManager.hpp
+++ b/src/managers/SeatManager.hpp
@@ -95,6 +95,8 @@ class CSeatManager {
 
         WP<CWLSurfaceResource> touchFocus;
         WP<CWLSeatResource>    touchFocusResource;
+
+        WP<CWLSurfaceResource> dndPointerFocus;
     } state;
 
     struct SSetCursorEvent {
@@ -105,6 +107,7 @@ class CSeatManager {
     struct {
         CSignal keyboardFocusChange;
         CSignal pointerFocusChange;
+        CSignal dndPointerFocusChange;
         CSignal touchFocusChange;
         CSignal setCursor; // SSetCursorEvent
         CSignal setSelection;

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -374,8 +374,9 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus) {
     if (g_pPointerManager->softwareLockedFor(PMONITOR->self.lock()) > 0 && !skipFrameSchedule)
         g_pCompositor->scheduleFrameForMonitor(g_pCompositor->m_pLastMonitor.lock(), Aquamarine::IOutput::AQ_SCHEDULE_CURSOR_MOVE);
 
-    // grabs
-    if (g_pSeatManager->seatGrab && !g_pSeatManager->seatGrab->accepts(foundSurface)) {
+    // FIXME: This will be disabled during DnD operations because we do not exactly follow the spec
+    // xdg-popup grabs should be keyboard-only, while they are absolute in our case...
+    if (g_pSeatManager->seatGrab && !g_pSeatManager->seatGrab->accepts(foundSurface) && !PROTO::data->dndActive()) {
         if (m_bHardInput || refocus) {
             g_pSeatManager->setGrab(nullptr);
             return; // setGrab will refocus

--- a/src/protocols/core/DataDevice.cpp
+++ b/src/protocols/core/DataDevice.cpp
@@ -578,15 +578,8 @@ void CWLDataDeviceProtocol::updateDrag() {
     if (!dndActive())
         return;
 
-    if (dnd.focusedDevice) {
-        if (g_pSeatManager->state.dndPointerFocus) {
-            const auto NEW = dataDeviceForClient(g_pSeatManager->state.dndPointerFocus->client());
-            if (NEW == dnd.focusedDevice)
-                return; // nothing to do
-        }
-
+    if (dnd.focusedDevice)
         dnd.focusedDevice->sendLeave();
-    }
 
     if (!g_pSeatManager->state.dndPointerFocus)
         return;

--- a/src/protocols/core/DataDevice.hpp
+++ b/src/protocols/core/DataDevice.hpp
@@ -155,6 +155,7 @@ class CWLDataDeviceProtocol : public IWaylandProtocol {
     void sendSelectionToDevice(SP<CWLDataDeviceResource> dev, SP<IDataSource> sel);
     void updateSelection();
     void onKeyboardFocus();
+    void onDndPointerFocus();
 
     struct {
         WP<CWLDataDeviceResource> focusedDevice;
@@ -191,6 +192,7 @@ class CWLDataDeviceProtocol : public IWaylandProtocol {
 
     struct {
         CHyprSignalListener onKeyboardFocusChange;
+        CHyprSignalListener onDndPointerFocusChange;
     } listeners;
 };
 


### PR DESCRIPTION
This is mostly to fix stuff from #7737

Cases:
 - [x] `pcmanfm-qt --desktop` -> panel
 - [x] `pcmanfm-qt` -> panel
 - [x] menu -> panel

Unsure why the last one doesn't work ATM.