### PR TITLE
xcursor: move config check to sync gsettings

### DIFF
--- a/src/managers/XCursorManager.cpp
+++ b/src/managers/XCursorManager.cpp
@@ -156,9 +156,7 @@ void CXCursorManager::loadTheme(std::string const& name, int size, float scale) 
         cursors.emplace_back(cursor);
     }
 
-    static auto SYNCGSETTINGS = CConfigValue<Hyprlang::INT>("cursor:sync_gsettings_theme");
-    if (*SYNCGSETTINGS)
-        syncGsettings();
+    syncGsettings();
 }
 
 SP<SXCursors> CXCursorManager::getShape(std::string const& shape, int size, float scale) {
@@ -560,6 +558,10 @@ std::vector<SP<SXCursors>> CXCursorManager::loadAllFromDir(std::string const& pa
 }
 
 void CXCursorManager::syncGsettings() {
+    static auto SYNCGSETTINGS = CConfigValue<Hyprlang::INT>("cursor:sync_gsettings_theme");
+    if (!*SYNCGSETTINGS)
+        return;
+
     auto checkParamExists = [](std::string const& paramName, std::string const& category) {
         auto* gSettingsSchemaSource = g_settings_schema_source_get_default();
 


### PR DESCRIPTION
move the check down into the function itself, 39df1f4 began syncing on session change, but isnt checking for the setting itself, so instead of duplicating checks all over. do it here.

related: #9441 


