### PR TITLE
remove rathandler and dont spuriously trigger onx11events

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1213,18 +1213,6 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SBoolData{true},
     },
     SConfigOptionDescription{
-        .value       = "misc:render_ahead_of_time",
-        .description = "[Warning: buggy] starts rendering before your monitor displays a frame in order to lower latency",
-        .type        = CONFIG_OPTION_BOOL,
-        .data        = SConfigOptionDescription::SBoolData{false},
-    },
-    SConfigOptionDescription{
-        .value       = "misc:render_ahead_safezone",
-        .description = "how many ms of safezone to add to rendering ahead of time. Recommended 1-2.",
-        .type        = CONFIG_OPTION_INT,
-        .data        = SConfigOptionDescription::SRangeData{1, 1, 10},
-    },
-    SConfigOptionDescription{
         .value       = "misc:allow_session_lock_restore",
         .description = "if true, will allow you to restart a lockscreen app in case it crashes (red screen of death)",
         .type        = CONFIG_OPTION_BOOL,

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -483,8 +483,6 @@ CConfigManager::CConfigManager() {
     registerConfigVar("misc:swallow_exception_regex", {STRVAL_EMPTY});
     registerConfigVar("misc:focus_on_activate", Hyprlang::INT{0});
     registerConfigVar("misc:mouse_move_focuses_monitor", Hyprlang::INT{1});
-    registerConfigVar("misc:render_ahead_of_time", Hyprlang::INT{0});
-    registerConfigVar("misc:render_ahead_safezone", Hyprlang::INT{1});
     registerConfigVar("misc:allow_session_lock_restore", Hyprlang::INT{0});
     registerConfigVar("misc:close_special_on_empty", Hyprlang::INT{1});
     registerConfigVar("misc:background_color", Hyprlang::INT{0xff111111});

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -149,7 +149,6 @@ class CMonitor {
     bool                        m_pendingFrame    = false; // if we schedule a frame during rendering, reschedule it after
     bool                        m_renderingActive = false;
 
-    wl_event_source*            m_renderTimer   = nullptr; // for RAT
     bool                        m_ratsScheduled = false;
     CTimer                      m_lastPresentationTimer;
 

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -961,7 +961,6 @@ CXWM::CXWM() : m_connection(makeUnique<CXCBConnection>(g_pXWayland->m_server->m_
     m_screen                              = screen_iterator.data;
 
     m_eventSource = wl_event_loop_add_fd(g_pCompositor->m_wlEventLoop, g_pXWayland->m_server->m_xwmFDs[0].get(), WL_EVENT_READABLE, ::onX11Event, nullptr);
-    wl_event_source_check(m_eventSource);
 
     gatherResources();
     getVisual();


### PR DESCRIPTION
rathandler doesnt seem used, remove it.


wl_event_source_check makes the event trigger until onx11event returns non
zero. but we arent removing the event source from the event loop so lets
not mark it at all and recieve spurious constant calls. meaning if we have no x11 events its gonna endlessly trigger and poll and return 0.
