### PR TITLE
WindowRules: fix disabling binary window rules with override

### DIFF
--- a/src/desktop/rule/windowRule/WindowRuleApplicator.hpp
+++ b/src/desktop/rule/windowRule/WindowRuleApplicator.hpp
@@ -40,12 +40,12 @@ namespace Desktop::Rule {
         struct {
             std::string              monitor, workspace, group;
 
-            bool                     floating       = false;
-            bool                     fullscreen     = false;
-            bool                     maximize       = false;
-            bool                     pseudo         = false;
-            bool                     pin            = false;
-            bool                     noInitialFocus = false;
+            std::optional<bool>      floating;
+            std::optional<bool>      fullscreen;
+            std::optional<bool>      maximize;
+            std::optional<bool>      pseudo;
+            std::optional<bool>      pin;
+            std::optional<bool>      noInitialFocus;
 
             std::optional<int>       fullscreenStateClient;
             std::optional<int>       fullscreenStateInternal;

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -2047,10 +2047,10 @@ void CWindow::mapWindow() {
             requestedFSMonitor = MONITOR_INVALID;
         }
 
-        m_isFloating = m_ruleApplicator->static_.floating;
-        m_isPseudotiled = m_ruleApplicator->static_.pseudo;
-        m_noInitialFocus = m_ruleApplicator->static_.noInitialFocus;
-        m_pinned = m_ruleApplicator->static_.pin;
+        m_isFloating     = m_ruleApplicator->static_.floating.value_or(m_isFloating);
+        m_isPseudotiled  = m_ruleApplicator->static_.pseudo.value_or(m_isPseudotiled);
+        m_noInitialFocus = m_ruleApplicator->static_.noInitialFocus.value_or(m_noInitialFocus);
+        m_pinned         = m_ruleApplicator->static_.pin.value_or(m_pinned);
 
         if (m_ruleApplicator->static_.fullscreenStateClient || m_ruleApplicator->static_.fullscreenStateInternal) {
             requestedFSState = Desktop::View::SFullscreenState{
@@ -2076,10 +2076,10 @@ void CWindow::mapWindow() {
             }
         }
 
-        if (m_ruleApplicator->static_.fullscreen)
+        if (m_ruleApplicator->static_.fullscreen.value_or(false))
             requestedInternalFSMode = FSMODE_FULLSCREEN;
 
-        if (m_ruleApplicator->static_.maximize)
+        if (m_ruleApplicator->static_.maximize.value_or(false))
             requestedInternalFSMode = FSMODE_MAXIMIZED;
 
         if (!m_ruleApplicator->static_.group.empty()) {

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -985,7 +985,7 @@ Vector2D IHyprLayout::predictSizeForNewWindowFloating(PHLWINDOW pWindow) { // ge
 }
 
 Vector2D IHyprLayout::predictSizeForNewWindow(PHLWINDOW pWindow) {
-    bool     shouldBeFloated = g_pXWaylandManager->shouldBeFloated(pWindow, true) || pWindow->m_ruleApplicator->static_.floating;
+    bool     shouldBeFloated = g_pXWaylandManager->shouldBeFloated(pWindow, true) || pWindow->m_ruleApplicator->static_.floating.value_or(false);
 
     Vector2D sizePredicted = {};
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

I assume this bug was the result of some mass refactoring. The state of these simple binary rules were only being set when the rule was true, which made it impossible for them to be set back to false by later rules.

Also changed the floating rule field to a bool, as far as I can tell there is no reason to use an optional bool here.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Should be ready to merge