### PR TITLE
Fix HyprError not displaying at startup

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1183,7 +1183,6 @@ bool CHyprOpenGLImpl::initShaders() {
     m_shadersInitialized = true;
 
     Debug::log(LOG, "Shaders initialized successfully.");
-    g_pHyprError->destroy();
     return true;
 }
 


### PR DESCRIPTION
Fixes `HyprError` not showing at startup - it's currently destroyed right after we load the config and queue the errors
Idk why it was even there in the first place.
Was added in https://github.com/hyprwm/Hyprland/pull/9600