### PR TITLE
nix/module: toHyprconf -> toHyprlang

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,0 +1,59 @@
+lib: with lib; {
+  toHyprlang = {
+    topCommandsPrefixes ? ["$"],
+    bottomCommandsPrefixes ? [],
+  }: attrs: let
+    toHyprlang' = attrs: let
+      toStr = x:
+        if isBool x
+        then boolToString x
+        else toString x;
+
+      categories = filterAttrs (n: v: isAttrs v || (isList v && all isAttrs v)) attrs;
+      mkCategory = parent: attrs:
+        if lib.isList attrs
+        then concatMapStringsSep "\n" (a: mkCategory parent a) attrs
+        else
+          concatStringsSep "\n" (
+            mapAttrsToList (
+              k: v:
+                if isAttrs v
+                then mkCategory "${parent}:${k}" v
+                else if isList v
+                then concatMapStringsSep "\n" (item: "${parent}:${k} = ${toStr item}") v
+                else "${parent}:${k} = ${toStr v}"
+            )
+            attrs
+          );
+
+      mkCommands = toKeyValue {
+        mkKeyValue = mkKeyValueDefault {} " = ";
+        listsAsDuplicateKeys = true;
+        indent = "";
+      };
+
+      allCommands = filterAttrs (n: v: !(isAttrs v || (isList v && all isAttrs v))) attrs;
+
+      filterCommands = list: n: foldl (acc: prefix: acc || hasPrefix prefix n) false list;
+
+      # Get topCommands attr names
+      result = partition (filterCommands topCommandsPrefixes) (attrNames allCommands);
+      # Filter top commands from all commands
+      topCommands = filterAttrs (n: _: (builtins.elem n result.right)) allCommands;
+      # Remaining commands = allcallCommands - topCommands
+      remainingCommands = removeAttrs allCommands result.right;
+
+      # Get bottomCommands attr names
+      result2 = partition (filterCommands bottomCommandsPrefixes) result.wrong;
+      # Filter bottom commands from remainingCommands
+      bottomCommands = filterAttrs (n: _: (builtins.elem n result2.right)) remainingCommands;
+      # Regular commands = allCommands - topCommands - bottomCommands
+      regularCommands = removeAttrs remainingCommands result2.right;
+    in
+      mkCommands topCommands
+      + concatStringsSep "\n" (mapAttrsToList mkCategory categories)
+      + mkCommands regularCommands
+      + mkCommands bottomCommands;
+  in
+    toHyprlang' attrs;
+}

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,4 +1,17 @@
-lib: with lib; let
+lib: let
+  inherit (lib)
+    attrNames
+    filterAttrs
+    foldl
+    generators
+    partition
+    ;
+
+  inherit (lib.strings)
+    concatMapStrings
+    hasPrefix
+    ;
+
   /**
     Convert a structured Nix attribute set into Hyprland's configuration format.
 

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,59 +1,122 @@
-lib: with lib; {
+lib: with lib; let
   toHyprlang = {
     topCommandsPrefixes ? ["$"],
     bottomCommandsPrefixes ? [],
   }: attrs: let
     toHyprlang' = attrs: let
-      toStr = x:
-        if isBool x
-        then boolToString x
-        else toString x;
-
-      categories = filterAttrs (n: v: isAttrs v || (isList v && all isAttrs v)) attrs;
-      mkCategory = parent: attrs:
-        if lib.isList attrs
-        then concatMapStringsSep "\n" (a: mkCategory parent a) attrs
-        else
-          concatStringsSep "\n" (
-            mapAttrsToList (
-              k: v:
-                if isAttrs v
-                then mkCategory "${parent}:${k}" v
-                else if isList v
-                then concatMapStringsSep "\n" (item: "${parent}:${k} = ${toStr item}") v
-                else "${parent}:${k} = ${toStr v}"
-            )
-            attrs
-          );
-
-      mkCommands = toKeyValue {
-        mkKeyValue = mkKeyValueDefault {} " = ";
+      # Specially configured `toKeyValue` generator with support for duplicate
+      # keys and legible key-value separator.
+      mkCommands = generators.toKeyValue {
+        mkKeyValue = generators.mkKeyValueDefault {} " = ";
         listsAsDuplicateKeys = true;
+        # No indent, since we don't have nesting
         indent = "";
       };
 
-      allCommands = filterAttrs (n: v: !(isAttrs v || (isList v && all isAttrs v))) attrs;
+      # Flatten the attrset, combining keys in a "path" like `"a:b:c" = "x"`.
+      # See `flattenAttrs` for more info.
+      commands = flattenAttrs (p: k: "${p}:${k}") attrs;
 
+      # General filtering command. Used for filtering top/bottom commands.
+      # Takes a list of prefixes and an element to check.
+      # Returns true if any of the prefixes matched, otherwise false.
       filterCommands = list: n: foldl (acc: prefix: acc || hasPrefix prefix n) false list;
 
-      # Get topCommands attr names
-      result = partition (filterCommands topCommandsPrefixes) (attrNames allCommands);
-      # Filter top commands from all commands
-      topCommands = filterAttrs (n: _: (builtins.elem n result.right)) allCommands;
-      # Remaining commands = allcallCommands - topCommands
-      remainingCommands = removeAttrs allCommands result.right;
+      # FIXME(docs): improve explanations for the below amalgamation
 
-      # Get bottomCommands attr names
+      # Get topCommands attribute names
+      result = partition (filterCommands topCommandsPrefixes) (attrNames commands);
+      # Filter top commands from all commands, using the attribute names
+      # previously obtained
+      topCommands = filterAttrs (n: _: (builtins.elem n result.right)) commands;
+      # Remaining commands = allcallCommands - topCommands
+      remainingCommands = removeAttrs commands result.right;
+
+      # Get bottomCommands attr names from commands remaining (in result.wrong)
       result2 = partition (filterCommands bottomCommandsPrefixes) result.wrong;
-      # Filter bottom commands from remainingCommands
+      # Filter bottom commands from remainingCommands using the attribute names
+      # previously obtained
       bottomCommands = filterAttrs (n: _: (builtins.elem n result2.right)) remainingCommands;
       # Regular commands = allCommands - topCommands - bottomCommands
       regularCommands = removeAttrs remainingCommands result2.right;
     in
-      mkCommands topCommands
-      + concatStringsSep "\n" (mapAttrsToList mkCategory categories)
-      + mkCommands regularCommands
-      + mkCommands bottomCommands;
+      # Concatenate the strings resulting from mapping `mkCommands` over the
+      # list of commands.
+      concatMapStrings mkCommands [
+        topCommands
+        regularCommands
+        bottomCommands
+      ];
   in
     toHyprlang' attrs;
+
+
+  /**
+    Flatten a nested attribute set into a flat attribute set, joining keys with a user-defined function.
+
+    This function takes a function `pred` that determines how nested keys should be joined,
+    and an attribute set `attrs` that should be flattened.
+
+    ## Example
+
+    ```nix
+    let
+      nested = {
+        a = "3";
+        b = { c = "4"; d = "5"; };
+      };
+
+      separator = (prefix: key: "${prefix}.${key}");  # Use dot notation
+    in flattenAttrs separator nested
+    ```
+
+    **Output:**
+    ```nix
+    {
+      "a" = "3";
+      "b.c" = "4";
+      "b.d" = "5";
+    }
+    ```
+
+    ## Parameters
+
+    - **pred** : function `(string -> string -> string)`
+      A function that takes a prefix and a key and returns the new flattened key.
+
+    - **attrs** : attrset
+      The nested attribute set to be flattened.
+
+    ## Returns
+
+    - **attrset** : A flattened attribute set where keys are joined according to `pred`.
+
+    ## Notes
+
+    - This function works recursively for any level of nesting.
+    - It does not modify non-attribute values.
+    - If `pred` is `prefix: key: "${prefix}.${key}"`, it mimics dot notation.
+   */
+  flattenAttrs = pred: attrs: let
+    flattenAttrs' = prefix: attrs:
+      builtins.foldl' (
+        acc: key: let
+          value = attrs.${key};
+          newKey =
+            if prefix == ""
+            then key
+            else pred prefix key;
+        in
+          acc
+          // (
+            if builtins.isAttrs value
+            then flattenAttrs' newKey value
+            else {"${newKey}" = value;}
+          )
+      ) {} (builtins.attrNames attrs);
+  in
+    flattenAttrs' "" attrs;
+in
+{
+  inherit flattenAttrs toHyprlang;
 }

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,47 +1,105 @@
 lib: with lib; let
+  /**
+    Convert a structured Nix attribute set into Hyprland's configuration format.
+
+    This function takes a nested attribute set and converts it into Hyprland-compatible
+    configuration syntax, supporting top, bottom, and regular command sections.
+    
+    Commands are flattened using the `flattenAttrs` function, and attributes are formatted as
+    `key = value` pairs. Lists are expanded as duplicate keys to match Hyprland's expected format.
+
+    Configuration:
+
+    * `topCommandsPrefixes` - A list of prefixes to define **top** commands (default: `["$"]`).
+    * `bottomCommandsPrefixes` - A list of prefixes to define **bottom** commands (default: `[]`).
+
+    Attention:
+
+    - The function ensures top commands appear **first** and bottom commands **last**.
+    - The generated configuration is a **single string**, suitable for writing to a config file.
+    - Lists are converted into multiple entries, ensuring compatibility with Hyprland.
+
+    # Inputs
+
+    Structured function argument:
+
+    : topCommandsPrefixes (optional, default: `["$"]`)
+      : A list of prefixes that define **top** commands. Any key starting with one of these
+        prefixes will be placed at the beginning of the configuration.
+    : bottomCommandsPrefixes (optional, default: `[]`)
+      : A list of prefixes that define **bottom** commands. Any key starting with one of these
+        prefixes will be placed at the end of the configuration.
+
+    Value:
+
+    : The attribute set to be converted to Hyprland configuration format.
+
+    # Type
+
+    ```
+    toHyprlang :: AttrSet -> AttrSet -> String
+    ```
+
+    # Examples
+    :::{.example}
+
+    ```nix
+    let
+      config = {
+        "$mod" = "SUPER";
+        monitor = {
+          "HDMI-A-1" = "1920x1080@60,0x0,1";
+        };
+        exec = [
+          "waybar"
+          "dunst"
+        ];
+      };
+    in lib.toHyprlang {} config
+    ```
+
+    **Output:**
+    ```nix
+    "$mod = SUPER"
+    "monitor:HDMI-A-1 = 1920x1080@60,0x0,1"
+    "exec = waybar"
+    "exec = dunst"
+    ```
+
+    :::
+  */
   toHyprlang = {
     topCommandsPrefixes ? ["$"],
     bottomCommandsPrefixes ? [],
   }: attrs: let
     toHyprlang' = attrs: let
-      # Specially configured `toKeyValue` generator with support for duplicate
-      # keys and legible key-value separator.
+      # Specially configured `toKeyValue` generator with support for duplicate keys
+      # and a legible key-value separator.
       mkCommands = generators.toKeyValue {
         mkKeyValue = generators.mkKeyValueDefault {} " = ";
         listsAsDuplicateKeys = true;
-        # No indent, since we don't have nesting
-        indent = "";
+        indent = ""; # No indent, since we don't have nesting
       };
 
       # Flatten the attrset, combining keys in a "path" like `"a:b:c" = "x"`.
-      # See `flattenAttrs` for more info.
+      # Uses `flattenAttrs` with a colon separator.
       commands = flattenAttrs (p: k: "${p}:${k}") attrs;
 
-      # General filtering command. Used for filtering top/bottom commands.
-      # Takes a list of prefixes and an element to check.
-      # Returns true if any of the prefixes matched, otherwise false.
-      filterCommands = list: n: foldl (acc: prefix: acc || hasPrefix prefix n) false list;
+      # General filtering function to check if a key starts with any prefix in a given list.
+      filterCommands = list: n:
+        foldl (acc: prefix: acc || hasPrefix prefix n) false list;
 
-      # FIXME(docs): improve explanations for the below amalgamation
-
-      # Get topCommands attribute names
+      # Partition keys into top commands and the rest
       result = partition (filterCommands topCommandsPrefixes) (attrNames commands);
-      # Filter top commands from all commands, using the attribute names
-      # previously obtained
-      topCommands = filterAttrs (n: _: (builtins.elem n result.right)) commands;
-      # Remaining commands = allcallCommands - topCommands
+      topCommands = filterAttrs (n: _: builtins.elem n result.right) commands;
       remainingCommands = removeAttrs commands result.right;
 
-      # Get bottomCommands attr names from commands remaining (in result.wrong)
+      # Partition remaining commands into bottom commands and regular commands
       result2 = partition (filterCommands bottomCommandsPrefixes) result.wrong;
-      # Filter bottom commands from remainingCommands using the attribute names
-      # previously obtained
-      bottomCommands = filterAttrs (n: _: (builtins.elem n result2.right)) remainingCommands;
-      # Regular commands = allCommands - topCommands - bottomCommands
+      bottomCommands = filterAttrs (n: _: builtins.elem n result2.right) remainingCommands;
       regularCommands = removeAttrs remainingCommands result2.right;
     in
-      # Concatenate the strings resulting from mapping `mkCommands` over the
-      # list of commands.
+      # Concatenate strings from mapping `mkCommands` over top, regular, and bottom commands.
       concatMapStrings mkCommands [
         topCommands
         regularCommands
@@ -50,14 +108,37 @@ lib: with lib; let
   in
     toHyprlang' attrs;
 
-
   /**
-    Flatten a nested attribute set into a flat attribute set, joining keys with a user-defined function.
+    Flatten a nested attribute set into a flat attribute set, using a custom key separator function.
 
-    This function takes a function `pred` that determines how nested keys should be joined,
-    and an attribute set `attrs` that should be flattened.
+    This function recursively traverses a nested attribute set and produces a flat attribute set
+    where keys are joined using a user-defined function (`pred`). It allows transforming deeply
+    nested structures into a single-level attribute set while preserving key-value relationships.
 
-    ## Example
+    Configuration:
+
+    * `pred` - A function `(string -> string -> string)` defining how keys should be concatenated.
+    
+    # Inputs
+
+    Structured function argument:
+
+    : pred (required)
+      : A function that determines how parent and child keys should be combined into a single key.
+        It takes a `prefix` (parent key) and `key` (current key) and returns the joined key.
+    
+    Value:
+
+    : The nested attribute set to be flattened.
+
+    # Type
+
+    ```
+    flattenAttrs :: (String -> String -> String) -> AttrSet -> AttrSet
+    ```
+
+    # Examples
+    :::{.example}
 
     ```nix
     let
@@ -67,7 +148,7 @@ lib: with lib; let
       };
 
       separator = (prefix: key: "${prefix}.${key}");  # Use dot notation
-    in flattenAttrs separator nested
+    in lib.flattenAttrs separator nested
     ```
 
     **Output:**
@@ -79,24 +160,9 @@ lib: with lib; let
     }
     ```
 
-    ## Parameters
+    :::
 
-    - **pred** : function `(string -> string -> string)`
-      A function that takes a prefix and a key and returns the new flattened key.
-
-    - **attrs** : attrset
-      The nested attribute set to be flattened.
-
-    ## Returns
-
-    - **attrset** : A flattened attribute set where keys are joined according to `pred`.
-
-    ## Notes
-
-    - This function works recursively for any level of nesting.
-    - It does not modify non-attribute values.
-    - If `pred` is `prefix: key: "${prefix}.${key}"`, it mimics dot notation.
-   */
+  */
   flattenAttrs = pred: attrs: let
     flattenAttrs' = prefix: attrs:
       builtins.foldl' (

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -205,9 +205,7 @@ in {
     {
       programs.hyprland = {
         package = lib.mkDefault inputs.self.packages.${system}.hyprland;
-        portalPackage = lib.mkDefault (inputs.self.packages.${system}.xdg-desktop-portal-hyprland.override {
-          hyprland = cfg.finalPackage;
-        });
+        portalPackage = lib.mkDefault inputs.self.packages.${system}.xdg-desktop-portal-hyprland;
       };
     }
     (lib.mkIf cfg.enable {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -5,100 +5,8 @@ inputs: {
   ...
 }: let
   inherit (pkgs.stdenv.hostPlatform) system;
+  selflib = import ./lib.nix lib;
   cfg = config.programs.hyprland;
-
-  toHyprlang = {
-    topCommandsPrefixes ? ["$"],
-    bottomCommandsPrefixes ? [],
-  }: attrs: let
-    inherit (pkgs) lib;
-    inherit
-      (lib.generators)
-      mkKeyValueDefault
-      toKeyValue
-      ;
-    inherit
-      (lib.attrsets)
-      filterAttrs
-      isAttrs
-      mapAttrsToList
-      ;
-    inherit
-      (lib.lists)
-      foldl
-      isList
-      ;
-    inherit
-      (lib.strings)
-      concatMapStringsSep
-      concatStringsSep
-      hasPrefix
-      ;
-    inherit
-      (lib.trivial)
-      boolToString
-      isBool
-      ;
-    inherit
-      (builtins)
-      all
-      attrNames
-      partition
-      ;
-
-    toHyprlang' = attrs: let
-      toStr = x:
-        if isBool x
-        then boolToString x
-        else toString x;
-
-      categories = filterAttrs (n: v: isAttrs v || (isList v && all isAttrs v)) attrs;
-      mkCategory = parent: attrs:
-        if lib.isList attrs
-        then concatMapStringsSep "\n" (a: mkCategory parent a) attrs
-        else
-          concatStringsSep "\n" (
-            mapAttrsToList (
-              k: v:
-                if isAttrs v
-                then mkCategory "${parent}:${k}" v
-                else if isList v
-                then concatMapStringsSep "\n" (item: "${parent}:${k} = ${toStr item}") v
-                else "${parent}:${k} = ${toStr v}"
-            )
-            attrs
-          );
-
-      mkCommands = toKeyValue {
-        mkKeyValue = mkKeyValueDefault {} " = ";
-        listsAsDuplicateKeys = true;
-        indent = "";
-      };
-
-      allCommands = filterAttrs (n: v: !(isAttrs v || (isList v && all isAttrs v))) attrs;
-
-      filterCommands = list: n: foldl (acc: prefix: acc || hasPrefix prefix n) false list;
-
-      # Get topCommands attr names
-      result = partition (filterCommands topCommandsPrefixes) (attrNames allCommands);
-      # Filter top commands from all commands
-      topCommands = filterAttrs (n: _: (builtins.elem n result.right)) allCommands;
-      # Remaining commands = allcallCommands - topCommands
-      remainingCommands = removeAttrs allCommands result.right;
-
-      # Get bottomCommands attr names
-      result2 = partition (filterCommands bottomCommandsPrefixes) result.wrong;
-      # Filter bottom commands from remainingCommands
-      bottomCommands = filterAttrs (n: _: (builtins.elem n result2.right)) remainingCommands;
-      # Regular commands = allCommands - topCommands - bottomCommands
-      regularCommands = removeAttrs remainingCommands result2.right;
-    in
-      mkCommands topCommands
-      + concatStringsSep "\n" (mapAttrsToList mkCategory categories)
-      + mkCommands regularCommands
-      + mkCommands bottomCommands;
-  in
-    toHyprlang' attrs;
 in {
   options = {
     programs.hyprland = {
@@ -213,7 +121,7 @@ in {
         shouldGenerate = cfg.extraConfig != "" || cfg.settings != {} || cfg.plugins != [];
 
         pluginsToHyprlang = plugins:
-          toHyprlang {
+          selflib.toHyprlang {
             topCommandsPrefixes = cfg.topPrefixes;
             bottomCommandsPrefixes = cfg.bottomPrefixes;
           }
@@ -232,7 +140,7 @@ in {
             lib.optionalString (cfg.plugins != [])
             (pluginsToHyprlang cfg.plugins)
             + lib.optionalString (cfg.settings != {})
-            (toHyprlang {
+            (selflib.toHyprlang {
                 topCommandsPrefixes = cfg.topPrefixes;
                 bottomCommandsPrefixes = cfg.bottomPrefixes;
               }


### PR DESCRIPTION
<!-- Updated generator that will end up living in Nixpkgs' `lib/generators`. -->

<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Reworks the current Nix to hyprland.conf generator implementation by using a more generic Nix 2 Hyprlang generator.
This allows any application using hyprlang to use this for easy config generation.

This is the second step towards getting this module into Nixpkgs.

Considerations:
- [x] Rename `section` -> `category`, to be in line with the [documentation](https://wiki.hyprland.org/Hypr-Ecosystem/hyprlang/#categories).
- [x] Use `category[special]:field = value` for special categories. This reduces the complexity in finding the `special` key inside the attrset and then properly ordering it as the first in the generated category. But this poses a question: how should we let the user define these categories?
  - [ ] Write them verbatim (`"device[some-device:0baf3-952c]" = { sensitivity = 0.3; }`)
  - [ ] Parse a list of devices in the module, rewrite the attrset and pass it to `toHyprlang`:
      ```nix
      device = [
        {
          name = "some-device:0baf3-952c";
          sensitivity = 0.3;
        }
        {
          # ...
        }
      ];

      # this will be transformed to the syntax in the point above
      ```
- [x] Ensure nested categories are handled by recursing over them.
- [x] Use `category:field = value` for everything instead of nested categories (`category {...}`). This further reduces complexity by having only one code path for all categories.
- [x] Remove `indentLevel`, no longer needed without expanded categories.
- [x] Change `importantPrefixes` -> `topCommandsPrefixes` and also add `bottomCommandsPrefixes` for greater flexibility. Group these as the first argument (called `options` from now on).
- [x] Separate `attrs` into a standalone argument, after the `options` arg. This is the actual config that will be translated to hyprlang.

CC: @bloxx12 @donovanglover @JohnRTitor @khaneliman @notashelf

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Needs testing. Different ideas and constructive criticism welcome.

#### Is it ready for merging, or does it need work?

Needs testing and discussion.

