### PR TITLE
input: add warp_on_toggle_special

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1476,7 +1476,8 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
     },
     SConfigOptionDescription{
         .value       = "cursor:warp_on_toggle_special",
-        .description = "Move the cursor to the last focused window when toggling a special workspace. Options: 0 (Disabled), 1 (Enabled), 2 (Force - ignores cursor:no_warps option)",
+        .description = "Move the cursor to the last focused window when toggling a special workspace. Options: 0 (Disabled), 1 (Enabled), "
+                       "2 (Force - ignores cursor:no_warps option)",
         .type        = CONFIG_OPTION_CHOICE,
         .data        = SConfigOptionDescription::SChoiceData{0, "Disabled,Enabled,Force"},
     },

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1475,6 +1475,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SChoiceData{0, "Disabled,Enabled,Force"},
     },
     SConfigOptionDescription{
+        .value       = "cursor:warp_on_toggle_special",
+        .description = "Move the cursor to the last focused window when toggling a special workspace. Options: 0 (Disabled), 1 (Enabled), 2 (Force - ignores cursor:no_warps option)",
+        .type        = CONFIG_OPTION_CHOICE,
+        .data        = SConfigOptionDescription::SChoiceData{0, "Disabled,Enabled,Force"},
+    },
+    SConfigOptionDescription{
         .value       = "cursor:default_monitor",
         .description = "the name of a default monitor for the cursor to be set to on startup (see hyprctl monitors for names)",
         .type        = CONFIG_OPTION_STRING_SHORT,

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -670,6 +670,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("cursor:no_warps", Hyprlang::INT{0});
     registerConfigVar("cursor:persistent_warps", Hyprlang::INT{0});
     registerConfigVar("cursor:warp_on_change_workspace", Hyprlang::INT{0});
+    registerConfigVar("cursor:warp_on_toggle_special", Hyprlang::INT{0});
     registerConfigVar("cursor:default_monitor", {STRVAL_EMPTY});
     registerConfigVar("cursor:zoom_factor", {1.f});
     registerConfigVar("cursor:zoom_rigid", Hyprlang::INT{0});

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2119,14 +2119,14 @@ SDispatchResult CKeybindManager::toggleSpecialWorkspace(std::string args) {
         focusedWorkspace = PSPECIALWORKSPACE;
     }
 
-    const static auto PWARPONWORKSPACECHANGE = CConfigValue<Hyprlang::INT>("cursor:warp_on_change_workspace");
+    const static auto PWARPONTOGGLESPECIAL = CConfigValue<Hyprlang::INT>("cursor:warp_on_toggle_special");
 
-    if (*PWARPONWORKSPACECHANGE > 0) {
+    if (*PWARPONTOGGLESPECIAL > 0) {
         auto PLAST     = focusedWorkspace->getLastFocusedWindow();
         auto HLSurface = CWLSurface::fromResource(g_pSeatManager->state.pointerFocus.lock());
 
         if (PLAST && (!HLSurface || HLSurface->getWindow()))
-            PLAST->warpCursor(*PWARPONWORKSPACECHANGE == 2);
+            PLAST->warpCursor(*PWARPONTOGGLESPECIAL == 2);
     }
 
     return {};


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Currently the `cursor:warp_on_change_workspace` option does only apply to changing normal workspaces and not to toggling special ones. This has been bothering me for quite some time because it seems unintuitive and I would often accidentally switch windows on my special workspace because of it.

This PR also warps the cursor on special workspace toggles when `cursor:warp_on_change_workspace` is enabled. I think this should be the expected behavior because to me opening a special workspace is also a "change of workspace".

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I can imagine that some users might prefer the old behaviour (i.e. only warping cursor on normal workspace change). So maybe it would be best to gate this behind an additional config var? I also thought about using a different number for `warp_on_change_workspace` to enable it for specials too, but that wouldn't really make too much sense because `2` is already used for forcing.


#### Is it ready for merging, or does it need work?
Yes

