### PR TITLE
renderer: improve modeset detection timings

### DIFF
--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -183,12 +183,15 @@ class CMonitor {
 
     // for dpms off anim
     PHLANIMVAR<float> m_dpmsBlackOpacity;
-    bool              m_pendingDpmsAnimation = false;
+    bool              m_pendingDpmsAnimation        = false;
+    int               m_pendingDpmsAnimationCounter = 0;
 
     PHLANIMVAR<float> m_cursorZoom;
 
     // for initial zoom anim
     PHLANIMVAR<float> m_zoomAnimProgress;
+    CTimer            m_newMonitorAnimTimer;
+    int               m_zoomAnimFrameCounter = 0;
 
     struct {
         bool canTear         = false;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1310,7 +1310,7 @@ void CHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     else
         g_pHyprOpenGL->m_renderData.mouseZoomFactor = 1.f;
 
-    if (pMonitor->m_zoomAnimProgress->isBeingAnimated()) {
+    if (pMonitor->m_zoomAnimProgress->value() != 1) {
         g_pHyprOpenGL->m_renderData.mouseZoomFactor    = 2.0 - pMonitor->m_zoomAnimProgress->value(); // 2x zoom -> 1x zoom
         g_pHyprOpenGL->m_renderData.mouseZoomUseMouse  = false;
         g_pHyprOpenGL->m_renderData.useNearestNeighbor = false;


### PR DESCRIPTION
some CRTCs will just happily eat frames and we can't do much. Some will eat one.

This adds a 5-frame buffer to DPMS and Added animations. Better than nothing.

It's still worth investigating if it's even possible to detect modeset finishing from userspace, other than a presentation sniff. Maybe someone knows.