### PR TITLE
Handle scRGB and experimental FP16

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1483,12 +1483,6 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .type        = CONFIG_OPTION_BOOL,
         .data        = SConfigOptionDescription::SBoolData{false},
     },
-    SConfigOptionDescription{
-        .value       = "render:use_fp16",
-        .description = "Use FP16 for internal buffers. Required for scRGB HDR. Slightly increases VRAM usage (64mb extra at 4k)",
-        .type        = CONFIG_OPTION_BOOL,
-        .data        = SConfigOptionDescription::SBoolData{false},
-    },
 
     /*
      * cursor:
@@ -1911,8 +1905,15 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
 
     SConfigOptionDescription{
         .value       = "experimental:xx_color_management_v4",
-        .description = "enable color management protocol",
+        .description = "enable old xx v4 color management protocol (deprecated)",
         .type        = CONFIG_OPTION_BOOL,
         .data        = SConfigOptionDescription::SBoolData{false},
+    },
+    SConfigOptionDescription{
+        .value = "experimental:use_fp16",
+        .description =
+            "Use FP16 for internal buffers. Required for scRGB HDR. Slightly increases VRAM usage (64mb extra at 4k). Has some visual desktop effects glitches. Requires restart",
+        .type = CONFIG_OPTION_BOOL,
+        .data = SConfigOptionDescription::SBoolData{false},
     },
 };

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1477,10 +1477,18 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SRangeData{.value = 1, .min = 0, .max = 2},
     },
     SConfigOptionDescription{
+
         .value       = "render:new_render_scheduling",
         .description = "enable new render scheduling, which should improve FPS on underpowered devices. This does not add latency when your PC can keep up.",
         .type        = CONFIG_OPTION_BOOL,
         .data        = SConfigOptionDescription::SBoolData{false},
+    },
+    SConfigOptionDescription{
+        .value       = "render:use_fp16",
+        .description = "Use FP16 for internal buffers. Required for scRGB HDR. Slightly increases VRAM usage (64mb extra at 4k)",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{true},
+
     },
 
     /*

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1487,8 +1487,7 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .value       = "render:use_fp16",
         .description = "Use FP16 for internal buffers. Required for scRGB HDR. Slightly increases VRAM usage (64mb extra at 4k)",
         .type        = CONFIG_OPTION_BOOL,
-        .data        = SConfigOptionDescription::SBoolData{true},
-
+        .data        = SConfigOptionDescription::SBoolData{false},
     },
 
     /*

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -748,13 +748,13 @@ CConfigManager::CConfigManager() {
     registerConfigVar("render:send_content_type", Hyprlang::INT{1});
     registerConfigVar("render:cm_auto_hdr", Hyprlang::INT{1});
     registerConfigVar("render:new_render_scheduling", Hyprlang::INT{0});
-    registerConfigVar("render:use_fp16", Hyprlang::INT{0});
 
     registerConfigVar("ecosystem:no_update_news", Hyprlang::INT{0});
     registerConfigVar("ecosystem:no_donation_nag", Hyprlang::INT{0});
     registerConfigVar("ecosystem:enforce_permissions", Hyprlang::INT{0});
 
     registerConfigVar("experimental:xx_color_management_v4", Hyprlang::INT{0});
+    registerConfigVar("experimental:use_fp16", Hyprlang::INT{0});
 
     // devices
     m_config->addSpecialCategory("device", {"name"});

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -748,7 +748,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("render:send_content_type", Hyprlang::INT{1});
     registerConfigVar("render:cm_auto_hdr", Hyprlang::INT{1});
     registerConfigVar("render:new_render_scheduling", Hyprlang::INT{0});
-    registerConfigVar("render:use_fp16", Hyprlang::INT{1});
+    registerConfigVar("render:use_fp16", Hyprlang::INT{0});
 
     registerConfigVar("ecosystem:no_update_news", Hyprlang::INT{0});
     registerConfigVar("ecosystem:no_donation_nag", Hyprlang::INT{0});

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -748,6 +748,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("render:send_content_type", Hyprlang::INT{1});
     registerConfigVar("render:cm_auto_hdr", Hyprlang::INT{1});
     registerConfigVar("render:new_render_scheduling", Hyprlang::INT{0});
+    registerConfigVar("render:use_fp16", Hyprlang::INT{1});
 
     registerConfigVar("ecosystem:no_update_news", Hyprlang::INT{0});
     registerConfigVar("ecosystem:no_donation_nag", Hyprlang::INT{0});

--- a/src/helpers/Format.cpp
+++ b/src/helpers/Format.cpp
@@ -258,6 +258,8 @@ uint32_t NFormatUtils::drmFormatToGL(DRMFormat drm) {
 }
 
 uint32_t NFormatUtils::glFormatToType(uint32_t gl) {
+    if (gl == GL_RGBA16F)
+        return GL_FLOAT;
     return gl != GL_RGBA ? GL_UNSIGNED_INT_2_10_10_10_REV : GL_UNSIGNED_BYTE;
 }
 

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -41,6 +41,7 @@ using namespace Hyprutils::String;
 using namespace Hyprutils::Utils;
 using namespace Hyprutils::OS;
 using enum NContentType::eContentType;
+using namespace NColorManagement;
 
 CMonitor::CMonitor(SP<Aquamarine::IOutput> output_) : m_state(this), m_output(output_) {
     g_pAnimationManager->createAnimation(0.f, m_specialFade, g_pConfigManager->getAnimationPropertyConfig("specialWorkspaceIn"), AVARDAMAGE_NONE);
@@ -753,9 +754,7 @@ bool CMonitor::applyMonitorRule(SMonitorRule* pMonitorRule, bool force) {
     // clang-format off
     static const std::array<std::vector<std::pair<std::string, uint32_t>>, 2> formats{
         std::vector<std::pair<std::string, uint32_t>>{ /* 10-bit */
-            {"DRM_FORMAT_XRGB16161616", DRM_FORMAT_XRGB16161616}, {"DRM_FORMAT_XBGR16161616", DRM_FORMAT_XBGR16161616},
-            {"DRM_FORMAT_XRGB2101010", DRM_FORMAT_XRGB2101010}, {"DRM_FORMAT_XBGR2101010", DRM_FORMAT_XBGR2101010},
-            {"DRM_FORMAT_XRGB8888", DRM_FORMAT_XRGB8888}, {"DRM_FORMAT_XBGR8888", DRM_FORMAT_XBGR8888}
+            {"DRM_FORMAT_XRGB2101010", DRM_FORMAT_XRGB2101010}, {"DRM_FORMAT_XBGR2101010", DRM_FORMAT_XBGR2101010},{"DRM_FORMAT_XRGB8888", DRM_FORMAT_XRGB8888}, {"DRM_FORMAT_XBGR8888", DRM_FORMAT_XBGR8888}
         },
         std::vector<std::pair<std::string, uint32_t>>{ /* 8-bit */
             {"DRM_FORMAT_XRGB8888", DRM_FORMAT_XRGB8888}, {"DRM_FORMAT_XBGR8888", DRM_FORMAT_XBGR8888}
@@ -774,7 +773,7 @@ bool CMonitor::applyMonitorRule(SMonitorRule* pMonitorRule, bool force) {
             Debug::log(ERR, "output {} failed basic test on format {}", m_name, fmt.first);
         } else {
             Debug::log(LOG, "output {} succeeded basic test on format {}", m_name, fmt.first);
-            if (RULE->enable10bit && (fmt.first.contains("101010") || fmt.first.contains("161616")))
+            if (RULE->enable10bit && fmt.first.contains("101010"))
                 set10bit = true;
             break;
         }
@@ -1592,6 +1591,18 @@ int CMonitor::maxLuminance() {
 
 int CMonitor::maxAvgLuminance() {
     return m_maxAvgLuminance >= 0 ? m_maxAvgLuminance : (m_output->parsedEDID.hdrMetadata.has_value() ? m_output->parsedEDID.hdrMetadata->desiredMaxFrameAverageLuminance : 80);
+}
+
+bool CMonitor::wantsWideColor() {
+    return supportsWideColor() && (wantsHDR() || m_imageDescription.primariesNamed == CM_PRIMARIES_BT2020);
+}
+
+bool CMonitor::wantsHDR() {
+    return supportsHDR() && inHDR();
+}
+
+bool CMonitor::inHDR() {
+    return m_output->state->state().hdrMetadata.hdmi_metadata_type1.eotf == 2;
 }
 
 CMonitorState::CMonitorState(CMonitor* owner) : m_owner(owner) {

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -753,7 +753,9 @@ bool CMonitor::applyMonitorRule(SMonitorRule* pMonitorRule, bool force) {
     // clang-format off
     static const std::array<std::vector<std::pair<std::string, uint32_t>>, 2> formats{
         std::vector<std::pair<std::string, uint32_t>>{ /* 10-bit */
-            {"DRM_FORMAT_XRGB2101010", DRM_FORMAT_XRGB2101010}, {"DRM_FORMAT_XBGR2101010", DRM_FORMAT_XBGR2101010}, {"DRM_FORMAT_XRGB8888", DRM_FORMAT_XRGB8888}, {"DRM_FORMAT_XBGR8888", DRM_FORMAT_XBGR8888}
+            {"DRM_FORMAT_XRGB16161616", DRM_FORMAT_XRGB16161616}, {"DRM_FORMAT_XBGR16161616", DRM_FORMAT_XBGR16161616},
+            {"DRM_FORMAT_XRGB2101010", DRM_FORMAT_XRGB2101010}, {"DRM_FORMAT_XBGR2101010", DRM_FORMAT_XBGR2101010},
+            {"DRM_FORMAT_XRGB8888", DRM_FORMAT_XRGB8888}, {"DRM_FORMAT_XBGR8888", DRM_FORMAT_XBGR8888}
         },
         std::vector<std::pair<std::string, uint32_t>>{ /* 8-bit */
             {"DRM_FORMAT_XRGB8888", DRM_FORMAT_XRGB8888}, {"DRM_FORMAT_XBGR8888", DRM_FORMAT_XBGR8888}
@@ -772,7 +774,7 @@ bool CMonitor::applyMonitorRule(SMonitorRule* pMonitorRule, bool force) {
             Debug::log(ERR, "output {} failed basic test on format {}", m_name, fmt.first);
         } else {
             Debug::log(LOG, "output {} succeeded basic test on format {}", m_name, fmt.first);
-            if (RULE->enable10bit && fmt.first.contains("101010"))
+            if (RULE->enable10bit && (fmt.first.contains("101010") || fmt.first.contains("161616")))
                 set10bit = true;
             break;
         }

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -413,6 +413,7 @@ void CMonitor::onDisconnect(bool destroy) {
 }
 
 void CMonitor::applyCMType(eCMType cmType) {
+    auto oldImageDescription = m_imageDescription;
     switch (cmType) {
         case CM_SRGB: m_imageDescription = {}; break; // assumes SImageDescirption defaults to sRGB
         case CM_WIDE:
@@ -462,6 +463,9 @@ void CMonitor::applyCMType(eCMType cmType) {
         m_imageDescription.luminances.max = m_maxLuminance;
     if (m_maxAvgLuminance >= 0)
         m_imageDescription.luminances.reference = m_maxAvgLuminance;
+
+    if (oldImageDescription != m_imageDescription)
+        PROTO::colorManagement->onMonitorImageDescriptionChanged(m_self);
 }
 
 bool CMonitor::applyMonitorRule(SMonitorRule* pMonitorRule, bool force) {
@@ -784,8 +788,7 @@ bool CMonitor::applyMonitorRule(SMonitorRule* pMonitorRule, bool force) {
     m_supportsWideColor = RULE->supportsHDR;
     m_supportsHDR       = RULE->supportsHDR;
 
-    auto oldImageDescription = m_imageDescription;
-    m_cmType                 = RULE->cmType;
+    m_cmType = RULE->cmType;
     switch (m_cmType) {
         case CM_AUTO: m_cmType = m_enabled10bit && supportsWideColor() ? CM_WIDE : CM_SRGB; break;
         case CM_EDID: m_cmType = m_output->parsedEDID.chromaticityCoords.has_value() ? CM_EDID : CM_SRGB; break;
@@ -802,8 +805,6 @@ bool CMonitor::applyMonitorRule(SMonitorRule* pMonitorRule, bool force) {
     m_maxAvgLuminance = RULE->maxAvgLuminance;
 
     applyCMType(m_cmType);
-    if (oldImageDescription != m_imageDescription)
-        PROTO::colorManagement->onMonitorImageDescriptionChanged(m_self);
 
     m_sdrSaturation = RULE->sdrSaturation;
     m_sdrBrightness = RULE->sdrBrightness;

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -238,6 +238,11 @@ class CMonitor {
     int                                 maxLuminance();
     int                                 maxAvgLuminance();
 
+    bool                                wantsWideColor();
+    bool                                wantsHDR();
+
+    bool                                inHDR();
+
     bool                                m_enabled             = false;
     bool                                m_renderingInitPassed = false;
     WP<CWindow>                         m_previousFSWindow;

--- a/src/managers/ProtocolManager.cpp
+++ b/src/managers/ProtocolManager.cpp
@@ -104,6 +104,7 @@ CProtocolManager::CProtocolManager() {
     static const auto PENABLECM   = CConfigValue<Hyprlang::INT>("render:cm_enabled");
     static const auto PENABLEXXCM = CConfigValue<Hyprlang::INT>("experimental:xx_color_management_v4");
     static const auto PDEBUGCM    = CConfigValue<Hyprlang::INT>("debug:full_cm_proto");
+    static const auto PFP16       = CConfigValue<Hyprlang::INT>("experimental:use_fp16");
 
     // Outputs are a bit dumb, we have to agree.
     static auto P = g_pHookSystem->hookDynamic("monitorAdded", [this](void* self, SCallbackInfo& info, std::any param) {
@@ -191,7 +192,7 @@ CProtocolManager::CProtocolManager() {
     PROTO::extWorkspace        = makeUnique<CExtWorkspaceProtocol>(&ext_workspace_manager_v1_interface, 1, "ExtWorkspace");
 
     if (*PENABLECM)
-        PROTO::colorManagement = makeUnique<CColorManagementProtocol>(&wp_color_manager_v1_interface, 1, "ColorManagement", *PDEBUGCM);
+        PROTO::colorManagement = makeUnique<CColorManagementProtocol>(&wp_color_manager_v1_interface, 1, "ColorManagement", *PDEBUGCM, *PFP16);
 
     if (*PENABLEXXCM && *PENABLECM) {
         PROTO::xxColorManagement   = makeUnique<CXXColorManagementProtocol>(&xx_color_manager_v4_interface, 1, "XXColorManagement");

--- a/src/protocols/ColorManagement.cpp
+++ b/src/protocols/ColorManagement.cpp
@@ -16,12 +16,14 @@ CColorManager::CColorManager(SP<CWpColorManagerV1> resource) : m_resource(resour
     m_resource->sendSupportedFeature(WP_COLOR_MANAGER_V1_FEATURE_SET_PRIMARIES);
     m_resource->sendSupportedFeature(WP_COLOR_MANAGER_V1_FEATURE_SET_LUMINANCES);
 
+    if (PROTO::colorManagement->m_debug || PROTO::colorManagement->m_allowScRGB)
+        m_resource->sendSupportedFeature(WP_COLOR_MANAGER_V1_FEATURE_WINDOWS_SCRGB);
+
     if (PROTO::colorManagement->m_debug) {
         m_resource->sendSupportedFeature(WP_COLOR_MANAGER_V1_FEATURE_ICC_V2_V4);
         m_resource->sendSupportedFeature(WP_COLOR_MANAGER_V1_FEATURE_SET_TF_POWER);
         m_resource->sendSupportedFeature(WP_COLOR_MANAGER_V1_FEATURE_SET_MASTERING_DISPLAY_PRIMARIES);
         m_resource->sendSupportedFeature(WP_COLOR_MANAGER_V1_FEATURE_EXTENDED_TARGET_VOLUME);
-        m_resource->sendSupportedFeature(WP_COLOR_MANAGER_V1_FEATURE_WINDOWS_SCRGB);
     }
 
     m_resource->sendSupportedPrimariesNamed(WP_COLOR_MANAGER_V1_PRIMARIES_SRGB);
@@ -773,8 +775,8 @@ wl_client* CColorManagementImageDescriptionInfo::client() {
     return m_client;
 }
 
-CColorManagementProtocol::CColorManagementProtocol(const wl_interface* iface, const int& ver, const std::string& name, bool debug) :
-    IWaylandProtocol(iface, ver, name), m_debug(debug) {
+CColorManagementProtocol::CColorManagementProtocol(const wl_interface* iface, const int& ver, const std::string& name, bool debug, bool scRGB) :
+    IWaylandProtocol(iface, ver, name), m_debug(debug), m_allowScRGB(scRGB) {
     ;
 }
 

--- a/src/protocols/ColorManagement.cpp
+++ b/src/protocols/ColorManagement.cpp
@@ -176,7 +176,7 @@ CColorManager::CColorManager(SP<CWpColorManagerV1> resource) : m_resource(resour
     });
     m_resource->setCreateWindowsScrgb([](CWpColorManagerV1* r, uint32_t id) {
         LOGM(WARN, "New Windows scRGB description id={} (unsupported)", id);
-        if (!PROTO::colorManagement->m_debug) {
+        if (!PROTO::colorManagement->m_debug && !PROTO::colorManagement->m_allowScRGB) {
             r->error(WP_COLOR_MANAGER_V1_ERROR_UNSUPPORTED_FEATURE, "Windows scRGB profiles are not supported");
             return;
         }

--- a/src/protocols/ColorManagement.cpp
+++ b/src/protocols/ColorManagement.cpp
@@ -260,11 +260,11 @@ CColorManagementSurface::CColorManagementSurface(SP<CWpColorManagementSurfaceV1>
     m_client = m_resource->client();
 
     m_resource->setDestroy([this](CWpColorManagementSurfaceV1* r) {
-        LOGM(TRACE, "Destroy xx cm surface {}", (uintptr_t)m_surface);
+        LOGM(TRACE, "Destroy wp cm surface {}", (uintptr_t)m_surface);
         PROTO::colorManagement->destroyResource(this);
     });
     m_resource->setOnDestroy([this](CWpColorManagementSurfaceV1* r) {
-        LOGM(TRACE, "Destroy xx cm surface {}", (uintptr_t)m_surface);
+        LOGM(TRACE, "Destroy wp cm surface {}", (uintptr_t)m_surface);
         PROTO::colorManagement->destroyResource(this);
     });
 
@@ -339,6 +339,16 @@ bool CColorManagementSurface::needsHdrMetadataUpdate() {
     return m_needsNewMetadata;
 }
 
+bool CColorManagementSurface::isHDR() {
+    return m_imageDescription.transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ || isWindowsScRGB();
+}
+
+bool CColorManagementSurface::isWindowsScRGB() {
+    return m_imageDescription.windowsScRGB ||
+        // autodetect scRGB, might be incorrect
+        (m_imageDescription.primariesNamed == NColorManagement::CM_PRIMARIES_SRGB && m_imageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_EXT_LINEAR);
+}
+
 CColorManagementFeedbackSurface::CColorManagementFeedbackSurface(SP<CWpColorManagementSurfaceFeedbackV1> resource, SP<CWLSurfaceResource> surface_) :
     m_surface(surface_), m_resource(resource) {
     if UNLIKELY (!good())
@@ -347,13 +357,13 @@ CColorManagementFeedbackSurface::CColorManagementFeedbackSurface(SP<CWpColorMana
     m_client = m_resource->client();
 
     m_resource->setDestroy([this](CWpColorManagementSurfaceFeedbackV1* r) {
-        LOGM(TRACE, "Destroy xx cm feedback surface {}", (uintptr_t)m_surface);
+        LOGM(TRACE, "Destroy wp cm feedback surface {}", (uintptr_t)m_surface);
         if (m_currentPreferred.valid())
             PROTO::colorManagement->destroyResource(m_currentPreferred.get());
         PROTO::colorManagement->destroyResource(this);
     });
     m_resource->setOnDestroy([this](CWpColorManagementSurfaceFeedbackV1* r) {
-        LOGM(TRACE, "Destroy xx cm feedback surface {}", (uintptr_t)m_surface);
+        LOGM(TRACE, "Destroy wp cm feedback surface {}", (uintptr_t)m_surface);
         if (m_currentPreferred.valid())
             PROTO::colorManagement->destroyResource(m_currentPreferred.get());
         PROTO::colorManagement->destroyResource(this);

--- a/src/protocols/ColorManagement.hpp
+++ b/src/protocols/ColorManagement.hpp
@@ -174,7 +174,7 @@ class CColorManagementImageDescriptionInfo {
 
 class CColorManagementProtocol : public IWaylandProtocol {
   public:
-    CColorManagementProtocol(const wl_interface* iface, const int& ver, const std::string& name, bool debug = false);
+    CColorManagementProtocol(const wl_interface* iface, const int& ver, const std::string& name, bool debug = false, bool scRGB = false);
 
     virtual void bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id);
 
@@ -197,7 +197,8 @@ class CColorManagementProtocol : public IWaylandProtocol {
     std::vector<SP<CColorManagementIccCreator>>        m_iccCreators;
     std::vector<SP<CColorManagementParametricCreator>> m_parametricCreators;
     std::vector<SP<CColorManagementImageDescription>>  m_imageDescriptions;
-    bool                                               m_debug = false;
+    bool                                               m_debug      = false;
+    bool                                               m_allowScRGB = false;
 
     friend class CColorManager;
     friend class CColorManagementOutput;

--- a/src/protocols/ColorManagement.hpp
+++ b/src/protocols/ColorManagement.hpp
@@ -60,6 +60,8 @@ class CColorManagementSurface {
     const hdr_output_metadata&                 hdrMetadata();
     void                                       setHDRMetadata(const hdr_output_metadata& metadata);
     bool                                       needsHdrMetadataUpdate();
+    bool                                       isHDR();
+    bool                                       isWindowsScRGB();
 
   private:
     SP<CWpColorManagementSurfaceV1>     m_resource;

--- a/src/protocols/types/ColorManagement.hpp
+++ b/src/protocols/types/ColorManagement.hpp
@@ -202,7 +202,8 @@ namespace NColorManagement {
 
         float getTFMaxLuminance(int sdrMaxLuminance = -1) const {
             switch (transferFunction) {
-                case CM_TRANSFER_FUNCTION_EXT_LINEAR: return HDR_MAX_LUMINANCE; // assume Windows scRGB
+                case CM_TRANSFER_FUNCTION_EXT_LINEAR:
+                    return SDR_MAX_LUMINANCE; // assume Windows scRGB. white color range 1.0 - 125.0 maps to SDR_MAX_LUMINANCE (80) - HDR_MAX_LUMINANCE (10000)
                 case CM_TRANSFER_FUNCTION_ST2084_PQ: return HDR_MAX_LUMINANCE;
                 case CM_TRANSFER_FUNCTION_HLG: return HLG_MAX_LUMINANCE;
                 case CM_TRANSFER_FUNCTION_GAMMA22:

--- a/src/protocols/types/ColorManagement.hpp
+++ b/src/protocols/types/ColorManagement.hpp
@@ -202,6 +202,7 @@ namespace NColorManagement {
 
         float getTFMaxLuminance(int sdrMaxLuminance = -1) const {
             switch (transferFunction) {
+                case CM_TRANSFER_FUNCTION_EXT_LINEAR: return HDR_MAX_LUMINANCE; // assume Windows scRGB
                 case CM_TRANSFER_FUNCTION_ST2084_PQ: return HDR_MAX_LUMINANCE;
                 case CM_TRANSFER_FUNCTION_HLG: return HLG_MAX_LUMINANCE;
                 case CM_TRANSFER_FUNCTION_GAMMA22:

--- a/src/render/Framebuffer.cpp
+++ b/src/render/Framebuffer.cpp
@@ -10,7 +10,7 @@ bool CFramebuffer::alloc(int w, int h, uint32_t drmFormat) {
     bool firstAlloc = false;
     RASSERT((w > 0 && h > 0), "cannot alloc a FB with negative / zero size! (attempted {}x{})", w, h);
 
-    static auto PFP16 = CConfigValue<Hyprlang::INT>("render:use_fp16");
+    static auto PFP16 = CConfigValue<Hyprlang::INT>("experimental:use_fp16");
 
     uint32_t    glFormat = *PFP16 ? GL_RGBA16F : NFormatUtils::drmFormatToGL(drmFormat);
     uint32_t    glType   = NFormatUtils::glFormatToType(glFormat);

--- a/src/render/Framebuffer.cpp
+++ b/src/render/Framebuffer.cpp
@@ -10,9 +10,9 @@ bool CFramebuffer::alloc(int w, int h, uint32_t drmFormat) {
     bool firstAlloc = false;
     RASSERT((w > 0 && h > 0), "cannot alloc a FB with negative / zero size! (attempted {}x{})", w, h);
 
-    static auto PFP16 = CConfigValue<Hyprlang::INT>("render:send_content_type");
+    static auto PFP16 = CConfigValue<Hyprlang::INT>("render:use_fp16");
 
-    uint32_t    glFormat = NFormatUtils::drmFormatToGL(drmFormat);
+    uint32_t    glFormat = *PFP16 ? GL_RGBA16F : NFormatUtils::drmFormatToGL(drmFormat);
     uint32_t    glType   = NFormatUtils::glFormatToType(glFormat);
 
     if (drmFormat != m_drmFormat || m_size != Vector2D{w, h})
@@ -39,7 +39,7 @@ bool CFramebuffer::alloc(int w, int h, uint32_t drmFormat) {
 
     if (firstAlloc || m_size != Vector2D(w, h)) {
         m_tex->bind();
-        glTexImage2D(GL_TEXTURE_2D, 0, *PFP16 ? GL_RGBA16F : glFormat, w, h, 0, GL_RGBA, glType, nullptr);
+        glTexImage2D(GL_TEXTURE_2D, 0, glFormat, w, h, 0, GL_RGBA, glType, nullptr);
         glBindFramebuffer(GL_FRAMEBUFFER, m_fb);
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_tex->m_texID, 0);
 

--- a/src/render/Framebuffer.cpp
+++ b/src/render/Framebuffer.cpp
@@ -1,5 +1,6 @@
 #include "Framebuffer.hpp"
 #include "OpenGL.hpp"
+#include "../config/ConfigValue.hpp"
 
 CFramebuffer::CFramebuffer() {
     ;
@@ -9,8 +10,10 @@ bool CFramebuffer::alloc(int w, int h, uint32_t drmFormat) {
     bool firstAlloc = false;
     RASSERT((w > 0 && h > 0), "cannot alloc a FB with negative / zero size! (attempted {}x{})", w, h);
 
-    uint32_t glFormat = NFormatUtils::drmFormatToGL(drmFormat);
-    uint32_t glType   = NFormatUtils::glFormatToType(glFormat);
+    static auto PFP16 = CConfigValue<Hyprlang::INT>("render:send_content_type");
+
+    uint32_t    glFormat = NFormatUtils::drmFormatToGL(drmFormat);
+    uint32_t    glType   = NFormatUtils::glFormatToType(glFormat);
 
     if (drmFormat != m_drmFormat || m_size != Vector2D{w, h})
         release();
@@ -36,7 +39,7 @@ bool CFramebuffer::alloc(int w, int h, uint32_t drmFormat) {
 
     if (firstAlloc || m_size != Vector2D(w, h)) {
         m_tex->bind();
-        glTexImage2D(GL_TEXTURE_2D, 0, glFormat, w, h, 0, GL_RGBA, glType, nullptr);
+        glTexImage2D(GL_TEXTURE_2D, 0, *PFP16 ? GL_RGBA16F : glFormat, w, h, 0, GL_RGBA, glType, nullptr);
         glBindFramebuffer(GL_FRAMEBUFFER, m_fb);
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, m_tex->m_texID, 0);
 

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1576,13 +1576,15 @@ void CHyprOpenGLImpl::renderTextureInternalWithDamage(SP<CTexture> tex, const CB
         tex->setTexParameter(GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     }
 
+    const bool canPassHDRSurface = m_renderData.surface.valid() && m_renderData.surface->m_colorManagement.valid() ?
+        m_renderData.surface->m_colorManagement->isHDR() && !m_renderData.surface->m_colorManagement->isWindowsScRGB() :
+        false; // windows scRGB requires CM shader
     const auto imageDescription =
         m_renderData.surface.valid() && m_renderData.surface->m_colorManagement.valid() ? m_renderData.surface->m_colorManagement->imageDescription() : SImageDescription{};
 
     const bool skipCM = !*PENABLECM || !m_cmSupported                      /* CM unsupported or disabled */
         || (imageDescription == m_renderData.pMonitor->m_imageDescription) /* Source and target have the same image description */
-        || ((*PPASS == 1 || (*PPASS == 2 && imageDescription.transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ)) && m_renderData.pMonitor->m_activeWorkspace &&
-            m_renderData.pMonitor->m_activeWorkspace->m_hasFullscreenWindow &&
+        || ((*PPASS == 1 || (*PPASS == 2 && canPassHDRSurface)) && m_renderData.pMonitor->m_activeWorkspace && m_renderData.pMonitor->m_activeWorkspace->m_hasFullscreenWindow &&
             m_renderData.pMonitor->m_activeWorkspace->m_fullscreenMode == FSMODE_FULLSCREEN) /* Fullscreen window with pass cm enabled */;
 
     if (!skipCM && !usingFinalShader && (texType == TEXTURE_RGBA || texType == TEXTURE_RGBX))

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -36,6 +36,7 @@
 #include "../protocols/ColorManagement.hpp"
 #include "../protocols/types/ContentType.hpp"
 #include "../helpers/MiscFunctions.hpp"
+#include "protocols/types/ColorManagement.hpp"
 
 #include <hyprutils/utils/ScopeGuard.hpp>
 using namespace Hyprutils::Utils;
@@ -1455,6 +1456,9 @@ static hdr_output_metadata       createHDRMetadata(SImageDescription settings, A
     switch (settings.transferFunction) {
         case CM_TRANSFER_FUNCTION_SRGB: eotf = 0; break; // used to send primaries and luminances to AQ. ignored for now
         case CM_TRANSFER_FUNCTION_ST2084_PQ: eotf = 2; break;
+        case CM_TRANSFER_FUNCTION_EXT_LINEAR:
+            eotf = 2;
+            break; // should be Windows scRGB
         // case CM_TRANSFER_FUNCTION_HLG: eotf = 3; break; TODO check display capabilities first
         default: return NO_HDR_METADATA; // empty metadata for SDR
     }
@@ -1497,7 +1501,6 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
     static auto PAUTOHDR = CConfigValue<Hyprlang::INT>("render:cm_auto_hdr");
 
     const bool  configuredHDR = (pMonitor->m_cmType == CM_HDR_EDID || pMonitor->m_cmType == CM_HDR);
-    const bool  hdsIsActive   = pMonitor->m_output->state->state().hdrMetadata.hdmi_metadata_type1.eotf == 2;
     bool        wantHDR       = configuredHDR;
 
     if (pMonitor->supportsHDR()) {
@@ -1520,7 +1523,7 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
 
             // we have a surface with image description
             if (SURF && SURF->m_colorManagement.valid() && SURF->m_colorManagement->hasImageDescription()) {
-                const bool surfaceIsHDR = SURF->m_colorManagement->imageDescription().transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ;
+                const bool surfaceIsHDR = SURF->m_colorManagement->isHDR();
                 if (*PPASS == 1 || (*PPASS == 2 && surfaceIsHDR)) {
                     // passthrough
                     bool needsHdrMetadataUpdate = SURF->m_colorManagement->needsHdrMetadataUpdate() || pMonitor->m_previousFSWindow != WINDOW;
@@ -1537,8 +1540,8 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
         }
 
         if (!hdrIsHandled) {
-            if (hdsIsActive != wantHDR) {
-                if (*PAUTOHDR && !(hdsIsActive && configuredHDR)) {
+            if (pMonitor->inHDR() != wantHDR) {
+                if (*PAUTOHDR && !(pMonitor->inHDR() && configuredHDR)) {
                     // modify or restore monitor image description for auto-hdr
                     // FIXME ok for now, will need some other logic if monitor image description can be modified some other way
                     pMonitor->applyCMType(wantHDR ? (*PAUTOHDR == 2 ? CM_HDR_EDID : CM_HDR) : pMonitor->m_cmType);
@@ -1549,7 +1552,7 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
         }
     }
 
-    const bool needsWCG = pMonitor->m_output->state->state().hdrMetadata.hdmi_metadata_type1.eotf == 2 || pMonitor->m_imageDescription.primariesNamed == CM_PRIMARIES_BT2020;
+    const bool needsWCG = pMonitor->wantsWideColor();
     if (pMonitor->m_output->state->state().wideColorGamut != needsWCG) {
         Debug::log(TRACE, "Setting wide color gamut {}", needsWCG ? "on" : "off");
         pMonitor->m_output->state->setWideColorGamut(needsWCG);

--- a/src/render/pass/SurfacePassElement.cpp
+++ b/src/render/pass/SurfacePassElement.cpp
@@ -77,8 +77,6 @@ void CSurfacePassElement::draw(const CRegion& damage) {
         DELTALESSTHAN(windowBox.height, m_data.surface->m_current.bufferSize.y, 3) /* off by one-or-two */ &&
         (!m_data.pWindow || (!m_data.pWindow->m_realSize->isBeingAnimated() && !INTERACTIVERESIZEINPROGRESS)) /* not window or not animated/resizing */;
 
-    if (m_data.surface->m_colorManagement.valid())
-        Debug::log(TRACE, "FIXME: rendering surface with color management enabled, should apply necessary transformations");
     g_pHyprRenderer->calculateUVForSurface(m_data.pWindow, m_data.surface, m_data.pMonitor->m_self.lock(), m_data.mainSurface, windowBox.size(), PROJSIZEUNSCALED, MISALIGNEDFSV1);
 
     auto cancelRender                      = false;

--- a/src/render/shaders/glsl/blurprepare.frag
+++ b/src/render/shaders/glsl/blurprepare.frag
@@ -43,6 +43,8 @@ void main() {
     if (brightness > 1.0) {
         pixColor.rgb *= brightness;
     }
+    
+    pixColor.rgb = clamp(pixColor.rgb, vec3(0.0), vec3(1.0));
 
     fragColor = pixColor;
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds `experimental:use_fp16` to create internal framebuffers with FP16 format. Requires restart or something else to trigger framebuffer recreation.
Handles windows scRGB and matching formats as HDR. Fixes HDR in Control.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Most of the shaders, mirroring and image export stuff aren't ready to deal with FP16. This PR focuses on correct scRGB handling.
Known issues:
* blur/shadows might have incorrect colors depending on background, color and contrast/brightness settings
* screenshots are black
* transparent parts of some overlay layers might turn black (strange one, eww bar renders black on top of fullscreen windows between it's widgets while the widgets themselves aren't rendered)

Easier to test with Cyberpunk 2077. If it's working then PQ HDR and scRGB shouldn't have any noticeable difference. If it doesn't then scRGB should either switch to SDR mode or have obviously incorrect colors.

#### Is it ready for merging, or does it need work?
Somewhat ready (assuming fp16 issues will be fixed in some other PR)
