### PR TITLE
CrashReporter.cpp: fix stderr conflict

### DIFF
--- a/src/debug/CrashReporter.cpp
+++ b/src/debug/CrashReporter.cpp
@@ -76,15 +76,15 @@ void NCrashReporter::createAndSaveCrash(int sig) {
         reportPath += ".txt";
 
         {
-            CBufFileWriter<64> stderr(2);
-            stderr += "Hyprland has crashed :( Consult the crash report at ";
+            CBufFileWriter<64> stderr_out(STDERR_FILENO);
+            stderr_out += "Hyprland has crashed :( Consult the crash report at ";
             if (!reportPath.boundsExceeded()) {
-                stderr += reportPath.getStr();
+                stderr_out += reportPath.getStr();
             } else {
-                stderr += "[ERROR: Crash report path does not fit into memory! Check if your $CACHE_HOME/$HOME is too deeply nested. Max 255 characters.]";
+                stderr_out += "[ERROR: Crash report path does not fit into memory! Check if your $CACHE_HOME/$HOME is too deeply nested. Max 255 characters.]";
             }
-            stderr += " for more information.\n";
-            stderr.flush();
+            stderr_out += " for more information.\n";
+            stderr_out.flush();
         }
 
         reportFd = open(reportPath.getStr(), O_WRONLY | O_CREAT, S_IRUSR | S_IWUSR);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This PR fixes following compile error on OpenBSD-7.8/amd64 (clang-19.1.7).
This is caused `stderr` symbol conflict.

```
uaa@framboise:~/z/hyprland/build$ make
[  2%] Built target libudis86
[  2%] Building CXX object CMakeFiles/Hyprland.dir/src/debug/CrashReporter.cpp.o
/home/uaa/z/hyprland/src/debug/CrashReporter.cpp:79:13: error: no matching conversion for functional-style cast from 'struct __sFILE *' to 'CBufFileWriter<64>'
   79 |             CBufFileWriter<64> stderr(2);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~
/home/uaa/z/hyprland/src/debug/../signal-safe.hpp:57:7: note: candidate constructor (the implicit copy constructor) not viable: cannot convert argument of incomplete type 'struct __sFILE *' to 'const CBufFileWriter<64>' for 1st argument
   57 | class CBufFileWriter {
      |       ^~~~~~~~~~~~~~
/home/uaa/z/hyprland/src/debug/../signal-safe.hpp:59:5: note: candidate constructor not viable: cannot convert argument of incomplete type 'struct __sFILE *' to 'int' for 1st argument
   59 |     CBufFileWriter(int fd_) : m_fd(fd_) {}
      |     ^              ~~~~~~~
/home/uaa/z/hyprland/src/debug/CrashReporter.cpp:79:13: error: type 'CBufFileWriter<64>' does not provide a call operator
   79 |             CBufFileWriter<64> stderr(2);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~
/home/uaa/z/hyprland/src/debug/CrashReporter.cpp:80:20: error: invalid operands to binary expression ('struct __sFILE *' and 'const char[53]')
   80 |             stderr += "Hyprland has crashed :( Consult the crash report at ";
      |             ~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/uaa/z/hyprland/src/debug/CrashReporter.cpp:82:24: error: invalid operands to binary expression ('struct __sFILE *' and 'const char *')
   82 |                 stderr += reportPath.getStr();
      |                 ~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~
/home/uaa/z/hyprland/src/debug/CrashReporter.cpp:84:24: error: invalid operands to binary expression ('struct __sFILE *' and 'const char[127]')
   84 |                 stderr += "[ERROR: Crash report path does not fit into memory! Check if your $CACHE_HOME/$HOME is too deeply nested. Max 255 characters.]";
      |                 ~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/uaa/z/hyprland/src/debug/CrashReporter.cpp:86:20: error: invalid operands to binary expression ('struct __sFILE *' and 'const char[24]')
   86 |             stderr += " for more information.\n";
      |             ~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/uaa/z/hyprland/src/debug/CrashReporter.cpp:87:19: error: member reference type 'struct __sFILE *' is a pointer; did you mean to use '->'?
   87 |             stderr.flush();
      |             ~~~~~~^
      |                   ->
/home/uaa/z/hyprland/src/debug/CrashReporter.cpp:87:19: error: incomplete definition of type 'struct __sFILE'
   87 |             stderr.flush();
      |             ~~~~~~^
/usr/include/wchar.h:68:16: note: forward declaration of '__sFILE'
   68 | typedef struct __sFILE FILE;
      |                ^
8 errors generated.
*** Error 1 in . (CMakeFiles/Hyprland.dir/build.make:580 'CMakeFiles/Hyprland.dir/src/debug/CrashReporter.cpp.o': /usr/bin/c++ -DDATAROOTDIR...)
*** Error 2 in . (CMakeFiles/Makefile2:220 'CMakeFiles/Hyprland.dir/all': make -s -f CMakeFiles/Hyprland.dir/build.make CMakeFiles/Hyprland....)
*** Error 2 in /home/uaa/z/hyprland/build (Makefile:156 'all': make -s -f CMakeFiles/Makefile2 all)
uaa@framboise:~/z/hyprland/build$
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Even this is fixed, some errors are still remained (not serious problem).
But, need to disable building hyprtester.
And obtained Hyprland executable is not work (on OpenBSD) yet.

I think https://github.com/open-watcom/open-watcom-v2/pull/1394/commits/db30b8f94e07514185d0213272b1baf9db57fd76 will be a hint for alternative of KERN_PROC_PATHNAME.

#### Is it ready for merging, or does it need work?

Ready.