### PR TITLE
eventloopmgr fixes

### DIFF
--- a/src/managers/eventLoop/EventLoopManager.hpp
+++ b/src/managers/eventLoop/EventLoopManager.hpp
@@ -89,9 +89,9 @@ class CEventLoopManager {
         bool                             recalcScheduled = false;
     } m_timers;
 
-    SIdleData                                                 m_idle;
-    std::map<int, SEventSourceData>                           m_aqEventSources;
-    std::unordered_map<SReadableWaiter*, UP<SReadableWaiter>> m_readableWaiters;
+    SIdleData                        m_idle;
+    std::map<int, SEventSourceData>  m_aqEventSources;
+    std::vector<UP<SReadableWaiter>> m_readableWaiters;
 
     struct {
         CHyprSignalListener pollFDsChanged;


### PR DESCRIPTION
move the idle functions instead of copying, avoids std::function copies.



the manpage for timerfd_create and read states this.

timefd_create creates a new timer object, and returns a file descriptor
that can be used to read the number of expirations that have occurred.

The FD becomes readable when the timer expires.

read removes the “readable” state from the FD.

so most likely it has somewhat worked because of the scheduleRecalc()
function.