### PR TITLE
Temp fix for memory leak on mouse movement

### DIFF
--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -361,7 +361,7 @@ bool CPointerManager::attemptHardwareCursor(SP<CPointerManager::SMonitorPointerS
 
     if (!success) {
         Debug::log(TRACE, "[pointer] hw cursor failed applying, hiding");
-        setHWCursorBuffer(state, nullptr);
+        // setHWCursorBuffer(state, nullptr);
         return false;
     } else
         state->hwApplied = true;
@@ -377,10 +377,9 @@ bool CPointerManager::setHWCursorBuffer(SP<SMonitorPointerState> state, SP<Aquam
 
     Debug::log(TRACE, "[pointer] hw transformed hotspot for {}: {}", state->monitor->m_name, HOTSPOT);
 
+    state->cursorFrontBuffer = buf;
     if (!state->monitor->m_output->setCursor(buf, HOTSPOT))
         return false;
-
-    state->cursorFrontBuffer = buf;
 
     if (!state->monitor->shouldSkipScheduleFrameOnMouseEvent())
         g_pCompositor->scheduleFrameForMonitor(state->monitor.lock(), Aquamarine::IOutput::AQ_SCHEDULE_CURSOR_SHAPE);


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
On my Arch Linux environment, I started getting severe slowness on mouse movent after just some 30minus of using it.
I realized there was a memory leak whenever I moved my mouse over the external HDMI monitor.
It is probably not a definitive fix, but it could be some work around before the fix is possible. This is the only way I can get use my system for some hours without having to restart Hyprland every 1/2 an hour 


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Need some better clearance on why this leak happens if we try resetting the buffer after the failure. Could it be some leak on specific HDMI monitor buffers? And why doesn't it happen?

#### Is it ready for merging, or does it need work?
I acceptable as a temporary workaround, yes.

