### PR TITLE
master: make loop around optional when cycling

### DIFF
--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -87,7 +87,7 @@ class CHyprMasterLayout : public IHyprLayout {
     SMasterNodeData*                  getMasterNodeOnWorkspace(const WORKSPACEID&);
     SMasterWorkspaceData*             getMasterWorkspaceData(const WORKSPACEID&);
     void                              calculateWorkspace(PHLWORKSPACE);
-    PHLWINDOW                         getNextWindow(PHLWINDOW, bool);
+    PHLWINDOW                         getNextWindow(PHLWINDOW, bool, bool);
     int                               getMastersOnWorkspace(const WORKSPACEID&);
 
     friend struct SMasterNodeData;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?


Implement the option to not loop around when cycling windows in the master layout (i.e. going from master to the last slave or vice-versa), replicating this layout's behavior in DWL.

No default behavior was modified, and the option `noLoopAround` option was added to `cyclenext`, `cycleprev`, `swapnext` and `swapprev`. This ensures no current setups are broken.

Example usage:
- Default, can cycle around as always:
  ```sh
  bind = $mainMod, up,    layoutmsg, cycleprev
  bind = $mainMod, down,  layoutmsg, cyclenext
  ```
- Same as default but with explicit option set:
  ```sh
  bind = $mainMod, up,    layoutmsg, cycleprev loop
  bind = $mainMod, down,  layoutmsg, cyclenext loop
  ```
- No looping around (as in DWM):
  ```sh
  bind = $mainMod, up,    layoutmsg, cycleprev noloop
  bind = $mainMod, down,  layoutmsg, cyclenext noloop
  ```

#### Is it ready for merging, or does it need work?

I think it is, I tested it and it works, but I am new in this codebase so some important test may be missing.

