### PR TITLE
Provide a non-zero time for button release triggered during window unmap

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1707,8 +1707,11 @@ void CInputManager::releaseAllMouseButtons() {
     if (PROTO::data->dndActive())
         return;
 
+    timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+
     for (auto const& mb : buttonsCopy) {
-        g_pSeatManager->sendPointerButton(0, mb, WL_POINTER_BUTTON_STATE_RELEASED);
+        g_pSeatManager->sendPointerButton(now.tv_sec * 1000 + now.tv_nsec / 1000000, mb, WL_POINTER_BUTTON_STATE_RELEASED);
     }
 
     m_lCurrentlyHeldButtons.clear();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

It doesn't seem that this is actually required, but it seems more consistant with other areas, such as in CVirtualKeyboardV1Resource::releasePressed.

I discovered this due to this assert in blender, which may itself be erroneous, but it doesn't seem like it hurts to provide better event time data in this case.

https://projects.blender.org/blender/blender/src/commit/97a1ec806355d7ffc2839706b7deaaac62a84f9b/intern/ghost/intern/GHOST_SystemWayland.cc#L782


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Seems unlikely to break compatibility, been testing it locally with no issues.


#### Is it ready for merging, or does it need work?

Ready for merging.

