### PR TITLE
monitor: remove disconnected monitor from list before entering unsafestate

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -411,6 +411,7 @@ void CMonitor::onDisconnect(bool destroy) {
         m_layerSurfaceLayers[i].clear();
     }
 
+    std::erase_if(g_pCompositor->m_monitors, [&](PHLMONITOR& el) { return el.get() == this; });
     Debug::log(LOG, "Removed monitor {}!", m_name);
 
     if (!BACKUPMON) {
@@ -462,7 +463,7 @@ void CMonitor::onDisconnect(bool destroy) {
         PHLMONITOR pMonitorMostHz = nullptr;
 
         for (auto const& m : g_pCompositor->m_monitors) {
-            if (m->m_refreshRate > mostHz && m != m_self) {
+            if (m->m_refreshRate > mostHz) {
                 pMonitorMostHz = m;
                 mostHz         = m->m_refreshRate;
             }
@@ -470,7 +471,6 @@ void CMonitor::onDisconnect(bool destroy) {
 
         g_pHyprRenderer->m_mostHzMonitor = pMonitorMostHz;
     }
-    std::erase_if(g_pCompositor->m_monitors, [&](PHLMONITOR& el) { return el.get() == this; });
 }
 
 void CMonitor::applyCMType(NCMType::eCMType cmType, int cmSdrEotf) {


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

#### Describe your PR, what does it fix/add?
Fixes my issue described here #12539

The crash was occurring due to mirror monitor rule `monitor = ,preferred,auto,1, mirror, HDMI-A-2`  being applied to `unsafeOutput` when its created, because HDMI-A-2 output hansn't yet been removed from `m_monitors` before entering unsafe state.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
noting

#### Is it ready for merging, or does it need work?

~~I'll be testing it for couple of days~~
Should be ready, haven't encountered any issues