### PR TITLE
Fix window offset when a window is dragged while a workspace is animated

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1258,7 +1258,7 @@ void CWindow::setAnimationsToMove() {
 
 void CWindow::onWorkspaceAnimUpdate() {
     // clip box for animated offsets
-    if (!m_bIsFloating || m_bPinned || isFullscreen()) {
+    if (!m_bIsFloating || m_bPinned || isFullscreen() || m_bDraggingTiled) {
         m_vFloatingOffset = Vector2D(0, 0);
         return;
     }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes windows getting stuck with offset when dragged outside a workspace that is being animated (fixes #7789)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This fix makes the offset snap to 0 the instant a window is moved to another monitor. This technically fixes the bug but may not be wanted behavior. (It is not easily noticeable, I can see it with animations slowed down for the purpose of fixing this bug only if I pay attention to it.)

I have not made a different fix (i.e. making the animation persist on a different monitor) as I did not want to waste time on something that could be unwanted by the maintainers.

#### Is it ready for merging, or does it need work?

It's ready if snapping is wanted behavior.
