### PR TITLE
opengl: add missing vao for screenshader

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1262,6 +1262,7 @@ void CHyprOpenGLImpl::applyScreenShader(const std::string& path) {
     }
     m_finalScreenShader.texAttrib = glGetAttribLocation(m_finalScreenShader.program, "texcoord");
     m_finalScreenShader.posAttrib = glGetAttribLocation(m_finalScreenShader.program, "pos");
+    m_finalScreenShader.createVao();
 }
 
 void CHyprOpenGLImpl::clear(const CHyprColor& color) {


### PR DESCRIPTION
missed creating vertex array objects in 04124988e8b4a9cdfc5995388ebfaad0005b4b31 add it.

see https://github.com/hyprwm/Hyprland/discussions/10394

