### PR TITLE
ctm: fix crash when finishing ctm progress with a destroyed monitor

### DIFF
--- a/src/protocols/CTMControl.cpp
+++ b/src/protocols/CTMControl.cpp
@@ -158,7 +158,8 @@ void CHyprlandCTMControlProtocol::setCTM(PHLMONITOR monitor, const Mat3x3& ctm) 
 
     data->progress->setCallbackOnEnd([monitor = PHLMONITORREF{monitor}, this](auto) {
         if (!monitor || !m_mCTMDatas.contains(monitor)) {
-            monitor->setCTM(Mat3x3::identity());
+            if (monitor)
+                monitor->setCTM(Mat3x3::identity());
             return;
         }
         auto& data = m_mCTMDatas.at(monitor);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Grimblast currently broken when using ctm-control (hyprsunset).

Fixes https://github.com/hyprwm/contrib/issues/143

This crash when using ctm-control:

```
#0  0x00007f9d2e29916c in __pthread_kill_implementation ()
   from /nix/store/rmy663w9p7xb202rcln4jjzmvivznmz8-glibc-2.40-66/lib/libc.so.6
#1  0x00007f9d2e240e86 in raise ()
   from /nix/store/rmy663w9p7xb202rcln4jjzmvivznmz8-glibc-2.40-66/lib/libc.so.6
#2  0x00007f9d2e22893a in abort ()
   from /nix/store/rmy663w9p7xb202rcln4jjzmvivznmz8-glibc-2.40-66/lib/libc.so.6
#3  0x00000000011dff7c in handleUnrecoverableSignal (sig=11)
    at /home/max/desk/Hyprland/src/Compositor.cpp:111
#4  <signal handler called>
#5  0x0000000001486e1f in CMonitor::setCTM (this=0x0, ctm_=...)
    at /home/max/desk/Hyprland/src/helpers/Monitor.cpp:1325
#6  0x000000000174c6f5 in operator()<Hyprutils::Memory::CWeakPointer<Hyprutils::Animation::CBaseAnimatedVariable> > (__closure=0x2c21ede0)
    at /home/max/desk/Hyprland/src/protocols/CTMControl.cpp:161
#7  0x0000000001755636 in std::__invoke_impl<void, CHyprlandCTMControlProtocol::setCTM(PHLMONITOR, const Hyprutils::Math::Mat3x3&)::<lambda(auto:60)>&, Hyprutils::Memory::CWeakPointer<Hyprutils::Animation::CBaseAnimatedVariable> >(std::__invoke_other, struct {...} &) (__f=...)
    at /nix/store/il0r2x1l03qjda9nxva18c1mjsqggcn9-gcc-14-20241116/include/c++/14-20241116/bits/invoke.h:61
#8  0x000000000175380f in std::__invoke_r<void, CHyprlandCTMControlProtocol::setCTM(PHLMONITOR, const Hyprutils::Math::Mat3x3&)::<lambda(auto:60)>&, Hyprutils::Memory::CWeakPointer<Hyprutils::Animation::CBaseAnimatedVariable> >(struct {...} &) (__fn=...)
    at /nix/store/il0r2x1l03qjda9nxva18c1mjsqggcn9-gcc-14-20241116/include/c++/14-20241116/bits/invoke.h:111
#9  0x000000000175086c in std::_Function_handler<void(Hyprutils::Memory::CWeakPointer<Hyprutils::Animation::CBaseAnimatedVariable>), CHyprlandCTMControlProtocol::setCTM(PHLMONITOR, const Hyprutils::Math::Mat3x3&)::<lambda(auto:60)> >::_M_invoke(const std::_Any_data &, Hyprutils::Memory::CWeakPointer<Hyprutils::Animation::CBaseAnimatedVariable> &&) (__functor=..., __args#0=...)
    at /nix/store/il0r2x1l03qjda9nxva18c1mjsqggcn9-gcc-14-20241116/include/c++/14-20241116/bits/std_function.h:290
#10 0x00007f9d2fa3b32d in Hyprutils::Animation::CBaseAnimatedVariable::onAnimationEnd() ()
   from /nix/store/43hm1zkv8rcbw031haaw6inbba7mw7p1-hyprutils-0.5.2+date=2025-03-26_7248194/lib/libhyprutils.so.4
#11 0x0000000001373fa3 in Hyprutils::Animation::CGenericAnimatedVariable<float, SAnimationContext>::warp (this=0x2c330640, endCallback=true, forceDisconnect=false)
    at /nix/store/1wsawvr26r7x9scp4cf42lky0bry3gfd-hyprutils-0.5.2+date=2025-03-26_7248194-dev/include/hyprutils/animation/AnimatedVariable.hpp:167
#12 0x000000000153b0fb in updateVariable<float> (av=..., POINTY=1, warp=true)
    at /home/max/desk/Hyprland/src/managers/AnimationManager.cpp:46
#13 0x0000000001535fd4 in handleUpdate<float> (av=..., warp=false)
    at /home/max/desk/Hyprland/src/managers/AnimationManager.cpp:156
#14 0x0000000001530a86 in CHyprAnimationManager::tick (this=0x2a946000)
    at /home/max/desk/Hyprland/src/managers/AnimationManager.cpp:233
```

We already captured the montior reference as a weak pointer in the callback lambda, but we didn't properly use it.
Now we just lock it and use the SP.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Yes

