### PR TITLE
Groupbar: Add options for setting group bar title font weight (and indicator gap)

### DIFF
--- a/src/config/ConfigDataValues.hpp
+++ b/src/config/ConfigDataValues.hpp
@@ -4,10 +4,10 @@
 #include <vector>
 
 enum eConfigValueDataTypes : int8_t {
-    CVD_TYPE_INVALID    = -1,
-    CVD_TYPE_GRADIENT   = 0,
-    CVD_TYPE_CSS_VALUE  = 1,
-    CVD_TYPE_STR_OR_INT = 2,
+    CVD_TYPE_INVALID     = -1,
+    CVD_TYPE_GRADIENT    = 0,
+    CVD_TYPE_CSS_VALUE   = 1,
+    CVD_TYPE_FONT_WEIGHT = 2,
 };
 
 class ICustomConfigValueData {
@@ -143,13 +143,13 @@ class CFontWeightConfigValueData : public ICustomConfigValueData {
     CFontWeightConfigValueData() = default;
     CFontWeightConfigValueData(const char* weight) {
         std::string strWeight = weight;
-        value = parseWeight(strWeight);
+        value                 = parseWeight(strWeight);
     }
 
     int64_t                       value;
 
     virtual eConfigValueDataTypes getDataType() {
-        return CVD_TYPE_STR_OR_INT;
+        return CVD_TYPE_FONT_WEIGHT;
     }
 
     virtual std::string toString() {

--- a/src/config/ConfigDataValues.hpp
+++ b/src/config/ConfigDataValues.hpp
@@ -4,9 +4,10 @@
 #include <vector>
 
 enum eConfigValueDataTypes : int8_t {
-    CVD_TYPE_INVALID   = -1,
-    CVD_TYPE_GRADIENT  = 0,
-    CVD_TYPE_CSS_VALUE = 1
+    CVD_TYPE_INVALID    = -1,
+    CVD_TYPE_GRADIENT   = 0,
+    CVD_TYPE_CSS_VALUE  = 1,
+    CVD_TYPE_STR_OR_INT = 2,
 };
 
 class ICustomConfigValueData {
@@ -134,5 +135,20 @@ class CCssGapData : public ICustomConfigValueData {
 
     virtual std::string toString() {
         return std::format("{} {} {} {}", m_top, m_right, m_bottom, m_left);
+    }
+};
+
+class CStringOrInt : public ICustomConfigValueData {
+  public:
+    CStringOrInt() = default;
+
+    int64_t                       value;
+
+    virtual eConfigValueDataTypes getDataType() {
+        return CVD_TYPE_STR_OR_INT;
+    }
+
+    virtual std::string toString() {
+        return std::format("{}", value);
     }
 };

--- a/src/config/ConfigDataValues.hpp
+++ b/src/config/ConfigDataValues.hpp
@@ -2,6 +2,7 @@
 #include "../defines.hpp"
 #include "../helpers/varlist/VarList.hpp"
 #include <vector>
+#include <map>
 
 enum eConfigValueDataTypes : int8_t {
     CVD_TYPE_INVALID     = -1,
@@ -145,14 +146,14 @@ class CFontWeightConfigValueData : public ICustomConfigValueData {
         parseWeight(weight);
     }
 
-    int64_t                       value = 400; // default to normal weight
+    int64_t                       m_value = 400; // default to normal weight
 
     virtual eConfigValueDataTypes getDataType() {
         return CVD_TYPE_FONT_WEIGHT;
     }
 
     virtual std::string toString() {
-        return std::format("{}", value);
+        return std::format("{}", m_value);
     }
 
     void parseWeight(const std::string& strWeight) {
@@ -167,11 +168,11 @@ class CFontWeightConfigValueData : public ICustomConfigValueData {
 
         auto weight = WEIGHTS.find(lcWeight);
         if (weight != WEIGHTS.end())
-            value = weight->second;
+            m_value = weight->second;
         else {
             int w_i = std::stoi(strWeight);
             if (w_i < 100 || w_i > 1000)
-                value = 400;
+                m_value = 400;
         }
     }
 };

--- a/src/config/ConfigDataValues.hpp
+++ b/src/config/ConfigDataValues.hpp
@@ -142,8 +142,7 @@ class CFontWeightConfigValueData : public ICustomConfigValueData {
   public:
     CFontWeightConfigValueData() = default;
     CFontWeightConfigValueData(const char* weight) {
-        std::string strWeight = weight;
-        value                 = parseWeight(strWeight);
+        parseWeight(weight);
     }
 
     int64_t                       value;
@@ -156,40 +155,23 @@ class CFontWeightConfigValueData : public ICustomConfigValueData {
         return std::format("{}", value);
     }
 
-    static int parseWeight(const std::string& weight) {
-        auto loWeight{weight};
-        transform(weight.begin(), weight.end(), loWeight.begin(), ::tolower);
+    void parseWeight(const std::string& strWeight) {
+        auto lcWeight{strWeight};
+        transform(strWeight.begin(), strWeight.end(), lcWeight.begin(), ::tolower);
 
         // values taken from Pango weight enums
-        if (loWeight == "thin")
-            return 100;
-        if (loWeight == "ultralight")
-            return 200;
-        if (loWeight == "light")
-            return 300;
-        if (loWeight == "semilight")
-            return 350;
-        if (loWeight == "book")
-            return 380;
-        if (loWeight == "normal")
-            return 400;
-        if (loWeight == "medium")
-            return 500;
-        if (loWeight == "semibold")
-            return 600;
-        if (loWeight == "bold")
-            return 700;
-        if (loWeight == "ultrabold")
-            return 800;
-        if (loWeight == "heavy")
-            return 900;
-        if (loWeight == "ultraheavy")
-            return 1000;
+        const auto WEIGHTS = std::map<std::string, int>{
+            {"thin", 100},   {"ultralight", 200}, {"light", 300}, {"semilight", 350}, {"book", 380},  {"normal", 400},
+            {"medium", 500}, {"semibold", 600},   {"bold", 700},  {"ultrabold", 800}, {"heavy", 900}, {"ultraheavy", 1000},
+        };
 
-        int w_i = std::stoi(weight);
-        if (w_i < 100 || w_i > 1000)
-            return 400;
-
-        return w_i;
+        auto weight = WEIGHTS.find(lcWeight);
+        if (weight != WEIGHTS.end())
+            value = weight->second;
+        else {
+            int w_i = std::stoi(strWeight);
+            if (w_i < 100 || w_i > 1000)
+                value = 400;
+        }
     }
 };

--- a/src/config/ConfigDataValues.hpp
+++ b/src/config/ConfigDataValues.hpp
@@ -138,9 +138,13 @@ class CCssGapData : public ICustomConfigValueData {
     }
 };
 
-class CStringOrInt : public ICustomConfigValueData {
+class CFontWeightConfigValueData : public ICustomConfigValueData {
   public:
-    CStringOrInt() = default;
+    CFontWeightConfigValueData() = default;
+    CFontWeightConfigValueData(const char* weight) {
+        std::string strWeight = weight;
+        value = parseWeight(strWeight);
+    }
 
     int64_t                       value;
 
@@ -150,5 +154,42 @@ class CStringOrInt : public ICustomConfigValueData {
 
     virtual std::string toString() {
         return std::format("{}", value);
+    }
+
+    static int parseWeight(const std::string& weight) {
+        auto loWeight{weight};
+        transform(weight.begin(), weight.end(), loWeight.begin(), ::tolower);
+
+        // values taken from Pango weight enums
+        if (loWeight == "thin")
+            return 100;
+        if (loWeight == "ultralight")
+            return 200;
+        if (loWeight == "light")
+            return 300;
+        if (loWeight == "semilight")
+            return 350;
+        if (loWeight == "book")
+            return 380;
+        if (loWeight == "normal")
+            return 400;
+        if (loWeight == "medium")
+            return 500;
+        if (loWeight == "semibold")
+            return 600;
+        if (loWeight == "bold")
+            return 700;
+        if (loWeight == "ultrabold")
+            return 800;
+        if (loWeight == "heavy")
+            return 900;
+        if (loWeight == "ultraheavy")
+            return 1000;
+
+        int w_i = std::stoi(weight);
+        if (w_i < 100 || w_i > 1000)
+            return 400;
+
+        return w_i;
     }
 };

--- a/src/config/ConfigDataValues.hpp
+++ b/src/config/ConfigDataValues.hpp
@@ -145,7 +145,7 @@ class CFontWeightConfigValueData : public ICustomConfigValueData {
         parseWeight(weight);
     }
 
-    int64_t                       value;
+    int64_t                       value = 400; // default to normal weight
 
     virtual eConfigValueDataTypes getDataType() {
         return CVD_TYPE_FONT_WEIGHT;

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -928,6 +928,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SRangeData{14, 1, 64},
     },
     SConfigOptionDescription{
+        .value       = "group:groupbar:indicator_gap",
+        .description = "height of the gap between the groupbar indicator and title",
+        .type        = CONFIG_OPTION_INT,
+        .data        = SConfigOptionDescription::SRangeData{0, 0, 64},
+    },
+    SConfigOptionDescription{
         .value       = "group:groupbar:indicator_height",
         .description = "height of the groupbar indicator",
         .type        = CONFIG_OPTION_INT,

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -898,6 +898,18 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SStringData{STRVAL_EMPTY}, //##TODO UNSET?
     },
     SConfigOptionDescription{
+        .value       = "group:groupbar:font_weight_active",
+        .description = "weight of the font used to display active groupbar titles",
+        .type        = CONFIG_OPTION_STRING_SHORT,
+        .data        = SConfigOptionDescription::SStringData{"normal"},
+    },
+    SConfigOptionDescription{
+        .value       = "group:groupbar:font_weight_inactive",
+        .description = "weight of the font used to display inactive groupbar titles",
+        .type        = CONFIG_OPTION_STRING_SHORT,
+        .data        = SConfigOptionDescription::SStringData{"normal"},
+    },
+    SConfigOptionDescription{
         .value       = "group:groupbar:font_size",
         .description = "font size of groupbar title",
         .type        = CONFIG_OPTION_INT,

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -148,22 +148,34 @@ static void configHandleGapDestroy(void** data) {
 }
 
 static int strToPangoWeight(const std::string& weight) {
-    auto loWeight {weight};
+    auto loWeight{weight};
     transform(weight.begin(), weight.end(), loWeight.begin(), ::tolower);
-    
+
     // values taken from Pango weight enums
-    if (loWeight == "thin")       return 100;
-    if (loWeight == "ultralight") return 200;
-    if (loWeight == "light")      return 300;
-    if (loWeight == "semilight")  return 350;
-    if (loWeight == "book")       return 380;
-    if (loWeight == "normal")     return 400;
-    if (loWeight == "medium")     return 500;
-    if (loWeight == "semibold")   return 600;
-    if (loWeight == "bold")       return 700;
-    if (loWeight == "ultrabold")  return 800;
-    if (loWeight == "heavy")      return 900;
-    if (loWeight == "ultraheavy") return 1000;
+    if (loWeight == "thin")
+        return 100;
+    if (loWeight == "ultralight")
+        return 200;
+    if (loWeight == "light")
+        return 300;
+    if (loWeight == "semilight")
+        return 350;
+    if (loWeight == "book")
+        return 380;
+    if (loWeight == "normal")
+        return 400;
+    if (loWeight == "medium")
+        return 500;
+    if (loWeight == "semibold")
+        return 600;
+    if (loWeight == "bold")
+        return 700;
+    if (loWeight == "ultrabold")
+        return 800;
+    if (loWeight == "heavy")
+        return 900;
+    if (loWeight == "ultraheavy")
+        return 1000;
 
     int w_i = std::stoi(weight);
     if (w_i < 100 || w_i > 1000)
@@ -177,7 +189,7 @@ static Hyprlang::CParseResult configHandleFontWeightSet(const char* VALUE, void*
 
     if (!*data)
         *data = new int;
-        
+
     const auto             DATA = reinterpret_cast<Hyprlang::INT*>(*data);
     Hyprlang::CParseResult result;
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -147,54 +147,17 @@ static void configHandleGapDestroy(void** data) {
         delete reinterpret_cast<CCssGapData*>(*data);
 }
 
-static int strToPangoWeight(const std::string& weight) {
-    auto loWeight{weight};
-    transform(weight.begin(), weight.end(), loWeight.begin(), ::tolower);
-
-    // values taken from Pango weight enums
-    if (loWeight == "thin")
-        return 100;
-    if (loWeight == "ultralight")
-        return 200;
-    if (loWeight == "light")
-        return 300;
-    if (loWeight == "semilight")
-        return 350;
-    if (loWeight == "book")
-        return 380;
-    if (loWeight == "normal")
-        return 400;
-    if (loWeight == "medium")
-        return 500;
-    if (loWeight == "semibold")
-        return 600;
-    if (loWeight == "bold")
-        return 700;
-    if (loWeight == "ultrabold")
-        return 800;
-    if (loWeight == "heavy")
-        return 900;
-    if (loWeight == "ultraheavy")
-        return 1000;
-
-    int w_i = std::stoi(weight);
-    if (w_i < 100 || w_i > 1000)
-        return 400;
-
-    return w_i;
-}
-
 static Hyprlang::CParseResult configHandleFontWeightSet(const char* VALUE, void** data) {
     std::string V = VALUE;
 
     if (!*data)
-        *data = new CStringOrInt();
+        *data = new CFontWeightConfigValueData();
 
-    const auto             DATA = reinterpret_cast<CStringOrInt*>(*data);
+    const auto             DATA = reinterpret_cast<CFontWeightConfigValueData*>(*data);
     Hyprlang::CParseResult result;
 
     try {
-        DATA->value = strToPangoWeight(V);
+        DATA->value = CFontWeightConfigValueData::parseWeight(V);
     } catch (...) {
         std::string parseError = std::format("{} is not a valid font weight", V);
         result.setError(parseError.c_str());
@@ -205,7 +168,7 @@ static Hyprlang::CParseResult configHandleFontWeightSet(const char* VALUE, void*
 
 static void configHandleFontWeightDestroy(void** data) {
     if (*data)
-        delete reinterpret_cast<CStringOrInt*>(*data);
+        delete reinterpret_cast<CFontWeightConfigValueData*>(*data);
 }
 
 static Hyprlang::CParseResult handleExec(const char* c, const char* v) {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -188,13 +188,13 @@ static Hyprlang::CParseResult configHandleFontWeightSet(const char* VALUE, void*
     std::string V = VALUE;
 
     if (!*data)
-        *data = new int;
+        *data = new CStringOrInt();
 
-    const auto             DATA = reinterpret_cast<Hyprlang::INT*>(*data);
+    const auto             DATA = reinterpret_cast<CStringOrInt*>(*data);
     Hyprlang::CParseResult result;
 
     try {
-        *DATA = strToPangoWeight(V);
+        DATA->value = strToPangoWeight(V);
     } catch (...) {
         std::string parseError = std::format("{} is not a valid font weight", V);
         result.setError(parseError.c_str());
@@ -205,7 +205,7 @@ static Hyprlang::CParseResult configHandleFontWeightSet(const char* VALUE, void*
 
 static void configHandleFontWeightDestroy(void** data) {
     if (*data)
-        delete reinterpret_cast<Hyprlang::INT*>(*data);
+        delete reinterpret_cast<CStringOrInt*>(*data);
 }
 
 static Hyprlang::CParseResult handleExec(const char* c, const char* v) {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -539,6 +539,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("group:groupbar:font_size", Hyprlang::INT{8});
     registerConfigVar("group:groupbar:gradients", Hyprlang::INT{0});
     registerConfigVar("group:groupbar:height", Hyprlang::INT{14});
+    registerConfigVar("group:groupbar:indicator_gap", Hyprlang::INT{0});
     registerConfigVar("group:groupbar:indicator_height", Hyprlang::INT{3});
     registerConfigVar("group:groupbar:priority", Hyprlang::INT{3});
     registerConfigVar("group:groupbar:render_titles", Hyprlang::INT{1});

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -147,6 +147,55 @@ static void configHandleGapDestroy(void** data) {
         delete reinterpret_cast<CCssGapData*>(*data);
 }
 
+static int strToPangoWeight(const std::string& weight) {
+    auto loWeight {weight};
+    transform(weight.begin(), weight.end(), loWeight.begin(), ::tolower);
+    
+    // values taken from Pango weight enums
+    if (loWeight == "thin")       return 100;
+    if (loWeight == "ultralight") return 200;
+    if (loWeight == "light")      return 300;
+    if (loWeight == "semilight")  return 350;
+    if (loWeight == "book")       return 380;
+    if (loWeight == "normal")     return 400;
+    if (loWeight == "medium")     return 500;
+    if (loWeight == "semibold")   return 600;
+    if (loWeight == "bold")       return 700;
+    if (loWeight == "ultrabold")  return 800;
+    if (loWeight == "heavy")      return 900;
+    if (loWeight == "ultraheavy") return 1000;
+
+    int w_i = std::stoi(weight);
+    if (w_i < 100 || w_i > 1000)
+        return 400;
+
+    return w_i;
+}
+
+static Hyprlang::CParseResult configHandleFontWeightSet(const char* VALUE, void** data) {
+    std::string V = VALUE;
+
+    if (!*data)
+        *data = new int;
+        
+    const auto             DATA = reinterpret_cast<Hyprlang::INT*>(*data);
+    Hyprlang::CParseResult result;
+
+    try {
+        *DATA = strToPangoWeight(V);
+    } catch (...) {
+        std::string parseError = std::format("{} is not a valid font weight", V);
+        result.setError(parseError.c_str());
+    }
+
+    return result;
+}
+
+static void configHandleFontWeightDestroy(void** data) {
+    if (*data)
+        delete reinterpret_cast<Hyprlang::INT*>(*data);
+}
+
 static Hyprlang::CParseResult handleExec(const char* c, const char* v) {
     const std::string      VALUE   = v;
     const std::string      COMMAND = c;
@@ -485,6 +534,8 @@ CConfigManager::CConfigManager() {
     registerConfigVar("group:group_on_movetoworkspace", Hyprlang::INT{0});
     registerConfigVar("group:groupbar:enabled", Hyprlang::INT{1});
     registerConfigVar("group:groupbar:font_family", {STRVAL_EMPTY});
+    registerConfigVar("group:groupbar:font_weight_active", Hyprlang::CConfigCustomValueType{&configHandleFontWeightSet, configHandleFontWeightDestroy, "normal"});
+    registerConfigVar("group:groupbar:font_weight_inactive", Hyprlang::CConfigCustomValueType{&configHandleFontWeightSet, configHandleFontWeightDestroy, "normal"});
     registerConfigVar("group:groupbar:font_size", Hyprlang::INT{8});
     registerConfigVar("group:groupbar:gradients", Hyprlang::INT{0});
     registerConfigVar("group:groupbar:height", Hyprlang::INT{14});

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -148,8 +148,6 @@ static void configHandleGapDestroy(void** data) {
 }
 
 static Hyprlang::CParseResult configHandleFontWeightSet(const char* VALUE, void** data) {
-    std::string V = VALUE;
-
     if (!*data)
         *data = new CFontWeightConfigValueData();
 
@@ -157,9 +155,9 @@ static Hyprlang::CParseResult configHandleFontWeightSet(const char* VALUE, void*
     Hyprlang::CParseResult result;
 
     try {
-        DATA->value = CFontWeightConfigValueData::parseWeight(V);
+        DATA->parseWeight(VALUE);
     } catch (...) {
-        std::string parseError = std::format("{} is not a valid font weight", V);
+        std::string parseError = std::format("{} is not a valid font weight", VALUE);
         result.setError(parseError.c_str());
     }
 

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -2712,7 +2712,7 @@ SP<CTexture> CHyprOpenGLImpl::loadAsset(const std::string& filename) {
     cairo_surface_destroy(CAIROSURFACE);
 
     return tex;
-}    
+}
 
 SP<CTexture> CHyprOpenGLImpl::renderText(const std::string& text, CHyprColor col, int pt, bool italic, const std::string& fontFamily, int maxWidth, int weight) {
     SP<CTexture>          tex = makeShared<CTexture>();

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -2712,9 +2712,9 @@ SP<CTexture> CHyprOpenGLImpl::loadAsset(const std::string& filename) {
     cairo_surface_destroy(CAIROSURFACE);
 
     return tex;
-}
+}    
 
-SP<CTexture> CHyprOpenGLImpl::renderText(const std::string& text, CHyprColor col, int pt, bool italic, const std::string& fontFamily, int maxWidth) {
+SP<CTexture> CHyprOpenGLImpl::renderText(const std::string& text, CHyprColor col, int pt, bool italic, const std::string& fontFamily, int maxWidth, int weight) {
     SP<CTexture>          tex = makeShared<CTexture>();
 
     static auto           FONT = CConfigValue<std::string>("misc:font_family");
@@ -2732,7 +2732,7 @@ SP<CTexture> CHyprOpenGLImpl::renderText(const std::string& text, CHyprColor col
     pango_font_description_set_family_static(pangoFD, FONTFAMILY.c_str());
     pango_font_description_set_absolute_size(pangoFD, FONTSIZE * PANGO_SCALE);
     pango_font_description_set_style(pangoFD, italic ? PANGO_STYLE_ITALIC : PANGO_STYLE_NORMAL);
-    pango_font_description_set_weight(pangoFD, PANGO_WEIGHT_NORMAL);
+    pango_font_description_set_weight(pangoFD, static_cast<PangoWeight>(weight));
     pango_layout_set_font_description(layoutText, pangoFD);
 
     cairo_set_source_rgba(CAIRO, COLOR.r, COLOR.g, COLOR.b, COLOR.a);
@@ -2763,7 +2763,7 @@ SP<CTexture> CHyprOpenGLImpl::renderText(const std::string& text, CHyprColor col
     pango_font_description_set_family_static(pangoFD, FONTFAMILY.c_str());
     pango_font_description_set_absolute_size(pangoFD, FONTSIZE * PANGO_SCALE);
     pango_font_description_set_style(pangoFD, italic ? PANGO_STYLE_ITALIC : PANGO_STYLE_NORMAL);
-    pango_font_description_set_weight(pangoFD, PANGO_WEIGHT_NORMAL);
+    pango_font_description_set_weight(pangoFD, static_cast<PangoWeight>(weight));
     pango_layout_set_font_description(layoutText, pangoFD);
     pango_layout_set_text(layoutText, text.c_str(), -1);
 

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -225,7 +225,7 @@ class CHyprOpenGLImpl {
     void bindBackOnMain();
 
     SP<CTexture>                         loadAsset(const std::string& file);
-    SP<CTexture>                         renderText(const std::string& text, CHyprColor col, int pt, bool italic = false, const std::string& fontFamily = "", int maxWidth = 0);
+    SP<CTexture>                         renderText(const std::string& text, CHyprColor col, int pt, bool italic = false, const std::string& fontFamily = "", int maxWidth = 0, int weight = 400);
 
     void                                 setDamage(const CRegion& damage, std::optional<CRegion> finalDamage = {});
 

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -224,35 +224,35 @@ class CHyprOpenGLImpl {
     void renderOffToMain(CFramebuffer* off);
     void bindBackOnMain();
 
-    SP<CTexture>                         loadAsset(const std::string& file);
-    SP<CTexture>                         renderText(const std::string& text, CHyprColor col, int pt, bool italic = false, const std::string& fontFamily = "", int maxWidth = 0, int weight = 400);
+    SP<CTexture> loadAsset(const std::string& file);
+    SP<CTexture> renderText(const std::string& text, CHyprColor col, int pt, bool italic = false, const std::string& fontFamily = "", int maxWidth = 0, int weight = 400);
 
-    void                                 setDamage(const CRegion& damage, std::optional<CRegion> finalDamage = {});
+    void         setDamage(const CRegion& damage, std::optional<CRegion> finalDamage = {});
 
-    void                                 ensureBackgroundTexturePresence();
+    void         ensureBackgroundTexturePresence();
 
-    uint32_t                             getPreferredReadFormat(PHLMONITOR pMonitor);
-    std::vector<SDRMFormat>              getDRMFormats();
-    EGLImageKHR                          createEGLImage(const Aquamarine::SDMABUFAttrs& attrs);
-    SP<CEGLSync>                         createEGLSync(int fence = -1);
+    uint32_t     getPreferredReadFormat(PHLMONITOR pMonitor);
+    std::vector<SDRMFormat>                     getDRMFormats();
+    EGLImageKHR                                 createEGLImage(const Aquamarine::SDMABUFAttrs& attrs);
+    SP<CEGLSync>                                createEGLSync(int fence = -1);
 
-    bool                                 initShaders();
-    bool                                 m_bShadersInitialized = false;
-    SP<SPreparedShaders>                 m_shaders;
+    bool                                        initShaders();
+    bool                                        m_bShadersInitialized = false;
+    SP<SPreparedShaders>                        m_shaders;
 
-    SCurrentRenderData                   m_RenderData;
+    SCurrentRenderData                          m_RenderData;
 
-    Hyprutils::OS::CFileDescriptor       m_iGBMFD;
-    gbm_device*                          m_pGbmDevice   = nullptr;
-    EGLContext                           m_pEglContext  = nullptr;
-    EGLDisplay                           m_pEglDisplay  = nullptr;
-    EGLDeviceEXT                         m_pEglDevice   = nullptr;
-    uint                                 failedAssetsNo = 0;
+    Hyprutils::OS::CFileDescriptor              m_iGBMFD;
+    gbm_device*                                 m_pGbmDevice   = nullptr;
+    EGLContext                                  m_pEglContext  = nullptr;
+    EGLDisplay                                  m_pEglDisplay  = nullptr;
+    EGLDeviceEXT                                m_pEglDevice   = nullptr;
+    uint                                        failedAssetsNo = 0;
 
-    bool                                 m_bReloadScreenShader = true; // at launch it can be set
+    bool                                        m_bReloadScreenShader = true; // at launch it can be set
 
-    std::map<PHLWINDOWREF, CFramebuffer> m_mWindowFramebuffers;
-    std::map<PHLLSREF, CFramebuffer>     m_mLayerFramebuffers;
+    std::map<PHLWINDOWREF, CFramebuffer>        m_mWindowFramebuffers;
+    std::map<PHLLSREF, CFramebuffer>            m_mLayerFramebuffers;
     std::map<PHLMONITORREF, SMonitorRenderData> m_mMonitorRenderResources;
     std::map<PHLMONITORREF, CFramebuffer>       m_mMonitorBGFBs;
 

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -285,14 +285,14 @@ CTitleTex::CTitleTex(PHLWINDOW pWindow, const Vector2D& bufferSize, const float 
     static auto      PTITLEFONTWEIGHTACTIVE   = CConfigValue<Hyprlang::CUSTOMTYPE>("group:groupbar:font_weight_active");
     static auto      PTITLEFONTWEIGHTINACTIVE = CConfigValue<Hyprlang::CUSTOMTYPE>("group:groupbar:font_weight_inactive");
 
-    const auto       FONTWEIGHTACTIVE   = (Hyprlang::INT*)(PTITLEFONTWEIGHTACTIVE.ptr())->getData();
-    const auto       FONTWEIGHTINACTIVE = (Hyprlang::INT*)(PTITLEFONTWEIGHTINACTIVE.ptr())->getData();
+    const auto       FONTWEIGHTACTIVE   = (CStringOrInt*)(PTITLEFONTWEIGHTACTIVE.ptr())->getData();
+    const auto       FONTWEIGHTINACTIVE = (CStringOrInt*)(PTITLEFONTWEIGHTINACTIVE.ptr())->getData();
 
     const CHyprColor COLOR      = CHyprColor(*PTEXTCOLOR);
     const auto       FONTFAMILY = *PTITLEFONTFAMILY != STRVAL_EMPTY ? *PTITLEFONTFAMILY : *FALLBACKFONT;
 
-    texActive = g_pHyprOpenGL->renderText(pWindow->m_szTitle, COLOR, *PTITLEFONTSIZE * monitorScale, false, FONTFAMILY, bufferSize.x - 2 /* some padding yk */, *FONTWEIGHTACTIVE);
-    texInactive = g_pHyprOpenGL->renderText(pWindow->m_szTitle, COLOR, *PTITLEFONTSIZE * monitorScale, false, FONTFAMILY, bufferSize.x - 2 /* some padding yk */, *FONTWEIGHTINACTIVE);
+    texActive = g_pHyprOpenGL->renderText(pWindow->m_szTitle, COLOR, *PTITLEFONTSIZE * monitorScale, false, FONTFAMILY, bufferSize.x - 2 /* some padding yk */, FONTWEIGHTACTIVE->value);
+    texInactive = g_pHyprOpenGL->renderText(pWindow->m_szTitle, COLOR, *PTITLEFONTSIZE * monitorScale, false, FONTFAMILY, bufferSize.x - 2 /* some padding yk */, FONTWEIGHTINACTIVE->value);
 }
 
 static void renderGradientTo(SP<CTexture> tex, CGradientValueData* grad) {

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -285,8 +285,8 @@ CTitleTex::CTitleTex(PHLWINDOW pWindow, const Vector2D& bufferSize, const float 
     static auto      PTITLEFONTWEIGHTACTIVE   = CConfigValue<Hyprlang::CUSTOMTYPE>("group:groupbar:font_weight_active");
     static auto      PTITLEFONTWEIGHTINACTIVE = CConfigValue<Hyprlang::CUSTOMTYPE>("group:groupbar:font_weight_inactive");
 
-    const auto       FONTWEIGHTACTIVE   = (CStringOrInt*)(PTITLEFONTWEIGHTACTIVE.ptr())->getData();
-    const auto       FONTWEIGHTINACTIVE = (CStringOrInt*)(PTITLEFONTWEIGHTINACTIVE.ptr())->getData();
+    const auto       FONTWEIGHTACTIVE   = (CFontWeightConfigValueData*)(PTITLEFONTWEIGHTACTIVE.ptr())->getData();
+    const auto       FONTWEIGHTINACTIVE = (CFontWeightConfigValueData*)(PTITLEFONTWEIGHTINACTIVE.ptr())->getData();
 
     const CHyprColor COLOR      = CHyprColor(*PTEXTCOLOR);
     const auto       FONTFAMILY = *PTITLEFONTFAMILY != STRVAL_EMPTY ? *PTITLEFONTFAMILY : *FALLBACKFONT;

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -238,7 +238,7 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
                                                                 Vector2D{m_fBarWidth * pMonitor->scale, (*PTITLEFONTSIZE + 2L * BAR_TEXT_PAD) * pMonitor->scale}, pMonitor->scale))
                             .get();
 
-                const auto titleTex = m_dwGroupMembers[WINDOWINDEX] == g_pCompositor->m_pLastWindow ? pTitleTex->texActive : pTitleTex->texInactive;
+                const auto titleTex = m_dwGroupMembers[WINDOWINDEX] == g_pCompositor->m_lastWindow ? pTitleTex->texActive : pTitleTex->texInactive;
                 rect.y += std::ceil(((rect.height - titleTex->m_vSize.y) / 2.0) - (*PTEXTOFFSET * pMonitor->scale));
                 rect.height = titleTex->m_vSize.y;
                 rect.width  = titleTex->m_vSize.x;
@@ -291,8 +291,8 @@ CTitleTex::CTitleTex(PHLWINDOW pWindow, const Vector2D& bufferSize, const float 
     const CHyprColor COLOR      = CHyprColor(*PTEXTCOLOR);
     const auto       FONTFAMILY = *PTITLEFONTFAMILY != STRVAL_EMPTY ? *PTITLEFONTFAMILY : *FALLBACKFONT;
 
-    texActive = g_pHyprOpenGL->renderText(pWindow->m_szTitle, COLOR, *PTITLEFONTSIZE * monitorScale, false, FONTFAMILY, bufferSize.x - 2 /* some padding yk */, FONTWEIGHTACTIVE->value);
-    texInactive = g_pHyprOpenGL->renderText(pWindow->m_szTitle, COLOR, *PTITLEFONTSIZE * monitorScale, false, FONTFAMILY, bufferSize.x - 2 /* some padding yk */, FONTWEIGHTINACTIVE->value);
+    texActive   = g_pHyprOpenGL->renderText(pWindow->m_szTitle, COLOR, *PTITLEFONTSIZE * monitorScale, false, FONTFAMILY, bufferSize.x - 2, FONTWEIGHTACTIVE->m_value);
+    texInactive = g_pHyprOpenGL->renderText(pWindow->m_szTitle, COLOR, *PTITLEFONTSIZE * monitorScale, false, FONTFAMILY, bufferSize.x - 2, FONTWEIGHTINACTIVE->m_value);
 }
 
 static void renderGradientTo(SP<CTexture> tex, CGradientValueData* grad) {

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -27,6 +27,7 @@ CHyprGroupBarDecoration::CHyprGroupBarDecoration(PHLWINDOW pWindow) : IHyprWindo
 
 SDecorationPositioningInfo CHyprGroupBarDecoration::getPositioningInfo() {
     static auto                PHEIGHT          = CConfigValue<Hyprlang::INT>("group:groupbar:height");
+    static auto                PINDICATORGAP    = CConfigValue<Hyprlang::INT>("group:groupbar:indicator_gap");
     static auto                PINDICATORHEIGHT = CConfigValue<Hyprlang::INT>("group:groupbar:indicator_height");
     static auto                PENABLED         = CConfigValue<Hyprlang::INT>("group:groupbar:enabled");
     static auto                PRENDERTITLES    = CConfigValue<Hyprlang::INT>("group:groupbar:render_titles");
@@ -44,10 +45,10 @@ SDecorationPositioningInfo CHyprGroupBarDecoration::getPositioningInfo() {
 
     if (*PENABLED && m_pWindow->m_sWindowData.decorate.valueOrDefault()) {
         if (*PSTACKED) {
-            const auto ONEBARHEIGHT = *POUTERGAP + *PINDICATORHEIGHT + (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0);
+            const auto ONEBARHEIGHT = *POUTERGAP + *PINDICATORHEIGHT + *PINDICATORGAP + (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0);
             info.desiredExtents     = {{0, (ONEBARHEIGHT * m_dwGroupMembers.size()) + (*PKEEPUPPERGAP * *POUTERGAP)}, {0, 0}};
         } else
-            info.desiredExtents = {{0, *POUTERGAP * (1 + *PKEEPUPPERGAP) + *PINDICATORHEIGHT + (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0)}, {0, 0}};
+            info.desiredExtents = {{0, *POUTERGAP * (1 + *PKEEPUPPERGAP) + *PINDICATORHEIGHT + *PINDICATORGAP + (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0)}, {0, 0}};
     } else
         info.desiredExtents = {{0, 0}, {0, 0}};
     return info;
@@ -105,6 +106,7 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
     static auto PRENDERTITLES              = CConfigValue<Hyprlang::INT>("group:groupbar:render_titles");
     static auto PTITLEFONTSIZE             = CConfigValue<Hyprlang::INT>("group:groupbar:font_size");
     static auto PHEIGHT                    = CConfigValue<Hyprlang::INT>("group:groupbar:height");
+    static auto PINDICATORGAP              = CConfigValue<Hyprlang::INT>("group:groupbar:indicator_gap");
     static auto PINDICATORHEIGHT           = CConfigValue<Hyprlang::INT>("group:groupbar:indicator_height");
     static auto PGRADIENTS                 = CConfigValue<Hyprlang::INT>("group:groupbar:gradients");
     static auto PSTACKED                   = CConfigValue<Hyprlang::INT>("group:groupbar:stacked");
@@ -127,7 +129,7 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
 
     const auto  ASSIGNEDBOX = assignedBoxGlobal();
 
-    const auto  ONEBARHEIGHT = *POUTERGAP + *PINDICATORHEIGHT + (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0);
+    const auto  ONEBARHEIGHT = *POUTERGAP + *PINDICATORHEIGHT + *PINDICATORGAP + (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0);
     m_fBarWidth              = *PSTACKED ? ASSIGNEDBOX.w : (ASSIGNEDBOX.w - *PINNERGAP * (barsToDraw - 1)) / barsToDraw;
     m_fBarHeight             = *PSTACKED ? ((ASSIGNEDBOX.h - *POUTERGAP * *PKEEPUPPERGAP) - *POUTERGAP * (barsToDraw)) / barsToDraw : ASSIGNEDBOX.h - *POUTERGAP * *PKEEPUPPERGAP;
 
@@ -141,7 +143,7 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
     for (int i = 0; i < barsToDraw; ++i) {
         const auto WINDOWINDEX = *PSTACKED ? m_dwGroupMembers.size() - i - 1 : i;
 
-        CBox       rect = {ASSIGNEDBOX.x + floor(xoff) - pMonitor->vecPosition.x + m_pWindow->m_vFloatingOffset.x,
+        CBox       rect = {ASSIGNEDBOX.x + xoff - pMonitor->vecPosition.x + m_pWindow->m_vFloatingOffset.x,
                            ASSIGNEDBOX.y + ASSIGNEDBOX.h - floor(yoff) - *PINDICATORHEIGHT - *POUTERGAP - pMonitor->vecPosition.y + m_pWindow->m_vFloatingOffset.y, m_fBarWidth,
                            *PINDICATORHEIGHT};
 
@@ -185,7 +187,7 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
             g_pHyprRenderer->m_sRenderPass.add(makeShared<CRectPassElement>(rectdata));
         }
 
-        rect = {ASSIGNEDBOX.x + floor(xoff) - pMonitor->vecPosition.x + m_pWindow->m_vFloatingOffset.x,
+        rect = {ASSIGNEDBOX.x + xoff - pMonitor->vecPosition.x + m_pWindow->m_vFloatingOffset.x,
                 ASSIGNEDBOX.y + ASSIGNEDBOX.h - floor(yoff) - ONEBARHEIGHT - pMonitor->vecPosition.y + m_pWindow->m_vFloatingOffset.y, m_fBarWidth,
                 (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0)};
         rect.scale(pMonitor->scale);

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -12,9 +12,9 @@ class CTitleTex {
     CTitleTex(PHLWINDOW pWindow, const Vector2D& bufferSize, const float monitorScale);
     ~CTitleTex() = default;
 
-    SP<CTexture> tex;
+    SP<CTexture> texActive;
+    SP<CTexture> texInactive;
     std::string  szContent;
-    Vector2D     texSize;
 
     PHLWINDOWREF pWindowOwner;
 };


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Adds config options for setting the font weight of active and inactive group bar title text. The option is set to be a string, but can also be an integer. Valid values are based on Pango weight enums (`thin`, `ultralight`, `light`, `semilight`, `book`, `normal`, `medium`, `semibold`, `bold`, `ultrabold`, `heavy`, `ultraheavy`, defaults to `normal` for both).

Also adds a config option to set the space between the group bar indicator and the title/gradient (defaults to 0).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready to merge

