### PR TITLE
config: disable borderangle by default

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -882,6 +882,7 @@ void CConfigManager::setDefaultAnimationVars() {
     // init the root nodes
     m_AnimationTree.setConfigForNode("global", 1, 8.f, "", "default");
     m_AnimationTree.setConfigForNode("__internal_fadeCTM", 1, 5.f, "", "linear");
+    m_AnimationTree.setConfigForNode("borderangle", 0, 0.f, "", "default");
 }
 
 std::optional<std::string> CConfigManager::resetHLConfig() {

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -552,9 +552,11 @@ void CWindow::onMap() {
 
     m_fMovingFromWorkspaceAlpha->setValueAndWarp(1.F);
 
-    m_fBorderAngleAnimationProgress->setValueAndWarp(0.f);
-    m_fBorderAngleAnimationProgress->setCallbackOnEnd([&](WP<CBaseAnimatedVariable> p) { onBorderAngleAnimEnd(p); }, false);
-    *m_fBorderAngleAnimationProgress = 1.f;
+    if (m_fBorderAngleAnimationProgress->enabled()) {
+        m_fBorderAngleAnimationProgress->setValueAndWarp(0.f);
+        m_fBorderAngleAnimationProgress->setCallbackOnEnd([&](WP<CBaseAnimatedVariable> p) { onBorderAngleAnimEnd(p); }, false);
+        *m_fBorderAngleAnimationProgress = 1.f;
+    }
 
     m_fMovingFromWorkspaceAlpha->setValueAndWarp(1.F);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Since borderangle once works again, it will run by default. 
The borderangle animation is also not in the example conf and looks award if you don't account for it.
So i thought just disabling it by default is ok? we don't do that with other animations though.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Yes
