### PR TITLE
added the resizeactiveedge dispatcher that allows expanding/shrinking a window in any direction

### DIFF
--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -209,6 +209,7 @@ class CKeybindManager {
     static SDispatchResult toggleSpecialWorkspace(std::string);
     static SDispatchResult forceRendererReload(std::string);
     static SDispatchResult resizeActive(std::string);
+    static SDispatchResult resizeActiveEdge(std::string);
     static SDispatchResult moveActive(std::string);
     static SDispatchResult moveWindow(std::string);
     static SDispatchResult resizeWindow(std::string);


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

currently there is no way to change the expand / shrink a windows from all corners if it is floating or entirely surrounded by other windows, this allow you to resize in all directions.

you can use it like that `resizeactiveedge <direction> pixels` ie `resizeactiveedge u -10`

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

this should not collide with any existing thing

#### Is it ready for merging, or does it need work?

it works, you tell me.
thank you !
