### PR TITLE
protocols: allow xdg share pickers to reconcile with hyprctl

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1212,6 +1212,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SRangeData{1000, 0, 5000},
     },
     SConfigOptionDescription{
+        .value       = "misc:xdg_portal_window_address_forwarding",
+        .description = "forwards the window address in the title of the xdg portal window.",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{false},
+    },
+    SConfigOptionDescription{
         .value       = "misc:enable_anr_dialog",
         .description = "whether to enable the ANR (app not responding) dialog when your apps hang",
         .type        = CONFIG_OPTION_BOOL,

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -458,6 +458,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("misc:disable_xdg_env_checks", Hyprlang::INT{0});
     registerConfigVar("misc:disable_hyprland_qtutils_check", Hyprlang::INT{0});
     registerConfigVar("misc:lockdead_screen_delay", Hyprlang::INT{1000});
+    registerConfigVar("misc:xdg_portal_window_address_forwarding", Hyprlang::INT{0});
     registerConfigVar("misc:enable_anr_dialog", Hyprlang::INT{1});
 
     registerConfigVar("group:insert_after_current", Hyprlang::INT{1});

--- a/src/protocols/ForeignToplevelWlr.hpp
+++ b/src/protocols/ForeignToplevelWlr.hpp
@@ -47,6 +47,7 @@ class CForeignToplevelWlrManager {
     PHLWINDOWREF                               lastFocus; // READ-ONLY
 
     SP<CForeignToplevelHandleWlr>              handleForWindow(PHLWINDOW pWindow);
+    std::string                                getWindowTitle(PHLWINDOW pWindow);
 
     std::vector<WP<CForeignToplevelHandleWlr>> handles;
 };


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Recently, xdph got the possiblity to use your own share picker.

For the sharing output to follow the window when it moves or is resized, it is needed to return the handle id back.

Tools like slurp are really nice ui wise, but they dont know about those handles, and they are not accessible from hyprctl.

To be able to reconcile the `XDPH_WINDOW_SHARING_LIST` env variable provided to the picker with the informations from hyprctl, we need to provide it somehow.

I know nothing about wayland, wlr, xdg, foreign top level stuff, and dont know how to code in c++. I still wanted to see if I could make something nice to use as I share my desktop all the time for work.

It seems like we have to comply with the protocol defined here: 
https://wayland.app/protocols/wlr-foreign-toplevel-management-unstable-v1#zwlr_foreign_toplevel_handle_v1:event:app_id
but I dont understand why neither...

Anyway, this PR uses the title to propagate the window address to  the portal that will in turn propagate it to the picker, allowing for the nice window selection.

#### Is it ready for merging, or does it need work?

I dont really aim to merge this, i was planning on maintaining a patch (its like 10 lines total of code that has not really moved a lot), but if there is a way to achieve the same with a clean approach, I can dedicate some time to it. 
