### PR TITLE
toplevelexport: fix transformed origin for shm buffers

### DIFF
--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -289,7 +289,30 @@ bool CToplevelExportFrame::copyShm(timespec* now) {
     glPixelStorei(GL_PACK_ALIGNMENT, 1);
 
     auto glFormat = PFORMAT->flipRB ? GL_BGRA_EXT : GL_RGBA;
-    glReadPixels(0, 0, box.width, box.height, glFormat, PFORMAT->glType, pixelData);
+
+    int  origin_x = 0;
+    int  origin_y = 0;
+    switch (PMONITOR->transform) {
+        case WL_OUTPUT_TRANSFORM_FLIPPED_180:
+        case WL_OUTPUT_TRANSFORM_90: {
+            origin_y = PMONITOR->vecPixelSize.y - box.height;
+            break;
+        }
+        case WL_OUTPUT_TRANSFORM_FLIPPED_270:
+        case WL_OUTPUT_TRANSFORM_180: {
+            origin_x = PMONITOR->vecPixelSize.x - box.width;
+            origin_y = PMONITOR->vecPixelSize.y - box.height;
+            break;
+        }
+        case WL_OUTPUT_TRANSFORM_FLIPPED:
+        case WL_OUTPUT_TRANSFORM_270: {
+            origin_x = PMONITOR->vecPixelSize.x - box.width;
+            break;
+        }
+        default: break;
+    }
+
+    glReadPixels(origin_x, origin_y, box.width, box.height, glFormat, PFORMAT->glType, pixelData);
 
     if (overlayCursor) {
         g_pPointerManager->unlockSoftwareForMonitor(PMONITOR->self.lock());

--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -11,6 +11,7 @@
 #include "../render/Renderer.hpp"
 
 #include <algorithm>
+#include <hyprutils/math/Vector2D.hpp>
 
 CToplevelExportClient::CToplevelExportClient(SP<CHyprlandToplevelExportManagerV1> resource_) : resource(resource_) {
     if UNLIKELY (!good())
@@ -290,29 +291,28 @@ bool CToplevelExportFrame::copyShm(timespec* now) {
 
     auto glFormat = PFORMAT->flipRB ? GL_BGRA_EXT : GL_RGBA;
 
-    int  origin_x = 0;
-    int  origin_y = 0;
+    auto origin = Vector2D(0, 0);
     switch (PMONITOR->transform) {
         case WL_OUTPUT_TRANSFORM_FLIPPED_180:
         case WL_OUTPUT_TRANSFORM_90: {
-            origin_y = PMONITOR->vecPixelSize.y - box.height;
+            origin.y = PMONITOR->vecPixelSize.y - box.height;
             break;
         }
         case WL_OUTPUT_TRANSFORM_FLIPPED_270:
         case WL_OUTPUT_TRANSFORM_180: {
-            origin_x = PMONITOR->vecPixelSize.x - box.width;
-            origin_y = PMONITOR->vecPixelSize.y - box.height;
+            origin.x = PMONITOR->vecPixelSize.x - box.width;
+            origin.y = PMONITOR->vecPixelSize.y - box.height;
             break;
         }
         case WL_OUTPUT_TRANSFORM_FLIPPED:
         case WL_OUTPUT_TRANSFORM_270: {
-            origin_x = PMONITOR->vecPixelSize.x - box.width;
+            origin.x = PMONITOR->vecPixelSize.x - box.width;
             break;
         }
         default: break;
     }
 
-    glReadPixels(origin_x, origin_y, box.width, box.height, glFormat, PFORMAT->glType, pixelData);
+    glReadPixels(origin.x, origin.y, box.width, box.height, glFormat, PFORMAT->glType, pixelData);
 
     if (overlayCursor) {
         g_pPointerManager->unlockSoftwareForMonitor(PMONITOR->self.lock());


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

When using a shm buffer for the toplevel export of a window which is on a transformed output, the origin for copying the frame into the buffer is not transformed which can produce black spots or entirely black images. I've implemented the origin transformations for all allowed output transformations.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I don't know whether it's intended that frames captured using the toplevel export protocol do not respect transformations of the outputs their on but since I've found this code I assume it isn't intended:

https://github.com/hyprwm/Hyprland/blob/8a6778f0a087cdfc4bc1d3751b0be2c2bf3322aa/src/protocols/ToplevelExport.cpp#L122-L124

however, since `pWindow->m_vRealSize` is the size of the window with transformations taken into account, transforming the box can cause undesired box dimensions (in my case of `WL_OUTPUT_TRANSFORM_270` the height and width are swapped). 

In my opinion there are two possible solutions to "fixing" this:
1. **Inform the client about the transformation**: In this case, we would ideally change the `hyprland_toplevel_export_frame_v1` protocol to inform the client (in the buffer event?) about the transformation of the output on which the window is, such that the client can implement the transformation itself. Alternatively, there is already the option for the client to get the output for the window by it's address handle using e.g. the hyprland socket and read the transformation from there. In this case the problem is already kind of solved.

2. **Transform the buffer on the server**: Since the `renderWindow` method doesn't care about the transformation of the output on which the window is, we would need to read the pixels into a temporary buffer from which we can transform them accordingly. For the dma buffer something similar would need to be implemented

Let me know if I missed something or got something wrong. 

#### Is it ready for merging, or does it need work?

I think solving the transformation problem (should it even be one) would be better off in a separate issue. In this case this pull request is ready for merging
