### PR TITLE
render: include numbers header

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -2,6 +2,7 @@
 #include <hyprgraphics/color/Color.hpp>
 #include <hyprutils/string/String.hpp>
 #include <hyprutils/path/Path.hpp>
+#include <numbers>
 #include <random>
 #include <pango/pangocairo.h>
 #include "OpenGL.hpp"


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

I've added the numbers header for  [std::numbers](https://en.cppreference.com/w/cpp/numeric/constants.html),
this fixes the error `no member named 'numbers' in namespace 'std'` on Gentoo Linux amd64 (musl/llvm).
<details>

```sh
[332/372] clang++ -Isrc/Hyprland.p -Isrc -I../hyprland-9999/src -Isubprojects/udis86 -I../hyprland-9999/subprojects/udis86 -I../hyprland-9999/subprojects/udis86/libudis86 -Iprotocols -I/usr/lib/libffi/include -I/usr/include/cairo -I/usr/include/libpng16 -I/usr/include/freetype2 -I/usr/include/harfbuzz -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/pixman-1 -I/usr/include/libdrm -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/pango-1.0 -I/usr/include/fribidi -I/usr/include/uuid -flto -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=c++26 -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wno-narrowing -Wno-pointer-arith '-DDATAROOTDIR="/usr/share"' '-DHYPRLAND_VERSION="0.50.0"' -DHAS_EXECINFO '-DAQUAMARINE_VERSION="0.9.2"' -DAQUAMARINE_VERSION_MAJOR=0 -DAQUAMARINE_VERSION_MINOR=9 -DAQUAMARINE_VERSION_PATCH=2 '-DHYPRCURSOR_VERSION="0.1.12"' '-DHYPRGRAPHICS_VERSION="0.1.4"' '-DHYPRLANG_VERSION="0.6.3"' '-DHYPRUTILS_VERSION="0.8.3"' -O3 -pipe -march=native -g0 -D_FORTIFY_SOURCE=3 -stdlib=libc++ -pthread -Wno-float-conversion -Wno-implicit-float-conversion -Wno-implicit-int-float-conversion -Wno-unknown-warning-option -MD -MQ src/Hyprland.p/render_OpenGL.cpp.o -MF src/Hyprland.p/render_OpenGL.cpp.o.d -o src/Hyprland.p/render_OpenGL.cpp.o -c ../hyprland-9999/src/render/OpenGL.cpp
FAILED: [code=1] src/Hyprland.p/render_OpenGL.cpp.o 
clang++ -Isrc/Hyprland.p -Isrc -I../hyprland-9999/src -Isubprojects/udis86 -I../hyprland-9999/subprojects/udis86 -I../hyprland-9999/subprojects/udis86/libudis86 -Iprotocols -I/usr/lib/libffi/include -I/usr/include/cairo -I/usr/include/libpng16 -I/usr/include/freetype2 -I/usr/include/harfbuzz -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/pixman-1 -I/usr/include/libdrm -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/pango-1.0 -I/usr/include/fribidi -I/usr/include/uuid -flto -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=c++26 -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wno-narrowing -Wno-pointer-arith '-DDATAROOTDIR="/usr/share"' '-DHYPRLAND_VERSION="0.50.0"' -DHAS_EXECINFO '-DAQUAMARINE_VERSION="0.9.2"' -DAQUAMARINE_VERSION_MAJOR=0 -DAQUAMARINE_VERSION_MINOR=9 -DAQUAMARINE_VERSION_PATCH=2 '-DHYPRCURSOR_VERSION="0.1.12"' '-DHYPRGRAPHICS_VERSION="0.1.4"' '-DHYPRLANG_VERSION="0.6.3"' '-DHYPRUTILS_VERSION="0.8.3"' -O3 -pipe -march=native -g0 -D_FORTIFY_SOURCE=3 -stdlib=libc++ -pthread -Wno-float-conversion -Wno-implicit-float-conversion -Wno-implicit-int-float-conversion -Wno-unknown-warning-option -MD -MQ src/Hyprland.p/render_OpenGL.cpp.o -MF src/Hyprland.p/render_OpenGL.cpp.o.d -o src/Hyprland.p/render_OpenGL.cpp.o -c ../hyprland-9999/src/render/OpenGL.cpp
../hyprland-9999/src/render/OpenGL.cpp:2364:87: error: no member named 'numbers' in namespace 'std'
 2364 |     m_shaders->m_shBORDER1.setUniformFloat(SHADER_ANGLE, sc<int>(grad.m_angle / (std::numbers::pi / 180.0)) % 360 * (std::numbers::pi / 180.0));
      |                                                                                  ~~~~~^
../hyprland-9999/src/render/OpenGL.cpp:2364:123: error: no member named 'numbers' in namespace 'std'
 2364 |     m_shaders->m_shBORDER1.setUniformFloat(SHADER_ANGLE, sc<int>(grad.m_angle / (std::numbers::pi / 180.0)) % 360 * (std::numbers::pi / 180.0));
      |                                                                                                                      ~~~~~^
../hyprland-9999/src/render/OpenGL.cpp:2450:88: error: no member named 'numbers' in namespace 'std'
 2450 |     m_shaders->m_shBORDER1.setUniformFloat(SHADER_ANGLE, sc<int>(grad1.m_angle / (std::numbers::pi / 180.0)) % 360 * (std::numbers::pi / 180.0));
      |                                                                                   ~~~~~^
../hyprland-9999/src/render/OpenGL.cpp:2450:124: error: no member named 'numbers' in namespace 'std'
 2450 |     m_shaders->m_shBORDER1.setUniformFloat(SHADER_ANGLE, sc<int>(grad1.m_angle / (std::numbers::pi / 180.0)) % 360 * (std::numbers::pi / 180.0));
      |                                                                                                                       ~~~~~^
../hyprland-9999/src/render/OpenGL.cpp:2454:89: error: no member named 'numbers' in namespace 'std'
 2454 |     m_shaders->m_shBORDER1.setUniformFloat(SHADER_ANGLE2, sc<int>(grad2.m_angle / (std::numbers::pi / 180.0)) % 360 * (std::numbers::pi / 180.0));
      |                                                                                    ~~~~~^
../hyprland-9999/src/render/OpenGL.cpp:2454:125: error: no member named 'numbers' in namespace 'std'
 2454 |     m_shaders->m_shBORDER1.setUniformFloat(SHADER_ANGLE2, sc<int>(grad2.m_angle / (std::numbers::pi / 180.0)) % 360 * (std::numbers::pi / 180.0));
      |                                                                                                                        ~~~~~^
6 errors generated.
```
</details>

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

#### Is it ready for merging, or does it need work?

This is ready for merging
