### PR TITLE
hyprpm: clean up root access and properly check input

### DIFF
--- a/hyprpm/src/core/Manifest.cpp
+++ b/hyprpm/src/core/Manifest.cpp
@@ -1,6 +1,12 @@
 #include "Manifest.hpp"
 #include <toml++/toml.hpp>
-#include <iostream>
+#include <algorithm>
+
+// Alphanumerics and -_ allowed for plugin names. No magic names.
+// [A-Za-z0-9\-_]*
+static bool validManifestName(const std::string_view& n) {
+    return std::ranges::all_of(n, [](const char& c) { return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '-' || c == '_' || c == '=' || (c >= '0' && c <= '9'); });
+}
 
 CManifest::CManifest(const eManifestType type, const std::string& path) {
     auto manifest = toml::parse_file(path);
@@ -11,11 +17,17 @@ CManifest::CManifest(const eManifestType type, const std::string& path) {
                 continue;
 
             CManifest::SManifestPlugin plugin;
+
+            if (!validManifestName(key.str())) {
+                m_good = false;
+                return;
+            }
+
             plugin.name = key;
-            m_vPlugins.push_back(plugin);
+            m_plugins.push_back(plugin);
         }
 
-        for (auto& plugin : m_vPlugins) {
+        for (auto& plugin : m_plugins) {
             plugin.description = manifest[plugin.name]["description"].value_or("?");
             plugin.version     = manifest[plugin.name]["version"].value_or("?");
             plugin.output      = manifest[plugin.name]["build"]["output"].value_or("?");
@@ -37,21 +49,21 @@ CManifest::CManifest(const eManifestType type, const std::string& path) {
             }
 
             if (plugin.output.empty() || plugin.buildSteps.empty()) {
-                m_bGood = false;
+                m_good = false;
                 return;
             }
         }
     } else if (type == MANIFEST_HYPRPM) {
-        m_sRepository.name = manifest["repository"]["name"].value_or("");
-        auto authors       = manifest["repository"]["authors"].as_array();
+        m_repository.name = manifest["repository"]["name"].value_or("");
+        auto authors      = manifest["repository"]["authors"].as_array();
         if (authors) {
             for (auto&& a : *authors) {
-                m_sRepository.authors.push_back(a.as_string()->value_or("?"));
+                m_repository.authors.push_back(a.as_string()->value_or("?"));
             }
         } else {
             auto author = manifest["repository"]["author"].value_or("");
             if (!std::string{author}.empty())
-                m_sRepository.authors.push_back(author);
+                m_repository.authors.push_back(author);
         }
 
         auto pins = manifest["repository"]["commit_pins"].as_array();
@@ -59,7 +71,7 @@ CManifest::CManifest(const eManifestType type, const std::string& path) {
             for (auto&& pin : *pins) {
                 auto pinArr = pin.as_array();
                 if (pinArr && pinArr->get(1))
-                    m_sRepository.commitPins.push_back(std::make_pair<>(pinArr->get(0)->as_string()->get(), pinArr->get(1)->as_string()->get()));
+                    m_repository.commitPins.push_back(std::make_pair<>(pinArr->get(0)->as_string()->get(), pinArr->get(1)->as_string()->get()));
             }
         }
 
@@ -68,11 +80,17 @@ CManifest::CManifest(const eManifestType type, const std::string& path) {
                 continue;
 
             CManifest::SManifestPlugin plugin;
+
+            if (!validManifestName(key.str())) {
+                m_good = false;
+                return;
+            }
+
             plugin.name = key;
-            m_vPlugins.push_back(plugin);
+            m_plugins.push_back(plugin);
         }
 
-        for (auto& plugin : m_vPlugins) {
+        for (auto& plugin : m_plugins) {
             plugin.description = manifest[plugin.name]["description"].value_or("?");
             plugin.output      = manifest[plugin.name]["output"].value_or("?");
             plugin.since       = manifest[plugin.name]["since_hyprland"].value_or(0);
@@ -94,12 +112,12 @@ CManifest::CManifest(const eManifestType type, const std::string& path) {
             }
 
             if (plugin.output.empty() || plugin.buildSteps.empty()) {
-                m_bGood = false;
+                m_good = false;
                 return;
             }
         }
     } else {
         // ???
-        m_bGood = false;
+        m_good = false;
     }
 }

--- a/hyprpm/src/core/Manifest.hpp
+++ b/hyprpm/src/core/Manifest.hpp
@@ -27,8 +27,8 @@ class CManifest {
         std::string                                      name;
         std::vector<std::string>                         authors;
         std::vector<std::pair<std::string, std::string>> commitPins;
-    } m_sRepository;
+    } m_repository;
 
-    std::vector<SManifestPlugin> m_vPlugins;
-    bool                         m_bGood = true;
+    std::vector<SManifestPlugin> m_plugins;
+    bool                         m_good = true;
 };

--- a/hyprpm/src/core/PluginManager.cpp
+++ b/hyprpm/src/core/PluginManager.cpp
@@ -566,13 +566,14 @@ bool CPluginManager::updateHeaders(bool force) {
 
     ret = execAndGet(cmd);
 
-    cmd = std::format("cd {} && make installheaders && chmod -R 644 {} && find {} -type d -exec chmod o+x {{}} \\;", WORKINGDIR, DataState::getHeadersPath(),
+    cmd = std::format("make -C '{}' installheaders && chmod -R 644 '{}' && find '{}' -type d -exec chmod o+x {{}} \\;", WORKINGDIR, DataState::getHeadersPath(),
                       DataState::getHeadersPath());
 
     if (m_bVerbose)
         progress.printMessageAbove(verboseString("install will run as sudo: {}", cmd));
 
-    ret = NSys::runAsSuperuser(cmd);
+    // WORKINGDIR and headersPath should not contain anything unsafe. Usernames can't contain cmd exec parts.
+    ret = NSys::root::runAsSuperuserUnsafe(cmd);
 
     if (m_bVerbose)
         std::println("{}", verboseString("installer returned: {}", ret));

--- a/hyprpm/src/helpers/Sys.cpp
+++ b/hyprpm/src/helpers/Sys.cpp
@@ -131,7 +131,7 @@ bool NSys::root::removeRecursive(const std::string& path) {
     if (!verifyStringValid(path))
         return false;
 
-    std::error_code ec;
+    std::error_code   ec;
     const std::string PATH_ABSOLUTE = std::filesystem::canonical(path, ec);
 
     if (ec)
@@ -152,7 +152,7 @@ bool NSys::root::install(const std::string& what, const std::string& where, cons
     if (!std::ranges::all_of(mode, [](const char& c) { return c >= '0' && c <= '9'; }))
         return false;
 
-    CProcess proc(subin(), {"install", "-m" + mode, "-o", "root", "-g", "root", what, where });
+    CProcess proc(subin(), {"install", "-m" + mode, "-o", "root", "-g", "root", what, where});
 
     return proc.runSync() && proc.exitCode() == 0;
 }

--- a/hyprpm/src/helpers/Sys.hpp
+++ b/hyprpm/src/helpers/Sys.hpp
@@ -3,10 +3,21 @@
 #include <string>
 
 namespace NSys {
-    bool        isSuperuser();
-    int         getUID();
-    int         getEUID();
-    std::string runAsSuperuser(const std::string& cmd);
-    void        cacheSudo();
-    void        dropSudo();
+    bool isSuperuser();
+    int  getUID();
+    int  getEUID();
+
+    // NOLINTNEXTLINE
+    namespace root {
+        void cacheSudo();
+        void dropSudo();
+
+        //
+        [[nodiscard("Discarding could lead to vulnerabilities and bugs")]] bool createDirectory(const std::string& path, const std::string& mode);
+        [[nodiscard("Discarding could lead to vulnerabilities and bugs")]] bool removeRecursive(const std::string& path);
+        [[nodiscard("Discarding could lead to vulnerabilities and bugs")]] bool install(const std::string& what, const std::string& where, const std::string& mode);
+
+        // Do not use this unless absolutely necessary!
+        std::string runAsSuperuserUnsafe(const std::string& cmd);
+    };
 };

--- a/hyprpm/src/main.cpp
+++ b/hyprpm/src/main.cpp
@@ -101,8 +101,8 @@ int                        main(int argc, char** argv, char** envp) {
         if (command.size() >= 3)
             rev = command[2];
 
-        NSys::cacheSudo();
-        CScopeGuard x([] { NSys::dropSudo(); });
+        NSys::root::cacheSudo();
+        CScopeGuard x([] { NSys::root::dropSudo(); });
 
         return g_pPluginManager->addNewPluginRepo(command[1], rev) ? 0 : 1;
     } else if (command[0] == "remove") {
@@ -111,13 +111,13 @@ int                        main(int argc, char** argv, char** envp) {
             return 1;
         }
 
-        NSys::cacheSudo();
-        CScopeGuard x([] { NSys::dropSudo(); });
+        NSys::root::cacheSudo();
+        CScopeGuard x([] { NSys::root::dropSudo(); });
 
         return g_pPluginManager->removePluginRepo(command[1]) ? 0 : 1;
     } else if (command[0] == "update") {
-        NSys::cacheSudo();
-        CScopeGuard x([] { NSys::dropSudo(); });
+        NSys::root::cacheSudo();
+        CScopeGuard x([] { NSys::root::dropSudo(); });
 
         bool        headersValid = g_pPluginManager->headersValid() == HEADERS_OK;
         bool        headers      = g_pPluginManager->updateHeaders(force);
@@ -152,8 +152,8 @@ int                        main(int argc, char** argv, char** envp) {
             return 1;
         }
 
-        NSys::cacheSudo();
-        CScopeGuard x([] { NSys::dropSudo(); });
+        NSys::root::cacheSudo();
+        CScopeGuard x([] { NSys::root::dropSudo(); });
 
         auto        ret = g_pPluginManager->ensurePluginsLoadState();
 
@@ -173,8 +173,8 @@ int                        main(int argc, char** argv, char** envp) {
             return 1;
         }
 
-        NSys::cacheSudo();
-        CScopeGuard x([] { NSys::dropSudo(); });
+        NSys::root::cacheSudo();
+        CScopeGuard x([] { NSys::root::dropSudo(); });
 
         auto        ret = g_pPluginManager->ensurePluginsLoadState();
 
@@ -200,8 +200,8 @@ int                        main(int argc, char** argv, char** envp) {
             g_pPluginManager->notify(ICON_OK, 0, 4000, "[hyprpm] Loaded plugins");
         }
     } else if (command[0] == "purge-cache") {
-        NSys::cacheSudo();
-        CScopeGuard x([] { NSys::dropSudo(); });
+        NSys::root::cacheSudo();
+        CScopeGuard x([] { NSys::root::dropSudo(); });
         DataState::purgeAllCache();
     } else if (command[0] == "list") {
         g_pPluginManager->listAllPlugins();


### PR DESCRIPTION
This MR restructures how hyprpm accesses root privileges, limiting how we use the shell (minimizing root shell overall to one instance where it's not really possible) and sanitizes the input. 

Also restricts plugin names to reasonable names only (`A-Za-z0-9\-_`)

