### PR TITLE
presentation: only send sync output on presented

### DIFF
--- a/src/protocols/PresentationTime.cpp
+++ b/src/protocols/PresentationTime.cpp
@@ -43,7 +43,7 @@ bool CPresentationFeedback::good() {
 void CPresentationFeedback::sendQueued(WP<CQueuedPresentationData> data, const Time::steady_tp& when, uint32_t untilRefreshNs, uint64_t seq, uint32_t reportedFlags) {
     auto client = m_resource->client();
 
-    if LIKELY (PROTO::outputs.contains(data->m_monitor->m_name)) {
+    if LIKELY (PROTO::outputs.contains(data->m_monitor->m_name) && data->m_wasPresented) {
         if LIKELY (auto outputResource = PROTO::outputs.at(data->m_monitor->m_name)->outputResourceFrom(client); outputResource)
             m_resource->sendSyncOutput(outputResource->getResource()->resource());
     }


### PR DESCRIPTION
as protocol states there is two events. 'presented' or 'discarded'.

wp_presentation_feedback::sync_output
As presentation can be synchronized to only one output at a time, this event tells which output it was. This event is only sent prior to the presented event.

https://wayland.app/protocols/presentation-time#wp_presentation_feedback:event:sync_output
