### PR TITLE
opengl: default initialize m_capStatus

### DIFF
--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -355,7 +355,7 @@ class CHyprOpenGLImpl {
         GLsizei height = 0;
     } m_lastViewport;
 
-    std::array<bool, CAP_STATUS_END>  m_capStatus;
+    std::array<bool, CAP_STATUS_END>  m_capStatus = {};
 
     std::vector<SDRMFormat>           m_drmFormats;
     bool                              m_hasModifiers = false;


### PR DESCRIPTION
ubsan reports under wonky situation a runtime error of uninitialized value lookups because of m_capStatus isnt initialized. so default initialize it.

`OpenGL.cpp:3331:26: runtime error: load of value 190, which is not a valid value for type 'bool'`


