### PR TITLE
input: add option to rotate device input

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -479,6 +479,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SBoolData{false},
     },
     SConfigOptionDescription{
+        .value       = "input:rotation",
+        .description = "Sets the rotation of a device in degrees clockwise off the logical neutral position. Value is clamped to the range 0 to 359.",
+        .type        = CONFIG_OPTION_INT,
+        .data        = SConfigOptionDescription::SRangeData{0, 0, 359},
+    },
+    SConfigOptionDescription{
         .value       = "input:left_handed",
         .description = "Switches RMB and LMB",
         .type        = CONFIG_OPTION_BOOL,

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -654,6 +654,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("input:off_window_axis_events", Hyprlang::INT{1});
     registerConfigVar("input:sensitivity", {0.f});
     registerConfigVar("input:accel_profile", {STRVAL_EMPTY});
+    registerConfigVar("input:rotation", Hyprlang::INT{0});
     registerConfigVar("input:kb_file", {STRVAL_EMPTY});
     registerConfigVar("input:kb_layout", {"us"});
     registerConfigVar("input:kb_variant", {STRVAL_EMPTY});
@@ -789,6 +790,7 @@ CConfigManager::CConfigManager() {
     m_config->addSpecialCategory("device", {"name"});
     m_config->addSpecialConfigValue("device", "sensitivity", {0.F});
     m_config->addSpecialConfigValue("device", "accel_profile", {STRVAL_EMPTY});
+    m_config->addSpecialConfigValue("device", "rotation", Hyprlang::INT{0});
     m_config->addSpecialConfigValue("device", "kb_file", {STRVAL_EMPTY});
     m_config->addSpecialConfigValue("device", "kb_layout", {"us"});
     m_config->addSpecialConfigValue("device", "kb_variant", {STRVAL_EMPTY});

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1279,6 +1279,11 @@ void CInputManager::setPointerConfigs() {
             const auto LIBINPUTSENS = std::clamp(g_pConfigManager->getDeviceFloat(devname, "sensitivity", "input:sensitivity"), -1.f, 1.f);
             libinput_device_config_accel_set_speed(LIBINPUTDEV, LIBINPUTSENS);
 
+            if (libinput_device_config_rotation_is_available(LIBINPUTDEV)) {
+                const auto ROTATION = std::clamp(g_pConfigManager->getDeviceInt(devname, "rotation", "input:rotation"), 0, 359);
+                libinput_device_config_rotation_set_angle(LIBINPUTDEV, ROTATION);
+            }
+
             m->m_flipX = g_pConfigManager->getDeviceInt(devname, "flip_x", "input:touchpad:flip_x") != 0;
             m->m_flipY = g_pConfigManager->getDeviceInt(devname, "flip_y", "input:touchpad:flip_y") != 0;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Adds the option to set the rotation of an input device that supports it. The implementation just uses libinput to [check](https://wayland.freedesktop.org/libinput/doc/latest/api/group__config.html#ga2fab82b2ba0cac9a645c1ce8e32df448) if rotation is available for the input device and then [sets](https://wayland.freedesktop.org/libinput/doc/latest/api/group__config.html#ga136b2f7753235c5d2a9fb2762a040eef) the rotation.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Corresponding Wiki PR [#1248](https://github.com/hyprwm/hyprland-wiki/pull/1248)

#### Is it ready for merging, or does it need work?

Should be ready for merging.


