### PR TITLE
Fix m_cursorSurfaceInfo not being updated while a cursor override is set

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -50,9 +50,6 @@
 
 CInputManager::CInputManager() {
     m_listeners.setCursorShape = PROTO::cursorShape->m_events.setShape.listen([this](const CCursorShapeProtocol::SSetShapeEvent& event) {
-        if (!cursorImageUnlocked())
-            return;
-
         if (!g_pSeatManager->m_state.pointerFocusResource)
             return;
 
@@ -65,6 +62,9 @@ CInputManager::CInputManager() {
         m_cursorSurfaceInfo.vHotspot = {};
         m_cursorSurfaceInfo.name     = event.shapeName;
         m_cursorSurfaceInfo.hidden   = false;
+
+        if (!cursorImageUnlocked())
+            return;
 
         g_pHyprRenderer->setCursorFromName(m_cursorSurfaceInfo.name);
     });
@@ -653,9 +653,6 @@ void CInputManager::onMouseButton(IPointer::SButtonEvent e) {
 }
 
 void CInputManager::processMouseRequest(const CSeatManager::SSetCursorEvent& event) {
-    if (!cursorImageUnlocked())
-        return;
-
     Debug::log(LOG, "cursorImage request: surface {:x}", rc<uintptr_t>(event.surf.get()));
 
     if (event.surf != m_cursorSurfaceInfo.wlSurface->resource()) {
@@ -674,6 +671,9 @@ void CInputManager::processMouseRequest(const CSeatManager::SSetCursorEvent& eve
     }
 
     m_cursorSurfaceInfo.name = "";
+
+    if (!cursorImageUnlocked())
+        return;
 
     g_pHyprRenderer->setCursorSurface(m_cursorSurfaceInfo.wlSurface, event.hotspot.x, event.hotspot.y);
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

In `InputManager`, `processMouseRequest` and the `SetShapeEvent` handler return immediately if a cursor override is set. This causes issues when moving between windows while and override is set (such as with resize_on_border), i.e. the new window will still show the last cursor requested by the former window (see [here](https://github.com/hyprwm/Hyprland/discussions/12268#discussioncomment-14979427)) once the override is removed.

We should still update m_cursorSurfaceInfo and only return before calling the `g_pHyprRenderer` method.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I don't think so.

#### Is it ready for merging, or does it need work?

Should be fine.
