### PR TITLE
Catch filesystem exceptions while iterating RunTimeDir

### DIFF
--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -72,7 +72,14 @@ std::vector<SInstanceData> instances() {
             return {};
     } catch (std::exception& e) { return {}; }
 
-    for (const auto& el : std::filesystem::directory_iterator(getRuntimeDir())) {
+    std::filesystem::directory_iterator it;
+    try {
+        it = std::filesystem::directory_iterator(getRuntimeDir(), std::filesystem::directory_options::skip_permission_denied);
+    } catch (std::exception& e) {
+        return {};
+    }
+
+    for (const auto& el : it) {
         if (!el.is_directory() || !std::filesystem::exists(el.path().string() + "/hyprland.lock"))
             continue;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This PR wraps the `std::filesystem::directory_iterator` with a `try-catch` block to prevent runtime exceptions (e.g., permission errors or etc.) when iterating over `RunTimeDir()`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Useful in environments where Hyprctl is run as another user or in sandboxed/containerized contexts.

#### Is it ready for merging, or does it need work?
Ready.

