### PR TITLE
Fix subtractWindow typo for POSYSTR

### DIFF
--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -498,7 +498,7 @@ void Events::listener_mapWindow(void* owner, void* data) {
                         }
 
                         if (POSYSTR.starts_with("100%-")) {
-                            const bool subtractWindow = POSYSTR.starts_with("100%-w-");
+                            const bool subtractWindow = POSYSTR.starts_with("100%-h-");
                             const auto POSYRAW        = (subtractWindow) ? POSYSTR.substr(7) : POSYSTR.substr(5);
                             posY =
                                 PMONITOR->m_size.y - (!POSYRAW.contains('%') ? std::stoi(POSYRAW) : std::stof(POSYRAW.substr(0, POSYRAW.length() - 1)) * 0.01 * PMONITOR->m_size.y);


### PR DESCRIPTION
This type really pisses me off

<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Just a typo fix


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No, it's just a typo


#### Is it ready for merging, or does it need work?

You're free to merge it, no additional work required 

