### PR TITLE
core: fix requestedMinSize crash

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1692,7 +1692,9 @@ bool CWindow::isModal() {
 }
 
 Vector2D CWindow::requestedMinSize() {
-    if ((m_isX11 && !m_xwaylandSurface->m_sizeHints) || (!m_isX11 && !m_xdgSurface->m_toplevel))
+    bool hasSizeHints = m_xwaylandSurface ? m_xwaylandSurface->m_sizeHints : false;
+    bool hasTopLevel  = m_xdgSurface ? m_xdgSurface->m_toplevel : false;
+    if ((m_isX11 && !hasSizeHints) || (!m_isX11 && !hasTopLevel))
         return Vector2D(1, 1);
 
     Vector2D minSize = m_isX11 ? Vector2D(m_xwaylandSurface->m_sizeHints->min_width, m_xwaylandSurface->m_sizeHints->min_height) : m_xdgSurface->m_toplevel->layoutMinSize();


### PR DESCRIPTION
I was getting random crashes sometimes when trying to get the minSize of windows in my plugin, and it was due to m_xwaylandSurface being assumed to exist when the window was an X11 window.

The fix was to check for the existence of the xwayland surface first, and then check if has sizeHints.
