### PR TITLE
Fix: add XBGR2101010 format to screencopy_force_8b

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -3323,7 +3323,7 @@ uint32_t CHyprOpenGLImpl::getPreferredReadFormat(PHLMONITOR pMonitor) {
 
     auto fmt = pMonitor->m_output->state->state().drmFormat;
 
-    if (fmt == DRM_FORMAT_BGRA1010102 || fmt == DRM_FORMAT_ARGB2101010 || fmt == DRM_FORMAT_XRGB2101010 || fmt == DRM_FORMAT_BGRX1010102)
+    if (fmt == DRM_FORMAT_BGRA1010102 || fmt == DRM_FORMAT_ARGB2101010 || fmt == DRM_FORMAT_XRGB2101010 || fmt == DRM_FORMAT_BGRX1010102 || fmt == DRM_FORMAT_XBGR2101010)
         return DRM_FORMAT_XRGB8888;
 
     return fmt;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->
#### Describe your PR, what does it fix/add?

Adds missing DRM_FORMAT_XBGR2101010 to screencopy_force_8b that leads to "no more input formats" Pipewire error for monitors set to 10-bit color depth/where currentFormat is XBGR2101010.

Fixes implementation from #11623
Fixes hyprwm/xdg-desktop-portal-hyprland#270
Fixes hyprwm/xdg-desktop-portal-hyprland#102

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Edits limited to single conditional statement that left out the format when forcing 8-bit color depth for screensharing.  Should not cause any issues.  In testing, works with applications that previously required manually changing monitor to 8-bit color depth in conf.

#### Is it ready for merging, or does it need work?
Should be ready for merge.

