### PR TITLE
hyprpm: add missing return

### DIFF
--- a/hyprpm/src/helpers/Sys.cpp
+++ b/hyprpm/src/helpers/Sys.cpp
@@ -118,5 +118,6 @@ void NSys::dropSudo() {
             // note the superuser binary that is being dropped
             std::println("{}", infoString("Don't know how to drop timestamp for '{}', ignoring.", BIN));
         }
+        return;
     }
 }


### PR DESCRIPTION

<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Add a missing return statement after handling the first superuser binary in the `dropSudo` function

Fixes: 1c530cb

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I think @nots1dd accidentally removed the return statement in MR #10246

#### Is it ready for merging, or does it need work?
 yes

