### PR TITLE
adapt to AQ CFileDescriptor usage

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1286,7 +1286,7 @@ bool CMonitor::attemptDirectScanout() {
     // FIXME: make sure the buffer actually follows the available scanout dmabuf formats
     // and comes from the appropriate device. This may implode on multi-gpu!!
 
-    const auto params = PSURFACE->current.buffer->buffer->dmabuf();
+    const auto& params = PSURFACE->current.buffer->buffer->dmabuf();
     // scanout buffer isn't dmabuf, so no scanout
     if (!params.success)
         return false;
@@ -1450,7 +1450,7 @@ void CMonitorState::ensureBufferPresent() {
     }
 
     if (STATE.buffer) {
-        if (const auto params = STATE.buffer->dmabuf(); params.success && params.format == m_pOwner->drmFormat)
+        if (const auto& params = STATE.buffer->dmabuf(); params.success && params.format == m_pOwner->drmFormat)
             return;
     }
 

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1332,7 +1332,7 @@ bool CMonitor::attemptDirectScanout() {
 
     if (DOEXPLICIT) {
         Debug::log(TRACE, "attemptDirectScanout: setting IN_FENCE for aq to {}", explicitWaitFD.get());
-        output->state->setExplicitInFence(explicitWaitFD.get());
+        output->state->setExplicitInFence(std::move(explicitWaitFD));
     }
 
     bool ok = output->commit();
@@ -1443,7 +1443,7 @@ CMonitorState::CMonitorState(CMonitor* owner) : m_pOwner(owner) {
 }
 
 void CMonitorState::ensureBufferPresent() {
-    const auto STATE = m_pOwner->output->state->state();
+    const auto& STATE = m_pOwner->output->state->state();
     if (!STATE.enabled) {
         Debug::log(TRACE, "CMonitorState::ensureBufferPresent: Ignoring, monitor is not enabled");
         return;

--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -486,7 +486,7 @@ SP<Aquamarine::IBuffer> CPointerManager::renderHWCursorBuffer(SP<CPointerManager
 
         // then, we just yeet it into the dumb buffer
 
-        const auto DMABUF      = buf->dmabuf();
+        const auto& DMABUF     = buf->dmabuf();
         auto [data, fmt, size] = buf->beginDataPtr(0);
 
         auto CAIROSURFACE = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, DMABUF.size.x, DMABUF.size.y);

--- a/src/protocols/LinuxDMABUF.hpp
+++ b/src/protocols/LinuxDMABUF.hpp
@@ -16,7 +16,7 @@ class CWLSurfaceResource;
 
 class CLinuxDMABuffer {
   public:
-    CLinuxDMABuffer(uint32_t id, wl_client* client, Aquamarine::SDMABUFAttrs attrs);
+    CLinuxDMABuffer(uint32_t id, wl_client* client, Aquamarine::SDMABUFAttrs&& attrs);
     ~CLinuxDMABuffer();
 
     bool good();

--- a/src/protocols/LinuxDMABUF.hpp
+++ b/src/protocols/LinuxDMABUF.hpp
@@ -59,26 +59,25 @@ class CDMABUFFormatTable {
 
 class CLinuxDMABUFParamsResource {
   public:
-    CLinuxDMABUFParamsResource(SP<CZwpLinuxBufferParamsV1> resource_);
+    CLinuxDMABUFParamsResource(UP<CZwpLinuxBufferParamsV1>&& resource_);
     ~CLinuxDMABUFParamsResource() = default;
 
-    bool                         good();
-    void                         create(uint32_t id); // 0 means not immed
+    bool                good();
+    void                create(uint32_t id, Vector2D size, uint32_t format); // 0 means not immed
 
-    SP<Aquamarine::SDMABUFAttrs> attrs;
-    WP<CLinuxDMABuffer>          createdBuffer;
-    bool                         used = false;
+    WP<CLinuxDMABuffer> createdBuffer;
+    bool                used = false;
 
   private:
-    SP<CZwpLinuxBufferParamsV1> resource;
-
+    UP<CZwpLinuxBufferParamsV1> resource;
+    Aquamarine::SDMABUFAttrs    m_attrs;
     bool                        verify();
     bool                        commence();
 };
 
 class CLinuxDMABUFFeedbackResource {
   public:
-    CLinuxDMABUFFeedbackResource(SP<CZwpLinuxDmabufFeedbackV1> resource_, SP<CWLSurfaceResource> surface_);
+    CLinuxDMABUFFeedbackResource(UP<CZwpLinuxDmabufFeedbackV1>&& resource_, SP<CWLSurfaceResource> surface_);
     ~CLinuxDMABUFFeedbackResource() = default;
 
     bool                   good();
@@ -88,7 +87,7 @@ class CLinuxDMABUFFeedbackResource {
     SP<CWLSurfaceResource> surface; // optional, for surface feedbacks
 
   private:
-    SP<CZwpLinuxDmabufFeedbackV1> resource;
+    UP<CZwpLinuxDmabufFeedbackV1> resource;
     bool                          lastFeedbackWasScanout = false;
 
     friend class CLinuxDMABufV1Protocol;
@@ -96,13 +95,13 @@ class CLinuxDMABUFFeedbackResource {
 
 class CLinuxDMABUFResource {
   public:
-    CLinuxDMABUFResource(SP<CZwpLinuxDmabufV1> resource_);
+    CLinuxDMABUFResource(UP<CZwpLinuxDmabufV1>&& resource_);
 
     bool good();
     void sendMods();
 
   private:
-    SP<CZwpLinuxDmabufV1> resource;
+    UP<CZwpLinuxDmabufV1> resource;
 };
 
 class CLinuxDMABufV1Protocol : public IWaylandProtocol {
@@ -122,10 +121,10 @@ class CLinuxDMABufV1Protocol : public IWaylandProtocol {
     void resetFormatTable();
 
     //
-    std::vector<SP<CLinuxDMABUFResource>>         m_vManagers;
-    std::vector<SP<CLinuxDMABUFFeedbackResource>> m_vFeedbacks;
-    std::vector<SP<CLinuxDMABUFParamsResource>>   m_vParams;
-    std::vector<SP<CLinuxDMABuffer>>              m_vBuffers;
+    std::vector<UP<CLinuxDMABUFResource>>         m_vManagers;
+    std::vector<UP<CLinuxDMABUFFeedbackResource>> m_vFeedbacks;
+    std::vector<UP<CLinuxDMABUFParamsResource>>   m_vParams;
+    std::vector<UP<CLinuxDMABuffer>>              m_vBuffers;
 
     UP<CDMABUFFormatTable>                        formatTable;
     dev_t                                         mainDevice;

--- a/src/protocols/MesaDRM.hpp
+++ b/src/protocols/MesaDRM.hpp
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include <cstdint>
+#include <hyprutils/os/FileDescriptor.hpp>
 #include "WaylandProtocol.hpp"
 #include "wayland-drm.hpp"
 #include "types/Buffer.hpp"
@@ -9,7 +10,7 @@
 
 class CMesaDRMBufferResource {
   public:
-    CMesaDRMBufferResource(uint32_t id, wl_client* client, Aquamarine::SDMABUFAttrs attrs);
+    CMesaDRMBufferResource(uint32_t id, wl_client* client, Aquamarine::SDMABUFAttrs&& attrs);
     ~CMesaDRMBufferResource();
 
     bool good();

--- a/src/protocols/Screencopy.cpp
+++ b/src/protocols/Screencopy.cpp
@@ -117,7 +117,7 @@ void CScreencopyFrame::copy(CZwlrScreencopyFrameV1* pFrame, wl_resource* buffer_
         return;
     }
 
-    if (auto attrs = PBUFFER->buffer->dmabuf(); attrs.success) {
+    if (const auto& attrs = PBUFFER->buffer->dmabuf(); attrs.success) {
         bufferDMA = true;
 
         if (attrs.format != dmabufFormat) {
@@ -126,7 +126,7 @@ void CScreencopyFrame::copy(CZwlrScreencopyFrameV1* pFrame, wl_resource* buffer_
             PROTO::screencopy->destroyResource(this);
             return;
         }
-    } else if (auto attrs = PBUFFER->buffer->shm(); attrs.success) {
+    } else if (const auto& attrs = PBUFFER->buffer->shm(); attrs.success) {
         if (attrs.format != shmFormat) {
             LOGM(ERR, "Invalid buffer shm format in {:x}", (uintptr_t)pFrame);
             resource->error(ZWLR_SCREENCOPY_FRAME_V1_ERROR_INVALID_BUFFER, "invalid buffer format");

--- a/src/protocols/SinglePixel.cpp
+++ b/src/protocols/SinglePixel.cpp
@@ -40,8 +40,8 @@ void CSinglePixelBuffer::update(const CRegion& damage) {
     ;
 }
 
-Aquamarine::SDMABUFAttrs CSinglePixelBuffer::dmabuf() {
-    return {.success = false};
+const Aquamarine::SDMABUFAttrs& CSinglePixelBuffer::dmabuf() const {
+    return m_attrs;
 }
 
 std::tuple<uint8_t*, uint32_t, size_t> CSinglePixelBuffer::beginDataPtr(uint32_t flags) {

--- a/src/protocols/SinglePixel.hpp
+++ b/src/protocols/SinglePixel.hpp
@@ -15,7 +15,7 @@ class CSinglePixelBuffer : public IHLBuffer {
     virtual Aquamarine::eBufferType                type();
     virtual bool                                   isSynchronous();
     virtual void                                   update(const CRegion& damage);
-    virtual Aquamarine::SDMABUFAttrs               dmabuf();
+    virtual const Aquamarine::SDMABUFAttrs&        dmabuf() const;
     virtual std::tuple<uint8_t*, uint32_t, size_t> beginDataPtr(uint32_t flags);
     virtual void                                   endDataPtr();
     //
@@ -23,7 +23,8 @@ class CSinglePixelBuffer : public IHLBuffer {
     bool success = false;
 
   private:
-    uint32_t color = 0x00000000;
+    uint32_t                       color   = 0x00000000;
+    const Aquamarine::SDMABUFAttrs m_attrs = {.success = false};
 
     struct {
         CHyprSignalListener resourceDestroy;

--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -172,7 +172,7 @@ void CToplevelExportFrame::copy(CHyprlandToplevelExportFrameV1* pFrame, wl_resou
         return;
     }
 
-    if (auto attrs = PBUFFER->buffer->dmabuf(); attrs.success) {
+    if (const auto& attrs = PBUFFER->buffer->dmabuf(); attrs.success) {
         bufferDMA = true;
 
         if (attrs.format != dmabufFormat) {
@@ -180,7 +180,7 @@ void CToplevelExportFrame::copy(CHyprlandToplevelExportFrameV1* pFrame, wl_resou
             PROTO::toplevelExport->destroyResource(this);
             return;
         }
-    } else if (auto attrs = PBUFFER->buffer->shm(); attrs.success) {
+    } else if (const auto& attrs = PBUFFER->buffer->shm(); attrs.success) {
         if (attrs.format != shmFormat) {
             resource->error(HYPRLAND_TOPLEVEL_EXPORT_FRAME_V1_ERROR_INVALID_BUFFER, "invalid buffer format");
             PROTO::toplevelExport->destroyResource(this);

--- a/src/protocols/types/DMABuffer.hpp
+++ b/src/protocols/types/DMABuffer.hpp
@@ -4,23 +4,23 @@
 
 class CDMABuffer : public IHLBuffer {
   public:
-    CDMABuffer(uint32_t id, wl_client* client, Aquamarine::SDMABUFAttrs const& attrs_);
-    virtual ~CDMABuffer();
+    CDMABuffer(uint32_t id, wl_client* client, Aquamarine::SDMABUFAttrs&& attrs_);
+    virtual ~CDMABuffer() = default;
 
     virtual Aquamarine::eBufferCapability          caps();
     virtual Aquamarine::eBufferType                type();
     virtual bool                                   isSynchronous();
     virtual void                                   update(const CRegion& damage);
-    virtual Aquamarine::SDMABUFAttrs               dmabuf();
+    virtual const Aquamarine::SDMABUFAttrs&        dmabuf() const;
     virtual std::tuple<uint8_t*, uint32_t, size_t> beginDataPtr(uint32_t flags);
     virtual void                                   endDataPtr();
     bool                                           good();
-    void                                           closeFDs();
 
     bool                                           success = false;
 
   private:
-    Aquamarine::SDMABUFAttrs attrs;
+    const Aquamarine::SDMABUFAttrs attrs;
+    Aquamarine::SDMABUFAttrs       implicit;
 
     struct {
         CHyprSignalListener resourceDestroy;

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -535,7 +535,7 @@ EGLImageKHR CHyprOpenGLImpl::createEGLImage(const Aquamarine::SDMABUFAttrs& attr
 
     for (int i = 0; i < attrs.planes; i++) {
         attribs.push_back(attrNames[i].fd);
-        attribs.push_back(attrs.fds[i]);
+        attribs.push_back(attrs.fds[i].get());
         attribs.push_back(attrNames[i].offset);
         attribs.push_back(attrs.offsets[i]);
         attribs.push_back(attrNames[i].pitch);

--- a/src/render/Renderbuffer.cpp
+++ b/src/render/Renderbuffer.cpp
@@ -22,7 +22,7 @@ CRenderbuffer::~CRenderbuffer() {
 }
 
 CRenderbuffer::CRenderbuffer(SP<Aquamarine::IBuffer> buffer, uint32_t format) : m_pHLBuffer(buffer), m_uDrmFormat(format) {
-    auto dma = buffer->dmabuf();
+    const auto& dma = buffer->dmabuf();
 
     m_iImage = g_pHyprOpenGL->createEGLImage(dma);
     if (m_iImage == EGL_NO_IMAGE_KHR) {

--- a/src/render/Texture.cpp
+++ b/src/render/Texture.cpp
@@ -29,7 +29,7 @@ CTexture::CTexture(const SP<Aquamarine::IBuffer> buffer, bool keepDataCopy) : m_
 
     m_bOpaque = buffer->opaque;
 
-    auto attrs = buffer->dmabuf();
+    const auto& attrs = buffer->dmabuf();
 
     if (!attrs.success) {
         // attempt shm


### PR DESCRIPTION
lets start using CFileDescriptors in AQ, adapt to its changed and refactor a bit of code in related usage.
this also makes it use more references and unique pointers in dmabuf handling. because CFileDescriptor not being copyable. should in turn be less wasteful.

requires. https://github.com/hyprwm/aquamarine/pull/142


