### PR TITLE
xwl: dont close the fd to early

### DIFF
--- a/src/xwayland/Server.hpp
+++ b/src/xwayland/Server.hpp
@@ -20,7 +20,7 @@ class CXWaylandServer {
     bool start();
 
     // called on ready
-    int  ready(Hyprutils::OS::CFileDescriptor fd, uint32_t mask);
+    int  ready(int fd, uint32_t mask);
 
     void die();
 


### PR DESCRIPTION
dont close the fd until the wl_event_source is removed, so we dont get another event triggered with an already closed fd.

seems to be the reason some people hit Xwayland not starting randomly. but a bit hard to pinpoint since it only happends rarely and only for some.



