### PR TITLE
src/protocols/types/DMABuffer.cpp: <sys/ioctl.h> is required for ioctl(), not only linux.

### DIFF
--- a/src/protocols/types/DMABuffer.cpp
+++ b/src/protocols/types/DMABuffer.cpp
@@ -7,8 +7,8 @@
 #if defined(__linux__)
 #include <linux/dma-buf.h>
 #include <linux/sync_file.h>
-#include <sys/ioctl.h>
 #endif
+#include <sys/ioctl.h>
 
 using namespace Hyprutils::OS;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

solve build error on OpenBSD.
not only Linux, *BSD requires `<sys/ioctl.h>` for ioctl().

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Nothing.

#### Is it ready for merging, or does it need work?

Ready.