### PR TITLE
chore: fix non-relative imports

### DIFF
--- a/src/protocols/core/Compositor.hpp
+++ b/src/protocols/core/Compositor.hpp
@@ -13,7 +13,7 @@
 #include <cstdint>
 #include "../WaylandProtocol.hpp"
 #include "../../render/Texture.hpp"
-#include "protocols/types/SurfaceStateQueue.hpp"
+#include "../types/SurfaceStateQueue.hpp"
 #include "wayland.hpp"
 #include "../../helpers/signal/Signal.hpp"
 #include "../../helpers/math/Math.hpp"

--- a/src/protocols/types/SurfaceStateQueue.hpp
+++ b/src/protocols/types/SurfaceStateQueue.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "helpers/memory/Memory.hpp"
+#include "../../helpers/memory/Memory.hpp"
 #include "SurfaceState.hpp"
 #include <deque>
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Fix non-relative imports because they breaks plugins:
```
error: builder for '/nix/store/izl4gpd0b5n7s1i0yw6y667zp11lmzzr-csgo-vulkan-fix-0.1.drv' failed with exit code 2;
       last 25 log lines:
       >     CMAKE_INSTALL_INFODIR
       >     CMAKE_INSTALL_LIBEXECDIR
       >     CMAKE_INSTALL_LOCALEDIR
       >     CMAKE_INSTALL_MANDIR
       >     CMAKE_INSTALL_SBINDIR
       >     CMAKE_POLICY_DEFAULT_CMP0025
       >
       > 
       > -- Build files have been written to: /build/csgo-vulkan-fix/build
       > cmake: enabled parallel building
       > cmake: enabled parallel installing
       > Running phase: buildPhase
       > build flags: -j32 SHELL=/nix/store/ciarnmsx8lvsrmdbjddpmx0pqjrm8imb-bash-5.3p3/bin/bash
       > [ 33%] Building CXX object CMakeFiles/csgo-vulkan-fix.dir/CMakeFiles/4.1.2/CompilerIdCXX/CMakeCXXCompilerId.cpp.o
       > [ 66%] Building CXX object CMakeFiles/csgo-vulkan-fix.dir/main.cpp.o
       > In file included from /nix/store/kgdwsplygkd8ix1ivy7v0v0r03ilhdfg-hyprland-0.51.0+date=2025-11-06_8e8bfbb-dev/include/hyprland/src/render/OpenGL.hpp:33,
       >                  from /nix/store/kgdwsplygkd8ix1ivy7v0v0r03ilhdfg-hyprland-0.51.0+date=2025-11-06_8e8bfbb-dev/include/hyprland/src/render/Renderer.hpp:7,
       >                  from /build/csgo-vulkan-fix/main.cpp:10:
       > /nix/store/kgdwsplygkd8ix1ivy7v0v0r03ilhdfg-hyprland-0.51.0+date=2025-11-06_8e8bfbb-dev/include/hyprland/src/protocols/core/Compositor.hpp:16:10: fatal error: protocols/types/SurfaceStateQueue.hpp: No such file or directory
       >    16 | #include "protocols/types/SurfaceStateQueue.hpp"
       >       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       > compilation terminated.
       > make[2]: *** [CMakeFiles/csgo-vulkan-fix.dir/build.make:93: CMakeFiles/csgo-vulkan-fix.dir/main.cpp.o] Error 1
       > make[1]: *** [CMakeFiles/Makefile2:87: CMakeFiles/csgo-vulkan-fix.dir/all] Error 2
       > make: *** [Makefile:136: all] Error 2
       For full logs, run 'nix log /nix/store/izl4gpd0b5n7s1i0yw6y667zp11lmzzr-csgo-vulkan-fix-0.1.drv'.
```


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

/


#### Is it ready for merging, or does it need work?

Builds using this ref:
```
hyprland-plugins on  chase-hyprland:main [≡✶⇡] via △ via   took 18s 
› nix flake update hyprland  
warning: Git tree '/home/amadejk/Documents/hyprland-plugins' is dirty
warning: updating lock file '/home/amadejk/Documents/hyprland-plugins/flake.lock':
• Updated input 'hyprland':
    'github:amadejkastelic/Hyprland/2522af59e3466fe828d5aedb59958774423632b9' (2025-11-06)
  → 'github:amadejkastelic/Hyprland/b4176440e1dec015af1ae2e721ef32e1888ff431' (2025-11-06)
warning: Git tree '/home/amadejk/Documents/hyprland-plugins' is dirty

hyprland-plugins on  chase-hyprland:main [≡✶⇡] via △ via   took 4s 
› nix build .#csgo-vulkan-fix                    
warning: Git tree '/home/amadejk/Documents/hyprland-plugins' is dirty

hyprland-plugins on  chase-hyprland:main [≡✶⇡] via △ via   took 1m36s 
› ll result/lib/libcsgo-vulkan-fix.so                             
.r-xr-xr-x 139k root  1 Jan  1970  result/lib/libcsgo-vulkan-fix.so
```
