### PR TITLE
Less crash-prone monitor config parser

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1946,11 +1946,17 @@ std::optional<std::string> CConfigManager::handleMonitor(const std::string& comm
             error += "invalid resolution ";
             newrule.resolution = Vector2D();
         } else {
-            newrule.resolution.x = stoi(ARGS[1].substr(0, ARGS[1].find_first_of('x')));
-            newrule.resolution.y = stoi(ARGS[1].substr(ARGS[1].find_first_of('x') + 1, ARGS[1].find_first_of('@')));
+            try {
+                newrule.resolution.x = stoi(ARGS[1].substr(0, ARGS[1].find_first_of('x')));
+                newrule.resolution.y = stoi(ARGS[1].substr(ARGS[1].find_first_of('x') + 1, ARGS[1].find_first_of('@')));
 
-            if (ARGS[1].contains("@"))
-                newrule.refreshRate = stof(ARGS[1].substr(ARGS[1].find_first_of('@') + 1));
+                if (ARGS[1].contains("@"))
+                    newrule.refreshRate = stof(ARGS[1].substr(ARGS[1].find_first_of('@') + 1));
+            }
+            catch (...) {
+                error += "invalid resolution ";
+                newrule.resolution = Vector2D();
+            }
         }
     }
 


### PR DESCRIPTION
monitor=HDMI-A-2, disabled 1680x1050, 1920x0, 1

The above config line crashes the entire app. stoi gets handed "disabled 1680" which is definitely not an integer. The check for "x" isn't enough to catch it. I'm unsure how (or if) this should be fixed so the band-aid try-catch hack is just a placeholder. Consider this a bug report.