### PR TITLE
managers: refactor class member vars

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -93,8 +93,8 @@ static void handleUnrecoverableSignal(int sig) {
     signal(SIGABRT, SIG_DFL);
     signal(SIGSEGV, SIG_DFL);
 
-    if (g_pHookSystem && g_pHookSystem->m_bCurrentEventPlugin) {
-        longjmp(g_pHookSystem->m_jbHookFaultJumpBuf, 1);
+    if (g_pHookSystem && g_pHookSystem->m_currentEventPlugin) {
+        longjmp(g_pHookSystem->m_hookFaultJumpBuf, 1);
         return;
     }
 
@@ -1132,7 +1132,7 @@ void CCompositor::focusWindow(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface
         return;
     }
 
-    if (m_lastWindow.lock() == pWindow && g_pSeatManager->state.keyboardFocus == pSurface && g_pSeatManager->state.keyboardFocus)
+    if (m_lastWindow.lock() == pWindow && g_pSeatManager->m_state.keyboardFocus == pSurface && g_pSeatManager->m_state.keyboardFocus)
         return;
 
     if (pWindow->m_pinned)
@@ -1216,13 +1216,13 @@ void CCompositor::focusWindow(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface
 
 void CCompositor::focusSurface(SP<CWLSurfaceResource> pSurface, PHLWINDOW pWindowOwner) {
 
-    if (g_pSeatManager->state.keyboardFocus == pSurface || (pWindowOwner && g_pSeatManager->state.keyboardFocus == pWindowOwner->m_wlSurface->resource()))
+    if (g_pSeatManager->m_state.keyboardFocus == pSurface || (pWindowOwner && g_pSeatManager->m_state.keyboardFocus == pWindowOwner->m_wlSurface->resource()))
         return; // Don't focus when already focused on this.
 
     if (g_pSessionLockManager->isSessionLocked() && pSurface && !g_pSessionLockManager->isSurfaceSessionLock(pSurface))
         return;
 
-    if (g_pSeatManager->seatGrab && !g_pSeatManager->seatGrab->accepts(pSurface)) {
+    if (g_pSeatManager->m_seatGrab && !g_pSeatManager->m_seatGrab->accepts(pSurface)) {
         Debug::log(LOG, "surface {:x} won't receive kb focus becuase grab rejected it", (uintptr_t)pSurface.get());
         return;
     }
@@ -1242,7 +1242,7 @@ void CCompositor::focusSurface(SP<CWLSurfaceResource> pSurface, PHLWINDOW pWindo
         return;
     }
 
-    if (g_pSeatManager->keyboard)
+    if (g_pSeatManager->m_keyboard)
         g_pSeatManager->setKeyboardFocus(pSurface);
 
     if (pWindowOwner)

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2359,9 +2359,9 @@ std::optional<std::string> CConfigManager::handleBind(const std::string& command
     // to lower
     std::transform(HANDLER.begin(), HANDLER.end(), HANDLER.begin(), ::tolower);
 
-    const auto DISPATCHER = g_pKeybindManager->m_mDispatchers.find(HANDLER);
+    const auto DISPATCHER = g_pKeybindManager->m_dispatchers.find(HANDLER);
 
-    if (DISPATCHER == g_pKeybindManager->m_mDispatchers.end()) {
+    if (DISPATCHER == g_pKeybindManager->m_dispatchers.end()) {
         Debug::log(ERR, "Invalid dispatcher: {}", HANDLER);
         return "Invalid dispatcher, requested \"" + HANDLER + "\" does not exist";
     }

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -866,7 +866,7 @@ static std::string globalShortcutsRequest(eHyprCtlOutputFormat format, std::stri
 static std::string bindsRequest(eHyprCtlOutputFormat format, std::string request) {
     std::string ret = "";
     if (format == eHyprCtlOutputFormat::FORMAT_NORMAL) {
-        for (auto const& kb : g_pKeybindManager->m_vKeybinds) {
+        for (auto const& kb : g_pKeybindManager->m_keybinds) {
             ret += "bind";
             if (kb->locked)
                 ret += "l";
@@ -887,7 +887,7 @@ static std::string bindsRequest(eHyprCtlOutputFormat format, std::string request
     } else {
         // json
         ret += "[";
-        for (auto const& kb : g_pKeybindManager->m_vKeybinds) {
+        for (auto const& kb : g_pKeybindManager->m_keybinds) {
             ret += std::format(
                 R"#(
 {{
@@ -1076,8 +1076,8 @@ static std::string dispatchRequest(eHyprCtlOutputFormat format, std::string in) 
     if ((int)in.find_first_of(' ') != -1)
         DISPATCHARG = in.substr(in.find_first_of(' ') + 1);
 
-    const auto DISPATCHER = g_pKeybindManager->m_mDispatchers.find(DISPATCHSTR);
-    if (DISPATCHER == g_pKeybindManager->m_mDispatchers.end())
+    const auto DISPATCHER = g_pKeybindManager->m_dispatchers.find(DISPATCHSTR);
+    if (DISPATCHER == g_pKeybindManager->m_dispatchers.end())
         return "Invalid dispatcher";
 
     SDispatchResult res = DISPATCHER->second(DISPATCHARG);
@@ -1352,7 +1352,7 @@ static std::string dispatchSeterror(eHyprCtlOutputFormat format, std::string req
 }
 
 static std::string dispatchSetProp(eHyprCtlOutputFormat format, std::string request) {
-    auto result = g_pKeybindManager->m_mDispatchers["setprop"](request.substr(request.find_first_of(' ') + 1));
+    auto result = g_pKeybindManager->m_dispatchers["setprop"](request.substr(request.find_first_of(' ') + 1));
     return "DEPRECATED: use hyprctl dispatch setprop instead" + (result.success ? "" : "\n" + result.error);
 }
 

--- a/src/debug/HyprDebugOverlay.cpp
+++ b/src/debug/HyprDebugOverlay.cpp
@@ -62,7 +62,7 @@ void CHyprMonitorDebugOverlay::frameData(PHLMONITOR pMonitor) {
         if (m_lastAnimationTicks.size() > (long unsigned int)PMONITORFORTICKS->m_refreshRate)
             m_lastAnimationTicks.pop_front();
 
-        m_lastAnimationTicks.push_back(g_pAnimationManager->m_fLastTickTime);
+        m_lastAnimationTicks.push_back(g_pAnimationManager->m_lastTickTimeMs);
     }
 }
 

--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -163,7 +163,7 @@ void CLayerSurface::onMap() {
     const bool GRABSFOCUS = ISEXCLUSIVE ||
         (m_layerSurface->current.interactivity != ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE &&
          // don't focus if constrained
-         (g_pSeatManager->mouse.expired() || !g_pInputManager->isConstrained()));
+         (g_pSeatManager->m_mouse.expired() || !g_pInputManager->isConstrained()));
 
     if (GRABSFOCUS) {
         // TODO: use the new superb really very cool grab
@@ -231,7 +231,7 @@ void CLayerSurface::onUnmap() {
 
     const auto PMONITOR = m_monitor.lock();
 
-    const bool WASLASTFOCUS = g_pSeatManager->state.keyboardFocus == m_surface->resource() || g_pSeatManager->state.pointerFocus == m_surface->resource();
+    const bool WASLASTFOCUS = g_pSeatManager->m_state.keyboardFocus == m_surface->resource() || g_pSeatManager->m_state.pointerFocus == m_surface->resource();
 
     if (!PMONITOR)
         return;
@@ -333,12 +333,12 @@ void CLayerSurface::onCommit() {
     if (m_mapped && (m_layerSurface->current.committed & CLayerShellResource::eCommittedState::STATE_INTERACTIVITY)) {
         bool WASLASTFOCUS = false;
         m_layerSurface->surface->breadthfirst(
-            [&WASLASTFOCUS](SP<CWLSurfaceResource> surf, const Vector2D& offset, void* data) { WASLASTFOCUS = WASLASTFOCUS || g_pSeatManager->state.keyboardFocus == surf; },
+            [&WASLASTFOCUS](SP<CWLSurfaceResource> surf, const Vector2D& offset, void* data) { WASLASTFOCUS = WASLASTFOCUS || g_pSeatManager->m_state.keyboardFocus == surf; },
             nullptr);
         if (!WASLASTFOCUS && m_popupHead) {
             m_popupHead->breadthfirst(
                 [&WASLASTFOCUS](WP<CPopup> popup, void* data) {
-                    WASLASTFOCUS = WASLASTFOCUS || (popup->m_wlSurface && g_pSeatManager->state.keyboardFocus == popup->m_wlSurface->resource());
+                    WASLASTFOCUS = WASLASTFOCUS || (popup->m_wlSurface && g_pSeatManager->m_state.keyboardFocus == popup->m_wlSurface->resource());
                 },
                 nullptr);
         }

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -945,13 +945,13 @@ void CWindow::destroyGroup() {
         w->m_groupData.head = false;
     }
 
-    const bool GROUPSLOCKEDPREV        = g_pKeybindManager->m_bGroupsLocked;
-    g_pKeybindManager->m_bGroupsLocked = true;
+    const bool GROUPSLOCKEDPREV       = g_pKeybindManager->m_groupsLocked;
+    g_pKeybindManager->m_groupsLocked = true;
     for (auto const& w : members) {
         g_pLayoutManager->getCurrentLayout()->onWindowCreated(w);
         w->updateWindowDecos();
     }
-    g_pKeybindManager->m_bGroupsLocked = GROUPSLOCKEDPREV;
+    g_pKeybindManager->m_groupsLocked = GROUPSLOCKEDPREV;
 
     if (m_workspace) {
         m_workspace->updateWindows();
@@ -1000,7 +1000,7 @@ bool CWindow::canBeGroupedInto(PHLWINDOW pWindow) {
     static auto ALLOWGROUPMERGE       = CConfigValue<Hyprlang::INT>("group:merge_groups_on_drag");
     bool        isGroup               = m_groupData.pNextWindow;
     bool        disallowDragIntoGroup = g_pInputManager->m_wasDraggingWindow && isGroup && !bool(*ALLOWGROUPMERGE);
-    return !g_pKeybindManager->m_bGroupsLocked                                               // global group lock disengaged
+    return !g_pKeybindManager->m_groupsLocked                                                // global group lock disengaged
         && ((m_groupRules & GROUP_INVADE && m_firstMap)                                      // window ignore local group locks, or
             || (!pWindow->getGroupHead()->m_groupData.locked                                 //      target unlocked
                 && !(m_groupData.pNextWindow.lock() && getGroupHead()->m_groupData.locked))) //      source unlocked or isn't group

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -169,7 +169,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                     const auto PMONITORFROMID = PWINDOW->m_monitor.lock();
 
                     if (PWINDOW->m_monitor != PMONITOR) {
-                        g_pKeybindManager->m_mDispatchers["focusmonitor"](std::to_string(PWINDOW->monitorID()));
+                        g_pKeybindManager->m_dispatchers["focusmonitor"](std::to_string(PWINDOW->monitorID()));
                         PMONITOR = PMONITORFROMID;
                     }
                     PWINDOW->m_workspace = PMONITOR->m_activeSpecialWorkspace ? PMONITOR->m_activeSpecialWorkspace : PMONITOR->m_activeWorkspace;
@@ -363,7 +363,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                 if (pWorkspace->m_isSpecialWorkspace)
                     pWorkspace->m_monitor->setSpecialWorkspace(pWorkspace);
                 else if (PMONITOR->activeWorkspaceID() != REQUESTEDWORKSPACEID && !PWINDOW->m_noInitialFocus)
-                    g_pKeybindManager->m_mDispatchers["workspace"](requestedWorkspaceName);
+                    g_pKeybindManager->m_dispatchers["workspace"](requestedWorkspaceName);
 
                 PMONITOR = g_pCompositor->m_lastMonitor.lock();
             }
@@ -382,7 +382,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
         const auto PMONITORFROMID = PWINDOW->m_monitor.lock();
 
         if (PWINDOW->m_monitor != PMONITOR) {
-            g_pKeybindManager->m_mDispatchers["focusmonitor"](std::to_string(PWINDOW->monitorID()));
+            g_pKeybindManager->m_dispatchers["focusmonitor"](std::to_string(PWINDOW->monitorID()));
             PMONITOR = PMONITORFROMID;
         }
         PWINDOW->m_workspace = PMONITOR->m_activeSpecialWorkspace ? PMONITOR->m_activeSpecialWorkspace : PMONITOR->m_activeWorkspace;
@@ -690,7 +690,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
     g_pCompositor->setPreferredScaleForSurface(PWINDOW->m_wlSurface->resource(), PMONITOR->m_scale);
     g_pCompositor->setPreferredTransformForSurface(PWINDOW->m_wlSurface->resource(), PMONITOR->m_transform);
 
-    if (g_pSeatManager->mouse.expired() || !g_pInputManager->isConstrained())
+    if (g_pSeatManager->m_mouse.expired() || !g_pInputManager->isConstrained())
         g_pInputManager->sendMotionEventsToFocused();
 
     // fix some xwayland apps that don't behave nicely
@@ -871,19 +871,19 @@ void Events::listener_commitWindow(void* owner, void* data) {
     const auto PMONITOR = PWINDOW->m_monitor.lock();
 
     if (PMONITOR)
-        PMONITOR->debugLastPresentation(g_pSeatManager->isPointerFrameCommit ? "listener_commitWindow skip" : "listener_commitWindow");
+        PMONITOR->debugLastPresentation(g_pSeatManager->m_isPointerFrameCommit ? "listener_commitWindow skip" : "listener_commitWindow");
 
-    if (g_pSeatManager->isPointerFrameCommit) {
-        g_pSeatManager->isPointerFrameSkipped = false;
-        g_pSeatManager->isPointerFrameCommit  = false;
+    if (g_pSeatManager->m_isPointerFrameCommit) {
+        g_pSeatManager->m_isPointerFrameSkipped = false;
+        g_pSeatManager->m_isPointerFrameCommit  = false;
     } else
         g_pHyprRenderer->damageSurface(PWINDOW->m_wlSurface->resource(), PWINDOW->m_realPosition->goal().x, PWINDOW->m_realPosition->goal().y,
                                        PWINDOW->m_isX11 ? 1.0 / PWINDOW->m_X11SurfaceScaledBy : 1.0);
 
-    if (g_pSeatManager->isPointerFrameSkipped) {
+    if (g_pSeatManager->m_isPointerFrameSkipped) {
         g_pPointerManager->sendStoredMovement();
         g_pSeatManager->sendPointerFrame();
-        g_pSeatManager->isPointerFrameCommit = true;
+        g_pSeatManager->m_isPointerFrameCommit = true;
     }
 
     if (!PWINDOW->m_isX11) {

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -1174,7 +1174,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
             return 0;
 
         if (header.pWindow->m_isFloating) {
-            g_pKeybindManager->m_mDispatchers["swapnext"]("");
+            g_pKeybindManager->m_dispatchers["swapnext"]("");
             return 0;
         }
 
@@ -1191,7 +1191,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
             return 0;
 
         if (header.pWindow->m_isFloating) {
-            g_pKeybindManager->m_mDispatchers["swapnext"]("prev");
+            g_pKeybindManager->m_dispatchers["swapnext"]("prev");
             return 0;
         }
 
@@ -1296,7 +1296,7 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
     } else if (command == "orientationcycle") {
         runOrientationCycle(header, &vars, 1);
     } else if (command == "mfact") {
-        g_pKeybindManager->m_mDispatchers["splitratio"](vars[1] + " " + vars[2]);
+        g_pKeybindManager->m_dispatchers["splitratio"](vars[1] + " " + vars[2]);
     } else if (command == "rollnext") {
         const auto PWINDOW = header.pWindow;
         const auto PNODE   = getNodeFromWindow(PWINDOW);

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -33,9 +33,9 @@ static int wlTick(SP<CEventLoopTimer> self, void* data) {
 }
 
 CHyprAnimationManager::CHyprAnimationManager() {
-    m_pAnimationTimer = SP<CEventLoopTimer>(new CEventLoopTimer(std::chrono::microseconds(500), wlTick, nullptr));
+    m_animationTimer = SP<CEventLoopTimer>(new CEventLoopTimer(std::chrono::microseconds(500), wlTick, nullptr));
     if (g_pEventLoopManager) // null in --verify-config mode
-        g_pEventLoopManager->addTimer(m_pAnimationTimer);
+        g_pEventLoopManager->addTimer(m_animationTimer);
 
     addBezierWithName("linear", Vector2D(0.0, 0.0), Vector2D(1.0, 1.0));
 }
@@ -213,7 +213,7 @@ static void handleUpdate(CAnimatedVariable<VarType>& av, bool warp) {
 
 void CHyprAnimationManager::tick() {
     static std::chrono::time_point lastTick = std::chrono::high_resolution_clock::now();
-    m_fLastTickTime                         = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - lastTick).count() / 1000.0;
+    m_lastTickTimeMs                        = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now() - lastTick).count() / 1000.0;
     lastTick                                = std::chrono::high_resolution_clock::now();
 
     static auto PANIMENABLED = CConfigValue<Hyprlang::INT>("animations:enabled");
@@ -250,15 +250,15 @@ void CHyprAnimationManager::tick() {
 }
 
 void CHyprAnimationManager::scheduleTick() {
-    if (m_bTickScheduled)
+    if (m_tickScheduled)
         return;
 
-    m_bTickScheduled = true;
+    m_tickScheduled = true;
 
     const auto PMOSTHZ = g_pHyprRenderer->m_pMostHzMonitor;
 
     if (!PMOSTHZ) {
-        m_pAnimationTimer->updateTimeout(std::chrono::milliseconds(16));
+        m_animationTimer->updateTimeout(std::chrono::milliseconds(16));
         return;
     }
 
@@ -268,11 +268,11 @@ void CHyprAnimationManager::scheduleTick() {
 
     const auto  TOPRES = std::clamp(refreshDelayMs - SINCEPRES, 1.1f, 1000.f); // we can't send 0, that will disarm it
 
-    m_pAnimationTimer->updateTimeout(std::chrono::milliseconds((int)std::floor(TOPRES)));
+    m_animationTimer->updateTimeout(std::chrono::milliseconds((int)std::floor(TOPRES)));
 }
 
 void CHyprAnimationManager::onTicked() {
-    m_bTickScheduled = false;
+    m_tickScheduled = false;
 }
 
 //

--- a/src/managers/AnimationManager.hpp
+++ b/src/managers/AnimationManager.hpp
@@ -49,12 +49,12 @@ class CHyprAnimationManager : public Hyprutils::Animation::CAnimationManager {
 
     std::string         styleValidInConfigVar(const std::string&, const std::string&);
 
-    SP<CEventLoopTimer> m_pAnimationTimer;
+    SP<CEventLoopTimer> m_animationTimer;
 
-    float               m_fLastTickTime; // in ms
+    float               m_lastTickTimeMs;
 
   private:
-    bool m_bTickScheduled = false;
+    bool m_tickScheduled = false;
 
     // Anim stuff
     void animationPopin(PHLWINDOW, bool close = false, float minPerc = 0.f);

--- a/src/managers/CursorManager.hpp
+++ b/src/managers/CursorManager.hpp
@@ -56,22 +56,22 @@ class CCursorManager {
     void                    tickAnimatedCursor();
 
   private:
-    bool                               m_bOurBufferConnected = false;
-    std::vector<SP<CCursorBuffer>>     m_vCursorBuffers;
+    bool                               m_ourBufferConnected = false;
+    std::vector<SP<CCursorBuffer>>     m_cursorBuffers;
 
-    UP<Hyprcursor::CHyprcursorManager> m_pHyprcursor;
-    UP<CXCursorManager>                m_pXcursor;
+    UP<Hyprcursor::CHyprcursorManager> m_hyprcursor;
+    UP<CXCursorManager>                m_xcursor;
     SP<SXCursors>                      m_currentXcursor;
 
-    std::string                        m_szTheme      = "";
-    int                                m_iSize        = 0;
-    float                              m_fCursorScale = 1.0;
+    std::string                        m_theme       = "";
+    int                                m_size        = 0;
+    float                              m_cursorScale = 1.0;
 
-    Hyprcursor::SCursorStyleInfo       m_sCurrentStyleInfo;
+    Hyprcursor::SCursorStyleInfo       m_currentStyleInfo;
 
-    SP<CEventLoopTimer>                m_pAnimationTimer;
-    int                                m_iCurrentAnimationFrame = 0;
-    Hyprcursor::SCursorShapeData       m_sCurrentCursorShapeData;
+    SP<CEventLoopTimer>                m_animationTimer;
+    int                                m_currentAnimationFrame = 0;
+    Hyprcursor::SCursorShapeData       m_currentCursorShapeData;
 };
 
 inline UP<CCursorManager> g_pCursorManager;

--- a/src/managers/DonationNagManager.cpp
+++ b/src/managers/DonationNagManager.cpp
@@ -102,7 +102,7 @@ CDonationNagManager::CDonationNagManager() {
         break;
     }
 
-    if (!m_bFired)
+    if (!m_fired)
         Debug::log(LOG, "DonationNag: didn't hit any nagging periods, checking update");
 
     if (state.major < currentMajor) {
@@ -115,18 +115,18 @@ CDonationNagManager::CDonationNagManager() {
         writeState(state);
     }
 
-    if (!m_bFired)
+    if (!m_fired)
         Debug::log(LOG, "DonationNag: didn't hit nagging conditions");
 }
 
 bool CDonationNagManager::fired() {
-    return m_bFired;
+    return m_fired;
 }
 
 void CDonationNagManager::fire() {
     static const auto DATAROOT = NFsUtils::getDataHome();
 
-    m_bFired = true;
+    m_fired = true;
 
     g_pEventLoopManager->doLater([] {
         CProcess proc("hyprland-donate-screen", {});

--- a/src/managers/DonationNagManager.hpp
+++ b/src/managers/DonationNagManager.hpp
@@ -19,7 +19,7 @@ class CDonationNagManager {
     void       writeState(const SStateData& s);
     void       fire();
 
-    bool       m_bFired = false;
+    bool       m_fired = false;
 };
 
 inline UP<CDonationNagManager> g_pDonationNagManager;

--- a/src/managers/EventManager.hpp
+++ b/src/managers/EventManager.hpp
@@ -35,10 +35,10 @@ class CEventManager {
     std::vector<SClient>::iterator removeClientByFD(int fd);
 
   private:
-    Hyprutils::OS::CFileDescriptor m_iSocketFD;
-    wl_event_source*               m_pEventSource = nullptr;
+    Hyprutils::OS::CFileDescriptor m_socketFD;
+    wl_event_source*               m_eventSource = nullptr;
 
-    std::vector<SClient>           m_vClients;
+    std::vector<SClient>           m_clients;
 };
 
 inline UP<CEventManager> g_pEventManager;

--- a/src/managers/HookSystemManager.hpp
+++ b/src/managers/HookSystemManager.hpp
@@ -50,11 +50,11 @@ class CHookSystemManager {
     void                         emit(std::vector<SCallbackFNPtr>* const callbacks, SCallbackInfo& info, std::any data = 0);
     std::vector<SCallbackFNPtr>* getVecForEvent(const std::string& event);
 
-    bool                         m_bCurrentEventPlugin = false;
-    jmp_buf                      m_jbHookFaultJumpBuf;
+    bool                         m_currentEventPlugin = false;
+    jmp_buf                      m_hookFaultJumpBuf;
 
   private:
-    std::unordered_map<std::string, std::vector<SCallbackFNPtr>> m_mRegisteredHooks;
+    std::unordered_map<std::string, std::vector<SCallbackFNPtr>> m_registeredHooks;
 };
 
 inline UP<CHookSystemManager> g_pHookSystem;

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -70,109 +70,109 @@ static std::vector<std::pair<std::string, std::string>> getHyprlandLaunchEnv(PHL
 CKeybindManager::CKeybindManager() {
     // initialize all dispatchers
 
-    m_mDispatchers["exec"]                           = spawn;
-    m_mDispatchers["execr"]                          = spawnRaw;
-    m_mDispatchers["killactive"]                     = closeActive;
-    m_mDispatchers["forcekillactive"]                = killActive;
-    m_mDispatchers["closewindow"]                    = closeWindow;
-    m_mDispatchers["killwindow"]                     = killWindow;
-    m_mDispatchers["signal"]                         = signalActive;
-    m_mDispatchers["signalwindow"]                   = signalWindow;
-    m_mDispatchers["togglefloating"]                 = toggleActiveFloating;
-    m_mDispatchers["setfloating"]                    = setActiveFloating;
-    m_mDispatchers["settiled"]                       = setActiveTiled;
-    m_mDispatchers["workspace"]                      = changeworkspace;
-    m_mDispatchers["renameworkspace"]                = renameWorkspace;
-    m_mDispatchers["fullscreen"]                     = fullscreenActive;
-    m_mDispatchers["fullscreenstate"]                = fullscreenStateActive;
-    m_mDispatchers["movetoworkspace"]                = moveActiveToWorkspace;
-    m_mDispatchers["movetoworkspacesilent"]          = moveActiveToWorkspaceSilent;
-    m_mDispatchers["pseudo"]                         = toggleActivePseudo;
-    m_mDispatchers["movefocus"]                      = moveFocusTo;
-    m_mDispatchers["movewindow"]                     = moveActiveTo;
-    m_mDispatchers["swapwindow"]                     = swapActive;
-    m_mDispatchers["centerwindow"]                   = centerWindow;
-    m_mDispatchers["togglegroup"]                    = toggleGroup;
-    m_mDispatchers["changegroupactive"]              = changeGroupActive;
-    m_mDispatchers["movegroupwindow"]                = moveGroupWindow;
-    m_mDispatchers["togglesplit"]                    = toggleSplit;
-    m_mDispatchers["swapsplit"]                      = swapSplit;
-    m_mDispatchers["splitratio"]                     = alterSplitRatio;
-    m_mDispatchers["focusmonitor"]                   = focusMonitor;
-    m_mDispatchers["movecursortocorner"]             = moveCursorToCorner;
-    m_mDispatchers["movecursor"]                     = moveCursor;
-    m_mDispatchers["workspaceopt"]                   = workspaceOpt;
-    m_mDispatchers["exit"]                           = exitHyprland;
-    m_mDispatchers["movecurrentworkspacetomonitor"]  = moveCurrentWorkspaceToMonitor;
-    m_mDispatchers["focusworkspaceoncurrentmonitor"] = focusWorkspaceOnCurrentMonitor;
-    m_mDispatchers["moveworkspacetomonitor"]         = moveWorkspaceToMonitor;
-    m_mDispatchers["togglespecialworkspace"]         = toggleSpecialWorkspace;
-    m_mDispatchers["forcerendererreload"]            = forceRendererReload;
-    m_mDispatchers["resizeactive"]                   = resizeActive;
-    m_mDispatchers["moveactive"]                     = moveActive;
-    m_mDispatchers["cyclenext"]                      = circleNext;
-    m_mDispatchers["focuswindowbyclass"]             = focusWindow;
-    m_mDispatchers["focuswindow"]                    = focusWindow;
-    m_mDispatchers["tagwindow"]                      = tagWindow;
-    m_mDispatchers["toggleswallow"]                  = toggleSwallow;
-    m_mDispatchers["submap"]                         = setSubmap;
-    m_mDispatchers["pass"]                           = pass;
-    m_mDispatchers["sendshortcut"]                   = sendshortcut;
-    m_mDispatchers["sendkeystate"]                   = sendkeystate;
-    m_mDispatchers["layoutmsg"]                      = layoutmsg;
-    m_mDispatchers["dpms"]                           = dpms;
-    m_mDispatchers["movewindowpixel"]                = moveWindow;
-    m_mDispatchers["resizewindowpixel"]              = resizeWindow;
-    m_mDispatchers["swapnext"]                       = swapnext;
-    m_mDispatchers["swapactiveworkspaces"]           = swapActiveWorkspaces;
-    m_mDispatchers["pin"]                            = pinActive;
-    m_mDispatchers["mouse"]                          = mouse;
-    m_mDispatchers["bringactivetotop"]               = bringActiveToTop;
-    m_mDispatchers["alterzorder"]                    = alterZOrder;
-    m_mDispatchers["focusurgentorlast"]              = focusUrgentOrLast;
-    m_mDispatchers["focuscurrentorlast"]             = focusCurrentOrLast;
-    m_mDispatchers["lockgroups"]                     = lockGroups;
-    m_mDispatchers["lockactivegroup"]                = lockActiveGroup;
-    m_mDispatchers["moveintogroup"]                  = moveIntoGroup;
-    m_mDispatchers["moveoutofgroup"]                 = moveOutOfGroup;
-    m_mDispatchers["movewindoworgroup"]              = moveWindowOrGroup;
-    m_mDispatchers["setignoregrouplock"]             = setIgnoreGroupLock;
-    m_mDispatchers["denywindowfromgroup"]            = denyWindowFromGroup;
-    m_mDispatchers["event"]                          = event;
-    m_mDispatchers["global"]                         = global;
-    m_mDispatchers["setprop"]                        = setProp;
+    m_dispatchers["exec"]                           = spawn;
+    m_dispatchers["execr"]                          = spawnRaw;
+    m_dispatchers["killactive"]                     = closeActive;
+    m_dispatchers["forcekillactive"]                = killActive;
+    m_dispatchers["closewindow"]                    = closeWindow;
+    m_dispatchers["killwindow"]                     = killWindow;
+    m_dispatchers["signal"]                         = signalActive;
+    m_dispatchers["signalwindow"]                   = signalWindow;
+    m_dispatchers["togglefloating"]                 = toggleActiveFloating;
+    m_dispatchers["setfloating"]                    = setActiveFloating;
+    m_dispatchers["settiled"]                       = setActiveTiled;
+    m_dispatchers["workspace"]                      = changeworkspace;
+    m_dispatchers["renameworkspace"]                = renameWorkspace;
+    m_dispatchers["fullscreen"]                     = fullscreenActive;
+    m_dispatchers["fullscreenstate"]                = fullscreenStateActive;
+    m_dispatchers["movetoworkspace"]                = moveActiveToWorkspace;
+    m_dispatchers["movetoworkspacesilent"]          = moveActiveToWorkspaceSilent;
+    m_dispatchers["pseudo"]                         = toggleActivePseudo;
+    m_dispatchers["movefocus"]                      = moveFocusTo;
+    m_dispatchers["movewindow"]                     = moveActiveTo;
+    m_dispatchers["swapwindow"]                     = swapActive;
+    m_dispatchers["centerwindow"]                   = centerWindow;
+    m_dispatchers["togglegroup"]                    = toggleGroup;
+    m_dispatchers["changegroupactive"]              = changeGroupActive;
+    m_dispatchers["movegroupwindow"]                = moveGroupWindow;
+    m_dispatchers["togglesplit"]                    = toggleSplit;
+    m_dispatchers["swapsplit"]                      = swapSplit;
+    m_dispatchers["splitratio"]                     = alterSplitRatio;
+    m_dispatchers["focusmonitor"]                   = focusMonitor;
+    m_dispatchers["movecursortocorner"]             = moveCursorToCorner;
+    m_dispatchers["movecursor"]                     = moveCursor;
+    m_dispatchers["workspaceopt"]                   = workspaceOpt;
+    m_dispatchers["exit"]                           = exitHyprland;
+    m_dispatchers["movecurrentworkspacetomonitor"]  = moveCurrentWorkspaceToMonitor;
+    m_dispatchers["focusworkspaceoncurrentmonitor"] = focusWorkspaceOnCurrentMonitor;
+    m_dispatchers["moveworkspacetomonitor"]         = moveWorkspaceToMonitor;
+    m_dispatchers["togglespecialworkspace"]         = toggleSpecialWorkspace;
+    m_dispatchers["forcerendererreload"]            = forceRendererReload;
+    m_dispatchers["resizeactive"]                   = resizeActive;
+    m_dispatchers["moveactive"]                     = moveActive;
+    m_dispatchers["cyclenext"]                      = circleNext;
+    m_dispatchers["focuswindowbyclass"]             = focusWindow;
+    m_dispatchers["focuswindow"]                    = focusWindow;
+    m_dispatchers["tagwindow"]                      = tagWindow;
+    m_dispatchers["toggleswallow"]                  = toggleSwallow;
+    m_dispatchers["submap"]                         = setSubmap;
+    m_dispatchers["pass"]                           = pass;
+    m_dispatchers["sendshortcut"]                   = sendshortcut;
+    m_dispatchers["sendkeystate"]                   = sendkeystate;
+    m_dispatchers["layoutmsg"]                      = layoutmsg;
+    m_dispatchers["dpms"]                           = dpms;
+    m_dispatchers["movewindowpixel"]                = moveWindow;
+    m_dispatchers["resizewindowpixel"]              = resizeWindow;
+    m_dispatchers["swapnext"]                       = swapnext;
+    m_dispatchers["swapactiveworkspaces"]           = swapActiveWorkspaces;
+    m_dispatchers["pin"]                            = pinActive;
+    m_dispatchers["mouse"]                          = mouse;
+    m_dispatchers["bringactivetotop"]               = bringActiveToTop;
+    m_dispatchers["alterzorder"]                    = alterZOrder;
+    m_dispatchers["focusurgentorlast"]              = focusUrgentOrLast;
+    m_dispatchers["focuscurrentorlast"]             = focusCurrentOrLast;
+    m_dispatchers["lockgroups"]                     = lockGroups;
+    m_dispatchers["lockactivegroup"]                = lockActiveGroup;
+    m_dispatchers["moveintogroup"]                  = moveIntoGroup;
+    m_dispatchers["moveoutofgroup"]                 = moveOutOfGroup;
+    m_dispatchers["movewindoworgroup"]              = moveWindowOrGroup;
+    m_dispatchers["setignoregrouplock"]             = setIgnoreGroupLock;
+    m_dispatchers["denywindowfromgroup"]            = denyWindowFromGroup;
+    m_dispatchers["event"]                          = event;
+    m_dispatchers["global"]                         = global;
+    m_dispatchers["setprop"]                        = setProp;
 
-    m_tScrollTimer.reset();
+    m_scrollTimer.reset();
 
-    m_pLongPressTimer = makeShared<CEventLoopTimer>(
+    m_longPressTimer = makeShared<CEventLoopTimer>(
         std::nullopt,
         [this](SP<CEventLoopTimer> self, void* data) {
-            if (!m_pLastLongPressKeybind || g_pSeatManager->keyboard.expired())
+            if (!m_lastLongPressKeybind || g_pSeatManager->m_keyboard.expired())
                 return;
 
-            const auto PACTIVEKEEB = g_pSeatManager->keyboard.lock();
+            const auto PACTIVEKEEB = g_pSeatManager->m_keyboard.lock();
             if (!PACTIVEKEEB->m_allowBinds)
                 return;
 
-            const auto DISPATCHER = g_pKeybindManager->m_mDispatchers.find(m_pLastLongPressKeybind->handler);
+            const auto DISPATCHER = g_pKeybindManager->m_dispatchers.find(m_lastLongPressKeybind->handler);
 
             Debug::log(LOG, "Long press timeout passed, calling dispatcher.");
-            DISPATCHER->second(m_pLastLongPressKeybind->arg);
+            DISPATCHER->second(m_lastLongPressKeybind->arg);
         },
         nullptr);
 
-    m_pRepeatKeyTimer = makeShared<CEventLoopTimer>(
+    m_repeatKeyTimer = makeShared<CEventLoopTimer>(
         std::nullopt,
         [this](SP<CEventLoopTimer> self, void* data) {
-            if (m_vActiveKeybinds.size() == 0 || g_pSeatManager->keyboard.expired())
+            if (m_activeKeybinds.size() == 0 || g_pSeatManager->m_keyboard.expired())
                 return;
 
-            const auto PACTIVEKEEB = g_pSeatManager->keyboard.lock();
+            const auto PACTIVEKEEB = g_pSeatManager->m_keyboard.lock();
             if (!PACTIVEKEEB->m_allowBinds)
                 return;
 
-            for (const auto& k : m_vActiveKeybinds) {
-                const auto DISPATCHER = g_pKeybindManager->m_mDispatchers.find(k->handler);
+            for (const auto& k : m_activeKeybinds) {
+                const auto DISPATCHER = g_pKeybindManager->m_dispatchers.find(k->handler);
 
                 Debug::log(LOG, "Keybind repeat triggered, calling dispatcher.");
                 DISPATCHER->second(k->arg);
@@ -184,43 +184,43 @@ CKeybindManager::CKeybindManager() {
 
     // null in --verify-config mode
     if (g_pEventLoopManager) {
-        g_pEventLoopManager->addTimer(m_pLongPressTimer);
-        g_pEventLoopManager->addTimer(m_pRepeatKeyTimer);
+        g_pEventLoopManager->addTimer(m_longPressTimer);
+        g_pEventLoopManager->addTimer(m_repeatKeyTimer);
     }
 
     static auto P = g_pHookSystem->hookDynamic("configReloaded", [this](void* hk, SCallbackInfo& info, std::any param) {
         // clear cuz realloc'd
-        m_vActiveKeybinds.clear();
-        m_pLastLongPressKeybind.reset();
-        m_vPressedSpecialBinds.clear();
+        m_activeKeybinds.clear();
+        m_lastLongPressKeybind.reset();
+        m_pressedSpecialBinds.clear();
     });
 }
 
 CKeybindManager::~CKeybindManager() {
-    if (m_pXKBTranslationState)
-        xkb_state_unref(m_pXKBTranslationState);
-    if (m_pLongPressTimer && g_pEventLoopManager) {
-        g_pEventLoopManager->removeTimer(m_pLongPressTimer);
-        m_pLongPressTimer.reset();
+    if (m_xkbTranslationState)
+        xkb_state_unref(m_xkbTranslationState);
+    if (m_longPressTimer && g_pEventLoopManager) {
+        g_pEventLoopManager->removeTimer(m_longPressTimer);
+        m_longPressTimer.reset();
     }
-    if (m_pRepeatKeyTimer && g_pEventLoopManager) {
-        g_pEventLoopManager->removeTimer(m_pRepeatKeyTimer);
-        m_pRepeatKeyTimer.reset();
+    if (m_repeatKeyTimer && g_pEventLoopManager) {
+        g_pEventLoopManager->removeTimer(m_repeatKeyTimer);
+        m_repeatKeyTimer.reset();
     }
 }
 
 void CKeybindManager::addKeybind(SKeybind kb) {
-    m_vKeybinds.emplace_back(makeShared<SKeybind>(kb));
+    m_keybinds.emplace_back(makeShared<SKeybind>(kb));
 
-    m_vActiveKeybinds.clear();
-    m_pLastLongPressKeybind.reset();
+    m_activeKeybinds.clear();
+    m_lastLongPressKeybind.reset();
 }
 
 void CKeybindManager::removeKeybind(uint32_t mod, const SParsedKey& key) {
-    std::erase_if(m_vKeybinds, [&mod, &key](const auto& el) { return el->modmask == mod && el->key == key.key && el->keycode == key.keycode && el->catchAll == key.catchAll; });
+    std::erase_if(m_keybinds, [&mod, &key](const auto& el) { return el->modmask == mod && el->key == key.key && el->keycode == key.keycode && el->catchAll == key.catchAll; });
 
-    m_vActiveKeybinds.clear();
-    m_pLastLongPressKeybind.reset();
+    m_activeKeybinds.clear();
+    m_lastLongPressKeybind.reset();
 }
 
 uint32_t CKeybindManager::stringToModMask(std::string mods) {
@@ -266,10 +266,10 @@ uint32_t CKeybindManager::keycodeToModifier(xkb_keycode_t keycode) {
 }
 
 void CKeybindManager::updateXKBTranslationState() {
-    if (m_pXKBTranslationState) {
-        xkb_state_unref(m_pXKBTranslationState);
+    if (m_xkbTranslationState) {
+        xkb_state_unref(m_xkbTranslationState);
 
-        m_pXKBTranslationState = nullptr;
+        m_xkbTranslationState = nullptr;
     }
 
     static auto       PFILEPATH = CConfigValue<std::string>("input:kb_file");
@@ -308,7 +308,7 @@ void CKeybindManager::updateXKBTranslationState() {
     }
 
     xkb_context_unref(PCONTEXT);
-    m_pXKBTranslationState = xkb_state_new(PKEYMAP);
+    m_xkbTranslationState = xkb_state_new(PKEYMAP);
     xkb_keymap_unref(PKEYMAP);
 }
 
@@ -427,18 +427,18 @@ void CKeybindManager::switchToWindow(PHLWINDOW PWINDOWTOCHANGETO, bool preserveF
 
 bool CKeybindManager::onKeyEvent(std::any event, SP<IKeyboard> pKeyboard) {
     if (!g_pCompositor->m_sessionActive || g_pCompositor->m_unsafeState) {
-        m_dPressedKeys.clear();
+        m_pressedKeys.clear();
         return true;
     }
 
     if (!pKeyboard->m_allowBinds)
         return true;
 
-    if (!m_pXKBTranslationState) {
+    if (!m_xkbTranslationState) {
         Debug::log(ERR, "BUG THIS: m_pXKBTranslationState nullptr!");
         updateXKBTranslationState();
 
-        if (!m_pXKBTranslationState)
+        if (!m_xkbTranslationState)
             return true;
     }
 
@@ -446,7 +446,7 @@ bool CKeybindManager::onKeyEvent(std::any event, SP<IKeyboard> pKeyboard) {
 
     const auto         KEYCODE = e.keycode + 8; // Because to xkbcommon it's +8 from libinput
 
-    const xkb_keysym_t keysym         = xkb_state_key_get_one_sym(pKeyboard->m_resolveBindsBySym ? pKeyboard->m_xkbSymState : m_pXKBTranslationState, KEYCODE);
+    const xkb_keysym_t keysym         = xkb_state_key_get_one_sym(pKeyboard->m_resolveBindsBySym ? pKeyboard->m_xkbSymState : m_xkbTranslationState, KEYCODE);
     const xkb_keysym_t internalKeysym = xkb_state_key_get_one_sym(pKeyboard->m_xkbState, KEYCODE);
 
     if (keysym == XKB_KEY_Escape || internalKeysym == XKB_KEY_Escape)
@@ -459,9 +459,9 @@ bool CKeybindManager::onKeyEvent(std::any event, SP<IKeyboard> pKeyboard) {
 
     const auto MODS = g_pInputManager->accumulateModsFromAllKBs();
 
-    m_uTimeLastMs    = e.timeMs;
-    m_uLastCode      = KEYCODE;
-    m_uLastMouseCode = 0;
+    m_timeLastMs    = e.timeMs;
+    m_lastCode      = KEYCODE;
+    m_lastMouseCode = 0;
 
     bool       mouseBindWasActive = ensureMouseBindState();
 
@@ -470,34 +470,34 @@ bool CKeybindManager::onKeyEvent(std::any event, SP<IKeyboard> pKeyboard) {
         .keycode            = KEYCODE,
         .modmaskAtPressTime = MODS,
         .sent               = true,
-        .submapAtPress      = m_szCurrentSelectedSubmap,
+        .submapAtPress      = m_currentSelectedSubmap,
         .mousePosAtPress    = g_pInputManager->getMouseCoordsInternal(),
     };
 
-    m_vActiveKeybinds.clear();
+    m_activeKeybinds.clear();
 
-    m_pLastLongPressKeybind.reset();
+    m_lastLongPressKeybind.reset();
 
     bool suppressEvent = false;
     if (e.state == WL_KEYBOARD_KEY_STATE_PRESSED) {
 
-        m_dPressedKeys.push_back(KEY);
+        m_pressedKeys.push_back(KEY);
 
         suppressEvent = !handleKeybinds(MODS, KEY, true).passEvent;
 
         if (suppressEvent)
             shadowKeybinds(keysym, KEYCODE);
 
-        m_dPressedKeys.back().sent = !suppressEvent;
+        m_pressedKeys.back().sent = !suppressEvent;
     } else { // key release
 
         bool foundInPressedKeys = false;
-        for (auto it = m_dPressedKeys.begin(); it != m_dPressedKeys.end();) {
+        for (auto it = m_pressedKeys.begin(); it != m_pressedKeys.end();) {
             if (it->keycode == KEYCODE) {
                 handleKeybinds(MODS, *it, false);
                 foundInPressedKeys = true;
                 suppressEvent      = !it->sent;
-                it                 = m_dPressedKeys.erase(it);
+                it                 = m_pressedKeys.erase(it);
             } else {
                 ++it;
             }
@@ -519,14 +519,14 @@ bool CKeybindManager::onAxisEvent(const IPointer::SAxisEvent& e) {
 
     static auto PDELAY = CConfigValue<Hyprlang::INT>("binds:scroll_event_delay");
 
-    if (m_tScrollTimer.getMillis() < *PDELAY) {
-        m_tScrollTimer.reset();
+    if (m_scrollTimer.getMillis() < *PDELAY) {
+        m_scrollTimer.reset();
         return true; // timer hasn't passed yet!
     }
 
-    m_tScrollTimer.reset();
+    m_scrollTimer.reset();
 
-    m_vActiveKeybinds.clear();
+    m_activeKeybinds.clear();
 
     bool found = false;
     if (e.source == WL_POINTER_AXIS_SOURCE_WHEEL && e.axis == WL_POINTER_AXIS_VERTICAL_SCROLL) {
@@ -552,9 +552,9 @@ bool CKeybindManager::onMouseEvent(const IPointer::SButtonEvent& e) {
 
     bool       suppressEvent = false;
 
-    m_uLastMouseCode = e.button;
-    m_uLastCode      = 0;
-    m_uTimeLastMs    = e.timeMs;
+    m_lastMouseCode = e.button;
+    m_lastCode      = 0;
+    m_timeLastMs    = e.timeMs;
 
     bool       mouseBindWasActive = ensureMouseBindState();
 
@@ -566,25 +566,25 @@ bool CKeybindManager::onMouseEvent(const IPointer::SButtonEvent& e) {
         .mousePosAtPress    = g_pInputManager->getMouseCoordsInternal(),
     };
 
-    m_vActiveKeybinds.clear();
+    m_activeKeybinds.clear();
 
     if (e.state == WL_POINTER_BUTTON_STATE_PRESSED) {
-        m_dPressedKeys.push_back(KEY);
+        m_pressedKeys.push_back(KEY);
 
         suppressEvent = !handleKeybinds(MODS, KEY, true).passEvent;
 
         if (suppressEvent)
             shadowKeybinds();
 
-        m_dPressedKeys.back().sent = !suppressEvent;
+        m_pressedKeys.back().sent = !suppressEvent;
     } else {
         bool foundInPressedKeys = false;
-        for (auto it = m_dPressedKeys.begin(); it != m_dPressedKeys.end();) {
+        for (auto it = m_pressedKeys.begin(); it != m_pressedKeys.end();) {
             if (it->keyName == KEY_NAME) {
                 suppressEvent      = !handleKeybinds(MODS, *it, false).passEvent;
                 foundInPressedKeys = true;
                 suppressEvent      = !it->sent;
-                it                 = m_dPressedKeys.erase(it);
+                it                 = m_pressedKeys.erase(it);
             } else {
                 ++it;
             }
@@ -639,14 +639,14 @@ eMultiKeyCase CKeybindManager::mkKeysymSetMatches(const std::set<xkb_keysym_t> k
 }
 
 eMultiKeyCase CKeybindManager::mkBindMatches(const SP<SKeybind> keybind) {
-    if (mkKeysymSetMatches(keybind->sMkMods, m_sMkMods) != MK_FULL_MATCH)
+    if (mkKeysymSetMatches(keybind->sMkMods, m_mkMods) != MK_FULL_MATCH)
         return MK_NO_MATCH;
 
-    return mkKeysymSetMatches(keybind->sMkKeys, m_sMkKeys);
+    return mkKeysymSetMatches(keybind->sMkKeys, m_mkKeys);
 }
 
 std::string CKeybindManager::getCurrentSubmap() {
-    return m_szCurrentSelectedSubmap;
+    return m_currentSelectedSubmap;
 }
 
 SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SPressedKeyWithMods& key, bool pressed) {
@@ -658,20 +658,20 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
 
     if (pressed) {
         if (keycodeToModifier(key.keycode))
-            m_sMkMods.insert(key.keysym);
+            m_mkMods.insert(key.keysym);
         else
-            m_sMkKeys.insert(key.keysym);
+            m_mkKeys.insert(key.keysym);
     } else {
         if (keycodeToModifier(key.keycode))
-            m_sMkMods.erase(key.keysym);
+            m_mkMods.erase(key.keysym);
         else
-            m_sMkKeys.erase(key.keysym);
+            m_mkKeys.erase(key.keysym);
     }
 
-    for (auto& k : m_vKeybinds) {
+    for (auto& k : m_keybinds) {
         const bool SPECIALDISPATCHER = k->handler == "global" || k->handler == "pass" || k->handler == "sendshortcut" || k->handler == "mouse";
         const bool SPECIALTRIGGERED =
-            std::find_if(m_vPressedSpecialBinds.begin(), m_vPressedSpecialBinds.end(), [&](const auto& other) { return other == k; }) != m_vPressedSpecialBinds.end();
+            std::find_if(m_pressedSpecialBinds.begin(), m_pressedSpecialBinds.end(), [&](const auto& other) { return other == k; }) != m_pressedSpecialBinds.end();
         const bool IGNORECONDITIONS =
             SPECIALDISPATCHER && !pressed && SPECIALTRIGGERED; // ignore mods. Pass, global dispatchers should be released immediately once the key is released.
 
@@ -681,7 +681,7 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
         if (!k->locked && g_pSessionLockManager->isSessionLocked())
             continue;
 
-        if (!IGNORECONDITIONS && ((modmask != k->modmask && !k->ignoreMods) || k->submap != m_szCurrentSelectedSubmap || k->shadowed))
+        if (!IGNORECONDITIONS && ((modmask != k->modmask && !k->ignoreMods) || k->submap != m_currentSelectedSubmap || k->shadowed))
             continue;
 
         if (k->multiKey) {
@@ -697,7 +697,7 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
             if (key.keycode != k->keycode)
                 continue;
         } else if (k->catchAll) {
-            if (found || key.submapAtPress != m_szCurrentSelectedSubmap)
+            if (found || key.submapAtPress != m_currentSelectedSubmap)
                 continue;
         } else {
             // in this case, we only have the keysym to go off of for this keybind, and it's invalid
@@ -762,29 +762,29 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
         }
 
         if (k->longPress) {
-            const auto PACTIVEKEEB = g_pSeatManager->keyboard.lock();
+            const auto PACTIVEKEEB = g_pSeatManager->m_keyboard.lock();
 
-            m_pLongPressTimer->updateTimeout(std::chrono::milliseconds(PACTIVEKEEB->m_repeatDelay));
-            m_pLastLongPressKeybind = k;
+            m_longPressTimer->updateTimeout(std::chrono::milliseconds(PACTIVEKEEB->m_repeatDelay));
+            m_lastLongPressKeybind = k;
 
             continue;
         }
 
-        const auto DISPATCHER = m_mDispatchers.find(k->mouse ? "mouse" : k->handler);
+        const auto DISPATCHER = m_dispatchers.find(k->mouse ? "mouse" : k->handler);
 
         if (SPECIALTRIGGERED && !pressed)
-            std::erase_if(m_vPressedSpecialBinds, [&](const auto& other) { return other == k; });
+            std::erase_if(m_pressedSpecialBinds, [&](const auto& other) { return other == k; });
         else if (SPECIALDISPATCHER && pressed)
-            m_vPressedSpecialBinds.emplace_back(k);
+            m_pressedSpecialBinds.emplace_back(k);
 
         // Should never happen, as we check in the ConfigManager, but oh well
-        if (DISPATCHER == m_mDispatchers.end()) {
+        if (DISPATCHER == m_dispatchers.end()) {
             Debug::log(ERR, "Invalid handler in a keybind! (handler {} does not exist)", k->handler);
         } else {
             // call the dispatcher
             Debug::log(LOG, "Keybind triggered, calling dispatcher ({}, {}, {}, {})", modmask, key.keyName, key.keysym, DISPATCHER->first);
 
-            m_iPassPressed = (int)pressed;
+            m_passPressed = (int)pressed;
 
             // if the dispatchers says to pass event then we will
             if (k->handler == "mouse")
@@ -792,7 +792,7 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
             else
                 res = DISPATCHER->second(k->arg);
 
-            m_iPassPressed = -1;
+            m_passPressed = -1;
 
             if (k->handler == "submap") {
                 found = true; // don't process keybinds on submap change.
@@ -801,10 +801,10 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
         }
 
         if (k->repeat) {
-            const auto PACTIVEKEEB = g_pSeatManager->keyboard.lock();
+            const auto PACTIVEKEEB = g_pSeatManager->m_keyboard.lock();
 
-            m_vActiveKeybinds.emplace_back(k);
-            m_pRepeatKeyTimer->updateTimeout(std::chrono::milliseconds(PACTIVEKEEB->m_repeatDelay));
+            m_activeKeybinds.emplace_back(k);
+            m_repeatKeyTimer->updateTimeout(std::chrono::milliseconds(PACTIVEKEEB->m_repeatDelay));
         }
 
         if (!k->nonConsuming)
@@ -830,7 +830,7 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
 void CKeybindManager::shadowKeybinds(const xkb_keysym_t& doesntHave, const uint32_t doesntHaveCode) {
     // shadow disables keybinds after one has been triggered
 
-    for (auto& k : m_vKeybinds) {
+    for (auto& k : m_keybinds) {
 
         bool shadow = false;
 
@@ -843,7 +843,7 @@ void CKeybindManager::shadowKeybinds(const xkb_keysym_t& doesntHave, const uint3
             const auto KBKEY      = xkb_keysym_from_name(k->key.c_str(), XKB_KEYSYM_CASE_INSENSITIVE);
             const auto KBKEYUPPER = xkb_keysym_to_upper(KBKEY);
 
-            for (auto const& pk : m_dPressedKeys) {
+            for (auto const& pk : m_pressedKeys) {
                 if ((pk.keysym != 0 && (pk.keysym == KBKEY || pk.keysym == KBKEYUPPER))) {
                     shadow = true;
 
@@ -1125,7 +1125,7 @@ SDispatchResult CKeybindManager::signalWindow(std::string args) {
 }
 
 void CKeybindManager::clearKeybinds() {
-    m_vKeybinds.clear();
+    m_keybinds.clear();
 }
 
 static SDispatchResult toggleActiveFloatingCore(std::string args, std::optional<bool> floatState) {
@@ -1336,7 +1336,7 @@ SDispatchResult CKeybindManager::changeworkspace(std::string args) {
 
     if (*PWARPONWORKSPACECHANGE > 0) {
         auto PLAST     = pWorkspaceToChangeTo->getLastFocusedWindow();
-        auto HLSurface = CWLSurface::fromResource(g_pSeatManager->state.pointerFocus.lock());
+        auto HLSurface = CWLSurface::fromResource(g_pSeatManager->m_state.pointerFocus.lock());
 
         if (PLAST && (!HLSurface || HLSurface->getWindow()))
             PLAST->warpCursor(*PWARPONWORKSPACECHANGE == 2);
@@ -2154,7 +2154,7 @@ SDispatchResult CKeybindManager::toggleSpecialWorkspace(std::string args) {
 
     if (*PWARPONTOGGLESPECIAL > 0) {
         auto PLAST     = focusedWorkspace->getLastFocusedWindow();
-        auto HLSurface = CWLSurface::fromResource(g_pSeatManager->state.pointerFocus.lock());
+        auto HLSurface = CWLSurface::fromResource(g_pSeatManager->m_state.pointerFocus.lock());
 
         if (PLAST && (!HLSurface || HLSurface->getWindow()))
             PLAST->warpCursor(*PWARPONTOGGLESPECIAL == 2);
@@ -2400,19 +2400,19 @@ SDispatchResult CKeybindManager::toggleSwallow(std::string args) {
 
 SDispatchResult CKeybindManager::setSubmap(std::string submap) {
     if (submap == "reset" || submap == "") {
-        m_szCurrentSelectedSubmap = "";
+        m_currentSelectedSubmap = "";
         Debug::log(LOG, "Reset active submap to the default one.");
         g_pEventManager->postEvent(SHyprIPCEvent{"submap", ""});
-        EMIT_HOOK_EVENT("submap", m_szCurrentSelectedSubmap);
+        EMIT_HOOK_EVENT("submap", m_currentSelectedSubmap);
         return {};
     }
 
-    for (const auto& k : g_pKeybindManager->m_vKeybinds) {
+    for (const auto& k : g_pKeybindManager->m_keybinds) {
         if (k->submap == submap) {
-            m_szCurrentSelectedSubmap = submap;
+            m_currentSelectedSubmap = submap;
             Debug::log(LOG, "Changed keybind submap to {}", submap);
             g_pEventManager->postEvent(SHyprIPCEvent{"submap", submap});
-            EMIT_HOOK_EVENT("submap", m_szCurrentSelectedSubmap);
+            EMIT_HOOK_EVENT("submap", m_currentSelectedSubmap);
             return {};
         }
     }
@@ -2431,18 +2431,18 @@ SDispatchResult CKeybindManager::pass(std::string regexp) {
         return {.success = false, .error = "pass: window not found"};
     }
 
-    if (!g_pSeatManager->keyboard) {
+    if (!g_pSeatManager->m_keyboard) {
         Debug::log(ERR, "No kb in pass?");
         return {.success = false, .error = "No kb in pass?"};
     }
 
     const auto XWTOXW        = PWINDOW->m_isX11 && g_pCompositor->m_lastWindow.lock() && g_pCompositor->m_lastWindow->m_isX11;
-    const auto LASTMOUSESURF = g_pSeatManager->state.pointerFocus.lock();
-    const auto LASTKBSURF    = g_pSeatManager->state.keyboardFocus.lock();
+    const auto LASTMOUSESURF = g_pSeatManager->m_state.pointerFocus.lock();
+    const auto LASTKBSURF    = g_pSeatManager->m_state.keyboardFocus.lock();
 
     // pass all mf shit
     if (!XWTOXW) {
-        if (g_pKeybindManager->m_uLastCode != 0)
+        if (g_pKeybindManager->m_lastCode != 0)
             g_pSeatManager->setKeyboardFocus(PWINDOW->m_wlSurface->resource());
         else
             g_pSeatManager->setPointerFocus(PWINDOW->m_wlSurface->resource(), {1, 1});
@@ -2450,24 +2450,24 @@ SDispatchResult CKeybindManager::pass(std::string regexp) {
 
     g_pSeatManager->sendKeyboardMods(g_pInputManager->accumulateModsFromAllKBs(), 0, 0, 0);
 
-    if (g_pKeybindManager->m_iPassPressed == 1) {
-        if (g_pKeybindManager->m_uLastCode != 0)
-            g_pSeatManager->sendKeyboardKey(g_pKeybindManager->m_uTimeLastMs, g_pKeybindManager->m_uLastCode - 8, WL_KEYBOARD_KEY_STATE_PRESSED);
+    if (g_pKeybindManager->m_passPressed == 1) {
+        if (g_pKeybindManager->m_lastCode != 0)
+            g_pSeatManager->sendKeyboardKey(g_pKeybindManager->m_timeLastMs, g_pKeybindManager->m_lastCode - 8, WL_KEYBOARD_KEY_STATE_PRESSED);
         else
-            g_pSeatManager->sendPointerButton(g_pKeybindManager->m_uTimeLastMs, g_pKeybindManager->m_uLastMouseCode, WL_POINTER_BUTTON_STATE_PRESSED);
-    } else if (g_pKeybindManager->m_iPassPressed == 0)
-        if (g_pKeybindManager->m_uLastCode != 0)
-            g_pSeatManager->sendKeyboardKey(g_pKeybindManager->m_uTimeLastMs, g_pKeybindManager->m_uLastCode - 8, WL_KEYBOARD_KEY_STATE_RELEASED);
+            g_pSeatManager->sendPointerButton(g_pKeybindManager->m_timeLastMs, g_pKeybindManager->m_lastMouseCode, WL_POINTER_BUTTON_STATE_PRESSED);
+    } else if (g_pKeybindManager->m_passPressed == 0)
+        if (g_pKeybindManager->m_lastCode != 0)
+            g_pSeatManager->sendKeyboardKey(g_pKeybindManager->m_timeLastMs, g_pKeybindManager->m_lastCode - 8, WL_KEYBOARD_KEY_STATE_RELEASED);
         else
-            g_pSeatManager->sendPointerButton(g_pKeybindManager->m_uTimeLastMs, g_pKeybindManager->m_uLastMouseCode, WL_POINTER_BUTTON_STATE_RELEASED);
+            g_pSeatManager->sendPointerButton(g_pKeybindManager->m_timeLastMs, g_pKeybindManager->m_lastMouseCode, WL_POINTER_BUTTON_STATE_RELEASED);
     else {
         // dynamic call of the dispatcher
-        if (g_pKeybindManager->m_uLastCode != 0) {
-            g_pSeatManager->sendKeyboardKey(g_pKeybindManager->m_uTimeLastMs, g_pKeybindManager->m_uLastCode - 8, WL_KEYBOARD_KEY_STATE_PRESSED);
-            g_pSeatManager->sendKeyboardKey(g_pKeybindManager->m_uTimeLastMs, g_pKeybindManager->m_uLastCode - 8, WL_KEYBOARD_KEY_STATE_RELEASED);
+        if (g_pKeybindManager->m_lastCode != 0) {
+            g_pSeatManager->sendKeyboardKey(g_pKeybindManager->m_timeLastMs, g_pKeybindManager->m_lastCode - 8, WL_KEYBOARD_KEY_STATE_PRESSED);
+            g_pSeatManager->sendKeyboardKey(g_pKeybindManager->m_timeLastMs, g_pKeybindManager->m_lastCode - 8, WL_KEYBOARD_KEY_STATE_RELEASED);
         } else {
-            g_pSeatManager->sendPointerButton(g_pKeybindManager->m_uTimeLastMs, g_pKeybindManager->m_uLastMouseCode, WL_POINTER_BUTTON_STATE_PRESSED);
-            g_pSeatManager->sendPointerButton(g_pKeybindManager->m_uTimeLastMs, g_pKeybindManager->m_uLastMouseCode, WL_POINTER_BUTTON_STATE_RELEASED);
+            g_pSeatManager->sendPointerButton(g_pKeybindManager->m_timeLastMs, g_pKeybindManager->m_lastMouseCode, WL_POINTER_BUTTON_STATE_PRESSED);
+            g_pSeatManager->sendPointerButton(g_pKeybindManager->m_timeLastMs, g_pKeybindManager->m_lastMouseCode, WL_POINTER_BUTTON_STATE_RELEASED);
         }
     }
 
@@ -2478,18 +2478,18 @@ SDispatchResult CKeybindManager::pass(std::string regexp) {
     // this will make g_pSeatManager NOT send the leave event to XWayland apps, provided we are not on an XWayland window already.
     // please kill me
     if (PWINDOW->m_isX11) {
-        if (g_pKeybindManager->m_uLastCode != 0) {
-            g_pSeatManager->state.keyboardFocus.reset();
-            g_pSeatManager->state.keyboardFocusResource.reset();
+        if (g_pKeybindManager->m_lastCode != 0) {
+            g_pSeatManager->m_state.keyboardFocus.reset();
+            g_pSeatManager->m_state.keyboardFocusResource.reset();
         } else {
-            g_pSeatManager->state.pointerFocus.reset();
-            g_pSeatManager->state.pointerFocusResource.reset();
+            g_pSeatManager->m_state.pointerFocus.reset();
+            g_pSeatManager->m_state.pointerFocusResource.reset();
         }
     }
 
     const auto SL = PWINDOW->m_realPosition->goal() - g_pInputManager->getMouseCoordsInternal();
 
-    if (g_pKeybindManager->m_uLastCode != 0)
+    if (g_pKeybindManager->m_lastCode != 0)
         g_pSeatManager->setKeyboardFocus(LASTKBSURF);
     else
         g_pSeatManager->setPointerFocus(LASTMOUSESURF, SL);
@@ -2531,7 +2531,7 @@ SDispatchResult CKeybindManager::sendshortcut(std::string args) {
         const auto KEYSYM = xkb_keysym_from_name(KEY.c_str(), XKB_KEYSYM_CASE_INSENSITIVE);
         keycode           = 0;
 
-        const auto KB = g_pSeatManager->keyboard;
+        const auto KB = g_pSeatManager->m_keyboard;
 
         if (!KB) {
             Debug::log(ERR, "sendshortcut: no kb");
@@ -2540,7 +2540,7 @@ SDispatchResult CKeybindManager::sendshortcut(std::string args) {
 
         const auto KEYPAIRSTRING = std::format("{}{}", (uintptr_t)KB.get(), KEY);
 
-        if (!g_pKeybindManager->m_mKeyToCodeCache.contains(KEYPAIRSTRING)) {
+        if (!g_pKeybindManager->m_keyToCodeCache.contains(KEYPAIRSTRING)) {
             xkb_keymap*   km = KB->m_xkbKeymap;
             xkb_state*    ks = KB->m_xkbState;
 
@@ -2552,8 +2552,8 @@ SDispatchResult CKeybindManager::sendshortcut(std::string args) {
                 xkb_keysym_t sym = xkb_state_key_get_one_sym(ks, kc);
 
                 if (sym == KEYSYM) {
-                    keycode                                             = kc;
-                    g_pKeybindManager->m_mKeyToCodeCache[KEYPAIRSTRING] = keycode;
+                    keycode                                            = kc;
+                    g_pKeybindManager->m_keyToCodeCache[KEYPAIRSTRING] = keycode;
                 }
             }
 
@@ -2563,7 +2563,7 @@ SDispatchResult CKeybindManager::sendshortcut(std::string args) {
             }
 
         } else
-            keycode = g_pKeybindManager->m_mKeyToCodeCache[KEYPAIRSTRING];
+            keycode = g_pKeybindManager->m_keyToCodeCache[KEYPAIRSTRING];
     }
 
     if (!keycode) {
@@ -2585,7 +2585,7 @@ SDispatchResult CKeybindManager::sendshortcut(std::string args) {
             return {.success = false, .error = "sendshortcut: window not found"};
         }
 
-        if (!g_pSeatManager->keyboard) {
+        if (!g_pSeatManager->m_keyboard) {
             Debug::log(ERR, "No kb in sendshortcut?");
             return {.success = false, .error = "No kb in sendshortcut?"};
         }
@@ -2606,24 +2606,24 @@ SDispatchResult CKeybindManager::sendshortcut(std::string args) {
 
     g_pSeatManager->sendKeyboardMods(MOD, 0, 0, 0);
 
-    if (g_pKeybindManager->m_iPassPressed == 1) {
+    if (g_pKeybindManager->m_passPressed == 1) {
         if (!isMouse)
-            g_pSeatManager->sendKeyboardKey(g_pKeybindManager->m_uTimeLastMs, keycode - 8, WL_KEYBOARD_KEY_STATE_PRESSED);
+            g_pSeatManager->sendKeyboardKey(g_pKeybindManager->m_timeLastMs, keycode - 8, WL_KEYBOARD_KEY_STATE_PRESSED);
         else
-            g_pSeatManager->sendPointerButton(g_pKeybindManager->m_uTimeLastMs, keycode, WL_POINTER_BUTTON_STATE_PRESSED);
-    } else if (g_pKeybindManager->m_iPassPressed == 0) {
+            g_pSeatManager->sendPointerButton(g_pKeybindManager->m_timeLastMs, keycode, WL_POINTER_BUTTON_STATE_PRESSED);
+    } else if (g_pKeybindManager->m_passPressed == 0) {
         if (!isMouse)
-            g_pSeatManager->sendKeyboardKey(g_pKeybindManager->m_uTimeLastMs, keycode - 8, WL_KEYBOARD_KEY_STATE_RELEASED);
+            g_pSeatManager->sendKeyboardKey(g_pKeybindManager->m_timeLastMs, keycode - 8, WL_KEYBOARD_KEY_STATE_RELEASED);
         else
-            g_pSeatManager->sendPointerButton(g_pKeybindManager->m_uTimeLastMs, keycode, WL_POINTER_BUTTON_STATE_RELEASED);
+            g_pSeatManager->sendPointerButton(g_pKeybindManager->m_timeLastMs, keycode, WL_POINTER_BUTTON_STATE_RELEASED);
     } else {
         // dynamic call of the dispatcher
         if (!isMouse) {
-            g_pSeatManager->sendKeyboardKey(g_pKeybindManager->m_uTimeLastMs, keycode - 8, WL_KEYBOARD_KEY_STATE_PRESSED);
-            g_pSeatManager->sendKeyboardKey(g_pKeybindManager->m_uTimeLastMs, keycode - 8, WL_KEYBOARD_KEY_STATE_RELEASED);
+            g_pSeatManager->sendKeyboardKey(g_pKeybindManager->m_timeLastMs, keycode - 8, WL_KEYBOARD_KEY_STATE_PRESSED);
+            g_pSeatManager->sendKeyboardKey(g_pKeybindManager->m_timeLastMs, keycode - 8, WL_KEYBOARD_KEY_STATE_RELEASED);
         } else {
-            g_pSeatManager->sendPointerButton(g_pKeybindManager->m_uTimeLastMs, keycode, WL_POINTER_BUTTON_STATE_PRESSED);
-            g_pSeatManager->sendPointerButton(g_pKeybindManager->m_uTimeLastMs, keycode, WL_POINTER_BUTTON_STATE_RELEASED);
+            g_pSeatManager->sendPointerButton(g_pKeybindManager->m_timeLastMs, keycode, WL_POINTER_BUTTON_STATE_PRESSED);
+            g_pSeatManager->sendPointerButton(g_pKeybindManager->m_timeLastMs, keycode, WL_POINTER_BUTTON_STATE_RELEASED);
         }
     }
 
@@ -2634,11 +2634,11 @@ SDispatchResult CKeybindManager::sendshortcut(std::string args) {
 
     if (PWINDOW->m_isX11) { //xwayland hack, see pass
         if (!isMouse) {
-            g_pSeatManager->state.keyboardFocus.reset();
-            g_pSeatManager->state.keyboardFocusResource.reset();
+            g_pSeatManager->m_state.keyboardFocus.reset();
+            g_pSeatManager->m_state.keyboardFocusResource.reset();
         } else {
-            g_pSeatManager->state.pointerFocus.reset();
-            g_pSeatManager->state.pointerFocusResource.reset();
+            g_pSeatManager->m_state.pointerFocus.reset();
+            g_pSeatManager->m_state.pointerFocusResource.reset();
         }
     }
 
@@ -2877,13 +2877,13 @@ SDispatchResult CKeybindManager::alterZOrder(std::string args) {
 
 SDispatchResult CKeybindManager::lockGroups(std::string args) {
     if (args == "lock" || args.empty() || args == "lockgroups")
-        g_pKeybindManager->m_bGroupsLocked = true;
+        g_pKeybindManager->m_groupsLocked = true;
     else if (args == "toggle")
-        g_pKeybindManager->m_bGroupsLocked = !g_pKeybindManager->m_bGroupsLocked;
+        g_pKeybindManager->m_groupsLocked = !g_pKeybindManager->m_groupsLocked;
     else
-        g_pKeybindManager->m_bGroupsLocked = false;
+        g_pKeybindManager->m_groupsLocked = false;
 
-    g_pEventManager->postEvent(SHyprIPCEvent{"lockgroups", g_pKeybindManager->m_bGroupsLocked ? "1" : "0"});
+    g_pEventManager->postEvent(SHyprIPCEvent{"lockgroups", g_pKeybindManager->m_groupsLocked ? "1" : "0"});
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 
     return {};
@@ -2962,12 +2962,12 @@ void CKeybindManager::moveWindowOutOfGroup(PHLWINDOW pWindow, const std::string&
     } else {
         g_pLayoutManager->getCurrentLayout()->onWindowRemoved(pWindow);
 
-        const auto GROUPSLOCKEDPREV        = g_pKeybindManager->m_bGroupsLocked;
-        g_pKeybindManager->m_bGroupsLocked = true;
+        const auto GROUPSLOCKEDPREV       = g_pKeybindManager->m_groupsLocked;
+        g_pKeybindManager->m_groupsLocked = true;
 
         g_pLayoutManager->getCurrentLayout()->onWindowCreated(pWindow, direction);
 
-        g_pKeybindManager->m_bGroupsLocked = GROUPSLOCKEDPREV;
+        g_pKeybindManager->m_groupsLocked = GROUPSLOCKEDPREV;
     }
 
     if (*BFOCUSREMOVEDWINDOW) {
@@ -2986,7 +2986,7 @@ SDispatchResult CKeybindManager::moveIntoGroup(std::string args) {
 
     static auto PIGNOREGROUPLOCK = CConfigValue<Hyprlang::INT>("binds:ignore_group_lock");
 
-    if (!*PIGNOREGROUPLOCK && g_pKeybindManager->m_bGroupsLocked)
+    if (!*PIGNOREGROUPLOCK && g_pKeybindManager->m_groupsLocked)
         return {};
 
     if (!isDirection(args)) {
@@ -3016,7 +3016,7 @@ SDispatchResult CKeybindManager::moveIntoGroup(std::string args) {
 SDispatchResult CKeybindManager::moveOutOfGroup(std::string args) {
     static auto PIGNOREGROUPLOCK = CConfigValue<Hyprlang::INT>("binds:ignore_group_lock");
 
-    if (!*PIGNOREGROUPLOCK && g_pKeybindManager->m_bGroupsLocked)
+    if (!*PIGNOREGROUPLOCK && g_pKeybindManager->m_groupsLocked)
         return {.success = false, .error = "Groups locked"};
 
     PHLWINDOW PWINDOW = nullptr;
@@ -3054,7 +3054,7 @@ SDispatchResult CKeybindManager::moveWindowOrGroup(std::string args) {
     if (PWINDOW->isFullscreen())
         return {};
 
-    if (!*PIGNOREGROUPLOCK && g_pKeybindManager->m_bGroupsLocked) {
+    if (!*PIGNOREGROUPLOCK && g_pKeybindManager->m_groupsLocked) {
         g_pLayoutManager->getCurrentLayout()->moveWindowTo(PWINDOW, args);
         return {};
     }
@@ -3130,7 +3130,7 @@ SDispatchResult CKeybindManager::global(std::string args) {
     if (!PROTO::globalShortcuts->isTaken(APPID, NAME))
         return {};
 
-    PROTO::globalShortcuts->sendGlobalShortcutEvent(APPID, NAME, g_pKeybindManager->m_iPassPressed);
+    PROTO::globalShortcuts->sendGlobalShortcutEvent(APPID, NAME, g_pKeybindManager->m_passPressed);
 
     return {};
 }
@@ -3296,21 +3296,21 @@ SDispatchResult CKeybindManager::sendkeystate(std::string args) {
 
     std::string modifiedArgs = ARGS[0] + "," + ARGS[1] + "," + ARGS[3];
 
-    const int   oldPassPressed = g_pKeybindManager->m_iPassPressed;
+    const int   oldPassPressed = g_pKeybindManager->m_passPressed;
 
     if (STATE == "down")
-        g_pKeybindManager->m_iPassPressed = 1;
+        g_pKeybindManager->m_passPressed = 1;
     else if (STATE == "up")
-        g_pKeybindManager->m_iPassPressed = 0;
+        g_pKeybindManager->m_passPressed = 0;
     else if (STATE == "repeat")
-        g_pKeybindManager->m_iPassPressed = 1;
+        g_pKeybindManager->m_passPressed = 1;
 
     auto result = sendshortcut(modifiedArgs);
 
     if (STATE == "repeat" && result.success)
         result = sendshortcut(modifiedArgs);
 
-    g_pKeybindManager->m_iPassPressed = oldPassPressed;
+    g_pKeybindManager->m_passPressed = oldPassPressed;
 
     if (!result.success && !result.error.empty()) {
         size_t pos = result.error.find("sendshortcut:");

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -100,50 +100,52 @@ class CKeybindManager {
     void                                                                         shadowKeybinds(const xkb_keysym_t& doesntHave = 0, const uint32_t doesntHaveCode = 0);
     std::string                                                                  getCurrentSubmap();
 
-    std::unordered_map<std::string, std::function<SDispatchResult(std::string)>> m_mDispatchers;
+    std::unordered_map<std::string, std::function<SDispatchResult(std::string)>> m_dispatchers;
 
-    bool                                                                         m_bGroupsLocked = false;
+    bool                                                                         m_groupsLocked = false;
 
-    std::vector<SP<SKeybind>>                                                    m_vKeybinds;
+    std::vector<SP<SKeybind>>                                                    m_keybinds;
 
     //since we cant find keycode through keyname in xkb:
     //on sendshortcut call, we once search for keyname (e.g. "g") the correct keycode (e.g. 42)
     //and cache it in this map to make sendshortcut calls faster
     //we also store the keyboard pointer (in the string) to differentiate between different keyboard (layouts)
-    std::unordered_map<std::string, xkb_keycode_t> m_mKeyToCodeCache;
+    std::unordered_map<std::string, xkb_keycode_t> m_keyToCodeCache;
 
     static SDispatchResult                         changeMouseBindMode(const eMouseBindMode mode);
 
   private:
-    std::vector<SPressedKeyWithMods> m_dPressedKeys;
+    std::vector<SPressedKeyWithMods> m_pressedKeys;
 
-    inline static std::string        m_szCurrentSelectedSubmap = "";
+    inline static std::string        m_currentSelectedSubmap = "";
 
-    std::vector<WP<SKeybind>>        m_vActiveKeybinds;
-    WP<SKeybind>                     m_pLastLongPressKeybind;
-    SP<CEventLoopTimer>              m_pLongPressTimer, m_pRepeatKeyTimer;
+    std::vector<WP<SKeybind>>        m_activeKeybinds;
+    WP<SKeybind>                     m_lastLongPressKeybind;
 
-    uint32_t                         m_uTimeLastMs    = 0;
-    uint32_t                         m_uLastCode      = 0;
-    uint32_t                         m_uLastMouseCode = 0;
+    SP<CEventLoopTimer>              m_longPressTimer;
+    SP<CEventLoopTimer>              m_repeatKeyTimer;
 
-    std::vector<WP<SKeybind>>        m_vPressedSpecialBinds;
+    uint32_t                         m_timeLastMs    = 0;
+    uint32_t                         m_lastCode      = 0;
+    uint32_t                         m_lastMouseCode = 0;
 
-    int                              m_iPassPressed = -1; // used for pass
+    std::vector<WP<SKeybind>>        m_pressedSpecialBinds;
 
-    CTimer                           m_tScrollTimer;
+    int                              m_passPressed = -1; // used for pass
+
+    CTimer                           m_scrollTimer;
 
     SDispatchResult                  handleKeybinds(const uint32_t, const SPressedKeyWithMods&, bool);
 
-    std::set<xkb_keysym_t>           m_sMkKeys = {};
-    std::set<xkb_keysym_t>           m_sMkMods = {};
+    std::set<xkb_keysym_t>           m_mkKeys = {};
+    std::set<xkb_keysym_t>           m_mkMods = {};
     eMultiKeyCase                    mkBindMatches(const SP<SKeybind>);
     eMultiKeyCase                    mkKeysymSetMatches(const std::set<xkb_keysym_t>, const std::set<xkb_keysym_t>);
 
     bool                             handleInternalKeybinds(xkb_keysym_t);
     bool                             handleVT(xkb_keysym_t);
 
-    xkb_state*                       m_pXKBTranslationState = nullptr;
+    xkb_state*                       m_xkbTranslationState = nullptr;
 
     void                             updateXKBTranslationState();
     bool                             ensureMouseBindState();

--- a/src/managers/LayoutManager.cpp
+++ b/src/managers/LayoutManager.cpp
@@ -1,22 +1,22 @@
 #include "LayoutManager.hpp"
 
 CLayoutManager::CLayoutManager() {
-    m_vLayouts.emplace_back(std::make_pair<>("dwindle", &m_cDwindleLayout));
-    m_vLayouts.emplace_back(std::make_pair<>("master", &m_cMasterLayout));
+    m_layouts.emplace_back(std::make_pair<>("dwindle", &m_dwindleLayout));
+    m_layouts.emplace_back(std::make_pair<>("master", &m_masterLayout));
 }
 
 IHyprLayout* CLayoutManager::getCurrentLayout() {
-    return m_vLayouts[m_iCurrentLayoutID].second;
+    return m_layouts[m_currentLayoutID].second;
 }
 
 void CLayoutManager::switchToLayout(std::string layout) {
-    for (size_t i = 0; i < m_vLayouts.size(); ++i) {
-        if (m_vLayouts[i].first == layout) {
-            if (i == (size_t)m_iCurrentLayoutID)
+    for (size_t i = 0; i < m_layouts.size(); ++i) {
+        if (m_layouts[i].first == layout) {
+            if (i == (size_t)m_currentLayoutID)
                 return;
 
             getCurrentLayout()->onDisable();
-            m_iCurrentLayoutID = i;
+            m_currentLayoutID = i;
             getCurrentLayout()->onEnable();
             return;
         }
@@ -26,10 +26,10 @@ void CLayoutManager::switchToLayout(std::string layout) {
 }
 
 bool CLayoutManager::addLayout(const std::string& name, IHyprLayout* layout) {
-    if (std::find_if(m_vLayouts.begin(), m_vLayouts.end(), [&](const auto& other) { return other.first == name || other.second == layout; }) != m_vLayouts.end())
+    if (std::find_if(m_layouts.begin(), m_layouts.end(), [&](const auto& other) { return other.first == name || other.second == layout; }) != m_layouts.end())
         return false;
 
-    m_vLayouts.emplace_back(std::make_pair<>(name, layout));
+    m_layouts.emplace_back(std::make_pair<>(name, layout));
 
     Debug::log(LOG, "Added new layout {} at {:x}", name, (uintptr_t)layout);
 
@@ -37,24 +37,24 @@ bool CLayoutManager::addLayout(const std::string& name, IHyprLayout* layout) {
 }
 
 bool CLayoutManager::removeLayout(IHyprLayout* layout) {
-    const auto IT = std::find_if(m_vLayouts.begin(), m_vLayouts.end(), [&](const auto& other) { return other.second == layout; });
+    const auto IT = std::find_if(m_layouts.begin(), m_layouts.end(), [&](const auto& other) { return other.second == layout; });
 
-    if (IT == m_vLayouts.end() || IT->first == "dwindle" || IT->first == "master")
+    if (IT == m_layouts.end() || IT->first == "dwindle" || IT->first == "master")
         return false;
 
-    if (m_iCurrentLayoutID == IT - m_vLayouts.begin())
+    if (m_currentLayoutID == IT - m_layouts.begin())
         switchToLayout("dwindle");
 
     Debug::log(LOG, "Removed a layout {} at {:x}", IT->first, (uintptr_t)layout);
 
-    std::erase(m_vLayouts, *IT);
+    std::erase(m_layouts, *IT);
 
     return true;
 }
 
 std::vector<std::string> CLayoutManager::getAllLayoutNames() {
-    std::vector<std::string> results(m_vLayouts.size());
-    for (size_t i = 0; i < m_vLayouts.size(); ++i)
-        results[i] = m_vLayouts[i].first;
+    std::vector<std::string> results(m_layouts.size());
+    for (size_t i = 0; i < m_layouts.size(); ++i)
+        results[i] = m_layouts[i].first;
     return results;
 }

--- a/src/managers/LayoutManager.hpp
+++ b/src/managers/LayoutManager.hpp
@@ -21,11 +21,11 @@ class CLayoutManager {
         LAYOUT_MASTER
     };
 
-    int                                               m_iCurrentLayoutID = LAYOUT_DWINDLE;
+    int                                               m_currentLayoutID = LAYOUT_DWINDLE;
 
-    CHyprDwindleLayout                                m_cDwindleLayout;
-    CHyprMasterLayout                                 m_cMasterLayout;
-    std::vector<std::pair<std::string, IHyprLayout*>> m_vLayouts;
+    CHyprDwindleLayout                                m_dwindleLayout;
+    CHyprMasterLayout                                 m_masterLayout;
+    std::vector<std::pair<std::string, IHyprLayout*>> m_layouts;
 };
 
 inline UP<CLayoutManager> g_pLayoutManager;

--- a/src/managers/PointerManager.hpp
+++ b/src/managers/PointerManager.hpp
@@ -110,7 +110,7 @@ class CPointerManager {
 
         WP<IPointer>        pointer;
     };
-    std::vector<SP<SPointerListener>> pointerListeners;
+    std::vector<SP<SPointerListener>> m_pointerListeners;
 
     struct STouchListener {
         CHyprSignalListener destroy;
@@ -122,7 +122,7 @@ class CPointerManager {
 
         WP<ITouch>          touch;
     };
-    std::vector<SP<STouchListener>> touchListeners;
+    std::vector<SP<STouchListener>> m_touchListeners;
 
     struct STabletListener {
         CHyprSignalListener destroy;
@@ -133,11 +133,11 @@ class CPointerManager {
 
         WP<CTablet>         tablet;
     };
-    std::vector<SP<STabletListener>> tabletListeners;
+    std::vector<SP<STabletListener>> m_tabletListeners;
 
     struct {
         std::vector<CBox> monitorBoxes;
-    } currentMonitorLayout;
+    } m_currentMonitorLayout;
 
     struct {
         SP<Aquamarine::IBuffer> pBuffer;
@@ -150,13 +150,13 @@ class CPointerManager {
 
         CHyprSignalListener     destroySurface;
         CHyprSignalListener     commitSurface;
-    } currentCursorImage; // TODO: support various sizes per-output so we can have pixel-perfect cursors
+    } m_currentCursorImage; // TODO: support various sizes per-output so we can have pixel-perfect cursors
 
-    Vector2D pointerPos = {0, 0};
+    Vector2D m_pointerPos = {0, 0};
 
-    uint64_t storedTime    = 0;
-    Vector2D storedDelta   = {0, 0};
-    Vector2D storedUnaccel = {0, 0};
+    uint64_t m_storedTime    = 0;
+    Vector2D m_storedDelta   = {0, 0};
+    Vector2D m_storedUnaccel = {0, 0};
 
     struct SMonitorPointerState {
         SMonitorPointerState(const PHLMONITOR& m) : monitor(m) {}
@@ -174,7 +174,7 @@ class CPointerManager {
         SP<Aquamarine::IBuffer> cursorFrontBuffer;
     };
 
-    std::vector<SP<SMonitorPointerState>> monitorStates;
+    std::vector<SP<SMonitorPointerState>> m_monitorStates;
     SP<SMonitorPointerState>              stateFor(PHLMONITOR mon);
     bool                                  attemptHardwareCursor(SP<SMonitorPointerState> state);
     SP<Aquamarine::IBuffer>               renderHWCursorBuffer(SP<SMonitorPointerState> state, SP<CTexture> texture);
@@ -183,7 +183,7 @@ class CPointerManager {
     struct {
         SP<HOOK_CALLBACK_FN> monitorAdded;
         SP<HOOK_CALLBACK_FN> monitorPreRender;
-    } hooks;
+    } m_hooks;
 };
 
 inline UP<CPointerManager> g_pPointerManager;

--- a/src/managers/ProtocolManager.cpp
+++ b/src/managers/ProtocolManager.cpp
@@ -122,7 +122,7 @@ CProtocolManager::CProtocolManager() {
         PROTO::outputs.emplace(M->m_name, ref);
         ref->self = ref;
 
-        m_mModeChangeListeners[M->m_name] = M->m_events.modeChanged.registerListener([M, this](std::any d) { onMonitorModeChange(M); });
+        m_modeChangeListeners[M->m_name] = M->m_events.modeChanged.registerListener([M, this](std::any d) { onMonitorModeChange(M); });
     });
 
     static auto P2 = g_pHookSystem->hookDynamic("monitorRemoved", [this](void* self, SCallbackInfo& info, std::any param) {
@@ -130,7 +130,7 @@ CProtocolManager::CProtocolManager() {
         if (!PROTO::outputs.contains(M->m_name))
             return;
         PROTO::outputs.at(M->m_name)->remove();
-        m_mModeChangeListeners.erase(M->m_name);
+        m_modeChangeListeners.erase(M->m_name);
     });
 
     // Core

--- a/src/managers/ProtocolManager.hpp
+++ b/src/managers/ProtocolManager.hpp
@@ -13,7 +13,7 @@ class CProtocolManager {
     bool isGlobalPrivileged(const wl_global* global);
 
   private:
-    std::unordered_map<std::string, CHyprSignalListener> m_mModeChangeListeners;
+    std::unordered_map<std::string, CHyprSignalListener> m_modeChangeListeners;
 
     void                                                 onMonitorModeChange(PHLMONITOR pMonitor);
 };

--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -14,20 +14,20 @@
 #include <ranges>
 
 CSeatManager::CSeatManager() {
-    listeners.newSeatResource = PROTO::seat->events.newSeatResource.registerListener([this](std::any res) { onNewSeatResource(std::any_cast<SP<CWLSeatResource>>(res)); });
+    m_listeners.newSeatResource = PROTO::seat->events.newSeatResource.registerListener([this](std::any res) { onNewSeatResource(std::any_cast<SP<CWLSeatResource>>(res)); });
 }
 
 CSeatManager::SSeatResourceContainer::SSeatResourceContainer(SP<CWLSeatResource> res) : resource(res) {
     listeners.destroy = res->events.destroy.registerListener(
-        [this](std::any data) { std::erase_if(g_pSeatManager->seatResources, [this](const auto& e) { return e->resource.expired() || e->resource == resource; }); });
+        [this](std::any data) { std::erase_if(g_pSeatManager->m_seatResources, [this](const auto& e) { return e->resource.expired() || e->resource == resource; }); });
 }
 
 void CSeatManager::onNewSeatResource(SP<CWLSeatResource> resource) {
-    seatResources.emplace_back(makeShared<SSeatResourceContainer>(resource));
+    m_seatResources.emplace_back(makeShared<SSeatResourceContainer>(resource));
 }
 
 SP<CSeatManager::SSeatResourceContainer> CSeatManager::containerForResource(SP<CWLSeatResource> seatResource) {
-    for (auto const& c : seatResources) {
+    for (auto const& c : m_seatResources) {
         if (c->resource == seatResource)
             return c;
     }
@@ -76,19 +76,19 @@ void CSeatManager::updateCapabilities(uint32_t capabilities) {
 }
 
 void CSeatManager::setMouse(SP<IPointer> MAUZ) {
-    if (mouse == MAUZ)
+    if (m_mouse == MAUZ)
         return;
 
-    mouse = MAUZ;
+    m_mouse = MAUZ;
 }
 
 void CSeatManager::setKeyboard(SP<IKeyboard> KEEB) {
-    if (keyboard == KEEB)
+    if (m_keyboard == KEEB)
         return;
 
-    if (keyboard)
-        keyboard->m_active = false;
-    keyboard = KEEB;
+    if (m_keyboard)
+        m_keyboard->m_active = false;
+    m_keyboard = KEEB;
 
     if (KEEB)
         KEEB->m_active = true;
@@ -97,25 +97,25 @@ void CSeatManager::setKeyboard(SP<IKeyboard> KEEB) {
 }
 
 void CSeatManager::updateActiveKeyboardData() {
-    if (keyboard)
-        PROTO::seat->updateRepeatInfo(keyboard->m_repeatRate, keyboard->m_repeatDelay);
+    if (m_keyboard)
+        PROTO::seat->updateRepeatInfo(m_keyboard->m_repeatRate, m_keyboard->m_repeatDelay);
     PROTO::seat->updateKeymap();
 }
 
 void CSeatManager::setKeyboardFocus(SP<CWLSurfaceResource> surf) {
-    if (state.keyboardFocus == surf)
+    if (m_state.keyboardFocus == surf)
         return;
 
-    if (!keyboard) {
+    if (!m_keyboard) {
         Debug::log(ERR, "BUG THIS: setKeyboardFocus without a valid keyboard set");
         return;
     }
 
-    listeners.keyboardSurfaceDestroy.reset();
+    m_listeners.keyboardSurfaceDestroy.reset();
 
-    if (state.keyboardFocusResource) {
-        auto client = state.keyboardFocusResource->client();
-        for (auto const& s : seatResources) {
+    if (m_state.keyboardFocusResource) {
+        auto client = m_state.keyboardFocusResource->client();
+        for (auto const& s : m_seatResources) {
             if (s->resource->client() != client)
                 continue;
 
@@ -128,40 +128,40 @@ void CSeatManager::setKeyboardFocus(SP<CWLSurfaceResource> surf) {
         }
     }
 
-    state.keyboardFocusResource.reset();
-    state.keyboardFocus = surf;
+    m_state.keyboardFocusResource.reset();
+    m_state.keyboardFocus = surf;
 
     if (!surf) {
-        events.keyboardFocusChange.emit();
+        m_events.keyboardFocusChange.emit();
         return;
     }
 
     auto client = surf->client();
-    for (auto const& r : seatResources | std::views::reverse) {
+    for (auto const& r : m_seatResources | std::views::reverse) {
         if (r->resource->client() != client)
             continue;
 
-        state.keyboardFocusResource = r->resource;
+        m_state.keyboardFocusResource = r->resource;
         for (auto const& k : r->resource->keyboards) {
             if (!k)
                 continue;
 
             k->sendEnter(surf);
-            k->sendMods(keyboard->m_modifiersState.depressed, keyboard->m_modifiersState.latched, keyboard->m_modifiersState.locked, keyboard->m_modifiersState.group);
+            k->sendMods(m_keyboard->m_modifiersState.depressed, m_keyboard->m_modifiersState.latched, m_keyboard->m_modifiersState.locked, m_keyboard->m_modifiersState.group);
         }
     }
 
-    listeners.keyboardSurfaceDestroy = surf->events.destroy.registerListener([this](std::any d) { setKeyboardFocus(nullptr); });
+    m_listeners.keyboardSurfaceDestroy = surf->events.destroy.registerListener([this](std::any d) { setKeyboardFocus(nullptr); });
 
-    events.keyboardFocusChange.emit();
+    m_events.keyboardFocusChange.emit();
 }
 
 void CSeatManager::sendKeyboardKey(uint32_t timeMs, uint32_t key, wl_keyboard_key_state state_) {
-    if (!state.keyboardFocusResource)
+    if (!m_state.keyboardFocusResource)
         return;
 
-    for (auto const& s : seatResources) {
-        if (s->resource->client() != state.keyboardFocusResource->client())
+    for (auto const& s : m_seatResources) {
+        if (s->resource->client() != m_state.keyboardFocusResource->client())
             continue;
 
         for (auto const& k : s->resource->keyboards) {
@@ -174,11 +174,11 @@ void CSeatManager::sendKeyboardKey(uint32_t timeMs, uint32_t key, wl_keyboard_ke
 }
 
 void CSeatManager::sendKeyboardMods(uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group) {
-    if (!state.keyboardFocusResource)
+    if (!m_state.keyboardFocusResource)
         return;
 
-    for (auto const& s : seatResources) {
-        if (s->resource->client() != state.keyboardFocusResource->client())
+    for (auto const& s : m_seatResources) {
+        if (s->resource->client() != m_state.keyboardFocusResource->client())
             continue;
 
         for (auto const& k : s->resource->keyboards) {
@@ -191,28 +191,28 @@ void CSeatManager::sendKeyboardMods(uint32_t depressed, uint32_t latched, uint32
 }
 
 void CSeatManager::setPointerFocus(SP<CWLSurfaceResource> surf, const Vector2D& local) {
-    if (state.pointerFocus == surf)
+    if (m_state.pointerFocus == surf)
         return;
 
     if (PROTO::data->dndActive() && surf) {
-        if (state.dndPointerFocus == surf)
+        if (m_state.dndPointerFocus == surf)
             return;
         Debug::log(LOG, "[seatmgr] Refusing pointer focus during an active dnd, but setting dndPointerFocus");
-        state.dndPointerFocus = surf;
-        events.dndPointerFocusChange.emit();
+        m_state.dndPointerFocus = surf;
+        m_events.dndPointerFocusChange.emit();
         return;
     }
 
-    if (!mouse) {
+    if (!m_mouse) {
         Debug::log(ERR, "BUG THIS: setPointerFocus without a valid mouse set");
         return;
     }
 
-    listeners.pointerSurfaceDestroy.reset();
+    m_listeners.pointerSurfaceDestroy.reset();
 
-    if (state.pointerFocusResource) {
-        auto client = state.pointerFocusResource->client();
-        for (auto const& s : seatResources) {
+    if (m_state.pointerFocusResource) {
+        auto client = m_state.pointerFocusResource->client();
+        for (auto const& s : m_seatResources) {
             if (s->resource->client() != client)
                 continue;
 
@@ -225,26 +225,26 @@ void CSeatManager::setPointerFocus(SP<CWLSurfaceResource> surf, const Vector2D& 
         }
     }
 
-    auto lastPointerFocusResource = state.pointerFocusResource;
+    auto lastPointerFocusResource = m_state.pointerFocusResource;
 
-    state.dndPointerFocus.reset();
-    state.pointerFocusResource.reset();
-    state.pointerFocus = surf;
+    m_state.dndPointerFocus.reset();
+    m_state.pointerFocusResource.reset();
+    m_state.pointerFocus = surf;
 
     if (!surf) {
         sendPointerFrame(lastPointerFocusResource);
-        events.pointerFocusChange.emit();
+        m_events.pointerFocusChange.emit();
         return;
     }
 
-    state.dndPointerFocus = surf;
+    m_state.dndPointerFocus = surf;
 
     auto client = surf->client();
-    for (auto const& r : seatResources | std::views::reverse) {
+    for (auto const& r : m_seatResources | std::views::reverse) {
         if (r->resource->client() != client)
             continue;
 
-        state.pointerFocusResource = r->resource;
+        m_state.pointerFocusResource = r->resource;
         for (auto const& p : r->resource->pointers) {
             if (!p)
                 continue;
@@ -253,23 +253,23 @@ void CSeatManager::setPointerFocus(SP<CWLSurfaceResource> surf, const Vector2D& 
         }
     }
 
-    if (state.pointerFocusResource != lastPointerFocusResource)
+    if (m_state.pointerFocusResource != lastPointerFocusResource)
         sendPointerFrame(lastPointerFocusResource);
 
     sendPointerFrame();
 
-    listeners.pointerSurfaceDestroy = surf->events.destroy.registerListener([this](std::any d) { setPointerFocus(nullptr, {}); });
+    m_listeners.pointerSurfaceDestroy = surf->events.destroy.registerListener([this](std::any d) { setPointerFocus(nullptr, {}); });
 
-    events.pointerFocusChange.emit();
-    events.dndPointerFocusChange.emit();
+    m_events.pointerFocusChange.emit();
+    m_events.dndPointerFocusChange.emit();
 }
 
 void CSeatManager::sendPointerMotion(uint32_t timeMs, const Vector2D& local) {
-    if (!state.pointerFocusResource)
+    if (!m_state.pointerFocusResource)
         return;
 
-    for (auto const& s : seatResources) {
-        if (s->resource->client() != state.pointerFocusResource->client())
+    for (auto const& s : m_seatResources) {
+        if (s->resource->client() != m_state.pointerFocusResource->client())
             continue;
 
         for (auto const& p : s->resource->pointers) {
@@ -280,15 +280,15 @@ void CSeatManager::sendPointerMotion(uint32_t timeMs, const Vector2D& local) {
         }
     }
 
-    lastLocalCoords = local;
+    m_lastLocalCoords = local;
 }
 
 void CSeatManager::sendPointerButton(uint32_t timeMs, uint32_t key, wl_pointer_button_state state_) {
-    if (!state.pointerFocusResource || PROTO::data->dndActive())
+    if (!m_state.pointerFocusResource || PROTO::data->dndActive())
         return;
 
-    for (auto const& s : seatResources) {
-        if (s->resource->client() != state.pointerFocusResource->client())
+    for (auto const& s : m_seatResources) {
+        if (s->resource->client() != m_state.pointerFocusResource->client())
             continue;
 
         for (auto const& p : s->resource->pointers) {
@@ -301,17 +301,17 @@ void CSeatManager::sendPointerButton(uint32_t timeMs, uint32_t key, wl_pointer_b
 }
 
 void CSeatManager::sendPointerFrame() {
-    if (!state.pointerFocusResource)
+    if (!m_state.pointerFocusResource)
         return;
 
-    sendPointerFrame(state.pointerFocusResource);
+    sendPointerFrame(m_state.pointerFocusResource);
 }
 
 void CSeatManager::sendPointerFrame(WP<CWLSeatResource> pResource) {
     if (!pResource)
         return;
 
-    for (auto const& s : seatResources) {
+    for (auto const& s : m_seatResources) {
         if (s->resource->client() != pResource->client())
             continue;
 
@@ -326,11 +326,11 @@ void CSeatManager::sendPointerFrame(WP<CWLSeatResource> pResource) {
 
 void CSeatManager::sendPointerAxis(uint32_t timeMs, wl_pointer_axis axis, double value, int32_t discrete, int32_t value120, wl_pointer_axis_source source,
                                    wl_pointer_axis_relative_direction relative) {
-    if (!state.pointerFocusResource)
+    if (!m_state.pointerFocusResource)
         return;
 
-    for (auto const& s : seatResources) {
-        if (s->resource->client() != state.pointerFocusResource->client())
+    for (auto const& s : m_seatResources) {
+        if (s->resource->client() != m_state.pointerFocusResource->client())
             continue;
 
         for (auto const& p : s->resource->pointers) {
@@ -353,17 +353,17 @@ void CSeatManager::sendPointerAxis(uint32_t timeMs, wl_pointer_axis axis, double
 }
 
 void CSeatManager::sendTouchDown(SP<CWLSurfaceResource> surf, uint32_t timeMs, int32_t id, const Vector2D& local) {
-    listeners.touchSurfaceDestroy.reset();
+    m_listeners.touchSurfaceDestroy.reset();
 
-    state.touchFocusResource.reset();
-    state.touchFocus = surf;
+    m_state.touchFocusResource.reset();
+    m_state.touchFocus = surf;
 
     auto client = surf->client();
-    for (auto const& r : seatResources | std::views::reverse) {
+    for (auto const& r : m_seatResources | std::views::reverse) {
         if (r->resource->client() != client)
             continue;
 
-        state.touchFocusResource = r->resource;
+        m_state.touchFocusResource = r->resource;
         for (auto const& t : r->resource->touches) {
             if (!t)
                 continue;
@@ -372,24 +372,24 @@ void CSeatManager::sendTouchDown(SP<CWLSurfaceResource> surf, uint32_t timeMs, i
         }
     }
 
-    listeners.touchSurfaceDestroy = surf->events.destroy.registerListener([this, timeMs, id](std::any d) { sendTouchUp(timeMs + 10, id); });
+    m_listeners.touchSurfaceDestroy = surf->events.destroy.registerListener([this, timeMs, id](std::any d) { sendTouchUp(timeMs + 10, id); });
 
-    touchLocks++;
+    m_touchLocks++;
 
-    if (touchLocks <= 1)
-        events.touchFocusChange.emit();
+    if (m_touchLocks <= 1)
+        m_events.touchFocusChange.emit();
 }
 
 void CSeatManager::sendTouchUp(uint32_t timeMs, int32_t id) {
-    if (!state.touchFocusResource || touchLocks <= 0)
+    if (!m_state.touchFocusResource || m_touchLocks <= 0)
         return;
 
-    auto client = state.touchFocusResource->client();
-    for (auto const& r : seatResources | std::views::reverse) {
+    auto client = m_state.touchFocusResource->client();
+    for (auto const& r : m_seatResources | std::views::reverse) {
         if (r->resource->client() != client)
             continue;
 
-        state.touchFocusResource = r->resource;
+        m_state.touchFocusResource = r->resource;
         for (auto const& t : r->resource->touches) {
             if (!t)
                 continue;
@@ -398,18 +398,18 @@ void CSeatManager::sendTouchUp(uint32_t timeMs, int32_t id) {
         }
     }
 
-    touchLocks--;
+    m_touchLocks--;
 
-    if (touchLocks <= 0)
-        events.touchFocusChange.emit();
+    if (m_touchLocks <= 0)
+        m_events.touchFocusChange.emit();
 }
 
 void CSeatManager::sendTouchMotion(uint32_t timeMs, int32_t id, const Vector2D& local) {
-    if (!state.touchFocusResource)
+    if (!m_state.touchFocusResource)
         return;
 
-    for (auto const& s : seatResources) {
-        if (s->resource->client() != state.touchFocusResource->client())
+    for (auto const& s : m_seatResources) {
+        if (s->resource->client() != m_state.touchFocusResource->client())
             continue;
 
         for (auto const& t : s->resource->touches) {
@@ -422,11 +422,11 @@ void CSeatManager::sendTouchMotion(uint32_t timeMs, int32_t id, const Vector2D& 
 }
 
 void CSeatManager::sendTouchFrame() {
-    if (!state.touchFocusResource)
+    if (!m_state.touchFocusResource)
         return;
 
-    for (auto const& s : seatResources) {
-        if (s->resource->client() != state.touchFocusResource->client())
+    for (auto const& s : m_seatResources) {
+        if (s->resource->client() != m_state.touchFocusResource->client())
             continue;
 
         for (auto const& t : s->resource->touches) {
@@ -439,11 +439,11 @@ void CSeatManager::sendTouchFrame() {
 }
 
 void CSeatManager::sendTouchCancel() {
-    if (!state.touchFocusResource)
+    if (!m_state.touchFocusResource)
         return;
 
-    for (auto const& s : seatResources) {
-        if (s->resource->client() != state.touchFocusResource->client())
+    for (auto const& s : m_seatResources) {
+        if (s->resource->client() != m_state.touchFocusResource->client())
             continue;
 
         for (auto const& t : s->resource->touches) {
@@ -456,11 +456,11 @@ void CSeatManager::sendTouchCancel() {
 }
 
 void CSeatManager::sendTouchShape(int32_t id, const Vector2D& shape) {
-    if (!state.touchFocusResource)
+    if (!m_state.touchFocusResource)
         return;
 
-    for (auto const& s : seatResources) {
-        if (s->resource->client() != state.touchFocusResource->client())
+    for (auto const& s : m_seatResources) {
+        if (s->resource->client() != m_state.touchFocusResource->client())
             continue;
 
         for (auto const& t : s->resource->touches) {
@@ -473,11 +473,11 @@ void CSeatManager::sendTouchShape(int32_t id, const Vector2D& shape) {
 }
 
 void CSeatManager::sendTouchOrientation(int32_t id, double angle) {
-    if (!state.touchFocusResource)
+    if (!m_state.touchFocusResource)
         return;
 
-    for (auto const& s : seatResources) {
-        if (s->resource->client() != state.touchFocusResource->client())
+    for (auto const& s : m_seatResources) {
+        if (s->resource->client() != m_state.touchFocusResource->client())
             continue;
 
         for (auto const& t : s->resource->touches) {
@@ -490,13 +490,13 @@ void CSeatManager::sendTouchOrientation(int32_t id, double angle) {
 }
 
 void CSeatManager::refocusGrab() {
-    if (!seatGrab)
+    if (!m_seatGrab)
         return;
 
-    if (seatGrab->surfs.size() > 0) {
+    if (m_seatGrab->m_surfs.size() > 0) {
         // try to find a surf in focus first
         const auto MOUSE = g_pInputManager->getMouseCoordsInternal();
-        for (auto const& s : seatGrab->surfs) {
+        for (auto const& s : m_seatGrab->m_surfs) {
             auto hlSurf = CWLSurface::fromResource(s.lock());
             if (!hlSurf)
                 continue;
@@ -508,23 +508,23 @@ void CSeatManager::refocusGrab() {
             if (!b->containsPoint(MOUSE))
                 continue;
 
-            if (seatGrab->keyboard)
+            if (m_seatGrab->m_keyboard)
                 setKeyboardFocus(s.lock());
-            if (seatGrab->pointer)
+            if (m_seatGrab->m_pointer)
                 setPointerFocus(s.lock(), MOUSE - b->pos());
             return;
         }
 
-        SP<CWLSurfaceResource> surf = seatGrab->surfs.at(0).lock();
-        if (seatGrab->keyboard)
+        SP<CWLSurfaceResource> surf = m_seatGrab->m_surfs.at(0).lock();
+        if (m_seatGrab->m_keyboard)
             setKeyboardFocus(surf);
-        if (seatGrab->pointer)
+        if (m_seatGrab->m_pointer)
             setPointerFocus(surf, {});
     }
 }
 
 void CSeatManager::onSetCursor(SP<CWLSeatResource> seatResource, uint32_t serial, SP<CWLSurfaceResource> surf, const Vector2D& hotspot) {
-    if (!state.pointerFocusResource || !seatResource || seatResource->client() != state.pointerFocusResource->client()) {
+    if (!m_state.pointerFocusResource || !seatResource || seatResource->client() != m_state.pointerFocusResource->client()) {
         Debug::log(LOG, "[seatmgr] Rejecting a setCursor because the client ain't in focus");
         return;
     }
@@ -535,7 +535,7 @@ void CSeatManager::onSetCursor(SP<CWLSeatResource> seatResource, uint32_t serial
     //     return;
     // }
 
-    events.setCursor.emit(SSetCursorEvent{surf, hotspot});
+    m_events.setCursor.emit(SSetCursorEvent{surf, hotspot});
 }
 
 SP<CWLSeatResource> CSeatManager::seatResourceForClient(wl_client* client) {
@@ -543,62 +543,62 @@ SP<CWLSeatResource> CSeatManager::seatResourceForClient(wl_client* client) {
 }
 
 void CSeatManager::setCurrentSelection(SP<IDataSource> source) {
-    if (source == selection.currentSelection) {
+    if (source == m_selection.currentSelection) {
         Debug::log(WARN, "[seat] duplicated setCurrentSelection?");
         return;
     }
 
-    selection.destroySelection.reset();
+    m_selection.destroySelection.reset();
 
-    if (selection.currentSelection)
-        selection.currentSelection->cancelled();
+    if (m_selection.currentSelection)
+        m_selection.currentSelection->cancelled();
 
     if (!source)
         PROTO::data->setSelection(nullptr);
 
-    selection.currentSelection = source;
+    m_selection.currentSelection = source;
 
     if (source) {
-        selection.destroySelection = source->events.destroy.registerListener([this](std::any d) { setCurrentSelection(nullptr); });
+        m_selection.destroySelection = source->events.destroy.registerListener([this](std::any d) { setCurrentSelection(nullptr); });
         PROTO::data->setSelection(source);
         PROTO::dataWlr->setSelection(source, false);
     }
 
-    events.setSelection.emit();
+    m_events.setSelection.emit();
 }
 
 void CSeatManager::setCurrentPrimarySelection(SP<IDataSource> source) {
-    if (source == selection.currentPrimarySelection) {
+    if (source == m_selection.currentPrimarySelection) {
         Debug::log(WARN, "[seat] duplicated setCurrentPrimarySelection?");
         return;
     }
 
-    selection.destroyPrimarySelection.reset();
+    m_selection.destroyPrimarySelection.reset();
 
-    if (selection.currentPrimarySelection)
-        selection.currentPrimarySelection->cancelled();
+    if (m_selection.currentPrimarySelection)
+        m_selection.currentPrimarySelection->cancelled();
 
     if (!source)
         PROTO::primarySelection->setSelection(nullptr);
 
-    selection.currentPrimarySelection = source;
+    m_selection.currentPrimarySelection = source;
 
     if (source) {
-        selection.destroyPrimarySelection = source->events.destroy.registerListener([this](std::any d) { setCurrentPrimarySelection(nullptr); });
+        m_selection.destroyPrimarySelection = source->events.destroy.registerListener([this](std::any d) { setCurrentPrimarySelection(nullptr); });
         PROTO::primarySelection->setSelection(source);
         PROTO::dataWlr->setSelection(source, true);
     }
 
-    events.setPrimarySelection.emit();
+    m_events.setPrimarySelection.emit();
 }
 
 void CSeatManager::setGrab(SP<CSeatGrab> grab) {
-    if (seatGrab) {
-        auto oldGrab = seatGrab;
-        seatGrab.reset();
+    if (m_seatGrab) {
+        auto oldGrab = m_seatGrab;
+        m_seatGrab.reset();
         g_pInputManager->refocus();
 
-        auto           currentFocus = state.keyboardFocus.lock();
+        auto           currentFocus = m_state.keyboardFocus.lock();
         auto           refocus      = !currentFocus;
 
         SP<CWLSurface> surf;
@@ -627,23 +627,23 @@ void CSeatManager::setGrab(SP<CSeatGrab> grab) {
                 g_pCompositor->focusWindow(candidate);
         }
 
-        if (oldGrab->onEnd)
-            oldGrab->onEnd();
+        if (oldGrab->m_onEnd)
+            oldGrab->m_onEnd();
     }
 
     if (!grab)
         return;
 
-    seatGrab = grab;
+    m_seatGrab = grab;
 
     refocusGrab();
 }
 
 void CSeatManager::resendEnterEvents() {
-    SP<CWLSurfaceResource> kb = state.keyboardFocus.lock();
-    SP<CWLSurfaceResource> pt = state.pointerFocus.lock();
+    SP<CWLSurfaceResource> kb = m_state.keyboardFocus.lock();
+    SP<CWLSurfaceResource> pt = m_state.pointerFocus.lock();
 
-    auto                   last = lastLocalCoords;
+    auto                   last = m_lastLocalCoords;
 
     setKeyboardFocus(nullptr);
     setPointerFocus(nullptr, {});
@@ -653,23 +653,23 @@ void CSeatManager::resendEnterEvents() {
 }
 
 bool CSeatGrab::accepts(SP<CWLSurfaceResource> surf) {
-    return std::find(surfs.begin(), surfs.end(), surf) != surfs.end();
+    return std::find(m_surfs.begin(), m_surfs.end(), surf) != m_surfs.end();
 }
 
 void CSeatGrab::add(SP<CWLSurfaceResource> surf) {
-    surfs.emplace_back(surf);
+    m_surfs.emplace_back(surf);
 }
 
 void CSeatGrab::remove(SP<CWLSurfaceResource> surf) {
-    std::erase(surfs, surf);
-    if ((keyboard && g_pSeatManager->state.keyboardFocus == surf) || (pointer && g_pSeatManager->state.pointerFocus == surf))
+    std::erase(m_surfs, surf);
+    if ((m_keyboard && g_pSeatManager->m_state.keyboardFocus == surf) || (m_pointer && g_pSeatManager->m_state.pointerFocus == surf))
         g_pSeatManager->refocusGrab();
 }
 
 void CSeatGrab::setCallback(std::function<void()> onEnd_) {
-    onEnd = onEnd_;
+    m_onEnd = onEnd_;
 }
 
 void CSeatGrab::clear() {
-    surfs.clear();
+    m_surfs.clear();
 }

--- a/src/managers/SeatManager.hpp
+++ b/src/managers/SeatManager.hpp
@@ -33,15 +33,12 @@ class CSeatGrab {
     void setCallback(std::function<void()> onEnd_);
     void clear();
 
-    bool keyboard = false;
-    bool pointer  = false;
-    bool touch    = false;
-
-    bool removeOnInput = true; // on hard input e.g. click outside, remove
+    bool m_keyboard = false;
+    bool m_pointer  = false;
 
   private:
-    std::vector<WP<CWLSurfaceResource>> surfs;
-    std::function<void()>               onEnd;
+    std::vector<WP<CWLSurfaceResource>> m_surfs;
+    std::function<void()>               m_onEnd;
     friend class CSeatManager;
 };
 
@@ -96,7 +93,7 @@ class CSeatManager {
         WP<CWLSeatResource>    touchFocusResource;
 
         WP<CWLSurfaceResource> dndPointerFocus;
-    } state;
+    } m_state;
 
     struct SSetCursorEvent {
         SP<CWLSurfaceResource> surf = nullptr;
@@ -111,27 +108,27 @@ class CSeatManager {
         CSignal setCursor; // SSetCursorEvent
         CSignal setSelection;
         CSignal setPrimarySelection;
-    } events;
+    } m_events;
 
     struct {
         WP<IDataSource>     currentSelection;
         CHyprSignalListener destroySelection;
         WP<IDataSource>     currentPrimarySelection;
         CHyprSignalListener destroyPrimarySelection;
-    } selection;
+    } m_selection;
 
     void setCurrentSelection(SP<IDataSource> source);
     void setCurrentPrimarySelection(SP<IDataSource> source);
 
     // do not write to directly, use set...
-    WP<IPointer>  mouse;
-    WP<IKeyboard> keyboard;
+    WP<IPointer>  m_mouse;
+    WP<IKeyboard> m_keyboard;
 
     void          setGrab(SP<CSeatGrab> grab); // nullptr removes
-    SP<CSeatGrab> seatGrab;
+    SP<CSeatGrab> m_seatGrab;
 
-    bool          isPointerFrameSkipped = false;
-    bool          isPointerFrameCommit  = false;
+    bool          m_isPointerFrameSkipped = false;
+    bool          m_isPointerFrameCommit  = false;
 
   private:
     struct SSeatResourceContainer {
@@ -145,7 +142,7 @@ class CSeatManager {
         } listeners;
     };
 
-    std::vector<SP<SSeatResourceContainer>> seatResources;
+    std::vector<SP<SSeatResourceContainer>> m_seatResources;
     void                                    onNewSeatResource(SP<CWLSeatResource> resource);
     SP<SSeatResourceContainer>              containerForResource(SP<CWLSeatResource> seatResource);
 
@@ -156,10 +153,10 @@ class CSeatManager {
         CHyprSignalListener keyboardSurfaceDestroy;
         CHyprSignalListener pointerSurfaceDestroy;
         CHyprSignalListener touchSurfaceDestroy;
-    } listeners;
+    } m_listeners;
 
-    Vector2D lastLocalCoords;
-    int      touchLocks = 0; // we assume there aint like 20 touch devices at once...
+    Vector2D m_lastLocalCoords;
+    int      m_touchLocks = 0; // we assume there aint like 20 touch devices at once...
 
     friend struct SSeatResourceContainer;
     friend class CSeatGrab;

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -42,7 +42,7 @@ SSessionLockSurface::SSessionLockSurface(SP<CSessionLockSurface> surface_) : sur
 }
 
 CSessionLockManager::CSessionLockManager() {
-    listeners.newLock = PROTO::sessionLock->events.newLock.registerListener([this](std::any data) { this->onNewSessionLock(std::any_cast<SP<CSessionLock>>(data)); });
+    m_listeners.newLock = PROTO::sessionLock->events.newLock.registerListener([this](std::any data) { this->onNewSessionLock(std::any_cast<SP<CSessionLock>>(data)); });
 }
 
 void CSessionLockManager::onNewSessionLock(SP<CSessionLock> pLock) {
@@ -57,30 +57,30 @@ void CSessionLockManager::onNewSessionLock(SP<CSessionLock> pLock) {
 
     Debug::log(LOG, "Session got locked by {:x}", (uintptr_t)pLock.get());
 
-    m_pSessionLock       = makeUnique<SSessionLock>();
-    m_pSessionLock->lock = pLock;
-    m_pSessionLock->mLockTimer.reset();
+    m_sessionLock       = makeUnique<SSessionLock>();
+    m_sessionLock->lock = pLock;
+    m_sessionLock->mLockTimer.reset();
 
-    m_pSessionLock->listeners.newSurface = pLock->events.newLockSurface.registerListener([this](std::any data) {
+    m_sessionLock->listeners.newSurface = pLock->events.newLockSurface.registerListener([this](std::any data) {
         auto       SURFACE = std::any_cast<SP<CSessionLockSurface>>(data);
 
         const auto PMONITOR = SURFACE->monitor();
 
-        const auto NEWSURFACE  = m_pSessionLock->vSessionLockSurfaces.emplace_back(makeUnique<SSessionLockSurface>(SURFACE)).get();
+        const auto NEWSURFACE  = m_sessionLock->vSessionLockSurfaces.emplace_back(makeUnique<SSessionLockSurface>(SURFACE)).get();
         NEWSURFACE->iMonitorID = PMONITOR->m_id;
         PROTO::fractional->sendScale(SURFACE->surface(), PMONITOR->m_scale);
     });
 
-    m_pSessionLock->listeners.unlock = pLock->events.unlockAndDestroy.registerListener([this](std::any data) {
-        m_pSessionLock.reset();
+    m_sessionLock->listeners.unlock = pLock->events.unlockAndDestroy.registerListener([this](std::any data) {
+        m_sessionLock.reset();
         g_pInputManager->refocus();
 
         for (auto const& m : g_pCompositor->m_monitors)
             g_pHyprRenderer->damageMonitor(m);
     });
 
-    m_pSessionLock->listeners.destroy = pLock->events.destroyed.registerListener([this](std::any data) {
-        m_pSessionLock.reset();
+    m_sessionLock->listeners.destroy = pLock->events.destroyed.registerListener([this](std::any data) {
+        m_sessionLock.reset();
         g_pCompositor->focusSurface(nullptr);
 
         for (auto const& m : g_pCompositor->m_monitors)
@@ -93,8 +93,8 @@ void CSessionLockManager::onNewSessionLock(SP<CSessionLock> pLock) {
     // Normally the locked event is sent after each output rendered a lock screen frame.
     // When there are no outputs, send it right away.
     if (g_pCompositor->m_unsafeState) {
-        m_pSessionLock->lock->sendLocked();
-        m_pSessionLock->m_hasSentLocked = true;
+        m_sessionLock->lock->sendLocked();
+        m_sessionLock->hasSentLocked = true;
     }
 }
 
@@ -103,10 +103,10 @@ bool CSessionLockManager::isSessionLocked() {
 }
 
 WP<SSessionLockSurface> CSessionLockManager::getSessionLockSurfaceForMonitor(uint64_t id) {
-    if (!m_pSessionLock)
+    if (!m_sessionLock)
         return {};
 
-    for (auto const& sls : m_pSessionLock->vSessionLockSurfaces) {
+    for (auto const& sls : m_sessionLock->vSessionLockSurfaces) {
         if (sls->iMonitorID == id) {
             if (sls->mapped)
                 return sls;
@@ -120,14 +120,14 @@ WP<SSessionLockSurface> CSessionLockManager::getSessionLockSurfaceForMonitor(uin
 
 // We don't want the red screen to flash.
 float CSessionLockManager::getRedScreenAlphaForMonitor(uint64_t id) {
-    if (!m_pSessionLock)
+    if (!m_sessionLock)
         return 1.F;
 
-    const auto& NOMAPPEDSURFACETIMER = m_pSessionLock->mMonitorsWithoutMappedSurfaceTimers.find(id);
+    const auto& NOMAPPEDSURFACETIMER = m_sessionLock->mMonitorsWithoutMappedSurfaceTimers.find(id);
 
-    if (NOMAPPEDSURFACETIMER == m_pSessionLock->mMonitorsWithoutMappedSurfaceTimers.end()) {
-        m_pSessionLock->mMonitorsWithoutMappedSurfaceTimers.emplace(id, CTimer());
-        m_pSessionLock->mMonitorsWithoutMappedSurfaceTimers[id].reset();
+    if (NOMAPPEDSURFACETIMER == m_sessionLock->mMonitorsWithoutMappedSurfaceTimers.end()) {
+        m_sessionLock->mMonitorsWithoutMappedSurfaceTimers.emplace(id, CTimer());
+        m_sessionLock->mMonitorsWithoutMappedSurfaceTimers[id].reset();
         return 0.f;
     }
 
@@ -135,13 +135,13 @@ float CSessionLockManager::getRedScreenAlphaForMonitor(uint64_t id) {
 }
 
 void CSessionLockManager::onLockscreenRenderedOnMonitor(uint64_t id) {
-    if (!m_pSessionLock || m_pSessionLock->m_hasSentLocked)
+    if (!m_sessionLock || m_sessionLock->hasSentLocked)
         return;
-    m_pSessionLock->m_lockedMonitors.emplace(id);
-    const bool LOCKED = std::ranges::all_of(g_pCompositor->m_monitors, [this](auto m) { return m_pSessionLock->m_lockedMonitors.contains(m->m_id); });
-    if (LOCKED && m_pSessionLock->lock->good()) {
-        m_pSessionLock->lock->sendLocked();
-        m_pSessionLock->m_hasSentLocked = true;
+    m_sessionLock->lockedMonitors.emplace(id);
+    const bool LOCKED = std::ranges::all_of(g_pCompositor->m_monitors, [this](auto m) { return m_sessionLock->lockedMonitors.contains(m->m_id); });
+    if (LOCKED && m_sessionLock->lock->good()) {
+        m_sessionLock->lock->sendLocked();
+        m_sessionLock->hasSentLocked = true;
     }
 }
 
@@ -149,10 +149,10 @@ bool CSessionLockManager::isSurfaceSessionLock(SP<CWLSurfaceResource> pSurface) 
     // TODO: this has some edge cases when it's wrong (e.g. destroyed lock but not yet surfaces)
     // but can be easily fixed when I rewrite wlr_surface
 
-    if (!m_pSessionLock)
+    if (!m_sessionLock)
         return false;
 
-    for (auto const& sls : m_pSessionLock->vSessionLockSurfaces) {
+    for (auto const& sls : m_sessionLock->vSessionLockSurfaces) {
         if (sls->surface->surface() == pSurface)
             return true;
     }
@@ -161,15 +161,15 @@ bool CSessionLockManager::isSurfaceSessionLock(SP<CWLSurfaceResource> pSurface) 
 }
 
 void CSessionLockManager::removeSessionLockSurface(SSessionLockSurface* pSLS) {
-    if (!m_pSessionLock)
+    if (!m_sessionLock)
         return;
 
-    std::erase_if(m_pSessionLock->vSessionLockSurfaces, [&](const auto& other) { return pSLS == other.get(); });
+    std::erase_if(m_sessionLock->vSessionLockSurfaces, [&](const auto& other) { return pSLS == other.get(); });
 
     if (g_pCompositor->m_lastFocus)
         return;
 
-    for (auto const& sls : m_pSessionLock->vSessionLockSurfaces) {
+    for (auto const& sls : m_sessionLock->vSessionLockSurfaces) {
         if (!sls->mapped)
             continue;
 
@@ -179,18 +179,18 @@ void CSessionLockManager::removeSessionLockSurface(SSessionLockSurface* pSLS) {
 }
 
 bool CSessionLockManager::isSessionLockPresent() {
-    return m_pSessionLock && !m_pSessionLock->vSessionLockSurfaces.empty();
+    return m_sessionLock && !m_sessionLock->vSessionLockSurfaces.empty();
 }
 
 bool CSessionLockManager::anySessionLockSurfacesPresent() {
-    return m_pSessionLock && std::ranges::any_of(m_pSessionLock->vSessionLockSurfaces, [](const auto& surf) { return surf->mapped; });
+    return m_sessionLock && std::ranges::any_of(m_sessionLock->vSessionLockSurfaces, [](const auto& surf) { return surf->mapped; });
 }
 
 bool CSessionLockManager::shallConsiderLockMissing() {
-    if (!m_pSessionLock)
+    if (!m_sessionLock)
         return false;
 
     static auto LOCKDEAD_SCREEN_DELAY = CConfigValue<Hyprlang::INT>("misc:lockdead_screen_delay");
 
-    return m_pSessionLock->mLockTimer.getMillis() > *LOCKDEAD_SCREEN_DELAY;
+    return m_sessionLock->mLockTimer.getMillis() > *LOCKDEAD_SCREEN_DELAY;
 }

--- a/src/managers/SessionLockManager.hpp
+++ b/src/managers/SessionLockManager.hpp
@@ -40,8 +40,8 @@ struct SSessionLock {
         CHyprSignalListener destroy;
     } listeners;
 
-    bool                         m_hasSentLocked = false;
-    std::unordered_set<uint64_t> m_lockedMonitors;
+    bool                         hasSentLocked = false;
+    std::unordered_set<uint64_t> lockedMonitors;
 };
 
 class CSessionLockManager {
@@ -65,11 +65,11 @@ class CSessionLockManager {
     bool                    shallConsiderLockMissing();
 
   private:
-    UP<SSessionLock> m_pSessionLock;
+    UP<SSessionLock> m_sessionLock;
 
     struct {
         CHyprSignalListener newLock;
-    } listeners;
+    } m_listeners;
 
     void onNewSessionLock(SP<CSessionLock> pWlrLock);
 };

--- a/src/managers/TokenManager.cpp
+++ b/src/managers/TokenManager.cpp
@@ -18,7 +18,7 @@ std::string CTokenManager::getRandomUUID() {
         uuid = std::format("{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}", (uint16_t)uuid_[0], (uint16_t)uuid_[1],
                            (uint16_t)uuid_[2], (uint16_t)uuid_[3], (uint16_t)uuid_[4], (uint16_t)uuid_[5], (uint16_t)uuid_[6], (uint16_t)uuid_[7], (uint16_t)uuid_[8],
                            (uint16_t)uuid_[9], (uint16_t)uuid_[10], (uint16_t)uuid_[11], (uint16_t)uuid_[12], (uint16_t)uuid_[13], (uint16_t)uuid_[14], (uint16_t)uuid_[15]);
-    } while (m_mTokens.contains(uuid));
+    } while (m_tokens.contains(uuid));
 
     return uuid;
 }
@@ -26,7 +26,7 @@ std::string CTokenManager::getRandomUUID() {
 std::string CTokenManager::registerNewToken(std::any data, Time::steady_dur expires) {
     std::string uuid = getRandomUUID();
 
-    m_mTokens[uuid] = makeShared<CUUIDToken>(uuid, data, expires);
+    m_tokens[uuid] = makeShared<CUUIDToken>(uuid, data, expires);
     return uuid;
 }
 
@@ -34,16 +34,16 @@ SP<CUUIDToken> CTokenManager::getToken(const std::string& uuid) {
 
     // cleanup expired tokens
     const auto NOW = Time::steadyNow();
-    std::erase_if(m_mTokens, [&NOW](const auto& el) { return el.second->m_expiresAt < NOW; });
+    std::erase_if(m_tokens, [&NOW](const auto& el) { return el.second->m_expiresAt < NOW; });
 
-    if (!m_mTokens.contains(uuid))
+    if (!m_tokens.contains(uuid))
         return {};
 
-    return m_mTokens.at(uuid);
+    return m_tokens.at(uuid);
 }
 
 void CTokenManager::removeToken(SP<CUUIDToken> token) {
     if (!token)
         return;
-    m_mTokens.erase(token->m_uuid);
+    m_tokens.erase(token->m_uuid);
 }

--- a/src/managers/TokenManager.hpp
+++ b/src/managers/TokenManager.hpp
@@ -31,7 +31,7 @@ class CTokenManager {
     void           removeToken(SP<CUUIDToken> token);
 
   private:
-    std::unordered_map<std::string, SP<CUUIDToken>> m_mTokens;
+    std::unordered_map<std::string, SP<CUUIDToken>> m_tokens;
 };
 
 inline UP<CTokenManager> g_pTokenManager;

--- a/src/managers/VersionKeeperManager.cpp
+++ b/src/managers/VersionKeeperManager.cpp
@@ -50,7 +50,7 @@ CVersionKeeperManager::CVersionKeeperManager() {
         return;
     }
 
-    m_bFired = true;
+    m_fired = true;
 
     g_pEventLoopManager->doLater([]() {
         CProcess proc("hyprland-update-screen", {"--new-version", HYPRLAND_VERSION});
@@ -81,5 +81,5 @@ bool CVersionKeeperManager::isVersionOlderThanRunning(const std::string& ver) {
 }
 
 bool CVersionKeeperManager::fired() {
-    return m_bFired;
+    return m_fired;
 }

--- a/src/managers/VersionKeeperManager.hpp
+++ b/src/managers/VersionKeeperManager.hpp
@@ -12,7 +12,7 @@ class CVersionKeeperManager {
   private:
     bool isVersionOlderThanRunning(const std::string& ver);
 
-    bool m_bFired = false;
+    bool m_fired = false;
 };
 
 inline UP<CVersionKeeperManager> g_pVersionKeeperMgr;

--- a/src/managers/XCursorManager.hpp
+++ b/src/managers/XCursorManager.hpp
@@ -36,10 +36,10 @@ class CXCursorManager {
     std::vector<SP<SXCursors>> loadStandardCursors(std::string const& name, int size);
     std::vector<SP<SXCursors>> loadAllFromDir(std::string const& path, int size);
 
-    int                        lastLoadSize  = 0;
-    float                      lastLoadScale = 0;
-    std::string                themeName     = "";
-    SP<SXCursors>              defaultCursor;
-    SP<SXCursors>              hyprCursor;
-    std::vector<SP<SXCursors>> cursors;
+    int                        m_lastLoadSize  = 0;
+    float                      m_lastLoadScale = 0;
+    std::string                m_themeName     = "";
+    SP<SXCursors>              m_defaultCursor;
+    SP<SXCursors>              m_hyprCursor;
+    std::vector<SP<SXCursors>> m_cursors;
 };

--- a/src/managers/input/Tablets.cpp
+++ b/src/managers/input/Tablets.cpp
@@ -36,7 +36,7 @@ static void focusTool(SP<CTabletTool> tool, SP<CTablet> tablet, SP<CWLSurfaceRes
 }
 
 static void refocusTablet(SP<CTablet> tab, SP<CTabletTool> tool, bool motion = false) {
-    const auto LASTHLSURFACE = CWLSurface::fromResource(g_pSeatManager->state.pointerFocus.lock());
+    const auto LASTHLSURFACE = CWLSurface::fromResource(g_pSeatManager->m_state.pointerFocus.lock());
 
     if (!LASTHLSURFACE || !tool->m_active) {
         if (tool->getSurface())
@@ -56,7 +56,7 @@ static void refocusTablet(SP<CTablet> tab, SP<CTabletTool> tool, bool motion = f
 
     const auto CURSORPOS = g_pInputManager->getMouseCoordsInternal();
 
-    focusTool(tool, tab, g_pSeatManager->state.pointerFocus.lock());
+    focusTool(tool, tab, g_pSeatManager->m_state.pointerFocus.lock());
 
     if (!motion)
         return;

--- a/src/plugins/PluginAPI.cpp
+++ b/src/plugins/PluginAPI.cpp
@@ -200,7 +200,7 @@ APICALL bool HyprlandAPI::addDispatcher(HANDLE handle, const std::string& name, 
 
     PLUGIN->registeredDispatchers.push_back(name);
 
-    g_pKeybindManager->m_mDispatchers[name] = [handler](std::string arg1) -> SDispatchResult {
+    g_pKeybindManager->m_dispatchers[name] = [handler](std::string arg1) -> SDispatchResult {
         handler(arg1);
         return {};
     };
@@ -216,7 +216,7 @@ APICALL bool HyprlandAPI::addDispatcherV2(HANDLE handle, const std::string& name
 
     PLUGIN->registeredDispatchers.push_back(name);
 
-    g_pKeybindManager->m_mDispatchers[name] = handler;
+    g_pKeybindManager->m_dispatchers[name] = handler;
 
     return true;
 }
@@ -227,7 +227,7 @@ APICALL bool HyprlandAPI::removeDispatcher(HANDLE handle, const std::string& nam
     if (!PLUGIN)
         return false;
 
-    std::erase_if(g_pKeybindManager->m_mDispatchers, [&](const auto& other) { return other.first == name; });
+    std::erase_if(g_pKeybindManager->m_dispatchers, [&](const auto& other) { return other.first == name; });
     std::erase_if(PLUGIN->registeredDispatchers, [&](const auto& other) { return other == name; });
 
     return true;

--- a/src/protocols/DataDeviceWlr.cpp
+++ b/src/protocols/DataDeviceWlr.cpp
@@ -154,8 +154,8 @@ wl_client* CWLRDataDevice::client() {
 }
 
 void CWLRDataDevice::sendInitialSelections() {
-    PROTO::dataWlr->sendSelectionToDevice(self.lock(), g_pSeatManager->selection.currentSelection.lock(), false);
-    PROTO::dataWlr->sendSelectionToDevice(self.lock(), g_pSeatManager->selection.currentPrimarySelection.lock(), true);
+    PROTO::dataWlr->sendSelectionToDevice(self.lock(), g_pSeatManager->m_selection.currentSelection.lock(), false);
+    PROTO::dataWlr->sendSelectionToDevice(self.lock(), g_pSeatManager->m_selection.currentPrimarySelection.lock(), true);
 }
 
 void CWLRDataDevice::sendDataOffer(SP<CWLRDataOffer> offer) {

--- a/src/protocols/FocusGrab.cpp
+++ b/src/protocols/FocusGrab.cpp
@@ -15,9 +15,9 @@ CFocusGrab::CFocusGrab(SP<CHyprlandFocusGrabV1> resource_) : resource(resource_)
     if UNLIKELY (!resource->resource())
         return;
 
-    grab           = makeShared<CSeatGrab>();
-    grab->keyboard = true;
-    grab->pointer  = true;
+    grab             = makeShared<CSeatGrab>();
+    grab->m_keyboard = true;
+    grab->m_pointer  = true;
     grab->setCallback([this]() { finish(true); });
 
     resource->setDestroy([this](CHyprlandFocusGrabV1* pMgr) { PROTO::focusGrab->destroyGrab(this); });
@@ -58,7 +58,7 @@ void CFocusGrab::finish(bool sendCleared) {
     if (m_bGrabActive) {
         m_bGrabActive = false;
 
-        if (g_pSeatManager->seatGrab == grab)
+        if (g_pSeatManager->m_seatGrab == grab)
             g_pSeatManager->setGrab(nullptr);
 
         grab->clear();
@@ -91,7 +91,7 @@ void CFocusGrab::eraseSurface(SP<CWLSurfaceResource> surface) {
 }
 
 void CFocusGrab::refocusKeyboard() {
-    auto keyboardSurface = g_pSeatManager->state.keyboardFocus;
+    auto keyboardSurface = g_pSeatManager->m_state.keyboardFocus;
     if (keyboardSurface && isSurfaceComitted(keyboardSurface.lock()))
         return;
 

--- a/src/protocols/InputMethodV2.cpp
+++ b/src/protocols/InputMethodV2.cpp
@@ -13,12 +13,12 @@ CInputMethodKeyboardGrabV2::CInputMethodKeyboardGrabV2(SP<CZwpInputMethodKeyboar
     resource->setRelease([this](CZwpInputMethodKeyboardGrabV2* r) { PROTO::ime->destroyResource(this); });
     resource->setOnDestroy([this](CZwpInputMethodKeyboardGrabV2* r) { PROTO::ime->destroyResource(this); });
 
-    if (!g_pSeatManager->keyboard) {
+    if (!g_pSeatManager->m_keyboard) {
         LOGM(ERR, "IME called but no active keyboard???");
         return;
     }
 
-    sendKeyboardData(g_pSeatManager->keyboard.lock());
+    sendKeyboardData(g_pSeatManager->m_keyboard.lock());
 }
 
 CInputMethodKeyboardGrabV2::~CInputMethodKeyboardGrabV2() {

--- a/src/protocols/PointerConstraints.cpp
+++ b/src/protocols/PointerConstraints.cpp
@@ -125,7 +125,7 @@ void CPointerConstraint::activate() {
         return;
 
     // TODO: hack, probably not a super duper great idea
-    if (g_pSeatManager->state.pointerFocus != pHLSurface->resource()) {
+    if (g_pSeatManager->m_state.pointerFocus != pHLSurface->resource()) {
         const auto SURFBOX = pHLSurface->getSurfaceBoxGlobal();
         const auto LOCAL   = SURFBOX.has_value() ? logicPositionHint() - SURFBOX->pos() : Vector2D{};
         g_pSeatManager->setPointerFocus(pHLSurface->resource(), LOCAL);

--- a/src/protocols/PointerGestures.cpp
+++ b/src/protocols/PointerGestures.cpp
@@ -103,26 +103,26 @@ void CPointerGesturesProtocol::onGetHoldGesture(CZwpPointerGesturesV1* pMgr, uin
 }
 
 void CPointerGesturesProtocol::swipeBegin(uint32_t timeMs, uint32_t fingers) {
-    if (!g_pSeatManager->state.pointerFocusResource)
+    if (!g_pSeatManager->m_state.pointerFocusResource)
         return;
 
-    const auto FOCUSEDCLIENT = g_pSeatManager->state.pointerFocusResource->client();
+    const auto FOCUSEDCLIENT = g_pSeatManager->m_state.pointerFocusResource->client();
 
-    const auto SERIAL = g_pSeatManager->nextSerial(g_pSeatManager->state.pointerFocusResource.lock());
+    const auto SERIAL = g_pSeatManager->nextSerial(g_pSeatManager->m_state.pointerFocusResource.lock());
 
     for (auto const& sw : m_vSwipes) {
         if (sw->resource->client() != FOCUSEDCLIENT)
             continue;
 
-        sw->resource->sendBegin(SERIAL, timeMs, g_pSeatManager->state.pointerFocus->getResource()->resource(), fingers);
+        sw->resource->sendBegin(SERIAL, timeMs, g_pSeatManager->m_state.pointerFocus->getResource()->resource(), fingers);
     }
 }
 
 void CPointerGesturesProtocol::swipeUpdate(uint32_t timeMs, const Vector2D& delta) {
-    if (!g_pSeatManager->state.pointerFocusResource)
+    if (!g_pSeatManager->m_state.pointerFocusResource)
         return;
 
-    const auto FOCUSEDCLIENT = g_pSeatManager->state.pointerFocusResource->client();
+    const auto FOCUSEDCLIENT = g_pSeatManager->m_state.pointerFocusResource->client();
 
     for (auto const& sw : m_vSwipes) {
         if (sw->resource->client() != FOCUSEDCLIENT)
@@ -133,12 +133,12 @@ void CPointerGesturesProtocol::swipeUpdate(uint32_t timeMs, const Vector2D& delt
 }
 
 void CPointerGesturesProtocol::swipeEnd(uint32_t timeMs, bool cancelled) {
-    if (!g_pSeatManager->state.pointerFocusResource)
+    if (!g_pSeatManager->m_state.pointerFocusResource)
         return;
 
-    const auto FOCUSEDCLIENT = g_pSeatManager->state.pointerFocusResource->client();
+    const auto FOCUSEDCLIENT = g_pSeatManager->m_state.pointerFocusResource->client();
 
-    const auto SERIAL = g_pSeatManager->nextSerial(g_pSeatManager->state.pointerFocusResource.lock());
+    const auto SERIAL = g_pSeatManager->nextSerial(g_pSeatManager->m_state.pointerFocusResource.lock());
 
     for (auto const& sw : m_vSwipes) {
         if (sw->resource->client() != FOCUSEDCLIENT)
@@ -149,26 +149,26 @@ void CPointerGesturesProtocol::swipeEnd(uint32_t timeMs, bool cancelled) {
 }
 
 void CPointerGesturesProtocol::pinchBegin(uint32_t timeMs, uint32_t fingers) {
-    if (!g_pSeatManager->state.pointerFocusResource)
+    if (!g_pSeatManager->m_state.pointerFocusResource)
         return;
 
-    const auto FOCUSEDCLIENT = g_pSeatManager->state.pointerFocusResource->client();
+    const auto FOCUSEDCLIENT = g_pSeatManager->m_state.pointerFocusResource->client();
 
-    const auto SERIAL = g_pSeatManager->nextSerial(g_pSeatManager->state.pointerFocusResource.lock());
+    const auto SERIAL = g_pSeatManager->nextSerial(g_pSeatManager->m_state.pointerFocusResource.lock());
 
     for (auto const& sw : m_vPinches) {
         if (sw->resource->client() != FOCUSEDCLIENT)
             continue;
 
-        sw->resource->sendBegin(SERIAL, timeMs, g_pSeatManager->state.pointerFocus->getResource()->resource(), fingers);
+        sw->resource->sendBegin(SERIAL, timeMs, g_pSeatManager->m_state.pointerFocus->getResource()->resource(), fingers);
     }
 }
 
 void CPointerGesturesProtocol::pinchUpdate(uint32_t timeMs, const Vector2D& delta, double scale, double rotation) {
-    if (!g_pSeatManager->state.pointerFocusResource)
+    if (!g_pSeatManager->m_state.pointerFocusResource)
         return;
 
-    const auto FOCUSEDCLIENT = g_pSeatManager->state.pointerFocusResource->client();
+    const auto FOCUSEDCLIENT = g_pSeatManager->m_state.pointerFocusResource->client();
 
     for (auto const& sw : m_vPinches) {
         if (sw->resource->client() != FOCUSEDCLIENT)
@@ -179,12 +179,12 @@ void CPointerGesturesProtocol::pinchUpdate(uint32_t timeMs, const Vector2D& delt
 }
 
 void CPointerGesturesProtocol::pinchEnd(uint32_t timeMs, bool cancelled) {
-    if (!g_pSeatManager->state.pointerFocusResource)
+    if (!g_pSeatManager->m_state.pointerFocusResource)
         return;
 
-    const auto FOCUSEDCLIENT = g_pSeatManager->state.pointerFocusResource->client();
+    const auto FOCUSEDCLIENT = g_pSeatManager->m_state.pointerFocusResource->client();
 
-    const auto SERIAL = g_pSeatManager->nextSerial(g_pSeatManager->state.pointerFocusResource.lock());
+    const auto SERIAL = g_pSeatManager->nextSerial(g_pSeatManager->m_state.pointerFocusResource.lock());
 
     for (auto const& sw : m_vPinches) {
         if (sw->resource->client() != FOCUSEDCLIENT)
@@ -195,28 +195,28 @@ void CPointerGesturesProtocol::pinchEnd(uint32_t timeMs, bool cancelled) {
 }
 
 void CPointerGesturesProtocol::holdBegin(uint32_t timeMs, uint32_t fingers) {
-    if (!g_pSeatManager->state.pointerFocusResource)
+    if (!g_pSeatManager->m_state.pointerFocusResource)
         return;
 
-    const auto FOCUSEDCLIENT = g_pSeatManager->state.pointerFocusResource->client();
+    const auto FOCUSEDCLIENT = g_pSeatManager->m_state.pointerFocusResource->client();
 
-    const auto SERIAL = g_pSeatManager->nextSerial(g_pSeatManager->state.pointerFocusResource.lock());
+    const auto SERIAL = g_pSeatManager->nextSerial(g_pSeatManager->m_state.pointerFocusResource.lock());
 
     for (auto const& sw : m_vHolds) {
         if (sw->resource->client() != FOCUSEDCLIENT)
             continue;
 
-        sw->resource->sendBegin(SERIAL, timeMs, g_pSeatManager->state.pointerFocus->getResource()->resource(), fingers);
+        sw->resource->sendBegin(SERIAL, timeMs, g_pSeatManager->m_state.pointerFocus->getResource()->resource(), fingers);
     }
 }
 
 void CPointerGesturesProtocol::holdEnd(uint32_t timeMs, bool cancelled) {
-    if (!g_pSeatManager->state.pointerFocusResource)
+    if (!g_pSeatManager->m_state.pointerFocusResource)
         return;
 
-    const auto FOCUSEDCLIENT = g_pSeatManager->state.pointerFocusResource->client();
+    const auto FOCUSEDCLIENT = g_pSeatManager->m_state.pointerFocusResource->client();
 
-    const auto SERIAL = g_pSeatManager->nextSerial(g_pSeatManager->state.pointerFocusResource.lock());
+    const auto SERIAL = g_pSeatManager->nextSerial(g_pSeatManager->m_state.pointerFocusResource.lock());
 
     for (auto const& sw : m_vHolds) {
         if (sw->resource->client() != FOCUSEDCLIENT)

--- a/src/protocols/PrimarySelection.cpp
+++ b/src/protocols/PrimarySelection.cpp
@@ -228,7 +228,7 @@ void CPrimarySelectionProtocol::bindManager(wl_client* client, void* data, uint3
 
     // we need to do it here because protocols come before seatMgr
     if (!listeners.onPointerFocusChange)
-        listeners.onPointerFocusChange = g_pSeatManager->events.pointerFocusChange.registerListener([this](std::any d) { this->onPointerFocus(); });
+        listeners.onPointerFocusChange = g_pSeatManager->m_events.pointerFocusChange.registerListener([this](std::any d) { this->onPointerFocus(); });
 }
 
 void CPrimarySelectionProtocol::destroyResource(CPrimarySelectionManager* resource) {
@@ -279,10 +279,10 @@ void CPrimarySelectionProtocol::setSelection(SP<IDataSource> source) {
     if (!source) {
         LOGM(LOG, "resetting selection");
 
-        if (!g_pSeatManager->state.pointerFocusResource)
+        if (!g_pSeatManager->m_state.pointerFocusResource)
             return;
 
-        auto DESTDEVICE = dataDeviceForClient(g_pSeatManager->state.pointerFocusResource->client());
+        auto DESTDEVICE = dataDeviceForClient(g_pSeatManager->m_state.pointerFocusResource->client());
         if (DESTDEVICE)
             sendSelectionToDevice(DESTDEVICE, nullptr);
 
@@ -291,10 +291,10 @@ void CPrimarySelectionProtocol::setSelection(SP<IDataSource> source) {
 
     LOGM(LOG, "New selection for data source {:x}", (uintptr_t)source.get());
 
-    if (!g_pSeatManager->state.pointerFocusResource)
+    if (!g_pSeatManager->m_state.pointerFocusResource)
         return;
 
-    auto DESTDEVICE = dataDeviceForClient(g_pSeatManager->state.pointerFocusResource->client());
+    auto DESTDEVICE = dataDeviceForClient(g_pSeatManager->m_state.pointerFocusResource->client());
 
     if (!DESTDEVICE) {
         LOGM(LOG, "CWLDataDeviceProtocol::setSelection: cannot send selection to a client without a data_device");
@@ -305,17 +305,17 @@ void CPrimarySelectionProtocol::setSelection(SP<IDataSource> source) {
 }
 
 void CPrimarySelectionProtocol::updateSelection() {
-    if (!g_pSeatManager->state.pointerFocusResource)
+    if (!g_pSeatManager->m_state.pointerFocusResource)
         return;
 
-    auto DESTDEVICE = dataDeviceForClient(g_pSeatManager->state.pointerFocusResource->client());
+    auto DESTDEVICE = dataDeviceForClient(g_pSeatManager->m_state.pointerFocusResource->client());
 
     if (!DESTDEVICE) {
         LOGM(LOG, "CPrimarySelectionProtocol::updateSelection: cannot send selection to a client without a data_device");
         return;
     }
 
-    sendSelectionToDevice(DESTDEVICE, g_pSeatManager->selection.currentPrimarySelection.lock());
+    sendSelectionToDevice(DESTDEVICE, g_pSeatManager->m_selection.currentPrimarySelection.lock());
 }
 
 void CPrimarySelectionProtocol::onPointerFocus() {

--- a/src/protocols/RelativePointer.cpp
+++ b/src/protocols/RelativePointer.cpp
@@ -59,10 +59,10 @@ void CRelativePointerProtocol::onGetRelativePointer(CZwpRelativePointerManagerV1
 
 void CRelativePointerProtocol::sendRelativeMotion(uint64_t time, const Vector2D& delta, const Vector2D& deltaUnaccel) {
 
-    if (!g_pSeatManager->state.pointerFocusResource)
+    if (!g_pSeatManager->m_state.pointerFocusResource)
         return;
 
-    const auto FOCUSED = g_pSeatManager->state.pointerFocusResource->client();
+    const auto FOCUSED = g_pSeatManager->m_state.pointerFocusResource->client();
 
     for (auto const& rp : m_vRelativePointers) {
         if (FOCUSED != rp->client())

--- a/src/protocols/Tablet.cpp
+++ b/src/protocols/Tablet.cpp
@@ -157,7 +157,7 @@ CTabletToolV2Resource::CTabletToolV2Resource(SP<CZwpTabletToolV2> resource_, SP<
     resource->setOnDestroy([this](CZwpTabletToolV2* r) { PROTO::tablet->destroyResource(this); });
 
     resource->setSetCursor([](CZwpTabletToolV2* r, uint32_t serial, wl_resource* surf, int32_t hot_x, int32_t hot_y) {
-        if (!g_pSeatManager->state.pointerFocusResource || g_pSeatManager->state.pointerFocusResource->client() != r->client())
+        if (!g_pSeatManager->m_state.pointerFocusResource || g_pSeatManager->m_state.pointerFocusResource->client() != r->client())
             return;
 
         g_pInputManager->processMouseRequest(CSeatManager::SSetCursorEvent{surf ? CWLSurfaceResource::fromResource(surf) : nullptr, {hot_x, hot_y}});

--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -372,7 +372,7 @@ bool CToplevelExportFrame::shouldOverlayCursor() const {
     if (!cursorOverlayRequested)
         return false;
 
-    auto pointerSurfaceResource = g_pSeatManager->state.pointerFocus.lock();
+    auto pointerSurfaceResource = g_pSeatManager->m_state.pointerFocus.lock();
 
     if (!pointerSurfaceResource)
         return false;

--- a/src/protocols/XDGShell.cpp
+++ b/src/protocols/XDGShell.cpp
@@ -764,9 +764,9 @@ void CXDGWMBase::ping() {
 }
 
 CXDGShellProtocol::CXDGShellProtocol(const wl_interface* iface, const int& ver, const std::string& name) : IWaylandProtocol(iface, ver, name) {
-    grab           = makeShared<CSeatGrab>();
-    grab->keyboard = true;
-    grab->pointer  = true;
+    grab             = makeShared<CSeatGrab>();
+    grab->m_keyboard = true;
+    grab->m_pointer  = true;
     grab->setCallback([this]() {
         for (auto const& g : grabbed) {
             g->done();

--- a/src/protocols/core/Seat.cpp
+++ b/src/protocols/core/Seat.cpp
@@ -133,8 +133,8 @@ CWLPointerResource::CWLPointerResource(SP<CWlPointer> resource_, SP<CWLSeatResou
         g_pSeatManager->onSetCursor(owner.lock(), serial, surfResource, {hotX, hotY});
     });
 
-    if (g_pSeatManager->state.pointerFocus && g_pSeatManager->state.pointerFocus->client() == resource->client())
-        sendEnter(g_pSeatManager->state.pointerFocus.lock(), {-1, -1} /* Coords don't really matter that much, they will be updated next move */);
+    if (g_pSeatManager->m_state.pointerFocus && g_pSeatManager->m_state.pointerFocus->client() == resource->client())
+        sendEnter(g_pSeatManager->m_state.pointerFocus.lock(), {-1, -1} /* Coords don't really matter that much, they will be updated next move */);
 }
 
 int CWLPointerResource::version() {
@@ -297,16 +297,16 @@ CWLKeyboardResource::CWLKeyboardResource(SP<CWlKeyboard> resource_, SP<CWLSeatRe
     resource->setRelease([this](CWlKeyboard* r) { PROTO::seat->destroyResource(this); });
     resource->setOnDestroy([this](CWlKeyboard* r) { PROTO::seat->destroyResource(this); });
 
-    if (!g_pSeatManager->keyboard) {
+    if (!g_pSeatManager->m_keyboard) {
         LOGM(ERR, "No keyboard on bound wl_keyboard??");
         return;
     }
 
-    sendKeymap(g_pSeatManager->keyboard.lock());
-    repeatInfo(g_pSeatManager->keyboard->m_repeatRate, g_pSeatManager->keyboard->m_repeatDelay);
+    sendKeymap(g_pSeatManager->m_keyboard.lock());
+    repeatInfo(g_pSeatManager->m_keyboard->m_repeatRate, g_pSeatManager->m_keyboard->m_repeatDelay);
 
-    if (g_pSeatManager->state.keyboardFocus && g_pSeatManager->state.keyboardFocus->client() == resource->client())
-        sendEnter(g_pSeatManager->state.keyboardFocus.lock());
+    if (g_pSeatManager->m_state.keyboardFocus && g_pSeatManager->m_state.keyboardFocus->client() == resource->client())
+        sendEnter(g_pSeatManager->m_state.keyboardFocus.lock());
 }
 
 bool CWLKeyboardResource::good() {
@@ -533,7 +533,7 @@ void CWLSeatProtocol::updateKeymap() {
         return;
 
     for (auto const& k : m_vKeyboards) {
-        k->sendKeymap(g_pSeatManager->keyboard.lock());
+        k->sendKeymap(g_pSeatManager->m_keyboard.lock());
     }
 }
 

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -149,7 +149,7 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
 
         rect.scale(pMonitor->m_scale).round();
 
-        const bool        GROUPLOCKED  = m_pWindow->getGroupHead()->m_groupData.locked || g_pKeybindManager->m_bGroupsLocked;
+        const bool        GROUPLOCKED  = m_pWindow->getGroupHead()->m_groupData.locked || g_pKeybindManager->m_groupsLocked;
         const auto* const PCOLACTIVE   = GROUPLOCKED ? GROUPCOLACTIVELOCKED : GROUPCOLACTIVE;
         const auto* const PCOLINACTIVE = GROUPLOCKED ? GROUPCOLINACTIVELOCKED : GROUPCOLINACTIVE;
 
@@ -398,10 +398,10 @@ bool CHyprGroupBarDecoration::onBeginWindowDragOnDeco(const Vector2D& pos) {
     // hack
     g_pLayoutManager->getCurrentLayout()->onWindowRemoved(pWindow);
     if (!pWindow->m_isFloating) {
-        const bool GROUPSLOCKEDPREV        = g_pKeybindManager->m_bGroupsLocked;
-        g_pKeybindManager->m_bGroupsLocked = true;
+        const bool GROUPSLOCKEDPREV       = g_pKeybindManager->m_groupsLocked;
+        g_pKeybindManager->m_groupsLocked = true;
         g_pLayoutManager->getCurrentLayout()->onWindowCreated(pWindow);
-        g_pKeybindManager->m_bGroupsLocked = GROUPSLOCKEDPREV;
+        g_pKeybindManager->m_groupsLocked = GROUPSLOCKEDPREV;
     }
 
     g_pInputManager->m_currentlyDraggedWindow = pWindow;

--- a/src/render/pass/Pass.cpp
+++ b/src/render/pass/Pass.cpp
@@ -238,19 +238,19 @@ void CRenderPass::renderDebugData() {
         offsets[surface.get()] += texture->m_vSize.y;
     };
 
-    renderHLSurface(debugData.keyboardFocusText, g_pSeatManager->state.keyboardFocus.lock(), Colors::PURPLE.modifyA(0.1F));
-    renderHLSurface(debugData.pointerFocusText, g_pSeatManager->state.pointerFocus.lock(), Colors::ORANGE.modifyA(0.1F));
+    renderHLSurface(debugData.keyboardFocusText, g_pSeatManager->m_state.keyboardFocus.lock(), Colors::PURPLE.modifyA(0.1F));
+    renderHLSurface(debugData.pointerFocusText, g_pSeatManager->m_state.pointerFocus.lock(), Colors::ORANGE.modifyA(0.1F));
     if (g_pCompositor->m_lastWindow)
         renderHLSurface(debugData.lastWindowText, g_pCompositor->m_lastWindow->m_wlSurface->resource(), Colors::LIGHT_BLUE.modifyA(0.1F));
 
-    if (g_pSeatManager->state.pointerFocus) {
-        if (g_pSeatManager->state.pointerFocus->current.input.intersect(CBox{{}, g_pSeatManager->state.pointerFocus->current.size}).getExtents().size() !=
-            g_pSeatManager->state.pointerFocus->current.size) {
-            auto hlSurface = CWLSurface::fromResource(g_pSeatManager->state.pointerFocus.lock());
+    if (g_pSeatManager->m_state.pointerFocus) {
+        if (g_pSeatManager->m_state.pointerFocus->current.input.intersect(CBox{{}, g_pSeatManager->m_state.pointerFocus->current.size}).getExtents().size() !=
+            g_pSeatManager->m_state.pointerFocus->current.size) {
+            auto hlSurface = CWLSurface::fromResource(g_pSeatManager->m_state.pointerFocus.lock());
             if (hlSurface) {
                 auto BOX = hlSurface->getSurfaceBoxGlobal();
                 if (BOX) {
-                    auto region = g_pSeatManager->state.pointerFocus->current.input.copy()
+                    auto region = g_pSeatManager->m_state.pointerFocus->current.input.copy()
                                       .scale(g_pHyprOpenGL->m_RenderData.pMonitor->m_scale)
                                       .translate(BOX->pos() - g_pHyprOpenGL->m_RenderData.pMonitor->m_position);
                     g_pHyprOpenGL->renderRectWithDamage(box, CHyprColor{0.8F, 0.8F, 0.2F, 0.4F}, region);

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -650,7 +650,7 @@ void CXWM::handleSelectionRequest(xcb_selection_request_event_t* e) {
         return;
     }
 
-    if (!g_pSeatManager->state.keyboardFocusResource || g_pSeatManager->state.keyboardFocusResource->client() != g_pXWayland->pServer->xwaylandClient) {
+    if (!g_pSeatManager->m_state.keyboardFocusResource || g_pSeatManager->m_state.keyboardFocusResource->client() != g_pXWayland->pServer->xwaylandClient) {
         Debug::log(TRACE, "[xwm] Ignoring clipboard access: xwayland not in focus");
         selectionSendNotify(e, false);
         return;
@@ -659,8 +659,8 @@ void CXWM::handleSelectionRequest(xcb_selection_request_event_t* e) {
     if (e->target == HYPRATOMS["TARGETS"]) {
         // send mime types
         std::vector<std::string> mimes;
-        if (sel == &clipboard && g_pSeatManager->selection.currentSelection)
-            mimes = g_pSeatManager->selection.currentSelection->mimes();
+        if (sel == &clipboard && g_pSeatManager->m_selection.currentSelection)
+            mimes = g_pSeatManager->m_selection.currentSelection->mimes();
         else if (sel == &dndSelection && !dndDataOffers.empty() && dndDataOffers.at(0)->source)
             mimes = dndDataOffers.at(0)->source->mimes();
 
@@ -1179,8 +1179,8 @@ void CXWM::initSelection() {
         XCB_XFIXES_SELECTION_EVENT_MASK_SET_SELECTION_OWNER | XCB_XFIXES_SELECTION_EVENT_MASK_SELECTION_WINDOW_DESTROY | XCB_XFIXES_SELECTION_EVENT_MASK_SELECTION_CLIENT_CLOSE;
     xcb_xfixes_select_selection_input(connection, clipboard.window, HYPRATOMS["CLIPBOARD"], mask2);
 
-    clipboard.listeners.setSelection        = g_pSeatManager->events.setSelection.registerListener([this](std::any d) { clipboard.onSelection(); });
-    clipboard.listeners.keyboardFocusChange = g_pSeatManager->events.keyboardFocusChange.registerListener([this](std::any d) { clipboard.onKeyboardFocus(); });
+    clipboard.listeners.setSelection        = g_pSeatManager->m_events.setSelection.registerListener([this](std::any d) { clipboard.onSelection(); });
+    clipboard.listeners.keyboardFocusChange = g_pSeatManager->m_events.keyboardFocusChange.registerListener([this](std::any d) { clipboard.onKeyboardFocus(); });
 
     primarySelection.window = xcb_generate_id(connection);
     xcb_create_window(connection, XCB_COPY_FROM_PARENT, primarySelection.window, screen->root, 0, 0, 10, 10, 0, XCB_WINDOW_CLASS_INPUT_OUTPUT, screen->root_visual,
@@ -1189,8 +1189,8 @@ void CXWM::initSelection() {
 
     xcb_xfixes_select_selection_input(connection, primarySelection.window, HYPRATOMS["PRIMARY"], mask2);
 
-    primarySelection.listeners.setSelection        = g_pSeatManager->events.setPrimarySelection.registerListener([this](std::any d) { primarySelection.onSelection(); });
-    primarySelection.listeners.keyboardFocusChange = g_pSeatManager->events.keyboardFocusChange.registerListener([this](std::any d) { primarySelection.onKeyboardFocus(); });
+    primarySelection.listeners.setSelection        = g_pSeatManager->m_events.setPrimarySelection.registerListener([this](std::any d) { primarySelection.onSelection(); });
+    primarySelection.listeners.keyboardFocusChange = g_pSeatManager->m_events.keyboardFocusChange.registerListener([this](std::any d) { primarySelection.onKeyboardFocus(); });
 
     dndSelection.window = xcb_generate_id(connection);
     xcb_create_window(connection, XCB_COPY_FROM_PARENT, dndSelection.window, screen->root, 0, 0, 8192, 8192, 0, XCB_WINDOW_CLASS_INPUT_ONLY, screen->root_visual, XCB_CW_EVENT_MASK,
@@ -1330,16 +1330,16 @@ SP<IDataOffer> CXWM::createX11DataOffer(SP<CWLSurfaceResource> surf, SP<IDataSou
 }
 
 void SXSelection::onSelection() {
-    if ((this == &g_pXWayland->pWM->clipboard && g_pSeatManager->selection.currentSelection && g_pSeatManager->selection.currentSelection->type() == DATA_SOURCE_TYPE_X11) ||
-        (this == &g_pXWayland->pWM->primarySelection && g_pSeatManager->selection.currentPrimarySelection &&
-         g_pSeatManager->selection.currentPrimarySelection->type() == DATA_SOURCE_TYPE_X11))
+    if ((this == &g_pXWayland->pWM->clipboard && g_pSeatManager->m_selection.currentSelection && g_pSeatManager->m_selection.currentSelection->type() == DATA_SOURCE_TYPE_X11) ||
+        (this == &g_pXWayland->pWM->primarySelection && g_pSeatManager->m_selection.currentPrimarySelection &&
+         g_pSeatManager->m_selection.currentPrimarySelection->type() == DATA_SOURCE_TYPE_X11))
         return;
 
-    if (this == &g_pXWayland->pWM->clipboard && g_pSeatManager->selection.currentSelection) {
+    if (this == &g_pXWayland->pWM->clipboard && g_pSeatManager->m_selection.currentSelection) {
         xcb_set_selection_owner(g_pXWayland->pWM->connection, g_pXWayland->pWM->clipboard.window, HYPRATOMS["CLIPBOARD"], XCB_TIME_CURRENT_TIME);
         xcb_flush(g_pXWayland->pWM->connection);
         g_pXWayland->pWM->clipboard.notifyOnFocus = true;
-    } else if (this == &g_pXWayland->pWM->primarySelection && g_pSeatManager->selection.currentPrimarySelection) {
+    } else if (this == &g_pXWayland->pWM->primarySelection && g_pSeatManager->m_selection.currentPrimarySelection) {
         xcb_set_selection_owner(g_pXWayland->pWM->connection, g_pXWayland->pWM->primarySelection.window, HYPRATOMS["PRIMARY"], XCB_TIME_CURRENT_TIME);
         xcb_flush(g_pXWayland->pWM->connection);
         g_pXWayland->pWM->primarySelection.notifyOnFocus = true;
@@ -1347,7 +1347,7 @@ void SXSelection::onSelection() {
 }
 
 void SXSelection::onKeyboardFocus() {
-    if (!g_pSeatManager->state.keyboardFocusResource || g_pSeatManager->state.keyboardFocusResource->client() != g_pXWayland->pServer->xwaylandClient)
+    if (!g_pSeatManager->m_state.keyboardFocusResource || g_pSeatManager->m_state.keyboardFocusResource->client() != g_pXWayland->pServer->xwaylandClient)
         return;
 
     if (this == &g_pXWayland->pWM->clipboard && g_pXWayland->pWM->clipboard.notifyOnFocus) {
@@ -1404,9 +1404,9 @@ static int readDataSource(int fd, uint32_t mask, void* data) {
 bool SXSelection::sendData(xcb_selection_request_event_t* e, std::string mime) {
     WP<IDataSource> selection;
     if (this == &g_pXWayland->pWM->clipboard)
-        selection = g_pSeatManager->selection.currentSelection;
+        selection = g_pSeatManager->m_selection.currentSelection;
     else if (this == &g_pXWayland->pWM->primarySelection)
-        selection = g_pSeatManager->selection.currentPrimarySelection;
+        selection = g_pSeatManager->m_selection.currentPrimarySelection;
     else if (!g_pXWayland->pWM->dndDataOffers.empty())
         selection = g_pXWayland->pWM->dndDataOffers.at(0)->getSource();
 


### PR DESCRIPTION
part of https://github.com/hyprwm/Hyprland/issues/9870

`touch` and `removeOnInput` removed from SeatManager.hpp (unused)

also removed `m_` prefix from `SSessionLock` fields