### PR TITLE
Only use system glaze package if above version 6.0.0

### DIFF
--- a/hyprpm/CMakeLists.txt
+++ b/hyprpm/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_CXX_STANDARD 23)
 
 pkg_check_modules(hyprpm_deps REQUIRED IMPORTED_TARGET tomlplusplus hyprutils>=0.7.0)
 
-find_package(glaze QUIET)
+find_package(glaze 6.0.0 QUIET)
 if (NOT glaze_FOUND)
     set(GLAZE_VERSION v6.1.0)
     message(STATUS "glaze dependency not found, retrieving ${GLAZE_VERSION} with FetchContent")


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This PR will prevent using system's version of Glaze below 6.0.0.
Due to breaking changes in v6.0.0, hyprpm will only compile with Glaze v6.0.0+

#### Is it ready for merging, or does it need work?
So simple you can just merge it.

