### PR TITLE
input: ensure seat grabs from exclusive layers can be dismissed

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -607,6 +607,12 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse) {
             foundSurface = nullptr;
     }
 
+    // Releases any seat grabs after a click outside of them not handled by an earlier case (notably exclusive layers).
+    if ((m_hardInput || refocus) && g_pSeatManager->m_seatGrab && !foundSurface) {
+        g_pSeatManager->setGrab(nullptr);
+        return; // setGrab will refocus
+    }
+
     g_pSeatManager->setPointerFocus(foundSurface, surfaceLocal);
     g_pSeatManager->sendPointerMotion(time, surfaceLocal);
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Exclusive layers currently can't receive seat grab clears. This fixes that.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This is tested and works, but there might be a better way to handle it.

#### Is it ready for merging, or does it need work?
Based on https://github.com/hyprwm/Hyprland/pull/10416, which should be merged first. Otherwise ready.

