### PR TITLE
hyprpm: Minor optimizations and refactor of helpers and progress bar

### DIFF
--- a/hyprpm/src/helpers/Sys.cpp
+++ b/hyprpm/src/helpers/Sys.cpp
@@ -33,15 +33,15 @@ static std::string fetchSuperuserBins() {
 }
 
 static bool executableExistsInPath(const std::string& exe) {
-    const char* pathEnv = std::getenv("PATH");
-    if (!pathEnv)
+    const char* PATHENV = std::getenv("PATH");
+    if (!PATHENV)
         return false;
 
-    CVarList        paths(pathEnv, 0, ':', true);
+    CVarList        paths(PATHENV, 0, ':', true);
     std::error_code ec;
 
-    for (const auto& p : paths) {
-        std::filesystem::path candidate = std::filesystem::path(p) / exe;
+    for (const auto& PATH : paths) {
+        std::filesystem::path candidate = std::filesystem::path(PATH) / exe;
         if (!std::filesystem::exists(candidate, ec) || ec)
             continue;
         if (!std::filesystem::is_regular_file(candidate, ec) || ec)
@@ -100,11 +100,11 @@ bool NSys::isSuperuser() {
 std::string NSys::runAsSuperuser(const std::string& cmd) {
     const std::string escapedCmd = shellEscape(cmd);
 
-    for (const auto& bin : SUPERUSER_BINARIES) {
-        if (!executableExistsInPath(std::string{bin}))
+    for (const auto& BIN : SUPERUSER_BINARIES) {
+        if (!executableExistsInPath(std::string{BIN}))
             continue;
 
-        const auto result = execAndGet(std::string{bin} + " /bin/sh -c " + escapedCmd, true);
+        const auto result = execAndGet(std::string{BIN} + " /bin/sh -c " + escapedCmd, true);
         if (!result.has_value() || result->second != 0)
             Debug::die("Failed to run a command as sudo. This could be due to an invalid password, or a hyprpm bug.");
 
@@ -122,15 +122,15 @@ void NSys::cacheSudo() {
 }
 
 void NSys::dropSudo() {
-    for (const auto& bin : SUPERUSER_BINARIES) {
-        if (!executableExistsInPath(std::string{bin}))
+    for (const auto& BIN : SUPERUSER_BINARIES) {
+        if (!executableExistsInPath(std::string{BIN}))
             continue;
 
-        if (bin == "sudo")
+        if (BIN == "sudo")
             execAndGet("sudo -k");
         else {
             // note the superuser binary that is being dropped
-            std::println("{}", infoString("Don't know how to drop timestamp for '{}', ignoring.", bin));
+            std::println("{}", infoString("Don't know how to drop timestamp for '{}', ignoring.", BIN));
         }
     }
 }

--- a/hyprpm/src/helpers/Sys.cpp
+++ b/hyprpm/src/helpers/Sys.cpp
@@ -128,8 +128,9 @@ void NSys::dropSudo() {
 
         if (bin == "sudo")
             execAndGet("sudo -k");
-        else
+        else {
             // note the superuser binary that is being dropped
             std::println("{}", infoString("Don't know how to drop timestamp for '{}', ignoring.", bin));
+        }
     }
 }

--- a/hyprpm/src/helpers/Sys.cpp
+++ b/hyprpm/src/helpers/Sys.cpp
@@ -69,18 +69,6 @@ static std::optional<std::pair<std::string, int>> execAndGet(std::string_view cm
     return {{proc.stdOut(), proc.exitCode()}};
 }
 
-static std::string shellEscape(const std::string& input) {
-    std::string escaped = "'";
-    for (char c : input) {
-        if (c == '\'')
-            escaped += "'\\''";
-        else
-            escaped += c;
-    }
-    escaped += "'";
-    return escaped;
-}
-
 int NSys::getUID() {
     const auto UID   = getuid();
     const auto PWUID = getpwuid(UID);
@@ -98,13 +86,11 @@ bool NSys::isSuperuser() {
 }
 
 std::string NSys::runAsSuperuser(const std::string& cmd) {
-    const std::string escapedCmd = shellEscape(cmd);
-
     for (const auto& BIN : SUPERUSER_BINARIES) {
         if (!executableExistsInPath(std::string{BIN}))
             continue;
 
-        const auto result = execAndGet(std::string{BIN} + " /bin/sh -c " + escapedCmd, true);
+        const auto result = execAndGet(std::string{BIN} + " /bin/sh -c " + cmd, true);
         if (!result.has_value() || result->second != 0)
             Debug::die("Failed to run a command as sudo. This could be due to an invalid password, or a hyprpm bug.");
 

--- a/hyprpm/src/helpers/Sys.cpp
+++ b/hyprpm/src/helpers/Sys.cpp
@@ -22,9 +22,7 @@ inline constexpr std::array<std::string_view, 3> SUPERUSER_BINARIES = {
 
 static std::string fetchSuperuserBins() {
     std::ostringstream oss;
-    oss << "Failed to find a superuser binary. Supported: ";
-
-    auto it = SUPERUSER_BINARIES.begin();
+    auto               it = SUPERUSER_BINARIES.begin();
     if (it != SUPERUSER_BINARIES.end()) {
         oss << *it++;
         for (; it != SUPERUSER_BINARIES.end(); ++it)
@@ -113,7 +111,7 @@ std::string NSys::runAsSuperuser(const std::string& cmd) {
         return result->first;
     }
 
-    Debug::die("{} {}", "Failed to find a superuser binary. Supported:", fetchSuperuserBins());
+    Debug::die("{} {}", "Failed to find a superuser binary. Supported: ", fetchSuperuserBins());
     return "";
 }
 

--- a/hyprpm/src/helpers/Sys.cpp
+++ b/hyprpm/src/helpers/Sys.cpp
@@ -1,59 +1,86 @@
 #include "Sys.hpp"
 #include "Die.hpp"
 #include "StringUtils.hpp"
+
 #include <pwd.h>
 #include <unistd.h>
 #include <print>
 #include <filesystem>
+#include <optional>
 
 #include <hyprutils/os/Process.hpp>
 #include <hyprutils/string/VarList.hpp>
+
 using namespace Hyprutils::OS;
 using namespace Hyprutils::String;
 
-static const std::vector<const char*> SUPERUSER_BINARIES = {
+inline constexpr std::array<std::string_view, 3> SUPERUSER_BINARIES = {
     "sudo",
     "doas",
     "run0",
 };
 
+static std::string fetchSuperuserBins() {
+    std::ostringstream oss;
+    oss << "Failed to find a superuser binary. Supported: ";
+
+    auto it = SUPERUSER_BINARIES.begin();
+    if (it != SUPERUSER_BINARIES.end()) {
+        oss << *it++;
+        for (; it != SUPERUSER_BINARIES.end(); ++it)
+            oss << ", " << *it;
+    }
+
+    return oss.str();
+}
+
 static bool executableExistsInPath(const std::string& exe) {
-    if (!getenv("PATH"))
+    const char* pathEnv = std::getenv("PATH");
+    if (!pathEnv)
         return false;
 
-    static CVarList paths(getenv("PATH"), 0, ':', true);
+    CVarList        paths(pathEnv, 0, ':', true);
+    std::error_code ec;
 
-    for (auto& p : paths) {
-        std::string     path = p + std::string{"/"} + exe;
-        std::error_code ec;
-        if (!std::filesystem::exists(path, ec) || ec)
+    for (const auto& p : paths) {
+        std::filesystem::path candidate = std::filesystem::path(p) / exe;
+        if (!std::filesystem::exists(candidate, ec) || ec)
             continue;
-
-        if (!std::filesystem::is_regular_file(path, ec) || ec)
+        if (!std::filesystem::is_regular_file(candidate, ec) || ec)
             continue;
-
-        auto stat = std::filesystem::status(path, ec);
+        auto perms = std::filesystem::status(candidate, ec).permissions();
         if (ec)
             continue;
-
-        auto perms = stat.permissions();
-
-        return std::filesystem::perms::none != (perms & std::filesystem::perms::others_exec);
+        if ((perms & std::filesystem::perms::others_exec) != std::filesystem::perms::none)
+            return true;
     }
 
     return false;
 }
 
-static std::pair<std::string, int> execAndGet(std::string cmd, bool noRedirect = false) {
+static std::optional<std::pair<std::string, int>> execAndGet(std::string_view cmd, bool noRedirect = false) {
+    std::string command = std::string{cmd};
     if (!noRedirect)
-        cmd += " 2>&1";
+        command += " 2>&1";
 
-    CProcess proc("/bin/sh", {"-c", cmd});
-
+    CProcess proc("/bin/sh", {"-c", command});
     if (!proc.runSync())
-        return {"error", 1};
+        // optional handles nullopt gracefully
+        return std::nullopt;
 
-    return {proc.stdOut(), proc.exitCode()};
+    return {{proc.stdOut(), proc.exitCode()}};
+}
+
+static std::string shellEscape(const std::string& input) {
+    std::string escaped = "'";
+    for (char c : input) {
+        if (c == '\'')
+            escaped += "'\\''";
+        else
+            escaped += c;
+    }
+    escaped += "'";
+    return escaped;
 }
 
 int NSys::getUID() {
@@ -69,23 +96,24 @@ int NSys::getEUID() {
 }
 
 bool NSys::isSuperuser() {
-    return getuid() != geteuid() || !geteuid();
+    return getuid() != geteuid() || geteuid() == 0;
 }
 
 std::string NSys::runAsSuperuser(const std::string& cmd) {
-    for (const auto& SB : SUPERUSER_BINARIES) {
-        if (!executableExistsInPath(SB))
+    const std::string escapedCmd = shellEscape(cmd);
+
+    for (const auto& bin : SUPERUSER_BINARIES) {
+        if (!executableExistsInPath(std::string{bin}))
             continue;
 
-        const auto RESULT = execAndGet(std::string{SB} + " /bin/sh -c \"" + cmd + "\"", true);
-
-        if (RESULT.second != 0)
+        const auto result = execAndGet(std::string{bin} + " /bin/sh -c " + escapedCmd, true);
+        if (!result.has_value() || result->second != 0)
             Debug::die("Failed to run a command as sudo. This could be due to an invalid password, or a hyprpm bug.");
 
-        return RESULT.first;
+        return result->first;
     }
 
-    Debug::die("Failed to find a superuser binary. Supported: sudo, doas, run0.");
+    Debug::die("{} {}", "Failed to find a superuser binary. Supported:", fetchSuperuserBins());
     return "";
 }
 
@@ -96,15 +124,15 @@ void NSys::cacheSudo() {
 }
 
 void NSys::dropSudo() {
-    for (const auto& SB : SUPERUSER_BINARIES) {
-        if (!executableExistsInPath(SB))
+    for (const auto& bin : SUPERUSER_BINARIES) {
+        if (!executableExistsInPath(std::string{bin}))
             continue;
 
-        if (SB == std::string_view{"sudo"})
+        if (bin == "sudo") {
             execAndGet("sudo -k");
-        else
-            std::println("{}", infoString("Don't know how to drop timestamp for {}, ignoring.", SB));
-
-        return;
+        } else {
+            // note the superuser binary that is being dropped
+            std::println("{}", infoString("Don't know how to drop timestamp for '{}', ignoring.", bin));
+        }
     }
 }

--- a/hyprpm/src/helpers/Sys.cpp
+++ b/hyprpm/src/helpers/Sys.cpp
@@ -126,11 +126,10 @@ void NSys::dropSudo() {
         if (!executableExistsInPath(std::string{bin}))
             continue;
 
-        if (bin == "sudo") {
+        if (bin == "sudo")
             execAndGet("sudo -k");
-        } else {
+        else
             // note the superuser binary that is being dropped
             std::println("{}", infoString("Don't know how to drop timestamp for '{}', ignoring.", bin));
-        }
     }
 }

--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -4,7 +4,6 @@
 #include "core/DataState.hpp"
 #include "helpers/Sys.hpp"
 
-#include <cstdio>
 #include <vector>
 #include <string>
 #include <print>

--- a/hyprpm/src/progress/CProgressBar.cpp
+++ b/hyprpm/src/progress/CProgressBar.cpp
@@ -1,82 +1,80 @@
 #include "CProgressBar.hpp"
 
 #include <sys/ioctl.h>
-#include <algorithm>
+#include <unistd.h>
 #include <cmath>
 #include <format>
-
 #include <print>
-#include <stdio.h>
-#include <unistd.h>
+#include <cstdio>
+
+#include <algorithm>
+#include <sstream>
 
 #include "../helpers/Colors.hpp"
 
-void CProgressBar::printMessageAbove(const std::string& msg) {
-    struct winsize w;
+static winsize getTerminalSize() {
+    winsize w{};
     ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
+    return w;
+}
 
-    std::string spaces;
-    spaces.reserve(w.ws_col);
-    for (size_t i = 0; i < w.ws_col; ++i) {
-        spaces += ' ';
-    }
+static void clearCurrentLine() {
+    std::print("\r\33[2K"); // ansi escape sequence to clear entire line
+}
 
-    std::println("\r{}\r{}", spaces, msg);
-    print();
+void CProgressBar::printMessageAbove(const std::string& msg) {
+    clearCurrentLine();
+    std::print("\r{}\n", msg);
+
+    print(); // reprint bar underneath
 }
 
 void CProgressBar::print() {
-    struct winsize w;
-    ioctl(STDOUT_FILENO, TIOCGWINSZ, &w);
+    const auto w = getTerminalSize();
 
-    if (m_bFirstPrint)
+    if (m_bFirstPrint) {
         std::print("\n");
-    m_bFirstPrint = false;
-
-    std::string spaces;
-    spaces.reserve(w.ws_col);
-    for (size_t i = 0; i < w.ws_col; ++i) {
-        spaces += ' ';
+        m_bFirstPrint = false;
     }
 
-    std::print("\r{}\r", spaces);
+    clearCurrentLine();
 
-    std::string message = "";
-
-    float       percentDone = 0;
-    if (m_fPercentage >= 0)
+    float percentDone = 0.0f;
+    if (m_fPercentage >= 0.0f) {
         percentDone = m_fPercentage;
-    else
-        percentDone = (float)m_iSteps / (float)m_iMaxSteps;
+    } else {
+        // check for divide-by-zero
+        percentDone = m_iMaxSteps > 0 ? static_cast<float>(m_iSteps) / m_iMaxSteps : 0.0f;
+    }
+    // clamp to ensure no overflows (sanity check)
+    percentDone = std::clamp(percentDone, 0.0f, 1.0f);
 
-    const auto BARWIDTH = std::clamp(w.ws_col - static_cast<unsigned long>(m_szCurrentMessage.length()) - 2, 0UL, 50UL);
+    const size_t       barWidth = std::clamp<size_t>(w.ws_col - m_szCurrentMessage.length() - 2, 0, 50);
 
-    // draw bar
-    message += std::string{" "} + Colors::GREEN;
-    size_t i = 0;
-    for (; i < std::floor(percentDone * BARWIDTH); ++i) {
-        message += "━";
+    std::ostringstream oss;
+    oss << ' ' << Colors::GREEN;
+
+    size_t filled = static_cast<size_t>(std::floor(percentDone * barWidth));
+    size_t i      = 0;
+
+    for (; i < filled; ++i)
+        oss << "━";
+
+    if (i < barWidth) {
+        oss << "╍" << Colors::RESET;
+        ++i;
+        for (; i < barWidth; ++i)
+            oss << "━";
+    } else {
+        oss << Colors::RESET;
     }
 
-    if (i < BARWIDTH) {
-        i++;
+    if (m_fPercentage >= 0.0f) {
+        oss << "  " << std::format("{}%", static_cast<int>(percentDone * 100.0)) << ' ';
+    } else {
+        oss << "  " << std::format("{} / {}", m_iSteps, m_iMaxSteps) << ' ';
+    }
 
-        message += std::string{"╍"} + Colors::RESET;
-
-        for (; i < BARWIDTH; ++i) {
-            message += "━";
-        }
-    } else
-        message += Colors::RESET;
-
-    // draw progress
-    if (m_fPercentage >= 0)
-        message += "  " + std::format("{}%", static_cast<int>(percentDone * 100.0)) + " ";
-    else
-        message += "  " + std::format("{} / {}", m_iSteps, m_iMaxSteps) + " ";
-
-    // draw message
-    std::print("{} {}", message, m_szCurrentMessage);
-
+    std::print("{} {}", oss.str(), m_szCurrentMessage);
     std::fflush(stdout);
 }

--- a/hyprpm/src/progress/CProgressBar.cpp
+++ b/hyprpm/src/progress/CProgressBar.cpp
@@ -49,21 +49,21 @@ void CProgressBar::print() {
     // clamp to ensure no overflows (sanity check)
     percentDone = std::clamp(percentDone, 0.0f, 1.0f);
 
-    const size_t       barWidth = std::clamp<size_t>(w.ws_col - m_szCurrentMessage.length() - 2, 0, 50);
+    const size_t       BARWIDTH = std::clamp<size_t>(w.ws_col - m_szCurrentMessage.length() - 2, 0, 50);
 
     std::ostringstream oss;
     oss << ' ' << Colors::GREEN;
 
-    size_t filled = static_cast<size_t>(std::floor(percentDone * barWidth));
+    size_t filled = static_cast<size_t>(std::floor(percentDone * BARWIDTH));
     size_t i      = 0;
 
     for (; i < filled; ++i)
         oss << "━";
 
-    if (i < barWidth) {
+    if (i < BARWIDTH) {
         oss << "╍" << Colors::RESET;
         ++i;
-        for (; i < barWidth; ++i)
+        for (; i < BARWIDTH; ++i)
             oss << "━";
     } else
         oss << Colors::RESET;

--- a/hyprpm/src/progress/CProgressBar.cpp
+++ b/hyprpm/src/progress/CProgressBar.cpp
@@ -42,9 +42,10 @@ void CProgressBar::print() {
     float percentDone = 0.0f;
     if (m_fPercentage >= 0.0f)
         percentDone = m_fPercentage;
-    else
+    else {
         // check for divide-by-zero
         percentDone = m_iMaxSteps > 0 ? static_cast<float>(m_iSteps) / m_iMaxSteps : 0.0f;
+    }
     // clamp to ensure no overflows (sanity check)
     percentDone = std::clamp(percentDone, 0.0f, 1.0f);
 
@@ -64,9 +65,8 @@ void CProgressBar::print() {
         ++i;
         for (; i < barWidth; ++i)
             oss << "━";
-    } else {
+    } else
         oss << Colors::RESET;
-    }
 
     if (m_fPercentage >= 0.0f)
         oss << "  " << std::format("{}%", static_cast<int>(percentDone * 100.0)) << ' ';

--- a/hyprpm/src/progress/CProgressBar.cpp
+++ b/hyprpm/src/progress/CProgressBar.cpp
@@ -40,12 +40,11 @@ void CProgressBar::print() {
     clearCurrentLine();
 
     float percentDone = 0.0f;
-    if (m_fPercentage >= 0.0f) {
+    if (m_fPercentage >= 0.0f)
         percentDone = m_fPercentage;
-    } else {
+    else
         // check for divide-by-zero
         percentDone = m_iMaxSteps > 0 ? static_cast<float>(m_iSteps) / m_iMaxSteps : 0.0f;
-    }
     // clamp to ensure no overflows (sanity check)
     percentDone = std::clamp(percentDone, 0.0f, 1.0f);
 
@@ -69,11 +68,10 @@ void CProgressBar::print() {
         oss << Colors::RESET;
     }
 
-    if (m_fPercentage >= 0.0f) {
+    if (m_fPercentage >= 0.0f)
         oss << "  " << std::format("{}%", static_cast<int>(percentDone * 100.0)) << ' ';
-    } else {
+    else
         oss << "  " << std::format("{} / {}", m_iSteps, m_iMaxSteps) << ' ';
-    }
 
     std::print("{} {}", oss.str(), m_szCurrentMessage);
     std::fflush(stdout);


### PR DESCRIPTION
### PR Contents

File 1: Sys.cpp (in `hyprpm/helpers`)

1. Made `SUPERUSER_BINARIES` into `std::array` of `std::string_view` to avoid useless allocs with subsequent changes within the same file.
2. In the function `executableExistsInPath()`, instead of repeatedly concatenating strings, used `std::filesystem::path(p)` operators instead along with some minor changes in the function.
3. Converted `execAndGet` to an `optional` for clear failure indications that accepts `std::string_view` as parameter instead of `std::string` (can convert to `std::string` whenever needed, string view makes sense for just read only input here)
4. New function `shellEscape` that takes in a command to be executed as param:
    a. Escapes shell commands safely to handle special characters (', ;, &, etc.).
    b. Prevents shell injection when wrapping commands in sh -c.

5. In `dropSudo` function, just compare `bin` (previously SB) with the string counterpart without converting to `std::string_view` explicitly
6. New function `fetchSuperuserBins` to print the `Debug::die` to show list of supported super user binaries dynamically instead of hardcoding

File 2: CProgressBar.cpp (in `hyprpm/progress`)

1. Use stringstream instead of instead repeated string concat
2. Added ANSI escape sequence to clear entire line without unnecessary logic previously in `printMessageAbove`
3. Moved logic to find terminal size to new function `getTerminalSize`
5. Have a divide by zero logical check in `print` while checking for percentage done
7. Clamp as a sanity check

### Is it ready for merging, or does it need work?
This PR is be ready for merge





