### PR TITLE
fix: typo on color simage description op

### DIFF
--- a/src/protocols/types/ColorManagement.hpp
+++ b/src/protocols/types/ColorManagement.hpp
@@ -179,8 +179,9 @@ namespace NColorManagement {
         bool     operator==(const SImageDescription& d2) const {
             return (id != 0 && id == d2.id) ||
                 (icc == d2.icc && windowsScRGB == d2.windowsScRGB && transferFunction == d2.transferFunction && transferFunctionPower == d2.transferFunctionPower &&
-                 ((primariesNameSet && primariesNamed == d2.primariesNameSet) || (primaries == d2.primaries)) && masteringPrimaries == d2.masteringPrimaries &&
-                 luminances == d2.luminances && masteringLuminances == d2.masteringLuminances && maxCLL == d2.maxCLL && maxFALL == d2.maxFALL);
+                 (primariesNameSet == d2.primariesNameSet && (primariesNameSet ? primariesNamed == d2.primariesNamed : primaries == d2.primaries)) &&
+                 masteringPrimaries == d2.masteringPrimaries && luminances == d2.luminances && masteringLuminances == d2.masteringLuminances && maxCLL == d2.maxCLL &&
+                 maxFALL == d2.maxFALL);
         }
 
         const SPCPRimaries& getPrimaries() const {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixed typo in SImageDescription::operator==: primariesNamed == d2.primariesNameSet → primariesNamed == d2.primariesNamed

Fixes the fixme in
https://github.com/hyprwm/hyprtoolkit/pull/24/files#diff-79aaa34a8c0d38c7b0b752fa1e4abfc9d9f6330b671f3eb4f062c24ed3df2229R305

In the hyprtoolkit you can then do 

`imageDesc->sendSetPrimariesNamed(WP_COLOR_MANAGER_V1_PRIMARIES_SRGB);`

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
not sure

