### PR TITLE
added no screenshot option to layers

### DIFF
--- a/src/desktop/LayerRule.cpp
+++ b/src/desktop/LayerRule.cpp
@@ -4,7 +4,7 @@
 #include <algorithm>
 #include "../debug/Log.hpp"
 
-static const auto RULES        = std::unordered_set<std::string>{"noanim", "blur", "blurpopups", "dimaround"};
+static const auto RULES        = std::unordered_set<std::string>{"noanim", "blur", "blurpopups", "dimaround", "noscreenshare"};
 static const auto RULES_PREFIX = std::unordered_set<std::string>{"ignorealpha", "ignorezero", "xray", "animation", "order", "abovelock"};
 
 CLayerRule::CLayerRule(const std::string& rule_, const std::string& ns_) : m_targetNamespace(ns_), m_rule(rule_) {
@@ -21,6 +21,8 @@ CLayerRule::CLayerRule(const std::string& rule_, const std::string& ns_) : m_tar
         m_ruleType = RULE_BLURPOPUPS;
     else if (m_rule == "dimaround")
         m_ruleType = RULE_DIMAROUND;
+    else if (m_rule == "noscreenshare")
+        m_ruleType = RULE_NOSCREENSHARE;
     else if (m_rule.starts_with("ignorealpha"))
         m_ruleType = RULE_IGNOREALPHA;
     else if (m_rule.starts_with("ignorezero"))

--- a/src/desktop/LayerRule.hpp
+++ b/src/desktop/LayerRule.hpp
@@ -14,6 +14,7 @@ class CLayerRule {
         RULE_BLUR,
         RULE_BLURPOPUPS,
         RULE_DIMAROUND,
+        RULE_NOSCREENSHARE,
         RULE_ABOVELOCK,
         RULE_IGNOREALPHA,
         RULE_IGNOREZERO,

--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -392,6 +392,7 @@ void CLayerSurface::applyRules() {
     m_dimAround        = false;
     m_xray             = -1;
     m_animationStyle.reset();
+    m_noScreenshare = false;
 
     for (auto const& rule : g_pConfigManager->getMatchingRules(m_self.lock())) {
         switch (rule->m_ruleType) {
@@ -423,6 +424,10 @@ void CLayerSurface::applyRules() {
             }
             case CLayerRule::RULE_DIMAROUND: {
                 m_dimAround = true;
+                break;
+            }
+            case CLayerRule::RULE_NOSCREENSHARE: {
+                m_noScreenshare = true;
                 break;
             }
             case CLayerRule::RULE_XRAY: {

--- a/src/desktop/LayerSurface.hpp
+++ b/src/desktop/LayerSurface.hpp
@@ -51,6 +51,7 @@ class CLayerSurface {
     int64_t                    m_order                       = 0;
     bool                       m_aboveLockscreen             = false;
     bool                       m_aboveLockscreenInteractable = false;
+    bool                       m_noScreenshare               = false;
 
     std::optional<std::string> m_animationStyle;
 

--- a/src/protocols/Screencopy.cpp
+++ b/src/protocols/Screencopy.cpp
@@ -211,6 +211,19 @@ void CScreencopyFrame::renderMon() {
     g_pHyprOpenGL->setRenderModifEnabled(true);
     g_pHyprOpenGL->popMonitorTransformEnabled();
 
+    for (auto const& l : g_pCompositor->m_layers) {
+        if (!l->m_noScreenshare)
+            continue;
+
+        const auto noScreenShareBox =
+            CBox{l->m_realPosition->value().x, l->m_realPosition->value().y, std::max(l->m_realSize->value().x, 5.0), std::max(l->m_realSize->value().y, 5.0)}
+                .translate(-m_monitor->m_position)
+                .scale(m_monitor->m_scale)
+                .translate(-m_box.pos());
+
+        g_pHyprOpenGL->renderRect(noScreenShareBox, Colors::BLACK, {});
+    }
+
     for (auto const& w : g_pCompositor->m_windows) {
         if (!w->m_windowData.noScreenShare.valueOrDefault())
             continue;


### PR DESCRIPTION
#### Added layer rule to disallow screensharing
This PR is for issue #11547

It can be used like other layer rules: layerrule = noscreenshare, <name/address> 

example: rofi

<img width="1884" height="1054" alt="2025-09-11-194650_hyprshot" src="https://github.com/user-attachments/assets/cd347365-0bd4-41a0-997f-9c2b0ff3224f" />
When noscreenshare is turned off 

<img width="1904" height="1074" alt="2025-09-11-194029_hyprshot" src="https://github.com/user-attachments/assets/47314194-0f63-4cd4-b5e3-ed41e7e7b2e1" /> 
When noscreenshare is turned on 

#### Ready to merge
