### PR TITLE
config: add group: selector

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1403,10 +1403,10 @@ std::vector<SP<CWindowRule>> CConfigManager::getMatchingRules(PHLWINDOW pWindow,
                         continue;
                 }
 
-				if (rule->m_group != -1) {
-					if (rule->m_group != isGrouped)
-						continue;
-				}
+                if (rule->m_group != -1) {
+                    if (rule->m_group != isGrouped)
+                        continue;
+                }
 
                 if (!rule->m_fullscreenState.empty()) {
                     const auto ARGS = CVarList(rule->m_fullscreenState, 2, ' ');
@@ -2450,7 +2450,7 @@ std::optional<std::string> CConfigManager::handleWindowRule(const std::string& c
     const auto ONWORKSPACEPOS     = VALUE.find("onworkspace:");
     const auto CONTENTTYPEPOS     = VALUE.find("content:");
     const auto XDGTAGPOS          = VALUE.find("xdgTag:");
-	const auto GROUPPOS = VALUE.find("group:");
+    const auto GROUPPOS           = VALUE.find("group:");
 
     // find workspacepos that isn't onworkspacepos
     size_t WORKSPACEPOS = std::string::npos;
@@ -2463,7 +2463,7 @@ std::optional<std::string> CConfigManager::handleWindowRule(const std::string& c
         currentPos = VALUE.find("workspace:", currentPos + 1);
     }
 
-    const auto checkPos = std::unordered_set{TAGPOS,    TITLEPOS,           CLASSPOS,     INITIALTITLEPOS, INITIALCLASSPOS, X11POS,         FLOATPOS, FULLSCREENPOS,
+    const auto checkPos = std::unordered_set{TAGPOS,    TITLEPOS,           CLASSPOS,     INITIALTITLEPOS, INITIALCLASSPOS, X11POS,         FLOATPOS,  FULLSCREENPOS,
                                              PINNEDPOS, FULLSCREENSTATEPOS, WORKSPACEPOS, FOCUSPOS,        ONWORKSPACEPOS,  CONTENTTYPEPOS, XDGTAGPOS, GROUPPOS};
     if (checkPos.size() == 1 && checkPos.contains(std::string::npos)) {
         Debug::log(ERR, "Invalid rulev2 syntax: {}", VALUE);
@@ -2507,7 +2507,6 @@ std::optional<std::string> CConfigManager::handleWindowRule(const std::string& c
             min = XDGTAGPOS;
         if (GROUPPOS > pos && GROUPPOS < min)
             min = GROUPPOS;
-
 
         result = result.substr(0, min - pos);
 
@@ -2622,8 +2621,8 @@ std::optional<std::string> CConfigManager::handleWindowRule(const std::string& c
                 if (!rule->m_contentType.empty() && rule->m_contentType != other->m_contentType)
                     return false;
 
-				if (rule->m_group != -1 && rule->m_group != other->m_group)
-					return false;
+                if (rule->m_group != -1 && rule->m_group != other->m_group)
+                    return false;
 
                 return true;
             }

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1354,7 +1354,7 @@ std::vector<SP<CWindowRule>> CConfigManager::getMatchingRules(PHLWINDOW pWindow,
     // since some rules will be applied later, we need to store some flags
     bool hasFloating   = pWindow->m_isFloating;
     bool hasFullscreen = pWindow->isFullscreen();
-    bool isGrouped     = pWindow->m_groupData.pNextWindow.lock() != nullptr;
+    bool isGrouped     = pWindow->m_groupData.pNextWindow;
 
     // local tags for dynamic tag rule match
     auto tags = pWindow->m_tags;

--- a/src/desktop/WindowRule.hpp
+++ b/src/desktop/WindowRule.hpp
@@ -58,6 +58,7 @@ class CWindowRule {
     int               m_fullscreen      = -1;
     int               m_pinned          = -1;
     int               m_focus           = -1;
+	int               m_group           = -1; 
     std::string       m_fullscreenState = ""; // empty means any
     std::string       m_onWorkspace     = ""; // empty means any
     std::string       m_workspace       = ""; // empty means any

--- a/src/desktop/WindowRule.hpp
+++ b/src/desktop/WindowRule.hpp
@@ -58,7 +58,7 @@ class CWindowRule {
     int               m_fullscreen      = -1;
     int               m_pinned          = -1;
     int               m_focus           = -1;
-	int               m_group           = -1; 
+    int               m_group           = -1;
     std::string       m_fullscreenState = ""; // empty means any
     std::string       m_onWorkspace     = ""; // empty means any
     std::string       m_workspace       = ""; // empty means any


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Implements the group: selector described in #10489. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Seems functional with the following lines in config. Can test further if needed, but I don't use groups so don't know what people want. 

```
windowrulev2 = bordercolor rgba(000000FF) rgba(FF69B4FF),group:1
windowrulev2 = bordersize 200, group:1
windowrulev2 = opacity 0.4, group:1
windowrulev2 = bordersize 20, group:0
```

I'm new here, so didn't go ahead with deprecating previously variables. As a result, the color used by previous group: variables is still shown for several frames when windows are added to group. Would want guidance for what needs to be changed in the compositor to handle this case and allow removal.

#### Is it ready for merging, or does it need work?

See above, and eventual wiki update. 