### PR TITLE
render: refactor class member vars

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -136,21 +136,21 @@ static void aqLog(Aquamarine::eBackendLogLevel level, std::string msg) {
 }
 
 void CCompositor::bumpNofile() {
-    if (!getrlimit(RLIMIT_NOFILE, &m_sOriginalNofile))
-        Debug::log(LOG, "Old rlimit: soft -> {}, hard -> {}", m_sOriginalNofile.rlim_cur, m_sOriginalNofile.rlim_max);
+    if (!getrlimit(RLIMIT_NOFILE, &m_originalNofile))
+        Debug::log(LOG, "Old rlimit: soft -> {}, hard -> {}", m_originalNofile.rlim_cur, m_originalNofile.rlim_max);
     else {
         Debug::log(ERR, "Failed to get NOFILE rlimits");
-        m_sOriginalNofile.rlim_max = 0;
+        m_originalNofile.rlim_max = 0;
         return;
     }
 
-    rlimit newLimit = m_sOriginalNofile;
+    rlimit newLimit = m_originalNofile;
 
     newLimit.rlim_cur = newLimit.rlim_max;
 
     if (setrlimit(RLIMIT_NOFILE, &newLimit) < 0) {
         Debug::log(ERR, "Failed bumping NOFILE limits higher");
-        m_sOriginalNofile.rlim_max = 0;
+        m_originalNofile.rlim_max = 0;
         return;
     }
 
@@ -159,10 +159,10 @@ void CCompositor::bumpNofile() {
 }
 
 void CCompositor::restoreNofile() {
-    if (m_sOriginalNofile.rlim_max <= 0)
+    if (m_originalNofile.rlim_max <= 0)
         return;
 
-    if (setrlimit(RLIMIT_NOFILE, &m_sOriginalNofile) < 0)
+    if (setrlimit(RLIMIT_NOFILE, &m_originalNofile) < 0)
         Debug::log(ERR, "Failed restoring NOFILE limits");
 }
 
@@ -176,7 +176,7 @@ void CCompositor::setMallocThreshold() {
 #endif
 }
 
-CCompositor::CCompositor(bool onlyConfig) : m_onlyConfigVerification(onlyConfig), m_iHyprlandPID(getpid()) {
+CCompositor::CCompositor(bool onlyConfig) : m_onlyConfigVerification(onlyConfig), m_hyprlandPID(getpid()) {
     if (onlyConfig)
         return;
 
@@ -225,7 +225,7 @@ CCompositor::CCompositor(bool onlyConfig) : m_onlyConfigVerification(onlyConfig)
 
     Debug::log(LOG, "Runtime directory: {}", m_instancePath);
 
-    Debug::log(LOG, "Hyprland PID: {}", m_iHyprlandPID);
+    Debug::log(LOG, "Hyprland PID: {}", m_hyprlandPID);
 
     Debug::log(LOG, "===== SYSTEM INFO: =====");
 
@@ -710,7 +710,7 @@ void CCompositor::createLockFile() {
 
     std::ofstream ofs(PATH, std::ios::trunc);
 
-    ofs << m_iHyprlandPID << "\n" << m_wlDisplaySocket << "\n";
+    ofs << m_hyprlandPID << "\n" << m_wlDisplaySocket << "\n";
 
     ofs.close();
 }
@@ -2706,9 +2706,9 @@ void CCompositor::performUserChecks() {
         }
     }
 
-    if (g_pHyprOpenGL->failedAssetsNo > 0) {
+    if (g_pHyprOpenGL->m_failedAssetsNo > 0) {
         g_pHyprNotificationOverlay->addNotification(std::format("Hyprland failed to load {} essential asset{}, blame your distro's packager for doing a bad job at packaging!",
-                                                                g_pHyprOpenGL->failedAssetsNo, g_pHyprOpenGL->failedAssetsNo > 1 ? "s" : ""),
+                                                                g_pHyprOpenGL->m_failedAssetsNo, g_pHyprOpenGL->m_failedAssetsNo > 1 ? "s" : ""),
                                                     CHyprColor{1.0, 0.1, 0.1, 1.0}, 15000, ICON_ERROR);
     }
 }
@@ -3033,8 +3033,8 @@ void CCompositor::onNewMonitor(SP<Aquamarine::IOutput> output) {
 
     // ready to process if we have a real monitor
 
-    if ((!g_pHyprRenderer->m_pMostHzMonitor || PNEWMONITOR->m_refreshRate > g_pHyprRenderer->m_pMostHzMonitor->m_refreshRate) && PNEWMONITOR->m_enabled)
-        g_pHyprRenderer->m_pMostHzMonitor = PNEWMONITOR;
+    if ((!g_pHyprRenderer->m_mostHzMonitor || PNEWMONITOR->m_refreshRate > g_pHyprRenderer->m_mostHzMonitor->m_refreshRate) && PNEWMONITOR->m_enabled)
+        g_pHyprRenderer->m_mostHzMonitor = PNEWMONITOR;
 
     g_pCompositor->m_readyToProcess = true;
 

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -152,7 +152,7 @@ class CCompositor {
     NColorManagement::SImageDescription getPreferredImageDescription();
     bool                                shouldChangePreferredImageDescription();
 
-    std::string                         explicitConfigPath;
+    std::string                         m_explicitConfigPath;
 
   private:
     void             initAllSignals();
@@ -165,9 +165,9 @@ class CCompositor {
     void             removeLockFile();
     void             setMallocThreshold();
 
-    uint64_t         m_iHyprlandPID    = 0;
-    wl_event_source* m_critSigSource   = nullptr;
-    rlimit           m_sOriginalNofile = {};
+    uint64_t         m_hyprlandPID    = 0;
+    wl_event_source* m_critSigSource  = nullptr;
+    rlimit           m_originalNofile = {};
 };
 
 inline UP<CCompositor> g_pCompositor;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -857,8 +857,8 @@ std::optional<std::string> CConfigManager::generateConfig(std::string configPath
 
 std::string CConfigManager::getMainConfigPath() {
     static std::string CONFIG_PATH = [this]() -> std::string {
-        if (!g_pCompositor->explicitConfigPath.empty())
-            return g_pCompositor->explicitConfigPath;
+        if (!g_pCompositor->m_explicitConfigPath.empty())
+            return g_pCompositor->m_explicitConfigPath;
 
         if (const auto CFG_ENV = getenv("HYPRLAND_CONFIG"); CFG_ENV)
             return CFG_ENV;
@@ -1025,7 +1025,7 @@ void CConfigManager::postConfigReload(const Hyprlang::CParseResult& result) {
         g_pInputManager->setTouchDeviceConfigs();
         g_pInputManager->setTabletConfigs();
 
-        g_pHyprOpenGL->m_bReloadScreenShader = true;
+        g_pHyprOpenGL->m_reloadScreenShader = true;
 
         g_pHyprOpenGL->ensureBackgroundTexturePresence();
     }

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1128,10 +1128,10 @@ static std::string dispatchKeyword(eHyprCtlOutputFormat format, std::string in) 
         g_pLayoutManager->switchToLayout(*PLAYOUT); // update layout
 
     if (COMMAND.contains("decoration:screen_shader") || COMMAND == "source")
-        g_pHyprOpenGL->m_bReloadScreenShader = true;
+        g_pHyprOpenGL->m_reloadScreenShader = true;
 
     if (COMMAND.contains("blur") || COMMAND == "source") {
-        for (auto& [m, rd] : g_pHyprOpenGL->m_mMonitorRenderResources) {
+        for (auto& [m, rd] : g_pHyprOpenGL->m_monitorRenderResources) {
             rd.blurFBDirty = true;
         }
     }
@@ -1821,9 +1821,9 @@ std::string CHyprCtl::getReply(std::string request) {
 
         g_pLayoutManager->switchToLayout(*PLAYOUT); // update layout
 
-        g_pHyprOpenGL->m_bReloadScreenShader = true;
+        g_pHyprOpenGL->m_reloadScreenShader = true;
 
-        for (auto& [m, rd] : g_pHyprOpenGL->m_mMonitorRenderResources) {
+        for (auto& [m, rd] : g_pHyprOpenGL->m_monitorRenderResources) {
             rd.blurFBDirty = true;
         }
 

--- a/src/debug/HyprDebugOverlay.cpp
+++ b/src/debug/HyprDebugOverlay.cpp
@@ -57,7 +57,7 @@ void CHyprMonitorDebugOverlay::frameData(PHLMONITOR pMonitor) {
         m_monitor = pMonitor;
 
     // anim data too
-    const auto PMONITORFORTICKS = g_pHyprRenderer->m_pMostHzMonitor ? g_pHyprRenderer->m_pMostHzMonitor.lock() : g_pCompositor->m_lastMonitor.lock();
+    const auto PMONITORFORTICKS = g_pHyprRenderer->m_mostHzMonitor ? g_pHyprRenderer->m_mostHzMonitor.lock() : g_pCompositor->m_lastMonitor.lock();
     if (PMONITORFORTICKS) {
         if (m_lastAnimationTicks.size() > (long unsigned int)PMONITORFORTICKS->m_refreshRate)
             m_lastAnimationTicks.pop_front();
@@ -260,7 +260,7 @@ void CHyprDebugOverlay::draw() {
     // copy the data to an OpenGL texture we have
     const auto DATA = cairo_image_surface_get_data(m_cairoSurface);
     m_texture->allocate();
-    glBindTexture(GL_TEXTURE_2D, m_texture->m_iTexID);
+    glBindTexture(GL_TEXTURE_2D, m_texture->m_texID);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 
@@ -274,5 +274,5 @@ void CHyprDebugOverlay::draw() {
     CTexPassElement::SRenderData data;
     data.tex = m_texture;
     data.box = {0, 0, PMONITOR->m_pixelSize.x, PMONITOR->m_pixelSize.y};
-    g_pHyprRenderer->m_sRenderPass.add(makeShared<CTexPassElement>(data));
+    g_pHyprRenderer->m_renderPass.add(makeShared<CTexPassElement>(data));
 }

--- a/src/debug/HyprNotificationOverlay.cpp
+++ b/src/debug/HyprNotificationOverlay.cpp
@@ -235,7 +235,7 @@ void CHyprNotificationOverlay::draw(PHLMONITOR pMonitor) {
     // copy the data to an OpenGL texture we have
     const auto DATA = cairo_image_surface_get_data(m_cairoSurface);
     m_texture->allocate();
-    glBindTexture(GL_TEXTURE_2D, m_texture->m_iTexID);
+    glBindTexture(GL_TEXTURE_2D, m_texture->m_texID);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 
@@ -251,7 +251,7 @@ void CHyprNotificationOverlay::draw(PHLMONITOR pMonitor) {
     data.box = {0, 0, MONSIZE.x, MONSIZE.y};
     data.a   = 1.F;
 
-    g_pHyprRenderer->m_sRenderPass.add(makeShared<CTexPassElement>(data));
+    g_pHyprRenderer->m_renderPass.add(makeShared<CTexPassElement>(data));
 }
 
 bool CHyprNotificationOverlay::hasAny() {

--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -74,7 +74,7 @@ CLayerSurface::~CLayerSurface() {
     if (m_surface)
         m_surface->unassign();
     g_pHyprRenderer->makeEGLCurrent();
-    std::erase_if(g_pHyprOpenGL->m_mLayerFramebuffers, [&](const auto& other) { return other.first.expired() || other.first.lock() == m_self.lock(); });
+    std::erase_if(g_pHyprOpenGL->m_layerFramebuffers, [&](const auto& other) { return other.first.expired() || other.first.lock() == m_self.lock(); });
 
     for (auto const& mon : g_pCompositor->m_realMonitors) {
         for (auto& lsl : mon->m_layerSurfaceLayers) {

--- a/src/desktop/WLSurface.cpp
+++ b/src/desktop/WLSurface.cpp
@@ -143,8 +143,8 @@ void CWLSurface::destroy() {
     m_subsurfaceOwner = nullptr;
     m_inert           = true;
 
-    if (g_pHyprRenderer && g_pHyprRenderer->m_sLastCursorData.surf && g_pHyprRenderer->m_sLastCursorData.surf->get() == this)
-        g_pHyprRenderer->m_sLastCursorData.surf.reset();
+    if (g_pHyprRenderer && g_pHyprRenderer->m_lastCursorData.surf && g_pHyprRenderer->m_lastCursorData.surf->get() == this)
+        g_pHyprRenderer->m_lastCursorData.surf.reset();
 
     m_resource.reset();
 

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -126,7 +126,7 @@ CWindow::~CWindow() {
         return;
 
     g_pHyprRenderer->makeEGLCurrent();
-    std::erase_if(g_pHyprOpenGL->m_mWindowFramebuffers, [&](const auto& other) { return other.first.expired() || other.first.get() == this; });
+    std::erase_if(g_pHyprOpenGL->m_windowFramebuffers, [&](const auto& other) { return other.first.expired() || other.first.get() == this; });
 }
 
 SBoxExtents CWindow::getFullWindowExtents() {
@@ -1160,7 +1160,7 @@ bool CWindow::opaque() {
         return false;
 
     if (m_isX11 && m_xwaylandSurface && m_xwaylandSurface->surface && m_xwaylandSurface->surface->m_current.texture)
-        return m_xwaylandSurface->surface->m_current.texture->m_bOpaque;
+        return m_xwaylandSurface->surface->m_current.texture->m_opaque;
 
     if (!m_wlSurface->resource() || !m_wlSurface->resource()->m_current.texture)
         return false;
@@ -1170,7 +1170,7 @@ bool CWindow::opaque() {
     if (EXTENTS.w >= m_xdgSurface->m_surface->m_current.bufferSize.x && EXTENTS.h >= m_xdgSurface->m_surface->m_current.bufferSize.y)
         return true;
 
-    return m_wlSurface->resource()->m_current.texture->m_bOpaque;
+    return m_wlSurface->resource()->m_current.texture->m_opaque;
 }
 
 float CWindow::rounding() {

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -386,7 +386,7 @@ void CMonitor::onDisconnect(bool destroy) {
     if (g_pCompositor->m_lastMonitor == m_self)
         g_pCompositor->setActiveMonitor(BACKUPMON ? BACKUPMON : g_pCompositor->m_unsafeOutput.lock());
 
-    if (g_pHyprRenderer->m_pMostHzMonitor == m_self) {
+    if (g_pHyprRenderer->m_mostHzMonitor == m_self) {
         int        mostHz         = 0;
         PHLMONITOR pMonitorMostHz = nullptr;
 
@@ -397,7 +397,7 @@ void CMonitor::onDisconnect(bool destroy) {
             }
         }
 
-        g_pHyprRenderer->m_pMostHzMonitor = pMonitorMostHz;
+        g_pHyprRenderer->m_mostHzMonitor = pMonitorMostHz;
     }
     std::erase_if(g_pCompositor->m_monitors, [&](PHLMONITOR& el) { return el.get() == this; });
 }
@@ -1355,7 +1355,7 @@ void CMonitor::setCTM(const Mat3x3& ctm_) {
 }
 
 bool CMonitor::attemptDirectScanout() {
-    if (!m_mirrors.empty() || isMirror() || g_pHyprRenderer->m_bDirectScanoutBlocked)
+    if (!m_mirrors.empty() || isMirror() || g_pHyprRenderer->m_directScanoutBlocked)
         return false; // do not DS if this monitor is being mirrored. Will break the functionality.
 
     if (g_pPointerManager->softwareLockedFor(m_self.lock()))
@@ -1376,7 +1376,7 @@ bool CMonitor::attemptDirectScanout() {
 
     // we can't scanout shm buffers.
     const auto params = PSURFACE->m_current.buffer->dmabuf();
-    if (!params.success || !PSURFACE->m_current.texture->m_pEglImage /* dmabuf */)
+    if (!params.success || !PSURFACE->m_current.texture->m_eglImage /* dmabuf */)
         return false;
 
     Debug::log(TRACE, "attemptDirectScanout: surface {:x} passed, will attempt, buffer {}", (uintptr_t)PSURFACE.get(), (uintptr_t)PSURFACE->m_current.buffer.m_buffer.get());

--- a/src/hyprerror/HyprError.cpp
+++ b/src/hyprerror/HyprError.cpp
@@ -143,7 +143,7 @@ void CHyprError::createQueued() {
     // copy the data to an OpenGL texture we have
     const auto DATA = cairo_image_surface_get_data(CAIROSURFACE);
     m_texture->allocate();
-    glBindTexture(GL_TEXTURE_2D, m_texture->m_iTexID);
+    glBindTexture(GL_TEXTURE_2D, m_texture->m_texID);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 
@@ -194,7 +194,7 @@ void CHyprError::draw() {
         }
     }
 
-    const auto PMONITOR = g_pHyprOpenGL->m_RenderData.pMonitor;
+    const auto PMONITOR = g_pHyprOpenGL->m_renderData.pMonitor;
 
     CBox       monbox = {0, 0, PMONITOR->m_pixelSize.x, PMONITOR->m_pixelSize.y};
 
@@ -211,7 +211,7 @@ void CHyprError::draw() {
     data.box = monbox;
     data.a   = m_fadeOpacity->value();
 
-    g_pHyprRenderer->m_sRenderPass.add(makeShared<CTexPassElement>(data));
+    g_pHyprRenderer->m_renderPass.add(makeShared<CTexPassElement>(data));
 }
 
 void CHyprError::destroy() {

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -553,7 +553,7 @@ void IHyprLayout::onMouseMove(const Vector2D& mousePos) {
 
     const auto  TIMERDELTA    = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - TIMER).count();
     const auto  MSDELTA       = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now() - MSTIMER).count();
-    const auto  MSMONITOR     = 1000.0 / g_pHyprRenderer->m_pMostHzMonitor->m_refreshRate;
+    const auto  MSMONITOR     = 1000.0 / g_pHyprRenderer->m_mostHzMonitor->m_refreshRate;
     static int  totalMs       = 0;
     bool        canSkipUpdate = true;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -161,7 +161,7 @@ int main(int argc, char** argv) {
     // it initializes basic Wayland stuff in the constructor.
     try {
         g_pCompositor                     = makeUnique<CCompositor>(verifyConfig);
-        g_pCompositor->explicitConfigPath = configPath;
+        g_pCompositor->m_explicitConfigPath = configPath;
     } catch (const std::exception& e) {
         std::println(stderr, "Hyprland threw in ctor: {}\nCannot continue.", e.what());
         return 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -160,7 +160,7 @@ int main(int argc, char** argv) {
     // let's init the compositor.
     // it initializes basic Wayland stuff in the constructor.
     try {
-        g_pCompositor                     = makeUnique<CCompositor>(verifyConfig);
+        g_pCompositor                       = makeUnique<CCompositor>(verifyConfig);
         g_pCompositor->m_explicitConfigPath = configPath;
     } catch (const std::exception& e) {
         std::println(stderr, "Hyprland threw in ctor: {}\nCannot continue.", e.what());

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -255,7 +255,7 @@ void CHyprAnimationManager::scheduleTick() {
 
     m_tickScheduled = true;
 
-    const auto PMOSTHZ = g_pHyprRenderer->m_pMostHzMonitor;
+    const auto PMOSTHZ = g_pHyprRenderer->m_mostHzMonitor;
 
     if (!PMOSTHZ) {
         m_animationTimer->updateTimeout(std::chrono::milliseconds(16));

--- a/src/protocols/Screencopy.cpp
+++ b/src/protocols/Screencopy.cpp
@@ -215,8 +215,7 @@ void CScreencopyFrame::copyDmabuf(std::function<void(bool)> callback) {
         g_pHyprOpenGL->clear(Colors::BLACK);
     else {
         g_pHyprOpenGL->clear(Colors::BLACK);
-        CBox texbox =
-            CBox{m_monitor->m_transformedSize / 2.F, g_pHyprOpenGL->m_screencopyDeniedTexture->m_size}.translate(-g_pHyprOpenGL->m_screencopyDeniedTexture->m_size / 2.F);
+        CBox texbox = CBox{m_monitor->m_transformedSize / 2.F, g_pHyprOpenGL->m_screencopyDeniedTexture->m_size}.translate(-g_pHyprOpenGL->m_screencopyDeniedTexture->m_size / 2.F);
         g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_screencopyDeniedTexture, texbox, 1);
     }
 
@@ -261,8 +260,7 @@ bool CScreencopyFrame::copyShm() {
         g_pHyprOpenGL->clear(Colors::BLACK);
     else {
         g_pHyprOpenGL->clear(Colors::BLACK);
-        CBox texbox =
-            CBox{m_monitor->m_transformedSize / 2.F, g_pHyprOpenGL->m_screencopyDeniedTexture->m_size}.translate(-g_pHyprOpenGL->m_screencopyDeniedTexture->m_size / 2.F);
+        CBox texbox = CBox{m_monitor->m_transformedSize / 2.F, g_pHyprOpenGL->m_screencopyDeniedTexture->m_size}.translate(-g_pHyprOpenGL->m_screencopyDeniedTexture->m_size / 2.F);
         g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_screencopyDeniedTexture, texbox, 1);
     }
 

--- a/src/protocols/Screencopy.cpp
+++ b/src/protocols/Screencopy.cpp
@@ -146,7 +146,7 @@ void CScreencopyFrame::copy(CZwlrScreencopyFrameV1* pFrame, wl_resource* buffer_
 
     PROTO::screencopy->m_framesAwaitingWrite.emplace_back(m_self);
 
-    g_pHyprRenderer->m_bDirectScanoutBlocked = true;
+    g_pHyprRenderer->m_directScanoutBlocked = true;
 
     if (!m_withDamage)
         g_pHyprRenderer->damageMonitor(m_monitor.lock());
@@ -216,11 +216,11 @@ void CScreencopyFrame::copyDmabuf(std::function<void(bool)> callback) {
     else {
         g_pHyprOpenGL->clear(Colors::BLACK);
         CBox texbox =
-            CBox{m_monitor->m_transformedSize / 2.F, g_pHyprOpenGL->m_pScreencopyDeniedTexture->m_vSize}.translate(-g_pHyprOpenGL->m_pScreencopyDeniedTexture->m_vSize / 2.F);
-        g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_pScreencopyDeniedTexture, texbox, 1);
+            CBox{m_monitor->m_transformedSize / 2.F, g_pHyprOpenGL->m_screencopyDeniedTexture->m_size}.translate(-g_pHyprOpenGL->m_screencopyDeniedTexture->m_size / 2.F);
+        g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_screencopyDeniedTexture, texbox, 1);
     }
 
-    g_pHyprOpenGL->m_RenderData.blockScreenShader = true;
+    g_pHyprOpenGL->m_renderData.blockScreenShader = true;
 
     g_pHyprRenderer->endRender([callback]() {
         LOGM(TRACE, "Copied frame via dma");
@@ -262,8 +262,8 @@ bool CScreencopyFrame::copyShm() {
     else {
         g_pHyprOpenGL->clear(Colors::BLACK);
         CBox texbox =
-            CBox{m_monitor->m_transformedSize / 2.F, g_pHyprOpenGL->m_pScreencopyDeniedTexture->m_vSize}.translate(-g_pHyprOpenGL->m_pScreencopyDeniedTexture->m_vSize / 2.F);
-        g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_pScreencopyDeniedTexture, texbox, 1);
+            CBox{m_monitor->m_transformedSize / 2.F, g_pHyprOpenGL->m_screencopyDeniedTexture->m_size}.translate(-g_pHyprOpenGL->m_screencopyDeniedTexture->m_size / 2.F);
+        g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_screencopyDeniedTexture, texbox, 1);
     }
 
 #ifndef GLES2
@@ -281,11 +281,11 @@ bool CScreencopyFrame::copyShm() {
 
     auto glFormat = PFORMAT->flipRB ? GL_BGRA_EXT : GL_RGBA;
 
-    g_pHyprOpenGL->m_RenderData.blockScreenShader = true;
+    g_pHyprOpenGL->m_renderData.blockScreenShader = true;
     g_pHyprRenderer->endRender();
 
     g_pHyprRenderer->makeEGLCurrent();
-    g_pHyprOpenGL->m_RenderData.pMonitor = m_monitor;
+    g_pHyprOpenGL->m_renderData.pMonitor = m_monitor;
     fb.bind();
 
     glPixelStorei(GL_PACK_ALIGNMENT, 1);
@@ -304,7 +304,7 @@ bool CScreencopyFrame::copyShm() {
         }
     }
 
-    g_pHyprOpenGL->m_RenderData.pMonitor.reset();
+    g_pHyprOpenGL->m_renderData.pMonitor.reset();
 
 #ifndef GLES2
     glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
@@ -414,7 +414,7 @@ void CScreencopyProtocol::destroyResource(CScreencopyFrame* frame) {
 
 void CScreencopyProtocol::onOutputCommit(PHLMONITOR pMonitor) {
     if (m_framesAwaitingWrite.empty()) {
-        g_pHyprRenderer->m_bDirectScanoutBlocked = false;
+        g_pHyprRenderer->m_directScanoutBlocked = false;
         return; // nothing to share
     }
 

--- a/src/protocols/SinglePixel.cpp
+++ b/src/protocols/SinglePixel.cpp
@@ -16,7 +16,7 @@ CSinglePixelBuffer::CSinglePixelBuffer(uint32_t id, wl_client* client, CHyprColo
 
     m_resource = CWLBufferResource::create(makeShared<CWlBuffer>(client, 1, id));
 
-    m_success = m_texture->m_iTexID;
+    m_success = m_texture->m_texID;
 
     size = {1, 1};
 

--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -264,8 +264,7 @@ bool CToplevelExportFrame::copyShm(const Time::steady_tp& now) {
         if (overlayCursor)
             g_pPointerManager->renderSoftwareCursorsFor(PMONITOR->m_self.lock(), now, fakeDamage, g_pInputManager->getMouseCoordsInternal() - m_window->m_realPosition->value());
     } else if (PERM == PERMISSION_RULE_ALLOW_MODE_DENY) {
-        CBox texbox =
-            CBox{PMONITOR->m_transformedSize / 2.F, g_pHyprOpenGL->m_screencopyDeniedTexture->m_size}.translate(-g_pHyprOpenGL->m_screencopyDeniedTexture->m_size / 2.F);
+        CBox texbox = CBox{PMONITOR->m_transformedSize / 2.F, g_pHyprOpenGL->m_screencopyDeniedTexture->m_size}.translate(-g_pHyprOpenGL->m_screencopyDeniedTexture->m_size / 2.F);
         g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_screencopyDeniedTexture, texbox, 1);
     }
 
@@ -352,8 +351,7 @@ bool CToplevelExportFrame::copyDmabuf(const Time::steady_tp& now) {
         if (overlayCursor)
             g_pPointerManager->renderSoftwareCursorsFor(PMONITOR->m_self.lock(), now, fakeDamage, g_pInputManager->getMouseCoordsInternal() - m_window->m_realPosition->value());
     } else if (PERM == PERMISSION_RULE_ALLOW_MODE_DENY) {
-        CBox texbox =
-            CBox{PMONITOR->m_transformedSize / 2.F, g_pHyprOpenGL->m_screencopyDeniedTexture->m_size}.translate(-g_pHyprOpenGL->m_screencopyDeniedTexture->m_size / 2.F);
+        CBox texbox = CBox{PMONITOR->m_transformedSize / 2.F, g_pHyprOpenGL->m_screencopyDeniedTexture->m_size}.translate(-g_pHyprOpenGL->m_screencopyDeniedTexture->m_size / 2.F);
         g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_screencopyDeniedTexture, texbox, 1);
     }
 

--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -265,8 +265,8 @@ bool CToplevelExportFrame::copyShm(const Time::steady_tp& now) {
             g_pPointerManager->renderSoftwareCursorsFor(PMONITOR->m_self.lock(), now, fakeDamage, g_pInputManager->getMouseCoordsInternal() - m_window->m_realPosition->value());
     } else if (PERM == PERMISSION_RULE_ALLOW_MODE_DENY) {
         CBox texbox =
-            CBox{PMONITOR->m_transformedSize / 2.F, g_pHyprOpenGL->m_pScreencopyDeniedTexture->m_vSize}.translate(-g_pHyprOpenGL->m_pScreencopyDeniedTexture->m_vSize / 2.F);
-        g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_pScreencopyDeniedTexture, texbox, 1);
+            CBox{PMONITOR->m_transformedSize / 2.F, g_pHyprOpenGL->m_screencopyDeniedTexture->m_size}.translate(-g_pHyprOpenGL->m_screencopyDeniedTexture->m_size / 2.F);
+        g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_screencopyDeniedTexture, texbox, 1);
     }
 
     const auto PFORMAT = NFormatUtils::getPixelFormatFromDRM(shm.format);
@@ -275,11 +275,11 @@ bool CToplevelExportFrame::copyShm(const Time::steady_tp& now) {
         return false;
     }
 
-    g_pHyprOpenGL->m_RenderData.blockScreenShader = true;
+    g_pHyprOpenGL->m_renderData.blockScreenShader = true;
     g_pHyprRenderer->endRender();
 
     g_pHyprRenderer->makeEGLCurrent();
-    g_pHyprOpenGL->m_RenderData.pMonitor = PMONITOR;
+    g_pHyprOpenGL->m_renderData.pMonitor = PMONITOR;
     outFB.bind();
 
 #ifndef GLES2
@@ -353,11 +353,11 @@ bool CToplevelExportFrame::copyDmabuf(const Time::steady_tp& now) {
             g_pPointerManager->renderSoftwareCursorsFor(PMONITOR->m_self.lock(), now, fakeDamage, g_pInputManager->getMouseCoordsInternal() - m_window->m_realPosition->value());
     } else if (PERM == PERMISSION_RULE_ALLOW_MODE_DENY) {
         CBox texbox =
-            CBox{PMONITOR->m_transformedSize / 2.F, g_pHyprOpenGL->m_pScreencopyDeniedTexture->m_vSize}.translate(-g_pHyprOpenGL->m_pScreencopyDeniedTexture->m_vSize / 2.F);
-        g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_pScreencopyDeniedTexture, texbox, 1);
+            CBox{PMONITOR->m_transformedSize / 2.F, g_pHyprOpenGL->m_screencopyDeniedTexture->m_size}.translate(-g_pHyprOpenGL->m_screencopyDeniedTexture->m_size / 2.F);
+        g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_screencopyDeniedTexture, texbox, 1);
     }
 
-    g_pHyprOpenGL->m_RenderData.blockScreenShader = true;
+    g_pHyprOpenGL->m_renderData.blockScreenShader = true;
     g_pHyprRenderer->endRender();
 
     if (overlayCursor) {

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -495,7 +495,7 @@ void CWLSurfaceResource::commitState(SSurfaceState& state) {
     }
 
     if (m_current.texture)
-        m_current.texture->m_eTransform = wlTransformToHyprutils(m_current.transform);
+        m_current.texture->m_transform = wlTransformToHyprutils(m_current.transform);
 
     if (m_role->role() == SURFACE_ROLE_SUBSURFACE) {
         auto subsurface = ((CSubsurfaceRole*)m_role.get())->m_subsurface.lock();

--- a/src/protocols/core/DataDevice.cpp
+++ b/src/protocols/core/DataDevice.cpp
@@ -814,7 +814,7 @@ void CWLDataDeviceProtocol::renderDND(PHLMONITOR pMonitor, const Time::steady_tp
     CTexPassElement::SRenderData data;
     data.tex = m_dnd.dndSurface->m_current.texture;
     data.box = box;
-    g_pHyprRenderer->m_sRenderPass.add(makeShared<CTexPassElement>(data));
+    g_pHyprRenderer->m_renderPass.add(makeShared<CTexPassElement>(data));
 
     CBox damageBox = CBox{surfacePos, m_dnd.dndSurface->m_current.size}.expand(5);
     g_pHyprRenderer->damageBox(damageBox);

--- a/src/protocols/types/DMABuffer.cpp
+++ b/src/protocols/types/DMABuffer.cpp
@@ -37,7 +37,7 @@ CDMABuffer::CDMABuffer(uint32_t id, wl_client* client, Aquamarine::SDMABUFAttrs 
 
     m_texture = makeShared<CTexture>(m_attrs, eglImage); // texture takes ownership of the eglImage
     m_opaque  = NFormatUtils::isFormatOpaque(m_attrs.format);
-    m_success = m_texture->m_iTexID;
+    m_success = m_texture->m_texID;
 
     if UNLIKELY (!m_success)
         Debug::log(ERR, "Failed to create a dmabuf: texture is null");

--- a/src/protocols/types/SurfaceState.cpp
+++ b/src/protocols/types/SurfaceState.cpp
@@ -39,7 +39,7 @@ void SSurfaceState::updateSynchronousTexture(SP<CTexture> lastTexture) {
     if (dataPtr) {
         auto drmFmt = NFormatUtils::shmToDRM(fmt);
         auto stride = bufferSize.y ? size / bufferSize.y : 0;
-        if (lastTexture && lastTexture->m_isSynchronous && lastTexture->m_vSize == bufferSize) {
+        if (lastTexture && lastTexture->m_isSynchronous && lastTexture->m_size == bufferSize) {
             texture = lastTexture;
             texture->update(drmFmt, dataPtr, stride, accumulateBufferDamage());
         } else

--- a/src/render/Framebuffer.cpp
+++ b/src/render/Framebuffer.cpp
@@ -12,10 +12,10 @@ bool CFramebuffer::alloc(int w, int h, uint32_t drmFormat) {
     uint32_t glFormat = NFormatUtils::drmFormatToGL(drmFormat);
     uint32_t glType   = NFormatUtils::glFormatToType(glFormat);
 
-    if (!m_cTex) {
-        m_cTex = makeShared<CTexture>();
-        m_cTex->allocate();
-        glBindTexture(GL_TEXTURE_2D, m_cTex->m_iTexID);
+    if (!m_tex) {
+        m_tex = makeShared<CTexture>();
+        m_tex->allocate();
+        glBindTexture(GL_TEXTURE_2D, m_tex->m_texID);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
@@ -23,24 +23,24 @@ bool CFramebuffer::alloc(int w, int h, uint32_t drmFormat) {
         firstAlloc = true;
     }
 
-    if (!m_iFbAllocated) {
-        glGenFramebuffers(1, &m_iFb);
-        m_iFbAllocated = true;
-        firstAlloc     = true;
+    if (!m_fbAllocated) {
+        glGenFramebuffers(1, &m_fb);
+        m_fbAllocated = true;
+        firstAlloc    = true;
     }
 
-    if (firstAlloc || m_vSize != Vector2D(w, h)) {
-        glBindTexture(GL_TEXTURE_2D, m_cTex->m_iTexID);
+    if (firstAlloc || m_size != Vector2D(w, h)) {
+        glBindTexture(GL_TEXTURE_2D, m_tex->m_texID);
         glTexImage2D(GL_TEXTURE_2D, 0, glFormat, w, h, 0, GL_RGBA, glType, nullptr);
-        glBindFramebuffer(GL_FRAMEBUFFER, m_iFb);
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_cTex->m_iTexID, 0);
+        glBindFramebuffer(GL_FRAMEBUFFER, m_fb);
+        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_tex->m_texID, 0);
 
 // TODO: Allow this with gles2
 #ifndef GLES2
-        if (m_pStencilTex) {
-            glBindTexture(GL_TEXTURE_2D, m_pStencilTex->m_iTexID);
+        if (m_stencilTex) {
+            glBindTexture(GL_TEXTURE_2D, m_stencilTex->m_texID);
             glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH24_STENCIL8, w, h, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, nullptr);
-            glFramebufferTexture2D(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, m_pStencilTex->m_iTexID, 0);
+            glFramebufferTexture2D(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, m_stencilTex->m_texID, 0);
         }
 #endif
 
@@ -53,7 +53,7 @@ bool CFramebuffer::alloc(int w, int h, uint32_t drmFormat) {
     glBindTexture(GL_TEXTURE_2D, 0);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
-    m_vSize = Vector2D(w, h);
+    m_size = Vector2D(w, h);
 
     return true;
 }
@@ -61,13 +61,13 @@ bool CFramebuffer::alloc(int w, int h, uint32_t drmFormat) {
 void CFramebuffer::addStencil(SP<CTexture> tex) {
     // TODO: Allow this with gles2
 #ifndef GLES2
-    m_pStencilTex = tex;
-    glBindTexture(GL_TEXTURE_2D, m_pStencilTex->m_iTexID);
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH24_STENCIL8, m_vSize.x, m_vSize.y, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, nullptr);
+    m_stencilTex = tex;
+    glBindTexture(GL_TEXTURE_2D, m_stencilTex->m_texID);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH24_STENCIL8, m_size.x, m_size.y, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, nullptr);
 
-    glBindFramebuffer(GL_FRAMEBUFFER, m_iFb);
+    glBindFramebuffer(GL_FRAMEBUFFER, m_fb);
 
-    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, m_pStencilTex->m_iTexID, 0);
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, m_stencilTex->m_texID, 0);
 
     auto status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
     RASSERT((status == GL_FRAMEBUFFER_COMPLETE), "Failed adding a stencil to fbo!", status);
@@ -79,15 +79,15 @@ void CFramebuffer::addStencil(SP<CTexture> tex) {
 
 void CFramebuffer::bind() {
 #ifndef GLES2
-    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_iFb);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_fb);
 #else
     glBindFramebuffer(GL_FRAMEBUFFER, m_iFb);
 #endif
 
     if (g_pHyprOpenGL)
-        glViewport(0, 0, g_pHyprOpenGL->m_RenderData.pMonitor->m_pixelSize.x, g_pHyprOpenGL->m_RenderData.pMonitor->m_pixelSize.y);
+        glViewport(0, 0, g_pHyprOpenGL->m_renderData.pMonitor->m_pixelSize.x, g_pHyprOpenGL->m_renderData.pMonitor->m_pixelSize.y);
     else
-        glViewport(0, 0, m_vSize.x, m_vSize.y);
+        glViewport(0, 0, m_size.x, m_size.y);
 }
 
 void CFramebuffer::unbind() {
@@ -99,20 +99,20 @@ void CFramebuffer::unbind() {
 }
 
 void CFramebuffer::release() {
-    if (m_iFbAllocated) {
-        glBindFramebuffer(GL_FRAMEBUFFER, m_iFb);
+    if (m_fbAllocated) {
+        glBindFramebuffer(GL_FRAMEBUFFER, m_fb);
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
-        glDeleteFramebuffers(1, &m_iFb);
-        m_iFbAllocated = false;
-        m_iFb          = 0;
+        glDeleteFramebuffers(1, &m_fb);
+        m_fbAllocated = false;
+        m_fb          = 0;
     }
 
-    if (m_cTex)
-        m_cTex.reset();
+    if (m_tex)
+        m_tex.reset();
 
-    m_vSize = Vector2D();
+    m_size = Vector2D();
 }
 
 CFramebuffer::~CFramebuffer() {
@@ -120,17 +120,17 @@ CFramebuffer::~CFramebuffer() {
 }
 
 bool CFramebuffer::isAllocated() {
-    return m_iFbAllocated && m_cTex;
+    return m_fbAllocated && m_tex;
 }
 
 SP<CTexture> CFramebuffer::getTexture() {
-    return m_cTex;
+    return m_tex;
 }
 
 GLuint CFramebuffer::getFBID() {
-    return m_iFbAllocated ? m_iFb : 0;
+    return m_fbAllocated ? m_fb : 0;
 }
 
 SP<CTexture> CFramebuffer::getStencilTex() {
-    return m_pStencilTex;
+    return m_stencilTex;
 }

--- a/src/render/Framebuffer.hpp
+++ b/src/render/Framebuffer.hpp
@@ -19,14 +19,14 @@ class CFramebuffer {
     SP<CTexture> getStencilTex();
     GLuint       getFBID();
 
-    Vector2D     m_vSize;
+    Vector2D     m_size;
 
   private:
-    SP<CTexture> m_cTex;
-    GLuint       m_iFb          = -1;
-    bool         m_iFbAllocated = false;
+    SP<CTexture> m_tex;
+    GLuint       m_fb          = -1;
+    bool         m_fbAllocated = false;
 
-    SP<CTexture> m_pStencilTex;
+    SP<CTexture> m_stencilTex;
 
     friend class CRenderbuffer;
 };

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -124,37 +124,37 @@ static int openRenderNode(int drmFd) {
 
 void CHyprOpenGLImpl::initEGL(bool gbm) {
     std::vector<EGLint> attrs;
-    if (m_sExts.KHR_display_reference) {
+    if (m_exts.KHR_display_reference) {
         attrs.push_back(EGL_TRACK_REFERENCES_KHR);
         attrs.push_back(EGL_TRUE);
     }
 
     attrs.push_back(EGL_NONE);
 
-    m_pEglDisplay = m_sProc.eglGetPlatformDisplayEXT(gbm ? EGL_PLATFORM_GBM_KHR : EGL_PLATFORM_DEVICE_EXT, gbm ? m_pGbmDevice : m_pEglDevice, attrs.data());
-    if (m_pEglDisplay == EGL_NO_DISPLAY)
+    m_eglDisplay = m_proc.eglGetPlatformDisplayEXT(gbm ? EGL_PLATFORM_GBM_KHR : EGL_PLATFORM_DEVICE_EXT, gbm ? m_gbmDevice : m_eglDevice, attrs.data());
+    if (m_eglDisplay == EGL_NO_DISPLAY)
         RASSERT(false, "EGL: failed to create a platform display");
 
     attrs.clear();
 
     EGLint major, minor;
-    if (eglInitialize(m_pEglDisplay, &major, &minor) == EGL_FALSE)
+    if (eglInitialize(m_eglDisplay, &major, &minor) == EGL_FALSE)
         RASSERT(false, "EGL: failed to initialize a platform display");
 
-    const std::string EGLEXTENSIONS = (const char*)eglQueryString(m_pEglDisplay, EGL_EXTENSIONS);
+    const std::string EGLEXTENSIONS = (const char*)eglQueryString(m_eglDisplay, EGL_EXTENSIONS);
 
-    m_sExts.IMG_context_priority               = EGLEXTENSIONS.contains("IMG_context_priority");
-    m_sExts.EXT_create_context_robustness      = EGLEXTENSIONS.contains("EXT_create_context_robustness");
-    m_sExts.EXT_image_dma_buf_import           = EGLEXTENSIONS.contains("EXT_image_dma_buf_import");
-    m_sExts.EXT_image_dma_buf_import_modifiers = EGLEXTENSIONS.contains("EXT_image_dma_buf_import_modifiers");
+    m_exts.IMG_context_priority               = EGLEXTENSIONS.contains("IMG_context_priority");
+    m_exts.EXT_create_context_robustness      = EGLEXTENSIONS.contains("EXT_create_context_robustness");
+    m_exts.EXT_image_dma_buf_import           = EGLEXTENSIONS.contains("EXT_image_dma_buf_import");
+    m_exts.EXT_image_dma_buf_import_modifiers = EGLEXTENSIONS.contains("EXT_image_dma_buf_import_modifiers");
 
-    if (m_sExts.IMG_context_priority) {
+    if (m_exts.IMG_context_priority) {
         Debug::log(LOG, "EGL: IMG_context_priority supported, requesting high");
         attrs.push_back(EGL_CONTEXT_PRIORITY_LEVEL_IMG);
         attrs.push_back(EGL_CONTEXT_PRIORITY_HIGH_IMG);
     }
 
-    if (m_sExts.EXT_create_context_robustness) {
+    if (m_exts.EXT_create_context_robustness) {
         Debug::log(LOG, "EGL: EXT_create_context_robustness supported, requesting lose on reset");
         attrs.push_back(EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY_EXT);
         attrs.push_back(EGL_LOSE_CONTEXT_ON_RESET_EXT);
@@ -175,8 +175,8 @@ void CHyprOpenGLImpl::initEGL(bool gbm) {
 
     attrs.push_back(EGL_NONE);
 
-    m_pEglContext = eglCreateContext(m_pEglDisplay, EGL_NO_CONFIG_KHR, EGL_NO_CONTEXT, attrs.data());
-    if (m_pEglContext == EGL_NO_CONTEXT) {
+    m_eglContext = eglCreateContext(m_eglDisplay, EGL_NO_CONFIG_KHR, EGL_NO_CONTEXT, attrs.data());
+    if (m_eglContext == EGL_NO_CONTEXT) {
 #ifdef GLES2
         RASSERT(false, "EGL: failed to create a context with GLES2.0");
 #endif
@@ -189,23 +189,23 @@ void CHyprOpenGLImpl::initEGL(bool gbm) {
         attrs.push_back(0);
         attrs.push_back(EGL_NONE);
 
-        m_pEglContext       = eglCreateContext(m_pEglDisplay, EGL_NO_CONFIG_KHR, EGL_NO_CONTEXT, attrs.data());
+        m_eglContext        = eglCreateContext(m_eglDisplay, EGL_NO_CONFIG_KHR, EGL_NO_CONTEXT, attrs.data());
         m_eglContextVersion = EGL_CONTEXT_GLES_3_0;
 
-        if (m_pEglContext == EGL_NO_CONTEXT)
+        if (m_eglContext == EGL_NO_CONTEXT)
             RASSERT(false, "EGL: failed to create a context with either GLES3.2 or 3.0");
     }
 
-    if (m_sExts.IMG_context_priority) {
+    if (m_exts.IMG_context_priority) {
         EGLint priority = EGL_CONTEXT_PRIORITY_MEDIUM_IMG;
-        eglQueryContext(m_pEglDisplay, m_pEglContext, EGL_CONTEXT_PRIORITY_LEVEL_IMG, &priority);
+        eglQueryContext(m_eglDisplay, m_eglContext, EGL_CONTEXT_PRIORITY_LEVEL_IMG, &priority);
         if (priority != EGL_CONTEXT_PRIORITY_HIGH_IMG)
             Debug::log(ERR, "EGL: Failed to obtain a high priority context");
         else
             Debug::log(LOG, "EGL: Got a high priority context");
     }
 
-    eglMakeCurrent(m_pEglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, m_pEglContext);
+    eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, m_eglContext);
 }
 
 static bool drmDeviceHasName(const drmDevice* device, const std::string& name) {
@@ -221,7 +221,7 @@ static bool drmDeviceHasName(const drmDevice* device, const std::string& name) {
 
 EGLDeviceEXT CHyprOpenGLImpl::eglDeviceFromDRMFD(int drmFD) {
     EGLint nDevices = 0;
-    if (!m_sProc.eglQueryDevicesEXT(0, nullptr, &nDevices)) {
+    if (!m_proc.eglQueryDevicesEXT(0, nullptr, &nDevices)) {
         Debug::log(ERR, "eglDeviceFromDRMFD: eglQueryDevicesEXT failed");
         return EGL_NO_DEVICE_EXT;
     }
@@ -234,7 +234,7 @@ EGLDeviceEXT CHyprOpenGLImpl::eglDeviceFromDRMFD(int drmFD) {
     std::vector<EGLDeviceEXT> devices;
     devices.resize(nDevices);
 
-    if (!m_sProc.eglQueryDevicesEXT(nDevices, devices.data(), &nDevices)) {
+    if (!m_proc.eglQueryDevicesEXT(nDevices, devices.data(), &nDevices)) {
         Debug::log(ERR, "eglDeviceFromDRMFD: eglQueryDevicesEXT failed (2)");
         return EGL_NO_DEVICE_EXT;
     }
@@ -246,7 +246,7 @@ EGLDeviceEXT CHyprOpenGLImpl::eglDeviceFromDRMFD(int drmFD) {
     }
 
     for (auto const& d : devices) {
-        auto devName = m_sProc.eglQueryDeviceStringEXT(d, EGL_DRM_DEVICE_FILE_EXT);
+        auto devName = m_proc.eglQueryDeviceStringEXT(d, EGL_DRM_DEVICE_FILE_EXT);
         if (!devName)
             continue;
 
@@ -262,53 +262,53 @@ EGLDeviceEXT CHyprOpenGLImpl::eglDeviceFromDRMFD(int drmFD) {
     return EGL_NO_DEVICE_EXT;
 }
 
-CHyprOpenGLImpl::CHyprOpenGLImpl() : m_iDRMFD(g_pCompositor->m_drmFD) {
+CHyprOpenGLImpl::CHyprOpenGLImpl() : m_drmFD(g_pCompositor->m_drmFD) {
     const std::string EGLEXTENSIONS = (const char*)eglQueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS);
 
     Debug::log(LOG, "Supported EGL extensions: ({}) {}", std::count(EGLEXTENSIONS.begin(), EGLEXTENSIONS.end(), ' '), EGLEXTENSIONS);
 
-    m_sExts.KHR_display_reference = EGLEXTENSIONS.contains("KHR_display_reference");
+    m_exts.KHR_display_reference = EGLEXTENSIONS.contains("KHR_display_reference");
 
-    loadGLProc(&m_sProc.glEGLImageTargetRenderbufferStorageOES, "glEGLImageTargetRenderbufferStorageOES");
-    loadGLProc(&m_sProc.eglCreateImageKHR, "eglCreateImageKHR");
-    loadGLProc(&m_sProc.eglDestroyImageKHR, "eglDestroyImageKHR");
-    loadGLProc(&m_sProc.eglQueryDmaBufFormatsEXT, "eglQueryDmaBufFormatsEXT");
-    loadGLProc(&m_sProc.eglQueryDmaBufModifiersEXT, "eglQueryDmaBufModifiersEXT");
-    loadGLProc(&m_sProc.glEGLImageTargetTexture2DOES, "glEGLImageTargetTexture2DOES");
-    loadGLProc(&m_sProc.eglDebugMessageControlKHR, "eglDebugMessageControlKHR");
-    loadGLProc(&m_sProc.eglGetPlatformDisplayEXT, "eglGetPlatformDisplayEXT");
-    loadGLProc(&m_sProc.eglCreateSyncKHR, "eglCreateSyncKHR");
-    loadGLProc(&m_sProc.eglDestroySyncKHR, "eglDestroySyncKHR");
-    loadGLProc(&m_sProc.eglDupNativeFenceFDANDROID, "eglDupNativeFenceFDANDROID");
-    loadGLProc(&m_sProc.eglWaitSyncKHR, "eglWaitSyncKHR");
+    loadGLProc(&m_proc.glEGLImageTargetRenderbufferStorageOES, "glEGLImageTargetRenderbufferStorageOES");
+    loadGLProc(&m_proc.eglCreateImageKHR, "eglCreateImageKHR");
+    loadGLProc(&m_proc.eglDestroyImageKHR, "eglDestroyImageKHR");
+    loadGLProc(&m_proc.eglQueryDmaBufFormatsEXT, "eglQueryDmaBufFormatsEXT");
+    loadGLProc(&m_proc.eglQueryDmaBufModifiersEXT, "eglQueryDmaBufModifiersEXT");
+    loadGLProc(&m_proc.glEGLImageTargetTexture2DOES, "glEGLImageTargetTexture2DOES");
+    loadGLProc(&m_proc.eglDebugMessageControlKHR, "eglDebugMessageControlKHR");
+    loadGLProc(&m_proc.eglGetPlatformDisplayEXT, "eglGetPlatformDisplayEXT");
+    loadGLProc(&m_proc.eglCreateSyncKHR, "eglCreateSyncKHR");
+    loadGLProc(&m_proc.eglDestroySyncKHR, "eglDestroySyncKHR");
+    loadGLProc(&m_proc.eglDupNativeFenceFDANDROID, "eglDupNativeFenceFDANDROID");
+    loadGLProc(&m_proc.eglWaitSyncKHR, "eglWaitSyncKHR");
 
-    RASSERT(m_sProc.eglCreateSyncKHR, "Display driver doesn't support eglCreateSyncKHR");
-    RASSERT(m_sProc.eglDupNativeFenceFDANDROID, "Display driver doesn't support eglDupNativeFenceFDANDROID");
-    RASSERT(m_sProc.eglWaitSyncKHR, "Display driver doesn't support eglWaitSyncKHR");
+    RASSERT(m_proc.eglCreateSyncKHR, "Display driver doesn't support eglCreateSyncKHR");
+    RASSERT(m_proc.eglDupNativeFenceFDANDROID, "Display driver doesn't support eglDupNativeFenceFDANDROID");
+    RASSERT(m_proc.eglWaitSyncKHR, "Display driver doesn't support eglWaitSyncKHR");
 
     if (EGLEXTENSIONS.contains("EGL_EXT_device_base") || EGLEXTENSIONS.contains("EGL_EXT_device_enumeration"))
-        loadGLProc(&m_sProc.eglQueryDevicesEXT, "eglQueryDevicesEXT");
+        loadGLProc(&m_proc.eglQueryDevicesEXT, "eglQueryDevicesEXT");
 
     if (EGLEXTENSIONS.contains("EGL_EXT_device_base") || EGLEXTENSIONS.contains("EGL_EXT_device_query")) {
-        loadGLProc(&m_sProc.eglQueryDeviceStringEXT, "eglQueryDeviceStringEXT");
-        loadGLProc(&m_sProc.eglQueryDisplayAttribEXT, "eglQueryDisplayAttribEXT");
+        loadGLProc(&m_proc.eglQueryDeviceStringEXT, "eglQueryDeviceStringEXT");
+        loadGLProc(&m_proc.eglQueryDisplayAttribEXT, "eglQueryDisplayAttribEXT");
     }
 
     if (EGLEXTENSIONS.contains("EGL_KHR_debug")) {
-        loadGLProc(&m_sProc.eglDebugMessageControlKHR, "eglDebugMessageControlKHR");
+        loadGLProc(&m_proc.eglDebugMessageControlKHR, "eglDebugMessageControlKHR");
         static const EGLAttrib debugAttrs[] = {
             EGL_DEBUG_MSG_CRITICAL_KHR, EGL_TRUE, EGL_DEBUG_MSG_ERROR_KHR, EGL_TRUE, EGL_DEBUG_MSG_WARN_KHR, EGL_TRUE, EGL_DEBUG_MSG_INFO_KHR, EGL_TRUE, EGL_NONE,
         };
-        m_sProc.eglDebugMessageControlKHR(::eglLog, debugAttrs);
+        m_proc.eglDebugMessageControlKHR(::eglLog, debugAttrs);
     }
 
     RASSERT(eglBindAPI(EGL_OPENGL_ES_API) != EGL_FALSE, "Couldn't bind to EGL's opengl ES API. This means your gpu driver f'd up. This is not a hyprland issue.");
 
     bool success = false;
-    if (EGLEXTENSIONS.contains("EXT_platform_device") || !m_sProc.eglQueryDevicesEXT || !m_sProc.eglQueryDeviceStringEXT) {
-        m_pEglDevice = eglDeviceFromDRMFD(m_iDRMFD);
+    if (EGLEXTENSIONS.contains("EXT_platform_device") || !m_proc.eglQueryDevicesEXT || !m_proc.eglQueryDeviceStringEXT) {
+        m_eglDevice = eglDeviceFromDRMFD(m_drmFD);
 
-        if (m_pEglDevice != EGL_NO_DEVICE_EXT) {
+        if (m_eglDevice != EGL_NO_DEVICE_EXT) {
             success = true;
             initEGL(false);
         }
@@ -317,13 +317,13 @@ CHyprOpenGLImpl::CHyprOpenGLImpl() : m_iDRMFD(g_pCompositor->m_drmFD) {
     if (!success) {
         Debug::log(WARN, "EGL: EXT_platform_device or EGL_EXT_device_query not supported, using gbm");
         if (EGLEXTENSIONS.contains("KHR_platform_gbm")) {
-            success  = true;
-            m_iGBMFD = CFileDescriptor{openRenderNode(m_iDRMFD)};
-            if (!m_iGBMFD.isValid())
+            success = true;
+            m_gbmFD = CFileDescriptor{openRenderNode(m_drmFD)};
+            if (!m_gbmFD.isValid())
                 RASSERT(false, "Couldn't open a gbm fd");
 
-            m_pGbmDevice = gbm_create_device(m_iGBMFD.get());
-            if (!m_pGbmDevice)
+            m_gbmDevice = gbm_create_device(m_gbmFD.get());
+            if (!m_gbmDevice)
                 RASSERT(false, "Couldn't open a gbm device");
 
             initEGL(true);
@@ -335,21 +335,21 @@ CHyprOpenGLImpl::CHyprOpenGLImpl() : m_iDRMFD(g_pCompositor->m_drmFD) {
     auto* const EXTENSIONS = (const char*)glGetString(GL_EXTENSIONS);
     RASSERT(EXTENSIONS, "Couldn't retrieve openGL extensions!");
 
-    m_szExtensions = EXTENSIONS;
+    m_extensions = EXTENSIONS;
 
     Debug::log(LOG, "Creating the Hypr OpenGL Renderer!");
     Debug::log(LOG, "Using: {}", (char*)glGetString(GL_VERSION));
     Debug::log(LOG, "Vendor: {}", (char*)glGetString(GL_VENDOR));
     Debug::log(LOG, "Renderer: {}", (char*)glGetString(GL_RENDERER));
-    Debug::log(LOG, "Supported extensions: ({}) {}", std::count(m_szExtensions.begin(), m_szExtensions.end(), ' '), m_szExtensions);
+    Debug::log(LOG, "Supported extensions: ({}) {}", std::count(m_extensions.begin(), m_extensions.end(), ' '), m_extensions);
 
-    m_sExts.EXT_read_format_bgra = m_szExtensions.contains("GL_EXT_read_format_bgra");
+    m_exts.EXT_read_format_bgra = m_extensions.contains("GL_EXT_read_format_bgra");
 
-    RASSERT(m_szExtensions.contains("GL_EXT_texture_format_BGRA8888"), "GL_EXT_texture_format_BGRA8888 support by the GPU driver is required");
+    RASSERT(m_extensions.contains("GL_EXT_texture_format_BGRA8888"), "GL_EXT_texture_format_BGRA8888 support by the GPU driver is required");
 
-    if (!m_sExts.EXT_read_format_bgra)
+    if (!m_exts.EXT_read_format_bgra)
         Debug::log(WARN, "Your GPU does not support GL_EXT_read_format_bgra, this may cause issues with texture importing");
-    if (!m_sExts.EXT_image_dma_buf_import || !m_sExts.EXT_image_dma_buf_import_modifiers)
+    if (!m_exts.EXT_image_dma_buf_import || !m_exts.EXT_image_dma_buf_import_modifiers)
         Debug::log(WARN, "Your GPU does not support DMABUFs, this will possibly cause issues and will take a hit on the performance.");
 
 #ifdef USE_TRACY_GPU
@@ -372,32 +372,32 @@ CHyprOpenGLImpl::CHyprOpenGLImpl() : m_iDRMFD(g_pCompositor->m_drmFD) {
 
     static auto P = g_pHookSystem->hookDynamic("preRender", [&](void* self, SCallbackInfo& info, std::any data) { preRender(std::any_cast<PHLMONITOR>(data)); });
 
-    RASSERT(eglMakeCurrent(m_pEglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT), "Couldn't unset current EGL!");
+    RASSERT(eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT), "Couldn't unset current EGL!");
 
-    m_tGlobalTimer.reset();
+    m_globalTimer.reset();
 }
 
 CHyprOpenGLImpl::~CHyprOpenGLImpl() {
-    if (m_pEglDisplay && m_pEglContext != EGL_NO_CONTEXT)
-        eglDestroyContext(m_pEglDisplay, m_pEglContext);
+    if (m_eglDisplay && m_eglContext != EGL_NO_CONTEXT)
+        eglDestroyContext(m_eglDisplay, m_eglContext);
 
-    if (m_pEglDisplay)
-        eglTerminate(m_pEglDisplay);
+    if (m_eglDisplay)
+        eglTerminate(m_eglDisplay);
 
     eglReleaseThread();
 
-    if (m_pGbmDevice)
-        gbm_device_destroy(m_pGbmDevice);
+    if (m_gbmDevice)
+        gbm_device_destroy(m_gbmDevice);
 }
 
 std::optional<std::vector<uint64_t>> CHyprOpenGLImpl::getModsForFormat(EGLint format) {
     // TODO: return std::expected when clang supports it
 
-    if (!m_sExts.EXT_image_dma_buf_import_modifiers)
+    if (!m_exts.EXT_image_dma_buf_import_modifiers)
         return std::nullopt;
 
     EGLint len = 0;
-    if (!m_sProc.eglQueryDmaBufModifiersEXT(m_pEglDisplay, format, 0, nullptr, nullptr, &len)) {
+    if (!m_proc.eglQueryDmaBufModifiersEXT(m_eglDisplay, format, 0, nullptr, nullptr, &len)) {
         Debug::log(ERR, "EGL: Failed to query mods");
         return std::nullopt;
     }
@@ -411,7 +411,7 @@ std::optional<std::vector<uint64_t>> CHyprOpenGLImpl::getModsForFormat(EGLint fo
     mods.resize(len);
     external.resize(len);
 
-    m_sProc.eglQueryDmaBufModifiersEXT(m_pEglDisplay, format, len, mods.data(), external.data(), &len);
+    m_proc.eglQueryDmaBufModifiersEXT(m_eglDisplay, format, len, mods.data(), external.data(), &len);
 
     std::vector<uint64_t> result;
     // reserve number of elements to avoid reallocations
@@ -440,22 +440,22 @@ void CHyprOpenGLImpl::initDRMFormats() {
     if (DISABLE_MODS)
         Debug::log(WARN, "HYPRLAND_EGL_NO_MODIFIERS set, disabling modifiers");
 
-    if (!m_sExts.EXT_image_dma_buf_import) {
+    if (!m_exts.EXT_image_dma_buf_import) {
         Debug::log(ERR, "EGL: No dmabuf import, DMABufs will not work.");
         return;
     }
 
     std::vector<EGLint> formats;
 
-    if (!m_sExts.EXT_image_dma_buf_import_modifiers || !m_sProc.eglQueryDmaBufFormatsEXT) {
+    if (!m_exts.EXT_image_dma_buf_import_modifiers || !m_proc.eglQueryDmaBufFormatsEXT) {
         formats.push_back(DRM_FORMAT_ARGB8888);
         formats.push_back(DRM_FORMAT_XRGB8888);
         Debug::log(WARN, "EGL: No mod support");
     } else {
         EGLint len = 0;
-        m_sProc.eglQueryDmaBufFormatsEXT(m_pEglDisplay, 0, nullptr, &len);
+        m_proc.eglQueryDmaBufFormatsEXT(m_eglDisplay, 0, nullptr, &len);
         formats.resize(len);
-        m_sProc.eglQueryDmaBufFormatsEXT(m_pEglDisplay, len, formats.data(), &len);
+        m_proc.eglQueryDmaBufFormatsEXT(m_eglDisplay, len, formats.data(), &len);
     }
 
     if (formats.size() == 0) {
@@ -480,7 +480,7 @@ void CHyprOpenGLImpl::initDRMFormats() {
         } else
             mods = {DRM_FORMAT_MOD_LINEAR};
 
-        m_bHasModifiers = m_bHasModifiers || mods.size() > 0;
+        m_hasModifiers = m_hasModifiers || mods.size() > 0;
 
         // EGL can always do implicit modifiers.
         mods.push_back(DRM_FORMAT_MOD_INVALID);
@@ -524,7 +524,7 @@ void CHyprOpenGLImpl::initDRMFormats() {
         Debug::log(WARN,
                    "EGL: WARNING: No dmabuf formats were found, dmabuf will be disabled. This will degrade performance, but is most likely a driver issue or a very old GPU.");
 
-    drmFormats = dmaFormats;
+    m_drmFormats = dmaFormats;
 }
 
 EGLImageKHR CHyprOpenGLImpl::createEGLImage(const Aquamarine::SDMABUFAttrs& attrs) {
@@ -556,7 +556,7 @@ EGLImageKHR CHyprOpenGLImpl::createEGLImage(const Aquamarine::SDMABUFAttrs& attr
         attribs.push_back(attrs.offsets[i]);
         attribs.push_back(attrNames[i].pitch);
         attribs.push_back(attrs.strides[i]);
-        if (m_bHasModifiers && attrs.modifier != DRM_FORMAT_MOD_INVALID) {
+        if (m_hasModifiers && attrs.modifier != DRM_FORMAT_MOD_INVALID) {
             attribs.push_back(attrNames[i].modlo);
             attribs.push_back(attrs.modifier & 0xFFFFFFFF);
             attribs.push_back(attrNames[i].modhi);
@@ -569,7 +569,7 @@ EGLImageKHR CHyprOpenGLImpl::createEGLImage(const Aquamarine::SDMABUFAttrs& attr
 
     attribs.push_back(EGL_NONE);
 
-    EGLImageKHR image = m_sProc.eglCreateImageKHR(m_pEglDisplay, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, (int*)attribs.data());
+    EGLImageKHR image = m_proc.eglCreateImageKHR(m_eglDisplay, EGL_NO_CONTEXT, EGL_LINUX_DMA_BUF_EXT, nullptr, (int*)attribs.data());
     if (image == EGL_NO_IMAGE_KHR) {
         Debug::log(ERR, "EGL: EGLCreateImageKHR failed: {}", eglGetError());
         return EGL_NO_IMAGE_KHR;
@@ -667,7 +667,7 @@ GLuint CHyprOpenGLImpl::compileShader(const GLuint& type, std::string src, bool 
 }
 
 void CHyprOpenGLImpl::beginSimple(PHLMONITOR pMonitor, const CRegion& damage, SP<CRenderbuffer> rb, CFramebuffer* fb) {
-    m_RenderData.pMonitor = pMonitor;
+    m_renderData.pMonitor = pMonitor;
 
 #ifndef GLES2
     const GLenum RESETSTATUS = glGetGraphicsResetStatus();
@@ -690,36 +690,36 @@ void CHyprOpenGLImpl::beginSimple(PHLMONITOR pMonitor, const CRegion& damage, SP
 
     glViewport(0, 0, pMonitor->m_pixelSize.x, pMonitor->m_pixelSize.y);
 
-    m_RenderData.projection = Mat3x3::outputProjection(pMonitor->m_pixelSize, HYPRUTILS_TRANSFORM_NORMAL);
+    m_renderData.projection = Mat3x3::outputProjection(pMonitor->m_pixelSize, HYPRUTILS_TRANSFORM_NORMAL);
 
-    m_RenderData.monitorProjection = Mat3x3::identity();
+    m_renderData.monitorProjection = Mat3x3::identity();
     if (pMonitor->m_transform != WL_OUTPUT_TRANSFORM_NORMAL) {
-        const Vector2D tfmd = pMonitor->m_transform % 2 == 1 ? Vector2D{FBO->m_vSize.y, FBO->m_vSize.x} : FBO->m_vSize;
-        m_RenderData.monitorProjection.translate(FBO->m_vSize / 2.0).transform(wlTransformToHyprutils(pMonitor->m_transform)).translate(-tfmd / 2.0);
+        const Vector2D tfmd = pMonitor->m_transform % 2 == 1 ? Vector2D{FBO->m_size.y, FBO->m_size.x} : FBO->m_size;
+        m_renderData.monitorProjection.translate(FBO->m_size / 2.0).transform(wlTransformToHyprutils(pMonitor->m_transform)).translate(-tfmd / 2.0);
     }
 
-    m_RenderData.pCurrentMonData = &m_mMonitorRenderResources[pMonitor];
+    m_renderData.pCurrentMonData = &m_monitorRenderResources[pMonitor];
 
-    if (!m_bShadersInitialized)
+    if (!m_shadersInitialized)
         initShaders();
 
-    m_RenderData.damage.set(damage);
-    m_RenderData.finalDamage.set(damage);
+    m_renderData.damage.set(damage);
+    m_renderData.finalDamage.set(damage);
 
-    m_bFakeFrame = true;
+    m_fakeFrame = true;
 
-    m_RenderData.currentFB = FBO;
+    m_renderData.currentFB = FBO;
     FBO->bind();
-    m_bOffloadedFramebuffer = false;
+    m_offloadedFramebuffer = false;
 
-    m_RenderData.mainFB = m_RenderData.currentFB;
-    m_RenderData.outFB  = FBO;
+    m_renderData.mainFB = m_renderData.currentFB;
+    m_renderData.outFB  = FBO;
 
-    m_RenderData.simplePass = true;
+    m_renderData.simplePass = true;
 }
 
 void CHyprOpenGLImpl::begin(PHLMONITOR pMonitor, const CRegion& damage_, CFramebuffer* fb, std::optional<CRegion> finalDamage) {
-    m_RenderData.pMonitor = pMonitor;
+    m_renderData.pMonitor = pMonitor;
 
 #ifndef GLES2
     const GLenum RESETSTATUS = glGetGraphicsResetStatus();
@@ -740,51 +740,51 @@ void CHyprOpenGLImpl::begin(PHLMONITOR pMonitor, const CRegion& damage_, CFrameb
 
     glViewport(0, 0, pMonitor->m_pixelSize.x, pMonitor->m_pixelSize.y);
 
-    m_RenderData.projection = Mat3x3::outputProjection(pMonitor->m_pixelSize, HYPRUTILS_TRANSFORM_NORMAL);
+    m_renderData.projection = Mat3x3::outputProjection(pMonitor->m_pixelSize, HYPRUTILS_TRANSFORM_NORMAL);
 
-    m_RenderData.monitorProjection = pMonitor->m_projMatrix;
+    m_renderData.monitorProjection = pMonitor->m_projMatrix;
 
-    if (m_mMonitorRenderResources.contains(pMonitor) && m_mMonitorRenderResources.at(pMonitor).offloadFB.m_vSize != pMonitor->m_pixelSize)
+    if (m_monitorRenderResources.contains(pMonitor) && m_monitorRenderResources.at(pMonitor).offloadFB.m_size != pMonitor->m_pixelSize)
         destroyMonitorResources(pMonitor);
 
-    m_RenderData.pCurrentMonData = &m_mMonitorRenderResources[pMonitor];
+    m_renderData.pCurrentMonData = &m_monitorRenderResources[pMonitor];
 
-    if (!m_bShadersInitialized)
+    if (!m_shadersInitialized)
         initShaders();
 
     // ensure a framebuffer for the monitor exists
-    if (m_RenderData.pCurrentMonData->offloadFB.m_vSize != pMonitor->m_pixelSize) {
-        m_RenderData.pCurrentMonData->stencilTex->allocate();
+    if (m_renderData.pCurrentMonData->offloadFB.m_size != pMonitor->m_pixelSize) {
+        m_renderData.pCurrentMonData->stencilTex->allocate();
 
-        m_RenderData.pCurrentMonData->offloadFB.alloc(pMonitor->m_pixelSize.x, pMonitor->m_pixelSize.y, pMonitor->m_output->state->state().drmFormat);
-        m_RenderData.pCurrentMonData->mirrorFB.alloc(pMonitor->m_pixelSize.x, pMonitor->m_pixelSize.y, pMonitor->m_output->state->state().drmFormat);
-        m_RenderData.pCurrentMonData->mirrorSwapFB.alloc(pMonitor->m_pixelSize.x, pMonitor->m_pixelSize.y, pMonitor->m_output->state->state().drmFormat);
+        m_renderData.pCurrentMonData->offloadFB.alloc(pMonitor->m_pixelSize.x, pMonitor->m_pixelSize.y, pMonitor->m_output->state->state().drmFormat);
+        m_renderData.pCurrentMonData->mirrorFB.alloc(pMonitor->m_pixelSize.x, pMonitor->m_pixelSize.y, pMonitor->m_output->state->state().drmFormat);
+        m_renderData.pCurrentMonData->mirrorSwapFB.alloc(pMonitor->m_pixelSize.x, pMonitor->m_pixelSize.y, pMonitor->m_output->state->state().drmFormat);
 
-        m_RenderData.pCurrentMonData->offloadFB.addStencil(m_RenderData.pCurrentMonData->stencilTex);
-        m_RenderData.pCurrentMonData->mirrorFB.addStencil(m_RenderData.pCurrentMonData->stencilTex);
-        m_RenderData.pCurrentMonData->mirrorSwapFB.addStencil(m_RenderData.pCurrentMonData->stencilTex);
+        m_renderData.pCurrentMonData->offloadFB.addStencil(m_renderData.pCurrentMonData->stencilTex);
+        m_renderData.pCurrentMonData->mirrorFB.addStencil(m_renderData.pCurrentMonData->stencilTex);
+        m_renderData.pCurrentMonData->mirrorSwapFB.addStencil(m_renderData.pCurrentMonData->stencilTex);
     }
 
-    if (m_RenderData.pCurrentMonData->monitorMirrorFB.isAllocated() && m_RenderData.pMonitor->m_mirrors.empty())
-        m_RenderData.pCurrentMonData->monitorMirrorFB.release();
+    if (m_renderData.pCurrentMonData->monitorMirrorFB.isAllocated() && m_renderData.pMonitor->m_mirrors.empty())
+        m_renderData.pCurrentMonData->monitorMirrorFB.release();
 
-    m_RenderData.damage.set(damage_);
-    m_RenderData.finalDamage.set(finalDamage.value_or(damage_));
+    m_renderData.damage.set(damage_);
+    m_renderData.finalDamage.set(finalDamage.value_or(damage_));
 
-    m_bFakeFrame = fb;
+    m_fakeFrame = fb;
 
-    if (m_bReloadScreenShader) {
-        m_bReloadScreenShader = false;
-        static auto PSHADER   = CConfigValue<std::string>("decoration:screen_shader");
+    if (m_reloadScreenShader) {
+        m_reloadScreenShader = false;
+        static auto PSHADER  = CConfigValue<std::string>("decoration:screen_shader");
         applyScreenShader(*PSHADER);
     }
 
-    m_RenderData.pCurrentMonData->offloadFB.bind();
-    m_RenderData.currentFB  = &m_RenderData.pCurrentMonData->offloadFB;
-    m_bOffloadedFramebuffer = true;
+    m_renderData.pCurrentMonData->offloadFB.bind();
+    m_renderData.currentFB = &m_renderData.pCurrentMonData->offloadFB;
+    m_offloadedFramebuffer = true;
 
-    m_RenderData.mainFB = m_RenderData.currentFB;
-    m_RenderData.outFB  = fb ? fb : g_pHyprRenderer->getCurrentRBO()->getFB();
+    m_renderData.mainFB = m_renderData.currentFB;
+    m_renderData.outFB  = fb ? fb : g_pHyprRenderer->getCurrentRBO()->getFB();
 }
 
 void CHyprOpenGLImpl::end() {
@@ -793,67 +793,67 @@ void CHyprOpenGLImpl::end() {
     TRACY_GPU_ZONE("RenderEnd");
 
     // end the render, copy the data to the main framebuffer
-    if (m_bOffloadedFramebuffer) {
-        m_RenderData.damage = m_RenderData.finalDamage;
-        m_bEndFrame         = true;
+    if (m_offloadedFramebuffer) {
+        m_renderData.damage = m_renderData.finalDamage;
+        m_endFrame          = true;
 
-        CBox monbox = {0, 0, m_RenderData.pMonitor->m_transformedSize.x, m_RenderData.pMonitor->m_transformedSize.y};
+        CBox monbox = {0, 0, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y};
 
-        if (m_RenderData.mouseZoomFactor != 1.f) {
-            const auto ZOOMCENTER = m_RenderData.mouseZoomUseMouse ?
-                (g_pInputManager->getMouseCoordsInternal() - m_RenderData.pMonitor->m_position) * m_RenderData.pMonitor->m_scale :
-                m_RenderData.pMonitor->m_transformedSize / 2.f;
+        if (m_renderData.mouseZoomFactor != 1.f) {
+            const auto ZOOMCENTER = m_renderData.mouseZoomUseMouse ?
+                (g_pInputManager->getMouseCoordsInternal() - m_renderData.pMonitor->m_position) * m_renderData.pMonitor->m_scale :
+                m_renderData.pMonitor->m_transformedSize / 2.f;
 
-            monbox.translate(-ZOOMCENTER).scale(m_RenderData.mouseZoomFactor).translate(*PZOOMRIGID ? m_RenderData.pMonitor->m_transformedSize / 2.0 : ZOOMCENTER);
+            monbox.translate(-ZOOMCENTER).scale(m_renderData.mouseZoomFactor).translate(*PZOOMRIGID ? m_renderData.pMonitor->m_transformedSize / 2.0 : ZOOMCENTER);
 
             if (monbox.x > 0)
                 monbox.x = 0;
             if (monbox.y > 0)
                 monbox.y = 0;
-            if (monbox.x + monbox.width < m_RenderData.pMonitor->m_transformedSize.x)
-                monbox.x = m_RenderData.pMonitor->m_transformedSize.x - monbox.width;
-            if (monbox.y + monbox.height < m_RenderData.pMonitor->m_transformedSize.y)
-                monbox.y = m_RenderData.pMonitor->m_transformedSize.y - monbox.height;
+            if (monbox.x + monbox.width < m_renderData.pMonitor->m_transformedSize.x)
+                monbox.x = m_renderData.pMonitor->m_transformedSize.x - monbox.width;
+            if (monbox.y + monbox.height < m_renderData.pMonitor->m_transformedSize.y)
+                monbox.y = m_renderData.pMonitor->m_transformedSize.y - monbox.height;
         }
 
-        m_bApplyFinalShader = !m_RenderData.blockScreenShader;
-        if (m_RenderData.mouseZoomUseMouse)
-            m_RenderData.useNearestNeighbor = true;
+        m_applyFinalShader = !m_renderData.blockScreenShader;
+        if (m_renderData.mouseZoomUseMouse)
+            m_renderData.useNearestNeighbor = true;
 
         // copy the damaged areas into the mirror buffer
         // we can't use the offloadFB for mirroring, as it contains artifacts from blurring
-        if (!m_RenderData.pMonitor->m_mirrors.empty() && !m_bFakeFrame)
+        if (!m_renderData.pMonitor->m_mirrors.empty() && !m_fakeFrame)
             saveBufferForMirror(monbox);
 
-        m_RenderData.outFB->bind();
+        m_renderData.outFB->bind();
         blend(false);
 
-        if (m_sFinalScreenShader.program < 1 && !g_pHyprRenderer->m_bCrashingInProgress)
-            renderTexturePrimitive(m_RenderData.pCurrentMonData->offloadFB.getTexture(), monbox);
+        if (m_finalScreenShader.program < 1 && !g_pHyprRenderer->m_crashingInProgress)
+            renderTexturePrimitive(m_renderData.pCurrentMonData->offloadFB.getTexture(), monbox);
         else
-            renderTexture(m_RenderData.pCurrentMonData->offloadFB.getTexture(), monbox, 1.f);
+            renderTexture(m_renderData.pCurrentMonData->offloadFB.getTexture(), monbox, 1.f);
 
         blend(true);
 
-        m_RenderData.useNearestNeighbor = false;
-        m_bApplyFinalShader             = false;
-        m_bEndFrame                     = false;
+        m_renderData.useNearestNeighbor = false;
+        m_applyFinalShader              = false;
+        m_endFrame                      = false;
     }
 
     // reset our data
-    m_RenderData.pMonitor.reset();
-    m_RenderData.mouseZoomFactor   = 1.f;
-    m_RenderData.mouseZoomUseMouse = true;
-    m_RenderData.blockScreenShader = false;
-    m_RenderData.currentFB         = nullptr;
-    m_RenderData.mainFB            = nullptr;
-    m_RenderData.outFB             = nullptr;
+    m_renderData.pMonitor.reset();
+    m_renderData.mouseZoomFactor   = 1.f;
+    m_renderData.mouseZoomUseMouse = true;
+    m_renderData.blockScreenShader = false;
+    m_renderData.currentFB         = nullptr;
+    m_renderData.mainFB            = nullptr;
+    m_renderData.outFB             = nullptr;
 
     // if we dropped to offMain, release it now.
     // if there is a plugin constantly using it, this might be a bit slow,
     // but I havent seen a single plugin yet use these, so it's better to drop a bit of vram.
-    if (m_RenderData.pCurrentMonData->offMainFB.isAllocated())
-        m_RenderData.pCurrentMonData->offMainFB.release();
+    if (m_renderData.pCurrentMonData->offMainFB.isAllocated())
+        m_renderData.pCurrentMonData->offMainFB.release();
 
     // check for gl errors
     const GLenum ERR = glGetError();
@@ -867,8 +867,8 @@ void CHyprOpenGLImpl::end() {
 }
 
 void CHyprOpenGLImpl::setDamage(const CRegion& damage_, std::optional<CRegion> finalDamage) {
-    m_RenderData.damage.set(damage_);
-    m_RenderData.finalDamage.set(finalDamage.value_or(damage_));
+    m_renderData.damage.set(damage_);
+    m_renderData.finalDamage.set(finalDamage.value_or(damage_));
 }
 
 // TODO notify user if bundled shader is newer than ~/.config override
@@ -931,7 +931,7 @@ static void getRoundingShaderUniforms(CShader& shader) {
 
 bool CHyprOpenGLImpl::initShaders() {
     auto              shaders   = makeShared<SPreparedShaders>();
-    const bool        isDynamic = m_bShadersInitialized;
+    const bool        isDynamic = m_shadersInitialized;
     static const auto PCM       = CConfigValue<Hyprlang::INT>("render:cm_enabled");
 
     try {
@@ -948,16 +948,16 @@ bool CHyprOpenGLImpl::initShaders() {
         m_bCMSupported = false;
 #else
         if (!*PCM)
-            m_bCMSupported = false;
+            m_cmSupported = false;
         else {
             const auto TEXFRAGSRCCM = processShader("CM.frag", includes);
 
             prog = createProgram(shaders->TEXVERTSRC300, TEXFRAGSRCCM, true, true);
-            if (m_bShadersInitialized && m_bCMSupported && prog == 0)
+            if (m_shadersInitialized && m_cmSupported && prog == 0)
                 g_pHyprNotificationOverlay->addNotification("CM shader reload failed, falling back to rgba/rgbx", CHyprColor{}, 15000, ICON_WARNING);
 
-            m_bCMSupported = prog > 0;
-            if (m_bCMSupported) {
+            m_cmSupported = prog > 0;
+            if (m_cmSupported) {
                 shaders->m_shCM.program = prog;
                 getCMShaderUniforms(shaders->m_shCM);
                 getRoundingShaderUniforms(shaders->m_shCM);
@@ -982,10 +982,10 @@ bool CHyprOpenGLImpl::initShaders() {
         }
 #endif
 
-        const auto FRAGSHADOW             = processShader(m_bCMSupported ? "shadow.frag" : "shadow_legacy.frag", includes);
-        const auto FRAGBORDER1            = processShader(m_bCMSupported ? "border.frag" : "border_legacy.frag", includes);
-        const auto FRAGBLURPREPARE        = processShader(m_bCMSupported ? "blurprepare.frag" : "blurprepare_legacy.frag", includes);
-        const auto FRAGBLURFINISH         = processShader(m_bCMSupported ? "blurfinish.frag" : "blurfinish_legacy.frag", includes);
+        const auto FRAGSHADOW             = processShader(m_cmSupported ? "shadow.frag" : "shadow_legacy.frag", includes);
+        const auto FRAGBORDER1            = processShader(m_cmSupported ? "border.frag" : "border_legacy.frag", includes);
+        const auto FRAGBLURPREPARE        = processShader(m_cmSupported ? "blurprepare.frag" : "blurprepare_legacy.frag", includes);
+        const auto FRAGBLURFINISH         = processShader(m_cmSupported ? "blurfinish.frag" : "blurfinish_legacy.frag", includes);
         const auto QUADFRAGSRC            = processShader("quad.frag", includes);
         const auto TEXFRAGSRCRGBA         = processShader("rgba.frag", includes);
         const auto TEXFRAGSRCRGBAPASSTHRU = processShader("passthru.frag", includes);
@@ -1114,11 +1114,11 @@ bool CHyprOpenGLImpl::initShaders() {
         shaders->m_shBLUR2.radius    = glGetUniformLocation(prog, "radius");
         shaders->m_shBLUR2.halfpixel = glGetUniformLocation(prog, "halfpixel");
 
-        prog = createProgram(m_bCMSupported ? shaders->TEXVERTSRC300 : shaders->TEXVERTSRC, FRAGBLURPREPARE, isDynamic);
+        prog = createProgram(m_cmSupported ? shaders->TEXVERTSRC300 : shaders->TEXVERTSRC, FRAGBLURPREPARE, isDynamic);
         if (!prog)
             return false;
         shaders->m_shBLURPREPARE.program = prog;
-        if (m_bCMSupported)
+        if (m_cmSupported)
             getCMShaderUniforms(shaders->m_shBLURPREPARE);
 
         shaders->m_shBLURPREPARE.tex        = glGetUniformLocation(prog, "tex");
@@ -1128,7 +1128,7 @@ bool CHyprOpenGLImpl::initShaders() {
         shaders->m_shBLURPREPARE.contrast   = glGetUniformLocation(prog, "contrast");
         shaders->m_shBLURPREPARE.brightness = glGetUniformLocation(prog, "brightness");
 
-        prog = createProgram(m_bCMSupported ? shaders->TEXVERTSRC300 : shaders->TEXVERTSRC, FRAGBLURFINISH, isDynamic);
+        prog = createProgram(m_cmSupported ? shaders->TEXVERTSRC300 : shaders->TEXVERTSRC, FRAGBLURFINISH, isDynamic);
         if (!prog)
             return false;
         shaders->m_shBLURFINISH.program = prog;
@@ -1141,10 +1141,10 @@ bool CHyprOpenGLImpl::initShaders() {
         shaders->m_shBLURFINISH.brightness = glGetUniformLocation(prog, "brightness");
         shaders->m_shBLURFINISH.noise      = glGetUniformLocation(prog, "noise");
 
-        prog = createProgram(m_bCMSupported ? shaders->TEXVERTSRC300 : shaders->TEXVERTSRC, FRAGSHADOW, isDynamic);
+        prog = createProgram(m_cmSupported ? shaders->TEXVERTSRC300 : shaders->TEXVERTSRC, FRAGSHADOW, isDynamic);
         if (!prog)
             return false;
-        if (m_bCMSupported)
+        if (m_cmSupported)
             shaders->m_shSHADOW.program = prog;
         getCMShaderUniforms(shaders->m_shSHADOW);
         getRoundingShaderUniforms(shaders->m_shSHADOW);
@@ -1156,11 +1156,11 @@ bool CHyprOpenGLImpl::initShaders() {
         shaders->m_shSHADOW.shadowPower = glGetUniformLocation(prog, "shadowPower");
         shaders->m_shSHADOW.color       = glGetUniformLocation(prog, "color");
 
-        prog = createProgram(m_bCMSupported ? shaders->TEXVERTSRC300 : shaders->TEXVERTSRC, FRAGBORDER1, isDynamic);
+        prog = createProgram(m_cmSupported ? shaders->TEXVERTSRC300 : shaders->TEXVERTSRC, FRAGBORDER1, isDynamic);
         if (!prog)
             return false;
         shaders->m_shBORDER1.program = prog;
-        if (m_bCMSupported)
+        if (m_cmSupported)
             getCMShaderUniforms(shaders->m_shBORDER1);
 
         getRoundingShaderUniforms(shaders->m_shBORDER1);
@@ -1180,15 +1180,15 @@ bool CHyprOpenGLImpl::initShaders() {
         shaders->m_shBORDER1.gradientLerp          = glGetUniformLocation(prog, "gradientLerp");
         shaders->m_shBORDER1.alpha                 = glGetUniformLocation(prog, "alpha");
     } catch (const std::exception& e) {
-        if (!m_bShadersInitialized)
+        if (!m_shadersInitialized)
             throw e;
 
         Debug::log(ERR, "Shaders update failed: {}", e.what());
         return false;
     }
 
-    m_shaders             = shaders;
-    m_bShadersInitialized = true;
+    m_shaders            = shaders;
+    m_shadersInitialized = true;
 
     Debug::log(LOG, "Shaders initialized successfully.");
     g_pHyprError->destroy();
@@ -1199,7 +1199,7 @@ void CHyprOpenGLImpl::applyScreenShader(const std::string& path) {
 
     static auto PDT = CConfigValue<Hyprlang::INT>("debug:damage_tracking");
 
-    m_sFinalScreenShader.destroy();
+    m_finalScreenShader.destroy();
 
     if (path == "" || path == STRVAL_EMPTY)
         return;
@@ -1213,7 +1213,7 @@ void CHyprOpenGLImpl::applyScreenShader(const std::string& path) {
 
     std::string fragmentShader((std::istreambuf_iterator<char>(infile)), (std::istreambuf_iterator<char>()));
 
-    m_sFinalScreenShader.program = createProgram(     //
+    m_finalScreenShader.program = createProgram(      //
         fragmentShader.starts_with("#version 320 es") // do not break existing custom shaders
             ?
             m_shaders->TEXVERTSRC320 :
@@ -1223,39 +1223,39 @@ void CHyprOpenGLImpl::applyScreenShader(const std::string& path) {
                  m_shaders->TEXVERTSRC),
         fragmentShader, true);
 
-    if (!m_sFinalScreenShader.program) {
+    if (!m_finalScreenShader.program) {
         // Error will have been sent by now by the underlying cause
         return;
     }
 
-    m_sFinalScreenShader.proj = glGetUniformLocation(m_sFinalScreenShader.program, "proj");
-    m_sFinalScreenShader.tex  = glGetUniformLocation(m_sFinalScreenShader.program, "tex");
-    m_sFinalScreenShader.time = glGetUniformLocation(m_sFinalScreenShader.program, "time");
-    if (m_sFinalScreenShader.time != -1)
-        m_sFinalScreenShader.initialTime = m_tGlobalTimer.getSeconds();
-    m_sFinalScreenShader.wl_output = glGetUniformLocation(m_sFinalScreenShader.program, "wl_output");
-    m_sFinalScreenShader.fullSize  = glGetUniformLocation(m_sFinalScreenShader.program, "screen_size");
-    if (m_sFinalScreenShader.fullSize == -1)
-        m_sFinalScreenShader.fullSize = glGetUniformLocation(m_sFinalScreenShader.program, "screenSize");
-    if (m_sFinalScreenShader.time != -1 && *PDT != 0 && !g_pHyprRenderer->m_bCrashingInProgress) {
+    m_finalScreenShader.proj = glGetUniformLocation(m_finalScreenShader.program, "proj");
+    m_finalScreenShader.tex  = glGetUniformLocation(m_finalScreenShader.program, "tex");
+    m_finalScreenShader.time = glGetUniformLocation(m_finalScreenShader.program, "time");
+    if (m_finalScreenShader.time != -1)
+        m_finalScreenShader.initialTime = m_globalTimer.getSeconds();
+    m_finalScreenShader.wl_output = glGetUniformLocation(m_finalScreenShader.program, "wl_output");
+    m_finalScreenShader.fullSize  = glGetUniformLocation(m_finalScreenShader.program, "screen_size");
+    if (m_finalScreenShader.fullSize == -1)
+        m_finalScreenShader.fullSize = glGetUniformLocation(m_finalScreenShader.program, "screenSize");
+    if (m_finalScreenShader.time != -1 && *PDT != 0 && !g_pHyprRenderer->m_crashingInProgress) {
         // The screen shader uses the "time" uniform
         // Since the screen shader could change every frame, damage tracking *needs* to be disabled
         g_pConfigManager->addParseError("Screen shader: Screen shader uses uniform 'time', which requires debug:damage_tracking to be switched off.\n"
                                         "WARNING: Disabling damage tracking will *massively* increase GPU utilization!");
     }
-    m_sFinalScreenShader.texAttrib = glGetAttribLocation(m_sFinalScreenShader.program, "texcoord");
-    m_sFinalScreenShader.posAttrib = glGetAttribLocation(m_sFinalScreenShader.program, "pos");
+    m_finalScreenShader.texAttrib = glGetAttribLocation(m_finalScreenShader.program, "texcoord");
+    m_finalScreenShader.posAttrib = glGetAttribLocation(m_finalScreenShader.program, "pos");
 }
 
 void CHyprOpenGLImpl::clear(const CHyprColor& color) {
-    RASSERT(m_RenderData.pMonitor, "Tried to render without begin()!");
+    RASSERT(m_renderData.pMonitor, "Tried to render without begin()!");
 
     TRACY_GPU_ZONE("RenderClear");
 
     glClearColor(color.r, color.g, color.b, color.a);
 
-    if (!m_RenderData.damage.empty()) {
-        for (auto const& RECT : m_RenderData.damage.getRects()) {
+    if (!m_renderData.damage.empty()) {
+        for (auto const& RECT : m_renderData.damage.getRects()) {
             scissor(&RECT);
             glClear(GL_COLOR_BUFFER_BIT);
         }
@@ -1271,16 +1271,16 @@ void CHyprOpenGLImpl::blend(bool enabled) {
     } else
         glDisable(GL_BLEND);
 
-    m_bBlend = enabled;
+    m_blend = enabled;
 }
 
 void CHyprOpenGLImpl::scissor(const CBox& originalBox, bool transform) {
-    RASSERT(m_RenderData.pMonitor, "Tried to scissor without begin()!");
+    RASSERT(m_renderData.pMonitor, "Tried to scissor without begin()!");
 
     if (transform) {
         CBox       box = originalBox;
-        const auto TR  = wlTransformToHyprutils(invertTransform(m_RenderData.pMonitor->m_transform));
-        box.transform(TR, m_RenderData.pMonitor->m_transformedSize.x, m_RenderData.pMonitor->m_transformedSize.y);
+        const auto TR  = wlTransformToHyprutils(invertTransform(m_renderData.pMonitor->m_transform));
+        box.transform(TR, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y);
         glScissor(box.x, box.y, box.width, box.height);
         glEnable(GL_SCISSOR_TEST);
         return;
@@ -1291,7 +1291,7 @@ void CHyprOpenGLImpl::scissor(const CBox& originalBox, bool transform) {
 }
 
 void CHyprOpenGLImpl::scissor(const pixman_box32* pBox, bool transform) {
-    RASSERT(m_RenderData.pMonitor, "Tried to scissor without begin()!");
+    RASSERT(m_renderData.pMonitor, "Tried to scissor without begin()!");
 
     if (!pBox) {
         glDisable(GL_SCISSOR_TEST);
@@ -1309,20 +1309,20 @@ void CHyprOpenGLImpl::scissor(const int x, const int y, const int w, const int h
 }
 
 void CHyprOpenGLImpl::renderRect(const CBox& box, const CHyprColor& col, int round, float roundingPower) {
-    if (!m_RenderData.damage.empty())
-        renderRectWithDamage(box, col, m_RenderData.damage, round, roundingPower);
+    if (!m_renderData.damage.empty())
+        renderRectWithDamage(box, col, m_renderData.damage, round, roundingPower);
 }
 
 void CHyprOpenGLImpl::renderRectWithBlur(const CBox& box, const CHyprColor& col, int round, float roundingPower, float blurA, bool xray) {
-    if (m_RenderData.damage.empty())
+    if (m_renderData.damage.empty())
         return;
 
-    CRegion damage{m_RenderData.damage};
+    CRegion damage{m_renderData.damage};
     damage.intersect(box);
 
-    CFramebuffer* POUTFB = xray ? &m_RenderData.pCurrentMonData->blurFB : blurMainFramebufferWithDamage(blurA, &damage);
+    CFramebuffer* POUTFB = xray ? &m_renderData.pCurrentMonData->blurFB : blurMainFramebufferWithDamage(blurA, &damage);
 
-    m_RenderData.currentFB->bind();
+    m_renderData.currentFB->bind();
 
     // make a stencil for rounded corners to work with blur
     scissor(nullptr); // allow the entire window and stencil to render
@@ -1342,13 +1342,13 @@ void CHyprOpenGLImpl::renderRectWithBlur(const CBox& box, const CHyprColor& col,
     glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
 
     scissor(box);
-    CBox MONITORBOX             = {0, 0, m_RenderData.pMonitor->m_transformedSize.x, m_RenderData.pMonitor->m_transformedSize.y};
-    m_bEndFrame                 = true; // fix transformed
-    const auto SAVEDRENDERMODIF = m_RenderData.renderModif;
-    m_RenderData.renderModif    = {}; // fix shit
+    CBox MONITORBOX             = {0, 0, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y};
+    m_endFrame                  = true; // fix transformed
+    const auto SAVEDRENDERMODIF = m_renderData.renderModif;
+    m_renderData.renderModif    = {}; // fix shit
     renderTextureInternalWithDamage(POUTFB->getTexture(), MONITORBOX, blurA, damage, 0, 2.0f, false, false, false);
-    m_bEndFrame              = false;
-    m_RenderData.renderModif = SAVEDRENDERMODIF;
+    m_endFrame               = false;
+    m_renderData.renderModif = SAVEDRENDERMODIF;
 
     glClearStencil(0);
     glClear(GL_STENCIL_BUFFER_BIT);
@@ -1357,21 +1357,21 @@ void CHyprOpenGLImpl::renderRectWithBlur(const CBox& box, const CHyprColor& col,
     glStencilFunc(GL_ALWAYS, 1, 0xFF);
     scissor(nullptr);
 
-    renderRectWithDamage(box, col, m_RenderData.damage, round, roundingPower);
+    renderRectWithDamage(box, col, m_renderData.damage, round, roundingPower);
 }
 
 void CHyprOpenGLImpl::renderRectWithDamage(const CBox& box, const CHyprColor& col, const CRegion& damage, int round, float roundingPower) {
     RASSERT((box.width > 0 && box.height > 0), "Tried to render rect with width/height < 0!");
-    RASSERT(m_RenderData.pMonitor, "Tried to render rect without begin()!");
+    RASSERT(m_renderData.pMonitor, "Tried to render rect without begin()!");
 
     TRACY_GPU_ZONE("RenderRectWithDamage");
 
     CBox newBox = box;
-    m_RenderData.renderModif.applyToBox(newBox);
+    m_renderData.renderModif.applyToBox(newBox);
 
-    Mat3x3 matrix = m_RenderData.monitorProjection.projectBox(
-        newBox, wlTransformToHyprutils(invertTransform(!m_bEndFrame ? WL_OUTPUT_TRANSFORM_NORMAL : m_RenderData.pMonitor->m_transform)), newBox.rot);
-    Mat3x3 glMatrix = m_RenderData.projection.copy().multiply(matrix);
+    Mat3x3 matrix = m_renderData.monitorProjection.projectBox(
+        newBox, wlTransformToHyprutils(invertTransform(!m_endFrame ? WL_OUTPUT_TRANSFORM_NORMAL : m_renderData.pMonitor->m_transform)), newBox.rot);
+    Mat3x3 glMatrix = m_renderData.projection.copy().multiply(matrix);
 
     glUseProgram(m_shaders->m_shQUAD.program);
 
@@ -1386,8 +1386,8 @@ void CHyprOpenGLImpl::renderRectWithDamage(const CBox& box, const CHyprColor& co
     glUniform4f(m_shaders->m_shQUAD.color, col.r * col.a, col.g * col.a, col.b * col.a, col.a);
 
     CBox transformedBox = box;
-    transformedBox.transform(wlTransformToHyprutils(invertTransform(m_RenderData.pMonitor->m_transform)), m_RenderData.pMonitor->m_transformedSize.x,
-                             m_RenderData.pMonitor->m_transformedSize.y);
+    transformedBox.transform(wlTransformToHyprutils(invertTransform(m_renderData.pMonitor->m_transform)), m_renderData.pMonitor->m_transformedSize.x,
+                             m_renderData.pMonitor->m_transformedSize.y);
 
     const auto TOPLEFT  = Vector2D(transformedBox.x, transformedBox.y);
     const auto FULLSIZE = Vector2D(transformedBox.width, transformedBox.height);
@@ -1402,8 +1402,8 @@ void CHyprOpenGLImpl::renderRectWithDamage(const CBox& box, const CHyprColor& co
 
     glEnableVertexAttribArray(m_shaders->m_shQUAD.posAttrib);
 
-    if (m_RenderData.clipBox.width != 0 && m_RenderData.clipBox.height != 0) {
-        CRegion damageClip{m_RenderData.clipBox.x, m_RenderData.clipBox.y, m_RenderData.clipBox.width, m_RenderData.clipBox.height};
+    if (m_renderData.clipBox.width != 0 && m_renderData.clipBox.height != 0) {
+        CRegion damageClip{m_renderData.clipBox.x, m_renderData.clipBox.y, m_renderData.clipBox.width, m_renderData.clipBox.height};
         damageClip.intersect(damage);
 
         if (!damageClip.empty()) {
@@ -1425,16 +1425,16 @@ void CHyprOpenGLImpl::renderRectWithDamage(const CBox& box, const CHyprColor& co
 }
 
 void CHyprOpenGLImpl::renderTexture(SP<CTexture> tex, const CBox& box, float alpha, int round, float roundingPower, bool discardActive, bool allowCustomUV) {
-    RASSERT(m_RenderData.pMonitor, "Tried to render texture without begin()!");
+    RASSERT(m_renderData.pMonitor, "Tried to render texture without begin()!");
 
-    renderTextureInternalWithDamage(tex, box, alpha, m_RenderData.damage, round, roundingPower, discardActive, false, allowCustomUV, true);
+    renderTextureInternalWithDamage(tex, box, alpha, m_renderData.damage, round, roundingPower, discardActive, false, allowCustomUV, true);
 
     scissor(nullptr);
 }
 
 void CHyprOpenGLImpl::renderTextureWithDamage(SP<CTexture> tex, const CBox& box, const CRegion& damage, float alpha, int round, float roundingPower, bool discardActive,
                                               bool allowCustomUV) {
-    RASSERT(m_RenderData.pMonitor, "Tried to render texture without begin()!");
+    RASSERT(m_renderData.pMonitor, "Tried to render texture without begin()!");
 
     renderTextureInternalWithDamage(tex, box, alpha, damage, round, roundingPower, discardActive, false, allowCustomUV, true);
 
@@ -1466,12 +1466,12 @@ void CHyprOpenGLImpl::passCMUniforms(const CShader& shader, const NColorManageme
     glUniform1f(shader.dstMaxLuminance, targetImageDescription.luminances.max > 0 ? targetImageDescription.luminances.max : 10000);
     glUniform1f(shader.dstRefLuminance, targetImageDescription.luminances.reference);
     glUniform1f(shader.sdrSaturation,
-                modifySDR && m_RenderData.pMonitor->m_sdrSaturation > 0 && targetImageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ ?
-                    m_RenderData.pMonitor->m_sdrSaturation :
+                modifySDR && m_renderData.pMonitor->m_sdrSaturation > 0 && targetImageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ ?
+                    m_renderData.pMonitor->m_sdrSaturation :
                     1.0f);
     glUniform1f(shader.sdrBrightness,
-                modifySDR && m_RenderData.pMonitor->m_sdrBrightness > 0 && targetImageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ ?
-                    m_RenderData.pMonitor->m_sdrBrightness :
+                modifySDR && m_renderData.pMonitor->m_sdrBrightness > 0 && targetImageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ ?
+                    m_renderData.pMonitor->m_sdrBrightness :
 
                     1.0f);
     const auto cacheKey = std::make_pair(imageDescription.getId(), targetImageDescription.getId());
@@ -1488,13 +1488,13 @@ void CHyprOpenGLImpl::passCMUniforms(const CShader& shader, const NColorManageme
 }
 
 void CHyprOpenGLImpl::passCMUniforms(const CShader& shader, const SImageDescription& imageDescription) {
-    passCMUniforms(shader, imageDescription, m_RenderData.pMonitor->m_imageDescription, true);
+    passCMUniforms(shader, imageDescription, m_renderData.pMonitor->m_imageDescription, true);
 }
 
 void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, const CBox& box, float alpha, const CRegion& damage, int round, float roundingPower, bool discardActive,
                                                       bool noAA, bool allowCustomUV, bool allowDim) {
-    RASSERT(m_RenderData.pMonitor, "Tried to render texture without begin()!");
-    RASSERT((tex->m_iTexID > 0), "Attempted to draw nullptr texture!");
+    RASSERT(m_renderData.pMonitor, "Tried to render texture without begin()!");
+    RASSERT((tex->m_texID > 0), "Attempted to draw nullptr texture!");
 
     TRACY_GPU_ZONE("RenderTextureInternalWithDamage");
 
@@ -1504,41 +1504,41 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, const CB
         return;
 
     CBox newBox = box;
-    m_RenderData.renderModif.applyToBox(newBox);
+    m_renderData.renderModif.applyToBox(newBox);
 
     static const auto PDT       = CConfigValue<Hyprlang::INT>("debug:damage_tracking");
     static const auto PPASS     = CConfigValue<Hyprlang::INT>("render:cm_fs_passthrough");
     static const auto PENABLECM = CConfigValue<Hyprlang::INT>("render:cm_enabled");
 
     // get the needed transform for this texture
-    const bool TRANSFORMS_MATCH = wlTransformToHyprutils(m_RenderData.pMonitor->m_transform) == tex->m_eTransform; // FIXME: combine them properly!!!
+    const bool TRANSFORMS_MATCH = wlTransformToHyprutils(m_renderData.pMonitor->m_transform) == tex->m_transform; // FIXME: combine them properly!!!
     eTransform TRANSFORM        = HYPRUTILS_TRANSFORM_NORMAL;
-    if (m_bEndFrame || TRANSFORMS_MATCH)
-        TRANSFORM = wlTransformToHyprutils(invertTransform(m_RenderData.pMonitor->m_transform));
+    if (m_endFrame || TRANSFORMS_MATCH)
+        TRANSFORM = wlTransformToHyprutils(invertTransform(m_renderData.pMonitor->m_transform));
 
-    Mat3x3     matrix   = m_RenderData.monitorProjection.projectBox(newBox, TRANSFORM, newBox.rot);
-    Mat3x3     glMatrix = m_RenderData.projection.copy().multiply(matrix);
+    Mat3x3     matrix   = m_renderData.monitorProjection.projectBox(newBox, TRANSFORM, newBox.rot);
+    Mat3x3     glMatrix = m_renderData.projection.copy().multiply(matrix);
 
     CShader*   shader = nullptr;
 
     bool       usingFinalShader = false;
 
-    const bool CRASHING = m_bApplyFinalShader && g_pHyprRenderer->m_bCrashingInProgress;
+    const bool CRASHING = m_applyFinalShader && g_pHyprRenderer->m_crashingInProgress;
 
-    auto       texType = tex->m_iType;
+    auto       texType = tex->m_type;
 
     if (CRASHING) {
         shader           = &m_shaders->m_shGLITCH;
         usingFinalShader = true;
-    } else if (m_bApplyFinalShader && m_sFinalScreenShader.program) {
-        shader           = &m_sFinalScreenShader;
+    } else if (m_applyFinalShader && m_finalScreenShader.program) {
+        shader           = &m_finalScreenShader;
         usingFinalShader = true;
     } else {
-        if (m_bApplyFinalShader) {
+        if (m_applyFinalShader) {
             shader           = &m_shaders->m_shPASSTHRURGBA;
             usingFinalShader = true;
         } else {
-            switch (tex->m_iType) {
+            switch (tex->m_type) {
                 case TEXTURE_RGBA: shader = &m_shaders->m_shRGBA; break;
                 case TEXTURE_RGBX: shader = &m_shaders->m_shRGBX; break;
 
@@ -1548,33 +1548,33 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, const CB
         }
     }
 
-    if (m_RenderData.currentWindow && m_RenderData.currentWindow->m_windowData.RGBX.valueOrDefault()) {
+    if (m_renderData.currentWindow && m_renderData.currentWindow->m_windowData.RGBX.valueOrDefault()) {
         shader  = &m_shaders->m_shRGBX;
         texType = TEXTURE_RGBX;
     }
 
     glActiveTexture(GL_TEXTURE0);
-    glBindTexture(tex->m_iTarget, tex->m_iTexID);
+    glBindTexture(tex->m_target, tex->m_texID);
 
-    glTexParameteri(tex->m_iTarget, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(tex->m_iTarget, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(tex->m_target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(tex->m_target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    if (m_RenderData.useNearestNeighbor) {
-        glTexParameteri(tex->m_iTarget, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-        glTexParameteri(tex->m_iTarget, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    if (m_renderData.useNearestNeighbor) {
+        glTexParameteri(tex->m_target, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        glTexParameteri(tex->m_target, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     } else {
-        glTexParameteri(tex->m_iTarget, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-        glTexParameteri(tex->m_iTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(tex->m_target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexParameteri(tex->m_target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     }
 
     const auto imageDescription =
-        m_RenderData.surface.valid() && m_RenderData.surface->m_colorManagement.valid() ? m_RenderData.surface->m_colorManagement->imageDescription() : SImageDescription{};
+        m_renderData.surface.valid() && m_renderData.surface->m_colorManagement.valid() ? m_renderData.surface->m_colorManagement->imageDescription() : SImageDescription{};
 
-    const bool skipCM = !*PENABLECM || !m_bCMSupported                     /* CM unsupported or disabled */
-        || (imageDescription == m_RenderData.pMonitor->m_imageDescription) /* Source and target have the same image description */
-        || ((*PPASS == 1 || (*PPASS == 2 && imageDescription.transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ)) && m_RenderData.pMonitor->m_activeWorkspace &&
-            m_RenderData.pMonitor->m_activeWorkspace->m_hasFullscreenWindow &&
-            m_RenderData.pMonitor->m_activeWorkspace->m_fullscreenMode == FSMODE_FULLSCREEN) /* Fullscreen window with pass cm enabled */;
+    const bool skipCM = !*PENABLECM || !m_cmSupported                      /* CM unsupported or disabled */
+        || (imageDescription == m_renderData.pMonitor->m_imageDescription) /* Source and target have the same image description */
+        || ((*PPASS == 1 || (*PPASS == 2 && imageDescription.transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ)) && m_renderData.pMonitor->m_activeWorkspace &&
+            m_renderData.pMonitor->m_activeWorkspace->m_hasFullscreenWindow &&
+            m_renderData.pMonitor->m_activeWorkspace->m_fullscreenMode == FSMODE_FULLSCREEN) /* Fullscreen window with pass cm enabled */;
 
     if (!skipCM && !usingFinalShader && (texType == TEXTURE_RGBA || texType == TEXTURE_RGBX))
         shader = &m_shaders->m_shCM;
@@ -1595,29 +1595,29 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, const CB
     glUniform1i(shader->tex, 0);
 
     if ((usingFinalShader && *PDT == 0) || CRASHING) {
-        glUniform1f(shader->time, m_tGlobalTimer.getSeconds() - shader->initialTime);
+        glUniform1f(shader->time, m_globalTimer.getSeconds() - shader->initialTime);
     } else if (usingFinalShader && shader->time != -1) {
         // Don't let time be unitialised
         glUniform1f(shader->time, 0.f);
     }
 
     if (usingFinalShader && shader->wl_output != -1)
-        glUniform1i(shader->wl_output, m_RenderData.pMonitor->m_id);
+        glUniform1i(shader->wl_output, m_renderData.pMonitor->m_id);
     if (usingFinalShader && shader->fullSize != -1)
-        glUniform2f(shader->fullSize, m_RenderData.pMonitor->m_pixelSize.x, m_RenderData.pMonitor->m_pixelSize.y);
+        glUniform2f(shader->fullSize, m_renderData.pMonitor->m_pixelSize.x, m_renderData.pMonitor->m_pixelSize.y);
 
     if (CRASHING) {
-        glUniform1f(shader->distort, g_pHyprRenderer->m_fCrashingDistort);
-        glUniform2f(shader->fullSize, m_RenderData.pMonitor->m_pixelSize.x, m_RenderData.pMonitor->m_pixelSize.y);
+        glUniform1f(shader->distort, g_pHyprRenderer->m_crashingDistort);
+        glUniform2f(shader->fullSize, m_renderData.pMonitor->m_pixelSize.x, m_renderData.pMonitor->m_pixelSize.y);
     }
 
     if (!usingFinalShader) {
         glUniform1f(shader->alpha, alpha);
 
         if (discardActive) {
-            glUniform1i(shader->discardOpaque, !!(m_RenderData.discardMode & DISCARD_OPAQUE));
-            glUniform1i(shader->discardAlpha, !!(m_RenderData.discardMode & DISCARD_ALPHA));
-            glUniform1f(shader->discardAlphaValue, m_RenderData.discardOpacity);
+            glUniform1i(shader->discardOpaque, !!(m_renderData.discardMode & DISCARD_OPAQUE));
+            glUniform1i(shader->discardAlpha, !!(m_renderData.discardMode & DISCARD_ALPHA));
+            glUniform1f(shader->discardAlphaValue, m_renderData.discardOpacity);
         } else {
             glUniform1i(shader->discardOpaque, 0);
             glUniform1i(shader->discardAlpha, 0);
@@ -1625,8 +1625,8 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, const CB
     }
 
     CBox transformedBox = newBox;
-    transformedBox.transform(wlTransformToHyprutils(invertTransform(m_RenderData.pMonitor->m_transform)), m_RenderData.pMonitor->m_transformedSize.x,
-                             m_RenderData.pMonitor->m_transformedSize.y);
+    transformedBox.transform(wlTransformToHyprutils(invertTransform(m_renderData.pMonitor->m_transform)), m_renderData.pMonitor->m_transformedSize.x,
+                             m_renderData.pMonitor->m_transformedSize.y);
 
     const auto TOPLEFT  = Vector2D(transformedBox.x, transformedBox.y);
     const auto FULLSIZE = Vector2D(transformedBox.width, transformedBox.height);
@@ -1638,14 +1638,14 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, const CB
         glUniform1f(shader->radius, round);
         glUniform1f(shader->roundingPower, roundingPower);
 
-        if (allowDim && m_RenderData.currentWindow) {
-            if (m_RenderData.currentWindow->m_notRespondingTint->value() > 0) {
-                const auto DIM = m_RenderData.currentWindow->m_notRespondingTint->value();
+        if (allowDim && m_renderData.currentWindow) {
+            if (m_renderData.currentWindow->m_notRespondingTint->value() > 0) {
+                const auto DIM = m_renderData.currentWindow->m_notRespondingTint->value();
                 glUniform1i(shader->applyTint, 1);
                 glUniform3f(shader->tint, 1.f - DIM, 1.f - DIM, 1.f - DIM);
-            } else if (m_RenderData.currentWindow->m_dimPercent->value() > 0) {
+            } else if (m_renderData.currentWindow->m_dimPercent->value() > 0) {
                 glUniform1i(shader->applyTint, 1);
-                const auto DIM = m_RenderData.currentWindow->m_dimPercent->value();
+                const auto DIM = m_renderData.currentWindow->m_dimPercent->value();
                 glUniform3f(shader->tint, 1.f - DIM, 1.f - DIM, 1.f - DIM);
             } else
                 glUniform1i(shader->applyTint, 0);
@@ -1654,15 +1654,15 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, const CB
     }
 
     const float verts[] = {
-        m_RenderData.primarySurfaceUVBottomRight.x, m_RenderData.primarySurfaceUVTopLeft.y,     // top right
-        m_RenderData.primarySurfaceUVTopLeft.x,     m_RenderData.primarySurfaceUVTopLeft.y,     // top left
-        m_RenderData.primarySurfaceUVBottomRight.x, m_RenderData.primarySurfaceUVBottomRight.y, // bottom right
-        m_RenderData.primarySurfaceUVTopLeft.x,     m_RenderData.primarySurfaceUVBottomRight.y, // bottom left
+        m_renderData.primarySurfaceUVBottomRight.x, m_renderData.primarySurfaceUVTopLeft.y,     // top right
+        m_renderData.primarySurfaceUVTopLeft.x,     m_renderData.primarySurfaceUVTopLeft.y,     // top left
+        m_renderData.primarySurfaceUVBottomRight.x, m_renderData.primarySurfaceUVBottomRight.y, // bottom right
+        m_renderData.primarySurfaceUVTopLeft.x,     m_renderData.primarySurfaceUVBottomRight.y, // bottom left
     };
 
     glVertexAttribPointer(shader->posAttrib, 2, GL_FLOAT, GL_FALSE, 0, fullVerts);
 
-    if (allowCustomUV && m_RenderData.primarySurfaceUVTopLeft != Vector2D(-1, -1))
+    if (allowCustomUV && m_renderData.primarySurfaceUVTopLeft != Vector2D(-1, -1))
         glVertexAttribPointer(shader->texAttrib, 2, GL_FLOAT, GL_FALSE, 0, verts);
     else
         glVertexAttribPointer(shader->texAttrib, 2, GL_FLOAT, GL_FALSE, 0, fullVerts);
@@ -1670,14 +1670,14 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, const CB
     glEnableVertexAttribArray(shader->posAttrib);
     glEnableVertexAttribArray(shader->texAttrib);
 
-    if (!m_RenderData.clipBox.empty() || !m_RenderData.clipRegion.empty()) {
-        CRegion damageClip = m_RenderData.clipBox;
+    if (!m_renderData.clipBox.empty() || !m_renderData.clipRegion.empty()) {
+        CRegion damageClip = m_renderData.clipBox;
 
-        if (!m_RenderData.clipRegion.empty()) {
-            if (m_RenderData.clipBox.empty())
-                damageClip = m_RenderData.clipRegion;
+        if (!m_renderData.clipRegion.empty()) {
+            if (m_renderData.clipBox.empty())
+                damageClip = m_renderData.clipRegion;
             else
-                damageClip.intersect(m_RenderData.clipRegion);
+                damageClip.intersect(m_renderData.clipRegion);
         }
 
         if (!damageClip.empty()) {
@@ -1696,30 +1696,30 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, const CB
     glDisableVertexAttribArray(shader->posAttrib);
     glDisableVertexAttribArray(shader->texAttrib);
 
-    glBindTexture(tex->m_iTarget, 0);
+    glBindTexture(tex->m_target, 0);
 }
 
 void CHyprOpenGLImpl::renderTexturePrimitive(SP<CTexture> tex, const CBox& box) {
-    RASSERT(m_RenderData.pMonitor, "Tried to render texture without begin()!");
-    RASSERT((tex->m_iTexID > 0), "Attempted to draw nullptr texture!");
+    RASSERT(m_renderData.pMonitor, "Tried to render texture without begin()!");
+    RASSERT((tex->m_texID > 0), "Attempted to draw nullptr texture!");
 
     TRACY_GPU_ZONE("RenderTexturePrimitive");
 
-    if (m_RenderData.damage.empty())
+    if (m_renderData.damage.empty())
         return;
 
     CBox newBox = box;
-    m_RenderData.renderModif.applyToBox(newBox);
+    m_renderData.renderModif.applyToBox(newBox);
 
     // get transform
-    const auto TRANSFORM = wlTransformToHyprutils(invertTransform(!m_bEndFrame ? WL_OUTPUT_TRANSFORM_NORMAL : m_RenderData.pMonitor->m_transform));
-    Mat3x3     matrix    = m_RenderData.monitorProjection.projectBox(newBox, TRANSFORM, newBox.rot);
-    Mat3x3     glMatrix  = m_RenderData.projection.copy().multiply(matrix);
+    const auto TRANSFORM = wlTransformToHyprutils(invertTransform(!m_endFrame ? WL_OUTPUT_TRANSFORM_NORMAL : m_renderData.pMonitor->m_transform));
+    Mat3x3     matrix    = m_renderData.monitorProjection.projectBox(newBox, TRANSFORM, newBox.rot);
+    Mat3x3     glMatrix  = m_renderData.projection.copy().multiply(matrix);
 
     CShader*   shader = &m_shaders->m_shPASSTHRURGBA;
 
     glActiveTexture(GL_TEXTURE0);
-    glBindTexture(tex->m_iTarget, tex->m_iTexID);
+    glBindTexture(tex->m_target, tex->m_texID);
 
     glUseProgram(shader->program);
 
@@ -1737,7 +1737,7 @@ void CHyprOpenGLImpl::renderTexturePrimitive(SP<CTexture> tex, const CBox& box) 
     glEnableVertexAttribArray(shader->posAttrib);
     glEnableVertexAttribArray(shader->texAttrib);
 
-    for (auto const& RECT : m_RenderData.damage.getRects()) {
+    for (auto const& RECT : m_renderData.damage.getRects()) {
         scissor(&RECT);
         glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
     }
@@ -1747,25 +1747,25 @@ void CHyprOpenGLImpl::renderTexturePrimitive(SP<CTexture> tex, const CBox& box) 
     glDisableVertexAttribArray(shader->posAttrib);
     glDisableVertexAttribArray(shader->texAttrib);
 
-    glBindTexture(tex->m_iTarget, 0);
+    glBindTexture(tex->m_target, 0);
 }
 
 void CHyprOpenGLImpl::renderTextureMatte(SP<CTexture> tex, const CBox& box, CFramebuffer& matte) {
-    RASSERT(m_RenderData.pMonitor, "Tried to render texture without begin()!");
-    RASSERT((tex->m_iTexID > 0), "Attempted to draw nullptr texture!");
+    RASSERT(m_renderData.pMonitor, "Tried to render texture without begin()!");
+    RASSERT((tex->m_texID > 0), "Attempted to draw nullptr texture!");
 
     TRACY_GPU_ZONE("RenderTextureMatte");
 
-    if (m_RenderData.damage.empty())
+    if (m_renderData.damage.empty())
         return;
 
     CBox newBox = box;
-    m_RenderData.renderModif.applyToBox(newBox);
+    m_renderData.renderModif.applyToBox(newBox);
 
     // get transform
-    const auto TRANSFORM = wlTransformToHyprutils(invertTransform(!m_bEndFrame ? WL_OUTPUT_TRANSFORM_NORMAL : m_RenderData.pMonitor->m_transform));
-    Mat3x3     matrix    = m_RenderData.monitorProjection.projectBox(newBox, TRANSFORM, newBox.rot);
-    Mat3x3     glMatrix  = m_RenderData.projection.copy().multiply(matrix);
+    const auto TRANSFORM = wlTransformToHyprutils(invertTransform(!m_endFrame ? WL_OUTPUT_TRANSFORM_NORMAL : m_renderData.pMonitor->m_transform));
+    Mat3x3     matrix    = m_renderData.monitorProjection.projectBox(newBox, TRANSFORM, newBox.rot);
+    Mat3x3     glMatrix  = m_renderData.projection.copy().multiply(matrix);
 
     CShader*   shader = &m_shaders->m_shMATTE;
 
@@ -1781,11 +1781,11 @@ void CHyprOpenGLImpl::renderTextureMatte(SP<CTexture> tex, const CBox& box, CFra
     glUniform1i(shader->alphaMatte, 1);
 
     glActiveTexture(GL_TEXTURE0);
-    glBindTexture(tex->m_iTarget, tex->m_iTexID);
+    glBindTexture(tex->m_target, tex->m_texID);
 
     glActiveTexture(GL_TEXTURE0 + 1);
     auto matteTex = matte.getTexture();
-    glBindTexture(matteTex->m_iTarget, matteTex->m_iTexID);
+    glBindTexture(matteTex->m_target, matteTex->m_texID);
 
     glVertexAttribPointer(shader->posAttrib, 2, GL_FLOAT, GL_FALSE, 0, fullVerts);
     glVertexAttribPointer(shader->texAttrib, 2, GL_FLOAT, GL_FALSE, 0, fullVerts);
@@ -1793,7 +1793,7 @@ void CHyprOpenGLImpl::renderTextureMatte(SP<CTexture> tex, const CBox& box, CFra
     glEnableVertexAttribArray(shader->posAttrib);
     glEnableVertexAttribArray(shader->texAttrib);
 
-    for (auto const& RECT : m_RenderData.damage.getRects()) {
+    for (auto const& RECT : m_renderData.damage.getRects()) {
         scissor(&RECT);
         glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
     }
@@ -1803,7 +1803,7 @@ void CHyprOpenGLImpl::renderTextureMatte(SP<CTexture> tex, const CBox& box, CFra
     glDisableVertexAttribArray(shader->posAttrib);
     glDisableVertexAttribArray(shader->texAttrib);
 
-    glBindTexture(tex->m_iTarget, 0);
+    glBindTexture(tex->m_target, 0);
 }
 
 // This probably isn't the fastest
@@ -1812,22 +1812,22 @@ void CHyprOpenGLImpl::renderTextureMatte(SP<CTexture> tex, const CBox& box, CFra
 // Dual (or more) kawase blur
 CFramebuffer* CHyprOpenGLImpl::blurMainFramebufferWithDamage(float a, CRegion* originalDamage) {
 
-    if (!m_RenderData.currentFB->getTexture()) {
+    if (!m_renderData.currentFB->getTexture()) {
         Debug::log(ERR, "BUG THIS: null fb texture while attempting to blur main fb?! (introspection off?!)");
-        return &m_RenderData.pCurrentMonData->mirrorFB; // return something to sample from at least
+        return &m_renderData.pCurrentMonData->mirrorFB; // return something to sample from at least
     }
 
     TRACY_GPU_ZONE("RenderBlurMainFramebufferWithDamage");
 
-    const auto BLENDBEFORE = m_bBlend;
+    const auto BLENDBEFORE = m_blend;
     blend(false);
     glDisable(GL_STENCIL_TEST);
 
     // get transforms for the full monitor
-    const auto TRANSFORM  = wlTransformToHyprutils(invertTransform(m_RenderData.pMonitor->m_transform));
-    CBox       MONITORBOX = {0, 0, m_RenderData.pMonitor->m_transformedSize.x, m_RenderData.pMonitor->m_transformedSize.y};
-    Mat3x3     matrix     = m_RenderData.monitorProjection.projectBox(MONITORBOX, TRANSFORM);
-    Mat3x3     glMatrix   = m_RenderData.projection.copy().multiply(matrix);
+    const auto TRANSFORM  = wlTransformToHyprutils(invertTransform(m_renderData.pMonitor->m_transform));
+    CBox       MONITORBOX = {0, 0, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y};
+    Mat3x3     matrix     = m_renderData.monitorProjection.projectBox(MONITORBOX, TRANSFORM);
+    Mat3x3     glMatrix   = m_renderData.projection.copy().multiply(matrix);
 
     // get the config settings
     static auto PBLURSIZE             = CConfigValue<Hyprlang::INT>("decoration:blur:size");
@@ -1837,13 +1837,13 @@ CFramebuffer* CHyprOpenGLImpl::blurMainFramebufferWithDamage(float a, CRegion* o
 
     // prep damage
     CRegion damage{*originalDamage};
-    damage.transform(wlTransformToHyprutils(invertTransform(m_RenderData.pMonitor->m_transform)), m_RenderData.pMonitor->m_transformedSize.x,
-                     m_RenderData.pMonitor->m_transformedSize.y);
+    damage.transform(wlTransformToHyprutils(invertTransform(m_renderData.pMonitor->m_transform)), m_renderData.pMonitor->m_transformedSize.x,
+                     m_renderData.pMonitor->m_transformedSize.y);
     damage.expand(*PBLURPASSES > 10 ? pow(2, 15) : std::clamp(*PBLURSIZE, (int64_t)1, (int64_t)40) * pow(2, *PBLURPASSES));
 
     // helper
-    const auto    PMIRRORFB     = &m_RenderData.pCurrentMonData->mirrorFB;
-    const auto    PMIRRORSWAPFB = &m_RenderData.pCurrentMonData->mirrorSwapFB;
+    const auto    PMIRRORFB     = &m_renderData.pCurrentMonData->mirrorFB;
+    const auto    PMIRRORSWAPFB = &m_renderData.pCurrentMonData->mirrorSwapFB;
 
     CFramebuffer* currentRenderToFB = PMIRRORFB;
 
@@ -1857,28 +1857,28 @@ CFramebuffer* CHyprOpenGLImpl::blurMainFramebufferWithDamage(float a, CRegion* o
 
         glActiveTexture(GL_TEXTURE0);
 
-        auto currentTex = m_RenderData.currentFB->getTexture();
+        auto currentTex = m_renderData.currentFB->getTexture();
 
-        glBindTexture(currentTex->m_iTarget, currentTex->m_iTexID);
+        glBindTexture(currentTex->m_target, currentTex->m_texID);
 
-        glTexParameteri(currentTex->m_iTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(currentTex->m_target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
         glUseProgram(m_shaders->m_shBLURPREPARE.program);
 
         // From FB to sRGB
-        const bool skipCM = !m_bCMSupported || m_RenderData.pMonitor->m_imageDescription == SImageDescription{};
+        const bool skipCM = !m_cmSupported || m_renderData.pMonitor->m_imageDescription == SImageDescription{};
         glUniform1i(m_shaders->m_shBLURPREPARE.skipCM, skipCM);
         if (!skipCM) {
-            passCMUniforms(m_shaders->m_shBLURPREPARE, m_RenderData.pMonitor->m_imageDescription, SImageDescription{});
+            passCMUniforms(m_shaders->m_shBLURPREPARE, m_renderData.pMonitor->m_imageDescription, SImageDescription{});
             glUniform1f(m_shaders->m_shBLURPREPARE.sdrSaturation,
-                        m_RenderData.pMonitor->m_sdrSaturation > 0 &&
-                                m_RenderData.pMonitor->m_imageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ ?
-                            m_RenderData.pMonitor->m_sdrSaturation :
+                        m_renderData.pMonitor->m_sdrSaturation > 0 &&
+                                m_renderData.pMonitor->m_imageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ ?
+                            m_renderData.pMonitor->m_sdrSaturation :
                             1.0f);
             glUniform1f(m_shaders->m_shBLURPREPARE.sdrBrightness,
-                        m_RenderData.pMonitor->m_sdrBrightness > 0 &&
-                                m_RenderData.pMonitor->m_imageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ ?
-                            m_RenderData.pMonitor->m_sdrBrightness :
+                        m_renderData.pMonitor->m_sdrBrightness > 0 &&
+                                m_renderData.pMonitor->m_imageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ ?
+                            m_renderData.pMonitor->m_sdrBrightness :
                             1.0f);
         }
 
@@ -1922,9 +1922,9 @@ CFramebuffer* CHyprOpenGLImpl::blurMainFramebufferWithDamage(float a, CRegion* o
 
         auto currentTex = currentRenderToFB->getTexture();
 
-        glBindTexture(currentTex->m_iTarget, currentTex->m_iTexID);
+        glBindTexture(currentTex->m_target, currentTex->m_texID);
 
-        glTexParameteri(currentTex->m_iTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(currentTex->m_target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
         glUseProgram(pShader->program);
 
@@ -1937,12 +1937,12 @@ CFramebuffer* CHyprOpenGLImpl::blurMainFramebufferWithDamage(float a, CRegion* o
 #endif
         glUniform1f(pShader->radius, *PBLURSIZE * a); // this makes the blursize change with a
         if (pShader == &m_shaders->m_shBLUR1) {
-            glUniform2f(m_shaders->m_shBLUR1.halfpixel, 0.5f / (m_RenderData.pMonitor->m_pixelSize.x / 2.f), 0.5f / (m_RenderData.pMonitor->m_pixelSize.y / 2.f));
+            glUniform2f(m_shaders->m_shBLUR1.halfpixel, 0.5f / (m_renderData.pMonitor->m_pixelSize.x / 2.f), 0.5f / (m_renderData.pMonitor->m_pixelSize.y / 2.f));
             glUniform1i(m_shaders->m_shBLUR1.passes, *PBLURPASSES);
             glUniform1f(m_shaders->m_shBLUR1.vibrancy, *PBLURVIBRANCY);
             glUniform1f(m_shaders->m_shBLUR1.vibrancy_darkness, *PBLURVIBRANCYDARKNESS);
         } else
-            glUniform2f(m_shaders->m_shBLUR2.halfpixel, 0.5f / (m_RenderData.pMonitor->m_pixelSize.x * 2.f), 0.5f / (m_RenderData.pMonitor->m_pixelSize.y * 2.f));
+            glUniform2f(m_shaders->m_shBLUR2.halfpixel, 0.5f / (m_renderData.pMonitor->m_pixelSize.x * 2.f), 0.5f / (m_renderData.pMonitor->m_pixelSize.y * 2.f));
         glUniform1i(pShader->tex, 0);
 
         glVertexAttribPointer(pShader->posAttrib, 2, GL_FLOAT, GL_FALSE, 0, fullVerts);
@@ -1970,7 +1970,7 @@ CFramebuffer* CHyprOpenGLImpl::blurMainFramebufferWithDamage(float a, CRegion* o
     // draw the things.
     // first draw is swap -> mirr
     PMIRRORFB->bind();
-    glBindTexture(PMIRRORSWAPFB->getTexture()->m_iTarget, PMIRRORSWAPFB->getTexture()->m_iTexID);
+    glBindTexture(PMIRRORSWAPFB->getTexture()->m_target, PMIRRORSWAPFB->getTexture()->m_texID);
 
     // damage region will be scaled, make a temp
     CRegion tempDamage{damage};
@@ -2000,9 +2000,9 @@ CFramebuffer* CHyprOpenGLImpl::blurMainFramebufferWithDamage(float a, CRegion* o
 
         auto currentTex = currentRenderToFB->getTexture();
 
-        glBindTexture(currentTex->m_iTarget, currentTex->m_iTexID);
+        glBindTexture(currentTex->m_target, currentTex->m_texID);
 
-        glTexParameteri(currentTex->m_iTarget, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(currentTex->m_target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
         glUseProgram(m_shaders->m_shBLURFINISH.program);
 
@@ -2040,7 +2040,7 @@ CFramebuffer* CHyprOpenGLImpl::blurMainFramebufferWithDamage(float a, CRegion* o
     }
 
     // finish
-    glBindTexture(PMIRRORFB->getTexture()->m_iTarget, 0);
+    glBindTexture(PMIRRORFB->getTexture()->m_target, 0);
 
     blend(BLENDBEFORE);
 
@@ -2048,7 +2048,7 @@ CFramebuffer* CHyprOpenGLImpl::blurMainFramebufferWithDamage(float a, CRegion* o
 }
 
 void CHyprOpenGLImpl::markBlurDirtyForMonitor(PHLMONITOR pMonitor) {
-    m_mMonitorRenderResources[pMonitor].blurFBDirty = true;
+    m_monitorRenderResources[pMonitor].blurFBDirty = true;
 }
 
 void CHyprOpenGLImpl::preRender(PHLMONITOR pMonitor) {
@@ -2056,7 +2056,7 @@ void CHyprOpenGLImpl::preRender(PHLMONITOR pMonitor) {
     static auto PBLURXRAY        = CConfigValue<Hyprlang::INT>("decoration:blur:xray");
     static auto PBLUR            = CConfigValue<Hyprlang::INT>("decoration:blur:enabled");
 
-    if (!*PBLURNEWOPTIMIZE || !m_mMonitorRenderResources[pMonitor].blurFBDirty || !*PBLUR)
+    if (!*PBLURNEWOPTIMIZE || !m_monitorRenderResources[pMonitor].blurFBDirty || !*PBLUR)
         return;
 
     // ignore if solitary present, nothing to blur
@@ -2131,60 +2131,60 @@ void CHyprOpenGLImpl::preRender(PHLMONITOR pMonitor) {
         return;
 
     g_pHyprRenderer->damageMonitor(pMonitor);
-    m_mMonitorRenderResources[pMonitor].blurFBShouldRender = true;
+    m_monitorRenderResources[pMonitor].blurFBShouldRender = true;
 }
 
 void CHyprOpenGLImpl::preBlurForCurrentMonitor() {
 
     TRACY_GPU_ZONE("RenderPreBlurForCurrentMonitor");
 
-    const auto SAVEDRENDERMODIF = m_RenderData.renderModif;
-    m_RenderData.renderModif    = {}; // fix shit
+    const auto SAVEDRENDERMODIF = m_renderData.renderModif;
+    m_renderData.renderModif    = {}; // fix shit
 
     // make the fake dmg
-    CRegion    fakeDamage{0, 0, m_RenderData.pMonitor->m_transformedSize.x, m_RenderData.pMonitor->m_transformedSize.y};
+    CRegion    fakeDamage{0, 0, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y};
     const auto POUTFB = blurMainFramebufferWithDamage(1, &fakeDamage);
 
     // render onto blurFB
-    m_RenderData.pCurrentMonData->blurFB.alloc(m_RenderData.pMonitor->m_pixelSize.x, m_RenderData.pMonitor->m_pixelSize.y,
-                                               m_RenderData.pMonitor->m_output->state->state().drmFormat);
-    m_RenderData.pCurrentMonData->blurFB.bind();
+    m_renderData.pCurrentMonData->blurFB.alloc(m_renderData.pMonitor->m_pixelSize.x, m_renderData.pMonitor->m_pixelSize.y,
+                                               m_renderData.pMonitor->m_output->state->state().drmFormat);
+    m_renderData.pCurrentMonData->blurFB.bind();
 
     clear(CHyprColor(0, 0, 0, 0));
 
-    m_bEndFrame = true; // fix transformed
-    renderTextureInternalWithDamage(POUTFB->getTexture(), CBox{0, 0, m_RenderData.pMonitor->m_transformedSize.x, m_RenderData.pMonitor->m_transformedSize.y}, 1, fakeDamage, 0,
+    m_endFrame = true; // fix transformed
+    renderTextureInternalWithDamage(POUTFB->getTexture(), CBox{0, 0, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y}, 1, fakeDamage, 0,
                                     2.0f, false, true, false);
-    m_bEndFrame = false;
+    m_endFrame = false;
 
-    m_RenderData.currentFB->bind();
+    m_renderData.currentFB->bind();
 
-    m_RenderData.pCurrentMonData->blurFBDirty = false;
+    m_renderData.pCurrentMonData->blurFBDirty = false;
 
-    m_RenderData.renderModif = SAVEDRENDERMODIF;
+    m_renderData.renderModif = SAVEDRENDERMODIF;
 
-    m_mMonitorRenderResources[m_RenderData.pMonitor].blurFBShouldRender = false;
+    m_monitorRenderResources[m_renderData.pMonitor].blurFBShouldRender = false;
 }
 
 void CHyprOpenGLImpl::preWindowPass() {
     if (!preBlurQueued())
         return;
 
-    g_pHyprRenderer->m_sRenderPass.add(makeShared<CPreBlurElement>());
+    g_pHyprRenderer->m_renderPass.add(makeShared<CPreBlurElement>());
 }
 
 bool CHyprOpenGLImpl::preBlurQueued() {
     static auto PBLURNEWOPTIMIZE = CConfigValue<Hyprlang::INT>("decoration:blur:new_optimizations");
     static auto PBLUR            = CConfigValue<Hyprlang::INT>("decoration:blur:enabled");
 
-    return m_RenderData.pCurrentMonData->blurFBDirty && *PBLURNEWOPTIMIZE && *PBLUR && m_RenderData.pCurrentMonData->blurFBShouldRender;
+    return m_renderData.pCurrentMonData->blurFBDirty && *PBLURNEWOPTIMIZE && *PBLUR && m_renderData.pCurrentMonData->blurFBShouldRender;
 }
 
 bool CHyprOpenGLImpl::shouldUseNewBlurOptimizations(PHLLS pLayer, PHLWINDOW pWindow) {
     static auto PBLURNEWOPTIMIZE = CConfigValue<Hyprlang::INT>("decoration:blur:new_optimizations");
     static auto PBLURXRAY        = CConfigValue<Hyprlang::INT>("decoration:blur:xray");
 
-    if (!m_RenderData.pCurrentMonData->blurFB.getTexture())
+    if (!m_renderData.pCurrentMonData->blurFB.getTexture())
         return false;
 
     if (pWindow && pWindow->m_windowData.xray.hasValue() && !pWindow->m_windowData.xray.valueOrDefault())
@@ -2204,28 +2204,28 @@ bool CHyprOpenGLImpl::shouldUseNewBlurOptimizations(PHLLS pLayer, PHLWINDOW pWin
 
 void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, const CBox& box, float a, SP<CWLSurfaceResource> pSurface, int round, float roundingPower, bool blockBlurOptimization,
                                             float blurA, float overallA) {
-    RASSERT(m_RenderData.pMonitor, "Tried to render texture with blur without begin()!");
+    RASSERT(m_renderData.pMonitor, "Tried to render texture with blur without begin()!");
 
     TRACY_GPU_ZONE("RenderTextureWithBlur");
 
     // make a damage region for this window
-    CRegion texDamage{m_RenderData.damage};
+    CRegion texDamage{m_renderData.damage};
     texDamage.intersect(box.x, box.y, box.width, box.height);
 
     // While renderTextureInternalWithDamage will clip the blur as well,
     // clipping texDamage here allows blur generation to be optimized.
-    if (!m_RenderData.clipRegion.empty())
-        texDamage.intersect(m_RenderData.clipRegion);
+    if (!m_renderData.clipRegion.empty())
+        texDamage.intersect(m_renderData.clipRegion);
 
     if (texDamage.empty())
         return;
 
-    m_RenderData.renderModif.applyToRegion(texDamage);
+    m_renderData.renderModif.applyToRegion(texDamage);
 
     // amazing hack: the surface has an opaque region!
     CRegion inverseOpaque;
-    if (a >= 1.f && std::round(pSurface->m_current.size.x * m_RenderData.pMonitor->m_scale) == box.w &&
-        std::round(pSurface->m_current.size.y * m_RenderData.pMonitor->m_scale) == box.h) {
+    if (a >= 1.f && std::round(pSurface->m_current.size.x * m_renderData.pMonitor->m_scale) == box.w &&
+        std::round(pSurface->m_current.size.y * m_renderData.pMonitor->m_scale) == box.h) {
         pixman_box32_t surfbox = {0, 0, pSurface->m_current.size.x * pSurface->m_current.scale, pSurface->m_current.size.y * pSurface->m_current.scale};
         inverseOpaque          = pSurface->m_current.opaque;
         inverseOpaque.invert(&surfbox).intersect(0, 0, pSurface->m_current.size.x * pSurface->m_current.scale, pSurface->m_current.size.y * pSurface->m_current.scale);
@@ -2237,22 +2237,22 @@ void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, const CBox& box, f
     } else
         inverseOpaque = {0, 0, box.width, box.height};
 
-    inverseOpaque.scale(m_RenderData.pMonitor->m_scale);
+    inverseOpaque.scale(m_renderData.pMonitor->m_scale);
 
     //   vvv TODO: layered blur fbs?
-    const bool    USENEWOPTIMIZE = shouldUseNewBlurOptimizations(m_RenderData.currentLS.lock(), m_RenderData.currentWindow.lock()) && !blockBlurOptimization;
+    const bool    USENEWOPTIMIZE = shouldUseNewBlurOptimizations(m_renderData.currentLS.lock(), m_renderData.currentWindow.lock()) && !blockBlurOptimization;
 
     CFramebuffer* POUTFB = nullptr;
     if (!USENEWOPTIMIZE) {
         inverseOpaque.translate(box.pos());
-        m_RenderData.renderModif.applyToRegion(inverseOpaque);
+        m_renderData.renderModif.applyToRegion(inverseOpaque);
         inverseOpaque.intersect(texDamage);
 
         POUTFB = blurMainFramebufferWithDamage(a, &inverseOpaque);
     } else
-        POUTFB = &m_RenderData.pCurrentMonData->blurFB;
+        POUTFB = &m_renderData.pCurrentMonData->blurFB;
 
-    m_RenderData.currentFB->bind();
+    m_renderData.currentFB->bind();
 
     // make a stencil for rounded corners to work with blur
     scissor(nullptr); // allow the entire window and stencil to render
@@ -2265,7 +2265,7 @@ void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, const CBox& box, f
     glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
 
     glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
-    if (USENEWOPTIMIZE && !(m_RenderData.discardMode & DISCARD_ALPHA))
+    if (USENEWOPTIMIZE && !(m_renderData.discardMode & DISCARD_ALPHA))
         renderRect(box, CHyprColor(0, 0, 0, 0), round, roundingPower);
     else
         renderTexture(tex, box, a, round, roundingPower, true, true); // discard opaque
@@ -2275,20 +2275,20 @@ void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, const CBox& box, f
     glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
 
     // stencil done. Render everything.
-    const auto LASTTL = m_RenderData.primarySurfaceUVTopLeft;
-    const auto LASTBR = m_RenderData.primarySurfaceUVBottomRight;
+    const auto LASTTL = m_renderData.primarySurfaceUVTopLeft;
+    const auto LASTBR = m_renderData.primarySurfaceUVBottomRight;
 
     CBox       transformedBox = box;
-    transformedBox.transform(wlTransformToHyprutils(invertTransform(m_RenderData.pMonitor->m_transform)), m_RenderData.pMonitor->m_transformedSize.x,
-                             m_RenderData.pMonitor->m_transformedSize.y);
+    transformedBox.transform(wlTransformToHyprutils(invertTransform(m_renderData.pMonitor->m_transform)), m_renderData.pMonitor->m_transformedSize.x,
+                             m_renderData.pMonitor->m_transformedSize.y);
 
-    CBox monitorSpaceBox = {transformedBox.pos().x / m_RenderData.pMonitor->m_pixelSize.x * m_RenderData.pMonitor->m_transformedSize.x,
-                            transformedBox.pos().y / m_RenderData.pMonitor->m_pixelSize.y * m_RenderData.pMonitor->m_transformedSize.y,
-                            transformedBox.width / m_RenderData.pMonitor->m_pixelSize.x * m_RenderData.pMonitor->m_transformedSize.x,
-                            transformedBox.height / m_RenderData.pMonitor->m_pixelSize.y * m_RenderData.pMonitor->m_transformedSize.y};
+    CBox monitorSpaceBox = {transformedBox.pos().x / m_renderData.pMonitor->m_pixelSize.x * m_renderData.pMonitor->m_transformedSize.x,
+                            transformedBox.pos().y / m_renderData.pMonitor->m_pixelSize.y * m_renderData.pMonitor->m_transformedSize.y,
+                            transformedBox.width / m_renderData.pMonitor->m_pixelSize.x * m_renderData.pMonitor->m_transformedSize.x,
+                            transformedBox.height / m_renderData.pMonitor->m_pixelSize.y * m_renderData.pMonitor->m_transformedSize.y};
 
-    m_RenderData.primarySurfaceUVTopLeft     = monitorSpaceBox.pos() / m_RenderData.pMonitor->m_transformedSize;
-    m_RenderData.primarySurfaceUVBottomRight = (monitorSpaceBox.pos() + monitorSpaceBox.size()) / m_RenderData.pMonitor->m_transformedSize;
+    m_renderData.primarySurfaceUVTopLeft     = monitorSpaceBox.pos() / m_renderData.pMonitor->m_transformedSize;
+    m_renderData.primarySurfaceUVBottomRight = (monitorSpaceBox.pos() + monitorSpaceBox.size()) / m_renderData.pMonitor->m_transformedSize;
 
     static auto PBLURIGNOREOPACITY = CConfigValue<Hyprlang::INT>("decoration:blur:ignore_opacity");
     setMonitorTransformEnabled(true);
@@ -2299,8 +2299,8 @@ void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, const CBox& box, f
         setRenderModifEnabled(true);
     setMonitorTransformEnabled(false);
 
-    m_RenderData.primarySurfaceUVTopLeft     = LASTTL;
-    m_RenderData.primarySurfaceUVBottomRight = LASTBR;
+    m_renderData.primarySurfaceUVTopLeft     = LASTTL;
+    m_renderData.primarySurfaceUVBottomRight = LASTBR;
 
     // render the window, but clear stencil
     glClearStencil(0);
@@ -2317,21 +2317,21 @@ void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, const CBox& box, f
 
 void CHyprOpenGLImpl::renderBorder(const CBox& box, const CGradientValueData& grad, int round, float roundingPower, int borderSize, float a, int outerRound) {
     RASSERT((box.width > 0 && box.height > 0), "Tried to render rect with width/height < 0!");
-    RASSERT(m_RenderData.pMonitor, "Tried to render rect without begin()!");
+    RASSERT(m_renderData.pMonitor, "Tried to render rect without begin()!");
 
     TRACY_GPU_ZONE("RenderBorder");
 
-    if (m_RenderData.damage.empty() || (m_RenderData.currentWindow && m_RenderData.currentWindow->m_windowData.noBorder.valueOrDefault()))
+    if (m_renderData.damage.empty() || (m_renderData.currentWindow && m_renderData.currentWindow->m_windowData.noBorder.valueOrDefault()))
         return;
 
     CBox newBox = box;
-    m_RenderData.renderModif.applyToBox(newBox);
+    m_renderData.renderModif.applyToBox(newBox);
 
     if (borderSize < 1)
         return;
 
-    int scaledBorderSize = std::round(borderSize * m_RenderData.pMonitor->m_scale);
-    scaledBorderSize     = std::round(scaledBorderSize * m_RenderData.renderModif.combinedScale());
+    int scaledBorderSize = std::round(borderSize * m_renderData.pMonitor->m_scale);
+    scaledBorderSize     = std::round(scaledBorderSize * m_renderData.renderModif.combinedScale());
 
     // adjust box
     newBox.x -= scaledBorderSize;
@@ -2341,16 +2341,16 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const CGradientValueData& gr
 
     round += round == 0 ? 0 : scaledBorderSize;
 
-    Mat3x3 matrix = m_RenderData.monitorProjection.projectBox(
-        newBox, wlTransformToHyprutils(invertTransform(!m_bEndFrame ? WL_OUTPUT_TRANSFORM_NORMAL : m_RenderData.pMonitor->m_transform)), newBox.rot);
-    Mat3x3     glMatrix = m_RenderData.projection.copy().multiply(matrix);
+    Mat3x3 matrix = m_renderData.monitorProjection.projectBox(
+        newBox, wlTransformToHyprutils(invertTransform(!m_endFrame ? WL_OUTPUT_TRANSFORM_NORMAL : m_renderData.pMonitor->m_transform)), newBox.rot);
+    Mat3x3     glMatrix = m_renderData.projection.copy().multiply(matrix);
 
-    const auto BLEND = m_bBlend;
+    const auto BLEND = m_blend;
     blend(true);
 
     glUseProgram(m_shaders->m_shBORDER1.program);
 
-    const bool skipCM = !m_bCMSupported || m_RenderData.pMonitor->m_imageDescription == SImageDescription{};
+    const bool skipCM = !m_cmSupported || m_renderData.pMonitor->m_imageDescription == SImageDescription{};
     glUniform1i(m_shaders->m_shBORDER1.skipCM, skipCM);
     if (!skipCM)
         passCMUniforms(m_shaders->m_shBORDER1, SImageDescription{});
@@ -2369,8 +2369,8 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const CGradientValueData& gr
     glUniform1i(m_shaders->m_shBORDER1.gradient2Length, 0);
 
     CBox transformedBox = newBox;
-    transformedBox.transform(wlTransformToHyprutils(invertTransform(m_RenderData.pMonitor->m_transform)), m_RenderData.pMonitor->m_transformedSize.x,
-                             m_RenderData.pMonitor->m_transformedSize.y);
+    transformedBox.transform(wlTransformToHyprutils(invertTransform(m_renderData.pMonitor->m_transform)), m_renderData.pMonitor->m_transformedSize.x,
+                             m_renderData.pMonitor->m_transformedSize.y);
 
     const auto TOPLEFT  = Vector2D(transformedBox.x, transformedBox.y);
     const auto FULLSIZE = Vector2D(transformedBox.width, transformedBox.height);
@@ -2389,9 +2389,9 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const CGradientValueData& gr
     glEnableVertexAttribArray(m_shaders->m_shBORDER1.posAttrib);
     glEnableVertexAttribArray(m_shaders->m_shBORDER1.texAttrib);
 
-    if (m_RenderData.clipBox.width != 0 && m_RenderData.clipBox.height != 0) {
-        CRegion damageClip{m_RenderData.clipBox.x, m_RenderData.clipBox.y, m_RenderData.clipBox.width, m_RenderData.clipBox.height};
-        damageClip.intersect(m_RenderData.damage);
+    if (m_renderData.clipBox.width != 0 && m_renderData.clipBox.height != 0) {
+        CRegion damageClip{m_renderData.clipBox.x, m_renderData.clipBox.y, m_renderData.clipBox.width, m_renderData.clipBox.height};
+        damageClip.intersect(m_renderData.damage);
 
         if (!damageClip.empty()) {
             for (auto const& RECT : damageClip.getRects()) {
@@ -2400,7 +2400,7 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const CGradientValueData& gr
             }
         }
     } else {
-        for (auto const& RECT : m_RenderData.damage.getRects()) {
+        for (auto const& RECT : m_renderData.damage.getRects()) {
             scissor(&RECT);
             glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
         }
@@ -2415,21 +2415,21 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const CGradientValueData& gr
 void CHyprOpenGLImpl::renderBorder(const CBox& box, const CGradientValueData& grad1, const CGradientValueData& grad2, float lerp, int round, float roundingPower, int borderSize,
                                    float a, int outerRound) {
     RASSERT((box.width > 0 && box.height > 0), "Tried to render rect with width/height < 0!");
-    RASSERT(m_RenderData.pMonitor, "Tried to render rect without begin()!");
+    RASSERT(m_renderData.pMonitor, "Tried to render rect without begin()!");
 
     TRACY_GPU_ZONE("RenderBorder2");
 
-    if (m_RenderData.damage.empty() || (m_RenderData.currentWindow && m_RenderData.currentWindow->m_windowData.noBorder.valueOrDefault()))
+    if (m_renderData.damage.empty() || (m_renderData.currentWindow && m_renderData.currentWindow->m_windowData.noBorder.valueOrDefault()))
         return;
 
     CBox newBox = box;
-    m_RenderData.renderModif.applyToBox(newBox);
+    m_renderData.renderModif.applyToBox(newBox);
 
     if (borderSize < 1)
         return;
 
-    int scaledBorderSize = std::round(borderSize * m_RenderData.pMonitor->m_scale);
-    scaledBorderSize     = std::round(scaledBorderSize * m_RenderData.renderModif.combinedScale());
+    int scaledBorderSize = std::round(borderSize * m_renderData.pMonitor->m_scale);
+    scaledBorderSize     = std::round(scaledBorderSize * m_renderData.renderModif.combinedScale());
 
     // adjust box
     newBox.x -= scaledBorderSize;
@@ -2439,11 +2439,11 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const CGradientValueData& gr
 
     round += round == 0 ? 0 : scaledBorderSize;
 
-    Mat3x3 matrix = m_RenderData.monitorProjection.projectBox(
-        newBox, wlTransformToHyprutils(invertTransform(!m_bEndFrame ? WL_OUTPUT_TRANSFORM_NORMAL : m_RenderData.pMonitor->m_transform)), newBox.rot);
-    Mat3x3     glMatrix = m_RenderData.projection.copy().multiply(matrix);
+    Mat3x3 matrix = m_renderData.monitorProjection.projectBox(
+        newBox, wlTransformToHyprutils(invertTransform(!m_endFrame ? WL_OUTPUT_TRANSFORM_NORMAL : m_renderData.pMonitor->m_transform)), newBox.rot);
+    Mat3x3     glMatrix = m_renderData.projection.copy().multiply(matrix);
 
-    const auto BLEND = m_bBlend;
+    const auto BLEND = m_blend;
     blend(true);
 
     glUseProgram(m_shaders->m_shBORDER1.program);
@@ -2466,8 +2466,8 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const CGradientValueData& gr
     glUniform1f(m_shaders->m_shBORDER1.gradientLerp, lerp);
 
     CBox transformedBox = newBox;
-    transformedBox.transform(wlTransformToHyprutils(invertTransform(m_RenderData.pMonitor->m_transform)), m_RenderData.pMonitor->m_transformedSize.x,
-                             m_RenderData.pMonitor->m_transformedSize.y);
+    transformedBox.transform(wlTransformToHyprutils(invertTransform(m_renderData.pMonitor->m_transform)), m_renderData.pMonitor->m_transformedSize.x,
+                             m_renderData.pMonitor->m_transformedSize.y);
 
     const auto TOPLEFT  = Vector2D(transformedBox.x, transformedBox.y);
     const auto FULLSIZE = Vector2D(transformedBox.width, transformedBox.height);
@@ -2486,9 +2486,9 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const CGradientValueData& gr
     glEnableVertexAttribArray(m_shaders->m_shBORDER1.posAttrib);
     glEnableVertexAttribArray(m_shaders->m_shBORDER1.texAttrib);
 
-    if (m_RenderData.clipBox.width != 0 && m_RenderData.clipBox.height != 0) {
-        CRegion damageClip{m_RenderData.clipBox.x, m_RenderData.clipBox.y, m_RenderData.clipBox.width, m_RenderData.clipBox.height};
-        damageClip.intersect(m_RenderData.damage);
+    if (m_renderData.clipBox.width != 0 && m_renderData.clipBox.height != 0) {
+        CRegion damageClip{m_renderData.clipBox.x, m_renderData.clipBox.y, m_renderData.clipBox.width, m_renderData.clipBox.height};
+        damageClip.intersect(m_renderData.damage);
 
         if (!damageClip.empty()) {
             for (auto const& RECT : damageClip.getRects()) {
@@ -2497,7 +2497,7 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const CGradientValueData& gr
             }
         }
     } else {
-        for (auto const& RECT : m_RenderData.damage.getRects()) {
+        for (auto const& RECT : m_renderData.damage.getRects()) {
             scissor(&RECT);
             glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
         }
@@ -2510,17 +2510,17 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const CGradientValueData& gr
 }
 
 void CHyprOpenGLImpl::renderRoundedShadow(const CBox& box, int round, float roundingPower, int range, const CHyprColor& color, float a) {
-    RASSERT(m_RenderData.pMonitor, "Tried to render shadow without begin()!");
+    RASSERT(m_renderData.pMonitor, "Tried to render shadow without begin()!");
     RASSERT((box.width > 0 && box.height > 0), "Tried to render shadow with width/height < 0!");
-    RASSERT(m_RenderData.currentWindow, "Tried to render shadow without a window!");
+    RASSERT(m_renderData.currentWindow, "Tried to render shadow without a window!");
 
-    if (m_RenderData.damage.empty())
+    if (m_renderData.damage.empty())
         return;
 
     TRACY_GPU_ZONE("RenderShadow");
 
     CBox newBox = box;
-    m_RenderData.renderModif.applyToBox(newBox);
+    m_renderData.renderModif.applyToBox(newBox);
 
     static auto PSHADOWPOWER = CConfigValue<Hyprlang::INT>("decoration:shadow:render_power");
 
@@ -2528,14 +2528,14 @@ void CHyprOpenGLImpl::renderRoundedShadow(const CBox& box, int round, float roun
 
     const auto  col = color;
 
-    Mat3x3      matrix = m_RenderData.monitorProjection.projectBox(
-        newBox, wlTransformToHyprutils(invertTransform(!m_bEndFrame ? WL_OUTPUT_TRANSFORM_NORMAL : m_RenderData.pMonitor->m_transform)), newBox.rot);
-    Mat3x3 glMatrix = m_RenderData.projection.copy().multiply(matrix);
+    Mat3x3      matrix = m_renderData.monitorProjection.projectBox(
+        newBox, wlTransformToHyprutils(invertTransform(!m_endFrame ? WL_OUTPUT_TRANSFORM_NORMAL : m_renderData.pMonitor->m_transform)), newBox.rot);
+    Mat3x3 glMatrix = m_renderData.projection.copy().multiply(matrix);
 
     blend(true);
 
     glUseProgram(m_shaders->m_shSHADOW.program);
-    const bool skipCM = !m_bCMSupported || m_RenderData.pMonitor->m_imageDescription == SImageDescription{};
+    const bool skipCM = !m_cmSupported || m_renderData.pMonitor->m_imageDescription == SImageDescription{};
     glUniform1i(m_shaders->m_shSHADOW.skipCM, skipCM);
     if (!skipCM)
         passCMUniforms(m_shaders->m_shSHADOW, SImageDescription{});
@@ -2567,9 +2567,9 @@ void CHyprOpenGLImpl::renderRoundedShadow(const CBox& box, int round, float roun
     glEnableVertexAttribArray(m_shaders->m_shSHADOW.posAttrib);
     glEnableVertexAttribArray(m_shaders->m_shSHADOW.texAttrib);
 
-    if (m_RenderData.clipBox.width != 0 && m_RenderData.clipBox.height != 0) {
-        CRegion damageClip{m_RenderData.clipBox.x, m_RenderData.clipBox.y, m_RenderData.clipBox.width, m_RenderData.clipBox.height};
-        damageClip.intersect(m_RenderData.damage);
+    if (m_renderData.clipBox.width != 0 && m_renderData.clipBox.height != 0) {
+        CRegion damageClip{m_renderData.clipBox.x, m_renderData.clipBox.y, m_renderData.clipBox.width, m_renderData.clipBox.height};
+        damageClip.intersect(m_renderData.damage);
 
         if (!damageClip.empty()) {
             for (auto const& RECT : damageClip.getRects()) {
@@ -2578,7 +2578,7 @@ void CHyprOpenGLImpl::renderRoundedShadow(const CBox& box, int round, float roun
             }
         }
     } else {
-        for (auto const& RECT : m_RenderData.damage.getRects()) {
+        for (auto const& RECT : m_renderData.damage.getRects()) {
             scissor(&RECT);
             glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
         }
@@ -2590,24 +2590,24 @@ void CHyprOpenGLImpl::renderRoundedShadow(const CBox& box, int round, float roun
 
 void CHyprOpenGLImpl::saveBufferForMirror(const CBox& box) {
 
-    if (!m_RenderData.pCurrentMonData->monitorMirrorFB.isAllocated())
-        m_RenderData.pCurrentMonData->monitorMirrorFB.alloc(m_RenderData.pMonitor->m_pixelSize.x, m_RenderData.pMonitor->m_pixelSize.y,
-                                                            m_RenderData.pMonitor->m_output->state->state().drmFormat);
+    if (!m_renderData.pCurrentMonData->monitorMirrorFB.isAllocated())
+        m_renderData.pCurrentMonData->monitorMirrorFB.alloc(m_renderData.pMonitor->m_pixelSize.x, m_renderData.pMonitor->m_pixelSize.y,
+                                                            m_renderData.pMonitor->m_output->state->state().drmFormat);
 
-    m_RenderData.pCurrentMonData->monitorMirrorFB.bind();
+    m_renderData.pCurrentMonData->monitorMirrorFB.bind();
 
     blend(false);
 
-    renderTexture(m_RenderData.currentFB->getTexture(), box, 1.f, 0, 2.0f, false, false);
+    renderTexture(m_renderData.currentFB->getTexture(), box, 1.f, 0, 2.0f, false, false);
 
     blend(true);
 
-    m_RenderData.currentFB->bind();
+    m_renderData.currentFB->bind();
 }
 
 void CHyprOpenGLImpl::renderMirrored() {
 
-    auto         monitor  = m_RenderData.pMonitor;
+    auto         monitor  = m_renderData.pMonitor;
     auto         mirrored = monitor->m_mirrorOf;
 
     const double scale  = std::min(monitor->m_transformedSize.x / mirrored->m_transformedSize.x, monitor->m_transformedSize.y / mirrored->m_transformedSize.y);
@@ -2619,11 +2619,11 @@ void CHyprOpenGLImpl::renderMirrored() {
     monbox.x = (monitor->m_transformedSize.x - monbox.w) / 2;
     monbox.y = (monitor->m_transformedSize.y - monbox.h) / 2;
 
-    const auto PFB = &m_mMonitorRenderResources[mirrored].monitorMirrorFB;
+    const auto PFB = &m_monitorRenderResources[mirrored].monitorMirrorFB;
     if (!PFB->isAllocated() || !PFB->getTexture())
         return;
 
-    g_pHyprRenderer->m_sRenderPass.add(makeShared<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
+    g_pHyprRenderer->m_renderPass.add(makeShared<CClearPassElement>(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)}));
 
     CTexPassElement::SRenderData data;
     data.tex               = PFB->getTexture();
@@ -2634,7 +2634,7 @@ void CHyprOpenGLImpl::renderMirrored() {
                                  .transform(wlTransformToHyprutils(invertTransform(mirrored->m_transform)))
                                  .translate(-monitor->m_transformedSize / 2.0);
 
-    g_pHyprRenderer->m_sRenderPass.add(makeShared<CTexPassElement>(data));
+    g_pHyprRenderer->m_renderPass.add(makeShared<CTexPassElement>(data));
 }
 
 void CHyprOpenGLImpl::renderSplash(cairo_t* const CAIRO, cairo_surface_t* const CAIROSURFACE, double offsetY, const Vector2D& size) {
@@ -2686,24 +2686,24 @@ SP<CTexture> CHyprOpenGLImpl::loadAsset(const std::string& filename) {
     }
 
     if (fullPath.empty()) {
-        failedAssetsNo++;
+        m_failedAssetsNo++;
         Debug::log(ERR, "loadAsset: looking for {} failed (no provider found)", filename);
-        return m_pMissingAssetTexture;
+        return m_missingAssetTexture;
     }
 
     const auto CAIROSURFACE = cairo_image_surface_create_from_png(fullPath.c_str());
 
     if (!CAIROSURFACE) {
-        failedAssetsNo++;
+        m_failedAssetsNo++;
         Debug::log(ERR, "loadAsset: failed to load {} (corrupt / inaccessible / not png)", fullPath);
-        return m_pMissingAssetTexture;
+        return m_missingAssetTexture;
     }
 
     const auto CAIROFORMAT = cairo_image_surface_get_format(CAIROSURFACE);
     auto       tex         = makeShared<CTexture>();
 
     tex->allocate();
-    tex->m_vSize = {cairo_image_surface_get_width(CAIROSURFACE), cairo_image_surface_get_height(CAIROSURFACE)};
+    tex->m_size = {cairo_image_surface_get_width(CAIROSURFACE), cairo_image_surface_get_height(CAIROSURFACE)};
 
     const GLint glIFormat = CAIROFORMAT == CAIRO_FORMAT_RGB96F ?
 #ifdef GLES2
@@ -2716,7 +2716,7 @@ SP<CTexture> CHyprOpenGLImpl::loadAsset(const std::string& filename) {
     const GLint glType   = CAIROFORMAT == CAIRO_FORMAT_RGB96F ? GL_FLOAT : GL_UNSIGNED_BYTE;
 
     const auto  DATA = cairo_image_surface_get_data(CAIROSURFACE);
-    glBindTexture(GL_TEXTURE_2D, tex->m_iTexID);
+    glBindTexture(GL_TEXTURE_2D, tex->m_texID);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 #ifndef GLES2
@@ -2725,7 +2725,7 @@ SP<CTexture> CHyprOpenGLImpl::loadAsset(const std::string& filename) {
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED);
     }
 #endif
-    glTexImage2D(GL_TEXTURE_2D, 0, glIFormat, tex->m_vSize.x, tex->m_vSize.y, 0, glFormat, glType, DATA);
+    glTexImage2D(GL_TEXTURE_2D, 0, glIFormat, tex->m_size.x, tex->m_size.y, 0, glFormat, glType, DATA);
 
     cairo_surface_destroy(CAIROSURFACE);
 
@@ -2796,17 +2796,17 @@ SP<CTexture> CHyprOpenGLImpl::renderText(const std::string& text, CHyprColor col
     cairo_surface_flush(CAIROSURFACE);
 
     tex->allocate();
-    tex->m_vSize = {cairo_image_surface_get_width(CAIROSURFACE), cairo_image_surface_get_height(CAIROSURFACE)};
+    tex->m_size = {cairo_image_surface_get_width(CAIROSURFACE), cairo_image_surface_get_height(CAIROSURFACE)};
 
     const auto DATA = cairo_image_surface_get_data(CAIROSURFACE);
-    glBindTexture(GL_TEXTURE_2D, tex->m_iTexID);
+    glBindTexture(GL_TEXTURE_2D, tex->m_texID);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 #ifndef GLES2
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_BLUE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED);
 #endif
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, tex->m_vSize.x, tex->m_vSize.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, DATA);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, tex->m_size.x, tex->m_size.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, DATA);
 
     cairo_destroy(CAIRO);
     cairo_surface_destroy(CAIROSURFACE);
@@ -2835,40 +2835,40 @@ void CHyprOpenGLImpl::initMissingAssetTexture() {
 
     cairo_surface_flush(CAIROSURFACE);
 
-    tex->m_vSize = {512, 512};
+    tex->m_size = {512, 512};
 
     // copy the data to an OpenGL texture we have
     const GLint glFormat = GL_RGBA;
     const GLint glType   = GL_UNSIGNED_BYTE;
 
     const auto  DATA = cairo_image_surface_get_data(CAIROSURFACE);
-    glBindTexture(GL_TEXTURE_2D, tex->m_iTexID);
+    glBindTexture(GL_TEXTURE_2D, tex->m_texID);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 #ifndef GLES2
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_BLUE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED);
 #endif
-    glTexImage2D(GL_TEXTURE_2D, 0, glFormat, tex->m_vSize.x, tex->m_vSize.y, 0, glFormat, glType, DATA);
+    glTexImage2D(GL_TEXTURE_2D, 0, glFormat, tex->m_size.x, tex->m_size.y, 0, glFormat, glType, DATA);
 
     cairo_surface_destroy(CAIROSURFACE);
     cairo_destroy(CAIRO);
 
-    m_pMissingAssetTexture = tex;
+    m_missingAssetTexture = tex;
 }
 
 void CHyprOpenGLImpl::initAssets() {
     initMissingAssetTexture();
 
-    m_pLockDeadTexture  = loadAsset("lockdead.png");
-    m_pLockDead2Texture = loadAsset("lockdead2.png");
+    m_lockDeadTexture  = loadAsset("lockdead.png");
+    m_lockDead2Texture = loadAsset("lockdead2.png");
 
-    m_pLockTtyTextTexture = renderText(
+    m_lockTtyTextTexture = renderText(
         std::format("Running on tty {}",
                     g_pCompositor->m_aqBackend->hasSession() && g_pCompositor->m_aqBackend->session->vt > 0 ? std::to_string(g_pCompositor->m_aqBackend->session->vt) : "unknown"),
         CHyprColor{0.9F, 0.9F, 0.9F, 0.7F}, 20, true);
 
-    m_pScreencopyDeniedTexture = renderText("Permission denied to share screen", Colors::WHITE, 20);
+    m_screencopyDeniedTexture = renderText("Permission denied to share screen", Colors::WHITE, 20);
 
     ensureBackgroundTexturePresence();
 }
@@ -2880,8 +2880,8 @@ void CHyprOpenGLImpl::ensureBackgroundTexturePresence() {
     const auto  FORCEWALLPAPER = std::clamp(*PFORCEWALLPAPER, static_cast<int64_t>(-1L), static_cast<int64_t>(2L));
 
     if (*PNOWALLPAPER)
-        m_pBackgroundTexture.reset();
-    else if (!m_pBackgroundTexture) {
+        m_backgroundTexture.reset();
+    else if (!m_backgroundTexture) {
         // create the default background texture
         std::string texPath = "wall";
 
@@ -2896,12 +2896,12 @@ void CHyprOpenGLImpl::ensureBackgroundTexturePresence() {
 
         texPath += ".png";
 
-        m_pBackgroundTexture = loadAsset(texPath);
+        m_backgroundTexture = loadAsset(texPath);
     }
 }
 
 void CHyprOpenGLImpl::createBGTextureForMonitor(PHLMONITOR pMonitor) {
-    RASSERT(m_RenderData.pMonitor, "Tried to createBGTex without begin()!");
+    RASSERT(m_renderData.pMonitor, "Tried to createBGTex without begin()!");
 
     Debug::log(LOG, "Creating a texture for BGTex");
 
@@ -2912,12 +2912,12 @@ void CHyprOpenGLImpl::createBGTextureForMonitor(PHLMONITOR pMonitor) {
         return;
 
     // release the last tex if exists
-    const auto PFB = &m_mMonitorBGFBs[pMonitor];
+    const auto PFB = &m_monitorBGFBs[pMonitor];
     PFB->release();
 
     PFB->alloc(pMonitor->m_pixelSize.x, pMonitor->m_pixelSize.y, pMonitor->m_output->state->state().drmFormat);
 
-    if (!m_pBackgroundTexture) // ?!?!?!
+    if (!m_backgroundTexture) // ?!?!?!
         return;
 
     // create a new one with cairo
@@ -2940,21 +2940,21 @@ void CHyprOpenGLImpl::createBGTextureForMonitor(PHLMONITOR pMonitor) {
 
     cairo_surface_flush(CAIROSURFACE);
 
-    tex->m_vSize = pMonitor->m_pixelSize;
+    tex->m_size = pMonitor->m_pixelSize;
 
     // copy the data to an OpenGL texture we have
     const GLint glFormat = GL_RGBA;
     const GLint glType   = GL_UNSIGNED_BYTE;
 
     const auto  DATA = cairo_image_surface_get_data(CAIROSURFACE);
-    glBindTexture(GL_TEXTURE_2D, tex->m_iTexID);
+    glBindTexture(GL_TEXTURE_2D, tex->m_texID);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 #ifndef GLES2
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_BLUE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED);
 #endif
-    glTexImage2D(GL_TEXTURE_2D, 0, glFormat, tex->m_vSize.x, tex->m_vSize.y, 0, glFormat, glType, DATA);
+    glTexImage2D(GL_TEXTURE_2D, 0, glFormat, tex->m_size.x, tex->m_size.y, 0, glFormat, glType, DATA);
 
     cairo_surface_destroy(CAIROSURFACE);
     cairo_destroy(CAIRO);
@@ -2967,50 +2967,50 @@ void CHyprOpenGLImpl::createBGTextureForMonitor(PHLMONITOR pMonitor) {
     clear(CHyprColor{0, 0, 0, 1});
 
     // first render the background
-    if (m_pBackgroundTexture) {
-        const double MONRATIO = m_RenderData.pMonitor->m_transformedSize.x / m_RenderData.pMonitor->m_transformedSize.y;
-        const double WPRATIO  = m_pBackgroundTexture->m_vSize.x / m_pBackgroundTexture->m_vSize.y;
+    if (m_backgroundTexture) {
+        const double MONRATIO = m_renderData.pMonitor->m_transformedSize.x / m_renderData.pMonitor->m_transformedSize.y;
+        const double WPRATIO  = m_backgroundTexture->m_size.x / m_backgroundTexture->m_size.y;
         Vector2D     origin;
         double       scale = 1.0;
 
         if (MONRATIO > WPRATIO) {
-            scale    = m_RenderData.pMonitor->m_transformedSize.x / m_pBackgroundTexture->m_vSize.x;
-            origin.y = (m_RenderData.pMonitor->m_transformedSize.y - m_pBackgroundTexture->m_vSize.y * scale) / 2.0;
+            scale    = m_renderData.pMonitor->m_transformedSize.x / m_backgroundTexture->m_size.x;
+            origin.y = (m_renderData.pMonitor->m_transformedSize.y - m_backgroundTexture->m_size.y * scale) / 2.0;
         } else {
-            scale    = m_RenderData.pMonitor->m_transformedSize.y / m_pBackgroundTexture->m_vSize.y;
-            origin.x = (m_RenderData.pMonitor->m_transformedSize.x - m_pBackgroundTexture->m_vSize.x * scale) / 2.0;
+            scale    = m_renderData.pMonitor->m_transformedSize.y / m_backgroundTexture->m_size.y;
+            origin.x = (m_renderData.pMonitor->m_transformedSize.x - m_backgroundTexture->m_size.x * scale) / 2.0;
         }
 
-        CBox texbox = CBox{origin, m_pBackgroundTexture->m_vSize * scale};
-        renderTextureInternalWithDamage(m_pBackgroundTexture, texbox, 1.0, fakeDamage);
+        CBox texbox = CBox{origin, m_backgroundTexture->m_size * scale};
+        renderTextureInternalWithDamage(m_backgroundTexture, texbox, 1.0, fakeDamage);
     }
 
     CBox monbox = {{}, pMonitor->m_pixelSize};
     renderTextureInternalWithDamage(tex, monbox, 1.0, fakeDamage);
 
     // bind back
-    if (m_RenderData.currentFB)
-        m_RenderData.currentFB->bind();
+    if (m_renderData.currentFB)
+        m_renderData.currentFB->bind();
 
     Debug::log(LOG, "Background created for monitor {}", pMonitor->m_name);
 }
 
 void CHyprOpenGLImpl::clearWithTex() {
-    RASSERT(m_RenderData.pMonitor, "Tried to render BGtex without begin()!");
+    RASSERT(m_renderData.pMonitor, "Tried to render BGtex without begin()!");
 
-    auto TEXIT = m_mMonitorBGFBs.find(m_RenderData.pMonitor);
+    auto TEXIT = m_monitorBGFBs.find(m_renderData.pMonitor);
 
-    if (TEXIT == m_mMonitorBGFBs.end()) {
-        createBGTextureForMonitor(m_RenderData.pMonitor.lock());
-        TEXIT = m_mMonitorBGFBs.find(m_RenderData.pMonitor);
+    if (TEXIT == m_monitorBGFBs.end()) {
+        createBGTextureForMonitor(m_renderData.pMonitor.lock());
+        TEXIT = m_monitorBGFBs.find(m_renderData.pMonitor);
     }
 
-    if (TEXIT != m_mMonitorBGFBs.end()) {
+    if (TEXIT != m_monitorBGFBs.end()) {
         CTexPassElement::SRenderData data;
-        data.box          = {0, 0, m_RenderData.pMonitor->m_transformedSize.x, m_RenderData.pMonitor->m_transformedSize.y};
+        data.box          = {0, 0, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y};
         data.flipEndFrame = true;
         data.tex          = TEXIT->second.getTexture();
-        g_pHyprRenderer->m_sRenderPass.add(makeShared<CTexPassElement>(data));
+        g_pHyprRenderer->m_renderPass.add(makeShared<CTexPassElement>(data));
     }
 }
 
@@ -3020,8 +3020,8 @@ void CHyprOpenGLImpl::destroyMonitorResources(PHLMONITORREF pMonitor) {
     if (!g_pHyprOpenGL)
         return;
 
-    auto RESIT = g_pHyprOpenGL->m_mMonitorRenderResources.find(pMonitor);
-    if (RESIT != g_pHyprOpenGL->m_mMonitorRenderResources.end()) {
+    auto RESIT = g_pHyprOpenGL->m_monitorRenderResources.find(pMonitor);
+    if (RESIT != g_pHyprOpenGL->m_monitorRenderResources.end()) {
         RESIT->second.mirrorFB.release();
         RESIT->second.offloadFB.release();
         RESIT->second.mirrorSwapFB.release();
@@ -3029,13 +3029,13 @@ void CHyprOpenGLImpl::destroyMonitorResources(PHLMONITORREF pMonitor) {
         RESIT->second.blurFB.release();
         RESIT->second.offMainFB.release();
         RESIT->second.stencilTex->destroyTexture();
-        g_pHyprOpenGL->m_mMonitorRenderResources.erase(RESIT);
+        g_pHyprOpenGL->m_monitorRenderResources.erase(RESIT);
     }
 
-    auto TEXIT = g_pHyprOpenGL->m_mMonitorBGFBs.find(pMonitor);
-    if (TEXIT != g_pHyprOpenGL->m_mMonitorBGFBs.end()) {
+    auto TEXIT = g_pHyprOpenGL->m_monitorBGFBs.find(pMonitor);
+    if (TEXIT != g_pHyprOpenGL->m_monitorBGFBs.end()) {
         TEXIT->second.release();
-        g_pHyprOpenGL->m_mMonitorBGFBs.erase(TEXIT);
+        g_pHyprOpenGL->m_monitorBGFBs.erase(TEXIT);
     }
 
     if (pMonitor)
@@ -3043,46 +3043,46 @@ void CHyprOpenGLImpl::destroyMonitorResources(PHLMONITORREF pMonitor) {
 }
 
 void CHyprOpenGLImpl::saveMatrix() {
-    m_RenderData.savedProjection = m_RenderData.projection;
+    m_renderData.savedProjection = m_renderData.projection;
 }
 
 void CHyprOpenGLImpl::setMatrixScaleTranslate(const Vector2D& translate, const float& scale) {
-    m_RenderData.projection.scale(scale).translate(translate);
+    m_renderData.projection.scale(scale).translate(translate);
 }
 
 void CHyprOpenGLImpl::restoreMatrix() {
-    m_RenderData.projection = m_RenderData.savedProjection;
+    m_renderData.projection = m_renderData.savedProjection;
 }
 
 void CHyprOpenGLImpl::bindOffMain() {
-    if (!m_RenderData.pCurrentMonData->offMainFB.isAllocated()) {
-        m_RenderData.pCurrentMonData->offMainFB.alloc(m_RenderData.pMonitor->m_pixelSize.x, m_RenderData.pMonitor->m_pixelSize.y,
-                                                      m_RenderData.pMonitor->m_output->state->state().drmFormat);
+    if (!m_renderData.pCurrentMonData->offMainFB.isAllocated()) {
+        m_renderData.pCurrentMonData->offMainFB.alloc(m_renderData.pMonitor->m_pixelSize.x, m_renderData.pMonitor->m_pixelSize.y,
+                                                      m_renderData.pMonitor->m_output->state->state().drmFormat);
 
-        m_RenderData.pCurrentMonData->offMainFB.addStencil(m_RenderData.pCurrentMonData->stencilTex);
+        m_renderData.pCurrentMonData->offMainFB.addStencil(m_renderData.pCurrentMonData->stencilTex);
     }
 
-    m_RenderData.pCurrentMonData->offMainFB.bind();
+    m_renderData.pCurrentMonData->offMainFB.bind();
     clear(CHyprColor(0, 0, 0, 0));
-    m_RenderData.currentFB = &m_RenderData.pCurrentMonData->offMainFB;
+    m_renderData.currentFB = &m_renderData.pCurrentMonData->offMainFB;
 }
 
 void CHyprOpenGLImpl::renderOffToMain(CFramebuffer* off) {
-    CBox monbox = {0, 0, m_RenderData.pMonitor->m_transformedSize.x, m_RenderData.pMonitor->m_transformedSize.y};
+    CBox monbox = {0, 0, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y};
     renderTexturePrimitive(off->getTexture(), monbox);
 }
 
 void CHyprOpenGLImpl::bindBackOnMain() {
-    m_RenderData.mainFB->bind();
-    m_RenderData.currentFB = m_RenderData.mainFB;
+    m_renderData.mainFB->bind();
+    m_renderData.currentFB = m_renderData.mainFB;
 }
 
 void CHyprOpenGLImpl::setMonitorTransformEnabled(bool enabled) {
-    m_bEndFrame = enabled;
+    m_endFrame = enabled;
 }
 
 void CHyprOpenGLImpl::setRenderModifEnabled(bool enabled) {
-    m_RenderData.renderModif.enabled = enabled;
+    m_renderData.renderModif.enabled = enabled;
 }
 
 uint32_t CHyprOpenGLImpl::getPreferredReadFormat(PHLMONITOR pMonitor) {
@@ -3090,7 +3090,7 @@ uint32_t CHyprOpenGLImpl::getPreferredReadFormat(PHLMONITOR pMonitor) {
 }
 
 std::vector<SDRMFormat> CHyprOpenGLImpl::getDRMFormats() {
-    return drmFormats;
+    return m_drmFormats;
 }
 
 void SRenderModifData::applyToBox(CBox& box) {
@@ -3155,7 +3155,7 @@ float SRenderModifData::combinedScale() {
 }
 
 UP<CEGLSync> CEGLSync::create() {
-    EGLSyncKHR sync = g_pHyprOpenGL->m_sProc.eglCreateSyncKHR(g_pHyprOpenGL->m_pEglDisplay, EGL_SYNC_NATIVE_FENCE_ANDROID, nullptr);
+    EGLSyncKHR sync = g_pHyprOpenGL->m_proc.eglCreateSyncKHR(g_pHyprOpenGL->m_eglDisplay, EGL_SYNC_NATIVE_FENCE_ANDROID, nullptr);
 
     if (sync == EGL_NO_SYNC_KHR) {
         Debug::log(ERR, "eglCreateSyncKHR failed");
@@ -3165,7 +3165,7 @@ UP<CEGLSync> CEGLSync::create() {
     // we need to flush otherwise we might not get a valid fd
     glFlush();
 
-    int fd = g_pHyprOpenGL->m_sProc.eglDupNativeFenceFDANDROID(g_pHyprOpenGL->m_pEglDisplay, sync);
+    int fd = g_pHyprOpenGL->m_proc.eglDupNativeFenceFDANDROID(g_pHyprOpenGL->m_eglDisplay, sync);
     if (fd == EGL_NO_NATIVE_FENCE_FD_ANDROID) {
         Debug::log(ERR, "eglDupNativeFenceFDANDROID failed");
         return nullptr;
@@ -3183,7 +3183,7 @@ CEGLSync::~CEGLSync() {
     if (m_sync == EGL_NO_SYNC_KHR)
         return;
 
-    if (g_pHyprOpenGL && g_pHyprOpenGL->m_sProc.eglDestroySyncKHR(g_pHyprOpenGL->m_pEglDisplay, m_sync) != EGL_TRUE)
+    if (g_pHyprOpenGL && g_pHyprOpenGL->m_proc.eglDestroySyncKHR(g_pHyprOpenGL->m_eglDisplay, m_sync) != EGL_TRUE)
         Debug::log(ERR, "eglDestroySyncKHR failed");
 }
 

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -239,24 +239,24 @@ class CHyprOpenGLImpl {
     EGLImageKHR                                 createEGLImage(const Aquamarine::SDMABUFAttrs& attrs);
 
     bool                                        initShaders();
-    bool                                        m_bShadersInitialized = false;
+    bool                                        m_shadersInitialized = false;
     SP<SPreparedShaders>                        m_shaders;
 
-    SCurrentRenderData                          m_RenderData;
+    SCurrentRenderData                          m_renderData;
 
-    Hyprutils::OS::CFileDescriptor              m_iGBMFD;
-    gbm_device*                                 m_pGbmDevice   = nullptr;
-    EGLContext                                  m_pEglContext  = nullptr;
-    EGLDisplay                                  m_pEglDisplay  = nullptr;
-    EGLDeviceEXT                                m_pEglDevice   = nullptr;
-    uint                                        failedAssetsNo = 0;
+    Hyprutils::OS::CFileDescriptor              m_gbmFD;
+    gbm_device*                                 m_gbmDevice      = nullptr;
+    EGLContext                                  m_eglContext     = nullptr;
+    EGLDisplay                                  m_eglDisplay     = nullptr;
+    EGLDeviceEXT                                m_eglDevice      = nullptr;
+    uint                                        m_failedAssetsNo = 0;
 
-    bool                                        m_bReloadScreenShader = true; // at launch it can be set
+    bool                                        m_reloadScreenShader = true; // at launch it can be set
 
-    std::map<PHLWINDOWREF, CFramebuffer>        m_mWindowFramebuffers;
-    std::map<PHLLSREF, CFramebuffer>            m_mLayerFramebuffers;
-    std::map<PHLMONITORREF, SMonitorRenderData> m_mMonitorRenderResources;
-    std::map<PHLMONITORREF, CFramebuffer>       m_mMonitorBGFBs;
+    std::map<PHLWINDOWREF, CFramebuffer>        m_windowFramebuffers;
+    std::map<PHLLSREF, CFramebuffer>            m_layerFramebuffers;
+    std::map<PHLMONITORREF, SMonitorRenderData> m_monitorRenderResources;
+    std::map<PHLMONITORREF, CFramebuffer>       m_monitorBGFBs;
 
     struct {
         PFNGLEGLIMAGETARGETRENDERBUFFERSTORAGEOESPROC glEGLImageTargetRenderbufferStorageOES = nullptr;
@@ -274,7 +274,7 @@ class CHyprOpenGLImpl {
         PFNEGLDESTROYSYNCKHRPROC                      eglDestroySyncKHR                      = nullptr;
         PFNEGLDUPNATIVEFENCEFDANDROIDPROC             eglDupNativeFenceFDANDROID             = nullptr;
         PFNEGLWAITSYNCKHRPROC                         eglWaitSyncKHR                         = nullptr;
-    } m_sProc;
+    } m_proc;
 
     struct {
         bool EXT_read_format_bgra               = false;
@@ -283,9 +283,9 @@ class CHyprOpenGLImpl {
         bool KHR_display_reference              = false;
         bool IMG_context_priority               = false;
         bool EXT_create_context_robustness      = false;
-    } m_sExts;
+    } m_exts;
 
-    SP<CTexture> m_pScreencopyDeniedTexture;
+    SP<CTexture> m_screencopyDeniedTexture;
 
   private:
     enum eEGLContextVersion : uint8_t {
@@ -296,26 +296,27 @@ class CHyprOpenGLImpl {
 
     eEGLContextVersion      m_eglContextVersion = EGL_CONTEXT_GLES_3_2;
 
-    std::list<GLuint>       m_lBuffers;
-    std::list<GLuint>       m_lTextures;
+    std::vector<SDRMFormat> m_drmFormats;
+    bool                    m_hasModifiers = false;
 
-    std::vector<SDRMFormat> drmFormats;
-    bool                    m_bHasModifiers = false;
+    int                     m_drmFD = -1;
+    std::string             m_extensions;
 
-    int                     m_iDRMFD = -1;
-    std::string             m_szExtensions;
+    bool                    m_fakeFrame            = false;
+    bool                    m_endFrame             = false;
+    bool                    m_applyFinalShader     = false;
+    bool                    m_blend                = false;
+    bool                    m_offloadedFramebuffer = false;
+    bool                    m_cmSupported          = true;
 
-    bool                    m_bFakeFrame            = false;
-    bool                    m_bEndFrame             = false;
-    bool                    m_bApplyFinalShader     = false;
-    bool                    m_bBlend                = false;
-    bool                    m_bOffloadedFramebuffer = false;
-    bool                    m_bCMSupported          = true;
+    CShader                 m_finalScreenShader;
+    CTimer                  m_globalTimer;
 
-    CShader                 m_sFinalScreenShader;
-    CTimer                  m_tGlobalTimer;
-
-    SP<CTexture>            m_pMissingAssetTexture, m_pBackgroundTexture, m_pLockDeadTexture, m_pLockDead2Texture, m_pLockTtyTextTexture; // TODO: don't always load lock
+    SP<CTexture>            m_missingAssetTexture;
+    SP<CTexture>            m_backgroundTexture;
+    SP<CTexture>            m_lockDeadTexture;
+    SP<CTexture>            m_lockDead2Texture;
+    SP<CTexture>            m_lockTtyTextTexture; // TODO: don't always load lock
 
     void                    logShaderError(const GLuint&, bool program = false, bool silent = false);
     GLuint                  createProgram(const std::string&, const std::string&, bool dynamic = false, bool silent = false);

--- a/src/render/Renderbuffer.hpp
+++ b/src/render/Renderbuffer.hpp
@@ -19,16 +19,16 @@ class CRenderbuffer {
     CFramebuffer*           getFB();
     uint32_t                getFormat();
 
-    WP<Aquamarine::IBuffer> m_pHLBuffer;
+    WP<Aquamarine::IBuffer> m_hlBuffer;
 
   private:
-    void*        m_iImage = nullptr;
-    GLuint       m_iRBO   = 0;
-    CFramebuffer m_sFramebuffer;
-    uint32_t     m_uDrmFormat = 0;
-    bool         m_bGood      = false;
+    void*        m_image = nullptr;
+    GLuint       m_rbo   = 0;
+    CFramebuffer m_framebuffer;
+    uint32_t     m_drmFormat = 0;
+    bool         m_good      = false;
 
     struct {
         CHyprSignalListener destroyBuffer;
-    } listeners;
+    } m_listeners;
 };

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -91,29 +91,29 @@ class CHyprRenderer {
 
     bool m_bBlockSurfaceFeedback = false;
     bool m_bRenderingSnapshot    = false;
-    PHLMONITORREF                   m_pMostHzMonitor;
-    bool                            m_bDirectScanoutBlocked = false;
+    PHLMONITORREF                   m_mostHzMonitor;
+    bool                            m_directScanoutBlocked = false;
 
     void                            setSurfaceScanoutMode(SP<CWLSurfaceResource> surface, PHLMONITOR monitor); // nullptr monitor resets
     void                            initiateManualCrash();
 
-    bool                            m_bCrashingInProgress = false;
-    float                           m_fCrashingDistort    = 0.5f;
-    wl_event_source*                m_pCrashingLoop       = nullptr;
-    wl_event_source*                m_pCursorTicker       = nullptr;
+    bool                            m_crashingInProgress = false;
+    float                           m_crashingDistort    = 0.5f;
+    wl_event_source*                m_crashingLoop       = nullptr;
+    wl_event_source*                m_cursorTicker       = nullptr;
 
-    CTimer                          m_tRenderTimer;
+    CTimer                          m_renderTimer;
 
-    std::vector<CHLBufferReference> usedAsyncBuffers;
+    std::vector<CHLBufferReference> m_usedAsyncBuffers;
 
     struct {
         int                           hotspotX = 0;
         int                           hotspotY = 0;
         std::optional<SP<CWLSurface>> surf;
         std::string                   name;
-    } m_sLastCursorData;
+    } m_lastCursorData;
 
-    CRenderPass m_sRenderPass = {};
+    CRenderPass m_renderPass = {};
 
   private:
     void arrangeLayerArray(PHLMONITOR, const std::vector<PHLLSREF>&, bool, CBox*);
@@ -131,23 +131,23 @@ class CHyprRenderer {
 
     bool commitPendingAndDoExplicitSync(PHLMONITOR pMonitor);
 
-    bool m_bCursorHidden                           = false;
-    bool m_bCursorHasSurface                       = false;
-    SP<CRenderbuffer>       m_pCurrentRenderbuffer = nullptr;
-    SP<Aquamarine::IBuffer> m_pCurrentBuffer       = nullptr;
-    eRenderMode             m_eRenderMode          = RENDER_MODE_NORMAL;
-    bool                    m_bNvidia              = false;
+    bool m_cursorHidden                           = false;
+    bool m_cursorHasSurface                       = false;
+    SP<CRenderbuffer>       m_currentRenderbuffer = nullptr;
+    SP<Aquamarine::IBuffer> m_currentBuffer       = nullptr;
+    eRenderMode             m_renderMode          = RENDER_MODE_NORMAL;
+    bool                    m_nvidia              = false;
 
     struct {
         bool hiddenOnTouch    = false;
         bool hiddenOnTimeout  = false;
         bool hiddenOnKeyboard = false;
-    } m_sCursorHiddenConditions;
+    } m_cursorHiddenConditions;
 
     SP<CRenderbuffer>              getOrCreateRenderbuffer(SP<Aquamarine::IBuffer> buffer, uint32_t fmt);
-    std::vector<SP<CRenderbuffer>> m_vRenderbuffers;
-    std::vector<PHLWINDOWREF>      m_vRenderUnfocused;
-    SP<CEventLoopTimer>            m_tRenderUnfocusedTimer;
+    std::vector<SP<CRenderbuffer>> m_renderbuffers;
+    std::vector<PHLWINDOWREF>      m_renderUnfocused;
+    SP<CEventLoopTimer>            m_renderUnfocusedTimer;
 
     friend class CHyprOpenGLImpl;
     friend class CToplevelExportFrame;

--- a/src/render/Shader.hpp
+++ b/src/render/Shader.hpp
@@ -78,7 +78,4 @@ class CShader {
     GLint noise      = -1;
 
     void  destroy();
-
-  private:
-    std::unordered_map<std::string, GLint> m_muUniforms;
 };

--- a/src/render/Texture.hpp
+++ b/src/render/Texture.hpp
@@ -35,21 +35,21 @@ class CTexture {
     void                        update(uint32_t drmFormat, uint8_t* pixels, uint32_t stride, const CRegion& damage);
     const std::vector<uint8_t>& dataCopy();
 
-    eTextureType                m_iType         = TEXTURE_RGBA;
-    GLenum                      m_iTarget       = GL_TEXTURE_2D;
-    GLuint                      m_iTexID        = 0;
-    Vector2D                    m_vSize         = {};
-    void*                       m_pEglImage     = nullptr;
-    eTransform                  m_eTransform    = HYPRUTILS_TRANSFORM_NORMAL;
-    bool                        m_bOpaque       = false;
-    uint32_t                    m_iDrmFormat    = 0; // for shm
+    eTextureType                m_type          = TEXTURE_RGBA;
+    GLenum                      m_target        = GL_TEXTURE_2D;
+    GLuint                      m_texID         = 0;
+    Vector2D                    m_size          = {};
+    void*                       m_eglImage      = nullptr;
+    eTransform                  m_transform     = HYPRUTILS_TRANSFORM_NORMAL;
+    bool                        m_opaque        = false;
+    uint32_t                    m_drmFormat     = 0; // for shm
     bool                        m_isSynchronous = false;
 
   private:
     void                 createFromShm(uint32_t drmFormat, uint8_t* pixels, uint32_t stride, const Vector2D& size);
     void                 createFromDma(const Aquamarine::SDMABUFAttrs&, void* image);
 
-    bool                 m_bKeepDataCopy = false;
+    bool                 m_keepDataCopy = false;
 
-    std::vector<uint8_t> m_vDataCopy;
+    std::vector<uint8_t> m_dataCopy;
 };

--- a/src/render/decorations/CHyprBorderDecoration.hpp
+++ b/src/render/decorations/CHyprBorderDecoration.hpp
@@ -26,17 +26,14 @@ class CHyprBorderDecoration : public IHyprWindowDecoration {
     virtual std::string                getDisplayName();
 
   private:
-    SBoxExtents  m_seExtents;
-    SBoxExtents  m_seReportedExtents;
+    SBoxExtents  m_extents;
+    SBoxExtents  m_reportedExtents;
 
-    PHLWINDOWREF m_pWindow;
+    PHLWINDOWREF m_window;
 
-    Vector2D     m_vLastWindowPos;
-    Vector2D     m_vLastWindowSize;
+    CBox         m_assignedGeometry = {0};
 
-    CBox         m_bAssignedGeometry = {0};
-
-    int          m_iLastBorderSize = -1;
+    int          m_lastBorderSize = -1;
 
     CBox         assignedBoxGlobal();
     bool         doesntWantBorders();

--- a/src/render/decorations/CHyprDropShadowDecoration.hpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.hpp
@@ -28,16 +28,16 @@ class CHyprDropShadowDecoration : public IHyprWindowDecoration {
     void                               render(PHLMONITOR, float const& a);
 
   private:
-    SBoxExtents  m_seExtents;
-    SBoxExtents  m_seReportedExtents;
+    SBoxExtents  m_extents;
+    SBoxExtents  m_reportedExtents;
 
-    PHLWINDOWREF m_pWindow;
+    PHLWINDOWREF m_window;
 
-    Vector2D     m_vLastWindowPos;
-    Vector2D     m_vLastWindowSize;
+    Vector2D     m_lastWindowPos;
+    Vector2D     m_lastWindowSize;
 
     void         drawShadowInternal(const CBox& box, int round, float roundingPower, int range, CHyprColor color, float a);
 
-    CBox         m_bLastWindowBox          = {0};
-    CBox         m_bLastWindowBoxWithDecos = {0};
+    CBox         m_lastWindowBox          = {0};
+    CBox         m_lastWindowBoxWithDecos = {0};
 };

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -12,11 +12,11 @@ class CTitleTex {
     CTitleTex(PHLWINDOW pWindow, const Vector2D& bufferSize, const float monitorScale);
     ~CTitleTex() = default;
 
-    SP<CTexture> texActive;
-    SP<CTexture> texInactive;
-    std::string  szContent;
+    SP<CTexture> m_texActive;
+    SP<CTexture> m_texInactive;
+    std::string  m_content;
 
-    PHLWINDOWREF pWindowOwner;
+    PHLWINDOWREF m_windowOwner;
 };
 
 void refreshGroupBarGradients();
@@ -47,16 +47,14 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
     virtual std::string                getDisplayName();
 
   private:
-    SBoxExtents               m_seExtents;
+    CBox                      m_assignedBox = {0};
 
-    CBox                      m_bAssignedBox = {0};
-
-    PHLWINDOWREF              m_pWindow;
+    PHLWINDOWREF              m_window;
 
     std::vector<PHLWINDOWREF> m_dwGroupMembers;
 
-    float                     m_fBarWidth;
-    float                     m_fBarHeight;
+    float                     m_barWidth;
+    float                     m_barHeight;
 
     CTitleTex*                textureFromTitle(const std::string&);
     void                      invalidateTextures();
@@ -71,5 +69,5 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
     struct STitleTexs {
         // STitleTexs*                            overriden = nullptr; // TODO: make shit shared in-group to decrease VRAM usage.
         std::vector<UP<CTitleTex>> titleTexs;
-    } m_sTitleTexs;
+    } m_titleTexs;
 };

--- a/src/render/decorations/DecorationPositioner.cpp
+++ b/src/render/decorations/DecorationPositioner.cpp
@@ -59,10 +59,10 @@ Vector2D CDecorationPositioner::getEdgeDefinedPoint(uint32_t edges, PHLWINDOW pW
 }
 
 void CDecorationPositioner::uncacheDecoration(IHyprWindowDecoration* deco) {
-    std::erase_if(m_vWindowPositioningDatas, [&](const auto& data) { return !data->pWindow.lock() || data->pDecoration == deco; });
+    std::erase_if(m_windowPositioningDatas, [&](const auto& data) { return !data->pWindow.lock() || data->pDecoration == deco; });
 
-    const auto WIT = std::find_if(m_mWindowDatas.begin(), m_mWindowDatas.end(), [&](const auto& other) { return other.first.lock() == deco->m_pWindow.lock(); });
-    if (WIT == m_mWindowDatas.end())
+    const auto WIT = std::find_if(m_windowDatas.begin(), m_windowDatas.end(), [&](const auto& other) { return other.first.lock() == deco->m_window.lock(); });
+    if (WIT == m_windowDatas.end())
         return;
 
     WIT->second.needsRecalc = true;
@@ -70,16 +70,16 @@ void CDecorationPositioner::uncacheDecoration(IHyprWindowDecoration* deco) {
 
 void CDecorationPositioner::repositionDeco(IHyprWindowDecoration* deco) {
     uncacheDecoration(deco);
-    onWindowUpdate(deco->m_pWindow.lock());
+    onWindowUpdate(deco->m_window.lock());
 }
 
 CDecorationPositioner::SWindowPositioningData* CDecorationPositioner::getDataFor(IHyprWindowDecoration* pDecoration, PHLWINDOW pWindow) {
-    auto it = std::find_if(m_vWindowPositioningDatas.begin(), m_vWindowPositioningDatas.end(), [&](const auto& el) { return el->pDecoration == pDecoration; });
+    auto it = std::find_if(m_windowPositioningDatas.begin(), m_windowPositioningDatas.end(), [&](const auto& el) { return el->pDecoration == pDecoration; });
 
-    if (it != m_vWindowPositioningDatas.end())
+    if (it != m_windowPositioningDatas.end())
         return it->get();
 
-    const auto DATA = m_vWindowPositioningDatas.emplace_back(makeUnique<CDecorationPositioner::SWindowPositioningData>(pWindow, pDecoration)).get();
+    const auto DATA = m_windowPositioningDatas.emplace_back(makeUnique<CDecorationPositioner::SWindowPositioningData>(pWindow, pDecoration)).get();
 
     DATA->positioningInfo = pDecoration->getPositioningInfo();
 
@@ -87,8 +87,8 @@ CDecorationPositioner::SWindowPositioningData* CDecorationPositioner::getDataFor
 }
 
 void CDecorationPositioner::sanitizeDatas() {
-    std::erase_if(m_mWindowDatas, [](const auto& other) { return !valid(other.first); });
-    std::erase_if(m_vWindowPositioningDatas, [](const auto& other) {
+    std::erase_if(m_windowDatas, [](const auto& other) { return !valid(other.first); });
+    std::erase_if(m_windowPositioningDatas, [](const auto& other) {
         if (!validMapped(other->pWindow))
             return true;
         if (std::find_if(other->pWindow->m_windowDecorations.begin(), other->pWindow->m_windowDecorations.end(), [&](const auto& el) { return el.get() == other->pDecoration; }) ==
@@ -99,8 +99,8 @@ void CDecorationPositioner::sanitizeDatas() {
 }
 
 void CDecorationPositioner::forceRecalcFor(PHLWINDOW pWindow) {
-    const auto WIT = std::find_if(m_mWindowDatas.begin(), m_mWindowDatas.end(), [&](const auto& other) { return other.first.lock() == pWindow; });
-    if (WIT == m_mWindowDatas.end())
+    const auto WIT = std::find_if(m_windowDatas.begin(), m_windowDatas.end(), [&](const auto& other) { return other.first.lock() == pWindow; });
+    if (WIT == m_windowDatas.end())
         return;
 
     const auto WINDOWDATA = &WIT->second;
@@ -112,8 +112,8 @@ void CDecorationPositioner::onWindowUpdate(PHLWINDOW pWindow) {
     if (!validMapped(pWindow))
         return;
 
-    const auto WIT = std::find_if(m_mWindowDatas.begin(), m_mWindowDatas.end(), [&](const auto& other) { return other.first.lock() == pWindow; });
-    if (WIT == m_mWindowDatas.end())
+    const auto WIT = std::find_if(m_windowDatas.begin(), m_windowDatas.end(), [&](const auto& other) { return other.first.lock() == pWindow; });
+    if (WIT == m_windowDatas.end())
         return;
 
     const auto WINDOWDATA = &WIT->second;
@@ -130,7 +130,7 @@ void CDecorationPositioner::onWindowUpdate(PHLWINDOW pWindow) {
     }
 
     if (WINDOWDATA->lastWindowSize == pWindow->m_realSize->value() /* position not changed */
-        && std::all_of(m_vWindowPositioningDatas.begin(), m_vWindowPositioningDatas.end(),
+        && std::all_of(m_windowPositioningDatas.begin(), m_windowPositioningDatas.end(),
                        [pWindow](const auto& data) { return pWindow != data->pWindow.lock() || !data->needsReposition; })
         /* all window datas are either not for this window or don't need a reposition */
         && !WINDOWDATA->needsRecalc /* window doesn't need recalc */
@@ -282,17 +282,17 @@ void CDecorationPositioner::onWindowUpdate(PHLWINDOW pWindow) {
 }
 
 void CDecorationPositioner::onWindowUnmap(PHLWINDOW pWindow) {
-    std::erase_if(m_vWindowPositioningDatas, [&](const auto& data) { return data->pWindow.lock() == pWindow; });
-    m_mWindowDatas.erase(pWindow);
+    std::erase_if(m_windowPositioningDatas, [&](const auto& data) { return data->pWindow.lock() == pWindow; });
+    m_windowDatas.erase(pWindow);
 }
 
 void CDecorationPositioner::onWindowMap(PHLWINDOW pWindow) {
-    m_mWindowDatas[pWindow] = {};
+    m_windowDatas[pWindow] = {};
 }
 
 SBoxExtents CDecorationPositioner::getWindowDecorationReserved(PHLWINDOW pWindow) {
     try {
-        const auto E = m_mWindowDatas.at(pWindow);
+        const auto E = m_windowDatas.at(pWindow);
         return E.reserved;
     } catch (std::out_of_range& e) { return {}; }
 }
@@ -301,7 +301,7 @@ SBoxExtents CDecorationPositioner::getWindowDecorationExtents(PHLWINDOW pWindow,
     CBox const mainSurfaceBox = pWindow->getWindowMainSurfaceBox();
     CBox       accum          = mainSurfaceBox;
 
-    for (auto const& data : m_vWindowPositioningDatas) {
+    for (auto const& data : m_windowPositioningDatas) {
         if (!data->pDecoration || (inputOnly && !(data->pDecoration->getDecorationFlags() & DECORATION_ALLOWS_MOUSE_INPUT)))
             continue;
 
@@ -349,7 +349,7 @@ SBoxExtents CDecorationPositioner::getWindowDecorationExtents(PHLWINDOW pWindow,
 CBox CDecorationPositioner::getBoxWithIncludedDecos(PHLWINDOW pWindow) {
     CBox accum = pWindow->getWindowMainSurfaceBox();
 
-    for (auto const& data : m_vWindowPositioningDatas) {
+    for (auto const& data : m_windowPositioningDatas) {
         if (data->pWindow.lock() != pWindow)
             continue;
 
@@ -385,7 +385,7 @@ CBox CDecorationPositioner::getBoxWithIncludedDecos(PHLWINDOW pWindow) {
 }
 
 CBox CDecorationPositioner::getWindowDecorationBox(IHyprWindowDecoration* deco) {
-    auto const window = deco->m_pWindow.lock();
+    auto const window = deco->m_window.lock();
     const auto DATA   = getDataFor(deco, window);
 
     CBox       box = DATA->lastReply.assignedGeometry;

--- a/src/render/decorations/DecorationPositioner.hpp
+++ b/src/render/decorations/DecorationPositioner.hpp
@@ -87,8 +87,8 @@ class CDecorationPositioner {
         bool        needsRecalc    = false;
     };
 
-    std::map<PHLWINDOWREF, SWindowData>     m_mWindowDatas;
-    std::vector<UP<SWindowPositioningData>> m_vWindowPositioningDatas;
+    std::map<PHLWINDOWREF, SWindowData>     m_windowDatas;
+    std::vector<UP<SWindowPositioningData>> m_windowPositioningDatas;
 
     SWindowPositioningData*                 getDataFor(IHyprWindowDecoration* pDecoration, PHLWINDOW pWindow);
     void                                    onWindowUnmap(PHLWINDOW pWindow);

--- a/src/render/decorations/IHyprWindowDecoration.cpp
+++ b/src/render/decorations/IHyprWindowDecoration.cpp
@@ -2,7 +2,7 @@
 
 class CWindow;
 
-IHyprWindowDecoration::IHyprWindowDecoration(PHLWINDOW pWindow) : m_pWindow(pWindow) {
+IHyprWindowDecoration::IHyprWindowDecoration(PHLWINDOW pWindow) : m_window(pWindow) {
     ;
 }
 

--- a/src/render/decorations/IHyprWindowDecoration.hpp
+++ b/src/render/decorations/IHyprWindowDecoration.hpp
@@ -56,7 +56,7 @@ class IHyprWindowDecoration {
     virtual std::string                getDisplayName();
 
   private:
-    PHLWINDOWREF m_pWindow;
+    PHLWINDOWREF m_window;
 
     friend class CDecorationPositioner;
 };

--- a/src/render/pass/BorderPassElement.cpp
+++ b/src/render/pass/BorderPassElement.cpp
@@ -1,15 +1,15 @@
 #include "BorderPassElement.hpp"
 #include "../OpenGL.hpp"
 
-CBorderPassElement::CBorderPassElement(const CBorderPassElement::SBorderData& data_) : data(data_) {
+CBorderPassElement::CBorderPassElement(const CBorderPassElement::SBorderData& data_) : m_data(data_) {
     ;
 }
 
 void CBorderPassElement::draw(const CRegion& damage) {
-    if (data.hasGrad2)
-        g_pHyprOpenGL->renderBorder(data.box, data.grad1, data.grad2, data.lerp, data.round, data.roundingPower, data.borderSize, data.a, data.outerRound);
+    if (m_data.hasGrad2)
+        g_pHyprOpenGL->renderBorder(m_data.box, m_data.grad1, m_data.grad2, m_data.lerp, m_data.round, m_data.roundingPower, m_data.borderSize, m_data.a, m_data.outerRound);
     else
-        g_pHyprOpenGL->renderBorder(data.box, data.grad1, data.round, data.roundingPower, data.borderSize, data.a, data.outerRound);
+        g_pHyprOpenGL->renderBorder(m_data.box, m_data.grad1, m_data.round, m_data.roundingPower, m_data.borderSize, m_data.a, m_data.outerRound);
 }
 
 bool CBorderPassElement::needsLiveBlur() {

--- a/src/render/pass/BorderPassElement.hpp
+++ b/src/render/pass/BorderPassElement.hpp
@@ -27,5 +27,5 @@ class CBorderPassElement : public IPassElement {
     }
 
   private:
-    SBorderData data;
+    SBorderData m_data;
 };

--- a/src/render/pass/ClearPassElement.cpp
+++ b/src/render/pass/ClearPassElement.cpp
@@ -1,12 +1,12 @@
 #include "ClearPassElement.hpp"
 #include "../OpenGL.hpp"
 
-CClearPassElement::CClearPassElement(const CClearPassElement::SClearData& data_) : data(data_) {
+CClearPassElement::CClearPassElement(const CClearPassElement::SClearData& data_) : m_data(data_) {
     ;
 }
 
 void CClearPassElement::draw(const CRegion& damage) {
-    g_pHyprOpenGL->clear(data.color);
+    g_pHyprOpenGL->clear(m_data.color);
 }
 
 bool CClearPassElement::needsLiveBlur() {

--- a/src/render/pass/ClearPassElement.hpp
+++ b/src/render/pass/ClearPassElement.hpp
@@ -21,5 +21,5 @@ class CClearPassElement : public IPassElement {
     }
 
   private:
-    SClearData data;
+    SClearData m_data;
 };

--- a/src/render/pass/FramebufferElement.cpp
+++ b/src/render/pass/FramebufferElement.cpp
@@ -1,18 +1,18 @@
 #include "FramebufferElement.hpp"
 #include "../OpenGL.hpp"
 
-CFramebufferElement::CFramebufferElement(const CFramebufferElement::SFramebufferElementData& data_) : data(data_) {
+CFramebufferElement::CFramebufferElement(const CFramebufferElement::SFramebufferElementData& data_) : m_data(data_) {
     ;
 }
 
 void CFramebufferElement::draw(const CRegion& damage) {
     CFramebuffer* fb = nullptr;
 
-    if (data.main) {
-        switch (data.framebufferID) {
-            case FB_MONITOR_RENDER_MAIN: fb = g_pHyprOpenGL->m_RenderData.mainFB; break;
-            case FB_MONITOR_RENDER_CURRENT: fb = g_pHyprOpenGL->m_RenderData.currentFB; break;
-            case FB_MONITOR_RENDER_OUT: fb = g_pHyprOpenGL->m_RenderData.outFB; break;
+    if (m_data.main) {
+        switch (m_data.framebufferID) {
+            case FB_MONITOR_RENDER_MAIN: fb = g_pHyprOpenGL->m_renderData.mainFB; break;
+            case FB_MONITOR_RENDER_CURRENT: fb = g_pHyprOpenGL->m_renderData.currentFB; break;
+            case FB_MONITOR_RENDER_OUT: fb = g_pHyprOpenGL->m_renderData.outFB; break;
         }
 
         if (!fb) {
@@ -21,13 +21,13 @@ void CFramebufferElement::draw(const CRegion& damage) {
         }
 
     } else {
-        switch (data.framebufferID) {
-            case FB_MONITOR_RENDER_EXTRA_OFFLOAD: fb = &g_pHyprOpenGL->m_RenderData.pCurrentMonData->offloadFB; break;
-            case FB_MONITOR_RENDER_EXTRA_MIRROR: fb = &g_pHyprOpenGL->m_RenderData.pCurrentMonData->mirrorFB; break;
-            case FB_MONITOR_RENDER_EXTRA_MIRROR_SWAP: fb = &g_pHyprOpenGL->m_RenderData.pCurrentMonData->mirrorSwapFB; break;
-            case FB_MONITOR_RENDER_EXTRA_OFF_MAIN: fb = &g_pHyprOpenGL->m_RenderData.pCurrentMonData->offMainFB; break;
-            case FB_MONITOR_RENDER_EXTRA_MONITOR_MIRROR: fb = &g_pHyprOpenGL->m_RenderData.pCurrentMonData->monitorMirrorFB; break;
-            case FB_MONITOR_RENDER_EXTRA_BLUR: fb = &g_pHyprOpenGL->m_RenderData.pCurrentMonData->blurFB; break;
+        switch (m_data.framebufferID) {
+            case FB_MONITOR_RENDER_EXTRA_OFFLOAD: fb = &g_pHyprOpenGL->m_renderData.pCurrentMonData->offloadFB; break;
+            case FB_MONITOR_RENDER_EXTRA_MIRROR: fb = &g_pHyprOpenGL->m_renderData.pCurrentMonData->mirrorFB; break;
+            case FB_MONITOR_RENDER_EXTRA_MIRROR_SWAP: fb = &g_pHyprOpenGL->m_renderData.pCurrentMonData->mirrorSwapFB; break;
+            case FB_MONITOR_RENDER_EXTRA_OFF_MAIN: fb = &g_pHyprOpenGL->m_renderData.pCurrentMonData->offMainFB; break;
+            case FB_MONITOR_RENDER_EXTRA_MONITOR_MIRROR: fb = &g_pHyprOpenGL->m_renderData.pCurrentMonData->monitorMirrorFB; break;
+            case FB_MONITOR_RENDER_EXTRA_BLUR: fb = &g_pHyprOpenGL->m_renderData.pCurrentMonData->blurFB; break;
         }
 
         if (!fb) {

--- a/src/render/pass/FramebufferElement.hpp
+++ b/src/render/pass/FramebufferElement.hpp
@@ -21,5 +21,5 @@ class CFramebufferElement : public IPassElement {
     }
 
   private:
-    SFramebufferElementData data;
+    SFramebufferElementData m_data;
 };

--- a/src/render/pass/Pass.hpp
+++ b/src/render/pass/Pass.hpp
@@ -18,9 +18,9 @@ class CRenderPass {
     CRegion render(const CRegion& damage_);
 
   private:
-    CRegion              damage;
-    std::vector<CRegion> occludedRegions;
-    CRegion              totalLiveBlurRegion;
+    CRegion              m_damage;
+    std::vector<CRegion> m_occludedRegions;
+    CRegion              m_totalLiveBlurRegion;
 
     struct SPassElementData {
         CRegion          elementDamage;
@@ -28,9 +28,7 @@ class CRenderPass {
         bool             discard = false;
     };
 
-    std::vector<SP<SPassElementData>> m_vPassElements;
-
-    SP<IPassElement>                  currentPassInfo = nullptr;
+    std::vector<SP<SPassElementData>> m_passElements;
 
     void                              simplify();
     float                             oneBlurRadius();
@@ -39,7 +37,7 @@ class CRenderPass {
     struct {
         bool         present = false;
         SP<CTexture> keyboardFocusText, pointerFocusText, lastWindowText;
-    } debugData;
+    } m_debugData;
 
     friend class CHyprOpenGLImpl;
 };

--- a/src/render/pass/RectPassElement.cpp
+++ b/src/render/pass/RectPassElement.cpp
@@ -1,45 +1,45 @@
 #include "RectPassElement.hpp"
 #include "../OpenGL.hpp"
 
-CRectPassElement::CRectPassElement(const CRectPassElement::SRectData& data_) : data(data_) {
+CRectPassElement::CRectPassElement(const CRectPassElement::SRectData& data_) : m_data(data_) {
     ;
 }
 
 void CRectPassElement::draw(const CRegion& damage) {
-    if (data.box.w <= 0 || data.box.h <= 0)
+    if (m_data.box.w <= 0 || m_data.box.h <= 0)
         return;
 
-    if (!data.clipBox.empty())
-        g_pHyprOpenGL->m_RenderData.clipBox = data.clipBox;
+    if (!m_data.clipBox.empty())
+        g_pHyprOpenGL->m_renderData.clipBox = m_data.clipBox;
 
-    if (data.color.a == 1.F || !data.blur)
-        g_pHyprOpenGL->renderRectWithDamage(data.box, data.color, damage, data.round, data.roundingPower);
+    if (m_data.color.a == 1.F || !m_data.blur)
+        g_pHyprOpenGL->renderRectWithDamage(m_data.box, m_data.color, damage, m_data.round, m_data.roundingPower);
     else
-        g_pHyprOpenGL->renderRectWithBlur(data.box, data.color, data.round, data.roundingPower, data.blurA, data.xray);
+        g_pHyprOpenGL->renderRectWithBlur(m_data.box, m_data.color, m_data.round, m_data.roundingPower, m_data.blurA, m_data.xray);
 
-    g_pHyprOpenGL->m_RenderData.clipBox = {};
+    g_pHyprOpenGL->m_renderData.clipBox = {};
 }
 
 bool CRectPassElement::needsLiveBlur() {
-    return data.color.a < 1.F && !data.xray && data.blur;
+    return m_data.color.a < 1.F && !m_data.xray && m_data.blur;
 }
 
 bool CRectPassElement::needsPrecomputeBlur() {
-    return data.color.a < 1.F && data.xray && data.blur;
+    return m_data.color.a < 1.F && m_data.xray && m_data.blur;
 }
 
 std::optional<CBox> CRectPassElement::boundingBox() {
-    return data.box.copy().scale(1.F / g_pHyprOpenGL->m_RenderData.pMonitor->m_scale).round();
+    return m_data.box.copy().scale(1.F / g_pHyprOpenGL->m_renderData.pMonitor->m_scale).round();
 }
 
 CRegion CRectPassElement::opaqueRegion() {
-    if (data.color.a < 1.F)
+    if (m_data.color.a < 1.F)
         return CRegion{};
 
-    CRegion rg = boundingBox()->expand(-data.round);
+    CRegion rg = boundingBox()->expand(-m_data.round);
 
-    if (!data.clipBox.empty())
-        rg.intersect(data.clipBox);
+    if (!m_data.clipBox.empty())
+        rg.intersect(m_data.clipBox);
 
     return rg;
 }

--- a/src/render/pass/RectPassElement.hpp
+++ b/src/render/pass/RectPassElement.hpp
@@ -27,5 +27,5 @@ class CRectPassElement : public IPassElement {
     }
 
   private:
-    SRectData data;
+    SRectData m_data;
 };

--- a/src/render/pass/RendererHintsPassElement.cpp
+++ b/src/render/pass/RendererHintsPassElement.cpp
@@ -1,13 +1,13 @@
 #include "RendererHintsPassElement.hpp"
 #include "../OpenGL.hpp"
 
-CRendererHintsPassElement::CRendererHintsPassElement(const CRendererHintsPassElement::SData& data_) : data(data_) {
+CRendererHintsPassElement::CRendererHintsPassElement(const CRendererHintsPassElement::SData& data_) : m_data(data_) {
     ;
 }
 
 void CRendererHintsPassElement::draw(const CRegion& damage) {
-    if (data.renderModif.has_value())
-        g_pHyprOpenGL->m_RenderData.renderModif = *data.renderModif;
+    if (m_data.renderModif.has_value())
+        g_pHyprOpenGL->m_renderData.renderModif = *m_data.renderModif;
 }
 
 bool CRendererHintsPassElement::needsLiveBlur() {

--- a/src/render/pass/RendererHintsPassElement.hpp
+++ b/src/render/pass/RendererHintsPassElement.hpp
@@ -22,5 +22,5 @@ class CRendererHintsPassElement : public IPassElement {
     }
 
   private:
-    SData data;
+    SData m_data;
 };

--- a/src/render/pass/ShadowPassElement.cpp
+++ b/src/render/pass/ShadowPassElement.cpp
@@ -2,12 +2,12 @@
 #include "../OpenGL.hpp"
 #include "../decorations/CHyprDropShadowDecoration.hpp"
 
-CShadowPassElement::CShadowPassElement(const CShadowPassElement::SShadowData& data_) : data(data_) {
+CShadowPassElement::CShadowPassElement(const CShadowPassElement::SShadowData& data_) : m_data(data_) {
     ;
 }
 
 void CShadowPassElement::draw(const CRegion& damage) {
-    data.deco->render(g_pHyprOpenGL->m_RenderData.pMonitor.lock(), data.a);
+    m_data.deco->render(g_pHyprOpenGL->m_renderData.pMonitor.lock(), m_data.a);
 }
 
 bool CShadowPassElement::needsLiveBlur() {

--- a/src/render/pass/ShadowPassElement.hpp
+++ b/src/render/pass/ShadowPassElement.hpp
@@ -22,5 +22,5 @@ class CShadowPassElement : public IPassElement {
     }
 
   private:
-    SShadowData data;
+    SShadowData m_data;
 };

--- a/src/render/pass/SurfacePassElement.cpp
+++ b/src/render/pass/SurfacePassElement.cpp
@@ -12,59 +12,59 @@
 #include <hyprutils/utils/ScopeGuard.hpp>
 using namespace Hyprutils::Utils;
 
-CSurfacePassElement::CSurfacePassElement(const CSurfacePassElement::SRenderData& data_) : data(data_) {
+CSurfacePassElement::CSurfacePassElement(const CSurfacePassElement::SRenderData& data_) : m_data(data_) {
     ;
 }
 
 void CSurfacePassElement::draw(const CRegion& damage) {
-    g_pHyprOpenGL->m_RenderData.currentWindow      = data.pWindow;
-    g_pHyprOpenGL->m_RenderData.surface            = data.surface;
-    g_pHyprOpenGL->m_RenderData.currentLS          = data.pLS;
-    g_pHyprOpenGL->m_RenderData.clipBox            = data.clipBox;
-    g_pHyprOpenGL->m_RenderData.discardMode        = data.discardMode;
-    g_pHyprOpenGL->m_RenderData.discardOpacity     = data.discardOpacity;
-    g_pHyprOpenGL->m_RenderData.useNearestNeighbor = data.useNearestNeighbor;
-    g_pHyprOpenGL->m_bEndFrame                     = data.flipEndFrame;
+    g_pHyprOpenGL->m_renderData.currentWindow      = m_data.pWindow;
+    g_pHyprOpenGL->m_renderData.surface            = m_data.surface;
+    g_pHyprOpenGL->m_renderData.currentLS          = m_data.pLS;
+    g_pHyprOpenGL->m_renderData.clipBox            = m_data.clipBox;
+    g_pHyprOpenGL->m_renderData.discardMode        = m_data.discardMode;
+    g_pHyprOpenGL->m_renderData.discardOpacity     = m_data.discardOpacity;
+    g_pHyprOpenGL->m_renderData.useNearestNeighbor = m_data.useNearestNeighbor;
+    g_pHyprOpenGL->m_endFrame                     = m_data.flipEndFrame;
 
     CScopeGuard x = {[]() {
-        g_pHyprOpenGL->m_RenderData.primarySurfaceUVTopLeft     = Vector2D(-1, -1);
-        g_pHyprOpenGL->m_RenderData.primarySurfaceUVBottomRight = Vector2D(-1, -1);
-        g_pHyprOpenGL->m_RenderData.useNearestNeighbor          = false;
-        g_pHyprOpenGL->m_RenderData.clipBox                     = {};
-        g_pHyprOpenGL->m_RenderData.clipRegion                  = {};
-        g_pHyprOpenGL->m_RenderData.discardMode                 = 0;
-        g_pHyprOpenGL->m_RenderData.discardOpacity              = 0;
-        g_pHyprOpenGL->m_RenderData.useNearestNeighbor          = false;
-        g_pHyprOpenGL->m_bEndFrame                              = false;
-        g_pHyprOpenGL->m_RenderData.currentWindow.reset();
-        g_pHyprOpenGL->m_RenderData.surface.reset();
-        g_pHyprOpenGL->m_RenderData.currentLS.reset();
+        g_pHyprOpenGL->m_renderData.primarySurfaceUVTopLeft     = Vector2D(-1, -1);
+        g_pHyprOpenGL->m_renderData.primarySurfaceUVBottomRight = Vector2D(-1, -1);
+        g_pHyprOpenGL->m_renderData.useNearestNeighbor          = false;
+        g_pHyprOpenGL->m_renderData.clipBox                     = {};
+        g_pHyprOpenGL->m_renderData.clipRegion                  = {};
+        g_pHyprOpenGL->m_renderData.discardMode                 = 0;
+        g_pHyprOpenGL->m_renderData.discardOpacity              = 0;
+        g_pHyprOpenGL->m_renderData.useNearestNeighbor          = false;
+        g_pHyprOpenGL->m_endFrame                              = false;
+        g_pHyprOpenGL->m_renderData.currentWindow.reset();
+        g_pHyprOpenGL->m_renderData.surface.reset();
+        g_pHyprOpenGL->m_renderData.currentLS.reset();
     }};
 
-    if (!data.texture)
+    if (!m_data.texture)
         return;
 
-    const auto& TEXTURE = data.texture;
+    const auto& TEXTURE = m_data.texture;
 
     // this is bad, probably has been logged elsewhere. Means the texture failed
     // uploading to the GPU.
-    if (!TEXTURE->m_iTexID)
+    if (!TEXTURE->m_texID)
         return;
 
-    const auto INTERACTIVERESIZEINPROGRESS = data.pWindow && g_pInputManager->m_currentlyDraggedWindow && g_pInputManager->m_dragMode == MBIND_RESIZE;
+    const auto INTERACTIVERESIZEINPROGRESS = m_data.pWindow && g_pInputManager->m_currentlyDraggedWindow && g_pInputManager->m_dragMode == MBIND_RESIZE;
     TRACY_GPU_ZONE("RenderSurface");
 
-    auto        PSURFACE = CWLSurface::fromResource(data.surface);
+    auto        PSURFACE = CWLSurface::fromResource(m_data.surface);
 
-    const float ALPHA         = data.alpha * data.fadeAlpha * (PSURFACE ? PSURFACE->m_alphaModifier : 1.F);
+    const float ALPHA         = m_data.alpha * m_data.fadeAlpha * (PSURFACE ? PSURFACE->m_alphaModifier : 1.F);
     const float OVERALL_ALPHA = PSURFACE ? PSURFACE->m_overallOpacity : 1.F;
-    const bool  BLUR          = data.blur && (!TEXTURE->m_bOpaque || ALPHA < 1.F || OVERALL_ALPHA < 1.F);
+    const bool  BLUR          = m_data.blur && (!TEXTURE->m_opaque || ALPHA < 1.F || OVERALL_ALPHA < 1.F);
 
     auto        windowBox = getTexBox();
 
     const auto  PROJSIZEUNSCALED = windowBox.size();
 
-    windowBox.scale(data.pMonitor->m_scale);
+    windowBox.scale(m_data.pMonitor->m_scale);
     windowBox.round();
 
     if (windowBox.width <= 1 || windowBox.height <= 1) {
@@ -72,17 +72,17 @@ void CSurfacePassElement::draw(const CRegion& damage) {
         return;
     }
 
-    const bool MISALIGNEDFSV1 = std::floor(data.pMonitor->m_scale) != data.pMonitor->m_scale /* Fractional */ && data.surface->m_current.scale == 1 /* fs protocol */ &&
-        windowBox.size() != data.surface->m_current.bufferSize /* misaligned */ && DELTALESSTHAN(windowBox.width, data.surface->m_current.bufferSize.x, 3) &&
-        DELTALESSTHAN(windowBox.height, data.surface->m_current.bufferSize.y, 3) /* off by one-or-two */ &&
-        (!data.pWindow || (!data.pWindow->m_realSize->isBeingAnimated() && !INTERACTIVERESIZEINPROGRESS)) /* not window or not animated/resizing */;
+    const bool MISALIGNEDFSV1 = std::floor(m_data.pMonitor->m_scale) != m_data.pMonitor->m_scale /* Fractional */ && m_data.surface->m_current.scale == 1 /* fs protocol */ &&
+        windowBox.size() != m_data.surface->m_current.bufferSize /* misaligned */ && DELTALESSTHAN(windowBox.width, m_data.surface->m_current.bufferSize.x, 3) &&
+        DELTALESSTHAN(windowBox.height, m_data.surface->m_current.bufferSize.y, 3) /* off by one-or-two */ &&
+        (!m_data.pWindow || (!m_data.pWindow->m_realSize->isBeingAnimated() && !INTERACTIVERESIZEINPROGRESS)) /* not window or not animated/resizing */;
 
-    if (data.surface->m_colorManagement.valid())
+    if (m_data.surface->m_colorManagement.valid())
         Debug::log(TRACE, "FIXME: rendering surface with color management enabled, should apply necessary transformations");
-    g_pHyprRenderer->calculateUVForSurface(data.pWindow, data.surface, data.pMonitor->m_self.lock(), data.mainSurface, windowBox.size(), PROJSIZEUNSCALED, MISALIGNEDFSV1);
+    g_pHyprRenderer->calculateUVForSurface(m_data.pWindow, m_data.surface, m_data.pMonitor->m_self.lock(), m_data.mainSurface, windowBox.size(), PROJSIZEUNSCALED, MISALIGNEDFSV1);
 
     auto cancelRender                      = false;
-    g_pHyprOpenGL->m_RenderData.clipRegion = visibleRegion(cancelRender);
+    g_pHyprOpenGL->m_renderData.clipRegion = visibleRegion(cancelRender);
     if (cancelRender)
         return;
 
@@ -91,19 +91,19 @@ void CSurfacePassElement::draw(const CRegion& damage) {
     // as long as the window is not animated. During those it'd look weird.
     // UV will fixup it as well
     if (MISALIGNEDFSV1)
-        g_pHyprOpenGL->m_RenderData.useNearestNeighbor = true;
+        g_pHyprOpenGL->m_renderData.useNearestNeighbor = true;
 
-    float rounding      = data.rounding;
-    float roundingPower = data.roundingPower;
+    float rounding      = m_data.rounding;
+    float roundingPower = m_data.roundingPower;
 
     rounding -= 1; // to fix a border issue
 
-    if (data.dontRound) {
+    if (m_data.dontRound) {
         rounding      = 0;
         roundingPower = 2.0f;
     }
 
-    const bool WINDOWOPAQUE    = data.pWindow && data.pWindow->m_wlSurface->resource() == data.surface ? data.pWindow->opaque() : false;
+    const bool WINDOWOPAQUE    = m_data.pWindow && m_data.pWindow->m_wlSurface->resource() == m_data.surface ? m_data.pWindow->opaque() : false;
     const bool CANDISABLEBLEND = ALPHA >= 1.f && OVERALL_ALPHA >= 1.f && rounding == 0 && WINDOWOPAQUE;
 
     if (CANDISABLEBLEND)
@@ -114,38 +114,38 @@ void CSurfacePassElement::draw(const CRegion& damage) {
     // FIXME: This is wrong and will bug the blur out as shit if the first surface
     // is a subsurface that does NOT cover the entire frame. In such cases, we probably should fall back
     // to what we do for misaligned surfaces (blur the entire thing and then render shit without blur)
-    if (data.surfaceCounter == 0 && !data.popup) {
+    if (m_data.surfaceCounter == 0 && !m_data.popup) {
         if (BLUR)
-            g_pHyprOpenGL->renderTextureWithBlur(TEXTURE, windowBox, ALPHA, data.surface, rounding, roundingPower, data.blockBlurOptimization, data.fadeAlpha, OVERALL_ALPHA);
+            g_pHyprOpenGL->renderTextureWithBlur(TEXTURE, windowBox, ALPHA, m_data.surface, rounding, roundingPower, m_data.blockBlurOptimization, m_data.fadeAlpha, OVERALL_ALPHA);
         else
             g_pHyprOpenGL->renderTexture(TEXTURE, windowBox, ALPHA * OVERALL_ALPHA, rounding, roundingPower, false, true);
     } else {
-        if (BLUR && data.popup)
-            g_pHyprOpenGL->renderTextureWithBlur(TEXTURE, windowBox, ALPHA, data.surface, rounding, roundingPower, true, data.fadeAlpha, OVERALL_ALPHA);
+        if (BLUR && m_data.popup)
+            g_pHyprOpenGL->renderTextureWithBlur(TEXTURE, windowBox, ALPHA, m_data.surface, rounding, roundingPower, true, m_data.fadeAlpha, OVERALL_ALPHA);
         else
             g_pHyprOpenGL->renderTexture(TEXTURE, windowBox, ALPHA * OVERALL_ALPHA, rounding, roundingPower, false, true);
     }
 
     if (!g_pHyprRenderer->m_bBlockSurfaceFeedback)
-        data.surface->presentFeedback(data.when, data.pMonitor->m_self.lock());
+        m_data.surface->presentFeedback(m_data.when, m_data.pMonitor->m_self.lock());
 
     // add async (dmabuf) buffers to usedBuffers so we can handle release later
     // sync (shm) buffers will be released in commitState, so no need to track them here
-    if (data.surface->m_current.buffer && !data.surface->m_current.buffer->isSynchronous())
-        g_pHyprRenderer->usedAsyncBuffers.emplace_back(data.surface->m_current.buffer);
+    if (m_data.surface->m_current.buffer && !m_data.surface->m_current.buffer->isSynchronous())
+        g_pHyprRenderer->m_usedAsyncBuffers.emplace_back(m_data.surface->m_current.buffer);
 
     g_pHyprOpenGL->blend(true);
 }
 
 CBox CSurfacePassElement::getTexBox() {
-    const double outputX = -data.pMonitor->m_position.x, outputY = -data.pMonitor->m_position.y;
+    const double outputX = -m_data.pMonitor->m_position.x, outputY = -m_data.pMonitor->m_position.y;
 
-    const auto   INTERACTIVERESIZEINPROGRESS = data.pWindow && g_pInputManager->m_currentlyDraggedWindow && g_pInputManager->m_dragMode == MBIND_RESIZE;
-    auto         PSURFACE                    = CWLSurface::fromResource(data.surface);
+    const auto   INTERACTIVERESIZEINPROGRESS = m_data.pWindow && g_pInputManager->m_currentlyDraggedWindow && g_pInputManager->m_dragMode == MBIND_RESIZE;
+    auto         PSURFACE                    = CWLSurface::fromResource(m_data.surface);
 
     CBox         windowBox;
-    if (data.surface && data.mainSurface) {
-        windowBox = {(int)outputX + data.pos.x + data.localPos.x, (int)outputY + data.pos.y + data.localPos.y, data.w, data.h};
+    if (m_data.surface && m_data.mainSurface) {
+        windowBox = {(int)outputX + m_data.pos.x + m_data.localPos.x, (int)outputY + m_data.pos.y + m_data.localPos.y, m_data.w, m_data.h};
 
         // however, if surface buffer w / h < box, we need to adjust them
         const auto PWINDOW = PSURFACE ? PSURFACE->getWindow() : nullptr;
@@ -167,49 +167,49 @@ CBox CSurfacePassElement::getTexBox() {
         }
 
     } else { //  here we clamp to 2, these might be some tiny specks
-        windowBox = {(int)outputX + data.pos.x + data.localPos.x, (int)outputY + data.pos.y + data.localPos.y, std::max((float)data.surface->m_current.size.x, 2.F),
-                     std::max((float)data.surface->m_current.size.y, 2.F)};
-        if (data.pWindow && data.pWindow->m_realSize->isBeingAnimated() && data.surface && !data.mainSurface && data.squishOversized /* subsurface */) {
+        windowBox = {(int)outputX + m_data.pos.x + m_data.localPos.x, (int)outputY + m_data.pos.y + m_data.localPos.y, std::max((float)m_data.surface->m_current.size.x, 2.F),
+                     std::max((float)m_data.surface->m_current.size.y, 2.F)};
+        if (m_data.pWindow && m_data.pWindow->m_realSize->isBeingAnimated() && m_data.surface && !m_data.mainSurface && m_data.squishOversized /* subsurface */) {
             // adjust subsurfaces to the window
-            windowBox.width  = (windowBox.width / data.pWindow->m_reportedSize.x) * data.pWindow->m_realSize->value().x;
-            windowBox.height = (windowBox.height / data.pWindow->m_reportedSize.y) * data.pWindow->m_realSize->value().y;
+            windowBox.width  = (windowBox.width / m_data.pWindow->m_reportedSize.x) * m_data.pWindow->m_realSize->value().x;
+            windowBox.height = (windowBox.height / m_data.pWindow->m_reportedSize.y) * m_data.pWindow->m_realSize->value().y;
         }
     }
 
-    if (data.squishOversized) {
-        if (data.localPos.x + windowBox.width > data.w)
-            windowBox.width = data.w - data.localPos.x;
-        if (data.localPos.y + windowBox.height > data.h)
-            windowBox.height = data.h - data.localPos.y;
+    if (m_data.squishOversized) {
+        if (m_data.localPos.x + windowBox.width > m_data.w)
+            windowBox.width = m_data.w - m_data.localPos.x;
+        if (m_data.localPos.y + windowBox.height > m_data.h)
+            windowBox.height = m_data.h - m_data.localPos.y;
     }
 
     return windowBox;
 }
 
 bool CSurfacePassElement::needsLiveBlur() {
-    auto        PSURFACE = CWLSurface::fromResource(data.surface);
+    auto        PSURFACE = CWLSurface::fromResource(m_data.surface);
 
-    const float ALPHA = data.alpha * data.fadeAlpha * (PSURFACE ? PSURFACE->m_alphaModifier * PSURFACE->m_overallOpacity : 1.F);
-    const bool  BLUR  = data.blur && (!data.texture || !data.texture->m_bOpaque || ALPHA < 1.F);
+    const float ALPHA = m_data.alpha * m_data.fadeAlpha * (PSURFACE ? PSURFACE->m_alphaModifier * PSURFACE->m_overallOpacity : 1.F);
+    const bool  BLUR  = m_data.blur && (!m_data.texture || !m_data.texture->m_opaque || ALPHA < 1.F);
 
-    if (!data.pLS && !data.pWindow)
+    if (!m_data.pLS && !m_data.pWindow)
         return BLUR;
 
-    const bool NEWOPTIM = g_pHyprOpenGL->shouldUseNewBlurOptimizations(data.pLS, data.pWindow);
+    const bool NEWOPTIM = g_pHyprOpenGL->shouldUseNewBlurOptimizations(m_data.pLS, m_data.pWindow);
 
     return BLUR && !NEWOPTIM;
 }
 
 bool CSurfacePassElement::needsPrecomputeBlur() {
-    auto        PSURFACE = CWLSurface::fromResource(data.surface);
+    auto        PSURFACE = CWLSurface::fromResource(m_data.surface);
 
-    const float ALPHA = data.alpha * data.fadeAlpha * (PSURFACE ? PSURFACE->m_alphaModifier * PSURFACE->m_overallOpacity : 1.F);
-    const bool  BLUR  = data.blur && (!data.texture || !data.texture->m_bOpaque || ALPHA < 1.F);
+    const float ALPHA = m_data.alpha * m_data.fadeAlpha * (PSURFACE ? PSURFACE->m_alphaModifier * PSURFACE->m_overallOpacity : 1.F);
+    const bool  BLUR  = m_data.blur && (!m_data.texture || !m_data.texture->m_opaque || ALPHA < 1.F);
 
-    if (!data.pLS && !data.pWindow)
+    if (!m_data.pLS && !m_data.pWindow)
         return BLUR;
 
-    const bool NEWOPTIM = g_pHyprOpenGL->shouldUseNewBlurOptimizations(data.pLS, data.pWindow);
+    const bool NEWOPTIM = g_pHyprOpenGL->shouldUseNewBlurOptimizations(m_data.pLS, m_data.pWindow);
 
     return BLUR && NEWOPTIM;
 }
@@ -219,29 +219,29 @@ std::optional<CBox> CSurfacePassElement::boundingBox() {
 }
 
 CRegion CSurfacePassElement::opaqueRegion() {
-    auto        PSURFACE = CWLSurface::fromResource(data.surface);
+    auto        PSURFACE = CWLSurface::fromResource(m_data.surface);
 
-    const float ALPHA = data.alpha * data.fadeAlpha * (PSURFACE ? PSURFACE->m_alphaModifier * PSURFACE->m_overallOpacity : 1.F);
+    const float ALPHA = m_data.alpha * m_data.fadeAlpha * (PSURFACE ? PSURFACE->m_alphaModifier * PSURFACE->m_overallOpacity : 1.F);
 
     if (ALPHA < 1.F)
         return {};
 
-    if (data.surface && data.surface->m_current.size == Vector2D{data.w, data.h}) {
-        CRegion    opaqueSurf = data.surface->m_current.opaque.copy().intersect(CBox{{}, {data.w, data.h}});
+    if (m_data.surface && m_data.surface->m_current.size == Vector2D{m_data.w, m_data.h}) {
+        CRegion    opaqueSurf = m_data.surface->m_current.opaque.copy().intersect(CBox{{}, {m_data.w, m_data.h}});
         const auto texBox     = getTexBox();
-        opaqueSurf.scale(texBox.size() / Vector2D{data.w, data.h});
-        return opaqueSurf.translate(data.pos + data.localPos - data.pMonitor->m_position).expand(-data.rounding);
+        opaqueSurf.scale(texBox.size() / Vector2D{m_data.w, m_data.h});
+        return opaqueSurf.translate(m_data.pos + m_data.localPos - m_data.pMonitor->m_position).expand(-m_data.rounding);
     }
 
-    return data.texture && data.texture->m_bOpaque ? boundingBox()->expand(-data.rounding) : CRegion{};
+    return m_data.texture && m_data.texture->m_opaque ? boundingBox()->expand(-m_data.rounding) : CRegion{};
 }
 
 CRegion CSurfacePassElement::visibleRegion(bool& cancel) {
-    auto PSURFACE = CWLSurface::fromResource(data.surface);
+    auto PSURFACE = CWLSurface::fromResource(m_data.surface);
     if (!PSURFACE)
         return {};
 
-    const auto& bufferSize = data.surface->m_current.bufferSize;
+    const auto& bufferSize = m_data.surface->m_current.bufferSize;
 
     auto        visibleRegion = PSURFACE->m_visibleRegion.copy();
     if (visibleRegion.empty())
@@ -257,8 +257,8 @@ CRegion CSurfacePassElement::visibleRegion(bool& cancel) {
     // deal with any rounding errors that might come from scaling
     visibleRegion.expand(1);
 
-    auto uvTL = g_pHyprOpenGL->m_RenderData.primarySurfaceUVTopLeft;
-    auto uvBR = g_pHyprOpenGL->m_RenderData.primarySurfaceUVBottomRight;
+    auto uvTL = g_pHyprOpenGL->m_renderData.primarySurfaceUVTopLeft;
+    auto uvBR = g_pHyprOpenGL->m_renderData.primarySurfaceUVBottomRight;
 
     if (uvTL == Vector2D(-1, -1))
         uvTL = Vector2D(0, 0);
@@ -269,11 +269,11 @@ CRegion CSurfacePassElement::visibleRegion(bool& cancel) {
     visibleRegion.translate(-uvTL * bufferSize);
 
     auto texBox = getTexBox();
-    texBox.scale(data.pMonitor->m_scale);
+    texBox.scale(m_data.pMonitor->m_scale);
     texBox.round();
 
     visibleRegion.scale((Vector2D(1, 1) / (uvBR - uvTL)) * (texBox.size() / bufferSize));
-    visibleRegion.translate((data.pos + data.localPos) * data.pMonitor->m_scale - data.pMonitor->m_position);
+    visibleRegion.translate((m_data.pos + m_data.localPos) * m_data.pMonitor->m_scale - m_data.pMonitor->m_position);
 
     return visibleRegion;
 }
@@ -281,6 +281,6 @@ CRegion CSurfacePassElement::visibleRegion(bool& cancel) {
 void CSurfacePassElement::discard() {
     if (!g_pHyprRenderer->m_bBlockSurfaceFeedback) {
         Debug::log(TRACE, "discard for invisible surface");
-        data.surface->presentFeedback(data.when, data.pMonitor->m_self.lock(), true);
+        m_data.surface->presentFeedback(m_data.when, m_data.pMonitor->m_self.lock(), true);
     }
 }

--- a/src/render/pass/SurfacePassElement.cpp
+++ b/src/render/pass/SurfacePassElement.cpp
@@ -24,7 +24,7 @@ void CSurfacePassElement::draw(const CRegion& damage) {
     g_pHyprOpenGL->m_renderData.discardMode        = m_data.discardMode;
     g_pHyprOpenGL->m_renderData.discardOpacity     = m_data.discardOpacity;
     g_pHyprOpenGL->m_renderData.useNearestNeighbor = m_data.useNearestNeighbor;
-    g_pHyprOpenGL->m_endFrame                     = m_data.flipEndFrame;
+    g_pHyprOpenGL->m_endFrame                      = m_data.flipEndFrame;
 
     CScopeGuard x = {[]() {
         g_pHyprOpenGL->m_renderData.primarySurfaceUVTopLeft     = Vector2D(-1, -1);
@@ -35,7 +35,7 @@ void CSurfacePassElement::draw(const CRegion& damage) {
         g_pHyprOpenGL->m_renderData.discardMode                 = 0;
         g_pHyprOpenGL->m_renderData.discardOpacity              = 0;
         g_pHyprOpenGL->m_renderData.useNearestNeighbor          = false;
-        g_pHyprOpenGL->m_endFrame                              = false;
+        g_pHyprOpenGL->m_endFrame                               = false;
         g_pHyprOpenGL->m_renderData.currentWindow.reset();
         g_pHyprOpenGL->m_renderData.surface.reset();
         g_pHyprOpenGL->m_renderData.currentLS.reset();

--- a/src/render/pass/SurfacePassElement.hpp
+++ b/src/render/pass/SurfacePassElement.hpp
@@ -65,7 +65,7 @@ class CSurfacePassElement : public IPassElement {
     }
 
   private:
-    SRenderData data;
+    SRenderData m_data;
 
     CBox        getTexBox();
 };

--- a/src/render/pass/TexPassElement.cpp
+++ b/src/render/pass/TexPassElement.cpp
@@ -13,7 +13,7 @@ void CTexPassElement::draw(const CRegion& damage) {
 
     CScopeGuard x = {[]() {
         //
-        g_pHyprOpenGL->m_endFrame          = false;
+        g_pHyprOpenGL->m_endFrame           = false;
         g_pHyprOpenGL->m_renderData.clipBox = {};
     }};
 

--- a/src/render/pass/TexPassElement.cpp
+++ b/src/render/pass/TexPassElement.cpp
@@ -4,27 +4,27 @@
 #include <hyprutils/utils/ScopeGuard.hpp>
 using namespace Hyprutils::Utils;
 
-CTexPassElement::CTexPassElement(const CTexPassElement::SRenderData& data_) : data(data_) {
+CTexPassElement::CTexPassElement(const CTexPassElement::SRenderData& data_) : m_data(data_) {
     ;
 }
 
 void CTexPassElement::draw(const CRegion& damage) {
-    g_pHyprOpenGL->m_bEndFrame = data.flipEndFrame;
+    g_pHyprOpenGL->m_endFrame = m_data.flipEndFrame;
 
     CScopeGuard x = {[]() {
         //
-        g_pHyprOpenGL->m_bEndFrame          = false;
-        g_pHyprOpenGL->m_RenderData.clipBox = {};
+        g_pHyprOpenGL->m_endFrame          = false;
+        g_pHyprOpenGL->m_renderData.clipBox = {};
     }};
 
-    if (!data.clipBox.empty())
-        g_pHyprOpenGL->m_RenderData.clipBox = data.clipBox;
+    if (!m_data.clipBox.empty())
+        g_pHyprOpenGL->m_renderData.clipBox = m_data.clipBox;
 
-    if (data.replaceProjection)
-        g_pHyprOpenGL->m_RenderData.monitorProjection = *data.replaceProjection;
-    g_pHyprOpenGL->renderTextureInternalWithDamage(data.tex, data.box, data.a, data.damage.empty() ? damage : data.damage, data.round, data.roundingPower);
-    if (data.replaceProjection)
-        g_pHyprOpenGL->m_RenderData.monitorProjection = g_pHyprOpenGL->m_RenderData.pMonitor->m_projMatrix;
+    if (m_data.replaceProjection)
+        g_pHyprOpenGL->m_renderData.monitorProjection = *m_data.replaceProjection;
+    g_pHyprOpenGL->renderTextureInternalWithDamage(m_data.tex, m_data.box, m_data.a, m_data.damage.empty() ? damage : m_data.damage, m_data.round, m_data.roundingPower);
+    if (m_data.replaceProjection)
+        g_pHyprOpenGL->m_renderData.monitorProjection = g_pHyprOpenGL->m_renderData.pMonitor->m_projMatrix;
 }
 
 bool CTexPassElement::needsLiveBlur() {
@@ -36,7 +36,7 @@ bool CTexPassElement::needsPrecomputeBlur() {
 }
 
 std::optional<CBox> CTexPassElement::boundingBox() {
-    return data.box.copy().scale(1.F / g_pHyprOpenGL->m_RenderData.pMonitor->m_scale).round();
+    return m_data.box.copy().scale(1.F / g_pHyprOpenGL->m_renderData.pMonitor->m_scale).round();
 }
 
 CRegion CTexPassElement::opaqueRegion() {

--- a/src/render/pass/TexPassElement.hpp
+++ b/src/render/pass/TexPassElement.hpp
@@ -35,5 +35,5 @@ class CTexPassElement : public IPassElement {
     }
 
   private:
-    SRenderData data;
+    SRenderData m_data;
 };

--- a/src/render/pass/TextureMatteElement.cpp
+++ b/src/render/pass/TextureMatteElement.cpp
@@ -1,19 +1,19 @@
 #include "TextureMatteElement.hpp"
 #include "../OpenGL.hpp"
 
-CTextureMatteElement::CTextureMatteElement(const CTextureMatteElement::STextureMatteData& data_) : data(data_) {
+CTextureMatteElement::CTextureMatteElement(const CTextureMatteElement::STextureMatteData& data_) : m_data(data_) {
     ;
 }
 
 void CTextureMatteElement::draw(const CRegion& damage) {
-    if (data.disableTransformAndModify) {
+    if (m_data.disableTransformAndModify) {
         g_pHyprOpenGL->setMonitorTransformEnabled(true);
         g_pHyprOpenGL->setRenderModifEnabled(false);
-        g_pHyprOpenGL->renderTextureMatte(data.tex, data.box, *data.fb);
+        g_pHyprOpenGL->renderTextureMatte(m_data.tex, m_data.box, *m_data.fb);
         g_pHyprOpenGL->setRenderModifEnabled(true);
         g_pHyprOpenGL->setMonitorTransformEnabled(false);
     } else
-        g_pHyprOpenGL->renderTextureMatte(data.tex, data.box, *data.fb);
+        g_pHyprOpenGL->renderTextureMatte(m_data.tex, m_data.box, *m_data.fb);
 }
 
 bool CTextureMatteElement::needsLiveBlur() {

--- a/src/render/pass/TextureMatteElement.hpp
+++ b/src/render/pass/TextureMatteElement.hpp
@@ -25,5 +25,5 @@ class CTextureMatteElement : public IPassElement {
     }
 
   private:
-    STextureMatteData data;
+    STextureMatteData m_data;
 };


### PR DESCRIPTION
part of https://github.com/hyprwm/Hyprland/issues/9870

includes some fixes in Compositor.hpp

not sure if we want `m_` prefix in `CShader`

removals:
```
CHyprBorderDecoration
- m_vLastWindowPos
- m_vLastWindowSize

CRenderPass
- currentPassInfo

CHyprOpenGLImpl
- m_lBuffers
- m_lTextures

CShader
- m_muUniforms