### PR TITLE
window: only damage floating on clamped size change

### DIFF
--- a/src/desktop/view/Window.hpp
+++ b/src/desktop/view/Window.hpp
@@ -286,7 +286,7 @@ namespace Desktop::View {
         bool                       onSpecialWorkspace();
         void                       activate(bool force = false);
         int                        surfacesCount();
-        void                       clampWindowSize(const std::optional<Vector2D> minSize, const std::optional<Vector2D> maxSize);
+        bool                       clampWindowSize(const std::optional<Vector2D> minSize, const std::optional<Vector2D> maxSize);
         bool                       isFullscreen();
         bool                       isEffectiveInternalFSMode(const eFullscreenMode) const;
         int                        getRealBorderSize() const;


### PR DESCRIPTION
currently it damage the entire window if its floating and not x11 nor fullscreen meaning damage isnt working at all for floating. im tracing this back to a364df4 where the logic changed from damaging window only if size was being forced to now unconditonally doing it.

change clampWindowSize to return as a bool if size changed and only damage window if it got clamped.


