### PR TITLE
compositor: guard null view() in getWindowFromSurface

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1185,7 +1185,7 @@ PHLWINDOW CCompositor::getWindowFromSurface(SP<CWLSurfaceResource> pSurface) {
 
     const auto VIEW = pSurface->m_hlSurface->view();
 
-    if (VIEW->type() != Desktop::View::VIEW_TYPE_WINDOW)
+    if (!VIEW || VIEW->type() != Desktop::View::VIEW_TYPE_WINDOW)
         return nullptr;
 
     return dynamicPointerCast<Desktop::View::CWindow>(VIEW);


### PR DESCRIPTION
`getWindowFromSurface` dereferences `view()` without a null check. Surfaces without a `Desktop::View` (e.g. `zwp_input_popup_surface_v2` popups) return null from `view()`, causing a SIGSEGV when scrolling over them.

Reproducible by scrolling the mouse wheel over an IME popup surface that uses `zwp_input_popup_surface_v2`.

PR #12772 fixed the same pattern in `processMouseDownNormal`. This fixes it in  `getWindowFromSurface` to cover all callers.


