### PR TITLE
screencast: wait for fence if explicit sync

### DIFF
--- a/src/protocols/Screencopy.cpp
+++ b/src/protocols/Screencopy.cpp
@@ -221,6 +221,12 @@ bool CScreencopyFrame::copyDmabuf() {
     g_pHyprOpenGL->m_RenderData.blockScreenShader = true;
     g_pHyprRenderer->endRender();
 
+    auto explicitOptions = g_pHyprRenderer->getExplicitSyncSettings(pMonitor->output);
+    if (explicitOptions.explicitEnabled) {
+        auto sync = g_pHyprOpenGL->createEGLSync();
+        sync->wait();
+    }
+
     LOGM(TRACE, "Copied frame via dma");
 
     return true;
@@ -294,6 +300,12 @@ bool CScreencopyFrame::copyShm() {
 #else
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 #endif
+
+    auto explicitOptions = g_pHyprRenderer->getExplicitSyncSettings(pMonitor->output);
+    if (explicitOptions.explicitEnabled) {
+        auto sync = g_pHyprOpenGL->createEGLSync();
+        sync->wait();
+    }
 
     LOGM(TRACE, "Copied frame via shm");
 

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -3025,3 +3025,7 @@ CFileDescriptor&& CEGLSync::takeFD() {
 CFileDescriptor& CEGLSync::fd() {
     return m_iFd;
 }
+
+bool CEGLSync::wait() {
+    return g_pHyprOpenGL->m_sProc.eglWaitSyncKHR(g_pHyprOpenGL->m_pEglDisplay, sync, 0) == EGL_TRUE;
+}

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -152,6 +152,7 @@ class CEGLSync {
 
     Hyprutils::OS::CFileDescriptor&& takeFD();
     Hyprutils::OS::CFileDescriptor&  fd();
+    bool                             wait();
 
   private:
     CEGLSync() = default;


### PR DESCRIPTION
wait for fence if explicit sync is enabled, to reduce jankiness on screencasting.


before
https://github.com/user-attachments/assets/b6a5279c-9481-4b97-87d3-f89eb61d9ae0

after, shitty quality because file got huge, so dropped bitrate etc.

https://github.com/user-attachments/assets/12ae2e33-5b24-4d8f-a57d-b44ff6055c11



