### PR TITLE
xwayland: send synthetic configure events

### DIFF
--- a/src/xwayland/XSurface.cpp
+++ b/src/xwayland/XSurface.cpp
@@ -169,6 +169,22 @@ void CXWaylandSurface::configure(const CBox& box) {
     uint32_t values[] = {box.x, box.y, box.width, box.height, 0};
     xcb_configure_window(g_pXWayland->pWM->connection, xID, mask, values);
 
+    if (geometry.width == box.width && geometry.height == box.height) {
+        // ICCCM requires a synthetic event when window size is not changed
+        xcb_configure_notify_event_t e;
+        e.response_type     = XCB_CONFIGURE_NOTIFY;
+        e.event             = xID;
+        e.window            = xID;
+        e.x                 = box.x;
+        e.y                 = box.y;
+        e.width             = box.width;
+        e.height            = box.height;
+        e.border_width      = 0;
+        e.above_sibling     = XCB_NONE;
+        e.override_redirect = overrideRedirect;
+        xcb_send_event(g_pXWayland->pWM->connection, false, xID, XCB_EVENT_MASK_STRUCTURE_NOTIFY, (const char*)&e);
+    }
+
     g_pXWayland->pWM->updateClientList();
 
     xcb_flush(g_pXWayland->pWM->connection);


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

ICCCM says that when we move a window or receive ConfigureRequest but decide not to change the window size, a synthetic ConfigureNotify event should be sent in addition to the real event possibly generated by the X server.

This is mainly because:
1. For reparenting WMs, the event generated by the X server contains coordinates relative to the parent window, which are not quite useful, while the synthetic event should contain coordinates relative to the root window. Hyprland's XWM is not reparenting, so this should be irrelevant here.
2. If we decide not to change window geometry despite client's request (because the window is tiled for example), the client should be informed but the X server will not generate ConfigureNotify events if we call xcb_configure_window with the old geometry.

This should fix the problem that, when GIMP's window is tiled and wants to extend itself to display a large image, it will become unresponsive, waiting for a ConfigureNotify event.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

N/A

#### Is it ready for merging, or does it need work?

Y