### PR TITLE
Fixed weird size issue of 1st foot slave when set floating

### DIFF
--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -12,7 +12,7 @@ void IHyprLayout::onWindowCreated(PHLWINDOW pWindow, eDirection direction) {
     CBox desiredGeometry = {};
     g_pXWaylandManager->getGeometryForWindow(pWindow, &desiredGeometry);
 
-    if (desiredGeometry.width <= 5 || desiredGeometry.height <= 5) {
+    if (desiredGeometry.width <= 14 || desiredGeometry.height <= 14) {
         const auto PMONITOR          = pWindow->m_pMonitor.lock();
         pWindow->m_vLastFloatingSize = PMONITOR->vecSize / 2.f;
     } else


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
First slave window of foot terminal always had desired width = 14
Hyprland allowed all desired sizes with width & height greater than 5 so foot window saved 14 as width in last saved floating size.
So, later when this window is set floating it would have a width of 14 which looks very weird.

This only happens with 1st slave window of foot terminal, [here is a video demo](https://youtu.be/9XPqwA03uAw)
I modified the code to allow all desired sizes with width & height more than 14.
Now, desired width 14 for first slave window of foot terminal becomes invalid and Hyprland resizes it appropriately. [which looks normal as shown in this video](https://youtu.be/mjvs033lJDo)

It relates to issue #8834 but i was only able to replicate the very tall and narrow window (when 1st slave is set floating) for foot terminal only

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
- This only happens with foot terminal and that too with 1st slave window which is very weird.
- Should this be treated as bug of foot terminal?
Although minimum allowed size should be not related to how to different applications behave, width/height 14 is still very small. So it should not be allowed. 

#### Is it ready for merging, or does it need work?
It requires review.