### PR TITLE
hyprland.desktop: install with full bin path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -575,6 +575,11 @@ install(
         \"\$ENV{DESTDIR}${CMAKE_INSTALL_FULL_BINDIR}/hyprland\" \
         )")
 # session file
+configure_file(
+    ${CMAKE_SOURCE_DIR}/example/hyprland.desktop.in
+    ${CMAKE_SOURCE_DIR}/example/hyprland.desktop
+    @ONLY
+)
 install(FILES ${CMAKE_SOURCE_DIR}/example/hyprland.desktop
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/wayland-sessions)
 

--- a/example/hyprland.desktop.in
+++ b/example/hyprland.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Hyprland
 Comment=An intelligent dynamic tiling Wayland compositor
-Exec=start-hyprland
+Exec=@CMAKE_INSTALL_BINDIR@/start-hyprland
 Type=Application
 DesktopNames=Hyprland
 Keywords=tiling;wayland;compositor;

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -97,7 +97,7 @@ in
             ../systemd
             ../VERSION
             (fs.fileFilter (file: file.hasExt "1") ../docs)
-            (fs.fileFilter (file: file.hasExt "conf" || file.hasExt "desktop") ../example)
+            (fs.fileFilter (file: file.hasExt "conf" || file.hasExt "in") ../example)
             (fs.fileFilter (file: file.hasExt "sh") ../scripts)
             (fs.fileFilter (file: file.name == "CMakeLists.txt") ../.)
             (optional withTests [../tests ../hyprtester])


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

- **Nix: re-enable uwsm desktop file**
- **example/hyprland.desktop: install with full path in Exec**

Related:
- https://github.com/Vladimir-csp/uwsm/issues/186
- https://github.com/NixOS/nixpkgs/pull/471349

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Likely ready
