### PR TITLE
Fix the non-working tearing #9429

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1148,9 +1148,6 @@ bool CWindow::opaque() {
     if (m_fAlpha->value() != 1.f || m_fActiveInactiveAlpha->value() != 1.f)
         return false;
 
-    if (m_vRealSize->goal().floor() != m_vReportedSize)
-        return false;
-
     const auto PWORKSPACE = m_pWorkspace;
 
     if (m_pWLSurface->small() && !m_pWLSurface->m_bFillIgnoreSmall)


### PR DESCRIPTION
Fixes the non-working tearing by skipping a few checks for the solitary windows and making exceptions for the X11 windows when checking for the solitary window for a monitor.

The corresponding changes touch the nature of the X11 scaling in Wayland (Hyprland in particular), where there is a difference between the reported window size and real size, all depending on the scaling and whether the `xwayland:force_zero_scaling` is set to `true` or `false`. By avoiding the checks for the X11 windows, which require calculations based on the real window size, or comparing the two (the real and the reported) sizes, the solitary window check ends up finding a solitary window on the screen, and so, the tearing works again.

Fixes #9429

Ready for merge and review.

