### PR TITLE
Fix DPMS animation playing when not changing state

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1599,6 +1599,10 @@ bool CMonitor::attemptDirectScanout() {
 }
 
 void CMonitor::setDPMS(bool on) {
+    // Don't trigger animation if the target state is the same
+    if (m_dpmsStatus == on)
+        return;
+
     m_dpmsStatus = on;
     m_events.dpmsChanged.emit();
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
When running `hyprctl dispatch dpms on`, the animation plays every time, even if the display is currently on. This PR prevents that and only plays the animation if the state has actually changed. Fixes #11479

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
There's probably a better way to do this, feel free to close it and do it a different way if you want.

#### Is it ready for merging, or does it need work?
Should be ready for merging unless someone knows of a better method.

