### PR TITLE
buffer: add move constructor and operator to CHLBufferReference

### DIFF
--- a/src/protocols/types/Buffer.cpp
+++ b/src/protocols/types/Buffer.cpp
@@ -59,6 +59,10 @@ CHLBufferReference::CHLBufferReference(const CHLBufferReference& other) : m_buff
         m_buffer->lock();
 }
 
+CHLBufferReference::CHLBufferReference(CHLBufferReference&& other) noexcept : m_buffer(std::move(other.m_buffer)) {
+    ;
+}
+
 CHLBufferReference::CHLBufferReference(SP<IHLBuffer> buffer_) : m_buffer(buffer_) {
     if (m_buffer)
         m_buffer->lock();
@@ -70,11 +74,24 @@ CHLBufferReference::~CHLBufferReference() {
 }
 
 CHLBufferReference& CHLBufferReference::operator=(const CHLBufferReference& other) {
+    if (m_buffer == other.m_buffer)
+        return *this; // same buffer, do nothing
+
     if (other.m_buffer)
         other.m_buffer->lock();
     if (m_buffer)
         m_buffer->unlock();
     m_buffer = other.m_buffer;
+    return *this;
+}
+
+CHLBufferReference& CHLBufferReference::operator=(CHLBufferReference&& other) {
+    if (this != &other) {
+        if (m_buffer)
+            m_buffer->unlock();
+        m_buffer       = other.m_buffer;
+        other.m_buffer = nullptr;
+    }
     return *this;
 }
 

--- a/src/protocols/types/Buffer.hpp
+++ b/src/protocols/types/Buffer.hpp
@@ -49,10 +49,13 @@ class CHLBufferReference {
   public:
     CHLBufferReference();
     CHLBufferReference(const CHLBufferReference& other);
+    CHLBufferReference(CHLBufferReference&& other) noexcept;
     CHLBufferReference(SP<IHLBuffer> buffer);
     ~CHLBufferReference();
 
     CHLBufferReference& operator=(const CHLBufferReference& other);
+    CHLBufferReference& operator=(CHLBufferReference&& other);
+
     bool                operator==(const CHLBufferReference& other) const;
     bool                operator==(const SP<IHLBuffer>& other) const;
     bool                operator==(const SP<Aquamarine::IBuffer>& other) const;


### PR DESCRIPTION
add missing move constructor and operator, a lot of churn was done on always copying CHLBufferReference, also add a self copy check.


