### PR TITLE
renderer: fix uv calculations once and for all

### DIFF
--- a/src/desktop/WLSurface.cpp
+++ b/src/desktop/WLSurface.cpp
@@ -64,7 +64,10 @@ bool CWLSurface::small() const {
 
     const auto O = m_windowOwner.lock();
 
-    return O->m_reportedSize.x > m_resource->m_current.size.x + 1 || O->m_reportedSize.y > m_resource->m_current.size.y + 1;
+    if (O->m_isX11)
+        return O->m_reportedSize.x > m_resource->m_current.size.x + 1 || O->m_reportedSize.y > m_resource->m_current.size.y + 1;
+    else
+        return m_resource->m_current.ackedSize.x > m_resource->m_current.size.x + 1 || m_resource->m_current.ackedSize.y > m_resource->m_current.size.y + 1;
 }
 
 Vector2D CWLSurface::correctSmallVec() const {

--- a/src/desktop/WLSurface.cpp
+++ b/src/desktop/WLSurface.cpp
@@ -62,12 +62,10 @@ bool CWLSurface::small() const {
     if (!m_resource->m_current.texture)
         return false;
 
-    const auto O = m_windowOwner.lock();
+    const auto O             = m_windowOwner.lock();
+    const auto REPORTED_SIZE = O->getReportedSize();
 
-    if (O->m_isX11)
-        return O->m_reportedSize.x > m_resource->m_current.size.x + 1 || O->m_reportedSize.y > m_resource->m_current.size.y + 1;
-    else
-        return m_resource->m_current.ackedSize.x > m_resource->m_current.size.x + 1 || m_resource->m_current.ackedSize.y > m_resource->m_current.size.y + 1;
+    return REPORTED_SIZE.x > m_resource->m_current.size.x + 1 || REPORTED_SIZE.y > m_resource->m_current.size.y + 1;
 }
 
 Vector2D CWLSurface::correctSmallVec() const {

--- a/src/desktop/WLSurface.cpp
+++ b/src/desktop/WLSurface.cpp
@@ -74,8 +74,9 @@ Vector2D CWLSurface::correctSmallVec() const {
 
     const auto SIZE = getViewporterCorrectedSize();
     const auto O    = m_windowOwner.lock();
+    const auto REP  = O->getReportedSize();
 
-    return Vector2D{(O->m_reportedSize.x - SIZE.x) / 2, (O->m_reportedSize.y - SIZE.y) / 2}.clamp({}, {INFINITY, INFINITY}) * (O->m_realSize->value() / O->m_reportedSize);
+    return Vector2D{(REP.x - SIZE.x) / 2, (REP.y - SIZE.y) / 2}.clamp({}, {INFINITY, INFINITY}) * (O->m_realSize->value() / REP);
 }
 
 Vector2D CWLSurface::correctSmallVecBuf() const {

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1910,3 +1910,11 @@ SP<CWLSurfaceResource> CWindow::getSolitaryResource() {
 
     return nullptr;
 }
+
+Vector2D CWindow::getReportedSize() {
+    if (m_isX11)
+        return m_reportedSize;
+    if (m_wlSurface && m_wlSurface->resource())
+        return m_wlSurface->resource()->m_current.ackedSize;
+    return m_reportedSize;
+}

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1805,7 +1805,7 @@ void CWindow::sendWindowSize(bool force) {
     if (m_isX11 && m_xwaylandSurface)
         m_xwaylandSurface->configure({REPORTPOS, REPORTSIZE});
     else if (m_xdgSurface && m_xdgSurface->m_toplevel)
-        m_pendingSizeAcks.emplace_back(m_xdgSurface->m_toplevel->setSize(REPORTSIZE), REPORTPOS.floor());
+        m_pendingSizeAcks.emplace_back(m_xdgSurface->m_toplevel->setSize(REPORTSIZE), REPORTSIZE.floor());
 }
 
 NContentType::eContentType CWindow::getContentType() {

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1555,7 +1555,7 @@ std::string CWindow::fetchClass() {
 }
 
 void CWindow::onAck(uint32_t serial) {
-    const auto SERIAL = std::ranges::find_if(m_pendingSizeAcks | std::views::reverse, [serial](const auto& e) { return e.first == serial; });
+    const auto SERIAL = std::ranges::find_if(m_pendingSizeAcks | std::views::reverse, [serial](const auto& e) { return e.first <= serial; });
 
     if (SERIAL == m_pendingSizeAcks.rend())
         return;

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -416,6 +416,7 @@ class CWindow {
     PHLWINDOW                  parent();
     bool                       priorityFocus();
     SP<CWLSurfaceResource>     getSolitaryResource();
+    Vector2D                   getReportedSize();
 
     CBox                       getWindowMainSurfaceBox() const {
         return {m_realPosition->value().x, m_realPosition->value().y, m_realSize->value().x, m_realSize->value().y};

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -868,7 +868,15 @@ void Events::listener_commitWindow(void* owner, void* data) {
     if (!PWINDOW->m_isMapped || PWINDOW->isHidden())
         return;
 
-    PWINDOW->m_reportedSize = PWINDOW->m_pendingReportedSize; // apply pending size. We pinged, the window ponged.
+    if (PWINDOW->m_pendingSizeAck) {
+        if (PWINDOW->m_isX11)
+            PWINDOW->m_reportedSize = PWINDOW->m_pendingSizeAck->second;
+        else {
+            PWINDOW->m_wlSurface->resource()->m_pending.ackedSize          = PWINDOW->m_pendingSizeAck->second; // apply pending size. We pinged, the window ponged.
+            PWINDOW->m_wlSurface->resource()->m_pending.updated.bits.acked = true;
+            PWINDOW->m_pendingSizeAck.reset();
+        }
+    }
 
     if (!PWINDOW->m_isX11 && !PWINDOW->isFullscreen() && PWINDOW->m_isFloating) {
         const auto MINSIZE = PWINDOW->m_xdgSurface->m_toplevel->layoutMinSize();

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -868,10 +868,8 @@ void Events::listener_commitWindow(void* owner, void* data) {
     if (!PWINDOW->m_isMapped || PWINDOW->isHidden())
         return;
 
-    if (PWINDOW->m_pendingSizeAck && PWINDOW->m_isX11) {
-        PWINDOW->m_reportedSize = PWINDOW->m_pendingSizeAck->second;
-        PWINDOW->m_pendingSizeAck.reset();
-    }
+    if (PWINDOW->m_isX11)
+        PWINDOW->m_reportedSize = PWINDOW->m_pendingReportedSize;
 
     if (!PWINDOW->m_isX11 && !PWINDOW->isFullscreen() && PWINDOW->m_isFloating) {
         const auto MINSIZE = PWINDOW->m_xdgSurface->m_toplevel->layoutMinSize();

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -868,14 +868,9 @@ void Events::listener_commitWindow(void* owner, void* data) {
     if (!PWINDOW->m_isMapped || PWINDOW->isHidden())
         return;
 
-    if (PWINDOW->m_pendingSizeAck) {
-        if (PWINDOW->m_isX11)
-            PWINDOW->m_reportedSize = PWINDOW->m_pendingSizeAck->second;
-        else {
-            PWINDOW->m_wlSurface->resource()->m_pending.ackedSize          = PWINDOW->m_pendingSizeAck->second; // apply pending size. We pinged, the window ponged.
-            PWINDOW->m_wlSurface->resource()->m_pending.updated.bits.acked = true;
-            PWINDOW->m_pendingSizeAck.reset();
-        }
+    if (PWINDOW->m_pendingSizeAck && PWINDOW->m_isX11) {
+        PWINDOW->m_reportedSize = PWINDOW->m_pendingSizeAck->second;
+        PWINDOW->m_pendingSizeAck.reset();
     }
 
     if (!PWINDOW->m_isX11 && !PWINDOW->isFullscreen() && PWINDOW->m_isFloating) {

--- a/src/protocols/types/SurfaceState.cpp
+++ b/src/protocols/types/SurfaceState.cpp
@@ -97,4 +97,7 @@ void SSurfaceState::updateFrom(SSurfaceState& ref) {
 
     if (ref.updated.bits.acquire)
         acquire = ref.acquire;
+
+    if (ref.updated.bits.acked)
+        ackedSize = ref.ackedSize;
 }

--- a/src/protocols/types/SurfaceState.hpp
+++ b/src/protocols/types/SurfaceState.hpp
@@ -20,6 +20,7 @@ struct SSurfaceState {
             bool offset : 1;
             bool viewport : 1;
             bool acquire : 1;
+            bool acked : 1;
         } bits;
     } updated;
 
@@ -36,6 +37,9 @@ struct SSurfaceState {
     // these don't have well defined initial values in the protocol, but these work
     Vector2D size, bufferSize;
     Vector2D offset;
+
+    // for xdg_shell resizing
+    Vector2D ackedSize;
 
     // viewporter protocol surface state
     struct {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1129,11 +1129,16 @@ void CHyprRenderer::calculateUVForSurface(PHLWINDOW pWindow, SP<CWLSurfaceResour
                     .round();
 
             const auto RATIO = projSize / EXPECTED_SIZE;
-            if (!SCALE_UNAWARE && (RATIO.x > 1 || RATIO.y > 1)) {
-                // this will not work with shm AFAIK, idk why.
-                // NOTE: this math is wrong if we have a source... or geom updates later, but I don't think we can do much
-                const auto FIX = RATIO.clamp(Vector2D{1, 1}, Vector2D{1000000, 1000000});
-                uvBR           = uvBR * FIX;
+            if (!SCALE_UNAWARE) {
+                if (*PEXPANDEDGES && !SCALE_UNAWARE && (RATIO.x > 1 || RATIO.y > 1)) {
+                    const auto FIX = RATIO.clamp(Vector2D{1, 1}, Vector2D{1000000, 1000000});
+                    uvBR           = uvBR * FIX;
+                }
+
+                if (RATIO.x < 1 || RATIO.y < 1) {
+                    const auto FIX = RATIO.clamp(Vector2D{0.0001, 0.0001}, Vector2D{1, 1});
+                    uvBR           = uvBR * FIX;
+                }
             }
         }
 
@@ -1164,29 +1169,6 @@ void CHyprRenderer::calculateUVForSurface(PHLWINDOW pWindow, SP<CWLSurfaceResour
         //     uvBR               = uvBR - Vector2D((1.0 - WPERC) * (uvBR.x - uvTL.x), (1.0 - HPERC) * (uvBR.y - uvTL.y));
         //     uvTL               = uvTL + TOADDTL;
         // }
-
-        // Only for clamping: extend edges is done before
-        if (!pSurface->m_current.viewport.hasSource) {
-            const auto MONITOR_WL_SCALE = std::ceil(pMonitor->m_scale);
-            const bool SCALE_UNAWARE    = MONITOR_WL_SCALE != pSurface->m_current.scale && !pSurface->m_current.viewport.hasDestination;
-            auto       maxSize =
-                ((pSurface->m_current.viewport.hasDestination ?
-                      pSurface->m_current.viewport.destination :
-                      (pSurface->m_current.viewport.hasSource ? pSurface->m_current.viewport.source.size() : pSurface->m_current.bufferSize) / pSurface->m_current.scale) *
-                 pMonitor->m_scale)
-                    .round();
-
-            if (pWindow->m_wlSurface->small() && !pWindow->m_wlSurface->m_fillIgnoreSmall)
-                maxSize = pWindow->m_wlSurface->getViewporterCorrectedSize();
-
-            const auto RATIO = projSize / maxSize;
-            if (!SCALE_UNAWARE && (RATIO.x < 1 || RATIO.y < 1)) {
-                // this will not work with shm AFAIK, idk why.
-                // NOTE: this math is wrong if we have a source... or geom updates later, but I don't think we can do much
-                const auto FIX = RATIO.clamp(Vector2D{0.0001, 0.0001}, Vector2D{1, 1});
-                uvBR           = uvBR * FIX;
-            }
-        }
 
         g_pHyprOpenGL->m_renderData.primarySurfaceUVTopLeft     = uvTL;
         g_pHyprOpenGL->m_renderData.primarySurfaceUVBottomRight = uvBR;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1123,10 +1123,11 @@ void CHyprRenderer::calculateUVForSurface(PHLWINDOW pWindow, SP<CWLSurfaceResour
         if (*PEXPANDEDGES) {
             const auto MONITOR_WL_SCALE = std::ceil(pMonitor->m_scale);
             const bool SCALE_UNAWARE    = MONITOR_WL_SCALE != pSurface->m_current.scale && !pSurface->m_current.viewport.hasDestination;
-            const auto EXPECTED_SIZE =
-                ((pSurface->m_current.viewport.hasDestination ? pSurface->m_current.viewport.destination : pSurface->m_current.bufferSize / pSurface->m_current.scale) *
-                 pMonitor->m_scale)
-                    .round();
+            const auto EXPECTED_SIZE    = ((pSurface->m_current.viewport.hasDestination ?
+                                                pSurface->m_current.viewport.destination :
+                                                (pSurface->m_current.viewport.hasSource ? pSurface->m_current.viewport.source.size() / pSurface->m_current.scale : projSize)) *
+                                        pMonitor->m_scale)
+                                           .round();
 
             const auto RATIO = projSize / EXPECTED_SIZE;
             if (!SCALE_UNAWARE) {
@@ -1135,7 +1136,9 @@ void CHyprRenderer::calculateUVForSurface(PHLWINDOW pWindow, SP<CWLSurfaceResour
                     uvBR           = uvBR * FIX;
                 }
 
-                if (RATIO.x < 1 || RATIO.y < 1) {
+                // FIXME: probably do this for in anims on all views...
+                const auto SHOULD_SKIP = !pWindow || pWindow->m_animatingIn;
+                if (!SHOULD_SKIP && (RATIO.x < 1 || RATIO.y < 1)) {
                     const auto FIX = RATIO.clamp(Vector2D{0.0001, 0.0001}, Vector2D{1, 1});
                     uvBR           = uvBR * FIX;
                 }

--- a/src/render/pass/SurfacePassElement.cpp
+++ b/src/render/pass/SurfacePassElement.cpp
@@ -174,27 +174,31 @@ CBox CSurfacePassElement::getTexBox() {
 
         // center the surface if it's smaller than the viewport we assign it
         if (PSURFACE && !PSURFACE->m_fillIgnoreSmall && PSURFACE->small() /* guarantees PWINDOW */) {
-            const auto CORRECT = PSURFACE->correctSmallVec();
-            const auto SIZE    = PSURFACE->getViewporterCorrectedSize();
+            const auto CORRECT  = PSURFACE->correctSmallVec();
+            const auto SIZE     = PSURFACE->getViewporterCorrectedSize();
+            const auto REPORTED = PWINDOW->getReportedSize();
 
             if (!INTERACTIVERESIZEINPROGRESS) {
                 windowBox.translate(CORRECT);
 
-                windowBox.width  = SIZE.x * (PWINDOW->m_realSize->value().x / PWINDOW->m_reportedSize.x);
-                windowBox.height = SIZE.y * (PWINDOW->m_realSize->value().y / PWINDOW->m_reportedSize.y);
+                windowBox.width  = SIZE.x * (PWINDOW->m_realSize->value().x / REPORTED.x);
+                windowBox.height = SIZE.y * (PWINDOW->m_realSize->value().y / REPORTED.y);
             } else {
                 windowBox.width  = SIZE.x;
                 windowBox.height = SIZE.y;
             }
         }
-
     } else { //  here we clamp to 2, these might be some tiny specks
-        windowBox = {sc<int>(outputX) + m_data.pos.x + m_data.localPos.x, sc<int>(outputY) + m_data.pos.y + m_data.localPos.y,
-                     std::max(sc<float>(m_data.surface->m_current.size.x), 2.F), std::max(sc<float>(m_data.surface->m_current.size.y), 2.F)};
+
+        const auto SURFSIZE = m_data.surface->m_current.viewport.hasSource ? m_data.surface->m_current.viewport.source.size() : m_data.surface->m_current.size;
+
+        windowBox = {sc<int>(outputX) + m_data.pos.x + m_data.localPos.x, sc<int>(outputY) + m_data.pos.y + m_data.localPos.y, std::max(sc<float>(SURFSIZE.x), 2.F),
+                     std::max(sc<float>(SURFSIZE.y), 2.F)};
         if (m_data.pWindow && m_data.pWindow->m_realSize->isBeingAnimated() && m_data.surface && !m_data.mainSurface && m_data.squishOversized /* subsurface */) {
             // adjust subsurfaces to the window
-            windowBox.width  = (windowBox.width / m_data.pWindow->m_reportedSize.x) * m_data.pWindow->m_realSize->value().x;
-            windowBox.height = (windowBox.height / m_data.pWindow->m_reportedSize.y) * m_data.pWindow->m_realSize->value().y;
+            const auto REPORTED = m_data.pWindow->getReportedSize();
+            windowBox.width     = (windowBox.width / REPORTED.x) * m_data.pWindow->m_realSize->value().x;
+            windowBox.height    = (windowBox.height / REPORTED.y) * m_data.pWindow->m_realSize->value().y;
         }
     }
 

--- a/src/render/pass/SurfacePassElement.cpp
+++ b/src/render/pass/SurfacePassElement.cpp
@@ -190,15 +190,17 @@ CBox CSurfacePassElement::getTexBox() {
         }
     } else { //  here we clamp to 2, these might be some tiny specks
 
-        const auto SURFSIZE = m_data.surface->m_current.viewport.hasSource ? m_data.surface->m_current.viewport.source.size() : m_data.surface->m_current.size;
+        const auto SURFSIZE = m_data.surface->m_current.size;
 
         windowBox = {sc<int>(outputX) + m_data.pos.x + m_data.localPos.x, sc<int>(outputY) + m_data.pos.y + m_data.localPos.y, std::max(sc<float>(SURFSIZE.x), 2.F),
                      std::max(sc<float>(SURFSIZE.y), 2.F)};
         if (m_data.pWindow && m_data.pWindow->m_realSize->isBeingAnimated() && m_data.surface && !m_data.mainSurface && m_data.squishOversized /* subsurface */) {
             // adjust subsurfaces to the window
             const auto REPORTED = m_data.pWindow->getReportedSize();
-            windowBox.width     = (windowBox.width / REPORTED.x) * m_data.pWindow->m_realSize->value().x;
-            windowBox.height    = (windowBox.height / REPORTED.y) * m_data.pWindow->m_realSize->value().y;
+            if (REPORTED.x != 0 && REPORTED.y != 0) {
+                windowBox.width  = (windowBox.width / REPORTED.x) * m_data.pWindow->m_realSize->value().x;
+                windowBox.height = (windowBox.height / REPORTED.y) * m_data.pWindow->m_realSize->value().y;
+            }
         }
     }
 


### PR DESCRIPTION
fixes synchronization of ackd sizes, fixes wrong xdg stuff

Removes xdg_geometry uv handling altogether. It wasn't sync'd properly and we send MAXIMIZED anyways, so geometry is pointless.

Needs some testing if I didnt break shit.

