### PR TITLE
dispatchers: add forceidle

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -4,6 +4,7 @@
 #include "../protocols/LayerShell.hpp"
 #include "../protocols/ShortcutsInhibit.hpp"
 #include "../protocols/GlobalShortcuts.hpp"
+#include "../protocols/IdleNotify.hpp"
 #include "../protocols/core/DataDevice.hpp"
 #include "../render/decorations/CHyprGroupBarDecoration.hpp"
 #include "KeybindManager.hpp"
@@ -142,6 +143,7 @@ CKeybindManager::CKeybindManager() {
     m_dispatchers["event"]                          = event;
     m_dispatchers["global"]                         = global;
     m_dispatchers["setprop"]                        = setProp;
+    m_dispatchers["forceidle"]                      = forceIdle;
 
     m_scrollTimer.reset();
 
@@ -3238,6 +3240,19 @@ SDispatchResult CKeybindManager::setProp(std::string args) {
 
     for (auto const& m : g_pCompositor->m_monitors)
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m->m_id);
+
+    return {};
+}
+
+SDispatchResult CKeybindManager::forceIdle(std::string args) {
+    std::optional<float> duration = getPlusMinusKeywordResult(args, 0);
+
+    if (!duration.has_value()) {
+        Debug::log(ERR, "Duration invalid in forceIdle!");
+        return {.success = false, .error = "Duration invalid in forceIdle!"};
+    }
+
+    PROTO::idle->setTimers(duration.value() * 1000.0);
 
     return {};
 }

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -229,6 +229,7 @@ class CKeybindManager {
     static SDispatchResult global(std::string);
     static SDispatchResult event(std::string);
     static SDispatchResult setProp(std::string);
+    static SDispatchResult forceIdle(std::string);
 
     friend class CCompositor;
     friend class CInputManager;

--- a/src/protocols/IdleNotify.cpp
+++ b/src/protocols/IdleNotify.cpp
@@ -21,7 +21,7 @@ CExtIdleNotification::CExtIdleNotification(SP<CExtIdleNotificationV1> resource_,
     m_timer = makeShared<CEventLoopTimer>(std::nullopt, onTimer, this);
     g_pEventLoopManager->addTimer(m_timer);
 
-    updateTimer();
+    update();
 
     LOGM(LOG, "Registered idle-notification for {}ms", timeoutMs_);
 }
@@ -35,24 +35,39 @@ bool CExtIdleNotification::good() {
     return m_resource->resource();
 }
 
-void CExtIdleNotification::updateTimer() {
-    if (PROTO::idle->isInhibited && m_obeyInhibitors)
-        m_timer->updateTimeout(std::nullopt);
-    else
-        m_timer->updateTimeout(std::chrono::milliseconds(m_timeoutMs));
+void CExtIdleNotification::update(uint32_t elapsedMs) {
+    m_timer->updateTimeout(std::nullopt);
+
+    if (elapsedMs == 0 && PROTO::idle->isInhibited && m_obeyInhibitors) {
+        reset();
+        return;
+    }
+
+    if (m_timeoutMs > elapsedMs) {
+        reset();
+        m_timer->updateTimeout(std::chrono::milliseconds(m_timeoutMs - elapsedMs));
+    } else
+        onTimerFired();
+}
+
+void CExtIdleNotification::update() {
+    update(0);
 }
 
 void CExtIdleNotification::onTimerFired() {
+    if (m_idled)
+        return;
+
     m_resource->sendIdled();
     m_idled = true;
 }
 
-void CExtIdleNotification::onActivity() {
-    if (m_idled)
-        m_resource->sendResumed();
+void CExtIdleNotification::reset() {
+    if (!m_idled)
+        return;
 
+    m_resource->sendResumed();
     m_idled = false;
-    updateTimer();
 }
 
 bool CExtIdleNotification::inhibitorsAreObeyed() const {
@@ -96,7 +111,7 @@ void CIdleNotifyProtocol::onGetNotification(CExtIdleNotifierV1* pMgr, uint32_t i
 
 void CIdleNotifyProtocol::onActivity() {
     for (auto const& n : m_notifications) {
-        n->onActivity();
+        n->update();
     }
 }
 
@@ -104,6 +119,12 @@ void CIdleNotifyProtocol::setInhibit(bool inhibited) {
     isInhibited = inhibited;
     for (auto const& n : m_notifications) {
         if (n->inhibitorsAreObeyed())
-            n->onActivity();
+            n->update();
+    }
+}
+
+void CIdleNotifyProtocol::setTimers(uint32_t elapsedMs) {
+    for (auto const& n : m_notifications) {
+        n->update(elapsedMs);
     }
 }

--- a/src/protocols/IdleNotify.hpp
+++ b/src/protocols/IdleNotify.hpp
@@ -14,7 +14,6 @@ class CExtIdleNotification {
 
     bool good();
     void onTimerFired();
-    void onActivity();
 
     bool inhibitorsAreObeyed() const;
 
@@ -26,7 +25,11 @@ class CExtIdleNotification {
     bool                       m_idled          = false;
     bool                       m_obeyInhibitors = false;
 
-    void                       updateTimer();
+    void                       reset();
+    void                       update();
+    void                       update(uint32_t elapsedMs);
+
+    friend class CIdleNotifyProtocol;
 };
 
 class CIdleNotifyProtocol : public IWaylandProtocol {
@@ -37,6 +40,7 @@ class CIdleNotifyProtocol : public IWaylandProtocol {
 
     void         onActivity();
     void         setInhibit(bool inhibited);
+    void         setTimers(uint32_t elapsedMs);
 
   private:
     void onManagerResourceDestroy(wl_resource* res);


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

The `forceidle` dispatcher resets all ext-idle-notify timers as if the user had
already been idle for the specified number of seconds. If a notification has
already fired, but would now be set with a nonzero delay, then it is reset.
Conversely, if a timer has not yet fired, but would now be set to a nonpositive
delay, then it is immediately fired. This process ignores any existing
inhibitors, but timers are otherwise reset as normal if any new inhibitors are
created or destroyed.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

A small refactor of how ext-idle-notify timers was necessary for this, but, in
my opinion, it makes the code better and more robust.

As with the `dpms` dispatcher, this should not be set with a keybind directly.

I don't use any idle inhibitors on my system, so I think more testing might be
good on that front. The way that `forceidle` v. inhibitors is resolved on a
recency basis might be a bit weird, but doing anything else felt unnecessarily
complicated (I did experiment with it, but ultimately decided against it).
Overall, the one weird piece of behavior here is where removing an inhibitor
will reset a timer that was set by `forceidle`, but I think this can be fixed if
desired.


#### Is it ready for merging, or does it need work?

Other than code review (obviously) and maybe some testing with inhibitors, it
should be ready for merging.
