### PR TITLE
Refactor: Always use `empty()` to check for emptiness.

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -100,7 +100,7 @@ static Hyprlang::CParseResult configHandleGradientSet(const char* VALUE, void** 
         }
     }
 
-    if (DATA->m_colors.size() == 0) {
+    if (DATA->m_colors.empty()) {
         Debug::log(WARN, "Error parsing gradient {}", V);
         if (parseError.empty())
             parseError = "Error parsing gradient " + V + ": No colors?";
@@ -2093,7 +2093,7 @@ std::optional<std::string> CConfigManager::handleMonitor(const std::string& comm
 
     int argno = 4;
 
-    while (ARGS[argno] != "") {
+    while (!ARGS[argno].empty()) {
         if (ARGS[argno] == "mirror") {
             newrule.mirrorOf = ARGS[argno + 1];
             argno++;
@@ -2185,23 +2185,23 @@ std::optional<std::string> CConfigManager::handleBezier(const std::string& comma
 
     std::string bezierName = ARGS[0];
 
-    if (ARGS[1] == "")
+    if (ARGS[1].empty())
         return "too few arguments";
     float p1x = std::stof(ARGS[1]);
 
-    if (ARGS[2] == "")
+    if (ARGS[2].empty())
         return "too few arguments";
     float p1y = std::stof(ARGS[2]);
 
-    if (ARGS[3] == "")
+    if (ARGS[3].empty())
         return "too few arguments";
     float p2x = std::stof(ARGS[3]);
 
-    if (ARGS[4] == "")
+    if (ARGS[4].empty())
         return "too few arguments";
     float p2y = std::stof(ARGS[4]);
 
-    if (ARGS[5] != "")
+    if (!ARGS[5].empty())
         return "too many arguments";
 
     g_pAnimationManager->addBezierWithName(bezierName, Vector2D(p1x, p1y), Vector2D(p2x, p2y));
@@ -2256,10 +2256,10 @@ std::optional<std::string> CConfigManager::handleAnimation(const std::string& co
         return "no such bezier";
     }
 
-    if (ARGS[4] != "") {
+    if (!ARGS[4].empty()) {
         auto ERR = g_pAnimationManager->styleValidInConfigVar(ANIMNAME, ARGS[4]);
 
-        if (ERR != "")
+        if (!ERR.empty())
             return ERR;
     }
 
@@ -2384,12 +2384,12 @@ std::optional<std::string> CConfigManager::handleBind(const std::string& command
         return "Invalid dispatcher, requested \"" + HANDLER + "\" does not exist";
     }
 
-    if (MOD == 0 && MODSTR != "") {
+    if (MOD == 0 && !MODSTR.empty()) {
         Debug::log(ERR, "Invalid mod: {}", MODSTR);
         return "Invalid mod, requested mod \"" + MODSTR + "\" is not a valid mod.";
     }
 
-    if ((KEY != "") || multiKey) {
+    if ((!KEY.empty()) || multiKey) {
         SParsedKey parsedKey = parseKey(KEY);
 
         if (parsedKey.catchAll && m_currentSubmap.empty()) {

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -516,7 +516,7 @@ static std::string layersRequest(eHyprCtlOutputFormat format, std::string reques
 
                 trimTrailingComma(result);
 
-                if (level.size() > 0)
+                if (!level.empty())
                     result += "\n        ";
 
                 result += "],";
@@ -1144,7 +1144,7 @@ static std::string dispatchKeyword(eHyprCtlOutputFormat format, std::string in) 
 
     Debug::log(LOG, "Hyprctl: keyword {} : {}", COMMAND, VALUE);
 
-    if (retval == "")
+    if (retval.empty())
         return "ok";
 
     return retval;
@@ -1528,7 +1528,7 @@ static std::string dispatchPlugin(eHyprCtlOutputFormat format, std::string reque
         if (format == eHyprCtlOutputFormat::FORMAT_JSON) {
             result += "[";
 
-            if (PLUGINS.size() == 0)
+            if (PLUGINS.empty())
                 return "[]";
 
             for (auto const& p : PLUGINS) {
@@ -1546,7 +1546,7 @@ static std::string dispatchPlugin(eHyprCtlOutputFormat format, std::string reque
             trimTrailingComma(result);
             result += "]";
         } else {
-            if (PLUGINS.size() == 0)
+            if (PLUGINS.empty())
                 return "no plugins loaded";
 
             for (auto const& p : PLUGINS) {

--- a/src/debug/HyprDebugOverlay.cpp
+++ b/src/debug/HyprDebugOverlay.cpp
@@ -83,7 +83,7 @@ int CHyprMonitorDebugOverlay::draw(int offset) {
         avgFrametime += ft;
     }
     float varFrametime = maxFrametime - minFrametime;
-    avgFrametime /= m_lastFrametimes.size() == 0 ? 1 : m_lastFrametimes.size();
+    avgFrametime /= m_lastFrametimes.empty() ? 1 : m_lastFrametimes.size();
 
     float avgRenderTime = 0;
     float maxRenderTime = 0;
@@ -96,7 +96,7 @@ int CHyprMonitorDebugOverlay::draw(int offset) {
         avgRenderTime += rt;
     }
     float varRenderTime = maxRenderTime - minRenderTime;
-    avgRenderTime /= m_lastRenderTimes.size() == 0 ? 1 : m_lastRenderTimes.size();
+    avgRenderTime /= m_lastRenderTimes.empty() ? 1 : m_lastRenderTimes.size();
 
     float avgRenderTimeNoOverlay = 0;
     float maxRenderTimeNoOverlay = 0;
@@ -109,7 +109,7 @@ int CHyprMonitorDebugOverlay::draw(int offset) {
         avgRenderTimeNoOverlay += rt;
     }
     float varRenderTimeNoOverlay = maxRenderTimeNoOverlay - minRenderTimeNoOverlay;
-    avgRenderTimeNoOverlay /= m_lastRenderTimes.size() == 0 ? 1 : m_lastRenderTimes.size();
+    avgRenderTimeNoOverlay /= m_lastRenderTimes.empty() ? 1 : m_lastRenderTimes.size();
 
     float avgAnimMgrTick = 0;
     float maxAnimMgrTick = 0;
@@ -122,7 +122,7 @@ int CHyprMonitorDebugOverlay::draw(int offset) {
         avgAnimMgrTick += at;
     }
     float varAnimMgrTick = maxAnimMgrTick - minAnimMgrTick;
-    avgAnimMgrTick /= m_lastAnimationTicks.size() == 0 ? 1 : m_lastAnimationTicks.size();
+    avgAnimMgrTick /= m_lastAnimationTicks.empty() ? 1 : m_lastAnimationTicks.size();
 
     const float           FPS      = 1.f / (avgFrametime / 1000.f); // frametimes are in ms
     const float           idealFPS = m_lastFrametimes.size();

--- a/src/debug/HyprNotificationOverlay.cpp
+++ b/src/debug/HyprNotificationOverlay.cpp
@@ -23,7 +23,7 @@ static inline auto iconBackendFromLayout(PangoLayout* layout) {
 
 CHyprNotificationOverlay::CHyprNotificationOverlay() {
     static auto P = g_pHookSystem->hookDynamic("focusedMon", [&](void* self, SCallbackInfo& info, std::any param) {
-        if (m_notifications.size() == 0)
+        if (m_notifications.empty())
             return;
 
         g_pHyprRenderer->damageBox(m_lastDamage);
@@ -210,7 +210,7 @@ void CHyprNotificationOverlay::draw(PHLMONITOR pMonitor) {
     }
 
     // Draw the notifications
-    if (m_notifications.size() == 0)
+    if (m_notifications.empty())
         return;
 
     // Render to the monitor

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1624,13 +1624,13 @@ PHLWINDOW CWindow::getSwallower() {
     if (!(*PSWALLOWREGEX).empty())
         std::erase_if(candidates, [&](const auto& other) { return !RE2::FullMatch(other->m_class, *PSWALLOWREGEX); });
 
-    if (candidates.size() == 0)
+    if (candidates.empty())
         return nullptr;
 
     if (!(*PSWALLOWEXREGEX).empty())
         std::erase_if(candidates, [&](const auto& other) { return RE2::FullMatch(other->m_title, *PSWALLOWEXREGEX); });
 
-    if (candidates.size() == 0)
+    if (candidates.empty())
         return nullptr;
 
     if (candidates.size() == 1)

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -418,8 +418,8 @@ void Events::listener_mapWindow(void* owner, void* data) {
         PWINDOW->m_swallowed->m_currentlySwallowed = true;
 
     // emit the IPC event before the layout might focus the window to avoid a focus event first
-    g_pEventManager->postEvent(
-        SHyprIPCEvent{"openwindow", std::format("{:x},{},{},{}", PWINDOW, requestedWorkspace != "" ? requestedWorkspace : PWORKSPACE->m_name, PWINDOW->m_class, PWINDOW->m_title)});
+    g_pEventManager->postEvent(SHyprIPCEvent{
+        "openwindow", std::format("{:x},{},{},{}", PWINDOW, !requestedWorkspace.empty() ? requestedWorkspace : PWORKSPACE->m_name, PWINDOW->m_class, PWINDOW->m_title)});
 
     if (PWINDOW->m_isFloating) {
         g_pLayoutManager->getCurrentLayout()->onWindowCreated(PWINDOW);

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -326,7 +326,7 @@ SWorkspaceIDName getWorkspaceIDNameFromString(const std::string& in) {
                         finalWSID = curID;
                     }
                     if (finalWSID <= 0 || invalidWSes.contains(finalWSID)) {
-                        if (namedWSes.size()) {
+                        if (!namedWSes.empty()) {
                             // Go to the named workspaces
                             // Need remainingWSes more
                             auto namedWSIdx = namedWSes.size() - remainingWSes;

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -988,7 +988,7 @@ void CMonitor::setupDefaultWS(const SMonitorRule& monitorRule) {
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m_id);
         PNEWWORKSPACE->startAnim(true, true, true);
     } else {
-        if (newDefaultWorkspaceName == "")
+        if (newDefaultWorkspaceName.empty())
             newDefaultWorkspaceName = std::to_string(wsID);
 
         PNEWWORKSPACE = g_pCompositor->m_workspaces.emplace_back(CWorkspace::create(wsID, m_self.lock(), newDefaultWorkspaceName));

--- a/src/hyprerror/HyprError.cpp
+++ b/src/hyprerror/HyprError.cpp
@@ -165,8 +165,8 @@ void CHyprError::createQueued() {
 }
 
 void CHyprError::draw() {
-    if (!m_isCreated || m_queued != "") {
-        if (m_queued != "")
+    if (!m_isCreated || !m_queued.empty()) {
+        if (!m_queued.empty())
             createQueued();
         return;
     }

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -1359,7 +1359,7 @@ void CHyprMasterLayout::runOrientationCycle(SLayoutMessageHeader& header, CVarLi
     if (vars != nullptr)
         buildOrientationCycleVectorFromVars(cycle, *vars);
 
-    if (cycle.size() == 0)
+    if (cycle.empty())
         buildOrientationCycleVectorFromEOperation(cycle);
 
     const auto PWINDOW = header.pWindow;

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -306,7 +306,7 @@ void CHyprAnimationManager::animationSlide(PHLWINDOW pWindow, std::string force,
 
     Vector2D posOffset;
 
-    if (force != "") {
+    if (!force.empty()) {
         if (force == "bottom")
             posOffset = Vector2D(GOALPOS.x, PMONITOR->m_position.y + PMONITOR->m_size.y);
         else if (force == "left")
@@ -490,7 +490,7 @@ std::string CHyprAnimationManager::styleValidInConfigVar(const std::string& conf
             return "";
         return "unknown style";
     } else if (config.starts_with("layers")) {
-        if (style == "fade" || style == "" || style == "slide")
+        if (style.empty() || style == "fade" || style == "slide")
             return "";
         else if (style.starts_with("popin")) {
             // try parsing

--- a/src/managers/CursorManager.cpp
+++ b/src/managers/CursorManager.cpp
@@ -183,7 +183,7 @@ void CCursorManager::setCursorFromName(const std::string& name) {
     auto setHyprCursor = [this](auto const& name) {
         m_currentCursorShapeData = m_hyprcursor->getShape(name.c_str(), m_currentStyleInfo);
 
-        if (m_currentCursorShapeData.images.size() < 1) {
+        if (m_currentCursorShapeData.images.empty()) {
             // try with '_' first (old hc, etc)
             std::string newName = name;
             std::ranges::replace(newName, '-', '_');
@@ -191,18 +191,18 @@ void CCursorManager::setCursorFromName(const std::string& name) {
             m_currentCursorShapeData = m_hyprcursor->getShape(newName.c_str(), m_currentStyleInfo);
         }
 
-        if (m_currentCursorShapeData.images.size() < 1) {
+        if (m_currentCursorShapeData.images.empty()) {
             // fallback to a default if available
             constexpr const std::array<const char*, 3> fallbackShapes = {"default", "left_ptr", "left-ptr"};
 
             for (auto const& s : fallbackShapes) {
                 m_currentCursorShapeData = m_hyprcursor->getShape(s, m_currentStyleInfo);
 
-                if (m_currentCursorShapeData.images.size() > 0)
+                if (!m_currentCursorShapeData.images.empty())
                     break;
             }
 
-            if (m_currentCursorShapeData.images.size() < 1) {
+            if (m_currentCursorShapeData.images.empty()) {
                 Debug::log(ERR, "BUG THIS: No fallback found for a cursor in setCursorFromName");
                 return false;
             }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -164,7 +164,7 @@ CKeybindManager::CKeybindManager() {
     m_repeatKeyTimer = makeShared<CEventLoopTimer>(
         std::nullopt,
         [this](SP<CEventLoopTimer> self, void* data) {
-            if (m_activeKeybinds.size() == 0 || g_pSeatManager->m_keyboard.expired())
+            if (m_activeKeybinds.empty() || g_pSeatManager->m_keyboard.expired())
                 return;
 
             const auto PACTIVEKEEB = g_pSeatManager->m_keyboard.lock();
@@ -288,7 +288,7 @@ void CKeybindManager::updateXKBTranslationState() {
 
     xkb_rule_names    rules      = {.rules = RULES.c_str(), .model = MODEL.c_str(), .layout = LAYOUT.c_str(), .variant = VARIANT.c_str(), .options = OPTIONS.c_str()};
     const auto        PCONTEXT   = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
-    FILE* const       KEYMAPFILE = FILEPATH == "" ? nullptr : fopen(absolutePath(FILEPATH, g_pConfigManager->m_configCurrentPath).c_str(), "r");
+    FILE* const       KEYMAPFILE = FILEPATH.empty() ? nullptr : fopen(absolutePath(FILEPATH, g_pConfigManager->m_configCurrentPath).c_str(), "r");
 
     auto              PKEYMAP = KEYMAPFILE ? xkb_keymap_new_from_file(PCONTEXT, KEYMAPFILE, XKB_KEYMAP_FORMAT_TEXT_V1, XKB_KEYMAP_COMPILE_NO_FLAGS) :
                                              xkb_keymap_new_from_names(PCONTEXT, &rules, XKB_KEYMAP_COMPILE_NO_FLAGS);
@@ -630,7 +630,7 @@ eMultiKeyCase CKeybindManager::mkKeysymSetMatches(const std::set<xkb_keysym_t> k
     if (boundKeysNotPressed.empty() && pressedKeysNotBound.empty())
         return MK_FULL_MATCH;
 
-    if (boundKeysNotPressed.size() && pressedKeysNotBound.empty())
+    if (!boundKeysNotPressed.empty() && pressedKeysNotBound.empty())
         return MK_PARTIAL_MATCH;
 
     return MK_NO_MATCH;
@@ -2398,7 +2398,7 @@ SDispatchResult CKeybindManager::toggleSwallow(std::string args) {
 }
 
 SDispatchResult CKeybindManager::setSubmap(std::string submap) {
-    if (submap == "reset" || submap == "") {
+    if (submap == "reset" || submap.empty()) {
         m_currentSelectedSubmap = "";
         Debug::log(LOG, "Reset active submap to the default one.");
         g_pEventManager->postEvent(SHyprIPCEvent{"submap", ""});
@@ -2576,7 +2576,7 @@ SDispatchResult CKeybindManager::sendshortcut(std::string args) {
 
     //if regexp is not empty, send shortcut to current window
     //else, dont change focus
-    if (regexp != "") {
+    if (!regexp.empty()) {
         PWINDOW = g_pCompositor->getWindowByRegex(regexp);
 
         if (!PWINDOW) {

--- a/src/managers/ProtocolManager.cpp
+++ b/src/managers/ProtocolManager.cpp
@@ -209,7 +209,7 @@ CProtocolManager::CProtocolManager() {
         break;
     }
 
-    if (g_pHyprOpenGL->getDRMFormats().size() > 0) {
+    if (!g_pHyprOpenGL->getDRMFormats().empty()) {
         PROTO::mesaDRM  = makeUnique<CMesaDRMProtocol>(&wl_drm_interface, 2, "MesaDRM");
         PROTO::linuxDma = makeUnique<CLinuxDMABufV1Protocol>(&zwp_linux_dmabuf_v1_interface, 5, "LinuxDMABUF");
     } else

--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -493,7 +493,7 @@ void CSeatManager::refocusGrab() {
     if (!m_seatGrab)
         return;
 
-    if (m_seatGrab->m_surfs.size() > 0) {
+    if (!m_seatGrab->m_surfs.empty()) {
         // try to find a surf in focus first
         const auto MOUSE = g_pInputManager->getMouseCoordsInternal();
         for (auto const& s : m_seatGrab->m_surfs) {

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1082,7 +1082,7 @@ void CInputManager::applyConfigToKeyboard(SP<IKeyboard> pKeyboard) {
         pKeyboard->m_allowed = PERM == PERMISSION_RULE_ALLOW_MODE_ALLOW;
 
     try {
-        if (NUMLOCKON == pKeyboard->m_numlockOn && REPEATDELAY == pKeyboard->m_repeatDelay && REPEATRATE == pKeyboard->m_repeatRate && RULES != "" &&
+        if (NUMLOCKON == pKeyboard->m_numlockOn && REPEATDELAY == pKeyboard->m_repeatDelay && REPEATRATE == pKeyboard->m_repeatRate && !RULES.empty() &&
             RULES == pKeyboard->m_currentRules.rules && MODEL == pKeyboard->m_currentRules.model && LAYOUT == pKeyboard->m_currentRules.layout &&
             VARIANT == pKeyboard->m_currentRules.variant && OPTIONS == pKeyboard->m_currentRules.options && FILEPATH == pKeyboard->m_xkbFilePath) {
             Debug::log(LOG, "Not applying config to keyboard, it did not change.");
@@ -1205,7 +1205,7 @@ void CInputManager::setPointerConfigs() {
                     libinput_device_config_middle_emulation_set_enabled(LIBINPUTDEV, LIBINPUT_CONFIG_MIDDLE_EMULATION_DISABLED);
 
                 const auto TAP_MAP = g_pConfigManager->getDeviceString(devname, "tap_button_map", "input:touchpad:tap_button_map");
-                if (TAP_MAP == "" || TAP_MAP == "lrm")
+                if (TAP_MAP.empty() || TAP_MAP == "lrm")
                     libinput_device_config_tap_set_button_map(LIBINPUTDEV, LIBINPUT_CONFIG_TAP_MAP_LRM);
                 else if (TAP_MAP == "lmr")
                     libinput_device_config_tap_set_button_map(LIBINPUTDEV, LIBINPUT_CONFIG_TAP_MAP_LMR);
@@ -1214,7 +1214,7 @@ void CInputManager::setPointerConfigs() {
             }
 
             const auto SCROLLMETHOD = g_pConfigManager->getDeviceString(devname, "scroll_method", "input:scroll_method");
-            if (SCROLLMETHOD == "") {
+            if (SCROLLMETHOD.empty()) {
                 libinput_device_config_scroll_set_method(LIBINPUTDEV, libinput_device_config_scroll_get_default_method(LIBINPUTDEV));
             } else if (SCROLLMETHOD == "no_scroll") {
                 libinput_device_config_scroll_set_method(LIBINPUTDEV, LIBINPUT_CONFIG_SCROLL_NO_SCROLL);
@@ -1330,7 +1330,7 @@ void CInputManager::destroyKeyboard(SP<IKeyboard> pKeyboard) {
 
     std::erase_if(m_keyboards, [pKeyboard](const auto& other) { return other == pKeyboard; });
 
-    if (m_keyboards.size() > 0) {
+    if (!m_keyboards.empty()) {
         bool found = false;
         for (auto const& k : m_keyboards | std::views::reverse) {
             if (!k)
@@ -1354,7 +1354,7 @@ void CInputManager::destroyPointer(SP<IPointer> mouse) {
 
     std::erase_if(m_pointers, [mouse](const auto& other) { return other == mouse; });
 
-    g_pSeatManager->setMouse(m_pointers.size() > 0 ? m_pointers.front() : nullptr);
+    g_pSeatManager->setMouse(!m_pointers.empty() ? m_pointers.front() : nullptr);
 
     if (!g_pSeatManager->m_mouse.expired())
         unconstrainMouse();

--- a/src/plugins/HookSystem.cpp
+++ b/src/plugins/HookSystem.cpp
@@ -167,7 +167,7 @@ bool CFunctionHook::hook() {
 
     const auto PROBEFIXEDASM = fixInstructionProbeRIPCalls(probe);
 
-    if (PROBEFIXEDASM.bytes.size() == 0) {
+    if (PROBEFIXEDASM.bytes.empty()) {
         Debug::log(ERR, "[functionhook] failed, unsupported asm / failed assembling:\n{}", probe.assembly);
         return false;
     }

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -415,7 +415,7 @@ std::optional<std::vector<uint64_t>> CHyprOpenGLImpl::getModsForFormat(EGLint fo
     }
 
     // if the driver doesn't mark linear as external, add it. It's allowed unless the driver says otherwise. (e.g. nvidia)
-    if (!linearIsExternal && std::ranges::find(mods, DRM_FORMAT_MOD_LINEAR) == mods.end() && mods.size() == 0)
+    if (!linearIsExternal && std::ranges::find(mods, DRM_FORMAT_MOD_LINEAR) == mods.end() && mods.empty())
         mods.push_back(DRM_FORMAT_MOD_LINEAR);
 
     return result;
@@ -444,7 +444,7 @@ void CHyprOpenGLImpl::initDRMFormats() {
         m_proc.eglQueryDmaBufFormatsEXT(m_eglDisplay, len, formats.data(), &len);
     }
 
-    if (formats.size() == 0) {
+    if (formats.empty()) {
         Debug::log(ERR, "EGL: Failed to get formats, DMABufs will not work.");
         return;
     }
@@ -466,7 +466,7 @@ void CHyprOpenGLImpl::initDRMFormats() {
         } else
             mods = {DRM_FORMAT_MOD_LINEAR};
 
-        m_hasModifiers = m_hasModifiers || mods.size() > 0;
+        m_hasModifiers = m_hasModifiers || !mods.empty();
 
         // EGL can always do implicit modifiers.
         mods.push_back(DRM_FORMAT_MOD_INVALID);
@@ -506,7 +506,7 @@ void CHyprOpenGLImpl::initDRMFormats() {
 
     Debug::log(LOG, "EGL: {} formats found in total. Some modifiers may be omitted as they are external-only.", dmaFormats.size());
 
-    if (dmaFormats.size() == 0)
+    if (dmaFormats.empty())
         Debug::log(WARN,
                    "EGL: WARNING: No dmabuf formats were found, dmabuf will be disabled. This will degrade performance, but is most likely a driver issue or a very old GPU.");
 
@@ -1193,7 +1193,7 @@ void CHyprOpenGLImpl::applyScreenShader(const std::string& path) {
 
     m_finalScreenShader.destroy();
 
-    if (path == "" || path == STRVAL_EMPTY)
+    if (path.empty() || path == STRVAL_EMPTY)
         return;
 
     std::ifstream infile(absolutePath(path, g_pConfigManager->getMainConfigPath()));
@@ -2362,7 +2362,7 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const CGradientValueData& gr
     glUniform4fv(m_shaders->m_shBORDER1.gradient, grad1.m_colorsOkLabA.size() / 4, (float*)grad1.m_colorsOkLabA.data());
     glUniform1i(m_shaders->m_shBORDER1.gradientLength, grad1.m_colorsOkLabA.size() / 4);
     glUniform1f(m_shaders->m_shBORDER1.angle, (int)(grad1.m_angle / (PI / 180.0)) % 360 * (PI / 180.0));
-    if (grad2.m_colorsOkLabA.size() > 0)
+    if (!grad2.m_colorsOkLabA.empty())
         glUniform4fv(m_shaders->m_shBORDER1.gradient2, grad2.m_colorsOkLabA.size() / 4, (float*)grad2.m_colorsOkLabA.data());
     glUniform1i(m_shaders->m_shBORDER1.gradient2Length, grad2.m_colorsOkLabA.size() / 4);
     glUniform1f(m_shaders->m_shBORDER1.angle2, (int)(grad2.m_angle / (PI / 180.0)) % 360 * (PI / 180.0));

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2077,7 +2077,7 @@ std::tuple<float, float, float> CHyprRenderer::getRenderTimes(PHLMONITOR pMonito
             minRenderTime = rt;
         avgRenderTime += rt;
     }
-    avgRenderTime /= POVERLAY->m_lastRenderTimes.size() == 0 ? 1 : POVERLAY->m_lastRenderTimes.size();
+    avgRenderTime /= POVERLAY->m_lastRenderTimes.empty() ? 1 : POVERLAY->m_lastRenderTimes.size();
 
     return std::make_tuple<>(avgRenderTime, maxRenderTime, minRenderTime);
 }

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -81,7 +81,7 @@ void CHyprGroupBarDecoration::updateWindow(PHLWINDOW pWindow) {
 
     damageEntire();
 
-    if (m_dwGroupMembers.size() == 0) {
+    if (m_dwGroupMembers.empty()) {
         m_window->removeWindowDeco(this);
         return;
     }


### PR DESCRIPTION
Continuing my journey of low-effort refactoring