### PR TITLE
Add openSUSE motto "Have a lot of fun!" to Splashes.hpp

### DIFF
--- a/src/helpers/Splashes.hpp
+++ b/src/helpers/Splashes.hpp
@@ -101,6 +101,7 @@ namespace NSplashes {
         "Demons come at night and they bring the end",
         "All I wanna say is that they don't really care about us",
         "Has he lost his mind? Can he see or is he blind?",
+        "\"Have a lot of fun!\" - openSUSE",
         // clang-format on
     };
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Hello Hyprland devs!

I'm working on a hyprland pattern for openSUSE (Predefined group with hyprland plugins, waybar, openSUSE branding etc). We need pattern so hyprland is listed in our new installer as an install option.
https://build.opensuse.org/project/show/home:lkocman:hyprland

I noticed there were some AUR related quotes on the startup. I just thought it would be very nice to have an openSUSE motto "Have a lot of fun!" ocassionally flashing there to cheer up our users.

Lubos

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nope

#### Is it ready for merging, or does it need work?

Ready to merge