### PR TITLE
Fix DS and VRR automation

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1054,9 +1054,9 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
     },
     SConfigOptionDescription{
         .value       = "misc:vrr",
-        .description = "	controls the VRR (Adaptive Sync) of your monitors. 0 - off, 1 - on, 2 - fullscreen only [0/1/2]",
+        .description = "	controls the VRR (Adaptive Sync) of your monitors. 0 - off, 1 - on, 2 - fullscreen only, 3 - fullscreen with game or video content type [0/1/2/3]",
         .type        = CONFIG_OPTION_INT,
-        .data        = SConfigOptionDescription::SRangeData{0, 0, 2},
+        .data        = SConfigOptionDescription::SRangeData{.value = 0, .min = 0, .max = 3},
     },
     SConfigOptionDescription{
         .value       = "misc:mouse_move_enables_dpms",

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1216,7 +1216,8 @@ void CHyprRenderer::renderMonitor(PHLMONITOR pMonitor) {
     pMonitor->tearingState.activelyTearing = shouldTear;
 
     if ((*PDIRECTSCANOUT == 1 ||
-         (*PDIRECTSCANOUT == 2 && pMonitor->activeWorkspace->getFullscreenWindow() && pMonitor->activeWorkspace->getFullscreenWindow()->getContentType() == CONTENT_TYPE_GAME)) &&
+         (*PDIRECTSCANOUT == 2 && pMonitor->activeWorkspace && pMonitor->activeWorkspace->m_bHasFullscreenWindow &&
+          pMonitor->activeWorkspace->m_efFullscreenMode == FSMODE_FULLSCREEN && pMonitor->activeWorkspace->getFullscreenWindow()->getContentType() == CONTENT_TYPE_GAME)) &&
         !shouldTear) {
         if (pMonitor->attemptDirectScanout()) {
             return;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fix DS automation conditions. Fixes https://github.com/hyprwm/Hyprland/issues/9331
Fix VRR auto activation. Might fix https://github.com/hyprwm/Hyprland/issues/9230
Add `misc:vrr = 3` to auto enable VRR for game or video content types. Can be used instead of a window rule https://github.com/hyprwm/Hyprland/issues/7621

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
There is no need to commit VRR state and deal with explicit sync inside `ensureVRR`. Next rendered frame should pickup new desired state. Legacy renderer is untested.
Needs more testing with `vrr = 2` or `vrr = 3` and monitors without VRR support.

#### Is it ready for merging, or does it need work?
Ready

