### PR TITLE
render:send_content_type setting

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1444,6 +1444,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .type        = CONFIG_OPTION_BOOL,
         .data        = SConfigOptionDescription::SBoolData{true},
     },
+    SConfigOptionDescription{
+        .value       = "render:send_content_type",
+        .description = "Report content type to allow monitor profile autoswitch (may result in a black screen during the switch)",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{true},
+    },
 
     /*
      * cursor:

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -739,6 +739,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("render:ctm_animation", Hyprlang::INT{2});
     registerConfigVar("render:cm_fs_passthrough", Hyprlang::INT{2});
     registerConfigVar("render:cm_enabled", Hyprlang::INT{1});
+    registerConfigVar("render:send_content_type", Hyprlang::INT{1});
 
     registerConfigVar("ecosystem:no_update_news", Hyprlang::INT{0});
     registerConfigVar("ecosystem:no_donation_nag", Hyprlang::INT{0});

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1477,6 +1477,7 @@ static hdr_output_metadata       createHDRMetadata(SImageDescription settings, A
 }
 
 bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
+    static auto PCT   = CConfigValue<Hyprlang::INT>("render:send_content_type");
     static auto PPASS = CConfigValue<Hyprlang::INT>("render:cm_fs_passthrough");
     const bool  PHDR  = pMonitor->imageDescription.transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ;
 
@@ -1540,11 +1541,13 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
         }
     }
 
-    if (pMonitor->activeWorkspace && pMonitor->activeWorkspace->m_hasFullscreenWindow && pMonitor->activeWorkspace->m_fullscreenMode == FSMODE_FULLSCREEN) {
-        const auto WINDOW = pMonitor->activeWorkspace->getFullscreenWindow();
-        pMonitor->output->state->setContentType(NContentType::toDRM(WINDOW->getContentType()));
-    } else
-        pMonitor->output->state->setContentType(NContentType::toDRM(CONTENT_TYPE_NONE));
+    if (*PCT) {
+        if (pMonitor->activeWorkspace && pMonitor->activeWorkspace->m_hasFullscreenWindow && pMonitor->activeWorkspace->m_fullscreenMode == FSMODE_FULLSCREEN) {
+            const auto WINDOW = pMonitor->activeWorkspace->getFullscreenWindow();
+            pMonitor->output->state->setContentType(NContentType::toDRM(WINDOW->getContentType()));
+        } else
+            pMonitor->output->state->setContentType(NContentType::toDRM(CONTENT_TYPE_NONE));
+    }
 
     if (pMonitor->ctmUpdated) {
         pMonitor->ctmUpdated = false;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds `render:send_content_type` to disable drm content type switch. Fixes #9786

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
Ready