### PR TITLE
input/layers: Fix exclusive LS focus / refocus after unmap

### DIFF
--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -234,9 +234,10 @@ void CLayerSurface::onUnmap() {
 
     // refocus if needed
     //                                vvvvvvvvvvvvv if there is a last focus and the last focus is not keyboard focusable, fallback to window
-    if (WASLASTFOCUS || (g_pCompositor->m_pLastFocus && g_pCompositor->m_pLastFocus->hlSurface && !g_pCompositor->m_pLastFocus->hlSurface->keyboardFocusable()))
-        g_pInputManager->refocusLastWindow(PMONITOR);
-    else if (g_pCompositor->m_pLastFocus && g_pCompositor->m_pLastFocus != surface->resource())
+    if (WASLASTFOCUS || (g_pCompositor->m_pLastFocus && g_pCompositor->m_pLastFocus->hlSurface && !g_pCompositor->m_pLastFocus->hlSurface->keyboardFocusable())) {
+        if (!g_pInputManager->refocusLastWindow(PMONITOR))
+            g_pInputManager->refocus();
+    } else if (g_pCompositor->m_pLastFocus && g_pCompositor->m_pLastFocus != surface->resource())
         g_pSeatManager->setKeyboardFocus(g_pCompositor->m_pLastFocus.lock());
 
     CBox geomFixed = {geometry.x + PMONITOR->vecPosition.x, geometry.y + PMONITOR->vecPosition.y, geometry.width, geometry.height};

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -114,7 +114,7 @@ class CInputManager {
 
     Vector2D           getMouseCoordsInternal();
     void               refocus();
-    void               refocusLastWindow(PHLMONITOR pMonitor);
+    bool               refocusLastWindow(PHLMONITOR pMonitor);
     void               simulateMouseMovement();
     void               sendMotionEventsToFocused();
 


### PR DESCRIPTION
Fixes #9980

There are two parts at play here:
- firstly, refocusLastWindow should not attempt that when we have an active exclusive LS 
- secondly, mouseMoveUnified should force focus to exclusive LSes in general 

@user111111111111111111111111111111111 as op for testing, works on my end