### PR TITLE
hyprctl: active layout index field in devices 

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -734,8 +734,9 @@ static std::string devicesRequest(eHyprCtlOutputFormat format, std::string reque
 
         result += "\"keyboards\": [\n";
         for (auto const& k : g_pInputManager->m_keyboards) {
-            const auto KI = std::to_string(k->getActiveLayoutIndex());
-            const auto KM = k->getActiveLayout();
+            const auto INDEX_OPT = k->getActiveLayoutIndex();
+            const auto KI        = INDEX_OPT.has_value() ? std::to_string(INDEX_OPT.value()) : "none";
+            const auto KM        = k->getActiveLayout();
             result += std::format(
                 R"#(    {{
         "address": "0x{:x}",
@@ -838,8 +839,9 @@ static std::string devicesRequest(eHyprCtlOutputFormat format, std::string reque
         result += "\n\nKeyboards:\n";
 
         for (auto const& k : g_pInputManager->m_keyboards) {
-            const auto KI = std::to_string(k->getActiveLayoutIndex());
-            const auto KM = k->getActiveLayout();
+            const auto INDEX_OPT = k->getActiveLayoutIndex();
+            const auto KI        = INDEX_OPT.has_value() ? std::to_string(INDEX_OPT.value()) : "none";
+            const auto KM        = k->getActiveLayout();
             result += std::format("\tKeyboard at {:x}:\n\t\t{}\n\t\t\trules: r \"{}\", m \"{}\", l \"{}\", v \"{}\", o \"{}\"\n\t\t\tactive layout index: {}\n\t\t\tactive keymap: "
                                   "{}\n\t\t\tcapsLock: "
                                   "{}\n\t\t\tnumLock: {}\n\t\t\tmain: {}\n",

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -753,9 +753,8 @@ static std::string devicesRequest(eHyprCtlOutputFormat format, std::string reque
         "main": {}
     }},)#",
                 rc<uintptr_t>(k.get()), escapeJSONStrings(k->m_hlName), escapeJSONStrings(k->m_currentRules.rules), escapeJSONStrings(k->m_currentRules.model),
-                escapeJSONStrings(k->m_currentRules.layout), escapeJSONStrings(k->m_currentRules.variant), escapeJSONStrings(k->m_currentRules.options), escapeJSONStrings(KI),
-                escapeJSONStrings(KM), (getModState(k, XKB_MOD_NAME_CAPS) ? "true" : "false"), (getModState(k, XKB_MOD_NAME_NUM) ? "true" : "false"),
-                (k->m_active ? "true" : "false"));
+                escapeJSONStrings(k->m_currentRules.layout), escapeJSONStrings(k->m_currentRules.variant), escapeJSONStrings(k->m_currentRules.options), KI, escapeJSONStrings(KM),
+                (getModState(k, XKB_MOD_NAME_CAPS) ? "true" : "false"), (getModState(k, XKB_MOD_NAME_NUM) ? "true" : "false"), (k->m_active ? "true" : "false"));
         }
 
         trimTrailingComma(result);

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -734,6 +734,7 @@ static std::string devicesRequest(eHyprCtlOutputFormat format, std::string reque
 
         result += "\"keyboards\": [\n";
         for (auto const& k : g_pInputManager->m_keyboards) {
+            const auto KI = std::to_string(k->getActiveLayoutIndex());
             const auto KM = k->getActiveLayout();
             result += std::format(
                 R"#(    {{
@@ -744,14 +745,16 @@ static std::string devicesRequest(eHyprCtlOutputFormat format, std::string reque
         "layout": "{}",
         "variant": "{}",
         "options": "{}",
+        "active_layout_index": {},
         "active_keymap": "{}",
         "capsLock": {},
         "numLock": {},
         "main": {}
     }},)#",
                 rc<uintptr_t>(k.get()), escapeJSONStrings(k->m_hlName), escapeJSONStrings(k->m_currentRules.rules), escapeJSONStrings(k->m_currentRules.model),
-                escapeJSONStrings(k->m_currentRules.layout), escapeJSONStrings(k->m_currentRules.variant), escapeJSONStrings(k->m_currentRules.options), escapeJSONStrings(KM),
-                (getModState(k, XKB_MOD_NAME_CAPS) ? "true" : "false"), (getModState(k, XKB_MOD_NAME_NUM) ? "true" : "false"), (k->m_active ? "true" : "false"));
+                escapeJSONStrings(k->m_currentRules.layout), escapeJSONStrings(k->m_currentRules.variant), escapeJSONStrings(k->m_currentRules.options), escapeJSONStrings(KI),
+                escapeJSONStrings(KM), (getModState(k, XKB_MOD_NAME_CAPS) ? "true" : "false"), (getModState(k, XKB_MOD_NAME_NUM) ? "true" : "false"),
+                (k->m_active ? "true" : "false"));
         }
 
         trimTrailingComma(result);
@@ -835,11 +838,13 @@ static std::string devicesRequest(eHyprCtlOutputFormat format, std::string reque
         result += "\n\nKeyboards:\n";
 
         for (auto const& k : g_pInputManager->m_keyboards) {
+            const auto KI = std::to_string(k->getActiveLayoutIndex());
             const auto KM = k->getActiveLayout();
-            result += std::format("\tKeyboard at {:x}:\n\t\t{}\n\t\t\trules: r \"{}\", m \"{}\", l \"{}\", v \"{}\", o \"{}\"\n\t\t\tactive keymap: {}\n\t\t\tcapsLock: "
+            result += std::format("\tKeyboard at {:x}:\n\t\t{}\n\t\t\trules: r \"{}\", m \"{}\", l \"{}\", v \"{}\", o \"{}\"\n\t\t\tactive layout index: {}\n\t\t\tactive keymap: "
+                                  "{}\n\t\t\tcapsLock: "
                                   "{}\n\t\t\tnumLock: {}\n\t\t\tmain: {}\n",
                                   rc<uintptr_t>(k.get()), k->m_hlName, k->m_currentRules.rules, k->m_currentRules.model, k->m_currentRules.layout, k->m_currentRules.variant,
-                                  k->m_currentRules.options, KM, (getModState(k, XKB_MOD_NAME_CAPS) ? "yes" : "no"), (getModState(k, XKB_MOD_NAME_NUM) ? "yes" : "no"),
+                                  k->m_currentRules.options, KI, KM, (getModState(k, XKB_MOD_NAME_CAPS) ? "yes" : "no"), (getModState(k, XKB_MOD_NAME_NUM) ? "yes" : "no"),
                                   (k->m_active ? "yes" : "no"));
         }
 

--- a/src/devices/IKeyboard.cpp
+++ b/src/devices/IKeyboard.cpp
@@ -266,6 +266,20 @@ void IKeyboard::updateXKBTranslationState(xkb_keymap* const keymap) {
     xkb_context_unref(PCONTEXT);
 }
 
+xkb_layout_index_t IKeyboard::getActiveLayoutIndex() {
+    const auto KEYMAP     = m_xkbKeymap;
+    const auto STATE      = m_xkbState;
+    const auto LAYOUTSNUM = xkb_keymap_num_layouts(KEYMAP);
+
+    for (xkb_layout_index_t i = 0; i < LAYOUTSNUM; ++i) {
+        if (xkb_state_layout_index_is_active(STATE, i, XKB_STATE_LAYOUT_EFFECTIVE) == 1) {
+            return i;
+        }
+    }
+
+    return 0;
+}
+
 std::string IKeyboard::getActiveLayout() {
     const auto KEYMAP     = m_xkbKeymap;
     const auto STATE      = m_xkbState;

--- a/src/devices/IKeyboard.cpp
+++ b/src/devices/IKeyboard.cpp
@@ -266,18 +266,17 @@ void IKeyboard::updateXKBTranslationState(xkb_keymap* const keymap) {
     xkb_context_unref(PCONTEXT);
 }
 
-xkb_layout_index_t IKeyboard::getActiveLayoutIndex() {
+std::optional<xkb_layout_index_t> IKeyboard::getActiveLayoutIndex() {
     const auto KEYMAP     = m_xkbKeymap;
     const auto STATE      = m_xkbState;
     const auto LAYOUTSNUM = xkb_keymap_num_layouts(KEYMAP);
 
     for (xkb_layout_index_t i = 0; i < LAYOUTSNUM; ++i) {
-        if (xkb_state_layout_index_is_active(STATE, i, XKB_STATE_LAYOUT_EFFECTIVE) == 1) {
+        if (xkb_state_layout_index_is_active(STATE, i, XKB_STATE_LAYOUT_EFFECTIVE) == 1)
             return i;
-        }
     }
 
-    return 0;
+    return {};
 }
 
 std::string IKeyboard::getActiveLayout() {

--- a/src/devices/IKeyboard.hpp
+++ b/src/devices/IKeyboard.hpp
@@ -67,6 +67,7 @@ class IKeyboard : public IHID {
 
     void                    setKeymap(const SStringRuleNames& rules);
     void                    updateXKBTranslationState(xkb_keymap* const keymap = nullptr);
+    xkb_layout_index_t      getActiveLayoutIndex();
     std::string             getActiveLayout();
     std::optional<uint32_t> getLEDs();
     void                    updateLEDs();

--- a/src/devices/IKeyboard.hpp
+++ b/src/devices/IKeyboard.hpp
@@ -65,24 +65,24 @@ class IKeyboard : public IHID {
         std::string rules   = "";
     };
 
-    void                    setKeymap(const SStringRuleNames& rules);
-    void                    updateXKBTranslationState(xkb_keymap* const keymap = nullptr);
-    xkb_layout_index_t      getActiveLayoutIndex();
-    std::string             getActiveLayout();
-    std::optional<uint32_t> getLEDs();
-    void                    updateLEDs();
-    void                    updateLEDs(uint32_t leds);
-    uint32_t                getModifiers();
-    void                    updateModifiers(uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group);
-    bool                    updateModifiersState(); // rets whether changed
-    void                    updateXkbStateWithKey(uint32_t xkbKey, bool pressed);
-    void                    updateKeymapFD();
-    bool                    getPressed(uint32_t key);
-    bool                    shareStates();
+    void                              setKeymap(const SStringRuleNames& rules);
+    void                              updateXKBTranslationState(xkb_keymap* const keymap = nullptr);
+    std::optional<xkb_layout_index_t> getActiveLayoutIndex();
+    std::string                       getActiveLayout();
+    std::optional<uint32_t>           getLEDs();
+    void                              updateLEDs();
+    void                              updateLEDs(uint32_t leds);
+    uint32_t                          getModifiers();
+    void                              updateModifiers(uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group);
+    bool                              updateModifiersState(); // rets whether changed
+    void                              updateXkbStateWithKey(uint32_t xkbKey, bool pressed);
+    void                              updateKeymapFD();
+    bool                              getPressed(uint32_t key);
+    bool                              shareStates();
 
-    bool                    m_active     = false;
-    bool                    m_enabled    = true;
-    bool                    m_allowBinds = true;
+    bool                              m_active     = false;
+    bool                              m_enabled    = true;
+    bool                              m_allowBinds = true;
 
     // permission flag: whether this keyboard is allowed to be processed
     bool m_allowed = true;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
This PR adds a new info field to `hyprctl devices` output, specifically active layout index, that can be used by 
`hyprctl switchxkblayout` for scripting purposes. 
There is a new function `getActiveLayoutIndex()` in `IKeyboard` for that, which logic is copied from `getActiveLayout()` function, but it returns `xkb_layout_index_t`. 

The reason to add this feature is that there is not much ways to determine the index of current layout in hyprland configuration. 
There are ways to parse language code from active_layout field, like here https://github.com/hyprwm/Hyprland/discussions/2616, but the result will be incompatible with input.kb_layout definition in config, thus determining the index of the current layout is possible but complicated. Or I missed some part of functionality that makes it possible to get this index.  

I personally need this to make vim remember last lang used in insert mode, before switching to English in normal, all using hyprctl, but there may be other use cases.   
#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No. 

#### Is it ready for merging, or does it need work?
From my pov, it is ready for merging. But there might be a better naming for the field.