### PR TITLE
hyprctl: added getprop

### DIFF
--- a/hyprctl/Strings.hpp
+++ b/hyprctl/Strings.hpp
@@ -49,6 +49,7 @@ commands:
                           the same format as in colors in config. Will reset
                           when Hyprland's config is reloaded
     setprop ...         → Sets a window property
+    getprop ...         → Gets a window property
     splash              → Get the current splash
     switchxkblayout ... → Sets the xkb layout index for a keyboard
     systeminfo          → Get system info
@@ -155,6 +156,18 @@ value:
 lock:
     Optional argument. If lock is not added, will be unlocked. Locking means a
     dynamic windowrule cannot override this setting.
+
+flags:
+    See 'hyprctl --help')#";
+
+const std::string_view GETPROP_HELP = R"#(usage: hyprctl [flags] getprop <regex> <property>
+
+regex:
+    Regular expression by which a window will be searched
+
+property:
+    See https://wiki.hypr.land/Configuring/Using-hyprctl/#setprop for list
+    of properties
 
 flags:
     See 'hyprctl --help')#";

--- a/hyprctl/main.cpp
+++ b/hyprctl/main.cpp
@@ -425,6 +425,8 @@ int main(int argc, char** argv) {
                     std::println("{}", PLUGIN_HELP);
                 } else if (cmd == "setprop") {
                     std::println("{}", SETPROP_HELP);
+                } else if (cmd == "getprop") {
+                    std::println("{}", GETPROP_HELP);
                 } else if (cmd == "switchxkblayout") {
                     std::println("{}", SWITCHXKBLAYOUT_HELP);
                 } else {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
It adds `getprop` to `hyprctl` to complement the existing `setprop`.
It allows getting properties about windows.
Fixes: hyprwm/Hyprland#11191 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
There were some properties that have no obvious default value:
- `animationstyle` I have returned `(unset)` and an empty string for JSON
- `minsize` has an internal default of `MIN_WINDOW_SIZE` that I returned
- `maxsize` has an internal default of `MAX_WINDOW_SIZE` that I returned
- `bordercolor` get their default values from the config

#### Is it ready for merging, or does it need work?
It should be ready for reviewing, would appreciate if someone could check that the default return values I chose make sense.
Haven't added getprop to completion files (like hyprctl.bash / hyprctl.usage) as I don't have experience with them.