### PR TITLE
Updated window position/size for grouped fullscreen-windows in setGroupCurrent fn

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1026,13 +1026,13 @@ void CWindow::setGroupCurrent(PHLWINDOW pWindow) {
     const auto WORKSPACE  = PCURRENT->m_pWorkspace;
     const auto MODE       = PCURRENT->m_sFullscreenState.internal;
 
-    const auto PWINDOWSIZE = PCURRENT->m_vRealSize.goal();
-    const auto PWINDOWPOS  = PCURRENT->m_vRealPosition.goal();
-
     const auto CURRENTISFOCUS = PCURRENT == g_pCompositor->m_pLastWindow.lock();
 
     if (FULLSCREEN)
         g_pCompositor->setWindowFullscreenInternal(PCURRENT, FSMODE_NONE);
+
+    const auto PWINDOWSIZE = PCURRENT->m_vRealSize.goal();
+    const auto PWINDOWPOS  = PCURRENT->m_vRealPosition.goal();
 
     PCURRENT->setHidden(true);
     pWindow->setHidden(false); // can remove m_pLastWindow


### PR DESCRIPTION
# Change

In `setGroupCurrent` function in `src/desktop/window.cpp` file,
Fullscreen windows were not able to get effective values for `m_vRealSize` and `m_vRealPosition`
With this PR, both size and position are updated after changing fullscreenstate in the same function.

# Effect
This effects fullscreen group of floating windows. 

Issues fixed:
- If a group of floating windows is fullscreen with static window rule `group` set new added windows in group were not able to toggle fullscreen
- If a group of floating windows is fullscreen then after switching to next window in group with `changegroupactive` any window in group was not able to toggle fullscreen.

**With this PR, both of these issues are now fixed and Issue #8855 can be closed.**

I hope i've not misunderstood something.
In case you are not interested, feel also free to close this PR :)

Cheers!