### PR TITLE
apply group rules after window creation

### DIFF
--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -28,7 +28,7 @@ void IHyprLayout::onWindowCreated(PHLWINDOW pWindow, eDirection direction) {
         onWindowCreatedFloating(pWindow);
     else
         onWindowCreatedTiling(pWindow, direction);
-    
+
     if (!g_pXWaylandManager->shouldBeFloated(pWindow)) // do not apply group rules to child windows
         pWindow->applyGroupRules();
 }

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -20,9 +20,6 @@ void IHyprLayout::onWindowCreated(PHLWINDOW pWindow, eDirection direction) {
 
     pWindow->m_vPseudoSize = pWindow->m_vLastFloatingSize;
 
-    if (!g_pXWaylandManager->shouldBeFloated(pWindow)) // do not apply group rules to child windows
-        pWindow->applyGroupRules();
-
     bool autoGrouped = IHyprLayout::onWindowCreatedAutoGroup(pWindow);
     if (autoGrouped)
         return;
@@ -31,6 +28,9 @@ void IHyprLayout::onWindowCreated(PHLWINDOW pWindow, eDirection direction) {
         onWindowCreatedFloating(pWindow);
     else
         onWindowCreatedTiling(pWindow, direction);
+    
+    if (!g_pXWaylandManager->shouldBeFloated(pWindow)) // do not apply group rules to child windows
+        pWindow->applyGroupRules();
 }
 
 void IHyprLayout::onWindowRemoved(PHLWINDOW pWindow) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes a crash that happens when:
1. you have this window rule: `windowrulev2 = group set, class:.*`
2. open an xwayland program that remains on tray when the window is closed, for example: discord or steam.
3. close the window.
4. open it again from tray or from your launcher.
5. hyprland crashes.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I don't know the root reason of why this happens. It does not reproduce with a native wayland program that close to tray (crow-translate).

#### Is it ready for merging, or does it need work?
Ready.