### PR TITLE
opengl: set EGL_CONTEXT_RELEASE_BEHAVIOR_KHR if supported

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -160,6 +160,7 @@ void CHyprOpenGLImpl::initEGL(bool gbm) {
     m_exts.EXT_create_context_robustness      = EGLEXTENSIONS.contains("EXT_create_context_robustness");
     m_exts.EXT_image_dma_buf_import           = EGLEXTENSIONS.contains("EXT_image_dma_buf_import");
     m_exts.EXT_image_dma_buf_import_modifiers = EGLEXTENSIONS.contains("EXT_image_dma_buf_import_modifiers");
+    m_exts.KHR_context_flush_control          = EGLEXTENSIONS.contains("EGL_KHR_context_flush_control");
 
     if (m_exts.IMG_context_priority) {
         Log::logger->log(Log::DEBUG, "EGL: IMG_context_priority supported, requesting high");
@@ -171,6 +172,12 @@ void CHyprOpenGLImpl::initEGL(bool gbm) {
         Log::logger->log(Log::DEBUG, "EGL: EXT_create_context_robustness supported, requesting lose on reset");
         attrs.push_back(EGL_CONTEXT_OPENGL_RESET_NOTIFICATION_STRATEGY_EXT);
         attrs.push_back(EGL_LOSE_CONTEXT_ON_RESET_EXT);
+    }
+
+    if (m_exts.KHR_context_flush_control) {
+        Log::logger->log(Log::DEBUG, "EGL: Using KHR_context_flush_control");
+        attrs.push_back(EGL_CONTEXT_RELEASE_BEHAVIOR_KHR);
+        attrs.push_back(EGL_CONTEXT_RELEASE_BEHAVIOR_NONE_KHR); // or _FLUSH_KHR
     }
 
     auto attrsNoVer = attrs;

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -361,6 +361,7 @@ class CHyprOpenGLImpl {
         bool EXT_read_format_bgra               = false;
         bool EXT_image_dma_buf_import           = false;
         bool EXT_image_dma_buf_import_modifiers = false;
+        bool KHR_context_flush_control          = false;
         bool KHR_display_reference              = false;
         bool IMG_context_priority               = false;
         bool EXT_create_context_robustness      = false;


### PR DESCRIPTION
EGL_CONTEXT_RELEASE_BEHAVIOR_KHR determines what happends with implicit flushes when context changes, on multigpu scenario we change context frequently when blitting content. while we still rely on explicit sync fences, the flush is destroying driver optimisations.

setting it to EGL_CONTEXT_RELEASE_BEHAVIOR_NONE_KHR essentially mean just swap context and continue processing on the next context.

might require some various dual gpu testing so this implicit flush wasnt something we relied on, here it upped the blitting performance by 6 times, glmark went from 900 to 6200 score. the cpu usage went from ~90% to mere ~10% when blitting.

with the aq pr: https://github.com/hyprwm/aquamarine/pull/234


