### PR TITLE
desktop: add ability to target pinned windows in workspace rules

### DIFF
--- a/scripts/generateVersion.sh
+++ b/scripts/generateVersion.sh
@@ -1,4 +1,13 @@
 #!/bin/sh
+
+# if the git directory doesn't exist, don't gather data to avoid overwriting, unless
+# the version file is missing altogether (otherwise compiling will fail)
+if [[ ! -d ./.git ]]; then
+    if [[ -f ./src/version.h ]]; then
+        exit 0
+    fi
+fi
+
 cp -fr ./src/version.h.in ./src/version.h
 
 HASH=${HASH-$(git rev-parse HEAD)}

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -451,9 +451,9 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
 
                 WORKSPACEID count;
                 if (wantsCountGroup)
-                    count = getGroups(wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled),
-                                      wantsOnlyPinned ? std::optional<bool>(wantsOnlyPinned) : std::nullopt,
-                                      wantsCountVisible ? std::optional<bool>(wantsCountVisible) : std::nullopt);
+                    count =
+                        getGroups(wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled),
+                                  wantsOnlyPinned ? std::optional<bool>(wantsOnlyPinned) : std::nullopt, wantsCountVisible ? std::optional<bool>(wantsCountVisible) : std::nullopt);
                 else
                     count = getWindows(wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>((bool)wantsOnlyTiled),
                                        wantsOnlyPinned ? std::optional<bool>(wantsOnlyPinned) : std::nullopt,

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -72,8 +72,8 @@ class CWorkspace {
     SWorkspaceIDName getPrevWorkspaceIDName() const;
     void             updateWindowDecos();
     void             updateWindowData();
-    int              getWindows(std::optional<bool> onlyTiled = {}, std::optional<bool> onlyVisible = {});
-    int              getGroups(std::optional<bool> onlyTiled = {}, std::optional<bool> onlyVisible = {});
+    int              getWindows(std::optional<bool> onlyTiled = {}, std::optional<bool> onlyPinned = {}, std::optional<bool> onlyVisible = {});
+    int              getGroups(std::optional<bool> onlyTiled = {}, std::optional<bool> onlyPinned = {}, std::optional<bool> onlyVisible = {});
     bool             hasUrgentWindow();
     PHLWINDOW        getFirstWindow();
     PHLWINDOW        getTopLeftWindow();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Hello

This PR introduces the ability to check for pinned windows and groups in workspace rules by adding the `p` flag (`w[p1]` / `w[p1-2]` / `w[pg1]` / `w[pg1-2]`).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
It should be complete