### PR TITLE
renderer/cm: allow gamma 2.2 instead of sRGB EOTF

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1542,6 +1542,13 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .type        = CONFIG_OPTION_CHOICE,
         .data        = SConfigOptionDescription::SChoiceData{0, "disable,always,ondemand,ignore"},
     },
+    SConfigOptionDescription{
+        .value       = "render:cm_sdr_eotf",
+        .description = "Default transfer function for displaying SDR apps. 0 - Treat unspecified as sRGB, 1 - Treat unspecified as Gamma 2.2, 2 - Treat "
+                       "unspecified and sRGB as Gamma 2.2",
+        .type        = CONFIG_OPTION_CHOICE,
+        .data        = SConfigOptionDescription::SChoiceData{0, "srgb,gamma22,gamma22force"},
+    },
 
     /*
      * cursor:

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -781,6 +781,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("render:cm_auto_hdr", Hyprlang::INT{1});
     registerConfigVar("render:new_render_scheduling", Hyprlang::INT{0});
     registerConfigVar("render:non_shader_cm", Hyprlang::INT{2});
+    registerConfigVar("render:cm_sdr_eotf", Hyprlang::INT{0});
 
     registerConfigVar("ecosystem:no_update_news", Hyprlang::INT{0});
     registerConfigVar("ecosystem:no_donation_nag", Hyprlang::INT{0});
@@ -842,6 +843,7 @@ CConfigManager::CConfigManager() {
     m_config->addSpecialConfigValue("monitorv2", "mirror", {STRVAL_EMPTY});
     m_config->addSpecialConfigValue("monitorv2", "bitdepth", {STRVAL_EMPTY}); // TODO use correct type
     m_config->addSpecialConfigValue("monitorv2", "cm", {"auto"});
+    m_config->addSpecialConfigValue("monitorv2", "sdr_eotf", Hyprlang::INT{0});
     m_config->addSpecialConfigValue("monitorv2", "sdrbrightness", Hyprlang::FLOAT{1.0});
     m_config->addSpecialConfigValue("monitorv2", "sdrsaturation", Hyprlang::FLOAT{1.0});
     m_config->addSpecialConfigValue("monitorv2", "vrr", Hyprlang::INT{0});
@@ -1115,6 +1117,9 @@ std::optional<std::string> CConfigManager::handleMonitorv2(const std::string& ou
     VAL = m_config->getSpecialConfigValuePtr("monitorv2", "cm", output.c_str());
     if (VAL && VAL->m_bSetByUser)
         parser.parseCM(std::any_cast<Hyprlang::STRING>(VAL->getValue()));
+    VAL = m_config->getSpecialConfigValuePtr("monitorv2", "sdr_eotf", output.c_str());
+    if (VAL && VAL->m_bSetByUser)
+        parser.rule().sdrEotf = std::any_cast<Hyprlang::INT>(VAL->getValue());
     VAL = m_config->getSpecialConfigValuePtr("monitorv2", "sdrbrightness", output.c_str());
     if (VAL && VAL->m_bSetByUser)
         parser.rule().sdrBrightness = std::any_cast<Hyprlang::FLOAT>(VAL->getValue());

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -48,6 +48,7 @@ struct SMonitorRule {
     std::string         mirrorOf      = "";
     bool                enable10bit   = false;
     NCMType::eCMType    cmType        = NCMType::CM_SRGB;
+    int                 sdrEotf       = 0;
     float               sdrSaturation = 1.0f; // SDR -> HDR
     float               sdrBrightness = 1.0f; // SDR -> HDR
 
@@ -131,6 +132,7 @@ class CMonitor {
     bool                        m_vrrActive        = false; // this can be TRUE even if VRR is not active in the case that this display does not support it.
     bool                        m_enabled10bit     = false; // as above, this can be TRUE even if 10 bit failed.
     NCMType::eCMType            m_cmType           = NCMType::CM_SRGB;
+    int                         m_sdrEotf          = 0;
     float                       m_sdrSaturation    = 1.0f;
     float                       m_sdrBrightness    = 1.0f;
     float                       m_sdrMinLuminance  = 0.2f;
@@ -272,7 +274,7 @@ class CMonitor {
     // methods
     void        onConnect(bool noRule);
     void        onDisconnect(bool destroy = false);
-    void        applyCMType(NCMType::eCMType cmType);
+    void        applyCMType(NCMType::eCMType cmType, int cmSdrEotf);
     bool        applyMonitorRule(SMonitorRule* pMonitorRule, bool force = false);
     void        addDamage(const pixman_region32_t* rg);
     void        addDamage(const CRegion& rg);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1555,9 +1555,10 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
                 if (*PAUTOHDR && !(pMonitor->inHDR() && configuredHDR)) {
                     // modify or restore monitor image description for auto-hdr
                     // FIXME ok for now, will need some other logic if monitor image description can be modified some other way
-                    const auto targetCM = wantHDR ? (*PAUTOHDR == 2 ? NCMType::CM_HDR_EDID : NCMType::CM_HDR) : pMonitor->m_cmType;
+                    const auto targetCM      = wantHDR ? (*PAUTOHDR == 2 ? NCMType::CM_HDR_EDID : NCMType::CM_HDR) : pMonitor->m_cmType;
+                    const auto targetSDREOTF = pMonitor->m_sdrEotf;
                     Debug::log(INFO, "[CM] Auto HDR: changing monitor cm to {}", sc<uint8_t>(targetCM));
-                    pMonitor->applyCMType(targetCM);
+                    pMonitor->applyCMType(targetCM, targetSDREOTF);
                     pMonitor->m_previousFSWindow.reset(); // trigger CTM update
                 }
                 Debug::log(INFO, wantHDR ? "[CM] Updating HDR metadata from monitor" : "[CM] Restoring SDR mode");

--- a/src/render/shaders/glsl/CM.glsl
+++ b/src/render/shaders/glsl/CM.glsl
@@ -416,7 +416,7 @@ vec4 doColorManagement(vec4 pixColor, int srcTF, int dstTF, mat4x2 dstPrimaries)
     mat3 dstxyz = primaries2xyz(dstPrimaries);
     pixColor = tonemap(pixColor, dstxyz);
     pixColor = fromLinearNit(pixColor, dstTF, dstTFRange);
-    if (srcTF == CM_TRANSFER_FUNCTION_SRGB && dstTF == CM_TRANSFER_FUNCTION_ST2084_PQ) {
+    if ((srcTF == CM_TRANSFER_FUNCTION_SRGB || srcTF == CM_TRANSFER_FUNCTION_GAMMA22) && dstTF == CM_TRANSFER_FUNCTION_ST2084_PQ) {
         pixColor = saturate(pixColor, dstxyz, sdrSaturation);
         pixColor.rgb *= sdrBrightnessMultiplier;
     }


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

#### Describe your PR, what does it fix/add?
Instead of the piecewise sRGB EOTF, allow the user to choose Gamma 2.2 for untagged, and/or all sRGB EOTF surfaces.
Makes SDR content with `cm = hdr` look more like how it does with `cm = srgb` on an average monitor in SDR, as SDR media content typically assumes a gamma 2.2 curve. 

Should help https://github.com/hyprwm/Hyprland/discussions/10950, https://github.com/hyprwm/Hyprland/discussions/11341 or anyone who felt the existing gamma curve felt too "washed-out" compared to what they're used to.

Adds `render:cm_sdr_eotf` for specifying the transfer function for sRGB content in general for both SDR and HDR.
`0`: Piecewise sRGB (Existing behavior)
`1`: Treat untagged surfaces as Gamma 2.2
`2`: Treat untagged surfaces and all sRGB EOTF surfaces as Gamma 2.2

I added `2` because a lot of desktop content seems to have been developed in an environment that is encoded for sRGB on the PC side, with the expectation of being decoded by a Gamma 2.2 monitor/TV. KWin seems to behave with this in mind, and this tweak gets me the appearance I expect after spending some time with KDE.

`1` was my initial plan, but I noticed a fair few apps did get tagged for sRGB transfer that I wasn't expecting (Gamescope, Proton Wayland)

On the `monitorv2` side, we also have a `sdr_eotf` var with values of:
`0`: Follow the default SDR EOTF from `render:sdr_eotf`. This will be sRGB for `cm_sdr_eotf = 0`, and Gamma 2.2 for `1`, `2`
`1`: sRGB piecewise function
`2`: Gamma 2.2

Many (most?) monitors with an sRGB clamp also enforce a Gamma of 2.2 because it's become a standard (I don't think you'll find the piecewise sRGB EOTF on much beyond color professional displays). This allows us to acknowledge that for displays configured that way.

I left the defaults as sRGB on both ends to avoid breaking anyone's setups. Personally, I'm having a good time setting `render:cm_srgb_eotf = 2` and `monitorv2[*]:cm_srgb_eotf" 1` to keep a consistent image in SDR and HDR.

This also allows you to set `render:cm_sdr_eotf = 0` and `monitorv2[*]:sdr_eotf" 1` to get the piecewise sRGB curve on a Gamma 2.2 display, making SDR mode consistent with the default SDR-on-HDR image, if you want.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This is the default behavior in KWin, wlroots(`-git`), and I believe Mutter.
I believe macOS allows the user to choose the EOTF.

Works so far on my machine. With my monitor's SDR settings set to sRGB w/ Gamma 2.2, toggling HDR on and off in Elden Ring keeps a consistent image (but with different dynamic range). This is with setting `render:cm_sdr_eotf = 2` and `monitorv2[*]:sdr_eotf" 0` (or `2`).

Editing `CM.glsl` to over-brighten `CM_TRANSFER_FUNCTION_GAMMA22` as a sanity check, `cm = srgb` is entirely unaffected by default as expected, and with `cm = hdr`, and `render:cm_sdr_eotf = 1`, most of my windows follow the expected new gamma curve, except for `kitty`, which is color-managed and explicitly requests sRGB. 

#### Is it ready for merging, or does it need work?

Ready
