### PR TITLE
nix: make mold optional

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,11 +16,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755632680,
-        "narHash": "sha256-EjaD8+d7AiAV2fGRN4NTMboWDwk8szDfwbzZ8DL1PhQ=",
+        "lastModified": 1755946532,
+        "narHash": "sha256-POePremlUY5GyA1zfbtic6XLxDaQcqHN6l+bIxdT5gc=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "50637ed23e962f0db294d6b0ef534f37b144644b",
+        "rev": "81584dae2df6ac79f6b6dae0ecb7705e95129ada",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755416120,
-        "narHash": "sha256-PosTxeL39YrLvCX5MqqPA6NNWQ4T5ea5K55nmN7ju9Q=",
+        "lastModified": 1755795954,
+        "narHash": "sha256-9QoDVkjLwjiZDR+y4cMWc/FVudRu5jCIG4rn15Afa9w=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "e631ea36ddba721eceda69bfee6dd01068416489",
+        "rev": "b364dcb7391709acb4492e100fe750ca722992e1",
         "type": "github"
       },
       "original": {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -52,6 +52,9 @@
   nvidiaPatches ? false,
   hidpiXWayland ? false,
   legacyRenderer ? false,
+  # whether to use the mold linker
+  # disable this for older machines without SSE4_2 and AVX2 support
+  withMold ? true,
 }: let
   inherit (builtins) foldl' readFile;
   inherit (lib.asserts) assertMsg;
@@ -61,7 +64,7 @@
   fs = lib.fileset;
 
   adapters = flatten [
-    stdenvAdapters.useMoldLinker
+    (lib.optional withMold stdenvAdapters.useMoldLinker)
     (lib.optional debug stdenvAdapters.keepDebugInfo)
   ];
 
@@ -134,7 +137,7 @@ in
 
       buildInputs = concatLists [
         [
-          aquamarine
+          (aquamarine.override {inherit withMold;})
           cairo
           git
           glaze
@@ -142,7 +145,7 @@ in
           hyprgraphics
           hyprland-protocols
           hyprlang
-          hyprutils
+          (hyprutils.override {inherit withMold;})
           libdrm
           libGL
           libinput


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Allows users to disable the mold linker. Mostly useful on older machines that do not support SSE4_2 and AVX2.
Fixes hyprwm/hyprutils#73.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Probably ready. @notashelf @spikespaz thoughts?
