### PR TITLE
feat: add support for supercircular (e.g. squircles) window corner rounding

### DIFF
--- a/example/hyprland.conf
+++ b/example/hyprland.conf
@@ -81,6 +81,7 @@ general {
 # https://wiki.hyprland.org/Configuring/Variables/#decoration
 decoration {
     rounding = 10
+    rounding_power = 2
 
     # Change transparency of focused and unfocused windows
     active_opacity = 1.0

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -140,6 +140,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SRangeData{0, 0, 20},
     },
     SConfigOptionDescription{
+        .value       = "decoration:rounding_power",
+        .description = "rouding power of corners (2 is a circle)",
+        .type        = CONFIG_OPTION_FLOAT,
+        .data        = SConfigOptionDescription::SFloatData{2, 2, 10},
+    },
+    SConfigOptionDescription{
         .value       = "decoration:active_opacity",
         .description = "opacity of active windows. [0.0 - 1.0]",
         .type        = CONFIG_OPTION_FLOAT,

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -427,6 +427,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("debug:colored_stdout_logs", Hyprlang::INT{1});
 
     m_pConfig->addConfigValue("decoration:rounding", Hyprlang::INT{0});
+    m_pConfig->addConfigValue("decoration:rounding_power", {2.F});
     m_pConfig->addConfigValue("decoration:blur:enabled", Hyprlang::INT{1});
     m_pConfig->addConfigValue("decoration:blur:size", Hyprlang::INT{8});
     m_pConfig->addConfigValue("decoration:blur:passes", Hyprlang::INT{1});

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -259,6 +259,7 @@ class CConfigManager {
     };
 
     std::unordered_map<std::string, std::function<CWindowOverridableVar<float>*(PHLWINDOW)>> mfWindowProperties = {
+        {"roundingpower", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.roundingPower; }},
         {"scrollmouse", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.scrollMouse; }},
         {"scrolltouchpad", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.scrollTouchpad; }}};
 

--- a/src/config/defaultConfig.hpp
+++ b/src/config/defaultConfig.hpp
@@ -94,6 +94,7 @@ general {
 # https://wiki.hyprland.org/Configuring/Variables/#decoration
 decoration {
     rounding = 10
+    rounding_power = 2
 
     # Change transparency of focused and unfocused windows
     active_opacity = 1.0

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -183,6 +183,7 @@ struct SWindowData {
     CWindowOverridableVar<bool>               renderUnfocused    = false;
 
     CWindowOverridableVar<int>                rounding;
+    CWindowOverridableVar<float>              roundingPower;
     CWindowOverridableVar<int>                borderSize;
 
     CWindowOverridableVar<float>              scrollMouse;
@@ -414,6 +415,7 @@ class CWindow {
     Vector2D               middle();
     bool                   opaque();
     float                  rounding();
+    float                  roundingPower();
     bool                   canBeTorn();
     void                   setSuspended(bool suspend);
     bool                   visibleOnMonitor(PHLMONITOR pMonitor);

--- a/src/desktop/WindowRule.cpp
+++ b/src/desktop/WindowRule.cpp
@@ -8,8 +8,8 @@ static const auto RULES = std::unordered_set<std::string>{
     "float", "fullscreen", "maximize", "noinitialfocus", "pin", "stayfocused", "tile", "renderunfocused",
 };
 static const auto RULES_PREFIX = std::unordered_set<std::string>{
-    "animation", "bordercolor", "bordersize", "center",   "fullscreenstate", "group",          "idleinhibit", "maxsize",       "minsize", "monitor",   "move", "opacity",
-    "plugin:",   "prop",        "pseudo",     "rounding", "scrollmouse",     "scrolltouchpad", "size",        "suppressevent", "tag",     "workspace", "xray",
+    "animation", "bordercolor", "bordersize", "center",   "fullscreenstate", "group",       "idleinhibit",    "maxsize", "minsize",       "monitor", "move",      "opacity",
+    "plugin:",   "prop",        "pseudo",     "rounding", "roundingpower",   "scrollmouse", "scrolltouchpad", "size",    "suppressevent", "tag",     "workspace", "xray",
 };
 
 CWindowRule::CWindowRule(const std::string& rule, const std::string& value, bool isV2, bool isExecRule) : szValue(value), szRule(rule), v2(isV2), execRule(isExecRule) {

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -971,14 +971,15 @@ void CHyprOpenGLImpl::setDamage(const CRegion& damage_, std::optional<CRegion> f
 }
 
 void CHyprOpenGLImpl::initShaders() {
-    GLuint prog                                      = createProgram(QUADVERTSRC, QUADFRAGSRC);
-    m_RenderData.pCurrentMonData->m_shQUAD.program   = prog;
-    m_RenderData.pCurrentMonData->m_shQUAD.proj      = glGetUniformLocation(prog, "proj");
-    m_RenderData.pCurrentMonData->m_shQUAD.color     = glGetUniformLocation(prog, "color");
-    m_RenderData.pCurrentMonData->m_shQUAD.posAttrib = glGetAttribLocation(prog, "pos");
-    m_RenderData.pCurrentMonData->m_shQUAD.topLeft   = glGetUniformLocation(prog, "topLeft");
-    m_RenderData.pCurrentMonData->m_shQUAD.fullSize  = glGetUniformLocation(prog, "fullSize");
-    m_RenderData.pCurrentMonData->m_shQUAD.radius    = glGetUniformLocation(prog, "radius");
+    GLuint prog                                          = createProgram(QUADVERTSRC, QUADFRAGSRC);
+    m_RenderData.pCurrentMonData->m_shQUAD.program       = prog;
+    m_RenderData.pCurrentMonData->m_shQUAD.proj          = glGetUniformLocation(prog, "proj");
+    m_RenderData.pCurrentMonData->m_shQUAD.color         = glGetUniformLocation(prog, "color");
+    m_RenderData.pCurrentMonData->m_shQUAD.posAttrib     = glGetAttribLocation(prog, "pos");
+    m_RenderData.pCurrentMonData->m_shQUAD.topLeft       = glGetUniformLocation(prog, "topLeft");
+    m_RenderData.pCurrentMonData->m_shQUAD.fullSize      = glGetUniformLocation(prog, "fullSize");
+    m_RenderData.pCurrentMonData->m_shQUAD.radius        = glGetUniformLocation(prog, "radius");
+    m_RenderData.pCurrentMonData->m_shQUAD.roundingPower = glGetUniformLocation(prog, "roundingPower");
 
     prog                                                     = createProgram(TEXVERTSRC, TEXFRAGSRCRGBA);
     m_RenderData.pCurrentMonData->m_shRGBA.program           = prog;
@@ -995,6 +996,7 @@ void CHyprOpenGLImpl::initShaders() {
     m_RenderData.pCurrentMonData->m_shRGBA.topLeft           = glGetUniformLocation(prog, "topLeft");
     m_RenderData.pCurrentMonData->m_shRGBA.fullSize          = glGetUniformLocation(prog, "fullSize");
     m_RenderData.pCurrentMonData->m_shRGBA.radius            = glGetUniformLocation(prog, "radius");
+    m_RenderData.pCurrentMonData->m_shRGBA.roundingPower     = glGetUniformLocation(prog, "roundingPower");
     m_RenderData.pCurrentMonData->m_shRGBA.applyTint         = glGetUniformLocation(prog, "applyTint");
     m_RenderData.pCurrentMonData->m_shRGBA.tint              = glGetUniformLocation(prog, "tint");
     m_RenderData.pCurrentMonData->m_shRGBA.useAlphaMatte     = glGetUniformLocation(prog, "useAlphaMatte");
@@ -1037,6 +1039,7 @@ void CHyprOpenGLImpl::initShaders() {
     m_RenderData.pCurrentMonData->m_shRGBX.topLeft           = glGetUniformLocation(prog, "topLeft");
     m_RenderData.pCurrentMonData->m_shRGBX.fullSize          = glGetUniformLocation(prog, "fullSize");
     m_RenderData.pCurrentMonData->m_shRGBX.radius            = glGetUniformLocation(prog, "radius");
+    m_RenderData.pCurrentMonData->m_shRGBX.roundingPower     = glGetUniformLocation(prog, "roundingPower");
     m_RenderData.pCurrentMonData->m_shRGBX.applyTint         = glGetUniformLocation(prog, "applyTint");
     m_RenderData.pCurrentMonData->m_shRGBX.tint              = glGetUniformLocation(prog, "tint");
 
@@ -1053,6 +1056,7 @@ void CHyprOpenGLImpl::initShaders() {
     m_RenderData.pCurrentMonData->m_shEXT.topLeft           = glGetUniformLocation(prog, "topLeft");
     m_RenderData.pCurrentMonData->m_shEXT.fullSize          = glGetUniformLocation(prog, "fullSize");
     m_RenderData.pCurrentMonData->m_shEXT.radius            = glGetUniformLocation(prog, "radius");
+    m_RenderData.pCurrentMonData->m_shEXT.roundingPower     = glGetUniformLocation(prog, "roundingPower");
     m_RenderData.pCurrentMonData->m_shEXT.applyTint         = glGetUniformLocation(prog, "applyTint");
     m_RenderData.pCurrentMonData->m_shEXT.tint              = glGetUniformLocation(prog, "tint");
 
@@ -1097,18 +1101,19 @@ void CHyprOpenGLImpl::initShaders() {
     m_RenderData.pCurrentMonData->m_shBLURFINISH.brightness = glGetUniformLocation(prog, "brightness");
     m_RenderData.pCurrentMonData->m_shBLURFINISH.noise      = glGetUniformLocation(prog, "noise");
 
-    prog                                                 = createProgram(QUADVERTSRC, FRAGSHADOW);
-    m_RenderData.pCurrentMonData->m_shSHADOW.program     = prog;
-    m_RenderData.pCurrentMonData->m_shSHADOW.proj        = glGetUniformLocation(prog, "proj");
-    m_RenderData.pCurrentMonData->m_shSHADOW.posAttrib   = glGetAttribLocation(prog, "pos");
-    m_RenderData.pCurrentMonData->m_shSHADOW.texAttrib   = glGetAttribLocation(prog, "texcoord");
-    m_RenderData.pCurrentMonData->m_shSHADOW.topLeft     = glGetUniformLocation(prog, "topLeft");
-    m_RenderData.pCurrentMonData->m_shSHADOW.bottomRight = glGetUniformLocation(prog, "bottomRight");
-    m_RenderData.pCurrentMonData->m_shSHADOW.fullSize    = glGetUniformLocation(prog, "fullSize");
-    m_RenderData.pCurrentMonData->m_shSHADOW.radius      = glGetUniformLocation(prog, "radius");
-    m_RenderData.pCurrentMonData->m_shSHADOW.range       = glGetUniformLocation(prog, "range");
-    m_RenderData.pCurrentMonData->m_shSHADOW.shadowPower = glGetUniformLocation(prog, "shadowPower");
-    m_RenderData.pCurrentMonData->m_shSHADOW.color       = glGetUniformLocation(prog, "color");
+    prog                                                   = createProgram(QUADVERTSRC, FRAGSHADOW);
+    m_RenderData.pCurrentMonData->m_shSHADOW.program       = prog;
+    m_RenderData.pCurrentMonData->m_shSHADOW.proj          = glGetUniformLocation(prog, "proj");
+    m_RenderData.pCurrentMonData->m_shSHADOW.posAttrib     = glGetAttribLocation(prog, "pos");
+    m_RenderData.pCurrentMonData->m_shSHADOW.texAttrib     = glGetAttribLocation(prog, "texcoord");
+    m_RenderData.pCurrentMonData->m_shSHADOW.topLeft       = glGetUniformLocation(prog, "topLeft");
+    m_RenderData.pCurrentMonData->m_shSHADOW.bottomRight   = glGetUniformLocation(prog, "bottomRight");
+    m_RenderData.pCurrentMonData->m_shSHADOW.fullSize      = glGetUniformLocation(prog, "fullSize");
+    m_RenderData.pCurrentMonData->m_shSHADOW.radius        = glGetUniformLocation(prog, "radius");
+    m_RenderData.pCurrentMonData->m_shSHADOW.roundingPower = glGetUniformLocation(prog, "roundingPower");
+    m_RenderData.pCurrentMonData->m_shSHADOW.range         = glGetUniformLocation(prog, "range");
+    m_RenderData.pCurrentMonData->m_shSHADOW.shadowPower   = glGetUniformLocation(prog, "shadowPower");
+    m_RenderData.pCurrentMonData->m_shSHADOW.color         = glGetUniformLocation(prog, "color");
 
     prog                                                            = createProgram(QUADVERTSRC, FRAGBORDER1);
     m_RenderData.pCurrentMonData->m_shBORDER1.program               = prog;
@@ -1122,6 +1127,7 @@ void CHyprOpenGLImpl::initShaders() {
     m_RenderData.pCurrentMonData->m_shBORDER1.fullSizeUntransformed = glGetUniformLocation(prog, "fullSizeUntransformed");
     m_RenderData.pCurrentMonData->m_shBORDER1.radius                = glGetUniformLocation(prog, "radius");
     m_RenderData.pCurrentMonData->m_shBORDER1.radiusOuter           = glGetUniformLocation(prog, "radiusOuter");
+    m_RenderData.pCurrentMonData->m_shBORDER1.roundingPower         = glGetUniformLocation(prog, "roundingPower");
     m_RenderData.pCurrentMonData->m_shBORDER1.gradient              = glGetUniformLocation(prog, "gradient");
     m_RenderData.pCurrentMonData->m_shBORDER1.gradient2             = glGetUniformLocation(prog, "gradient2");
     m_RenderData.pCurrentMonData->m_shBORDER1.gradientLength        = glGetUniformLocation(prog, "gradientLength");
@@ -1244,12 +1250,12 @@ void CHyprOpenGLImpl::scissor(const int x, const int y, const int w, const int h
     scissor(&box, transform);
 }
 
-void CHyprOpenGLImpl::renderRect(CBox* box, const CHyprColor& col, int round) {
+void CHyprOpenGLImpl::renderRect(CBox* box, const CHyprColor& col, int round, float roundingPower) {
     if (!m_RenderData.damage.empty())
-        renderRectWithDamage(box, col, m_RenderData.damage, round);
+        renderRectWithDamage(box, col, m_RenderData.damage, round, roundingPower);
 }
 
-void CHyprOpenGLImpl::renderRectWithBlur(CBox* box, const CHyprColor& col, int round, float blurA, bool xray) {
+void CHyprOpenGLImpl::renderRectWithBlur(CBox* box, const CHyprColor& col, int round, float roundingPower, float blurA, bool xray) {
     if (m_RenderData.damage.empty())
         return;
 
@@ -1271,7 +1277,7 @@ void CHyprOpenGLImpl::renderRectWithBlur(CBox* box, const CHyprColor& col, int r
     glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
 
     glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
-    renderRect(box, CHyprColor(0, 0, 0, 0), round);
+    renderRect(box, CHyprColor(0, 0, 0, 0), round, roundingPower);
     glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 
     glStencilFunc(GL_EQUAL, 1, 0xFF);
@@ -1282,7 +1288,7 @@ void CHyprOpenGLImpl::renderRectWithBlur(CBox* box, const CHyprColor& col, int r
     m_bEndFrame                 = true; // fix transformed
     const auto SAVEDRENDERMODIF = m_RenderData.renderModif;
     m_RenderData.renderModif    = {}; // fix shit
-    renderTextureInternalWithDamage(POUTFB->getTexture(), &MONITORBOX, blurA, damage, 0, false, false, false);
+    renderTextureInternalWithDamage(POUTFB->getTexture(), &MONITORBOX, blurA, damage, 0, 2.0f, false, false, false);
     m_bEndFrame              = false;
     m_RenderData.renderModif = SAVEDRENDERMODIF;
 
@@ -1293,10 +1299,10 @@ void CHyprOpenGLImpl::renderRectWithBlur(CBox* box, const CHyprColor& col, int r
     glStencilFunc(GL_ALWAYS, 1, 0xFF);
     scissor((CBox*)nullptr);
 
-    renderRectWithDamage(box, col, m_RenderData.damage, round);
+    renderRectWithDamage(box, col, m_RenderData.damage, round, roundingPower);
 }
 
-void CHyprOpenGLImpl::renderRectWithDamage(CBox* box, const CHyprColor& col, const CRegion& damage, int round) {
+void CHyprOpenGLImpl::renderRectWithDamage(CBox* box, const CHyprColor& col, const CRegion& damage, int round, float roundingPower) {
     RASSERT((box->width > 0 && box->height > 0), "Tried to render rect with width/height < 0!");
     RASSERT(m_RenderData.pMonitor, "Tried to render rect without begin()!");
 
@@ -1334,6 +1340,7 @@ void CHyprOpenGLImpl::renderRectWithDamage(CBox* box, const CHyprColor& col, con
     glUniform2f(m_RenderData.pCurrentMonData->m_shQUAD.topLeft, (float)TOPLEFT.x, (float)TOPLEFT.y);
     glUniform2f(m_RenderData.pCurrentMonData->m_shQUAD.fullSize, (float)FULLSIZE.x, (float)FULLSIZE.y);
     glUniform1f(m_RenderData.pCurrentMonData->m_shQUAD.radius, round);
+    glUniform1f(m_RenderData.pCurrentMonData->m_shQUAD.roundingPower, roundingPower);
 
     glVertexAttribPointer(m_RenderData.pCurrentMonData->m_shQUAD.posAttrib, 2, GL_FLOAT, GL_FALSE, 0, fullVerts);
 
@@ -1361,25 +1368,25 @@ void CHyprOpenGLImpl::renderRectWithDamage(CBox* box, const CHyprColor& col, con
     scissor((CBox*)nullptr);
 }
 
-void CHyprOpenGLImpl::renderTexture(SP<CTexture> tex, CBox* pBox, float alpha, int round, bool discardActive, bool allowCustomUV) {
+void CHyprOpenGLImpl::renderTexture(SP<CTexture> tex, CBox* pBox, float alpha, int round, float roundingPower, bool discardActive, bool allowCustomUV) {
     RASSERT(m_RenderData.pMonitor, "Tried to render texture without begin()!");
 
-    renderTextureInternalWithDamage(tex, pBox, alpha, m_RenderData.damage, round, discardActive, false, allowCustomUV, true);
+    renderTextureInternalWithDamage(tex, pBox, alpha, m_RenderData.damage, round, roundingPower, discardActive, false, allowCustomUV, true);
 
     scissor((CBox*)nullptr);
 }
 
-void CHyprOpenGLImpl::renderTextureWithDamage(SP<CTexture> tex, CBox* pBox, const CRegion& damage, float alpha, int round, bool discardActive, bool allowCustomUV,
-                                              SP<CSyncTimeline> waitTimeline, uint64_t waitPoint) {
+void CHyprOpenGLImpl::renderTextureWithDamage(SP<CTexture> tex, CBox* pBox, const CRegion& damage, float alpha, int round, float roundingPower, bool discardActive,
+                                              bool allowCustomUV, SP<CSyncTimeline> waitTimeline, uint64_t waitPoint) {
     RASSERT(m_RenderData.pMonitor, "Tried to render texture without begin()!");
 
-    renderTextureInternalWithDamage(tex, pBox, alpha, damage, round, discardActive, false, allowCustomUV, true, waitTimeline, waitPoint);
+    renderTextureInternalWithDamage(tex, pBox, alpha, damage, round, roundingPower, discardActive, false, allowCustomUV, true, waitTimeline, waitPoint);
 
     scissor((CBox*)nullptr);
 }
 
-void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, CBox* pBox, float alpha, const CRegion& damage, int round, bool discardActive, bool noAA,
-                                                      bool allowCustomUV, bool allowDim, SP<CSyncTimeline> waitTimeline, uint64_t waitPoint) {
+void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, CBox* pBox, float alpha, const CRegion& damage, int round, float roundingPower, bool discardActive,
+                                                      bool noAA, bool allowCustomUV, bool allowDim, SP<CSyncTimeline> waitTimeline, uint64_t waitPoint) {
     RASSERT(m_RenderData.pMonitor, "Tried to render texture without begin()!");
     RASSERT((tex->m_iTexID > 0), "Attempted to draw nullptr texture!");
 
@@ -1506,6 +1513,7 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, CBox* pB
         glUniform2f(shader->topLeft, TOPLEFT.x, TOPLEFT.y);
         glUniform2f(shader->fullSize, FULLSIZE.x, FULLSIZE.y);
         glUniform1f(shader->radius, round);
+        glUniform1f(shader->roundingPower, roundingPower);
 
         if (allowDim && m_RenderData.currentWindow) {
             glUniform1i(shader->applyTint, 1);
@@ -1997,7 +2005,7 @@ void CHyprOpenGLImpl::preBlurForCurrentMonitor() {
     clear(CHyprColor(0, 0, 0, 0));
 
     m_bEndFrame = true; // fix transformed
-    renderTextureInternalWithDamage(POUTFB->getTexture(), &wholeMonitor, 1, fakeDamage, 0, false, true, false);
+    renderTextureInternalWithDamage(POUTFB->getTexture(), &wholeMonitor, 1, fakeDamage, 0, 2.0f, false, true, false);
     m_bEndFrame = false;
 
     m_RenderData.currentFB->bind();
@@ -2045,8 +2053,8 @@ bool CHyprOpenGLImpl::shouldUseNewBlurOptimizations(PHLLS pLayer, PHLWINDOW pWin
     return false;
 }
 
-void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, CBox* pBox, float a, SP<CWLSurfaceResource> pSurface, int round, bool blockBlurOptimization, float blurA,
-                                            float overallA) {
+void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, CBox* pBox, float a, SP<CWLSurfaceResource> pSurface, int round, float roundingPower, bool blockBlurOptimization,
+                                            float blurA, float overallA) {
     RASSERT(m_RenderData.pMonitor, "Tried to render texture with blur without begin()!");
 
     static auto PNOBLUROVERSIZED = CConfigValue<Hyprlang::INT>("decoration:no_blur_on_oversized");
@@ -2063,7 +2071,7 @@ void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, CBox* pBox, float 
     m_RenderData.renderModif.applyToRegion(texDamage);
 
     if (*PNOBLUROVERSIZED && m_RenderData.primarySurfaceUVTopLeft != Vector2D(-1, -1)) {
-        renderTexture(tex, pBox, a, round, false, true);
+        renderTexture(tex, pBox, a, round, roundingPower, false, true);
         return;
     }
 
@@ -2076,7 +2084,7 @@ void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, CBox* pBox, float 
         inverseOpaque.invert(&surfbox).intersect(0, 0, pSurface->current.size.x * pSurface->current.scale, pSurface->current.size.y * pSurface->current.scale);
 
         if (inverseOpaque.empty()) {
-            renderTexture(tex, pBox, a, round, false, true);
+            renderTexture(tex, pBox, a, round, roundingPower, false, true);
             return;
         }
     } else {
@@ -2112,9 +2120,9 @@ void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, CBox* pBox, float 
 
     glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
     if (USENEWOPTIMIZE && !(m_RenderData.discardMode & DISCARD_ALPHA))
-        renderRect(pBox, CHyprColor(0, 0, 0, 0), round);
+        renderRect(pBox, CHyprColor(0, 0, 0, 0), round, roundingPower);
     else
-        renderTexture(tex, pBox, a, round, true, true); // discard opaque
+        renderTexture(tex, pBox, a, round, roundingPower, true, true); // discard opaque
     glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 
     glStencilFunc(GL_EQUAL, 1, 0xFF);
@@ -2127,7 +2135,7 @@ void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, CBox* pBox, float 
     setMonitorTransformEnabled(true);
     if (!USENEWOPTIMIZE)
         setRenderModifEnabled(false);
-    renderTextureInternalWithDamage(POUTFB->getTexture(), &MONITORBOX, (*PBLURIGNOREOPACITY ? blurA : a * blurA) * overallA, texDamage, 0, false, false, false);
+    renderTextureInternalWithDamage(POUTFB->getTexture(), &MONITORBOX, (*PBLURIGNOREOPACITY ? blurA : a * blurA) * overallA, texDamage, 0, 2.0f, false, false, false);
     if (!USENEWOPTIMIZE)
         setRenderModifEnabled(true);
     setMonitorTransformEnabled(false);
@@ -2138,14 +2146,14 @@ void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, CBox* pBox, float 
 
     // draw window
     glDisable(GL_STENCIL_TEST);
-    renderTextureInternalWithDamage(tex, pBox, a * overallA, texDamage, round, false, false, true, true);
+    renderTextureInternalWithDamage(tex, pBox, a * overallA, texDamage, round, roundingPower, false, false, true, true);
 
     glStencilMask(0xFF);
     glStencilFunc(GL_ALWAYS, 1, 0xFF);
     scissor((CBox*)nullptr);
 }
 
-void CHyprOpenGLImpl::renderBorder(CBox* box, const CGradientValueData& grad, int round, int borderSize, float a, int outerRound) {
+void CHyprOpenGLImpl::renderBorder(CBox* box, const CGradientValueData& grad, int round, float roundingPower, int borderSize, float a, int outerRound) {
     RASSERT((box->width > 0 && box->height > 0), "Tried to render rect with width/height < 0!");
     RASSERT(m_RenderData.pMonitor, "Tried to render rect without begin()!");
 
@@ -2207,6 +2215,7 @@ void CHyprOpenGLImpl::renderBorder(CBox* box, const CGradientValueData& grad, in
     glUniform2f(m_RenderData.pCurrentMonData->m_shBORDER1.fullSizeUntransformed, (float)box->width, (float)box->height);
     glUniform1f(m_RenderData.pCurrentMonData->m_shBORDER1.radius, round);
     glUniform1f(m_RenderData.pCurrentMonData->m_shBORDER1.radiusOuter, outerRound == -1 ? round : outerRound);
+    glUniform1f(m_RenderData.pCurrentMonData->m_shBORDER1.roundingPower, roundingPower);
     glUniform1f(m_RenderData.pCurrentMonData->m_shBORDER1.thick, scaledBorderSize);
 
     glVertexAttribPointer(m_RenderData.pCurrentMonData->m_shBORDER1.posAttrib, 2, GL_FLOAT, GL_FALSE, 0, fullVerts);
@@ -2238,7 +2247,8 @@ void CHyprOpenGLImpl::renderBorder(CBox* box, const CGradientValueData& grad, in
     blend(BLEND);
 }
 
-void CHyprOpenGLImpl::renderBorder(CBox* box, const CGradientValueData& grad1, const CGradientValueData& grad2, float lerp, int round, int borderSize, float a, int outerRound) {
+void CHyprOpenGLImpl::renderBorder(CBox* box, const CGradientValueData& grad1, const CGradientValueData& grad2, float lerp, int round, float roundingPower, int borderSize, float a,
+                                   int outerRound) {
     RASSERT((box->width > 0 && box->height > 0), "Tried to render rect with width/height < 0!");
     RASSERT(m_RenderData.pMonitor, "Tried to render rect without begin()!");
 
@@ -2304,6 +2314,7 @@ void CHyprOpenGLImpl::renderBorder(CBox* box, const CGradientValueData& grad1, c
     glUniform2f(m_RenderData.pCurrentMonData->m_shBORDER1.fullSizeUntransformed, (float)box->width, (float)box->height);
     glUniform1f(m_RenderData.pCurrentMonData->m_shBORDER1.radius, round);
     glUniform1f(m_RenderData.pCurrentMonData->m_shBORDER1.radiusOuter, outerRound == -1 ? round : outerRound);
+    glUniform1f(m_RenderData.pCurrentMonData->m_shBORDER1.roundingPower, roundingPower);
     glUniform1f(m_RenderData.pCurrentMonData->m_shBORDER1.thick, scaledBorderSize);
 
     glVertexAttribPointer(m_RenderData.pCurrentMonData->m_shBORDER1.posAttrib, 2, GL_FLOAT, GL_FALSE, 0, fullVerts);
@@ -2335,7 +2346,7 @@ void CHyprOpenGLImpl::renderBorder(CBox* box, const CGradientValueData& grad1, c
     blend(BLEND);
 }
 
-void CHyprOpenGLImpl::renderRoundedShadow(CBox* box, int round, int range, const CHyprColor& color, float a) {
+void CHyprOpenGLImpl::renderRoundedShadow(CBox* box, int round, float roundingPower, int range, const CHyprColor& color, float a) {
     RASSERT(m_RenderData.pMonitor, "Tried to render shadow without begin()!");
     RASSERT((box->width > 0 && box->height > 0), "Tried to render shadow with width/height < 0!");
     RASSERT(m_RenderData.currentWindow, "Tried to render shadow without a window!");
@@ -2381,6 +2392,7 @@ void CHyprOpenGLImpl::renderRoundedShadow(CBox* box, int round, int range, const
     glUniform2f(m_RenderData.pCurrentMonData->m_shSHADOW.bottomRight, (float)BOTTOMRIGHT.x, (float)BOTTOMRIGHT.y);
     glUniform2f(m_RenderData.pCurrentMonData->m_shSHADOW.fullSize, (float)FULLSIZE.x, (float)FULLSIZE.y);
     glUniform1f(m_RenderData.pCurrentMonData->m_shSHADOW.radius, range + round);
+    glUniform1f(m_RenderData.pCurrentMonData->m_shSHADOW.roundingPower, roundingPower);
     glUniform1f(m_RenderData.pCurrentMonData->m_shSHADOW.range, range);
     glUniform1f(m_RenderData.pCurrentMonData->m_shSHADOW.shadowPower, SHADOWPOWER);
 
@@ -2421,7 +2433,7 @@ void CHyprOpenGLImpl::saveBufferForMirror(CBox* box) {
 
     blend(false);
 
-    renderTexture(m_RenderData.currentFB->getTexture(), box, 1.f, 0, false, false);
+    renderTexture(m_RenderData.currentFB->getTexture(), box, 1.f, 0, 2.0f, false, false);
 
     blend(true);
 

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -166,83 +166,84 @@ class CHyprOpenGLImpl {
     CHyprOpenGLImpl();
     ~CHyprOpenGLImpl();
 
-    void begin(PHLMONITOR, const CRegion& damage, CFramebuffer* fb = nullptr, std::optional<CRegion> finalDamage = {});
-    void beginSimple(PHLMONITOR, const CRegion& damage, SP<CRenderbuffer> rb = nullptr, CFramebuffer* fb = nullptr);
-    void end();
+    void         begin(PHLMONITOR, const CRegion& damage, CFramebuffer* fb = nullptr, std::optional<CRegion> finalDamage = {});
+    void         beginSimple(PHLMONITOR, const CRegion& damage, SP<CRenderbuffer> rb = nullptr, CFramebuffer* fb = nullptr);
+    void         end();
 
-    void renderRect(CBox*, const CHyprColor&, int round = 0);
-    void renderRectWithBlur(CBox*, const CHyprColor&, int round = 0, float blurA = 1.f, bool xray = false);
-    void renderRectWithDamage(CBox*, const CHyprColor&, const CRegion& damage, int round = 0);
-    void renderTexture(SP<CTexture>, CBox*, float a, int round = 0, bool discardActive = false, bool allowCustomUV = false);
-    void renderTextureWithDamage(SP<CTexture>, CBox*, const CRegion& damage, float a, int round = 0, bool discardActive = false, bool allowCustomUV = false,
-                                 SP<CSyncTimeline> waitTimeline = nullptr, uint64_t waitPoint = 0);
-    void renderTextureWithBlur(SP<CTexture>, CBox*, float a, SP<CWLSurfaceResource> pSurface, int round = 0, bool blockBlurOptimization = false, float blurA = 1.f,
-                               float overallA = 1.f);
-    void renderRoundedShadow(CBox*, int round, int range, const CHyprColor& color, float a = 1.0);
-    void renderBorder(CBox*, const CGradientValueData&, int round, int borderSize, float a = 1.0, int outerRound = -1 /* use round */);
-    void renderBorder(CBox*, const CGradientValueData&, const CGradientValueData&, float lerp, int round, int borderSize, float a = 1.0, int outerRound = -1 /* use round */);
-    void renderTextureMatte(SP<CTexture> tex, CBox* pBox, CFramebuffer& matte);
+    void         renderRect(CBox*, const CHyprColor&, int round = 0, float roundingPower = 2.0f);
+    void         renderRectWithBlur(CBox*, const CHyprColor&, int round = 0, float roundingPower = 2.0f, float blurA = 1.f, bool xray = false);
+    void         renderRectWithDamage(CBox*, const CHyprColor&, const CRegion& damage, int round = 0, float roundingPower = 2.0f);
+    void         renderTexture(SP<CTexture>, CBox*, float a, int round = 0, float roundingPower = 2.0f, bool discardActive = false, bool allowCustomUV = false);
+    void         renderTextureWithDamage(SP<CTexture>, CBox*, const CRegion& damage, float a, int round = 0, float roundingPower = 2.0f, bool discardActive = false,
+                                         bool allowCustomUV = false, SP<CSyncTimeline> waitTimeline = nullptr, uint64_t waitPoint = 0);
+    void         renderTextureWithBlur(SP<CTexture>, CBox*, float a, SP<CWLSurfaceResource> pSurface, int round = 0, float roundingPower = 2.0f, bool blockBlurOptimization = false,
+                                       float blurA = 1.f, float overallA = 1.f);
+    void         renderRoundedShadow(CBox*, int round, float roundingPower, int range, const CHyprColor& color, float a = 1.0);
+    void         renderBorder(CBox*, const CGradientValueData&, int round, float roundingPower, int borderSize, float a = 1.0, int outerRound = -1 /* use round */);
+    void         renderBorder(CBox*, const CGradientValueData&, const CGradientValueData&, float lerp, int round, float roundingPower, int borderSize, float a = 1.0,
+                              int outerRound = -1 /* use round */);
+    void         renderTextureMatte(SP<CTexture> tex, CBox* pBox, CFramebuffer& matte);
 
-    void setMonitorTransformEnabled(bool enabled);
-    void setRenderModifEnabled(bool enabled);
+    void         setMonitorTransformEnabled(bool enabled);
+    void         setRenderModifEnabled(bool enabled);
 
-    void saveMatrix();
-    void setMatrixScaleTranslate(const Vector2D& translate, const float& scale);
-    void restoreMatrix();
+    void         saveMatrix();
+    void         setMatrixScaleTranslate(const Vector2D& translate, const float& scale);
+    void         restoreMatrix();
 
-    void blend(bool enabled);
+    void         blend(bool enabled);
 
-    bool shouldUseNewBlurOptimizations(PHLLS pLayer, PHLWINDOW pWindow);
+    bool         shouldUseNewBlurOptimizations(PHLLS pLayer, PHLWINDOW pWindow);
 
-    void clear(const CHyprColor&);
-    void clearWithTex();
-    void scissor(const CBox*, bool transform = true);
-    void scissor(const pixman_box32*, bool transform = true);
-    void scissor(const int x, const int y, const int w, const int h, bool transform = true);
+    void         clear(const CHyprColor&);
+    void         clearWithTex();
+    void         scissor(const CBox*, bool transform = true);
+    void         scissor(const pixman_box32*, bool transform = true);
+    void         scissor(const int x, const int y, const int w, const int h, bool transform = true);
 
-    void destroyMonitorResources(PHLMONITOR);
+    void         destroyMonitorResources(PHLMONITOR);
 
-    void markBlurDirtyForMonitor(PHLMONITOR);
+    void         markBlurDirtyForMonitor(PHLMONITOR);
 
-    void preWindowPass();
-    bool preBlurQueued();
-    void preRender(PHLMONITOR);
+    void         preWindowPass();
+    bool         preBlurQueued();
+    void         preRender(PHLMONITOR);
 
-    void saveBufferForMirror(CBox*);
-    void renderMirrored();
+    void         saveBufferForMirror(CBox*);
+    void         renderMirrored();
 
-    void applyScreenShader(const std::string& path);
+    void         applyScreenShader(const std::string& path);
 
-    void bindOffMain();
-    void renderOffToMain(CFramebuffer* off);
-    void bindBackOnMain();
+    void         bindOffMain();
+    void         renderOffToMain(CFramebuffer* off);
+    void         bindBackOnMain();
 
-    SP<CTexture>                         loadAsset(const std::string& file);
-    SP<CTexture>                         renderText(const std::string& text, CHyprColor col, int pt, bool italic = false, const std::string& fontFamily = "", int maxWidth = 0);
+    SP<CTexture> loadAsset(const std::string& file);
+    SP<CTexture> renderText(const std::string& text, CHyprColor col, int pt, bool italic = false, const std::string& fontFamily = "", int maxWidth = 0);
 
-    void                                 setDamage(const CRegion& damage, std::optional<CRegion> finalDamage = {});
+    void         setDamage(const CRegion& damage, std::optional<CRegion> finalDamage = {});
 
-    uint32_t                             getPreferredReadFormat(PHLMONITOR pMonitor);
-    std::vector<SDRMFormat>              getDRMFormats();
-    EGLImageKHR                          createEGLImage(const Aquamarine::SDMABUFAttrs& attrs);
-    SP<CEGLSync>                         createEGLSync(int fenceFD);
-    bool                                 waitForTimelinePoint(SP<CSyncTimeline> timeline, uint64_t point);
+    uint32_t     getPreferredReadFormat(PHLMONITOR pMonitor);
+    std::vector<SDRMFormat>                     getDRMFormats();
+    EGLImageKHR                                 createEGLImage(const Aquamarine::SDMABUFAttrs& attrs);
+    SP<CEGLSync>                                createEGLSync(int fenceFD);
+    bool                                        waitForTimelinePoint(SP<CSyncTimeline> timeline, uint64_t point);
 
-    SCurrentRenderData                   m_RenderData;
+    SCurrentRenderData                          m_RenderData;
 
-    GLint                                m_iCurrentOutputFb = 0;
+    GLint                                       m_iCurrentOutputFb = 0;
 
-    int                                  m_iGBMFD       = -1;
-    gbm_device*                          m_pGbmDevice   = nullptr;
-    EGLContext                           m_pEglContext  = nullptr;
-    EGLDisplay                           m_pEglDisplay  = nullptr;
-    EGLDeviceEXT                         m_pEglDevice   = nullptr;
-    uint                                 failedAssetsNo = 0;
+    int                                         m_iGBMFD       = -1;
+    gbm_device*                                 m_pGbmDevice   = nullptr;
+    EGLContext                                  m_pEglContext  = nullptr;
+    EGLDisplay                                  m_pEglDisplay  = nullptr;
+    EGLDeviceEXT                                m_pEglDevice   = nullptr;
+    uint                                        failedAssetsNo = 0;
 
-    bool                                 m_bReloadScreenShader = true; // at launch it can be set
+    bool                                        m_bReloadScreenShader = true; // at launch it can be set
 
-    std::map<PHLWINDOWREF, CFramebuffer> m_mWindowFramebuffers;
-    std::map<PHLLSREF, CFramebuffer>     m_mLayerFramebuffers;
+    std::map<PHLWINDOWREF, CFramebuffer>        m_mWindowFramebuffers;
+    std::map<PHLLSREF, CFramebuffer>            m_mLayerFramebuffers;
     std::map<PHLMONITORREF, SMonitorRenderData> m_mMonitorRenderResources;
     std::map<PHLMONITORREF, CFramebuffer>       m_mMonitorBGFBs;
 
@@ -311,8 +312,8 @@ class CHyprOpenGLImpl {
     // returns the out FB, can be either Mirror or MirrorSwap
     CFramebuffer* blurMainFramebufferWithDamage(float a, CRegion* damage);
 
-    void          renderTextureInternalWithDamage(SP<CTexture>, CBox* pBox, float a, const CRegion& damage, int round = 0, bool discardOpaque = false, bool noAA = false,
-                                                  bool allowCustomUV = false, bool allowDim = false, SP<CSyncTimeline> = nullptr, uint64_t waitPoint = 0);
+    void          renderTextureInternalWithDamage(SP<CTexture>, CBox* pBox, float a, const CRegion& damage, int round = 0, float roundingPower = 2.0f, bool discardOpaque = false,
+                                                  bool noAA = false, bool allowCustomUV = false, bool allowDim = false, SP<CSyncTimeline> = nullptr, uint64_t waitPoint = 0);
     void          renderTexturePrimitive(SP<CTexture> tex, CBox* pBox);
     void          renderSplash(cairo_t* const, cairo_surface_t* const, double offset, const Vector2D& size);
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -460,11 +460,12 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, timespe
     renderdata.dontRound = pWindow->isEffectiveInternalFSMode(FSMODE_FULLSCREEN) || pWindow->m_sWindowData.noRounding.valueOrDefault();
     renderdata.fadeAlpha = pWindow->m_fAlpha.value() * (pWindow->m_bPinned || USE_WORKSPACE_FADE_ALPHA ? 1.f : PWORKSPACE->m_fAlpha.value()) *
         (USE_WORKSPACE_FADE_ALPHA ? pWindow->m_fMovingToWorkspaceAlpha.value() : 1.F) * pWindow->m_fMovingFromWorkspaceAlpha.value();
-    renderdata.alpha    = pWindow->m_fActiveInactiveAlpha.value();
-    renderdata.decorate = decorate && !pWindow->m_bX11DoesntWantBorders && !pWindow->isEffectiveInternalFSMode(FSMODE_FULLSCREEN);
-    renderdata.rounding = ignoreAllGeometry || renderdata.dontRound ? 0 : pWindow->rounding() * pMonitor->scale;
-    renderdata.blur     = !ignoreAllGeometry && *PBLUR && !DONT_BLUR;
-    renderdata.pWindow  = pWindow;
+    renderdata.alpha         = pWindow->m_fActiveInactiveAlpha.value();
+    renderdata.decorate      = decorate && !pWindow->m_bX11DoesntWantBorders && !pWindow->isEffectiveInternalFSMode(FSMODE_FULLSCREEN);
+    renderdata.rounding      = ignoreAllGeometry || renderdata.dontRound ? 0 : pWindow->rounding() * pMonitor->scale;
+    renderdata.roundingPower = ignoreAllGeometry || renderdata.dontRound ? 2.0f : pWindow->roundingPower();
+    renderdata.blur          = !ignoreAllGeometry && *PBLUR && !DONT_BLUR;
+    renderdata.pWindow       = pWindow;
 
     if (ignoreAllGeometry) {
         renderdata.alpha     = 1.f;

--- a/src/render/Shader.hpp
+++ b/src/render/Shader.hpp
@@ -26,6 +26,7 @@ class CShader {
     GLint   fullSizeUntransformed = -1;
     GLint   radius                = -1;
     GLint   radiusOuter           = -1;
+    GLfloat roundingPower         = -1;
 
     GLint   thick = -1;
 

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -67,15 +67,17 @@ void CHyprBorderDecoration::draw(PHLMONITOR pMonitor, float const& a) {
         grad.m_fAngle = normalizeAngleRad(grad.m_fAngle);
     }
 
-    int                             borderSize = m_pWindow->getRealBorderSize();
-    const auto                      ROUNDING   = m_pWindow->rounding() * pMonitor->scale;
+    int                             borderSize    = m_pWindow->getRealBorderSize();
+    const auto                      ROUNDING      = m_pWindow->rounding() * pMonitor->scale;
+    const auto                      ROUNDINGPOWER = m_pWindow->roundingPower();
 
     CBorderPassElement::SBorderData data;
-    data.box        = windowBox;
-    data.grad1      = grad;
-    data.round      = ROUNDING;
-    data.a          = a;
-    data.borderSize = borderSize;
+    data.box           = windowBox;
+    data.grad1         = grad;
+    data.round         = ROUNDING;
+    data.roundingPower = ROUNDINGPOWER;
+    data.a             = a;
+    data.borderSize    = borderSize;
 
     if (ANIMATED) {
         data.hasGrad2 = true;

--- a/src/render/decorations/CHyprDropShadowDecoration.hpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.hpp
@@ -36,7 +36,7 @@ class CHyprDropShadowDecoration : public IHyprWindowDecoration {
     Vector2D     m_vLastWindowPos;
     Vector2D     m_vLastWindowSize;
 
-    void         drawShadowInternal(CBox* box, int round, int range, CHyprColor color, float a);
+    void         drawShadowInternal(CBox* box, int round, float roundingPower, int range, CHyprColor color, float a);
 
     CBox         m_bLastWindowBox          = {0};
     CBox         m_bLastWindowBoxWithDecos = {0};

--- a/src/render/pass/BorderPassElement.cpp
+++ b/src/render/pass/BorderPassElement.cpp
@@ -7,9 +7,9 @@ CBorderPassElement::CBorderPassElement(const CBorderPassElement::SBorderData& da
 
 void CBorderPassElement::draw(const CRegion& damage) {
     if (data.hasGrad2)
-        g_pHyprOpenGL->renderBorder(&data.box, data.grad1, data.grad2, data.lerp, data.round, data.borderSize, data.a, data.outerRound);
+        g_pHyprOpenGL->renderBorder(&data.box, data.grad1, data.grad2, data.lerp, data.round, data.roundingPower, data.borderSize, data.a, data.outerRound);
     else
-        g_pHyprOpenGL->renderBorder(&data.box, data.grad1, data.round, data.borderSize, data.a, data.outerRound);
+        g_pHyprOpenGL->renderBorder(&data.box, data.grad1, data.round, data.roundingPower, data.borderSize, data.a, data.outerRound);
 }
 
 bool CBorderPassElement::needsLiveBlur() {

--- a/src/render/pass/BorderPassElement.hpp
+++ b/src/render/pass/BorderPassElement.hpp
@@ -12,6 +12,7 @@ class CBorderPassElement : public IPassElement {
         bool               hasGrad2 = false;
         float              lerp = 0.F, a = 1.F;
         int                round = 0, borderSize = 1, outerRound = -1;
+        float              roundingPower = 2.F;
     };
 
     CBorderPassElement(const SBorderData& data_);

--- a/src/render/pass/RectPassElement.cpp
+++ b/src/render/pass/RectPassElement.cpp
@@ -10,9 +10,9 @@ void CRectPassElement::draw(const CRegion& damage) {
         return;
 
     if (data.color.a == 1.F || !data.blur)
-        g_pHyprOpenGL->renderRectWithDamage(&data.box, data.color, damage, data.round);
+        g_pHyprOpenGL->renderRectWithDamage(&data.box, data.color, damage, data.round, data.roundingPower);
     else
-        g_pHyprOpenGL->renderRectWithBlur(&data.box, data.color, data.round, data.blurA, data.xray);
+        g_pHyprOpenGL->renderRectWithBlur(&data.box, data.color, data.round, data.roundingPower, data.blurA, data.xray);
 }
 
 bool CRectPassElement::needsLiveBlur() {

--- a/src/render/pass/RectPassElement.hpp
+++ b/src/render/pass/RectPassElement.hpp
@@ -6,7 +6,8 @@ class CRectPassElement : public IPassElement {
     struct SRectData {
         CBox       box;
         CHyprColor color;
-        int        round = 0;
+        int        round         = 0;
+        float      roundingPower = 2.0f;
         bool       blur = false, xray = false;
         float      blurA = 1.F;
     };

--- a/src/render/pass/SurfacePassElement.cpp
+++ b/src/render/pass/SurfacePassElement.cpp
@@ -88,12 +88,15 @@ void CSurfacePassElement::draw(const CRegion& damage) {
     if (MISALIGNEDFSV1)
         g_pHyprOpenGL->m_RenderData.useNearestNeighbor = true;
 
-    float rounding = data.rounding;
+    float rounding      = data.rounding;
+    float roundingPower = data.roundingPower;
 
     rounding -= 1; // to fix a border issue
 
-    if (data.dontRound)
-        rounding = 0;
+    if (data.dontRound) {
+        rounding      = 0;
+        roundingPower = 2.0f;
+    }
 
     const bool WINDOWOPAQUE    = data.pWindow && data.pWindow->m_pWLSurface->resource() == data.surface ? data.pWindow->opaque() : false;
     const bool CANDISABLEBLEND = ALPHA >= 1.f && OVERALL_ALPHA >= 1.f && rounding == 0 && WINDOWOPAQUE;
@@ -108,14 +111,14 @@ void CSurfacePassElement::draw(const CRegion& damage) {
     // to what we do for misaligned surfaces (blur the entire thing and then render shit without blur)
     if (data.surfaceCounter == 0 && !data.popup) {
         if (BLUR)
-            g_pHyprOpenGL->renderTextureWithBlur(TEXTURE, &windowBox, ALPHA, data.surface, rounding, data.blockBlurOptimization, data.fadeAlpha, OVERALL_ALPHA);
+            g_pHyprOpenGL->renderTextureWithBlur(TEXTURE, &windowBox, ALPHA, data.surface, rounding, roundingPower, data.blockBlurOptimization, data.fadeAlpha, OVERALL_ALPHA);
         else
-            g_pHyprOpenGL->renderTexture(TEXTURE, &windowBox, ALPHA * OVERALL_ALPHA, rounding, false, true);
+            g_pHyprOpenGL->renderTexture(TEXTURE, &windowBox, ALPHA * OVERALL_ALPHA, rounding, roundingPower, false, true);
     } else {
         if (BLUR && data.popup)
-            g_pHyprOpenGL->renderTextureWithBlur(TEXTURE, &windowBox, ALPHA, data.surface, rounding, true, data.fadeAlpha, OVERALL_ALPHA);
+            g_pHyprOpenGL->renderTextureWithBlur(TEXTURE, &windowBox, ALPHA, data.surface, rounding, roundingPower, true, data.fadeAlpha, OVERALL_ALPHA);
         else
-            g_pHyprOpenGL->renderTexture(TEXTURE, &windowBox, ALPHA * OVERALL_ALPHA, rounding, false, true);
+            g_pHyprOpenGL->renderTexture(TEXTURE, &windowBox, ALPHA * OVERALL_ALPHA, rounding, roundingPower, false, true);
     }
 
     if (!g_pHyprRenderer->m_bBlockSurfaceFeedback)

--- a/src/render/pass/SurfacePassElement.hpp
+++ b/src/render/pass/SurfacePassElement.hpp
@@ -35,6 +35,9 @@ class CSurfacePassElement : public IPassElement {
         // for custom round values
         int rounding = -1; // -1 means not set
 
+        // for custom rounding powers
+        float roundingPower = 2.0f;
+
         // for blurring
         bool blur                  = false;
         bool blockBlurOptimization = false;

--- a/src/render/pass/TexPassElement.cpp
+++ b/src/render/pass/TexPassElement.cpp
@@ -18,7 +18,8 @@ void CTexPassElement::draw(const CRegion& damage) {
 
     if (data.replaceProjection)
         g_pHyprOpenGL->m_RenderData.monitorProjection = *data.replaceProjection;
-    g_pHyprOpenGL->renderTextureInternalWithDamage(data.tex, &data.box, data.a, data.damage.empty() ? damage : data.damage, data.round, data.syncTimeline, data.syncPoint);
+    g_pHyprOpenGL->renderTextureInternalWithDamage(data.tex, &data.box, data.a, data.damage.empty() ? damage : data.damage, data.round, data.roundingPower, data.syncTimeline,
+                                                   data.syncPoint);
     if (data.replaceProjection)
         g_pHyprOpenGL->m_RenderData.monitorProjection = g_pHyprOpenGL->m_RenderData.pMonitor->projMatrix;
 }

--- a/src/render/pass/TexPassElement.hpp
+++ b/src/render/pass/TexPassElement.hpp
@@ -13,8 +13,9 @@ class CTexPassElement : public IPassElement {
         CBox                  box;
         float                 a = 1.F;
         CRegion               damage;
-        int                   round        = 0;
-        bool                  flipEndFrame = false;
+        int                   round         = 0;
+        float                 roundingPower = 2.0f;
+        bool                  flipEndFrame  = false;
         SP<CSyncTimeline>     syncTimeline;
         int64_t               syncPoint = 0;
         std::optional<Mat3x3> replaceProjection;

--- a/src/render/shaders/Border.hpp
+++ b/src/render/shaders/Border.hpp
@@ -15,6 +15,7 @@ uniform vec2 fullSize;
 uniform vec2 fullSizeUntransformed;
 uniform float radius;
 uniform float radiusOuter;
+uniform float roundingPower;
 uniform float thick;
 
 // Gradients are in OkLabA!!!! {l, a, b, alpha}
@@ -138,9 +139,9 @@ void main() {
         const float SMOOTHING_CONSTANT = )#" +
     std::format("{:.7f}", SHADER_ROUNDED_SMOOTHING_FACTOR) + R"#(;
 
-	    float dist = length(pixCoord);
-	    float distOuter = length(pixCoordOuter);
-        float h = (thick / 2.0);
+	    float dist = pow(pow(pixCoord.x,roundingPower)+pow(pixCoord.y,roundingPower),1.0/roundingPower);
+	    float distOuter = pow(pow(pixCoordOuter.x,roundingPower)+pow(pixCoordOuter.y,roundingPower),1.0/roundingPower);
+      float h = (thick / 2.0);
 
 	    if (dist < radius - h) {
             // lower

--- a/src/render/shaders/Shadow.hpp
+++ b/src/render/shaders/Shadow.hpp
@@ -11,6 +11,7 @@ uniform vec2 topLeft;
 uniform vec2 bottomRight;
 uniform vec2 fullSize;
 uniform float radius;
+uniform float roundingPower;
 uniform float range;
 uniform float shadowPower;
 
@@ -24,6 +25,10 @@ float pixAlphaRoundedDistance(float distanceToCorner) {
     }
 
     return 1.0;
+}
+
+float modifiedLength(vec2 a) {
+    return pow(pow(abs(a.x),roundingPower)+pow(abs(a.y),roundingPower),1.0/roundingPower);
 }
 
 void main() {
@@ -40,21 +45,21 @@ void main() {
     if (pixCoord[0] < topLeft[0]) {
         if (pixCoord[1] < topLeft[1]) {
             // top left
-            pixColor[3] = pixColor[3] * pixAlphaRoundedDistance(distance(pixCoord, topLeft));
+            pixColor[3] = pixColor[3] * pixAlphaRoundedDistance(modifiedLength(pixCoord - topLeft));
             done = true;
         } else if (pixCoord[1] > bottomRight[1]) {
             // bottom left
-            pixColor[3] = pixColor[3] * pixAlphaRoundedDistance(distance(pixCoord, vec2(topLeft[0], bottomRight[1])));
+            pixColor[3] = pixColor[3] * pixAlphaRoundedDistance(modifiedLength(pixCoord - vec2(topLeft[0], bottomRight[1])));
             done = true;
         }
     } else if (pixCoord[0] > bottomRight[0]) {
         if (pixCoord[1] < topLeft[1]) {
             // top right
-            pixColor[3] = pixColor[3] * pixAlphaRoundedDistance(distance(pixCoord, vec2(bottomRight[0], topLeft[1])));
+            pixColor[3] = pixColor[3] * pixAlphaRoundedDistance(modifiedLength(pixCoord - vec2(bottomRight[0], topLeft[1])));
             done = true;
         } else if (pixCoord[1] > bottomRight[1]) {
             // bottom right
-            pixColor[3] = pixColor[3] * pixAlphaRoundedDistance(distance(pixCoord, bottomRight));
+            pixColor[3] = pixColor[3] * pixAlphaRoundedDistance(modifiedLength(pixCoord - bottomRight));
             done = true;
         }
     }

--- a/src/render/shaders/Textures.hpp
+++ b/src/render/shaders/Textures.hpp
@@ -19,23 +19,18 @@ inline static constexpr auto ROUNDED_SHADER_FUNC = [](const std::string colorVar
     const float SMOOTHING_CONSTANT = )#" +
         std::format("{:.7f}", SHADER_ROUNDED_SMOOTHING_FACTOR) + R"#(;
 
-    if (pixCoord.x + pixCoord.y > radius) {
+    //if (pixCoord.x + pixCoord.y > radius) {
 
-	    float dist = length(pixCoord);
+	      float dist = pow(pow(pixCoord.x, roundingPower) + pow(pixCoord.y, roundingPower), 1.0/roundingPower);
 
-	    if (dist > radius + SMOOTHING_CONSTANT * 2.0)
-	        discard;
+	      if (dist > radius + SMOOTHING_CONSTANT)
+	          discard;
 
-	    if (dist > radius - SMOOTHING_CONSTANT * 2.0) {
-	        float dist = length(pixCoord);
+        float normalized = 1.0 - smoothstep(0.0, 1.0, (dist - radius + SMOOTHING_CONSTANT) / (SMOOTHING_CONSTANT * 2.0));
 
-            float normalized = 1.0 - smoothstep(0.0, 1.0, (dist - radius + SMOOTHING_CONSTANT) / (SMOOTHING_CONSTANT * 2.0));
-
-	        )#" +
+	      )#" +
         colorVarName + R"#( = )#" + colorVarName + R"#( * normalized;
-        }
-
-    }
+    //}
 )#";
 };
 
@@ -63,6 +58,7 @@ varying vec4 v_color;
 uniform vec2 topLeft;
 uniform vec2 fullSize;
 uniform float radius;
+uniform float roundingPower;
 
 void main() {
 
@@ -107,6 +103,7 @@ uniform float alpha;
 uniform vec2 topLeft;
 uniform vec2 fullSize;
 uniform float radius;
+uniform float roundingPower;
 
 uniform int discardOpaque;
 uniform int discardAlpha;
@@ -167,6 +164,7 @@ uniform float alpha;
 uniform vec2 topLeft;
 uniform vec2 fullSize;
 uniform float radius;
+uniform float roundingPower;
 
 uniform int discardOpaque;
 uniform int discardAlpha;
@@ -440,6 +438,7 @@ uniform float alpha;
 uniform vec2 topLeft;
 uniform vec2 fullSize;
 uniform float radius;
+uniform float roundingPower;
 
 uniform int discardOpaque;
 uniform int discardAlpha;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

This PR adds support for using generalized supercircles for rounding the corners of windows.

Supercircles are curves defined by equations of the form $x^n + y^n = R^n$, which includes regular circles ($n=2$) and squircles ($n\approx4$). Many consider these to be a more aesthetically pleasing way to round the corners of rectangles, when compared to circles, since they don't introduce curvature discontinuities for $n\geq3$. (See the image below.)

It adds a single configuration parameter `decoration:rounding_power`, which is used as the value of $n$ and defaults to 2 to conserve existing behavior.

Here is a comparison showing the difference between a rounding power of 2 (left, current behavior) and a rounding power of 4 (right):
![hyprland-corners-comparison](https://github.com/user-attachments/assets/da78054f-9601-49f3-8d5a-2805a7cd16d1)


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This modification preserves existing behavior, although it may have a slight performance impact. I am open to benchmarking the code, but would need some tips on how to do so.

#### Is it ready for merging, or does it need work?

It should be ready for merging.