### PR TITLE
protocols: Fix cursor shape protocol valid shape check

### DIFF
--- a/src/protocols/CursorShape.cpp
+++ b/src/protocols/CursorShape.cpp
@@ -41,7 +41,7 @@ void CCursorShapeProtocol::createCursorShapeDevice(CWpCursorShapeManagerV1* pMgr
 }
 
 void CCursorShapeProtocol::onSetShape(CWpCursorShapeDeviceV1* pMgr, uint32_t serial, wpCursorShapeDeviceV1Shape shape) {
-    if UNLIKELY ((uint32_t)shape == 0 || (uint32_t)shape > CURSOR_SHAPE_NAMES.size()) {
+    if UNLIKELY ((uint32_t)shape == 0 || (uint32_t)shape >= CURSOR_SHAPE_NAMES.size()) {
         pMgr->error(WP_CURSOR_SHAPE_DEVICE_V1_ERROR_INVALID_SHAPE, "The shape is invalid");
         return;
     }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
If `shape == CURSOR_SHAPE_NAMES.size()`, then `CURSOR_SHAPE_NAMES.at(shape)` will throw an exception because it's out of range. I'm not sure if that's caught anywhere but it should be included in this bound check regardless.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I haven't seen or replicated the crash (I just came across this while reading the code), but it seems fairly straightforward.

#### Is it ready for merging, or does it need work?
Ready for merging