### PR TITLE
renderer: render blur on fade out

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1156,7 +1156,7 @@ bool CWindow::opaque() {
     if (m_wlSurface->small() && !m_wlSurface->m_fillIgnoreSmall)
         return false;
 
-    if (PWORKSPACE->m_alpha->value() != 1.f)
+    if (PWORKSPACE && PWORKSPACE->m_alpha->value() != 1.f)
         return false;
 
     if (m_isX11 && m_xwaylandSurface && m_xwaylandSurface->m_surface && m_xwaylandSurface->m_surface->m_current.texture)

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -751,7 +751,8 @@ void Events::listener_unmapWindow(void* owner, void* data) {
         g_pCompositor->setWindowFullscreenInternal(PWINDOW, FSMODE_NONE);
 
     // Allow the renderer to catch the last frame.
-    g_pHyprRenderer->makeWindowSnapshot(PWINDOW);
+    if (g_pHyprRenderer->shouldRenderWindow(PWINDOW))
+        g_pHyprRenderer->makeWindowSnapshot(PWINDOW);
 
     // swallowing
     if (valid(PWINDOW->m_swallowed)) {

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -2227,7 +2227,7 @@ void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, const CBox& box, f
 
     // amazing hack: the surface has an opaque region!
     CRegion inverseOpaque;
-    if (a >= 1.f && std::round(pSurface->m_current.size.x * m_renderData.pMonitor->m_scale) == box.w &&
+    if (a >= 1.f && pSurface && std::round(pSurface->m_current.size.x * m_renderData.pMonitor->m_scale) == box.w &&
         std::round(pSurface->m_current.size.y * m_renderData.pMonitor->m_scale) == box.h) {
         pixman_box32_t surfbox = {0, 0, pSurface->m_current.size.x * pSurface->m_current.scale, pSurface->m_current.size.y * pSurface->m_current.scale};
         inverseOpaque          = pSurface->m_current.opaque;

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -2243,19 +2243,14 @@ void CHyprOpenGLImpl::renderTextureWithBlur(SP<CTexture> tex, const CBox& box, f
     inverseOpaque.scale(m_renderData.pMonitor->m_scale);
 
     //   vvv TODO: layered blur fbs?
-    const bool USENEWOPTIMIZE =
-        shouldUseNewBlurOptimizations(m_renderData.currentLS.lock(), m_renderData.currentWindow.lock()) && !blockBlurOptimization && !m_renderData.overrideBlurSourceFB;
+    const bool    USENEWOPTIMIZE = shouldUseNewBlurOptimizations(m_renderData.currentLS.lock(), m_renderData.currentWindow.lock()) && !blockBlurOptimization;
 
     CFramebuffer* POUTFB = nullptr;
     if (!USENEWOPTIMIZE) {
         inverseOpaque.translate(box.pos());
         m_renderData.renderModif.applyToRegion(inverseOpaque);
         inverseOpaque.intersect(texDamage);
-
-        if (m_renderData.overrideBlurSourceFB)
-            POUTFB = blurFramebufferWithDamage(a, &inverseOpaque, *m_renderData.overrideBlurSourceFB);
-        else
-            POUTFB = blurMainFramebufferWithDamage(a, &inverseOpaque);
+        POUTFB = blurMainFramebufferWithDamage(a, &inverseOpaque);
     } else
         POUTFB = &m_renderData.pCurrentMonData->blurFB;
 

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -124,7 +124,6 @@ struct SCurrentRenderData {
     CFramebuffer*          currentFB            = nullptr; // current rendering to
     CFramebuffer*          mainFB               = nullptr; // main to render to
     CFramebuffer*          outFB                = nullptr; // out to render to (if offloaded, etc)
-    CFramebuffer*          overrideBlurSourceFB = nullptr;
 
     CRegion                damage;
     CRegion                finalDamage; // damage used for funal off -> main

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -120,10 +120,10 @@ struct SCurrentRenderData {
     Mat3x3        monitorProjection;
 
     // FIXME: raw pointer galore!
-    SMonitorRenderData*    pCurrentMonData      = nullptr;
-    CFramebuffer*          currentFB            = nullptr; // current rendering to
-    CFramebuffer*          mainFB               = nullptr; // main to render to
-    CFramebuffer*          outFB                = nullptr; // out to render to (if offloaded, etc)
+    SMonitorRenderData*    pCurrentMonData = nullptr;
+    CFramebuffer*          currentFB       = nullptr; // current rendering to
+    CFramebuffer*          mainFB          = nullptr; // main to render to
+    CFramebuffer*          outFB           = nullptr; // out to render to (if offloaded, etc)
 
     CRegion                damage;
     CRegion                finalDamage; // damage used for funal off -> main

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -114,15 +114,17 @@ struct SMonitorRenderData {
 };
 
 struct SCurrentRenderData {
-    PHLMONITORREF          pMonitor;
-    Mat3x3                 projection;
-    Mat3x3                 savedProjection;
-    Mat3x3                 monitorProjection;
+    PHLMONITORREF pMonitor;
+    Mat3x3        projection;
+    Mat3x3        savedProjection;
+    Mat3x3        monitorProjection;
 
-    SMonitorRenderData*    pCurrentMonData = nullptr;
-    CFramebuffer*          currentFB       = nullptr; // current rendering to
-    CFramebuffer*          mainFB          = nullptr; // main to render to
-    CFramebuffer*          outFB           = nullptr; // out to render to (if offloaded, etc)
+    // FIXME: raw pointer galore!
+    SMonitorRenderData*    pCurrentMonData      = nullptr;
+    CFramebuffer*          currentFB            = nullptr; // current rendering to
+    CFramebuffer*          mainFB               = nullptr; // main to render to
+    CFramebuffer*          outFB                = nullptr; // out to render to (if offloaded, etc)
+    CFramebuffer*          overrideBlurSourceFB = nullptr;
 
     CRegion                damage;
     CRegion                finalDamage; // damage used for funal off -> main
@@ -333,6 +335,7 @@ class CHyprOpenGLImpl {
 
     // returns the out FB, can be either Mirror or MirrorSwap
     CFramebuffer* blurMainFramebufferWithDamage(float a, CRegion* damage);
+    CFramebuffer* blurFramebufferWithDamage(float a, CRegion* damage, CFramebuffer& source);
 
     void          passCMUniforms(const SShader&, const NColorManagement::SImageDescription& imageDescription, const NColorManagement::SImageDescription& targetImageDescription,
                                  bool modifySDR = false);

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -37,12 +37,6 @@ enum eRenderMode : uint8_t {
     RENDER_MODE_TO_BUFFER_READ_ONLY = 3,
 };
 
-enum eRenderCallResult : uint8_t {
-    RENDER_CALL_OK = 0,
-    RENDER_CALL_FAILED,
-    RENDER_CALL_BREAK,
-};
-
 class CToplevelExportProtocolManager;
 class CInputManager;
 struct SSessionLockSurface;
@@ -129,13 +123,9 @@ class CHyprRenderer {
   private:
     void arrangeLayerArray(PHLMONITOR, const std::vector<PHLLSREF>&, bool, CBox*);
     void renderWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now, const CBox& geometry);
-    eRenderCallResult
-                      renderWorkspaceWindowsFullscreen(PHLMONITOR, PHLWORKSPACE, const Time::steady_tp&,
-                                                       const SRenderWorkspaceUntilData& until = {}); // renders workspace windows (fullscreen) (tiled, floating, pinned, but no special)
-    eRenderCallResult renderWorkspaceWindows(PHLMONITOR, PHLWORKSPACE, const Time::steady_tp&,
-                                             const SRenderWorkspaceUntilData& until = {}); // renders workspace windows (no fullscreen) (tiled, floating, pinned, but no special)
-    void renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now, const Vector2D& translate = {0, 0}, const float& scale = 1.f,
-                                      const SRenderWorkspaceUntilData& until = {});
+    void renderWorkspaceWindowsFullscreen(PHLMONITOR, PHLWORKSPACE, const Time::steady_tp&); // renders workspace windows (fullscreen) (tiled, floating, pinned, but no special)
+    void renderWorkspaceWindows(PHLMONITOR, PHLWORKSPACE, const Time::steady_tp&);           // renders workspace windows (no fullscreen) (tiled, floating, pinned, but no special)
+    void renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now, const Vector2D& translate = {0, 0}, const float& scale = 1.f);
     void renderWindow(PHLWINDOW, PHLMONITOR, const Time::steady_tp&, bool, eRenderPassMode, bool ignorePosition = false, bool standalone = false);
     void renderLayer(PHLLS, PHLMONITOR, const Time::steady_tp&, bool popups = false, bool lockscreen = false);
     void renderSessionLockSurface(WP<SSessionLockSurface>, PHLMONITOR, const Time::steady_tp&);

--- a/src/render/pass/TexPassElement.cpp
+++ b/src/render/pass/TexPassElement.cpp
@@ -11,10 +11,14 @@ CTexPassElement::CTexPassElement(const CTexPassElement::SRenderData& data_) : m_
 void CTexPassElement::draw(const CRegion& damage) {
     g_pHyprOpenGL->m_endFrame = m_data.flipEndFrame;
 
-    CScopeGuard x = {[]() {
+    CScopeGuard x = {[this]() {
         //
         g_pHyprOpenGL->m_endFrame           = false;
         g_pHyprOpenGL->m_renderData.clipBox = {};
+        if (m_data.replaceProjection)
+            g_pHyprOpenGL->m_renderData.monitorProjection = g_pHyprOpenGL->m_renderData.pMonitor->m_projMatrix;
+        if (m_data.ignoreAlpha.has_value())
+            g_pHyprOpenGL->m_renderData.discardMode = 0;
     }};
 
     if (!m_data.clipBox.empty())
@@ -22,9 +26,16 @@ void CTexPassElement::draw(const CRegion& damage) {
 
     if (m_data.replaceProjection)
         g_pHyprOpenGL->m_renderData.monitorProjection = *m_data.replaceProjection;
-    g_pHyprOpenGL->renderTextureInternalWithDamage(m_data.tex, m_data.box, m_data.a, m_data.damage.empty() ? damage : m_data.damage, m_data.round, m_data.roundingPower);
-    if (m_data.replaceProjection)
-        g_pHyprOpenGL->m_renderData.monitorProjection = g_pHyprOpenGL->m_renderData.pMonitor->m_projMatrix;
+
+    if (m_data.ignoreAlpha.has_value()) {
+        g_pHyprOpenGL->m_renderData.discardMode    = DISCARD_ALPHA;
+        g_pHyprOpenGL->m_renderData.discardOpacity = *m_data.ignoreAlpha;
+    }
+
+    if (m_data.blur)
+        g_pHyprOpenGL->renderTextureWithBlur(m_data.tex, m_data.box, m_data.a, nullptr, m_data.round, m_data.roundingPower, false, m_data.blurA, 1.F);
+    else
+        g_pHyprOpenGL->renderTextureInternalWithDamage(m_data.tex, m_data.box, m_data.a, m_data.damage.empty() ? damage : m_data.damage, m_data.round, m_data.roundingPower);
 }
 
 bool CTexPassElement::needsLiveBlur() {

--- a/src/render/pass/TexPassElement.hpp
+++ b/src/render/pass/TexPassElement.hpp
@@ -11,13 +11,16 @@ class CTexPassElement : public IPassElement {
     struct SRenderData {
         SP<CTexture>          tex;
         CBox                  box;
-        float                 a = 1.F;
+        float                 a     = 1.F;
+        float                 blurA = 1.F;
         CRegion               damage;
         int                   round         = 0;
         float                 roundingPower = 2.0f;
         bool                  flipEndFrame  = false;
         std::optional<Mat3x3> replaceProjection;
         CBox                  clipBox;
+        bool                  blur = false;
+        std::optional<float>  ignoreAlpha;
     };
 
     CTexPassElement(const SRenderData& data);


### PR DESCRIPTION
This MR makes it so that the blur of a window / ls is still there when fading out, instead of disappearing.

Needs testing.