### PR TITLE
hyprerror: add padding & adjust for scale when reserving area

### DIFF
--- a/src/hyprerror/HyprError.cpp
+++ b/src/hyprerror/HyprError.cpp
@@ -168,7 +168,8 @@ void CHyprError::createQueued() {
         m->m_reservedArea.resetType(Desktop::RESERVED_DYNAMIC_TYPE_ERROR_BAR);
     }
 
-    PMONITOR->m_reservedArea.addType(Desktop::RESERVED_DYNAMIC_TYPE_ERROR_BAR, Vector2D{0.0, *BAR_POSITION == 0 ? HEIGHT : 0.0}, Vector2D{0.0, *BAR_POSITION != 0 ? HEIGHT : 0.0});
+    const auto RESERVED = (HEIGHT + PAD) / SCALE;
+    PMONITOR->m_reservedArea.addType(Desktop::RESERVED_DYNAMIC_TYPE_ERROR_BAR, Vector2D{0.0, TOPBAR ? RESERVED : 0.0}, Vector2D{0.0, !TOPBAR ? RESERVED : 0.0});
 
     for (const auto& m : g_pCompositor->m_monitors) {
         g_pHyprRenderer->arrangeLayersForMonitor(m->m_id);


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->



#### Describe your PR, what does it fix/add?

Fix cases where the error bar covers part of the window or top bar with scales <= 1, or when it reserves more area than it needs on scales > 1

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
noting

#### Is it ready for merging, or does it need work?
yea

