### PR TITLE
config: add change_focus config for touchdevices

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -688,6 +688,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .type        = CONFIG_OPTION_BOOL,
         .data        = SConfigOptionDescription::SBoolData{true},
     },
+    SConfigOptionDescription{
+        .value       = "input:touchdevice:change_focus",
+        .description = "Whether a window should be focused when it receives a touch event.",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{true},
+    },
 
     /*
      * input:virtualkeyboard:

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -672,6 +672,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("input:touchdevice:transform", Hyprlang::INT{-1});
     registerConfigVar("input:touchdevice:output", {"[[Auto]]"});
     registerConfigVar("input:touchdevice:enabled", Hyprlang::INT{1});
+    registerConfigVar("input:touchdevice:change_focus", Hyprlang::INT{1});
     registerConfigVar("input:virtualkeyboard:share_states", Hyprlang::INT{2});
     registerConfigVar("input:virtualkeyboard:release_pressed_on_close", Hyprlang::INT{0});
     registerConfigVar("input:tablet:transform", Hyprlang::INT{0});
@@ -814,6 +815,7 @@ CConfigManager::CConfigManager() {
     m_config->addSpecialConfigValue("device", "keybinds", Hyprlang::INT{1});                 // enable/disable keybinds
     m_config->addSpecialConfigValue("device", "share_states", Hyprlang::INT{0});             // only for virtualkeyboards
     m_config->addSpecialConfigValue("device", "release_pressed_on_close", Hyprlang::INT{0}); // only for virtualkeyboards
+    m_config->addSpecialConfigValue("device", "change_focus", Hyprlang::INT{1});             // only for touchdevices
 
     m_config->addSpecialCategory("monitorv2", {.key = "output"});
     m_config->addSpecialConfigValue("monitorv2", "disabled", Hyprlang::INT{0});

--- a/src/devices/ITouch.hpp
+++ b/src/devices/ITouch.hpp
@@ -45,6 +45,7 @@ class ITouch : public IHID {
     } m_touchEvents;
 
     std::string m_boundOutput = "";
+    bool        m_changeFocus = true;
 
     WP<ITouch>  m_self;
 };

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -182,7 +182,7 @@ void CInputManager::sendMotionEventsToFocused() {
     g_pSeatManager->setPointerFocus(g_pCompositor->m_lastFocus.lock(), LOCAL);
 }
 
-void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, std::optional<Vector2D> overridePos) {
+void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, std::optional<Vector2D> overridePos, bool allowKeyboardRefocus) {
     m_lastInputMouse = mouse;
 
     if (!g_pCompositor->m_readyToProcess || g_pCompositor->m_isShuttingDown || g_pCompositor->m_unsafeState)
@@ -511,8 +511,6 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
 
     if (pFoundWindow && pFoundWindow->m_isX11) // for x11 force scale zero
         surfaceLocal = surfaceLocal * pFoundWindow->m_X11SurfaceScaledBy;
-
-    bool allowKeyboardRefocus = true;
 
     if (!refocus && g_pCompositor->m_lastFocus) {
         const auto PLS = g_pCompositor->getLayerSurfaceFromSurface(g_pCompositor->m_lastFocus.lock());
@@ -1765,6 +1763,8 @@ void CInputManager::setTouchDeviceConfigs(SP<ITouch> dev) {
                 // wlr_cursor_map_input_to_output(g_pCompositor->m_sWLRCursor, &PTOUCHDEV->wlr()->base, PMONITOR->output);
             } else if (bound)
                 Debug::log(ERR, "Failed to bind touch device {} to output '{}': monitor not found", PTOUCHDEV->m_hlName, output);
+
+            PTOUCHDEV->m_changeFocus = g_pConfigManager->getDeviceInt(PTOUCHDEV->m_hlName, "change_focus", "input:touchdevice:change_focus") != 0;
         }
     };
 

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -244,7 +244,7 @@ class CInputManager {
 
     uint32_t           m_capabilities = 0;
 
-    void               mouseMoveUnified(uint32_t, bool refocus = false, bool mouse = false, std::optional<Vector2D> overridePos = std::nullopt);
+    void               mouseMoveUnified(uint32_t, bool refocus = false, bool mouse = false, std::optional<Vector2D> overridePos = std::nullopt, bool allowKeyboardRefocus = true);
     void               recheckMouseWarpOnMouseInput();
 
     SP<CTabletTool>    ensureTabletToolPresent(SP<Aquamarine::ITabletTool>);

--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -30,7 +30,8 @@ void CInputManager::onTouchDown(ITouch::SDownEvent e) {
 
     const auto TOUCH_COORDS = PMONITOR->m_position + (e.pos * PMONITOR->m_size);
 
-    refocus(TOUCH_COORDS);
+    const auto allowKeyboardRefocus = e.device->m_changeFocus;
+    mouseMoveUnified(0, true, false, TOUCH_COORDS, allowKeyboardRefocus);
 
     if (m_clickBehavior == CLICKMODE_KILL) {
         IPointer::SButtonEvent e;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Adds a config option for touchdevices to enable/disable touch events from changing the focus.
This is useful for me as I have a single touchscreen monitor which I want to be able to use without affecting my workflow.  Without this change I'm forced to manually refocus what I'm working on after pressing something on the touchdevice which never needed focus to begin with.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No, tested the input:touchdevice:change_focus and device:change_focus options, everything works just fine.

#### Is it ready for merging, or does it need work?
Ready

