### PR TITLE
window: skip window rule updates on hidden windows

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1910,6 +1910,9 @@ void CCompositor::updateAllWindowsAnimatedDecorationValues() {
 }
 
 void CCompositor::updateWindowAnimatedDecorationValues(PHLWINDOW pWindow) {
+    if (!pWindow->m_isMapped || pWindow->isHidden())
+        return;
+
     // optimization
     static auto PACTIVECOL              = CConfigValue<Hyprlang::CUSTOMTYPE>("general:col.active_border");
     static auto PINACTIVECOL            = CConfigValue<Hyprlang::CUSTOMTYPE>("general:col.inactive_border");

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -822,6 +822,9 @@ void CWindow::applyDynamicRule(const SP<CWindowRule>& r) {
 }
 
 void CWindow::updateDynamicRules() {
+    if (!m_isMapped || isHidden())
+        return;
+
     m_windowData.alpha.unset(PRIORITY_WINDOW_RULE);
     m_windowData.alphaInactive.unset(PRIORITY_WINDOW_RULE);
     m_windowData.alphaFullscreen.unset(PRIORITY_WINDOW_RULE);


### PR DESCRIPTION
Not needed, and can cause weird transitions where we don't do any anims on changing windows but props can animate