### PR TITLE
debug: fix data race in Debug::log()

### DIFF
--- a/src/debug/Log.cpp
+++ b/src/debug/Log.cpp
@@ -26,7 +26,7 @@ void Debug::log(eLogLevel level, std::string str) {
 
     std::lock_guard<std::mutex> guard(m_logMutex);
 
-    std::string coloredStr = str;
+    std::string                 coloredStr = str;
     //NOLINTBEGIN
     switch (level) {
         case LOG:

--- a/src/debug/Log.cpp
+++ b/src/debug/Log.cpp
@@ -24,6 +24,8 @@ void Debug::log(eLogLevel level, std::string str) {
     if (m_shuttingDown)
         return;
 
+    std::lock_guard<std::mutex> guard(m_logMutex);
+
     std::string coloredStr = str;
     //NOLINTBEGIN
     switch (level) {

--- a/src/debug/Log.hpp
+++ b/src/debug/Log.hpp
@@ -42,8 +42,6 @@ namespace Debug {
     template <typename... Args>
     //NOLINTNEXTLINE
     void log(eLogLevel level, std::format_string<Args...> fmt, Args&&... args) {
-        std::lock_guard<std::mutex> guard(m_logMutex);
-
         if (level == TRACE && !m_trace)
             return;
 


### PR DESCRIPTION
Fixes a data race in the logging system that causes crashes when plugins use background threads.

**The issue:**

The templated `Debug::log(eLogLevel, fmt, args...)` locks `m_logMutex` and calls the non-templated `Debug::log(eLogLevel, std::string)`, but the non-templated version doesn't lock anything. This causes crashes when background threads (like in hypr-dynamic-cursors) call `Debug::log()` while the main thread is also logging.

**The fix:**

Added a private `logImpl()` that does the actual logging work, with both public `log()` entry points handling the locking. This uses a regular mutex instead of recursive_mutex and avoids duplicate checks.

Fixes: #11929
Fixes: VirtCode/hypr-dynamic-cursors#99

See also: https://github.com/hyprwm/Hyprland/discussions/11930