### PR TITLE
renderer: fix background bleeding in blur on special workspaces

### DIFF
--- a/src/render/pass/Pass.cpp
+++ b/src/render/pass/Pass.cpp
@@ -71,11 +71,6 @@ void CRenderPass::simplify() {
             if (WILLBLUR) {
                 CRegion liveBlurRegion;
                 for (auto& el2 : m_passElements) {
-                    // if we reach self, no problem, we can break.
-                    // if the blur is above us, we don't care, it will work fine.
-                    if (el2 == el)
-                        break;
-
                     if (!el2->element->needsLiveBlur())
                         continue;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fix background bleeding in blur around special workspace windows.

Here is discussion with that bug description.
https://github.com/hyprwm/Hyprland/discussions/11761

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready for merging