### PR TITLE
hyprctl: small fix

### DIFF
--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -354,7 +354,12 @@ int main(int argc, char** argv) {
             parseArgs = false;
             continue;
         }
-        if (parseArgs && (ARGS[i][0] == '-') && !isNumber(ARGS[i], true) /* For stuff like -2 */) {
+
+        std::size_t argumentLength = ARGS[i].find(',');
+        if (argumentLength == std::string::npos)
+            argumentLength = ARGS[i].size();
+
+        if (parseArgs && (ARGS[i][0] == '-') && !isNumber(ARGS[i].substr(0, argumentLength), true) /* For stuff like -2 */) {
             // parse
             if (ARGS[i] == "-j" && !fullArgs.contains("j")) {
                 fullArgs += "j";


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
hyprctl (the executable) doesn't accept arguments like:
```sh
hyprctl dispatch movewindowpixel 10 -10,active
```
this is because arguments are split at spaces, not commas by the shell

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
nothing to mention

#### Is it ready for merging, or does it need work?
yes, it is ready

