### PR TITLE
dwindle: add smart_split_on_drop option

### DIFF
--- a/hyprtester/src/tests/main/smartSplit.cpp
+++ b/hyprtester/src/tests/main/smartSplit.cpp
@@ -1,41 +1,21 @@
-#include <hyprutils/os/Process.hpp>
-#include <hyprutils/memory/WeakPtr.hpp>
-
+#include "tests.hpp"
 #include "../../shared.hpp"
 #include "../../hyprctlCompat.hpp"
+#include <hyprutils/os/Process.hpp>
+#include <hyprutils/memory/WeakPtr.hpp>
 #include "../shared.hpp"
-#include "tests.hpp"
 
 static int ret = 0;
 
-static bool spawnKitty(const std::string& class_) {
-    NLog::log("{}Spawning {}", Colors::YELLOW, class_);
-    if (!Tests::spawnKitty(class_)) {
-        NLog::log("{}Error: {} did not spawn", Colors::RED, class_);
-        return false;
-    }
-    return true;
-}
-
-static std::string getWindowAttribute(const std::string& winInfo, const std::string& attr) {
-    auto pos = winInfo.find(attr);
-    if (pos == std::string::npos) {
-        NLog::log("{}Wrong window attribute", Colors::RED);
-        ret = 1;
-        return "Wrong window attribute";
-    }
-    auto pos2 = winInfo.find('\n', pos);
-    return winInfo.substr(pos, pos2 - pos);
-}
+using namespace Hyprutils::OS;
+using namespace Hyprutils::Memory;
 
 static void testConfigRegistration() {
-    NLog::log("{}Testing config option registration", Colors::GREEN);
+    NLog::log("{}Testing config: dwindle:smart_split_on_drop", Colors::GREEN);
     
-    // Test that the config option can be set and retrieved
     NLog::log("{}Setting dwindle:smart_split_on_drop to true", Colors::YELLOW);
     OK(getFromSocket("/keyword dwindle:smart_split_on_drop true"));
     
-    // Verify it was set correctly by checking the config
     auto configStr = getFromSocket("/getoption dwindle:smart_split_on_drop");
     EXPECT_CONTAINS(configStr, "1");
     
@@ -47,135 +27,97 @@ static void testConfigRegistration() {
 }
 
 static void testSmartSplitBehavior() {
-    NLog::log("{}Testing smart split behavior", Colors::GREEN);
+    NLog::log("{}Testing smart split behavior with smart_split_on_drop enabled", Colors::YELLOW);
     
-    // Test on workspace "smart_split"
     NLog::log("{}Switching to workspace \"smart_split\"", Colors::YELLOW);
     getFromSocket("/dispatch workspace name:smart_split");
     
-    // Enable smart_split and smart_split_on_drop
     OK(getFromSocket("/keyword dwindle:smart_split 1"));
     OK(getFromSocket("/keyword dwindle:smart_split_on_drop true"));
-    
-    // Set a specific split ratio for predictable behavior
     OK(getFromSocket("/keyword dwindle:split_width_multiplier 1.5"));
     
-    // Spawn first window
-    if (!spawnKitty("kitty_A"))
+    if (!Tests::spawnKitty("kitty_A"))
         return;
     
     NLog::log("{}Expecting 1 window", Colors::YELLOW);
     EXPECT(Tests::windowCount(), 1);
     
-    // Spawn second window - this should use regular split behavior (not smart split)
-    // because smart_split_on_drop is enabled but this is not a drop operation
-    if (!spawnKitty("kitty_B"))
+    if (!Tests::spawnKitty("kitty_B"))
         return;
     
     NLog::log("{}Expecting 2 windows", Colors::YELLOW);
     EXPECT(Tests::windowCount(), 2);
     
-    // Just verify that windows were created successfully
-    // The exact sizing behavior may vary in the test environment
     NLog::log("{}Windows created successfully with smart_split_on_drop enabled", Colors::YELLOW);
     
-    // Clean up
     Tests::killAllWindows();
     EXPECT(Tests::windowCount(), 0);
 }
 
 static void testSmartSplitOnDropBehavior() {
-    NLog::log("{}Testing smart split on drop behavior", Colors::GREEN);
+    NLog::log("{}Testing smart split with drop simulation", Colors::YELLOW);
     
-    // Test on workspace "smart_split_drop"
     NLog::log("{}Switching to workspace \"smart_split_drop\"", Colors::YELLOW);
     getFromSocket("/dispatch workspace name:smart_split_drop");
     
-    // Enable smart_split and smart_split_on_drop
     OK(getFromSocket("/keyword dwindle:smart_split 1"));
     OK(getFromSocket("/keyword dwindle:smart_split_on_drop true"));
-    
-    // Set a specific split ratio for predictable behavior
     OK(getFromSocket("/keyword dwindle:split_width_multiplier 1.5"));
     
-    // Spawn first window
-    if (!spawnKitty("kitty_A"))
+    if (!Tests::spawnKitty("kitty_A"))
         return;
     
     NLog::log("{}Expecting 1 window", Colors::YELLOW);
     EXPECT(Tests::windowCount(), 1);
     
-    // Simulate a drop operation by using movewindow (this should trigger smart split)
-    // First, spawn a second window
-    if (!spawnKitty("kitty_B"))
+    if (!Tests::spawnKitty("kitty_B"))
         return;
     
-    // Move the second window to simulate a drop operation
-    // This should trigger the smart split behavior
     OK(getFromSocket("/dispatch moveactive exact 100 100"));
     
     NLog::log("{}Expecting 2 windows after drop simulation", Colors::YELLOW);
     EXPECT(Tests::windowCount(), 2);
     
-    // Just verify that windows were created and moved successfully
     NLog::log("{}Windows created and moved successfully with smart split on drop", Colors::YELLOW);
     
-    // Clean up
     Tests::killAllWindows();
     EXPECT(Tests::windowCount(), 0);
 }
 
 static void testDefaultBehavior() {
-    NLog::log("{}Testing default behavior (smart_split_on_drop disabled)", Colors::GREEN);
+    NLog::log("{}Testing default behavior with smart_split_on_drop disabled", Colors::YELLOW);
     
-    // Test on workspace "default_behavior"
     NLog::log("{}Switching to workspace \"default_behavior\"", Colors::YELLOW);
     getFromSocket("/dispatch workspace name:default_behavior");
     
-    // Enable smart_split but disable smart_split_on_drop (default)
     OK(getFromSocket("/keyword dwindle:smart_split 1"));
     OK(getFromSocket("/keyword dwindle:smart_split_on_drop false"));
-    
-    // Set a specific split ratio for predictable behavior
     OK(getFromSocket("/keyword dwindle:split_width_multiplier 1.5"));
     
-    // Spawn first window
-    if (!spawnKitty("kitty_A"))
+    if (!Tests::spawnKitty("kitty_A"))
         return;
     
     NLog::log("{}Expecting 1 window", Colors::YELLOW);
     EXPECT(Tests::windowCount(), 1);
     
-    // Spawn second window - this should use smart split behavior
-    // because smart_split_on_drop is disabled, so smart_split applies to all operations
-    if (!spawnKitty("kitty_B"))
+    if (!Tests::spawnKitty("kitty_B"))
         return;
     
     NLog::log("{}Expecting 2 windows", Colors::YELLOW);
     EXPECT(Tests::windowCount(), 2);
     
-    // With smart split enabled, the behavior should be cursor-position based
-    // The exact behavior depends on cursor position, so we just verify windows were created
     NLog::log("{}Windows created successfully with smart_split enabled for all operations", Colors::YELLOW);
     
-    // Clean up
     Tests::killAllWindows();
     EXPECT(Tests::windowCount(), 0);
 }
 
 static bool test() {
-    NLog::log("{}Testing smart_split_on_drop feature", Colors::GREEN);
+    NLog::log("{}Testing config: dwindle:smart_split_on_drop", Colors::GREEN);
     
-    // Test config registration
     testConfigRegistration();
-    
-    // Test smart split behavior when smart_split_on_drop is enabled
     testSmartSplitBehavior();
-    
-    // Test smart split on drop behavior
     testSmartSplitOnDropBehavior();
-    
-    // Test default behavior (smart_split_on_drop disabled)
     testDefaultBehavior();
     
     return !ret;

--- a/hyprtester/src/tests/main/smart_split.cpp
+++ b/hyprtester/src/tests/main/smart_split.cpp
@@ -1,0 +1,184 @@
+#include <hyprutils/os/Process.hpp>
+#include <hyprutils/memory/WeakPtr.hpp>
+
+#include "../../shared.hpp"
+#include "../../hyprctlCompat.hpp"
+#include "../shared.hpp"
+#include "tests.hpp"
+
+static int ret = 0;
+
+static bool spawnKitty(const std::string& class_) {
+    NLog::log("{}Spawning {}", Colors::YELLOW, class_);
+    if (!Tests::spawnKitty(class_)) {
+        NLog::log("{}Error: {} did not spawn", Colors::RED, class_);
+        return false;
+    }
+    return true;
+}
+
+static std::string getWindowAttribute(const std::string& winInfo, const std::string& attr) {
+    auto pos = winInfo.find(attr);
+    if (pos == std::string::npos) {
+        NLog::log("{}Wrong window attribute", Colors::RED);
+        ret = 1;
+        return "Wrong window attribute";
+    }
+    auto pos2 = winInfo.find('\n', pos);
+    return winInfo.substr(pos, pos2 - pos);
+}
+
+static void testConfigRegistration() {
+    NLog::log("{}Testing config option registration", Colors::GREEN);
+    
+    // Test that the config option can be set and retrieved
+    NLog::log("{}Setting dwindle:smart_split_on_drop to true", Colors::YELLOW);
+    OK(getFromSocket("/keyword dwindle:smart_split_on_drop true"));
+    
+    // Verify it was set correctly by checking the config
+    auto configStr = getFromSocket("/getoption dwindle:smart_split_on_drop");
+    EXPECT_CONTAINS(configStr, "1");
+    
+    NLog::log("{}Setting dwindle:smart_split_on_drop to false", Colors::YELLOW);
+    OK(getFromSocket("/keyword dwindle:smart_split_on_drop false"));
+    
+    configStr = getFromSocket("/getoption dwindle:smart_split_on_drop");
+    EXPECT_CONTAINS(configStr, "0");
+}
+
+static void testSmartSplitBehavior() {
+    NLog::log("{}Testing smart split behavior", Colors::GREEN);
+    
+    // Test on workspace "smart_split"
+    NLog::log("{}Switching to workspace \"smart_split\"", Colors::YELLOW);
+    getFromSocket("/dispatch workspace name:smart_split");
+    
+    // Enable smart_split and smart_split_on_drop
+    OK(getFromSocket("/keyword dwindle:smart_split 1"));
+    OK(getFromSocket("/keyword dwindle:smart_split_on_drop true"));
+    
+    // Set a specific split ratio for predictable behavior
+    OK(getFromSocket("/keyword dwindle:split_width_multiplier 1.5"));
+    
+    // Spawn first window
+    if (!spawnKitty("kitty_A"))
+        return;
+    
+    NLog::log("{}Expecting 1 window", Colors::YELLOW);
+    EXPECT(Tests::windowCount(), 1);
+    
+    // Spawn second window - this should use regular split behavior (not smart split)
+    // because smart_split_on_drop is enabled but this is not a drop operation
+    if (!spawnKitty("kitty_B"))
+        return;
+    
+    NLog::log("{}Expecting 2 windows", Colors::YELLOW);
+    EXPECT(Tests::windowCount(), 2);
+    
+    // Just verify that windows were created successfully
+    // The exact sizing behavior may vary in the test environment
+    NLog::log("{}Windows created successfully with smart_split_on_drop enabled", Colors::YELLOW);
+    
+    // Clean up
+    Tests::killAllWindows();
+    EXPECT(Tests::windowCount(), 0);
+}
+
+static void testSmartSplitOnDropBehavior() {
+    NLog::log("{}Testing smart split on drop behavior", Colors::GREEN);
+    
+    // Test on workspace "smart_split_drop"
+    NLog::log("{}Switching to workspace \"smart_split_drop\"", Colors::YELLOW);
+    getFromSocket("/dispatch workspace name:smart_split_drop");
+    
+    // Enable smart_split and smart_split_on_drop
+    OK(getFromSocket("/keyword dwindle:smart_split 1"));
+    OK(getFromSocket("/keyword dwindle:smart_split_on_drop true"));
+    
+    // Set a specific split ratio for predictable behavior
+    OK(getFromSocket("/keyword dwindle:split_width_multiplier 1.5"));
+    
+    // Spawn first window
+    if (!spawnKitty("kitty_A"))
+        return;
+    
+    NLog::log("{}Expecting 1 window", Colors::YELLOW);
+    EXPECT(Tests::windowCount(), 1);
+    
+    // Simulate a drop operation by using movewindow (this should trigger smart split)
+    // First, spawn a second window
+    if (!spawnKitty("kitty_B"))
+        return;
+    
+    // Move the second window to simulate a drop operation
+    // This should trigger the smart split behavior
+    OK(getFromSocket("/dispatch moveactive exact 100 100"));
+    
+    NLog::log("{}Expecting 2 windows after drop simulation", Colors::YELLOW);
+    EXPECT(Tests::windowCount(), 2);
+    
+    // Just verify that windows were created and moved successfully
+    NLog::log("{}Windows created and moved successfully with smart split on drop", Colors::YELLOW);
+    
+    // Clean up
+    Tests::killAllWindows();
+    EXPECT(Tests::windowCount(), 0);
+}
+
+static void testDefaultBehavior() {
+    NLog::log("{}Testing default behavior (smart_split_on_drop disabled)", Colors::GREEN);
+    
+    // Test on workspace "default_behavior"
+    NLog::log("{}Switching to workspace \"default_behavior\"", Colors::YELLOW);
+    getFromSocket("/dispatch workspace name:default_behavior");
+    
+    // Enable smart_split but disable smart_split_on_drop (default)
+    OK(getFromSocket("/keyword dwindle:smart_split 1"));
+    OK(getFromSocket("/keyword dwindle:smart_split_on_drop false"));
+    
+    // Set a specific split ratio for predictable behavior
+    OK(getFromSocket("/keyword dwindle:split_width_multiplier 1.5"));
+    
+    // Spawn first window
+    if (!spawnKitty("kitty_A"))
+        return;
+    
+    NLog::log("{}Expecting 1 window", Colors::YELLOW);
+    EXPECT(Tests::windowCount(), 1);
+    
+    // Spawn second window - this should use smart split behavior
+    // because smart_split_on_drop is disabled, so smart_split applies to all operations
+    if (!spawnKitty("kitty_B"))
+        return;
+    
+    NLog::log("{}Expecting 2 windows", Colors::YELLOW);
+    EXPECT(Tests::windowCount(), 2);
+    
+    // With smart split enabled, the behavior should be cursor-position based
+    // The exact behavior depends on cursor position, so we just verify windows were created
+    NLog::log("{}Windows created successfully with smart_split enabled for all operations", Colors::YELLOW);
+    
+    // Clean up
+    Tests::killAllWindows();
+    EXPECT(Tests::windowCount(), 0);
+}
+
+static bool test() {
+    NLog::log("{}Testing smart_split_on_drop feature", Colors::GREEN);
+    
+    // Test config registration
+    testConfigRegistration();
+    
+    // Test smart split behavior when smart_split_on_drop is enabled
+    testSmartSplitBehavior();
+    
+    // Test smart split on drop behavior
+    testSmartSplitOnDropBehavior();
+    
+    // Test default behavior (smart_split_on_drop disabled)
+    testDefaultBehavior();
+    
+    return !ret;
+}
+
+REGISTER_TEST_FN(test)

--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1794,6 +1794,13 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SBoolData{false},
     },
     SConfigOptionDescription{
+        .value = "dwindle:smart_split_on_drop",
+        .description =
+            "if enabled, smart split (cursor-position-based splitting) is only used for mouse drop operations. Otherwise, uses regular split_width_multiplier-based splitting.",
+        .type = CONFIG_OPTION_BOOL,
+        .data = SConfigOptionDescription::SBoolData{false},
+    },
+    SConfigOptionDescription{
         .value = "dwindle:smart_resizing",
         .description =
             "if enabled, resizing direction will be determined by the mouse's position on the window (nearest to which corner). Else, it is based on the window's tiling position.",

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -625,6 +625,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("dwindle:split_bias", Hyprlang::INT{0});
     registerConfigVar("dwindle:smart_split", Hyprlang::INT{0});
     registerConfigVar("dwindle:smart_resizing", Hyprlang::INT{1});
+    registerConfigVar("dwindle:smart_split_on_drop", Hyprlang::INT{0});
     registerConfigVar("dwindle:precise_mouse_move", Hyprlang::INT{0});
     registerConfigVar("dwindle:single_window_aspect_ratio", Hyprlang::VEC2{0, 0});
     registerConfigVar("dwindle:single_window_aspect_ratio_tolerance", {0.1f});

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -338,7 +338,8 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
     NEWPARENT->isNode      = true; // it is a node
     NEWPARENT->splitRatio  = std::clamp(*PDEFAULTSPLIT, 0.1f, 1.9f);
 
-    static auto PWIDTHMULTIPLIER = CConfigValue<Hyprlang::FLOAT>("dwindle:split_width_multiplier");
+    static auto PWIDTHMULTIPLIER   = CConfigValue<Hyprlang::FLOAT>("dwindle:split_width_multiplier");
+    static auto PSMARTSPLITONDDROP = CConfigValue<Hyprlang::INT>("dwindle:smart_split_on_drop");
 
     // if cursor over first child, make it first, etc
     const auto SIDEBYSIDE = NEWPARENT->box.w > NEWPARENT->box.h * *PWIDTHMULTIPLIER;
@@ -373,7 +374,10 @@ void CHyprDwindleLayout::onWindowCreatedTiling(PHLWINDOW pWindow, eDirection dir
         // whether or not the override persists after opening one window
         if (*PERMANENTDIRECTIONOVERRIDE == 0)
             m_overrideDirection = DIRECTION_DEFAULT;
-    } else if (*PSMARTSPLIT == 1) {
+    } else if (*PSMARTSPLIT == 1 && (!*PSMARTSPLITONDDROP || g_pInputManager->m_wasDraggingWindow)) {
+        // Smart split with cursor position - applies when:
+        // 1. smart_split_on_drop is disabled (use smart_split for everything)
+        // 2. OR this is a mouse drop operation (only use smart split for drops)
         const auto PARENT_CENTER      = NEWPARENT->box.pos() + NEWPARENT->box.size() / 2;
         const auto PARENT_PROPORTIONS = NEWPARENT->box.h / NEWPARENT->box.w;
         const auto DELTA              = MOUSECOORDS - PARENT_CENTER;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

#### Describe your PR, what does it fix/add?

https://github.com/user-attachments/assets/d1fc3f8f-2da1-47a6-a5a0-32962e0b1a02




Adds a new configuration option `dwindle:smart_split_on_drop` that provides more granular control over when smart split behavior is used in the dwindle layout. 

When enabled, smart split (cursor-position-based splitting) is only used for mouse drop operations, while regular `split_width_multiplier`-based splitting is used for splits during window creation.



This way, you can still split based on aspect ratio when creating new windows, while drag and drop to rearrange using mouse position.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

- The change is backward compatible - the new option defaults to `false`, maintaining existing behavior

#### Is it ready for merging, or does it need work?

Pay extra attention to the test