### PR TITLE
ihyprlayout: avoid nullptr deref

### DIFF
--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -206,7 +206,7 @@ bool IHyprLayout::onWindowCreatedAutoGroup(PHLWINDOW pWindow) {
     const PHLWINDOW OPENINGON        = g_pCompositor->m_lastWindow.lock() && g_pCompositor->m_lastWindow->m_workspace == pWindow->m_workspace ?
                g_pCompositor->m_lastWindow.lock() :
                (pWindow->m_workspace ? pWindow->m_workspace->getFirstWindow() : nullptr);
-    const bool      FLOATEDINTOTILED = pWindow->m_isFloating && !OPENINGON->m_isFloating;
+    const bool      FLOATEDINTOTILED = pWindow->m_isFloating && OPENINGON && !OPENINGON->m_isFloating;
     const bool      SWALLOWING       = pWindow->m_swallowed || pWindow->m_groupSwallowed;
 
     if ((*PAUTOGROUP || SWALLOWING)                      // continue if auto_group is enabled or if dealing with window swallowing.


### PR DESCRIPTION
OPENINGON can be a nullptr and that makes FLOATEDINTOTILED to nullptr deref and segfault.

see: https://github.com/hyprwm/Hyprland/discussions/11830

