### PR TITLE
layout: center floating window at cursor when picked up from fullscreen

### DIFF
--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -240,10 +240,9 @@ void IHyprLayout::onBeginDragWindow() {
         return;
     }
 
-    bool wasFullscreen = false;
-    if (DRAGGINGWINDOW->isFullscreen()) {
+    const bool WAS_FULLSCREEN = DRAGGINGWINDOW->isFullscreen();
+    if (WAS_FULLSCREEN) {
         Debug::log(LOG, "Dragging a fullscreen window");
-        wasFullscreen = true;
         g_pCompositor->setWindowFullscreenInternal(DRAGGINGWINDOW, FSMODE_NONE);
     }
 
@@ -259,7 +258,7 @@ void IHyprLayout::onBeginDragWindow() {
 
     m_vDraggingWindowOriginalFloatSize = DRAGGINGWINDOW->m_vLastFloatingSize;
 
-    if (wasFullscreen && DRAGGINGWINDOW->m_bIsFloating) {
+    if (WAS_FULLSCREEN && DRAGGINGWINDOW->m_bIsFloating) {
         const auto MOUSECOORDS           = g_pInputManager->getMouseCoordsInternal();
         *DRAGGINGWINDOW->m_vRealPosition = MOUSECOORDS - DRAGGINGWINDOW->m_vRealSize->goal() / 2.f;
     } else if (!DRAGGINGWINDOW->m_bIsFloating) {

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -240,8 +240,10 @@ void IHyprLayout::onBeginDragWindow() {
         return;
     }
 
+    bool wasFullscreen = false;
     if (DRAGGINGWINDOW->isFullscreen()) {
         Debug::log(LOG, "Dragging a fullscreen window");
+        wasFullscreen = true;
         g_pCompositor->setWindowFullscreenInternal(DRAGGINGWINDOW, FSMODE_NONE);
     }
 
@@ -257,7 +259,10 @@ void IHyprLayout::onBeginDragWindow() {
 
     m_vDraggingWindowOriginalFloatSize = DRAGGINGWINDOW->m_vLastFloatingSize;
 
-    if (!DRAGGINGWINDOW->m_bIsFloating) {
+    if (wasFullscreen && DRAGGINGWINDOW->m_bIsFloating) {
+        const auto MOUSECOORDS           = g_pInputManager->getMouseCoordsInternal();
+        *DRAGGINGWINDOW->m_vRealPosition = MOUSECOORDS - DRAGGINGWINDOW->m_vRealSize->goal() / 2.f;
+    } else if (!DRAGGINGWINDOW->m_bIsFloating) {
         if (g_pInputManager->dragMode == MBIND_MOVE) {
             DRAGGINGWINDOW->m_vLastFloatingSize = (DRAGGINGWINDOW->m_vRealSize->goal() * 0.8489).clamp(Vector2D{5, 5}, Vector2D{}).floor();
             changeWindowFloatingMode(DRAGGINGWINDOW);


### PR DESCRIPTION
when picking up a floating window after it had been fullscreened before it would return to its previous position which looked ugly because the cursor could be no where near the windows original position, this patch makes it so that the window is returned to the users current cursor position

video of the previous behavior:

https://github.com/hyprwm/Hyprland/issues/9779#issuecomment-2763122913

it's wayyy better now

fixes #9779 

