### PR TITLE
keybinds: add HDR dispatcher

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -137,6 +137,7 @@ CKeybindManager::CKeybindManager() {
     m_mDispatchers["event"]                          = event;
     m_mDispatchers["global"]                         = global;
     m_mDispatchers["setprop"]                        = setProp;
+    m_mDispatchers["hdr"]                            = hdr;
 
     m_tScrollTimer.reset();
 
@@ -3164,6 +3165,15 @@ SDispatchResult CKeybindManager::setProp(std::string args) {
 
     for (auto const& m : g_pCompositor->m_vMonitors)
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m->ID);
+
+    return {};
+}
+
+SDispatchResult CKeybindManager::hdr(std::string arg) {
+    if (arg.starts_with("toggle"))
+        g_pHyprRenderer->m_bHDR = !g_pHyprRenderer->m_bHDR;
+    else
+        g_pHyprRenderer->m_bHDR = arg.starts_with("on");
 
     return {};
 }

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -221,6 +221,7 @@ class CKeybindManager {
     static SDispatchResult global(std::string);
     static SDispatchResult event(std::string);
     static SDispatchResult setProp(std::string);
+    static SDispatchResult hdr(std::string);
 
     friend class CCompositor;
     friend class CInputManager;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1480,11 +1480,11 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
                     SURF->colorManagement->setHDRMetadata(createHDRMetadata(SURF->colorManagement.get()->imageDescription(), pMonitor->output->parsedEDID));
                 if (needsHdrMetadataUpdate)
                     pMonitor->output->state->setHDRMetadata(SURF->colorManagement->hdrMetadata());
-            } else if ((pMonitor->output->state->state().hdrMetadata.hdmi_metadata_type1.eotf == 2) != *PHDR)
+            } else if ((pMonitor->output->state->state().hdrMetadata.hdmi_metadata_type1.eotf == 2) != *PHDR || m_bHDR)
                 pMonitor->output->state->setHDRMetadata(*PHDR ? createHDRMetadata(2, pMonitor->output->parsedEDID) : createHDRMetadata(0, pMonitor->output->parsedEDID));
             pMonitor->m_previousFSWindow = WINDOW;
         } else {
-            if ((pMonitor->output->state->state().hdrMetadata.hdmi_metadata_type1.eotf == 2) != *PHDR)
+            if ((pMonitor->output->state->state().hdrMetadata.hdmi_metadata_type1.eotf == 2) != *PHDR || m_bHDR)
                 pMonitor->output->state->setHDRMetadata(*PHDR ? createHDRMetadata(2, pMonitor->output->parsedEDID) : createHDRMetadata(0, pMonitor->output->parsedEDID));
             pMonitor->m_previousFSWindow.reset();
         }

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -64,6 +64,7 @@ class CHyprRenderer {
     bool shouldRenderCursor();
     void setCursorHidden(bool hide);
     void calculateUVForSurface(PHLWINDOW, SP<CWLSurfaceResource>, PHLMONITOR pMonitor, bool main = false, const Vector2D& projSize = {}, const Vector2D& projSizeUnscaled = {},
+
                                bool fixMisalignedFSV1 = false);
     std::tuple<float, float, float> getRenderTimes(PHLMONITOR pMonitor); // avg max min
     void                            renderLockscreen(PHLMONITOR pMonitor, timespec* now, const CBox& geometry);
@@ -89,6 +90,7 @@ class CHyprRenderer {
     void endRender();
 
     bool m_bBlockSurfaceFeedback = false;
+    bool m_bHDR                  = false;
     bool m_bRenderingSnapshot    = false;
     PHLMONITORREF                       m_pMostHzMonitor;
     bool                                m_bDirectScanoutBlocked = false;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Many thanks to @UjinT34 for all the work HDR and color management. I am still amazed by it (just got myself a new monitor), seeing this working is just great.

Currently I have no way of enabling HDR output. I am not sure if I am just holding it wrong, but an application requesting it does not seem to be good enough to put my screen in HDR mode.

In https://github.com/hyprwm/Hyprland/pull/9076, the if got added (before fullscreen enabled HDR):

```
if ((pMonitor->output->state->state().hdrMetadata.hdmi_metadata_type1.eotf == 2) != *PHDR)
  pMonitor->output->state->setHDRMetadata(*PHDR ? createHDRMetadata(2, pMonitor->output->parsedEDID) : createHDRMetadata(0, pMonitor->output->parsedEDID));
```

This is my first time looking at Hyprlands code, so I am far from fully understanding what is going on here. To me it looks like it is querying the monitor if it is in HDR mode. My monitor cannot be put in HDR mode manually, it must be done by software. Currently it fails to detect if the software is requesting HDR for whatever reason.

I added a `hdr` dispatcher, to force enable HDR mode. This does not only reliably enable and disable HDR for games etc, it also helps to test, profile and calibrate the monitor in HDR mode.

To use it, HDR must be enabled in Hyprland (`experimental.hdr`) and supported by the system. The dispatcher expects an argument which can either be `on`, `off` or `toggle`.

If merged, I will revise the WIKI as well.

<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

First time contributor, so maybe have an extra look. The change however, is very straight forward.

#### Is it ready for merging, or does it need work?

Ready to be merged.
