### PR TITLE
window: fix centering calculation for floating windows

### DIFF
--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -166,7 +166,7 @@ void IHyprLayout::onWindowCreatedFloating(PHLWINDOW pWindow) {
             // otherwise middle of parent if available
             if (!pWindow->m_isX11) {
                 if (const auto PARENT = pWindow->parent(); PARENT) {
-                    *pWindow->m_realPosition = PARENT->m_position + PARENT->m_size / 2.F - desiredGeometry.size() / 2.F;
+                    *pWindow->m_realPosition = PARENT->m_realPosition->goal() + PARENT->m_realSize->goal() / 2.F - desiredGeometry.size() / 2.F;
                     pWindow->m_workspace     = PARENT->m_workspace;
                     pWindow->m_monitor       = PARENT->m_monitor;
                     centeredOnParent         = true;


### PR DESCRIPTION
The `m_size` and `m_position` of parent windows is `0, 0` if you auto float all windows
```ini
windowrulev2 = float, class:.*
```
This bug makes windows spawn at the wrong location. The fix was to use `m_realPosition` and `m_realSize` of parent in the centering calculation.

<img width="1280" height="1600" alt="diff" src="https://github.com/user-attachments/assets/e55e2d84-1ce2-4e98-a00d-3af6ba364e74" />

