### PR TITLE
drm-lease: Add Multi-GPU Support

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -173,8 +173,13 @@ void CMonitor::onConnect(bool noRule) {
 
     if (m_output->nonDesktop) {
         Debug::log(LOG, "Not configuring non-desktop output");
-        if (PROTO::lease)
-            PROTO::lease->offer(m_self.lock());
+
+        for (auto& [name, lease] : PROTO::lease) {
+            if (!lease || m_output->getBackend() != lease->getBackend())
+                continue;
+
+            lease->offer(m_self.lock());
+        }
 
         return;
     }


### PR DESCRIPTION
Adds multi-GPU support for the `wp_drm_lease_v1` protocol, and should fix the issue in #10053.

It seems to work fine on my system; I can start and stop monado several times without issues, but I'm not sure if it's fully ready to merge.

Turns `PROTO::lease` into an array of `CDRMLeaseProtocol` pointers, adds a `backend` parameter to the constructor for `CDRMLeaseProtocol`, and adds `WP<CDRMLeaseDeviceResource>` parameters to the constructors for a few resource types.

Resource freeing could be an issue, I had a few crashes with the `onDestroy` callbacks for at least the `CDRMLeaseResource`.