### PR TITLE
xwayland: Don't leave shell process

### DIFF
--- a/src/xwayland/Server.cpp
+++ b/src/xwayland/Server.cpp
@@ -299,7 +299,7 @@ void CXWaylandServer::runXWayland(CFileDescriptor& notifyFD) {
         _exit(EXIT_FAILURE);
     }
 
-    auto cmd = std::format("Xwayland {} -rootless -core -listenfd {} -listenfd {} -displayfd {} -wm {}", m_displayName, m_xFDs[0].get(), m_xFDs[1].get(), notifyFD.get(),
+    auto cmd = std::format("exec Xwayland {} -rootless -core -listenfd {} -listenfd {} -displayfd {} -wm {}", m_displayName, m_xFDs[0].get(), m_xFDs[1].get(), notifyFD.get(),
                            m_xwmFDs[1].get());
 
     auto waylandSocket = std::format("{}", m_waylandFDs[1].get());


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Just adds `exec` to shell command that launches Xwayland.
Before:
![image](https://github.com/user-attachments/assets/47aaaa0f-f38f-4402-8f00-c7be5dd5cab5)

After:
![image](https://github.com/user-attachments/assets/0a5c214b-406c-49d4-8655-94e29337fdcd)


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I suppose it would be more elegant to compose argument array and feed it directly to `execl` without any shell, but here is just a minimal change that does the job.

#### Is it ready for merging, or does it need work?
Ready.