### PR TITLE
i18n: improve Spanish translations for clarity and consistency

### DIFF
--- a/src/i18n/Engine.cpp
+++ b/src/i18n/Engine.cpp
@@ -286,8 +286,8 @@ I18n::CI18nEngine::CI18nEngine() {
     huEngine->registerEntry("es", TXT_KEY_NOTIF_FAILED_ASSETS, [](const Hyprutils::I18n::translationVarMap& vars) {
         int assetsNo = std::stoi(vars.at("count"));
         if (assetsNo <= 1)
-            return "Hyprland no pudo cargar {count} recurso esencial; ¡culpa al empaquetador de tu distribución por un mal empaquetado!";
-        return "Hyprland no pudo cargar {count} recursos esenciales; ¡culpa al empaquetador de tu distribución por un mal empaquetado!";
+            return "No se pudo cargar {count} recurso esencial. Contacta al empaquetador de tu distribución.";
+        return "No se pudieron cargar {count} recursos esenciales. Contacta al empaquetador de tu distribución.";
     });
     huEngine->registerEntry("es", TXT_KEY_NOTIF_INVALID_MONITOR_LAYOUT,
                             "La configuración de tus monitores no es correcta. El monitor {name} se superpone con otros monitores en la disposición. Consulta la wiki (página "


### PR DESCRIPTION
Improve the Spanish translation strings in Engine.cpp by:

- Refining ANR (Application Not Responding) dialog to use "La aplicación" and change the terminate option to "Forzar cierre" for clarity
- Standardizing permission prompts with "¿Deseas...?" for consistency
- Rewording keyboard permission prompt: "permitir su uso" is clearer than "permitir su funcionamiento"
- Adding explicit reference to "permisos" in the persistence hint
- Improving Wayland app identification: "ID de cliente de Wayland" instead of "wayland client ID {wayland_id}"
- Enhancing environment variable notification with better punctuation and clarity ("gestionarse externamente" vs "estar gestionada externamente")
- Simplifying hyprland-guiutils message with direct, concise wording
- Rewriting failed assets lambda to be more natural and add context about distribution packagers
- Improving monitor-related messages with clearer tone and better sentence structure (monitor layout, mode fallback, auto-scale)
- Using "shader" instead of "sombreador" (more common in Spanish tech)
- Changing "10-bit" to "10 bits" for proper Spanish plural form

Overall tone improvements include consistent use of "tú" forms and clearer, more natural Spanish phrasing throughout the user-facing messages.



