### PR TITLE
protocols/gamma: fix GammaControl destroy conditions

### DIFF
--- a/src/protocols/GammaControl.cpp
+++ b/src/protocols/GammaControl.cpp
@@ -179,7 +179,7 @@ void CGammaControlProtocol::onManagerResourceDestroy(wl_resource* res) {
 }
 
 void CGammaControlProtocol::destroyGammaControl(CGammaControl* gamma) {
-    std::erase_if(m_gammaControllers, [&](const auto& other) { return other.get() == gamma; });
+    std::erase_if(m_gammaControllers, [&](const auto& other) { return other->getMonitor() == gamma->getMonitor(); });
 }
 
 void CGammaControlProtocol::onGetGammaControl(CZwlrGammaControlManagerV1* pMgr, uint32_t id, wl_resource* output) {


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

This PR fix the issue that gammastep randomly stop working like
```
Warning: Zero outputs support gamma adjustment.
Warning: 1/1 output(s) do not support gamma adjustment.
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Yes
