### PR TITLE
plugins: add eRenderStage::RENDER_POST_WALLPAPER

### DIFF
--- a/src/SharedDefs.hpp
+++ b/src/SharedDefs.hpp
@@ -18,15 +18,16 @@ enum eIcons : uint8_t {
 };
 
 enum eRenderStage : uint8_t {
-    RENDER_PRE = 0,      /* Before binding the gl context */
-    RENDER_BEGIN,        /* Just when the rendering begins, nothing has been rendered yet. Damage, current render data in opengl valid. */
-    RENDER_PRE_WINDOWS,  /* Pre windows, post bottom and overlay layers */
-    RENDER_POST_WINDOWS, /* Post windows, pre top/overlay layers, etc */
-    RENDER_LAST_MOMENT,  /* Last moment to render with the gl context */
-    RENDER_POST,         /* After rendering is finished, gl context not available anymore */
-    RENDER_POST_MIRROR,  /* After rendering a mirror */
-    RENDER_PRE_WINDOW,   /* Before rendering a window (any pass) Note some windows (e.g. tiled) may have 2 passes (main & popup) */
-    RENDER_POST_WINDOW,  /* After rendering a window (any pass) */
+    RENDER_PRE = 0,        /* Before binding the gl context */
+    RENDER_BEGIN,          /* Just when the rendering begins, nothing has been rendered yet. Damage, current render data in opengl valid. */
+    RENDER_POST_WALLPAPER, /* After background layer, but before bottom and overlay layers */
+    RENDER_PRE_WINDOWS,    /* Pre windows, post bottom and overlay layers */
+    RENDER_POST_WINDOWS,   /* Post windows, pre top/overlay layers, etc */
+    RENDER_LAST_MOMENT,    /* Last moment to render with the gl context */
+    RENDER_POST,           /* After rendering is finished, gl context not available anymore */
+    RENDER_POST_MIRROR,    /* After rendering a mirror */
+    RENDER_PRE_WINDOW,     /* Before rendering a window (any pass) Note some windows (e.g. tiled) may have 2 passes (main & popup) */
+    RENDER_POST_WINDOW,    /* After rendering a window (any pass) */
 };
 
 enum eInputType : uint8_t {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -884,6 +884,8 @@ void CHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
             renderLayer(ls.lock(), pMonitor, time);
         }
 
+        EMIT_HOOK_EVENT("render", RENDER_POST_WALLPAPER);
+
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]) {
             renderLayer(ls.lock(), pMonitor, time);
         }
@@ -908,6 +910,8 @@ void CHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]) {
             renderLayer(ls.lock(), pMonitor, time);
         }
+
+        EMIT_HOOK_EVENT("render", RENDER_POST_WALLPAPER);
 
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]) {
             renderLayer(ls.lock(), pMonitor, time);


### PR DESCRIPTION
I was trying to draw on the wallpaper with my plugin. The problem was that `RENDER_PRE_WINDOWS` comes after docks and panels are drawn, and so I would, unexpectedly end up drawing over docks.

This PR adds an `eRenderStage` that comes after the wallpaper texture and background layers are drawn, but before `RENDER_PRE_WINDOWS`, and I've tested it as working.