### PR TITLE
Fix: Replace unsafe strcpy with snprintf

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -2000,7 +2000,7 @@ void CHyprCtl::startHyprCtlSocket() {
 
     m_socketPath = g_pCompositor->m_instancePath + "/.socket.sock";
 
-    strcpy(SERVERADDRESS.sun_path, m_socketPath.c_str());
+    snprintf(SERVERADDRESS.sun_path, sizeof(SERVERADDRESS.sun_path), "%s", m_socketPath.c_str());
 
     if (bind(m_socketFD.get(), (sockaddr*)&SERVERADDRESS, SUN_LEN(&SERVERADDRESS)) < 0) {
         Debug::log(ERR, "Couldn't start the Hyprland Socket. (2) IPC will not work.");

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -107,8 +107,7 @@ static int openRenderNode(int drmFd) {
             Debug::log(LOG, "DRM dev versionName", render_version->name);
             if (strcmp(render_version->name, "evdi") == 0) {
                 free(renderName);
-                renderName = (char*)malloc(sizeof(char) * 15);
-                snprintf(renderName, 15, "%s", "/dev/dri/card0");
+                renderName = strdup("/dev/dri/card0");
             }
             drmFreeVersion(render_version);
         }

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -108,7 +108,7 @@ static int openRenderNode(int drmFd) {
             if (strcmp(render_version->name, "evdi") == 0) {
                 free(renderName);
                 renderName = (char*)malloc(sizeof(char) * 15);
-                strcpy(renderName, "/dev/dri/card0");
+                snprintf(renderName, 15, "%s", "/dev/dri/card0");
             }
             drmFreeVersion(render_version);
         }


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/ -Done
-->


#### Describe your PR, what does it fix/add?
Replaced unsafe strcpy calls with snprintf to prevent potential buffer overflows and improve code safety.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Breaking nothing.

#### Is it ready for merging, or does it need work?
Ready to merge.

