### PR TITLE
renderer: fix CRendererHintsPassElement reset duplication issue

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -807,12 +807,15 @@ void CHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
     if (scale != 1.f)
         RENDERMODIFDATA.modifs.emplace_back(std::make_pair<>(SRenderModifData::eRenderModifType::RMOD_TYPE_SCALE, scale));
 
-    CScopeGuard x([] {});
-
     if (!RENDERMODIFDATA.modifs.empty()) {
         g_pHyprRenderer->m_sRenderPass.add(makeShared<CRendererHintsPassElement>(CRendererHintsPassElement::SData{RENDERMODIFDATA}));
-        x = CScopeGuard([] { g_pHyprRenderer->m_sRenderPass.add(makeShared<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}})); });
     }
+
+    CScopeGuard x([&RENDERMODIFDATA] {
+        if (!RENDERMODIFDATA.modifs.empty()) {
+            g_pHyprRenderer->m_sRenderPass.add(makeShared<CRendererHintsPassElement>(CRendererHintsPassElement::SData{SRenderModifData{}}));
+        }
+    });
 
     if (!pWorkspace) {
         // allow rendering without a workspace. In this case, just render layers.


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes a bug where the "reset" RendererHintsPassElement for renderModifs would be duplicated, preventing renderModifs from begin applied.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Good?
