### PR TITLE
feat(ipc): add activespecialv2

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1095,6 +1095,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
             activeSpecialWorkspace->m_bVisible = false;
             activeSpecialWorkspace->startAnim(false, false);
             g_pEventManager->postEvent(SHyprIPCEvent{"activespecial", "," + szName});
+            g_pEventManager->postEvent(SHyprIPCEvent{"activespecialv2", ",," + szName});
         }
         activeSpecialWorkspace.reset();
 
@@ -1128,6 +1129,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
         PMWSOWNER->activeSpecialWorkspace.reset();
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(PMWSOWNER->ID);
         g_pEventManager->postEvent(SHyprIPCEvent{"activespecial", "," + PMWSOWNER->szName});
+        g_pEventManager->postEvent(SHyprIPCEvent{"activespecialv2", ",," + PMWSOWNER->szName});
 
         const auto PACTIVEWORKSPACE = PMWSOWNER->activeWorkspace;
         g_pCompositor->updateFullscreenFadeOnWorkspace(PACTIVEWORKSPACE);
@@ -1176,6 +1178,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
     }
 
     g_pEventManager->postEvent(SHyprIPCEvent{"activespecial", pWorkspace->m_szName + "," + szName});
+    g_pEventManager->postEvent(SHyprIPCEvent{"activespecialv2", pWorkspace->m_iID + "," + pWorkspace->m_szName + "," + szName});
 
     g_pHyprRenderer->damageMonitor(self.lock());
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This is a simple PR that brings the `activespecial` IPC event into parity with other [socket v2 events](https://github.com/hyprwm/Hyprland/pull/5022) to contain workspace ID.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This PR addresses the only "missing" IPC functionality that prevents related projects like Waybar from moving to completely [ID-based workspace tracking](https://github.com/Alexays/Waybar/pull/3878). 

Maintains backwards-compatibility.

Documented in https://github.com/hyprwm/hyprland-wiki/pull/994

#### Is it ready for merging, or does it need work?

This change is ready to go.
