### PR TITLE
core: Correctly track SHM buffer damage

### DIFF
--- a/src/desktop/WLSurface.cpp
+++ b/src/desktop/WLSurface.cpp
@@ -98,7 +98,7 @@ CRegion CWLSurface::computeDamage() const {
     if (!m_pResource->current.texture)
         return {};
 
-    CRegion damage = m_pResource->accumulateCurrentBufferDamage();
+    CRegion damage = m_pResource->current.accumulateBufferDamage();
     damage.transform(wlTransformToHyprutils(m_pResource->current.transform), m_pResource->current.bufferSize.x, m_pResource->current.bufferSize.y);
 
     const auto BUFSIZE    = m_pResource->current.bufferSize;

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -880,7 +880,7 @@ void Events::listener_commitWindow(void* owner, void* data) {
 
     // tearing: if solitary, redraw it. This still might be a single surface window
     if (PMONITOR && PMONITOR->solitaryClient.lock() == PWINDOW && PWINDOW->canBeTorn() && PMONITOR->tearingState.canTear && PWINDOW->m_pWLSurface->resource()->current.texture) {
-        CRegion damageBox{PWINDOW->m_pWLSurface->resource()->accumulateCurrentBufferDamage()};
+        CRegion damageBox{PWINDOW->m_pWLSurface->resource()->current.accumulateBufferDamage()};
 
         if (!damageBox.empty()) {
             if (PMONITOR->tearingState.busy) {

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1401,7 +1401,7 @@ bool CMonitor::attemptDirectScanout() {
     clock_gettime(CLOCK_MONOTONIC, &now);
     PSURFACE->presentFeedback(&now, self.lock());
 
-    output->state->addDamage(PSURFACE->accumulateCurrentBufferDamage());
+    output->state->addDamage(PSURFACE->current.accumulateBufferDamage());
     output->state->resetExplicitFences();
 
     auto cleanup = CScopeGuard([this]() { output->state->resetExplicitFences(); });

--- a/src/protocols/DRMSyncobj.cpp
+++ b/src/protocols/DRMSyncobj.cpp
@@ -137,7 +137,7 @@ CDRMSyncobjSurfaceResource::~CDRMSyncobjSurfaceResource() {
 }
 
 bool CDRMSyncobjSurfaceResource::protocolError() {
-    if (!surface->pending.texture) {
+    if (!surface->pending.buffer) {
         resource->error(WP_LINUX_DRM_SYNCOBJ_SURFACE_V1_ERROR_NO_BUFFER, "Missing buffer");
         surface->pending.rejected = true;
         return true;

--- a/src/protocols/Viewporter.cpp
+++ b/src/protocols/Viewporter.cpp
@@ -52,7 +52,7 @@ CViewportResource::CViewportResource(SP<CWpViewport> resource_, SP<CWLSurfaceRes
     });
 
     listeners.surfacePrecommit = surface->events.precommit.registerListener([this](std::any d) {
-        if (!surface || !surface->pending.texture)
+        if (!surface || !surface->pending.buffer)
             return;
 
         if (surface->pending.viewport.hasSource) {

--- a/src/protocols/XDGShell.cpp
+++ b/src/protocols/XDGShell.cpp
@@ -387,7 +387,7 @@ CXDGSurfaceResource::CXDGSurfaceResource(SP<CXdgSurface> resource_, SP<CXDGWMBas
         if (toplevel)
             toplevel->current = toplevel->pending;
 
-        if UNLIKELY (initialCommit && surface->pending.texture) {
+        if UNLIKELY (initialCommit && surface->pending.buffer) {
             resource->error(-1, "Buffer attached before initial commit");
             return;
         }

--- a/src/protocols/core/Compositor.hpp
+++ b/src/protocols/core/Compositor.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 #include <cstdint>
 #include "../WaylandProtocol.hpp"
+#include "render/Texture.hpp"
 #include "wayland.hpp"
 #include "../../helpers/signal/Signal.hpp"
 #include "../../helpers/math/Math.hpp"
@@ -75,7 +76,6 @@ class CWLSurfaceResource {
     SP<CWlSurface>                getResource();
     CBox                          extends();
     void                          resetRole();
-    Vector2D                      sourceSize();
 
     struct {
         CSignal precommit; // before commit
@@ -102,7 +102,6 @@ class CWLSurfaceResource {
 
     void                                   breadthfirst(std::function<void(SP<CWLSurfaceResource>, const Vector2D&, void*)> fn, void* data);
     SP<CWLSurfaceResource>                 findFirstPreorder(std::function<bool(SP<CWLSurfaceResource>)> fn);
-    CRegion                                accumulateCurrentBufferDamage();
     void                                   presentFeedback(timespec* when, PHLMONITOR pMonitor, bool discarded = false);
     void                                   commitPendingState(SSurfaceState& state);
 

--- a/src/protocols/core/Shm.cpp
+++ b/src/protocols/core/Shm.cpp
@@ -22,19 +22,12 @@ CWLSHMBuffer::CWLSHMBuffer(SP<CWLSHMPoolResource> pool_, uint32_t id, int32_t of
     offset = offset_;
     opaque = NFormatUtils::isFormatOpaque(NFormatUtils::shmToDRM(fmt_));
 
-    texture = makeShared<CTexture>(NFormatUtils::shmToDRM(fmt), (uint8_t*)pool->data + offset, stride, size_);
-
     resource = CWLBufferResource::create(makeShared<CWlBuffer>(pool_->resource->client(), 1, id));
 
     listeners.bufferResourceDestroy = events.destroy.registerListener([this](std::any d) {
         listeners.bufferResourceDestroy.reset();
         PROTO::shm->destroyResource(this);
     });
-
-    success = texture->m_iTexID;
-
-    if UNLIKELY (!success)
-        Debug::log(ERR, "Failed creating a shm texture: null texture id");
 }
 
 CWLSHMBuffer::~CWLSHMBuffer() {
@@ -74,11 +67,11 @@ void CWLSHMBuffer::endDataPtr() {
 }
 
 bool CWLSHMBuffer::good() {
-    return success;
+    return true;
 }
 
 void CWLSHMBuffer::update(const CRegion& damage) {
-    texture->update(NFormatUtils::shmToDRM(fmt), (uint8_t*)pool->data + offset, stride, damage);
+    ;
 }
 
 CSHMPool::CSHMPool(CFileDescriptor fd_, size_t size_) : fd(std::move(fd_)), size(size_), data(mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd.get(), 0)) {

--- a/src/protocols/core/Shm.hpp
+++ b/src/protocols/core/Shm.hpp
@@ -50,8 +50,6 @@ class CWLSHMBuffer : public IHLBuffer {
     SP<CSHMPool>                                   pool;
 
   private:
-    bool success = false;
-
     struct {
         CHyprSignalListener bufferResourceDestroy;
     } listeners;

--- a/src/protocols/types/SurfaceState.cpp
+++ b/src/protocols/types/SurfaceState.cpp
@@ -1,0 +1,58 @@
+#include "SurfaceState.hpp"
+#include "helpers/Format.hpp"
+#include "protocols/types/Buffer.hpp"
+#include "render/Texture.hpp"
+
+Vector2D SSurfaceState::sourceSize() {
+    if UNLIKELY (!texture)
+        return {};
+
+    if UNLIKELY (viewport.hasSource)
+        return viewport.source.size();
+
+    Vector2D trc = transform % 2 == 1 ? Vector2D{bufferSize.y, bufferSize.x} : bufferSize;
+    return trc / scale;
+}
+
+CRegion SSurfaceState::accumulateBufferDamage() {
+    if (damage.empty())
+        return bufferDamage;
+
+    CRegion surfaceDamage = damage;
+    if (viewport.hasDestination) {
+        Vector2D scale = sourceSize() / viewport.destination;
+        surfaceDamage.scale(scale);
+    }
+
+    if (viewport.hasSource)
+        surfaceDamage.translate(viewport.source.pos());
+
+    Vector2D trc = transform % 2 == 1 ? Vector2D{bufferSize.y, bufferSize.x} : bufferSize;
+
+    bufferDamage = surfaceDamage.scale(scale).transform(wlTransformToHyprutils(invertTransform(transform)), trc.x, trc.y).add(bufferDamage);
+    damage.clear();
+    return bufferDamage;
+}
+
+void SSurfaceState::updateSynchronousTexture(SP<CTexture> lastTexture) {
+    auto [dataPtr, fmt, size] = buffer->buffer->beginDataPtr(0);
+    if (dataPtr) {
+        auto drmFmt = NFormatUtils::shmToDRM(fmt);
+        auto stride = bufferSize.y ? size / bufferSize.y : 0;
+        if (lastTexture && lastTexture->m_isSynchronous && lastTexture->m_vSize == bufferSize) {
+            texture = lastTexture;
+            texture->update(drmFmt, dataPtr, stride, accumulateBufferDamage());
+        } else
+            texture = makeShared<CTexture>(drmFmt, dataPtr, stride, bufferSize);
+    }
+    buffer->buffer->endDataPtr();
+}
+
+void SSurfaceState::reset() {
+    damage.clear();
+    bufferDamage.clear();
+    transform = WL_OUTPUT_TRANSFORM_NORMAL;
+    scale     = 1;
+    offset    = {};
+    size      = {};
+}

--- a/src/protocols/types/SurfaceState.hpp
+++ b/src/protocols/types/SurfaceState.hpp
@@ -20,16 +20,12 @@ struct SSurfaceState {
         Vector2D destination;
         CBox     source;
     } viewport;
-    bool rejected  = false;
-    bool newBuffer = false;
+    bool     rejected  = false;
+    bool     newBuffer = false;
 
-    //
-    void reset() {
-        damage.clear();
-        bufferDamage.clear();
-        transform = WL_OUTPUT_TRANSFORM_NORMAL;
-        scale     = 1;
-        offset    = {};
-        size      = {};
-    }
+    Vector2D sourceSize();
+    // Translates damage into bufferDamage, clearing damage and returning the updated bufferDamage
+    CRegion accumulateBufferDamage();
+    void    updateSynchronousTexture(SP<CTexture> lastTexture);
+    void    reset();
 };

--- a/src/render/Texture.cpp
+++ b/src/render/Texture.cpp
@@ -64,8 +64,9 @@ void CTexture::createFromShm(uint32_t drmFormat, uint8_t* pixels, uint32_t strid
     const auto format = NFormatUtils::getPixelFormatFromDRM(drmFormat);
     ASSERT(format);
 
-    m_iType = format->withAlpha ? TEXTURE_RGBA : TEXTURE_RGBX;
-    m_vSize = size_;
+    m_iType         = format->withAlpha ? TEXTURE_RGBA : TEXTURE_RGBX;
+    m_vSize         = size_;
+    m_isSynchronous = true;
     allocate();
 
     GLCALL(glBindTexture(GL_TEXTURE_2D, m_iTexID));

--- a/src/render/Texture.hpp
+++ b/src/render/Texture.hpp
@@ -35,14 +35,15 @@ class CTexture {
     void                        update(uint32_t drmFormat, uint8_t* pixels, uint32_t stride, const CRegion& damage);
     const std::vector<uint8_t>& dataCopy();
 
-    eTextureType                m_iType      = TEXTURE_RGBA;
-    GLenum                      m_iTarget    = GL_TEXTURE_2D;
-    GLuint                      m_iTexID     = 0;
-    Vector2D                    m_vSize      = {};
-    void*                       m_pEglImage  = nullptr;
-    eTransform                  m_eTransform = HYPRUTILS_TRANSFORM_NORMAL;
-    bool                        m_bOpaque    = false;
-    uint32_t                    m_iDrmFormat = 0; // for shm
+    eTextureType                m_iType         = TEXTURE_RGBA;
+    GLenum                      m_iTarget       = GL_TEXTURE_2D;
+    GLuint                      m_iTexID        = 0;
+    Vector2D                    m_vSize         = {};
+    void*                       m_pEglImage     = nullptr;
+    eTransform                  m_eTransform    = HYPRUTILS_TRANSFORM_NORMAL;
+    bool                        m_bOpaque       = false;
+    uint32_t                    m_iDrmFormat    = 0; // for shm
+    bool                        m_isSynchronous = false;
 
   private:
     void                 createFromShm(uint32_t drmFormat, uint8_t* pixels, uint32_t stride, const Vector2D& size);

--- a/src/xwayland/XSurface.cpp
+++ b/src/xwayland/XSurface.cpp
@@ -62,12 +62,12 @@ void CXWaylandSurface::ensureListeners() {
         });
 
         listeners.commitSurface = surface->events.commit.registerListener([this](std::any d) {
-            if (surface->pending.texture && !mapped) {
+            if (surface->current.texture && !mapped) {
                 map();
                 return;
             }
 
-            if (!surface->pending.texture && mapped) {
+            if (!surface->current.texture && mapped) {
                 unmap();
                 return;
             }
@@ -131,7 +131,7 @@ void CXWaylandSurface::considerMap() {
         return;
     }
 
-    if (surface->pending.texture) {
+    if (surface->current.texture) {
         Debug::log(LOG, "XWayland surface: considerMap, sure, we have a buffer");
         map();
         return;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Previously, `commitPendingState` interpreted damage as "damage against the buffer texture". However, that is per-buffer, which means that it can easily be incorrect. What damage really means is "damage against the last rendered buffer", which is completely different if a new buffer has been attached in the meantime (which is the expected behavior).

Example of where the old behavior goes wrong:
- Client attaches, damages, and commits SHM buffer A
- Client creates SHM buffer B with garbage data and then writes the next frame to it
- Client attaches SHM buffer B, damages the parts different than SHM buffer A, and then commits it
- Before this PR, Hyprland would render garbage everywhere outside of the damaged areas, because the texture it's using was created when SHM buffer B was created. After this PR, it'll instead update a texture based on SHM buffer A's contents, which has the correct undamaged areas.

This PR keeps a running `shmTexture` instead of storing the texture in the SHM buffer. That `shmTexture` is then updated with the damage, meaning that even if a different buffer is committed damage is properly tracked.

The main alternative to consider is simply not tracking damage at all for SHM buffers and instead re-importing the whole buffer every commit. That would be significantly simpler, though less performant.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Seems to work from my testing of an SHM application.

#### Is it ready for merging, or does it need work?
Ready for merging