### PR TITLE
Fix wp-cm "invalid luminance" check

### DIFF
--- a/src/protocols/ColorManagement.cpp
+++ b/src/protocols/ColorManagement.cpp
@@ -608,7 +608,7 @@ CColorManagementParametricCreator::CColorManagementParametricCreator(SP<CWpImage
             r->error(WP_IMAGE_DESCRIPTION_CREATOR_PARAMS_V1_ERROR_ALREADY_SET, "Luminances already set");
             return;
         }
-        if (max_lum < reference_lum || reference_lum <= min) {
+        if (max_lum <= min || reference_lum <= min) {
             r->error(WP_IMAGE_DESCRIPTION_CREATOR_PARAMS_V1_ERROR_INVALID_LUMINANCE, "Invalid luminances");
             return;
         }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes incorrect wp-cp "invalid luminance" check.

XX
> If 'max_lum' is less than the 'reference_lum', or 'reference_lum' is less than or equal to 'min_lum', the protocol error invalid_luminance is raised.

WP
> If 'max_lum' or 'reference_lum' are less than or equal to 'min_lum',  the protocol error invalid_luminance is raised.

https://github.com/hyprwm/Hyprland/issues/9064#issuecomment-2973646890
https://github.com/Zamundaaa/VK_hdr_layer/issues/13

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
There might be some other differences between xx and wp protocol requirements. I've looked through the protocol changes while implementing the wp but missed this one. Someone else should verify that there is nothing else missing.

#### Is it ready for merging, or does it need work?
Ready

