### PR TITLE
protocols: whitelist wp_color_manager_v1

### DIFF
--- a/src/managers/ProtocolManager.cpp
+++ b/src/managers/ProtocolManager.cpp
@@ -336,6 +336,7 @@ bool CProtocolManager::isGlobalPrivileged(const wl_global* global) {
         PROTO::sync     ? PROTO::sync->getGlobal()      : nullptr,
         PROTO::mesaDRM  ? PROTO::mesaDRM->getGlobal()   : nullptr,
         PROTO::linuxDma ? PROTO::linuxDma->getGlobal()  : nullptr,
+	PROTO::colorManagement ? PROTO::colorManagement->getGlobal() : nullptr,
     };
     // clang-format on
 


### PR DESCRIPTION
Now that `wine` (and `proton-ge`) supports Wayland it makes sense to allow the `wp_color_manager_v1` in Flatpak for native HDR without the need for `gamescope`!

<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Allows for native HDR in Flatpak. Look ma, no gamescope!

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I don't know much about the `wp_color_manager_v1` protocol.  It may be that it contains sensitive data/operations that mustn't be allowed in sandboxes.  I hope that's not the case!

#### Is it ready for merging, or does it need work?

Ready
