### PR TITLE
handle setGroupCurrent properly on fulscreen groups

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1041,29 +1041,32 @@ void CWindow::setGroupCurrent(PHLWINDOW pWindow) {
 
     const auto CURRENTISFOCUS = PCURRENT == g_pCompositor->m_lastWindow.lock();
 
+    const auto PWINDOWSIZE                 = PCURRENT->m_realSize->goal();
+    const auto PWINDOWPOS                  = PCURRENT->m_realPosition->goal();
+    const auto PWINDOWLASTFLOATINGSIZE     = PCURRENT->m_lastFloatingSize;
+    const auto PWINDOWLASTFLOATINGPOSITION = PCURRENT->m_lastFloatingPosition;
+
     if (FULLSCREEN)
         g_pCompositor->setWindowFullscreenInternal(PCURRENT, FSMODE_NONE);
-
-    const auto PWINDOWSIZE = PCURRENT->m_realSize->goal();
-    const auto PWINDOWPOS  = PCURRENT->m_realPosition->goal();
 
     PCURRENT->setHidden(true);
     pWindow->setHidden(false); // can remove m_pLastWindow
 
     g_pLayoutManager->getCurrentLayout()->replaceWindowDataWith(PCURRENT, pWindow);
 
-    if (PCURRENT->m_isFloating) {
-        pWindow->m_realPosition->setValueAndWarp(PWINDOWPOS);
-        pWindow->m_realSize->setValueAndWarp(PWINDOWSIZE);
-    }
+    pWindow->m_realPosition->setValueAndWarp(PWINDOWPOS);
+    pWindow->m_realSize->setValueAndWarp(PWINDOWSIZE);
+
+    if (FULLSCREEN)
+        g_pCompositor->setWindowFullscreenInternal(pWindow, MODE);
+
+    pWindow->m_lastFloatingSize     = PWINDOWLASTFLOATINGSIZE;
+    pWindow->m_lastFloatingPosition = PWINDOWLASTFLOATINGPOSITION;
 
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 
     if (CURRENTISFOCUS)
         g_pCompositor->focusWindow(pWindow);
-
-    if (FULLSCREEN)
-        g_pCompositor->setWindowFullscreenInternal(pWindow, MODE);
 
     g_pHyprRenderer->damageWindow(pWindow);
 


### PR DESCRIPTION
always warps window size and pos on `setGroupCurrent`
replaces hacky solution for restoring last floating size and pos by just overriding the values set when changing in/out of fullscreen

seems to work fine

example of what this fixes:
create a workspace with a window and a group with 2 windows
fulscreen the group
change the active group window
notice it always animates