### PR TITLE
screencopy, render: Use explicit sync for screencopy

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -57,8 +57,7 @@ void CMonitor::onConnect(bool noRule) {
     g_pEventLoopManager->doLater([] { g_pConfigManager->ensurePersistentWorkspacesPresent(); });
 
     if (output->supportsExplicit) {
-        inTimeline  = CSyncTimeline::create(output->getBackend()->drmFD());
-        outTimeline = CSyncTimeline::create(output->getBackend()->drmFD());
+        inTimeline = CSyncTimeline::create(output->getBackend()->drmFD());
     }
 
     listeners.frame  = output->events.frame.registerListener([this](std::any d) { onMonitorFrame(); });
@@ -1420,8 +1419,6 @@ bool CMonitor::attemptDirectScanout() {
             DOEXPLICIT = false;
         }
     }
-
-    commitSeq++;
 
     bool ok = output->commit();
 

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -140,10 +140,9 @@ class CMonitor {
 
     // explicit sync
     SP<CSyncTimeline>              inTimeline;
-    SP<CSyncTimeline>              outTimeline;
     Hyprutils::OS::CFileDescriptor inFence;
     SP<CEGLSync>                   eglSync;
-    uint64_t                       commitSeq = 0;
+    uint64_t                       inTimelinePoint = 0;
 
     PHLMONITORREF                  self;
 

--- a/src/protocols/Screencopy.cpp
+++ b/src/protocols/Screencopy.cpp
@@ -226,7 +226,7 @@ void CScreencopyFrame::copyDmabuf(std::function<void(bool)> callback) {
     g_pHyprRenderer->endRender();
 
     auto explicitOptions = g_pHyprRenderer->getExplicitSyncSettings(pMonitor->output);
-    if (pMonitor->inTimeline && explicitOptions.explicitEnabled && explicitOptions.explicitKMSEnabled) {
+    if (pMonitor->inTimeline && explicitOptions.explicitEnabled) {
         pMonitor->inTimeline->addWaiter(
             [callback]() {
                 LOGM(TRACE, "Copied frame via dma with explicit sync");

--- a/src/protocols/Screencopy.cpp
+++ b/src/protocols/Screencopy.cpp
@@ -12,6 +12,7 @@
 #include "../helpers/Format.hpp"
 
 #include <algorithm>
+#include <functional>
 
 CScreencopyFrame::~CScreencopyFrame() {
     if (buffer && buffer->locked())
@@ -174,39 +175,42 @@ void CScreencopyFrame::share() {
     timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);
 
-    if (bufferDMA) {
-        if (!copyDmabuf()) {
-            LOGM(ERR, "Dmabuf copy failed in {:x}", (uintptr_t)this);
+    auto callback = [this, now, weak = self](bool success) {
+        if (weak.expired())
+            return;
+
+        if (!success) {
+            LOGM(ERR, "{} copy failed in {:x}", bufferDMA ? "Dmabuf" : "Shm", (uintptr_t)this);
             resource->sendFailed();
             return;
         }
-    } else {
-        if (!copyShm()) {
-            LOGM(ERR, "Shm copy failed in {:x}", (uintptr_t)this);
-            resource->sendFailed();
-            return;
+
+        resource->sendFlags((zwlrScreencopyFrameV1Flags)0);
+        if (withDamage) {
+            // TODO: add a damage ring for this.
+            resource->sendDamage(0, 0, buffer->size.x, buffer->size.y);
         }
-    }
 
-    resource->sendFlags((zwlrScreencopyFrameV1Flags)0);
-    if (withDamage) {
-        // TODO: add a damage ring for this.
-        resource->sendDamage(0, 0, buffer->size.x, buffer->size.y);
-    }
+        uint32_t tvSecHi = (sizeof(now.tv_sec) > 4) ? now.tv_sec >> 32 : 0;
+        uint32_t tvSecLo = now.tv_sec & 0xFFFFFFFF;
+        resource->sendReady(tvSecHi, tvSecLo, now.tv_nsec);
+    };
 
-    uint32_t tvSecHi = (sizeof(now.tv_sec) > 4) ? now.tv_sec >> 32 : 0;
-    uint32_t tvSecLo = now.tv_sec & 0xFFFFFFFF;
-    resource->sendReady(tvSecHi, tvSecLo, now.tv_nsec);
+    if (bufferDMA)
+        copyDmabuf(callback);
+    else
+        callback(copyShm());
 }
 
-bool CScreencopyFrame::copyDmabuf() {
+void CScreencopyFrame::copyDmabuf(std::function<void(bool)> callback) {
     auto    TEXTURE = makeShared<CTexture>(pMonitor->output->state->state().buffer);
 
     CRegion fakeDamage = {0, 0, INT16_MAX, INT16_MAX};
 
     if (!g_pHyprRenderer->beginRender(pMonitor.lock(), fakeDamage, RENDER_MODE_TO_BUFFER, buffer.lock(), nullptr, true)) {
         LOGM(ERR, "Can't copy: failed to begin rendering to dma frame");
-        return false;
+        callback(false);
+        return;
     }
 
     CBox monbox = CBox{0, 0, pMonitor->vecPixelSize.x, pMonitor->vecPixelSize.y}
@@ -221,9 +225,12 @@ bool CScreencopyFrame::copyDmabuf() {
     g_pHyprOpenGL->m_RenderData.blockScreenShader = true;
     g_pHyprRenderer->endRender();
 
-    LOGM(TRACE, "Copied frame via dma");
-
-    return true;
+    pMonitor->inTimeline->addWaiter(
+        [callback]() {
+            LOGM(TRACE, "Copied frame via dma");
+            callback(true);
+        },
+        pMonitor->inTimelinePoint, 0);
 }
 
 bool CScreencopyFrame::copyShm() {
@@ -278,6 +285,8 @@ bool CScreencopyFrame::copyShm() {
     const auto drmFmt     = NFormatUtils::getPixelFormatFromDRM(shm.format);
     uint32_t   packStride = NFormatUtils::minStride(drmFmt, box.w);
 
+    // This could be optimized by using a pixel buffer object to make this async,
+    // but really clients should just use a dma buffer anyways.
     if (packStride == (uint32_t)shm.stride) {
         glReadPixels(0, 0, box.w, box.h, glFormat, PFORMAT->glType, pixelData);
     } else {

--- a/src/protocols/Screencopy.hpp
+++ b/src/protocols/Screencopy.hpp
@@ -73,7 +73,7 @@ class CScreencopyFrame {
     CBox                       box          = {};
 
     void                       copy(CZwlrScreencopyFrameV1* pFrame, wl_resource* buffer);
-    bool                       copyDmabuf();
+    void                       copyDmabuf(std::function<void(bool)> callback);
     bool                       copyShm();
     void                       share();
 

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -522,7 +522,7 @@ void CWLSurfaceResource::presentFeedback(timespec* when, PHLMONITOR pMonitor, bo
         FEEDBACK->presented();
     PROTO::presentation->queueData(FEEDBACK);
 
-    if (!pMonitor || !pMonitor->outTimeline || !syncobj)
+    if (!pMonitor || !pMonitor->inTimeline || !syncobj)
         return;
 
     // attach explicit sync

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2253,7 +2253,7 @@ void CHyprRenderer::endRender() {
 
     auto explicitOptions = getExplicitSyncSettings(PMONITOR->output);
 
-    if (PMONITOR->inTimeline && explicitOptions.explicitEnabled && explicitOptions.explicitKMSEnabled) {
+    if (PMONITOR->inTimeline && explicitOptions.explicitEnabled) {
         PMONITOR->eglSync = g_pHyprOpenGL->createEGLSync();
         if (!PMONITOR->eglSync) {
             Debug::log(ERR, "renderer: couldn't create an EGLSync for out in endRender");
@@ -2267,7 +2267,7 @@ void CHyprRenderer::endRender() {
             return;
         }
 
-        if (m_eRenderMode == RENDER_MODE_NORMAL) {
+        if (m_eRenderMode == RENDER_MODE_NORMAL && explicitOptions.explicitKMSEnabled) {
             PMONITOR->inFence = CFileDescriptor{PMONITOR->inTimeline->exportAsSyncFileFD(PMONITOR->inTimelinePoint)};
             if (!PMONITOR->inFence.isValid()) {
                 Debug::log(ERR, "renderer: couldn't export from sync timeline in endRender");


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This PR waits for rendering to complete via explicit sync before handing the frame back to the client, eliminating tearing/flickering.

This PR is an alternative to https://github.com/hyprwm/Hyprland/pull/9696 that I think correctly uses the explicit sync API by asynchronously waiting for rendering to complete and the sync to be triggered before notifying the client that the copy is done and the buffer is ready for reading.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I did a bit of refactoring around explicit sync in the monitor and render code for this, but nothing that should change behavior.

#### Is it ready for merging, or does it need work?
Ready for merging