### PR TITLE
layout: properly track floating window position

### DIFF
--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -618,6 +618,8 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
             DRAGGINGWINDOW->sendWindowSize();
         }
 
+        DRAGGINGWINDOW->m_vPosition = wb.pos();
+
     } else if (g_pInputManager->dragMode == MBIND_RESIZE || g_pInputManager->dragMode == MBIND_RESIZE_FORCE_RATIO || g_pInputManager->dragMode == MBIND_RESIZE_BLOCK_RATIO) {
         if (DRAGGINGWINDOW->m_bIsFloating) {
 
@@ -689,6 +691,9 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
                 DRAGGINGWINDOW->m_vRealPosition->setValueAndWarp(wb.pos());
                 DRAGGINGWINDOW->sendWindowSize();
             }
+
+            DRAGGINGWINDOW->m_vPosition = wb.pos();
+            DRAGGINGWINDOW->m_vSize     = wb.size();
         } else {
             resizeActiveWindow(TICKDELTA, m_eGrabbedCorner, DRAGGINGWINDOW);
         }
@@ -780,8 +785,8 @@ void IHyprLayout::changeWindowFloatingMode(PHLWINDOW pWindow) {
         *pWindow->m_vRealPosition = wb.pos();
         *pWindow->m_vRealSize     = wb.size();
 
-        pWindow->m_vSize     = wb.pos();
-        pWindow->m_vPosition = wb.size();
+        pWindow->m_vSize     = wb.size();
+        pWindow->m_vPosition = wb.pos();
 
         g_pHyprRenderer->damageMonitor(pWindow->m_pMonitor.lock());
 
@@ -810,6 +815,7 @@ void IHyprLayout::moveActiveWindow(const Vector2D& delta, PHLWINDOW pWindow) {
 
     PWINDOW->setAnimationsToMove();
 
+    PWINDOW->m_vPosition += delta;
     *PWINDOW->m_vRealPosition = PWINDOW->m_vRealPosition->goal() + delta;
 
     g_pHyprRenderer->damageWindow(PWINDOW);


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Currently, the `cursor:persistent_warps` do not work on floating windows, the cursor is always being centered. The reason for that turned out to be that the window position was not being updated properly, i.e. pos and size were swapped (lol) on `changeWindowFloatingMode`, and the position of the window was not updated when performing a mouse drag or moving via keybinds.

fixes #7247 (didn't bother to open a discussion, and decided to fix it instead)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
The current fix works well on my end but maybe there is a codepath where the position is also not being updated that I missed in testing. Lmk if you know of any.

#### Is it ready for merging, or does it need work?
Yes


