### PR TITLE
window: move size reporting to animation begin callback

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2327,7 +2327,7 @@ void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, SFullscreenS
 
     updateFullscreenFadeOnWorkspace(PWORKSPACE);
 
-    PWINDOW->sendWindowSize(PWINDOW->m_vRealSize->goal(), true);
+    PWINDOW->sendWindowSize(true);
 
     PWORKSPACE->forceReportSizesToWindows();
 

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -561,6 +561,11 @@ void CWindow::onMap() {
         *m_fBorderAngleAnimationProgress = 1.f;
     }
 
+    m_vRealSize->setUpdateCallback([this](auto) {
+        if (m_bIsFloating)
+            sendWindowSize(m_vRealSize->goal());
+    });
+
     m_fMovingFromWorkspaceAlpha->setValueAndWarp(1.F);
 
     g_pCompositor->m_vWindowFocusHistory.push_back(m_pSelf);

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -561,10 +561,12 @@ void CWindow::onMap() {
         *m_fBorderAngleAnimationProgress = 1.f;
     }
 
-    m_vRealSize->setUpdateCallback([this](auto) {
-        if (validMapped(m_pSelf) && m_bIsFloating)
-            sendWindowSize();
-    });
+    m_vRealSize->setCallbackOnBegin(
+        [this](auto) {
+            if (m_bIsMapped && m_bIsFloating)
+                sendWindowSize();
+        },
+        false);
 
     m_fMovingFromWorkspaceAlpha->setValueAndWarp(1.F);
 
@@ -1705,8 +1707,8 @@ void CWindow::sendWindowSize(bool force) {
     const auto  PMONITOR           = m_pMonitor.lock();
 
     // TODO: this should be decoupled from setWindowSize IMO
-    Vector2D    windowPos = m_vRealPosition->goal();
-    Vector2D    size      = m_vRealSize->goal().clamp(Vector2D{1, 1}, Vector2D{std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()});
+    Vector2D windowPos = m_vRealPosition->goal();
+    Vector2D size      = m_vRealSize->goal().clamp(Vector2D{1, 1}, Vector2D{std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()});
 
     if (m_bIsX11 && PMONITOR) {
         windowPos = g_pXWaylandManager->waylandToXWaylandCoords(windowPos);

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -457,7 +457,7 @@ void CWindow::moveToWorkspace(PHLWORKSPACE pWorkspace) {
     }
 
     // update xwayland coords
-    sendWindowSize(m_vRealSize->goal());
+    sendWindowSize();
 
     if (OLDWORKSPACE && g_pCompositor->isWorkspaceSpecial(OLDWORKSPACE->m_iID) && OLDWORKSPACE->getWindows() == 0 && *PCLOSEONLASTSPECIAL) {
         if (const auto PMONITOR = OLDWORKSPACE->m_pMonitor.lock(); PMONITOR)
@@ -562,8 +562,8 @@ void CWindow::onMap() {
     }
 
     m_vRealSize->setUpdateCallback([this](auto) {
-        if (m_bIsFloating)
-            sendWindowSize(m_vRealSize->goal());
+        if (validMapped(m_pSelf) && m_bIsFloating)
+            sendWindowSize();
     });
 
     m_fMovingFromWorkspaceAlpha->setValueAndWarp(1.F);
@@ -1318,7 +1318,7 @@ void CWindow::clampWindowSize(const std::optional<Vector2D> minSize, const std::
 
     *m_vRealPosition = m_vRealPosition->goal() + DELTA / 2.0;
     *m_vRealSize     = NEWSIZE;
-    sendWindowSize(NEWSIZE);
+    sendWindowSize();
 }
 
 bool CWindow::isFullscreen() {
@@ -1542,7 +1542,7 @@ void CWindow::onX11Configure(CBox box) {
     g_pHyprRenderer->damageWindow(m_pSelf.lock());
 
     if (!m_bIsFloating || isFullscreen() || g_pInputManager->currentlyDraggedWindow == m_pSelf) {
-        sendWindowSize(m_vRealSize->goal(), true);
+        sendWindowSize(true);
         g_pInputManager->refocus();
         g_pHyprRenderer->damageWindow(m_pSelf.lock());
         return;
@@ -1569,7 +1569,7 @@ void CWindow::onX11Configure(CBox box) {
     m_vPosition = m_vRealPosition->goal();
     m_vSize     = m_vRealSize->goal();
 
-    sendWindowSize(box.size(), true);
+    sendWindowSize(true);
 
     m_vPendingReportedSize = box.size();
     m_vReportedSize        = box.size();
@@ -1700,15 +1700,13 @@ Vector2D CWindow::requestedMaxSize() {
     return maxSize;
 }
 
-void CWindow::sendWindowSize(Vector2D size, bool force, std::optional<Vector2D> overridePos) {
+void CWindow::sendWindowSize(bool force) {
     static auto PXWLFORCESCALEZERO = CConfigValue<Hyprlang::INT>("xwayland:force_zero_scaling");
     const auto  PMONITOR           = m_pMonitor.lock();
 
-    size = size.clamp(Vector2D{1, 1}, Vector2D{std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()});
-
-    // calculate pos
     // TODO: this should be decoupled from setWindowSize IMO
-    Vector2D windowPos = overridePos.value_or(m_vRealPosition->goal());
+    Vector2D    windowPos = m_vRealPosition->goal();
+    Vector2D    size      = m_vRealSize->goal().clamp(Vector2D{1, 1}, Vector2D{std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()});
 
     if (m_bIsX11 && PMONITOR) {
         windowPos = g_pXWaylandManager->waylandToXWaylandCoords(windowPos);

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -470,7 +470,7 @@ class CWindow {
     bool                       isModal();
     Vector2D                   requestedMinSize();
     Vector2D                   requestedMaxSize();
-    void                       sendWindowSize(Vector2D size, bool force = false, std::optional<Vector2D> overridePos = std::nullopt);
+    void                       sendWindowSize(bool force = false);
     NContentType::eContentType getContentType();
     void                       setContentType(NContentType::eContentType contentType);
 

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -624,7 +624,7 @@ void CWorkspace::forceReportSizesToWindows() {
         if (w->m_pWorkspace != m_pSelf || !w->m_bIsMapped || w->isHidden())
             continue;
 
-        w->sendWindowSize(w->m_vRealSize->goal(), true);
+        w->sendWindowSize(true);
     }
 }
 

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -686,9 +686,6 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
     if (PMONITOR && PWINDOW->isX11OverrideRedirect())
         PWINDOW->m_fX11SurfaceScaledBy = PMONITOR->scale;
-
-    if (!PWINDOW->isX11OverrideRedirect() && PWINDOW->m_bIsX11 && PWINDOW->m_bIsFloating)
-        PWINDOW->sendWindowSize(PWINDOW->m_vRealSize->goal(), true);
 }
 
 void Events::listener_unmapWindow(void* owner, void* data) {
@@ -955,7 +952,7 @@ void Events::listener_unmanagedSetGeometry(void* owner, void* data) {
         PWINDOW->setHidden(true);
 
     if (PWINDOW->isFullscreen() || !PWINDOW->m_bIsFloating) {
-        PWINDOW->sendWindowSize(PWINDOW->m_vRealSize->goal(), true);
+        PWINDOW->sendWindowSize(true);
         g_pHyprRenderer->damageWindow(PWINDOW);
         return;
     }

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -979,6 +979,7 @@ void Events::listener_unmanagedSetGeometry(void* owner, void* data) {
 
         PWINDOW->m_vPosition = PWINDOW->m_vRealPosition->goal();
         PWINDOW->m_vSize     = PWINDOW->m_vRealSize->goal();
+        PWINDOW->sendWindowSize();
 
         PWINDOW->m_pWorkspace = g_pCompositor->getMonitorFromVector(PWINDOW->m_vRealPosition->value() + PWINDOW->m_vRealSize->value() / 2.f)->activeWorkspace;
 

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -979,7 +979,6 @@ void Events::listener_unmanagedSetGeometry(void* owner, void* data) {
 
         PWINDOW->m_vPosition = PWINDOW->m_vRealPosition->goal();
         PWINDOW->m_vSize     = PWINDOW->m_vRealSize->goal();
-        PWINDOW->sendWindowSize();
 
         PWINDOW->m_pWorkspace = g_pCompositor->getMonitorFromVector(PWINDOW->m_vRealPosition->value() + PWINDOW->m_vRealSize->value() / 2.f)->activeWorkspace;
 

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -687,12 +687,8 @@ void Events::listener_mapWindow(void* owner, void* data) {
     if (PMONITOR && PWINDOW->isX11OverrideRedirect())
         PWINDOW->m_fX11SurfaceScaledBy = PMONITOR->scale;
 
-    // Fix some X11 popups being invisible / having incorrect size on open.
-    // What the ACTUAL FUCK is going on?????? I HATE X11
-    if (!PWINDOW->isX11OverrideRedirect() && PWINDOW->m_bIsX11 && PWINDOW->m_bIsFloating) {
-        PWINDOW->sendWindowSize(PWINDOW->m_vRealSize->goal(), true, PWINDOW->m_vRealPosition->goal() - Vector2D{1, 1});
+    if (!PWINDOW->isX11OverrideRedirect() && PWINDOW->m_bIsX11 && PWINDOW->m_bIsFloating)
         PWINDOW->sendWindowSize(PWINDOW->m_vRealSize->goal(), true);
-    }
 }
 
 void Events::listener_unmapWindow(void* owner, void* data) {

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -198,16 +198,12 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
 
         *PWINDOW->m_vRealPosition = wb.pos();
         *PWINDOW->m_vRealSize     = wb.size();
-
-        PWINDOW->sendWindowSize();
     } else {
         CBox wb = {calcPos, calcSize};
         wb.round(); // avoid rounding mess
 
         *PWINDOW->m_vRealSize     = wb.size();
         *PWINDOW->m_vRealPosition = wb.pos();
-
-        PWINDOW->sendWindowSize();
     }
 
     if (force) {

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -199,7 +199,7 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
         *PWINDOW->m_vRealPosition = wb.pos();
         *PWINDOW->m_vRealSize     = wb.size();
 
-        PWINDOW->sendWindowSize(wb.size());
+        PWINDOW->sendWindowSize();
     } else {
         CBox wb = {calcPos, calcSize};
         wb.round(); // avoid rounding mess
@@ -207,7 +207,7 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
         *PWINDOW->m_vRealSize     = wb.size();
         *PWINDOW->m_vRealPosition = wb.pos();
 
-        PWINDOW->sendWindowSize(wb.size());
+        PWINDOW->sendWindowSize();
     }
 
     if (force) {

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -176,11 +176,9 @@ void IHyprLayout::onWindowCreatedFloating(PHLWINDOW pWindow) {
         pWindow->m_vRealSize->warp();
     }
 
-    if (!pWindow->isX11OverrideRedirect()) {
-        pWindow->sendWindowSize();
-
+    if (!pWindow->isX11OverrideRedirect())
         g_pCompositor->changeWindowZOrder(pWindow, true);
-    } else {
+    else {
         pWindow->m_vPendingReportedSize = pWindow->m_vRealSize->goal();
         pWindow->m_vReportedSize        = pWindow->m_vPendingReportedSize;
     }
@@ -361,9 +359,6 @@ void IHyprLayout::onEndDragWindow() {
                 DRAGGINGWINDOW->m_bIsFloating       = pWindow->m_bIsFloating; // match the floating state of the window
                 DRAGGINGWINDOW->m_vLastFloatingSize = m_vDraggingWindowOriginalFloatSize;
                 DRAGGINGWINDOW->m_bDraggingTiled    = false;
-
-                if (pWindow->m_bIsFloating)
-                    DRAGGINGWINDOW->sendWindowSize(); // match the size of the window
 
                 static auto USECURRPOS = CConfigValue<Hyprlang::INT>("group:insert_after_current");
                 (*USECURRPOS ? pWindow : pWindow->getGroupTail())->insertWindowToGroup(DRAGGINGWINDOW);
@@ -606,10 +601,11 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
 
         if (*PANIMATEMOUSE)
             *DRAGGINGWINDOW->m_vRealPosition = wb.pos();
-        else
+        else {
             DRAGGINGWINDOW->m_vRealPosition->setValueAndWarp(wb.pos());
+            DRAGGINGWINDOW->sendWindowSize();
+        }
 
-        DRAGGINGWINDOW->sendWindowSize();
     } else if (g_pInputManager->dragMode == MBIND_RESIZE || g_pInputManager->dragMode == MBIND_RESIZE_FORCE_RATIO || g_pInputManager->dragMode == MBIND_RESIZE_BLOCK_RATIO) {
         if (DRAGGINGWINDOW->m_bIsFloating) {
 
@@ -679,9 +675,8 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
             } else {
                 DRAGGINGWINDOW->m_vRealSize->setValueAndWarp(wb.size());
                 DRAGGINGWINDOW->m_vRealPosition->setValueAndWarp(wb.pos());
+                DRAGGINGWINDOW->sendWindowSize();
             }
-
-            DRAGGINGWINDOW->sendWindowSize();
         } else {
             resizeActiveWindow(TICKDELTA, m_eGrabbedCorner, DRAGGINGWINDOW);
         }
@@ -787,7 +782,6 @@ void IHyprLayout::changeWindowFloatingMode(PHLWINDOW pWindow) {
 
     g_pCompositor->updateWindowAnimatedDecorationValues(pWindow);
     pWindow->updateToplevel();
-    pWindow->sendWindowSize();
     g_pHyprRenderer->damageWindow(pWindow);
 }
 

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -177,7 +177,7 @@ void IHyprLayout::onWindowCreatedFloating(PHLWINDOW pWindow) {
     }
 
     if (!pWindow->isX11OverrideRedirect()) {
-        pWindow->sendWindowSize(pWindow->m_vRealSize->goal());
+        pWindow->sendWindowSize();
 
         g_pCompositor->changeWindowZOrder(pWindow, true);
     } else {
@@ -363,7 +363,7 @@ void IHyprLayout::onEndDragWindow() {
                 DRAGGINGWINDOW->m_bDraggingTiled    = false;
 
                 if (pWindow->m_bIsFloating)
-                    DRAGGINGWINDOW->sendWindowSize(DRAGGINGWINDOW->m_vRealSize->goal()); // match the size of the window
+                    DRAGGINGWINDOW->sendWindowSize(); // match the size of the window
 
                 static auto USECURRPOS = CConfigValue<Hyprlang::INT>("group:insert_after_current");
                 (*USECURRPOS ? pWindow : pWindow->getGroupTail())->insertWindowToGroup(DRAGGINGWINDOW);
@@ -609,7 +609,7 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
         else
             DRAGGINGWINDOW->m_vRealPosition->setValueAndWarp(wb.pos());
 
-        DRAGGINGWINDOW->sendWindowSize(DRAGGINGWINDOW->m_vRealSize->goal());
+        DRAGGINGWINDOW->sendWindowSize();
     } else if (g_pInputManager->dragMode == MBIND_RESIZE || g_pInputManager->dragMode == MBIND_RESIZE_FORCE_RATIO || g_pInputManager->dragMode == MBIND_RESIZE_BLOCK_RATIO) {
         if (DRAGGINGWINDOW->m_bIsFloating) {
 
@@ -681,7 +681,7 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
                 DRAGGINGWINDOW->m_vRealPosition->setValueAndWarp(wb.pos());
             }
 
-            DRAGGINGWINDOW->sendWindowSize(DRAGGINGWINDOW->m_vRealSize->goal());
+            DRAGGINGWINDOW->sendWindowSize();
         } else {
             resizeActiveWindow(TICKDELTA, m_eGrabbedCorner, DRAGGINGWINDOW);
         }
@@ -787,7 +787,7 @@ void IHyprLayout::changeWindowFloatingMode(PHLWINDOW pWindow) {
 
     g_pCompositor->updateWindowAnimatedDecorationValues(pWindow);
     pWindow->updateToplevel();
-    pWindow->sendWindowSize(pWindow->m_vRealSize->goal());
+    pWindow->sendWindowSize();
     g_pHyprRenderer->damageWindow(pWindow);
 }
 

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -678,16 +678,12 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
 
         *PWINDOW->m_vRealPosition = wb.pos();
         *PWINDOW->m_vRealSize     = wb.size();
-
-        PWINDOW->sendWindowSize();
     } else {
         CBox wb = {calcPos, calcSize};
         wb.round(); // avoid rounding mess
 
         *PWINDOW->m_vRealPosition = wb.pos();
         *PWINDOW->m_vRealSize     = wb.size();
-
-        PWINDOW->sendWindowSize();
     }
 
     if (m_bForceWarps && !*PANIMATE) {

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -679,7 +679,7 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
         *PWINDOW->m_vRealPosition = wb.pos();
         *PWINDOW->m_vRealSize     = wb.size();
 
-        PWINDOW->sendWindowSize(wb.size());
+        PWINDOW->sendWindowSize();
     } else {
         CBox wb = {calcPos, calcSize};
         wb.round(); // avoid rounding mess
@@ -687,7 +687,7 @@ void CHyprMasterLayout::applyNodeDataToWindow(SMasterNodeData* pNode) {
         *PWINDOW->m_vRealPosition = wb.pos();
         *PWINDOW->m_vRealSize     = wb.size();
 
-        PWINDOW->sendWindowSize(wb.size());
+        PWINDOW->sendWindowSize();
     }
 
     if (m_bForceWarps && !*PANIMATE) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1907,7 +1907,6 @@ SDispatchResult CKeybindManager::workspaceOpt(std::string args) {
                 if (PWORKSPACE->m_bDefaultFloating) {
                     w->m_vRealPosition->setValueAndWarp(SAVEDPOS);
                     w->m_vRealSize->setValueAndWarp(SAVEDSIZE);
-                    w->sendWindowSize();
                     *w->m_vRealSize     = w->m_vRealSize->value() + Vector2D(4, 4);
                     *w->m_vRealPosition = w->m_vRealPosition->value() - Vector2D(2, 2);
                 }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1907,7 +1907,7 @@ SDispatchResult CKeybindManager::workspaceOpt(std::string args) {
                 if (PWORKSPACE->m_bDefaultFloating) {
                     w->m_vRealPosition->setValueAndWarp(SAVEDPOS);
                     w->m_vRealSize->setValueAndWarp(SAVEDSIZE);
-                    w->sendWindowSize(SAVEDSIZE);
+                    w->sendWindowSize();
                     *w->m_vRealSize     = w->m_vRealSize->value() + Vector2D(4, 4);
                     *w->m_vRealPosition = w->m_vRealPosition->value() - Vector2D(2, 2);
                 }

--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -55,7 +55,7 @@ void CHyprXWaylandManager::activateWindow(PHLWINDOW pWindow, bool activate) {
     if (pWindow->m_bIsX11) {
 
         if (activate) {
-            pWindow->sendWindowSize(pWindow->m_vRealSize->value(), true); // update xwayland output pos
+            pWindow->sendWindowSize(true); // update xwayland output pos
             pWindow->m_pXWaylandSurface->setMinimized(false);
 
             if (!pWindow->isX11OverrideRedirect())

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -456,15 +456,13 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, PHLWIND
 
     pDraggedWindow->m_bIsFloating = pWindowInsertAfter->m_bIsFloating; // match the floating state of the window
 
-    if (pWindowInsertAfter->m_bIsFloating)
-        pDraggedWindow->sendWindowSize(pWindowInsertAfter->m_vRealSize->goal()); // match the size of the window
-
     pWindowInsertAfter->insertWindowToGroup(pDraggedWindow);
 
     if (WINDOWINDEX == -1)
         std::swap(pDraggedHead->m_sGroupData.head, pWindowInsertEnd->m_sGroupData.head);
 
     m_pWindow->setGroupCurrent(pDraggedWindow);
+    m_pWindow->sendWindowSize();
     pDraggedWindow->applyGroupRules();
     pDraggedWindow->updateWindowDecos();
     g_pLayoutManager->getCurrentLayout()->recalculateWindow(pDraggedWindow);

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -462,7 +462,6 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, PHLWIND
         std::swap(pDraggedHead->m_sGroupData.head, pWindowInsertEnd->m_sGroupData.head);
 
     m_pWindow->setGroupCurrent(pDraggedWindow);
-    m_pWindow->sendWindowSize();
     pDraggedWindow->applyGroupRules();
     pDraggedWindow->updateWindowDecos();
     g_pLayoutManager->getCurrentLayout()->recalculateWindow(pDraggedWindow);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Made so many mistakes in the animation PR...
I removed this from `tick` when playing around with damage:
```cpp
// set size and pos if valid, but only if damage policy entire (dont if border for example)
if (validMapped(PWINDOW) && av->m_eDamagePolicy == AVARDAMAGE_ENTIRE && !PWINDOW->isX11OverrideRedirect())
    g_pXWaylandManager->setWindowSize(PWINDOW, PWINDOW->m_vRealSize.goal());

```
Had the intention to move that to a update callback for the window size, except - well - I didn't.
Worst thing about this is that some xwayland changes probably were only made because this was missing. Sorry for that.
I will go though other size/position related changes since and check if they are redundant tomorrow.

Closes https://github.com/hyprwm/Hyprland/issues/9269
Closes https://github.com/hyprwm/Hyprland/issues/9256
Closes #9279

~~CC @nnyyxxxx wanna verify that it fixes #9256?~~ :heavy_check_mark: 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

atlauncher import window still works ^^

#### Is it ready for merging, or does it need work?

Ready.