### PR TITLE
fix(keybinds): prevent crash when executing movewindoworgroup

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -3003,7 +3003,7 @@ SDispatchResult CKeybindManager::moveWindowOrGroup(std::string args) {
 
     const auto PWINDOWINDIR = g_pCompositor->getWindowInDirection(PWINDOW, arg);
 
-    const bool ISWINDOWGROUP       = !PWINDOW->m_sGroupData.pNextWindow;
+    const bool ISWINDOWGROUP       = PWINDOW->m_sGroupData.pNextWindow;
     const bool ISWINDOWGROUPLOCKED = ISWINDOWGROUP && PWINDOW->getGroupHead()->m_sGroupData.locked;
     const bool ISWINDOWGROUPSINGLE = ISWINDOWGROUP && PWINDOW->m_sGroupData.pNextWindow.lock() == PWINDOW;
 


### PR DESCRIPTION
fixes #9550 