### PR TITLE
socket2: add {,de}populateworkspace events

### DIFF
--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -561,3 +561,7 @@ void CWorkspace::setPersistent(bool persistent) {
 bool CWorkspace::isPersistent() {
     return m_persistent;
 }
+
+bool CWorkspace::hasWindow() {
+    return std::ranges::any_of(g_pCompositor->m_windows, [this](const auto& w) { return w->workspaceID() == m_id && w->aliveAndVisible(); });
+}

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -80,6 +80,7 @@ class CWorkspace {
     void             updateWindows();
     void             setPersistent(bool persistent);
     bool             isPersistent();
+    bool             hasWindow();
 
     struct {
         CSignalT<> destroy;

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -504,7 +504,7 @@ void CWindow::moveToWorkspace(PHLWORKSPACE pWorkspace) {
         }
     }
 
-    if (OLDWORKSPACE && g_pCompositor->isWorkspaceSpecial(OLDWORKSPACE->m_id) && OLDWORKSPACE->getWindows() == 0 && *PCLOSEONLASTSPECIAL) {
+    if (OLDWORKSPACE && g_pCompositor->isWorkspaceSpecial(OLDWORKSPACE->m_id) && !OLDWORKSPACE->hasWindow() && *PCLOSEONLASTSPECIAL) {
         if (const auto PMONITOR = OLDWORKSPACE->m_monitor.lock(); PMONITOR)
             PMONITOR->setSpecialWorkspace(nullptr);
     }
@@ -559,10 +559,10 @@ void CWindow::onUnmap() {
     // if the special workspace now has 0 windows, it will be closed, and this
     // window will no longer pass render checks, cuz the workspace will be nuked.
     // throw it into the main one for the fadeout.
-    if (m_workspace->m_isSpecialWorkspace && m_workspace->getWindows() == 0)
+    if (m_workspace->m_isSpecialWorkspace && !m_workspace->hasWindow())
         m_lastWorkspace = m_monitor->activeWorkspaceID();
 
-    if (*PCLOSEONLASTSPECIAL && m_workspace && m_workspace->getWindows() == 0 && onSpecialWorkspace()) {
+    if (*PCLOSEONLASTSPECIAL && m_workspace && !m_workspace->hasWindow() && onSpecialWorkspace()) {
         const auto PMONITOR = m_monitor.lock();
         if (PMONITOR && PMONITOR->m_activeSpecialWorkspace && PMONITOR->m_activeSpecialWorkspace == m_workspace)
             PMONITOR->setSpecialWorkspace(nullptr);
@@ -2503,7 +2503,7 @@ void CWindow::unmapWindow() {
                 g_pCompositor->setWindowFullscreenInternal(PWINDOWCANDIDATE, CURRENTFSMODE);
         }
 
-        if (!PWINDOWCANDIDATE && m_workspace && m_workspace->getWindows() == 0)
+        if (!PWINDOWCANDIDATE && m_workspace && !m_workspace->hasWindow())
             g_pInputManager->refocus();
 
         g_pInputManager->sendMotionEventsToFocused();

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -164,7 +164,7 @@ SWorkspaceIDName getWorkspaceIDNameFromString(const std::string& in) {
         WORKSPACEID id = next ? Desktop::focusState()->monitor()->activeWorkspaceID() : 0;
         while (++id < LONG_MAX) {
             const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(id);
-            if (!invalidWSes.contains(id) && (!PWORKSPACE || PWORKSPACE->getWindows() == 0)) {
+            if (!invalidWSes.contains(id) && (!PWORKSPACE || !PWORKSPACE->hasWindow())) {
                 result.id = id;
                 return result;
             }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2259,7 +2259,7 @@ SDispatchResult CKeybindManager::circleNext(std::string arg) {
     if (!Desktop::focusState()->window()) {
         // if we have a clear focus, find the first window and get the next focusable.
         const auto PWS = Desktop::focusState()->monitor()->m_activeWorkspace;
-        if (PWS && PWS->getWindows() > 0) {
+        if (PWS && PWS->hasWindow()) {
             const auto PWINDOW = PWS->getFirstWindow();
             switchToWindow(PWINDOW);
         }

--- a/src/managers/input/UnifiedWorkspaceSwipeGesture.cpp
+++ b/src/managers/input/UnifiedWorkspaceSwipeGesture.cpp
@@ -66,7 +66,7 @@ void CUnifiedWorkspaceSwipeGesture::update(double delta) {
     m_delta = std::clamp(m_delta, sc<double>(-SWIPEDISTANCE), sc<double>(SWIPEDISTANCE));
 
     if ((m_workspaceBegin->m_id == workspaceIDLeft && *PSWIPENEW && (m_delta < 0)) ||
-        (m_delta > 0 && m_workspaceBegin->getWindows() == 0 && workspaceIDRight <= m_workspaceBegin->m_id) || (m_delta < 0 && m_workspaceBegin->m_id <= workspaceIDLeft)) {
+        (m_delta > 0 && !m_workspaceBegin->hasWindow() && workspaceIDRight <= m_workspaceBegin->m_id) || (m_delta < 0 && m_workspaceBegin->m_id <= workspaceIDLeft)) {
 
         m_delta = 0;
         g_pHyprRenderer->damageMonitor(m_monitor.lock());


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This PR adds 2 events to the events socket: populateworkspace and depopulateworkspace. The former is emitted when an empty workspace gains a window, while the latter is emitted when a workspace no longer has any windows.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I tested it with this:
<details>
<summary>Rust code</summary>

```rust
use std::{
  env::{args, var},
  error::Error,
  io::{BufRead, BufReader},
  os::unix::net::UnixStream,
  path::PathBuf,
  process::Command,
};

type Res = Result<(), Box<dyn Error>>; 

fn main() -> Res {
  let his = var("HYPRLAND_INSTANCE_SIGNATURE")
    .or_else(|_| args()
      .nth(1)
      .ok_or(Box::<dyn Error>::from("No arguments provided to program"))
    )?;
  let path: PathBuf = [
    var("XDG_RUNTIME_DIR")?,
    "hypr".into(),
    his,
    ".socket2.sock".into()
  ].iter().collect();
  let stream = UnixStream::connect(path)?;
  let mut lines = BufReader::new(stream).lines();


  while let Some(Ok(msg)) = lines.next() {
    let msg: Vec<_> = msg.split(">>").collect();
    let data: Vec<_> = msg[1].split(',').collect();

    match (msg[0], &*data) {
      ("depopulateworkspace", [_, name]) => notify(name, false)?,
      ("populateworkspace",   [_, name]) => notify(name, true)?,
      _ => (),
    }
  }
  Ok(())
}

fn notify(ws: &str, populated: bool) -> Res {
  let prefix = if populated {""} else {"de"};
  let _ = Command::new("hyprctl")
    .args(["notify", "6", "10000", "0", &format!("Workspace {ws} has been {prefix}populated")])
    .spawn()?;

  Ok(())
}
```
</details>

[Demonstration video](https://vimeo.com/1141203630)
A red circle in the the workspace indicator window at the top(which is separate) means that a workspace is populated, while grey means that it is not.

~The only issue that I have seen(from my limited testing) is that, sometimes, events are not emitted in the correct order when you use the `movetoworkspace` dispatch, as can be see from second 29 until the end. I'm not sure why that happens.~
EDIT: That only seems to happen from the notification side of things in the script I sent. Simply printing each time an event occurs seems to reliably preserve the order of events.

#### Is it ready for merging, or does it need work?

I think that it is ready for merging ~if that issue is not a dealbreaker.~