### PR TITLE
hyprpm: ignore pins when adding a package with a git rev

### DIFF
--- a/hyprpm/src/core/PluginManager.cpp
+++ b/hyprpm/src/core/PluginManager.cpp
@@ -256,7 +256,7 @@ bool CPluginManager::addNewPluginRepo(const std::string& url, const std::string&
         progress.printMessageAbove(message);
     }
 
-    if (!pManifest->m_repository.commitPins.empty()) {
+    if (rev.empty() && !pManifest->m_repository.commitPins.empty()) {
         // check commit pins
 
         progress.printMessageAbove(infoString("Manifest has {} pins, checking", pManifest->m_repository.commitPins.size()));


### PR DESCRIPTION
fixes #10436

#### Describe your PR, what does it fix/add?
makes `hyprpm add` do what it claims in the help section. This is already handled correctly in `hyprpm update`, but seems to have been missed here.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
It will always be Hyp**E**rland in my heart.

#### Is it ready for merging, or does it need work?
ready
