### PR TITLE
input: do not accumulate modifiers from all keyboards for binds and seats

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -457,7 +457,7 @@ bool CKeybindManager::onKeyEvent(std::any event, SP<IKeyboard> pKeyboard) {
     if (handleInternalKeybinds(internalKeysym))
         return false;
 
-    const auto MODS = g_pInputManager->accumulateModsFromAllKBs();
+    const auto MODS = g_pInputManager->getLastKeyboardMods();
 
     m_timeLastMs    = e.timeMs;
     m_lastCode      = KEYCODE;
@@ -515,7 +515,7 @@ bool CKeybindManager::onKeyEvent(std::any event, SP<IKeyboard> pKeyboard) {
 }
 
 bool CKeybindManager::onAxisEvent(const IPointer::SAxisEvent& e) {
-    const auto  MODS = g_pInputManager->accumulateModsFromAllKBs();
+    const auto  MODS = g_pInputManager->getLastKeyboardMods();
 
     static auto PDELAY = CConfigValue<Hyprlang::INT>("binds:scroll_event_delay");
 
@@ -548,7 +548,7 @@ bool CKeybindManager::onAxisEvent(const IPointer::SAxisEvent& e) {
 }
 
 bool CKeybindManager::onMouseEvent(const IPointer::SButtonEvent& e) {
-    const auto MODS = g_pInputManager->accumulateModsFromAllKBs();
+    const auto MODS = g_pInputManager->getLastKeyboardMods();
 
     bool       suppressEvent = false;
 
@@ -2456,7 +2456,7 @@ SDispatchResult CKeybindManager::pass(std::string regexp) {
             g_pSeatManager->setPointerFocus(PWINDOW->m_wlSurface->resource(), {1, 1});
     }
 
-    g_pSeatManager->sendKeyboardMods(g_pInputManager->accumulateModsFromAllKBs(), 0, 0, 0);
+    g_pSeatManager->sendKeyboardMods(g_pInputManager->getLastKeyboardMods(), 0, 0, 0);
 
     if (g_pKeybindManager->m_passPressed == 1) {
         if (g_pKeybindManager->m_lastCode != 0)

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1424,10 +1424,7 @@ void CInputManager::onKeyboardMod(SP<IKeyboard> pKeyboard) {
 
     const bool DISALLOWACTION = pKeyboard->isVirtual() && shouldIgnoreVirtualKeyboard(pKeyboard);
 
-    const auto ALLMODS = accumulateModsFromAllKBs();
-
     auto       MODS = pKeyboard->m_modifiersState;
-    MODS.depressed  = ALLMODS;
 
     const auto IME = m_relay.m_inputMethod.lock();
 
@@ -1437,6 +1434,8 @@ void CInputManager::onKeyboardMod(SP<IKeyboard> pKeyboard) {
     } else {
         g_pSeatManager->setKeyboard(pKeyboard);
         g_pSeatManager->sendKeyboardMods(MODS.depressed, MODS.latched, MODS.locked, MODS.group);
+
+        m_lastKeyboardMods = MODS.depressed;
     }
 
     updateKeyboardsLeds(pKeyboard);
@@ -1564,21 +1563,8 @@ void CInputManager::updateCapabilities() {
     m_capabilities = caps;
 }
 
-uint32_t CInputManager::accumulateModsFromAllKBs() {
-
-    uint32_t finalMask = 0;
-
-    for (auto const& kb : m_keyboards) {
-        if (kb->isVirtual() && shouldIgnoreVirtualKeyboard(kb))
-            continue;
-
-        if (!kb->m_enabled)
-            continue;
-
-        finalMask |= kb->getModifiers();
-    }
-
-    return finalMask;
+uint32_t CInputManager::getLastKeyboardMods() {
+    return m_lastKeyboardMods;
 }
 
 void CInputManager::disableAllKeyboards(bool virt) {

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -184,8 +184,7 @@ class CInputManager {
 
     CInputMethodRelay m_relay;
 
-    // for shared mods
-    uint32_t accumulateModsFromAllKBs();
+    uint32_t getLastKeyboardMods();
 
     // for virtual keyboards: whether we should respect them as normal ones
     bool shouldIgnoreVirtualKeyboard(SP<IKeyboard>);
@@ -304,6 +303,8 @@ class CInputManager {
         uint32_t lastEventTime     = 0;
         uint32_t accumulatedScroll = 0;
     } m_scrollWheelState;
+
+    uint32_t m_lastKeyboardMods = 0;
 
     friend class CKeybindManager;
     friend class CWLSurface;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

The current behavior breaks when fcitx5 (which uses input method v2 and virtual keyboard) is running, specifically when persistent virtual keyboard is enabled in fcitx5.

Manifested issues include modifier keys get stuck when modifier keys are held during window focus switching, (e.g. from fcitx5 active window to fcitx5 non-active window)

Possibly related:

https://github.com/hyprwm/Hyprland/discussions/10360
https://github.com/hyprwm/Hyprland/discussions/10967
https://github.com/hyprwm/Hyprland/discussions/11034
