### PR TITLE
xwayland: fix sending large clipboard data

### DIFF
--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -1163,6 +1163,11 @@ void CXWM::setClipboardToWayland(SXSelection& sel) {
     g_pSeatManager->setCurrentSelection(sel.dataSource);
 }
 
+static int writeDataSource(int fd, uint32_t mask, void* data) {
+    auto selection = (SXSelection*)data;
+    return selection->onWrite();
+}
+
 void CXWM::getTransferData(SXSelection& sel) {
     Debug::log(LOG, "[xwm] getTransferData");
 
@@ -1174,26 +1179,9 @@ void CXWM::getTransferData(SXSelection& sel) {
         sel.transfer.reset();
         return;
     } else {
-        char*   property  = (char*)xcb_get_property_value(sel.transfer->propertyReply);
-        int     remainder = xcb_get_property_value_length(sel.transfer->propertyReply) - sel.transfer->propertyStart;
-
-        ssize_t len = write(sel.transfer->wlFD, property + sel.transfer->propertyStart, remainder);
-        if (len == -1) {
-            Debug::log(ERR, "[xwm] write died in transfer get");
-            close(sel.transfer->wlFD);
-            sel.transfer.reset();
-            return;
-        }
-
-        if (len < remainder) {
-            sel.transfer->propertyStart += len;
-            Debug::log(ERR, "[xwm] wl client read partially: len {}", len);
-            return;
-        } else {
-            Debug::log(LOG, "[xwm] cb transfer to wl client complete, read {} bytes", len);
-            close(sel.transfer->wlFD);
-            sel.transfer.reset();
-        }
+        sel.onWrite();
+        if (sel.transfer)
+            sel.transfer->eventSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, sel.transfer->wlFD, WL_EVENT_WRITABLE, ::writeDataSource, &sel);
     }
 }
 
@@ -1355,7 +1343,8 @@ bool SXSelection::sendData(xcb_selection_request_event_t* e, std::string mime) {
     fcntl(p[0], F_SETFD, FD_CLOEXEC);
     fcntl(p[0], F_SETFL, O_NONBLOCK);
     fcntl(p[1], F_SETFD, FD_CLOEXEC);
-    fcntl(p[1], F_SETFL, O_NONBLOCK);
+    // the wayland client might not expect a non-blocking fd
+    // fcntl(p[1], F_SETFL, O_NONBLOCK);
 
     transfer->wlFD = p[0];
 
@@ -1366,6 +1355,30 @@ bool SXSelection::sendData(xcb_selection_request_event_t* e, std::string mime) {
     transfer->eventSource = wl_event_loop_add_fd(g_pCompositor->m_sWLEventLoop, transfer->wlFD, WL_EVENT_READABLE, ::readDataSource, this);
 
     return true;
+}
+
+int SXSelection::onWrite() {
+    char*   property  = (char*)xcb_get_property_value(transfer->propertyReply);
+    int     remainder = xcb_get_property_value_length(transfer->propertyReply) - transfer->propertyStart;
+
+    ssize_t len = write(transfer->wlFD, property + transfer->propertyStart, remainder);
+    if (len == -1) {
+        Debug::log(ERR, "[xwm] write died in transfer get");
+        close(transfer->wlFD);
+        transfer.reset();
+        return 0;
+    }
+
+    if (len < remainder) {
+        transfer->propertyStart += len;
+        Debug::log(LOG, "[xwm] wl client read partially: len {}", len);
+    } else {
+        Debug::log(LOG, "[xwm] cb transfer to wl client complete, read {} bytes", len);
+        close(transfer->wlFD);
+        transfer.reset();
+    }
+
+    return 1;
 }
 
 SXTransfer::~SXTransfer() {

--- a/src/xwayland/XWM.hpp
+++ b/src/xwayland/XWM.hpp
@@ -48,6 +48,7 @@ struct SXSelection {
     void             onSelection();
     bool             sendData(xcb_selection_request_event_t* e, std::string mime);
     int              onRead(int fd, uint32_t mask);
+    int              onWrite();
 
     struct {
         CHyprSignalListener setSelection;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Wayland to X11:
Wayland clients might not expect a non-blocking fd. e.g. KSystemClipboard in KGuiAddons (used by Flameshot) [uses a single write to the fd and doesn't check the return value](https://github.com/KDE/kguiaddons/blob/35e508e2061e4c3d843a4be986613fb3bc954835/src/systemclipboard/waylandclipboard.cpp#L379). If we pass a non-blocking fd, the write call will return early and result in partially transferred data.
This PR removes the O_NONBLOCK flag from the pipe fd passed to Wayland clients. Clients requiring non-blocking I/O can still set the flag themselves.

X11 to Wayland:
The fd received from Wayland clients [has O_NONBLOCK set](https://github.com/hyprwm/Hyprland/blob/ce48bc540824fcaefd777959703df9908e258d0a/src/xwayland/XDataSource.cpp#L83), but we only write to it once and error out if data is transferred partially. Instead we should use the Wayland event loop to keep writing to the fd until all data is transferred.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

INCR is still not implemented so the size of clipboard data is still limited by x11 request size, which is 16MB by default.

#### Is it ready for merging, or does it need work?

Y

