### PR TITLE
Change non_shader_cm ignore behavior and set default to it

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1538,7 +1538,7 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
     },
     SConfigOptionDescription{
         .value       = "render:non_shader_cm",
-        .description = "Enable CM without shader. 0 - disable, 1 - whenever possible, 2 - DS and passthrough only, 3 - don't block DS when non-shader CM isn't available",
+        .description = "Enable CM without shader. 0 - disable, 1 - whenever possible, 2 - DS and passthrough only, 3 - disable and ignore CM issues",
         .type        = CONFIG_OPTION_CHOICE,
         .data        = SConfigOptionDescription::SChoiceData{0, "disable,always,ondemand,ignore"},
     },

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -780,7 +780,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("render:send_content_type", Hyprlang::INT{1});
     registerConfigVar("render:cm_auto_hdr", Hyprlang::INT{1});
     registerConfigVar("render:new_render_scheduling", Hyprlang::INT{0});
-    registerConfigVar("render:non_shader_cm", Hyprlang::INT{2});
+    registerConfigVar("render:non_shader_cm", Hyprlang::INT{3});
     registerConfigVar("render:cm_sdr_eotf", Hyprlang::INT{0});
 
     registerConfigVar("ecosystem:no_update_news", Hyprlang::INT{0});

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1588,7 +1588,8 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
         pMonitor->m_output->state->setContentType(NContentType::toDRM(FS_WINDOW ? FS_WINDOW->getContentType() : CONTENT_TYPE_NONE));
 
     if (FS_WINDOW != pMonitor->m_previousFSWindow) {
-        if (!FS_WINDOW || !pMonitor->needsCM() || !pMonitor->canNoShaderCM() || (*PNONSHADER == CM_NS_ONDEMAND && pMonitor->m_lastScanout.expired() && *PPASS != 1)) {
+        if (*PNONSHADER == CM_NS_IGNORE || !FS_WINDOW || !pMonitor->needsCM() || !pMonitor->canNoShaderCM() ||
+            (*PNONSHADER == CM_NS_ONDEMAND && pMonitor->m_lastScanout.expired() && *PPASS != 1)) {
             if (pMonitor->m_noShaderCTM) {
                 Debug::log(INFO, "[CM] No fullscreen CTM, restoring previous one");
                 pMonitor->m_noShaderCTM = false;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
`render:non_shader_cm = 3` now disables non shader CM. Should work the same as it was before this feature.

`render:non_shader_cm` is meant to fix oversaturated colors in fullscreen games when DS is active. It turned out that DS might be activated by a much wider set of apps which leads to unwanted behavior. `render:non_shader_cm = 0` fixes this issue but also blocks DS when CM is needed.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Someone should fix `render:non_shader_cm = 1` interaction with hyprsunset and similar tools or make `render:non_shader_cm = 2` to work only with games (assuming nobody wants hyprsunset modifications in games)

#### Is it ready for merging, or does it need work?
Ready
