### PR TITLE
Request: Fix typo in variable name from 'recieved' to 'received'

### DIFF
--- a/hyprtester/src/tests/clients/pointer-warp.cpp
+++ b/hyprtester/src/tests/clients/pointer-warp.cpp
@@ -101,8 +101,8 @@ static bool sendWarp(SClient& client, int x, int y) {
         return false;
 
     client.readBuf[bytesRead] = 0;
-    std::string recieved      = std::string{client.readBuf.data()};
-    recieved.pop_back();
+    std::string received      = std::string{client.readBuf.data()};
+    received.pop_back();
 
     return true;
 }


### PR DESCRIPTION
Found Typo:

File: hyprtester/src/tests/clients/pointer-warp.cpp (Line ~104-105)

std::string recieved = std::string{client.readBuf.data()};

Issue: recieved should be received
- Correct spelling: "received" (i-before-e after c)
- Current spelling: "recieved" (incorrect)

<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?


