### PR TITLE
Simplify and fix hdr metadata setting

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1382,8 +1382,9 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, const CB
     const auto imageDescription =
         m_RenderData.surface.valid() && m_RenderData.surface->colorManagement.valid() ? m_RenderData.surface->colorManagement->imageDescription() : SImageDescription{};
 
-    const bool skipCM = !*PENABLECM                                      /* CM disabled by the user */
-        || !m_bCMSupported                                               /* CM unsupported - hw failed to compile the shader probably */
+    const bool skipCM = !*PENABLECM /* CM disabled by the user */
+        || !m_RenderData.surface    /* FIXME unknown texture settings should be treated as sRGB and go through CM if monitor isn't in sRGB mode */
+        || !m_bCMSupported          /* CM unsupported - hw failed to compile the shader probably */
         || (imageDescription == m_RenderData.pMonitor->imageDescription) /* Source and target have the same image description */
         || ((*PPASS == 1 || (*PPASS == 2 && imageDescription.transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ)) && m_RenderData.pMonitor->activeWorkspace &&
             m_RenderData.pMonitor->activeWorkspace->m_bHasFullscreenWindow &&

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1383,7 +1383,6 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, const CB
         m_RenderData.surface.valid() && m_RenderData.surface->colorManagement.valid() ? m_RenderData.surface->colorManagement->imageDescription() : SImageDescription{};
 
     const bool skipCM = !*PENABLECM                                      /* CM disabled by the user */
-        || !m_RenderData.surface                                         /* No surface - no point in CM */
         || !m_bCMSupported                                               /* CM unsupported - hw failed to compile the shader probably */
         || (imageDescription == m_RenderData.pMonitor->imageDescription) /* Source and target have the same image description */
         || ((*PPASS == 1 || (*PPASS == 2 && imageDescription.transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ)) && m_RenderData.pMonitor->activeWorkspace &&


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes unwanted switch to SDR for fullscreen apps with CM support when `cm_fs_passthrough=2` (foot should no longer cause a modeset)
Fixes metadata creation. Primaries weren't sent correctly. Doesn't seem to have any effect on nvidia, other drivers might have some color improvements (need some info on how those values should be handled by the driver)
Sends primaries and luminances info for SDR content in case it'll be useful for fixing SDR passthrough on AQ side. Might make sense to set a hdr metadata blob with SDR eotf if those primaries and luminances are handled by the driver.
Simplifies hdr metadata switching logic

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
CM skip for rendering without a surface data should be removed. E verything that doesn't explicitly set an image description is considered sRGB and should go through the CM if monitor isn't in sRGB. If there are cases when `renderTextureInternalWithDamage` is called without a surface and the provided texture is encoded the same way then there should be a way to provide this info explicitly. Image description should be set on a `CTexture` level probably. Keeping it as is till #9600


#### Is it ready for merging, or does it need work?
Ready
