### PR TITLE
CI: drop no_pch and make default, drop noxwayland

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Build Hyprland
         run: |
-          CFLAGS=-Werror CXXFLAGS=-Werror make all
+          CFLAGS=-Werror CXXFLAGS=-Werror make nopch
 
       - name: Compress and package artifacts
         run: |
@@ -40,47 +40,6 @@ jobs:
         with:
           name: Build archive
           path: Hyprland.tar.xz
-
-  no-pch:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork
-    name: "Build Hyprland without precompiled headers (Arch)"
-    runs-on: ubuntu-latest
-    container:
-      image: archlinux
-    steps:
-      - name: Checkout repository actions
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: .github/actions
-
-      - name: Setup base
-        uses: ./.github/actions/setup_base
-        with:
-          INSTALL_XORG_PKGS: true
-
-      - name: Compile
-        run: make nopch
-
-  noxwayland:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork
-    name: "Build Hyprland in pure Wayland (Arch)"
-    runs-on: ubuntu-latest
-    container:
-      image: archlinux
-    steps:
-      - name: Checkout repository actions
-        uses: actions/checkout@v4
-        with:
-          sparse-checkout: .github/actions
-
-      - name: Setup base
-        uses: ./.github/actions/setup_base
-
-      - name: Configure
-        run: mkdir -p build && cmake --no-warn-unused-cli -DCMAKE_BUILD_TYPE:STRING=Release -DNO_XWAYLAND:STRING=true -H./ -B./build -G Ninja
-
-      - name: Compile
-        run: make release
 
   clang-format:
     permissions: read-all


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Part of the ongoing work of easing up resources on our share of GitHub Action runners.

`nopch` is now default. If it builds, surely PCH-enabled builds will work as well.
`noxwayland` should also build fine. Can be re-added if needed.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Ready.
