### PR TITLE
nix module: load plugins using exec-once

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -126,13 +126,14 @@ in {
             bottomCommandsPrefixes = cfg.bottomPrefixes;
           }
           {
-            plugin = let
+            "exec-once" = let
               mkEntry = entry:
                 if lib.types.package.check entry
                 then "${entry}/lib/lib${entry.pname}.so"
                 else entry;
+              hyprctl = lib.getExe' config.programs.hyprland.package "hyprctl";
             in
-              map mkEntry cfg.plugins;
+              map (p: "${hyprctl} plugin load ${mkEntry p}") cfg.plugins;
           };
       in
         lib.mkIf shouldGenerate {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This PR changes the way hyprland plugins are loaded in nix. Instead of loading all plugins each config reload, they are now only loaded once using `exec-once`. This approach has the following advantages (after hyprland / plugin updates):
- `hyprctl reload` doesn't try to load invalid plugins (hash mismatches / crashes).
- Old plugins remain loaded until hyprland is restarted


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I am not sure if this is the best way. Maybe we could also load plugins once in a different way I am not aware of. Maybe having a section in hyprland config that is only executed once.


#### Is it ready for merging, or does it need work?

Yes, I've tested it on my system and it works as expected.
