### PR TITLE
snap: snap only to windows floating over top of fullscreen window if one exists

### DIFF
--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -421,11 +421,13 @@ static void performSnap(Vector2D& sourcePos, Vector2D& sourceSize, PHLWINDOW DRA
     SRange sourceY = {sourcePos.y, sourcePos.y + sourceSize.y};
 
     if (*SNAPWINDOWGAP) {
-        const double GAPSIZE = *SNAPWINDOWGAP;
-        const auto   WSID    = DRAGGINGWINDOW->workspaceID();
+        const double GAPSIZE       = *SNAPWINDOWGAP;
+        const auto   WSID          = DRAGGINGWINDOW->workspaceID();
+        const bool   HASFULLSCREEN = DRAGGINGWINDOW->m_pWorkspace && DRAGGINGWINDOW->m_pWorkspace->m_bHasFullscreenWindow;
 
         for (auto& other : g_pCompositor->m_vWindows) {
-            if (other == DRAGGINGWINDOW || other->workspaceID() != WSID || !other->m_bIsMapped || other->m_bFadingOut || other->isX11OverrideRedirect())
+            if ((HASFULLSCREEN && !other->m_bCreatedOverFullscreen) || other == DRAGGINGWINDOW || other->workspaceID() != WSID || !other->m_bIsMapped || other->m_bFadingOut ||
+                other->isX11OverrideRedirect())
                 continue;
 
             const int    OTHERBORDERSIZE = other->getRealBorderSize();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Addresses https://github.com/hyprwm/Hyprland/issues/8647

If the dragging window is pinned, and the workspace of the dragging window has a fullscreen window, it won't snap to any windows that might be hidden underneath the fullscreen window.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Nope

#### Is it ready for merging, or does it need work?

Ready for merging