### PR TITLE
plugins: make currentWindow available to plugins in RENDER_PRE_WINDOW

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -517,6 +517,9 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
 
     renderdata.pWindow = pWindow;
 
+    // for plugins
+    g_pHyprOpenGL->m_renderData.currentWindow = pWindow;
+
     EMIT_HOOK_EVENT("render", RENDER_PRE_WINDOW);
 
     const auto fullAlpha = renderdata.alpha * renderdata.fadeAlpha;
@@ -680,9 +683,6 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
             }
         }
     }
-
-    // for plugins
-    g_pHyprOpenGL->m_renderData.currentWindow = pWindow;
 
     EMIT_HOOK_EVENT("render", RENDER_POST_WINDOW);
 


### PR DESCRIPTION
I was writing a plugin trying to lock `g_pHyprOpenGL->m_renderData.currentWindow` inside `RENDER_PRE_WINDOW`, but it was failing due to it not being set before `EMIT_HOOK_EVENT("render", RENDER_PRE_WINDOW)` was called.

The fix was to set `g_pHyprOpenGL->m_renderData.currentWindow` before the hook.