### PR TITLE
Use `using` instead of `#define` to alias smart pointers

### DIFF
--- a/src/helpers/memory/Memory.hpp
+++ b/src/helpers/memory/Memory.hpp
@@ -2,9 +2,12 @@
 
 #include <hyprutils/memory/WeakPtr.hpp>
 
-//NOLINTNEXTLINE
 using namespace Hyprutils::Memory;
 
-#define SP Hyprutils::Memory::CSharedPointer
-#define WP Hyprutils::Memory::CWeakPointer
-#define UP Hyprutils::Memory::CUniquePointer
+template <typename T>
+using SP = Hyprutils::Memory::CSharedPointer<T>;
+template <typename T>
+using WP = Hyprutils::Memory::CWeakPointer<T>;
+template <typename T>
+using UP = Hyprutils::Memory::CUniquePointer<T>;
+

--- a/src/helpers/memory/Memory.hpp
+++ b/src/helpers/memory/Memory.hpp
@@ -10,4 +10,3 @@ template <typename T>
 using WP = Hyprutils::Memory::CWeakPointer<T>;
 template <typename T>
 using UP = Hyprutils::Memory::CUniquePointer<T>;
-


### PR DESCRIPTION
### Why?
Because these aliases are used everywhere, switching to `using` helps IDEs better understand what `PHLWINDOW` and similar types actually are. There may also be additional benefits.
A more thorough solution would be to eliminate all unnecessary `#define`s throughout the codebase - but I'm lazy.