### PR TITLE
fix(window): respect noinitialfocus

### DIFF
--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -349,7 +349,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
             if (!workspaceSilent) {
                 if (pWorkspace->m_bIsSpecialWorkspace)
                     pWorkspace->m_pMonitor->setSpecialWorkspace(pWorkspace);
-                else if (PMONITOR->activeWorkspaceID() != REQUESTEDWORKSPACEID)
+                else if (PMONITOR->activeWorkspaceID() != REQUESTEDWORKSPACEID && !PWINDOW->m_bNoInitialFocus)
                     g_pKeybindManager->m_mDispatchers["workspace"](requestedWorkspaceName);
 
                 PMONITOR = g_pCompositor->m_pLastMonitor.lock();


### PR DESCRIPTION
If a window is specifically placed on another workspace then we should not "focus" that workspace even if the window itself never gets focused when noinitialfocus is enabled for the window.

fixes #9365 
