### PR TITLE
snap: revert #8659, use bounds checking instead of bit mask

### DIFF
--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -457,7 +457,7 @@ static void performSnap(Vector2D& sourcePos, Vector2D& sourceSize, PHLWINDOW DRA
 
             // corner snapping
             const double BORDERDIFF = OTHERBORDERSIZE - DRAGGINGBORDERSIZE;
-            if (snaps & (SNAP_LEFT | SNAP_RIGHT)) {
+            if (sourceX.start == SURFBX.end || SURFBX.start == sourceX.end) {
                 const SRange SURFY = {SURF.y - BORDERDIFF, SURF.y + SURF.h + BORDERDIFF};
                 if (CORNER & (CORNER_TOPLEFT | CORNER_TOPRIGHT) && canSnap(sourceY.start, SURFY.start, GAPSIZE)) {
                     SNAP(sourceY.start, sourceY.end, SURFY.start);
@@ -467,7 +467,7 @@ static void performSnap(Vector2D& sourcePos, Vector2D& sourceSize, PHLWINDOW DRA
                     snaps |= SNAP_DOWN;
                 }
             }
-            if (snaps & (SNAP_UP | SNAP_DOWN)) {
+            if (sourceY.start == SURFBY.end || SURFBY.start == sourceY.end) {
                 const SRange SURFX = {SURF.x - BORDERDIFF, SURF.x + SURF.w + BORDERDIFF};
                 if (CORNER & (CORNER_TOPLEFT | CORNER_BOTTOMLEFT) && canSnap(sourceX.start, SURFX.start, GAPSIZE)) {
                     SNAP(sourceX.start, sourceX.end, SURFX.start);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

In https://github.com/hyprwm/Hyprland/pull/8659 I mistakenly thought that using the snap bit mask to check for window edge snapping would have identical behavior to bounds checking, but a snap bit might not be turned on as expected if we grab a different corner after an edge has already been snapped. Here is a before and after:

Before:

https://github.com/user-attachments/assets/27f28196-ccab-44be-9ba3-e46ac513c29d

After:

https://github.com/user-attachments/assets/e1aecb9b-6861-439b-bcf4-611794217fca

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Nope.

#### Is it ready for merging, or does it need work?

Ready for merging.
