### PR TITLE
cmake: do not install version.h.in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -447,6 +447,7 @@ install(
   DIRECTORY ${HEADERS_SRC}
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/hyprland
   FILES_MATCHING
-  PATTERN "*.h*"
+  PATTERN "*.h"
+  PATTERN "*.hpp"
   PATTERN "*.inc"
   )


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
fixes https://github.com/hyprwm/Hyprland/discussions/10018

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Maybe there is a cleaner way to check for `.h` and `.hpp` on a single line? not regex so idk. This way is alright

#### Is it ready for merging, or does it need work?
ready

