### PR TITLE
Fix non-relative import in Compositor.hpp

### DIFF
--- a/src/protocols/core/Compositor.hpp
+++ b/src/protocols/core/Compositor.hpp
@@ -11,7 +11,7 @@
 #include <vector>
 #include <cstdint>
 #include "../WaylandProtocol.hpp"
-#include "render/Texture.hpp"
+#include "../../render/Texture.hpp"
 #include "wayland.hpp"
 #include "../../helpers/signal/Signal.hpp"
 #include "../../helpers/math/Math.hpp"


### PR DESCRIPTION
Fix non-relative import because this breaks plugins.