### PR TITLE
Add rotatesplit functionality to dwindle layout

### DIFF
--- a/hyprtester/src/tests/main/dwindle.cpp
+++ b/hyprtester/src/tests/main/dwindle.cpp
@@ -135,6 +135,98 @@ static void testSplit() {
     Tests::killAllWindows();
 }
 
+static void testRotatesplit() {
+    OK(getFromSocket("r/keyword general:gaps_in 0"));
+    OK(getFromSocket("r/keyword general:gaps_out 0"));
+    OK(getFromSocket("r/keyword general:border_size 0"));
+
+    for (auto const& win : {"a", "b"}) {
+        if (!Tests::spawnKitty(win)) {
+            NLog::log("{}Failed to spawn kitty with win class `{}`", Colors::RED, win);
+            ++TESTS_FAILED;
+            ret = 1;
+            return;
+        }
+    }
+
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_CONTAINS(str, "at: 0,0");
+        EXPECT_CONTAINS(str, "size: 960,1080");
+    }
+
+    // test 4 repeated rotations by 90 degrees
+    OK(getFromSocket("/dispatch layoutmsg rotatesplit"));
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_CONTAINS(str, "at: 0,0");
+        EXPECT_CONTAINS(str, "size: 1920,540");
+    }
+
+    OK(getFromSocket("/dispatch layoutmsg rotatesplit"));
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_CONTAINS(str, "at: 960,0");
+        EXPECT_CONTAINS(str, "size: 960,1080");
+    }
+
+    OK(getFromSocket("/dispatch layoutmsg rotatesplit"));
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_CONTAINS(str, "at: 0,540");
+        EXPECT_CONTAINS(str, "size: 1920,540");
+    }
+
+    OK(getFromSocket("/dispatch layoutmsg rotatesplit"));
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_CONTAINS(str, "at: 0,0");
+        EXPECT_CONTAINS(str, "size: 960,1080");
+    }
+
+    // test different angles
+    OK(getFromSocket("/dispatch layoutmsg rotatesplit 180"));
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_CONTAINS(str, "at: 960,0");
+        EXPECT_CONTAINS(str, "size: 960,1080");
+    }
+
+    OK(getFromSocket("/dispatch layoutmsg rotatesplit 270"));
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_CONTAINS(str, "at: 0,540");
+        EXPECT_CONTAINS(str, "size: 1920,540");
+    }
+
+    OK(getFromSocket("/dispatch layoutmsg rotatesplit 360"));
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_CONTAINS(str, "at: 0,0");
+        EXPECT_CONTAINS(str, "size: 1920,540");
+    }
+
+    // test negative angles
+    OK(getFromSocket("/dispatch layoutmsg rotatesplit -90"));
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_CONTAINS(str, "at: 0,0");
+        EXPECT_CONTAINS(str, "size: 960,1080");
+    }
+
+    OK(getFromSocket("/dispatch layoutmsg rotatesplit -180"));
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_CONTAINS(str, "at: 960,0");
+        EXPECT_CONTAINS(str, "size: 960,1080");
+    }
+
+    NLog::log("{}Killing all windows", Colors::YELLOW);
+    Tests::killAllWindows();
+
+    OK(getFromSocket("/reload"));
+}
+
 static bool test() {
     NLog::log("{}Testing Dwindle layout", Colors::GREEN);
 
@@ -147,6 +239,9 @@ static bool test() {
 
     NLog::log("{}Testing splits", Colors::GREEN);
     testSplit();
+
+    NLog::log("{}Testing rotatesplit", Colors::GREEN);
+    testRotatesplit();
 
     // clean up
     NLog::log("Cleaning up", Colors::YELLOW);

--- a/src/layout/algorithm/tiled/dwindle/DwindleAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/dwindle/DwindleAlgorithm.cpp
@@ -666,6 +666,19 @@ std::expected<void, std::string> CDwindleAlgorithm::layoutMsg(const std::string_
             if (!swapSplit(CURRENT_NODE))
                 return std::unexpected("can't swapsplit in the current workspace");
         }
+    } else if (ARGS[0] == "rotatesplit") {
+        if (CURRENT_NODE) {
+            int angle = 90;
+            if (!ARGS[1].empty()) {
+                try {
+                    angle = std::stoi(std::string{ARGS[1]});
+                } catch (const std::exception& e) {
+                    Log::logger->log(Log::WARN, "Invalid angle argument for rotatesplit: {}", ARGS[1]);
+                    return std::unexpected("Invalid angle argument");
+                }
+            }
+            rotateSplit(CURRENT_NODE, angle);
+        }
     } else if (ARGS[0] == "movetoroot") {
         auto node = CURRENT_NODE;
         if (!ARGS[1].empty()) {
@@ -758,6 +771,43 @@ bool CDwindleAlgorithm::swapSplit(SP<SDwindleNodeData> x) {
     x->pParent->recalcSizePosRecursive();
 
     return true;
+}
+
+void CDwindleAlgorithm::rotateSplit(SP<SDwindleNodeData> x, int angle) {
+    if (!x || !x->pParent)
+        return;
+
+    if (x->pTarget->fullscreenMode() != FSMODE_NONE)
+        return;
+
+    // normalize the angle to multiples of 90 degrees
+    int  normalizedAngle = ((sc<int>(angle / 90) % 4) + 4) % 4; // ensures positive modulo
+
+    auto pParent = x->pParent;
+
+    bool shouldSwap = false;
+
+    switch (normalizedAngle) {
+        case 0: // 0 degrees - no change
+            break;
+        case 1:
+            if (pParent->splitTop)
+                shouldSwap = true;
+            pParent->splitTop = !pParent->splitTop;
+            break;
+        case 2: shouldSwap = true; break;
+        case 3:
+            if (!pParent->splitTop)
+                shouldSwap = true;
+            pParent->splitTop = !pParent->splitTop;
+            break;
+        default: break; // should never happen
+    }
+
+    if (shouldSwap)
+        std::swap(pParent->children[0], pParent->children[1]);
+
+    pParent->recalcSizePosRecursive();
 }
 
 bool CDwindleAlgorithm::moveToRoot(SP<SDwindleNodeData> x, bool stable) {

--- a/src/layout/algorithm/tiled/dwindle/DwindleAlgorithm.hpp
+++ b/src/layout/algorithm/tiled/dwindle/DwindleAlgorithm.hpp
@@ -50,6 +50,7 @@ namespace Layout::Tiled {
 
         bool                    toggleSplit(SP<SDwindleNodeData>);
         bool                    swapSplit(SP<SDwindleNodeData>);
+        void                    rotateSplit(SP<SDwindleNodeData>, int angle = 90);
         bool                    moveToRoot(SP<SDwindleNodeData>, bool stable = true);
 
         Math::eDirection        m_overrideDirection = Math::DIRECTION_DEFAULT;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

Add new layout message to the Dwindle layout: `rotatesplit`. Instead of toggling between vertical or horizontal split, or swapping two halves of the split, it "rotates" the split around a center point by a specified angle (90 by default). It's one of the functions found in bspwm, and I (and presumably others) was very used to it, and found it's lacking from Hyprland after switching. https://man.archlinux.org/man/bspwm.1.en, search for `--rotate`.
Same result _can_ be achieved with togglesplit and swapsplit, but this allows to use one utility bind instead of fiddling with two. I find it easier to press one bind a couple of times to achieve orientation I want, instead of mindfully controlling how exactly I need to joggle the split with two commands to end up with the position I want.
It should be possible to replicate this with external script, but I found it to be a bit clunky, and it seemed useful enough to just add it, mirroring bspwm functionality.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I've tested it for a couple of days and it seems to function correctly, though it still needs to be documented

#### Is it ready for merging, or does it need work?
Ready

