### PR TITLE
input: Correct tablet active_area calculation for rotated transforms

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1788,8 +1788,13 @@ void CInputManager::setTabletConfigs() {
             const auto ACTIVE_AREA_SIZE = g_pConfigManager->getDeviceVec(NAME, "active_area_size", "input:tablet:active_area_size");
             const auto ACTIVE_AREA_POS  = g_pConfigManager->getDeviceVec(NAME, "active_area_position", "input:tablet:active_area_position");
             if (ACTIVE_AREA_SIZE.x != 0 || ACTIVE_AREA_SIZE.y != 0) {
-                t->m_activeArea = CBox{ACTIVE_AREA_POS.x / t->aq()->physicalSize.x, ACTIVE_AREA_POS.y / t->aq()->physicalSize.y,
-                                       (ACTIVE_AREA_POS.x + ACTIVE_AREA_SIZE.x) / t->aq()->physicalSize.x, (ACTIVE_AREA_POS.y + ACTIVE_AREA_SIZE.y) / t->aq()->physicalSize.y};
+                // Rotations with an odd index (90 and 270 degrees, and their flipped variants) swap the X and Y axes.
+                // Use swapped dimensions when the axes are rotated, otherwise keep the original ones.
+                const Vector2D effectivePhysicalSize = (ROTATION % 2) ? Vector2D{t->aq()->physicalSize.y, t->aq()->physicalSize.x} : t->aq()->physicalSize;
+
+                // Scale the active area coordinates into normalized space (0–1) using the effective dimensions.
+                t->m_activeArea = CBox{ACTIVE_AREA_POS.x / effectivePhysicalSize.x, ACTIVE_AREA_POS.y / effectivePhysicalSize.y,
+                                       (ACTIVE_AREA_POS.x + ACTIVE_AREA_SIZE.x) / effectivePhysicalSize.x, (ACTIVE_AREA_POS.y + ACTIVE_AREA_SIZE.y) / effectivePhysicalSize.y};
             }
         }
     }


### PR DESCRIPTION
#### Issue overview

When a user applies a 90- or 270-degree `transform` to a tablet, the `active_area_size` and `active_area_position` settings behave unintuitively. The normalization of these millimeter values always uses the tablet's native (un-rotated) physical dimensions.

This forces the user to manually calculate "pre-distorted" values to define their desired active area. For example, to map a `127mm x 142.875mm` physical area on a tablet rotated by 90 degrees, they might have to configure `active_area_size = 203.2 89.3`, which is confusing and error-prone.

#### What does this change do?

This commit fixes the issue by making the active area calculation aware of the `transform` setting.

Before normalizing the `active_area` values, the code now checks if the applied transform is one that swaps the tablet's axes (90°, 270°, and their flipped equivalents). If so, it swaps the tablet's physical width and height to create an `effectivePhysicalSize`. The normalization is then performed against these corrected dimensions.

#### Why is this change necessary?

With this fix, users can specify `active_area_size` and `active_area_position` with the obvious, real-world millimeter values that correspond to the *final, transformed orientation* of their tablet. This makes the configuration more intuitive, predictable, and aligned with user expectations.

#### Is it ready for merging, or does it need work?

I’ve tested this change with all rotation values, including flipped variants, and everything behaves as expected. I believe it is ready to merge.
