### PR TITLE
Don't force default cursor on config reload/monitor reconfigure

### DIFF
--- a/src/managers/CursorManager.cpp
+++ b/src/managers/CursorManager.cpp
@@ -302,8 +302,6 @@ void CCursorManager::updateTheme() {
             m_pHyprcursor->loadThemeStyle(m_sCurrentStyleInfo);
     }
 
-    setCursorFromName("left_ptr");
-
     for (auto const& m : g_pCompositor->m_vMonitors) {
         m->forceFullFrames = 5;
         g_pCompositor->scheduleFrameForMonitor(m, Aquamarine::IOutput::AQ_SCHEDULE_CURSOR_SHAPE);


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

When you change monitor rotation/reload config it forces the cursor to be visible even when you were using a touchscreen before, and it also gets stuck like that until you move it with a mouse.
The really annoying part is the getting stuck bug but its also silly to make the cursor visible when you might not even have a touchpad/mouse connected. (also i dont know how i would specifically fix that)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Idk it doesnt seem to break things?
