### PR TITLE
Fix bad practice in client tests

### DIFF
--- a/hyprtester/src/tests/clients/pointer-scroll.cpp
+++ b/hyprtester/src/tests/clients/pointer-scroll.cpp
@@ -42,6 +42,7 @@ static bool startClient(SClient& client) {
     client.readFd = CFileDescriptor(pipeFds2[0]);
     client.proc->setStdoutFD(pipeFds2[1]);
 
+    const int COUNT_BEFORE = Tests::windowCount();
     client.proc->runAsync();
 
     close(pipeFds1[0]);
@@ -62,7 +63,16 @@ static bool startClient(SClient& client) {
     }
 
     // wait for window to appear
-    std::this_thread::sleep_for(std::chrono::milliseconds(5000));
+    int counter = 0;
+    while (Tests::processAlive(client.proc->pid()) && Tests::windowCount() == COUNT_BEFORE) {
+        counter++;
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        if (counter > 50) {
+            NLog::log("{}pointer-scroll client took too long to open", Colors::RED);
+            return false;
+        }
+    }
 
     if (getFromSocket(std::format("/dispatch setprop pid:{} no_anim 1", client.proc->pid())) != "ok") {
         NLog::log("{}Failed to disable animations for client window", Colors::RED, ret);

--- a/hyprtester/src/tests/clients/pointer-warp.cpp
+++ b/hyprtester/src/tests/clients/pointer-warp.cpp
@@ -42,6 +42,7 @@ static bool startClient(SClient& client) {
     client.readFd = CFileDescriptor(pipeFds2[0]);
     client.proc->setStdoutFD(pipeFds2[1]);
 
+    const int COUNT_BEFORE = Tests::windowCount();
     client.proc->runAsync();
 
     close(pipeFds1[0]);
@@ -62,7 +63,16 @@ static bool startClient(SClient& client) {
     }
 
     // wait for window to appear
-    std::this_thread::sleep_for(std::chrono::milliseconds(5000));
+    int counter = 0;
+    while (Tests::processAlive(client.proc->pid()) && Tests::windowCount() == COUNT_BEFORE) {
+        counter++;
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        if (counter > 50) {
+            NLog::log("{}pointer-warp client took too long to open", Colors::RED);
+            return false;
+        }
+    }
 
     if (getFromSocket(std::format("/dispatch setprop pid:{} no_anim 1", client.proc->pid())) != "ok") {
         NLog::log("{}Failed to disable animations for client window", Colors::RED, ret);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Replace the sleep_for() calls in the pointer-scroll and pointer-warp tests with the same wait system in Tests::spawnKitty()

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Yes

