### PR TITLE
fix crash in data device on shutdown

### DIFF
--- a/src/protocols/core/DataDevice.cpp
+++ b/src/protocols/core/DataDevice.cpp
@@ -420,7 +420,7 @@ void CWLDataDeviceProtocol::destroyResource(CWLDataOfferResource* resource) {
 
 SP<IDataDevice> CWLDataDeviceProtocol::dataDeviceForClient(wl_client* c) {
 #ifndef NO_XWAYLAND
-    if (g_pXWayland->pServer && c == g_pXWayland->pServer->xwaylandClient)
+    if (g_pXWayland && g_pXWayland->pServer && c == g_pXWayland->pServer->xwaylandClient)
         return g_pXWayland->pWM->getDataDevice();
 #endif
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
null check to prevent crash in data device

<details><summary>a bit of the stacktrace</summary>

```
(gdb) bt full
#0  0x0000637bb71326e2 in Hyprutils::Memory::CUniquePointer<CXWaylandServer>::operator bool (this=0x0) at /usr/include/hyprutils/memory/UniquePtr.hpp:73
#1  0x0000637bb71c92e9 in CWLDataDeviceProtocol::dataDeviceForClient (this=0x637bc91a1a90, c=0x637bcbd46760)
    at /home/ikalco/prog/Hyprland/src/protocols/core/DataDevice.cpp:423
        it = {impl_ = 0x637bc8f3e830}
#2  0x0000637bb71ca422 in CWLDataDeviceProtocol::setSelection (this=0x637bc91a1a90, source=...) at /home/ikalco/prog/Hyprland/src/protocols/core/DataDevice.cpp:488
        DESTDEVICE = {impl_ = 0x637bcbeb2aa0}
        DESTDEVICE = {impl_ = 0x637bcbeb2aa0}
#3  0x0000637bb6cb805f in CSeatManager::setCurrentSelection (this=0x637bc91dd520, source=...) at /home/ikalco/prog/Hyprland/src/managers/SeatManager.cpp:557
#4  0x0000637bb6cb7ef5 in operator() (__closure=0x637bcbda5920, d=std::any [no contained value]) at /home/ikalco/prog/Hyprland/src/managers/SeatManager.cpp:562
#5  0x0000637bb6cc0ee2 in std::__invoke_impl<void, CSeatManager::setCurrentSelection(Hyprutils::Memory::CSharedPointer<IDataSource>)::<lambda(std::any)>&, std::any>(std::__invoke_other, struct {...} &) (__f=...) at /usr/include/c++/14.2.1/bits/invoke.h:61
#6  0x0000637bb6cbf141 in std::__invoke_r<void, CSeatManager::setCurrentSelection(Hyprutils::Memory::CSharedPointer<IDataSource>)::<lambda(std::any)>&, std::any>(struct {...} &) (__fn=...) at /usr/include/c++/14.2.1/bits/invoke.h:111
#7  0x0000637bb6cbc45d in std::_Function_handler<void(std::any), CSeatManager::setCurrentSelection(Hyprutils::Memory::CSharedPointer<IDataSource>)::<lambda(std::any)> >::_M_invoke(const std::_Any_data &, std::any &&) (__functor=..., __args#0=...) at /usr/include/c++/14.2.1/bits/std_function.h:290
#8  0x00007096cde7b00f in Hyprutils::Signal::CSignalListener::emit(std::any) () at /usr/lib/libhyprutils.so.5
#9  0x00007096cde7b8ab in Hyprutils::Signal::CSignal::emit(std::any) () at /usr/lib/libhyprutils.so.5
#10 0x0000637bb6e6b89a in operator() (__closure=0x637bcbeabee0, r=0x637bcbeabea0) at /home/ikalco/prog/Hyprland/src/protocols/DataDeviceWlr.cpp:56
#11 0x0000637bb6e748f6 in std::__invoke_impl<void, CWLRDataSource::CWLRDataSource(Hyprutils::Memory::CSharedPointer<CZwlrDataControlSourceV1>, Hyprutils::Memory::CSharedPointer<CWLRDataDevice>)::<lambda(CZwlrDataControlSourceV1*)>&, CZwlrDataControlSourceV1*>(std::__invoke_other, struct {...} &) (__f=...)
    at /usr/include/c++/14.2.1/bits/invoke.h:61
c#12 0x0000637bb6e73071 in std::__invoke_r<void, CWLRDataSource::CWLRDataSource(Hyprutils::Memory::CSharedPointer<CZwlrDataControlSourceV1>, Hyprutils::Memory::CSharedPointer<CWLRDataDevice>)::<lambda(CZwlrDataControlSourceV1*)>&, CZwlrDataControlSourceV1*>(struct {...} &) (__fn=...) at /usr/include/c++/14.2.1/bits/invoke.h:111
#13 0x0000637bb6e716b1 in std::_Function_handler<void(CZwlrDataControlSourceV1*), CWLRDataSource::CWLRDataSource(Hyprutils::Memory::CSharedPointer<CZwlrDataControlSourceV1>, Hyprutils::Memory::CSharedPointer<CWLRDataDevice>)::<lambda(CZwlrDataControlSourceV1*)> >::_M_invoke(const std::_Any_data &, CZwlrDataControlSourceV1 *&&)
    (__functor=..., __args#0=@0x7ffd8d84f800: 0x637bcbeabea0) at /usr/include/c++/14.2.1/bits/std_function.h:290
#14 0x0000637bb7392a0f in std::function<void(CZwlrDataControlSourceV1*)>::operator() (this=0x637bcbeabee0, __args#0=0x637bcbeabea0)
    at /usr/include/c++/14.2.1/bits/std_function.h:591
#15 0x0000637bb7391e12 in CZwlrDataControlSourceV1::onDestroyCalled (this=0x637bcbeabea0) at /home/ikalco/prog/Hyprland/protocols/wlr-data-control-unstable-v1.cpp:427
```
</details>

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

#### Is it ready for merging, or does it need work?
yes
