### PR TITLE
global rule for spawnWithRule

### DIFF
--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -610,20 +610,23 @@ std::vector<pid_t> getAllPIDOf(const std::string& name) {
     std::vector<pid_t> results;
 
 #if defined(KERN_PROC_ALL)
-    int mib[] = {
-        CTL_KERN, KERN_PROC, KERN_PROC_ALL,
+    int mib[] = {CTL_KERN,
+                 KERN_PROC,
+                 KERN_PROC_ALL,
 #if defined(__NetBSD__) || defined(__OpenBSD__)
-        0, sizeof(KINFO_PROC), 0
+                 0,
+                 sizeof(KINFO_PROC),
+                 0
 #endif
     };
-    u_int miblen = sizeof(mib) / sizeof(mib[0]);
-    
+    u_int  miblen = sizeof(mib) / sizeof(mib[0]);
+
     size_t size = 0;
     if (sysctl(mib, miblen, NULL, &size, NULL, 0) == -1)
         return results;
 
     std::vector<KINFO_PROC> kprocList(size / sizeof(KINFO_PROC));
-    
+
     if (sysctl(mib, miblen, kprocList.data(), &size, NULL, 0) != -1) {
         for (auto& kproc : kprocList) {
 #if defined(__DragonFly__)
@@ -648,7 +651,7 @@ std::vector<pid_t> getAllPIDOf(const std::string& name) {
         if (!isNumber(dirname))
             continue;
 
-        const auto pid = std::stoll(dirname);
+        const auto  pid      = std::stoll(dirname);
         std::string procName = getProcNameOf(pid);
 
         if (procName == name)
@@ -686,14 +689,14 @@ std::string getProcNameOf(pid_t pid) {
     return {};
 #else
     const std::string commPath = "/proc/" + std::to_string(pid) + "/comm";
-    CFileDescriptor fd{open(commPath.c_str(), O_RDONLY | O_CLOEXEC)};
-    
+    CFileDescriptor   fd{open(commPath.c_str(), O_RDONLY | O_CLOEXEC)};
+
     if (!fd.isValid())
         return {};
 
-    char buffer[256] = {0};
-    const auto bytesRead = read(fd.get(), buffer, sizeof(buffer) - 1);
-    
+    char       buffer[256] = {0};
+    const auto bytesRead   = read(fd.get(), buffer, sizeof(buffer) - 1);
+
     if (bytesRead <= 0)
         return {};
 
@@ -704,8 +707,6 @@ std::string getProcNameOf(pid_t pid) {
     return name;
 #endif
 }
-
-
 
 std::expected<int64_t, std::string> configStringToInt(const std::string& VALUE) {
     auto parseHex = [](const std::string& value) -> std::expected<int64_t, std::string> {

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -652,7 +652,7 @@ std::vector<pid_t> getAllPIDOf(const std::string& name) {
             continue;
 
         const auto  pid      = std::stoll(dirname);
-        std::string procName = getProcNameOf(pid);
+        std::string procName = binaryNameForPid(pid).value_or("");
 
         if (procName == name)
             results.push_back(pid);

--- a/src/helpers/MiscFunctions.hpp
+++ b/src/helpers/MiscFunctions.hpp
@@ -19,29 +19,29 @@ struct SWorkspaceIDName {
     std::string name;
 };
 
-std::string                         absolutePath(const std::string&, const std::string&);
-std::string                         escapeJSONStrings(const std::string& str);
-bool                                isDirection(const std::string&);
-bool                                isDirection(const char&);
-SWorkspaceIDName                    getWorkspaceIDNameFromString(const std::string&);
-std::optional<std::string>          cleanCmdForWorkspace(const std::string&, std::string);
-float                               vecToRectDistanceSquared(const Vector2D& vec, const Vector2D& p1, const Vector2D& p2);
-void                                logSystemInfo();
-std::string                         execAndGet(const char*);
-pid_t                               getPPIDof(pid_t pid);
-std::string                         getProcNameOf(pid_t pid);
-std::vector<pid_t>                  getAllPIDOf(const std::string& name);
-std::expected<int64_t, std::string> configStringToInt(const std::string&);
-Vector2D                            configStringToVector2D(const std::string&);
-std::optional<float>                getPlusMinusKeywordResult(std::string in, float relative);
-double                              normalizeAngleRad(double ang);
-std::vector<SCallstackFrameInfo>    getBacktrace();
-void                                throwError(const std::string& err);
-bool                                envEnabled(const std::string& env);
-Hyprutils::OS::CFileDescriptor      allocateSHMFile(size_t len);
-bool                                allocateSHMFilePair(size_t size, Hyprutils::OS::CFileDescriptor& rw_fd_ptr, Hyprutils::OS::CFileDescriptor& ro_fd_ptr);
-float                               stringToPercentage(const std::string& VALUE, const float REL);
-bool                                isNvidiaDriverVersionAtLeast(int threshold);
+std::string                             absolutePath(const std::string&, const std::string&);
+std::string                             escapeJSONStrings(const std::string& str);
+bool                                    isDirection(const std::string&);
+bool                                    isDirection(const char&);
+SWorkspaceIDName                        getWorkspaceIDNameFromString(const std::string&);
+std::optional<std::string>              cleanCmdForWorkspace(const std::string&, std::string);
+float                                   vecToRectDistanceSquared(const Vector2D& vec, const Vector2D& p1, const Vector2D& p2);
+void                                    logSystemInfo();
+std::string                             execAndGet(const char*);
+pid_t                                   getPPIDof(pid_t pid);
+std::expected<std::string, std::string> binaryNameForPid(pid_t pid);
+std::vector<pid_t>                      getAllPIDOf(const std::string& name);
+std::expected<int64_t, std::string>     configStringToInt(const std::string&);
+Vector2D                                configStringToVector2D(const std::string&);
+std::optional<float>                    getPlusMinusKeywordResult(std::string in, float relative);
+double                                  normalizeAngleRad(double ang);
+std::vector<SCallstackFrameInfo>        getBacktrace();
+void                                    throwError(const std::string& err);
+bool                                    envEnabled(const std::string& env);
+Hyprutils::OS::CFileDescriptor          allocateSHMFile(size_t len);
+bool                                    allocateSHMFilePair(size_t size, Hyprutils::OS::CFileDescriptor& rw_fd_ptr, Hyprutils::OS::CFileDescriptor& ro_fd_ptr);
+float                                   stringToPercentage(const std::string& VALUE, const float REL);
+bool                                    isNvidiaDriverVersionAtLeast(int threshold);
 
 template <typename... Args>
 [[deprecated("use std::format instead")]] std::string getFormat(std::format_string<Args...> fmt, Args&&... args) {

--- a/src/helpers/MiscFunctions.hpp
+++ b/src/helpers/MiscFunctions.hpp
@@ -29,7 +29,7 @@ float                               vecToRectDistanceSquared(const Vector2D& vec
 void                                logSystemInfo();
 std::string                         execAndGet(const char*);
 pid_t                             getPPIDof(pid_t pid);
-std::string getProcNameOf(int64_t pid);
+std::string getProcNameOf(pid_t pid);
 std::vector<pid_t> getAllPIDOf(const std::string& name);
 std::expected<int64_t, std::string> configStringToInt(const std::string&);
 Vector2D                            configStringToVector2D(const std::string&);

--- a/src/helpers/MiscFunctions.hpp
+++ b/src/helpers/MiscFunctions.hpp
@@ -28,9 +28,9 @@ std::optional<std::string>          cleanCmdForWorkspace(const std::string&, std
 float                               vecToRectDistanceSquared(const Vector2D& vec, const Vector2D& p1, const Vector2D& p2);
 void                                logSystemInfo();
 std::string                         execAndGet(const char*);
-pid_t                             getPPIDof(pid_t pid);
-std::string getProcNameOf(pid_t pid);
-std::vector<pid_t> getAllPIDOf(const std::string& name);
+pid_t                               getPPIDof(pid_t pid);
+std::string                         getProcNameOf(pid_t pid);
+std::vector<pid_t>                  getAllPIDOf(const std::string& name);
 std::expected<int64_t, std::string> configStringToInt(const std::string&);
 Vector2D                            configStringToVector2D(const std::string&);
 std::optional<float>                getPlusMinusKeywordResult(std::string in, float relative);

--- a/src/helpers/MiscFunctions.hpp
+++ b/src/helpers/MiscFunctions.hpp
@@ -28,7 +28,9 @@ std::optional<std::string>          cleanCmdForWorkspace(const std::string&, std
 float                               vecToRectDistanceSquared(const Vector2D& vec, const Vector2D& p1, const Vector2D& p2);
 void                                logSystemInfo();
 std::string                         execAndGet(const char*);
-int64_t                             getPPIDof(int64_t pid);
+pid_t                             getPPIDof(pid_t pid);
+std::string getProcNameOf(int64_t pid);
+std::vector<pid_t> getAllPIDOf(const std::string& name);
 std::expected<int64_t, std::string> configStringToInt(const std::string&);
 Vector2D                            configStringToVector2D(const std::string&);
 std::optional<float>                getPlusMinusKeywordResult(std::string in, float relative);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -949,7 +949,7 @@ pid_t CKeybindManager::spawnWithRules(std::string args, PHLWORKSPACE pInitialWor
                 global = true;
             else {
                 if (global)
-                    for (const auto& pid : getAllPIDOf(getProcNameOf(PROC)))
+                    for (const auto& pid : getAllPIDOf(binaryNameForPid(PROC)))
                         g_pConfigManager->addExecRule({r, (unsigned long)pid});
                 else
                     g_pConfigManager->addExecRule({r, (unsigned long)PROC});

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -945,6 +945,9 @@ pid_t CKeybindManager::spawnWithRules(std::string args, PHLWORKSPACE pInitialWor
         auto       global    = false;
 
         for (auto const& r : RULESLIST) {
+            Debug::log(CRIT, "PROC = {}", PROC);
+            Debug::log(CRIT, "getProcNameOf(PROC) = {}", getProcNameOf(PROC));
+            Debug::log(CRIT, "getAllPIDOf(getProcNameOf(PROC)) = {}", getAllPIDOf(getProcNameOf(PROC)));
             if (r == "global")
                 global = true;
             else {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -19,6 +19,7 @@
 #include "../render/Renderer.hpp"
 #include "../hyprerror/HyprError.hpp"
 #include "../config/ConfigManager.hpp"
+#include "../helpers/MiscFunctions.hpp"
 
 #include <optional>
 #include <iterator>
@@ -941,9 +942,18 @@ uint64_t CKeybindManager::spawnWithRules(std::string args, PHLWORKSPACE pInitial
 
     if (!RULES.empty()) {
         const auto RULESLIST = CVarList(RULES, 0, ';');
+        auto       global    = false;
 
         for (auto const& r : RULESLIST) {
-            g_pConfigManager->addExecRule({r, (unsigned long)PROC});
+            if (r == "global")
+                global = true;
+            else {
+                if (global) {
+                    for (const auto& pid : getAllPIDOf(getProcNameOf(PROC)))
+                        g_pConfigManager->addExecRule({r, (unsigned long)pid});
+                } else
+                    g_pConfigManager->addExecRule({r, (unsigned long)PROC});
+            }
         }
 
         Debug::log(LOG, "Applied {} rule arguments for exec.", RULESLIST.size());

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -948,10 +948,10 @@ pid_t CKeybindManager::spawnWithRules(std::string args, PHLWORKSPACE pInitialWor
             if (r == "global")
                 global = true;
             else {
-                if (global) {
+                if (global)
                     for (const auto& pid : getAllPIDOf(getProcNameOf(PROC)))
                         g_pConfigManager->addExecRule({r, (unsigned long)pid});
-                } else
+                else
                     g_pConfigManager->addExecRule({r, (unsigned long)PROC});
             }
         }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -946,13 +946,13 @@ pid_t CKeybindManager::spawnWithRules(std::string args, PHLWORKSPACE pInitialWor
 
         for (auto const& r : RULESLIST) {
             Debug::log(CRIT, "PROC = {}", PROC);
-            Debug::log(CRIT, "getProcNameOf(PROC) = {}", getProcNameOf(PROC));
-            Debug::log(CRIT, "getAllPIDOf(getProcNameOf(PROC)) = {}", getAllPIDOf(getProcNameOf(PROC)));
+            Debug::log(CRIT, "getProcNameOf(PROC) = {}", *binaryNameForPid(PROC));
+            Debug::log(CRIT, "getAllPIDOf(getProcNameOf(PROC)) = {}", getAllPIDOf(*binaryNameForPid(PROC)));
             if (r == "global")
                 global = true;
             else {
                 if (global)
-                    for (const auto& pid : getAllPIDOf(binaryNameForPid(PROC)))
+                    for (const auto& pid : getAllPIDOf(*binaryNameForPid(PROC)))
                         g_pConfigManager->addExecRule({r, (unsigned long)pid});
                 else
                     g_pConfigManager->addExecRule({r, (unsigned long)PROC});

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -922,11 +922,11 @@ bool CKeybindManager::handleInternalKeybinds(xkb_keysym_t keysym) {
 
 // Dispatchers
 SDispatchResult CKeybindManager::spawn(std::string args) {
-    const uint64_t PROC = spawnWithRules(args, nullptr);
+    const pid_t PROC = spawnWithRules(args, nullptr);
     return {.success = PROC > 0, .error = std::format("Failed to start process {}", args)};
 }
 
-uint64_t CKeybindManager::spawnWithRules(std::string args, PHLWORKSPACE pInitialWorkspace) {
+pid_t CKeybindManager::spawnWithRules(std::string args, PHLWORKSPACE pInitialWorkspace) {
 
     args = trim(args);
 
@@ -938,7 +938,7 @@ uint64_t CKeybindManager::spawnWithRules(std::string args, PHLWORKSPACE pInitial
         args  = args.substr(args.find_first_of(']') + 1);
     }
 
-    const uint64_t PROC = spawnRawProc(args, pInitialWorkspace);
+    const pid_t PROC = spawnRawProc(args, pInitialWorkspace);
 
     if (!RULES.empty()) {
         const auto RULESLIST = CVarList(RULES, 0, ';');
@@ -963,11 +963,11 @@ uint64_t CKeybindManager::spawnWithRules(std::string args, PHLWORKSPACE pInitial
 }
 
 SDispatchResult CKeybindManager::spawnRaw(std::string args) {
-    const uint64_t PROC = spawnRawProc(args, nullptr);
+    const pid_t PROC = spawnRawProc(args, nullptr);
     return {.success = PROC > 0, .error = std::format("Failed to start process {}", args)};
 }
 
-uint64_t CKeybindManager::spawnRawProc(std::string args, PHLWORKSPACE pInitialWorkspace) {
+pid_t CKeybindManager::spawnRawProc(std::string args, PHLWORKSPACE pInitialWorkspace) {
     Debug::log(LOG, "Executing {}", args);
 
     const auto HLENV = getHyprlandLaunchEnv(pInitialWorkspace);

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -154,8 +154,8 @@ class CKeybindManager {
     static void                      moveWindowOutOfGroup(PHLWINDOW pWindow, const std::string& dir = "");
     static void                      moveWindowIntoGroup(PHLWINDOW pWindow, PHLWINDOW pWindowInDirection);
     static void                      switchToWindow(PHLWINDOW PWINDOWTOCHANGETO, bool preserveFocusHistory = false);
-    static pid_t                  spawnRawProc(std::string, PHLWORKSPACE pInitialWorkspace);
-    static pid_t                  spawnWithRules(std::string, PHLWORKSPACE pInitialWorkspace);
+    static pid_t                     spawnRawProc(std::string, PHLWORKSPACE pInitialWorkspace);
+    static pid_t                     spawnWithRules(std::string, PHLWORKSPACE pInitialWorkspace);
 
     // -------------- Dispatchers -------------- //
     static SDispatchResult closeActive(std::string);

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -154,8 +154,8 @@ class CKeybindManager {
     static void                      moveWindowOutOfGroup(PHLWINDOW pWindow, const std::string& dir = "");
     static void                      moveWindowIntoGroup(PHLWINDOW pWindow, PHLWINDOW pWindowInDirection);
     static void                      switchToWindow(PHLWINDOW PWINDOWTOCHANGETO, bool preserveFocusHistory = false);
-    static uint64_t                  spawnRawProc(std::string, PHLWORKSPACE pInitialWorkspace);
-    static uint64_t                  spawnWithRules(std::string, PHLWORKSPACE pInitialWorkspace);
+    static pid_t                  spawnRawProc(std::string, PHLWORKSPACE pInitialWorkspace);
+    static pid_t                  spawnWithRules(std::string, PHLWORKSPACE pInitialWorkspace);
 
     // -------------- Dispatchers -------------- //
     static SDispatchResult closeActive(std::string);

--- a/src/managers/permissions/DynamicPermissionManager.cpp
+++ b/src/managers/permissions/DynamicPermissionManager.cpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include "../../Compositor.hpp"
 #include "../../config/ConfigValue.hpp"
+#include "../../helpers/MiscFunctions.hpp"
 
 #include <hyprutils/string/String.hpp>
 using namespace Hyprutils::String;
@@ -67,41 +68,6 @@ static const char* permissionToHumanString(eDynamicPermissionType type) {
     }
 
     return "error";
-}
-
-static std::expected<std::string, std::string> binaryNameForPid(pid_t pid) {
-    if (pid <= 0)
-        return std::unexpected("No pid for client");
-
-#if defined(KERN_PROC_PATHNAME)
-    int mib[] = {
-        CTL_KERN,
-#if defined(__NetBSD__)
-        KERN_PROC_ARGS,
-        pid,
-        KERN_PROC_PATHNAME,
-#else
-        KERN_PROC,
-        KERN_PROC_PATHNAME,
-        pid,
-#endif
-    };
-    u_int  miblen        = sizeof(mib) / sizeof(mib[0]);
-    char   exe[PATH_MAX] = "/nonexistent";
-    size_t sz            = sizeof(exe);
-    sysctl(mib, miblen, &exe, &sz, NULL, 0);
-    std::string path = exe;
-#else
-    std::string path = std::format("/proc/{}/exe", (uint64_t)pid);
-#endif
-    std::error_code ec;
-
-    std::string     fullPath = std::filesystem::canonical(path, ec);
-
-    if (ec)
-        return std::unexpected("canonical failed");
-
-    return fullPath;
 }
 
 static std::expected<std::string, std::string> binaryNameForWlClient(wl_client* client) {


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
closes #8949
adds a rule for spawnWithRule called global


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
- [x] get all pid of the same proc name from its pid
- [x] actual impl of the global rule in spawnWithRule etc


#### Is it ready for merging, or does it need work?
currently: `getProcNameOf` doesn't seem to work with procs spawned by hyprland
