### PR TITLE
core: Don't damage the entire surface every frame

### DIFF
--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -127,18 +127,18 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : resource(reso
     });
 
     resource->setSetBufferScale([this](CWlSurface* r, int32_t scale) {
-        if (scale != pending.scale) {
-            pending.updated |= SSurfaceState::eUpdatedProperties::SURFACE_UPDATED_SCALE | SSurfaceState::eUpdatedProperties::SURFACE_UPDATED_DAMAGE;
-            pending.scale        = scale;
-            pending.bufferDamage = CBox{{}, {INT32_MAX, INT32_MAX}};
-        }
+        if (scale == pending.scale)
+            return;
+        pending.updated |= SSurfaceState::eUpdatedProperties::SURFACE_UPDATED_SCALE | SSurfaceState::eUpdatedProperties::SURFACE_UPDATED_DAMAGE;
+        pending.scale        = scale;
+        pending.bufferDamage = CBox{{}, {INT32_MAX, INT32_MAX}};
     });
     resource->setSetBufferTransform([this](CWlSurface* r, uint32_t tr) {
-        if (tr != pending.transform) {
-            pending.updated |= SSurfaceState::eUpdatedProperties::SURFACE_UPDATED_TRANSFORM | SSurfaceState::eUpdatedProperties::SURFACE_UPDATED_DAMAGE;
-            pending.transform    = (wl_output_transform)tr;
-            pending.bufferDamage = CBox{{}, {INT32_MAX, INT32_MAX}};
-        }
+        if (tr == pending.transform)
+            return;
+        pending.updated |= SSurfaceState::eUpdatedProperties::SURFACE_UPDATED_TRANSFORM | SSurfaceState::eUpdatedProperties::SURFACE_UPDATED_DAMAGE;
+        pending.transform    = (wl_output_transform)tr;
+        pending.bufferDamage = CBox{{}, {INT32_MAX, INT32_MAX}};
     });
 
     resource->setSetInputRegion([this](CWlSurface* r, wl_resource* region) {

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -77,6 +77,7 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : resource(reso
         if (!buffer) {
             pending.buffer.reset();
             pending.texture.reset();
+            pending.bufferSize = Vector2D{};
         } else {
             auto res           = CWLBufferResource::fromResource(buffer);
             pending.buffer     = res && res->buffer ? makeShared<CHLBufferReference>(res->buffer.lock(), self.lock()) : nullptr;
@@ -84,6 +85,9 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : resource(reso
             pending.texture    = res && res->buffer ? res->buffer->texture : nullptr;
             pending.bufferSize = res && res->buffer ? res->buffer->size : Vector2D{};
         }
+
+        if (pending.bufferSize != current.bufferSize)
+            pending.bufferDamage = CBox{{}, {INT32_MAX, INT32_MAX}};
     });
 
     resource->setCommit([this](CWlSurface* r) {
@@ -123,12 +127,18 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : resource(reso
     });
 
     resource->setSetBufferScale([this](CWlSurface* r, int32_t scale) {
-        pending.updated |= SSurfaceState::eUpdatedProperties::SURFACE_UPDATED_SCALE;
-        pending.scale = scale;
+        if (scale != pending.scale) {
+            pending.updated |= SSurfaceState::eUpdatedProperties::SURFACE_UPDATED_SCALE | SSurfaceState::eUpdatedProperties::SURFACE_UPDATED_DAMAGE;
+            pending.scale        = scale;
+            pending.bufferDamage = CBox{{}, {INT32_MAX, INT32_MAX}};
+        }
     });
     resource->setSetBufferTransform([this](CWlSurface* r, uint32_t tr) {
-        pending.updated |= SSurfaceState::eUpdatedProperties::SURFACE_UPDATED_TRANSFORM;
-        pending.transform = (wl_output_transform)tr;
+        if (tr != pending.transform) {
+            pending.updated |= SSurfaceState::eUpdatedProperties::SURFACE_UPDATED_TRANSFORM | SSurfaceState::eUpdatedProperties::SURFACE_UPDATED_DAMAGE;
+            pending.transform    = (wl_output_transform)tr;
+            pending.bufferDamage = CBox{{}, {INT32_MAX, INT32_MAX}};
+        }
     });
 
     resource->setSetInputRegion([this](CWlSurface* r, wl_resource* region) {

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -84,12 +84,6 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : resource(reso
             pending.texture    = res && res->buffer ? res->buffer->texture : nullptr;
             pending.bufferSize = res && res->buffer ? res->buffer->size : Vector2D{};
         }
-
-        Vector2D oldBufSize = current.buffer ? current.bufferSize : Vector2D{};
-        Vector2D newBufSize = pending.buffer ? pending.bufferSize : Vector2D{};
-
-        if (oldBufSize != newBufSize || current.buffer != pending.buffer)
-            pending.bufferDamage = CBox{{}, {INT32_MAX, INT32_MAX}};
     });
 
     resource->setCommit([this](CWlSurface* r) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Previously, every time a client would attach a buffer, Hyprland would damage the entire buffer. That's because we just created a new CHLBufferReference so `current.buffer != pending.buffer` is always true. The equality operator for `SP<CHLBufferReference>` doesn't check if the buffers themselves are equal, it just checks if the shared pointers point to the same CHLBufferReference.

Fixes #6844

We could fix that check, but I think this whole if statement and bufferDamage assignment is unnecessary. The Wayland spec suggests it's on the client to indicate where damage occurred, and doesn't specify anything about resizing or changing buffers implicitly damaging the surface. It especially makes no sense for changing the buffer to trigger damage, because any dmabuf client needs to do that every frame.

I suspect this code was originally added to workaround (perhaps unknowingly) SHM buffer damage being incorrectly implemented, but that was already fixed in #9678

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I've tested this on a couple of apps including dbeaver, but because this is such a broad change it'd be good to get more testing from other users and other apps.

#### Is it ready for merging, or does it need work?
~~I think we should get more testing before merging, but the code's ready~~ Probably ready for merging with this amount of testing
