### PR TITLE
scRGB, HLG and SDR -> HDR fixes

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -42,6 +42,7 @@ using namespace Hyprutils::String;
 using namespace Hyprutils::Utils;
 using namespace Hyprutils::OS;
 using enum NContentType::eContentType;
+using namespace NColorManagement;
 
 CMonitor::CMonitor(SP<Aquamarine::IOutput> output_) : m_state(this), m_output(output_) {
     g_pAnimationManager->createAnimation(0.f, m_specialFade, g_pConfigManager->getAnimationPropertyConfig("specialWorkspaceIn"), AVARDAMAGE_NONE);
@@ -1684,6 +1685,18 @@ int CMonitor::maxLuminance(int defaultValue) {
 int CMonitor::maxAvgLuminance(int defaultValue) {
     return m_maxAvgLuminance >= 0 ? m_maxAvgLuminance :
                                     (m_output->parsedEDID.hdrMetadata.has_value() ? m_output->parsedEDID.hdrMetadata->desiredMaxFrameAverageLuminance : defaultValue);
+}
+
+bool CMonitor::wantsWideColor() {
+    return supportsWideColor() && (wantsHDR() || m_imageDescription.primariesNamed == CM_PRIMARIES_BT2020);
+}
+
+bool CMonitor::wantsHDR() {
+    return supportsHDR() && inHDR();
+}
+
+bool CMonitor::inHDR() {
+    return m_output->state->state().hdrMetadata.hdmi_metadata_type1.eotf == 2;
 }
 
 CMonitorState::CMonitorState(CMonitor* owner) : m_owner(owner) {

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -249,6 +249,11 @@ class CMonitor {
     int                                 maxLuminance(int defaultValue = 80);
     int                                 maxAvgLuminance(int defaultValue = 80);
 
+    bool                                wantsWideColor();
+    bool                                wantsHDR();
+
+    bool                                inHDR();
+
     bool                                m_enabled             = false;
     bool                                m_renderingInitPassed = false;
     WP<CWindow>                         m_previousFSWindow;

--- a/src/protocols/ColorManagement.cpp
+++ b/src/protocols/ColorManagement.cpp
@@ -341,13 +341,13 @@ bool CColorManagementSurface::needsHdrMetadataUpdate() {
 }
 
 bool CColorManagementSurface::isHDR() {
-    return m_imageDescription.transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ || isWindowsScRGB();
+    return m_imageDescription.transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ || m_imageDescription.transferFunction == CM_TRANSFER_FUNCTION_HLG || isWindowsScRGB();
 }
 
 bool CColorManagementSurface::isWindowsScRGB() {
     return m_imageDescription.windowsScRGB ||
         // autodetect scRGB, might be incorrect
-        (m_imageDescription.primariesNamed == NColorManagement::CM_PRIMARIES_SRGB && m_imageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_EXT_LINEAR);
+        (m_imageDescription.primariesNamed == CM_PRIMARIES_SRGB && m_imageDescription.transferFunction == CM_TRANSFER_FUNCTION_EXT_LINEAR);
 }
 
 CColorManagementFeedbackSurface::CColorManagementFeedbackSurface(SP<CWpColorManagementSurfaceFeedbackV1> resource, SP<CWLSurfaceResource> surface_) :

--- a/src/protocols/ColorManagement.cpp
+++ b/src/protocols/ColorManagement.cpp
@@ -261,11 +261,11 @@ CColorManagementSurface::CColorManagementSurface(SP<CWpColorManagementSurfaceV1>
     m_client = m_resource->client();
 
     m_resource->setDestroy([this](CWpColorManagementSurfaceV1* r) {
-        LOGM(TRACE, "Destroy xx cm surface {}", (uintptr_t)m_surface);
+        LOGM(TRACE, "Destroy wp cm surface {}", (uintptr_t)m_surface);
         PROTO::colorManagement->destroyResource(this);
     });
     m_resource->setOnDestroy([this](CWpColorManagementSurfaceV1* r) {
-        LOGM(TRACE, "Destroy xx cm surface {}", (uintptr_t)m_surface);
+        LOGM(TRACE, "Destroy wp cm surface {}", (uintptr_t)m_surface);
         PROTO::colorManagement->destroyResource(this);
     });
 
@@ -340,6 +340,16 @@ bool CColorManagementSurface::needsHdrMetadataUpdate() {
     return m_needsNewMetadata;
 }
 
+bool CColorManagementSurface::isHDR() {
+    return m_imageDescription.transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ || isWindowsScRGB();
+}
+
+bool CColorManagementSurface::isWindowsScRGB() {
+    return m_imageDescription.windowsScRGB ||
+        // autodetect scRGB, might be incorrect
+        (m_imageDescription.primariesNamed == NColorManagement::CM_PRIMARIES_SRGB && m_imageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_EXT_LINEAR);
+}
+
 CColorManagementFeedbackSurface::CColorManagementFeedbackSurface(SP<CWpColorManagementSurfaceFeedbackV1> resource, SP<CWLSurfaceResource> surface_) :
     m_surface(surface_), m_resource(resource) {
     if UNLIKELY (!good())
@@ -348,13 +358,13 @@ CColorManagementFeedbackSurface::CColorManagementFeedbackSurface(SP<CWpColorMana
     m_client = m_resource->client();
 
     m_resource->setDestroy([this](CWpColorManagementSurfaceFeedbackV1* r) {
-        LOGM(TRACE, "Destroy xx cm feedback surface {}", (uintptr_t)m_surface);
+        LOGM(TRACE, "Destroy wp cm feedback surface {}", (uintptr_t)m_surface);
         if (m_currentPreferred.valid())
             PROTO::colorManagement->destroyResource(m_currentPreferred.get());
         PROTO::colorManagement->destroyResource(this);
     });
     m_resource->setOnDestroy([this](CWpColorManagementSurfaceFeedbackV1* r) {
-        LOGM(TRACE, "Destroy xx cm feedback surface {}", (uintptr_t)m_surface);
+        LOGM(TRACE, "Destroy wp cm feedback surface {}", (uintptr_t)m_surface);
         if (m_currentPreferred.valid())
             PROTO::colorManagement->destroyResource(m_currentPreferred.get());
         PROTO::colorManagement->destroyResource(this);

--- a/src/protocols/ColorManagement.cpp
+++ b/src/protocols/ColorManagement.cpp
@@ -15,13 +15,13 @@ CColorManager::CColorManager(SP<CWpColorManagerV1> resource) : m_resource(resour
     m_resource->sendSupportedFeature(WP_COLOR_MANAGER_V1_FEATURE_PARAMETRIC);
     m_resource->sendSupportedFeature(WP_COLOR_MANAGER_V1_FEATURE_SET_PRIMARIES);
     m_resource->sendSupportedFeature(WP_COLOR_MANAGER_V1_FEATURE_SET_LUMINANCES);
+    m_resource->sendSupportedFeature(WP_COLOR_MANAGER_V1_FEATURE_WINDOWS_SCRGB);
 
     if (PROTO::colorManagement->m_debug) {
         m_resource->sendSupportedFeature(WP_COLOR_MANAGER_V1_FEATURE_ICC_V2_V4);
         m_resource->sendSupportedFeature(WP_COLOR_MANAGER_V1_FEATURE_SET_TF_POWER);
         m_resource->sendSupportedFeature(WP_COLOR_MANAGER_V1_FEATURE_SET_MASTERING_DISPLAY_PRIMARIES);
         m_resource->sendSupportedFeature(WP_COLOR_MANAGER_V1_FEATURE_EXTENDED_TARGET_VOLUME);
-        m_resource->sendSupportedFeature(WP_COLOR_MANAGER_V1_FEATURE_WINDOWS_SCRGB);
     }
 
     m_resource->sendSupportedPrimariesNamed(WP_COLOR_MANAGER_V1_PRIMARIES_SRGB);
@@ -170,11 +170,7 @@ CColorManager::CColorManager(SP<CWpColorManagerV1> resource) : m_resource(resour
         RESOURCE->m_self = RESOURCE;
     });
     m_resource->setCreateWindowsScrgb([](CWpColorManagerV1* r, uint32_t id) {
-        LOGM(WARN, "New Windows scRGB description id={} (unsupported)", id);
-        if (!PROTO::colorManagement->m_debug) {
-            r->error(WP_COLOR_MANAGER_V1_ERROR_UNSUPPORTED_FEATURE, "Windows scRGB profiles are not supported");
-            return;
-        }
+        LOGM(WARN, "New Windows scRGB description id={}", id);
 
         const auto RESOURCE = PROTO::colorManagement->m_imageDescriptions.emplace_back(
             makeShared<CColorManagementImageDescription>(makeShared<CWpImageDescriptionV1>(r->client(), r->version(), id), false));
@@ -624,10 +620,6 @@ CColorManagementParametricCreator::CColorManagementParametricCreator(SP<CWpImage
             LOGM(TRACE, "Set image description primaries by values r:{},{} g:{},{} b:{},{} w:{},{}", r_x, r_y, g_x, g_y, b_x, b_y, w_x, w_y);
             if (m_valuesSet & PC_PRIMARIES) {
                 r->error(WP_IMAGE_DESCRIPTION_CREATOR_PARAMS_V1_ERROR_ALREADY_SET, "Primaries already set");
-                return;
-            }
-            if (!PROTO::colorManagement->m_debug) {
-                r->error(WP_COLOR_MANAGER_V1_ERROR_UNSUPPORTED_FEATURE, "Custom primaries aren't supported");
                 return;
             }
             m_settings.primariesNameSet = false;

--- a/src/protocols/ColorManagement.hpp
+++ b/src/protocols/ColorManagement.hpp
@@ -61,6 +61,8 @@ class CColorManagementSurface {
     const hdr_output_metadata&                 hdrMetadata();
     void                                       setHDRMetadata(const hdr_output_metadata& metadata);
     bool                                       needsHdrMetadataUpdate();
+    bool                                       isHDR();
+    bool                                       isWindowsScRGB();
 
   private:
     SP<CWpColorManagementSurfaceV1>     m_resource;

--- a/src/protocols/types/ColorManagement.hpp
+++ b/src/protocols/types/ColorManagement.hpp
@@ -203,6 +203,7 @@ namespace NColorManagement {
 
         float getTFMaxLuminance(int sdrMaxLuminance = -1) const {
             switch (transferFunction) {
+                case CM_TRANSFER_FUNCTION_EXT_LINEAR: return HDR_MAX_LUMINANCE; // assume Windows scRGB
                 case CM_TRANSFER_FUNCTION_ST2084_PQ: return HDR_MAX_LUMINANCE;
                 case CM_TRANSFER_FUNCTION_HLG: return HLG_MAX_LUMINANCE;
                 case CM_TRANSFER_FUNCTION_GAMMA22:

--- a/src/protocols/types/ColorManagement.hpp
+++ b/src/protocols/types/ColorManagement.hpp
@@ -203,7 +203,8 @@ namespace NColorManagement {
 
         float getTFMaxLuminance(int sdrMaxLuminance = -1) const {
             switch (transferFunction) {
-                case CM_TRANSFER_FUNCTION_EXT_LINEAR: return HDR_MAX_LUMINANCE; // assume Windows scRGB
+                case CM_TRANSFER_FUNCTION_EXT_LINEAR:
+                    return SDR_MAX_LUMINANCE; // assume Windows scRGB. white color range 1.0 - 125.0 maps to SDR_MAX_LUMINANCE (80) - HDR_MAX_LUMINANCE (10000)
                 case CM_TRANSFER_FUNCTION_ST2084_PQ: return HDR_MAX_LUMINANCE;
                 case CM_TRANSFER_FUNCTION_HLG: return HLG_MAX_LUMINANCE;
                 case CM_TRANSFER_FUNCTION_GAMMA22:

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1600,9 +1600,9 @@ void CHyprOpenGLImpl::renderTextureInternal(SP<CTexture> tex, const CBox& box, c
     const bool canPassHDRSurface = m_renderData.surface.valid() && m_renderData.surface->m_colorManagement.valid() ?
         m_renderData.surface->m_colorManagement->isHDR() && !m_renderData.surface->m_colorManagement->isWindowsScRGB() :
         false; // windows scRGB requires CM shader
-    const auto imageDescription  = m_renderData.surface.valid() && m_renderData.surface->m_colorManagement.valid() ?
-         m_renderData.surface->m_colorManagement->imageDescription() :
-         (data.cmBackToSRGB ? data.cmBackToSRGBSource->m_imageDescription : SImageDescription{});
+    auto       imageDescription  = m_renderData.surface.valid() && m_renderData.surface->m_colorManagement.valid() ?
+               m_renderData.surface->m_colorManagement->imageDescription() :
+               (data.cmBackToSRGB ? data.cmBackToSRGBSource->m_imageDescription : SImageDescription{});
 
     const bool skipCM = !*PENABLECM || !m_cmSupported                                            /* CM unsupported or disabled */
         || (imageDescription == m_renderData.pMonitor->m_imageDescription && !data.cmBackToSRGB) /* Source and target have the same image description */

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -37,7 +37,6 @@
 #include "../protocols/types/ContentType.hpp"
 #include "../helpers/MiscFunctions.hpp"
 #include "render/OpenGL.hpp"
-#include "protocols/types/ColorManagement.hpp"
 
 #include <hyprutils/utils/ScopeGuard.hpp>
 using namespace Hyprutils::Utils;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -37,6 +37,7 @@
 #include "../protocols/types/ContentType.hpp"
 #include "../helpers/MiscFunctions.hpp"
 #include "render/OpenGL.hpp"
+#include "protocols/types/ColorManagement.hpp"
 
 #include <hyprutils/utils/ScopeGuard.hpp>
 using namespace Hyprutils::Utils;
@@ -1460,6 +1461,9 @@ static hdr_output_metadata       createHDRMetadata(SImageDescription settings, S
     switch (settings.transferFunction) {
         case CM_TRANSFER_FUNCTION_SRGB: eotf = 0; break; // used to send primaries and luminances to AQ. ignored for now
         case CM_TRANSFER_FUNCTION_ST2084_PQ: eotf = 2; break;
+        case CM_TRANSFER_FUNCTION_EXT_LINEAR:
+            eotf = 2;
+            break; // should be Windows scRGB
         // case CM_TRANSFER_FUNCTION_HLG: eotf = 3; break; TODO check display capabilities first
         default: return NO_HDR_METADATA; // empty metadata for SDR
     }
@@ -1501,7 +1505,6 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
     static auto PAUTOHDR = CConfigValue<Hyprlang::INT>("render:cm_auto_hdr");
 
     const bool  configuredHDR = (pMonitor->m_cmType == CM_HDR_EDID || pMonitor->m_cmType == CM_HDR);
-    const bool  hdsIsActive   = pMonitor->m_output->state->state().hdrMetadata.hdmi_metadata_type1.eotf == 2;
     bool        wantHDR       = configuredHDR;
 
     if (pMonitor->supportsHDR()) {
@@ -1524,7 +1527,7 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
 
             // we have a surface with image description
             if (SURF && SURF->m_colorManagement.valid() && SURF->m_colorManagement->hasImageDescription()) {
-                const bool surfaceIsHDR = SURF->m_colorManagement->imageDescription().transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ;
+                const bool surfaceIsHDR = SURF->m_colorManagement->isHDR();
                 if (*PPASS == 1 || (*PPASS == 2 && surfaceIsHDR)) {
                     // passthrough
                     bool needsHdrMetadataUpdate = SURF->m_colorManagement->needsHdrMetadataUpdate() || pMonitor->m_previousFSWindow != WINDOW;
@@ -1541,8 +1544,8 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
         }
 
         if (!hdrIsHandled) {
-            if (hdsIsActive != wantHDR) {
-                if (*PAUTOHDR && !(hdsIsActive && configuredHDR)) {
+            if (pMonitor->inHDR() != wantHDR) {
+                if (*PAUTOHDR && !(pMonitor->inHDR() && configuredHDR)) {
                     // modify or restore monitor image description for auto-hdr
                     // FIXME ok for now, will need some other logic if monitor image description can be modified some other way
                     pMonitor->applyCMType(wantHDR ? (*PAUTOHDR == 2 ? CM_HDR_EDID : CM_HDR) : pMonitor->m_cmType);
@@ -1553,7 +1556,7 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
         }
     }
 
-    const bool needsWCG = pMonitor->m_output->state->state().hdrMetadata.hdmi_metadata_type1.eotf == 2 || pMonitor->m_imageDescription.primariesNamed == CM_PRIMARIES_BT2020;
+    const bool needsWCG = pMonitor->wantsWideColor();
     if (pMonitor->m_output->state->state().wideColorGamut != needsWCG) {
         Debug::log(TRACE, "Setting wide color gamut {}", needsWCG ? "on" : "off");
         pMonitor->m_output->state->setWideColorGamut(needsWCG);

--- a/src/render/pass/SurfacePassElement.cpp
+++ b/src/render/pass/SurfacePassElement.cpp
@@ -77,8 +77,6 @@ void CSurfacePassElement::draw(const CRegion& damage) {
         DELTALESSTHAN(windowBox.height, m_data.surface->m_current.bufferSize.y, 3) /* off by one-or-two */ &&
         (!m_data.pWindow || (!m_data.pWindow->m_realSize->isBeingAnimated() && !INTERACTIVERESIZEINPROGRESS)) /* not window or not animated/resizing */;
 
-    if (m_data.surface->m_colorManagement.valid())
-        Debug::log(TRACE, "FIXME: rendering surface with color management enabled, should apply necessary transformations");
     g_pHyprRenderer->calculateUVForSurface(m_data.pWindow, m_data.surface, m_data.pMonitor->m_self.lock(), m_data.mainSurface, windowBox.size(), PROJSIZEUNSCALED, MISALIGNEDFSV1);
 
     auto cancelRender                      = false;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
* Handles HLG as HDR
* Handles windows scRGB and matching formats as HDR. Fixes HDR in Control.
* Restricts monitorv2 sdr settings to SDR -> HDR scenario.
* Removed some unneeded cm debug checks.
* Some minor debug log fixes.

Part of #11000 without fp16 stuff

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
scRGB can't be used with `cm_fs_passthrough`. `cm_fs_passthrough = 2` should handle this automatically but might fail. `cm_fs_passthrough = 0` is a more reliable setting.

Easier to test with Cyberpunk 2077. If it's working then PQ HDR and scRGB shouldn't have any noticeable difference. If it doesn't then scRGB should either switch to SDR mode or have obviously incorrect colors.

#### Is it ready for merging, or does it need work?
Ready
