### PR TITLE
Implement CWindow::getEnv() for BSDs

### DIFF
--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1211,8 +1211,8 @@ std::unordered_map<std::string, std::string> CWindow::getEnv() {
 
     std::unordered_map<std::string, std::string> results;
 
-    std::vector<char> buffer;
-    size_t            needle = 0;
+    std::vector<char>                            buffer;
+    size_t                                       needle = 0;
 
 #if defined(__linux__)
     //
@@ -1228,8 +1228,8 @@ std::unordered_map<std::string, std::string> CWindow::getEnv() {
         needle += 512;
     }
 #elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
-    int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_ENV, static_cast<int>(PID) };
-    size_t len = 0;
+    int    mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_ENV, static_cast<int>(PID)};
+    size_t len    = 0;
 
     if (sysctl(mib, 4, nullptr, &len, nullptr, 0) < 0 || len == 0)
         return {};


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

#### Describe your PR, what does it fix/add?

The current `CWindow::getEnv()` implementation relies on procfs for retrieving a process' environment. Some BSDs provide procfs to access kernel information. However, BSDs' procfs does not provide information on a process' environment variables. Instead `sysctl(3)` function is usually used for system information retrieval on BSDs. The proposed changes add an implementation of `CWindow::getEnv()` for BSDs using `sysctl()`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

The change was proposed in another PR (https://github.com/hyprwm/Hyprland/pull/12269#issuecomment-3573626573) and asked to create a separate PR.

#### Is it ready for merging, or does it need work?

Ready for merging.