### PR TITLE
compositor: fix race to finish on null buffer

### DIFF
--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -128,6 +128,13 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
             (!m_pending.buffer && !m_pending.texture) // null buffer attached
         ) {
             commitState(m_pending);
+
+            if (!m_pending.buffer && !m_pending.texture) {
+                // null buffer attached, remove any pending states.
+                while (!m_pendingStates.empty()) {
+                    m_pendingStates.pop();
+                }
+            }
             m_pending.reset();
             return;
         }


### PR DESCRIPTION
if a null buffer is commited and a pending state is awaiting, drop the pending state so we dont end up in race to finish brokeness.

see: https://github.com/hyprwm/Hyprland/discussions/10951


