### PR TITLE
Allow force disabling WCG and HDR per monitor

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1973,11 +1973,22 @@ void CMonitor::onCursorMovedOnMonitor() {
 }
 
 bool CMonitor::supportsWideColor() {
-    return m_supportsWideColor || m_output->parsedEDID.supportsBT2020;
+    switch (m_supportsWideColor) {
+        case -1: return false;
+        case 1: return true;
+        default: return m_output->parsedEDID.supportsBT2020;
+    }
 }
 
 bool CMonitor::supportsHDR() {
-    return supportsWideColor() && (m_supportsHDR || (m_output->parsedEDID.hdrMetadata.has_value() ? m_output->parsedEDID.hdrMetadata->supportsPQ : false));
+    if (!supportsWideColor())
+        return false;
+
+    switch (m_supportsHDR) {
+        case -1: return false;
+        case 1: return true;
+        default: return m_output->parsedEDID.hdrMetadata.has_value() ? m_output->parsedEDID.hdrMetadata->supportsPQ : false;
+    }
 }
 
 float CMonitor::minLuminance(float defaultValue) {

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -55,10 +55,10 @@ struct SMonitorRule {
     float                  sdrBrightness = 1.0f; // SDR -> HDR
     Desktop::CReservedArea reservedArea;
 
-    bool                   supportsWideColor = false; // false does nothing, true overrides EDID
-    bool                   supportsHDR       = false; // false does nothing, true overrides EDID
-    float                  sdrMinLuminance   = 0.2f;  // SDR -> HDR
-    int                    sdrMaxLuminance   = 80;    // SDR -> HDR
+    int                    supportsWideColor = 0;    // 0 - auto, 1 - force enable, -1 - force disable
+    int                    supportsHDR       = 0;    // 0 - auto, 1 - force enable, -1 - force disable
+    float                  sdrMinLuminance   = 0.2f; // SDR -> HDR
+    int                    sdrMaxLuminance   = 80;   // SDR -> HDR
 
     // Incorrect values will result in reduced luminance range or incorrect tonemapping. Shouldn't damage the HW. Use with care in case of a faulty monitor firmware.
     float              minLuminance    = -1.0f; // >= 0 overrides EDID
@@ -368,8 +368,8 @@ class CMonitor {
         CHyprSignalListener commit;
     } m_listeners;
 
-    bool  m_supportsWideColor = false;
-    bool  m_supportsHDR       = false;
+    int   m_supportsWideColor = 0;
+    int   m_supportsHDR       = 0;
     float m_minLuminance      = -1.0f;
     int   m_maxLuminance      = -1;
     int   m_maxAvgLuminance   = -1;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Allow `monitorv2:supports_wide_color = -1` and `monitorv2:supports_hdr = -1` to force disable those features.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Needs some testing

#### Is it ready for merging, or does it need work?
Ready
