### PR TITLE
Fix fractional scale artifact

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1137,13 +1137,11 @@ void CHyprRenderer::calculateUVForSurface(PHLWINDOW pWindow, SP<CWLSurfaceResour
             const Vector2D MISALIGNMENT = pSurface->m_current.bufferSize - projSize;
             if (MISALIGNMENT != Vector2D{})
                 uvBR -= MISALIGNMENT * PIXELASUV;
-        }
-
-        // if the surface is smaller than our viewport, extend its edges.
-        // this will break if later on xdg geometry is hit, but we really try
-        // to let the apps know to NOT add CSD. Also if source is there.
-        // there is no way to fix this if that's the case
-        {
+        } else {
+            // if the surface is smaller than our viewport, extend its edges.
+            // this will break if later on xdg geometry is hit, but we really try
+            // to let the apps know to NOT add CSD. Also if source is there.
+            // there is no way to fix this if that's the case
             const auto MONITOR_WL_SCALE = std::ceil(pMonitor->m_scale);
             const bool SCALE_UNAWARE    = MONITOR_WL_SCALE > 1 && (MONITOR_WL_SCALE == pSurface->m_current.scale || !pSurface->m_current.viewport.hasDestination);
             const auto EXPECTED_SIZE    = getSurfaceExpectedSize(pWindow, pSurface, pMonitor, main).value_or((projSize * pMonitor->m_scale).round());


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
* In fractional scaling environments, we confirmed that the shrink adjustment for `render:expand_undersized_textures` was reacting even to rounding errors of less than 1px, causing textures to be unnecessarily trimmed.
* In `CHyprRenderer::calculateUVForSurface`, we introduced a 1px threshold to the `projSize < EXPECTED_SIZE` check so that UVs are only shrunk on axes where the actually visible area is sufficiently smaller than the expected size.
* As a result, pixel-level offsets under fractional scaling are eliminated, while the original behavior is preserved in scenarios where the texture should indeed be reduced.

- before

<img width="520" height="786" alt="image" src="https://github.com/user-attachments/assets/a243b7b6-2c00-4a77-882d-ea817ad14635" />

- after

<img width="473" height="786" alt="image" src="https://github.com/user-attachments/assets/0427709e-b7d9-407c-987c-523356319d7b" />


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
For now, there’s nothing in particular.

#### Is it ready for merging, or does it need work?
ready