### PR TITLE
CTM: check for finite value aswell

### DIFF
--- a/src/protocols/CTMControl.cpp
+++ b/src/protocols/CTMControl.cpp
@@ -34,8 +34,8 @@ CHyprlandCTMControlResource::CHyprlandCTMControlResource(UP<CHyprlandCtmControlM
                                           wl_fixed_to_double(mat5), wl_fixed_to_double(mat6), wl_fixed_to_double(mat7), wl_fixed_to_double(mat8)};
 
         for (auto& el : MAT) {
-            if (el < 0.F) {
-                m_resource->error(HYPRLAND_CTM_CONTROL_MANAGER_V1_ERROR_INVALID_MATRIX, "a matrix component was < 0");
+            if (!std::isfinite(el) || el < 0.F) {
+                m_resource->error(HYPRLAND_CTM_CONTROL_MANAGER_V1_ERROR_INVALID_MATRIX, "a matrix component was invalid");
                 return;
             }
         }


### PR DESCRIPTION
checking for < 0.F will not catch NaN or inf values, use std::isfinite aswell.

related: https://github.com/hyprwm/Hyprland/issues/11181

now as to why nan/inf values are happening here i dont know.


