### PR TITLE
xwayland: Support cross DnD from Wayland

### DIFF
--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -213,6 +213,36 @@ void CHyprXWaylandManager::setWindowFullscreen(PHLWINDOW pWindow, bool fullscree
         pWindow->m_pXDGSurface->toplevel->setFullscreen(fullscreen);
 }
 
+Vector2D CHyprXWaylandManager::waylandToXWaylandCoords(const Vector2D& coord) {
+    static auto PXWLFORCESCALEZERO = CConfigValue<Hyprlang::INT>("xwayland:force_zero_scaling");
+
+    PHLMONITOR  pMonitor     = nullptr;
+    double      bestDistance = __FLT_MAX__;
+    for (const auto& m : g_pCompositor->m_vMonitors) {
+        const auto SIZ = *PXWLFORCESCALEZERO ? m->vecTransformedSize : m->vecSize;
+
+        double     distance = vecToRectDistanceSquared(coord, {m->vecPosition.x, m->vecPosition.y}, {m->vecPosition.x + SIZ.x - 1, m->vecPosition.y + SIZ.y - 1});
+
+        if (distance < bestDistance) {
+            bestDistance = distance;
+            pMonitor     = m;
+        }
+    }
+
+    if (!pMonitor)
+        return Vector2D{};
+
+    // get local coords
+    Vector2D result = coord - pMonitor->vecPosition;
+    // if scaled, scale
+    if (*PXWLFORCESCALEZERO)
+        result *= pMonitor->scale;
+    // add pos
+    result += pMonitor->vecXWaylandPosition;
+
+    return result;
+}
+
 Vector2D CHyprXWaylandManager::xwaylandToWaylandCoords(const Vector2D& coord) {
 
     static auto PXWLFORCESCALEZERO = CConfigValue<Hyprlang::INT>("xwayland:force_zero_scaling");

--- a/src/managers/XWaylandManager.hpp
+++ b/src/managers/XWaylandManager.hpp
@@ -22,6 +22,7 @@ class CHyprXWaylandManager {
     bool                   shouldBeFloated(PHLWINDOW, bool pending = false);
     void                   checkBorders(PHLWINDOW);
     Vector2D               xwaylandToWaylandCoords(const Vector2D&);
+    Vector2D               waylandToXWaylandCoords(const Vector2D&);
 };
 
 inline std::unique_ptr<CHyprXWaylandManager> g_pXWaylandManager;

--- a/src/protocols/core/DataDevice.cpp
+++ b/src/protocols/core/DataDevice.cpp
@@ -6,6 +6,8 @@
 #include "../../Compositor.hpp"
 #include "Seat.hpp"
 #include "Compositor.hpp"
+#include "../../xwayland/XWayland.hpp"
+#include "../../xwayland/Server.hpp"
 
 CWLDataOfferResource::CWLDataOfferResource(SP<CWlDataOffer> resource_, SP<IDataSource> source_) : source(source_), resource(resource_) {
     if (!good())
@@ -101,6 +103,22 @@ void CWLDataOfferResource::sendData() {
         LOGM(LOG, " | offer {:x} supports mime {}", (uintptr_t)this, m);
         resource->sendOffer(m.c_str());
     }
+}
+
+eDataSourceType CWLDataOfferResource::type() {
+    return DATA_SOURCE_TYPE_WAYLAND;
+}
+
+SP<CWLDataOfferResource> CWLDataOfferResource::getWayland() {
+    return self.lock();
+}
+
+SP<CX11DataOffer> CWLDataOfferResource::getX11() {
+    return nullptr;
+}
+
+SP<IDataSource> CWLDataOfferResource::getSource() {
+    return source.lock();
 }
 
 CWLDataSourceResource::CWLDataSourceResource(SP<CWlDataSource> resource_, SP<CWLDataDeviceResource> device_) : device(device_), resource(resource_) {
@@ -209,6 +227,10 @@ uint32_t CWLDataSourceResource::actions() {
     return supportedActions;
 }
 
+eDataSourceType CWLDataSourceResource::type() {
+    return DATA_SOURCE_TYPE_WAYLAND;
+}
+
 CWLDataDeviceResource::CWLDataDeviceResource(SP<CWlDataDevice> resource_) : resource(resource_) {
     if (!good())
         return;
@@ -260,15 +282,18 @@ wl_client* CWLDataDeviceResource::client() {
     return pClient;
 }
 
-void CWLDataDeviceResource::sendDataOffer(SP<CWLDataOfferResource> offer) {
-    if (offer)
-        resource->sendDataOffer(offer->resource.get());
-    else
+void CWLDataDeviceResource::sendDataOffer(SP<IDataOffer> offer) {
+    if (!offer)
         resource->sendDataOfferRaw(nullptr);
+    else if (const auto WL = offer->getWayland(); WL)
+        resource->sendDataOffer(WL->resource.get());
+    //FIXME: X11
 }
 
-void CWLDataDeviceResource::sendEnter(uint32_t serial, SP<CWLSurfaceResource> surf, const Vector2D& local, SP<CWLDataOfferResource> offer) {
-    resource->sendEnterRaw(serial, surf->getResource()->resource(), wl_fixed_from_double(local.x), wl_fixed_from_double(local.y), offer->resource->resource());
+void CWLDataDeviceResource::sendEnter(uint32_t serial, SP<CWLSurfaceResource> surf, const Vector2D& local, SP<IDataOffer> offer) {
+    if (const auto WL = offer->getWayland(); WL)
+        resource->sendEnterRaw(serial, surf->getResource()->resource(), wl_fixed_from_double(local.x), wl_fixed_from_double(local.y), WL->resource->resource());
+    // FIXME: X11
 }
 
 void CWLDataDeviceResource::sendLeave() {
@@ -283,11 +308,23 @@ void CWLDataDeviceResource::sendDrop() {
     resource->sendDrop();
 }
 
-void CWLDataDeviceResource::sendSelection(SP<CWLDataOfferResource> offer) {
+void CWLDataDeviceResource::sendSelection(SP<IDataOffer> offer) {
     if (!offer)
         resource->sendSelectionRaw(nullptr);
-    else
-        resource->sendSelection(offer->resource.get());
+    else if (const auto WL = offer->getWayland(); WL)
+        resource->sendSelection(WL->resource.get());
+}
+
+eDataSourceType CWLDataDeviceResource::type() {
+    return DATA_SOURCE_TYPE_WAYLAND;
+}
+
+SP<CWLDataDeviceResource> CWLDataDeviceResource::getWayland() {
+    return self.lock();
+}
+
+SP<CX11DataDevice> CWLDataDeviceResource::getX11() {
+    return nullptr;
 }
 
 CWLDataDeviceManagerResource::CWLDataDeviceManagerResource(SP<CWlDataDeviceManager> resource_) : resource(resource_) {
@@ -377,32 +414,48 @@ void CWLDataDeviceProtocol::destroyResource(CWLDataOfferResource* resource) {
     std::erase_if(m_vOffers, [&](const auto& other) { return other.get() == resource; });
 }
 
-SP<CWLDataDeviceResource> CWLDataDeviceProtocol::dataDeviceForClient(wl_client* c) {
+SP<IDataDevice> CWLDataDeviceProtocol::dataDeviceForClient(wl_client* c) {
+    if (c == g_pXWayland->pServer->xwaylandClient)
+        return g_pXWayland->pWM->getDataDevice();
+
     auto it = std::find_if(m_vDevices.begin(), m_vDevices.end(), [c](const auto& e) { return e->client() == c; });
     if (it == m_vDevices.end())
         return nullptr;
     return *it;
 }
 
-void CWLDataDeviceProtocol::sendSelectionToDevice(SP<CWLDataDeviceResource> dev, SP<IDataSource> sel) {
+void CWLDataDeviceProtocol::sendSelectionToDevice(SP<IDataDevice> dev, SP<IDataSource> sel) {
     if (!sel) {
         dev->sendSelection(nullptr);
         return;
     }
 
-    const auto OFFER = m_vOffers.emplace_back(makeShared<CWLDataOfferResource>(makeShared<CWlDataOffer>(dev->resource->client(), dev->resource->version(), 0), sel));
+    SP<IDataOffer> offer;
 
-    if (!OFFER->good()) {
-        dev->resource->noMemory();
-        m_vOffers.pop_back();
+    if (const auto WL = dev->getWayland(); WL) {
+        const auto OFFER = m_vOffers.emplace_back(makeShared<CWLDataOfferResource>(makeShared<CWlDataOffer>(WL->resource->client(), WL->resource->version(), 0), sel));
+        if (!OFFER->good()) {
+            WL->resource->noMemory();
+            m_vOffers.pop_back();
+            return;
+        }
+        OFFER->source = sel;
+        OFFER->self   = OFFER;
+        offer         = OFFER;
+    } else if (const auto X11 = dev->getX11(); X11)
+        offer = g_pXWayland->pWM->createX11DataOffer(g_pSeatManager->state.keyboardFocus.lock(), sel);
+
+    if (!offer) {
+        LOGM(ERR, "No offer could be created in sendSelectionToDevice");
         return;
     }
 
-    LOGM(LOG, "New offer {:x} for data source {:x}", (uintptr_t)OFFER.get(), (uintptr_t)sel.get());
+    LOGM(LOG, "New {} offer {:x} for data source {:x}", offer->type() == DATA_SOURCE_TYPE_WAYLAND ? "wayland" : "X11", (uintptr_t)offer.get(), (uintptr_t)sel.get());
 
-    dev->sendDataOffer(OFFER);
-    OFFER->sendData();
-    dev->sendSelection(OFFER);
+    dev->sendDataOffer(offer);
+    if (const auto WL = offer->getWayland(); WL)
+        WL->sendData();
+    dev->sendSelection(offer);
 }
 
 void CWLDataDeviceProtocol::onDestroyDataSource(WP<CWLDataSourceResource> source) {
@@ -424,7 +477,7 @@ void CWLDataDeviceProtocol::setSelection(SP<IDataSource> source) {
             return;
 
         auto DESTDEVICE = dataDeviceForClient(g_pSeatManager->state.keyboardFocusResource->client());
-        if (DESTDEVICE)
+        if (DESTDEVICE && DESTDEVICE->type() == DATA_SOURCE_TYPE_WAYLAND)
             sendSelectionToDevice(DESTDEVICE, nullptr);
 
         return;
@@ -439,6 +492,11 @@ void CWLDataDeviceProtocol::setSelection(SP<IDataSource> source) {
 
     if (!DESTDEVICE) {
         LOGM(LOG, "CWLDataDeviceProtocol::setSelection: cannot send selection to a client without a data_device");
+        return;
+    }
+
+    if (DESTDEVICE->type() != DATA_SOURCE_TYPE_WAYLAND) {
+        LOGM(LOG, "CWLDataDeviceProtocol::setSelection: ignoring X11 data device");
         return;
     }
 
@@ -589,22 +647,35 @@ void CWLDataDeviceProtocol::updateDrag() {
     if (!dnd.focusedDevice)
         return;
 
-    // make a new offer
-    const auto OFFER = m_vOffers.emplace_back(
-        makeShared<CWLDataOfferResource>(makeShared<CWlDataOffer>(dnd.focusedDevice->resource->client(), dnd.focusedDevice->resource->version(), 0), dnd.currentSource.lock()));
+    SP<IDataOffer> offer;
 
-    if (!OFFER->good()) {
-        dnd.currentSource->resource->noMemory();
-        m_vOffers.pop_back();
+    if (const auto WL = dnd.focusedDevice->getWayland(); WL) {
+        const auto OFFER =
+            m_vOffers.emplace_back(makeShared<CWLDataOfferResource>(makeShared<CWlDataOffer>(WL->resource->client(), WL->resource->version(), 0), dnd.currentSource.lock()));
+        if (!OFFER->good()) {
+            WL->resource->noMemory();
+            m_vOffers.pop_back();
+            return;
+        }
+        OFFER->source = dnd.currentSource;
+        OFFER->self   = OFFER;
+        offer         = OFFER;
+    } else if (const auto X11 = dnd.focusedDevice->getX11(); X11)
+        offer = g_pXWayland->pWM->createX11DataOffer(g_pSeatManager->state.keyboardFocus.lock(), dnd.currentSource.lock());
+
+    if (!offer) {
+        LOGM(ERR, "No offer could be created in updateDrag");
         return;
     }
 
-    LOGM(LOG, "New dnd offer {:x} for data source {:x}", (uintptr_t)OFFER.get(), (uintptr_t)dnd.currentSource.get());
+    LOGM(LOG, "New {} dnd offer {:x} for data source {:x}", offer->type() == DATA_SOURCE_TYPE_WAYLAND ? "wayland" : "X11", (uintptr_t)offer.get(),
+         (uintptr_t)dnd.currentSource.get());
 
-    dnd.focusedDevice->sendDataOffer(OFFER);
-    OFFER->sendData();
+    dnd.focusedDevice->sendDataOffer(offer);
+    if (const auto WL = offer->getWayland(); WL)
+        WL->sendData();
     dnd.focusedDevice->sendEnter(wl_display_next_serial(g_pCompositor->m_sWLDisplay), g_pSeatManager->state.dndPointerFocus.lock(),
-                                 g_pSeatManager->state.dndPointerFocus->current.size / 2.F, OFFER);
+                                 g_pSeatManager->state.dndPointerFocus->current.size / 2.F, offer);
 }
 
 void CWLDataDeviceProtocol::resetDndState() {
@@ -649,6 +720,16 @@ bool CWLDataDeviceProtocol::wasDragSuccessful() {
 
         if (o->recvd || o->accepted)
             return true;
+    }
+
+    for (auto const& o : g_pXWayland->pWM->dndDataOffers) {
+        if (o->dead || !o->source || !o->source->hasDnd())
+            continue;
+
+        if (o->source != dnd.currentSource)
+            continue;
+
+        return true;
     }
 
     return false;

--- a/src/protocols/core/DataDevice.hpp
+++ b/src/protocols/core/DataDevice.hpp
@@ -26,21 +26,27 @@ class CWLDataOfferResource;
 class CWLSurfaceResource;
 class CMonitor;
 
-class CWLDataOfferResource {
+class CWLDataOfferResource : public IDataOffer {
   public:
     CWLDataOfferResource(SP<CWlDataOffer> resource_, SP<IDataSource> source_);
     ~CWLDataOfferResource();
 
-    bool            good();
-    void            sendData();
+    bool                             good();
+    void                             sendData();
 
-    WP<IDataSource> source;
+    virtual eDataSourceType          type();
+    virtual SP<CWLDataOfferResource> getWayland();
+    virtual SP<CX11DataOffer>        getX11();
+    virtual SP<IDataSource>          getSource();
 
-    bool            dead     = false;
-    bool            accepted = false;
-    bool            recvd    = false;
+    WP<IDataSource>                  source;
+    WP<CWLDataOfferResource>         self;
 
-    uint32_t        actions = 0;
+    bool                             dead     = false;
+    bool                             accepted = false;
+    bool                             recvd    = false;
+
+    uint32_t                         actions = 0;
 
   private:
     SP<CWlDataOffer> resource;
@@ -66,9 +72,9 @@ class CWLDataSourceResource : public IDataSource {
     virtual void                     error(uint32_t code, const std::string& msg);
     virtual void                     sendDndFinished();
     virtual uint32_t                 actions(); // wl_data_device_manager.dnd_action
-
-    void                             sendDndDropPerformed();
-    void                             sendDndAction(wl_data_device_manager_dnd_action a);
+    virtual eDataSourceType          type();
+    virtual void                     sendDndDropPerformed();
+    virtual void                     sendDndAction(wl_data_device_manager_dnd_action a);
 
     bool                             used       = false;
     bool                             dnd        = false;
@@ -88,21 +94,24 @@ class CWLDataSourceResource : public IDataSource {
     friend class CWLDataDeviceProtocol;
 };
 
-class CWLDataDeviceResource {
+class CWLDataDeviceResource : public IDataDevice {
   public:
     CWLDataDeviceResource(SP<CWlDataDevice> resource_);
 
-    bool                      good();
-    wl_client*                client();
+    bool                              good();
+    wl_client*                        client();
 
-    void                      sendDataOffer(SP<CWLDataOfferResource> offer);
-    void                      sendEnter(uint32_t serial, SP<CWLSurfaceResource> surf, const Vector2D& local, SP<CWLDataOfferResource> offer);
-    void                      sendLeave();
-    void                      sendMotion(uint32_t timeMs, const Vector2D& local);
-    void                      sendDrop();
-    void                      sendSelection(SP<CWLDataOfferResource> offer);
+    virtual SP<CWLDataDeviceResource> getWayland();
+    virtual SP<CX11DataDevice>        getX11();
+    virtual void                      sendDataOffer(SP<IDataOffer> offer);
+    virtual void                      sendEnter(uint32_t serial, SP<CWLSurfaceResource> surf, const Vector2D& local, SP<IDataOffer> offer);
+    virtual void                      sendLeave();
+    virtual void                      sendMotion(uint32_t timeMs, const Vector2D& local);
+    virtual void                      sendDrop();
+    virtual void                      sendSelection(SP<IDataOffer> offer);
+    virtual eDataSourceType           type();
 
-    WP<CWLDataDeviceResource> self;
+    WP<CWLDataDeviceResource>         self;
 
   private:
     SP<CWlDataDevice> resource;
@@ -152,19 +161,19 @@ class CWLDataDeviceProtocol : public IWaylandProtocol {
 
     void onDestroyDataSource(WP<CWLDataSourceResource> source);
     void setSelection(SP<IDataSource> source);
-    void sendSelectionToDevice(SP<CWLDataDeviceResource> dev, SP<IDataSource> sel);
+    void sendSelectionToDevice(SP<IDataDevice> dev, SP<IDataSource> sel);
     void updateSelection();
     void onKeyboardFocus();
     void onDndPointerFocus();
 
     struct {
-        WP<CWLDataDeviceResource> focusedDevice;
-        WP<CWLDataSourceResource> currentSource;
-        WP<CWLSurfaceResource>    dndSurface;
-        WP<CWLSurfaceResource>    originSurface;
-        bool                      overriddenCursor = false;
-        CHyprSignalListener       dndSurfaceDestroy;
-        CHyprSignalListener       dndSurfaceCommit;
+        WP<IDataDevice>        focusedDevice;
+        WP<IDataSource>        currentSource;
+        WP<CWLSurfaceResource> dndSurface;
+        WP<CWLSurfaceResource> originSurface;
+        bool                   overriddenCursor = false;
+        CHyprSignalListener    dndSurfaceDestroy;
+        CHyprSignalListener    dndSurfaceCommit;
 
         // for ending a dnd
         SP<HOOK_CALLBACK_FN> mouseMove;
@@ -182,7 +191,7 @@ class CWLDataDeviceProtocol : public IWaylandProtocol {
     bool wasDragSuccessful();
 
     //
-    SP<CWLDataDeviceResource> dataDeviceForClient(wl_client*);
+    SP<IDataDevice> dataDeviceForClient(wl_client*);
 
     friend class CSeatManager;
     friend class CWLDataDeviceManagerResource;

--- a/src/protocols/types/DataDevice.cpp
+++ b/src/protocols/types/DataDevice.cpp
@@ -27,3 +27,15 @@ void IDataSource::sendDndFinished() {
 uint32_t IDataSource::actions() {
     return 7; // all
 }
+
+void IDataSource::sendDndDropPerformed() {
+    ;
+}
+
+void IDataSource::sendDndAction(wl_data_device_manager_dnd_action a) {
+    ;
+}
+
+void IDataOffer::markDead() {
+    ;
+}

--- a/src/protocols/types/DataDevice.hpp
+++ b/src/protocols/types/DataDevice.hpp
@@ -5,6 +5,11 @@
 #include <cstdint>
 #include "../../helpers/signal/Signal.hpp"
 
+class CWLDataOfferResource;
+class CX11DataOffer;
+class CX11DataDevice;
+class CWLDataDeviceResource;
+
 enum eDataSourceType : uint8_t {
     DATA_SOURCE_TYPE_WAYLAND = 0,
     DATA_SOURCE_TYPE_X11,
@@ -27,6 +32,8 @@ class IDataSource {
     virtual void                     error(uint32_t code, const std::string& msg) = 0;
     virtual eDataSourceType          type();
     virtual uint32_t                 actions(); // wl_data_device_manager.dnd_action
+    virtual void                     sendDndDropPerformed();
+    virtual void                     sendDndAction(wl_data_device_manager_dnd_action a);
 
     struct {
         CSignal destroy;
@@ -34,4 +41,32 @@ class IDataSource {
 
   private:
     bool wasUsed = false;
+};
+
+class IDataOffer {
+  public:
+    IDataOffer()          = default;
+    virtual ~IDataOffer() = default;
+
+    virtual eDataSourceType          type()       = 0;
+    virtual SP<CWLDataOfferResource> getWayland() = 0;
+    virtual SP<CX11DataOffer>        getX11()     = 0;
+    virtual SP<IDataSource>          getSource()  = 0;
+    virtual void                     markDead();
+};
+
+class IDataDevice {
+  public:
+    IDataDevice()          = default;
+    virtual ~IDataDevice() = default;
+
+    virtual SP<CWLDataDeviceResource> getWayland()                                                                                         = 0;
+    virtual SP<CX11DataDevice>        getX11()                                                                                             = 0;
+    virtual void                      sendDataOffer(SP<IDataOffer> offer)                                                                  = 0;
+    virtual void                      sendEnter(uint32_t serial, SP<CWLSurfaceResource> surf, const Vector2D& local, SP<IDataOffer> offer) = 0;
+    virtual void                      sendLeave()                                                                                          = 0;
+    virtual void                      sendMotion(uint32_t timeMs, const Vector2D& local)                                                   = 0;
+    virtual void                      sendDrop()                                                                                           = 0;
+    virtual void                      sendSelection(SP<IDataOffer> offer)                                                                  = 0;
+    virtual eDataSourceType           type()                                                                                               = 0;
 };

--- a/src/protocols/types/DataDevice.hpp
+++ b/src/protocols/types/DataDevice.hpp
@@ -9,6 +9,7 @@ class CWLDataOfferResource;
 class CX11DataOffer;
 class CX11DataDevice;
 class CWLDataDeviceResource;
+class CWLSurfaceResource;
 
 enum eDataSourceType : uint8_t {
     DATA_SOURCE_TYPE_WAYLAND = 0,

--- a/src/protocols/types/DataDevice.hpp
+++ b/src/protocols/types/DataDevice.hpp
@@ -4,6 +4,8 @@
 #include <vector>
 #include <cstdint>
 #include "../../helpers/signal/Signal.hpp"
+#include <wayland-server-protocol.h>
+#include "../../helpers/memory/Memory.hpp"
 
 class CWLDataOfferResource;
 class CX11DataOffer;

--- a/src/protocols/types/DataDevice.hpp
+++ b/src/protocols/types/DataDevice.hpp
@@ -6,6 +6,7 @@
 #include "../../helpers/signal/Signal.hpp"
 #include <wayland-server-protocol.h>
 #include "../../helpers/memory/Memory.hpp"
+#include "../../helpers/math/Math.hpp"
 
 class CWLDataOfferResource;
 class CX11DataOffer;

--- a/src/xwayland/Dnd.cpp
+++ b/src/xwayland/Dnd.cpp
@@ -1,0 +1,203 @@
+#include "Dnd.hpp"
+#include "XWM.hpp"
+#include "XWayland.hpp"
+#include "Server.hpp"
+#include "../managers/XWaylandManager.hpp"
+#include "../desktop/WLSurface.hpp"
+
+static xcb_atom_t dndActionToAtom(uint32_t actions) {
+    if (actions & WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY)
+        return HYPRATOMS["XdndActionCopy"];
+    else if (actions & WL_DATA_DEVICE_MANAGER_DND_ACTION_MOVE)
+        return HYPRATOMS["XdndActionMove"];
+    else if (actions & WL_DATA_DEVICE_MANAGER_DND_ACTION_ASK)
+        return HYPRATOMS["XdndActionAsk"];
+
+    return XCB_ATOM_NONE;
+}
+
+eDataSourceType CX11DataOffer::type() {
+    return DATA_SOURCE_TYPE_X11;
+}
+
+SP<CWLDataOfferResource> CX11DataOffer::getWayland() {
+    return nullptr;
+}
+
+SP<CX11DataOffer> CX11DataOffer::getX11() {
+    return self.lock();
+}
+
+SP<IDataSource> CX11DataOffer::getSource() {
+    return source.lock();
+}
+
+void CX11DataOffer::markDead() {
+    std::erase(g_pXWayland->pWM->dndDataOffers, self);
+}
+
+void CX11DataDevice::sendDataOffer(SP<IDataOffer> offer) {
+    ; // no-op, I don't think this has an X equiv
+}
+
+void CX11DataDevice::sendEnter(uint32_t serial, SP<CWLSurfaceResource> surf, const Vector2D& local, SP<IDataOffer> offer) {
+    auto XSURF = g_pXWayland->pWM->windowForWayland(surf);
+
+    if (offer == lastOffer)
+        return;
+
+    if (!XSURF) {
+        Debug::log(ERR, "CX11DataDevice::sendEnter: No xwayland surface for destination");
+        return;
+    }
+
+    auto SOURCE = offer->getSource();
+
+    if (!SOURCE) {
+        Debug::log(ERR, "CX11DataDevice::sendEnter: No source");
+        return;
+    }
+
+    // invalidate old
+    std::erase_if(g_pXWayland->pWM->dndDataOffers, [this](const auto& e) { return e != self; });
+
+    xcb_set_selection_owner(g_pXWayland->pWM->connection, g_pXWayland->pWM->dndSelection.window, HYPRATOMS["XdndSelection"], XCB_TIME_CURRENT_TIME);
+
+    xcb_client_message_data_t data = {0};
+    data.data32[0]                 = g_pXWayland->pWM->dndSelection.window;
+    data.data32[1]                 = XDND_VERSION << 24;
+
+    // let the client know it needs to check for DND_TYPE_LIST
+    data.data32[1] |= 1;
+
+    std::vector<xcb_atom_t> targets;
+
+    for (auto& mime : SOURCE->mimes()) {
+        targets.emplace_back(g_pXWayland->pWM->mimeToAtom(mime));
+    }
+
+    xcb_change_property(g_pXWayland->pWM->connection, XCB_PROP_MODE_REPLACE, g_pXWayland->pWM->dndSelection.window, HYPRATOMS["XdndTypeList"], XCB_ATOM_ATOM, 32, targets.size(),
+                        targets.data());
+
+    g_pXWayland->pWM->sendDndEvent(surf, HYPRATOMS["XdndEnter"], data);
+
+    lastSurface = XSURF;
+    lastOffer   = offer;
+
+    auto hlSurface = CWLSurface::fromResource(surf);
+    if (!hlSurface) {
+        Debug::log(ERR, "CX11DataDevice::sendEnter: Non desktop x surface?!");
+        lastSurfaceCoords = {};
+        return;
+    }
+
+    lastSurfaceCoords = hlSurface->getSurfaceBoxGlobal().value_or(CBox{}).pos();
+}
+
+void CX11DataDevice::sendLeave() {
+    if (!lastSurface)
+        return;
+
+    xcb_client_message_data_t data = {0};
+    data.data32[0]                 = g_pXWayland->pWM->dndSelection.window;
+
+    g_pXWayland->pWM->sendDndEvent(lastSurface->surface.lock(), HYPRATOMS["XdndLeave"], data);
+
+    lastSurface.reset();
+    lastOffer.reset();
+
+    xcb_set_selection_owner(g_pXWayland->pWM->connection, g_pXWayland->pWM->dndSelection.window, XCB_ATOM_NONE, XCB_TIME_CURRENT_TIME);
+}
+
+void CX11DataDevice::sendMotion(uint32_t timeMs, const Vector2D& local) {
+    if (!lastSurface || !lastOffer || !lastOffer->getSource())
+        return;
+
+    const auto                XCOORDS = g_pXWaylandManager->waylandToXWaylandCoords(lastSurfaceCoords + local);
+
+    xcb_client_message_data_t data = {0};
+    data.data32[0]                 = g_pXWayland->pWM->dndSelection.window;
+    data.data32[2]                 = (((int32_t)XCOORDS.x) << 16) | (int32_t)XCOORDS.y;
+    data.data32[3]                 = timeMs;
+    data.data32[4]                 = dndActionToAtom(lastOffer->getSource()->actions());
+
+    g_pXWayland->pWM->sendDndEvent(lastSurface->surface.lock(), HYPRATOMS["XdndPosition"], data);
+    lastTime = timeMs;
+}
+
+void CX11DataDevice::sendDrop() {
+    if (!lastSurface || !lastOffer)
+        return;
+
+    // we don't have timeMs here, just send last time + 1
+
+    xcb_client_message_data_t data = {0};
+    data.data32[0]                 = g_pXWayland->pWM->dndSelection.window;
+    data.data32[2]                 = lastTime + 1;
+
+    g_pXWayland->pWM->sendDndEvent(lastSurface->surface.lock(), HYPRATOMS["XdndDrop"], data);
+}
+
+void CX11DataDevice::sendSelection(SP<IDataOffer> offer) {
+    ; // no-op. Selection is done separately.
+}
+
+eDataSourceType CX11DataDevice::type() {
+    return DATA_SOURCE_TYPE_X11;
+}
+
+SP<CWLDataDeviceResource> CX11DataDevice::getWayland() {
+    return nullptr;
+}
+
+SP<CX11DataDevice> CX11DataDevice::getX11() {
+    return self.lock();
+}
+
+std::vector<std::string> CX11DataSource::mimes() {
+    return mimeTypes;
+}
+
+void CX11DataSource::send(const std::string& mime, uint32_t fd) {
+    ;
+}
+
+void CX11DataSource::accepted(const std::string& mime) {
+    ;
+}
+
+void CX11DataSource::cancelled() {
+    ;
+}
+
+bool CX11DataSource::hasDnd() {
+    return dnd;
+}
+
+bool CX11DataSource::dndDone() {
+    return dropped;
+}
+
+void CX11DataSource::error(uint32_t code, const std::string& msg) {
+    Debug::log(ERR, "CX11DataSource::error: this fn is a stub: code {} msg {}", code, msg);
+}
+
+void CX11DataSource::sendDndFinished() {
+    ;
+}
+
+uint32_t CX11DataSource::actions() {
+    return supportedActions;
+}
+
+eDataSourceType CX11DataSource::type() {
+    return DATA_SOURCE_TYPE_X11;
+}
+
+void CX11DataSource::sendDndDropPerformed() {
+    ; // FIXME:
+}
+
+void CX11DataSource::sendDndAction(wl_data_device_manager_dnd_action a) {
+    ; // FIXME:
+}

--- a/src/xwayland/Dnd.cpp
+++ b/src/xwayland/Dnd.cpp
@@ -33,7 +33,9 @@ SP<IDataSource> CX11DataOffer::getSource() {
 }
 
 void CX11DataOffer::markDead() {
+#ifndef NO_XWAYLAND
     std::erase(g_pXWayland->pWM->dndDataOffers, self);
+#endif
 }
 
 void CX11DataDevice::sendDataOffer(SP<IDataOffer> offer) {
@@ -41,6 +43,7 @@ void CX11DataDevice::sendDataOffer(SP<IDataOffer> offer) {
 }
 
 void CX11DataDevice::sendEnter(uint32_t serial, SP<CWLSurfaceResource> surf, const Vector2D& local, SP<IDataOffer> offer) {
+#ifndef NO_XWAYLAND
     auto XSURF = g_pXWayland->pWM->windowForWayland(surf);
 
     if (offer == lastOffer)
@@ -89,9 +92,11 @@ void CX11DataDevice::sendEnter(uint32_t serial, SP<CWLSurfaceResource> surf, con
     }
 
     lastSurfaceCoords = hlSurface->getSurfaceBoxGlobal().value_or(CBox{}).pos();
+#endif
 }
 
 void CX11DataDevice::sendLeave() {
+#ifndef NO_XWAYLAND
     if (!lastSurface)
         return;
 
@@ -104,9 +109,11 @@ void CX11DataDevice::sendLeave() {
     lastOffer.reset();
 
     xcb_set_selection_owner(g_pXWayland->pWM->connection, g_pXWayland->pWM->dndSelection.window, XCB_ATOM_NONE, XCB_TIME_CURRENT_TIME);
+#endif
 }
 
 void CX11DataDevice::sendMotion(uint32_t timeMs, const Vector2D& local) {
+#ifndef NO_XWAYLAND
     if (!lastSurface || !lastOffer || !lastOffer->getSource())
         return;
 
@@ -120,14 +127,15 @@ void CX11DataDevice::sendMotion(uint32_t timeMs, const Vector2D& local) {
 
     g_pXWayland->pWM->sendDndEvent(lastSurface->surface.lock(), HYPRATOMS["XdndPosition"], data);
     lastTime = timeMs;
+#endif
 }
 
 void CX11DataDevice::sendDrop() {
+#ifndef NO_XWAYLAND
     if (!lastSurface || !lastOffer)
         return;
 
     // we don't have timeMs here, just send last time + 1
-
     xcb_client_message_data_t data = {0};
     data.data32[0]                 = g_pXWayland->pWM->dndSelection.window;
     data.data32[2]                 = lastTime + 1;
@@ -135,6 +143,7 @@ void CX11DataDevice::sendDrop() {
     g_pXWayland->pWM->sendDndEvent(lastSurface->surface.lock(), HYPRATOMS["XdndDrop"], data);
 
     sendLeave();
+#endif
 }
 
 void CX11DataDevice::sendSelection(SP<IDataOffer> offer) {
@@ -194,9 +203,9 @@ eDataSourceType CX11DataSource::type() {
 }
 
 void CX11DataSource::sendDndDropPerformed() {
-    ; // FIXME:
+    ;
 }
 
 void CX11DataSource::sendDndAction(wl_data_device_manager_dnd_action a) {
-    ; // FIXME:
+    ;
 }

--- a/src/xwayland/Dnd.cpp
+++ b/src/xwayland/Dnd.cpp
@@ -58,9 +58,6 @@ void CX11DataDevice::sendEnter(uint32_t serial, SP<CWLSurfaceResource> surf, con
         return;
     }
 
-    // invalidate old
-    std::erase_if(g_pXWayland->pWM->dndDataOffers, [this](const auto& e) { return e != self; });
-
     xcb_set_selection_owner(g_pXWayland->pWM->connection, g_pXWayland->pWM->dndSelection.window, HYPRATOMS["XdndSelection"], XCB_TIME_CURRENT_TIME);
 
     xcb_client_message_data_t data = {0};
@@ -136,6 +133,8 @@ void CX11DataDevice::sendDrop() {
     data.data32[2]                 = lastTime + 1;
 
     g_pXWayland->pWM->sendDndEvent(lastSurface->surface.lock(), HYPRATOMS["XdndDrop"], data);
+
+    sendLeave();
 }
 
 void CX11DataDevice::sendSelection(SP<IDataOffer> offer) {

--- a/src/xwayland/Dnd.hpp
+++ b/src/xwayland/Dnd.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "../protocols/types/DataDevice.hpp"
+#include <wayland-server-protocol.h>
+
+#define XDND_VERSION 5
+
+class CXWaylandSurface;
+
+class CX11DataOffer : public IDataOffer {
+  public:
+    CX11DataOffer()  = default;
+    ~CX11DataOffer() = default;
+
+    virtual eDataSourceType          type();
+    virtual SP<CWLDataOfferResource> getWayland();
+    virtual SP<CX11DataOffer>        getX11();
+    virtual SP<IDataSource>          getSource();
+    virtual void                     markDead();
+
+    WP<IDataSource>                  source;
+    WP<CX11DataOffer>                self;
+    WP<CXWaylandSurface>             xwaylandSurface;
+
+    bool                             dead     = false;
+    bool                             accepted = false;
+    bool                             recvd    = false;
+
+    uint32_t                         actions = 0;
+};
+
+class CX11DataSource : public IDataSource {
+  public:
+    CX11DataSource()  = default;
+    ~CX11DataSource() = default;
+
+    virtual std::vector<std::string> mimes();
+    virtual void                     send(const std::string& mime, uint32_t fd);
+    virtual void                     accepted(const std::string& mime);
+    virtual void                     cancelled();
+    virtual bool                     hasDnd();
+    virtual bool                     dndDone();
+    virtual void                     error(uint32_t code, const std::string& msg);
+    virtual void                     sendDndFinished();
+    virtual uint32_t                 actions(); // wl_data_device_manager.dnd_action
+    virtual eDataSourceType          type();
+    virtual void                     sendDndDropPerformed();
+    virtual void                     sendDndAction(wl_data_device_manager_dnd_action a);
+
+    bool                             used       = false;
+    bool                             dnd        = true;
+    bool                             dndSuccess = false;
+    bool                             dropped    = false;
+
+    WP<CX11DataSource>               self;
+
+    std::vector<std::string>         mimeTypes;
+    uint32_t                         supportedActions = 0;
+};
+
+class CX11DataDevice : public IDataDevice {
+  public:
+    CX11DataDevice() = default;
+
+    virtual SP<CWLDataDeviceResource> getWayland();
+    virtual SP<CX11DataDevice>        getX11();
+    virtual void                      sendDataOffer(SP<IDataOffer> offer);
+    virtual void                      sendEnter(uint32_t serial, SP<CWLSurfaceResource> surf, const Vector2D& local, SP<IDataOffer> offer);
+    virtual void                      sendLeave();
+    virtual void                      sendMotion(uint32_t timeMs, const Vector2D& local);
+    virtual void                      sendDrop();
+    virtual void                      sendSelection(SP<IDataOffer> offer);
+    virtual eDataSourceType           type();
+
+    WP<CX11DataDevice>                self;
+
+  private:
+    WP<CXWaylandSurface> lastSurface;
+    WP<IDataOffer>       lastOffer;
+    Vector2D             lastSurfaceCoords;
+    uint32_t             lastTime = 0;
+};

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -1258,6 +1258,9 @@ SP<IDataOffer> CXWM::createX11DataOffer(SP<CWLSurfaceResource> surf, SP<IDataSou
         return nullptr;
     }
 
+    // invalidate old
+    g_pXWayland->pWM->dndDataOffers.clear();
+
     auto offer             = dndDataOffers.emplace_back(makeShared<CX11DataOffer>());
     offer->self            = offer;
     offer->xwaylandSurface = XSURF;


### PR DESCRIPTION
This MR adds support for DnD operations that cross the barrier between XWayland and wayland.

## Work
 - [x] wl -> xwl
 - [ ] ~~xwl -> wl~~ sway can't do either, idk if it's easily doable.

## Issues
 - [x] wl -> xwl dnd only works once atm
 - [ ] Thunar just fucking spams the shit out of X on every odd-numbered DnD. Even ones work. wtf?