### PR TITLE
ctm: enable fade animation on nvidia driver versions 575 and above

### DIFF
--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -828,16 +828,16 @@ bool isNvidiaDriverVersionAtLeast(int threshold) {
     if (once) {
         once = false;
 
-        if (std::filesystem::exists("/sys/module/nvidia_drm/version")) {
+        std::error_code ec;
+        if (std::filesystem::exists("/sys/module/nvidia_drm/version", ec) && !ec) {
             std::ifstream ifs("/sys/module/nvidia_drm/version");
             if (ifs.good()) {
                 try {
                     std::string driverInfo((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
 
                     size_t      firstDot = driverInfo.find('.');
-                    if (firstDot != std::string::npos) {
+                    if (firstDot != std::string::npos)
                         driverMajor = std::stoi(driverInfo.substr(0, firstDot));
-                    }
 
                     Debug::log(LOG, "Parsed NVIDIA major version: {}", driverMajor);
 

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -817,3 +817,38 @@ float stringToPercentage(const std::string& VALUE, const float REL) {
     else
         return std::stof(VALUE);
 }
+
+// Checks if Nvidia driver major version is at least given version.
+// Useful for explicit_sync_kms and ctm_animation as they only work
+// past certain driver versions.
+bool isNvidiaDriverVersionAtLeast(int threshold) {
+    static int  driverMajor = 0;
+    static bool once        = true;
+
+    if (once) {
+        once = false;
+
+        if (std::filesystem::exists("/sys/module/nvidia_drm/version")) {
+            std::ifstream ifs("/sys/module/nvidia_drm/version");
+            if (ifs.good()) {
+                try {
+                    std::string driverInfo((std::istreambuf_iterator<char>(ifs)), (std::istreambuf_iterator<char>()));
+
+                    size_t      firstDot = driverInfo.find('.');
+                    if (firstDot != std::string::npos) {
+                        driverMajor = std::stoi(driverInfo.substr(0, firstDot));
+                    }
+
+                    Debug::log(LOG, "Parsed NVIDIA major version: {}", driverMajor);
+
+                } catch (std::exception& e) {
+                    driverMajor = 0; // Default to 0 if parsing fails
+                }
+
+                ifs.close();
+            }
+        }
+    }
+
+    return driverMajor >= threshold;
+}

--- a/src/helpers/MiscFunctions.hpp
+++ b/src/helpers/MiscFunctions.hpp
@@ -39,6 +39,7 @@ bool                                envEnabled(const std::string& env);
 Hyprutils::OS::CFileDescriptor      allocateSHMFile(size_t len);
 bool                                allocateSHMFilePair(size_t size, Hyprutils::OS::CFileDescriptor& rw_fd_ptr, Hyprutils::OS::CFileDescriptor& ro_fd_ptr);
 float                               stringToPercentage(const std::string& VALUE, const float REL);
+bool                                isNvidiaDriverVersionAtLeast(int threshold);
 
 template <typename... Args>
 [[deprecated("use std::format instead")]] std::string getFormat(std::format_string<Args...> fmt, Args&&... args) {

--- a/src/protocols/CTMControl.cpp
+++ b/src/protocols/CTMControl.cpp
@@ -6,6 +6,7 @@
 #include "../config/ConfigManager.hpp"
 #include "managers/AnimationManager.hpp"
 #include "../helpers/Monitor.hpp"
+#include "../helpers/MiscFunctions.hpp"
 
 CHyprlandCTMControlResource::CHyprlandCTMControlResource(SP<CHyprlandCtmControlManagerV1> resource_) : resource(resource_) {
     if UNLIKELY (!good())
@@ -109,8 +110,12 @@ void CHyprlandCTMControlProtocol::destroyResource(CHyprlandCTMControlResource* r
 bool CHyprlandCTMControlProtocol::isCTMAnimationEnabled() {
     static auto PENABLEANIM = CConfigValue<Hyprlang::INT>("render:ctm_animation");
 
-    if (*PENABLEANIM == 2)
-        return !g_pHyprRenderer->isNvidia();
+    if (*PENABLEANIM == 2 /* auto */) {
+        if (!g_pHyprRenderer->isNvidia())
+            return true;
+        // CTM animations are bugged on versions below.
+        return isNvidiaDriverVersionAtLeast(575);
+    }
     return *PENABLEANIM;
 }
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Copies the logic for explicit_sync_kms over to ctm_animation since novideo fixed #8891 root cause in 575 release: https://www.nvidia.com/en-us/drivers/details/243334/ specifically 
![image](https://github.com/user-attachments/assets/759109c2-78a9-45f9-8427-16a136f1fba6)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Could move the logic to a helper function checkNvidiaMajorVersion or something but since we only use it twice idk if u wanna do that, lmk

The logic is copied over pretty much identically so it should be OK. I checked and it enabled as expected on 575 and then was disabled as it was before on 570.

#### Is it ready for merging, or does it need work?

Yea

:muscle: <img src="https://github.com/user-attachments/assets/3847e46e-4da6-48aa-966d-d9a9d20593b0" alt="nvuv logo" width="50"/> :muscle: 