### PR TITLE
Fix CColorManagementSurface m_imageDescription init

### DIFF
--- a/src/protocols/ColorManagement.cpp
+++ b/src/protocols/ColorManagement.cpp
@@ -233,7 +233,8 @@ CColorManagementSurface::CColorManagementSurface(SP<CWpColorManagementSurfaceV1>
     if UNLIKELY (!good())
         return;
 
-    m_client = m_resource->client();
+    m_client           = m_resource->client();
+    m_imageDescription = DEFAULT_IMAGE_DESCRIPTION;
 
     m_resource->setDestroy([this](CWpColorManagementSurfaceV1* r) {
         LOGM(Log::TRACE, "Destroy wp cm surface {}", (uintptr_t)m_surface);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes a crash when `m_imageDescription` isn't initialised. It's expected to always have some value.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
https://discord.com/channels/961691461554950145/1070436481912549497/1454543097362120818

#### Is it ready for merging, or does it need work?
Ready
