### PR TITLE
Fix `undefined template 'std::basic_ostringstream<char>'` with libc++

### DIFF
--- a/hyprpm/src/helpers/Sys.cpp
+++ b/hyprpm/src/helpers/Sys.cpp
@@ -8,6 +8,7 @@
 #include <print>
 #include <filesystem>
 #include <algorithm>
+#include <sstream>
 
 #include <hyprutils/os/Process.hpp>
 #include <hyprutils/string/VarList.hpp>


### PR DESCRIPTION


<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Build with libc++ fails due to transitive include with:
```
s_Sys.cpp.o -c ../hyprland-source/hyprpm/src/helpers/Sys.cpp
../hyprland-source/hyprpm/src/helpers/Sys.cpp:24:24: error: implicit instantiation of undefined template 'std::basic_ostringstream<char>'
   24 |     std::ostringstream oss;
      |                        ^
/usr/include/c++/v1/__fwd/sstream.h:28:28: note: template is declared here
   28 | class _LIBCPP_TEMPLATE_VIS basic_ostringstream;
      |                            ^
1 error generated.
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Checked with systemwide clang/libc++ 20, Gentoo LLVM profile

#### Is it ready for merging, or does it need work?
Ready to merge

