### PR TITLE
input(tablet): naive window refocusing

### DIFF
--- a/src/managers/input/Tablets.cpp
+++ b/src/managers/input/Tablets.cpp
@@ -134,6 +134,7 @@ void CInputManager::onTabletAxis(CTablet::SAxisEvent e) {
             }
         }
 
+        simulateMouseMovement();
         refocusTablet(PTAB, PTOOL, true);
         m_tmrLastCursorMovement.reset();
     }
@@ -173,6 +174,9 @@ void CInputManager::onTabletTip(CTablet::STipEvent e) {
     else
         g_pPointerManager->warpAbsolute(transformToActiveRegion(POS, PTAB->activeArea), PTAB);
 
+    if (e.in)
+        refocus();
+
     refocusTablet(PTAB, PTOOL, true);
 
     if (e.in)
@@ -185,6 +189,9 @@ void CInputManager::onTabletTip(CTablet::STipEvent e) {
 
 void CInputManager::onTabletButton(CTablet::SButtonEvent e) {
     const auto PTOOL = ensureTabletToolPresent(e.tool);
+
+    if (e.down)
+        refocus();
 
     PROTO::tablet->buttonTool(PTOOL, e.button, e.down);
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
The first naive bird for #9878 (#9758 & #5989).
This patch implements basic window refocusing by tablet events.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I've test this PR for the last week and haven’t found any _new_ issues, except that sometimes the added `simulateMouseMovement()` makes Qt applications (Krita) change focus on pen movements — as if `input:follow_mouse` were activated (when it’s not).

There's still significant work needed to make graphics tablets work great in Hyprland. This PR only trying to provide a base QoL improvement for tablet users.

#### Is it ready for merging, or does it need work?
rdy
