### PR TITLE
CM without shader settings

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1524,6 +1524,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .type        = CONFIG_OPTION_BOOL,
         .data        = SConfigOptionDescription::SBoolData{false},
     },
+    SConfigOptionDescription{
+        .value       = "render:non_shader_cm",
+        .description = "Enable CM without shader. 0 - disable, 1 - whenever possible, 2 - DS and passthrough only, 3 - don't block DS when non-shader CM isn't available",
+        .type        = CONFIG_OPTION_CHOICE,
+        .data        = SConfigOptionDescription::SChoiceData{0, "disable,always,ondemand,ignore"},
+    },
 
     /*
      * cursor:

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -777,6 +777,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("render:send_content_type", Hyprlang::INT{1});
     registerConfigVar("render:cm_auto_hdr", Hyprlang::INT{1});
     registerConfigVar("render:new_render_scheduling", Hyprlang::INT{0});
+    registerConfigVar("render:non_shader_cm", Hyprlang::INT{2});
 
     registerConfigVar("ecosystem:no_update_news", Hyprlang::INT{0});
     registerConfigVar("ecosystem:no_donation_nag", Hyprlang::INT{0});

--- a/src/protocols/types/ColorManagement.hpp
+++ b/src/protocols/types/ColorManagement.hpp
@@ -11,6 +11,13 @@
 #define HLG_MAX_LUMINANCE 1000.0
 
 namespace NColorManagement {
+    enum eNoShader : uint8_t {
+        CM_NS_DISABLE  = 0,
+        CM_NS_ALWAYS   = 1,
+        CM_NS_ONDEMAND = 2,
+        CM_NS_IGNORE   = 3,
+    };
+
     enum ePrimaries : uint8_t {
         CM_PRIMARIES_SRGB         = 1,
         CM_PRIMARIES_PAL_M        = 2,

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1483,9 +1483,10 @@ static hdr_output_metadata       createHDRMetadata(SImageDescription settings, S
 }
 
 bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
-    static auto PCT      = CConfigValue<Hyprlang::INT>("render:send_content_type");
-    static auto PPASS    = CConfigValue<Hyprlang::INT>("render:cm_fs_passthrough");
-    static auto PAUTOHDR = CConfigValue<Hyprlang::INT>("render:cm_auto_hdr");
+    static auto PCT        = CConfigValue<Hyprlang::INT>("render:send_content_type");
+    static auto PPASS      = CConfigValue<Hyprlang::INT>("render:cm_fs_passthrough");
+    static auto PAUTOHDR   = CConfigValue<Hyprlang::INT>("render:cm_auto_hdr");
+    static auto PNONSHADER = CConfigValue<Hyprlang::INT>("render:non_shader_cm");
 
     static bool needsHDRupdate = false;
 
@@ -1570,7 +1571,7 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
         pMonitor->m_output->state->setContentType(NContentType::toDRM(FS_WINDOW ? FS_WINDOW->getContentType() : CONTENT_TYPE_NONE));
 
     if (FS_WINDOW != pMonitor->m_previousFSWindow) {
-        if (!FS_WINDOW || !pMonitor->needsCM() || !pMonitor->canNoShaderCM()) {
+        if (!FS_WINDOW || !pMonitor->needsCM() || !pMonitor->canNoShaderCM() || (*PNONSHADER == CM_NS_ONDEMAND && pMonitor->m_lastScanout.expired() && *PPASS != 1)) {
             if (pMonitor->m_noShaderCTM) {
                 Debug::log(INFO, "[CM] No fullscreen CTM, restoring previous one");
                 pMonitor->m_noShaderCTM = false;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds `render:non_shader_cm` to control CM without shader. 
0 - disable 
1 - whenever possible (current without this PR, best for performance and lower power consumption)
2 - DS and passthrough only (default, better compatibility with external CTM and gamma control tools)
3 - don't block DS when non-shader CM isn't available

Fixes a crash when cm is disabled and monitor has some cm value set.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
https://github.com/hyprwm/hyprsunset/issues/61 should use `render:non_shader_cm = 0` or `render:non_shader_cm = 2` with disabled DS and passthrough.

#### Is it ready for merging, or does it need work?
Ready