### PR TITLE
added bindm swapwindow, swaps are atomic

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2747,6 +2747,8 @@ SDispatchResult CKeybindManager::mouse(std::string args) {
 
     if (ARGS[0] == "movewindow") {
         return changeMouseBindMode(MBIND_MOVE);
+    } else if (ARGS[0] == "swapwindow") {
+        return changeMouseBindMode(MBIND_SWAP);
     } else {
         try {
             switch (std::stoi(ARGS[1])) {
@@ -2769,13 +2771,19 @@ SDispatchResult CKeybindManager::changeMouseBindMode(const eMouseBindMode MODE) 
         if (!PWINDOW)
             return SDispatchResult{.passEvent = true};
 
-        if (!PWINDOW->isFullscreen() && MODE == MBIND_MOVE)
+        if (PWINDOW->isFullscreen())
+            return SDispatchResult{.passEvent = true};
+
+        // For floating windows, use move mode instead of swap mode
+        const auto DRAG_MODE = (PWINDOW->m_isFloating && MODE == MBIND_SWAP) ? MBIND_MOVE : MODE;
+
+        if (DRAG_MODE == MBIND_MOVE)
             PWINDOW->checkInputOnDecos(INPUT_TYPE_DRAG_START, MOUSECOORDS);
 
         if (g_pInputManager->m_currentlyDraggedWindow.expired())
             g_pInputManager->m_currentlyDraggedWindow = PWINDOW;
 
-        g_pInputManager->m_dragMode = MODE;
+        g_pInputManager->m_dragMode = DRAG_MODE;
 
         g_pLayoutManager->getCurrentLayout()->onBeginDragWindow();
     } else {

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -39,7 +39,8 @@ enum eMouseBindMode : int8_t {
     MBIND_MOVE               = 0,
     MBIND_RESIZE             = 1,
     MBIND_RESIZE_BLOCK_RATIO = 2,
-    MBIND_RESIZE_FORCE_RATIO = 3
+    MBIND_RESIZE_FORCE_RATIO = 3,
+    MBIND_SWAP               = 4
 };
 
 enum eBorderIconDirection : uint8_t {


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

#### Describe your PR, what does it fix/add?
this is mostly porting a feature from bspwm as i'm switching from it and am a few features away from having everything i like.
basicaly it allows you to first click a mouse with that, ie super + click, and then move your mouse around, as soon as you hover another window, it'll instantly swap their position, you can of course swap back, or continue swaping the window with other windows to move your windows around before releasing the click.
if you hover an empty workspace it'll also instantly move the window there.

anyway, this is a very handy feature i use practicaly everyday, i don't wanna miss it, i'm binding bindm movewindow to CTRL + super now, having both is nice.

you can bind it like that :
`bindm = $mainMod, mouse:272, swapwindow`

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

i've tested it to work and not break existing functionality, does what i want it to, so should be good.

#### Is it ready for merging, or does it need work?

should be ready.
thanks !
