### PR TITLE
animation: reset tick state on session activation

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -483,6 +483,10 @@ void CCompositor::initAllSignals() {
 
                 m_sessionActive = true;
 
+                // Reset animation tick state to avoid stale timer issues after suspend/wake
+                if (g_pAnimationManager)
+                    g_pAnimationManager->resetTickState();
+
                 for (auto const& m : m_monitors) {
                     scheduleFrameForMonitor(m);
                     m->applyMonitorRule(&m->m_activeMonitorRule, true);

--- a/src/managers/animation/AnimationManager.cpp
+++ b/src/managers/animation/AnimationManager.cpp
@@ -286,6 +286,11 @@ void CHyprAnimationManager::onTicked() {
     m_tickScheduled = false;
 }
 
+void CHyprAnimationManager::resetTickState() {
+    m_lastTickValid = false;
+    m_tickScheduled = false;
+}
+
 std::string CHyprAnimationManager::styleValidInConfigVar(const std::string& config, const std::string& style) {
     if (config.starts_with("window")) {
         if (style.starts_with("slide") || style == "gnome" || style == "gnomed")

--- a/src/managers/animation/AnimationManager.hpp
+++ b/src/managers/animation/AnimationManager.hpp
@@ -18,6 +18,9 @@ class CHyprAnimationManager : public Hyprutils::Animation::CAnimationManager {
     virtual void scheduleTick();
     virtual void onTicked();
 
+    // Reset tick state after session changes (suspend/wake, lock/unlock)
+    void resetTickState();
+
     using SAnimationPropertyConfig = Hyprutils::Animation::SAnimationPropertyConfig;
     template <Animable VarType>
     void createAnimation(const VarType& v, PHLANIMVAR<VarType>& pav, SP<SAnimationPropertyConfig> pConfig, eAVarDamagePolicy policy) {


### PR DESCRIPTION
## Summary

Fixes framerate drops when blur is enabled after waking from suspend or unlocking the session.

## Problem

After commit 2b0fd417 ("animation: improve animations on multi refresh rate monitors"), the animation tick timer state (`m_lastTickValid`, `m_tickScheduled`) could become stale after suspend/wake cycles. When the session becomes active again, the animation system would be in an inconsistent state, causing performance degradation particularly noticeable when blur effects are enabled.

## Solution

Add a `resetTickState()` method to `CHyprAnimationManager` that resets the tick state flags, and call it when the session becomes active in `CCompositor::initAllSignals()`.

## Testing

- Manually tested by suspending and waking the system with blur enabled
- Verified that framerate remains stable after wake
- Confirmed that toggling blur on/off does not resolve the issue without this fix (as expected, since the issue was in the animation timer state, not blur itself)