### PR TITLE
anr: remove window on closewindow

### DIFF
--- a/src/managers/ANRManager.cpp
+++ b/src/managers/ANRManager.cpp
@@ -53,8 +53,9 @@ CANRManager::CANRManager() {
             d->killDialog();
             d->missedResponses = 0;
             d->dialogSaidWait  = false;
-            return;
         }
+
+        std::erase_if(m_data, [&window](auto& w) { return w == window; });
     });
 
     m_timer->updateTimeout(TIMER_TIMEOUT);


### PR DESCRIPTION
m_data was never cleaned and continously built up the m_data, remove the entry on closeWindow.

without delving too deep into ANR i think this was the idea?


