### PR TITLE
core: fix artifacts when fullscreening

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2308,12 +2308,8 @@ void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, SFullscreenS
     const eFullscreenMode CURRENT_EFFECTIVE_MODE = (eFullscreenMode)std::bit_floor((uint8_t)PWINDOW->m_sFullscreenState.internal);
     const eFullscreenMode EFFECTIVE_MODE         = (eFullscreenMode)std::bit_floor((uint8_t)state.internal);
 
-    if (PWINDOW->m_bIsFloating && CURRENT_EFFECTIVE_MODE == FSMODE_NONE && EFFECTIVE_MODE != FSMODE_NONE) {
-        for (auto& m : m_vMonitors) {
-            if (PWINDOW->visibleOnMonitor(m) && m != PMONITOR)
-                g_pHyprRenderer->damageMonitor(m);
-        }
-    }
+    if (PWINDOW->m_bIsFloating && CURRENT_EFFECTIVE_MODE == FSMODE_NONE && EFFECTIVE_MODE != FSMODE_NONE)
+        g_pHyprRenderer->damageWindow(PWINDOW);
 
     if (*PALLOWPINFULLSCREEN && !PWINDOW->m_bPinFullscreened && !PWINDOW->isFullscreen() && PWINDOW->m_bPinned) {
         PWINDOW->m_bPinned          = false;

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2308,6 +2308,13 @@ void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, SFullscreenS
     const eFullscreenMode CURRENT_EFFECTIVE_MODE = (eFullscreenMode)std::bit_floor((uint8_t)PWINDOW->m_sFullscreenState.internal);
     const eFullscreenMode EFFECTIVE_MODE         = (eFullscreenMode)std::bit_floor((uint8_t)state.internal);
 
+    if (PWINDOW->m_bIsFloating && CURRENT_EFFECTIVE_MODE == FSMODE_NONE && EFFECTIVE_MODE != FSMODE_NONE) {
+        for (auto& m : m_vMonitors) {
+            if (PWINDOW->visibleOnMonitor(m) && m != PMONITOR)
+                g_pHyprRenderer->damageMonitor(m);
+        }
+    }
+
     if (*PALLOWPINFULLSCREEN && !PWINDOW->m_bPinFullscreened && !PWINDOW->isFullscreen() && PWINDOW->m_bPinned) {
         PWINDOW->m_bPinned          = false;
         PWINDOW->m_bPinFullscreened = true;


### PR DESCRIPTION
fixes an issue where fullscreening a floating window that is between two monitors causes artifacts to appear on the monitor where it did not become fullscreened on

fixes #9673 

