### PR TITLE
window: treat maximize as toggle request

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1466,13 +1466,11 @@ void CWindow::onUpdateState() {
     }
 
     if (requestsMX.has_value() && !(m_suppressedEvents & SUPPRESS_MAXIMIZE)) {
-        if (requestsMX.has_value()) {
-            if (m_isMapped) {
-                auto window    = m_self.lock();
-                auto state     = sc<int8_t>(window->m_fullscreenState.client);
-                bool maximized = (state & sc<uint8_t>(FSMODE_MAXIMIZED)) != 0;
-                g_pCompositor->changeWindowFullscreenModeClient(window, FSMODE_MAXIMIZED, !maximized);
-            }
+        if (m_isMapped) {
+            auto window    = m_self.lock();
+            auto state     = sc<int8_t>(window->m_fullscreenState.client);
+            bool maximized = (state & sc<uint8_t>(FSMODE_MAXIMIZED)) != 0;
+            g_pCompositor->changeWindowFullscreenModeClient(window, FSMODE_MAXIMIZED, !maximized);
         }
     }
 }


### PR DESCRIPTION
This PR changes the meaning of maximize requests from clients to be "toggle the current maximize state", which is something that we (as the compositor) know, but the application does not.

This fixes the following behavior where it's possible to be stuck with a maximized window, if the user doesn't have a binding to the fullscreen toggle, or doesn't even realize why the window won't demaximize.


https://github.com/user-attachments/assets/bf4bfec5-e5c8-4092-bb20-048eb307e62f

And it throttles requests at 100ms because some apps I've tried out like firefox can misbehave and send two instant request rather than one.

