### PR TITLE
Fix a bunch of issues with dropCurrentBuffer

### DIFF
--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -428,6 +428,7 @@ void CWLSurfaceResource::commitPendingState() {
     pending.damage.clear();
     pending.bufferDamage.clear();
     pending.newBuffer = false;
+    dropPendingBuffer(); // at this point current.buffer holds the same SP and we don't use pending anymore
 
     events.roleCommit.emit();
 
@@ -448,10 +449,9 @@ void CWLSurfaceResource::commitPendingState() {
 
         // release the buffer if it's synchronous as update() has done everything thats needed
         // so we can let the app know we're done.
-        if (current.buffer->buffer->isSynchronous()) {
-            dropCurrentBuffer();
-            dropPendingBuffer(); // pending atm is just a copied ref of the current, drop it too to send a release
-        }
+        // Some clients aren't ready to receive a release this early. Should be fine to release it on the next commitPendingState.
+        // if (current.buffer->buffer->isSynchronous())
+        //     dropCurrentBuffer();
     }
 
     // TODO: we should _accumulate_ and not replace above if sync


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Moved `dropPendingBuffer` closer to a point where we stop using it.
Commented out `dropCurrentBuffer` for sync buffers since it causes more trouble than solves.
Looks like it it either wrong to drop the buffer so early or there is a bug somewhere else. Gamescope complains about incorrect buffer releases from time to time (definitely not on every release) https://github.com/ValveSoftware/gamescope/blob/f873ec7868fe84d2850e91148bcbd6d6b19a7443/src/Backends/WaylandBackend.cpp#L786 For some reason it fails to detect that the buffer was acquired by the compositor. I guess that some other clients have similar issues but they are not smart enough to handle the release correctly and destroy the buffer upon receiving a release while they still need it for something internally.
This fixes 
https://github.com/hyprwm/Hyprland/issues/6844
https://github.com/hyprwm/Hyprland/issues/6912
https://github.com/hyprwm/Hyprland/pull/8399#issuecomment-2468427288 and bunch of other corrupted/invisible cursors with `cursor:use_cpu_buffer`

https://github.com/hyprwm/hyprpicker/issues/85 seems to work fine. Couldn't reproduce https://github.com/hyprwm/Hyprland/issues/7091 but if it'll come back with this PR I'd rather have some minor green artifacts while having a stroke trying to resize kitty than issues mentioned above.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Tested it for a long time since https://github.com/hyprwm/Hyprland/issues/6844#issuecomment-2473766368 without an issue. Still might need more testing, haven't checked everything related to https://github.com/hyprwm/Hyprland/pull/7110. Might behave differently with explicit sync disabled.
Maybe `isSynchronous` isn't always correct? Or some clients have a different idea about buffer sync? Or some events should be sent before the release?

#### Is it ready for merging, or does it need work?
Ready.

