### PR TITLE
Config option: binds:hide_special_on_workspace_change

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2117,6 +2117,8 @@ PHLMONITOR CCompositor::getMonitorFromString(const std::string& name) {
 }
 
 void CCompositor::moveWorkspaceToMonitor(PHLWORKSPACE pWorkspace, PHLMONITOR pMonitor, bool noWarpCursor) {
+    static auto PHIDESPECIALONWORKSPACECHANGE = CConfigValue<Hyprlang::INT>("binds:hide_special_on_workspace_change");
+
     if (!pWorkspace || !pMonitor)
         return;
 
@@ -2198,6 +2200,9 @@ void CCompositor::moveWorkspaceToMonitor(PHLWORKSPACE pWorkspace, PHLMONITOR pMo
             pMonitor->activeWorkspace->m_bVisible = false;
             pMonitor->activeWorkspace->startAnim(false, false);
         }
+
+        if (*PHIDESPECIALONWORKSPACECHANGE)
+            pMonitor->setSpecialWorkspace(nullptr);
 
         setActiveMonitor(pMonitor);
         pMonitor->activeWorkspace = pWorkspace;

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1247,6 +1247,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SBoolData{false},
     },
     SConfigOptionDescription{
+        .value       = "binds:hide_special_on_workspace_change",
+        .description = "If enabled, changing the active workspace (including to itself) will hide the special workspace on the monitor where the newly active workspace resides.",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{false},
+    },
+    SConfigOptionDescription{
         .value       = "binds:allow_workspace_cycles",
         .description = "If enabled, workspaces don’t forget their previous workspace, so cycles can be created by switching to the first workspace in a sequence, then endlessly "
                        "going to the previous workspace.",

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -626,6 +626,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("binds:pass_mouse_when_bound", Hyprlang::INT{0});
     registerConfigVar("binds:scroll_event_delay", Hyprlang::INT{300});
     registerConfigVar("binds:workspace_back_and_forth", Hyprlang::INT{0});
+    registerConfigVar("binds:hide_special_on_workspace_change", Hyprlang::INT{0});
     registerConfigVar("binds:allow_workspace_cycles", Hyprlang::INT{0});
     registerConfigVar("binds:workspace_center_on", Hyprlang::INT{1});
     registerConfigVar("binds:focus_preferred_method", Hyprlang::INT{0});


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Adds a new config option `hide_special_on_workspace_change` under `binds`.  

Currently, changing the active (non-special) workspace does not hide a special workspace if the newly active workspace ends up behind it. For example, if workspace 1 is active on a monitor that has a special workspace visible, dispatching `workspace 2` will change the monitor's active workspace to 2 but will not hide the special workspace; the focus remains on the special workspace. Similarly, other dispatchers that change the active workspace will not hide a special workspace if the newly active workspace ends up behind it. This also includes cases where the active workspace is changed to itself: if workspace 1 is on monitor 0 and monitor 1 has a special workspace open, dispatching `movecurrentworkspacetomonitor 1` will change the focus to monitor 1 along with workspace 1, but will not hide the special workspace on monitor 1.

Though this is behavior does make sense for what special workspaces are meant to be, one might also reasonably expect that dispatching a workspace change would actually change the user to the specified workspace, rather than focusing on a special workspace and placing the specified workspace behind it. 


With `binds:hide_special_on_workspace_change` set to `true`, changing the active workspace (including to itself) will hide the special workspace on the monitor where the newly active workspace resides. Some examples, assuming we have a monitor 0 with an visibile special workspace and active workspace 1:
- `workspace 2` will hide monitor 0's special workspace and set its active workspace to 2.
- `workspace 1` will hide monitor 0's special workspace, changing focus to workspace 1. 
- If we are focused on workspace 3 on some monitor 3, `moveworkspacetomonitor  3 0`  will move workspace 3 to monitor 0 and hide the special workspace on monitor 0, (since `moveworkspacetomonitor` also moves focus along with the workspace). On the other hand, if workspace 4 is also on monitor 3 but not focused, `moveworkspacetomonitor  4 0` will NOT hide monitor 0's special workspace (since we stay focused on workspace 3).
- If we are focused on some monitor 2,  `focusworkspaceoncurrentmonitor 1` will NOT hide monitor 0's special workspace, but will hide monitor 2's special workspace if it is visible.

In all above examples, the special workspace would not be hidden under Hyprland's current behavior. If `binds:hide_special_on_workspace_change` is set to `false` (default), there is no impact on the current behavior. 



#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Yes

