### PR TITLE
Nix: change meson buildtype from debugoptimized to debug

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -155,7 +155,7 @@ in
 
       mesonBuildType =
         if debug
-        then "debugoptimized"
+        then "debug"
         else "release";
 
       mesonFlags = flatten [


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
When using the `hyprland-debug` package, the `HYPRLAND_DEBUG` flag is not set, which leads to having to use `--config ~/.config/hypr/hyprlandd.conf` everytime you start a debugging session.

`meson.build` only enables `HYPRLAND_DEBUG` when `debug` is set but not `debugoptimized`.

The builtype got changed from `debug` to `debugoptimized` in f75f8efb1be227e586cc0ba2ce6153ce56e04314. Though I couldn't figure out why, `tracy_enable` is always false, so that isn't an issue.

So my suggestion is to set it back to `debug`.
Something like this would also be an option, but it probably will lead to problems with tracy:
```diff
--- a/meson.build
+++ b/meson.build
@@ -77,7 +77,7 @@ if get_option('legacy_renderer').enabled()
   add_project_arguments('-DLEGACY_RENDERER', language: 'cpp')
 endif

-if get_option('buildtype') == 'debug'
+if get_option('buildtype') == 'debug' or get_option('buildtype') == 'debugoptimized'
   add_project_arguments('-DHYPRLAND_DEBUG', language: 'cpp')
 endif
```