### PR TITLE
Feature: add monitorremovedv2 IPC event

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -277,6 +277,7 @@ void CMonitor::onDisconnect(bool destroy) {
         if (g_pCompositor->m_isShuttingDown)
             return;
         g_pEventManager->postEvent(SHyprIPCEvent{"monitorremoved", m_name});
+        g_pEventManager->postEvent(SHyprIPCEvent{"monitorremovedv2", std::format("{},{},{}", m_id, m_name, m_shortDescription)});
         EMIT_HOOK_EVENT("monitorRemoved", m_self.lock());
         g_pCompositor->arrangeMonitors();
     }};


### PR DESCRIPTION
 <!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->
Feature: monitoraddedv2 IPC event for monitor description

#### Describe your PR, what does it fix/add?

builds off of #4646. adds an IPC event in the same format as `monitoraddedv2` so that there's a deterministic method for triggering scripts based on monitor removal events.  

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I tested it on my setup - works fine for me. It's not doing anything special, the bulk of the code was added in #4646 and the last couple of refactoring commits for `Monitors.cpp`. 

I opened a PR for the wiki: https://github.com/hyprwm/hyprland-wiki/pull/1053

#### Is it ready for merging, or does it need work?

Ready for merging. 


