### PR TITLE
presentation: handle vrr for v1 clients

### DIFF
--- a/src/protocols/PresentationTime.cpp
+++ b/src/protocols/PresentationTime.cpp
@@ -64,8 +64,10 @@ void CPresentationFeedback::sendQueued(WP<CQueuedPresentationData> data, const T
     if (sizeof(time_t) > 4)
         tv_sec = TIMESPEC.tv_sec >> 32;
 
+    uint32_t refreshNs = m_resource->version() == 1 && data->m_monitor->m_vrrActive ? 0 : untilRefreshNs;
+
     if (data->m_wasPresented)
-        m_resource->sendPresented(sc<uint32_t>(tv_sec), sc<uint32_t>(TIMESPEC.tv_sec & 0xFFFFFFFF), sc<uint32_t>(TIMESPEC.tv_nsec), untilRefreshNs, sc<uint32_t>(seq >> 32),
+        m_resource->sendPresented(sc<uint32_t>(tv_sec), sc<uint32_t>(TIMESPEC.tv_sec & 0xFFFFFFFF), sc<uint32_t>(TIMESPEC.tv_nsec), refreshNs, sc<uint32_t>(seq >> 32),
                                   sc<uint32_t>(seq & 0xFFFFFFFF), sc<wpPresentationFeedbackKind>(flags));
     else
         m_resource->sendDiscarded();


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
The potential for an issue was mentioned in https://github.com/hyprwm/Hyprland/pull/11306, but it turns out that Gamescope is a notable `wp_presentation_v1`-only client that expects `refresh` to be 0 in the VRR case ([ref](https://github.com/ValveSoftware/gamescope/blob/cf288b95fa376a15f30fe8d1a9f750cad54742df/src/Backends/WaylandBackend.cpp#L1720)).

Resolves https://github.com/hyprwm/Hyprland/discussions/11406


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I opened an uglier/less-likely-to-be-accepted PR to support V2 on gamescope [here](https://github.com/ValveSoftware/gamescope/pull/1963), but V1 is more reliable for communicating VRR status anyway.

I'm new to Wayland protocols and contributing to Hyprland, so I'm open to criticism.


#### Is it ready for merging, or does it need work?

Works on my machine with `gamescope --backend wayland -f -H 1440 -h 1440 -W 2560 -w 2560 --adaptive-sync -r 180 -- env MANGOHUD_CONFIG="no_display,fps_limit=133" vkgears`
