### PR TITLE
Autodetect GLES version

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -154,7 +154,7 @@ void CHyprOpenGLImpl::initEGL(bool gbm) {
     attrs.push_back(EGL_CONTEXT_MAJOR_VERSION);
     attrs.push_back(3);
     attrs.push_back(EGL_CONTEXT_MINOR_VERSION);
-    attrs.push_back(2);
+    attrs.push_back(0);
 #else
     attrs.push_back(EGL_CONTEXT_CLIENT_VERSION);
     attrs.push_back(2);
@@ -167,19 +167,7 @@ void CHyprOpenGLImpl::initEGL(bool gbm) {
 #ifdef GLES2
         RASSERT(false, "EGL: failed to create a context with GLES2.0");
 #endif
-        Debug::log(WARN, "EGL: Failed to create a context with GLES3.2, retrying 3.0");
-
-        attrs = attrsNoVer;
-        attrs.push_back(EGL_CONTEXT_MAJOR_VERSION);
-        attrs.push_back(3);
-        attrs.push_back(EGL_CONTEXT_MINOR_VERSION);
-        attrs.push_back(0);
-        attrs.push_back(EGL_NONE);
-
-        m_pEglContext = eglCreateContext(m_pEglDisplay, EGL_NO_CONFIG_KHR, EGL_NO_CONTEXT, attrs.data());
-
-        if (m_pEglContext == EGL_NO_CONTEXT)
-            RASSERT(false, "EGL: failed to create a context with either GLES3.2 or 3.0");
+        Debug::log(WARN, "EGL: Failed to create a context with GLES3.0");
     }
 
     if (m_sExts.IMG_context_priority) {
@@ -868,7 +856,7 @@ void CHyprOpenGLImpl::initShaders() {
     m_RenderData.pCurrentMonData->m_shQUAD.roundingPower = glGetUniformLocation(prog, "roundingPower");
 
 #ifndef GLES2
-    prog           = createProgram(TEXVERTSRC320, TEXFRAGSRCCM, true);
+    prog           = createProgram(TEXVERTSRC300, TEXFRAGSRCCM, true);
     m_bCMSupported = prog > 0;
     if (m_bCMSupported) {
         m_RenderData.pCurrentMonData->m_shCM.program           = prog;
@@ -1085,7 +1073,7 @@ void CHyprOpenGLImpl::applyScreenShader(const std::string& path) {
 
     std::string fragmentShader((std::istreambuf_iterator<char>(infile)), (std::istreambuf_iterator<char>()));
 
-    m_sFinalScreenShader.program = createProgram(fragmentShader.starts_with("#version 320 es") ? TEXVERTSRC320 : TEXVERTSRC, fragmentShader, true);
+    m_sFinalScreenShader.program = createProgram(fragmentShader.starts_with("#version 300 es") ? TEXVERTSRC300 : TEXVERTSRC, fragmentShader, true);
 
     if (!m_sFinalScreenShader.program) {
         // Error will have been sent by now by the underlying cause

--- a/src/render/shaders/CM.frag
+++ b/src/render/shaders/CM.frag
@@ -1,5 +1,5 @@
 R"#(
-#version 320 es
+#version 300 es
 //#extension GL_OES_EGL_image_external : require
 
 precision highp float;

--- a/src/render/shaders/Textures.hpp
+++ b/src/render/shaders/Textures.hpp
@@ -83,7 +83,7 @@ void main() {
     v_texcoord = texcoord;
 })#";
 
-inline const std::string TEXVERTSRC320 = R"#(#version 320 es
+inline const std::string TEXVERTSRC300 = R"#(#version 300 es
 uniform mat3 proj;
 in vec2 pos;
 in vec2 texcoord;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This should automatically use the highest available version of GLES.
Should be fine for GLES 3.x es since nothing major changed between the versions, IE it should be compatible.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Haven't tested screen shaders or cm since i don't have one available on hand but should be all good according to logs.
I feel like this could be done better, LMK if there's any changes needed.

#### Is it ready for merging, or does it need work?
Ready to be merged.


Final words:
Vaxry if you're going to do Embedded System stuff at least support it properly.
As a man who plays with this stuff daily i feel like i have a say on this.
