### PR TITLE
anr: don't open for hyprland dialogs

### DIFF
--- a/src/helpers/AsyncDialogBox.cpp
+++ b/src/helpers/AsyncDialogBox.cpp
@@ -147,6 +147,10 @@ bool CAsyncDialogBox::isRunning() const {
     return m_readEventSource;
 }
 
+pid_t CAsyncDialogBox::getPID() const {
+    return m_dialogPid;
+}
+
 SP<CAsyncDialogBox> CAsyncDialogBox::lockSelf() {
     return m_selfWeakReference.lock();
 }

--- a/src/helpers/AsyncDialogBox.hpp
+++ b/src/helpers/AsyncDialogBox.hpp
@@ -26,6 +26,7 @@ class CAsyncDialogBox {
     SP<CPromise<std::string>> open();
     void                      kill();
     bool                      isRunning() const;
+    pid_t                     getPID() const;
 
     SP<CAsyncDialogBox>       lockSelf();
 

--- a/src/managers/ANRManager.cpp
+++ b/src/managers/ANRManager.cpp
@@ -1,4 +1,5 @@
 #include "ANRManager.hpp"
+
 #include "../helpers/fs/FsUtils.hpp"
 #include "../debug/Log.hpp"
 #include "../macros.hpp"
@@ -29,6 +30,10 @@ CANRManager::CANRManager() {
         auto window = std::any_cast<PHLWINDOW>(data);
 
         for (const auto& d : m_data) {
+            // Window is ANR dialog
+            if (d->isRunning() && d->dialogBox->getPID() == window->getPID())
+                return;
+
             if (d->fitsWindow(window))
                 return;
         }
@@ -84,7 +89,7 @@ void CANRManager::onTick() {
 
         if (data->missedResponses >= *PANRTHRESHOLD) {
             if (!data->isRunning() && !data->dialogSaidWait) {
-                data->runDialog(firstWindow->m_title, firstWindow->m_class, data->getPid());
+                data->runDialog(firstWindow->m_title, firstWindow->m_class, data->getPID());
 
                 for (const auto& w : g_pCompositor->m_windows) {
                     if (!w->m_isMapped)
@@ -240,7 +245,7 @@ bool CANRManager::SANRData::isDefunct() const {
     return xdgBase.expired() && xwaylandSurface.expired();
 }
 
-pid_t CANRManager::SANRData::getPid() const {
+pid_t CANRManager::SANRData::getPID() const {
     if (xdgBase) {
         pid_t pid = 0;
         wl_client_get_credentials(xdgBase->client(), &pid, nullptr, nullptr);

--- a/src/managers/ANRManager.hpp
+++ b/src/managers/ANRManager.hpp
@@ -44,7 +44,7 @@ class CANRManager {
         void                 killDialog();
         bool                 isDefunct() const;
         bool                 fitsWindow(PHLWINDOW pWindow) const;
-        pid_t                getPid() const;
+        pid_t                getPID() const;
         void                 ping();
     };
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Doesn't open ANR dialog for when hyprland dialogs are unresponsive, fixes #12528.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
It won't open ANR dialogs for any hyprland dialog instead of just not ANR dialogs.

#### Is it ready for merging, or does it need work?
Should be ready.

