### PR TITLE
protocols: immediately copy toplevel content when ignoreDamage set

### DIFF
--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -202,7 +202,12 @@ void CToplevelExportFrame::copy(CHyprlandToplevelExportFrameV1* pFrame, wl_resou
 
     buffer = PBUFFER->buffer;
 
-    PROTO::toplevelExport->m_vFramesAwaitingWrite.emplace_back(self);
+    m_ignoreDamage = ignoreDamage;
+
+    if (ignoreDamage && validMapped(pWindow))
+        share();
+    else
+        PROTO::toplevelExport->m_vFramesAwaitingWrite.emplace_back(self);
 }
 
 void CToplevelExportFrame::share() {
@@ -226,7 +231,7 @@ void CToplevelExportFrame::share() {
 
     resource->sendFlags((hyprlandToplevelExportFrameV1Flags)0);
 
-    if (!ignoreDamage) {
+    if (!m_ignoreDamage) {
         resource->sendDamage(0, 0, box.width, box.height);
     }
 

--- a/src/protocols/ToplevelExport.hpp
+++ b/src/protocols/ToplevelExport.hpp
@@ -52,7 +52,7 @@ class CToplevelExportFrame {
 
     PHLWINDOW                          pWindow;
     bool                               cursorOverlayRequested = false;
-    bool                               ignoreDamage           = false;
+    bool                               m_ignoreDamage         = false;
     bool                               lockedSWCursors        = false;
 
     WP<IHLBuffer>                      buffer;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Makes hyprland_toplevel_export_frame_v1.copy attempt to capture a frame immediately if ignoreDamage was set. Additionally makes the field of the same name actually do something, as it was previously never set.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I'm not sure if anything else needs to be done to ensure the window is in a good state to capture, e.g. damage the monitor or the window, but it seems to work as is.

#### Is it ready for merging, or does it need work?
Ready to merge.
