### PR TITLE
protocols: Don't update hdr metadata if image description is unchanged

### DIFF
--- a/src/protocols/ColorManagement.cpp
+++ b/src/protocols/ColorManagement.cpp
@@ -331,11 +331,16 @@ const hdr_output_metadata& CColorManagementSurface::hdrMetadata() {
 }
 
 void CColorManagementSurface::setHDRMetadata(const hdr_output_metadata& metadata) {
-    m_hdrMetadata      = metadata;
-    m_needsNewMetadata = false;
+    m_hdrMetadata          = metadata;
+    m_lastImageDescription = m_imageDescription;
+    m_needsNewMetadata     = false;
 }
 
 bool CColorManagementSurface::needsHdrMetadataUpdate() {
+    if (!m_needsNewMetadata)
+        return false;
+    if (m_imageDescription == m_lastImageDescription)
+        m_needsNewMetadata = false;
     return m_needsNewMetadata;
 }
 

--- a/src/protocols/ColorManagement.hpp
+++ b/src/protocols/ColorManagement.hpp
@@ -65,6 +65,7 @@ class CColorManagementSurface {
     SP<CWpColorManagementSurfaceV1>     m_resource;
     wl_client*                          pClient = nullptr;
     NColorManagement::SImageDescription m_imageDescription;
+    NColorManagement::SImageDescription m_lastImageDescription;
     bool                                m_hasImageDescription = false;
     bool                                m_needsNewMetadata    = false;
     hdr_output_metadata                 m_hdrMetadata;

--- a/src/protocols/XXColorManagement.cpp
+++ b/src/protocols/XXColorManagement.cpp
@@ -245,8 +245,8 @@ CXXColorManagementSurface::CXXColorManagementSurface(SP<CXxColorManagementSurfac
         }
 
         if (surface.valid()) {
-            surface->colorManagement->setHasImageDescription(true);
             surface->colorManagement->m_imageDescription = imageDescription->get()->settings;
+            surface->colorManagement->setHasImageDescription(true);
         } else
             LOGM(ERR, "Set image description for invalid surface");
     });


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Gamescope sends a new frog color management protocol `set_render_intent`, `set_known_container_color_volume`, and `set_known_transfer_function` every commit. Previously, this would trigger a modeset every commit, despite the new image description being equal to the old image description.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I'm not familiar with color management so it might be good to get @UjinT34's review, but this PR does fix the issue for the user who [reported it on Discord](https://discord.com/channels/961691461554950145/1070436481912549497/1355298799756771389).

#### Is it ready for merging, or does it need work?
Ready for merging