### PR TITLE
disable buffer readability checks on intel

### DIFF
--- a/src/helpers/sync/SyncTimeline.cpp
+++ b/src/helpers/sync/SyncTimeline.cpp
@@ -64,7 +64,7 @@ std::optional<bool> CSyncTimeline::check(uint64_t point, uint32_t flags) {
     return ret == 0;
 }
 
-bool CSyncTimeline::addWaiter(const std::function<void()>& waiter, uint64_t point, uint32_t flags) {
+bool CSyncTimeline::addWaiter(std::function<void()>&& waiter, uint64_t point, uint32_t flags) {
     auto eventFd = CFileDescriptor(eventfd(0, EFD_CLOEXEC));
 
     if (!eventFd.isValid()) {
@@ -77,7 +77,7 @@ bool CSyncTimeline::addWaiter(const std::function<void()>& waiter, uint64_t poin
         return false;
     }
 
-    g_pEventLoopManager->doOnReadable(std::move(eventFd), waiter);
+    g_pEventLoopManager->doOnReadable(std::move(eventFd), std::move(waiter));
 
     return true;
 }

--- a/src/helpers/sync/SyncTimeline.hpp
+++ b/src/helpers/sync/SyncTimeline.hpp
@@ -25,7 +25,7 @@ class CSyncTimeline {
     // std::nullopt on fail
     std::optional<bool>            check(uint64_t point, uint32_t flags);
 
-    bool                           addWaiter(const std::function<void()>& waiter, uint64_t point, uint32_t flags);
+    bool                           addWaiter(std::function<void()>&& waiter, uint64_t point, uint32_t flags);
     Hyprutils::OS::CFileDescriptor exportAsSyncFileFD(uint64_t src);
     bool                           importFromSyncFileFD(uint64_t dst, Hyprutils::OS::CFileDescriptor& fd);
     bool                           transfer(SP<CSyncTimeline> from, uint64_t fromPoint, uint64_t toPoint);

--- a/src/managers/eventLoop/EventLoopManager.cpp
+++ b/src/managers/eventLoop/EventLoopManager.cpp
@@ -193,13 +193,13 @@ void CEventLoopManager::doLater(const std::function<void()>& fn) {
         &m_idle);
 }
 
-void CEventLoopManager::doOnReadable(CFileDescriptor fd, const std::function<void()>& fn) {
+void CEventLoopManager::doOnReadable(CFileDescriptor fd, std::function<void()>&& fn) {
     if (!fd.isValid() || fd.isReadable()) {
         fn();
         return;
     }
 
-    auto& waiter   = m_readableWaiters.emplace_back(makeUnique<SReadableWaiter>(nullptr, std::move(fd), fn));
+    auto& waiter   = m_readableWaiters.emplace_back(makeUnique<SReadableWaiter>(nullptr, std::move(fd), std::move(fn)));
     waiter->source = wl_event_loop_add_fd(g_pEventLoopManager->m_wayland.loop, waiter->fd.get(), WL_EVENT_READABLE, ::handleWaiterFD, waiter.get());
 }
 

--- a/src/managers/eventLoop/EventLoopManager.hpp
+++ b/src/managers/eventLoop/EventLoopManager.hpp
@@ -63,7 +63,7 @@ class CEventLoopManager {
 
     // schedule function to when fd is readable (WL_EVENT_READABLE / POLLIN),
     // takes ownership of fd
-    void doOnReadable(Hyprutils::OS::CFileDescriptor fd, const std::function<void()>& fn);
+    void doOnReadable(Hyprutils::OS::CFileDescriptor fd, std::function<void()>&& fn);
     void onFdReadable(SReadableWaiter* waiter);
 
   private:

--- a/src/protocols/DRMSyncobj.cpp
+++ b/src/protocols/DRMSyncobj.cpp
@@ -27,9 +27,9 @@ UP<CSyncReleaser> CDRMSyncPointState::createSyncRelease() {
     return makeUnique<CSyncReleaser>(m_timeline, m_point);
 }
 
-bool CDRMSyncPointState::addWaiter(const std::function<void()>& waiter) {
+bool CDRMSyncPointState::addWaiter(std::function<void()>&& waiter) {
     m_acquireCommitted = true;
-    return m_timeline->addWaiter(waiter, m_point, 0u);
+    return m_timeline->addWaiter(std::move(waiter), m_point, 0u);
 }
 
 bool CDRMSyncPointState::committed() {

--- a/src/protocols/DRMSyncobj.hpp
+++ b/src/protocols/DRMSyncobj.hpp
@@ -20,7 +20,7 @@ class CDRMSyncPointState {
     const uint64_t&                                  point();
     WP<CSyncTimeline>                                timeline();
     Hyprutils::Memory::CUniquePointer<CSyncReleaser> createSyncRelease();
-    bool                                             addWaiter(const std::function<void()>& waiter);
+    bool                                             addWaiter(std::function<void()>&& waiter);
     bool                                             committed();
     Hyprutils::OS::CFileDescriptor                   exportAsFD();
     void                                             signal();

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -161,7 +161,7 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
 
         if (state->updated.bits.acquire) {
             // wait on acquire point for this surface, from explicit sync protocol
-            state->acquire.addWaiter(whenReadable);
+            state->acquire.addWaiter(std::move(whenReadable));
         } else if (state->buffer->isSynchronous()) {
             // synchronous (shm) buffers can be read immediately
             whenReadable();
@@ -170,7 +170,7 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
             auto syncFd = dc<CDMABuffer*>(state->buffer.m_buffer.get())->exportSyncFile();
 
             if (syncFd.isValid())
-                g_pEventLoopManager->doOnReadable(std::move(syncFd), whenReadable);
+                g_pEventLoopManager->doOnReadable(std::move(syncFd), std::move(whenReadable));
             else
                 whenReadable();
         } else {

--- a/src/protocols/types/DMABuffer.cpp
+++ b/src/protocols/types/DMABuffer.cpp
@@ -118,8 +118,12 @@ CFileDescriptor CDMABuffer::exportSyncFile() {
         if (fd == -1)
             continue;
 
-        if (CFileDescriptor::isReadable(fd))
-            continue;
+        // buffer readability checks are rather slow on some Intel laptops
+        // see https://gitlab.freedesktop.org/drm/intel/-/issues/9415
+        if (g_pHyprRenderer && !g_pHyprRenderer->isIntel()) {
+            if (CFileDescriptor::isReadable(fd))
+                continue;
+        }
 
         dma_buf_export_sync_file request{
             .flags = DMA_BUF_SYNC_READ,

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -67,6 +67,8 @@ CHyprRenderer::CHyprRenderer() {
 
             if (name.contains("nvidia"))
                 m_nvidia = true;
+            else if (name.contains("i915"))
+                m_intel = true;
 
             Debug::log(LOG, "DRM driver information: {} v{}.{}.{} from {} description {}", name, DRMV->version_major, DRMV->version_minor, DRMV->version_patchlevel,
                        std::string{DRMV->date, DRMV->date_len}, std::string{DRMV->desc, DRMV->desc_len});
@@ -85,6 +87,8 @@ CHyprRenderer::CHyprRenderer() {
 
             if (name.contains("nvidia"))
                 m_nvidia = true;
+            else if (name.contains("i915"))
+                m_intel = true;
 
             Debug::log(LOG, "Primary DRM driver information: {} v{}.{}.{} from {} description {}", name, DRMV->version_major, DRMV->version_minor, DRMV->version_patchlevel,
                        std::string{DRMV->date, DRMV->date_len}, std::string{DRMV->desc, DRMV->desc_len});
@@ -2285,6 +2289,10 @@ SP<CRenderbuffer> CHyprRenderer::getCurrentRBO() {
 
 bool CHyprRenderer::isNvidia() {
     return m_nvidia;
+}
+
+bool CHyprRenderer::isIntel() {
+    return m_intel;
 }
 
 bool CHyprRenderer::isMgpu() {

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -74,6 +74,7 @@ class CHyprRenderer {
     void                            onRenderbufferDestroy(CRenderbuffer* rb);
     SP<CRenderbuffer>               getCurrentRBO();
     bool                            isNvidia();
+    bool                            isIntel();
     bool                            isMgpu();
     void                            makeEGLCurrent();
     void                            unsetEGL();
@@ -141,6 +142,7 @@ class CHyprRenderer {
     SP<Aquamarine::IBuffer> m_currentBuffer       = nullptr;
     eRenderMode             m_renderMode          = RENDER_MODE_NORMAL;
     bool                    m_nvidia              = false;
+    bool                    m_intel               = false;
     bool                    m_mgpu                = false;
 
     struct {


### PR DESCRIPTION
buffer readability checks are rather slow on some Intel laptops see https://gitlab.freedesktop.org/drm/intel/-/issues/9415

and make addwaiter, doonreadable take rvalue reference because most of the time we store it in the SReadableWaiter, otherwise just let it go when function goes out of scope.


