### PR TITLE
versionkeeper: create version file if not present

### DIFF
--- a/src/managers/VersionKeeperManager.cpp
+++ b/src/managers/VersionKeeperManager.cpp
@@ -26,10 +26,12 @@ CVersionKeeperManager::CVersionKeeperManager() {
     if (!DATAROOT)
         return;
 
-    const auto LASTVER = NFsUtils::readFileAsString(*DATAROOT + "/" + VERSION_FILE_NAME);
+    auto LASTVER = NFsUtils::readFileAsString(*DATAROOT + "/" + VERSION_FILE_NAME);
 
-    if (!LASTVER)
-        return;
+    if (!LASTVER) {
+        NFsUtils::writeToFile(*DATAROOT + "/" + VERSION_FILE_NAME, "0.0.0");
+        LASTVER = "0.0.0";
+    }
 
     if (!isVersionOlderThanRunning(*LASTVER)) {
         Debug::log(LOG, "CVersionKeeperManager: Read version {} matches or is older than running.", *LASTVER);


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

I think this should fix https://github.com/hyprwm/Hyprland/issues/9771 by creating the version file if it does not exist?
I guess initially this was done here when it was introduced: https://github.com/hyprwm/Hyprland/blob/bba2d9a1971b51a25a5ae3fc30a453e106e6b8a9/src/managers/VersionKeeperManager.cpp#L105C1-L110C6

( https://github.com/hyprwm/Hyprland/commit/bba2d9a1971b51a25a5ae3fc30a453e106e6b8a9 set it to 0.0.0 so I did that the same way here as well again )

but it seems like it got accidentally removed in https://github.com/hyprwm/Hyprland/commit/b5fb6110ab1f75440b4b90d09f95d304d8c2080b with the refactor of the function and the addition to the donation nag

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

so right now after installing Hyprland and starting it the first time, the update popup with the version gets shown, since I suppose that was the intention by setting it to 0.0.0

#### Is it ready for merging, or does it need work?
i guess it is ready