### PR TITLE
core: add maxwidth resolution mode

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2013,6 +2013,8 @@ std::optional<std::string> CConfigManager::handleMonitor(const std::string& comm
         newrule.resolution = Vector2D(-1, -1);
     } else if (ARGS[1].starts_with("highres")) {
         newrule.resolution = Vector2D(-1, -2);
+    } else if (ARGS[1].starts_with("maxwidth")) {
+        newrule.resolution = Vector2D(-1, -3);
     } else if (parseModeLine(ARGS[1], newrule.drmMode)) {
         newrule.resolution  = Vector2D(newrule.drmMode.hdisplay, newrule.drmMode.vdisplay);
         newrule.refreshRate = float(newrule.drmMode.vrefresh) / 1000;

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -515,12 +515,23 @@ bool CMonitor::applyMonitorRule(SMonitorRule* pMonitorRule, bool force) {
     } else if (RULE->resolution == Vector2D(-1, -2)) {
         requestedStr = "highres";
 
-        // sort prioritizing resultion 1st and refresh rate 2nd, then add best 3
+        // sort prioritizing resolution 1st and refresh rate 2nd, then add best 3
         addBest3Modes([](auto const& a, auto const& b) {
             if (a->pixelSize.x > b->pixelSize.x && a->pixelSize.y > b->pixelSize.y)
                 return true;
             else if (DELTALESSTHAN(a->pixelSize.x, b->pixelSize.x, 1) && DELTALESSTHAN(a->pixelSize.y, b->pixelSize.y, 1) &&
                      std::round(a->refreshRate) > std::round(b->refreshRate))
+                return true;
+            return false;
+        });
+    } else if (RULE->resolution == Vector2D(-1, -3)) {
+        requestedStr = "maxwidth";
+
+        // sort prioritizing widest resolution 1st and refresh rate 2nd, then add best 3
+        addBest3Modes([](auto const& a, auto const& b) {
+            if (a->pixelSize.x > b->pixelSize.x)
+                return true;
+            if (a->pixelSize.x == b->pixelSize.x && std::round(a->refreshRate) > std::round(b->refreshRate))
                 return true;
             return false;
         });


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Adds a new `maxwidth` monitor rule that picks the top display modes sorted by widest horizontal resolution first (breaking ties by refresh rate). Ideal for super-ultrawide setups where a higher pixel‐count mode (e.g. 3840×2160) would otherwise overshadow the native ultrawide.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No breaking changes, everything else behaves as before. Manual testing on a multi‐monitor setup confirms desired behavior.

#### Is it ready for merging, or does it need work?

Ready for merge, as far as I know.
