### PR TITLE
Add groupbar blur

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1115,6 +1115,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .type        = CONFIG_OPTION_BOOL,
         .data        = SConfigOptionDescription::SRangeData{0, -20, 20},
     },
+    SConfigOptionDescription{
+        .value       = "group:groupbar:blur",
+        .description = "enable background blur for groupbars",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{false},
+    },
 
     /*
      * misc:

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -560,6 +560,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("group:groupbar:gaps_in", Hyprlang::INT{2});
     registerConfigVar("group:groupbar:keep_upper_gap", Hyprlang::INT{1});
     registerConfigVar("group:groupbar:text_offset", Hyprlang::INT{0});
+    registerConfigVar("group:groupbar:blur", Hyprlang::INT{0});
 
     registerConfigVar("debug:log_damage", Hyprlang::INT{0});
     registerConfigVar("debug:overlay", Hyprlang::INT{0});

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -126,6 +126,7 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
     static auto PINNERGAP                  = CConfigValue<Hyprlang::INT>("group:groupbar:gaps_in");
     static auto PKEEPUPPERGAP              = CConfigValue<Hyprlang::INT>("group:groupbar:keep_upper_gap");
     static auto PTEXTOFFSET                = CConfigValue<Hyprlang::INT>("group:groupbar:text_offset");
+    static auto PBLUR                      = CConfigValue<Hyprlang::INT>("group:groupbar:blur");
     auto* const GROUPCOLACTIVE             = sc<CGradientValueData*>((PGROUPCOLACTIVE.ptr())->getData());
     auto* const GROUPCOLINACTIVE           = sc<CGradientValueData*>((PGROUPCOLINACTIVE.ptr())->getData());
     auto* const GROUPCOLACTIVELOCKED       = sc<CGradientValueData*>((PGROUPCOLACTIVELOCKED.ptr())->getData());
@@ -143,6 +144,8 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
 
     float xoff = 0;
     float yoff = 0;
+
+    bool  blur = *PBLUR != 0;
 
     for (int i = 0; i < barsToDraw; ++i) {
         const auto WINDOWINDEX = *PSTACKED ? m_dwGroupMembers.size() - i - 1 : i;
@@ -163,6 +166,7 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
         if (!rect.empty()) {
             CRectPassElement::SRectData rectdata;
             rectdata.color = color;
+            rectdata.blur  = blur;
             rectdata.box   = rect;
             if (*PROUNDING) {
                 rectdata.round         = *PROUNDING;
@@ -194,8 +198,9 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
                                                                                                          (GROUPLOCKED ? m_tGradientLockedInactive : m_tGradientInactive));
                 if (GRADIENTTEX->m_texID) {
                     CTexPassElement::SRenderData data;
-                    data.tex = GRADIENTTEX;
-                    data.box = rect;
+                    data.tex  = GRADIENTTEX;
+                    data.blur = blur;
+                    data.box  = rect;
                     if (*PGRADIENTROUNDING) {
                         data.round         = *PGRADIENTROUNDING;
                         data.roundingPower = *PGRADIENTROUNDINGPOWER;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This PR implements a simple config option to enable blur on the groupbar.
The config options is called `group:groupbar:blur` and is a boolean.

When enabled, it applies blur to the group indicator and gradient.
<img width="674" height="216" alt="image" src="https://github.com/user-attachments/assets/a970cbd6-d6c3-49a2-a1bd-c15a0b7813e6" />


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I refactored the groupbar rounding logic to fix the visual artifact shown below. Instead of drawing 2 rectangles, I extended the edge that should not be rounded and clipped it at its original size.
<img width="759" height="216" alt="image" src="https://github.com/user-attachments/assets/2cfefe7a-afd0-4bc5-a9c6-042c8a7dab37" />


#### Is it ready for merging, or does it need work?

I think it's ready.
