### PR TITLE
opengl: add a renderBlitFramebuffer fast path

### DIFF
--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -406,6 +406,7 @@ class CHyprOpenGLImpl {
     void          passCMUniforms(SShader&, const NColorManagement::PImageDescription imageDescription, const NColorManagement::PImageDescription targetImageDescription,
                                  bool modifySDR = false, float sdrMinLuminance = -1.0f, int sdrMaxLuminance = -1);
     void          passCMUniforms(SShader&, const NColorManagement::PImageDescription imageDescription);
+    void          renderBlitFrameBuffer(CFramebuffer& read, CFramebuffer& draw, const CBox& box);
     void          renderTexturePrimitive(SP<CTexture> tex, const CBox& box);
     void          renderSplash(cairo_t* const, cairo_surface_t* const, double offset, const Vector2D& size);
     void          renderRectInternal(const CBox&, const CHyprColor&, const SRectRenderData& data);


### PR DESCRIPTION
if we have no screenshader, no transforms we can use glBlitFramebuffer to blit offloadFB to the outFB. which is a much faster way to render the content.


