### PR TITLE
Fix Presentation time proto version

### DIFF
--- a/src/managers/ProtocolManager.cpp
+++ b/src/managers/ProtocolManager.cpp
@@ -172,7 +172,7 @@ CProtocolManager::CProtocolManager() {
     PROTO::focusGrab           = makeUnique<CFocusGrabProtocol>(&hyprland_focus_grab_manager_v1_interface, 1, "FocusGrab");
     PROTO::tablet              = makeUnique<CTabletV2Protocol>(&zwp_tablet_manager_v2_interface, 1, "TabletV2");
     PROTO::layerShell          = makeUnique<CLayerShellProtocol>(&zwlr_layer_shell_v1_interface, 5, "LayerShell");
-    PROTO::presentation        = makeUnique<CPresentationProtocol>(&wp_presentation_interface, 1, "Presentation");
+    PROTO::presentation        = makeUnique<CPresentationProtocol>(&wp_presentation_interface, 2, "Presentation");
     PROTO::xdgShell            = makeUnique<CXDGShellProtocol>(&xdg_wm_base_interface, 7, "XDGShell");
     PROTO::dataWlr             = makeUnique<CDataDeviceWLRProtocol>(&zwlr_data_control_manager_v1_interface, 2, "DataDeviceWlr");
     PROTO::primarySelection    = makeUnique<CPrimarySelectionProtocol>(&zwp_primary_selection_device_manager_v1_interface, 1, "PrimarySelection");


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
v2 doesn't seem to differ much from v1.
https://wayland.app/protocols/presentation-time

> For version 2 and later, if the output does not have a constant refresh rate, explicit video mode switches excluded, then the refresh argument must be either an appropriate rate picked by the compositor (e.g. fastest rate), or 0 if no such rate  exists. For version 1, if the output does not have a constant refresh rate, the refresh argument must be zero.

This rate comes from [AQ](https://github.com/hyprwm/aquamarine/blob/be166e11d86ba4186db93e10c54a141058bdce49/src/backend/drm/DRM.cpp#L942) and follows the v2 requirements.
Some clients might get confused by non-zero rate coming from v1 proto in a vrr scenario.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No idea whether it fixes anything.

#### Is it ready for merging, or does it need work?
Ready