### PR TITLE
renderer: improve zoom in anims

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -381,12 +381,6 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SBoolData{true},
     },
     SConfigOptionDescription{
-        .value       = "animations:first_launch_animation",
-        .description = "enable first launch animation",
-        .type        = CONFIG_OPTION_BOOL,
-        .data        = SConfigOptionDescription::SBoolData{true},
-    },
-    SConfigOptionDescription{
         .value       = "animations:workspace_wraparound",
         .description = "changes the direction of slide animations between the first and last workspaces",
         .type        = CONFIG_OPTION_BOOL,

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -617,7 +617,6 @@ CConfigManager::CConfigManager() {
     registerConfigVar("master:always_keep_position", Hyprlang::INT{0});
 
     registerConfigVar("animations:enabled", Hyprlang::INT{1});
-    registerConfigVar("animations:first_launch_animation", Hyprlang::INT{1});
     registerConfigVar("animations:workspace_wraparound", Hyprlang::INT{0});
 
     registerConfigVar("input:follow_mouse", Hyprlang::INT{1});
@@ -983,6 +982,7 @@ void CConfigManager::setDefaultAnimationVars() {
     m_animationTree.createNode("borderangle", "global");
     m_animationTree.createNode("workspaces", "global");
     m_animationTree.createNode("zoomFactor", "global");
+    m_animationTree.createNode("monitorAdded", "global");
 
     // layer
     m_animationTree.createNode("layersIn", "layers");

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -49,6 +49,8 @@ CMonitor::CMonitor(SP<Aquamarine::IOutput> output_) : m_state(this), m_output(ou
     static auto PZOOMFACTOR = CConfigValue<Hyprlang::FLOAT>("cursor:zoom_factor");
     g_pAnimationManager->createAnimation(*PZOOMFACTOR, m_cursorZoom, g_pConfigManager->getAnimationPropertyConfig("zoomFactor"), AVARDAMAGE_NONE);
     m_cursorZoom->setUpdateCallback([this](auto) { g_pHyprRenderer->damageMonitor(m_self.lock()); });
+    g_pAnimationManager->createAnimation(0.F, m_zoomAnimProgress, g_pConfigManager->getAnimationPropertyConfig("monitorAdded"), AVARDAMAGE_NONE);
+    m_zoomAnimProgress->setUpdateCallback([this](auto) { g_pHyprRenderer->damageMonitor(m_self.lock()); });
 }
 
 CMonitor::~CMonitor() {
@@ -60,6 +62,8 @@ CMonitor::~CMonitor() {
 void CMonitor::onConnect(bool noRule) {
     EMIT_HOOK_EVENT("preMonitorAdded", m_self.lock());
     CScopeGuard x = {[]() { g_pCompositor->arrangeMonitors(); }};
+
+    m_zoomAnimProgress->setValueAndWarp(0.F);
 
     g_pEventLoopManager->doLater([] { g_pConfigManager->ensurePersistentWorkspacesPresent(); });
 
@@ -85,6 +89,9 @@ void CMonitor::onConnect(bool noRule) {
             PROTO::presentation->onPresented(m_self.lock(), Time::steadyNow(), event.refresh, event.seq, event.flags);
         else
             PROTO::presentation->onPresented(m_self.lock(), Time::fromTimespec(event.when), event.refresh, event.seq, event.flags);
+
+        if (m_zoomAnimProgress->goal() == 0.F)
+            *m_zoomAnimProgress = 1.F;
 
         m_frameScheduler->onPresented();
     });

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -183,6 +183,9 @@ class CMonitor {
 
     PHLANIMVAR<float> m_cursorZoom;
 
+    // for initial zoom anim
+    PHLANIMVAR<float> m_zoomAnimProgress;
+
     struct {
         bool canTear         = false;
         bool nextRenderTorn  = false;

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -104,8 +104,6 @@ class CHyprRenderer {
     wl_event_source*                m_crashingLoop       = nullptr;
     wl_event_source*                m_cursorTicker       = nullptr;
 
-    CTimer                          m_renderTimer;
-
     std::vector<CHLBufferReference> m_usedAsyncBuffers;
 
     struct {


### PR DESCRIPTION
Improves the monitor zoom in animations when a display is connected.

Fixes:
- zoom in anims now are per-display
- zoom in anims should now wait for the display to modeset before starting
- zoom in anims now follow the animation tree with `monitorAdded`

Removed `animations:first_launch_animation` as it's useless now

Part of #11440, @System64fumo can you test this