### PR TITLE
fix: make HDR update tracking per-monitor

### DIFF
--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -336,6 +336,7 @@ class CMonitor {
     bool                                m_enabled             = false;
     bool                                m_renderingInitPassed = false;
     WP<CWindow>                         m_previousFSWindow;
+    bool                                m_needsHDRupdate = false;
     NColorManagement::SImageDescription m_imageDescription;
     bool                                m_noShaderCTM = false; // sets drm CTM, restore needed
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1557,8 +1557,6 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
     static auto PAUTOHDR   = CConfigValue<Hyprlang::INT>("render:cm_auto_hdr");
     static auto PNONSHADER = CConfigValue<Hyprlang::INT>("render:non_shader_cm");
 
-    static bool needsHDRupdate = false;
-
     const bool  configuredHDR = (pMonitor->m_cmType == NCMType::CM_HDR_EDID || pMonitor->m_cmType == NCMType::CM_HDR);
     bool        wantHDR       = configuredHDR;
 
@@ -1587,7 +1585,7 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
                 const bool surfaceIsHDR = SURF->m_colorManagement->isHDR();
                 if (!SURF->m_colorManagement->isWindowsScRGB() && (*PPASS == 1 || ((*PPASS == 2 || !pMonitor->m_lastScanout.expired()) && surfaceIsHDR))) {
                     // passthrough
-                    bool needsHdrMetadataUpdate = SURF->m_colorManagement->needsHdrMetadataUpdate() || pMonitor->m_previousFSWindow != FS_WINDOW || needsHDRupdate;
+                    bool needsHdrMetadataUpdate = SURF->m_colorManagement->needsHdrMetadataUpdate() || pMonitor->m_previousFSWindow != FS_WINDOW || pMonitor->m_needsHDRupdate;
                     if (SURF->m_colorManagement->needsHdrMetadataUpdate()) {
                         Debug::log(INFO, "[CM] Recreating HDR metadata for surface");
                         SURF->m_colorManagement->setHDRMetadata(createHDRMetadata(SURF->m_colorManagement->imageDescription(), pMonitor));
@@ -1596,8 +1594,8 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
                         Debug::log(INFO, "[CM] Updating HDR metadata from surface");
                         pMonitor->m_output->state->setHDRMetadata(SURF->m_colorManagement->hdrMetadata());
                     }
-                    hdrIsHandled   = true;
-                    needsHDRupdate = false;
+                    hdrIsHandled               = true;
+                    pMonitor->m_needsHDRupdate = false;
                 } else if (*PAUTOHDR && surfaceIsHDR)
                     wantHDR = true; // auto-hdr: hdr on
             }
@@ -1617,7 +1615,7 @@ bool CHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
                 Debug::log(INFO, wantHDR ? "[CM] Updating HDR metadata from monitor" : "[CM] Restoring SDR mode");
                 pMonitor->m_output->state->setHDRMetadata(wantHDR ? createHDRMetadata(pMonitor->m_imageDescription, pMonitor) : NO_HDR_METADATA);
             }
-            needsHDRupdate = true;
+            pMonitor->m_needsHDRupdate = true;
         }
     }
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Fixes https://github.com/hyprwm/Hyprland/discussions/12503. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Although the problem won't happen anymore, I'm not sure *why* exactly the CPU keeps increasing over time when continuously updating HDR metadata from surface

#### Is it ready for merging, or does it need work?
Ready

