### PR TITLE
seat: set keyboardFocus when m_lastFocus doesn't match the keyboard focus…

### DIFF
--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -90,8 +90,13 @@ void CSeatManager::setKeyboard(SP<IKeyboard> KEEB) {
         m_keyboard->m_active = false;
     m_keyboard = KEEB;
 
-    if (KEEB)
+    if (KEEB) {
         KEEB->m_active = true;
+
+        // m_lastFocus was set without a keyboard
+        if (KEEB->m_enabled && g_pCompositor->m_lastFocus && g_pCompositor->m_lastFocus != m_state.keyboardFocus)
+            setKeyboardFocus(g_pCompositor->m_lastFocus.lock());
+    }
 
     updateActiveKeyboardData();
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Attempts to fix issues like this: https://github.com/hyprwm/hyprlock/issues/797

I thought it would also fix the cursor not being hidden when switching ttys without mouse movement. For some reason that is not the case though. (Also not when instead of using `setKeyboardFocus()`, calling the entire `g_pInputManager->refocus()` function.)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

The current problem is easily reproducible.

1. `sleep 5 && hyprlock`
2. switch tty and wait for the sleep to finish
3. switch back
4. SLS has no keyboard focus

This fixes that.
Although I am not sure if there would be a better place to handle this stuff.
Alternative solution ideas welcome.

#### Is it ready for merging, or does it need work?

Theoretically ready.

