### PR TITLE
xwayland: respect window size set by configure requests

### DIFF
--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -82,29 +82,9 @@ CBox CHyprXWaylandManager::getGeometryForWindow(PHLWINDOW pWindow) {
 
     CBox box;
 
-    if (pWindow->m_bIsX11) {
-        const auto SIZEHINTS = pWindow->m_pXWaylandSurface->sizeHints.get();
-
-        if (SIZEHINTS && !pWindow->isX11OverrideRedirect()) {
-            // WM_SIZE_HINTS' x,y,w,h is deprecated it seems.
-            // Source: https://x.org/releases/X11R7.6/doc/xorg-docs/specs/ICCCM/icccm.html#wm_normal_hints_property
-            box.x = pWindow->m_pXWaylandSurface->geometry.x;
-            box.y = pWindow->m_pXWaylandSurface->geometry.y;
-
-            constexpr int ICCCM_USSize = 0x2;
-            constexpr int ICCCM_PSize  = 0x8;
-
-            if ((SIZEHINTS->flags & ICCCM_USSize) || (SIZEHINTS->flags & ICCCM_PSize)) {
-                box.w = SIZEHINTS->base_width;
-                box.h = SIZEHINTS->base_height;
-            } else {
-                box.w = pWindow->m_pXWaylandSurface->geometry.w;
-                box.h = pWindow->m_pXWaylandSurface->geometry.h;
-            }
-        } else
-            box = pWindow->m_pXWaylandSurface->geometry;
-
-    } else if (pWindow->m_pXDGSurface)
+    if (pWindow->m_bIsX11)
+        box = pWindow->m_pXWaylandSurface->geometry;
+    else if (pWindow->m_pXDGSurface)
         box = pWindow->m_pXDGSurface->current.geometry;
 
     return box;

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -102,8 +102,8 @@ void CXWM::handleMapRequest(xcb_map_request_event_t* e) {
     const bool HAS_HINTS   = XSURF->sizeHints && Vector2D{XSURF->sizeHints->base_width, XSURF->sizeHints->base_height} > Vector2D{5, 5};
     const auto DESIREDSIZE = HAS_HINTS ? Vector2D{XSURF->sizeHints->base_width, XSURF->sizeHints->base_height} : Vector2D{800, 800};
 
-    // if it's too small, or its base size is set, configure it.
-    if ((SMALL || HAS_HINTS) && !XSURF->overrideRedirect) // default to 800 x 800
+    // if it's too small, configure it.
+    if (SMALL && !XSURF->overrideRedirect) // default to 800 x 800
         XSURF->configure({XSURF->geometry.pos(), DESIREDSIZE});
 
     Debug::log(LOG, "[xwm] Mapping window {} in X (geometry {}x{} at {}x{}))", e->window, XSURF->geometry.width, XSURF->geometry.height, XSURF->geometry.x, XSURF->geometry.y);


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Currently for XWayland windows, base_width & base_height from WM_NORMAL_HINTS is used as initial size if available. This is undesirable as some X11 applications (including VLC and LibreOffice) set initial window size by sending ConfigureWindow **before** MapWindow, which gets overridden by base size in handleMapRequest. Instead we should keep CXWaylandSurface::geometry, which is set by CreateWindow or ConfigureWindow, as is when possible.

Also, according to ICCCM:

>  The x, y, width, and height fields have been removed from the WM_NORMAL_HINTS property and replaced by pad fields. Values set into these fields will be ignored. The position and size of the window should be set by setting the appropriate window attributes. 

> The base_width and base_height elements in conjunction with width_inc and height_inc define an arithmetic progression of preferred window widths and heights for non-negative integers i and j

>  Window managers that honor aspect ratios should take into account the base size in determining the preferred window size. If a base size is provided along with the aspect ratio fields, the base size should be subtracted from the window size prior to checking that the aspect ratio falls in range.

We are not implementing constraints described in the latter two paragraphs, and the deprecated size fields are replaced by "setting the appropriate window attributes", which I think are the fields in CreateWindow and ConfigureWindow requests.

VLC and LibreOffice (run under XWayland) having bad initial window size:

![image](https://github.com/user-attachments/assets/287db369-b99c-4449-adae-c312c4dbb2ec)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

N/A

#### Is it ready for merging, or does it need work?

Y