### PR TITLE
config: completely remove windowrulev2

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -290,18 +290,6 @@ static Hyprlang::CParseResult handleLayerRule(const char* c, const char* v) {
     return result;
 }
 
-static Hyprlang::CParseResult handleWindowRuleV2(const char* c, const char* v) {
-    const std::string      VALUE   = v;
-    const std::string      COMMAND = c;
-
-    const auto             RESULT = g_pConfigManager->handleWindowRule(COMMAND, VALUE);
-
-    Hyprlang::CParseResult result;
-    if (RESULT.has_value())
-        result.setError(RESULT.value().c_str());
-    return result;
-}
-
 static Hyprlang::CParseResult handleBlurLS(const char* c, const char* v) {
     const std::string      VALUE   = v;
     const std::string      COMMAND = c;
@@ -753,7 +741,6 @@ CConfigManager::CConfigManager() {
     m_pConfig->registerHandler(&::handleWorkspaceRules, "workspace", {false});
     m_pConfig->registerHandler(&::handleWindowRule, "windowrule", {false});
     m_pConfig->registerHandler(&::handleLayerRule, "layerrule", {false});
-    m_pConfig->registerHandler(&::handleWindowRuleV2, "windowrulev2", {false});
     m_pConfig->registerHandler(&::handleBezier, "bezier", {false});
     m_pConfig->registerHandler(&::handleAnimation, "animation", {false});
     m_pConfig->registerHandler(&::handleSource, "source", {false});


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
remove the config option `windowrulev2` which doesn't need anymore in version 0.48.0

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I think we should replace all `windowrulev2` with `windowrule` in the config file instead of keeping both options that do the same thing
#### Is it ready for merging, or does it need work?

Ready
