### PR TITLE
core: defer wl_surface.leave until frame callbacks complete

### DIFF
--- a/src/protocols/core/Compositor.hpp
+++ b/src/protocols/core/Compositor.hpp
@@ -131,6 +131,8 @@ class CWLSurfaceResource {
     SP<CWlSurface>         m_resource;
     wl_client*             m_client = nullptr;
 
+    std::vector<PHLMONITORREF> m_pendingLeaveOutputs;
+
     void                   destroy();
     void                   releaseBuffers(bool onlyCurrent = true);
     void                   dropPendingBuffer();


### PR DESCRIPTION
fixes chromium based browsers (brave, chrome, edge) crashing with sigtrap when moving windows between visible monitors.

the crash occurs because hyprland sends wl_surface.leave events immediately while pending frame callbacks exist for the old output. chromium ozone/wayland backend expects all frame callbacks from an output to complete before receiving a leave event. when this ordering is violated, chromium hits a dcheck assertion and triggers a trap.

this fix defers leave events until after all pending frame callbacks are sent, ensuring proper event ordering that matches client expectations.

changes:
- added m_pendingLeaveOutputs to track monitors requiring deferred leave events
- modified CWLSurfaceResource::leave() to defer leave when callbacks are pending
- modified CWLSurfaceResource::frame() to send deferred leave events after callbacks
- clear pending leaves on surface unmap to prevent stale events

the crash only occurred when moving between visible monitors (both actively rendering), not when moving to hidden workspaces (no active frames). setting wayland_debug=1 avoided the crash by serializing events, which confirmed this was a timing issue.

tested with brave browser moving between two monitors on different workspaces.