### PR TITLE
animation: don't immediately disconnect active vars during tick

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ find_package(OpenGL REQUIRED COMPONENTS ${GLES_VERSION})
 pkg_check_modules(aquamarine_dep REQUIRED IMPORTED_TARGET aquamarine>=0.4.5)
 pkg_check_modules(hyprlang_dep REQUIRED IMPORTED_TARGET hyprlang>=0.3.2)
 pkg_check_modules(hyprcursor_dep REQUIRED IMPORTED_TARGET hyprcursor>=0.1.7)
-pkg_check_modules(hyprutils_dep REQUIRED IMPORTED_TARGET hyprutils>=0.4.0)
+pkg_check_modules(hyprutils_dep REQUIRED IMPORTED_TARGET hyprutils>=0.5.0)
 pkg_check_modules(hyprgraphics_dep REQUIRED IMPORTED_TARGET hyprgraphics>=0.1.1)
 
 add_compile_definitions(AQUAMARINE_VERSION="${aquamarine_dep_VERSION}")

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -43,7 +43,7 @@ CHyprAnimationManager::CHyprAnimationManager() {
 template <Animable VarType>
 static void updateVariable(CAnimatedVariable<VarType>& av, const float POINTY, bool warp = false) {
     if (warp || av.value() == av.goal()) {
-        av.warp();
+        av.warp(true, false);
         return;
     }
 
@@ -53,7 +53,7 @@ static void updateVariable(CAnimatedVariable<VarType>& av, const float POINTY, b
 
 static void updateColorVariable(CAnimatedVariable<CHyprColor>& av, const float POINTY, bool warp) {
     if (warp || av.value() == av.goal()) {
-        av.warp();
+        av.warp(true, false);
         return;
     }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This avoids removing active vars during tick().

Also happens to fix https://github.com/hyprwm/Hyprland/issues/9251
But https://github.com/hyprwm/hyprutils/pull/43 is the actual fix for that (We want both I think)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Yes


