### PR TITLE
fix(window): use stored size for new floating window when persistentsize is set

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -3051,13 +3051,18 @@ void CConfigManager::ensurePersistentWorkspacesPresent() {
 }
 
 void CConfigManager::storeFloatingSize(PHLWINDOW window, const Vector2D& size) {
-    Debug::log(LOG, "storing floating size {}x{} for window {}::{}", size.x, size.y, window->m_class, window->m_title);
-    SFloatCache id{window};
+    Debug::log(LOG, "storing floating size {}x{} for window {}::{}", size.x, size.y, window->m_initialClass, window->m_initialTitle);
+    // true -> use m_initialClass and m_initialTitle
+    SFloatCache id{window, true};
     m_mStoredFloatingSizes[id] = size;
 }
 
 std::optional<Vector2D> CConfigManager::getStoredFloatingSize(PHLWINDOW window) {
-    SFloatCache id{window};
+    // At startup, m_initialClass and m_initialTitle are undefined 
+    // and m_class and m_title are just "initial" ones.
+    // false -> use m_class and m_title
+    SFloatCache id{window, false};
+    Debug::log(LOG, "Hash for window {}::{} = {}", window->m_class, window->m_title, id.hash);
     if (m_mStoredFloatingSizes.contains(id)) {
         Debug::log(LOG, "got stored size {}x{} for window {}::{}", m_mStoredFloatingSizes[id].x, m_mStoredFloatingSizes[id].y, window->m_class, window->m_title);
         return m_mStoredFloatingSizes[id];

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -3058,7 +3058,7 @@ void CConfigManager::storeFloatingSize(PHLWINDOW window, const Vector2D& size) {
 }
 
 std::optional<Vector2D> CConfigManager::getStoredFloatingSize(PHLWINDOW window) {
-    // At startup, m_initialClass and m_initialTitle are undefined 
+    // At startup, m_initialClass and m_initialTitle are undefined
     // and m_class and m_title are just "initial" ones.
     // false -> use m_class and m_title
     SFloatCache id{window, false};

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -148,9 +148,8 @@ struct SFloatCache {
 
         // Use empty string as default tag value
         std::string tagValue = "";
-        if (auto xdgTag = window->xdgTag()) {
+        if (auto xdgTag = window->xdgTag())
             tagValue = xdgTag.value();
-        }
 
         // Combine hashes
         hash = baseHash ^ (std::hash<std::string>{}(tagValue) << 2);

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -142,10 +142,18 @@ struct SFloatCache {
     size_t hash;
 
     SFloatCache(PHLWINDOW window, bool initial) {
-        if (initial)
-            hash = std::hash<std::string>{}(window->m_initialClass) ^ (std::hash<std::string>{}(window->m_initialTitle) << 1);
-        else
-            hash = std::hash<std::string>{}(window->m_class) ^ (std::hash<std::string>{}(window->m_title) << 1);
+        // Base hash from class/title
+        size_t baseHash = initial ? (std::hash<std::string>{}(window->m_initialClass) ^ (std::hash<std::string>{}(window->m_initialTitle) << 1)) :
+                                    (std::hash<std::string>{}(window->m_class) ^ (std::hash<std::string>{}(window->m_title) << 1));
+
+        // Use empty string as default tag value
+        std::string tagValue = "";
+        if (auto xdgTag = window->xdgTag()) {
+            tagValue = xdgTag.value();
+        }
+
+        // Combine hashes
+        hash = baseHash ^ (std::hash<std::string>{}(tagValue) << 2);
     }
 
     bool operator==(const SFloatCache& other) const {

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -141,8 +141,11 @@ struct SFirstExecRequest {
 struct SFloatCache {
     size_t hash;
 
-    SFloatCache(PHLWINDOW window) {
-        hash = std::hash<std::string>{}(window->m_class) ^ (std::hash<std::string>{}(window->m_title) << 1);
+    SFloatCache(PHLWINDOW window, bool initial) {
+        if (initial)
+            hash = std::hash<std::string>{}(window->m_initialClass) ^ (std::hash<std::string>{}(window->m_initialTitle) << 1);
+        else
+            hash = std::hash<std::string>{}(window->m_class) ^ (std::hash<std::string>{}(window->m_title) << 1);
     }
 
     bool operator==(const SFloatCache& other) const {

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -17,8 +17,7 @@
 void IHyprLayout::onWindowCreated(PHLWINDOW pWindow, eDirection direction) {
     CBox       desiredGeometry = g_pXWaylandManager->getGeometryForWindow(pWindow);
 
-    const bool HASPERSISTENTSIZE =
-        std::any_of(pWindow->m_matchedRules.begin(), pWindow->m_matchedRules.end(), [](const auto& rule) { return rule->m_ruleType == CWindowRule::RULE_PERSISTENTSIZE; });
+    const bool HASPERSISTENTSIZE = std::ranges::any_of(pWindow->m_matchedRules, [](const auto& rule) { return rule->m_ruleType == CWindowRule::RULE_PERSISTENTSIZE; });
 
     const auto STOREDSIZE = HASPERSISTENTSIZE ? g_pConfigManager->getStoredFloatingSize(pWindow) : std::nullopt;
 
@@ -890,8 +889,7 @@ Vector2D IHyprLayout::predictSizeForNewWindowFloating(PHLWINDOW pWindow) { // ge
     if (g_pCompositor->m_lastMonitor) {
 
         // If `persistentsize` is set, use the stored size if available.
-        const bool HASPERSISTENTSIZE =
-            std::any_of(pWindow->m_matchedRules.begin(), pWindow->m_matchedRules.end(), [](const auto& rule) { return rule->m_ruleType == CWindowRule::RULE_PERSISTENTSIZE; });
+        const bool HASPERSISTENTSIZE = std::ranges::any_of(pWindow->m_matchedRules, [](const auto& rule) { return rule->m_ruleType == CWindowRule::RULE_PERSISTENTSIZE; });
 
         const auto STOREDSIZE = HASPERSISTENTSIZE ? g_pConfigManager->getStoredFloatingSize(pWindow) : std::nullopt;
 

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -888,6 +888,18 @@ void IHyprLayout::requestFocusForWindow(PHLWINDOW pWindow) {
 Vector2D IHyprLayout::predictSizeForNewWindowFloating(PHLWINDOW pWindow) { // get all rules, see if we have any size overrides.
     Vector2D sizeOverride = {};
     if (g_pCompositor->m_lastMonitor) {
+
+        // If `persistentsize` is set, use the stored size if available.
+        const bool HASPERSISTENTSIZE =
+            std::any_of(pWindow->m_matchedRules.begin(), pWindow->m_matchedRules.end(), [](const auto& rule) { return rule->m_ruleType == CWindowRule::RULE_PERSISTENTSIZE; });
+
+        const auto STOREDSIZE = HASPERSISTENTSIZE ? g_pConfigManager->getStoredFloatingSize(pWindow) : std::nullopt;
+
+        if (STOREDSIZE.has_value()) {
+            Debug::log(LOG, "using stored size {}x{} for new floating window {}::{}", STOREDSIZE->x, STOREDSIZE->y, pWindow->m_class, pWindow->m_title);
+            return STOREDSIZE.value();
+        }
+
         for (auto const& r : g_pConfigManager->getMatchingRules(pWindow, true, true)) {
             if (r->m_ruleType != CWindowRule::RULE_SIZE)
                 continue;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

#### Describe your PR, what does it fix/add?

fix #9422.

When open a floating window (i.e. windowrule `float` applied on the window), it should use the stored size if `persistentsize` is set.

#### Is it ready for merging, or does it need work?

I want to further improve the windowrule `persistentsize` by storing the sizes in cache or config file so that sizes can be persistent across boots, but I am a newbie in C++ and I don't know the conventional method to do this in this project, so I will wait for your kind instructions.

