### PR TITLE
desktop: Damage subsurface when position changes

### DIFF
--- a/src/desktop/Subsurface.hpp
+++ b/src/desktop/Subsurface.hpp
@@ -49,7 +49,8 @@ class CSubsurface {
 
     WP<CWLSubsurfaceResource> m_pSubsurface;
     SP<CWLSurface>            m_pWLSurface;
-    Vector2D                  m_vLastSize = {};
+    Vector2D                  m_vLastSize     = {};
+    Vector2D                  m_vLastPosition = {};
 
     // if nullptr, means it's a dummy node
     WP<CSubsurface>              m_pParent;
@@ -64,4 +65,5 @@ class CSubsurface {
     void                         initSignals();
     void                         initExistingSubsurfaces(SP<CWLSurfaceResource> pSurface);
     void                         checkSiblingDamage();
+    void                         damageEntireParent();
 };


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Previously, when a subsurface was committed at a new position, its old position wouldn't be damaged. Fixes https://github.com/hyprwm/Hyprland/discussions/10079 for me

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Right now this PR just damages the entire parent surface, which is what was done for size as well. This works though isn't optimal for performance, but I think that's fine for now.

#### Is it ready for merging, or does it need work?
Ready for merging