### PR TITLE
clear keyboard focus if found surface can't be focused

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -425,7 +425,9 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse) {
         }
 
         g_pSeatManager->setPointerFocus(nullptr, {});
+    }
 
+    if (!foundSurface || !foundSurface->hlSurface->keyboardFocusable()) {
         if (refocus || g_pCompositor->m_pLastWindow.expired()) // if we are forcing a refocus, and we don't find a surface, clear the kb focus too!
             g_pCompositor->focusWindow(nullptr);
 


### PR DESCRIPTION
clears keyboard focus if found surface can't be keyboard focused
fixes active window not being set to null after closing a special workspace if cursor is above layer that's not keyboard focusable

unsure what side effects this can cause