### PR TITLE
Fix French quote in Splashes.hpp

### DIFF
--- a/src/helpers/Splashes.hpp
+++ b/src/helpers/Splashes.hpp
@@ -61,7 +61,7 @@ namespace NSplashes {
         "3 years!",
         "Beauty will save the world", // 4th ricing comp winner - zacoons' choice
         // music reference / quote section
-        "J'remue le ciel, le jour, la nuit.",
+        "Je remue le ciel, le jour, la nuit.", // I am assuming the song this is from is Indila - Dernière Danse, and the quote would be this 
         "aezakmi, aezakmi, aezakmi, aezakmi, aezakmi, aezakmi, aezakmi!",
         "Wir sind schon sehr lang zusammen...",
         "I see a red door and I want it painted black.",


### PR DESCRIPTION
Corrected the French quote in the splash text.

Fixed:
I fixed the French quote in src/helpers/Splashes.hpp, corrected “J'remue” to “Je remue…” since contraction is appropriate only before a vowel, matching the original French lyric from Indila – Dernière Danse. (Also I think Google Translate will correct you if you put the original in)

Just a string fix, ready for merging


