### PR TITLE
desktop/window: guard against nullptr monitor in onUpdateState

### DIFF
--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -1335,6 +1335,8 @@ void CWindow::onUpdateState() {
         if (requestsID.has_value() && (requestsID.value() != MONITOR_INVALID) && !(m_suppressedEvents & SUPPRESS_FULLSCREEN_OUTPUT)) {
             if (m_isMapped) {
                 const auto monitor = g_pCompositor->getMonitorFromID(requestsID.value());
+                if (!monitor)
+                    return;
                 g_pCompositor->moveWindowToWorkspaceSafe(m_self.lock(), monitor->m_activeWorkspace);
                 Desktop::focusState()->rawMonitorFocus(monitor);
             }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes a crash (`SIGABRT` via `std::bad_any_cast`) when a DisplayPort monitor disconnects during DPMS sleep/wake.

When `onUpdateState()` fires during a surface commit, it calls `getMonitorFromID()` using a stale `MONITORID` from `requestsFullscreenMonitor`. The monitor has already been destroyed by Aquamarine's connector disconnect handler, so `getMonitorFromID()` returns `nullptr`. Dereferencing it on `monitor->m_activeWorkspace` crashes Hyprland.

This adds a `nullptr` guard consistent with how other callsites handle `getMonitorFromID()` (e.g. `Compositor.cpp:2440`).

**Crash backtrace:**
```
std::__throw_bad_any_cast()
CXDGToplevelResource::setMaximized(bool)
CWLSurfaceResource::commitState(SSurfaceState&)
CSurfaceStateQueue::tryProcess()
CEventLoopManager::enterLoop()
```

**Trigger:** Any DP link state change that causes Aquamarine to call `SDRMConnector::disconnect()` — DPMS off/on, monitor power cycling, even another device waking the monitor on a different input.

**Tested on:** v0.53.3, NVIDIA RTX 2060, dual monitor (DP-3 2560x1440@165Hz + HDMI-A-1 1920x1080@60Hz). Confirmed the Aquamarine disconnect/reconnect cycle still occurs in the logs but Hyprland no longer crashes.

Related: #12884, #12758

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

The underlying trigger is in Aquamarine — `recheckOutputs()` treats a DPMS-off DP link drop as a real physical disconnect. That should also be addressed long-term, but Hyprland should handle a gone monitor gracefully regardless. Monitors can disappear for many reasons (cable unplug, GPU reset, KVM switch), so the guard is warranted either way.

#### Is it ready for merging, or does it need work?

Ready. Two-line fix, clang-format clean, tested and confirmed working.
