### PR TITLE
Remove unnecessary assert from renderRoundedShadow

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -2643,7 +2643,6 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const CGradientValueData& gr
 void CHyprOpenGLImpl::renderRoundedShadow(const CBox& box, int round, float roundingPower, int range, const CHyprColor& color, float a) {
     RASSERT(m_renderData.pMonitor, "Tried to render shadow without begin()!");
     RASSERT((box.width > 0 && box.height > 0), "Tried to render shadow with width/height < 0!");
-    RASSERT(m_renderData.currentWindow, "Tried to render shadow without a window!");
 
     if (m_renderData.damage.empty())
         return;


### PR DESCRIPTION
This assert causes a crash in plugins who just want to render a shadow, even though the `renderRoundedShadow` function does not actually ever use `currentWindow` in its body. 

It's just a faulty assert, and removing it lets this function be used without a reference to a window.