### PR TITLE
Auto hdr

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1398,9 +1398,9 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
     },
     SConfigOptionDescription{
         .value       = "render:cm_auto_hdr",
-        .description = "Auto-switch to hdr mode when fullscreen app is in hdr (cm_fs_passthrough can switch to hdr even when this setting is off)",
-        .type        = CONFIG_OPTION_BOOL,
-        .data        = SConfigOptionDescription::SBoolData{true},
+        .description = "Auto-switch to hdr mode when fullscreen app is in hdr, 0 - off, 1 - hdr, 2 - hdredid (cm_fs_passthrough can switch to hdr even when this setting is off)",
+        .type        = CONFIG_OPTION_INT,
+        .data        = SConfigOptionDescription::SRangeData{.value = 1, .min = 0, .max = 2},
     },
 
     /*

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1396,6 +1396,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .type        = CONFIG_OPTION_BOOL,
         .data        = SConfigOptionDescription::SBoolData{true},
     },
+    SConfigOptionDescription{
+        .value       = "render:cm_auto_hdr",
+        .description = "Auto-switch to hdr mode when fullscreen app is in hdr (cm_fs_passthrough can switch to hdr even when this setting is off)",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{true},
+    },
 
     /*
      * cursor:

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -696,6 +696,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("render:ctm_animation", Hyprlang::INT{2});
     registerConfigVar("render:cm_fs_passthrough", Hyprlang::INT{2});
     registerConfigVar("render:cm_enabled", Hyprlang::INT{1});
+    registerConfigVar("render:cm_auto_hdr", Hyprlang::INT{1});
 
     registerConfigVar("ecosystem:no_update_news", Hyprlang::INT{0});
     registerConfigVar("ecosystem:no_donation_nag", Hyprlang::INT{0});

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -374,6 +374,52 @@ void CMonitor::onDisconnect(bool destroy) {
     std::erase_if(g_pCompositor->m_vMonitors, [&](PHLMONITOR& el) { return el.get() == this; });
 }
 
+void CMonitor::applyCMType(eCMType cmType) {
+    switch (cmType) {
+        case CM_SRGB: imageDescription = {}; break; // assumes SImageDescirption defaults to sRGB
+        case CM_WIDE:
+            imageDescription = {.primariesNameSet = true,
+                                .primariesNamed   = NColorManagement::CM_PRIMARIES_BT2020,
+                                .primaries        = NColorManagement::getPrimaries(NColorManagement::CM_PRIMARIES_BT2020)};
+            break;
+        case CM_EDID:
+            imageDescription = {.primariesNameSet = false,
+                                .primariesNamed   = NColorManagement::CM_PRIMARIES_BT2020,
+                                .primaries        = {
+                                           .red   = {.x = output->parsedEDID.chromaticityCoords->red.x, .y = output->parsedEDID.chromaticityCoords->red.y},
+                                           .green = {.x = output->parsedEDID.chromaticityCoords->green.x, .y = output->parsedEDID.chromaticityCoords->green.y},
+                                           .blue  = {.x = output->parsedEDID.chromaticityCoords->blue.x, .y = output->parsedEDID.chromaticityCoords->blue.y},
+                                           .white = {.x = output->parsedEDID.chromaticityCoords->white.x, .y = output->parsedEDID.chromaticityCoords->white.y},
+                                }};
+            break;
+        case CM_HDR:
+            imageDescription = {.transferFunction = NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ,
+                                .primariesNameSet = true,
+                                .primariesNamed   = NColorManagement::CM_PRIMARIES_BT2020,
+                                .primaries        = NColorManagement::getPrimaries(NColorManagement::CM_PRIMARIES_BT2020),
+                                .luminances       = {.min = 0, .max = 10000, .reference = 203}};
+            break;
+        case CM_HDR_EDID:
+            imageDescription = {.transferFunction = NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ,
+                                .primariesNameSet = false,
+                                .primariesNamed   = NColorManagement::CM_PRIMARIES_BT2020,
+                                .primaries        = output->parsedEDID.chromaticityCoords.has_value() ?
+                                           NColorManagement::SPCPRimaries{
+                                               .red   = {.x = output->parsedEDID.chromaticityCoords->red.x, .y = output->parsedEDID.chromaticityCoords->red.y},
+                                               .green = {.x = output->parsedEDID.chromaticityCoords->green.x, .y = output->parsedEDID.chromaticityCoords->green.y},
+                                               .blue  = {.x = output->parsedEDID.chromaticityCoords->blue.x, .y = output->parsedEDID.chromaticityCoords->blue.y},
+                                               .white = {.x = output->parsedEDID.chromaticityCoords->white.x, .y = output->parsedEDID.chromaticityCoords->white.y},
+                                    } :
+                                           NColorManagement::getPrimaries(NColorManagement::CM_PRIMARIES_BT2020),
+                                .luminances       = {.min       = output->parsedEDID.hdrMetadata->desiredContentMinLuminance,
+                                                     .max       = output->parsedEDID.hdrMetadata->desiredContentMaxLuminance,
+                                                     .reference = output->parsedEDID.hdrMetadata->desiredMaxFrameAverageLuminance}};
+
+            break;
+        default: UNREACHABLE();
+    }
+}
+
 bool CMonitor::applyMonitorRule(SMonitorRule* pMonitorRule, bool force) {
 
     static auto PDISABLESCALECHECKS = CConfigValue<Hyprlang::INT>("debug:disable_scale_checks");
@@ -682,49 +728,7 @@ bool CMonitor::applyMonitorRule(SMonitorRule* pMonitorRule, bool force) {
             break;
         default: break;
     }
-    switch (cmType) {
-        case CM_SRGB: imageDescription = {}; break; // assumes SImageDescirption defaults to sRGB
-        case CM_WIDE:
-            imageDescription = {.primariesNameSet = true,
-                                .primariesNamed   = NColorManagement::CM_PRIMARIES_BT2020,
-                                .primaries        = NColorManagement::getPrimaries(NColorManagement::CM_PRIMARIES_BT2020)};
-            break;
-        case CM_EDID:
-            imageDescription = {.primariesNameSet = false,
-                                .primariesNamed   = NColorManagement::CM_PRIMARIES_BT2020,
-                                .primaries        = {
-                                           .red   = {.x = output->parsedEDID.chromaticityCoords->red.x, .y = output->parsedEDID.chromaticityCoords->red.y},
-                                           .green = {.x = output->parsedEDID.chromaticityCoords->green.x, .y = output->parsedEDID.chromaticityCoords->green.y},
-                                           .blue  = {.x = output->parsedEDID.chromaticityCoords->blue.x, .y = output->parsedEDID.chromaticityCoords->blue.y},
-                                           .white = {.x = output->parsedEDID.chromaticityCoords->white.x, .y = output->parsedEDID.chromaticityCoords->white.y},
-                                }};
-            break;
-        case CM_HDR:
-            imageDescription = {.transferFunction = NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ,
-                                .primariesNameSet = true,
-                                .primariesNamed   = NColorManagement::CM_PRIMARIES_BT2020,
-                                .primaries        = NColorManagement::getPrimaries(NColorManagement::CM_PRIMARIES_BT2020),
-                                .luminances       = {.min = 0, .max = 10000, .reference = 203}};
-            break;
-        case CM_HDR_EDID:
-            imageDescription = {.transferFunction = NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ,
-                                .primariesNameSet = false,
-                                .primariesNamed   = NColorManagement::CM_PRIMARIES_BT2020,
-                                .primaries        = output->parsedEDID.chromaticityCoords.has_value() ?
-                                           NColorManagement::SPCPRimaries{
-                                               .red   = {.x = output->parsedEDID.chromaticityCoords->red.x, .y = output->parsedEDID.chromaticityCoords->red.y},
-                                               .green = {.x = output->parsedEDID.chromaticityCoords->green.x, .y = output->parsedEDID.chromaticityCoords->green.y},
-                                               .blue  = {.x = output->parsedEDID.chromaticityCoords->blue.x, .y = output->parsedEDID.chromaticityCoords->blue.y},
-                                               .white = {.x = output->parsedEDID.chromaticityCoords->white.x, .y = output->parsedEDID.chromaticityCoords->white.y},
-                                    } :
-                                           NColorManagement::getPrimaries(NColorManagement::CM_PRIMARIES_BT2020),
-                                .luminances       = {.min       = output->parsedEDID.hdrMetadata->desiredContentMinLuminance,
-                                                     .max       = output->parsedEDID.hdrMetadata->desiredContentMaxLuminance,
-                                                     .reference = output->parsedEDID.hdrMetadata->desiredMaxFrameAverageLuminance}};
-
-            break;
-        default: UNREACHABLE();
-    }
+    applyCMType(cmType);
     if (oldImageDescription != imageDescription)
         PROTO::colorManagement->onMonitorImageDescriptionChanged(self);
 

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -183,6 +183,7 @@ class CMonitor {
     // methods
     void                                onConnect(bool noRule);
     void                                onDisconnect(bool destroy = false);
+    void                                applyCMType(eCMType cmType);
     bool                                applyMonitorRule(SMonitorRule* pMonitorRule, bool force = false);
     void                                addDamage(const pixman_region32_t* rg);
     void                                addDamage(const CRegion& rg);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -26,6 +26,7 @@
 #include "../hyprerror/HyprError.hpp"
 #include "../debug/HyprDebugOverlay.hpp"
 #include "../debug/HyprNotificationOverlay.hpp"
+#include "helpers/Monitor.hpp"
 #include "pass/TexPassElement.hpp"
 #include "pass/ClearPassElement.hpp"
 #include "pass/RectPassElement.hpp"
@@ -1455,8 +1456,9 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
     static auto PPASS    = CConfigValue<Hyprlang::INT>("render:cm_fs_passthrough");
     static auto PAUTOHDR = CConfigValue<Hyprlang::INT>("render:cm_auto_hdr");
 
-    bool        wantHDR     = (pMonitor->cmType == CM_HDR_EDID || pMonitor->cmType == CM_HDR);
-    const bool  hdsIsActive = pMonitor->output->state->state().hdrMetadata.hdmi_metadata_type1.eotf == 2;
+    const bool  configuredHDR = (pMonitor->cmType == CM_HDR_EDID || pMonitor->cmType == CM_HDR);
+    const bool  hdsIsActive   = pMonitor->output->state->state().hdrMetadata.hdmi_metadata_type1.eotf == 2;
+    bool        wantHDR       = configuredHDR;
 
     const bool  SUPPORTSPQ = pMonitor->output->parsedEDID.hdrMetadata.has_value() ? pMonitor->output->parsedEDID.hdrMetadata->supportsPQ : false;
     Debug::log(TRACE, "ColorManagement supportsBT2020 {}, supportsPQ {}", pMonitor->output->parsedEDID.supportsBT2020, SUPPORTSPQ);
@@ -1499,10 +1501,10 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
 
         if (!hdrIsHandled) {
             if (hdsIsActive != wantHDR) {
-                if (*PAUTOHDR && (!hdsIsActive || (hdsIsActive && pMonitor->cmType != CM_HDR))) {
+                if (*PAUTOHDR && hdsIsActive != configuredHDR) {
                     // modify or restore monitor image description for auto-hdr
                     // FIXME ok for now, will need some other logic if monitor image description can be modified some other way
-                    pMonitor->applyCMType(wantHDR ? CM_HDR : pMonitor->cmType);
+                    pMonitor->applyCMType(wantHDR ? (*PAUTOHDR == 2 ? CM_HDR_EDID : CM_HDR) : pMonitor->cmType);
                 }
                 pMonitor->output->state->setHDRMetadata(wantHDR ? createHDRMetadata(pMonitor->imageDescription, pMonitor->output->parsedEDID) : NO_HDR_METADATA);
             }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1501,7 +1501,7 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
 
         if (!hdrIsHandled) {
             if (hdsIsActive != wantHDR) {
-                if (*PAUTOHDR && hdsIsActive != configuredHDR) {
+                if (*PAUTOHDR && !(hdsIsActive && configuredHDR)) {
                     // modify or restore monitor image description for auto-hdr
                     // FIXME ok for now, will need some other logic if monitor image description can be modified some other way
                     pMonitor->applyCMType(wantHDR ? (*PAUTOHDR == 2 ? CM_HDR_EDID : CM_HDR) : pMonitor->cmType);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1452,8 +1452,11 @@ static hdr_output_metadata       createHDRMetadata(SImageDescription settings, A
 }
 
 bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
-    static auto PPASS = CConfigValue<Hyprlang::INT>("render:cm_fs_passthrough");
-    const bool  PHDR  = pMonitor->imageDescription.transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ;
+    static auto PPASS    = CConfigValue<Hyprlang::INT>("render:cm_fs_passthrough");
+    static auto PAUTOHDR = CConfigValue<Hyprlang::INT>("render:cm_auto_hdr");
+
+    bool        wantHDR     = (pMonitor->cmType == CM_HDR_EDID || pMonitor->cmType == CM_HDR);
+    const bool  hdsIsActive = pMonitor->output->state->state().hdrMetadata.hdmi_metadata_type1.eotf == 2;
 
     const bool  SUPPORTSPQ = pMonitor->output->parsedEDID.hdrMetadata.has_value() ? pMonitor->output->parsedEDID.hdrMetadata->supportsPQ : false;
     Debug::log(TRACE, "ColorManagement supportsBT2020 {}, supportsPQ {}", pMonitor->output->parsedEDID.supportsBT2020, SUPPORTSPQ);
@@ -1469,32 +1472,40 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
         //           fullscreen SDR surface: monitor settings
         //           fullscreen HDR surface: surface settings
 
-        bool wantHDR      = PHDR;
         bool hdrIsHandled = false;
-        if (*PPASS && pMonitor->activeWorkspace && pMonitor->activeWorkspace->m_bHasFullscreenWindow && pMonitor->activeWorkspace->m_efFullscreenMode == FSMODE_FULLSCREEN) {
+        if (pMonitor->activeWorkspace && pMonitor->activeWorkspace->m_bHasFullscreenWindow && pMonitor->activeWorkspace->m_efFullscreenMode == FSMODE_FULLSCREEN) {
             const auto WINDOW    = pMonitor->activeWorkspace->getFullscreenWindow();
             const auto ROOT_SURF = WINDOW->m_pWLSurface->resource();
             const auto SURF =
                 ROOT_SURF->findFirstPreorder([ROOT_SURF](SP<CWLSurfaceResource> surf) { return surf->colorManagement.valid() && surf->extends() == ROOT_SURF->extends(); });
 
-            wantHDR = PHDR && *PPASS == 2;
-
-            // we have a surface with image description and it's allowed by wantHDR
-            if (SURF && SURF->colorManagement.valid() && SURF->colorManagement->hasImageDescription() &&
-                (!wantHDR || SURF->colorManagement->imageDescription().transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ)) {
-                bool needsHdrMetadataUpdate = SURF->colorManagement->needsHdrMetadataUpdate() || pMonitor->m_previousFSWindow != WINDOW;
-                if (SURF->colorManagement->needsHdrMetadataUpdate())
-                    SURF->colorManagement->setHDRMetadata(createHDRMetadata(SURF->colorManagement->imageDescription(), pMonitor->output->parsedEDID));
-                if (needsHdrMetadataUpdate)
-                    pMonitor->output->state->setHDRMetadata(SURF->colorManagement->hdrMetadata());
-                hdrIsHandled = true;
+            // we have a surface with image description
+            if (SURF && SURF->colorManagement.valid() && SURF->colorManagement->hasImageDescription()) {
+                const bool surfaceIsHDR = SURF->colorManagement->imageDescription().transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ;
+                if (*PPASS == 1 || (*PPASS == 2 && surfaceIsHDR)) {
+                    // passthrough
+                    bool needsHdrMetadataUpdate = SURF->colorManagement->needsHdrMetadataUpdate() || pMonitor->m_previousFSWindow != WINDOW;
+                    if (SURF->colorManagement->needsHdrMetadataUpdate())
+                        SURF->colorManagement->setHDRMetadata(createHDRMetadata(SURF->colorManagement->imageDescription(), pMonitor->output->parsedEDID));
+                    if (needsHdrMetadataUpdate)
+                        pMonitor->output->state->setHDRMetadata(SURF->colorManagement->hdrMetadata());
+                    hdrIsHandled = true;
+                } else if (*PAUTOHDR && surfaceIsHDR)
+                    wantHDR = true; // auto-hdr: hdr on
             }
 
             pMonitor->m_previousFSWindow = WINDOW;
         }
+
         if (!hdrIsHandled) {
-            if ((pMonitor->output->state->state().hdrMetadata.hdmi_metadata_type1.eotf == 2) != wantHDR)
+            if (hdsIsActive != wantHDR) {
+                if (*PAUTOHDR && (!hdsIsActive || (hdsIsActive && pMonitor->cmType != CM_HDR))) {
+                    // modify or restore monitor image description for auto-hdr
+                    // FIXME ok for now, will need some other logic if monitor image description can be modified some other way
+                    pMonitor->applyCMType(wantHDR ? CM_HDR : pMonitor->cmType);
+                }
                 pMonitor->output->state->setHDRMetadata(wantHDR ? createHDRMetadata(pMonitor->imageDescription, pMonitor->output->parsedEDID) : NO_HDR_METADATA);
+            }
             pMonitor->m_previousFSWindow.reset();
         }
     }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds `render:cm_auto_hdr` for hdr automation. Should be used with `cm_fs_passthrough = 0`, won't do anything with other values.
0 - off
1 - sets `cm, hdr`
2 - sets `cm, hdredid`

Can be used to fix the same issue as in https://github.com/hyprwm/Hyprland/pull/9776 in a more reliable way (both PRs are needed to cover all possible configurations)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Needs more testing with different `cm`, `cm_fs_passthrough` and `cm_auto_hdr` values. Might not work as expected with some combo. I've tested most sensible ones.

#### Is it ready for merging, or does it need work?
Ready

