### PR TITLE
Put Linux-only linux/limit.h header behind ifdef

### DIFF
--- a/src/config/ConfigWatcher.cpp
+++ b/src/config/ConfigWatcher.cpp
@@ -1,5 +1,7 @@
 #include "ConfigWatcher.hpp"
+#if defined(__linux__)
 #include <linux/limits.h>
+#endif
 #include <sys/inotify.h>
 #include "../debug/Log.hpp"
 #include <ranges>


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

#### Describe your PR, what does it fix/add?

`linux/limits.h` is a header only in Linux. Hyprland builds fine on FreeBSD without the header. So put it behind `#ifdef (__linux__)`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Yes.