### PR TITLE
add overFullscreen field in hyprctl window debug

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -387,7 +387,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
     "pinned": {},
     "fullscreen": {},
     "fullscreenClient": {},
-    "overFullscreen":{},
+    "overFullscreen": {},
     "grouped": [{}],
     "tags": [{}],
     "swallowing": "0x{:x}",


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
add overFullscreen field in window debug when performing `hyprctl clients` or simmilar command, The new field indicates whether a window is rendered above a fullscreen window or behind one. so it can distinguish window layering relative to fullscreen state, which is currently not exposed. for my use case  i have this kill window script, when i kill a window in a workspace with a fullscreen window, i can prioritize the next focus window order as : over fullscreen -> fullscreen -> under fullscreen.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
nope, all good

#### Is it ready for merging, or does it need work?
Yes
