### PR TITLE
renderer: disable anti-aliasing on cursor:zoom_factor (#6135)

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1760,6 +1760,16 @@ void CHyprOpenGLImpl::renderTexturePrimitive(SP<CTexture> tex, const CBox& box) 
     glActiveTexture(GL_TEXTURE0);
     tex->bind();
 
+    // ensure the final blit uses the desired sampling filter
+    // when cursor zoom is active we want nearest-neighbor (no anti-aliasing)
+    if (m_renderData.useNearestNeighbor) {
+        tex->setTexParameter(GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        tex->setTexParameter(GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    } else {
+        tex->setTexParameter(GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        tex->setTexParameter(GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+    }
+
     useProgram(shader->program);
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
     shader->setUniformInt(SHADER_TEX, 0);


### PR DESCRIPTION
use nearest-neighbor filtering for cursor scaling to avoid blurriness

<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Disables anti-aliasing on cursor:zoom_factor. You can test with:

```bash
$ hyprctl keyword cursor:zoom_factor 1.25
$ hyprctl keyword cursor:zoom_factor 1.5
$ hyprctl keyword cursor:zoom_factor 1.75
$ hyprctl keyword cursor:zoom_factor 1.0
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

- https://github.com/hyprwm/Hyprland/discussions/6135#discussioncomment-14466717

#### Is it ready for merging, or does it need work?

Yes.