### PR TITLE
swipe: fix swiping onto a new workspace bound to another monitor (#8176)

### DIFF
--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -71,19 +71,8 @@ void CInputManager::endWorkspaceSwipe() {
 
     // If we've been swiping off the right end with PSWIPENEW enabled, there is
     // no workspace there yet, and we need to choose an ID for a new one now.
-    // With multiple monitors, it might not be appropriate to choose one more
-    // than the ID of the workspace we're swiping from, because that ID might
-    // just be on another monitor.  It's also not just the smallest unused ID,
-    // because that could be a gap in the existing workspace numbers, and it'd
-    // be counterintuitive to swipe rightwards onto a new workspace and end up
-    // left of where we started.  Instead, it's one more than the greatest
-    // workspace ID that currently exists.
     if (workspaceIDRight <= m_sActiveSwipe.pWorkspaceBegin->m_iID && *PSWIPENEW) {
-        WORKSPACEID maxWorkspace = 0;
-        for (const auto& ws : g_pCompositor->m_vWorkspaces) {
-            maxWorkspace = std::max(maxWorkspace, ws->m_iID);
-        }
-        workspaceIDRight = maxWorkspace + 1;
+        workspaceIDRight = getWorkspaceIDNameFromString("r+1").id;
     }
 
     auto         PWORKSPACER = g_pCompositor->getWorkspaceByID(workspaceIDRight); // not guaranteed if PSWIPENEW || PSWIPENUMBER


### PR DESCRIPTION
#### Description

The previous code didn't check if the chosen new workspace was bound to another monitor, causing buggy behavior where workspace was simultaneously open and not.

The fix simply uses `r+1` for new workspace selection.

Also, the previous code would select rightmost workspace + 1, creating large gaps in workspace IDs in some scenarios. Example (`()` and `[]` indicate workspaces on different monitors):

`(1), 2, 3, 4, 5, 6, 7, 8, 9, [10]`

Swipe right on `()` monitor would create:

`(1), 2, 3, 4, 5, 6, 7, 8, 9, [10], (11)`

But with this commit:

`(1), (2), 3, 4, 5, 6, 7, 8, 9, [10]`

Fixes #8176.