### PR TITLE
added error log when getEdgeDefinedPoint is impossible

### DIFF
--- a/src/render/decorations/DecorationPositioner.cpp
+++ b/src/render/decorations/DecorationPositioner.cpp
@@ -42,7 +42,6 @@ Vector2D CDecorationPositioner::getEdgeDefinedPoint(uint32_t edges, PHLWINDOW pW
             return wb.pos() + Vector2D{0.0, wb.size().y / 2.0};
         else if (RIGHT)
             return wb.pos() + Vector2D{wb.size().x, wb.size().y / 2.0};
-        UNREACHABLE();
     } else {
         if (TOP && LEFT)
             return wb.pos();
@@ -52,9 +51,8 @@ Vector2D CDecorationPositioner::getEdgeDefinedPoint(uint32_t edges, PHLWINDOW pW
             return wb.pos() + wb.size();
         if (BOTTOM && LEFT)
             return wb.pos() + Vector2D{0.0, wb.size().y};
-        UNREACHABLE();
     }
-    UNREACHABLE();
+    Debug::log(ERR, "getEdgeDefinedPoint: invalid configuration of edges");
     return {};
 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Added a log message when the decoration configuration is unsupported.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Having a log message like this may have saved me hours of trying to figure out why my plugin wasn't working.

#### Is it ready for merging, or does it need work?

It's ready to merge.
