### PR TITLE
dispatcher: include mirrors of monitor in dpms

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2629,16 +2629,15 @@ SDispatchResult CKeybindManager::dpms(std::string arg) {
     if (arg.find_first_of(' ') != std::string::npos)
         port = arg.substr(arg.find_first_of(' ') + 1);
 
-    for (auto const& m : g_pCompositor->m_monitors) {
+    for (auto const& m : g_pCompositor->m_realMonitors) {
+        if (!m->m_enabled)
+            continue;
 
         if (!port.empty() && m->m_name != port)
             continue;
 
         if (isToggle)
             enable = !m->m_dpmsStatus;
-
-        for (const auto& mirror : m->m_mirrors)
-            mirror->setDPMS(enable);
 
         m->setDPMS(enable);
     }


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Fixes mirrors not being turned off for example on idle with `hyprctl dispatch dpms off` 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
noting

#### Is it ready for merging, or does it need work?
Ready

