### PR TITLE
Fix movefocus fallback for special workspaces

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1534,7 +1534,8 @@ SDispatchResult CKeybindManager::moveFocusTo(std::string args) {
             break;
     }
 
-    const auto PWINDOWCANDIDATE = g_pCompositor->getWindowInDirection(box, PMONITOR->activeWorkspace, arg, PLASTWINDOW, PLASTWINDOW->m_bIsFloating);
+    const auto PWINDOWCANDIDATE = g_pCompositor->getWindowInDirection(box, PMONITOR->activeSpecialWorkspace ? PMONITOR->activeSpecialWorkspace : PMONITOR->activeWorkspace, arg,
+                                                                      PLASTWINDOW, PLASTWINDOW->m_bIsFloating);
     if (PWINDOWCANDIDATE)
         switchToWindow(PWINDOWCANDIDATE);
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
`movefocus` on a special workspace does not behave as expected when focus fallback is required.

Currently, if there's a window in the workspace beneath the special workspace, it will move focus to that and if there's no window beneath, it won't do anything. What it should be doing instead is just rotate focus on the special workspace only.

This happens because while calling `getWindowInDirection`, the case of special workspace being present on current monitor is not handled. The fix is just to handle it.

Fixes #9020

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready to merge
