### PR TITLE
xdg-shell: fix some null refs

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1237,10 +1237,10 @@ void CWindow::setSuspended(bool suspend) {
     if (suspend == m_bSuspended)
         return;
 
-    if (m_bIsX11 || !m_pXDGSurface.lock() || !m_pXDGSurface.lock()->toplevel)
+    if (m_bIsX11 || !m_pXDGSurface || !m_pXDGSurface->toplevel)
         return;
 
-    m_pXDGSurface.lock()->toplevel->setSuspeneded(suspend);
+    m_pXDGSurface->toplevel->setSuspeneded(suspend);
     m_bSuspended = suspend;
 }
 
@@ -1687,10 +1687,10 @@ Vector2D CWindow::requestedMinSize() {
 
 Vector2D CWindow::requestedMaxSize() {
     constexpr int NO_MAX_SIZE_LIMIT = 99999;
-    if (((m_bIsX11 && !m_pXWaylandSurface->sizeHints) || (!m_bIsX11 && (!m_pXDGSurface.lock() || !m_pXDGSurface.lock()->toplevel)) || m_sWindowData.noMaxSize.valueOrDefault()))
+    if (((m_bIsX11 && !m_pXWaylandSurface->sizeHints) || (!m_bIsX11 && (!m_pXDGSurface || !m_pXDGSurface->toplevel)) || m_sWindowData.noMaxSize.valueOrDefault()))
         return Vector2D(NO_MAX_SIZE_LIMIT, NO_MAX_SIZE_LIMIT);
 
-    Vector2D maxSize = m_bIsX11 ? Vector2D(m_pXWaylandSurface->sizeHints->max_width, m_pXWaylandSurface->sizeHints->max_height) : m_pXDGSurface.lock()->toplevel->layoutMaxSize();
+    Vector2D maxSize = m_bIsX11 ? Vector2D(m_pXWaylandSurface->sizeHints->max_width, m_pXWaylandSurface->sizeHints->max_height) : m_pXDGSurface->toplevel->layoutMaxSize();
 
     if (maxSize.x < 5)
         maxSize.x = NO_MAX_SIZE_LIMIT;

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1237,10 +1237,10 @@ void CWindow::setSuspended(bool suspend) {
     if (suspend == m_bSuspended)
         return;
 
-    if (m_bIsX11 || !m_pXDGSurface->toplevel)
+    if (m_bIsX11 || !m_pXDGSurface.lock() || !m_pXDGSurface.lock()->toplevel)
         return;
 
-    m_pXDGSurface->toplevel->setSuspeneded(suspend);
+    m_pXDGSurface.lock()->toplevel->setSuspeneded(suspend);
     m_bSuspended = suspend;
 }
 
@@ -1687,10 +1687,10 @@ Vector2D CWindow::requestedMinSize() {
 
 Vector2D CWindow::requestedMaxSize() {
     constexpr int NO_MAX_SIZE_LIMIT = 99999;
-    if (((m_bIsX11 && !m_pXWaylandSurface->sizeHints) || (!m_bIsX11 && !m_pXDGSurface->toplevel) || m_sWindowData.noMaxSize.valueOrDefault()))
+    if (((m_bIsX11 && !m_pXWaylandSurface->sizeHints) || (!m_bIsX11 && (!m_pXDGSurface.lock() || !m_pXDGSurface.lock()->toplevel)) || m_sWindowData.noMaxSize.valueOrDefault()))
         return Vector2D(NO_MAX_SIZE_LIMIT, NO_MAX_SIZE_LIMIT);
 
-    Vector2D maxSize = m_bIsX11 ? Vector2D(m_pXWaylandSurface->sizeHints->max_width, m_pXWaylandSurface->sizeHints->max_height) : m_pXDGSurface->toplevel->layoutMaxSize();
+    Vector2D maxSize = m_bIsX11 ? Vector2D(m_pXWaylandSurface->sizeHints->max_width, m_pXWaylandSurface->sizeHints->max_height) : m_pXDGSurface.lock()->toplevel->layoutMaxSize();
 
     if (maxSize.x < 5)
         maxSize.x = NO_MAX_SIZE_LIMIT;

--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -123,8 +123,10 @@ bool CHyprXWaylandManager::shouldBeFloated(PHLWINDOW pWindow, bool pending) {
             (SIZEHINTS && (SIZEHINTS->min_width == SIZEHINTS->max_width) && (SIZEHINTS->min_height == SIZEHINTS->max_height)))
             return true;
     } else {
-        const auto PSTATE = pending ? &pWindow->m_pXDGSurface->toplevel->pending : &pWindow->m_pXDGSurface->toplevel->current;
+        if (!pWindow->m_pXDGSurface.lock() || !pWindow->m_pXDGSurface.lock()->toplevel)
+            return false;
 
+        const auto PSTATE = pending ? &pWindow->m_pXDGSurface->toplevel->pending : &pWindow->m_pXDGSurface->toplevel->current;
         if (pWindow->m_pXDGSurface->toplevel->parent ||
             (PSTATE->minSize.x != 0 && PSTATE->minSize.y != 0 && (PSTATE->minSize.x == PSTATE->maxSize.x || PSTATE->minSize.y == PSTATE->maxSize.y)))
             return true;

--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -123,7 +123,7 @@ bool CHyprXWaylandManager::shouldBeFloated(PHLWINDOW pWindow, bool pending) {
             (SIZEHINTS && (SIZEHINTS->min_width == SIZEHINTS->max_width) && (SIZEHINTS->min_height == SIZEHINTS->max_height)))
             return true;
     } else {
-        if (!pWindow->m_pXDGSurface.lock() || !pWindow->m_pXDGSurface.lock()->toplevel)
+        if (!pWindow->m_pXDGSurface || !pWindow->m_pXDGSurface->toplevel)
             return false;
 
         const auto PSTATE = pending ? &pWindow->m_pXDGSurface->toplevel->pending : &pWindow->m_pXDGSurface->toplevel->current;


### PR DESCRIPTION
fixes some crashes i experienced with swallowing + ueberzup (whatever the fuck its called)

shrimply make alacritty swallow some images via ueberzup (whatever the fuck its called) and yazi and then killall alacritty in another terminal, you will get led down a rabbit hole of traces

this is one of many
[hyprlandCrashReport92989.txt](https://github.com/user-attachments/files/19650904/hyprlandCrashReport92989.txt)

it might be possible to just reproduce this without swallowing (idk havent tried), (nvm just checked)

