### PR TITLE
Fix meson build not working since re2 merge

### DIFF
--- a/hyprctl/meson.build
+++ b/hyprctl/meson.build
@@ -3,6 +3,7 @@ executable(
   'main.cpp',
   dependencies: [
     dependency('hyprutils', version: '>= 0.1.1'),
+    dependency('re2')
   ],
   install: true,
 )

--- a/meson.build
+++ b/meson.build
@@ -51,6 +51,7 @@ xcb_res_dep = dependency('xcb-res', required: get_option('xwayland'))
 xcb_xfixes_dep = dependency('xcb-xfixes', required: get_option('xwayland'))
 
 gio_dep = dependency('gio-2.0', required: true)
+re2_dep = dependency('re2', required: true)
 
 if not xcb_dep.found()
   add_project_arguments('-DNO_XWAYLAND', language: 'cpp')


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

#### Describe your PR, what does it fix/add?
attempt to fix meson build, currently fails the `hyprland-git` AUR package (we're also wondering why we're even using meson in the first place). https://aur.archlinux.org/packages/hyprland-git#comment-1002446

Mainly creating this draft PR to ask for help from people who actually know how meson works.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

hyprctl now properly links with this PR, but Hyprland doesn't yet:
```
[306/306] Linking target src/Hyprland
FAILED: src/Hyprland 
c++  -o src/Hyprland src/Hyprland.p/meson-generated_.._.._protocols_wlr-gamma-control-unstable-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_wlr-foreign-toplevel-management-unstable-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_wlr-output-power-management-unstable-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_input-method-unstable-v2.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_virtual-keyboard-unstable-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_wlr-virtual-pointer-unstable-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_wlr-output-management-unstable-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_kde-server-decoration.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_wlr-layer-shell-unstable-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_wayland-drm.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_wlr-data-control-unstable-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_wlr-screencopy-unstable-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_hyprland-global-shortcuts-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_hyprland-toplevel-export-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_hyprland-focus-grab-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_hyprland-ctm-control-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_tearing-control-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_fractional-scale-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_xdg-output-unstable-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_cursor-shape-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_idle-inhibit-unstable-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_relative-pointer-unstable-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_xdg-decoration-unstable-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_alpha-modifier-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_ext-foreign-toplevel-list-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_pointer-gestures-unstable-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_keyboard-shortcuts-inhibit-unstable-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_text-input-unstable-v3.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_text-input-unstable-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_pointer-constraints-unstable-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_xdg-activation-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_ext-idle-notify-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_ext-session-lock-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_tablet-v2.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_presentation-time.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_xdg-shell.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_primary-selection-unstable-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_xwayland-shell-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_viewporter.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_linux-dmabuf-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_drm-lease-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_linux-drm-syncobj-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_xdg-dialog-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_single-pixel-buffer-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_security-context-v1.cpp.o src/Hyprland.p/meson-generated_.._.._protocols_wayland.cpp.o src/Hyprland.p/Compositor.cpp.o src/Hyprland.p/config_ConfigManager.cpp.o src/Hyprland.p/debug_CrashReporter.cpp.o src/Hyprland.p/debug_HyprCtl.cpp.o src/Hyprland.p/debug_HyprDebugOverlay.cpp.o src/Hyprland.p/debug_HyprNotificationOverlay.cpp.o src/Hyprland.p/debug_Log.cpp.o src/Hyprland.p/desktop_LayerRule.cpp.o src/Hyprland.p/desktop_LayerSurface.cpp.o src/Hyprland.p/desktop_Popup.cpp.o src/Hyprland.p/desktop_Subsurface.cpp.o src/Hyprland.p/desktop_Window.cpp.o src/Hyprland.p/desktop_WindowRule.cpp.o src/Hyprland.p/desktop_WLSurface.cpp.o src/Hyprland.p/desktop_Workspace.cpp.o src/Hyprland.p/devices_IHID.cpp.o src/Hyprland.p/devices_IKeyboard.cpp.o src/Hyprland.p/devices_IPointer.cpp.o src/Hyprland.p/devices_ITouch.cpp.o src/Hyprland.p/devices_Keyboard.cpp.o src/Hyprland.p/devices_Mouse.cpp.o src/Hyprland.p/devices_Tablet.cpp.o src/Hyprland.p/devices_TouchDevice.cpp.o src/Hyprland.p/devices_VirtualKeyboard.cpp.o src/Hyprland.p/devices_VirtualPointer.cpp.o src/Hyprland.p/events_Windows.cpp.o src/Hyprland.p/helpers_AnimatedVariable.cpp.o src/Hyprland.p/helpers_BezierCurve.cpp.o src/Hyprland.p/helpers_Color.cpp.o src/Hyprland.p/helpers_DamageRing.cpp.o src/Hyprland.p/helpers_Format.cpp.o src/Hyprland.p/helpers_math_Math.cpp.o src/Hyprland.p/helpers_MiscFunctions.cpp.o src/Hyprland.p/helpers_Monitor.cpp.o src/Hyprland.p/helpers_SdDaemon.cpp.o src/Hyprland.p/helpers_sync_SyncReleaser.cpp.o src/Hyprland.p/helpers_sync_SyncTimeline.cpp.o src/Hyprland.p/helpers_TagKeeper.cpp.o src/Hyprland.p/helpers_Timer.cpp.o src/Hyprland.p/helpers_Watchdog.cpp.o src/Hyprland.p/helpers_WLClasses.cpp.o src/Hyprland.p/hyprerror_HyprError.cpp.o src/Hyprland.p/init_initHelpers.cpp.o src/Hyprland.p/layout_DwindleLayout.cpp.o src/Hyprland.p/layout_IHyprLayout.cpp.o src/Hyprland.p/layout_MasterLayout.cpp.o src/Hyprland.p/main.cpp.o src/Hyprland.p/managers_AnimationManager.cpp.o src/Hyprland.p/managers_CursorManager.cpp.o src/Hyprland.p/managers_eventLoop_EventLoopManager.cpp.o src/Hyprland.p/managers_eventLoop_EventLoopTimer.cpp.o src/Hyprland.p/managers_EventManager.cpp.o src/Hyprland.p/managers_HookSystemManager.cpp.o src/Hyprland.p/managers_input_IdleInhibitor.cpp.o src/Hyprland.p/managers_input_InputManager.cpp.o src/Hyprland.p/managers_input_InputMethodPopup.cpp.o src/Hyprland.p/managers_input_InputMethodRelay.cpp.o src/Hyprland.p/managers_input_Swipe.cpp.o src/Hyprland.p/managers_input_Tablets.cpp.o src/Hyprland.p/managers_input_TextInput.cpp.o src/Hyprland.p/managers_input_Touch.cpp.o src/Hyprland.p/managers_KeybindManager.cpp.o src/Hyprland.p/managers_LayoutManager.cpp.o src/Hyprland.p/managers_PointerManager.cpp.o src/Hyprland.p/managers_ProtocolManager.cpp.o src/Hyprland.p/managers_SeatManager.cpp.o src/Hyprland.p/managers_SessionLockManager.cpp.o src/Hyprland.p/managers_ThreadManager.cpp.o src/Hyprland.p/managers_TokenManager.cpp.o src/Hyprland.p/managers_VersionKeeperManager.cpp.o src/Hyprland.p/managers_XCursorManager.cpp.o src/Hyprland.p/managers_XWaylandManager.cpp.o src/Hyprland.p/plugins_HookSystem.cpp.o src/Hyprland.p/plugins_PluginAPI.cpp.o src/Hyprland.p/plugins_PluginSystem.cpp.o src/Hyprland.p/protocols_AlphaModifier.cpp.o src/Hyprland.p/protocols_core_Compositor.cpp.o src/Hyprland.p/protocols_core_DataDevice.cpp.o src/Hyprland.p/protocols_core_Output.cpp.o src/Hyprland.p/protocols_core_Seat.cpp.o src/Hyprland.p/protocols_core_Shm.cpp.o src/Hyprland.p/protocols_core_Subcompositor.cpp.o src/Hyprland.p/protocols_CTMControl.cpp.o src/Hyprland.p/protocols_CursorShape.cpp.o src/Hyprland.p/protocols_DataDeviceWlr.cpp.o src/Hyprland.p/protocols_DRMLease.cpp.o src/Hyprland.p/protocols_DRMSyncobj.cpp.o src/Hyprland.p/protocols_FocusGrab.cpp.o src/Hyprland.p/protocols_ForeignToplevel.cpp.o src/Hyprland.p/protocols_ForeignToplevelWlr.cpp.o src/Hyprland.p/protocols_FractionalScale.cpp.o src/Hyprland.p/protocols_GammaControl.cpp.o src/Hyprland.p/protocols_GlobalShortcuts.cpp.o src/Hyprland.p/protocols_IdleInhibit.cpp.o src/Hyprland.p/protocols_IdleNotify.cpp.o src/Hyprland.p/protocols_InputMethodV2.cpp.o src/Hyprland.p/protocols_LayerShell.cpp.o src/Hyprland.p/protocols_LinuxDMABUF.cpp.o src/Hyprland.p/protocols_MesaDRM.cpp.o src/Hyprland.p/protocols_OutputManagement.cpp.o src/Hyprland.p/protocols_OutputPower.cpp.o src/Hyprland.p/protocols_PointerConstraints.cpp.o src/Hyprland.p/protocols_PointerGestures.cpp.o src/Hyprland.p/protocols_PresentationTime.cpp.o src/Hyprland.p/protocols_PrimarySelection.cpp.o src/Hyprland.p/protocols_RelativePointer.cpp.o src/Hyprland.p/protocols_Screencopy.cpp.o src/Hyprland.p/protocols_SecurityContext.cpp.o src/Hyprland.p/protocols_ServerDecorationKDE.cpp.o src/Hyprland.p/protocols_SessionLock.cpp.o src/Hyprland.p/protocols_ShortcutsInhibit.cpp.o src/Hyprland.p/protocols_SinglePixel.cpp.o src/Hyprland.p/protocols_Tablet.cpp.o src/Hyprland.p/protocols_TearingControl.cpp.o src/Hyprland.p/protocols_TextInputV1.cpp.o src/Hyprland.p/protocols_TextInputV3.cpp.o src/Hyprland.p/protocols_ToplevelExport.cpp.o src/Hyprland.p/protocols_types_Buffer.cpp.o src/Hyprland.p/protocols_types_DataDevice.cpp.o src/Hyprland.p/protocols_types_DMABuffer.cpp.o src/Hyprland.p/protocols_types_WLBuffer.cpp.o src/Hyprland.p/protocols_Viewporter.cpp.o src/Hyprland.p/protocols_VirtualKeyboard.cpp.o src/Hyprland.p/protocols_VirtualPointer.cpp.o src/Hyprland.p/protocols_WaylandProtocol.cpp.o src/Hyprland.p/protocols_XDGActivation.cpp.o src/Hyprland.p/protocols_XDGDecoration.cpp.o src/Hyprland.p/protocols_XDGDialog.cpp.o src/Hyprland.p/protocols_XDGOutput.cpp.o src/Hyprland.p/protocols_XDGShell.cpp.o src/Hyprland.p/protocols_XWaylandShell.cpp.o src/Hyprland.p/render_decorations_CHyprBorderDecoration.cpp.o src/Hyprland.p/render_decorations_CHyprDropShadowDecoration.cpp.o src/Hyprland.p/render_decorations_CHyprGroupBarDecoration.cpp.o src/Hyprland.p/render_decorations_DecorationPositioner.cpp.o src/Hyprland.p/render_decorations_IHyprWindowDecoration.cpp.o src/Hyprland.p/render_Framebuffer.cpp.o src/Hyprland.p/render_OpenGL.cpp.o src/Hyprland.p/render_Renderbuffer.cpp.o src/Hyprland.p/render_Renderer.cpp.o src/Hyprland.p/render_Shader.cpp.o src/Hyprland.p/render_Texture.cpp.o src/Hyprland.p/render_Transformer.cpp.o src/Hyprland.p/signal-safe.cpp.o src/Hyprland.p/xwayland_Dnd.cpp.o src/Hyprland.p/xwayland_Server.cpp.o src/Hyprland.p/xwayland_XDataSource.cpp.o src/Hyprland.p/xwayland_XSurface.cpp.o src/Hyprland.p/xwayland_XWayland.cpp.o src/Hyprland.p/xwayland_XWM.cpp.o -Wl,--as-needed -Wl,--no-undefined -Wl,-O1 -Wl,--start-group protocols/libserver_protos.a subprojects/udis86/liblibudis86.a -rdynamic /usr/lib/libaquamarine.so /usr/lib/libhyprcursor.so /usr/lib/libhyprgraphics.so /usr/lib/libhyprlang.so /usr/lib/libhyprutils.so /usr/lib/libgbm.so /usr/lib/libXcursor.so /usr/lib/libwayland-server.so /usr/lib/libwayland-client.so /usr/lib/libcairo.so /usr/lib/libdrm.so /usr/lib/libEGL.so /usr/lib/libxkbcommon.so /usr/lib/libinput.so /usr/lib/libxcb.so /usr/lib/libxcb-composite.so /usr/lib/libxcb-errors.so /usr/lib/libxcb-icccm.so /usr/lib/libxcb-render.so /usr/lib/libxcb-res.so /usr/lib/libxcb-xfixes.so /usr/lib/libgio-2.0.so /usr/lib/libgobject-2.0.so /usr/lib/libglib-2.0.so /usr/lib/libpixman-1.so /usr/lib/libGL.so -pthread /usr/lib/libpango-1.0.so /usr/lib/libharfbuzz.so /usr/lib/libpangocairo-1.0.so /usr/lib/libuuid.so -Wl,--end-group
/usr/bin/ld: src/Hyprland.p/Compositor.cpp.o: in function `CCompositor::getWindowByRegex(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
Compositor.cpp:(.text+0x18d9b): undefined reference to `re2::RE2::RE2(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: Compositor.cpp:(.text+0x18dbe): undefined reference to `re2::RE2::FullMatchN(std::basic_string_view<char, std::char_traits<char> >, re2::RE2 const&, re2::RE2::Arg const* const*, int)'
/usr/bin/ld: Compositor.cpp:(.text+0x18dc9): undefined reference to `re2::RE2::~RE2()'
/usr/bin/ld: Compositor.cpp:(.text+0x19104): undefined reference to `re2::RE2::RE2(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: Compositor.cpp:(.text+0x19127): undefined reference to `re2::RE2::FullMatchN(std::basic_string_view<char, std::char_traits<char> >, re2::RE2 const&, re2::RE2::Arg const* const*, int)'
/usr/bin/ld: Compositor.cpp:(.text+0x19132): undefined reference to `re2::RE2::~RE2()'
/usr/bin/ld: Compositor.cpp:(.text+0x19400): undefined reference to `re2::RE2::RE2(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: Compositor.cpp:(.text+0x19423): undefined reference to `re2::RE2::FullMatchN(std::basic_string_view<char, std::char_traits<char> >, re2::RE2 const&, re2::RE2::Arg const* const*, int)'
/usr/bin/ld: Compositor.cpp:(.text+0x19490): undefined reference to `re2::RE2::RE2(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: Compositor.cpp:(.text+0x194b3): undefined reference to `re2::RE2::FullMatchN(std::basic_string_view<char, std::char_traits<char> >, re2::RE2 const&, re2::RE2::Arg const* const*, int)'
/usr/bin/ld: src/Hyprland.p/Compositor.cpp.o: in function `CCompositor::getWindowByRegex(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) [clone .cold]':
Compositor.cpp:(.text.unlikely+0x2a66): undefined reference to `re2::RE2::~RE2()'
/usr/bin/ld: Compositor.cpp:(.text.unlikely+0x2ab3): undefined reference to `re2::RE2::~RE2()'
/usr/bin/ld: Compositor.cpp:(.text.unlikely+0x2ad4): undefined reference to `re2::RE2::~RE2()'
/usr/bin/ld: Compositor.cpp:(.text.unlikely+0x2afc): undefined reference to `re2::RE2::~RE2()'
/usr/bin/ld: src/Hyprland.p/config_ConfigManager.cpp.o: in function `CConfigManager::getMatchingRules(Hyprutils::Memory::CSharedPointer<CLayerSurface>)':
ConfigManager.cpp:(.text+0x12cb9): undefined reference to `re2::RE2::RE2(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: ConfigManager.cpp:(.text+0x12d02): undefined reference to `re2::RE2::FullMatchN(std::basic_string_view<char, std::char_traits<char> >, re2::RE2 const&, re2::RE2::Arg const* const*, int)'
/usr/bin/ld: ConfigManager.cpp:(.text+0x12d0e): undefined reference to `re2::RE2::~RE2()'
/usr/bin/ld: src/Hyprland.p/config_ConfigManager.cpp.o: in function `CConfigManager::getMatchingRules(Hyprutils::Memory::CSharedPointer<CWindow>, bool, bool)':
ConfigManager.cpp:(.text+0x25e67): undefined reference to `re2::RE2::RE2(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: ConfigManager.cpp:(.text+0x25eb5): undefined reference to `re2::RE2::FullMatchN(std::basic_string_view<char, std::char_traits<char> >, re2::RE2 const&, re2::RE2::Arg const* const*, int)'
/usr/bin/ld: ConfigManager.cpp:(.text+0x25ec0): undefined reference to `re2::RE2::~RE2()'
/usr/bin/ld: ConfigManager.cpp:(.text+0x26673): undefined reference to `re2::RE2::RE2(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: ConfigManager.cpp:(.text+0x266d6): undefined reference to `re2::RE2::FullMatchN(std::basic_string_view<char, std::char_traits<char> >, re2::RE2 const&, re2::RE2::Arg const* const*, int)'
/usr/bin/ld: ConfigManager.cpp:(.text+0x266e6): undefined reference to `re2::RE2::~RE2()'
/usr/bin/ld: ConfigManager.cpp:(.text+0x26736): undefined reference to `re2::RE2::RE2(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: ConfigManager.cpp:(.text+0x26799): undefined reference to `re2::RE2::FullMatchN(std::basic_string_view<char, std::char_traits<char> >, re2::RE2 const&, re2::RE2::Arg const* const*, int)'
/usr/bin/ld: ConfigManager.cpp:(.text+0x267a9): undefined reference to `re2::RE2::~RE2()'
/usr/bin/ld: ConfigManager.cpp:(.text+0x267f9): undefined reference to `re2::RE2::RE2(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: ConfigManager.cpp:(.text+0x2685c): undefined reference to `re2::RE2::FullMatchN(std::basic_string_view<char, std::char_traits<char> >, re2::RE2 const&, re2::RE2::Arg const* const*, int)'
/usr/bin/ld: ConfigManager.cpp:(.text+0x2686c): undefined reference to `re2::RE2::~RE2()'
/usr/bin/ld: ConfigManager.cpp:(.text+0x26cad): undefined reference to `re2::RE2::RE2(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: ConfigManager.cpp:(.text+0x26cfe): undefined reference to `re2::RE2::FullMatchN(std::basic_string_view<char, std::char_traits<char> >, re2::RE2 const&, re2::RE2::Arg const* const*, int)'
/usr/bin/ld: ConfigManager.cpp:(.text+0x26d0a): undefined reference to `re2::RE2::~RE2()'
/usr/bin/ld: ConfigManager.cpp:(.text+0x26d21): undefined reference to `re2::RE2::~RE2()'
/usr/bin/ld: ConfigManager.cpp:(.text+0x272d5): undefined reference to `re2::RE2::RE2(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: ConfigManager.cpp:(.text+0x27326): undefined reference to `re2::RE2::FullMatchN(std::basic_string_view<char, std::char_traits<char> >, re2::RE2 const&, re2::RE2::Arg const* const*, int)'
/usr/bin/ld: ConfigManager.cpp:(.text+0x27336): undefined reference to `re2::RE2::~RE2()'
/usr/bin/ld: ConfigManager.cpp:(.text+0x2760d): undefined reference to `re2::RE2::~RE2()'
/usr/bin/ld: ConfigManager.cpp:(.text+0x27626): undefined reference to `re2::RE2::~RE2()'
/usr/bin/ld: ConfigManager.cpp:(.text+0x27644): undefined reference to `re2::RE2::~RE2()'
/usr/bin/ld: ConfigManager.cpp:(.text+0x27658): undefined reference to `re2::RE2::~RE2()'
/usr/bin/ld: src/Hyprland.p/config_ConfigManager.cpp.o:ConfigManager.cpp:(.text.unlikely+0x6d97): more undefined references to `re2::RE2::~RE2()' follow
/usr/bin/ld: src/Hyprland.p/desktop_Window.cpp.o: in function `auto CWindow::getSwallower()::{lambda(auto:1 const&)#2}::operator()<Hyprutils::Memory::CSharedPointer<CWindow> >(Hyprutils::Memory::CSharedPointer<CWindow> const&) const [clone .isra.0]':
Window.cpp:(.text+0x6960): undefined reference to `re2::RE2::RE2(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: Window.cpp:(.text+0x6993): undefined reference to `re2::RE2::FullMatchN(std::basic_string_view<char, std::char_traits<char> >, re2::RE2 const&, re2::RE2::Arg const* const*, int)'
/usr/bin/ld: Window.cpp:(.text+0x699e): undefined reference to `re2::RE2::~RE2()'
/usr/bin/ld: src/Hyprland.p/desktop_Window.cpp.o: in function `auto CWindow::getSwallower()::{lambda(auto:1 const&)#1}::operator()<Hyprutils::Memory::CSharedPointer<CWindow> >(Hyprutils::Memory::CSharedPointer<CWindow> const&) const [clone .isra.0]':
Window.cpp:(.text+0x6ac0): undefined reference to `re2::RE2::RE2(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
/usr/bin/ld: Window.cpp:(.text+0x6af3): undefined reference to `re2::RE2::FullMatchN(std::basic_string_view<char, std::char_traits<char> >, re2::RE2 const&, re2::RE2::Arg const* const*, int)'
/usr/bin/ld: Window.cpp:(.text+0x6b01): undefined reference to `re2::RE2::~RE2()'
/usr/bin/ld: src/Hyprland.p/desktop_Window.cpp.o: in function `auto CWindow::getSwallower()::{lambda(auto:1 const&)#2}::operator()<Hyprutils::Memory::CSharedPointer<CWindow> >(Hyprutils::Memory::CSharedPointer<CWindow> const&) const [clone .isra.0] [clone .cold]':
Window.cpp:(.text.unlikely+0x6b3): undefined reference to `re2::RE2::~RE2()'
/usr/bin/ld: src/Hyprland.p/desktop_Window.cpp.o: in function `auto CWindow::getSwallower()::{lambda(auto:1 const&)#1}::operator()<Hyprutils::Memory::CSharedPointer<CWindow> >(Hyprutils::Memory::CSharedPointer<CWindow> const&) const [clone .isra.0] [clone .cold]':
Window.cpp:(.text.unlikely+0x707): undefined reference to `re2::RE2::~RE2()'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

#### Is it ready for merging, or does it need work?
not ready

