### PR TITLE
Implement version 2 of ext-idle-notify-v1 protocol 

### DIFF
--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -1,6 +1,6 @@
 wayland_protos = dependency(
 	'wayland-protocols',
-	version: '>=1.32',
+	version: '>=1.40',
 	fallback: 'wayland-protocols',
 	default_options: ['tests=false'],
 )

--- a/src/managers/ProtocolManager.cpp
+++ b/src/managers/ProtocolManager.cpp
@@ -147,7 +147,7 @@ CProtocolManager::CProtocolManager() {
     PROTO::constraints         = makeUnique<CPointerConstraintsProtocol>(&zwp_pointer_constraints_v1_interface, 1, "PointerConstraints");
     PROTO::outputPower         = makeUnique<COutputPowerProtocol>(&zwlr_output_power_manager_v1_interface, 1, "OutputPower");
     PROTO::activation          = makeUnique<CXDGActivationProtocol>(&xdg_activation_v1_interface, 1, "XDGActivation");
-    PROTO::idle                = makeUnique<CIdleNotifyProtocol>(&ext_idle_notifier_v1_interface, 1, "IdleNotify");
+    PROTO::idle                = makeUnique<CIdleNotifyProtocol>(&ext_idle_notifier_v1_interface, 2, "IdleNotify");
     PROTO::lockNotify          = makeUnique<CLockNotifyProtocol>(&hyprland_lock_notifier_v1_interface, 1, "IdleNotify");
     PROTO::sessionLock         = makeUnique<CSessionLockProtocol>(&ext_session_lock_manager_v1_interface, 1, "SessionLock");
     PROTO::ime                 = makeUnique<CInputMethodV2Protocol>(&zwp_input_method_manager_v2_interface, 1, "IMEv2");

--- a/src/protocols/IdleNotify.cpp
+++ b/src/protocols/IdleNotify.cpp
@@ -10,7 +10,8 @@ static int onTimer(SP<CEventLoopTimer> self, void* data) {
     return 0;
 }
 
-CExtIdleNotification::CExtIdleNotification(SP<CExtIdleNotificationV1> resource_, uint32_t timeoutMs_) : resource(resource_), timeoutMs(timeoutMs_) {
+CExtIdleNotification::CExtIdleNotification(SP<CExtIdleNotificationV1> resource_, uint32_t timeoutMs_, bool obeyInhibitors_) :
+    resource(resource_), timeoutMs(timeoutMs_), obeyInhibitors(obeyInhibitors_) {
     if UNLIKELY (!resource_->resource())
         return;
 
@@ -35,7 +36,7 @@ bool CExtIdleNotification::good() {
 }
 
 void CExtIdleNotification::updateTimer() {
-    if (PROTO::idle->isInhibited)
+    if (PROTO::idle->isInhibited && obeyInhibitors)
         timer->updateTimeout(std::nullopt);
     else
         timer->updateTimeout(std::chrono::milliseconds(timeoutMs));
@@ -54,6 +55,10 @@ void CExtIdleNotification::onActivity() {
     updateTimer();
 }
 
+bool CExtIdleNotification::inhibitorsAreObeyed() const {
+    return obeyInhibitors;
+}
+
 CIdleNotifyProtocol::CIdleNotifyProtocol(const wl_interface* iface, const int& ver, const std::string& name) : IWaylandProtocol(iface, ver, name) {
     ;
 }
@@ -63,7 +68,10 @@ void CIdleNotifyProtocol::bindManager(wl_client* client, void* data, uint32_t ve
     RESOURCE->setOnDestroy([this](CExtIdleNotifierV1* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CExtIdleNotifierV1* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });
-    RESOURCE->setGetIdleNotification([this](CExtIdleNotifierV1* pMgr, uint32_t id, uint32_t timeout, wl_resource* seat) { this->onGetNotification(pMgr, id, timeout, seat); });
+    RESOURCE->setGetIdleNotification(
+        [this](CExtIdleNotifierV1* pMgr, uint32_t id, uint32_t timeout, wl_resource* seat) { this->onGetNotification(pMgr, id, timeout, seat, true); });
+    RESOURCE->setGetInputIdleNotification(
+        [this](CExtIdleNotifierV1* pMgr, uint32_t id, uint32_t timeout, wl_resource* seat) { this->onGetNotification(pMgr, id, timeout, seat, false); });
 }
 
 void CIdleNotifyProtocol::onManagerResourceDestroy(wl_resource* res) {
@@ -74,9 +82,10 @@ void CIdleNotifyProtocol::destroyNotification(CExtIdleNotification* notif) {
     std::erase_if(m_vNotifications, [&](const auto& other) { return other.get() == notif; });
 }
 
-void CIdleNotifyProtocol::onGetNotification(CExtIdleNotifierV1* pMgr, uint32_t id, uint32_t timeout, wl_resource* seat) {
-    const auto CLIENT   = pMgr->client();
-    const auto RESOURCE = m_vNotifications.emplace_back(makeShared<CExtIdleNotification>(makeShared<CExtIdleNotificationV1>(CLIENT, pMgr->version(), id), timeout)).get();
+void CIdleNotifyProtocol::onGetNotification(CExtIdleNotifierV1* pMgr, uint32_t id, uint32_t timeout, wl_resource* seat, bool obeyInhibitors) {
+    const auto CLIENT = pMgr->client();
+    const auto RESOURCE =
+        m_vNotifications.emplace_back(makeShared<CExtIdleNotification>(makeShared<CExtIdleNotificationV1>(CLIENT, pMgr->version(), id), timeout, obeyInhibitors)).get();
 
     if UNLIKELY (!RESOURCE->good()) {
         pMgr->noMemory();
@@ -94,6 +103,7 @@ void CIdleNotifyProtocol::onActivity() {
 void CIdleNotifyProtocol::setInhibit(bool inhibited) {
     isInhibited = inhibited;
     for (auto const& n : m_vNotifications) {
-        n->onActivity();
+        if (n->inhibitorsAreObeyed())
+            n->onActivity();
     }
 }

--- a/src/protocols/IdleNotify.hpp
+++ b/src/protocols/IdleNotify.hpp
@@ -9,19 +9,22 @@ class CEventLoopTimer;
 
 class CExtIdleNotification {
   public:
-    CExtIdleNotification(SP<CExtIdleNotificationV1> resource_, uint32_t timeoutMs);
+    CExtIdleNotification(SP<CExtIdleNotificationV1> resource_, uint32_t timeoutMs, bool obeyInhibitors);
     ~CExtIdleNotification();
 
     bool good();
     void onTimerFired();
     void onActivity();
 
+    bool inhibitorsAreObeyed() const;
+
   private:
     SP<CExtIdleNotificationV1> resource;
     uint32_t                   timeoutMs = 0;
     SP<CEventLoopTimer>        timer;
 
-    bool                       idled = false;
+    bool                       idled          = false;
+    bool                       obeyInhibitors = false;
 
     void                       updateTimer();
 };
@@ -38,7 +41,7 @@ class CIdleNotifyProtocol : public IWaylandProtocol {
   private:
     void onManagerResourceDestroy(wl_resource* res);
     void destroyNotification(CExtIdleNotification* notif);
-    void onGetNotification(CExtIdleNotifierV1* pMgr, uint32_t id, uint32_t timeout, wl_resource* seat);
+    void onGetNotification(CExtIdleNotifierV1* pMgr, uint32_t id, uint32_t timeout, wl_resource* seat, bool obeyInhibitors);
 
     bool isInhibited = false;
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

This is basically a counterpart to a [similar draft merge request that I did for wlroots](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4937), one that is meant to implement a revision to the ext-idle-notify protocol described in this merge request to wayland-protocols here: [wayland/wayland-protocols!367](https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/367)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I did test this to make sure that it would work at least with [my fork of Workrave](https://github.com/rcaelers/workrave/pull/590).

#### Is it ready for merging, or does it need work?

~~This is a draft simply because the merge request for the wayland-protocols is still pending. Once it stops being pending, the commit "Temporarily allow build with w/o JJR fork of wayland-protocols" should be reverted. There is also the possibility that there will be further changes to the wayland-protocols merge request before it gets approved -- presuming of course that it gets approved at all.~~

This should work with the wayland-protocols from commit 20bcf732a9a173ae7d437882159fb7ababb4713e or later.