### PR TITLE
Named persistent workspaces: ensures unique identifiers

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1719,6 +1719,13 @@ WORKSPACEID CCompositor::getNextAvailableNamedWorkspace() {
             lowest = w->m_id;
     }
 
+    // Give priority to persistent workspaces to avoid any conflicts between them.
+    for (auto const& rule : g_pConfigManager->getAllWorkspaceRules()) {
+        if (rule.isPersistent && rule.workspaceId < -1 && rule.workspaceId < lowest) {
+            lowest = rule.workspaceId;
+        }
+    }
+
     return lowest - 1;
 }
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

In this calll: https://github.com/hyprwm/Hyprland/blob/50758505d5c784052437a371a707fc2dc60bb34a/src/Compositor.cpp#L3101-L3107

All named persistent rules had the exact same ID, so only the first one was created. See #11146. This PR fixes this by checking ID uniqueness not only across existing workspaces, but also across persistent ones (which might not yet exist).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?


