### PR TITLE
xwm: always sync clipboard from xwl.

### DIFF
--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -610,11 +610,6 @@ void CXWM::handleSelectionNotify(xcb_selection_notify_event_t* e) {
             sel->transfers.erase(it);
         }
     } else if (e->target == HYPRATOMS["TARGETS"]) {
-        if (!m_focusedSurface) {
-            Debug::log(TRACE, "[xwm] denying access to write to clipboard because no X client is in focus");
-            return;
-        }
-
         setClipboardToWayland(*sel);
     } else if (!sel->transfers.empty())
         getTransferData(*sel);


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Some app (or scripts) use x11 clipboard only, but it may run in wayland window (like terminal and electron apps). We should set the wayland clipboard so that these apps can work properly.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
yes

