### PR TITLE
compositor: fix incorrect cast, use lambda capture instead

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2505,13 +2505,13 @@ PHLLS CCompositor::getLayerSurfaceFromSurface(SP<CWLSurfaceResource> pSurface) {
             continue;
 
         ls->layerSurface->surface->breadthfirst(
-            [](SP<CWLSurfaceResource> surf, const Vector2D& offset, void* data) {
-                if (surf == ((std::pair<SP<CWLSurfaceResource>, bool>*)data)->first) {
-                    *(bool*)data = true;
+            [&result](SP<CWLSurfaceResource> surf, const Vector2D& offset, void* data) {
+                if (surf == result.first) {
+                    result.second = true;
                     return;
                 }
             },
-            &result);
+            nullptr);
 
         if (result.second)
             return ls;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Fixes a very sus `*(bool*)data` cast (which should've been `((std::pair<SP<CWLSurfaceResource>, bool>*)data)->second`) that was causing segfaults from time to time (haven't found a consistent way to reproduce it though), and replaces it with cleaner lambda capture.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No


#### Is it ready for merging, or does it need work?
Ready

