### PR TITLE
Fix CCompositor::getMonitorInDirection does not return focused monitor

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1780,7 +1780,7 @@ PHLMONITOR CCompositor::getMonitorInDirection(PHLMONITOR pSourceMonitor, const c
     PHLMONITOR longestIntersectMonitor = nullptr;
 
     for (auto const& m : m_vMonitors) {
-        if (m == m_pLastMonitor)
+        if (m == pSourceMonitor)
             continue;
 
         const auto POSB  = m->vecPosition;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Currently, `CCompositor::getMonitorInDirection(PHLMONITOR pSourceMonitor, const char& dir)` does not return focused monitor and returns `nullptr` or another monitor instead.
This PR fix this.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

It is ready.
