### PR TITLE
protocols: fix output power protocol not sending mode confirmation

### DIFF
--- a/src/protocols/OutputPower.cpp
+++ b/src/protocols/OutputPower.cpp
@@ -13,12 +13,7 @@ COutputPower::COutputPower(SP<CZwlrOutputPowerV1> resource_, PHLMONITOR pMonitor
         if (!m_monitor)
             return;
 
-        m_monitor->m_dpmsStatus = mode == ZWLR_OUTPUT_POWER_V1_MODE_ON;
-
-        m_monitor->m_output->state->setEnabled(mode == ZWLR_OUTPUT_POWER_V1_MODE_ON);
-
-        if (!m_monitor->m_state.commit())
-            LOGM(ERR, "Couldn't set dpms to {} for {}", m_monitor->m_dpmsStatus, m_monitor->m_name);
+        m_monitor->setDPMS(mode == ZWLR_OUTPUT_POWER_V1_MODE_ON);
     });
 
     m_resource->sendMode(m_monitor->m_dpmsStatus ? ZWLR_OUTPUT_POWER_V1_MODE_ON : ZWLR_OUTPUT_POWER_V1_MODE_OFF);


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Use `setDPMS()` instead of directly manipulating `m_dpmsStatus` to ensure the `dpmsChanged` event fires and protocol clients receive mode change confirmation via `sendMode()`.

More context: https://github.com/any1/wayvnc/issues/408

When dpms is off, wayvnc will request to turn it on and then [wait for the changed event](https://github.com/any1/wayvnc/blob/e12cb689f3afb333f0678de03ff25a431ffd2207/src/output.c#L307). Without this event, connecting to wayvnc when dpms is off shows a blank grey screen.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I only tested locally and it works. Not sure if any unit tests can be added.

#### Is it ready for merging, or does it need work?

Yes I think it's ready.
