### PR TITLE
hyprerror: fix horizontal overflow and damage box

### DIFF
--- a/src/hyprerror/HyprError.cpp
+++ b/src/hyprerror/HyprError.cpp
@@ -202,9 +202,9 @@ void CHyprError::draw() {
         }
     }
 
-    const auto PMONITOR = g_pHyprOpenGL->m_renderData.pMonitor;
+    const auto  PMONITOR = g_pHyprOpenGL->m_renderData.pMonitor;
 
-    CBox       monbox = {0, 0, PMONITOR->m_pixelSize.x, PMONITOR->m_pixelSize.y};
+    CBox        monbox = {0, 0, PMONITOR->m_pixelSize.x, PMONITOR->m_pixelSize.y};
 
     static auto BAR_POSITION = CConfigValue<Hyprlang::INT>("debug:error_position");
     m_damageBox.x            = sc<int>(PMONITOR->m_position.x);


### PR DESCRIPTION
I would like to fix this horisontal overflow on right side of error box:
<img width="404" height="258" alt="image" src="https://github.com/user-attachments/assets/43986a23-ed95-47bf-8827-b51ae71aa4c9" />

This is my first PR and I'm not 100% sure I know what I'm doing, but according to my manual testing it fixes the issue by clamping the layout width and using ellipsization.

## Summary

- clamp the HyprError Pango layout to the drawable width
- enable end ellipsization so long lines don't overflow

## Testing

- manual: trigger HyprError with an overlong line and verify it shows ellipsis without overflowing


## Before
<img width="343" alt="screenshot-2025-12-25_16-48-34" src="https://github.com/user-attachments/assets/f6850e3c-ec9d-4e3e-9e85-25124a01959e" />
re

## After
<img width="335"  alt="screenshot-2025-12-25_17-08-32" src="https://github.com/user-attachments/assets/aed4c870-96d5-4607-9f7b-45bb8113b975" />



