### PR TITLE
Add missing #include <unistd.h>

### DIFF
--- a/hyprtester/clients/child-window.cpp
+++ b/hyprtester/clients/child-window.cpp
@@ -3,6 +3,7 @@
 #include <sys/mman.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <unistd.h>
 
 #include <wayland-client.h>
 #include <wayland.hpp>

--- a/hyprtester/clients/pointer-scroll.cpp
+++ b/hyprtester/clients/pointer-scroll.cpp
@@ -2,6 +2,7 @@
 #include <sys/poll.h>
 #include <sys/mman.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include <print>
 #include <format>
 #include <string>

--- a/hyprtester/clients/pointer-warp.cpp
+++ b/hyprtester/clients/pointer-warp.cpp
@@ -2,6 +2,7 @@
 #include <sys/poll.h>
 #include <sys/mman.h>
 #include <fcntl.h>
+#include <unistd.h>
 #include <print>
 #include <format>
 #include <string>

--- a/hyprtester/src/tests/clients/child-window.cpp
+++ b/hyprtester/src/tests/clients/child-window.cpp
@@ -8,6 +8,7 @@
 #include <hyprutils/os/Process.hpp>
 
 #include <sys/poll.h>
+#include <unistd.h>
 #include <csignal>
 #include <thread>
 

--- a/hyprtester/src/tests/clients/pointer-scroll.cpp
+++ b/hyprtester/src/tests/clients/pointer-scroll.cpp
@@ -8,6 +8,7 @@
 #include <hyprutils/os/Process.hpp>
 
 #include <sys/poll.h>
+#include <unistd.h>
 #include <csignal>
 #include <thread>
 

--- a/hyprtester/src/tests/clients/pointer-warp.cpp
+++ b/hyprtester/src/tests/clients/pointer-warp.cpp
@@ -8,6 +8,7 @@
 #include <hyprutils/os/Process.hpp>
 
 #include <sys/poll.h>
+#include <unistd.h>
 #include <csignal>
 #include <thread>
 

--- a/hyprtester/src/tests/main/window.cpp
+++ b/hyprtester/src/tests/main/window.cpp
@@ -1,3 +1,4 @@
+#include <unistd.h>
 #include <cmath>
 #include <chrono>
 #include <cstdlib>


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

#### Describe your PR, what does it fix/add?

This PR adds missing `#include <unistd.h>` to some hyprtester sources. Without it, FreeBSD clang fails to compile the codes. The header is required for `read()`, `write()`, `pipe()`, `close()`, etc.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Yes.