### PR TITLE
master: improved predicted window size

### DIFF
--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -1491,9 +1491,9 @@ Vector2D CHyprMasterLayout::predictSizeForNewWindowTiled() {
     if (!Desktop::focusState()->monitor())
         return {};
 
-    const auto WORKSPACE   = Desktop::focusState()->monitor()->m_activeWorkspace;
-    const auto WORKAREA    = workAreaOnWorkspace(WORKSPACE);
-    const int NODES = getNodesOnWorkspace(WORKSPACE->m_id);
+    const auto WORKSPACE = Desktop::focusState()->monitor()->m_activeWorkspace;
+    const auto WORKAREA  = workAreaOnWorkspace(WORKSPACE);
+    const int  NODES     = getNodesOnWorkspace(WORKSPACE->m_id);
 
     if (NODES <= 0)
         return WORKAREA.size();
@@ -1506,8 +1506,7 @@ Vector2D CHyprMasterLayout::predictSizeForNewWindowTiled() {
         return MASTER->size;
     } else {
         const auto SLAVES = NODES - getMastersOnWorkspace(WORKSPACE->m_id);
-
-        double width = WORKAREA.size().x;
+        double     width  = WORKAREA.size().x;
         if (SLAVES > 0)
             width -= MASTER->size.x;
         else

--- a/src/layout/MasterLayout.cpp
+++ b/src/layout/MasterLayout.cpp
@@ -1491,22 +1491,31 @@ Vector2D CHyprMasterLayout::predictSizeForNewWindowTiled() {
     if (!Desktop::focusState()->monitor())
         return {};
 
-    const int NODES = getNodesOnWorkspace(Desktop::focusState()->monitor()->m_activeWorkspace->m_id);
+    const auto WORKSPACE   = Desktop::focusState()->monitor()->m_activeWorkspace;
+    const auto WORKAREA    = workAreaOnWorkspace(WORKSPACE);
+    const int NODES = getNodesOnWorkspace(WORKSPACE->m_id);
 
     if (NODES <= 0)
-        return Desktop::focusState()->monitor()->m_size;
+        return WORKAREA.size();
 
-    const auto MASTER = getMasterNodeOnWorkspace(Desktop::focusState()->monitor()->m_activeWorkspace->m_id);
+    const auto MASTER = getMasterNodeOnWorkspace(WORKSPACE->m_id);
     if (!MASTER) // wtf
         return {};
 
     if (*PNEWSTATUS == "master") {
         return MASTER->size;
     } else {
-        const auto SLAVES = NODES - getMastersOnWorkspace(Desktop::focusState()->monitor()->m_activeWorkspace->m_id);
+        const auto SLAVES = NODES - getMastersOnWorkspace(WORKSPACE->m_id);
 
-        // TODO: make this better
-        return {Desktop::focusState()->monitor()->m_size.x - MASTER->size.x, Desktop::focusState()->monitor()->m_size.y / (SLAVES + 1)};
+        double width = WORKAREA.size().x;
+        if (SLAVES > 0)
+            width -= MASTER->size.x;
+        else
+            width -= (MASTER->size.x * MASTER->percMaster);
+
+        const double HEIGHT = WORKAREA.size().y / (SLAVES + 1);
+
+        return {width, HEIGHT};
     }
 
     return {};


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Improves the size prediction when spawning new windows in the master layout.

Somehow, #12383 introduced this bug where the 1st slave window is only 10px wide when it spawns and therefore only 10px wide when floating (see video below). I think it's because before #12383, the width of the master window was actually the whole monitor width, which would send a predicted width of `0` to the client, which the client would take as a hint to compute its own size. But now, for the 1st slave window, the master size is actually the `monitor size` minus `reserved + gaps`, so we send `reserved + gaps` width to the client.

This PR improves the computation, taking into account that when the 1st slave window spawns, the master is taking the whole work area. And also use the work area size instead of the monitor size, which should fix #12398.

Before this PR:

https://github.com/user-attachments/assets/da0bc0a1-e3d2-4e82-a635-478bdda12dc1

After this PR:


https://github.com/user-attachments/assets/e575e423-6f04-4c95-a1e1-c43ec83f397b



#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

n/a

#### Is it ready for merging, or does it need work?

Ready for merging

