### PR TITLE
fix minor ubsan errors

### DIFF
--- a/src/protocols/XDGShell.cpp
+++ b/src/protocols/XDGShell.cpp
@@ -319,8 +319,11 @@ uint32_t CXDGToplevelResource::setSuspeneded(bool sus) {
 void CXDGToplevelResource::applyState() {
     wl_array arr;
     wl_array_init(&arr);
-    wl_array_add(&arr, pendingApply.states.size() * sizeof(int));
-    memcpy(arr.data, pendingApply.states.data(), pendingApply.states.size() * sizeof(int));
+
+    if (!pendingApply.states.empty()) {
+        wl_array_add(&arr, pendingApply.states.size() * sizeof(int));
+        memcpy(arr.data, pendingApply.states.data(), pendingApply.states.size() * sizeof(int));
+    }
 
     resource->sendConfigure(pendingApply.size.x, pendingApply.size.y, &arr);
 

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -3016,7 +3016,7 @@ CEGLSync::~CEGLSync() {
     if (sync == EGL_NO_SYNC_KHR)
         return;
 
-    if (g_pHyprOpenGL->m_sProc.eglDestroySyncKHR(g_pHyprOpenGL->m_pEglDisplay, sync) != EGL_TRUE)
+    if (g_pHyprOpenGL && g_pHyprOpenGL->m_sProc.eglDestroySyncKHR(g_pHyprOpenGL->m_pEglDisplay, sync) != EGL_TRUE)
         Debug::log(ERR, "eglDestroySyncKHR failed");
 }
 


### PR DESCRIPTION
check so g_pHyprOpenGL is a valid pointer on destruction of compositor, and check that we actually have any pendingApply states before trying to create a wl_array on a empty container.

opengl
```
/src/render/OpenGL.cpp:3019:32: runtime error: member access within null pointer of type 'struct CHyprOpenGLImpl'
     #0 0x555565eed979 in CEGLSync::~CEGLSync() /src/render/OpenGL.cpp:3019
     #1 0x555565f6271e in std::default_delete<CEGLSync>::operator()(CEGLSync*)
     const /usr/lib/gcc/x86_64-pc-linux-gnu/14/include/g++-v14/bits/unique_ptr.h:93
```

xdgshell
```
/src/protocols/XDGShell.cpp:323:11: runtime error: null pointer passed as argument 2, which is declared to never be null
     #0 0x5555659bf67e in CXDGToplevelResource::applyState() /src/protocols/XDGShell.cpp:323
     #1 0x5555659bcedc in CXDGToplevelResource::setSize(Hyprutils::Math::Vector2D const&) /src/protocols/XDGShell.cpp:  256
     #2 0x555563eed0ef in Events::listener_commitWindow(void*, void*) /src/events/Windows.cpp:841
     ```