### PR TITLE
xwayland: handle minimize and maximize requests

### DIFF
--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -433,6 +433,14 @@ void CXWM::handleClientMessage(xcb_client_message_event_t* e) {
 
             XSURF->m_events.stateChanged.emit();
         }
+    } else if (e->type == HYPRATOMS["WM_CHANGE_STATE"]) {
+		int state = e->data.data32[0];
+        if (state == XCB_ICCCM_WM_STATE_ICONIC || state == XCB_ICCCM_WM_STATE_WITHDRAWN) {
+            XSURF->m_state.requestsMinimize = true;
+        } else if (state == XCB_ICCCM_WM_STATE_NORMAL) {
+            XSURF->m_state.requestsMinimize = false;
+        }
+        XSURF->m_events.stateChanged.emit();
     } else if (e->type == HYPRATOMS["_NET_ACTIVE_WINDOW"]) {
         XSURF->m_events.activate.emit();
     } else if (e->type == HYPRATOMS["XdndStatus"]) {

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -425,6 +425,10 @@ void CXWM::handleClientMessage(xcb_client_message_event_t* e) {
 
                 if (prop == HYPRATOMS["_NET_WM_STATE_FULLSCREEN"])
                     XSURF->m_state.requestsFullscreen = updateState(action, XSURF->m_fullscreen);
+                if (prop == HYPRATOMS["_NET_WM_STATE_HIDDEN"])
+                    XSURF->m_state.requestsMinimize = updateState(action, XSURF->m_minimized);
+                if (prop == HYPRATOMS["_NET_WM_STATE_MAXIMIZED_VERT"] || prop == HYPRATOMS["_NET_WM_STATE_MAXIMIZED_HORZ"])
+                    XSURF->m_state.requestsMaximize = updateState(action, XSURF->m_maximized);
             }
 
             XSURF->m_events.stateChanged.emit();

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -434,7 +434,7 @@ void CXWM::handleClientMessage(xcb_client_message_event_t* e) {
             XSURF->m_events.stateChanged.emit();
         }
     } else if (e->type == HYPRATOMS["WM_CHANGE_STATE"]) {
-		int state = e->data.data32[0];
+        int state = e->data.data32[0];
         if (state == XCB_ICCCM_WM_STATE_ICONIC || state == XCB_ICCCM_WM_STATE_WITHDRAWN) {
             XSURF->m_state.requestsMinimize = true;
         } else if (state == XCB_ICCCM_WM_STATE_NORMAL) {

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -435,11 +435,10 @@ void CXWM::handleClientMessage(xcb_client_message_event_t* e) {
         }
     } else if (e->type == HYPRATOMS["WM_CHANGE_STATE"]) {
         int state = e->data.data32[0];
-        if (state == XCB_ICCCM_WM_STATE_ICONIC || state == XCB_ICCCM_WM_STATE_WITHDRAWN) {
+        if (state == XCB_ICCCM_WM_STATE_ICONIC || state == XCB_ICCCM_WM_STATE_WITHDRAWN)
             XSURF->m_state.requestsMinimize = true;
-        } else if (state == XCB_ICCCM_WM_STATE_NORMAL) {
+        else if (state == XCB_ICCCM_WM_STATE_NORMAL)
             XSURF->m_state.requestsMinimize = false;
-        }
         XSURF->m_events.stateChanged.emit();
     } else if (e->type == HYPRATOMS["_NET_ACTIVE_WINDOW"]) {
         XSURF->m_events.activate.emit();


### PR DESCRIPTION
I was missing requests from x clients to maximize or to minimize for my plugin.

_NET_STATE atoms are described [here](https://specifications.freedesktop.org/wm-spec/1.3/ar01s05.html#id-1.6.8).

If you're wondering, WM_CHANGE_STATE is generated by XIconifyWindow (or equivalent xcb call), and is described [here](https://tronche.com/gui/x/xlib/ICC/client-to-window-manager/XIconifyWindow.html). 

I've tested this PR as working.