### PR TITLE
fix: crash when monitor position contains non-integer values

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2196,8 +2196,14 @@ bool CMonitorRuleParser::parsePosition(const std::string& value, bool isFirst) {
             m_rule.offset = Vector2D(-INT32_MAX, -INT32_MAX);
             return false;
         } else {
-            m_rule.offset.x = stoi(value.substr(0, value.find_first_of('x')));
-            m_rule.offset.y = stoi(value.substr(value.find_first_of('x') + 1));
+            try {
+                m_rule.offset.x = stoi(value.substr(0, value.find_first_of('x')));
+                m_rule.offset.y = stoi(value.substr(value.find_first_of('x') + 1));
+            } catch (...) {
+                m_error += "invalid offset ";
+                m_rule.offset = Vector2D(-INT32_MAX, -INT32_MAX);
+                return false;
+            }
         }
     }
     return true;


### PR DESCRIPTION
# Fix crash on invalid monitor position values in config

I discovered that specifying a monitor position with non-integer values before or after the `x` character (for example, `monitor = HDMI-A-1, 1920x1080, oxo, 1`) causes Hyprland to crash. This was due to the lack of error handling when parsing the position string in `CMonitorRuleParser::parsePosition`.

This PR adds error handling for monitor position parsing, reporting an error for invalid values.