### PR TITLE
virtualkeyboard: do not sent release event for pressed key during destroy

### DIFF
--- a/src/protocols/VirtualKeyboard.hpp
+++ b/src/protocols/VirtualKeyboard.hpp
@@ -28,12 +28,7 @@ class CVirtualKeyboardV1Resource {
 
   private:
     SP<CZwpVirtualKeyboardV1> m_resource;
-
-    void                      releasePressed();
-
     bool                      m_hasKeymap = false;
-
-    std::vector<uint32_t>     m_pressed;
 };
 
 class CVirtualKeyboardProtocol : public IWaylandProtocol {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

The current behavior breaks when fcitx5 (which uses input method v2 and virtual keyboard) is running, leading to issues in third-party applications like this one:

https://github.com/H3rmt/hyprshell/issues/294

More discussion here:

https://github.com/fcitx/fcitx5/pull/1391

(I previously reported the issue for hyprland here: https://github.com/hyprwm/Hyprland/discussions/11186 ; after discussion with fcitx5 maintainer it is believed that hyprland shouldn't send release events on virtual keyboard destroy)
