### PR TITLE
handle null pointer in CLinuxDMABufV1Protocol::resetFormatTable

### DIFF
--- a/src/protocols/LinuxDMABUF.cpp
+++ b/src/protocols/LinuxDMABUF.cpp
@@ -507,13 +507,17 @@ void CLinuxDMABufV1Protocol::resetFormatTable() {
         if (feedback->m_lastFeedbackWasScanout) {
             PHLMONITOR mon;
             auto       HLSurface = CWLSurface::fromResource(feedback->m_surface);
+            if (!HLSurface) {
+                feedback->sendDefaultFeedback();
+                continue;
+            }
             if (auto w = HLSurface->getWindow(); w)
                 if (auto m = w->m_monitor.lock(); m)
                     mon = m->m_self.lock();
 
             if (!mon) {
                 feedback->sendDefaultFeedback();
-                return;
+                continue;
             }
 
             updateScanoutTranche(feedback->m_surface, mon);


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Crashed here non-deterministically when turning off/on secondary display.

```
Stack trace of thread 3132:
                #0  0x00007f818da9caac __pthread_kill_implementation (libc.so.6 + 0x9caac)
                #1  0x00007f818da4190e raise (libc.so.6 + 0x4190e)
                #2  0x00007f818da28942 abort (libc.so.6 + 0x28942)
                #3  0x00005561ec3e8ab0 _ZL25handleUnrecoverableSignali (/nix/store/ljq9h7w2w7b85d7zca82621gr1xyy0fb-hyprland-0.51.1/bin/.Hyprland-wrapped + 0x40aab0)
                #4  0x00007f818da419c0 __restore_rt (libc.so.6 + 0x419c0)
                #5  0x00005561ec5160c0 _ZNK10CWLSurface9getWindowEv (/nix/store/ljq9h7w2w7b85d7zca82621gr1xyy0fb-hyprland-0.51.1/bin/.Hyprland-wrapped + 0x5380c0)
                #6  0x00005561ec8630a2 _ZN22CLinuxDMABufV1Protocol16resetFormatTableEv (/nix/store/ljq9h7w2w7b85d7zca82621gr1xyy0fb-hyprland-0.51.1/bin/.Hyprland-wrapped + 0x8850a2)
                #7  0x00005561ec863f40 _ZNSt17_Function_handlerIFvPvR13SCallbackInfoSt3anyEZZN22CLinuxDMABufV1ProtocolC4EPK12wl_interfaceRKiRKNSt7__cxx1112basic_stringIcSt11char_tr>
                #8  0x00005561ec6473ff _ZN18CHookSystemManager4emitEPSt6vectorI14SCallbackFNPtrSaIS1_EER13SCallbackInfoSt3any (/nix/store/ljq9h7w2w7b85d7zca82621gr1xyy0fb-hyprland->
                #9  0x00005561ec5c9396 _ZNSt17_Function_handlerIFvvEZN8CMonitor12onDisconnectEbEUlvE_E9_M_invokeERKSt9_Any_data (/nix/store/ljq9h7w2w7b85d7zca82621gr1xyy0fb-hyprlan>
                #10 0x00007f818e92cd76 _ZN9Hyprutils5Utils11CScopeGuardD1Ev (libhyprutils.so.9 + 0x36d76)
                #11 0x00005561ec5cb57f _ZN8CMonitor12onDisconnectEb (/nix/store/ljq9h7w2w7b85d7zca82621gr1xyy0fb-hyprland-0.51.1/bin/.Hyprland-wrapped + 0x5ed57f)
                #12 0x00005561ec5cdd22 _ZN8CMonitor16applyMonitorRuleEP12SMonitorRuleb (/nix/store/ljq9h7w2w7b85d7zca82621gr1xyy0fb-hyprland-0.51.1/bin/.Hyprland-wrapped + 0x5efd22)
                #13 0x00005561ec467c06 _ZN14CConfigManager19ensureMonitorStatusEv (/nix/store/ljq9h7w2w7b85d7zca82621gr1xyy0fb-hyprland-0.51.1/bin/.Hyprland-wrapped + 0x489c06)
                #14 0x00005561ec4bb225 _ZL13hyprCtlFDTickijPv (/nix/store/ljq9h7w2w7b85d7zca82621gr1xyy0fb-hyprland-0.51.1/bin/.Hyprland-wrapped + 0x4dd225)
                #15 0x00007f818e8d51c2 wl_event_loop_dispatch (libwayland-server.so.0 + 0xd1c2)
                #16 0x00007f818e8d26d5 wl_display_run (libwayland-server.so.0 + 0xa6d5)
                #17 0x00005561ec6f8d0c _ZN17CEventLoopManager9enterLoopEv (/nix/store/ljq9h7w2w7b85d7zca82621gr1xyy0fb-hyprland-0.51.1/bin/.Hyprland-wrapped + 0x71ad0c)
                #18 0x00005561ec62b940 main (/nix/store/ljq9h7w2w7b85d7zca82621gr1xyy0fb-hyprland-0.51.1/bin/.Hyprland-wrapped + 0x64d940)
                #19 0x00007f818da2a4d8 __libc_start_call_main (libc.so.6 + 0x2a4d8)
                #20 0x00007f818da2a59b __libc_start_main@@GLIBC_2.34 (libc.so.6 + 0x2a59b)
                #21 0x00005561ec394de5 _start (/nix/store/ljq9h7w2w7b85d7zca82621gr1xyy0fb-hyprland-0.51.1/bin/.Hyprland-wrapped + 0x3b6de5)
```


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Yes?
