### PR TITLE
core: Fix dropping cursor buffer data early

### DIFF
--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -12,6 +12,7 @@
 #include "../DRMSyncobj.hpp"
 #include "../../render/Renderer.hpp"
 #include "config/ConfigValue.hpp"
+#include "protocols/types/SurfaceRole.hpp"
 #include "render/Texture.hpp"
 #include <cstring>
 
@@ -445,7 +446,8 @@ void CWLSurfaceResource::commitPendingState(SSurfaceState& state) {
 
     // release the buffer if it's synchronous (SHM) as update() has done everything thats needed
     // so we can let the app know we're done.
-    if (current.buffer && current.buffer->buffer && current.buffer->buffer->isSynchronous())
+    // if it doesn't have a role, we can't release it yet, in case it gets turned into a cursor.
+    if (current.buffer && current.buffer->buffer && current.buffer->buffer->isSynchronous() && role->role() != SURFACE_ROLE_UNASSIGNED)
         dropCurrentBuffer();
 }
 

--- a/src/protocols/core/Seat.cpp
+++ b/src/protocols/core/Seat.cpp
@@ -124,7 +124,7 @@ CWLPointerResource::CWLPointerResource(SP<CWlPointer> resource_, SP<CWLSeatResou
             return;
         }
 
-        if (surfResource) {
+        if (surfResource && surfResource->role->role() != SURFACE_ROLE_CURSOR) {
             surfResource->role = makeShared<CCursorSurfaceRole>();
             surfResource->updateCursorShm();
         }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes #9289

If a client commits a surface before assigning it a role, we need to keep the buffer around in case it turns out to be a cursor surface and we need the buffer for `updateCursorShm()`. The previous issue was:

> Blender commits the surface before assigning it the cursor role. That means that the commit never sets the cursorPixelData needed for cpu buffer cursor rendering. updateCursorShm is called when the client calls set_cursor, but by that point, the buffer has already been dropped and only the texture remains.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nope

#### Is it ready for merging, or does it need work?
Ready for merging