### PR TITLE
CI/Nix: fix glaze dependency issue

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -11,7 +11,7 @@
   cairo,
   epoll-shim,
   git,
-  glaze,
+  glaze-hyprland,
   gtest,
   hyprcursor,
   hyprgraphics,
@@ -143,7 +143,7 @@ in
           aquamarine
           cairo
           git
-          glaze
+          glaze-hyprland
           gtest
           hyprcursor
           hyprgraphics

--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -30,6 +30,7 @@ in {
     inputs.hyprwayland-scanner.overlays.default
     inputs.hyprwire.overlays.default
     self.overlays.udis86
+    self.overlays.glaze
 
     # Hyprland packages themselves
     (final: _prev: let
@@ -109,5 +110,14 @@ in {
 
       patches = [];
     });
+  };
+
+  # Even though glaze itself disables it by default, nixpkgs sets ENABLE_SSL set to true.
+  # Since we don't include openssl, the build failes without the `enableSSL = false;` override
+  glaze = final: prev: {
+    glaze-hyprland = prev.glaze.override {
+      enableSSL = false;
+      enableInterop = false;
+    };
   };
 }


### PR DESCRIPTION
*Edit: Becomes relevant on the next nixpkgs update*

Uhm the json library suddenly requires openssl support xD

Since I had to fix this myself already, I thought I would open this PR to fix the CI and devShell builds.

@fufexan

#### Describe your PR, what does it fix/add?

Fixes CI and nix devShell builds

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Yes
