### PR TITLE
Allow matching monitor rules by mode

### DIFF
--- a/hyprtester/src/tests/main/monitors.cpp
+++ b/hyprtester/src/tests/main/monitors.cpp
@@ -1,0 +1,53 @@
+#include "tests.hpp"
+#include "../../shared.hpp"
+#include "../../hyprctlCompat.hpp"
+#include "../shared.hpp"
+
+static int ret = 0;
+
+static bool test() {
+    NLog::log("{}Testing monitor mode: and desc: selectors", Colors::GREEN);
+
+    std::string monitorsSpec = getFromSocket("j/monitors");
+    EXPECT_CONTAINS(monitorsSpec, "HEADLESS-2");
+
+    NLog::log("{}Testing mode: selector (matching)", Colors::YELLOW);
+
+    OK(getFromSocket("/reload"));
+    OK(getFromSocket("/keyword monitor ,preferred,auto,2"));
+    OK(getFromSocket("/keyword monitor mode:1920x1080,preferred,auto,1"));
+
+    monitorsSpec = getFromSocket("j/monitors");
+    EXPECT_CONTAINS(monitorsSpec, R"("scale": 1.00)");
+
+    NLog::log("{}Testing mode: selector (non-matching)", Colors::YELLOW);
+
+    OK(getFromSocket("/reload"));
+    OK(getFromSocket("/keyword monitor ,preferred,auto,2"));
+    OK(getFromSocket("/keyword monitor mode:2560x1440,preferred,auto,1"));
+
+    monitorsSpec = getFromSocket("j/monitors");
+    EXPECT_CONTAINS(monitorsSpec, R"("scale": 2.00)");
+
+    NLog::log("{}Testing desc: selector (matching)", Colors::YELLOW);
+
+    OK(getFromSocket("/reload"));
+    OK(getFromSocket("/keyword monitor ,preferred,auto,2"));
+    OK(getFromSocket("/keyword monitor desc:,preferred,auto,1"));
+
+    monitorsSpec = getFromSocket("j/monitors");
+    EXPECT_CONTAINS(monitorsSpec, R"("scale": 1.00)");
+
+    NLog::log("{}Testing desc: selector (non-matching)", Colors::YELLOW);
+
+    OK(getFromSocket("/reload"));
+    OK(getFromSocket("/keyword monitor ,preferred,auto,2"));
+    OK(getFromSocket("/keyword monitor desc:NonExistent,preferred,auto,1"));
+
+    monitorsSpec = getFromSocket("j/monitors");
+    EXPECT_CONTAINS(monitorsSpec, R"("scale": 2.00)");
+
+    return !ret;
+}
+
+REGISTER_TEST_FN(test)

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1068,6 +1068,14 @@ bool CMonitor::matchesStaticSelector(const std::string& selector) const {
         const auto DESCRIPTIONSELECTOR = trim(selector.substr(5));
 
         return m_description.starts_with(DESCRIPTIONSELECTOR) || m_shortDescription.starts_with(DESCRIPTIONSELECTOR);
+    } else if (selector.starts_with("mode:")) {
+        // match by available mode
+        const auto MODESELECTOR = trim(selector.substr(5));
+
+        return std::ranges::any_of(m_output->modes, [&MODESELECTOR](const auto& mode) {
+            const auto MODESTR = std::format("{}x{}@{:.2f}Hz", mode->pixelSize.x, mode->pixelSize.y, mode->refreshRate / 1000.0);
+            return MODESTR.starts_with(MODESELECTOR);
+        });
     } else {
         // match by selector
         return m_name == selector;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Adds a "mode:" matcher prefix to monitor rules, in a similar style as the existing "desc:" matcher prefix. A rule using "mode:" will match a monitor that supports that mode.

Modes are matched as `starts_with` so they can include or omit the refresh rate portion as necessary.

An example rule could be:

    monitor=mode:3840x2160,preferred,auto,2

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This feature was prompted by trying to get Apple monitors (Studio Display & Pro XDR) to work over Thunderbolt. For some broken MST reason, both of those devices actually report themselves as two separate monitors, but with identical serial, description etc. They show up as both a) working monitor with all the expected modes, and b) broken one with only a few low-res modes. If the broken one is left enabled, it results in a sort of ghost workspace you can never see.

Since the ports can change between sessions, and the serial/desc/etc matches, we can't differentiate between them in the config. But if we can target the modes, we can do something like this:

    monitor=desc:Apple Computer Inc StudioDisplay,disable
    monitor=mode:5120x2880,preferred,auto,2

#### Is it ready for merging, or does it need work?

I've been running this patch for a few days and it's been stable for me. I also added a test for the new behaviour. I think it's good to go, but happy to take feedback.