### PR TITLE
no longer refocusing under cursor when the last window of a workspace closes and follow_mouse != 1

### DIFF
--- a/src/desktop/view/LayerSurface.cpp
+++ b/src/desktop/view/LayerSurface.cpp
@@ -277,8 +277,11 @@ void CLayerSurface::onUnmap() {
     //                                vvvvvvvvvvvvv if there is a last focus and the last focus is not keyboard focusable, fallback to window
     if (WASLASTFOCUS ||
         (Desktop::focusState()->surface() && Desktop::focusState()->surface()->m_hlSurface && !Desktop::focusState()->surface()->m_hlSurface->keyboardFocusable())) {
-        if (!g_pInputManager->refocusLastWindow(PMONITOR))
-            g_pInputManager->refocus();
+        if (!g_pInputManager->refocusLastWindow(PMONITOR)) {
+            static auto PFOLLOWMOUSE = CConfigValue<Hyprlang::INT>("input:follow_mouse");
+            if (*PFOLLOWMOUSE == 1)
+                g_pInputManager->refocus();
+        }
     } else if (Desktop::focusState()->surface() && Desktop::focusState()->surface() != m_wlSurface->resource())
         g_pSeatManager->setKeyboardFocus(Desktop::focusState()->surface());
 

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -2527,8 +2527,11 @@ void CWindow::unmapWindow() {
                 g_pCompositor->setWindowFullscreenInternal(candidate, CURRENTFSMODE);
         }
 
-        if (!candidate && m_workspace && m_workspace->getWindows() == 0)
-            g_pInputManager->refocus();
+        if (!candidate && m_workspace && m_workspace->getWindows() == 0) {
+            static auto PFOLLOWMOUSE = CConfigValue<Hyprlang::INT>("input:follow_mouse");
+            if (*PFOLLOWMOUSE == 1)
+                g_pInputManager->refocus();
+        }
 
         g_pInputManager->sendMotionEventsToFocused();
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -281,7 +281,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
                              rc<uintptr_t>(CONSTRAINT.get()));
     }
 
-    if (PMONITOR != Desktop::focusState()->monitor() && (*PMOUSEFOCUSMON || refocus) && m_forcedFocus.expired())
+    if (PMONITOR != Desktop::focusState()->monitor() && (*PMOUSEFOCUSMON || (refocus && *PFOLLOWMOUSE == 1)) && m_forcedFocus.expired())
         Desktop::focusState()->rawMonitorFocus(PMONITOR);
 
     // check for windows that have focus priority like our permission popups
@@ -1580,13 +1580,16 @@ void CInputManager::refocus(std::optional<Vector2D> overridePos) {
 }
 
 bool CInputManager::refocusLastWindow(PHLMONITOR pMonitor) {
+    static auto PFOLLOWMOUSE = CConfigValue<Hyprlang::INT>("input:follow_mouse");
+
     if (!m_exclusiveLSes.empty()) {
         Log::logger->log(Log::DEBUG, "CInputManager::refocusLastWindow: ignoring, exclusive LS present.");
         return false;
     }
 
     if (!pMonitor) {
-        refocus();
+        if (*PFOLLOWMOUSE == 1)
+            refocus();
         return true;
     }
 
@@ -1623,7 +1626,8 @@ bool CInputManager::refocusLastWindow(PHLMONITOR pMonitor) {
             Desktop::focusState()->fullWindowFocus(PLASTWINDOW);
         }
 
-        refocus();
+        if (*PFOLLOWMOUSE == 1)
+            refocus();
     }
 
     return true;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

this adds the new "switch_monitor_on_empty" option which fixed this issue #12991 when set to false, the default behavior is not changed if it is not used

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
i tested it, i confirmed that it solved my issue, i've not found it to cause any other issue, but this would be my first contribution to the project so any criticism is welcomed.

#### Is it ready for merging, or does it need work?
it's not a big change so i think it should be ready but you tell me.

thank you !
