### PR TITLE
Fix fcitx5 popup artifacts

### DIFF
--- a/src/managers/input/InputMethodPopup.cpp
+++ b/src/managers/input/InputMethodPopup.cpp
@@ -120,11 +120,18 @@ void CInputPopup::updateBox() {
     CBox cursorBoxLocal({-popupOffset.x, -popupOffset.y}, cursorBoxParent.size());
     m_popup->sendInputRectangle(cursorBoxLocal);
 
-    CBox popupBoxParent(cursorBoxParent.pos() + popupOffset, currentPopupSize);
-    if (popupBoxParent != m_lastBoxLocal) {
+    CBox       popupBoxParent(cursorBoxParent.pos() + popupOffset, currentPopupSize);
+    const bool boxChanged = popupBoxParent != m_lastBoxLocal;
+    if (boxChanged)
+        damageEntire(); // damage the old location before updating
+
+    m_lastBoxLocal = popupBoxParent;
+
+    // Since a redraw request is not always sent when only the position is updated,
+    // a manual redraw may be required in some cases.
+    if (boxChanged)
         damageEntire();
-        m_lastBoxLocal = popupBoxParent;
-    }
+
     damageSurface();
 
     if (const auto PM = g_pCompositor->getMonitorFromCursor(); PM && PM->m_id != m_lastMonitor) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
I’ve fixed an issue where popup windows could sometimes be partially clipped when typing with fcitx5.

- before

https://github.com/user-attachments/assets/e9783c70-475d-4af4-bf30-c0f65a27e3e4

- after

https://github.com/user-attachments/assets/5cbbe95c-51d4-4bec-b868-89e830971624

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
ready

