### PR TITLE
buffers: revert buffer state merging

### DIFF
--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -550,13 +550,6 @@ void CWLSurfaceResource::commitState(SSurfaceState& state) {
             nullptr);
     }
 
-    if (m_current.updated.bits.damage) {
-        // damage is always relative to the current commit
-        m_current.updated.bits.damage = false;
-        m_current.damage.clear();
-        m_current.bufferDamage.clear();
-    }
-
     // release the buffer if it's synchronous (SHM) as updateSynchronousTexture() has copied the buffer data to a GPU tex
     // if it doesn't have a role, we can't release it yet, in case it gets turned into a cursor.
     if (m_current.buffer && m_current.buffer->isSynchronous() && m_role->role() != SURFACE_ROLE_UNASSIGNED)

--- a/src/protocols/types/SurfaceState.cpp
+++ b/src/protocols/types/SurfaceState.cpp
@@ -65,11 +65,8 @@ void SSurfaceState::reset() {
     lockMask = LOCK_REASON_NONE;
 }
 
-void SSurfaceState::updateFrom(SSurfaceState& ref, bool merge) {
-    if (merge)
-        updated.all |= ref.updated.all;
-    else
-        updated = ref.updated;
+void SSurfaceState::updateFrom(SSurfaceState& ref) {
+    updated = ref.updated;
 
     if (ref.updated.bits.buffer) {
         buffer     = ref.buffer;
@@ -81,6 +78,10 @@ void SSurfaceState::updateFrom(SSurfaceState& ref, bool merge) {
     if (ref.updated.bits.damage) {
         damage       = ref.damage;
         bufferDamage = ref.bufferDamage;
+    } else {
+        // damage is always relative to the current commit
+        damage.clear();
+        bufferDamage.clear();
     }
 
     if (ref.updated.bits.input)

--- a/src/protocols/types/SurfaceState.hpp
+++ b/src/protocols/types/SurfaceState.hpp
@@ -89,7 +89,7 @@ struct SSurfaceState {
     void         updateSynchronousTexture(SP<CTexture> lastTexture);
 
     // helpers
-    CRegion accumulateBufferDamage();                           // transforms state.damage and merges it into state.bufferDamage
-    void    updateFrom(SSurfaceState& ref, bool merge = false); // updates this state based on a reference state.
-    void    reset();                                            // resets pending state after commit
+    CRegion accumulateBufferDamage();       // transforms state.damage and merges it into state.bufferDamage
+    void    updateFrom(SSurfaceState& ref); // updates this state based on a reference state.
+    void    reset();                        // resets pending state after commit
 };


### PR DESCRIPTION
8e8bfbb0b146fb1f3234b2a3e3e92b63989e1993 specifically https://github.com/hyprwm/Hyprland/pull/12052/commits/bfee2238b6fab23174e27683731668c64b1dd90a added fifo and merged non buffer states before comitting them, something about certain xwayland non buffer commits expects a commit to happend and causes regressions as in low fps.

cant reproduce locally since i neither own those games nor can find a way to trigger it locally. so below reporters needs to fill in.
fixes: #12449 
fixes: #12408 