### PR TITLE
LayerSurface: cleanup framebuffers in onDestroy()

### DIFF
--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -73,8 +73,6 @@ CLayerSurface::~CLayerSurface() {
 
     if (surface)
         surface->unassign();
-    g_pHyprRenderer->makeEGLCurrent();
-    std::erase_if(g_pHyprOpenGL->m_mLayerFramebuffers, [&](const auto& other) { return other.first.expired() || other.first.lock() == self.lock(); });
 
     for (auto const& mon : g_pCompositor->m_vRealMonitors) {
         for (auto& lsl : mon->m_aLayerSurfaceLayers) {
@@ -117,6 +115,9 @@ void CLayerSurface::onDestroy() {
         CBox geomFixed = {geometry.x + PMONITOR->vecPosition.x, geometry.y + PMONITOR->vecPosition.y, geometry.width, geometry.height};
         g_pHyprRenderer->damageBox(geomFixed);
     }
+
+    g_pHyprRenderer->makeEGLCurrent();
+    std::erase_if(g_pHyprOpenGL->m_mLayerFramebuffers, [&](const auto& other) { return other.first.expired() || other.first.lock() == self.lock(); });
 
     readyToDelete = true;
     layerSurface.reset();


### PR DESCRIPTION
the cleanup was happening too late which causes stuff like #9800 to happen

fixes #9800 