### PR TITLE
Renderer: Implement new render scheduling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ find_package(Threads REQUIRED)
 set(GLES_VERSION "GLES3")
 find_package(OpenGL REQUIRED COMPONENTS ${GLES_VERSION})
 
-pkg_check_modules(aquamarine_dep REQUIRED IMPORTED_TARGET aquamarine>=0.8.0)
+pkg_check_modules(aquamarine_dep REQUIRED IMPORTED_TARGET aquamarine>=0.9.0)
 pkg_check_modules(hyprlang_dep REQUIRED IMPORTED_TARGET hyprlang>=0.3.2)
 pkg_check_modules(hyprcursor_dep REQUIRED IMPORTED_TARGET hyprcursor>=0.1.7)
 pkg_check_modules(hyprutils_dep REQUIRED IMPORTED_TARGET hyprutils>=0.7.0)

--- a/flake.lock
+++ b/flake.lock
@@ -16,11 +16,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751713351,
-        "narHash": "sha256-Nf71frhVuTbxxSaqd8Hqz5yhsrs/M0HKkR1Wd9EngPg=",
+        "lastModified": 1751740947,
+        "narHash": "sha256-35040CHH7P3JGmhGVfEb2oJHL/A5mI2IXumhkxrBnao=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "0bd03a8e2676f38a40ed4fcb8bd9c095c75f11c2",
+        "rev": "dfc1db15a08c4cd234288f66e1199c653495301f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -16,11 +16,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1751569683,
-        "narHash": "sha256-PoQcCYTiN52PanxgWBN4Tqet1x4PCk6KtjaHNjELH88=",
+        "lastModified": 1751713351,
+        "narHash": "sha256-Nf71frhVuTbxxSaqd8Hqz5yhsrs/M0HKkR1Wd9EngPg=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "c0c56dde3e471030edb135425a82107cf0057c6f",
+        "rev": "0bd03a8e2676f38a40ed4fcb8bd9c095c75f11c2",
         "type": "github"
       },
       "original": {

--- a/meson.build
+++ b/meson.build
@@ -31,7 +31,7 @@ if cpp_compiler.check_header('execinfo.h')
   add_project_arguments('-DHAS_EXECINFO', language: 'cpp')
 endif
 
-aquamarine = dependency('aquamarine', version: '>=0.8.0')
+aquamarine = dependency('aquamarine', version: '>=0.9.0')
 hyprcursor = dependency('hyprcursor', version: '>=0.1.7')
 hyprgraphics = dependency('hyprgraphics', version: '>= 0.1.3')
 hyprlang = dependency('hyprlang', version: '>= 0.3.2')

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -62,6 +62,7 @@
 #include "hyprerror/HyprError.hpp"
 #include "debug/HyprNotificationOverlay.hpp"
 #include "debug/HyprDebugOverlay.hpp"
+#include "helpers/MonitorFrameScheduler.hpp"
 
 #include <hyprutils/string/String.hpp>
 #include <aquamarine/input/Input.hpp>
@@ -3097,7 +3098,7 @@ void CCompositor::onNewMonitor(SP<Aquamarine::IOutput> output) {
     }
 
     g_pHyprRenderer->damageMonitor(PNEWMONITOR);
-    PNEWMONITOR->onMonitorFrame();
+    PNEWMONITOR->m_frameScheduler->onFrame();
 
     if (PROTO::colorManagement && shouldChangePreferredImageDescription()) {
         Debug::log(ERR, "FIXME: color management protocol is enabled, need a preferred image description id");

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1488,6 +1488,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .type        = CONFIG_OPTION_INT,
         .data        = SConfigOptionDescription::SRangeData{.value = 1, .min = 0, .max = 2},
     },
+    SConfigOptionDescription{
+        .value       = "render:new_render_scheduling",
+        .description = "enable new render scheduling, which should improve FPS on underpowered devices. This does not add latency when your PC can keep up.",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{true},
+    },
 
     /*
      * cursor:
@@ -1911,12 +1917,6 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
     SConfigOptionDescription{
         .value       = "experimental:xx_color_management_v4",
         .description = "enable color management protocol",
-        .type        = CONFIG_OPTION_BOOL,
-        .data        = SConfigOptionDescription::SBoolData{false},
-    },
-    SConfigOptionDescription{
-        .value       = "experimental:new_render_scheduling",
-        .description = "enable new render scheduling",
         .type        = CONFIG_OPTION_BOOL,
         .data        = SConfigOptionDescription::SBoolData{false},
     },

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1898,14 +1898,25 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SBoolData{true},
     },
     SConfigOptionDescription{
+        .value       = "master:always_keep_position",
+        .description = "whether to keep the master window in its configured position when there are no slave windows",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{false},
+    },
+
+    /*
+     * Experimental
+    */
+
+    SConfigOptionDescription{
         .value       = "experimental:xx_color_management_v4",
         .description = "enable color management protocol",
         .type        = CONFIG_OPTION_BOOL,
         .data        = SConfigOptionDescription::SBoolData{false},
     },
     SConfigOptionDescription{
-        .value       = "master:always_keep_position",
-        .description = "whether to keep the master window in its configured position when there are no slave windows",
+        .value       = "experimental:new_render_scheduling",
+        .description = "enable new render scheduling",
         .type        = CONFIG_OPTION_BOOL,
         .data        = SConfigOptionDescription::SBoolData{false},
     },

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -755,6 +755,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("ecosystem:enforce_permissions", Hyprlang::INT{0});
 
     registerConfigVar("experimental:xx_color_management_v4", Hyprlang::INT{0});
+    registerConfigVar("experimental:new_render_scheduling", Hyprlang::INT{0});
 
     // devices
     m_config->addSpecialCategory("device", {"name"});

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -749,13 +749,13 @@ CConfigManager::CConfigManager() {
     registerConfigVar("render:cm_enabled", Hyprlang::INT{1});
     registerConfigVar("render:send_content_type", Hyprlang::INT{1});
     registerConfigVar("render:cm_auto_hdr", Hyprlang::INT{1});
+    registerConfigVar("render:new_render_scheduling", Hyprlang::INT{1});
 
     registerConfigVar("ecosystem:no_update_news", Hyprlang::INT{0});
     registerConfigVar("ecosystem:no_donation_nag", Hyprlang::INT{0});
     registerConfigVar("ecosystem:enforce_permissions", Hyprlang::INT{0});
 
     registerConfigVar("experimental:xx_color_management_v4", Hyprlang::INT{0});
-    registerConfigVar("experimental:new_render_scheduling", Hyprlang::INT{0});
 
     // devices
     m_config->addSpecialCategory("device", {"name"});

--- a/src/helpers/DamageRing.hpp
+++ b/src/helpers/DamageRing.hpp
@@ -3,7 +3,7 @@
 #include "./math/Math.hpp"
 #include <array>
 
-constexpr static int DAMAGE_RING_PREVIOUS_LEN = 2;
+constexpr static int DAMAGE_RING_PREVIOUS_LEN = 3;
 
 class CDamageRing {
   public:

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -20,6 +20,8 @@
 #include <aquamarine/allocator/Swapchain.hpp>
 #include <hyprutils/os/FileDescriptor.hpp>
 
+class CMonitorFrameScheduler;
+
 // Enum for the different types of auto directions, e.g. auto-left, auto-up.
 enum eAutoDirs : uint8_t {
     DIR_AUTO_NONE = 0, /* None will be treated as right. */
@@ -160,6 +162,8 @@ class CMonitor {
 
     PHLMONITORREF                  m_self;
 
+    UP<CMonitorFrameScheduler>     m_frameScheduler;
+
     // mirroring
     PHLMONITORREF              m_mirrorOf;
     std::vector<PHLMONITORREF> m_mirrors;
@@ -228,7 +232,6 @@ class CMonitor {
     void                                onCursorMovedOnMonitor();
 
     void                                debugLastPresentation(const std::string& message);
-    void                                onMonitorFrame();
 
     bool                                supportsWideColor();
     bool                                supportsHDR();

--- a/src/helpers/MonitorFrameScheduler.cpp
+++ b/src/helpers/MonitorFrameScheduler.cpp
@@ -1,0 +1,109 @@
+#include "MonitorFrameScheduler.hpp"
+#include "../config/ConfigValue.hpp"
+#include "../Compositor.hpp"
+#include "../render/Renderer.hpp"
+#include "../managers/eventLoop/EventLoopManager.hpp"
+
+CMonitorFrameScheduler::CMonitorFrameScheduler(PHLMONITOR m) : m_monitor(m) {
+    ;
+}
+
+void CMonitorFrameScheduler::onSyncFired() {
+    // Sync fired: reset submitted state, set as rendered. Check the last render time. If we are running
+    // late, we will instantly render here.
+
+    if (std::chrono::duration_cast<std::chrono::microseconds>(hrc::now() - m_lastRenderBegun).count() / 1000.F < 1000.F / m_monitor->m_refreshRate) {
+        // we are in. Frame is valid. We can just render as normal.
+        Debug::log(TRACE, "CMonitorFrameScheduler: {} -> onSyncFired, didn't miss.", m_monitor->m_name);
+        m_renderAtFrame = true;
+        return;
+    }
+
+    Debug::log(TRACE, "CMonitorFrameScheduler: {} -> onSyncFired, missed.", m_monitor->m_name);
+
+    // we are out. The frame is taking too long to render. Begin rendering immediately, but don't commit yet.
+    m_pendingThird  = true;
+    m_renderAtFrame = false; // block frame rendering, we already scheduled
+
+    m_lastRenderBegun = hrc::now();
+    g_pHyprRenderer->renderMonitor(m_monitor.lock(), false);
+    onFinishRender();
+}
+
+void CMonitorFrameScheduler::onPresented() {
+    static auto PENABLENEW = CConfigValue<Hyprlang::INT>("experimental:new_render_scheduling");
+
+    if (!*PENABLENEW)
+        return;
+
+    if (!m_pendingThird)
+        return;
+
+    Debug::log(TRACE, "CMonitorFrameScheduler: {} -> onPresented, missed, committing pending.", m_monitor->m_name);
+
+    m_pendingThird = false;
+    g_pHyprRenderer->commitPendingAndDoExplicitSync(m_monitor.lock()); // commit the pending frame. If it didn't fire yet (is not rendered) it doesn't matter. Syncs will wait.
+}
+
+void CMonitorFrameScheduler::onFrame() {
+    static auto PENABLENEW = CConfigValue<Hyprlang::INT>("experimental:new_render_scheduling");
+
+    if (!canRender())
+        return;
+
+    g_pHyprRenderer->recheckSolitaryForMonitor(m_monitor.lock());
+
+    m_monitor->m_tearingState.busy = false;
+
+    if (m_monitor->m_tearingState.activelyTearing && m_monitor->m_solitaryClient.lock() /* can be invalidated by a recheck */) {
+
+        if (!m_monitor->m_tearingState.frameScheduledWhileBusy)
+            return; // we did not schedule a frame yet to be displayed, but we are tearing. Why render?
+
+        m_monitor->m_tearingState.nextRenderTorn          = true;
+        m_monitor->m_tearingState.frameScheduledWhileBusy = false;
+    }
+
+    if (!*PENABLENEW) {
+        m_monitor->m_lastPresentationTimer.reset();
+
+        g_pHyprRenderer->renderMonitor(m_monitor.lock());
+        return;
+    }
+
+    if (!m_renderAtFrame) {
+        Debug::log(TRACE, "CMonitorFrameScheduler: {} -> frame event, but m_renderAtFrame = false.", m_monitor->m_name);
+        return;
+    }
+
+    Debug::log(TRACE, "CMonitorFrameScheduler: {} -> frame event, render = true, rendering normally.", m_monitor->m_name);
+
+    m_lastRenderBegun = hrc::now();
+    g_pHyprRenderer->renderMonitor(m_monitor.lock());
+    onFinishRender();
+}
+
+void CMonitorFrameScheduler::onFinishRender() {
+    m_sync = CEGLSync::create(); // this destroys the old sync
+    g_pEventLoopManager->doOnReadable(m_sync->fd().duplicate(), [this] { onSyncFired(); });
+}
+
+bool CMonitorFrameScheduler::canRender() {
+    if ((g_pCompositor->m_aqBackend->hasSession() && !g_pCompositor->m_aqBackend->session->active) || !g_pCompositor->m_sessionActive || g_pCompositor->m_unsafeState) {
+        Debug::log(WARN, "Attempted to render frame on inactive session!");
+
+        if (g_pCompositor->m_unsafeState && std::ranges::any_of(g_pCompositor->m_monitors.begin(), g_pCompositor->m_monitors.end(), [&](auto& m) {
+                return m->m_output != g_pCompositor->m_unsafeOutput->m_output;
+            })) {
+            // restore from unsafe state
+            g_pCompositor->leaveUnsafeState();
+        }
+
+        return false; // cannot draw on session inactive (different tty)
+    }
+
+    if (!m_monitor->m_enabled)
+        return false;
+
+    return true;
+}

--- a/src/helpers/MonitorFrameScheduler.cpp
+++ b/src/helpers/MonitorFrameScheduler.cpp
@@ -42,12 +42,19 @@ void CMonitorFrameScheduler::onPresented() {
     Debug::log(TRACE, "CMonitorFrameScheduler: {} -> onPresented, missed, committing pending.", m_monitor->m_name);
 
     m_pendingThird = false;
-    g_pHyprRenderer->commitPendingAndDoExplicitSync(m_monitor.lock()); // commit the pending frame. If it didn't fire yet (is not rendered) it doesn't matter. Syncs will wait.
 
-    // schedule a frame: we might have some missed damage, which got cleared due to the above commit.
-    // TODO: this is not always necessary, but doesn't hurt in general. We likely won't hit this if nothing's happening anyways.
-    if (m_monitor->m_damage.hasChanged())
-        g_pCompositor->scheduleFrameForMonitor(m_monitor.lock());
+    Debug::log(TRACE, "CMonitorFrameScheduler: {} -> onPresented, missed, committing pending at the earliest convenience.", m_monitor->m_name);
+
+    m_pendingThird = false;
+
+    g_pEventLoopManager->doLater([m = m_monitor.lock()] {
+        g_pHyprRenderer->commitPendingAndDoExplicitSync(m); // commit the pending frame. If it didn't fire yet (is not rendered) it doesn't matter. Syncs will wait.
+
+        // schedule a frame: we might have some missed damage, which got cleared due to the above commit.
+        // TODO: this is not always necessary, but doesn't hurt in general. We likely won't hit this if nothing's happening anyways.
+        if (m->m_damage.hasChanged())
+            g_pCompositor->scheduleFrameForMonitor(m);
+    });
 }
 
 void CMonitorFrameScheduler::onFrame() {

--- a/src/helpers/MonitorFrameScheduler.cpp
+++ b/src/helpers/MonitorFrameScheduler.cpp
@@ -9,7 +9,7 @@ CMonitorFrameScheduler::CMonitorFrameScheduler(PHLMONITOR m) : m_monitor(m) {
 }
 
 void CMonitorFrameScheduler::onSyncFired() {
-    static auto PENABLENEW = CConfigValue<Hyprlang::INT>("experimental:new_render_scheduling");
+    static auto PENABLENEW = CConfigValue<Hyprlang::INT>("render:new_render_scheduling");
 
     if (!*PENABLENEW)
         return;
@@ -36,7 +36,7 @@ void CMonitorFrameScheduler::onSyncFired() {
 }
 
 void CMonitorFrameScheduler::onPresented() {
-    static auto PENABLENEW = CConfigValue<Hyprlang::INT>("experimental:new_render_scheduling");
+    static auto PENABLENEW = CConfigValue<Hyprlang::INT>("render:new_render_scheduling");
 
     if (!*PENABLENEW)
         return;
@@ -63,7 +63,7 @@ void CMonitorFrameScheduler::onPresented() {
 }
 
 void CMonitorFrameScheduler::onFrame() {
-    static auto PENABLENEW = CConfigValue<Hyprlang::INT>("experimental:new_render_scheduling");
+    static auto PENABLENEW = CConfigValue<Hyprlang::INT>("render:new_render_scheduling");
 
     if (!canRender())
         return;

--- a/src/helpers/MonitorFrameScheduler.cpp
+++ b/src/helpers/MonitorFrameScheduler.cpp
@@ -9,6 +9,11 @@ CMonitorFrameScheduler::CMonitorFrameScheduler(PHLMONITOR m) : m_monitor(m) {
 }
 
 void CMonitorFrameScheduler::onSyncFired() {
+    static auto PENABLENEW = CConfigValue<Hyprlang::INT>("experimental:new_render_scheduling");
+
+    if (!*PENABLENEW)
+        return;
+
     // Sync fired: reset submitted state, set as rendered. Check the last render time. If we are running
     // late, we will instantly render here.
 

--- a/src/helpers/MonitorFrameScheduler.cpp
+++ b/src/helpers/MonitorFrameScheduler.cpp
@@ -43,6 +43,11 @@ void CMonitorFrameScheduler::onPresented() {
 
     m_pendingThird = false;
     g_pHyprRenderer->commitPendingAndDoExplicitSync(m_monitor.lock()); // commit the pending frame. If it didn't fire yet (is not rendered) it doesn't matter. Syncs will wait.
+
+    // schedule a frame: we might have some missed damage, which got cleared due to the above commit.
+    // TODO: this is not always necessary, but doesn't hurt in general. We likely won't hit this if nothing's happening anyways.
+    if (m_monitor->m_damage.hasChanged())
+        g_pCompositor->scheduleFrameForMonitor(m_monitor.lock());
 }
 
 void CMonitorFrameScheduler::onFrame() {

--- a/src/helpers/MonitorFrameScheduler.cpp
+++ b/src/helpers/MonitorFrameScheduler.cpp
@@ -97,7 +97,11 @@ void CMonitorFrameScheduler::onFrame() {
 
 void CMonitorFrameScheduler::onFinishRender() {
     m_sync = CEGLSync::create(); // this destroys the old sync
-    g_pEventLoopManager->doOnReadable(m_sync->fd().duplicate(), [this] { onSyncFired(); });
+    g_pEventLoopManager->doOnReadable(m_sync->fd().duplicate(), [this, mon = m_monitor] {
+        if (!m_monitor) // might've gotten destroyed
+            return;
+        onSyncFired();
+    });
 }
 
 bool CMonitorFrameScheduler::canRender() {

--- a/src/helpers/MonitorFrameScheduler.hpp
+++ b/src/helpers/MonitorFrameScheduler.hpp
@@ -23,7 +23,7 @@ class CMonitorFrameScheduler {
 
   private:
     bool            canRender();
-    void                    onFinishRender();
+    void            onFinishRender();
 
     bool            m_renderAtFrame = true;
     bool            m_pendingThird  = false;

--- a/src/helpers/MonitorFrameScheduler.hpp
+++ b/src/helpers/MonitorFrameScheduler.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "Monitor.hpp"
+
+#include <chrono>
+
+class CEGLSync;
+
+class CMonitorFrameScheduler {
+  public:
+    using hrc = std::chrono::high_resolution_clock;
+
+    CMonitorFrameScheduler(PHLMONITOR m);
+
+    CMonitorFrameScheduler(const CMonitorFrameScheduler&)            = delete;
+    CMonitorFrameScheduler(CMonitorFrameScheduler&&)                 = delete;
+    CMonitorFrameScheduler& operator=(const CMonitorFrameScheduler&) = delete;
+    CMonitorFrameScheduler& operator=(CMonitorFrameScheduler&&)      = delete;
+
+    void                    onSyncFired();
+    void                    onPresented();
+    void                    onFrame();
+
+  private:
+    bool            canRender();
+    void                    onFinishRender();
+
+    bool            m_renderAtFrame = true;
+    bool            m_pendingThird  = false;
+    hrc::time_point m_lastRenderBegun;
+
+    PHLMONITORREF   m_monitor;
+
+    UP<CEGLSync>    m_sync;
+};

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -51,7 +51,7 @@ class CHyprRenderer {
     CHyprRenderer();
     ~CHyprRenderer();
 
-    void renderMonitor(PHLMONITOR pMonitor);
+    void renderMonitor(PHLMONITOR pMonitor, bool commit = true);
     void arrangeLayersForMonitor(const MONITORID&);
     void damageSurface(SP<CWLSurfaceResource>, double, double, double scale = 1.0);
     void damageWindow(PHLWINDOW, bool forceFull = false);
@@ -156,6 +156,7 @@ class CHyprRenderer {
     friend class CInputManager;
     friend class CPointerManager;
     friend class CMonitor;
+    friend class CMonitorFrameScheduler;
 };
 
 inline UP<CHyprRenderer> g_pHyprRenderer;


### PR DESCRIPTION
Since we now have the entire explicit sync framework quite robust, we can implement a new render scheduling mechanism, akin to triple buffering.

This should considerably improve FPS on underpowered devices, as we no longer cut FPS in half once a frame misses, which also has a side-effect of potentially starving iGPUs.

NEEDS TESTING - I've tested it on my laptop, and seems to work very well, but I am not everyone.

My own laptop results, when stressed (fade animations between workspaces):
Plugged in: 45FPS -> 90FPS
Unplugged: 45FPS -> 70FPS

!! PLEASE NOTE: requires `experimental:new_render_scheduling`.

Setups to be tested, please:
- [x] Tearing
- [ ] DS
- [x] Multi-GPU

TODOs for the future:
- Make this automatic - for now, we always allocate a 3-sized swapchain... maybe it'd be beneficial to shrink it when we don't need it? Though idk what the allocation times might be when we resize.

cc @gulafaran

Draft until tests are conducted and it works.

!!! NEEDS AQUAMARINE-GIT