### PR TITLE
animation: fixup adding animvars during ::tick

### DIFF
--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -216,11 +216,8 @@ void CHyprAnimationManager::tick() {
 
     static auto PANIMENABLED = CConfigValue<Hyprlang::INT>("animations:enabled");
 
-    // We need to do this because it's perfectly valid to add/change a var during this (via callbacks)
-    // FIXME: instead of doing this, make a fn to defer adding until tick is done and not in progress anymore.
-    const auto PAVS = m_vActiveAnimatedVariables;
-    for (auto const& pav : PAVS) {
-        const auto PAV = pav.lock();
+    for (size_t i = 0; i < m_vActiveAnimatedVariables.size(); i++) {
+        const auto PAV = m_vActiveAnimatedVariables[i].lock();
         if (!PAV)
             continue;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Removes the FIXME regarding adding animvars via callbacks during a tick.
Looping via indices resolves the problem when vars get added to active via a callback.

Vars are only actively removed from `m_vActiveAnimatedVaraibles` via the dtor of `CBaseAnimatedVariable`. But a `CBaseAnimatedVariable` can't be deleted during a callback, since we own a SP to it when calling the callback in the first place. So having elements of `m_vActiveAnimatedVariables` be removed via a callback during `::tick` is currently not possible anyways.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Ready.

