### PR TITLE
hyprpm: return 1 when plugins are outdated

### DIFF
--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -165,15 +165,19 @@ int                        main(int argc, char** argv, char** envp) {
     } else if (command[0] == "reload") {
         auto ret = g_pPluginManager->ensurePluginsLoadState(force);
 
-        if (ret != LOADSTATE_OK && notify) {
-            switch (ret) {
-                case LOADSTATE_FAIL:
-                case LOADSTATE_PARTIAL_FAIL: g_pPluginManager->notify(ICON_ERROR, 0, 10000, "[hyprpm] Failed to load plugins"); break;
-                case LOADSTATE_HEADERS_OUTDATED:
-                    g_pPluginManager->notify(ICON_ERROR, 0, 10000, "[hyprpm] Failed to load plugins: Outdated headers. Please run hyprpm update manually.");
-                    break;
-                default: break;
+        if (ret != LOADSTATE_OK) {
+            
+            if (notify) {
+                switch (ret) {
+                    case LOADSTATE_FAIL:
+                    case LOADSTATE_PARTIAL_FAIL: g_pPluginManager->notify(ICON_ERROR, 0, 10000, "[hyprpm] Failed to load plugins"); break;
+                    case LOADSTATE_HEADERS_OUTDATED:
+                        g_pPluginManager->notify(ICON_ERROR, 0, 10000, "[hyprpm] Failed to load plugins: Outdated headers. Please run hyprpm update manually.");
+                        break;
+                    default: break;
+                }
             }
+            
             return 1;
         } else if (notify && !notifyFail) {
             g_pPluginManager->notify(ICON_OK, 0, 4000, "[hyprpm] Loaded plugins");

--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -166,7 +166,6 @@ int                        main(int argc, char** argv, char** envp) {
         auto ret = g_pPluginManager->ensurePluginsLoadState(force);
 
         if (ret != LOADSTATE_OK) {
-            
             if (notify) {
                 switch (ret) {
                     case LOADSTATE_FAIL:
@@ -177,7 +176,7 @@ int                        main(int argc, char** argv, char** envp) {
                     default: break;
                 }
             }
-            
+
             return 1;
         } else if (notify && !notifyFail) {
             g_pPluginManager->notify(ICON_OK, 0, 4000, "[hyprpm] Loaded plugins");


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
`hyprpm reload` should not return 0 when failing

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
-

#### Is it ready for merging, or does it need work?
ready

