### PR TITLE
windows: refactor class member vars

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -851,7 +851,7 @@ PHLMONITOR CCompositor::getMonitorFromVector(const Vector2D& point) {
 }
 
 void CCompositor::removeWindowFromVectorSafe(PHLWINDOW pWindow) {
-    if (!pWindow->m_bFadingOut) {
+    if (!pWindow->m_fadingOut) {
         EMIT_HOOK_EVENT("destroyWindow", pWindow);
 
         std::erase_if(m_windows, [&](SP<CWindow>& el) { return el == pWindow; });
@@ -874,14 +874,13 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
     // pinned windows on top of floating regardless
     if (properties & ALLOW_FLOATING) {
         for (auto const& w : m_windows | std::views::reverse) {
-            if (w->m_bIsFloating && w->m_bIsMapped && !w->isHidden() && !w->m_bX11ShouldntFocus && w->m_bPinned && !w->m_sWindowData.noFocus.valueOrDefault() &&
-                w != pIgnoreWindow) {
+            if (w->m_isFloating && w->m_isMapped && !w->isHidden() && !w->m_X11ShouldntFocus && w->m_pinned && !w->m_windowData.noFocus.valueOrDefault() && w != pIgnoreWindow) {
                 const auto BB  = w->getWindowBoxUnified(properties);
                 CBox       box = BB.copy().expand(!w->isX11OverrideRedirect() ? BORDER_GRAB_AREA : 0);
                 if (box.containsPoint(g_pPointerManager->position()))
                     return w;
 
-                if (!w->m_bIsX11) {
+                if (!w->m_isX11) {
                     if (w->hasPopupAt(pos))
                         return w;
                 }
@@ -896,13 +895,13 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
                 if (special && !w->onSpecialWorkspace()) // because special floating may creep up into regular
                     continue;
 
-                if (!w->m_pWorkspace)
+                if (!w->m_workspace)
                     continue;
 
-                const auto PWINDOWMONITOR = w->m_pMonitor.lock();
+                const auto PWINDOWMONITOR = w->m_monitor.lock();
 
                 // to avoid focusing windows behind special workspaces from other monitors
-                if (!*PSPECIALFALLTHRU && PWINDOWMONITOR && PWINDOWMONITOR->activeSpecialWorkspace && w->m_pWorkspace != PWINDOWMONITOR->activeSpecialWorkspace) {
+                if (!*PSPECIALFALLTHRU && PWINDOWMONITOR && PWINDOWMONITOR->activeSpecialWorkspace && w->m_workspace != PWINDOWMONITOR->activeSpecialWorkspace) {
                     const auto BB = w->getWindowBoxUnified(properties);
                     if (BB.x >= PWINDOWMONITOR->vecPosition.x && BB.y >= PWINDOWMONITOR->vecPosition.y &&
                         BB.x + BB.width <= PWINDOWMONITOR->vecPosition.x + PWINDOWMONITOR->vecSize.x &&
@@ -910,17 +909,17 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
                         continue;
                 }
 
-                if (w->m_bIsFloating && w->m_bIsMapped && w->m_pWorkspace->isVisible() && !w->isHidden() && !w->m_bPinned && !w->m_sWindowData.noFocus.valueOrDefault() &&
-                    w != pIgnoreWindow && (!aboveFullscreen || w->m_bCreatedOverFullscreen)) {
+                if (w->m_isFloating && w->m_isMapped && w->m_workspace->isVisible() && !w->isHidden() && !w->m_pinned && !w->m_windowData.noFocus.valueOrDefault() &&
+                    w != pIgnoreWindow && (!aboveFullscreen || w->m_createdOverFullscreen)) {
                     // OR windows should add focus to parent
-                    if (w->m_bX11ShouldntFocus && !w->isX11OverrideRedirect())
+                    if (w->m_X11ShouldntFocus && !w->isX11OverrideRedirect())
                         continue;
 
                     const auto BB  = w->getWindowBoxUnified(properties);
                     CBox       box = BB.copy().expand(!w->isX11OverrideRedirect() ? BORDER_GRAB_AREA : 0);
                     if (box.containsPoint(g_pPointerManager->position())) {
 
-                        if (w->m_bIsX11 && w->isX11OverrideRedirect() && !w->m_pXWaylandSurface->wantsFocus()) {
+                        if (w->m_isX11 && w->isX11OverrideRedirect() && !w->m_xwaylandSurface->wantsFocus()) {
                             // Override Redirect
                             return g_pCompositor->m_lastWindow.lock(); // we kinda trick everything here.
                             // TODO: this is wrong, we should focus the parent, but idk how to get it considering it's nullptr in most cases.
@@ -929,7 +928,7 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
                         return w;
                     }
 
-                    if (!w->m_bIsX11) {
+                    if (!w->m_isX11) {
                         if (w->hasPopupAt(pos))
                             return w;
                     }
@@ -964,11 +963,11 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
             if (special != w->onSpecialWorkspace())
                 continue;
 
-            if (!w->m_pWorkspace)
+            if (!w->m_workspace)
                 continue;
 
-            if (!w->m_bIsX11 && !w->m_bIsFloating && w->m_bIsMapped && w->workspaceID() == WSPID && !w->isHidden() && !w->m_bX11ShouldntFocus &&
-                !w->m_sWindowData.noFocus.valueOrDefault() && w != pIgnoreWindow) {
+            if (!w->m_isX11 && !w->m_isFloating && w->m_isMapped && w->workspaceID() == WSPID && !w->isHidden() && !w->m_X11ShouldntFocus &&
+                !w->m_windowData.noFocus.valueOrDefault() && w != pIgnoreWindow) {
                 if (w->hasPopupAt(pos))
                     return w;
             }
@@ -978,12 +977,12 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
             if (special != w->onSpecialWorkspace())
                 continue;
 
-            if (!w->m_pWorkspace)
+            if (!w->m_workspace)
                 continue;
 
-            if (!w->m_bIsFloating && w->m_bIsMapped && w->workspaceID() == WSPID && !w->isHidden() && !w->m_bX11ShouldntFocus && !w->m_sWindowData.noFocus.valueOrDefault() &&
+            if (!w->m_isFloating && w->m_isMapped && w->workspaceID() == WSPID && !w->isHidden() && !w->m_X11ShouldntFocus && !w->m_windowData.noFocus.valueOrDefault() &&
                 w != pIgnoreWindow) {
-                CBox box = (properties & USE_PROP_TILED) ? w->getWindowBoxUnified(properties) : CBox{w->m_vPosition, w->m_vSize};
+                CBox box = (properties & USE_PROP_TILED) ? w->getWindowBoxUnified(properties) : CBox{w->m_position, w->m_size};
                 if (box.containsPoint(pos))
                     return w;
             }
@@ -1011,18 +1010,18 @@ SP<CWLSurfaceResource> CCompositor::vectorWindowToSurface(const Vector2D& pos, P
     if (!validMapped(pWindow))
         return nullptr;
 
-    RASSERT(!pWindow->m_bIsX11, "Cannot call vectorWindowToSurface on an X11 window!");
+    RASSERT(!pWindow->m_isX11, "Cannot call vectorWindowToSurface on an X11 window!");
 
     // try popups first
-    const auto PPOPUP = pWindow->m_pPopupHead->at(pos);
+    const auto PPOPUP = pWindow->m_popupHead->at(pos);
 
     if (PPOPUP) {
         const auto OFF = PPOPUP->coordsRelativeToParent();
-        sl             = pos - pWindow->m_vRealPosition->goal() - OFF;
+        sl             = pos - pWindow->m_realPosition->goal() - OFF;
         return PPOPUP->m_wlSurface->resource();
     }
 
-    auto [surf, local] = pWindow->m_pWLSurface->resource()->at(pos - pWindow->m_vRealPosition->goal(), true);
+    auto [surf, local] = pWindow->m_wlSurface->resource()->at(pos - pWindow->m_realPosition->goal(), true);
     if (surf) {
         sl = local;
         return surf;
@@ -1035,16 +1034,16 @@ Vector2D CCompositor::vectorToSurfaceLocal(const Vector2D& vec, PHLWINDOW pWindo
     if (!validMapped(pWindow))
         return {};
 
-    if (pWindow->m_bIsX11)
-        return vec - pWindow->m_vRealPosition->goal();
+    if (pWindow->m_isX11)
+        return vec - pWindow->m_realPosition->goal();
 
-    const auto PPOPUP = pWindow->m_pPopupHead->at(vec);
+    const auto PPOPUP = pWindow->m_popupHead->at(vec);
     if (PPOPUP)
         return vec - PPOPUP->coordsGlobal();
 
     std::tuple<SP<CWLSurfaceResource>, Vector2D> iterData = {pSurface, {-1337, -1337}};
 
-    pWindow->m_pWLSurface->resource()->breadthfirst(
+    pWindow->m_wlSurface->resource()->breadthfirst(
         [](SP<CWLSurfaceResource> surf, const Vector2D& offset, void* data) {
             const auto PDATA = (std::tuple<SP<CWLSurfaceResource>, Vector2D>*)data;
             if (surf == std::get<0>(*PDATA))
@@ -1052,12 +1051,12 @@ Vector2D CCompositor::vectorToSurfaceLocal(const Vector2D& vec, PHLWINDOW pWindo
         },
         &iterData);
 
-    CBox geom = pWindow->m_pXDGSurface->current.geometry;
+    CBox geom = pWindow->m_xdgSurface->current.geometry;
 
     if (std::get<1>(iterData) == Vector2D{-1337, -1337})
-        return vec - pWindow->m_vRealPosition->goal();
+        return vec - pWindow->m_realPosition->goal();
 
-    return vec - pWindow->m_vRealPosition->goal() - std::get<1>(iterData) + Vector2D{geom.x, geom.y};
+    return vec - pWindow->m_realPosition->goal() - std::get<1>(iterData) + Vector2D{geom.x, geom.y};
 }
 
 PHLMONITOR CCompositor::getMonitorFromOutput(SP<Aquamarine::IOutput> out) {
@@ -1095,7 +1094,7 @@ void CCompositor::focusWindow(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface
         return;
     }
 
-    if (pWindow && pWindow->m_bIsX11 && pWindow->isX11OverrideRedirect() && !pWindow->m_pXWaylandSurface->wantsFocus())
+    if (pWindow && pWindow->m_isX11 && pWindow->isX11OverrideRedirect() && !pWindow->m_xwaylandSurface->wantsFocus())
         return;
 
     g_pLayoutManager->getCurrentLayout()->bringWindowToTop(pWindow);
@@ -1108,7 +1107,7 @@ void CCompositor::focusWindow(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface
         const auto PLASTWINDOW = m_lastWindow.lock();
         m_lastWindow.reset();
 
-        if (PLASTWINDOW && PLASTWINDOW->m_bIsMapped) {
+        if (PLASTWINDOW && PLASTWINDOW->m_isMapped) {
             updateWindowAnimatedDecorationValues(PLASTWINDOW);
 
             g_pXWaylandManager->activateWindow(PLASTWINDOW, false);
@@ -1129,7 +1128,7 @@ void CCompositor::focusWindow(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface
         return;
     }
 
-    if (pWindow->m_sWindowData.noFocus.valueOrDefault()) {
+    if (pWindow->m_windowData.noFocus.valueOrDefault()) {
         Debug::log(LOG, "Ignoring focus to nofocus window!");
         return;
     }
@@ -1137,13 +1136,13 @@ void CCompositor::focusWindow(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface
     if (m_lastWindow.lock() == pWindow && g_pSeatManager->state.keyboardFocus == pSurface && g_pSeatManager->state.keyboardFocus)
         return;
 
-    if (pWindow->m_bPinned)
-        pWindow->m_pWorkspace = m_lastMonitor->activeWorkspace;
+    if (pWindow->m_pinned)
+        pWindow->m_workspace = m_lastMonitor->activeWorkspace;
 
-    const auto PMONITOR = pWindow->m_pMonitor.lock();
+    const auto PMONITOR = pWindow->m_monitor.lock();
 
-    if (!pWindow->m_pWorkspace || !pWindow->m_pWorkspace->isVisible()) {
-        const auto PWORKSPACE = pWindow->m_pWorkspace;
+    if (!pWindow->m_workspace || !pWindow->m_workspace->isVisible()) {
+        const auto PWORKSPACE = pWindow->m_workspace;
         // This is to fix incorrect feedback on the focus history.
         PWORKSPACE->m_lastFocusedWindow = pWindow;
         if (m_lastMonitor->activeWorkspace)
@@ -1161,22 +1160,22 @@ void CCompositor::focusWindow(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface
 
     /* If special fallthrough is enabled, this behavior will be disabled, as I have no better idea of nicely tracking which
        window focuses are "via keybinds" and which ones aren't. */
-    if (PMONITOR && PMONITOR->activeSpecialWorkspace && PMONITOR->activeSpecialWorkspace != pWindow->m_pWorkspace && !pWindow->m_bPinned && !*PSPECIALFALLTHROUGH)
+    if (PMONITOR && PMONITOR->activeSpecialWorkspace && PMONITOR->activeSpecialWorkspace != pWindow->m_workspace && !pWindow->m_pinned && !*PSPECIALFALLTHROUGH)
         PMONITOR->setSpecialWorkspace(nullptr);
 
     // we need to make the PLASTWINDOW not equal to m_pLastWindow so that RENDERDATA is correct for an unfocused window
-    if (PLASTWINDOW && PLASTWINDOW->m_bIsMapped) {
+    if (PLASTWINDOW && PLASTWINDOW->m_isMapped) {
         PLASTWINDOW->updateDynamicRules();
 
         updateWindowAnimatedDecorationValues(PLASTWINDOW);
 
-        if (!pWindow->m_bIsX11 || !pWindow->isX11OverrideRedirect())
+        if (!pWindow->m_isX11 || !pWindow->isX11OverrideRedirect())
             g_pXWaylandManager->activateWindow(PLASTWINDOW, false);
     }
 
     m_lastWindow = PLASTWINDOW;
 
-    const auto PWINDOWSURFACE = pSurface ? pSurface : pWindow->m_pWLSurface->resource();
+    const auto PWINDOWSURFACE = pSurface ? pSurface : pWindow->m_wlSurface->resource();
 
     focusSurface(PWINDOWSURFACE, pWindow);
 
@@ -1187,11 +1186,11 @@ void CCompositor::focusWindow(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface
 
     updateWindowAnimatedDecorationValues(pWindow);
 
-    if (pWindow->m_bIsUrgent)
-        pWindow->m_bIsUrgent = false;
+    if (pWindow->m_isUrgent)
+        pWindow->m_isUrgent = false;
 
     // Send an event
-    g_pEventManager->postEvent(SHyprIPCEvent{.event = "activewindow", .data = pWindow->m_szClass + "," + pWindow->m_szTitle});
+    g_pEventManager->postEvent(SHyprIPCEvent{.event = "activewindow", .data = pWindow->m_class + "," + pWindow->m_title});
     g_pEventManager->postEvent(SHyprIPCEvent{.event = "activewindowv2", .data = std::format("{:x}", (uintptr_t)pWindow.get())});
 
     EMIT_HOOK_EVENT("activeWindow", pWindow);
@@ -1212,13 +1211,13 @@ void CCompositor::focusWindow(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface
     if (*PFOLLOWMOUSE == 0)
         g_pInputManager->sendMotionEventsToFocused();
 
-    if (pWindow->m_sGroupData.pNextWindow)
+    if (pWindow->m_groupData.pNextWindow)
         pWindow->deactivateGroupMembers();
 }
 
 void CCompositor::focusSurface(SP<CWLSurfaceResource> pSurface, PHLWINDOW pWindowOwner) {
 
-    if (g_pSeatManager->state.keyboardFocus == pSurface || (pWindowOwner && g_pSeatManager->state.keyboardFocus == pWindowOwner->m_pWLSurface->resource()))
+    if (g_pSeatManager->state.keyboardFocus == pSurface || (pWindowOwner && g_pSeatManager->state.keyboardFocus == pWindowOwner->m_wlSurface->resource()))
         return; // Don't focus when already focused on this.
 
     if (g_pSessionLockManager->isSessionLocked() && pSurface && !g_pSessionLockManager->isSurfaceSessionLock(pSurface))
@@ -1351,7 +1350,7 @@ void CCompositor::sanityCheckWorkspaces() {
 
 PHLWINDOW CCompositor::getUrgentWindow() {
     for (auto const& w : m_windows) {
-        if (w->m_bIsMapped && w->m_bIsUrgent)
+        if (w->m_isMapped && w->m_isUrgent)
             return w;
     }
 
@@ -1362,10 +1361,10 @@ bool CCompositor::isWindowActive(PHLWINDOW pWindow) {
     if (m_lastWindow.expired() && !m_lastFocus)
         return false;
 
-    if (!pWindow->m_bIsMapped)
+    if (!pWindow->m_isMapped)
         return false;
 
-    const auto PSURFACE = pWindow->m_pWLSurface->resource();
+    const auto PSURFACE = pWindow->m_wlSurface->resource();
 
     return PSURFACE == m_lastFocus || pWindow == m_lastWindow.lock();
 }
@@ -1375,7 +1374,7 @@ void CCompositor::changeWindowZOrder(PHLWINDOW pWindow, bool top) {
         return;
 
     if (top)
-        pWindow->m_bCreatedOverFullscreen = true;
+        pWindow->m_createdOverFullscreen = true;
 
     if (pWindow == (top ? m_windows.back() : m_windows.front()))
         return;
@@ -1397,11 +1396,11 @@ void CCompositor::changeWindowZOrder(PHLWINDOW pWindow, bool top) {
             }
         }
 
-        if (pw->m_bIsMapped)
-            g_pHyprRenderer->damageMonitor(pw->m_pMonitor.lock());
+        if (pw->m_isMapped)
+            g_pHyprRenderer->damageMonitor(pw->m_monitor.lock());
     };
 
-    if (!pWindow->m_bIsX11)
+    if (!pWindow->m_isX11)
         moveToZ(pWindow, top);
     else {
         // move X11 window stack
@@ -1415,7 +1414,7 @@ void CCompositor::changeWindowZOrder(PHLWINDOW pWindow, bool top) {
                 toMove.insert(toMove.begin(), pw);
 
             for (auto const& w : m_windows) {
-                if (w->m_bIsMapped && !w->isHidden() && w->m_bIsX11 && w->x11TransientFor() == pw && w != pw && std::ranges::find(toMove, w) == toMove.end()) {
+                if (w->m_isMapped && !w->isHidden() && w->m_isX11 && w->x11TransientFor() == pw && w != pw && std::ranges::find(toMove, w) == toMove.end()) {
                     x11Stack(w, top, x11Stack);
                 }
             }
@@ -1433,14 +1432,14 @@ void CCompositor::cleanupFadingOut(const MONITORID& monid) {
 
         auto w = ww.lock();
 
-        if (w->monitorID() != monid && w->m_pMonitor)
+        if (w->monitorID() != monid && w->m_monitor)
             continue;
 
-        if (!w->m_bFadingOut || w->m_fAlpha->value() == 0.f) {
+        if (!w->m_fadingOut || w->m_alpha->value() == 0.f) {
 
-            w->m_bFadingOut = false;
+            w->m_fadingOut = false;
 
-            if (!w->m_bReadyToDelete)
+            if (!w->m_readyToDelete)
                 continue;
 
             removeWindowFromVectorSafe(w);
@@ -1521,15 +1520,15 @@ PHLWINDOW CCompositor::getWindowInDirection(PHLWINDOW pWindow, char dir) {
     if (!isDirection(dir))
         return nullptr;
 
-    const auto PMONITOR = pWindow->m_pMonitor.lock();
+    const auto PMONITOR = pWindow->m_monitor.lock();
 
     if (!PMONITOR)
         return nullptr; // ??
 
     const auto WINDOWIDEALBB = pWindow->isFullscreen() ? CBox{PMONITOR->vecPosition, PMONITOR->vecSize} : pWindow->getWindowIdealBoundingBoxIgnoreReserved();
-    const auto PWORKSPACE    = pWindow->m_pWorkspace;
+    const auto PWORKSPACE    = pWindow->m_workspace;
 
-    return getWindowInDirection(WINDOWIDEALBB, PWORKSPACE, dir, pWindow, pWindow->m_bIsFloating);
+    return getWindowInDirection(WINDOWIDEALBB, PWORKSPACE, dir, pWindow, pWindow->m_isFloating);
 }
 
 PHLWINDOW CCompositor::getWindowInDirection(const CBox& box, PHLWORKSPACE pWorkspace, char dir, PHLWINDOW ignoreWindow, bool useVectorAngles) {
@@ -1548,16 +1547,16 @@ PHLWINDOW CCompositor::getWindowInDirection(const CBox& box, PHLWORKSPACE pWorks
 
     if (!useVectorAngles) {
         for (auto const& w : m_windows) {
-            if (w == ignoreWindow || !w->m_pWorkspace || !w->m_bIsMapped || w->isHidden() || (!w->isFullscreen() && w->m_bIsFloating) || !w->m_pWorkspace->isVisible())
+            if (w == ignoreWindow || !w->m_workspace || !w->m_isMapped || w->isHidden() || (!w->isFullscreen() && w->m_isFloating) || !w->m_workspace->isVisible())
                 continue;
 
-            if (pWorkspace->m_monitor == w->m_pMonitor && pWorkspace != w->m_pWorkspace)
+            if (pWorkspace->m_monitor == w->m_monitor && pWorkspace != w->m_workspace)
                 continue;
 
-            if (pWorkspace->m_hasFullscreenWindow && !w->isFullscreen() && !w->m_bCreatedOverFullscreen)
+            if (pWorkspace->m_hasFullscreenWindow && !w->isFullscreen() && !w->m_createdOverFullscreen)
                 continue;
 
-            if (!*PMONITORFALLBACK && pWorkspace->m_monitor != w->m_pMonitor)
+            if (!*PMONITORFALLBACK && pWorkspace->m_monitor != w->m_monitor)
                 continue;
 
             const auto BWINDOWIDEALBB = w->getWindowIdealBoundingBoxIgnoreReserved();
@@ -1637,16 +1636,16 @@ PHLWINDOW CCompositor::getWindowInDirection(const CBox& box, PHLWORKSPACE pWorks
         constexpr float THRESHOLD    = 0.3 * M_PI;
 
         for (auto const& w : m_windows) {
-            if (w == ignoreWindow || !w->m_bIsMapped || !w->m_pWorkspace || w->isHidden() || (!w->isFullscreen() && !w->m_bIsFloating) || !w->m_pWorkspace->isVisible())
+            if (w == ignoreWindow || !w->m_isMapped || !w->m_workspace || w->isHidden() || (!w->isFullscreen() && !w->m_isFloating) || !w->m_workspace->isVisible())
                 continue;
 
-            if (pWorkspace->m_monitor == w->m_pMonitor && pWorkspace != w->m_pWorkspace)
+            if (pWorkspace->m_monitor == w->m_monitor && pWorkspace != w->m_workspace)
                 continue;
 
-            if (pWorkspace->m_hasFullscreenWindow && !w->isFullscreen() && !w->m_bCreatedOverFullscreen)
+            if (pWorkspace->m_hasFullscreenWindow && !w->isFullscreen() && !w->m_createdOverFullscreen)
                 continue;
 
-            if (!*PMONITORFALLBACK && pWorkspace->m_monitor != w->m_pMonitor)
+            if (!*PMONITORFALLBACK && pWorkspace->m_monitor != w->m_monitor)
                 continue;
 
             const auto DIST  = w->middle().distance(box.middle());
@@ -1674,18 +1673,18 @@ PHLWINDOW CCompositor::getWindowInDirection(const CBox& box, PHLWORKSPACE pWorks
 
 template <typename WINDOWPTR>
 static bool isWorkspaceMatches(WINDOWPTR pWindow, const WINDOWPTR w, bool anyWorkspace) {
-    return anyWorkspace ? w->m_pWorkspace && w->m_pWorkspace->isVisible() : w->m_pWorkspace == pWindow->m_pWorkspace;
+    return anyWorkspace ? w->m_workspace && w->m_workspace->isVisible() : w->m_workspace == pWindow->m_workspace;
 }
 
 template <typename WINDOWPTR>
 static bool isFloatingMatches(WINDOWPTR w, std::optional<bool> floating) {
-    return !floating.has_value() || w->m_bIsFloating == floating.value();
+    return !floating.has_value() || w->m_isFloating == floating.value();
 }
 
 template <typename WINDOWPTR>
 static bool isWindowAvailableForCycle(WINDOWPTR pWindow, WINDOWPTR w, bool focusableOnly, std::optional<bool> floating, bool anyWorkspace = false) {
     return isFloatingMatches(w, floating) &&
-        (w != pWindow && isWorkspaceMatches(pWindow, w, anyWorkspace) && w->m_bIsMapped && !w->isHidden() && (!focusableOnly || !w->m_sWindowData.noFocus.valueOrDefault()));
+        (w != pWindow && isWorkspaceMatches(pWindow, w, anyWorkspace) && w->m_isMapped && !w->isHidden() && (!focusableOnly || !w->m_windowData.noFocus.valueOrDefault()));
 }
 
 template <typename Iterator>
@@ -1834,7 +1833,7 @@ PHLMONITOR CCompositor::getMonitorInDirection(PHLMONITOR pSourceMonitor, const c
 
 void CCompositor::updateAllWindowsAnimatedDecorationValues() {
     for (auto const& w : m_windows) {
-        if (!w->m_bIsMapped)
+        if (!w->m_isMapped)
             continue;
 
         updateWindowAnimatedDecorationValues(w);
@@ -1869,48 +1868,48 @@ void CCompositor::updateWindowAnimatedDecorationValues(PHLWINDOW pWindow) {
     auto* const GROUPINACTIVELOCKEDCOL = (CGradientValueData*)(PGROUPINACTIVELOCKEDCOL.ptr())->getData();
 
     auto        setBorderColor = [&](CGradientValueData grad) -> void {
-        if (grad == pWindow->m_cRealBorderColor)
+        if (grad == pWindow->m_realBorderColor)
             return;
 
-        pWindow->m_cRealBorderColorPrevious = pWindow->m_cRealBorderColor;
-        pWindow->m_cRealBorderColor         = grad;
-        pWindow->m_fBorderFadeAnimationProgress->setValueAndWarp(0.f);
-        *pWindow->m_fBorderFadeAnimationProgress = 1.f;
+        pWindow->m_realBorderColorPrevious = pWindow->m_realBorderColor;
+        pWindow->m_realBorderColor         = grad;
+        pWindow->m_borderFadeAnimationProgress->setValueAndWarp(0.f);
+        *pWindow->m_borderFadeAnimationProgress = 1.f;
     };
 
-    const bool IS_SHADOWED_BY_MODAL = pWindow->m_pXDGSurface && pWindow->m_pXDGSurface->toplevel && pWindow->m_pXDGSurface->toplevel->anyChildModal();
+    const bool IS_SHADOWED_BY_MODAL = pWindow->m_xdgSurface && pWindow->m_xdgSurface->toplevel && pWindow->m_xdgSurface->toplevel->anyChildModal();
 
     // border
     const auto RENDERDATA = g_pLayoutManager->getCurrentLayout()->requestRenderHints(pWindow);
     if (RENDERDATA.isBorderGradient)
         setBorderColor(*RENDERDATA.borderGradient);
     else {
-        const bool GROUPLOCKED = pWindow->m_sGroupData.pNextWindow.lock() ? pWindow->getGroupHead()->m_sGroupData.locked : false;
+        const bool GROUPLOCKED = pWindow->m_groupData.pNextWindow.lock() ? pWindow->getGroupHead()->m_groupData.locked : false;
         if (pWindow == m_lastWindow) {
             const auto* const ACTIVECOLOR =
-                !pWindow->m_sGroupData.pNextWindow.lock() ? (!pWindow->m_sGroupData.deny ? ACTIVECOL : NOGROUPACTIVECOL) : (GROUPLOCKED ? GROUPACTIVELOCKEDCOL : GROUPACTIVECOL);
-            setBorderColor(pWindow->m_sWindowData.activeBorderColor.valueOr(*ACTIVECOLOR));
+                !pWindow->m_groupData.pNextWindow.lock() ? (!pWindow->m_groupData.deny ? ACTIVECOL : NOGROUPACTIVECOL) : (GROUPLOCKED ? GROUPACTIVELOCKEDCOL : GROUPACTIVECOL);
+            setBorderColor(pWindow->m_windowData.activeBorderColor.valueOr(*ACTIVECOLOR));
         } else {
-            const auto* const INACTIVECOLOR = !pWindow->m_sGroupData.pNextWindow.lock() ? (!pWindow->m_sGroupData.deny ? INACTIVECOL : NOGROUPINACTIVECOL) :
-                                                                                          (GROUPLOCKED ? GROUPINACTIVELOCKEDCOL : GROUPINACTIVECOL);
-            setBorderColor(pWindow->m_sWindowData.inactiveBorderColor.valueOr(*INACTIVECOLOR));
+            const auto* const INACTIVECOLOR = !pWindow->m_groupData.pNextWindow.lock() ? (!pWindow->m_groupData.deny ? INACTIVECOL : NOGROUPINACTIVECOL) :
+                                                                                         (GROUPLOCKED ? GROUPINACTIVELOCKEDCOL : GROUPINACTIVECOL);
+            setBorderColor(pWindow->m_windowData.inactiveBorderColor.valueOr(*INACTIVECOLOR));
         }
     }
 
     // opacity
-    const auto PWORKSPACE = pWindow->m_pWorkspace;
+    const auto PWORKSPACE = pWindow->m_workspace;
     if (pWindow->isEffectiveInternalFSMode(FSMODE_FULLSCREEN)) {
-        *pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaFullscreen.valueOrDefault().applyAlpha(*PFULLSCREENALPHA);
+        *pWindow->m_activeInactiveAlpha = pWindow->m_windowData.alphaFullscreen.valueOrDefault().applyAlpha(*PFULLSCREENALPHA);
     } else {
         if (pWindow == m_lastWindow)
-            *pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alpha.valueOrDefault().applyAlpha(*PACTIVEALPHA);
+            *pWindow->m_activeInactiveAlpha = pWindow->m_windowData.alpha.valueOrDefault().applyAlpha(*PACTIVEALPHA);
         else
-            *pWindow->m_fActiveInactiveAlpha = pWindow->m_sWindowData.alphaInactive.valueOrDefault().applyAlpha(*PINACTIVEALPHA);
+            *pWindow->m_activeInactiveAlpha = pWindow->m_windowData.alphaInactive.valueOrDefault().applyAlpha(*PINACTIVEALPHA);
     }
 
     // dim
     float goalDim = 1.F;
-    if (pWindow == m_lastWindow.lock() || pWindow->m_sWindowData.noDim.valueOrDefault() || !*PDIMENABLED)
+    if (pWindow == m_lastWindow.lock() || pWindow->m_windowData.noDim.valueOrDefault() || !*PDIMENABLED)
         goalDim = 0;
     else
         goalDim = *PDIMSTRENGTH;
@@ -1918,16 +1917,16 @@ void CCompositor::updateWindowAnimatedDecorationValues(PHLWINDOW pWindow) {
     if (IS_SHADOWED_BY_MODAL)
         goalDim += (1.F - goalDim) / 2.F;
 
-    *pWindow->m_fDimPercent = goalDim;
+    *pWindow->m_dimPercent = goalDim;
 
     // shadow
-    if (!pWindow->isX11OverrideRedirect() && !pWindow->m_bX11DoesntWantBorders) {
+    if (!pWindow->isX11OverrideRedirect() && !pWindow->m_X11DoesntWantBorders) {
         if (pWindow == m_lastWindow)
-            *pWindow->m_cRealShadowColor = CHyprColor(*PSHADOWCOL);
+            *pWindow->m_realShadowColor = CHyprColor(*PSHADOWCOL);
         else
-            *pWindow->m_cRealShadowColor = CHyprColor(*PSHADOWCOLINACTIVE != INT64_MAX ? *PSHADOWCOLINACTIVE : *PSHADOWCOL);
+            *pWindow->m_realShadowColor = CHyprColor(*PSHADOWCOLINACTIVE != INT64_MAX ? *PSHADOWCOLINACTIVE : *PSHADOWCOL);
     } else {
-        pWindow->m_cRealShadowColor->setValueAndWarp(CHyprColor(0, 0, 0, 0)); // no shadow
+        pWindow->m_realShadowColor->setValueAndWarp(CHyprColor(0, 0, 0, 0)); // no shadow
     }
 
     pWindow->updateWindowDecos();
@@ -1960,21 +1959,21 @@ void CCompositor::swapActiveWorkspaces(PHLMONITOR pMonitorA, PHLMONITOR pMonitor
     PWORKSPACEA->moveToMonitor(pMonitorB->ID);
 
     for (auto const& w : m_windows) {
-        if (w->m_pWorkspace == PWORKSPACEA) {
-            if (w->m_bPinned) {
-                w->m_pWorkspace = PWORKSPACEB;
+        if (w->m_workspace == PWORKSPACEA) {
+            if (w->m_pinned) {
+                w->m_workspace = PWORKSPACEB;
                 continue;
             }
 
-            w->m_pMonitor = pMonitorB;
+            w->m_monitor = pMonitorB;
 
             // additionally, move floating and fs windows manually
-            if (w->m_bIsFloating)
-                *w->m_vRealPosition = w->m_vRealPosition->goal() - pMonitorA->vecPosition + pMonitorB->vecPosition;
+            if (w->m_isFloating)
+                *w->m_realPosition = w->m_realPosition->goal() - pMonitorA->vecPosition + pMonitorB->vecPosition;
 
             if (w->isFullscreen()) {
-                *w->m_vRealPosition = pMonitorB->vecPosition;
-                *w->m_vRealSize     = pMonitorB->vecSize;
+                *w->m_realPosition = pMonitorB->vecPosition;
+                *w->m_realSize     = pMonitorB->vecSize;
             }
 
             w->updateToplevel();
@@ -1985,21 +1984,21 @@ void CCompositor::swapActiveWorkspaces(PHLMONITOR pMonitorA, PHLMONITOR pMonitor
     PWORKSPACEB->moveToMonitor(pMonitorA->ID);
 
     for (auto const& w : m_windows) {
-        if (w->m_pWorkspace == PWORKSPACEB) {
-            if (w->m_bPinned) {
-                w->m_pWorkspace = PWORKSPACEA;
+        if (w->m_workspace == PWORKSPACEB) {
+            if (w->m_pinned) {
+                w->m_workspace = PWORKSPACEA;
                 continue;
             }
 
-            w->m_pMonitor = pMonitorA;
+            w->m_monitor = pMonitorA;
 
             // additionally, move floating and fs windows manually
-            if (w->m_bIsFloating)
-                *w->m_vRealPosition = w->m_vRealPosition->goal() - pMonitorB->vecPosition + pMonitorA->vecPosition;
+            if (w->m_isFloating)
+                *w->m_realPosition = w->m_realPosition->goal() - pMonitorB->vecPosition + pMonitorA->vecPosition;
 
             if (w->isFullscreen()) {
-                *w->m_vRealPosition = pMonitorA->vecPosition;
-                *w->m_vRealSize     = pMonitorA->vecSize;
+                *w->m_realPosition = pMonitorA->vecPosition;
+                *w->m_realSize     = pMonitorA->vecSize;
             }
 
             w->updateToplevel();
@@ -2165,28 +2164,28 @@ void CCompositor::moveWorkspaceToMonitor(PHLWORKSPACE pWorkspace, PHLMONITOR pMo
     pWorkspace->moveToMonitor(pMonitor->ID);
 
     for (auto const& w : m_windows) {
-        if (w->m_pWorkspace == pWorkspace) {
-            if (w->m_bPinned) {
-                w->m_pWorkspace = g_pCompositor->getWorkspaceByID(nextWorkspaceOnMonitorID);
+        if (w->m_workspace == pWorkspace) {
+            if (w->m_pinned) {
+                w->m_workspace = g_pCompositor->getWorkspaceByID(nextWorkspaceOnMonitorID);
                 continue;
             }
 
-            w->m_pMonitor = pMonitor;
+            w->m_monitor = pMonitor;
 
             // additionally, move floating and fs windows manually
-            if (w->m_bIsMapped && !w->isHidden()) {
+            if (w->m_isMapped && !w->isHidden()) {
                 if (POLDMON) {
-                    if (w->m_bIsFloating)
-                        *w->m_vRealPosition = w->m_vRealPosition->goal() - POLDMON->vecPosition + pMonitor->vecPosition;
+                    if (w->m_isFloating)
+                        *w->m_realPosition = w->m_realPosition->goal() - POLDMON->vecPosition + pMonitor->vecPosition;
 
                     if (w->isFullscreen()) {
-                        *w->m_vRealPosition = pMonitor->vecPosition;
-                        *w->m_vRealSize     = pMonitor->vecSize;
+                        *w->m_realPosition = pMonitor->vecPosition;
+                        *w->m_realSize     = pMonitor->vecSize;
                     }
                 } else
-                    *w->m_vRealPosition = Vector2D{
-                        (pMonitor->vecSize.x != 0) ? (int)w->m_vRealPosition->goal().x % (int)pMonitor->vecSize.x : 0,
-                        (pMonitor->vecSize.y != 0) ? (int)w->m_vRealPosition->goal().y % (int)pMonitor->vecSize.y : 0,
+                    *w->m_realPosition = Vector2D{
+                        (pMonitor->vecSize.x != 0) ? (int)w->m_realPosition->goal().x % (int)pMonitor->vecSize.x : 0,
+                        (pMonitor->vecSize.y != 0) ? (int)w->m_realPosition->goal().y % (int)pMonitor->vecSize.y : 0,
                     };
             }
 
@@ -2257,15 +2256,15 @@ void CCompositor::updateFullscreenFadeOnWorkspace(PHLWORKSPACE pWorkspace) {
     const auto FULLSCREEN = pWorkspace->m_hasFullscreenWindow;
 
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->m_pWorkspace == pWorkspace) {
+        if (w->m_workspace == pWorkspace) {
 
-            if (w->m_bFadingOut || w->m_bPinned || w->isFullscreen())
+            if (w->m_fadingOut || w->m_pinned || w->isFullscreen())
                 continue;
 
             if (!FULLSCREEN)
-                *w->m_fAlpha = 1.f;
+                *w->m_alpha = 1.f;
             else if (!w->isFullscreen())
-                *w->m_fAlpha = !w->m_bCreatedOverFullscreen ? 0.f : 1.f;
+                *w->m_alpha = !w->m_createdOverFullscreen ? 0.f : 1.f;
         }
     }
 
@@ -2281,21 +2280,21 @@ void CCompositor::updateFullscreenFadeOnWorkspace(PHLWORKSPACE pWorkspace) {
 
 void CCompositor::changeWindowFullscreenModeClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE, const bool ON) {
     setWindowFullscreenClient(PWINDOW,
-                              (eFullscreenMode)(ON ? (uint8_t)PWINDOW->m_sFullscreenState.client | (uint8_t)MODE : ((uint8_t)PWINDOW->m_sFullscreenState.client & (uint8_t)~MODE)));
+                              (eFullscreenMode)(ON ? (uint8_t)PWINDOW->m_fullscreenState.client | (uint8_t)MODE : ((uint8_t)PWINDOW->m_fullscreenState.client & (uint8_t)~MODE)));
 }
 
 void CCompositor::setWindowFullscreenInternal(const PHLWINDOW PWINDOW, const eFullscreenMode MODE) {
-    if (PWINDOW->m_sWindowData.syncFullscreen.valueOrDefault())
+    if (PWINDOW->m_windowData.syncFullscreen.valueOrDefault())
         setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = MODE, .client = MODE});
     else
-        setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = MODE, .client = PWINDOW->m_sFullscreenState.client});
+        setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = MODE, .client = PWINDOW->m_fullscreenState.client});
 }
 
 void CCompositor::setWindowFullscreenClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE) {
-    if (PWINDOW->m_sWindowData.syncFullscreen.valueOrDefault())
+    if (PWINDOW->m_windowData.syncFullscreen.valueOrDefault())
         setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = MODE, .client = MODE});
     else
-        setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = PWINDOW->m_sFullscreenState.internal, .client = MODE});
+        setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = PWINDOW->m_fullscreenState.internal, .client = MODE});
 }
 
 void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, SFullscreenState state) {
@@ -2308,35 +2307,35 @@ void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, SFullscreenS
     state.internal = std::clamp(state.internal, (eFullscreenMode)0, FSMODE_MAX);
     state.client   = std::clamp(state.client, (eFullscreenMode)0, FSMODE_MAX);
 
-    const auto            PMONITOR   = PWINDOW->m_pMonitor.lock();
-    const auto            PWORKSPACE = PWINDOW->m_pWorkspace;
+    const auto            PMONITOR   = PWINDOW->m_monitor.lock();
+    const auto            PWORKSPACE = PWINDOW->m_workspace;
 
-    const eFullscreenMode CURRENT_EFFECTIVE_MODE = (eFullscreenMode)std::bit_floor((uint8_t)PWINDOW->m_sFullscreenState.internal);
+    const eFullscreenMode CURRENT_EFFECTIVE_MODE = (eFullscreenMode)std::bit_floor((uint8_t)PWINDOW->m_fullscreenState.internal);
     const eFullscreenMode EFFECTIVE_MODE         = (eFullscreenMode)std::bit_floor((uint8_t)state.internal);
 
-    if (PWINDOW->m_bIsFloating && CURRENT_EFFECTIVE_MODE == FSMODE_NONE && EFFECTIVE_MODE != FSMODE_NONE)
+    if (PWINDOW->m_isFloating && CURRENT_EFFECTIVE_MODE == FSMODE_NONE && EFFECTIVE_MODE != FSMODE_NONE)
         g_pHyprRenderer->damageWindow(PWINDOW);
 
-    if (*PALLOWPINFULLSCREEN && !PWINDOW->m_bPinFullscreened && !PWINDOW->isFullscreen() && PWINDOW->m_bPinned) {
-        PWINDOW->m_bPinned          = false;
-        PWINDOW->m_bPinFullscreened = true;
+    if (*PALLOWPINFULLSCREEN && !PWINDOW->m_pinFullscreened && !PWINDOW->isFullscreen() && PWINDOW->m_pinned) {
+        PWINDOW->m_pinned          = false;
+        PWINDOW->m_pinFullscreened = true;
     }
 
     if (PWORKSPACE->m_hasFullscreenWindow && !PWINDOW->isFullscreen())
         setWindowFullscreenInternal(PWORKSPACE->getFullscreenWindow(), FSMODE_NONE);
 
-    const bool CHANGEINTERNAL = !PWINDOW->m_bPinned && CURRENT_EFFECTIVE_MODE != EFFECTIVE_MODE;
+    const bool CHANGEINTERNAL = !PWINDOW->m_pinned && CURRENT_EFFECTIVE_MODE != EFFECTIVE_MODE;
 
-    if (*PALLOWPINFULLSCREEN && PWINDOW->m_bPinFullscreened && PWINDOW->isFullscreen() && !PWINDOW->m_bPinned && state.internal == FSMODE_NONE) {
-        PWINDOW->m_bPinned          = true;
-        PWINDOW->m_bPinFullscreened = false;
+    if (*PALLOWPINFULLSCREEN && PWINDOW->m_pinFullscreened && PWINDOW->isFullscreen() && !PWINDOW->m_pinned && state.internal == FSMODE_NONE) {
+        PWINDOW->m_pinned          = true;
+        PWINDOW->m_pinFullscreened = false;
     }
 
     // TODO: update the state on syncFullscreen changes
-    if (!CHANGEINTERNAL && PWINDOW->m_sWindowData.syncFullscreen.valueOrDefault())
+    if (!CHANGEINTERNAL && PWINDOW->m_windowData.syncFullscreen.valueOrDefault())
         return;
 
-    PWINDOW->m_sFullscreenState.client = state.client;
+    PWINDOW->m_fullscreenState.client = state.client;
     g_pXWaylandManager->setWindowFullscreen(PWINDOW, state.client & FSMODE_FULLSCREEN);
 
     if (!CHANGEINTERNAL) {
@@ -2348,9 +2347,9 @@ void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, SFullscreenS
 
     g_pLayoutManager->getCurrentLayout()->fullscreenRequestForWindow(PWINDOW, CURRENT_EFFECTIVE_MODE, EFFECTIVE_MODE);
 
-    PWINDOW->m_sFullscreenState.internal = state.internal;
-    PWORKSPACE->m_fullscreenMode         = EFFECTIVE_MODE;
-    PWORKSPACE->m_hasFullscreenWindow    = EFFECTIVE_MODE != FSMODE_NONE;
+    PWINDOW->m_fullscreenState.internal = state.internal;
+    PWORKSPACE->m_fullscreenMode        = EFFECTIVE_MODE;
+    PWORKSPACE->m_hasFullscreenWindow   = EFFECTIVE_MODE != FSMODE_NONE;
 
     g_pEventManager->postEvent(SHyprIPCEvent{.event = "fullscreen", .data = std::to_string((int)EFFECTIVE_MODE != FSMODE_NONE)});
     EMIT_HOOK_EVENT("fullscreen", PWINDOW);
@@ -2361,8 +2360,8 @@ void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, SFullscreenS
 
     // make all windows on the same workspace under the fullscreen window
     for (auto const& w : m_windows) {
-        if (w->m_pWorkspace == PWORKSPACE && !w->isFullscreen() && !w->m_bFadingOut && !w->m_bPinned)
-            w->m_bCreatedOverFullscreen = false;
+        if (w->m_workspace == PWORKSPACE && !w->isFullscreen() && !w->m_fadingOut && !w->m_pinned)
+            w->m_createdOverFullscreen = false;
     }
 
     updateFullscreenFadeOnWorkspace(PWORKSPACE);
@@ -2380,20 +2379,20 @@ void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, SFullscreenS
     // send a scanout tranche if we are entering fullscreen, and send a regular one if we aren't.
     // ignore if DS is disabled.
     if (*PDIRECTSCANOUT == 1 || (*PDIRECTSCANOUT == 2 && PWINDOW->getContentType() == CONTENT_TYPE_GAME))
-        g_pHyprRenderer->setSurfaceScanoutMode(PWINDOW->m_pWLSurface->resource(), EFFECTIVE_MODE != FSMODE_NONE ? PMONITOR->self.lock() : nullptr);
+        g_pHyprRenderer->setSurfaceScanoutMode(PWINDOW->m_wlSurface->resource(), EFFECTIVE_MODE != FSMODE_NONE ? PMONITOR->self.lock() : nullptr);
 
     g_pConfigManager->ensureVRR(PMONITOR);
 }
 
 PHLWINDOW CCompositor::getX11Parent(PHLWINDOW pWindow) {
-    if (!pWindow->m_bIsX11)
+    if (!pWindow->m_isX11)
         return nullptr;
 
     for (auto const& w : m_windows) {
-        if (!w->m_bIsX11)
+        if (!w->m_isX11)
             continue;
 
-        if (w->m_pXWaylandSurface == pWindow->m_pXWaylandSurface->parent)
+        if (w->m_xwaylandSurface == pWindow->m_xwaylandSurface->parent)
             return w;
     }
 
@@ -2426,7 +2425,7 @@ PHLWINDOW CCompositor::getWindowByRegex(const std::string& regexp_) {
         const bool FLOAT = regexp.starts_with("floating");
 
         for (auto const& w : m_windows) {
-            if (!w->m_bIsMapped || w->m_bIsFloating != FLOAT || w->m_pWorkspace != m_lastWindow->m_pWorkspace || w->isHidden())
+            if (!w->m_isMapped || w->m_isFloating != FLOAT || w->m_workspace != m_lastWindow->m_workspace || w->isHidden())
                 continue;
 
             return w;
@@ -2462,30 +2461,30 @@ PHLWINDOW CCompositor::getWindowByRegex(const std::string& regexp_) {
     }
 
     for (auto const& w : g_pCompositor->m_windows) {
-        if (!w->m_bIsMapped || (w->isHidden() && !g_pLayoutManager->getCurrentLayout()->isWindowReachable(w)))
+        if (!w->m_isMapped || (w->isHidden() && !g_pLayoutManager->getCurrentLayout()->isWindowReachable(w)))
             continue;
 
         switch (mode) {
             case MODE_CLASS_REGEX: {
-                const auto windowClass = w->m_szClass;
+                const auto windowClass = w->m_class;
                 if (!RE2::FullMatch(windowClass, regexCheck))
                     continue;
                 break;
             }
             case MODE_INITIAL_CLASS_REGEX: {
-                const auto initialWindowClass = w->m_szInitialClass;
+                const auto initialWindowClass = w->m_initialClass;
                 if (!RE2::FullMatch(initialWindowClass, regexCheck))
                     continue;
                 break;
             }
             case MODE_TITLE_REGEX: {
-                const auto windowTitle = w->m_szTitle;
+                const auto windowTitle = w->m_title;
                 if (!RE2::FullMatch(windowTitle, regexCheck))
                     continue;
                 break;
             }
             case MODE_INITIAL_TITLE_REGEX: {
-                const auto initialWindowTitle = w->m_szInitialTitle;
+                const auto initialWindowTitle = w->m_initialTitle;
                 if (!RE2::FullMatch(initialWindowTitle, regexCheck))
                     continue;
                 break;
@@ -2717,40 +2716,40 @@ void CCompositor::moveWindowToWorkspaceSafe(PHLWINDOW pWindow, PHLWORKSPACE pWor
     if (!pWindow || !pWorkspace)
         return;
 
-    if (pWindow->m_bPinned && pWorkspace->m_isSpecialWorkspace)
+    if (pWindow->m_pinned && pWorkspace->m_isSpecialWorkspace)
         return;
 
-    if (pWindow->m_pWorkspace == pWorkspace)
+    if (pWindow->m_workspace == pWorkspace)
         return;
 
     const bool FULLSCREEN     = pWindow->isFullscreen();
-    const auto FULLSCREENMODE = pWindow->m_sFullscreenState.internal;
-    const bool WASVISIBLE     = pWindow->m_pWorkspace && pWindow->m_pWorkspace->isVisible();
+    const auto FULLSCREENMODE = pWindow->m_fullscreenState.internal;
+    const bool WASVISIBLE     = pWindow->m_workspace && pWindow->m_workspace->isVisible();
 
     if (FULLSCREEN)
         setWindowFullscreenInternal(pWindow, FSMODE_NONE);
 
     const PHLWINDOW pFirstWindowOnWorkspace   = pWorkspace->getFirstWindow();
     const int       visibleWindowsOnWorkspace = pWorkspace->getWindows(std::nullopt, true);
-    const auto      POSTOMON                  = pWindow->m_vRealPosition->goal() - (pWindow->m_pMonitor ? pWindow->m_pMonitor->vecPosition : Vector2D{});
+    const auto      POSTOMON                  = pWindow->m_realPosition->goal() - (pWindow->m_monitor ? pWindow->m_monitor->vecPosition : Vector2D{});
     const auto      PWORKSPACEMONITOR         = pWorkspace->m_monitor.lock();
 
-    if (!pWindow->m_bIsFloating)
+    if (!pWindow->m_isFloating)
         g_pLayoutManager->getCurrentLayout()->onWindowRemovedTiling(pWindow);
 
     pWindow->moveToWorkspace(pWorkspace);
-    pWindow->m_pMonitor = pWorkspace->m_monitor;
+    pWindow->m_monitor = pWorkspace->m_monitor;
 
     static auto PGROUPONMOVETOWORKSPACE = CConfigValue<Hyprlang::INT>("group:group_on_movetoworkspace");
     if (*PGROUPONMOVETOWORKSPACE && visibleWindowsOnWorkspace == 1 && pFirstWindowOnWorkspace && pFirstWindowOnWorkspace != pWindow &&
-        pFirstWindowOnWorkspace->m_sGroupData.pNextWindow.lock() && pWindow->canBeGroupedInto(pFirstWindowOnWorkspace)) {
+        pFirstWindowOnWorkspace->m_groupData.pNextWindow.lock() && pWindow->canBeGroupedInto(pFirstWindowOnWorkspace)) {
 
-        pWindow->m_bIsFloating = pFirstWindowOnWorkspace->m_bIsFloating; // match the floating state. Needed to group tiled into floated and vice versa.
-        if (!pWindow->m_sGroupData.pNextWindow.expired()) {
-            PHLWINDOW next = pWindow->m_sGroupData.pNextWindow.lock();
+        pWindow->m_isFloating = pFirstWindowOnWorkspace->m_isFloating; // match the floating state. Needed to group tiled into floated and vice versa.
+        if (!pWindow->m_groupData.pNextWindow.expired()) {
+            PHLWINDOW next = pWindow->m_groupData.pNextWindow.lock();
             while (next != pWindow) {
-                next->m_bIsFloating = pFirstWindowOnWorkspace->m_bIsFloating; // match the floating state of group members
-                next                = next->m_sGroupData.pNextWindow.lock();
+                next->m_isFloating = pFirstWindowOnWorkspace->m_isFloating; // match the floating state of group members
+                next               = next->m_groupData.pNextWindow.lock();
             }
         }
 
@@ -2765,11 +2764,11 @@ void CCompositor::moveWindowToWorkspaceSafe(PHLWINDOW pWindow, PHLWORKSPACE pWor
             pWindow->addWindowDeco(makeUnique<CHyprGroupBarDecoration>(pWindow));
 
     } else {
-        if (!pWindow->m_bIsFloating)
+        if (!pWindow->m_isFloating)
             g_pLayoutManager->getCurrentLayout()->onWindowCreatedTiling(pWindow);
 
-        if (pWindow->m_bIsFloating)
-            *pWindow->m_vRealPosition = POSTOMON + PWORKSPACEMONITOR->vecPosition;
+        if (pWindow->m_isFloating)
+            *pWindow->m_realPosition = POSTOMON + PWORKSPACEMONITOR->vecPosition;
     }
 
     pWindow->updateToplevel();
@@ -2777,11 +2776,11 @@ void CCompositor::moveWindowToWorkspaceSafe(PHLWINDOW pWindow, PHLWORKSPACE pWor
     pWindow->uncacheWindowDecos();
     pWindow->updateGroupOutputs();
 
-    if (!pWindow->m_sGroupData.pNextWindow.expired()) {
-        PHLWINDOW next = pWindow->m_sGroupData.pNextWindow.lock();
+    if (!pWindow->m_groupData.pNextWindow.expired()) {
+        PHLWINDOW next = pWindow->m_groupData.pNextWindow.lock();
         while (next != pWindow) {
             next->updateToplevel();
-            next = next->m_sGroupData.pNextWindow.lock();
+            next = next->m_groupData.pNextWindow.lock();
         }
     }
 
@@ -2789,22 +2788,22 @@ void CCompositor::moveWindowToWorkspaceSafe(PHLWINDOW pWindow, PHLWORKSPACE pWor
         setWindowFullscreenInternal(pWindow, FULLSCREENMODE);
 
     pWorkspace->updateWindows();
-    if (pWindow->m_pWorkspace)
-        pWindow->m_pWorkspace->updateWindows();
+    if (pWindow->m_workspace)
+        pWindow->m_workspace->updateWindows();
     g_pCompositor->updateSuspendedStates();
 
-    if (!WASVISIBLE && pWindow->m_pWorkspace && pWindow->m_pWorkspace->isVisible()) {
-        pWindow->m_fMovingFromWorkspaceAlpha->setValueAndWarp(0.F);
-        *pWindow->m_fMovingFromWorkspaceAlpha = 1.F;
+    if (!WASVISIBLE && pWindow->m_workspace && pWindow->m_workspace->isVisible()) {
+        pWindow->m_movingFromWorkspaceAlpha->setValueAndWarp(0.F);
+        *pWindow->m_movingFromWorkspaceAlpha = 1.F;
     }
 }
 
 PHLWINDOW CCompositor::getForceFocus() {
     for (auto const& w : m_windows) {
-        if (!w->m_bIsMapped || w->isHidden() || !w->m_pWorkspace || !w->m_pWorkspace->isVisible())
+        if (!w->m_isMapped || w->isHidden() || !w->m_workspace || !w->m_workspace->isVisible())
             continue;
 
-        if (!w->m_bStayFocused)
+        if (!w->m_stayFocused)
             continue;
 
         return w;
@@ -2968,10 +2967,10 @@ void CCompositor::setPreferredTransformForSurface(SP<CWLSurfaceResource> pSurfac
 
 void CCompositor::updateSuspendedStates() {
     for (auto const& w : g_pCompositor->m_windows) {
-        if (!w->m_bIsMapped)
+        if (!w->m_isMapped)
             continue;
 
-        w->setSuspended(w->isHidden() || !w->m_pWorkspace || !w->m_pWorkspace->isVisible());
+        w->setSuspended(w->isHidden() || !w->m_workspace || !w->m_workspace->isVisible());
     }
 }
 
@@ -3044,8 +3043,8 @@ void CCompositor::onNewMonitor(SP<Aquamarine::IOutput> output) {
     checkDefaultCursorWarp(PNEWMONITOR);
 
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->m_pMonitor == PNEWMONITOR) {
-            w->m_iLastSurfaceMonitorID = MONITOR_INVALID;
+        if (w->m_monitor == PNEWMONITOR) {
+            w->m_lastSurfaceMonitorID = MONITOR_INVALID;
             w->updateSurfaceScaleTransformDetails();
         }
     }

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -142,7 +142,7 @@ struct SFloatCache {
     size_t hash;
 
     SFloatCache(PHLWINDOW window) {
-        hash = std::hash<std::string>{}(window->m_szClass) ^ (std::hash<std::string>{}(window->m_szTitle) << 1);
+        hash = std::hash<std::string>{}(window->m_class) ^ (std::hash<std::string>{}(window->m_title) << 1);
     }
 
     bool operator==(const SFloatCache& other) const {

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -199,7 +199,7 @@ static std::string getTagsData(PHLWINDOW w, eHyprCtlOutputFormat format) {
 
 static std::string getGroupedData(PHLWINDOW w, eHyprCtlOutputFormat format) {
     const bool isJson = format == eHyprCtlOutputFormat::FORMAT_JSON;
-    if (w->m_sGroupData.pNextWindow.expired())
+    if (w->m_groupData.pNextWindow.expired())
         return isJson ? "" : "0";
 
     std::ostringstream result;
@@ -211,7 +211,7 @@ static std::string getGroupedData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             result << std::format("\"0x{:x}\"", (uintptr_t)curr.get());
         else
             result << std::format("{:x}", (uintptr_t)curr.get());
-        curr = curr->m_sGroupData.pNextWindow.lock();
+        curr = curr->m_groupData.pNextWindow.lock();
         // We've wrapped around to the start, break out without trailing comma
         if (curr == head)
             break;
@@ -262,14 +262,13 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
     "xdgTag": "{}",
     "xdgDescription": "{}"
 }},)#",
-            (uintptr_t)w.get(), (w->m_bIsMapped ? "true" : "false"), (w->isHidden() ? "true" : "false"), (int)w->m_vRealPosition->goal().x, (int)w->m_vRealPosition->goal().y,
-            (int)w->m_vRealSize->goal().x, (int)w->m_vRealSize->goal().y, w->m_pWorkspace ? w->workspaceID() : WORKSPACE_INVALID,
-            escapeJSONStrings(!w->m_pWorkspace ? "" : w->m_pWorkspace->m_name), ((int)w->m_bIsFloating == 1 ? "true" : "false"), (w->m_bIsPseudotiled ? "true" : "false"),
-            (int64_t)w->monitorID(), escapeJSONStrings(w->m_szClass), escapeJSONStrings(w->m_szTitle), escapeJSONStrings(w->m_szInitialClass),
-            escapeJSONStrings(w->m_szInitialTitle), w->getPID(), ((int)w->m_bIsX11 == 1 ? "true" : "false"), (w->m_bPinned ? "true" : "false"),
-            (uint8_t)w->m_sFullscreenState.internal, (uint8_t)w->m_sFullscreenState.client, getGroupedData(w, format), getTagsData(w, format), (uintptr_t)w->m_pSwallowed.get(),
-            getFocusHistoryID(w), (g_pInputManager->isWindowInhibiting(w, false) ? "true" : "false"), escapeJSONStrings(w->xdgTag().value_or("")),
-            escapeJSONStrings(w->xdgDescription().value_or("")));
+            (uintptr_t)w.get(), (w->m_isMapped ? "true" : "false"), (w->isHidden() ? "true" : "false"), (int)w->m_realPosition->goal().x, (int)w->m_realPosition->goal().y,
+            (int)w->m_realSize->goal().x, (int)w->m_realSize->goal().y, w->m_workspace ? w->workspaceID() : WORKSPACE_INVALID,
+            escapeJSONStrings(!w->m_workspace ? "" : w->m_workspace->m_name), ((int)w->m_isFloating == 1 ? "true" : "false"), (w->m_isPseudotiled ? "true" : "false"),
+            (int64_t)w->monitorID(), escapeJSONStrings(w->m_class), escapeJSONStrings(w->m_title), escapeJSONStrings(w->m_initialClass), escapeJSONStrings(w->m_initialTitle),
+            w->getPID(), ((int)w->m_isX11 == 1 ? "true" : "false"), (w->m_pinned ? "true" : "false"), (uint8_t)w->m_fullscreenState.internal, (uint8_t)w->m_fullscreenState.client,
+            getGroupedData(w, format), getTagsData(w, format), (uintptr_t)w->m_swallowed.get(), getFocusHistoryID(w),
+            (g_pInputManager->isWindowInhibiting(w, false) ? "true" : "false"), escapeJSONStrings(w->xdgTag().value_or("")), escapeJSONStrings(w->xdgDescription().value_or("")));
     } else {
         return std::format(
             "Window {:x} -> {}:\n\tmapped: {}\n\thidden: {}\n\tat: {},{}\n\tsize: {},{}\n\tworkspace: {} ({})\n\tfloating: {}\n\tpseudo: {}\n\tmonitor: {}\n\tclass: {}\n\ttitle: "
@@ -277,11 +276,11 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             "{}\n\txwayland: {}\n\tpinned: "
             "{}\n\tfullscreen: {}\n\tfullscreenClient: {}\n\tgrouped: {}\n\ttags: {}\n\tswallowing: {:x}\n\tfocusHistoryID: {}\n\tinhibitingIdle: {}\n\txdgTag: "
             "{}\n\txdgDescription: {}\n\n",
-            (uintptr_t)w.get(), w->m_szTitle, (int)w->m_bIsMapped, (int)w->isHidden(), (int)w->m_vRealPosition->goal().x, (int)w->m_vRealPosition->goal().y,
-            (int)w->m_vRealSize->goal().x, (int)w->m_vRealSize->goal().y, w->m_pWorkspace ? w->workspaceID() : WORKSPACE_INVALID, (!w->m_pWorkspace ? "" : w->m_pWorkspace->m_name),
-            (int)w->m_bIsFloating, (int)w->m_bIsPseudotiled, (int64_t)w->monitorID(), w->m_szClass, w->m_szTitle, w->m_szInitialClass, w->m_szInitialTitle, w->getPID(),
-            (int)w->m_bIsX11, (int)w->m_bPinned, (uint8_t)w->m_sFullscreenState.internal, (uint8_t)w->m_sFullscreenState.client, getGroupedData(w, format), getTagsData(w, format),
-            (uintptr_t)w->m_pSwallowed.get(), getFocusHistoryID(w), (int)g_pInputManager->isWindowInhibiting(w, false), w->xdgTag().value_or(""), w->xdgDescription().value_or(""));
+            (uintptr_t)w.get(), w->m_title, (int)w->m_isMapped, (int)w->isHidden(), (int)w->m_realPosition->goal().x, (int)w->m_realPosition->goal().y,
+            (int)w->m_realSize->goal().x, (int)w->m_realSize->goal().y, w->m_workspace ? w->workspaceID() : WORKSPACE_INVALID, (!w->m_workspace ? "" : w->m_workspace->m_name),
+            (int)w->m_isFloating, (int)w->m_isPseudotiled, (int64_t)w->monitorID(), w->m_class, w->m_title, w->m_initialClass, w->m_initialTitle, w->getPID(), (int)w->m_isX11,
+            (int)w->m_pinned, (uint8_t)w->m_fullscreenState.internal, (uint8_t)w->m_fullscreenState.client, getGroupedData(w, format), getTagsData(w, format),
+            (uintptr_t)w->m_swallowed.get(), getFocusHistoryID(w), (int)g_pInputManager->isWindowInhibiting(w, false), w->xdgTag().value_or(""), w->xdgDescription().value_or(""));
     }
 }
 
@@ -291,7 +290,7 @@ static std::string clientsRequest(eHyprCtlOutputFormat format, std::string reque
         result += "[";
 
         for (auto const& w : g_pCompositor->m_windows) {
-            if (!w->m_bIsMapped && !g_pHyprCtl->m_currentRequestParams.all)
+            if (!w->m_isMapped && !g_pHyprCtl->m_currentRequestParams.all)
                 continue;
 
             result += CHyprCtl::getWindowData(w, format);
@@ -302,7 +301,7 @@ static std::string clientsRequest(eHyprCtlOutputFormat format, std::string reque
         result += "]";
     } else {
         for (auto const& w : g_pCompositor->m_windows) {
-            if (!w->m_bIsMapped && !g_pHyprCtl->m_currentRequestParams.all)
+            if (!w->m_isMapped && !g_pHyprCtl->m_currentRequestParams.all)
                 continue;
 
             result += CHyprCtl::getWindowData(w, format);
@@ -328,12 +327,12 @@ std::string CHyprCtl::getWorkspaceData(PHLWORKSPACE w, eHyprCtlOutputFormat form
 }})#",
                            w->m_id, escapeJSONStrings(w->m_name), escapeJSONStrings(PMONITOR ? PMONITOR->szName : "?"),
                            escapeJSONStrings(PMONITOR ? std::to_string(PMONITOR->ID) : "null"), w->getWindows(), w->m_hasFullscreenWindow ? "true" : "false",
-                           (uintptr_t)PLASTW.get(), PLASTW ? escapeJSONStrings(PLASTW->m_szTitle) : "", w->m_persistent ? "true" : "false");
+                           (uintptr_t)PLASTW.get(), PLASTW ? escapeJSONStrings(PLASTW->m_title) : "", w->m_persistent ? "true" : "false");
     } else {
         return std::format(
             "workspace ID {} ({}) on monitor {}:\n\tmonitorID: {}\n\twindows: {}\n\thasfullscreen: {}\n\tlastwindow: 0x{:x}\n\tlastwindowtitle: {}\n\tispersistent: {}\n\n",
             w->m_id, w->m_name, PMONITOR ? PMONITOR->szName : "?", PMONITOR ? std::to_string(PMONITOR->ID) : "null", w->getWindows(), (int)w->m_hasFullscreenWindow,
-            (uintptr_t)PLASTW.get(), PLASTW ? PLASTW->m_szTitle : "", (int)w->m_persistent);
+            (uintptr_t)PLASTW.get(), PLASTW ? PLASTW->m_title : "", (int)w->m_persistent);
     }
 }
 
@@ -1397,7 +1396,7 @@ static std::string decorationRequest(eHyprCtlOutputFormat format, std::string re
     std::string result = "";
     if (format == eHyprCtlOutputFormat::FORMAT_JSON) {
         result += "[";
-        for (auto const& wd : PWINDOW->m_dWindowDecorations) {
+        for (auto const& wd : PWINDOW->m_windowDecorations) {
             result += "{\n\"decorationName\": \"" + wd->getDisplayName() + "\",\n\"priority\": " + std::to_string(wd->getPositioningInfo().priority) + "\n},";
         }
 
@@ -1405,7 +1404,7 @@ static std::string decorationRequest(eHyprCtlOutputFormat format, std::string re
         result += "]";
     } else {
         result = +"Decoration\tPriority\n";
-        for (auto const& wd : PWINDOW->m_dWindowDecorations) {
+        for (auto const& wd : PWINDOW->m_windowDecorations) {
             result += wd->getDisplayName() + "\t" + std::to_string(wd->getPositioningInfo().priority) + "\n";
         }
     }
@@ -1794,7 +1793,7 @@ std::string CHyprCtl::getReply(std::string request) {
         }
 
         for (auto const& w : g_pCompositor->m_windows) {
-            if (!w->m_bIsMapped || !w->m_pWorkspace || !w->m_pWorkspace->isVisible())
+            if (!w->m_isMapped || !w->m_workspace || !w->m_workspace->isVisible())
                 continue;
 
             w->updateDynamicRules();

--- a/src/desktop/Popup.cpp
+++ b/src/desktop/Popup.cpp
@@ -54,8 +54,7 @@ void CPopup::initAllSignals() {
 
     if (!m_resource) {
         if (!m_windowOwner.expired())
-            m_listeners.newPopup =
-                m_windowOwner->m_pXDGSurface->events.newPopup.registerListener([this](std::any d) { this->onNewPopup(std::any_cast<SP<CXDGPopupResource>>(d)); });
+            m_listeners.newPopup = m_windowOwner->m_xdgSurface->events.newPopup.registerListener([this](std::any d) { this->onNewPopup(std::any_cast<SP<CXDGPopupResource>>(d)); });
         else if (!m_layerOwner.expired())
             m_listeners.newPopup =
                 m_layerOwner->m_layerSurface->events.newPopup.registerListener([this](std::any d) { this->onNewPopup(std::any_cast<SP<CXDGPopupResource>>(d)); });
@@ -172,7 +171,7 @@ void CPopup::onCommit(bool ignoreSiblings) {
         return;
     }
 
-    if (!m_windowOwner.expired() && (!m_windowOwner->m_bIsMapped || !m_windowOwner->m_pWorkspace->m_visible)) {
+    if (!m_windowOwner.expired() && (!m_windowOwner->m_isMapped || !m_windowOwner->m_workspace->m_visible)) {
         m_lastSize = m_resource->surface->surface->current.size;
 
         static auto PLOGDAMAGE = CConfigValue<Hyprlang::INT>("debug:log_damage");
@@ -231,7 +230,7 @@ void CPopup::reposition() {
 
 SP<CWLSurface> CPopup::getT1Owner() {
     if (m_windowOwner)
-        return m_windowOwner->m_pWLSurface;
+        return m_windowOwner->m_wlSurface;
     else
         return m_layerOwner->m_surface;
 }
@@ -266,7 +265,7 @@ Vector2D CPopup::localToGlobal(const Vector2D& rel) {
 
 Vector2D CPopup::t1ParentCoords() {
     if (!m_windowOwner.expired())
-        return m_windowOwner->m_vRealPosition->value();
+        return m_windowOwner->m_realPosition->value();
     if (!m_layerOwner.expired())
         return m_layerOwner->m_realPosition->value();
 
@@ -301,7 +300,7 @@ Vector2D CPopup::size() {
 
 void CPopup::sendScale() {
     if (!m_windowOwner.expired())
-        g_pCompositor->setPreferredScaleForSurface(m_wlSurface->resource(), m_windowOwner->m_pWLSurface->m_lastScaleFloat);
+        g_pCompositor->setPreferredScaleForSurface(m_wlSurface->resource(), m_windowOwner->m_wlSurface->m_lastScaleFloat);
     else if (!m_layerOwner.expired())
         g_pCompositor->setPreferredScaleForSurface(m_wlSurface->resource(), m_layerOwner->m_surface->m_lastScaleFloat);
     else

--- a/src/desktop/Subsurface.cpp
+++ b/src/desktop/Subsurface.cpp
@@ -13,7 +13,7 @@ UP<CSubsurface> CSubsurface::create(PHLWINDOW pOwner) {
     subsurface->m_self         = subsurface;
 
     subsurface->initSignals();
-    subsurface->initExistingSubsurfaces(pOwner->m_pWLSurface->resource());
+    subsurface->initExistingSubsurfaces(pOwner->m_wlSurface->resource());
     return subsurface;
 }
 
@@ -60,7 +60,7 @@ void CSubsurface::initSignals() {
             m_subsurface->surface->events.newSubsurface.registerListener([this](std::any d) { onNewSubsurface(std::any_cast<SP<CWLSubsurfaceResource>>(d)); });
     } else {
         if (m_windowParent)
-            m_listeners.newSubsurface = m_windowParent->m_pWLSurface->resource()->events.newSubsurface.registerListener(
+            m_listeners.newSubsurface = m_windowParent->m_wlSurface->resource()->events.newSubsurface.registerListener(
                 [this](std::any d) { onNewSubsurface(std::any_cast<SP<CWLSubsurfaceResource>>(d)); });
         else if (m_popupParent)
             m_listeners.newSubsurface =
@@ -74,7 +74,7 @@ void CSubsurface::checkSiblingDamage() {
     if (!m_parent)
         return; // ??????????
 
-    const double SCALE = m_windowParent.lock() && m_windowParent->m_bIsX11 ? 1.0 / m_windowParent->m_fX11SurfaceScaledBy : 1.0;
+    const double SCALE = m_windowParent.lock() && m_windowParent->m_isX11 ? 1.0 / m_windowParent->m_X11SurfaceScaledBy : 1.0;
 
     for (auto const& n : m_parent->m_children) {
         if (n.get() == this)
@@ -94,7 +94,7 @@ void CSubsurface::recheckDamageForSubsurfaces() {
 
 void CSubsurface::onCommit() {
     // no damaging if it's not visible
-    if (!m_windowParent.expired() && (!m_windowParent->m_bIsMapped || !m_windowParent->m_pWorkspace->m_visible)) {
+    if (!m_windowParent.expired() && (!m_windowParent->m_isMapped || !m_windowParent->m_workspace->m_visible)) {
         m_lastSize = m_wlSurface->resource()->current.size;
 
         static auto PLOGDAMAGE = CConfigValue<Hyprlang::INT>("debug:log_damage");
@@ -110,7 +110,7 @@ void CSubsurface::onCommit() {
     if (m_popupParent && !m_popupParent->inert() && m_popupParent->m_wlSurface)
         m_popupParent->recheckTree();
     if (!m_windowParent.expired()) // I hate you firefox why are you doing this
-        m_windowParent->m_pPopupHead->recheckTree();
+        m_windowParent->m_popupHead->recheckTree();
 
     // I do not think this is correct, but it solves a lot of issues with some apps (e.g. firefox)
     checkSiblingDamage();
@@ -191,7 +191,7 @@ Vector2D CSubsurface::coordsGlobal() {
     Vector2D coords = coordsRelativeToParent();
 
     if (!m_windowParent.expired())
-        coords += m_windowParent->m_vRealPosition->value();
+        coords += m_windowParent->m_realPosition->value();
     else if (m_popupParent)
         coords += m_popupParent->coordsGlobal();
 

--- a/src/desktop/WLSurface.cpp
+++ b/src/desktop/WLSurface.cpp
@@ -64,7 +64,7 @@ bool CWLSurface::small() const {
 
     const auto O = m_windowOwner.lock();
 
-    return O->m_vReportedSize.x > m_resource->current.size.x + 1 || O->m_vReportedSize.y > m_resource->current.size.y + 1;
+    return O->m_reportedSize.x > m_resource->current.size.x + 1 || O->m_reportedSize.y > m_resource->current.size.y + 1;
 }
 
 Vector2D CWLSurface::correctSmallVec() const {
@@ -74,7 +74,7 @@ Vector2D CWLSurface::correctSmallVec() const {
     const auto SIZE = getViewporterCorrectedSize();
     const auto O    = m_windowOwner.lock();
 
-    return Vector2D{(O->m_vReportedSize.x - SIZE.x) / 2, (O->m_vReportedSize.y - SIZE.y) / 2}.clamp({}, {INFINITY, INFINITY}) * (O->m_vRealSize->value() / O->m_vReportedSize);
+    return Vector2D{(O->m_reportedSize.x - SIZE.x) / 2, (O->m_reportedSize.y - SIZE.y) / 2}.clamp({}, {INFINITY, INFINITY}) * (O->m_realSize->value() / O->m_reportedSize);
 }
 
 Vector2D CWLSurface::correctSmallVecBuf() const {
@@ -121,7 +121,7 @@ CRegion CWLSurface::computeDamage() const {
     damage.scale(SCALE);
 
     if (m_windowOwner)
-        damage.scale(m_windowOwner->m_fX11SurfaceScaledBy); // fix xwayland:force_zero_scaling stuff that will be fucked by the above a bit
+        damage.scale(m_windowOwner->m_X11SurfaceScaledBy); // fix xwayland:force_zero_scaling stuff that will be fucked by the above a bit
 
     return damage;
 }

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -38,19 +38,19 @@ using enum NContentType::eContentType;
 PHLWINDOW CWindow::create(SP<CXWaylandSurface> surface) {
     PHLWINDOW pWindow = SP<CWindow>(new CWindow(surface));
 
-    pWindow->m_pSelf  = pWindow;
-    pWindow->m_bIsX11 = true;
+    pWindow->m_self  = pWindow;
+    pWindow->m_isX11 = true;
 
-    g_pAnimationManager->createAnimation(Vector2D(0, 0), pWindow->m_vRealPosition, g_pConfigManager->getAnimationPropertyConfig("windowsIn"), pWindow, AVARDAMAGE_ENTIRE);
-    g_pAnimationManager->createAnimation(Vector2D(0, 0), pWindow->m_vRealSize, g_pConfigManager->getAnimationPropertyConfig("windowsIn"), pWindow, AVARDAMAGE_ENTIRE);
-    g_pAnimationManager->createAnimation(0.f, pWindow->m_fBorderFadeAnimationProgress, g_pConfigManager->getAnimationPropertyConfig("border"), pWindow, AVARDAMAGE_BORDER);
-    g_pAnimationManager->createAnimation(0.f, pWindow->m_fBorderAngleAnimationProgress, g_pConfigManager->getAnimationPropertyConfig("borderangle"), pWindow, AVARDAMAGE_BORDER);
-    g_pAnimationManager->createAnimation(1.f, pWindow->m_fAlpha, g_pConfigManager->getAnimationPropertyConfig("fadeIn"), pWindow, AVARDAMAGE_ENTIRE);
-    g_pAnimationManager->createAnimation(1.f, pWindow->m_fActiveInactiveAlpha, g_pConfigManager->getAnimationPropertyConfig("fadeSwitch"), pWindow, AVARDAMAGE_ENTIRE);
-    g_pAnimationManager->createAnimation(CHyprColor(), pWindow->m_cRealShadowColor, g_pConfigManager->getAnimationPropertyConfig("fadeShadow"), pWindow, AVARDAMAGE_SHADOW);
-    g_pAnimationManager->createAnimation(0.f, pWindow->m_fDimPercent, g_pConfigManager->getAnimationPropertyConfig("fadeDim"), pWindow, AVARDAMAGE_ENTIRE);
-    g_pAnimationManager->createAnimation(0.f, pWindow->m_fMovingToWorkspaceAlpha, g_pConfigManager->getAnimationPropertyConfig("fadeOut"), pWindow, AVARDAMAGE_ENTIRE);
-    g_pAnimationManager->createAnimation(0.f, pWindow->m_fMovingFromWorkspaceAlpha, g_pConfigManager->getAnimationPropertyConfig("fadeIn"), pWindow, AVARDAMAGE_ENTIRE);
+    g_pAnimationManager->createAnimation(Vector2D(0, 0), pWindow->m_realPosition, g_pConfigManager->getAnimationPropertyConfig("windowsIn"), pWindow, AVARDAMAGE_ENTIRE);
+    g_pAnimationManager->createAnimation(Vector2D(0, 0), pWindow->m_realSize, g_pConfigManager->getAnimationPropertyConfig("windowsIn"), pWindow, AVARDAMAGE_ENTIRE);
+    g_pAnimationManager->createAnimation(0.f, pWindow->m_borderFadeAnimationProgress, g_pConfigManager->getAnimationPropertyConfig("border"), pWindow, AVARDAMAGE_BORDER);
+    g_pAnimationManager->createAnimation(0.f, pWindow->m_borderAngleAnimationProgress, g_pConfigManager->getAnimationPropertyConfig("borderangle"), pWindow, AVARDAMAGE_BORDER);
+    g_pAnimationManager->createAnimation(1.f, pWindow->m_alpha, g_pConfigManager->getAnimationPropertyConfig("fadeIn"), pWindow, AVARDAMAGE_ENTIRE);
+    g_pAnimationManager->createAnimation(1.f, pWindow->m_activeInactiveAlpha, g_pConfigManager->getAnimationPropertyConfig("fadeSwitch"), pWindow, AVARDAMAGE_ENTIRE);
+    g_pAnimationManager->createAnimation(CHyprColor(), pWindow->m_realShadowColor, g_pConfigManager->getAnimationPropertyConfig("fadeShadow"), pWindow, AVARDAMAGE_SHADOW);
+    g_pAnimationManager->createAnimation(0.f, pWindow->m_dimPercent, g_pConfigManager->getAnimationPropertyConfig("fadeDim"), pWindow, AVARDAMAGE_ENTIRE);
+    g_pAnimationManager->createAnimation(0.f, pWindow->m_movingToWorkspaceAlpha, g_pConfigManager->getAnimationPropertyConfig("fadeOut"), pWindow, AVARDAMAGE_ENTIRE);
+    g_pAnimationManager->createAnimation(0.f, pWindow->m_movingFromWorkspaceAlpha, g_pConfigManager->getAnimationPropertyConfig("fadeIn"), pWindow, AVARDAMAGE_ENTIRE);
     g_pAnimationManager->createAnimation(0.f, pWindow->m_notRespondingTint, g_pConfigManager->getAnimationPropertyConfig("fade"), pWindow, AVARDAMAGE_ENTIRE);
 
     pWindow->addWindowDeco(makeUnique<CHyprDropShadowDecoration>(pWindow));
@@ -62,65 +62,65 @@ PHLWINDOW CWindow::create(SP<CXWaylandSurface> surface) {
 PHLWINDOW CWindow::create(SP<CXDGSurfaceResource> resource) {
     PHLWINDOW pWindow = SP<CWindow>(new CWindow(resource));
 
-    pWindow->m_pSelf           = pWindow;
+    pWindow->m_self            = pWindow;
     resource->toplevel->window = pWindow;
 
-    g_pAnimationManager->createAnimation(Vector2D(0, 0), pWindow->m_vRealPosition, g_pConfigManager->getAnimationPropertyConfig("windowsIn"), pWindow, AVARDAMAGE_ENTIRE);
-    g_pAnimationManager->createAnimation(Vector2D(0, 0), pWindow->m_vRealSize, g_pConfigManager->getAnimationPropertyConfig("windowsIn"), pWindow, AVARDAMAGE_ENTIRE);
-    g_pAnimationManager->createAnimation(0.f, pWindow->m_fBorderFadeAnimationProgress, g_pConfigManager->getAnimationPropertyConfig("border"), pWindow, AVARDAMAGE_BORDER);
-    g_pAnimationManager->createAnimation(0.f, pWindow->m_fBorderAngleAnimationProgress, g_pConfigManager->getAnimationPropertyConfig("borderangle"), pWindow, AVARDAMAGE_BORDER);
-    g_pAnimationManager->createAnimation(1.f, pWindow->m_fAlpha, g_pConfigManager->getAnimationPropertyConfig("fadeIn"), pWindow, AVARDAMAGE_ENTIRE);
-    g_pAnimationManager->createAnimation(1.f, pWindow->m_fActiveInactiveAlpha, g_pConfigManager->getAnimationPropertyConfig("fadeSwitch"), pWindow, AVARDAMAGE_ENTIRE);
-    g_pAnimationManager->createAnimation(CHyprColor(), pWindow->m_cRealShadowColor, g_pConfigManager->getAnimationPropertyConfig("fadeShadow"), pWindow, AVARDAMAGE_SHADOW);
-    g_pAnimationManager->createAnimation(0.f, pWindow->m_fDimPercent, g_pConfigManager->getAnimationPropertyConfig("fadeDim"), pWindow, AVARDAMAGE_ENTIRE);
-    g_pAnimationManager->createAnimation(0.f, pWindow->m_fMovingToWorkspaceAlpha, g_pConfigManager->getAnimationPropertyConfig("fadeOut"), pWindow, AVARDAMAGE_ENTIRE);
-    g_pAnimationManager->createAnimation(0.f, pWindow->m_fMovingFromWorkspaceAlpha, g_pConfigManager->getAnimationPropertyConfig("fadeIn"), pWindow, AVARDAMAGE_ENTIRE);
+    g_pAnimationManager->createAnimation(Vector2D(0, 0), pWindow->m_realPosition, g_pConfigManager->getAnimationPropertyConfig("windowsIn"), pWindow, AVARDAMAGE_ENTIRE);
+    g_pAnimationManager->createAnimation(Vector2D(0, 0), pWindow->m_realSize, g_pConfigManager->getAnimationPropertyConfig("windowsIn"), pWindow, AVARDAMAGE_ENTIRE);
+    g_pAnimationManager->createAnimation(0.f, pWindow->m_borderFadeAnimationProgress, g_pConfigManager->getAnimationPropertyConfig("border"), pWindow, AVARDAMAGE_BORDER);
+    g_pAnimationManager->createAnimation(0.f, pWindow->m_borderAngleAnimationProgress, g_pConfigManager->getAnimationPropertyConfig("borderangle"), pWindow, AVARDAMAGE_BORDER);
+    g_pAnimationManager->createAnimation(1.f, pWindow->m_alpha, g_pConfigManager->getAnimationPropertyConfig("fadeIn"), pWindow, AVARDAMAGE_ENTIRE);
+    g_pAnimationManager->createAnimation(1.f, pWindow->m_activeInactiveAlpha, g_pConfigManager->getAnimationPropertyConfig("fadeSwitch"), pWindow, AVARDAMAGE_ENTIRE);
+    g_pAnimationManager->createAnimation(CHyprColor(), pWindow->m_realShadowColor, g_pConfigManager->getAnimationPropertyConfig("fadeShadow"), pWindow, AVARDAMAGE_SHADOW);
+    g_pAnimationManager->createAnimation(0.f, pWindow->m_dimPercent, g_pConfigManager->getAnimationPropertyConfig("fadeDim"), pWindow, AVARDAMAGE_ENTIRE);
+    g_pAnimationManager->createAnimation(0.f, pWindow->m_movingToWorkspaceAlpha, g_pConfigManager->getAnimationPropertyConfig("fadeOut"), pWindow, AVARDAMAGE_ENTIRE);
+    g_pAnimationManager->createAnimation(0.f, pWindow->m_movingFromWorkspaceAlpha, g_pConfigManager->getAnimationPropertyConfig("fadeIn"), pWindow, AVARDAMAGE_ENTIRE);
     g_pAnimationManager->createAnimation(0.f, pWindow->m_notRespondingTint, g_pConfigManager->getAnimationPropertyConfig("fade"), pWindow, AVARDAMAGE_ENTIRE);
 
     pWindow->addWindowDeco(makeUnique<CHyprDropShadowDecoration>(pWindow));
     pWindow->addWindowDeco(makeUnique<CHyprBorderDecoration>(pWindow));
 
-    pWindow->m_pWLSurface->assign(pWindow->m_pXDGSurface->surface.lock(), pWindow);
+    pWindow->m_wlSurface->assign(pWindow->m_xdgSurface->surface.lock(), pWindow);
 
     return pWindow;
 }
 
-CWindow::CWindow(SP<CXDGSurfaceResource> resource) : m_pXDGSurface(resource) {
-    m_pWLSurface = CWLSurface::create();
+CWindow::CWindow(SP<CXDGSurfaceResource> resource) : m_xdgSurface(resource) {
+    m_wlSurface = CWLSurface::create();
 
-    listeners.map            = m_pXDGSurface->events.map.registerListener([this](std::any d) { Events::listener_mapWindow(this, nullptr); });
-    listeners.ack            = m_pXDGSurface->events.ack.registerListener([this](std::any d) { onAck(std::any_cast<uint32_t>(d)); });
-    listeners.unmap          = m_pXDGSurface->events.unmap.registerListener([this](std::any d) { Events::listener_unmapWindow(this, nullptr); });
-    listeners.destroy        = m_pXDGSurface->events.destroy.registerListener([this](std::any d) { Events::listener_destroyWindow(this, nullptr); });
-    listeners.commit         = m_pXDGSurface->events.commit.registerListener([this](std::any d) { Events::listener_commitWindow(this, nullptr); });
-    listeners.updateState    = m_pXDGSurface->toplevel->events.stateChanged.registerListener([this](std::any d) { onUpdateState(); });
-    listeners.updateMetadata = m_pXDGSurface->toplevel->events.metadataChanged.registerListener([this](std::any d) { onUpdateMeta(); });
+    m_listeners.map            = m_xdgSurface->events.map.registerListener([this](std::any d) { Events::listener_mapWindow(this, nullptr); });
+    m_listeners.ack            = m_xdgSurface->events.ack.registerListener([this](std::any d) { onAck(std::any_cast<uint32_t>(d)); });
+    m_listeners.unmap          = m_xdgSurface->events.unmap.registerListener([this](std::any d) { Events::listener_unmapWindow(this, nullptr); });
+    m_listeners.destroy        = m_xdgSurface->events.destroy.registerListener([this](std::any d) { Events::listener_destroyWindow(this, nullptr); });
+    m_listeners.commit         = m_xdgSurface->events.commit.registerListener([this](std::any d) { Events::listener_commitWindow(this, nullptr); });
+    m_listeners.updateState    = m_xdgSurface->toplevel->events.stateChanged.registerListener([this](std::any d) { onUpdateState(); });
+    m_listeners.updateMetadata = m_xdgSurface->toplevel->events.metadataChanged.registerListener([this](std::any d) { onUpdateMeta(); });
 }
 
-CWindow::CWindow(SP<CXWaylandSurface> surface) : m_pXWaylandSurface(surface) {
-    m_pWLSurface = CWLSurface::create();
+CWindow::CWindow(SP<CXWaylandSurface> surface) : m_xwaylandSurface(surface) {
+    m_wlSurface = CWLSurface::create();
 
-    listeners.map              = m_pXWaylandSurface->events.map.registerListener([this](std::any d) { Events::listener_mapWindow(this, nullptr); });
-    listeners.unmap            = m_pXWaylandSurface->events.unmap.registerListener([this](std::any d) { Events::listener_unmapWindow(this, nullptr); });
-    listeners.destroy          = m_pXWaylandSurface->events.destroy.registerListener([this](std::any d) { Events::listener_destroyWindow(this, nullptr); });
-    listeners.commit           = m_pXWaylandSurface->events.commit.registerListener([this](std::any d) { Events::listener_commitWindow(this, nullptr); });
-    listeners.configureRequest = m_pXWaylandSurface->events.configureRequest.registerListener([this](std::any d) { onX11ConfigureRequest(std::any_cast<CBox>(d)); });
-    listeners.updateState      = m_pXWaylandSurface->events.stateChanged.registerListener([this](std::any d) { onUpdateState(); });
-    listeners.updateMetadata   = m_pXWaylandSurface->events.metadataChanged.registerListener([this](std::any d) { onUpdateMeta(); });
-    listeners.resourceChange   = m_pXWaylandSurface->events.resourceChange.registerListener([this](std::any d) { onResourceChangeX11(); });
-    listeners.activate         = m_pXWaylandSurface->events.activate.registerListener([this](std::any d) { Events::listener_activateX11(this, nullptr); });
+    m_listeners.map              = m_xwaylandSurface->events.map.registerListener([this](std::any d) { Events::listener_mapWindow(this, nullptr); });
+    m_listeners.unmap            = m_xwaylandSurface->events.unmap.registerListener([this](std::any d) { Events::listener_unmapWindow(this, nullptr); });
+    m_listeners.destroy          = m_xwaylandSurface->events.destroy.registerListener([this](std::any d) { Events::listener_destroyWindow(this, nullptr); });
+    m_listeners.commit           = m_xwaylandSurface->events.commit.registerListener([this](std::any d) { Events::listener_commitWindow(this, nullptr); });
+    m_listeners.configureRequest = m_xwaylandSurface->events.configureRequest.registerListener([this](std::any d) { onX11ConfigureRequest(std::any_cast<CBox>(d)); });
+    m_listeners.updateState      = m_xwaylandSurface->events.stateChanged.registerListener([this](std::any d) { onUpdateState(); });
+    m_listeners.updateMetadata   = m_xwaylandSurface->events.metadataChanged.registerListener([this](std::any d) { onUpdateMeta(); });
+    m_listeners.resourceChange   = m_xwaylandSurface->events.resourceChange.registerListener([this](std::any d) { onResourceChangeX11(); });
+    m_listeners.activate         = m_xwaylandSurface->events.activate.registerListener([this](std::any d) { Events::listener_activateX11(this, nullptr); });
 
-    if (m_pXWaylandSurface->overrideRedirect)
-        listeners.setGeometry = m_pXWaylandSurface->events.setGeometry.registerListener([this](std::any d) { Events::listener_unmanagedSetGeometry(this, nullptr); });
+    if (m_xwaylandSurface->overrideRedirect)
+        m_listeners.setGeometry = m_xwaylandSurface->events.setGeometry.registerListener([this](std::any d) { Events::listener_unmanagedSetGeometry(this, nullptr); });
 }
 
 CWindow::~CWindow() {
-    if (g_pCompositor->m_lastWindow == m_pSelf) {
+    if (g_pCompositor->m_lastWindow == m_self) {
         g_pCompositor->m_lastFocus.reset();
         g_pCompositor->m_lastWindow.reset();
     }
 
-    events.destroy.emit();
+    m_events.destroy.emit();
 
     if (!g_pHyprOpenGL)
         return;
@@ -130,20 +130,20 @@ CWindow::~CWindow() {
 }
 
 SBoxExtents CWindow::getFullWindowExtents() {
-    if (m_bFadingOut)
-        return m_eOriginalClosedExtents;
+    if (m_fadingOut)
+        return m_originalClosedExtents;
 
     const int BORDERSIZE = getRealBorderSize();
 
-    if (m_sWindowData.dimAround.valueOrDefault()) {
-        if (const auto PMONITOR = m_pMonitor.lock(); PMONITOR)
-            return {{m_vRealPosition->value().x - PMONITOR->vecPosition.x, m_vRealPosition->value().y - PMONITOR->vecPosition.y},
-                    {PMONITOR->vecSize.x - (m_vRealPosition->value().x - PMONITOR->vecPosition.x), PMONITOR->vecSize.y - (m_vRealPosition->value().y - PMONITOR->vecPosition.y)}};
+    if (m_windowData.dimAround.valueOrDefault()) {
+        if (const auto PMONITOR = m_monitor.lock(); PMONITOR)
+            return {{m_realPosition->value().x - PMONITOR->vecPosition.x, m_realPosition->value().y - PMONITOR->vecPosition.y},
+                    {PMONITOR->vecSize.x - (m_realPosition->value().x - PMONITOR->vecPosition.x), PMONITOR->vecSize.y - (m_realPosition->value().y - PMONITOR->vecPosition.y)}};
     }
 
     SBoxExtents maxExtents = {{BORDERSIZE + 2, BORDERSIZE + 2}, {BORDERSIZE + 2, BORDERSIZE + 2}};
 
-    const auto  EXTENTS = g_pDecorationPositioner->getWindowDecorationExtents(m_pSelf.lock());
+    const auto  EXTENTS = g_pDecorationPositioner->getWindowDecorationExtents(m_self.lock());
 
     if (EXTENTS.topLeft.x > maxExtents.topLeft.x)
         maxExtents.topLeft.x = EXTENTS.topLeft.x;
@@ -157,10 +157,10 @@ SBoxExtents CWindow::getFullWindowExtents() {
     if (EXTENTS.bottomRight.y > maxExtents.bottomRight.y)
         maxExtents.bottomRight.y = EXTENTS.bottomRight.y;
 
-    if (m_pWLSurface->exists() && !m_bIsX11 && m_pPopupHead) {
+    if (m_wlSurface->exists() && !m_isX11 && m_popupHead) {
         CBox surfaceExtents = {0, 0, 0, 0};
         // TODO: this could be better, perhaps make a getFullWindowRegion?
-        m_pPopupHead->breadthfirst(
+        m_popupHead->breadthfirst(
             [](WP<CPopup> popup, void* data) {
                 if (!popup->m_wlSurface || !popup->m_wlSurface->resource())
                     return;
@@ -184,38 +184,38 @@ SBoxExtents CWindow::getFullWindowExtents() {
         if (-surfaceExtents.y > maxExtents.topLeft.y)
             maxExtents.topLeft.y = -surfaceExtents.y;
 
-        if (surfaceExtents.x + surfaceExtents.width > m_pWLSurface->resource()->current.size.x + maxExtents.bottomRight.x)
-            maxExtents.bottomRight.x = surfaceExtents.x + surfaceExtents.width - m_pWLSurface->resource()->current.size.x;
+        if (surfaceExtents.x + surfaceExtents.width > m_wlSurface->resource()->current.size.x + maxExtents.bottomRight.x)
+            maxExtents.bottomRight.x = surfaceExtents.x + surfaceExtents.width - m_wlSurface->resource()->current.size.x;
 
-        if (surfaceExtents.y + surfaceExtents.height > m_pWLSurface->resource()->current.size.y + maxExtents.bottomRight.y)
-            maxExtents.bottomRight.y = surfaceExtents.y + surfaceExtents.height - m_pWLSurface->resource()->current.size.y;
+        if (surfaceExtents.y + surfaceExtents.height > m_wlSurface->resource()->current.size.y + maxExtents.bottomRight.y)
+            maxExtents.bottomRight.y = surfaceExtents.y + surfaceExtents.height - m_wlSurface->resource()->current.size.y;
     }
 
     return maxExtents;
 }
 
 CBox CWindow::getFullWindowBoundingBox() {
-    if (m_sWindowData.dimAround.valueOrDefault()) {
-        if (const auto PMONITOR = m_pMonitor.lock(); PMONITOR)
+    if (m_windowData.dimAround.valueOrDefault()) {
+        if (const auto PMONITOR = m_monitor.lock(); PMONITOR)
             return {PMONITOR->vecPosition.x, PMONITOR->vecPosition.y, PMONITOR->vecSize.x, PMONITOR->vecSize.y};
     }
 
     auto maxExtents = getFullWindowExtents();
 
-    CBox finalBox = {m_vRealPosition->value().x - maxExtents.topLeft.x, m_vRealPosition->value().y - maxExtents.topLeft.y,
-                     m_vRealSize->value().x + maxExtents.topLeft.x + maxExtents.bottomRight.x, m_vRealSize->value().y + maxExtents.topLeft.y + maxExtents.bottomRight.y};
+    CBox finalBox = {m_realPosition->value().x - maxExtents.topLeft.x, m_realPosition->value().y - maxExtents.topLeft.y,
+                     m_realSize->value().x + maxExtents.topLeft.x + maxExtents.bottomRight.x, m_realSize->value().y + maxExtents.topLeft.y + maxExtents.bottomRight.y};
 
     return finalBox;
 }
 
 CBox CWindow::getWindowIdealBoundingBoxIgnoreReserved() {
-    const auto PMONITOR = m_pMonitor.lock();
+    const auto PMONITOR = m_monitor.lock();
 
     if (!PMONITOR)
-        return {m_vPosition, m_vSize};
+        return {m_position, m_size};
 
-    auto POS  = m_vPosition;
-    auto SIZE = m_vSize;
+    auto POS  = m_position;
+    auto SIZE = m_size;
 
     if (isFullscreen()) {
         POS  = PMONITOR->vecPosition;
@@ -243,82 +243,82 @@ CBox CWindow::getWindowIdealBoundingBoxIgnoreReserved() {
 }
 
 CBox CWindow::getWindowBoxUnified(uint64_t properties) {
-    if (m_sWindowData.dimAround.valueOrDefault()) {
-        const auto PMONITOR = m_pMonitor.lock();
+    if (m_windowData.dimAround.valueOrDefault()) {
+        const auto PMONITOR = m_monitor.lock();
         if (PMONITOR)
             return {PMONITOR->vecPosition.x, PMONITOR->vecPosition.y, PMONITOR->vecSize.x, PMONITOR->vecSize.y};
     }
 
     SBoxExtents EXTENTS = {{0, 0}, {0, 0}};
     if (properties & RESERVED_EXTENTS)
-        EXTENTS.addExtents(g_pDecorationPositioner->getWindowDecorationReserved(m_pSelf.lock()));
+        EXTENTS.addExtents(g_pDecorationPositioner->getWindowDecorationReserved(m_self.lock()));
     if (properties & INPUT_EXTENTS)
-        EXTENTS.addExtents(g_pDecorationPositioner->getWindowDecorationExtents(m_pSelf.lock(), true));
+        EXTENTS.addExtents(g_pDecorationPositioner->getWindowDecorationExtents(m_self.lock(), true));
     if (properties & FULL_EXTENTS)
-        EXTENTS.addExtents(g_pDecorationPositioner->getWindowDecorationExtents(m_pSelf.lock(), false));
+        EXTENTS.addExtents(g_pDecorationPositioner->getWindowDecorationExtents(m_self.lock(), false));
 
-    CBox box = {m_vRealPosition->value().x, m_vRealPosition->value().y, m_vRealSize->value().x, m_vRealSize->value().y};
+    CBox box = {m_realPosition->value().x, m_realPosition->value().y, m_realSize->value().x, m_realSize->value().y};
     box.addExtents(EXTENTS);
 
     return box;
 }
 
 SBoxExtents CWindow::getFullWindowReservedArea() {
-    return g_pDecorationPositioner->getWindowDecorationReserved(m_pSelf.lock());
+    return g_pDecorationPositioner->getWindowDecorationReserved(m_self.lock());
 }
 
 void CWindow::updateWindowDecos() {
 
-    if (!m_bIsMapped || isHidden())
+    if (!m_isMapped || isHidden())
         return;
 
-    for (auto const& wd : m_vDecosToRemove) {
-        for (auto it = m_dWindowDecorations.begin(); it != m_dWindowDecorations.end(); it++) {
+    for (auto const& wd : m_decosToRemove) {
+        for (auto it = m_windowDecorations.begin(); it != m_windowDecorations.end(); it++) {
             if (it->get() == wd) {
                 g_pDecorationPositioner->uncacheDecoration(it->get());
-                it = m_dWindowDecorations.erase(it);
-                if (it == m_dWindowDecorations.end())
+                it = m_windowDecorations.erase(it);
+                if (it == m_windowDecorations.end())
                     break;
             }
         }
     }
 
-    g_pDecorationPositioner->onWindowUpdate(m_pSelf.lock());
+    g_pDecorationPositioner->onWindowUpdate(m_self.lock());
 
-    m_vDecosToRemove.clear();
+    m_decosToRemove.clear();
 
     // make a copy because updateWindow can remove decos.
     std::vector<IHyprWindowDecoration*> decos;
     // reserve to avoid reallocations
-    decos.reserve(m_dWindowDecorations.size());
+    decos.reserve(m_windowDecorations.size());
 
-    for (auto const& wd : m_dWindowDecorations) {
+    for (auto const& wd : m_windowDecorations) {
         decos.push_back(wd.get());
     }
 
     for (auto const& wd : decos) {
-        if (std::find_if(m_dWindowDecorations.begin(), m_dWindowDecorations.end(), [wd](const auto& other) { return other.get() == wd; }) == m_dWindowDecorations.end())
+        if (std::find_if(m_windowDecorations.begin(), m_windowDecorations.end(), [wd](const auto& other) { return other.get() == wd; }) == m_windowDecorations.end())
             continue;
-        wd->updateWindow(m_pSelf.lock());
+        wd->updateWindow(m_self.lock());
     }
 }
 
 void CWindow::addWindowDeco(UP<IHyprWindowDecoration> deco) {
-    m_dWindowDecorations.emplace_back(std::move(deco));
-    g_pDecorationPositioner->forceRecalcFor(m_pSelf.lock());
+    m_windowDecorations.emplace_back(std::move(deco));
+    g_pDecorationPositioner->forceRecalcFor(m_self.lock());
     updateWindowDecos();
-    g_pLayoutManager->getCurrentLayout()->recalculateWindow(m_pSelf.lock());
+    g_pLayoutManager->getCurrentLayout()->recalculateWindow(m_self.lock());
 }
 
 void CWindow::removeWindowDeco(IHyprWindowDecoration* deco) {
-    m_vDecosToRemove.push_back(deco);
-    g_pDecorationPositioner->forceRecalcFor(m_pSelf.lock());
+    m_decosToRemove.push_back(deco);
+    g_pDecorationPositioner->forceRecalcFor(m_self.lock());
     updateWindowDecos();
-    g_pLayoutManager->getCurrentLayout()->recalculateWindow(m_pSelf.lock());
+    g_pLayoutManager->getCurrentLayout()->recalculateWindow(m_self.lock());
 }
 
 void CWindow::uncacheWindowDecos() {
-    for (auto const& wd : m_dWindowDecorations) {
+    for (auto const& wd : m_windowDecorations) {
         g_pDecorationPositioner->uncacheDecoration(wd.get());
     }
 }
@@ -327,7 +327,7 @@ bool CWindow::checkInputOnDecos(const eInputType type, const Vector2D& mouseCoor
     if (type != INPUT_TYPE_DRAG_END && hasPopupAt(mouseCoords))
         return false;
 
-    for (auto const& wd : m_dWindowDecorations) {
+    for (auto const& wd : m_windowDecorations) {
         if (!(wd->getDecorationFlags() & DECORATION_ALLOWS_MOUSE_INPUT))
             continue;
 
@@ -343,23 +343,23 @@ bool CWindow::checkInputOnDecos(const eInputType type, const Vector2D& mouseCoor
 
 pid_t CWindow::getPID() {
     pid_t PID = -1;
-    if (!m_bIsX11) {
-        if (!m_pXDGSurface || !m_pXDGSurface->owner /* happens at unmap */)
+    if (!m_isX11) {
+        if (!m_xdgSurface || !m_xdgSurface->owner /* happens at unmap */)
             return -1;
 
-        wl_client_get_credentials(m_pXDGSurface->owner->client(), &PID, nullptr, nullptr);
+        wl_client_get_credentials(m_xdgSurface->owner->client(), &PID, nullptr, nullptr);
     } else {
-        if (!m_pXWaylandSurface)
+        if (!m_xwaylandSurface)
             return -1;
 
-        PID = m_pXWaylandSurface->pid;
+        PID = m_xwaylandSurface->pid;
     }
 
     return PID;
 }
 
 IHyprWindowDecoration* CWindow::getDecorationByType(eDecorationType type) {
-    for (auto const& wd : m_dWindowDecorations) {
+    for (auto const& wd : m_windowDecorations) {
         if (wd->getDecorationType() == type)
             return wd.get();
     }
@@ -372,28 +372,28 @@ void CWindow::updateToplevel() {
 }
 
 void CWindow::updateSurfaceScaleTransformDetails(bool force) {
-    if (!m_bIsMapped || m_bHidden || g_pCompositor->m_unsafeState)
+    if (!m_isMapped || m_hidden || g_pCompositor->m_unsafeState)
         return;
 
-    const auto PLASTMONITOR = g_pCompositor->getMonitorFromID(m_iLastSurfaceMonitorID);
+    const auto PLASTMONITOR = g_pCompositor->getMonitorFromID(m_lastSurfaceMonitorID);
 
-    m_iLastSurfaceMonitorID = monitorID();
+    m_lastSurfaceMonitorID = monitorID();
 
-    const auto PNEWMONITOR = m_pMonitor.lock();
+    const auto PNEWMONITOR = m_monitor.lock();
 
     if (!PNEWMONITOR)
         return;
 
     if (PNEWMONITOR != PLASTMONITOR || force) {
         if (PLASTMONITOR && PLASTMONITOR->m_bEnabled && PNEWMONITOR != PLASTMONITOR)
-            m_pWLSurface->resource()->breadthfirst([PLASTMONITOR](SP<CWLSurfaceResource> s, const Vector2D& offset, void* d) { s->leave(PLASTMONITOR->self.lock()); }, nullptr);
+            m_wlSurface->resource()->breadthfirst([PLASTMONITOR](SP<CWLSurfaceResource> s, const Vector2D& offset, void* d) { s->leave(PLASTMONITOR->self.lock()); }, nullptr);
 
-        m_pWLSurface->resource()->breadthfirst([PNEWMONITOR](SP<CWLSurfaceResource> s, const Vector2D& offset, void* d) { s->enter(PNEWMONITOR->self.lock()); }, nullptr);
+        m_wlSurface->resource()->breadthfirst([PNEWMONITOR](SP<CWLSurfaceResource> s, const Vector2D& offset, void* d) { s->enter(PNEWMONITOR->self.lock()); }, nullptr);
     }
 
-    const auto PMONITOR = m_pMonitor.lock();
+    const auto PMONITOR = m_monitor.lock();
 
-    m_pWLSurface->resource()->breadthfirst(
+    m_wlSurface->resource()->breadthfirst(
         [PMONITOR](SP<CWLSurfaceResource> s, const Vector2D& offset, void* d) {
             const auto PSURFACE = CWLSurface::fromResource(s);
             if (PSURFACE && PSURFACE->m_lastScaleFloat == PMONITOR->scale)
@@ -407,18 +407,18 @@ void CWindow::updateSurfaceScaleTransformDetails(bool force) {
 }
 
 void CWindow::moveToWorkspace(PHLWORKSPACE pWorkspace) {
-    if (m_pWorkspace == pWorkspace)
+    if (m_workspace == pWorkspace)
         return;
 
     static auto PINITIALWSTRACKING = CConfigValue<Hyprlang::INT>("misc:initial_workspace_tracking");
 
-    if (!m_szInitialWorkspaceToken.empty()) {
-        const auto TOKEN = g_pTokenManager->getToken(m_szInitialWorkspaceToken);
+    if (!m_initialWorkspaceToken.empty()) {
+        const auto TOKEN = g_pTokenManager->getToken(m_initialWorkspaceToken);
         if (TOKEN) {
             if (*PINITIALWSTRACKING == 2) {
                 // persistent
                 SInitialWorkspaceToken token = std::any_cast<SInitialWorkspaceToken>(TOKEN->m_data);
-                if (token.primaryOwner == m_pSelf) {
+                if (token.primaryOwner == m_self) {
                     token.workspace = pWorkspace->getConfigName();
                     TOKEN->m_data   = token;
                 }
@@ -428,16 +428,16 @@ void CWindow::moveToWorkspace(PHLWORKSPACE pWorkspace) {
 
     static auto PCLOSEONLASTSPECIAL = CConfigValue<Hyprlang::INT>("misc:close_special_on_empty");
 
-    const auto  OLDWORKSPACE = m_pWorkspace;
+    const auto  OLDWORKSPACE = m_workspace;
 
     if (OLDWORKSPACE->isVisible()) {
-        m_fMovingToWorkspaceAlpha->setValueAndWarp(1.F);
-        *m_fMovingToWorkspaceAlpha = 0.F;
-        m_fMovingToWorkspaceAlpha->setCallbackOnEnd([this](auto) { m_iMonitorMovedFrom = -1; });
-        m_iMonitorMovedFrom = OLDWORKSPACE ? OLDWORKSPACE->monitorID() : -1;
+        m_movingToWorkspaceAlpha->setValueAndWarp(1.F);
+        *m_movingToWorkspaceAlpha = 0.F;
+        m_movingToWorkspaceAlpha->setCallbackOnEnd([this](auto) { m_monitorMovedFrom = -1; });
+        m_monitorMovedFrom = OLDWORKSPACE ? OLDWORKSPACE->monitorID() : -1;
     }
 
-    m_pWorkspace = pWorkspace;
+    m_workspace = pWorkspace;
 
     setAnimationsToMove();
 
@@ -454,13 +454,13 @@ void CWindow::moveToWorkspace(PHLWORKSPACE pWorkspace) {
     if (valid(pWorkspace)) {
         g_pEventManager->postEvent(SHyprIPCEvent{"movewindow", std::format("{:x},{}", (uintptr_t)this, pWorkspace->m_name)});
         g_pEventManager->postEvent(SHyprIPCEvent{"movewindowv2", std::format("{:x},{},{}", (uintptr_t)this, pWorkspace->m_id, pWorkspace->m_name)});
-        EMIT_HOOK_EVENT("moveWindow", (std::vector<std::any>{m_pSelf.lock(), pWorkspace}));
+        EMIT_HOOK_EVENT("moveWindow", (std::vector<std::any>{m_self.lock(), pWorkspace}));
     }
 
-    if (const auto SWALLOWED = m_pSwallowed.lock()) {
-        if (SWALLOWED->m_bCurrentlySwallowed) {
+    if (const auto SWALLOWED = m_swallowed.lock()) {
+        if (SWALLOWED->m_currentlySwallowed) {
             SWALLOWED->moveToWorkspace(pWorkspace);
-            SWALLOWED->m_pMonitor = m_pMonitor;
+            SWALLOWED->m_monitor = m_monitor;
         }
     }
 
@@ -471,10 +471,10 @@ void CWindow::moveToWorkspace(PHLWORKSPACE pWorkspace) {
 }
 
 PHLWINDOW CWindow::x11TransientFor() {
-    if (!m_pXWaylandSurface || !m_pXWaylandSurface->parent)
+    if (!m_xwaylandSurface || !m_xwaylandSurface->parent)
         return nullptr;
 
-    auto                              s = m_pXWaylandSurface->parent;
+    auto                              s = m_xwaylandSurface->parent;
     std::vector<SP<CXWaylandSurface>> visited;
     while (s) {
         // break loops. Some X apps make them, and it seems like it's valid behavior?!?!?!
@@ -486,11 +486,11 @@ PHLWINDOW CWindow::x11TransientFor() {
         s = s->parent;
     }
 
-    if (s == m_pXWaylandSurface)
+    if (s == m_xwaylandSurface)
         return nullptr; // dead-ass circle
 
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->m_pXWaylandSurface != s)
+        if (w->m_xwaylandSurface != s)
             continue;
         return w;
     }
@@ -502,93 +502,93 @@ void CWindow::onUnmap() {
     static auto PCLOSEONLASTSPECIAL = CConfigValue<Hyprlang::INT>("misc:close_special_on_empty");
     static auto PINITIALWSTRACKING  = CConfigValue<Hyprlang::INT>("misc:initial_workspace_tracking");
 
-    if (!m_szInitialWorkspaceToken.empty()) {
-        const auto TOKEN = g_pTokenManager->getToken(m_szInitialWorkspaceToken);
+    if (!m_initialWorkspaceToken.empty()) {
+        const auto TOKEN = g_pTokenManager->getToken(m_initialWorkspaceToken);
         if (TOKEN) {
             if (*PINITIALWSTRACKING == 2) {
                 // persistent token, but the first window got removed so the token is gone
                 SInitialWorkspaceToken token = std::any_cast<SInitialWorkspaceToken>(TOKEN->m_data);
-                if (token.primaryOwner == m_pSelf)
+                if (token.primaryOwner == m_self)
                     g_pTokenManager->removeToken(TOKEN);
             }
         }
     }
 
-    m_iLastWorkspace = m_pWorkspace->m_id;
+    m_lastWorkspace = m_workspace->m_id;
 
-    std::erase_if(g_pCompositor->m_windowFocusHistory, [this](const auto& other) { return other.expired() || other == m_pSelf; });
+    std::erase_if(g_pCompositor->m_windowFocusHistory, [this](const auto& other) { return other.expired() || other == m_self; });
 
-    if (*PCLOSEONLASTSPECIAL && m_pWorkspace && m_pWorkspace->getWindows() == 0 && onSpecialWorkspace()) {
-        const auto PMONITOR = m_pMonitor.lock();
-        if (PMONITOR && PMONITOR->activeSpecialWorkspace && PMONITOR->activeSpecialWorkspace == m_pWorkspace)
+    if (*PCLOSEONLASTSPECIAL && m_workspace && m_workspace->getWindows() == 0 && onSpecialWorkspace()) {
+        const auto PMONITOR = m_monitor.lock();
+        if (PMONITOR && PMONITOR->activeSpecialWorkspace && PMONITOR->activeSpecialWorkspace == m_workspace)
             PMONITOR->setSpecialWorkspace(nullptr);
     }
 
-    const auto PMONITOR = m_pMonitor.lock();
+    const auto PMONITOR = m_monitor.lock();
 
-    if (PMONITOR && PMONITOR->solitaryClient == m_pSelf)
+    if (PMONITOR && PMONITOR->solitaryClient == m_self)
         PMONITOR->solitaryClient.reset();
 
-    if (m_pWorkspace) {
-        m_pWorkspace->updateWindows();
-        m_pWorkspace->updateWindowData();
+    if (m_workspace) {
+        m_workspace->updateWindows();
+        m_workspace->updateWindowData();
     }
     g_pLayoutManager->getCurrentLayout()->recalculateMonitor(monitorID());
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 
-    m_pWorkspace.reset();
+    m_workspace.reset();
 
-    if (m_bIsX11)
+    if (m_isX11)
         return;
 
-    m_pSubsurfaceHead.reset();
-    m_pPopupHead.reset();
+    m_subsurfaceHead.reset();
+    m_popupHead.reset();
 }
 
 void CWindow::onMap() {
     // JIC, reset the callbacks. If any are set, we'll make sure they are cleared so we don't accidentally unset them. (In case a window got remapped)
-    m_vRealPosition->resetAllCallbacks();
-    m_vRealSize->resetAllCallbacks();
-    m_fBorderFadeAnimationProgress->resetAllCallbacks();
-    m_fBorderAngleAnimationProgress->resetAllCallbacks();
-    m_fActiveInactiveAlpha->resetAllCallbacks();
-    m_fAlpha->resetAllCallbacks();
-    m_cRealShadowColor->resetAllCallbacks();
-    m_fDimPercent->resetAllCallbacks();
-    m_fMovingToWorkspaceAlpha->resetAllCallbacks();
-    m_fMovingFromWorkspaceAlpha->resetAllCallbacks();
+    m_realPosition->resetAllCallbacks();
+    m_realSize->resetAllCallbacks();
+    m_borderFadeAnimationProgress->resetAllCallbacks();
+    m_borderAngleAnimationProgress->resetAllCallbacks();
+    m_activeInactiveAlpha->resetAllCallbacks();
+    m_alpha->resetAllCallbacks();
+    m_realShadowColor->resetAllCallbacks();
+    m_dimPercent->resetAllCallbacks();
+    m_movingToWorkspaceAlpha->resetAllCallbacks();
+    m_movingFromWorkspaceAlpha->resetAllCallbacks();
 
-    m_fMovingFromWorkspaceAlpha->setValueAndWarp(1.F);
+    m_movingFromWorkspaceAlpha->setValueAndWarp(1.F);
 
-    if (m_fBorderAngleAnimationProgress->enabled()) {
-        m_fBorderAngleAnimationProgress->setValueAndWarp(0.f);
-        m_fBorderAngleAnimationProgress->setCallbackOnEnd([&](WP<CBaseAnimatedVariable> p) { onBorderAngleAnimEnd(p); }, false);
-        *m_fBorderAngleAnimationProgress = 1.f;
+    if (m_borderAngleAnimationProgress->enabled()) {
+        m_borderAngleAnimationProgress->setValueAndWarp(0.f);
+        m_borderAngleAnimationProgress->setCallbackOnEnd([&](WP<CBaseAnimatedVariable> p) { onBorderAngleAnimEnd(p); }, false);
+        *m_borderAngleAnimationProgress = 1.f;
     }
 
-    m_vRealSize->setCallbackOnBegin(
+    m_realSize->setCallbackOnBegin(
         [this](auto) {
-            if (!m_bIsMapped || isX11OverrideRedirect())
+            if (!m_isMapped || isX11OverrideRedirect())
                 return;
 
             sendWindowSize();
         },
         false);
 
-    m_fMovingFromWorkspaceAlpha->setValueAndWarp(1.F);
+    m_movingFromWorkspaceAlpha->setValueAndWarp(1.F);
 
-    g_pCompositor->m_windowFocusHistory.push_back(m_pSelf);
+    g_pCompositor->m_windowFocusHistory.push_back(m_self);
 
-    m_vReportedSize = m_vPendingReportedSize;
-    m_bAnimatingIn  = true;
+    m_reportedSize = m_pendingReportedSize;
+    m_animatingIn  = true;
 
     updateSurfaceScaleTransformDetails(true);
 
-    if (m_bIsX11)
+    if (m_isX11)
         return;
 
-    m_pSubsurfaceHead = CSubsurface::create(m_pSelf.lock());
-    m_pPopupHead      = CPopup::create(m_pSelf.lock());
+    m_subsurfaceHead = CSubsurface::create(m_self.lock());
+    m_popupHead      = CPopup::create(m_self.lock());
 }
 
 void CWindow::onBorderAngleAnimEnd(WP<CBaseAnimatedVariable> pav) {
@@ -610,34 +610,34 @@ void CWindow::onBorderAngleAnimEnd(WP<CBaseAnimatedVariable> pav) {
 }
 
 void CWindow::setHidden(bool hidden) {
-    m_bHidden = hidden;
+    m_hidden = hidden;
 
-    if (hidden && g_pCompositor->m_lastWindow == m_pSelf)
+    if (hidden && g_pCompositor->m_lastWindow == m_self)
         g_pCompositor->m_lastWindow.reset();
 
     setSuspended(hidden);
 }
 
 bool CWindow::isHidden() {
-    return m_bHidden;
+    return m_hidden;
 }
 
 void CWindow::applyDynamicRule(const SP<CWindowRule>& r) {
-    const eOverridePriority priority = r->execRule ? PRIORITY_SET_PROP : PRIORITY_WINDOW_RULE;
+    const eOverridePriority priority = r->m_execRule ? PRIORITY_SET_PROP : PRIORITY_WINDOW_RULE;
 
-    switch (r->ruleType) {
+    switch (r->m_ruleType) {
         case CWindowRule::RULE_TAG: {
-            CVarList vars{r->szRule, 0, 's', true};
+            CVarList vars{r->m_rule, 0, 's', true};
 
             if (vars.size() == 2 && vars[0] == "tag")
                 m_tags.applyTag(vars[1], true);
             else
-                Debug::log(ERR, "Tag rule invalid: {}", r->szRule);
+                Debug::log(ERR, "Tag rule invalid: {}", r->m_rule);
             break;
         }
         case CWindowRule::RULE_OPACITY: {
             try {
-                CVarList vars(r->szRule, 0, ' ');
+                CVarList vars(r->m_rule, 0, ' ');
 
                 int      opacityIDX = 0;
 
@@ -647,18 +647,18 @@ void CWindow::applyDynamicRule(const SP<CWindowRule>& r) {
 
                     if (r == "override") {
                         if (opacityIDX == 1)
-                            m_sWindowData.alpha = CWindowOverridableVar(SAlphaValue{m_sWindowData.alpha.value().m_fAlpha, true}, priority);
+                            m_windowData.alpha = CWindowOverridableVar(SAlphaValue{m_windowData.alpha.value().alpha, true}, priority);
                         else if (opacityIDX == 2)
-                            m_sWindowData.alphaInactive = CWindowOverridableVar(SAlphaValue{m_sWindowData.alphaInactive.value().m_fAlpha, true}, priority);
+                            m_windowData.alphaInactive = CWindowOverridableVar(SAlphaValue{m_windowData.alphaInactive.value().alpha, true}, priority);
                         else if (opacityIDX == 3)
-                            m_sWindowData.alphaFullscreen = CWindowOverridableVar(SAlphaValue{m_sWindowData.alphaFullscreen.value().m_fAlpha, true}, priority);
+                            m_windowData.alphaFullscreen = CWindowOverridableVar(SAlphaValue{m_windowData.alphaFullscreen.value().alpha, true}, priority);
                     } else {
                         if (opacityIDX == 0) {
-                            m_sWindowData.alpha = CWindowOverridableVar(SAlphaValue{std::stof(r), false}, priority);
+                            m_windowData.alpha = CWindowOverridableVar(SAlphaValue{std::stof(r), false}, priority);
                         } else if (opacityIDX == 1) {
-                            m_sWindowData.alphaInactive = CWindowOverridableVar(SAlphaValue{std::stof(r), false}, priority);
+                            m_windowData.alphaInactive = CWindowOverridableVar(SAlphaValue{std::stof(r), false}, priority);
                         } else if (opacityIDX == 2) {
-                            m_sWindowData.alphaFullscreen = CWindowOverridableVar(SAlphaValue{std::stof(r), false}, priority);
+                            m_windowData.alphaFullscreen = CWindowOverridableVar(SAlphaValue{std::stof(r), false}, priority);
                         } else {
                             throw std::runtime_error("more than 3 alpha values");
                         }
@@ -668,15 +668,15 @@ void CWindow::applyDynamicRule(const SP<CWindowRule>& r) {
                 }
 
                 if (opacityIDX == 1) {
-                    m_sWindowData.alphaInactive   = m_sWindowData.alpha;
-                    m_sWindowData.alphaFullscreen = m_sWindowData.alpha;
+                    m_windowData.alphaInactive   = m_windowData.alpha;
+                    m_windowData.alphaFullscreen = m_windowData.alpha;
                 }
-            } catch (std::exception& e) { Debug::log(ERR, "Opacity rule \"{}\" failed with: {}", r->szRule, e.what()); }
+            } catch (std::exception& e) { Debug::log(ERR, "Opacity rule \"{}\" failed with: {}", r->m_rule, e.what()); }
             break;
         }
         case CWindowRule::RULE_ANIMATION: {
-            auto STYLE                   = r->szRule.substr(r->szRule.find_first_of(' ') + 1);
-            m_sWindowData.animationStyle = CWindowOverridableVar(STYLE, priority);
+            auto STYLE                  = r->m_rule.substr(r->m_rule.find_first_of(' ') + 1);
+            m_windowData.animationStyle = CWindowOverridableVar(STYLE, priority);
             break;
         }
         case CWindowRule::RULE_BORDERCOLOR: {
@@ -685,12 +685,12 @@ void CWindow::applyDynamicRule(const SP<CWindowRule>& r) {
                 CGradientValueData activeBorderGradient   = {};
                 CGradientValueData inactiveBorderGradient = {};
                 bool               active                 = true;
-                CVarList           colorsAndAngles        = CVarList(trim(r->szRule.substr(r->szRule.find_first_of(' ') + 1)), 0, 's', true);
+                CVarList           colorsAndAngles        = CVarList(trim(r->m_rule.substr(r->m_rule.find_first_of(' ') + 1)), 0, 's', true);
 
                 // Basic form has only two colors, everything else can be parsed as a gradient
                 if (colorsAndAngles.size() == 2 && !colorsAndAngles[1].contains("deg")) {
-                    m_sWindowData.activeBorderColor   = CWindowOverridableVar(CGradientValueData(CHyprColor(configStringToInt(colorsAndAngles[0]).value_or(0))), priority);
-                    m_sWindowData.inactiveBorderColor = CWindowOverridableVar(CGradientValueData(CHyprColor(configStringToInt(colorsAndAngles[1]).value_or(0))), priority);
+                    m_windowData.activeBorderColor   = CWindowOverridableVar(CGradientValueData(CHyprColor(configStringToInt(colorsAndAngles[0]).value_or(0))), priority);
+                    m_windowData.inactiveBorderColor = CWindowOverridableVar(CGradientValueData(CHyprColor(configStringToInt(colorsAndAngles[1]).value_or(0))), priority);
                     return;
                 }
 
@@ -711,91 +711,91 @@ void CWindow::applyDynamicRule(const SP<CWindowRule>& r) {
 
                 // Includes sanity checks for the number of colors in each gradient
                 if (activeBorderGradient.m_colors.size() > 10 || inactiveBorderGradient.m_colors.size() > 10)
-                    Debug::log(WARN, "Bordercolor rule \"{}\" has more than 10 colors in one gradient, ignoring", r->szRule);
+                    Debug::log(WARN, "Bordercolor rule \"{}\" has more than 10 colors in one gradient, ignoring", r->m_rule);
                 else if (activeBorderGradient.m_colors.empty())
-                    Debug::log(WARN, "Bordercolor rule \"{}\" has no colors, ignoring", r->szRule);
+                    Debug::log(WARN, "Bordercolor rule \"{}\" has no colors, ignoring", r->m_rule);
                 else if (inactiveBorderGradient.m_colors.empty())
-                    m_sWindowData.activeBorderColor = CWindowOverridableVar(activeBorderGradient, priority);
+                    m_windowData.activeBorderColor = CWindowOverridableVar(activeBorderGradient, priority);
                 else {
-                    m_sWindowData.activeBorderColor   = CWindowOverridableVar(activeBorderGradient, priority);
-                    m_sWindowData.inactiveBorderColor = CWindowOverridableVar(inactiveBorderGradient, priority);
+                    m_windowData.activeBorderColor   = CWindowOverridableVar(activeBorderGradient, priority);
+                    m_windowData.inactiveBorderColor = CWindowOverridableVar(inactiveBorderGradient, priority);
                 }
-            } catch (std::exception& e) { Debug::log(ERR, "BorderColor rule \"{}\" failed with: {}", r->szRule, e.what()); }
+            } catch (std::exception& e) { Debug::log(ERR, "BorderColor rule \"{}\" failed with: {}", r->m_rule, e.what()); }
             break;
         }
         case CWindowRule::RULE_IDLEINHIBIT: {
-            auto IDLERULE = r->szRule.substr(r->szRule.find_first_of(' ') + 1);
+            auto IDLERULE = r->m_rule.substr(r->m_rule.find_first_of(' ') + 1);
 
             if (IDLERULE == "none")
-                m_eIdleInhibitMode = IDLEINHIBIT_NONE;
+                m_idleInhibitMode = IDLEINHIBIT_NONE;
             else if (IDLERULE == "always")
-                m_eIdleInhibitMode = IDLEINHIBIT_ALWAYS;
+                m_idleInhibitMode = IDLEINHIBIT_ALWAYS;
             else if (IDLERULE == "focus")
-                m_eIdleInhibitMode = IDLEINHIBIT_FOCUS;
+                m_idleInhibitMode = IDLEINHIBIT_FOCUS;
             else if (IDLERULE == "fullscreen")
-                m_eIdleInhibitMode = IDLEINHIBIT_FULLSCREEN;
+                m_idleInhibitMode = IDLEINHIBIT_FULLSCREEN;
             else
                 Debug::log(ERR, "Rule idleinhibit: unknown mode {}", IDLERULE);
             break;
         }
         case CWindowRule::RULE_MAXSIZE: {
             try {
-                if (!m_bIsFloating)
+                if (!m_isFloating)
                     return;
-                const auto VEC = configStringToVector2D(r->szRule.substr(8));
+                const auto VEC = configStringToVector2D(r->m_rule.substr(8));
                 if (VEC.x < 1 || VEC.y < 1) {
                     Debug::log(ERR, "Invalid size for maxsize");
                     return;
                 }
 
-                m_sWindowData.maxSize = CWindowOverridableVar(VEC, priority);
-                clampWindowSize(std::nullopt, m_sWindowData.maxSize.value());
+                m_windowData.maxSize = CWindowOverridableVar(VEC, priority);
+                clampWindowSize(std::nullopt, m_windowData.maxSize.value());
 
-            } catch (std::exception& e) { Debug::log(ERR, "maxsize rule \"{}\" failed with: {}", r->szRule, e.what()); }
+            } catch (std::exception& e) { Debug::log(ERR, "maxsize rule \"{}\" failed with: {}", r->m_rule, e.what()); }
             break;
         }
         case CWindowRule::RULE_MINSIZE: {
             try {
-                if (!m_bIsFloating)
+                if (!m_isFloating)
                     return;
-                const auto VEC = configStringToVector2D(r->szRule.substr(8));
+                const auto VEC = configStringToVector2D(r->m_rule.substr(8));
                 if (VEC.x < 1 || VEC.y < 1) {
                     Debug::log(ERR, "Invalid size for minsize");
                     return;
                 }
 
-                m_sWindowData.minSize = CWindowOverridableVar(VEC, priority);
-                clampWindowSize(m_sWindowData.minSize.value(), std::nullopt);
+                m_windowData.minSize = CWindowOverridableVar(VEC, priority);
+                clampWindowSize(m_windowData.minSize.value(), std::nullopt);
 
-                if (m_sGroupData.pNextWindow.expired())
+                if (m_groupData.pNextWindow.expired())
                     setHidden(false);
-            } catch (std::exception& e) { Debug::log(ERR, "minsize rule \"{}\" failed with: {}", r->szRule, e.what()); }
+            } catch (std::exception& e) { Debug::log(ERR, "minsize rule \"{}\" failed with: {}", r->m_rule, e.what()); }
             break;
         }
         case CWindowRule::RULE_RENDERUNFOCUSED: {
-            m_sWindowData.renderUnfocused = CWindowOverridableVar(true, priority);
-            g_pHyprRenderer->addWindowToRenderUnfocused(m_pSelf.lock());
+            m_windowData.renderUnfocused = CWindowOverridableVar(true, priority);
+            g_pHyprRenderer->addWindowToRenderUnfocused(m_self.lock());
             break;
         }
         case CWindowRule::RULE_PROP: {
-            const CVarList VARS(r->szRule, 0, ' ');
+            const CVarList VARS(r->m_rule, 0, ' ');
             if (auto search = NWindowProperties::intWindowProperties.find(VARS[1]); search != NWindowProperties::intWindowProperties.end()) {
                 try {
-                    *(search->second(m_pSelf.lock())) = CWindowOverridableVar(Hyprlang::INT(std::stoi(VARS[2])), priority);
-                } catch (std::exception& e) { Debug::log(ERR, "Rule \"{}\" failed with: {}", r->szRule, e.what()); }
+                    *(search->second(m_self.lock())) = CWindowOverridableVar(Hyprlang::INT(std::stoi(VARS[2])), priority);
+                } catch (std::exception& e) { Debug::log(ERR, "Rule \"{}\" failed with: {}", r->m_rule, e.what()); }
             } else if (auto search = NWindowProperties::floatWindowProperties.find(VARS[1]); search != NWindowProperties::floatWindowProperties.end()) {
                 try {
-                    *(search->second(m_pSelf.lock())) = CWindowOverridableVar(std::stof(VARS[2]), priority);
-                } catch (std::exception& e) { Debug::log(ERR, "Rule \"{}\" failed with: {}", r->szRule, e.what()); }
+                    *(search->second(m_self.lock())) = CWindowOverridableVar(std::stof(VARS[2]), priority);
+                } catch (std::exception& e) { Debug::log(ERR, "Rule \"{}\" failed with: {}", r->m_rule, e.what()); }
             } else if (auto search = NWindowProperties::boolWindowProperties.find(VARS[1]); search != NWindowProperties::boolWindowProperties.end()) {
                 try {
-                    *(search->second(m_pSelf.lock())) = CWindowOverridableVar(VARS[2].empty() ? true : (bool)std::stoi(VARS[2]), priority);
-                } catch (std::exception& e) { Debug::log(ERR, "Rule \"{}\" failed with: {}", r->szRule, e.what()); }
+                    *(search->second(m_self.lock())) = CWindowOverridableVar(VARS[2].empty() ? true : (bool)std::stoi(VARS[2]), priority);
+                } catch (std::exception& e) { Debug::log(ERR, "Rule \"{}\" failed with: {}", r->m_rule, e.what()); }
             }
             break;
         }
         case CWindowRule::RULE_PERSISTENTSIZE: {
-            m_sWindowData.persistentSize = CWindowOverridableVar(true, PRIORITY_WINDOW_RULE);
+            m_windowData.persistentSize = CWindowOverridableVar(true, PRIORITY_WINDOW_RULE);
             break;
         }
         default: break;
@@ -803,31 +803,31 @@ void CWindow::applyDynamicRule(const SP<CWindowRule>& r) {
 }
 
 void CWindow::updateDynamicRules() {
-    m_sWindowData.alpha.unset(PRIORITY_WINDOW_RULE);
-    m_sWindowData.alphaInactive.unset(PRIORITY_WINDOW_RULE);
-    m_sWindowData.alphaFullscreen.unset(PRIORITY_WINDOW_RULE);
+    m_windowData.alpha.unset(PRIORITY_WINDOW_RULE);
+    m_windowData.alphaInactive.unset(PRIORITY_WINDOW_RULE);
+    m_windowData.alphaFullscreen.unset(PRIORITY_WINDOW_RULE);
 
     unsetWindowData(PRIORITY_WINDOW_RULE);
 
-    m_sWindowData.animationStyle.unset(PRIORITY_WINDOW_RULE);
-    m_sWindowData.maxSize.unset(PRIORITY_WINDOW_RULE);
-    m_sWindowData.minSize.unset(PRIORITY_WINDOW_RULE);
+    m_windowData.animationStyle.unset(PRIORITY_WINDOW_RULE);
+    m_windowData.maxSize.unset(PRIORITY_WINDOW_RULE);
+    m_windowData.minSize.unset(PRIORITY_WINDOW_RULE);
 
-    m_sWindowData.activeBorderColor.unset(PRIORITY_WINDOW_RULE);
-    m_sWindowData.inactiveBorderColor.unset(PRIORITY_WINDOW_RULE);
+    m_windowData.activeBorderColor.unset(PRIORITY_WINDOW_RULE);
+    m_windowData.inactiveBorderColor.unset(PRIORITY_WINDOW_RULE);
 
-    m_sWindowData.renderUnfocused.unset(PRIORITY_WINDOW_RULE);
+    m_windowData.renderUnfocused.unset(PRIORITY_WINDOW_RULE);
 
-    m_eIdleInhibitMode = IDLEINHIBIT_NONE;
+    m_idleInhibitMode = IDLEINHIBIT_NONE;
 
     m_tags.removeDynamicTags();
 
-    m_vMatchedRules = g_pConfigManager->getMatchingRules(m_pSelf.lock());
-    for (const auto& r : m_vMatchedRules) {
+    m_matchedRules = g_pConfigManager->getMatchingRules(m_self.lock());
+    for (const auto& r : m_matchedRules) {
         applyDynamicRule(r);
     }
 
-    EMIT_HOOK_EVENT("windowUpdateRules", m_pSelf.lock());
+    EMIT_HOOK_EVENT("windowUpdateRules", m_self.lock());
 
     g_pLayoutManager->getCurrentLayout()->recalculateMonitor(monitorID());
 }
@@ -842,10 +842,10 @@ bool CWindow::isInCurvedCorner(double x, double y) {
         return false;
 
     // (x0, y0), (x0, y1), ... are the center point of rounding at each corner
-    double x0 = m_vRealPosition->value().x + ROUNDING;
-    double y0 = m_vRealPosition->value().y + ROUNDING;
-    double x1 = m_vRealPosition->value().x + m_vRealSize->value().x - ROUNDING;
-    double y1 = m_vRealPosition->value().y + m_vRealSize->value().y - ROUNDING;
+    double x0 = m_realPosition->value().x + ROUNDING;
+    double y0 = m_realPosition->value().y + ROUNDING;
+    double x1 = m_realPosition->value().x + m_realSize->value().x - ROUNDING;
+    double y1 = m_realPosition->value().y + m_realSize->value().y - ROUNDING;
 
     if (x < x0 && y < y0) {
         return std::pow(x0 - x, ROUNDINGPOWER) + std::pow(y0 - y, ROUNDINGPOWER) > std::pow((double)ROUNDING, ROUNDINGPOWER);
@@ -865,39 +865,39 @@ bool CWindow::isInCurvedCorner(double x, double y) {
 
 // checks if the wayland window has a popup at pos
 bool CWindow::hasPopupAt(const Vector2D& pos) {
-    if (m_bIsX11)
+    if (m_isX11)
         return false;
 
-    auto popup = m_pPopupHead->at(pos);
+    auto popup = m_popupHead->at(pos);
 
     return popup && popup->m_wlSurface->resource();
 }
 
 void CWindow::applyGroupRules() {
-    if ((m_eGroupRules & GROUP_SET && m_bFirstMap) || m_eGroupRules & GROUP_SET_ALWAYS)
+    if ((m_groupRules & GROUP_SET && m_firstMap) || m_groupRules & GROUP_SET_ALWAYS)
         createGroup();
 
-    if (m_sGroupData.pNextWindow.lock() && ((m_eGroupRules & GROUP_LOCK && m_bFirstMap) || m_eGroupRules & GROUP_LOCK_ALWAYS))
-        getGroupHead()->m_sGroupData.locked = true;
+    if (m_groupData.pNextWindow.lock() && ((m_groupRules & GROUP_LOCK && m_firstMap) || m_groupRules & GROUP_LOCK_ALWAYS))
+        getGroupHead()->m_groupData.locked = true;
 }
 
 void CWindow::createGroup() {
-    if (m_sGroupData.deny) {
-        Debug::log(LOG, "createGroup: window:{:x},title:{} is denied as a group, ignored", (uintptr_t)this, this->m_szTitle);
+    if (m_groupData.deny) {
+        Debug::log(LOG, "createGroup: window:{:x},title:{} is denied as a group, ignored", (uintptr_t)this, this->m_title);
         return;
     }
 
-    if (m_sGroupData.pNextWindow.expired()) {
-        m_sGroupData.pNextWindow = m_pSelf;
-        m_sGroupData.head        = true;
-        m_sGroupData.locked      = false;
-        m_sGroupData.deny        = false;
+    if (m_groupData.pNextWindow.expired()) {
+        m_groupData.pNextWindow = m_self;
+        m_groupData.head        = true;
+        m_groupData.locked      = false;
+        m_groupData.deny        = false;
 
-        addWindowDeco(makeUnique<CHyprGroupBarDecoration>(m_pSelf.lock()));
+        addWindowDeco(makeUnique<CHyprGroupBarDecoration>(m_self.lock()));
 
-        if (m_pWorkspace) {
-            m_pWorkspace->updateWindows();
-            m_pWorkspace->updateWindowData();
+        if (m_workspace) {
+            m_workspace->updateWindows();
+            m_workspace->updateWindowData();
         }
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(monitorID());
         g_pCompositor->updateAllWindowsAnimatedDecorationValues();
@@ -907,17 +907,17 @@ void CWindow::createGroup() {
 }
 
 void CWindow::destroyGroup() {
-    if (m_sGroupData.pNextWindow == m_pSelf) {
-        if (m_eGroupRules & GROUP_SET_ALWAYS) {
-            Debug::log(LOG, "destoryGroup: window:{:x},title:{} has rule [group set always], ignored", (uintptr_t)this, this->m_szTitle);
+    if (m_groupData.pNextWindow == m_self) {
+        if (m_groupRules & GROUP_SET_ALWAYS) {
+            Debug::log(LOG, "destoryGroup: window:{:x},title:{} has rule [group set always], ignored", (uintptr_t)this, this->m_title);
             return;
         }
-        m_sGroupData.pNextWindow.reset();
-        m_sGroupData.head = false;
+        m_groupData.pNextWindow.reset();
+        m_groupData.head = false;
         updateWindowDecos();
-        if (m_pWorkspace) {
-            m_pWorkspace->updateWindows();
-            m_pWorkspace->updateWindowData();
+        if (m_workspace) {
+            m_workspace->updateWindows();
+            m_workspace->updateWindowData();
         }
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(monitorID());
         g_pCompositor->updateAllWindowsAnimatedDecorationValues();
@@ -927,12 +927,12 @@ void CWindow::destroyGroup() {
     }
 
     std::string            addresses;
-    PHLWINDOW              curr = m_pSelf.lock();
+    PHLWINDOW              curr = m_self.lock();
     std::vector<PHLWINDOW> members;
     do {
         const auto PLASTWIN = curr;
-        curr                = curr->m_sGroupData.pNextWindow.lock();
-        PLASTWIN->m_sGroupData.pNextWindow.reset();
+        curr                = curr->m_groupData.pNextWindow.lock();
+        PLASTWIN->m_groupData.pNextWindow.reset();
         curr->setHidden(false);
         members.push_back(curr);
 
@@ -940,9 +940,9 @@ void CWindow::destroyGroup() {
     } while (curr.get() != this);
 
     for (auto const& w : members) {
-        if (w->m_sGroupData.head)
+        if (w->m_groupData.head)
             g_pLayoutManager->getCurrentLayout()->onWindowRemoved(curr);
-        w->m_sGroupData.head = false;
+        w->m_groupData.head = false;
     }
 
     const bool GROUPSLOCKEDPREV        = g_pKeybindManager->m_bGroupsLocked;
@@ -953,9 +953,9 @@ void CWindow::destroyGroup() {
     }
     g_pKeybindManager->m_bGroupsLocked = GROUPSLOCKEDPREV;
 
-    if (m_pWorkspace) {
-        m_pWorkspace->updateWindows();
-        m_pWorkspace->updateWindowData();
+    if (m_workspace) {
+        m_workspace->updateWindows();
+        m_workspace->updateWindowData();
     }
     g_pLayoutManager->getCurrentLayout()->recalculateMonitor(monitorID());
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
@@ -966,31 +966,31 @@ void CWindow::destroyGroup() {
 }
 
 PHLWINDOW CWindow::getGroupHead() {
-    PHLWINDOW curr = m_pSelf.lock();
-    while (!curr->m_sGroupData.head)
-        curr = curr->m_sGroupData.pNextWindow.lock();
+    PHLWINDOW curr = m_self.lock();
+    while (!curr->m_groupData.head)
+        curr = curr->m_groupData.pNextWindow.lock();
     return curr;
 }
 
 PHLWINDOW CWindow::getGroupTail() {
-    PHLWINDOW curr = m_pSelf.lock();
-    while (!curr->m_sGroupData.pNextWindow->m_sGroupData.head)
-        curr = curr->m_sGroupData.pNextWindow.lock();
+    PHLWINDOW curr = m_self.lock();
+    while (!curr->m_groupData.pNextWindow->m_groupData.head)
+        curr = curr->m_groupData.pNextWindow.lock();
     return curr;
 }
 
 PHLWINDOW CWindow::getGroupCurrent() {
-    PHLWINDOW curr = m_pSelf.lock();
+    PHLWINDOW curr = m_self.lock();
     while (curr->isHidden())
-        curr = curr->m_sGroupData.pNextWindow.lock();
+        curr = curr->m_groupData.pNextWindow.lock();
     return curr;
 }
 
 int CWindow::getGroupSize() {
     int       size = 1;
-    PHLWINDOW curr = m_pSelf.lock();
-    while (curr->m_sGroupData.pNextWindow != m_pSelf) {
-        curr = curr->m_sGroupData.pNextWindow.lock();
+    PHLWINDOW curr = m_self.lock();
+    while (curr->m_groupData.pNextWindow != m_self) {
+        curr = curr->m_groupData.pNextWindow.lock();
         size++;
     }
     return size;
@@ -998,15 +998,15 @@ int CWindow::getGroupSize() {
 
 bool CWindow::canBeGroupedInto(PHLWINDOW pWindow) {
     static auto ALLOWGROUPMERGE       = CConfigValue<Hyprlang::INT>("group:merge_groups_on_drag");
-    bool        isGroup               = m_sGroupData.pNextWindow;
+    bool        isGroup               = m_groupData.pNextWindow;
     bool        disallowDragIntoGroup = g_pInputManager->m_bWasDraggingWindow && isGroup && !bool(*ALLOWGROUPMERGE);
-    return !g_pKeybindManager->m_bGroupsLocked                                                 // global group lock disengaged
-        && ((m_eGroupRules & GROUP_INVADE && m_bFirstMap)                                      // window ignore local group locks, or
-            || (!pWindow->getGroupHead()->m_sGroupData.locked                                  //      target unlocked
-                && !(m_sGroupData.pNextWindow.lock() && getGroupHead()->m_sGroupData.locked))) //      source unlocked or isn't group
-        && !m_sGroupData.deny                                                                  // source is not denied entry
-        && !(m_eGroupRules & GROUP_BARRED && m_bFirstMap)                                      // group rule doesn't prevent adding window
-        && !disallowDragIntoGroup;                                                             // config allows groups to be merged
+    return !g_pKeybindManager->m_bGroupsLocked                                               // global group lock disengaged
+        && ((m_groupRules & GROUP_INVADE && m_firstMap)                                      // window ignore local group locks, or
+            || (!pWindow->getGroupHead()->m_groupData.locked                                 //      target unlocked
+                && !(m_groupData.pNextWindow.lock() && getGroupHead()->m_groupData.locked))) //      source unlocked or isn't group
+        && !m_groupData.deny                                                                 // source is not denied entry
+        && !(m_groupRules & GROUP_BARRED && m_firstMap)                                      // group rule doesn't prevent adding window
+        && !disallowDragIntoGroup;                                                           // config allows groups to be merged
 }
 
 PHLWINDOW CWindow::getGroupWindowByIndex(int index) {
@@ -1014,21 +1014,21 @@ PHLWINDOW CWindow::getGroupWindowByIndex(int index) {
     index          = ((index % SIZE) + SIZE) % SIZE;
     PHLWINDOW curr = getGroupHead();
     while (index > 0) {
-        curr = curr->m_sGroupData.pNextWindow.lock();
+        curr = curr->m_groupData.pNextWindow.lock();
         index--;
     }
     return curr;
 }
 
 void CWindow::setGroupCurrent(PHLWINDOW pWindow) {
-    PHLWINDOW curr     = m_sGroupData.pNextWindow.lock();
+    PHLWINDOW curr     = m_groupData.pNextWindow.lock();
     bool      isMember = false;
     while (curr.get() != this) {
         if (curr == pWindow) {
             isMember = true;
             break;
         }
-        curr = curr->m_sGroupData.pNextWindow.lock();
+        curr = curr->m_groupData.pNextWindow.lock();
     }
 
     if (!isMember && pWindow.get() != this)
@@ -1036,25 +1036,25 @@ void CWindow::setGroupCurrent(PHLWINDOW pWindow) {
 
     const auto PCURRENT   = getGroupCurrent();
     const bool FULLSCREEN = PCURRENT->isFullscreen();
-    const auto WORKSPACE  = PCURRENT->m_pWorkspace;
-    const auto MODE       = PCURRENT->m_sFullscreenState.internal;
+    const auto WORKSPACE  = PCURRENT->m_workspace;
+    const auto MODE       = PCURRENT->m_fullscreenState.internal;
 
     const auto CURRENTISFOCUS = PCURRENT == g_pCompositor->m_lastWindow.lock();
 
     if (FULLSCREEN)
         g_pCompositor->setWindowFullscreenInternal(PCURRENT, FSMODE_NONE);
 
-    const auto PWINDOWSIZE = PCURRENT->m_vRealSize->goal();
-    const auto PWINDOWPOS  = PCURRENT->m_vRealPosition->goal();
+    const auto PWINDOWSIZE = PCURRENT->m_realSize->goal();
+    const auto PWINDOWPOS  = PCURRENT->m_realPosition->goal();
 
     PCURRENT->setHidden(true);
     pWindow->setHidden(false); // can remove m_pLastWindow
 
     g_pLayoutManager->getCurrentLayout()->replaceWindowDataWith(PCURRENT, pWindow);
 
-    if (PCURRENT->m_bIsFloating) {
-        pWindow->m_vRealPosition->setValueAndWarp(PWINDOWPOS);
-        pWindow->m_vRealSize->setValueAndWarp(PWINDOWSIZE);
+    if (PCURRENT->m_isFloating) {
+        pWindow->m_realPosition->setValueAndWarp(PWINDOWPOS);
+        pWindow->m_realSize->setValueAndWarp(PWINDOWSIZE);
     }
 
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
@@ -1071,126 +1071,126 @@ void CWindow::setGroupCurrent(PHLWINDOW pWindow) {
 }
 
 void CWindow::insertWindowToGroup(PHLWINDOW pWindow) {
-    const auto BEGINAT = m_pSelf.lock();
-    const auto ENDAT   = m_sGroupData.pNextWindow.lock();
+    const auto BEGINAT = m_self.lock();
+    const auto ENDAT   = m_groupData.pNextWindow.lock();
 
     if (!pWindow->getDecorationByType(DECORATION_GROUPBAR))
         pWindow->addWindowDeco(makeUnique<CHyprGroupBarDecoration>(pWindow));
 
-    if (!pWindow->m_sGroupData.pNextWindow.lock()) {
-        BEGINAT->m_sGroupData.pNextWindow = pWindow;
-        pWindow->m_sGroupData.pNextWindow = ENDAT;
-        pWindow->m_sGroupData.head        = false;
+    if (!pWindow->m_groupData.pNextWindow.lock()) {
+        BEGINAT->m_groupData.pNextWindow = pWindow;
+        pWindow->m_groupData.pNextWindow = ENDAT;
+        pWindow->m_groupData.head        = false;
         return;
     }
 
     const auto SHEAD = pWindow->getGroupHead();
     const auto STAIL = pWindow->getGroupTail();
 
-    SHEAD->m_sGroupData.head          = false;
-    BEGINAT->m_sGroupData.pNextWindow = SHEAD;
-    STAIL->m_sGroupData.pNextWindow   = ENDAT;
+    SHEAD->m_groupData.head          = false;
+    BEGINAT->m_groupData.pNextWindow = SHEAD;
+    STAIL->m_groupData.pNextWindow   = ENDAT;
 }
 
 PHLWINDOW CWindow::getGroupPrevious() {
-    PHLWINDOW curr = m_sGroupData.pNextWindow.lock();
+    PHLWINDOW curr = m_groupData.pNextWindow.lock();
 
-    while (curr != m_pSelf && curr->m_sGroupData.pNextWindow != m_pSelf)
-        curr = curr->m_sGroupData.pNextWindow.lock();
+    while (curr != m_self && curr->m_groupData.pNextWindow != m_self)
+        curr = curr->m_groupData.pNextWindow.lock();
 
     return curr;
 }
 
 void CWindow::switchWithWindowInGroup(PHLWINDOW pWindow) {
-    if (!m_sGroupData.pNextWindow.lock() || !pWindow->m_sGroupData.pNextWindow.lock())
+    if (!m_groupData.pNextWindow.lock() || !pWindow->m_groupData.pNextWindow.lock())
         return;
 
-    if (m_sGroupData.pNextWindow.lock() == pWindow) { // A -> this -> pWindow -> B >> A -> pWindow -> this -> B
-        getGroupPrevious()->m_sGroupData.pNextWindow = pWindow;
-        m_sGroupData.pNextWindow                     = pWindow->m_sGroupData.pNextWindow;
-        pWindow->m_sGroupData.pNextWindow            = m_pSelf;
+    if (m_groupData.pNextWindow.lock() == pWindow) { // A -> this -> pWindow -> B >> A -> pWindow -> this -> B
+        getGroupPrevious()->m_groupData.pNextWindow = pWindow;
+        m_groupData.pNextWindow                     = pWindow->m_groupData.pNextWindow;
+        pWindow->m_groupData.pNextWindow            = m_self;
 
-    } else if (pWindow->m_sGroupData.pNextWindow == m_pSelf) { // A -> pWindow -> this -> B >> A -> this -> pWindow -> B
-        pWindow->getGroupPrevious()->m_sGroupData.pNextWindow = m_pSelf;
-        pWindow->m_sGroupData.pNextWindow                     = m_sGroupData.pNextWindow;
-        m_sGroupData.pNextWindow                              = pWindow;
+    } else if (pWindow->m_groupData.pNextWindow == m_self) { // A -> pWindow -> this -> B >> A -> this -> pWindow -> B
+        pWindow->getGroupPrevious()->m_groupData.pNextWindow = m_self;
+        pWindow->m_groupData.pNextWindow                     = m_groupData.pNextWindow;
+        m_groupData.pNextWindow                              = pWindow;
 
     } else { // A -> this -> B | C -> pWindow -> D >> A -> pWindow -> B | C -> this -> D
-        std::swap(m_sGroupData.pNextWindow, pWindow->m_sGroupData.pNextWindow);
-        std::swap(getGroupPrevious()->m_sGroupData.pNextWindow, pWindow->getGroupPrevious()->m_sGroupData.pNextWindow);
+        std::swap(m_groupData.pNextWindow, pWindow->m_groupData.pNextWindow);
+        std::swap(getGroupPrevious()->m_groupData.pNextWindow, pWindow->getGroupPrevious()->m_groupData.pNextWindow);
     }
 
-    std::swap(m_sGroupData.head, pWindow->m_sGroupData.head);
-    std::swap(m_sGroupData.locked, pWindow->m_sGroupData.locked);
+    std::swap(m_groupData.head, pWindow->m_groupData.head);
+    std::swap(m_groupData.locked, pWindow->m_groupData.locked);
 }
 
 void CWindow::updateGroupOutputs() {
-    if (m_sGroupData.pNextWindow.expired())
+    if (m_groupData.pNextWindow.expired())
         return;
 
-    PHLWINDOW  curr = m_sGroupData.pNextWindow.lock();
+    PHLWINDOW  curr = m_groupData.pNextWindow.lock();
 
-    const auto WS = m_pWorkspace;
+    const auto WS = m_workspace;
 
     while (curr.get() != this) {
-        curr->m_pMonitor = m_pMonitor;
+        curr->m_monitor = m_monitor;
         curr->moveToWorkspace(WS);
 
-        *curr->m_vRealPosition = m_vRealPosition->goal();
-        *curr->m_vRealSize     = m_vRealSize->goal();
+        *curr->m_realPosition = m_realPosition->goal();
+        *curr->m_realSize     = m_realSize->goal();
 
-        curr = curr->m_sGroupData.pNextWindow.lock();
+        curr = curr->m_groupData.pNextWindow.lock();
     }
 }
 
 Vector2D CWindow::middle() {
-    return m_vRealPosition->goal() + m_vRealSize->goal() / 2.f;
+    return m_realPosition->goal() + m_realSize->goal() / 2.f;
 }
 
 bool CWindow::opaque() {
-    if (m_fAlpha->value() != 1.f || m_fActiveInactiveAlpha->value() != 1.f)
+    if (m_alpha->value() != 1.f || m_activeInactiveAlpha->value() != 1.f)
         return false;
 
-    const auto PWORKSPACE = m_pWorkspace;
+    const auto PWORKSPACE = m_workspace;
 
-    if (m_pWLSurface->small() && !m_pWLSurface->m_fillIgnoreSmall)
+    if (m_wlSurface->small() && !m_wlSurface->m_fillIgnoreSmall)
         return false;
 
     if (PWORKSPACE->m_alpha->value() != 1.f)
         return false;
 
-    if (m_bIsX11 && m_pXWaylandSurface && m_pXWaylandSurface->surface && m_pXWaylandSurface->surface->current.texture)
-        return m_pXWaylandSurface->surface->current.texture->m_bOpaque;
+    if (m_isX11 && m_xwaylandSurface && m_xwaylandSurface->surface && m_xwaylandSurface->surface->current.texture)
+        return m_xwaylandSurface->surface->current.texture->m_bOpaque;
 
-    if (!m_pWLSurface->resource() || !m_pWLSurface->resource()->current.texture)
+    if (!m_wlSurface->resource() || !m_wlSurface->resource()->current.texture)
         return false;
 
     // TODO: this is wrong
-    const auto EXTENTS = m_pXDGSurface->surface->current.opaque.getExtents();
-    if (EXTENTS.w >= m_pXDGSurface->surface->current.bufferSize.x && EXTENTS.h >= m_pXDGSurface->surface->current.bufferSize.y)
+    const auto EXTENTS = m_xdgSurface->surface->current.opaque.getExtents();
+    if (EXTENTS.w >= m_xdgSurface->surface->current.bufferSize.x && EXTENTS.h >= m_xdgSurface->surface->current.bufferSize.y)
         return true;
 
-    return m_pWLSurface->resource()->current.texture->m_bOpaque;
+    return m_wlSurface->resource()->current.texture->m_bOpaque;
 }
 
 float CWindow::rounding() {
     static auto PROUNDING      = CConfigValue<Hyprlang::INT>("decoration:rounding");
     static auto PROUNDINGPOWER = CConfigValue<Hyprlang::FLOAT>("decoration:rounding_power");
 
-    float       roundingPower = m_sWindowData.roundingPower.valueOr(*PROUNDINGPOWER);
-    float       rounding      = m_sWindowData.rounding.valueOr(*PROUNDING) * (roundingPower / 2.0); /* Make perceived roundness consistent. */
+    float       roundingPower = m_windowData.roundingPower.valueOr(*PROUNDINGPOWER);
+    float       rounding      = m_windowData.rounding.valueOr(*PROUNDING) * (roundingPower / 2.0); /* Make perceived roundness consistent. */
 
-    return m_sWindowData.noRounding.valueOrDefault() ? 0 : rounding;
+    return m_windowData.noRounding.valueOrDefault() ? 0 : rounding;
 }
 
 float CWindow::roundingPower() {
     static auto PROUNDINGPOWER = CConfigValue<Hyprlang::FLOAT>("decoration:rounding_power");
 
-    return m_sWindowData.roundingPower.valueOr(*PROUNDINGPOWER);
+    return m_windowData.roundingPower.valueOr(*PROUNDINGPOWER);
 }
 
 void CWindow::updateWindowData() {
-    const auto PWORKSPACE    = m_pWorkspace;
+    const auto PWORKSPACE    = m_workspace;
     const auto WORKSPACERULE = PWORKSPACE ? g_pConfigManager->getWorkspaceRuleFor(PWORKSPACE) : SWorkspaceRule{};
     updateWindowData(WORKSPACERULE);
 }
@@ -1199,76 +1199,76 @@ void CWindow::updateWindowData(const SWorkspaceRule& workspaceRule) {
     static auto PNOBORDERONFLOATING = CConfigValue<Hyprlang::INT>("general:no_border_on_floating");
 
     if (*PNOBORDERONFLOATING)
-        m_sWindowData.noBorder = CWindowOverridableVar(m_bIsFloating, PRIORITY_LAYOUT);
+        m_windowData.noBorder = CWindowOverridableVar(m_isFloating, PRIORITY_LAYOUT);
     else
-        m_sWindowData.noBorder.unset(PRIORITY_LAYOUT);
+        m_windowData.noBorder.unset(PRIORITY_LAYOUT);
 
-    m_sWindowData.borderSize.matchOptional(workspaceRule.borderSize, PRIORITY_WORKSPACE_RULE);
-    m_sWindowData.decorate.matchOptional(workspaceRule.decorate, PRIORITY_WORKSPACE_RULE);
-    m_sWindowData.noBorder.matchOptional(workspaceRule.noBorder, PRIORITY_WORKSPACE_RULE);
-    m_sWindowData.noRounding.matchOptional(workspaceRule.noRounding, PRIORITY_WORKSPACE_RULE);
-    m_sWindowData.noShadow.matchOptional(workspaceRule.noShadow, PRIORITY_WORKSPACE_RULE);
+    m_windowData.borderSize.matchOptional(workspaceRule.borderSize, PRIORITY_WORKSPACE_RULE);
+    m_windowData.decorate.matchOptional(workspaceRule.decorate, PRIORITY_WORKSPACE_RULE);
+    m_windowData.noBorder.matchOptional(workspaceRule.noBorder, PRIORITY_WORKSPACE_RULE);
+    m_windowData.noRounding.matchOptional(workspaceRule.noRounding, PRIORITY_WORKSPACE_RULE);
+    m_windowData.noShadow.matchOptional(workspaceRule.noShadow, PRIORITY_WORKSPACE_RULE);
 }
 
 int CWindow::getRealBorderSize() {
-    if (m_sWindowData.noBorder.valueOrDefault() || (m_pWorkspace && isEffectiveInternalFSMode(FSMODE_FULLSCREEN)))
+    if (m_windowData.noBorder.valueOrDefault() || (m_workspace && isEffectiveInternalFSMode(FSMODE_FULLSCREEN)))
         return 0;
 
     static auto PBORDERSIZE = CConfigValue<Hyprlang::INT>("general:border_size");
 
-    return m_sWindowData.borderSize.valueOr(*PBORDERSIZE);
+    return m_windowData.borderSize.valueOr(*PBORDERSIZE);
 }
 
 float CWindow::getScrollMouse() {
     static auto PINPUTSCROLLFACTOR = CConfigValue<Hyprlang::FLOAT>("input:scroll_factor");
-    return m_sWindowData.scrollMouse.valueOr(*PINPUTSCROLLFACTOR);
+    return m_windowData.scrollMouse.valueOr(*PINPUTSCROLLFACTOR);
 }
 
 float CWindow::getScrollTouchpad() {
     static auto PTOUCHPADSCROLLFACTOR = CConfigValue<Hyprlang::FLOAT>("input:touchpad:scroll_factor");
-    return m_sWindowData.scrollTouchpad.valueOr(*PTOUCHPADSCROLLFACTOR);
+    return m_windowData.scrollTouchpad.valueOr(*PTOUCHPADSCROLLFACTOR);
 }
 
 bool CWindow::canBeTorn() {
     static auto PTEARING = CConfigValue<Hyprlang::INT>("general:allow_tearing");
-    return m_sWindowData.tearing.valueOr(m_bTearingHint) && *PTEARING;
+    return m_windowData.tearing.valueOr(m_tearingHint) && *PTEARING;
 }
 
 void CWindow::setSuspended(bool suspend) {
-    if (suspend == m_bSuspended)
+    if (suspend == m_suspended)
         return;
 
-    if (m_bIsX11 || !m_pXDGSurface || !m_pXDGSurface->toplevel)
+    if (m_isX11 || !m_xdgSurface || !m_xdgSurface->toplevel)
         return;
 
-    m_pXDGSurface->toplevel->setSuspeneded(suspend);
-    m_bSuspended = suspend;
+    m_xdgSurface->toplevel->setSuspeneded(suspend);
+    m_suspended = suspend;
 }
 
 bool CWindow::visibleOnMonitor(PHLMONITOR pMonitor) {
-    CBox wbox = {m_vRealPosition->value(), m_vRealSize->value()};
+    CBox wbox = {m_realPosition->value(), m_realSize->value()};
 
     return !wbox.intersection({pMonitor->vecPosition, pMonitor->vecSize}).empty();
 }
 
 void CWindow::setAnimationsToMove() {
-    m_vRealPosition->setConfig(g_pConfigManager->getAnimationPropertyConfig("windowsMove"));
-    m_bAnimatingIn = false;
+    m_realPosition->setConfig(g_pConfigManager->getAnimationPropertyConfig("windowsMove"));
+    m_animatingIn = false;
 }
 
 void CWindow::onWorkspaceAnimUpdate() {
     // clip box for animated offsets
-    if (!m_bIsFloating || m_bPinned || isFullscreen() || m_bDraggingTiled) {
-        m_vFloatingOffset = Vector2D(0, 0);
+    if (!m_isFloating || m_pinned || isFullscreen() || m_draggingTiled) {
+        m_floatingOffset = Vector2D(0, 0);
         return;
     }
 
     Vector2D   offset;
-    const auto PWORKSPACE = m_pWorkspace;
+    const auto PWORKSPACE = m_workspace;
     if (!PWORKSPACE)
         return;
 
-    const auto PWSMON = m_pMonitor.lock();
+    const auto PWSMON = m_monitor.lock();
     if (!PWSMON)
         return;
 
@@ -1291,62 +1291,62 @@ void CWindow::onWorkspaceAnimUpdate() {
             offset.y += (WINBB.y + WINBB.height - PWSMON->vecPosition.y - PWSMON->vecSize.y) * PROGRESS;
     }
 
-    m_vFloatingOffset = offset;
+    m_floatingOffset = offset;
 }
 
 void CWindow::onFocusAnimUpdate() {
     // borderangle once
-    if (m_fBorderAngleAnimationProgress->enabled() && !m_fBorderAngleAnimationProgress->isBeingAnimated()) {
-        m_fBorderAngleAnimationProgress->setValueAndWarp(0.f);
-        *m_fBorderAngleAnimationProgress = 1.f;
+    if (m_borderAngleAnimationProgress->enabled() && !m_borderAngleAnimationProgress->isBeingAnimated()) {
+        m_borderAngleAnimationProgress->setValueAndWarp(0.f);
+        *m_borderAngleAnimationProgress = 1.f;
     }
 }
 
 int CWindow::popupsCount() {
-    if (m_bIsX11)
+    if (m_isX11)
         return 0;
 
     int no = -1;
-    m_pPopupHead->breadthfirst([](WP<CPopup> p, void* d) { *((int*)d) += 1; }, &no);
+    m_popupHead->breadthfirst([](WP<CPopup> p, void* d) { *((int*)d) += 1; }, &no);
     return no;
 }
 
 int CWindow::surfacesCount() {
-    if (m_bIsX11)
+    if (m_isX11)
         return 1;
 
     int no = 0;
-    m_pWLSurface->resource()->breadthfirst([](SP<CWLSurfaceResource> r, const Vector2D& offset, void* d) { *((int*)d) += 1; }, &no);
+    m_wlSurface->resource()->breadthfirst([](SP<CWLSurfaceResource> r, const Vector2D& offset, void* d) { *((int*)d) += 1; }, &no);
     return no;
 }
 
 void CWindow::clampWindowSize(const std::optional<Vector2D> minSize, const std::optional<Vector2D> maxSize) {
-    const Vector2D REALSIZE = m_vRealSize->goal();
+    const Vector2D REALSIZE = m_realSize->goal();
     const Vector2D NEWSIZE  = REALSIZE.clamp(minSize.value_or(Vector2D{MIN_WINDOW_SIZE, MIN_WINDOW_SIZE}), maxSize.value_or(Vector2D{INFINITY, INFINITY}));
     const Vector2D DELTA    = REALSIZE - NEWSIZE;
 
-    *m_vRealPosition = m_vRealPosition->goal() + DELTA / 2.0;
-    *m_vRealSize     = NEWSIZE;
+    *m_realPosition = m_realPosition->goal() + DELTA / 2.0;
+    *m_realSize     = NEWSIZE;
 }
 
 bool CWindow::isFullscreen() {
-    return m_sFullscreenState.internal != FSMODE_NONE;
+    return m_fullscreenState.internal != FSMODE_NONE;
 }
 
 bool CWindow::isEffectiveInternalFSMode(const eFullscreenMode MODE) {
-    return (eFullscreenMode)std::bit_floor((uint8_t)m_sFullscreenState.internal) == MODE;
+    return (eFullscreenMode)std::bit_floor((uint8_t)m_fullscreenState.internal) == MODE;
 }
 
 WORKSPACEID CWindow::workspaceID() {
-    return m_pWorkspace ? m_pWorkspace->m_id : m_iLastWorkspace;
+    return m_workspace ? m_workspace->m_id : m_lastWorkspace;
 }
 
 MONITORID CWindow::monitorID() {
-    return m_pMonitor ? m_pMonitor->ID : MONITOR_INVALID;
+    return m_monitor ? m_monitor->ID : MONITOR_INVALID;
 }
 
 bool CWindow::onSpecialWorkspace() {
-    return m_pWorkspace ? m_pWorkspace->m_isSpecialWorkspace : g_pCompositor->isWorkspaceSpecial(m_iLastWorkspace);
+    return m_workspace ? m_workspace->m_isSpecialWorkspace : g_pCompositor->isWorkspaceSpecial(m_lastWorkspace);
 }
 
 std::unordered_map<std::string, std::string> CWindow::getEnv() {
@@ -1392,59 +1392,59 @@ std::unordered_map<std::string, std::string> CWindow::getEnv() {
 }
 
 void CWindow::activate(bool force) {
-    if (g_pCompositor->m_lastWindow == m_pSelf)
+    if (g_pCompositor->m_lastWindow == m_self)
         return;
 
     static auto PFOCUSONACTIVATE = CConfigValue<Hyprlang::INT>("misc:focus_on_activate");
 
-    m_bIsUrgent = true;
+    m_isUrgent = true;
 
     g_pEventManager->postEvent(SHyprIPCEvent{"urgent", std::format("{:x}", (uintptr_t)this)});
-    EMIT_HOOK_EVENT("urgent", m_pSelf.lock());
+    EMIT_HOOK_EVENT("urgent", m_self.lock());
 
-    if (!force && (!m_sWindowData.focusOnActivate.valueOr(*PFOCUSONACTIVATE) || (m_eSuppressedEvents & SUPPRESS_ACTIVATE_FOCUSONLY) || (m_eSuppressedEvents & SUPPRESS_ACTIVATE)))
+    if (!force && (!m_windowData.focusOnActivate.valueOr(*PFOCUSONACTIVATE) || (m_suppressedEvents & SUPPRESS_ACTIVATE_FOCUSONLY) || (m_suppressedEvents & SUPPRESS_ACTIVATE)))
         return;
 
-    if (!m_bIsMapped) {
+    if (!m_isMapped) {
         Debug::log(LOG, "Ignoring CWindow::activate focus/warp, window is not mapped yet.");
         return;
     }
 
-    if (m_bIsFloating)
-        g_pCompositor->changeWindowZOrder(m_pSelf.lock(), true);
+    if (m_isFloating)
+        g_pCompositor->changeWindowZOrder(m_self.lock(), true);
 
-    g_pCompositor->focusWindow(m_pSelf.lock());
+    g_pCompositor->focusWindow(m_self.lock());
     warpCursor();
 }
 
 void CWindow::onUpdateState() {
-    std::optional<bool>      requestsFS = m_pXDGSurface ? m_pXDGSurface->toplevel->state.requestsFullscreen : m_pXWaylandSurface->state.requestsFullscreen;
-    std::optional<MONITORID> requestsID = m_pXDGSurface ? m_pXDGSurface->toplevel->state.requestsFullscreenMonitor : MONITOR_INVALID;
-    std::optional<bool>      requestsMX = m_pXDGSurface ? m_pXDGSurface->toplevel->state.requestsMaximize : m_pXWaylandSurface->state.requestsMaximize;
+    std::optional<bool>      requestsFS = m_xdgSurface ? m_xdgSurface->toplevel->state.requestsFullscreen : m_xwaylandSurface->state.requestsFullscreen;
+    std::optional<MONITORID> requestsID = m_xdgSurface ? m_xdgSurface->toplevel->state.requestsFullscreenMonitor : MONITOR_INVALID;
+    std::optional<bool>      requestsMX = m_xdgSurface ? m_xdgSurface->toplevel->state.requestsMaximize : m_xwaylandSurface->state.requestsMaximize;
 
-    if (requestsFS.has_value() && !(m_eSuppressedEvents & SUPPRESS_FULLSCREEN)) {
-        if (requestsID.has_value() && (requestsID.value() != MONITOR_INVALID) && !(m_eSuppressedEvents & SUPPRESS_FULLSCREEN_OUTPUT)) {
-            if (m_bIsMapped) {
+    if (requestsFS.has_value() && !(m_suppressedEvents & SUPPRESS_FULLSCREEN)) {
+        if (requestsID.has_value() && (requestsID.value() != MONITOR_INVALID) && !(m_suppressedEvents & SUPPRESS_FULLSCREEN_OUTPUT)) {
+            if (m_isMapped) {
                 const auto monitor = g_pCompositor->getMonitorFromID(requestsID.value());
-                g_pCompositor->moveWindowToWorkspaceSafe(m_pSelf.lock(), monitor->activeWorkspace);
+                g_pCompositor->moveWindowToWorkspaceSafe(m_self.lock(), monitor->activeWorkspace);
                 g_pCompositor->setActiveMonitor(monitor);
             }
 
-            if (!m_bIsMapped)
-                m_iWantsInitialFullscreenMonitor = requestsID.value();
+            if (!m_isMapped)
+                m_wantsInitialFullscreenMonitor = requestsID.value();
         }
 
         bool fs = requestsFS.value();
-        if (m_bIsMapped)
-            g_pCompositor->changeWindowFullscreenModeClient(m_pSelf.lock(), FSMODE_FULLSCREEN, requestsFS.value());
+        if (m_isMapped)
+            g_pCompositor->changeWindowFullscreenModeClient(m_self.lock(), FSMODE_FULLSCREEN, requestsFS.value());
 
-        if (!m_bIsMapped)
-            m_bWantsInitialFullscreen = fs;
+        if (!m_isMapped)
+            m_wantsInitialFullscreen = fs;
     }
 
-    if (requestsMX.has_value() && !(m_eSuppressedEvents & SUPPRESS_MAXIMIZE)) {
-        if (m_bIsMapped)
-            g_pCompositor->changeWindowFullscreenModeClient(m_pSelf.lock(), FSMODE_MAXIMIZED, requestsMX.value());
+    if (requestsMX.has_value() && !(m_suppressedEvents & SUPPRESS_MAXIMIZE)) {
+        if (m_isMapped)
+            g_pCompositor->changeWindowFullscreenModeClient(m_self.lock(), FSMODE_MAXIMIZED, requestsMX.value());
     }
 }
 
@@ -1452,107 +1452,107 @@ void CWindow::onUpdateMeta() {
     const auto NEWTITLE = fetchTitle();
     bool       doUpdate = false;
 
-    if (m_szTitle != NEWTITLE) {
-        m_szTitle = NEWTITLE;
+    if (m_title != NEWTITLE) {
+        m_title = NEWTITLE;
         g_pEventManager->postEvent(SHyprIPCEvent{"windowtitle", std::format("{:x}", (uintptr_t)this)});
-        g_pEventManager->postEvent(SHyprIPCEvent{"windowtitlev2", std::format("{:x},{}", (uintptr_t)this, m_szTitle)});
-        EMIT_HOOK_EVENT("windowTitle", m_pSelf.lock());
+        g_pEventManager->postEvent(SHyprIPCEvent{"windowtitlev2", std::format("{:x},{}", (uintptr_t)this, m_title)});
+        EMIT_HOOK_EVENT("windowTitle", m_self.lock());
 
-        if (m_pSelf == g_pCompositor->m_lastWindow) { // if it's the active, let's post an event to update others
-            g_pEventManager->postEvent(SHyprIPCEvent{"activewindow", m_szClass + "," + m_szTitle});
+        if (m_self == g_pCompositor->m_lastWindow) { // if it's the active, let's post an event to update others
+            g_pEventManager->postEvent(SHyprIPCEvent{"activewindow", m_class + "," + m_title});
             g_pEventManager->postEvent(SHyprIPCEvent{"activewindowv2", std::format("{:x}", (uintptr_t)this)});
-            EMIT_HOOK_EVENT("activeWindow", m_pSelf.lock());
+            EMIT_HOOK_EVENT("activeWindow", m_self.lock());
         }
 
-        Debug::log(LOG, "Window {:x} set title to {}", (uintptr_t)this, m_szTitle);
+        Debug::log(LOG, "Window {:x} set title to {}", (uintptr_t)this, m_title);
         doUpdate = true;
     }
 
     const auto NEWCLASS = fetchClass();
-    if (m_szClass != NEWCLASS) {
-        m_szClass = NEWCLASS;
+    if (m_class != NEWCLASS) {
+        m_class = NEWCLASS;
 
-        if (m_pSelf == g_pCompositor->m_lastWindow) { // if it's the active, let's post an event to update others
-            g_pEventManager->postEvent(SHyprIPCEvent{"activewindow", m_szClass + "," + m_szTitle});
+        if (m_self == g_pCompositor->m_lastWindow) { // if it's the active, let's post an event to update others
+            g_pEventManager->postEvent(SHyprIPCEvent{"activewindow", m_class + "," + m_title});
             g_pEventManager->postEvent(SHyprIPCEvent{"activewindowv2", std::format("{:x}", (uintptr_t)this)});
-            EMIT_HOOK_EVENT("activeWindow", m_pSelf.lock());
+            EMIT_HOOK_EVENT("activeWindow", m_self.lock());
         }
 
-        Debug::log(LOG, "Window {:x} set class to {}", (uintptr_t)this, m_szClass);
+        Debug::log(LOG, "Window {:x} set class to {}", (uintptr_t)this, m_class);
         doUpdate = true;
     }
 
     if (doUpdate) {
         updateDynamicRules();
-        g_pCompositor->updateWindowAnimatedDecorationValues(m_pSelf.lock());
+        g_pCompositor->updateWindowAnimatedDecorationValues(m_self.lock());
         updateToplevel();
     }
 }
 
 std::string CWindow::fetchTitle() {
-    if (!m_bIsX11) {
-        if (m_pXDGSurface && m_pXDGSurface->toplevel)
-            return m_pXDGSurface->toplevel->state.title;
+    if (!m_isX11) {
+        if (m_xdgSurface && m_xdgSurface->toplevel)
+            return m_xdgSurface->toplevel->state.title;
     } else {
-        if (m_pXWaylandSurface)
-            return m_pXWaylandSurface->state.title;
+        if (m_xwaylandSurface)
+            return m_xwaylandSurface->state.title;
     }
 
     return "";
 }
 
 std::string CWindow::fetchClass() {
-    if (!m_bIsX11) {
-        if (m_pXDGSurface && m_pXDGSurface->toplevel)
-            return m_pXDGSurface->toplevel->state.appid;
+    if (!m_isX11) {
+        if (m_xdgSurface && m_xdgSurface->toplevel)
+            return m_xdgSurface->toplevel->state.appid;
     } else {
-        if (m_pXWaylandSurface)
-            return m_pXWaylandSurface->state.appid;
+        if (m_xwaylandSurface)
+            return m_xwaylandSurface->state.appid;
     }
 
     return "";
 }
 
 void CWindow::onAck(uint32_t serial) {
-    const auto SERIAL = std::find_if(m_vPendingSizeAcks.rbegin(), m_vPendingSizeAcks.rend(), [serial](const auto& e) { return e.first == serial; });
+    const auto SERIAL = std::find_if(m_pendingSizeAcks.rbegin(), m_pendingSizeAcks.rend(), [serial](const auto& e) { return e.first == serial; });
 
-    if (SERIAL == m_vPendingSizeAcks.rend())
+    if (SERIAL == m_pendingSizeAcks.rend())
         return;
 
-    m_pPendingSizeAck = *SERIAL;
-    std::erase_if(m_vPendingSizeAcks, [&](const auto& el) { return el.first <= SERIAL->first; });
+    m_pendingSizeAck = *SERIAL;
+    std::erase_if(m_pendingSizeAcks, [&](const auto& el) { return el.first <= SERIAL->first; });
 }
 
 void CWindow::onResourceChangeX11() {
-    if (m_pXWaylandSurface->surface && !m_pWLSurface->resource())
-        m_pWLSurface->assign(m_pXWaylandSurface->surface.lock(), m_pSelf.lock());
-    else if (!m_pXWaylandSurface->surface && m_pWLSurface->resource())
-        m_pWLSurface->unassign();
+    if (m_xwaylandSurface->surface && !m_wlSurface->resource())
+        m_wlSurface->assign(m_xwaylandSurface->surface.lock(), m_self.lock());
+    else if (!m_xwaylandSurface->surface && m_wlSurface->resource())
+        m_wlSurface->unassign();
 
     // update metadata as well,
     // could be first assoc and we need to catch the class
     onUpdateMeta();
 
-    Debug::log(LOG, "xwayland window {:x} -> association to {:x}", (uintptr_t)m_pXWaylandSurface.get(), (uintptr_t)m_pWLSurface->resource().get());
+    Debug::log(LOG, "xwayland window {:x} -> association to {:x}", (uintptr_t)m_xwaylandSurface.get(), (uintptr_t)m_wlSurface->resource().get());
 }
 
 void CWindow::onX11ConfigureRequest(CBox box) {
 
-    if (!m_pXWaylandSurface->surface || !m_pXWaylandSurface->mapped || !m_bIsMapped) {
-        m_pXWaylandSurface->configure(box);
-        m_vPendingReportedSize = box.size();
-        m_vReportedSize        = box.size();
-        m_vReportedPosition    = box.pos();
+    if (!m_xwaylandSurface->surface || !m_xwaylandSurface->mapped || !m_isMapped) {
+        m_xwaylandSurface->configure(box);
+        m_pendingReportedSize = box.size();
+        m_reportedSize        = box.size();
+        m_reportedPosition    = box.pos();
         updateX11SurfaceScale();
         return;
     }
 
-    g_pHyprRenderer->damageWindow(m_pSelf.lock());
+    g_pHyprRenderer->damageWindow(m_self.lock());
 
-    if (!m_bIsFloating || isFullscreen() || g_pInputManager->currentlyDraggedWindow == m_pSelf) {
+    if (!m_isFloating || isFullscreen() || g_pInputManager->currentlyDraggedWindow == m_self) {
         sendWindowSize(true);
         g_pInputManager->refocus();
-        g_pHyprRenderer->damageWindow(m_pSelf.lock());
+        g_pHyprRenderer->damageWindow(m_self.lock());
         return;
     }
 
@@ -1561,41 +1561,41 @@ void CWindow::onX11ConfigureRequest(CBox box) {
     else
         setHidden(true);
 
-    m_vRealPosition->setValueAndWarp(xwaylandPositionToReal(box.pos()));
-    m_vRealSize->setValueAndWarp(xwaylandSizeToReal(box.size()));
+    m_realPosition->setValueAndWarp(xwaylandPositionToReal(box.pos()));
+    m_realSize->setValueAndWarp(xwaylandSizeToReal(box.size()));
 
-    m_vPosition = m_vRealPosition->goal();
-    m_vSize     = m_vRealSize->goal();
+    m_position = m_realPosition->goal();
+    m_size     = m_realSize->goal();
 
-    if (m_vPendingReportedSize != box.size() || m_vReportedPosition != box.pos()) {
-        m_pXWaylandSurface->configure(box);
-        m_vReportedSize        = box.size();
-        m_vPendingReportedSize = box.size();
-        m_vReportedPosition    = box.pos();
+    if (m_pendingReportedSize != box.size() || m_reportedPosition != box.pos()) {
+        m_xwaylandSurface->configure(box);
+        m_reportedSize        = box.size();
+        m_pendingReportedSize = box.size();
+        m_reportedPosition    = box.pos();
     }
 
     updateX11SurfaceScale();
     updateWindowDecos();
 
-    if (!m_pWorkspace || !m_pWorkspace->isVisible())
+    if (!m_workspace || !m_workspace->isVisible())
         return; // further things are only for visible windows
 
-    m_pWorkspace = g_pCompositor->getMonitorFromVector(m_vRealPosition->goal() + m_vRealSize->goal() / 2.f)->activeWorkspace;
+    m_workspace = g_pCompositor->getMonitorFromVector(m_realPosition->goal() + m_realSize->goal() / 2.f)->activeWorkspace;
 
-    g_pCompositor->changeWindowZOrder(m_pSelf.lock(), true);
+    g_pCompositor->changeWindowZOrder(m_self.lock(), true);
 
-    m_bCreatedOverFullscreen = true;
+    m_createdOverFullscreen = true;
 
-    g_pHyprRenderer->damageWindow(m_pSelf.lock());
+    g_pHyprRenderer->damageWindow(m_self.lock());
 }
 
 void CWindow::warpCursor(bool force) {
-    static auto PERSISTENTWARPS         = CConfigValue<Hyprlang::INT>("cursor:persistent_warps");
-    const auto  coords                  = m_vRelativeCursorCoordsOnLastWarp;
-    m_vRelativeCursorCoordsOnLastWarp.x = -1; // reset m_vRelativeCursorCoordsOnLastWarp
+    static auto PERSISTENTWARPS        = CConfigValue<Hyprlang::INT>("cursor:persistent_warps");
+    const auto  coords                 = m_relativeCursorCoordsOnLastWarp;
+    m_relativeCursorCoordsOnLastWarp.x = -1; // reset m_vRelativeCursorCoordsOnLastWarp
 
-    if (*PERSISTENTWARPS && coords.x > 0 && coords.y > 0 && coords < m_vSize) // don't warp cursor outside the window
-        g_pCompositor->warpCursorTo(m_vPosition + coords, force);
+    if (*PERSISTENTWARPS && coords.x > 0 && coords.y > 0 && coords < m_size) // don't warp cursor outside the window
+        g_pCompositor->warpCursorTo(m_position + coords, force);
     else
         g_pCompositor->warpCursorTo(middle(), force);
 }
@@ -1619,7 +1619,7 @@ PHLWINDOW CWindow::getSwallower() {
             break;
 
         for (auto const& w : g_pCompositor->m_windows) {
-            if (!w->m_bIsMapped || w->isHidden())
+            if (!w->m_isMapped || w->isHidden())
                 continue;
 
             if (w->getPID() == currentPid)
@@ -1628,13 +1628,13 @@ PHLWINDOW CWindow::getSwallower() {
     }
 
     if (!(*PSWALLOWREGEX).empty())
-        std::erase_if(candidates, [&](const auto& other) { return !RE2::FullMatch(other->m_szClass, *PSWALLOWREGEX); });
+        std::erase_if(candidates, [&](const auto& other) { return !RE2::FullMatch(other->m_class, *PSWALLOWREGEX); });
 
     if (candidates.size() == 0)
         return nullptr;
 
     if (!(*PSWALLOWEXREGEX).empty())
-        std::erase_if(candidates, [&](const auto& other) { return RE2::FullMatch(other->m_szTitle, *PSWALLOWEXREGEX); });
+        std::erase_if(candidates, [&](const auto& other) { return RE2::FullMatch(other->m_title, *PSWALLOWEXREGEX); });
 
     if (candidates.size() == 0)
         return nullptr;
@@ -1657,29 +1657,29 @@ PHLWINDOW CWindow::getSwallower() {
 
 void CWindow::unsetWindowData(eOverridePriority priority) {
     for (auto const& element : NWindowProperties::boolWindowProperties) {
-        element.second(m_pSelf.lock())->unset(priority);
+        element.second(m_self.lock())->unset(priority);
     }
     for (auto const& element : NWindowProperties::intWindowProperties) {
-        element.second(m_pSelf.lock())->unset(priority);
+        element.second(m_self.lock())->unset(priority);
     }
     for (auto const& element : NWindowProperties::floatWindowProperties) {
-        element.second(m_pSelf.lock())->unset(priority);
+        element.second(m_self.lock())->unset(priority);
     }
 }
 
 bool CWindow::isX11OverrideRedirect() {
-    return m_pXWaylandSurface && m_pXWaylandSurface->overrideRedirect;
+    return m_xwaylandSurface && m_xwaylandSurface->overrideRedirect;
 }
 
 bool CWindow::isModal() {
-    return (m_pXWaylandSurface && m_pXWaylandSurface->modal);
+    return (m_xwaylandSurface && m_xwaylandSurface->modal);
 }
 
 Vector2D CWindow::requestedMinSize() {
-    if ((m_bIsX11 && !m_pXWaylandSurface->sizeHints) || (!m_bIsX11 && !m_pXDGSurface->toplevel))
+    if ((m_isX11 && !m_xwaylandSurface->sizeHints) || (!m_isX11 && !m_xdgSurface->toplevel))
         return Vector2D(1, 1);
 
-    Vector2D minSize = m_bIsX11 ? Vector2D(m_pXWaylandSurface->sizeHints->min_width, m_pXWaylandSurface->sizeHints->min_height) : m_pXDGSurface->toplevel->layoutMinSize();
+    Vector2D minSize = m_isX11 ? Vector2D(m_xwaylandSurface->sizeHints->min_width, m_xwaylandSurface->sizeHints->min_height) : m_xdgSurface->toplevel->layoutMinSize();
 
     minSize = minSize.clamp({1, 1});
 
@@ -1688,10 +1688,10 @@ Vector2D CWindow::requestedMinSize() {
 
 Vector2D CWindow::requestedMaxSize() {
     constexpr int NO_MAX_SIZE_LIMIT = 99999;
-    if (((m_bIsX11 && !m_pXWaylandSurface->sizeHints) || (!m_bIsX11 && (!m_pXDGSurface || !m_pXDGSurface->toplevel)) || m_sWindowData.noMaxSize.valueOrDefault()))
+    if (((m_isX11 && !m_xwaylandSurface->sizeHints) || (!m_isX11 && (!m_xdgSurface || !m_xdgSurface->toplevel)) || m_windowData.noMaxSize.valueOrDefault()))
         return Vector2D(NO_MAX_SIZE_LIMIT, NO_MAX_SIZE_LIMIT);
 
-    Vector2D maxSize = m_bIsX11 ? Vector2D(m_pXWaylandSurface->sizeHints->max_width, m_pXWaylandSurface->sizeHints->max_height) : m_pXDGSurface->toplevel->layoutMaxSize();
+    Vector2D maxSize = m_isX11 ? Vector2D(m_xwaylandSurface->sizeHints->max_width, m_xwaylandSurface->sizeHints->max_height) : m_xdgSurface->toplevel->layoutMaxSize();
 
     if (maxSize.x < 5)
         maxSize.x = NO_MAX_SIZE_LIMIT;
@@ -1702,13 +1702,13 @@ Vector2D CWindow::requestedMaxSize() {
 }
 
 Vector2D CWindow::realToReportSize() {
-    if (!m_bIsX11)
-        return m_vRealSize->goal().clamp(Vector2D{0, 0}, Vector2D{std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()});
+    if (!m_isX11)
+        return m_realSize->goal().clamp(Vector2D{0, 0}, Vector2D{std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()});
 
     static auto PXWLFORCESCALEZERO = CConfigValue<Hyprlang::INT>("xwayland:force_zero_scaling");
 
-    const auto  REPORTSIZE = m_vRealSize->goal().clamp(Vector2D{1, 1}, Vector2D{std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()});
-    const auto  PMONITOR   = m_pMonitor.lock();
+    const auto  REPORTSIZE = m_realSize->goal().clamp(Vector2D{1, 1}, Vector2D{std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()});
+    const auto  PMONITOR   = m_monitor.lock();
 
     if (*PXWLFORCESCALEZERO && PMONITOR)
         return REPORTSIZE * PMONITOR->scale;
@@ -1717,16 +1717,16 @@ Vector2D CWindow::realToReportSize() {
 }
 
 Vector2D CWindow::realToReportPosition() {
-    if (!m_bIsX11)
-        return m_vRealPosition->goal();
+    if (!m_isX11)
+        return m_realPosition->goal();
 
-    return g_pXWaylandManager->waylandToXWaylandCoords(m_vRealPosition->goal());
+    return g_pXWaylandManager->waylandToXWaylandCoords(m_realPosition->goal());
 }
 
 Vector2D CWindow::xwaylandSizeToReal(Vector2D size) {
     static auto PXWLFORCESCALEZERO = CConfigValue<Hyprlang::INT>("xwayland:force_zero_scaling");
 
-    const auto  PMONITOR = m_pMonitor.lock();
+    const auto  PMONITOR = m_monitor.lock();
     const auto  SIZE     = size.clamp(Vector2D{1, 1}, Vector2D{std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()});
     const auto  SCALE    = *PXWLFORCESCALEZERO ? PMONITOR->scale : 1.0f;
 
@@ -1740,85 +1740,85 @@ Vector2D CWindow::xwaylandPositionToReal(Vector2D pos) {
 void CWindow::updateX11SurfaceScale() {
     static auto PXWLFORCESCALEZERO = CConfigValue<Hyprlang::INT>("xwayland:force_zero_scaling");
 
-    m_fX11SurfaceScaledBy = 1.0f;
-    if (m_bIsX11 && *PXWLFORCESCALEZERO) {
-        if (const auto PMONITOR = m_pMonitor.lock(); PMONITOR)
-            m_fX11SurfaceScaledBy = PMONITOR->scale;
+    m_X11SurfaceScaledBy = 1.0f;
+    if (m_isX11 && *PXWLFORCESCALEZERO) {
+        if (const auto PMONITOR = m_monitor.lock(); PMONITOR)
+            m_X11SurfaceScaledBy = PMONITOR->scale;
     }
 }
 
 void CWindow::sendWindowSize(bool force) {
-    const auto PMONITOR = m_pMonitor.lock();
+    const auto PMONITOR = m_monitor.lock();
 
-    Debug::log(TRACE, "sendWindowSize: window:{:x},title:{} with real pos {}, real size {} (force: {})", (uintptr_t)this, this->m_szTitle, m_vRealPosition->goal(),
-               m_vRealSize->goal(), force);
+    Debug::log(TRACE, "sendWindowSize: window:{:x},title:{} with real pos {}, real size {} (force: {})", (uintptr_t)this, this->m_title, m_realPosition->goal(), m_realSize->goal(),
+               force);
 
     // TODO: this should be decoupled from setWindowSize IMO
     const auto REPORTPOS = realToReportPosition();
 
     const auto REPORTSIZE = realToReportSize();
 
-    if (!force && m_vPendingReportedSize == REPORTSIZE && (m_vReportedPosition == REPORTPOS || !m_bIsX11))
+    if (!force && m_pendingReportedSize == REPORTSIZE && (m_reportedPosition == REPORTPOS || !m_isX11))
         return;
 
-    m_vReportedPosition    = REPORTPOS;
-    m_vPendingReportedSize = REPORTSIZE;
+    m_reportedPosition    = REPORTPOS;
+    m_pendingReportedSize = REPORTSIZE;
     updateX11SurfaceScale();
 
-    if (m_bIsX11 && m_pXWaylandSurface)
-        m_pXWaylandSurface->configure({REPORTPOS, REPORTSIZE});
-    else if (m_pXDGSurface && m_pXDGSurface->toplevel)
-        m_vPendingSizeAcks.emplace_back(m_pXDGSurface->toplevel->setSize(REPORTSIZE), REPORTPOS.floor());
+    if (m_isX11 && m_xwaylandSurface)
+        m_xwaylandSurface->configure({REPORTPOS, REPORTSIZE});
+    else if (m_xdgSurface && m_xdgSurface->toplevel)
+        m_pendingSizeAcks.emplace_back(m_xdgSurface->toplevel->setSize(REPORTSIZE), REPORTPOS.floor());
 }
 
 NContentType::eContentType CWindow::getContentType() {
-    if (!m_pWLSurface || !m_pWLSurface->resource() || !m_pWLSurface->resource()->contentType.valid())
+    if (!m_wlSurface || !m_wlSurface->resource() || !m_wlSurface->resource()->contentType.valid())
         return CONTENT_TYPE_NONE;
 
-    return m_pWLSurface->resource()->contentType->value;
+    return m_wlSurface->resource()->contentType->value;
 }
 
 void CWindow::setContentType(NContentType::eContentType contentType) {
-    if (!m_pWLSurface->resource()->contentType.valid())
-        m_pWLSurface->resource()->contentType = PROTO::contentType->getContentType(m_pWLSurface->resource());
+    if (!m_wlSurface->resource()->contentType.valid())
+        m_wlSurface->resource()->contentType = PROTO::contentType->getContentType(m_wlSurface->resource());
     // else disallow content type change if proto is used?
 
     Debug::log(INFO, "ContentType for window {}", (int)contentType);
-    m_pWLSurface->resource()->contentType->value = contentType;
+    m_wlSurface->resource()->contentType->value = contentType;
 }
 
 void CWindow::deactivateGroupMembers() {
     auto curr = getGroupHead();
     while (curr) {
-        if (curr != m_pSelf.lock()) {
+        if (curr != m_self.lock()) {
             // we dont want to deactivate unfocused xwayland windows
             // because X is weird, keep the behavior for wayland windows
             // also its not really needed for xwayland windows
             // ref: #9760 #9294
-            if (!curr->m_bIsX11 && curr->m_pXDGSurface && curr->m_pXDGSurface->toplevel)
-                curr->m_pXDGSurface->toplevel->setActive(false);
+            if (!curr->m_isX11 && curr->m_xdgSurface && curr->m_xdgSurface->toplevel)
+                curr->m_xdgSurface->toplevel->setActive(false);
         }
 
-        curr = curr->m_sGroupData.pNextWindow.lock();
+        curr = curr->m_groupData.pNextWindow.lock();
         if (curr == getGroupHead())
             break;
     }
 }
 
 bool CWindow::isNotResponding() {
-    return g_pANRManager->isNotResponding(m_pSelf.lock());
+    return g_pANRManager->isNotResponding(m_self.lock());
 }
 
 std::optional<std::string> CWindow::xdgTag() {
-    if (!m_pXDGSurface || !m_pXDGSurface->toplevel)
+    if (!m_xdgSurface || !m_xdgSurface->toplevel)
         return std::nullopt;
 
-    return m_pXDGSurface->toplevel->m_toplevelTag;
+    return m_xdgSurface->toplevel->m_toplevelTag;
 }
 
 std::optional<std::string> CWindow::xdgDescription() {
-    if (!m_pXDGSurface || !m_pXDGSurface->toplevel)
+    if (!m_xdgSurface || !m_xdgSurface->toplevel)
         return std::nullopt;
 
-    return m_pXDGSurface->toplevel->m_toplevelDescription;
+    return m_xdgSurface->toplevel->m_toplevelDescription;
 }

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1397,10 +1397,10 @@ void CWindow::activate(bool force) {
 
     static auto PFOCUSONACTIVATE = CConfigValue<Hyprlang::INT>("misc:focus_on_activate");
 
+    m_bIsUrgent = true;
+
     g_pEventManager->postEvent(SHyprIPCEvent{"urgent", std::format("{:x}", (uintptr_t)this)});
     EMIT_HOOK_EVENT("urgent", m_pSelf.lock());
-
-    m_bIsUrgent = true;
 
     if (!force && (!m_sWindowData.focusOnActivate.valueOr(*PFOCUSONACTIVATE) || (m_eSuppressedEvents & SUPPRESS_ACTIVATE_FOCUSONLY) || (m_eSuppressedEvents & SUPPRESS_ACTIVATE)))
         return;

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -67,14 +67,14 @@ enum eSuppressEvents : uint8_t {
 class IWindowTransformer;
 
 struct SAlphaValue {
-    float m_fAlpha;
-    bool  m_bOverride;
+    float alpha;
+    bool  override;
 
     float applyAlpha(float alpha) const {
-        if (m_bOverride)
-            return m_fAlpha;
+        if (override)
+            return alpha;
         else
-            return m_fAlpha * alpha;
+            return alpha * alpha;
     };
 };
 
@@ -145,154 +145,151 @@ class CWindow {
   public:
     ~CWindow();
 
-    SP<CWLSurface> m_pWLSurface;
+    SP<CWLSurface> m_wlSurface;
 
     struct {
         CSignal destroy;
-    } events;
+    } m_events;
 
-    WP<CXDGSurfaceResource> m_pXDGSurface;
-    WP<CXWaylandSurface>    m_pXWaylandSurface;
+    WP<CXDGSurfaceResource> m_xdgSurface;
+    WP<CXWaylandSurface>    m_xwaylandSurface;
 
     // this is the position and size of the "bounding box"
-    Vector2D m_vPosition = Vector2D(0, 0);
-    Vector2D m_vSize     = Vector2D(0, 0);
+    Vector2D m_position = Vector2D(0, 0);
+    Vector2D m_size     = Vector2D(0, 0);
 
     // this is the real position and size used to draw the thing
-    PHLANIMVAR<Vector2D> m_vRealPosition;
-    PHLANIMVAR<Vector2D> m_vRealSize;
+    PHLANIMVAR<Vector2D> m_realPosition;
+    PHLANIMVAR<Vector2D> m_realSize;
 
     // for not spamming the protocols
-    Vector2D                                     m_vReportedPosition;
-    Vector2D                                     m_vReportedSize;
-    Vector2D                                     m_vPendingReportedSize;
-    std::optional<std::pair<uint32_t, Vector2D>> m_pPendingSizeAck;
-    std::vector<std::pair<uint32_t, Vector2D>>   m_vPendingSizeAcks;
+    Vector2D                                     m_reportedPosition;
+    Vector2D                                     m_reportedSize;
+    Vector2D                                     m_pendingReportedSize;
+    std::optional<std::pair<uint32_t, Vector2D>> m_pendingSizeAck;
+    std::vector<std::pair<uint32_t, Vector2D>>   m_pendingSizeAcks;
 
     // for restoring floating statuses
-    Vector2D m_vLastFloatingSize;
-    Vector2D m_vLastFloatingPosition;
+    Vector2D m_lastFloatingSize;
+    Vector2D m_lastFloatingPosition;
 
     // for floating window offset in workspace animations
-    Vector2D m_vFloatingOffset = Vector2D(0, 0);
+    Vector2D m_floatingOffset = Vector2D(0, 0);
 
     // this is used for pseudotiling
-    bool     m_bIsPseudotiled = false;
-    Vector2D m_vPseudoSize    = Vector2D(1280, 720);
+    bool     m_isPseudotiled = false;
+    Vector2D m_pseudoSize    = Vector2D(1280, 720);
 
     // for recovering relative cursor position
-    Vector2D         m_vRelativeCursorCoordsOnLastWarp = Vector2D(-1, -1);
+    Vector2D         m_relativeCursorCoordsOnLastWarp = Vector2D(-1, -1);
 
-    bool             m_bFirstMap        = false; // for layouts
-    bool             m_bIsFloating      = false;
-    bool             m_bDraggingTiled   = false; // for dragging around tiled windows
-    bool             m_bWasMaximized    = false;
-    SFullscreenState m_sFullscreenState = {.internal = FSMODE_NONE, .client = FSMODE_NONE};
-    std::string      m_szTitle          = "";
-    std::string      m_szClass          = "";
-    std::string      m_szInitialTitle   = "";
-    std::string      m_szInitialClass   = "";
-    PHLWORKSPACE     m_pWorkspace;
-    PHLMONITORREF    m_pMonitor;
+    bool             m_firstMap        = false; // for layouts
+    bool             m_isFloating      = false;
+    bool             m_draggingTiled   = false; // for dragging around tiled windows
+    SFullscreenState m_fullscreenState = {.internal = FSMODE_NONE, .client = FSMODE_NONE};
+    std::string      m_title           = "";
+    std::string      m_class           = "";
+    std::string      m_initialTitle    = "";
+    std::string      m_initialClass    = "";
+    PHLWORKSPACE     m_workspace;
+    PHLMONITORREF    m_monitor;
 
-    bool             m_bIsMapped = false;
+    bool             m_isMapped = false;
 
-    bool             m_bRequestsFloat = false;
+    bool             m_requestsFloat = false;
 
     // This is for fullscreen apps
-    bool m_bCreatedOverFullscreen = false;
+    bool m_createdOverFullscreen = false;
 
     // XWayland stuff
-    bool         m_bIsX11 = false;
-    PHLWINDOWREF m_pX11Parent;
-    bool         m_bX11DoesntWantBorders = false;
-    bool         m_bX11ShouldntFocus     = false;
-    float        m_fX11SurfaceScaledBy   = 1.f;
+    bool  m_isX11                = false;
+    bool  m_X11DoesntWantBorders = false;
+    bool  m_X11ShouldntFocus     = false;
+    float m_X11SurfaceScaledBy   = 1.f;
     //
 
     // For nofocus
-    bool m_bNoInitialFocus = false;
+    bool m_noInitialFocus = false;
 
     // Fullscreen and Maximize
-    bool      m_bWantsInitialFullscreen        = false;
-    MONITORID m_iWantsInitialFullscreenMonitor = MONITOR_INVALID;
+    bool      m_wantsInitialFullscreen        = false;
+    MONITORID m_wantsInitialFullscreenMonitor = MONITOR_INVALID;
 
-    // bitfield eSuppressEvents
-    uint64_t m_eSuppressedEvents = SUPPRESS_NONE;
+    // bitfield suppressEvents
+    uint64_t m_suppressedEvents = SUPPRESS_NONE;
 
     // desktop components
-    UP<CSubsurface> m_pSubsurfaceHead;
-    UP<CPopup>      m_pPopupHead;
+    UP<CSubsurface> m_subsurfaceHead;
+    UP<CPopup>      m_popupHead;
 
     // Animated border
-    CGradientValueData m_cRealBorderColor         = {0};
-    CGradientValueData m_cRealBorderColorPrevious = {0};
-    PHLANIMVAR<float>  m_fBorderFadeAnimationProgress;
-    PHLANIMVAR<float>  m_fBorderAngleAnimationProgress;
+    CGradientValueData m_realBorderColor         = {0};
+    CGradientValueData m_realBorderColorPrevious = {0};
+    PHLANIMVAR<float>  m_borderFadeAnimationProgress;
+    PHLANIMVAR<float>  m_borderAngleAnimationProgress;
 
     // Fade in-out
-    PHLANIMVAR<float> m_fAlpha;
-    bool              m_bFadingOut     = false;
-    bool              m_bReadyToDelete = false;
-    Vector2D          m_vOriginalClosedPos;  // these will be used for calculations later on in
-    Vector2D          m_vOriginalClosedSize; // drawing the closing animations
-    SBoxExtents       m_eOriginalClosedExtents;
-    bool              m_bAnimatingIn = false;
+    PHLANIMVAR<float> m_alpha;
+    bool              m_fadingOut     = false;
+    bool              m_readyToDelete = false;
+    Vector2D          m_originalClosedPos;  // these will be used for calculations later on in
+    Vector2D          m_originalClosedSize; // drawing the closing animations
+    SBoxExtents       m_originalClosedExtents;
+    bool              m_animatingIn = false;
 
     // For pinned (sticky) windows
-    bool m_bPinned = false;
+    bool m_pinned = false;
 
     // For preserving pinned state when fullscreening a pinned window
-    bool m_bPinFullscreened = false;
+    bool m_pinFullscreened = false;
 
     // urgency hint
-    bool m_bIsUrgent = false;
+    bool m_isUrgent = false;
 
     // for proper cycling. While cycling we can't just move the pointers, so we need to keep track of the last cycled window.
-    PHLWINDOWREF m_pLastCycledWindow;
+    PHLWINDOWREF m_lastCycledWindow;
 
     // Window decorations
     // TODO: make this a SP.
-    std::vector<UP<IHyprWindowDecoration>> m_dWindowDecorations;
-    std::vector<IHyprWindowDecoration*>    m_vDecosToRemove;
+    std::vector<UP<IHyprWindowDecoration>> m_windowDecorations;
+    std::vector<IHyprWindowDecoration*>    m_decosToRemove;
 
     // Special render data, rules, etc
-    SWindowData m_sWindowData;
+    SWindowData m_windowData;
 
     // Transformers
-    std::vector<UP<IWindowTransformer>> m_vTransformers;
+    std::vector<UP<IWindowTransformer>> m_transformers;
 
     // for alpha
-    PHLANIMVAR<float> m_fActiveInactiveAlpha;
-    PHLANIMVAR<float> m_fMovingFromWorkspaceAlpha;
+    PHLANIMVAR<float> m_activeInactiveAlpha;
+    PHLANIMVAR<float> m_movingFromWorkspaceAlpha;
 
     // animated shadow color
-    PHLANIMVAR<CHyprColor> m_cRealShadowColor;
+    PHLANIMVAR<CHyprColor> m_realShadowColor;
 
     // animated tint
-    PHLANIMVAR<float> m_fDimPercent;
+    PHLANIMVAR<float> m_dimPercent;
 
     // animate moving to an invisible workspace
-    int               m_iMonitorMovedFrom = -1; // -1 means not moving
-    PHLANIMVAR<float> m_fMovingToWorkspaceAlpha;
+    int               m_monitorMovedFrom = -1; // -1 means not moving
+    PHLANIMVAR<float> m_movingToWorkspaceAlpha;
 
     // swallowing
-    PHLWINDOWREF m_pSwallowed;
-    bool         m_bCurrentlySwallowed = false;
-    bool         m_bGroupSwallowed     = false;
+    PHLWINDOWREF m_swallowed;
+    bool         m_currentlySwallowed = false;
+    bool         m_groupSwallowed     = false;
 
     // focus stuff
-    bool m_bStayFocused = false;
+    bool m_stayFocused = false;
 
     // for toplevel monitor events
-    MONITORID m_iLastToplevelMonitorID = -1;
-    MONITORID m_iLastSurfaceMonitorID  = -1;
+    MONITORID m_lastSurfaceMonitorID = -1;
 
     // for idle inhibiting windows
-    eIdleInhibitMode m_eIdleInhibitMode = IDLEINHIBIT_NONE;
+    eIdleInhibitMode m_idleInhibitMode = IDLEINHIBIT_NONE;
 
     // initial token. Will be unregistered on workspace change or timeout of 2 minutes
-    std::string m_szInitialWorkspaceToken = "";
+    std::string m_initialWorkspaceToken = "";
 
     // for groups
     struct SGroupData {
@@ -300,13 +297,13 @@ class CWindow {
         bool         head   = false;
         bool         locked = false; // per group lock
         bool         deny   = false; // deny window from enter a group or made a group
-    } m_sGroupData;
-    uint16_t m_eGroupRules = GROUP_NONE;
+    } m_groupData;
+    uint16_t m_groupRules = GROUP_NONE;
 
-    bool     m_bTearingHint = false;
+    bool     m_tearingHint = false;
 
     // stores the currently matched window rules
-    std::vector<SP<CWindowRule>> m_vMatchedRules;
+    std::vector<SP<CWindowRule>> m_matchedRules;
 
     // window tags
     CTagKeeper m_tags;
@@ -316,8 +313,8 @@ class CWindow {
 
     // For the list lookup
     bool operator==(const CWindow& rhs) const {
-        return m_pXDGSurface == rhs.m_pXDGSurface && m_pXWaylandSurface == rhs.m_pXWaylandSurface && m_vPosition == rhs.m_vPosition && m_vSize == rhs.m_vSize &&
-            m_bFadingOut == rhs.m_bFadingOut;
+        return m_xdgSurface == rhs.m_xdgSurface && m_xwaylandSurface == rhs.m_xwaylandSurface && m_position == rhs.m_position && m_size == rhs.m_size &&
+            m_fadingOut == rhs.m_fadingOut;
     }
 
     // methods
@@ -411,7 +408,7 @@ class CWindow {
     std::optional<std::string> xdgDescription();
 
     CBox                       getWindowMainSurfaceBox() const {
-        return {m_vRealPosition->value().x, m_vRealPosition->value().y, m_vRealSize->value().x, m_vRealSize->value().y};
+        return {m_realPosition->value().x, m_realPosition->value().y, m_realSize->value().x, m_realSize->value().y};
     }
 
     // listeners
@@ -421,7 +418,7 @@ class CWindow {
     std::unordered_map<std::string, std::string> getEnv();
 
     //
-    PHLWINDOWREF m_pSelf;
+    PHLWINDOWREF m_self;
 
     // make private once we move listeners to inside CWindow
     struct {
@@ -436,13 +433,13 @@ class CWindow {
         CHyprSignalListener updateState;
         CHyprSignalListener updateMetadata;
         CHyprSignalListener resourceChange;
-    } listeners;
+    } m_listeners;
 
   private:
     // For hidden windows and stuff
-    bool        m_bHidden        = false;
-    bool        m_bSuspended     = false;
-    WORKSPACEID m_iLastWorkspace = WORKSPACE_INVALID;
+    bool        m_hidden        = false;
+    bool        m_suspended     = false;
+    WORKSPACEID m_lastWorkspace = WORKSPACE_INVALID;
 };
 
 inline bool valid(PHLWINDOW w) {
@@ -456,49 +453,49 @@ inline bool valid(PHLWINDOWREF w) {
 inline bool validMapped(PHLWINDOW w) {
     if (!valid(w))
         return false;
-    return w->m_bIsMapped;
+    return w->m_isMapped;
 }
 
 inline bool validMapped(PHLWINDOWREF w) {
     if (!valid(w))
         return false;
-    return w->m_bIsMapped;
+    return w->m_isMapped;
 }
 
 namespace NWindowProperties {
     static const std::unordered_map<std::string, std::function<CWindowOverridableVar<bool>*(const PHLWINDOW&)>> boolWindowProperties = {
-        {"allowsinput", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.allowsInput; }},
-        {"dimaround", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.dimAround; }},
-        {"decorate", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.decorate; }},
-        {"focusonactivate", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.focusOnActivate; }},
-        {"keepaspectratio", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.keepAspectRatio; }},
-        {"nearestneighbor", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.nearestNeighbor; }},
-        {"noanim", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.noAnim; }},
-        {"noblur", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.noBlur; }},
-        {"noborder", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.noBorder; }},
-        {"nodim", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.noDim; }},
-        {"nofocus", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.noFocus; }},
-        {"nomaxsize", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.noMaxSize; }},
-        {"norounding", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.noRounding; }},
-        {"noshadow", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.noShadow; }},
-        {"noshortcutsinhibit", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.noShortcutsInhibit; }},
-        {"opaque", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.opaque; }},
-        {"forcergbx", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.RGBX; }},
-        {"syncfullscreen", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.syncFullscreen; }},
-        {"immediate", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.tearing; }},
-        {"xray", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.xray; }},
-        {"nofollowmouse", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.noFollowMouse; }},
+        {"allowsinput", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.allowsInput; }},
+        {"dimaround", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.dimAround; }},
+        {"decorate", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.decorate; }},
+        {"focusonactivate", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.focusOnActivate; }},
+        {"keepaspectratio", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.keepAspectRatio; }},
+        {"nearestneighbor", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.nearestNeighbor; }},
+        {"noanim", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.noAnim; }},
+        {"noblur", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.noBlur; }},
+        {"noborder", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.noBorder; }},
+        {"nodim", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.noDim; }},
+        {"nofocus", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.noFocus; }},
+        {"nomaxsize", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.noMaxSize; }},
+        {"norounding", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.noRounding; }},
+        {"noshadow", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.noShadow; }},
+        {"noshortcutsinhibit", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.noShortcutsInhibit; }},
+        {"opaque", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.opaque; }},
+        {"forcergbx", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.RGBX; }},
+        {"syncfullscreen", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.syncFullscreen; }},
+        {"immediate", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.tearing; }},
+        {"xray", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.xray; }},
+        {"nofollowmouse", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.noFollowMouse; }},
     };
 
     const std::unordered_map<std::string, std::function<CWindowOverridableVar<Hyprlang::INT>*(const PHLWINDOW&)>> intWindowProperties = {
-        {"rounding", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.rounding; }},
-        {"bordersize", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.borderSize; }},
+        {"rounding", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.rounding; }},
+        {"bordersize", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.borderSize; }},
     };
 
     const std::unordered_map<std::string, std::function<CWindowOverridableVar<Hyprlang::FLOAT>*(PHLWINDOW)>> floatWindowProperties = {
-        {"roundingpower", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.roundingPower; }},
-        {"scrollmouse", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.scrollMouse; }},
-        {"scrolltouchpad", [](const PHLWINDOW& pWindow) { return &pWindow->m_sWindowData.scrollTouchpad; }},
+        {"roundingpower", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.roundingPower; }},
+        {"scrollmouse", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.scrollMouse; }},
+        {"scrolltouchpad", [](const PHLWINDOW& pWindow) { return &pWindow->m_windowData.scrollTouchpad; }},
     };
 };
 
@@ -532,13 +529,13 @@ struct std::formatter<PHLWINDOW, CharT> : std::formatter<CharT> {
             return std::format_to(out, "[Window nullptr]");
 
         std::format_to(out, "[");
-        std::format_to(out, "Window {:x}: title: \"{}\"", (uintptr_t)w.get(), w->m_szTitle);
+        std::format_to(out, "Window {:x}: title: \"{}\"", (uintptr_t)w.get(), w->m_title);
         if (formatWorkspace)
-            std::format_to(out, ", workspace: {}", w->m_pWorkspace ? w->workspaceID() : WORKSPACE_INVALID);
+            std::format_to(out, ", workspace: {}", w->m_workspace ? w->workspaceID() : WORKSPACE_INVALID);
         if (formatMonitor)
             std::format_to(out, ", monitor: {}", w->monitorID());
         if (formatClass)
-            std::format_to(out, ", class: {}", w->m_szClass);
+            std::format_to(out, ", class: {}", w->m_class);
         return std::format_to(out, "]");
     }
 };

--- a/src/desktop/WindowRule.cpp
+++ b/src/desktop/WindowRule.cpp
@@ -13,7 +13,7 @@ static const auto RULES_PREFIX = std::unordered_set<std::string>{
     "size",      "suppressevent", "tag",        "workspace", "xray",
 };
 
-CWindowRule::CWindowRule(const std::string& rule, const std::string& value, bool isV2, bool isExecRule) : szValue(value), szRule(rule), v2(isV2), execRule(isExecRule) {
+CWindowRule::CWindowRule(const std::string& rule, const std::string& value, bool isV2, bool isExecRule) : m_value(value), m_rule(rule), m_v2(isV2), m_execRule(isExecRule) {
     const auto VALS  = CVarList(rule, 2, ' ');
     const bool VALID = RULES.contains(rule) || std::any_of(RULES_PREFIX.begin(), RULES_PREFIX.end(), [&rule](auto prefix) { return rule.starts_with(prefix); }) ||
         (NWindowProperties::boolWindowProperties.find(VALS[0]) != NWindowProperties::boolWindowProperties.end()) ||
@@ -24,73 +24,73 @@ CWindowRule::CWindowRule(const std::string& rule, const std::string& value, bool
         return;
 
     if (rule == "float")
-        ruleType = RULE_FLOAT;
+        m_ruleType = RULE_FLOAT;
     else if (rule == "fullscreen")
-        ruleType = RULE_FULLSCREEN;
+        m_ruleType = RULE_FULLSCREEN;
     else if (rule == "maximize")
-        ruleType = RULE_MAXIMIZE;
+        m_ruleType = RULE_MAXIMIZE;
     else if (rule == "noinitialfocus")
-        ruleType = RULE_NOINITIALFOCUS;
+        m_ruleType = RULE_NOINITIALFOCUS;
     else if (rule == "pin")
-        ruleType = RULE_PIN;
+        m_ruleType = RULE_PIN;
     else if (rule == "stayfocused")
-        ruleType = RULE_STAYFOCUSED;
+        m_ruleType = RULE_STAYFOCUSED;
     else if (rule == "tile")
-        ruleType = RULE_TILE;
+        m_ruleType = RULE_TILE;
     else if (rule == "renderunfocused")
-        ruleType = RULE_RENDERUNFOCUSED;
+        m_ruleType = RULE_RENDERUNFOCUSED;
     else if (rule == "persistentsize")
-        ruleType = RULE_PERSISTENTSIZE;
+        m_ruleType = RULE_PERSISTENTSIZE;
     else if (rule.starts_with("animation"))
-        ruleType = RULE_ANIMATION;
+        m_ruleType = RULE_ANIMATION;
     else if (rule.starts_with("bordercolor"))
-        ruleType = RULE_BORDERCOLOR;
+        m_ruleType = RULE_BORDERCOLOR;
     else if (rule.starts_with("center"))
-        ruleType = RULE_CENTER;
+        m_ruleType = RULE_CENTER;
     else if (rule.starts_with("fullscreenstate"))
-        ruleType = RULE_FULLSCREENSTATE;
+        m_ruleType = RULE_FULLSCREENSTATE;
     else if (rule.starts_with("group"))
-        ruleType = RULE_GROUP;
+        m_ruleType = RULE_GROUP;
     else if (rule.starts_with("idleinhibit"))
-        ruleType = RULE_IDLEINHIBIT;
+        m_ruleType = RULE_IDLEINHIBIT;
     else if (rule.starts_with("maxsize"))
-        ruleType = RULE_MAXSIZE;
+        m_ruleType = RULE_MAXSIZE;
     else if (rule.starts_with("minsize"))
-        ruleType = RULE_MINSIZE;
+        m_ruleType = RULE_MINSIZE;
     else if (rule.starts_with("monitor"))
-        ruleType = RULE_MONITOR;
+        m_ruleType = RULE_MONITOR;
     else if (rule.starts_with("move"))
-        ruleType = RULE_MOVE;
+        m_ruleType = RULE_MOVE;
     else if (rule.starts_with("opacity"))
-        ruleType = RULE_OPACITY;
+        m_ruleType = RULE_OPACITY;
     else if (rule.starts_with("plugin:"))
-        ruleType = RULE_PLUGIN;
+        m_ruleType = RULE_PLUGIN;
     else if (rule.starts_with("pseudo"))
-        ruleType = RULE_PSEUDO;
+        m_ruleType = RULE_PSEUDO;
     else if (rule.starts_with("size"))
-        ruleType = RULE_SIZE;
+        m_ruleType = RULE_SIZE;
     else if (rule.starts_with("suppressevent"))
-        ruleType = RULE_SUPPRESSEVENT;
+        m_ruleType = RULE_SUPPRESSEVENT;
     else if (rule.starts_with("tag"))
-        ruleType = RULE_TAG;
+        m_ruleType = RULE_TAG;
     else if (rule.starts_with("workspace"))
-        ruleType = RULE_WORKSPACE;
+        m_ruleType = RULE_WORKSPACE;
     else if (rule.starts_with("prop"))
-        ruleType = RULE_PROP;
+        m_ruleType = RULE_PROP;
     else if (rule.starts_with("content"))
-        ruleType = RULE_CONTENT;
+        m_ruleType = RULE_CONTENT;
     else {
         // check if this is a prop.
         const CVarList VARS(rule, 0, 's', true);
         if (NWindowProperties::intWindowProperties.find(VARS[0]) != NWindowProperties::intWindowProperties.end() ||
             NWindowProperties::boolWindowProperties.find(VARS[0]) != NWindowProperties::boolWindowProperties.end() ||
             NWindowProperties::floatWindowProperties.find(VARS[0]) != NWindowProperties::floatWindowProperties.end()) {
-            *const_cast<std::string*>(&szRule) = "prop " + rule;
-            ruleType                           = RULE_PROP;
-            Debug::log(LOG, "CWindowRule: direct prop rule found, rewritten {} -> {}", rule, szRule);
+            *const_cast<std::string*>(&m_rule) = "prop " + rule;
+            m_ruleType                         = RULE_PROP;
+            Debug::log(LOG, "CWindowRule: direct prop rule found, rewritten {} -> {}", rule, m_rule);
         } else {
             Debug::log(ERR, "CWindowRule: didn't match a rule that was found valid?!");
-            ruleType = RULE_INVALID;
+            m_ruleType = RULE_INVALID;
         }
     }
 }

--- a/src/desktop/WindowRule.hpp
+++ b/src/desktop/WindowRule.hpp
@@ -40,33 +40,33 @@ class CWindowRule {
         RULE_PERSISTENTSIZE
     };
 
-    eRuleType         ruleType = RULE_INVALID;
+    eRuleType         m_ruleType = RULE_INVALID;
 
-    const std::string szValue;
-    const std::string szRule;
-    const bool        v2       = false;
-    const bool        execRule = false;
+    const std::string m_value;
+    const std::string m_rule;
+    const bool        m_v2       = false;
+    const bool        m_execRule = false;
 
-    std::string       szTitle;
-    std::string       szClass;
-    std::string       szInitialTitle;
-    std::string       szInitialClass;
-    std::string       szTag;
-    int               bX11              = -1; // -1 means "ANY"
-    int               bFloating         = -1;
-    int               bFullscreen       = -1;
-    int               bPinned           = -1;
-    int               bFocus            = -1;
-    std::string       szFullscreenState = ""; // empty means any
-    std::string       szOnWorkspace     = ""; // empty means any
-    std::string       szWorkspace       = ""; // empty means any
-    std::string       szContentType     = ""; // empty means any
-    std::string       szXdgTag          = ""; // empty means any
+    std::string       m_title;
+    std::string       m_class;
+    std::string       m_initialTitle;
+    std::string       m_initialClass;
+    std::string       m_tag;
+    int               m_X11             = -1; // -1 means "ANY"
+    int               m_floating        = -1;
+    int               m_fullscreen      = -1;
+    int               m_pinned          = -1;
+    int               m_focus           = -1;
+    std::string       m_fullscreenState = ""; // empty means any
+    std::string       m_onWorkspace     = ""; // empty means any
+    std::string       m_workspace       = ""; // empty means any
+    std::string       m_contentType     = ""; // empty means any
+    std::string       m_xdgTag          = ""; // empty means any
 
     // precompiled regexes
-    CRuleRegexContainer rTitle;
-    CRuleRegexContainer rClass;
-    CRuleRegexContainer rInitialTitle;
-    CRuleRegexContainer rInitialClass;
-    CRuleRegexContainer rV1Regex;
+    CRuleRegexContainer m_titleRegex;
+    CRuleRegexContainer m_classRegex;
+    CRuleRegexContainer m_initialTitleRegex;
+    CRuleRegexContainer m_initialClassRegex;
+    CRuleRegexContainer m_v1Regex;
 };

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -525,7 +525,7 @@ MONITORID CWorkspace::monitorID() {
 
 PHLWINDOW CWorkspace::getFullscreenWindow() {
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->m_pWorkspace == m_self && w->isFullscreen())
+        if (w->m_workspace == m_self && w->isFullscreen())
             return w;
     }
 
@@ -547,11 +547,11 @@ bool CWorkspace::isVisibleNotCovered() {
 int CWorkspace::getWindows(std::optional<bool> onlyTiled, std::optional<bool> onlyPinned, std::optional<bool> onlyVisible) {
     int no = 0;
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->workspaceID() != m_id || !w->m_bIsMapped)
+        if (w->workspaceID() != m_id || !w->m_isMapped)
             continue;
-        if (onlyTiled.has_value() && w->m_bIsFloating == onlyTiled.value())
+        if (onlyTiled.has_value() && w->m_isFloating == onlyTiled.value())
             continue;
-        if (onlyPinned.has_value() && w->m_bPinned != onlyPinned.value())
+        if (onlyPinned.has_value() && w->m_pinned != onlyPinned.value())
             continue;
         if (onlyVisible.has_value() && w->isHidden() == onlyVisible.value())
             continue;
@@ -564,13 +564,13 @@ int CWorkspace::getWindows(std::optional<bool> onlyTiled, std::optional<bool> on
 int CWorkspace::getGroups(std::optional<bool> onlyTiled, std::optional<bool> onlyPinned, std::optional<bool> onlyVisible) {
     int no = 0;
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->workspaceID() != m_id || !w->m_bIsMapped)
+        if (w->workspaceID() != m_id || !w->m_isMapped)
             continue;
-        if (!w->m_sGroupData.head)
+        if (!w->m_groupData.head)
             continue;
-        if (onlyTiled.has_value() && w->m_bIsFloating == onlyTiled.value())
+        if (onlyTiled.has_value() && w->m_isFloating == onlyTiled.value())
             continue;
-        if (onlyPinned.has_value() && w->m_bPinned != onlyPinned.value())
+        if (onlyPinned.has_value() && w->m_pinned != onlyPinned.value())
             continue;
         if (onlyVisible.has_value() && w->isHidden() == onlyVisible.value())
             continue;
@@ -581,7 +581,7 @@ int CWorkspace::getGroups(std::optional<bool> onlyTiled, std::optional<bool> onl
 
 PHLWINDOW CWorkspace::getFirstWindow() {
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->m_pWorkspace == m_self && w->m_bIsMapped && !w->isHidden())
+        if (w->m_workspace == m_self && w->m_isMapped && !w->isHidden())
             return w;
     }
 
@@ -592,7 +592,7 @@ PHLWINDOW CWorkspace::getTopLeftWindow() {
     const auto PMONITOR = m_monitor.lock();
 
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->m_pWorkspace != m_self || !w->m_bIsMapped || w->isHidden())
+        if (w->m_workspace != m_self || !w->m_isMapped || w->isHidden())
             continue;
 
         const auto WINDOWIDEALBB = w->getWindowIdealBoundingBoxIgnoreReserved();
@@ -605,7 +605,7 @@ PHLWINDOW CWorkspace::getTopLeftWindow() {
 
 bool CWorkspace::hasUrgentWindow() {
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->m_pWorkspace == m_self && w->m_bIsMapped && w->m_bIsUrgent)
+        if (w->m_workspace == m_self && w->m_isMapped && w->m_isUrgent)
             return true;
     }
 
@@ -614,7 +614,7 @@ bool CWorkspace::hasUrgentWindow() {
 
 void CWorkspace::updateWindowDecos() {
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->m_pWorkspace != m_self)
+        if (w->m_workspace != m_self)
             continue;
 
         w->updateWindowDecos();
@@ -625,7 +625,7 @@ void CWorkspace::updateWindowData() {
     const auto WORKSPACERULE = g_pConfigManager->getWorkspaceRuleFor(m_self.lock());
 
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->m_pWorkspace != m_self)
+        if (w->m_workspace != m_self)
             continue;
 
         w->updateWindowData(WORKSPACERULE);
@@ -634,7 +634,7 @@ void CWorkspace::updateWindowData() {
 
 void CWorkspace::forceReportSizesToWindows() {
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->m_pWorkspace != m_self || !w->m_bIsMapped || w->isHidden())
+        if (w->m_workspace != m_self || !w->m_isMapped || w->isHidden())
             continue;
 
         w->sendWindowSize(true);
@@ -658,10 +658,10 @@ void CWorkspace::rename(const std::string& name) {
 }
 
 void CWorkspace::updateWindows() {
-    m_hasFullscreenWindow = std::ranges::any_of(g_pCompositor->m_windows, [this](const auto& w) { return w->m_bIsMapped && w->m_pWorkspace == m_self && w->isFullscreen(); });
+    m_hasFullscreenWindow = std::ranges::any_of(g_pCompositor->m_windows, [this](const auto& w) { return w->m_isMapped && w->m_workspace == m_self && w->isFullscreen(); });
 
     for (auto const& w : g_pCompositor->m_windows) {
-        if (!w->m_bIsMapped || w->m_pWorkspace != m_self)
+        if (!w->m_isMapped || w->m_workspace != m_self)
             continue;
 
         w->updateDynamicRules();

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1127,12 +1127,12 @@ void CMonitor::changeWorkspace(const PHLWORKSPACE& pWorkspace, bool internal, bo
 
         // move pinned windows
         for (auto const& w : g_pCompositor->m_windows) {
-            if (w->m_pWorkspace == POLDWORKSPACE && w->m_bPinned)
+            if (w->m_workspace == POLDWORKSPACE && w->m_pinned)
                 w->moveToWorkspace(pWorkspace);
         }
 
         if (!noFocus && !g_pCompositor->m_lastMonitor->activeSpecialWorkspace &&
-            !(g_pCompositor->m_lastWindow.lock() && g_pCompositor->m_lastWindow->m_bPinned && g_pCompositor->m_lastWindow->m_pMonitor == self)) {
+            !(g_pCompositor->m_lastWindow.lock() && g_pCompositor->m_lastWindow->m_pinned && g_pCompositor->m_lastWindow->m_monitor == self)) {
             static auto PFOLLOWMOUSE = CConfigValue<Hyprlang::INT>("input:follow_mouse");
             auto        pWindow      = pWorkspace->m_hasFullscreenWindow ? pWorkspace->getFullscreenWindow() : pWorkspace->getLastFocusedWindow();
 
@@ -1194,7 +1194,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
 
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(ID);
 
-        if (!(g_pCompositor->m_lastWindow.lock() && g_pCompositor->m_lastWindow->m_bPinned && g_pCompositor->m_lastWindow->m_pMonitor == self)) {
+        if (!(g_pCompositor->m_lastWindow.lock() && g_pCompositor->m_lastWindow->m_pinned && g_pCompositor->m_lastWindow->m_monitor == self)) {
             if (const auto PLAST = activeWorkspace->getLastFocusedWindow(); PLAST)
                 g_pCompositor->focusWindow(PLAST);
             else
@@ -1238,32 +1238,32 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
         pWorkspace->startAnim(true, true);
 
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->m_pWorkspace == pWorkspace) {
-            w->m_pMonitor = self;
+        if (w->m_workspace == pWorkspace) {
+            w->m_monitor = self;
             w->updateSurfaceScaleTransformDetails();
             w->setAnimationsToMove();
 
             const auto MIDDLE = w->middle();
-            if (w->m_bIsFloating && !VECINRECT(MIDDLE, vecPosition.x, vecPosition.y, vecPosition.x + vecSize.x, vecPosition.y + vecSize.y) && !w->isX11OverrideRedirect()) {
+            if (w->m_isFloating && !VECINRECT(MIDDLE, vecPosition.x, vecPosition.y, vecPosition.x + vecSize.x, vecPosition.y + vecSize.y) && !w->isX11OverrideRedirect()) {
                 // if it's floating and the middle isnt on the current mon, move it to the center
                 const auto PMONFROMMIDDLE = g_pCompositor->getMonitorFromVector(MIDDLE);
-                Vector2D   pos            = w->m_vRealPosition->goal();
+                Vector2D   pos            = w->m_realPosition->goal();
                 if (!VECINRECT(MIDDLE, PMONFROMMIDDLE->vecPosition.x, PMONFROMMIDDLE->vecPosition.y, PMONFROMMIDDLE->vecPosition.x + PMONFROMMIDDLE->vecSize.x,
                                PMONFROMMIDDLE->vecPosition.y + PMONFROMMIDDLE->vecSize.y)) {
                     // not on any monitor, center
-                    pos = middle() / 2.f - w->m_vRealSize->goal() / 2.f;
+                    pos = middle() / 2.f - w->m_realSize->goal() / 2.f;
                 } else
                     pos = pos - PMONFROMMIDDLE->vecPosition + vecPosition;
 
-                *w->m_vRealPosition = pos;
-                w->m_vPosition      = pos;
+                *w->m_realPosition = pos;
+                w->m_position      = pos;
             }
         }
     }
 
     g_pLayoutManager->getCurrentLayout()->recalculateMonitor(ID);
 
-    if (!(g_pCompositor->m_lastWindow.lock() && g_pCompositor->m_lastWindow->m_bPinned && g_pCompositor->m_lastWindow->m_pMonitor == self)) {
+    if (!(g_pCompositor->m_lastWindow.lock() && g_pCompositor->m_lastWindow->m_pinned && g_pCompositor->m_lastWindow->m_monitor == self)) {
         if (const auto PLAST = pWorkspace->getLastFocusedWindow(); PLAST)
             g_pCompositor->focusWindow(PLAST);
         else
@@ -1447,7 +1447,7 @@ bool CMonitor::attemptDirectScanout() {
 
     if (lastScanout.expired()) {
         lastScanout = PCANDIDATE;
-        Debug::log(LOG, "Entered a direct scanout to {:x}: \"{}\"", (uintptr_t)PCANDIDATE.get(), PCANDIDATE->m_szTitle);
+        Debug::log(LOG, "Entered a direct scanout to {:x}: \"{}\"", (uintptr_t)PCANDIDATE.get(), PCANDIDATE->m_title);
     }
 
     scanoutNeedsCursorUpdate = false;

--- a/src/managers/ANRManager.cpp
+++ b/src/managers/ANRManager.cpp
@@ -51,7 +51,7 @@ void CANRManager::onTick() {
         PHLWINDOW firstWindow;
         int       count = 0;
         for (const auto& w : g_pCompositor->m_windows) {
-            if (!w->m_bIsMapped)
+            if (!w->m_isMapped)
                 continue;
 
             if (!data->fitsWindow(w))
@@ -67,10 +67,10 @@ void CANRManager::onTick() {
 
         if (data->missedResponses >= *PANRTHRESHOLD) {
             if (!data->isRunning() && !data->dialogSaidWait) {
-                data->runDialog("Application Not Responding", firstWindow->m_szTitle, firstWindow->m_szClass, data->getPid());
+                data->runDialog("Application Not Responding", firstWindow->m_title, firstWindow->m_class, data->getPid());
 
                 for (const auto& w : g_pCompositor->m_windows) {
-                    if (!w->m_bIsMapped)
+                    if (!w->m_isMapped)
                         continue;
 
                     if (!data->fitsWindow(w))
@@ -133,10 +133,10 @@ bool CANRManager::isNotResponding(SP<CANRManager::SANRData> data) {
 
 SP<CANRManager::SANRData> CANRManager::dataFor(PHLWINDOW pWindow) {
     auto it = m_data.end();
-    if (pWindow->m_pXWaylandSurface)
-        it = std::ranges::find_if(m_data, [&pWindow](const auto& data) { return data->xwaylandSurface && data->xwaylandSurface == pWindow->m_pXWaylandSurface; });
-    else if (pWindow->m_pXDGSurface)
-        it = std::ranges::find_if(m_data, [&pWindow](const auto& data) { return data->xdgBase && data->xdgBase == pWindow->m_pXDGSurface->owner; });
+    if (pWindow->m_xwaylandSurface)
+        it = std::ranges::find_if(m_data, [&pWindow](const auto& data) { return data->xwaylandSurface && data->xwaylandSurface == pWindow->m_xwaylandSurface; });
+    else if (pWindow->m_xdgSurface)
+        it = std::ranges::find_if(m_data, [&pWindow](const auto& data) { return data->xdgBase && data->xdgBase == pWindow->m_xdgSurface->owner; });
     return it == m_data.end() ? nullptr : *it;
 }
 
@@ -150,8 +150,7 @@ SP<CANRManager::SANRData> CANRManager::dataFor(SP<CXWaylandSurface> pXwaylandSur
     return it == m_data.end() ? nullptr : *it;
 }
 
-CANRManager::SANRData::SANRData(PHLWINDOW pWindow) :
-    xwaylandSurface(pWindow->m_pXWaylandSurface), xdgBase(pWindow->m_pXDGSurface ? pWindow->m_pXDGSurface->owner : WP<CXDGWMBase>{}) {
+CANRManager::SANRData::SANRData(PHLWINDOW pWindow) : xwaylandSurface(pWindow->m_xwaylandSurface), xdgBase(pWindow->m_xdgSurface ? pWindow->m_xdgSurface->owner : WP<CXDGWMBase>{}) {
     ;
 }
 
@@ -192,10 +191,10 @@ void CANRManager::SANRData::killDialog() {
 }
 
 bool CANRManager::SANRData::fitsWindow(PHLWINDOW pWindow) const {
-    if (pWindow->m_pXWaylandSurface)
-        return pWindow->m_pXWaylandSurface == xwaylandSurface;
-    else if (pWindow->m_pXDGSurface)
-        return pWindow->m_pXDGSurface->owner == xdgBase && xdgBase;
+    if (pWindow->m_xwaylandSurface)
+        return pWindow->m_xwaylandSurface == xwaylandSurface;
+    else if (pWindow->m_xdgSurface)
+        return pWindow->m_xdgSurface->owner == xdgBase && xdgBase;
     return false;
 }
 

--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -21,7 +21,7 @@ CHyprXWaylandManager::~CHyprXWaylandManager() {
 }
 
 SP<CWLSurfaceResource> CHyprXWaylandManager::getWindowSurface(PHLWINDOW pWindow) {
-    return pWindow ? pWindow->m_pWLSurface->resource() : nullptr;
+    return pWindow ? pWindow->m_wlSurface->resource() : nullptr;
 }
 
 void CHyprXWaylandManager::activateSurface(SP<CWLSurfaceResource> pSurface, bool activate) {
@@ -40,41 +40,41 @@ void CHyprXWaylandManager::activateSurface(SP<CWLSurfaceResource> pSurface, bool
         return;
     }
 
-    if (PWINDOW->m_bIsX11) {
-        if (PWINDOW->m_pXWaylandSurface) {
+    if (PWINDOW->m_isX11) {
+        if (PWINDOW->m_xwaylandSurface) {
             if (activate) {
-                PWINDOW->m_pXWaylandSurface->setMinimized(false);
-                PWINDOW->m_pXWaylandSurface->restackToTop();
+                PWINDOW->m_xwaylandSurface->setMinimized(false);
+                PWINDOW->m_xwaylandSurface->restackToTop();
             }
-            PWINDOW->m_pXWaylandSurface->activate(activate);
+            PWINDOW->m_xwaylandSurface->activate(activate);
         }
-    } else if (PWINDOW->m_pXDGSurface && PWINDOW->m_pXDGSurface->toplevel)
-        PWINDOW->m_pXDGSurface->toplevel->setActive(activate);
+    } else if (PWINDOW->m_xdgSurface && PWINDOW->m_xdgSurface->toplevel)
+        PWINDOW->m_xdgSurface->toplevel->setActive(activate);
 }
 
 void CHyprXWaylandManager::activateWindow(PHLWINDOW pWindow, bool activate) {
-    if (pWindow->m_bIsX11) {
+    if (pWindow->m_isX11) {
 
         if (activate) {
             pWindow->sendWindowSize(true); // update xwayland output pos
-            pWindow->m_pXWaylandSurface->setMinimized(false);
+            pWindow->m_xwaylandSurface->setMinimized(false);
 
             if (!pWindow->isX11OverrideRedirect())
-                pWindow->m_pXWaylandSurface->restackToTop();
+                pWindow->m_xwaylandSurface->restackToTop();
         }
 
-        pWindow->m_pXWaylandSurface->activate(activate);
+        pWindow->m_xwaylandSurface->activate(activate);
 
-    } else if (pWindow->m_pXDGSurface && pWindow->m_pXDGSurface->toplevel)
-        pWindow->m_pXDGSurface->toplevel->setActive(activate);
+    } else if (pWindow->m_xdgSurface && pWindow->m_xdgSurface->toplevel)
+        pWindow->m_xdgSurface->toplevel->setActive(activate);
 
     if (activate) {
         g_pCompositor->m_lastFocus  = getWindowSurface(pWindow);
         g_pCompositor->m_lastWindow = pWindow;
     }
 
-    if (!pWindow->m_bPinned)
-        pWindow->m_pWorkspace->m_lastFocusedWindow = pWindow;
+    if (!pWindow->m_pinned)
+        pWindow->m_workspace->m_lastFocusedWindow = pWindow;
 }
 
 CBox CHyprXWaylandManager::getGeometryForWindow(PHLWINDOW pWindow) {
@@ -83,52 +83,52 @@ CBox CHyprXWaylandManager::getGeometryForWindow(PHLWINDOW pWindow) {
 
     CBox box;
 
-    if (pWindow->m_bIsX11)
-        box = pWindow->m_pXWaylandSurface->geometry;
-    else if (pWindow->m_pXDGSurface)
-        box = pWindow->m_pXDGSurface->current.geometry;
+    if (pWindow->m_isX11)
+        box = pWindow->m_xwaylandSurface->geometry;
+    else if (pWindow->m_xdgSurface)
+        box = pWindow->m_xdgSurface->current.geometry;
 
     return box;
 }
 
 void CHyprXWaylandManager::sendCloseWindow(PHLWINDOW pWindow) {
-    if (pWindow->m_bIsX11)
-        pWindow->m_pXWaylandSurface->close();
-    else if (pWindow->m_pXDGSurface && pWindow->m_pXDGSurface->toplevel)
-        pWindow->m_pXDGSurface->toplevel->close();
+    if (pWindow->m_isX11)
+        pWindow->m_xwaylandSurface->close();
+    else if (pWindow->m_xdgSurface && pWindow->m_xdgSurface->toplevel)
+        pWindow->m_xdgSurface->toplevel->close();
 }
 
 bool CHyprXWaylandManager::shouldBeFloated(PHLWINDOW pWindow, bool pending) {
-    if (pWindow->m_bIsX11) {
-        for (const auto& a : pWindow->m_pXWaylandSurface->atoms)
+    if (pWindow->m_isX11) {
+        for (const auto& a : pWindow->m_xwaylandSurface->atoms)
             if (a == HYPRATOMS["_NET_WM_WINDOW_TYPE_DIALOG"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_SPLASH"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_TOOLBAR"] ||
                 a == HYPRATOMS["_NET_WM_WINDOW_TYPE_UTILITY"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_TOOLTIP"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_POPUP_MENU"] ||
                 a == HYPRATOMS["_NET_WM_WINDOW_TYPE_DOCK"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_DROPDOWN_MENU"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_MENU"] ||
                 a == HYPRATOMS["_KDE_NET_WM_WINDOW_TYPE_OVERRIDE"]) {
 
                 if (a == HYPRATOMS["_NET_WM_WINDOW_TYPE_DROPDOWN_MENU"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_MENU"])
-                    pWindow->m_bX11ShouldntFocus = true;
+                    pWindow->m_X11ShouldntFocus = true;
 
                 if (a != HYPRATOMS["_NET_WM_WINDOW_TYPE_DIALOG"])
-                    pWindow->m_bNoInitialFocus = true;
+                    pWindow->m_noInitialFocus = true;
 
                 return true;
             }
 
-        if (pWindow->isModal() || pWindow->m_pXWaylandSurface->transient ||
-            (pWindow->m_pXWaylandSurface->role.contains("task_dialog") || pWindow->m_pXWaylandSurface->role.contains("pop-up")) || pWindow->m_pXWaylandSurface->overrideRedirect)
+        if (pWindow->isModal() || pWindow->m_xwaylandSurface->transient ||
+            (pWindow->m_xwaylandSurface->role.contains("task_dialog") || pWindow->m_xwaylandSurface->role.contains("pop-up")) || pWindow->m_xwaylandSurface->overrideRedirect)
             return true;
 
-        const auto SIZEHINTS = pWindow->m_pXWaylandSurface->sizeHints.get();
-        if (pWindow->m_pXWaylandSurface->transient || pWindow->m_pXWaylandSurface->parent ||
+        const auto SIZEHINTS = pWindow->m_xwaylandSurface->sizeHints.get();
+        if (pWindow->m_xwaylandSurface->transient || pWindow->m_xwaylandSurface->parent ||
             (SIZEHINTS && (SIZEHINTS->min_width == SIZEHINTS->max_width) && (SIZEHINTS->min_height == SIZEHINTS->max_height)))
             return true;
     } else {
-        if (!pWindow->m_pXDGSurface || !pWindow->m_pXDGSurface->toplevel)
+        if (!pWindow->m_xdgSurface || !pWindow->m_xdgSurface->toplevel)
             return false;
 
-        const auto PSTATE = pending ? &pWindow->m_pXDGSurface->toplevel->pending : &pWindow->m_pXDGSurface->toplevel->current;
-        if (pWindow->m_pXDGSurface->toplevel->parent ||
+        const auto PSTATE = pending ? &pWindow->m_xdgSurface->toplevel->pending : &pWindow->m_xdgSurface->toplevel->current;
+        if (pWindow->m_xdgSurface->toplevel->parent ||
             (PSTATE->minSize.x != 0 && PSTATE->minSize.y != 0 && (PSTATE->minSize.x == PSTATE->maxSize.x || PSTATE->minSize.y == PSTATE->maxSize.y)))
             return true;
     }
@@ -137,31 +137,31 @@ bool CHyprXWaylandManager::shouldBeFloated(PHLWINDOW pWindow, bool pending) {
 }
 
 void CHyprXWaylandManager::checkBorders(PHLWINDOW pWindow) {
-    if (!pWindow->m_bIsX11)
+    if (!pWindow->m_isX11)
         return;
 
-    for (auto const& a : pWindow->m_pXWaylandSurface->atoms) {
+    for (auto const& a : pWindow->m_xwaylandSurface->atoms) {
         if (a == HYPRATOMS["_NET_WM_WINDOW_TYPE_POPUP_MENU"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_NOTIFICATION"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_DROPDOWN_MENU"] ||
             a == HYPRATOMS["_NET_WM_WINDOW_TYPE_COMBO"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_MENU"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_SPLASH"] ||
             a == HYPRATOMS["_NET_WM_WINDOW_TYPE_TOOLTIP"]) {
 
-            pWindow->m_bX11DoesntWantBorders = true;
+            pWindow->m_X11DoesntWantBorders = true;
             return;
         }
     }
 
     if (pWindow->isX11OverrideRedirect())
-        pWindow->m_bX11DoesntWantBorders = true;
+        pWindow->m_X11DoesntWantBorders = true;
 }
 
 void CHyprXWaylandManager::setWindowFullscreen(PHLWINDOW pWindow, bool fullscreen) {
     if (!pWindow)
         return;
 
-    if (pWindow->m_bIsX11)
-        pWindow->m_pXWaylandSurface->setFullscreen(fullscreen);
-    else if (pWindow->m_pXDGSurface && pWindow->m_pXDGSurface->toplevel)
-        pWindow->m_pXDGSurface->toplevel->setFullscreen(fullscreen);
+    if (pWindow->m_isX11)
+        pWindow->m_xwaylandSurface->setFullscreen(fullscreen);
+    else if (pWindow->m_xdgSurface && pWindow->m_xdgSurface->toplevel)
+        pWindow->m_xdgSurface->toplevel->setFullscreen(fullscreen);
 }
 
 Vector2D CHyprXWaylandManager::waylandToXWaylandCoords(const Vector2D& coord) {

--- a/src/managers/input/IdleInhibitor.cpp
+++ b/src/managers/input/IdleInhibitor.cpp
@@ -61,13 +61,13 @@ void CInputManager::recheckIdleInhibitorStatus() {
 }
 
 bool CInputManager::isWindowInhibiting(const PHLWINDOW& w, bool onlyHl) {
-    if (w->m_eIdleInhibitMode == IDLEINHIBIT_ALWAYS)
+    if (w->m_idleInhibitMode == IDLEINHIBIT_ALWAYS)
         return true;
 
-    if (w->m_eIdleInhibitMode == IDLEINHIBIT_FOCUS && g_pCompositor->isWindowActive(w))
+    if (w->m_idleInhibitMode == IDLEINHIBIT_FOCUS && g_pCompositor->isWindowActive(w))
         return true;
 
-    if (w->m_eIdleInhibitMode == IDLEINHIBIT_FULLSCREEN && w->isFullscreen() && w->m_pWorkspace && w->m_pWorkspace->isVisible())
+    if (w->m_idleInhibitMode == IDLEINHIBIT_FULLSCREEN && w->isFullscreen() && w->m_workspace && w->m_workspace->isVisible())
         return true;
 
     if (onlyHl)
@@ -78,7 +78,7 @@ bool CInputManager::isWindowInhibiting(const PHLWINDOW& w, bool onlyHl) {
             continue;
 
         bool isInhibiting = false;
-        w->m_pWLSurface->resource()->breadthfirst(
+        w->m_wlSurface->resource()->breadthfirst(
             [&ii](SP<CWLSurfaceResource> surf, const Vector2D& pos, void* data) {
                 if (ii->inhibitor->surface != surf)
                     return;

--- a/src/managers/input/Tablets.cpp
+++ b/src/managers/input/Tablets.cpp
@@ -69,12 +69,12 @@ static void refocusTablet(SP<CTablet> tab, SP<CTabletTool> tool, bool motion = f
 
         // yes, this technically ignores any regions set by the app. Too bad!
         if (LASTHLSURFACE->getWindow())
-            local = tool->absolutePos * LASTHLSURFACE->getWindow()->m_vRealSize->goal();
+            local = tool->absolutePos * LASTHLSURFACE->getWindow()->m_realSize->goal();
         else
             local = tool->absolutePos * BOX->size();
 
-        if (LASTHLSURFACE->getWindow() && LASTHLSURFACE->getWindow()->m_bIsX11)
-            local = local * LASTHLSURFACE->getWindow()->m_fX11SurfaceScaledBy;
+        if (LASTHLSURFACE->getWindow() && LASTHLSURFACE->getWindow()->m_isX11)
+            local = local * LASTHLSURFACE->getWindow()->m_X11SurfaceScaledBy;
 
         PROTO::tablet->motion(tool, local);
         return;
@@ -82,8 +82,8 @@ static void refocusTablet(SP<CTablet> tab, SP<CTabletTool> tool, bool motion = f
 
     auto local = CURSORPOS - BOX->pos();
 
-    if (LASTHLSURFACE->getWindow() && LASTHLSURFACE->getWindow()->m_bIsX11)
-        local = local * LASTHLSURFACE->getWindow()->m_fX11SurfaceScaledBy;
+    if (LASTHLSURFACE->getWindow() && LASTHLSURFACE->getWindow()->m_isX11)
+        local = local * LASTHLSURFACE->getWindow()->m_X11SurfaceScaledBy;
 
     PROTO::tablet->motion(tool, local);
 }

--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -80,9 +80,9 @@ void CInputManager::onTouchDown(ITouch::SDownEvent e) {
         local                           = g_pInputManager->getMouseCoordsInternal() - PMONITOR->vecPosition;
         m_sTouchData.touchSurfaceOrigin = g_pInputManager->getMouseCoordsInternal() - local;
     } else if (!m_sTouchData.touchFocusWindow.expired()) {
-        if (m_sTouchData.touchFocusWindow->m_bIsX11) {
-            local = (g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchFocusWindow->m_vRealPosition->goal()) * m_sTouchData.touchFocusWindow->m_fX11SurfaceScaledBy;
-            m_sTouchData.touchSurfaceOrigin = m_sTouchData.touchFocusWindow->m_vRealPosition->goal();
+        if (m_sTouchData.touchFocusWindow->m_isX11) {
+            local = (g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchFocusWindow->m_realPosition->goal()) * m_sTouchData.touchFocusWindow->m_X11SurfaceScaledBy;
+            m_sTouchData.touchSurfaceOrigin = m_sTouchData.touchFocusWindow->m_realPosition->goal();
         } else {
             g_pCompositor->vectorWindowToSurface(g_pInputManager->getMouseCoordsInternal(), m_sTouchData.touchFocusWindow.lock(), local);
             m_sTouchData.touchSurfaceOrigin = g_pInputManager->getMouseCoordsInternal() - local;
@@ -148,13 +148,13 @@ void CInputManager::onTouchMove(ITouch::SMotionEvent e) {
         auto local = g_pInputManager->getMouseCoordsInternal() - PMONITOR->vecPosition;
         g_pSeatManager->sendTouchMotion(e.timeMs, e.touchID, local);
     } else if (validMapped(m_sTouchData.touchFocusWindow)) {
-        const auto PMONITOR = m_sTouchData.touchFocusWindow->m_pMonitor.lock();
+        const auto PMONITOR = m_sTouchData.touchFocusWindow->m_monitor.lock();
 
         g_pCompositor->warpCursorTo({PMONITOR->vecPosition.x + e.pos.x * PMONITOR->vecSize.x, PMONITOR->vecPosition.y + e.pos.y * PMONITOR->vecSize.y}, true);
 
         auto local = g_pInputManager->getMouseCoordsInternal() - m_sTouchData.touchSurfaceOrigin;
-        if (m_sTouchData.touchFocusWindow->m_bIsX11)
-            local = local * m_sTouchData.touchFocusWindow->m_fX11SurfaceScaledBy;
+        if (m_sTouchData.touchFocusWindow->m_isX11)
+            local = local * m_sTouchData.touchFocusWindow->m_X11SurfaceScaledBy;
 
         g_pSeatManager->sendTouchMotion(e.timeMs, e.touchID, local);
     } else if (!m_sTouchData.touchFocusLS.expired()) {

--- a/src/plugins/PluginAPI.cpp
+++ b/src/plugins/PluginAPI.cpp
@@ -131,7 +131,7 @@ APICALL bool HyprlandAPI::removeWindowDecoration(HANDLE handle, IHyprWindowDecor
         return false;
 
     for (auto const& w : g_pCompositor->m_windows) {
-        for (auto const& d : w->m_dWindowDecorations) {
+        for (auto const& d : w->m_windowDecorations) {
             if (d.get() == pDecoration) {
                 w->removeWindowDeco(pDecoration);
                 return true;

--- a/src/protocols/ForeignToplevel.cpp
+++ b/src/protocols/ForeignToplevel.cpp
@@ -60,8 +60,8 @@ void CForeignToplevelList::onMap(PHLWINDOW pWindow) {
     LOGM(LOG, "Newly mapped window gets an identifier of {}", IDENTIFIER);
     resource->sendToplevel(NEWHANDLE->resource.get());
     NEWHANDLE->resource->sendIdentifier(IDENTIFIER.c_str());
-    NEWHANDLE->resource->sendAppId(pWindow->m_szInitialClass.c_str());
-    NEWHANDLE->resource->sendTitle(pWindow->m_szInitialTitle.c_str());
+    NEWHANDLE->resource->sendAppId(pWindow->m_initialClass.c_str());
+    NEWHANDLE->resource->sendTitle(pWindow->m_initialTitle.c_str());
     NEWHANDLE->resource->sendDone();
 
     handles.push_back(NEWHANDLE);
@@ -81,7 +81,7 @@ void CForeignToplevelList::onTitle(PHLWINDOW pWindow) {
     if UNLIKELY (!H || H->closed)
         return;
 
-    H->resource->sendTitle(pWindow->m_szTitle.c_str());
+    H->resource->sendTitle(pWindow->m_title.c_str());
     H->resource->sendDone();
 }
 
@@ -93,7 +93,7 @@ void CForeignToplevelList::onClass(PHLWINDOW pWindow) {
     if UNLIKELY (!H || H->closed)
         return;
 
-    H->resource->sendAppId(pWindow->m_szClass.c_str());
+    H->resource->sendAppId(pWindow->m_class.c_str());
     H->resource->sendDone();
 }
 

--- a/src/protocols/LinuxDMABUF.cpp
+++ b/src/protocols/LinuxDMABUF.cpp
@@ -499,7 +499,7 @@ void CLinuxDMABufV1Protocol::resetFormatTable() {
             PHLMONITOR mon;
             auto       HLSurface = CWLSurface::fromResource(feedback->surface);
             if (auto w = HLSurface->getWindow(); w)
-                if (auto m = w->m_pMonitor.lock(); m)
+                if (auto m = w->m_monitor.lock(); m)
                     mon = m->self.lock();
 
             if (!mon) {

--- a/src/protocols/PointerConstraints.cpp
+++ b/src/protocols/PointerConstraints.cpp
@@ -36,8 +36,8 @@ CPointerConstraint::CPointerConstraint(SP<CZwpLockedPointerV1> resource_, SP<CWL
         float      scale   = 1.f;
         const auto PWINDOW = pHLSurface->getWindow();
         if (PWINDOW) {
-            const auto ISXWL = PWINDOW->m_bIsX11;
-            scale            = ISXWL && *PXWLFORCESCALEZERO ? PWINDOW->m_fX11SurfaceScaledBy : 1.f;
+            const auto ISXWL = PWINDOW->m_isX11;
+            scale            = ISXWL && *PXWLFORCESCALEZERO ? PWINDOW->m_X11SurfaceScaledBy : 1.f;
         }
 
         positionHint = {wl_fixed_to_double(x) / scale, wl_fixed_to_double(y) / scale};

--- a/src/protocols/ShortcutsInhibit.cpp
+++ b/src/protocols/ShortcutsInhibit.cpp
@@ -71,7 +71,7 @@ bool CKeyboardShortcutsInhibitProtocol::isInhibited() {
     if (!g_pCompositor->m_lastFocus)
         return false;
 
-    if (const auto PWINDOW = g_pCompositor->getWindowFromSurface(g_pCompositor->m_lastFocus.lock()); PWINDOW && PWINDOW->m_sWindowData.noShortcutsInhibit.valueOrDefault())
+    if (const auto PWINDOW = g_pCompositor->getWindowFromSurface(g_pCompositor->m_lastFocus.lock()); PWINDOW && PWINDOW->m_windowData.noShortcutsInhibit.valueOrDefault())
         return false;
 
     for (auto const& in : m_vInhibitors) {

--- a/src/protocols/TearingControl.cpp
+++ b/src/protocols/TearingControl.cpp
@@ -54,7 +54,7 @@ CTearingControl::CTearingControl(SP<CWpTearingControlV1> resource_, SP<CWLSurfac
     resource->setSetPresentationHint([this](CWpTearingControlV1* res, wpTearingControlV1PresentationHint hint) { this->onHint(hint); });
 
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->m_pWLSurface->resource() == surf_) {
+        if (w->m_wlSurface->resource() == surf_) {
             pWindow = w;
             break;
         }
@@ -70,7 +70,7 @@ void CTearingControl::updateWindow() {
     if UNLIKELY (pWindow.expired())
         return;
 
-    pWindow->m_bTearingHint = hint == WP_TEARING_CONTROL_V1_PRESENTATION_HINT_ASYNC;
+    pWindow->m_tearingHint = hint == WP_TEARING_CONTROL_V1_PRESENTATION_HINT_ASYNC;
 }
 
 bool CTearingControl::good() {

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1533,7 +1533,7 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, const CB
         }
     }
 
-    if (m_RenderData.currentWindow && m_RenderData.currentWindow->m_sWindowData.RGBX.valueOrDefault()) {
+    if (m_RenderData.currentWindow && m_RenderData.currentWindow->m_windowData.RGBX.valueOrDefault()) {
         shader  = &m_shaders->m_shRGBX;
         texType = TEXTURE_RGBX;
     }
@@ -1628,9 +1628,9 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, const CB
                 const auto DIM = m_RenderData.currentWindow->m_notRespondingTint->value();
                 glUniform1i(shader->applyTint, 1);
                 glUniform3f(shader->tint, 1.f - DIM, 1.f - DIM, 1.f - DIM);
-            } else if (m_RenderData.currentWindow->m_fDimPercent->value() > 0) {
+            } else if (m_RenderData.currentWindow->m_dimPercent->value() > 0) {
                 glUniform1i(shader->applyTint, 1);
-                const auto DIM = m_RenderData.currentWindow->m_fDimPercent->value();
+                const auto DIM = m_RenderData.currentWindow->m_dimPercent->value();
                 glUniform3f(shader->tint, 1.f - DIM, 1.f - DIM, 1.f - DIM);
             } else
                 glUniform1i(shader->applyTint, 0);
@@ -2054,16 +2054,16 @@ void CHyprOpenGLImpl::preRender(PHLMONITOR pMonitor) {
         if (!pWindow)
             return false;
 
-        if (pWindow->m_sWindowData.noBlur.valueOrDefault())
+        if (pWindow->m_windowData.noBlur.valueOrDefault())
             return false;
 
-        if (pWindow->m_pWLSurface->small() && !pWindow->m_pWLSurface->m_fillIgnoreSmall)
+        if (pWindow->m_wlSurface->small() && !pWindow->m_wlSurface->m_fillIgnoreSmall)
             return true;
 
-        const auto  PSURFACE = pWindow->m_pWLSurface->resource();
+        const auto  PSURFACE = pWindow->m_wlSurface->resource();
 
-        const auto  PWORKSPACE = pWindow->m_pWorkspace;
-        const float A          = pWindow->m_fAlpha->value() * pWindow->m_fActiveInactiveAlpha->value() * PWORKSPACE->m_alpha->value();
+        const auto  PWORKSPACE = pWindow->m_workspace;
+        const float A          = pWindow->m_alpha->value() * pWindow->m_activeInactiveAlpha->value() * PWORKSPACE->m_alpha->value();
 
         if (A >= 1.f) {
             // if (PSURFACE->opaque)
@@ -2084,7 +2084,7 @@ void CHyprOpenGLImpl::preRender(PHLMONITOR pMonitor) {
 
     bool hasWindows = false;
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->m_pWorkspace == pMonitor->activeWorkspace && !w->isHidden() && w->m_bIsMapped && (!w->m_bIsFloating || *PBLURXRAY)) {
+        if (w->m_workspace == pMonitor->activeWorkspace && !w->isHidden() && w->m_isMapped && (!w->m_isFloating || *PBLURXRAY)) {
 
             // check if window is valid
             if (!windowShouldBeBlurred(w))
@@ -2170,16 +2170,16 @@ bool CHyprOpenGLImpl::shouldUseNewBlurOptimizations(PHLLS pLayer, PHLWINDOW pWin
     if (!m_RenderData.pCurrentMonData->blurFB.getTexture())
         return false;
 
-    if (pWindow && pWindow->m_sWindowData.xray.hasValue() && !pWindow->m_sWindowData.xray.valueOrDefault())
+    if (pWindow && pWindow->m_windowData.xray.hasValue() && !pWindow->m_windowData.xray.valueOrDefault())
         return false;
 
     if (pLayer && pLayer->m_xray == 0)
         return false;
 
-    if ((*PBLURNEWOPTIMIZE && pWindow && !pWindow->m_bIsFloating && !pWindow->onSpecialWorkspace()) || *PBLURXRAY)
+    if ((*PBLURNEWOPTIMIZE && pWindow && !pWindow->m_isFloating && !pWindow->onSpecialWorkspace()) || *PBLURXRAY)
         return true;
 
-    if ((pLayer && pLayer->m_xray == 1) || (pWindow && pWindow->m_sWindowData.xray.valueOrDefault()))
+    if ((pLayer && pLayer->m_xray == 1) || (pWindow && pWindow->m_windowData.xray.valueOrDefault()))
         return true;
 
     return false;
@@ -2303,7 +2303,7 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const CGradientValueData& gr
 
     TRACY_GPU_ZONE("RenderBorder");
 
-    if (m_RenderData.damage.empty() || (m_RenderData.currentWindow && m_RenderData.currentWindow->m_sWindowData.noBorder.valueOrDefault()))
+    if (m_RenderData.damage.empty() || (m_RenderData.currentWindow && m_RenderData.currentWindow->m_windowData.noBorder.valueOrDefault()))
         return;
 
     CBox newBox = box;
@@ -2401,7 +2401,7 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const CGradientValueData& gr
 
     TRACY_GPU_ZONE("RenderBorder2");
 
-    if (m_RenderData.damage.empty() || (m_RenderData.currentWindow && m_RenderData.currentWindow->m_sWindowData.noBorder.valueOrDefault()))
+    if (m_RenderData.damage.empty() || (m_RenderData.currentWindow && m_RenderData.currentWindow->m_windowData.noBorder.valueOrDefault()))
         return;
 
     CBox newBox = box;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -143,18 +143,18 @@ CHyprRenderer::CHyprRenderer() {
                     continue;
                 }
 
-                if (!w->m_pWLSurface || !w->m_pWLSurface->resource() || shouldRenderWindow(w.lock()))
+                if (!w->m_wlSurface || !w->m_wlSurface->resource() || shouldRenderWindow(w.lock()))
                     continue;
 
-                w->m_pWLSurface->resource()->frame(Time::steadyNow());
-                auto FEEDBACK = makeShared<CQueuedPresentationData>(w->m_pWLSurface->resource());
+                w->m_wlSurface->resource()->frame(Time::steadyNow());
+                auto FEEDBACK = makeShared<CQueuedPresentationData>(w->m_wlSurface->resource());
                 FEEDBACK->attachMonitor(g_pCompositor->m_lastMonitor.lock());
                 FEEDBACK->discarded();
                 PROTO::presentation->queueData(FEEDBACK);
             }
 
             if (dirty)
-                std::erase_if(m_vRenderUnfocused, [](const auto& e) { return !e || !e->m_sWindowData.renderUnfocused.valueOr(false); });
+                std::erase_if(m_vRenderUnfocused, [](const auto& e) { return !e || !e->m_windowData.renderUnfocused.valueOr(false); });
 
             if (!m_vRenderUnfocused.empty())
                 m_tRenderUnfocusedTimer->updateTimeout(std::chrono::milliseconds(1000 / *PFPS));
@@ -173,52 +173,51 @@ bool CHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
     if (!pWindow->visibleOnMonitor(pMonitor))
         return false;
 
-    if (!pWindow->m_pWorkspace && !pWindow->m_bFadingOut)
+    if (!pWindow->m_workspace && !pWindow->m_fadingOut)
         return false;
 
-    if (!pWindow->m_pWorkspace && pWindow->m_bFadingOut)
+    if (!pWindow->m_workspace && pWindow->m_fadingOut)
         return pWindow->workspaceID() == pMonitor->activeWorkspaceID();
 
-    if (pWindow->m_bPinned)
+    if (pWindow->m_pinned)
         return true;
 
     // if the window is being moved to a workspace that is not invisible, and the alpha is > 0.F, render it.
-    if (pWindow->m_iMonitorMovedFrom != -1 && pWindow->m_fMovingToWorkspaceAlpha->isBeingAnimated() && pWindow->m_fMovingToWorkspaceAlpha->value() > 0.F && pWindow->m_pWorkspace &&
-        !pWindow->m_pWorkspace->isVisible())
+    if (pWindow->m_monitorMovedFrom != -1 && pWindow->m_movingToWorkspaceAlpha->isBeingAnimated() && pWindow->m_movingToWorkspaceAlpha->value() > 0.F && pWindow->m_workspace &&
+        !pWindow->m_workspace->isVisible())
         return true;
 
-    const auto PWINDOWWORKSPACE = pWindow->m_pWorkspace;
+    const auto PWINDOWWORKSPACE = pWindow->m_workspace;
     if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_monitor == pMonitor) {
         if (PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated() || PWINDOWWORKSPACE->m_alpha->isBeingAnimated() || PWINDOWWORKSPACE->m_forceRendering)
             return true;
 
         // if hidden behind fullscreen
-        if (PWINDOWWORKSPACE->m_hasFullscreenWindow && !pWindow->isFullscreen() && (!pWindow->m_bIsFloating || !pWindow->m_bCreatedOverFullscreen) &&
-            pWindow->m_fAlpha->value() == 0)
+        if (PWINDOWWORKSPACE->m_hasFullscreenWindow && !pWindow->isFullscreen() && (!pWindow->m_isFloating || !pWindow->m_createdOverFullscreen) && pWindow->m_alpha->value() == 0)
             return false;
 
         if (!PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated() && !PWINDOWWORKSPACE->m_alpha->isBeingAnimated() && !PWINDOWWORKSPACE->isVisible())
             return false;
     }
 
-    if (pWindow->m_pMonitor == pMonitor)
+    if (pWindow->m_monitor == pMonitor)
         return true;
 
-    if ((!pWindow->m_pWorkspace || !pWindow->m_pWorkspace->isVisible()) && pWindow->m_pMonitor != pMonitor)
+    if ((!pWindow->m_workspace || !pWindow->m_workspace->isVisible()) && pWindow->m_monitor != pMonitor)
         return false;
 
     // if not, check if it maybe is active on a different monitor.
-    if (pWindow->m_pWorkspace && pWindow->m_pWorkspace->isVisible() && pWindow->m_bIsFloating /* tiled windows can't be multi-ws */)
+    if (pWindow->m_workspace && pWindow->m_workspace->isVisible() && pWindow->m_isFloating /* tiled windows can't be multi-ws */)
         return !pWindow->isFullscreen(); // Do not draw fullscreen windows on other monitors
 
-    if (pMonitor->activeSpecialWorkspace == pWindow->m_pWorkspace)
+    if (pMonitor->activeSpecialWorkspace == pWindow->m_workspace)
         return true;
 
     // if window is tiled and it's flying in, don't render on other mons (for slide)
-    if (!pWindow->m_bIsFloating && pWindow->m_vRealPosition->isBeingAnimated() && pWindow->m_bAnimatingIn && pWindow->m_pMonitor != pMonitor)
+    if (!pWindow->m_isFloating && pWindow->m_realPosition->isBeingAnimated() && pWindow->m_animatingIn && pWindow->m_monitor != pMonitor)
         return false;
 
-    if (pWindow->m_vRealPosition->isBeingAnimated()) {
+    if (pWindow->m_realPosition->isBeingAnimated()) {
         if (PWINDOWWORKSPACE && !PWINDOWWORKSPACE->m_isSpecialWorkspace && PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated())
             return false;
         // render window if window and monitor intersect
@@ -226,10 +225,10 @@ bool CHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
         CBox windowBox = pWindow->getFullWindowBoundingBox();
         if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated())
             windowBox.translate(PWINDOWWORKSPACE->m_renderOffset->value());
-        windowBox.translate(pWindow->m_vFloatingOffset);
+        windowBox.translate(pWindow->m_floatingOffset);
 
         const CBox monitorBox = {pMonitor->vecPosition, pMonitor->vecSize};
-        if (!windowBox.intersection(monitorBox).empty() && (pWindow->workspaceID() == pMonitor->activeWorkspaceID() || pWindow->m_iMonitorMovedFrom != -1))
+        if (!windowBox.intersection(monitorBox).empty() && (pWindow->workspaceID() == pMonitor->activeWorkspaceID() || pWindow->m_monitorMovedFrom != -1))
             return true;
     }
 
@@ -241,12 +240,12 @@ bool CHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow) {
     if (!validMapped(pWindow))
         return false;
 
-    const auto PWORKSPACE = pWindow->m_pWorkspace;
+    const auto PWORKSPACE = pWindow->m_workspace;
 
-    if (!pWindow->m_pWorkspace)
+    if (!pWindow->m_workspace)
         return false;
 
-    if (pWindow->m_bPinned || PWORKSPACE->m_forceRendering)
+    if (pWindow->m_pinned || PWORKSPACE->m_forceRendering)
         return true;
 
     if (PWORKSPACE && PWORKSPACE->isVisible())
@@ -273,10 +272,10 @@ void CHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
         if (!shouldRenderWindow(w, pMonitor))
             continue;
 
-        if (w->m_fAlpha->value() == 0.f)
+        if (w->m_alpha->value() == 0.f)
             continue;
 
-        if (w->isFullscreen() || w->m_bIsFloating)
+        if (w->isFullscreen() || w->m_isFloating)
             continue;
 
         if (pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
@@ -290,16 +289,16 @@ void CHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
         if (!shouldRenderWindow(w, pMonitor))
             continue;
 
-        if (w->m_fAlpha->value() == 0.f)
+        if (w->m_alpha->value() == 0.f)
             continue;
 
-        if (w->isFullscreen() || !w->m_bIsFloating)
+        if (w->isFullscreen() || !w->m_isFloating)
             continue;
 
-        if (w->m_pMonitor == pWorkspace->m_monitor && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
+        if (w->m_monitor == pWorkspace->m_monitor && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
             continue;
 
-        if (pWorkspace->m_isSpecialWorkspace && w->m_pMonitor != pWorkspace->m_monitor)
+        if (pWorkspace->m_isSpecialWorkspace && w->m_monitor != pWorkspace->m_monitor)
             continue; // special on another are rendered as a part of the base pass
 
         renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
@@ -307,26 +306,26 @@ void CHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
 
     // TODO: this pass sucks
     for (auto const& w : g_pCompositor->m_windows) {
-        const auto PWORKSPACE = w->m_pWorkspace;
+        const auto PWORKSPACE = w->m_workspace;
 
-        if (w->m_pWorkspace != pWorkspace || !w->isFullscreen()) {
+        if (w->m_workspace != pWorkspace || !w->isFullscreen()) {
             if (!(PWORKSPACE && (PWORKSPACE->m_renderOffset->isBeingAnimated() || PWORKSPACE->m_alpha->isBeingAnimated() || PWORKSPACE->m_forceRendering)))
                 continue;
 
-            if (w->m_pMonitor != pMonitor)
+            if (w->m_monitor != pMonitor)
                 continue;
         }
 
         if (!w->isFullscreen())
             continue;
 
-        if (w->m_pMonitor == pWorkspace->m_monitor && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
+        if (w->m_monitor == pWorkspace->m_monitor && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
             continue;
 
         if (shouldRenderWindow(w, pMonitor))
             renderWindow(w, pMonitor, time, pWorkspace->m_fullscreenMode != FSMODE_FULLSCREEN, RENDER_PASS_ALL);
 
-        if (w->m_pWorkspace != pWorkspace)
+        if (w->m_workspace != pWorkspace)
             continue;
 
         pWorkspaceWindow = w;
@@ -340,14 +339,14 @@ void CHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
 
     // then render windows over fullscreen.
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->m_pWorkspace != pWorkspaceWindow->m_pWorkspace || !w->m_bIsFloating || (!w->m_bCreatedOverFullscreen && !w->m_bPinned) || (!w->m_bIsMapped && !w->m_bFadingOut) ||
+        if (w->m_workspace != pWorkspaceWindow->m_workspace || !w->m_isFloating || (!w->m_createdOverFullscreen && !w->m_pinned) || (!w->m_isMapped && !w->m_fadingOut) ||
             w->isFullscreen())
             continue;
 
-        if (w->m_pMonitor == pWorkspace->m_monitor && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
+        if (w->m_monitor == pWorkspace->m_monitor && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
             continue;
 
-        if (pWorkspace->m_isSpecialWorkspace && w->m_pMonitor != pWorkspace->m_monitor)
+        if (pWorkspace->m_isSpecialWorkspace && w->m_monitor != pWorkspace->m_monitor)
             continue; // special on another are rendered as a part of the base pass
 
         renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
@@ -363,7 +362,7 @@ void CHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
     windows.reserve(g_pCompositor->m_windows.size());
 
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->isHidden() || (!w->m_bIsMapped && !w->m_bFadingOut))
+        if (w->isHidden() || (!w->m_isMapped && !w->m_fadingOut))
             continue;
 
         if (!shouldRenderWindow(w, pMonitor))
@@ -374,11 +373,11 @@ void CHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
 
     // Non-floating main
     for (auto& w : windows) {
-        if (w->m_bIsFloating)
+        if (w->m_isFloating)
             continue; // floating are in the second pass
 
         // some things may force us to ignore the special/not special disparity
-        const bool IGNORE_SPECIAL_CHECK = w->m_iMonitorMovedFrom != -1 && (w->m_pWorkspace && !w->m_pWorkspace->isVisible());
+        const bool IGNORE_SPECIAL_CHECK = w->m_monitorMovedFrom != -1 && (w->m_workspace && !w->m_workspace->isVisible());
 
         if (!IGNORE_SPECIAL_CHECK && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
             continue;
@@ -390,7 +389,7 @@ void CHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
         }
 
         // render tiled fading out after others
-        if (w->m_bFadingOut) {
+        if (w->m_fadingOut) {
             tiledFadingOut.emplace_back(w);
             w.reset();
             continue;
@@ -416,11 +415,11 @@ void CHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
         if (!w)
             continue;
 
-        if (w->m_bIsFloating)
+        if (w->m_isFloating)
             continue; // floating are in the second pass
 
         // some things may force us to ignore the special/not special disparity
-        const bool IGNORE_SPECIAL_CHECK = w->m_iMonitorMovedFrom != -1 && (w->m_pWorkspace && !w->m_pWorkspace->isVisible());
+        const bool IGNORE_SPECIAL_CHECK = w->m_monitorMovedFrom != -1 && (w->m_workspace && !w->m_workspace->isVisible());
 
         if (!IGNORE_SPECIAL_CHECK && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
             continue;
@@ -435,16 +434,16 @@ void CHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
         if (!w)
             continue;
 
-        if (!w->m_bIsFloating || w->m_bPinned)
+        if (!w->m_isFloating || w->m_pinned)
             continue;
 
         // some things may force us to ignore the special/not special disparity
-        const bool IGNORE_SPECIAL_CHECK = w->m_iMonitorMovedFrom != -1 && (w->m_pWorkspace && !w->m_pWorkspace->isVisible());
+        const bool IGNORE_SPECIAL_CHECK = w->m_monitorMovedFrom != -1 && (w->m_workspace && !w->m_workspace->isVisible());
 
         if (!IGNORE_SPECIAL_CHECK && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
             continue;
 
-        if (pWorkspace->m_isSpecialWorkspace && w->m_pMonitor != pWorkspace->m_monitor)
+        if (pWorkspace->m_isSpecialWorkspace && w->m_monitor != pWorkspace->m_monitor)
             continue; // special on another are rendered as a part of the base pass
 
         // render the bad boy
@@ -456,24 +455,24 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     if (pWindow->isHidden() && !standalone)
         return;
 
-    if (pWindow->m_bFadingOut) {
-        if (pMonitor == pWindow->m_pMonitor) // TODO: fix this
+    if (pWindow->m_fadingOut) {
+        if (pMonitor == pWindow->m_monitor) // TODO: fix this
             renderSnapshot(pWindow);
         return;
     }
 
-    if (!pWindow->m_bIsMapped)
+    if (!pWindow->m_isMapped)
         return;
 
     TRACY_GPU_ZONE("RenderWindow");
 
-    const auto                       PWORKSPACE = pWindow->m_pWorkspace;
-    const auto                       REALPOS    = pWindow->m_vRealPosition->value() + (pWindow->m_bPinned ? Vector2D{} : PWORKSPACE->m_renderOffset->value());
+    const auto                       PWORKSPACE = pWindow->m_workspace;
+    const auto                       REALPOS    = pWindow->m_realPosition->value() + (pWindow->m_pinned ? Vector2D{} : PWORKSPACE->m_renderOffset->value());
     static auto                      PDIMAROUND = CConfigValue<Hyprlang::FLOAT>("decoration:dim_around");
     static auto                      PBLUR      = CConfigValue<Hyprlang::INT>("decoration:blur:enabled");
 
     CSurfacePassElement::SRenderData renderdata = {pMonitor, time};
-    CBox                             textureBox = {REALPOS.x, REALPOS.y, std::max(pWindow->m_vRealSize->value().x, 5.0), std::max(pWindow->m_vRealSize->value().y, 5.0)};
+    CBox                             textureBox = {REALPOS.x, REALPOS.y, std::max(pWindow->m_realSize->value().x, 5.0), std::max(pWindow->m_realSize->value().y, 5.0)};
 
     renderdata.pos.x = textureBox.x;
     renderdata.pos.y = textureBox.y;
@@ -495,15 +494,15 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
         decorate = false;
 
     // whether to use m_fMovingToWorkspaceAlpha, only if fading out into an invisible ws
-    const bool USE_WORKSPACE_FADE_ALPHA = pWindow->m_iMonitorMovedFrom != -1 && (!PWORKSPACE || !PWORKSPACE->isVisible());
-    const bool DONT_BLUR                = pWindow->m_sWindowData.noBlur.valueOrDefault() || pWindow->m_sWindowData.RGBX.valueOrDefault() || pWindow->opaque();
+    const bool USE_WORKSPACE_FADE_ALPHA = pWindow->m_monitorMovedFrom != -1 && (!PWORKSPACE || !PWORKSPACE->isVisible());
+    const bool DONT_BLUR                = pWindow->m_windowData.noBlur.valueOrDefault() || pWindow->m_windowData.RGBX.valueOrDefault() || pWindow->opaque();
 
-    renderdata.surface   = pWindow->m_pWLSurface->resource();
-    renderdata.dontRound = pWindow->isEffectiveInternalFSMode(FSMODE_FULLSCREEN) || pWindow->m_sWindowData.noRounding.valueOrDefault();
-    renderdata.fadeAlpha = pWindow->m_fAlpha->value() * (pWindow->m_bPinned || USE_WORKSPACE_FADE_ALPHA ? 1.f : PWORKSPACE->m_alpha->value()) *
-        (USE_WORKSPACE_FADE_ALPHA ? pWindow->m_fMovingToWorkspaceAlpha->value() : 1.F) * pWindow->m_fMovingFromWorkspaceAlpha->value();
-    renderdata.alpha         = pWindow->m_fActiveInactiveAlpha->value();
-    renderdata.decorate      = decorate && !pWindow->m_bX11DoesntWantBorders && !pWindow->isEffectiveInternalFSMode(FSMODE_FULLSCREEN);
+    renderdata.surface   = pWindow->m_wlSurface->resource();
+    renderdata.dontRound = pWindow->isEffectiveInternalFSMode(FSMODE_FULLSCREEN) || pWindow->m_windowData.noRounding.valueOrDefault();
+    renderdata.fadeAlpha = pWindow->m_alpha->value() * (pWindow->m_pinned || USE_WORKSPACE_FADE_ALPHA ? 1.f : PWORKSPACE->m_alpha->value()) *
+        (USE_WORKSPACE_FADE_ALPHA ? pWindow->m_movingToWorkspaceAlpha->value() : 1.F) * pWindow->m_movingFromWorkspaceAlpha->value();
+    renderdata.alpha         = pWindow->m_activeInactiveAlpha->value();
+    renderdata.decorate      = decorate && !pWindow->m_X11DoesntWantBorders && !pWindow->isEffectiveInternalFSMode(FSMODE_FULLSCREEN);
     renderdata.rounding      = standalone || renderdata.dontRound ? 0 : pWindow->rounding() * pMonitor->scale;
     renderdata.roundingPower = standalone || renderdata.dontRound ? 2.0f : pWindow->roundingPower();
     renderdata.blur          = !standalone && *PBLUR && !DONT_BLUR;
@@ -515,14 +514,14 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     }
 
     // apply opaque
-    if (pWindow->m_sWindowData.opaque.valueOrDefault())
+    if (pWindow->m_windowData.opaque.valueOrDefault())
         renderdata.alpha = 1.f;
 
     renderdata.pWindow = pWindow;
 
     EMIT_HOOK_EVENT("render", RENDER_PRE_WINDOW);
 
-    if (*PDIMAROUND && pWindow->m_sWindowData.dimAround.valueOrDefault() && !m_bRenderingSnapshot && mode != RENDER_PASS_POPUP) {
+    if (*PDIMAROUND && pWindow->m_windowData.dimAround.valueOrDefault() && !m_bRenderingSnapshot && mode != RENDER_PASS_POPUP) {
         CBox                        monbox = {0, 0, g_pHyprOpenGL->m_RenderData.pMonitor->vecTransformedSize.x, g_pHyprOpenGL->m_RenderData.pMonitor->vecTransformedSize.y};
         CRectPassElement::SRectData data;
         data.color = CHyprColor(0, 0, 0, *PDIMAROUND * renderdata.alpha * renderdata.fadeAlpha);
@@ -530,38 +529,37 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
         m_sRenderPass.add(makeShared<CRectPassElement>(data));
     }
 
-    renderdata.pos.x += pWindow->m_vFloatingOffset.x;
-    renderdata.pos.y += pWindow->m_vFloatingOffset.y;
+    renderdata.pos.x += pWindow->m_floatingOffset.x;
+    renderdata.pos.y += pWindow->m_floatingOffset.y;
 
     // if window is floating and we have a slide animation, clip it to its full bb
-    if (!ignorePosition && pWindow->m_bIsFloating && !pWindow->isFullscreen() && PWORKSPACE->m_renderOffset->isBeingAnimated() && !pWindow->m_bPinned) {
-        CRegion rg =
-            pWindow->getFullWindowBoundingBox().translate(-pMonitor->vecPosition + PWORKSPACE->m_renderOffset->value() + pWindow->m_vFloatingOffset).scale(pMonitor->scale);
+    if (!ignorePosition && pWindow->m_isFloating && !pWindow->isFullscreen() && PWORKSPACE->m_renderOffset->isBeingAnimated() && !pWindow->m_pinned) {
+        CRegion rg = pWindow->getFullWindowBoundingBox().translate(-pMonitor->vecPosition + PWORKSPACE->m_renderOffset->value() + pWindow->m_floatingOffset).scale(pMonitor->scale);
         renderdata.clipBox = rg.getExtents();
     }
 
     // render window decorations first, if not fullscreen full
     if (mode == RENDER_PASS_ALL || mode == RENDER_PASS_MAIN) {
 
-        const bool TRANSFORMERSPRESENT = !pWindow->m_vTransformers.empty();
+        const bool TRANSFORMERSPRESENT = !pWindow->m_transformers.empty();
 
         if (TRANSFORMERSPRESENT) {
             g_pHyprOpenGL->bindOffMain();
 
-            for (auto const& t : pWindow->m_vTransformers) {
+            for (auto const& t : pWindow->m_transformers) {
                 t->preWindowRender(&renderdata);
             }
         }
 
         if (renderdata.decorate) {
-            for (auto const& wd : pWindow->m_dWindowDecorations) {
+            for (auto const& wd : pWindow->m_windowDecorations) {
                 if (wd->getDecorationLayer() != DECORATION_LAYER_BOTTOM)
                     continue;
 
                 wd->draw(pMonitor, renderdata.alpha * renderdata.fadeAlpha);
             }
 
-            for (auto const& wd : pWindow->m_dWindowDecorations) {
+            for (auto const& wd : pWindow->m_windowDecorations) {
                 if (wd->getDecorationLayer() != DECORATION_LAYER_UNDER)
                     continue;
 
@@ -570,10 +568,10 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
         }
 
         static auto PXWLUSENN = CConfigValue<Hyprlang::INT>("xwayland:use_nearest_neighbor");
-        if ((pWindow->m_bIsX11 && *PXWLUSENN) || pWindow->m_sWindowData.nearestNeighbor.valueOrDefault())
+        if ((pWindow->m_isX11 && *PXWLUSENN) || pWindow->m_windowData.nearestNeighbor.valueOrDefault())
             renderdata.useNearestNeighbor = true;
 
-        if (!pWindow->m_sWindowData.noBlur.valueOrDefault() && pWindow->m_pWLSurface->small() && !pWindow->m_pWLSurface->m_fillIgnoreSmall && renderdata.blur && *PBLUR) {
+        if (!pWindow->m_windowData.noBlur.valueOrDefault() && pWindow->m_wlSurface->small() && !pWindow->m_wlSurface->m_fillIgnoreSmall && renderdata.blur && *PBLUR) {
             CBox wb = {renderdata.pos.x - pMonitor->vecPosition.x, renderdata.pos.y - pMonitor->vecPosition.y, renderdata.w, renderdata.h};
             wb.scale(pMonitor->scale).round();
             CRectPassElement::SRectData data;
@@ -588,12 +586,12 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
         }
 
         renderdata.surfaceCounter = 0;
-        pWindow->m_pWLSurface->resource()->breadthfirst(
+        pWindow->m_wlSurface->resource()->breadthfirst(
             [this, &renderdata, &pWindow](SP<CWLSurfaceResource> s, const Vector2D& offset, void* data) {
                 renderdata.localPos    = offset;
                 renderdata.texture     = s->current.texture;
                 renderdata.surface     = s;
-                renderdata.mainSurface = s == pWindow->m_pWLSurface->resource();
+                renderdata.mainSurface = s == pWindow->m_wlSurface->resource();
                 m_sRenderPass.add(makeShared<CSurfacePassElement>(renderdata));
                 renderdata.surfaceCounter++;
             },
@@ -602,7 +600,7 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
         renderdata.useNearestNeighbor = false;
 
         if (renderdata.decorate) {
-            for (auto const& wd : pWindow->m_dWindowDecorations) {
+            for (auto const& wd : pWindow->m_windowDecorations) {
                 if (wd->getDecorationLayer() != DECORATION_LAYER_OVER)
                     continue;
 
@@ -612,7 +610,7 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
 
         if (TRANSFORMERSPRESENT) {
             CFramebuffer* last = g_pHyprOpenGL->m_RenderData.currentFB;
-            for (auto const& t : pWindow->m_vTransformers) {
+            for (auto const& t : pWindow->m_transformers) {
                 last = t->transform(last);
             }
 
@@ -624,8 +622,8 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     g_pHyprOpenGL->m_RenderData.clipBox = CBox();
 
     if (mode == RENDER_PASS_ALL || mode == RENDER_PASS_POPUP) {
-        if (!pWindow->m_bIsX11) {
-            CBox geom = pWindow->m_pXDGSurface->current.geometry;
+        if (!pWindow->m_isX11) {
+            CBox geom = pWindow->m_xdgSurface->current.geometry;
 
             renderdata.pos -= geom.pos();
             renderdata.dontRound       = true; // don't round popups
@@ -643,12 +641,12 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
                 renderdata.discardOpacity = *PBLURIGNOREA;
             }
 
-            if (pWindow->m_sWindowData.nearestNeighbor.valueOrDefault())
+            if (pWindow->m_windowData.nearestNeighbor.valueOrDefault())
                 renderdata.useNearestNeighbor = true;
 
             renderdata.surfaceCounter = 0;
 
-            pWindow->m_pPopupHead->breadthfirst(
+            pWindow->m_popupHead->breadthfirst(
                 [this, &renderdata](WP<CPopup> popup, void* data) {
                     if (!popup->m_wlSurface || !popup->m_wlSurface->resource() || !popup->m_mapped)
                         return;
@@ -673,7 +671,7 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
         }
 
         if (decorate) {
-            for (auto const& wd : pWindow->m_dWindowDecorations) {
+            for (auto const& wd : pWindow->m_windowDecorations) {
                 if (wd->getDecorationLayer() != DECORATION_LAYER_OVERLAY)
                     continue;
 
@@ -946,10 +944,10 @@ void CHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
 
     // pinned always above
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->isHidden() && !w->m_bIsMapped && !w->m_bFadingOut)
+        if (w->isHidden() && !w->m_isMapped && !w->m_fadingOut)
             continue;
 
-        if (!w->m_bPinned || !w->m_bIsFloating)
+        if (!w->m_pinned || !w->m_isFloating)
             continue;
 
         if (!shouldRenderWindow(w, pMonitor))
@@ -1032,7 +1030,7 @@ void CHyprRenderer::renderSessionLockMissing(PHLMONITOR pMonitor) {
 
 void CHyprRenderer::calculateUVForSurface(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface, PHLMONITOR pMonitor, bool main, const Vector2D& projSize,
                                           const Vector2D& projSizeUnscaled, bool fixMisalignedFSV1) {
-    if (!pWindow || !pWindow->m_bIsX11) {
+    if (!pWindow || !pWindow->m_isX11) {
         static auto PEXPANDEDGES = CConfigValue<Hyprlang::INT>("render:expand_undersized_textures");
 
         Vector2D    uvTL;
@@ -1092,7 +1090,7 @@ void CHyprRenderer::calculateUVForSurface(PHLWINDOW pWindow, SP<CWLSurfaceResour
         if (!main || !pWindow)
             return;
 
-        CBox geom = pWindow->m_pXDGSurface->current.geometry;
+        CBox geom = pWindow->m_xdgSurface->current.geometry;
 
         // ignore X and Y, adjust uv
         if (geom.x != 0 || geom.y != 0 || geom.width > projSizeUnscaled.x || geom.height > projSizeUnscaled.y) {
@@ -1107,8 +1105,8 @@ void CHyprRenderer::calculateUVForSurface(PHLWINDOW pWindow, SP<CWLSurfaceResour
 
             auto maxSize = projSizeUnscaled;
 
-            if (pWindow->m_pWLSurface->small() && !pWindow->m_pWLSurface->m_fillIgnoreSmall)
-                maxSize = pWindow->m_pWLSurface->getViewporterCorrectedSize();
+            if (pWindow->m_wlSurface->small() && !pWindow->m_wlSurface->m_fillIgnoreSmall)
+                maxSize = pWindow->m_wlSurface->getViewporterCorrectedSize();
 
             if (geom.width > maxSize.x)
                 uvBR.x = uvBR.x * (maxSize.x / geom.width);
@@ -1483,7 +1481,7 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
         bool hdrIsHandled = false;
         if (*PPASS && pMonitor->activeWorkspace && pMonitor->activeWorkspace->m_hasFullscreenWindow && pMonitor->activeWorkspace->m_fullscreenMode == FSMODE_FULLSCREEN) {
             const auto WINDOW    = pMonitor->activeWorkspace->getFullscreenWindow();
-            const auto ROOT_SURF = WINDOW->m_pWLSurface->resource();
+            const auto ROOT_SURF = WINDOW->m_wlSurface->resource();
             const auto SURF =
                 ROOT_SURF->findFirstPreorder([ROOT_SURF](SP<CWLSurfaceResource> surf) { return surf->colorManagement.valid() && surf->extends() == ROOT_SURF->extends(); });
 
@@ -1592,13 +1590,13 @@ void CHyprRenderer::renderWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace
 
 void CHyprRenderer::sendFrameEventsToWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now) {
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->isHidden() || !w->m_bIsMapped || w->m_bFadingOut || !w->m_pWLSurface->resource())
+        if (w->isHidden() || !w->m_isMapped || w->m_fadingOut || !w->m_wlSurface->resource())
             continue;
 
         if (!shouldRenderWindow(w, pMonitor))
             continue;
 
-        w->m_pWLSurface->resource()->breadthfirst([now](SP<CWLSurfaceResource> r, const Vector2D& offset, void* d) { r->frame(now); }, nullptr);
+        w->m_wlSurface->resource()->breadthfirst([now](SP<CWLSurfaceResource> r, const Vector2D& offset, void* d) { r->frame(now); }, nullptr);
     }
 
     for (auto const& lsl : pMonitor->m_aLayerSurfaceLayers) {
@@ -1869,10 +1867,10 @@ void CHyprRenderer::damageWindow(PHLWINDOW pWindow, bool forceFull) {
         return;
 
     CBox       windowBox        = pWindow->getFullWindowBoundingBox();
-    const auto PWINDOWWORKSPACE = pWindow->m_pWorkspace;
-    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated() && !pWindow->m_bPinned)
+    const auto PWINDOWWORKSPACE = pWindow->m_workspace;
+    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated() && !pWindow->m_pinned)
         windowBox.translate(PWINDOWWORKSPACE->m_renderOffset->value());
-    windowBox.translate(pWindow->m_vFloatingOffset);
+    windowBox.translate(pWindow->m_floatingOffset);
 
     for (auto const& m : g_pCompositor->m_monitors) {
         if (forceFull || shouldRenderWindow(pWindow, m)) { // only damage if window is rendered on monitor
@@ -1882,13 +1880,13 @@ void CHyprRenderer::damageWindow(PHLWINDOW pWindow, bool forceFull) {
         }
     }
 
-    for (auto const& wd : pWindow->m_dWindowDecorations)
+    for (auto const& wd : pWindow->m_windowDecorations)
         wd->damageEntire();
 
     static auto PLOGDAMAGE = CConfigValue<Hyprlang::INT>("debug:log_damage");
 
     if (*PLOGDAMAGE)
-        Debug::log(LOG, "Damage: Window ({}): xy: {}, {} wh: {}, {}", pWindow->m_szTitle, windowBox.x, windowBox.y, windowBox.width, windowBox.height);
+        Debug::log(LOG, "Damage: Window ({}): xy: {}, {} wh: {}, {}", pWindow->m_title, windowBox.x, windowBox.y, windowBox.width, windowBox.height);
 }
 
 void CHyprRenderer::damageMonitor(PHLMONITOR pMonitor) {
@@ -2131,8 +2129,8 @@ void CHyprRenderer::recheckSolitaryForMonitor(PHLMONITOR pMonitor) {
     if (!PCANDIDATE->opaque())
         return;
 
-    if (PCANDIDATE->m_vRealSize->value() != pMonitor->vecSize || PCANDIDATE->m_vRealPosition->value() != pMonitor->vecPosition || PCANDIDATE->m_vRealPosition->isBeingAnimated() ||
-        PCANDIDATE->m_vRealSize->isBeingAnimated())
+    if (PCANDIDATE->m_realSize->value() != pMonitor->vecSize || PCANDIDATE->m_realPosition->value() != pMonitor->vecPosition || PCANDIDATE->m_realPosition->isBeingAnimated() ||
+        PCANDIDATE->m_realSize->isBeingAnimated())
         return;
 
     if (!pMonitor->m_aLayerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY].empty())
@@ -2144,10 +2142,10 @@ void CHyprRenderer::recheckSolitaryForMonitor(PHLMONITOR pMonitor) {
     }
 
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w == PCANDIDATE || (!w->m_bIsMapped && !w->m_bFadingOut) || w->isHidden())
+        if (w == PCANDIDATE || (!w->m_isMapped && !w->m_fadingOut) || w->isHidden())
             continue;
 
-        if (w->m_pWorkspace == PCANDIDATE->m_pWorkspace && w->m_bIsFloating && w->m_bCreatedOverFullscreen && w->visibleOnMonitor(pMonitor))
+        if (w->m_workspace == PCANDIDATE->m_workspace && w->m_isFloating && w->m_createdOverFullscreen && w->visibleOnMonitor(pMonitor))
             return;
     }
 
@@ -2156,7 +2154,7 @@ void CHyprRenderer::recheckSolitaryForMonitor(PHLMONITOR pMonitor) {
 
     // check if it did not open any subsurfaces or shit
     int surfaceCount = 0;
-    if (PCANDIDATE->m_bIsX11)
+    if (PCANDIDATE->m_isX11)
         surfaceCount = 1;
     else
         surfaceCount = PCANDIDATE->popupsCount() + PCANDIDATE->surfacesCount();
@@ -2370,7 +2368,7 @@ void CHyprRenderer::addWindowToRenderUnfocused(PHLWINDOW window) {
 
 void CHyprRenderer::makeRawWindowSnapshot(PHLWINDOW pWindow, CFramebuffer* pFramebuffer) {
     // we trust the window is valid.
-    const auto PMONITOR = pWindow->m_pMonitor.lock();
+    const auto PMONITOR = pWindow->m_monitor.lock();
 
     if (!PMONITOR || !PMONITOR->output || PMONITOR->vecPixelSize.x <= 0 || PMONITOR->vecPixelSize.y <= 0)
         return;
@@ -2414,7 +2412,7 @@ void CHyprRenderer::makeRawWindowSnapshot(PHLWINDOW pWindow, CFramebuffer* pFram
 
 void CHyprRenderer::makeWindowSnapshot(PHLWINDOW pWindow) {
     // we trust the window is valid.
-    const auto PMONITOR = pWindow->m_pMonitor.lock();
+    const auto PMONITOR = pWindow->m_monitor.lock();
 
     if (!PMONITOR || !PMONITOR->output || PMONITOR->vecPixelSize.x <= 0 || PMONITOR->vecPixelSize.y <= 0)
         return;
@@ -2452,7 +2450,7 @@ void CHyprRenderer::makeWindowSnapshot(PHLWINDOW pWindow) {
 
     g_pHyprOpenGL->clear(CHyprColor(0, 0, 0, 0)); // JIC
 
-    renderWindow(pWindow, PMONITOR, Time::steadyNow(), !pWindow->m_bX11DoesntWantBorders, RENDER_PASS_ALL);
+    renderWindow(pWindow, PMONITOR, Time::steadyNow(), !pWindow->m_X11DoesntWantBorders, RENDER_PASS_ALL);
 
     **PBLUR = BLURVAL;
 
@@ -2511,27 +2509,27 @@ void CHyprRenderer::renderSnapshot(PHLWINDOW pWindow) {
     if (!FBDATA->getTexture())
         return;
 
-    const auto PMONITOR = pWindow->m_pMonitor.lock();
+    const auto PMONITOR = pWindow->m_monitor.lock();
 
     CBox       windowBox;
     // some mafs to figure out the correct box
     // the originalClosedPos is relative to the monitor's pos
-    Vector2D scaleXY = Vector2D((PMONITOR->scale * pWindow->m_vRealSize->value().x / (pWindow->m_vOriginalClosedSize.x * PMONITOR->scale)),
-                                (PMONITOR->scale * pWindow->m_vRealSize->value().y / (pWindow->m_vOriginalClosedSize.y * PMONITOR->scale)));
+    Vector2D scaleXY = Vector2D((PMONITOR->scale * pWindow->m_realSize->value().x / (pWindow->m_originalClosedSize.x * PMONITOR->scale)),
+                                (PMONITOR->scale * pWindow->m_realSize->value().y / (pWindow->m_originalClosedSize.y * PMONITOR->scale)));
 
     windowBox.width  = PMONITOR->vecTransformedSize.x * scaleXY.x;
     windowBox.height = PMONITOR->vecTransformedSize.y * scaleXY.y;
-    windowBox.x      = ((pWindow->m_vRealPosition->value().x - PMONITOR->vecPosition.x) * PMONITOR->scale) - ((pWindow->m_vOriginalClosedPos.x * PMONITOR->scale) * scaleXY.x);
-    windowBox.y      = ((pWindow->m_vRealPosition->value().y - PMONITOR->vecPosition.y) * PMONITOR->scale) - ((pWindow->m_vOriginalClosedPos.y * PMONITOR->scale) * scaleXY.y);
+    windowBox.x      = ((pWindow->m_realPosition->value().x - PMONITOR->vecPosition.x) * PMONITOR->scale) - ((pWindow->m_originalClosedPos.x * PMONITOR->scale) * scaleXY.x);
+    windowBox.y      = ((pWindow->m_realPosition->value().y - PMONITOR->vecPosition.y) * PMONITOR->scale) - ((pWindow->m_originalClosedPos.y * PMONITOR->scale) * scaleXY.y);
 
     CRegion fakeDamage{0, 0, PMONITOR->vecTransformedSize.x, PMONITOR->vecTransformedSize.y};
 
-    if (*PDIMAROUND && pWindow->m_sWindowData.dimAround.valueOrDefault()) {
+    if (*PDIMAROUND && pWindow->m_windowData.dimAround.valueOrDefault()) {
 
         CRectPassElement::SRectData data;
 
         data.box   = {0, 0, g_pHyprOpenGL->m_RenderData.pMonitor->vecPixelSize.x, g_pHyprOpenGL->m_RenderData.pMonitor->vecPixelSize.y};
-        data.color = CHyprColor(0, 0, 0, *PDIMAROUND * pWindow->m_fAlpha->value());
+        data.color = CHyprColor(0, 0, 0, *PDIMAROUND * pWindow->m_alpha->value());
 
         m_sRenderPass.add(makeShared<CRectPassElement>(data));
         damageMonitor(PMONITOR);
@@ -2541,7 +2539,7 @@ void CHyprRenderer::renderSnapshot(PHLWINDOW pWindow) {
     data.flipEndFrame = true;
     data.tex          = FBDATA->getTexture();
     data.box          = windowBox;
-    data.a            = pWindow->m_fAlpha->value();
+    data.a            = pWindow->m_alpha->value();
     data.damage       = fakeDamage;
 
     m_sRenderPass.add(makeShared<CTexPassElement>(data));

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -36,12 +36,12 @@ CBox CHyprBorderDecoration::assignedBoxGlobal() {
     CBox box = m_bAssignedGeometry;
     box.translate(g_pDecorationPositioner->getEdgeDefinedPoint(DECORATION_EDGE_BOTTOM | DECORATION_EDGE_LEFT | DECORATION_EDGE_RIGHT | DECORATION_EDGE_TOP, m_pWindow.lock()));
 
-    const auto PWORKSPACE = m_pWindow->m_pWorkspace;
+    const auto PWORKSPACE = m_pWindow->m_workspace;
 
     if (!PWORKSPACE)
         return box;
 
-    const auto WORKSPACEOFFSET = PWORKSPACE && !m_pWindow->m_bPinned ? PWORKSPACE->m_renderOffset->value() : Vector2D();
+    const auto WORKSPACEOFFSET = PWORKSPACE && !m_pWindow->m_pinned ? PWORKSPACE->m_renderOffset->value() : Vector2D();
     return box.translate(WORKSPACEOFFSET);
 }
 
@@ -52,22 +52,22 @@ void CHyprBorderDecoration::draw(PHLMONITOR pMonitor, float const& a) {
     if (m_bAssignedGeometry.width < m_seExtents.topLeft.x + 1 || m_bAssignedGeometry.height < m_seExtents.topLeft.y + 1)
         return;
 
-    CBox windowBox = assignedBoxGlobal().translate(-pMonitor->vecPosition + m_pWindow->m_vFloatingOffset).expand(-m_pWindow->getRealBorderSize()).scale(pMonitor->scale).round();
+    CBox windowBox = assignedBoxGlobal().translate(-pMonitor->vecPosition + m_pWindow->m_floatingOffset).expand(-m_pWindow->getRealBorderSize()).scale(pMonitor->scale).round();
 
     if (windowBox.width < 1 || windowBox.height < 1)
         return;
 
-    auto       grad     = m_pWindow->m_cRealBorderColor;
-    const bool ANIMATED = m_pWindow->m_fBorderFadeAnimationProgress->isBeingAnimated();
+    auto       grad     = m_pWindow->m_realBorderColor;
+    const bool ANIMATED = m_pWindow->m_borderFadeAnimationProgress->isBeingAnimated();
 
-    if (m_pWindow->m_fBorderAngleAnimationProgress->enabled()) {
-        grad.m_angle += m_pWindow->m_fBorderAngleAnimationProgress->value() * M_PI * 2;
+    if (m_pWindow->m_borderAngleAnimationProgress->enabled()) {
+        grad.m_angle += m_pWindow->m_borderAngleAnimationProgress->value() * M_PI * 2;
         grad.m_angle = normalizeAngleRad(grad.m_angle);
 
         // When borderangle is animated, it is counterintuitive to fade between inactive/active gradient angles.
         // Instead we sync the angles to avoid fading between them and additionally rotating the border angle.
         if (ANIMATED)
-            m_pWindow->m_cRealBorderColorPrevious.m_angle = grad.m_angle;
+            m_pWindow->m_realBorderColorPrevious.m_angle = grad.m_angle;
     }
 
     int                             borderSize    = m_pWindow->getRealBorderSize();
@@ -84,9 +84,9 @@ void CHyprBorderDecoration::draw(PHLMONITOR pMonitor, float const& a) {
 
     if (ANIMATED) {
         data.hasGrad2 = true;
-        data.grad1    = m_pWindow->m_cRealBorderColorPrevious;
+        data.grad1    = m_pWindow->m_realBorderColorPrevious;
         data.grad2    = grad;
-        data.lerp     = m_pWindow->m_fBorderFadeAnimationProgress->value();
+        data.lerp     = m_pWindow->m_borderFadeAnimationProgress->value();
     }
 
     g_pHyprRenderer->m_sRenderPass.add(makeShared<CBorderPassElement>(data));
@@ -119,10 +119,10 @@ void CHyprBorderDecoration::damageEntire() {
     const auto ROUNDINGSIZE = ROUNDING - M_SQRT1_2 * ROUNDING + 2;
     const auto BORDERSIZE   = m_pWindow->getRealBorderSize() + 1;
 
-    const auto PWINDOWWORKSPACE = m_pWindow->m_pWorkspace;
-    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated() && !m_pWindow->m_bPinned)
+    const auto PWINDOWWORKSPACE = m_pWindow->m_workspace;
+    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated() && !m_pWindow->m_pinned)
         surfaceBox.translate(PWINDOWWORKSPACE->m_renderOffset->value());
-    surfaceBox.translate(m_pWindow->m_vFloatingOffset);
+    surfaceBox.translate(m_pWindow->m_floatingOffset);
 
     CBox surfaceBoxExpandedBorder = surfaceBox;
     surfaceBoxExpandedBorder.expand(BORDERSIZE);
@@ -157,5 +157,5 @@ std::string CHyprBorderDecoration::getDisplayName() {
 }
 
 bool CHyprBorderDecoration::doesntWantBorders() {
-    return m_pWindow->m_sWindowData.noBorder.valueOrDefault() || m_pWindow->m_bX11DoesntWantBorders || m_pWindow->getRealBorderSize() == 0;
+    return m_pWindow->m_windowData.noBorder.valueOrDefault() || m_pWindow->m_X11DoesntWantBorders || m_pWindow->getRealBorderSize() == 0;
 }

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -43,7 +43,7 @@ SDecorationPositioningInfo CHyprGroupBarDecoration::getPositioningInfo() {
     info.priority = *PPRIORITY;
     info.reserved = true;
 
-    if (*PENABLED && m_pWindow->m_sWindowData.decorate.valueOrDefault()) {
+    if (*PENABLED && m_pWindow->m_windowData.decorate.valueOrDefault()) {
         if (*PSTACKED) {
             const auto ONEBARHEIGHT = *POUTERGAP + *PINDICATORHEIGHT + *PINDICATORGAP + (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0);
             info.desiredExtents     = {{0, (ONEBARHEIGHT * m_dwGroupMembers.size()) + (*PKEEPUPPERGAP * *POUTERGAP)}, {0, 0}};
@@ -65,7 +65,7 @@ eDecorationType CHyprGroupBarDecoration::getDecorationType() {
 //
 
 void CHyprGroupBarDecoration::updateWindow(PHLWINDOW pWindow) {
-    if (m_pWindow->m_sGroupData.pNextWindow.expired()) {
+    if (m_pWindow->m_groupData.pNextWindow.expired()) {
         m_pWindow->removeWindowDeco(this);
         return;
     }
@@ -74,10 +74,10 @@ void CHyprGroupBarDecoration::updateWindow(PHLWINDOW pWindow) {
     PHLWINDOW head = pWindow->getGroupHead();
     m_dwGroupMembers.emplace_back(head);
 
-    PHLWINDOW curr = head->m_sGroupData.pNextWindow.lock();
+    PHLWINDOW curr = head->m_groupData.pNextWindow.lock();
     while (curr != head) {
         m_dwGroupMembers.emplace_back(curr);
-        curr = curr->m_sGroupData.pNextWindow.lock();
+        curr = curr->m_groupData.pNextWindow.lock();
     }
 
     damageEntire();
@@ -90,7 +90,7 @@ void CHyprGroupBarDecoration::updateWindow(PHLWINDOW pWindow) {
 
 void CHyprGroupBarDecoration::damageEntire() {
     auto box = assignedBoxGlobal();
-    box.translate(m_pWindow->m_vFloatingOffset);
+    box.translate(m_pWindow->m_floatingOffset);
     g_pHyprRenderer->damageBox(box);
 }
 
@@ -100,7 +100,7 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
 
     static auto PENABLED = CConfigValue<Hyprlang::INT>("group:groupbar:enabled");
 
-    if (!*PENABLED || !m_pWindow->m_sWindowData.decorate.valueOrDefault())
+    if (!*PENABLED || !m_pWindow->m_windowData.decorate.valueOrDefault())
         return;
 
     static auto PRENDERTITLES              = CConfigValue<Hyprlang::INT>("group:groupbar:render_titles");
@@ -143,13 +143,13 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
     for (int i = 0; i < barsToDraw; ++i) {
         const auto WINDOWINDEX = *PSTACKED ? m_dwGroupMembers.size() - i - 1 : i;
 
-        CBox       rect = {ASSIGNEDBOX.x + xoff - pMonitor->vecPosition.x + m_pWindow->m_vFloatingOffset.x,
-                           ASSIGNEDBOX.y + ASSIGNEDBOX.h - floor(yoff) - *PINDICATORHEIGHT - *POUTERGAP - pMonitor->vecPosition.y + m_pWindow->m_vFloatingOffset.y, m_fBarWidth,
+        CBox       rect = {ASSIGNEDBOX.x + xoff - pMonitor->vecPosition.x + m_pWindow->m_floatingOffset.x,
+                           ASSIGNEDBOX.y + ASSIGNEDBOX.h - floor(yoff) - *PINDICATORHEIGHT - *POUTERGAP - pMonitor->vecPosition.y + m_pWindow->m_floatingOffset.y, m_fBarWidth,
                            *PINDICATORHEIGHT};
 
         rect.scale(pMonitor->scale).round();
 
-        const bool        GROUPLOCKED  = m_pWindow->getGroupHead()->m_sGroupData.locked || g_pKeybindManager->m_bGroupsLocked;
+        const bool        GROUPLOCKED  = m_pWindow->getGroupHead()->m_groupData.locked || g_pKeybindManager->m_bGroupsLocked;
         const auto* const PCOLACTIVE   = GROUPLOCKED ? GROUPCOLACTIVELOCKED : GROUPCOLACTIVE;
         const auto* const PCOLINACTIVE = GROUPLOCKED ? GROUPCOLINACTIVELOCKED : GROUPCOLINACTIVE;
 
@@ -187,8 +187,8 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
             g_pHyprRenderer->m_sRenderPass.add(makeShared<CRectPassElement>(rectdata));
         }
 
-        rect = {ASSIGNEDBOX.x + xoff - pMonitor->vecPosition.x + m_pWindow->m_vFloatingOffset.x,
-                ASSIGNEDBOX.y + ASSIGNEDBOX.h - floor(yoff) - ONEBARHEIGHT - pMonitor->vecPosition.y + m_pWindow->m_vFloatingOffset.y, m_fBarWidth,
+        rect = {ASSIGNEDBOX.x + xoff - pMonitor->vecPosition.x + m_pWindow->m_floatingOffset.x,
+                ASSIGNEDBOX.y + ASSIGNEDBOX.h - floor(yoff) - ONEBARHEIGHT - pMonitor->vecPosition.y + m_pWindow->m_floatingOffset.y, m_fBarWidth,
                 (*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0)};
         rect.scale(pMonitor->scale);
 
@@ -229,7 +229,7 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
             }
 
             if (*PRENDERTITLES) {
-                CTitleTex* pTitleTex = textureFromTitle(m_dwGroupMembers[WINDOWINDEX]->m_szTitle);
+                CTitleTex* pTitleTex = textureFromTitle(m_dwGroupMembers[WINDOWINDEX]->m_title);
 
                 if (!pTitleTex)
                     pTitleTex =
@@ -276,7 +276,7 @@ void CHyprGroupBarDecoration::invalidateTextures() {
     m_sTitleTexs.titleTexs.clear();
 }
 
-CTitleTex::CTitleTex(PHLWINDOW pWindow, const Vector2D& bufferSize, const float monitorScale) : szContent(pWindow->m_szTitle), pWindowOwner(pWindow) {
+CTitleTex::CTitleTex(PHLWINDOW pWindow, const Vector2D& bufferSize, const float monitorScale) : szContent(pWindow->m_title), pWindowOwner(pWindow) {
     static auto      FALLBACKFONT     = CConfigValue<std::string>("misc:font_family");
     static auto      PTITLEFONTFAMILY = CConfigValue<std::string>("group:groupbar:font_family");
     static auto      PTITLEFONTSIZE   = CConfigValue<Hyprlang::INT>("group:groupbar:font_size");
@@ -291,8 +291,8 @@ CTitleTex::CTitleTex(PHLWINDOW pWindow, const Vector2D& bufferSize, const float 
     const CHyprColor COLOR      = CHyprColor(*PTEXTCOLOR);
     const auto       FONTFAMILY = *PTITLEFONTFAMILY != STRVAL_EMPTY ? *PTITLEFONTFAMILY : *FALLBACKFONT;
 
-    texActive   = g_pHyprOpenGL->renderText(pWindow->m_szTitle, COLOR, *PTITLEFONTSIZE * monitorScale, false, FONTFAMILY, bufferSize.x - 2, FONTWEIGHTACTIVE->m_value);
-    texInactive = g_pHyprOpenGL->renderText(pWindow->m_szTitle, COLOR, *PTITLEFONTSIZE * monitorScale, false, FONTFAMILY, bufferSize.x - 2, FONTWEIGHTINACTIVE->m_value);
+    texActive   = g_pHyprOpenGL->renderText(pWindow->m_title, COLOR, *PTITLEFONTSIZE * monitorScale, false, FONTFAMILY, bufferSize.x - 2, FONTWEIGHTACTIVE->m_value);
+    texInactive = g_pHyprOpenGL->renderText(pWindow->m_title, COLOR, *PTITLEFONTSIZE * monitorScale, false, FONTFAMILY, bufferSize.x - 2, FONTWEIGHTINACTIVE->m_value);
 }
 
 static void renderGradientTo(SP<CTexture> tex, CGradientValueData* grad) {
@@ -380,7 +380,7 @@ bool CHyprGroupBarDecoration::onBeginWindowDragOnDeco(const Vector2D& pos) {
     static auto PSTACKED  = CConfigValue<Hyprlang::INT>("group:groupbar:stacked");
     static auto POUTERGAP = CConfigValue<Hyprlang::INT>("group:groupbar:gaps_out");
     static auto PINNERGAP = CConfigValue<Hyprlang::INT>("group:groupbar:gaps_in");
-    if (m_pWindow.lock() == m_pWindow->m_sGroupData.pNextWindow.lock())
+    if (m_pWindow.lock() == m_pWindow->m_groupData.pNextWindow.lock())
         return false;
 
     const float BARRELATIVEX = pos.x - assignedBoxGlobal().x;
@@ -397,7 +397,7 @@ bool CHyprGroupBarDecoration::onBeginWindowDragOnDeco(const Vector2D& pos) {
 
     // hack
     g_pLayoutManager->getCurrentLayout()->onWindowRemoved(pWindow);
-    if (!pWindow->m_bIsFloating) {
+    if (!pWindow->m_isFloating) {
         const bool GROUPSLOCKEDPREV        = g_pKeybindManager->m_bGroupsLocked;
         g_pKeybindManager->m_bGroupsLocked = true;
         g_pLayoutManager->getCurrentLayout()->onWindowCreated(pWindow);
@@ -419,12 +419,12 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, PHLWIND
     static auto PMERGEGROUPSONGROUPBAR           = CConfigValue<Hyprlang::INT>("group:merge_groups_on_groupbar");
     static auto POUTERGAP                        = CConfigValue<Hyprlang::INT>("group:groupbar:gaps_out");
     static auto PINNERGAP                        = CConfigValue<Hyprlang::INT>("group:groupbar:gaps_in");
-    const bool  FLOATEDINTOTILED                 = !m_pWindow->m_bIsFloating && !pDraggedWindow->m_bDraggingTiled;
+    const bool  FLOATEDINTOTILED                 = !m_pWindow->m_isFloating && !pDraggedWindow->m_draggingTiled;
 
     g_pInputManager->m_bWasDraggingWindow = false;
 
     if (!pDraggedWindow->canBeGroupedInto(m_pWindow.lock()) || (*PDRAGINTOGROUP != 1 && *PDRAGINTOGROUP != 2) || (FLOATEDINTOTILED && !*PMERGEFLOATEDINTOTILEDONGROUPBAR) ||
-        (!*PMERGEGROUPSONGROUPBAR && pDraggedWindow->m_sGroupData.pNextWindow.lock() && m_pWindow->m_sGroupData.pNextWindow.lock())) {
+        (!*PMERGEGROUPSONGROUPBAR && pDraggedWindow->m_groupData.pNextWindow.lock() && m_pWindow->m_groupData.pNextWindow.lock())) {
         g_pInputManager->m_bWasDraggingWindow = true;
         return false;
     }
@@ -434,49 +434,49 @@ bool CHyprGroupBarDecoration::onEndWindowDragOnDeco(const Vector2D& pos, PHLWIND
     const int   WINDOWINDEX = BARRELATIVE < 0 ? -1 : BARRELATIVE / BARSIZE;
 
     PHLWINDOW   pWindowInsertAfter = m_pWindow->getGroupWindowByIndex(WINDOWINDEX);
-    PHLWINDOW   pWindowInsertEnd   = pWindowInsertAfter->m_sGroupData.pNextWindow.lock();
-    PHLWINDOW   pDraggedHead       = pDraggedWindow->m_sGroupData.pNextWindow.lock() ? pDraggedWindow->getGroupHead() : pDraggedWindow;
+    PHLWINDOW   pWindowInsertEnd   = pWindowInsertAfter->m_groupData.pNextWindow.lock();
+    PHLWINDOW   pDraggedHead       = pDraggedWindow->m_groupData.pNextWindow.lock() ? pDraggedWindow->getGroupHead() : pDraggedWindow;
 
-    if (!pDraggedWindow->m_sGroupData.pNextWindow.expired()) {
+    if (!pDraggedWindow->m_groupData.pNextWindow.expired()) {
 
         // stores group data
         std::vector<PHLWINDOW> members;
         PHLWINDOW              curr      = pDraggedHead;
-        const bool             WASLOCKED = pDraggedHead->m_sGroupData.locked;
+        const bool             WASLOCKED = pDraggedHead->m_groupData.locked;
         do {
             members.push_back(curr);
-            curr = curr->m_sGroupData.pNextWindow.lock();
+            curr = curr->m_groupData.pNextWindow.lock();
         } while (curr != members[0]);
 
         // removes all windows
         for (const PHLWINDOW& w : members) {
-            w->m_sGroupData.pNextWindow.reset();
-            w->m_sGroupData.head   = false;
-            w->m_sGroupData.locked = false;
+            w->m_groupData.pNextWindow.reset();
+            w->m_groupData.head   = false;
+            w->m_groupData.locked = false;
             g_pLayoutManager->getCurrentLayout()->onWindowRemoved(w);
         }
 
         // restores the group
         for (auto it = members.begin(); it != members.end(); ++it) {
-            (*it)->m_bIsFloating    = pWindowInsertAfter->m_bIsFloating;           // match the floating state of group members
-            *(*it)->m_vRealSize     = pWindowInsertAfter->m_vRealSize->goal();     // match the size of group members
-            *(*it)->m_vRealPosition = pWindowInsertAfter->m_vRealPosition->goal(); // match the position of group members
+            (*it)->m_isFloating    = pWindowInsertAfter->m_isFloating;           // match the floating state of group members
+            *(*it)->m_realSize     = pWindowInsertAfter->m_realSize->goal();     // match the size of group members
+            *(*it)->m_realPosition = pWindowInsertAfter->m_realPosition->goal(); // match the position of group members
             if (std::next(it) != members.end())
-                (*it)->m_sGroupData.pNextWindow = *std::next(it);
+                (*it)->m_groupData.pNextWindow = *std::next(it);
             else
-                (*it)->m_sGroupData.pNextWindow = members[0];
+                (*it)->m_groupData.pNextWindow = members[0];
         }
-        members[0]->m_sGroupData.head   = true;
-        members[0]->m_sGroupData.locked = WASLOCKED;
+        members[0]->m_groupData.head   = true;
+        members[0]->m_groupData.locked = WASLOCKED;
     } else
         g_pLayoutManager->getCurrentLayout()->onWindowRemoved(pDraggedWindow);
 
-    pDraggedWindow->m_bIsFloating = pWindowInsertAfter->m_bIsFloating; // match the floating state of the window
+    pDraggedWindow->m_isFloating = pWindowInsertAfter->m_isFloating; // match the floating state of the window
 
     pWindowInsertAfter->insertWindowToGroup(pDraggedWindow);
 
     if (WINDOWINDEX == -1)
-        std::swap(pDraggedHead->m_sGroupData.head, pWindowInsertEnd->m_sGroupData.head);
+        std::swap(pDraggedHead->m_groupData.head, pWindowInsertEnd->m_groupData.head);
 
     m_pWindow->setGroupCurrent(pDraggedWindow);
     pDraggedWindow->applyGroupRules();
@@ -533,7 +533,7 @@ bool CHyprGroupBarDecoration::onMouseButtonOnDeco(const Vector2D& pos, const IPo
     if (!g_pCompositor->isWindowActive(pWindow) && *PFOLLOWMOUSE != 3)
         g_pCompositor->focusWindow(pWindow);
 
-    if (pWindow->m_bIsFloating)
+    if (pWindow->m_isFloating)
         g_pCompositor->changeWindowZOrder(pWindow, true);
 
     return true;
@@ -542,11 +542,11 @@ bool CHyprGroupBarDecoration::onMouseButtonOnDeco(const Vector2D& pos, const IPo
 bool CHyprGroupBarDecoration::onScrollOnDeco(const Vector2D& pos, const IPointer::SAxisEvent e) {
     static auto PGROUPBARSCROLLING = CConfigValue<Hyprlang::INT>("group:groupbar:scrolling");
 
-    if (!*PGROUPBARSCROLLING || m_pWindow->m_sGroupData.pNextWindow.expired())
+    if (!*PGROUPBARSCROLLING || m_pWindow->m_groupData.pNextWindow.expired())
         return false;
 
     if (e.delta > 0)
-        m_pWindow->setGroupCurrent(m_pWindow->m_sGroupData.pNextWindow.lock());
+        m_pWindow->setGroupCurrent(m_pWindow->m_groupData.pNextWindow.lock());
     else
         m_pWindow->setGroupCurrent(m_pWindow->getGroupPrevious());
 
@@ -579,9 +579,9 @@ CBox CHyprGroupBarDecoration::assignedBoxGlobal() {
     CBox box = m_bAssignedBox;
     box.translate(g_pDecorationPositioner->getEdgeDefinedPoint(DECORATION_EDGE_TOP, m_pWindow.lock()));
 
-    const auto PWORKSPACE = m_pWindow->m_pWorkspace;
+    const auto PWORKSPACE = m_pWindow->m_workspace;
 
-    if (PWORKSPACE && !m_pWindow->m_bPinned)
+    if (PWORKSPACE && !m_pWindow->m_pinned)
         box.translate(PWORKSPACE->m_renderOffset->value());
 
     return box.round();

--- a/src/render/decorations/DecorationPositioner.cpp
+++ b/src/render/decorations/DecorationPositioner.cpp
@@ -91,8 +91,8 @@ void CDecorationPositioner::sanitizeDatas() {
     std::erase_if(m_vWindowPositioningDatas, [](const auto& other) {
         if (!validMapped(other->pWindow))
             return true;
-        if (std::find_if(other->pWindow->m_dWindowDecorations.begin(), other->pWindow->m_dWindowDecorations.end(),
-                         [&](const auto& el) { return el.get() == other->pDecoration; }) == other->pWindow->m_dWindowDecorations.end())
+        if (std::find_if(other->pWindow->m_windowDecorations.begin(), other->pWindow->m_windowDecorations.end(), [&](const auto& el) { return el.get() == other->pDecoration; }) ==
+            other->pWindow->m_windowDecorations.end())
             return true;
         return false;
     });
@@ -123,13 +123,13 @@ void CDecorationPositioner::onWindowUpdate(PHLWINDOW pWindow) {
     //
     std::vector<CDecorationPositioner::SWindowPositioningData*> datas;
     // reserve to avoid reallocations
-    datas.reserve(pWindow->m_dWindowDecorations.size());
+    datas.reserve(pWindow->m_windowDecorations.size());
 
-    for (auto const& wd : pWindow->m_dWindowDecorations) {
+    for (auto const& wd : pWindow->m_windowDecorations) {
         datas.push_back(getDataFor(wd.get(), pWindow));
     }
 
-    if (WINDOWDATA->lastWindowSize == pWindow->m_vRealSize->value() /* position not changed */
+    if (WINDOWDATA->lastWindowSize == pWindow->m_realSize->value() /* position not changed */
         && std::all_of(m_vWindowPositioningDatas.begin(), m_vWindowPositioningDatas.end(),
                        [pWindow](const auto& data) { return pWindow != data->pWindow.lock() || !data->needsReposition; })
         /* all window datas are either not for this window or don't need a reposition */
@@ -137,9 +137,9 @@ void CDecorationPositioner::onWindowUpdate(PHLWINDOW pWindow) {
     )
         return;
 
-    WINDOWDATA->lastWindowSize = pWindow->m_vRealSize->value();
+    WINDOWDATA->lastWindowSize = pWindow->m_realSize->value();
     WINDOWDATA->needsRecalc    = false;
-    const bool EPHEMERAL       = pWindow->m_vRealSize->isBeingAnimated();
+    const bool EPHEMERAL       = pWindow->m_realSize->isBeingAnimated();
 
     std::sort(datas.begin(), datas.end(), [](const auto& a, const auto& b) { return a->positioningInfo.priority > b->positioningInfo.priority; });
 

--- a/src/render/pass/Pass.cpp
+++ b/src/render/pass/Pass.cpp
@@ -241,7 +241,7 @@ void CRenderPass::renderDebugData() {
     renderHLSurface(debugData.keyboardFocusText, g_pSeatManager->state.keyboardFocus.lock(), Colors::PURPLE.modifyA(0.1F));
     renderHLSurface(debugData.pointerFocusText, g_pSeatManager->state.pointerFocus.lock(), Colors::ORANGE.modifyA(0.1F));
     if (g_pCompositor->m_lastWindow)
-        renderHLSurface(debugData.lastWindowText, g_pCompositor->m_lastWindow->m_pWLSurface->resource(), Colors::LIGHT_BLUE.modifyA(0.1F));
+        renderHLSurface(debugData.lastWindowText, g_pCompositor->m_lastWindow->m_wlSurface->resource(), Colors::LIGHT_BLUE.modifyA(0.1F));
 
     if (g_pSeatManager->state.pointerFocus) {
         if (g_pSeatManager->state.pointerFocus->current.input.intersect(CBox{{}, g_pSeatManager->state.pointerFocus->current.size}).getExtents().size() !=

--- a/src/render/pass/SurfacePassElement.cpp
+++ b/src/render/pass/SurfacePassElement.cpp
@@ -75,7 +75,7 @@ void CSurfacePassElement::draw(const CRegion& damage) {
     const bool MISALIGNEDFSV1 = std::floor(data.pMonitor->scale) != data.pMonitor->scale /* Fractional */ && data.surface->current.scale == 1 /* fs protocol */ &&
         windowBox.size() != data.surface->current.bufferSize /* misaligned */ && DELTALESSTHAN(windowBox.width, data.surface->current.bufferSize.x, 3) &&
         DELTALESSTHAN(windowBox.height, data.surface->current.bufferSize.y, 3) /* off by one-or-two */ &&
-        (!data.pWindow || (!data.pWindow->m_vRealSize->isBeingAnimated() && !INTERACTIVERESIZEINPROGRESS)) /* not window or not animated/resizing */;
+        (!data.pWindow || (!data.pWindow->m_realSize->isBeingAnimated() && !INTERACTIVERESIZEINPROGRESS)) /* not window or not animated/resizing */;
 
     if (data.surface->colorManagement.valid())
         Debug::log(TRACE, "FIXME: rendering surface with color management enabled, should apply necessary transformations");
@@ -103,7 +103,7 @@ void CSurfacePassElement::draw(const CRegion& damage) {
         roundingPower = 2.0f;
     }
 
-    const bool WINDOWOPAQUE    = data.pWindow && data.pWindow->m_pWLSurface->resource() == data.surface ? data.pWindow->opaque() : false;
+    const bool WINDOWOPAQUE    = data.pWindow && data.pWindow->m_wlSurface->resource() == data.surface ? data.pWindow->opaque() : false;
     const bool CANDISABLEBLEND = ALPHA >= 1.f && OVERALL_ALPHA >= 1.f && rounding == 0 && WINDOWOPAQUE;
 
     if (CANDISABLEBLEND)
@@ -153,8 +153,8 @@ CBox CSurfacePassElement::getTexBox() {
             if (!INTERACTIVERESIZEINPROGRESS) {
                 windowBox.translate(CORRECT);
 
-                windowBox.width  = SIZE.x * (PWINDOW->m_vRealSize->value().x / PWINDOW->m_vReportedSize.x);
-                windowBox.height = SIZE.y * (PWINDOW->m_vRealSize->value().y / PWINDOW->m_vReportedSize.y);
+                windowBox.width  = SIZE.x * (PWINDOW->m_realSize->value().x / PWINDOW->m_reportedSize.x);
+                windowBox.height = SIZE.y * (PWINDOW->m_realSize->value().y / PWINDOW->m_reportedSize.y);
             } else {
                 windowBox.width  = SIZE.x;
                 windowBox.height = SIZE.y;
@@ -164,10 +164,10 @@ CBox CSurfacePassElement::getTexBox() {
     } else { //  here we clamp to 2, these might be some tiny specks
         windowBox = {(int)outputX + data.pos.x + data.localPos.x, (int)outputY + data.pos.y + data.localPos.y, std::max((float)data.surface->current.size.x, 2.F),
                      std::max((float)data.surface->current.size.y, 2.F)};
-        if (data.pWindow && data.pWindow->m_vRealSize->isBeingAnimated() && data.surface && !data.mainSurface && data.squishOversized /* subsurface */) {
+        if (data.pWindow && data.pWindow->m_realSize->isBeingAnimated() && data.surface && !data.mainSurface && data.squishOversized /* subsurface */) {
             // adjust subsurfaces to the window
-            windowBox.width  = (windowBox.width / data.pWindow->m_vReportedSize.x) * data.pWindow->m_vRealSize->value().x;
-            windowBox.height = (windowBox.height / data.pWindow->m_vReportedSize.y) * data.pWindow->m_vRealSize->value().y;
+            windowBox.width  = (windowBox.width / data.pWindow->m_reportedSize.x) * data.pWindow->m_realSize->value().x;
+            windowBox.height = (windowBox.height / data.pWindow->m_reportedSize.y) * data.pWindow->m_realSize->value().y;
         }
     }
 

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -46,7 +46,7 @@ void CXWM::handleCreate(xcb_create_notify_event_t* e) {
 
     const auto WINDOW = CWindow::create(XSURF);
     g_pCompositor->m_windows.emplace_back(WINDOW);
-    WINDOW->m_pSelf = WINDOW;
+    WINDOW->m_self = WINDOW;
     Debug::log(LOG, "[xwm] New XWayland window at {:x} for surf {:x}", (uintptr_t)WINDOW.get(), (uintptr_t)XSURF.get());
 }
 
@@ -1000,7 +1000,7 @@ void CXWM::activateSurface(SP<CXWaylandSurface> surf, bool activate) {
     if ((surf == focusedSurface && activate) || (surf && surf->overrideRedirect))
         return;
 
-    if (!surf || (!activate && g_pCompositor->m_lastWindow && !g_pCompositor->m_lastWindow->m_bIsX11)) {
+    if (!surf || (!activate && g_pCompositor->m_lastWindow && !g_pCompositor->m_lastWindow->m_isX11)) {
         setActiveWindow((uint32_t)XCB_WINDOW_NONE);
         focusWindow(nullptr);
     } else {

--- a/src/xwayland/XWayland.cpp
+++ b/src/xwayland/XWayland.cpp
@@ -9,7 +9,7 @@ CXWayland::CXWayland(const bool wantsEnabled) {
     if (!wantsEnabled) {
         Debug::log(LOG, "XWayland has been disabled, cleaning up...");
         for (auto& w : g_pCompositor->m_windows) {
-            if (!w->m_bIsX11)
+            if (!w->m_isX11)
                 continue;
             g_pCompositor->closeWindow(w);
         }


### PR DESCRIPTION
part of https://github.com/hyprwm/Hyprland/issues/9870

SAlphaValue has no `m_` prefix to be consistent with other structs. Eventually we'll refactor them separately.
```
struct SAlphaValue {
    float alpha;
    bool  override;
    ...
```

Removed since unused:
```
m_bWasMaximized
m_pX11Parent
m_iLastToplevelMonitorID
```