### PR TITLE
windowrules: fix persistent_size not applying

### DIFF
--- a/hyprtester/src/tests/main/window.cpp
+++ b/hyprtester/src/tests/main/window.cpp
@@ -397,6 +397,34 @@ static bool test() {
     OK(getFromSocket("/reload"));
     Tests::killAllWindows();
 
+    // test persistent_size between floating window launches
+    OK(getFromSocket("/keyword windowrule match:class persistent_size_kitty, persistent_size true, float true"));
+
+    if (!spawnKitty("persistent_size_kitty"))
+        return false;
+
+    OK(getFromSocket("/dispatch resizeactive exact 600 400"))
+
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "size: 600,400");
+        EXPECT_CONTAINS(str, "floating: 1");
+    }
+
+    Tests::killAllWindows();
+
+    if (!spawnKitty("persistent_size_kitty"))
+        return false;
+
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "size: 600,400");
+        EXPECT_CONTAINS(str, "floating: 1");
+    }
+
+    OK(getFromSocket("/reload"));
+    Tests::killAllWindows();
+
     OK(getFromSocket("/keyword general:border_size 0"));
     OK(getFromSocket("/keyword windowrule match:float true, border_size 10"));
 

--- a/src/desktop/rule/windowRule/WindowRuleApplicator.cpp
+++ b/src/desktop/rule/windowRule/WindowRuleApplicator.cpp
@@ -130,10 +130,8 @@ CWindowRuleApplicator::SRuleResult CWindowRuleApplicator::applyDynamicRule(const
                 break;
             }
             case WINDOW_RULE_EFFECT_PERSISTENT_SIZE: {
-                try {
-                    m_persistentSize.first.set(std::stoi(effect), Types::PRIORITY_WINDOW_RULE);
-                    m_persistentSize.second |= rule->getPropertiesMask();
-                } catch (...) { Debug::log(ERR, "CWindowRuleApplicator::applyDynamicRule: invalid rounding_power {}", effect); }
+                m_persistentSize.first.set(truthy(effect), Types::PRIORITY_WINDOW_RULE);
+                m_persistentSize.second |= rule->getPropertiesMask();
                 break;
             }
             case WINDOW_RULE_EFFECT_ANIMATION: {

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -108,6 +108,9 @@ void IHyprLayout::onWindowCreatedFloating(PHLWINDOW pWindow) {
         xy                = g_pXWaylandManager->xwaylandToWaylandCoords(xy);
         desiredGeometry.x = xy.x;
         desiredGeometry.y = xy.y;
+    } else if (pWindow->m_ruleApplicator->persistentSize().valueOrDefault()) {
+        desiredGeometry.w = pWindow->m_lastFloatingSize.x;
+        desiredGeometry.h = pWindow->m_lastFloatingSize.y;
     }
 
     static auto PXWLFORCESCALEZERO = CConfigValue<Hyprlang::INT>("xwayland:force_zero_scaling");


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

#12435 Fixes persistent_size being parsed an integer instead of bool, and applies stored size if the rule is set

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Is there a way to make tests more consistent. Gestures test and Monitor color setting thiny fail and sometimes not

#### Is it ready for merging, or does it need work?
I think yes

