### PR TITLE
fix two minor asan reported leaks

### DIFF
--- a/src/devices/IKeyboard.cpp
+++ b/src/devices/IKeyboard.cpp
@@ -44,6 +44,10 @@ void IKeyboard::clearManuallyAllocd() {
     if (xkbKeymapFD >= 0)
         close(xkbKeymapFD);
 
+    if (xkbSymState)
+        xkb_state_unref(xkbSymState);
+
+    xkbSymState    = nullptr;
     xkbKeymap      = nullptr;
     xkbState       = nullptr;
     xkbStaticState = nullptr;


### PR DESCRIPTION
free xkbSymState on destruction or call to clearManuallyAllocd if its allocated, otherwise we leak it.

globfree seems to only free internal resources allocated by glob() so lets free the glob_t structure aswell.

