### PR TITLE
window: don't deactivate unfocused xwayland windows in groups

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1791,6 +1791,10 @@ void CWindow::deactivateGroupMembers() {
     auto curr = getGroupHead();
     while (curr) {
         if (curr != m_pSelf.lock()) {
+            // we dont want to deactivate unfocused xwayland windows
+            // because X is weird, keep the behavior for wayland windows
+            // also its not really needed for xwayland windows
+            // ref: #9760 #9294
             if (!curr->m_bIsX11 && curr->m_pXDGSurface && curr->m_pXDGSurface->toplevel)
                 curr->m_pXDGSurface->toplevel->setActive(false);
         }

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1791,9 +1791,7 @@ void CWindow::deactivateGroupMembers() {
     auto curr = getGroupHead();
     while (curr) {
         if (curr != m_pSelf.lock()) {
-            if (curr->m_bIsX11)
-                curr->m_pXWaylandSurface->activate(false);
-            else if (curr->m_pXDGSurface && curr->m_pXDGSurface->toplevel)
+            if (!curr->m_bIsX11 && curr->m_pXDGSurface && curr->m_pXDGSurface->toplevel)
                 curr->m_pXDGSurface->toplevel->setActive(false);
         }
 


### PR DESCRIPTION
we dont want to deactivate unfocused xwayland windows because X is weird, keep the behavior for wayland windows
also its not really needed for xwayland windows

fixes #9760 

