### PR TITLE
hyprerror: clear reserved area on destroy

### DIFF
--- a/src/hyprerror/HyprError.cpp
+++ b/src/hyprerror/HyprError.cpp
@@ -192,6 +192,7 @@ void CHyprError::draw() {
 
                 for (auto& m : g_pCompositor->m_monitors) {
                     g_pHyprRenderer->arrangeLayersForMonitor(m->m_id);
+                    m->m_reservedArea.resetType(Desktop::RESERVED_DYNAMIC_TYPE_ERROR_BAR);
                 }
 
                 return;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
It clears the reserved area for hyprerror errors when destroy is queued, fixing (#12927)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This change fixed the issue for me but could be good if people in the issue discussion could check it works for them too.

#### Is it ready for merging, or does it need work?
Should be ready.