### PR TITLE
Fix touch calibration matrix

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -605,7 +605,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("input:touchpad:scroll_factor", {1.f});
     registerConfigVar("input:touchpad:flip_x", Hyprlang::INT{0});
     registerConfigVar("input:touchpad:flip_y", Hyprlang::INT{0});
-    registerConfigVar("input:touchdevice:transform", Hyprlang::INT{0});
+    registerConfigVar("input:touchdevice:transform", Hyprlang::INT{-1});
     registerConfigVar("input:touchdevice:output", {"[[Auto]]"});
     registerConfigVar("input:touchdevice:enabled", Hyprlang::INT{1});
     registerConfigVar("input:tablet:transform", Hyprlang::INT{0});

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -724,7 +724,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->addSpecialConfigValue("device", "scroll_button", Hyprlang::INT{0});
     m_pConfig->addSpecialConfigValue("device", "scroll_button_lock", Hyprlang::INT{0});
     m_pConfig->addSpecialConfigValue("device", "scroll_points", {STRVAL_EMPTY});
-    m_pConfig->addSpecialConfigValue("device", "transform", Hyprlang::INT{0});
+    m_pConfig->addSpecialConfigValue("device", "transform", Hyprlang::INT{-1});
     m_pConfig->addSpecialConfigValue("device", "output", {STRVAL_EMPTY});
     m_pConfig->addSpecialConfigValue("device", "enabled", Hyprlang::INT{1});                  // only for mice, touchpads, and touchdevices
     m_pConfig->addSpecialConfigValue("device", "region_position", Hyprlang::VEC2{0, 0});      // only for tablets

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1624,9 +1624,10 @@ void CInputManager::setTabletConfigs() {
             const auto RELINPUT = g_pConfigManager->getDeviceInt(NAME, "relative_input", "input:tablet:relative_input");
             t->relativeInput    = RELINPUT;
 
-            const int ROTATION = std::clamp(g_pConfigManager->getDeviceInt(NAME, "transform", "input:tablet:transform"), 0, 7);
+            const int ROTATION = std::clamp(g_pConfigManager->getDeviceInt(NAME, "transform", "input:tablet:transform"), -1, 7);
             Debug::log(LOG, "Setting calibration matrix for device {}", NAME);
-            libinput_device_config_calibration_set_matrix(LIBINPUTDEV, MATRICES[ROTATION]);
+            if (ROTATION > -1)
+                libinput_device_config_calibration_set_matrix(LIBINPUTDEV, MATRICES[ROTATION]);
 
             if (g_pConfigManager->getDeviceInt(NAME, "left_handed", "input:tablet:left_handed") == 0)
                 libinput_device_config_left_handed_set(LIBINPUTDEV, 0);

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1578,8 +1578,14 @@ void CInputManager::setTouchDeviceConfigs(SP<ITouch> dev) {
 
             const int ROTATION = std::clamp(g_pConfigManager->getDeviceInt(PTOUCHDEV->hlName, "transform", "input:touchdevice:transform"), 0, 7);
             Debug::log(LOG, "Setting calibration matrix for device {}", PTOUCHDEV->hlName);
-            if (libinput_device_config_calibration_has_matrix(LIBINPUTDEV))
-                libinput_device_config_calibration_set_matrix(LIBINPUTDEV, MATRICES[ROTATION]);
+            if (libinput_device_config_calibration_has_matrix(LIBINPUTDEV)) {
+                float current_matrix[6] = {.0, .0, .0, .0, .0, .0};
+                if (libinput_device_config_calibration_get_default_matrix(LIBINPUTDEV, current_matrix)) {
+                    Debug::log(LOG, "Touch device {} has a non-default calibration. Ignoring transform", PTOUCHDEV->hlName);
+                } else {
+                    libinput_device_config_calibration_set_matrix(LIBINPUTDEV, MATRICES[ROTATION]);
+                }
+            }
 
             auto       output     = g_pConfigManager->getDeviceString(PTOUCHDEV->hlName, "output", "input:touchdevice:output");
             bool       bound      = !output.empty() && output != STRVAL_EMPTY;

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1580,11 +1580,10 @@ void CInputManager::setTouchDeviceConfigs(SP<ITouch> dev) {
             Debug::log(LOG, "Setting calibration matrix for device {}", PTOUCHDEV->hlName);
             if (libinput_device_config_calibration_has_matrix(LIBINPUTDEV)) {
                 float current_matrix[6] = {.0, .0, .0, .0, .0, .0};
-                if (libinput_device_config_calibration_get_default_matrix(LIBINPUTDEV, current_matrix)) {
+                if (libinput_device_config_calibration_get_default_matrix(LIBINPUTDEV, current_matrix))
                     Debug::log(LOG, "Touch device {} has a non-default calibration. Ignoring transform", PTOUCHDEV->hlName);
-                } else {
+                else
                     libinput_device_config_calibration_set_matrix(LIBINPUTDEV, MATRICES[ROTATION]);
-                }
             }
 
             auto       output     = g_pConfigManager->getDeviceString(PTOUCHDEV->hlName, "output", "input:touchdevice:output");

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1576,13 +1576,11 @@ void CInputManager::setTouchDeviceConfigs(SP<ITouch> dev) {
             if (libinput_device_config_send_events_get_mode(LIBINPUTDEV) != mode)
                 libinput_device_config_send_events_set_mode(LIBINPUTDEV, mode);
 
-            const int ROTATION = std::clamp(g_pConfigManager->getDeviceInt(PTOUCHDEV->hlName, "transform", "input:touchdevice:transform"), 0, 7);
-            Debug::log(LOG, "Setting calibration matrix for device {}", PTOUCHDEV->hlName);
             if (libinput_device_config_calibration_has_matrix(LIBINPUTDEV)) {
-                float current_matrix[6] = {.0, .0, .0, .0, .0, .0};
-                if (libinput_device_config_calibration_get_default_matrix(LIBINPUTDEV, current_matrix))
-                    Debug::log(LOG, "Touch device {} has a non-default calibration. Ignoring transform", PTOUCHDEV->hlName);
-                else
+                Debug::log(LOG, "Setting calibration matrix for device {}", PTOUCHDEV->hlName);
+                // default value of transform being -1 means it's unset.
+                const int ROTATION = std::clamp(g_pConfigManager->getDeviceInt(PTOUCHDEV->hlName, "transform", "input:touchdevice:transform"), -1, 7);
+                if (ROTATION > -1)
                     libinput_device_config_calibration_set_matrix(LIBINPUTDEV, MATRICES[ROTATION]);
             }
 


### PR DESCRIPTION

<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
The previous implementation overrides any calibration matrix that is set (like in hwdb), even when `transform` is not set in the config. This PR checks if a calibration matrix is set, and would ignore transforms as they'd already be applied. Otherwise, matrices set by transform are used.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This could also be applied to tablets in `setTabletConfigs` but I haven't tested that.

#### Is it ready for merging, or does it need work?
I believe it is ready.

