### PR TITLE
animations: fix XWayland cursor glitch and refactor skill issues

### DIFF
--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -38,7 +38,7 @@ static void setVector2DAnimToMove(WP<CBaseAnimatedVariable> pav) {
     animvar->setConfig(g_pConfigManager->getAnimationPropertyConfig("windowsMove"));
 
     const auto PHLWINDOW = animvar->m_Context.pWindow.lock();
-    if (PHLWINDOW && PHLWINDOW->m_vRealPosition->isBeingAnimated() && PHLWINDOW->m_vRealSize->isBeingAnimated())
+    if (PHLWINDOW && !PHLWINDOW->m_vRealPosition->isBeingAnimated() && !PHLWINDOW->m_vRealSize->isBeingAnimated())
         PHLWINDOW->m_bAnimatingIn = false;
 }
 

--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -123,7 +123,7 @@ void CHyprXWaylandManager::setWindowSize(PHLWINDOW pWindow, Vector2D size, bool 
 
     // calculate pos
     // TODO: this should be decoupled from setWindowSize IMO
-    Vector2D windowPos = pWindow->m_vRealPosition->value();
+    Vector2D windowPos = pWindow->m_vRealPosition->goal();
 
     if (pWindow->m_bIsX11 && PMONITOR) {
         windowPos -= PMONITOR->vecPosition; // normalize to monitor


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes https://github.com/hyprwm/Hyprland/issues/9017

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

The changed line in `XWaylandManager` was not changed in the hyprutils animation pr. No idea why the pr broke that but changing it to `goal` fixes it. I also think that is the correct thing to do in `setWindowSize`.

#### Is it ready for merging, or does it need work?

~Maybe wait for OP in #9017 to test the patch.~ Ready.


