### PR TITLE
fix direct scanout glitches

### DIFF
--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -439,9 +439,8 @@ void CWLSurfaceResource::unlockPendingState() {
 }
 
 void CWLSurfaceResource::commitPendingState() {
-    static auto PDROP          = CConfigValue<Hyprlang::INT>("render:allow_early_buffer_release");
-    auto const  previousBuffer = current.buffer;
-    current                    = pending;
+    static auto PDROP = CConfigValue<Hyprlang::INT>("render:allow_early_buffer_release");
+    current           = pending;
     pending.damage.clear();
     pending.bufferDamage.clear();
     pending.newBuffer = false;
@@ -493,15 +492,6 @@ void CWLSurfaceResource::commitPendingState() {
                 surf->events.commit.emit();
             },
             nullptr);
-    }
-
-    // for async buffers, we can only release the buffer once we are unrefing it from current.
-    // if the backend took it, ref it with the lambda. Otherwise, the end of this scope will release it.
-    if (previousBuffer && previousBuffer->buffer && !previousBuffer->buffer->isSynchronous()) {
-        if (previousBuffer->buffer->lockedByBackend && !previousBuffer->buffer->hlEvents.backendRelease) {
-            previousBuffer->buffer->lock();
-            previousBuffer->buffer->unlockOnBufferRelease(self);
-        }
     }
 
     lastBuffer = current.buffer ? current.buffer->buffer : WP<IHLBuffer>{};

--- a/src/protocols/types/Buffer.cpp
+++ b/src/protocols/types/Buffer.cpp
@@ -26,9 +26,14 @@ bool IHLBuffer::locked() {
     return nLocks > 0;
 }
 
-void IHLBuffer::unlockOnBufferRelease(WP<CWLSurfaceResource> surf) {
-    hlEvents.backendRelease = events.backendRelease.registerListener([this](std::any data) {
-        unlock();
+void IHLBuffer::onBackendRelease(const std::function<void()>& fn) {
+    if (hlEvents.backendRelease) {
+        hlEvents.backendRelease->emit(nullptr);
+        Debug::log(LOG, "backendRelease emitted early");
+    }
+
+    hlEvents.backendRelease = events.backendRelease.registerListener([this, fn](std::any) {
+        fn();
         hlEvents.backendRelease.reset();
     });
 }

--- a/src/protocols/types/Buffer.hpp
+++ b/src/protocols/types/Buffer.hpp
@@ -21,7 +21,7 @@ class IHLBuffer : public Aquamarine::IBuffer {
     virtual void                          unlock();
     virtual bool                          locked();
 
-    void                                  unlockOnBufferRelease(WP<CWLSurfaceResource> surf /* optional */);
+    void                                  onBackendRelease(const std::function<void()>& fn);
 
     SP<CTexture>                          texture;
     bool                                  opaque = false;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1486,6 +1486,8 @@ static hdr_output_metadata createHDRMetadata(SImageDescription settings, Aquamar
 }
 
 bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
+    pMonitor->commitSeq++;
+
     // apply timelines for explicit sync
     // save inFD otherwise reset will reset it
     CFileDescriptor inFD{pMonitor->output->state->state().explicitInFence};
@@ -2277,8 +2279,6 @@ bool CHyprRenderer::beginRender(PHLMONITOR pMonitor, CRegion& damage, eRenderMod
 void CHyprRenderer::endRender() {
     const auto  PMONITOR           = g_pHyprOpenGL->m_RenderData.pMonitor;
     static auto PNVIDIAANTIFLICKER = CConfigValue<Hyprlang::INT>("opengl:nvidia_anti_flicker");
-
-    PMONITOR->commitSeq++;
 
     g_pHyprOpenGL->m_RenderData.damage = m_sRenderPass.render(g_pHyprOpenGL->m_RenderData.damage);
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

#### Describe your PR, what does it fix/add?
this fixes direct scanout glitches by ensuring that attemptDirectScanout doesn't try to recommit the same buffer to AQ
which would cause a pageflip event and the backendRelease to release the same buffer too early

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
consider enabling ds by default?
I haven't really looked for other issues
but i remember that the glitches was the blocker for default enabled ds when AQ was merged

#### Is it ready for merging, or does it need work?
yes