### PR TITLE
fix: hyprland exiting with code 1 when there is a negative value with a comma behind it

### DIFF
--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -389,7 +389,7 @@ int main(int argc, char** argv) {
             parseArgs = false;
             continue;
         }
-        if (parseArgs && (ARGS[i][0] == '-') && !isNumber(ARGS[i], true) /* For stuff like -2 */) {
+        if (parseArgs && (ARGS[i][0] == '-') && !(isNumber(ARGS[i], true) || isNumber(ARGS[i].substr(0, ARGS[i].length() - 1), true)) /* For stuff like -2 or -2, */) {
             // parse
             if (ARGS[i] == "-j" && !fullArgs.contains("j")) {
                 fullArgs += "j";


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

As explained in [this](https://github.com/hyprwm/Hyprland/discussions/10670) discussion, hyprctl does not complete successfully if there is a comma behind a negative value.
```
hyprctl dispatch movewindowpixel -100 -100, class:firefox
```
With this pull request, it is fixed.
#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.

#### Is it ready for merging, or does it need work?
It is ready.


