### PR TITLE
fix(input): replace not mouse check

### DIFF
--- a/src/devices/IPointer.hpp
+++ b/src/devices/IPointer.hpp
@@ -112,6 +112,7 @@ class IPointer : public IHID {
     std::string  boundOutput = "";
     bool         flipX       = false; // decide to invert horizontal movement
     bool         flipY       = false; // decide to invert vertical movement
+    bool         isTouchpad  = false; // is it a touchpad?
 
     WP<IPointer> self;
 };

--- a/src/devices/IPointer.hpp
+++ b/src/devices/IPointer.hpp
@@ -112,7 +112,7 @@ class IPointer : public IHID {
     std::string  boundOutput = "";
     bool         flipX       = false; // decide to invert horizontal movement
     bool         flipY       = false; // decide to invert vertical movement
-    bool         isTouchpad  = false; // is it a touchpad?
+    bool         isTouchpad  = false;
 
     WP<IPointer> self;
 };

--- a/src/devices/Mouse.cpp
+++ b/src/devices/Mouse.cpp
@@ -14,6 +14,11 @@ CMouse::CMouse(SP<Aquamarine::IPointer> mouse_) : mouse(mouse_) {
     if (!mouse)
         return;
 
+    if (auto handle = mouse->getLibinputHandle()) {
+        double w = 0, h = 0;
+        isTouchpad = libinput_device_has_capability(handle, LIBINPUT_DEVICE_CAP_POINTER) && libinput_device_get_size(handle, &w, &h) == 0;
+    }
+
     listeners.destroy = mouse->events.destroy.registerListener([this](std::any d) {
         mouse.reset();
         events.destroy.emit();

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -93,12 +93,8 @@ void CInputManager::onMouseMoved(IPointer::SMotionEvent e) {
     Vector2D    delta   = e.delta;
     Vector2D    unaccel = e.unaccel;
 
-    if (e.device && e.device->aq() && e.device->aq()->getLibinputHandle()) {
-        double     touchw = 0, touchh = 0;
-        const auto ISTOUCHPAD = libinput_device_has_capability(e.device->aq()->getLibinputHandle(), LIBINPUT_DEVICE_CAP_POINTER) &&
-            libinput_device_get_size(e.device->aq()->getLibinputHandle(), &touchw, &touchh) == 0;
-
-        if (ISTOUCHPAD) {
+    if (e.device) {
+        if (e.device->isTouchpad) {
             if (e.device->flipX) {
                 delta.x   = -delta.x;
                 unaccel.x = -unaccel.x;

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -93,7 +93,7 @@ void CInputManager::onMouseMoved(IPointer::SMotionEvent e) {
     Vector2D    delta   = e.delta;
     Vector2D    unaccel = e.unaccel;
 
-    if (!e.mouse && e.device) {
+    if (e.device) {
         if (e.device->flipX) {
             delta.x   = -delta.x;
             unaccel.x = -unaccel.x;

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -93,14 +93,20 @@ void CInputManager::onMouseMoved(IPointer::SMotionEvent e) {
     Vector2D    delta   = e.delta;
     Vector2D    unaccel = e.unaccel;
 
-    if (e.device) {
-        if (e.device->flipX) {
-            delta.x   = -delta.x;
-            unaccel.x = -unaccel.x;
-        }
-        if (e.device->flipY) {
-            delta.y   = -delta.y;
-            unaccel.y = -unaccel.y;
+    if (e.device && e.device->aq() && e.device->aq()->getLibinputHandle()) {
+        double     touchw = 0, touchh = 0;
+        const auto ISTOUCHPAD = libinput_device_has_capability(e.device->aq()->getLibinputHandle(), LIBINPUT_DEVICE_CAP_POINTER) &&
+            libinput_device_get_size(e.device->aq()->getLibinputHandle(), &touchw, &touchh) == 0;
+
+        if (ISTOUCHPAD) {
+            if (e.device->flipX) {
+                delta.x   = -delta.x;
+                unaccel.x = -unaccel.x;
+            }
+            if (e.device->flipY) {
+                delta.y   = -delta.y;
+                unaccel.y = -unaccel.y;
+            }
         }
     }
 


### PR DESCRIPTION
This replaces the !e.mouse check due to reports of flip_x and flip_y not working because of a logical error.

https://github.com/hyprwm/Hyprland/issues/8795#issuecomment-2697190172