### PR TITLE
Update cmake required version for xkbcommon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,7 +220,7 @@ pkg_check_modules(
   deps
   REQUIRED
   IMPORTED_TARGET
-  xkbcommon
+  xkbcommon>=1.11.0
   uuid
   wayland-server>=1.22.90
   wayland-protocols>=1.45


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
This PR updates the dependency needed for xbkcommon. This dependency is needed for the code in PR #7919, and I have been asked from the PR author to contribute to the upstream instead to their PR.  

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
The flag XKB_KEYMAP_FORMAT_TEXT_V2 and the function xkb_keymap_new_from_names2 were introduced in version 1.11.0 of the package libxkbcommon. Some distros (in particular Fedora 42) still have older versions in their mainline repos, so this check blocks anyone from compiling the package and having an error due to invalid functions for library mismatch.

#### Is it ready for merging, or does it need work?

Should be ready to merge

