### PR TITLE
nix/lib: add bezier to topCommandsPrefixes

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -82,7 +82,7 @@ lib: let
     :::
   */
   toHyprlang = {
-    topCommandsPrefixes ? ["$"],
+    topCommandsPrefixes ? ["$" "bezier"],
     bottomCommandsPrefixes ? [],
   }: attrs: let
     toHyprlang' = attrs: let


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

if any custom beziers are defined for animations, hyprland will complain that the beziers haven't been defined. I think this change makes sense as its likely most configurations are defining custom beziers anyway.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

all looks fine. Does this file need to be formatted? running alejandra on the file also reformatted your comments so leaving it for now.

#### Is it ready for merging, or does it need work?

should be ready