### PR TITLE
input: disallow virtual keyboards from changing LED state

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1368,7 +1368,7 @@ void CInputManager::destroyTabletPad(SP<CTabletPad> pad) {
 }
 
 void CInputManager::updateKeyboardsLeds(SP<IKeyboard> pKeyboard) {
-    if (!pKeyboard)
+    if (!pKeyboard || pKeyboard->isVirtual())
         return;
 
     std::optional<uint32_t> leds = pKeyboard->getLEDs();


### PR DESCRIPTION
Virtual keyboards should not be allowed to update LED state.

Thanks @Kam1k4dze for finding, can you verify this works?

Fixes #10183