### PR TITLE
fix noscreenshare layerrule popups

### DIFF
--- a/src/protocols/Screencopy.cpp
+++ b/src/protocols/Screencopy.cpp
@@ -211,6 +211,24 @@ void CScreencopyFrame::renderMon() {
     g_pHyprOpenGL->setRenderModifEnabled(true);
     g_pHyprOpenGL->popMonitorTransformEnabled();
 
+    auto hidePopups = [&](Vector2D popupBaseOffset) {
+        return [&, popupBaseOffset](WP<CPopup> popup, void*) {
+            if (!popup->m_wlSurface || !popup->m_wlSurface->resource() || !popup->m_mapped)
+                return;
+
+            const auto popRel = popup->coordsRelativeToParent();
+            popup->m_wlSurface->resource()->breadthfirst(
+                [&](SP<CWLSurfaceResource> surf, const Vector2D& localOff, void*) {
+                    const auto size    = surf->m_current.size;
+                    const auto surfBox = CBox{popupBaseOffset + popRel + localOff, size}.translate(m_monitor->m_position).scale(m_monitor->m_scale).translate(-m_box.pos());
+
+                    if LIKELY (surfBox.w > 0 && surfBox.h > 0)
+                        g_pHyprOpenGL->renderRect(surfBox, Colors::BLACK, {});
+                },
+                nullptr);
+        };
+    };
+
     for (auto const& l : g_pCompositor->m_layers) {
         if (!l->m_noScreenShare)
             continue;
@@ -225,6 +243,10 @@ void CScreencopyFrame::renderMon() {
             CBox{REALPOS.x, REALPOS.y, std::max(REALSIZE.x, 5.0), std::max(REALSIZE.y, 5.0)}.translate(-m_monitor->m_position).scale(m_monitor->m_scale).translate(-m_box.pos());
 
         g_pHyprOpenGL->renderRect(noScreenShareBox, Colors::BLACK, {});
+
+        const auto     geom            = l->m_geometry;
+        const Vector2D popupBaseOffset = REALPOS - Vector2D{geom.pos().x, geom.pos().y};
+        l->m_popupHead->breadthfirst(hidePopups(popupBaseOffset), nullptr);
     }
 
     for (auto const& w : g_pCompositor->m_windows) {
@@ -261,23 +283,7 @@ void CScreencopyFrame::renderMon() {
         const auto     geom            = w->m_xdgSurface->m_current.geometry;
         const Vector2D popupBaseOffset = REALPOS - Vector2D{geom.pos().x, geom.pos().y};
 
-        w->m_popupHead->breadthfirst(
-            [&](WP<CPopup> popup, void*) {
-                if (!popup->m_wlSurface || !popup->m_wlSurface->resource() || !popup->m_mapped)
-                    return;
-
-                const auto popRel = popup->coordsRelativeToParent();
-                popup->m_wlSurface->resource()->breadthfirst(
-                    [&](SP<CWLSurfaceResource> surf, const Vector2D& localOff, void*) {
-                        const auto size    = surf->m_current.size;
-                        const auto surfBox = CBox{popupBaseOffset + popRel + localOff, size}.translate(-m_monitor->m_position).scale(m_monitor->m_scale).translate(-m_box.pos());
-
-                        if LIKELY (surfBox.w > 0 && surfBox.h > 0)
-                            g_pHyprOpenGL->renderRect(surfBox, Colors::BLACK, {});
-                    },
-                    nullptr);
-            },
-            nullptr);
+        w->m_popupHead->breadthfirst(hidePopups(popupBaseOffset), nullptr);
     }
 
     if (m_overlayCursor)


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Hides popups when you use `noscreenshare` layerrule.
before:
<img width="1920" height="1080" alt="before" src="https://github.com/user-attachments/assets/5fc46467-bb7d-4ae9-b819-88d45053818a" />
after:
<img width="1920" height="1080" alt="after" src="https://github.com/user-attachments/assets/6fd9538e-7954-479f-a781-58d289b188b5" />
(waybar with nm-applet)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready

