### PR TITLE
i18n: add Traditional Chinese (zh_TW) translations

### DIFF
--- a/src/i18n/Engine.cpp
+++ b/src/i18n/Engine.cpp
@@ -1142,6 +1142,17 @@ I18n::CI18nEngine::CI18nEngine() {
     huEngine->registerEntry("zh_CN", TXT_KEY_NOTIF_FAILED_TO_LOAD_PLUGIN, "无法加载插件 {name}：{error}");
     huEngine->registerEntry("zh_CN", TXT_KEY_NOTIF_CM_RELOAD_FAILED, "无法重新加载CM着色器，将使用rgba/rgbx兜底。");
     huEngine->registerEntry("zh_CN", TXT_KEY_NOTIF_WIDE_COLOR_NOT_10B, "显示器 {name}：宽色域被启用了，但是显示器并不在10-bit模式。");
+    huEngine->registerEntry("zh_CN", TXT_KEY_NOTIF_NO_WATCHDOG, "Hyprland 启动时未使用 start-hyprland。除非你处于调试环境，否则极度不推荐这样做。");
+
+    huEngine->registerEntry("zh_CN", TXT_KEY_SAFE_MODE_TITLE, "安全模式");
+    huEngine->registerEntry("zh_CN", TXT_KEY_SAFE_MODE_DESCRIPTION,
+                            "Hyprland "
+                            "已在安全模式下启动，这意味着你上次会话崩溃了。\n安全模式会阻止加载你的配置。你可以在此环境中进行故障排除，或者使用下方按钮加载你的配置。\n默认快"
+                            "捷键适用：SUPER+Q 打开 Kitty，SUPER+R 打开简易启动器，SUPER+M 退出。\n重新启动 "
+                            "Hyprland 将再次进入正常模式。");
+    huEngine->registerEntry("zh_CN", TXT_KEY_SAFE_MODE_BUTTON_LOAD_CONFIG, "加载配置");
+    huEngine->registerEntry("zh_CN", TXT_KEY_SAFE_MODE_BUTTON_OPEN_CRASH_REPORT_DIR, "打开崩溃报告目录");
+    huEngine->registerEntry("zh_CN", TXT_KEY_SAFE_MODE_BUTTON_UNDERSTOOD, "好的，关闭窗口");
 
     // zh_TW (Traditional Chinese)
     huEngine->registerEntry("zh_TW", TXT_KEY_ANR_TITLE, "應用程式沒有回應");


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This PR adds Traditional Chinese (`zh_TW`) translations to `src/i18n/Engine.cpp`.
Also fills in the missing translations for Simplified Chinese (zh_CN).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

The translation follows standard Traditional Chinese (Taiwan) computer terminology and localization habits (e.g., using `設定檔` for config, `螢幕` for screen, and `資源` for assets).
reference: https://hackmd.io/@l10n-tw/glossaries

#### Is it ready for merging, or does it need work?

Ready for merging.