### PR TITLE
begin using CFileDescriptor from hyprutils

### DIFF
--- a/src/config/ConfigWatcher.hpp
+++ b/src/config/ConfigWatcher.hpp
@@ -3,20 +3,21 @@
 #include <vector>
 #include <string>
 #include <functional>
+#include <hyprutils/os/FileDescriptor.hpp>
 
 class CConfigWatcher {
   public:
     CConfigWatcher();
-    ~CConfigWatcher();
+    ~CConfigWatcher() = default;
 
     struct SConfigWatchEvent {
         std::string file;
     };
 
-    int  getInotifyFD();
-    void setWatchList(const std::vector<std::string>& paths);
-    void setOnChange(const std::function<void(const SConfigWatchEvent&)>& fn);
-    void onInotifyEvent();
+    Hyprutils::OS::CFileDescriptor& getInotifyFD();
+    void                            setWatchList(const std::vector<std::string>& paths);
+    void                            setOnChange(const std::function<void(const SConfigWatchEvent&)>& fn);
+    void                            onInotifyEvent();
 
   private:
     struct SInotifyWatch {
@@ -26,7 +27,7 @@ class CConfigWatcher {
 
     std::function<void(const SConfigWatchEvent&)> m_watchCallback;
     std::vector<SInotifyWatch>                    m_watches;
-    int                                           m_inotifyFd = -1;
+    Hyprutils::OS::CFileDescriptor                m_inotifyFd;
 };
 
 inline UP<CConfigWatcher> g_pConfigWatcher = makeUnique<CConfigWatcher>();

--- a/src/debug/HyprCtl.hpp
+++ b/src/debug/HyprCtl.hpp
@@ -4,6 +4,7 @@
 #include "../helpers/MiscFunctions.hpp"
 #include "../desktop/Window.hpp"
 #include <functional>
+#include <hyprutils/os/FileDescriptor.hpp>
 
 // exposed for main.cpp
 std::string systemInfoRequest(eHyprCtlOutputFormat format, std::string request);
@@ -14,12 +15,12 @@ class CHyprCtl {
     CHyprCtl();
     ~CHyprCtl();
 
-    std::string         makeDynamicCall(const std::string& input);
-    SP<SHyprCtlCommand> registerCommand(SHyprCtlCommand cmd);
-    void                unregisterCommand(const SP<SHyprCtlCommand>& cmd);
-    std::string         getReply(std::string);
+    std::string                    makeDynamicCall(const std::string& input);
+    SP<SHyprCtlCommand>            registerCommand(SHyprCtlCommand cmd);
+    void                           unregisterCommand(const SP<SHyprCtlCommand>& cmd);
+    std::string                    getReply(std::string);
 
-    int                 m_iSocketFD = -1;
+    Hyprutils::OS::CFileDescriptor m_iSocketFD;
 
     struct {
         bool all           = false;

--- a/src/devices/IKeyboard.hpp
+++ b/src/devices/IKeyboard.hpp
@@ -6,6 +6,7 @@
 
 #include <optional>
 #include <xkbcommon/xkbcommon.h>
+#include <hyprutils/os/FileDescriptor.hpp>
 
 AQUAMARINE_FORWARD(IKeyboard);
 
@@ -96,7 +97,7 @@ class IKeyboard : public IHID {
 
     std::string                    xkbFilePath     = "";
     std::string                    xkbKeymapString = "";
-    int                            xkbKeymapFD     = -1;
+    Hyprutils::OS::CFileDescriptor xkbKeymapFD;
 
     SStringRuleNames               currentRules;
     int                            repeatRate        = 0;

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -836,50 +836,48 @@ bool envEnabled(const std::string& env) {
     return std::string(ENV) == "1";
 }
 
-std::pair<int, std::string> openExclusiveShm() {
+std::pair<CFileDescriptor, std::string> openExclusiveShm() {
     // Only absolute paths can be shared across different shm_open() calls
     std::string name = "/" + g_pTokenManager->getRandomUUID();
 
     for (size_t i = 0; i < 69; ++i) {
-        int fd = shm_open(name.c_str(), O_RDWR | O_CREAT | O_EXCL, 0600);
-        if (fd >= 0)
-            return {fd, name};
+        CFileDescriptor fd{shm_open(name.c_str(), O_RDWR | O_CREAT | O_EXCL, 0600)};
+        if (fd.isValid())
+            return {std::move(fd), name};
     }
 
-    return {-1, ""};
+    return {{}, ""};
 }
 
-int allocateSHMFile(size_t len) {
+CFileDescriptor allocateSHMFile(size_t len) {
     auto [fd, name] = openExclusiveShm();
-    if (fd < 0)
-        return -1;
+    if (!fd.isValid())
+        return {};
 
     shm_unlink(name.c_str());
 
     int ret;
     do {
-        ret = ftruncate(fd, len);
+        ret = ftruncate(fd.get(), len);
     } while (ret < 0 && errno == EINTR);
 
     if (ret < 0) {
-        close(fd);
-        return -1;
+        return {};
     }
 
-    return fd;
+    return std::move(fd);
 }
 
-bool allocateSHMFilePair(size_t size, int* rw_fd_ptr, int* ro_fd_ptr) {
+bool allocateSHMFilePair(size_t size, CFileDescriptor& rw_fd_ptr, CFileDescriptor& ro_fd_ptr) {
     auto [fd, name] = openExclusiveShm();
-    if (fd < 0) {
+    if (!fd.isValid()) {
         return false;
     }
 
     // CLOEXEC is guaranteed to be set by shm_open
-    int ro_fd = shm_open(name.c_str(), O_RDONLY, 0);
-    if (ro_fd < 0) {
+    CFileDescriptor ro_fd{shm_open(name.c_str(), O_RDONLY, 0)};
+    if (!ro_fd.isValid()) {
         shm_unlink(name.c_str());
-        close(fd);
         return false;
     }
 
@@ -887,24 +885,20 @@ bool allocateSHMFilePair(size_t size, int* rw_fd_ptr, int* ro_fd_ptr) {
 
     // Make sure the file cannot be re-opened in read-write mode (e.g. via
     // "/proc/self/fd/" on Linux)
-    if (fchmod(fd, 0) != 0) {
-        close(fd);
-        close(ro_fd);
+    if (fchmod(fd.get(), 0) != 0) {
         return false;
     }
 
     int ret;
     do {
-        ret = ftruncate(fd, size);
+        ret = ftruncate(fd.get(), size);
     } while (ret < 0 && errno == EINTR);
     if (ret < 0) {
-        close(fd);
-        close(ro_fd);
         return false;
     }
 
-    *rw_fd_ptr = fd;
-    *ro_fd_ptr = ro_fd;
+    rw_fd_ptr = std::move(fd);
+    ro_fd_ptr = std::move(ro_fd);
     return true;
 }
 

--- a/src/helpers/MiscFunctions.hpp
+++ b/src/helpers/MiscFunctions.hpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <format>
 #include <expected>
+#include <hyprutils/os/FileDescriptor.hpp>
 #include "../SharedDefs.hpp"
 #include "../macros.hpp"
 
@@ -35,8 +36,8 @@ double                              normalizeAngleRad(double ang);
 std::vector<SCallstackFrameInfo>    getBacktrace();
 void                                throwError(const std::string& err);
 bool                                envEnabled(const std::string& env);
-int                                 allocateSHMFile(size_t len);
-bool                                allocateSHMFilePair(size_t size, int* rw_fd_ptr, int* ro_fd_ptr);
+Hyprutils::OS::CFileDescriptor      allocateSHMFile(size_t len);
+bool                                allocateSHMFilePair(size_t size, Hyprutils::OS::CFileDescriptor& rw_fd_ptr, Hyprutils::OS::CFileDescriptor& ro_fd_ptr);
 float                               stringToPercentage(const std::string& VALUE, const float REL);
 
 template <typename... Args>

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -32,6 +32,7 @@
 #include <ranges>
 using namespace Hyprutils::String;
 using namespace Hyprutils::Utils;
+using namespace Hyprutils::OS;
 
 static int ratHandler(void* data) {
     g_pHyprRenderer->renderMonitor(((CMonitor*)data)->self.lock());
@@ -1301,19 +1302,15 @@ bool CMonitor::attemptDirectScanout() {
 
     // wait for the explicit fence if present, and if kms explicit is allowed
     bool DOEXPLICIT = PSURFACE->syncobj && PSURFACE->syncobj->current.acquireTimeline && PSURFACE->syncobj->current.acquireTimeline->timeline && explicitOptions.explicitKMSEnabled;
-    int  explicitWaitFD = -1;
+    CFileDescriptor explicitWaitFD;
     if (DOEXPLICIT) {
         explicitWaitFD = PSURFACE->syncobj->current.acquireTimeline->timeline->exportAsSyncFileFD(PSURFACE->syncobj->current.acquirePoint);
-        if (explicitWaitFD < 0)
+        if (!explicitWaitFD.isValid())
             Debug::log(TRACE, "attemptDirectScanout: failed to acquire an explicit wait fd");
     }
-    DOEXPLICIT = DOEXPLICIT && explicitWaitFD >= 0;
+    DOEXPLICIT = DOEXPLICIT && explicitWaitFD.isValid();
 
-    auto     cleanup = CScopeGuard([explicitWaitFD, this]() {
-        output->state->resetExplicitFences();
-        if (explicitWaitFD >= 0)
-            close(explicitWaitFD);
-    });
+    auto     cleanup = CScopeGuard([this]() { output->state->resetExplicitFences(); });
 
     timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);
@@ -1323,8 +1320,8 @@ bool CMonitor::attemptDirectScanout() {
     output->state->resetExplicitFences();
 
     if (DOEXPLICIT) {
-        Debug::log(TRACE, "attemptDirectScanout: setting IN_FENCE for aq to {}", explicitWaitFD);
-        output->state->setExplicitInFence(explicitWaitFD);
+        Debug::log(TRACE, "attemptDirectScanout: setting IN_FENCE for aq to {}", explicitWaitFD.get());
+        output->state->setExplicitInFence(explicitWaitFD.get());
     }
 
     bool ok = output->commit();

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -16,6 +16,7 @@
 #include "DamageRing.hpp"
 #include <aquamarine/output/Output.hpp>
 #include <aquamarine/allocator/Swapchain.hpp>
+#include <hyprutils/os/FileDescriptor.hpp>
 
 // Enum for the different types of auto directions, e.g. auto-left, auto-up.
 enum eAutoDirs : uint8_t {

--- a/src/helpers/sync/SyncTimeline.hpp
+++ b/src/helpers/sync/SyncTimeline.hpp
@@ -4,6 +4,7 @@
 #include <optional>
 #include <vector>
 #include <functional>
+#include <hyprutils/os/FileDescriptor.hpp>
 #include "../memory/Memory.hpp"
 
 /*
@@ -20,26 +21,27 @@ class CSyncTimeline {
     ~CSyncTimeline();
 
     struct SWaiter {
-        std::function<void()> fn;
-        wl_event_source*      source = nullptr;
-        WP<CSyncTimeline>     timeline;
+        std::function<void()>          fn;
+        wl_event_source*               source = nullptr;
+        WP<CSyncTimeline>              timeline;
+        Hyprutils::OS::CFileDescriptor eventFd;
     };
 
     // check if the timeline point has been signaled
     // flags: DRM_SYNCOBJ_WAIT_FLAGS_WAIT_FOR_SUBMIT or DRM_SYNCOBJ_WAIT_FLAGS_WAIT_AVAILABLE
     // std::nullopt on fail
-    std::optional<bool> check(uint64_t point, uint32_t flags);
+    std::optional<bool>            check(uint64_t point, uint32_t flags);
 
-    bool                addWaiter(const std::function<void()>& waiter, uint64_t point, uint32_t flags);
-    void                removeWaiter(SWaiter*);
-    int                 exportAsSyncFileFD(uint64_t src);
-    bool                importFromSyncFileFD(uint64_t dst, int fd);
-    bool                transfer(SP<CSyncTimeline> from, uint64_t fromPoint, uint64_t toPoint);
-    void                signal(uint64_t point);
+    bool                           addWaiter(const std::function<void()>& waiter, uint64_t point, uint32_t flags);
+    void                           removeWaiter(SWaiter*);
+    Hyprutils::OS::CFileDescriptor exportAsSyncFileFD(uint64_t src);
+    bool                           importFromSyncFileFD(uint64_t dst, Hyprutils::OS::CFileDescriptor& fd);
+    bool                           transfer(SP<CSyncTimeline> from, uint64_t fromPoint, uint64_t toPoint);
+    void                           signal(uint64_t point);
 
-    int                 drmFD  = -1;
-    uint32_t            handle = 0;
-    WP<CSyncTimeline>   self;
+    int                            drmFD  = -1;
+    uint32_t                       handle = 0;
+    WP<CSyncTimeline>              self;
 
   private:
     CSyncTimeline() = default;

--- a/src/managers/EventManager.cpp
+++ b/src/managers/EventManager.cpp
@@ -9,9 +9,10 @@
 #include <sys/un.h>
 #include <unistd.h>
 #include <cstring>
+using namespace Hyprutils::OS;
 
 CEventManager::CEventManager() : m_iSocketFD(socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC | SOCK_NONBLOCK, 0)) {
-    if (m_iSocketFD < 0) {
+    if (!m_iSocketFD.isValid()) {
         Debug::log(ERR, "Couldn't start the Hyprland Socket 2. (1) IPC will not work.");
         return;
     }
@@ -25,31 +26,27 @@ CEventManager::CEventManager() : m_iSocketFD(socket(AF_UNIX, SOCK_STREAM | SOCK_
 
     strncpy(SERVERADDRESS.sun_path, PATH.c_str(), sizeof(SERVERADDRESS.sun_path) - 1);
 
-    if (bind(m_iSocketFD, (sockaddr*)&SERVERADDRESS, SUN_LEN(&SERVERADDRESS)) < 0) {
+    if (bind(m_iSocketFD.get(), (sockaddr*)&SERVERADDRESS, SUN_LEN(&SERVERADDRESS)) < 0) {
         Debug::log(ERR, "Couldn't bind the Hyprland Socket 2. (3) IPC will not work.");
         return;
     }
 
     // 10 max queued.
-    if (listen(m_iSocketFD, 10) < 0) {
+    if (listen(m_iSocketFD.get(), 10) < 0) {
         Debug::log(ERR, "Couldn't listen on the Hyprland Socket 2. (4) IPC will not work.");
         return;
     }
 
-    m_pEventSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, m_iSocketFD, WL_EVENT_READABLE, onClientEvent, nullptr);
+    m_pEventSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, m_iSocketFD.get(), WL_EVENT_READABLE, onClientEvent, nullptr);
 }
 
 CEventManager::~CEventManager() {
     for (const auto& client : m_vClients) {
         wl_event_source_remove(client.eventSource);
-        close(client.fd);
     }
 
     if (m_pEventSource != nullptr)
         wl_event_source_remove(m_pEventSource);
-
-    if (m_iSocketFD >= 0)
-        close(m_iSocketFD);
 }
 
 int CEventManager::onServerEvent(int fd, uint32_t mask, void* data) {
@@ -66,33 +63,31 @@ int CEventManager::onServerEvent(int fd, uint32_t mask) {
 
         wl_event_source_remove(m_pEventSource);
         m_pEventSource = nullptr;
-        close(fd);
-        m_iSocketFD = -1;
+        m_iSocketFD.reset();
 
         return 0;
     }
 
-    sockaddr_in clientAddress;
-    socklen_t   clientSize         = sizeof(clientAddress);
-    const auto  ACCEPTEDCONNECTION = accept4(m_iSocketFD, (sockaddr*)&clientAddress, &clientSize, SOCK_CLOEXEC | SOCK_NONBLOCK);
-    if (ACCEPTEDCONNECTION < 0) {
+    sockaddr_in     clientAddress;
+    socklen_t       clientSize = sizeof(clientAddress);
+    CFileDescriptor ACCEPTEDCONNECTION{accept4(m_iSocketFD.get(), (sockaddr*)&clientAddress, &clientSize, SOCK_CLOEXEC | SOCK_NONBLOCK)};
+    if (!ACCEPTEDCONNECTION.isValid()) {
         if (errno != EAGAIN) {
             Debug::log(ERR, "Socket2 failed receiving connection, errno: {}", errno);
             wl_event_source_remove(m_pEventSource);
             m_pEventSource = nullptr;
-            close(fd);
-            m_iSocketFD = -1;
+            m_iSocketFD.reset();
         }
 
         return 0;
     }
 
-    Debug::log(LOG, "Socket2 accepted a new client at FD {}", ACCEPTEDCONNECTION);
+    Debug::log(LOG, "Socket2 accepted a new client at FD {}", ACCEPTEDCONNECTION.get());
 
     // add to event loop so we can close it when we need to
-    auto* eventSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, ACCEPTEDCONNECTION, 0, onServerEvent, nullptr);
+    auto* eventSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, ACCEPTEDCONNECTION.get(), 0, onServerEvent, nullptr);
     m_vClients.emplace_back(SClient{
-        ACCEPTEDCONNECTION,
+        std::move(ACCEPTEDCONNECTION),
         {},
         eventSource,
     });
@@ -113,7 +108,7 @@ int CEventManager::onClientEvent(int fd, uint32_t mask) {
         // send all queued events
         while (!CLIENTIT->events.empty()) {
             const auto& event = CLIENTIT->events.front();
-            if (write(CLIENTIT->fd, event->c_str(), event->length()) < 0)
+            if (write(CLIENTIT->fd.get(), event->c_str(), event->length()) < 0)
                 break;
 
             CLIENTIT->events.erase(CLIENTIT->events.begin());
@@ -128,13 +123,12 @@ int CEventManager::onClientEvent(int fd, uint32_t mask) {
 }
 
 std::vector<CEventManager::SClient>::iterator CEventManager::findClientByFD(int fd) {
-    return std::find_if(m_vClients.begin(), m_vClients.end(), [fd](const auto& client) { return client.fd == fd; });
+    return std::find_if(m_vClients.begin(), m_vClients.end(), [fd](const auto& client) { return client.fd.get() == fd; });
 }
 
 std::vector<CEventManager::SClient>::iterator CEventManager::removeClientByFD(int fd) {
     const auto CLIENTIT = findClientByFD(fd);
     wl_event_source_remove(CLIENTIT->eventSource);
-    close(fd);
 
     return m_vClients.erase(CLIENTIT);
 }
@@ -157,11 +151,11 @@ void CEventManager::postEvent(const SHyprIPCEvent& event) {
     for (auto it = m_vClients.begin(); it != m_vClients.end();) {
         // try to send the event immediately if the queue is empty
         const auto QUEUESIZE = it->events.size();
-        if (QUEUESIZE > 0 || write(it->fd, sharedEvent->c_str(), sharedEvent->length()) < 0) {
+        if (QUEUESIZE > 0 || write(it->fd.get(), sharedEvent->c_str(), sharedEvent->length()) < 0) {
             if (QUEUESIZE >= MAX_QUEUED_EVENTS) {
                 // too many events queued, remove the client
-                Debug::log(ERR, "Socket2 fd {} overflowed event queue, removing", it->fd);
-                it = removeClientByFD(it->fd);
+                Debug::log(ERR, "Socket2 fd {} overflowed event queue, removing", it->fd.get());
+                it = removeClientByFD(it->fd.get());
                 continue;
             }
 

--- a/src/managers/EventManager.hpp
+++ b/src/managers/EventManager.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include <vector>
-
+#include <hyprutils/os/FileDescriptor.hpp>
 #include "../defines.hpp"
 #include "../helpers/memory/Memory.hpp"
 
@@ -26,19 +26,19 @@ class CEventManager {
     int         onClientEvent(int fd, uint32_t mask);
 
     struct SClient {
-        int                          fd = -1;
-        std::vector<SP<std::string>> events;
-        wl_event_source*             eventSource = nullptr;
+        Hyprutils::OS::CFileDescriptor fd;
+        std::vector<SP<std::string>>   events;
+        wl_event_source*               eventSource = nullptr;
     };
 
     std::vector<SClient>::iterator findClientByFD(int fd);
     std::vector<SClient>::iterator removeClientByFD(int fd);
 
   private:
-    int                  m_iSocketFD    = -1;
-    wl_event_source*     m_pEventSource = nullptr;
+    Hyprutils::OS::CFileDescriptor m_iSocketFD;
+    wl_event_source*               m_pEventSource = nullptr;
 
-    std::vector<SClient> m_vClients;
+    std::vector<SClient>           m_vClients;
 };
 
 inline UP<CEventManager> g_pEventManager;

--- a/src/managers/eventLoop/EventLoopManager.cpp
+++ b/src/managers/eventLoop/EventLoopManager.cpp
@@ -54,8 +54,8 @@ static int configWatcherWrite(int fd, uint32_t mask, void* data) {
 void CEventLoopManager::enterLoop() {
     m_sWayland.eventSource = wl_event_loop_add_fd(m_sWayland.loop, m_sTimers.timerfd, WL_EVENT_READABLE, timerWrite, nullptr);
 
-    if (const auto FD = g_pConfigWatcher->getInotifyFD(); FD >= 0)
-        m_configWatcherInotifySource = wl_event_loop_add_fd(m_sWayland.loop, FD, WL_EVENT_READABLE, configWatcherWrite, nullptr);
+    if (const auto& FD = g_pConfigWatcher->getInotifyFD(); FD.isValid())
+        m_configWatcherInotifySource = wl_event_loop_add_fd(m_sWayland.loop, FD.get(), WL_EVENT_READABLE, configWatcherWrite, nullptr);
 
     syncPollFDs();
     m_sListeners.pollFDsChanged = g_pCompositor->m_pAqBackend->events.pollFDsChanged.registerListener([this](std::any d) { syncPollFDs(); });

--- a/src/managers/eventLoop/EventLoopManager.hpp
+++ b/src/managers/eventLoop/EventLoopManager.hpp
@@ -6,6 +6,7 @@
 #include <thread>
 #include <wayland-server.h>
 #include "helpers/signal/Signal.hpp"
+#include <hyprutils/os/FileDescriptor.hpp>
 
 #include "EventLoopTimer.hpp"
 
@@ -54,7 +55,7 @@ class CEventLoopManager {
 
     struct {
         std::vector<SP<CEventLoopTimer>> timers;
-        int                              timerfd = -1;
+        Hyprutils::OS::CFileDescriptor   timerfd;
     } m_sTimers;
 
     SIdleData                       m_sIdle;

--- a/src/protocols/DRMLease.hpp
+++ b/src/protocols/DRMLease.hpp
@@ -5,6 +5,7 @@
 #include "WaylandProtocol.hpp"
 #include "drm-lease-v1.hpp"
 #include "../helpers/signal/Signal.hpp"
+#include <hyprutils/os/FileDescriptor.hpp>
 
 /*
     TODO: this protocol is not made for systems with multiple DRM nodes (e.g. multigpu)

--- a/src/protocols/DRMSyncobj.hpp
+++ b/src/protocols/DRMSyncobj.hpp
@@ -4,6 +4,7 @@
 #include "WaylandProtocol.hpp"
 #include "linux-drm-syncobj-v1.hpp"
 #include "../helpers/signal/Signal.hpp"
+#include <hyprutils/os/FileDescriptor.hpp>
 
 class CWLSurfaceResource;
 class CDRMSyncobjTimelineResource;
@@ -32,14 +33,14 @@ class CDRMSyncobjSurfaceResource {
 
 class CDRMSyncobjTimelineResource {
   public:
-    CDRMSyncobjTimelineResource(SP<CWpLinuxDrmSyncobjTimelineV1> resource_, int fd_);
-    ~CDRMSyncobjTimelineResource();
+    CDRMSyncobjTimelineResource(SP<CWpLinuxDrmSyncobjTimelineV1> resource_, Hyprutils::OS::CFileDescriptor fd_);
+    ~CDRMSyncobjTimelineResource() = default;
     static SP<CDRMSyncobjTimelineResource> fromResource(wl_resource*);
 
     bool                                   good();
 
     WP<CDRMSyncobjTimelineResource>        self;
-    int                                    fd = -1;
+    Hyprutils::OS::CFileDescriptor         fd;
     SP<CSyncTimeline>                      timeline;
 
   private:

--- a/src/protocols/DataDeviceWlr.hpp
+++ b/src/protocols/DataDeviceWlr.hpp
@@ -5,6 +5,7 @@
 #include "WaylandProtocol.hpp"
 #include "wlr-data-control-unstable-v1.hpp"
 #include "types/DataDevice.hpp"
+#include <hyprutils/os/FileDescriptor.hpp>
 
 class CWLRDataControlManagerResource;
 class CWLRDataSource;
@@ -38,7 +39,7 @@ class CWLRDataSource : public IDataSource {
     bool                             good();
 
     virtual std::vector<std::string> mimes();
-    virtual void                     send(const std::string& mime, uint32_t fd);
+    virtual void                     send(const std::string& mime, Hyprutils::OS::CFileDescriptor fd);
     virtual void                     accepted(const std::string& mime);
     virtual void                     cancelled();
     virtual void                     error(uint32_t code, const std::string& msg);

--- a/src/protocols/InputMethodV2.cpp
+++ b/src/protocols/InputMethodV2.cpp
@@ -33,25 +33,22 @@ void CInputMethodKeyboardGrabV2::sendKeyboardData(SP<IKeyboard> keyboard) {
 
     pLastKeyboard = keyboard;
 
-    int keymapFD = allocateSHMFile(keyboard->xkbKeymapString.length() + 1);
-    if UNLIKELY (keymapFD < 0) {
+    auto keymapFD = allocateSHMFile(keyboard->xkbKeymapString.length() + 1);
+    if UNLIKELY (!keymapFD.isValid()) {
         LOGM(ERR, "Failed to create a keymap file for keyboard grab");
         return;
     }
 
-    void* data = mmap(nullptr, keyboard->xkbKeymapString.length() + 1, PROT_READ | PROT_WRITE, MAP_SHARED, keymapFD, 0);
+    void* data = mmap(nullptr, keyboard->xkbKeymapString.length() + 1, PROT_READ | PROT_WRITE, MAP_SHARED, keymapFD.get(), 0);
     if UNLIKELY (data == MAP_FAILED) {
         LOGM(ERR, "Failed to mmap a keymap file for keyboard grab");
-        close(keymapFD);
         return;
     }
 
     memcpy(data, keyboard->xkbKeymapString.c_str(), keyboard->xkbKeymapString.length());
     munmap(data, keyboard->xkbKeymapString.length() + 1);
 
-    resource->sendKeymap(WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1, keymapFD, keyboard->xkbKeymapString.length() + 1);
-
-    close(keymapFD);
+    resource->sendKeymap(WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1, keymapFD.get(), keyboard->xkbKeymapString.length() + 1);
 
     sendMods(keyboard->modifiersState.depressed, keyboard->modifiersState.latched, keyboard->modifiersState.locked, keyboard->modifiersState.group);
 

--- a/src/protocols/LinuxDMABUF.hpp
+++ b/src/protocols/LinuxDMABUF.hpp
@@ -9,6 +9,7 @@
 #include "../helpers/Format.hpp"
 #include "../helpers/Monitor.hpp"
 #include <aquamarine/buffer/Buffer.hpp>
+#include <hyprutils/os/FileDescriptor.hpp>
 
 class CDMABuffer;
 class CWLSurfaceResource;
@@ -48,9 +49,9 @@ struct SDMABUFTranche {
 class CDMABUFFormatTable {
   public:
     CDMABUFFormatTable(SDMABUFTranche rendererTranche, std::vector<std::pair<PHLMONITORREF, SDMABUFTranche>> tranches);
-    ~CDMABUFFormatTable();
+    ~CDMABUFFormatTable() = default;
 
-    int                                                   tableFD   = -1;
+    Hyprutils::OS::CFileDescriptor                        tableFD;
     size_t                                                tableSize = 0;
     SDMABUFTranche                                        rendererTranche;
     std::vector<std::pair<PHLMONITORREF, SDMABUFTranche>> monitorTranches;

--- a/src/protocols/LinuxDMABUF.hpp
+++ b/src/protocols/LinuxDMABUF.hpp
@@ -108,7 +108,7 @@ class CLinuxDMABUFResource {
 class CLinuxDMABufV1Protocol : public IWaylandProtocol {
   public:
     CLinuxDMABufV1Protocol(const wl_interface* iface, const int& ver, const std::string& name);
-    ~CLinuxDMABufV1Protocol();
+    ~CLinuxDMABufV1Protocol() = default;
 
     virtual void bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id);
     void         updateScanoutTranche(SP<CWLSurfaceResource> surface, PHLMONITOR pMonitor);
@@ -129,7 +129,7 @@ class CLinuxDMABufV1Protocol : public IWaylandProtocol {
 
     UP<CDMABUFFormatTable>                        formatTable;
     dev_t                                         mainDevice;
-    int                                           mainDeviceFD = -1;
+    Hyprutils::OS::CFileDescriptor                mainDeviceFD;
 
     friend class CLinuxDMABUFResource;
     friend class CLinuxDMABUFFeedbackResource;

--- a/src/protocols/PrimarySelection.hpp
+++ b/src/protocols/PrimarySelection.hpp
@@ -5,6 +5,7 @@
 #include "WaylandProtocol.hpp"
 #include "primary-selection-unstable-v1.hpp"
 #include "types/DataDevice.hpp"
+#include <hyprutils/os/FileDescriptor.hpp>
 
 class CPrimarySelectionOffer;
 class CPrimarySelectionSource;
@@ -38,7 +39,7 @@ class CPrimarySelectionSource : public IDataSource {
     bool                               good();
 
     virtual std::vector<std::string>   mimes();
-    virtual void                       send(const std::string& mime, uint32_t fd);
+    virtual void                       send(const std::string& mime, Hyprutils::OS::CFileDescriptor fd);
     virtual void                       accepted(const std::string& mime);
     virtual void                       cancelled();
     virtual void                       error(uint32_t code, const std::string& msg);

--- a/src/protocols/SecurityContext.hpp
+++ b/src/protocols/SecurityContext.hpp
@@ -4,19 +4,20 @@
 #include <cstdint>
 #include "WaylandProtocol.hpp"
 #include "security-context-v1.hpp"
+#include <hyprutils/os/FileDescriptor.hpp>
 
 class CSecurityContext {
   public:
     CSecurityContext(SP<CWpSecurityContextV1> resource_, int listenFD_, int closeFD_);
     ~CSecurityContext();
 
-    bool        good();
+    bool                           good();
 
-    std::string sandboxEngine, appID, instanceID;
-    int         listenFD = -1, closeFD = -1;
+    std::string                    sandboxEngine, appID, instanceID;
+    Hyprutils::OS::CFileDescriptor listenFD, closeFD;
 
-    void        onListen(uint32_t mask);
-    void        onClose(uint32_t mask);
+    void                           onListen(uint32_t mask);
+    void                           onClose(uint32_t mask);
 
   private:
     SP<CWpSecurityContextV1> resource;
@@ -44,7 +45,7 @@ struct SCSecurityContextSandboxedClientDestroyWrapper {
 
 class CSecurityContextSandboxedClient {
   public:
-    static SP<CSecurityContextSandboxedClient> create(int clientFD);
+    static SP<CSecurityContextSandboxedClient> create(Hyprutils::OS::CFileDescriptor clientFD);
     ~CSecurityContextSandboxedClient();
 
     void                                           onDestroy();
@@ -52,10 +53,10 @@ class CSecurityContextSandboxedClient {
     SCSecurityContextSandboxedClientDestroyWrapper destroyListener;
 
   private:
-    CSecurityContextSandboxedClient(int clientFD_);
+    CSecurityContextSandboxedClient(Hyprutils::OS::CFileDescriptor clientFD_);
 
-    wl_client* client   = nullptr;
-    int        clientFD = -1;
+    wl_client*                     client = nullptr;
+    Hyprutils::OS::CFileDescriptor clientFD;
 
     friend class CSecurityContextProtocol;
     friend class CSecurityContext;

--- a/src/protocols/VirtualKeyboard.hpp
+++ b/src/protocols/VirtualKeyboard.hpp
@@ -5,6 +5,7 @@
 #include "WaylandProtocol.hpp"
 #include "virtual-keyboard-unstable-v1.hpp"
 #include "../helpers/signal/Signal.hpp"
+#include <hyprutils/os/FileDescriptor.hpp>
 
 class CVirtualKeyboardV1Resource {
   public:

--- a/src/protocols/core/DataDevice.hpp
+++ b/src/protocols/core/DataDevice.hpp
@@ -16,6 +16,7 @@
 #include "../../helpers/signal/Signal.hpp"
 #include "../../helpers/math/Math.hpp"
 #include "../types/DataDevice.hpp"
+#include <hyprutils/os/FileDescriptor.hpp>
 
 class CWLDataDeviceResource;
 class CWLDataDeviceManagerResource;
@@ -63,7 +64,7 @@ class CWLDataSourceResource : public IDataSource {
     bool                             good();
 
     virtual std::vector<std::string> mimes();
-    virtual void                     send(const std::string& mime, uint32_t fd);
+    virtual void                     send(const std::string& mime, Hyprutils::OS::CFileDescriptor fd);
     virtual void                     accepted(const std::string& mime);
     virtual void                     cancelled();
     virtual bool                     hasDnd();

--- a/src/protocols/core/Shm.hpp
+++ b/src/protocols/core/Shm.hpp
@@ -7,6 +7,8 @@
      - wl_buffer with shm
 */
 
+#include <hyprutils/os/FileDescriptor.hpp>
+#include <memory>
 #include <vector>
 #include <cstdint>
 #include "../WaylandProtocol.hpp"
@@ -18,14 +20,14 @@ class CWLSHMPoolResource;
 
 class CSHMPool {
   public:
-    CSHMPool(int fd, size_t size);
+    CSHMPool(Hyprutils::OS::CFileDescriptor fd, size_t size);
     ~CSHMPool();
 
-    int    fd   = 0;
-    size_t size = 0;
-    void*  data = nullptr;
+    Hyprutils::OS::CFileDescriptor fd;
+    size_t                         size = 0;
+    void*                          data = nullptr;
 
-    void   resize(size_t size);
+    void                           resize(size_t size);
 };
 
 class CWLSHMBuffer : public IHLBuffer {
@@ -57,7 +59,7 @@ class CWLSHMBuffer : public IHLBuffer {
 
 class CWLSHMPoolResource {
   public:
-    CWLSHMPoolResource(SP<CWlShmPool> resource_, int fd, size_t size);
+    CWLSHMPoolResource(SP<CWlShmPool> resource_, Hyprutils::OS::CFileDescriptor fd, size_t size);
 
     bool                   good();
 

--- a/src/protocols/types/DataDevice.hpp
+++ b/src/protocols/types/DataDevice.hpp
@@ -7,6 +7,7 @@
 #include <wayland-server-protocol.h>
 #include "../../helpers/memory/Memory.hpp"
 #include "../../helpers/math/Math.hpp"
+#include <hyprutils/os/FileDescriptor.hpp>
 
 class CWLDataOfferResource;
 class CX11DataOffer;
@@ -24,10 +25,10 @@ class IDataSource {
     IDataSource()          = default;
     virtual ~IDataSource() = default;
 
-    virtual std::vector<std::string> mimes()                                    = 0;
-    virtual void                     send(const std::string& mime, uint32_t fd) = 0;
-    virtual void                     accepted(const std::string& mime)          = 0;
-    virtual void                     cancelled()                                = 0;
+    virtual std::vector<std::string> mimes()                                                          = 0;
+    virtual void                     send(const std::string& mime, Hyprutils::OS::CFileDescriptor fd) = 0;
+    virtual void                     accepted(const std::string& mime)                                = 0;
+    virtual void                     cancelled()                                                      = 0;
     virtual bool                     hasDnd();
     virtual bool                     dndDone();
     virtual void                     sendDndFinished();

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -302,11 +302,11 @@ CHyprOpenGLImpl::CHyprOpenGLImpl() : m_iDRMFD(g_pCompositor->m_iDRMFD) {
         Debug::log(WARN, "EGL: EXT_platform_device or EGL_EXT_device_query not supported, using gbm");
         if (EGLEXTENSIONS.contains("KHR_platform_gbm")) {
             success  = true;
-            m_iGBMFD = openRenderNode(m_iDRMFD);
-            if (m_iGBMFD < 0)
+            m_iGBMFD = CFileDescriptor{openRenderNode(m_iDRMFD)};
+            if (!m_iGBMFD.isValid())
                 RASSERT(false, "Couldn't open a gbm fd");
 
-            m_pGbmDevice = gbm_create_device(m_iGBMFD);
+            m_pGbmDevice = gbm_create_device(m_iGBMFD.get());
             if (!m_pGbmDevice)
                 RASSERT(false, "Couldn't open a gbm device");
 
@@ -372,9 +372,6 @@ CHyprOpenGLImpl::~CHyprOpenGLImpl() {
 
     if (m_pGbmDevice)
         gbm_device_destroy(m_pGbmDevice);
-
-    if (m_iGBMFD >= 0)
-        close(m_iGBMFD);
 }
 
 std::optional<std::vector<uint64_t>> CHyprOpenGLImpl::getModsForFormat(EGLint format) {

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -24,6 +24,7 @@
 #include <EGL/eglext.h>
 #include <GLES2/gl2ext.h>
 #include <aquamarine/buffer/Buffer.hpp>
+#include <hyprutils/os/FileDescriptor.hpp>
 
 #include "../debug/TracyDefines.hpp"
 
@@ -146,15 +147,15 @@ class CEGLSync {
   public:
     ~CEGLSync();
 
-    EGLSyncKHR sync = nullptr;
+    EGLSyncKHR                      sync = nullptr;
 
-    int        fd();
-    bool       wait();
+    Hyprutils::OS::CFileDescriptor& fd();
+    bool                            wait();
 
   private:
     CEGLSync() = default;
 
-    int m_iFd = -1;
+    Hyprutils::OS::CFileDescriptor m_iFd;
 
     friend class CHyprOpenGLImpl;
 };
@@ -228,7 +229,7 @@ class CHyprOpenGLImpl {
     uint32_t                             getPreferredReadFormat(PHLMONITOR pMonitor);
     std::vector<SDRMFormat>              getDRMFormats();
     EGLImageKHR                          createEGLImage(const Aquamarine::SDMABUFAttrs& attrs);
-    SP<CEGLSync>                         createEGLSync(int fenceFD);
+    SP<CEGLSync>                         createEGLSync(Hyprutils::OS::CFileDescriptor fenceFD);
     bool                                 waitForTimelinePoint(SP<CSyncTimeline> timeline, uint64_t point);
 
     SCurrentRenderData                   m_RenderData;

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -236,7 +236,7 @@ class CHyprOpenGLImpl {
 
     GLint                                m_iCurrentOutputFb = 0;
 
-    int                                  m_iGBMFD       = -1;
+    Hyprutils::OS::CFileDescriptor       m_iGBMFD;
     gbm_device*                          m_pGbmDevice   = nullptr;
     EGLContext                           m_pEglContext  = nullptr;
     EGLDisplay                           m_pEglDisplay  = nullptr;

--- a/src/xwayland/Dnd.cpp
+++ b/src/xwayland/Dnd.cpp
@@ -7,6 +7,8 @@
 #include "../managers/XWaylandManager.hpp"
 #include "../desktop/WLSurface.hpp"
 
+using namespace Hyprutils::OS;
+
 #ifndef NO_XWAYLAND
 static xcb_atom_t dndActionToAtom(uint32_t actions) {
     if (actions & WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY)
@@ -172,7 +174,7 @@ std::vector<std::string> CX11DataSource::mimes() {
     return mimeTypes;
 }
 
-void CX11DataSource::send(const std::string& mime, uint32_t fd) {
+void CX11DataSource::send(const std::string& mime, CFileDescriptor fd) {
     ;
 }
 

--- a/src/xwayland/Dnd.hpp
+++ b/src/xwayland/Dnd.hpp
@@ -2,6 +2,7 @@
 
 #include "../protocols/types/DataDevice.hpp"
 #include <wayland-server-protocol.h>
+#include <hyprutils/os/FileDescriptor.hpp>
 
 #define XDND_VERSION 5
 
@@ -35,7 +36,7 @@ class CX11DataSource : public IDataSource {
     ~CX11DataSource() = default;
 
     virtual std::vector<std::string> mimes();
-    virtual void                     send(const std::string& mime, uint32_t fd);
+    virtual void                     send(const std::string& mime, Hyprutils::OS::CFileDescriptor fd);
     virtual void                     accepted(const std::string& mime);
     virtual void                     cancelled();
     virtual bool                     hasDnd();

--- a/src/xwayland/Server.cpp
+++ b/src/xwayland/Server.cpp
@@ -24,70 +24,41 @@
 #include "../defines.hpp"
 #include "../Compositor.hpp"
 #include "../managers/CursorManager.hpp"
+using namespace Hyprutils::OS;
 
 // Constants
-constexpr int SOCKET_DIR_PERMISSIONS = 0755;
-constexpr int SOCKET_BACKLOG         = 1;
-constexpr int MAX_SOCKET_RETRIES     = 32;
-constexpr int LOCK_FILE_MODE         = 0444;
+constexpr int          SOCKET_DIR_PERMISSIONS = 0755;
+constexpr int          SOCKET_BACKLOG         = 1;
+constexpr int          MAX_SOCKET_RETRIES     = 32;
+constexpr int          LOCK_FILE_MODE         = 0444;
 
-static bool   setCloseOnExec(int fd, bool cloexec) {
-    int flags = fcntl(fd, F_GETFD);
-    if (flags == -1) {
-        Debug::log(ERR, "fcntl failed");
-        return false;
-    }
-
-    if (cloexec)
-        flags = flags | FD_CLOEXEC;
-    else
-        flags = flags & ~FD_CLOEXEC;
-
-    if (fcntl(fd, F_SETFD, flags) == -1) {
-        Debug::log(ERR, "fcntl failed");
-        return false;
-    }
-
-    return true;
-}
-
-static void cleanUpSocket(int fd, const char* path) {
-    close(fd);
-    if (path[0])
-        unlink(path);
-}
-
-static inline void closeSocketSafely(int& fd) {
-    if (fd >= 0)
-        close(fd);
-}
-
-static int createSocket(struct sockaddr_un* addr, size_t path_size) {
-    socklen_t size = offsetof(struct sockaddr_un, sun_path) + path_size + 1;
-    int       fd   = socket(AF_UNIX, SOCK_STREAM, 0);
-    if (fd < 0) {
+static CFileDescriptor createSocket(struct sockaddr_un* addr, size_t path_size) {
+    socklen_t       size = offsetof(struct sockaddr_un, sun_path) + path_size + 1;
+    CFileDescriptor fd{socket(AF_UNIX, SOCK_STREAM, 0)};
+    if (!fd.isValid()) {
         Debug::log(ERR, "Failed to create socket {}{}", addr->sun_path[0] ? addr->sun_path[0] : '@', addr->sun_path + 1);
-        return -1;
+        return {};
     }
 
-    if (!setCloseOnExec(fd, true)) {
-        close(fd);
-        return -1;
+    if (!fd.setFlags(fd.getFlags() | FD_CLOEXEC)) {
+        return {};
     }
 
     if (addr->sun_path[0])
         unlink(addr->sun_path);
 
-    if (bind(fd, (struct sockaddr*)addr, size) < 0) {
+    if (bind(fd.get(), (struct sockaddr*)addr, size) < 0) {
         Debug::log(ERR, "Failed to bind socket {}{}", addr->sun_path[0] ? addr->sun_path[0] : '@', addr->sun_path + 1);
-        cleanUpSocket(fd, addr->sun_path);
-        return -1;
+        if (addr->sun_path[0])
+            unlink(addr->sun_path);
+        return {};
     }
 
-    if (listen(fd, SOCKET_BACKLOG) < 0) {
+    if (listen(fd.get(), SOCKET_BACKLOG) < 0) {
         Debug::log(ERR, "Failed to listen to socket {}{}", addr->sun_path[0] ? addr->sun_path[0] : '@', addr->sun_path + 1);
-        cleanUpSocket(fd, addr->sun_path);
-        return -1;
+        if (addr->sun_path[0])
+            unlink(addr->sun_path);
+        return {};
     }
 
     return fd;
@@ -141,7 +112,7 @@ static std::string getSocketPath(int display, bool isLinux) {
     return std::format("/tmp/.X11-unix/X{}_", display);
 }
 
-static bool openSockets(std::array<int, 2>& sockets, int display) {
+static bool openSockets(std::array<CFileDescriptor, 2>& sockets, int display) {
     if (!ensureSocketDirExists())
         return false;
 
@@ -151,17 +122,16 @@ static bool openSockets(std::array<int, 2>& sockets, int display) {
     path = getSocketPath(display, false);
     strncpy(addr.sun_path, path.c_str(), path.length() + 1);
 
-    sockets[0] = createSocket(&addr, path.length());
-    if (sockets[0] < 0)
+    sockets[0] = CFileDescriptor{createSocket(&addr, path.length())};
+    if (!sockets[0].isValid())
         return false;
 
     path = getSocketPath(display, true);
     strncpy(addr.sun_path, path.c_str(), path.length() + 1);
 
-    sockets[1] = createSocket(&addr, path.length());
-    if (sockets[1] < 0) {
-        close(sockets[0]);
-        sockets[0] = -1;
+    sockets[1] = CFileDescriptor{createSocket(&addr, path.length())};
+    if (!sockets[1].isValid()) {
+        sockets[0].reset();
         return false;
     }
 
@@ -174,7 +144,8 @@ static void startServer(void* data) {
 }
 
 static int xwaylandReady(int fd, uint32_t mask, void* data) {
-    return g_pXWayland->pServer->ready(fd, mask);
+    CFileDescriptor xwlFd{fd};
+    return g_pXWayland->pServer->ready(std::move(xwlFd), mask);
 }
 
 static bool safeRemove(const std::string& path) {
@@ -186,38 +157,34 @@ static bool safeRemove(const std::string& path) {
 
 bool CXWaylandServer::tryOpenSockets() {
     for (size_t i = 0; i <= MAX_SOCKET_RETRIES; ++i) {
-        std::string lockPath = std::format("/tmp/.X{}-lock", i);
+        std::string     lockPath = std::format("/tmp/.X{}-lock", i);
 
-        int         fd = open(lockPath.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, LOCK_FILE_MODE);
-        if (fd >= 0) {
+        CFileDescriptor fd{open(lockPath.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, LOCK_FILE_MODE)};
+        if (fd.isValid()) {
             // we managed to open the lock
             if (!openSockets(xFDs, i)) {
                 safeRemove(lockPath);
-                close(fd);
                 continue;
             }
 
             const std::string pidStr = std::to_string(getpid());
-            if (write(fd, pidStr.c_str(), pidStr.length()) != (long)pidStr.length()) {
+            if (write(fd.get(), pidStr.c_str(), pidStr.length()) != (long)pidStr.length()) {
                 safeRemove(lockPath);
-                close(fd);
                 continue;
             }
 
-            close(fd);
             display     = i;
             displayName = std::format(":{}", display);
             break;
         }
 
-        fd = open(lockPath.c_str(), O_RDONLY | O_CLOEXEC);
+        fd = CFileDescriptor{open(lockPath.c_str(), O_RDONLY | O_CLOEXEC)};
 
-        if (fd < 0)
+        if (!fd.isValid())
             continue;
 
         char pidstr[12] = {0};
-        read(fd, pidstr, sizeof(pidstr) - 1);
-        close(fd);
+        read(fd.get(), pidstr, sizeof(pidstr) - 1);
 
         int32_t pid = 0;
         try {
@@ -249,9 +216,6 @@ CXWaylandServer::~CXWaylandServer() {
     if (display < 0)
         return;
 
-    closeSocketSafely(xFDs[0]);
-    closeSocketSafely(xFDs[1]);
-
     std::string lockPath = std::format("/tmp/.X{}-lock", display);
     safeRemove(lockPath);
 
@@ -277,21 +241,11 @@ void CXWaylandServer::die() {
     if (pipeSource)
         wl_event_source_remove(pipeSource);
 
-    if (pipeFd >= 0)
-        close(pipeFd);
-
-    closeSocketSafely(waylandFDs[0]);
-    closeSocketSafely(waylandFDs[1]);
-    closeSocketSafely(xwmFDs[0]);
-    closeSocketSafely(xwmFDs[1]);
-
     // possible crash. Better to leak a bit.
     //if (xwaylandClient)
     //    wl_client_destroy(xwaylandClient);
 
     xwaylandClient = nullptr;
-    waylandFDs     = {-1, -1};
-    xwmFDs         = {-1, -1};
 }
 
 bool CXWaylandServer::create() {
@@ -307,15 +261,17 @@ bool CXWaylandServer::create() {
     return true;
 }
 
-void CXWaylandServer::runXWayland(int notifyFD) {
-    if (!setCloseOnExec(xFDs[0], false) || !setCloseOnExec(xFDs[1], false) || !setCloseOnExec(waylandFDs[1], false) || !setCloseOnExec(xwmFDs[1], false)) {
+void CXWaylandServer::runXWayland(CFileDescriptor& notifyFD) {
+    if (!xFDs[0].setFlags(xFDs[0].getFlags() & ~FD_CLOEXEC) || !xFDs[1].setFlags(xFDs[1].getFlags() & ~FD_CLOEXEC) ||
+        !waylandFDs[1].setFlags(waylandFDs[1].getFlags() & ~FD_CLOEXEC) || !xwmFDs[1].setFlags(xwmFDs[1].getFlags() & ~FD_CLOEXEC)) {
         Debug::log(ERR, "Failed to unset cloexec on fds");
         _exit(EXIT_FAILURE);
     }
 
-    auto cmd = std::format("Xwayland {} -rootless -core -listenfd {} -listenfd {} -displayfd {} -wm {}", displayName, xFDs[0], xFDs[1], notifyFD, xwmFDs[1]);
+    auto cmd =
+        std::format("Xwayland {} -rootless -core -listenfd {} -listenfd {} -displayfd {} -wm {}", displayName, xFDs[0].get(), xFDs[1].get(), notifyFD.get(), xwmFDs[1].get());
 
-    auto waylandSocket = std::format("{}", waylandFDs[1]);
+    auto waylandSocket = std::format("{}", waylandFDs[1].get());
     setenv("WAYLAND_SOCKET", waylandSocket.c_str(), true);
 
     Debug::log(LOG, "Starting XWayland with \"{}\", bon voyage!", cmd);
@@ -327,40 +283,46 @@ void CXWaylandServer::runXWayland(int notifyFD) {
 }
 
 bool CXWaylandServer::start() {
-    idleSource = nullptr;
-
-    if (socketpair(AF_UNIX, SOCK_STREAM, 0, waylandFDs.data()) != 0) {
+    idleSource    = nullptr;
+    int wlPair[2] = {-1, -1};
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, wlPair) != 0) {
         Debug::log(ERR, "socketpair failed (1)");
         die();
         return false;
     }
+    waylandFDs[0] = CFileDescriptor{wlPair[0]};
+    waylandFDs[1] = CFileDescriptor{wlPair[1]};
 
-    if (!setCloseOnExec(waylandFDs[0], true) || !setCloseOnExec(waylandFDs[1], true)) {
+    if (!waylandFDs[0].setFlags(waylandFDs[0].getFlags() | FD_CLOEXEC) || !waylandFDs[1].setFlags(waylandFDs[1].getFlags() | FD_CLOEXEC)) {
         Debug::log(ERR, "set_cloexec failed (1)");
         die();
         return false;
     }
 
-    if (socketpair(AF_UNIX, SOCK_STREAM, 0, xwmFDs.data()) != 0) {
+    int xwmPair[2] = {-1, -1};
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, xwmPair) != 0) {
         Debug::log(ERR, "socketpair failed (2)");
         die();
         return false;
     }
 
-    if (!setCloseOnExec(xwmFDs[0], true) || !setCloseOnExec(xwmFDs[1], true)) {
+    xwmFDs[0] = CFileDescriptor{xwmPair[0]};
+    xwmFDs[1] = CFileDescriptor{xwmPair[1]};
+
+    if (!xwmFDs[0].setFlags(xwmFDs[0].getFlags() | FD_CLOEXEC) || !xwmFDs[1].setFlags(xwmFDs[1].getFlags() | FD_CLOEXEC)) {
         Debug::log(ERR, "set_cloexec failed (2)");
         die();
         return false;
     }
 
-    xwaylandClient = wl_client_create(g_pCompositor->m_sWLDisplay, waylandFDs[0]);
+    xwaylandClient = wl_client_create(g_pCompositor->m_sWLDisplay, waylandFDs[0].get());
     if (!xwaylandClient) {
         Debug::log(ERR, "wl_client_create failed");
         die();
         return false;
     }
 
-    waylandFDs[0] = -1;
+    waylandFDs[0].take(); // does this leak?
 
     int notify[2] = {-1, -1};
     if (pipe(notify) < 0) {
@@ -369,22 +331,20 @@ bool CXWaylandServer::start() {
         return false;
     }
 
-    if (!setCloseOnExec(notify[0], true)) {
+    CFileDescriptor notifyFds[2] = {CFileDescriptor{notify[0]}, CFileDescriptor{notify[1]}};
+
+    if (!notifyFds[0].setFlags(notifyFds[0].getFlags() | FD_CLOEXEC)) {
         Debug::log(ERR, "set_cloexec failed (3)");
-        close(notify[0]);
-        close(notify[1]);
         die();
         return false;
     }
 
-    pipeSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, notify[0], WL_EVENT_READABLE, ::xwaylandReady, nullptr);
-    pipeFd     = notify[0];
+    pipeSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, notifyFds[0].get(), WL_EVENT_READABLE, ::xwaylandReady, nullptr);
+    pipeFd     = std::move(notifyFds[0]);
 
     serverPID = fork();
     if (serverPID < 0) {
         Debug::log(ERR, "fork failed");
-        close(notify[0]);
-        close(notify[1]);
         die();
         return false;
     } else if (serverPID == 0) {
@@ -393,25 +353,19 @@ bool CXWaylandServer::start() {
             Debug::log(ERR, "second fork failed");
             _exit(1);
         } else if (pid == 0)
-            runXWayland(notify[1]);
+            runXWayland(notifyFds[1]);
 
         _exit(0);
     }
 
-    close(notify[1]);
-    close(waylandFDs[1]);
-    closeSocketSafely(xwmFDs[1]);
-    waylandFDs[1] = -1;
-    xwmFDs[1]     = -1;
-
     return true;
 }
 
-int CXWaylandServer::ready(int fd, uint32_t mask) {
+int CXWaylandServer::ready(CFileDescriptor fd, uint32_t mask) {
     if (mask & WL_EVENT_READABLE) {
         // xwayland writes twice
         char    buf[64];
-        ssize_t n = read(fd, buf, sizeof(buf));
+        ssize_t n = read(fd.get(), buf, sizeof(buf));
         if (n < 0 && errno != EINTR) {
             Debug::log(ERR, "Xwayland: read from displayFd failed");
             mask = 0;
@@ -436,7 +390,6 @@ int CXWaylandServer::ready(int fd, uint32_t mask) {
 
     Debug::log(LOG, "XWayland is ready");
 
-    close(fd);
     wl_event_source_remove(pipeSource);
     pipeSource = nullptr;
 

--- a/src/xwayland/Server.hpp
+++ b/src/xwayland/Server.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <hyprutils/os/FileDescriptor.hpp>
 #include "../helpers/signal/Signal.hpp"
 
 struct wl_event_source;
@@ -19,7 +20,7 @@ class CXWaylandServer {
     bool start();
 
     // called on ready
-    int  ready(int fd, uint32_t mask);
+    int  ready(Hyprutils::OS::CFileDescriptor fd, uint32_t mask);
 
     void die();
 
@@ -30,20 +31,20 @@ class CXWaylandServer {
     wl_client* xwaylandClient = nullptr;
 
   private:
-    bool                            tryOpenSockets();
-    void                            runXWayland(int notifyFD);
+    bool                                          tryOpenSockets();
+    void                                          runXWayland(Hyprutils::OS::CFileDescriptor& notifyFD);
 
-    pid_t                           serverPID = 0;
+    pid_t                                         serverPID = 0;
 
-    std::string                     displayName;
-    int                             display       = -1;
-    std::array<int, 2>              xFDs          = {-1, -1};
-    std::array<wl_event_source*, 2> xFDReadEvents = {nullptr, nullptr};
-    wl_event_source*                idleSource    = nullptr;
-    wl_event_source*                pipeSource    = nullptr;
-    int                             pipeFd        = -1;
-    std::array<int, 2>              xwmFDs        = {-1, -1};
-    std::array<int, 2>              waylandFDs    = {-1, -1};
+    std::string                                   displayName;
+    int                                           display = -1;
+    std::array<Hyprutils::OS::CFileDescriptor, 2> xFDs;
+    std::array<wl_event_source*, 2>               xFDReadEvents = {nullptr, nullptr};
+    wl_event_source*                              idleSource    = nullptr;
+    wl_event_source*                              pipeSource    = nullptr;
+    Hyprutils::OS::CFileDescriptor                pipeFd;
+    std::array<Hyprutils::OS::CFileDescriptor, 2> xwmFDs;
+    std::array<Hyprutils::OS::CFileDescriptor, 2> waylandFDs;
 
     friend class CXWM;
 };

--- a/src/xwayland/XDataSource.hpp
+++ b/src/xwayland/XDataSource.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../protocols/types/DataDevice.hpp"
+#include <hyprutils/os/FileDescriptor.hpp>
 
 struct SXSelection;
 
@@ -9,7 +10,7 @@ class CXDataSource : public IDataSource {
     CXDataSource(SXSelection&);
 
     virtual std::vector<std::string> mimes();
-    virtual void                     send(const std::string& mime, uint32_t fd);
+    virtual void                     send(const std::string& mime, Hyprutils::OS::CFileDescriptor fd);
     virtual void                     accepted(const std::string& mime);
     virtual void                     cancelled();
     virtual void                     error(uint32_t code, const std::string& msg);

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -17,6 +17,7 @@
 #include "../managers/SeatManager.hpp"
 #include "../protocols/XWaylandShell.hpp"
 #include "../protocols/core/Compositor.hpp"
+using namespace Hyprutils::OS;
 
 #define XCB_EVENT_RESPONSE_TYPE_MASK 0x7f
 #define INCR_CHUNK_SIZE              (64 * 1024)
@@ -1180,13 +1181,12 @@ void CXWM::getTransferData(SXSelection& sel) {
 
     if (sel.transfer->propertyReply->type == HYPRATOMS["INCR"]) {
         Debug::log(ERR, "[xwm] Transfer is INCR, which we don't support :(");
-        close(sel.transfer->wlFD);
         sel.transfer.reset();
         return;
     } else {
         sel.onWrite();
         if (sel.transfer)
-            sel.transfer->eventSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, sel.transfer->wlFD, WL_EVENT_WRITABLE, ::writeDataSource, &sel);
+            sel.transfer->eventSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, sel.transfer->wlFD.get(), WL_EVENT_WRITABLE, ::writeDataSource, &sel);
     }
 }
 
@@ -1361,13 +1361,13 @@ bool SXSelection::sendData(xcb_selection_request_event_t* e, std::string mime) {
     // the wayland client might not expect a non-blocking fd
     // fcntl(p[1], F_SETFL, O_NONBLOCK);
 
-    transfer->wlFD = p[0];
+    transfer->wlFD = CFileDescriptor{p[0]};
 
     Debug::log(LOG, "[xwm] sending wayland selection to xwayland with mime {}, target {}, fds {} {}", mime, e->target, p[0], p[1]);
 
-    selection->send(mime, p[1]);
+    selection->send(mime, CFileDescriptor{p[1]});
 
-    transfer->eventSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, transfer->wlFD, WL_EVENT_READABLE, ::readDataSource, this);
+    transfer->eventSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, transfer->wlFD.get(), WL_EVENT_READABLE, ::readDataSource, this);
 
     return true;
 }
@@ -1376,10 +1376,9 @@ int SXSelection::onWrite() {
     char*   property  = (char*)xcb_get_property_value(transfer->propertyReply);
     int     remainder = xcb_get_property_value_length(transfer->propertyReply) - transfer->propertyStart;
 
-    ssize_t len = write(transfer->wlFD, property + transfer->propertyStart, remainder);
+    ssize_t len = write(transfer->wlFD.get(), property + transfer->propertyStart, remainder);
     if (len == -1) {
         Debug::log(ERR, "[xwm] write died in transfer get");
-        close(transfer->wlFD);
         transfer.reset();
         return 0;
     }
@@ -1389,7 +1388,6 @@ int SXSelection::onWrite() {
         Debug::log(LOG, "[xwm] wl client read partially: len {}", len);
     } else {
         Debug::log(LOG, "[xwm] cb transfer to wl client complete, read {} bytes", len);
-        close(transfer->wlFD);
         transfer.reset();
     }
 
@@ -1397,8 +1395,6 @@ int SXSelection::onWrite() {
 }
 
 SXTransfer::~SXTransfer() {
-    if (wlFD)
-        close(wlFD);
     if (eventSource)
         wl_event_source_remove(eventSource);
     if (incomingWindow)

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -884,7 +884,7 @@ void CXWM::getRenderFormat() {
     free(reply);
 }
 
-CXWM::CXWM() : connection(g_pXWayland->pServer->xwmFDs[0]) {
+CXWM::CXWM() : connection(g_pXWayland->pServer->xwmFDs[0].get()) {
 
     if (connection.hasError()) {
         Debug::log(ERR, "[xwm] Couldn't start, error {}", connection.hasError());
@@ -902,7 +902,7 @@ CXWM::CXWM() : connection(g_pXWayland->pServer->xwmFDs[0]) {
     xcb_screen_iterator_t screen_iterator = xcb_setup_roots_iterator(xcb_get_setup(connection));
     screen                                = screen_iterator.data;
 
-    eventSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, g_pXWayland->pServer->xwmFDs[0], WL_EVENT_READABLE, ::onX11Event, nullptr);
+    eventSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, g_pXWayland->pServer->xwmFDs[0].get(), WL_EVENT_READABLE, ::onX11Event, nullptr);
     wl_event_source_check(eventSource);
 
     gatherResources();

--- a/src/xwayland/XWM.hpp
+++ b/src/xwayland/XWM.hpp
@@ -10,6 +10,7 @@
 #include <xcb/xfixes.h>
 #include <xcb/composite.h>
 #include <xcb/xcb_errors.h>
+#include <hyprutils/os/FileDescriptor.hpp>
 
 struct wl_event_source;
 class CXWaylandSurfaceResource;
@@ -18,25 +19,25 @@ struct SXSelection;
 struct SXTransfer {
     ~SXTransfer();
 
-    SXSelection&                  selection;
-    bool                          out = true;
+    SXSelection&                   selection;
+    bool                           out = true;
 
-    bool                          incremental   = false;
-    bool                          flushOnDelete = false;
-    bool                          propertySet   = false;
+    bool                           incremental   = false;
+    bool                           flushOnDelete = false;
+    bool                           propertySet   = false;
 
-    int                           wlFD        = -1;
-    wl_event_source*              eventSource = nullptr;
+    Hyprutils::OS::CFileDescriptor wlFD;
+    wl_event_source*               eventSource = nullptr;
 
-    std::vector<uint8_t>          data;
+    std::vector<uint8_t>           data;
 
-    xcb_selection_request_event_t request;
+    xcb_selection_request_event_t  request;
 
-    int                           propertyStart;
-    xcb_get_property_reply_t*     propertyReply;
-    xcb_window_t                  incomingWindow;
+    int                            propertyStart;
+    xcb_get_property_reply_t*      propertyReply;
+    xcb_window_t                   incomingWindow;
 
-    bool                          getIncomingSelectionProp(bool erase);
+    bool                           getIncomingSelectionProp(bool erase);
 };
 
 struct SXSelection {


### PR DESCRIPTION
its big, it touches many things. and it can be sneaky if fd's suddenly close at wrong time or begins rampantly leaking. so this warrants some testing. and reviewing.

this moves most fd handling over to CFileDescriptor while leaving the bits that is intertwined with aquamarine. the aquamarine bits is for future PR. IKeyboard also got a few lines of seemingly dead code removed unless the intention there originally was something else.