### PR TITLE
Update persistence on workspace rename

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -3040,7 +3040,13 @@ void CCompositor::ensurePersistentWorkspacesPresent(const std::vector<SWorkspace
             continue;
         }
 
-        auto PWORKSPACE = pWorkspace;
+        PHLWORKSPACE PWORKSPACE = nullptr;
+        if (pWorkspace) {
+            if (pWorkspace->matchesStaticSelector(rule.workspaceString))
+                PWORKSPACE = pWorkspace;
+            else
+                continue;
+        }
 
         if (!PWORKSPACE) {
             WORKSPACEID id     = rule.workspaceId;

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -3040,11 +3040,12 @@ void CCompositor::ensurePersistentWorkspacesPresent(const std::vector<SWorkspace
             continue;
         }
 
-        auto        PWORKSPACE = pWorkspace;
+        auto PWORKSPACE = pWorkspace;
 
-        WORKSPACEID id     = rule.workspaceId;
-        std::string wsname = rule.workspaceName;
         if (!PWORKSPACE) {
+            WORKSPACEID id     = rule.workspaceId;
+            std::string wsname = rule.workspaceName;
+
             if (id == WORKSPACE_INVALID) {
                 const auto R = getWorkspaceIDNameFromString(rule.workspaceString);
                 id           = R.id;
@@ -3056,6 +3057,8 @@ void CCompositor::ensurePersistentWorkspacesPresent(const std::vector<SWorkspace
                 continue;
             }
             PWORKSPACE = getWorkspaceByID(id);
+            if (!PWORKSPACE)
+                createNewWorkspace(id, PMONITOR ? PMONITOR : m_pLastMonitor.lock(), wsname, false);
         }
         if (PWORKSPACE) {
             PWORKSPACE->m_bPersistent = true;
@@ -3069,8 +3072,7 @@ void CCompositor::ensurePersistentWorkspacesPresent(const std::vector<SWorkspace
             Debug::log(LOG, "ensurePersistentWorkspacesPresent: workspace persistent {} not on {}, moving", rule.workspaceString, PMONITOR->szName);
             moveWorkspaceToMonitor(PWORKSPACE, PMONITOR);
             continue;
-        } else
-            createNewWorkspace(id, PMONITOR ? PMONITOR : m_pLastMonitor.lock(), wsname, false);
+        }
     }
 
     // cleanup old

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -3027,7 +3027,8 @@ bool CCompositor::shouldChangePreferredImageDescription() {
     return false;
 }
 
-void CCompositor::ensurePersistentWorkspacesPresent(const std::vector<SWorkspaceRule>& rules) {
+void CCompositor::ensurePersistentWorkspacesPresent(const std::vector<SWorkspaceRule>& rules, PHLWORKSPACE pWorkspace) {
+
     for (const auto& rule : rules) {
         if (!rule.isPersistent)
             continue;
@@ -3039,31 +3040,37 @@ void CCompositor::ensurePersistentWorkspacesPresent(const std::vector<SWorkspace
             continue;
         }
 
+        auto        PWORKSPACE = pWorkspace;
+
         WORKSPACEID id     = rule.workspaceId;
         std::string wsname = rule.workspaceName;
-        if (id == WORKSPACE_INVALID) {
-            const auto R = getWorkspaceIDNameFromString(rule.workspaceString);
-            id           = R.id;
-            wsname       = R.name;
-        }
+        if (!PWORKSPACE) {
+            if (id == WORKSPACE_INVALID) {
+                const auto R = getWorkspaceIDNameFromString(rule.workspaceString);
+                id           = R.id;
+                wsname       = R.name;
+            }
 
-        if (id == WORKSPACE_INVALID) {
-            Debug::log(ERR, "ensurePersistentWorkspacesPresent: couldn't resolve id for workspace {}", rule.workspaceString);
-            continue;
+            if (id == WORKSPACE_INVALID) {
+                Debug::log(ERR, "ensurePersistentWorkspacesPresent: couldn't resolve id for workspace {}", rule.workspaceString);
+                continue;
+            }
+            PWORKSPACE = getWorkspaceByID(id);
         }
+        if (PWORKSPACE) {
+            PWORKSPACE->m_bPersistent = true;
 
-        if (const auto PWORKSPACE = getWorkspaceByID(id); PWORKSPACE) {
             if (PWORKSPACE->m_pMonitor == PMONITOR) {
                 Debug::log(LOG, "ensurePersistentWorkspacesPresent: workspace persistent {} already on {}", rule.workspaceString, PMONITOR->szName);
+
                 continue;
             }
 
             Debug::log(LOG, "ensurePersistentWorkspacesPresent: workspace persistent {} not on {}, moving", rule.workspaceString, PMONITOR->szName);
             moveWorkspaceToMonitor(PWORKSPACE, PMONITOR);
             continue;
-        }
-
-        createNewWorkspace(id, PMONITOR ? PMONITOR : m_pLastMonitor.lock(), wsname, false);
+        } else
+            createNewWorkspace(id, PMONITOR ? PMONITOR : m_pLastMonitor.lock(), wsname, false);
     }
 
     // cleanup old

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -3033,13 +3033,6 @@ void CCompositor::ensurePersistentWorkspacesPresent(const std::vector<SWorkspace
         if (!rule.isPersistent)
             continue;
 
-        const auto PMONITOR = getMonitorFromString(rule.monitor);
-
-        if (!PMONITOR) {
-            Debug::log(ERR, "ensurePersistentWorkspacesPresent: couldn't resolve monitor for {}, skipping", rule.monitor);
-            continue;
-        }
-
         PHLWORKSPACE PWORKSPACE = nullptr;
         if (pWorkspace) {
             if (pWorkspace->matchesStaticSelector(rule.workspaceString))
@@ -3047,6 +3040,8 @@ void CCompositor::ensurePersistentWorkspacesPresent(const std::vector<SWorkspace
             else
                 continue;
         }
+
+        const auto PMONITOR = getMonitorFromString(rule.monitor);
 
         if (!PWORKSPACE) {
             WORKSPACEID id     = rule.workspaceId;
@@ -3066,9 +3061,16 @@ void CCompositor::ensurePersistentWorkspacesPresent(const std::vector<SWorkspace
             if (!PWORKSPACE)
                 createNewWorkspace(id, PMONITOR ? PMONITOR : m_pLastMonitor.lock(), wsname, false);
         }
-        if (PWORKSPACE) {
+
+        if (PWORKSPACE)
             PWORKSPACE->m_bPersistent = true;
 
+        if (!PMONITOR) {
+            Debug::log(ERR, "ensurePersistentWorkspacesPresent: couldn't resolve monitor for {}, skipping", rule.monitor);
+            continue;
+        }
+
+        if (PWORKSPACE) {
             if (PWORKSPACE->m_pMonitor == PMONITOR) {
                 Debug::log(LOG, "ensurePersistentWorkspacesPresent: workspace persistent {} already on {}", rule.workspaceString, PMONITOR->szName);
 

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -149,7 +149,7 @@ class CCompositor {
     void                   setPreferredTransformForSurface(SP<CWLSurfaceResource> pSurface, wl_output_transform transform);
     void                   updateSuspendedStates();
     void                   onNewMonitor(SP<Aquamarine::IOutput> output);
-    void                   ensurePersistentWorkspacesPresent(const std::vector<SWorkspaceRule>& rules);
+    void                   ensurePersistentWorkspacesPresent(const std::vector<SWorkspaceRule>& rules, PHLWORKSPACE pWorkspace = nullptr);
 
     SImageDescription      getPreferredImageDescription();
     bool                   shouldChangePreferredImageDescription();

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -323,8 +323,8 @@ std::string CHyprCtl::getWorkspaceData(PHLWORKSPACE w, eHyprCtlOutputFormat form
     "ispersistent": {}
 }})#",
                            w->m_iID, escapeJSONStrings(w->m_szName), escapeJSONStrings(PMONITOR ? PMONITOR->szName : "?"),
-                           escapeJSONStrings(PMONITOR ? std::to_string(PMONITOR->ID) : "null"), w->getWindows(), ((int)w->m_bHasFullscreenWindow == 1 ? "true" : "false"),
-                           (uintptr_t)PLASTW.get(), PLASTW ? escapeJSONStrings(PLASTW->m_szTitle) : "", ((int)w->m_bPersistent == 1 ? "true" : "false"));
+                           escapeJSONStrings(PMONITOR ? std::to_string(PMONITOR->ID) : "null"), w->getWindows(), w->m_bHasFullscreenWindow ? "true" : "false",
+                           (uintptr_t)PLASTW.get(), PLASTW ? escapeJSONStrings(PLASTW->m_szTitle) : "", w->m_bPersistent ? "true" : "false");
     } else {
         return std::format(
             "workspace ID {} ({}) on monitor {}:\n\tmonitorID: {}\n\twindows: {}\n\thasfullscreen: {}\n\tlastwindow: 0x{:x}\n\tlastwindowtitle: {}\n\tispersistent: {}\n\n",

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -319,15 +319,17 @@ std::string CHyprCtl::getWorkspaceData(PHLWORKSPACE w, eHyprCtlOutputFormat form
     "windows": {},
     "hasfullscreen": {},
     "lastwindow": "0x{:x}",
-    "lastwindowtitle": "{}"
+    "lastwindowtitle": "{}",
+    "ispersistent": {}
 }})#",
                            w->m_iID, escapeJSONStrings(w->m_szName), escapeJSONStrings(PMONITOR ? PMONITOR->szName : "?"),
                            escapeJSONStrings(PMONITOR ? std::to_string(PMONITOR->ID) : "null"), w->getWindows(), ((int)w->m_bHasFullscreenWindow == 1 ? "true" : "false"),
-                           (uintptr_t)PLASTW.get(), PLASTW ? escapeJSONStrings(PLASTW->m_szTitle) : "");
+                           (uintptr_t)PLASTW.get(), PLASTW ? escapeJSONStrings(PLASTW->m_szTitle) : "", ((int)w->m_bPersistent == 1 ? "true" : "false"));
     } else {
-        return std::format("workspace ID {} ({}) on monitor {}:\n\tmonitorID: {}\n\twindows: {}\n\thasfullscreen: {}\n\tlastwindow: 0x{:x}\n\tlastwindowtitle: {}\n\n", w->m_iID,
-                           w->m_szName, PMONITOR ? PMONITOR->szName : "?", PMONITOR ? std::to_string(PMONITOR->ID) : "null", w->getWindows(), (int)w->m_bHasFullscreenWindow,
-                           (uintptr_t)PLASTW.get(), PLASTW ? PLASTW->m_szTitle : "");
+        return std::format(
+            "workspace ID {} ({}) on monitor {}:\n\tmonitorID: {}\n\twindows: {}\n\thasfullscreen: {}\n\tlastwindow: 0x{:x}\n\tlastwindowtitle: {}\n\tispersistent: {}\n\n",
+            w->m_iID, w->m_szName, PMONITOR ? PMONITOR->szName : "?", PMONITOR ? std::to_string(PMONITOR->ID) : "null", w->getWindows(), (int)w->m_bHasFullscreenWindow,
+            (uintptr_t)PLASTW.get(), PLASTW ? PLASTW->m_szTitle : "", (int)w->m_bPersistent);
     }
 }
 

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -632,6 +632,11 @@ void CWorkspace::updateWindowData() {
     }
 }
 
+void CWorkspace::recheckPersistent() {
+    const auto WORKSPACERULE = g_pConfigManager->getWorkspaceRuleFor(m_pSelf.lock());
+    m_bPersistent            = WORKSPACERULE.isPersistent;
+}
+
 void CWorkspace::forceReportSizesToWindows() {
     for (auto const& w : g_pCompositor->m_vWindows) {
         if (w->m_pWorkspace != m_pSelf || !w->m_bIsMapped || w->isHidden())
@@ -648,8 +653,7 @@ void CWorkspace::rename(const std::string& name) {
     Debug::log(LOG, "CWorkspace::rename: Renaming workspace {} to '{}'", m_iID, name);
     m_szName = name;
 
-    const auto WORKSPACERULE = g_pConfigManager->getWorkspaceRuleFor(m_pSelf.lock());
-    m_bPersistent            = WORKSPACERULE.isPersistent;
+    recheckPersistent();
 
     g_pEventManager->postEvent({"renameworkspace", std::to_string(m_iID) + "," + m_szName});
 }

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -632,11 +632,6 @@ void CWorkspace::updateWindowData() {
     }
 }
 
-void CWorkspace::recheckPersistent() {
-    const auto WORKSPACERULE = g_pConfigManager->getWorkspaceRuleFor(m_pSelf.lock());
-    m_bPersistent            = WORKSPACERULE.isPersistent;
-}
-
 void CWorkspace::forceReportSizesToWindows() {
     for (auto const& w : g_pCompositor->m_vWindows) {
         if (w->m_pWorkspace != m_pSelf || !w->m_bIsMapped || w->isHidden())
@@ -653,7 +648,11 @@ void CWorkspace::rename(const std::string& name) {
     Debug::log(LOG, "CWorkspace::rename: Renaming workspace {} to '{}'", m_iID, name);
     m_szName = name;
 
-    recheckPersistent();
+    const auto WORKSPACERULE = g_pConfigManager->getWorkspaceRuleFor(m_pSelf.lock());
+    m_bPersistent            = WORKSPACERULE.isPersistent;
+
+    if (WORKSPACERULE.isPersistent)
+        g_pCompositor->ensurePersistentWorkspacesPresent(std::vector<SWorkspaceRule>{WORKSPACERULE}, m_pSelf.lock());
 
     g_pEventManager->postEvent({"renameworkspace", std::to_string(m_iID) + "," + m_szName});
 }

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -648,6 +648,9 @@ void CWorkspace::rename(const std::string& name) {
     Debug::log(LOG, "CWorkspace::rename: Renaming workspace {} to '{}'", m_iID, name);
     m_szName = name;
 
+    const auto WORKSPACERULE = g_pConfigManager->getWorkspaceRuleFor(m_pSelf.lock());
+    m_bPersistent            = WORKSPACERULE.isPersistent;
+
     g_pEventManager->postEvent({"renameworkspace", std::to_string(m_iID) + "," + m_szName});
 }
 

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -72,7 +72,6 @@ class CWorkspace {
     SWorkspaceIDName getPrevWorkspaceIDName() const;
     void             updateWindowDecos();
     void             updateWindowData();
-    void             recheckPersistent();
     int              getWindows(std::optional<bool> onlyTiled = {}, std::optional<bool> onlyPinned = {}, std::optional<bool> onlyVisible = {});
     int              getGroups(std::optional<bool> onlyTiled = {}, std::optional<bool> onlyPinned = {}, std::optional<bool> onlyVisible = {});
     bool             hasUrgentWindow();

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -72,6 +72,7 @@ class CWorkspace {
     SWorkspaceIDName getPrevWorkspaceIDName() const;
     void             updateWindowDecos();
     void             updateWindowData();
+    void             recheckPersistent();
     int              getWindows(std::optional<bool> onlyTiled = {}, std::optional<bool> onlyPinned = {}, std::optional<bool> onlyVisible = {});
     int              getGroups(std::optional<bool> onlyTiled = {}, std::optional<bool> onlyPinned = {}, std::optional<bool> onlyVisible = {});
     bool             hasUrgentWindow();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
The persistent workspace property is defined with workspace rules. 
At the moment there is no way to remove or edit a workspace rule. One consequence of this is that when a workspace is made persistent there is no way to remove that persistent property, and thus there is no way to remove the workspace.

**This pull request reevaluate the workspace rule when a workspace is renamed**, making the workspace rule to be respected. As a side effect it allows to rename the workspace in order to remove the persistence. 

I also added a line in the workspace info to show the status of persistence for the workspace.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
There are other ways to do this, I just thought this is a change little enough to not have too much code change. 
Other possible ways: 
1) implement a way to remove or edit a workspace rule
2) [probably ugly] implement a deleteworkspace which will remove the workspace even if it is persistent (but still must be empty)
3) extending this pr by enforcing all the properties of a workspace rule, not only the persistent bit. I think it would just be a matter of invoking `updateWindowData()`, but maybe optimizing a bit to only fetch the workspace rule once.

Anyway I still think that people would expect the workspace rules to be an "invariant", which is enforced at all time, not only at workspace creation

#### Is it ready for merging, or does it need work?
Ready and tested.

