### PR TITLE
input: lock focus for tablet when down

### DIFF
--- a/src/managers/input/Tablets.cpp
+++ b/src/managers/input/Tablets.cpp
@@ -135,7 +135,8 @@ void CInputManager::onTabletAxis(CTablet::SAxisEvent e) {
         }
 
         m_lastInputTouch = false;
-        simulateMouseMovement();
+        if (!PTOOL->m_isDown)
+            simulateMouseMovement();
         refocusTablet(PTAB, PTOOL, true);
         m_lastCursorMovement.reset();
     }


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

mouseMoveUnified locks focus when the mouse is down, but does not when tablet stylus is down. This can cause event interruption in some software when using the tablet because of rapid surface refocusing. This adds focus locking for tablets by only calling simulateMouseMovement if the tablet is up. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?

ready and tested
