### PR TITLE
CTMControl: allow CTM animation to work on Nvidia IF there is only one monitor enabled

### DIFF
--- a/src/protocols/CTMControl.cpp
+++ b/src/protocols/CTMControl.cpp
@@ -109,7 +109,7 @@ bool CHyprlandCTMControlProtocol::isCTMAnimationEnabled() {
     static auto PENABLEANIM = CConfigValue<Hyprlang::INT>("render:ctm_animation");
 
     if (*PENABLEANIM == 2)
-        return !g_pHyprRenderer->isNvidia();
+        return !(g_pHyprRenderer->isNvidia() && g_pCompositor->m_vMonitors.size() > 1);
     return *PENABLEANIM;
 }
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

This PR adds an extra check for `ctm_animation = 2` so that if Nvidia is in use BUT there is only one monitor enabled / attached, still allow ctm animations to work. The bug from #8891 only applies to multi monitor setups, so we should still allow them on single monitor setups.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Idk, might need testing from other nvidia users but works fine on my end. I temporarily disabled my secondary monitor with `hyprctl -i 0 keyword monitor desc:Philips,disable`, and triggered hyprsunset, which correctly displayed the ctm animations without freezes. Upon enabling my secondary monitor again, the animation was correctly skipped as it would cause freezes otherwise.

#### Is it ready for merging, or does it need work?

Should be
