### PR TITLE
tablet: send `motion`s on tip events

### DIFF
--- a/src/managers/input/Tablets.cpp
+++ b/src/managers/input/Tablets.cpp
@@ -159,12 +159,13 @@ void CInputManager::onTabletAxis(CTablet::SAxisEvent e) {
 void CInputManager::onTabletTip(CTablet::STipEvent e) {
     const auto PTAB  = e.tablet;
     const auto PTOOL = ensureTabletToolPresent(e.tool);
+    const auto POS   = e.tip;
+    g_pPointerManager->warpAbsolute(POS, PTAB);
+    refocusTablet(PTAB, PTOOL, true);
 
-    if (e.in) {
-        simulateMouseMovement();
-        refocusTablet(PTAB, PTOOL);
+    if (e.in)
         PROTO::tablet->down(PTOOL);
-    } else
+    else
         PROTO::tablet->up(PTOOL);
 
     PTOOL->isDown = e.in;


### PR DESCRIPTION
Typically, the position of the tool tip also changes on tool tip events, so we should forward this update to the clients.

Otherwise, strokes can be too messy for tablets to be functional, even at moderate writing speeds.

Before:

https://github.com/user-attachments/assets/0317a98a-ff5a-483f-861e-131e1ef03f91

After:

https://github.com/user-attachments/assets/10eb961e-dd62-4e7e-8e6c-fd4c9d1ad96e

fixes #8751 .