### PR TITLE
tablet: do not lock focus when dnd-ing

### DIFF
--- a/src/managers/input/Tablets.cpp
+++ b/src/managers/input/Tablets.cpp
@@ -6,6 +6,7 @@
 #include "../../managers/PointerManager.hpp"
 #include "../../managers/SeatManager.hpp"
 #include "../../protocols/PointerConstraints.hpp"
+#include "../../protocols/core/DataDevice.hpp"
 
 static void unfocusTool(SP<CTabletTool> tool) {
     if (!tool->getSurface())
@@ -136,7 +137,7 @@ void CInputManager::onTabletAxis(CTablet::SAxisEvent e) {
         }
 
         m_lastInputTouch = false;
-        if (!PTOOL->m_isDown)
+        if (!PTOOL->m_isDown || PROTO::data->dndActive())
             simulateMouseMovement();
         refocusTablet(PTAB, PTOOL, true);
         m_lastCursorMovement.reset();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
I made and tested #11270 before #11219 was merged so I did not notice that it broke dnd focus with tablets. This PR fixes that.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Touch has the same problem (although it is also broken by other things), `onTouchMove` doesn't update dnd focus.

In my opinion, instead of locking focus how is done here, it might be a better idea to refactor `mouseMoveUnified` to be able to tell it when focus is supposed to be locked, or something like that.
I would try to do something but I can't wrap my head around the code.

#### Is it ready for merging, or does it need work?
It should be fine to merge.