### PR TITLE
fix(dwindle): ignore fullscreen window for positioning when use_active_for_splits=false

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -954,7 +954,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
         const WORKSPACEID WSPID      = special ? PMONITOR->activeSpecialWorkspaceID() : PMONITOR->activeWorkspaceID();
         const auto        PWORKSPACE = getWorkspaceByID(WSPID);
 
-        if (PWORKSPACE->m_bHasFullscreenWindow)
+        if (PWORKSPACE->m_bHasFullscreenWindow && !(properties & NON_FULLSCREEN))
             return PWORKSPACE->getFullscreenWindow();
 
         auto found = floating(false);

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -954,7 +954,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
         const WORKSPACEID WSPID      = special ? PMONITOR->activeSpecialWorkspaceID() : PMONITOR->activeWorkspaceID();
         const auto        PWORKSPACE = getWorkspaceByID(WSPID);
 
-        if (PWORKSPACE->m_bHasFullscreenWindow && !(properties & NON_FULLSCREEN))
+        if (PWORKSPACE->m_bHasFullscreenWindow && !(properties & SKIP_FULLSCREEN_PRIORITY))
             return PWORKSPACE->getFullscreenWindow();
 
         auto found = floating(false);

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -44,14 +44,14 @@ enum eGroupRules : uint8_t {
 };
 
 enum eGetWindowProperties : uint8_t {
-    WINDOW_ONLY      = 0,
-    RESERVED_EXTENTS = 1 << 0,
-    INPUT_EXTENTS    = 1 << 1,
-    FULL_EXTENTS     = 1 << 2,
-    FLOATING_ONLY    = 1 << 3,
-    ALLOW_FLOATING   = 1 << 4,
-    USE_PROP_TILED   = 1 << 5,
-    NON_FULLSCREEN   = 1 << 6,
+    WINDOW_ONLY              = 0,
+    RESERVED_EXTENTS         = 1 << 0,
+    INPUT_EXTENTS            = 1 << 1,
+    FULL_EXTENTS             = 1 << 2,
+    FLOATING_ONLY            = 1 << 3,
+    ALLOW_FLOATING           = 1 << 4,
+    USE_PROP_TILED           = 1 << 5,
+    SKIP_FULLSCREEN_PRIORITY = 1 << 6,
 };
 
 enum eSuppressEvents : uint8_t {

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -51,6 +51,7 @@ enum eGetWindowProperties : uint8_t {
     FLOATING_ONLY    = 1 << 3,
     ALLOW_FLOATING   = 1 << 4,
     USE_PROP_TILED   = 1 << 5,
+    NON_FULLSCREEN   = 1 << 6,
 };
 
 enum eSuppressEvents : uint8_t {

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -246,7 +246,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
 
     if (PMONITOR->ID == MONFROMCURSOR->ID &&
         (PNODE->workspaceID == PMONITOR->activeWorkspaceID() || (g_pCompositor->isWorkspaceSpecial(PNODE->workspaceID) && PMONITOR->activeSpecialWorkspace)) && !*PUSEACTIVE) {
-        OPENINGON = getNodeFromWindow(g_pCompositor->vectorToWindowUnified(MOUSECOORDS, RESERVED_EXTENTS | INPUT_EXTENTS | NON_FULLSCREEN));
+        OPENINGON = getNodeFromWindow(g_pCompositor->vectorToWindowUnified(MOUSECOORDS, RESERVED_EXTENTS | INPUT_EXTENTS | SKIP_FULLSCREEN_PRIORITY));
 
         if (!OPENINGON && g_pCompositor->isPointOnReservedArea(MOUSECOORDS, PMONITOR))
             OPENINGON = getClosestNodeOnWorkspace(PNODE->workspaceID, MOUSECOORDS);

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -246,7 +246,7 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
 
     if (PMONITOR->ID == MONFROMCURSOR->ID &&
         (PNODE->workspaceID == PMONITOR->activeWorkspaceID() || (g_pCompositor->isWorkspaceSpecial(PNODE->workspaceID) && PMONITOR->activeSpecialWorkspace)) && !*PUSEACTIVE) {
-        OPENINGON = getNodeFromWindow(g_pCompositor->vectorToWindowUnified(MOUSECOORDS, RESERVED_EXTENTS | INPUT_EXTENTS));
+        OPENINGON = getNodeFromWindow(g_pCompositor->vectorToWindowUnified(MOUSECOORDS, RESERVED_EXTENTS | INPUT_EXTENTS | NON_FULLSCREEN));
 
         if (!OPENINGON && g_pCompositor->isPointOnReservedArea(MOUSECOORDS, PMONITOR))
             OPENINGON = getClosestNodeOnWorkspace(PNODE->workspaceID, MOUSECOORDS);


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

#### Describe your PR, what does it fix/add?

#### Repro Steps: 
1. Use dwindle + `use_active_for_splits=0`
2. have 3 windows open next to each other (layed out horizontally and spaced evenly)
3. maximize the leftmost one
4. move mouse pointer near the right edge of the screen
5. open a new window (e.g. a terminal)

#### Actual:

The new window opens next to leftmost window.

#### Expected:

The new window opens next to the rightmost window - nearby where the mouse cursor is. That's what `use_active_for_splits=0` should do (from wiki: "prefer mouse position for splits")

Note, that this behavor is exactly what would happen if you inserted an extra step of minimizing the fullscreen window between the steps 4 and 5. And this PR attempts to do exacly this, trying to ignore the current fullscreen window when creating a new one.

#### Before vs after videos

In the following videos I have also set `smart_split=1`, which makes the issue more pronounced. Btw on videos I'm not doing the exact steps above, sowwy about that (they are old vids), but it should be clear enough I hope.

Before: 

<details>
<summary>Details</summary>

https://github.com/user-attachments/assets/722bfe01-0de8-44b5-a57b-75285f5c79a0

</details>

After:

<details>
<summary>Details</summary>

https://github.com/user-attachments/assets/80b62702-182f-41a8-a851-2231d4a60889

</details>

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

It actually used to work like this before a year ago or so, and it's been annoying me for a long time. I've had enough.

#### Is it ready for merging, or does it need work?

should be ready to go, unless we want to make this configurable.