### PR TITLE
ci: remove duplicate cp and redundant mkdir commands from CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,13 +27,10 @@ jobs:
         run: |
           mkdir x86_64-pc-linux-gnu
           mkdir hyprland
-          mkdir hyprland/example
-          mkdir hyprland/assets
           cp ./LICENSE hyprland/
           cp build/Hyprland hyprland/
           cp build/hyprctl/hyprctl hyprland/
           cp build/hyprpm/hyprpm hyprland/
-          cp build/Hyprland hyprland/
           cp -r example/ hyprland/
           cp -r assets/ hyprland/
           tar -cvJf Hyprland.tar.xz hyprland


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

- Removes the duplicate `cp build/Hyprland hyprland/` command.
- Removes unnecessary `mkdir hyprland/example` and `mkdir hyprland/assets` commands since the directories are populated via `cp -r` later.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No breaking changes expected.

#### Is it ready for merging, or does it need work?

Ready to merge.
