### PR TITLE
layershell: check if layer is valid

### DIFF
--- a/src/protocols/LayerShell.cpp
+++ b/src/protocols/LayerShell.cpp
@@ -233,6 +233,11 @@ void CLayerShellProtocol::onGetLayerSurface(CZwlrLayerShellV1* pMgr, uint32_t id
         return;
     }
 
+    if UNLIKELY (layer > ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY) {
+        pMgr->error(ZWLR_LAYER_SHELL_V1_ERROR_INVALID_LAYER, "Invalid layer");
+        return;
+    }
+
     const auto RESOURCE = m_vLayers.emplace_back(makeShared<CLayerShellResource>(makeShared<CZwlrLayerSurfaceV1>(CLIENT, pMgr->version(), id), SURF, namespace_, PMONITOR, layer));
 
     if UNLIKELY (!RESOURCE->good()) {


### PR DESCRIPTION
Fixes compositor crash when client tried to create a layer surface with invalid layer argument

<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
When playing around with wayland clients I noticed that hyprland would crash when I try to pass an invalid layer param, turns out it was causing out of bounds array access in https://github.com/hyprwm/Hyprland/blob/57a39984dddd00fd1aca436e149b7566e5e48d95/src/desktop/LayerSurface.cpp#L37

Basically copy pasted the check from https://github.com/hyprwm/Hyprland/blob/57a39984dddd00fd1aca436e149b7566e5e48d95/src/protocols/LayerShell.cpp#L147


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nope


#### Is it ready for merging, or does it need work?
Ready

