### PR TITLE
protocols: do not destroy screencopy resources before client request

### DIFF
--- a/src/protocols/Screencopy.cpp
+++ b/src/protocols/Screencopy.cpp
@@ -24,7 +24,6 @@ CScreencopyFrame::CScreencopyFrame(SP<CZwlrScreencopyFrameV1> resource_, int32_t
     if (!pMonitor) {
         LOGM(ERR, "Client requested sharing of a monitor that doesnt exist");
         resource->sendFailed();
-        PROTO::screencopy->destroyResource(this);
         return;
     }
 
@@ -42,7 +41,6 @@ CScreencopyFrame::CScreencopyFrame(SP<CZwlrScreencopyFrameV1> resource_, int32_t
     if (shmFormat == DRM_FORMAT_INVALID) {
         LOGM(ERR, "No format supported by renderer in capture output");
         resource->sendFailed();
-        PROTO::screencopy->destroyResource(this);
         return;
     }
 
@@ -54,7 +52,6 @@ CScreencopyFrame::CScreencopyFrame(SP<CZwlrScreencopyFrameV1> resource_, int32_t
     if (!PSHMINFO) {
         LOGM(ERR, "No pixel format supported by renderer in capture output");
         resource->sendFailed();
-        PROTO::screencopy->destroyResource(this);
         return;
     }
 
@@ -90,7 +87,6 @@ void CScreencopyFrame::copy(CZwlrScreencopyFrameV1* pFrame, wl_resource* buffer_
     if (!g_pCompositor->monitorExists(pMonitor.lock())) {
         LOGM(ERR, "Client requested sharing of a monitor that is gone");
         resource->sendFailed();
-        PROTO::screencopy->destroyResource(this);
         return;
     }
 

--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -83,14 +83,12 @@ CToplevelExportFrame::CToplevelExportFrame(SP<CHyprlandToplevelExportFrameV1> re
     if (!pWindow) {
         LOGM(ERR, "Client requested sharing of window handle {:x} which does not exist!", pWindow);
         resource->sendFailed();
-        PROTO::toplevelExport->destroyResource(this);
         return;
     }
 
     if (!pWindow->m_bIsMapped) {
         LOGM(ERR, "Client requested sharing of window handle {:x} which is not shareable!", pWindow);
         resource->sendFailed();
-        PROTO::toplevelExport->destroyResource(this);
         return;
     }
 
@@ -106,7 +104,6 @@ CToplevelExportFrame::CToplevelExportFrame(SP<CHyprlandToplevelExportFrameV1> re
     if (shmFormat == DRM_FORMAT_INVALID) {
         LOGM(ERR, "No format supported by renderer in capture toplevel");
         resource->sendFailed();
-        PROTO::toplevelExport->destroyResource(this);
         return;
     }
 
@@ -114,7 +111,6 @@ CToplevelExportFrame::CToplevelExportFrame(SP<CHyprlandToplevelExportFrameV1> re
     if (!PSHMINFO) {
         LOGM(ERR, "No pixel format supported by renderer in capture toplevel");
         resource->sendFailed();
-        PROTO::toplevelExport->destroyResource(this);
         return;
     }
 
@@ -144,14 +140,12 @@ void CToplevelExportFrame::copy(CHyprlandToplevelExportFrameV1* pFrame, wl_resou
     if (!validMapped(pWindow)) {
         LOGM(ERR, "Client requested sharing of window handle {:x} which is gone!", pWindow);
         resource->sendFailed();
-        PROTO::toplevelExport->destroyResource(this);
         return;
     }
 
     if (!pWindow->m_bIsMapped) {
         LOGM(ERR, "Client requested sharing of window handle {:x} which is not shareable (2)!", pWindow);
         resource->sendFailed();
-        PROTO::toplevelExport->destroyResource(this);
         return;
     }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes client-side use-after-frees caused by screencopy failures. `failed()` is not a destructor, which means clients will attempt to call destroy() after receiving it, which becomes a use after free (protocol error) due to hyprland prematurely deleting the object.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.

#### Is it ready for merging, or does it need work?
Ready to merge.

