### PR TITLE
IHyprLayout: simulate mouse movement after dropping window

### DIFF
--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -366,6 +366,8 @@ void IHyprLayout::onEndDragWindow() {
     g_pCompositor->focusWindow(DRAGGINGWINDOW);
 
     g_pInputManager->m_bWasDraggingWindow = false;
+
+    g_pInputManager->simulateMouseMovement();
 }
 
 static inline bool canSnap(const double SIDEA, const double SIDEB, const double GAP) {


### PR DESCRIPTION
without this the window still thinks the pointer is in the middle of the window which is incorrect (only if the user never moves their mouse themselves after dropping, also the cursor icon doesn't update either if it gets changed while dropping, this addresses both issues)

we should probably do this in more places other than just on drag end (e.g. fullscreening)