### PR TITLE
Remove unneeded preferred image description ref

### DIFF
--- a/src/protocols/ColorManagement.hpp
+++ b/src/protocols/ColorManagement.hpp
@@ -91,7 +91,6 @@ class CColorManagementFeedbackSurface {
     SP<CWpColorManagementSurfaceFeedbackV1> m_resource;
     wl_client*                              m_client = nullptr;
 
-    WP<CColorManagementImageDescription>    m_currentPreferred;
     uint32_t                                m_currentPreferredId = 0;
 
     struct {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes https://github.com/hyprwm/Hyprland/discussions/11843

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No idea why this doesn't happen with other clients. A small chance of a memory leak if a client doesn't destroy the previous preferred image description as required by the proto.

#### Is it ready for merging, or does it need work?
Ready