### PR TITLE
dwindle: fix single_window_aspect_ratio not updating with config reload

### DIFF
--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -160,10 +160,10 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
 
     Vector2D          ratioPadding;
 
-    if (REQUESTEDRATIO.ptr()->y != 0 && !pNode->pParent) {
+    if ((*REQUESTEDRATIO).y != 0 && !pNode->pParent) {
         const Vector2D originalSize = PMONITOR->m_size - PMONITOR->m_reservedTopLeft - PMONITOR->m_reservedBottomRight;
 
-        const double   requestedRatio = REQUESTEDRATIO.ptr()->x / REQUESTEDRATIO.ptr()->y;
+        const double   requestedRatio = (*REQUESTEDRATIO).x / (*REQUESTEDRATIO).y;
         const double   originalRatio  = originalSize.x / originalSize.y;
 
         if (requestedRatio > originalRatio) {

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -155,15 +155,15 @@ void CHyprDwindleLayout::applyNodeDataToWindow(SDwindleNodeData* pNode, bool for
     auto              calcPos  = PWINDOW->m_position;
     auto              calcSize = PWINDOW->m_size;
 
-    const static auto REQUESTEDRATIO          = *CConfigValue<Hyprlang::VEC2>("dwindle:single_window_aspect_ratio");
+    const static auto REQUESTEDRATIO          = CConfigValue<Hyprlang::VEC2>("dwindle:single_window_aspect_ratio");
     const static auto REQUESTEDRATIOTOLERANCE = CConfigValue<Hyprlang::FLOAT>("dwindle:single_window_aspect_ratio_tolerance");
 
     Vector2D          ratioPadding;
 
-    if (REQUESTEDRATIO.y != 0 && !pNode->pParent) {
+    if (REQUESTEDRATIO.ptr()->y != 0 && !pNode->pParent) {
         const Vector2D originalSize = PMONITOR->m_size - PMONITOR->m_reservedTopLeft - PMONITOR->m_reservedBottomRight;
 
-        const double   requestedRatio = REQUESTEDRATIO.x / REQUESTEDRATIO.y;
+        const double   requestedRatio = REQUESTEDRATIO.ptr()->x / REQUESTEDRATIO.ptr()->y;
         const double   originalRatio  = originalSize.x / originalSize.y;
 
         if (requestedRatio > originalRatio) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

The config value `dwindle:single_window_aspect_ratio` doesn't update at runtime because the `VEC2` is stored as a value in a static variable. This PR fixes this by storing the `CConfigValue` in a static variable and accessing the `VEC2` value through the `ptr` method.

This fixes the problem mentioned in #11088

- https://github.com/hyprwm/Hyprland/issues/11088#issuecomment-3094729535
- https://github.com/hyprwm/Hyprland/issues/11088#issuecomment-3094733502

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I tested this in a debug build and it works, i.e., the config value is now applied immediately when the config is saved.
I also ran `clang-format`, checked that the project still builds, and ran `hyprtester`.

#### Is it ready for merging, or does it need work?

This should be ready to merge.
