### PR TITLE
frameshed: dont if check deleted weakpointer

### DIFF
--- a/src/helpers/MonitorFrameScheduler.cpp
+++ b/src/helpers/MonitorFrameScheduler.cpp
@@ -103,7 +103,7 @@ void CMonitorFrameScheduler::onFrame() {
 void CMonitorFrameScheduler::onFinishRender() {
     m_sync = CEGLSync::create(); // this destroys the old sync
     g_pEventLoopManager->doOnReadable(m_sync->fd().duplicate(), [this, mon = m_monitor] {
-        if (!m_monitor) // might've gotten destroyed
+        if (!mon) // might've gotten destroyed
             return;
         onSyncFired();
     });


### PR DESCRIPTION
if m_monitor is destroyed the doOnReadable will eventually hit UB on destruction if checking a destroyed m_monitor. acctually use the captured mon weak pointer.


rare occurance catched it once in nested with UBSAN.


