### PR TITLE
Fix matching monitor by description to allow space prefix

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1706,8 +1706,8 @@ void CConfigManager::addParseError(const std::string& err) {
 
 PHLMONITOR CConfigManager::getBoundMonitorForWS(const std::string& wsname) {
     auto monitor = getBoundMonitorStringForWS(wsname);
-    if (monitor.substr(0, 5) == "desc:")
-        return g_pCompositor->getMonitorFromDesc(monitor.substr(5));
+    if (monitor.starts_with("desc:"))
+        return g_pCompositor->getMonitorFromDesc(trim(monitor.substr(5)));
     else
         return g_pCompositor->getMonitorFromName(monitor);
 }
@@ -1797,8 +1797,8 @@ std::string CConfigManager::getDefaultWorkspaceFor(const std::string& name) {
         if (other->isDefault) {
             if (other->monitor == name)
                 return other->workspaceString;
-            if (other->monitor.substr(0, 5) == "desc:") {
-                auto const monitor = g_pCompositor->getMonitorFromDesc(other->monitor.substr(5));
+            if (other->monitor.starts_with("desc:")) {
+                auto const monitor = g_pCompositor->getMonitorFromDesc(trim(other->monitor.substr(5)));
                 if (monitor && monitor->szName == name)
                     return other->workspaceString;
             }

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -881,7 +881,7 @@ bool CMonitor::isMirror() {
 bool CMonitor::matchesStaticSelector(const std::string& selector) const {
     if (selector.starts_with("desc:")) {
         // match by description
-        const auto DESCRIPTIONSELECTOR = selector.substr(5);
+        const auto DESCRIPTIONSELECTOR = trim(selector.substr(5));
 
         return szDescription.starts_with(DESCRIPTIONSELECTOR) || szShortDescription.starts_with(DESCRIPTIONSELECTOR);
     } else {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
When configuring a monitor by description such as : 
```
monitor=desc: Chimei Innolux Corporation 0x1417,preferred,auto,1
```
It will not work because there is a space after `:`. it took me a while to get that there mustn't be any spaces. 

This PR is to allow spaces after `desc:`. while I'm at it, I used `start_with` instead of `substr`  as it can throw out of  range exception.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nothing.

#### Is it ready for merging, or does it need work?
I don't see blockers. 

