### PR TITLE
xwayland: fix clipboard mime name and atom mismatch

### DIFF
--- a/src/xwayland/XDataSource.cpp
+++ b/src/xwayland/XDataSource.cpp
@@ -34,7 +34,8 @@ CXDataSource::CXDataSource(SXSelection& sel_) : selection(sel_) {
                 continue;
 
             mimeTypes.push_back(type);
-        }
+        } else
+            continue;
 
         mimeAtoms.push_back(value[i]);
     }


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

The TARGETS and TIMESTAMP targets are skipped when processing the target list returned from X11 clipboard sources, but still added to the mimeAtoms list erroneously. As a result, the mimeAtoms and mimeTypes lists are out of sync and the target atom later passed to xcb_convert_selection will be incorrect if an mime type appearing after the aforementioned two targets is used.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

N/A

#### Is it ready for merging, or does it need work?

Y
