### PR TITLE
protocols: Fix blocked color management get_information

### DIFF
--- a/src/protocols/ColorManagement.cpp
+++ b/src/protocols/ColorManagement.cpp
@@ -186,7 +186,7 @@ CColorManager::CColorManager(SP<CWpColorManagerV1> resource) : m_resource(resour
         }
 
         const auto RESOURCE = PROTO::colorManagement->m_vImageDescriptions.emplace_back(
-            makeShared<CColorManagementImageDescription>(makeShared<CWpImageDescriptionV1>(r->client(), r->version(), id)));
+            makeShared<CColorManagementImageDescription>(makeShared<CWpImageDescriptionV1>(r->client(), r->version(), id), false));
 
         if UNLIKELY (!RESOURCE->good()) {
             r->noMemory();
@@ -230,7 +230,7 @@ CColorManagementOutput::CColorManagementOutput(SP<CWpColorManagementOutputV1> re
             PROTO::colorManagement->destroyResource(imageDescription.get());
 
         const auto RESOURCE = PROTO::colorManagement->m_vImageDescriptions.emplace_back(
-            makeShared<CColorManagementImageDescription>(makeShared<CWpImageDescriptionV1>(r->client(), r->version(), id)));
+            makeShared<CColorManagementImageDescription>(makeShared<CWpImageDescriptionV1>(r->client(), r->version(), id), true));
 
         if UNLIKELY (!RESOURCE->good()) {
             r->noMemory();
@@ -448,7 +448,7 @@ CColorManagementIccCreator::CColorManagementIccCreator(SP<CWpImageDescriptionCre
         }
 
         const auto RESOURCE = PROTO::colorManagement->m_vImageDescriptions.emplace_back(
-            makeShared<CColorManagementImageDescription>(makeShared<CWpImageDescriptionV1>(r->client(), r->version(), id)));
+            makeShared<CColorManagementImageDescription>(makeShared<CWpImageDescriptionV1>(r->client(), r->version(), id), false));
 
         if UNLIKELY (!RESOURCE->good()) {
             r->noMemory();
@@ -505,7 +505,7 @@ CColorManagementParametricCreator::CColorManagementParametricCreator(SP<CWpImage
         }
 
         const auto RESOURCE = PROTO::colorManagement->m_vImageDescriptions.emplace_back(
-            makeShared<CColorManagementImageDescription>(makeShared<CWpImageDescriptionV1>(r->client(), r->version(), id)));
+            makeShared<CColorManagementImageDescription>(makeShared<CWpImageDescriptionV1>(r->client(), r->version(), id), false));
 
         if UNLIKELY (!RESOURCE->good()) {
             r->noMemory();

--- a/src/protocols/ColorManagement.hpp
+++ b/src/protocols/ColorManagement.hpp
@@ -138,7 +138,7 @@ class CColorManagementParametricCreator {
 
 class CColorManagementImageDescription {
   public:
-    CColorManagementImageDescription(SP<CWpImageDescriptionV1> resource, bool allowGetInformation = false);
+    CColorManagementImageDescription(SP<CWpImageDescriptionV1> resource, bool allowGetInformation);
 
     bool                                 good();
     wl_client*                           client();

--- a/src/protocols/XXColorManagement.cpp
+++ b/src/protocols/XXColorManagement.cpp
@@ -161,7 +161,7 @@ CXXColorManagementOutput::CXXColorManagementOutput(SP<CXxColorManagementOutputV4
             PROTO::xxColorManagement->destroyResource(imageDescription.get());
 
         const auto RESOURCE = PROTO::xxColorManagement->m_vImageDescriptions.emplace_back(
-            makeShared<CXXColorManagementImageDescription>(makeShared<CXxImageDescriptionV4>(r->client(), r->version(), id)));
+            makeShared<CXXColorManagementImageDescription>(makeShared<CXxImageDescriptionV4>(r->client(), r->version(), id), true));
 
         if UNLIKELY (!RESOURCE->good()) {
             r->noMemory();
@@ -368,7 +368,7 @@ CXXColorManagementParametricCreator::CXXColorManagementParametricCreator(SP<CXxI
         }
 
         const auto RESOURCE = PROTO::xxColorManagement->m_vImageDescriptions.emplace_back(
-            makeShared<CXXColorManagementImageDescription>(makeShared<CXxImageDescriptionV4>(r->client(), r->version(), id)));
+            makeShared<CXXColorManagementImageDescription>(makeShared<CXxImageDescriptionV4>(r->client(), r->version(), id), false));
 
         if UNLIKELY (!RESOURCE->good()) {
             r->noMemory();

--- a/src/protocols/XXColorManagement.hpp
+++ b/src/protocols/XXColorManagement.hpp
@@ -119,7 +119,7 @@ class CXXColorManagementParametricCreator {
 
 class CXXColorManagementImageDescription {
   public:
-    CXXColorManagementImageDescription(SP<CXxImageDescriptionV4> resource_, bool allowGetInformation = false);
+    CXXColorManagementImageDescription(SP<CXxImageDescriptionV4> resource_, bool allowGetInformation);
 
     bool                                   good();
     wl_client*                             client();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

The wayland color_management_v1 protocol specifies that an image description returned by get_image_description should allow the get_information call, but it was previously not allowed in Hyprland's impl by mistake. I also removed the default value of the allowGetInformation parameter because it can very easily be overlooked and cause this issue.

Fixes #9510

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nope, I tested the example reproduction in #9510 and confirmed this fixed it.

#### Is it ready for merging, or does it need work?
Ready for merging