### PR TITLE
shader: replace texture2d with texture

### DIFF
--- a/src/render/shaders/glsl/blur1.frag
+++ b/src/render/shaders/glsl/blur1.frag
@@ -112,11 +112,11 @@ layout(location = 0) out vec4 fragColor;
 void main() {
     vec2 uv = v_texcoord * 2.0;
 
-    vec4 sum = texture2D(tex, uv) * 4.0;
-    sum += texture2D(tex, uv - halfpixel.xy * radius);
-    sum += texture2D(tex, uv + halfpixel.xy * radius);
-    sum += texture2D(tex, uv + vec2(halfpixel.x, -halfpixel.y) * radius);
-    sum += texture2D(tex, uv - vec2(halfpixel.x, -halfpixel.y) * radius);
+    vec4 sum = texture(tex, uv) * 4.0;
+    sum += texture(tex, uv - halfpixel.xy * radius);
+    sum += texture(tex, uv + halfpixel.xy * radius);
+    sum += texture(tex, uv + vec2(halfpixel.x, -halfpixel.y) * radius);
+    sum += texture(tex, uv - vec2(halfpixel.x, -halfpixel.y) * radius);
 
     vec4 color = sum / 8.0;
 

--- a/src/render/shaders/glsl/blur2.frag
+++ b/src/render/shaders/glsl/blur2.frag
@@ -1,27 +1,25 @@
 #version 300 es
 precision highp float;
-uniform sampler2D tex;
 
+uniform sampler2D tex;
 uniform float radius;
 uniform vec2 halfpixel;
 
 in vec2 v_texcoord;
-
-out vec4 v_color;
-
 layout(location = 0) out vec4 fragColor;
+
 void main() {
     vec2 uv = v_texcoord / 2.0;
 
-    vec4 sum = texture2D(tex, uv + vec2(-halfpixel.x * 2.0, 0.0) * radius);
+    vec4 sum = texture(tex, uv + vec2(-halfpixel.x * 2.0, 0.0) * radius);
 
-    sum += texture2D(tex, uv + vec2(-halfpixel.x, halfpixel.y) * radius) * 2.0;
-    sum += texture2D(tex, uv + vec2(0.0, halfpixel.y * 2.0) * radius);
-    sum += texture2D(tex, uv + vec2(halfpixel.x, halfpixel.y) * radius) * 2.0;
-    sum += texture2D(tex, uv + vec2(halfpixel.x * 2.0, 0.0) * radius);
-    sum += texture2D(tex, uv + vec2(halfpixel.x, -halfpixel.y) * radius) * 2.0;
-    sum += texture2D(tex, uv + vec2(0.0, -halfpixel.y * 2.0) * radius);
-    sum += texture2D(tex, uv + vec2(-halfpixel.x, -halfpixel.y) * radius) * 2.0;
+    sum += texture(tex, uv + vec2(-halfpixel.x,  halfpixel.y) * radius) * 2.0;
+    sum += texture(tex, uv + vec2(0.0,           halfpixel.y * 2.0) * radius);
+    sum += texture(tex, uv + vec2(halfpixel.x,   halfpixel.y) * radius) * 2.0;
+    sum += texture(tex, uv + vec2(halfpixel.x * 2.0, 0.0) * radius);
+    sum += texture(tex, uv + vec2(halfpixel.x,  -halfpixel.y) * radius) * 2.0;
+    sum += texture(tex, uv + vec2(0.0,          -halfpixel.y * 2.0) * radius);
+    sum += texture(tex, uv + vec2(-halfpixel.x, -halfpixel.y) * radius) * 2.0;
 
     fragColor = sum / 12.0;
 }

--- a/src/render/shaders/glsl/glitch.frag
+++ b/src/render/shaders/glsl/glitch.frag
@@ -54,9 +54,9 @@ void main() {
 
     vec2 pixCoord = vec2(v_texcoord.x + offset + NOISE * 3.0 / screenSize.x + blockOffset.x, v_texcoord.y - meltAmount + 0.02 * NOISE / screenSize.x + NOISE * 3.0 / screenSize.y  + blockOffset.y);
 
-    vec4 pixColor = texture2D(tex, pixCoord);
-    vec4 pixColorLeft = texture2D(tex, pixCoord + vec2(ABERR_OFFSET / screenSize.x, 0));
-    vec4 pixColorRight = texture2D(tex, pixCoord + vec2(-ABERR_OFFSET / screenSize.x, 0));
+    vec4 pixColor = texture(tex, pixCoord);
+    vec4 pixColorLeft = texture(tex, pixCoord + vec2(ABERR_OFFSET / screenSize.x, 0));
+    vec4 pixColorRight = texture(tex, pixCoord + vec2(-ABERR_OFFSET / screenSize.x, 0));
 
     pixColor[0] = pixColorLeft[0];
     pixColor[2] = pixColorRight[2];

--- a/src/render/shaders/glsl/passthru.frag
+++ b/src/render/shaders/glsl/passthru.frag
@@ -6,5 +6,5 @@ uniform sampler2D tex;
 
 layout(location = 0) out vec4 fragColor;
 void main() {
-    fragColor = texture2D(tex, v_texcoord);
+    fragColor = texture(tex, v_texcoord);
 }

--- a/src/render/shaders/glsl/rgba.frag
+++ b/src/render/shaders/glsl/rgba.frag
@@ -18,7 +18,7 @@ uniform vec3 tint;
 layout(location = 0) out vec4 fragColor;
 void main() {
 
-    vec4 pixColor = texture2D(tex, v_texcoord);
+    vec4 pixColor = texture(tex, v_texcoord);
 
     if (discardOpaque == 1 && pixColor[3] * alpha == 1.0)
 	    discard;

--- a/src/render/shaders/glsl/rgbamatte.frag
+++ b/src/render/shaders/glsl/rgbamatte.frag
@@ -7,5 +7,5 @@ uniform sampler2D texMatte;
 
 layout(location = 0) out vec4 fragColor;
 void main() {
-    fragColor = texture2D(tex, v_texcoord) * texture2D(texMatte, v_texcoord)[0]; // I know it only uses R, but matte should be black/white anyways.
+    fragColor = texture(tex, v_texcoord) * texture(texMatte, v_texcoord)[0]; // I know it only uses R, but matte should be black/white anyways.
 }

--- a/src/render/shaders/glsl/rgbx.frag
+++ b/src/render/shaders/glsl/rgbx.frag
@@ -20,7 +20,7 @@ void main() {
     if (discardOpaque == 1 && alpha == 1.0)
 	discard;
 
-    vec4 pixColor = vec4(texture2D(tex, v_texcoord).rgb, 1.0);
+    vec4 pixColor = vec4(texture(tex, v_texcoord).rgb, 1.0);
 
     if (applyTint == 1) {
 	    pixColor[0] = pixColor[0] * tint[0];


### PR DESCRIPTION
remove unused v_color and replace deprecated texture2d with texture.

replace all the usage of texture2d with texture, besides one place. in the ext.frag because samplerExternalOES requires texture2D and as i understand it its provided by the GL_OES_EGL_image_external extension for just that usecase.


