### PR TITLE
core: Move regex from stdlib to re2

### DIFF
--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -60,7 +60,8 @@ runs:
           xcb-util \
           xcb-util-image \
           libzip \
-          librsvg
+          librsvg \
+          re2
 
     - name: Get hyprwayland-scanner-git
       shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,8 +101,6 @@ else()
 endif()
 find_package(OpenGL REQUIRED COMPONENTS ${GLES_VERSION})
 
-pkg_check_modules(hyprctl_deps REQUIRED IMPORTED_TARGET hyprutils>=0.2.4)
-
 pkg_check_modules(aquamarine_dep REQUIRED IMPORTED_TARGET aquamarine>=0.4.5)
 pkg_check_modules(hyprlang_dep REQUIRED IMPORTED_TARGET hyprlang>=0.3.2)
 pkg_check_modules(hyprcursor_dep REQUIRED IMPORTED_TARGET hyprcursor>=0.1.7)
@@ -131,7 +129,8 @@ pkg_check_modules(
   libdrm
   libinput
   gbm
-  gio-2.0)
+  gio-2.0
+  re2)
 
 find_package(hyprwayland-scanner 0.3.10 REQUIRED)
 

--- a/hyprctl/CMakeLists.txt
+++ b/hyprctl/CMakeLists.txt
@@ -5,7 +5,7 @@ project(
     DESCRIPTION "Control utility for Hyprland"
 )
 
-pkg_check_modules(deps REQUIRED IMPORTED_TARGET hyprutils>=0.1.1)
+pkg_check_modules(hyprctl_deps REQUIRED IMPORTED_TARGET hyprutils>=0.2.4 re2)
 
 add_executable(hyprctl "main.cpp")
 

--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -1,3 +1,5 @@
+#include <re2/re2.h>
+
 #include <cctype>
 #include <netdb.h>
 #include <netinet/in.h>
@@ -14,7 +16,6 @@
 #include <algorithm>
 #include <csignal>
 #include <format>
-#include <re2/re2.h>
 
 #include <iostream>
 #include <string>

--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <csignal>
 #include <format>
+#include <re2/re2.h>
 
 #include <iostream>
 #include <string>
@@ -23,7 +24,6 @@
 #include <vector>
 #include <filesystem>
 #include <cstdarg>
-#include <regex>
 #include <sys/socket.h>
 #include <hyprutils/string/String.hpp>
 #include <cstring>
@@ -281,11 +281,10 @@ int requestHyprpaper(std::string arg) {
 }
 
 void batchRequest(std::string arg, bool json) {
-    std::string commands = arg.substr(arg.find_first_of(" ") + 1);
+    std::string commands = arg.substr(arg.find_first_of(' ') + 1);
 
-    if (json) {
-        commands = "j/" + std::regex_replace(commands, std::regex(";\\s*"), ";j/");
-    }
+    if (json)
+        RE2::GlobalReplace(&commands, ";\\s*", ";j/");
 
     std::string rq = "[[BATCH]]" + commands;
     request(rq);

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1,3 +1,5 @@
+#include <re2/re2.h>
+
 #include "Compositor.hpp"
 #include "debug/Log.hpp"
 #include "helpers/Splashes.hpp"
@@ -2392,19 +2394,19 @@ PHLWINDOW CCompositor::getWindowByRegex(const std::string& regexp_) {
 
     eFocusWindowMode mode = MODE_CLASS_REGEX;
 
-    std::regex       regexCheck(regexp_);
+    std::string      regexCheck;
     std::string      matchCheck;
     if (regexp.starts_with("class:")) {
-        regexCheck = std::regex(regexp.substr(6));
+        regexCheck = regexp.substr(6);
     } else if (regexp.starts_with("initialclass:")) {
         mode       = MODE_INITIAL_CLASS_REGEX;
-        regexCheck = std::regex(regexp.substr(13));
+        regexCheck = regexp.substr(13);
     } else if (regexp.starts_with("title:")) {
         mode       = MODE_TITLE_REGEX;
-        regexCheck = std::regex(regexp.substr(6));
+        regexCheck = regexp.substr(6);
     } else if (regexp.starts_with("initialtitle:")) {
         mode       = MODE_INITIAL_TITLE_REGEX;
-        regexCheck = std::regex(regexp.substr(13));
+        regexCheck = regexp.substr(13);
     } else if (regexp.starts_with("address:")) {
         mode       = MODE_ADDRESS;
         matchCheck = regexp.substr(8);
@@ -2420,25 +2422,25 @@ PHLWINDOW CCompositor::getWindowByRegex(const std::string& regexp_) {
         switch (mode) {
             case MODE_CLASS_REGEX: {
                 const auto windowClass = w->m_szClass;
-                if (!std::regex_search(windowClass, regexCheck))
+                if (!RE2::FullMatch(windowClass, regexCheck))
                     continue;
                 break;
             }
             case MODE_INITIAL_CLASS_REGEX: {
                 const auto initialWindowClass = w->m_szInitialClass;
-                if (!std::regex_search(initialWindowClass, regexCheck))
+                if (!RE2::FullMatch(initialWindowClass, regexCheck))
                     continue;
                 break;
             }
             case MODE_TITLE_REGEX: {
                 const auto windowTitle = w->m_szTitle;
-                if (!std::regex_search(windowTitle, regexCheck))
+                if (!RE2::FullMatch(windowTitle, regexCheck))
                     continue;
                 break;
             }
             case MODE_INITIAL_TITLE_REGEX: {
                 const auto initialWindowTitle = w->m_szInitialTitle;
-                if (!std::regex_search(initialWindowTitle, regexCheck))
+                if (!RE2::FullMatch(initialWindowTitle, regexCheck))
                     continue;
                 break;
             }

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -20,6 +20,7 @@
 #include <unistd.h>
 #include <glob.h>
 #include <xkbcommon/xkbcommon.h>
+#include <re2/re2.h>
 
 #include <algorithm>
 #include <fstream>
@@ -1257,14 +1258,10 @@ std::vector<SP<CWindowRule>> CConfigManager::getMatchingRules(PHLWINDOW pWindow,
                     continue;
 
                 if (rule->szValue.starts_with("title:")) {
-                    std::regex RULECHECK(rule->szValue.substr(6));
-
-                    if (!std::regex_search(pWindow->m_szTitle, RULECHECK))
+                    if (!RE2::FullMatch(pWindow->m_szTitle, rule->szValue.substr(6)))
                         continue;
                 } else {
-                    std::regex classCheck(rule->szValue);
-
-                    if (!std::regex_search(pWindow->m_szClass, classCheck))
+                    if (!RE2::FullMatch(pWindow->m_szClass, rule->szValue))
                         continue;
                 }
             } catch (...) {

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -9,7 +9,6 @@
 #include <variant>
 #include <vector>
 #include <algorithm>
-#include <regex>
 #include <optional>
 #include <functional>
 #include <xf86drmMode.h>

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1,3 +1,5 @@
+#include <re2/re2.h>
+
 #include <any>
 #include <bit>
 #include <string_view>
@@ -1601,13 +1603,13 @@ PHLWINDOW CWindow::getSwallower() {
     }
 
     if (!(*PSWALLOWREGEX).empty())
-        std::erase_if(candidates, [&](const auto& other) { return !std::regex_match(other->m_szClass, std::regex(*PSWALLOWREGEX)); });
+        std::erase_if(candidates, [&](const auto& other) { return !RE2::FullMatch(other->m_szClass, *PSWALLOWREGEX); });
 
     if (candidates.size() <= 0)
         return nullptr;
 
     if (!(*PSWALLOWEXREGEX).empty())
-        std::erase_if(candidates, [&](const auto& other) { return std::regex_match(other->m_szTitle, std::regex(*PSWALLOWEXREGEX)); });
+        std::erase_if(candidates, [&](const auto& other) { return RE2::FullMatch(other->m_szTitle, *PSWALLOWEXREGEX); });
 
     if (candidates.size() <= 0)
         return nullptr;

--- a/src/pch/pch.hpp
+++ b/src/pch/pch.hpp
@@ -1,5 +1,3 @@
-#include "Compositor.hpp"
-
 #include <algorithm>
 #include <any>
 #include <array>

--- a/src/pch/pch.hpp
+++ b/src/pch/pch.hpp
@@ -18,7 +18,6 @@
 #include <optional>
 #include <random>
 #include <ranges>
-#include <regex>
 #include <set>
 #include <sstream>
 #include <string>


### PR DESCRIPTION
Moves regex parsing from stdlib (slow as shit) to Google's RE2: https://github.com/google/re2

RE2 is BSD-3-Clause, so we good.

ref #8732