### PR TITLE
xwayland: fix game permanent blackscreen

### DIFF
--- a/src/xwayland/XSurface.cpp
+++ b/src/xwayland/XSurface.cpp
@@ -195,6 +195,7 @@ void CXWaylandSurface::configure(const CBox& box) {
 void CXWaylandSurface::activate(bool activate) {
     if (m_overrideRedirect && !activate)
         return;
+    setWithdrawn(false);
     g_pXWayland->m_wm->activateSurface(m_self.lock(), activate);
 }
 


### PR DESCRIPTION
Fixes the bug where some games became permanently black (due to being withdrawn).