### PR TITLE
Added submap universal keybind flag

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -2549,52 +2549,45 @@ std::optional<std::string> CConfigManager::handleBind(const std::string& command
     // bind[fl]=SUPER,G,exec,dmenu_run <args>
 
     // flags
-    bool       locked         = false;
-    bool       release        = false;
-    bool       repeat         = false;
-    bool       mouse          = false;
-    bool       nonConsuming   = false;
-    bool       transparent    = false;
-    bool       ignoreMods     = false;
-    bool       multiKey       = false;
-    bool       longPress      = false;
-    bool       hasDescription = false;
-    bool       dontInhibit    = false;
-    bool       click          = false;
-    bool       drag           = false;
-    const auto BINDARGS       = command.substr(4);
+    bool       locked          = false;
+    bool       release         = false;
+    bool       repeat          = false;
+    bool       mouse           = false;
+    bool       nonConsuming    = false;
+    bool       transparent     = false;
+    bool       ignoreMods      = false;
+    bool       multiKey        = false;
+    bool       longPress       = false;
+    bool       hasDescription  = false;
+    bool       dontInhibit     = false;
+    bool       click           = false;
+    bool       drag            = false;
+    bool       submapUniversal = false;
+    const auto BINDARGS        = command.substr(4);
 
     for (auto const& arg : BINDARGS) {
-        if (arg == 'l') {
-            locked = true;
-        } else if (arg == 'r') {
-            release = true;
-        } else if (arg == 'e') {
-            repeat = true;
-        } else if (arg == 'm') {
-            mouse = true;
-        } else if (arg == 'n') {
-            nonConsuming = true;
-        } else if (arg == 't') {
-            transparent = true;
-        } else if (arg == 'i') {
-            ignoreMods = true;
-        } else if (arg == 's') {
-            multiKey = true;
-        } else if (arg == 'o') {
-            longPress = true;
-        } else if (arg == 'd') {
-            hasDescription = true;
-        } else if (arg == 'p') {
-            dontInhibit = true;
-        } else if (arg == 'c') {
-            click   = true;
-            release = true;
-        } else if (arg == 'g') {
-            drag    = true;
-            release = true;
-        } else {
-            return "bind: invalid flag";
+        switch (arg) {
+            case 'l': locked = true; break;
+            case 'r': release = true; break;
+            case 'e': repeat = true; break;
+            case 'm': mouse = true; break;
+            case 'n': nonConsuming = true; break;
+            case 't': transparent = true; break;
+            case 'i': ignoreMods = true; break;
+            case 's': multiKey = true; break;
+            case 'o': longPress = true; break;
+            case 'd': hasDescription = true; break;
+            case 'p': dontInhibit = true; break;
+            case 'c':
+                click   = true;
+                release = true;
+                break;
+            case 'g':
+                drag    = true;
+                release = true;
+                break;
+            case 'u': submapUniversal = true; break;
+            default: return "bind: invalid flag";
         }
     }
 
@@ -2667,7 +2660,7 @@ std::optional<std::string> CConfigManager::handleBind(const std::string& command
         g_pKeybindManager->addKeybind(SKeybind{parsedKey.key, KEYSYMS,      parsedKey.keycode, parsedKey.catchAll, MOD,      MODS,           HANDLER,
                                                COMMAND,       locked,       m_currentSubmap,   DESCRIPTION,        release,  repeat,         longPress,
                                                mouse,         nonConsuming, transparent,       ignoreMods,         multiKey, hasDescription, dontInhibit,
-                                               click,         drag});
+                                               click,         drag,         submapUniversal});
     }
 
     return {};

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1018,6 +1018,7 @@ static std::string bindsRequest(eHyprCtlOutputFormat format, std::string request
     "has_description": {},
     "modmask": {},
     "submap": "{}",
+    "submap_universal": "{}",
     "key": "{}",
     "keycode": {},
     "catch_all": {},
@@ -1026,8 +1027,9 @@ static std::string bindsRequest(eHyprCtlOutputFormat format, std::string request
     "arg": "{}"
 }},)#",
                 kb->locked ? "true" : "false", kb->mouse ? "true" : "false", kb->release ? "true" : "false", kb->repeat ? "true" : "false", kb->longPress ? "true" : "false",
-                kb->nonConsuming ? "true" : "false", kb->hasDescription ? "true" : "false", kb->modmask, escapeJSONStrings(kb->submap.name), escapeJSONStrings(kb->key),
-                kb->keycode, kb->catchAll ? "true" : "false", escapeJSONStrings(kb->description), escapeJSONStrings(kb->handler), escapeJSONStrings(kb->arg));
+                kb->nonConsuming ? "true" : "false", kb->hasDescription ? "true" : "false", kb->modmask, escapeJSONStrings(kb->submap.name), kb->submapUniversal,
+                escapeJSONStrings(kb->key), kb->keycode, kb->catchAll ? "true" : "false", escapeJSONStrings(kb->description), escapeJSONStrings(kb->handler),
+                escapeJSONStrings(kb->arg));
         }
         trimTrailingComma(ret);
         ret += "]";

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -680,7 +680,7 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
         if (!k->locked && g_pSessionLockManager->isSessionLocked())
             continue;
 
-        if (!IGNORECONDITIONS && ((modmask != k->modmask && !k->ignoreMods) || k->submap != m_currentSelectedSubmap || k->shadowed))
+        if (!IGNORECONDITIONS && ((modmask != k->modmask && !k->ignoreMods) || (k->submap != m_currentSelectedSubmap && !k->submapUniversal) || k->shadowed))
             continue;
 
         if (k->multiKey) {

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -26,29 +26,30 @@ struct SSubmap {
 };
 
 struct SKeybind {
-    std::string            key            = "";
-    std::set<xkb_keysym_t> sMkKeys        = {};
-    uint32_t               keycode        = 0;
-    bool                   catchAll       = false;
-    uint32_t               modmask        = 0;
-    std::set<xkb_keysym_t> sMkMods        = {};
-    std::string            handler        = "";
-    std::string            arg            = "";
-    bool                   locked         = false;
-    SSubmap                submap         = {};
-    std::string            description    = "";
-    bool                   release        = false;
-    bool                   repeat         = false;
-    bool                   longPress      = false;
-    bool                   mouse          = false;
-    bool                   nonConsuming   = false;
-    bool                   transparent    = false;
-    bool                   ignoreMods     = false;
-    bool                   multiKey       = false;
-    bool                   hasDescription = false;
-    bool                   dontInhibit    = false;
-    bool                   click          = false;
-    bool                   drag           = false;
+    std::string            key             = "";
+    std::set<xkb_keysym_t> sMkKeys         = {};
+    uint32_t               keycode         = 0;
+    bool                   catchAll        = false;
+    uint32_t               modmask         = 0;
+    std::set<xkb_keysym_t> sMkMods         = {};
+    std::string            handler         = "";
+    std::string            arg             = "";
+    bool                   locked          = false;
+    SSubmap                submap          = {};
+    std::string            description     = "";
+    bool                   release         = false;
+    bool                   repeat          = false;
+    bool                   longPress       = false;
+    bool                   mouse           = false;
+    bool                   nonConsuming    = false;
+    bool                   transparent     = false;
+    bool                   ignoreMods      = false;
+    bool                   multiKey        = false;
+    bool                   hasDescription  = false;
+    bool                   dontInhibit     = false;
+    bool                   click           = false;
+    bool                   drag            = false;
+    bool                   submapUniversal = false;
 
     // DO NOT INITIALIZE
     bool shadowed = false;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Implements #11818. Added bind flag (u) that makes the bind ignore the submap so it is active no matter the current submap.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I updated syntax in the bind argument loop to remove {} as many cases are one liners, just checking that this is the correct style.
https://github.com/Brumus14/Hyprland/blob/71052a3850eebfae67275c60828a5efdfbde2d01/src/config/ConfigManager.cpp#L2568-L2601


#### Is it ready for merging, or does it need work?
Should be ready for merging.


