### PR TITLE
Add parent-death handling for BSDs

### DIFF
--- a/start/src/core/Instance.cpp
+++ b/start/src/core/Instance.cpp
@@ -52,16 +52,6 @@ void CHyprlandInstance::runHyprlandThread(bool safeMode) {
 #elif defined(__FreeBSD__)
         int sig = SIGKILL;
         procctl(P_PID, getpid(), PROC_PDEATHSIG_CTL, &sig);
-#elif defined(__OpenBSD__) || defined(__NetBSD__) || defined(__DragonFly__)
-        pid_t ppid = getppid();
-        if (fork() == 0) {
-            for (;;) {
-                if (getppid() != ppid)
-                    kill(getpid(), SIGKILL);
-                sleep(1);
-            }
-            _exit(1);
-        }
 #endif
 
         execvp(g_state->customPath.value_or("Hyprland").c_str(), args.data());


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

#### Describe your PR, what does it fix/add?

This PR adds a parent-death handling mechanism similar to Linux one for BSDs.

`prctl()` is a system call specific to Linux. So we cannot use it on BSDs.

FreeBSD has a system call `procctl()` which is similar to `prctl()`. We can use it with `PROC_PDEATHSIG_CTL`.

OpenBSD, NetBSD, and DragonFly BSD do not appear to have a similar mechanism. So intead of relying on a system call, we need to manually poll ppid to see if the parent process has died.

With the changes, the spawned Hyprland process is terminated when the launcher process exits, matching Linux behavior as closely as possible on BSD platforms.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Yes. I hope so :-)