### PR TITLE
Nix/module: add defaultSettings

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -9,6 +9,25 @@ let
   inherit (pkgs.stdenv.hostPlatform) system;
   selflib = import ./lib.nix lib;
   cfg = config.programs.hyprland;
+
+  hyprlangType =
+    with lib.types;
+    let
+      valueType =
+        nullOr (oneOf [
+          bool
+          int
+          float
+          str
+          path
+          (attrsOf valueType)
+          (listOf valueType)
+        ])
+        // {
+          description = "Hyprland configuration value";
+        };
+    in
+    valueType;
 in
 {
   options = {
@@ -23,24 +42,7 @@ in
       };
 
       settings = lib.mkOption {
-        type =
-          with lib.types;
-          let
-            valueType =
-              nullOr (oneOf [
-                bool
-                int
-                float
-                str
-                path
-                (attrsOf valueType)
-                (listOf valueType)
-              ])
-              // {
-                description = "Hyprland configuration value";
-              };
-          in
-          valueType;
+        type = hyprlangType;
         default = { };
         description = ''
           Hyprland configuration written in Nix. Entries with the same key
@@ -73,6 +75,30 @@ in
             ];
           }
         '';
+      };
+
+      defaultSettings = lib.mkOption {
+        type = hyprlangType;
+
+        default = {
+          permission = [
+            "${cfg.portalPackage}/libexec/.xdg-desktop-portal-hyprland-wrapped, screencopy, allow"
+            "${lib.getExe pkgs.grim}, screencopy, allow"
+          ];
+        };
+
+        defaultText = lib.literalExpression ''
+          {
+            permission = [
+              "${cfg.portalPackage}/libexec/.xdg-desktop-portal-hyprland-wrapped, screencopy, allow"
+              "${lib.getExe pkgs.grim}, screencopy, allow"
+            ];
+          }
+        '';
+
+        example = lib.literalExpression "{ }";
+
+        description = "Default settings. Can be disabled by setting this option to `{}`.";
       };
 
       extraConfig = lib.mkOption {
@@ -158,6 +184,12 @@ in
                 topCommandsPrefixes = cfg.topPrefixes;
                 bottomCommandsPrefixes = cfg.bottomPrefixes;
               } cfg.settings
+            )
+            + lib.optionalString (cfg.defaultSettings != { }) (
+              selflib.toHyprlang {
+                topCommandsPrefixes = cfg.topPrefixes;
+                bottomCommandsPrefixes = cfg.bottomPrefixes;
+              } cfg.defaultSettings
             )
             + lib.optionalString (cfg.extraConfig != "") cfg.extraConfig;
         };


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

TO BE MERGED AFTER #9930

Add `defaultSettings` option in the NixOS module. Can be disabled by setting it to `{}`.

Default settings currently includes allowing screencopy for XDPH and grim, and optionally adding `exec-once = uwsm finalize` in case `withUWSM = true`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Brainstorming is welcome. This is what made sense to me at the time of opening this PR.

#### Is it ready for merging, or does it need work?

Untested, no.
