### PR TITLE
layerrules: fix abovelock interactivity for touch input

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -270,6 +270,12 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse) {
             foundSurface  = foundLockSurface;
         }
 
+        if (refocus) {
+            m_foundLSToFocus      = pFoundLayerSurface;
+            m_foundWindowToFocus  = pFoundWindow;
+            m_foundSurfaceToFocus = foundSurface;
+        }
+
         g_pSeatManager->setPointerFocus(foundSurface, surfaceCoords);
         g_pSeatManager->sendPointerMotion(time, surfaceCoords);
 

--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -61,7 +61,8 @@ void CInputManager::onTouchDown(ITouch::SDownEvent e) {
         }
     }
 
-    if (g_pSessionLockManager->isSessionLocked()) {
+    // could have abovelock surface, thus only use lock if no ls found
+    if (g_pSessionLockManager->isSessionLocked() && m_foundLSToFocus.expired()) {
         m_touchData.touchFocusLockSurface = g_pSessionLockManager->getSessionLockSurfaceForMonitor(PMONITOR->m_id);
         if (!m_touchData.touchFocusLockSurface)
             Debug::log(WARN, "The session is locked but can't find a lock surface");


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Makes touch input work for layer surfaces with `abovelock true`. This should fix https://github.com/hyprwm/Hyprland/pull/9793#issuecomment-2846084396.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nope

#### Is it ready for merging, or does it need work?
I think is ready for merging, but maybe @JuneStepp could confirm that it also works on their end.


