### PR TITLE
Allow DS for surfaces with inert subsurfaces

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1927,13 +1927,18 @@ SP<CWLSurfaceResource> CWindow::getSolitaryResource() {
     if (res->m_subsurfaces.size() == 0)
         return res;
 
-    if (res->m_subsurfaces.size() == 1) {
-        if (res->m_subsurfaces[0].expired() || res->m_subsurfaces[0]->m_surface.expired())
-            return nullptr;
-        auto surf = res->m_subsurfaces[0]->m_surface.lock();
-        if (!surf || surf->m_subsurfaces.size() != 0 || surf->extends() != res->extends() || !surf->m_current.texture || !surf->m_current.texture->m_opaque)
-            return nullptr;
-        return surf;
+    if (res->m_subsurfaces.size() >= 1) {
+        if (!res->hasVisibleSubsurface())
+            return res;
+
+        if (res->m_subsurfaces.size() == 1) {
+            if (res->m_subsurfaces[0].expired() || res->m_subsurfaces[0]->m_surface.expired())
+                return nullptr;
+            auto surf = res->m_subsurfaces[0]->m_surface.lock();
+            if (!surf || surf->m_subsurfaces.size() != 0 || surf->extends() != res->extends() || !surf->m_current.texture || !surf->m_current.texture->m_opaque)
+                return nullptr;
+            return surf;
+        }
     }
 
     return nullptr;

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -602,6 +602,19 @@ void CWLSurfaceResource::sortSubsurfaces() {
     }
 }
 
+bool CWLSurfaceResource::hasVisibleSubsurface() {
+    for (auto const& subsurface : m_subsurfaces) {
+        if (!subsurface || !subsurface->m_surface)
+            continue;
+
+        const auto& surf = subsurface->m_surface;
+        if (surf->m_current.size.x > 0 && surf->m_current.size.y > 0)
+            return true;
+    }
+
+    return false;
+}
+
 void CWLSurfaceResource::updateCursorShm(CRegion damage) {
     if (damage.empty())
         return;

--- a/src/protocols/core/Compositor.hpp
+++ b/src/protocols/core/Compositor.hpp
@@ -128,6 +128,7 @@ class CWLSurfaceResource {
     void                                   commitState(SSurfaceState& state);
     NColorManagement::SImageDescription    getPreferredImageDescription();
     void                                   sortSubsurfaces();
+    bool                                   hasVisibleSubsurface();
 
     // returns a pair: found surface (null if not found) and surface local coords.
     // localCoords param is relative to 0,0 of this surface


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Gets DS working with Gamescope. `gamescope --mangoapp` disables DS for `subsurfaces`, and toggling it on/off with `Shift_R+F12` works as expected.
Note: Gamescope doesn't do hardware cursors with its Wayland backend, so moving the cursor will go in/out of DS. This outcome is the same as Sway, and works fine for games with captured cursors, so I think it's okay. Given that toggling `mangoapp` doesn't cause this stutter, it's probably a Gamescope issue.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

My knowledge of subsurfaces is lacking. If this is stupid, please say so.

#### Is it ready for merging, or does it need work?

Ready
