### PR TITLE
core: Add null activeWorkspace check in moveWorkspaceToMonitor

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2210,7 +2210,8 @@ void CCompositor::moveWorkspaceToMonitor(PHLWORKSPACE pWorkspace, PHLMONITOR pMo
     // finalize
     if (POLDMON) {
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(POLDMON->ID);
-        updateFullscreenFadeOnWorkspace(POLDMON->activeWorkspace);
+        if (valid(POLDMON->activeWorkspace))
+            updateFullscreenFadeOnWorkspace(POLDMON->activeWorkspace);
         updateSuspendedStates();
     }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

After I turn all monitors off with DPMS and then turn them back on, Hyprland would sometimes crash. I looked at a core dump and it seems to be just a missing null check (this backtrace is from Hyprland v0.47.2, it's from a release build with debug symbols):

```
#4  0x000064333164c1de in handleUnrecoverableSignal (sig=11) at /usr/src/debug/hyprland/Hyprland-0.47.2/src/Compositor.cpp:108
#5  <signal handler called>
#6  0x000064333157f4cd in CCompositor::updateFullscreenFadeOnWorkspace (this=this@entry=0x643343adde30, pWorkspace=...) at /usr/src/debug/hyprland/Hyprland-0.47.2/src/Compositor.cpp:2217
#7  0x0000643331666360 in CCompositor::moveWorkspaceToMonitor (this=0x643343adde30, pWorkspace=..., pMonitor=..., noWarpCursor=false) at /usr/src/debug/hyprland/Hyprland-0.47.2/src/Compositor.cpp:2184
#8  0x0000643331752b99 in CMonitor::setupDefaultWS (this=0x643345249710, monitorRule=...) at /usr/src/debug/hyprland/Hyprland-0.47.2/src/helpers/Monitor.cpp:869
#9  0x0000643331750055 in CMonitor::onConnect (this=0x643345249710, noRule=<optimized out>) at /usr/src/debug/hyprland/Hyprland-0.47.2/src/helpers/Monitor.cpp:195
#10 0x0000643331670639 in CCompositor::onNewMonitor (this=0x643343adde30, output=...) at /usr/src/debug/hyprland/Hyprland-0.47.2/src/Compositor.cpp:2982
```

As you can see from the backtrace, the new monitor's setupDefaultWS calls moveWorkspaceToMonitor but there isn't an active workspace of the monitor at that point.

```
(gdb) frame
#6  0x000064333157f4cd in CCompositor::updateFullscreenFadeOnWorkspace (this=this@entry=0x643343adde30, pWorkspace=...) at /usr/src/debug/hyprland/Hyprland-0.47.2/src/Compositor.cpp:2217
2217	    const auto FULLSCREEN = pWorkspace->m_bHasFullscreenWindow;
(gdb) p pWorkspace
$3 = {impl_ = 0x0}
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I'm not sure on the exact conditions to replicate this issue so I'm not 100% sure it fully fixes the issue, but it definitely adds a needed null check where there wasn't one before.

#### Is it ready for merging, or does it need work?
Ready for merging