### PR TITLE
protocols: xdg_activation send invalid token when serial is not valid

### DIFF
--- a/src/protocols/XDGActivation.cpp
+++ b/src/protocols/XDGActivation.cpp
@@ -1,6 +1,7 @@
 #include "XDGActivation.hpp"
 #include "../managers/TokenManager.hpp"
 #include "../Compositor.hpp"
+#include "../managers/SeatManager.hpp"
 #include "core/Compositor.hpp"
 #include <algorithm>
 
@@ -20,6 +21,12 @@ CXDGActivationToken::CXDGActivationToken(SP<CXdgActivationTokenV1> resource_) : 
         // if it was used? the protocol spec doesn't say _when_ it should be sent...
         if UNLIKELY (m_committed) {
             LOGM(WARN, "possible protocol error, two commits from one token. Ignoring.");
+            return;
+        }
+
+        if (!g_pSeatManager->serialValid(g_pSeatManager->seatResourceForClient(m_resource->client()), m_serial)) {
+            LOGM(LOG, "serial not found, sending invalid token");
+            m_resource->sendDone("__invalid__");
             return;
         }
 


### PR DESCRIPTION

### Add serial validation to the protocol xdg_activation 

The current xdg activation protocol implementation allows clients to activate toplevel without any validation of user input. Some popular apps abuse this behavior (Telegram with the Draw attention setting on), also other apps could abuse this.

This makes having `misc:focus_on_activate true` a bit annoying.

If we validate the serial from the user input then we solve the problem of apps activating them self without user interaction.

#### Ruff edges
The current way of invalidating serials is not the best IMO. The gtk 3 implementation of gtk_window_present will use the last serial received. This means that even if the serial was created two hours ago the serial will be valid.