### PR TITLE
general: add screen cast border indicators

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -16,6 +16,18 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SRangeData{1, 0, 20},
     },
     SConfigOptionDescription{
+        .value       = "general:screencast_border.enabled",
+        .description = "enable red border indicator when screen sharing",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{true},
+    },
+    SConfigOptionDescription{
+        .value       = "general:screencast_border.color",
+        .description = "border color when screen sharing",
+        .type        = CONFIG_OPTION_GRADIENT,
+        .data        = SConfigOptionDescription::SGradientData{"0xffff0000"},
+    },
+    SConfigOptionDescription{
         .value       = "general:gaps_in",
         .description = "gaps between windows\n\nsupports css style gaps (top, right, bottom, left -> 5 10 15 20)",
         .type        = CONFIG_OPTION_STRING_SHORT,

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -443,6 +443,8 @@ CConfigManager::CConfigManager() {
     m_config = makeUnique<Hyprlang::CConfig>(m_configPaths.begin()->c_str(), Hyprlang::SConfigOptions{.throwAllErrors = true, .allowMissingConfig = true});
 
     registerConfigVar("general:border_size", Hyprlang::INT{1});
+    registerConfigVar("general:screencast_border.enabled", Hyprlang::INT{1});
+    registerConfigVar("general:screencast_border.color", Hyprlang::CConfigCustomValueType{&configHandleGradientSet, configHandleGradientDestroy, "0xffff0000"});
     registerConfigVar("general:gaps_in", Hyprlang::CConfigCustomValueType{configHandleGapSet, configHandleGapDestroy, "5"});
     registerConfigVar("general:gaps_out", Hyprlang::CConfigCustomValueType{configHandleGapSet, configHandleGapDestroy, "20"});
     registerConfigVar("general:float_gaps", Hyprlang::CConfigCustomValueType{configHandleGapSet, configHandleGapDestroy, "0"});

--- a/src/protocols/Screencopy.cpp
+++ b/src/protocols/Screencopy.cpp
@@ -514,6 +514,11 @@ void CScreencopyProtocol::destroyResource(CScreencopyClient* client) {
 }
 
 void CScreencopyProtocol::destroyResource(CScreencopyFrame* frame) {
+    // Damage the monitor before destroying the frame so the border updates
+    if (frame && frame->m_monitor) {
+        if (auto monitor = frame->m_monitor.lock())
+            g_pHyprRenderer->damageMonitor(monitor);
+    }
     std::erase_if(m_frames, [&](const auto& other) { return other.get() == frame; });
     std::erase_if(m_framesAwaitingWrite, [&](const auto& other) { return !other || other.get() == frame; });
 }

--- a/src/protocols/Screencopy.hpp
+++ b/src/protocols/Screencopy.hpp
@@ -36,12 +36,13 @@ class CScreencopyClient {
     CTimer                m_lastFrame;
     int                   m_frameCounter = 0;
 
+    bool                  m_sentScreencast = false;
+
   private:
     SP<CZwlrScreencopyManagerV1> m_resource;
 
     int                          m_framesInLastHalfSecond = 0;
     CTimer                       m_lastMeasure;
-    bool                         m_sentScreencast = false;
 
     SP<HOOK_CALLBACK_FN>         m_tickCallback;
     void                         onTick();
@@ -59,11 +60,10 @@ class CScreencopyFrame {
 
     WP<CScreencopyFrame>  m_self;
     WP<CScreencopyClient> m_client;
+    PHLMONITORREF         m_monitor;
 
   private:
     SP<CZwlrScreencopyFrameV1> m_resource;
-
-    PHLMONITORREF              m_monitor;
     bool                       m_overlayCursor = false;
     bool                       m_withDamage    = false;
 
@@ -97,8 +97,9 @@ class CScreencopyProtocol : public IWaylandProtocol {
 
     void         onOutputCommit(PHLMONITOR pMonitor);
 
-  private:
     std::vector<SP<CScreencopyFrame>>  m_frames;
+
+  private:
     std::vector<WP<CScreencopyFrame>>  m_framesAwaitingWrite;
     std::vector<SP<CScreencopyClient>> m_clients;
 

--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -74,7 +74,7 @@ bool CToplevelExportClient::good() {
     return m_resource->resource();
 }
 
-CToplevelExportFrame::CToplevelExportFrame(SP<CHyprlandToplevelExportFrameV1> resource_, int32_t overlayCursor_, PHLWINDOW pWindow_) : m_resource(resource_), m_window(pWindow_) {
+CToplevelExportFrame::CToplevelExportFrame(SP<CHyprlandToplevelExportFrameV1> resource_, int32_t overlayCursor_, PHLWINDOW pWindow_) : m_window(pWindow_), m_resource(resource_) {
     if UNLIKELY (!good())
         return;
 
@@ -411,6 +411,10 @@ void CToplevelExportProtocol::destroyResource(CToplevelExportClient* client) {
 }
 
 void CToplevelExportProtocol::destroyResource(CToplevelExportFrame* frame) {
+    // Damage the window before destroying the frame so the border updates
+    if (frame && frame->m_window) {
+        g_pHyprRenderer->damageWindow(frame->m_window);
+    }
     std::erase_if(m_frames, [&](const auto& other) { return other.get() == frame; });
     std::erase_if(m_framesAwaitingWrite, [&](const auto& other) { return !other || other.get() == frame; });
 }

--- a/src/protocols/ToplevelExport.hpp
+++ b/src/protocols/ToplevelExport.hpp
@@ -22,12 +22,13 @@ class CToplevelExportClient {
     CTimer                    m_lastFrame;
     int                       m_frameCounter = 0;
 
+    bool                      m_sentScreencast = false;
+
   private:
     SP<CHyprlandToplevelExportManagerV1> m_resource;
 
     int                                  m_framesInLastHalfSecond = 0;
     CTimer                               m_lastMeasure;
-    bool                                 m_sentScreencast = false;
 
     SP<HOOK_CALLBACK_FN>                 m_tickCallback;
     void                                 onTick();
@@ -45,11 +46,10 @@ class CToplevelExportFrame {
 
     WP<CToplevelExportFrame>  m_self;
     WP<CToplevelExportClient> m_client;
+    PHLWINDOW                 m_window;
 
   private:
     SP<CHyprlandToplevelExportFrameV1> m_resource;
-
-    PHLWINDOW                          m_window;
     bool                               m_cursorOverlayRequested = false;
     bool                               m_ignoreDamage           = false;
 
@@ -79,9 +79,10 @@ class CToplevelExportProtocol : IWaylandProtocol {
 
     void onOutputCommit(PHLMONITOR pMonitor);
 
+    std::vector<SP<CToplevelExportFrame>> m_frames;
+
   private:
     std::vector<SP<CToplevelExportClient>> m_clients;
-    std::vector<SP<CToplevelExportFrame>>  m_frames;
     std::vector<WP<CToplevelExportFrame>>  m_framesAwaitingWrite;
 
     void                                   onWindowUnmap(PHLWINDOW pWindow);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Add options to enable and set a color around windows or monitors when they are screencasted.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I did not know how to name the options and/or which categories to put them in.

#### Is it ready for merging, or does it need work?

Options names and categories could be changed.

