### PR TITLE
protocols: simulate mouse movement after activating a toplevel

### DIFF
--- a/src/protocols/ForeignToplevelWlr.cpp
+++ b/src/protocols/ForeignToplevelWlr.cpp
@@ -1,6 +1,7 @@
 #include "ForeignToplevelWlr.hpp"
 #include <algorithm>
 #include "../Compositor.hpp"
+#include "managers/input/InputManager.hpp"
 #include "protocols/core/Output.hpp"
 #include "render/Renderer.hpp"
 #include "../managers/HookSystemManager.hpp"
@@ -24,6 +25,7 @@ CForeignToplevelHandleWlr::CForeignToplevelHandleWlr(SP<CZwlrForeignToplevelHand
         // these requests bypass the config'd stuff cuz it's usually like
         // window switchers and shit
         PWINDOW->activate(true);
+        g_pInputManager->simulateMouseMovement();
     });
 
     m_resource->setSetFullscreen([this](CZwlrForeignToplevelHandleV1* p, wl_resource* output) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds a simulateMouseMovement after activating a toplevel via the wlr foreign toplevel protocol. Prior to this change, pointer focus would remain wherever it was before until mouse move.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Maybe this should just be part of activate()?

#### Is it ready for merging, or does it need work?
Ready to merge.

