### PR TITLE
opengl: check for g_pHyprOpengl pointer

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -3175,7 +3175,7 @@ CEGLSync::~CEGLSync() {
     if (sync == EGL_NO_SYNC_KHR)
         return;
 
-    if (g_pHyprOpenGL->m_sProc.eglDestroySyncKHR(g_pHyprOpenGL->m_pEglDisplay, sync) != EGL_TRUE)
+    if (g_pHyprOpenGL && g_pHyprOpenGL->m_sProc.eglDestroySyncKHR(g_pHyprOpenGL->m_pEglDisplay, sync) != EGL_TRUE)
         Debug::log(ERR, "eglDestroySyncKHR failed");
 }
 


### PR DESCRIPTION
restore the pointer check to avoid null ptr dereference on compositor destruction.

was accidently removed in https://github.com/hyprwm/Hyprland/commit/7374a023eff964817c9e5fbe75a661540516f798

fixes: https://github.com/hyprwm/Hyprland/issues/9787
