### PR TITLE
opengl: allow texture filter to be changed

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1363,8 +1363,8 @@ void CHyprOpenGLImpl::renderTextureInternal(SP<CTexture> tex, const CBox& box, c
         tex->setTexParameter(GL_TEXTURE_MAG_FILTER, GL_NEAREST);
         tex->setTexParameter(GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     } else {
-        tex->setTexParameter(GL_TEXTURE_MAG_FILTER, tex->textureMagFilter);
-        tex->setTexParameter(GL_TEXTURE_MIN_FILTER, tex->textureMinFilter);
+        tex->setTexParameter(GL_TEXTURE_MAG_FILTER, tex->magFilter);
+        tex->setTexParameter(GL_TEXTURE_MIN_FILTER, tex->minFilter);
     }
 
     const bool isHDRSurface      = m_renderData.surface.valid() && m_renderData.surface->m_colorManagement.valid() ? m_renderData.surface->m_colorManagement->isHDR() : false;
@@ -1616,8 +1616,8 @@ void CHyprOpenGLImpl::renderTexturePrimitive(SP<CTexture> tex, const CBox& box) 
         tex->setTexParameter(GL_TEXTURE_MAG_FILTER, GL_NEAREST);
         tex->setTexParameter(GL_TEXTURE_MIN_FILTER, GL_NEAREST);
     } else {
-        tex->setTexParameter(GL_TEXTURE_MAG_FILTER, tex->textureMagFilter);
-        tex->setTexParameter(GL_TEXTURE_MIN_FILTER, tex->textureMinFilter);
+        tex->setTexParameter(GL_TEXTURE_MAG_FILTER, tex->magFilter);
+        tex->setTexParameter(GL_TEXTURE_MIN_FILTER, tex->minFilter);
     }
 
     auto shader = useShader(m_shaders->frag[SH_FRAG_PASSTHRURGBA]);

--- a/src/render/Texture.hpp
+++ b/src/render/Texture.hpp
@@ -49,8 +49,8 @@ class CTexture {
     uint32_t                    m_drmFormat     = 0; // for shm
     bool                        m_isSynchronous = false;
 
-    GLenum                      textureMagFilter = GL_LINEAR; // useNearestNeighbor overwrites these
-    GLenum                      textureMinFilter = GL_LINEAR;
+    GLenum                      magFilter = GL_LINEAR; // useNearestNeighbor overwrites these
+    GLenum                      minFilter = GL_LINEAR;
 
   private:
     enum eTextureParam : uint8_t {


### PR DESCRIPTION
This lets mipmap filters be set when rendering a texture. (Wanted for my plugin, but also useful for hyprexpo and the like so that textures don't shimmer when scaled down).