### PR TITLE
CI/Nix: add cache-nix-action

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -18,7 +18,35 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: DeterminateSystems/nix-installer-action@main
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v31
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          # restore and save a cache using this key
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          # if there's no cache hit, restore a cache by this prefix
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          # collect garbage until the Nix store size (in bytes) is at most this number
+          # before trying to save a new cache
+          # 1G = 1073741824
+          gc-max-store-size-linux: 1G
+          # do purge caches
+          purge: true
+          # purge all versions of the cache
+          purge-prefixes: nix-${{ runner.os }}-
+          # created more than this number of seconds ago
+          purge-created: 0
+          # or, last accessed more than this number of seconds ago
+          # relative to the start of the `Post Restore and save Nix store` phase
+          purge-last-accessed: 0
+          # except any version with the key that is the same as the `primary-key`
+          purge-primary-key: never
 
       - uses: cachix/cachix-action@v15
         with:

--- a/.github/workflows/nix-update-inputs.yml
+++ b/.github/workflows/nix-update-inputs.yml
@@ -17,7 +17,36 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - name: Install Nix
+        uses: nixbuild/nix-quick-install-action@v31
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          # restore and save a cache using this key
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          # if there's no cache hit, restore a cache by this prefix
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          # collect garbage until the Nix store size (in bytes) is at most this number
+          # before trying to save a new cache
+          # 1G = 1073741824
+          gc-max-store-size-linux: 1G
+          # do purge caches
+          purge: true
+          # purge all versions of the cache
+          purge-prefixes: nix-${{ runner.os }}-
+          # created more than this number of seconds ago
+          purge-created: 0
+          # or, last accessed more than this number of seconds ago
+          # relative to the start of the `Post Restore and save Nix store` phase
+          purge-last-accessed: 0
+          # except any version with the key that is the same as the `primary-key`
+          purge-primary-key: never
+
       - name: Update inputs
         run: nix/update-inputs.sh
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

After https://github.com/DeterminateSystems/magic-nix-cache-action has been deprecated, we've been running Nix Actions without a cache for `/nix/store`. This meant that all dependencies had to be downloaded on each action run.

With this PR, caching will work again.

Use nixbuild/nix-quick-install-action which pairs well with nix-community/cache-nix-action.

Parameters are taken from https://github.com/nix-community/cache-nix-action and may be tweaked later.

Should be replicated for all hyprwm repos with Nix actions.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.


#### Is it ready for merging, or does it need work?

Ready, but I'd prefer to merge this last, adding the same functionality to all repos down the dependency tree.

