### PR TITLE
added wrapping options to renderTexture method

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1409,10 +1409,11 @@ void CHyprOpenGLImpl::renderRectWithDamage(const CBox& box, const CHyprColor& co
     scissor(nullptr);
 }
 
-void CHyprOpenGLImpl::renderTexture(SP<CTexture> tex, const CBox& box, float alpha, int round, float roundingPower, bool discardActive, bool allowCustomUV) {
+void CHyprOpenGLImpl::renderTexture(SP<CTexture> tex, const CBox& box, float alpha, int round, float roundingPower, bool discardActive, bool allowCustomUV, GLenum wrapX,
+                                    GLenum wrapY) {
     RASSERT(m_renderData.pMonitor, "Tried to render texture without begin()!");
 
-    renderTextureInternalWithDamage(tex, box, alpha, m_renderData.damage, round, roundingPower, discardActive, false, allowCustomUV, true);
+    renderTextureInternalWithDamage(tex, box, alpha, m_renderData.damage, round, roundingPower, discardActive, false, allowCustomUV, true, wrapX, wrapY);
 
     scissor(nullptr);
 }
@@ -1477,7 +1478,7 @@ void CHyprOpenGLImpl::passCMUniforms(const SShader& shader, const SImageDescript
 }
 
 void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, const CBox& box, float alpha, const CRegion& damage, int round, float roundingPower, bool discardActive,
-                                                      bool noAA, bool allowCustomUV, bool allowDim) {
+                                                      bool noAA, bool allowCustomUV, bool allowDim, GLenum wrapX, GLenum wrapY) {
     RASSERT(m_renderData.pMonitor, "Tried to render texture without begin()!");
     RASSERT((tex->m_texID > 0), "Attempted to draw nullptr texture!");
 
@@ -1541,8 +1542,8 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, const CB
     glActiveTexture(GL_TEXTURE0);
     glBindTexture(tex->m_target, tex->m_texID);
 
-    glTexParameteri(tex->m_target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(tex->m_target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(tex->m_target, GL_TEXTURE_WRAP_S, wrapX);
+    glTexParameteri(tex->m_target, GL_TEXTURE_WRAP_T, wrapY);
 
     if (m_renderData.useNearestNeighbor) {
         glTexParameteri(tex->m_target, GL_TEXTURE_MAG_FILTER, GL_NEAREST);

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -183,7 +183,8 @@ class CHyprOpenGLImpl {
     void renderRect(const CBox&, const CHyprColor&, int round = 0, float roundingPower = 2.0f);
     void renderRectWithBlur(const CBox&, const CHyprColor&, int round = 0, float roundingPower = 2.0f, float blurA = 1.f, bool xray = false);
     void renderRectWithDamage(const CBox&, const CHyprColor&, const CRegion& damage, int round = 0, float roundingPower = 2.0f);
-    void renderTexture(SP<CTexture>, const CBox&, float a, int round = 0, float roundingPower = 2.0f, bool discardActive = false, bool allowCustomUV = false);
+    void renderTexture(SP<CTexture>, const CBox&, float a, int round = 0, float roundingPower = 2.0f, bool discardActive = false, bool allowCustomUV = false,
+                       GLenum wrapX = GL_CLAMP_TO_EDGE, GLenum wrapY = GL_CLAMP_TO_EDGE);
     void renderTextureWithDamage(SP<CTexture>, const CBox&, const CRegion& damage, float a, int round = 0, float roundingPower = 2.0f, bool discardActive = false,
                                  bool allowCustomUV = false);
     void renderTextureWithBlur(SP<CTexture>, const CBox&, float a, SP<CWLSurfaceResource> pSurface, int round = 0, float roundingPower = 2.0f, bool blockBlurOptimization = false,
@@ -344,7 +345,7 @@ class CHyprOpenGLImpl {
                                  bool modifySDR = false);
     void          passCMUniforms(const SShader&, const NColorManagement::SImageDescription& imageDescription);
     void renderTextureInternalWithDamage(SP<CTexture>, const CBox& box, float a, const CRegion& damage, int round = 0, float roundingPower = 2.0f, bool discardOpaque = false,
-                                         bool noAA = false, bool allowCustomUV = false, bool allowDim = false);
+                                         bool noAA = false, bool allowCustomUV = false, bool allowDim = false, GLenum wrapX = GL_CLAMP_TO_EDGE, GLenum wrapY = GL_CLAMP_TO_EDGE);
     void renderTexturePrimitive(SP<CTexture> tex, const CBox& box);
     void renderSplash(cairo_t* const, cairo_surface_t* const, double offset, const Vector2D& size);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Adds wrapping options to the `renderTexture` method.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Shouldn't break compatibility.

#### Is it ready for merging, or does it need work?

I'll add similar params to the other renderTexture-related methods if you want. I don't think I'll be needing them just now though.