### PR TITLE
fix: include decorations in visibleOnMonitor calculation

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1261,6 +1261,9 @@ void CWindow::setSuspended(bool suspend) {
 bool CWindow::visibleOnMonitor(PHLMONITOR pMonitor) {
     CBox wbox = {m_realPosition->value(), m_realSize->value()};
 
+    if (m_isFloating)
+        wbox = getFullWindowBoundingBox();
+
     return !wbox.intersection({pMonitor->m_position, pMonitor->m_size}).empty();
 }
 


### PR DESCRIPTION
Fixes: https://github.com/hyprwm/Hyprland/discussions/11203

The window turned invisible when just outside the monitor bounds, even though it should have stayed visible given its decorations.

The fix was to include the decorations when determining if a window is on a monitor.

---

Sorry about opening a second pull request, I didn't realize github was going to automatically close the old one when I did a sync.