### PR TITLE
layouts: set real size/position for FSMODE_MAXIMIZED

### DIFF
--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -516,11 +516,11 @@ void CHyprDwindleLayout::calculateWorkspace(const PHLWORKSPACE& pWorkspace) {
             *PFULLWINDOW->m_vRealSize     = PMONITOR->vecSize;
         } else if (pWorkspace->m_efFullscreenMode == FSMODE_MAXIMIZED) {
             SDwindleNodeData fakeNode;
-            fakeNode.pWindow         = PFULLWINDOW;
-            fakeNode.box             = {PMONITOR->vecPosition + PMONITOR->vecReservedTopLeft, PMONITOR->vecSize - PMONITOR->vecReservedTopLeft - PMONITOR->vecReservedBottomRight};
-            fakeNode.workspaceID     = pWorkspace->m_iID;
-            PFULLWINDOW->m_vPosition = fakeNode.box.pos();
-            PFULLWINDOW->m_vSize     = fakeNode.box.size();
+            fakeNode.pWindow     = PFULLWINDOW;
+            fakeNode.box         = {PMONITOR->vecPosition + PMONITOR->vecReservedTopLeft, PMONITOR->vecSize - PMONITOR->vecReservedTopLeft - PMONITOR->vecReservedBottomRight};
+            fakeNode.workspaceID = pWorkspace->m_iID;
+            *PFULLWINDOW->m_vRealPosition   = fakeNode.box.pos();
+            *PFULLWINDOW->m_vRealSize       = fakeNode.box.size();
             fakeNode.ignoreFullscreenChecks = true;
 
             applyNodeDataToWindow(&fakeNode);

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -313,8 +313,8 @@ void CHyprMasterLayout::calculateWorkspace(PHLWORKSPACE pWorkspace) {
             fakeNode.position               = PMONITOR->vecPosition + PMONITOR->vecReservedTopLeft;
             fakeNode.size                   = PMONITOR->vecSize - PMONITOR->vecReservedTopLeft - PMONITOR->vecReservedBottomRight;
             fakeNode.workspaceID            = pWorkspace->m_iID;
-            PFULLWINDOW->m_vPosition        = fakeNode.position;
-            PFULLWINDOW->m_vSize            = fakeNode.size;
+            *PFULLWINDOW->m_vRealPosition   = fakeNode.position;
+            *PFULLWINDOW->m_vRealSize       = fakeNode.size;
             fakeNode.ignoreFullscreenChecks = true;
 
             applyNodeDataToWindow(&fakeNode);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

~~Closes https://github.com/hyprwm/Hyprland/issues/9214~~

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

If there is a reason behind `m_vSize` being used instead of `m_vRealSize`, I did not get it. Has been introduced in #1831. I tested scaling my monitor while having a game fullscreen and Hyprland adapts the window position just fine. (Issue linked to the PR)

#### Is it ready for merging, or does it need work?

Ready, but please test it. I did not find any issues with it.
