### PR TITLE
layout: fix window position snap before drag_threshold reached

### DIFF
--- a/src/layout/supplementary/DragController.cpp
+++ b/src/layout/supplementary/DragController.cpp
@@ -58,15 +58,15 @@ bool CDragStateController::updateDragWindow() {
     m_draggingTiled                   = false;
     m_draggingWindowOriginalFloatSize = DRAGGINGTARGET->lastFloatingSize();
 
-    if (WAS_FULLSCREEN && DRAGGINGTARGET->floating()) {
+    if (WAS_FULLSCREEN && DRAGGINGTARGET->floating() && m_dragThresholdReached) {
         const auto MOUSECOORDS = g_pInputManager->getMouseCoordsInternal();
         DRAGGINGTARGET->setPositionGlobal(CBox{MOUSECOORDS - DRAGGINGTARGET->position().size() / 2.F, DRAGGINGTARGET->position().size()});
     } else if (!DRAGGINGTARGET->floating() && m_dragMode == MBIND_MOVE) {
         Vector2D MINSIZE = DRAGGINGTARGET->minSize().value_or(Vector2D{MIN_WINDOW_SIZE, MIN_WINDOW_SIZE});
         DRAGGINGTARGET->rememberFloatingSize((DRAGGINGTARGET->position().size() * 0.8489).clamp(MINSIZE, Vector2D{}).floor());
-        DRAGGINGTARGET->setPositionGlobal(CBox{g_pInputManager->getMouseCoordsInternal() - DRAGGINGTARGET->position().size() / 2.F, DRAGGINGTARGET->position().size()});
 
         if (m_dragThresholdReached) {
+            DRAGGINGTARGET->setPositionGlobal(CBox{g_pInputManager->getMouseCoordsInternal() - DRAGGINGTARGET->position().size() / 2.F, DRAGGINGTARGET->position().size()});
             g_layoutManager->changeFloatingMode(DRAGGINGTARGET);
             m_draggingTiled = true;
         }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

  Fixes a regression introduced in v0.53.0 where windows would immediately snap to the cursor
  position on mouse button press, even before the `drag_threshold` was exceeded. This caused both
  `bindm` (drag) and `bindc` (click) actions to trigger simultaneously when using the same button.

  **Root Cause:**
  The issue was in `IHyprLayout::updateDragWindow()` where window position was unconditionally set to
   the mouse cursor location before checking if `m_dragThresholdReached` was true.

  **Changes:**
  - Guard fullscreen floating window repositioning (line 1023) with `m_dragThresholdReached` check
  - Move tiled-to-floating window repositioning (line 1029) inside the existing
  `m_dragThresholdReached` conditional block

  **Testing:**
  Tested with configuration:
  ```conf
  binds {
      drag_threshold = 50
  }

  bindm = , mouse:274, movewindow
  bindc = , mouse:274, workspace, r+1
```

  Before fix: Window snaps to cursor immediately on button press, both actions trigger.
  After fix: Window only moves after dragging past 50 pixels, click action fires if released within
  threshold.

  Resolves: https://github.com/hyprwm/Hyprland/discussions/12796

  Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking
  compatibility, etc.)

  The fix only affects behavior when drag_threshold > 0. When drag_threshold = 0 (disabled), behavior
   remains unchanged as m_dragThresholdReached is set to true in onBeginDragWindow().

  Is it ready for merging, or does it need work?

  Ready for merging. The fix is minimal, well-tested, and restores the intended behavior of
  drag_threshold without breaking compatibility.