### PR TITLE
xwl: ensure NO_XWAYLAND builds

### DIFF
--- a/src/xwayland/XSurface.hpp
+++ b/src/xwayland/XSurface.hpp
@@ -11,6 +11,7 @@ class CXWaylandSurfaceResource;
 #ifdef NO_XWAYLAND
 using xcb_pixmap_t         = uint32_t;
 using xcb_window_t         = uint32_t;
+using xcb_atom_t           = uint32_t;
 using xcb_icccm_wm_hints_t = struct {
     int32_t      flags;
     uint32_t     input;


### PR DESCRIPTION
add , using xcb_atom_t = uint32_t;

fixes: https://github.com/hyprwm/Hyprland/discussions/13159


