### PR TITLE
fix kinetic scroll

### DIFF
--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -935,10 +935,11 @@ void CPointerManager::attachPointer(SP<IPointer> pointer) {
         PROTO::idle->onActivity();
     });
 
-    listener->axis = pointer->m_pointerEvents.axis.listen([weak = WP<IPointer>(pointer)](const IPointer::SAxisEvent& event) {
+    listener->axis  = pointer->m_pointerEvents.axis.listen([weak = WP<IPointer>(pointer)](const IPointer::SAxisEvent& event) {
         g_pInputManager->onMouseWheel(event, weak.lock());
         PROTO::idle->onActivity();
     });
+    listener->frame = pointer->m_pointerEvents.frame.listen([] { g_pInputManager->onPointerFrame(); });
 
     listener->swipeBegin = pointer->m_pointerEvents.swipeBegin.listen([](const IPointer::SSwipeBeginEvent& event) {
         g_pInputManager->onSwipeBegin(event);

--- a/src/managers/PointerManager.hpp
+++ b/src/managers/PointerManager.hpp
@@ -93,6 +93,7 @@ class CPointerManager {
         CHyprSignalListener motionAbsolute;
         CHyprSignalListener button;
         CHyprSignalListener axis;
+        CHyprSignalListener frame;
 
         CHyprSignalListener swipeBegin;
         CHyprSignalListener swipeEnd;

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -952,6 +952,22 @@ void CInputManager::onMouseWheel(IPointer::SAxisEvent e, SP<IPointer> pointer) {
     int32_t deltaDiscrete = std::abs(discrete) != 0 && std::abs(discrete) < 1 ? std::copysign(1, discrete) : std::round(discrete);
 
     g_pSeatManager->sendPointerAxis(e.timeMs, e.axis, delta, deltaDiscrete, value120, e.source, WL_POINTER_AXIS_RELATIVE_DIRECTION_IDENTICAL);
+
+    const bool deferPointerFrame = e.source == WL_POINTER_AXIS_SOURCE_FINGER || e.source == WL_POINTER_AXIS_SOURCE_CONTINUOUS;
+    if (deferPointerFrame) {
+        m_pointerAxisFramePending = true;
+        return;
+    }
+
+    m_pointerAxisFramePending = false;
+    g_pSeatManager->sendPointerFrame();
+}
+
+void CInputManager::onPointerFrame() {
+    if (!m_pointerAxisFramePending)
+        return;
+
+    m_pointerAxisFramePending = false;
     g_pSeatManager->sendPointerFrame();
 }
 

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -91,6 +91,7 @@ class CInputManager {
     void               onMouseWarp(IPointer::SMotionAbsoluteEvent);
     void               onMouseButton(IPointer::SButtonEvent);
     void               onMouseWheel(IPointer::SAxisEvent, SP<IPointer> pointer = nullptr);
+    void               onPointerFrame();
     void               onKeyboardKey(const IKeyboard::SKeyEvent&, SP<IKeyboard>);
     void               onKeyboardMod(SP<IKeyboard>);
 
@@ -299,6 +300,7 @@ class CInputManager {
         uint32_t lastEventTime     = 0;
         uint32_t accumulatedScroll = 0;
     } m_scrollWheelState;
+    bool                  m_pointerAxisFramePending = false;
 
     bool                  shareKeyFromAllKBs(uint32_t key, bool pressed);
     uint32_t              shareModsFromAllKBs(uint32_t depressed);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
The immediate pointer frame dispatch introduced for VRR(https://github.com/hyprwm/Hyprland/pull/12665) improved cursor responsiveness, but it broke event framing for touchpad scrolling (notably kinetic scrolling in Chromium-based apps).
This PR keeps low-latency behavior while restoring proper frame-boundary handling for scroll events.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
ready