### PR TITLE
CMake, Meson: add option controlling building hyprpm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,7 +366,13 @@ protocolwayland()
 
 # tools
 add_subdirectory(hyprctl)
-add_subdirectory(hyprpm)
+
+if(NO_HYPRPM)
+  message(STATUS "hyprpm is disabled")
+else()
+  add_subdirectory(hyprpm)
+  message(STATUS "hyprpm is enabled (NO_HYPRPM not defined)")
+endif()
 
 # binary and symlink
 install(TARGETS Hyprland)

--- a/meson.build
+++ b/meson.build
@@ -101,10 +101,13 @@ endif
 subdir('protocols')
 subdir('src')
 subdir('hyprctl')
-subdir('hyprpm/src')
 subdir('assets')
 subdir('example')
 subdir('docs')
+
+if get_option('hyprpm').enabled()
+  subdir('hyprpm/src')
+endif
 
 # Generate hyprland.pc
 pkg_install_dir = join_paths(get_option('datadir'), 'pkgconfig')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,4 +2,5 @@ option('xwayland', type: 'feature', value: 'auto', description: 'Enable support 
 option('systemd', type: 'feature', value: 'auto', description: 'Enable systemd integration')
 option('uwsm', type: 'feature', value: 'enabled', description: 'Enable uwsm integration (only if systemd is enabled)')
 option('legacy_renderer', type: 'feature', value: 'disabled', description: 'Enable legacy renderer')
+option('hyprpm', type: 'feature', value: 'enabled', description: 'Enable hyprpm')
 option('tracy_enable', type: 'boolean', value: false , description: 'Enable profiling')

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -163,6 +163,7 @@ in
           "xwayland" = enableXWayland;
           "legacy_renderer" = legacyRenderer;
           "uwsm" = false;
+          "hyprpm" = false;
         })
         (mapAttrsToList mesonBool {
           "b_pch" = false;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Adds an option to control whether hyprpm will be built or not.
Ref: https://github.com/hyprwm/Hyprland/pull/9067
Wiki ref: https://github.com/hyprwm/hyprland-wiki/pull/949

Usage:
`-DNO_HYPRPM:BOOL=TRUE` for CMake
`-Dhyprpm=disabled` for Meson

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Seems to work for both CMake and Meson.

#### Is it ready for merging, or does it need work?

Ready.
