### PR TITLE
xwl: get supported props on constructing surface

### DIFF
--- a/src/xwayland/XSurface.hpp
+++ b/src/xwayland/XSurface.hpp
@@ -118,5 +118,7 @@ class CXWaylandSurface {
         CHyprSignalListener commitSurface;
     } m_listeners;
 
+    std::unordered_map<xcb_atom_t, bool> m_supportedProps;
+
     friend class CXWM;
 };


### PR DESCRIPTION
not all clients supports WM_DELETE_WINDOW like glxgears, so get supported props in constuctor of surface, and if not supported forcefully kill the client.

fixes killactive on glxgears and other xwl clients that does not support WM_DELETE_WINDOW

