### PR TITLE
fix PointerConstraints activation occurring before attached to InputManager

### DIFF
--- a/src/protocols/PointerConstraints.cpp
+++ b/src/protocols/PointerConstraints.cpp
@@ -93,9 +93,6 @@ void CPointerConstraint::sharedConstructions() {
     }
 
     cursorPosOnActivate = g_pInputManager->getMouseCoordsInternal();
-
-    if (g_pCompositor->m_pLastFocus == pHLSurface->resource())
-        activate();
 }
 
 bool CPointerConstraint::good() {
@@ -111,8 +108,7 @@ void CPointerConstraint::deactivate() {
     else
         resourceC->sendUnconfined();
 
-    pendingActivation = false;
-    active            = false;
+    active = false;
 
     if (lifetime == ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_ONESHOT) {
         dead = true;
@@ -128,13 +124,7 @@ void CPointerConstraint::activate() {
     if (dead || active)
         return;
 
-    if (!attached) {
-        pendingActivation = true;
-        return;
-    }
-    pendingActivation = false;
-
-    //TODO: hack, probably not a super duper great idea
+    // TODO: hack, probably not a super duper great idea
     if (g_pSeatManager->state.pointerFocus != pHLSurface->resource()) {
         const auto SURFBOX = pHLSurface->getSurfaceBoxGlobal();
         const auto LOCAL   = SURFBOX.has_value() ? logicPositionHint() - SURFBOX->pos() : Vector2D{};
@@ -153,14 +143,6 @@ void CPointerConstraint::activate() {
 
 bool CPointerConstraint::isActive() {
     return active;
-}
-
-void CPointerConstraint::setAttached() {
-    attached = true;
-}
-
-bool CPointerConstraint::isActivationPending() {
-    return pendingActivation;
 }
 
 void CPointerConstraint::onSetRegion(wl_resource* wlRegion) {
@@ -260,8 +242,7 @@ void CPointerConstraintsProtocol::onNewConstraint(SP<CPointerConstraint> constra
 
     g_pInputManager->m_vConstraints.emplace_back(constraint);
 
-    constraint->setAttached();
-    if (constraint->isActivationPending())
+    if (g_pCompositor->m_pLastFocus == OWNER->resource())
         constraint->activate();
 }
 

--- a/src/protocols/PointerConstraints.hpp
+++ b/src/protocols/PointerConstraints.hpp
@@ -24,6 +24,9 @@ class CPointerConstraint {
     void           activate();
     bool           isActive();
 
+    void           setAttached();
+    bool           isActivationPending();
+
     SP<CWLSurface> owner();
 
     CRegion        logicConstraintRegion();
@@ -42,6 +45,8 @@ class CPointerConstraint {
     Vector2D                        positionHint        = {-1, -1};
     Vector2D                        cursorPosOnActivate = {-1, -1};
     bool                            active              = false;
+    bool                            attached            = false;
+    bool                            pendingActivation   = false;
     bool                            locked              = false;
     bool                            dead                = false;
     zwpPointerConstraintsV1Lifetime lifetime            = ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_ONESHOT;

--- a/src/protocols/PointerConstraints.hpp
+++ b/src/protocols/PointerConstraints.hpp
@@ -24,9 +24,6 @@ class CPointerConstraint {
     void           activate();
     bool           isActive();
 
-    void           setAttached();
-    bool           isActivationPending();
-
     SP<CWLSurface> owner();
 
     CRegion        logicConstraintRegion();
@@ -45,8 +42,6 @@ class CPointerConstraint {
     Vector2D                        positionHint        = {-1, -1};
     Vector2D                        cursorPosOnActivate = {-1, -1};
     bool                            active              = false;
-    bool                            attached            = false;
-    bool                            pendingActivation   = false;
     bool                            locked              = false;
     bool                            dead                = false;
     zwpPointerConstraintsV1Lifetime lifetime            = ZWP_POINTER_CONSTRAINTS_V1_LIFETIME_ONESHOT;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes  [#8506](https://github.com/hyprwm/Hyprland/issues/8506)

It is possible for the CInputManager::simulateMouseMovement() method to be called via CPointerConstraint::activate() without the constraint being present in InputManager.m_vConstraints.

This occurs when the constraint is activated before CPointerConstraintsProtocol::onNewConstraint is called, which is what places it in InputManager.m_vConstraints.

The lack of the instance of CPointerConstraint in m_vConstraints causes the CInputManager::isConstrained() method to fail and return false. As a result, the CInputManager::mouseMoveUnified method is run erroneously until it's end when the constraint is activated.

This does not seem to be very common behavior, but the FFXIV game running via wine and xwayland can trigger this.

As a solution, I found it ideal to postpone the activation of the constraint until after the onNewConstraint call.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This change assumes that it is true that a constraint cannot be activated before it is bound to the Input Manager. I don't see any sense in which this could be wrong, but it would be good to have a sanity check.

Later I will test other games that restrict the mouse to see if anything obviously broke.

#### Is it ready for merging, or does it need work?

Ready for merging.
