### PR TITLE
fix: prevent pixman crashes and ensure valid color management metadata

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1017,6 +1017,10 @@ void CMonitor::addDamage(const CRegion& rg) {
 }
 
 void CMonitor::addDamage(const CBox& box) {
+
+    if (box.width <= 0 || box.height <= 0)
+        return;
+
     if (m_cursorZoom->value() != 1.f && g_pCompositor->getMonitorFromCursor() == m_self) {
         m_damage.damageEntire();
         g_pCompositor->scheduleFrameForMonitor(m_self.lock(), Aquamarine::IOutput::AQ_SCHEDULE_DAMAGE);


### PR DESCRIPTION
## Description
This PR addresses two related issues causing crashes in clients (specifically Chromium/Electron-based applications) due to invalid data being passed from the compositor.

## Changes

### 1. Fix Invalid Pixman Rectangles (Monitor.cpp)
In `CMonitor::addDamage(const CBox& box)`, a guard clause was added to ignore boxes with non-positive dimensions. 
Previously, passing a box with `width <= 0` or `height <= 0` to `pixman_region32_init_rect` caused an assertion failure or crash with the error:
`*** BUG *** In pixman_region32_init_rect: Invalid rectangle passed`

### 2. Fix Incomplete Image Description (ColorManagement.cpp)
Updated `CColorManagementImageDescriptionInfo` and scRGB creation to ensure valid metadata is always sent to clients:
* **Fallback Primaries:** If `primaries` are invalid (e.g., zeroed out), the protocol now sends standard sRGB primaries instead of sending invalid data.
* **scRGB Luminance:** Hardcoded valid default luminance values (min: 0.0001, ref: 80, max: 600) for Windows scRGB generation to satisfy strict client validation.

## Impact
This fixes crashes observed in applications logging:
* `[wayland_wp_image_description.cc] Incomplete image description info from compositor`
* `pixman_region32_init_rect: Invalid rectangle passed`