### PR TITLE
Permission Manager: add permission management for screencopy

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -15,6 +15,7 @@
 #include "managers/DonationNagManager.hpp"
 #include "managers/ANRManager.hpp"
 #include "managers/eventLoop/EventLoopManager.hpp"
+#include "managers/permissions/DynamicPermissionManager.hpp"
 #include <algorithm>
 #include <aquamarine/output/Output.hpp>
 #include <bit>
@@ -570,6 +571,7 @@ void CCompositor::cleanup() {
     removeAllSignals();
 
     g_pInputManager.reset();
+    g_pDynamicPermissionManager.reset();
     g_pDecorationPositioner.reset();
     g_pCursorManager.reset();
     g_pPluginSystem.reset();
@@ -623,6 +625,9 @@ void CCompositor::initManagers(eManagersInitStage stage) {
 
             Debug::log(LOG, "Creating the AnimationManager!");
             g_pAnimationManager = makeUnique<CHyprAnimationManager>();
+
+            Debug::log(LOG, "Creating the DynamicPermissionManager!");
+            g_pDynamicPermissionManager = makeUnique<CDynamicPermissionManager>();
 
             Debug::log(LOG, "Creating the ConfigManager!");
             g_pConfigManager = makeUnique<CConfigManager>();

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -22,6 +22,7 @@
 #include "../managers/eventLoop/EventLoopManager.hpp"
 #include "../managers/LayoutManager.hpp"
 #include "../managers/EventManager.hpp"
+#include "../managers/permissions/DynamicPermissionManager.hpp"
 #include "../debug/HyprNotificationOverlay.hpp"
 #include "../plugins/PluginSystem.hpp"
 
@@ -367,6 +368,18 @@ static Hyprlang::CParseResult handlePlugin(const char* c, const char* v) {
     const std::string      COMMAND = c;
 
     const auto             RESULT = g_pConfigManager->handlePlugin(COMMAND, VALUE);
+
+    Hyprlang::CParseResult result;
+    if (RESULT.has_value())
+        result.setError(RESULT.value().c_str());
+    return result;
+}
+
+static Hyprlang::CParseResult handlePermission(const char* c, const char* v) {
+    const std::string      VALUE   = v;
+    const std::string      COMMAND = c;
+
+    const auto             RESULT = g_pConfigManager->handlePermission(COMMAND, VALUE);
 
     Hyprlang::CParseResult result;
     if (RESULT.has_value())
@@ -764,6 +777,7 @@ CConfigManager::CConfigManager() {
     m_pConfig->registerHandler(&::handleSubmap, "submap", {false});
     m_pConfig->registerHandler(&::handleBlurLS, "blurls", {false});
     m_pConfig->registerHandler(&::handlePlugin, "plugin", {false});
+    m_pConfig->registerHandler(&::handlePermission, "permission", {false});
     m_pConfig->registerHandler(&::handleEnv, "env", {true});
 
     // pluginza
@@ -945,6 +959,8 @@ std::optional<std::string> CConfigManager::resetHLConfig() {
     m_vLayerRules.clear();
     m_vFailedPluginConfigValues.clear();
     finalExecRequests.clear();
+
+    g_pDynamicPermissionManager->clearConfigPermissions();
 
     // paths
     m_configPaths.clear();
@@ -2827,6 +2843,32 @@ std::optional<std::string> CConfigManager::handlePlugin(const std::string& comma
         return "plugin '" + path + "' declared twice";
 
     m_vDeclaredPlugins.push_back(path);
+
+    return {};
+}
+
+std::optional<std::string> CConfigManager::handlePermission(const std::string& command, const std::string& value) {
+    CVarList                    data(value);
+
+    eDynamicPermissionType      type = PERMISSION_TYPE_UNKNOWN;
+    eDynamicPermissionAllowMode mode = PERMISSION_RULE_ALLOW_MODE_UNKNOWN;
+
+    if (data[1] == "screencopy")
+        type = PERMISSION_TYPE_SCREENCOPY;
+
+    if (data[2] == "ask")
+        mode = PERMISSION_RULE_ALLOW_MODE_ASK;
+    else if (data[2] == "allow")
+        mode = PERMISSION_RULE_ALLOW_MODE_ALLOW;
+    else if (data[2] == "deny")
+        mode = PERMISSION_RULE_ALLOW_MODE_DENY;
+
+    if (type == PERMISSION_TYPE_UNKNOWN)
+        return "unknown permission type";
+    if (mode == PERMISSION_RULE_ALLOW_MODE_UNKNOWN)
+        return "unknown permission allow mode";
+
+    g_pDynamicPermissionManager->addConfigPermissionRule(data[0], type, mode);
 
     return {};
 }

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -244,6 +244,7 @@ class CConfigManager {
     std::optional<std::string> handleBindWS(const std::string&, const std::string&);
     std::optional<std::string> handleEnv(const std::string&, const std::string&);
     std::optional<std::string> handlePlugin(const std::string&, const std::string&);
+    std::optional<std::string> handlePermission(const std::string&, const std::string&);
 
     std::string                configCurrentPath;
 

--- a/src/managers/permissions/DynamicPermissionManager.cpp
+++ b/src/managers/permissions/DynamicPermissionManager.cpp
@@ -1,0 +1,193 @@
+#include "DynamicPermissionManager.hpp"
+#include <algorithm>
+#include <wayland-server-core.h>
+#include <expected>
+#include <filesystem>
+#include "../../Compositor.hpp"
+
+static void clientDestroyInternal(struct wl_listener* listener, void* data) {
+    SDynamicPermissionRuleDestroyWrapper* wrap = wl_container_of(listener, wrap, listener);
+    CDynamicPermissionRule*               rule = wrap->parent;
+    g_pDynamicPermissionManager->removeRulesForClient(rule->client());
+}
+
+CDynamicPermissionRule::CDynamicPermissionRule(const std::string& binaryPath, eDynamicPermissionType type, eDynamicPermissionAllowMode defaultAllowMode) :
+    m_type(type), m_source(PERMISSION_RULE_SOURCE_CONFIG), m_binaryPath(binaryPath), m_allowMode(defaultAllowMode) {
+    ;
+}
+
+CDynamicPermissionRule::CDynamicPermissionRule(wl_client* const client, eDynamicPermissionType type, eDynamicPermissionAllowMode defaultAllowMode) :
+    m_type(type), m_source(PERMISSION_RULE_SOURCE_RUNTIME_USER), m_client(client), m_allowMode(defaultAllowMode) {
+    wl_list_init(&m_destroyWrapper.listener.link);
+    m_destroyWrapper.listener.notify = ::clientDestroyInternal;
+    m_destroyWrapper.parent          = this;
+    wl_display_add_destroy_listener(g_pCompositor->m_sWLDisplay, &m_destroyWrapper.listener);
+}
+
+CDynamicPermissionRule::~CDynamicPermissionRule() {
+    if (m_client) {
+        wl_list_remove(&m_destroyWrapper.listener.link);
+        wl_list_init(&m_destroyWrapper.listener.link);
+    }
+
+    if (m_dialogBox && m_dialogBox->isRunning())
+        m_dialogBox->kill();
+}
+
+wl_client* CDynamicPermissionRule::client() const {
+    return m_client;
+}
+
+static const char* permissionToString(eDynamicPermissionType type) {
+    switch (type) {
+        case PERMISSION_TYPE_UNKNOWN: return "PERMISSION_TYPE_UNKNOWN";
+        case PERMISSION_TYPE_SCREENCOPY: return "PERMISSION_TYPE_SCREENCOPY";
+    }
+
+    return "error";
+}
+
+static const char* permissionToHumanString(eDynamicPermissionType type) {
+    switch (type) {
+        case PERMISSION_TYPE_UNKNOWN: return "an unknown permission";
+        case PERMISSION_TYPE_SCREENCOPY: return "access to your screen (screenshot / screenshare)";
+    }
+
+    return "error";
+}
+
+static std::expected<std::string, std::string> binaryNameForWlClient(wl_client* client) {
+    pid_t pid = 0;
+    wl_client_get_credentials(client, &pid, nullptr, nullptr);
+
+    if (pid <= 0)
+        return std::unexpected("No pid for client");
+
+    // FIXME: this won't work on BSDs. Can we fix this?
+
+    std::string     path = std::format("/proc/{}/exe", (uint64_t)pid);
+    std::error_code ec;
+
+    std::string     fullPath = std::filesystem::canonical(path, ec);
+
+    if (ec)
+        return std::unexpected("canonical failed");
+
+    return fullPath;
+}
+
+void CDynamicPermissionManager::clearConfigPermissions() {
+    std::erase_if(m_rules, [](const auto& e) { return e->m_source == PERMISSION_RULE_SOURCE_CONFIG; });
+}
+
+void CDynamicPermissionManager::addConfigPermissionRule(const std::string& binaryName, eDynamicPermissionType type, eDynamicPermissionAllowMode mode) {
+    m_rules.emplace_back(SP<CDynamicPermissionRule>(new CDynamicPermissionRule(binaryName, type, mode)));
+}
+
+eDynamicPermissionAllowMode CDynamicPermissionManager::clientPermissionMode(wl_client* client, eDynamicPermissionType permission) {
+
+    const auto LOOKUP = binaryNameForWlClient(client);
+
+    Debug::log(TRACE, "CDynamicPermissionManager::clientHasPermission: checking permission {} for client {:x} (binary {})", permissionToString(permission), (uintptr_t)client,
+               LOOKUP.value_or("lookup failed: " + LOOKUP.error()));
+
+    // first, check if we have the client + perm combo in our cache.
+    auto it = std::ranges::find_if(m_rules, [client, permission](const auto& e) { return e->m_client == client && e->m_type == permission; });
+    if (it == m_rules.end()) {
+        Debug::log(TRACE, "CDynamicPermissionManager::clientHasPermission: permission not cached, checking binary name");
+
+        if (!LOOKUP.has_value())
+            Debug::log(TRACE, "CDynamicPermissionManager::clientHasPermission: binary name check failed");
+        else {
+            Debug::log(TRACE, "CDynamicPermissionManager::clientHasPermission: binary path {}, name {}", LOOKUP.value(),
+                       LOOKUP.value().substr(LOOKUP.value().find_last_of('/') + 1));
+
+            it = std::ranges::find_if(m_rules, [clientBinaryPath = LOOKUP.value(), permission](const auto& e) {
+                //                  vvv same path         or                  vvvvv path is empty and it's a config rule                          vvv and matches perm type
+                return (e->m_binaryPath == clientBinaryPath || (e->m_binaryPath.empty() && e->m_source == PERMISSION_RULE_SOURCE_CONFIG)) && e->m_type == permission;
+            });
+
+            if (it == m_rules.end())
+                Debug::log(TRACE, "CDynamicPermissionManager::clientHasPermission: no rule for binary");
+            else {
+                if ((*it)->m_allowMode == PERMISSION_RULE_ALLOW_MODE_ALLOW) {
+                    Debug::log(TRACE, "CDynamicPermissionManager::clientHasPermission: permission allowed by config rule");
+                    return PERMISSION_RULE_ALLOW_MODE_ALLOW;
+                } else if ((*it)->m_allowMode == PERMISSION_RULE_ALLOW_MODE_DENY) {
+                    Debug::log(TRACE, "CDynamicPermissionManager::clientHasPermission: permission denied by config rule");
+                    return PERMISSION_RULE_ALLOW_MODE_DENY;
+                } else if ((*it)->m_allowMode == PERMISSION_RULE_ALLOW_MODE_PENDING) {
+                    Debug::log(TRACE, "CDynamicPermissionManager::clientHasPermission: permission pending by config rule");
+                    return PERMISSION_RULE_ALLOW_MODE_PENDING;
+                } else
+                    Debug::log(TRACE, "CDynamicPermissionManager::clientHasPermission: permission ask by config rule");
+            }
+        }
+    } else if ((*it)->m_allowMode == PERMISSION_RULE_ALLOW_MODE_ALLOW) {
+        Debug::log(TRACE, "CDynamicPermissionManager::clientHasPermission: permission allowed before by user");
+        return PERMISSION_RULE_ALLOW_MODE_ALLOW;
+    } else if ((*it)->m_allowMode == PERMISSION_RULE_ALLOW_MODE_DENY) {
+        Debug::log(TRACE, "CDynamicPermissionManager::clientHasPermission: permission denied before by user");
+        return PERMISSION_RULE_ALLOW_MODE_DENY;
+    } else if ((*it)->m_allowMode == PERMISSION_RULE_ALLOW_MODE_PENDING) {
+        Debug::log(TRACE, "CDynamicPermissionManager::clientHasPermission: permission pending before by user");
+        return PERMISSION_RULE_ALLOW_MODE_PENDING;
+    }
+
+    // if we are here, we need to ask.
+    askForPermission(client, LOOKUP.value_or(""), permission);
+
+    return PERMISSION_RULE_ALLOW_MODE_PENDING;
+}
+
+void CDynamicPermissionManager::askForPermission(wl_client* client, const std::string& binaryPath, eDynamicPermissionType type) {
+    auto        rule = m_rules.emplace_back(SP<CDynamicPermissionRule>(new CDynamicPermissionRule(client, type, PERMISSION_RULE_ALLOW_MODE_PENDING)));
+
+    std::string description = "";
+    if (binaryPath.empty())
+        description = std::format("An unknown application (wayland client ID 0x{:x}) is requesting {}.", (uintptr_t)client, permissionToHumanString(type));
+    else {
+        std::string binaryName = binaryPath.substr(binaryPath.find_last_of('/') + 1);
+        description            = std::format("An application {} ({}) is requesting {}.", binaryName, binaryPath, permissionToHumanString(type));
+    }
+
+    description += "<br/><br/>Do you want to allow it to?";
+
+    std::vector<std::string> options;
+
+    if (!binaryPath.empty()) {
+        description += "<br/><br/><i>Hint: you can set persistent rules for these in the Hyprland config file.</i>";
+        options = {"Deny", "Allow and remember app", "Allow once"};
+    } else
+        options = {"Deny", "Allow"};
+
+    rule->m_dialogBox = CAsyncDialogBox::create("Permission request", description, options);
+
+    if (!rule->m_dialogBox) {
+        Debug::log(ERR, "CDynamicPermissionManager::askForPermission: hyprland-qtutils likely missing, cannot ask! Disabling permission control...");
+        rule->m_allowMode = PERMISSION_RULE_ALLOW_MODE_ALLOW;
+        return;
+    }
+
+    rule->m_dialogBox->open([r = WP<CDynamicPermissionRule>(rule), binaryPath](std::string result) {
+        if (!r)
+            return;
+
+        Debug::log(TRACE, "CDynamicPermissionRule: user returned {}", result);
+
+        if (result.starts_with("Allow once"))
+            r->m_allowMode = PERMISSION_RULE_ALLOW_MODE_ALLOW;
+        else if (result.starts_with("Deny")) {
+            r->m_allowMode  = PERMISSION_RULE_ALLOW_MODE_DENY;
+            r->m_binaryPath = binaryPath;
+        } else if (result.starts_with("Allow and remember")) {
+            r->m_allowMode  = PERMISSION_RULE_ALLOW_MODE_ALLOW;
+            r->m_binaryPath = binaryPath;
+        } else if (result.starts_with("Allow"))
+            r->m_allowMode = PERMISSION_RULE_ALLOW_MODE_ALLOW;
+    });
+}
+
+void CDynamicPermissionManager::removeRulesForClient(wl_client* client) {
+    std::erase_if(m_rules, [client](const auto& e) { return e->m_client == client; });
+}

--- a/src/managers/permissions/DynamicPermissionManager.hpp
+++ b/src/managers/permissions/DynamicPermissionManager.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "../../macros.hpp"
+#include "../../helpers/memory/Memory.hpp"
+#include "../../helpers/AsyncDialogBox.hpp"
+#include <vector>
+#include <wayland-server-core.h>
+
+enum eDynamicPermissionType : uint8_t {
+    PERMISSION_TYPE_UNKNOWN = 0,
+    PERMISSION_TYPE_SCREENCOPY,
+};
+
+enum eDynamicPermissionRuleSource : uint8_t {
+    PERMISSION_RULE_SOURCE_UNKNOWN = 0,
+    PERMISSION_RULE_SOURCE_CONFIG,
+    PERMISSION_RULE_SOURCE_RUNTIME_USER,
+};
+
+enum eDynamicPermissionAllowMode : uint8_t {
+    PERMISSION_RULE_ALLOW_MODE_UNKNOWN = 0,
+    PERMISSION_RULE_ALLOW_MODE_DENY,
+    PERMISSION_RULE_ALLOW_MODE_ASK,
+    PERMISSION_RULE_ALLOW_MODE_ALLOW,
+    PERMISSION_RULE_ALLOW_MODE_PENDING, // popup is open
+};
+
+class CDynamicPermissionRule;
+
+struct SDynamicPermissionRuleDestroyWrapper {
+    wl_listener             listener;
+    CDynamicPermissionRule* parent = nullptr;
+};
+
+class CDynamicPermissionRule {
+  public:
+    ~CDynamicPermissionRule();
+
+    wl_client* client() const;
+
+  private:
+    // config rule
+    CDynamicPermissionRule(const std::string& binaryPath, eDynamicPermissionType type, eDynamicPermissionAllowMode defaultAllowMode = PERMISSION_RULE_ALLOW_MODE_ASK);
+    // user rule
+    CDynamicPermissionRule(wl_client* const client, eDynamicPermissionType type, eDynamicPermissionAllowMode defaultAllowMode = PERMISSION_RULE_ALLOW_MODE_ASK);
+
+    const eDynamicPermissionType         m_type       = PERMISSION_TYPE_UNKNOWN;
+    const eDynamicPermissionRuleSource   m_source     = PERMISSION_RULE_SOURCE_UNKNOWN;
+    wl_client* const                     m_client     = nullptr;
+    std::string                          m_binaryPath = "";
+
+    eDynamicPermissionAllowMode          m_allowMode = PERMISSION_RULE_ALLOW_MODE_ASK;
+    SP<CAsyncDialogBox>                  m_dialogBox; // for pending
+
+    SDynamicPermissionRuleDestroyWrapper m_destroyWrapper;
+
+    friend class CDynamicPermissionManager;
+};
+
+class CDynamicPermissionManager {
+  public:
+    void clearConfigPermissions();
+    void addConfigPermissionRule(const std::string& binaryPath, eDynamicPermissionType type, eDynamicPermissionAllowMode mode);
+
+    // if the rule is "ask", or missing, will pop up a dialog and return false until the user agrees.
+    // (will continue returning false if the user does not agree, of course.)
+    eDynamicPermissionAllowMode clientPermissionMode(wl_client* client, eDynamicPermissionType permission);
+
+    void                        removeRulesForClient(wl_client* client);
+
+  private:
+    void askForPermission(wl_client* client, const std::string& binaryName, eDynamicPermissionType type);
+
+    //
+    std::vector<SP<CDynamicPermissionRule>> m_rules;
+};
+
+inline UP<CDynamicPermissionManager> g_pDynamicPermissionManager;

--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -8,6 +8,7 @@
 #include "../helpers/Format.hpp"
 #include "../managers/EventManager.hpp"
 #include "../managers/input/InputManager.hpp"
+#include "../managers/permissions/DynamicPermissionManager.hpp"
 #include "../render/Renderer.hpp"
 
 #include <algorithm>
@@ -238,7 +239,8 @@ void CToplevelExportFrame::share() {
 }
 
 bool CToplevelExportFrame::copyShm(timespec* now) {
-    auto shm                      = buffer->shm();
+    const auto PERM               = g_pDynamicPermissionManager->clientPermissionMode(resource->client(), PERMISSION_TYPE_SCREENCOPY);
+    auto       shm                = buffer->shm();
     auto [pixelData, fmt, bufLen] = buffer->beginDataPtr(0); // no need for end, cuz it's shm
 
     // render the client
@@ -263,12 +265,14 @@ bool CToplevelExportFrame::copyShm(timespec* now) {
     g_pHyprOpenGL->clear(CHyprColor(0, 0, 0, 1.0));
 
     // render client at 0,0
-    g_pHyprRenderer->m_bBlockSurfaceFeedback = g_pHyprRenderer->shouldRenderWindow(pWindow); // block the feedback to avoid spamming the surface if it's visible
-    g_pHyprRenderer->renderWindow(pWindow, PMONITOR, now, false, RENDER_PASS_ALL, true, true);
-    g_pHyprRenderer->m_bBlockSurfaceFeedback = false;
+    if (PERM == PERMISSION_RULE_ALLOW_MODE_ALLOW) {
+        g_pHyprRenderer->m_bBlockSurfaceFeedback = g_pHyprRenderer->shouldRenderWindow(pWindow); // block the feedback to avoid spamming the surface if it's visible
+        g_pHyprRenderer->renderWindow(pWindow, PMONITOR, now, false, RENDER_PASS_ALL, true, true);
+        g_pHyprRenderer->m_bBlockSurfaceFeedback = false;
 
-    if (overlayCursor)
-        g_pPointerManager->renderSoftwareCursorsFor(PMONITOR->self.lock(), now, fakeDamage, g_pInputManager->getMouseCoordsInternal() - pWindow->m_vRealPosition->value());
+        if (overlayCursor)
+            g_pPointerManager->renderSoftwareCursorsFor(PMONITOR->self.lock(), now, fakeDamage, g_pInputManager->getMouseCoordsInternal() - pWindow->m_vRealPosition->value());
+    }
 
     const auto PFORMAT = NFormatUtils::getPixelFormatFromDRM(shm.format);
     if (!PFORMAT) {
@@ -329,6 +333,7 @@ bool CToplevelExportFrame::copyShm(timespec* now) {
 }
 
 bool CToplevelExportFrame::copyDmabuf(timespec* now) {
+    const auto PERM     = g_pDynamicPermissionManager->clientPermissionMode(resource->client(), PERMISSION_TYPE_SCREENCOPY);
     const auto PMONITOR = pWindow->m_pMonitor.lock();
 
     CRegion    fakeDamage{0, 0, INT16_MAX, INT16_MAX};
@@ -344,13 +349,14 @@ bool CToplevelExportFrame::copyDmabuf(timespec* now) {
         return false;
 
     g_pHyprOpenGL->clear(CHyprColor(0, 0, 0, 1.0));
+    if (PERM == PERMISSION_RULE_ALLOW_MODE_ALLOW) {
+        g_pHyprRenderer->m_bBlockSurfaceFeedback = g_pHyprRenderer->shouldRenderWindow(pWindow); // block the feedback to avoid spamming the surface if it's visible
+        g_pHyprRenderer->renderWindow(pWindow, PMONITOR, now, false, RENDER_PASS_ALL, true, true);
+        g_pHyprRenderer->m_bBlockSurfaceFeedback = false;
 
-    g_pHyprRenderer->m_bBlockSurfaceFeedback = g_pHyprRenderer->shouldRenderWindow(pWindow); // block the feedback to avoid spamming the surface if it's visible
-    g_pHyprRenderer->renderWindow(pWindow, PMONITOR, now, false, RENDER_PASS_ALL, true, true);
-    g_pHyprRenderer->m_bBlockSurfaceFeedback = false;
-
-    if (overlayCursor)
-        g_pPointerManager->renderSoftwareCursorsFor(PMONITOR->self.lock(), now, fakeDamage, g_pInputManager->getMouseCoordsInternal() - pWindow->m_vRealPosition->value());
+        if (overlayCursor)
+            g_pPointerManager->renderSoftwareCursorsFor(PMONITOR->self.lock(), now, fakeDamage, g_pInputManager->getMouseCoordsInternal() - pWindow->m_vRealPosition->value());
+    }
 
     g_pHyprOpenGL->m_RenderData.blockScreenShader = true;
     g_pHyprRenderer->endRender();
@@ -423,6 +429,12 @@ void CToplevelExportProtocol::onOutputCommit(PHLMONITOR pMonitor) {
     for (auto const& f : m_vFramesAwaitingWrite) {
         if (!f)
             continue;
+
+        // check permissions
+        const auto PERM = g_pDynamicPermissionManager->clientPermissionMode(f->resource->client(), PERMISSION_TYPE_SCREENCOPY);
+
+        if (PERM == PERMISSION_RULE_ALLOW_MODE_PENDING)
+            continue; // pending an answer, don't do anything yet.
 
         if (!validMapped(f->pWindow)) {
             framesToRemove.emplace_back(f);


### PR DESCRIPTION
This adds a permission manager for denying access to screencopy.

As usual, Hyprland is the first environment to implement this.

Basically, every time an app wants to copy your screen, it will pop up a notification:
![image](https://github.com/user-attachments/assets/2a1c97ee-0fc8-417f-bd76-b962671e7503)

These permissions are configurable as well, and you can allow / deny globally, or per app.

Closes #9915

@jbeich  for BSD: we use `/proc/pid/exe` to determine the app's binary path. This is not portable. Do you have any ideas for BSD ways to get a process' binary path / name?

Otherwise it's not a dealbreaker, users will just not be able to configure permissions per-app. Either globally, or every app will ask every time it's restarted.

TODO:
 - [ ] Default rules in the config + rules for xdph?
 - [ ] some testing
 - [ ] BSD stuff