### PR TITLE
window: only set m_iMonitorMovedFrom, when moving to a different monitor

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1867,7 +1867,6 @@ void CCompositor::updateWindowAnimatedDecorationValues(PHLWINDOW pWindow) {
     }
 
     // opacity
-    const auto PWORKSPACE = pWindow->m_pWorkspace;
     if (pWindow->isEffectiveInternalFSMode(FSMODE_FULLSCREEN)) {
         *pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaFullscreen.valueOrDefault().applyAlpha(*PFULLSCREENALPHA);
     } else {

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -420,12 +420,13 @@ void CWindow::moveToWorkspace(PHLWORKSPACE pWorkspace) {
 
     static auto PCLOSEONLASTSPECIAL = CConfigValue<Hyprlang::INT>("misc:close_special_on_empty");
 
-    const auto  OLDWORKSPACE = m_pWorkspace;
+    const auto  OLDWORKSPACE     = m_pWorkspace;
+    const bool  TOANOTHERMONITOR = OLDWORKSPACE && OLDWORKSPACE->monitorID() != pWorkspace->monitorID();
 
     m_fMovingToWorkspaceAlpha->setValueAndWarp(1.F);
     *m_fMovingToWorkspaceAlpha = 0.F;
     m_fMovingToWorkspaceAlpha->setCallbackOnEnd([this](auto) { m_iMonitorMovedFrom = -1; });
-    m_iMonitorMovedFrom = OLDWORKSPACE ? OLDWORKSPACE->monitorID() : -1;
+    m_iMonitorMovedFrom = TOANOTHERMONITOR ? OLDWORKSPACE->monitorID() : -1;
 
     m_pWorkspace = pWorkspace;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Closes https://github.com/hyprwm/Hyprland/issues/8826

I think `m_iMonitorMovedFrom` was supposed to remain `-1` in case the window gets moved to another workspace on the same montior. That fixes the issue.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Ready
