### PR TITLE
dispatchers: added setfullscreen, unsetfullscreen and setfullscreenstate

### DIFF
--- a/hyprtester/src/tests/main/misc.cpp
+++ b/hyprtester/src/tests/main/misc.cpp
@@ -131,6 +131,69 @@ static bool test() {
         EXPECT_CONTAINS(str, "fullscreen: 2");
     }
 
+    Tests::killAllWindows();
+
+    NLog::log("{}Testing fullscreen and fullscreenstate dispatcher", Colors::YELLOW);
+
+    Tests::spawnKitty("kitty_A");
+    Tests::spawnKitty("kitty_B");
+
+    OK(getFromSocket("/dispatch fullscreen 0 set"));
+
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "fullscreen: 2");
+    }
+
+    OK(getFromSocket("/dispatch fullscreen 0 unset"));
+
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "fullscreen: 0");
+    }
+
+    OK(getFromSocket("/dispatch fullscreen 1 toggle"));
+
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "fullscreen: 1");
+    }
+
+    OK(getFromSocket("/dispatch fullscreen 1 toggle"));
+
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "fullscreen: 0");
+    }
+
+    OK(getFromSocket("/dispatch fullscreenstate 2 2 set"));
+
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "fullscreen: 2");
+    }
+
+    OK(getFromSocket("/dispatch fullscreenstate 2 2 set"));
+
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "fullscreen: 2");
+    }
+
+    OK(getFromSocket("/dispatch fullscreenstate 2 2 toggle"));
+
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "fullscreen: 0");
+    }
+
+    OK(getFromSocket("/dispatch fullscreenstate 2 2 toggle"));
+
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "fullscreen: 2");
+    }
+
     // kill all
     NLog::log("{}Killing all windows", Colors::YELLOW);
     Tests::killAllWindows();

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1310,23 +1310,32 @@ SDispatchResult CKeybindManager::changeworkspace(std::string args) {
 
 SDispatchResult CKeybindManager::fullscreenActive(std::string args) {
     const auto PWINDOW = g_pCompositor->m_lastWindow.lock();
+    const auto ARGS    = CVarList(args, 2, ' ');
 
     if (!PWINDOW)
         return {.success = false, .error = "Window not found"};
 
-    const eFullscreenMode MODE = args == "1" ? FSMODE_MAXIMIZED : FSMODE_FULLSCREEN;
+    const eFullscreenMode MODE = ARGS.size() > 0 && ARGS[0] == "1" ? FSMODE_MAXIMIZED : FSMODE_FULLSCREEN;
 
-    if (PWINDOW->isEffectiveInternalFSMode(MODE))
-        g_pCompositor->setWindowFullscreenInternal(PWINDOW, FSMODE_NONE);
-    else
-        g_pCompositor->setWindowFullscreenInternal(PWINDOW, MODE);
-
+    if (ARGS.size() <= 1 || ARGS[1] == "toggle") {
+        if (PWINDOW->isEffectiveInternalFSMode(MODE))
+            g_pCompositor->setWindowFullscreenInternal(PWINDOW, FSMODE_NONE);
+        else
+            g_pCompositor->setWindowFullscreenInternal(PWINDOW, MODE);
+    } else {
+        if (ARGS[1] == "set") {
+            g_pCompositor->setWindowFullscreenInternal(PWINDOW, MODE);
+        } else if (ARGS[1] == "unset") {
+            g_pCompositor->setWindowFullscreenInternal(PWINDOW, FSMODE_NONE);
+        }
+    }
+    
     return {};
 }
 
 SDispatchResult CKeybindManager::fullscreenStateActive(std::string args) {
     const auto PWINDOW = g_pCompositor->m_lastWindow.lock();
-    const auto ARGS    = CVarList(args, 2, ' ');
+    const auto ARGS    = CVarList(args, 3, ' ');
 
     if (!PWINDOW)
         return {.success = false, .error = "Window not found"};
@@ -1344,14 +1353,18 @@ SDispatchResult CKeybindManager::fullscreenStateActive(std::string args) {
     const SFullscreenState STATE = SFullscreenState{.internal = (internalMode != -1 ? sc<eFullscreenMode>(internalMode) : PWINDOW->m_fullscreenState.internal),
                                                     .client   = (clientMode != -1 ? sc<eFullscreenMode>(clientMode) : PWINDOW->m_fullscreenState.client)};
 
-    if (internalMode != -1 && clientMode != -1 && PWINDOW->m_fullscreenState.internal == STATE.internal && PWINDOW->m_fullscreenState.client == STATE.client)
-        g_pCompositor->setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = FSMODE_NONE, .client = FSMODE_NONE});
-    else if (internalMode != -1 && clientMode == -1 && PWINDOW->m_fullscreenState.internal == STATE.internal)
-        g_pCompositor->setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = FSMODE_NONE, .client = PWINDOW->m_fullscreenState.client});
-    else if (internalMode == -1 && clientMode != -1 && PWINDOW->m_fullscreenState.client == STATE.client)
-        g_pCompositor->setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = PWINDOW->m_fullscreenState.internal, .client = FSMODE_NONE});
-    else
+    if (ARGS.size() <= 2 || ARGS[2] == "toggle") {
+        if (internalMode != -1 && clientMode != -1 && PWINDOW->m_fullscreenState.internal == STATE.internal && PWINDOW->m_fullscreenState.client == STATE.client)
+            g_pCompositor->setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = FSMODE_NONE, .client = FSMODE_NONE});
+        else if (internalMode != -1 && clientMode == -1 && PWINDOW->m_fullscreenState.internal == STATE.internal)
+            g_pCompositor->setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = FSMODE_NONE, .client = PWINDOW->m_fullscreenState.client});
+        else if (internalMode == -1 && clientMode != -1 && PWINDOW->m_fullscreenState.client == STATE.client)
+            g_pCompositor->setWindowFullscreenState(PWINDOW, SFullscreenState{.internal = PWINDOW->m_fullscreenState.internal, .client = FSMODE_NONE});
+        else
+            g_pCompositor->setWindowFullscreenState(PWINDOW, STATE);
+    } else if (ARGS[2] == "set") {
         g_pCompositor->setWindowFullscreenState(PWINDOW, STATE);
+    }
 
     PWINDOW->m_windowData.syncFullscreen = CWindowOverridableVar(PWINDOW->m_fullscreenState.internal == PWINDOW->m_fullscreenState.client, PRIORITY_SET_PROP);
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1324,12 +1324,12 @@ SDispatchResult CKeybindManager::fullscreenActive(std::string args) {
         else
             g_pCompositor->setWindowFullscreenInternal(PWINDOW, MODE);
     } else {
-        if (ARGS[1] == "set") 
+        if (ARGS[1] == "set")
             g_pCompositor->setWindowFullscreenInternal(PWINDOW, MODE);
         else if (ARGS[1] == "unset")
             g_pCompositor->setWindowFullscreenInternal(PWINDOW, FSMODE_NONE);
     }
-    
+
     return {};
 }
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -28,6 +28,7 @@
 #include <cstring>
 
 #include <hyprutils/string/String.hpp>
+#include <hyprutils/string/ConstVarList.hpp>
 #include <hyprutils/os/FileDescriptor.hpp>
 using namespace Hyprutils::String;
 using namespace Hyprutils::OS;
@@ -1310,7 +1311,7 @@ SDispatchResult CKeybindManager::changeworkspace(std::string args) {
 
 SDispatchResult CKeybindManager::fullscreenActive(std::string args) {
     const auto PWINDOW = g_pCompositor->m_lastWindow.lock();
-    const auto ARGS    = CVarList(args, 2, ' ');
+    const auto ARGS    = CConstVarList(args, 2, ' ');
 
     if (!PWINDOW)
         return {.success = false, .error = "Window not found"};
@@ -1323,11 +1324,10 @@ SDispatchResult CKeybindManager::fullscreenActive(std::string args) {
         else
             g_pCompositor->setWindowFullscreenInternal(PWINDOW, MODE);
     } else {
-        if (ARGS[1] == "set") {
+        if (ARGS[1] == "set") 
             g_pCompositor->setWindowFullscreenInternal(PWINDOW, MODE);
-        } else if (ARGS[1] == "unset") {
+        else if (ARGS[1] == "unset")
             g_pCompositor->setWindowFullscreenInternal(PWINDOW, FSMODE_NONE);
-        }
     }
     
     return {};


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
I noticed that some dispatchers for fullscreen were missing. In particular it wasn't possible to set or unset the fullscreen mode without toggling it. To add that feature, I renamed `fullscreen` to `togglefullscreen` and `fullscreenstate` to `togglefullscreenstate`. I then added 3 new dispatchers:
 - `setfullscreen`: set fullscreen or maximize mode
 - `unsetfullscreen`: unset fullscreen or maximize mode only if it's currently enabled
 - `setfullscreenstate`: set the specified internal and client fullscreen state
 
A typical use case would be using the gestures to trigger only set/unset of fullscreen:
```
gesture = 3, down, unsetfullscreen
gesture = 3, up, setfullscreen
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I tested the feature and I didn't notice any problems.


#### Is it ready for merging, or does it need work?
I created multiple dispatchers, maybe I should've added a parameter instead. I don't know what the Hyprland team prefers. Additionally, I repeated some code without refactoring the common parts, although I’m not sure if it’s worth it.