### PR TITLE
hyprpm: fix hyrpm sometimes returning 0 despite errors occuring

### DIFF
--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -73,7 +73,7 @@ int                        main(int argc, char** argv, char** envp) {
 
     if (command.empty()) {
         std::println(stderr, "{}", HELP);
-        return 0;
+        return 1;
     }
 
     g_pPluginManager               = std::make_unique<CPluginManager>();
@@ -159,12 +159,15 @@ int                        main(int argc, char** argv, char** envp) {
         if (ret != LOADSTATE_OK && notify) {
             switch (ret) {
                 case LOADSTATE_FAIL:
-                case LOADSTATE_PARTIAL_FAIL: g_pPluginManager->notify(ICON_ERROR, 0, 10000, "[hyprpm] Failed to load plugins"); break;
+                case LOADSTATE_PARTIAL_FAIL:
+                    g_pPluginManager->notify(ICON_ERROR, 0, 10000, "[hyprpm] Failed to load plugins");
+                    break;
                 case LOADSTATE_HEADERS_OUTDATED:
                     g_pPluginManager->notify(ICON_ERROR, 0, 10000, "[hyprpm] Failed to load plugins: Outdated headers. Please run hyprpm update manually.");
                     break;
                 default: break;
             }
+            return 1;
         } else if (notify && !notifyFail) {
             g_pPluginManager->notify(ICON_OK, 0, 4000, "[hyprpm] Loaded plugins");
         }

--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -159,9 +159,7 @@ int                        main(int argc, char** argv, char** envp) {
         if (ret != LOADSTATE_OK && notify) {
             switch (ret) {
                 case LOADSTATE_FAIL:
-                case LOADSTATE_PARTIAL_FAIL:
-                    g_pPluginManager->notify(ICON_ERROR, 0, 10000, "[hyprpm] Failed to load plugins");
-                    break;
+                case LOADSTATE_PARTIAL_FAIL: g_pPluginManager->notify(ICON_ERROR, 0, 10000, "[hyprpm] Failed to load plugins"); break;
                 case LOADSTATE_HEADERS_OUTDATED:
                     g_pPluginManager->notify(ICON_ERROR, 0, 10000, "[hyprpm] Failed to load plugins: Outdated headers. Please run hyprpm update manually.");
                     break;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
This PR changes `hyprpm`'s return codes in a couple of misusage situations, mainly when `hyprpm reload` fails because of headers being out of date. This, alongside with being a behavior most people would expect, as the command did not, in fact, execute successfully, makes some basic scripting like `hyprpm reload 2>&1 | grep "not up-to-date" && hyprpm update` easier (the example can be reduced to `hyprpm reload || hyprpm update`)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no.

#### Is it ready for merging, or does it need work?
should be good to go, as it doesn't really change anything significant. Still, lmk if you'd like anything to act differently