### PR TITLE
foreign-toplevel: continue past skipped invalid windows

### DIFF
--- a/src/protocols/ForeignToplevel.cpp
+++ b/src/protocols/ForeignToplevel.cpp
@@ -35,7 +35,7 @@ CForeignToplevelList::CForeignToplevelList(SP<CExtForeignToplevelListV1> resourc
 
     for (auto const& w : g_pCompositor->m_windows) {
         if (!PROTO::foreignToplevel->windowValidForForeign(w))
-            return;
+            continue;
 
         onMap(w);
     }


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Fix regression caused by 904f9b6aee6a4524fba554f76b32747f85f0609d where encountering an invalid foreign window returned out of the loop instead of continuing enumeration. That prevented valid toplevels from being sent. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
yes

