### PR TITLE
Fix clicking through groupbar tabs

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -296,9 +296,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse) {
                     const auto PWINDOW = HLSurface->getWindow();
                     surfacePos         = BOX->pos();
                     pFoundLayerSurface = HLSurface->getLayer();
-
-                    if (PWINDOW)
-                        pFoundWindow = PWINDOW->isHidden() ? g_pCompositor->m_pLastWindow.lock() : PWINDOW;
+                    pFoundWindow       = !PWINDOW || PWINDOW->isHidden() ? g_pCompositor->m_pLastWindow.lock() : PWINDOW;
                 } else // reset foundSurface, find one normally
                     foundSurface = nullptr;
             } else // reset foundSurface, find one normally

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -295,7 +295,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse) {
                 if (BOX) {
                     surfacePos         = BOX->pos();
                     pFoundLayerSurface = HLSurface->getLayer();
-                    pFoundWindow       = g_pCompositor->m_pLastWindow.lock();
+                    pFoundWindow       = HLSurface->getWindow()->isHidden() ? g_pCompositor->m_pLastWindow.lock() : HLSurface->getWindow();
                 } else // reset foundSurface, find one normally
                     foundSurface = nullptr;
             } else // reset foundSurface, find one normally

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -295,7 +295,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse) {
                 if (BOX) {
                     surfacePos         = BOX->pos();
                     pFoundLayerSurface = HLSurface->getLayer();
-                    pFoundWindow       = HLSurface->getWindow();
+                    pFoundWindow       = g_pCompositor->m_pLastWindow.lock();
                 } else // reset foundSurface, find one normally
                     foundSurface = nullptr;
             } else // reset foundSurface, find one normally

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -293,9 +293,12 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse) {
                 const auto BOX = HLSurface->getSurfaceBoxGlobal();
 
                 if (BOX) {
+                    const auto PWINDOW = HLSurface->getWindow();
                     surfacePos         = BOX->pos();
                     pFoundLayerSurface = HLSurface->getLayer();
-                    pFoundWindow       = HLSurface->getWindow()->isHidden() ? g_pCompositor->m_pLastWindow.lock() : HLSurface->getWindow();
+
+                    if (PWINDOW)
+                        pFoundWindow = PWINDOW->isHidden() ? g_pCompositor->m_pLastWindow.lock() : PWINDOW;
                 } else // reset foundSurface, find one normally
                     foundSurface = nullptr;
             } else // reset foundSurface, find one normally


### PR DESCRIPTION
keeps the focus on the new window rather than the one obtained from the groupbar surface, which is just the previous one

fixes https://github.com/hyprwm/Hyprland/issues/7416