### PR TITLE
Fix CXDGToplevelResource crash upon checking pinned flag

### DIFF
--- a/src/protocols/XDGShell.cpp
+++ b/src/protocols/XDGShell.cpp
@@ -257,11 +257,12 @@ CXDGToplevelResource::CXDGToplevelResource(SP<CXdgToplevel> resource_, SP<CXDGSu
 
         m_parent = newp;
 
-        if (m_parent)
+        if (m_parent) {
             m_parent->m_children.emplace_back(m_self);
 
-        if (m_parent->m_window->m_pinned)
-            m_self->m_window->m_pinned = true;
+            if (m_parent->m_window && m_parent->m_window->m_pinned)
+                m_self->m_window->m_pinned = true;
+        }
 
         LOGM(Log::DEBUG, "Toplevel {:x} sets parent to {:x}{}", (uintptr_t)this, (uintptr_t)newp.get(), (oldParent ? std::format(" (was {:x})", (uintptr_t)oldParent.get()) : ""));
     });


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes HL crash when FF starts and hits `m_parent->m_window->m_pinned` inside `CXDGToplevelResource`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No idea why `m_parent` or `m_parent->m_window` might be null at this point. `m_pinned` probably isn't handled as intended when this happens.

#### Is it ready for merging, or does it need work?
Ready
