### PR TITLE
protocols: allow hyprland-toplevel-export to capture hidden windows

### DIFF
--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -86,7 +86,7 @@ CToplevelExportFrame::CToplevelExportFrame(SP<CHyprlandToplevelExportFrameV1> re
         return;
     }
 
-    if (!pWindow->m_bIsMapped || pWindow->isHidden()) {
+    if (!pWindow->m_bIsMapped) {
         LOGM(ERR, "Client requested sharing of window handle {:x} which is not shareable!", pWindow);
         resource->sendFailed();
         PROTO::toplevelExport->destroyResource(this);
@@ -147,7 +147,7 @@ void CToplevelExportFrame::copy(CHyprlandToplevelExportFrameV1* pFrame, wl_resou
         return;
     }
 
-    if (!pWindow->m_bIsMapped || pWindow->isHidden()) {
+    if (!pWindow->m_bIsMapped) {
         LOGM(ERR, "Client requested sharing of window handle {:x} which is not shareable (2)!", pWindow);
         resource->sendFailed();
         PROTO::toplevelExport->destroyResource(this);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -417,8 +417,8 @@ void CHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
     }
 }
 
-void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, timespec* time, bool decorate, eRenderPassMode mode, bool ignorePosition, bool ignoreAllGeometry) {
-    if (pWindow->isHidden())
+void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, timespec* time, bool decorate, eRenderPassMode mode, bool ignorePosition, bool standalone) {
+    if (pWindow->isHidden() && !standalone)
         return;
 
     if (pWindow->m_bFadingOut) {
@@ -450,7 +450,7 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, timespe
         renderdata.pos.y = pMonitor->vecPosition.y;
     }
 
-    if (ignoreAllGeometry)
+    if (standalone)
         decorate = false;
 
     // whether to use m_fMovingToWorkspaceAlpha, only if fading out into an invisible ws
@@ -463,12 +463,12 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, timespe
         (USE_WORKSPACE_FADE_ALPHA ? pWindow->m_fMovingToWorkspaceAlpha->value() : 1.F) * pWindow->m_fMovingFromWorkspaceAlpha->value();
     renderdata.alpha         = pWindow->m_fActiveInactiveAlpha->value();
     renderdata.decorate      = decorate && !pWindow->m_bX11DoesntWantBorders && !pWindow->isEffectiveInternalFSMode(FSMODE_FULLSCREEN);
-    renderdata.rounding      = ignoreAllGeometry || renderdata.dontRound ? 0 : pWindow->rounding() * pMonitor->scale;
-    renderdata.roundingPower = ignoreAllGeometry || renderdata.dontRound ? 2.0f : pWindow->roundingPower();
-    renderdata.blur          = !ignoreAllGeometry && *PBLUR && !DONT_BLUR;
+    renderdata.rounding      = standalone || renderdata.dontRound ? 0 : pWindow->rounding() * pMonitor->scale;
+    renderdata.roundingPower = standalone || renderdata.dontRound ? 2.0f : pWindow->roundingPower();
+    renderdata.blur          = !standalone && *PBLUR && !DONT_BLUR;
     renderdata.pWindow       = pWindow;
 
-    if (ignoreAllGeometry) {
+    if (standalone) {
         renderdata.alpha     = 1.f;
         renderdata.fadeAlpha = 1.f;
     }

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -117,7 +117,7 @@ class CHyprRenderer {
     void              arrangeLayerArray(PHLMONITOR, const std::vector<PHLLSREF>&, bool, CBox*);
     void              renderWorkspaceWindowsFullscreen(PHLMONITOR, PHLWORKSPACE, timespec*); // renders workspace windows (fullscreen) (tiled, floating, pinned, but no special)
     void              renderWorkspaceWindows(PHLMONITOR, PHLWORKSPACE, timespec*);           // renders workspace windows (no fullscreen) (tiled, floating, pinned, but no special)
-    void              renderWindow(PHLWINDOW, PHLMONITOR, timespec*, bool, eRenderPassMode, bool ignorePosition = false, bool ignoreAllGeometry = false);
+    void              renderWindow(PHLWINDOW, PHLMONITOR, timespec*, bool, eRenderPassMode, bool ignorePosition = false, bool standalone = false);
     void              renderLayer(PHLLS, PHLMONITOR, timespec*, bool popups = false);
     void              renderSessionLockSurface(SSessionLockSurface*, PHLMONITOR, timespec*);
     void              renderDragIcon(PHLMONITOR, timespec*);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This allows hyprland-toplevel-export clients like xdph and quickshell to capture hidden windows. This fixes capture sessions breaking when you hide a window in a group or try to capture a hidden window. It also doesn't seem to break anything.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.

#### Is it ready for merging, or does it need work?
Ready to merge.
