### PR TITLE
add support for focus_on_close

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1087,7 +1087,12 @@ PHLMONITOR CCompositor::getRealMonitorFromOutput(SP<Aquamarine::IOutput> out) {
     return nullptr;
 }
 
-void CCompositor::focusWindow(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface, bool preserveFocusHistory) {
+void CCompositor::focusWindow(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface, std::optional<bool> preserveFocusHistory) {
+
+    bool preserve = false;
+    if(preserveFocusHistory == std::nullopt){
+        preserve = m_preserveHistory.value_or(false);
+    }
 
     static auto PFOLLOWMOUSE        = CConfigValue<Hyprlang::INT>("input:follow_mouse");
     static auto PSPECIALFALLTHROUGH = CConfigValue<Hyprlang::INT>("input:special_fallthrough");
@@ -1209,13 +1214,15 @@ void CCompositor::focusWindow(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface
 
     g_pInputManager->recheckIdleInhibitorStatus();
 
-    if (!preserveFocusHistory) {
+    if (!preserve) {
         // move to front of the window history
         const auto HISTORYPIVOT = std::ranges::find_if(m_windowFocusHistory, [&](const auto& other) { return other.lock() == pWindow; });
         if (HISTORYPIVOT == m_windowFocusHistory.end())
             Debug::log(ERR, "BUG THIS: {} has no pivot in history", pWindow);
         else
             std::rotate(m_windowFocusHistory.begin(), HISTORYPIVOT, HISTORYPIVOT + 1);
+    } else {
+        m_windowFocusHistory.push_back(pWindow);
     }
 
     if (*PFOLLOWMOUSE == 0)
@@ -2548,7 +2555,20 @@ void CCompositor::warpCursorTo(const Vector2D& pos, bool force) {
         setActiveMonitor(PMONITORNEW);
 }
 
+void CCompositor::setPreserveHistory(bool preserveHistory){
+    m_preserveHistory = preserveHistory;
+}
+
 void CCompositor::closeWindow(PHLWINDOW pWindow) {
+
+    if(m_preserveHistory.value_or(false)) {
+        PHLWINDOW thisWindow = m_windowFocusHistory.back().lock();
+        m_windowFocusHistory.pop_back();
+        PHLWINDOW prevWindow = m_windowFocusHistory.back().lock();
+        m_windowFocusHistory.pop_back();
+        focusWindow(prevWindow);
+    }
+
     if (pWindow && validMapped(pWindow))
         g_pXWaylandManager->sendCloseWindow(pWindow);
 }

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -12,6 +12,7 @@
 
 #include <aquamarine/backend/Backend.hpp>
 #include <aquamarine/output/Output.hpp>
+#include <optional>
 
 class CWLSurfaceResource;
 struct SWorkspaceRule;
@@ -89,7 +90,7 @@ class CCompositor {
     PHLMONITOR             getMonitorFromCursor();
     PHLMONITOR             getMonitorFromVector(const Vector2D&);
     void                   removeWindowFromVectorSafe(PHLWINDOW);
-    void                   focusWindow(PHLWINDOW, SP<CWLSurfaceResource> pSurface = nullptr, bool preserveFocusHistory = false);
+    void                   focusWindow(PHLWINDOW, SP<CWLSurfaceResource> pSurface = nullptr, std::optional<bool> preserveFocusHistory = std::nullopt);
     void                   focusSurface(SP<CWLSurfaceResource>, PHLWINDOW pWindowOwner = nullptr);
     bool                   monitorExists(PHLMONITOR);
     PHLWINDOW              vectorToWindowUnified(const Vector2D&, uint8_t properties, PHLWINDOW pIgnoreWindow = nullptr);
@@ -150,6 +151,7 @@ class CCompositor {
     void                   arrangeMonitors();
     void                   enterUnsafeState();
     void                   leaveUnsafeState();
+    void                   setPreserveHistory(bool preserveHistory);
     void                   setPreferredScaleForSurface(SP<CWLSurfaceResource> pSurface, double scale);
     void                   setPreferredTransformForSurface(SP<CWLSurfaceResource> pSurface, wl_output_transform transform);
     void                   updateSuspendedStates();
@@ -180,6 +182,8 @@ class CCompositor {
     rlimit                       m_originalNofile = {};
 
     std::vector<PHLWORKSPACEREF> m_workspaces;
+
+    std::optional<bool>    m_preserveHistory = std::nullopt;
 };
 
 inline UP<CCompositor> g_pCompositor;

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1920,4 +1920,10 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .type        = CONFIG_OPTION_BOOL,
         .data        = SConfigOptionDescription::SBoolData{false},
     },
+    SConfigOptionDescription{
+            .value       = "master:focus_on_close",
+            .description = "whether to focus the previous window after a window is closed",
+            .type        = CONFIG_OPTION_BOOL,
+            .data        = SConfigOptionDescription::SBoolData{false},
+    },
 };

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -614,6 +614,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("master:smart_resizing", Hyprlang::INT{1});
     registerConfigVar("master:drop_at_cursor", Hyprlang::INT{1});
     registerConfigVar("master:always_keep_position", Hyprlang::INT{0});
+    registerConfigVar("master:focus_on_close", Hyprlang::INT{1});
 
     registerConfigVar("animations:enabled", Hyprlang::INT{1});
     registerConfigVar("animations:first_launch_animation", Hyprlang::INT{1});

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -81,6 +81,10 @@ PHLWINDOW CWindow::create(SP<CXDGSurfaceResource> resource) {
     pWindow->addWindowDeco(makeUnique<CHyprDropShadowDecoration>(pWindow));
     pWindow->addWindowDeco(makeUnique<CHyprBorderDecoration>(pWindow));
 
+    static auto PRESERVE_HIST = reinterpret_cast<int64_t* const*>(g_pConfigManager->getConfigValuePtr("master:focus_on_close"));
+
+    g_pCompositor->setPreserveHistory(**PRESERVE_HIST > 0 ? true : false);
+
     pWindow->m_wlSurface->assign(pWindow->m_xdgSurface->m_surface.lock(), pWindow);
 
     return pWindow;
@@ -1077,8 +1081,10 @@ void CWindow::setGroupCurrent(PHLWINDOW pWindow) {
 
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 
-    if (CURRENTISFOCUS)
+
+    if (CURRENTISFOCUS){
         g_pCompositor->focusWindow(pWindow);
+    }
 
     g_pHyprRenderer->damageWindow(pWindow);
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2299,10 +2299,12 @@ SDispatchResult CKeybindManager::circleNext(std::string arg) {
     else if (args.contains("float") || args.contains("floating"))
         floatStatus = true;
 
+    static auto PRESERVE_HIST = reinterpret_cast<int64_t* const*>(g_pConfigManager->getConfigValuePtr("master:focus_on_close"));
+
     const auto  VISIBLE = args.contains("visible") || args.contains("v");
     const auto  PREV    = args.contains("prev") || args.contains("p") || args.contains("last") || args.contains("l");
     const auto  NEXT    = args.contains("next") || args.contains("n"); // prev is default in classic alt+tab
-    const auto  HIST    = args.contains("hist") || args.contains("h");
+    const auto  HIST    = args.contains("hist") || args.contains("h") || (**PRESERVE_HIST > 0 ? true : false);
     const auto& w       = HIST ? g_pCompositor->getWindowCycleHist(g_pCompositor->m_lastWindow, true, floatStatus, VISIBLE, NEXT) :
                                  g_pCompositor->getWindowCycle(g_pCompositor->m_lastWindow.lock(), true, floatStatus, VISIBLE, PREV);
 


### PR DESCRIPTION
this adds a new config option master:focus_on_close and sets a parameter in CCompositor::focusWindow which sets a member variable that gets checked again in CCompositor::closeWindow.
fixes #10655