### PR TITLE
fix wrong animations in setGroupCurrent

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1862,11 +1862,13 @@ void CCompositor::updateWindowAnimatedDecorationValues(PHLWINDOW pWindow) {
     auto* const GROUPINACTIVELOCKEDCOL = (CGradientValueData*)(PGROUPINACTIVELOCKEDCOL.ptr())->getData();
 
     auto        setBorderColor = [&](CGradientValueData grad) -> void {
-        if (grad == pWindow->m_realBorderColor)
+        if (pWindow->isHidden() || grad == pWindow->m_realBorderColor)
             return;
 
-        pWindow->m_realBorderColorPrevious = pWindow->m_realBorderColor;
-        pWindow->m_realBorderColor         = grad;
+        if (pWindow->m_borderFadeAnimationProgress->value() > 0.5f) // should interpolate current and previous border color, but that isn't straightforward
+            pWindow->m_realBorderColorPrevious = pWindow->m_realBorderColor;
+
+        pWindow->m_realBorderColor = grad;
         pWindow->m_borderFadeAnimationProgress->setValueAndWarp(0.f);
         *pWindow->m_borderFadeAnimationProgress = 1.f;
     };

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -117,9 +117,9 @@ class CCompositor {
     void                   swapActiveWorkspaces(PHLMONITOR, PHLMONITOR);
     PHLMONITOR             getMonitorFromString(const std::string&);
     bool                   workspaceIDOutOfBounds(const WORKSPACEID&);
-    void                   setWindowFullscreenInternal(const PHLWINDOW PWINDOW, const eFullscreenMode MODE, const bool recalculate=true);
+    void                   setWindowFullscreenInternal(const PHLWINDOW PWINDOW, const eFullscreenMode MODE, const bool recalculate = true);
     void                   setWindowFullscreenClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE);
-    void                   setWindowFullscreenState(const PHLWINDOW PWINDOW, const SFullscreenState state, const bool recalculate=true);
+    void                   setWindowFullscreenState(const PHLWINDOW PWINDOW, const SFullscreenState state, const bool recalculate = true);
     void                   changeWindowFullscreenModeClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE, const bool ON);
     void                   updateFullscreenFadeOnWorkspace(PHLWORKSPACE);
     PHLWINDOW              getX11Parent(PHLWINDOW);

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -117,9 +117,9 @@ class CCompositor {
     void                   swapActiveWorkspaces(PHLMONITOR, PHLMONITOR);
     PHLMONITOR             getMonitorFromString(const std::string&);
     bool                   workspaceIDOutOfBounds(const WORKSPACEID&);
-    void                   setWindowFullscreenInternal(const PHLWINDOW PWINDOW, const eFullscreenMode MODE);
+    void                   setWindowFullscreenInternal(const PHLWINDOW PWINDOW, const eFullscreenMode MODE, const bool recalculate=true);
     void                   setWindowFullscreenClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE);
-    void                   setWindowFullscreenState(const PHLWINDOW PWINDOW, const SFullscreenState state);
+    void                   setWindowFullscreenState(const PHLWINDOW PWINDOW, const SFullscreenState state, const bool recalculate=true);
     void                   changeWindowFullscreenModeClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE, const bool ON);
     void                   updateFullscreenFadeOnWorkspace(PHLWORKSPACE);
     PHLWINDOW              getX11Parent(PHLWINDOW);

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1045,6 +1045,7 @@ void CWindow::setGroupCurrent(PHLWINDOW pWindow) {
 
     const auto CURRENTISFOCUS = PCURRENT == g_pCompositor->m_lastWindow.lock();
 
+    const auto PWINDOWALPHA                = PCURRENT->m_alpha->value();
     const auto PWINDOWSIZE                 = PCURRENT->m_realSize->value();
     const auto PWINDOWPOS                  = PCURRENT->m_realPosition->value();
     const auto PWINDOWSIZEGOAL             = PCURRENT->m_realSize->goal();
@@ -1068,6 +1069,7 @@ void CWindow::setGroupCurrent(PHLWINDOW pWindow) {
 
     pWindow->m_realPosition->setValue(PWINDOWPOS);
     pWindow->m_realSize->setValue(PWINDOWSIZE);
+    pWindow->m_alpha->setValue(PWINDOWALPHA);
 
     if (FULLSCREEN)
         g_pCompositor->setWindowFullscreenInternal(pWindow, MODE);

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1054,7 +1054,7 @@ void CWindow::setGroupCurrent(PHLWINDOW pWindow) {
     const auto PWINDOWLASTFLOATINGPOSITION = PCURRENT->m_lastFloatingPosition;
 
     if (FULLSCREEN)
-        g_pCompositor->setWindowFullscreenInternal(PCURRENT, FSMODE_NONE);
+        g_pCompositor->setWindowFullscreenInternal(PCURRENT, FSMODE_NONE, false);
 
     PCURRENT->setHidden(true);
     pWindow->setHidden(false); // can remove m_pLastWindow


### PR DESCRIPTION
on `setGroupCurrent` for fullscreen / maximized:
- matches the windows alpha values
- don't animate from the inactive border color
- make the first frame have the proper window texture size (don't recalculate the monitor before turning fullscreen back on)