### PR TITLE
Update README.md to ensure proper grammar and consistency with the rest of the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ easy IPC, much more QoL stuff than other compositors and more...
 
 - All of the eyecandy: gradient borders, blur, animations, shadows and much more
 - A lot of customization
-- 100% independent, no wlroots, no libweston, no kwin, no mutter.
+- 100% independent, no wlroots, no libweston, no kwin and no mutter.
 - Custom bezier curves for the best animations
 - Powerful plugin support
 - Built-in plugin manager

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ easy IPC, much more QoL stuff than other compositors and more...
 
 - All of the eyecandy: gradient borders, blur, animations, shadows and much more
 - A lot of customization
-- 100% independent; no wlroots, no libweston, no kwin and no mutter.
+- 100% independent; no wlroots, no libweston, no kwin and no mutter
 - Custom bezier curves for the best animations
 - Powerful plugin support
 - Built-in plugin manager

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ easy IPC, much more QoL stuff than other compositors and more...
 
 - All of the eyecandy: gradient borders, blur, animations, shadows and much more
 - A lot of customization
-- 100% independent, no wlroots, no libweston, no kwin and no mutter.
+- 100% independent; no wlroots, no libweston, no kwin and no mutter.
 - Custom bezier curves for the best animations
 - Powerful plugin support
 - Built-in plugin manager


### PR DESCRIPTION
This pull request updates `README.md` to remove the oxford comma (the University of Oxford recommends this, as can be seen [here](https://www.ox.ac.uk/sites/files/oxford/media_wysiwyg/University%20of%20Oxford%20Style%20Guide.pdf). This is optional, though. If Vaxry wishes to keep the oxford comma, it is **fine by me** as it is defined by other bodies that an oxford comma is appropriate in this context. I have allowed edits by maintainers so that he can do this if he wishes.

However, the first colon here is widely considered incorrect and should be updated to be a semicolon.

The other issue with the current readme is that it has a full stop one one specific line, which should be rectified for consistency. This PR also does this.

---
Depending on Vaxry's opinion on the oxford comma being used in this context, it may or may not be ready for merging.

Happy hypring!