### PR TITLE
plugin/hook: disallow multiple hooks per function

### DIFF
--- a/src/plugins/HookSystem.cpp
+++ b/src/plugins/HookSystem.cpp
@@ -144,6 +144,12 @@ bool CFunctionHook::hook() {
     return false;
 #endif
 
+    if (g_pFunctionHookSystem->m_activeHooks.contains(rc<uint64_t>(m_source))) {
+        // TODO: return actual error codes...
+        Debug::log(ERR, "[functionhook] failed, function is already hooked");
+        return false;
+    }
+
     // jmp rel32
     // offset for relative addr: 1
     static constexpr uint8_t RELATIVE_JMP_ADDRESS[]      = {0xE9, 0x00, 0x00, 0x00, 0x00};
@@ -231,6 +237,8 @@ bool CFunctionHook::hook() {
     m_active  = true;
     m_hookLen = ORIGSIZE;
 
+    g_pFunctionHookSystem->m_activeHooks.emplace(rc<uint64_t>(m_source));
+
     return true;
 }
 
@@ -242,6 +250,8 @@ bool CFunctionHook::unhook() {
 
     if (!m_active)
         return false;
+
+    g_pFunctionHookSystem->m_activeHooks.erase(rc<uint64_t>(m_source));
 
     // allow write to src
     mprotect(sc<uint8_t*>(m_source) - rc<uint64_t>(m_source) % sysconf(_SC_PAGE_SIZE), sysconf(_SC_PAGE_SIZE), PROT_READ | PROT_WRITE | PROT_EXEC);

--- a/src/plugins/HookSystem.hpp
+++ b/src/plugins/HookSystem.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <cstddef>
+#include <unordered_set>
 #include "../helpers/memory/Memory.hpp"
 
 #define HANDLE                   void*
@@ -70,7 +71,8 @@ class CHookSystem {
         uint64_t used = 0;
     };
 
-    std::vector<SAllocatedPage> m_pages;
+    std::vector<SAllocatedPage>  m_pages;
+    std::unordered_set<uint64_t> m_activeHooks;
 
     friend class CFunctionHook;
 };


### PR DESCRIPTION
this was never safe. After recent changes, it's become even less so. Just disallow it.

ref #11992



