### PR TITLE
xdg: exclude reserved area from popup unconstrain (use work area)

### DIFF
--- a/src/desktop/Popup.hpp
+++ b/src/desktop/Popup.hpp
@@ -74,15 +74,20 @@ class CPopup {
     std::vector<UP<CPopup>> m_children;
     UP<CSubsurface>         m_subsurfaceHead;
 
-    struct {
-        CHyprSignalListener newPopup;
-        CHyprSignalListener destroy;
-        CHyprSignalListener map;
-        CHyprSignalListener unmap;
-        CHyprSignalListener commit;
-        CHyprSignalListener dismissed;
-        CHyprSignalListener reposition;
-    } m_listeners;
+  struct {
+      CHyprSignalListener newPopup;
+      CHyprSignalListener reposition;
+      CHyprSignalListener map;
+      CHyprSignalListener unmap;
+      CHyprSignalListener commit;
+      CHyprSignalListener dismissed;
+      CHyprSignalListener destroy;
+
+      // added for dynamic re-clamp
+      CHyprSignalListener monModeChanged;
+      CHyprSignalListener monWorkareaChanged; // optional; keep if you later wire it
+  } m_listeners;
+
 
     void        initAllSignals();
     void        reposition();


### PR DESCRIPTION
Context
-------
XDG popups (e.g., Chromium context menu) were unconstrained against the *full*
monitor bounds, so they could overlap bars/panels that reserve space via
exclusive zones. See #11604.

What this changes
-----------------
- In `CPopup::reposition()`, the unconstrain region passed to
  `applyPositioning(...)` is now the monitor **work area**:
  `monitor.position + reservedTopLeft` ..
  `monitor.size - reservedTopLeft - reservedBottomRight`.
- In `CPopup::initAllSignals()`, listen for `monitor.modeChanged` and call
  `reposition()` so active popups re-clamp after resolution/scale changes.

Why it’s safe / scope
---------------------
- IME popups are a separate path (unchanged).
- Change is localized to `desktop/Popup.*`.
- No behavior change to regular windows; only xdg-popups’ unconstrain bounds.

User-visible effect
-------------------
Popups no longer overlap exclusive zones (top/bottom bars). If the bar size or
monitor mode changes while a popup is open, the popup repositions to remain
inside the usable area.

Testing
-------
Manual on Wayland:
1) `hyprctl keyword monitor eDP-1,addreserved,40,0,0,0`
2) Right-click near the top edge in Chromium → popup stays below the bar.
3) Change scale/resolution (`hyprctl keyword monitor eDP-1,preferred,auto,1.25`)
   → popup re-snaps within work area.
4) Repeat with reserved on other edges.

Notes
-----
- If the tree exposes a dedicated workarea/reserved-changed signal on the
  monitor, we can additionally hook it to call `reposition()`. This patch keeps
  it minimal by using `modeChanged`, which already covers common changes.
