### PR TITLE
add sticky option for drag_lock

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -623,9 +623,10 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
     },
     SConfigOptionDescription{
         .value       = "input:touchpad:drag_lock",
-        .description = "When enabled, lifting the finger off for a short time while dragging will not drop the dragged item.",
-        .type        = CONFIG_OPTION_BOOL,
-        .data        = SConfigOptionDescription::SBoolData{false},
+        .description = "When enabled, lifting the finger off while dragging will not drop the dragged item. 0 -> disabled, 1 -> enabled with timeout, 2 -> enabled sticky."
+                       "dragging will not drop the dragged item.",
+        .type        = CONFIG_OPTION_INT,
+        .data        = SConfigOptionDescription::SRangeData{0, 0, 2},
     },
     SConfigOptionDescription{
         .value       = "input:touchpad:tap-and-drag",

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -626,7 +626,7 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .description = "When enabled, lifting the finger off while dragging will not drop the dragged item. 0 -> disabled, 1 -> enabled with timeout, 2 -> enabled sticky."
                        "dragging will not drop the dragged item.",
         .type        = CONFIG_OPTION_INT,
-        .data        = SConfigOptionDescription::SRangeData{0, 0, 2},
+        .data        = SConfigOptionDescription::SRangeData{2, 0, 2},
     },
     SConfigOptionDescription{
         .value       = "input:touchpad:tap-and-drag",

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -652,7 +652,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("input:touchpad:middle_button_emulation", Hyprlang::INT{0});
     registerConfigVar("input:touchpad:tap-to-click", Hyprlang::INT{1});
     registerConfigVar("input:touchpad:tap-and-drag", Hyprlang::INT{1});
-    registerConfigVar("input:touchpad:drag_lock", Hyprlang::INT{0});
+    registerConfigVar("input:touchpad:drag_lock", Hyprlang::INT{2});
     registerConfigVar("input:touchpad:scroll_factor", {1.f});
     registerConfigVar("input:touchpad:flip_x", Hyprlang::INT{0});
     registerConfigVar("input:touchpad:flip_y", Hyprlang::INT{0});
@@ -775,7 +775,7 @@ CConfigManager::CConfigManager() {
     m_config->addSpecialConfigValue("device", "middle_button_emulation", Hyprlang::INT{0});
     m_config->addSpecialConfigValue("device", "tap-to-click", Hyprlang::INT{1});
     m_config->addSpecialConfigValue("device", "tap-and-drag", Hyprlang::INT{1});
-    m_config->addSpecialConfigValue("device", "drag_lock", Hyprlang::INT{0});
+    m_config->addSpecialConfigValue("device", "drag_lock", Hyprlang::INT{2});
     m_config->addSpecialConfigValue("device", "left_handed", Hyprlang::INT{0});
     m_config->addSpecialConfigValue("device", "scroll_method", {STRVAL_EMPTY});
     m_config->addSpecialConfigValue("device", "scroll_button", Hyprlang::INT{0});

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1233,10 +1233,8 @@ void CInputManager::setPointerConfigs() {
             else
                 libinput_device_config_tap_set_drag_enabled(LIBINPUTDEV, LIBINPUT_CONFIG_DRAG_ENABLED);
 
-            if (g_pConfigManager->getDeviceInt(devname, "drag_lock", "input:touchpad:drag_lock") == 0)
-                libinput_device_config_tap_set_drag_lock_enabled(LIBINPUTDEV, LIBINPUT_CONFIG_DRAG_LOCK_DISABLED);
-            else
-                libinput_device_config_tap_set_drag_lock_enabled(LIBINPUTDEV, LIBINPUT_CONFIG_DRAG_LOCK_ENABLED);
+            const auto TAP_DRAG_LOCK = static_cast<libinput_config_drag_lock_state>(g_pConfigManager->getDeviceInt(devname, "drag_lock", "input:touchpad:drag_lock"));
+            libinput_device_config_tap_set_drag_lock_enabled(LIBINPUTDEV, TAP_DRAG_LOCK);
 
             if (libinput_device_config_tap_get_finger_count(LIBINPUTDEV)) // this is for tapping (like on a laptop)
                 libinput_device_config_tap_set_enabled(LIBINPUTDEV,


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

libinput 1.27 (released nov 2024) comes with a new option for the `drag_lock` config: `ENABLED_STICKY`. this pr makes it so you can actually set that option in hyprland.

the official release docs (https://lists.freedesktop.org/archives/wayland-devel/2024-November/043860.html) recommend changing the default to `sticky`, so i did just that, but in a separate commit, so i can very easily revert it if you do not want to change the default.

<!-- #### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.) -->

#### Is it ready for merging, or does it need work?

i tested it locally and it worked fine for me, this should be ready.

hyprland-wiki pr ~~will be up in a second~~ up at https://github.com/hyprwm/hyprland-wiki/pull/1114.
