### PR TITLE
ext-foreign-toplevel: remove stale handles when remapping

### DIFF
--- a/src/protocols/ForeignToplevel.cpp
+++ b/src/protocols/ForeignToplevel.cpp
@@ -45,6 +45,15 @@ void CForeignToplevelList::onMap(PHLWINDOW pWindow) {
     if UNLIKELY (m_finished)
         return;
 
+    // check if the window already had a handle in the past
+    const auto OLDHANDLE = handleForWindow(pWindow);
+    if (OLDHANDLE) {
+        if (!OLDHANDLE->m_closed)
+            OLDHANDLE->m_resource->sendClosed();
+
+        std::erase_if(m_handles, [&](const auto& other) { return other.get() == OLDHANDLE.get(); });
+    }
+
     const auto NEWHANDLE = PROTO::foreignToplevel->m_handles.emplace_back(
         makeShared<CForeignToplevelHandle>(makeShared<CExtForeignToplevelHandleV1>(m_resource->client(), m_resource->version(), 0), pWindow));
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
This fixes a bug that the current `ext-foreign-toplevel-list-v1` would sometimes send two `closed` events for the same handle. This protocol violation causes application made with [cosmic's iced](https://github.com/pop-os/iced), and so by extension my own bar to panic. I have spent a few hours getting a reproduction case and debugging but think I have figured it out.

This is what's happening AFAICT:
1. Window is mapped -> protocol creates a handle
2. Window is unmapped -> protocol sends `closed` event to handle
3. Same window is mapped again -> protocol **creates a new handle**
4. Window is unmapped -> protocol sends `closed` **to old handle**

This exact behaviour relies on two things tho:
- The client does **not** destroy the old handle when receiving `closed` (which cosmic's iced seems to)
- The same window must be unmapped and remapped multiple times, so far I have only observed this with xwayland windows

So the fix is relatively straight forward. When mapping a window it checks whether there already exists a handle for it. If so, it removes the handle from the manager, such that `handleWindow` won't return it anymore in the future if it is not destroyed. We can then proceed to create a new handle for the toplevel as usual.

If you for some reason want to reproduce on your system, you can do the following:
1. Start [my bar](https://github.com/VirtCode/liischte) (to see it freeze), or any other application which binds `ext-foreign-toplevel-list` with `WAYLAND_DEBUG`
2. Open steam and close it (but it's open in the background)
3. Open steam again and close it

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I have also added a bit of code which would send a `closed` to the old handle if it is not yet closed. This isn't really needed because normally you wouldn't map a window again before unmapping it. I just added that for robustness sake but I can remove it again as it is technically superfluous.

#### Is it ready for merging, or does it need work?
yes


