### PR TITLE
compositor: fix crash when moving a workspace to a monitor with size 0x0

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2186,9 +2186,11 @@ void CCompositor::moveWorkspaceToMonitor(PHLWORKSPACE pWorkspace, PHLMONITOR pMo
                         *w->m_vRealPosition = pMonitor->vecPosition;
                         *w->m_vRealSize     = pMonitor->vecSize;
                     }
-                } else {
-                    *w->m_vRealPosition = Vector2D{(int)w->m_vRealPosition->goal().x % (int)pMonitor->vecSize.x, (int)w->m_vRealPosition->goal().y % (int)pMonitor->vecSize.y};
-                }
+                } else
+                    *w->m_vRealPosition = Vector2D{
+                        (pMonitor->vecSize.x != 0) ? (int)w->m_vRealPosition->goal().x % (int)pMonitor->vecSize.x : 0,
+                        (pMonitor->vecSize.y != 0) ? (int)w->m_vRealPosition->goal().y % (int)pMonitor->vecSize.y : 0,
+                    };
             }
 
             w->updateToplevel();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes a crash I hit a few times when looking into hyprlock suspend and unsafe state related issues.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Ready.
