### PR TITLE
reserve vector sizes as much as we can

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2785,11 +2785,9 @@ PHLWINDOW CCompositor::getForceFocus() {
 void CCompositor::arrangeMonitors() {
     static auto* const      PXWLFORCESCALEZERO = (Hyprlang::INT* const*)g_pConfigManager->getConfigValuePtr("xwayland:force_zero_scaling");
 
-    std::vector<PHLMONITOR> toArrange;
+    std::vector<PHLMONITOR> toArrange(m_vMonitors.begin(), m_vMonitors.end());
     std::vector<PHLMONITOR> arranged;
-
-    for (auto const& m : m_vMonitors)
-        toArrange.push_back(m);
+    arranged.reserve(toArrange.size());
 
     Debug::log(LOG, "arrangeMonitors: {} to arrange", toArrange.size());
 

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -282,6 +282,8 @@ void CWindow::updateWindowDecos() {
 
     // make a copy because updateWindow can remove decos.
     std::vector<IHyprWindowDecoration*> decos;
+    // reserve to avoid reallocations
+    decos.reserve(m_dWindowDecorations.size());
 
     for (auto const& wd : m_dWindowDecorations) {
         decos.push_back(wd.get());

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1891,9 +1891,7 @@ SDispatchResult CKeybindManager::workspaceOpt(std::string args) {
         // apply
 
         // we make a copy because changeWindowFloatingMode might invalidate the iterator
-        std::vector<PHLWINDOW> ptrs;
-        for (auto const& w : g_pCompositor->m_vWindows)
-            ptrs.push_back(w);
+        std::vector<PHLWINDOW> ptrs(g_pCompositor->m_vWindows.begin(), g_pCompositor->m_vWindows.end());
 
         for (auto const& w : ptrs) {
             if (!w->m_bIsMapped || w->m_pWorkspace != PWORKSPACE || w->isHidden())

--- a/src/protocols/DRMLease.cpp
+++ b/src/protocols/DRMLease.cpp
@@ -34,6 +34,9 @@ CDRMLeaseResource::CDRMLeaseResource(SP<CWpDrmLeaseV1> resource_, SP<CDRMLeaseRe
     }());
 
     std::vector<SP<Aquamarine::IOutput>> outputs;
+    // reserve to avoid reallocations
+    outputs.reserve(requested.size());
+
     for (auto const& m : requested) {
         outputs.emplace_back(m->monitor->output);
     }

--- a/src/protocols/GlobalShortcuts.cpp
+++ b/src/protocols/GlobalShortcuts.cpp
@@ -83,8 +83,19 @@ void CGlobalShortcutsProtocol::sendGlobalShortcutEvent(std::string appid, std::s
 
 std::vector<SShortcut> CGlobalShortcutsProtocol::getAllShortcuts() {
     std::vector<SShortcut> copy;
-    for (auto const& c : m_vClients) {
-        for (auto const& sh : c->shortcuts) {
+    // calculate the total number of shortcuts, precomputing size is linear
+    // and potential reallocation is more costly then the added precompute overhead of looping
+    // and finding the total size.
+    size_t totalShortcuts = 0;
+    for (const auto& c : m_vClients) {
+        totalShortcuts += c->shortcuts.size();
+    }
+
+    // reserve number of elements to avoid reallocations
+    copy.reserve(totalShortcuts);
+
+    for (const auto& c : m_vClients) {
+        for (const auto& sh : c->shortcuts) {
             copy.push_back(*sh);
         }
     }

--- a/src/protocols/Screencopy.cpp
+++ b/src/protocols/Screencopy.cpp
@@ -412,6 +412,8 @@ void CScreencopyProtocol::onOutputCommit(PHLMONITOR pMonitor) {
     }
 
     std::vector<WP<CScreencopyFrame>> framesToRemove;
+    // reserve number of elements to avoid reallocations
+    framesToRemove.reserve(m_vFramesAwaitingWrite.size());
 
     // share frame if correct output
     for (auto const& f : m_vFramesAwaitingWrite) {

--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -393,6 +393,8 @@ void CToplevelExportProtocol::onOutputCommit(PHLMONITOR pMonitor) {
         return; // nothing to share
 
     std::vector<WP<CToplevelExportFrame>> framesToRemove;
+    // reserve number of elements to avoid reallocations
+    framesToRemove.reserve(m_vFramesAwaitingWrite.size());
 
     // share frame if correct output
     for (auto const& f : m_vFramesAwaitingWrite) {

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -400,7 +400,10 @@ std::optional<std::vector<uint64_t>> CHyprOpenGLImpl::getModsForFormat(EGLint fo
     m_sProc.eglQueryDmaBufModifiersEXT(m_pEglDisplay, format, len, mods.data(), external.data(), &len);
 
     std::vector<uint64_t> result;
-    bool                  linearIsExternal = false;
+    // reserve number of elements to avoid reallocations
+    result.reserve(mods.size());
+
+    bool linearIsExternal = false;
     for (size_t i = 0; i < mods.size(); ++i) {
         if (external.at(i)) {
             if (mods.at(i) == DRM_FORMAT_MOD_LINEAR)
@@ -449,6 +452,8 @@ void CHyprOpenGLImpl::initDRMFormats() {
     Debug::log(LOG, "Supported DMA-BUF formats:");
 
     std::vector<SDRMFormat> dmaFormats;
+    // reserve number of elements to avoid reallocations
+    dmaFormats.reserve(formats.size());
 
     for (auto const& fmt : formats) {
         std::vector<uint64_t> mods;
@@ -472,8 +477,10 @@ void CHyprOpenGLImpl::initDRMFormats() {
         });
 
         std::vector<std::pair<uint64_t, std::string>> modifierData;
+        // reserve number of elements to avoid reallocations
+        modifierData.reserve(mods.size());
 
-        auto                                          fmtName = drmGetFormatName(fmt);
+        auto fmtName = drmGetFormatName(fmt);
         Debug::log(LOG, "EGL: GPU Supports Format {} (0x{:x})", fmtName ? fmtName : "?unknown?", fmt);
         for (auto const& mod : mods) {
             auto modName = drmGetFormatModifierName(mod);
@@ -2942,7 +2949,8 @@ SP<CEGLSync> CHyprOpenGLImpl::createEGLSync(int fenceFD) {
             Debug::log(ERR, "createEGLSync: dup failed");
             return nullptr;
         }
-
+        // reserve number of elements to avoid reallocations
+        attribs.reserve(3);
         attribs.push_back(EGL_SYNC_NATIVE_FENCE_FD_ANDROID);
         attribs.push_back(dupFd);
         attribs.push_back(EGL_NONE);

--- a/src/render/decorations/DecorationPositioner.cpp
+++ b/src/render/decorations/DecorationPositioner.cpp
@@ -122,6 +122,9 @@ void CDecorationPositioner::onWindowUpdate(PHLWINDOW pWindow) {
 
     //
     std::vector<CDecorationPositioner::SWindowPositioningData*> datas;
+    // reserve to avoid reallocations
+    datas.reserve(pWindow->m_dWindowDecorations.size());
+
     for (auto const& wd : pWindow->m_dWindowDecorations) {
         datas.push_back(getDataFor(wd.get(), pWindow));
     }

--- a/src/xwayland/Dnd.cpp
+++ b/src/xwayland/Dnd.cpp
@@ -75,6 +75,8 @@ void CX11DataDevice::sendEnter(uint32_t serial, SP<CWLSurfaceResource> surf, con
     data.data32[1] |= 1;
 
     std::vector<xcb_atom_t> targets;
+    // reserve to avoid reallocations
+    targets.reserve(SOURCE->mimes().size());
 
     for (auto& mime : SOURCE->mimes()) {
         targets.emplace_back(g_pXWayland->pWM->mimeToAtom(mime));

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -643,6 +643,8 @@ void CXWM::handleSelectionRequest(xcb_selection_request_event_t* e) {
             Debug::log(WARN, "[xwm] WARNING: No mimes in TARGETS?");
 
         std::vector<xcb_atom_t> atoms;
+        // reserve to avoid reallocations
+        atoms.reserve(mimes.size() + 2);
         atoms.push_back(HYPRATOMS["TIMESTAMP"]);
         atoms.push_back(HYPRATOMS["TARGETS"]);
 
@@ -989,6 +991,8 @@ void CXWM::sendState(SP<CXWaylandSurface> surf) {
     }
 
     std::vector<uint32_t> props;
+    // reserve to avoid reallocations
+    props.reserve(6); // props below
     if (surf->modal)
         props.push_back(HYPRATOMS["_NET_WM_STATE_MODAL"]);
     if (surf->fullscreen)


### PR DESCRIPTION
avoid reallocations as much as possible with a few edge cases where the reservation overshoots a tiny bit. but a few bytes of memory short term is better used then the overhead of potential reallocation.

