### PR TITLE
Guard plugin longjmp when jump buffer isn’t primed 

### DIFF
--- a/src/managers/HookSystemManager.hpp
+++ b/src/managers/HookSystemManager.hpp
@@ -51,6 +51,7 @@ class CHookSystemManager {
     std::vector<SCallbackFNPtr>* getVecForEvent(const std::string& event);
 
     bool                         m_currentEventPlugin = false;
+    bool                         m_hookFaultJumpBufReady = false;
     jmp_buf                      m_hookFaultJumpBuf;
 
   private:


### PR DESCRIPTION
## Summary                                                                                                        
- track whether the hook jump buffer is initialized before longjmp                                                
- skip the jump when missing/invalid and fall back to crash reporting                                             

## Testing                                                                                                        
- manual: load a faulting plugin; verify no longjmp into uninitialized buffer and crash path is taken