### PR TITLE
pass: remove unusued timeline in texpass

### DIFF
--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -621,14 +621,10 @@ void CPointerManager::renderSoftwareCursorsFor(PHLMONITOR pMonitor, timespec* no
     box.y = std::round(box.y);
 
     CTexPassElement::SRenderData data;
-    data.tex          = texture;
-    data.box          = box.round();
-    data.syncTimeline = currentCursorImage.waitTimeline;
-    data.syncPoint    = currentCursorImage.waitPoint;
-    g_pHyprRenderer->m_sRenderPass.add(makeShared<CTexPassElement>(data));
+    data.tex = texture;
+    data.box = box.round();
 
-    currentCursorImage.waitTimeline.reset();
-    currentCursorImage.waitPoint = 0;
+    g_pHyprRenderer->m_sRenderPass.add(makeShared<CTexPassElement>(data));
 
     if (currentCursorImage.surface)
         currentCursorImage.surface->resource()->frame(now);

--- a/src/managers/PointerManager.hpp
+++ b/src/managers/PointerManager.hpp
@@ -148,8 +148,6 @@ class CPointerManager {
 
         CHyprSignalListener     destroySurface;
         CHyprSignalListener     commitSurface;
-        SP<CSyncTimeline>       waitTimeline = nullptr;
-        uint64_t                waitPoint    = 0;
     } currentCursorImage; // TODO: support various sizes per-output so we can have pixel-perfect cursors
 
     Vector2D pointerPos = {0, 0};

--- a/src/render/pass/TexPassElement.cpp
+++ b/src/render/pass/TexPassElement.cpp
@@ -22,8 +22,7 @@ void CTexPassElement::draw(const CRegion& damage) {
 
     if (data.replaceProjection)
         g_pHyprOpenGL->m_RenderData.monitorProjection = *data.replaceProjection;
-    g_pHyprOpenGL->renderTextureInternalWithDamage(data.tex, data.box, data.a, data.damage.empty() ? damage : data.damage, data.round, data.roundingPower, data.syncTimeline,
-                                                   data.syncPoint);
+    g_pHyprOpenGL->renderTextureInternalWithDamage(data.tex, data.box, data.a, data.damage.empty() ? damage : data.damage, data.round, data.roundingPower);
     if (data.replaceProjection)
         g_pHyprOpenGL->m_RenderData.monitorProjection = g_pHyprOpenGL->m_RenderData.pMonitor->projMatrix;
 }

--- a/src/render/pass/TexPassElement.hpp
+++ b/src/render/pass/TexPassElement.hpp
@@ -16,8 +16,6 @@ class CTexPassElement : public IPassElement {
         int                   round         = 0;
         float                 roundingPower = 2.0f;
         bool                  flipEndFrame  = false;
-        SP<CSyncTimeline>     syncTimeline;
-        int64_t               syncPoint = 0;
         std::optional<Mat3x3> replaceProjection;
         CBox                  clipBox;
     };


### PR DESCRIPTION
remove unused timeline and waitpoint in texpass and especially remove the passing it to renderTextureInternalWithDamage that implicitly converted it to bool. setting discardActive and allowCustomUV.

cursors themself might need some explicit sync work in non cpu buffer cases but not through these.


