### PR TITLE
cursor: fix screencopy cursor pos and duplicate shape with sw cursors

### DIFF
--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -603,6 +603,11 @@ void CPointerManager::renderSoftwareCursorsFor(PHLMONITOR pMonitor, const Time::
         return;
     }
 
+    // don't render cursor if forced but we are already using sw cursors for the monitor
+    // otherwise we draw the cursor again for screencopy when using sw cursors
+    if (forceRender && (state->hardwareFailed || state->softwareLocks != 0))
+        return;
+
     auto box = state->box.copy();
     if (overridePos.has_value()) {
         box.x = overridePos->x;

--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -607,6 +607,8 @@ void CPointerManager::renderSoftwareCursorsFor(PHLMONITOR pMonitor, const Time::
     if (overridePos.has_value()) {
         box.x = overridePos->x;
         box.y = overridePos->y;
+
+        box.translate(-m_currentCursorImage.hotspot);
     }
 
     if (box.intersection(CBox{{}, {pMonitor->m_size}}).empty())


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
The implementation of showing the cursor screencopy for hardware cursors, https://github.com/hyprwm/Hyprland/commit/c505eb55ff967f2a0474e88a50803412ba550a61, does actually not account for the shape hotspot. So the position of the cursor was ever so slightly off in these cases on the screencopy.

When the user was using sw cursors, they would also see the shape rendered twice, as the sw cursor shape would be at the right position, but the composited shape for screencopy would be above it and slightly off. See for example https://github.com/hyprwm/Hyprland/pull/10356#issuecomment-2870226923. This mainly is a problem for my plugin, because I force sw cursors on nvidia (kinda need the gpu for the transforms, don't wanna do that on the cpu), so you'd see that double shape on screencap on nvidia. Otherwise nobody really uses sw cursors anymore I think.

So as a fix, I have done the following:
- account for the hotspot position when using `overridePos` for sw cursor rendering. Otherwise it is already accounted for when using the monitor state's box. I think that we want to handle that in the pointer manager so a caller of the method doesn't have to worry about it.
- also skip the rendering if `forceRender` is true but we are using software cursors anyways. This way the shape isn't drawn twice anymore to save a tiny bit on performance. 


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
The name `forceRender` is no longer entirely accurate with this MR so we might wanna change that, but so far we only use it in screencopy, so it doesn't really matter.

#### Is it ready for merging, or does it need work?
yes

