### PR TITLE
monitor: improve DS enter/exit

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1804,8 +1804,20 @@ uint16_t CMonitor::isDSBlocked(bool full) {
 
 bool CMonitor::attemptDirectScanout() {
     const auto blockedReason = isDSBlocked();
-    if (blockedReason)
+
+    // wait 30 frames without a blocker before enabling DS
+    if (blockedReason) {
+        if (!m_lastScanout.expired())
+            m_lastScanout.reset();
+
+        m_scanoutDebounceCounter = 0;
         return false;
+    }
+
+    if (m_scanoutDebounceCounter < 30) {
+        m_scanoutDebounceCounter++;
+        return false;
+    }
 
     const auto PCANDIDATE = m_solitaryClient.lock();
     const auto PSURFACE   = PCANDIDATE->getSolitaryResource();

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -178,6 +178,7 @@ class CMonitor {
     // for direct scanout
     PHLWINDOWREF m_lastScanout;
     bool         m_scanoutNeedsCursorUpdate = false;
+    int          m_scanoutDebounceCounter   = 0;
 
     // for special fade/blur
     PHLANIMVAR<float> m_specialFade;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
Makes DS enter/exit a bit more robust

- 30-frame debounce timer for entering DS
  - Should help cases like screenshots capturing a black buffer from race condition
- Reset scanout buffer when DS is blocked
  - Prevents cases where DS seems to be activated preemptively, causing signal dropout
  - My simplest test case was `xeyes`. Without this change, fullscreening _and_ un-fullscreening it with `render:direct_scanout = 1` dropped the signal on my monitor, taking a few seconds to recover
  - Also helps with running Steam through `gamescope -e -- steam -bigpicture`, in which case opening the overlay/sidebar dropped signal. It was annoying on a monitor, but on my TV, it would simply not recover without a manual modeset

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Not sure how correct/excessive the condition for calling `m_lastScanout.reset()` is, but it does fix this issue for me.

#### Is it ready for merging, or does it need work?

Ready for testing. (I anticipate needing to make changes for correctness though.)
