### PR TITLE
Fix crash at startup on FreeBSD

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -3029,6 +3029,8 @@ void CCompositor::arrangeMonitors() {
 
 #ifndef NO_XWAYLAND
     CBox box = g_pCompositor->calculateX11WorkArea();
+    if (!g_pXWayland || !g_pXWayland->m_wm)
+        return;
     g_pXWayland->m_wm->updateWorkArea(box.x, box.y, box.w, box.h);
 #endif
 }

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -601,6 +601,8 @@ void CHyprDwindleLayout::recalculateMonitor(const MONITORID& monid) {
 
 #ifndef NO_XWAYLAND
     CBox box = g_pCompositor->calculateX11WorkArea();
+    if (!g_pXWayland || !g_pXWayland->m_wm)
+        return;
     g_pXWayland->m_wm->updateWorkArea(box.x, box.y, box.w, box.h);
 #endif
 }

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -297,6 +297,8 @@ void CHyprMasterLayout::recalculateMonitor(const MONITORID& monid) {
 
 #ifndef NO_XWAYLAND
     CBox box = g_pCompositor->calculateX11WorkArea();
+    if (!g_pXWayland || !g_pXWayland->m_wm)
+        return;
     g_pXWayland->m_wm->updateWorkArea(box.x, box.y, box.w, box.h);
 #endif
 }


### PR DESCRIPTION
The latest Hyprland has an issue that it crashes with SIGSEGV at starting up on FreeBSD (clang/libc++ 19). That appears due to the change introduced with ce9787b3f47ce550027274a1aa25e74b6fb1c74a.

<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

#### Describe your PR, what does it fix/add?

The code in question is `g_pXWayland->m_wm->updateWorkArea(box.x, box.y, box.w, box.h);` in the following three files. There may be the case that `g_pXWayland` or `g_pXWayland->m_wm` is NULL and trying to call `updateWorkArea()` leads to a crash. Adding check before calling `updateWorkArea()` seems to solve the problem.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

- I guess this PR should fix #12215, which seems a similar crash to this case.
- The crash only occurs with a release build of Hyprland, not a debug build (using clang 19).

#### Is it ready for merging, or does it need work?

Yes, I hope so.

I would be appreciate it if this PR is considered for inclusion in future releases.