### PR TITLE
session-lock: send locked when in unsafe state

### DIFF
--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -89,6 +89,13 @@ void CSessionLockManager::onNewSessionLock(SP<CSessionLock> pLock) {
 
     g_pCompositor->focusSurface(nullptr);
     g_pSeatManager->setGrab(nullptr);
+
+    // Normally the locked event is sent after each output rendered a lock screen frame.
+    // When there are no outputs, send it right away.
+    if (g_pCompositor->m_bUnsafeState) {
+        m_pSessionLock->lock->sendLocked();
+        m_pSessionLock->m_hasSentLocked = true;
+    }
 }
 
 bool CSessionLockManager::isSessionLocked() {
@@ -131,8 +138,7 @@ void CSessionLockManager::onLockscreenRenderedOnMonitor(uint64_t id) {
     if (!m_pSessionLock || m_pSessionLock->m_hasSentLocked)
         return;
     m_pSessionLock->m_lockedMonitors.emplace(id);
-    const auto MONITORS = g_pCompositor->m_vMonitors;
-    const bool LOCKED   = std::all_of(MONITORS.begin(), MONITORS.end(), [this](auto m) { return m_pSessionLock->m_lockedMonitors.contains(m->ID); });
+    const bool LOCKED = std::ranges::all_of(g_pCompositor->m_vMonitors, [this](auto m) { return m_pSessionLock->m_lockedMonitors.contains(m->ID); });
     if (LOCKED && m_pSessionLock->lock->good()) {
         m_pSessionLock->lock->sendLocked();
         m_pSessionLock->m_hasSentLocked = true;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Currently when we get locked during unsafe state, it won't send the "locked" event at all until a monitor is added.
Which is not that big of a problem, but not ideal either.

Hyprlock doesn't handle this quite right either.
It will create a new session lock surface dynamically when a new output is added. However, it checks if we received `locked` in order to do that, which results in hyprlock doing nothing when a new output is added.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Yes.
