### PR TITLE
protocols: Fix IWaylandProtocol onDisplayDestroy m_pGlobal double-free

### DIFF
--- a/src/protocols/WaylandProtocol.cpp
+++ b/src/protocols/WaylandProtocol.cpp
@@ -14,7 +14,10 @@ static void displayDestroyInternal(struct wl_listener* listener, void* data) {
 void IWaylandProtocol::onDisplayDestroy() {
     wl_list_remove(&m_liDisplayDestroy.listener.link);
     wl_list_init(&m_liDisplayDestroy.listener.link);
-    wl_global_destroy(m_pGlobal);
+    if (m_pGlobal) {
+        wl_global_destroy(m_pGlobal);
+        m_pGlobal = nullptr;
+    }
 }
 
 IWaylandProtocol::IWaylandProtocol(const wl_interface* iface, const int& ver, const std::string& name) :
@@ -38,7 +41,8 @@ IWaylandProtocol::~IWaylandProtocol() {
 }
 
 void IWaylandProtocol::removeGlobal() {
-    wl_global_remove(m_pGlobal);
+    if (m_pGlobal)
+        wl_global_remove(m_pGlobal);
 }
 
 wl_global* IWaylandProtocol::getGlobal() {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This fixes a segfault on Hyprland shutdown caused by the wl_global_destroy call modified in this PR:

```
#0  0x00007a75f51443af in wl_list_remove (elm=elm@entry=0x5ec7ca5e15a8) at ../wayland-1.23.1/src/wayland-util.c:56
#1  0x00007a75f5145cb0 in wl_global_destroy (global=0x5ec7ca5e1580) at ../wayland-1.23.1/src/wayland-server.c:1399
#2  0x00005ec78c6d7017 in IWaylandProtocol::onDisplayDestroy (this=0x5ec7ca5e1620)
    at /home/lee/code/cpp/Hyprland/src/protocols/WaylandProtocol.cpp:17
#3  0x00005ec78c6d7707 in IWaylandProtocol::~IWaylandProtocol (this=0x5ec7ca5e1620)
    at /home/lee/code/cpp/Hyprland/src/protocols/WaylandProtocol.cpp:37
```

Looking at the code, m_pGlobal will be destroyed first when the display is destroyed by the onDisplayDestroy hook, and then a second time when the wayland protocol is destroyed (if that happens later) by the IWaylandProtocol destructor calling onDisplayDestroy a second time. This PR fixes that by setting m_pGlobal to nullptr after destroying it and adding null checks.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I don't think the m_pGlobal null check in removeGlobal is necessary, but better safe than sorry I figure.

The `m_liDisplayDestroy.listener.link` removal is fine as-is because it's already re-init'ed afterwards in the existing code, meaning that the second removal will be a no-op.

#### Is it ready for merging, or does it need work?
Ready for merging