### PR TITLE
Add render:allow_early_buffer_release to restore old behavior

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1313,6 +1313,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .type        = CONFIG_OPTION_INT,
         .data        = SConfigOptionDescription::SRangeData{2, 0, 2},
     },
+    SConfigOptionDescription{
+        .value       = "render:allow_early_buffer_release",
+        .description = "Allow early buffer release event. Fixes stuttering and missing frames for some apps. Causes graphical glitches and memory leaks in others",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{true},
+    },
 
     /*
      * cursor:

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -619,6 +619,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("render:expand_undersized_textures", Hyprlang::INT{1});
     m_pConfig->addConfigValue("render:xp_mode", Hyprlang::INT{0});
     m_pConfig->addConfigValue("render:ctm_animation", Hyprlang::INT{2});
+    m_pConfig->addConfigValue("render:allow_early_buffer_release", Hyprlang::INT{1});
 
     m_pConfig->addConfigValue("ecosystem:no_update_news", Hyprlang::INT{0});
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Add an option `render:allow_early_buffer_release` to restore behavior prior to https://github.com/hyprwm/Hyprland/pull/8966. Defaults to true.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Couldn't reproduce issues related to https://github.com/hyprwm/Hyprland/pull/8966. Firefox/Floorp work fine on nvidia desktop and intel notebook https://github.com/hyprwm/Hyprland/issues/8983. Minecraft flickers even with old buffer drops https://github.com/hyprwm/Hyprland/issues/9011.

#### Is it ready for merging, or does it need work?
Ready.

