### PR TITLE
ANR: Emit 'applicationnotresponding' when app freezes

### DIFF
--- a/src/managers/ANRManager.cpp
+++ b/src/managers/ANRManager.cpp
@@ -8,6 +8,8 @@
 #include "./eventLoop/EventLoopManager.hpp"
 #include "../config/ConfigValue.hpp"
 #include "../xwayland/XSurface.hpp"
+#include "./EventManager.hpp"
+#include <string>
 
 using namespace Hyprutils::OS;
 
@@ -83,6 +85,9 @@ void CANRManager::onTick() {
 
         if (data->missedResponses >= *PANRTHRESHOLD) {
             if (!data->isRunning() && !data->dialogSaidWait) {
+                if (data->missedResponses == *PANRTHRESHOLD)
+                    g_pEventManager->postEvent(SHyprIPCEvent{.event = "applicationnotresponding", .data = std::to_string(data->getPid())});
+
                 data->runDialog("Application Not Responding", firstWindow->m_title, firstWindow->m_class, data->getPid());
 
                 for (const auto& w : g_pCompositor->m_windows) {

--- a/src/managers/ANRManager.cpp
+++ b/src/managers/ANRManager.cpp
@@ -81,7 +81,7 @@ void CANRManager::onTick() {
         if (data->missedResponses >= *PANRTHRESHOLD) {
             if (!data->isRunning() && !data->dialogSaidWait) {
                 if (data->missedResponses == *PANRTHRESHOLD)
-                    g_pEventManager->postEvent(SHyprIPCEvent{.event = "applicationnotresponding", .data = std::to_string(data->getPid())});
+                    g_pEventManager->postEvent(SHyprIPCEvent{.event = "anr", .data = std::to_string(data->getPid())});
 
                 if (*PENABLEANR) {
                     data->runDialog("Application Not Responding", firstWindow->m_title, firstWindow->m_class, data->getPid());

--- a/src/managers/ANRManager.cpp
+++ b/src/managers/ANRManager.cpp
@@ -60,11 +60,6 @@ void CANRManager::onTick() {
     static auto PENABLEANR    = CConfigValue<Hyprlang::INT>("misc:enable_anr_dialog");
     static auto PANRTHRESHOLD = CConfigValue<Hyprlang::INT>("misc:anr_missed_pings");
 
-    if (!*PENABLEANR) {
-        m_timer->updateTimeout(TIMER_TIMEOUT * 10);
-        return;
-    }
-
     for (auto& data : m_data) {
         PHLWINDOW firstWindow;
         int       count = 0;
@@ -88,16 +83,18 @@ void CANRManager::onTick() {
                 if (data->missedResponses == *PANRTHRESHOLD)
                     g_pEventManager->postEvent(SHyprIPCEvent{.event = "applicationnotresponding", .data = std::to_string(data->getPid())});
 
-                data->runDialog("Application Not Responding", firstWindow->m_title, firstWindow->m_class, data->getPid());
+                if (*PENABLEANR) {
+                    data->runDialog("Application Not Responding", firstWindow->m_title, firstWindow->m_class, data->getPid());
 
-                for (const auto& w : g_pCompositor->m_windows) {
-                    if (!w->m_isMapped)
-                        continue;
+                    for (const auto& w : g_pCompositor->m_windows) {
+                        if (!w->m_isMapped)
+                            continue;
 
-                    if (!data->fitsWindow(w))
-                        continue;
+                        if (!data->fitsWindow(w))
+                            continue;
 
-                    *w->m_notRespondingTint = 0.2F;
+                        *w->m_notRespondingTint = 0.2F;
+                    }
                 }
             }
         } else if (data->isRunning())

--- a/src/managers/ANRManager.hpp
+++ b/src/managers/ANRManager.hpp
@@ -34,7 +34,9 @@ class CANRManager {
         WP<CXWaylandSurface> xwaylandSurface;
         WP<CXDGWMBase>       xdgBase;
 
-        int                  missedResponses = 0;
+        int                  missedResponses  = 0;
+        bool                 wasNotResponding = false;
+        pid_t                cachedPid        = 0;
 
         bool                 dialogSaidWait = false;
         SP<CAsyncDialogBox>  dialogBox;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
emits "applicationnotresponding" on sock2 when application becomes unresponsive with the application PID as data. Closes #10611 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
There don’t appear to be existing tests for socket2 events, but I’m happy to add one if needed.

#### Is it ready for merging, or does it need work?
Ready unless test is required.

