### PR TITLE
layerSurface: warp position and size before taking a snapshot

### DIFF
--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -214,6 +214,10 @@ void CLayerSurface::onUnmap() {
         return;
     }
 
+    // end any pending animations so that snapshot has right dimensions
+    realPosition->warp();
+    realSize->warp();
+
     // make a snapshot and start fade
     g_pHyprRenderer->makeLayerSnapshot(self.lock());
 


### PR DESCRIPTION
We don't want the snapshot to be stretched or have weird dimensions as that will break damage + look off.

Fixes #10028