### PR TITLE
hyprctl: fix no_vrr prop ref

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -3328,7 +3328,7 @@ SDispatchResult CKeybindManager::setProp(std::string args) {
         g_pCompositor->focusWindow(PLASTWINDOW);
     }
 
-    if (PROP == "novrr")
+    if (PROP == "no_vrr")
         g_pConfigManager->ensureVRR(PWINDOW->m_monitor.lock());
 
     for (auto const& m : g_pCompositor->m_monitors)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes the VRR rule not applying immediately after setting the `no_vrr` window property via `hyprctl setprop`.

The issue was that the `setProp` function was checking for `"novrr"` instead of the correct property name `"no_vrr"`. This caused `ensureVRR()` to never be called when the property was changed, preventing immediate VRR state updates.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No, this is a simple one-line fix correcting a typo in the property name check.

#### Is it ready for merging, or does it need work?

Ready for merging.