### PR TITLE
DonationNag: ask after each major update

### DIFF
--- a/src/managers/DonationNagManager.cpp
+++ b/src/managers/DonationNagManager.cpp
@@ -94,7 +94,7 @@ CDonationNagManager::CDonationNagManager() {
         Debug::log(LOG, "DonationNag: hit nag month {} days {}-{}, it's {} today, nagging", MONTH, nagPoint.dayStart, nagPoint.dayEnd, DAY);
 
         fire();
-        
+
         state.major = currentMajor;
         state.epoch = EPOCH;
         writeState(state);
@@ -109,7 +109,7 @@ CDonationNagManager::CDonationNagManager() {
         Debug::log(LOG, "DonationNag: hit nag for major update {} -> {}", state.major, currentMajor);
 
         fire();
-        
+
         state.major = currentMajor;
         state.epoch = EPOCH;
         writeState(state);

--- a/src/managers/DonationNagManager.cpp
+++ b/src/managers/DonationNagManager.cpp
@@ -59,7 +59,7 @@ CDonationNagManager::CDonationNagManager() {
 
     auto state = getState();
 
-    if (!state.major && currentMajor <= 48) {
+    if ((!state.major && currentMajor <= 48) || !state.epoch) {
         state.major = currentMajor;
         state.epoch = state.epoch == 0 ? EPOCH : state.epoch;
         writeState(state);

--- a/src/managers/DonationNagManager.hpp
+++ b/src/managers/DonationNagManager.hpp
@@ -10,7 +10,16 @@ class CDonationNagManager {
     bool fired();
 
   private:
-    bool m_bFired = false;
+    struct SStateData {
+        uint64_t epoch = 0;
+        uint64_t major = 0;
+    };
+
+    SStateData getState();
+    void       writeState(const SStateData& s);
+    void       fire();
+
+    bool       m_bFired = false;
 };
 
 inline UP<CDonationNagManager> g_pDonationNagManager;


### PR DESCRIPTION
This changes how the donation nag timing works.

The donation nag will now appear:
- after a major update (e.g. 48 -> 49)\*
- once in late july
- once in december

_however_, a donation nag will never pop up more than once a month. So, if there is an update on the 26th of November, and you get a popup on the 28th, you will _not get one in december_.

This is of course still disableable in your config.

*\*Not directly after. Directly after comes the update screen. The next time you launch Hyprland, the donation popup will appear.*

**Why?**

Living ain't free. Furthermore, the results of the fifth census so far show that users support this approach.