### PR TITLE
ensure dmabuf textures isnt reacreated on same buffer commits

### DIFF
--- a/src/protocols/types/DMABuffer.cpp
+++ b/src/protocols/types/DMABuffer.cpp
@@ -60,6 +60,9 @@ void CDMABuffer::endDataPtr() {
 }
 
 SP<CTexture> CDMABuffer::createTexture() {
+    if (m_texture) // dmabuffers only get one texture per buffer.
+        return m_texture;
+
     g_pHyprRenderer->makeEGLCurrent();
     auto eglImage = g_pHyprOpenGL->createEGLImage(m_attrs);
 
@@ -73,14 +76,14 @@ SP<CTexture> CDMABuffer::createTexture() {
         }
     }
 
-    auto tex = makeShared<CTexture>(m_attrs, eglImage); // texture takes ownership of the eglImage
+    m_texture = makeShared<CTexture>(m_attrs, eglImage); // texture takes ownership of the eglImage
 
-    if UNLIKELY (!tex->m_texID) {
+    if UNLIKELY (!m_texture->m_texID) {
         Debug::log(ERR, "Failed to create a dmabuf: texture is null");
         return nullptr;
     }
 
-    return tex;
+    return m_texture;
 }
 
 bool CDMABuffer::good() {

--- a/src/protocols/types/DMABuffer.hpp
+++ b/src/protocols/types/DMABuffer.hpp
@@ -22,6 +22,7 @@ class CDMABuffer : public IHLBuffer {
 
   private:
     Aquamarine::SDMABUFAttrs m_attrs;
+    SP<CTexture>             m_texture;
 
     struct {
         CHyprSignalListener resourceDestroy;


### PR DESCRIPTION
dmabuffers doesnt always recreate on attach, they send damage and we damage the area. store the texture in the buffer and return the pointer to it if it already exist.


