### PR TITLE
exec(-onec) with rules and execr(-once)

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1465,7 +1465,7 @@ void CConfigManager::dispatchExecOnce() {
     isLaunchingExecOnce = true;
 
     for (auto const& c : firstExecRequests) {
-		c.second ? handleExec("", c.first) : handleRawExec("", c.first);
+        c.second ? handleExec("", c.first) : handleRawExec("", c.first);
     }
 
     firstExecRequests.clear(); // free some kb of memory :P

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1465,7 +1465,7 @@ void CConfigManager::dispatchExecOnce() {
     isLaunchingExecOnce = true;
 
     for (auto const& c : firstExecRequests) {
-        c.second ? handleExec("", c.first) : handleRawExec("", c.first);
+        c.withRules ? handleExec("", c.exec) : handleRawExec("", c.exec);
     }
 
     firstExecRequests.clear(); // free some kb of memory :P

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -285,11 +285,11 @@ class CConfigManager {
     std::vector<SP<CLayerRule>>                      m_vLayerRules;
     std::vector<std::string>                         m_dBlurLSNamespaces;
 
-    bool                                                      firstExecDispatched     = false;
-    bool                                                      m_bManualCrashInitiated = false;
+    bool                                             firstExecDispatched     = false;
+    bool                                             m_bManualCrashInitiated = false;
 
-    std::vector<SFirstExecRequest>                            firstExecRequests; // bool is for if with rules
-    std::vector<std::string>                                  finalExecRequests;
+    std::vector<SFirstExecRequest>                   firstExecRequests; // bool is for if with rules
+    std::vector<std::string>                         finalExecRequests;
 
     std::vector<std::pair<std::string, std::string>> m_vFailedPluginConfigValues; // for plugin values of unloaded plugins
     std::string                                      m_szConfigErrors = "";

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -132,9 +132,9 @@ struct SConfigOptionDescription {
     std::variant<SBoolData, SRangeData, SFloatData, SStringData, SColorData, SChoiceData, SGradientData, SVectorData> data;
 };
 
-struct SfirstExecRequest {
-    std::string exec;
-    bool        withRules;
+struct SFirstExecRequest {
+    std::string exec = "";
+    bool        withRules = false;
 };
 
 class CConfigManager {
@@ -288,7 +288,7 @@ class CConfigManager {
     bool                                                      firstExecDispatched     = false;
     bool                                                      m_bManualCrashInitiated = false;
 
-    std::vector<SfirstExecRequest>                            firstExecRequests; // bool is for if with rules
+    std::vector<SFirstExecRequest>                            firstExecRequests; // bool is for if with rules
     std::vector<std::string>                                  finalExecRequests;
 
     std::vector<std::pair<std::string, std::string>> m_vFailedPluginConfigValues; // for plugin values of unloaded plugins

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -196,7 +196,9 @@ class CConfigManager {
 
     // keywords
     std::optional<std::string>                                                                     handleRawExec(const std::string&, const std::string&);
+    std::optional<std::string>                                                                     handleExec(const std::string&, const std::string&);
     std::optional<std::string>                                                                     handleExecOnce(const std::string&, const std::string&);
+    std::optional<std::string>                                                                     handleExecRawOnce(const std::string&, const std::string&);
     std::optional<std::string>                                                                     handleExecShutdown(const std::string&, const std::string&);
     std::optional<std::string>                                                                     handleMonitor(const std::string&, const std::string&);
     std::optional<std::string>                                                                     handleBind(const std::string&, const std::string&);
@@ -280,7 +282,7 @@ class CConfigManager {
 
     bool                                             firstExecDispatched     = false;
     bool                                             m_bManualCrashInitiated = false;
-    std::vector<std::string>                         firstExecRequests;
+    std::vector<std::pair<std::string, bool>>        firstExecRequests; // bool is for if with rules
     std::vector<std::string>                         finalExecRequests;
 
     std::vector<std::pair<std::string, std::string>> m_vFailedPluginConfigValues; // for plugin values of unloaded plugins

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -280,10 +280,10 @@ class CConfigManager {
     std::vector<SP<CLayerRule>>                      m_vLayerRules;
     std::vector<std::string>                         m_dBlurLSNamespaces;
 
-    bool                                             firstExecDispatched     = false;
-    bool                                             m_bManualCrashInitiated = false;
-    std::vector<std::pair<std::string, bool>>        firstExecRequests; // bool is for if with rules
-    std::vector<std::string>                         finalExecRequests;
+    bool                                                      firstExecDispatched     = false;
+    bool                                                      m_bManualCrashInitiated = false;
+    std::vector<std::pair<std::string, bool>>                 firstExecRequests; // bool is for if with rules
+    std::vector<std::string>                                  finalExecRequests;
 
     std::vector<std::pair<std::string, std::string>> m_vFailedPluginConfigValues; // for plugin values of unloaded plugins
     std::string                                      m_szConfigErrors = "";

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -132,6 +132,11 @@ struct SConfigOptionDescription {
     std::variant<SBoolData, SRangeData, SFloatData, SStringData, SColorData, SChoiceData, SGradientData, SVectorData> data;
 };
 
+struct SfirstExecRequest {
+	std::string exec;
+	bool withRules;
+};
+
 class CConfigManager {
   public:
     CConfigManager();
@@ -282,7 +287,8 @@ class CConfigManager {
 
     bool                                                      firstExecDispatched     = false;
     bool                                                      m_bManualCrashInitiated = false;
-    std::vector<std::pair<std::string, bool>>                 firstExecRequests; // bool is for if with rules
+
+    std::vector<SfirstExecRequest>                			  firstExecRequests; // bool is for if with rules
     std::vector<std::string>                                  finalExecRequests;
 
     std::vector<std::pair<std::string, std::string>> m_vFailedPluginConfigValues; // for plugin values of unloaded plugins

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -133,8 +133,8 @@ struct SConfigOptionDescription {
 };
 
 struct SfirstExecRequest {
-	std::string exec;
-	bool withRules;
+    std::string exec;
+    bool        withRules;
 };
 
 class CConfigManager {
@@ -288,7 +288,7 @@ class CConfigManager {
     bool                                                      firstExecDispatched     = false;
     bool                                                      m_bManualCrashInitiated = false;
 
-    std::vector<SfirstExecRequest>                			  firstExecRequests; // bool is for if with rules
+    std::vector<SfirstExecRequest>                            firstExecRequests; // bool is for if with rules
     std::vector<std::string>                                  finalExecRequests;
 
     std::vector<std::pair<std::string, std::string>> m_vFailedPluginConfigValues; // for plugin values of unloaded plugins

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -133,7 +133,7 @@ struct SConfigOptionDescription {
 };
 
 struct SFirstExecRequest {
-    std::string exec = "";
+    std::string exec      = "";
     bool        withRules = false;
 };
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
currently both exec-once and exec does not support window rule like their dispatchers, i've added that feature and also added execr and execr-once


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
for the change in firstExecRequests, not sure if i shall also do that to finalExecRequests, i think it's better to keep it as it is, since exec-shutdown is executed when shutting down thus it's not necessary for window rule?


#### Is it ready for merging, or does it need work?
ready


