### PR TITLE
CI/release: populate git info

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,20 +8,37 @@ on:
 jobs:
   source-tarball:
     runs-on: ubuntu-latest
-    container:
-      image: archlinux
     steps:
-      - name: Checkout repository actions
-        uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v5
         with:
-          sparse-checkout: .github/actions
+          fetch-depth: 0
+          submodules: recursive
 
-      - name: Setup base
-        uses: ./.github/actions/setup_base
-
-      - name: Generate version
+      - name: Populate git info in version.h.in
         run: |
-          cmake -S . -B /tmp/build
+          git fetch --tags --unshallow || true
+
+          COMMIT_HASH=$(git rev-parse HEAD)
+          BRANCH="${GITHUB_REF_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
+          COMMIT_MSG=$(git show -s --format=%s | sed 's/[&/]/\\&/g')
+          COMMIT_DATE=$(git show -s --format=%cd --date=local)
+          GIT_DIRTY=$(git diff-index --quiet HEAD -- && echo "clean" || echo "dirty")
+          GIT_TAG=$(git describe --tags --always || echo "unknown")
+          GIT_COMMITS=$(git rev-list --count HEAD)
+
+          echo "Branch: $BRANCH"
+          echo "Tag: $GIT_TAG"
+
+          sed -i \
+            -e "s|@GIT_COMMIT_HASH@|$COMMIT_HASH|" \
+            -e "s|@GIT_BRANCH@|$BRANCH|" \
+            -e "s|@GIT_COMMIT_MESSAGE@|$COMMIT_MSG|" \
+            -e "s|@GIT_COMMIT_DATE@|$COMMIT_DATE|" \
+            -e "s|@GIT_DIRTY@|$GIT_DIRTY|" \
+            -e "s|@GIT_TAG@|$GIT_TAG|" \
+            -e "s|@GIT_COMMITS@|$GIT_COMMITS|" \
+            src/version.h.in
 
       - name: Create tarball with submodules
         id: tar


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Pre-populates git info inside `version.h.in`, leaving deps to be configured by CMake running on the user's machine.

`version.h.in` from manually running the workflow:

```c
#pragma once
#define GIT_COMMIT_HASH    "017b8e4c830d2ef7003f55218bf1ef247a122afc"
#define GIT_BRANCH         "release-workflow"
#define GIT_COMMIT_MESSAGE "CI/release: populate git info"
#define GIT_COMMIT_DATE    "Sun Nov 9 20:16:02 2025"
#define GIT_DIRTY          "clean"
#define GIT_TAG            "v0.51.1-326-g017b8e4c"
#define GIT_COMMITS        "6563"

#define AQUAMARINE_VERSION "@AQUAMARINE_VERSION@"
// clang-format off
#define AQUAMARINE_VERSION_MAJOR @AQUAMARINE_VERSION_MAJOR@
#define AQUAMARINE_VERSION_MINOR @AQUAMARINE_VERSION_MINOR@
#define AQUAMARINE_VERSION_PATCH @AQUAMARINE_VERSION_PATCH@
// clang-format on
#define HYPRLANG_VERSION     "@HYPRLANG_VERSION@"
#define HYPRUTILS_VERSION    "@HYPRUTILS_VERSION@"
#define HYPRCURSOR_VERSION   "@HYPRCURSOR_VERSION@"
#define HYPRGRAPHICS_VERSION "@HYPRGRAPHICS_VERSION@"
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Ready.
