### PR TITLE
renderer: fix uv sufrace calc with scales < 1

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1195,7 +1195,7 @@ void CHyprRenderer::calculateUVForSurface(PHLWINDOW pWindow, SP<CWLSurfaceResour
             // to let the apps know to NOT add CSD. Also if source is there.
             // there is no way to fix this if that's the case
             const auto MONITOR_WL_SCALE = std::ceil(pMonitor->m_scale);
-            const bool SCALE_UNAWARE    = MONITOR_WL_SCALE > 1 && (MONITOR_WL_SCALE == pSurface->m_current.scale || !pSurface->m_current.viewport.hasDestination);
+            const bool SCALE_UNAWARE    = pMonitor->m_scale != 1.f && (MONITOR_WL_SCALE == pSurface->m_current.scale || !pSurface->m_current.viewport.hasDestination);
             const auto EXPECTED_SIZE    = getSurfaceExpectedSize(pWindow, pSurface, pMonitor, main).value_or((projSize * pMonitor->m_scale).round());
 
             const auto RATIO = projSize / EXPECTED_SIZE;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
scales less than 1 get ceil'ed to 1, so SCALE_UNAWARE always returns false for them

fixes #12245 
#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
Ready

