### PR TITLE
xwayland: fix pointer mismatches with multiple monitors

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1702,11 +1702,9 @@ void CWindow::sendWindowSize(Vector2D size, bool force, std::optional<Vector2D> 
     // TODO: this should be decoupled from setWindowSize IMO
     Vector2D windowPos = overridePos.value_or(m_vRealPosition->goal());
 
-    if (m_bIsX11 && PMONITOR) {
-        windowPos -= PMONITOR->vecPosition; // normalize to monitor
-        if (*PXWLFORCESCALEZERO)
-            windowPos *= PMONITOR->scale;           // scale if applicable
-        windowPos += PMONITOR->vecXWaylandPosition; // move to correct position for xwayland
+    if (m_bIsX11) {
+        if (const auto XWAYLANDPOS = g_pXWaylandManager->waylandToXWaylandCoords(windowPos); XWAYLANDPOS != Vector2D{})
+            windowPos = XWAYLANDPOS;
     }
 
     if (!force && m_vPendingReportedSize == size && (windowPos == m_vReportedPosition || !m_bIsX11))


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes an xwayland pointer mismatch. I think it only happens with multiple monitors. See this:

<details> <summary>Recordings of the problem</summary>

BEFORE:

https://github.com/user-attachments/assets/99c6746d-f249-4f4f-ab7a-94cca6a1771d

AFTER:

https://github.com/user-attachments/assets/08b5edd1-7d66-4774-8a20-53d86cd12262

</details>

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

*No idea if there is a reason why `waylandToXWaylandCoords` was not used and maybe this is wrong*

Tried some xwayland stuff and everything I tested still works.

#### Is it ready for merging, or does it need work?

Ready.

