### PR TITLE
screencopy: un-hdr screencopy buffers for cm-unaware clients

### DIFF
--- a/src/protocols/ColorManagement.cpp
+++ b/src/protocols/ColorManagement.cpp
@@ -204,6 +204,10 @@ bool CColorManager::good() {
     return m_resource->resource();
 }
 
+wl_client* CColorManager::client() {
+    return m_resource->client();
+}
+
 CColorManagementOutput::CColorManagementOutput(SP<CWpColorManagementOutputV1> resource, WP<CMonitor> monitor) : m_resource(resource), m_monitor(monitor) {
     if UNLIKELY (!good())
         return;
@@ -816,6 +820,10 @@ void CColorManagementProtocol::onMonitorImageDescriptionChanged(WP<CMonitor> mon
     // recheck feedbacks
     for (auto const& feedback : m_feedbackSurfaces)
         feedback->onPreferredChanged();
+}
+
+bool CColorManagementProtocol::isClientCMAware(wl_client* client) {
+    return std::ranges::any_of(m_managers, [client](const auto& m) { return m->client() == client; });
 }
 
 void CColorManagementProtocol::destroyResource(CColorManager* resource) {

--- a/src/protocols/ColorManagement.hpp
+++ b/src/protocols/ColorManagement.hpp
@@ -18,7 +18,8 @@ class CColorManager {
   public:
     CColorManager(SP<CWpColorManagerV1> resource);
 
-    bool good();
+    bool       good();
+    wl_client* client();
 
   private:
     SP<CWpColorManagerV1> m_resource;
@@ -186,6 +187,8 @@ class CColorManagementProtocol : public IWaylandProtocol {
 
     void         onImagePreferredChanged(uint32_t preferredId);
     void         onMonitorImageDescriptionChanged(WP<CMonitor> monitor);
+
+    bool         isClientCMAware(wl_client* client);
 
   private:
     void                                               destroyResource(CColorManager* resource);

--- a/src/protocols/Screencopy.hpp
+++ b/src/protocols/Screencopy.hpp
@@ -28,6 +28,7 @@ class CScreencopyClient {
     ~CScreencopyClient();
 
     bool                  good();
+    wl_client*            client();
 
     WP<CScreencopyClient> m_self;
     eClientOwners         m_clientOwner = CLIENT_SCREENCOPY;

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -200,6 +200,8 @@ class CHyprOpenGLImpl {
         bool                   noAA                  = false;
         bool                   blockBlurOptimization = false;
         GLenum                 wrapX = GL_CLAMP_TO_EDGE, wrapY = GL_CLAMP_TO_EDGE;
+        bool                   cmBackToSRGB = false;
+        SP<CMonitor>           cmBackToSRGBSource;
     };
 
     struct SBorderRenderData {


### PR DESCRIPTION
Fixes #11284 

Transform HDR monitor buffers back to SDR if the screencopy client is cm-unaware.

Doesn't do a _perfect_ job, but it's close enough IMO. 1:1 translation might be hard to achieve.

cc @UjinT34 