### PR TITLE
turn on -Wpedantic and name the anonymous struct

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,7 @@ add_compile_options(
   -Wno-narrowing
   -Wno-pointer-arith
   -Wno-clobbered
+  -Wpedantic
   -fmacro-prefix-map=${CMAKE_SOURCE_DIR}/=)
 
 set(CMAKE_EXECUTABLE_ENABLE_EXPORTS TRUE)

--- a/src/protocols/DRMSyncobj.cpp
+++ b/src/protocols/DRMSyncobj.cpp
@@ -75,7 +75,7 @@ CDRMSyncobjSurfaceResource::CDRMSyncobjSurfaceResource(UP<CWpLinuxDrmSyncobjSurf
     });
 
     m_listeners.surfacePrecommit = m_surface->m_events.precommit.registerListener([this](std::any d) {
-        if (!m_surface->m_pending.updated.buffer || !m_surface->m_pending.buffer) {
+        if (!m_surface->m_pending.updated.bits.buffer || !m_surface->m_pending.buffer) {
             if (m_pendingAcquire.timeline() || m_pendingRelease.timeline()) {
                 m_resource->error(WP_LINUX_DRM_SYNCOBJ_SURFACE_V1_ERROR_NO_BUFFER, "Missing buffer");
                 m_surface->m_pending.rejected = true;
@@ -101,9 +101,9 @@ CDRMSyncobjSurfaceResource::CDRMSyncobjSurfaceResource(UP<CWpLinuxDrmSyncobjSurf
             return;
         }
 
-        m_surface->m_pending.updated.acquire = true;
-        m_surface->m_pending.acquire         = m_pendingAcquire;
-        m_pendingAcquire                     = {};
+        m_surface->m_pending.updated.bits.acquire = true;
+        m_surface->m_pending.acquire              = m_pendingAcquire;
+        m_pendingAcquire                          = {};
 
         m_surface->m_pending.buffer->addReleasePoint(m_pendingRelease);
         m_pendingRelease = {};

--- a/src/protocols/Viewporter.cpp
+++ b/src/protocols/Viewporter.cpp
@@ -15,7 +15,7 @@ CViewportResource::CViewportResource(SP<CWpViewport> resource_, SP<CWLSurfaceRes
             return;
         }
 
-        m_surface->m_pending.updated.viewport = true;
+        m_surface->m_pending.updated.bits.viewport = true;
 
         if (x == -1 && y == -1) {
             m_surface->m_pending.viewport.hasDestination = false;
@@ -37,7 +37,7 @@ CViewportResource::CViewportResource(SP<CWpViewport> resource_, SP<CWLSurfaceRes
             return;
         }
 
-        m_surface->m_pending.updated.viewport = true;
+        m_surface->m_pending.updated.bits.viewport = true;
 
         double x = wl_fixed_to_double(fx), y = wl_fixed_to_double(fy), w = wl_fixed_to_double(fw), h = wl_fixed_to_double(fh);
 

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -72,8 +72,8 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
     m_resource->setOnDestroy([this](CWlSurface* r) { destroy(); });
 
     m_resource->setAttach([this](CWlSurface* r, wl_resource* buffer, int32_t x, int32_t y) {
-        m_pending.updated.buffer = true;
-        m_pending.updated.offset = true;
+        m_pending.updated.bits.buffer = true;
+        m_pending.updated.bits.offset = true;
 
         m_pending.offset = {x, y};
 
@@ -95,8 +95,8 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
         }
 
         if (m_pending.bufferSize != m_current.bufferSize) {
-            m_pending.updated.damage = true;
-            m_pending.bufferDamage   = CBox{{}, {INT32_MAX, INT32_MAX}};
+            m_pending.updated.bits.damage = true;
+            m_pending.bufferDamage        = CBox{{}, {INT32_MAX, INT32_MAX}};
         }
     });
 
@@ -124,7 +124,7 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
             return;
         }
 
-        if ((!m_pending.updated.buffer) ||            // no new buffer attached
+        if ((!m_pending.updated.bits.buffer) ||       // no new buffer attached
             (!m_pending.buffer && !m_pending.texture) // null buffer attached
         ) {
             commitState(m_pending);
@@ -149,7 +149,7 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
             m_pendingStates.pop();
         };
 
-        if (state->updated.acquire) {
+        if (state->updated.bits.acquire) {
             // wait on acquire point for this surface, from explicit sync protocol
             state->acquire.addWaiter(whenReadable);
         } else if (state->buffer->isSynchronous()) {
@@ -170,11 +170,11 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
     });
 
     m_resource->setDamage([this](CWlSurface* r, int32_t x, int32_t y, int32_t w, int32_t h) {
-        m_pending.updated.damage = true;
+        m_pending.updated.bits.damage = true;
         m_pending.damage.add(CBox{x, y, w, h});
     });
     m_resource->setDamageBuffer([this](CWlSurface* r, int32_t x, int32_t y, int32_t w, int32_t h) {
-        m_pending.updated.damage = true;
+        m_pending.updated.bits.damage = true;
         m_pending.bufferDamage.add(CBox{x, y, w, h});
     });
 
@@ -182,8 +182,8 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
         if (scale == m_pending.scale)
             return;
 
-        m_pending.updated.scale  = true;
-        m_pending.updated.damage = true;
+        m_pending.updated.bits.scale  = true;
+        m_pending.updated.bits.damage = true;
 
         m_pending.scale        = scale;
         m_pending.bufferDamage = CBox{{}, {INT32_MAX, INT32_MAX}};
@@ -193,15 +193,15 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
         if (tr == m_pending.transform)
             return;
 
-        m_pending.updated.transform = true;
-        m_pending.updated.damage    = true;
+        m_pending.updated.bits.transform = true;
+        m_pending.updated.bits.damage    = true;
 
         m_pending.transform    = (wl_output_transform)tr;
         m_pending.bufferDamage = CBox{{}, {INT32_MAX, INT32_MAX}};
     });
 
     m_resource->setSetInputRegion([this](CWlSurface* r, wl_resource* region) {
-        m_pending.updated.input = true;
+        m_pending.updated.bits.input = true;
 
         if (!region) {
             m_pending.input = CBox{{}, {INT32_MAX, INT32_MAX}};
@@ -213,7 +213,7 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
     });
 
     m_resource->setSetOpaqueRegion([this](CWlSurface* r, wl_resource* region) {
-        m_pending.updated.opaque = true;
+        m_pending.updated.bits.opaque = true;
 
         if (!region) {
             m_pending.opaque = CBox{{}, {}};
@@ -227,8 +227,8 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
     m_resource->setFrame([this](CWlSurface* r, uint32_t id) { m_callbacks.emplace_back(makeShared<CWLCallbackResource>(makeShared<CWlCallback>(m_client, 1, id))); });
 
     m_resource->setOffset([this](CWlSurface* r, int32_t x, int32_t y) {
-        m_pending.updated.offset = true;
-        m_pending.offset         = {x, y};
+        m_pending.updated.bits.offset = true;
+        m_pending.offset              = {x, y};
     });
 }
 

--- a/src/protocols/types/SurfaceState.cpp
+++ b/src/protocols/types/SurfaceState.cpp
@@ -65,36 +65,36 @@ void SSurfaceState::reset() {
 void SSurfaceState::updateFrom(SSurfaceState& ref) {
     updated = ref.updated;
 
-    if (ref.updated.buffer) {
+    if (ref.updated.bits.buffer) {
         buffer     = ref.buffer;
         texture    = ref.texture;
         size       = ref.size;
         bufferSize = ref.bufferSize;
     }
 
-    if (ref.updated.damage) {
+    if (ref.updated.bits.damage) {
         damage       = ref.damage;
         bufferDamage = ref.bufferDamage;
     }
 
-    if (ref.updated.input)
+    if (ref.updated.bits.input)
         input = ref.input;
 
-    if (ref.updated.opaque)
+    if (ref.updated.bits.opaque)
         opaque = ref.opaque;
 
-    if (ref.updated.offset)
+    if (ref.updated.bits.offset)
         offset = ref.offset;
 
-    if (ref.updated.scale)
+    if (ref.updated.bits.scale)
         scale = ref.scale;
 
-    if (ref.updated.transform)
+    if (ref.updated.bits.transform)
         transform = ref.transform;
 
-    if (ref.updated.viewport)
+    if (ref.updated.bits.viewport)
         viewport = ref.viewport;
 
-    if (ref.updated.acquire)
+    if (ref.updated.bits.acquire)
         acquire = ref.acquire;
 }

--- a/src/protocols/types/SurfaceState.hpp
+++ b/src/protocols/types/SurfaceState.hpp
@@ -20,7 +20,7 @@ struct SSurfaceState {
             bool offset : 1;
             bool viewport : 1;
             bool acquire : 1;
-        };
+        } bits;
     } updated;
 
     bool rejected = false;


### PR DESCRIPTION
turn on -Wpedantic and name the anonymous struct. to silence the warning.

makes us catch https://github.com/hyprwm/hyprwayland-scanner/commit/8fb426b3e5452fd9169453fd6c10f8c14ca37120 ahead of time instead of later.


