### PR TITLE
renderer: add windowrule type suppressvrr

### DIFF
--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -314,6 +314,9 @@ class CWindow {
     // For the noclosefor windowrule
     Time::steady_tp m_closeableSince = Time::steadyNow();
 
+    // VRR
+    bool m_suppressVrr = false;
+
     // For the list lookup
     bool operator==(const CWindow& rhs) const {
         return m_xdgSurface == rhs.m_xdgSurface && m_xwaylandSurface == rhs.m_xwaylandSurface && m_position == rhs.m_position && m_size == rhs.m_size &&

--- a/src/desktop/WindowRule.cpp
+++ b/src/desktop/WindowRule.cpp
@@ -5,7 +5,7 @@
 #include "../config/ConfigManager.hpp"
 
 static const auto RULES = std::unordered_set<std::string>{
-    "float", "fullscreen", "maximize", "noinitialfocus", "pin", "stayfocused", "tile", "renderunfocused", "persistentsize",
+    "float", "fullscreen", "maximize", "noinitialfocus", "pin", "stayfocused", "tile", "renderunfocused", "persistentsize", "suppressvrr",
 };
 static const auto RULES_PREFIX = std::unordered_set<std::string>{
     "animation",     "bordercolor", "bordersize", "center",  "content", "fullscreenstate", "group",    "idleinhibit",   "maxsize",     "minsize",        "monitor",
@@ -41,6 +41,8 @@ CWindowRule::CWindowRule(const std::string& rule, const std::string& value, bool
         m_ruleType = RULE_RENDERUNFOCUSED;
     else if (rule == "persistentsize")
         m_ruleType = RULE_PERSISTENTSIZE;
+    else if (rule == "suppressvrr")
+        m_ruleType = RULE_SUPPRESSVRR;
     else if (rule.starts_with("animation"))
         m_ruleType = RULE_ANIMATION;
     else if (rule.starts_with("bordercolor"))

--- a/src/desktop/WindowRule.hpp
+++ b/src/desktop/WindowRule.hpp
@@ -39,6 +39,7 @@ class CWindowRule {
         RULE_CONTENT,
         RULE_PERSISTENTSIZE,
         RULE_NOCLOSEFOR,
+        RULE_SUPPRESSVRR,
     };
 
     eRuleType         m_ruleType = RULE_INVALID;

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -321,6 +321,11 @@ void Events::listener_mapWindow(void* owner, void* data) {
                 try {
                     PWINDOW->m_closeableSince = Time::steadyNow() + std::chrono::milliseconds(std::stoull(VARS[1]));
                 } catch (std::exception& e) { Debug::log(ERR, "Rule \"{}\" failed with: {}", r->m_rule, e.what()); }
+                break;
+            }
+            case CWindowRule::RULE_SUPPRESSVRR: {
+                PWINDOW->m_suppressVrr = true;
+                break;
             }
             default: break;
         }
@@ -710,6 +715,9 @@ void Events::listener_mapWindow(void* owner, void* data) {
 
     if (PMONITOR && PWINDOW->isX11OverrideRedirect())
         PWINDOW->m_X11SurfaceScaledBy = PMONITOR->m_scale;
+
+    // VRR should update
+    g_pConfigManager->ensureVRR(PWINDOW->m_monitor.lock());
 }
 
 void Events::listener_unmapWindow(void* owner, void* data) {
@@ -847,6 +855,9 @@ void Events::listener_unmapWindow(void* owner, void* data) {
 
     // update lastwindow after focus
     PWINDOW->onUnmap();
+
+    // VRR should update
+    g_pConfigManager->ensureVRR(PMONITOR);
 }
 
 void Events::listener_commitWindow(void* owner, void* data) {


### PR DESCRIPTION
### Describe your PR, what does it fix/add?

Aims to enable functionality described in #10147 .

From commit message:
- `suppressvrr` is a type of `windowrule`
- whenever a matching window is visible on-screen in the current workspace of a monitor, that particular monitor will necessarily prevent VRR from being enabled.
- this rule works in conjunction with `misc:vrr` and per-monitor VRR settings and gets applied last in the vrr logic
- example usage: `windowrule = suppressvrr, class:nemo` will prevent VRR on any monitors that currently display a nemo window
- as a small optimization, a workspace that has a fullscreen window will either necessarily suppress VRR or not depending on whether that particular window was matched for `suppressvrr`. Whether other windows in that workspace match for `suppressvrr` or not is irrelevant to this logic.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

As this is my first contribution to the project, I am not sure whether I put the additional calls to `ensureVRR` in the correct, canonical places. For now, I added the calls inside the listeners for mapping/unmapping.

#### Is it ready for merging, or does it need work?

Should be good to go afaik, aside from the question raised above.
