### PR TITLE
renderer: fix popup fadeout blur

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2596,16 +2596,16 @@ void CHyprRenderer::renderSnapshot(WP<CPopup> popup) {
     const bool                   SHOULD_BLUR = shouldBlur(popup);
 
     CTexPassElement::SRenderData data;
-    data.flipEndFrame = true;
-    data.tex          = FBDATA->getTexture();
-    data.box          = {{}, PMONITOR->m_transformedSize};
-    data.a            = popup->m_alpha->value();
-    data.damage       = fakeDamage;
-    data.blur         = SHOULD_BLUR;
-    data.blurA        = sqrt(popup->m_alpha->value()); // sqrt makes the blur fadeout more realistic.
+    data.flipEndFrame          = true;
+    data.tex                   = FBDATA->getTexture();
+    data.box                   = {{}, PMONITOR->m_transformedSize};
+    data.a                     = popup->m_alpha->value();
+    data.damage                = fakeDamage;
+    data.blur                  = SHOULD_BLUR;
+    data.blurA                 = sqrt(popup->m_alpha->value()); // sqrt makes the blur fadeout more realistic.
+    data.blockBlurOptimization = SHOULD_BLUR; // force no xray on this (popups never have xray)
     if (SHOULD_BLUR)
         data.ignoreAlpha = std::max(*PBLURIGNOREA, 0.01F); /* ignore the alpha 0 regions */
-    ;
 
     m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
 }

--- a/src/render/pass/TexPassElement.cpp
+++ b/src/render/pass/TexPassElement.cpp
@@ -36,13 +36,21 @@ void CTexPassElement::draw(const CRegion& damage) {
         g_pHyprOpenGL->m_renderData.discardOpacity = *m_data.ignoreAlpha;
     }
 
-    if (m_data.blur)
-        g_pHyprOpenGL->renderTexture(
-            m_data.tex, m_data.box,
-            {.a = m_data.a, .blur = true, .blurA = m_data.blurA, .overallA = 1.F, .round = m_data.round, .roundingPower = m_data.roundingPower, .blockBlurOptimization = false});
-    else
+    if (m_data.blur) {
+        g_pHyprOpenGL->renderTexture(m_data.tex, m_data.box,
+                                     {
+                                         .a                     = m_data.a,
+                                         .blur                  = true,
+                                         .blurA                 = m_data.blurA,
+                                         .overallA              = 1.F,
+                                         .round                 = m_data.round,
+                                         .roundingPower         = m_data.roundingPower,
+                                         .blockBlurOptimization = m_data.blockBlurOptimization.value_or(false),
+                                     });
+    } else {
         g_pHyprOpenGL->renderTexture(m_data.tex, m_data.box,
                                      {.damage = m_data.damage.empty() ? &damage : &m_data.damage, .a = m_data.a, .round = m_data.round, .roundingPower = m_data.roundingPower});
+    }
 }
 
 bool CTexPassElement::needsLiveBlur() {

--- a/src/render/pass/TexPassElement.hpp
+++ b/src/render/pass/TexPassElement.hpp
@@ -21,6 +21,7 @@ class CTexPassElement : public IPassElement {
         CBox                  clipBox;
         bool                  blur = false;
         std::optional<float>  ignoreAlpha;
+        std::optional<bool>   blockBlurOptimization;
     };
 
     CTexPassElement(const SRenderData& data);


### PR DESCRIPTION
Ref https://github.com/hyprwm/Hyprland/discussions/11381#discussioncomment-14441205

Popups don't get xray ever, so don't make them xray in snapshot code.