### PR TITLE
buffer: check if buffer fd already readable

### DIFF
--- a/src/protocols/types/DMABuffer.cpp
+++ b/src/protocols/types/DMABuffer.cpp
@@ -118,6 +118,9 @@ CFileDescriptor CDMABuffer::exportSyncFile() {
         if (fd == -1)
             continue;
 
+        if (CFileDescriptor::isReadable(fd))
+            continue;
+
         dma_buf_export_sync_file request{
             .flags = DMA_BUF_SYNC_READ,
             .fd    = -1,


### PR DESCRIPTION
check if buffer fd is already readable, to avoid a lot of unnecessery systemcalls and churn.

improves glmark2 a lot.


