### PR TITLE
layout/dwindle: add presets

### DIFF
--- a/hyprtester/src/tests/main/dwindle.cpp
+++ b/hyprtester/src/tests/main/dwindle.cpp
@@ -1,0 +1,96 @@
+#include "tests.hpp"
+#include "../../shared.hpp"
+#include "../../hyprctlCompat.hpp"
+#include <thread>
+#include <chrono>
+#include <hyprutils/os/Process.hpp>
+#include <hyprutils/memory/WeakPtr.hpp>
+#include "../shared.hpp"
+
+static int ret = 0;
+
+using namespace Hyprutils::OS;
+using namespace Hyprutils::Memory;
+
+#define UP CUniquePointer
+#define SP CSharedPointer
+
+static bool test() {
+    NLog::log("{}Testing dwindle", Colors::GREEN);
+
+    OK(getFromSocket("/dispatch workspace 101"));
+
+    // test the layout preset
+
+    Tests::spawnKitty();
+
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_COUNT_STRING(str, "at: 22,22", 1);
+        EXPECT_COUNT_STRING(str, "size: 1876,1036", 1);
+    }
+
+    Tests::spawnKitty();
+
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_COUNT_STRING(str, "at: 22,22", 1);
+        EXPECT_COUNT_STRING(str, "size: 605,1036", 1);
+
+        EXPECT_COUNT_STRING(str, "at: 641,22", 1);
+        EXPECT_COUNT_STRING(str, "size: 1257,1036", 1);
+    }
+
+    Tests::spawnKitty();
+
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_COUNT_STRING(str, "at: 22,22", 1);
+        EXPECT_COUNT_STRING(str, "at: 641,22", 1);
+        EXPECT_COUNT_STRING(str, "at: 1284,22", 1);
+
+        EXPECT_COUNT_STRING(str, "size: 605,1036", 1);
+        EXPECT_COUNT_STRING(str, "size: 629,1036", 1);
+        EXPECT_COUNT_STRING(str, "size: 614,1036", 1);
+    }
+
+    Tests::spawnKitty();
+
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_COUNT_STRING(str, "at: 22,22", 1);
+        EXPECT_COUNT_STRING(str, "at: 641,22", 1);
+        EXPECT_COUNT_STRING(str, "at: 1284,22", 1);
+        EXPECT_COUNT_STRING(str, "at: 1284,547", 1);
+
+        EXPECT_COUNT_STRING(str, "size: 605,1036", 1);
+        EXPECT_COUNT_STRING(str, "size: 629,1036", 1);
+        EXPECT_COUNT_STRING(str, "size: 614,511", 2);
+    }
+
+    Tests::spawnKitty();
+
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_COUNT_STRING(str, "at: 22,22", 1);
+        EXPECT_COUNT_STRING(str, "at: 641,22", 1);
+        EXPECT_COUNT_STRING(str, "at: 1284,22", 1);
+        EXPECT_COUNT_STRING(str, "at: 1284,547", 1);
+        EXPECT_COUNT_STRING(str, "at: 22,547", 1);
+
+        EXPECT_COUNT_STRING(str, "size: 629,1036", 1);
+        EXPECT_COUNT_STRING(str, "size: 614,511", 2);
+        EXPECT_COUNT_STRING(str, "size: 605,511", 2);
+    }
+
+    Tests::killAllWindows();
+
+    OK(getFromSocket("/dispatch workspace 1"));
+
+    NLog::log("{}Reloading the config", Colors::YELLOW);
+    OK(getFromSocket("/reload"));
+
+    return !ret;
+}
+
+REGISTER_TEST_FN(test)

--- a/hyprtester/test.conf
+++ b/hyprtester/test.conf
@@ -222,6 +222,8 @@ debug {
     disable_logs = false
 }
 
+preset = dwindle, testPreset, horizontal 33% right, horizontal 50% right, vertical 50% right, up up up left vertical 50% right
+workspace = 101, layoutopt:preset testPreset
 
 ###################
 ### KEYBINDINGS ###

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2473,62 +2473,8 @@ PHLWINDOW CCompositor::getWindowByRegex(const std::string& regexp_) {
     }
 
     for (auto const& w : g_pCompositor->m_windows) {
-        if (!w->m_isMapped || (w->isHidden() && !g_pLayoutManager->getCurrentLayout()->isWindowReachable(w)))
-            continue;
-
-        switch (mode) {
-            case MODE_CLASS_REGEX: {
-                const auto windowClass = w->m_class;
-                if (!RE2::FullMatch(windowClass, regexCheck))
-                    continue;
-                break;
-            }
-            case MODE_INITIAL_CLASS_REGEX: {
-                const auto initialWindowClass = w->m_initialClass;
-                if (!RE2::FullMatch(initialWindowClass, regexCheck))
-                    continue;
-                break;
-            }
-            case MODE_TITLE_REGEX: {
-                const auto windowTitle = w->m_title;
-                if (!RE2::FullMatch(windowTitle, regexCheck))
-                    continue;
-                break;
-            }
-            case MODE_INITIAL_TITLE_REGEX: {
-                const auto initialWindowTitle = w->m_initialTitle;
-                if (!RE2::FullMatch(initialWindowTitle, regexCheck))
-                    continue;
-                break;
-            }
-            case MODE_TAG_REGEX: {
-                bool tagMatched = false;
-                for (auto const& t : w->m_tags.getTags()) {
-                    if (RE2::FullMatch(t, regexCheck)) {
-                        tagMatched = true;
-                        break;
-                    }
-                }
-                if (!tagMatched)
-                    continue;
-                break;
-            }
-            case MODE_ADDRESS: {
-                std::string addr = std::format("0x{:x}", rc<uintptr_t>(w.get()));
-                if (matchCheck != addr)
-                    continue;
-                break;
-            }
-            case MODE_PID: {
-                std::string pid = std::format("{}", w->getPID());
-                if (matchCheck != pid)
-                    continue;
-                break;
-            }
-            default: break;
-        }
-
-        return w;
+        if (w->matchesStaticSelector(mode, matchCheck))
+            return w;
     }
 
     return nullptr;

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1063,6 +1063,7 @@ void CConfigManager::setDefaultAnimationVars() {
 std::optional<std::string> CConfigManager::resetHLConfig() {
     m_monitorRules.clear();
     m_windowRules.clear();
+    m_layoutPresets.clear();
     g_pKeybindManager->clearKeybinds();
     g_pAnimationManager->removeAllBeziers();
     g_pAnimationManager->addBezierWithName("linear", Vector2D(0.0, 0.0), Vector2D(1.0, 1.0));

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1301,7 +1301,7 @@ void CConfigManager::postConfigReload(const Hyprlang::CParseResult& result) {
     if (!m_isFirstLaunch)
         ensurePersistentWorkspacesPresent();
 
-    g_pLayoutManager->getCurrentLayout()->presetsChanged(m_layoutPresets);
+    updateLayoutPresets();
 
     EMIT_HOOK_EVENT("configReloaded", nullptr);
     if (g_pEventManager)
@@ -3415,6 +3415,10 @@ std::string SConfigOptionDescription::jsonify() const {
 
 void CConfigManager::ensurePersistentWorkspacesPresent() {
     g_pCompositor->ensurePersistentWorkspacesPresent(m_workspaceRules);
+}
+
+void CConfigManager::updateLayoutPresets() {
+    g_pLayoutManager->getCurrentLayout()->presetsChanged(m_layoutPresets);
 }
 
 void CConfigManager::storeFloatingSize(PHLWINDOW window, const Vector2D& size) {

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -432,6 +432,18 @@ static Hyprlang::CParseResult handleGesture(const char* c, const char* v) {
     return result;
 }
 
+static Hyprlang::CParseResult handlePreset(const char* c, const char* v) {
+    const std::string      VALUE   = v;
+    const std::string      COMMAND = c;
+
+    const auto             RESULT = g_pConfigManager->handlePreset(COMMAND, VALUE);
+
+    Hyprlang::CParseResult result;
+    if (RESULT.has_value())
+        result.setError(RESULT.value().c_str());
+    return result;
+}
+
 void CConfigManager::registerConfigVar(const char* name, const Hyprlang::INT& val) {
     m_configValueNumber++;
     m_config->addConfigValue(name, val);
@@ -870,6 +882,7 @@ CConfigManager::CConfigManager() {
     m_config->registerHandler(&::handlePlugin, "plugin", {false});
     m_config->registerHandler(&::handlePermission, "permission", {false});
     m_config->registerHandler(&::handleGesture, "gesture", {false});
+    m_config->registerHandler(&::handlePreset, "preset", {false});
     m_config->registerHandler(&::handleEnv, "env", {true});
 
     // pluginza
@@ -1287,6 +1300,8 @@ void CConfigManager::postConfigReload(const Hyprlang::CParseResult& result) {
     // update persistent workspaces
     if (!m_isFirstLaunch)
         ensurePersistentWorkspacesPresent();
+
+    g_pLayoutManager->getCurrentLayout()->presetsChanged(m_layoutPresets);
 
     EMIT_HOOK_EVENT("configReloaded", nullptr);
     if (g_pEventManager)
@@ -3018,14 +3033,21 @@ std::optional<std::string> CConfigManager::handleWorkspaceRules(const std::strin
             wsRule.onCreatedEmptyRunCmd = *X;
         } else if ((delim = rule.find("layoutopt:")) != std::string::npos) {
             std::string opt = rule.substr(delim + 10);
-            if (!opt.contains(":")) {
-                // invalid
-                Debug::log(ERR, "Invalid workspace rule found: {}", rule);
-                return "Invalid workspace rule found: " + rule;
-            }
 
-            std::string val = opt.substr(opt.find(':') + 1);
-            opt             = opt.substr(0, opt.find(':'));
+            size_t      delimPos = 0;
+            if (!opt.contains(':')) {
+                if (!opt.contains(' ')) {
+                    // invalid
+                    Debug::log(ERR, "Invalid workspace rule found: {}", rule);
+                    return "Invalid workspace rule found: " + rule;
+                }
+
+                delimPos = opt.find(' ');
+            } else
+                delimPos = opt.find(':');
+
+            std::string val = opt.substr(delimPos + 1);
+            opt             = opt.substr(0, delimPos);
 
             wsRule.layoutopts[opt] = val;
         }
@@ -3254,6 +3276,12 @@ std::optional<std::string> CConfigManager::handleGesture(const std::string& comm
 
     if (!result)
         return result.error();
+
+    return std::nullopt;
+}
+
+std::optional<std::string> CConfigManager::handlePreset(const std::string& command, const std::string& value) {
+    m_layoutPresets.emplace_back(value);
 
     return std::nullopt;
 }

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -286,6 +286,7 @@ class CConfigManager {
     std::optional<std::string> handlePlugin(const std::string&, const std::string&);
     std::optional<std::string> handlePermission(const std::string&, const std::string&);
     std::optional<std::string> handleGesture(const std::string&, const std::string&);
+    std::optional<std::string> handlePreset(const std::string&, const std::string&);
 
     std::optional<std::string> handleMonitorv2(const std::string& output);
     Hyprlang::CParseResult     handleMonitorv2();
@@ -322,6 +323,7 @@ class CConfigManager {
     std::vector<SP<CWindowRule>>                     m_windowRules;
     std::vector<SP<CLayerRule>>                      m_layerRules;
     std::vector<std::string>                         m_blurLSNamespaces;
+    std::vector<std::string>                         m_layoutPresets;
 
     bool                                             m_firstExecDispatched  = false;
     bool                                             m_manualCrashInitiated = false;

--- a/src/config/ConfigManager.hpp
+++ b/src/config/ConfigManager.hpp
@@ -231,6 +231,7 @@ class CConfigManager {
     std::vector<SP<CWindowRule>>                                    getMatchingRules(PHLWINDOW, bool dynamic = true, bool shadowExec = false);
     std::vector<SP<CLayerRule>>                                     getMatchingRules(PHLLS);
     void                                                            ensurePersistentWorkspacesPresent();
+    void                                                            updateLayoutPresets();
 
     const std::vector<SConfigOptionDescription>&                    getAllDescriptions();
 

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -2108,6 +2108,8 @@ std::string CHyprCtl::getReply(std::string request) {
             g_pCompositor->updateWindowAnimatedDecorationValues(w);
         }
 
+        g_pConfigManager->updateLayoutPresets();
+
         for (auto const& m : g_pCompositor->m_monitors) {
             g_pHyprRenderer->damageMonitor(m);
             g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m->m_id);

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -23,6 +23,8 @@
 class CXDGSurfaceResource;
 class CXWaylandSurface;
 
+enum eFocusWindowMode : uint8_t;
+
 enum eIdleInhibitMode : uint8_t {
     IDLEINHIBIT_NONE = 0,
     IDLEINHIBIT_ALWAYS,
@@ -416,6 +418,8 @@ class CWindow {
     PHLWINDOW                  parent();
     bool                       priorityFocus();
     SP<CWLSurfaceResource>     getSolitaryResource();
+    bool                       matchesStaticSelector(const std::string& regexp);
+    bool                       matchesStaticSelector(eFocusWindowMode mode, const std::string& matchCheck);
 
     CBox                       getWindowMainSurfaceBox() const {
         return {m_realPosition->value().x, m_realPosition->value().y, m_realSize->value().x, m_realSize->value().y};

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -521,11 +521,7 @@ void CHyprDwindleLayout::onWindowRemovedTilingInternal(PHLWINDOW pWindow) {
 void CHyprDwindleLayout::onWindowRemovedTiling(PHLWINDOW pWindow) {
     onWindowRemovedTilingInternal(pWindow);
 
-    g_pEventLoopManager->doLater([this, ws = PHLWORKSPACEREF{pWindow->m_workspace}]() {
-        if (!ws || g_pLayoutManager->getCurrentLayout() != this)
-            return;
-        recheckPresetRule(ws.lock());
-    });
+    recheckPresetRule(pWindow->m_workspace);
 }
 
 void CHyprDwindleLayout::recalculateMonitor(const MONITORID& monid) {
@@ -1048,14 +1044,14 @@ std::string CHyprDwindleLayout::usePreset(const std::string& name) {
 
     std::deque<PHLWINDOW> windows, windowsPreOrder;
 
-    for (const auto& w : g_pCompositor->m_windows) {
-        if (!validMapped(w) || w->m_isFloating || !getNodeFromWindow(w) ||
-            w->workspaceID() !=
+    for (const auto& w : m_dwindleNodesData) {
+        if (!validMapped(w.pWindow) ||
+            w.pWindow->workspaceID() !=
                 (g_pCompositor->m_lastMonitor->m_activeSpecialWorkspace ? g_pCompositor->m_lastMonitor->activeSpecialWorkspaceID() :
                                                                           g_pCompositor->m_lastMonitor->activeWorkspaceID()))
             continue;
 
-        windowsPreOrder.emplace_back(w);
+        windowsPreOrder.emplace_back(w.pWindow.lock());
     }
 
     if (windowsPreOrder.empty())

--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -10,6 +10,7 @@
 #include <format>
 
 class CHyprDwindleLayout;
+class CDwindlePreset;
 enum eFullscreenMode : int8_t;
 
 struct SDwindleNodeData {
@@ -60,6 +61,7 @@ class CHyprDwindleLayout : public IHyprLayout {
     virtual std::string              getLayoutName();
     virtual void                     replaceWindowDataWith(PHLWINDOW from, PHLWINDOW to);
     virtual Vector2D                 predictSizeForNewWindowTiled();
+    virtual void                     presetsChanged(const std::vector<std::string>& presets);
 
     virtual void                     onEnable();
     virtual void                     onDisable();
@@ -74,21 +76,25 @@ class CHyprDwindleLayout : public IHyprLayout {
         bool yExtent = false;
     } m_pseudoDragFlags;
 
-    std::optional<Vector2D> m_overrideFocalPoint; // for onWindowCreatedTiling.
+    std::optional<Vector2D>         m_overrideFocalPoint; // for onWindowCreatedTiling.
+    std::vector<SP<CDwindlePreset>> m_presets;
 
-    int                     getNodesOnWorkspace(const WORKSPACEID&);
-    void                    applyNodeDataToWindow(SDwindleNodeData*, bool force = false);
-    void                    calculateWorkspace(const PHLWORKSPACE& pWorkspace);
-    SDwindleNodeData*       getNodeFromWindow(PHLWINDOW);
-    SDwindleNodeData*       getFirstNodeOnWorkspace(const WORKSPACEID&);
-    SDwindleNodeData*       getClosestNodeOnWorkspace(const WORKSPACEID&, const Vector2D&);
-    SDwindleNodeData*       getMasterNodeOnWorkspace(const WORKSPACEID&);
+    void                            onWindowCreatedTilingInternal(PHLWINDOW, eDirection direction, PHLWINDOW overrideOpeningOn = nullptr);
 
-    void                    toggleSplit(PHLWINDOW);
-    void                    swapSplit(PHLWINDOW);
-    void                    moveToRoot(PHLWINDOW, bool stable = true);
+    int                             getNodesOnWorkspace(const WORKSPACEID&);
+    void                            applyNodeDataToWindow(SDwindleNodeData*, bool force = false);
+    void                            calculateWorkspace(const PHLWORKSPACE& pWorkspace);
+    SDwindleNodeData*               getNodeFromWindow(PHLWINDOW);
+    SDwindleNodeData*               getFirstNodeOnWorkspace(const WORKSPACEID&);
+    SDwindleNodeData*               getClosestNodeOnWorkspace(const WORKSPACEID&, const Vector2D&);
+    SDwindleNodeData*               getMasterNodeOnWorkspace(const WORKSPACEID&);
+    std::string                     usePreset(const std::string& name);
 
-    eDirection              m_overrideDirection = DIRECTION_DEFAULT;
+    void                            toggleSplit(PHLWINDOW);
+    void                            swapSplit(PHLWINDOW);
+    void                            moveToRoot(PHLWINDOW, bool stable = true);
+
+    eDirection                      m_overrideDirection = DIRECTION_DEFAULT;
 
     friend struct SDwindleNodeData;
 };

--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -80,6 +80,7 @@ class CHyprDwindleLayout : public IHyprLayout {
     std::vector<SP<CDwindlePreset>> m_presets;
 
     void                            onWindowCreatedTilingInternal(PHLWINDOW, eDirection direction, PHLWINDOW overrideOpeningOn = nullptr);
+    void                            onWindowRemovedTilingInternal(PHLWINDOW);
 
     int                             getNodesOnWorkspace(const WORKSPACEID&);
     void                            applyNodeDataToWindow(SDwindleNodeData*, bool force = false);
@@ -89,6 +90,7 @@ class CHyprDwindleLayout : public IHyprLayout {
     SDwindleNodeData*               getClosestNodeOnWorkspace(const WORKSPACEID&, const Vector2D&);
     SDwindleNodeData*               getMasterNodeOnWorkspace(const WORKSPACEID&);
     std::string                     usePreset(const std::string& name);
+    void                            recheckPresetRule(PHLWORKSPACE);
 
     void                            toggleSplit(PHLWINDOW);
     void                            swapSplit(PHLWINDOW);

--- a/src/layout/DwindlePreset.cpp
+++ b/src/layout/DwindlePreset.cpp
@@ -36,7 +36,8 @@ bool CDwindlePreset::addChunk(const std::string_view& dataStr) {
 
     SDwindlePresetNodeData chunk;
 
-    size_t                 step = 0;
+    size_t                 step           = 0;
+    std::string            windowSelector = "";
 
     for (const auto& d : data) {
         switch (step) {
@@ -50,6 +51,11 @@ bool CDwindlePreset::addChunk(const std::string_view& dataStr) {
                     break;
                 } else if (d == "right") {
                     chunk.moves.emplace_back(PRESET_MOVE_RIGHT);
+                    break;
+                } else if (d == "root") {
+                    // special treatment to select root
+                    step       = 4;
+                    chunk.root = true;
                     break;
                 }
 
@@ -106,13 +112,29 @@ bool CDwindlePreset::addChunk(const std::string_view& dataStr) {
                 break;
             }
 
-            case 4:
+            case 4: {
+
+                // add to window selector
+                windowSelector += d;
+                windowSelector += " ";
+
+                break;
+            }
+
             default: {
                 Debug::log(ERR, "CDwindlePreset::addChunk: failed to parse chunk \"{}\", trailing data", dataStr);
                 return false;
             }
         }
     }
+
+    if (!windowSelector.empty())
+        windowSelector.pop_back();
+
+    chunk.windowSelector = windowSelector;
+
+    if (m_data.empty() && !chunk.root)
+        m_data.emplace_back(SDwindlePresetNodeData{.root = true});
 
     m_data.emplace_back(std::move(chunk));
 

--- a/src/layout/DwindlePreset.cpp
+++ b/src/layout/DwindlePreset.cpp
@@ -1,0 +1,124 @@
+#include "DwindlePreset.hpp"
+#include "../debug/Log.hpp"
+#include <hyprutils/string/ConstVarList.hpp>
+
+using namespace Hyprutils::String;
+
+SP<CDwindlePreset> CDwindlePreset::create(const std::string& dataStr) {
+
+    CConstVarList data(dataStr);
+
+    if (data[0] != "dwindle") {
+        Debug::log(LOG, "CDwindlePreset: Skipping preset, not for dwindle");
+        return nullptr;
+    }
+
+    if (data[1].empty()) {
+        Debug::log(LOG, "CDwindlePreset: Skipping preset, no name");
+        return nullptr;
+    }
+
+    SP<CDwindlePreset> preset = SP<CDwindlePreset>(new CDwindlePreset(std::string{data[1]}));
+
+    // start parsing chunks
+
+    for (size_t i = 2; i < data.size(); ++i) {
+        if (!preset->addChunk(data[i]))
+            return nullptr;
+    }
+
+    return preset;
+}
+
+bool CDwindlePreset::addChunk(const std::string_view& dataStr) {
+
+    CConstVarList          data(std::string{dataStr}, 0, 's');
+
+    SDwindlePresetNodeData chunk;
+
+    size_t                 step = 0;
+
+    for (const auto& d : data) {
+        switch (step) {
+            case 0: {
+                // directions
+                if (d == "up") {
+                    chunk.moves.emplace_back(PRESET_MOVE_UP);
+                    break;
+                } else if (d == "left") {
+                    chunk.moves.emplace_back(PRESET_MOVE_LEFT);
+                    break;
+                } else if (d == "right") {
+                    chunk.moves.emplace_back(PRESET_MOVE_RIGHT);
+                    break;
+                }
+
+                // not a direction, let's move to step 2
+            }
+                [[fallthrough]];
+            case 1: {
+                // split direction
+                if (d == "horizontal" || d == "horiz")
+                    chunk.splitHorizontal = true;
+                else if (d == "vertical" || d == "vert")
+                    chunk.splitHorizontal = false;
+                else {
+                    Debug::log(ERR, "CDwindlePreset::addChunk: failed to parse chunk \"{}\", no direction", dataStr);
+                    return false;
+                }
+                step = 2;
+                break;
+            }
+
+            case 2: {
+                // split width
+                float perc = 100.F;
+                try {
+                    perc = d.ends_with('%') ? std::stoi(std::string{d.substr(0, d.length() - 1)}) : std::stoi(std::string{d});
+                } catch (...) {
+                    Debug::log(ERR, "CDwindlePreset::addChunk: failed to parse chunk \"{}\", no percentage", dataStr);
+                    return false;
+                }
+
+                if (perc <= 1 || perc >= 99) {
+                    Debug::log(ERR, "CDwindlePreset::addChunk: failed to parse chunk \"{}\", invalid percentage", dataStr);
+                    return false;
+                }
+
+                chunk.splitRatio = perc / 50.F;
+                step             = 3;
+                break;
+            }
+
+            case 3: {
+                // split direction
+                if (d == "left")
+                    chunk.splitRight = false;
+                else if (d == "right")
+                    chunk.splitRight = true;
+                else {
+                    Debug::log(ERR, "CDwindlePreset::addChunk: failed to parse chunk \"{}\", no split direction", dataStr);
+                    return false;
+                }
+
+                step = 4;
+
+                break;
+            }
+
+            case 4:
+            default: {
+                Debug::log(ERR, "CDwindlePreset::addChunk: failed to parse chunk \"{}\", trailing data", dataStr);
+                return false;
+            }
+        }
+    }
+
+    m_data.emplace_back(std::move(chunk));
+
+    return true;
+}
+
+const std::vector<CDwindlePreset::SDwindlePresetNodeData>& CDwindlePreset::data() {
+    return m_data;
+}

--- a/src/layout/DwindlePreset.hpp
+++ b/src/layout/DwindlePreset.hpp
@@ -33,5 +33,5 @@ class CDwindlePreset {
 
     std::vector<SDwindlePresetNodeData> m_data;
 
-    bool addChunk(const std::string_view& data);
+    bool                                addChunk(const std::string_view& data);
 };

--- a/src/layout/DwindlePreset.hpp
+++ b/src/layout/DwindlePreset.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <string_view>
+#include <string>
+#include <vector>
+#include <cstdint>
+#include "../helpers/memory/Memory.hpp"
+
+class CDwindlePreset {
+  public:
+    // can return nullptr if failed or not for dwindle
+    static SP<CDwindlePreset> create(const std::string& data);
+    ~CDwindlePreset() = default;
+
+    enum eMoveDirection : uint8_t {
+        PRESET_MOVE_UP = 0,
+        PRESET_MOVE_LEFT,
+        PRESET_MOVE_RIGHT,
+    };
+
+    struct SDwindlePresetNodeData {
+        bool                        splitHorizontal = true, splitRight = true;
+        float                       splitRatio = 1.F;
+        std::vector<eMoveDirection> moves;
+    };
+
+    const std::vector<SDwindlePresetNodeData>& data();
+
+    const std::string                          m_name = "";
+
+  private:
+    CDwindlePreset(const std::string& name) : m_name(name) {}
+
+    std::vector<SDwindlePresetNodeData> m_data;
+
+    bool addChunk(const std::string_view& data);
+};

--- a/src/layout/DwindlePreset.hpp
+++ b/src/layout/DwindlePreset.hpp
@@ -19,9 +19,10 @@ class CDwindlePreset {
     };
 
     struct SDwindlePresetNodeData {
-        bool                        splitHorizontal = true, splitRight = true;
+        bool                        splitHorizontal = true, splitRight = true, root = false;
         float                       splitRatio = 1.F;
         std::vector<eMoveDirection> moves;
+        std::string                 windowSelector;
     };
 
     const std::vector<SDwindlePresetNodeData>& data();

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -1029,3 +1029,7 @@ bool IHyprLayout::updateDragWindow() {
 
     return false;
 }
+
+void IHyprLayout::presetsChanged(const std::vector<std::string>& presets) {
+    Debug::log(LOG, "IHyprLayout: ignoring presets -> current layout doesn't support them");
+}

--- a/src/layout/IHyprLayout.hpp
+++ b/src/layout/IHyprLayout.hpp
@@ -225,6 +225,11 @@ class IHyprLayout {
     */
     virtual void performSnap(Vector2D& sourcePos, Vector2D& sourceSize, PHLWINDOW DRAGGINGWINDOW, const eMouseBindMode MODE, const int CORNER, const Vector2D& BEGINSIZE);
 
+    /*
+        Config manager will send this when presets change
+    */
+    virtual void presetsChanged(const std::vector<std::string>& presets);
+
   private:
     int          m_mouseMoveEventCount;
     Vector2D     m_beginDragXY;


### PR DESCRIPTION
Adds layout presets for dwindle. Available as both a layoutmsg to snap, and as a workspace rule.

syntax:
```ini
preset = dwindle, [name], [rules...]
```

For example:
```ini
preset = dwindle, myPreset, horizontal 33% right, horizontal 50% right, vertical 50% right, up up up left vertical 50% right
```
For creating an H shaped layout.

you can also specify windows for slots and add a root slot:
```ini
preset = dwindle, myPreset, root class:amogus, horizontal 33% right, horizontal 50% right class:amogus2, vertical 50% right, up up up left vertical 50% right
```

Workspace rule:
```ini
workspace = 1, layoutopt:preset one
```

layoutmsg (dwindle):
```sh
hyprctl dispatch layoutmsg preset one
```

https://github.com/user-attachments/assets/8db5a597-ad57-4c72-8231-24fc21203ab1

https://github.com/user-attachments/assets/2646ba55-f902-4010-a3e9-b6a94cd70ce3

TODO: 
- [ ] testing
- [x] tests