### PR TITLE
hyprpm: add glaze dependency FetchContent fallback

### DIFF
--- a/hyprpm/CMakeLists.txt
+++ b/hyprpm/CMakeLists.txt
@@ -10,7 +10,20 @@ file(GLOB_RECURSE SRCFILES CONFIGURE_DEPENDS "src/*.cpp")
 set(CMAKE_CXX_STANDARD 23)
 
 pkg_check_modules(hyprpm_deps REQUIRED IMPORTED_TARGET tomlplusplus hyprutils>=0.2.4)
-find_package(glaze REQUIRED)
+
+find_package(glaze QUIET)
+if (NOT glaze_FOUND)
+    set(GLAZE_VERSION v4.2.3)
+    message(STATUS "glaze dependency not found, retrieving ${GLAZE_VERSION} with FetchContent")
+    include(FetchContent)
+    FetchContent_Declare(
+        glaze
+        GIT_REPOSITORY https://github.com/stephenberry/glaze.git
+        GIT_TAG ${GLAZE_VERSION}
+        GIT_SHALLOW TRUE
+    )
+    FetchContent_MakeAvailable(glaze)
+endif()
 
 add_executable(hyprpm ${SRCFILES})
 


### PR DESCRIPTION
Use FetchContent to retrieve glaze dependency if not available with find_package.
Allows to build hyprpm w/o installing glaze at system level (on some distros is not available in official repositories).

Inspired from glaze documentation (ref. https://github.com/stephenberry/glaze?tab=readme-ov-file#see-this-example-repository-for-how-to-use-glaze-in-a-new-project and https://github.com/stephenberry/glaze_example/blob/main/CMakeLists.txt), let me know if there's a better way to achieve that.