### PR TITLE
syncobj: store CDRMSyncobjTimelineResource as SP

### DIFF
--- a/src/helpers/sync/SyncTimeline.cpp
+++ b/src/helpers/sync/SyncTimeline.cpp
@@ -19,12 +19,13 @@ SP<CSyncTimeline> CSyncTimeline::create(int drmFD_) {
     return timeline;
 }
 
-SP<CSyncTimeline> CSyncTimeline::create(int drmFD_, int drmSyncobjFD) {
-    auto timeline   = SP<CSyncTimeline>(new CSyncTimeline);
-    timeline->drmFD = drmFD_;
-    timeline->self  = timeline;
+SP<CSyncTimeline> CSyncTimeline::create(int drmFD_, CFileDescriptor&& drmSyncobjFD) {
+    auto timeline       = SP<CSyncTimeline>(new CSyncTimeline);
+    timeline->drmFD     = drmFD_;
+    timeline->syncobjFd = std::move(drmSyncobjFD);
+    timeline->self      = timeline;
 
-    if (drmSyncobjFDToHandle(drmFD_, drmSyncobjFD, &timeline->handle)) {
+    if (drmSyncobjFDToHandle(drmFD_, timeline->syncobjFd.get(), &timeline->handle)) {
         Debug::log(ERR, "CSyncTimeline: failed to create a drm syncobj from fd??");
         return nullptr;
     }

--- a/src/helpers/sync/SyncTimeline.hpp
+++ b/src/helpers/sync/SyncTimeline.hpp
@@ -17,7 +17,7 @@ struct wl_event_source;
 class CSyncTimeline {
   public:
     static SP<CSyncTimeline> create(int drmFD_);
-    static SP<CSyncTimeline> create(int drmFD_, int drmSyncobjFD);
+    static SP<CSyncTimeline> create(int drmFD_, Hyprutils::OS::CFileDescriptor&& drmSyncobjFD);
     ~CSyncTimeline();
 
     struct SWaiter {
@@ -40,7 +40,8 @@ class CSyncTimeline {
     bool                           transfer(SP<CSyncTimeline> from, uint64_t fromPoint, uint64_t toPoint);
     void                           signal(uint64_t point);
 
-    int                            drmFD  = -1;
+    int                            drmFD = -1;
+    Hyprutils::OS::CFileDescriptor syncobjFd;
     uint32_t                       handle = 0;
     WP<CSyncTimeline>              self;
 

--- a/src/protocols/DRMSyncobj.hpp
+++ b/src/protocols/DRMSyncobj.hpp
@@ -17,13 +17,11 @@ struct SSurfaceState;
 class CDRMSyncPointState {
   public:
     CDRMSyncPointState() = default;
-    CDRMSyncPointState(WP<CDRMSyncobjTimelineResource> resource_, uint64_t point_);
+    CDRMSyncPointState(SP<CSyncTimeline> timeline_, uint64_t point_);
     ~CDRMSyncPointState() = default;
 
     const uint64_t&                                  point();
-    WP<CDRMSyncobjTimelineResource>                  resource();
     WP<CSyncTimeline>                                timeline();
-    bool                                             expired();
     Hyprutils::Memory::CUniquePointer<CSyncReleaser> createSyncRelease();
     bool                                             addWaiter(const std::function<void()>& waiter);
     bool                                             comitted();
@@ -31,11 +29,10 @@ class CDRMSyncPointState {
     void                                             signal();
 
   private:
-    WP<CDRMSyncobjTimelineResource> m_resource         = {};
-    uint64_t                        m_point            = 0;
-    WP<CSyncTimeline>               m_timeline         = {};
-    bool                            m_acquireCommitted = false;
-    bool                            m_releaseTaken     = false;
+    SP<CSyncTimeline> m_timeline         = {};
+    uint64_t          m_point            = 0;
+    bool              m_acquireCommitted = false;
+    bool              m_releaseTaken     = false;
 };
 
 class CDRMSyncobjSurfaceResource {


### PR DESCRIPTION
store the CDRMSyncobjTimelineResource as a shared pointer to ensure the syncobj fd doesnt destruct before we actually are done with it.

