### PR TITLE
opengl: add debug:gl_debugging

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1753,6 +1753,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SBoolData{false},
     },
     SConfigOptionDescription{
+        .value       = "debug:gl_debugging",
+        .description = "enable OpenGL debugging and error checking, they hurt performance.",
+        .type        = CONFIG_OPTION_BOOL,
+        .data        = SConfigOptionDescription::SBoolData{false},
+    },
+    SConfigOptionDescription{
         .value       = "debug:disable_logs",
         .description = "disable logging to a file",
         .type        = CONFIG_OPTION_BOOL,

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -561,6 +561,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("debug:overlay", Hyprlang::INT{0});
     registerConfigVar("debug:damage_blink", Hyprlang::INT{0});
     registerConfigVar("debug:pass", Hyprlang::INT{0});
+    registerConfigVar("debug:gl_debugging", Hyprlang::INT{0});
     registerConfigVar("debug:disable_logs", Hyprlang::INT{1});
     registerConfigVar("debug:disable_time", Hyprlang::INT{1});
     registerConfigVar("debug:enable_stdout_logs", Hyprlang::INT{0});

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -96,10 +96,13 @@
 #define GLCALL(__CALL__)                                                                                                                                                           \
     {                                                                                                                                                                              \
         __CALL__;                                                                                                                                                                  \
-        auto err = glGetError();                                                                                                                                                   \
-        if (err != GL_NO_ERROR) {                                                                                                                                                  \
-            Log::logger->log(Log::ERR, "[GLES] Error in call at {}@{}: 0x{:x}", __LINE__,                                                                                          \
-                             ([]() constexpr -> std::string { return std::string(__FILE__).substr(std::string(__FILE__).find_last_of('/') + 1); })(), err);                        \
+        static const auto GLDEBUG = CConfigValue<Hyprlang::INT>("debug:gl_debugging");                                                                                             \
+        if (*GLDEBUG) {                                                                                                                                                            \
+            auto err = glGetError();                                                                                                                                               \
+            if (err != GL_NO_ERROR) {                                                                                                                                              \
+                Log::logger->log(Log::ERR, "[GLES] Error in call at {}@{}: 0x{:x}", __LINE__,                                                                                      \
+                                 ([]() constexpr -> std::string { return std::string(__FILE__).substr(std::string(__FILE__).find_last_of('/') + 1); })(), err);                    \
+            }                                                                                                                                                                      \
         }                                                                                                                                                                          \
     }
 


### PR DESCRIPTION
add debug:gl_debugging so we can disable gl debugging entirerly, both glGetError and enabling EGL_KHR_debug has its cost, we still have EXT_create_context_robustness and glGetGraphicsResetStatus that should catch context loss, and is generally cheap to call it only checks a flag set.

glGetError might cause a implicit flush to get any pending calls sent to the gpu.

however to get EGL_KHR_debug back enabled we now require a restart of the compositor after changing debug:disable_gl_debugging


