### PR TITLE
update groups on movewindow

### DIFF
--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -847,6 +847,15 @@ void CHyprDwindleLayout::moveWindowTo(PHLWINDOW pWindow, const std::string& dir,
         pWindow->m_pMonitor = PMONITORFOCAL;
     }
 
+    pWindow->updateGroupOutputs();
+    if (!pWindow->m_sGroupData.pNextWindow.expired()) {
+        PHLWINDOW next = pWindow->m_sGroupData.pNextWindow.lock();
+        while (next != pWindow) {
+            next->updateToplevel();
+            next = next->m_sGroupData.pNextWindow.lock();
+        }
+    }
+
     onWindowCreatedTiling(pWindow);
 
     m_vOverrideFocalPoint.reset();

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -945,6 +945,15 @@ void CHyprMasterLayout::moveWindowTo(PHLWINDOW pWindow, const std::string& dir, 
         if (silent)
             g_pCompositor->focusWindow(PWINDOW2);
     }
+
+    pWindow->updateGroupOutputs();
+    if (!pWindow->m_sGroupData.pNextWindow.expired()) {
+        PHLWINDOW next = pWindow->m_sGroupData.pNextWindow.lock();
+        while (next != pWindow) {
+            next->updateToplevel();
+            next = next->m_sGroupData.pNextWindow.lock();
+        }
+    }
 }
 
 void CHyprMasterLayout::switchWindows(PHLWINDOW pWindow, PHLWINDOW pWindow2) {


### PR DESCRIPTION
fixes `movewindow` between monitors for grouped windows making hidden (when moved) group windows invisible and belonging to the wrong monitor.