### PR TITLE
Snap plugins

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -236,6 +236,18 @@ CBox CWindow::getWindowIdealBoundingBoxIgnoreReserved() {
     return CBox{(int)POS.x, (int)POS.y, (int)SIZE.x, (int)SIZE.y};
 }
 
+SBoxExtents CWindow::getWindowExtentsUnified(uint64_t properties) {
+    SBoxExtents extents = {.topLeft = {0, 0}, .bottomRight = {0, 0}};
+    if (properties & RESERVED_EXTENTS)
+        extents.addExtents(g_pDecorationPositioner->getWindowDecorationReserved(m_self.lock()));
+    if (properties & INPUT_EXTENTS)
+        extents.addExtents(g_pDecorationPositioner->getWindowDecorationExtents(m_self.lock(), true));
+    if (properties & FULL_EXTENTS)
+        extents.addExtents(g_pDecorationPositioner->getWindowDecorationExtents(m_self.lock(), false));
+
+    return extents;
+}
+
 CBox CWindow::getWindowBoxUnified(uint64_t properties) {
     if (m_windowData.dimAround.valueOrDefault()) {
         const auto PMONITOR = m_monitor.lock();
@@ -243,16 +255,8 @@ CBox CWindow::getWindowBoxUnified(uint64_t properties) {
             return {PMONITOR->m_position.x, PMONITOR->m_position.y, PMONITOR->m_size.x, PMONITOR->m_size.y};
     }
 
-    SBoxExtents EXTENTS = {.topLeft = {0, 0}, .bottomRight = {0, 0}};
-    if (properties & RESERVED_EXTENTS)
-        EXTENTS.addExtents(g_pDecorationPositioner->getWindowDecorationReserved(m_self.lock()));
-    if (properties & INPUT_EXTENTS)
-        EXTENTS.addExtents(g_pDecorationPositioner->getWindowDecorationExtents(m_self.lock(), true));
-    if (properties & FULL_EXTENTS)
-        EXTENTS.addExtents(g_pDecorationPositioner->getWindowDecorationExtents(m_self.lock(), false));
-
     CBox box = {m_realPosition->value().x, m_realPosition->value().y, m_realSize->value().x, m_realSize->value().y};
-    box.addExtents(EXTENTS);
+    box.addExtents(getWindowExtentsUnified(properties));
 
     return box;
 }

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -324,6 +324,7 @@ class CWindow {
     CBox                       getFullWindowBoundingBox();
     SBoxExtents                getFullWindowExtents();
     CBox                       getWindowBoxUnified(uint64_t props);
+    SBoxExtents                getWindowExtentsUnified(uint64_t props);
     CBox                       getWindowIdealBoundingBoxIgnoreReserved();
     void                       addWindowDeco(UP<IHyprWindowDecoration> deco);
     void                       updateWindowDecos();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes #10731

Also includes changes to `respect_gaps` to respect css style gaps.

`border_overlap` no longer does anything for window snapping, only monitor snapping. It's one thing for borders to overlap each other, but extents overlapping each other could start to look messy, depending on what's in them.

Here is a video showing the new behavior of `respect_gaps`, as well as snapping behavior with the hyprbars plugin:

https://github.com/user-attachments/assets/13263e3e-4ab7-48e4-a502-e811bb283c93

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

n/a

#### Is it ready for merging, or does it need work?

Ready for merging.