### PR TITLE
opengl: improve render fn arg clarity

### DIFF
--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -579,7 +579,7 @@ SP<Aquamarine::IBuffer> CPointerManager::renderHWCursorBuffer(SP<CPointerManager
     Debug::log(TRACE, "[pointer] monitor: {}, size: {}, hw buf: {}, scale: {:.2f}, monscale: {:.2f}, xbox: {}", state->monitor->m_name, m_currentCursorImage.size, cursorSize,
                m_currentCursorImage.scale, state->monitor->m_scale, xbox.size());
 
-    g_pHyprOpenGL->renderTexture(texture, xbox, 1.F);
+    g_pHyprOpenGL->renderTexture(texture, xbox, {});
 
     g_pHyprOpenGL->end();
     g_pHyprOpenGL->m_renderData.pMonitor.reset();

--- a/src/protocols/Screencopy.cpp
+++ b/src/protocols/Screencopy.cpp
@@ -200,7 +200,7 @@ void CScreencopyFrame::renderMon() {
                       .transform(wlTransformToHyprutils(invertTransform(m_monitor->m_transform)), m_monitor->m_pixelSize.x, m_monitor->m_pixelSize.y);
     g_pHyprOpenGL->pushMonitorTransformEnabled(true);
     g_pHyprOpenGL->setRenderModifEnabled(false);
-    g_pHyprOpenGL->renderTexture(TEXTURE, monbox, 1);
+    g_pHyprOpenGL->renderTexture(TEXTURE, monbox, {});
     g_pHyprOpenGL->setRenderModifEnabled(true);
     g_pHyprOpenGL->popMonitorTransformEnabled();
 
@@ -229,7 +229,7 @@ void CScreencopyFrame::renderMon() {
         const auto rounding      = dontRound ? 0 : w->rounding() * m_monitor->m_scale;
         const auto roundingPower = dontRound ? 2.0f : w->roundingPower();
 
-        g_pHyprOpenGL->renderRect(noScreenShareBox, Colors::BLACK, rounding, roundingPower);
+        g_pHyprOpenGL->renderRect(noScreenShareBox, Colors::BLACK, {.round = rounding, .roundingPower = roundingPower});
 
         if (w->m_isX11 || !w->m_popupHead)
             continue;
@@ -249,7 +249,7 @@ void CScreencopyFrame::renderMon() {
                         const auto surfBox = CBox{popupBaseOffset + popRel + localOff, size}.translate(-m_monitor->m_position).scale(m_monitor->m_scale).translate(-m_box.pos());
 
                         if LIKELY (surfBox.w > 0 && surfBox.h > 0)
-                            g_pHyprOpenGL->renderRect(surfBox, Colors::BLACK);
+                            g_pHyprOpenGL->renderRect(surfBox, Colors::BLACK, {});
                     },
                     nullptr);
             },
@@ -292,7 +292,7 @@ void CScreencopyFrame::copyDmabuf(std::function<void(bool)> callback) {
     if (PERM == PERMISSION_RULE_ALLOW_MODE_ALLOW) {
         if (m_tempFb.isAllocated()) {
             CBox texbox = {{}, m_box.size()};
-            g_pHyprOpenGL->renderTexture(m_tempFb.getTexture(), texbox, 1);
+            g_pHyprOpenGL->renderTexture(m_tempFb.getTexture(), texbox, {});
             m_tempFb.release();
         } else
             renderMon();
@@ -301,7 +301,7 @@ void CScreencopyFrame::copyDmabuf(std::function<void(bool)> callback) {
     else {
         g_pHyprOpenGL->clear(Colors::BLACK);
         CBox texbox = CBox{m_monitor->m_transformedSize / 2.F, g_pHyprOpenGL->m_screencopyDeniedTexture->m_size}.translate(-g_pHyprOpenGL->m_screencopyDeniedTexture->m_size / 2.F);
-        g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_screencopyDeniedTexture, texbox, 1);
+        g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_screencopyDeniedTexture, texbox, {});
     }
 
     g_pHyprOpenGL->m_renderData.blockScreenShader = true;
@@ -333,7 +333,7 @@ bool CScreencopyFrame::copyShm() {
     if (PERM == PERMISSION_RULE_ALLOW_MODE_ALLOW) {
         if (m_tempFb.isAllocated()) {
             CBox texbox = {{}, m_box.size()};
-            g_pHyprOpenGL->renderTexture(m_tempFb.getTexture(), texbox, 1);
+            g_pHyprOpenGL->renderTexture(m_tempFb.getTexture(), texbox, {});
             m_tempFb.release();
         } else
             renderMon();
@@ -342,7 +342,7 @@ bool CScreencopyFrame::copyShm() {
     else {
         g_pHyprOpenGL->clear(Colors::BLACK);
         CBox texbox = CBox{m_monitor->m_transformedSize / 2.F, g_pHyprOpenGL->m_screencopyDeniedTexture->m_size}.translate(-g_pHyprOpenGL->m_screencopyDeniedTexture->m_size / 2.F);
-        g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_screencopyDeniedTexture, texbox, 1);
+        g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_screencopyDeniedTexture, texbox, {});
     }
 
     glBindFramebuffer(GL_READ_FRAMEBUFFER, fb.getFBID());

--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -266,7 +266,7 @@ bool CToplevelExportFrame::copyShm(const Time::steady_tp& now) {
             g_pPointerManager->renderSoftwareCursorsFor(PMONITOR->m_self.lock(), now, fakeDamage, g_pInputManager->getMouseCoordsInternal() - m_window->m_realPosition->value());
     } else if (PERM == PERMISSION_RULE_ALLOW_MODE_DENY) {
         CBox texbox = CBox{PMONITOR->m_transformedSize / 2.F, g_pHyprOpenGL->m_screencopyDeniedTexture->m_size}.translate(-g_pHyprOpenGL->m_screencopyDeniedTexture->m_size / 2.F);
-        g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_screencopyDeniedTexture, texbox, 1);
+        g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_screencopyDeniedTexture, texbox, {});
     }
 
     const auto PFORMAT = NFormatUtils::getPixelFormatFromDRM(shm.format);
@@ -349,7 +349,7 @@ bool CToplevelExportFrame::copyDmabuf(const Time::steady_tp& now) {
             g_pPointerManager->renderSoftwareCursorsFor(PMONITOR->m_self.lock(), now, fakeDamage, g_pInputManager->getMouseCoordsInternal() - m_window->m_realPosition->value());
     } else if (PERM == PERMISSION_RULE_ALLOW_MODE_DENY) {
         CBox texbox = CBox{PMONITOR->m_transformedSize / 2.F, g_pHyprOpenGL->m_screencopyDeniedTexture->m_size}.translate(-g_pHyprOpenGL->m_screencopyDeniedTexture->m_size / 2.F);
-        g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_screencopyDeniedTexture, texbox, 1);
+        g_pHyprOpenGL->renderTexture(g_pHyprOpenGL->m_screencopyDeniedTexture, texbox, {});
     }
 
     g_pHyprOpenGL->m_renderData.blockScreenShader = true;

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -2334,7 +2334,7 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const CGradientValueData& gr
     newBox.width += 2 * scaledBorderSize;
     newBox.height += 2 * scaledBorderSize;
 
-    float  round = data.round + data.round == 0 ? 0 : scaledBorderSize;
+    float  round = data.round + (data.round == 0 ? 0 : scaledBorderSize);
 
     Mat3x3 matrix = m_renderData.monitorProjection.projectBox(
         newBox, wlTransformToHyprutils(invertTransform(!m_monitorTransformEnabled ? WL_OUTPUT_TRANSFORM_NORMAL : m_renderData.pMonitor->m_transform)), newBox.rot);
@@ -2420,7 +2420,7 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const CGradientValueData& gr
     newBox.width += 2 * scaledBorderSize;
     newBox.height += 2 * scaledBorderSize;
 
-    float  round = data.round + data.round == 0 ? 0 : scaledBorderSize;
+    float  round = data.round + (data.round == 0 ? 0 : scaledBorderSize);
 
     Mat3x3 matrix = m_renderData.monitorProjection.projectBox(
         newBox, wlTransformToHyprutils(invertTransform(!m_monitorTransformEnabled ? WL_OUTPUT_TRANSFORM_NORMAL : m_renderData.pMonitor->m_transform)), newBox.rot);

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1337,12 +1337,13 @@ void CHyprOpenGLImpl::scissor(const int x, const int y, const int w, const int h
 }
 
 void CHyprOpenGLImpl::renderRect(const CBox& box, const CHyprColor& col, SRectRenderData data) {
-    if (data.damage)
-        renderRectWithDamageInternal(box, col, data);
-    else if (!m_renderData.damage.empty()) {
+    if (!data.damage)
         data.damage = &m_renderData.damage;
+
+    if (data.blur)
+        renderRectWithBlurInternal(box, col, data);
+    else
         renderRectWithDamageInternal(box, col, data);
-    }
 }
 
 void CHyprOpenGLImpl::renderRectWithBlurInternal(const CBox& box, const CHyprColor& col, const SRectRenderData& data) {

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -189,18 +189,19 @@ void CHyprDropShadowDecoration::render(PHLMONITOR pMonitor, float const& a) {
         // build the matte
         // 10-bit formats have dogshit alpha channels, so we have to use the matte to its fullest.
         // first, clear region of interest with black (fully transparent)
-        g_pHyprOpenGL->renderRect(fullBox, CHyprColor(0, 0, 0, 1), 0);
+        g_pHyprOpenGL->renderRect(fullBox, CHyprColor(0, 0, 0, 1), {.round = 0});
 
         // render white shadow with the alpha of the shadow color (otherwise we clear with alpha later and shit it to 2 bit)
         drawShadowInternal(fullBox, ROUNDING * pMonitor->m_scale, ROUNDINGPOWER, *PSHADOWSIZE * pMonitor->m_scale, CHyprColor(1, 1, 1, PWINDOW->m_realShadowColor->value().a), a);
 
         // render black window box ("clip")
-        g_pHyprOpenGL->renderRect(windowBox, CHyprColor(0, 0, 0, 1.0), (ROUNDING + 1 /* This fixes small pixel gaps. */) * pMonitor->m_scale, ROUNDINGPOWER);
+        g_pHyprOpenGL->renderRect(windowBox, CHyprColor(0, 0, 0, 1.0),
+                                  {.round = (ROUNDING + 1 /* This fixes small pixel gaps. */) * pMonitor->m_scale, .roundingPower = ROUNDINGPOWER});
 
         alphaSwapFB.bind();
 
         // alpha swap just has the shadow color. It will be the "texture" to render.
-        g_pHyprOpenGL->renderRect(fullBox, PWINDOW->m_realShadowColor->value().stripA(), 0);
+        g_pHyprOpenGL->renderRect(fullBox, PWINDOW->m_realShadowColor->value().stripA(), {.round = 0});
 
         LASTFB->bind();
 
@@ -237,7 +238,7 @@ void CHyprDropShadowDecoration::drawShadowInternal(const CBox& box, int round, f
     color.a *= a;
 
     if (*PSHADOWSHARP)
-        g_pHyprOpenGL->renderRect(box, color, round, roundingPower);
+        g_pHyprOpenGL->renderRect(box, color, {.round = round, .roundingPower = roundingPower});
     else
         g_pHyprOpenGL->renderRoundedShadow(box, round, roundingPower, range, color, 1.F);
 }

--- a/src/render/pass/BorderPassElement.cpp
+++ b/src/render/pass/BorderPassElement.cpp
@@ -7,9 +7,13 @@ CBorderPassElement::CBorderPassElement(const CBorderPassElement::SBorderData& da
 
 void CBorderPassElement::draw(const CRegion& damage) {
     if (m_data.hasGrad2)
-        g_pHyprOpenGL->renderBorder(m_data.box, m_data.grad1, m_data.grad2, m_data.lerp, m_data.round, m_data.roundingPower, m_data.borderSize, m_data.a, m_data.outerRound);
+        g_pHyprOpenGL->renderBorder(
+            m_data.box, m_data.grad1, m_data.grad2, m_data.lerp,
+            {.round = m_data.round, .roundingPower = m_data.roundingPower, .borderSize = m_data.borderSize, .a = m_data.a, .outerRound = m_data.outerRound});
     else
-        g_pHyprOpenGL->renderBorder(m_data.box, m_data.grad1, m_data.round, m_data.roundingPower, m_data.borderSize, m_data.a, m_data.outerRound);
+        g_pHyprOpenGL->renderBorder(
+            m_data.box, m_data.grad1,
+            {.round = m_data.round, .roundingPower = m_data.roundingPower, .borderSize = m_data.borderSize, .a = m_data.a, .outerRound = m_data.outerRound});
 }
 
 bool CBorderPassElement::needsLiveBlur() {

--- a/src/render/pass/Pass.cpp
+++ b/src/render/pass/Pass.cpp
@@ -199,9 +199,9 @@ CRegion CRenderPass::render(const CRegion& damage_) {
 void CRenderPass::renderDebugData() {
     CBox box = {{}, g_pHyprOpenGL->m_renderData.pMonitor->m_transformedSize};
     for (const auto& rg : m_occludedRegions) {
-        g_pHyprOpenGL->renderRectWithDamage(box, Colors::RED.modifyA(0.1F), rg);
+        g_pHyprOpenGL->renderRect(box, Colors::RED.modifyA(0.1F), {.damage = &rg});
     }
-    g_pHyprOpenGL->renderRectWithDamage(box, Colors::GREEN.modifyA(0.1F), m_totalLiveBlurRegion);
+    g_pHyprOpenGL->renderRect(box, Colors::GREEN.modifyA(0.1F), {.damage = &m_totalLiveBlurRegion});
 
     std::unordered_map<CWLSurfaceResource*, float> offsets;
 
@@ -224,7 +224,9 @@ void CRenderPass::renderDebugData() {
         if (box.intersection(CBox{{}, g_pHyprOpenGL->m_renderData.pMonitor->m_size}).empty())
             return;
 
-        g_pHyprOpenGL->renderRectWithDamage(box, color, CRegion{0, 0, INT32_MAX, INT32_MAX});
+        static const auto FULL_REGION = CRegion{0, 0, INT32_MAX, INT32_MAX};
+
+        g_pHyprOpenGL->renderRect(box, color, {.damage = &FULL_REGION});
 
         if (offsets.contains(surface.get()))
             box.translate(Vector2D{0.F, offsets[surface.get()]});
@@ -232,8 +234,8 @@ void CRenderPass::renderDebugData() {
             offsets[surface.get()] = 0;
 
         box = {box.pos(), texture->m_size};
-        g_pHyprOpenGL->renderRectWithDamage(box, CHyprColor{0.F, 0.F, 0.F, 0.2F}, CRegion{0, 0, INT32_MAX, INT32_MAX}, std::min(5.0, box.size().y));
-        g_pHyprOpenGL->renderTexture(texture, box, 1.F);
+        g_pHyprOpenGL->renderRect(box, CHyprColor{0.F, 0.F, 0.F, 0.2F}, {.damage = &FULL_REGION, .round = std::min(5.0, box.size().y)});
+        g_pHyprOpenGL->renderTexture(texture, box, {});
 
         offsets[surface.get()] += texture->m_size.y;
     };
@@ -253,7 +255,7 @@ void CRenderPass::renderDebugData() {
                     auto region = g_pSeatManager->m_state.pointerFocus->m_current.input.copy()
                                       .scale(g_pHyprOpenGL->m_renderData.pMonitor->m_scale)
                                       .translate(BOX->pos() - g_pHyprOpenGL->m_renderData.pMonitor->m_position);
-                    g_pHyprOpenGL->renderRectWithDamage(box, CHyprColor{0.8F, 0.8F, 0.2F, 0.4F}, region);
+                    g_pHyprOpenGL->renderRect(box, CHyprColor{0.8F, 0.8F, 0.2F, 0.4F}, {.damage = &region});
                 }
             }
         }
@@ -266,7 +268,7 @@ void CRenderPass::renderDebugData() {
 
     if (tex) {
         box = CBox{{0.F, g_pHyprOpenGL->m_renderData.pMonitor->m_size.y - tex->m_size.y}, tex->m_size}.scale(g_pHyprOpenGL->m_renderData.pMonitor->m_scale);
-        g_pHyprOpenGL->renderTexture(tex, box, 1.F);
+        g_pHyprOpenGL->renderTexture(tex, box, {});
     }
 
     std::string passStructure;
@@ -284,7 +286,7 @@ void CRenderPass::renderDebugData() {
     if (tex) {
         box = CBox{{g_pHyprOpenGL->m_renderData.pMonitor->m_size.x - tex->m_size.x, g_pHyprOpenGL->m_renderData.pMonitor->m_size.y - tex->m_size.y}, tex->m_size}.scale(
             g_pHyprOpenGL->m_renderData.pMonitor->m_scale);
-        g_pHyprOpenGL->renderTexture(tex, box, 1.F);
+        g_pHyprOpenGL->renderTexture(tex, box, {});
     }
 }
 

--- a/src/render/pass/RectPassElement.cpp
+++ b/src/render/pass/RectPassElement.cpp
@@ -13,9 +13,10 @@ void CRectPassElement::draw(const CRegion& damage) {
         g_pHyprOpenGL->m_renderData.clipBox = m_data.clipBox;
 
     if (m_data.color.a == 1.F || !m_data.blur)
-        g_pHyprOpenGL->renderRectWithDamage(m_data.box, m_data.color, damage, m_data.round, m_data.roundingPower);
+        g_pHyprOpenGL->renderRect(m_data.box, m_data.color, {.damage = &damage, .round = m_data.round, .roundingPower = m_data.roundingPower});
     else
-        g_pHyprOpenGL->renderRectWithBlur(m_data.box, m_data.color, m_data.round, m_data.roundingPower, m_data.blurA, m_data.xray);
+        g_pHyprOpenGL->renderRect(m_data.box, m_data.color,
+                                  {.round = m_data.round, .roundingPower = m_data.roundingPower, .blur = true, .blurA = m_data.blurA, .xray = m_data.xray});
 
     g_pHyprOpenGL->m_renderData.clipBox = {};
 }

--- a/src/render/pass/SurfacePassElement.cpp
+++ b/src/render/pass/SurfacePassElement.cpp
@@ -125,6 +125,7 @@ void CSurfacePassElement::draw(const CRegion& damage) {
                                              .overallA              = OVERALL_ALPHA,
                                              .round                 = rounding,
                                              .roundingPower         = roundingPower,
+                                             .allowCustomUV         = true,
                                              .blockBlurOptimization = m_data.blockBlurOptimization,
                                          });
         else
@@ -141,6 +142,7 @@ void CSurfacePassElement::draw(const CRegion& damage) {
                                              .overallA              = OVERALL_ALPHA,
                                              .round                 = rounding,
                                              .roundingPower         = roundingPower,
+                                             .allowCustomUV         = true,
                                              .blockBlurOptimization = true,
                                          });
         else

--- a/src/render/pass/SurfacePassElement.cpp
+++ b/src/render/pass/SurfacePassElement.cpp
@@ -116,14 +116,36 @@ void CSurfacePassElement::draw(const CRegion& damage) {
     // to what we do for misaligned surfaces (blur the entire thing and then render shit without blur)
     if (m_data.surfaceCounter == 0 && !m_data.popup) {
         if (BLUR)
-            g_pHyprOpenGL->renderTextureWithBlur(TEXTURE, windowBox, ALPHA, m_data.surface, rounding, roundingPower, m_data.blockBlurOptimization, m_data.fadeAlpha, OVERALL_ALPHA);
+            g_pHyprOpenGL->renderTexture(TEXTURE, windowBox,
+                                         {
+                                             .surface               = m_data.surface,
+                                             .a                     = ALPHA,
+                                             .blur                  = true,
+                                             .blurA                 = m_data.fadeAlpha,
+                                             .overallA              = OVERALL_ALPHA,
+                                             .round                 = rounding,
+                                             .roundingPower         = roundingPower,
+                                             .blockBlurOptimization = m_data.blockBlurOptimization,
+                                         });
         else
-            g_pHyprOpenGL->renderTexture(TEXTURE, windowBox, ALPHA * OVERALL_ALPHA, rounding, roundingPower, false, true);
+            g_pHyprOpenGL->renderTexture(TEXTURE, windowBox,
+                                         {.a = ALPHA * OVERALL_ALPHA, .round = rounding, .roundingPower = roundingPower, .discardActive = false, .allowCustomUV = true});
     } else {
         if (BLUR && m_data.popup)
-            g_pHyprOpenGL->renderTextureWithBlur(TEXTURE, windowBox, ALPHA, m_data.surface, rounding, roundingPower, true, m_data.fadeAlpha, OVERALL_ALPHA);
+            g_pHyprOpenGL->renderTexture(TEXTURE, windowBox,
+                                         {
+                                             .surface               = m_data.surface,
+                                             .a                     = ALPHA,
+                                             .blur                  = true,
+                                             .blurA                 = m_data.fadeAlpha,
+                                             .overallA              = OVERALL_ALPHA,
+                                             .round                 = rounding,
+                                             .roundingPower         = roundingPower,
+                                             .blockBlurOptimization = true,
+                                         });
         else
-            g_pHyprOpenGL->renderTexture(TEXTURE, windowBox, ALPHA * OVERALL_ALPHA, rounding, roundingPower, false, true);
+            g_pHyprOpenGL->renderTexture(TEXTURE, windowBox,
+                                         {.a = ALPHA * OVERALL_ALPHA, .round = rounding, .roundingPower = roundingPower, .discardActive = false, .allowCustomUV = true});
     }
 
     if (!g_pHyprRenderer->m_bBlockSurfaceFeedback)

--- a/src/render/pass/TexPassElement.cpp
+++ b/src/render/pass/TexPassElement.cpp
@@ -37,9 +37,12 @@ void CTexPassElement::draw(const CRegion& damage) {
     }
 
     if (m_data.blur)
-        g_pHyprOpenGL->renderTextureWithBlur(m_data.tex, m_data.box, m_data.a, nullptr, m_data.round, m_data.roundingPower, false, m_data.blurA, 1.F);
+        g_pHyprOpenGL->renderTexture(
+            m_data.tex, m_data.box,
+            {.a = m_data.a, .blur = true, .blurA = m_data.blurA, .overallA = 1.F, .round = m_data.round, .roundingPower = m_data.roundingPower, .blockBlurOptimization = false});
     else
-        g_pHyprOpenGL->renderTextureInternalWithDamage(m_data.tex, m_data.box, m_data.a, m_data.damage.empty() ? damage : m_data.damage, m_data.round, m_data.roundingPower);
+        g_pHyprOpenGL->renderTexture(m_data.tex, m_data.box,
+                                     {.damage = m_data.damage.empty() ? &damage : &m_data.damage, .a = m_data.a, .round = m_data.round, .roundingPower = m_data.roundingPower});
 }
 
 bool CTexPassElement::needsLiveBlur() {


### PR DESCRIPTION
Improves the readability of opengl fns by using structs for params

First step before #11284 because I am not adding another param to a raw ass fn call

needs testing if it didnt break anything, this is very typo prone

probably breaks plugins