### PR TITLE
added reference to CTimer class in KeybindManager

### DIFF
--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -8,6 +8,7 @@
 #include <xkbcommon/xkbcommon.h>
 #include "../devices/IPointer.hpp"
 #include "eventLoop/EventLoopTimer.hpp"
+#include "../helpers/Timer.hpp"
 
 class CInputManager;
 class CConfigManager;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
It adds a single line in `src/managers/KeybindManager.hpp` to include a reference to `../helpers/Timer.hpp` which I found was missing when debugging a plugin (Hyprhook).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No, thank you.

#### Is it ready for merging, or does it need work?
Yes, it is ready for merging.