### PR TITLE
Share hyprctl flags with hyprpaper

### DIFF
--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -255,8 +255,10 @@ int requestHyprpaper(std::string arg) {
         return 3;
     }
 
-    arg = arg.substr(arg.find_first_of('/') + 1); // strip flags
-    arg = arg.substr(arg.find_first_of(' ') + 1); // strip "hyprpaper"
+		std::string flags = arg.substr(0, arg.find_first_of('/'));
+		arg = arg.substr(arg.find_first_of('/') + 1); // strip flags
+		arg = arg.substr(arg.find_first_of(' ') + 1); // strip "hyprpaper"
+		arg = arg + "/" + flags;
 
     auto sizeWritten = write(SERVERSOCKET, arg.c_str(), arg.length());
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
To allow [json output for hyprpaper](https://github.com/hyprwm/hyprpaper/issues/186), sharing the flags with hyprpaper is needed. This change just appends the flags **at the end of the request**, with a slash. This allows it to still be compatible with hyprpaper which doesn't handle the flags.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
nope

#### Is it ready for merging, or does it need work?
Maybe needs some discussion, but since it's a really simple fix I think it's ready.
