### PR TITLE
core: add auto-center arrangements

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2890,6 +2890,30 @@ void CCompositor::arrangeMonitors() {
             case eAutoDirs::DIR_AUTO_LEFT: newPosition.x = maxXOffsetLeft - m->m_size.x; break;
             case eAutoDirs::DIR_AUTO_RIGHT:
             case eAutoDirs::DIR_AUTO_NONE: newPosition.x = maxXOffsetRight; break;
+            case eAutoDirs::DIR_AUTO_CENTER_UP: {
+                int width     = maxXOffsetRight - maxXOffsetLeft;
+                newPosition.y = maxYOffsetUp - m->m_size.y;
+                newPosition.x = maxXOffsetLeft + (width - m->m_size.x) / 2;
+                break;
+            }
+            case eAutoDirs::DIR_AUTO_CENTER_DOWN: {
+                int width     = maxXOffsetRight - maxXOffsetLeft;
+                newPosition.y = maxYOffsetDown;
+                newPosition.x = maxXOffsetLeft + (width - m->m_size.x) / 2;
+                break;
+            }
+            case eAutoDirs::DIR_AUTO_CENTER_LEFT: {
+                int height    = maxYOffsetDown - maxYOffsetUp;
+                newPosition.x = maxXOffsetLeft - m->m_size.x;
+                newPosition.y = maxYOffsetUp + (height - m->m_size.y) / 2;
+                break;
+            }
+            case eAutoDirs::DIR_AUTO_CENTER_RIGHT: {
+                int height    = maxYOffsetDown - maxYOffsetUp;
+                newPosition.x = maxXOffsetRight;
+                newPosition.y = maxYOffsetUp + (height - m->m_size.y) / 2;
+                break;
+            }
             default: UNREACHABLE();
         }
         Debug::log(LOG, "arrangeMonitors: {} auto {:j}", m->m_name, m->m_position);

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2046,10 +2046,20 @@ std::optional<std::string> CConfigManager::handleMonitor(const std::string& comm
             newrule.autoDir = eAutoDirs::DIR_AUTO_UP;
         else if (ARGS[2] == "auto-down")
             newrule.autoDir = eAutoDirs::DIR_AUTO_DOWN;
+        else if (ARGS[2] == "auto-center-right")
+            newrule.autoDir = eAutoDirs::DIR_AUTO_CENTER_RIGHT;
+        else if (ARGS[2] == "auto-center-left")
+            newrule.autoDir = eAutoDirs::DIR_AUTO_CENTER_LEFT;
+        else if (ARGS[2] == "auto-center-up")
+            newrule.autoDir = eAutoDirs::DIR_AUTO_CENTER_UP;
+        else if (ARGS[2] == "auto-center-down")
+            newrule.autoDir = eAutoDirs::DIR_AUTO_CENTER_DOWN;
         else {
             Debug::log(WARN,
                        "Invalid auto direction. Valid options are 'auto',"
-                       "'auto-up', 'auto-down', 'auto-left', and 'auto-right'.");
+                       "'auto-up', 'auto-down', 'auto-left', 'auto-right',"
+                       "'auto-center-up', 'auto-center-down',"
+                       "'auto-center-left', and 'auto-center-right'.");
             error += "invalid auto direction ";
         }
     } else {

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -25,7 +25,11 @@ enum eAutoDirs : uint8_t {
     DIR_AUTO_UP,
     DIR_AUTO_DOWN,
     DIR_AUTO_LEFT,
-    DIR_AUTO_RIGHT
+    DIR_AUTO_RIGHT,
+    DIR_AUTO_CENTER_UP,
+    DIR_AUTO_CENTER_DOWN,
+    DIR_AUTO_CENTER_LEFT,
+    DIR_AUTO_CENTER_RIGHT
 };
 
 enum eCMType : uint8_t {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Introduces four new "center" auto-alignment modes: `auto-center-up`, `auto-center-down`, `auto-center-left`, `auto-center-right`. These position monitors relative to the monitor's center instead of the top left edge.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No breaking changes, manual testing on a multi‐monitor setup confirms center alignments behave as expected.

#### Is it ready for merging, or does it need work?

Ready for merge, as far as I know.
