### PR TITLE
texture: zero out the cached states in destroy

### DIFF
--- a/src/render/Texture.cpp
+++ b/src/render/Texture.cpp
@@ -156,6 +156,7 @@ void CTexture::destroyTexture() {
     if (m_eglImage)
         g_pHyprOpenGL->m_proc.eglDestroyImageKHR(g_pHyprOpenGL->m_eglDisplay, m_eglImage);
     m_eglImage = nullptr;
+    m_cachedStates.fill(std::nullopt);
 }
 
 void CTexture::allocate() {


### PR DESCRIPTION
if destroyTexture is called outside of the texture destructor we need to empty out the cached states.

see: https://github.com/hyprwm/Hyprland/discussions/10934

thanks @EvilLary for both reporting it, finding it and pin pointing to why.


