### PR TITLE
fix: prevent infinite event loop in XWM clipboard transfers

### DIFF
--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -1287,12 +1287,10 @@ void CXWM::getTransferData(SXSelection& sel) {
     }
 
     const size_t transferIndex = std::distance(sel.transfers.begin(), it);
-    int writeResult = sel.onWrite();
+    int          writeResult   = sel.onWrite();
 
-    if (writeResult != 1) {
-    return;
-    }
-
+    if (writeResult != 1)
+        return;
 
     if (transferIndex >= sel.transfers.size())
         return;


### PR DESCRIPTION
Error: [ERR] [xwm] No transfer with property data found

Fix: Prevent infinite event loop in XWM clipboard transfers

The writeDataSource callback was being recreated even when onWrite() 
failed (returned 0), causing an infinite loop and high CPU usage.

Only recreate the event source when onWrite() returns 1 (needs continuation).