### PR TITLE
nix: add hyprland-uwsm to passthru.providedSessions

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -230,7 +230,7 @@ in
         ''}
       '';
 
-      passthru.providedSessions = ["hyprland"];
+      passthru.providedSessions = ["hyprland"] ++ optionals withSystemd ["hyprland-uwsm"];
 
       meta = {
         homepage = "https://github.com/hyprwm/Hyprland";


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

#### Describe your PR, what does it fix/add?
Fix issue with displayManager `defaultSession` not accepting the stringsince it's missing from the lookup it does
with`passthru.providedSessions`.

Copy of https://github.com/NixOS/nixpkgs/pull/478472

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?

Ready

CC @fufexan 
