### PR TITLE
layout: properly assign workspace and monitor when moving a child to the parent

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1822,3 +1822,24 @@ std::optional<std::string> CWindow::xdgDescription() {
 
     return m_xdgSurface->m_toplevel->m_toplevelDescription;
 }
+
+PHLWINDOW CWindow::parent() {
+    if (m_isX11) {
+        auto t = x11TransientFor();
+
+        // don't return a parent that's not mapped
+        if (!validMapped(t))
+            return nullptr;
+
+        return t;
+    }
+
+    if (!m_xdgSurface || !m_xdgSurface->m_toplevel || !m_xdgSurface->m_toplevel->m_parent)
+        return nullptr;
+
+    // don't return a parent that's not mapped
+    if (!m_xdgSurface->m_toplevel->m_parent->m_window || !validMapped(m_xdgSurface->m_toplevel->m_parent->m_window))
+        return nullptr;
+
+    return m_xdgSurface->m_toplevel->m_parent->m_window.lock();
+}

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -409,6 +409,7 @@ class CWindow {
     bool                       isNotResponding();
     std::optional<std::string> xdgTag();
     std::optional<std::string> xdgDescription();
+    PHLWINDOW                  parent();
 
     CBox                       getWindowMainSurfaceBox() const {
         return {m_realPosition->value().x, m_realPosition->value().y, m_realSize->value().x, m_realSize->value().y};


### PR DESCRIPTION
fixes #10321
supersedes https://github.com/hyprwm/Hyprland/pull/10328