### PR TITLE
session-lock: don't render workspaces when locked

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1231,6 +1231,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SBoolData{false},
     },
     SConfigOptionDescription{
+        .value       = "misc:session_lock_xray",
+        .description = "keep rendering workspaces below your lockscreen",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{false},
+    },
+    SConfigOptionDescription{
         .value       = "misc:background_color",
         .description = "change the background color. (requires enabled disable_hyprland_logo)",
         .type        = CONFIG_OPTION_COLOR,

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -486,6 +486,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("misc:render_ahead_of_time", Hyprlang::INT{0});
     registerConfigVar("misc:render_ahead_safezone", Hyprlang::INT{1});
     registerConfigVar("misc:allow_session_lock_restore", Hyprlang::INT{0});
+    registerConfigVar("misc:session_lock_xray", Hyprlang::INT{0});
     registerConfigVar("misc:close_special_on_empty", Hyprlang::INT{1});
     registerConfigVar("misc:background_color", Hyprlang::INT{0xff111111});
     registerConfigVar("misc:new_window_takes_over_fullscreen", Hyprlang::INT{0});

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -33,7 +33,7 @@ static int wlTick(SP<CEventLoopTimer> self, void* data) {
 }
 
 CHyprAnimationManager::CHyprAnimationManager() {
-    m_animationTimer = SP<CEventLoopTimer>(new CEventLoopTimer(std::chrono::microseconds(500), wlTick, nullptr));
+    m_animationTimer = makeShared<CEventLoopTimer>(std::chrono::microseconds(500), wlTick, nullptr);
     if (g_pEventLoopManager) // null in --verify-config mode
         g_pEventLoopManager->addTimer(m_animationTimer);
 

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -94,7 +94,8 @@ void CSessionLockManager::onNewSessionLock(SP<CSessionLock> pLock) {
     g_pCompositor->focusSurface(nullptr);
     g_pSeatManager->setGrab(nullptr);
 
-    m_sessionLock->sendDeniedTimer = SP<CEventLoopTimer>(new CEventLoopTimer(
+    m_sessionLock->sendDeniedTimer = makeShared<CEventLoopTimer>(
+        // Within this arbitrary amount of time, a session-lock client is expected to create and commit a lock surface for each output. If the client fails to do that, it will be denied.
         std::chrono::seconds(5),
         [](auto, auto) {
             if (!g_pSessionLockManager || g_pSessionLockManager->clientLocked() || g_pSessionLockManager->clientDenied())
@@ -113,7 +114,7 @@ void CSessionLockManager::onNewSessionLock(SP<CSessionLock> pLock) {
                 g_pSessionLockManager->m_sessionLock->hasSentDenied = true;
             }
         },
-        nullptr));
+        nullptr);
 
     if (m_sessionLock->sendDeniedTimer)
         g_pEventLoopManager->addTimer(m_sessionLock->sendDeniedTimer);

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -100,6 +100,14 @@ void CSessionLockManager::onNewSessionLock(SP<CSessionLock> pLock) {
             if (!g_pSessionLockManager || g_pSessionLockManager->clientLocked() || g_pSessionLockManager->clientDenied())
                 return;
 
+            if (g_pCompositor->m_unsafeState || !g_pCompositor->m_aqBackend->hasSession() || !g_pCompositor->m_aqBackend->session->active) {
+                // Because the session is inactive, there is a good reason for why the client did't recieve locked or denied.
+                // We send locked, although this could lead to imperfect frames when we start to render again.
+                g_pSessionLockManager->m_sessionLock->lock->sendLocked();
+                g_pSessionLockManager->m_sessionLock->hasSentLocked = true;
+                return;
+            }
+
             if (g_pSessionLockManager->m_sessionLock && g_pSessionLockManager->m_sessionLock->lock) {
                 g_pSessionLockManager->m_sessionLock->lock->sendDenied();
                 g_pSessionLockManager->m_sessionLock->hasSentDenied = true;

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -142,22 +142,6 @@ WP<SSessionLockSurface> CSessionLockManager::getSessionLockSurfaceForMonitor(uin
     return {};
 }
 
-// We don't want the red screen to flash.
-float CSessionLockManager::getRedScreenAlphaForMonitor(uint64_t id) {
-    if (!m_sessionLock)
-        return 1.F;
-
-    const auto& NOMAPPEDSURFACETIMER = m_sessionLock->mMonitorsWithoutMappedSurfaceTimers.find(id);
-
-    if (NOMAPPEDSURFACETIMER == m_sessionLock->mMonitorsWithoutMappedSurfaceTimers.end()) {
-        m_sessionLock->mMonitorsWithoutMappedSurfaceTimers.emplace(id, CTimer());
-        m_sessionLock->mMonitorsWithoutMappedSurfaceTimers[id].reset();
-        return 0.f;
-    }
-
-    return std::clamp(NOMAPPEDSURFACETIMER->second.getSeconds() - /* delay for screencopy */ 0.5f, 0.f, 1.f);
-}
-
 void CSessionLockManager::onLockscreenRenderedOnMonitor(uint64_t id) {
     if (!m_sessionLock || m_sessionLock->hasSentLocked)
         return;

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -178,12 +178,8 @@ void CSessionLockManager::removeSessionLockSurface(SSessionLockSurface* pSLS) {
     }
 }
 
-bool CSessionLockManager::isSessionLockPresent() {
-    return m_sessionLock && !m_sessionLock->vSessionLockSurfaces.empty();
-}
-
-bool CSessionLockManager::anySessionLockSurfacesPresent() {
-    return m_sessionLock && std::ranges::any_of(m_sessionLock->vSessionLockSurfaces, [](const auto& surf) { return surf->mapped; });
+bool CSessionLockManager::hasSentLocked() {
+    return m_sessionLock && m_sessionLock->hasSentLocked;
 }
 
 bool CSessionLockManager::shallConsiderLockMissing() {

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -183,6 +183,10 @@ bool CSessionLockManager::isSurfaceSessionLock(SP<CWLSurfaceResource> pSurface) 
     return false;
 }
 
+bool CSessionLockManager::anySessionLockSurfacesPresent() {
+    return m_sessionLock && std::ranges::any_of(m_sessionLock->vSessionLockSurfaces, [](const auto& surf) { return surf->mapped; });
+}
+
 void CSessionLockManager::removeSessionLockSurface(SSessionLockSurface* pSLS) {
     if (!m_sessionLock)
         return;

--- a/src/managers/SessionLockManager.hpp
+++ b/src/managers/SessionLockManager.hpp
@@ -57,6 +57,7 @@ class CSessionLockManager {
     bool                    clientLocked();
     bool                    clientDenied();
     bool                    isSurfaceSessionLock(SP<CWLSurfaceResource>);
+    bool                    anySessionLockSurfacesPresent();
 
     void                    removeSessionLockSurface(SSessionLockSurface*);
 

--- a/src/managers/SessionLockManager.hpp
+++ b/src/managers/SessionLockManager.hpp
@@ -3,6 +3,7 @@
 #include "../defines.hpp"
 #include "../helpers/time/Timer.hpp"
 #include "../helpers/signal/Signal.hpp"
+#include "./eventLoop/EventLoopTimer.hpp"
 #include <cstdint>
 #include <unordered_map>
 #include <unordered_set>
@@ -29,7 +30,8 @@ struct SSessionLockSurface {
 
 struct SSessionLock {
     WP<CSessionLock>                     lock;
-    CTimer                               mLockTimer;
+    CTimer                               lockTimer;
+    SP<CEventLoopTimer>                  sendDeniedTimer;
 
     std::vector<UP<SSessionLockSurface>> vSessionLockSurfaces;
     std::unordered_map<uint64_t, CTimer> mMonitorsWithoutMappedSurfaceTimers;
@@ -71,6 +73,7 @@ class CSessionLockManager {
     } m_listeners;
 
     void onNewSessionLock(SP<CSessionLock> pWlrLock);
+    void removeSendDeniedTimer();
 };
 
 inline UP<CSessionLockManager> g_pSessionLockManager;

--- a/src/managers/SessionLockManager.hpp
+++ b/src/managers/SessionLockManager.hpp
@@ -54,9 +54,8 @@ class CSessionLockManager {
     float                   getRedScreenAlphaForMonitor(uint64_t);
 
     bool                    isSessionLocked();
-    bool                    isSessionLockPresent();
+    bool                    hasSentLocked();
     bool                    isSurfaceSessionLock(SP<CWLSurfaceResource>);
-    bool                    anySessionLockSurfacesPresent();
 
     void                    removeSessionLockSurface(SSessionLockSurface*);
 

--- a/src/managers/SessionLockManager.hpp
+++ b/src/managers/SessionLockManager.hpp
@@ -54,8 +54,8 @@ class CSessionLockManager {
     WP<SSessionLockSurface> getSessionLockSurfaceForMonitor(uint64_t);
 
     bool                    isSessionLocked();
-    bool                    hasSentLocked();
-    bool                    hasSentDenied();
+    bool                    clientLocked();
+    bool                    clientDenied();
     bool                    isSurfaceSessionLock(SP<CWLSurfaceResource>);
 
     void                    removeSessionLockSurface(SSessionLockSurface*);

--- a/src/managers/SessionLockManager.hpp
+++ b/src/managers/SessionLockManager.hpp
@@ -42,6 +42,7 @@ struct SSessionLock {
     } listeners;
 
     bool                         hasSentLocked = false;
+    bool                         hasSentDenied = false;
     std::unordered_set<uint64_t> lockedMonitors;
 };
 
@@ -54,6 +55,7 @@ class CSessionLockManager {
 
     bool                    isSessionLocked();
     bool                    hasSentLocked();
+    bool                    hasSentDenied();
     bool                    isSurfaceSessionLock(SP<CWLSurfaceResource>);
 
     void                    removeSessionLockSurface(SSessionLockSurface*);

--- a/src/managers/SessionLockManager.hpp
+++ b/src/managers/SessionLockManager.hpp
@@ -34,7 +34,6 @@ struct SSessionLock {
     SP<CEventLoopTimer>                  sendDeniedTimer;
 
     std::vector<UP<SSessionLockSurface>> vSessionLockSurfaces;
-    std::unordered_map<uint64_t, CTimer> mMonitorsWithoutMappedSurfaceTimers;
 
     struct {
         CHyprSignalListener newSurface;
@@ -52,8 +51,6 @@ class CSessionLockManager {
     ~CSessionLockManager() = default;
 
     WP<SSessionLockSurface> getSessionLockSurfaceForMonitor(uint64_t);
-
-    float                   getRedScreenAlphaForMonitor(uint64_t);
 
     bool                    isSessionLocked();
     bool                    hasSentLocked();

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -997,9 +997,13 @@ void CHyprRenderer::renderLockscreen(PHLMONITOR pMonitor, const Time::steady_tp&
         return;
     }
 
-    const bool LOCKMISSING = g_pSessionLockManager->shallConsiderLockMissing() && !g_pSessionLockManager->hasSentLocked();
+    const bool LOCKMISSING  = g_pSessionLockManager->shallConsiderLockMissing() && !g_pSessionLockManager->hasSentLocked();
+    const bool RENDERPRIMER = g_pSessionLockManager->shallConsiderLockMissing() || g_pSessionLockManager->hasSentLocked();
 
     g_pHyprOpenGL->ensureLockTexturesRendered(LOCKMISSING);
+
+    if (RENDERPRIMER)
+        renderSessionLockPrimer(pMonitor);
 
     const auto PSLS = g_pSessionLockManager->getSessionLockSurfaceForMonitor(pMonitor->m_id);
     if (!PSLS) {
@@ -1022,6 +1026,14 @@ void CHyprRenderer::renderLockscreen(PHLMONITOR pMonitor, const Time::steady_tp&
 
         g_pSessionLockManager->onLockscreenRenderedOnMonitor(pMonitor->m_id);
     }
+}
+
+void CHyprRenderer::renderSessionLockPrimer(PHLMONITOR pMonitor) {
+    CRectPassElement::SRectData data;
+    data.color = CHyprColor(0, 0, 0, 1);
+    data.box   = CBox{{}, pMonitor->m_pixelSize};
+
+    m_renderPass.add(makeShared<CRectPassElement>(data));
 }
 
 void CHyprRenderer::renderSessionLockMissing(PHLMONITOR pMonitor) {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -831,13 +831,14 @@ void CHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
     static auto PRENDERTEX       = CConfigValue<Hyprlang::INT>("misc:disable_hyprland_logo");
     static auto PBACKGROUNDCOLOR = CConfigValue<Hyprlang::INT>("misc:background_color");
     static auto PXPMODE          = CConfigValue<Hyprlang::INT>("render:xp_mode");
+    static auto PSESSIONLOCKXRAY = CConfigValue<Hyprlang::INT>("misc:session_lock_xray");
 
     if (!pMonitor)
         return;
 
-    if (g_pSessionLockManager->isSessionLocked()) {
-        // We stop to render workspaces as soon as the session is covered by the lockscreen,
-        // or alternatively after misc:lockdead_screen_delay has passed.
+    if (g_pSessionLockManager->isSessionLocked() && !*PSESSIONLOCKXRAY) {
+        // We stop to render workspaces as soon as the lockscreen was sent the "locked" or "finished" (aka denied) event.
+        // In addition we make sure to stop rendering workspaces after misc:lockdead_screen_delay has passed.
         if (g_pSessionLockManager->shallConsiderLockMissing() || g_pSessionLockManager->clientLocked() || g_pSessionLockManager->clientDenied())
             return;
     }
@@ -1027,6 +1028,10 @@ void CHyprRenderer::renderLockscreen(PHLMONITOR pMonitor, const Time::steady_tp&
 }
 
 void CHyprRenderer::renderSessionLockPrimer(PHLMONITOR pMonitor) {
+    static auto PSESSIONLOCKXRAY = CConfigValue<Hyprlang::INT>("misc:session_lock_xray");
+    if (*PSESSIONLOCKXRAY)
+        return;
+
     CRectPassElement::SRectData data;
     data.color = CHyprColor(0, 0, 0, 1.f);
     data.box   = CBox{{}, pMonitor->m_pixelSize};

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1011,6 +1011,7 @@ void CHyprRenderer::renderLockscreen(PHLMONITOR pMonitor, const Time::steady_tp&
             renderSessionLockMissing(pMonitor);
     } else {
         renderSessionLockSurface(PSLS, pMonitor, now);
+        g_pSessionLockManager->onLockscreenRenderedOnMonitor(pMonitor->m_id);
 
         // render layers and then their popups for abovelock rule
         for (auto const& lsl : pMonitor->m_layerSurfaceLayers) {
@@ -1023,37 +1024,28 @@ void CHyprRenderer::renderLockscreen(PHLMONITOR pMonitor, const Time::steady_tp&
                 renderLayer(ls.lock(), pMonitor, now, true, true);
             }
         }
-
-        g_pSessionLockManager->onLockscreenRenderedOnMonitor(pMonitor->m_id);
     }
 }
 
 void CHyprRenderer::renderSessionLockPrimer(PHLMONITOR pMonitor) {
     CRectPassElement::SRectData data;
-    data.color = CHyprColor(0, 0, 0, 1);
+    data.color = CHyprColor(0, 0, 0, 1.f);
     data.box   = CBox{{}, pMonitor->m_pixelSize};
 
     m_renderPass.add(makeShared<CRectPassElement>(data));
 }
 
 void CHyprRenderer::renderSessionLockMissing(PHLMONITOR pMonitor) {
-    const auto ALPHA = g_pSessionLockManager->getRedScreenAlphaForMonitor(pMonitor->m_id);
-
-    CBox       monbox = {{}, pMonitor->m_pixelSize};
+    CBox monbox = {{}, pMonitor->m_pixelSize};
 
     // render image, with instructions. Lock is gone.
-    g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_lockDeadTexture, monbox, ALPHA);
+    g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_lockDeadTexture, monbox, 1.f);
 
     // also render text for the tty number
     if (g_pHyprOpenGL->m_lockTtyTextTexture) {
         CBox texbox = {{}, g_pHyprOpenGL->m_lockTtyTextTexture->m_size};
-        g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_lockTtyTextTexture, texbox, ALPHA);
+        g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_lockTtyTextTexture, texbox, 1.f);
     }
-
-    if (ALPHA < 1.f) /* animate */
-        damageMonitor(pMonitor);
-    else
-        g_pSessionLockManager->onLockscreenRenderedOnMonitor(pMonitor->m_id);
 }
 
 void CHyprRenderer::calculateUVForSurface(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface, PHLMONITOR pMonitor, bool main, const Vector2D& projSize,

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -126,6 +126,7 @@ class CHyprRenderer {
     void renderDragIcon(PHLMONITOR, const Time::steady_tp&);
     void renderIMEPopup(CInputPopup*, PHLMONITOR, const Time::steady_tp&);
     void sendFrameEventsToWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now); // sends frame displayed events but doesn't actually render anything
+    void renderSessionLockPrimer(PHLMONITOR pMonitor);
     void renderSessionLockMissing(PHLMONITOR pMonitor);
 
     bool commitPendingAndDoExplicitSync(PHLMONITOR pMonitor);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Includes a bunch of session lock improvements I wanted to do for a while.
Let me know if you want me to split the PR. The changes are somewhat depend on each other, so I did it like this.
I managed to keep the commit history pretty clean, so it does a ok job of explaining what this PR changes.

##### Details

The major change is that this disables rendering of workspaces when the session is locked by default.
We stop rendering workspaces as soon as the client recieved `locked` or `finished` or the `misc:lockdead_screen_delay` has passed. This works slightly different than other session-lock implementations, that don't wait for `locked` or `finished` to stop rendering workspaces. This behaviour is well within what the protocol describes and makes sure there are no bad frames between the lockscreen client fully covering the screens and the request to lock the session in the first place.

Users can bypass this with the `misc:session_lock_xray` option.

This change sort of made `getRedScreenAlphaForMonitor` obsolete, so I removed it.

To ensure that we can't get into a situation, where neither `locked` or `finished` is sent, I added an event loop timer of 5 seconds that sends finished in case the client  wasn't able to create and commit lock surfaces within that time.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

- With hyprlock 0.8.2, this breaks the optics of fade-in (as long as `misc:session_lock_xray` is disabled). It is intended to be used with hyprlock >= https://github.com/hyprwm/hyprlock/commit/a9638986c31ab74fd95e83057f7cdd5187747ec7

- hyprlock's `shape:xray` now requires `misc:session_lock_xray`.

- Not sure, but workspaces stop being rendered may introduce some unexpected side effects. So far I haven't encountered any though 

#### Is it ready for merging, or does it need work?

Theoretically ready. Testing appreciated.
