### PR TITLE
Groupbar: fix rounding logic for edge cases

### DIFF
--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -172,12 +172,13 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
                 rectdata.round         = *PROUNDING;
                 rectdata.roundingPower = *PROUNDINGPOWER;
                 if (*PROUNDONLYEDGES) {
+                    rectdata.round      = 0;
+                    const double offset = *PROUNDING * 2;
                     if (i == 0) {
                         rectdata.round   = *PROUNDING;
                         rectdata.clipBox = rect;
-                        rectdata.box     = CBox{rect.pos(), Vector2D{rect.w + (*PROUNDING * 2), rect.h}};
+                        rectdata.box     = CBox{rect.pos(), Vector2D{rect.w + offset, rect.h}};
                     } else if (i == barsToDraw - 1) {
-                        double offset    = *PROUNDING * 2;
                         rectdata.round   = *PROUNDING;
                         rectdata.clipBox = rect;
                         rectdata.box     = CBox{rect.pos() - Vector2D{offset, 0.F}, Vector2D{rect.w + offset, rect.h}};
@@ -205,15 +206,16 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
                         data.round         = *PGRADIENTROUNDING;
                         data.roundingPower = *PGRADIENTROUNDINGPOWER;
                         if (*PGRADIENTROUNDINGONLYEDGES) {
+                            data.round          = 0;
+                            const double offset = *PGRADIENTROUNDING * 2;
                             if (i == 0) {
                                 data.round   = *PGRADIENTROUNDING;
                                 data.clipBox = rect;
-                                data.box     = CBox{rect.pos(), Vector2D{rect.w + (*PGRADIENTROUNDING * 2), rect.h}};
+                                data.box     = CBox{rect.pos(), Vector2D{rect.w + offset, rect.h}};
                             } else if (i == barsToDraw - 1) {
-                                double offset = *PGRADIENTROUNDING * 2;
-                                data.round    = *PGRADIENTROUNDING;
-                                data.clipBox  = rect;
-                                data.box      = CBox{rect.pos() - Vector2D{offset, 0.F}, Vector2D{rect.w + offset, rect.h}};
+                                data.round   = *PGRADIENTROUNDING;
+                                data.clipBox = rect;
+                                data.box     = CBox{rect.pos() - Vector2D{offset, 0.F}, Vector2D{rect.w + offset, rect.h}};
                             }
                         }
                     }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Add `round = 0` back in for all tabs except the outer ones when `round only edges` is enabled.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Ready.
