### PR TITLE
permissions: add permission management for keyboards

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2900,6 +2900,8 @@ std::optional<std::string> CConfigManager::handlePermission(const std::string& c
         type = PERMISSION_TYPE_SCREENCOPY;
     else if (data[1] == "plugin")
         type = PERMISSION_TYPE_PLUGIN;
+    else if (data[1] == "keyboard" || data[1] == "keeb")
+        type = PERMISSION_TYPE_KEYBOARD;
 
     if (data[2] == "ask")
         mode = PERMISSION_RULE_ALLOW_MODE_ASK;

--- a/src/devices/IKeyboard.hpp
+++ b/src/devices/IKeyboard.hpp
@@ -78,6 +78,9 @@ class IKeyboard : public IHID {
     bool                    m_enabled    = true;
     bool                    m_allowBinds = true;
 
+    // permission flag: whether this keyboard is allowed to be processed
+    bool m_allowed = true;
+
     // if the keymap is overridden by the implementation,
     // don't try to set keyboard rules anymore, to avoid overwriting the requested one.
     // e.g. Virtual keyboards with custom maps.

--- a/src/managers/permissions/DynamicPermissionManager.hpp
+++ b/src/managers/permissions/DynamicPermissionManager.hpp
@@ -17,6 +17,7 @@ enum eDynamicPermissionType : uint8_t {
     PERMISSION_TYPE_UNKNOWN = 0,
     PERMISSION_TYPE_SCREENCOPY,
     PERMISSION_TYPE_PLUGIN,
+    PERMISSION_TYPE_KEYBOARD,
 };
 
 enum eDynamicPermissionRuleSource : uint8_t {


### PR DESCRIPTION
Adds permission management for keyboards.

By default, a fallback is that every keyboard is _allowed_.

To make a whitelist, you can:
```ini
permission = my_keyboard, keyboard, allow
permission = .*, keyboard, deny
```

Make sure the deny is last.

Fixes #10343