### PR TITLE
Fix use-after-free in CommitTiming timer callback

### DIFF
--- a/src/protocols/CommitTiming.cpp
+++ b/src/protocols/CommitTiming.cpp
@@ -39,11 +39,11 @@ CCommitTimerResource::CCommitTimerResource(UP<CWpCommitTimerV1>&& resource_, SP<
         if (!state->timer) {
             state->timer = makeShared<CEventLoopTimer>(
                 state->pendingTimeout,
-                [this, state](SP<CEventLoopTimer> self, void* data) {
-                    if (!m_surface || !state)
+                [surface = m_surface, state](SP<CEventLoopTimer> self, void* data) {
+                    if (!surface || !state)
                         return;
 
-                    m_surface->m_stateQueue.unlock(state, LOCK_REASON_TIMER);
+                    surface->m_stateQueue.unlock(state, LOCK_REASON_TIMER);
                 },
                 nullptr);
             g_pEventLoopManager->addTimer(state->timer);


### PR DESCRIPTION
My Vulkan app was crashing Hyprland on window resize. Capturing `m_surface` by value in the timer lambda stops the callback from dereferencing a destroyed `CCommitTimerResource`


[backtrace.txt](https://github.com/user-attachments/files/25312404/backtrace.txt)
