### PR TITLE
`movefocus_cycle_groupfirst`: cycle within group on single monitor if no window found in the argument direction.

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1395,17 +1395,16 @@ SDispatchResult CKeybindManager::moveFocusTo(std::string args) {
         g_pCompositor->getWindowInDirection(PLASTWINDOW, arg);
 
     // Prioritize focus change within groups if the window is a part of it.
-    if (*PGROUPCYCLE) {
-        if (!PLASTWINDOW->m_sGroupData.pNextWindow.expired()) {
-            if (arg == 'l' && PLASTWINDOW != PLASTWINDOW->getGroupHead()) {
-                PLASTWINDOW->setGroupCurrent(PLASTWINDOW->getGroupPrevious());
-                return {};
-            }
+    if (*PGROUPCYCLE && (!PLASTWINDOW->m_sGroupData.pNextWindow.expired())) {
+        auto isTheOnlyGroupOnWs = (PWINDOWTOCHANGETO == nullptr);
+        if (arg == 'l' && (PLASTWINDOW != PLASTWINDOW->getGroupHead() || isTheOnlyGroupOnWs)) {
+            PLASTWINDOW->setGroupCurrent(PLASTWINDOW->getGroupPrevious());
+            return {};
+        }
 
-            else if (arg == 'r' && PLASTWINDOW != PLASTWINDOW->getGroupTail()) {
-                PLASTWINDOW->setGroupCurrent(PLASTWINDOW->m_sGroupData.pNextWindow.lock());
-                return {};
-            }
+        else if (arg == 'r' && (PLASTWINDOW != PLASTWINDOW->getGroupTail() || isTheOnlyGroupOnWs)) {
+            PLASTWINDOW->setGroupCurrent(PLASTWINDOW->m_sGroupData.pNextWindow.lock());
+            return {};
         }
     }
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1396,7 +1396,7 @@ SDispatchResult CKeybindManager::moveFocusTo(std::string args) {
 
     // Prioritize focus change within groups if the window is a part of it.
     if (*PGROUPCYCLE && (!PLASTWINDOW->m_sGroupData.pNextWindow.expired())) {
-        auto isTheOnlyGroupOnWs = (PWINDOWTOCHANGETO == nullptr);
+        auto isTheOnlyGroupOnWs = (PWINDOWTOCHANGETO == nullptr) && (g_pCompositor->m_vMonitors.size() == 1);
         if (arg == 'l' && (PLASTWINDOW != PLASTWINDOW->getGroupHead() || isTheOnlyGroupOnWs)) {
             PLASTWINDOW->setGroupCurrent(PLASTWINDOW->getGroupPrevious());
             return {};


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
+ Modified the logic of `movefocus_cycle_groupfirst` to keep cycling within the group if there is no window found in the argument direction for single monitor users. Example cases:
  + For single-monitor users
    + if there's only a single group in the workspace, focus will keep cycling to the other end instead of ending on one side. https://github.com/hyprwm/Hyprland/pull/8601#issuecomment-2543070992
    + If the there is no window to the left of the group and the user tries to go left, it will cycle back into the tail of the group instead of trying to look for the next window on the workspace.
  + For multi-monitor users, the logic remains same as the previous.

OBS keeps crashing after I installed hyprland-git and I haven't looked into it so I can't post a video, sorry.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I don't have multiple monitors so I haven't tested for it. I think the logic should work as intended.

#### Is it ready for merging, or does it need work?
Changes are limited to the original code. Ready.

