### PR TITLE
Fix DMA-BUF checks and events

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -2017,5 +2017,11 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .type        = CONFIG_OPTION_INT,
         .data        = SConfigOptionDescription::SRangeData{.value = 0, .min = 0, .max = 2},
     },
+    SConfigOptionDescription{
+        .value       = "quirks:skip_non_kms_dmabuf_formats",
+        .description = "Do not report dmabuf formats which cannot be imported into KMS",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{true},
+    },
 
 };

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -785,6 +785,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("ecosystem:enforce_permissions", Hyprlang::INT{0});
 
     registerConfigVar("quirks:prefer_hdr", Hyprlang::INT{0});
+    registerConfigVar("quirks:skip_non_kms_dmabuf_formats", Hyprlang::INT{0});
 
     // devices
     m_config->addSpecialCategory("device", {"name"});

--- a/src/protocols/LinuxDMABUF.cpp
+++ b/src/protocols/LinuxDMABUF.cpp
@@ -23,21 +23,6 @@ static std::optional<dev_t> devIDFromFD(int fd) {
     return stat.st_rdev;
 }
 
-// from AQ utils
-static std::string fourccToName(uint32_t drmFormat) {
-    auto        fmt  = drmGetFormatName(drmFormat);
-    std::string name = fmt ? fmt : "unknown";
-    free(fmt); // NOLINT(cppcoreguidelines-no-malloc,-warnings-as-errors)
-    return name;
-}
-
-static std::string drmModifierToName(uint64_t drmModifier) {
-    auto        n    = drmGetFormatModifierName(drmModifier);
-    std::string name = n;
-    free(n); // NOLINT(cppcoreguidelines-no-malloc,-warnings-as-errors)
-    return name;
-}
-
 CDMABUFFormatTable::CDMABUFFormatTable(SDMABUFTranche _rendererTranche, std::vector<std::pair<PHLMONITORREF, SDMABUFTranche>> tranches_) :
     m_rendererTranche(_rendererTranche), m_monitorTranches(tranches_) {
 
@@ -52,7 +37,7 @@ CDMABUFFormatTable::CDMABUFFormatTable(SDMABUFTranche _rendererTranche, std::vec
     m_rendererTranche.indices.clear();
     for (auto const& fmt : m_rendererTranche.formats) {
         for (auto const& mod : fmt.modifiers) {
-            LOGM(Log::TRACE, "Render format 0x{:x} ({}) with mod 0x{:x} ({})", fmt.drmFormat, fourccToName(fmt.drmFormat), mod, drmModifierToName(mod));
+            LOGM(Log::TRACE, "Render format 0x{:x} ({}) with mod 0x{:x} ({})", fmt.drmFormat, NFormatUtils::drmFormatName(fmt.drmFormat), mod, NFormatUtils::drmModifierName(mod));
             if (*PSKIP_NON_KMS && !m_monitorTranches.empty()) {
                 if (std::ranges::none_of(m_monitorTranches, [fmt, mod](const std::pair<PHLMONITORREF, SDMABUFTranche>& pair) {
                         return std::ranges::any_of(pair.second.formats, [fmt, mod](const SDRMFormat& format) {
@@ -84,7 +69,8 @@ CDMABUFFormatTable::CDMABUFFormatTable(SDMABUFTranche _rendererTranche, std::vec
         tranche.indices.clear();
         for (auto const& fmt : tranche.formats) {
             for (auto const& mod : fmt.modifiers) {
-                LOGM(Log::TRACE, "[DMA] Monitor format 0x{:x} ({}) with mod 0x{:x} ({})", fmt.drmFormat, fourccToName(fmt.drmFormat), mod, drmModifierToName(mod));
+                LOGM(Log::TRACE, "[DMA] Monitor format 0x{:x} ({}) with mod 0x{:x} ({})", fmt.drmFormat, NFormatUtils::drmFormatName(fmt.drmFormat), mod,
+                     NFormatUtils::drmModifierName(mod));
                 // FIXME: recheck this. DRM_FORMAT_MOD_INVALID is allowed by the proto "For legacy support". DRM_FORMAT_MOD_LINEAR should be the most compatible mod
                 // apparently these can implode on planes, so don't use them
                 if (mod == DRM_FORMAT_MOD_INVALID || mod == DRM_FORMAT_MOD_LINEAR)

--- a/src/protocols/LinuxDMABUF.cpp
+++ b/src/protocols/LinuxDMABUF.cpp
@@ -497,6 +497,15 @@ CLinuxDMABufV1Protocol::CLinuxDMABufV1Protocol(const wl_interface* iface, const 
                 std::erase_if(m_formatTable->m_monitorTranches, [pMonitor](std::pair<PHLMONITORREF, SDMABUFTranche> pair) { return pair.first == pMonitor; });
                 resetFormatTable();
             });
+
+            static auto configReloaded = g_pHookSystem->hookDynamic("configReloaded", [this](void* self, SCallbackInfo& info, std::any param) {
+                static const auto PSKIP_NON_KMS = CConfigValue<Hyprlang::INT>("quirks:skip_non_kms_dmabuf_formats");
+                static auto       prev          = *PSKIP_NON_KMS;
+                if (prev != *PSKIP_NON_KMS) {
+                    prev = *PSKIP_NON_KMS;
+                    resetFormatTable();
+                }
+            });
         }
 
         m_formatTable = makeUnique<CDMABUFFormatTable>(eglTranche, tches);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Correctly sends format and modifier events on bind.
Adds two v4 and v5 sanity checks https://wayland.app/protocols/linux-dmabuf-v1#zwp_linux_buffer_params_v1:request:add
Adds `quirks:skip_non_kms_dmabuf_formats` to not report format+modifier pairs which aren't importable to KMS. Fixes wine-wayland DS activation on my nvidia setup. Fixes mpv freeze with DS. Requires restart or triggering `resetFormatTable`. #12714

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
`quirks:skip_non_kms_dmabuf_formats` probably has no effect on mesa because `eglQueryDmaBufFormatsEXT` and `getModsForFormat` return the same set as `Aquamarine::CDRMBackend::getRenderFormats`. For me egl returns extra mods with compression and those aren't importable into KMS.
Format table order matters. Some clients seem to choose first/last format or modifier without actually checking whether it's suitable.
Clients that actually check the format table and support feedbacks should work without `quirks:skip_non_kms_dmabuf_formats`.

#### Is it ready for merging, or does it need work?
Ready
