### PR TITLE
screencopy: fix applying `noscreenshare` to invisible special workspaces

### DIFF
--- a/src/protocols/Screencopy.cpp
+++ b/src/protocols/Screencopy.cpp
@@ -214,9 +214,6 @@ void CScreencopyFrame::renderMon() {
         if UNLIKELY (!PWORKSPACE)
             continue;
 
-        if UNLIKELY (PWORKSPACE->m_isSpecialWorkspace && !PWORKSPACE->m_visible && !PWORKSPACE->m_alpha->isBeingAnimated())
-            continue;
-
         const auto REALPOS          = w->m_realPosition->value() + (w->m_pinned ? Vector2D{} : PWORKSPACE->m_renderOffset->value());
         const auto noScreenShareBox = CBox{REALPOS.x, REALPOS.y, std::max(w->m_realSize->value().x, 5.0), std::max(w->m_realSize->value().y, 5.0)}
                                           .scale(m_monitor->m_scale)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

The `noscreenshare` window rule is applied even if a window resides in a special workspace, and is hidden from view. This PR adds a simple check to ensure the screen is not blocked if the window is hidden, accounting for animation transparency.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This is just one scenario I encountered myself. Apart from this, and what's already mentioned in #10482, there might be other missing cases.

I'm also not well-versed in the Hyprland codebase, or otherwise a Hyprland expert, so I might be missing some catch with this approach.

#### Is it ready for merging, or does it need work?

Should be ready.