### PR TITLE
screencopy: wait longer to re-enable DS

### DIFF
--- a/src/protocols/Screencopy.cpp
+++ b/src/protocols/Screencopy.cpp
@@ -513,6 +513,10 @@ void CScreencopyProtocol::destroyResource(CScreencopyFrame* frame) {
 
 void CScreencopyProtocol::onOutputCommit(PHLMONITOR pMonitor) {
     if (m_framesAwaitingWrite.empty()) {
+        for (auto client : m_clients) {
+            if (client->m_framesInLastHalfSecond > 0)
+                return;
+        }
         g_pHyprRenderer->m_directScanoutBlocked = false;
         return; // nothing to share
     }


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

When screen-recording, DS constantly enables/disables between frames if the capture framerate is lower than the render framerate, causing frequent stutter (games) and modesets (VLC, non-shader CM). This change gives it some headroom before re-enabling DS.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Tested with games/VLC and capturing with `gpu-screen-recorder` w/ pipewire capture, and OBS.

#### Is it ready for merging, or does it need work?

Ready
