### PR TITLE
protocols: do not capture cursor in hyprland-toplevel-export without pointer focus

### DIFF
--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -2,6 +2,7 @@
 #include "../Compositor.hpp"
 #include "ForeignToplevelWlr.hpp"
 #include "../managers/PointerManager.hpp"
+#include "../managers/SeatManager.hpp"
 #include "types/WLBuffer.hpp"
 #include "types/Buffer.hpp"
 #include "../helpers/Format.hpp"
@@ -77,7 +78,7 @@ CToplevelExportFrame::CToplevelExportFrame(SP<CHyprlandToplevelExportFrameV1> re
     if (!good())
         return;
 
-    overlayCursor = !!overlayCursor_;
+    cursorOverlayRequested = !!overlayCursor_;
 
     if (!pWindow) {
         LOGM(ERR, "Client requested sharing of window handle {:x} which does not exist!", pWindow);
@@ -247,6 +248,8 @@ bool CToplevelExportFrame::copyShm(timespec* now) {
     CFramebuffer outFB;
     outFB.alloc(PMONITOR->vecPixelSize.x, PMONITOR->vecPixelSize.y, PMONITOR->output->state->state().drmFormat);
 
+    auto overlayCursor = shouldOverlayCursor();
+
     if (overlayCursor) {
         g_pPointerManager->lockSoftwareForMonitor(PMONITOR->self.lock());
         g_pPointerManager->damageCursor(PMONITOR->self.lock());
@@ -300,6 +303,8 @@ bool CToplevelExportFrame::copyDmabuf(timespec* now) {
 
     CRegion    fakeDamage{0, 0, INT16_MAX, INT16_MAX};
 
+    auto       overlayCursor = shouldOverlayCursor();
+
     if (overlayCursor) {
         g_pPointerManager->lockSoftwareForMonitor(PMONITOR->self.lock());
         g_pPointerManager->damageCursor(PMONITOR->self.lock());
@@ -326,6 +331,20 @@ bool CToplevelExportFrame::copyDmabuf(timespec* now) {
     }
 
     return true;
+}
+
+bool CToplevelExportFrame::shouldOverlayCursor() const {
+    if (!cursorOverlayRequested)
+        return false;
+
+    auto pointerSurfaceResource = g_pSeatManager->state.pointerFocus.lock();
+
+    if (!pointerSurfaceResource)
+        return false;
+
+    auto pointerSurface = CWLSurface::fromResource(pointerSurfaceResource);
+
+    return pointerSurface && pointerSurface->getWindow() == pWindow;
 }
 
 bool CToplevelExportFrame::good() {

--- a/src/protocols/ToplevelExport.hpp
+++ b/src/protocols/ToplevelExport.hpp
@@ -51,9 +51,9 @@ class CToplevelExportFrame {
     SP<CHyprlandToplevelExportFrameV1> resource;
 
     PHLWINDOW                          pWindow;
-    bool                               overlayCursor   = false;
-    bool                               ignoreDamage    = false;
-    bool                               lockedSWCursors = false;
+    bool                               cursorOverlayRequested = false;
+    bool                               ignoreDamage           = false;
+    bool                               lockedSWCursors        = false;
 
     WP<IHLBuffer>                      buffer;
     bool                               bufferDMA    = false;
@@ -66,6 +66,7 @@ class CToplevelExportFrame {
     bool                               copyDmabuf(timespec* now);
     bool                               copyShm(timespec* now);
     void                               share();
+    bool                               shouldOverlayCursor() const;
 
     friend class CToplevelExportProtocol;
 };


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes cursors being rendered on exported toplevels when they don't have pointer focus. This is usually when they're on another workspace or covered by a window.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.

#### Is it ready for merging, or does it need work?
Ready to merge.