### PR TITLE
Revert "refactor: use std::ranges whenever possible"

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1724,13 +1724,13 @@ static PHLWINDOW getWeakWindowPred(Iterator cur, Iterator end, Iterator begin, c
 PHLWINDOW CCompositor::getWindowCycleHist(PHLWINDOWREF cur, bool focusableOnly, std::optional<bool> floating, bool visible, bool next) {
     const auto FINDER = [&](const PHLWINDOWREF& w) { return isWindowAvailableForCycle(cur, w, focusableOnly, floating, visible); };
     // also m_vWindowFocusHistory has reverse order, so when it is next - we need to reverse again
-    return next ? getWeakWindowPred(std::ranges::find(m_windowFocusHistory | std::views::reverse, cur), m_windowFocusHistory.rend(), m_windowFocusHistory.rbegin(), FINDER) :
+    return next ? getWeakWindowPred(std::ranges::find(std::ranges::reverse_view(m_windowFocusHistory), cur), m_windowFocusHistory.rend(), m_windowFocusHistory.rbegin(), FINDER) :
                   getWeakWindowPred(std::ranges::find(m_windowFocusHistory, cur), m_windowFocusHistory.end(), m_windowFocusHistory.begin(), FINDER);
 }
 
 PHLWINDOW CCompositor::getWindowCycle(PHLWINDOW cur, bool focusableOnly, std::optional<bool> floating, bool visible, bool prev) {
     const auto FINDER = [&](const PHLWINDOW& w) { return isWindowAvailableForCycle(cur, w, focusableOnly, floating, visible); };
-    return prev ? getWindowPred(std::ranges::find(m_windows | std::views::reverse, cur), m_windows.rend(), m_windows.rbegin(), FINDER) :
+    return prev ? getWindowPred(std::ranges::find(std::ranges::reverse_view(m_windows), cur), m_windows.rend(), m_windows.rbegin(), FINDER) :
                   getWindowPred(std::ranges::find(m_windows, cur), m_windows.end(), m_windows.begin(), FINDER);
 }
 

--- a/src/config/ConfigDataValues.hpp
+++ b/src/config/ConfigDataValues.hpp
@@ -158,7 +158,7 @@ class CFontWeightConfigValueData : public ICustomConfigValueData {
 
     void parseWeight(const std::string& strWeight) {
         auto lcWeight{strWeight};
-        std::ranges::transform(strWeight, lcWeight.begin(), ::tolower);
+        transform(strWeight.begin(), strWeight.end(), lcWeight.begin(), ::tolower);
 
         // values taken from Pango weight enums
         const auto WEIGHTS = std::map<std::string, int>{

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1651,7 +1651,7 @@ Hyprlang::CConfigValue* CConfigManager::getHyprlangConfigValuePtr(const std::str
 
 bool CConfigManager::deviceConfigExists(const std::string& dev) {
     auto copy = dev;
-    std::ranges::replace(copy, ' ', '-');
+    std::replace(copy.begin(), copy.end(), ' ', '-');
 
     return m_config->specialCategoryExistsForKey("device", copy.c_str());
 }
@@ -1902,7 +1902,7 @@ static bool parseModeLine(const std::string& modeline, drmModeModeInfo& mode) {
     auto args = CVarList(modeline, 0, 's');
 
     auto keyword = args[0];
-    std::ranges::transform(keyword, keyword.begin(), ::tolower);
+    std::transform(keyword.begin(), keyword.end(), keyword.begin(), ::tolower);
 
     if (keyword != "modeline")
         return false;
@@ -1938,7 +1938,7 @@ static bool parseModeLine(const std::string& modeline, drmModeModeInfo& mode) {
 
     for (; argno < static_cast<int>(args.size()); argno++) {
         auto key = args[argno];
-        std::ranges::transform(key, key.begin(), ::tolower);
+        std::transform(key.begin(), key.end(), key.begin(), ::tolower);
 
         auto it = flagsmap.find(key);
 
@@ -2375,7 +2375,7 @@ std::optional<std::string> CConfigManager::handleBind(const std::string& command
         HANDLER = "mouse";
 
     // to lower
-    std::ranges::transform(HANDLER, HANDLER.begin(), ::tolower);
+    std::transform(HANDLER.begin(), HANDLER.end(), HANDLER.begin(), ::tolower);
 
     const auto DISPATCHER = g_pKeybindManager->m_dispatchers.find(HANDLER);
 
@@ -2798,7 +2798,7 @@ std::optional<std::string> CConfigManager::handleWorkspaceRules(const std::strin
     wsRule.workspaceId   = id;
     wsRule.workspaceName = name;
 
-    const auto IT = std::ranges::find_if(m_workspaceRules, [&](const auto& other) { return other.workspaceString == wsRule.workspaceString; });
+    const auto IT = std::find_if(m_workspaceRules.begin(), m_workspaceRules.end(), [&](const auto& other) { return other.workspaceString == wsRule.workspaceString; });
 
     if (IT == m_workspaceRules.end())
         m_workspaceRules.emplace_back(wsRule);
@@ -2896,7 +2896,7 @@ std::optional<std::string> CConfigManager::handleEnv(const std::string& command,
 }
 
 std::optional<std::string> CConfigManager::handlePlugin(const std::string& command, const std::string& path) {
-    if (std::ranges::find(m_declaredPlugins, path) != m_declaredPlugins.end())
+    if (std::find(m_declaredPlugins.begin(), m_declaredPlugins.end(), path) != m_declaredPlugins.end())
         return "plugin '" + path + "' declared twice";
 
     m_declaredPlugins.push_back(path);

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -216,10 +216,10 @@ static std::string getTagsData(PHLWINDOW w, eHyprCtlOutputFormat format) {
     const auto tags = w->m_tags.getTags();
 
     if (format == eHyprCtlOutputFormat::FORMAT_JSON)
-        return std::ranges::fold_left(tags, std::string(),
-                                      [](const std::string& a, const std::string& b) { return a.empty() ? std::format("\"{}\"", b) : std::format("{}, \"{}\"", a, b); });
+        return std::accumulate(tags.begin(), tags.end(), std::string(),
+                               [](const std::string& a, const std::string& b) { return a.empty() ? std::format("\"{}\"", b) : std::format("{}, \"{}\"", a, b); });
     else
-        return std::ranges::fold_left(tags, std::string(), [](const std::string& a, const std::string& b) { return a.empty() ? b : a + ", " + b; });
+        return std::accumulate(tags.begin(), tags.end(), std::string(), [](const std::string& a, const std::string& b) { return a.empty() ? b : a + ", " + b; });
 }
 
 static std::string getGroupedData(PHLWINDOW w, eHyprCtlOutputFormat format) {
@@ -921,7 +921,7 @@ static std::string bindsRequest(eHyprCtlOutputFormat format, std::string request
 std::string versionRequest(eHyprCtlOutputFormat format, std::string request) {
 
     auto commitMsg = trim(GIT_COMMIT_MESSAGE);
-    std::ranges::replace(commitMsg, '#', ' ');
+    std::replace(commitMsg.begin(), commitMsg.end(), '#', ' ');
 
     if (format == eHyprCtlOutputFormat::FORMAT_NORMAL) {
         std::string result = std::format("Hyprland {} built from branch {} at commit {} {} ({}).\n"
@@ -1296,7 +1296,8 @@ static std::string switchXKBLayoutRequest(eHyprCtlOutputFormat format, std::stri
         }
         return result.empty() ? "ok" : result;
     } else {
-        auto k = std::ranges::find_if(g_pInputManager->m_keyboards, [&](const auto& other) { return other->m_hlName == g_pInputManager->deviceNameToInternalString(KB); });
+        auto k = std::find_if(g_pInputManager->m_keyboards.begin(), g_pInputManager->m_keyboards.end(),
+                              [&](const auto& other) { return other->m_hlName == g_pInputManager->deviceNameToInternalString(KB); });
 
         if (k == g_pInputManager->m_keyboards.end())
             return "device not found";

--- a/src/debug/HyprNotificationOverlay.cpp
+++ b/src/debug/HyprNotificationOverlay.cpp
@@ -13,7 +13,7 @@ static inline auto iconBackendFromLayout(PangoLayout* layout) {
     // preference: Nerd > FontAwesome > text
     auto eIconBackendChecks = std::array<eIconBackend, 2>{ICONS_BACKEND_NF, ICONS_BACKEND_FA};
     for (auto iconID : eIconBackendChecks) {
-        auto iconsText = std::ranges::fold_left(ICONS_ARRAY[iconID], std::string(), std::plus<>());
+        auto iconsText = std::accumulate(ICONS_ARRAY[iconID].begin(), ICONS_ARRAY[iconID].end(), std::string());
         pango_layout_set_text(layout, iconsText.c_str(), -1);
         if (pango_layout_get_unknown_glyphs_count(layout) == 0)
             return iconID;

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <ranges>
 #include <hyprutils/animation/AnimatedVariable.hpp>
 #include <re2/re2.h>
 
@@ -1508,7 +1507,7 @@ std::string CWindow::fetchClass() {
 }
 
 void CWindow::onAck(uint32_t serial) {
-    const auto SERIAL = std::ranges::find_if(m_pendingSizeAcks | std::views::reverse, [serial](const auto& e) { return e.first == serial; });
+    const auto SERIAL = std::ranges::find_if(m_pendingSizeAcks.rbegin(), m_pendingSizeAcks.rend(), [serial](const auto& e) { return e.first == serial; });
 
     if (SERIAL == m_pendingSizeAcks.rend())
         return;

--- a/src/devices/IKeyboard.cpp
+++ b/src/devices/IKeyboard.cpp
@@ -379,7 +379,7 @@ bool IKeyboard::updateModifiersState() {
 
 void IKeyboard::updateXkbStateWithKey(uint32_t xkbKey, bool pressed) {
 
-    const auto contains = std::ranges::find(m_pressedXKB, xkbKey) != m_pressedXKB.end();
+    const auto contains = std::find(m_pressedXKB.begin(), m_pressedXKB.end(), xkbKey) != m_pressedXKB.end();
 
     if (contains && pressed)
         return;

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -742,7 +742,7 @@ void Events::listener_unmapWindow(void* owner, void* data) {
     EMIT_HOOK_EVENT("closeWindow", PWINDOW);
 
     if (PWINDOW->m_isFloating && !PWINDOW->m_isX11 &&
-        std::ranges::any_of(PWINDOW->m_matchedRules, [](const auto& r) { return r->m_ruleType == CWindowRule::RULE_PERSISTENTSIZE; })) {
+        std::any_of(PWINDOW->m_matchedRules.begin(), PWINDOW->m_matchedRules.end(), [](const auto& r) { return r->m_ruleType == CWindowRule::RULE_PERSISTENTSIZE; })) {
         Debug::log(LOG, "storing floating size {}x{} for window {}::{} on close", PWINDOW->m_realSize->value().x, PWINDOW->m_realSize->value().y, PWINDOW->m_class,
                    PWINDOW->m_title);
         g_pConfigManager->storeFloatingSize(PWINDOW, PWINDOW->m_realSize->value());

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -243,7 +243,7 @@ SWorkspaceIDName getWorkspaceIDNameFromString(const std::string& in) {
 
                 namedWSes.push_back(ws->m_id);
             }
-            std::ranges::sort(namedWSes);
+            std::sort(namedWSes.begin(), namedWSes.end());
 
             if (absolute) {
                 // 1-index
@@ -388,7 +388,7 @@ SWorkspaceIDName getWorkspaceIDNameFromString(const std::string& in) {
                 validWSes.push_back(ws->m_id);
             }
 
-            std::ranges::sort(validWSes);
+            std::sort(validWSes.begin(), validWSes.end());
 
             ssize_t currentItem = -1;
 
@@ -623,7 +623,7 @@ std::expected<int64_t, std::string> configStringToInt(const std::string& VALUE) 
         const auto VALUEWITHOUTFUNC = trim(VALUE.substr(5, VALUE.length() - 6));
 
         // try doing it the comma way first
-        if (std::ranges::count(VALUEWITHOUTFUNC, ',') == 3) {
+        if (std::count(VALUEWITHOUTFUNC.begin(), VALUEWITHOUTFUNC.end(), ',') == 3) {
             // cool
             std::string rolling = VALUEWITHOUTFUNC;
             auto        r       = configStringToInt(trim(rolling.substr(0, rolling.find(','))));
@@ -657,7 +657,7 @@ std::expected<int64_t, std::string> configStringToInt(const std::string& VALUE) 
         const auto VALUEWITHOUTFUNC = trim(VALUE.substr(4, VALUE.length() - 5));
 
         // try doing it the comma way first
-        if (std::ranges::count(VALUEWITHOUTFUNC, ',') == 2) {
+        if (std::count(VALUEWITHOUTFUNC.begin(), VALUEWITHOUTFUNC.end(), ',') == 2) {
             // cool
             std::string rolling = VALUEWITHOUTFUNC;
             auto        r       = configStringToInt(trim(rolling.substr(0, rolling.find(','))));

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -32,8 +32,6 @@
 #include <hyprutils/utils/ScopeGuard.hpp>
 #include <cstring>
 #include <ranges>
-#include <vector>
-#include <algorithm>
 
 using namespace Hyprutils::String;
 using namespace Hyprutils::Utils;
@@ -191,7 +189,7 @@ void CMonitor::onConnect(bool noRule) {
 
     RASSERT(thisWrapper->get(), "CMonitor::onConnect: Had no wrapper???");
 
-    if (std::ranges::find_if(g_pCompositor->m_monitors, [&](auto& other) { return other.get() == this; }) == g_pCompositor->m_monitors.end())
+    if (std::find_if(g_pCompositor->m_monitors.begin(), g_pCompositor->m_monitors.end(), [&](auto& other) { return other.get() == this; }) == g_pCompositor->m_monitors.end())
         g_pCompositor->m_monitors.push_back(*thisWrapper);
 
     m_enabled = true;
@@ -322,7 +320,7 @@ void CMonitor::onDisconnect(bool destroy) {
 
     // remove mirror
     if (m_mirrorOf) {
-        m_mirrorOf->m_mirrors.erase(std::ranges::find_if(m_mirrorOf->m_mirrors, [&](const auto& other) { return other == m_self; }));
+        m_mirrorOf->m_mirrors.erase(std::find_if(m_mirrorOf->m_mirrors.begin(), m_mirrorOf->m_mirrors.end(), [&](const auto& other) { return other == m_self; }));
 
         // unlock software for mirrored monitor
         g_pPointerManager->unlockSoftwareForMonitor(m_mirrorOf.lock());
@@ -488,7 +486,7 @@ bool CMonitor::applyMonitorRule(SMonitorRule* pMonitorRule, bool force) {
         std::ranges::sort(sortedModes, sortFunc);
         if (sortedModes.size() > 3)
             sortedModes.erase(sortedModes.begin() + 3, sortedModes.end());
-        requestedModes.insert_range(requestedModes.end(), sortedModes | std::views::reverse);
+        requestedModes.insert(requestedModes.end(), sortedModes.rbegin(), sortedModes.rend());
     };
 
     // last fallback is always preferred mode
@@ -1021,7 +1019,7 @@ void CMonitor::setMirror(const std::string& mirrorOf) {
         // disable mirroring
 
         if (m_mirrorOf) {
-            m_mirrorOf->m_mirrors.erase(std::ranges::find_if(m_mirrorOf->m_mirrors, [&](const auto& other) { return other == m_self; }));
+            m_mirrorOf->m_mirrors.erase(std::find_if(m_mirrorOf->m_mirrors.begin(), m_mirrorOf->m_mirrors.end(), [&](const auto& other) { return other == m_self; }));
 
             // unlock software for mirrored monitor
             g_pPointerManager->unlockSoftwareForMonitor(m_mirrorOf.lock());
@@ -1048,7 +1046,7 @@ void CMonitor::setMirror(const std::string& mirrorOf) {
 
         RASSERT(thisWrapper->get(), "CMonitor::setMirror: Had no wrapper???");
 
-        if (std::ranges::find_if(g_pCompositor->m_monitors, [&](auto& other) { return other.get() == this; }) == g_pCompositor->m_monitors.end()) {
+        if (std::find_if(g_pCompositor->m_monitors.begin(), g_pCompositor->m_monitors.end(), [&](auto& other) { return other.get() == this; }) == g_pCompositor->m_monitors.end()) {
             g_pCompositor->m_monitors.push_back(*thisWrapper);
         }
 

--- a/src/hyprerror/HyprError.cpp
+++ b/src/hyprerror/HyprError.cpp
@@ -63,7 +63,7 @@ void CHyprError::createQueued() {
     cairo_paint(CAIRO);
     cairo_restore(CAIRO);
 
-    const auto   LINECOUNT    = Hyprlang::INT{1} + std::ranges::count(m_queued, '\n');
+    const auto   LINECOUNT    = Hyprlang::INT{1} + std::count(m_queued.begin(), m_queued.end(), '\n');
     static auto  LINELIMIT    = CConfigValue<Hyprlang::INT>("debug:error_limit");
     static auto  BAR_POSITION = CConfigValue<Hyprlang::INT>("debug:error_position");
 

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -94,7 +94,7 @@ void CHyprMasterLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dire
         if (*PNEWONACTIVE != "none" && !BNEWISMASTER) {
             const auto pLastNode = getNodeFromWindow(g_pCompositor->m_lastWindow.lock());
             if (pLastNode && !(pLastNode->isMaster && (getMastersOnWorkspace(pWindow->workspaceID()) == 1 || *PNEWSTATUS == "slave"))) {
-                auto it = std::ranges::find(m_masterNodesData, *pLastNode);
+                auto it = std::find(m_masterNodesData.begin(), m_masterNodesData.end(), *pLastNode);
                 if (!BNEWBEFOREACTIVE)
                     ++it;
                 return &(*m_masterNodesData.emplace(it));
@@ -117,7 +117,7 @@ void CHyprMasterLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dire
     const auto   MOUSECOORDS   = g_pInputManager->getMouseCoordsInternal();
     static auto  PDROPATCURSOR = CConfigValue<Hyprlang::INT>("master:drop_at_cursor");
     eOrientation orientation   = getDynamicOrientation(pWindow->m_workspace);
-    const auto   NODEIT        = std::ranges::find(m_masterNodesData, *PNODE);
+    const auto   NODEIT        = std::find(m_masterNodesData.begin(), m_masterNodesData.end(), *PNODE);
 
     bool         forceDropAsMaster = false;
     // if dragging window to move, drop it at the cursor position instead of bottom/top of stack
@@ -804,8 +804,8 @@ void CHyprMasterLayout::resizeActiveWindow(const Vector2D& pixResize, eRectCorne
         if (!*PSMARTRESIZING) {
             PNODE->percSize = std::clamp(PNODE->percSize + RESIZEDELTA / SIZE, 0.05, 1.95);
         } else {
-            const auto  NODEIT    = std::ranges::find(m_masterNodesData, *PNODE);
-            const auto  REVNODEIT = std::ranges::find(m_masterNodesData | std::views::reverse, *PNODE);
+            const auto  NODEIT    = std::find(m_masterNodesData.begin(), m_masterNodesData.end(), *PNODE);
+            const auto  REVNODEIT = std::find(m_masterNodesData.rbegin(), m_masterNodesData.rend(), *PNODE);
 
             const float totalSize       = isStackVertical ? WSSIZE.y : WSSIZE.x;
             const float minSize         = totalSize / nodesInSameColumn * 0.2;
@@ -1026,15 +1026,16 @@ PHLWINDOW CHyprMasterLayout::getNextWindow(PHLWINDOW pWindow, bool next, bool lo
 
     auto       nodes = m_masterNodesData;
     if (!next)
-        std::ranges::reverse(nodes);
+        std::reverse(nodes.begin(), nodes.end());
 
-    const auto NODEIT = std::ranges::find(nodes, *PNODE);
+    const auto NODEIT = std::find(nodes.begin(), nodes.end(), *PNODE);
 
     const bool ISMASTER = PNODE->isMaster;
 
     auto CANDIDATE = std::find_if(NODEIT, nodes.end(), [&](const auto& other) { return other != *PNODE && ISMASTER == other.isMaster && other.workspaceID == PNODE->workspaceID; });
     if (CANDIDATE == nodes.end())
-        CANDIDATE = std::ranges::find_if(nodes, [&](const auto& other) { return other != *PNODE && ISMASTER != other.isMaster && other.workspaceID == PNODE->workspaceID; });
+        CANDIDATE =
+            std::find_if(nodes.begin(), nodes.end(), [&](const auto& other) { return other != *PNODE && ISMASTER != other.isMaster && other.workspaceID == PNODE->workspaceID; });
 
     if (CANDIDATE != nodes.end() && !loop) {
         if (CANDIDATE->isMaster && next)
@@ -1307,12 +1308,12 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
         if (!OLDMASTER)
             return 0;
 
-        const auto OLDMASTERIT = std::ranges::find(m_masterNodesData, *OLDMASTER);
+        const auto OLDMASTERIT = std::find(m_masterNodesData.begin(), m_masterNodesData.end(), *OLDMASTER);
 
         for (auto& nd : m_masterNodesData) {
             if (nd.workspaceID == PNODE->workspaceID && !nd.isMaster) {
                 nd.isMaster            = true;
-                const auto NEWMASTERIT = std::ranges::find(m_masterNodesData, nd);
+                const auto NEWMASTERIT = std::find(m_masterNodesData.begin(), m_masterNodesData.end(), nd);
                 m_masterNodesData.splice(OLDMASTERIT, m_masterNodesData, NEWMASTERIT);
                 switchToWindow(nd.pWindow.lock());
                 OLDMASTER->isMaster = false;
@@ -1333,12 +1334,12 @@ std::any CHyprMasterLayout::layoutMessage(SLayoutMessageHeader header, std::stri
         if (!OLDMASTER)
             return 0;
 
-        const auto OLDMASTERIT = std::ranges::find(m_masterNodesData, *OLDMASTER);
+        const auto OLDMASTERIT = std::find(m_masterNodesData.begin(), m_masterNodesData.end(), *OLDMASTER);
 
         for (auto& nd : m_masterNodesData | std::views::reverse) {
             if (nd.workspaceID == PNODE->workspaceID && !nd.isMaster) {
                 nd.isMaster            = true;
-                const auto NEWMASTERIT = std::ranges::find(m_masterNodesData, nd);
+                const auto NEWMASTERIT = std::find(m_masterNodesData.begin(), m_masterNodesData.end(), nd);
                 m_masterNodesData.splice(OLDMASTERIT, m_masterNodesData, NEWMASTERIT);
                 switchToWindow(nd.pWindow.lock());
                 OLDMASTER->isMaster = false;

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -384,7 +384,7 @@ void CHyprAnimationManager::onWindowPostCreateClose(PHLWINDOW pWindow, bool clos
     }
 
     std::string ANIMSTYLE = pWindow->m_realPosition->getStyle();
-    std::ranges::transform(ANIMSTYLE, ANIMSTYLE.begin(), ::tolower);
+    transform(ANIMSTYLE.begin(), ANIMSTYLE.end(), ANIMSTYLE.begin(), ::tolower);
 
     CVarList animList(ANIMSTYLE, 0, 's');
 

--- a/src/managers/CursorManager.cpp
+++ b/src/managers/CursorManager.cpp
@@ -186,7 +186,7 @@ void CCursorManager::setCursorFromName(const std::string& name) {
         if (m_currentCursorShapeData.images.size() < 1) {
             // try with '_' first (old hc, etc)
             std::string newName = name;
-            std::ranges::replace(newName, '-', '_');
+            std::replace(newName.begin(), newName.end(), '-', '_');
 
             m_currentCursorShapeData = m_hyprcursor->getShape(newName.c_str(), m_currentStyleInfo);
         }

--- a/src/managers/EventManager.cpp
+++ b/src/managers/EventManager.cpp
@@ -123,7 +123,7 @@ int CEventManager::onClientEvent(int fd, uint32_t mask) {
 }
 
 std::vector<CEventManager::SClient>::iterator CEventManager::findClientByFD(int fd) {
-    return std::ranges::find_if(m_clients, [fd](const auto& client) { return client.fd.get() == fd; });
+    return std::find_if(m_clients.begin(), m_clients.end(), [fd](const auto& client) { return client.fd.get() == fd; });
 }
 
 std::vector<CEventManager::SClient>::iterator CEventManager::removeClientByFD(int fd) {

--- a/src/managers/HookSystemManager.cpp
+++ b/src/managers/HookSystemManager.cpp
@@ -46,7 +46,7 @@ void CHookSystemManager::emit(std::vector<SCallbackFNPtr>* const callbacks, SCal
 
         m_currentEventPlugin = true;
 
-        if (std::ranges::find(faultyHandles, cb.handle) != faultyHandles.end())
+        if (std::find(faultyHandles.begin(), faultyHandles.end(), cb.handle) != faultyHandles.end())
             continue;
 
         try {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -225,7 +225,7 @@ void CKeybindManager::removeKeybind(uint32_t mod, const SParsedKey& key) {
 
 uint32_t CKeybindManager::stringToModMask(std::string mods) {
     uint32_t modMask = 0;
-    std::ranges::transform(mods, mods.begin(), ::toupper);
+    std::transform(mods.begin(), mods.end(), mods.begin(), ::toupper);
     if (mods.contains("SHIFT"))
         modMask |= HL_MODIFIER_SHIFT;
     if (mods.contains("CAPS"))
@@ -624,8 +624,10 @@ eMultiKeyCase CKeybindManager::mkKeysymSetMatches(const std::set<xkb_keysym_t> k
     std::set<xkb_keysym_t> boundKeysNotPressed;
     std::set<xkb_keysym_t> pressedKeysNotBound;
 
-    std::ranges::set_difference(keybindKeysyms, pressedKeysyms, std::inserter(boundKeysNotPressed, boundKeysNotPressed.begin()));
-    std::ranges::set_difference(pressedKeysyms, keybindKeysyms, std::inserter(pressedKeysNotBound, pressedKeysNotBound.begin()));
+    std::set_difference(keybindKeysyms.begin(), keybindKeysyms.end(), pressedKeysyms.begin(), pressedKeysyms.end(),
+                        std::inserter(boundKeysNotPressed, boundKeysNotPressed.begin()));
+    std::set_difference(pressedKeysyms.begin(), pressedKeysyms.end(), keybindKeysyms.begin(), keybindKeysyms.end(),
+                        std::inserter(pressedKeysNotBound, pressedKeysNotBound.begin()));
 
     if (boundKeysNotPressed.empty() && pressedKeysNotBound.empty())
         return MK_FULL_MATCH;
@@ -668,7 +670,8 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
 
     for (auto& k : m_keybinds) {
         const bool SPECIALDISPATCHER = k->handler == "global" || k->handler == "pass" || k->handler == "sendshortcut" || k->handler == "mouse";
-        const bool SPECIALTRIGGERED  = std::ranges::find_if(m_pressedSpecialBinds, [&](const auto& other) { return other == k; }) != m_pressedSpecialBinds.end();
+        const bool SPECIALTRIGGERED =
+            std::find_if(m_pressedSpecialBinds.begin(), m_pressedSpecialBinds.end(), [&](const auto& other) { return other == k; }) != m_pressedSpecialBinds.end();
         const bool IGNORECONDITIONS =
             SPECIALDISPATCHER && !pressed && SPECIALTRIGGERED; // ignore mods. Pass, global dispatchers should be released immediately once the key is released.
 
@@ -1103,7 +1106,7 @@ SDispatchResult CKeybindManager::signalWindow(std::string args) {
         return {.success = false, .error = "signalWindow: no window"};
     }
 
-    if (!std::ranges::all_of(SIGNAL, ::isdigit))
+    if (!std::all_of(SIGNAL.begin(), SIGNAL.end(), ::isdigit))
         return {.success = false, .error = "signalWindow: signal has to be int"};
 
     try {

--- a/src/managers/LayoutManager.cpp
+++ b/src/managers/LayoutManager.cpp
@@ -26,7 +26,7 @@ void CLayoutManager::switchToLayout(std::string layout) {
 }
 
 bool CLayoutManager::addLayout(const std::string& name, IHyprLayout* layout) {
-    if (std::ranges::find_if(m_layouts, [&](const auto& other) { return other.first == name || other.second == layout; }) != m_layouts.end())
+    if (std::find_if(m_layouts.begin(), m_layouts.end(), [&](const auto& other) { return other.first == name || other.second == layout; }) != m_layouts.end())
         return false;
 
     m_layouts.emplace_back(std::make_pair<>(name, layout));
@@ -37,7 +37,7 @@ bool CLayoutManager::addLayout(const std::string& name, IHyprLayout* layout) {
 }
 
 bool CLayoutManager::removeLayout(IHyprLayout* layout) {
-    const auto IT = std::ranges::find_if(m_layouts, [&](const auto& other) { return other.second == layout; });
+    const auto IT = std::find_if(m_layouts.begin(), m_layouts.end(), [&](const auto& other) { return other.second == layout; });
 
     if (IT == m_layouts.end() || IT->first == "dwindle" || IT->first == "master")
         return false;

--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -94,7 +94,7 @@ bool CPointerManager::hasCursor() {
 }
 
 SP<CPointerManager::SMonitorPointerState> CPointerManager::stateFor(PHLMONITOR mon) {
-    auto it = std::ranges::find_if(m_monitorStates, [mon](const auto& other) { return other->monitor == mon; });
+    auto it = std::find_if(m_monitorStates.begin(), m_monitorStates.end(), [mon](const auto& other) { return other->monitor == mon; });
     if (it == m_monitorStates.end())
         return m_monitorStates.emplace_back(makeShared<CPointerManager::SMonitorPointerState>(mon));
     return *it;

--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -653,7 +653,7 @@ void CSeatManager::resendEnterEvents() {
 }
 
 bool CSeatGrab::accepts(SP<CWLSurfaceResource> surf) {
-    return std::ranges::find(m_surfs, surf) != m_surfs.end();
+    return std::find(m_surfs.begin(), m_surfs.end(), surf) != m_surfs.end();
 }
 
 void CSeatGrab::add(SP<CWLSurfaceResource> surf) {

--- a/src/managers/XCursorManager.cpp
+++ b/src/managers/XCursorManager.cpp
@@ -127,8 +127,8 @@ void CXCursorManager::loadTheme(std::string const& name, int size, float scale) 
         for (auto const& p : paths) {
             try {
                 auto dirCursors = loadAllFromDir(p, m_lastLoadSize);
-                std::ranges::copy_if(dirCursors, std::back_inserter(m_cursors),
-                                     [this](auto const& p) { return std::ranges::none_of(m_cursors, [&p](auto const& dp) { return dp->shape == p->shape; }); });
+                std::copy_if(dirCursors.begin(), dirCursors.end(), std::back_inserter(m_cursors),
+                             [this](auto const& p) { return std::none_of(m_cursors.begin(), m_cursors.end(), [&p](auto const& dp) { return dp->shape == p->shape; }); });
             } catch (std::exception& e) { Debug::log(ERR, "XCursor path {} can't be loaded: threw error {}", p, e.what()); }
         }
     }
@@ -144,14 +144,14 @@ void CXCursorManager::loadTheme(std::string const& name, int size, float scale) 
         if (legacyName.empty())
             continue;
 
-        auto it = std::ranges::find_if(m_cursors, [&legacyName](auto const& c) { return c->shape == legacyName; });
+        auto it = std::find_if(m_cursors.begin(), m_cursors.end(), [&legacyName](auto const& c) { return c->shape == legacyName; });
 
         if (it == m_cursors.end()) {
             Debug::log(LOG, "XCursor failed to find a legacy shape with name {}, skipping", legacyName);
             continue;
         }
 
-        if (std::ranges::any_of(m_cursors, [&shape](auto const& dp) { return dp->shape == shape; })) {
+        if (std::any_of(m_cursors.begin(), m_cursors.end(), [&shape](auto const& dp) { return dp->shape == shape; })) {
             Debug::log(LOG, "XCursor already has a shape {} loaded, skipping", shape);
             continue;
         }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -619,7 +619,7 @@ void CInputManager::onMouseButton(IPointer::SButtonEvent e) {
     if (e.state == WL_POINTER_BUTTON_STATE_PRESSED) {
         m_currentlyHeldButtons.push_back(e.button);
     } else {
-        if (std::ranges::find_if(m_currentlyHeldButtons, [&](const auto& other) { return other == e.button; }) == m_currentlyHeldButtons.end())
+        if (std::find_if(m_currentlyHeldButtons.begin(), m_currentlyHeldButtons.end(), [&](const auto& other) { return other == e.button; }) == m_currentlyHeldButtons.end())
             return;
         std::erase_if(m_currentlyHeldButtons, [&](const auto& other) { return other == e.button; });
     }
@@ -1552,7 +1552,7 @@ void CInputManager::unconstrainMouse() {
 }
 
 bool CInputManager::isConstrained() {
-    return std::ranges::any_of(m_constraints, [](auto const& c) {
+    return std::any_of(m_constraints.begin(), m_constraints.end(), [](auto const& c) {
         const auto constraint = c.lock();
         return constraint && constraint->isActive() && constraint->owner()->resource() == g_pCompositor->m_lastFocus;
     });
@@ -1773,9 +1773,9 @@ void CInputManager::unsetCursorImage() {
 }
 
 std::string CInputManager::deviceNameToInternalString(std::string in) {
-    std::ranges::replace(in, ' ', '-');
-    std::ranges::replace(in, '\n', '-');
-    std::ranges::transform(in, in.begin(), ::tolower);
+    std::replace(in.begin(), in.end(), ' ', '-');
+    std::replace(in.begin(), in.end(), '\n', '-');
+    std::transform(in.begin(), in.end(), in.begin(), ::tolower);
     return in;
 }
 
@@ -1786,7 +1786,7 @@ std::string CInputManager::getNameForNewDevice(std::string internalName) {
 
     auto makeNewName = [&]() { return (proposedNewName.empty() ? "unknown-device" : proposedNewName) + (dupeno == 0 ? "" : ("-" + std::to_string(dupeno))); };
 
-    while (std::ranges::find_if(m_hids, [&](const auto& other) { return other->m_hlName == makeNewName(); }) != m_hids.end())
+    while (std::find_if(m_hids.begin(), m_hids.end(), [&](const auto& other) { return other->m_hlName == makeNewName(); }) != m_hids.end())
         dupeno++;
 
     return makeNewName();

--- a/src/protocols/AlphaModifier.cpp
+++ b/src/protocols/AlphaModifier.cpp
@@ -81,7 +81,7 @@ void CAlphaModifierProtocol::destroyAlphaModifier(CAlphaModifier* modifier) {
 
 void CAlphaModifierProtocol::getSurface(CWpAlphaModifierV1* manager, uint32_t id, SP<CWLSurfaceResource> surface) {
     CAlphaModifier* alphaModifier = nullptr;
-    auto            iter          = std::ranges::find_if(m_alphaModifiers, [&](const auto& entry) { return entry.second->m_surface == surface; });
+    auto            iter          = std::find_if(m_alphaModifiers.begin(), m_alphaModifiers.end(), [&](const auto& entry) { return entry.second->m_surface == surface; });
 
     if (iter != m_alphaModifiers.end()) {
         if (iter->second->m_resource) {

--- a/src/protocols/ColorManagement.cpp
+++ b/src/protocols/ColorManagement.cpp
@@ -281,8 +281,8 @@ CColorManagementSurface::CColorManagementSurface(SP<CWpColorManagementSurfaceV1>
             return;
         }
 
-        const auto imageDescription =
-            std::ranges::find_if(PROTO::colorManagement->m_imageDescriptions, [&](const auto& other) { return other->resource()->resource() == image_description; });
+        const auto imageDescription = std::find_if(PROTO::colorManagement->m_imageDescriptions.begin(), PROTO::colorManagement->m_imageDescriptions.end(),
+                                                   [&](const auto& other) { return other->resource()->resource() == image_description; });
         if (imageDescription == PROTO::colorManagement->m_imageDescriptions.end()) {
             r->error(WP_COLOR_MANAGEMENT_SURFACE_V1_ERROR_IMAGE_DESCRIPTION, "Image description not found");
             return;

--- a/src/protocols/DRMLease.cpp
+++ b/src/protocols/DRMLease.cpp
@@ -96,7 +96,7 @@ CDRMLeaseRequestResource::CDRMLeaseRequestResource(SP<CWpDrmLeaseRequestV1> reso
 
         auto CONNECTOR = CDRMLeaseConnectorResource::fromResource(conn);
 
-        if (std::ranges::find(m_requested, CONNECTOR) != m_requested.end()) {
+        if (std::find(m_requested.begin(), m_requested.end(), CONNECTOR) != m_requested.end()) {
             m_resource->error(WP_DRM_LEASE_REQUEST_V1_ERROR_DUPLICATE_CONNECTOR, "Connector already requested");
             return;
         }
@@ -208,7 +208,7 @@ bool CDRMLeaseDeviceResource::good() {
 }
 
 void CDRMLeaseDeviceResource::sendConnector(PHLMONITOR monitor) {
-    if (std::ranges::find_if(m_connectorsSent, [monitor](const auto& e) { return e && !e->m_dead && e->m_monitor == monitor; }) != m_connectorsSent.end())
+    if (std::find_if(m_connectorsSent.begin(), m_connectorsSent.end(), [monitor](const auto& e) { return e && !e->m_dead && e->m_monitor == monitor; }) != m_connectorsSent.end())
         return;
 
     auto RESOURCE = makeShared<CDRMLeaseConnectorResource>(makeShared<CWpDrmLeaseConnectorV1>(m_resource->client(), m_resource->version(), 0), monitor);
@@ -294,7 +294,7 @@ void CDRMLeaseProtocol::destroyResource(CDRMLeaseResource* resource) {
 
 void CDRMLeaseProtocol::offer(PHLMONITOR monitor) {
     std::erase_if(m_primaryDevice->m_offeredOutputs, [](const auto& e) { return e.expired(); });
-    if (std::ranges::find(m_primaryDevice->m_offeredOutputs, monitor) != m_primaryDevice->m_offeredOutputs.end())
+    if (std::find(m_primaryDevice->m_offeredOutputs.begin(), m_primaryDevice->m_offeredOutputs.end(), monitor) != m_primaryDevice->m_offeredOutputs.end())
         return;
 
     if (monitor->m_output->getBackend()->type() != Aquamarine::AQ_BACKEND_DRM)

--- a/src/protocols/DataDeviceWlr.cpp
+++ b/src/protocols/DataDeviceWlr.cpp
@@ -78,7 +78,7 @@ std::vector<std::string> CWLRDataSource::mimes() {
 }
 
 void CWLRDataSource::send(const std::string& mime, CFileDescriptor fd) {
-    if (std::ranges::find(m_mimeTypes, mime) == m_mimeTypes.end()) {
+    if (std::find(m_mimeTypes.begin(), m_mimeTypes.end(), mime) == m_mimeTypes.end()) {
         LOGM(ERR, "Compositor/App bug: CWLRDataSource::sendAskSend with non-existent mime");
         return;
     }
@@ -87,7 +87,7 @@ void CWLRDataSource::send(const std::string& mime, CFileDescriptor fd) {
 }
 
 void CWLRDataSource::accepted(const std::string& mime) {
-    if (std::ranges::find(m_mimeTypes, mime) == m_mimeTypes.end())
+    if (std::find(m_mimeTypes.begin(), m_mimeTypes.end(), mime) == m_mimeTypes.end())
         LOGM(ERR, "Compositor/App bug: CWLRDataSource::sendAccepted with non-existent mime");
 
     // wlr has no accepted
@@ -315,7 +315,7 @@ void CDataDeviceWLRProtocol::setSelection(SP<IDataSource> source, bool primary) 
 }
 
 SP<CWLRDataDevice> CDataDeviceWLRProtocol::dataDeviceForClient(wl_client* c) {
-    auto it = std::ranges::find_if(m_devices, [c](const auto& e) { return e->client() == c; });
+    auto it = std::find_if(m_devices.begin(), m_devices.end(), [c](const auto& e) { return e->client() == c; });
     if (it == m_devices.end())
         return nullptr;
     return *it;

--- a/src/protocols/FocusGrab.cpp
+++ b/src/protocols/FocusGrab.cpp
@@ -36,7 +36,7 @@ bool CFocusGrab::good() {
 }
 
 bool CFocusGrab::isSurfaceComitted(SP<CWLSurfaceResource> surface) {
-    auto iter = std::ranges::find_if(m_surfaces, [surface](const auto& o) { return o.first == surface; });
+    auto iter = std::find_if(m_surfaces.begin(), m_surfaces.end(), [surface](const auto& o) { return o.first == surface; });
     if (iter == m_surfaces.end())
         return false;
 
@@ -70,7 +70,7 @@ void CFocusGrab::finish(bool sendCleared) {
 }
 
 void CFocusGrab::addSurface(SP<CWLSurfaceResource> surface) {
-    auto iter = std::ranges::find_if(m_surfaces, [surface](const auto& e) { return e.first == surface; });
+    auto iter = std::find_if(m_surfaces.begin(), m_surfaces.end(), [surface](const auto& e) { return e.first == surface; });
     if (iter == m_surfaces.end())
         m_surfaces.emplace(surface, makeUnique<CFocusGrabSurfaceState>(this, surface));
 }

--- a/src/protocols/ForeignToplevel.cpp
+++ b/src/protocols/ForeignToplevel.cpp
@@ -69,7 +69,7 @@ void CForeignToplevelList::onMap(PHLWINDOW pWindow) {
 
 SP<CForeignToplevelHandle> CForeignToplevelList::handleForWindow(PHLWINDOW pWindow) {
     std::erase_if(m_handles, [](const auto& wp) { return wp.expired(); });
-    const auto IT = std::ranges::find_if(m_handles, [pWindow](const auto& h) { return h->window() == pWindow; });
+    const auto IT = std::find_if(m_handles.begin(), m_handles.end(), [pWindow](const auto& h) { return h->window() == pWindow; });
     return IT == m_handles.end() ? SP<CForeignToplevelHandle>{} : IT->lock();
 }
 

--- a/src/protocols/ForeignToplevelWlr.cpp
+++ b/src/protocols/ForeignToplevelWlr.cpp
@@ -247,7 +247,7 @@ void CForeignToplevelWlrManager::onMap(PHLWINDOW pWindow) {
 
 SP<CForeignToplevelHandleWlr> CForeignToplevelWlrManager::handleForWindow(PHLWINDOW pWindow) {
     std::erase_if(m_handles, [](const auto& wp) { return wp.expired(); });
-    const auto IT = std::ranges::find_if(m_handles, [pWindow](const auto& h) { return h->window() == pWindow; });
+    const auto IT = std::find_if(m_handles.begin(), m_handles.end(), [pWindow](const auto& h) { return h->window() == pWindow; });
     return IT == m_handles.end() ? SP<CForeignToplevelHandleWlr>{} : IT->lock();
 }
 

--- a/src/protocols/HyprlandSurface.cpp
+++ b/src/protocols/HyprlandSurface.cpp
@@ -109,7 +109,7 @@ void CHyprlandSurfaceProtocol::destroySurface(CHyprlandSurface* surface) {
 
 void CHyprlandSurfaceProtocol::getSurface(CHyprlandSurfaceManagerV1* manager, uint32_t id, SP<CWLSurfaceResource> surface) {
     CHyprlandSurface* hyprlandSurface = nullptr;
-    auto              iter            = std::ranges::find_if(m_surfaces, [&](const auto& entry) { return entry.second->m_surface == surface; });
+    auto              iter            = std::find_if(m_surfaces.begin(), m_surfaces.end(), [&](const auto& entry) { return entry.second->m_surface == surface; });
 
     if (iter != m_surfaces.end()) {
         if (iter->second->m_resource) {

--- a/src/protocols/LayerShell.cpp
+++ b/src/protocols/LayerShell.cpp
@@ -130,7 +130,7 @@ CLayerShellResource::CLayerShellResource(SP<CZwlrLayerSurfaceV1> resource_, SP<C
     });
 
     m_resource->setAckConfigure([this](CZwlrLayerSurfaceV1* r, uint32_t serial) {
-        auto serialFound = std::ranges::find_if(m_serials, [serial](const auto& e) { return e.first == serial; });
+        auto serialFound = std::find_if(m_serials.begin(), m_serials.end(), [serial](const auto& e) { return e.first == serial; });
 
         if (serialFound == m_serials.end()) {
             r->error(ZWLR_LAYER_SURFACE_V1_ERROR_INVALID_SURFACE_STATE, "Serial invalid in ack_configure");

--- a/src/protocols/LinuxDMABUF.cpp
+++ b/src/protocols/LinuxDMABUF.cpp
@@ -46,7 +46,8 @@ CDMABUFFormatTable::CDMABUFFormatTable(SDMABUFTranche _rendererTranche, std::vec
                 });
             } else {
                 // if it wasn't inserted then find its index in vec
-                auto it = std::ranges::find_if(formatsVec, [fmt, mod](const SDMABUFFormatTableEntry& oth) { return oth.fmt == fmt.drmFormat && oth.modifier == mod; });
+                auto it =
+                    std::find_if(formatsVec.begin(), formatsVec.end(), [fmt, mod](const SDMABUFFormatTableEntry& oth) { return oth.fmt == fmt.drmFormat && oth.modifier == mod; });
                 m_rendererTranche.indicies.push_back(it - formatsVec.begin());
             }
         }
@@ -68,7 +69,8 @@ CDMABUFFormatTable::CDMABUFFormatTable(SDMABUFTranche _rendererTranche, std::vec
                         .modifier = mod,
                     });
                 } else {
-                    auto it = std::ranges::find_if(formatsVec, [fmt, mod](const SDMABUFFormatTableEntry& oth) { return oth.fmt == fmt.drmFormat && oth.modifier == mod; });
+                    auto it = std::find_if(formatsVec.begin(), formatsVec.end(),
+                                           [fmt, mod](const SDMABUFFormatTableEntry& oth) { return oth.fmt == fmt.drmFormat && oth.modifier == mod; });
                     tranche.indicies.push_back(it - formatsVec.begin());
                 }
             }
@@ -87,7 +89,7 @@ CDMABUFFormatTable::CDMABUFFormatTable(SDMABUFTranche _rendererTranche, std::vec
         return;
     }
 
-    std::ranges::copy(formatsVec, arr);
+    std::copy(formatsVec.begin(), formatsVec.end(), arr);
 
     munmap(arr, m_tableSize);
 
@@ -167,7 +169,7 @@ CLinuxDMABUFParamsResource::CLinuxDMABUFParamsResource(SP<CZwpLinuxBufferParamsV
 
         m_attrs->size   = {w, h};
         m_attrs->format = fmt;
-        m_attrs->planes = 4 - std::ranges::count(m_attrs->fds, -1);
+        m_attrs->planes = 4 - std::count(m_attrs->fds.begin(), m_attrs->fds.end(), -1);
 
         create(0);
     });
@@ -186,7 +188,7 @@ CLinuxDMABUFParamsResource::CLinuxDMABUFParamsResource(SP<CZwpLinuxBufferParamsV
 
         m_attrs->size   = {w, h};
         m_attrs->format = fmt;
-        m_attrs->planes = 4 - std::ranges::count(m_attrs->fds, -1);
+        m_attrs->planes = 4 - std::count(m_attrs->fds.begin(), m_attrs->fds.end(), -1);
 
         create(id);
     });
@@ -562,8 +564,8 @@ void CLinuxDMABufV1Protocol::updateScanoutTranche(SP<CWLSurfaceResource> surface
         return;
     }
 
-    const auto& monitorTranchePair =
-        std::ranges::find_if(m_formatTable->m_monitorTranches, [pMonitor](std::pair<PHLMONITORREF, SDMABUFTranche> pair) { return pair.first == pMonitor; });
+    const auto& monitorTranchePair = std::find_if(m_formatTable->m_monitorTranches.begin(), m_formatTable->m_monitorTranches.end(),
+                                                  [pMonitor](std::pair<PHLMONITORREF, SDMABUFTranche> pair) { return pair.first == pMonitor; });
 
     if (monitorTranchePair == m_formatTable->m_monitorTranches.end()) {
         LOGM(LOG, "updateScanoutTranche: monitor has no tranche");

--- a/src/protocols/PointerConstraints.cpp
+++ b/src/protocols/PointerConstraints.cpp
@@ -229,7 +229,7 @@ void CPointerConstraintsProtocol::onNewConstraint(SP<CPointerConstraint> constra
 
     const auto OWNER = constraint->owner();
 
-    const auto DUPES = std::ranges::count_if(m_constraints, [OWNER](const auto& c) { return c->owner() == OWNER; });
+    const auto DUPES = std::count_if(m_constraints.begin(), m_constraints.end(), [OWNER](const auto& c) { return c->owner() == OWNER; });
 
     if UNLIKELY (DUPES > 1) {
         LOGM(ERR, "Constraint for surface duped");

--- a/src/protocols/PrimarySelection.cpp
+++ b/src/protocols/PrimarySelection.cpp
@@ -79,7 +79,7 @@ std::vector<std::string> CPrimarySelectionSource::mimes() {
 }
 
 void CPrimarySelectionSource::send(const std::string& mime, CFileDescriptor fd) {
-    if (std::ranges::find(m_mimeTypes, mime) == m_mimeTypes.end()) {
+    if (std::find(m_mimeTypes.begin(), m_mimeTypes.end(), mime) == m_mimeTypes.end()) {
         LOGM(ERR, "Compositor/App bug: CPrimarySelectionSource::sendAskSend with non-existent mime");
         return;
     }
@@ -88,7 +88,7 @@ void CPrimarySelectionSource::send(const std::string& mime, CFileDescriptor fd) 
 }
 
 void CPrimarySelectionSource::accepted(const std::string& mime) {
-    if (std::ranges::find(m_mimeTypes, mime) == m_mimeTypes.end())
+    if (std::find(m_mimeTypes.begin(), m_mimeTypes.end(), mime) == m_mimeTypes.end())
         LOGM(ERR, "Compositor/App bug: CPrimarySelectionSource::sendAccepted with non-existent mime");
 
     // primary sel has no accepted
@@ -327,7 +327,7 @@ void CPrimarySelectionProtocol::onPointerFocus() {
 }
 
 SP<CPrimarySelectionDevice> CPrimarySelectionProtocol::dataDeviceForClient(wl_client* c) {
-    auto it = std::ranges::find_if(m_devices, [c](const auto& e) { return e->client() == c; });
+    auto it = std::find_if(m_devices.begin(), m_devices.end(), [c](const auto& e) { return e->client() == c; });
     if (it == m_devices.end())
         return nullptr;
     return *it;

--- a/src/protocols/SecurityContext.cpp
+++ b/src/protocols/SecurityContext.cpp
@@ -214,5 +214,5 @@ void CSecurityContextProtocol::destroyContext(CSecurityContext* context) {
 }
 
 bool CSecurityContextProtocol::isClientSandboxed(const wl_client* client) {
-    return std::ranges::find_if(m_sandboxedClients, [client](const auto& e) { return e->m_client == client; }) != m_sandboxedClients.end();
+    return std::find_if(m_sandboxedClients.begin(), m_sandboxedClients.end(), [client](const auto& e) { return e->m_client == client; }) != m_sandboxedClients.end();
 }

--- a/src/protocols/VirtualKeyboard.cpp
+++ b/src/protocols/VirtualKeyboard.cpp
@@ -31,7 +31,7 @@ CVirtualKeyboardV1Resource::CVirtualKeyboardV1Resource(SP<CZwpVirtualKeyboardV1>
             .state   = (wl_keyboard_key_state)state,
         });
 
-        const bool CONTAINS = std::ranges::find(m_pressed, key) != m_pressed.end();
+        const bool CONTAINS = std::find(m_pressed.begin(), m_pressed.end(), key) != m_pressed.end();
         if (state && !CONTAINS)
             m_pressed.emplace_back(key);
         else if (!state && CONTAINS)

--- a/src/protocols/XDGActivation.cpp
+++ b/src/protocols/XDGActivation.cpp
@@ -33,7 +33,8 @@ CXDGActivationToken::CXDGActivationToken(SP<CXdgActivationTokenV1> resource_) : 
 
         PROTO::activation->m_sentTokens.push_back({m_token, m_resource->client()});
 
-        auto count = std::ranges::count_if(PROTO::activation->m_sentTokens, [this](const auto& other) { return other.client == m_resource->client(); });
+        auto count = std::count_if(PROTO::activation->m_sentTokens.begin(), PROTO::activation->m_sentTokens.end(),
+                                   [this](const auto& other) { return other.client == m_resource->client(); });
 
         if UNLIKELY (count > 10) {
             // remove first token. Too many, dear app.
@@ -67,7 +68,7 @@ void CXDGActivationProtocol::bindManager(wl_client* client, void* data, uint32_t
     RESOURCE->setDestroy([this](CXdgActivationV1* pMgr) { this->onManagerResourceDestroy(pMgr->resource()); });
     RESOURCE->setGetActivationToken([this](CXdgActivationV1* pMgr, uint32_t id) { this->onGetToken(pMgr, id); });
     RESOURCE->setActivate([this](CXdgActivationV1* pMgr, const char* token, wl_resource* surface) {
-        auto TOKEN = std::ranges::find_if(m_sentTokens, [token](const auto& t) { return t.token == token; });
+        auto TOKEN = std::find_if(m_sentTokens.begin(), m_sentTokens.end(), [token](const auto& t) { return t.token == token; });
 
         if UNLIKELY (TOKEN == m_sentTokens.end()) {
             LOGM(WARN, "activate event for non-existent token {}??", token);

--- a/src/protocols/XDGShell.cpp
+++ b/src/protocols/XDGShell.cpp
@@ -258,7 +258,7 @@ uint32_t CXDGToplevelResource::setSize(const Vector2D& size) {
 }
 
 uint32_t CXDGToplevelResource::setMaximized(bool maximized) {
-    bool set = std::ranges::find(m_pendingApply.states, XDG_TOPLEVEL_STATE_MAXIMIZED) != m_pendingApply.states.end();
+    bool set = std::find(m_pendingApply.states.begin(), m_pendingApply.states.end(), XDG_TOPLEVEL_STATE_MAXIMIZED) != m_pendingApply.states.end();
 
     if (maximized == set)
         return m_owner->m_scheduledSerial;
@@ -272,7 +272,7 @@ uint32_t CXDGToplevelResource::setMaximized(bool maximized) {
 }
 
 uint32_t CXDGToplevelResource::setFullscreen(bool fullscreen) {
-    bool set = std::ranges::find(m_pendingApply.states, XDG_TOPLEVEL_STATE_FULLSCREEN) != m_pendingApply.states.end();
+    bool set = std::find(m_pendingApply.states.begin(), m_pendingApply.states.end(), XDG_TOPLEVEL_STATE_FULLSCREEN) != m_pendingApply.states.end();
 
     if (fullscreen == set)
         return m_owner->m_scheduledSerial;
@@ -286,7 +286,7 @@ uint32_t CXDGToplevelResource::setFullscreen(bool fullscreen) {
 }
 
 uint32_t CXDGToplevelResource::setActive(bool active) {
-    bool set = std::ranges::find(m_pendingApply.states, XDG_TOPLEVEL_STATE_ACTIVATED) != m_pendingApply.states.end();
+    bool set = std::find(m_pendingApply.states.begin(), m_pendingApply.states.end(), XDG_TOPLEVEL_STATE_ACTIVATED) != m_pendingApply.states.end();
 
     if (active == set)
         return m_owner->m_scheduledSerial;
@@ -303,7 +303,7 @@ uint32_t CXDGToplevelResource::setSuspeneded(bool sus) {
     if (m_resource->version() < 6)
         return m_owner->scheduleConfigure(); // SUSPENDED is since 6
 
-    bool set = std::ranges::find(m_pendingApply.states, XDG_TOPLEVEL_STATE_SUSPENDED) != m_pendingApply.states.end();
+    bool set = std::find(m_pendingApply.states.begin(), m_pendingApply.states.end(), XDG_TOPLEVEL_STATE_SUSPENDED) != m_pendingApply.states.end();
 
     if (sus == set)
         return m_owner->m_scheduledSerial;

--- a/src/protocols/XXColorManagement.cpp
+++ b/src/protocols/XXColorManagement.cpp
@@ -237,8 +237,8 @@ CXXColorManagementSurface::CXXColorManagementSurface(SP<CXxColorManagementSurfac
             return;
         }
 
-        const auto imageDescription =
-            std::ranges::find_if(PROTO::xxColorManagement->m_imageDescriptions, [&](const auto& other) { return other->resource()->resource() == image_description; });
+        const auto imageDescription = std::find_if(PROTO::xxColorManagement->m_imageDescriptions.begin(), PROTO::xxColorManagement->m_imageDescriptions.end(),
+                                                   [&](const auto& other) { return other->resource()->resource() == image_description; });
         if (imageDescription == PROTO::xxColorManagement->m_imageDescriptions.end()) {
             r->error(XX_COLOR_MANAGEMENT_SURFACE_V4_ERROR_IMAGE_DESCRIPTION, "Image description not found");
             return;

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -268,7 +268,7 @@ wl_client* CWLSurfaceResource::client() {
 }
 
 void CWLSurfaceResource::enter(PHLMONITOR monitor) {
-    if (std::ranges::find(m_enteredOutputs, monitor) != m_enteredOutputs.end())
+    if (std::find(m_enteredOutputs.begin(), m_enteredOutputs.end(), monitor) != m_enteredOutputs.end())
         return;
 
     if UNLIKELY (!PROTO::outputs.contains(monitor->m_name)) {
@@ -295,7 +295,7 @@ void CWLSurfaceResource::enter(PHLMONITOR monitor) {
 }
 
 void CWLSurfaceResource::leave(PHLMONITOR monitor) {
-    if UNLIKELY (std::ranges::find(m_enteredOutputs, monitor) == m_enteredOutputs.end())
+    if UNLIKELY (std::find(m_enteredOutputs.begin(), m_enteredOutputs.end(), monitor) == m_enteredOutputs.end())
         return;
 
     auto output = PROTO::outputs.at(monitor->m_name)->outputResourceFrom(m_client);

--- a/src/protocols/core/DataDevice.cpp
+++ b/src/protocols/core/DataDevice.cpp
@@ -171,7 +171,7 @@ void CWLDataSourceResource::accepted(const std::string& mime) {
         return;
     }
 
-    if (std::ranges::find(m_mimeTypes, mime) == m_mimeTypes.end()) {
+    if (std::find(m_mimeTypes.begin(), m_mimeTypes.end(), mime) == m_mimeTypes.end()) {
         LOGM(ERR, "Compositor/App bug: CWLDataSourceResource::sendAccepted with non-existent mime");
         return;
     }
@@ -184,7 +184,7 @@ std::vector<std::string> CWLDataSourceResource::mimes() {
 }
 
 void CWLDataSourceResource::send(const std::string& mime, CFileDescriptor fd) {
-    if (std::ranges::find(m_mimeTypes, mime) == m_mimeTypes.end()) {
+    if (std::find(m_mimeTypes.begin(), m_mimeTypes.end(), mime) == m_mimeTypes.end()) {
         LOGM(ERR, "Compositor/App bug: CWLDataSourceResource::sendAskSend with non-existent mime");
         return;
     }
@@ -424,7 +424,7 @@ SP<IDataDevice> CWLDataDeviceProtocol::dataDeviceForClient(wl_client* c) {
         return g_pXWayland->m_wm->getDataDevice();
 #endif
 
-    auto it = std::ranges::find_if(m_devices, [c](const auto& e) { return e->client() == c; });
+    auto it = std::find_if(m_devices.begin(), m_devices.end(), [c](const auto& e) { return e->client() == c; });
     if (it == m_devices.end())
         return nullptr;
     return *it;

--- a/src/protocols/core/Seat.cpp
+++ b/src/protocols/core/Seat.cpp
@@ -204,10 +204,10 @@ void CWLPointerResource::sendButton(uint32_t timeMs, uint32_t button, wl_pointer
     if (!(PROTO::seat->m_currentCaps & eHIDCapabilityType::HID_INPUT_CAPABILITY_POINTER))
         return;
 
-    if (state == WL_POINTER_BUTTON_STATE_RELEASED && std::ranges::find(m_pressedButtons, button) == m_pressedButtons.end()) {
+    if (state == WL_POINTER_BUTTON_STATE_RELEASED && std::find(m_pressedButtons.begin(), m_pressedButtons.end(), button) == m_pressedButtons.end()) {
         LOGM(ERR, "sendButton release on a non-pressed button");
         return;
-    } else if (state == WL_POINTER_BUTTON_STATE_PRESSED && std::ranges::find(m_pressedButtons, button) != m_pressedButtons.end()) {
+    } else if (state == WL_POINTER_BUTTON_STATE_PRESSED && std::find(m_pressedButtons.begin(), m_pressedButtons.end(), button) != m_pressedButtons.end()) {
         LOGM(ERR, "sendButton press on a non-pressed button");
         return;
     }

--- a/src/protocols/core/Shm.cpp
+++ b/src/protocols/core/Shm.cpp
@@ -137,7 +137,7 @@ CWLSHMPoolResource::CWLSHMPoolResource(SP<CWlShmPool> resource_, CFileDescriptor
             return;
         }
 
-        if UNLIKELY (std::ranges::find(PROTO::shm->m_shmFormats, fmt) == PROTO::shm->m_shmFormats.end()) {
+        if UNLIKELY (std::find(PROTO::shm->m_shmFormats.begin(), PROTO::shm->m_shmFormats.end(), fmt) == PROTO::shm->m_shmFormats.end()) {
             r->error(WL_SHM_ERROR_INVALID_FORMAT, "Format invalid");
             return;
         }

--- a/src/protocols/core/Subcompositor.cpp
+++ b/src/protocols/core/Subcompositor.cpp
@@ -30,7 +30,7 @@ CWLSubsurfaceResource::CWLSubsurfaceResource(SP<CWlSubsurface> resource_, SP<CWL
 
         std::erase_if(m_parent->m_subsurfaces, [this](const auto& e) { return e == m_self || !e; });
 
-        auto it = std::ranges::find(m_parent->m_subsurfaces, SURF);
+        auto it = std::find(m_parent->m_subsurfaces.begin(), m_parent->m_subsurfaces.end(), SURF);
 
         if (it == m_parent->m_subsurfaces.end()) {
             LOGM(ERR, "Invalid surface reference in placeAbove, likely parent");
@@ -43,7 +43,7 @@ CWLSubsurfaceResource::CWLSubsurfaceResource(SP<CWlSubsurface> resource_, SP<CWL
             m_parent->m_subsurfaces.emplace_back(m_self);
         }
 
-        std::ranges::sort(m_parent->m_subsurfaces, [](const auto& a, const auto& b) { return a->m_zIndex < b->m_zIndex; });
+        std::sort(m_parent->m_subsurfaces.begin(), m_parent->m_subsurfaces.end(), [](const auto& a, const auto& b) { return a->m_zIndex < b->m_zIndex; });
     });
 
     m_resource->setPlaceBelow([this](CWlSubsurface* r, wl_resource* surf) {
@@ -61,7 +61,7 @@ CWLSubsurfaceResource::CWLSubsurfaceResource(SP<CWlSubsurface> resource_, SP<CWL
 
         std::erase_if(m_parent->m_subsurfaces, [this](const auto& e) { return e == m_self || !e; });
 
-        auto it = std::ranges::find(m_parent->m_subsurfaces, SURF);
+        auto it = std::find(m_parent->m_subsurfaces.begin(), m_parent->m_subsurfaces.end(), SURF);
 
         if (it == m_parent->m_subsurfaces.end()) {
             LOGM(ERR, "Invalid surface reference in placeBelow, likely parent");
@@ -74,7 +74,7 @@ CWLSubsurfaceResource::CWLSubsurfaceResource(SP<CWlSubsurface> resource_, SP<CWL
             m_parent->m_subsurfaces.emplace_back(m_self);
         }
 
-        std::ranges::sort(m_parent->m_subsurfaces, [](const auto& a, const auto& b) { return a->m_zIndex < b->m_zIndex; });
+        std::sort(m_parent->m_subsurfaces.begin(), m_parent->m_subsurfaces.end(), [](const auto& a, const auto& b) { return a->m_zIndex < b->m_zIndex; });
     });
 
     m_listeners.commitSurface = m_surface->m_events.commit.registerListener([this](std::any d) {
@@ -116,7 +116,8 @@ Vector2D CWLSubsurfaceResource::posRelativeToParent() {
     // surfaces we've visited and if we hit a surface we've visited we bail out.
     std::vector<SP<CWLSurfaceResource>> surfacesVisited;
 
-    while (surf->m_role->role() == SURFACE_ROLE_SUBSURFACE && std::ranges::find_if(surfacesVisited, [surf](const auto& other) { return surf == other; }) == surfacesVisited.end()) {
+    while (surf->m_role->role() == SURFACE_ROLE_SUBSURFACE &&
+           std::find_if(surfacesVisited.begin(), surfacesVisited.end(), [surf](const auto& other) { return surf == other; }) == surfacesVisited.end()) {
         surfacesVisited.emplace_back(surf);
         auto subsurface = ((CSubsurfaceRole*)m_parent->m_role.get())->m_subsurface.lock();
         pos += subsurface->m_position;
@@ -133,7 +134,8 @@ SP<CWLSurfaceResource> CWLSubsurfaceResource::t1Parent() {
     SP<CWLSurfaceResource>              surf = m_parent.lock();
     std::vector<SP<CWLSurfaceResource>> surfacesVisited;
 
-    while (surf->m_role->role() == SURFACE_ROLE_SUBSURFACE && std::ranges::find_if(surfacesVisited, [surf](const auto& other) { return surf == other; }) == surfacesVisited.end()) {
+    while (surf->m_role->role() == SURFACE_ROLE_SUBSURFACE &&
+           std::find_if(surfacesVisited.begin(), surfacesVisited.end(), [surf](const auto& other) { return surf == other; }) == surfacesVisited.end()) {
         surfacesVisited.emplace_back(surf);
         auto subsurface = ((CSubsurfaceRole*)m_parent->m_role.get())->m_subsurface.lock();
         surf            = subsurface->m_parent.lock();

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -255,7 +255,7 @@ EGLDeviceEXT CHyprOpenGLImpl::eglDeviceFromDRMFD(int drmFD) {
 CHyprOpenGLImpl::CHyprOpenGLImpl() : m_drmFD(g_pCompositor->m_drmFD) {
     const std::string EGLEXTENSIONS = (const char*)eglQueryString(EGL_NO_DISPLAY, EGL_EXTENSIONS);
 
-    Debug::log(LOG, "Supported EGL extensions: ({}) {}", std::ranges::count(EGLEXTENSIONS, ' '), EGLEXTENSIONS);
+    Debug::log(LOG, "Supported EGL extensions: ({}) {}", std::count(EGLEXTENSIONS.begin(), EGLEXTENSIONS.end(), ' '), EGLEXTENSIONS);
 
     m_exts.KHR_display_reference = EGLEXTENSIONS.contains("KHR_display_reference");
 
@@ -331,7 +331,7 @@ CHyprOpenGLImpl::CHyprOpenGLImpl() : m_drmFD(g_pCompositor->m_drmFD) {
     Debug::log(LOG, "Using: {}", (char*)glGetString(GL_VERSION));
     Debug::log(LOG, "Vendor: {}", (char*)glGetString(GL_VENDOR));
     Debug::log(LOG, "Renderer: {}", (char*)glGetString(GL_RENDERER));
-    Debug::log(LOG, "Supported extensions: ({}) {}", std::ranges::count(m_extensions, ' '), m_extensions);
+    Debug::log(LOG, "Supported extensions: ({}) {}", std::count(m_extensions.begin(), m_extensions.end(), ' '), m_extensions);
 
     m_exts.EXT_read_format_bgra = m_extensions.contains("GL_EXT_read_format_bgra");
 
@@ -415,7 +415,7 @@ std::optional<std::vector<uint64_t>> CHyprOpenGLImpl::getModsForFormat(EGLint fo
     }
 
     // if the driver doesn't mark linear as external, add it. It's allowed unless the driver says otherwise. (e.g. nvidia)
-    if (!linearIsExternal && std::ranges::find(mods, DRM_FORMAT_MOD_LINEAR) == mods.end() && mods.size() == 0)
+    if (!linearIsExternal && std::find(mods.begin(), mods.end(), DRM_FORMAT_MOD_LINEAR) == mods.end() && mods.size() == 0)
         mods.push_back(DRM_FORMAT_MOD_LINEAR);
 
     return result;
@@ -490,7 +490,7 @@ void CHyprOpenGLImpl::initDRMFormats() {
         free(fmtName);
 
         mods.clear();
-        std::ranges::sort(modifierData, [](const auto& a, const auto& b) {
+        std::sort(modifierData.begin(), modifierData.end(), [](const auto& a, const auto& b) {
             if (a.first == 0)
                 return false;
             if (a.second.contains("DCC"))

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -59,7 +59,7 @@ CHyprRenderer::CHyprRenderer() {
             if (!DRMV)
                 continue;
             std::string name = std::string{DRMV->name, DRMV->name_len};
-            std::ranges::transform(name, name.begin(), tolower);
+            std::transform(name.begin(), name.end(), name.begin(), tolower);
 
             if (name.contains("nvidia"))
                 m_nvidia = true;
@@ -76,7 +76,7 @@ CHyprRenderer::CHyprRenderer() {
 
         if (DRMV) {
             std::string name = std::string{DRMV->name, DRMV->name_len};
-            std::ranges::transform(name, name.begin(), tolower);
+            std::transform(name.begin(), name.end(), name.begin(), tolower);
 
             if (name.contains("nvidia"))
                 m_nvidia = true;
@@ -1794,7 +1794,7 @@ void CHyprRenderer::arrangeLayersForMonitor(const MONITORID& monitor) {
     }
 
     for (auto& la : PMONITOR->m_layerSurfaceLayers) {
-        std::ranges::stable_sort(la, [](const PHLLSREF& a, const PHLLSREF& b) { return a->m_order > b->m_order; });
+        std::stable_sort(la.begin(), la.end(), [](const PHLLSREF& a, const PHLLSREF& b) { return a->m_order > b->m_order; });
     }
 
     for (auto const& la : PMONITOR->m_layerSurfaceLayers)
@@ -2171,7 +2171,7 @@ void CHyprRenderer::recheckSolitaryForMonitor(PHLMONITOR pMonitor) {
 }
 
 SP<CRenderbuffer> CHyprRenderer::getOrCreateRenderbuffer(SP<Aquamarine::IBuffer> buffer, uint32_t fmt) {
-    auto it = std::ranges::find_if(m_renderbuffers, [&](const auto& other) { return other->m_hlBuffer == buffer; });
+    auto it = std::find_if(m_renderbuffers.begin(), m_renderbuffers.end(), [&](const auto& other) { return other->m_hlBuffer == buffer; });
 
     if (it != m_renderbuffers.end())
         return *it;
@@ -2364,7 +2364,7 @@ SExplicitSyncSettings CHyprRenderer::getExplicitSyncSettings(SP<Aquamarine::IOut
 void CHyprRenderer::addWindowToRenderUnfocused(PHLWINDOW window) {
     static auto PFPS = CConfigValue<Hyprlang::INT>("misc:render_unfocused_fps");
 
-    if (std::ranges::find(m_renderUnfocused, window) != m_renderUnfocused.end())
+    if (std::find(m_renderUnfocused.begin(), m_renderUnfocused.end(), window) != m_renderUnfocused.end())
         return;
 
     m_renderUnfocused.emplace_back(window);

--- a/src/render/decorations/DecorationPositioner.cpp
+++ b/src/render/decorations/DecorationPositioner.cpp
@@ -59,7 +59,7 @@ Vector2D CDecorationPositioner::getEdgeDefinedPoint(uint32_t edges, PHLWINDOW pW
 void CDecorationPositioner::uncacheDecoration(IHyprWindowDecoration* deco) {
     std::erase_if(m_windowPositioningDatas, [&](const auto& data) { return !data->pWindow.lock() || data->pDecoration == deco; });
 
-    const auto WIT = std::ranges::find_if(m_windowDatas, [&](const auto& other) { return other.first.lock() == deco->m_window.lock(); });
+    const auto WIT = std::find_if(m_windowDatas.begin(), m_windowDatas.end(), [&](const auto& other) { return other.first.lock() == deco->m_window.lock(); });
     if (WIT == m_windowDatas.end())
         return;
 
@@ -72,7 +72,7 @@ void CDecorationPositioner::repositionDeco(IHyprWindowDecoration* deco) {
 }
 
 CDecorationPositioner::SWindowPositioningData* CDecorationPositioner::getDataFor(IHyprWindowDecoration* pDecoration, PHLWINDOW pWindow) {
-    auto it = std::ranges::find_if(m_windowPositioningDatas, [&](const auto& el) { return el->pDecoration == pDecoration; });
+    auto it = std::find_if(m_windowPositioningDatas.begin(), m_windowPositioningDatas.end(), [&](const auto& el) { return el->pDecoration == pDecoration; });
 
     if (it != m_windowPositioningDatas.end())
         return it->get();
@@ -89,14 +89,15 @@ void CDecorationPositioner::sanitizeDatas() {
     std::erase_if(m_windowPositioningDatas, [](const auto& other) {
         if (!validMapped(other->pWindow))
             return true;
-        if (std::ranges::find_if(other->pWindow->m_windowDecorations, [&](const auto& el) { return el.get() == other->pDecoration; }) == other->pWindow->m_windowDecorations.end())
+        if (std::find_if(other->pWindow->m_windowDecorations.begin(), other->pWindow->m_windowDecorations.end(), [&](const auto& el) { return el.get() == other->pDecoration; }) ==
+            other->pWindow->m_windowDecorations.end())
             return true;
         return false;
     });
 }
 
 void CDecorationPositioner::forceRecalcFor(PHLWINDOW pWindow) {
-    const auto WIT = std::ranges::find_if(m_windowDatas, [&](const auto& other) { return other.first.lock() == pWindow; });
+    const auto WIT = std::find_if(m_windowDatas.begin(), m_windowDatas.end(), [&](const auto& other) { return other.first.lock() == pWindow; });
     if (WIT == m_windowDatas.end())
         return;
 
@@ -109,7 +110,7 @@ void CDecorationPositioner::onWindowUpdate(PHLWINDOW pWindow) {
     if (!validMapped(pWindow))
         return;
 
-    const auto WIT = std::ranges::find_if(m_windowDatas, [&](const auto& other) { return other.first.lock() == pWindow; });
+    const auto WIT = std::find_if(m_windowDatas.begin(), m_windowDatas.end(), [&](const auto& other) { return other.first.lock() == pWindow; });
     if (WIT == m_windowDatas.end())
         return;
 
@@ -127,7 +128,8 @@ void CDecorationPositioner::onWindowUpdate(PHLWINDOW pWindow) {
     }
 
     if (WINDOWDATA->lastWindowSize == pWindow->m_realSize->value() /* position not changed */
-        && std::ranges::all_of(m_windowPositioningDatas, [pWindow](const auto& data) { return pWindow != data->pWindow.lock() || !data->needsReposition; })
+        && std::all_of(m_windowPositioningDatas.begin(), m_windowPositioningDatas.end(),
+                       [pWindow](const auto& data) { return pWindow != data->pWindow.lock() || !data->needsReposition; })
         /* all window datas are either not for this window or don't need a reposition */
         && !WINDOWDATA->needsRecalc /* window doesn't need recalc */
     )
@@ -141,7 +143,7 @@ void CDecorationPositioner::onWindowUpdate(PHLWINDOW pWindow) {
     WINDOWDATA->needsRecalc    = false;
     const bool EPHEMERAL       = pWindow->m_realSize->isBeingAnimated();
 
-    std::ranges::sort(datas, [](const auto& a, const auto& b) { return a->positioningInfo.priority > b->positioningInfo.priority; });
+    std::sort(datas.begin(), datas.end(), [](const auto& a, const auto& b) { return a->positioningInfo.priority > b->positioningInfo.priority; });
 
     CBox wb = pWindow->getWindowMainSurfaceBox();
 

--- a/src/render/pass/Pass.cpp
+++ b/src/render/pass/Pass.cpp
@@ -259,7 +259,7 @@ void CRenderPass::renderDebugData() {
         }
     }
 
-    const auto DISCARDED_ELEMENTS = std::ranges::count_if(m_passElements, [](const auto& e) { return e->discard; });
+    const auto DISCARDED_ELEMENTS = std::count_if(m_passElements.begin(), m_passElements.end(), [](const auto& e) { return e->discard; });
     auto tex = g_pHyprOpenGL->renderText(std::format("occlusion layers: {}\npass elements: {} ({} discarded)\nviewport: {:X0}", m_occludedRegions.size(), m_passElements.size(),
                                                      DISCARDED_ELEMENTS, g_pHyprOpenGL->m_renderData.pMonitor->m_pixelSize),
                                          Colors::WHITE, 12);

--- a/src/xwayland/XSurface.cpp
+++ b/src/xwayland/XSurface.cpp
@@ -214,7 +214,7 @@ void CXWaylandSurface::restackToTop() {
     xcb_configure_window(g_pXWayland->m_wm->m_connection, m_xID, XCB_CONFIG_WINDOW_STACK_MODE, values);
 
     auto& stack = g_pXWayland->m_wm->m_mappedSurfacesStacking;
-    auto  it    = std::ranges::find(stack, m_self);
+    auto  it    = std::find(stack.begin(), stack.end(), m_self);
 
     if (it != stack.end())
         std::rotate(it, it + 1, stack.end());

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -164,7 +164,7 @@ static bool lookupParentExists(SP<CXWaylandSurface> XSURF, SP<CXWaylandSurface> 
 
         XSURF = XSURF->m_parent.lock();
 
-        if (std::ranges::find(visited, XSURF) != visited.end())
+        if (std::find(visited.begin(), visited.end(), XSURF) != visited.end())
             return false;
     }
 
@@ -202,7 +202,7 @@ void CXWM::readProp(SP<CXWaylandSurface> XSURF, uint32_t atom, xcb_get_property_
         size_t len           = xcb_get_property_value_length(reply);
         char*  string        = (char*)xcb_get_property_value(reply);
         XSURF->m_state.appid = std::string{string, len};
-        if (std::ranges::count(XSURF->m_state.appid, '\000') == 2)
+        if (std::count(XSURF->m_state.appid.begin(), XSURF->m_state.appid.end(), '\000') == 2)
             XSURF->m_state.appid = XSURF->m_state.appid.substr(XSURF->m_state.appid.find_first_of('\000') + 1); // fuck you X
         if (!XSURF->m_state.appid.empty())
             XSURF->m_state.appid.pop_back();
@@ -1109,7 +1109,7 @@ void CXWM::associate(SP<CXWaylandSurface> surf, SP<CWLSurfaceResource> wlSurf) {
     if (surf->m_surface)
         return;
 
-    auto existing = std::ranges::find_if(m_surfaces, [wlSurf](const auto& e) { return e->m_surface == wlSurf; });
+    auto existing = std::find_if(m_surfaces.begin(), m_surfaces.end(), [wlSurf](const auto& e) { return e->m_surface == wlSurf; });
 
     if (existing != m_surfaces.end()) {
         Debug::log(WARN, "[xwm] associate() called but surface is already associated to {:x}, ignoring...", (uintptr_t)surf.get());
@@ -1420,7 +1420,7 @@ bool SXSelection::sendData(xcb_selection_request_event_t* e, std::string mime) {
     if (MIMES.empty())
         return false;
 
-    if (std::ranges::find(MIMES, mime) == MIMES.end()) {
+    if (std::find(MIMES.begin(), MIMES.end(), mime) == MIMES.end()) {
         Debug::log(ERR, "[xwm] X Client asked for an invalid MIME, sending the first advertised. THIS SHIT MAY BREAK!");
         mime = *MIMES.begin();
     }


### PR DESCRIPTION
Reverts hyprwm/Hyprland#10584

What was it merged?  It didn't even pass CI

Either roll back  [this](https://github.com/hyprwm/Hyprland/commit/9190443d951c21ab24201d033accf90b4d172f46#diff-4e1d4134b02a69e00c2481018960bca9e1f5c71bac62fe285b4f30fce402530aR49) change, or correct its work