### PR TITLE
protocols: fix wlr-randr by defering success event until monitor reloads

### DIFF
--- a/src/protocols/OutputManagement.hpp
+++ b/src/protocols/OutputManagement.hpp
@@ -141,8 +141,12 @@ class COutputConfiguration {
     SP<CZwlrOutputConfigurationV1>            m_resource;
     std::vector<WP<COutputConfigurationHead>> m_heads;
     WP<COutputManager>                        m_owner;
+    WP<COutputConfiguration>                  m_self;
 
     bool                                      applyTestConfiguration(bool test);
+
+    friend class COutputManagementProtocol;
+    friend class COutputManager;
 };
 
 class COutputManagementProtocol : public IWaylandProtocol {
@@ -153,6 +157,8 @@ class COutputManagementProtocol : public IWaylandProtocol {
 
     // doesn't have to return one
     SP<SWlrManagerSavedOutputState> getOutputStateFor(PHLMONITOR pMonitor);
+
+    void                            sendPendingSuccessEvents();
 
   private:
     void destroyResource(COutputManager* resource);
@@ -169,6 +175,7 @@ class COutputManagementProtocol : public IWaylandProtocol {
     std::vector<SP<COutputMode>>              m_modes;
     std::vector<SP<COutputConfiguration>>     m_configurations;
     std::vector<SP<COutputConfigurationHead>> m_configurationHeads;
+    std::vector<WP<COutputConfiguration>>     m_pendingConfigurationSuccessEvents;
 
     SP<COutputHead>                           headFromResource(wl_resource* r);
     SP<COutputMode>                           modeFromResource(wl_resource* r);


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

This fixes issues with wlr-randr not applying any changes.

The issue was:
- wlr-randr sets configuration
- hyprland immediately sends success event
- wlr-randr disconnects upon receiving the success event
- performMonitorReload executes but the configuration was already lost

This PR postpones the success event until the performMonitorReload completes, thus keeping the wlr-output-management connection alive long enough for the configuration to be applied.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I am not cpp dev, it is possible that I screwed something, thorough review required then.

#### Is it ready for merging, or does it need work?

ready for merge
