### PR TITLE
Prevent double-free in attemptDirectScanout 

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1554,10 +1554,9 @@ bool CMonitor::attemptDirectScanout() {
     // lock buffer while DRM/KMS is using it, then release it when page flip happens since DRM/KMS should be done by then
     // btw buffer's syncReleaser will take care of signaling release point, so we don't do that here
     PBUFFER->lock();
-    auto weakBuffer = WP<IHLBuffer>(PBUFFER);
-    PBUFFER->onBackendRelease([weakBuffer]() {
-        if (auto buffer = weakBuffer.lock())
-            buffer->unlock();
+    PBUFFER->onBackendRelease([wb = WP<IHLBuffer>{PBUFFER}] {
+        if (wb)
+            wb->unlock();
     });
 
     return true;


### PR DESCRIPTION
Fixes https://github.com/hyprwm/Hyprland/discussions/10940

This is what came to my mind after looking at the asan https://github.com/hyprwm/Hyprland/discussions/10940#discussioncomment-13702123
Sorry, if this is not right way to fix that.