### PR TITLE
xwayland: Cleanup server startup and FDs

### DIFF
--- a/src/xwayland/Server.hpp
+++ b/src/xwayland/Server.hpp
@@ -34,8 +34,6 @@ class CXWaylandServer {
     bool                                          tryOpenSockets();
     void                                          runXWayland(Hyprutils::OS::CFileDescriptor& notifyFD);
 
-    pid_t                                         serverPID = 0;
-
     std::string                                   displayName;
     int                                           display = -1;
     std::array<Hyprutils::OS::CFileDescriptor, 2> xFDs;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
- We were previously double closing pipeFD, once explicitly with `close(fd);` and once on shutdown when CXWaylandServer was destructed.
- When starting up Xwayland, we forked twice, but did nothing but exit in one of the forks. Then we waited for that useless fork to exit. Perhaps that fork did something at some point, but I removed it as it currently doesn't do anything.
- When generating the Xwayland command, we did `notifyFD.take()` but `.get()` for the other FDs. There's no need to `.take()` because the FD would only be destructed at the end of the function, which isn't reachable because there's no early return and the function ends with an exit call.
- I clarified a comment that wl_client does indeed own the FD and will close it when destroyed, per the wl_client_create docs.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nope

#### Is it ready for merging, or does it need work?
Ready for merging