### PR TITLE
monitor: retry after monitor modesetting fails

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -699,7 +699,7 @@ bool CMonitor::applyMonitorRule(SMonitorRule* pMonitorRule, bool force) {
 
     if (!success) {
         Debug::log(ERR, "Monitor {} has NO FALLBACK MODES, and an INVALID one was requested: {:X0}@{:.2f}Hz", m_name, RULE->resolution, RULE->refreshRate);
-        m_failedModeRetries = 1;
+        m_failedModeRetries++;
         g_pEventLoopManager->doLater([] { g_pConfigManager->m_wantsMonitorReload = true; });
         return true;
     }

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -119,8 +119,9 @@ class CMonitor {
     std::optional<Vector2D>     m_forceSize;
     SP<Aquamarine::SOutputMode> m_currentMode;
     SP<Aquamarine::CSwapchain>  m_cursorSwapchain;
-    uint32_t                    m_drmFormat     = DRM_FORMAT_INVALID;
-    uint32_t                    m_prevDrmFormat = DRM_FORMAT_INVALID;
+    uint32_t                    m_drmFormat         = DRM_FORMAT_INVALID;
+    uint32_t                    m_prevDrmFormat     = DRM_FORMAT_INVALID;
+    uint32_t                    m_failedModeRetries = 0;
 
     bool                        m_dpmsStatus       = true;
     bool                        m_vrrActive        = false; // this can be TRUE even if VRR is not active in the case that this display does not support it.


### PR DESCRIPTION
When a modesetting fails, we can retry up to 4 times. This sometimes happens due to some wonky driver timings.

If an invalid mode is passed and all tries fail, we still have https://github.com/hyprwm/Hyprland/commit/f7526d6be00d75f3abde72883903f9a7116de097 so it should not crash.

Fixes https://github.com/hyprwm/Hyprland/issues/10678

Needs testing from affected users @Lederstrumpf @ryzendew


