### PR TITLE
animation: fix borderangle once

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1155,6 +1155,7 @@ void CCompositor::focusWindow(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface
     g_pXWaylandManager->activateWindow(pWindow, true); // sets the m_pLastWindow
 
     pWindow->updateDynamicRules();
+    pWindow->onFocusAnimUpdate();
 
     updateWindowAnimatedDecorationValues(pWindow);
 
@@ -1850,10 +1851,6 @@ void CCompositor::updateWindowAnimatedDecorationValues(PHLWINDOW pWindow) {
             setBorderColor(pWindow->m_sWindowData.inactiveBorderColor.valueOr(*INACTIVECOLOR));
         }
     }
-
-    // tick angle if it's not running (aka dead)
-    if (!pWindow->m_fBorderAngleAnimationProgress->isBeingAnimated())
-        pWindow->m_fBorderAngleAnimationProgress->setValueAndWarp(0.f);
 
     // opacity
     const auto PWORKSPACE = pWindow->m_pWorkspace;

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1274,6 +1274,14 @@ void CWindow::onWorkspaceAnimUpdate() {
     m_vFloatingOffset = offset;
 }
 
+void CWindow::onFocusAnimUpdate() {
+    // borderangle once
+    if (m_fBorderAngleAnimationProgress->enabled() && !m_fBorderAngleAnimationProgress->isBeingAnimated()) {
+        m_fBorderAngleAnimationProgress->setValueAndWarp(0.f);
+        *m_fBorderAngleAnimationProgress = 1.f;
+    }
+}
+
 int CWindow::popupsCount() {
     if (m_bIsX11)
         return 0;

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -454,6 +454,7 @@ class CWindow {
     void                   switchWithWindowInGroup(PHLWINDOW pWindow);
     void                   setAnimationsToMove();
     void                   onWorkspaceAnimUpdate();
+    void                   onFocusAnimUpdate();
     void                   onUpdateState();
     void                   onUpdateMeta();
     void                   onX11Configure(CBox box);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Closes https://github.com/hyprwm/Hyprland/issues/9065

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Personally I would prefer if it we would increment the progress by 1 on a focus change. That way it would always rotate by 360 degrees when the focus changes. But it would mean that the angle is not static and can shift, so the way it is now probably makes more sense.

#### Is it ready for merging, or does it need work?

Ready

