### PR TITLE
datadevice: do the unfocus surface stuff before dndActive is true

### DIFF
--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -194,7 +194,7 @@ void CSeatManager::setPointerFocus(SP<CWLSurfaceResource> surf, const Vector2D& 
     if (state.pointerFocus == surf)
         return;
 
-    if (PROTO::data->dndActive()) {
+    if (PROTO::data->dndActive() && surf) {
         if (state.dndPointerFocus == surf)
             return;
         Debug::log(LOG, "[seatmgr] Refusing pointer focus during an active dnd, but setting dndPointerFocus");


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Closes https://github.com/hyprwm/Hyprland/issues/8923

Basically re-adds the workaround added in https://github.com/hyprwm/Hyprland/commit/1b5444494d26624804de8f479da3cffb5d480dc6.
In https://github.com/hyprwm/Hyprland/commit/9f7a96b997d90c4c188f3837e02859a25a05611e the `&& surf` part of the if statement was removed breaking the workaround.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Dnd... Who knows which app will break. Any list of problem childs?

#### Is it ready for merging, or does it need work?

Ready, but some testing would be good.
