### PR TITLE
types: Upgrade buffer ref from WP to SP

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1342,7 +1342,7 @@ bool CMonitor::attemptDirectScanout() {
 
     const auto PSURFACE = g_pXWaylandManager->getWindowSurface(PCANDIDATE);
 
-    if (!PSURFACE || !PSURFACE->current.texture || !PSURFACE->current.buffer || PSURFACE->current.buffer->buffer.expired())
+    if (!PSURFACE || !PSURFACE->current.texture || !PSURFACE->current.buffer)
         return false;
 
     if (PSURFACE->current.bufferSize != vecPixelSize || PSURFACE->current.transform != transform)
@@ -1355,7 +1355,7 @@ bool CMonitor::attemptDirectScanout() {
 
     Debug::log(TRACE, "attemptDirectScanout: surface {:x} passed, will attempt, buffer {}", (uintptr_t)PSURFACE.get(), (uintptr_t)PSURFACE->current.buffer->buffer.get());
 
-    auto PBUFFER = PSURFACE->current.buffer->buffer.lock();
+    auto PBUFFER = PSURFACE->current.buffer->buffer;
 
     if (PBUFFER == output->state->state().buffer) {
         if (scanoutNeedsCursorUpdate) {

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -440,7 +440,7 @@ void CWLSurfaceResource::commitPendingState(SSurfaceState& state) {
     if (current.texture)
         current.texture->m_eTransform = wlTransformToHyprutils(current.transform);
 
-    if (current.buffer && current.buffer->buffer) {
+    if (current.buffer) {
         const auto DAMAGE = accumulateCurrentBufferDamage();
         current.buffer->buffer->update(DAMAGE);
 
@@ -480,7 +480,7 @@ void CWLSurfaceResource::commitPendingState(SSurfaceState& state) {
 }
 
 void CWLSurfaceResource::updateCursorShm(CRegion damage) {
-    auto buf = current.buffer ? current.buffer->buffer : WP<IHLBuffer>{};
+    auto buf = current.buffer ? current.buffer->buffer : SP<IHLBuffer>{};
 
     if UNLIKELY (!buf)
         return;

--- a/src/protocols/types/Buffer.hpp
+++ b/src/protocols/types/Buffer.hpp
@@ -45,7 +45,7 @@ class CHLBufferReference {
     CHLBufferReference(SP<IHLBuffer> buffer, SP<CWLSurfaceResource> surface);
     ~CHLBufferReference();
 
-    WP<IHLBuffer>          buffer;
+    SP<IHLBuffer>          buffer;
     UP<CDRMSyncPointState> acquire;
     UP<CDRMSyncPointState> release;
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1532,7 +1532,7 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
         Debug::log(TRACE, "Explicit: can't add sync, EGLSync failed");
     else {
         for (auto const& e : explicitPresented) {
-            if (!e->current.buffer || !e->current.buffer->buffer || !e->current.buffer->buffer->syncReleaser)
+            if (!e->current.buffer || !e->current.buffer->buffer->syncReleaser)
                 continue;
 
             e->current.buffer->buffer->syncReleaser->addReleaseSync(sync);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Even if the client destroys the buffer before release, we should hang on to it until we're done rendering. Per the wayland spec:
> Destroying the wl_buffer after wl_buffer.release does not change the surface contents. Destroying the wl_buffer before wl_buffer.release is allowed as long as the underlying buffer storage isn't re-used (this can happen e.g. on client process termination). However, if the client destroys the wl_buffer before receiving the wl_buffer.release event and mutates the underlying buffer storage, the surface contents become undefined immediately.

https://wayland.app/protocols/wayland#wl_buffer:request:destroy

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nope. I tested this and didn't see any evidence of a memory leak, which makes sense given that this doesn't introduce any cyclical references.

#### Is it ready for merging, or does it need work?
Ready for merging

