### PR TITLE
Fix DS deactivation

### DIFF
--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -177,6 +177,7 @@ class CMonitor {
 
     // for direct scanout
     PHLWINDOWREF m_lastScanout;
+    bool         m_directScanoutIsActive    = false; // for cleanup logic. m_lastScanout.expired() can become true before the DS cleanup if client crashes/exits while DS is active.
     bool         m_scanoutNeedsCursorUpdate = false;
 
     // for special fade/blur

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1315,10 +1315,12 @@ void CHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     bool shouldTear = pMonitor->updateTearing();
 
     if (pMonitor->attemptDirectScanout()) {
+        pMonitor->m_directScanoutIsActive = true;
         return;
-    } else if (!pMonitor->m_lastScanout.expired()) {
+    } else if (!pMonitor->m_lastScanout.expired() || pMonitor->m_directScanoutIsActive) {
         Log::logger->log(Log::DEBUG, "Left a direct scanout.");
         pMonitor->m_lastScanout.reset();
+        pMonitor->m_directScanoutIsActive = false;
 
         // reset DRM format, but only if needed since it might modeset
         if (pMonitor->m_output->state->state().drmFormat != pMonitor->m_prevDrmFormat)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes DS deactivation when `m_lastScanout` goes away before the deactivation logic leaving output with an incorrect drm format.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
Ready
