### PR TITLE
desktopAnimationMgr: don't set fade 0 for members of a fs group

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1037,6 +1037,16 @@ PHLWINDOW CWindow::getGroupWindowByIndex(int index) {
     return curr;
 }
 
+bool CWindow::hasInGroup(PHLWINDOW w) {
+    PHLWINDOW curr = m_groupData.pNextWindow.lock();
+    while (curr && curr != m_self) {
+        if (curr == w)
+            return true;
+        curr = curr->m_groupData.pNextWindow.lock();
+    }
+    return false;
+}
+
 void CWindow::setGroupCurrent(PHLWINDOW pWindow) {
     PHLWINDOW curr     = m_groupData.pNextWindow.lock();
     bool      isMember = false;

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -379,6 +379,7 @@ class CWindow {
     PHLWINDOW                  getGroupCurrent();
     PHLWINDOW                  getGroupPrevious();
     PHLWINDOW                  getGroupWindowByIndex(int);
+    bool                       hasInGroup(PHLWINDOW);
     int                        getGroupSize();
     bool                       canBeGroupedInto(PHLWINDOW pWindow);
     void                       setGroupCurrent(PHLWINDOW pWindow);

--- a/src/managers/animation/DesktopAnimationManager.cpp
+++ b/src/managers/animation/DesktopAnimationManager.cpp
@@ -459,6 +459,8 @@ void CDesktopAnimationManager::setFullscreenFadeAnimation(PHLWORKSPACE ws, eAnim
 
     const auto FULLSCREEN = type == ANIMATION_TYPE_IN;
 
+    const auto FSWINDOW = ws->getFullscreenWindow();
+
     for (auto const& w : g_pCompositor->m_windows) {
         if (w->m_workspace == ws) {
 
@@ -467,8 +469,11 @@ void CDesktopAnimationManager::setFullscreenFadeAnimation(PHLWORKSPACE ws, eAnim
 
             if (!FULLSCREEN)
                 *w->m_alpha = 1.F;
-            else if (!w->isFullscreen())
-                *w->m_alpha = !w->m_createdOverFullscreen ? 0.f : 1.f;
+            else if (!w->isFullscreen()) {
+                const bool CREATED_OVER_FS   = w->m_createdOverFullscreen;
+                const bool IS_IN_GROUP_OF_FS = FSWINDOW && FSWINDOW->hasInGroup(w);
+                *w->m_alpha                  = !CREATED_OVER_FS && !IS_IN_GROUP_OF_FS ? 0.f : 1.f;
+            }
         }
     }
 


### PR DESCRIPTION
fixes a flash of opacity that shouldnt be there



