### PR TITLE
layer-shell: fix fullscreen alpha when changing layers

### DIFF
--- a/src/desktop/LayerSurface.cpp
+++ b/src/desktop/LayerSurface.cpp
@@ -303,7 +303,7 @@ void CLayerSurface::onCommit() {
             auto PWORKSPACE = PMONITOR->m_activeSpecialWorkspace ? PMONITOR->m_activeSpecialWorkspace : PMONITOR->m_activeWorkspace;
             if (PWORKSPACE && PWORKSPACE->m_fullscreenMode == FSMODE_FULLSCREEN) {
                 // warp if switching render layer so we don't see glitches and have clean fade
-                if ((m_layer == ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM || m_layer == ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM) &&
+                if ((m_layer == ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND || m_layer == ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM) &&
                     (m_layerSurface->m_current.layer == ZWLR_LAYER_SHELL_V1_LAYER_TOP || m_layerSurface->m_current.layer == ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY))
                     m_alpha->setValueAndWarp(0.f);
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

#### Describe your PR, what does it fix/add?
So I was experimenting with switching the layer of my bar on demand to show it above fullscreen windows. But then I noticed that hyprland doesn't change the alpha of a layer surface if it switches layer. ~~Additionally layers opened on the `top` layer with a window in fullscreen wouldn't have their alpha set correctly either.~~

So this MR fixes most of these issues when a window is in fullscreen:
- ~~Opening a `top` layer is invisible as it should be~~ (apparently this is intended)
- Moving a layer from `overlay` to somewhere else makes it invisible
- Moving a layer to `overlay` makes it visible
- The moving between `background` or `bottom` and `top` works correctly without artifacts (one minor issue see below)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
There are two anomalies which still exist with the current approach but I don't think they are fixed without increasing complexity/rewriting a lot:
- When moving from `overlay` to `bottom` or `background` it does not fade - it just disappears (because the layer stays visible, just the order changed).
- When the fullscreened window is partially transparent, moving between `background` or `bottom` and `top` or `overlay` looks a bit weird but I don't even know what the correct behaviour would be in this case.

#### Is it ready for merging, or does it need work?
yes

