### PR TITLE
fix: previous_per_monitor logic

### DIFF
--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -52,10 +52,7 @@ void CWorkspace::init(PHLWORKSPACE self) {
     EMIT_HOOK_EVENT("createWorkspace", this);
 }
 
-SWorkspaceIDName CWorkspace::getPrevWorkspaceIDName(bool perMonitor) const {
-    if (perMonitor)
-        return m_sPrevWorkspacePerMonitor;
-
+SWorkspaceIDName CWorkspace::getPrevWorkspaceIDName() const {
     return m_sPrevWorkspace;
 }
 
@@ -216,10 +213,7 @@ void CWorkspace::rememberPrevWorkspace(const PHLWORKSPACE& prev) {
     m_sPrevWorkspace.id   = prev->m_iID;
     m_sPrevWorkspace.name = prev->m_szName;
 
-    if (prev->m_pMonitor == m_pMonitor) {
-        m_sPrevWorkspacePerMonitor.id   = prev->m_iID;
-        m_sPrevWorkspacePerMonitor.name = prev->m_szName;
-    }
+    prev->m_pMonitor->addPrevWorkspaceID(prev->m_iID);
 }
 
 std::string CWorkspace::getConfigName() {

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -24,17 +24,14 @@ class CWorkspace {
 
     // Workspaces ID-based have IDs > 0
     // and workspaces name-based have IDs starting with -1337
-    WORKSPACEID   m_iID    = WORKSPACE_INVALID;
-    std::string   m_szName = "";
-    PHLMONITORREF m_pMonitor;
-    // Previous workspace ID and name is stored during a workspace change, allowing travel
-    // to the previous workspace.
-    SWorkspaceIDName m_sPrevWorkspace, m_sPrevWorkspacePerMonitor;
+    WORKSPACEID     m_iID    = WORKSPACE_INVALID;
+    std::string     m_szName = "";
+    PHLMONITORREF   m_pMonitor;
 
-    bool             m_bHasFullscreenWindow = false;
-    eFullscreenMode  m_efFullscreenMode     = FSMODE_NONE;
+    bool            m_bHasFullscreenWindow = false;
+    eFullscreenMode m_efFullscreenMode     = FSMODE_NONE;
 
-    wl_array         m_wlrCoordinateArr;
+    wl_array        m_wlrCoordinateArr;
 
     // for animations
     PHLANIMVAR<Vector2D> m_vRenderOffset;
@@ -72,7 +69,7 @@ class CWorkspace {
     std::string      getConfigName();
     bool             matchesStaticSelector(const std::string& selector);
     void             markInert();
-    SWorkspaceIDName getPrevWorkspaceIDName(bool perMonitor) const;
+    SWorkspaceIDName getPrevWorkspaceIDName() const;
     void             updateWindowDecos();
     void             updateWindowData();
     int              getWindows(std::optional<bool> onlyTiled = {}, std::optional<bool> onlyVisible = {});
@@ -88,7 +85,10 @@ class CWorkspace {
     void             updateWindows();
 
   private:
-    void                 init(PHLWORKSPACE self);
+    void init(PHLWORKSPACE self);
+    // Previous workspace ID and name is stored during a workspace change, allowing travel
+    // to the previous workspace.
+    SWorkspaceIDName     m_sPrevWorkspace;
 
     SP<HOOK_CALLBACK_FN> m_pFocusedWindowHook;
     bool                 m_bInert = true;

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -258,7 +258,7 @@ SWorkspaceIDName getWorkspaceIDNameFromString(const std::string& in) {
         if (!valid(PWORKSPACE))
             return {WORKSPACE_INVALID};
 
-        const auto PLASTWORKSPACE = g_pCompositor->getWorkspaceByID(PWORKSPACE->m_sPrevWorkspace.id);
+        const auto PLASTWORKSPACE = g_pCompositor->getWorkspaceByID(PWORKSPACE->getPrevWorkspaceIDName().id);
 
         if (!PLASTWORKSPACE)
             return {WORKSPACE_INVALID};

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1,5 +1,6 @@
 #include "Monitor.hpp"
 #include "MiscFunctions.hpp"
+#include "macros.hpp"
 #include "math/Math.hpp"
 #include "sync/SyncReleaser.hpp"
 #include "../Compositor.hpp"
@@ -1167,6 +1168,29 @@ void CMonitor::setSpecialWorkspace(const WORKSPACEID& id) {
 
 void CMonitor::moveTo(const Vector2D& pos) {
     vecPosition = pos;
+}
+
+SWorkspaceIDName CMonitor::getPrevWorkspaceIDName(const WORKSPACEID id) {
+    while (!prevWorkSpaces.empty()) {
+        const int PREVID = prevWorkSpaces.top();
+        prevWorkSpaces.pop();
+        if (PREVID == id) // skip same workspace
+            continue;
+
+        // recheck if previous workspace's was moved to another monitor
+        const auto ws = g_pCompositor->getWorkspaceByID(PREVID);
+        if (ws && ws->monitorID() == ID)
+            return {.id = PREVID, .name = ws->m_szName};
+    }
+
+    return {.id = WORKSPACE_INVALID};
+}
+
+void CMonitor::addPrevWorkspaceID(const WORKSPACEID id) {
+    if (!prevWorkSpaces.empty() && prevWorkSpaces.top() == id)
+        return;
+
+    prevWorkSpaces.emplace(id);
 }
 
 Vector2D CMonitor::middle() {

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "../defines.hpp"
+#include <stack>
 #include <vector>
+#include "SharedDefs.hpp"
 #include "WLClasses.hpp"
 #include <vector>
 #include <array>
@@ -196,11 +198,16 @@ class CMonitor {
         return vecPosition == rhs.vecPosition && vecSize == rhs.vecSize && szName == rhs.szName;
     }
 
-  private:
-    void        setupDefaultWS(const SMonitorRule&);
-    WORKSPACEID findAvailableDefaultWS();
+    // workspace previous per monitor functionality
+    SWorkspaceIDName getPrevWorkspaceIDName(const WORKSPACEID id);
+    void             addPrevWorkspaceID(const WORKSPACEID id);
 
-    bool        doneScheduled = false;
+  private:
+    void                    setupDefaultWS(const SMonitorRule&);
+    WORKSPACEID             findAvailableDefaultWS();
+
+    bool                    doneScheduled = false;
+    std::stack<WORKSPACEID> prevWorkSpaces;
 
     struct {
         CHyprSignalListener frame;

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1169,27 +1169,24 @@ SDispatchResult CKeybindManager::toggleActivePseudo(std::string args) {
     return {};
 }
 
-static SWorkspaceIDName getWorkspaceToChangeFromArgs(std::string args, PHLWORKSPACE PCURRENTWORKSPACE) {
+static SWorkspaceIDName getWorkspaceToChangeFromArgs(std::string args, PHLWORKSPACE PCURRENTWORKSPACE, PHLMONITORREF PMONITOR) {
     if (!args.starts_with("previous")) {
         return getWorkspaceIDNameFromString(args);
     }
 
     const bool             PER_MON = args.contains("_per_monitor");
-    const SWorkspaceIDName PPREVWS = PCURRENTWORKSPACE->getPrevWorkspaceIDName(PER_MON);
+    const SWorkspaceIDName PPREVWS = PER_MON ? PMONITOR->getPrevWorkspaceIDName(PCURRENTWORKSPACE->m_iID) : PCURRENTWORKSPACE->getPrevWorkspaceIDName();
     // Do nothing if there's no previous workspace, otherwise switch to it.
-    if (PPREVWS.id == -1) {
+    if (PPREVWS.id == -1 || PPREVWS.id == PCURRENTWORKSPACE->m_iID) {
         Debug::log(LOG, "No previous workspace to change to");
-        return {WORKSPACE_NOT_CHANGED, ""};
+        return {.id = WORKSPACE_NOT_CHANGED};
     }
 
-    const auto ID = PCURRENTWORKSPACE->m_iID;
     if (const auto PWORKSPACETOCHANGETO = g_pCompositor->getWorkspaceByID(PPREVWS.id); PWORKSPACETOCHANGETO) {
-        if (PER_MON && PCURRENTWORKSPACE->m_pMonitor != PWORKSPACETOCHANGETO->m_pMonitor)
-            return {WORKSPACE_NOT_CHANGED, ""};
-        return {ID, PWORKSPACETOCHANGETO->m_szName};
+        return {.id = PWORKSPACETOCHANGETO->m_iID, .name = PWORKSPACETOCHANGETO->m_szName};
     }
 
-    return {ID, PPREVWS.name.empty() ? std::to_string(PPREVWS.id) : PPREVWS.name};
+    return {.id = PPREVWS.id, .name = PPREVWS.name.empty() ? std::to_string(PPREVWS.id) : PPREVWS.name};
 }
 
 SDispatchResult CKeybindManager::changeworkspace(std::string args) {
@@ -1207,7 +1204,7 @@ SDispatchResult CKeybindManager::changeworkspace(std::string args) {
     const auto PCURRENTWORKSPACE = PMONITOR->activeWorkspace;
     const bool EXPLICITPREVIOUS  = args.contains("previous");
 
-    const auto& [workspaceToChangeTo, workspaceName] = getWorkspaceToChangeFromArgs(args, PCURRENTWORKSPACE);
+    const auto& [workspaceToChangeTo, workspaceName] = getWorkspaceToChangeFromArgs(args, PCURRENTWORKSPACE, PMONITOR);
     if (workspaceToChangeTo == WORKSPACE_INVALID) {
         Debug::log(ERR, "Error in changeworkspace, invalid value");
         return {.success = false, .error = "Error in changeworkspace, invalid value"};
@@ -1216,19 +1213,19 @@ SDispatchResult CKeybindManager::changeworkspace(std::string args) {
     if (workspaceToChangeTo == WORKSPACE_NOT_CHANGED)
         return {};
 
-    const auto PREVWS = PCURRENTWORKSPACE->getPrevWorkspaceIDName(args.contains("_per_monitor"));
+    const SWorkspaceIDName PPREVWS = args.contains("_per_monitor") ? PMONITOR->getPrevWorkspaceIDName(PCURRENTWORKSPACE->m_iID) : PCURRENTWORKSPACE->getPrevWorkspaceIDName();
 
-    const bool BISWORKSPACECURRENT = workspaceToChangeTo == PCURRENTWORKSPACE->m_iID;
-    if (BISWORKSPACECURRENT && (!(*PBACKANDFORTH || EXPLICITPREVIOUS) || PREVWS.id == -1))
+    const bool             BISWORKSPACECURRENT = workspaceToChangeTo == PCURRENTWORKSPACE->m_iID;
+    if (BISWORKSPACECURRENT && (!(*PBACKANDFORTH || EXPLICITPREVIOUS) || PPREVWS.id == -1))
         return {.success = false, .error = "Previous workspace doesn't exist"};
 
     g_pInputManager->unconstrainMouse();
     g_pInputManager->m_bEmptyFocusCursorSet = false;
 
-    auto pWorkspaceToChangeTo = g_pCompositor->getWorkspaceByID(BISWORKSPACECURRENT ? PREVWS.id : workspaceToChangeTo);
+    auto pWorkspaceToChangeTo = g_pCompositor->getWorkspaceByID(BISWORKSPACECURRENT ? PPREVWS.id : workspaceToChangeTo);
     if (!pWorkspaceToChangeTo)
         pWorkspaceToChangeTo =
-            g_pCompositor->createNewWorkspace(BISWORKSPACECURRENT ? PREVWS.id : workspaceToChangeTo, PMONITOR->ID, BISWORKSPACECURRENT ? PREVWS.name : workspaceName);
+            g_pCompositor->createNewWorkspace(BISWORKSPACECURRENT ? PPREVWS.id : workspaceToChangeTo, PMONITOR->ID, BISWORKSPACECURRENT ? PPREVWS.name : workspaceName);
 
     if (!BISWORKSPACECURRENT && pWorkspaceToChangeTo->m_bIsSpecialWorkspace) {
         PMONITOR->setSpecialWorkspace(pWorkspaceToChangeTo);
@@ -1400,9 +1397,7 @@ SDispatchResult CKeybindManager::moveActiveToWorkspace(std::string args) {
 }
 
 SDispatchResult CKeybindManager::moveActiveToWorkspaceSilent(std::string args) {
-    PHLWINDOW  PWINDOW = nullptr;
-
-    const auto ORIGINALARGS = args;
+    PHLWINDOW PWINDOW = nullptr;
 
     if (args.contains(',')) {
         PWINDOW = g_pCompositor->getWindowByRegex(args.substr(args.find_last_of(',') + 1));
@@ -2026,7 +2021,7 @@ SDispatchResult CKeybindManager::focusWorkspaceOnCurrentMonitor(std::string args
     }
 
     static auto PBACKANDFORTH = CConfigValue<Hyprlang::INT>("binds:workspace_back_and_forth");
-    const auto  PREVWS        = pWorkspace->getPrevWorkspaceIDName(false);
+    const auto  PREVWS        = pWorkspace->getPrevWorkspaceIDName();
 
     if (*PBACKANDFORTH && PCURRMONITOR->activeWorkspaceID() == workspaceID && PREVWS.id != -1) {
         // Workspace to focus is previous workspace


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
https://github.com/hyprwm/Hyprland/issues/6641
https://github.com/hyprwm/Hyprland/issues/6684

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
moved storage of previous workspaces relative to monitor to monitor class for dispatcher previous_per_monitor
also made some changes to CMakeLists to build successfully

#### Is it ready for merging, or does it need work?
ready for merge

