### PR TITLE
core: drop the legacy renderer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,11 +99,7 @@ message(STATUS "Checking deps...")
 
 find_package(Threads REQUIRED)
 
-if(LEGACY_RENDERER)
-  set(GLES_VERSION "GLES2")
-else()
-  set(GLES_VERSION "GLES3")
-endif()
+set(GLES_VERSION "GLES3")
 find_package(OpenGL REQUIRED COMPONENTS ${GLES_VERSION})
 
 pkg_check_modules(aquamarine_dep REQUIRED IMPORTED_TARGET aquamarine>=0.8.0)
@@ -214,11 +210,6 @@ check_include_file("sys/inotify.h" HAS_INOTIFY)
 pkg_check_modules(inotify IMPORTED_TARGET libinotify)
 if(NOT HAS_INOTIFY AND inotify_FOUND)
   target_link_libraries(Hyprland PkgConfig::inotify)
-endif()
-
-if(LEGACY_RENDERER)
-  message(STATUS "Using the legacy GLES2 renderer!")
-  add_compile_definitions(LEGACY_RENDERER)
 endif()
 
 if(NO_XWAYLAND)

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,6 @@ PREFIX = /usr/local
 stub:
 	@echo "Do not run $(MAKE) directly without any arguments. Please refer to the wiki on how to compile Hyprland."
 
-legacyrenderer:
-	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX:STRING=${PREFIX} -DLEGACY_RENDERER:BOOL=true -S . -B ./build
-	cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
-
-legacyrendererdebug:
-	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Debug -DCMAKE_INSTALL_PREFIX:STRING=${PREFIX} -DLEGACY_RENDERER:BOOL=true -S . -B ./build
-	cmake --build ./build --config Debug --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
-
 release:
 	cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DCMAKE_INSTALL_PREFIX:STRING=${PREFIX} -S . -B ./build
 	cmake --build ./build --config Release --target all -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`

--- a/flake.nix
+++ b/flake.nix
@@ -132,7 +132,6 @@
         # hyprland-packages
         hyprland
         hyprland-debug
-        hyprland-legacy-renderer
         hyprland-unwrapped
         # hyprland-extras
         xdg-desktop-portal-hyprland

--- a/meson.build
+++ b/meson.build
@@ -77,10 +77,6 @@ if (systemd_option.enabled())
   subdir('systemd')
 endif
 
-if get_option('legacy_renderer').enabled()
-  add_project_arguments('-DLEGACY_RENDERER', language: 'cpp')
-endif
-
 if get_option('buildtype') == 'debug'
   add_project_arguments('-DHYPRLAND_DEBUG', language: 'cpp')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,6 +1,5 @@
 option('xwayland', type: 'feature', value: 'auto', description: 'Enable support for X11 applications')
 option('systemd', type: 'feature', value: 'auto', description: 'Enable systemd integration')
 option('uwsm', type: 'feature', value: 'enabled', description: 'Enable uwsm integration (only if systemd is enabled)')
-option('legacy_renderer', type: 'feature', value: 'disabled', description: 'Enable legacy renderer')
 option('hyprpm', type: 'feature', value: 'enabled', description: 'Enable hyprpm')
 option('tracy_enable', type: 'boolean', value: false , description: 'Enable profiling')

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -41,7 +41,6 @@
   xwayland,
   debug ? false,
   enableXWayland ? true,
-  legacyRenderer ? false,
   withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
   wrapRuntimeDeps ? true,
   version ? "git",
@@ -52,6 +51,7 @@
   enableNvidiaPatches ? false,
   nvidiaPatches ? false,
   hidpiXWayland ? false,
+  legacyRenderer ? false,
 }: let
   inherit (builtins) baseNameOf foldl' readFile;
   inherit (lib.asserts) assertMsg;
@@ -70,6 +70,7 @@ in
   assert assertMsg (!nvidiaPatches) "The option `nvidiaPatches` has been removed.";
   assert assertMsg (!enableNvidiaPatches) "The option `enableNvidiaPatches` has been removed.";
   assert assertMsg (!hidpiXWayland) "The option `hidpiXWayland` has been removed. Please refer https://wiki.hyprland.org/Configuring/XWayland";
+  assert assertMsg (!legacyRenderer) "The option `legacyRenderer` has been removed. Legacy renderer is no longer supported.";
     customStdenv.mkDerivation (finalAttrs: {
       pname = "hyprland${optionalString debug "-debug"}";
       inherit version;
@@ -142,7 +143,7 @@ in
           wayland-scanner
           xorg.libXcursor
         ]
-        (optionals customStdenv.hostPlatform.isBSD [ epoll-shim ])
+        (optionals customStdenv.hostPlatform.isBSD [epoll-shim])
         (optionals customStdenv.hostPlatform.isMusl [libexecinfo])
         (optionals enableXWayland [
           xorg.libxcb
@@ -165,7 +166,6 @@ in
       mesonFlags = flatten [
         (mapAttrsToList mesonEnable {
           "xwayland" = enableXWayland;
-          "legacy_renderer" = legacyRenderer;
           "systemd" = withSystemd;
           "uwsm" = false;
           "hyprpm" = false;

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -50,9 +50,15 @@ in {
         hyprutils = final.hyprutils.override {debug = true;};
         debug = true;
       };
-      hyprland-legacy-renderer = final.hyprland.override {legacyRenderer = true;};
 
       # deprecated packages
+      hyprland-legacy-renderer =
+        builtins.trace ''
+          hyprland-legacy-renderer was removed. Please use the hyprland package.
+          Legacy renderer is no longer supported.
+        ''
+        final.hyprland;
+
       hyprland-nvidia =
         builtins.trace ''
           hyprland-nvidia was removed. Please use the hyprland package.

--- a/src/debug/CrashReporter.cpp
+++ b/src/debug/CrashReporter.cpp
@@ -109,9 +109,6 @@ void NCrashReporter::createAndSaveCrash(int sig) {
     finalCrashReport += "\nDate: ";
     finalCrashReport += GIT_COMMIT_DATE;
     finalCrashReport += "\nFlags:\n";
-#ifdef LEGACY_RENDERER
-    finalCrashReport += "legacyrenderer\n";
-#endif
 #if ISDEBUG
     finalCrashReport += "debug\n";
 #endif

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -931,13 +931,10 @@ std::string versionRequest(eHyprCtlOutputFormat format, std::string request) {
                                          HYPRLAND_VERSION, GIT_BRANCH, GIT_COMMIT_HASH, GIT_DIRTY, commitMsg, GIT_COMMIT_DATE, GIT_TAG, GIT_COMMITS, AQUAMARINE_VERSION,
                                          HYPRLANG_VERSION, HYPRUTILS_VERSION, HYPRCURSOR_VERSION, HYPRGRAPHICS_VERSION);
 
-#if (!defined(LEGACY_RENDERER) && !ISDEBUG && !defined(NO_XWAYLAND))
+#if (!ISDEBUG && !defined(NO_XWAYLAND))
         result += "no flags were set\n";
 #else
         result += "flags set:\n";
-#ifdef LEGACY_RENDERER
-        result += "legacyrenderer\n";
-#endif
 #if ISDEBUG
         result += "debug\n";
 #endif
@@ -966,9 +963,6 @@ std::string versionRequest(eHyprCtlOutputFormat format, std::string request) {
             GIT_BRANCH, GIT_COMMIT_HASH, HYPRLAND_VERSION, (strcmp(GIT_DIRTY, "dirty") == 0 ? "true" : "false"), escapeJSONStrings(commitMsg), GIT_COMMIT_DATE, GIT_TAG,
             GIT_COMMITS, AQUAMARINE_VERSION, HYPRLANG_VERSION, HYPRUTILS_VERSION, HYPRCURSOR_VERSION, HYPRGRAPHICS_VERSION);
 
-#ifdef LEGACY_RENDERER
-        result += "\"legacyrenderer\",";
-#endif
 #if ISDEBUG
         result += "\"debug\",";
 #endif

--- a/src/debug/HyprDebugOverlay.cpp
+++ b/src/debug/HyprDebugOverlay.cpp
@@ -263,11 +263,8 @@ void CHyprDebugOverlay::draw() {
     glBindTexture(GL_TEXTURE_2D, m_texture->m_texID);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-
-#ifndef GLES2
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_BLUE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED);
-#endif
 
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, PMONITOR->m_pixelSize.x, PMONITOR->m_pixelSize.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, DATA);
 

--- a/src/debug/HyprNotificationOverlay.cpp
+++ b/src/debug/HyprNotificationOverlay.cpp
@@ -238,11 +238,8 @@ void CHyprNotificationOverlay::draw(PHLMONITOR pMonitor) {
     glBindTexture(GL_TEXTURE_2D, m_texture->m_texID);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-
-#ifndef GLES2
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_BLUE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED);
-#endif
 
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, MONSIZE.x, MONSIZE.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, DATA);
 

--- a/src/helpers/Format.cpp
+++ b/src/helpers/Format.cpp
@@ -14,26 +14,18 @@
 */
 inline const std::vector<SPixelFormat> GLES3_FORMATS = {
     {
-        .drmFormat = DRM_FORMAT_ARGB8888,
-        .flipRB    = true,
-#ifndef GLES2
-        .glFormat = GL_RGBA,
-#else
-        .glFormat = GL_BGRA_EXT,
-#endif
+        .drmFormat     = DRM_FORMAT_ARGB8888,
+        .flipRB        = true,
+        .glFormat      = GL_RGBA,
         .glType        = GL_UNSIGNED_BYTE,
         .withAlpha     = true,
         .alphaStripped = DRM_FORMAT_XRGB8888,
         .bytesPerBlock = 4,
     },
     {
-        .drmFormat = DRM_FORMAT_XRGB8888,
-        .flipRB    = true,
-#ifndef GLES2
-        .glFormat = GL_RGBA,
-#else
-        .glFormat = GL_BGRA_EXT,
-#endif
+        .drmFormat     = DRM_FORMAT_XRGB8888,
+        .flipRB        = true,
+        .glFormat      = GL_RGBA,
         .glType        = GL_UNSIGNED_BYTE,
         .withAlpha     = false,
         .alphaStripped = DRM_FORMAT_XRGB8888,
@@ -104,96 +96,64 @@ inline const std::vector<SPixelFormat> GLES3_FORMATS = {
         .bytesPerBlock = 2,
     },
     {
-        .drmFormat = DRM_FORMAT_XBGR2101010,
-        .glFormat  = GL_RGBA,
-#ifndef GLES2
-        .glType = GL_UNSIGNED_INT_2_10_10_10_REV,
-#else
-        .glType = GL_UNSIGNED_INT_2_10_10_10_REV_EXT,
-#endif
+        .drmFormat     = DRM_FORMAT_XBGR2101010,
+        .glFormat      = GL_RGBA,
+        .glType        = GL_UNSIGNED_INT_2_10_10_10_REV,
         .withAlpha     = false,
         .alphaStripped = DRM_FORMAT_XBGR2101010,
         .bytesPerBlock = 4,
     },
     {
-        .drmFormat = DRM_FORMAT_ABGR2101010,
-        .glFormat  = GL_RGBA,
-#ifndef GLES2
-        .glType = GL_UNSIGNED_INT_2_10_10_10_REV,
-#else
-        .glType = GL_UNSIGNED_INT_2_10_10_10_REV_EXT,
-#endif
+        .drmFormat     = DRM_FORMAT_ABGR2101010,
+        .glFormat      = GL_RGBA,
+        .glType        = GL_UNSIGNED_INT_2_10_10_10_REV,
         .withAlpha     = true,
         .alphaStripped = DRM_FORMAT_XBGR2101010,
         .bytesPerBlock = 4,
     },
     {
-        .drmFormat = DRM_FORMAT_XRGB2101010,
-        .glFormat  = GL_RGBA,
-#ifndef GLES2
-        .glType = GL_UNSIGNED_INT_2_10_10_10_REV,
-#else
-        .glType = GL_UNSIGNED_INT_2_10_10_10_REV_EXT,
-#endif
+        .drmFormat     = DRM_FORMAT_XRGB2101010,
+        .glFormat      = GL_RGBA,
+        .glType        = GL_UNSIGNED_INT_2_10_10_10_REV,
         .withAlpha     = false,
         .alphaStripped = DRM_FORMAT_XRGB2101010,
         .bytesPerBlock = 4,
     },
     {
-        .drmFormat = DRM_FORMAT_ARGB2101010,
-        .glFormat  = GL_RGBA,
-#ifndef GLES2
-        .glType = GL_UNSIGNED_INT_2_10_10_10_REV,
-#else
-        .glType = GL_UNSIGNED_INT_2_10_10_10_REV_EXT,
-#endif
+        .drmFormat     = DRM_FORMAT_ARGB2101010,
+        .glFormat      = GL_RGBA,
+        .glType        = GL_UNSIGNED_INT_2_10_10_10_REV,
         .withAlpha     = true,
         .alphaStripped = DRM_FORMAT_XRGB2101010,
         .bytesPerBlock = 4,
     },
     {
-        .drmFormat = DRM_FORMAT_XBGR16161616F,
-        .glFormat  = GL_RGBA,
-#ifndef GLES2
-        .glType = GL_HALF_FLOAT,
-#else
-        .glType = GL_HALF_FLOAT_OES,
-#endif
+        .drmFormat     = DRM_FORMAT_XBGR16161616F,
+        .glFormat      = GL_RGBA,
+        .glType        = GL_HALF_FLOAT,
         .withAlpha     = false,
         .alphaStripped = DRM_FORMAT_XBGR16161616F,
         .bytesPerBlock = 8,
     },
     {
-        .drmFormat = DRM_FORMAT_ABGR16161616F,
-        .glFormat  = GL_RGBA,
-#ifndef GLES2
-        .glType = GL_HALF_FLOAT,
-#else
-        .glType = GL_HALF_FLOAT_OES,
-#endif
+        .drmFormat     = DRM_FORMAT_ABGR16161616F,
+        .glFormat      = GL_RGBA,
+        .glType        = GL_HALF_FLOAT,
         .withAlpha     = true,
         .alphaStripped = DRM_FORMAT_XBGR16161616F,
         .bytesPerBlock = 8,
     },
     {
-        .drmFormat = DRM_FORMAT_XBGR16161616,
-#ifndef GLES2
-        .glFormat = GL_RGBA16UI,
-#else
-        .glFormat = GL_RGBA16_EXT,
-#endif
+        .drmFormat     = DRM_FORMAT_XBGR16161616,
+        .glFormat      = GL_RGBA16UI,
         .glType        = GL_UNSIGNED_SHORT,
         .withAlpha     = false,
         .alphaStripped = DRM_FORMAT_XBGR16161616,
         .bytesPerBlock = 8,
     },
     {
-        .drmFormat = DRM_FORMAT_ABGR16161616,
-#ifndef GLES2
-        .glFormat = GL_RGBA16UI,
-#else
-        .glFormat = GL_RGBA16_EXT,
-#endif
+        .drmFormat     = DRM_FORMAT_ABGR16161616,
+        .glFormat      = GL_RGBA16UI,
         .glType        = GL_UNSIGNED_SHORT,
         .withAlpha     = true,
         .alphaStripped = DRM_FORMAT_XBGR16161616,
@@ -290,12 +250,7 @@ uint32_t NFormatUtils::drmFormatToGL(DRMFormat drm) {
         case DRM_FORMAT_XRGB8888:
         case DRM_FORMAT_XBGR8888: return GL_RGBA; // doesn't matter, opengl is gucci in this case.
         case DRM_FORMAT_XRGB2101010:
-        case DRM_FORMAT_XBGR2101010:
-#ifdef GLES2
-            return GL_RGB10_A2_EXT;
-#else
-            return GL_RGB10_A2;
-#endif
+        case DRM_FORMAT_XBGR2101010: return GL_RGB10_A2;
         default: return GL_RGBA;
     }
     UNREACHABLE();
@@ -303,13 +258,7 @@ uint32_t NFormatUtils::drmFormatToGL(DRMFormat drm) {
 }
 
 uint32_t NFormatUtils::glFormatToType(uint32_t gl) {
-    return gl != GL_RGBA ?
-#ifdef GLES2
-        GL_UNSIGNED_INT_2_10_10_10_REV_EXT :
-#else
-        GL_UNSIGNED_INT_2_10_10_10_REV :
-#endif
-        GL_UNSIGNED_BYTE;
+    return gl != GL_RGBA ? GL_UNSIGNED_INT_2_10_10_10_REV : GL_UNSIGNED_BYTE;
 }
 
 std::string NFormatUtils::drmFormatName(DRMFormat drm) {

--- a/src/hyprerror/HyprError.cpp
+++ b/src/hyprerror/HyprError.cpp
@@ -146,11 +146,8 @@ void CHyprError::createQueued() {
     glBindTexture(GL_TEXTURE_2D, m_texture->m_texID);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-
-#ifndef GLES2
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_BLUE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED);
-#endif
 
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, PMONITOR->m_pixelSize.x, PMONITOR->m_pixelSize.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, DATA);
 

--- a/src/includes.hpp
+++ b/src/includes.hpp
@@ -17,15 +17,9 @@
 #include <unistd.h>
 #include <wayland-server-core.h>
 
-#ifdef LEGACY_RENDERER
-#include <GLES2/gl2.h>
-#include <GLES2/gl2ext.h>
-#define GLES2
-#else
 #define GLES32
 #include <GLES3/gl32.h>
 #include <GLES3/gl3ext.h>
-#endif
 
 #ifdef NO_XWAYLAND
 #define XWAYLAND false

--- a/src/protocols/Screencopy.cpp
+++ b/src/protocols/Screencopy.cpp
@@ -264,11 +264,7 @@ bool CScreencopyFrame::copyShm() {
         g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_screencopyDeniedTexture, texbox, 1);
     }
 
-#ifndef GLES2
     glBindFramebuffer(GL_READ_FRAMEBUFFER, fb.getFBID());
-#else
-    glBindFramebuffer(GL_FRAMEBUFFER, fb.getFBID());
-#endif
 
     const auto PFORMAT = NFormatUtils::getPixelFormatFromDRM(shm.format);
     if (!PFORMAT) {
@@ -304,11 +300,7 @@ bool CScreencopyFrame::copyShm() {
 
     g_pHyprOpenGL->m_renderData.pMonitor.reset();
 
-#ifndef GLES2
     glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
-#else
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-#endif
 
     LOGM(TRACE, "Copied frame via shm");
 

--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -281,10 +281,7 @@ bool CToplevelExportFrame::copyShm(const Time::steady_tp& now) {
     g_pHyprOpenGL->m_renderData.pMonitor = PMONITOR;
     outFB.bind();
 
-#ifndef GLES2
     glBindFramebuffer(GL_READ_FRAMEBUFFER, outFB.getFBID());
-#endif
-
     glPixelStorei(GL_PACK_ALIGNMENT, 1);
 
     auto glFormat = PFORMAT->flipRB ? GL_BGRA_EXT : GL_RGBA;
@@ -318,10 +315,7 @@ bool CToplevelExportFrame::copyShm(const Time::steady_tp& now) {
     }
 
     outFB.unbind();
-
-#ifndef GLES2
     glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
-#endif
 
     return true;
 }

--- a/src/render/Framebuffer.cpp
+++ b/src/render/Framebuffer.cpp
@@ -40,14 +40,11 @@ bool CFramebuffer::alloc(int w, int h, uint32_t drmFormat) {
         glBindFramebuffer(GL_FRAMEBUFFER, m_fb);
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_tex->m_texID, 0);
 
-// TODO: Allow this with gles2
-#ifndef GLES2
         if (m_stencilTex) {
             glBindTexture(GL_TEXTURE_2D, m_stencilTex->m_texID);
             glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH24_STENCIL8, w, h, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, nullptr);
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, m_stencilTex->m_texID, 0);
         }
-#endif
 
         auto status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
         RASSERT((status == GL_FRAMEBUFFER_COMPLETE), "Framebuffer incomplete, couldn't create! (FB status: {}, GL Error: 0x{:x})", status, (int)glGetError());
@@ -64,8 +61,6 @@ bool CFramebuffer::alloc(int w, int h, uint32_t drmFormat) {
 }
 
 void CFramebuffer::addStencil(SP<CTexture> tex) {
-    // TODO: Allow this with gles2
-#ifndef GLES2
     m_stencilTex = tex;
     glBindTexture(GL_TEXTURE_2D, m_stencilTex->m_texID);
     glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH24_STENCIL8, m_size.x, m_size.y, 0, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, nullptr);
@@ -79,15 +74,10 @@ void CFramebuffer::addStencil(SP<CTexture> tex) {
 
     glBindTexture(GL_TEXTURE_2D, 0);
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
-#endif
 }
 
 void CFramebuffer::bind() {
-#ifndef GLES2
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_fb);
-#else
-    glBindFramebuffer(GL_FRAMEBUFFER, m_iFb);
-#endif
 
     if (g_pHyprOpenGL)
         glViewport(0, 0, g_pHyprOpenGL->m_renderData.pMonitor->m_pixelSize.x, g_pHyprOpenGL->m_renderData.pMonitor->m_pixelSize.y);
@@ -96,11 +86,7 @@ void CFramebuffer::bind() {
 }
 
 void CFramebuffer::unbind() {
-#ifndef GLES2
     glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
-#else
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-#endif
 }
 
 void CFramebuffer::release() {

--- a/src/render/Texture.cpp
+++ b/src/render/Texture.cpp
@@ -72,12 +72,12 @@ void CTexture::createFromShm(uint32_t drmFormat, uint8_t* pixels, uint32_t strid
     GLCALL(glBindTexture(GL_TEXTURE_2D, m_texID));
     GLCALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
     GLCALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
-#ifndef GLES2
+
     if (format->flipRB) {
         GLCALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_BLUE));
         GLCALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED));
     }
-#endif
+
     GLCALL(glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, stride / format->bytesPerBlock));
     GLCALL(glTexImage2D(GL_TEXTURE_2D, 0, format->glInternalFormat ? format->glInternalFormat : format->glFormat, size_.x, size_.y, 0, format->glFormat, format->glType, pixels));
     GLCALL(glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, 0));
@@ -120,12 +120,10 @@ void CTexture::update(uint32_t drmFormat, uint8_t* pixels, uint32_t stride, cons
 
     auto rects = damage.copy().intersect(CBox{{}, m_size}).getRects();
 
-#ifndef GLES2
     if (format->flipRB) {
         GLCALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_BLUE));
         GLCALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED));
     }
-#endif
 
     for (auto const& rect : rects) {
         GLCALL(glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, stride / format->bytesPerBlock));

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -332,11 +332,8 @@ static void renderGradientTo(SP<CTexture> tex, CGradientValueData* grad) {
     glBindTexture(GL_TEXTURE_2D, tex->m_texID);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-
-#ifndef GLES2
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_BLUE);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED);
-#endif
 
     glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, bufferSize.x, bufferSize.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, DATA);
 


### PR DESCRIPTION
the legacy renderer is broken and barely used, drop it. even asahi has 3.x support nowadays.
then we can also focus more on the new fancy gles3 features. that actually improves performance

