### PR TITLE
set default value group:groupbar:gradients to true

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -883,7 +883,7 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .value       = "group:groupbar:gradients",
         .description = "enables gradients",
         .type        = CONFIG_OPTION_BOOL,
-        .data        = SConfigOptionDescription::SBoolData{false},
+        .data        = SConfigOptionDescription::SBoolData{true},
     },
     SConfigOptionDescription{
         .value       = "group:groupbar:height",


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
gradients default value should be set to true (https://wiki.hyprland.org/Configuring/Variables/#groupbar)


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no


#### Is it ready for merging, or does it need work?
yes

