### PR TITLE
Remove dependency on glaze

### DIFF
--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -63,15 +63,6 @@ runs:
           librsvg \
           re2
 
-    - name: Get glaze
-      shell: bash
-      run: |
-        git clone https://github.com/stephenberry/glaze.git
-        cd glaze
-        cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX:PATH=/usr -S . -B ./build
-        cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
-        cmake --install build
-
     - name: Get hyprwayland-scanner-git
       shell: bash
       run: |

--- a/hyprctl/Strings.hpp
+++ b/hyprctl/Strings.hpp
@@ -124,9 +124,10 @@ const std::string_view PLUGIN_HELP = R"#(usage: hyprctl [flags] plugin <request>
 requests:
     load <path>     → Loads a plugin. Path must be absolute
     unload <path>   → Unloads a plugin. Path must be absolute
-    list            → Lists all loaded plugins
+    list [-t]       → Lists all loaded plugins
 
 flags:
+    -t              → Terse output mode
     See 'hyprctl --help')#";
 
 const std::string_view SETPROP_HELP = R"#(usage: hyprctl [flags] setprop <regex> <property> <value> [lock]

--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -358,6 +358,8 @@ int main(int argc, char** argv) {
             if (ARGS[i] == "-j" && !fullArgs.contains("j")) {
                 fullArgs += "j";
                 json = true;
+            } else if (ARGS[i] == "-t" && !fullArgs.contains("t")) {
+                fullArgs += "t";
             } else if (ARGS[i] == "-r" && !fullArgs.contains("r")) {
                 fullArgs += "r";
             } else if (ARGS[i] == "-a" && !fullArgs.contains("a")) {

--- a/hyprpm/CMakeLists.txt
+++ b/hyprpm/CMakeLists.txt
@@ -11,23 +11,9 @@ set(CMAKE_CXX_STANDARD 23)
 
 pkg_check_modules(hyprpm_deps REQUIRED IMPORTED_TARGET tomlplusplus hyprutils>=0.2.4)
 
-find_package(glaze QUIET)
-if (NOT glaze_FOUND)
-    set(GLAZE_VERSION v4.2.3)
-    message(STATUS "glaze dependency not found, retrieving ${GLAZE_VERSION} with FetchContent")
-    include(FetchContent)
-    FetchContent_Declare(
-        glaze
-        GIT_REPOSITORY https://github.com/stephenberry/glaze.git
-        GIT_TAG ${GLAZE_VERSION}
-        GIT_SHALLOW TRUE
-    )
-    FetchContent_MakeAvailable(glaze)
-endif()
-
 add_executable(hyprpm ${SRCFILES})
 
-target_link_libraries(hyprpm PUBLIC PkgConfig::hyprpm_deps glaze::glaze)
+target_link_libraries(hyprpm PUBLIC PkgConfig::hyprpm_deps)
 
 # binary
 install(TARGETS hyprpm)

--- a/hyprpm/src/meson.build
+++ b/hyprpm/src/meson.build
@@ -8,7 +8,6 @@ executable(
     dependency('hyprutils', version: '>= 0.1.1'),
     dependency('threads'),
     dependency('tomlplusplus'),
-    dependency('glaze', method: 'cmake'),
   ],
   install: true,
 )

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -5,14 +5,12 @@
   pkg-config,
   pkgconf,
   makeWrapper,
-  cmake,
   meson,
   ninja,
   aquamarine,
   binutils,
   cairo,
   git,
-  glaze,
   hyprcursor,
   hyprgraphics,
   hyprland-protocols,
@@ -104,7 +102,6 @@ in
         makeWrapper
         meson
         ninja
-        cmake # needed for glaze
         pkg-config
       ];
 
@@ -119,7 +116,6 @@ in
           aquamarine
           cairo
           git
-          glaze
           hyprcursor
           hyprgraphics
           hyprland-protocols

--- a/src/SharedDefs.hpp
+++ b/src/SharedDefs.hpp
@@ -43,7 +43,8 @@ struct SCallbackInfo {
 
 enum eHyprCtlOutputFormat : uint8_t {
     FORMAT_NORMAL = 0,
-    FORMAT_JSON
+    FORMAT_JSON,
+    FORMAT_TERSE
 };
 
 struct SHyprCtlCommand {

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1507,6 +1507,10 @@ static std::string dispatchPlugin(eHyprCtlOutputFormat format, std::string reque
             }
             trimTrailingComma(result);
             result += "]";
+        } else if (format == eHyprCtlOutputFormat::FORMAT_TERSE) {
+            for (auto const& p : PLUGINS) {
+                result += std::format("{}\n", p->name);
+            }
         } else {
             if (PLUGINS.size() == 0)
                 return "no plugins loaded";
@@ -1718,6 +1722,8 @@ std::string CHyprCtl::getReply(std::string request) {
 
             if (c == 'j')
                 format = eHyprCtlOutputFormat::FORMAT_JSON;
+            else if (c == 't')
+                format = eHyprCtlOutputFormat::FORMAT_TERSE;
             else if (c == 'r')
                 reloadAll = true;
             else if (c == 'a')
@@ -1754,7 +1760,7 @@ std::string CHyprCtl::getReply(std::string request) {
             }
         }
 
-    if (result.empty())
+    if (result.empty() && format != eHyprCtlOutputFormat::FORMAT_TERSE)
         return "unknown request";
 
     if (reloadAll) {


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Attempt to remove dependency on glaze by making `hyprctl plugins list` output a 'terse' format.

see #8812 #8899

I was originally trying to compile glaze on alpine, but it had issues (with _Float128 and `std::to_chars` and `std::from_chars`), which I think belong to libc++ when compiled on musl... Given that glaze was only added to simplify some string parsing, I think it would be much less effort for me to just not use glaze in hyprland than to fix issues compiling glaze.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Need to test this more

#### Is it ready for merging, or does it need work?

I've tested this... but not fully

Also needs documentation updates