### PR TITLE
renderer: create fence after each surface pass

### DIFF
--- a/src/helpers/MonitorFrameScheduler.cpp
+++ b/src/helpers/MonitorFrameScheduler.cpp
@@ -105,6 +105,8 @@ void CMonitorFrameScheduler::onFrame() {
 
 void CMonitorFrameScheduler::onFinishRender() {
     m_sync = CEGLSync::create(); // this destroys the old sync
+    m_sync->dupNativeFence(true);
+
     g_pEventLoopManager->doOnReadable(m_sync->fd().duplicate(), [this, mon = m_monitor] {
         if (!mon) // might've gotten destroyed
             return;

--- a/src/helpers/MonitorFrameScheduler.hpp
+++ b/src/helpers/MonitorFrameScheduler.hpp
@@ -31,6 +31,5 @@ class CMonitorFrameScheduler {
     hrc::time_point m_lastRenderBegun;
 
     PHLMONITORREF   m_monitor;
-
-    UP<CEGLSync>    m_sync;
+    bool            m_pendingSync = false;
 };

--- a/src/protocols/Screencopy.cpp
+++ b/src/protocols/Screencopy.cpp
@@ -313,10 +313,17 @@ void CScreencopyFrame::copyDmabuf(std::function<void(bool)> callback) {
 
     g_pHyprOpenGL->m_renderData.blockScreenShader = true;
 
-    g_pHyprRenderer->endRender([callback]() {
+    g_pHyprRenderer->endRender();
+
+    if (m_monitor->m_inFence.isValid()) {
+        g_pEventLoopManager->doOnReadable(m_monitor->m_inFence.duplicate(), [callback] {
+            LOGM(TRACE, "Copied frame via dma with explicit sync");
+            callback(true);
+        });
+    } else {
         LOGM(TRACE, "Copied frame via dma");
         callback(true);
-    });
+    }
 }
 
 bool CScreencopyFrame::copyShm() {

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -27,7 +27,7 @@ class CDefaultSurfaceRole : public ISurfaceRole {
     }
 };
 
-CWLCallbackResource::CWLCallbackResource(SP<CWlCallback> resource_) : m_resource(resource_) {
+CWLCallbackResource::CWLCallbackResource(UP<CWlCallback>&& resource_) : m_resource(std::move(resource_)) {
     ;
 }
 
@@ -239,7 +239,7 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
         m_pending.opaque = RG->m_region;
     });
 
-    m_resource->setFrame([this](CWlSurface* r, uint32_t id) { m_callbacks.emplace_back(makeShared<CWLCallbackResource>(makeShared<CWlCallback>(m_client, 1, id))); });
+    m_resource->setFrame([this](CWlSurface* r, uint32_t id) { m_callbacks.emplace_back(makeUnique<CWLCallbackResource>(makeUnique<CWlCallback>(m_client, 1, id))); });
 
     m_resource->setOffset([this](CWlSurface* r, int32_t x, int32_t y) {
         m_pending.updated.bits.offset = true;

--- a/src/protocols/core/Compositor.hpp
+++ b/src/protocols/core/Compositor.hpp
@@ -35,13 +35,13 @@ class CContentType;
 
 class CWLCallbackResource {
   public:
-    CWLCallbackResource(SP<CWlCallback> resource_);
+    CWLCallbackResource(UP<CWlCallback>&& resource_);
 
     bool good();
     void send(const Time::steady_tp& now);
 
   private:
-    SP<CWlCallback> m_resource;
+    UP<CWlCallback> m_resource;
 };
 
 class CWLRegionResource {
@@ -95,7 +95,7 @@ class CWLSurfaceResource {
     SSurfaceState                          m_pending;
     std::queue<UP<SSurfaceState>>          m_pendingStates;
 
-    std::vector<SP<CWLCallbackResource>>   m_callbacks;
+    std::vector<UP<CWLCallbackResource>>   m_callbacks;
     WP<CWLSurfaceResource>                 m_self;
     WP<CWLSurface>                         m_hlSurface;
     std::vector<PHLMONITORREF>             m_enteredOutputs;

--- a/src/protocols/types/Buffer.hpp
+++ b/src/protocols/types/Buffer.hpp
@@ -9,6 +9,7 @@
 
 class CSyncReleaser;
 class CHLBufferReference;
+class CEGLSync;
 
 class IHLBuffer : public Aquamarine::IBuffer {
   public:
@@ -30,6 +31,7 @@ class IHLBuffer : public Aquamarine::IBuffer {
     bool                                  m_opaque = false;
     SP<CWLBufferResource>                 m_resource;
     std::vector<UP<CSyncReleaser>>        m_syncReleasers;
+    UP<CEGLSync>                          m_eglSync;
 
     struct {
         CHyprSignalListener backendRelease;

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -153,9 +153,9 @@ struct SCurrentRenderData {
 class CEGLSync {
   public:
     static UP<CEGLSync> create();
-
     ~CEGLSync();
 
+    void                             dupNativeFence(bool flush = false);
     Hyprutils::OS::CFileDescriptor&  fd();
     Hyprutils::OS::CFileDescriptor&& takeFd();
     bool                             isValid();

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2358,7 +2358,6 @@ void CHyprRenderer::endRender() {
                 for (const auto& releaser : buf->m_syncReleasers) {
                     releaser->addSyncFileFd(buf->m_eglSync->fd());
                 }
-                buf->m_syncReleasers.clear(); // import the fd;
             }
         }
 

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -89,7 +89,7 @@ class CHyprRenderer {
     // if RENDER_MODE_NORMAL, provided damage will be written to.
     // otherwise, it will be the one used.
     bool beginRender(PHLMONITOR pMonitor, CRegion& damage, eRenderMode mode = RENDER_MODE_NORMAL, SP<IHLBuffer> buffer = {}, CFramebuffer* fb = nullptr, bool simple = false);
-    void endRender(const std::function<void()>& renderingDoneCallback = {});
+    void endRender();
 
     bool m_bBlockSurfaceFeedback = false;
     bool m_bRenderingSnapshot    = false;

--- a/src/render/pass/SurfacePassElement.cpp
+++ b/src/render/pass/SurfacePassElement.cpp
@@ -155,8 +155,10 @@ void CSurfacePassElement::draw(const CRegion& damage) {
 
     // add async (dmabuf) buffers to usedBuffers so we can handle release later
     // sync (shm) buffers will be released in commitState, so no need to track them here
-    if (m_data.surface->m_current.buffer && !m_data.surface->m_current.buffer->isSynchronous())
+    if (m_data.surface->m_current.buffer && !m_data.surface->m_current.buffer->isSynchronous()) {
+        m_data.surface->m_current.buffer->m_eglSync = CEGLSync::create(); // create a EGLSyncKHR just after the surface has been drawn.
         g_pHyprRenderer->m_usedAsyncBuffers.emplace_back(m_data.surface->m_current.buffer);
+    }
 
     g_pHyprOpenGL->blend(true);
 }


### PR DESCRIPTION
instead of adding the buffers to a vector and late release it on the fence in endrender that signals on ALL prior opengl work.

now its making a synckhr after the surface pass. and in endrender duping the native fd , and moving the dup nativefd to a seperate function in ceglsync that takes a param if we want to flush or not. in this case the endrender fence flushes, the buffer fence just gets the fd. and we are releasing buffers individually as early as possible with as few glflush as we can. however still warrants for some benchmarking and testing. 

because it now means creating a eglsynckhr and fd per surface. gain some, loose some.


