### PR TITLE
buffer: move texture creation to commit time

### DIFF
--- a/src/protocols/LinuxDMABUF.cpp
+++ b/src/protocols/LinuxDMABUF.cpp
@@ -103,9 +103,6 @@ CLinuxDMABuffer::CLinuxDMABuffer(uint32_t id, wl_client* client, Aquamarine::SDM
         m_listeners.bufferResourceDestroy.reset();
         PROTO::linuxDma->destroyResource(this);
     });
-
-    if (!m_buffer->m_success)
-        LOGM(ERR, "Possibly compositor bug: buffer failed to create");
 }
 
 CLinuxDMABuffer::~CLinuxDMABuffer() {
@@ -217,7 +214,7 @@ void CLinuxDMABUFParamsResource::create(uint32_t id) {
 
     auto& buf = PROTO::linuxDma->m_buffers.emplace_back(makeUnique<CLinuxDMABuffer>(id, m_resource->client(), *m_attrs));
 
-    if UNLIKELY (!buf->good() || !buf->m_buffer->m_success) {
+    if UNLIKELY (!buf->good()) {
         m_resource->sendFailed();
         PROTO::linuxDma->m_buffers.pop_back();
         return;

--- a/src/protocols/MesaDRM.cpp
+++ b/src/protocols/MesaDRM.cpp
@@ -18,9 +18,6 @@ CMesaDRMBufferResource::CMesaDRMBufferResource(uint32_t id, wl_client* client, A
         m_listeners.bufferResourceDestroy.reset();
         PROTO::mesaDRM->destroyResource(this);
     });
-
-    if (!m_buffer->m_success)
-        LOGM(ERR, "Possibly compositor bug: buffer failed to create");
 }
 
 CMesaDRMBufferResource::~CMesaDRMBufferResource() {

--- a/src/protocols/SinglePixel.cpp
+++ b/src/protocols/SinglePixel.cpp
@@ -50,11 +50,15 @@ void CSinglePixelBuffer::endDataPtr() {
     ;
 }
 
-void CSinglePixelBuffer::createTexture() {
-    m_texture = makeShared<CTexture>(DRM_FORMAT_ARGB8888, rc<uint8_t*>(&m_color), 4, Vector2D{1, 1});
-    m_success = m_texture->m_texID;
-    if (!m_success)
+SP<CTexture> CSinglePixelBuffer::createTexture() {
+    auto tex = makeShared<CTexture>(DRM_FORMAT_ARGB8888, rc<uint8_t*>(&m_color), 4, Vector2D{1, 1});
+
+    if (!tex->m_texID) {
         Debug::log(ERR, "Failed creating a single pixel texture: null texture id");
+        return nullptr;
+    }
+
+    return tex;
 }
 
 bool CSinglePixelBuffer::good() {

--- a/src/protocols/SinglePixel.cpp
+++ b/src/protocols/SinglePixel.cpp
@@ -12,16 +12,9 @@ CSinglePixelBuffer::CSinglePixelBuffer(uint32_t id, wl_client* client, CHyprColo
 
     m_opaque = col_.a >= 1.F;
 
-    m_texture = makeShared<CTexture>(DRM_FORMAT_ARGB8888, rc<uint8_t*>(&m_color), 4, Vector2D{1, 1});
-
     m_resource = CWLBufferResource::create(makeShared<CWlBuffer>(client, 1, id));
 
-    m_success = m_texture->m_texID;
-
     size = {1, 1};
-
-    if (!m_success)
-        Debug::log(ERR, "Failed creating a single pixel texture: null texture id");
 }
 
 CSinglePixelBuffer::~CSinglePixelBuffer() {
@@ -55,6 +48,13 @@ std::tuple<uint8_t*, uint32_t, size_t> CSinglePixelBuffer::beginDataPtr(uint32_t
 
 void CSinglePixelBuffer::endDataPtr() {
     ;
+}
+
+void CSinglePixelBuffer::createTexture() {
+    m_texture = makeShared<CTexture>(DRM_FORMAT_ARGB8888, rc<uint8_t*>(&m_color), 4, Vector2D{1, 1});
+    m_success = m_texture->m_texID;
+    if (!m_success)
+        Debug::log(ERR, "Failed creating a single pixel texture: null texture id");
 }
 
 bool CSinglePixelBuffer::good() {

--- a/src/protocols/SinglePixel.hpp
+++ b/src/protocols/SinglePixel.hpp
@@ -18,6 +18,7 @@ class CSinglePixelBuffer : public IHLBuffer {
     virtual Aquamarine::SDMABUFAttrs               dmabuf();
     virtual std::tuple<uint8_t*, uint32_t, size_t> beginDataPtr(uint32_t flags);
     virtual void                                   endDataPtr();
+    virtual void                                   createTexture();
     //
     bool good();
     bool m_success = false;

--- a/src/protocols/SinglePixel.hpp
+++ b/src/protocols/SinglePixel.hpp
@@ -18,7 +18,7 @@ class CSinglePixelBuffer : public IHLBuffer {
     virtual Aquamarine::SDMABUFAttrs               dmabuf();
     virtual std::tuple<uint8_t*, uint32_t, size_t> beginDataPtr(uint32_t flags);
     virtual void                                   endDataPtr();
-    virtual void                                   createTexture();
+    virtual SP<CTexture>                           createTexture();
     //
     bool good();
     bool m_success = false;

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -526,8 +526,8 @@ void CWLSurfaceResource::commitState(SSurfaceState& state) {
     if (m_current.buffer) {
         if (m_current.buffer->isSynchronous())
             m_current.updateSynchronousTexture(lastTexture);
-        else
-            m_current.updateAsyncSynchronousTexture();
+        else if (!m_current.buffer->isSynchronous() && state.updated.bits.buffer) // only get a new texture when a new buffer arrived
+            m_current.texture = m_current.buffer->createTexture();
 
         // if the surface is a cursor, update the shm buffer
         // TODO: don't update the entire texture

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -91,12 +91,10 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
 
         if (buf && buf->m_buffer) {
             m_pending.buffer     = CHLBufferReference(buf->m_buffer.lock());
-            m_pending.texture    = buf->m_buffer->m_texture;
             m_pending.size       = buf->m_buffer->size;
             m_pending.bufferSize = buf->m_buffer->size;
         } else {
-            m_pending.buffer = {};
-            m_pending.texture.reset();
+            m_pending.buffer     = {};
             m_pending.size       = Vector2D{};
             m_pending.bufferSize = Vector2D{};
         }
@@ -132,7 +130,7 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
         }
 
         // null buffer attached
-        if (!m_pending.buffer && !m_pending.texture && m_pending.updated.bits.buffer) {
+        if (!m_pending.buffer && m_pending.updated.bits.buffer) {
             commitState(m_pending);
 
             // remove any pending states.
@@ -528,6 +526,8 @@ void CWLSurfaceResource::commitState(SSurfaceState& state) {
     if (m_current.buffer) {
         if (m_current.buffer->isSynchronous())
             m_current.updateSynchronousTexture(lastTexture);
+        else
+            m_current.updateAsyncSynchronousTexture();
 
         // if the surface is a cursor, update the shm buffer
         // TODO: don't update the entire texture

--- a/src/protocols/core/Shm.cpp
+++ b/src/protocols/core/Shm.cpp
@@ -69,8 +69,8 @@ void CWLSHMBuffer::endDataPtr() {
     ;
 }
 
-void CWLSHMBuffer::createTexture() {
-    ;
+SP<CTexture> CWLSHMBuffer::createTexture() {
+    return nullptr;
 }
 
 bool CWLSHMBuffer::good() {

--- a/src/protocols/core/Shm.cpp
+++ b/src/protocols/core/Shm.cpp
@@ -69,6 +69,10 @@ void CWLSHMBuffer::endDataPtr() {
     ;
 }
 
+void CWLSHMBuffer::createTexture() {
+    ;
+}
+
 bool CWLSHMBuffer::good() {
     return true;
 }

--- a/src/protocols/core/Shm.hpp
+++ b/src/protocols/core/Shm.hpp
@@ -43,6 +43,7 @@ class CWLSHMBuffer : public IHLBuffer {
     virtual Aquamarine::SSHMAttrs                  shm();
     virtual std::tuple<uint8_t*, uint32_t, size_t> beginDataPtr(uint32_t flags);
     virtual void                                   endDataPtr();
+    virtual void                                   createTexture();
 
     bool                                           good();
 

--- a/src/protocols/core/Shm.hpp
+++ b/src/protocols/core/Shm.hpp
@@ -43,7 +43,7 @@ class CWLSHMBuffer : public IHLBuffer {
     virtual Aquamarine::SSHMAttrs                  shm();
     virtual std::tuple<uint8_t*, uint32_t, size_t> beginDataPtr(uint32_t flags);
     virtual void                                   endDataPtr();
-    virtual void                                   createTexture();
+    virtual SP<CTexture>                           createTexture();
 
     bool                                           good();
 

--- a/src/protocols/types/Buffer.hpp
+++ b/src/protocols/types/Buffer.hpp
@@ -22,12 +22,11 @@ class IHLBuffer : public Aquamarine::IBuffer {
     virtual void                          lock();
     virtual void                          unlock();
     virtual bool                          locked();
-    virtual void                          createTexture() = 0;
+    virtual SP<CTexture>                  createTexture() = 0;
 
     void                                  onBackendRelease(const std::function<void()>& fn);
     void                                  addReleasePoint(CDRMSyncPointState& point);
 
-    SP<CTexture>                          m_texture;
     bool                                  m_opaque = false;
     SP<CWLBufferResource>                 m_resource;
     std::vector<UP<CSyncReleaser>>        m_syncReleasers;
@@ -39,7 +38,6 @@ class IHLBuffer : public Aquamarine::IBuffer {
 
   private:
     int                   m_locks = 0;
-
     std::function<void()> m_backendReleaseQueuedFn;
 
     friend class CHLBufferReference;

--- a/src/protocols/types/Buffer.hpp
+++ b/src/protocols/types/Buffer.hpp
@@ -22,6 +22,7 @@ class IHLBuffer : public Aquamarine::IBuffer {
     virtual void                          lock();
     virtual void                          unlock();
     virtual bool                          locked();
+    virtual void                          createTexture() = 0;
 
     void                                  onBackendRelease(const std::function<void()>& fn);
     void                                  addReleasePoint(CDRMSyncPointState& point);

--- a/src/protocols/types/DMABuffer.hpp
+++ b/src/protocols/types/DMABuffer.hpp
@@ -15,6 +15,7 @@ class CDMABuffer : public IHLBuffer {
     virtual Aquamarine::SDMABUFAttrs               dmabuf();
     virtual std::tuple<uint8_t*, uint32_t, size_t> beginDataPtr(uint32_t flags);
     virtual void                                   endDataPtr();
+    virtual void                                   createTexture();
     bool                                           good();
     void                                           closeFDs();
     Hyprutils::OS::CFileDescriptor                 exportSyncFile();

--- a/src/protocols/types/DMABuffer.hpp
+++ b/src/protocols/types/DMABuffer.hpp
@@ -15,12 +15,10 @@ class CDMABuffer : public IHLBuffer {
     virtual Aquamarine::SDMABUFAttrs               dmabuf();
     virtual std::tuple<uint8_t*, uint32_t, size_t> beginDataPtr(uint32_t flags);
     virtual void                                   endDataPtr();
-    virtual void                                   createTexture();
+    virtual SP<CTexture>                           createTexture();
     bool                                           good();
     void                                           closeFDs();
     Hyprutils::OS::CFileDescriptor                 exportSyncFile();
-
-    bool                                           m_success = false;
 
   private:
     Aquamarine::SDMABUFAttrs m_attrs;

--- a/src/protocols/types/SurfaceState.cpp
+++ b/src/protocols/types/SurfaceState.cpp
@@ -48,11 +48,6 @@ void SSurfaceState::updateSynchronousTexture(SP<CTexture> lastTexture) {
     buffer->endDataPtr();
 }
 
-void SSurfaceState::updateAsyncSynchronousTexture() {
-    buffer->createTexture();
-    texture = buffer->m_texture;
-}
-
 void SSurfaceState::reset() {
     updated.all = false;
 

--- a/src/protocols/types/SurfaceState.cpp
+++ b/src/protocols/types/SurfaceState.cpp
@@ -48,6 +48,11 @@ void SSurfaceState::updateSynchronousTexture(SP<CTexture> lastTexture) {
     buffer->endDataPtr();
 }
 
+void SSurfaceState::updateAsyncSynchronousTexture() {
+    buffer->createTexture();
+    texture = buffer->m_texture;
+}
+
 void SSurfaceState::reset() {
     updated.all = false;
 
@@ -68,8 +73,10 @@ void SSurfaceState::updateFrom(SSurfaceState& ref) {
     updated = ref.updated;
 
     if (ref.updated.bits.buffer) {
+        if (!ref.buffer.m_buffer)
+            texture.reset(); // null buffer reset texture.
+
         buffer     = ref.buffer;
-        texture    = ref.texture;
         size       = ref.size;
         bufferSize = ref.bufferSize;
     }

--- a/src/protocols/types/SurfaceState.hpp
+++ b/src/protocols/types/SurfaceState.hpp
@@ -61,7 +61,6 @@ struct SSurfaceState {
     // texture of surface content, used for rendering
     SP<CTexture> texture;
     void         updateSynchronousTexture(SP<CTexture> lastTexture);
-    void         updateAsyncSynchronousTexture();
 
     // helpers
     CRegion accumulateBufferDamage();       // transforms state.damage and merges it into state.bufferDamage

--- a/src/protocols/types/SurfaceState.hpp
+++ b/src/protocols/types/SurfaceState.hpp
@@ -61,6 +61,7 @@ struct SSurfaceState {
     // texture of surface content, used for rendering
     SP<CTexture> texture;
     void         updateSynchronousTexture(SP<CTexture> lastTexture);
+    void         updateAsyncSynchronousTexture();
 
     // helpers
     CRegion accumulateBufferDamage();       // transforms state.damage and merges it into state.bufferDamage


### PR DESCRIPTION
move creating texture away from buffer attach into commitstate in an
attempt to postpone gpu work until its really needed. best case scenario
gpu clocks have ramped up before because we are actively doing things
causing surface states and a commit to happend meaning less visible lag.

this is one of those touch it and sneaky bugs shall appear.

locally on nvidia this makes a night and day difference.