### PR TITLE
desktop: fix segfault when destroying a partially create layer surface

### DIFF
--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -98,7 +98,8 @@ void CLayerSurface::onDestroy() {
             onUnmap();
         } else {
             Debug::log(LOG, "Removing LayerSurface that wasn't mapped.");
-            alpha->setValueAndWarp(0.f);
+            if (alpha)
+                alpha->setValueAndWarp(0.f);
             fadingOut = true;
             g_pCompositor->addToFadingOutSafe(self.lock());
         }


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

This fixes the bug that causes Hyprland to crash after monitors change. The bug
was caused by a layer surface being created for an invalid output, which causes
the constructor to fail early. This left the fade in animation variable
uninitialized, so when the surface was destroyed and the variable accessed,
Hyprland segfaulted. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

No

