### PR TITLE
Fix inconsistent border thickness for roundingPower < 2

### DIFF
--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -70,14 +70,18 @@ void CHyprBorderDecoration::draw(PHLMONITOR pMonitor, float const& a) {
             m_window->m_realBorderColorPrevious.m_angle = grad.m_angle;
     }
 
-    int                             borderSize    = m_window->getRealBorderSize();
-    const auto                      ROUNDING      = m_window->rounding() * pMonitor->m_scale;
-    const auto                      ROUNDINGPOWER = m_window->roundingPower();
+    int                             borderSize       = m_window->getRealBorderSize();
+    const auto                      ROUNDINGBASE     = m_window->rounding();
+    const auto                      ROUNDING         = ROUNDINGBASE * pMonitor->m_scale;
+    const auto                      ROUNDINGPOWER    = m_window->roundingPower();
+    const auto                      CORRECTIONOFFSET = (borderSize * (M_SQRT2 - 1) * std::max(2.0 - ROUNDINGPOWER, 0.0));
+    const auto                      OUTERROUND       = ((ROUNDINGBASE + borderSize) - CORRECTIONOFFSET) * pMonitor->m_scale;
 
     CBorderPassElement::SBorderData data;
     data.box           = windowBox;
     data.grad1         = grad;
     data.round         = ROUNDING;
+    data.outerRound    = OUTERROUND;
     data.roundingPower = ROUNDINGPOWER;
     data.a             = a;
     data.borderSize    = borderSize;

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -117,11 +117,13 @@ void CHyprDropShadowDecoration::render(PHLMONITOR pMonitor, float const& a) {
     if (*PSHADOWS != 1)
         return; // disabled
 
-    const auto ROUNDINGBASE    = PWINDOW->rounding();
-    const auto ROUNDINGPOWER   = PWINDOW->roundingPower();
-    const auto ROUNDING        = ROUNDINGBASE > 0 ? ROUNDINGBASE + PWINDOW->getRealBorderSize() : 0;
-    const auto PWORKSPACE      = PWINDOW->m_workspace;
-    const auto WORKSPACEOFFSET = PWORKSPACE && !PWINDOW->m_pinned ? PWORKSPACE->m_renderOffset->value() : Vector2D();
+    const auto BORDERSIZE       = PWINDOW->getRealBorderSize();
+    const auto ROUNDINGBASE     = PWINDOW->rounding();
+    const auto ROUNDINGPOWER    = PWINDOW->roundingPower();
+    const auto CORRECTIONOFFSET = (BORDERSIZE * (M_SQRT2 - 1) * std::max(2.0 - ROUNDINGPOWER, 0.0));
+    const auto ROUNDING         = ROUNDINGBASE > 0 ? (ROUNDINGBASE + BORDERSIZE) - CORRECTIONOFFSET : 0;
+    const auto PWORKSPACE       = PWINDOW->m_workspace;
+    const auto WORKSPACEOFFSET  = PWORKSPACE && !PWINDOW->m_pinned ? PWORKSPACE->m_renderOffset->value() : Vector2D();
 
     // draw the shadow
     CBox fullBox = m_lastWindowBoxWithDecos;

--- a/src/render/shaders/glsl/border.frag
+++ b/src/render/shaders/glsl/border.frag
@@ -1,6 +1,8 @@
 #version 300 es
 #extension GL_ARB_shading_language_include : enable
 
+# define M_SQRT1_2	0.70710678118654752440
+
 precision highp float;
 in vec2 v_texcoord;
 
@@ -125,7 +127,8 @@ void main() {
     pixCoord *= vec2(lessThan(pixCoord, vec2(0.0))) * -2.0 + 1.0;
     pixCoordOuter = pixCoord;
     pixCoord -= fullSize * 0.5 - radius;
-    pixCoordOuter -= fullSize * 0.5 - radiusOuter;
+    float correctionOffset = thick * (M_SQRT1_2 - 0.5) * max(2.0 - roundingPower, 0.0);
+    pixCoordOuter -= fullSize * 0.5 - radius + correctionOffset;
 
     // center the pixes don't make it top-left
     pixCoord += vec2(1.0, 1.0) / fullSize;

--- a/src/render/shaders/glsl/border.frag
+++ b/src/render/shaders/glsl/border.frag
@@ -134,7 +134,6 @@ void main() {
     if (min(pixCoord.x, pixCoord.y) > 0.0 && radius > 0.0) {
 	    float dist = pow(pow(pixCoord.x,roundingPower)+pow(pixCoord.y,roundingPower),1.0/roundingPower);
 	    float distOuter = pow(pow(pixCoordOuter.x,roundingPower)+pow(pixCoordOuter.y,roundingPower),1.0/roundingPower);
-
         float h = (thick / 2.0);
 
 	    if (dist < radius - h) {

--- a/src/render/shaders/glsl/border.frag
+++ b/src/render/shaders/glsl/border.frag
@@ -127,8 +127,7 @@ void main() {
     pixCoord *= vec2(lessThan(pixCoord, vec2(0.0))) * -2.0 + 1.0;
     pixCoordOuter = pixCoord;
     pixCoord -= fullSize * 0.5 - radius;
-    float correctionOffset = thick * (M_SQRT1_2 - 0.5) * max(2.0 - roundingPower, 0.0);
-    pixCoordOuter -= fullSize * 0.5 - radius + correctionOffset;
+    pixCoordOuter -= fullSize * 0.5 - radiusOuter;
 
     // center the pixes don't make it top-left
     pixCoord += vec2(1.0, 1.0) / fullSize;
@@ -137,6 +136,10 @@ void main() {
     if (min(pixCoord.x, pixCoord.y) > 0.0 && radius > 0.0) {
 	    float dist = pow(pow(pixCoord.x,roundingPower)+pow(pixCoord.y,roundingPower),1.0/roundingPower);
 	    float distOuter = pow(pow(pixCoordOuter.x,roundingPower)+pow(pixCoordOuter.y,roundingPower),1.0/roundingPower);
+
+        float correctionOffset = thick * (M_SQRT1_2 - 0.5) * max(2.0 - roundingPower, 0.0);
+        distOuter -= correctionOffset;
+
         float h = (thick / 2.0);
 
 	    if (dist < radius - h) {

--- a/src/render/shaders/glsl/border.frag
+++ b/src/render/shaders/glsl/border.frag
@@ -1,8 +1,6 @@
 #version 300 es
 #extension GL_ARB_shading_language_include : enable
 
-# define M_SQRT1_2	0.70710678118654752440
-
 precision highp float;
 in vec2 v_texcoord;
 
@@ -136,9 +134,6 @@ void main() {
     if (min(pixCoord.x, pixCoord.y) > 0.0 && radius > 0.0) {
 	    float dist = pow(pow(pixCoord.x,roundingPower)+pow(pixCoord.y,roundingPower),1.0/roundingPower);
 	    float distOuter = pow(pow(pixCoordOuter.x,roundingPower)+pow(pixCoordOuter.y,roundingPower),1.0/roundingPower);
-
-        float correctionOffset = thick * (M_SQRT1_2 - 0.5) * max(2.0 - roundingPower, 0.0);
-        distOuter -= correctionOffset;
 
         float h = (thick / 2.0);
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Setting decoration:roundingPower to a value smaller than 2 causes inconsistent thickness along corners. Example with roundingPower = 1:
<img width="201" height="201" alt="image" src="https://github.com/user-attachments/assets/6aa26d7a-ba0b-4a51-808a-a15ff01a2329" />

this PR fixes this by applying a correction offset to the rounding of borders and shadows:
<img width="172" height="187" alt="image" src="https://github.com/user-attachments/assets/a8800580-7bc1-48f4-b7e7-23892f652de0" />

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
- The offset is applied linearly based on the rounding power. This is an approximation but it works fine
- The Offset for the shadow is double the offset for the border, I have no Idea why, but it fits perfectly

#### Is it ready for merging, or does it need work?
Hopefully ready

