### PR TITLE
Removed a monitor reset on cleanup

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -574,9 +574,6 @@ void CCompositor::cleanup() {
 
     for (auto const& m : m_monitors) {
         g_pHyprOpenGL->destroyMonitorResources(m);
-
-        m->m_output->state->setEnabled(false);
-        m->m_state.commit();
     }
 
     g_pXWayland.reset();


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
This PR removes the disabling of all connected monitors upon shutdown, eliminating a modeset flicker when Hyprland exits. This fixes one the issues preventing Hyprland users from experiencing the glory of a flicker-free computing experience. For more information on the specific flickering issues I've found, see [this](https://github.com/hyprwm/aquamarine/issues/205) issue in aquamarine and #11560 here.

The issues with flickering on VT switches remain, ~~but I'm going to create a separate PR to address that as it lies in auqamarine~~, but that's addressed by [this](https://github.com/hyprwm/aquamarine/pull/223) PR in `aquamarine`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I've tested this change with different modes from the monitor default and validated that dpms still works, at least on my machine. If there's a good reason why this exists, feel free to correct me, but this helps get us closer to a flicker-free experience.

I've run the hyprtester and the unit tests, but either I'm doing something (likely) or the tests are currently broken (less likely) as on both `main` and this fork, I'm seeing failures.


#### Is it ready for merging, or does it need work?
As mentioned, I've tried testing this to the best of my ability, but I'm a bit of a novice when it comes to Linux DRM and Wayland compositors at large, so if there's someone more knowledgeable on why this functionality was there in the first place, please feel free to chime in.


