### PR TITLE
managers: fix movefocus wrapping with reserved areas/gaps

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1538,7 +1538,12 @@ SDispatchResult CKeybindManager::moveFocusTo(std::string args) {
     } else if (STICKS(PLASTWINDOW->m_position.y, PMONITOR->m_position.y) && STICKS(PLASTWINDOW->m_size.y, PMONITOR->m_size.y))
         return {.success = false, .error = "move does not make sense, would return back"};
 
-    CBox box = PMONITOR->logicalBox();
+    const auto PWORKSPACE = PLASTWINDOW->m_pWorkspace.lock();
+
+    CBox       box = g_pLayoutManager->getCurrentLayout()->workAreaOnWorkspace(PWORKSPACE);
+
+    if (box.width <= 0 || box.height <= 0)
+        box = PMONITOR->logicalBox();
     switch (arg) {
         case 'l':
             box.x += box.w;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?
I found a regression introduced in [`9264436f`](https://github.com/hyprwm/Hyprland/commit/9264436f) where the wrapping search of the movefocus dispatcher uses `PMONITOR->logicalBox()` which does not account for outer gaps or reserved area. Making the wrapping think that it `STICKS` only when both of these are set to 0. 

This switches the dispatcher to use the layout's `workAreaOnWorkspace` which should fix it.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I believe this needs some testing on dwindle and master layouts which I didn't check yet.

#### Is it ready for merging, or does it need work?
No, I want to test dwindle and master. I also trying to wrap my head around hyprtester as I intend to write a test for this.

