### PR TITLE
Prevent zombies at dawn

### DIFF
--- a/hyprtester/src/tests/main/misc.cpp
+++ b/hyprtester/src/tests/main/misc.cpp
@@ -194,6 +194,10 @@ static bool test() {
         EXPECT_CONTAINS(str, "fullscreen: 2");
     }
 
+    // Ensure that the process autostarted in the config does not
+    // become a zombie even if it terminates very quickly.
+    EXPECT(Tests::execAndGet("pgrep -f 'sleep 0'").empty(), true);
+
     // kill all
     NLog::log("{}Killing all windows", Colors::YELLOW);
     Tests::killAllWindows();

--- a/hyprtester/test.conf
+++ b/hyprtester/test.conf
@@ -46,6 +46,7 @@ $menu = wofi --show drun
 # Autostart necessary processes (like notifications daemons, status bars, etc.)
 # Or execute your favorite apps at launch like this:
 
+exec-once = sleep 0  # Terminates very quickly
 # exec-once = $terminal
 # exec-once = nm-applet &
 # exec-once = waybar & hyprpaper & firefox

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -187,6 +187,8 @@ int main(int argc, char** argv) {
         return 1;
     }
 
+    reapZombieChildrenAutomatically();
+
     g_pCompositor->initServer(socketName, socketFd);
 
     if (verifyConfig)
@@ -194,8 +196,6 @@ int main(int argc, char** argv) {
 
     if (!envEnabled("HYPRLAND_NO_RT"))
         NInit::gainRealTime();
-
-    reapZombieChildrenAutomatically();
 
     Debug::log(LOG, "Hyprland init finished.");
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Prevent `exec`/`exec-once` processes that terminate very early (before Hyprland declares that it does not want to reap zombies) from getting stuck as zombie processes.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Maybe make the commit message title more specific if you don't like this one.