### PR TITLE
xwayland: don't create an abstract unix domain socket on linux

### DIFF
--- a/src/xwayland/Server.cpp
+++ b/src/xwayland/Server.cpp
@@ -148,15 +148,8 @@ static bool openSockets(std::array<int, 2>& sockets, int display) {
     sockaddr_un addr = {.sun_family = AF_UNIX};
     std::string path;
 
-#ifdef __linux__
-    // cursed...
-    addr.sun_path[0] = 0;
-    path             = getSocketPath(display, true);
-    strncpy(addr.sun_path + 1, path.c_str(), path.length() + 1);
-#else
     path = getSocketPath(display, false);
     strncpy(addr.sun_path, path.c_str(), path.length() + 1);
-#endif
 
     sockets[0] = createSocket(&addr, path.length());
     if (sockets[0] < 0)


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

#### Describe your PR, what does it fix/add?

This PR removes the abstract Unix Domain Socket from the XWayland server. 

The Xorg abstract socket can be used to bypass certain sandboxing solutions (e.g. Flatpak and other bubblewrap-based systems) because these systems grant access to X11 by exposing a bind mount to the `/tmp/.X11-unix`directory under the assumption that Xwayland will be accessed through the traditional Unix Domain Socket. 

However, the corresponding abstract socket provided by Hyprland does not actually reside on the file system and is accessible regardless of the X11 socket directory being mounted. This makes it possible for an application in a sandbox to access the X11 socket without having `/tmp/.X11-unix` bind-mounted. 

To solve this issue, I removed the special-casing for Linux systems when creating the Xwayland abstract socket so that a traditional Unix Domain Socket is created instead.

References:

https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/1424
https://unix.stackexchange.com/a/512529

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

N/A

#### Is it ready for merging, or does it need work?

It should be ready for merging; the changes are minimal and it "works on my machine" with both Wayland and XWayland applications.
