### PR TITLE
cm: scale reference luminance when tonemapping

### DIFF
--- a/src/protocols/types/ColorManagement.hpp
+++ b/src/protocols/types/ColorManagement.hpp
@@ -6,8 +6,10 @@
 
 #define SDR_MIN_LUMINANCE 0.2
 #define SDR_MAX_LUMINANCE 80.0
+#define SDR_REF_LUMINANCE 80.0
 #define HDR_MIN_LUMINANCE 0.005
 #define HDR_MAX_LUMINANCE 10000.0
+#define HDR_REF_LUMINANCE 203.0
 #define HLG_MAX_LUMINANCE 1000.0
 
 namespace NColorManagement {
@@ -225,6 +227,25 @@ namespace NColorManagement {
                 case CM_TRANSFER_FUNCTION_ST428:
                 case CM_TRANSFER_FUNCTION_SRGB:
                 default: return sdrMaxLuminance >= 0 ? sdrMaxLuminance : SDR_MAX_LUMINANCE;
+            }
+        };
+
+        float getTFRefLuminance(int sdrRefLuminance = -1) const {
+            switch (transferFunction) {
+                case CM_TRANSFER_FUNCTION_EXT_LINEAR:
+                case CM_TRANSFER_FUNCTION_ST2084_PQ:
+                case CM_TRANSFER_FUNCTION_HLG: return HDR_REF_LUMINANCE;
+                case CM_TRANSFER_FUNCTION_GAMMA22:
+                case CM_TRANSFER_FUNCTION_GAMMA28:
+                case CM_TRANSFER_FUNCTION_BT1886:
+                case CM_TRANSFER_FUNCTION_ST240:
+                case CM_TRANSFER_FUNCTION_LOG_100:
+                case CM_TRANSFER_FUNCTION_LOG_316:
+                case CM_TRANSFER_FUNCTION_XVYCC:
+                case CM_TRANSFER_FUNCTION_EXT_SRGB:
+                case CM_TRANSFER_FUNCTION_ST428:
+                case CM_TRANSFER_FUNCTION_SRGB:
+                default: return sdrRefLuminance >= 0 ? sdrRefLuminance : SDR_REF_LUMINANCE;
             }
         };
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Simpler alternative to https://github.com/hyprwm/Hyprland/pull/12204

When tonemapping from HDR to SDR, scale the HDR source's reference luminance (203) to SDR (80). Prevents HDR screenshare from blowing out the brightness.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Unlike https://github.com/hyprwm/Hyprland/pull/12204, this method makes games typically look closer to how they do in SDR, at the risk of losing highlight detail that a game's native tonemapper might prioritize better.

Screenshots are of an extremely bright area, sort of a worst-case scenario, to emphasize the difference.

HDR-to-SDR on `master`:
<img width="1245" height="700" alt="image" src="https://github.com/user-attachments/assets/88d459a5-bcfd-4600-8be8-3d195ed29f56" />


HDR-to-SDR with this PR:
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/9fc37838-5378-4514-b2ba-9298677e1186" />

Native SDR:
<img width="2863" height="1599" alt="image" src="https://github.com/user-attachments/assets/21254481-6fde-4dc0-bed1-bfc667dd44fa" />

Also brings in a quick fix for https://github.com/hyprwm/Hyprland/pull/12094, which made screensharing too dark when `render:cm_sdr_eotf` > 0, which became apparent when testing this.

#### Is it ready for merging, or does it need work?

Heavily WIP
