### PR TITLE
fix(render): disable explicit if aquamarine output doesn't support it

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1312,7 +1312,7 @@ bool CMonitor::attemptDirectScanout() {
         return false;
     }
 
-    auto explicitOptions = g_pHyprRenderer->getExplicitSyncSettings();
+    auto explicitOptions = g_pHyprRenderer->getExplicitSyncSettings(output);
 
     // wait for the explicit fence if present, and if kms explicit is allowed
     bool DOEXPLICIT = PSURFACE->syncobj && PSURFACE->syncobj->current.acquireTimeline && PSURFACE->syncobj->current.acquireTimeline->timeline && explicitOptions.explicitKMSEnabled;

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -75,7 +75,7 @@ class CHyprRenderer {
     bool                            isNvidia();
     void                            makeEGLCurrent();
     void                            unsetEGL();
-    SExplicitSyncSettings           getExplicitSyncSettings();
+    SExplicitSyncSettings           getExplicitSyncSettings(SP<Aquamarine::IOutput> output);
     void                            addWindowToRenderUnfocused(PHLWINDOW window);
     void                            makeWindowSnapshot(PHLWINDOW);
     void                            makeRawWindowSnapshot(PHLWINDOW, CFramebuffer*);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes #9396.

The explicit settings ignore the aquamarine output.supportsExplicit attribute, which creates glitches on drivers not supporting explicit sync (example: freedreno).

If the output has been set as not supporting explicit, disable the explicit settings.

<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

#### Is it ready for merging, or does it need work?

Ready to merge.
