### PR TITLE
layerrules: add abovelock to render above lockscreen

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1286,9 +1286,12 @@ SP<CWLSurfaceResource> CCompositor::vectorToLayerPopupSurface(const Vector2D& po
     return nullptr;
 }
 
-SP<CWLSurfaceResource> CCompositor::vectorToLayerSurface(const Vector2D& pos, std::vector<PHLLSREF>* layerSurfaces, Vector2D* sCoords, PHLLS* ppLayerSurfaceFound, bool aboveLockscreen) {
+SP<CWLSurfaceResource> CCompositor::vectorToLayerSurface(const Vector2D& pos, std::vector<PHLLSREF>* layerSurfaces, Vector2D* sCoords, PHLLS* ppLayerSurfaceFound,
+                                                         bool aboveLockscreen) {
+
     for (auto const& ls : *layerSurfaces | std::views::reverse) {
-        if (!ls->m_mapped || ls->m_fadingOut || !ls->m_layerSurface || (ls->m_layerSurface && !ls->m_layerSurface->surface->mapped) || ls->m_alpha->value() == 0.f || (aboveLockscreen && (!ls->m_aboveLockscreen || !ls->m_aboveLockscreenInteractable)))
+    if (!ls->m_mapped || ls->m_fadingOut || !ls->m_layerSurface || (ls->m_layerSurface && !ls->m_layerSurface->surface->mapped) || ls->m_alpha->value() == 0.f ||
+        (aboveLockscreen && (!ls->m_aboveLockscreen || !ls->m_aboveLockscreenInteractable)))
             continue;
 
         auto [surf, local] = ls->m_layerSurface->surface->at(pos - ls->m_geometry.pos(), true);

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1286,9 +1286,9 @@ SP<CWLSurfaceResource> CCompositor::vectorToLayerPopupSurface(const Vector2D& po
     return nullptr;
 }
 
-SP<CWLSurfaceResource> CCompositor::vectorToLayerSurface(const Vector2D& pos, std::vector<PHLLSREF>* layerSurfaces, Vector2D* sCoords, PHLLS* ppLayerSurfaceFound) {
+SP<CWLSurfaceResource> CCompositor::vectorToLayerSurface(const Vector2D& pos, std::vector<PHLLSREF>* layerSurfaces, Vector2D* sCoords, PHLLS* ppLayerSurfaceFound, bool aboveLockscreen) {
     for (auto const& ls : *layerSurfaces | std::views::reverse) {
-        if (!ls->m_mapped || ls->m_fadingOut || !ls->m_layerSurface || (ls->m_layerSurface && !ls->m_layerSurface->surface->mapped) || ls->m_alpha->value() == 0.f)
+        if (!ls->m_mapped || ls->m_fadingOut || !ls->m_layerSurface || (ls->m_layerSurface && !ls->m_layerSurface->surface->mapped) || ls->m_alpha->value() == 0.f || (aboveLockscreen && (!ls->m_aboveLockscreen || !ls->m_aboveLockscreenInteractable)))
             continue;
 
         auto [surf, local] = ls->m_layerSurface->surface->at(pos - ls->m_geometry.pos(), true);

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1290,8 +1290,8 @@ SP<CWLSurfaceResource> CCompositor::vectorToLayerSurface(const Vector2D& pos, st
                                                          bool aboveLockscreen) {
 
     for (auto const& ls : *layerSurfaces | std::views::reverse) {
-    if (!ls->m_mapped || ls->m_fadingOut || !ls->m_layerSurface || (ls->m_layerSurface && !ls->m_layerSurface->surface->mapped) || ls->m_alpha->value() == 0.f ||
-        (aboveLockscreen && (!ls->m_aboveLockscreen || !ls->m_aboveLockscreenInteractable)))
+        if (!ls->m_mapped || ls->m_fadingOut || !ls->m_layerSurface || (ls->m_layerSurface && !ls->m_layerSurface->surface->mapped) || ls->m_alpha->value() == 0.f ||
+            (aboveLockscreen && (!ls->m_aboveLockscreen || !ls->m_aboveLockscreenInteractable)))
             continue;
 
         auto [surf, local] = ls->m_layerSurface->surface->at(pos - ls->m_geometry.pos(), true);

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -85,7 +85,7 @@ class CCompositor {
     void                   focusSurface(SP<CWLSurfaceResource>, PHLWINDOW pWindowOwner = nullptr);
     bool                   monitorExists(PHLMONITOR);
     PHLWINDOW              vectorToWindowUnified(const Vector2D&, uint8_t properties, PHLWINDOW pIgnoreWindow = nullptr);
-    SP<CWLSurfaceResource> vectorToLayerSurface(const Vector2D&, std::vector<PHLLSREF>*, Vector2D*, PHLLS*);
+    SP<CWLSurfaceResource> vectorToLayerSurface(const Vector2D&, std::vector<PHLLSREF>*, Vector2D*, PHLLS*, bool aboveLockscreen = false);
     SP<CWLSurfaceResource> vectorToLayerPopupSurface(const Vector2D&, PHLMONITOR monitor, Vector2D*, PHLLS*);
     SP<CWLSurfaceResource> vectorWindowToSurface(const Vector2D&, PHLWINDOW, Vector2D& sl);
     Vector2D               vectorToSurfaceLocal(const Vector2D&, PHLWINDOW, SP<CWLSurfaceResource>);

--- a/src/desktop/LayerRule.cpp
+++ b/src/desktop/LayerRule.cpp
@@ -4,8 +4,8 @@
 #include <algorithm>
 #include "../debug/Log.hpp"
 
-static const auto RULES        = std::unordered_set<std::string>{"noanim", "blur", "blurpopups", "dimaround", "abovelock"};
-static const auto RULES_PREFIX = std::unordered_set<std::string>{"ignorealpha", "ignorezero", "xray", "animation", "order"};
+static const auto RULES        = std::unordered_set<std::string>{"noanim", "blur", "blurpopups", "dimaround"};
+static const auto RULES_PREFIX = std::unordered_set<std::string>{"ignorealpha", "ignorezero", "xray", "animation", "order", "abovelock"};
 
 CLayerRule::CLayerRule(const std::string& rule_, const std::string& ns_) : m_targetNamespace(ns_), m_rule(rule_) {
     const bool VALID = RULES.contains(m_rule) || std::any_of(RULES_PREFIX.begin(), RULES_PREFIX.end(), [&rule_](const auto& prefix) { return rule_.starts_with(prefix); });
@@ -33,6 +33,8 @@ CLayerRule::CLayerRule(const std::string& rule_, const std::string& ns_) : m_tar
         m_ruleType = RULE_ANIMATION;
     else if (m_rule.starts_with("order"))
         m_ruleType = RULE_ORDER;
+    else if (m_rule.starts_with("abovelock"))
+        m_ruleType = RULE_ABOVELOCK;
     else {
         Debug::log(ERR, "CLayerRule: didn't match a rule that was found valid?!");
         m_ruleType = RULE_INVALID;

--- a/src/desktop/LayerRule.cpp
+++ b/src/desktop/LayerRule.cpp
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include "../debug/Log.hpp"
 
-static const auto RULES        = std::unordered_set<std::string>{"noanim", "blur", "blurpopups", "dimaround"};
+static const auto RULES        = std::unordered_set<std::string>{"noanim", "blur", "blurpopups", "dimaround", "abovelock"};
 static const auto RULES_PREFIX = std::unordered_set<std::string>{"ignorealpha", "ignorezero", "xray", "animation", "order"};
 
 CLayerRule::CLayerRule(const std::string& rule_, const std::string& ns_) : m_targetNamespace(ns_), m_rule(rule_) {
@@ -21,6 +21,8 @@ CLayerRule::CLayerRule(const std::string& rule_, const std::string& ns_) : m_tar
         m_ruleType = RULE_BLURPOPUPS;
     else if (m_rule == "dimaround")
         m_ruleType = RULE_DIMAROUND;
+    else if (m_rule == "abovelock")
+        m_ruleType = RULE_ABOVELOCK;
     else if (m_rule.starts_with("ignorealpha"))
         m_ruleType = RULE_IGNOREALPHA;
     else if (m_rule.starts_with("ignorezero"))

--- a/src/desktop/LayerRule.cpp
+++ b/src/desktop/LayerRule.cpp
@@ -21,8 +21,6 @@ CLayerRule::CLayerRule(const std::string& rule_, const std::string& ns_) : m_tar
         m_ruleType = RULE_BLURPOPUPS;
     else if (m_rule == "dimaround")
         m_ruleType = RULE_DIMAROUND;
-    else if (m_rule == "abovelock")
-        m_ruleType = RULE_ABOVELOCK;
     else if (m_rule.starts_with("ignorealpha"))
         m_ruleType = RULE_IGNOREALPHA;
     else if (m_rule.starts_with("ignorezero"))

--- a/src/desktop/LayerRule.hpp
+++ b/src/desktop/LayerRule.hpp
@@ -14,6 +14,7 @@ class CLayerRule {
         RULE_BLUR,
         RULE_BLURPOPUPS,
         RULE_DIMAROUND,
+        RULE_ABOVELOCK,
         RULE_IGNOREALPHA,
         RULE_IGNOREZERO,
         RULE_XRAY,

--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -440,6 +440,11 @@ void CLayerSurface::applyRules() {
             }
             case CLayerRule::RULE_ABOVELOCK: {
                 m_aboveLockscreen = true;
+
+                CVarList vars{rule->m_rule, 0, ' '};
+                try {
+                    m_aboveLockscreenInteractable = configStringToInt(vars[1]).value_or(false);
+                } catch (...) {}
                 break;
             }
             default: break;

--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -421,9 +421,8 @@ void CLayerSurface::applyRules() {
             }
             case CLayerRule::RULE_XRAY: {
                 CVarList vars{rule->m_rule, 0, ' '};
-                try {
-                    m_xray = configStringToInt(vars[1]).value_or(false);
-                } catch (...) {}
+                m_xray = configStringToInt(vars[1]).value_or(false);
+
                 break;
             }
             case CLayerRule::RULE_ANIMATION: {
@@ -442,9 +441,8 @@ void CLayerSurface::applyRules() {
                 m_aboveLockscreen = true;
 
                 CVarList vars{rule->m_rule, 0, ' '};
-                try {
-                    m_aboveLockscreenInteractable = configStringToInt(vars[1]).value_or(false);
-                } catch (...) {}
+                m_aboveLockscreenInteractable = configStringToInt(vars[1]).value_or(false);
+
                 break;
             }
             default: break;

--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -438,6 +438,10 @@ void CLayerSurface::applyRules() {
                 } catch (...) { Debug::log(ERR, "Invalid value passed to order"); }
                 break;
             }
+            case CLayerRule::RULE_ABOVELOCK: {
+                m_aboveLockscreen = true;
+                break;
+            }
             default: break;
         }
     }

--- a/src/desktop/LayerSurface.hpp
+++ b/src/desktop/LayerSurface.hpp
@@ -50,6 +50,7 @@ class CLayerSurface {
     float                      m_ignoreAlphaValue = 0.f;
     bool                       m_dimAround        = false;
     int64_t                    m_order            = 0;
+    bool                       m_aboveLockscreen  = false;
 
     std::optional<std::string> m_animationStyle;
 

--- a/src/desktop/LayerSurface.hpp
+++ b/src/desktop/LayerSurface.hpp
@@ -43,14 +43,14 @@ class CLayerSurface {
     bool                       m_noProcess     = false;
     bool                       m_noAnimations  = false;
 
-    bool                       m_forceBlur        = false;
-    bool                       m_forceBlurPopups  = false;
-    int64_t                    m_xray             = -1;
-    bool                       m_ignoreAlpha      = false;
-    float                      m_ignoreAlphaValue = 0.f;
-    bool                       m_dimAround        = false;
-    int64_t                    m_order            = 0;
-    bool                       m_aboveLockscreen  = false;
+    bool                       m_forceBlur                   = false;
+    bool                       m_forceBlurPopups             = false;
+    int64_t                    m_xray                        = -1;
+    bool                       m_ignoreAlpha                 = false;
+    float                      m_ignoreAlphaValue            = 0.f;
+    bool                       m_dimAround                   = false;
+    int64_t                    m_order                       = 0;
+    bool                       m_aboveLockscreen             = false;
     bool                       m_aboveLockscreenInteractable = false;
 
     std::optional<std::string> m_animationStyle;

--- a/src/desktop/LayerSurface.hpp
+++ b/src/desktop/LayerSurface.hpp
@@ -51,6 +51,7 @@ class CLayerSurface {
     bool                       m_dimAround        = false;
     int64_t                    m_order            = 0;
     bool                       m_aboveLockscreen  = false;
+    int64_t                    m_aboveLockscreenInteractable = false;
 
     std::optional<std::string> m_animationStyle;
 

--- a/src/desktop/LayerSurface.hpp
+++ b/src/desktop/LayerSurface.hpp
@@ -51,7 +51,7 @@ class CLayerSurface {
     bool                       m_dimAround        = false;
     int64_t                    m_order            = 0;
     bool                       m_aboveLockscreen  = false;
-    int64_t                    m_aboveLockscreenInteractable = false;
+    bool                       m_aboveLockscreenInteractable = false;
 
     std::optional<std::string> m_animationStyle;
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -2,6 +2,7 @@
 #include "../../Compositor.hpp"
 #include <aquamarine/output/Output.hpp>
 #include <cstdint>
+#include <hyprutils/math/Vector2D.hpp>
 #include <ranges>
 #include "../../config/ConfigValue.hpp"
 #include "../../config/ConfigManager.hpp"
@@ -249,15 +250,28 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse) {
         g_pCompositor->setActiveMonitor(PMONITOR);
 
     if (g_pSessionLockManager->isSessionLocked()) {
-        const auto PSESSIONLOCKSURFACE = g_pSessionLockManager->getSessionLockSurfaceForMonitor(PMONITOR->ID);
-        surfacePos                     = PMONITOR->vecPosition;
 
-        foundSurface = PSESSIONLOCKSURFACE ? PSESSIONLOCKSURFACE->surface->surface() : nullptr;
+        // search for interactable abovelock surfaces
+        for (auto& lsl : PMONITOR->m_aLayerSurfaceLayers | std::views::reverse) {
+            foundSurface = g_pCompositor->vectorToLayerSurface(mouseCoords, &lsl, &surfaceCoords, &pFoundLayerSurface, true);
+
+            if (foundSurface) break;
+        }
+
+        Vector2D surfacelocal = surfaceCoords;
+
+        // focus sessionlock surface if no abovelock layer found
+        if (!foundSurface) {
+            const auto PSESSIONLOCKSURFACE = g_pSessionLockManager->getSessionLockSurfaceForMonitor(PMONITOR->ID);
+
+            surfacelocal = mouseCoords - PMONITOR->vecPosition;
+            foundSurface = PSESSIONLOCKSURFACE ? PSESSIONLOCKSURFACE->surface->surface() : nullptr;
+        }
+
         g_pCompositor->focusSurface(foundSurface);
+        g_pSeatManager->setPointerFocus(foundSurface, surfacelocal);
+        g_pSeatManager->sendPointerMotion(time, surfacelocal);
 
-        const auto SURFACELOCAL = mouseCoords - surfacePos;
-        g_pSeatManager->setPointerFocus(foundSurface, SURFACELOCAL);
-        g_pSeatManager->sendPointerMotion(time, SURFACELOCAL);
         return;
     }
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -253,7 +253,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse) {
 
         // set keyboard focus on session lock surface regardless of layers
         const auto PSESSIONLOCKSURFACE = g_pSessionLockManager->getSessionLockSurfaceForMonitor(PMONITOR->ID);
-        const auto foundLockSurface = PSESSIONLOCKSURFACE ? PSESSIONLOCKSURFACE->surface->surface() : nullptr;
+        const auto foundLockSurface    = PSESSIONLOCKSURFACE ? PSESSIONLOCKSURFACE->surface->surface() : nullptr;
 
         g_pCompositor->focusSurface(foundLockSurface);
 
@@ -267,7 +267,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse) {
 
         if (!foundSurface) {
             surfaceCoords = mouseCoords - PMONITOR->vecPosition;
-            foundSurface = foundLockSurface;
+            foundSurface  = foundLockSurface;
         }
 
         g_pSeatManager->setPointerFocus(foundSurface, surfaceCoords);

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -255,7 +255,8 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse) {
         for (auto& lsl : PMONITOR->m_aLayerSurfaceLayers | std::views::reverse) {
             foundSurface = g_pCompositor->vectorToLayerSurface(mouseCoords, &lsl, &surfaceCoords, &pFoundLayerSurface, true);
 
-            if (foundSurface) break;
+            if (foundSurface)
+                break;
         }
 
         Vector2D surfacelocal = surfaceCoords;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -690,8 +690,12 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     g_pHyprOpenGL->m_RenderData.currentWindow.reset();
 }
 
-void CHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::steady_tp& time, bool popups) {
+void CHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::steady_tp& time, bool popups, bool lockscreen) {
     if (!pLayer)
+        return;
+
+    // skip rendering based on abovelock rule and make sure to not render abovelock layers twice
+    if ((pLayer->m_aboveLockscreen && !lockscreen && g_pSessionLockManager->isSessionLocked()) || (lockscreen && !pLayer->m_aboveLockscreen))
         return;
 
     static auto PDIMAROUND = CConfigValue<Hyprlang::FLOAT>("decoration:dim_around");
@@ -998,6 +1002,14 @@ void CHyprRenderer::renderLockscreen(PHLMONITOR pMonitor, const Time::steady_tp&
                 renderSessionLockMissing(pMonitor);
         } else {
             renderSessionLockSurface(PSLS, pMonitor, now);
+
+            // render layers for abovelock rule
+            for (auto const& lsl : pMonitor->m_aLayerSurfaceLayers) {
+                for (auto const& ls : lsl) {
+                    renderLayer(ls.lock(), pMonitor, now, false, true);
+                }
+            }
+
             g_pSessionLockManager->onLockscreenRenderedOnMonitor(pMonitor->ID);
         }
     }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1003,10 +1003,15 @@ void CHyprRenderer::renderLockscreen(PHLMONITOR pMonitor, const Time::steady_tp&
         } else {
             renderSessionLockSurface(PSLS, pMonitor, now);
 
-            // render layers for abovelock rule
+            // render layers and then their popups for abovelock rule
             for (auto const& lsl : pMonitor->m_aLayerSurfaceLayers) {
                 for (auto const& ls : lsl) {
                     renderLayer(ls.lock(), pMonitor, now, false, true);
+                }
+            }
+            for (auto const& lsl : pMonitor->m_aLayerSurfaceLayers) {
+                for (auto const& ls : lsl) {
+                    renderLayer(ls.lock(), pMonitor, now, true, true);
                 }
             }
 

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -120,7 +120,7 @@ class CHyprRenderer {
     void renderWorkspaceWindowsFullscreen(PHLMONITOR, PHLWORKSPACE, const Time::steady_tp&); // renders workspace windows (fullscreen) (tiled, floating, pinned, but no special)
     void renderWorkspaceWindows(PHLMONITOR, PHLWORKSPACE, const Time::steady_tp&);           // renders workspace windows (no fullscreen) (tiled, floating, pinned, but no special)
     void renderWindow(PHLWINDOW, PHLMONITOR, const Time::steady_tp&, bool, eRenderPassMode, bool ignorePosition = false, bool standalone = false);
-    void renderLayer(PHLLS, PHLMONITOR, const Time::steady_tp&, bool popups = false);
+    void renderLayer(PHLLS, PHLMONITOR, const Time::steady_tp&, bool popups = false, bool lockscreen = false);
     void renderSessionLockSurface(WP<SSessionLockSurface>, PHLMONITOR, const Time::steady_tp&);
     void renderDragIcon(PHLMONITOR, const Time::steady_tp&);
     void renderIMEPopup(CInputPopup*, PHLMONITOR, const Time::steady_tp&);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This PR adds a new layerrule `abovelock`. If this rule is set on a layer, it will be drawn above the lockscreen if the session is locked. Layers which are drawn above the lockscreen will _not_ be drawn twice (i.e. only above the lock and not also below it) if a lockscreen is active, so semi-transparent layers won't look shit when the lockscreen is just partially opaque.

The layerrule takes a _optional_ boolean as an argument to specify whether the surface should be interactable on the lockscreen. Default is false, meaning the user would not be able to interact with it. Currently, only pointer focus is implemented, so the **keyboard focus will stay on the lockscreen**, as that is probably the expected behaviour anyways.

Configuration example:
```
layerrule = abovelock true, notifications
```

I mainly want this for my own setup but I can imagine plenty of use cases where this would be very cool:
- Be able to see incoming notifications on the lockscreen
- One might want to have their bar above the lockscreen so you can still see your system info (e.g. battery level) on the lockscreen
- An OSD would also be nice if it would be shown on the lockscreen
- You'd be able to use OSKs for touch devices to be able to enter a password
- etc.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
- I am passing a new bool `aboveLockscreen` to `vectorToLayerSurface` such that I can filter the surfaces when checking them. Just checking the result for abovelock would lead to edge-cases e.g. when there are multiple layers above each other, not all being abovelock. Lmk if you have a better idea of handling this.

#### Is it ready for merging, or does it need work?
Yes


