### PR TITLE
core: move all unique_ptrs from the STL to hyprutils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ find_package(OpenGL REQUIRED COMPONENTS ${GLES_VERSION})
 pkg_check_modules(aquamarine_dep REQUIRED IMPORTED_TARGET aquamarine>=0.4.5)
 pkg_check_modules(hyprlang_dep REQUIRED IMPORTED_TARGET hyprlang>=0.3.2)
 pkg_check_modules(hyprcursor_dep REQUIRED IMPORTED_TARGET hyprcursor>=0.1.7)
-pkg_check_modules(hyprutils_dep REQUIRED IMPORTED_TARGET hyprutils>=0.3.3)
+pkg_check_modules(hyprutils_dep REQUIRED IMPORTED_TARGET hyprutils>=0.4.0)
 pkg_check_modules(hyprgraphics_dep REQUIRED IMPORTED_TARGET hyprgraphics>=0.1.1)
 
 add_compile_definitions(AQUAMARINE_VERSION="${aquamarine_dep_VERSION}")

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -586,92 +586,92 @@ void CCompositor::initManagers(eManagersInitStage stage) {
     switch (stage) {
         case STAGE_PRIORITY: {
             Debug::log(LOG, "Creating the EventLoopManager!");
-            g_pEventLoopManager = std::make_unique<CEventLoopManager>(m_sWLDisplay, m_sWLEventLoop);
+            g_pEventLoopManager = makeUnique<CEventLoopManager>(m_sWLDisplay, m_sWLEventLoop);
 
             Debug::log(LOG, "Creating the HookSystem!");
-            g_pHookSystem = std::make_unique<CHookSystemManager>();
+            g_pHookSystem = makeUnique<CHookSystemManager>();
 
             Debug::log(LOG, "Creating the KeybindManager!");
-            g_pKeybindManager = std::make_unique<CKeybindManager>();
+            g_pKeybindManager = makeUnique<CKeybindManager>();
 
             Debug::log(LOG, "Creating the AnimationManager!");
-            g_pAnimationManager = std::make_unique<CHyprAnimationManager>();
+            g_pAnimationManager = makeUnique<CHyprAnimationManager>();
 
             Debug::log(LOG, "Creating the ConfigManager!");
-            g_pConfigManager = std::make_unique<CConfigManager>();
+            g_pConfigManager = makeUnique<CConfigManager>();
 
             Debug::log(LOG, "Creating the CHyprError!");
-            g_pHyprError = std::make_unique<CHyprError>();
+            g_pHyprError = makeUnique<CHyprError>();
 
             Debug::log(LOG, "Creating the LayoutManager!");
-            g_pLayoutManager = std::make_unique<CLayoutManager>();
+            g_pLayoutManager = makeUnique<CLayoutManager>();
 
             Debug::log(LOG, "Creating the TokenManager!");
-            g_pTokenManager = std::make_unique<CTokenManager>();
+            g_pTokenManager = makeUnique<CTokenManager>();
 
             g_pConfigManager->init();
-            g_pWatchdog = std::make_unique<CWatchdog>(); // requires config
+            g_pWatchdog = makeUnique<CWatchdog>(); // requires config
             // wait for watchdog to initialize to not hit data races in reading config values.
             while (!g_pWatchdog->m_bWatchdogInitialized) {
                 std::this_thread::yield();
             }
 
             Debug::log(LOG, "Creating the PointerManager!");
-            g_pPointerManager = std::make_unique<CPointerManager>();
+            g_pPointerManager = makeUnique<CPointerManager>();
 
             Debug::log(LOG, "Creating the EventManager!");
-            g_pEventManager = std::make_unique<CEventManager>();
+            g_pEventManager = makeUnique<CEventManager>();
         } break;
         case STAGE_BASICINIT: {
             Debug::log(LOG, "Creating the CHyprOpenGLImpl!");
-            g_pHyprOpenGL = std::make_unique<CHyprOpenGLImpl>();
+            g_pHyprOpenGL = makeUnique<CHyprOpenGLImpl>();
 
             Debug::log(LOG, "Creating the ProtocolManager!");
-            g_pProtocolManager = std::make_unique<CProtocolManager>();
+            g_pProtocolManager = makeUnique<CProtocolManager>();
 
             Debug::log(LOG, "Creating the SeatManager!");
-            g_pSeatManager = std::make_unique<CSeatManager>();
+            g_pSeatManager = makeUnique<CSeatManager>();
         } break;
         case STAGE_LATE: {
             Debug::log(LOG, "Creating CHyprCtl");
-            g_pHyprCtl = std::make_unique<CHyprCtl>();
+            g_pHyprCtl = makeUnique<CHyprCtl>();
 
             Debug::log(LOG, "Creating the InputManager!");
-            g_pInputManager = std::make_unique<CInputManager>();
+            g_pInputManager = makeUnique<CInputManager>();
 
             Debug::log(LOG, "Creating the HyprRenderer!");
-            g_pHyprRenderer = std::make_unique<CHyprRenderer>();
+            g_pHyprRenderer = makeUnique<CHyprRenderer>();
 
             Debug::log(LOG, "Creating the XWaylandManager!");
-            g_pXWaylandManager = std::make_unique<CHyprXWaylandManager>();
+            g_pXWaylandManager = makeUnique<CHyprXWaylandManager>();
 
             Debug::log(LOG, "Creating the SessionLockManager!");
-            g_pSessionLockManager = std::make_unique<CSessionLockManager>();
+            g_pSessionLockManager = makeUnique<CSessionLockManager>();
 
             Debug::log(LOG, "Creating the HyprDebugOverlay!");
-            g_pDebugOverlay = std::make_unique<CHyprDebugOverlay>();
+            g_pDebugOverlay = makeUnique<CHyprDebugOverlay>();
 
             Debug::log(LOG, "Creating the HyprNotificationOverlay!");
-            g_pHyprNotificationOverlay = std::make_unique<CHyprNotificationOverlay>();
+            g_pHyprNotificationOverlay = makeUnique<CHyprNotificationOverlay>();
 
             Debug::log(LOG, "Creating the PluginSystem!");
-            g_pPluginSystem = std::make_unique<CPluginSystem>();
+            g_pPluginSystem = makeUnique<CPluginSystem>();
             g_pConfigManager->handlePluginLoads();
 
             Debug::log(LOG, "Creating the DecorationPositioner!");
-            g_pDecorationPositioner = std::make_unique<CDecorationPositioner>();
+            g_pDecorationPositioner = makeUnique<CDecorationPositioner>();
 
             Debug::log(LOG, "Creating the CursorManager!");
-            g_pCursorManager = std::make_unique<CCursorManager>();
+            g_pCursorManager = makeUnique<CCursorManager>();
 
             Debug::log(LOG, "Creating the VersionKeeper!");
-            g_pVersionKeeperMgr = std::make_unique<CVersionKeeperManager>();
+            g_pVersionKeeperMgr = makeUnique<CVersionKeeperManager>();
 
             Debug::log(LOG, "Creating the DonationNag!");
-            g_pDonationNagManager = std::make_unique<CDonationNagManager>();
+            g_pDonationNagManager = makeUnique<CDonationNagManager>();
 
             Debug::log(LOG, "Starting XWayland");
-            g_pXWayland = std::make_unique<CXWayland>(g_pCompositor->m_bWantsXwayland);
+            g_pXWayland = makeUnique<CXWayland>(g_pCompositor->m_bWantsXwayland);
         } break;
         default: UNREACHABLE();
     }
@@ -2701,7 +2701,7 @@ void CCompositor::moveWindowToWorkspaceSafe(PHLWINDOW pWindow, PHLWORKSPACE pWor
         g_pLayoutManager->getCurrentLayout()->recalculateWindow(pWindow);
 
         if (!pWindow->getDecorationByType(DECORATION_GROUPBAR))
-            pWindow->addWindowDeco(std::make_unique<CHyprGroupBarDecoration>(pWindow));
+            pWindow->addWindowDeco(makeUnique<CHyprGroupBarDecoration>(pWindow));
 
     } else {
         if (!pWindow->m_bIsFloating)

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <list>
 #include <sys/resource.h>
 
@@ -10,6 +9,7 @@
 #include "managers/SessionLockManager.hpp"
 #include "desktop/Window.hpp"
 #include "protocols/types/ColorManagement.hpp"
+#include "helpers/memory/Memory.hpp"
 
 #include <aquamarine/backend/Backend.hpp>
 #include <aquamarine/output/Output.hpp>
@@ -170,4 +170,4 @@ class CCompositor {
     rlimit           m_sOriginalNofile = {0};
 };
 
-inline std::unique_ptr<CCompositor> g_pCompositor;
+inline UP<CCompositor> g_pCompositor;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -44,6 +44,7 @@
 #include <unordered_set>
 #include <hyprutils/string/String.hpp>
 #include <filesystem>
+#include <memory>
 using namespace Hyprutils::String;
 using namespace Hyprutils::Animation;
 
@@ -374,7 +375,7 @@ CConfigManager::CConfigManager() {
     const auto ERR = verifyConfigExists();
 
     m_configPaths.emplace_back(getMainConfigPath());
-    m_pConfig = std::make_unique<Hyprlang::CConfig>(m_configPaths.begin()->c_str(), Hyprlang::SConfigOptions{.throwAllErrors = true, .allowMissingConfig = true});
+    m_pConfig = makeUnique<Hyprlang::CConfig>(m_configPaths.begin()->c_str(), Hyprlang::SConfigOptions{.throwAllErrors = true, .allowMissingConfig = true});
 
     m_pConfig->addConfigValue("general:border_size", Hyprlang::INT{1});
     m_pConfig->addConfigValue("general:no_border_on_floating", Hyprlang::INT{0});
@@ -955,9 +956,8 @@ void CConfigManager::postConfigReload(const Hyprlang::CParseResult& result) {
     // enable/disable xwayland usage
     if (!isFirstLaunch) {
         bool prevEnabledXwayland = g_pXWayland->enabled();
-        if (g_pCompositor->m_bWantsXwayland != prevEnabledXwayland) {
-            g_pXWayland = std::make_unique<CXWayland>(g_pCompositor->m_bWantsXwayland);
-        }
+        if (g_pCompositor->m_bWantsXwayland != prevEnabledXwayland)
+            g_pXWayland = makeUnique<CXWayland>(g_pCompositor->m_bWantsXwayland);
     } else
         g_pCompositor->m_bWantsXwayland = PENABLEXWAYLAND;
 #endif
@@ -1659,7 +1659,7 @@ void CConfigManager::addExecRule(const SExecRequestedRule& rule) {
 }
 
 void CConfigManager::handlePluginLoads() {
-    if (g_pPluginSystem == nullptr)
+    if (!g_pPluginSystem)
         return;
 
     bool pluginsChanged = false;

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -262,7 +262,7 @@ class CConfigManager {
     bool isLaunchingExecOnce   = false; // For exec-once to skip initial ws tracking
 
   private:
-    std::unique_ptr<Hyprlang::CConfig>               m_pConfig;
+    UP<Hyprlang::CConfig>                            m_pConfig;
 
     std::vector<std::string>                         m_configPaths;
 
@@ -303,4 +303,4 @@ class CConfigManager {
     SWorkspaceRule             mergeWorkspaceRules(const SWorkspaceRule&, const SWorkspaceRule&);
 };
 
-inline std::unique_ptr<CConfigManager> g_pConfigManager;
+inline UP<CConfigManager> g_pConfigManager;

--- a/src/config/ConfigWatcher.hpp
+++ b/src/config/ConfigWatcher.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <memory>
+#include "../helpers/memory/Memory.hpp"
 #include <vector>
 #include <string>
 #include <functional>
@@ -29,4 +29,4 @@ class CConfigWatcher {
     int                                           m_inotifyFd = -1;
 };
 
-inline std::unique_ptr<CConfigWatcher> g_pConfigWatcher = std::make_unique<CConfigWatcher>();
+inline UP<CConfigWatcher> g_pConfigWatcher = makeUnique<CConfigWatcher>();

--- a/src/debug/HyprCtl.hpp
+++ b/src/debug/HyprCtl.hpp
@@ -38,4 +38,4 @@ class CHyprCtl {
     std::string                      m_socketPath;
 };
 
-inline std::unique_ptr<CHyprCtl> g_pHyprCtl;
+inline UP<CHyprCtl> g_pHyprCtl;

--- a/src/debug/HyprDebugOverlay.hpp
+++ b/src/debug/HyprDebugOverlay.hpp
@@ -48,4 +48,4 @@ class CHyprDebugOverlay {
     friend class CHyprRenderer;
 };
 
-inline std::unique_ptr<CHyprDebugOverlay> g_pDebugOverlay;
+inline UP<CHyprDebugOverlay> g_pDebugOverlay;

--- a/src/debug/HyprNotificationOverlay.cpp
+++ b/src/debug/HyprNotificationOverlay.cpp
@@ -40,7 +40,7 @@ CHyprNotificationOverlay::~CHyprNotificationOverlay() {
 }
 
 void CHyprNotificationOverlay::addNotification(const std::string& text, const CHyprColor& color, const float timeMs, const eIcons icon, const float fontSize) {
-    const auto PNOTIF = m_vNotifications.emplace_back(std::make_unique<SNotification>()).get();
+    const auto PNOTIF = m_vNotifications.emplace_back(makeUnique<SNotification>()).get();
 
     PNOTIF->text  = icon != eIcons::ICON_NONE ? " " + text /* tiny bit of padding otherwise icon touches text */ : text;
     PNOTIF->color = color == CHyprColor(0) ? ICONS_COLORS[icon] : color;

--- a/src/debug/HyprNotificationOverlay.hpp
+++ b/src/debug/HyprNotificationOverlay.hpp
@@ -46,18 +46,18 @@ class CHyprNotificationOverlay {
     bool hasAny();
 
   private:
-    CBox                                        drawNotifications(PHLMONITOR pMonitor);
-    CBox                                        m_bLastDamage;
+    CBox                           drawNotifications(PHLMONITOR pMonitor);
+    CBox                           m_bLastDamage;
 
-    std::vector<std::unique_ptr<SNotification>> m_vNotifications;
+    std::vector<UP<SNotification>> m_vNotifications;
 
-    cairo_surface_t*                            m_pCairoSurface = nullptr;
-    cairo_t*                                    m_pCairo        = nullptr;
+    cairo_surface_t*               m_pCairoSurface = nullptr;
+    cairo_t*                       m_pCairo        = nullptr;
 
-    PHLMONITORREF                               m_pLastMonitor;
-    Vector2D                                    m_vecLastSize = Vector2D(-1, -1);
+    PHLMONITORREF                  m_pLastMonitor;
+    Vector2D                       m_vecLastSize = Vector2D(-1, -1);
 
-    SP<CTexture>                                m_pTexture;
+    SP<CTexture>                   m_pTexture;
 };
 
-inline std::unique_ptr<CHyprNotificationOverlay> g_pHyprNotificationOverlay;
+inline UP<CHyprNotificationOverlay> g_pHyprNotificationOverlay;

--- a/src/desktop/LayerRule.cpp
+++ b/src/desktop/LayerRule.cpp
@@ -1,7 +1,7 @@
+#include <re2/re2.h>
 #include "LayerRule.hpp"
 #include <unordered_set>
 #include <algorithm>
-#include <re2/re2.h>
 #include "../debug/Log.hpp"
 
 static const auto RULES        = std::unordered_set<std::string>{"noanim", "blur", "blurpopups", "dimaround"};

--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -32,7 +32,7 @@ PHLLS CLayerSurface::create(SP<CLayerShellResource> resource) {
     pLS->szNamespace = resource->layerNamespace;
 
     pLS->layer     = resource->current.layer;
-    pLS->popupHead = std::make_unique<CPopup>(pLS);
+    pLS->popupHead = makeUnique<CPopup>(pLS);
     pLS->monitor   = pMonitor;
     pMonitor->m_aLayerSurfaceLayers[resource->current.layer].emplace_back(pLS);
 

--- a/src/desktop/LayerSurface.hpp
+++ b/src/desktop/LayerSurface.hpp
@@ -59,7 +59,7 @@ class CLayerSurface {
     CBox                       geometry = {0, 0, 0, 0};
     Vector2D                   position;
     std::string                szNamespace = "";
-    std::unique_ptr<CPopup>    popupHead;
+    UP<CPopup>                 popupHead;
 
     void                       onDestroy();
     void                       onMap();

--- a/src/desktop/Popup.cpp
+++ b/src/desktop/Popup.cpp
@@ -89,7 +89,7 @@ void CPopup::onMap() {
 
     g_pInputManager->simulateMouseMovement();
 
-    m_pSubsurfaceHead = std::make_unique<CSubsurface>(this);
+    m_pSubsurfaceHead = makeUnique<CSubsurface>(this);
 
     //unconstrain();
     sendScale();

--- a/src/desktop/Popup.hpp
+++ b/src/desktop/Popup.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <vector>
-#include <memory>
 #include "Subsurface.hpp"
 #include "../helpers/signal/Signal.hpp"
+#include "../helpers/memory/Memory.hpp"
 
 class CXDGPopupResource;
 
@@ -61,8 +61,8 @@ class CPopup {
     bool                  m_bInert = false;
 
     //
-    std::vector<SP<CPopup>>      m_vChildren;
-    std::unique_ptr<CSubsurface> m_pSubsurfaceHead;
+    std::vector<SP<CPopup>> m_vChildren;
+    UP<CSubsurface>         m_pSubsurfaceHead;
 
     struct {
         CHyprSignalListener newPopup;

--- a/src/desktop/Rule.cpp
+++ b/src/desktop/Rule.cpp
@@ -1,12 +1,13 @@
-#include "Rule.hpp"
 #include <re2/re2.h>
+#include "../helpers/memory/Memory.hpp"
+#include "Rule.hpp"
 #include "../debug/Log.hpp"
 
 CRuleRegexContainer::CRuleRegexContainer(const std::string& regex_) {
     const bool NEGATIVE = regex_.starts_with("negative:");
 
     negative = NEGATIVE;
-    regex    = std::make_unique<RE2>(NEGATIVE ? regex_.substr(9) : regex_);
+    regex    = makeUnique<RE2>(NEGATIVE ? regex_.substr(9) : regex_);
 
     // TODO: maybe pop an error?
     if (!regex->ok())

--- a/src/desktop/Rule.hpp
+++ b/src/desktop/Rule.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <memory>
+#include <hyprutils/memory/UniquePtr.hpp>
 
 //NOLINTNEXTLINE
 namespace re2 {
@@ -16,6 +16,6 @@ class CRuleRegexContainer {
     bool passes(const std::string& str) const;
 
   private:
-    std::unique_ptr<re2::RE2> regex;
-    bool                      negative = false;
+    Hyprutils::Memory::CUniquePointer<re2::RE2> regex;
+    bool                                        negative = false;
 };

--- a/src/desktop/Subsurface.cpp
+++ b/src/desktop/Subsurface.cpp
@@ -126,9 +126,9 @@ void CSubsurface::onNewSubsurface(SP<CWLSubsurfaceResource> pSubsurface) {
     CSubsurface* PSUBSURFACE = nullptr;
 
     if (!m_pWindowParent.expired())
-        PSUBSURFACE = m_vChildren.emplace_back(std::make_unique<CSubsurface>(pSubsurface, m_pWindowParent.lock())).get();
+        PSUBSURFACE = m_vChildren.emplace_back(makeUnique<CSubsurface>(pSubsurface, m_pWindowParent.lock())).get();
     else if (m_pPopupParent)
-        PSUBSURFACE = m_vChildren.emplace_back(std::make_unique<CSubsurface>(pSubsurface, m_pPopupParent)).get();
+        PSUBSURFACE = m_vChildren.emplace_back(makeUnique<CSubsurface>(pSubsurface, m_pPopupParent)).get();
 
     ASSERT(PSUBSURFACE);
 

--- a/src/desktop/Subsurface.hpp
+++ b/src/desktop/Subsurface.hpp
@@ -48,16 +48,16 @@ class CSubsurface {
     Vector2D                  m_vLastSize = {};
 
     // if nullptr, means it's a dummy node
-    CSubsurface*                              m_pParent = nullptr;
+    CSubsurface*                 m_pParent = nullptr;
 
-    PHLWINDOWREF                              m_pWindowParent;
-    CPopup*                                   m_pPopupParent = nullptr;
+    PHLWINDOWREF                 m_pWindowParent;
+    CPopup*                      m_pPopupParent = nullptr;
 
-    std::vector<std::unique_ptr<CSubsurface>> m_vChildren;
+    std::vector<UP<CSubsurface>> m_vChildren;
 
-    bool                                      m_bInert = false;
+    bool                         m_bInert = false;
 
-    void                                      initSignals();
-    void                                      initExistingSubsurfaces(SP<CWLSurfaceResource> pSurface);
-    void                                      checkSiblingDamage();
+    void                         initSignals();
+    void                         initExistingSubsurfaces(SP<CWLSurfaceResource> pSurface);
+    void                         checkSiblingDamage();
 };

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -47,8 +47,8 @@ PHLWINDOW CWindow::create(SP<CXWaylandSurface> surface) {
     g_pAnimationManager->createAnimation(0.f, pWindow->m_fMovingToWorkspaceAlpha, g_pConfigManager->getAnimationPropertyConfig("fadeOut"), pWindow, AVARDAMAGE_ENTIRE);
     g_pAnimationManager->createAnimation(0.f, pWindow->m_fMovingFromWorkspaceAlpha, g_pConfigManager->getAnimationPropertyConfig("fadeIn"), pWindow, AVARDAMAGE_ENTIRE);
 
-    pWindow->addWindowDeco(std::make_unique<CHyprDropShadowDecoration>(pWindow));
-    pWindow->addWindowDeco(std::make_unique<CHyprBorderDecoration>(pWindow));
+    pWindow->addWindowDeco(makeUnique<CHyprDropShadowDecoration>(pWindow));
+    pWindow->addWindowDeco(makeUnique<CHyprBorderDecoration>(pWindow));
 
     return pWindow;
 }
@@ -70,8 +70,8 @@ PHLWINDOW CWindow::create(SP<CXDGSurfaceResource> resource) {
     g_pAnimationManager->createAnimation(0.f, pWindow->m_fMovingToWorkspaceAlpha, g_pConfigManager->getAnimationPropertyConfig("fadeOut"), pWindow, AVARDAMAGE_ENTIRE);
     g_pAnimationManager->createAnimation(0.f, pWindow->m_fMovingFromWorkspaceAlpha, g_pConfigManager->getAnimationPropertyConfig("fadeIn"), pWindow, AVARDAMAGE_ENTIRE);
 
-    pWindow->addWindowDeco(std::make_unique<CHyprDropShadowDecoration>(pWindow));
-    pWindow->addWindowDeco(std::make_unique<CHyprBorderDecoration>(pWindow));
+    pWindow->addWindowDeco(makeUnique<CHyprDropShadowDecoration>(pWindow));
+    pWindow->addWindowDeco(makeUnique<CHyprBorderDecoration>(pWindow));
 
     pWindow->m_pWLSurface->assign(pWindow->m_pXDGSurface->surface.lock(), pWindow);
 
@@ -296,7 +296,7 @@ void CWindow::updateWindowDecos() {
     }
 }
 
-void CWindow::addWindowDeco(std::unique_ptr<IHyprWindowDecoration> deco) {
+void CWindow::addWindowDeco(UP<IHyprWindowDecoration> deco) {
     m_dWindowDecorations.emplace_back(std::move(deco));
     g_pDecorationPositioner->forceRecalcFor(m_pSelf.lock());
     updateWindowDecos();
@@ -567,8 +567,8 @@ void CWindow::onMap() {
     if (m_bIsX11)
         return;
 
-    m_pSubsurfaceHead = std::make_unique<CSubsurface>(m_pSelf.lock());
-    m_pPopupHead      = std::make_unique<CPopup>(m_pSelf.lock());
+    m_pSubsurfaceHead = makeUnique<CSubsurface>(m_pSelf.lock());
+    m_pPopupHead      = makeUnique<CPopup>(m_pSelf.lock());
 }
 
 void CWindow::onBorderAngleAnimEnd(WP<CBaseAnimatedVariable> pav) {
@@ -870,7 +870,7 @@ void CWindow::createGroup() {
         m_sGroupData.locked      = false;
         m_sGroupData.deny        = false;
 
-        addWindowDeco(std::make_unique<CHyprGroupBarDecoration>(m_pSelf.lock()));
+        addWindowDeco(makeUnique<CHyprGroupBarDecoration>(m_pSelf.lock()));
 
         if (m_pWorkspace) {
             m_pWorkspace->updateWindows();
@@ -1052,7 +1052,7 @@ void CWindow::insertWindowToGroup(PHLWINDOW pWindow) {
     const auto ENDAT   = m_sGroupData.pNextWindow.lock();
 
     if (!pWindow->getDecorationByType(DECORATION_GROUPBAR))
-        pWindow->addWindowDeco(std::make_unique<CHyprGroupBarDecoration>(pWindow));
+        pWindow->addWindowDeco(makeUnique<CHyprGroupBarDecoration>(pWindow));
 
     if (!pWindow->m_sGroupData.pNextWindow.lock()) {
         BEGINAT->m_sGroupData.pNextWindow = pWindow;

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -296,8 +296,8 @@ class CWindow {
     uint64_t m_eSuppressedEvents = SUPPRESS_NONE;
 
     // desktop components
-    std::unique_ptr<CSubsurface> m_pSubsurfaceHead;
-    std::unique_ptr<CPopup>      m_pPopupHead;
+    UP<CSubsurface> m_pSubsurfaceHead;
+    UP<CPopup>      m_pPopupHead;
 
     // Animated border
     CGradientValueData m_cRealBorderColor         = {0};
@@ -328,14 +328,14 @@ class CWindow {
 
     // Window decorations
     // TODO: make this a SP.
-    std::vector<std::unique_ptr<IHyprWindowDecoration>> m_dWindowDecorations;
-    std::vector<IHyprWindowDecoration*>                 m_vDecosToRemove;
+    std::vector<UP<IHyprWindowDecoration>> m_dWindowDecorations;
+    std::vector<IHyprWindowDecoration*>    m_vDecosToRemove;
 
     // Special render data, rules, etc
     SWindowData m_sWindowData;
 
     // Transformers
-    std::vector<std::unique_ptr<IWindowTransformer>> m_vTransformers;
+    std::vector<UP<IWindowTransformer>> m_vTransformers;
 
     // for alpha
     PHLANIMVAR<float> m_fActiveInactiveAlpha;
@@ -396,7 +396,7 @@ class CWindow {
     SBoxExtents            getFullWindowExtents();
     CBox                   getWindowBoxUnified(uint64_t props);
     CBox                   getWindowIdealBoundingBoxIgnoreReserved();
-    void                   addWindowDeco(std::unique_ptr<IHyprWindowDecoration> deco);
+    void                   addWindowDeco(UP<IHyprWindowDecoration> deco);
     void                   updateWindowDecos();
     void                   removeWindowDeco(IHyprWindowDecoration* deco);
     void                   uncacheWindowDecos();

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -8,7 +8,7 @@
 #include "WLClasses.hpp"
 #include <vector>
 #include <array>
-#include <memory>
+
 #include <xf86drmMode.h>
 #include "Timer.hpp"
 #include "math/Math.hpp"

--- a/src/helpers/SdDaemon.cpp
+++ b/src/helpers/SdDaemon.cpp
@@ -1,7 +1,7 @@
 #include "SdDaemon.hpp"
+#include "memory/Memory.hpp"
 
 #include <memory>
-
 #include <fcntl.h>
 #include <unistd.h>
 #include <cerrno>

--- a/src/helpers/Watchdog.cpp
+++ b/src/helpers/Watchdog.cpp
@@ -14,7 +14,7 @@ CWatchdog::~CWatchdog() {
 
 CWatchdog::CWatchdog() : m_iMainThreadPID(pthread_self()) {
 
-    m_pWatchdog = std::make_unique<std::thread>([this] {
+    m_pWatchdog = makeUnique<std::thread>([this] {
         static auto PTIMEOUT = CConfigValue<Hyprlang::INT>("debug:watchdog_timeout");
 
         m_bWatchdogInitialized = true;

--- a/src/helpers/Watchdog.hpp
+++ b/src/helpers/Watchdog.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <memory>
+#include "memory/Memory.hpp"
 #include <chrono>
 #include <thread>
 #include <condition_variable>
@@ -24,11 +24,11 @@ class CWatchdog {
     std::atomic<bool>                              m_bWatching  = false;
     std::atomic<bool>                              m_bWillWatch = false;
 
-    std::unique_ptr<std::thread>                   m_pWatchdog;
+    UP<std::thread>                                m_pWatchdog;
     std::mutex                                     m_mWatchdogMutex;
     std::atomic<bool>                              m_bNotified   = false;
     std::atomic<bool>                              m_bExitThread = false;
     std::condition_variable                        m_cvWatchdogCondition;
 };
 
-inline std::unique_ptr<CWatchdog> g_pWatchdog;
+inline UP<CWatchdog> g_pWatchdog;

--- a/src/helpers/memory/Memory.hpp
+++ b/src/helpers/memory/Memory.hpp
@@ -7,4 +7,4 @@ using namespace Hyprutils::Memory;
 
 #define SP Hyprutils::Memory::CSharedPointer
 #define WP Hyprutils::Memory::CWeakPointer
-#define UP std::unique_ptr
+#define UP Hyprutils::Memory::CUniquePointer

--- a/src/hyprerror/HyprError.hpp
+++ b/src/hyprerror/HyprError.hpp
@@ -32,4 +32,4 @@ class CHyprError {
     bool              m_bMonitorChanged = false;
 };
 
-inline std::unique_ptr<CHyprError> g_pHyprError; // This is a full-screen error. Treat it with respect, and there can only be one at a time.
+inline UP<CHyprError> g_pHyprError; // This is a full-screen error. Treat it with respect, and there can only be one at a time.

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -215,7 +215,7 @@ bool IHyprLayout::onWindowCreatedAutoGroup(PHLWINDOW pWindow) {
         recalculateWindow(pWindow);
 
         if (!pWindow->getDecorationByType(DECORATION_GROUPBAR))
-            pWindow->addWindowDeco(std::make_unique<CHyprGroupBarDecoration>(pWindow));
+            pWindow->addWindowDeco(makeUnique<CHyprGroupBarDecoration>(pWindow));
 
         return true;
     }
@@ -374,7 +374,7 @@ void IHyprLayout::onEndDragWindow() {
                 DRAGGINGWINDOW->updateWindowDecos();
 
                 if (!DRAGGINGWINDOW->getDecorationByType(DECORATION_GROUPBAR))
-                    DRAGGINGWINDOW->addWindowDeco(std::make_unique<CHyprGroupBarDecoration>(DRAGGINGWINDOW));
+                    DRAGGINGWINDOW->addWindowDeco(makeUnique<CHyprGroupBarDecoration>(DRAGGINGWINDOW));
             }
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,7 +155,7 @@ int main(int argc, char** argv) {
     // let's init the compositor.
     // it initializes basic Wayland stuff in the constructor.
     try {
-        g_pCompositor                     = std::make_unique<CCompositor>();
+        g_pCompositor                     = makeUnique<CCompositor>();
         g_pCompositor->explicitConfigPath = configPath;
     } catch (const std::exception& e) {
         std::println(stderr, "Hyprland threw in ctor: {}\nCannot continue.", e.what());

--- a/src/managers/AnimationManager.hpp
+++ b/src/managers/AnimationManager.hpp
@@ -61,4 +61,4 @@ class CHyprAnimationManager : public Hyprutils::Animation::CAnimationManager {
     void animationSlide(PHLWINDOW, std::string force = "", bool close = false);
 };
 
-inline std::unique_ptr<CHyprAnimationManager> g_pAnimationManager;
+inline UP<CHyprAnimationManager> g_pAnimationManager;

--- a/src/managers/CursorManager.cpp
+++ b/src/managers/CursorManager.cpp
@@ -64,8 +64,8 @@ void CCursorBuffer::endDataPtr() {
 }
 
 CCursorManager::CCursorManager() {
-    m_pHyprcursor              = std::make_unique<Hyprcursor::CHyprcursorManager>(m_szTheme.empty() ? nullptr : m_szTheme.c_str(), hcLogger);
-    m_pXcursor                 = std::make_unique<CXCursorManager>();
+    m_pHyprcursor              = makeUnique<Hyprcursor::CHyprcursorManager>(m_szTheme.empty() ? nullptr : m_szTheme.c_str(), hcLogger);
+    m_pXcursor                 = makeUnique<CXCursorManager>();
     static auto PUSEHYPRCURSOR = CConfigValue<Hyprlang::INT>("cursor:enable_hyprcursor");
 
     if (m_pHyprcursor->valid() && *PUSEHYPRCURSOR) {
@@ -323,7 +323,7 @@ bool CCursorManager::changeTheme(const std::string& name, const int size) {
         m_szTheme                    = name.empty() ? "" : name;
         m_iSize                      = size;
 
-        m_pHyprcursor = std::make_unique<Hyprcursor::CHyprcursorManager>(m_szTheme.empty() ? nullptr : m_szTheme.c_str(), options);
+        m_pHyprcursor = makeUnique<Hyprcursor::CHyprcursorManager>(m_szTheme.empty() ? nullptr : m_szTheme.c_str(), options);
         if (!m_pHyprcursor->valid()) {
             Debug::log(ERR, "Hyprcursor failed loading theme \"{}\", falling back to XCursor.", m_szTheme);
             m_pXcursor->loadTheme(m_szTheme.empty() ? xcursor_theme : m_szTheme, m_iSize, m_fCursorScale);

--- a/src/managers/CursorManager.hpp
+++ b/src/managers/CursorManager.hpp
@@ -2,7 +2,6 @@
 
 #include <string>
 #include <hyprcursor/hyprcursor.hpp>
-#include <memory>
 #include "../includes.hpp"
 #include "../helpers/math/Math.hpp"
 #include "../helpers/memory/Memory.hpp"
@@ -58,22 +57,22 @@ class CCursorManager {
     void                    tickAnimatedCursor();
 
   private:
-    bool                                            m_bOurBufferConnected = false;
-    std::vector<SP<CCursorBuffer>>                  m_vCursorBuffers;
+    bool                               m_bOurBufferConnected = false;
+    std::vector<SP<CCursorBuffer>>     m_vCursorBuffers;
 
-    std::unique_ptr<Hyprcursor::CHyprcursorManager> m_pHyprcursor;
-    std::unique_ptr<CXCursorManager>                m_pXcursor;
-    SP<SXCursors>                                   m_currentXcursor;
+    UP<Hyprcursor::CHyprcursorManager> m_pHyprcursor;
+    UP<CXCursorManager>                m_pXcursor;
+    SP<SXCursors>                      m_currentXcursor;
 
-    std::string                                     m_szTheme      = "";
-    int                                             m_iSize        = 0;
-    float                                           m_fCursorScale = 1.0;
+    std::string                        m_szTheme      = "";
+    int                                m_iSize        = 0;
+    float                              m_fCursorScale = 1.0;
 
-    Hyprcursor::SCursorStyleInfo                    m_sCurrentStyleInfo;
+    Hyprcursor::SCursorStyleInfo       m_sCurrentStyleInfo;
 
-    SP<CEventLoopTimer>                             m_pAnimationTimer;
-    int                                             m_iCurrentAnimationFrame = 0;
-    Hyprcursor::SCursorShapeData                    m_sCurrentCursorShapeData;
+    SP<CEventLoopTimer>                m_pAnimationTimer;
+    int                                m_iCurrentAnimationFrame = 0;
+    Hyprcursor::SCursorShapeData       m_sCurrentCursorShapeData;
 };
 
-inline std::unique_ptr<CCursorManager> g_pCursorManager;
+inline UP<CCursorManager> g_pCursorManager;

--- a/src/managers/DonationNagManager.hpp
+++ b/src/managers/DonationNagManager.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <memory>
+#include "../helpers/memory/Memory.hpp"
 
 class CDonationNagManager {
   public:
@@ -13,4 +13,4 @@ class CDonationNagManager {
     bool m_bFired = false;
 };
 
-inline std::unique_ptr<CDonationNagManager> g_pDonationNagManager;
+inline UP<CDonationNagManager> g_pDonationNagManager;

--- a/src/managers/EventManager.hpp
+++ b/src/managers/EventManager.hpp
@@ -42,4 +42,4 @@ class CEventManager {
     std::vector<SClient> m_vClients;
 };
 
-inline std::unique_ptr<CEventManager> g_pEventManager;
+inline UP<CEventManager> g_pEventManager;

--- a/src/managers/HookSystemManager.hpp
+++ b/src/managers/HookSystemManager.hpp
@@ -57,4 +57,4 @@ class CHookSystemManager {
     std::unordered_map<std::string, std::vector<SCallbackFNPtr>> m_mRegisteredHooks;
 };
 
-inline std::unique_ptr<CHookSystemManager> g_pHookSystem;
+inline UP<CHookSystemManager> g_pHookSystem;

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2840,7 +2840,7 @@ void CKeybindManager::moveWindowIntoGroup(PHLWINDOW pWindow, PHLWINDOW pWindowIn
     pWindow->warpCursor();
 
     if (!pWindow->getDecorationByType(DECORATION_GROUPBAR))
-        pWindow->addWindowDeco(std::make_unique<CHyprGroupBarDecoration>(pWindow));
+        pWindow->addWindowDeco(makeUnique<CHyprGroupBarDecoration>(pWindow));
 
     g_pEventManager->postEvent(SHyprIPCEvent{"moveintogroup", std::format("{:x}", (uintptr_t)pWindow.get())});
 }

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -229,4 +229,4 @@ class CKeybindManager {
     friend class CPointerManager;
 };
 
-inline std::unique_ptr<CKeybindManager> g_pKeybindManager;
+inline UP<CKeybindManager> g_pKeybindManager;

--- a/src/managers/LayoutManager.hpp
+++ b/src/managers/LayoutManager.hpp
@@ -28,4 +28,4 @@ class CLayoutManager {
     std::vector<std::pair<std::string, IHyprLayout*>> m_vLayouts;
 };
 
-inline std::unique_ptr<CLayoutManager> g_pLayoutManager;
+inline UP<CLayoutManager> g_pLayoutManager;

--- a/src/managers/ProtocolManager.cpp
+++ b/src/managers/ProtocolManager.cpp
@@ -119,75 +119,75 @@ CProtocolManager::CProtocolManager() {
     });
 
     // Core
-    PROTO::seat          = std::make_unique<CWLSeatProtocol>(&wl_seat_interface, 9, "WLSeat");
-    PROTO::data          = std::make_unique<CWLDataDeviceProtocol>(&wl_data_device_manager_interface, 3, "WLDataDevice");
-    PROTO::compositor    = std::make_unique<CWLCompositorProtocol>(&wl_compositor_interface, 6, "WLCompositor");
-    PROTO::subcompositor = std::make_unique<CWLSubcompositorProtocol>(&wl_subcompositor_interface, 1, "WLSubcompositor");
-    PROTO::shm           = std::make_unique<CWLSHMProtocol>(&wl_shm_interface, 1, "WLSHM");
+    PROTO::seat          = makeUnique<CWLSeatProtocol>(&wl_seat_interface, 9, "WLSeat");
+    PROTO::data          = makeUnique<CWLDataDeviceProtocol>(&wl_data_device_manager_interface, 3, "WLDataDevice");
+    PROTO::compositor    = makeUnique<CWLCompositorProtocol>(&wl_compositor_interface, 6, "WLCompositor");
+    PROTO::subcompositor = makeUnique<CWLSubcompositorProtocol>(&wl_subcompositor_interface, 1, "WLSubcompositor");
+    PROTO::shm           = makeUnique<CWLSHMProtocol>(&wl_shm_interface, 1, "WLSHM");
 
     // Extensions
-    PROTO::viewport            = std::make_unique<CViewporterProtocol>(&wp_viewporter_interface, 1, "Viewporter");
-    PROTO::tearing             = std::make_unique<CTearingControlProtocol>(&wp_tearing_control_manager_v1_interface, 1, "TearingControl");
-    PROTO::fractional          = std::make_unique<CFractionalScaleProtocol>(&wp_fractional_scale_manager_v1_interface, 1, "FractionalScale");
-    PROTO::xdgOutput           = std::make_unique<CXDGOutputProtocol>(&zxdg_output_manager_v1_interface, 3, "XDGOutput");
-    PROTO::cursorShape         = std::make_unique<CCursorShapeProtocol>(&wp_cursor_shape_manager_v1_interface, 1, "CursorShape");
-    PROTO::idleInhibit         = std::make_unique<CIdleInhibitProtocol>(&zwp_idle_inhibit_manager_v1_interface, 1, "IdleInhibit");
-    PROTO::relativePointer     = std::make_unique<CRelativePointerProtocol>(&zwp_relative_pointer_manager_v1_interface, 1, "RelativePointer");
-    PROTO::xdgDecoration       = std::make_unique<CXDGDecorationProtocol>(&zxdg_decoration_manager_v1_interface, 1, "XDGDecoration");
-    PROTO::alphaModifier       = std::make_unique<CAlphaModifierProtocol>(&wp_alpha_modifier_v1_interface, 1, "AlphaModifier");
-    PROTO::gamma               = std::make_unique<CGammaControlProtocol>(&zwlr_gamma_control_manager_v1_interface, 1, "GammaControl");
-    PROTO::foreignToplevel     = std::make_unique<CForeignToplevelProtocol>(&ext_foreign_toplevel_list_v1_interface, 1, "ForeignToplevel");
-    PROTO::pointerGestures     = std::make_unique<CPointerGesturesProtocol>(&zwp_pointer_gestures_v1_interface, 3, "PointerGestures");
-    PROTO::foreignToplevelWlr  = std::make_unique<CForeignToplevelWlrProtocol>(&zwlr_foreign_toplevel_manager_v1_interface, 3, "ForeignToplevelWlr");
-    PROTO::shortcutsInhibit    = std::make_unique<CKeyboardShortcutsInhibitProtocol>(&zwp_keyboard_shortcuts_inhibit_manager_v1_interface, 1, "ShortcutsInhibit");
-    PROTO::textInputV1         = std::make_unique<CTextInputV1Protocol>(&zwp_text_input_manager_v1_interface, 1, "TextInputV1");
-    PROTO::textInputV3         = std::make_unique<CTextInputV3Protocol>(&zwp_text_input_manager_v3_interface, 1, "TextInputV3");
-    PROTO::constraints         = std::make_unique<CPointerConstraintsProtocol>(&zwp_pointer_constraints_v1_interface, 1, "PointerConstraints");
-    PROTO::outputPower         = std::make_unique<COutputPowerProtocol>(&zwlr_output_power_manager_v1_interface, 1, "OutputPower");
-    PROTO::activation          = std::make_unique<CXDGActivationProtocol>(&xdg_activation_v1_interface, 1, "XDGActivation");
-    PROTO::idle                = std::make_unique<CIdleNotifyProtocol>(&ext_idle_notifier_v1_interface, 1, "IdleNotify");
-    PROTO::lockNotify          = std::make_unique<CLockNotifyProtocol>(&hyprland_lock_notifier_v1_interface, 1, "IdleNotify");
-    PROTO::sessionLock         = std::make_unique<CSessionLockProtocol>(&ext_session_lock_manager_v1_interface, 1, "SessionLock");
-    PROTO::ime                 = std::make_unique<CInputMethodV2Protocol>(&zwp_input_method_manager_v2_interface, 1, "IMEv2");
-    PROTO::virtualKeyboard     = std::make_unique<CVirtualKeyboardProtocol>(&zwp_virtual_keyboard_manager_v1_interface, 1, "VirtualKeyboard");
-    PROTO::virtualPointer      = std::make_unique<CVirtualPointerProtocol>(&zwlr_virtual_pointer_manager_v1_interface, 2, "VirtualPointer");
-    PROTO::outputManagement    = std::make_unique<COutputManagementProtocol>(&zwlr_output_manager_v1_interface, 4, "OutputManagement");
-    PROTO::serverDecorationKDE = std::make_unique<CServerDecorationKDEProtocol>(&org_kde_kwin_server_decoration_manager_interface, 1, "ServerDecorationKDE");
-    PROTO::focusGrab           = std::make_unique<CFocusGrabProtocol>(&hyprland_focus_grab_manager_v1_interface, 1, "FocusGrab");
-    PROTO::tablet              = std::make_unique<CTabletV2Protocol>(&zwp_tablet_manager_v2_interface, 1, "TabletV2");
-    PROTO::layerShell          = std::make_unique<CLayerShellProtocol>(&zwlr_layer_shell_v1_interface, 5, "LayerShell");
-    PROTO::presentation        = std::make_unique<CPresentationProtocol>(&wp_presentation_interface, 1, "Presentation");
-    PROTO::xdgShell            = std::make_unique<CXDGShellProtocol>(&xdg_wm_base_interface, 6, "XDGShell");
-    PROTO::dataWlr             = std::make_unique<CDataDeviceWLRProtocol>(&zwlr_data_control_manager_v1_interface, 2, "DataDeviceWlr");
-    PROTO::primarySelection    = std::make_unique<CPrimarySelectionProtocol>(&zwp_primary_selection_device_manager_v1_interface, 1, "PrimarySelection");
-    PROTO::xwaylandShell       = std::make_unique<CXWaylandShellProtocol>(&xwayland_shell_v1_interface, 1, "XWaylandShell");
-    PROTO::screencopy          = std::make_unique<CScreencopyProtocol>(&zwlr_screencopy_manager_v1_interface, 3, "Screencopy");
-    PROTO::toplevelExport      = std::make_unique<CToplevelExportProtocol>(&hyprland_toplevel_export_manager_v1_interface, 2, "ToplevelExport");
-    PROTO::globalShortcuts     = std::make_unique<CGlobalShortcutsProtocol>(&hyprland_global_shortcuts_manager_v1_interface, 1, "GlobalShortcuts");
-    PROTO::xdgDialog           = std::make_unique<CXDGDialogProtocol>(&xdg_dialog_v1_interface, 1, "XDGDialog");
-    PROTO::singlePixel         = std::make_unique<CSinglePixelProtocol>(&wp_single_pixel_buffer_manager_v1_interface, 1, "SinglePixel");
-    PROTO::securityContext     = std::make_unique<CSecurityContextProtocol>(&wp_security_context_manager_v1_interface, 1, "SecurityContext");
-    PROTO::ctm                 = std::make_unique<CHyprlandCTMControlProtocol>(&hyprland_ctm_control_manager_v1_interface, 1, "CTMControl");
-    PROTO::hyprlandSurface     = std::make_unique<CHyprlandSurfaceProtocol>(&hyprland_surface_manager_v1_interface, 1, "HyprlandSurface");
+    PROTO::viewport            = makeUnique<CViewporterProtocol>(&wp_viewporter_interface, 1, "Viewporter");
+    PROTO::tearing             = makeUnique<CTearingControlProtocol>(&wp_tearing_control_manager_v1_interface, 1, "TearingControl");
+    PROTO::fractional          = makeUnique<CFractionalScaleProtocol>(&wp_fractional_scale_manager_v1_interface, 1, "FractionalScale");
+    PROTO::xdgOutput           = makeUnique<CXDGOutputProtocol>(&zxdg_output_manager_v1_interface, 3, "XDGOutput");
+    PROTO::cursorShape         = makeUnique<CCursorShapeProtocol>(&wp_cursor_shape_manager_v1_interface, 1, "CursorShape");
+    PROTO::idleInhibit         = makeUnique<CIdleInhibitProtocol>(&zwp_idle_inhibit_manager_v1_interface, 1, "IdleInhibit");
+    PROTO::relativePointer     = makeUnique<CRelativePointerProtocol>(&zwp_relative_pointer_manager_v1_interface, 1, "RelativePointer");
+    PROTO::xdgDecoration       = makeUnique<CXDGDecorationProtocol>(&zxdg_decoration_manager_v1_interface, 1, "XDGDecoration");
+    PROTO::alphaModifier       = makeUnique<CAlphaModifierProtocol>(&wp_alpha_modifier_v1_interface, 1, "AlphaModifier");
+    PROTO::gamma               = makeUnique<CGammaControlProtocol>(&zwlr_gamma_control_manager_v1_interface, 1, "GammaControl");
+    PROTO::foreignToplevel     = makeUnique<CForeignToplevelProtocol>(&ext_foreign_toplevel_list_v1_interface, 1, "ForeignToplevel");
+    PROTO::pointerGestures     = makeUnique<CPointerGesturesProtocol>(&zwp_pointer_gestures_v1_interface, 3, "PointerGestures");
+    PROTO::foreignToplevelWlr  = makeUnique<CForeignToplevelWlrProtocol>(&zwlr_foreign_toplevel_manager_v1_interface, 3, "ForeignToplevelWlr");
+    PROTO::shortcutsInhibit    = makeUnique<CKeyboardShortcutsInhibitProtocol>(&zwp_keyboard_shortcuts_inhibit_manager_v1_interface, 1, "ShortcutsInhibit");
+    PROTO::textInputV1         = makeUnique<CTextInputV1Protocol>(&zwp_text_input_manager_v1_interface, 1, "TextInputV1");
+    PROTO::textInputV3         = makeUnique<CTextInputV3Protocol>(&zwp_text_input_manager_v3_interface, 1, "TextInputV3");
+    PROTO::constraints         = makeUnique<CPointerConstraintsProtocol>(&zwp_pointer_constraints_v1_interface, 1, "PointerConstraints");
+    PROTO::outputPower         = makeUnique<COutputPowerProtocol>(&zwlr_output_power_manager_v1_interface, 1, "OutputPower");
+    PROTO::activation          = makeUnique<CXDGActivationProtocol>(&xdg_activation_v1_interface, 1, "XDGActivation");
+    PROTO::idle                = makeUnique<CIdleNotifyProtocol>(&ext_idle_notifier_v1_interface, 1, "IdleNotify");
+    PROTO::lockNotify          = makeUnique<CLockNotifyProtocol>(&hyprland_lock_notifier_v1_interface, 1, "IdleNotify");
+    PROTO::sessionLock         = makeUnique<CSessionLockProtocol>(&ext_session_lock_manager_v1_interface, 1, "SessionLock");
+    PROTO::ime                 = makeUnique<CInputMethodV2Protocol>(&zwp_input_method_manager_v2_interface, 1, "IMEv2");
+    PROTO::virtualKeyboard     = makeUnique<CVirtualKeyboardProtocol>(&zwp_virtual_keyboard_manager_v1_interface, 1, "VirtualKeyboard");
+    PROTO::virtualPointer      = makeUnique<CVirtualPointerProtocol>(&zwlr_virtual_pointer_manager_v1_interface, 2, "VirtualPointer");
+    PROTO::outputManagement    = makeUnique<COutputManagementProtocol>(&zwlr_output_manager_v1_interface, 4, "OutputManagement");
+    PROTO::serverDecorationKDE = makeUnique<CServerDecorationKDEProtocol>(&org_kde_kwin_server_decoration_manager_interface, 1, "ServerDecorationKDE");
+    PROTO::focusGrab           = makeUnique<CFocusGrabProtocol>(&hyprland_focus_grab_manager_v1_interface, 1, "FocusGrab");
+    PROTO::tablet              = makeUnique<CTabletV2Protocol>(&zwp_tablet_manager_v2_interface, 1, "TabletV2");
+    PROTO::layerShell          = makeUnique<CLayerShellProtocol>(&zwlr_layer_shell_v1_interface, 5, "LayerShell");
+    PROTO::presentation        = makeUnique<CPresentationProtocol>(&wp_presentation_interface, 1, "Presentation");
+    PROTO::xdgShell            = makeUnique<CXDGShellProtocol>(&xdg_wm_base_interface, 6, "XDGShell");
+    PROTO::dataWlr             = makeUnique<CDataDeviceWLRProtocol>(&zwlr_data_control_manager_v1_interface, 2, "DataDeviceWlr");
+    PROTO::primarySelection    = makeUnique<CPrimarySelectionProtocol>(&zwp_primary_selection_device_manager_v1_interface, 1, "PrimarySelection");
+    PROTO::xwaylandShell       = makeUnique<CXWaylandShellProtocol>(&xwayland_shell_v1_interface, 1, "XWaylandShell");
+    PROTO::screencopy          = makeUnique<CScreencopyProtocol>(&zwlr_screencopy_manager_v1_interface, 3, "Screencopy");
+    PROTO::toplevelExport      = makeUnique<CToplevelExportProtocol>(&hyprland_toplevel_export_manager_v1_interface, 2, "ToplevelExport");
+    PROTO::globalShortcuts     = makeUnique<CGlobalShortcutsProtocol>(&hyprland_global_shortcuts_manager_v1_interface, 1, "GlobalShortcuts");
+    PROTO::xdgDialog           = makeUnique<CXDGDialogProtocol>(&xdg_dialog_v1_interface, 1, "XDGDialog");
+    PROTO::singlePixel         = makeUnique<CSinglePixelProtocol>(&wp_single_pixel_buffer_manager_v1_interface, 1, "SinglePixel");
+    PROTO::securityContext     = makeUnique<CSecurityContextProtocol>(&wp_security_context_manager_v1_interface, 1, "SecurityContext");
+    PROTO::ctm                 = makeUnique<CHyprlandCTMControlProtocol>(&hyprland_ctm_control_manager_v1_interface, 1, "CTMControl");
+    PROTO::hyprlandSurface     = makeUnique<CHyprlandSurfaceProtocol>(&hyprland_surface_manager_v1_interface, 1, "HyprlandSurface");
 
     if (*PENABLEXXCM) {
-        PROTO::colorManagement     = std::make_unique<CColorManagementProtocol>(&xx_color_manager_v4_interface, 1, "ColorManagement");
-        PROTO::frogColorManagement = std::make_unique<CFrogColorManagementProtocol>(&frog_color_management_factory_v1_interface, 1, "FrogColorManagement");
+        PROTO::colorManagement     = makeUnique<CColorManagementProtocol>(&xx_color_manager_v4_interface, 1, "ColorManagement");
+        PROTO::frogColorManagement = makeUnique<CFrogColorManagementProtocol>(&frog_color_management_factory_v1_interface, 1, "FrogColorManagement");
     }
 
     for (auto const& b : g_pCompositor->m_pAqBackend->getImplementations()) {
         if (b->type() != Aquamarine::AQ_BACKEND_DRM)
             continue;
 
-        PROTO::lease = std::make_unique<CDRMLeaseProtocol>(&wp_drm_lease_device_v1_interface, 1, "DRMLease");
+        PROTO::lease = makeUnique<CDRMLeaseProtocol>(&wp_drm_lease_device_v1_interface, 1, "DRMLease");
         if (*PENABLEEXPLICIT)
-            PROTO::sync = std::make_unique<CDRMSyncobjProtocol>(&wp_linux_drm_syncobj_manager_v1_interface, 1, "DRMSyncobj");
+            PROTO::sync = makeUnique<CDRMSyncobjProtocol>(&wp_linux_drm_syncobj_manager_v1_interface, 1, "DRMSyncobj");
         break;
     }
 
     if (g_pHyprOpenGL->getDRMFormats().size() > 0) {
-        PROTO::mesaDRM  = std::make_unique<CMesaDRMProtocol>(&wl_drm_interface, 2, "MesaDRM");
-        PROTO::linuxDma = std::make_unique<CLinuxDMABufV1Protocol>(&zwp_linux_dmabuf_v1_interface, 5, "LinuxDMABUF");
+        PROTO::mesaDRM  = makeUnique<CMesaDRMProtocol>(&wl_drm_interface, 2, "MesaDRM");
+        PROTO::linuxDma = makeUnique<CLinuxDMABufV1Protocol>(&zwp_linux_dmabuf_v1_interface, 5, "LinuxDMABUF");
     } else
         Debug::log(WARN, "ProtocolManager: Not binding linux-dmabuf and MesaDRM: DMABUF not available");
 }

--- a/src/managers/ProtocolManager.hpp
+++ b/src/managers/ProtocolManager.hpp
@@ -18,4 +18,4 @@ class CProtocolManager {
     void                                                 onMonitorModeChange(PHLMONITOR pMonitor);
 };
 
-inline std::unique_ptr<CProtocolManager> g_pProtocolManager;
+inline UP<CProtocolManager> g_pProtocolManager;

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -57,7 +57,7 @@ void CSessionLockManager::onNewSessionLock(SP<CSessionLock> pLock) {
 
     Debug::log(LOG, "Session got locked by {:x}", (uintptr_t)pLock.get());
 
-    m_pSessionLock       = std::make_unique<SSessionLock>();
+    m_pSessionLock       = makeUnique<SSessionLock>();
     m_pSessionLock->lock = pLock;
     m_pSessionLock->mLockTimer.reset();
 
@@ -66,7 +66,7 @@ void CSessionLockManager::onNewSessionLock(SP<CSessionLock> pLock) {
 
         const auto PMONITOR = SURFACE->monitor();
 
-        const auto NEWSURFACE  = m_pSessionLock->vSessionLockSurfaces.emplace_back(std::make_unique<SSessionLockSurface>(SURFACE)).get();
+        const auto NEWSURFACE  = m_pSessionLock->vSessionLockSurfaces.emplace_back(makeUnique<SSessionLockSurface>(SURFACE)).get();
         NEWSURFACE->iMonitorID = PMONITOR->ID;
         PROTO::fractional->sendScale(SURFACE->surface(), PMONITOR->scale);
     });

--- a/src/managers/SessionLockManager.hpp
+++ b/src/managers/SessionLockManager.hpp
@@ -28,11 +28,11 @@ struct SSessionLockSurface {
 };
 
 struct SSessionLock {
-    WP<CSessionLock>                                  lock;
-    CTimer                                            mLockTimer;
+    WP<CSessionLock>                     lock;
+    CTimer                               mLockTimer;
 
-    std::vector<std::unique_ptr<SSessionLockSurface>> vSessionLockSurfaces;
-    std::unordered_map<uint64_t, CTimer>              mMonitorsWithoutMappedSurfaceTimers;
+    std::vector<UP<SSessionLockSurface>> vSessionLockSurfaces;
+    std::unordered_map<uint64_t, CTimer> mMonitorsWithoutMappedSurfaceTimers;
 
     struct {
         CHyprSignalListener newSurface;
@@ -74,4 +74,4 @@ class CSessionLockManager {
     void onNewSessionLock(SP<CSessionLock> pWlrLock);
 };
 
-inline std::unique_ptr<CSessionLockManager> g_pSessionLockManager;
+inline UP<CSessionLockManager> g_pSessionLockManager;

--- a/src/managers/TokenManager.hpp
+++ b/src/managers/TokenManager.hpp
@@ -35,4 +35,4 @@ class CTokenManager {
     std::unordered_map<std::string, SP<CUUIDToken>> m_mTokens;
 };
 
-inline std::unique_ptr<CTokenManager> g_pTokenManager;
+inline UP<CTokenManager> g_pTokenManager;

--- a/src/managers/VersionKeeperManager.hpp
+++ b/src/managers/VersionKeeperManager.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <memory>
+#include "../helpers/memory/Memory.hpp"
 
 class CVersionKeeperManager {
   public:
@@ -15,4 +15,4 @@ class CVersionKeeperManager {
     bool m_bFired = false;
 };
 
-inline std::unique_ptr<CVersionKeeperManager> g_pVersionKeeperMgr;
+inline UP<CVersionKeeperManager> g_pVersionKeeperMgr;

--- a/src/managers/XCursorManager.cpp
+++ b/src/managers/XCursorManager.cpp
@@ -9,6 +9,7 @@
 #include "../managers/CursorManager.hpp"
 #include "debug/Log.hpp"
 #include "XCursorManager.hpp"
+#include <memory>
 
 // clang-format off
 static std::vector<uint32_t> HYPR_XCURSOR_PIXELS = {

--- a/src/managers/XWaylandManager.hpp
+++ b/src/managers/XWaylandManager.hpp
@@ -25,4 +25,4 @@ class CHyprXWaylandManager {
     Vector2D               waylandToXWaylandCoords(const Vector2D&);
 };
 
-inline std::unique_ptr<CHyprXWaylandManager> g_pXWaylandManager;
+inline UP<CHyprXWaylandManager> g_pXWaylandManager;

--- a/src/managers/eventLoop/EventLoopManager.hpp
+++ b/src/managers/eventLoop/EventLoopManager.hpp
@@ -69,4 +69,4 @@ class CEventLoopManager {
     friend class CSyncTimeline;
 };
 
-inline std::unique_ptr<CEventLoopManager> g_pEventLoopManager;
+inline UP<CEventLoopManager> g_pEventLoopManager;

--- a/src/managers/input/IdleInhibitor.cpp
+++ b/src/managers/input/IdleInhibitor.cpp
@@ -5,7 +5,7 @@
 #include "../../protocols/core/Compositor.hpp"
 
 void CInputManager::newIdleInhibitor(std::any inhibitor) {
-    const auto PINHIBIT = m_vIdleInhibitors.emplace_back(std::make_unique<SIdleInhibitor>()).get();
+    const auto PINHIBIT = m_vIdleInhibitors.emplace_back(makeUnique<SIdleInhibitor>()).get();
     PINHIBIT->inhibitor = std::any_cast<SP<CIdleInhibitor>>(inhibitor);
 
     Debug::log(LOG, "New idle inhibitor registered for surface {:x}", (uintptr_t)PINHIBIT->inhibitor->surface.get());

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -268,7 +268,7 @@ class CInputManager {
         bool                nonDesktop = false;
         CHyprSignalListener surfaceDestroyListener;
     };
-    std::vector<std::unique_ptr<SIdleInhibitor>> m_vIdleInhibitors;
+    std::vector<UP<SIdleInhibitor>> m_vIdleInhibitors;
 
     // swipe
     void beginWorkspaceSwipe();
@@ -304,4 +304,4 @@ class CInputManager {
     friend class CWLSurface;
 };
 
-inline std::unique_ptr<CInputManager> g_pInputManager;
+inline UP<CInputManager> g_pInputManager;

--- a/src/managers/input/InputMethodRelay.cpp
+++ b/src/managers/input/InputMethodRelay.cpp
@@ -50,7 +50,7 @@ void CInputMethodRelay::onNewIME(SP<CInputMethodV2> pIME) {
     });
 
     listeners.newPopup = pIME->events.newPopup.registerListener([this](std::any d) {
-        m_vIMEPopups.emplace_back(std::make_unique<CInputPopup>(std::any_cast<SP<CInputMethodPopupV2>>(d)));
+        m_vIMEPopups.emplace_back(makeUnique<CInputPopup>(std::any_cast<SP<CInputMethodPopupV2>>(d)));
 
         Debug::log(LOG, "New input popup");
     });
@@ -86,11 +86,11 @@ CTextInput* CInputMethodRelay::getFocusedTextInput() {
 }
 
 void CInputMethodRelay::onNewTextInput(WP<CTextInputV3> tiv3) {
-    m_vTextInputs.emplace_back(std::make_unique<CTextInput>(tiv3));
+    m_vTextInputs.emplace_back(makeUnique<CTextInput>(tiv3));
 }
 
 void CInputMethodRelay::onNewTextInput(WP<CTextInputV1> pTIV1) {
-    m_vTextInputs.emplace_back(std::make_unique<CTextInput>(pTIV1));
+    m_vTextInputs.emplace_back(makeUnique<CTextInput>(pTIV1));
 }
 
 void CInputMethodRelay::removeTextInput(CTextInput* pInput) {

--- a/src/managers/input/InputMethodRelay.hpp
+++ b/src/managers/input/InputMethodRelay.hpp
@@ -40,10 +40,10 @@ class CInputMethodRelay {
     WP<CInputMethodV2> m_pIME;
 
   private:
-    std::vector<std::unique_ptr<CTextInput>>  m_vTextInputs;
-    std::vector<std::unique_ptr<CInputPopup>> m_vIMEPopups;
+    std::vector<UP<CTextInput>>  m_vTextInputs;
+    std::vector<UP<CInputPopup>> m_vIMEPopups;
 
-    WP<CWLSurfaceResource>                    m_pLastKbFocus;
+    WP<CWLSurfaceResource>       m_pLastKbFocus;
 
     struct {
         CHyprSignalListener newTIV3;

--- a/src/managers/input/TextInput.hpp
+++ b/src/managers/input/TextInput.hpp
@@ -3,7 +3,6 @@
 #include "../../helpers/math/Math.hpp"
 #include "../../helpers/signal/Signal.hpp"
 #include "../../helpers/memory/Memory.hpp"
-#include <memory>
 
 struct wl_client;
 

--- a/src/pch/pch.hpp
+++ b/src/pch/pch.hpp
@@ -11,7 +11,7 @@
 #include <iterator>
 #include <list>
 #include <map>
-#include <memory>
+
 #include <mutex>
 #include <optional>
 #include <random>

--- a/src/plugins/HookSystem.cpp
+++ b/src/plugins/HookSystem.cpp
@@ -253,7 +253,7 @@ bool CFunctionHook::unhook() {
 }
 
 CFunctionHook* CHookSystem::initHook(HANDLE owner, void* source, void* destination) {
-    return m_vHooks.emplace_back(std::make_unique<CFunctionHook>(owner, source, destination)).get();
+    return m_vHooks.emplace_back(makeUnique<CFunctionHook>(owner, source, destination)).get();
 }
 
 bool CHookSystem::removeHook(CFunctionHook* hook) {

--- a/src/plugins/HookSystem.hpp
+++ b/src/plugins/HookSystem.hpp
@@ -2,7 +2,7 @@
 
 #include <string>
 #include <vector>
-#include <memory>
+#include "../helpers/memory/Memory.hpp"
 
 #define HANDLE                   void*
 #define HOOK_TRAMPOLINE_MAX_SIZE 64
@@ -60,9 +60,9 @@ class CHookSystem {
     void           removeAllHooksFrom(HANDLE handle);
 
   private:
-    std::vector<std::unique_ptr<CFunctionHook>> m_vHooks;
+    std::vector<UP<CFunctionHook>> m_vHooks;
 
-    uint64_t                                    getAddressForTrampo();
+    uint64_t                       getAddressForTrampo();
 
     struct SAllocatedPage {
         uint64_t addr = 0;
@@ -75,4 +75,4 @@ class CHookSystem {
     friend class CFunctionHook;
 };
 
-inline std::unique_ptr<CHookSystem> g_pFunctionHookSystem;
+inline UP<CHookSystem> g_pFunctionHookSystem;

--- a/src/plugins/PluginAPI.cpp
+++ b/src/plugins/PluginAPI.cpp
@@ -106,7 +106,7 @@ APICALL bool HyprlandAPI::removeFunctionHook(HANDLE handle, CFunctionHook* hook)
     return g_pFunctionHookSystem->removeHook(hook);
 }
 
-APICALL bool HyprlandAPI::addWindowDecoration(HANDLE handle, PHLWINDOW pWindow, std::unique_ptr<IHyprWindowDecoration> pDecoration) {
+APICALL bool HyprlandAPI::addWindowDecoration(HANDLE handle, PHLWINDOW pWindow, UP<IHyprWindowDecoration> pDecoration) {
     auto* const PLUGIN = g_pPluginSystem->getPluginByHandle(handle);
 
     if (!PLUGIN)

--- a/src/plugins/PluginAPI.hpp
+++ b/src/plugins/PluginAPI.hpp
@@ -223,7 +223,7 @@ namespace HyprlandAPI {
 
         returns: true on success. False otherwise.
     */
-    APICALL bool addWindowDecoration(HANDLE handle, PHLWINDOW pWindow, std::unique_ptr<IHyprWindowDecoration> pDecoration);
+    APICALL bool addWindowDecoration(HANDLE handle, PHLWINDOW pWindow, UP<IHyprWindowDecoration> pDecoration);
 
     /*
         Removes a window decoration

--- a/src/plugins/PluginSystem.cpp
+++ b/src/plugins/PluginSystem.cpp
@@ -8,7 +8,7 @@
 #include "../managers/eventLoop/EventLoopManager.hpp"
 
 CPluginSystem::CPluginSystem() {
-    g_pFunctionHookSystem = std::make_unique<CHookSystem>();
+    g_pFunctionHookSystem = makeUnique<CHookSystem>();
 }
 
 CPlugin* CPluginSystem::loadPlugin(const std::string& path) {
@@ -21,7 +21,7 @@ CPlugin* CPluginSystem::loadPlugin(const std::string& path) {
         return nullptr;
     }
 
-    auto* const PLUGIN = m_vLoadedPlugins.emplace_back(std::make_unique<CPlugin>()).get();
+    auto* const PLUGIN = m_vLoadedPlugins.emplace_back(makeUnique<CPlugin>()).get();
 
     PLUGIN->path = path;
 

--- a/src/plugins/PluginSystem.hpp
+++ b/src/plugins/PluginSystem.hpp
@@ -44,9 +44,9 @@ class CPluginSystem {
     std::string              m_szLastError      = "";
 
   private:
-    std::vector<std::unique_ptr<CPlugin>> m_vLoadedPlugins;
+    std::vector<UP<CPlugin>> m_vLoadedPlugins;
 
-    jmp_buf                               m_jbPluginFaultJumpBuf;
+    jmp_buf                  m_jbPluginFaultJumpBuf;
 };
 
-inline std::unique_ptr<CPluginSystem> g_pPluginSystem;
+inline UP<CPluginSystem> g_pPluginSystem;

--- a/src/protocols/AlphaModifier.cpp
+++ b/src/protocols/AlphaModifier.cpp
@@ -64,7 +64,7 @@ CAlphaModifierProtocol::CAlphaModifierProtocol(const wl_interface* iface, const 
 }
 
 void CAlphaModifierProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CWpAlphaModifierV1>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CWpAlphaModifierV1>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CWpAlphaModifierV1* manager) { destroyManager(manager); });
 
     RESOURCE->setDestroy([this](CWpAlphaModifierV1* manager) { destroyManager(manager); });
@@ -93,9 +93,8 @@ void CAlphaModifierProtocol::getSurface(CWpAlphaModifierV1* manager, uint32_t id
             alphaModifier = iter->second.get();
         }
     } else {
-        alphaModifier =
-            m_mAlphaModifiers.emplace(surface, std::make_unique<CAlphaModifier>(makeShared<CWpAlphaModifierSurfaceV1>(manager->client(), manager->version(), id), surface))
-                .first->second.get();
+        alphaModifier = m_mAlphaModifiers.emplace(surface, makeUnique<CAlphaModifier>(makeShared<CWpAlphaModifierSurfaceV1>(manager->client(), manager->version(), id), surface))
+                            .first->second.get();
     }
 
     if UNLIKELY (!alphaModifier->good()) {

--- a/src/protocols/AlphaModifier.hpp
+++ b/src/protocols/AlphaModifier.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <unordered_map>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/CTMControl.cpp
+++ b/src/protocols/CTMControl.cpp
@@ -106,7 +106,7 @@ void CHyprlandCTMControlProtocol::setCTM(PHLMONITOR monitor, const Mat3x3& ctm) 
     std::erase_if(m_mCTMDatas, [](const auto& el) { return !el.first; });
 
     if (!m_mCTMDatas.contains(monitor))
-        m_mCTMDatas[monitor] = std::make_unique<SCTMData>();
+        m_mCTMDatas[monitor] = makeUnique<SCTMData>();
 
     auto& data = m_mCTMDatas.at(monitor);
 

--- a/src/protocols/CTMControl.hpp
+++ b/src/protocols/CTMControl.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"
@@ -45,7 +44,7 @@ class CHyprlandCTMControlProtocol : public IWaylandProtocol {
         Mat3x3            ctmFrom = Mat3x3::identity(), ctmTo = Mat3x3::identity();
         PHLANIMVAR<float> progress;
     };
-    std::map<PHLMONITORREF, std::unique_ptr<SCTMData>> m_mCTMDatas;
+    std::map<PHLMONITORREF, UP<SCTMData>> m_mCTMDatas;
 
     friend class CHyprlandCTMControlResource;
 };

--- a/src/protocols/ColorManagement.hpp
+++ b/src/protocols/ColorManagement.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <drm_mode.h>
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/CursorShape.cpp
+++ b/src/protocols/CursorShape.cpp
@@ -15,7 +15,7 @@ void CCursorShapeProtocol::onDeviceResourceDestroy(wl_resource* res) {
 }
 
 void CCursorShapeProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CWpCursorShapeManagerV1>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CWpCursorShapeManagerV1>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CWpCursorShapeManagerV1* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CWpCursorShapeManagerV1* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });

--- a/src/protocols/CursorShape.hpp
+++ b/src/protocols/CursorShape.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <unordered_map>
 #include "WaylandProtocol.hpp"
 #include "../helpers/signal/Signal.hpp"

--- a/src/protocols/DRMLease.hpp
+++ b/src/protocols/DRMLease.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <unordered_map>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/DRMSyncobj.hpp
+++ b/src/protocols/DRMSyncobj.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include "WaylandProtocol.hpp"
 #include "linux-drm-syncobj-v1.hpp"

--- a/src/protocols/DataDeviceWlr.hpp
+++ b/src/protocols/DataDeviceWlr.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/FocusGrab.cpp
+++ b/src/protocols/FocusGrab.cpp
@@ -5,7 +5,6 @@
 #include "../managers/SeatManager.hpp"
 #include "core/Compositor.hpp"
 #include <cstdint>
-#include <memory>
 #include <wayland-server.h>
 
 CFocusGrabSurfaceState::CFocusGrabSurfaceState(CFocusGrab* grab, SP<CWLSurfaceResource> surface) {
@@ -77,7 +76,7 @@ void CFocusGrab::finish(bool sendCleared) {
 void CFocusGrab::addSurface(SP<CWLSurfaceResource> surface) {
     auto iter = std::find_if(m_mSurfaces.begin(), m_mSurfaces.end(), [surface](const auto& e) { return e.first == surface; });
     if (iter == m_mSurfaces.end())
-        m_mSurfaces.emplace(surface, std::make_unique<CFocusGrabSurfaceState>(this, surface));
+        m_mSurfaces.emplace(surface, makeUnique<CFocusGrabSurfaceState>(this, surface));
 }
 
 void CFocusGrab::removeSurface(SP<CWLSurfaceResource> surface) {
@@ -151,7 +150,7 @@ CFocusGrabProtocol::CFocusGrabProtocol(const wl_interface* iface, const int& ver
 }
 
 void CFocusGrabProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CHyprlandFocusGrabManagerV1>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CHyprlandFocusGrabManagerV1>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CHyprlandFocusGrabManagerV1* p) { onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CHyprlandFocusGrabManagerV1* p) { onManagerResourceDestroy(p->resource()); });
@@ -167,7 +166,7 @@ void CFocusGrabProtocol::destroyGrab(CFocusGrab* grab) {
 }
 
 void CFocusGrabProtocol::onCreateGrab(CHyprlandFocusGrabManagerV1* pMgr, uint32_t id) {
-    m_vGrabs.push_back(std::make_unique<CFocusGrab>(makeShared<CHyprlandFocusGrabV1>(pMgr->client(), pMgr->version(), id)));
+    m_vGrabs.push_back(makeUnique<CFocusGrab>(makeShared<CHyprlandFocusGrabV1>(pMgr->client(), pMgr->version(), id)));
     const auto RESOURCE = m_vGrabs.back().get();
 
     if UNLIKELY (!RESOURCE->good()) {

--- a/src/protocols/ForeignToplevel.cpp
+++ b/src/protocols/ForeignToplevel.cpp
@@ -147,7 +147,7 @@ CForeignToplevelProtocol::CForeignToplevelProtocol(const wl_interface* iface, co
 }
 
 void CForeignToplevelProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CForeignToplevelList>(makeShared<CExtForeignToplevelListV1>(client, ver, id))).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CForeignToplevelList>(makeShared<CExtForeignToplevelListV1>(client, ver, id))).get();
 
     if UNLIKELY (!RESOURCE->good()) {
         LOGM(ERR, "Couldn't create a foreign list");

--- a/src/protocols/ForeignToplevel.hpp
+++ b/src/protocols/ForeignToplevel.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <unordered_map>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/ForeignToplevelWlr.cpp
+++ b/src/protocols/ForeignToplevelWlr.cpp
@@ -376,7 +376,7 @@ CForeignToplevelWlrProtocol::CForeignToplevelWlrProtocol(const wl_interface* ifa
 }
 
 void CForeignToplevelWlrProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CForeignToplevelWlrManager>(makeShared<CZwlrForeignToplevelManagerV1>(client, ver, id))).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CForeignToplevelWlrManager>(makeShared<CZwlrForeignToplevelManagerV1>(client, ver, id))).get();
 
     if UNLIKELY (!RESOURCE->good()) {
         LOGM(ERR, "Couldn't create a foreign list");

--- a/src/protocols/ForeignToplevelWlr.hpp
+++ b/src/protocols/ForeignToplevelWlr.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include "WaylandProtocol.hpp"
 #include "wlr-foreign-toplevel-management-unstable-v1.hpp"

--- a/src/protocols/FractionalScale.cpp
+++ b/src/protocols/FractionalScale.cpp
@@ -7,7 +7,7 @@ CFractionalScaleProtocol::CFractionalScaleProtocol(const wl_interface* iface, co
 }
 
 void CFractionalScaleProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CWpFractionalScaleManagerV1>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CWpFractionalScaleManagerV1>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CWpFractionalScaleManagerV1* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CWpFractionalScaleManagerV1* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });
@@ -33,7 +33,7 @@ void CFractionalScaleProtocol::onGetFractionalScale(CWpFractionalScaleManagerV1*
     }
 
     const auto PADDON =
-        m_mAddons.emplace(surface, std::make_unique<CFractionalScaleAddon>(makeShared<CWpFractionalScaleV1>(pMgr->client(), pMgr->version(), id), surface)).first->second.get();
+        m_mAddons.emplace(surface, makeUnique<CFractionalScaleAddon>(makeShared<CWpFractionalScaleV1>(pMgr->client(), pMgr->version(), id), surface)).first->second.get();
 
     if UNLIKELY (!PADDON->good()) {
         m_mAddons.erase(surface);

--- a/src/protocols/FractionalScale.hpp
+++ b/src/protocols/FractionalScale.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <unordered_map>
 #include "WaylandProtocol.hpp"
 #include "fractional-scale-v1.hpp"

--- a/src/protocols/FrogColorManagement.hpp
+++ b/src/protocols/FrogColorManagement.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <cstdint>
 #include "WaylandProtocol.hpp"
 #include "protocols/core/Compositor.hpp"

--- a/src/protocols/GammaControl.cpp
+++ b/src/protocols/GammaControl.cpp
@@ -160,7 +160,7 @@ CGammaControlProtocol::CGammaControlProtocol(const wl_interface* iface, const in
 }
 
 void CGammaControlProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CZwlrGammaControlManagerV1>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CZwlrGammaControlManagerV1>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CZwlrGammaControlManagerV1* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CZwlrGammaControlManagerV1* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });
@@ -177,7 +177,7 @@ void CGammaControlProtocol::destroyGammaControl(CGammaControl* gamma) {
 
 void CGammaControlProtocol::onGetGammaControl(CZwlrGammaControlManagerV1* pMgr, uint32_t id, wl_resource* output) {
     const auto CLIENT   = pMgr->client();
-    const auto RESOURCE = m_vGammaControllers.emplace_back(std::make_unique<CGammaControl>(makeShared<CZwlrGammaControlV1>(CLIENT, pMgr->version(), id), output)).get();
+    const auto RESOURCE = m_vGammaControllers.emplace_back(makeUnique<CGammaControl>(makeShared<CZwlrGammaControlV1>(CLIENT, pMgr->version(), id), output)).get();
 
     if UNLIKELY (!RESOURCE->good()) {
         pMgr->noMemory();

--- a/src/protocols/GammaControl.hpp
+++ b/src/protocols/GammaControl.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/HyprlandSurface.cpp
+++ b/src/protocols/HyprlandSurface.cpp
@@ -70,7 +70,7 @@ CHyprlandSurfaceProtocol::CHyprlandSurfaceProtocol(const wl_interface* iface, co
 }
 
 void CHyprlandSurfaceProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    auto manager = m_vManagers.emplace_back(std::make_unique<CHyprlandSurfaceManagerV1>(client, ver, id)).get();
+    auto manager = m_vManagers.emplace_back(makeUnique<CHyprlandSurfaceManagerV1>(client, ver, id)).get();
     manager->setOnDestroy([this](CHyprlandSurfaceManagerV1* manager) { destroyManager(manager); });
 
     manager->setDestroy([this](CHyprlandSurfaceManagerV1* manager) { destroyManager(manager); });
@@ -100,8 +100,8 @@ void CHyprlandSurfaceProtocol::getSurface(CHyprlandSurfaceManagerV1* manager, ui
             hyprlandSurface = iter->second.get();
         }
     } else {
-        hyprlandSurface = m_mSurfaces.emplace(surface, std::make_unique<CHyprlandSurface>(makeShared<CHyprlandSurfaceV1>(manager->client(), manager->version(), id), surface))
-                              .first->second.get();
+        hyprlandSurface =
+            m_mSurfaces.emplace(surface, makeUnique<CHyprlandSurface>(makeShared<CHyprlandSurfaceV1>(manager->client(), manager->version(), id), surface)).first->second.get();
     }
 
     if UNLIKELY (!hyprlandSurface->good()) {

--- a/src/protocols/HyprlandSurface.hpp
+++ b/src/protocols/HyprlandSurface.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <unordered_map>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/IdleInhibit.cpp
+++ b/src/protocols/IdleInhibit.cpp
@@ -31,7 +31,7 @@ void CIdleInhibitProtocol::onManagerResourceDestroy(wl_resource* res) {
 }
 
 void CIdleInhibitProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CZwpIdleInhibitManagerV1>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CZwpIdleInhibitManagerV1>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CZwpIdleInhibitManagerV1* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CZwpIdleInhibitManagerV1* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });

--- a/src/protocols/IdleInhibit.hpp
+++ b/src/protocols/IdleInhibit.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <unordered_map>
 #include "WaylandProtocol.hpp"
 #include "idle-inhibit-unstable-v1.hpp"

--- a/src/protocols/IdleNotify.cpp
+++ b/src/protocols/IdleNotify.cpp
@@ -59,7 +59,7 @@ CIdleNotifyProtocol::CIdleNotifyProtocol(const wl_interface* iface, const int& v
 }
 
 void CIdleNotifyProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CExtIdleNotifierV1>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CExtIdleNotifierV1>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CExtIdleNotifierV1* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CExtIdleNotifierV1* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });

--- a/src/protocols/IdleNotify.hpp
+++ b/src/protocols/IdleNotify.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <unordered_map>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/InputMethodV2.cpp
+++ b/src/protocols/InputMethodV2.cpp
@@ -334,7 +334,7 @@ CInputMethodV2Protocol::CInputMethodV2Protocol(const wl_interface* iface, const 
 }
 
 void CInputMethodV2Protocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CZwpInputMethodManagerV2>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CZwpInputMethodManagerV2>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CZwpInputMethodManagerV2* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CZwpInputMethodManagerV2* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });

--- a/src/protocols/InputMethodV2.hpp
+++ b/src/protocols/InputMethodV2.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/LayerShell.cpp
+++ b/src/protocols/LayerShell.cpp
@@ -201,7 +201,7 @@ CLayerShellProtocol::CLayerShellProtocol(const wl_interface* iface, const int& v
 }
 
 void CLayerShellProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CZwlrLayerShellV1>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CZwlrLayerShellV1>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CZwlrLayerShellV1* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CZwlrLayerShellV1* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });

--- a/src/protocols/LayerShell.hpp
+++ b/src/protocols/LayerShell.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include <tuple>

--- a/src/protocols/LinuxDMABUF.cpp
+++ b/src/protocols/LinuxDMABUF.cpp
@@ -469,7 +469,7 @@ CLinuxDMABufV1Protocol::CLinuxDMABufV1Protocol(const wl_interface* iface, const 
             });
         }
 
-        formatTable = std::make_unique<CDMABUFFormatTable>(eglTranche, tches);
+        formatTable = makeUnique<CDMABUFFormatTable>(eglTranche, tches);
 
         drmDevice* device = nullptr;
         if (drmGetDeviceFromDevId(mainDevice, 0, &device) != 0) {
@@ -501,7 +501,7 @@ void CLinuxDMABufV1Protocol::resetFormatTable() {
     LOGM(LOG, "Resetting format table");
 
     // this might be a big copy
-    auto newFormatTable = std::make_unique<CDMABUFFormatTable>(formatTable->rendererTranche, formatTable->monitorTranches);
+    auto newFormatTable = makeUnique<CDMABUFFormatTable>(formatTable->rendererTranche, formatTable->monitorTranches);
 
     for (auto const& feedback : m_vFeedbacks) {
         feedback->resource->sendFormatTable(newFormatTable->tableFD, newFormatTable->tableSize);

--- a/src/protocols/LinuxDMABUF.hpp
+++ b/src/protocols/LinuxDMABUF.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/LockNotify.cpp
+++ b/src/protocols/LockNotify.cpp
@@ -31,7 +31,7 @@ CLockNotifyProtocol::CLockNotifyProtocol(const wl_interface* iface, const int& v
 }
 
 void CLockNotifyProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_managers.emplace_back(std::make_unique<CHyprlandLockNotifierV1>(client, ver, id)).get();
+    const auto RESOURCE = m_managers.emplace_back(makeUnique<CHyprlandLockNotifierV1>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CHyprlandLockNotifierV1* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CHyprlandLockNotifierV1* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });

--- a/src/protocols/MesaDRM.hpp
+++ b/src/protocols/MesaDRM.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/OutputManagement.hpp
+++ b/src/protocols/OutputManagement.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include <unordered_map>

--- a/src/protocols/OutputPower.cpp
+++ b/src/protocols/OutputPower.cpp
@@ -43,7 +43,7 @@ COutputPowerProtocol::COutputPowerProtocol(const wl_interface* iface, const int&
 }
 
 void COutputPowerProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CZwlrOutputPowerManagerV1>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CZwlrOutputPowerManagerV1>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CZwlrOutputPowerManagerV1* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CZwlrOutputPowerManagerV1* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });
@@ -68,7 +68,7 @@ void COutputPowerProtocol::onGetOutputPower(CZwlrOutputPowerManagerV1* pMgr, uin
     }
 
     const auto CLIENT   = pMgr->client();
-    const auto RESOURCE = m_vOutputPowers.emplace_back(std::make_unique<COutputPower>(makeShared<CZwlrOutputPowerV1>(CLIENT, pMgr->version(), id), OUTPUT->monitor.lock())).get();
+    const auto RESOURCE = m_vOutputPowers.emplace_back(makeUnique<COutputPower>(makeShared<CZwlrOutputPowerV1>(CLIENT, pMgr->version(), id), OUTPUT->monitor.lock())).get();
 
     if UNLIKELY (!RESOURCE->good()) {
         pMgr->noMemory();

--- a/src/protocols/OutputPower.hpp
+++ b/src/protocols/OutputPower.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/PointerConstraints.cpp
+++ b/src/protocols/PointerConstraints.cpp
@@ -199,7 +199,7 @@ CPointerConstraintsProtocol::CPointerConstraintsProtocol(const wl_interface* ifa
 }
 
 void CPointerConstraintsProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CZwpPointerConstraintsV1>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CZwpPointerConstraintsV1>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CZwpPointerConstraintsV1* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CZwpPointerConstraintsV1* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });

--- a/src/protocols/PointerConstraints.hpp
+++ b/src/protocols/PointerConstraints.hpp
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/PointerGestures.cpp
+++ b/src/protocols/PointerGestures.cpp
@@ -44,7 +44,7 @@ CPointerGesturesProtocol::CPointerGesturesProtocol(const wl_interface* iface, co
 }
 
 void CPointerGesturesProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CZwpPointerGesturesV1>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CZwpPointerGesturesV1>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CZwpPointerGesturesV1* p) { this->onManagerResourceDestroy(p->resource()); });
     RESOURCE->setRelease([this](CZwpPointerGesturesV1* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });
 
@@ -71,7 +71,7 @@ void CPointerGesturesProtocol::onGestureDestroy(CPointerGestureHold* gesture) {
 
 void CPointerGesturesProtocol::onGetPinchGesture(CZwpPointerGesturesV1* pMgr, uint32_t id, wl_resource* pointer) {
     const auto CLIENT   = pMgr->client();
-    const auto RESOURCE = m_vPinches.emplace_back(std::make_unique<CPointerGesturePinch>(makeShared<CZwpPointerGesturePinchV1>(CLIENT, pMgr->version(), id))).get();
+    const auto RESOURCE = m_vPinches.emplace_back(makeUnique<CPointerGesturePinch>(makeShared<CZwpPointerGesturePinchV1>(CLIENT, pMgr->version(), id))).get();
 
     if UNLIKELY (!RESOURCE->good()) {
         pMgr->noMemory();
@@ -82,7 +82,7 @@ void CPointerGesturesProtocol::onGetPinchGesture(CZwpPointerGesturesV1* pMgr, ui
 
 void CPointerGesturesProtocol::onGetSwipeGesture(CZwpPointerGesturesV1* pMgr, uint32_t id, wl_resource* pointer) {
     const auto CLIENT   = pMgr->client();
-    const auto RESOURCE = m_vSwipes.emplace_back(std::make_unique<CPointerGestureSwipe>(makeShared<CZwpPointerGestureSwipeV1>(CLIENT, pMgr->version(), id))).get();
+    const auto RESOURCE = m_vSwipes.emplace_back(makeUnique<CPointerGestureSwipe>(makeShared<CZwpPointerGestureSwipeV1>(CLIENT, pMgr->version(), id))).get();
 
     if UNLIKELY (!RESOURCE->good()) {
         pMgr->noMemory();
@@ -93,7 +93,7 @@ void CPointerGesturesProtocol::onGetSwipeGesture(CZwpPointerGesturesV1* pMgr, ui
 
 void CPointerGesturesProtocol::onGetHoldGesture(CZwpPointerGesturesV1* pMgr, uint32_t id, wl_resource* pointer) {
     const auto CLIENT   = pMgr->client();
-    const auto RESOURCE = m_vHolds.emplace_back(std::make_unique<CPointerGestureHold>(makeShared<CZwpPointerGestureHoldV1>(CLIENT, pMgr->version(), id))).get();
+    const auto RESOURCE = m_vHolds.emplace_back(makeUnique<CPointerGestureHold>(makeShared<CZwpPointerGestureHoldV1>(CLIENT, pMgr->version(), id))).get();
 
     if UNLIKELY (!RESOURCE->good()) {
         pMgr->noMemory();

--- a/src/protocols/PointerGestures.hpp
+++ b/src/protocols/PointerGestures.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include "WaylandProtocol.hpp"
 #include "pointer-gestures-unstable-v1.hpp"

--- a/src/protocols/PresentationTime.cpp
+++ b/src/protocols/PresentationTime.cpp
@@ -79,7 +79,7 @@ CPresentationProtocol::CPresentationProtocol(const wl_interface* iface, const in
 }
 
 void CPresentationProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CWpPresentation>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CWpPresentation>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CWpPresentation* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CWpPresentation* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });

--- a/src/protocols/PresentationTime.hpp
+++ b/src/protocols/PresentationTime.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/PrimarySelection.hpp
+++ b/src/protocols/PrimarySelection.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/RelativePointer.cpp
+++ b/src/protocols/RelativePointer.cpp
@@ -31,7 +31,7 @@ CRelativePointerProtocol::CRelativePointerProtocol(const wl_interface* iface, co
 }
 
 void CRelativePointerProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CZwpRelativePointerManagerV1>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CZwpRelativePointerManagerV1>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CZwpRelativePointerManagerV1* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CZwpRelativePointerManagerV1* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });
@@ -48,7 +48,7 @@ void CRelativePointerProtocol::destroyRelativePointer(CRelativePointer* pointer)
 
 void CRelativePointerProtocol::onGetRelativePointer(CZwpRelativePointerManagerV1* pMgr, uint32_t id, wl_resource* pointer) {
     const auto CLIENT   = pMgr->client();
-    const auto RESOURCE = m_vRelativePointers.emplace_back(std::make_unique<CRelativePointer>(makeShared<CZwpRelativePointerV1>(CLIENT, pMgr->version(), id))).get();
+    const auto RESOURCE = m_vRelativePointers.emplace_back(makeUnique<CRelativePointer>(makeShared<CZwpRelativePointerV1>(CLIENT, pMgr->version(), id))).get();
 
     if UNLIKELY (!RESOURCE->good()) {
         pMgr->noMemory();

--- a/src/protocols/RelativePointer.hpp
+++ b/src/protocols/RelativePointer.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/SecurityContext.hpp
+++ b/src/protocols/SecurityContext.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/ServerDecorationKDE.cpp
+++ b/src/protocols/ServerDecorationKDE.cpp
@@ -21,7 +21,7 @@ CServerDecorationKDEProtocol::CServerDecorationKDEProtocol(const wl_interface* i
 }
 
 void CServerDecorationKDEProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<COrgKdeKwinServerDecorationManager>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<COrgKdeKwinServerDecorationManager>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](COrgKdeKwinServerDecorationManager* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setCreate([this](COrgKdeKwinServerDecorationManager* pMgr, uint32_t id, wl_resource* pointer) { this->createDecoration(pMgr, id, pointer); });
@@ -41,8 +41,7 @@ void CServerDecorationKDEProtocol::destroyResource(CServerDecorationKDE* hayperl
 void CServerDecorationKDEProtocol::createDecoration(COrgKdeKwinServerDecorationManager* pMgr, uint32_t id, wl_resource* surf) {
     const auto CLIENT = pMgr->client();
     const auto RESOURCE =
-        m_vDecos.emplace_back(std::make_unique<CServerDecorationKDE>(makeShared<COrgKdeKwinServerDecoration>(CLIENT, pMgr->version(), id), CWLSurfaceResource::fromResource(surf)))
-            .get();
+        m_vDecos.emplace_back(makeUnique<CServerDecorationKDE>(makeShared<COrgKdeKwinServerDecoration>(CLIENT, pMgr->version(), id), CWLSurfaceResource::fromResource(surf))).get();
 
     if UNLIKELY (!RESOURCE->good()) {
         pMgr->noMemory();

--- a/src/protocols/ServerDecorationKDE.hpp
+++ b/src/protocols/ServerDecorationKDE.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/SessionLock.cpp
+++ b/src/protocols/SessionLock.cpp
@@ -148,7 +148,7 @@ CSessionLockProtocol::CSessionLockProtocol(const wl_interface* iface, const int&
 }
 
 void CSessionLockProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CExtSessionLockManagerV1>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CExtSessionLockManagerV1>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CExtSessionLockManagerV1* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CExtSessionLockManagerV1* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });

--- a/src/protocols/SessionLock.hpp
+++ b/src/protocols/SessionLock.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/ShortcutsInhibit.cpp
+++ b/src/protocols/ShortcutsInhibit.cpp
@@ -28,7 +28,7 @@ CKeyboardShortcutsInhibitProtocol::CKeyboardShortcutsInhibitProtocol(const wl_in
 }
 
 void CKeyboardShortcutsInhibitProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CZwpKeyboardShortcutsInhibitManagerV1>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CZwpKeyboardShortcutsInhibitManagerV1>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CZwpKeyboardShortcutsInhibitManagerV1* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CZwpKeyboardShortcutsInhibitManagerV1* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });
@@ -57,7 +57,7 @@ void CKeyboardShortcutsInhibitProtocol::onInhibit(CZwpKeyboardShortcutsInhibitMa
     }
 
     const auto RESOURCE =
-        m_vInhibitors.emplace_back(std::make_unique<CKeyboardShortcutsInhibitor>(makeShared<CZwpKeyboardShortcutsInhibitorV1>(CLIENT, pMgr->version(), id), surf)).get();
+        m_vInhibitors.emplace_back(makeUnique<CKeyboardShortcutsInhibitor>(makeShared<CZwpKeyboardShortcutsInhibitorV1>(CLIENT, pMgr->version(), id), surf)).get();
 
     if UNLIKELY (!RESOURCE->good()) {
         pMgr->noMemory();

--- a/src/protocols/ShortcutsInhibit.hpp
+++ b/src/protocols/ShortcutsInhibit.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/SinglePixel.hpp
+++ b/src/protocols/SinglePixel.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/Tablet.cpp
+++ b/src/protocols/Tablet.cpp
@@ -315,7 +315,7 @@ CTabletV2Protocol::CTabletV2Protocol(const wl_interface* iface, const int& ver, 
 }
 
 void CTabletV2Protocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CZwpTabletManagerV2>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CZwpTabletManagerV2>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CZwpTabletManagerV2* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CZwpTabletManagerV2* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });

--- a/src/protocols/Tablet.hpp
+++ b/src/protocols/Tablet.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/TearingControl.cpp
+++ b/src/protocols/TearingControl.cpp
@@ -11,7 +11,7 @@ CTearingControlProtocol::CTearingControlProtocol(const wl_interface* iface, cons
 }
 
 void CTearingControlProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CWpTearingControlManagerV1>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CWpTearingControlManagerV1>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CWpTearingControlManagerV1* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CWpTearingControlManagerV1* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });
@@ -25,7 +25,7 @@ void CTearingControlProtocol::onManagerResourceDestroy(wl_resource* res) {
 }
 
 void CTearingControlProtocol::onGetController(wl_client* client, CWpTearingControlManagerV1* pMgr, uint32_t id, SP<CWLSurfaceResource> surf) {
-    const auto CONTROLLER = m_vTearingControllers.emplace_back(std::make_unique<CTearingControl>(makeShared<CWpTearingControlV1>(client, pMgr->version(), id), surf)).get();
+    const auto CONTROLLER = m_vTearingControllers.emplace_back(makeUnique<CTearingControl>(makeShared<CWpTearingControlV1>(client, pMgr->version(), id), surf)).get();
 
     if UNLIKELY (!CONTROLLER->good()) {
         pMgr->noMemory();

--- a/src/protocols/TearingControl.hpp
+++ b/src/protocols/TearingControl.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include "WaylandProtocol.hpp"
 #include "tearing-control-v1.hpp"
 

--- a/src/protocols/TextInputV3.cpp
+++ b/src/protocols/TextInputV3.cpp
@@ -110,7 +110,7 @@ CTextInputV3Protocol::CTextInputV3Protocol(const wl_interface* iface, const int&
 }
 
 void CTextInputV3Protocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CZwpTextInputManagerV3>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CZwpTextInputManagerV3>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CZwpTextInputManagerV3* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CZwpTextInputManagerV3* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });

--- a/src/protocols/TextInputV3.hpp
+++ b/src/protocols/TextInputV3.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include <string>

--- a/src/protocols/Viewporter.hpp
+++ b/src/protocols/Viewporter.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/VirtualKeyboard.cpp
+++ b/src/protocols/VirtualKeyboard.cpp
@@ -124,7 +124,7 @@ CVirtualKeyboardProtocol::CVirtualKeyboardProtocol(const wl_interface* iface, co
 }
 
 void CVirtualKeyboardProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CZwpVirtualKeyboardManagerV1>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CZwpVirtualKeyboardManagerV1>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CZwpVirtualKeyboardManagerV1* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setCreateVirtualKeyboard([this](CZwpVirtualKeyboardManagerV1* pMgr, wl_resource* seat, uint32_t id) { this->onCreateKeeb(pMgr, seat, id); });

--- a/src/protocols/VirtualKeyboard.hpp
+++ b/src/protocols/VirtualKeyboard.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/VirtualPointer.cpp
+++ b/src/protocols/VirtualPointer.cpp
@@ -107,7 +107,7 @@ CVirtualPointerProtocol::CVirtualPointerProtocol(const wl_interface* iface, cons
 }
 
 void CVirtualPointerProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CZwlrVirtualPointerManagerV1>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CZwlrVirtualPointerManagerV1>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CZwlrVirtualPointerManagerV1* p) { this->onManagerResourceDestroy(p->resource()); });
     RESOURCE->setDestroy([this](CZwlrVirtualPointerManagerV1* p) { this->onManagerResourceDestroy(p->resource()); });
 

--- a/src/protocols/VirtualPointer.hpp
+++ b/src/protocols/VirtualPointer.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include <array>

--- a/src/protocols/WaylandProtocol.hpp
+++ b/src/protocols/WaylandProtocol.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../defines.hpp"
+#include "../helpers/memory/Memory.hpp"
 
 #include <functional>
 

--- a/src/protocols/XDGActivation.cpp
+++ b/src/protocols/XDGActivation.cpp
@@ -62,7 +62,7 @@ CXDGActivationProtocol::CXDGActivationProtocol(const wl_interface* iface, const 
 }
 
 void CXDGActivationProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CXdgActivationV1>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CXdgActivationV1>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CXdgActivationV1* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CXdgActivationV1* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });
@@ -100,7 +100,7 @@ void CXDGActivationProtocol::destroyToken(CXDGActivationToken* token) {
 
 void CXDGActivationProtocol::onGetToken(CXdgActivationV1* pMgr, uint32_t id) {
     const auto CLIENT   = pMgr->client();
-    const auto RESOURCE = m_vTokens.emplace_back(std::make_unique<CXDGActivationToken>(makeShared<CXdgActivationTokenV1>(CLIENT, pMgr->version(), id))).get();
+    const auto RESOURCE = m_vTokens.emplace_back(makeUnique<CXDGActivationToken>(makeShared<CXdgActivationTokenV1>(CLIENT, pMgr->version(), id))).get();
 
     if UNLIKELY (!RESOURCE->good()) {
         pMgr->noMemory();

--- a/src/protocols/XDGActivation.hpp
+++ b/src/protocols/XDGActivation.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/XDGDecoration.cpp
+++ b/src/protocols/XDGDecoration.cpp
@@ -41,7 +41,7 @@ CXDGDecorationProtocol::CXDGDecorationProtocol(const wl_interface* iface, const 
 }
 
 void CXDGDecorationProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagers.emplace_back(std::make_unique<CZxdgDecorationManagerV1>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagers.emplace_back(makeUnique<CZxdgDecorationManagerV1>(client, ver, id)).get();
     RESOURCE->setOnDestroy([this](CZxdgDecorationManagerV1* p) { this->onManagerResourceDestroy(p->resource()); });
 
     RESOURCE->setDestroy([this](CZxdgDecorationManagerV1* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });
@@ -64,7 +64,7 @@ void CXDGDecorationProtocol::onGetDecoration(CZxdgDecorationManagerV1* pMgr, uin
 
     const auto CLIENT = pMgr->client();
     const auto RESOURCE =
-        m_mDecorations.emplace(xdgToplevel, std::make_unique<CXDGDecoration>(makeShared<CZxdgToplevelDecorationV1>(CLIENT, pMgr->version(), id), xdgToplevel)).first->second.get();
+        m_mDecorations.emplace(xdgToplevel, makeUnique<CXDGDecoration>(makeShared<CZxdgToplevelDecorationV1>(CLIENT, pMgr->version(), id), xdgToplevel)).first->second.get();
 
     if UNLIKELY (!RESOURCE->good()) {
         pMgr->noMemory();

--- a/src/protocols/XDGDecoration.hpp
+++ b/src/protocols/XDGDecoration.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <unordered_map>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/XDGDialog.hpp
+++ b/src/protocols/XDGDialog.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <unordered_map>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/XDGOutput.cpp
+++ b/src/protocols/XDGOutput.cpp
@@ -21,7 +21,7 @@ void CXDGOutputProtocol::onOutputResourceDestroy(wl_resource* res) {
 }
 
 void CXDGOutputProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = m_vManagerResources.emplace_back(std::make_unique<CZxdgOutputManagerV1>(client, ver, id)).get();
+    const auto RESOURCE = m_vManagerResources.emplace_back(makeUnique<CZxdgOutputManagerV1>(client, ver, id)).get();
 
     if UNLIKELY (!RESOURCE->resource()) {
         LOGM(LOG, "Couldn't bind XDGOutputMgr");
@@ -44,7 +44,7 @@ void CXDGOutputProtocol::onManagerGetXDGOutput(CZxdgOutputManagerV1* mgr, uint32
     const auto  PMONITOR = OUTPUT->monitor.lock();
     const auto  CLIENT   = mgr->client();
 
-    CXDGOutput* pXDGOutput = m_vXDGOutputs.emplace_back(std::make_unique<CXDGOutput>(makeShared<CZxdgOutputV1>(CLIENT, mgr->version(), id), PMONITOR)).get();
+    CXDGOutput* pXDGOutput = m_vXDGOutputs.emplace_back(makeUnique<CXDGOutput>(makeShared<CZxdgOutputV1>(CLIENT, mgr->version(), id), PMONITOR)).get();
 #ifndef NO_XWAYLAND
     if (g_pXWayland && g_pXWayland->pServer && g_pXWayland->pServer->xwaylandClient == CLIENT)
         pXDGOutput->isXWayland = true;

--- a/src/protocols/XDGShell.hpp
+++ b/src/protocols/XDGShell.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include <optional>

--- a/src/protocols/XWaylandShell.hpp
+++ b/src/protocols/XWaylandShell.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "WaylandProtocol.hpp"

--- a/src/protocols/core/Compositor.hpp
+++ b/src/protocols/core/Compositor.hpp
@@ -8,7 +8,6 @@
      - wl_callback
 */
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "../WaylandProtocol.hpp"

--- a/src/protocols/core/DataDevice.hpp
+++ b/src/protocols/core/DataDevice.hpp
@@ -8,7 +8,6 @@
      - wl_data_device_manager
 */
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "../WaylandProtocol.hpp"

--- a/src/protocols/core/Output.hpp
+++ b/src/protocols/core/Output.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "../WaylandProtocol.hpp"

--- a/src/protocols/core/Seat.hpp
+++ b/src/protocols/core/Seat.hpp
@@ -8,7 +8,6 @@
      - wl_touch
 */
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "../WaylandProtocol.hpp"

--- a/src/protocols/core/Shm.hpp
+++ b/src/protocols/core/Shm.hpp
@@ -7,7 +7,6 @@
      - wl_buffer with shm
 */
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "../WaylandProtocol.hpp"

--- a/src/protocols/core/Subcompositor.hpp
+++ b/src/protocols/core/Subcompositor.hpp
@@ -7,7 +7,6 @@
      - wl_subcompositor
 */
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "../WaylandProtocol.hpp"

--- a/src/protocols/types/WLBuffer.hpp
+++ b/src/protocols/types/WLBuffer.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include <vector>
 #include <cstdint>
 #include "../WaylandProtocol.hpp"

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -328,4 +328,4 @@ class CHyprOpenGLImpl {
     friend class CSurfacePassElement;
 };
 
-inline std::unique_ptr<CHyprOpenGLImpl> g_pHyprOpenGL;
+inline UP<CHyprOpenGLImpl> g_pHyprOpenGL;

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -155,4 +155,4 @@ class CHyprRenderer {
     friend class CMonitor;
 };
 
-inline std::unique_ptr<CHyprRenderer> g_pHyprRenderer;
+inline UP<CHyprRenderer> g_pHyprRenderer;

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -176,11 +176,11 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
             CTitleTex* pTitleTex = textureFromTitle(m_dwGroupMembers[WINDOWINDEX]->m_szTitle);
 
             if (!pTitleTex)
-                pTitleTex = m_sTitleTexs.titleTexs
-                                .emplace_back(std::make_unique<CTitleTex>(m_dwGroupMembers[WINDOWINDEX].lock(),
-                                                                          Vector2D{m_fBarWidth * pMonitor->scale, (*PTITLEFONTSIZE + 2L * BAR_TEXT_PAD) * pMonitor->scale},
-                                                                          pMonitor->scale))
-                                .get();
+                pTitleTex =
+                    m_sTitleTexs.titleTexs
+                        .emplace_back(makeUnique<CTitleTex>(m_dwGroupMembers[WINDOWINDEX].lock(),
+                                                            Vector2D{m_fBarWidth * pMonitor->scale, (*PTITLEFONTSIZE + 2L * BAR_TEXT_PAD) * pMonitor->scale}, pMonitor->scale))
+                        .get();
             rect.y += std::ceil((rect.height - pTitleTex->texSize.y) / 2.0);
             rect.height = pTitleTex->texSize.y;
             rect.width  = pTitleTex->texSize.x;
@@ -421,7 +421,7 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, PHLWIND
     g_pLayoutManager->getCurrentLayout()->recalculateWindow(pDraggedWindow);
 
     if (!pDraggedWindow->getDecorationByType(DECORATION_GROUPBAR))
-        pDraggedWindow->addWindowDeco(std::make_unique<CHyprGroupBarDecoration>(pDraggedWindow));
+        pDraggedWindow->addWindowDeco(makeUnique<CHyprGroupBarDecoration>(pDraggedWindow));
 
     return true;
 }

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -5,7 +5,7 @@
 #include <vector>
 #include "../Texture.hpp"
 #include <string>
-#include <memory>
+#include "../../helpers/memory/Memory.hpp"
 
 class CTitleTex {
   public:
@@ -70,6 +70,6 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
 
     struct STitleTexs {
         // STitleTexs*                            overriden = nullptr; // TODO: make shit shared in-group to decrease VRAM usage.
-        std::vector<std::unique_ptr<CTitleTex>> titleTexs;
+        std::vector<UP<CTitleTex>> titleTexs;
     } m_sTitleTexs;
 };

--- a/src/render/decorations/DecorationPositioner.cpp
+++ b/src/render/decorations/DecorationPositioner.cpp
@@ -79,7 +79,7 @@ CDecorationPositioner::SWindowPositioningData* CDecorationPositioner::getDataFor
     if (it != m_vWindowPositioningDatas.end())
         return it->get();
 
-    const auto DATA = m_vWindowPositioningDatas.emplace_back(std::make_unique<CDecorationPositioner::SWindowPositioningData>(pWindow, pDecoration)).get();
+    const auto DATA = m_vWindowPositioningDatas.emplace_back(makeUnique<CDecorationPositioner::SWindowPositioningData>(pWindow, pDecoration)).get();
 
     DATA->positioningInfo = pDecoration->getPositioningInfo();
 

--- a/src/render/decorations/DecorationPositioner.hpp
+++ b/src/render/decorations/DecorationPositioner.hpp
@@ -87,13 +87,13 @@ class CDecorationPositioner {
         bool        needsRecalc    = false;
     };
 
-    std::map<PHLWINDOWREF, SWindowData>                  m_mWindowDatas;
-    std::vector<std::unique_ptr<SWindowPositioningData>> m_vWindowPositioningDatas;
+    std::map<PHLWINDOWREF, SWindowData>     m_mWindowDatas;
+    std::vector<UP<SWindowPositioningData>> m_vWindowPositioningDatas;
 
-    SWindowPositioningData*                              getDataFor(IHyprWindowDecoration* pDecoration, PHLWINDOW pWindow);
-    void                                                 onWindowUnmap(PHLWINDOW pWindow);
-    void                                                 onWindowMap(PHLWINDOW pWindow);
-    void                                                 sanitizeDatas();
+    SWindowPositioningData*                 getDataFor(IHyprWindowDecoration* pDecoration, PHLWINDOW pWindow);
+    void                                    onWindowUnmap(PHLWINDOW pWindow);
+    void                                    onWindowMap(PHLWINDOW pWindow);
+    void                                    sanitizeDatas();
 };
 
-inline std::unique_ptr<CDecorationPositioner> g_pDecorationPositioner;
+inline UP<CDecorationPositioner> g_pDecorationPositioner;

--- a/src/xwayland/Server.cpp
+++ b/src/xwayland/Server.cpp
@@ -442,7 +442,7 @@ int CXWaylandServer::ready(int fd, uint32_t mask) {
 
     // start the wm
     if (!g_pXWayland->pWM)
-        g_pXWayland->pWM = std::make_unique<CXWM>();
+        g_pXWayland->pWM = makeUnique<CXWM>();
 
     g_pCursorManager->setXWaylandCursor();
 

--- a/src/xwayland/XDataSource.cpp
+++ b/src/xwayland/XDataSource.cpp
@@ -71,7 +71,7 @@ void CXDataSource::send(const std::string& mime, uint32_t fd) {
 
     Debug::log(LOG, "[XDataSource] send with mime {} to fd {}", mime, fd);
 
-    selection.transfer                 = std::make_unique<SXTransfer>(selection);
+    selection.transfer                 = makeUnique<SXTransfer>(selection);
     selection.transfer->incomingWindow = xcb_generate_id(g_pXWayland->pWM->connection);
     const uint32_t MASK                = XCB_EVENT_MASK_SUBSTRUCTURE_NOTIFY | XCB_EVENT_MASK_PROPERTY_CHANGE;
     xcb_create_window(g_pXWayland->pWM->connection, XCB_COPY_FROM_PARENT, selection.transfer->incomingWindow, g_pXWayland->pWM->screen->root, 0, 0, 10, 10, 0,

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -225,7 +225,7 @@ void CXWM::readProp(SP<CXWaylandSurface> XSURF, uint32_t atom, xcb_get_property_
         }
     } else if (atom == HYPRATOMS["WM_HINTS"]) {
         if (reply->value_len != 0) {
-            XSURF->hints = std::make_unique<xcb_icccm_wm_hints_t>();
+            XSURF->hints = makeUnique<xcb_icccm_wm_hints_t>();
             xcb_icccm_get_wm_hints_from_reply(XSURF->hints.get(), reply);
 
             if (!(XSURF->hints->flags & XCB_ICCCM_WM_HINT_INPUT))
@@ -254,7 +254,7 @@ void CXWM::readProp(SP<CXWaylandSurface> XSURF, uint32_t atom, xcb_get_property_
         }
     } else if (atom == HYPRATOMS["WM_NORMAL_HINTS"]) {
         if (reply->type == HYPRATOMS["WM_SIZE_HINTS"] && reply->value_len > 0) {
-            XSURF->sizeHints = std::make_unique<xcb_size_hints_t>();
+            XSURF->sizeHints = makeUnique<xcb_size_hints_t>();
             std::memset(XSURF->sizeHints.get(), 0, sizeof(xcb_size_hints_t));
 
             xcb_icccm_get_wm_size_hints_from_reply(XSURF->sizeHints.get(), reply);
@@ -735,7 +735,7 @@ int CXWM::onEvent(int fd, uint32_t mask) {
         g_pXWayland->pWM.reset();
         g_pXWayland->pServer.reset();
         // Attempt to create fresh instance
-        g_pEventLoopManager->doLater([]() { g_pXWayland = std::make_unique<CXWayland>(true); });
+        g_pEventLoopManager->doLater([]() { g_pXWayland = makeUnique<CXWayland>(true); });
         return 0;
     }
 
@@ -1346,7 +1346,7 @@ bool SXSelection::sendData(xcb_selection_request_event_t* e, std::string mime) {
         mime = *MIMES.begin();
     }
 
-    transfer          = std::make_unique<SXTransfer>(*this);
+    transfer          = makeUnique<SXTransfer>(*this);
     transfer->request = *e;
 
     int p[2];

--- a/src/xwayland/XWM.hpp
+++ b/src/xwayland/XWM.hpp
@@ -57,7 +57,7 @@ struct SXSelection {
         CHyprSignalListener keyboardFocusChange;
     } listeners;
 
-    std::unique_ptr<SXTransfer> transfer;
+    UP<SXTransfer> transfer;
 };
 
 class CXCBConnection {

--- a/src/xwayland/XWayland.cpp
+++ b/src/xwayland/XWayland.cpp
@@ -26,7 +26,7 @@ CXWayland::CXWayland(const bool wantsEnabled) {
 
     Debug::log(LOG, "Starting up the XWayland server");
 
-    pServer = std::make_unique<CXWaylandServer>();
+    pServer = makeUnique<CXWaylandServer>();
 
     if (!pServer->create()) {
         Debug::log(ERR, "XWayland failed to start: it will not work.");

--- a/src/xwayland/XWayland.hpp
+++ b/src/xwayland/XWayland.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <memory>
 #include "../helpers/signal/Signal.hpp"
 #include "../helpers/memory/Memory.hpp"
 #include "../macros.hpp"
@@ -20,8 +19,8 @@ class CXWayland {
     CXWayland(const bool wantsEnabled);
 
 #ifndef NO_XWAYLAND
-    std::unique_ptr<CXWaylandServer> pServer;
-    std::unique_ptr<CXWM>            pWM;
+    UP<CXWaylandServer> pServer;
+    UP<CXWM>            pWM;
 #endif
     bool enabled();
 
@@ -35,7 +34,7 @@ class CXWayland {
     bool m_enabled = false;
 };
 
-inline std::unique_ptr<CXWayland>                g_pXWayland;
+inline UP<CXWayland>                             g_pXWayland;
 
 inline std::unordered_map<std::string, uint32_t> HYPRATOMS = {
 #ifndef NO_XWAYLAND


### PR DESCRIPTION
Moves (almost) all unique_ptrs to hyprutils.

In the future, we also want to remove the remaining functions that return raw C pointers due to storage like vector<unique_ptr<>>