### PR TITLE
Bug fix for hyprctl --batch doesn't work with exec rules

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1150,34 +1150,28 @@ static std::string cursorPosRequest(eHyprCtlOutputFormat format, std::string req
 }
 
 static std::string dispatchBatch(eHyprCtlOutputFormat format, std::string request) {
-    // split by ;
+    // split by ; ignores ; inside [] and adds ; on last command
 
-    request             = request.substr(9);
-    std::string curitem = "";
-    std::string reply   = "";
-
-    auto        nextItem = [&]() {
-        auto idx = request.find_first_of(';');
-
-        if (idx != std::string::npos) {
-            curitem = request.substr(0, idx);
-            request = request.substr(idx + 1);
-        } else {
-            curitem = request;
-            request = "";
-        }
-
-        curitem = trim(curitem);
-    };
-
-    nextItem();
-
+    request                     = request.substr(9);
+    std::string       curitem   = "";
+    std::string       reply     = "";
     const std::string DELIMITER = "\n\n\n";
+    int               bracket   = 0;
 
-    while (curitem != "" || request != "") {
-        reply += g_pHyprCtl->getReply(curitem) + DELIMITER;
-
-        nextItem();
+    for (size_t i = 0; i <= request.size(); ++i) {
+        char ch = (i < request.size()) ? request[i] : ';';
+        if (ch == '[')
+            ++bracket;
+        else if (ch == ']')
+            --bracket;
+        else if (ch == ';' && bracket == 0) {
+            curitem = trim(curitem);
+            if (!curitem.empty())
+                reply += g_pHyprCtl->getReply(curitem).append(DELIMITER);
+            curitem.clear();
+            continue;
+        }
+        curitem += ch;
     }
 
     return reply.substr(0, std::max(static_cast<int>(reply.size() - DELIMITER.size()), 0));

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1153,10 +1153,10 @@ static std::string dispatchBatch(eHyprCtlOutputFormat format, std::string reques
     // split by ; ignores ; inside [] and adds ; on last command
 
     request                     = request.substr(9);
-    std::string       curitem   = "";
     std::string       reply     = "";
     const std::string DELIMITER = "\n\n\n";
     int               bracket   = 0;
+    size_t            idx       = 0;
 
     for (size_t i = 0; i <= request.size(); ++i) {
         char ch = (i < request.size()) ? request[i] : ';';
@@ -1165,13 +1165,11 @@ static std::string dispatchBatch(eHyprCtlOutputFormat format, std::string reques
         else if (ch == ']')
             --bracket;
         else if (ch == ';' && bracket == 0) {
-            curitem = trim(curitem);
-            if (!curitem.empty())
-                reply += g_pHyprCtl->getReply(curitem).append(DELIMITER);
-            curitem.clear();
+            if (idx < i)
+                reply += g_pHyprCtl->getReply(trim(request.substr(idx, i - idx))).append(DELIMITER);
+            idx = i + 1;
             continue;
         }
-        curitem += ch;
     }
 
     return reply.substr(0, std::max(static_cast<int>(reply.size() - DELIMITER.size()), 0));


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes #1820 by ignoring ';' inside brackets [ ]

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

For some reason the only app that was problematic when testing using commands like this -> 
`hyprctl --batch 'dispatch exec [noanim;float;workspace 7 silent] appname; dispatch exec [noanim;float;workspace 6 silent] appname; dispatch exec appname;'` 
was Wezterm, it would spawn on whatever workspace, other than that everything else worked without issues

#### Is it ready for merging, or does it need work?
Yeah, I was testing it with different apps and different combinations of commands and as mentioned above only Wezterm was problematic

