### PR TITLE
Fix `hyprctl` batch JSON command

### DIFF
--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -284,8 +284,10 @@ int requestHyprpaper(std::string arg) {
 void batchRequest(std::string arg, bool json) {
     std::string commands = arg.substr(arg.find_first_of(' ') + 1);
 
-    if (json)
+    if (json) {
         RE2::GlobalReplace(&commands, ";\\s*", ";j/");
+        commands.insert(0, "j/");
+    }
 
     std::string rq = "[[BATCH]]" + commands;
     request(rq);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixing `hyprctl --batch -j` where the first command doesn't output in JSON. Now it works as it should.

#### Is it ready for merging, or does it need work?
Ready.
