### PR TITLE
core: wait for dmabuf readiness

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1357,6 +1357,10 @@ bool CMonitor::attemptDirectScanout() {
     auto PBUFFER = PSURFACE->current.buffer.buffer;
 
     if (PBUFFER == output->state->state().buffer) {
+        timespec now;
+        clock_gettime(CLOCK_MONOTONIC, &now);
+        PSURFACE->presentFeedback(&now, self.lock());
+
         if (scanoutNeedsCursorUpdate) {
             if (!state.test()) {
                 Debug::log(TRACE, "attemptDirectScanout: failed basic test");
@@ -1403,31 +1407,9 @@ bool CMonitor::attemptDirectScanout() {
     output->state->addDamage(PSURFACE->current.accumulateBufferDamage());
     output->state->resetExplicitFences();
 
-    auto cleanup = CScopeGuard([this]() { output->state->resetExplicitFences(); });
-
-    auto explicitOptions = g_pHyprRenderer->getExplicitSyncSettings(output);
-
-    bool DOEXPLICIT = PSURFACE->syncobj && PSURFACE->current.buffer && PSURFACE->current.acquire && explicitOptions.explicitKMSEnabled;
-    if (DOEXPLICIT) {
-        // wait for surface's explicit fence if present
-        inFence = PSURFACE->current.acquire.exportAsFD();
-        if (inFence.isValid()) {
-            Debug::log(TRACE, "attemptDirectScanout: setting IN_FENCE for aq to {}", inFence.get());
-            output->state->setExplicitInFence(inFence.get());
-        } else {
-            Debug::log(TRACE, "attemptDirectScanout: failed to acquire an sync file fd for aq IN_FENCE");
-            DOEXPLICIT = false;
-        }
-    }
+    // no need to do explicit sync here as surface current can only ever be ready to read
 
     bool ok = output->commit();
-
-    if (!ok && DOEXPLICIT) {
-        Debug::log(TRACE, "attemptDirectScanout: EXPLICIT SYNC FAILED: commit() returned false. Resetting fences and retrying, might result in glitches.");
-        output->state->resetExplicitFences();
-
-        ok = output->commit();
-    }
 
     if (!ok) {
         Debug::log(TRACE, "attemptDirectScanout: failed to scanout surface");

--- a/src/helpers/sync/SyncTimeline.cpp
+++ b/src/helpers/sync/SyncTimeline.cpp
@@ -34,13 +34,6 @@ SP<CSyncTimeline> CSyncTimeline::create(int drmFD_, CFileDescriptor&& drmSyncobj
 }
 
 CSyncTimeline::~CSyncTimeline() {
-    for (auto& w : waiters) {
-        if (w->source) {
-            wl_event_source_remove(w->source);
-            w->source = nullptr;
-        }
-    }
-
     if (handle == 0)
         return;
 
@@ -64,34 +57,8 @@ std::optional<bool> CSyncTimeline::check(uint64_t point, uint32_t flags) {
     return ret == 0;
 }
 
-static int handleWaiterFD(int fd, uint32_t mask, void* data) {
-    auto waiter = (CSyncTimeline::SWaiter*)data;
-
-    if (mask & (WL_EVENT_HANGUP | WL_EVENT_ERROR)) {
-        Debug::log(ERR, "handleWaiterFD: eventfd error");
-        return 0;
-    }
-
-    if (mask & WL_EVENT_READABLE) {
-        uint64_t value = 0;
-        if (read(fd, &value, sizeof(value)) <= 0)
-            Debug::log(ERR, "handleWaiterFD: failed to read from eventfd");
-    }
-
-    wl_event_source_remove(waiter->source);
-    waiter->source = nullptr;
-
-    if (waiter->fn)
-        waiter->fn();
-
-    if (waiter->timeline)
-        waiter->timeline->removeWaiter(waiter);
-
-    return 0;
-}
-
 bool CSyncTimeline::addWaiter(const std::function<void()>& waiter, uint64_t point, uint32_t flags) {
-    CFileDescriptor eventFd = CFileDescriptor{eventfd(0, EFD_CLOEXEC)};
+    auto eventFd = CFileDescriptor(eventfd(0, EFD_CLOEXEC));
 
     if (!eventFd.isValid()) {
         Debug::log(ERR, "CSyncTimeline::addWaiter: failed to acquire an eventfd");
@@ -103,44 +70,9 @@ bool CSyncTimeline::addWaiter(const std::function<void()>& waiter, uint64_t poin
         return false;
     }
 
-    if (eventFd.isReadable()) {
-        waiter();
-        return true;
-    }
-
-    auto w      = makeShared<SWaiter>();
-    w->fn       = waiter;
-    w->timeline = self;
-    w->eventFd  = std::move(eventFd);
-
-    w->source = wl_event_loop_add_fd(g_pEventLoopManager->m_sWayland.loop, w->eventFd.get(), WL_EVENT_READABLE, ::handleWaiterFD, w.get());
-    if (!w->source) {
-        Debug::log(ERR, "CSyncTimeline::addWaiter: wl_event_loop_add_fd failed");
-        return false;
-    }
-
-    waiters.emplace_back(w);
+    g_pEventLoopManager->doOnReadable(std::move(eventFd), waiter);
 
     return true;
-}
-
-void CSyncTimeline::removeWaiter(SWaiter* w) {
-    if (w->source) {
-        wl_event_source_remove(w->source);
-        w->source = nullptr;
-    }
-    std::erase_if(waiters, [w](const auto& e) { return e.get() == w; });
-}
-
-void CSyncTimeline::removeAllWaiters() {
-    for (auto& w : waiters) {
-        if (w->source) {
-            wl_event_source_remove(w->source);
-            w->source = nullptr;
-        }
-    }
-
-    waiters.clear();
 }
 
 CFileDescriptor CSyncTimeline::exportAsSyncFileFD(uint64_t src) {

--- a/src/helpers/sync/SyncTimeline.hpp
+++ b/src/helpers/sync/SyncTimeline.hpp
@@ -20,21 +20,12 @@ class CSyncTimeline {
     static SP<CSyncTimeline> create(int drmFD_, Hyprutils::OS::CFileDescriptor&& drmSyncobjFD);
     ~CSyncTimeline();
 
-    struct SWaiter {
-        std::function<void()>          fn;
-        wl_event_source*               source = nullptr;
-        WP<CSyncTimeline>              timeline;
-        Hyprutils::OS::CFileDescriptor eventFd;
-    };
-
     // check if the timeline point has been signaled
     // flags: DRM_SYNCOBJ_WAIT_FLAGS_WAIT_FOR_SUBMIT or DRM_SYNCOBJ_WAIT_FLAGS_WAIT_AVAILABLE
     // std::nullopt on fail
     std::optional<bool>            check(uint64_t point, uint32_t flags);
 
     bool                           addWaiter(const std::function<void()>& waiter, uint64_t point, uint32_t flags);
-    void                           removeWaiter(SWaiter*);
-    void                           removeAllWaiters();
     Hyprutils::OS::CFileDescriptor exportAsSyncFileFD(uint64_t src);
     bool                           importFromSyncFileFD(uint64_t dst, Hyprutils::OS::CFileDescriptor& fd);
     bool                           transfer(SP<CSyncTimeline> from, uint64_t fromPoint, uint64_t toPoint);
@@ -47,6 +38,4 @@ class CSyncTimeline {
 
   private:
     CSyncTimeline() = default;
-
-    std::vector<SP<SWaiter>> waiters;
 };

--- a/src/managers/eventLoop/EventLoopManager.hpp
+++ b/src/managers/eventLoop/EventLoopManager.hpp
@@ -79,7 +79,6 @@ class CEventLoopManager {
 
     wl_event_source* m_configWatcherInotifySource = nullptr;
 
-    friend class CSyncTimeline;
     friend class CAsyncDialogBox;
 };
 

--- a/src/managers/eventLoop/EventLoopManager.hpp
+++ b/src/managers/eventLoop/EventLoopManager.hpp
@@ -38,6 +38,17 @@ class CEventLoopManager {
         std::vector<std::function<void()>> fns;
     };
 
+    struct SReadableWaiter {
+        wl_event_source*               source;
+        Hyprutils::OS::CFileDescriptor fd;
+        std::function<void()>          fn;
+    };
+
+    // schedule function to when fd is readable (WL_EVENT_READABLE / POLLIN),
+    // takes ownership of fd
+    void doOnReadable(Hyprutils::OS::CFileDescriptor fd, const std::function<void()>& fn);
+    void onFdReadable(SReadableWaiter* waiter);
+
   private:
     // Manages the event sources after AQ pollFDs change.
     void syncPollFDs();
@@ -58,8 +69,9 @@ class CEventLoopManager {
         Hyprutils::OS::CFileDescriptor   timerfd;
     } m_sTimers;
 
-    SIdleData                       m_sIdle;
-    std::map<int, SEventSourceData> aqEventSources;
+    SIdleData                        m_sIdle;
+    std::map<int, SEventSourceData>  aqEventSources;
+    std::vector<UP<SReadableWaiter>> m_vReadableWaiters;
 
     struct {
         CHyprSignalListener pollFDsChanged;

--- a/src/protocols/types/DMABuffer.cpp
+++ b/src/protocols/types/DMABuffer.cpp
@@ -4,6 +4,14 @@
 #include "../../render/Renderer.hpp"
 #include "../../helpers/Format.hpp"
 
+#if defined(__linux__)
+#include <linux/dma-buf.h>
+#include <linux/sync_file.h>
+#include <sys/ioctl.h>
+#endif
+
+using namespace Hyprutils::OS;
+
 CDMABuffer::CDMABuffer(uint32_t id, wl_client* client, Aquamarine::SDMABUFAttrs const& attrs_) : attrs(attrs_) {
     g_pHyprRenderer->makeEGLCurrent();
 
@@ -83,4 +91,63 @@ void CDMABuffer::closeFDs() {
         attrs.fds[i] = -1;
     }
     attrs.planes = 0;
+}
+
+static int doIoctl(int fd, unsigned long request, void* arg) {
+    int ret;
+
+    do {
+        ret = ioctl(fd, request, arg);
+    } while (ret == -1 && (errno == EINTR || errno == EAGAIN));
+    return ret;
+}
+
+// https://www.kernel.org/doc/html/latest/driver-api/dma-buf.html#c.dma_buf_export_sync_file
+// returns a sync file that will be signalled when dmabuf is ready to be read
+CFileDescriptor CDMABuffer::exportSyncFile() {
+    if (!good())
+        return {};
+
+#if !defined(__linux__)
+    return {};
+#else
+    std::vector<CFileDescriptor> syncFds(attrs.fds.size());
+    for (const auto& fd : attrs.fds) {
+        if (fd == -1)
+            continue;
+
+        dma_buf_export_sync_file request{
+            .flags = DMA_BUF_SYNC_READ,
+            .fd    = -1,
+        };
+
+        if (doIoctl(fd, DMA_BUF_IOCTL_EXPORT_SYNC_FILE, &request) == 0)
+            syncFds.emplace_back(request.fd);
+    }
+
+    if (syncFds.empty())
+        return {};
+
+    CFileDescriptor syncFd;
+    for (auto& fd : syncFds) {
+        if (!syncFd.isValid()) {
+            syncFd = std::move(fd);
+            continue;
+        }
+
+        struct sync_merge_data data{
+            .name  = "merged release fence",
+            .fd2   = fd.get(),
+            .fence = -1,
+        };
+
+        if (doIoctl(syncFd.get(), SYNC_IOC_MERGE, &data) == 0) {
+            syncFd = CFileDescriptor(data.fence);
+        } else {
+            syncFd = {};
+        }
+    }
+
+    return syncFd;
+#endif
 }

--- a/src/protocols/types/DMABuffer.cpp
+++ b/src/protocols/types/DMABuffer.cpp
@@ -141,11 +141,10 @@ CFileDescriptor CDMABuffer::exportSyncFile() {
             .fence = -1,
         };
 
-        if (doIoctl(syncFd.get(), SYNC_IOC_MERGE, &data) == 0) {
+        if (doIoctl(syncFd.get(), SYNC_IOC_MERGE, &data) == 0)
             syncFd = CFileDescriptor(data.fence);
-        } else {
+        else
             syncFd = {};
-        }
     }
 
     return syncFd;

--- a/src/protocols/types/DMABuffer.hpp
+++ b/src/protocols/types/DMABuffer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Buffer.hpp"
+#include <hyprutils/os/FileDescriptor.hpp>
 
 class CDMABuffer : public IHLBuffer {
   public:
@@ -16,6 +17,7 @@ class CDMABuffer : public IHLBuffer {
     virtual void                                   endDataPtr();
     bool                                           good();
     void                                           closeFDs();
+    Hyprutils::OS::CFileDescriptor                 exportSyncFile();
 
     bool                                           success = false;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
this pr makes it so that dmabuf buffers, without drmsyncobj acquire points, can only be read when they are ready
this is done by waiting on the [dmabuf's implicit sync read fence](https://www.kernel.org/doc/html/latest/driver-api/dma-buf.html#c.dma_buf_export_sync_file) before using it

the goal here is to ensure we only read buffers that are ready to be read

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

#### Is it ready for merging, or does it need work?
yes
