### PR TITLE
Fix unwanted reswallow

### DIFF
--- a/hyprtester/src/shared.hpp
+++ b/hyprtester/src/shared.hpp
@@ -155,7 +155,7 @@ class CTestCase {
                   std::string{haystack});                                                                                                                                          \
         MARK_TEST_FAILED_SILENT();                                                                                                                                                 \
     } else {                                                                                                                                                                       \
-        LOG_OK("{} contains {}.", #haystack, ASSERTED);                                                                                                                            \
+        LOG_OK("{} contains {}.", #haystack, #needle);                                                                                                                            \
     }
 
 #define EXPECT_NOT_CONTAINS(haystack, needle)                                                                                                                                      \

--- a/hyprtester/src/shared.hpp
+++ b/hyprtester/src/shared.hpp
@@ -155,7 +155,7 @@ class CTestCase {
                   std::string{haystack});                                                                                                                                          \
         MARK_TEST_FAILED_SILENT();                                                                                                                                                 \
     } else {                                                                                                                                                                       \
-        LOG_OK("{} contains {}.", #haystack, #needle);                                                                                                                            \
+        LOG_OK("{} contains {}.", #haystack, #needle);                                                                                                                             \
     }
 
 #define EXPECT_NOT_CONTAINS(haystack, needle)                                                                                                                                      \

--- a/hyprtester/src/shared.hpp
+++ b/hyprtester/src/shared.hpp
@@ -160,7 +160,7 @@ class CTestCase {
                   std::string{haystack});                                                                                                                                          \
         MARK_TEST_FAILED_SILENT();                                                                                                                                                 \
     } else {                                                                                                                                                                       \
-        LOG_OK("{} contains {}.", #haystack, #needle);                                                                                                                            \
+        LOG_OK("{} contains {}.", #haystack, #needle);                                                                                                                             \
     }
 
 #define EXPECT_NOT_CONTAINS(haystack, needle)                                                                                                                                      \

--- a/hyprtester/src/shared.hpp
+++ b/hyprtester/src/shared.hpp
@@ -160,7 +160,7 @@ class CTestCase {
                   std::string{haystack});                                                                                                                                          \
         MARK_TEST_FAILED_SILENT();                                                                                                                                                 \
     } else {                                                                                                                                                                       \
-        LOG_OK("{} contains {}.", #haystack, ASSERTED);                                                                                                                            \
+        LOG_OK("{} contains {}.", #haystack, #needle);                                                                                                                            \
     }
 
 #define EXPECT_NOT_CONTAINS(haystack, needle)                                                                                                                                      \

--- a/hyprtester/src/tests/main/swallow.cpp
+++ b/hyprtester/src/tests/main/swallow.cpp
@@ -1,0 +1,150 @@
+#include <thread>
+#include "tests.hpp"
+#include "../../shared.hpp"
+#include "../../hyprctlCompat.hpp"
+#include "../shared.hpp"
+
+using namespace Hyprutils::OS;
+using namespace Hyprutils::Memory;
+
+static void awaitKittyPrompt(const std::string& name) {
+    // wait until we see the shell prompt, meaning it's ready for test inputs
+    for (int i = 0; i < 10; i++) {
+        std::string output = Tests::execAndGet(std::format("kitten @ --to unix:/tmp/kitty_{}.sock get-text --extent all", name));
+        if (output.rfind('$') == std::string::npos) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+            continue;
+        }
+        return;
+    }
+    NLog::log("{}Error: timed out waiting for kitty prompt", Colors::RED);
+}
+
+static CUniquePointer<CProcess> spawnRemoteControlKitty(const std::string& name) {
+    auto kittyProc =
+        Tests::spawnKitty("kitty_swallowee", {"-o", "allow_remote_control=yes", "--listen-on", std::format("unix:/tmp/kitty_{}.sock", name), "--config", "NONE", "/bin/sh"});
+    // wait a bit to ensure shell prompt is sent, we are going to read the text after it
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    if (kittyProc)
+        awaitKittyPrompt(name);
+    return kittyProc;
+}
+
+static bool spawnSwallower(const std::string& parent, const std::string& name) {
+    auto cmd    = std::format("kitten @ --to unix:/tmp/kitty_{}.sock launch --type=background "
+                              "kitty -o allow_remote_control=yes --class kitty_{} --listen-on unix:/tmp/kitty_{}.sock --config NONE /bin/sh",
+                              parent, name, name);
+    auto result = Tests::execAndGet(cmd);
+    if (result == "error")
+        return false;
+
+    // wait a bit to ensure shell prompt is sent, we are going to read the text after it
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    awaitKittyPrompt(name);
+    return true;
+}
+
+static bool spawnKittyOsWindow(const std::string& parent) {
+    auto cmd    = std::format("kitten @ --to unix:/tmp/kitty_{}.sock launch --type=os-window", parent);
+    auto result = Tests::execAndGet(cmd);
+
+    if (result == "error")
+        return false;
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    return true;
+}
+
+static int swallowingCount() {
+    int notSwallowing = Tests::countOccurrences(getFromSocket("/clients"), "swallowing: 0\n");
+    return Tests::windowCount() - notSwallowing;
+}
+
+static std::string getActiveWindowID() {
+    std::string            activeWindow = getFromSocket("/activewindow");
+    std::string::size_type start        = 7; // Length of "Window "
+    std::string::size_type end          = activeWindow.find(" ->");
+    if (end == std::string::npos) {
+        return "error";
+    }
+    return activeWindow.substr(start, end - start);
+}
+
+TEST_CASE(swallow) {
+    NLog::log("{}Testing window swallowing", Colors::GREEN);
+
+    // test on workspace "swallow"
+    NLog::log("{}Switching to workspace `swallow`", Colors::YELLOW);
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'name:swallow' })"));
+
+    ASSERT(Tests::windowCount(), 0);
+
+    OK(getFromSocket("/eval hl.config({ misc = { enable_swallow = true } })"));
+    OK(getFromSocket("/eval hl.config({ misc = { swallow_regex = '^(kitty_swallowee)$' } })"));
+
+    // Initial kitty window that will be swallowed
+    spawnRemoteControlKitty("swallowee");
+
+    ASSERT(Tests::windowCount(), 1);
+    ASSERT(swallowingCount(), 0);
+
+    // Get the window ID
+    std::string swalloweeID = getActiveWindowID();
+    if (swalloweeID == "error") {
+        FAIL_TEST("Could not get window ID");
+    }
+    NLog::log("{}Got swalloweeID: {}", Colors::YELLOW, swalloweeID);
+
+    // Spawn a child process that should swallow the initial kitty window
+    ASSERT(spawnSwallower("swallowee", "swallower"), true);
+
+    {
+        // Verify that the initial window is swallowed
+        std::string clients = getFromSocket("/clients");
+        ASSERT_COUNT_STRING(clients, "swallowing: 0\n", 1);
+        ASSERT_COUNT_STRING(clients, std::format("swallowing: {}\n", swalloweeID), 1);
+
+        std::string workspaces = getFromSocket("/workspaces");
+        ASSERT_CONTAINS(workspaces, "windows: 1\n");
+    }
+
+    // Un-swallow the intial window
+    OK(getFromSocket("/dispatch hl.dsp.window.toggle_swallow()"));
+
+    {
+        // Verify that the initial window is un-swallowed
+        std::string clients = getFromSocket("/clients");
+        ASSERT_COUNT_STRING(clients, "swallowing: 0\n", 1);
+        ASSERT_COUNT_STRING(clients, std::format("swallowing: {}\n", swalloweeID), 1);
+
+        std::string workspaces = getFromSocket("/workspaces");
+        ASSERT_CONTAINS(workspaces, "windows: 2\n");
+    }
+
+    // Open new window of the swallower kitty
+    ASSERT(spawnKittyOsWindow("swallower"), true);
+
+    {
+        // Verify that the initial has NOT been re-swallowed
+        std::string clients = getFromSocket("/clients");
+        ASSERT_COUNT_STRING(clients, "swallowing: 0\n", 2);
+        ASSERT_COUNT_STRING(clients, std::format("swallowing: {}\n", swalloweeID), 1);
+
+        std::string workspaces = getFromSocket("/workspaces");
+        ASSERT_CONTAINS(workspaces, "windows: 3\n");
+    }
+
+    // Re-swallow the intial window
+    OK(getFromSocket("/dispatch hl.dsp.focus({ last = true })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.toggle_swallow()"));
+
+    {
+        // Verify that the initial has been re-swallowed
+        std::string clients = getFromSocket("/clients");
+        ASSERT_COUNT_STRING(clients, "swallowing: 0\n", 2);
+        ASSERT_COUNT_STRING(clients, std::format("swallowing: {}\n", swalloweeID), 1);
+
+        std::string workspaces = getFromSocket("/workspaces");
+        ASSERT_CONTAINS(workspaces, "windows: 2\n");
+    }
+}

--- a/src/config/lua/objects/LuaWindow.cpp
+++ b/src/config/lua/objects/LuaWindow.cpp
@@ -137,9 +137,9 @@ static int windowIndex(lua_State* L) {
             lua_rawseti(L, -2, i++);
         }
     } else if (key == "swallowing") {
-        const auto swallowed = w->m_swallowed.lock();
-        if (swallowed)
-            Objects::CLuaWindow::push(L, swallowed);
+        const auto swallowee = w->m_swallowee.lock();
+        if (swallowee)
+            Objects::CLuaWindow::push(L, swallowee);
         else
             lua_pushnil(L);
     } else if (key == "focus_history_id")

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -1155,17 +1155,17 @@ ActionResult Actions::forceRendererReload() {
 ActionResult Actions::toggleSwallow() {
     PHLWINDOWREF pWindow = Desktop::focusState()->window();
 
-    if (!valid(pWindow) || !valid(pWindow->m_swallowed))
+    if (!valid(pWindow) || !valid(pWindow->m_swallowee))
         return {};
 
-    if (pWindow->m_swallowed->m_currentlySwallowed) {
-        pWindow->m_swallowed->m_currentlySwallowed = false;
-        pWindow->m_swallowed->setHidden(false);
-        g_layoutManager->newTarget(pWindow->m_swallowed->layoutTarget(), pWindow->m_workspace->m_space);
+    if (pWindow->m_swallowee->m_currentlySwallowed) {
+        pWindow->m_swallowee->m_currentlySwallowed = false;
+        pWindow->m_swallowee->setHidden(false);
+        g_layoutManager->newTarget(pWindow->m_swallowee->layoutTarget(), pWindow->m_workspace->m_space);
     } else {
-        pWindow->m_swallowed->m_currentlySwallowed = true;
-        pWindow->m_swallowed->setHidden(true);
-        g_layoutManager->removeTarget(pWindow->m_swallowed->layoutTarget());
+        pWindow->m_swallowee->m_currentlySwallowed = true;
+        pWindow->m_swallowee->setHidden(true);
+        g_layoutManager->removeTarget(pWindow->m_swallowee->layoutTarget());
     }
 
     return {};

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -1179,17 +1179,17 @@ ActionResult Actions::forceRendererReload() {
 ActionResult Actions::toggleSwallow() {
     PHLWINDOWREF pWindow = Desktop::focusState()->window();
 
-    if (!valid(pWindow) || !valid(pWindow->m_swallowed))
+    if (!valid(pWindow) || !valid(pWindow->m_swallowee))
         return {};
 
-    if (pWindow->m_swallowed->m_currentlySwallowed) {
-        pWindow->m_swallowed->m_currentlySwallowed = false;
-        pWindow->m_swallowed->setHidden(false);
-        g_layoutManager->newTarget(pWindow->m_swallowed->layoutTarget(), pWindow->m_workspace->m_space);
+    if (pWindow->m_swallowee->m_currentlySwallowed) {
+        pWindow->m_swallowee->m_currentlySwallowed = false;
+        pWindow->m_swallowee->setHidden(false);
+        g_layoutManager->newTarget(pWindow->m_swallowee->layoutTarget(), pWindow->m_workspace->m_space);
     } else {
-        pWindow->m_swallowed->m_currentlySwallowed = true;
-        pWindow->m_swallowed->setHidden(true);
-        g_layoutManager->removeTarget(pWindow->m_swallowed->layoutTarget());
+        pWindow->m_swallowee->m_currentlySwallowed = true;
+        pWindow->m_swallowee->setHidden(true);
+        g_layoutManager->removeTarget(pWindow->m_swallowee->layoutTarget());
     }
 
     return {};

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -418,7 +418,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             (sc<int>(w->m_isFloating) == 1 ? "true" : "false"), w->monitorID(), escapeJSONStrings(w->m_class), escapeJSONStrings(w->m_title), escapeJSONStrings(w->m_initialClass),
             escapeJSONStrings(w->m_initialTitle), w->getPID(), (sc<int>(w->m_isX11) == 1 ? "true" : "false"), (w->m_pinned ? "true" : "false"),
             sc<uint8_t>(w->m_fullscreenState.internal), sc<uint8_t>(w->m_fullscreenState.client), (w->m_createdOverFullscreen ? "true" : "false"), getGroupedData(w, format),
-            getTagsData(w, format), rc<uintptr_t>(w->m_swallowed.get()), getFocusHistoryID(w), (g_pInputManager->isWindowInhibiting(w, false) ? "true" : "false"),
+            getTagsData(w, format), rc<uintptr_t>(w->m_swallowee.get()), getFocusHistoryID(w), (g_pInputManager->isWindowInhibiting(w, false) ? "true" : "false"),
             escapeJSONStrings(w->xdgTag().value_or("")), escapeJSONStrings(w->xdgDescription().value_or("")), escapeJSONStrings(NContentType::toString(w->getContentType())),
             w->m_stableID);
     } else {
@@ -434,7 +434,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             sc<int>(w->m_realPosition->goal().x), sc<int>(w->m_realPosition->goal().y), sc<int>(w->m_realSize->goal().x), sc<int>(w->m_realSize->goal().y),
             w->m_workspace ? w->workspaceID() : WORKSPACE_INVALID, (!w->m_workspace ? "" : w->m_workspace->m_name), sc<int>(w->m_isFloating), w->monitorID(), w->m_class,
             w->m_title, w->m_initialClass, w->m_initialTitle, w->getPID(), sc<int>(w->m_isX11), sc<int>(w->m_pinned), sc<uint8_t>(w->m_fullscreenState.internal),
-            sc<uint8_t>(w->m_fullscreenState.client), sc<int>(w->m_createdOverFullscreen), getGroupedData(w, format), getTagsData(w, format), rc<uintptr_t>(w->m_swallowed.get()),
+            sc<uint8_t>(w->m_fullscreenState.client), sc<int>(w->m_createdOverFullscreen), getGroupedData(w, format), getTagsData(w, format), rc<uintptr_t>(w->m_swallowee.get()),
             getFocusHistoryID(w), sc<int>(g_pInputManager->isWindowInhibiting(w, false)), w->xdgTag().value_or(""), w->xdgDescription().value_or(""),
             NContentType::toString(w->getContentType()), w->m_stableID);
     }

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -421,7 +421,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             (sc<int>(w->m_isFloating) == 1 ? "true" : "false"), w->monitorID(), escapeJSONStrings(w->m_class), escapeJSONStrings(w->m_title), escapeJSONStrings(w->m_initialClass),
             escapeJSONStrings(w->m_initialTitle), w->getPID(), (sc<int>(w->m_isX11) == 1 ? "true" : "false"), (w->m_pinned ? "true" : "false"),
             sc<uint8_t>(w->m_fullscreenState.internal), sc<uint8_t>(w->m_fullscreenState.client), (w->m_createdOverFullscreen ? "true" : "false"), getGroupedData(w, format),
-            getTagsData(w, format), rc<uintptr_t>(w->m_swallowed.get()), getFocusHistoryID(w), (g_pInputManager->isWindowInhibiting(w, false) ? "true" : "false"),
+            getTagsData(w, format), rc<uintptr_t>(w->m_swallowee.get()), getFocusHistoryID(w), (g_pInputManager->isWindowInhibiting(w, false) ? "true" : "false"),
             escapeJSONStrings(w->xdgTag().value_or("")), escapeJSONStrings(w->xdgDescription().value_or("")), escapeJSONStrings(NContentType::toString(w->getContentType())),
             w->m_stableID);
     } else {
@@ -437,7 +437,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             sc<int>(w->m_realPosition->goal().x), sc<int>(w->m_realPosition->goal().y), sc<int>(w->m_realSize->goal().x), sc<int>(w->m_realSize->goal().y),
             w->m_workspace ? w->workspaceID() : WORKSPACE_INVALID, (!w->m_workspace ? "" : w->m_workspace->m_name), sc<int>(w->m_isFloating), w->monitorID(), w->m_class,
             w->m_title, w->m_initialClass, w->m_initialTitle, w->getPID(), sc<int>(w->m_isX11), sc<int>(w->m_pinned), sc<uint8_t>(w->m_fullscreenState.internal),
-            sc<uint8_t>(w->m_fullscreenState.client), sc<int>(w->m_createdOverFullscreen), getGroupedData(w, format), getTagsData(w, format), rc<uintptr_t>(w->m_swallowed.get()),
+            sc<uint8_t>(w->m_fullscreenState.client), sc<int>(w->m_createdOverFullscreen), getGroupedData(w, format), getTagsData(w, format), rc<uintptr_t>(w->m_swallowee.get()),
             getFocusHistoryID(w), sc<int>(g_pInputManager->isWindowInhibiting(w, false)), w->xdgTag().value_or(""), w->xdgDescription().value_or(""),
             NContentType::toString(w->getContentType()), w->m_stableID);
     }

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -525,10 +525,10 @@ void CWindow::moveToWorkspace(PHLWORKSPACE pWorkspace) {
         Event::bus()->m_events.window.moveToWorkspace.emit(m_self.lock(), pWorkspace);
     }
 
-    if (const auto SWALLOWED = m_swallowed.lock()) {
-        if (SWALLOWED->m_currentlySwallowed) {
-            SWALLOWED->moveToWorkspace(pWorkspace);
-            SWALLOWED->m_monitor = m_monitor;
+    if (const auto SWALLOWEE = m_swallowee.lock()) {
+        if (SWALLOWEE->m_currentlySwallowed) {
+            SWALLOWEE->moveToWorkspace(pWorkspace);
+            SWALLOWEE->m_monitor = m_monitor;
         }
     }
 
@@ -1405,7 +1405,7 @@ void CWindow::warpCursor(bool force) {
         g_pCompositor->warpCursorTo(middle(), force);
 }
 
-PHLWINDOW CWindow::getSwallower() {
+PHLWINDOW CWindow::getSwallowee() {
     static auto PSWALLOWREGEX   = CConfigValue<std::string>("misc:swallow_regex");
     static auto PSWALLOWEXREGEX = CConfigValue<std::string>("misc:swallow_exception_regex");
     static auto PSWALLOW        = CConfigValue<Config::INTEGER>("misc:enable_swallow");
@@ -2088,13 +2088,13 @@ void CWindow::mapWindow() {
         Log::logger->log(Log::DEBUG, "Requested monitor, applying to {:mw}", m_self.lock());
     }
 
-    // Verify window swallowing. Get the swallower before calling onWindowCreated(m_self.lock()) because getSwallower() wouldn't get it after if m_self.lock() gets auto grouped.
-    const auto SWALLOWER = getSwallower();
+    // Verify window swallowing. Get the swallowee before calling onWindowCreated(m_self.lock()) because getSwallowee() wouldn't get it after if m_self.lock() gets auto grouped.
+    const auto SWALLOWEE = getSwallowee();
     // m_hasSwallower prevents secondary windows to swallow the parent when it's been unswallowed with `toggleswallow`.
-    if (SWALLOWER && !SWALLOWER->m_hasSwallower) {
-        SWALLOWER->m_currentlySwallowed = true;
-        SWALLOWER->m_hasSwallower = true;
-        m_swallowed = SWALLOWER;
+    if (SWALLOWEE && !SWALLOWEE->m_hasSwallower) {
+        SWALLOWEE->m_currentlySwallowed = true;
+        SWALLOWEE->m_hasSwallower = true;
+        m_swallowee = SWALLOWEE;
     }
 
     // emit the IPC event before the layout might focus the window to avoid a focus event first
@@ -2226,9 +2226,9 @@ void CWindow::mapWindow() {
     }
 
     // swallow
-    if (m_swallowed) {
-        g_layoutManager->removeTarget(SWALLOWER->layoutTarget());
-        SWALLOWER->setHidden(true);
+    if (m_swallowee) {
+        g_layoutManager->removeTarget(SWALLOWEE->layoutTarget());
+        SWALLOWEE->setHidden(true);
     }
 
     m_firstMap = false;
@@ -2312,20 +2312,20 @@ void CWindow::unmapWindow() {
         g_pHyprRenderer->makeSnapshot(m_self.lock());
 
     // swallowing
-    if (valid(m_swallowed)) {
-        if (m_swallowed->m_currentlySwallowed) {
-            m_swallowed->m_currentlySwallowed = false;
-            m_swallowed->setHidden(false);
+    if (const auto SWALLOWEE = m_swallowee.lock()) {
+        if (SWALLOWEE->m_currentlySwallowed) {
+            SWALLOWEE->m_currentlySwallowed = false;
+            SWALLOWEE->setHidden(false);
 
             if (m_group)
-                m_swallowed->m_groupSwallowed = true; // flag for the swallowed window to be created into the group where it belongs when auto_group = false.
+                SWALLOWEE->m_groupSwallowed = true; // flag for the swallowed window to be created into the group where it belongs when auto_group = false.
 
-            g_layoutManager->newTarget(m_swallowed->layoutTarget(), m_workspace->m_space);
+            g_layoutManager->newTarget(SWALLOWEE->layoutTarget(), m_workspace->m_space);
         }
 
-        m_swallowed->m_groupSwallowed = false;
-        m_swallowed->m_hasSwallower = false;
-        m_swallowed.reset();
+        SWALLOWEE->m_groupSwallowed = false;
+        SWALLOWEE->m_hasSwallower = false;
+        m_swallowee.reset();
     }
 
     bool      wasLastWindow = false;

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -2313,7 +2313,7 @@ void CWindow::unmapWindow() {
 
     // swallowing
     if (const auto SWALLOWEE = m_swallowee.lock()) {
-        if (SWALLOWEE->m_currentlySwallowed) {
+        if (SWALLOWEE->m_isMapped && SWALLOWEE->m_currentlySwallowed) {
             SWALLOWEE->m_currentlySwallowed = false;
             SWALLOWEE->setHidden(false);
 

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -2090,9 +2090,12 @@ void CWindow::mapWindow() {
 
     // Verify window swallowing. Get the swallower before calling onWindowCreated(m_self.lock()) because getSwallower() wouldn't get it after if m_self.lock() gets auto grouped.
     const auto SWALLOWER = getSwallower();
-    m_swallowed          = SWALLOWER;
-    if (m_swallowed)
-        m_swallowed->m_currentlySwallowed = true;
+    // m_hasSwallower prevents secondary windows to swallow the parent when it's been unswallowed with `toggleswallow`.
+    if (SWALLOWER && !SWALLOWER->m_hasSwallower) {
+        SWALLOWER->m_currentlySwallowed = true;
+        SWALLOWER->m_hasSwallower = true;
+        m_swallowed = SWALLOWER;
+    }
 
     // emit the IPC event before the layout might focus the window to avoid a focus event first
     g_pEventManager->postEvent(SHyprIPCEvent{"openwindow", std::format("{:x},{},{},{}", m_self.lock(), PWORKSPACE->m_name, m_class, m_title)});
@@ -2223,7 +2226,7 @@ void CWindow::mapWindow() {
     }
 
     // swallow
-    if (SWALLOWER) {
+    if (m_swallowed) {
         g_layoutManager->removeTarget(SWALLOWER->layoutTarget());
         SWALLOWER->setHidden(true);
     }
@@ -2321,6 +2324,7 @@ void CWindow::unmapWindow() {
         }
 
         m_swallowed->m_groupSwallowed = false;
+        m_swallowed->m_hasSwallower = false;
         m_swallowed.reset();
     }
 

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -2093,8 +2093,8 @@ void CWindow::mapWindow() {
     // m_hasSwallower prevents secondary windows to swallow the parent when it's been unswallowed with `toggleswallow`.
     if (SWALLOWEE && !SWALLOWEE->m_hasSwallower) {
         SWALLOWEE->m_currentlySwallowed = true;
-        SWALLOWEE->m_hasSwallower = true;
-        m_swallowee = SWALLOWEE;
+        SWALLOWEE->m_hasSwallower       = true;
+        m_swallowee                     = SWALLOWEE;
     }
 
     // emit the IPC event before the layout might focus the window to avoid a focus event first
@@ -2324,7 +2324,7 @@ void CWindow::unmapWindow() {
         }
 
         SWALLOWEE->m_groupSwallowed = false;
-        SWALLOWEE->m_hasSwallower = false;
+        SWALLOWEE->m_hasSwallower   = false;
         m_swallowee.reset();
     }
 

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -2221,8 +2221,8 @@ void CWindow::mapWindow() {
     // m_hasSwallower prevents secondary windows to swallow the parent when it's been unswallowed with `toggleswallow`.
     if (SWALLOWEE && !SWALLOWEE->m_hasSwallower) {
         SWALLOWEE->m_currentlySwallowed = true;
-        SWALLOWEE->m_hasSwallower = true;
-        m_swallowee = SWALLOWEE;
+        SWALLOWEE->m_hasSwallower       = true;
+        m_swallowee                     = SWALLOWEE;
     }
 
     // emit the IPC event before the layout might focus the window to avoid a focus event first
@@ -2454,7 +2454,7 @@ void CWindow::unmapWindow() {
         }
 
         SWALLOWEE->m_groupSwallowed = false;
-        SWALLOWEE->m_hasSwallower = false;
+        SWALLOWEE->m_hasSwallower   = false;
         m_swallowee.reset();
     }
 

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -539,10 +539,10 @@ void CWindow::moveToWorkspace(PHLWORKSPACE pWorkspace) {
         Event::bus()->m_events.window.moveToWorkspace.emit(m_self.lock(), pWorkspace);
     }
 
-    if (const auto SWALLOWED = m_swallowed.lock()) {
-        if (SWALLOWED->m_currentlySwallowed) {
-            SWALLOWED->moveToWorkspace(pWorkspace);
-            SWALLOWED->m_monitor = m_monitor;
+    if (const auto SWALLOWEE = m_swallowee.lock()) {
+        if (SWALLOWEE->m_currentlySwallowed) {
+            SWALLOWEE->moveToWorkspace(pWorkspace);
+            SWALLOWEE->m_monitor = m_monitor;
         }
     }
 
@@ -1518,7 +1518,7 @@ void CWindow::warpCursor(bool force) {
         g_pCompositor->warpCursorTo(middle(), force);
 }
 
-PHLWINDOW CWindow::getSwallower() {
+PHLWINDOW CWindow::getSwallowee() {
     static auto PSWALLOWREGEX   = CConfigValue<std::string>("misc:swallow_regex");
     static auto PSWALLOWEXREGEX = CConfigValue<std::string>("misc:swallow_exception_regex");
     static auto PSWALLOW        = CConfigValue<Config::INTEGER>("misc:enable_swallow");
@@ -2216,13 +2216,13 @@ void CWindow::mapWindow() {
 
     PMONITOR = m_monitor.lock();
 
-    // Verify window swallowing. Get the swallower before calling onWindowCreated(m_self.lock()) because getSwallower() wouldn't get it after if m_self.lock() gets auto grouped.
-    const auto SWALLOWER = getSwallower();
+    // Verify window swallowing. Get the swallowee before calling onWindowCreated(m_self.lock()) because getSwallowee() wouldn't get it after if m_self.lock() gets auto grouped.
+    const auto SWALLOWEE = getSwallowee();
     // m_hasSwallower prevents secondary windows to swallow the parent when it's been unswallowed with `toggleswallow`.
-    if (SWALLOWER && !SWALLOWER->m_hasSwallower) {
-        SWALLOWER->m_currentlySwallowed = true;
-        SWALLOWER->m_hasSwallower = true;
-        m_swallowed = SWALLOWER;
+    if (SWALLOWEE && !SWALLOWEE->m_hasSwallower) {
+        SWALLOWEE->m_currentlySwallowed = true;
+        SWALLOWEE->m_hasSwallower = true;
+        m_swallowee = SWALLOWEE;
     }
 
     // emit the IPC event before the layout might focus the window to avoid a focus event first
@@ -2359,9 +2359,9 @@ void CWindow::mapWindow() {
     }
 
     // swallow
-    if (m_swallowed) {
-        g_layoutManager->removeTarget(SWALLOWER->layoutTarget());
-        SWALLOWER->setHidden(true);
+    if (m_swallowee) {
+        g_layoutManager->removeTarget(SWALLOWEE->layoutTarget());
+        SWALLOWEE->setHidden(true);
     }
 
     m_firstMap = false;
@@ -2442,20 +2442,20 @@ void CWindow::unmapWindow() {
         g_pHyprRenderer->makeSnapshot(m_self.lock());
 
     // swallowing
-    if (valid(m_swallowed)) {
-        if (m_swallowed->m_currentlySwallowed) {
-            m_swallowed->m_currentlySwallowed = false;
-            m_swallowed->setHidden(false);
+    if (const auto SWALLOWEE = m_swallowee.lock()) {
+        if (SWALLOWEE->m_currentlySwallowed) {
+            SWALLOWEE->m_currentlySwallowed = false;
+            SWALLOWEE->setHidden(false);
 
             if (m_group)
-                m_swallowed->m_groupSwallowed = true; // flag for the swallowed window to be created into the group where it belongs when auto_group = false.
+                SWALLOWEE->m_groupSwallowed = true; // flag for the swallowed window to be created into the group where it belongs when auto_group = false.
 
-            g_layoutManager->newTarget(m_swallowed->layoutTarget(), m_workspace->m_space);
+            g_layoutManager->newTarget(SWALLOWEE->layoutTarget(), m_workspace->m_space);
         }
 
-        m_swallowed->m_groupSwallowed = false;
-        m_swallowed->m_hasSwallower = false;
-        m_swallowed.reset();
+        SWALLOWEE->m_groupSwallowed = false;
+        SWALLOWEE->m_hasSwallower = false;
+        m_swallowee.reset();
     }
 
     bool      wasLastWindow = false;

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -2443,7 +2443,7 @@ void CWindow::unmapWindow() {
 
     // swallowing
     if (const auto SWALLOWEE = m_swallowee.lock()) {
-        if (SWALLOWEE->m_currentlySwallowed) {
+        if (SWALLOWEE->m_isMapped && SWALLOWEE->m_currentlySwallowed) {
             SWALLOWEE->m_currentlySwallowed = false;
             SWALLOWEE->setHidden(false);
 

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -2218,9 +2218,12 @@ void CWindow::mapWindow() {
 
     // Verify window swallowing. Get the swallower before calling onWindowCreated(m_self.lock()) because getSwallower() wouldn't get it after if m_self.lock() gets auto grouped.
     const auto SWALLOWER = getSwallower();
-    m_swallowed          = SWALLOWER;
-    if (m_swallowed)
-        m_swallowed->m_currentlySwallowed = true;
+    // m_hasSwallower prevents secondary windows to swallow the parent when it's been unswallowed with `toggleswallow`.
+    if (SWALLOWER && !SWALLOWER->m_hasSwallower) {
+        SWALLOWER->m_currentlySwallowed = true;
+        SWALLOWER->m_hasSwallower = true;
+        m_swallowed = SWALLOWER;
+    }
 
     // emit the IPC event before the layout might focus the window to avoid a focus event first
     g_pEventManager->postEvent(SHyprIPCEvent{"openwindow", std::format("{:x},{},{},{}", m_self.lock(), PWORKSPACE->m_name, m_class, m_title)});
@@ -2356,7 +2359,7 @@ void CWindow::mapWindow() {
     }
 
     // swallow
-    if (SWALLOWER) {
+    if (m_swallowed) {
         g_layoutManager->removeTarget(SWALLOWER->layoutTarget());
         SWALLOWER->setHidden(true);
     }
@@ -2451,6 +2454,7 @@ void CWindow::unmapWindow() {
         }
 
         m_swallowed->m_groupSwallowed = false;
+        m_swallowed->m_hasSwallower = false;
         m_swallowed.reset();
     }
 

--- a/src/desktop/view/Window.hpp
+++ b/src/desktop/view/Window.hpp
@@ -257,7 +257,7 @@ namespace Desktop::View {
         int m_monitorMovedFrom = -1; // -1 means not moving
 
         // swallowing
-        PHLWINDOWREF m_swallowed;
+        PHLWINDOWREF m_swallowee;
         bool         m_currentlySwallowed = false;
         bool         m_groupSwallowed     = false;
         bool         m_hasSwallower       = false;
@@ -372,7 +372,7 @@ namespace Desktop::View {
         std::string                fetchTitle();
         std::string                fetchClass();
         void                       warpCursor(bool force = false);
-        PHLWINDOW                  getSwallower();
+        PHLWINDOW                  getSwallowee();
         bool                       isX11OverrideRedirect();
         bool                       isModal();
         Vector2D                   realToReportSize();

--- a/src/desktop/view/Window.hpp
+++ b/src/desktop/view/Window.hpp
@@ -260,6 +260,7 @@ namespace Desktop::View {
         PHLWINDOWREF m_swallowed;
         bool         m_currentlySwallowed = false;
         bool         m_groupSwallowed     = false;
+        bool         m_hasSwallower       = false;
 
         // for toplevel monitor events
         MONITORID m_lastSurfaceMonitorID = -1;

--- a/src/desktop/view/Window.hpp
+++ b/src/desktop/view/Window.hpp
@@ -257,7 +257,7 @@ namespace Desktop::View {
         int m_monitorMovedFrom = -1; // -1 means not moving
 
         // swallowing
-        PHLWINDOWREF m_swallowed;
+        PHLWINDOWREF m_swallowee;
         bool         m_currentlySwallowed = false;
         bool         m_groupSwallowed     = false;
         bool         m_hasSwallower       = false;
@@ -381,7 +381,7 @@ namespace Desktop::View {
         std::string                       fetchTitle();
         std::string                       fetchClass();
         void                              warpCursor(bool force = false);
-        PHLWINDOW                         getSwallower();
+        PHLWINDOW                         getSwallowee();
         bool                              isX11OverrideRedirect();
         bool                              isModal();
         Vector2D                          realToReportSize();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
After using `toggleswallow` to unswallow a window (e.g the terminal window to get the logs). If the swallower process creates additional windows, the unswallowed window gets reswallowed automatically which is unwanted behaviour.
This PR fixes this by ignoring the swallow request for new windows when the swallowee already has a swallower (i.e a primary window is already managing the swallow).

Before:

https://github.com/user-attachments/assets/3d6b38b5-4cb4-44c0-870c-cb52664bea5f

After:

https://github.com/user-attachments/assets/808a2d43-237d-4dc6-bbf1-feb8e70ffa8c


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
n/a

#### Is it ready for merging, or does it need work?
Ready for merging

