### PR TITLE
fix: do not raise error if layer surface is not anchored

### DIFF
--- a/src/protocols/LayerShell.cpp
+++ b/src/protocols/LayerShell.cpp
@@ -159,7 +159,7 @@ CLayerShellResource::CLayerShellResource(SP<CZwlrLayerSurfaceV1> resource_, SP<C
             return;
         }
 
-        if (!m_pending.anchor || !(m_pending.anchor & anchor)) {
+        if (anchor && (!m_pending.anchor || !(m_pending.anchor & anchor))) {
             r->error(ZWLR_LAYER_SURFACE_V1_ERROR_INVALID_EXCLUSIVE_EDGE, "Exclusive edge doesn't align with anchor");
             return;
         }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This reverts a change that was introduced as part of the following commit: https://github.com/hyprwm/Hyprland/commit/4d82cc595#diff-f16c4e2ac9ba86fa27f14e164d797a322b8ac9cb2d095ac9586f2009676c7b0dL162

It is unclear to me why this change was made, but it breaks layer shell surfaces that are not anchored and set an exclusive edge.

While setting an exclusive zone doesn't make much sense for surfaces that aren't anchored, most implementations, such as layer-shell-qt, still call `zwlr_layer_surface_v1_set_exclusive_edge(0)` implicitly, triggering the callback and thus the protocol error.

As an example, the https://github.com/vicinaehq/vicinae launcher  (uses layer-shell-qt) currently crashes the first time the window is shown after the layer shell surface gets initialized. 

Below is a proper wayland debug trace. With this change reverted, everything works as expected.

```
[ 254201.885] {Default Queue}  -> wl_compositor#7.create_surface(new id wl_surface#172)
[ 254201.900] {Default Queue}  -> wp_fractional_scale_manager_v1#11.get_fractional_scale(new id wp_fractional_scale_v1#45, wl_surface#172)
[ 254201.906] {Default Queue}  -> wp_viewporter#10.get_viewport(new id wp_viewport#53, wl_surface#172)
[ 254206.742] {Default Queue}  -> wl_registry#2.bind(24, "xdg_activation_v1", 1, new id [unknown]#115)
[ 254206.755] {Default Queue}  -> wl_registry#2.bind(35, "zwlr_layer_shell_v1", 5, new id [unknown]#125)
[ 254206.788] {Default Queue}  -> wp_viewport#53.set_destination(770, 480)
[ 254206.796] {Default Queue}  -> zwlr_layer_shell_v1#125.get_layer_surface(new id zwlr_layer_surface_v1#128, wl_surface#172, nil, 3, "vicinae")
[ 254206.800] {Default Queue}  -> zwlr_layer_surface_v1#128.set_anchor(0)
[ 254206.801] {Default Queue}  -> zwlr_layer_surface_v1#128.set_exclusive_zone(0)
[ 254206.803] {Default Queue}  -> zwlr_layer_surface_v1#128.set_exclusive_edge(0)
[ 254206.804] {Default Queue}  -> zwlr_layer_surface_v1#128.set_margin(0, 0, 0, 0)
[ 254206.808] {Default Queue}  -> zwlr_layer_surface_v1#128.set_keyboard_interactivity(1)
[ 254206.809] {Default Queue}  -> zwlr_layer_surface_v1#128.set_size(770, 480)
[ 254206.814] {Default Queue}  -> wp_viewport#53.set_destination(770, 480)
[ 254206.816] {Default Queue}  -> wp_viewport#53.set_destination(770, 480)
[ 254206.818] {Default Queue}  -> wl_surface#172.set_buffer_transform(0)
[ 254206.820] {Default Queue}  -> wl_surface#172.commit()
[ 254207.089] {Display Queue} wl_display#1.delete_id(90)
[ 254207.108] {Display Queue} wl_display#1.delete_id(81)
[ 254207.116] {Display Queue} wl_display#1.delete_id(75)
[ 254207.119] {Display Queue} wl_display#1.delete_id(69)
[ 254207.123] {Display Queue} wl_display#1.delete_id(145)
[ 254207.125] {Display Queue} wl_display#1.delete_id(153)
[ 254207.129] {Display Queue} wl_display#1.delete_id(161)
[ 254207.131] {Display Queue} wl_display#1.delete_id(169)
[ 254207.136] {Display Queue} wl_display#1.delete_id(177)
[ 254207.138] {Display Queue} wl_display#1.error(zwlr_layer_surface_v1#128, 4, "Exclusive edge doesn't align with anchor")
zwlr_layer_surface_v1#128: error 4: Exclusive edge doesn't align with anchor
[16:27:57.126] WARN   -  The Wayland connection experienced a fatal error: Protocol error
```

#### Is it ready for merging, or does it need work?

Ready for merging
