### PR TITLE
fix(xwayland): prevent invalid window configurations for X11 apps

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1717,8 +1717,6 @@ void CWindow::sendWindowSize(Vector2D size, bool force, std::optional<Vector2D> 
         windowPos += PMONITOR->vecXWaylandPosition;
     }
 
-    windowPos = windowPos.clamp(Vector2D{0, 0}, Vector2D{std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()});
-
     if (!force && m_vPendingReportedSize == size && (windowPos == m_vReportedPosition || !m_bIsX11))
         return;
 

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1700,7 +1700,7 @@ void CWindow::sendWindowSize(Vector2D size, bool force, std::optional<Vector2D> 
 
     const auto  PMONITOR = m_pMonitor.lock();
 
-    size = size.clamp(Vector2D{0, 0}, Vector2D{std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()});
+    size = size.clamp(Vector2D{1, 1}, Vector2D{std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()});
 
     // calculate pos
     // TODO: this should be decoupled from setWindowSize IMO
@@ -1716,6 +1716,8 @@ void CWindow::sendWindowSize(Vector2D size, bool force, std::optional<Vector2D> 
 
         windowPos += PMONITOR->vecXWaylandPosition;
     }
+
+    windowPos = windowPos.clamp(Vector2D{0, 0}, Vector2D{std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()});
 
     if (!force && m_vPendingReportedSize == size && (windowPos == m_vReportedPosition || !m_bIsX11))
         return;


### PR DESCRIPTION
fixes #9252 