### PR TITLE
fix resize icon persisting when moving cursor from a tiled window to fullscreen one

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -544,8 +544,12 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
     if (pFoundWindow) {
         // change cursor icon if hovering over border
         if (*PRESIZEONBORDER && *PRESIZECURSORICON) {
-            if (!pFoundWindow->isFullscreen() && !pFoundWindow->hasPopupAt(mouseCoords))
+            if (!pFoundWindow->isFullscreen() && !pFoundWindow->hasPopupAt(mouseCoords)) {
                 setCursorIconOnBorder(pFoundWindow);
+            } else if (m_borderIconDirection != BORDERICON_NONE) {
+                m_borderIconDirection = BORDERICON_NONE;
+                Cursor::overrideController->unsetOverride(Cursor::CURSOR_OVERRIDE_WINDOW_EDGE);
+            }
         }
 
         if (FOLLOWMOUSE != 1 && !refocus) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This PR fixes a small regression introduced in 5e6cec9, for which the resize cursor icon override persists when moving the cursor from a tiled window to a fullscreen window on a different monitor (while using resize_on_border).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This PR fixes #12257.

#### Is it ready for merging, or does it need work?

It should be ready.
