### PR TITLE
make wl_surface::frame follow pending states

### DIFF
--- a/src/protocols/core/Compositor.hpp
+++ b/src/protocols/core/Compositor.hpp
@@ -33,17 +33,6 @@ class CColorManagementSurface;
 class CFrogColorManagementSurface;
 class CContentType;
 
-class CWLCallbackResource {
-  public:
-    CWLCallbackResource(UP<CWlCallback>&& resource_);
-
-    bool good();
-    void send(const Time::steady_tp& now);
-
-  private:
-    UP<CWlCallback> m_resource;
-};
-
 class CWLRegionResource {
   public:
     CWLRegionResource(SP<CWlRegion> resource_);
@@ -95,7 +84,6 @@ class CWLSurfaceResource {
     SSurfaceState                          m_pending;
     std::queue<UP<SSurfaceState>>          m_pendingStates;
 
-    std::vector<UP<CWLCallbackResource>>   m_callbacks;
     WP<CWLSurfaceResource>                 m_self;
     WP<CWLSurface>                         m_hlSurface;
     std::vector<PHLMONITORREF>             m_enteredOutputs;

--- a/src/protocols/core/Compositor.hpp
+++ b/src/protocols/core/Compositor.hpp
@@ -33,6 +33,25 @@ class CColorManagementSurface;
 class CFrogColorManagementSurface;
 class CContentType;
 
+class CWLCallbackResource {
+  public:
+    CWLCallbackResource(SP<CWlCallback>&& resource_);
+    ~CWLCallbackResource() noexcept = default;
+    // disable copy
+    CWLCallbackResource(const CWLCallbackResource&)            = delete;
+    CWLCallbackResource& operator=(const CWLCallbackResource&) = delete;
+
+    // allow move
+    CWLCallbackResource(CWLCallbackResource&&) noexcept            = default;
+    CWLCallbackResource& operator=(CWLCallbackResource&&) noexcept = default;
+
+    bool                 good();
+    void                 send(const Time::steady_tp& now);
+
+  private:
+    SP<CWlCallback> m_resource;
+};
+
 class CWLRegionResource {
   public:
     CWLRegionResource(SP<CWlRegion> resource_);

--- a/src/protocols/core/Compositor.hpp
+++ b/src/protocols/core/Compositor.hpp
@@ -102,6 +102,7 @@ class CWLSurfaceResource {
     SSurfaceState                          m_current;
     SSurfaceState                          m_pending;
     std::queue<UP<SSurfaceState>>          m_pendingStates;
+    bool                                   m_pendingWaiting = false;
 
     WP<CWLSurfaceResource>                 m_self;
     WP<CWLSurface>                         m_hlSurface;
@@ -117,6 +118,7 @@ class CWLSurfaceResource {
     SP<CWLSurfaceResource>                 findFirstPreorder(std::function<bool(SP<CWLSurfaceResource>)> fn);
     SP<CWLSurfaceResource>                 findWithCM();
     void                                   presentFeedback(const Time::steady_tp& when, PHLMONITOR pMonitor, bool discarded = false);
+    void                                   scheduleState(WP<SSurfaceState> state);
     void                                   commitState(SSurfaceState& state);
     NColorManagement::SImageDescription    getPreferredImageDescription();
     void                                   sortSubsurfaces();

--- a/src/protocols/types/SurfaceState.cpp
+++ b/src/protocols/types/SurfaceState.cpp
@@ -3,22 +3,6 @@
 #include "protocols/types/Buffer.hpp"
 #include "render/Texture.hpp"
 
-SSurfaceStateFrameCB::SSurfaceStateFrameCB(SP<CWlCallback>&& resource_) : m_resource(std::move(resource_)) {
-    ;
-}
-
-bool SSurfaceStateFrameCB::good() {
-    return m_resource && m_resource->resource();
-}
-
-void SSurfaceStateFrameCB::send(const Time::steady_tp& now) {
-    if (!good())
-        return;
-
-    m_resource->sendDone(Time::millis(now));
-    m_resource.reset();
-}
-
 Vector2D SSurfaceState::sourceSize() {
     if UNLIKELY (!texture)
         return {};

--- a/src/protocols/types/SurfaceState.cpp
+++ b/src/protocols/types/SurfaceState.cpp
@@ -93,6 +93,10 @@ void SSurfaceState::updateFrom(SSurfaceState& ref) {
     if (ref.updated.bits.damage) {
         damage       = ref.damage;
         bufferDamage = ref.bufferDamage;
+    } else {
+        // damage is always relative to the current commit
+        damage.clear();
+        bufferDamage.clear();
     }
 
     if (ref.updated.bits.input)

--- a/src/protocols/types/SurfaceState.cpp
+++ b/src/protocols/types/SurfaceState.cpp
@@ -3,6 +3,22 @@
 #include "protocols/types/Buffer.hpp"
 #include "render/Texture.hpp"
 
+SSurfaceStateFrameCB::SSurfaceStateFrameCB(SP<CWlCallback>&& resource_) : m_resource(std::move(resource_)) {
+    ;
+}
+
+bool SSurfaceStateFrameCB::good() {
+    return m_resource && m_resource->resource();
+}
+
+void SSurfaceStateFrameCB::send(const Time::steady_tp& now) {
+    if (!good())
+        return;
+
+    m_resource->sendDone(Time::millis(now));
+    m_resource.reset();
+}
+
 Vector2D SSurfaceState::sourceSize() {
     if UNLIKELY (!texture)
         return {};
@@ -60,6 +76,8 @@ void SSurfaceState::reset() {
     // wl_surface.commit assigns pending ... and clears pending damage.
     damage.clear();
     bufferDamage.clear();
+
+    callbacks.clear();
 }
 
 void SSurfaceState::updateFrom(SSurfaceState& ref) {
@@ -100,4 +118,9 @@ void SSurfaceState::updateFrom(SSurfaceState& ref) {
 
     if (ref.updated.bits.acked)
         ackedSize = ref.ackedSize;
+
+    if (ref.updated.bits.frame) {
+        callbacks.insert(callbacks.end(), std::make_move_iterator(ref.callbacks.begin()), std::make_move_iterator(ref.callbacks.end()));
+        ref.callbacks.clear();
+    }
 }

--- a/src/protocols/types/SurfaceState.hpp
+++ b/src/protocols/types/SurfaceState.hpp
@@ -3,29 +3,10 @@
 #include "../../helpers/math/Math.hpp"
 #include "../WaylandProtocol.hpp"
 #include "./Buffer.hpp"
-#include "helpers/time/Time.hpp"
 
 class CTexture;
 class CDRMSyncPointState;
-
-struct SSurfaceStateFrameCB {
-  public:
-    SSurfaceStateFrameCB(SP<CWlCallback>&& resource_);
-    ~SSurfaceStateFrameCB() noexcept = default;
-    // disable copy
-    SSurfaceStateFrameCB(const SSurfaceStateFrameCB&)            = delete;
-    SSurfaceStateFrameCB& operator=(const SSurfaceStateFrameCB&) = delete;
-
-    // allow move
-    SSurfaceStateFrameCB(SSurfaceStateFrameCB&&) noexcept            = default;
-    SSurfaceStateFrameCB& operator=(SSurfaceStateFrameCB&&) noexcept = default;
-
-    bool                  good();
-    void                  send(const Time::steady_tp& now);
-
-  private:
-    SP<CWlCallback> m_resource;
-};
+class CWLCallbackResource;
 
 struct SSurfaceState {
     union {
@@ -60,9 +41,10 @@ struct SSurfaceState {
     Vector2D offset;
 
     // for xdg_shell resizing
-    Vector2D                              ackedSize;
+    Vector2D ackedSize;
 
-    std::vector<SP<SSurfaceStateFrameCB>> callbacks;
+    // for wl_surface::frame callbacks.
+    std::vector<SP<CWLCallbackResource>> callbacks;
 
     // viewporter protocol surface state
     struct {

--- a/src/render/Texture.cpp
+++ b/src/render/Texture.cpp
@@ -111,6 +111,9 @@ void CTexture::createFromDma(const Aquamarine::SDMABUFAttrs& attrs, void* image)
 }
 
 void CTexture::update(uint32_t drmFormat, uint8_t* pixels, uint32_t stride, const CRegion& damage) {
+    if (damage.empty())
+        return;
+
     g_pHyprRenderer->makeEGLCurrent();
 
     const auto format = NFormatUtils::getPixelFormatFromDRM(drmFormat);


### PR DESCRIPTION
same as #11896 only clear callbacks on m_pending.reset() so they dont pile up.

