### PR TITLE
hyprctl: add layout-specific properties to clients output (#11043)

### DIFF
--- a/hyprtester/src/tests/main/hyprctl.cpp
+++ b/hyprtester/src/tests/main/hyprctl.cpp
@@ -163,6 +163,75 @@ static bool testGetprop() {
     return true;
 }
 
+static bool testLayoutData() {
+    NLog::log("{}Testing hyprctl clients layout data", Colors::GREEN);
+
+    if (!Tests::spawnKitty()) {
+        NLog::log("{}Error: kitty did not spawn", Colors::RED);
+        return false;
+    }
+
+    std::string clientsJson = getFromSocket("j/clients");
+    std::string clientsPlain = getFromSocket("/clients");
+
+    // Dwindle
+    // layout field
+    EXPECT_CONTAINS(clientsJson, R"("layout":)");
+
+    // layout name (dwindle by default)
+    EXPECT_CONTAINS(clientsJson, R"("name": "dwindle")");
+
+    // dwindle-specific fields
+    EXPECT_CONTAINS(clientsJson, R"("dwindle":)");
+    EXPECT_CONTAINS(clientsJson, R"("splitRatio":)");
+    EXPECT_CONTAINS(clientsJson, R"("splitDirection":)");
+
+    EXPECT_CONTAINS(clientsPlain, "layout: dwindle");
+    EXPECT_CONTAINS(clientsPlain, "dwindle:splitRatio:");
+    EXPECT_CONTAINS(clientsPlain, "dwindle:splitDirection:");
+
+    // Floating
+    getFromSocket("/dispatch togglefloating");
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // floating window should have empty layout object
+    clientsJson = getFromSocket("j/clients");
+    EXPECT_CONTAINS(clientsJson, R"("layout": {})");
+    clientsPlain = getFromSocket("/clients");
+    EXPECT_CONTAINS(clientsPlain, "layout: ");
+
+    // Master
+    getFromSocket("/keyword general:layout master");
+    getFromSocket("/dispatch togglefloating"); // untile it back
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    clientsJson = getFromSocket("j/clients");
+    EXPECT_CONTAINS(clientsJson, R"("name": "Master")");
+    EXPECT_CONTAINS(clientsJson, R"("master":)");
+    EXPECT_CONTAINS(clientsJson, R"("isMaster":)");
+    EXPECT_CONTAINS(clientsJson, R"("percMaster":)");
+    EXPECT_CONTAINS(clientsJson, R"("percSize":)");
+    EXPECT_CONTAINS(clientsJson, R"("orientation":)");
+
+    clientsPlain = getFromSocket("/clients");
+    EXPECT_CONTAINS(clientsPlain, "layout: Master");
+    EXPECT_CONTAINS(clientsPlain, "master:isMaster:");
+    EXPECT_CONTAINS(clientsPlain, "master:percMaster:");
+    EXPECT_CONTAINS(clientsPlain, "master:percSize:");
+    EXPECT_CONTAINS(clientsPlain, "master:orientation:");
+
+    getFromSocket("/keyword general:layout dwindle");
+
+    // kill all
+    NLog::log("{}Killing all windows", Colors::YELLOW);
+    Tests::killAllWindows();
+
+    NLog::log("{}Expecting 0 windows", Colors::YELLOW);
+    EXPECT(Tests::windowCount(), 0);
+
+    return true;
+}
+
 static bool test() {
     NLog::log("{}Testing hyprctl", Colors::GREEN);
 
@@ -176,6 +245,7 @@ static bool test() {
 
     testGetprop();
     testDevicesActiveLayoutIndex();
+    testLayoutData();
     getFromSocket("/reload");
 
     return !ret;

--- a/src/layout/DwindleLayout.cpp
+++ b/src/layout/DwindleLayout.cpp
@@ -1188,3 +1188,14 @@ Vector2D CHyprDwindleLayout::predictSizeForNewWindowTiled() {
 
     return {};
 }
+
+std::optional<CHyprDwindleLayout::SLayoutData> CHyprDwindleLayout::getLayoutData(PHLWINDOW pWindow) {
+    auto pNode = getNodeFromWindow(pWindow);
+    if (!pNode)
+        return std::nullopt;
+
+    return SLayoutData{
+        .splitRatio = pNode->splitRatio,
+        .splitTop   = pNode->splitTop,
+    };
+}

--- a/src/layout/DwindleLayout.hpp
+++ b/src/layout/DwindleLayout.hpp
@@ -66,6 +66,12 @@ class CHyprDwindleLayout : public IHyprLayout {
     virtual void                     onEnable();
     virtual void                     onDisable();
 
+    struct SLayoutData {
+        float splitRatio;
+        bool  splitTop;
+    };
+    std::optional<SLayoutData> getLayoutData(PHLWINDOW);
+
   private:
     std::vector<SP<SDwindleNodeData>> m_dwindleNodesData;
 

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -1524,3 +1524,19 @@ void CHyprMasterLayout::onEnable() {
 void CHyprMasterLayout::onDisable() {
     m_masterNodesData.clear();
 }
+
+std::optional<CHyprMasterLayout::SLayoutData> CHyprMasterLayout::getLayoutData(PHLWINDOW pWindow) {
+    auto* pNode = getNodeFromWindow(pWindow);
+    if (!pNode)
+        return std::nullopt;
+
+    auto*        pWorkspaceData = getMasterWorkspaceData(pWindow->workspaceID());
+    eOrientation orientation    = pWorkspaceData ? pWorkspaceData->orientation : ORIENTATION_LEFT;
+
+    return SLayoutData{
+        .isMaster    = pNode->isMaster,
+        .percMaster  = pNode->percMaster,
+        .percSize    = pNode->percSize,
+        .orientation = orientation,
+    };
+}

--- a/src/layout/MasterLayout.hpp
+++ b/src/layout/MasterLayout.hpp
@@ -72,6 +72,14 @@ class CHyprMasterLayout : public IHyprLayout {
     virtual void                     onEnable();
     virtual void                     onDisable();
 
+    struct SLayoutData {
+        bool         isMaster;
+        float        percMaster;
+        float        percSize;
+        eOrientation orientation;
+    };
+    std::optional<SLayoutData> getLayoutData(PHLWINDOW);
+
   private:
     std::list<SMasterNodeData>        m_masterNodesData;
     std::vector<SMasterWorkspaceData> m_masterWorkspacesData;


### PR DESCRIPTION
### Describe your PR, what does it fix/add?

Adds layout-specific window properties to `hyprctl clients` command for scripting purposes.

Users can now query:
- **Dwindle layout**: `splitRatio`, `splitDirection`
- **Master layout**: `isMaster`, `percMaster`, `percSize`, `orientation`
- **Floating windows**: Empty layout object `{}`

Both JSON (`-j`) and plain text formats are supported.

**Example JSON output:**
```json
{
  "layout": {
    "name": "dwindle",
    "dwindle": {
      "splitRatio": 1,
      "splitDirection": "horizontal"
    }
  }
}
```

**Example plain text output:**
```
layout: dwindle
dwindle:splitRatio: 1
dwindle:splitDirection: horizontal
```

Fixes #11043
See also: https://github.com/hyprwm/Hyprland/discussions/11010

### Is there anything you want to mention?

- Added a hyprtester test (`testLayoutData`) covering dwindle, master, and floating window cases
- Implementation uses a public API via new `getLayoutData()` methods on layout classes
- Design is easily extensible: each layout defines its own `SLayoutData` struct, so more properties could potentially be added in the future without breaking existing code

### Is it ready for merging, or does it need work?

Ready for merging. Code is formatted with clang-format, tests pass, and manual testing confirmed functionality works as expected.