### PR TITLE
fix(window): store floating size on close instead of resize

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1327,11 +1327,6 @@ void CWindow::clampWindowSize(const std::optional<Vector2D> minSize, const std::
 
     *m_vRealPosition = m_vRealPosition->goal() + DELTA / 2.0;
     *m_vRealSize     = NEWSIZE;
-
-    if (m_bIsFloating && !m_bIsX11 && std::any_of(m_vMatchedRules.begin(), m_vMatchedRules.end(), [](const auto& r) { return r->ruleType == CWindowRule::RULE_PERSISTENTSIZE; })) {
-        Debug::log(LOG, "clamped window {}::{} to {}x{} (persistentsize)", m_szClass, m_szTitle, m_vRealSize->value().x, m_vRealSize->value().y);
-        g_pConfigManager->storeFloatingSize(m_pSelf.lock(), m_vRealSize->value());
-    }
 }
 
 bool CWindow::isFullscreen() {

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -716,6 +716,13 @@ void Events::listener_unmapWindow(void* owner, void* data) {
     g_pEventManager->postEvent(SHyprIPCEvent{"closewindow", std::format("{:x}", PWINDOW)});
     EMIT_HOOK_EVENT("closeWindow", PWINDOW);
 
+    if (PWINDOW->m_bIsFloating && !PWINDOW->m_bIsX11 && std::any_of(PWINDOW->m_vMatchedRules.begin(), PWINDOW->m_vMatchedRules.end(),
+        [](const auto& r) { return r->ruleType == CWindowRule::RULE_PERSISTENTSIZE; })) {
+        Debug::log(LOG, "storing floating size {}x{} for window {}::{} on close", PWINDOW->m_vRealSize->value().x, PWINDOW->m_vRealSize->value().y,
+            PWINDOW->m_szClass, PWINDOW->m_szTitle);
+        g_pConfigManager->storeFloatingSize(PWINDOW, PWINDOW->m_vRealSize->value());
+    }
+
     PROTO::toplevelExport->onWindowUnmap(PWINDOW);
 
     if (PWINDOW->isFullscreen())

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -716,10 +716,10 @@ void Events::listener_unmapWindow(void* owner, void* data) {
     g_pEventManager->postEvent(SHyprIPCEvent{"closewindow", std::format("{:x}", PWINDOW)});
     EMIT_HOOK_EVENT("closeWindow", PWINDOW);
 
-    if (PWINDOW->m_bIsFloating && !PWINDOW->m_bIsX11 && std::any_of(PWINDOW->m_vMatchedRules.begin(), PWINDOW->m_vMatchedRules.end(),
-        [](const auto& r) { return r->ruleType == CWindowRule::RULE_PERSISTENTSIZE; })) {
-        Debug::log(LOG, "storing floating size {}x{} for window {}::{} on close", PWINDOW->m_vRealSize->value().x, PWINDOW->m_vRealSize->value().y,
-            PWINDOW->m_szClass, PWINDOW->m_szTitle);
+    if (PWINDOW->m_bIsFloating && !PWINDOW->m_bIsX11 &&
+        std::any_of(PWINDOW->m_vMatchedRules.begin(), PWINDOW->m_vMatchedRules.end(), [](const auto& r) { return r->ruleType == CWindowRule::RULE_PERSISTENTSIZE; })) {
+        Debug::log(LOG, "storing floating size {}x{} for window {}::{} on close", PWINDOW->m_vRealSize->value().x, PWINDOW->m_vRealSize->value().y, PWINDOW->m_szClass,
+                   PWINDOW->m_szTitle);
         g_pConfigManager->storeFloatingSize(PWINDOW, PWINDOW->m_vRealSize->value());
     }
 


### PR DESCRIPTION
minor patch towards b80b64cd6c913f8c8ac820a1e4ca615a62ff958f

storing window size on resize is incorrect because the size can be lost (probably overwritten by something) if a resize event isn't sent