### PR TITLE
renderer: send frame events on onPresented

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -112,10 +112,8 @@ void CMonitor::onConnect(bool noRule) {
             ts = nullptr;
         }
 
-        if (!ts)
-            PROTO::presentation->onPresented(m_self.lock(), Time::steadyNow(), event.refresh, event.seq, event.flags);
-        else
-            PROTO::presentation->onPresented(m_self.lock(), Time::fromTimespec(event.when), event.refresh, event.seq, event.flags);
+        auto time = ts ? Time::fromTimespec(event.when) : Time::steadyNow();
+        PROTO::presentation->onPresented(m_self.lock(), time, event.refresh, event.seq, event.flags);
 
         if (m_zoomAnimFrameCounter < 5) {
             m_zoomAnimFrameCounter++;
@@ -138,7 +136,7 @@ void CMonitor::onConnect(bool noRule) {
             });
         }
 
-        m_frameScheduler->onPresented();
+        m_frameScheduler->onPresented(time);
     });
 
     m_listeners.destroy = m_output->events.destroy.listen([this] {

--- a/src/helpers/MonitorFrameScheduler.cpp
+++ b/src/helpers/MonitorFrameScheduler.cpp
@@ -50,6 +50,9 @@ void CMonitorFrameScheduler::onSyncFired() {
 }
 
 void CMonitorFrameScheduler::onPresented() {
+    if (!m_monitor->isMirror())
+        g_pHyprRenderer->sendFrameEventsToActiveWorkspace(m_monitor.lock(), Time::steadyNow());
+
     if (!newSchedulingEnabled())
         return;
 

--- a/src/helpers/MonitorFrameScheduler.cpp
+++ b/src/helpers/MonitorFrameScheduler.cpp
@@ -31,6 +31,10 @@ void CMonitorFrameScheduler::onSyncFired() {
 
     Debug::log(TRACE, "CMonitorFrameScheduler: {} -> onSyncFired, missed.", m_monitor->m_name);
 
+    // let clients know its a good time to render yet another frame
+    if (!m_monitor->isMirror())
+        g_pHyprRenderer->sendFrameEventsToMonitor(m_monitor.lock(), Time::steadyNow());
+
     // we are out. The frame is taking too long to render. Begin rendering immediately, but don't commit yet.
     m_pendingThird  = true;
     m_renderAtFrame = false; // block frame rendering, we already scheduled
@@ -51,7 +55,7 @@ void CMonitorFrameScheduler::onSyncFired() {
 
 void CMonitorFrameScheduler::onPresented(const Time::steady_tp& when) {
     if (!m_monitor->isMirror())
-        g_pHyprRenderer->sendFrameEventsMonitor(m_monitor.lock(), when);
+        g_pHyprRenderer->sendFrameEventsToMonitor(m_monitor.lock(), when);
 
     if (!newSchedulingEnabled())
         return;

--- a/src/helpers/MonitorFrameScheduler.cpp
+++ b/src/helpers/MonitorFrameScheduler.cpp
@@ -49,9 +49,9 @@ void CMonitorFrameScheduler::onSyncFired() {
     onFinishRender();
 }
 
-void CMonitorFrameScheduler::onPresented() {
+void CMonitorFrameScheduler::onPresented(const Time::steady_tp& when) {
     if (!m_monitor->isMirror())
-        g_pHyprRenderer->sendFrameEventsToActiveWorkspace(m_monitor.lock(), Time::steadyNow());
+        g_pHyprRenderer->sendFrameEventsMonitor(m_monitor.lock(), when);
 
     if (!newSchedulingEnabled())
         return;

--- a/src/helpers/MonitorFrameScheduler.hpp
+++ b/src/helpers/MonitorFrameScheduler.hpp
@@ -18,7 +18,7 @@ class CMonitorFrameScheduler {
     CMonitorFrameScheduler& operator=(CMonitorFrameScheduler&&)      = delete;
 
     void                    onSyncFired();
-    void                    onPresented();
+    void                    onPresented(const Time::steady_tp& when);
     void                    onFrame();
 
   private:

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -646,12 +646,8 @@ void CWLSurfaceResource::presentFeedback(const Time::steady_tp& when, PHLMONITOR
     FEEDBACK->attachMonitor(pMonitor);
     if (discarded)
         FEEDBACK->discarded();
-    else {
-        if (m_hlSurface && m_hlSurface->getPopup())
-            frame(when);
-
+    else
         FEEDBACK->presented();
-    }
 
     PROTO::presentation->queueData(std::move(FEEDBACK));
 }

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -642,13 +642,17 @@ void CWLSurfaceResource::updateCursorShm(CRegion damage) {
 }
 
 void CWLSurfaceResource::presentFeedback(const Time::steady_tp& when, PHLMONITOR pMonitor, bool discarded) {
-    frame(when);
     auto FEEDBACK = makeUnique<CQueuedPresentationData>(m_self.lock());
     FEEDBACK->attachMonitor(pMonitor);
     if (discarded)
         FEEDBACK->discarded();
-    else
+    else {
+        if (m_hlSurface && m_hlSurface->getPopup())
+            frame(when);
+
         FEEDBACK->presented();
+    }
+
     PROTO::presentation->queueData(std::move(FEEDBACK));
 }
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1631,7 +1631,7 @@ void CHyprRenderer::renderWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace
     renderAllClientsForWorkspace(pMonitor, pWorkspace, now, translate, scale);
 }
 
-void CHyprRenderer::sendFrameEventsMonitor(PHLMONITOR pMonitor, const Time::steady_tp& when) {
+void CHyprRenderer::sendFrameEventsToMonitor(PHLMONITOR pMonitor, const Time::steady_tp& when) {
     auto sendFrame = [](const auto& w, const auto& when) {
         w->m_wlSurface->resource()->breadthfirst([when](SP<CWLSurfaceResource> r, const Vector2D& offset, void* d) { r->frame(when); }, nullptr);
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1365,10 +1365,6 @@ void CHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
             }
         } else
             renderWindow(pMonitor->m_solitaryClient.lock(), pMonitor, NOW, false, RENDER_PASS_MAIN /* solitary = no popups */);
-    } else if (!pMonitor->isMirror()) {
-        sendFrameEventsToWorkspace(pMonitor, pMonitor->m_activeWorkspace, NOW);
-        if (pMonitor->m_activeSpecialWorkspace)
-            sendFrameEventsToWorkspace(pMonitor, pMonitor->m_activeSpecialWorkspace, NOW);
     }
 
     renderCursor = renderCursor && shouldRenderCursor();
@@ -1635,12 +1631,10 @@ void CHyprRenderer::renderWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace
     renderAllClientsForWorkspace(pMonitor, pWorkspace, now, translate, scale);
 }
 
-void CHyprRenderer::sendFrameEventsToWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now) {
+void CHyprRenderer::sendFrameEventsToActiveWorkspace(PHLMONITOR pMonitor, const Time::steady_tp& now) {
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->isHidden() || !w->m_isMapped || w->m_fadingOut || !w->m_wlSurface->resource())
-            continue;
-
-        if (!shouldRenderWindow(w, pMonitor))
+        if (w->isHidden() || !w->m_isMapped || w->m_fadingOut || !w->m_wlSurface->resource() ||
+            (w->workspaceID() != pMonitor->activeWorkspaceID() && w->workspaceID() != pMonitor->activeSpecialWorkspaceID()))
             continue;
 
         w->m_wlSurface->resource()->breadthfirst([now](SP<CWLSurfaceResource> r, const Vector2D& offset, void* d) { r->frame(now); }, nullptr);

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -127,7 +127,7 @@ class CHyprRenderer {
     void renderSessionLockSurface(WP<SSessionLockSurface>, PHLMONITOR, const Time::steady_tp&);
     void renderDragIcon(PHLMONITOR, const Time::steady_tp&);
     void renderIMEPopup(CInputPopup*, PHLMONITOR, const Time::steady_tp&);
-    void sendFrameEventsToWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now); // sends frame displayed events but doesn't actually render anything
+    void sendFrameEventsToActiveWorkspace(PHLMONITOR pMonitor, const Time::steady_tp& now); // sends frame displayed events but doesn't actually render anything
     void renderSessionLockPrimer(PHLMONITOR pMonitor);
     void renderSessionLockMissing(PHLMONITOR pMonitor);
     void renderBackground(PHLMONITOR pMonitor);

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -127,7 +127,7 @@ class CHyprRenderer {
     void renderSessionLockSurface(WP<SSessionLockSurface>, PHLMONITOR, const Time::steady_tp&);
     void renderDragIcon(PHLMONITOR, const Time::steady_tp&);
     void renderIMEPopup(CInputPopup*, PHLMONITOR, const Time::steady_tp&);
-    void sendFrameEventsToActiveWorkspace(PHLMONITOR pMonitor, const Time::steady_tp& now); // sends frame displayed events but doesn't actually render anything
+    void sendFrameEventsMonitor(PHLMONITOR pMonitor, const Time::steady_tp& now); // sends frame displayed events but doesn't actually render anything
     void renderSessionLockPrimer(PHLMONITOR pMonitor);
     void renderSessionLockMissing(PHLMONITOR pMonitor);
     void renderBackground(PHLMONITOR pMonitor);

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -127,7 +127,7 @@ class CHyprRenderer {
     void renderSessionLockSurface(WP<SSessionLockSurface>, PHLMONITOR, const Time::steady_tp&);
     void renderDragIcon(PHLMONITOR, const Time::steady_tp&);
     void renderIMEPopup(CInputPopup*, PHLMONITOR, const Time::steady_tp&);
-    void sendFrameEventsMonitor(PHLMONITOR pMonitor, const Time::steady_tp& now); // sends frame displayed events but doesn't actually render anything
+    void sendFrameEventsToMonitor(PHLMONITOR pMonitor, const Time::steady_tp& now); // sends frame displayed events but doesn't actually render anything
     void renderSessionLockPrimer(PHLMONITOR pMonitor);
     void renderSessionLockMissing(PHLMONITOR pMonitor);
     void renderBackground(PHLMONITOR pMonitor);


### PR DESCRIPTION
so previously the frame was sent on surface onPresented on both discarding and presenting also if the monitor had no damage in renderer, move it to simply present of the monitor. if using new_render_sched this means the third monitor frame rendering might never hit it because it has no pending presentation and yet the monitor has damage from other things, as such it stopped rendering and recieving frame calls.

rename it to sendFrameEventsToMonitor since thats all it was used for. and send it an extra time in new_render_sched


### TODO

- [ ] Figure out if this goes wrong when the compositor doesnt keep up on slow gpus that doesnt pageflip at native monitor HZ
- [ ] Send frame events properly to hyprlandsurfaces
- [ ] Do we want a timer based on monitor hz that sends the frames eg. `render::timer_based_frames = true`
