### PR TITLE
input: guard null `view()` when processing mouse down

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -806,8 +806,10 @@ void CInputManager::processMouseDownNormal(const IPointer::SButtonEvent& e) {
 
             auto HLSurf = Desktop::View::CWLSurface::fromResource(g_pSeatManager->m_state.pointerFocus.lock());
 
-            if (HLSurf && HLSurf->view()->type() == Desktop::View::VIEW_TYPE_WINDOW)
-                g_pCompositor->changeWindowZOrder(dynamicPointerCast<Desktop::View::CWindow>(HLSurf->view()), true);
+            // pointerFocus can target a surface without a Desktop::View (e.g. IME popups), so view() may be null.
+            const auto PVIEW = HLSurf ? HLSurf->view() : nullptr;
+            if (PVIEW && PVIEW->type() == Desktop::View::VIEW_TYPE_WINDOW)
+                g_pCompositor->changeWindowZOrder(dynamicPointerCast<Desktop::View::CWindow>(PVIEW), true);
 
             break;
         }


### PR DESCRIPTION
Fixes #12771.

On mouse button press, Hyprland may have `pointerFocus` on a surface with no associated `Desktop::View`. In this case `HLSurf->view()` can be null, causing a SIGSEGV. This is reproducible by clicking an fcitx5 candidate.

This [hyprland-gdb.log](https://github.com/user-attachments/files/24389079/hyprland-gdb.log) shows the null deref at `InputManager.cpp:809`.

Built skrmc/Hyprland@a365dd854f0821157c78670bf6622b0c95d2a4cb and confirmed the crash no longer reproduces.