### PR TITLE
cmake: use OpenGL::GLES3 when OpenGL::GL does not exist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,7 +476,11 @@ function(protocolWayland)
   set(PROTOCOL_SOURCES "${PROTOCOL_SOURCES}" PARENT_SCOPE)
 endfunction()
 
-target_link_libraries(hyprland_lib PUBLIC OpenGL::EGL OpenGL::GL Threads::Threads)
+if(TARGET OpenGL::GL)
+  target_link_libraries(hyprland_lib PUBLIC OpenGL::EGL OpenGL::GL Threads::Threads)
+else()
+  target_link_libraries(hyprland_lib PUBLIC OpenGL::EGL OpenGL::GLES3 Threads::Threads)
+endif()
 
 pkg_check_modules(hyprland_protocols_dep hyprland-protocols>=0.6.4)
 if(hyprland_protocols_dep_FOUND)


### PR DESCRIPTION
This will allow Hyprland to build on some systems without GLX.


#### Describe your PR, what does it fix/add?

On some systems, like my `-X` Gentoo system, the target `OpenGL::GL` does not exist. But thanks to Vaxry's confirmation in the discussion https://github.com/hyprwm/Hyprland/discussions/13254, Hyprland would still work as long as `OpenGL::GLES3` exists. This PR won't change anything on most systems with `OpenGL::GL`.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I have tested it on my Gentoo. Actually, even on systems with `OpenGL::GL`, the `libGL` would be cut during linking with `--as-needed`:
```
❯ readelf -d /usr/bin/Hyprland | rg 'GLES|EGL|OpenGL|libGL\.so'
 0x0000000000000001 (NEEDED)             Shared library: [libEGL.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libGLESv2.so.2]
 ```
So `OpenGL::GL` is probably not needed in general.


#### Is it ready for merging, or does it need work?

It should be ready.

