### PR TITLE
fix fractional scale artifacts

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1133,8 +1133,12 @@ void CHyprRenderer::calculateUVForSurface(PHLWINDOW pWindow, SP<CWLSurfaceResour
         if (projSize != Vector2D{} && fixMisalignedFSV1) {
             // instead of nearest_neighbor (we will repeat / skip)
             // just cut off / expand surface
-            const Vector2D PIXELASUV    = Vector2D{1, 1} / pSurface->m_current.bufferSize;
-            const Vector2D MISALIGNMENT = pSurface->m_current.bufferSize - projSize;
+            const Vector2D PIXELASUV   = Vector2D{1, 1} / pSurface->m_current.bufferSize;
+            const auto&    BUFFER_SIZE = pSurface->m_current.bufferSize;
+
+            // compute MISALIGN from the adjusted UV coordinates.
+            const Vector2D MISALIGNMENT = (uvBR - uvTL) * BUFFER_SIZE - projSize;
+
             if (MISALIGNMENT != Vector2D{})
                 uvBR -= MISALIGNMENT * PIXELASUV;
         } else {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
I’ve fixed an issue where artifacts could sometimes appear in the center of the screen when using fractional scaling.
I suspect the root cause is that, under fractional scaling, when the window size is not evenly divisible by the scaling factor, the sampling also fails to divide evenly, and the remainder shows up as visible error on the screen.
To mitigate this, the window size is now adjusted so that it becomes a multiple of the fractional part of the scaling factor in pixels. (Sorry for the slightly convoluted explanation.)
With this change, artifacts should no longer appear at any scale, as long as the window size isn’t freely resized to arbitrary values.
I also considered fixing it by adjusting the edge pixels, but I chose this approach instead to avoid conflicts with the existing misalign logic, and because the breakage was very noticeable in the first place.
I’m sorry for opening so many PRs, but I’d appreciate it if you could review this one as well.

You can reproduce the issue as follows.

1. Set scale = 1.8
2. Launch Chrome as a native Wayland client
3. Display the HTML below

With these steps, a line should appear around the center of the screen.

```html
<!DOCTYPE html>
<html lang="ja">

<head>
    <meta charset="UTF-8">
    <title>stripe</title>
    <style>
        html,
        body {
            margin: 0;
            height: 100%;
        }

        body {
            background-image: repeating-linear-gradient(45deg,
                    #000 0px,
                    #000 1px,
                    #fff 1px,
                    #fff 2px);
        }
    </style>
</head>

<body>
</body>

</html>
```

- before

<img width="1098" height="734" alt="screenshot-20251112-234611" src="https://github.com/user-attachments/assets/8416cd71-eb27-4cf0-b288-0f22b064ba03" />

- after

<img width="1189" height="783" alt="screenshot-20251112-234434" src="https://github.com/user-attachments/assets/0b9b982b-2a5f-4ec6-83a6-df4ae888e9a0" />


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Please see the comment below.

#### Is it ready for merging, or does it need work?
Please see the comment below.

