### PR TITLE
cm: follow preferred srgb eotf for screencopy

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1711,7 +1711,9 @@ void CHyprOpenGLImpl::renderTextureInternal(SP<CTexture> tex, const CBox& box, c
             // revert luma changes to avoid black screenshots.
             // this will likely not be 1:1, and might cause screenshots to be too bright, but it's better than pitch black.
             imageDescription.luminances = {};
-            passCMUniforms(*shader, imageDescription, NColorManagement::SImageDescription{}, true, -1, -1);
+            static auto PSDREOTF        = CConfigValue<Hyprlang::INT>("render:cm_sdr_eotf");
+            auto        chosenSdrEotf   = *PSDREOTF > 0 ? NColorManagement::CM_TRANSFER_FUNCTION_GAMMA22 : NColorManagement::CM_TRANSFER_FUNCTION_SRGB;
+            passCMUniforms(*shader, imageDescription, NColorManagement::SImageDescription{.transferFunction = chosenSdrEotf}, true, -1, -1);
         } else
             passCMUniforms(*shader, imageDescription);
     }


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Following https://github.com/hyprwm/Hyprland/pull/12094, setting `render:cm_srgb_eotf` above `0` for Gamma 2.2 caused a screencopy procedure of Gamma 2.2 -> sRGB, resulting in crushed black levels. This PR assumes the preferred SDR EOTF for screencopy, to get a 1:1 capture.

Before:
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/30465b7e-2f3d-407b-864e-3eed39173bd7" />


After:
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/867899f5-d2a4-4773-b2d8-890b8e062df9" />


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?

Ready
