### PR TITLE
unhide cursor on tablet events after touch events

### DIFF
--- a/src/managers/input/Tablets.cpp
+++ b/src/managers/input/Tablets.cpp
@@ -134,6 +134,7 @@ void CInputManager::onTabletAxis(CTablet::SAxisEvent e) {
             }
         }
 
+        m_lastInputTouch = false;
         simulateMouseMovement();
         refocusTablet(PTAB, PTOOL, true);
         m_lastCursorMovement.reset();


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Currently, after using a touch screen, using a graphics tablet doesn't re-show the cursor if it was hidden by the touch. This fixes that.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Tested against 0.48.1 but should still work.

#### Is it ready for merging, or does it need work?

Ready for merge