### PR TITLE
Update window fullscreen descriptor in hyprctl clients command

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -252,8 +252,10 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
     "pid": {},
     "xwayland": {},
     "pinned": {},
-    "fullscreen": {},
-    "fullscreenClient": {},
+    "fullscreenState": {{
+        "internal": {},
+        "client": {},
+    }},
     "grouped": [{}],
     "tags": [{}],
     "swallowing": "0x{:x}",
@@ -275,7 +277,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             "Window {:x} -> {}:\n\tmapped: {}\n\thidden: {}\n\tat: {},{}\n\tsize: {},{}\n\tworkspace: {} ({})\n\tfloating: {}\n\tpseudo: {}\n\tmonitor: {}\n\tclass: {}\n\ttitle: "
             "{}\n\tinitialClass: {}\n\tinitialTitle: {}\n\tpid: "
             "{}\n\txwayland: {}\n\tpinned: "
-            "{}\n\tfullscreen: {}\n\tfullscreenClient: {}\n\tgrouped: {}\n\ttags: {}\n\tswallowing: {:x}\n\tfocusHistoryID: {}\n\tinhibitingIdle: {}\n\txdgTag: "
+            "{}\n\tfullscreenState:\n\t\tinternal: {}\n\t\tclient: {}\n\tgrouped: {}\n\ttags: {}\n\tswallowing: {:x}\n\tfocusHistoryID: {}\n\tinhibitingIdle: {}\n\txdgTag: "
             "{}\n\txdgDescription: {}\n\n",
             (uintptr_t)w.get(), w->m_szTitle, (int)w->m_bIsMapped, (int)w->isHidden(), (int)w->m_vRealPosition->goal().x, (int)w->m_vRealPosition->goal().y,
             (int)w->m_vRealSize->goal().x, (int)w->m_vRealSize->goal().y, w->m_pWorkspace ? w->workspaceID() : WORKSPACE_INVALID, (!w->m_pWorkspace ? "" : w->m_pWorkspace->m_name),


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Spent more time than I'm proud to admit trying to figure out what "fullscreenClient" referred to especially cause the documentation only referred to "fullscreenState" for "internal" and "client". Figured it's worth updating the output of the `clients` command to more accurately reflect what is being shown

This: 
![20250427_18h19m02s_grim](https://github.com/user-attachments/assets/b4eb8d9c-184f-48d3-b94f-eae16e3d73a0)
![20250427_18h20m38s_grim](https://github.com/user-attachments/assets/4eaadb11-54b6-435a-8c1f-b8bd72c4497f)

Becomes this:
![20250427_18h20m14s_grim](https://github.com/user-attachments/assets/762f82fe-b771-407d-bb5a-6b13f6b5e4d6)
![20250427_18h20m23s_grim](https://github.com/user-attachments/assets/500225f4-c7a5-45fd-a252-15bc2899e9e9)


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
There is a possibility that some people are making use of this incorrect output for their automation - so maybe some sort of deprecation message would be useful.


#### Is it ready for merging, or does it need work?
Ready for merge.
