### PR TITLE
sessionlock: fix crash when sendScale is called on a disconnected and…

### DIFF
--- a/src/protocols/SessionLock.cpp
+++ b/src/protocols/SessionLock.cpp
@@ -57,8 +57,8 @@ CSessionLockSurface::CSessionLockSurface(SP<CExtSessionLockSurfaceV1> resource_,
         m_surface.reset();
     });
 
-    if (auto monitor = m_monitor.lock())
-        PROTO::fractional->sendScale(surface_, monitor->m_scale);
+    if (m_monitor)
+        PROTO::fractional->sendScale(surface_, m_monitor->m_scale);
 
     sendConfigure();
 
@@ -74,14 +74,13 @@ CSessionLockSurface::~CSessionLockSurface() {
 }
 
 void CSessionLockSurface::sendConfigure() {
-    auto monitor = m_monitor.lock();
-    if (!monitor) {
+    if (!m_monitor) {
         LOGM(ERR, "sendConfigure: monitor is gone");
         return;
     }
 
     const auto SERIAL = g_pSeatManager->nextSerial(g_pSeatManager->seatResourceForClient(m_resource->client()));
-    m_resource->sendConfigure(SERIAL, monitor->m_size.x, monitor->m_size.y);
+    m_resource->sendConfigure(SERIAL, m_monitor->m_size.x, m_monitor->m_size.y);
 }
 
 bool CSessionLockSurface::good() {


### PR DESCRIPTION
# Fix Hyprland Crash in `sendScale` when Monitor is Gone

Hyprland crashed with a segmentation fault in the `sendScale` function of the `SessionLock` protocol when the associated monitor was no longer available. This happened because the code attempted to access the monitor without checking if it was still valid. I've attached the crash report as [hyprlandCrashReport169.txt](https://github.com/user-attachments/files/23229862/hyprlandCrashReport169.txt)

This happened when:

1. An external monitor (DP-1) was disconnected and, therefore, destroyed.
2. `sendScale` was called on a `CSessionLockSurface` that referenced the now-destroyed monitor.
3. The code tried to access the monitor's scale property without verifying that the monitor pointer was still valid.

In `SessionLock.cpp`, the `CSessionLockSurface` constructor accessed the monitor's scale without checking if the monitor pointer was still valid:

```cpp
PROTO::fractional->sendScale(surface_, pMonitor_->m_scale);
```

This could also occur in the `sendConfigure` method:

```cpp
m_resource->sendConfigure(SERIAL, m_monitor->m_size.x, m_monitor->m_size.y);
```

## Fix

To fix this issue, I added checks to ensure that the monitor pointer is valid before accessing its properties using lock guards.
