### PR TITLE
Improve ultrawide support for dwindle layout

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1,8 +1,6 @@
 #pragma once
 
 #include "ConfigManager.hpp"
-#include "ConfigManager.hpp"
-#include "ConfigManager.hpp"
 
 inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
 

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "ConfigManager.hpp"
+#include "ConfigManager.hpp"
+#include "ConfigManager.hpp"
 
 inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
 
@@ -1775,6 +1777,18 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .description = "if enabled, bindm movewindow will drop the window more precisely depending on where your mouse is.",
         .type        = CONFIG_OPTION_BOOL,
         .data        = SConfigOptionDescription::SBoolData{false},
+    },
+    SConfigOptionDescription{
+        .value       = "dwindle:single_window_aspect_ratio",
+        .description = "If specified, whenever only a single window os open, it will be coerced into the specified aspect ratio.  Ignored if the y-value is zero.",
+        .type        = CONFIG_OPTION_VECTOR,
+        .data        = SConfigOptionDescription::SVectorData{{0, 0}, {0, 0}, {1000., 1000.}},
+    },
+    SConfigOptionDescription{
+        .value       = "dwindle:single_window_aspect_ratio_tolerance",
+        .description = "Minimum distance for single_window_aspect_ratio to take effect, in fractions of the monitor's size.",
+        .type        = CONFIG_OPTION_FLOAT,
+        .data        = SConfigOptionDescription::SFloatData{0.1f, 0.f, 1.f},
     },
 
     /*

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1778,7 +1778,7 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
     },
     SConfigOptionDescription{
         .value       = "dwindle:single_window_aspect_ratio",
-        .description = "If specified, whenever only a single window os open, it will be coerced into the specified aspect ratio.  Ignored if the y-value is zero.",
+        .description = "If specified, whenever only a single window is open, it will be coerced into the specified aspect ratio.  Ignored if the y-value is zero.",
         .type        = CONFIG_OPTION_VECTOR,
         .data        = SConfigOptionDescription::SVectorData{{0, 0}, {0, 0}, {1000., 1000.}},
     },

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -595,6 +595,8 @@ CConfigManager::CConfigManager() {
     registerConfigVar("dwindle:smart_split", Hyprlang::INT{0});
     registerConfigVar("dwindle:smart_resizing", Hyprlang::INT{1});
     registerConfigVar("dwindle:precise_mouse_move", Hyprlang::INT{0});
+    registerConfigVar("dwindle:single_window_aspect_ratio", Hyprlang::VEC2{0, 0});
+    registerConfigVar("dwindle:single_window_aspect_ratio_tolerance", {0.1f});
 
     registerConfigVar("master:special_scale_factor", {1.f});
     registerConfigVar("master:mfact", {0.55f});

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -301,20 +301,20 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
         Vector2D   ratioPadding;
 
         if (REQUESTED_RATIO.y != 0) {
-            Vector2D defaultBoxSize = PMONITOR->m_size - PMONITOR->m_reservedTopLeft - PMONITOR->m_reservedBottomRight;
+            const Vector2D originalSize = PMONITOR->m_size - PMONITOR->m_reservedTopLeft - PMONITOR->m_reservedBottomRight;
 
-            double   requestedRatio = REQUESTED_RATIO.x / REQUESTED_RATIO.y;
-            double   monitorRatio   = defaultBoxSize.x / defaultBoxSize.y;
+            const double   requestedRatio = REQUESTED_RATIO.x / REQUESTED_RATIO.y;
+            const double   originalRatio  = originalSize.x / originalSize.y;
 
-            if (requestedRatio > monitorRatio) {
-                double padding = defaultBoxSize.y - defaultBoxSize.x / requestedRatio;
+            if (requestedRatio > originalRatio) {
+                double padding = originalSize.y - originalSize.x / requestedRatio;
 
-                if (padding / 2 > (*REQUESTED_RATIO_TOLERANCE) * defaultBoxSize.y)
+                if (padding / 2 > (*REQUESTED_RATIO_TOLERANCE) * originalSize.y)
                     ratioPadding = Vector2D{0., padding};
-            } else if (requestedRatio < monitorRatio) {
-                double padding = defaultBoxSize.x - defaultBoxSize.y * requestedRatio;
+            } else if (requestedRatio < originalRatio) {
+                double padding = originalSize.x - originalSize.y * requestedRatio;
 
-                if (padding / 2 > (*REQUESTED_RATIO_TOLERANCE) * defaultBoxSize.x)
+                if (padding / 2 > (*REQUESTED_RATIO_TOLERANCE) * originalSize.x)
                     ratioPadding = Vector2D{padding, 0.};
             }
         }
@@ -567,20 +567,20 @@ void CHyprDwindleLayout::calculateWorkspace(const PHLWORKSPACE& pWorkspace) {
         Vector2D   ratioPadding;
 
         if (REQUESTED_RATIO.y != 0) {
-            Vector2D defaultBoxSize = PMONITOR->m_size - PMONITOR->m_reservedTopLeft - PMONITOR->m_reservedBottomRight;
+            const Vector2D originalSize = PMONITOR->m_size - PMONITOR->m_reservedTopLeft - PMONITOR->m_reservedBottomRight;
 
-            double   requestedRatio = REQUESTED_RATIO.x / REQUESTED_RATIO.y;
-            double   monitorRatio   = defaultBoxSize.x / defaultBoxSize.y;
+            const double   requestedRatio = REQUESTED_RATIO.x / REQUESTED_RATIO.y;
+            const double   originalRatio  = originalSize.x / originalSize.y;
 
-            if (requestedRatio > monitorRatio) {
-                double padding = defaultBoxSize.y - defaultBoxSize.x / requestedRatio;
+            if (requestedRatio > originalRatio) {
+                double padding = originalSize.y - originalSize.x / requestedRatio;
 
-                if (padding / 2 > (*REQUESTED_RATIO_TOLERANCE) * defaultBoxSize.y)
+                if (padding / 2 > (*REQUESTED_RATIO_TOLERANCE) * originalSize.y)
                     ratioPadding = Vector2D{0., padding};
-            } else if (requestedRatio < monitorRatio) {
-                double padding = defaultBoxSize.x - defaultBoxSize.y * requestedRatio;
+            } else if (requestedRatio < originalRatio) {
+                double padding = originalSize.x - originalSize.y * requestedRatio;
 
-                if (padding / 2 > (*REQUESTED_RATIO_TOLERANCE) * defaultBoxSize.x)
+                if (padding / 2 > (*REQUESTED_RATIO_TOLERANCE) * originalSize.x)
                     ratioPadding = Vector2D{padding, 0.};
             }
         }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

The pull request adds the ability to specify an aspect ratio for the dwindle layout, to be used when only a single window exists.  

This is necessary on ultrawide monitors where you basically never want to display an application in fullscreen (except some games and movies).  Master layout works well on ultrawide, thanks to #1642, but dwindle works to poorly it's nearly unusuable in its default functionality unless you pad the main window with idle terminals or something.

To illustrate the problem, here is the ultrawide fullscreen experience, note 10% of the UI buttons are half a kilometer to the right from the rest of the UI, and you physically need to turn your head to see them.

![image](https://github.com/user-attachments/assets/574d77ae-892f-44eb-a0e3-b870138a567c)

The code adds two new configuration options

    dwindle:single_window_aspect_ratio

Defaults to [0,0]; specifies the aspect ratio to coerce single windows into when a workspace only shows one window.  If the y-axis is zero, then the code doesn't run.

    dwindle:single_window_aspect_ratio_tolerance

Default 0.1.  If the added padding on one side is smaller than this value *  the width or height of the screen, no padding is added.  This is used to avoid introducing undesired padding when using waybar and similar widgets that push the windows in a bit.  


Demo of the changed logic below, coaxing a 16:9 screen into showing a 4:3 window:

![43_screenshot](https://github.com/user-attachments/assets/adef7602-8ab3-4e83-bb99-2853c3e71cdc)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I've added the logic in two places, both onWindowCreatedTiling and calculateWorkspace.  I'm not 100% sure the first pass of logic is necessary, but from reading the code it looks like it might be even if I haven't manage to trigger any bugs when it was removed. 

It may also be desirable to be able to configure this on a per-monitor basis, as the current fix only helps if you have one regular monitor and one ultrawide, not if you have a horizontal monitor and a vertical ultrawide monitor.  Though I don't know if this is a stopper for merging the change.

It's also unclear if single_window_aspect_ratio_tolerance needs to be configurable.  Setting it to something like 0.1 does seem good enough in most use cases.  

#### Is it ready for merging, or does it need work?

I'm daily driving this code on my computer and not seeing any issues.  The design decisions above should probably be discussed though.
