### PR TITLE
Add tiled window borders in special ws for smart gaps/no_gaps_when_only

### DIFF
--- a/example/hyprland.conf
+++ b/example/hyprland.conf
@@ -138,8 +138,8 @@ animations {
 # uncomment all if you wish to use that.
 # workspace = w[tv1], gapsout:0, gapsin:0
 # workspace = f[1], gapsout:0, gapsin:0
-# windowrulev2 = bordersize 0, floating:0, onworkspace:w[tv1]
-# windowrulev2 = rounding 0, floating:0, onworkspace:w[tv1]
+# windowrulev2 = bordersize 0, floating:0, onworkspace:w[tv1] s[false]
+# windowrulev2 = rounding 0, floating:0, onworkspace:w[tv1] s[false]
 # windowrulev2 = bordersize 0, floating:0, onworkspace:f[1]
 # windowrulev2 = rounding 0, floating:0, onworkspace:f[1]
 

--- a/src/config/defaultConfig.hpp
+++ b/src/config/defaultConfig.hpp
@@ -151,8 +151,8 @@ animations {
 # uncomment all if you wish to use that.
 # workspace = w[tv1], gapsout:0, gapsin:0
 # workspace = f[1], gapsout:0, gapsin:0
-# windowrulev2 = bordersize 0, floating:0, onworkspace:w[tv1]
-# windowrulev2 = rounding 0, floating:0, onworkspace:w[tv1]
+# windowrulev2 = bordersize 0, floating:0, onworkspace:w[tv1] s[false]
+# windowrulev2 = rounding 0, floating:0, onworkspace:w[tv1] s[false]
 # windowrulev2 = bordersize 0, floating:0, onworkspace:f[1]
 # windowrulev2 = rounding 0, floating:0, onworkspace:f[1]
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Simply adds border to tiled window when only 1 window is open, as special workspace have more padding it feels better.

![2024-12-17T03:59:49,508759896+01:00](https://github.com/user-attachments/assets/0d1eb08e-6987-4149-ae2e-5028b4d5037f)
![2024-12-17T03:59:06,743755855+01:00](https://github.com/user-attachments/assets/b0f4b0a8-d7cc-4d10-b3d4-b728092e8de2)


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

no

#### Is it ready for merging, or does it need work?


ready