### PR TITLE
compositor: early return on no monitor

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -894,7 +894,10 @@ bool CCompositor::monitorExists(PHLMONITOR pMonitor) {
 }
 
 PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t properties, PHLWINDOW pIgnoreWindow) {
-    const auto  PMONITOR             = getMonitorFromVector(pos);
+    const auto PMONITOR = getMonitorFromVector(pos);
+    if (!PMONITOR)
+        return nullptr;
+
     static auto PRESIZEONBORDER      = CConfigValue<Hyprlang::INT>("general:resize_on_border");
     static auto PBORDERSIZE          = CConfigValue<Hyprlang::INT>("general:border_size");
     static auto PBORDERGRABEXTEND    = CConfigValue<Hyprlang::INT>("general:extend_border_grab_area");


### PR DESCRIPTION
getMonitorFromVector can return nullptr on empty m_monitors, as such is the case when the compositor is going down and a surface exist. return early in vectorToWindowUnified if that happends.

fixes: #12636

```
0  0x000063a267bde3a9 in Hyprutils::Memory::CSharedPointer<CWorkspace>::operator bool (this=0x70) at /usr/include/hyprutils/memory/SharedPtr.hpp:110
#1  0x000063a267ba6296 in CCompositor::vectorToWindowUnified (this=0x63a28dbacbd0, pos=..., properties=19 '\023', pIgnoreWindow=...) at /home/spicy/git/Hyprland/src/Compositor.cpp:1043
        PMONITOR = {impl_ = 0x0, m_data = 0x0}
        PRESIZEONBORDER = {p_ = 0x63a28dc572b0}
        PBORDERSIZE = {p_ = 0x63a28dc53ba0}
        PBORDERGRABEXTEND = {p_ = 0x63a28dc586b0}
        PSPECIALFALLTHRU = {p_ = 0x63a28dc55ba0}
        PMODALPARENTBLOCKING = {p_ = 0x63a28dc53e20}
        BORDER_GRAB_AREA = 0
        ONLY_PRIORITY = false
        isShadowedByModal = {<No data fields>}
        windowForWorkspace = {__this = 0x63a28dbacbd0, __ONLY_PRIORITY = @0x7ffcdaebba3e, __properties = @0x7ffcdaebba14, __pIgnoreWindow = @0x7ffcdaebbcc0, __isShadowedByModal = @0x7ffcdaebba3f, __BORDER_GRAB_AREA = @0x7ffcdaebba40, __pos = @0x7ffcdaebbcb0, __PMONITOR = @0x7ffcdaebbaa0}
#2  0x000063a267f480d4 in IHyprLayout::getNextWindowCandidate (this=0x63a28dc2c2f0, pWindow=...) at /home/spicy/git/Hyprland/src/layout/IHyprLayout.cpp:928
        PWORKSPACE = {impl_ = 0x63a28e3cafe0, m_data = 0x63a28e421de0}
        pWindowCandidate = {impl_ = 0x63a28e3fb6e0, m_data = 0x7ffcdaebbe10}
#3  0x000063a267dff03c in Desktop::View::CWindow::unmapWindow (this=0x63a28eb471e0) at /home/spicy/git/Hyprland/src/desktop/view/Window.cpp:2496
        FOCUSONCLOSE = {p_ = 0x63a28dc584f0}
        PWINDOWCANDIDATE = {impl_ = 0x0, m_data = 0x0}
        PEXITRETAINSFS = {p_ = 0x63a28dc58290}
        CURRENTWINDOWFSSTATE = false
        CURRENTFSMODE = FSMODE_NONE
        PMONITOR = {impl_ = 0x63a28e3ccc70, m_data = 0x63a28e3da860}
        wasLastWindow = true
        PWORKSPACE = {impl_ = 0x63a28e3cafe0, m_data = 0x63a28e421de0}
#4  0x000063a267dd0cfc in operator() (__closure=0x63a28eb47930) at /home/spicy/git/Hyprland/src/desktop/view/Window.cpp:109
#5  0x000063a267e0decc in std::__invoke_impl<void, Desktop::View::CWindow::CWindow(SP<CXDGSurfaceResource>)::<lambda()>&>(std::__invoke_other, struct {...} &) (__f=...) at /usr/include/c++/15.2.1/bits/invoke.h:63
#6  0x000063a267e098d4 in std::__invoke_r<void, Desktop::View::CWindow::CWindow(SP<CXDGSurfaceResource>)::<lambda()>&>(struct {...} &) (__fn=...) at /usr/include/c++/15.2.1/bits/invoke.h:113
#7  0x000063a267e0654a in std::_Function_handler<void(), Desktop::View::CWindow::CWindow(SP<CXDGSurfaceResource>)::<lambda()> >::_M_invoke(const std::_Any_data &) (__functor=...)
    at /usr/include/c++/15.2.1/bits/std_function.h:292
#8  0x000063a267c0b037 in std::function<void()>::operator() (this=0x63a28eb47930) at /usr/include/c++/15.2.1/bits/std_function.h:593
#9  0x000063a267bf9145 in Hyprutils::Signal::CSignalT<>::mkHandler(std::function<void ()>)::{lambda(void*)#1}::operator()(void*) const (__closure=0x63a28eb47930, args=0x0)
    at /usr/include/hyprutils/signal/Signal.hpp:95
#10 0x000063a267c25738 in std::__invoke_impl<void, Hyprutils::Signal::CSignalT<>::mkHandler(std::function<void ()>)::{lambda(void*)#1}&, void*>(std::__invoke_other, Hyprutils::Signal::CSignalT<>::mkHandler(std::function<void ()>)::{lambda(void*)#1}&, void*&&) (__f=...) at /usr/include/c++/15.2.1/bits/invoke.h:63
#11 0x000063a267c1f3e8 in std::__invoke_r<void, Hyprutils::Signal::CSignalT<>::mkHandler(std::function<void ()>)::{lambda(void*)#1}&, void*>(Hyprutils::Signal::CSignalT<>::mkHandler(std::function<void ()>)::{lambda(void*)#1}&, void*&&) (__fn=...) at /usr/include/c++/15.2.1/bits/invoke.h:113
#12 0x000063a267c17582 in std::_Function_handler<void (void*), Hyprutils::Signal::CSignalT<>::mkHandler(std::function<void ()>)::{lambda(void*)#1}>::_M_invoke(std::_Any_data const&, void*&&)
    (__functor=..., __args#0=@0x7ffcdaebc050: 0x0) at /usr/include/c++/15.2.1/bits/std_function.h:292
#13 0x0000799d51e6434d in std::function<void(void*)>::operator() (this=<optimized out>, __args#0=<optimized out>) at /usr/include/c++/15.2.1/bits/std_function.h:593
#14 Hyprutils::Signal::CSignalListener::emitInternal (this=<optimized out>, data=data@entry=0x0) at /usr/src/debug/hyprutils-git/hyprutils/src/signal/Listener.cpp:14
#15 0x0000799d51e645e3 in Hyprutils::Signal::CSignalBase::emitInternal (this=<optimized out>, args=0x0) at /usr/src/debug/hyprutils-git/hyprutils/src/signal/Signal.cpp:30
        l = @0x63a28eb4b3f0: {impl_ = 0x63a28eb47960, m_data = 0x63a28eb47850}
        listeners = std::vector of length 1, capacity 1 = {{impl_ = 0x63a28eb47960, m_data = 0x63a28eb47850}}
        statics = std::vector of length 0, capacity 0
#16 0x000063a267bde8ba in Hyprutils::Signal::CSignalT<>::emit() (this=0x63a28eb46cf0) at /usr/include/hyprutils/signal/Signal.hpp:34
#17 0x000063a26857f456 in operator() (__closure=0x63a28eb45e40) at /home/spicy/git/Hyprland/src/protocols/XDGShell.cpp:410
#18 0x000063a2685963ba in std::__invoke_impl<void, CXDGSurfaceResource::CXDGSurfaceResource(SP<CXdgSurface>, SP<CXDGWMBase>, SP<CWLSurfaceResource>)::<lambda()>&>(std::__invoke_other, struct {...} &) (__f=...)
    at /usr/include/c++/15.2.1/bits/invoke.h:63
#19 0x000063a26859191c in std::__invoke_r<void, CXDGSurfaceResource::CXDGSurfaceResource(SP<CXdgSurface>, SP<CXDGWMBase>, SP<CWLSurfaceResource>)::<lambda()>&>(struct {...} &) (__fn=...)
    at /usr/include/c++/15.2.1/bits/invoke.h:113
#20 0x000063a26858c012 in std::_Function_handler<void(), CXDGSurfaceResource::CXDGSurfaceResource(SP<CXdgSurface>, SP<CXDGWMBase>, SP<CWLSurfaceResource>)::<lambda()> >::_M_invoke(const std::_Any_data &)
    (__functor=...) at /usr/include/c++/15.2.1/bits/std_function.h:292
#21 0x000063a267c0b037 in std::function<void()>::operator() (this=0x63a28eb45e40) at /usr/include/c++/15.2.1/bits/std_function.h:593
#22 0x000063a267bf9145 in Hyprutils::Signal::CSignalT<>::mkHandler(std::function<void ()>)::{lambda(void*)#1}::operator()(void*) const (__closure=0x63a28eb45e40, args=0x0)
    at /usr/include/hyprutils/signal/Signal.hpp:95
#23 0x000063a267c25738 in std::__invoke_impl<void, Hyprutils::Signal::CSignalT<>::mkHandler(std::function<void ()>)::{lambda(void*)#1}&, void*>(std::__invoke_other, Hyprutils::Signal::CSignalT<>::mkHandler(std::function<void ()>)::{lambda(void*)#1}&, void*&&) (__f=...) at /usr/include/c++/15.2.1/bits/invoke.h:63
#24 0x000063a267c1f3e8 in std::__invoke_r<void, Hyprutils::Signal::CSignalT<>::mkHandler(std::function<void ()>)::{lambda(void*)#1}&, void*>(Hyprutils::Signal::CSignalT<>::mkHandler(std::function<void ()>)::{lambda(void*)#1}&, void*&&) (__fn=...) at /usr/include/c++/15.2.1/bits/invoke.h:113
#25 0x000063a267c17582 in std::_Function_handler<void (void*), Hyprutils::Signal::CSignalT<>::mkHandler(std::function<void ()>)::{lambda(void*)#1}>::_M_invoke(std::_Any_data const&, void*&&)
    (__functor=..., __args#0=@0x7ffcdaebc4e0: 0x0) at /usr/include/c++/15.2.1/bits/std_function.h:292
#26 0x0000799d51e6434d in std::function<void(void*)>::operator() (this=<optimized out>, __args#0=<optimized out>) at /usr/include/c++/15.2.1/bits/std_function.h:593
#27 Hyprutils::Signal::CSignalListener::emitInternal (this=<optimized out>, data=data@entry=0x0) at /usr/src/debug/hyprutils-git/hyprutils/src/signal/Listener.cpp:14
#28 0x0000799d51e645e3 in Hyprutils::Signal::CSignalBase::emitInternal (this=<optimized out>, args=0x0) at /usr/src/debug/hyprutils-git/hyprutils/src/signal/Signal.cpp:30
        l = @0x63a28ea4f550: {impl_ = 0x63a28eb46260, m_data = 0x63a28ea9d2c0}
        listeners = std::vector of length 4, capacity 8 = {{impl_ = 0x63a28eb46260, m_data = 0x63a28ea9d2c0}, {impl_ = 0x63a28eb49c30, m_data = 0x63a28eb49ba0}, {impl_ = 0x63a28eb51660, m_data = 0x63a28eb50130}, {impl_ = 0x63a28eb505a0, m_data = 0x63a28eb4b4e0}}
        statics = std::vector of length 0, capacity 0
#29 0x000063a267bde8ba in Hyprutils::Signal::CSignalT<>::emit() (this=0x63a28eb46750) at /usr/include/hyprutils/signal/Signal.hpp:34
#30 0x000063a2685f6ec3 in CWLSurfaceResource::destroy (this=0x63a28eb46600) at /home/spicy/git/Hyprland/src/protocols/core/Compositor.cpp:248
#31 0x000063a2685f3c40 in operator() (__closure=0x63a28eb2b990, r=0x63a28eb2b830) at /home/spicy/git/Hyprland/src/protocols/core/Compositor.cpp:79
#32 0x000063a26860959e in std::__invoke_impl<void, CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface>)::<lambda(CWlSurface*)>&, CWlSurface*>(std::__invoke_other, struct {...} &) (__f=...)
    at /usr/include/c++/15.2.1/bits/invoke.h:63
#33 0x000063a26860598d in std::__invoke_r<void, CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface>)::<lambda(CWlSurface*)>&, CWlSurface*>(struct {...} &) (__fn=...) at /usr/include/c++/15.2.1/bits/invoke.h:113
#34 0x000063a26860245c in std::_Function_handler<void(CWlSurface*), CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface>)::<lambda(CWlSurface*)> >::_M_invoke(const std::_Any_data &, CWlSurface *&&)
    (__functor=..., __args#0=@0x7ffcdaebc6c0: 0x63a28eb2b830) at /usr/include/c++/15.2.1/bits/std_function.h:292
#35 0x000063a2688a5c54 in std::function<void(CWlSurface*)>::operator() (this=0x63a28eb2b990, __args#0=0x63a28eb2b830) at /usr/include/c++/15.2.1/bits/std_function.h:593
#36 0x000063a26889bd81 in CWlSurface::onDestroyCalled (this=0x63a28eb2b830) at /home/spicy/git/Hyprland/protocols/wayland.cpp:2033
#37 0x000063a26889b65b in _CWlSurface__DestroyListener (l=0x63a28eb2b9b8, d=0x63a28eb45bb0) at /home/spicy/git/Hyprland/protocols/wayland.cpp:1855
        wrap = 0x63a28eb2b9b8
        pResource = 0x63a28eb2b830
#38 0x0000799d51d26c18 in wl_priv_signal_final_emit (signal=<optimized out>, data=<optimized out>) at ../wayland-1.24.0/src/wayland-server.c:2533
        l = 0x63a28eb2b9b8
        pos = 0x63a28eb2b9b8
#39 remove_and_destroy_resource (element=0x63a28eb45bb0, data=data@entry=0x0, flags=0) at ../wayland-1.24.0/src/wayland-server.c:793
        resource = 0x63a28eb45bb0
        client = 0x63a28ead2680
        id = 39
#40 0x0000799d51d26dd2 in for_each_helper (entries=0x63a28ead26b0, func=0x799d51d26b00 <remove_and_destroy_resource>, data=0x0) at ../wayland-1.24.0/src/wayland-util.c:430
        idx = <optimized out>
        ret = WL_ITERATOR_CONTINUE
        entry = {next = <optimized out>, data = <optimized out>}
        start = <optimized out>
        count = <optimized out>
#41 wl_map_for_each (map=0x63a28ead26b0, func=0x799d51d26b00 <remove_and_destroy_resource>, data=0x0) at ../wayland-1.24.0/src/wayland-util.c:444
        ret = <optimized out>
#42 wl_client_destroy (client=0x63a28ead2680) at ../wayland-1.24.0/src/wayland-server.c:1014
#43 0x0000799d51d28306 in wl_display_destroy_clients (display=0x63a28dbad120) at ../wayland-1.24.0/src/wayland-server.c:1637
        tmp_client_list = {prev = 0x7ffcdaebc7b0, next = 0x7ffcdaebc7b0}
        pos = <optimized out>
        client = <optimized out>
#44 0x000063a267b9ea31 in CCompositor::cleanup (this=0x63a28dbacbd0) at /home/spicy/git/Hyprland/src/Compositor.cpp:586
#45 0x000063a267b6561e in main (argc=1, argv=0x7ffcdaebccf8) at /home/spicy/git/Hyprland/src/main.cpp:231
        cmd = "./build/Hyprland"
        configPath = ""
        socketName = ""
        socketFd = -1
        ignoreSudo = false
        verifyConfig = false
        safeMode = false
        watchdogFd = -1
        ``
