### PR TITLE
socket2: emit `kill` event (hyprctl kill)

### DIFF
--- a/src/event/EventBus.hpp
+++ b/src/event/EventBus.hpp
@@ -41,6 +41,7 @@ namespace Event {
                 Event<PHLWINDOW>                        openEarly;
                 Event<PHLWINDOW>                        destroy;
                 Event<PHLWINDOW>                        close;
+                Event<PHLWINDOW>                        kill;
                 Event<PHLWINDOW, Desktop::eFocusReason> active;
                 Event<PHLWINDOW>                        urgent;
                 Event<PHLWINDOW>                        title;

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -848,7 +848,7 @@ void CInputManager::processMouseDownKill(const IPointer::SButtonEvent& e) {
             }
 
             g_pEventManager->postEvent(SHyprIPCEvent({.event = "kill", .data = std::format("{:x}", rc<uintptr_t>(PWINDOW.m_data))}));
-            EMIT_HOOK_EVENT("kill", PWINDOW);
+            Event::bus()->m_events.window.kill.emit(PWINDOW);
 
             // kill the mf
             kill(PWINDOW->getPID(), SIGKILL);


### PR DESCRIPTION
This PR adds a new event when some window is killed via `hyprctl kill`. Event is `kill>>WINDOWADDRESS`. This will not trigger when a window is closed _normally_.

It's just two lines, tell me if something needs to be changed. I will add the table entry in a wiki PR after this gets merged.
