### PR TITLE
desktop/window: guard against nullptr monitor and workspace in surfac…

### DIFF
--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -1335,6 +1335,8 @@ void CWindow::onUpdateState() {
         if (requestsID.has_value() && (requestsID.value() != MONITOR_INVALID) && !(m_suppressedEvents & SUPPRESS_FULLSCREEN_OUTPUT)) {
             if (m_isMapped) {
                 const auto monitor = g_pCompositor->getMonitorFromID(requestsID.value());
+                if (!monitor)
+                    return;
                 g_pCompositor->moveWindowToWorkspaceSafe(m_self.lock(), monitor->m_activeWorkspace);
                 Desktop::focusState()->rawMonitorFocus(monitor);
             }
@@ -2590,7 +2592,7 @@ void CWindow::commitWindow() {
             g_pHyprRenderer->damageWindow(m_self.lock());
     }
 
-    if (!m_workspace->m_visible)
+    if (!m_workspace || !m_workspace->m_visible)
         return;
 
     const auto PMONITOR = m_monitor.lock();


### PR DESCRIPTION
*Note: Reopened from a previous PR that only fixed the first crash path. Testing on hardware revealed a second crash path through `commitWindow()` that triggers under the same conditions, so this PR now covers both.*

#### Describe your PR, what does it fix/add?

Fixes two crashes triggered when a DisplayPort monitor disconnects during DPMS sleep/wake.

When Aquamarine processes a DP link drop as a disconnect, the output and its workspace are destroyed while pending surface commits still reference them. This causes crashes in two paths:

1. **`onUpdateState()`** — calls `getMonitorFromID()` with a stale `MONITORID` from `requestsFullscreenMonitor`, gets `nullptr`, and dereferences it on `monitor->m_activeWorkspace` (SIGABRT via `std::bad_any_cast`).

2. **`commitWindow()`** — dereferences `m_workspace->m_visible` when `m_workspace` has been destroyed along with the monitor (SIGSEGV).

Both fixes are nullptr guards consistent with existing checks elsewhere in the codebase (`getMonitorFromID()` at Compositor.cpp:2440, `m_workspace` at Window.cpp:249).

**Crash backtraces:**

Crash 1 — `onUpdateState`:
```
std::__throw_bad_any_cast()
CXDGToplevelResource::setMaximized(bool)
CWLSurfaceResource::commitState(SSurfaceState&)
CSurfaceStateQueue::tryProcess()
CEventLoopManager::enterLoop()
```

Crash 2 — `commitWindow`:
```
handleUnrecoverableSignal(int)
CWindow::commitWindow() [clone .cold]
CXDGSurfaceResource (surfaceCommit lambda)
CWLSurfaceResource::commitState(SSurfaceState&)
CSurfaceStateQueue::tryProcess()
CEventLoopManager::enterLoop()
```

**Trigger:** Any DP link state change that causes Aquamarine to call `SDRMConnector::disconnect()` — DPMS off/on, monitor power cycling, even another device waking the monitor on a different input.

**Tested on:** v0.53.3, NVIDIA RTX 2060, dual monitor (DP-3 2560x1440@165Hz + HDMI-A-1 1920x1080@60Hz). Confirmed the Aquamarine disconnect/reconnect cycle still occurs in the logs but Hyprland no longer crashes.

Related: #12884, #12758

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

The underlying trigger is in Aquamarine — `recheckOutputs()` treats a DPMS-off DP link drop as a real physical disconnect. That should also be addressed long-term, but Hyprland should handle a gone monitor gracefully regardless. Monitors can disappear for many reasons (cable unplug, GPU reset, KVM switch), so the guards are warranted either way.

#### Is it ready for merging, or does it need work?

Ready. Three lines changed in one file, clang-format clean, both crash paths tested and confirmed fixed.
