### PR TITLE
monitor: Optimize direct scanout damage

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1384,7 +1384,7 @@ bool CMonitor::attemptDirectScanout() {
     clock_gettime(CLOCK_MONOTONIC, &now);
     PSURFACE->presentFeedback(&now, self.lock());
 
-    output->state->addDamage(CBox{{}, vecPixelSize});
+    output->state->addDamage(PSURFACE->accumulateCurrentBufferDamage());
     output->state->resetExplicitFences();
 
     auto cleanup = CScopeGuard([this]() { output->state->resetExplicitFences(); });


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Previously we were damaging the entire monitor, but we can instead only damage whatever the client damaged using the already existing `accumulateCurrentBufferDamage` method.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This seems to work for me and Skidam on Discord

#### Is it ready for merging, or does it need work?
Ready for merging