### PR TITLE
asyncDialogBox: lock box in fdWrite to prevent a uaf

### DIFF
--- a/src/helpers/AsyncDialogBox.cpp
+++ b/src/helpers/AsyncDialogBox.cpp
@@ -46,6 +46,9 @@ CAsyncDialogBox::CAsyncDialogBox(const std::string& title, const std::string& de
 static int onFdWrite(int fd, uint32_t mask, void* data) {
     auto box = (CAsyncDialogBox*)data;
 
+    // lock the box to prevent a UAF
+    auto lock = box->lockSelf();
+
     box->onWrite(fd, mask);
 
     return 0;
@@ -142,4 +145,8 @@ void CAsyncDialogBox::kill() {
 
 bool CAsyncDialogBox::isRunning() const {
     return m_readEventSource;
+}
+
+SP<CAsyncDialogBox> CAsyncDialogBox::lockSelf() {
+    return m_selfWeakReference.lock();
 }

--- a/src/helpers/AsyncDialogBox.hpp
+++ b/src/helpers/AsyncDialogBox.hpp
@@ -27,6 +27,8 @@ class CAsyncDialogBox {
     void                      kill();
     bool                      isRunning() const;
 
+    SP<CAsyncDialogBox>       lockSelf();
+
     // focus priority, only permission popups
     bool m_priority = false;
 


### PR DESCRIPTION
Funky UAF happens due to `onFdWrite` having to use a raw pointer. This should fix it. Untested, needs a test run.

Fixes #10758

cc @Nick82285 can you test this?