### PR TITLE
debug: fix ISDEBUG checking

### DIFF
--- a/src/debug/CrashReporter.cpp
+++ b/src/debug/CrashReporter.cpp
@@ -111,7 +111,7 @@ void NCrashReporter::createAndSaveCrash(int sig) {
 #ifdef LEGACY_RENDERER
     finalCrashReport += "legacyrenderer\n";
 #endif
-#ifndef ISDEBUG
+#if ISDEBUG
     finalCrashReport += "debug\n";
 #endif
 #ifdef NO_XWAYLAND

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -884,14 +884,14 @@ std::string versionRequest(eHyprCtlOutputFormat format, std::string request) {
                                          HYPRLAND_VERSION, GIT_BRANCH, GIT_COMMIT_HASH, GIT_DIRTY, commitMsg, GIT_COMMIT_DATE, GIT_TAG, GIT_COMMITS, AQUAMARINE_VERSION,
                                          HYPRLANG_VERSION, HYPRUTILS_VERSION, HYPRCURSOR_VERSION, HYPRGRAPHICS_VERSION);
 
-#if (!defined(LEGACY_RENDERER) && !defined(ISDEBUG) && !defined(NO_XWAYLAND))
+#if (!defined(LEGACY_RENDERER) && !ISDEBUG && !defined(NO_XWAYLAND))
         result += "no flags were set\n";
 #else
         result += "flags set:\n";
 #ifdef LEGACY_RENDERER
         result += "legacyrenderer\n";
 #endif
-#ifdef ISDEBUG
+#if ISDEBUG
         result += "debug\n";
 #endif
 #ifdef NO_XWAYLAND
@@ -922,7 +922,7 @@ std::string versionRequest(eHyprCtlOutputFormat format, std::string request) {
 #ifdef LEGACY_RENDERER
         result += "\"legacyrenderer\",";
 #endif
-#ifdef ISDEBUG
+#if ISDEBUG
         result += "\"debug\",";
 #endif
 #ifdef NO_XWAYLAND


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
`ISDEBUG` macro is always defined so checking it with `#ifdef` is a bug. Use `#if ISDEBUG` instead. 


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.

#### Is it ready for merging, or does it need work?
Ready to merge.

