### PR TITLE
xwayland: do not include xcb.h when xwayland is disabled

### DIFF
--- a/src/xwayland/Dnd.hpp
+++ b/src/xwayland/Dnd.hpp
@@ -5,7 +5,9 @@
 #include "../managers/input/InputManager.hpp"
 #include <wayland-server-protocol.h>
 #include <hyprutils/os/FileDescriptor.hpp>
+#ifndef NO_XWAYLAND
 #include <xcb/xcb.h>
+#endif
 
 #define XDND_VERSION 5
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

[xwayland: do not include xcb.h when xwayland is disabled](https://github.com/YukariChiba/Hyprland/commit/2f50a5c2007bf528ee5bd03cd656c8508471677b)

xcb.h should not be included when xwayland is disabled. 
This allows hyprland to not use X11 libraries at all when xwayland is disabled.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

N

#### Is it ready for merging, or does it need work?

Y