### PR TITLE
Fix edge grab resize logic for gaps_out > 0

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1038,6 +1038,8 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
             if (!w->m_isFloating && w->m_isMapped && w->workspaceID() == WSPID && !w->isHidden() && !w->m_X11ShouldntFocus && !w->m_ruleApplicator->noFocus().valueOrDefault() &&
                 w != pIgnoreWindow && !isShadowedByModal(w)) {
                 CBox box = (properties & Desktop::View::USE_PROP_TILED) ? w->getWindowBoxUnified(properties) : CBox{w->m_position, w->m_size};
+                if ((properties & Desktop::View::INPUT_EXTENTS) && BORDER_GRAB_AREA > 0 && !w->isX11OverrideRedirect())
+                    box.expand(BORDER_GRAB_AREA);
                 if (box.containsPoint(pos))
                     return w;
             }


### PR DESCRIPTION
Fix mouse edge grab detection for tiled windows when resize_on_border is true and gaps_out > 0.