### PR TITLE
fix(xwm): prevent onWrite infinite loop and clean orphan transfers

### DIFF
--- a/src/xwayland/XWM.hpp
+++ b/src/xwayland/XWM.hpp
@@ -35,9 +35,9 @@ struct SXTransfer {
 
     xcb_selection_request_event_t  request;
 
-    int                            propertyStart;
-    xcb_get_property_reply_t*      propertyReply;
-    xcb_window_t                   incomingWindow;
+    int                            propertyStart  = 0;
+    xcb_get_property_reply_t*      propertyReply  = nullptr;
+    xcb_window_t                   incomingWindow = 0;
 
     bool                           getIncomingSelectionProp(bool erase);
 };
@@ -54,6 +54,7 @@ struct SXSelection {
     bool             sendData(xcb_selection_request_event_t* e, std::string mime);
     int              onRead(int fd, uint32_t mask);
     int              onWrite();
+    void             removeTransfer(xcb_window_t window);
 
     struct {
         CHyprSignalListener setSelection;
@@ -163,6 +164,8 @@ class CXWM {
     void         handleFocusIn(xcb_focus_in_event_t* e);
     void         handleFocusOut(xcb_focus_out_event_t* e);
     void         handleError(xcb_value_error_t* e);
+
+    void         removeTransfersForWindow(xcb_window_t window);
 
     bool         handleSelectionEvent(xcb_generic_event_t* e);
     void         handleSelectionNotify(xcb_selection_notify_event_t* e);


### PR DESCRIPTION
Fixes #11411

  #### Describe your PR, what does it fix/add?

  Fixes `SXSelection::onWrite` infinite loop that causes 100% CPU usage on a single core.

  **Changes:**
  - Add early return in `onWrite()` after completing non-incremental transfers
  - Clean orphan transfers when windows are destroyed or property notify fails
  - Fix race condition in `getTransferData` by caching window ID before transfer erasure

  #### Is there anything you want to mention?

  This addresses the reported symptoms:
  - 100% CPU usage on single core causing overheating (up to 99°C)
  - Log spam filling tmpfs (`[ERR] [xwm] No transfer with property data found`)
  - Clipboard operations hanging between XWayland and Wayland apps

  The root cause was `onWrite()` continuing to poll after transfer completion, combined with orphan transfers accumulating when windows were destroyed mid-transfer.

  #### Is it ready for merging, or does it need work?

  Ready for review and merging.