### PR TITLE
core: recheck floating windows after monitor layout changes

### DIFF
--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -141,6 +141,7 @@ class CCompositor {
     void                   moveWindowToWorkspaceSafe(PHLWINDOW pWindow, PHLWORKSPACE pWorkspace);
     PHLWINDOW              getForceFocus();
     void                   arrangeMonitors();
+    void                   recheckFloatingWindowsOnScreen();
     void                   enterUnsafeState();
     void                   leaveUnsafeState();
     void                   setPreferredScaleForSurface(SP<CWLSurfaceResource> pSurface, double scale);

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -829,6 +829,8 @@ bool CMonitor::applyMonitorRule(SMonitorRule* pMonitorRule, bool force) {
 
     events.modeChanged.emit();
 
+    g_pEventLoopManager->doLater([]() { g_pCompositor->recheckFloatingWindowsOnScreen(); });
+
     return true;
 }
 


### PR DESCRIPTION
Rechecks the position of floating windows after monitor layout changes.

Fixes #10030