### PR TITLE
Fix monitor luminance overrides and missing edid hdr metadata

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1669,16 +1669,17 @@ bool CMonitor::supportsHDR() {
     return supportsWideColor() && (m_supportsHDR || (m_output->parsedEDID.hdrMetadata.has_value() ? m_output->parsedEDID.hdrMetadata->supportsPQ : false));
 }
 
-float CMonitor::minLuminance() {
-    return m_minLuminance >= 0 ? m_minLuminance : (m_output->parsedEDID.hdrMetadata.has_value() ? m_output->parsedEDID.hdrMetadata->desiredContentMinLuminance : 0);
+float CMonitor::minLuminance(float defaultValue) {
+    return m_minLuminance >= 0 ? m_minLuminance : (m_output->parsedEDID.hdrMetadata.has_value() ? m_output->parsedEDID.hdrMetadata->desiredContentMinLuminance : defaultValue);
 }
 
-int CMonitor::maxLuminance() {
-    return m_maxLuminance >= 0 ? m_maxLuminance : (m_output->parsedEDID.hdrMetadata.has_value() ? m_output->parsedEDID.hdrMetadata->desiredContentMaxLuminance : 80);
+int CMonitor::maxLuminance(int defaultValue) {
+    return m_maxLuminance >= 0 ? m_maxLuminance : (m_output->parsedEDID.hdrMetadata.has_value() ? m_output->parsedEDID.hdrMetadata->desiredContentMaxLuminance : defaultValue);
 }
 
-int CMonitor::maxAvgLuminance() {
-    return m_maxAvgLuminance >= 0 ? m_maxAvgLuminance : (m_output->parsedEDID.hdrMetadata.has_value() ? m_output->parsedEDID.hdrMetadata->desiredMaxFrameAverageLuminance : 80);
+int CMonitor::maxAvgLuminance(int defaultValue) {
+    return m_maxAvgLuminance >= 0 ? m_maxAvgLuminance :
+                                    (m_output->parsedEDID.hdrMetadata.has_value() ? m_output->parsedEDID.hdrMetadata->desiredMaxFrameAverageLuminance : defaultValue);
 }
 
 CMonitorState::CMonitorState(CMonitor* owner) : m_owner(owner) {

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -245,9 +245,9 @@ class CMonitor {
 
     bool                                supportsWideColor();
     bool                                supportsHDR();
-    float                               minLuminance();
-    int                                 maxLuminance();
-    int                                 maxAvgLuminance();
+    float                               minLuminance(float defaultValue = 0);
+    int                                 maxLuminance(int defaultValue = 80);
+    int                                 maxAvgLuminance(int defaultValue = 80);
 
     bool                                m_enabled             = false;
     bool                                m_renderingInitPassed = false;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes a crash when monitor has forced `supports_wide_color` and `supports_hdr` without EDID hdrMetadata.
Correctly pass overridden `min_luminance` and `max_luminance` settings to HDR metadata.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Might change colors in HDR mode. They should be more correct in terms of the overridden monitor settings but might yield unexpected results if those values are incorrect. My main setup with nvidia and external monitor works fine with this change. My intel laptop requires 10x the normal values for `sdr_max_luminance` and `max_luminance` to display something close to expected brightness. Probably some issue with my laptop because vt is also too dim in HDR mode while it is expected to be too bright. 

#### Is it ready for merging, or does it need work?
Ready