### PR TITLE
chore: add CXX_STANDARD_REQUIRED flag to ensure c++ version must be c++26

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ add_compile_definitions(HYPRLAND_VERSION="${HYPRLAND_VERSION}")
 include_directories(. "src/" "protocols/")
 
 set(CMAKE_CXX_STANDARD 26)
+set(CXX_STANDARD_REQUIRED ON)
 add_compile_options(
   -Wall
   -Wextra


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
As the [cmake documentation](https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD_REQUIRED.html) said, when we use the `CMAKE_CXX_STANDARD` without `CXX_STANDARD_REQUIRED`, then the standard version we set will be an optional value, and may decay back to older c++ version. So I add this configuration into cmakelist to ensure c++ version is `c++26`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nope.

#### Is it ready for merging, or does it need work?
Yes, its done.

