### PR TITLE
render, helpers: Call OpenGL destroyMonitorResources on disconnect

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -51,6 +51,7 @@ CMonitor::CMonitor(SP<Aquamarine::IOutput> output_) : state(this), output(output
 
 CMonitor::~CMonitor() {
     events.destroy.emit();
+    g_pHyprOpenGL->destroyMonitorResources(self);
 }
 
 void CMonitor::onConnect(bool noRule) {
@@ -295,6 +296,7 @@ void CMonitor::onDisconnect(bool destroy) {
     Debug::log(LOG, "onDisconnect called for {}", output->name);
 
     events.disconnect.emit();
+    g_pHyprOpenGL->destroyMonitorResources(self);
 
     // record what workspace this monitor was on
     if (activeWorkspace) {
@@ -832,7 +834,7 @@ bool CMonitor::applyMonitorRule(SMonitorRule* pMonitorRule, bool force) {
     updateMatrix();
 
     if (WAS10B != enabled10bit || OLDRES != vecPixelSize)
-        g_pHyprOpenGL->destroyMonitorResources(self.lock());
+        g_pHyprOpenGL->destroyMonitorResources(self);
 
     g_pCompositor->arrangeMonitors();
 

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -51,7 +51,8 @@ CMonitor::CMonitor(SP<Aquamarine::IOutput> output_) : state(this), output(output
 
 CMonitor::~CMonitor() {
     events.destroy.emit();
-    g_pHyprOpenGL->destroyMonitorResources(self);
+    if (g_pHyprOpenGL)
+        g_pHyprOpenGL->destroyMonitorResources(self);
 }
 
 void CMonitor::onConnect(bool noRule) {
@@ -296,7 +297,8 @@ void CMonitor::onDisconnect(bool destroy) {
     Debug::log(LOG, "onDisconnect called for {}", output->name);
 
     events.disconnect.emit();
-    g_pHyprOpenGL->destroyMonitorResources(self);
+    if (g_pHyprOpenGL)
+        g_pHyprOpenGL->destroyMonitorResources(self);
 
     // record what workspace this monitor was on
     if (activeWorkspace) {

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -2997,7 +2997,7 @@ void CHyprOpenGLImpl::clearWithTex() {
     }
 }
 
-void CHyprOpenGLImpl::destroyMonitorResources(PHLMONITOR pMonitor) {
+void CHyprOpenGLImpl::destroyMonitorResources(PHLMONITORREF pMonitor) {
     g_pHyprRenderer->makeEGLCurrent();
 
     if (!g_pHyprOpenGL)
@@ -3021,7 +3021,8 @@ void CHyprOpenGLImpl::destroyMonitorResources(PHLMONITOR pMonitor) {
         g_pHyprOpenGL->m_mMonitorBGFBs.erase(TEXIT);
     }
 
-    Debug::log(LOG, "Monitor {} -> destroyed all render data", pMonitor->szName);
+    if (pMonitor)
+        Debug::log(LOG, "Monitor {} -> destroyed all render data", pMonitor->szName);
 }
 
 void CHyprOpenGLImpl::saveMatrix() {

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -207,7 +207,7 @@ class CHyprOpenGLImpl {
     void scissor(const pixman_box32*, bool transform = true);
     void scissor(const int x, const int y, const int w, const int h, bool transform = true);
 
-    void destroyMonitorResources(PHLMONITOR);
+    void destroyMonitorResources(PHLMONITORREF);
 
     void markBlurDirtyForMonitor(PHLMONITOR);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes #10098

I think the monitor resources might be better implemented using e.g. the attachment system from hyprutils, but this fixes it for now.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
To prevent leaks we only need to call `destroyMonitorResources` in `~CMonitor`, but also calling it in `onDisconnect` is helpful to free up resources early and it's imo worth deallocating the VRAM temporarily even if the user reenables the monitor later.

#### Is it ready for merging, or does it need work?
Ready for merging