### PR TITLE
renderer: don't access hdrMetadata optional if it has no value

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1466,8 +1466,9 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
 
     static auto PHDR = CConfigValue<Hyprlang::INT>("experimental:hdr");
 
-    Debug::log(TRACE, "ColorManagement supportsBT2020 {}, supportsPQ {}", pMonitor->output->parsedEDID.supportsBT2020, pMonitor->output->parsedEDID.hdrMetadata->supportsPQ);
-    if (pMonitor->output->parsedEDID.supportsBT2020 && pMonitor->output->parsedEDID.hdrMetadata->supportsPQ) {
+    const bool  SUPPORTSPQ = pMonitor->output->parsedEDID.hdrMetadata.has_value() ? pMonitor->output->parsedEDID.hdrMetadata->supportsPQ : false;
+    Debug::log(TRACE, "ColorManagement supportsBT2020 {}, supportsPQ {}", pMonitor->output->parsedEDID.supportsBT2020, SUPPORTSPQ);
+    if (pMonitor->output->parsedEDID.supportsBT2020 && SUPPORTSPQ) {
         if (pMonitor->activeWorkspace && pMonitor->activeWorkspace->m_bHasFullscreenWindow && pMonitor->activeWorkspace->m_efFullscreenMode == FSMODE_FULLSCREEN) {
             const auto WINDOW = pMonitor->activeWorkspace->getFullscreenWindow();
             const auto SURF   = WINDOW->m_pWLSurface->resource();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes #8984

Cause was invalid optional access on `pMonitor->output->parsedEDID.hdrMetadata`

```
#0  0x00007f59ae6988ec in __pthread_kill_implementation () from /nix/store/65h17wjrrlsj2rj540igylrx7fqcd6vq-glibc-2.40-36/lib/libc.so.6
#1  0x00007f59ae6409c6 in raise () from /nix/store/65h17wjrrlsj2rj540igylrx7fqcd6vq-glibc-2.40-36/lib/libc.so.6
#2  0x00007f59ae628938 in abort () from /nix/store/65h17wjrrlsj2rj540igylrx7fqcd6vq-glibc-2.40-36/lib/libc.so.6
#3  0x000000000079b0f4 in exitWithError (err=err@entry=0x6ae9f8 "failed to mkdir() crash report directory\n") at ../src/debug/CrashReporter.cpp:42
#4  0x000000000079a6f5 in NCrashReporter::createAndSaveCrash (sig=sig@entry=6) at ../src/debug/CrashReporter.cpp:71
#5  0x0000000000724a34 in handleUnrecoverableSignal (sig=6) at ../src/Compositor.cpp:82
#6  <signal handler called>
#7  0x00007f59ae6988ec in __pthread_kill_implementation () from /nix/store/65h17wjrrlsj2rj540igylrx7fqcd6vq-glibc-2.40-36/lib/libc.so.6
#8  0x00007f59ae6409c6 in raise () from /nix/store/65h17wjrrlsj2rj540igylrx7fqcd6vq-glibc-2.40-36/lib/libc.so.6
#9  0x00007f59ae628938 in abort () from /nix/store/65h17wjrrlsj2rj540igylrx7fqcd6vq-glibc-2.40-36/lib/libc.so.6
#10 0x00007f59aeae119e in std::__glibcxx_assert_fail(char const*, int, char const*, char const*) () from /nix/store/4hcn6bhvnv990h58pgi51hbzglv2hqn0-gcc-14-20241116-lib/lib/libstdc++.so.6
#11 0x0000000000a4c25b in std::_Optional_base_impl<Aquamarine::IOutput::SHDRMetadata, std::_Optional_base<Aquamarine::IOutput::SHDRMetadata, true, true> >::_M_get (this=<optimized out>)
    at /nix/store/bcdjblwcvxy7590q067wsvdvawkxnwl1-gcc-14-20241116/include/c++/14-20241116/optional:475
#12 0x0000000000a3f52f in std::optional<Aquamarine::IOutput::SHDRMetadata>::operator-> (this=<optimized out>) at /nix/store/bcdjblwcvxy7590q067wsvdvawkxnwl1-gcc-14-20241116/include/c++/14-20241116/optional:963
#13 CHyprRenderer::commitPendingAndDoExplicitSync (this=this@entry=0x16331510, pMonitor=...) at ../src/render/Renderer.cpp:1469
#14 0x0000000000a484f0 in CHyprRenderer::renderMonitor (this=this@entry=0x16331510, pMonitor=...) at ../src/render/Renderer.cpp:1356
#15 0x000000000081df0d in CMonitor::onMonitorFrame (this=0x164fb2f0) at ../src/helpers/Monitor.cpp:1397
#16 0x0000000000737c69 in CCompositor::onNewMonitor (this=this@entry=0x14c73e50, output=...) at ../src/Compositor.cpp:2988
#17 0x000000000073cb12 in CCompositor::initServer (this=this@entry=0x14c73e50, socketName=..., socketFd=socketFd@entry=-1) at ../src/Compositor.cpp:351
#18 0x0000000000852c35 in main (argc=<optimized out>, argv=<optimized out>) at ../src/main.cpp:165

```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Yes


