### PR TITLE
syncobj: ensure we only add waiters on succesful checks

### DIFF
--- a/src/protocols/DRMSyncobj.cpp
+++ b/src/protocols/DRMSyncobj.cpp
@@ -75,7 +75,7 @@ CDRMSyncobjSurfaceResource::CDRMSyncobjSurfaceResource(SP<CWpLinuxDrmSyncobjSurf
             return;
         }
 
-        if (materialized)
+        if (materialized.value())
             return;
 
         surface->lockPendingState();
@@ -104,7 +104,7 @@ bool CDRMSyncobjSurfaceResource::good() {
     return resource->resource();
 }
 
-CDRMSyncobjTimelineResource::CDRMSyncobjTimelineResource(SP<CWpLinuxDrmSyncobjTimelineV1> resource_, CFileDescriptor fd_) : fd(std::move(fd_)), resource(resource_) {
+CDRMSyncobjTimelineResource::CDRMSyncobjTimelineResource(SP<CWpLinuxDrmSyncobjTimelineV1> resource_, CFileDescriptor&& fd_) : fd(std::move(fd_)), resource(resource_) {
     if UNLIKELY (!good())
         return;
 

--- a/src/protocols/DRMSyncobj.hpp
+++ b/src/protocols/DRMSyncobj.hpp
@@ -33,7 +33,7 @@ class CDRMSyncobjSurfaceResource {
 
 class CDRMSyncobjTimelineResource {
   public:
-    CDRMSyncobjTimelineResource(SP<CWpLinuxDrmSyncobjTimelineV1> resource_, Hyprutils::OS::CFileDescriptor fd_);
+    CDRMSyncobjTimelineResource(SP<CWpLinuxDrmSyncobjTimelineV1> resource_, Hyprutils::OS::CFileDescriptor&& fd_);
     ~CDRMSyncobjTimelineResource() = default;
     static SP<CDRMSyncobjTimelineResource> fromResource(wl_resource*);
 


### PR DESCRIPTION
timeline check only returns nullopt on ETIME_ERR , meaning the if check later on returns true if drmSyncobjTimelineWait returns anything else like EINVAL/EPERM/EACCESS etc, so actually check the returned .value() of the std::optional. also move the fd to rvalue references.
