### PR TITLE
ensure framebuffer textures are detached and deleted, avoid leaving framebuffers bound when not needed

### DIFF
--- a/src/protocols/Screencopy.cpp
+++ b/src/protocols/Screencopy.cpp
@@ -289,6 +289,12 @@ bool CScreencopyFrame::copyShm() {
 
     g_pHyprOpenGL->m_RenderData.pMonitor.reset();
 
+#ifndef GLES2
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+#else
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+#endif
+
     LOGM(TRACE, "Copied frame via shm");
 
     return true;

--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -296,6 +296,12 @@ bool CToplevelExportFrame::copyShm(timespec* now) {
         g_pPointerManager->damageCursor(PMONITOR->self.lock());
     }
 
+    outFB.unbind();
+
+#ifndef GLES2
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+#endif
+
     return true;
 }
 

--- a/src/render/Framebuffer.hpp
+++ b/src/render/Framebuffer.hpp
@@ -11,6 +11,7 @@ class CFramebuffer {
     bool         alloc(int w, int h, uint32_t format = GL_RGBA);
     void         addStencil(SP<CTexture> tex);
     void         bind();
+    void         unbind();
     void         release();
     void         reset();
     bool         isAllocated();

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -234,8 +234,6 @@ class CHyprOpenGLImpl {
 
     SCurrentRenderData                   m_RenderData;
 
-    GLint                                m_iCurrentOutputFb = 0;
-
     Hyprutils::OS::CFileDescriptor       m_iGBMFD;
     gbm_device*                          m_pGbmDevice   = nullptr;
     EGLContext                           m_pEglContext  = nullptr;

--- a/src/render/Renderbuffer.cpp
+++ b/src/render/Renderbuffer.cpp
@@ -46,7 +46,7 @@ CRenderbuffer::CRenderbuffer(SP<Aquamarine::IBuffer> buffer, uint32_t format) : 
         return;
     }
 
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    m_sFramebuffer.unbind();
 
     listeners.destroyBuffer = buffer->events.destroy.registerListener([this](std::any d) { g_pHyprRenderer->onRenderbufferDestroy(this); });
 
@@ -68,11 +68,7 @@ void CRenderbuffer::bindFB() {
 
 void CRenderbuffer::unbind() {
     glBindRenderbuffer(GL_RENDERBUFFER, 0);
-#ifndef GLES2
-    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
-#else
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-#endif
+    m_sFramebuffer.unbind();
 }
 
 CFramebuffer* CRenderbuffer::getFB() {

--- a/src/render/Shader.cpp
+++ b/src/render/Shader.cpp
@@ -17,6 +17,9 @@ CShader::~CShader() {
 }
 
 void CShader::destroy() {
+    if (program == 0)
+        return;
+
     glDeleteProgram(program);
 
     program = 0;


### PR DESCRIPTION
without detaching textures before deleting them they become dangling in vram if my google skills are correct. so ensure we call glFramebufferTexture2D on the framebuffer before deleting it. and in good practice try to unbind the framebuffers where framebuffers have been bound after its usage. and dont call glDeleteProgram on a zero program, its safe to do so but fills apitrace up with unnecessery lines.


