### PR TITLE
fix: ensure cursor reset on change window states

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -546,6 +546,13 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
         if (*PRESIZEONBORDER && *PRESIZECURSORICON) {
             if (!pFoundWindow->isFullscreen() && !pFoundWindow->hasPopupAt(mouseCoords))
                 setCursorIconOnBorder(pFoundWindow);
+            else if (m_borderIconDirection != BORDERICON_NONE) {
+                m_borderIconDirection = BORDERICON_NONE;
+                Cursor::overrideController->unsetOverride(Cursor::CURSOR_OVERRIDE_WINDOW_EDGE);
+            }
+        } else if (m_borderIconDirection != BORDERICON_NONE) {
+            m_borderIconDirection = BORDERICON_NONE;
+            Cursor::overrideController->unsetOverride(Cursor::CURSOR_OVERRIDE_WINDOW_EDGE);
         }
 
         if (FOLLOWMOUSE != 1 && !refocus) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?


Since https://github.com/hyprwm/Hyprland/commit/5e6cec962c780956177e56355ffc1d64cc5f83ca there is a new problem after the introduction of the new cursor override ( CursorShapeOverrideController).

However, it had a bug ( that I've also seen on Discord reported ).

When you hover over a window edge (non-fullscreen), the cursor changes to a resize cursor (e.g., "top_side", "left_side") via CURSOR_OVERRIDE_WINDOW_EDGE.

But when you then move to:
     - A fullscreen window
     - A window with popups
     - Or across monitors to different windows

The edge override was never cleared because the code only called setCursorIconOnBorder() for non-fullscreen windows without popups. This left the resize cursor "stuck" until something else changed it.

I added logic to explicity clear the CURSOR_OVERRIDE_WINDOW_EDGE override when:
- A window is fullscreen or has a popup
- The resize-on-border features are disabled but an override is active


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Naw. My first PR on Hyprland so I am not sure if this is not the proper solution.

#### Is it ready for merging, or does it need work?
Sirs, it works on my machine 🙆🏼‍♂️ 

