### PR TITLE
nix: wp-protocol version bump

### DIFF
--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -91,7 +91,7 @@ in {
     });
   };
 
-  # Temporary bump until https://nixpk.gs/pr-tracker.html?pr=367753 is merged.
+  # Temporary bump until https://nixpk.gs/pr-tracker.html?pr=382812 is merged.
   # Expect to build the universe.
   wayland-protocols-bump = final: prev: {
     wayland-protocols = prev.wayland-protocols.overrideAttrs (self: super: {

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -95,11 +95,11 @@ in {
   # Expect to build the universe.
   wayland-protocols-bump = final: prev: {
     wayland-protocols = prev.wayland-protocols.overrideAttrs (self: super: {
-      version = "1.40";
+      version = "1.41";
 
       src = prev.fetchurl {
         url = "https://gitlab.freedesktop.org/wayland/${super.pname}/-/releases/${self.version}/downloads/${super.pname}-${self.version}.tar.xz";
-        hash = "sha256-shcReTJHwsQnY5FDkt+p/LnjcoyktKoRCtuNkV/ABok=";
+        hash = "sha256-J4a2sbeZZeMT8sKJwSB1ue1wDUGESBDFGv2hDuMpV2s=";
       };
     });
   };


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
bumps wayland-protocols to 1.41, as required by wp-color
Fixes #9493.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Some plugins, such as split-monitor-workspaces, break. Can't tell if this is due to this commit or a previous one, as I can't build previous commits to bisect because I'm using nix, and on nix the previous builds fail. However, I can't think of a good reason why this commit would break anything

#### Is it ready for merging, or does it need work?
ready

