### PR TITLE
Unbreak build on FreeBSD via libinotify-kqueue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,12 @@ if(NOT HAS_TIMERFD AND epoll_FOUND)
   target_link_libraries(Hyprland PkgConfig::epoll)
 endif()
 
+check_include_file("sys/inotify.h" HAS_INOTIFY)
+pkg_check_modules(inotify IMPORTED_TARGET libinotify)
+if(NOT HAS_INOTIFY AND inotify_FOUND)
+  target_link_libraries(Hyprland PkgConfig::inotify)
+endif()
+
 if(LEGACY_RENDERER)
   message(STATUS "Using the legacy GLES2 renderer!")
   add_compile_definitions(LEGACY_RENDERER)

--- a/meson.build
+++ b/meson.build
@@ -58,6 +58,7 @@ endif
 
 backtrace_dep = cpp_compiler.find_library('execinfo', required: false)
 epoll_dep = dependency('epoll-shim', required: false) # timerfd on BSDs
+inotify_dep = dependency('libinotify', required: false) # inotify on BSDs
 
 re2 = dependency('re2', required: true)
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -32,6 +32,7 @@ executable(
     xcb_xfixes_dep,
     backtrace_dep,
     epoll_dep,
+    inotify_dep,
     gio_dep,
     tracy,
 


### PR DESCRIPTION
Similar to #5595 (timerfd). Also used by Wayfire, pipewire, etc.