### PR TITLE
config/ConfigWatcher.cpp: add missing include needed for clang

### DIFF
--- a/src/config/ConfigWatcher.cpp
+++ b/src/config/ConfigWatcher.cpp
@@ -3,6 +3,7 @@
 #include "../debug/Log.hpp"
 #include <ranges>
 #include <fcntl.h>
+#include <unistd.h>
 
 CConfigWatcher::CConfigWatcher() : m_inotifyFd(inotify_init()) {
     if (m_inotifyFd < 0) {


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Fixes clang build by including unistd.h which is needed for read() and close()


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready

