### PR TITLE
Add cursor:enabled to allow to disable it 

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1494,6 +1494,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
      */
 
     SConfigOptionDescription{
+        .value       = "cursor:enabled",
+        .description = "render a cursor",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{true},
+    },
+    SConfigOptionDescription{
         .value       = "cursor:no_hardware_cursors",
         .description = "disables hardware cursors. Auto = disable when multi-gpu on nvidia",
         .type        = CONFIG_OPTION_CHOICE,

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -709,6 +709,7 @@ CConfigManager::CConfigManager() {
 
     registerConfigVar("opengl:nvidia_anti_flicker", Hyprlang::INT{1});
 
+    registerConfigVar("cursor:enabled", Hyprlang::INT{1});
     registerConfigVar("cursor:no_hardware_cursors", Hyprlang::INT{2});
     registerConfigVar("cursor:no_break_fs_vrr", Hyprlang::INT{2});
     registerConfigVar("cursor:min_refresh_rate", Hyprlang::INT{24});

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2030,6 +2030,7 @@ void CHyprRenderer::setCursorFromName(const std::string& name, bool force) {
 }
 
 void CHyprRenderer::ensureCursorRenderingMode() {
+    static auto PENABLED       = CConfigValue<Hyprlang::INT>("cursor:enabled");
     static auto PCURSORTIMEOUT = CConfigValue<Hyprlang::FLOAT>("cursor:inactive_timeout");
     static auto PHIDEONTOUCH   = CConfigValue<Hyprlang::INT>("cursor:hide_on_touch");
     static auto PHIDEONKEY     = CConfigValue<Hyprlang::INT>("cursor:hide_on_key_press");
@@ -2044,7 +2045,10 @@ void CHyprRenderer::ensureCursorRenderingMode() {
     if (*PCURSORTIMEOUT > 0)
         m_cursorHiddenConditions.hiddenOnTimeout = *PCURSORTIMEOUT < g_pInputManager->m_lastCursorMovement.getSeconds();
 
-    const bool HIDE = m_cursorHiddenConditions.hiddenOnTimeout || m_cursorHiddenConditions.hiddenOnTouch || m_cursorHiddenConditions.hiddenOnKeyboard;
+    bool HIDE = m_cursorHiddenConditions.hiddenOnTimeout || m_cursorHiddenConditions.hiddenOnTouch || m_cursorHiddenConditions.hiddenOnKeyboard;
+
+    if (*PENABLED == 0)
+        HIDE = true;
 
     if (HIDE == m_cursorHidden)
         return;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
It allows users to disable the cursor as it now is possible to draw you own cursor using the screen shader

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
There is an issue when using the hardware cursor with disabled cursor as the monitor(s) don't get damaged(with demage tracking 0 as otherwise the pointer can not be used by the shader) and the shader is not rerun

#### Is it ready for merging, or does it need work?
Advice is needed on the hadware cursor issue

