### PR TITLE
render: properly release rendered buffers

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -60,10 +60,6 @@ void CMonitor::onConnect(bool noRule) {
 
     g_pEventLoopManager->doLater([] { g_pConfigManager->ensurePersistentWorkspacesPresent(); });
 
-    if (output->supportsExplicit) {
-        inTimeline = CSyncTimeline::create(output->getBackend()->drmFD());
-    }
-
     listeners.frame  = output->events.frame.registerListener([this](std::any d) { onMonitorFrame(); });
     listeners.commit = output->events.commit.registerListener([this](std::any d) {
         if (true) { // FIXME: E->state->committed & WLR_OUTPUT_STATE_BUFFER

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -3,7 +3,6 @@
 #include "../macros.hpp"
 #include "math/Math.hpp"
 #include "../protocols/ColorManagement.hpp"
-#include "sync/SyncReleaser.hpp"
 #include "../Compositor.hpp"
 #include "../config/ConfigValue.hpp"
 #include "../config/ConfigManager.hpp"

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -139,9 +139,7 @@ class CMonitor {
     SMonitorRule                activeMonitorRule;
 
     // explicit sync
-    SP<CSyncTimeline>              inTimeline;
     Hyprutils::OS::CFileDescriptor inFence; // TODO: remove when aq uses CFileDescriptor
-    uint64_t                       inTimelinePoint = 0;
 
     PHLMONITORREF                  self;
 

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -140,8 +140,7 @@ class CMonitor {
 
     // explicit sync
     SP<CSyncTimeline>              inTimeline;
-    Hyprutils::OS::CFileDescriptor inFence;
-    SP<CEGLSync>                   eglSync;
+    Hyprutils::OS::CFileDescriptor inFence; // TODO: remove when aq uses CFileDescriptor
     uint64_t                       inTimelinePoint = 0;
 
     PHLMONITORREF                  self;

--- a/src/helpers/sync/SyncReleaser.cpp
+++ b/src/helpers/sync/SyncReleaser.cpp
@@ -53,7 +53,7 @@ CFileDescriptor CSyncReleaser::mergeSyncFds(const CFileDescriptor& fd1, const CF
 
 void CSyncReleaser::addReleaseSync(SP<CEGLSync> sync) {
     if (m_fd.isValid())
-        m_fd = mergeSyncFds(m_fd, sync->takeFD());
+        m_fd = mergeSyncFds(m_fd, sync->takeFd());
     else
         m_fd = sync->fd().duplicate();
 

--- a/src/helpers/sync/SyncReleaser.hpp
+++ b/src/helpers/sync/SyncReleaser.hpp
@@ -22,9 +22,8 @@ class CSyncReleaser {
     // drops the releaser, will never signal anymore
     void drop();
 
-    // wait for this gpu job to finish before releasing
-    Hyprutils::OS::CFileDescriptor mergeSyncFds(const Hyprutils::OS::CFileDescriptor& fd1, const Hyprutils::OS::CFileDescriptor& fd2);
-    void                           addReleaseSync(SP<CEGLSync> sync);
+    // wait for this sync_fd to signal before releasing
+    void addSyncFileFd(const Hyprutils::OS::CFileDescriptor& syncFd);
 
   private:
     SP<CSyncTimeline>              m_timeline;

--- a/src/helpers/sync/SyncReleaser.hpp
+++ b/src/helpers/sync/SyncReleaser.hpp
@@ -12,7 +12,6 @@
 */
 
 class CSyncTimeline;
-class CEGLSync;
 
 class CSyncReleaser {
   public:
@@ -29,5 +28,4 @@ class CSyncReleaser {
     SP<CSyncTimeline>              m_timeline;
     uint64_t                       m_point = 0;
     Hyprutils::OS::CFileDescriptor m_fd;
-    SP<CEGLSync>                   m_sync;
 };

--- a/src/protocols/DRMSyncobj.cpp
+++ b/src/protocols/DRMSyncobj.cpp
@@ -105,10 +105,8 @@ CDRMSyncobjSurfaceResource::CDRMSyncobjSurfaceResource(UP<CWpLinuxDrmSyncobjSurf
         surface->pending.acquire         = pendingAcquire;
         pendingAcquire                   = {};
 
-        surface->pending.buffer.release = pendingRelease;
-        pendingRelease                  = {};
-
-        surface->pending.buffer->syncReleaser = surface->pending.buffer.release.createSyncRelease();
+        surface->pending.buffer->addReleasePoint(pendingRelease);
+        pendingRelease = {};
     });
 }
 

--- a/src/protocols/Screencopy.cpp
+++ b/src/protocols/Screencopy.cpp
@@ -221,21 +221,11 @@ void CScreencopyFrame::copyDmabuf(std::function<void(bool)> callback) {
     }
 
     g_pHyprOpenGL->m_RenderData.blockScreenShader = true;
-    g_pHyprRenderer->endRender();
 
-    auto explicitOptions = g_pHyprRenderer->getExplicitSyncSettings(pMonitor->output);
-    if (pMonitor->inTimeline && explicitOptions.explicitEnabled) {
-        if (pMonitor->inTimeline->addWaiter(
-                [callback, sync = pMonitor->eglSync]() {
-                    LOGM(TRACE, "Copied frame via dma with explicit sync");
-                    callback(true);
-                },
-                pMonitor->inTimelinePoint, 0))
-            return;
-        // on explicit sync failure, fallthrough to immediate callback
-    }
-    LOGM(TRACE, "Copied frame via dma");
-    callback(true);
+    g_pHyprRenderer->endRender([callback]() {
+        LOGM(TRACE, "Copied frame via dma");
+        callback(true);
+    });
 }
 
 bool CScreencopyFrame::copyShm() {

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -7,7 +7,6 @@
 #include "Subcompositor.hpp"
 #include "../Viewporter.hpp"
 #include "../../helpers/Monitor.hpp"
-#include "../../helpers/sync/SyncReleaser.hpp"
 #include "../PresentationTime.hpp"
 #include "../DRMSyncobj.hpp"
 #include "../types/DMABuffer.hpp"
@@ -518,8 +517,7 @@ void CWLSurfaceResource::commitState(SSurfaceState& state) {
             nullptr);
     }
 
-    // release the buffer if it's synchronous (SHM) as update() has done everything thats needed
-    // so we can let the app know we're done.
+    // release the buffer if it's synchronous (SHM) as updateSynchronousTexture() has copied the buffer data to a GPU tex
     // if it doesn't have a role, we can't release it yet, in case it gets turned into a cursor.
     if (current.buffer && current.buffer->isSynchronous() && role->role() != SURFACE_ROLE_UNASSIGNED)
         dropCurrentBuffer();
@@ -572,12 +570,6 @@ void CWLSurfaceResource::presentFeedback(const Time::steady_tp& when, PHLMONITOR
     else
         FEEDBACK->presented();
     PROTO::presentation->queueData(FEEDBACK);
-
-    if (!pMonitor || !pMonitor->inTimeline || !syncobj)
-        return;
-
-    // attach explicit sync
-    g_pHyprRenderer->explicitPresented.emplace_back(self.lock());
 }
 
 CWLCompositorResource::CWLCompositorResource(SP<CWlCompositor> resource_) : resource(resource_) {

--- a/src/protocols/types/Buffer.hpp
+++ b/src/protocols/types/Buffer.hpp
@@ -24,11 +24,12 @@ class IHLBuffer : public Aquamarine::IBuffer {
     virtual bool                          locked();
 
     void                                  onBackendRelease(const std::function<void()>& fn);
+    void                                  addReleasePoint(CDRMSyncPointState& point);
 
     SP<CTexture>                          texture;
     bool                                  opaque = false;
     SP<CWLBufferResource>                 resource;
-    UP<CSyncReleaser>                     syncReleaser;
+    std::vector<UP<CSyncReleaser>>        syncReleasers;
 
     struct {
         CHyprSignalListener backendRelease;
@@ -57,8 +58,7 @@ class CHLBufferReference {
     operator bool() const;
 
     // unlock and drop the buffer without sending release
-    void               drop();
+    void          drop();
 
-    CDRMSyncPointState release;
-    SP<IHLBuffer>      buffer;
+    SP<IHLBuffer> buffer;
 };

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -150,17 +150,17 @@ struct SCurrentRenderData {
 
 class CEGLSync {
   public:
+    CEGLSync();
     ~CEGLSync();
 
-    EGLSyncKHR                       sync = nullptr;
-
-    Hyprutils::OS::CFileDescriptor&& takeFD();
     Hyprutils::OS::CFileDescriptor&  fd();
+    Hyprutils::OS::CFileDescriptor&& takeFd();
+    bool                             isValid();
 
   private:
-    CEGLSync() = default;
-
-    Hyprutils::OS::CFileDescriptor m_iFd;
+    Hyprutils::OS::CFileDescriptor m_fd;
+    EGLSyncKHR                     sync    = nullptr;
+    bool                           m_valid = false;
 
     friend class CHyprOpenGLImpl;
 };
@@ -234,7 +234,6 @@ class CHyprOpenGLImpl {
     uint32_t     getPreferredReadFormat(PHLMONITOR pMonitor);
     std::vector<SDRMFormat>                     getDRMFormats();
     EGLImageKHR                                 createEGLImage(const Aquamarine::SDMABUFAttrs& attrs);
-    SP<CEGLSync>                                createEGLSync(int fence = -1);
 
     bool                                        initShaders();
     bool                                        m_bShadersInitialized = false;

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -150,7 +150,8 @@ struct SCurrentRenderData {
 
 class CEGLSync {
   public:
-    CEGLSync();
+    static UP<CEGLSync> create();
+
     ~CEGLSync();
 
     Hyprutils::OS::CFileDescriptor&  fd();
@@ -158,8 +159,10 @@ class CEGLSync {
     bool                             isValid();
 
   private:
+    CEGLSync() = default;
+
     Hyprutils::OS::CFileDescriptor m_fd;
-    EGLSyncKHR                     sync    = nullptr;
+    EGLSyncKHR                     m_sync  = EGL_NO_SYNC_KHR;
     bool                           m_valid = false;
 
     friend class CHyprOpenGLImpl;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1,7 +1,6 @@
 #include "Renderer.hpp"
 #include "../Compositor.hpp"
 #include "../helpers/math/Math.hpp"
-#include "../helpers/sync/SyncReleaser.hpp"
 #include <algorithm>
 #include <aquamarine/output/Output.hpp>
 #include <filesystem>
@@ -1571,25 +1570,6 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
         }
     }
 
-    auto explicitOptions = getExplicitSyncSettings(pMonitor->output);
-    if (!explicitOptions.explicitEnabled)
-        return ok;
-
-    Debug::log(TRACE, "Explicit: {} presented", explicitPresented.size());
-
-    if (!pMonitor->eglSync)
-        Debug::log(TRACE, "Explicit: can't add sync, monitor has no EGLSync");
-    else {
-        for (auto const& e : explicitPresented) {
-            if (!e->current.buffer || !e->current.buffer->syncReleaser)
-                continue;
-
-            e->current.buffer->syncReleaser->addReleaseSync(pMonitor->eglSync);
-        }
-    }
-
-    explicitPresented.clear();
-
     return ok;
 }
 
@@ -2296,42 +2276,42 @@ void CHyprRenderer::endRender() {
         g_pHyprOpenGL->m_RenderData.mouseZoomUseMouse = true;
     }
 
+    // send all queued opengl commands so rendering starts happening immediately
+    glFlush();
+
     if (m_eRenderMode == RENDER_MODE_FULL_FAKE)
         return;
 
     if (m_eRenderMode == RENDER_MODE_NORMAL)
         PMONITOR->output->state->setBuffer(m_pCurrentBuffer);
 
-    auto explicitOptions = getExplicitSyncSettings(PMONITOR->output);
-
-    if (PMONITOR->inTimeline && explicitOptions.explicitEnabled) {
-        PMONITOR->eglSync = makeShared<CEGLSync>();
-        if (!PMONITOR->eglSync->isValid()) {
-            Debug::log(ERR, "renderer: couldn't create an EGLSync for out in endRender");
-            return;
-        }
-
-        PMONITOR->inTimelinePoint++;
-        bool ok = PMONITOR->inTimeline->importFromSyncFileFD(PMONITOR->inTimelinePoint, PMONITOR->eglSync->fd());
-        if (!ok) {
-            Debug::log(ERR, "renderer: couldn't import from sync file fd in endRender");
-            return;
-        }
-
-        if (m_eRenderMode == RENDER_MODE_NORMAL && explicitOptions.explicitKMSEnabled) {
-            PMONITOR->inFence = CFileDescriptor{PMONITOR->inTimeline->exportAsSyncFileFD(PMONITOR->inTimelinePoint)};
-            if (!PMONITOR->inFence.isValid()) {
-                Debug::log(ERR, "renderer: couldn't export from sync timeline in endRender");
-                return;
+    CEGLSync eglSync = CEGLSync();
+    if (eglSync.isValid()) {
+        for (auto const& buf : usedAsyncBuffers) {
+            for (const auto& releaser : buf->syncReleasers) {
+                releaser->addSyncFileFd(eglSync.fd());
             }
+        }
 
+        // release buffer refs with release points now, since syncReleaser handles actual buffer release based on EGLSync
+        std::erase_if(usedAsyncBuffers, [](const auto& buf) { return !buf->syncReleasers.empty(); });
+
+        // release buffer refs without release points when EGLSync sync_file/fence is signalled
+        g_pEventLoopManager->doOnReadable(eglSync.fd().duplicate(), [prevbfs = std::move(usedAsyncBuffers)]() mutable { prevbfs.clear(); });
+        usedAsyncBuffers.clear();
+
+        if (m_eRenderMode == RENDER_MODE_NORMAL) {
+            PMONITOR->inFence = eglSync.takeFd();
             PMONITOR->output->state->setExplicitInFence(PMONITOR->inFence.get());
         }
     } else {
+        Debug::log(ERR, "renderer: couldn't use EGLSync for explicit gpu synchronization");
+
+        // nvidia doesn't have implicit sync, so we have to explicitly wait here
         if (isNvidia() && *PNVIDIAANTIFLICKER)
             glFinish();
-        else
-            glFlush();
+
+        usedAsyncBuffers.clear(); // release all buffer refs and hope implicit sync works
     }
 }
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2305,8 +2305,8 @@ void CHyprRenderer::endRender() {
     auto explicitOptions = getExplicitSyncSettings(PMONITOR->output);
 
     if (PMONITOR->inTimeline && explicitOptions.explicitEnabled) {
-        PMONITOR->eglSync = g_pHyprOpenGL->createEGLSync();
-        if (!PMONITOR->eglSync) {
+        PMONITOR->eglSync = makeShared<CEGLSync>();
+        if (!PMONITOR->eglSync->isValid()) {
             Debug::log(ERR, "renderer: couldn't create an EGLSync for out in endRender");
             return;
         }

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -91,20 +91,20 @@ class CHyprRenderer {
 
     bool m_bBlockSurfaceFeedback = false;
     bool m_bRenderingSnapshot    = false;
-    PHLMONITORREF                       m_pMostHzMonitor;
-    bool                                m_bDirectScanoutBlocked = false;
+    PHLMONITORREF                   m_pMostHzMonitor;
+    bool                            m_bDirectScanoutBlocked = false;
 
-    void                                setSurfaceScanoutMode(SP<CWLSurfaceResource> surface, PHLMONITOR monitor); // nullptr monitor resets
-    void                                initiateManualCrash();
+    void                            setSurfaceScanoutMode(SP<CWLSurfaceResource> surface, PHLMONITOR monitor); // nullptr monitor resets
+    void                            initiateManualCrash();
 
-    bool                                m_bCrashingInProgress = false;
-    float                               m_fCrashingDistort    = 0.5f;
-    wl_event_source*                    m_pCrashingLoop       = nullptr;
-    wl_event_source*                    m_pCursorTicker       = nullptr;
+    bool                            m_bCrashingInProgress = false;
+    float                           m_fCrashingDistort    = 0.5f;
+    wl_event_source*                m_pCrashingLoop       = nullptr;
+    wl_event_source*                m_pCursorTicker       = nullptr;
 
-    CTimer                              m_tRenderTimer;
+    CTimer                          m_tRenderTimer;
 
-    std::vector<SP<CWLSurfaceResource>> explicitPresented;
+    std::vector<CHLBufferReference> usedAsyncBuffers;
 
     struct {
         int                           hotspotX = 0;

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -87,7 +87,7 @@ class CHyprRenderer {
     // if RENDER_MODE_NORMAL, provided damage will be written to.
     // otherwise, it will be the one used.
     bool beginRender(PHLMONITOR pMonitor, CRegion& damage, eRenderMode mode = RENDER_MODE_NORMAL, SP<IHLBuffer> buffer = {}, CFramebuffer* fb = nullptr, bool simple = false);
-    void endRender();
+    void endRender(const std::function<void()>& renderingDoneCallback = {});
 
     bool m_bBlockSurfaceFeedback = false;
     bool m_bRenderingSnapshot    = false;

--- a/src/render/pass/SurfacePassElement.cpp
+++ b/src/render/pass/SurfacePassElement.cpp
@@ -129,6 +129,11 @@ void CSurfacePassElement::draw(const CRegion& damage) {
     if (!g_pHyprRenderer->m_bBlockSurfaceFeedback)
         data.surface->presentFeedback(data.when, data.pMonitor->self.lock());
 
+    // add async (dmabuf) buffers to usedBuffers so we can handle release later
+    // sync (shm) buffers will be released in commitState, so no need to track them here
+    if (data.surface->current.buffer && !data.surface->current.buffer->isSynchronous())
+        g_pHyprRenderer->usedAsyncBuffers.emplace_back(data.surface->current.buffer);
+
     g_pHyprOpenGL->blend(true);
 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
as title says, this pr intends to properly do buffer release when rendering by

* ensuring we keep all surface buffers used in rendering referenced, including non-drmsyncobj buffers since wl_events.release still applies for them
* ensuring we only release buffers when rendering is done, so either on EGLSync signal or after a glFinish
* as a bonus we can also make a `renderingDoneCallback`, which can be useful for some purposes like screencopy

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

#### Is it ready for merging, or does it need work?
yea