### PR TITLE
hyprpm: fix execute permission bit on installed dirs

### DIFF
--- a/hyprpm/src/core/PluginManager.cpp
+++ b/hyprpm/src/core/PluginManager.cpp
@@ -566,7 +566,7 @@ bool CPluginManager::updateHeaders(bool force) {
 
     ret = execAndGet(cmd);
 
-    cmd = std::format("make -C '{}' installheaders && chmod -R 644 '{}' && find '{}' -type d -exec chmod o+x {{}} \\;", WORKINGDIR, DataState::getHeadersPath(),
+    cmd = std::format("make -C '{}' installheaders && chmod -R 644 '{}' && find '{}' -type d -exec chmod a+x {{}} \\;", WORKINGDIR, DataState::getHeadersPath(),
                       DataState::getHeadersPath());
 
     if (m_bVerbose)


### PR DESCRIPTION
`o+x` does only others while we want `a+x`. See https://github.com/hyprwm/Hyprland/discussions/10256