### PR TITLE
touch: fix LS on different monitor than cursor not getting touch events

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -183,7 +183,7 @@ void CInputManager::sendMotionEventsToFocused() {
     g_pSeatManager->setPointerFocus(Desktop::focusState()->surface(), LOCAL);
 }
 
-void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, std::optional<Vector2D> overridePos) {
+void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, std::optional<Vector2D> overridePos, std::optional<PHLMONITOR> monitor) {
     m_lastInputMouse = mouse;
 
     if (!g_pCompositor->m_readyToProcess || g_pCompositor->m_isShuttingDown || g_pCompositor->m_unsafeState)
@@ -224,7 +224,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
 
     m_lastCursorPosFloored = MOUSECOORDSFLOORED;
 
-    const auto PMONITOR = isLocked() && Desktop::focusState()->monitor() ? Desktop::focusState()->monitor() : g_pCompositor->getMonitorFromCursor();
+    const auto PMONITOR = monitor ? monitor.value() : isLocked() && Desktop::focusState()->monitor() ? Desktop::focusState()->monitor() : g_pCompositor->getMonitorFromCursor();
 
     // this can happen if there are no displays hooked up to Hyprland
     if (PMONITOR == nullptr)
@@ -1547,8 +1547,8 @@ bool CInputManager::shouldIgnoreVirtualKeyboard(SP<IKeyboard> pKeyboard) {
     return DISALLOWACTION;
 }
 
-void CInputManager::refocus(std::optional<Vector2D> overridePos) {
-    mouseMoveUnified(0, true, false, overridePos);
+void CInputManager::refocus(std::optional<Vector2D> overridePos, std::optional<PHLMONITOR> monitor) {
+    mouseMoveUnified(0, true, false, overridePos, monitor);
 }
 
 bool CInputManager::refocusLastWindow(PHLMONITOR pMonitor) {

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -117,7 +117,7 @@ class CInputManager {
     bool               isLocked();
 
     Vector2D           getMouseCoordsInternal();
-    void               refocus(std::optional<Vector2D> overridePos = std::nullopt);
+    void               refocus(std::optional<Vector2D> overridePos = std::nullopt, std::optional<PHLMONITOR> monitor = std::nullopt);
     bool               refocusLastWindow(PHLMONITOR pMonitor);
     void               simulateMouseMovement();
     void               sendMotionEventsToFocused();
@@ -244,12 +244,12 @@ class CInputManager {
 
     uint32_t           m_capabilities = 0;
 
-    void               mouseMoveUnified(uint32_t, bool refocus = false, bool mouse = false, std::optional<Vector2D> overridePos = std::nullopt);
-    void               recheckMouseWarpOnMouseInput();
+    void mouseMoveUnified(uint32_t, bool refocus = false, bool mouse = false, std::optional<Vector2D> overridePos = std::nullopt, std::optional<PHLMONITOR> monitor = std::nullopt);
+    void recheckMouseWarpOnMouseInput();
 
-    SP<CTabletTool>    ensureTabletToolPresent(SP<Aquamarine::ITabletTool>);
+    SP<CTabletTool> ensureTabletToolPresent(SP<Aquamarine::ITabletTool>);
 
-    void               applyConfigToKeyboard(SP<IKeyboard>);
+    void            applyConfigToKeyboard(SP<IKeyboard>);
 
     // this will be set after a refocus()
     WP<CWLSurfaceResource> m_foundSurfaceToFocus;

--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -30,7 +30,7 @@ void CInputManager::onTouchDown(ITouch::SDownEvent e) {
 
     const auto TOUCH_COORDS = PMONITOR->m_position + (e.pos * PMONITOR->m_size);
 
-    refocus(TOUCH_COORDS);
+    refocus(TOUCH_COORDS, PMONITOR);
 
     if (m_clickBehavior == CLICKMODE_KILL) {
         IPointer::SButtonEvent e;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

fixes #12221

as mentioned in the discussion, layer shells do not get touch input if cursor is in a different
monitor

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?

yes

