### PR TITLE
nix: use gcc15

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -276,11 +276,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748026106,
-        "narHash": "sha256-6m1Y3/4pVw1RWTsrkAK2VMYSzG4MMIj7sqUy7o8th1o=",
+        "lastModified": 1748460289,
+        "narHash": "sha256-7doLyJBzCllvqX4gszYtmZUToxKvMUrg45EUWaUYmBg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "063f43f2dbdef86376cc29ad646c45c46e93234c",
+        "rev": "96ec055edbe5ee227f28cdbc3f1ddf1df5965102",
         "type": "github"
       },
       "original": {

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -35,7 +35,7 @@ in {
       date = mkDate (self.lastModifiedDate or "19700101");
     in {
       hyprland = final.callPackage ./default.nix {
-        stdenv = final.gcc14Stdenv;
+        stdenv = final.gcc15Stdenv;
         version = "${version}+date=${date}_${self.shortRev or "dirty"}";
         commit = self.rev or "";
         revCount = self.sourceInfo.revCount or "";


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
As an alternative to the revert PR (#10591), instead we can replace the use of `gcc14Stdenv` with `gcc15Stdenv` to use the features required to compile 9190443

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
The `nixpkgs` input needed to be updated as gcc15 was not available.

#### Is it ready for merging, or does it need work?
Yes