### PR TITLE
Disable LTO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,9 @@ add_compile_options(
   -Wno-clobbered
   -fmacro-prefix-map=${CMAKE_SOURCE_DIR}/=)
 
+# disable lto as it may break plugins
+add_compile_options(-fno-lto)
+
 set(CMAKE_EXECUTABLE_ENABLE_EXPORTS TRUE)
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
~~Disables some optimizations on `CPointerManager::move(Vector2D)` such that LTO on gcc doesn't optimize it out.~~ I need this method in dynamic-cursors because it lets me differentiate between warps and normal moves.

This PR now disables LTO completely to avoid similar problems in the future.

fixes https://github.com/VirtCode/hypr-dynamic-cursors/issues/98

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
nope

#### Is it ready for merging, or does it need work?
yes

