### PR TITLE
ci(clang-format): directly do the clang-format instead of error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,14 +125,24 @@ jobs:
         run: meson setup build -Ddefault_library=static
 
       - name: clang-format check
+        run: ninja -C build clang-format-check
+
+      - name: clang-format apply
+        if: failure()
         run: ninja -C build clang-format
 
-      - name: Push changes
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "style: clang-format"
-          commit_user_name: "github-actions[bot]"
-          commit_user_email: "github-actions[bot]@users.noreply.github.com"
-          commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
-          # commit_branch: ${{ github.head_ref }}
+      - name: Create patch
+        if: failure()
+        run: git diff > clang-format.patch
 
+      - name: Comment patch
+        if: failure()
+        uses: mshick/add-pr-comment@v2
+        with:
+          message-path: |
+            clang-format.patch
+          find: |
+            please fix the following formatting issues, or directly apply the patch
+            ```diff
+            << FILE_CONTENTS >>
+            ```

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,10 +139,12 @@ jobs:
         if: failure()
         uses: mshick/add-pr-comment@v2
         with:
-          message-path: |
-            clang-format.patch
-          find: |
+          message:
             please fix the following formatting issues, or directly apply the patch
             ```diff
             << FILE_CONTENTS >>
             ```
+          message-path: |
+            clang-format.patch
+          find: |
+            << FILE_CONTENTS >>

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,7 +138,9 @@ jobs:
           echo '<details>' >> clang-format.patch
           echo '<summary>clang-format.patch</summary>' >> clang-format.patch
           echo '```diff' >> clang-format.patch
+          echo >> clang-format.patch
           git diff >> clang-format.patch
+          echo >> clang-format.patch
           echo '```' >> clang-format.patch
           echo '</details>' >> clang-format.patch
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,12 +135,12 @@ jobs:
         if: failure()
         run: |
           echo 'Please fix the formatting issues by running [`clang-format`](https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/#code-style), or directly apply this patch:' > clang-format.patch
-          echo '```<details>' >> clang-format.patch
-          echo '```<summary>clang-format.patch</summary>' >> clang-format.patch
+          echo '<details>' >> clang-format.patch
+          echo '<summary>clang-format.patch</summary>' >> clang-format.patch
           echo '```diff' >> clang-format.patch
           git diff >> clang-format.patch
           echo '```' >> clang-format.patch
-          echo '```</details>' >> clang-format.patch
+          echo '</details>' >> clang-format.patch
 
       - name: Comment patch
         if: failure()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,11 +134,6 @@ jobs:
       - name: Create patch
         if: failure()
         run: |
-          message:
-            please fix the following formatting issues, or directly apply the patch
-            ```diff
-            << FILE_CONTENTS >>
-            ```
           echo "fix the following formatting issues, or directly apply the patch" > clang-format.patch
           echo '```diff' >> clang-format.patch
           git diff >> clang-format.patch

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,4 +125,14 @@ jobs:
         run: meson setup build -Ddefault_library=static
 
       - name: clang-format check
-        run: ninja -C build clang-format-check
+        run: ninja -C build clang-format
+
+      - name: Push changes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "style: clang-format"
+          commit_user_name: "github-actions[bot]"
+          commit_user_email: "github-actions[bot]@users.noreply.github.com"
+          commit_author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          # commit_branch: ${{ github.head_ref }}
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,11 +128,11 @@ jobs:
         run: ninja -C build clang-format-check
 
       - name: clang-format apply
-        if: failure()
+        if: ${{ failure() && github.event_name == 'pull_request' }}
         run: ninja -C build clang-format
 
       - name: Create patch
-        if: failure()
+        if: ${{ failure() && github.event_name == 'pull_request' }}
         run: |
           echo 'Please fix the formatting issues by running [`clang-format`](https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/#code-style), or directly apply this patch:' > clang-format.patch
           echo '<details>' >> clang-format.patch
@@ -145,7 +145,7 @@ jobs:
           echo '</details>' >> clang-format.patch
 
       - name: Comment patch
-        if: failure()
+        if: ${{ failure() && github.event_name == 'pull_request' }}
         uses: mshick/add-pr-comment@v2
         with:
           message-path: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,11 +137,11 @@ jobs:
           echo 'Please fix the formatting issues by running [`clang-format`](https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/#code-style), or directly apply this patch:' > clang-format.patch
           echo '<details>' >> clang-format.patch
           echo '<summary>clang-format.patch</summary>' >> clang-format.patch
+          echo >> clang-format.patch
           echo '```diff' >> clang-format.patch
-          echo >> clang-format.patch
           git diff >> clang-format.patch
-          echo >> clang-format.patch
           echo '```' >> clang-format.patch
+          echo >> clang-format.patch
           echo '</details>' >> clang-format.patch
 
       - name: Comment patch

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,10 +134,13 @@ jobs:
       - name: Create patch
         if: failure()
         run: |
-          echo "fix the following formatting issues, or directly apply the patch" > clang-format.patch
+          echo 'Please fix the formatting issues by running [`clang-format`](https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/#code-style), or directly apply this patch:' > clang-format.patch
+          echo '```<details>' >> clang-format.patch
+          echo '```<summary>clang-format.patch</summary>' >> clang-format.patch
           echo '```diff' >> clang-format.patch
           git diff >> clang-format.patch
           echo '```' >> clang-format.patch
+          echo '```</details>' >> clang-format.patch
 
       - name: Comment patch
         if: failure()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,18 +133,20 @@ jobs:
 
       - name: Create patch
         if: failure()
-        run: git diff > clang-format.patch
-
-      - name: Comment patch
-        if: failure()
-        uses: mshick/add-pr-comment@v2
-        with:
+        run: |
           message:
             please fix the following formatting issues, or directly apply the patch
             ```diff
             << FILE_CONTENTS >>
             ```
+          echo "fix the following formatting issues, or directly apply the patch" > clang-format.patch
+          echo '```diff' >> clang-format.patch
+          git diff >> clang-format.patch
+          echo '```' >> clang-format.patch
+
+      - name: Comment patch
+        if: failure()
+        uses: mshick/add-pr-comment@v2
+        with:
           message-path: |
             clang-format.patch
-          find: |
-            << FILE_CONTENTS >>


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
as title suggestes, atm clang-format will just give error and we have to manually fix it, this PR makes it so it automatically does it for us


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
if you dont mind the github actions bot spamming commits and growing in the contribution graph ig


#### Is it ready for merging, or does it need work?
tested in another repo

