### PR TITLE
monitor: revert "remove disconnected monitor before unsafe state #12544"

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -411,7 +411,6 @@ void CMonitor::onDisconnect(bool destroy) {
         m_layerSurfaceLayers[i].clear();
     }
 
-    std::erase_if(g_pCompositor->m_monitors, [&](PHLMONITOR& el) { return el.get() == this; });
     Log::logger->log(Log::DEBUG, "Removed monitor {}!", m_name);
 
     if (!BACKUPMON) {
@@ -463,7 +462,7 @@ void CMonitor::onDisconnect(bool destroy) {
         PHLMONITOR pMonitorMostHz = nullptr;
 
         for (auto const& m : g_pCompositor->m_monitors) {
-            if (m->m_refreshRate > mostHz) {
+            if (m->m_refreshRate > mostHz && m != m_self) {
                 pMonitorMostHz = m;
                 mostHz         = m->m_refreshRate;
             }
@@ -471,6 +470,8 @@ void CMonitor::onDisconnect(bool destroy) {
 
         g_pHyprRenderer->m_mostHzMonitor = pMonitorMostHz;
     }
+
+    std::erase_if(g_pCompositor->m_monitors, [&](PHLMONITOR& el) { return el.get() == this; });
 }
 
 void CMonitor::applyCMType(NCMType::eCMType cmType, int cmSdrEotf) {


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

#12544 causes more problems than it solves, as entering unsafe state with a pinned window causes a crash as the window's `m_workspace` becomes null when the workspace is moved to `unsafeOutput`  in`CCompositor::moveWorkspaceToMonitor` which expects the disconnected monitor to be there when creating a new workspace.

which is then dereferenced in `CWindow::commitWindow()`

I assume #12544 also caused other issues maybe not immediately obvious.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

~~Well, the original issue with mirror being applied to unsafeOutput is back. Idk what to do here tbh, maybe disallow monitor rules for unsafeOutput with `CMonitor::onConnect(true)`?~~
nvm I can no longer repro
#### Is it ready for merging, or does it need work?

should be

