### PR TITLE
Virtual keyboard: update cached mods before IME; add share_states = 2 config option for auto disable when IME client

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -683,9 +683,9 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
 
     SConfigOptionDescription{
         .value       = "input:virtualkeyboard:share_states",
-        .description = "Unify key down states and modifier states with other keyboards",
-        .type        = CONFIG_OPTION_BOOL,
-        .data        = SConfigOptionDescription::SBoolData{false},
+        .description = "Unify key down states and modifier states with other keyboards. 0 -> no, 1 -> yes, 2 -> yes unless IME client",
+        .type        = CONFIG_OPTION_INT,
+        .data        = SConfigOptionDescription::SRangeData{2, 0, 2},
     },
     SConfigOptionDescription{
         .value       = "input:virtualkeyboard:release_pressed_on_close",

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -689,7 +689,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("input:touchdevice:transform", Hyprlang::INT{-1});
     registerConfigVar("input:touchdevice:output", {"[[Auto]]"});
     registerConfigVar("input:touchdevice:enabled", Hyprlang::INT{1});
-    registerConfigVar("input:virtualkeyboard:share_states", Hyprlang::INT{0});
+    registerConfigVar("input:virtualkeyboard:share_states", Hyprlang::INT{2});
     registerConfigVar("input:virtualkeyboard:release_pressed_on_close", Hyprlang::INT{0});
     registerConfigVar("input:tablet:transform", Hyprlang::INT{0});
     registerConfigVar("input:tablet:output", {STRVAL_EMPTY});

--- a/src/devices/IKeyboard.cpp
+++ b/src/devices/IKeyboard.cpp
@@ -460,3 +460,8 @@ bool IKeyboard::getPressed(uint32_t key) {
 bool IKeyboard::shareStates() {
     return m_shareStates;
 }
+
+void IKeyboard::setShareStatesAuto(bool shareStates) {
+    if (m_shareStatesAuto)
+        m_shareStates = shareStates;
+}

--- a/src/devices/IKeyboard.hpp
+++ b/src/devices/IKeyboard.hpp
@@ -79,6 +79,7 @@ class IKeyboard : public IHID {
     void                              updateKeymapFD();
     bool                              getPressed(uint32_t key);
     bool                              shareStates();
+    void                              setShareStatesAuto(bool shareStates);
 
     bool                              m_active     = false;
     bool                              m_enabled    = true;
@@ -132,5 +133,6 @@ class IKeyboard : public IHID {
 
   protected:
     bool updatePressed(uint32_t key, bool pressed);
-    bool m_shareStates = true;
+    bool m_shareStates     = true;
+    bool m_shareStatesAuto = true;
 };

--- a/src/devices/VirtualKeyboard.cpp
+++ b/src/devices/VirtualKeyboard.cpp
@@ -44,8 +44,11 @@ CVirtualKeyboard::CVirtualKeyboard(SP<CVirtualKeyboardV1Resource> keeb_) : m_key
         m_keyboardEvents.keymap.emit(event);
     });
 
-    m_deviceName  = keeb_->m_name;
-    m_shareStates = g_pConfigManager->getDeviceInt(m_deviceName, "share_states", "input:virtualkeyboard:share_states");
+    m_deviceName = keeb_->m_name;
+
+    const auto SHARESTATES = g_pConfigManager->getDeviceInt(m_deviceName, "share_states", "input:virtualkeyboard:share_states");
+    m_shareStates          = SHARESTATES != 0;
+    m_shareStatesAuto      = SHARESTATES == 2;
 }
 
 bool CVirtualKeyboard::isVirtual() {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes issue discussed here: #11715

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

`share_states` config option is changed to an int. 0 is no, 1 is yes, 2 is auto (disable when IME client)

#### Is it ready for merging, or does it need work?

Need tesing..
