### PR TITLE
syncobj: restore SHM buffer reset

### DIFF
--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -57,6 +57,7 @@ struct SMonitorRule {
 
 class CMonitor;
 class CSyncTimeline;
+class CEGLSync;
 
 class CMonitorState {
   public:
@@ -141,6 +142,7 @@ class CMonitor {
     SP<CSyncTimeline>              inTimeline;
     SP<CSyncTimeline>              outTimeline;
     Hyprutils::OS::CFileDescriptor inFence;
+    SP<CEGLSync>                   eglSync;
     uint64_t                       commitSeq = 0;
 
     PHLMONITORREF                  self;

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -471,12 +471,10 @@ void CWLSurfaceResource::commitPendingState(SSurfaceState& state) {
             nullptr);
     }
 
-    // release the buffer if it's synchronous as update() has done everything thats needed
+    // release the buffer if it's synchronous (SHM) as update() has done everything thats needed
     // so we can let the app know we're done.
-    // if (!syncobj && current.buffer && current.buffer->buffer && current.buffer->buffer->isSynchronous()) {
-    // dropCurrentBuffer(); // lets not drop it at all, it will get dropped on next commit if a new buffer arrives.
-    // solves flickering on nonsyncobj apps on explicit sync.
-    // }
+    if (current.buffer && current.buffer->buffer && current.buffer->buffer->isSynchronous())
+        dropCurrentBuffer();
 }
 
 void CWLSurfaceResource::updateCursorShm(CRegion damage) {


### PR DESCRIPTION
reset shm buffers early to mitigate stuttering animations, also reuse the monitors eglSync and store the eglsync per monitor. this however reintroduces flickering in dbeaver nonsyncobj application.

reintroduces #6951 and potentially #6912.

until buffer releases is properly figured out, reset shm buffers early. and store eglsync per monitor. and add it as releasesync.
might require some testing so this doesnt break something else that wasbeing tested when eventfd went through its rigorous testing on VRR/DS. 

see https://github.com/hyprwm/Hyprland/issues/9636