### PR TITLE
cm: handle CM for SDR content with cm=hdr, cm_sdr_eotf=2

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1698,7 +1698,9 @@ void CHyprOpenGLImpl::renderTextureInternal(SP<CTexture> tex, const CBox& box, c
     const bool skipCM = !*PENABLECM || !m_cmSupported                                            /* CM unsupported or disabled */
         || m_renderData.pMonitor->doesNoShaderCM()                                               /* no shader needed */
         || (imageDescription == m_renderData.pMonitor->m_imageDescription && !data.cmBackToSRGB) /* Source and target have the same image description */
-        || (((*PPASS && canPassHDRSurface) || (*PPASS == 1 && !isHDRSurface)) && m_renderData.pMonitor->inFullscreenMode()) /* Fullscreen window with pass cm enabled */;
+        || (((*PPASS && canPassHDRSurface) ||
+             (*PPASS == 1 && !isHDRSurface && m_renderData.pMonitor->m_cmType != NCMType::CM_HDR && m_renderData.pMonitor->m_cmType != NCMType::CM_HDR_EDID)) &&
+            m_renderData.pMonitor->inFullscreenMode()) /* Fullscreen window with pass cm enabled */;
 
     if (!skipCM && !usingFinalShader && (texType == TEXTURE_RGBA || texType == TEXTURE_RGBX))
         shader = &m_shaders->m_shCM;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Primarily, stops colors from getting blown out when viewing some SDR content with `cm=hdr`.

Some SDR surfaces were both skipping color management and getting DS in HDR mode (`cm=hdr`, **not** Auto-HDR) when they shouldn't have been. This PR makes the conditions more strict by checking for SDR<->HDR mismatch, and differentiating being in HDR due to Auto-HDR, or manually using `cm=hdr(edid)`.

Fixing this also brought to light how `cm_sdr_eotf=2` would cause DS blockage because rendering sRGB EOTF as Gamma 2.2 on a Gamma 2.2 monitor still compared them in `canNoShaderCM()` as `srgb != gamma22`, so I threw in a check for that.

Resolves https://github.com/hyprwm/Hyprland/discussions/12104

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Tested `cm=hdr` with VLC and MPV, and gamescope: No blown-out colors
Tested `cm_sdr_eotf=2` with `vkcube`: color management not listed in `directScanoutBlockedBy`

#### Is it ready for merging, or does it need work?

Ready for merging
