### PR TITLE
CursorManager: Store cursor pixel data retrieved from X/HC as a copy.

### DIFF
--- a/src/managers/CursorManager.cpp
+++ b/src/managers/CursorManager.cpp
@@ -18,12 +18,16 @@ static void hcLogger(enum eHyprcursorLogLevel level, char* message) {
     Debug::log(NONE, "[hc] {}", message);
 }
 
-CCursorBuffer::CCursorBuffer(cairo_surface_t* surf, const Vector2D& size_, const Vector2D& hot_) : hotspot(hot_), surface(surf), stride(cairo_image_surface_get_stride(surf)) {
+CCursorBuffer::CCursorBuffer(cairo_surface_t* surf, const Vector2D& size_, const Vector2D& hot_) : m_hotspot(hot_), m_stride(cairo_image_surface_get_stride(surf)) {
     size = size_;
+
+    m_data = std::vector<uint8_t>((uint8_t*)cairo_image_surface_get_data(surf), ((uint8_t*)cairo_image_surface_get_data(surf)) + (cairo_image_surface_get_height(surf) * m_stride));
 }
 
-CCursorBuffer::CCursorBuffer(uint8_t* pixelData_, const Vector2D& size_, const Vector2D& hot_) : hotspot(hot_), pixelData(pixelData_), stride(4 * size_.x) {
+CCursorBuffer::CCursorBuffer(const uint8_t* pixelData, const Vector2D& size_, const Vector2D& hot_) : m_hotspot(hot_), m_stride(4 * size_.x) {
     size = size_;
+
+    m_data = std::vector<uint8_t>(pixelData, pixelData + ((int)size_.y * m_stride));
 }
 
 Aquamarine::eBufferCapability CCursorBuffer::caps() {
@@ -51,12 +55,12 @@ Aquamarine::SSHMAttrs CCursorBuffer::shm() {
     attrs.success = true;
     attrs.format  = DRM_FORMAT_ARGB8888;
     attrs.size    = size;
-    attrs.stride  = stride;
+    attrs.stride  = m_stride;
     return attrs;
 }
 
 std::tuple<uint8_t*, uint32_t, size_t> CCursorBuffer::beginDataPtr(uint32_t flags) {
-    return {pixelData ? pixelData : cairo_image_surface_get_data(surface), DRM_FORMAT_ARGB8888, stride};
+    return {m_data.data(), DRM_FORMAT_ARGB8888, m_stride};
 }
 
 void CCursorBuffer::endDataPtr() {

--- a/src/managers/CursorManager.hpp
+++ b/src/managers/CursorManager.hpp
@@ -17,7 +17,7 @@ AQUAMARINE_FORWARD(IBuffer);
 class CCursorBuffer : public Aquamarine::IBuffer {
   public:
     CCursorBuffer(cairo_surface_t* surf, const Vector2D& size, const Vector2D& hotspot);
-    CCursorBuffer(uint8_t* pixelData, const Vector2D& size, const Vector2D& hotspot);
+    CCursorBuffer(const uint8_t* pixelData, const Vector2D& size, const Vector2D& hotspot);
     ~CCursorBuffer() = default;
 
     virtual Aquamarine::eBufferCapability          caps();
@@ -30,10 +30,9 @@ class CCursorBuffer : public Aquamarine::IBuffer {
     virtual void                                   endDataPtr();
 
   private:
-    Vector2D         hotspot;
-    cairo_surface_t* surface   = nullptr;
-    uint8_t*         pixelData = nullptr;
-    size_t           stride    = 0;
+    Vector2D             m_hotspot;
+    std::vector<uint8_t> m_data;
+    size_t               m_stride = 0;
 };
 
 class CCursorManager {


### PR DESCRIPTION
Instead of storing pointers as refs (which could randomly get invalid very easily) copy the data. They aren't big anyways (4Bpp * ~32^2 = 4kB) and we gain memory safety.

Should fix #9972 but I haven't hit that myself so I'm pinging @zjeffer @onlycs and @nnyyxxxx for testing (which afaiu can repro this)