### PR TITLE
dnd: drop drag-and-drop on tablet pen tip up

### DIFF
--- a/src/managers/input/Tablets.cpp
+++ b/src/managers/input/Tablets.cpp
@@ -2,6 +2,7 @@
 #include "../../desktop/Window.hpp"
 #include "../../protocols/Tablet.hpp"
 #include "../../devices/Tablet.hpp"
+#include "../../managers/HookSystemManager.hpp"
 #include "../../managers/PointerManager.hpp"
 #include "../../managers/SeatManager.hpp"
 #include "../../protocols/PointerConstraints.hpp"
@@ -167,6 +168,8 @@ void CInputManager::onTabletAxis(CTablet::SAxisEvent e) {
 }
 
 void CInputManager::onTabletTip(CTablet::STipEvent e) {
+    EMIT_HOOK_EVENT_CANCELLABLE("tabletTip", e);
+
     const auto PTAB  = e.tablet;
     const auto PTOOL = ensureTabletToolPresent(e.tool);
     const auto POS   = e.tip;

--- a/src/protocols/core/DataDevice.cpp
+++ b/src/protocols/core/DataDevice.cpp
@@ -591,6 +591,14 @@ void CWLDataDeviceProtocol::initiateDrag(WP<CWLDataSourceResource> currentSource
         dropDrag();
     });
 
+    m_dnd.tabletTip = g_pHookSystem->hookDynamic("tabletTip", [this](void* self, SCallbackInfo& info, std::any e) {
+        auto E = std::any_cast<CTablet::STipEvent>(e);
+        if (!E.in) {
+            LOGM(LOG, "Dropping drag on tablet tipUp");
+            dropDrag();
+        }
+    });
+
     m_dnd.mouseMove = g_pHookSystem->hookDynamic("mouseMove", [this](void* self, SCallbackInfo& info, std::any e) {
         auto V = std::any_cast<const Vector2D>(e);
         if (m_dnd.focusedDevice && g_pSeatManager->m_state.dndPointerFocus) {
@@ -695,6 +703,7 @@ void CWLDataDeviceProtocol::cleanupDndState(bool resetDevice, bool resetSource, 
     m_dnd.mouseMove.reset();
     m_dnd.touchUp.reset();
     m_dnd.touchMove.reset();
+    m_dnd.tabletTip.reset();
 
     if (resetDevice)
         m_dnd.focusedDevice.reset();

--- a/src/protocols/core/DataDevice.hpp
+++ b/src/protocols/core/DataDevice.hpp
@@ -180,6 +180,7 @@ class CWLDataDeviceProtocol : public IWaylandProtocol {
         SP<HOOK_CALLBACK_FN> mouseButton;
         SP<HOOK_CALLBACK_FN> touchUp;
         SP<HOOK_CALLBACK_FN> touchMove;
+        SP<HOOK_CALLBACK_FN> tabletTip;
     } m_dnd;
 
     void abortDrag();


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Currently it seems like dropping dnd does not check for tablet events like is done with touch and mouse. This PR makes it possible to end dnd with a stylus.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
https://github.com/hyprwm/Hyprland/discussions/9878#discussioncomment-12904712 mentions dnd not being finished only "in some cases", which I find odd because I don't recall ever being able to drop dnd with a tablet.
Is there something that I am missing?

#### Is it ready for merging, or does it need work?
Ready but before merging I would like feedback as see above.

