### PR TITLE
Use glaze to parse hyprctl json output, other improvements

### DIFF
--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -63,6 +63,15 @@ runs:
           librsvg \
           re2
 
+    - name: Get glaze
+      shell: bash
+      run: |
+        git clone https://github.com/stephenberry/glaze.git
+        cd glaze
+        cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX:PATH=/usr -S . -B ./build
+        cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
+        cmake --install build
+
     - name: Get hyprwayland-scanner-git
       shell: bash
       run: |

--- a/hyprpm/CMakeLists.txt
+++ b/hyprpm/CMakeLists.txt
@@ -10,10 +10,11 @@ file(GLOB_RECURSE SRCFILES CONFIGURE_DEPENDS "src/*.cpp")
 set(CMAKE_CXX_STANDARD 23)
 
 pkg_check_modules(hyprpm_deps REQUIRED IMPORTED_TARGET tomlplusplus hyprutils>=0.2.4)
+find_package(glaze REQUIRED)
 
 add_executable(hyprpm ${SRCFILES})
 
-target_link_libraries(hyprpm PUBLIC PkgConfig::hyprpm_deps)
+target_link_libraries(hyprpm PUBLIC PkgConfig::hyprpm_deps glaze::glaze)
 
 # binary
 install(TARGETS hyprpm)

--- a/hyprpm/src/core/DataState.hpp
+++ b/hyprpm/src/core/DataState.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <filesystem>
 #include <string>
 #include <vector>
 #include "Plugin.hpp"
@@ -9,14 +10,15 @@ struct SGlobalState {
 };
 
 namespace DataState {
-    std::string                    getDataStatePath();
-    std::string                    getHeadersPath();
-    void                           ensureStateStoreExists();
-    void                           addNewPluginRepo(const SPluginRepository& repo);
-    void                           removePluginRepo(const std::string& urlOrName);
-    bool                           pluginRepoExists(const std::string& urlOrName);
-    void                           updateGlobalState(const SGlobalState& state);
-    SGlobalState                   getGlobalState();
-    bool                           setPluginEnabled(const std::string& name, bool enabled);
-    std::vector<SPluginRepository> getAllRepositories();
+    std::filesystem::path              getDataStatePath();
+    std::string                        getHeadersPath();
+    std::vector<std::filesystem::path> getPluginStates();
+    void                               ensureStateStoreExists();
+    void                               addNewPluginRepo(const SPluginRepository& repo);
+    void                               removePluginRepo(const std::string& urlOrName);
+    bool                               pluginRepoExists(const std::string& urlOrName);
+    void                               updateGlobalState(const SGlobalState& state);
+    SGlobalState                       getGlobalState();
+    bool                               setPluginEnabled(const std::string& name, bool enabled);
+    std::vector<SPluginRepository>     getAllRepositories();
 };

--- a/hyprpm/src/core/PluginManager.cpp
+++ b/hyprpm/src/core/PluginManager.cpp
@@ -7,10 +7,8 @@
 
 #include <cstdio>
 #include <iostream>
-#include <array>
 #include <filesystem>
 #include <print>
-#include <thread>
 #include <fstream>
 #include <algorithm>
 #include <format>
@@ -21,6 +19,7 @@
 #include <unistd.h>
 
 #include <toml++/toml.hpp>
+#include <glaze/glaze.hpp>
 
 #include <hyprutils/string/String.hpp>
 #include <hyprutils/os/Process.hpp>
@@ -83,13 +82,13 @@ SHyprlandVersion CPluginManager::getHyprlandVersion(bool running) {
     hlbranch             = hlbranch.substr(0, hlbranch.find(" at commit "));
 
     std::string hldate = HLVERCALL.substr(HLVERCALL.find("Date: ") + 6);
-    hldate             = hldate.substr(0, hldate.find("\n"));
+    hldate             = hldate.substr(0, hldate.find('\n'));
 
     std::string hlcommits;
 
     if (HLVERCALL.contains("commits:")) {
         hlcommits = HLVERCALL.substr(HLVERCALL.find("commits:") + 9);
-        hlcommits = hlcommits.substr(0, hlcommits.find(" "));
+        hlcommits = hlcommits.substr(0, hlcommits.find(' '));
     }
 
     int commits = 0;
@@ -378,7 +377,7 @@ eHeadersErrors CPluginManager::headersValid() {
 
     // find headers commit
     const std::string& cmd     = std::format("PKG_CONFIG_PATH=\"{}/share/pkgconfig\" pkgconf --cflags --keep-system-cflags hyprland", DataState::getHeadersPath());
-    auto               headers = execAndGet(cmd.c_str());
+    auto               headers = execAndGet(cmd);
 
     if (!headers.contains("-I/"))
         return HEADERS_MISSING;
@@ -790,34 +789,27 @@ ePluginLoadStateReturn CPluginManager::ensurePluginsLoadState() {
     const auto HOME = getenv("HOME");
     const auto HIS  = getenv("HYPRLAND_INSTANCE_SIGNATURE");
     if (!HOME || !HIS) {
-        std::println(stderr, "PluginManager: no $HOME or HIS");
+        std::println(stderr, "PluginManager: no $HOME or $HYPRLAND_INSTANCE_SIGNATURE");
         return LOADSTATE_FAIL;
     }
-    const auto               HYPRPMPATH = DataState::getDataStatePath() + "/";
+    const auto HYPRPMPATH = DataState::getDataStatePath();
 
-    auto                     pluginLines = execAndGet("hyprctl plugins list | grep Plugin");
+    const auto json = glz::read_json<glz::json_t::array_t>(execAndGet("hyprctl plugins list -j"));
+    if (!json) {
+        std::println(stderr, "PluginManager: couldn't parse hyprctl output");
+        return LOADSTATE_FAIL;
+    }
 
     std::vector<std::string> loadedPlugins;
+    for (const auto& plugin : json.value()) {
+        if (!plugin.is_object() || !plugin.contains("name")) {
+            std::println(stderr, "PluginManager: couldn't parse plugin object");
+            return LOADSTATE_FAIL;
+        }
+        loadedPlugins.emplace_back(plugin["name"].get<std::string>());
+    }
 
     std::println("{}", successString("Ensuring plugin load state"));
-
-    // iterate line by line
-    while (!pluginLines.empty()) {
-        auto plLine = pluginLines.substr(0, pluginLines.find('\n'));
-
-        if (pluginLines.find('\n') != std::string::npos)
-            pluginLines = pluginLines.substr(pluginLines.find('\n') + 1);
-        else
-            pluginLines = "";
-
-        if (plLine.back() != ':')
-            continue;
-
-        plLine = plLine.substr(7);
-        plLine = plLine.substr(0, plLine.find(" by "));
-
-        loadedPlugins.push_back(plLine);
-    }
 
     // get state
     const auto REPOS = DataState::getAllRepositories();
@@ -853,7 +845,7 @@ ePluginLoadStateReturn CPluginManager::ensurePluginsLoadState() {
     for (auto const& p : loadedPlugins) {
         if (!enabled(p)) {
             // unload
-            if (!loadUnloadPlugin(HYPRPMPATH + repoForName(p) + "/" + p + ".so", false)) {
+            if (!loadUnloadPlugin(HYPRPMPATH / repoForName(p) / (p + ".so"), false)) {
                 std::println("{}", infoString("{} will be unloaded after restarting Hyprland", p));
                 hyprlandVersionMismatch = true;
             } else
@@ -870,7 +862,7 @@ ePluginLoadStateReturn CPluginManager::ensurePluginsLoadState() {
             if (std::find_if(loadedPlugins.begin(), loadedPlugins.end(), [&](const auto& other) { return other == p.name; }) != loadedPlugins.end())
                 continue;
 
-            if (!loadUnloadPlugin(HYPRPMPATH + repoForName(p.name) + "/" + p.filename, true)) {
+            if (!loadUnloadPlugin(HYPRPMPATH / repoForName(p.name) / p.filename, true)) {
                 std::println("{}", infoString("{} will be loaded after restarting Hyprland", p.name));
                 hyprlandVersionMismatch = true;
             } else

--- a/hyprpm/src/meson.build
+++ b/hyprpm/src/meson.build
@@ -8,6 +8,7 @@ executable(
     dependency('hyprutils', version: '>= 0.1.1'),
     dependency('threads'),
     dependency('tomlplusplus'),
+    dependency('glaze', method: 'cmake'),
   ],
   install: true,
 )

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -5,12 +5,14 @@
   pkg-config,
   pkgconf,
   makeWrapper,
+  cmake,
   meson,
   ninja,
   aquamarine,
   binutils,
   cairo,
   git,
+  glaze,
   hyprcursor,
   hyprgraphics,
   hyprland-protocols,
@@ -102,6 +104,7 @@ in
         makeWrapper
         meson
         ninja
+        cmake # needed for glaze
         pkg-config
       ];
 
@@ -116,6 +119,7 @@ in
           aquamarine
           cairo
           git
+          glaze
           hyprcursor
           hyprgraphics
           hyprland-protocols


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
* Removed the very ugly manual parsing of the output of `hyprctl plugin list | grep Plugin`, by replacing it with a simple glaze  parse of the json output of `hyprctl plugin list -j` in PluginManager.cpp
* While I was busy, I noticed the patterns `folder + "/" + filename` and `folder + "/filename.ext"` came up a lot. I really dislike this so I replaced it with the std::filesystem `/` operator  (in a separate commit)
* I also added a helper method to get the state.toml files for every plugin, because the exact same logic was used 4 times in the same file. I extracted the logic into a new helper function "getPluginstates" in DataState.
* Also took care of some clang-tidy suggestions, for example `find` was being called with a single-character string `"x"` instead of just a character `'x'`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I'm planning on replacing more of these hyprctl calls with json parsing, like we discussed in this PR: https://github.com/hyprwm/Hyprland/pull/7152#issue-2445664270

#### Is it ready for merging, or does it need work?
Ready to merge
