### PR TITLE
Do not allow a null `CEGLSync` to reach `doOnReadable`

### DIFF
--- a/src/helpers/MonitorFrameScheduler.cpp
+++ b/src/helpers/MonitorFrameScheduler.cpp
@@ -102,6 +102,10 @@ void CMonitorFrameScheduler::onFrame() {
 
 void CMonitorFrameScheduler::onFinishRender() {
     m_sync = CEGLSync::create(); // this destroys the old sync
+    if (!m_sync) {
+        Debug::log(ERR, "onFinishRender: failed to create CEGLSync, skipping.");
+        return;
+    }
     g_pEventLoopManager->doOnReadable(m_sync->fd().duplicate(), [this, mon = m_monitor] {
         if (!m_monitor) // might've gotten destroyed
             return;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

The function `CEventLoopManager::doOnReadable` is expecting its first parameter to be a non-null value, but `CEGLSync::create` can potentially return a `nullptr`.

If `m_sync` is null, and it reaches `doOnReadable`, Hyprland will crash.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This is one way of addressing the problem, but there may be a better one. For example, maybe the null check should happen directly in `doOnReadable`. Here, I'm checking only where a null value might potentially reach the function.

#### Is it ready for merging, or does it need work?

It's ready for merging.