### PR TITLE
fixes #9322, take `active_area_size` into account when sending tip event

### DIFF
--- a/src/managers/input/Tablets.cpp
+++ b/src/managers/input/Tablets.cpp
@@ -160,7 +160,17 @@ void CInputManager::onTabletTip(CTablet::STipEvent e) {
     const auto PTAB  = e.tablet;
     const auto PTOOL = ensureTabletToolPresent(e.tool);
     const auto POS   = e.tip;
-    g_pPointerManager->warpAbsolute(POS, PTAB);
+
+    auto       x = POS.x;
+    auto       y = POS.y;
+    //Calculate transformations if active area is set
+    if (!PTAB->activeArea.empty()) {
+        if (!std::isnan(POS.x))
+            x = (POS.x - PTAB->activeArea.x) / (PTAB->activeArea.w - PTAB->activeArea.x);
+        if (!std::isnan(POS.y))
+            y = (POS.y - PTAB->activeArea.y) / (PTAB->activeArea.h - PTAB->activeArea.y);
+    }
+    g_pPointerManager->warpAbsolute({x, y}, PTAB);
     refocusTablet(PTAB, PTOOL, true);
 
     if (e.in)


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Fixes #9322. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
The transformation basically was just copied over from [`void CInputManager::onTabletAxis`](https://github.com/hyprwm/Hyprland/blob/3b99e906df8b439d65e740301940e57efc057012/src/managers/input/Tablets.cpp#L117). 

So perhaps the transformation should be applied instead in `warpAbsolute`? I'm not familiar with the codebase.

#### Is it ready for merging, or does it need work?
It fixes the bug and works for me. But would be cool if somebody could check it; especially if it does not introduce additional issues.

