### PR TITLE
fix xwayland artifact

### DIFF
--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -1607,7 +1607,8 @@ Vector2D CWindow::realToReportSize() {
     const auto  PMONITOR   = m_monitor.lock();
 
     if (*PXWLFORCESCALEZERO && PMONITOR)
-        return REPORTSIZE * PMONITOR->m_scale;
+        // Keep X11 configure sizes integral to avoid truncation (e.g. 2879.999 -> 2879) later in xcb.
+        return (REPORTSIZE * PMONITOR->m_scale).round();
 
     return REPORTSIZE;
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
I found a bug where applications launched via XWayland (for example, Minecraft when pressing F3) were reported with a resolution that was 1 pixel smaller than the actual window size.
After investigating, I found that an older fix (https://github.com/hyprwm/Hyprland/pull/3153) removed .round() from the resolution values reported to XWayland.
This was likely an incorrect fix. The renderer-side change should have been sufficient, but removing rounding from reported sizes as well appears to have caused this issue.
So, this patch partially restores the removed .round() and fixes the 1-pixel truncation that occurred during integer conversion of scaled sizes.
I also confirmed that this change does not reintroduce the issue reported in the past.

- firefox via XWayland
<img width="1244" height="737" alt="image" src="https://github.com/user-attachments/assets/c616cd3b-d805-4dbf-9941-fb93f7f137e1" />

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
ready
