### PR TITLE
renderer: remove opengl:nvidia_anti_flicker

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1467,17 +1467,6 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
     },
 
     /*
-     * opengl:
-     */
-
-    SConfigOptionDescription{
-        .value       = "opengl:nvidia_anti_flicker",
-        .description = "reduces flickering on nvidia at the cost of possible frame drops on lower-end GPUs. On non-nvidia, this is ignored.",
-        .type        = CONFIG_OPTION_BOOL,
-        .data        = SConfigOptionDescription::SBoolData{true},
-    },
-
-    /*
      * render:
      */
 

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -736,8 +736,6 @@ CConfigManager::CConfigManager() {
     registerConfigVar("xwayland:force_zero_scaling", Hyprlang::INT{0});
     registerConfigVar("xwayland:create_abstract_socket", Hyprlang::INT{0});
 
-    registerConfigVar("opengl:nvidia_anti_flicker", Hyprlang::INT{1});
-
     registerConfigVar("cursor:invisible", Hyprlang::INT{0});
     registerConfigVar("cursor:no_hardware_cursors", Hyprlang::INT{2});
     registerConfigVar("cursor:no_break_fs_vrr", Hyprlang::INT{2});

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2298,7 +2298,6 @@ bool CHyprRenderer::beginRender(PHLMONITOR pMonitor, CRegion& damage, eRenderMod
 
 void CHyprRenderer::endRender(const std::function<void()>& renderingDoneCallback) {
     const auto  PMONITOR           = g_pHyprOpenGL->m_renderData.pMonitor;
-    static auto PNVIDIAANTIFLICKER = CConfigValue<Hyprlang::INT>("opengl:nvidia_anti_flicker");
 
     g_pHyprOpenGL->m_renderData.damage = m_renderPass.render(g_pHyprOpenGL->m_renderData.damage);
 
@@ -2326,8 +2325,8 @@ void CHyprRenderer::endRender(const std::function<void()>& renderingDoneCallback
     if (!g_pHyprOpenGL->explicitSyncSupported()) {
         Debug::log(TRACE, "renderer: Explicit sync unsupported, falling back to implicit in endRender");
 
-        // nvidia doesn't have implicit sync, so we have to explicitly wait here, llvmpipe and other software renderer seems to bug out aswell.
-        if ((isNvidia() && *PNVIDIAANTIFLICKER) || isSoftware())
+        // llvmpipe and other software renderer seems to bug out if we don't wait here.
+        if (isSoftware())
             glFinish();
         else
             glFlush(); // mark an implicit sync point


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

we use explicit sync now so this option is useless afaik. I've been running with the option disabled since the inception of syncobj in Hyprland without issues.

https://github.com/hyprwm/Hyprland/issues/9361#issuecomment-2646299276

keep the glfinish() there because as stated it may help with sw renderers

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

breaking change that the option is removed i guess

#### Is it ready for merging, or does it need work?

mhm
