### PR TITLE
xwayland: support sending clipboard change notification on focus

### DIFF
--- a/src/xwayland/XWM.hpp
+++ b/src/xwayland/XWM.hpp
@@ -44,13 +44,16 @@ struct SXSelection {
     xcb_window_t     owner     = 0;
     xcb_timestamp_t  timestamp = 0;
     SP<CXDataSource> dataSource;
+    bool             notifyOnFocus = false;
 
     void             onSelection();
+    void             onKeyboardFocus();
     bool             sendData(xcb_selection_request_event_t* e, std::string mime);
     int              onRead(int fd, uint32_t mask);
 
     struct {
         CHyprSignalListener setSelection;
+        CHyprSignalListener keyboardFocusChange;
     } listeners;
 
     std::unique_ptr<SXTransfer> transfer;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Some X11 applications (namely Wine) tries to read and save clipboard content when notified of clipboard change via the XCB_XFIXES_SELECTION_NOTIFY event, and uses the saved content when the user tries to paste from the clipboard.

This is broken on Hyprland when the user copies from a Wayland window and tries to paste into a XWayland window. When the user performs the copy in the Wayland window, xcb_set_selection_owner is called by the XWM and the XWayland app is notified and immediately tries to read the clipboard. The read access will be denied because at this moment keyboard focus is on the Wayland window, but [the clipboard is only accessible to XWayland apps when keyboard focus is on any XWayland window](https://github.com/hyprwm/Hyprland/blob/f56153a9c1b0a00fac0932a95e0cfa5a4f6c681f/src/xwayland/XWM.cpp#L629).

This PR tries to solve the problem by calling xcb_set_selection_owner again (and thus sending the XCB_XFIXES_SELECTION_NOTIFY event) when keyboard focus is changed to a XWayland window.

Fixes: #2319

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

N/A

#### Is it ready for merging, or does it need work?

Y