### PR TITLE
gestures: added cursor zoom

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -39,6 +39,7 @@
 #include "../managers/input/trackpad/gestures/CloseGesture.hpp"
 #include "../managers/input/trackpad/gestures/FloatGesture.hpp"
 #include "../managers/input/trackpad/gestures/FullscreenGesture.hpp"
+#include "../managers/input/trackpad/gestures/CursorZoomGesture.hpp"
 
 #include "../managers/HookSystemManager.hpp"
 #include "../protocols/types/ContentType.hpp"
@@ -2913,7 +2914,10 @@ std::optional<std::string> CConfigManager::handleGesture(const std::string& comm
     else if (data[startDataIdx] == "fullscreen")
         result = g_pTrackpadGestures->addGesture(makeUnique<CFullscreenTrackpadGesture>(std::string{data[startDataIdx + 1]}), fingerCount, direction, modMask, deltaScale,
                                                  disableInhibit);
-    else if (data[startDataIdx] == "unset")
+    else if (data[startDataIdx] == "cursorZoom") {
+        result = g_pTrackpadGestures->addGesture(makeUnique<CCursorZoomTrackpadGesture>(std::string{data[startDataIdx + 1]}, std::string{data[startDataIdx + 2]}), fingerCount,
+                                                 direction, modMask, deltaScale, disableInhibit);
+    } else if (data[startDataIdx] == "unset")
         result = g_pTrackpadGestures->removeGesture(fingerCount, direction, modMask, deltaScale, disableInhibit);
     else
         return std::format("Invalid gesture: {}", data[startDataIdx]);

--- a/src/managers/input/trackpad/gestures/CursorZoomGesture.cpp
+++ b/src/managers/input/trackpad/gestures/CursorZoomGesture.cpp
@@ -1,0 +1,33 @@
+#include "CursorZoomGesture.hpp"
+
+#include "../../../../Compositor.hpp"
+#include "../../../../helpers/Monitor.hpp"
+
+CCursorZoomTrackpadGesture::CCursorZoomTrackpadGesture(const std::string& first, const std::string& second) {
+    try {
+        m_zoomValue = std::stof(first);
+    } catch (...) { ; }
+
+    if (second == "mult")
+        m_mode = MODE_MULT;
+}
+
+void CCursorZoomTrackpadGesture::begin(const ITrackpadGesture::STrackpadGestureBegin& e) {
+    ITrackpadGesture::begin(e);
+
+    if (m_mode == MODE_TOGGLE)
+        m_zoomed = !m_zoomed;
+
+    for (auto const& m : g_pCompositor->m_monitors) {
+        switch (m_mode) {
+            case MODE_TOGGLE:
+                static auto PZOOMFACTOR = CConfigValue<Hyprlang::FLOAT>("cursor:zoom_factor");
+                *m->m_cursorZoom        = m_zoomed ? m_zoomValue : *PZOOMFACTOR;
+                break;
+            case MODE_MULT: *m->m_cursorZoom = std::clamp(m->m_cursorZoom->goal() * m_zoomValue, 1.0F, 100.0F); break;
+        }
+    }
+}
+
+void CCursorZoomTrackpadGesture::update(const ITrackpadGesture::STrackpadGestureUpdate& e) {}
+void CCursorZoomTrackpadGesture::end(const ITrackpadGesture::STrackpadGestureEnd& e) {}

--- a/src/managers/input/trackpad/gestures/CursorZoomGesture.hpp
+++ b/src/managers/input/trackpad/gestures/CursorZoomGesture.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "ITrackpadGesture.hpp"
+
+class CCursorZoomTrackpadGesture : public ITrackpadGesture {
+  public:
+    CCursorZoomTrackpadGesture(const std::string& zoomLevel, const std::string& mode);
+    virtual ~CCursorZoomTrackpadGesture() = default;
+
+    virtual void begin(const ITrackpadGesture::STrackpadGestureBegin& e);
+    virtual void update(const ITrackpadGesture::STrackpadGestureUpdate& e);
+    virtual void end(const ITrackpadGesture::STrackpadGestureEnd& e);
+
+  private:
+    float              m_zoomValue = 1.0;
+    inline static bool m_zoomed    = false;
+
+    enum eMode : uint8_t {
+        MODE_TOGGLE = 0,
+        MODE_MULT,
+    };
+
+    eMode m_mode = MODE_TOGGLE;
+};


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
It adds a cursor zoom track pad gesture (#11637). There are three modes: toggle, in and out. The zoom level can be specified for in and toggle but defaults to cursor:zoom_factor in config.

```
gesture = 3, up, cursorZoom, in, 3.5
gesture = 3, down, cursorZoom, out
gesture = 3, right, cursorZoom, in, 2
# Toggle zoom
gesture = 3, left, cursorZoom, 3.0
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
Should be ready.