### PR TITLE
cm: block DS for scRGB in HDR mode

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1819,7 +1819,7 @@ uint16_t CMonitor::isDSBlocked(bool full) {
     const bool surfaceIsScRGB = surfaceIsHDR && PSURFACE->m_colorManagement->isWindowsScRGB();
 
     if (needsCM() && (*PNONSHADER != CM_NS_IGNORE || surfaceIsScRGB) && !canNoShaderCM() &&
-        ((inHDR() && (*PPASS == 0 || !surfaceIsHDR)) || (!inHDR() && (*PPASS != 1 || surfaceIsHDR))))
+        ((inHDR() && (*PPASS == 0 || !surfaceIsHDR || surfaceIsScRGB)) || (!inHDR() && (*PPASS != 1 || surfaceIsHDR))))
         reasons |= DS_BLOCK_CM;
 
     return reasons;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->

#### Describe your PR, what does it fix/add?

Conditions for enabling DS with `cm=hdr{edid}` only check that the source and destination are both HDR, but doesn't make a distinction for scRGB content, which we can't scan out yet. This leads to blown-out colors. Quick change to add the check.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Feels a little bad having two `surfaceIsScRGB` checks in there, but removing the first one would give bad output for `render:non_shader_cm = 3` (the default). Though, judging by its description (`disable and ignore CM issues`), maybe it should?

#### Is it ready for merging, or does it need work?

Ready
