### PR TITLE
Replaced always_center_master to slave_count_for_center_master

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1603,10 +1603,10 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SBoolData{true},
     },
     SConfigOptionDescription{
-        .value       = "master:always_center_master",
-        .description = "when using orientation=center, keep the master window centered, even when it is the only window in the workspace.",
-        .type        = CONFIG_OPTION_BOOL,
-        .data        = SConfigOptionDescription::SBoolData{false},
+        .value       = "master:slave_count_for_center_master",
+        .description = "when using orientation=center, make the master window centered only when at least this many slave windows are open. (Set 0 to always_center_master)",
+        .type        = CONFIG_OPTION_INT,
+        .data        = SConfigOptionDescription::SRangeData{2, 0, 10}, //##TODO RANGE?
     },
     SConfigOptionDescription{
         .value       = "master:center_ignores_reserved",

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -477,7 +477,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("master:special_scale_factor", {1.f});
     m_pConfig->addConfigValue("master:mfact", {0.55f});
     m_pConfig->addConfigValue("master:new_status", {"slave"});
-    m_pConfig->addConfigValue("master:always_center_master", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("master:slave_count_for_center_master", Hyprlang::INT{2});
     m_pConfig->addConfigValue("master:center_ignores_reserved", Hyprlang::INT{0});
     m_pConfig->addConfigValue("master:new_on_active", {"none"});
     m_pConfig->addConfigValue("master:new_on_top", Hyprlang::INT{0});


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

#### Describe your PR, what does it fix/add?
- Replaced boolean config parameter `always_center_master` to an integer value `slave_count_for_center_master` for more control on when to center master window.
- Also updated configuration parameter, type, description and related internal variable.

New description: **when using orientation=center, make the master window centered only when at least this many slave windows are open. (Set 0 to always_center_master)**

This effects center orientation of master layout.
Now, user can control when the master window would be centered which solves #8866
[Related Wiki Modification](https://github.com/hyprwm/hyprland-wiki/pull/918/files)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
- No.

#### Is it ready for merging, or does it need work?
- Ready

I hope i've not misunderstood something.
In case you are not interested, feel also free to close this PR :)

Cheers!