### PR TITLE
syncobj: use eventfd instead of stalling fd checks

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -691,7 +691,6 @@ CConfigManager::CConfigManager() {
     registerConfigVar("render:expand_undersized_textures", Hyprlang::INT{1});
     registerConfigVar("render:xp_mode", Hyprlang::INT{0});
     registerConfigVar("render:ctm_animation", Hyprlang::INT{2});
-    registerConfigVar("render:allow_early_buffer_release", Hyprlang::INT{1});
     registerConfigVar("render:cm_fs_passthrough", Hyprlang::INT{1});
 
     registerConfigVar("ecosystem:no_update_news", Hyprlang::INT{0});

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1391,16 +1391,17 @@ bool CMonitor::attemptDirectScanout() {
 
     auto explicitOptions = g_pHyprRenderer->getExplicitSyncSettings(output);
 
-    bool DOEXPLICIT = PSURFACE->syncobj && PSURFACE->syncobj->current.acquireTimeline && PSURFACE->syncobj->current.acquireTimeline->timeline && explicitOptions.explicitKMSEnabled;
+    bool DOEXPLICIT = PSURFACE->syncobj && PSURFACE->current.buffer && PSURFACE->current.buffer->acquire && explicitOptions.explicitKMSEnabled;
     if (DOEXPLICIT) {
         // wait for surface's explicit fence if present
-        CFileDescriptor fd = PSURFACE->syncobj->current.acquireTimeline->timeline->exportAsSyncFileFD(PSURFACE->syncobj->current.acquirePoint);
+        CFileDescriptor fd = PSURFACE->current.buffer->acquire->exportAsFD();
         if (fd.isValid()) {
             Debug::log(TRACE, "attemptDirectScanout: setting IN_FENCE for aq to {}", fd.get());
             output->state->setExplicitInFence(fd.get());
-        } else
+        } else {
             Debug::log(TRACE, "attemptDirectScanout: failed to acquire an sync file fd for aq IN_FENCE");
-        DOEXPLICIT = fd.isValid();
+            DOEXPLICIT = false;
+        }
     }
 
     commitSeq++;

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1426,7 +1426,7 @@ bool CMonitor::attemptDirectScanout() {
         Debug::log(LOG, "Entered a direct scanout to {:x}: \"{}\"", (uintptr_t)PCANDIDATE.get(), PCANDIDATE->m_szTitle);
     }
 
-    if (!PBUFFER->lockedByBackend)
+    if (!PBUFFER->lockedByBackend || PBUFFER->hlEvents.backendRelease)
         return true;
 
     // lock buffer while DRM/KMS is using it, then release it when page flip happens since DRM/KMS should be done by then

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1394,10 +1394,10 @@ bool CMonitor::attemptDirectScanout() {
     bool DOEXPLICIT = PSURFACE->syncobj && PSURFACE->current.buffer && PSURFACE->current.buffer->acquire && explicitOptions.explicitKMSEnabled;
     if (DOEXPLICIT) {
         // wait for surface's explicit fence if present
-        CFileDescriptor fd = PSURFACE->current.buffer->acquire->exportAsFD();
-        if (fd.isValid()) {
-            Debug::log(TRACE, "attemptDirectScanout: setting IN_FENCE for aq to {}", fd.get());
-            output->state->setExplicitInFence(fd.get());
+        inFence = PSURFACE->current.buffer->acquire->exportAsFD();
+        if (inFence.isValid()) {
+            Debug::log(TRACE, "attemptDirectScanout: setting IN_FENCE for aq to {}", inFence.get());
+            output->state->setExplicitInFence(inFence.get());
         } else {
             Debug::log(TRACE, "attemptDirectScanout: failed to acquire an sync file fd for aq IN_FENCE");
             DOEXPLICIT = false;

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -138,11 +138,12 @@ class CMonitor {
     SMonitorRule                activeMonitorRule;
 
     // explicit sync
-    SP<CSyncTimeline> inTimeline;
-    SP<CSyncTimeline> outTimeline;
-    uint64_t          commitSeq = 0;
+    SP<CSyncTimeline>              inTimeline;
+    SP<CSyncTimeline>              outTimeline;
+    Hyprutils::OS::CFileDescriptor inFence;
+    uint64_t                       commitSeq = 0;
 
-    PHLMONITORREF     self;
+    PHLMONITORREF                  self;
 
     // mirroring
     PHLMONITORREF              pMirrorOf;

--- a/src/helpers/sync/SyncReleaser.cpp
+++ b/src/helpers/sync/SyncReleaser.cpp
@@ -3,7 +3,7 @@
 #include "../../render/OpenGL.hpp"
 #include <sys/ioctl.h>
 
-#if defined(Q_OS_LINUX)
+#if defined(__linux__)
 #include <linux/sync_file.h>
 #else
 struct sync_merge_data {

--- a/src/helpers/sync/SyncReleaser.cpp
+++ b/src/helpers/sync/SyncReleaser.cpp
@@ -2,13 +2,15 @@
 #include "SyncTimeline.hpp"
 #include "../../render/OpenGL.hpp"
 
-CSyncReleaser::CSyncReleaser(WP<CSyncTimeline> timeline_, uint64_t point_) : timeline(timeline_), point(point_) {
+CSyncReleaser::CSyncReleaser(SP<CSyncTimeline> timeline_, uint64_t point_) : timeline(timeline_), point(point_) {
     ;
 }
 
 CSyncReleaser::~CSyncReleaser() {
-    if (timeline.expired())
+    if (!timeline) {
+        Debug::log(ERR, "CSyncReleaser destructing without a timeline");
         return;
+    }
 
     if (sync)
         timeline->importFromSyncFileFD(point, sync->fd());

--- a/src/helpers/sync/SyncReleaser.cpp
+++ b/src/helpers/sync/SyncReleaser.cpp
@@ -45,11 +45,10 @@ CFileDescriptor CSyncReleaser::mergeSyncFds(const CFileDescriptor& fd1, const CF
     do {
         err = ioctl(fd1.get(), SYNC_IOC_MERGE, &data);
     } while (err == -1 && (errno == EINTR || errno == EAGAIN));
-    if (err < 0) {
+    if (err < 0)
         return CFileDescriptor{};
-    } else {
+    else
         return CFileDescriptor(data.fence);
-    }
 }
 
 void CSyncReleaser::addReleaseSync(SP<CEGLSync> sync) {

--- a/src/helpers/sync/SyncReleaser.cpp
+++ b/src/helpers/sync/SyncReleaser.cpp
@@ -53,7 +53,7 @@ CFileDescriptor CSyncReleaser::mergeSyncFds(const CFileDescriptor& fd1, const CF
 
 void CSyncReleaser::addReleaseSync(SP<CEGLSync> sync) {
     if (m_fd.isValid())
-        mergeSyncFds(m_fd, sync->takeFD());
+        m_fd = mergeSyncFds(m_fd, sync->takeFD());
     else
         m_fd = sync->fd().duplicate();
 

--- a/src/helpers/sync/SyncReleaser.cpp
+++ b/src/helpers/sync/SyncReleaser.cpp
@@ -19,20 +19,20 @@ struct sync_merge_data {
 
 using namespace Hyprutils::OS;
 
-CSyncReleaser::CSyncReleaser(SP<CSyncTimeline> timeline_, uint64_t point_) : timeline(timeline_), point(point_) {
+CSyncReleaser::CSyncReleaser(SP<CSyncTimeline> timeline, uint64_t point) : m_timeline(timeline), m_point(point) {
     ;
 }
 
 CSyncReleaser::~CSyncReleaser() {
-    if (!timeline) {
+    if (!m_timeline) {
         Debug::log(ERR, "CSyncReleaser destructing without a timeline");
         return;
     }
 
     if (m_fd.isValid())
-        timeline->importFromSyncFileFD(point, m_fd);
+        m_timeline->importFromSyncFileFD(m_point, m_fd);
     else
-        timeline->signal(point);
+        m_timeline->signal(m_point);
 }
 
 CFileDescriptor CSyncReleaser::mergeSyncFds(const CFileDescriptor& fd1, const CFileDescriptor& fd2) {
@@ -61,5 +61,5 @@ void CSyncReleaser::addReleaseSync(SP<CEGLSync> sync) {
 }
 
 void CSyncReleaser::drop() {
-    timeline.reset();
+    m_timeline.reset();
 }

--- a/src/helpers/sync/SyncReleaser.cpp
+++ b/src/helpers/sync/SyncReleaser.cpp
@@ -1,6 +1,23 @@
 #include "SyncReleaser.hpp"
 #include "SyncTimeline.hpp"
 #include "../../render/OpenGL.hpp"
+#include <sys/ioctl.h>
+
+#if defined(Q_OS_LINUX)
+#include <linux/sync_file.h>
+#else
+struct sync_merge_data {
+    char  name[32];
+    __s32 fd2;
+    __s32 fence;
+    __u32 flags;
+    __u32 pad;
+};
+#define SYNC_IOC_MAGIC '>'
+#define SYNC_IOC_MERGE _IOWR(SYNC_IOC_MAGIC, 3, struct sync_merge_data)
+#endif
+
+using namespace Hyprutils::OS;
 
 CSyncReleaser::CSyncReleaser(SP<CSyncTimeline> timeline_, uint64_t point_) : timeline(timeline_), point(point_) {
     ;
@@ -12,14 +29,36 @@ CSyncReleaser::~CSyncReleaser() {
         return;
     }
 
-    if (sync)
-        timeline->importFromSyncFileFD(point, sync->fd());
+    if (m_fd.isValid())
+        timeline->importFromSyncFileFD(point, m_fd);
     else
         timeline->signal(point);
 }
 
-void CSyncReleaser::addReleaseSync(SP<CEGLSync> sync_) {
-    sync = sync_;
+CFileDescriptor CSyncReleaser::mergeSyncFds(const CFileDescriptor& fd1, const CFileDescriptor& fd2) {
+    struct sync_merge_data data{
+        .name  = "merged release fence",
+        .fd2   = fd2.get(),
+        .fence = -1,
+    };
+    int err = -1;
+    do {
+        err = ioctl(fd1.get(), SYNC_IOC_MERGE, &data);
+    } while (err == -1 && (errno == EINTR || errno == EAGAIN));
+    if (err < 0) {
+        return CFileDescriptor{};
+    } else {
+        return CFileDescriptor(data.fence);
+    }
+}
+
+void CSyncReleaser::addReleaseSync(SP<CEGLSync> sync) {
+    if (m_fd.isValid())
+        mergeSyncFds(m_fd, sync->takeFD());
+    else
+        m_fd = sync->fd().duplicate();
+
+    m_sync = sync;
 }
 
 void CSyncReleaser::drop() {

--- a/src/helpers/sync/SyncReleaser.hpp
+++ b/src/helpers/sync/SyncReleaser.hpp
@@ -15,7 +15,7 @@ class CEGLSync;
 
 class CSyncReleaser {
   public:
-    CSyncReleaser(WP<CSyncTimeline> timeline_, uint64_t point_);
+    CSyncReleaser(SP<CSyncTimeline> timeline_, uint64_t point_);
     ~CSyncReleaser();
 
     // drops the releaser, will never signal anymore
@@ -25,7 +25,7 @@ class CSyncReleaser {
     void addReleaseSync(SP<CEGLSync> sync);
 
   private:
-    WP<CSyncTimeline> timeline;
+    SP<CSyncTimeline> timeline;
     uint64_t          point = 0;
     SP<CEGLSync>      sync;
 };

--- a/src/helpers/sync/SyncReleaser.hpp
+++ b/src/helpers/sync/SyncReleaser.hpp
@@ -4,6 +4,7 @@
 #include <optional>
 #include <vector>
 #include <functional>
+#include <hyprutils/os/FileDescriptor.hpp>
 #include "../memory/Memory.hpp"
 
 /*
@@ -22,10 +23,12 @@ class CSyncReleaser {
     void drop();
 
     // wait for this gpu job to finish before releasing
-    void addReleaseSync(SP<CEGLSync> sync);
+    Hyprutils::OS::CFileDescriptor mergeSyncFds(const Hyprutils::OS::CFileDescriptor& fd1, const Hyprutils::OS::CFileDescriptor& fd2);
+    void                           addReleaseSync(SP<CEGLSync> sync);
 
   private:
-    SP<CSyncTimeline> timeline;
-    uint64_t          point = 0;
-    SP<CEGLSync>      sync;
+    SP<CSyncTimeline>              timeline;
+    uint64_t                       point = 0;
+    Hyprutils::OS::CFileDescriptor m_fd;
+    SP<CEGLSync>                   m_sync;
 };

--- a/src/helpers/sync/SyncReleaser.hpp
+++ b/src/helpers/sync/SyncReleaser.hpp
@@ -16,7 +16,7 @@ class CEGLSync;
 
 class CSyncReleaser {
   public:
-    CSyncReleaser(SP<CSyncTimeline> timeline_, uint64_t point_);
+    CSyncReleaser(SP<CSyncTimeline> timeline, uint64_t point);
     ~CSyncReleaser();
 
     // drops the releaser, will never signal anymore
@@ -27,8 +27,8 @@ class CSyncReleaser {
     void                           addReleaseSync(SP<CEGLSync> sync);
 
   private:
-    SP<CSyncTimeline>              timeline;
-    uint64_t                       point = 0;
+    SP<CSyncTimeline>              m_timeline;
+    uint64_t                       m_point = 0;
     Hyprutils::OS::CFileDescriptor m_fd;
     SP<CEGLSync>                   m_sync;
 };

--- a/src/helpers/sync/SyncTimeline.cpp
+++ b/src/helpers/sync/SyncTimeline.cpp
@@ -131,6 +131,15 @@ void CSyncTimeline::removeWaiter(SWaiter* w) {
     std::erase_if(waiters, [w](const auto& e) { return e.get() == w; });
 }
 
+void CSyncTimeline::stopAllWaiters() {
+    for (auto& w : waiters) {
+        if (w->source) {
+            wl_event_source_remove(w->source);
+            w->source = nullptr;
+        }
+    }
+}
+
 CFileDescriptor CSyncTimeline::exportAsSyncFileFD(uint64_t src) {
     int      sync = -1;
 

--- a/src/helpers/sync/SyncTimeline.cpp
+++ b/src/helpers/sync/SyncTimeline.cpp
@@ -33,6 +33,13 @@ SP<CSyncTimeline> CSyncTimeline::create(int drmFD_, int drmSyncobjFD) {
 }
 
 CSyncTimeline::~CSyncTimeline() {
+    for (auto& w : waiters) {
+        if (w->source) {
+            wl_event_source_remove(w->source);
+            w->source = nullptr;
+        }
+    }
+
     if (handle == 0)
         return;
 

--- a/src/helpers/sync/SyncTimeline.cpp
+++ b/src/helpers/sync/SyncTimeline.cpp
@@ -131,13 +131,15 @@ void CSyncTimeline::removeWaiter(SWaiter* w) {
     std::erase_if(waiters, [w](const auto& e) { return e.get() == w; });
 }
 
-void CSyncTimeline::stopAllWaiters() {
+void CSyncTimeline::removeAllWaiters() {
     for (auto& w : waiters) {
         if (w->source) {
             wl_event_source_remove(w->source);
             w->source = nullptr;
         }
     }
+
+    waiters.clear();
 }
 
 CFileDescriptor CSyncTimeline::exportAsSyncFileFD(uint64_t src) {

--- a/src/helpers/sync/SyncTimeline.hpp
+++ b/src/helpers/sync/SyncTimeline.hpp
@@ -34,6 +34,7 @@ class CSyncTimeline {
 
     bool                           addWaiter(const std::function<void()>& waiter, uint64_t point, uint32_t flags);
     void                           removeWaiter(SWaiter*);
+    void                           stopAllWaiters();
     Hyprutils::OS::CFileDescriptor exportAsSyncFileFD(uint64_t src);
     bool                           importFromSyncFileFD(uint64_t dst, Hyprutils::OS::CFileDescriptor& fd);
     bool                           transfer(SP<CSyncTimeline> from, uint64_t fromPoint, uint64_t toPoint);

--- a/src/helpers/sync/SyncTimeline.hpp
+++ b/src/helpers/sync/SyncTimeline.hpp
@@ -34,7 +34,7 @@ class CSyncTimeline {
 
     bool                           addWaiter(const std::function<void()>& waiter, uint64_t point, uint32_t flags);
     void                           removeWaiter(SWaiter*);
-    void                           stopAllWaiters();
+    void                           removeAllWaiters();
     Hyprutils::OS::CFileDescriptor exportAsSyncFileFD(uint64_t src);
     bool                           importFromSyncFileFD(uint64_t dst, Hyprutils::OS::CFileDescriptor& fd);
     bool                           transfer(SP<CSyncTimeline> from, uint64_t fromPoint, uint64_t toPoint);

--- a/src/protocols/DRMSyncobj.cpp
+++ b/src/protocols/DRMSyncobj.cpp
@@ -168,7 +168,6 @@ void CDRMSyncobjSurfaceResource::removeAllWaiters() {
 
 CDRMSyncobjSurfaceResource::~CDRMSyncobjSurfaceResource() {
     removeAllWaiters();
-    PROTO::sync->destroyResource(this);
 }
 
 bool CDRMSyncobjSurfaceResource::protocolError() {
@@ -215,10 +214,6 @@ CDRMSyncobjTimelineResource::CDRMSyncobjTimelineResource(UP<CWpLinuxDrmSyncobjTi
         resource->error(WP_LINUX_DRM_SYNCOBJ_MANAGER_V1_ERROR_INVALID_TIMELINE, "Timeline failed importing");
         return;
     }
-}
-
-CDRMSyncobjTimelineResource::~CDRMSyncobjTimelineResource() {
-    PROTO::sync->destroyResource(this);
 }
 
 WP<CDRMSyncobjTimelineResource> CDRMSyncobjTimelineResource::fromResource(wl_resource* res) {
@@ -282,10 +277,6 @@ CDRMSyncobjManagerResource::CDRMSyncobjManagerResource(UP<CWpLinuxDrmSyncobjMana
 
         LOGM(LOG, "New linux_drm_timeline at {:x}", (uintptr_t)RESOURCE.get());
     });
-}
-
-CDRMSyncobjManagerResource::~CDRMSyncobjManagerResource() {
-    PROTO::sync->destroyResource(this);
 }
 
 bool CDRMSyncobjManagerResource::good() {

--- a/src/protocols/DRMSyncobj.cpp
+++ b/src/protocols/DRMSyncobj.cpp
@@ -146,7 +146,7 @@ CDRMSyncobjSurfaceResource::CDRMSyncobjSurfaceResource(UP<CWpLinuxDrmSyncobjSurf
         surface->pending.newBuffer = false;
         surface->pending.buffer.reset();
 
-        state.buffer->syncReleaser = state.buffer->release->createSyncRelease();
+        state.buffer->buffer->syncReleaser = state.buffer->release->createSyncRelease();
         state.buffer->acquire->addWaiter([this, surf = surface, it = std::prev(pendingStates.end())] {
             if (!surf)
                 return;

--- a/src/protocols/DRMSyncobj.cpp
+++ b/src/protocols/DRMSyncobj.cpp
@@ -133,8 +133,11 @@ CDRMSyncobjSurfaceResource::CDRMSyncobjSurfaceResource(UP<CWpLinuxDrmSyncobjSurf
             return; // null buffer attached, destroy.
         }
 
-        if (!surface->pending.buffer && !surface->pending.newBuffer && surface->current.buffer)
+        if (!surface->pending.buffer && !surface->pending.newBuffer && surface->current.buffer) {
+            surface->current.damage.clear(); // #TODO clear damage to not rerender 24/7 ?
+            surface->current.bufferDamage.clear();
             surface->commitPendingState(); // no new buffer commit on current
+        }
 
         if (!surface->pending.buffer && !surface->pending.newBuffer)
             return; // no pending buffer, no current buffer. probably first commit, return.

--- a/src/protocols/DRMSyncobj.cpp
+++ b/src/protocols/DRMSyncobj.cpp
@@ -159,7 +159,7 @@ CDRMSyncobjSurfaceResource::CDRMSyncobjSurfaceResource(UP<CWpLinuxDrmSyncobjSurf
 
 void CDRMSyncobjSurfaceResource::removeAllWaiters() {
     for (auto& s : pendingStates) {
-        if (s.buffer && s.buffer->acquire)
+        if (s.buffer && s.buffer->acquire && !s.buffer->acquire->expired())
             s.buffer->acquire->resource()->timeline->removeAllWaiters();
     }
 

--- a/src/protocols/DRMSyncobj.hpp
+++ b/src/protocols/DRMSyncobj.hpp
@@ -56,7 +56,6 @@ class CDRMSyncobjSurfaceResource {
     std::list<SSurfaceState>        pendingStates;
 
     struct {
-        CHyprSignalListener surfaceBufferAttach;
         CHyprSignalListener surfacePrecommit;
     } listeners;
 };

--- a/src/protocols/DRMSyncobj.hpp
+++ b/src/protocols/DRMSyncobj.hpp
@@ -12,7 +12,8 @@ class CSyncTimeline;
 
 class CDRMSyncobjSurfaceResource {
   public:
-    CDRMSyncobjSurfaceResource(SP<CWpLinuxDrmSyncobjSurfaceV1> resource_, SP<CWLSurfaceResource> surface_);
+    CDRMSyncobjSurfaceResource(UP<CWpLinuxDrmSyncobjSurfaceV1>&& resource_, SP<CWLSurfaceResource> surface_);
+    ~CDRMSyncobjSurfaceResource() = default;
 
     bool                   good();
 
@@ -23,7 +24,7 @@ class CDRMSyncobjSurfaceResource {
     } current, pending;
 
   private:
-    SP<CWpLinuxDrmSyncobjSurfaceV1> resource;
+    UP<CWpLinuxDrmSyncobjSurfaceV1> resource;
 
     struct {
         CHyprSignalListener surfacePrecommit;
@@ -33,33 +34,34 @@ class CDRMSyncobjSurfaceResource {
 
 class CDRMSyncobjTimelineResource {
   public:
-    CDRMSyncobjTimelineResource(SP<CWpLinuxDrmSyncobjTimelineV1> resource_, Hyprutils::OS::CFileDescriptor&& fd_);
+    CDRMSyncobjTimelineResource(UP<CWpLinuxDrmSyncobjTimelineV1>&& resource_, Hyprutils::OS::CFileDescriptor&& fd_);
     ~CDRMSyncobjTimelineResource() = default;
-    static SP<CDRMSyncobjTimelineResource> fromResource(wl_resource*);
+    static WP<CDRMSyncobjTimelineResource> fromResource(wl_resource*);
 
     bool                                   good();
 
-    WP<CDRMSyncobjTimelineResource>        self;
     Hyprutils::OS::CFileDescriptor         fd;
     SP<CSyncTimeline>                      timeline;
 
   private:
-    SP<CWpLinuxDrmSyncobjTimelineV1> resource;
+    UP<CWpLinuxDrmSyncobjTimelineV1> resource;
 };
 
 class CDRMSyncobjManagerResource {
   public:
-    CDRMSyncobjManagerResource(SP<CWpLinuxDrmSyncobjManagerV1> resource_);
+    CDRMSyncobjManagerResource(UP<CWpLinuxDrmSyncobjManagerV1>&& resource_);
+    ~CDRMSyncobjManagerResource() = default;
 
     bool good();
 
   private:
-    SP<CWpLinuxDrmSyncobjManagerV1> resource;
+    UP<CWpLinuxDrmSyncobjManagerV1> resource;
 };
 
 class CDRMSyncobjProtocol : public IWaylandProtocol {
   public:
     CDRMSyncobjProtocol(const wl_interface* iface, const int& ver, const std::string& name);
+    ~CDRMSyncobjProtocol() = default;
 
     virtual void bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id);
 
@@ -69,9 +71,9 @@ class CDRMSyncobjProtocol : public IWaylandProtocol {
     void destroyResource(CDRMSyncobjSurfaceResource* resource);
 
     //
-    std::vector<SP<CDRMSyncobjManagerResource>>  m_vManagers;
-    std::vector<SP<CDRMSyncobjTimelineResource>> m_vTimelines;
-    std::vector<SP<CDRMSyncobjSurfaceResource>>  m_vSurfaces;
+    std::vector<UP<CDRMSyncobjManagerResource>>  m_vManagers;
+    std::vector<UP<CDRMSyncobjTimelineResource>> m_vTimelines;
+    std::vector<UP<CDRMSyncobjSurfaceResource>>  m_vSurfaces;
 
     //
     int drmFD = -1;

--- a/src/protocols/DRMSyncobj.hpp
+++ b/src/protocols/DRMSyncobj.hpp
@@ -5,6 +5,7 @@
 #include "helpers/sync/SyncReleaser.hpp"
 #include "linux-drm-syncobj-v1.hpp"
 #include "../helpers/signal/Signal.hpp"
+#include "types/SurfaceState.hpp"
 #include <hyprutils/os/FileDescriptor.hpp>
 #include <list>
 
@@ -63,7 +64,7 @@ class CDRMSyncobjSurfaceResource {
 class CDRMSyncobjTimelineResource {
   public:
     CDRMSyncobjTimelineResource(UP<CWpLinuxDrmSyncobjTimelineV1>&& resource_, Hyprutils::OS::CFileDescriptor&& fd_);
-    ~CDRMSyncobjTimelineResource();
+    ~CDRMSyncobjTimelineResource() = default;
     static WP<CDRMSyncobjTimelineResource> fromResource(wl_resource*);
 
     bool                                   good();
@@ -78,7 +79,7 @@ class CDRMSyncobjTimelineResource {
 class CDRMSyncobjManagerResource {
   public:
     CDRMSyncobjManagerResource(UP<CWpLinuxDrmSyncobjManagerV1>&& resource_);
-    ~CDRMSyncobjManagerResource();
+    ~CDRMSyncobjManagerResource() = default;
 
     bool good();
 

--- a/src/protocols/DRMSyncobj.hpp
+++ b/src/protocols/DRMSyncobj.hpp
@@ -54,7 +54,7 @@ class CDRMSyncobjSurfaceResource {
 
     CDRMSyncPointState              pendingAcquire;
     CDRMSyncPointState              pendingRelease;
-    std::list<SSurfaceState>        pendingStates;
+    std::vector<SP<SSurfaceState>>  pendingStates;
 
     struct {
         CHyprSignalListener surfacePrecommit;

--- a/src/protocols/DRMSyncobj.hpp
+++ b/src/protocols/DRMSyncobj.hpp
@@ -28,7 +28,6 @@ class CDRMSyncPointState {
     bool                                             comitted();
     Hyprutils::OS::CFileDescriptor                   exportAsFD();
     void                                             signal();
-    bool                                             waitOnTimelinePoint();
 
   private:
     WP<CDRMSyncobjTimelineResource> m_resource         = {};
@@ -36,7 +35,6 @@ class CDRMSyncPointState {
     WP<CSyncTimeline>               m_timeline         = {};
     bool                            m_acquirePoint     = false;
     bool                            m_acquireCommitted = false;
-    bool                            m_acquireWaitedOn  = false;
     bool                            m_releaseTaken     = false;
 };
 
@@ -49,6 +47,7 @@ class CDRMSyncobjSurfaceResource {
     bool good();
 
   private:
+    void                            removeAllWaiters();
     WP<CWLSurfaceResource>          surface;
     UP<CWpLinuxDrmSyncobjSurfaceV1> resource;
 
@@ -57,14 +56,7 @@ class CDRMSyncobjSurfaceResource {
     std::list<SSurfaceState>        pendingStates;
 
     struct {
-        CSignal acquireReady;
-    } events;
-
-    struct {
         CHyprSignalListener surfacePrecommit;
-        CHyprSignalListener surfaceRoleCommit;
-        CHyprSignalListener surfaceRoleCommitEnd;
-        CHyprSignalListener acquireReady;
     } listeners;
 };
 

--- a/src/protocols/DRMSyncobj.hpp
+++ b/src/protocols/DRMSyncobj.hpp
@@ -56,6 +56,7 @@ class CDRMSyncobjSurfaceResource {
     std::list<SSurfaceState>        pendingStates;
 
     struct {
+        CHyprSignalListener surfaceBufferAttach;
         CHyprSignalListener surfacePrecommit;
     } listeners;
 };
@@ -63,7 +64,7 @@ class CDRMSyncobjSurfaceResource {
 class CDRMSyncobjTimelineResource {
   public:
     CDRMSyncobjTimelineResource(UP<CWpLinuxDrmSyncobjTimelineV1>&& resource_, Hyprutils::OS::CFileDescriptor&& fd_);
-    ~CDRMSyncobjTimelineResource() = default;
+    ~CDRMSyncobjTimelineResource();
     static WP<CDRMSyncobjTimelineResource> fromResource(wl_resource*);
 
     bool                                   good();
@@ -78,7 +79,7 @@ class CDRMSyncobjTimelineResource {
 class CDRMSyncobjManagerResource {
   public:
     CDRMSyncobjManagerResource(UP<CWpLinuxDrmSyncobjManagerV1>&& resource_);
-    ~CDRMSyncobjManagerResource() = default;
+    ~CDRMSyncobjManagerResource();
 
     bool good();
 

--- a/src/protocols/LinuxDMABUF.cpp
+++ b/src/protocols/LinuxDMABUF.cpp
@@ -113,6 +113,7 @@ CLinuxDMABuffer::CLinuxDMABuffer(uint32_t id, wl_client* client, Aquamarine::SDM
 CLinuxDMABuffer::~CLinuxDMABuffer() {
     buffer.reset();
     listeners.bufferResourceDestroy.reset();
+    PROTO::linuxDma->destroyResource(this);
 }
 
 bool CLinuxDMABuffer::good() {
@@ -189,6 +190,10 @@ CLinuxDMABUFParamsResource::CLinuxDMABUFParamsResource(SP<CZwpLinuxBufferParamsV
 
         create(id);
     });
+}
+
+CLinuxDMABUFParamsResource::~CLinuxDMABUFParamsResource() {
+    PROTO::linuxDma->destroyResource(this);
 }
 
 bool CLinuxDMABUFParamsResource::good() {
@@ -301,6 +306,10 @@ CLinuxDMABUFFeedbackResource::CLinuxDMABUFFeedbackResource(SP<CZwpLinuxDmabufFee
     sendDefaultFeedback();
 }
 
+CLinuxDMABUFFeedbackResource::~CLinuxDMABUFFeedbackResource() {
+    PROTO::linuxDma->destroyResource(this);
+}
+
 bool CLinuxDMABUFFeedbackResource::good() {
     return resource->resource();
 }
@@ -381,6 +390,10 @@ CLinuxDMABUFResource::CLinuxDMABUFResource(SP<CZwpLinuxDmabufV1> resource_) : re
 
     if (resource->version() < 4)
         sendMods();
+}
+
+CLinuxDMABUFResource::~CLinuxDMABUFResource() {
+    PROTO::linuxDma->destroyResource(this);
 }
 
 bool CLinuxDMABUFResource::good() {

--- a/src/protocols/LinuxDMABUF.cpp
+++ b/src/protocols/LinuxDMABUF.cpp
@@ -113,7 +113,6 @@ CLinuxDMABuffer::CLinuxDMABuffer(uint32_t id, wl_client* client, Aquamarine::SDM
 CLinuxDMABuffer::~CLinuxDMABuffer() {
     buffer.reset();
     listeners.bufferResourceDestroy.reset();
-    PROTO::linuxDma->destroyResource(this);
 }
 
 bool CLinuxDMABuffer::good() {
@@ -190,10 +189,6 @@ CLinuxDMABUFParamsResource::CLinuxDMABUFParamsResource(SP<CZwpLinuxBufferParamsV
 
         create(id);
     });
-}
-
-CLinuxDMABUFParamsResource::~CLinuxDMABUFParamsResource() {
-    PROTO::linuxDma->destroyResource(this);
 }
 
 bool CLinuxDMABUFParamsResource::good() {
@@ -306,10 +301,6 @@ CLinuxDMABUFFeedbackResource::CLinuxDMABUFFeedbackResource(SP<CZwpLinuxDmabufFee
     sendDefaultFeedback();
 }
 
-CLinuxDMABUFFeedbackResource::~CLinuxDMABUFFeedbackResource() {
-    PROTO::linuxDma->destroyResource(this);
-}
-
 bool CLinuxDMABUFFeedbackResource::good() {
     return resource->resource();
 }
@@ -390,10 +381,6 @@ CLinuxDMABUFResource::CLinuxDMABUFResource(SP<CZwpLinuxDmabufV1> resource_) : re
 
     if (resource->version() < 4)
         sendMods();
-}
-
-CLinuxDMABUFResource::~CLinuxDMABUFResource() {
-    PROTO::linuxDma->destroyResource(this);
 }
 
 bool CLinuxDMABUFResource::good() {

--- a/src/protocols/LinuxDMABUF.cpp
+++ b/src/protocols/LinuxDMABUF.cpp
@@ -111,6 +111,9 @@ CLinuxDMABuffer::CLinuxDMABuffer(uint32_t id, wl_client* client, Aquamarine::SDM
 }
 
 CLinuxDMABuffer::~CLinuxDMABuffer() {
+    if (buffer && buffer->resource)
+        buffer->resource->sendRelease();
+
     buffer.reset();
     listeners.bufferResourceDestroy.reset();
 }

--- a/src/protocols/LinuxDMABUF.hpp
+++ b/src/protocols/LinuxDMABUF.hpp
@@ -60,7 +60,7 @@ class CDMABUFFormatTable {
 class CLinuxDMABUFParamsResource {
   public:
     CLinuxDMABUFParamsResource(SP<CZwpLinuxBufferParamsV1> resource_);
-    ~CLinuxDMABUFParamsResource();
+    ~CLinuxDMABUFParamsResource() = default;
 
     bool                         good();
     void                         create(uint32_t id); // 0 means not immed
@@ -79,7 +79,7 @@ class CLinuxDMABUFParamsResource {
 class CLinuxDMABUFFeedbackResource {
   public:
     CLinuxDMABUFFeedbackResource(SP<CZwpLinuxDmabufFeedbackV1> resource_, SP<CWLSurfaceResource> surface_);
-    ~CLinuxDMABUFFeedbackResource();
+    ~CLinuxDMABUFFeedbackResource() = default;
 
     bool                   good();
     void                   sendDefaultFeedback();
@@ -97,7 +97,7 @@ class CLinuxDMABUFFeedbackResource {
 class CLinuxDMABUFResource {
   public:
     CLinuxDMABUFResource(SP<CZwpLinuxDmabufV1> resource_);
-    ~CLinuxDMABUFResource();
+    ~CLinuxDMABUFResource() = default;
 
     bool good();
     void sendMods();

--- a/src/protocols/LinuxDMABUF.hpp
+++ b/src/protocols/LinuxDMABUF.hpp
@@ -60,7 +60,7 @@ class CDMABUFFormatTable {
 class CLinuxDMABUFParamsResource {
   public:
     CLinuxDMABUFParamsResource(SP<CZwpLinuxBufferParamsV1> resource_);
-    ~CLinuxDMABUFParamsResource() = default;
+    ~CLinuxDMABUFParamsResource();
 
     bool                         good();
     void                         create(uint32_t id); // 0 means not immed
@@ -79,7 +79,7 @@ class CLinuxDMABUFParamsResource {
 class CLinuxDMABUFFeedbackResource {
   public:
     CLinuxDMABUFFeedbackResource(SP<CZwpLinuxDmabufFeedbackV1> resource_, SP<CWLSurfaceResource> surface_);
-    ~CLinuxDMABUFFeedbackResource() = default;
+    ~CLinuxDMABUFFeedbackResource();
 
     bool                   good();
     void                   sendDefaultFeedback();
@@ -97,6 +97,7 @@ class CLinuxDMABUFFeedbackResource {
 class CLinuxDMABUFResource {
   public:
     CLinuxDMABUFResource(SP<CZwpLinuxDmabufV1> resource_);
+    ~CLinuxDMABUFResource();
 
     bool good();
     void sendMods();

--- a/src/protocols/SinglePixel.cpp
+++ b/src/protocols/SinglePixel.cpp
@@ -70,6 +70,10 @@ CSinglePixelBufferResource::CSinglePixelBufferResource(uint32_t id, wl_client* c
     });
 }
 
+CSinglePixelBufferResource::~CSinglePixelBufferResource() {
+    PROTO::singlePixel->destroyResource(this);
+}
+
 bool CSinglePixelBufferResource::good() {
     return buffer->good();
 }

--- a/src/protocols/SinglePixel.cpp
+++ b/src/protocols/SinglePixel.cpp
@@ -24,6 +24,11 @@ CSinglePixelBuffer::CSinglePixelBuffer(uint32_t id, wl_client* client, CHyprColo
         Debug::log(ERR, "Failed creating a single pixel texture: null texture id");
 }
 
+CSinglePixelBuffer::~CSinglePixelBuffer() {
+    if (resource)
+        resource->sendRelease();
+}
+
 Aquamarine::eBufferCapability CSinglePixelBuffer::caps() {
     return Aquamarine::eBufferCapability::BUFFER_CAPABILITY_DATAPTR;
 }

--- a/src/protocols/SinglePixel.cpp
+++ b/src/protocols/SinglePixel.cpp
@@ -70,10 +70,6 @@ CSinglePixelBufferResource::CSinglePixelBufferResource(uint32_t id, wl_client* c
     });
 }
 
-CSinglePixelBufferResource::~CSinglePixelBufferResource() {
-    PROTO::singlePixel->destroyResource(this);
-}
-
 bool CSinglePixelBufferResource::good() {
     return buffer->good();
 }

--- a/src/protocols/SinglePixel.hpp
+++ b/src/protocols/SinglePixel.hpp
@@ -9,7 +9,7 @@
 class CSinglePixelBuffer : public IHLBuffer {
   public:
     CSinglePixelBuffer(uint32_t id, wl_client* client, CHyprColor col);
-    virtual ~CSinglePixelBuffer() = default;
+    virtual ~CSinglePixelBuffer();
 
     virtual Aquamarine::eBufferCapability          caps();
     virtual Aquamarine::eBufferType                type();

--- a/src/protocols/SinglePixel.hpp
+++ b/src/protocols/SinglePixel.hpp
@@ -33,7 +33,7 @@ class CSinglePixelBuffer : public IHLBuffer {
 class CSinglePixelBufferResource {
   public:
     CSinglePixelBufferResource(uint32_t id, wl_client* client, CHyprColor color);
-    ~CSinglePixelBufferResource();
+    ~CSinglePixelBufferResource() = default;
 
     bool good();
 

--- a/src/protocols/SinglePixel.hpp
+++ b/src/protocols/SinglePixel.hpp
@@ -33,7 +33,7 @@ class CSinglePixelBuffer : public IHLBuffer {
 class CSinglePixelBufferResource {
   public:
     CSinglePixelBufferResource(uint32_t id, wl_client* client, CHyprColor color);
-    ~CSinglePixelBufferResource() = default;
+    ~CSinglePixelBufferResource();
 
     bool good();
 

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -478,13 +478,13 @@ void CWLSurfaceResource::commitPendingState(SSurfaceState& state) {
     // release the buffer if it's synchronous as update() has done everything thats needed
     // so we can let the app know we're done.
     if (!syncobj && current.buffer && current.buffer->buffer && current.buffer->buffer->isSynchronous()) {
-        dropCurrentBuffer();
+        //dropCurrentBuffer(); // lets not drop it at all, it will get dropped on next commit if a new buffer arrives.
+        // solves flickering on nonsyncobj apps on explicit sync.
     }
 
     // for async buffers, we can only release the buffer once we are unrefing it from current.
     // if the backend took it, ref it with the lambda. Otherwise, the end of this scope will release it.
-    // #TODO does this apply to explicit sync?
-    if (!syncobj && previousBuffer && previousBuffer->buffer && !previousBuffer->buffer->isSynchronous()) {
+    if (previousBuffer && previousBuffer->buffer && !previousBuffer->buffer->isSynchronous()) {
         if (previousBuffer->buffer->lockedByBackend && !previousBuffer->buffer->hlEvents.backendRelease) {
             previousBuffer->buffer->lock();
             previousBuffer->buffer->onBackendRelease([previousBuffer]() { previousBuffer->buffer->unlock(); });

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -452,12 +452,6 @@ void CWLSurfaceResource::commitPendingState(SSurfaceState& state) {
         // TODO: don't update the entire texture
         if (role->role() == SURFACE_ROLE_CURSOR && !DAMAGE.empty())
             updateCursorShm(DAMAGE);
-
-        // release the buffer if it's synchronous as update() has done everything thats needed
-        // so we can let the app know we're done.
-        if (!syncobj && current.buffer && current.buffer->buffer && current.buffer->buffer->isSynchronous()) {
-            dropCurrentBuffer();
-        }
     }
 
     // TODO: we should _accumulate_ and not replace above if sync
@@ -479,6 +473,12 @@ void CWLSurfaceResource::commitPendingState(SSurfaceState& state) {
                 surf->events.commit.emit();
             },
             nullptr);
+    }
+
+    // release the buffer if it's synchronous as update() has done everything thats needed
+    // so we can let the app know we're done.
+    if (!syncobj && current.buffer && current.buffer->buffer && current.buffer->buffer->isSynchronous()) {
+        dropCurrentBuffer();
     }
 
     // for async buffers, we can only release the buffer once we are unrefing it from current.

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -477,15 +477,6 @@ void CWLSurfaceResource::commitPendingState(SSurfaceState& state) {
     // dropCurrentBuffer(); // lets not drop it at all, it will get dropped on next commit if a new buffer arrives.
     // solves flickering on nonsyncobj apps on explicit sync.
     // }
-
-    // for async buffers, we can only release the buffer once we are unrefing it from current.
-    // if the backend took it, ref it with the lambda. Otherwise, the end of this scope will release it.
-    if (current.buffer && current.buffer->buffer && !current.buffer->buffer->isSynchronous()) {
-        if (current.buffer->buffer->lockedByBackend && !current.buffer->buffer->hlEvents.backendRelease) {
-            current.buffer->buffer->lock();
-            current.buffer->buffer->onBackendRelease([this]() { current.buffer->buffer->unlock(); });
-        }
-    }
 }
 
 void CWLSurfaceResource::updateCursorShm(CRegion damage) {

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -88,8 +88,6 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : resource(reso
 
         if (oldBufSize != newBufSize || current.buffer != pending.buffer)
             pending.bufferDamage = CBox{{}, {INT32_MAX, INT32_MAX}};
-
-        events.bufferAttach.emit();
     });
 
     resource->setCommit([this](CWlSurface* r) {

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -473,10 +473,10 @@ void CWLSurfaceResource::commitPendingState(SSurfaceState& state) {
 
     // release the buffer if it's synchronous as update() has done everything thats needed
     // so we can let the app know we're done.
-    if (!syncobj && current.buffer && current.buffer->buffer && current.buffer->buffer->isSynchronous()) {
-        //dropCurrentBuffer(); // lets not drop it at all, it will get dropped on next commit if a new buffer arrives.
-        // solves flickering on nonsyncobj apps on explicit sync.
-    }
+    // if (!syncobj && current.buffer && current.buffer->buffer && current.buffer->buffer->isSynchronous()) {
+    // dropCurrentBuffer(); // lets not drop it at all, it will get dropped on next commit if a new buffer arrives.
+    // solves flickering on nonsyncobj apps on explicit sync.
+    // }
 
     // for async buffers, we can only release the buffer once we are unrefing it from current.
     // if the backend took it, ref it with the lambda. Otherwise, the end of this scope will release it.

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -77,7 +77,7 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : resource(reso
             pending.texture.reset();
         } else {
             auto res           = CWLBufferResource::fromResource(buffer);
-            pending.buffer     = res && res->buffer ? makeShared<CHLBufferReference>(res->buffer.lock(), self.lock()) : nullptr;
+            pending.buffer     = res && res->buffer ? makeShared<CHLBufferReference>(res->buffer, self.lock()) : nullptr;
             pending.size       = res && res->buffer ? res->buffer->size : Vector2D{};
             pending.texture    = res && res->buffer ? res->buffer->texture : nullptr;
             pending.bufferSize = res && res->buffer ? res->buffer->size : Vector2D{};
@@ -88,6 +88,8 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : resource(reso
 
         if (oldBufSize != newBufSize || current.buffer != pending.buffer)
             pending.bufferDamage = CBox{{}, {INT32_MAX, INT32_MAX}};
+
+        events.bufferAttach.emit();
     });
 
     resource->setCommit([this](CWlSurface* r) {

--- a/src/protocols/core/Compositor.hpp
+++ b/src/protocols/core/Compositor.hpp
@@ -105,17 +105,15 @@ class CWLSurfaceResource {
     Vector2D                      sourceSize();
 
     struct {
-        CSignal precommit;  // before commit
-        CSignal roleCommit; // commit for role objects, before regular commit
-        CSignal roleCommitEnd;
-        CSignal commit; // after commit
+        CSignal precommit; // before commit
+        CSignal commit;    // after commit
         CSignal map;
         CSignal unmap;
         CSignal newSubsurface;
         CSignal destroy;
     } events;
 
-    SSurfaceState                          current, pending, ready;
+    SSurfaceState                          current, pending;
 
     std::vector<SP<CWLCallbackResource>>   callbacks;
     WP<CWLSurfaceResource>                 self;
@@ -133,7 +131,7 @@ class CWLSurfaceResource {
     SP<CWLSurfaceResource>                 findFirstPreorder(std::function<bool(SP<CWLSurfaceResource>)> fn);
     CRegion                                accumulateCurrentBufferDamage();
     void                                   presentFeedback(timespec* when, PHLMONITOR pMonitor, bool discarded = false);
-    void                                   commitPendingState();
+    void                                   commitPendingState(SSurfaceState& state);
 
     // returns a pair: found surface (null if not found) and surface local coords.
     // localCoords param is relative to 0,0 of this surface

--- a/src/protocols/core/Compositor.hpp
+++ b/src/protocols/core/Compositor.hpp
@@ -105,7 +105,6 @@ class CWLSurfaceResource {
     Vector2D                      sourceSize();
 
     struct {
-        CSignal bufferAttach;
         CSignal precommit; // before commit
         CSignal commit;    // after commit
         CSignal map;

--- a/src/protocols/core/Compositor.hpp
+++ b/src/protocols/core/Compositor.hpp
@@ -77,6 +77,7 @@ class CWLSurfaceResource {
     Vector2D                      sourceSize();
 
     struct {
+        CSignal bufferAttach;
         CSignal precommit;  // before commit
         CSignal roleCommit; // commit for role objects, before regular commit
         CSignal commit;     // after commit
@@ -102,6 +103,7 @@ class CWLSurfaceResource {
         } viewport;
         bool rejected  = false;
         bool newBuffer = false;
+        bool sameBufferCommit = false;
 
         //
         void reset() {
@@ -132,6 +134,7 @@ class CWLSurfaceResource {
     void                                   presentFeedback(timespec* when, PHLMONITOR pMonitor, bool discarded = false);
     void                                   lockPendingState();
     void                                   unlockPendingState();
+    void                                   commitPendingState();
 
     // returns a pair: found surface (null if not found) and surface local coords.
     // localCoords param is relative to 0,0 of this surface
@@ -145,13 +148,12 @@ class CWLSurfaceResource {
     // this stupid-ass hack is used
     WP<IHLBuffer>          lastBuffer;
 
-    int                    stateLocks = 0;
+    bool                   stateLocked = false;
 
     void                   destroy();
     void                   releaseBuffers(bool onlyCurrent = true);
     void                   dropPendingBuffer();
     void                   dropCurrentBuffer();
-    void                   commitPendingState();
     void                   bfHelper(std::vector<SP<CWLSurfaceResource>> const& nodes, std::function<void(SP<CWLSurfaceResource>, const Vector2D&, void*)> fn, void* data);
     SP<CWLSurfaceResource> findFirstPreorderHelper(SP<CWLSurfaceResource> root, std::function<bool(SP<CWLSurfaceResource>)> fn);
     void                   updateCursorShm(CRegion damage = CBox{0, 0, INT16_MAX, INT16_MAX});

--- a/src/protocols/core/Compositor.hpp
+++ b/src/protocols/core/Compositor.hpp
@@ -16,6 +16,7 @@
 #include "../../helpers/math/Math.hpp"
 #include "../types/Buffer.hpp"
 #include "../types/SurfaceRole.hpp"
+#include "../types/SurfaceState.hpp"
 
 class CWLOutputResource;
 class CMonitor;
@@ -51,34 +52,6 @@ class CWLRegionResource {
 
   private:
     SP<CWlRegion> resource;
-};
-
-struct SSurfaceState {
-    CRegion                opaque, input = CBox{{}, {INT32_MAX, INT32_MAX}}, damage, bufferDamage = CBox{{}, {INT32_MAX, INT32_MAX}} /* initial damage */;
-    wl_output_transform    transform = WL_OUTPUT_TRANSFORM_NORMAL;
-    int                    scale     = 1;
-    SP<CHLBufferReference> buffer; // buffer ref will be released once the buffer is no longer locked. For checking if a buffer is attached to this state, check texture.
-    SP<CTexture>           texture;
-    Vector2D               offset;
-    Vector2D               size, bufferSize;
-    struct {
-        bool     hasDestination = false;
-        bool     hasSource      = false;
-        Vector2D destination;
-        CBox     source;
-    } viewport;
-    bool rejected  = false;
-    bool newBuffer = false;
-
-    //
-    void reset() {
-        damage.clear();
-        bufferDamage.clear();
-        transform = WL_OUTPUT_TRANSFORM_NORMAL;
-        scale     = 1;
-        offset    = {};
-        size      = {};
-    }
 };
 
 class CWLSurfaceResource {

--- a/src/protocols/core/Compositor.hpp
+++ b/src/protocols/core/Compositor.hpp
@@ -105,6 +105,7 @@ class CWLSurfaceResource {
     Vector2D                      sourceSize();
 
     struct {
+        CSignal bufferAttach;
         CSignal precommit; // before commit
         CSignal commit;    // after commit
         CSignal map;

--- a/src/protocols/core/Shm.cpp
+++ b/src/protocols/core/Shm.cpp
@@ -37,6 +37,11 @@ CWLSHMBuffer::CWLSHMBuffer(SP<CWLSHMPoolResource> pool_, uint32_t id, int32_t of
         Debug::log(ERR, "Failed creating a shm texture: null texture id");
 }
 
+CWLSHMBuffer::~CWLSHMBuffer() {
+    if (resource)
+        resource->sendRelease();
+}
+
 Aquamarine::eBufferCapability CWLSHMBuffer::caps() {
     return Aquamarine::eBufferCapability::BUFFER_CAPABILITY_DATAPTR;
 }

--- a/src/protocols/core/Shm.hpp
+++ b/src/protocols/core/Shm.hpp
@@ -33,7 +33,7 @@ class CSHMPool {
 class CWLSHMBuffer : public IHLBuffer {
   public:
     CWLSHMBuffer(SP<CWLSHMPoolResource> pool, uint32_t id, int32_t offset, const Vector2D& size, int32_t stride, uint32_t fmt);
-    virtual ~CWLSHMBuffer() = default;
+    virtual ~CWLSHMBuffer();
 
     virtual Aquamarine::eBufferCapability          caps();
     virtual Aquamarine::eBufferType                type();

--- a/src/protocols/types/Buffer.cpp
+++ b/src/protocols/types/Buffer.cpp
@@ -18,8 +18,10 @@ void IHLBuffer::unlock() {
 
     ASSERT(nLocks >= 0);
 
-    if (nLocks == 0)
+    if (nLocks == 0) {
         sendRelease();
+        syncReleaser.reset();
+    }
 }
 
 bool IHLBuffer::locked() {

--- a/src/protocols/types/Buffer.cpp
+++ b/src/protocols/types/Buffer.cpp
@@ -38,7 +38,7 @@ void IHLBuffer::onBackendRelease(const std::function<void()>& fn) {
     });
 }
 
-CHLBufferReference::CHLBufferReference(SP<IHLBuffer> buffer_, SP<CWLSurfaceResource> surface_) : buffer(buffer_), surface(surface_) {
+CHLBufferReference::CHLBufferReference(WP<IHLBuffer> buffer_, SP<CWLSurfaceResource> surface_) : buffer(buffer_), surface(surface_) {
     buffer->lock();
 }
 

--- a/src/protocols/types/Buffer.cpp
+++ b/src/protocols/types/Buffer.cpp
@@ -38,12 +38,12 @@ void IHLBuffer::onBackendRelease(const std::function<void()>& fn) {
     });
 }
 
-CHLBufferReference::CHLBufferReference(WP<IHLBuffer> buffer_, SP<CWLSurfaceResource> surface_) : buffer(buffer_), surface(surface_) {
+CHLBufferReference::CHLBufferReference(SP<IHLBuffer> buffer_, SP<CWLSurfaceResource> surface_) : buffer(buffer_), surface(surface_) {
     buffer->lock();
 }
 
 CHLBufferReference::~CHLBufferReference() {
-    if (buffer.expired())
+    if (!buffer)
         return;
 
     buffer->unlock();

--- a/src/protocols/types/Buffer.hpp
+++ b/src/protocols/types/Buffer.hpp
@@ -27,6 +27,7 @@ class IHLBuffer : public Aquamarine::IBuffer {
     SP<CTexture>                          texture;
     bool                                  opaque = false;
     SP<CWLBufferResource>                 resource;
+    UP<CSyncReleaser>                     syncReleaser;
 
     struct {
         CHyprSignalListener backendRelease;
@@ -47,7 +48,6 @@ class CHLBufferReference {
     WP<IHLBuffer>          buffer;
     UP<CDRMSyncPointState> acquire;
     UP<CDRMSyncPointState> release;
-    UP<CSyncReleaser>      syncReleaser;
 
   private:
     WP<CWLSurfaceResource> surface;

--- a/src/protocols/types/Buffer.hpp
+++ b/src/protocols/types/Buffer.hpp
@@ -41,7 +41,7 @@ class IHLBuffer : public Aquamarine::IBuffer {
 // surface optional
 class CHLBufferReference {
   public:
-    CHLBufferReference(WP<IHLBuffer> buffer, SP<CWLSurfaceResource> surface);
+    CHLBufferReference(SP<IHLBuffer> buffer, SP<CWLSurfaceResource> surface);
     ~CHLBufferReference();
 
     WP<IHLBuffer>          buffer;

--- a/src/protocols/types/Buffer.hpp
+++ b/src/protocols/types/Buffer.hpp
@@ -41,7 +41,7 @@ class IHLBuffer : public Aquamarine::IBuffer {
 // surface optional
 class CHLBufferReference {
   public:
-    CHLBufferReference(SP<IHLBuffer> buffer, SP<CWLSurfaceResource> surface);
+    CHLBufferReference(WP<IHLBuffer> buffer, SP<CWLSurfaceResource> surface);
     ~CHLBufferReference();
 
     WP<IHLBuffer>          buffer;

--- a/src/protocols/types/Buffer.hpp
+++ b/src/protocols/types/Buffer.hpp
@@ -3,6 +3,7 @@
 #include "../../defines.hpp"
 #include "../../render/Texture.hpp"
 #include "./WLBuffer.hpp"
+#include "protocols/DRMSyncobj.hpp"
 
 #include <aquamarine/buffer/Buffer.hpp>
 
@@ -43,8 +44,10 @@ class CHLBufferReference {
     CHLBufferReference(SP<IHLBuffer> buffer, SP<CWLSurfaceResource> surface);
     ~CHLBufferReference();
 
-    WP<IHLBuffer>     buffer;
-    SP<CSyncReleaser> releaser;
+    WP<IHLBuffer>          buffer;
+    UP<CDRMSyncPointState> acquire;
+    UP<CDRMSyncPointState> release;
+    UP<CSyncReleaser>      syncReleaser;
 
   private:
     WP<CWLSurfaceResource> surface;

--- a/src/protocols/types/DMABuffer.cpp
+++ b/src/protocols/types/DMABuffer.cpp
@@ -36,6 +36,9 @@ CDMABuffer::CDMABuffer(uint32_t id, wl_client* client, Aquamarine::SDMABUFAttrs 
 }
 
 CDMABuffer::~CDMABuffer() {
+    if (resource)
+        resource->sendRelease();
+
     closeFDs();
 }
 

--- a/src/protocols/types/SurfaceState.hpp
+++ b/src/protocols/types/SurfaceState.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "../../helpers/math/Math.hpp"
+#include "../WaylandProtocol.hpp"
+
+class CHLBufferReference;
+class CTexture;
+
+struct SSurfaceState {
+    CRegion                opaque, input = CBox{{}, {INT32_MAX, INT32_MAX}}, damage, bufferDamage = CBox{{}, {INT32_MAX, INT32_MAX}} /* initial damage */;
+    wl_output_transform    transform = WL_OUTPUT_TRANSFORM_NORMAL;
+    int                    scale     = 1;
+    SP<CHLBufferReference> buffer; // buffer ref will be released once the buffer is no longer locked. For checking if a buffer is attached to this state, check texture.
+    SP<CTexture>           texture;
+    Vector2D               offset;
+    Vector2D               size, bufferSize;
+    struct {
+        bool     hasDestination = false;
+        bool     hasSource      = false;
+        Vector2D destination;
+        CBox     source;
+    } viewport;
+    bool rejected  = false;
+    bool newBuffer = false;
+
+    //
+    void reset() {
+        damage.clear();
+        bufferDamage.clear();
+        transform = WL_OUTPUT_TRANSFORM_NORMAL;
+        scale     = 1;
+        offset    = {};
+        size      = {};
+    }
+};

--- a/src/protocols/types/WLBuffer.cpp
+++ b/src/protocols/types/WLBuffer.cpp
@@ -5,7 +5,7 @@
 #include "../../helpers/sync/SyncTimeline.hpp"
 #include <xf86drm.h>
 
-CWLBufferResource::CWLBufferResource(SP<CWlBuffer> resource_) : resource(resource_) {
+CWLBufferResource::CWLBufferResource(WP<CWlBuffer> resource_) : resource(resource_.lock()) {
     if UNLIKELY (!good())
         return;
 
@@ -40,7 +40,7 @@ SP<CWLBufferResource> CWLBufferResource::fromResource(wl_resource* res) {
     return data ? data->self.lock() : nullptr;
 }
 
-SP<CWLBufferResource> CWLBufferResource::create(SP<CWlBuffer> resource) {
+SP<CWLBufferResource> CWLBufferResource::create(WP<CWlBuffer> resource) {
     auto p  = SP<CWLBufferResource>(new CWLBufferResource(resource));
     p->self = p;
     return p;

--- a/src/protocols/types/WLBuffer.hpp
+++ b/src/protocols/types/WLBuffer.hpp
@@ -11,7 +11,7 @@ class CWLSurfaceResource;
 
 class CWLBufferResource {
   public:
-    static SP<CWLBufferResource> create(SP<CWlBuffer> resource);
+    static SP<CWLBufferResource> create(WP<CWlBuffer> resource);
     static SP<CWLBufferResource> fromResource(wl_resource* res);
 
     bool                         good();
@@ -23,7 +23,7 @@ class CWLBufferResource {
     WP<CWLBufferResource>        self;
 
   private:
-    CWLBufferResource(SP<CWlBuffer> resource_);
+    CWLBufferResource(WP<CWlBuffer> resource_);
 
     SP<CWlBuffer> resource;
 

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -2908,11 +2908,11 @@ std::vector<SDRMFormat> CHyprOpenGLImpl::getDRMFormats() {
     return drmFormats;
 }
 
-SP<CEGLSync> CHyprOpenGLImpl::createEGLSync(CFileDescriptor fenceFD) {
+SP<CEGLSync> CHyprOpenGLImpl::createEGLSync(int fenceFD) {
     std::vector<EGLint> attribs;
     CFileDescriptor     dupFd;
-    if (fenceFD.isValid()) {
-        dupFd = fenceFD.duplicate();
+    if (fenceFD >= 0) {
+        dupFd = CFileDescriptor{fcntl(fenceFD, F_DUPFD_CLOEXEC, 0)};
         if (!dupFd.isValid()) {
             Debug::log(ERR, "createEGLSync: dup failed");
             return nullptr;

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -230,7 +230,7 @@ class CHyprOpenGLImpl {
     uint32_t                             getPreferredReadFormat(PHLMONITOR pMonitor);
     std::vector<SDRMFormat>              getDRMFormats();
     EGLImageKHR                          createEGLImage(const Aquamarine::SDMABUFAttrs& attrs);
-    SP<CEGLSync>                         createEGLSync(Hyprutils::OS::CFileDescriptor fenceFD);
+    SP<CEGLSync>                         createEGLSync(int fence = -1);
 
     SCurrentRenderData                   m_RenderData;
 

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -148,10 +148,10 @@ class CEGLSync {
   public:
     ~CEGLSync();
 
-    EGLSyncKHR                      sync = nullptr;
+    EGLSyncKHR                       sync = nullptr;
 
-    Hyprutils::OS::CFileDescriptor& fd();
-    bool                            wait();
+    Hyprutils::OS::CFileDescriptor&& takeFD();
+    Hyprutils::OS::CFileDescriptor&  fd();
 
   private:
     CEGLSync() = default;
@@ -177,7 +177,7 @@ class CHyprOpenGLImpl {
     void renderRectWithDamage(const CBox&, const CHyprColor&, const CRegion& damage, int round = 0, float roundingPower = 2.0f);
     void renderTexture(SP<CTexture>, const CBox&, float a, int round = 0, float roundingPower = 2.0f, bool discardActive = false, bool allowCustomUV = false);
     void renderTextureWithDamage(SP<CTexture>, const CBox&, const CRegion& damage, float a, int round = 0, float roundingPower = 2.0f, bool discardActive = false,
-                                 bool allowCustomUV = false, SP<CSyncTimeline> waitTimeline = nullptr, uint64_t waitPoint = 0);
+                                 bool allowCustomUV = false);
     void renderTextureWithBlur(SP<CTexture>, const CBox&, float a, SP<CWLSurfaceResource> pSurface, int round = 0, float roundingPower = 2.0f, bool blockBlurOptimization = false,
                                float blurA = 1.f, float overallA = 1.f);
     void renderRoundedShadow(const CBox&, int round, float roundingPower, int range, const CHyprColor& color, float a = 1.0);
@@ -231,7 +231,6 @@ class CHyprOpenGLImpl {
     std::vector<SDRMFormat>              getDRMFormats();
     EGLImageKHR                          createEGLImage(const Aquamarine::SDMABUFAttrs& attrs);
     SP<CEGLSync>                         createEGLSync(Hyprutils::OS::CFileDescriptor fenceFD);
-    bool                                 waitForTimelinePoint(SP<CSyncTimeline> timeline, uint64_t point);
 
     SCurrentRenderData                   m_RenderData;
 
@@ -315,7 +314,7 @@ class CHyprOpenGLImpl {
     CFramebuffer* blurMainFramebufferWithDamage(float a, CRegion* damage);
 
     void renderTextureInternalWithDamage(SP<CTexture>, const CBox& box, float a, const CRegion& damage, int round = 0, float roundingPower = 2.0f, bool discardOpaque = false,
-                                         bool noAA = false, bool allowCustomUV = false, bool allowDim = false, SP<CSyncTimeline> = nullptr, uint64_t waitPoint = 0);
+                                         bool noAA = false, bool allowCustomUV = false, bool allowDim = false);
     void renderTexturePrimitive(SP<CTexture> tex, const CBox& box);
     void renderSplash(cairo_t* const, cairo_surface_t* const, double offset, const Vector2D& size);
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1536,10 +1536,10 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
         Debug::log(TRACE, "Explicit: can't add sync, EGLSync failed");
     else {
         for (auto const& e : explicitPresented) {
-            if (!e->current.buffer || !e->current.buffer->syncReleaser)
+            if (!e->current.buffer || !e->current.buffer->buffer || !e->current.buffer->buffer->syncReleaser)
                 continue;
 
-            e->current.buffer->syncReleaser->addReleaseSync(sync);
+            e->current.buffer->buffer->syncReleaser->addReleaseSync(sync);
         }
     }
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1543,7 +1543,7 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
         Debug::log(TRACE, "Explicit: can't add sync, EGLSync failed");
     else {
         for (auto const& e : explicitPresented) {
-            if (!e->current.buffer || !e->current.buffer->syncReleaser || e->current.sameBufferCommit)
+            if (!e->current.buffer || !e->current.buffer->syncReleaser)
                 continue;
 
             e->current.buffer->syncReleaser->addReleaseSync(sync);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1543,10 +1543,10 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
         Debug::log(TRACE, "Explicit: can't add sync, EGLSync failed");
     else {
         for (auto const& e : explicitPresented) {
-            if (!e->current.buffer || !e->current.buffer->releaser)
+            if (!e->current.buffer || !e->current.buffer->syncReleaser || e->current.sameBufferCommit)
                 continue;
 
-            e->current.buffer->releaser->addReleaseSync(sync);
+            e->current.buffer->syncReleaser->addReleaseSync(sync);
         }
     }
 

--- a/src/render/pass/SurfacePassElement.cpp
+++ b/src/render/pass/SurfacePassElement.cpp
@@ -51,14 +51,6 @@ void CSurfacePassElement::draw(const CRegion& damage) {
     if (!TEXTURE->m_iTexID)
         return;
 
-    // explicit sync: wait for the timeline, if any
-    if (data.surface->syncobj && !data.surface->current.sameBufferCommit && data.surface->current.buffer && data.surface->current.buffer->acquire && !data.surface->current.buffer->acquire->expired()) {
-        if (!g_pHyprOpenGL->waitForTimelinePoint(data.surface->current.buffer->acquire->timeline().lock(), data.surface->current.buffer->acquire->point())) {
-            Debug::log(ERR, "Renderer: failed to wait for explicit timeline");
-            return;
-        }
-    }
-
     const auto INTERACTIVERESIZEINPROGRESS = data.pWindow && g_pInputManager->currentlyDraggedWindow && g_pInputManager->dragMode == MBIND_RESIZE;
     TRACY_GPU_ZONE("RenderSurface");
 

--- a/src/render/pass/SurfacePassElement.cpp
+++ b/src/render/pass/SurfacePassElement.cpp
@@ -52,8 +52,8 @@ void CSurfacePassElement::draw(const CRegion& damage) {
         return;
 
     // explicit sync: wait for the timeline, if any
-    if (data.surface->syncobj && data.surface->syncobj->current.acquireTimeline) {
-        if (!g_pHyprOpenGL->waitForTimelinePoint(data.surface->syncobj->current.acquireTimeline->timeline, data.surface->syncobj->current.acquirePoint)) {
+    if (data.surface->syncobj && !data.surface->current.sameBufferCommit && data.surface->current.buffer && data.surface->current.buffer->acquire && !data.surface->current.buffer->acquire->expired()) {
+        if (!g_pHyprOpenGL->waitForTimelinePoint(data.surface->current.buffer->acquire->timeline().lock(), data.surface->current.buffer->acquire->point())) {
             Debug::log(ERR, "Renderer: failed to wait for explicit timeline");
             return;
         }


### PR DESCRIPTION
use eventfd and add it to the event loop and when it recieves a signal release the the queued surfacestate, this means we dont stall entire compositor when waiting for materilisation of the fd. and change its related usage.


should solve a lot of "compositor 5 fps while ingame overlay shows 300fps" and other similiar weird stalls.

on nvidia this shuffles compositor stalls to sometimes a noticeable rendering stutter, technically the acquire point isnt signaled fast enough so the buffer is stuck and nothing gets rendered until it is. pretty much the same stall as seen before only now its per surface rendering. but that i contribute to nvidia driver being simply shit, and is visible on other compositors.

https://github.com/NVIDIA/open-gpu-kernel-modules/issues/777
https://github.com/NVIDIA/open-gpu-kernel-modules/issues/743

fixes https://github.com/hyprwm/Hyprland/issues/7857
fixes https://github.com/hyprwm/Hyprland/issues/9340
fixes https://github.com/hyprwm/Hyprland/issues/9340
fixes https://github.com/hyprwm/Hyprland/issues/8588
fixes https://github.com/hyprwm/Hyprland/issues/7643
fixes https://github.com/hyprwm/Hyprland/issues/7317
fixes https://github.com/hyprwm/Hyprland/issues/9376
fixes https://github.com/hyprwm/Hyprland/issues/6844
fixes https://github.com/hyprwm/Hyprland/issues/6912

potentially helps:
https://github.com/hyprwm/Hyprland/issues/6617
https://github.com/hyprwm/Hyprland/issues/9011


### remaining quirks to be fixed
- [ x ] resizing rendering window like vkcube is delayed hard
-  its because we are getting a gazzillion xdg shell configure requests that fill the wayland event loop, and eventfd signal gets behind in the queue.
- [ x ] walker crashes https://paste.pika-os.com/upload/bat-tiger-jaguar
-  https://github.com/wmww/gtk4-layer-shell/issues/50 requires gtk4-layer-shell 1.0.4
- [ ] test and see if implicit/explicit sync didnt break hard or some other card/vendors AMD/Intel/etc
- [ ] test and see if gpu/cpu usage didnt regress into other areas. not resetting damage or similiar
- [ x ] syncobj points for async buffers

