### PR TITLE
swipe: fix workspace swipe not rendering last frame if target ws is on edge

### DIFF
--- a/src/managers/input/Swipe.cpp
+++ b/src/managers/input/Swipe.cpp
@@ -241,6 +241,8 @@ void CInputManager::updateWorkspaceSwipe(double delta) {
         (m_activeSwipe.delta < 0 && m_activeSwipe.pWorkspaceBegin->m_id <= workspaceIDLeft)) {
 
         m_activeSwipe.delta = 0;
+        g_pHyprRenderer->damageMonitor(m_activeSwipe.pMonitor.lock());
+        m_activeSwipe.pWorkspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(0.0, 0.0));
         return;
     }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fix for a weird behaviour that happens when swipe is only valid in 1
direction (i.e. from ws 1)

When you start a swipe from the only direction possible, then swipe back
(without releasing), the last frame where the delta is reset to 0 was
not being rendered

More detail and demonstration video in [the bug report discussion](https://github.com/hyprwm/Hyprland/discussions/11163)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Might deserve some testing for various `workspace_swipe` configurations.

Pleaso also try to reproduce the problem I'm trying to address (from master or any version) to check I'm not fixing a problem no one else has.

#### Is it ready for merging, or does it need work?

Ready to me, does fix the issue on my setup
