### PR TITLE
Fix order of urgency flag and event emmission

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1396,10 +1396,10 @@ void CWindow::activate(bool force) {
 
     static auto PFOCUSONACTIVATE = CConfigValue<Hyprlang::INT>("misc:focus_on_activate");
 
+    m_bIsUrgent = true;
+
     g_pEventManager->postEvent(SHyprIPCEvent{"urgent", std::format("{:x}", (uintptr_t)this)});
     EMIT_HOOK_EVENT("urgent", m_pSelf.lock());
-
-    m_bIsUrgent = true;
 
     if (!force && (!m_sWindowData.focusOnActivate.valueOr(*PFOCUSONACTIVATE) || (m_eSuppressedEvents & SUPPRESS_ACTIVATE_FOCUSONLY) || (m_eSuppressedEvents & SUPPRESS_ACTIVATE)))
         return;


### PR DESCRIPTION
When the urgent flag is set, `m_bIsUrgent` was previously updated after emitting the `urgent` event. This meant plugin listeners had to handle an inconsistent state where `m_bIsUrgent` was still false.

This change updates `m_bIsUrgent` before emitting the event, so listeners always observe the correct state.

I was unable to find any other examples where the internal state was modified after event emission. So there is precedent for ordering the update this way.