### PR TITLE
XWayland: restore the abstract socket, make it optional, extend the default permissions for the regular X Unix socket

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1319,6 +1319,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .type        = CONFIG_OPTION_BOOL,
         .data        = SConfigOptionDescription::SBoolData{false},
     },
+    SConfigOptionDescription{
+        .value       = "xwayland:create_abstract_socket",
+        .description = "Create the abstract Unix domain socket for XWayland",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{false},
+    },
 
     /*
      * opengl:

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -652,6 +652,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("xwayland:enabled", Hyprlang::INT{1});
     registerConfigVar("xwayland:use_nearest_neighbor", Hyprlang::INT{1});
     registerConfigVar("xwayland:force_zero_scaling", Hyprlang::INT{0});
+    registerConfigVar("xwayland:create_abstract_socket", Hyprlang::INT{0});
 
     registerConfigVar("opengl:nvidia_anti_flicker", Hyprlang::INT{1});
 

--- a/src/xwayland/Server.cpp
+++ b/src/xwayland/Server.cpp
@@ -119,8 +119,15 @@ static bool openSockets(std::array<CFileDescriptor, 2>& sockets, int display) {
     sockaddr_un addr = {.sun_family = AF_UNIX};
     std::string path;
 
+#ifdef __linux__
+    // cursed...
+    addr.sun_path[0] = 0;
+    path             = getSocketPath(display, true);
+    strncpy(addr.sun_path + 1, path.c_str(), path.length() + 1);
+#else
     path = getSocketPath(display, false);
     strncpy(addr.sun_path, path.c_str(), path.length() + 1);
+#endif
 
     sockets[0] = CFileDescriptor{createSocket(&addr, path.length())};
     if (!sockets[0].isValid())


### PR DESCRIPTION
<!--
XWayland: restore the abstract socket, make it optional, extend default permissions for the regular X Unix socket


BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Resolve #9574.

##### XWayland
Roughly removing support for the abstract Unix domain sockets [broke](https://github.com/hyprwm/Hyprland/issues/9574) the `xhost` utility. Moreover, this way potentially has a few [other](https://gitlab.gnome.org/GNOME/mutter/-/issues/1613) [issues](https://gitlab.gnome.org/GNOME/mutter/-/issues/1454) repored in the GNOME tracker.

Keeping that in mind, I made a three changes
* The abstract X Unix domain socket has been restored.
* The abstract X Unix domain socket can now be turned off using the config variable `xwayland:create_abstract_socket`.
* The regular X Unix domain socket's permission mode is set to `0666`. This change ensures `xhost` continues to function when the abstract socket is disabled. And it's safe because XWayland must take care of actual socket ACL.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
* On Linux (with disabled abstract sockets) we create two regular Unix sockets, e.g., `X0` and `X0_`. This corresponds to the current Hyprland behavior, but the second one is unnecessary. It's not a real bug, and fixing it would require rewriting bulk of code, so I've left it as-is.
* I'm not sure sould we set `xwayland:create_abstract_socket` to `false` by default or not.
   * #8874 says yes
   * GNOME [probably](https://gitlab.gnome.org/GNOME/mutter/-/issues/1613) says no
   * atm ~~`true`~~ **`false`** is the default value

#### Is it ready for merging, or does it need work?
It's ready. All changes has been tested.
Only the default value for `xwayland:create_abstract_socket` make me worried a little.
