### PR TITLE
fix PointerConstraints activation occurring before attached to InputManager

### DIFF
--- a/src/protocols/PointerConstraints.cpp
+++ b/src/protocols/PointerConstraints.cpp
@@ -93,9 +93,6 @@ void CPointerConstraint::sharedConstructions() {
     }
 
     cursorPosOnActivate = g_pInputManager->getMouseCoordsInternal();
-
-    if (g_pCompositor->m_pLastFocus == pHLSurface->resource())
-        activate();
 }
 
 bool CPointerConstraint::good() {
@@ -244,6 +241,9 @@ void CPointerConstraintsProtocol::onNewConstraint(SP<CPointerConstraint> constra
     OWNER->appendConstraint(constraint);
 
     g_pInputManager->m_vConstraints.emplace_back(constraint);
+
+    if (g_pCompositor->m_pLastFocus == OWNER->resource())
+        constraint->activate();
 }
 
 void CPointerConstraintsProtocol::onLockPointer(CZwpPointerConstraintsV1* pMgr, uint32_t id, wl_resource* surface, wl_resource* pointer, wl_resource* region,


### PR DESCRIPTION
**I unintentionally closed the PR https://github.com/hyprwm/Hyprland/pull/9427 when renaming the branch in my fork. So I'm creating another one. Sorry for the mess I made.**

Describe your PR, what does it fix/add?

Fixes https://github.com/hyprwm/Hyprland/issues/8506

It is possible for the CInputManager::simulateMouseMovement() method to be called via CPointerConstraint::activate() without the constraint being present in InputManager.m_vConstraints.

This occurs when the constraint is activated before CPointerConstraintsProtocol::onNewConstraint, which is what places it in InputManager.m_vConstraints, is finalized.
The lack of the instance of CPointerConstraint in m_vConstraints causes the CInputManager::isConstrained() method to fail and return false. As a result, the CInputManager::mouseMoveUnified method is run erroneously until it's end when the constraint is activated.

This occurs because the constructor of CPointerConstraint itself calls activate() at the end.
Obviously, CPointerConstraint must be constructed to be included in the constraint list, but activate() expects it to already be included in the list.

As a solution, I found it ideal to move the activation of the constraint from the constructor to the end of onNewConstraint method.

Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

The modification is small, it's easy to see that it's safe. I've been using it for a while now.

Ready for merging. I don't plan to modify anything else.