### PR TITLE
fix: nix evaluation warnings, the xorg package set has been deprecated

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -25,6 +25,12 @@
   libdrm,
   libexecinfo,
   libinput,
+  libxcb,
+  libxcb-errors,
+  libxcb-render-util,
+  libxcb-wm,
+  libxdmcp,
+  libxcursor,
   libxkbcommon,
   libuuid,
   libgbm,
@@ -38,7 +44,6 @@
   wayland,
   wayland-protocols,
   wayland-scanner,
-  xorg,
   xwayland,
   debug ? false,
   withTests ? false,
@@ -161,11 +166,12 @@ in
           hyprutils
           hyprwire
           libdrm
+          libgbm
           libGL
           libinput
           libuuid
+          libxcursor
           libxkbcommon
-          libgbm
           muparser
           pango
           pciutils
@@ -175,16 +181,15 @@ in
           wayland
           wayland-protocols
           wayland-scanner
-          xorg.libXcursor
         ]
         (optionals customStdenv.hostPlatform.isBSD [epoll-shim])
         (optionals customStdenv.hostPlatform.isMusl [libexecinfo])
         (optionals enableXWayland [
-          xorg.libxcb
-          xorg.libXdmcp
-          xorg.xcbutilerrors
-          xorg.xcbutilrenderutil
-          xorg.xcbutilwm
+          libxcb
+          libxcb-errors
+          libxcb-render-util
+          libxcb-wm
+          libxdmcp
           xwayland
         ])
         (optional withSystemd systemd)

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -11,7 +11,7 @@ in {
         jq
         kitty
         wl-clipboard
-        xorg.xeyes
+        xeyes
       ];
 
       # Enabled by default for some reason


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

Fixes evaluation warnings introduced by **f16ebef00366d2f85499196b9c7fb702b9f1c547** due to the xorg package set being deprecated in nixpkgs.


Fixes the following warnings:
```
evaluation warning: The xorg package set has been deprecated, 'xorg.libXcursor' has been renamed to 'libxcursor'
evaluation warning: The xorg package set has been deprecated, 'xorg.libxcb' has been renamed to 'libxcb'
evaluation warning: The xorg package set has been deprecated, 'xorg.libXdmcp' has been renamed to 'libxdmcp'
evaluation warning: The xorg package set has been deprecated, 'xorg.xcbutilerrors' has been renamed to 'libxcb-errors'
evaluation warning: The xorg package set has been deprecated, 'xorg.xcbutilrenderutil' has been renamed to 'libxcb-render-util'
evaluation warning: The xorg package set has been deprecated, 'xorg.xcbutilwm' has been renamed to 'libxcb-wm'
```


