### PR TITLE
Fix wrong surface local coord for layer surface above an xwayland window

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -322,7 +322,8 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse) {
                     const auto PWINDOW = HLSurface->getWindow();
                     surfacePos         = BOX->pos();
                     pFoundLayerSurface = HLSurface->getLayer();
-                    pFoundWindow       = !PWINDOW || PWINDOW->isHidden() ? g_pCompositor->m_lastWindow.lock() : PWINDOW;
+                    if (!pFoundLayerSurface)
+                        pFoundWindow = !PWINDOW || PWINDOW->isHidden() ? g_pCompositor->m_lastWindow.lock() : PWINDOW;
                 } else // reset foundSurface, find one normally
                     foundSurface = nullptr;
             } else // reset foundSurface, find one normally


### PR DESCRIPTION
This PR fixes an incorrect selection rectangle issue that occurs when using [`slurp`](https://github.com/emersion/slurp) with a focused XWayland application.

While this represents a rare edge case, it consistently reproduces under the following technical circumstances:

* As a region selector, `slurp` requires users to maintain mouse button pressure until selection completion
* This action triggers special Drag-and-Drop focus retention logic, where `pFoundWindow` may be incorrectly set for layer surfaces (which `slurp` utilizes)
* When `pFoundWindow` references `m_lastWindow` from an XWayland instance with `force_zero_scaling` enabled, the special XWayland zero-scale handling branch activates
* The scaling effects intended for `m_lastWindow` erroneously apply to the current layer surface, corrupting surface-local coordinates

The solution prevents `pFoundWindow` assignment when encountering layer surfaces, which represents a logically sound approach.

https://github.com/user-attachments/assets/4f0269d7-ccff-4777-9970-8c2a5d7d33db
