### PR TITLE
remove renderer finalDamage since it's unused

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -701,7 +701,6 @@ void CHyprOpenGLImpl::beginSimple(PHLMONITOR pMonitor, const CRegion& damage, SP
         initShaders();
 
     m_RenderData.damage.set(damage);
-    m_RenderData.finalDamage.set(damage);
 
     m_bFakeFrame = true;
 
@@ -715,7 +714,7 @@ void CHyprOpenGLImpl::beginSimple(PHLMONITOR pMonitor, const CRegion& damage, SP
     m_RenderData.simplePass = true;
 }
 
-void CHyprOpenGLImpl::begin(PHLMONITOR pMonitor, const CRegion& damage_, CFramebuffer* fb, std::optional<CRegion> finalDamage) {
+void CHyprOpenGLImpl::begin(PHLMONITOR pMonitor, const CRegion& damage_, CFramebuffer* fb) {
     m_RenderData.pMonitor = pMonitor;
 
 #ifndef GLES2
@@ -766,7 +765,6 @@ void CHyprOpenGLImpl::begin(PHLMONITOR pMonitor, const CRegion& damage_, CFrameb
         m_RenderData.pCurrentMonData->monitorMirrorFB.release();
 
     m_RenderData.damage.set(damage_);
-    m_RenderData.finalDamage.set(finalDamage.value_or(damage_));
 
     m_bFakeFrame = fb;
 
@@ -791,8 +789,7 @@ void CHyprOpenGLImpl::end() {
 
     // end the render, copy the data to the main framebuffer
     if (m_bOffloadedFramebuffer) {
-        m_RenderData.damage = m_RenderData.finalDamage;
-        m_bEndFrame         = true;
+        m_bEndFrame = true;
 
         CBox monbox = {0, 0, m_RenderData.pMonitor->vecTransformedSize.x, m_RenderData.pMonitor->vecTransformedSize.y};
 
@@ -863,9 +860,8 @@ void CHyprOpenGLImpl::end() {
         RASSERT(false, "glGetError at Opengl::end() returned GL_CONTEXT_LOST. Cannot continue until proper GPU reset handling is implemented.");
 }
 
-void CHyprOpenGLImpl::setDamage(const CRegion& damage_, std::optional<CRegion> finalDamage) {
+void CHyprOpenGLImpl::setDamage(const CRegion& damage_) {
     m_RenderData.damage.set(damage_);
-    m_RenderData.finalDamage.set(finalDamage.value_or(damage_));
 }
 
 // TODO notify user if bundled shader is newer than ~/.config override

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -125,7 +125,6 @@ struct SCurrentRenderData {
     CFramebuffer*          outFB           = nullptr; // out to render to (if offloaded, etc)
 
     CRegion                damage;
-    CRegion                finalDamage; // damage used for funal off -> main
 
     SRenderModifData       renderModif;
     float                  mouseZoomFactor    = 1.f;
@@ -172,7 +171,7 @@ class CHyprOpenGLImpl {
     CHyprOpenGLImpl();
     ~CHyprOpenGLImpl();
 
-    void begin(PHLMONITOR, const CRegion& damage, CFramebuffer* fb = nullptr, std::optional<CRegion> finalDamage = {});
+    void begin(PHLMONITOR, const CRegion& damage, CFramebuffer* fb = nullptr);
     void beginSimple(PHLMONITOR, const CRegion& damage, SP<CRenderbuffer> rb = nullptr, CFramebuffer* fb = nullptr);
     void end();
 
@@ -227,7 +226,7 @@ class CHyprOpenGLImpl {
     SP<CTexture>                         loadAsset(const std::string& file);
     SP<CTexture>                         renderText(const std::string& text, CHyprColor col, int pt, bool italic = false, const std::string& fontFamily = "", int maxWidth = 0);
 
-    void                                 setDamage(const CRegion& damage, std::optional<CRegion> finalDamage = {});
+    void                                 setDamage(const CRegion& damage);
 
     void                                 ensureBackgroundTexturePresence();
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1292,7 +1292,7 @@ void CHyprRenderer::renderMonitor(PHLMONITOR pMonitor) {
         pMonitor->forceFullFrames                      = 10;
     }
 
-    CRegion damage, finalDamage;
+    CRegion damage;
     if (!beginRender(pMonitor, damage, RENDER_MODE_NORMAL)) {
         Debug::log(ERR, "renderer: couldn't beginRender()!");
         return;
@@ -1302,10 +1302,8 @@ void CHyprRenderer::renderMonitor(PHLMONITOR pMonitor) {
     if (*PDAMAGETRACKINGMODE == DAMAGE_TRACKING_NONE || *PDAMAGETRACKINGMODE == DAMAGE_TRACKING_MONITOR || pMonitor->forceFullFrames > 0 || damageBlinkCleanup > 0)
         damage = {0, 0, (int)pMonitor->vecTransformedSize.x * 10, (int)pMonitor->vecTransformedSize.y * 10};
 
-    finalDamage = damage;
-
     // update damage in renderdata as we modified it
-    g_pHyprOpenGL->setDamage(damage, finalDamage);
+    g_pHyprOpenGL->setDamage(damage);
 
     if (pMonitor->forceFullFrames > 0) {
         pMonitor->forceFullFrames -= 1;
@@ -1317,7 +1315,7 @@ void CHyprRenderer::renderMonitor(PHLMONITOR pMonitor) {
 
     bool renderCursor = true;
 
-    if (!finalDamage.empty()) {
+    if (!damage.empty()) {
         if (pMonitor->solitaryClient.expired()) {
             if (pMonitor->isMirror()) {
                 g_pHyprOpenGL->blend(false);

--- a/src/render/pass/Pass.cpp
+++ b/src/render/pass/Pass.cpp
@@ -119,8 +119,7 @@ CRegion CRenderPass::render(const CRegion& damage_) {
     }
 
     if (damage.empty()) {
-        g_pHyprOpenGL->m_RenderData.damage      = damage;
-        g_pHyprOpenGL->m_RenderData.finalDamage = damage;
+        g_pHyprOpenGL->m_RenderData.damage = damage;
         return damage;
     }
 
@@ -150,16 +149,13 @@ CRegion CRenderPass::render(const CRegion& damage_) {
 
         blurRegion.intersect(damage).expand(oneBlurRadius());
 
-        g_pHyprOpenGL->m_RenderData.finalDamage = blurRegion.copy().add(damage);
-
         // FIXME: why does this break on * 1.F ?
         // used to work when we expand all the damage... I think? Well, before pass.
         // moving a window over blur shows the edges being wonk.
         blurRegion.expand(oneBlurRadius() * 1.5F);
 
         damage = blurRegion.copy().add(damage);
-    } else
-        g_pHyprOpenGL->m_RenderData.finalDamage = damage;
+    }
 
     if (std::ranges::any_of(m_vPassElements, [](const auto& el) { return el->element->disableSimplification(); })) {
         for (auto& el : m_vPassElements) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
realized that finalDamage is just a copy of damage in renderMonitor,
then saw that nothing ever actually uses it

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

#### Is it ready for merging, or does it need work?
yes, did a quick test with blur on and off and it seemed fine