### PR TITLE
implemented follow_mouse_threshold

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -503,7 +503,7 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
     },
     SConfigOptionDescription{
         .value       = "input:follow_mouse_threshold",
-        .description = "The smallest distance the mouse needs to travel for the window under it to get focused, works only with follow_mouse = 1.",
+        .description = "The smallest distance in logical pixels the mouse needs to travel for the window under it to get focused. Works only with follow_mouse = 1.",
         .type        = CONFIG_OPTION_FLOAT,
         .data        = SConfigOptionDescription::SFloatData{},
     },

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -502,6 +502,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SRangeData{1, 0, 3},
     },
     SConfigOptionDescription{
+        .value       = "input:follow_mouse_threshold",
+        .description = "The smallest distance the mouse needs to travel for the window under it to get focused, works only with follow_mouse = 1.",
+        .type        = CONFIG_OPTION_FLOAT,
+        .data        = SConfigOptionDescription::SFloatData{},
+    },
+    SConfigOptionDescription{
         .value       = "input:focus_on_close",
         .description = "Controls the window focus behavior when a window is closed. When set to 0, focus will shift to the next window candidate. When set to 1, focus will shift "
                        "to the window under the cursor.",

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -539,6 +539,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addConfigValue("animations:first_launch_animation", Hyprlang::INT{1});
 
     m_pConfig->addConfigValue("input:follow_mouse", Hyprlang::INT{1});
+    m_pConfig->addConfigValue("input:follow_mouse_threshold", Hyprlang::FLOAT{0});
     m_pConfig->addConfigValue("input:focus_on_close", Hyprlang::INT{0});
     m_pConfig->addConfigValue("input:mouse_refocus", Hyprlang::INT{1});
     m_pConfig->addConfigValue("input:special_fallthrough", Hyprlang::INT{0});

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -161,16 +161,22 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse) {
     if (MOUSECOORDSFLOORED == m_vLastCursorPosFloored && !refocus)
         return;
 
-    static auto PFOLLOWMOUSE      = CConfigValue<Hyprlang::INT>("input:follow_mouse");
-    static auto PMOUSEREFOCUS     = CConfigValue<Hyprlang::INT>("input:mouse_refocus");
-    static auto PFOLLOWONDND      = CConfigValue<Hyprlang::INT>("misc:always_follow_on_dnd");
-    static auto PFLOATBEHAVIOR    = CConfigValue<Hyprlang::INT>("input:float_switch_override_focus");
-    static auto PMOUSEFOCUSMON    = CConfigValue<Hyprlang::INT>("misc:mouse_move_focuses_monitor");
-    static auto PRESIZEONBORDER   = CConfigValue<Hyprlang::INT>("general:resize_on_border");
-    static auto PRESIZECURSORICON = CConfigValue<Hyprlang::INT>("general:hover_icon_on_border");
-    static auto PZOOMFACTOR       = CConfigValue<Hyprlang::FLOAT>("cursor:zoom_factor");
+    static auto PFOLLOWMOUSE          = CConfigValue<Hyprlang::INT>("input:follow_mouse");
+    static auto PFOLLOWMOUSETHRESHOLD = CConfigValue<Hyprlang::FLOAT>("input:follow_mouse_threshold");
+    static auto PMOUSEREFOCUS         = CConfigValue<Hyprlang::INT>("input:mouse_refocus");
+    static auto PFOLLOWONDND          = CConfigValue<Hyprlang::INT>("misc:always_follow_on_dnd");
+    static auto PFLOATBEHAVIOR        = CConfigValue<Hyprlang::INT>("input:float_switch_override_focus");
+    static auto PMOUSEFOCUSMON        = CConfigValue<Hyprlang::INT>("misc:mouse_move_focuses_monitor");
+    static auto PRESIZEONBORDER       = CConfigValue<Hyprlang::INT>("general:resize_on_border");
+    static auto PRESIZECURSORICON     = CConfigValue<Hyprlang::INT>("general:hover_icon_on_border");
+    static auto PZOOMFACTOR           = CConfigValue<Hyprlang::FLOAT>("cursor:zoom_factor");
 
     const auto  FOLLOWMOUSE = *PFOLLOWONDND && PROTO::data->dndActive() ? 1 : *PFOLLOWMOUSE;
+
+    if (FOLLOWMOUSE == 1 && m_tmrLastCursorMovement.getSeconds() < 0.5)
+        m_vMousePosDelta += MOUSECOORDSFLOORED.distance(m_vLastCursorPosFloored);
+    else
+        m_vMousePosDelta = 0;
 
     m_pFoundSurfaceToFocus.reset();
     m_pFoundLSToFocus.reset();
@@ -513,9 +519,10 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse) {
 
                     // TODO: this looks wrong. When over a popup, it constantly is switching.
                     // Temp fix until that's figured out. Otherwise spams windowrule lookups and other shit.
-                    if (m_pLastMouseFocus.lock() != pFoundWindow || g_pCompositor->m_pLastWindow.lock() != pFoundWindow)
-                        g_pCompositor->focusWindow(pFoundWindow, foundSurface);
-                    else
+                    if (m_pLastMouseFocus.lock() != pFoundWindow || g_pCompositor->m_pLastWindow.lock() != pFoundWindow) {
+                        if (m_vMousePosDelta > *PFOLLOWMOUSETHRESHOLD || refocus)
+                            g_pCompositor->focusWindow(pFoundWindow, foundSurface);
+                    } else
                         g_pCompositor->focusSurface(foundSurface, pFoundWindow);
                 }
             }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -174,9 +174,9 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse) {
     const auto  FOLLOWMOUSE = *PFOLLOWONDND && PROTO::data->dndActive() ? 1 : *PFOLLOWMOUSE;
 
     if (FOLLOWMOUSE == 1 && m_tmrLastCursorMovement.getSeconds() < 0.5)
-        m_vMousePosDelta += MOUSECOORDSFLOORED.distance(m_vLastCursorPosFloored);
+        m_fMousePosDelta += MOUSECOORDSFLOORED.distance(m_vLastCursorPosFloored);
     else
-        m_vMousePosDelta = 0;
+        m_fMousePosDelta = 0;
 
     m_pFoundSurfaceToFocus.reset();
     m_pFoundLSToFocus.reset();
@@ -520,7 +520,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse) {
                     // TODO: this looks wrong. When over a popup, it constantly is switching.
                     // Temp fix until that's figured out. Otherwise spams windowrule lookups and other shit.
                     if (m_pLastMouseFocus.lock() != pFoundWindow || g_pCompositor->m_pLastWindow.lock() != pFoundWindow) {
-                        if (m_vMousePosDelta > *PFOLLOWMOUSETHRESHOLD || refocus)
+                        if (m_fMousePosDelta > *PFOLLOWMOUSETHRESHOLD || refocus)
                             g_pCompositor->focusWindow(pFoundWindow, foundSurface);
                     } else
                         g_pCompositor->focusSurface(foundSurface, pFoundWindow);

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -255,6 +255,7 @@ class CInputManager {
 
     // used for warping back after non-mouse input
     Vector2D m_vLastMousePos   = {};
+    double   m_vMousePosDelta  = 0;
     bool     m_bLastInputMouse = true;
 
     // for holding focus on buttons held

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -255,7 +255,7 @@ class CInputManager {
 
     // used for warping back after non-mouse input
     Vector2D m_vLastMousePos   = {};
-    double   m_vMousePosDelta  = 0;
+    double   m_fMousePosDelta  = 0;
     bool     m_bLastInputMouse = true;
 
     // for holding focus on buttons held


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds feature described in #9328. It introduces a new config variable input:follow_mouse_threshold

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I am not very familiar with this codebase so I did my best to understand what's happening, but please check if I got everything right!
I am unsure about the `|| refocus` in the last if before we call `focusWindow`, is it pointless?
Another thing is the magic constant that I used to determine if a mouse movement is "tied" to the last mouse movement or not (if they happened within 0.5 seconds of each other, they are considered to be the same mouse movement)

#### Is it ready for merging, or does it need work?
Yes, it's ready to be merged
