### PR TITLE
Add option to  show slaves on left in master layout center orientation

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1627,6 +1627,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SRangeData{2, 0, 10}, //##TODO RANGE?
     },
     SConfigOptionDescription{
+        .value       = "master:center_master_slaves_on_right",
+        .description = "set if the slaves should appear on right of master when slave_count_for_center_master > 2",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{true},
+    },
+    SConfigOptionDescription{
         .value       = "master:center_ignores_reserved",
         .description = "centers the master window on monitor ignoring reserved areas",
         .type        = CONFIG_OPTION_BOOL,

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -478,6 +478,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("master:mfact", {0.55f});
     m_pConfig->addConfigValue("master:new_status", {"slave"});
     m_pConfig->addConfigValue("master:slave_count_for_center_master", Hyprlang::INT{2});
+    m_pConfig->addConfigValue("master:center_master_slaves_on_right", Hyprlang::INT{1});
     m_pConfig->addConfigValue("master:center_ignores_reserved", Hyprlang::INT{0});
     m_pConfig->addConfigValue("master:new_on_active", {"none"});
     m_pConfig->addConfigValue("master:new_on_top", Hyprlang::INT{0});


### PR DESCRIPTION
Adds the option to use right master orientation when slave_count_for_center_master > 2 ,
also makes windows tile to left side first then to the right side when option is set.

#### Is it ready for merging, or does it need work?
I think it should e finished. I tested it, everything works as expected.

