### PR TITLE
Vulkan renderer WIP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,14 @@ include(CheckIncludeFile)
 include(GNUInstallDirs)
 
 set(HYPRLAND_VERSION ${VER})
+string(REPLACE "." ";" HYPRLAND_VERSION_LIST ${VER})
+list(GET HYPRLAND_VERSION_LIST 0 HYPRLAND_VERSION_MAJOR)
+list(GET HYPRLAND_VERSION_LIST 1 HYPRLAND_VERSION_MINOR)
+list(GET HYPRLAND_VERSION_LIST 2 HYPRLAND_VERSION_PATCH)
+set(HYPRLAND_VERSION_MAJOR "${HYPRLAND_VERSION_MAJOR}")
+set(HYPRLAND_VERSION_MINOR "${HYPRLAND_VERSION_MINOR}")
+set(HYPRLAND_VERSION_PATCH "${HYPRLAND_VERSION_PATCH}")
+
 set(PREFIX ${CMAKE_INSTALL_PREFIX})
 set(INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR})
 set(BINDIR ${CMAKE_INSTALL_BINDIR})
@@ -95,6 +103,9 @@ else()
 endif()
 
 add_compile_definitions(HYPRLAND_VERSION="${HYPRLAND_VERSION}")
+add_compile_definitions(HYPRLAND_VERSION_MAJOR=${HYPRLAND_VERSION_MAJOR})
+add_compile_definitions(HYPRLAND_VERSION_MINOR=${HYPRLAND_VERSION_MINOR})
+add_compile_definitions(HYPRLAND_VERSION_PATCH=${HYPRLAND_VERSION_PATCH})
 
 include_directories(. "src/" "protocols/")
 
@@ -128,6 +139,8 @@ find_package(Threads REQUIRED)
 
 set(GLES_VERSION "GLES3")
 find_package(OpenGL REQUIRED COMPONENTS ${GLES_VERSION})
+
+find_package(Vulkan COMPONENTS glslang)
 find_package(glslang CONFIG REQUIRED)
 
 set(AQUAMARINE_MINIMUM_VERSION 0.9.3)
@@ -509,9 +522,9 @@ function(protocolWayland)
 endfunction()
 
 if(TARGET OpenGL::GL)
-  target_link_libraries(hyprland_lib PUBLIC OpenGL::EGL OpenGL::GL glslang::glslang glslang::glslang-default-resource-limits glslang::SPIRV Threads::Threads)
+  target_link_libraries(hyprland_lib PUBLIC OpenGL::EGL OpenGL::GL Vulkan::Vulkan Vulkan::glslang glslang::glslang glslang::glslang-default-resource-limits glslang::SPIRV Threads::Threads)
 else()
-  target_link_libraries(hyprland_lib PUBLIC OpenGL::EGL OpenGL::GLES3 glslang::glslang glslang::glslang-default-resource-limits glslang::SPIRV Threads::Threads)
+  target_link_libraries(hyprland_lib PUBLIC OpenGL::EGL OpenGL::GLES3 Vulkan::Vulkan Vulkan::glslang glslang::glslang glslang::glslang-default-resource-limits glslang::SPIRV Threads::Threads)
 endif()
 
 pkg_check_modules(hyprland_protocols_dep hyprland-protocols>=0.6.4)

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -38,6 +38,8 @@
 #include "debug/crash/CrashReporter.hpp"
 #include "render/GLRenderer.hpp"
 #include "render/ShaderLoader.hpp"
+#include "render/VKRenderer.hpp"
+#include "render/vulkan/Vulkan.hpp"
 #ifdef USES_SYSTEMD
 #include <helpers/SdDaemon.hpp> // for SdNotify
 #endif
@@ -568,8 +570,13 @@ void CCompositor::cleanup() {
     m_workspaces.clear();
     m_windows.clear();
 
-    for (auto const& m : m_monitors) {
-        g_pHyprOpenGL->destroyMonitorResources(m);
+    if (g_pHyprRenderer) {
+        const auto gl = g_pHyprRenderer->glBackend();
+        if (gl) {
+            for (auto const& m : m_monitors) {
+                gl->destroyMonitorResources(m);
+            }
+        }
     }
 
     g_pXWayland.reset();
@@ -590,6 +597,7 @@ void CCompositor::cleanup() {
     g_pSessionLockManager.reset();
     g_pHyprRenderer.reset();
     g_pProtocolManager.reset();
+    Render::VK::g_pHyprVulkan.reset();
     g_pHyprOpenGL.reset();
     Render::g_pShaderLoader.reset();
     Config::mgr().reset();
@@ -664,8 +672,17 @@ void CCompositor::initManagers(eManagersInitStage stage) {
             Log::logger->log(Log::DEBUG, "Creating the CHyprOpenGLImpl!");
             g_pHyprOpenGL = makeUnique<CHyprOpenGLImpl>();
 
+            static auto PVKRENDERER = CConfigValue<Hyprlang::INT>("render:use_vulkan");
+            if (*PVKRENDERER) {
+                Log::logger->log(Log::DEBUG, "Creating the CHyprVulkanImpl!");
+                Render::VK::g_pHyprVulkan = makeUnique<Render::VK::CHyprVulkanImpl>();
+            }
+
             Log::logger->log(Log::DEBUG, "Creating the HyprRenderer!");
-            g_pHyprRenderer = makeUnique<CHyprGLRenderer>();
+            if (*PVKRENDERER)
+                g_pHyprRenderer = makeUnique<Render::VK::CHyprVKRenderer>();
+            else
+                g_pHyprRenderer = makeUnique<CHyprGLRenderer>();
 
             Log::logger->log(Log::DEBUG, "Creating the ProtocolManager!");
             g_pProtocolManager = makeUnique<CProtocolManager>();

--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -542,6 +542,7 @@ std::vector<SP<IValue>> Values::getConfigValues() {
         MS<Int>("render:non_shader_cm_interop", "non_shader_cm interaction with ctm proto (hyprsunset and similar).", 2,
                 {.min = 0, .max = 2, .map = OptionMap{{"disable", 0}, {"enable", 1}, {"auto", 2}}}),
         MS<Int>("render:fp16_sdr_tf", "Internal workbuffer transfer function for fp16 in SDR mode", 0, {.min = 0, .max = 1, .map = OptionMap{{"monitor", 0}, {"linear", 1}}}),
+        MS<Bool>("render:use_vulkan", "Use experimental vulkan renderer", false),
 
         /*
          * cursor:

--- a/src/helpers/Format.cpp
+++ b/src/helpers/Format.cpp
@@ -1,10 +1,155 @@
 #include "Format.hpp"
-#include <vector>
-#include "../includes.hpp"
-#include "debug/log/Logger.hpp"
-#include "../macros.hpp"
+#include <wayland-server-protocol.h>
 #include <xf86drm.h>
 #include <drm_fourcc.h>
+
+const std::map<DRMFormat, Render::VK::SVkFormatInfo> Render::VK::FORMATS = {
+    {
+        DRM_FORMAT_ARGB8888,
+        {
+            .drmFormat = DRM_FORMAT_ARGB8888,
+            .vkFormat  = VK_FORMAT_B8G8R8A8_UNORM,
+        },
+    },
+    {DRM_FORMAT_XRGB8888,
+     {
+         .drmFormat    = DRM_FORMAT_XRGB8888,
+         .vkFormat     = VK_FORMAT_B8G8R8A8_UNORM,
+         .vkSrgbFormat = VK_FORMAT_B8G8R8A8_SRGB,
+
+     }},
+    {DRM_FORMAT_XBGR8888,
+     {
+         .drmFormat    = DRM_FORMAT_XBGR8888,
+         .vkFormat     = VK_FORMAT_R8G8B8A8_UNORM,
+         .vkSrgbFormat = VK_FORMAT_R8G8B8A8_SRGB,
+
+     }},
+    {DRM_FORMAT_ABGR8888,
+     {
+         .drmFormat = DRM_FORMAT_ABGR8888,
+         .vkFormat  = VK_FORMAT_R8G8B8A8_UNORM,
+
+     }},
+    {DRM_FORMAT_BGR888,
+     {
+         .drmFormat    = DRM_FORMAT_BGR888,
+         .vkFormat     = VK_FORMAT_R8G8B8_UNORM,
+         .vkSrgbFormat = VK_FORMAT_R8G8B8_SRGB,
+
+     }},
+    {DRM_FORMAT_RGBX4444,
+     {
+         .drmFormat = DRM_FORMAT_RGBX4444,
+         .vkFormat  = VK_FORMAT_R4G4B4A4_UNORM_PACK16,
+
+     }},
+    {DRM_FORMAT_RGBA4444,
+     {
+         .drmFormat = DRM_FORMAT_RGBA4444,
+         .vkFormat  = VK_FORMAT_R4G4B4A4_UNORM_PACK16,
+
+     }},
+    {DRM_FORMAT_RGBX5551,
+     {
+         .drmFormat = DRM_FORMAT_RGBX5551,
+         .vkFormat  = VK_FORMAT_R5G5B5A1_UNORM_PACK16,
+
+     }},
+    {DRM_FORMAT_RGBA5551,
+     {
+         .drmFormat = DRM_FORMAT_RGBA5551,
+         .vkFormat  = VK_FORMAT_R5G5B5A1_UNORM_PACK16,
+
+     }},
+    {DRM_FORMAT_RGB565,
+     {
+         .drmFormat = DRM_FORMAT_RGB565,
+         .vkFormat  = VK_FORMAT_R5G6B5_UNORM_PACK16,
+
+     }},
+    {DRM_FORMAT_XBGR2101010,
+     {
+         .drmFormat = DRM_FORMAT_XBGR2101010,
+         .vkFormat  = VK_FORMAT_A2B10G10R10_UNORM_PACK32,
+
+     }},
+    {DRM_FORMAT_ABGR2101010,
+     {
+         .drmFormat = DRM_FORMAT_ABGR2101010,
+         .vkFormat  = VK_FORMAT_A2B10G10R10_UNORM_PACK32,
+
+     }},
+    {DRM_FORMAT_XRGB2101010,
+     {
+         .drmFormat = DRM_FORMAT_XRGB2101010,
+         .vkFormat  = VK_FORMAT_A2R10G10B10_UNORM_PACK32,
+
+     }},
+    {DRM_FORMAT_ARGB2101010,
+     {
+         .drmFormat = DRM_FORMAT_ARGB2101010,
+         .vkFormat  = VK_FORMAT_A2R10G10B10_UNORM_PACK32,
+
+     }},
+    {DRM_FORMAT_XBGR16161616F,
+     {
+         .drmFormat = DRM_FORMAT_XBGR16161616F,
+         .vkFormat  = VK_FORMAT_R16G16B16A16_SFLOAT,
+
+     }},
+    {DRM_FORMAT_ABGR16161616F,
+     {
+         .drmFormat = DRM_FORMAT_ABGR16161616F,
+         .vkFormat  = VK_FORMAT_R16G16B16A16_SFLOAT,
+
+     }},
+    {DRM_FORMAT_XBGR16161616,
+     {
+         .drmFormat = DRM_FORMAT_XBGR16161616,
+         .vkFormat  = VK_FORMAT_R16G16B16A16_UNORM,
+
+     }},
+    {DRM_FORMAT_ABGR16161616,
+     {
+         .drmFormat = DRM_FORMAT_ABGR16161616,
+         .vkFormat  = VK_FORMAT_R16G16B16A16_UNORM,
+
+     }},
+    {DRM_FORMAT_YVYU,
+     {
+         .drmFormat = DRM_FORMAT_YVYU,
+         .isYCC     = true,
+
+     }},
+    {DRM_FORMAT_VYUY,
+     {
+         .drmFormat = DRM_FORMAT_VYUY,
+         .isYCC     = true,
+
+     }},
+    {DRM_FORMAT_R8,
+     {
+         .drmFormat    = DRM_FORMAT_R8,
+         .vkFormat     = VK_FORMAT_R8_UNORM,
+         .vkSrgbFormat = VK_FORMAT_R8_SRGB,
+
+     }},
+    {DRM_FORMAT_GR88,
+     {
+         .drmFormat    = DRM_FORMAT_GR88,
+         .vkFormat     = VK_FORMAT_R8G8_UNORM,
+         .vkSrgbFormat = VK_FORMAT_R8G8_SRGB,
+
+     }},
+    {DRM_FORMAT_RGB888,
+     {
+         .drmFormat    = DRM_FORMAT_RGB888,
+         .vkFormat     = VK_FORMAT_B8G8R8_UNORM,
+         .vkSrgbFormat = VK_FORMAT_B8G8R8_SRGB,
+
+     }},
+};
 
 SHMFormat NFormatUtils::drmToShm(DRMFormat drm) {
     switch (drm) {

--- a/src/helpers/Format.hpp
+++ b/src/helpers/Format.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
 #include <cstdint>
+#include <drm_fourcc.h>
 #include <string>
 #include <GLES3/gl32.h>
-#include "math/Math.hpp"
 #include <aquamarine/backend/Misc.hpp>
+#include <map>
+#include <vulkan/vulkan_core.h>
 
 using DRMFormat = uint32_t;
 using SHMFormat = uint32_t;
@@ -19,3 +21,15 @@ namespace NFormatUtils {
     std::string drmModifierName(uint64_t mod);
     DRMFormat   alphaFormat(DRMFormat prevFormat);
 };
+
+// TODO move to hyprgraphics
+namespace Render::VK {
+    struct SVkFormatInfo {
+        DRMFormat drmFormat    = DRM_FORMAT_INVALID;
+        VkFormat  vkFormat     = VK_FORMAT_UNDEFINED;
+        VkFormat  vkSrgbFormat = VK_FORMAT_UNDEFINED;
+        bool      isYCC        = false;
+    };
+
+    extern const std::map<DRMFormat, SVkFormatInfo> FORMATS;
+}

--- a/src/helpers/SystemInfo.cpp
+++ b/src/helpers/SystemInfo.cpp
@@ -4,6 +4,7 @@
 #include "../version.h"
 #include "../plugins/PluginAPI.hpp"
 #include "../plugins/PluginSystem.hpp"
+#include "../render/Renderer.hpp"
 #include "../render/OpenGL.hpp"
 #include "../config/ConfigManager.hpp"
 
@@ -228,9 +229,12 @@ std::string SystemInfo::getSystemInfo() {
     } else
         result += "\tunknown: not runtime\n";
 
-    if (g_pHyprOpenGL) {
-        result += std::format("\nExplicit sync: {}", g_pHyprOpenGL->m_exts.EGL_ANDROID_native_fence_sync_ext ? "supported" : "missing");
-        result += std::format("\nGL ver: {}", g_pHyprOpenGL->m_eglContextVersion == CHyprOpenGLImpl::EGL_CONTEXT_GLES_3_2 ? "3.2" : "3.0");
+    if (g_pHyprRenderer) {
+        const auto gl = g_pHyprRenderer->glBackend();
+        if (gl) {
+            result += std::format("\nExplicit sync: {}", gl->m_exts.EGL_ANDROID_native_fence_sync_ext ? "supported" : "missing");
+            result += std::format("\nGL ver: {}", gl->m_eglContextVersion == CHyprOpenGLImpl::EGL_CONTEXT_GLES_3_2 ? "3.2" : "3.0");
+        }
     }
 
     if (g_pCompositor) {

--- a/src/render/ElementRenderer.cpp
+++ b/src/render/ElementRenderer.cpp
@@ -21,7 +21,7 @@ void IElementRenderer::drawElement(WP<IPassElement> element, const CRegion& dama
         case EK_RECT: drawRect(dynamicPointerCast<CRectPassElement>(element), damage); break;
         case EK_HINTS: drawHints(dynamicPointerCast<CRendererHintsPassElement>(element), damage); break;
         case EK_SHADOW: draw(dynamicPointerCast<CShadowPassElement>(element), damage); break;
-        case EK_INNER_GLOW: draw(dynamicPointerCast<CInnerGlowPassElement>(element), damage); break;
+        case EK_INNER_GLOW: drawGlow(dynamicPointerCast<CInnerGlowPassElement>(element), damage); break;
         case EK_SURFACE: preDrawSurface(dynamicPointerCast<CSurfacePassElement>(element), damage); break;
         case EK_TEXTURE: drawTex(dynamicPointerCast<CTexPassElement>(element), damage); break;
         case EK_TEXTURE_MATTE: drawTexMatte(dynamicPointerCast<CTextureMatteElement>(element), damage); break;
@@ -394,6 +394,14 @@ void IElementRenderer::preDrawSurface(WP<CSurfacePassElement> element, const CRe
     m_renderData.useNearestNeighbor = false;
     g_pHyprRenderer->popMonitorTransformEnabled();
     m_renderData.currentWindow.reset();
+}
+
+void IElementRenderer::drawGlow(WP<CInnerGlowPassElement> element, const CRegion& damage) {
+    static auto PGLOW = CConfigValue<Hyprlang::INT>("decoration:glow:enabled");
+    if (!*PGLOW)
+        return;
+
+    draw(element, damage);
 }
 
 void IElementRenderer::drawTex(WP<CTexPassElement> element, const CRegion& damage) {

--- a/src/render/ElementRenderer.hpp
+++ b/src/render/ElementRenderer.hpp
@@ -42,6 +42,7 @@ namespace Render {
         void drawClear(WP<CClearPassElement> element, const CRegion& damage);
         void drawSurface(WP<CSurfacePassElement> element, const CRegion& damage);
         void preDrawSurface(WP<CSurfacePassElement> element, const CRegion& damage);
+        void drawGlow(WP<CInnerGlowPassElement> element, const CRegion& damage);
         void drawTex(WP<CTexPassElement> element, const CRegion& damage);
         void drawTexMatte(WP<CTextureMatteElement> element, const CRegion& damage);
         void drawCustom(WP<IPassElement> element, const CRegion& damage);

--- a/src/render/Framebuffer.cpp
+++ b/src/render/Framebuffer.cpp
@@ -65,3 +65,7 @@ void IFramebuffer::setImageDescription(NColorManagement::PImageDescription desc)
     else
         Log::logger->log(Log::TRACE, "CM: FIXME no framebuffer texture");
 }
+
+void IFramebuffer::setName(const std::string& name) {
+    m_name = name;
+}

--- a/src/render/Framebuffer.hpp
+++ b/src/render/Framebuffer.hpp
@@ -32,6 +32,7 @@ namespace Render {
         void                                setImageDescription(NColorManagement::PImageDescription desc);
 
         virtual void                        addStencil(SP<ITexture> tex) = 0;
+        virtual void                        setName(const std::string& name);
 
         Vector2D                            m_size;
         DRMFormat                           m_drmFormat = DRM_FORMAT_INVALID;

--- a/src/render/ShaderLoader.cpp
+++ b/src/render/ShaderLoader.cpp
@@ -155,6 +155,7 @@ const std::map<std::string, std::string>& CShaderLoader::includes() {
 
 // TODO notify user if bundled shader is newer than ~/.config override
 std::string CShaderLoader::loadShader(const std::string& filename) {
+    Log::logger->log(Log::DEBUG, "Loading shader {}", filename);
     if (m_shaderPath.length()) {
         std::filesystem::path path = m_shaderPath;
         const auto            src  = NFsUtils::readFileAsString(path / filename);

--- a/src/render/VKRenderer.cpp
+++ b/src/render/VKRenderer.cpp
@@ -1,0 +1,719 @@
+#include "VKRenderer.hpp"
+#include "./vulkan/Framebuffer.hpp"
+#include "./vulkan/Pipeline.hpp"
+#include "./vulkan/RenderPass.hpp"
+#include "./vulkan/Vulkan.hpp"
+#include "./vulkan/PipelineLayout.hpp"
+#include "./vulkan/Shaders.hpp"
+#include "./vulkan/utils.hpp"
+#include "../debug/log/Logger.hpp"
+#include "../macros.hpp"
+#include "../managers/eventLoop/EventLoopManager.hpp"
+#include "./Framebuffer.hpp"
+#include "./OpenGL.hpp"
+#include "./Renderer.hpp"
+#include "./ShaderLoader.hpp"
+#include "./pass/TexPassElement.hpp"
+#include "./vulkan/BlurPass.hpp"
+#include "./vulkan/BorderGradientUBO.hpp"
+#include "./vulkan/VKElementRenderer.hpp"
+#include "./vulkan/VKTexture.hpp"
+#include "./vulkan/types.hpp"
+#include "helpers/cm/ColorManagement.hpp"
+#include <algorithm>
+#include <array>
+#include <cairo.h>
+#include <cstdint>
+#include <cstring>
+#include <hyprutils/math/Box.hpp>
+#include <hyprutils/math/Mat3x3.hpp>
+#include <hyprutils/math/Region.hpp>
+#include <hyprutils/math/Vector2D.hpp>
+#include <hyprutils/memory/SharedPtr.hpp>
+#include <hyprutils/memory/UniquePtr.hpp>
+#include <vector>
+#include <vulkan/vulkan_core.h>
+
+using namespace Render;
+using namespace Render::VK;
+
+CHyprVKRenderer::CHyprVKRenderer() : IHyprRenderer() {
+    if (!m_shaders)
+        m_shaders = makeShared<CVkShaders>(g_pHyprVulkan->m_device);
+}
+
+void CHyprVKRenderer::initRender() {
+    ASSERT(!m_busy);
+    m_busy = true;
+    m_currentPipeline.reset();
+    // for (const auto& cb : g_pHyprVulkan->m_commandBuffers) {
+    //     if (!cb->busy())
+    //         cb->resetUsedResources();
+    // }
+}
+
+SP<CVkRenderPass> CHyprVKRenderer::getRenderPass(uint32_t fmt) {
+    auto foundRP = std::ranges::find_if(m_renderPassList, [&](const auto& other) { return other->m_drmFormat == fmt; });
+    if (foundRP != m_renderPassList.end())
+        return *foundRP;
+    else
+        return m_renderPassList.emplace_back(makeShared<CVkRenderPass>(g_pHyprVulkan->m_device, fmt, m_shaders));
+}
+
+SP<CVKBlurPass> CHyprVKRenderer::getBlurPass(uint32_t fmt) {
+    static auto PBLURPASSES = CConfigValue<Hyprlang::INT>("decoration:blur:passes");
+    const auto  BLUR_PASSES = std::clamp(*PBLURPASSES, sc<int64_t>(1), sc<int64_t>(8));
+
+    auto        foundRP = std::ranges::find_if(m_blurPassList, [&](const auto& other) { return other->format() == fmt; });
+    if (foundRP != m_blurPassList.end()) {
+        if ((*foundRP)->passes() != BLUR_PASSES)
+            *foundRP = makeShared<CVKBlurPass>(g_pHyprVulkan->m_device, fmt, m_shaders, BLUR_PASSES);
+        return *foundRP;
+    } else
+        return m_blurPassList.emplace_back(makeShared<CVKBlurPass>(g_pHyprVulkan->m_device, fmt, m_shaders, BLUR_PASSES));
+}
+
+bool CHyprVKRenderer::initRenderBuffer(SP<Aquamarine::IBuffer> buffer, uint32_t fmt) {
+    m_currentDrmFormat = fmt;
+    m_renderData.outFB = getOrCreateRenderbuffer(buffer, fmt)->getFB();
+    m_renderData.outFB->setName("Out FB");
+
+    return true;
+};
+
+bool CHyprVKRenderer::beginFullFakeRenderInternal(PHLMONITOR pMonitor, CRegion& damage, SP<IFramebuffer> fb, bool simple) {
+    initRender();
+
+    m_renderData.outFB = fb;
+    m_currentDrmFormat = m_renderData.outFB->m_drmFormat;
+
+    m_renderData.outFB->setName("Out FB");
+
+    return beginRenderInternal(pMonitor, damage, simple);
+};
+
+SP<ITexture> CHyprVKRenderer::blurFramebuffer(SP<IFramebuffer> source, float a, CRegion* originalDamage) {
+    VK_CB_LABEL_BEGIN(m_currentCommandBuffer->vk(), "blurFramebuffer")
+    const auto bp = getBlurPass(VKFB(m_renderData.currentFB)->fb()->texture()->m_drmFormat);
+    m_currentCommandBuffer->useBlurPass(bp);
+    if (m_hasBoundFB)
+        m_currentRenderPass->endRendering();
+
+    m_currentCommandBuffer->changeLayout(source, //
+                                         {.layout = VK_IMAGE_LAYOUT_GENERAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = VK_ACCESS_TRANSFER_WRITE_BIT},
+                                         {.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = 0});
+
+    static auto PBLURSIZE   = CConfigValue<Hyprlang::INT>("decoration:blur:size");
+    static auto PBLURPASSES = CConfigValue<Hyprlang::INT>("decoration:blur:passes");
+    const auto  BLUR_PASSES = std::clamp(*PBLURPASSES, sc<int64_t>(1), sc<int64_t>(8));
+
+    // prep damage
+    CRegion damage{*originalDamage};
+    damage.transform(Math::wlTransformToHyprutils(Math::invertTransform(m_renderData.pMonitor->m_transform)), m_renderData.pMonitor->m_transformedSize.x,
+                     m_renderData.pMonitor->m_transformedSize.y);
+    damage.expand(std::clamp(*PBLURSIZE, sc<int64_t>(1), sc<int64_t>(40)) * pow(2, BLUR_PASSES));
+    const auto tex =
+        bp->blurTexture(source->getTexture(), m_renderData.pMonitor->resources()->getUnusedWorkBuffer(), m_renderData.pMonitor->resources()->getUnusedWorkBuffer(), a, damage);
+
+    m_currentCommandBuffer->changeLayout(
+        source, //
+        {.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = VK_ACCESS_TRANSFER_WRITE_BIT},
+        {.layout = VK_IMAGE_LAYOUT_GENERAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = 0});
+
+    if (m_hasBoundFB)
+        m_currentRenderPass->beginRendering(m_currentCommandBuffer.lock(), m_hasBoundFB);
+    VK_CB_LABEL_END(m_currentCommandBuffer->vk())
+    return tex;
+}
+
+void CHyprVKRenderer::renderOffToMain(SP<IFramebuffer> off) {
+    CBox       newBox = {0, 0, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y};
+
+    const auto tex = off->getTexture();
+    RASSERT(m_renderData.pMonitor, "Tried to render texture without begin()!");
+    RASSERT((tex->ok()), "Attempted to draw nullptr texture!");
+
+    TRACY_GPU_ZONE("RenderTexturePrimitive");
+
+    if (m_renderData.damage.empty())
+        return;
+
+    m_renderData.renderModif.applyToBox(newBox);
+
+    const auto cb = g_pHyprVulkan->renderCB();
+    cb->useTexture(tex);
+
+    const auto  mat = projectBoxToTarget(newBox).getMatrix();
+
+    const auto& vertData = matToVertShader(mat);
+
+    const auto  layout = m_currentRenderPass->passPipeline()->layout().lock();
+    const auto  view   = VKTEX(tex)->getView(layout);
+    if (!view)
+        return;
+
+    bindPipeline(m_currentRenderPass->passPipeline());
+
+    const auto ds = view->vkDS();
+    vkCmdBindDescriptorSets(cb->vk(), VK_PIPELINE_BIND_POINT_GRAPHICS, layout->vk(), 0, 1, &ds, 0, nullptr);
+
+    vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(vertData), &vertData);
+
+    // TODO
+    // ensure the final blit uses the desired sampling filter
+    // when cursor zoom is active we want nearest-neighbor (no anti-aliasing)
+    // if (m_renderData.useNearestNeighbor) {
+    //     tex->setTexParameter(GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+    //     tex->setTexParameter(GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    // } else {
+    //     tex->setTexParameter(GL_TEXTURE_MAG_FILTER, tex->magFilter);
+    //     tex->setTexParameter(GL_TEXTURE_MIN_FILTER, tex->minFilter);
+    // }
+
+    drawRegionRects(m_renderData.damage, cb->vk());
+
+    disableScissor();
+}
+
+SP<IRenderbuffer> CHyprVKRenderer::getOrCreateRenderbufferInternal(SP<Aquamarine::IBuffer> buffer, uint32_t fmt) {
+    return makeShared<CVKRenderBuffer>(buffer, fmt);
+}
+
+bool CHyprVKRenderer::beginRenderInternal(PHLMONITOR pMonitor, CRegion& damage, bool simple) {
+    m_renderData.mainFB       = simple ? m_renderData.outFB : pMonitor->resources()->getUnusedWorkBuffer();
+    m_renderData.currentFB    = m_renderData.mainFB;
+    m_currentRenderbufferSize = m_renderData.currentFB->m_size;
+    m_currentRenderPass       = getRenderPass(m_currentDrmFormat);
+
+    m_renderData.mainFB->setName("Main FB");
+
+    m_currentCommandBuffer = g_pHyprVulkan->begin();
+    VK_CB_LABEL_BEGIN(m_currentCommandBuffer->vk(), "Main render");
+
+    return true;
+}
+
+IHyprRenderer::eType CHyprVKRenderer::type() {
+    return RT_VK;
+}
+
+void CHyprVKRenderer::startRenderPass() {
+    m_currentCommandBuffer->useRenderPass(m_currentRenderPass);
+    bindFB(m_renderData.currentFB);
+
+    m_inRenderPass = true;
+}
+
+void CHyprVKRenderer::bindFB(SP<IFramebuffer> fb) {
+    if (m_hasBoundFB == fb)
+        return;
+
+    if (!fb)
+        return;
+
+    if (m_hasBoundFB) {
+        VK_CB_LABEL_BEGIN(m_currentCommandBuffer->vk(), "Switch FB")
+        m_currentRenderPass->endRendering();
+        if (m_hasBoundFB == dc<CVKFramebuffer*>(m_renderData.pMonitor->resources()->m_blurFB.get())->fb())
+            m_currentCommandBuffer->changeLayout(m_hasBoundFB, //
+                                                 {.layout = VK_IMAGE_LAYOUT_GENERAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = VK_ACCESS_TRANSFER_WRITE_BIT},
+                                                 {.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = 0});
+        VK_CB_LABEL_END(m_currentCommandBuffer->vk())
+    }
+    m_hasBoundFB = dynamicPointerCast<CVKFramebuffer>(fb);
+
+    if (m_currentRenderPass->m_drmFormat != m_hasBoundFB->fb()->texture()->m_drmFormat)
+        m_currentRenderPass = getRenderPass(m_hasBoundFB->fb()->texture()->m_drmFormat);
+
+    m_currentRenderPass->beginRendering(m_currentCommandBuffer.lock(), m_hasBoundFB);
+    m_currentCommandBuffer->useTexture(m_hasBoundFB->fb()->texture());
+}
+
+UP<ISyncFDManager> CHyprVKRenderer::createSyncFDManager() {
+    // TODO use vulkan sync
+    return Render::GL::CEGLSync::create();
+}
+
+WP<IElementRenderer> CHyprVKRenderer::elementRenderer() {
+    if UNLIKELY (!m_elementRenderer) {
+        WP<IHyprRenderer> wpRenderer = g_pHyprRenderer;
+        m_elementRenderer            = makeUnique<CVKElementRenderer>(dynamicPointerCast<CHyprVKRenderer>(wpRenderer));
+    }
+    return m_elementRenderer;
+}
+
+void CHyprVKRenderer::endRender(const std::function<void()>& renderingDoneCallback) {
+    if (!m_inRenderPass)
+        startRenderPass();
+
+    if (m_renderData.pMonitor->m_transform != WL_OUTPUT_TRANSFORM_NORMAL) {
+        // FIXME
+        m_renderData.damage = CBox{{0, 0}, m_renderData.pMonitor->m_transformedSize};
+    }
+    m_renderData.damage = m_renderPass.render(m_renderData.damage);
+
+    m_currentRenderPass->endRendering();
+    VK_CB_LABEL_END(m_currentCommandBuffer->vk())
+
+    m_inRenderPass = false;
+    m_hasBoundFB.reset();
+
+    if (m_renderData.outFB != m_renderData.mainFB) {
+        VK_CB_LABEL_BEGIN(m_currentCommandBuffer->vk(), "Offload to output");
+        m_currentCommandBuffer->changeLayout(
+            m_renderData.mainFB, //
+            {.layout = VKFB(m_renderData.mainFB)->m_lastKnownLayout, .stageMask = VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT, .accessMask = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT},
+            {.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, .stageMask = VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT, .accessMask = 0});
+        bindFB(m_renderData.outFB);
+        m_renderData.mainFB->getTexture()->m_transform = Math::wlTransformToHyprutils(Math::invertTransform(m_renderData.pMonitor->m_transform));
+        draw(
+            CTexPassElement::SRenderData{
+                .tex        = m_renderData.mainFB->getTexture(),
+                .box        = {{0, 0}, m_renderData.pMonitor->m_transformedSize},
+                .clipBox    = CBox{{0, 0}, m_renderData.pMonitor->m_transformedSize},
+                .clipRegion = CBox{{0, 0}, m_renderData.pMonitor->m_transformedSize},
+            },
+            CBox{{0, 0}, m_renderData.mainFB->getTexture()->m_size});
+        m_currentRenderPass->endRendering();
+        m_hasBoundFB.reset();
+        m_renderData.currentFB = m_renderData.outFB;
+        m_currentCommandBuffer->changeLayout(
+            m_renderData.mainFB, //
+            {.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = VK_ACCESS_TRANSFER_READ_BIT},
+            {.layout = VK_IMAGE_LAYOUT_GENERAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = 0});
+        VK_CB_LABEL_END(m_currentCommandBuffer->vk());
+    }
+
+    std::vector<VkImageMemoryBarrier> acquireBarriers;
+    std::vector<VkImageMemoryBarrier> releaseBarriers;
+    acquireBarriers.reserve(m_needBarriers.size() + 1);
+    releaseBarriers.reserve(m_needBarriers.size() + 1);
+
+    for (const auto& tex : m_needBarriers) {
+        acquireBarriers.push_back({
+            .sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+            .srcAccessMask       = 0,
+            .dstAccessMask       = VK_ACCESS_SHADER_READ_BIT,
+            .oldLayout           = VK_IMAGE_LAYOUT_GENERAL,
+            .newLayout           = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+            .srcQueueFamilyIndex = VK_QUEUE_FAMILY_FOREIGN_EXT,
+            .dstQueueFamilyIndex = g_pHyprVulkan->m_device->queueFamilyIndex(),
+            .image               = VKTEX(tex)->m_image,
+            .subresourceRange =
+                {
+                    .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                    .levelCount = 1,
+                    .layerCount = 1,
+                },
+        });
+
+        releaseBarriers.push_back({
+            .sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+            .srcAccessMask       = VK_ACCESS_SHADER_READ_BIT,
+            .dstAccessMask       = 0,
+            .oldLayout           = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+            .newLayout           = VK_IMAGE_LAYOUT_GENERAL,
+            .srcQueueFamilyIndex = g_pHyprVulkan->m_device->queueFamilyIndex(),
+            .dstQueueFamilyIndex = VK_QUEUE_FAMILY_FOREIGN_EXT,
+            .image               = VKTEX(tex)->m_image,
+            .subresourceRange =
+                {
+                    .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                    .levelCount = 1,
+                    .layerCount = 1,
+                },
+        });
+
+        VKTEX(tex)->m_barriersSet = false;
+    }
+    m_needBarriers.clear();
+    // TODO handle SHM tex sync
+
+    VkImageLayout srcLayout = VK_IMAGE_LAYOUT_GENERAL;
+    if (!VKFB(m_renderData.currentFB)->fb()->m_initialized) {
+        VKFB(m_renderData.currentFB)->fb()->m_initialized = true;
+        srcLayout                                         = VK_IMAGE_LAYOUT_PREINITIALIZED;
+    }
+
+    acquireBarriers.push_back({
+        .sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+        .srcAccessMask       = 0,
+        .dstAccessMask       = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+        .oldLayout           = srcLayout,
+        .newLayout           = VK_IMAGE_LAYOUT_GENERAL,
+        .srcQueueFamilyIndex = VK_QUEUE_FAMILY_FOREIGN_EXT,
+        .dstQueueFamilyIndex = g_pHyprVulkan->m_device->queueFamilyIndex(),
+        .image               = VKFB(m_renderData.currentFB)->fb()->vkImage(),
+        .subresourceRange =
+            {
+                .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                .levelCount = 1,
+                .layerCount = 1,
+            },
+    });
+
+    releaseBarriers.push_back({
+        .sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
+        .srcAccessMask       = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+        .dstAccessMask       = 0,
+        .oldLayout           = VK_IMAGE_LAYOUT_GENERAL,
+        .newLayout           = VK_IMAGE_LAYOUT_GENERAL,
+        .srcQueueFamilyIndex = g_pHyprVulkan->m_device->queueFamilyIndex(),
+        .dstQueueFamilyIndex = VK_QUEUE_FAMILY_FOREIGN_EXT,
+        .image               = VKFB(m_renderData.currentFB)->fb()->vkImage(),
+        .subresourceRange =
+            {
+                .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                .levelCount = 1,
+                .layerCount = 1,
+            },
+    });
+
+    vkCmdPipelineBarrier(g_pHyprVulkan->stageCB()->vk(), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT | VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                         0, 0, nullptr, 0, nullptr, acquireBarriers.size(), acquireBarriers.data());
+
+    vkCmdPipelineBarrier(g_pHyprVulkan->renderCB()->vk(), VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, nullptr, 0, nullptr,
+                         releaseBarriers.size(), releaseBarriers.data());
+
+    if (m_renderMode != RENDER_MODE_NORMAL)
+        m_currentCommandBuffer->changeLayout(m_renderData.currentFB,
+                                             {
+                                                 .layout     = VKFB(m_renderData.currentFB)->m_lastKnownLayout,
+                                                 .stageMask  = VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
+                                                 .accessMask = VK_ACCESS_SHADER_READ_BIT,
+                                             },
+                                             {
+                                                 .layout     = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                                                 .stageMask  = VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
+                                                 .accessMask = VK_ACCESS_SHADER_READ_BIT,
+                                             });
+
+    g_pHyprVulkan->end();
+
+    if (m_renderMode == RENDER_MODE_NORMAL)
+        renderData().pMonitor->m_output->state->setBuffer(m_currentBuffer);
+
+    if (m_renderMode == RENDER_MODE_FULL_FAKE) {
+        if (renderingDoneCallback)
+            renderingDoneCallback();
+    } else if (!explicitSyncSupported()) { // FIXME impossible with vulkan?
+        Log::logger->log(Log::ERR, "renderer: Explicit sync unsupported, falling back to implicit in endRender");
+
+        m_usedAsyncBuffers.clear(); // release all buffer refs and hope implicit sync works
+        if (renderingDoneCallback)
+            renderingDoneCallback();
+    } else {
+        auto sync = createSyncFDManager();
+        if LIKELY (sync && sync->isValid()) {
+            for (auto const& buf : m_usedAsyncBuffers) {
+                for (const auto& releaser : buf->m_syncReleasers) {
+                    releaser->addSyncFileFd(sync->fd());
+                }
+            }
+
+            // release buffer refs with release points now, since syncReleaser handles actual buffer release based on EGLSync
+            std::erase_if(m_usedAsyncBuffers, [](const auto& buf) { return !buf->m_syncReleasers.empty(); });
+
+            // release buffer refs without release points when EGLSync sync_file/fence is signalled
+            g_pEventLoopManager->doOnReadable(sync->fd().duplicate(), [renderingDoneCallback, prevbfs = std::move(m_usedAsyncBuffers)]() mutable {
+                prevbfs.clear();
+                if (renderingDoneCallback)
+                    renderingDoneCallback();
+            });
+            m_usedAsyncBuffers.clear();
+
+            if (m_renderMode == RENDER_MODE_NORMAL) {
+                m_renderData.pMonitor->m_inFence = sync->takeFd();
+                m_renderData.pMonitor->m_output->state->setExplicitInFence(m_renderData.pMonitor->m_inFence.get());
+            }
+        } else {
+            Log::logger->log(Log::ERR, "renderer: Explicit sync failed, releasing resources");
+
+            m_usedAsyncBuffers.clear(); // release all buffer refs and hope implicit sync works
+            if (renderingDoneCallback)
+                renderingDoneCallback();
+        }
+    }
+
+    m_currentBuffer        = nullptr;
+    m_renderData.currentFB = nullptr;
+    m_renderData.mainFB    = nullptr;
+    m_renderData.outFB     = nullptr;
+    m_currentRenderPass.reset();
+    m_busy = false;
+}
+
+SP<ITexture> CHyprVKRenderer::createStencilTexture(const int width, const int height) {
+    // VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT
+    return makeShared<CVKTexture>(VK_FORMAT_D24_UNORM_S8_UINT, width, height);
+}
+
+SP<ITexture> CHyprVKRenderer::createTexture(bool opaque) {
+    return makeShared<CVKTexture>(opaque);
+}
+
+SP<ITexture> CHyprVKRenderer::createTexture(uint32_t drmFormat, uint8_t* pixels, uint32_t stride, const Vector2D& size, bool keepDataCopy, bool opaque) {
+    auto tex = makeShared<CVKTexture>(drmFormat, pixels, stride, size, keepDataCopy, opaque);
+    tex->m_lastUsedCB->useTexture(tex);
+    return tex;
+}
+
+SP<ITexture> CHyprVKRenderer::createTexture(const Aquamarine::SDMABUFAttrs& attrs, bool opaque) {
+    auto tex = makeShared<CVKTexture>(attrs, opaque);
+    return tex;
+}
+
+SP<ITexture> CHyprVKRenderer::createTexture(const int width, const int height, unsigned char* const data) {
+    auto tex = createTexture(DRM_FORMAT_ARGB8888, data, width * 4, {width, height});
+    return tex;
+}
+
+SP<ITexture> CHyprVKRenderer::createTexture(cairo_surface_t* cairo) {
+    const auto CAIROFORMAT = cairo_image_surface_get_format(cairo);
+
+    const auto width  = cairo_image_surface_get_width(cairo);
+    const auto height = cairo_image_surface_get_height(cairo);
+
+    if (CAIROFORMAT == CAIRO_FORMAT_RGB96F) {
+        const auto recodeSurf  = cairo_image_surface_create(CAIRO_FORMAT_RGB30, width, height);
+        const auto recodeCairo = cairo_create(recodeSurf);
+        cairo_set_source_surface(recodeCairo, cairo, 0, 0);
+        cairo_rectangle(recodeCairo, 0, 0, width, height);
+        cairo_set_operator(recodeCairo, CAIRO_OPERATOR_SOURCE);
+        cairo_fill(recodeCairo);
+        cairo_surface_flush(recodeSurf);
+
+        auto tex = createTexture(DRM_FORMAT_XRGB2101010, cairo_image_surface_get_data(recodeSurf), width * 4, {width, height});
+
+        cairo_surface_destroy(recodeSurf);
+        cairo_destroy(recodeCairo);
+
+        return tex;
+    } else {
+        const auto DATA = cairo_image_surface_get_data(cairo);
+        return createTexture(width, height, DATA);
+    }
+}
+
+SP<ITexture> CHyprVKRenderer::createTexture(std::span<const float> lut3D, size_t N) {
+    Log::logger->log(Log::ERR, "fixme: unimplemented CHyprVKRenderer::createTexture for ICC lut");
+    return nullptr;
+}
+
+bool CHyprVKRenderer::explicitSyncSupported() {
+    return true; // FIXME actual check
+}
+
+std::vector<SDRMFormat> CHyprVKRenderer::getDRMFormats() {
+    // TODO cache
+    const auto              source = g_pHyprVulkan->m_device->formats();
+    std::vector<SDRMFormat> formats(source.size());
+    std::ranges::transform(source, formats.begin(), [](const auto fmt) {
+        std::set<uint64_t> modSet;
+        for (const auto& info : fmt.dmabuf.renderModifiers) {
+            modSet.insert(info.props.drmFormatModifier);
+        }
+        for (const auto& info : fmt.dmabuf.textureModifiers) {
+            modSet.insert(info.props.drmFormatModifier);
+        }
+        std::vector<uint64_t> mods(modSet.begin(), modSet.end());
+
+        return SDRMFormat{
+            .drmFormat = fmt.format.drmFormat,
+            .modifiers = mods,
+        };
+    });
+    return formats;
+}
+
+std::vector<uint64_t> CHyprVKRenderer::getDRMFormatModifiers(DRMFormat format) {
+    auto fmt = g_pHyprVulkan->m_device->getFormat(format);
+    if (!fmt.has_value())
+        return {};
+
+    std::set<uint64_t> modSet;
+    for (const auto& info : fmt->dmabuf.renderModifiers) {
+        modSet.insert(info.props.drmFormatModifier);
+    }
+    for (const auto& info : fmt->dmabuf.textureModifiers) {
+        modSet.insert(info.props.drmFormatModifier);
+    }
+    std::vector<uint64_t> mods(modSet.begin(), modSet.end());
+    return mods;
+}
+
+SP<IFramebuffer> CHyprVKRenderer::createFB(const std::string& name) {
+    return makeShared<CVKFramebuffer>(name);
+}
+
+void CHyprVKRenderer::disableScissor() {
+    VkRect2D rect = {
+        .offset = {.x = 0, .y = 0},
+        .extent = {.width = currentRBSize().x, .height = currentRBSize().y},
+    };
+
+    vkCmdSetScissor(g_pHyprVulkan->renderCB()->vk(), 0, 1, &rect);
+}
+
+void CHyprVKRenderer::blend(bool enabled) {
+    if (enabled)
+        return;
+    static int count = 0;
+    if (count < 10) {
+        count++;
+        Log::logger->log(Log::WARN, "Unimplimented blend");
+    }
+}
+
+void CHyprVKRenderer::drawShadow(const CBox& box, int round, float roundingPower, int range, CHyprColor color, float a) {
+    RASSERT(m_renderData.pMonitor, "Tried to render shadow without begin()!");
+    RASSERT((box.width > 0 && box.height > 0), "Tried to render shadow with width/height < 0!");
+
+    if (m_renderData.damage.empty())
+        return;
+
+    TRACY_GPU_ZONE("RenderShadow");
+
+    CBox newBox = box;
+    m_renderData.renderModif.applyToBox(newBox);
+
+    static auto               PSHADOWPOWER = CConfigValue<Hyprlang::INT>("decoration:shadow:render_power");
+    const auto                SHADOWPOWER  = std::clamp(sc<int>(*PSHADOWPOWER), 1, 4);
+    const auto                TOPLEFT      = Vector2D(range + round, range + round);
+    const auto                BOTTOMRIGHT  = Vector2D(newBox.width - (range + round), newBox.height - (range + round));
+    const auto                FULLSIZE     = Vector2D(newBox.width, newBox.height);
+
+    const auto&               vertData = matToVertShader(projectBoxToTarget(newBox).getMatrix());
+    const SVkShadowShaderData fragData = {
+        .color       = {color.r, color.g, color.b, color.a * a},
+        .bottomRight = {BOTTOMRIGHT.x, BOTTOMRIGHT.y},
+        .range       = range,
+        .shadowPower = SHADOWPOWER,
+    };
+    uint8_t   usedFeatures = 0;
+    SRounding roundingData = {
+        .radius   = range + round,
+        .power    = roundingPower,
+        .topLeft  = {TOPLEFT.x, TOPLEFT.y},
+        .fullSize = {FULLSIZE.x, FULLSIZE.y},
+    };
+    if (roundingData.radius > 0)
+        usedFeatures |= SH_FEAT_ROUNDING;
+
+    static const auto      PCM    = CConfigValue<Hyprlang::INT>("render:cm_enabled");
+    const bool             skipCM = !*PCM || m_renderData.pMonitor->m_imageDescription->id() == NColorManagement::getDefaultImageDescription()->id();
+    SShaderCM              cmData;
+    SShaderTonemap         tonemapData;
+    SShaderTargetPrimaries primariesData;
+    if (!skipCM) {
+        usedFeatures |= SH_FEAT_CM;
+        auto settings = getCMSettings(m_renderData.pMonitor->m_imageDescription, NColorManagement::getDefaultImageDescription(),
+                                      m_renderData.surface.valid() ? m_renderData.surface.lock() : nullptr);
+        usedFeatures |= passCMUniforms(settings, cmData, tonemapData, primariesData);
+    }
+
+    const auto cb       = g_pHyprVulkan->renderCB();
+    const auto pipeline = m_currentRenderPass->shadowPipeline(usedFeatures);
+    const auto layout   = pipeline->layout().lock();
+
+    bindPipeline(pipeline);
+
+    vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(vertData), &vertData);
+    vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, sizeof(vertData), sizeof(fragData), &fragData);
+    int featuresOffset = sizeof(vertData) + sizeof(fragData);
+    if (usedFeatures & SH_FEAT_ROUNDING) {
+        vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, featuresOffset, sizeof(roundingData), &roundingData);
+        featuresOffset += sizeof(roundingData);
+    }
+    if (usedFeatures & SH_FEAT_CM) {
+        vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, featuresOffset, sizeof(cmData), &cmData);
+        featuresOffset += sizeof(cmData);
+    }
+    if (usedFeatures & SH_FEAT_TONEMAP) {
+        vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, featuresOffset, sizeof(tonemapData), &tonemapData);
+        featuresOffset += sizeof(tonemapData);
+    }
+    if (usedFeatures & SH_FEAT_TONEMAP || usedFeatures & SH_FEAT_SDR_MOD) {
+        vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, featuresOffset, sizeof(primariesData), &primariesData);
+        featuresOffset += sizeof(primariesData);
+    }
+
+    CRegion damageClip{m_renderData.clipBox.x, m_renderData.clipBox.y, m_renderData.clipBox.width, m_renderData.clipBox.height};
+    auto    clipBox = m_renderData.clipBox.width != 0 && m_renderData.clipBox.height != 0 ? damageClip.intersect(m_renderData.damage) : m_renderData.damage;
+
+    drawRegionRects(clipBox, cb->vk());
+}
+
+void CHyprVKRenderer::setViewport(int x, int y, int width, int height) {
+    if (m_hasBoundFB && m_viewport.x == x && m_viewport.y == y && m_viewport.width == width && m_viewport.height == height)
+        return;
+
+    if (m_hasBoundFB)
+        m_currentRenderPass->endRendering();
+    else
+        m_hasBoundFB = dynamicPointerCast<CVKFramebuffer>(m_renderData.currentFB);
+
+    m_currentRenderPass->beginRendering(m_currentCommandBuffer.lock(), m_hasBoundFB);
+}
+
+bool CHyprVKRenderer::reloadShaders(const std::string& path) {
+    try {
+        auto shaders = makeShared<CVkShaders>(g_pHyprVulkan->m_device);
+
+        if (!shaders)
+            return false;
+
+        m_shaders = shaders;
+        m_renderPassList.clear();
+        m_blurPassList.clear();
+        return true;
+    } catch (const std::exception& e) {
+        Log::logger->log(Log::ERR, "Shaders update failed: {}", e.what());
+        return false;
+    }
+}
+
+void CHyprVKRenderer::bindPipeline(WP<CVkPipeline> pipeline) {
+    if (m_currentPipeline == pipeline)
+        return;
+
+    vkCmdBindPipeline(g_pHyprVulkan->renderCB()->vk(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline->vk());
+    m_currentPipeline = pipeline;
+}
+
+Vector2D CHyprVKRenderer::currentRBSize() {
+    return m_currentBuffer && m_currentBuffer->dmabuf().size.x > 0 && m_currentBuffer->dmabuf().size.y > 0 ? m_currentBuffer->dmabuf().size : m_currentRenderbufferSize;
+}
+
+SP<CVKBorderGradientUBO> CHyprVKRenderer::getGradientForWindow(PHLWINDOWREF window) {
+    std::erase_if(m_borderGradients, [](const auto& it) { return !it.first; });
+    if (!window)
+        return nullptr;
+
+    if (m_borderGradients.contains(window))
+        return m_borderGradients[window];
+
+    auto gradient             = makeShared<CVKBorderGradientUBO>(g_pHyprVulkan->device(), m_currentRenderPass->borderPipeline()->layout()->descriptorSets()[0]);
+    m_borderGradients[window] = gradient;
+    return gradient;
+}
+
+SP<CVkPipelineLayout> CHyprVKRenderer::ensurePipelineLayout(CVkPipelineLayout::KEY key) {
+    const auto pipeline = std::ranges::find_if(m_pipelineLayouts, [key](const auto layout) { return layout->key() == key; });
+    if (pipeline != m_pipelineLayouts.end()) {
+        return *pipeline;
+    }
+
+    return m_pipelineLayouts.emplace_back(makeShared<CVkPipelineLayout>(g_pHyprVulkan->m_device, key));
+}
+
+SP<CVkPipelineLayout> CHyprVKRenderer::ensurePipelineLayout(uint32_t vertSize, uint32_t fragSize, uint8_t texCount, uint8_t uboCount) {
+    return ensurePipelineLayout({vertSize, fragSize, VK_FILTER_LINEAR, texCount, uboCount});
+}
+
+void CHyprVKRenderer::setTexBarriers(SP<ITexture> tex) {
+    if (VKTEX(tex)->m_barriersSet)
+        return;
+    VKTEX(tex)->m_barriersSet = true;
+    m_needBarriers.push_back(tex);
+}

--- a/src/render/VKRenderer.hpp
+++ b/src/render/VKRenderer.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "Renderer.hpp"
+#include "./vulkan/Vulkan.hpp"
+#include "./vulkan/Framebuffer.hpp"
+#include "./vulkan/RenderPass.hpp"
+#include "./vulkan/Pipeline.hpp"
+#include "./vulkan/PipelineLayout.hpp"
+#include "./vulkan/Shaders.hpp"
+#include "desktop/DesktopTypes.hpp"
+#include "helpers/Format.hpp"
+#include "render/Framebuffer.hpp"
+#include "render/Texture.hpp"
+#include "render/vulkan/BlurPass.hpp"
+#include "render/vulkan/BorderGradientUBO.hpp"
+#include "render/vulkan/CommandBuffer.hpp"
+#include "render/vulkan/VKElementRenderer.hpp"
+#include <cstdint>
+#include <drm_fourcc.h>
+#include <hyprutils/math/Box.hpp>
+#include <vector>
+
+namespace Render::VK {
+    class CHyprVKRenderer : public IHyprRenderer {
+      public:
+        CHyprVKRenderer();
+
+        eType                   type() override;
+        void                    startRenderPass() override;
+        void                    endRender(const std::function<void()>& renderingDoneCallback = {}) override;
+        SP<ITexture>            createStencilTexture(const int width, const int height) override;
+        SP<ITexture>            createTexture(bool opaque = false) override;
+        SP<ITexture>            createTexture(uint32_t drmFormat, uint8_t* pixels, uint32_t stride, const Vector2D& size, bool keepDataCopy = false, bool opaque = false) override;
+        SP<ITexture>            createTexture(const Aquamarine::SDMABUFAttrs&, bool opaque = false) override;
+        SP<ITexture>            createTexture(const int width, const int height, unsigned char* const data) override;
+        SP<ITexture>            createTexture(cairo_surface_t* cairo) override;
+        SP<ITexture>            createTexture(std::span<const float> lut3D, size_t N) override;
+        bool                    explicitSyncSupported() override;
+        std::vector<SDRMFormat> getDRMFormats() override;
+        std::vector<uint64_t>   getDRMFormatModifiers(DRMFormat format) override;
+        SP<IFramebuffer>        createFB(const std::string& name = "") override;
+        void                    disableScissor() override;
+        void                    blend(bool enabled) override;
+        void                    drawShadow(const CBox& box, int round, float roundingPower, int range, CHyprColor color, float a) override;
+        void                    setViewport(int x, int y, int width, int height) override;
+        bool                    reloadShaders(const std::string& path = "") override;
+
+        // TODO fix api
+        SP<CVkPipelineLayout> ensurePipelineLayout(CVkPipelineLayout::KEY key);
+        SP<CVkPipelineLayout> ensurePipelineLayout(uint32_t vertSize, uint32_t fragSize, uint8_t texCount = 1, uint8_t uboCount = 0);
+        SP<CVkRenderPass>     getRenderPass(uint32_t fmt);
+        SP<CVKBlurPass>       getBlurPass(uint32_t fmt);
+        void                  bindFB(SP<IFramebuffer> fb) override;
+        UP<ISyncFDManager>    createSyncFDManager() override;
+        WP<IElementRenderer>  elementRenderer() override;
+
+      private:
+        SP<ITexture>                                     blurFramebuffer(SP<IFramebuffer> source, float a, CRegion* originalDamage) override;
+        void                                             renderOffToMain(SP<IFramebuffer> off) override;
+        SP<IRenderbuffer>                                getOrCreateRenderbufferInternal(SP<Aquamarine::IBuffer> buffer, uint32_t fmt) override;
+        bool                                             beginRenderInternal(PHLMONITOR pMonitor, CRegion& damage, bool simple = false) override;
+        bool                                             beginFullFakeRenderInternal(PHLMONITOR pMonitor, CRegion& damage, SP<IFramebuffer> fb, bool simple = false) override;
+        void                                             initRender() override;
+        bool                                             initRenderBuffer(SP<Aquamarine::IBuffer> buffer, uint32_t fmt) override;
+
+        void                                             bindPipeline(WP<CVkPipeline> pipeline);
+        Vector2D                                         currentRBSize();
+        SP<CVKBorderGradientUBO>                         getGradientForWindow(PHLWINDOWREF window);
+
+        void                                             setTexBarriers(SP<ITexture> tex);
+
+        UP<IElementRenderer>                             m_elementRenderer;
+
+        bool                                             m_busy         = false;
+        bool                                             m_inRenderPass = false;
+        SP<CVKFramebuffer>                               m_hasBoundFB;
+        CBox                                             m_viewport;
+
+        Vector2D                                         m_currentRenderbufferSize;
+
+        std::vector<SP<CVkRenderPass>>                   m_renderPassList;
+        std::vector<SP<CVKBlurPass>>                     m_blurPassList;
+        SP<CVkRenderPass>                                m_currentRenderPass;
+        SP<CVkShaders>                                   m_shaders;
+        DRMFormat                                        m_currentDrmFormat = DRM_FORMAT_INVALID;
+
+        std::vector<SP<CVkPipelineLayout>>               m_pipelineLayouts;
+
+        WP<CVkPipeline>                                  m_currentPipeline;
+        WP<CHyprVkCommandBuffer>                         m_currentCommandBuffer;
+
+        std::map<PHLWINDOWREF, SP<CVKBorderGradientUBO>> m_borderGradients;
+
+        std::vector<SP<ITexture>>                        m_needBarriers;
+
+        friend class CHyprVulkanImpl;
+        friend class CVKBlurPass;
+        friend class CVKElementRenderer;
+    };
+}

--- a/src/render/pass/TexPassElement.cpp
+++ b/src/render/pass/TexPassElement.cpp
@@ -1,12 +1,13 @@
 #include "TexPassElement.hpp"
 #include "../Renderer.hpp"
+#include "macros.hpp"
 
 CTexPassElement::CTexPassElement(const SRenderData& data) : m_data(data) {
-    ;
+    RASSERT(m_data.tex && m_data.tex->ok(), "Trying to render invalid tex");
 }
 
 CTexPassElement::CTexPassElement(CTexPassElement::SRenderData&& data) : m_data(std::move(data)) {
-    ;
+    RASSERT(m_data.tex && m_data.tex->ok(), "Trying to render invalid tex");
 }
 
 bool CTexPassElement::needsLiveBlur() {

--- a/src/render/shaders/glsl/structs.h
+++ b/src/render/shaders/glsl/structs.h
@@ -1,0 +1,47 @@
+#ifndef STRUCTS_H
+#define STRUCTS_H
+struct SShaderTargetPrimaries {
+    float xyz[3][3];
+    float sdrSaturation;
+    float sdrBrightnessMultiplier;
+    float _junk;
+};
+
+struct SShaderTonemap {
+    float maxLuminance;
+    float dstMaxLuminance;
+    float dstRefLuminance;
+    float _junk;
+};
+
+struct SShaderCM {
+    int   sourceTF; // eTransferFunction
+    int   targetTF; // eTransferFunction
+    float srcRefLuminance;
+
+    float srcTFRange[2];
+    float dstTFRange[2];
+
+    float convertMatrix[3][3];
+};
+
+struct SRounding {
+    float radius;
+    float power;
+    float topLeft[2];
+    float fullSize[2];
+    float _junk[2];
+};
+
+vec2 float2vec(float[2] v) {
+    return vec2(v[0], v[1]);
+}
+
+mat3 float33TOmat3(float[3][3] mat) {
+    return mat3(                         //
+        mat[0][0], mat[1][0], mat[2][0], //
+        mat[0][1], mat[1][1], mat[2][1], //
+        mat[0][2], mat[1][2], mat[2][2]  //
+    );
+}
+#endif

--- a/src/render/shaders/glsl/vk_blur1.frag
+++ b/src/render/shaders/glsl/vk_blur1.frag
@@ -1,0 +1,24 @@
+#version 450
+#define ALLOW_INCLUDES
+#extension GL_ARB_shading_language_include : enable
+
+precision highp float;
+layout(location = 0) in vec2 v_texcoord;
+layout(set = 0, binding = 0) uniform sampler2D tex;
+
+layout(push_constant, row_major) uniform UBO {
+    layout(offset = 80) float radius;
+    vec2                      halfpixel;
+    int                       passes;
+    float                     vibrancy;
+    float                     vibrancy_darkness;
+}
+data;
+
+layout(location = 0) out vec4 fragColor;
+
+#include "blur1.glsl"
+
+void main() {
+    fragColor = blur1(v_texcoord, tex, data.radius, data.halfpixel, data.passes, data.vibrancy, data.vibrancy_darkness);
+}

--- a/src/render/shaders/glsl/vk_blur2.frag
+++ b/src/render/shaders/glsl/vk_blur2.frag
@@ -1,0 +1,21 @@
+#version 450
+#define ALLOW_INCLUDES
+#extension GL_ARB_shading_language_include : enable
+
+precision highp float;
+layout(location = 0) in vec2 v_texcoord;
+layout(set = 0, binding = 0) uniform sampler2D tex;
+
+layout(push_constant, row_major) uniform UBO {
+    layout(offset = 80) float radius;
+    vec2                      halfpixel;
+}
+data;
+
+layout(location = 0) out vec4 fragColor;
+
+#include "blur2.glsl"
+
+void main() {
+    fragColor = blur2(v_texcoord, tex, data.radius, data.halfpixel);
+}

--- a/src/render/shaders/glsl/vk_blurfinish.frag
+++ b/src/render/shaders/glsl/vk_blurfinish.frag
@@ -1,0 +1,22 @@
+#version 450
+#define ALLOW_INCLUDES
+#extension GL_ARB_shading_language_include : enable
+
+precision highp float;
+layout(location = 0) in vec2 v_texcoord;
+layout(set = 0, binding = 0) uniform sampler2D tex;
+
+layout(push_constant, row_major) uniform UBO {
+    layout(offset = 80) float noise;
+    float                     brightness;
+}
+data;
+
+#include "blurFinish.glsl"
+
+layout(location = 0) out vec4 fragColor;
+void main() {
+    vec4 pixColor = texture(tex, v_texcoord);
+
+    fragColor = blurFinish(pixColor, v_texcoord, data.noise, data.brightness);
+}

--- a/src/render/shaders/glsl/vk_blurprepare.frag
+++ b/src/render/shaders/glsl/vk_blurprepare.frag
@@ -1,0 +1,34 @@
+#version 450
+#define ALLOW_INCLUDES
+#extension GL_ARB_shading_language_include : enable
+
+precision highp float;
+layout(location = 0) in vec2 v_texcoord;
+layout(set = 0, binding = 0) uniform sampler2D tex;
+
+#include "defines.h"
+#include "constants.h"
+#include "structs.h"
+
+layout(push_constant, row_major) uniform UBO {
+    layout(offset = 80) float contrast;
+    float                     brightness;
+    float                     sdrBrightnessMultiplier;
+#if USE_CM
+    layout(offset = 96) SShaderCM cm;
+#endif
+}
+data;
+
+layout(location = 0) out vec4 fragColor;
+#include "blurprepare.glsl"
+
+void main() {
+    fragColor = blurPrepare(texture(tex, v_texcoord), data.contrast, data.brightness
+#if USE_CM
+                            ,
+                            data.cm.sourceTF, data.cm.targetTF, float33TOmat3(data.cm.convertMatrix), float2vec(data.cm.srcTFRange), float2vec(data.cm.dstTFRange),
+                            data.cm.srcRefLuminance, data.sdrBrightnessMultiplier
+#endif
+    );
+}

--- a/src/render/shaders/glsl/vk_border.frag
+++ b/src/render/shaders/glsl/vk_border.frag
@@ -1,0 +1,69 @@
+#version 450
+#define ALLOW_INCLUDES
+#extension GL_ARB_shading_language_include : enable
+
+precision highp float;
+layout(location = 0) in vec2 v_texcoord;
+
+#include "defines.h"
+#include "constants.h"
+#include "structs.h"
+
+layout(push_constant, row_major) uniform UBOPush {
+    layout(offset = 80) float fullSizeUntransformed[2];
+    float                     radiusOuter;
+    float                     thick;
+    float                     angle;
+    float                     angle2;
+    float                     alpha;
+    float                     _junk;
+#if USE_ROUNDING
+    SRounding rounding;
+#endif
+#if USE_CM
+    SShaderCM cm;
+#endif
+#if USE_TONEMAP
+    SShaderTonemap tonemap;
+#endif
+#if USE_TONEMAP || USE_SDR_MOD
+    SShaderTargetPrimaries targetPrimaries;
+#endif
+}
+data;
+
+layout(std140, set = 0, binding = 0) uniform UBO {
+    vec4  gradient[10];
+    vec4  gradient2[10];
+    int   gradientLength;
+    int   gradient2Length;
+    float gradientLerp;
+}
+gradientData;
+
+#include "border.glsl"
+
+layout(location = 0) out vec4 fragColor;
+void main() {
+    fragColor = getBorder(v_texcoord, data.alpha, float2vec(data.fullSizeUntransformed), data.radiusOuter, data.thick, data.rounding.radius, data.rounding.power,
+                          float2vec(data.rounding.topLeft), float2vec(data.rounding.fullSize), gradientData.gradientLength, gradientData.gradient, data.angle,
+                          gradientData.gradient2Length, gradientData.gradient2, data.angle2, gradientData.gradientLerp
+#if USE_CM
+                          ,
+                          data.cm.sourceTF, data.cm.targetTF, float33TOmat3(data.cm.convertMatrix), float2vec(data.cm.srcTFRange), float2vec(data.cm.dstTFRange)
+#if USE_TONEMAP || USE_SDR_MOD
+                                                                                                                                       ,
+                          float33TOmat3(data.targetPrimaries.xyz)
+#endif
+#if USE_TONEMAP
+                              ,
+                          data.tonemap.maxLuminance, data.tonemap.dstMaxLuminance, data.tonemap.dstRefLuminance, data.cm.srcRefLuminance
+#endif
+#if USE_SDR_MOD
+                          ,
+                          data.targetPrimaries.sdrSaturation, data.targetPrimaries.sdrBrightnessMultiplier
+#endif
+#endif
+
+    );
+}

--- a/src/render/shaders/glsl/vk_border.frag
+++ b/src/render/shaders/glsl/vk_border.frag
@@ -17,9 +17,9 @@ layout(push_constant, row_major) uniform UBOPush {
     float                     angle2;
     float                     alpha;
     float                     _junk;
-#if USE_ROUNDING
+    // #if USE_ROUNDING
     SRounding rounding;
-#endif
+// #endif
 #if USE_CM
     SShaderCM cm;
 #endif

--- a/src/render/shaders/glsl/vk_matte.frag
+++ b/src/render/shaders/glsl/vk_matte.frag
@@ -1,0 +1,11 @@
+#version 450
+
+precision highp float;
+layout(location = 0) in vec2 v_texcoord;
+layout(set = 0, binding = 0) uniform sampler2D tex;
+layout(set = 1, binding = 0) uniform sampler2D texMatte;
+
+layout(location = 0) out vec4 fragColor;
+void main() {
+    fragColor = texture(tex, v_texcoord) * texture(texMatte, v_texcoord)[0]; // I know it only uses R, but matte should be black/white anyways.
+}

--- a/src/render/shaders/glsl/vk_pass.frag
+++ b/src/render/shaders/glsl/vk_pass.frag
@@ -1,0 +1,10 @@
+#version 450
+
+precision highp float;
+layout(location = 0) in vec2 v_texcoord;
+layout(set = 0, binding = 0) uniform sampler2D tex;
+
+layout(location = 0) out vec4 fragColor;
+void main() {
+    fragColor = texture(tex, v_texcoord);
+}

--- a/src/render/shaders/glsl/vk_quad.frag
+++ b/src/render/shaders/glsl/vk_quad.frag
@@ -1,0 +1,33 @@
+#version 450
+#define ALLOW_INCLUDES
+#extension GL_ARB_shading_language_include : enable
+
+precision highp float;
+layout(location = 0) in vec2 v_texcoord;
+
+#include "defines.h"
+#include "constants.h"
+#include "structs.h"
+
+layout(push_constant, row_major) uniform UBO {
+    layout(offset = 80) vec4 v_color;
+#if USE_ROUNDING
+    SRounding rounding;
+#endif
+}
+data;
+
+#if USE_ROUNDING
+#include "rounding.glsl"
+#endif
+
+layout(location = 0) out vec4 fragColor;
+void main() {
+    vec4 pixColor = data.v_color;
+
+#if USE_ROUNDING
+    pixColor = rounding(pixColor, data.rounding.radius, data.rounding.power, float2vec(data.rounding.topLeft), float2vec(data.rounding.fullSize));
+#endif
+
+    fragColor = pixColor;
+}

--- a/src/render/shaders/glsl/vk_shadow.frag
+++ b/src/render/shaders/glsl/vk_shadow.frag
@@ -1,0 +1,55 @@
+#version 450
+#define ALLOW_INCLUDES
+#extension GL_ARB_shading_language_include : enable
+
+precision highp float;
+layout(location = 0) in vec2 v_texcoord;
+
+#include "defines.h"
+#include "constants.h"
+#include "structs.h"
+
+layout(push_constant, row_major) uniform UBO {
+    layout(offset = 80) vec4 v_color;
+    vec2                     bottomRight;
+    float                    range;
+    float                    shadowPower;
+#if USE_ROUNDING
+    SRounding rounding;
+#endif
+#if USE_CM
+    SShaderCM cm;
+#endif
+#if USE_TONEMAP
+    SShaderTonemap tonemap;
+#endif
+#if USE_TONEMAP || USE_SDR_MOD
+    SShaderTargetPrimaries targetPrimaries;
+#endif
+}
+data;
+
+#include "shadow.glsl"
+
+layout(location = 0) out vec4 fragColor;
+void main() {
+    fragColor = getShadow(data.v_color, v_texcoord, data.rounding.radius, data.rounding.power, float2vec(data.rounding.topLeft), float2vec(data.rounding.fullSize), data.range,
+                          data.shadowPower, data.bottomRight
+#if USE_CM
+                          ,
+                          data.cm.sourceTF, data.cm.targetTF, float33TOmat3(data.cm.convertMatrix), float2vec(data.cm.srcTFRange), float2vec(data.cm.dstTFRange)
+#if USE_TONEMAP || USE_SDR_MOD
+                                                                                                                                       ,
+                          float33TOmat3(data.targetPrimaries.xyz)
+#endif
+#if USE_TONEMAP
+                              ,
+                          data.tonemap.maxLuminance, data.tonemap.dstMaxLuminance, data.tonemap.dstRefLuminance, data.cm.srcRefLuminance
+#endif
+#if USE_SDR_MOD
+                          ,
+                          data.targetPrimaries.sdrSaturation, data.targetPrimaries.sdrBrightnessMultiplier
+#endif
+#endif
+    );
+}

--- a/src/render/shaders/glsl/vk_tex.frag
+++ b/src/render/shaders/glsl/vk_tex.frag
@@ -1,0 +1,97 @@
+#version 450
+#define ALLOW_INCLUDES
+#extension GL_ARB_shading_language_include : enable
+#extension GL_EXT_debug_printf : enable
+
+layout(set = 0, binding = 0) uniform sampler2D tex;
+layout(set = 1, binding = 0) uniform sampler2D blurredBG;
+
+layout(location = 0) in vec2 v_texcoord;
+layout(location = 1) in vec2 uvOffset;
+layout(location = 2) in vec2 uvSize;
+layout(location = 0) out vec4 fragColor;
+
+#include "defines.h"
+#include "constants.h"
+#include "structs.h"
+
+layout(push_constant, row_major) uniform UBO {
+    layout(offset = 80) float alpha;
+    float                     tint;
+    int                       discardMode;
+    float                     discardAlphaValue;
+#if USE_ROUNDING
+    SRounding rounding;
+#endif
+#if USE_CM
+    SShaderCM cm;
+#endif
+#if USE_TONEMAP
+    SShaderTonemap tonemap;
+#endif
+#if USE_TONEMAP || USE_SDR_MOD
+    SShaderTargetPrimaries targetPrimaries;
+#endif
+}
+data;
+
+#if USE_CM
+#include "cm_helpers.glsl"
+#endif
+
+#if USE_ROUNDING
+#include "rounding.glsl"
+#endif
+
+void main() {
+#if USE_RGBA
+    vec4 pixColor = texture(tex, v_texcoord);
+#else
+    vec4 pixColor = vec4(texture(tex, v_texcoord).rgb, 1.0);
+#endif
+
+#if USE_DISCARD && !USE_BLUR
+    if ((data.discardMode == 1 || data.discardMode == 3) && pixColor.a * data.alpha == 1.0)
+        discard;
+
+    if ((data.discardMode == 2 || data.discardMode == 3) && pixColor.a <= data.discardAlphaValue)
+        discard;
+#endif
+
+#if USE_CM
+    mat3 convertMatrix = float33TOmat3(data.cm.convertMatrix);
+    pixColor           = doColorManagement(pixColor, data.cm.sourceTF, data.cm.targetTF, convertMatrix, float2vec(data.cm.srcTFRange), float2vec(data.cm.dstTFRange)
+#if USE_TONEMAP || USE_SDR_MOD
+                                                                                                                                 ,
+                                 float33TOmat3(data.targetPrimaries.xyz)
+#endif
+#if USE_TONEMAP
+                                     ,
+                                 data.tonemap.maxLuminance, data.tonemap.dstMaxLuminance, data.tonemap.dstRefLuminance, data.cm.srcRefLuminance
+#endif
+#if USE_SDR_MOD
+                                 ,
+                                 data.targetPrimaries.sdrSaturation, data.targetPrimaries.sdrBrightnessMultiplier
+#endif
+    );
+#endif
+
+#if USE_TINT
+    pixColor.rgb = pixColor.rgb * data.tint;
+#endif
+
+#if USE_ROUNDING
+    pixColor = rounding(pixColor, data.rounding.radius, data.rounding.power, float2vec(data.rounding.topLeft), float2vec(data.rounding.fullSize));
+#endif
+
+#if USE_BLUR
+#if USE_DISCARD
+    pixColor = mix(pixColor, vec4(mix(texture(blurredBG, v_texcoord * uvSize + uvOffset).rgb, pixColor.rgb, pixColor.a), 1.0),
+                   ((data.discardMode == 2 || data.discardMode == 3)) && (pixColor.a <= data.discardAlphaValue) ? 0.0 : 1.0);
+#else
+    pixColor = vec4(mix(texture(blurredBG, v_texcoord * uvSize + uvOffset).rgb, pixColor.rgb, pixColor.a), 1.0);
+#endif
+#endif
+
+    fragColor = pixColor * data.alpha;
+}

--- a/src/render/shaders/glsl/vulkan.vert
+++ b/src/render/shaders/glsl/vulkan.vert
@@ -1,0 +1,21 @@
+#version 450
+
+layout(push_constant, row_major) uniform UBO {
+    mat4 proj;
+    vec2 uvOffset;
+    vec2 uvSize;
+}
+data;
+
+layout(location = 0) out vec2 uv;
+layout(location = 1) out vec2 uvOffset;
+layout(location = 2) out vec2 uvSize;
+
+void main() {
+    vec2 pos = vec2(float((gl_VertexIndex + 1) & 2) * 0.5f, float(gl_VertexIndex & 2) * 0.5f);
+    // uv = data.uvOffset + pos * data.uvSize;
+    uv          = pos;
+    uvOffset    = data.uvOffset;
+    uvSize      = data.uvSize;
+    gl_Position = data.proj * vec4(pos, 0.0, 1.0);
+}

--- a/src/render/vulkan/BlurPass.cpp
+++ b/src/render/vulkan/BlurPass.cpp
@@ -1,0 +1,295 @@
+#include "BlurPass.hpp"
+#include "../Framebuffer.hpp"
+#include "Framebuffer.hpp"
+#include "VKTexture.hpp"
+#include "Vulkan.hpp"
+#include "helpers/cm/ColorManagement.hpp"
+#include "render/Renderer.hpp"
+#include "render/ShaderLoader.hpp"
+#include "render/Texture.hpp"
+#include "render/VKRenderer.hpp"
+#include "render/vulkan/CommandBuffer.hpp"
+#include "render/vulkan/types.hpp"
+#include "utils.hpp"
+#include <hyprutils/math/Misc.hpp>
+#include <hyprutils/math/Region.hpp>
+#include <hyprutils/memory/SharedPtr.hpp>
+#include <vulkan/vulkan_core.h>
+
+using namespace Render::VK;
+
+CVKBlurPass::CVKBlurPass(WP<CHyprVulkanDevice> device, DRMFormat format, SP<CVkShaders> shaders, int passes) :
+    IDeviceUser(device), m_drmFormat(format), m_shaders(shaders), m_passes(passes) {
+    const auto info = m_device->getFormat(m_drmFormat);
+    RASSERT(info.has_value(), "No info for drm format {}", NFormatUtils::drmFormatName(m_drmFormat));
+
+    m_preparePipeline   = makeShared<CVkPipeline>(m_device, info->format.vkFormat, m_shaders->m_vert, m_shaders->getShaderVariant(SH_FRAG_BLURPREPARE),
+                                                  CVkPipeline::SSettings{.subpass = 0, .blend = false});
+    m_prepareCMPipeline = makeShared<CVkPipeline>(m_device, info->format.vkFormat, m_shaders->m_vert, m_shaders->getShaderVariant(SH_FRAG_BLURPREPARE, SH_FEAT_CM),
+                                                  CVkPipeline::SSettings{.subpass = 0, .blend = false});
+    m_blur1Pipeline     = makeShared<CVkPipeline>(m_device, info->format.vkFormat, m_shaders->m_vert, m_shaders->getShaderVariant(SH_FRAG_BLUR1),
+                                                  CVkPipeline::SSettings{.subpass = 0, .blend = false});
+    m_blur2Pipeline     = makeShared<CVkPipeline>(m_device, info->format.vkFormat, m_shaders->m_vert, m_shaders->getShaderVariant(SH_FRAG_BLUR2),
+                                                  CVkPipeline::SSettings{.subpass = 0, .blend = false});
+    m_finishPipeline    = makeShared<CVkPipeline>(m_device, info->format.vkFormat, m_shaders->m_vert, m_shaders->getShaderVariant(SH_FRAG_BLURFINISH),
+                                                  CVkPipeline::SSettings{.subpass = 0, .blend = false});
+}
+
+CVKBlurPass::~CVKBlurPass() = default;
+
+DRMFormat CVKBlurPass::format() {
+    return m_drmFormat;
+}
+
+int CVKBlurPass::passes() {
+    return m_passes;
+}
+
+static void beginRendering(WP<CHyprVkCommandBuffer> cb, WP<CVKFramebuffer> target) {
+    cb->changeLayout(target, //
+                     {.layout = target->m_lastKnownLayout, .stageMask = VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, .accessMask = VK_ACCESS_TRANSFER_WRITE_BIT},
+                     {.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, .stageMask = VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, .accessMask = 0});
+
+    VkRenderingAttachmentInfo attachment = {
+        .sType       = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
+        .imageView   = VKTEX(target->getTexture())->vkView(),
+        .imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+        .loadOp      = VK_ATTACHMENT_LOAD_OP_LOAD,
+        .storeOp     = VK_ATTACHMENT_STORE_OP_STORE,
+        .clearValue  = {.color = {{0.0f, 0.0f, 0.0f, 0.0f}}},
+    };
+
+    VkRenderingInfo info = {
+        .sType = VK_STRUCTURE_TYPE_RENDERING_INFO,
+        .renderArea =
+            {
+                .offset = {0, 0},
+                .extent = {target->m_size.x, target->m_size.y},
+            },
+        .layerCount           = 1,
+        .colorAttachmentCount = 1,
+        .pColorAttachments    = &attachment,
+    };
+
+    vkCmdBeginRendering(cb->vk(), &info);
+
+    VkViewport viewport = {
+        .width    = target->m_size.x,
+        .height   = target->m_size.y,
+        .maxDepth = 1,
+    };
+    vkCmdSetViewport(g_pHyprVulkan->renderCB()->vk(), 0, 1, &viewport);
+}
+
+static void endRendering(WP<CHyprVkCommandBuffer> cb, WP<CVKFramebuffer> target) {
+    vkCmdEndRendering(cb->vk());
+
+    cb->changeLayout(target, //
+                     {.layout = target->m_lastKnownLayout, .stageMask = VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, .accessMask = VK_ACCESS_TRANSFER_WRITE_BIT},
+                     {.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, .stageMask = VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, .accessMask = 0});
+}
+
+SP<Render::ITexture> CVKBlurPass::blurTexture(SP<ITexture> tex, SP<IFramebuffer> first, SP<IFramebuffer> second, float a, const CRegion& damage) {
+    if (!tex)
+        return tex;
+
+    static auto PBLURSIZE             = CConfigValue<Hyprlang::INT>("decoration:blur:size");
+    static auto PBLURVIBRANCY         = CConfigValue<Hyprlang::FLOAT>("decoration:blur:vibrancy");
+    static auto PBLURVIBRANCYDARKNESS = CConfigValue<Hyprlang::FLOAT>("decoration:blur:vibrancy_darkness");
+    static auto PBLURCONTRAST         = CConfigValue<Hyprlang::FLOAT>("decoration:blur:contrast");
+    static auto PBLURBRIGHTNESS       = CConfigValue<Hyprlang::FLOAT>("decoration:blur:brightness");
+    static auto PBLURNOISE            = CConfigValue<Hyprlang::FLOAT>("decoration:blur:noise");
+
+    auto        fbSize  = first->getTexture()->m_size;
+    CRegion     clipBox = {0, 0, fbSize.x, fbSize.y};
+    // const CRegion& clipBox = damage;
+
+    const auto texture  = VKTEX(tex);
+    const auto renderer = dc<CHyprVKRenderer*>(g_pHyprRenderer.get());
+    const auto cb       = g_pHyprVulkan->renderCB();
+    cb->useTexture(tex);
+    cb->useTexture(first->getTexture());
+    cb->useTexture(second->getTexture());
+
+    const auto  TRANSFORM  = Math::wlTransformToHyprutils(Math::invertTransform(g_pHyprRenderer->m_renderData.pMonitor->m_transform));
+    CBox        MONITORBOX = {0, 0, g_pHyprRenderer->m_renderData.pMonitor->m_transformedSize.x, g_pHyprRenderer->m_renderData.pMonitor->m_transformedSize.y};
+
+    const auto  mat = g_pHyprRenderer->projectBoxToTarget(MONITORBOX, TRANSFORM).getMatrix();
+
+    const auto& vertData = matToVertShader(mat);
+
+    // prepare
+    {
+        VK_CB_LABEL_BEGIN(cb->vk(), "Prepare blur");
+        beginRendering(cb, dynamicPointerCast<CVKFramebuffer>(first));
+
+        static const auto PCM      = CConfigValue<Hyprlang::INT>("render:cm_enabled");
+        const bool        skipCM   = !*PCM || g_pHyprRenderer->m_renderData.pMonitor->m_imageDescription->id() == NColorManagement::getDefaultImageDescription()->id();
+        const auto        pipeline = skipCM ? m_preparePipeline : m_prepareCMPipeline;
+        const auto        layout   = pipeline->layout().lock();
+        const auto        view     = texture->getView(layout);
+        if (!view)
+            return tex;
+
+        // FIXME weird transform
+        const auto TRANSFORM =
+            g_pHyprRenderer->m_renderData.pMonitor->m_transform == WL_OUTPUT_TRANSFORM_90 || g_pHyprRenderer->m_renderData.pMonitor->m_transform == WL_OUTPUT_TRANSFORM_270 ?
+            HYPRUTILS_TRANSFORM_180 :
+            HYPRUTILS_TRANSFORM_NORMAL;
+        const auto           mat = g_pHyprRenderer->projectBoxToTarget(MONITORBOX, TRANSFORM).getMatrix();
+
+        const auto&          vertData = matToVertShader(mat);
+
+        SVkPrepareShaderData fragData = {
+            .contrast                = *PBLURCONTRAST,
+            .brightness              = *PBLURBRIGHTNESS,
+            .sdrBrightnessMultiplier = 1.0f,
+        };
+
+        SShaderCM cmData;
+        if (!skipCM) {
+            auto        settings = g_pHyprRenderer->getCMSettings(g_pHyprRenderer->m_renderData.pMonitor->m_imageDescription, NColorManagement::getDefaultImageDescription(),
+                                                                  g_pHyprRenderer->m_renderData.surface.valid() ? g_pHyprRenderer->m_renderData.surface.lock() : nullptr);
+            const auto& mat      = settings.convertMatrix;
+
+            cmData = {
+                .sourceTF        = settings.sourceTF,
+                .targetTF        = settings.targetTF,
+                .srcRefLuminance = settings.srcRefLuminance,
+
+                .srcTFRange = {settings.srcTFRange.min, settings.srcTFRange.max},
+                .dstTFRange = {settings.dstTFRange.min, settings.dstTFRange.max},
+
+                .convertMatrix =
+                    {
+                        {mat[0][0], mat[0][1], mat[0][2]}, //
+                        {mat[1][0], mat[1][1], mat[1][2]}, //
+                        {mat[2][0], mat[2][1], mat[2][2]}, //,
+                    },
+            };
+            fragData.sdrBrightnessMultiplier = settings.sdrBrightnessMultiplier;
+        }
+
+        renderer->bindPipeline(pipeline);
+
+        const auto ds = view->vkDS();
+        vkCmdBindDescriptorSets(cb->vk(), VK_PIPELINE_BIND_POINT_GRAPHICS, layout->vk(), 0, 1, &ds, 0, nullptr);
+
+        vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(vertData), &vertData);
+        vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, sizeof(vertData), sizeof(fragData), &fragData);
+        if (!skipCM)
+            vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, sizeof(vertData) + sizeof(fragData), sizeof(cmData), &cmData);
+
+        drawRegionRects(clipBox, cb->vk(), false);
+
+        endRendering(cb, dynamicPointerCast<CVKFramebuffer>(first));
+        VK_CB_LABEL_END(cb->vk());
+    }
+
+    const SP<IFramebuffer> buffers[2] = {first, second};
+    int                    sourceIdx  = 0;
+
+    for (int i = 0; i < m_passes; i++) {
+        // blur1
+        int targetIdx = (sourceIdx + 1) % 2;
+        VK_CB_LABEL_BEGIN(cb->vk(), std::format("Blur 1 pass {}", i));
+        beginRendering(cb, dynamicPointerCast<CVKFramebuffer>(buffers[targetIdx]));
+
+        const auto pipeline = m_blur1Pipeline;
+        const auto layout   = pipeline->layout().lock();
+        const auto view     = VKTEX(buffers[sourceIdx]->getTexture())->getView(layout);
+        if (!view)
+            return tex;
+
+        SVkBlur1ShaderData fragData = {
+            .radius           = *PBLURSIZE * a,
+            .halfpixel        = {0.5f / (g_pHyprRenderer->m_renderData.pMonitor->m_pixelSize.x / 2.f), 0.5f / (g_pHyprRenderer->m_renderData.pMonitor->m_pixelSize.y / 2.f)},
+            .passes           = m_passes,
+            .vibrancy         = *PBLURVIBRANCY,
+            .vibrancyDarkness = *PBLURVIBRANCYDARKNESS,
+        };
+
+        renderer->bindPipeline(pipeline);
+
+        const auto ds = view->vkDS();
+        vkCmdBindDescriptorSets(cb->vk(), VK_PIPELINE_BIND_POINT_GRAPHICS, layout->vk(), 0, 1, &ds, 0, nullptr);
+
+        vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(vertData), &vertData);
+        vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, sizeof(vertData), sizeof(fragData), &fragData);
+
+        drawRegionRects(clipBox, cb->vk(), false);
+
+        endRendering(cb, dynamicPointerCast<CVKFramebuffer>(buffers[targetIdx]));
+        VK_CB_LABEL_END(cb->vk());
+
+        sourceIdx = targetIdx;
+    }
+
+    for (int i = 0; i < m_passes; i++) {
+        // blur2
+        int targetIdx = (sourceIdx + 1) % 2;
+        VK_CB_LABEL_BEGIN(cb->vk(), std::format("Blur 2 pass {}", i));
+        beginRendering(cb, dynamicPointerCast<CVKFramebuffer>(buffers[targetIdx]));
+
+        const auto pipeline = m_blur2Pipeline;
+        const auto layout   = pipeline->layout().lock();
+        const auto view     = VKTEX(buffers[sourceIdx]->getTexture())->getView(layout);
+        if (!view)
+            return tex;
+
+        SVkBlur2ShaderData fragData = {
+            .radius    = *PBLURSIZE * a,
+            .halfpixel = {0.5f / (g_pHyprRenderer->m_renderData.pMonitor->m_pixelSize.x * 2.f), 0.5f / (g_pHyprRenderer->m_renderData.pMonitor->m_pixelSize.y * 2.f)},
+        };
+
+        renderer->bindPipeline(pipeline);
+
+        const auto ds = view->vkDS();
+        vkCmdBindDescriptorSets(cb->vk(), VK_PIPELINE_BIND_POINT_GRAPHICS, layout->vk(), 0, 1, &ds, 0, nullptr);
+
+        vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(vertData), &vertData);
+        vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, sizeof(vertData), sizeof(fragData), &fragData);
+
+        drawRegionRects(clipBox, cb->vk(), false);
+
+        endRendering(cb, dynamicPointerCast<CVKFramebuffer>(buffers[targetIdx]));
+        VK_CB_LABEL_END(cb->vk());
+
+        sourceIdx = targetIdx;
+    }
+
+    // finish
+    {
+        VK_CB_LABEL_BEGIN(cb->vk(), "Finish blur");
+        beginRendering(cb, dynamicPointerCast<CVKFramebuffer>(second));
+
+        const auto layout = m_finishPipeline->layout().lock();
+        const auto view   = VKTEX(first->getTexture())->getView(layout);
+        if (!view)
+            return tex;
+
+        SVkFinishShaderData fragData = {
+            .noise      = *PBLURNOISE,
+            .brightness = *PBLURBRIGHTNESS,
+        };
+
+        renderer->bindPipeline(m_finishPipeline);
+
+        const auto ds = view->vkDS();
+        vkCmdBindDescriptorSets(cb->vk(), VK_PIPELINE_BIND_POINT_GRAPHICS, layout->vk(), 0, 1, &ds, 0, nullptr);
+
+        vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(vertData), &vertData);
+        vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, sizeof(vertData), sizeof(fragData), &fragData);
+
+        drawRegionRects(clipBox, cb->vk(), false);
+
+        endRendering(cb, dynamicPointerCast<CVKFramebuffer>(second));
+        VK_CB_LABEL_END(cb->vk());
+    }
+
+    VKFB(first)->m_lastKnownLayout  = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    VKFB(second)->m_lastKnownLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+    second->getTexture()->m_transform = TRANSFORM;
+    return second->getTexture();
+}

--- a/src/render/vulkan/BlurPass.hpp
+++ b/src/render/vulkan/BlurPass.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "DeviceUser.hpp"
+#include "Shaders.hpp"
+#include "Pipeline.hpp"
+#include "../Texture.hpp"
+#include "../Framebuffer.hpp"
+
+namespace Render::VK {
+    class CVKBlurPass : IDeviceUser {
+      public:
+        CVKBlurPass(WP<CHyprVulkanDevice> device, DRMFormat format, SP<CVkShaders> shaders, int passes = 1);
+        ~CVKBlurPass();
+
+        DRMFormat    format();
+        VkRenderPass vk();
+        int          passes();
+
+        SP<ITexture> blurTexture(SP<ITexture> texture, SP<IFramebuffer> first, SP<IFramebuffer> second, float a, const CRegion& damage);
+
+      private:
+        SP<CVkPipeline> m_preparePipeline;
+        SP<CVkPipeline> m_prepareCMPipeline;
+        SP<CVkPipeline> m_blur1Pipeline;
+        SP<CVkPipeline> m_blur2Pipeline;
+        SP<CVkPipeline> m_finishPipeline;
+        SP<CVkPipeline> m_finishCMPipeline;
+
+        DRMFormat       m_drmFormat;
+        SP<CVkShaders>  m_shaders;
+        int             m_passes = 1;
+    };
+}

--- a/src/render/vulkan/BorderGradientUBO.cpp
+++ b/src/render/vulkan/BorderGradientUBO.cpp
@@ -1,0 +1,80 @@
+#include "BorderGradientUBO.hpp"
+#include "Vulkan.hpp"
+#include "utils.hpp"
+#include <cstring>
+#include <vulkan/vulkan_core.h>
+
+using namespace Render::VK;
+
+CVKBorderGradientUBO::CVKBorderGradientUBO(WP<CHyprVulkanDevice> device, VkDescriptorSetLayout layout) :
+    IDeviceUser(device), m_dsPool(g_pHyprVulkan->allocateDescriptorSet(layout, &m_desctiptorSet, CVKDescriptorPool::DSP_UBO)) {
+
+    if (!m_dsPool) {
+        Log::logger->log(Log::ERR, "failed to allocate descriptor");
+        return;
+    }
+
+    VkBufferCreateInfo bufferInfo = {
+        .sType       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .size        = sizeof(SVkBorderGradientShaderData),
+        .usage       = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+    };
+
+    if (vkCreateBuffer(vkDevice(), &bufferInfo, nullptr, &m_buffer) != VK_SUCCESS) {
+        throw std::runtime_error("failed to create buffer!");
+    }
+
+    VkMemoryRequirements memRequirements;
+    vkGetBufferMemoryRequirements(vkDevice(), m_buffer, &memRequirements);
+
+    VkMemoryAllocateInfo allocInfo{};
+    allocInfo.sType          = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    allocInfo.allocationSize = memRequirements.size;
+    allocInfo.memoryTypeIndex =
+        findVkMemType(m_device->physicalDevice(), VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, memRequirements.memoryTypeBits);
+
+    if (vkAllocateMemory(vkDevice(), &allocInfo, nullptr, &m_bufferMemory) != VK_SUCCESS) {
+        throw std::runtime_error("failed to allocate buffer memory!");
+    }
+
+    vkBindBufferMemory(vkDevice(), m_buffer, m_bufferMemory, 0);
+
+    VkDescriptorBufferInfo dsInfo = {
+        .buffer = m_buffer,
+        .offset = 0,
+        .range  = sizeof(SVkBorderGradientShaderData),
+    };
+
+    VkWriteDescriptorSet dsWrite = {
+        .sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+        .dstSet          = m_desctiptorSet,
+        .descriptorCount = 1,
+        .descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+        .pBufferInfo     = &dsInfo,
+    };
+
+    vkUpdateDescriptorSets(vkDevice(), 1, &dsWrite, 0, nullptr);
+}
+
+void CVKBorderGradientUBO::update(const SVkBorderGradientShaderData& gradients) {
+    void* uboData;
+    vkMapMemory(vkDevice(), m_bufferMemory, 0, sizeof(SVkBorderGradientShaderData), 0, &uboData);
+    memcpy(uboData, &gradients, sizeof(SVkBorderGradientShaderData));
+    vkUnmapMemory(vkDevice(), m_bufferMemory);
+}
+
+VkDescriptorSet CVKBorderGradientUBO::ds() {
+    return m_desctiptorSet;
+}
+
+CVKBorderGradientUBO::~CVKBorderGradientUBO() {
+    if (m_desctiptorSet)
+        vkFreeDescriptorSets(vkDevice(), m_dsPool->vkPool(), 1, &m_desctiptorSet);
+
+    if (m_buffer)
+        vkDestroyBuffer(vkDevice(), m_buffer, nullptr);
+
+    if (m_bufferMemory)
+        vkFreeMemory(vkDevice(), m_bufferMemory, nullptr);
+}

--- a/src/render/vulkan/BorderGradientUBO.hpp
+++ b/src/render/vulkan/BorderGradientUBO.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "DescriptorPool.hpp"
+#include "render/vulkan/DeviceUser.hpp"
+#include <vulkan/vulkan.h>
+
+namespace Render::VK {
+    class CVKBorderGradientUBO : IDeviceUser {
+      public:
+        CVKBorderGradientUBO(WP<CHyprVulkanDevice> device, VkDescriptorSetLayout layout);
+        ~CVKBorderGradientUBO();
+
+        void            update(const SVkBorderGradientShaderData& gradients);
+        VkDescriptorSet ds();
+
+      private:
+        VkDescriptorSet       m_desctiptorSet;
+        WP<CVKDescriptorPool> m_dsPool;
+        VkBuffer              m_buffer;
+        VkDeviceMemory        m_bufferMemory;
+    };
+}

--- a/src/render/vulkan/CommandBuffer.cpp
+++ b/src/render/vulkan/CommandBuffer.cpp
@@ -1,0 +1,151 @@
+#include "CommandBuffer.hpp"
+#include "../../macros.hpp"
+#include "debug/log/Logger.hpp"
+#include "render/vulkan/DeviceUser.hpp"
+#include "render/vulkan/VKTexture.hpp"
+#include "utils.hpp"
+#include <cstdint>
+#include <vulkan/vulkan_core.h>
+
+using namespace Render::VK;
+
+CHyprVkCommandBuffer::CHyprVkCommandBuffer(WP<CHyprVulkanDevice> device) : IDeviceUser(device) {
+    const VkCommandBufferAllocateInfo commandBufferAllocateInfo = {
+        .sType              = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO,
+        .commandPool        = m_device->commandPool(),
+        .level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+        .commandBufferCount = 1,
+    };
+
+    if (vkAllocateCommandBuffers(vkDevice(), &commandBufferAllocateInfo, &m_cmdBuffer) != VK_SUCCESS) {
+        CRIT("vkAllocateCommandBuffers failed");
+    }
+
+    const VkSemaphoreCreateInfo semaphoreCreateInfo{.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO};
+    if (vkCreateSemaphore(vkDevice(), &semaphoreCreateInfo, nullptr, &m_waitSemaphore) != VK_SUCCESS) {
+        CRIT("vkCreateSemaphore failed");
+    }
+
+    const VkSemaphoreTypeCreateInfoKHR semaphoreTypeInfo = {
+        .sType         = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO_KHR,
+        .semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE_KHR,
+        .initialValue  = 0,
+    };
+    const VkSemaphoreCreateInfo timelineCreateInfo{.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO, .pNext = &semaphoreTypeInfo};
+
+    if (vkCreateSemaphore(vkDevice(), &timelineCreateInfo, nullptr, &m_signalSemaphore) != VK_SUCCESS) {
+        CRIT("vkCreateSemaphore failed");
+    }
+}
+
+CHyprVkCommandBuffer::~CHyprVkCommandBuffer() {
+    if (!m_device)
+        return;
+
+    if (m_waitSemaphore)
+        vkDestroySemaphore(vkDevice(), m_waitSemaphore, nullptr);
+
+    if (m_signalSemaphore)
+        vkDestroySemaphore(vkDevice(), m_signalSemaphore, nullptr);
+
+    if (m_cmdBuffer)
+        vkFreeCommandBuffers(vkDevice(), m_device->commandPool(), 1, &m_cmdBuffer);
+}
+
+void CHyprVkCommandBuffer::begin() {
+    ASSERT(!m_recording);
+
+    resetUsedResources();
+
+    m_recording = true;
+
+    if (vkResetCommandBuffer(m_cmdBuffer, 0) != VK_SUCCESS) {
+        CRIT("vkResetCommandBuffer failed");
+    }
+
+    const VkCommandBufferBeginInfo beginInfo{
+        .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
+        // .flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT,
+    };
+
+    if (vkBeginCommandBuffer(m_cmdBuffer, &beginInfo) != VK_SUCCESS) {
+        CRIT("vkBeginCommandBuffer failed");
+    }
+}
+
+void CHyprVkCommandBuffer::end(uint64_t signalPoint) {
+    ASSERT(m_recording);
+    m_timelinePoint = signalPoint;
+
+    // Ends recording of commands for the frame
+    if (vkEndCommandBuffer(m_cmdBuffer) != VK_SUCCESS) {
+        CRIT("vkEndCommandBuffer failed");
+    }
+
+    m_recording = false;
+};
+
+VkCommandBuffer CHyprVkCommandBuffer::vk() {
+    return m_cmdBuffer;
+}
+
+void CHyprVkCommandBuffer::changeLayout(VkImage img, const SImageLayoutSettings& src, const SImageLayoutSettings& dst) {
+    VkImageMemoryBarrier2 barrier = {
+        .sType               = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2,
+        .srcStageMask        = src.stageMask,
+        .srcAccessMask       = src.accessMask,
+        .dstStageMask        = dst.stageMask,
+        .dstAccessMask       = dst.accessMask,
+        .oldLayout           = src.layout,
+        .newLayout           = dst.layout,
+        .srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+        .dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+        .image               = img,
+        .subresourceRange =
+            {
+                .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                .levelCount = 1,
+                .layerCount = 1,
+            },
+    };
+
+    VkDependencyInfo dep = {
+        .sType                   = VK_STRUCTURE_TYPE_DEPENDENCY_INFO,
+        .imageMemoryBarrierCount = 1,
+        .pImageMemoryBarriers    = &barrier,
+    };
+
+    vkCmdPipelineBarrier2(m_cmdBuffer, &dep);
+}
+
+void CHyprVkCommandBuffer::changeLayout(WP<IFramebuffer> fb, const SImageLayoutSettings& src, const SImageLayoutSettings& dst) {
+    changeLayout(VKTEX(fb->getTexture())->m_image, src, dst);
+    VKFB(fb)->m_lastKnownLayout = dst.layout;
+}
+
+bool CHyprVkCommandBuffer::busy() {
+    return m_recording;
+}
+
+void CHyprVkCommandBuffer::useTexture(SP<ITexture> tex) {
+    m_usedTextures.push_back(tex);
+}
+
+void CHyprVkCommandBuffer::useFB(SP<CHyprVkFramebuffer> fb) {
+    m_usedFB = fb;
+}
+
+void CHyprVkCommandBuffer::useRenderPass(SP<CVkRenderPass> rp) {
+    m_usedRenderPass = rp;
+}
+
+void CHyprVkCommandBuffer::useBlurPass(SP<CVKBlurPass> bp) {
+    m_usedBlurPass = bp;
+}
+
+void CHyprVkCommandBuffer::resetUsedResources() {
+    m_usedRenderPass.reset();
+    m_usedBlurPass.reset();
+    m_usedTextures.clear();
+    m_usedFB.reset();
+}

--- a/src/render/vulkan/CommandBuffer.hpp
+++ b/src/render/vulkan/CommandBuffer.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "Device.hpp"
+
+#include "../../helpers/memory/Memory.hpp"
+#include "DeviceUser.hpp"
+#include "../../render/Texture.hpp"
+#include "render/Framebuffer.hpp"
+#include "render/vulkan/BlurPass.hpp"
+#include "render/vulkan/RenderPass.hpp"
+#include <vulkan/vulkan_core.h>
+
+namespace Render::VK {
+
+    class CHyprVKRenderer;
+    class CHyprVkFramebuffer;
+
+    class CHyprVkCommandBuffer : public IDeviceUser {
+      public:
+        CHyprVkCommandBuffer(WP<CHyprVulkanDevice> device);
+        ~CHyprVkCommandBuffer();
+
+        struct SImageLayoutSettings {
+            VkImageLayout        layout;
+            VkPipelineStageFlags stageMask;
+            VkAccessFlags        accessMask;
+        };
+
+        void            begin();
+        void            end(uint64_t signalPoint);
+        VkCommandBuffer vk();
+        void            changeLayout(VkImage img, const SImageLayoutSettings& src, const SImageLayoutSettings& dst);
+        void            changeLayout(WP<IFramebuffer> fb, const SImageLayoutSettings& src, const SImageLayoutSettings& dst);
+        bool            busy();
+        uint64_t        m_timelinePoint = 0;
+        void            useTexture(SP<ITexture> tex);
+        void            useFB(SP<CHyprVkFramebuffer> fb);
+        void            useRenderPass(SP<CVkRenderPass> rp);
+        void            useBlurPass(SP<CVKBlurPass> bp);
+
+        void            resetUsedResources();
+
+      private:
+        VkCommandBuffer           m_cmdBuffer       = VK_NULL_HANDLE;
+        VkSemaphore               m_waitSemaphore   = VK_NULL_HANDLE;
+        VkSemaphore               m_signalSemaphore = VK_NULL_HANDLE;
+
+        bool                      m_recording = false;
+        std::vector<SP<ITexture>> m_usedTextures;
+        SP<CHyprVkFramebuffer>    m_usedFB;
+        SP<CVkRenderPass>         m_usedRenderPass;
+        SP<CVKBlurPass>           m_usedBlurPass;
+
+        // friend class CHyprVKRenderer;
+        // friend class CHyprVulkanImpl;
+    };
+}

--- a/src/render/vulkan/DescriptorPool.cpp
+++ b/src/render/vulkan/DescriptorPool.cpp
@@ -1,0 +1,52 @@
+#include "DescriptorPool.hpp"
+#include "../../debug/log/Logger.hpp"
+#include "utils.hpp"
+#include <vulkan/vulkan_core.h>
+
+using namespace Render::VK;
+
+CVKDescriptorPool::CVKDescriptorPool(WP<CHyprVulkanDevice> device, VkDescriptorType type, size_t size) : IDeviceUser(device), m_available(size) {
+    VkDescriptorPoolSize poolSize = {
+        .type            = type,
+        .descriptorCount = size,
+    };
+
+    VkDescriptorPoolCreateInfo poolInfo = {
+        .sType         = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+        .flags         = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT,
+        .maxSets       = size,
+        .poolSizeCount = 1,
+        .pPoolSizes    = &poolSize,
+    };
+
+    IF_VKFAIL(vkCreateDescriptorPool, vkDevice(), &poolInfo, nullptr, &m_pool) {
+        LOG_VKFAIL;
+        return;
+    }
+}
+
+VkResult CVKDescriptorPool::allocateSet(VkDescriptorSetLayout layout, VkDescriptorSet* ds) {
+    if (!m_available)
+        return VK_ERROR_OUT_OF_POOL_MEMORY;
+
+    VkDescriptorSetAllocateInfo dsInfo = {
+        .sType              = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+        .descriptorPool     = m_pool,
+        .descriptorSetCount = 1,
+        .pSetLayouts        = &layout,
+    };
+
+    const auto res = vkAllocateDescriptorSets(vkDevice(), &dsInfo, ds);
+    if (res == VK_SUCCESS)
+        --m_available;
+    return res;
+}
+
+VkDescriptorPool CVKDescriptorPool::vkPool() {
+    return m_pool;
+}
+
+CVKDescriptorPool::~CVKDescriptorPool() {
+    if (m_pool)
+        vkDestroyDescriptorPool(vkDevice(), m_pool, nullptr);
+}

--- a/src/render/vulkan/DescriptorPool.hpp
+++ b/src/render/vulkan/DescriptorPool.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "DeviceUser.hpp"
+#include <vulkan/vulkan_core.h>
+
+namespace Render::VK {
+    class CVKDescriptorPool : IDeviceUser {
+      public:
+        enum eDSPoolType : uint8_t {
+            DSP_SAMPLER = 0,
+            DSP_UBO     = 1,
+        };
+
+        CVKDescriptorPool(WP<CHyprVulkanDevice> device, VkDescriptorType type, size_t size);
+        ~CVKDescriptorPool();
+
+        VkResult         allocateSet(VkDescriptorSetLayout layout, VkDescriptorSet* ds);
+        VkDescriptorPool vkPool();
+
+      private:
+        VkDescriptorPool m_pool;
+        uint32_t         m_available = 0;
+    };
+}

--- a/src/render/vulkan/Device.cpp
+++ b/src/render/vulkan/Device.cpp
@@ -1,0 +1,459 @@
+#include "Device.hpp"
+#include "helpers/Format.hpp"
+#include "utils.hpp"
+
+#include "../../debug/log/Logger.hpp"
+#include "../../macros.hpp"
+#include <algorithm>
+#include <optional>
+
+using namespace Render::VK;
+
+inline void CHyprVulkanDevice::loadVulkanProc(void* pProc, const char* name) {
+    void* proc = rc<void*>(vkGetDeviceProcAddr(m_device, name));
+    if (proc == nullptr) {
+        CRIT("[VULKAN] vkGetDeviceProcAddr({}) failed", name);
+    }
+    *sc<void**>(pProc) = proc;
+}
+
+CHyprVulkanDevice::CHyprVulkanDevice(VkPhysicalDevice device, std::vector<VkExtensionProperties> extensions) : m_physicalDevice(device), m_extensions(std::move(extensions)) {
+    for (const auto& extension : m_extensions) {
+        Log::logger->log(Log::DEBUG, "Vulkan device extension {} v{}", extension.extensionName, extension.specVersion);
+    }
+
+    std::vector<const char*> enabledExtensions = {
+        VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
+        VK_EXT_EXTERNAL_MEMORY_DMA_BUF_EXTENSION_NAME,
+        VK_EXT_QUEUE_FAMILY_FOREIGN_EXTENSION_NAME,
+        VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME,
+    };
+
+    for (const auto& ext : enabledExtensions) {
+        if (!hasExtension(m_extensions, ext)) {
+            Log::logger->log(Log::ERR, "[VULKAN] Required device extension {} not found", ext);
+            return;
+        }
+    }
+
+    uint32_t queuePropCount;
+    vkGetPhysicalDeviceQueueFamilyProperties2(m_physicalDevice, &queuePropCount, nullptr);
+    ASSERT(queuePropCount > 0);
+    std::vector<VkQueueFamilyProperties2> queueProps(queuePropCount);
+    for (auto& prop : queueProps) {
+        prop.sType = VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2;
+    }
+    vkGetPhysicalDeviceQueueFamilyProperties2(m_physicalDevice, &queuePropCount, queueProps.data());
+
+    const auto prop = std::ranges::find_if(queueProps, [](const auto& prop) { return prop.queueFamilyProperties.queueFlags & VK_QUEUE_GRAPHICS_BIT; });
+    ASSERT(prop != queueProps.end());
+    m_queueFamilyIndex = prop - queueProps.begin();
+
+    const bool hasExternalSemaphoreFd = hasExtension(m_extensions, VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME);
+    if (hasExternalSemaphoreFd) {
+        const VkPhysicalDeviceExternalSemaphoreInfo extSemaphoreInfo = {
+            .sType      = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO,
+            .handleType = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT,
+        };
+        VkExternalSemaphoreProperties extSemaphoreProps = {
+            .sType = VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES,
+        };
+        vkGetPhysicalDeviceExternalSemaphoreProperties(m_physicalDevice, &extSemaphoreInfo, &extSemaphoreProps);
+        m_canExplicitSync = extSemaphoreProps.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT &&
+            extSemaphoreProps.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT;
+        enabledExtensions.push_back(VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME);
+    }
+
+    if (!m_canExplicitSync)
+        Log::logger->log(Log::DEBUG, "VkSemaphore is not usable as sync_file");
+
+    VkPhysicalDeviceSamplerYcbcrConversionFeatures YCCfeature = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES,
+    };
+    VkPhysicalDeviceFeatures2 features = {
+        .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2,
+        .pNext = &YCCfeature,
+    };
+    vkGetPhysicalDeviceFeatures2(m_physicalDevice, &features);
+
+    m_canConvertYCC = YCCfeature.samplerYcbcrConversion;
+    Log::logger->log(Log::DEBUG, "Sampler YCC conversion: {}", m_canConvertYCC);
+
+    const float             prio  = 1.f;
+    VkDeviceQueueCreateInfo qinfo = {
+        .sType            = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO,
+        .queueFamilyIndex = m_queueFamilyIndex,
+        .queueCount       = 1,
+        .pQueuePriorities = &prio,
+    };
+
+    VkDeviceQueueGlobalPriorityCreateInfoKHR globalPriority = {
+        .sType          = VK_STRUCTURE_TYPE_DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_KHR,
+        .globalPriority = VK_QUEUE_GLOBAL_PRIORITY_HIGH_KHR,
+    };
+    qinfo.pNext = &globalPriority;
+
+    VkPhysicalDeviceTimelineSemaphoreFeaturesKHR timelineFeatures = {
+        .sType             = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES_KHR,
+        .pNext             = &YCCfeature,
+        .timelineSemaphore = VK_TRUE,
+    };
+
+    VkPhysicalDeviceVulkan13Features vulkan13Features = {
+        .sType            = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES,
+        .pNext            = &timelineFeatures,
+        .synchronization2 = VK_TRUE,
+        .dynamicRendering = VK_TRUE,
+    };
+
+    VkDeviceCreateInfo devInfo = {
+        .sType                   = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
+        .pNext                   = &vulkan13Features,
+        .queueCreateInfoCount    = 1,
+        .pQueueCreateInfos       = &qinfo,
+        .enabledExtensionCount   = enabledExtensions.size(),
+        .ppEnabledExtensionNames = enabledExtensions.data(),
+    };
+
+    VkResult res = vkCreateDevice(m_physicalDevice, &devInfo, nullptr, &m_device);
+
+    if (res == VK_ERROR_NOT_PERMITTED_EXT || res == VK_ERROR_INITIALIZATION_FAILED) {
+        // Try to recover from the driver denying a global priority queue
+        Log::logger->log(Log::DEBUG, "Failed to obtain a high-priority device queue, falling back to regular queue");
+        qinfo.pNext = nullptr;
+        res         = vkCreateDevice(m_physicalDevice, &devInfo, nullptr, &m_device);
+    }
+
+    if (res != VK_SUCCESS) {
+        Log::logger->log(Log::ERR, "Failed to create vulkan device: {}", resultToStr(res));
+        return;
+    }
+
+    vkGetDeviceQueue(m_device, m_queueFamilyIndex, 0, &m_queue);
+
+    loadVulkanProc(&m_proc.vkGetMemoryFdPropertiesKHR, "vkGetMemoryFdPropertiesKHR");
+
+    if (m_canExplicitSync) {
+        loadVulkanProc(&m_proc.vkGetSemaphoreFdKHR, "vkGetSemaphoreFdKHR");
+        loadVulkanProc(&m_proc.vkImportSemaphoreFdKHR, "vkImportSemaphoreFdKHR");
+    }
+
+#if ISDEBUG
+
+    loadVulkanProc(&m_proc.vkSetDebugUtilsObjectNameEXT, "vkSetDebugUtilsObjectNameEXT");
+    loadVulkanProc(&m_proc.vkQueueBeginDebugUtilsLabelEXT, "vkQueueBeginDebugUtilsLabelEXT");
+    loadVulkanProc(&m_proc.vkQueueEndDebugUtilsLabelEXT, "vkQueueEndDebugUtilsLabelEXT");
+    loadVulkanProc(&m_proc.vkCmdBeginDebugUtilsLabelEXT, "vkCmdBeginDebugUtilsLabelEXT");
+    loadVulkanProc(&m_proc.vkCmdEndDebugUtilsLabelEXT, "vkCmdEndDebugUtilsLabelEXT");
+#endif
+
+    VkSemaphoreTypeCreateInfo timelineCreateInfo = {
+        .sType         = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO,
+        .pNext         = nullptr,
+        .semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE,
+        .initialValue  = m_timelinePoint,
+    };
+
+    const VkSemaphoreCreateInfo semaphoreCreateInfo{
+        .sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
+        .pNext = &timelineCreateInfo,
+    };
+
+    if (vkCreateSemaphore(m_device, &semaphoreCreateInfo, nullptr, &m_timelineSemaphore) != VK_SUCCESS) {
+        CRIT("vkCreateSemaphore failed");
+    }
+
+    const VkCommandPoolCreateInfo cmdPoolCreateInfo{
+        .sType            = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO,
+        .flags            = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
+        .queueFamilyIndex = queueFamilyIndex(),
+    };
+
+    if (vkCreateCommandPool(vkDevice(), &cmdPoolCreateInfo, nullptr, &m_commandPool) != VK_SUCCESS) {
+        CRIT("vkCreateCommandPool failed");
+    }
+
+    m_good = true;
+}
+
+bool CHyprVulkanDevice::good() {
+    return m_good;
+}
+
+VkDevice CHyprVulkanDevice::vkDevice() {
+    return m_device;
+}
+
+VkPhysicalDevice CHyprVulkanDevice::physicalDevice() {
+    return m_physicalDevice;
+}
+
+uint32_t CHyprVulkanDevice::queueFamilyIndex() {
+    return m_queueFamilyIndex;
+}
+
+VkQueue CHyprVulkanDevice::queue() {
+    return m_queue;
+}
+
+VkSemaphore CHyprVulkanDevice::timelineSemaphore() {
+    return m_timelineSemaphore;
+}
+
+uint64_t CHyprVulkanDevice::timelinePoint() {
+    uint64_t point;
+    IF_VKFAIL(vkGetSemaphoreCounterValue, vkDevice(), m_timelineSemaphore, &point) {
+        LOG_VKFAIL;
+        return 0;
+    }
+    return point;
+}
+
+VkCommandPool CHyprVulkanDevice::commandPool() {
+    return m_commandPool;
+}
+
+const std::vector<SVkFormatProps>& CHyprVulkanDevice::formats() {
+    return m_formats;
+}
+
+std::optional<const SVkFormatProps> CHyprVulkanDevice::getFormat(const DRMFormat format) {
+    const auto found = std::ranges::find_if(m_formats, [format](const auto fmt) { return fmt.format.drmFormat == format; });
+    if (found != m_formats.end())
+        return *found;
+
+    return {};
+}
+
+void CHyprVulkanDevice::loadFormats() {
+    for (const auto& format : Render::VK::FORMATS) {
+        const auto props = getFormat(format.first);
+        if (props.has_value()) {
+            Log::logger->log(Log::DEBUG, "Loaded format {}", NFormatUtils::drmFormatName(format.first));
+            m_formats.emplace_back(props.value());
+        }
+    }
+}
+
+std::optional<SVkFormatProps> CHyprVulkanDevice::getFormat(const SVkFormatInfo& format) {
+    if (format.isYCC && !m_canConvertYCC)
+        return {};
+
+    VkDrmFormatModifierPropertiesListEXT mods = {
+        .sType = VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT,
+    };
+    VkFormatProperties2 formatProps = {
+        .sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2,
+        .pNext = &mods,
+    };
+
+    vkGetPhysicalDeviceFormatProperties2(m_physicalDevice, format.vkFormat, &formatProps);
+
+    bool           isValid = false;
+    SVkFormatProps props   = {.format = format};
+
+    if ((formatProps.formatProperties.optimalTilingFeatures & SHM_TEX_FEATURES) == SHM_TEX_FEATURES && !format.isYCC) {
+        bool canSrgb = false;
+
+        auto supportedProps = getSupportedSHMProperties(format.vkFormat, format.vkSrgbFormat);
+        if (supportedProps.has_value())
+            canSrgb = props.hasSrgb();
+        else if (props.hasSrgb())
+            supportedProps = getSupportedSHMProperties(format.vkFormat, VK_FORMAT_UNDEFINED);
+
+        if (supportedProps.has_value()) {
+            props.shm.maxExtent.width  = supportedProps->maxExtent.width;
+            props.shm.maxExtent.height = supportedProps->maxExtent.height;
+            props.shm.features         = formatProps.formatProperties.optimalTilingFeatures;
+            props.shm.canSrgb          = canSrgb;
+            m_shmTextureFormats.insert(format.drmFormat);
+
+            isValid = true;
+        }
+    } else
+        Log::logger->log(Log::DEBUG, "{} missing required features", NFormatUtils::drmFormatName(format.drmFormat));
+
+    if (mods.drmFormatModifierCount > 0)
+        isValid |= getModifiers(props, mods.drmFormatModifierCount);
+
+    if (isValid)
+        return props;
+
+    return {};
+}
+
+std::optional<VkImageFormatProperties> CHyprVulkanDevice::getSupportedSHMProperties(VkFormat vkFormat, VkFormat vkSrgbFormat) {
+    VkFormat viewFormats[2] = {
+        vkFormat,
+        vkSrgbFormat,
+    };
+    VkImageFormatListCreateInfoKHR listi = {
+        .sType           = VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO_KHR,
+        .pNext           = nullptr,
+        .viewFormatCount = vkSrgbFormat != VK_FORMAT_UNDEFINED ? 2 : 1,
+        .pViewFormats    = viewFormats,
+    };
+    VkPhysicalDeviceImageFormatInfo2 formatInfo = {
+        .sType  = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2,
+        .pNext  = &listi,
+        .format = vkFormat,
+        .type   = VK_IMAGE_TYPE_2D,
+        .tiling = VK_IMAGE_TILING_OPTIMAL,
+        .usage  = VULKAN_SHM_TEX_USAGE,
+        .flags  = vkSrgbFormat != VK_FORMAT_UNDEFINED ? VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT : 0,
+    };
+    VkImageFormatProperties2 propInfo = {
+        .sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2,
+    };
+
+    const auto res = vkGetPhysicalDeviceImageFormatProperties2(m_physicalDevice, &formatInfo, &propInfo);
+    if (res != VK_SUCCESS) {
+        if (res == VK_ERROR_FORMAT_NOT_SUPPORTED)
+            Log::logger->log(Log::ERR, "Unsupported format {} ({})", (uint32_t)vkFormat, (uint32_t)vkSrgbFormat);
+        else
+            Log::logger->log(Log::ERR, "vkGetPhysicalDeviceImageFormatProperties2: {}", resultToStr(res));
+
+        return {};
+    }
+
+    return propInfo.imageFormatProperties;
+}
+
+bool CHyprVulkanDevice::getModifiers(SVkFormatProps& props, const size_t modifierCount) {
+    VkDrmFormatModifierPropertiesListEXT modProps = {
+        .sType                  = VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT,
+        .drmFormatModifierCount = modifierCount,
+    };
+    VkFormatProperties2 formatProps = {
+        .sType = VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2,
+        .pNext = &modProps,
+    };
+
+    std::vector<VkDrmFormatModifierPropertiesEXT> drmFormatModifierProperties(modifierCount);
+    modProps.pDrmFormatModifierProperties = drmFormatModifierProperties.data();
+
+    vkGetPhysicalDeviceFormatProperties2(m_physicalDevice, props.format.vkFormat, &formatProps);
+
+    props.dmabuf.renderModifiers.resize(modProps.drmFormatModifierCount);
+    props.dmabuf.textureModifiers.resize(modProps.drmFormatModifierCount);
+
+    bool found = false;
+    for (const auto& mod : drmFormatModifierProperties) {
+        if ((mod.drmFormatModifierTilingFeatures & RENDER_FEATURES) == RENDER_FEATURES && !props.format.isYCC) {
+            auto modProps = getSupportedDRMProperties(props.format.vkFormat, props.format.vkSrgbFormat, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, mod);
+
+            if (modProps.has_value())
+                modProps->canSrgb = props.hasSrgb();
+            else if (props.hasSrgb())
+                modProps = getSupportedDRMProperties(props.format.vkFormat, VK_FORMAT_UNDEFINED, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, mod);
+
+            if (modProps.has_value()) {
+                props.dmabuf.renderModifiers.emplace_back(modProps.value());
+                m_dmaRenderFormats.insert(props.format.drmFormat);
+                found = true;
+            }
+        } else
+            Log::logger->log(Log::DEBUG, "{}({}) missing required render features", NFormatUtils::drmFormatName(props.format.drmFormat),
+                             NFormatUtils::drmModifierName(mod.drmFormatModifier));
+
+        VkFormatFeatureFlags features = DMA_TEX_FEATURES;
+        if (props.format.isYCC)
+            features |= YCC_TEX_FEATURES;
+
+        if ((mod.drmFormatModifierTilingFeatures & features) == features) {
+            auto modProps = getSupportedDRMProperties(props.format.vkFormat, props.format.vkSrgbFormat, VULKAN_DMA_TEX_USAGE, mod);
+            if (modProps.has_value())
+                modProps->canSrgb = props.hasSrgb();
+            else if (props.hasSrgb())
+                modProps = getSupportedDRMProperties(props.format.vkFormat, VK_FORMAT_UNDEFINED, VULKAN_DMA_TEX_USAGE, mod);
+
+            if (modProps.has_value()) {
+                props.dmabuf.textureModifiers.emplace_back(modProps.value());
+                m_dmaTextureFormats.insert(props.format.drmFormat);
+                found = true;
+            }
+        } else
+            Log::logger->log(Log::ERR, "{}({}) missing required texture features", NFormatUtils::drmFormatName(props.format.drmFormat),
+                             NFormatUtils::drmModifierName(mod.drmFormatModifier));
+    }
+
+    return found;
+}
+
+std::optional<SVkFormatModifier> CHyprVulkanDevice::getSupportedDRMProperties(VkFormat vkFormat, VkFormat vkSrgbFormat, VkImageUsageFlags usage,
+                                                                              const VkDrmFormatModifierPropertiesEXT& mod) {
+    VkFormat view_formats[2] = {
+        vkFormat,
+        vkSrgbFormat,
+    };
+    VkImageFormatListCreateInfoKHR listi = {
+        .sType           = VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO_KHR,
+        .viewFormatCount = vkSrgbFormat != VK_FORMAT_UNDEFINED ? 2 : 1,
+        .pViewFormats    = view_formats,
+    };
+    VkPhysicalDeviceImageDrmFormatModifierInfoEXT modi = {
+        .sType             = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_DRM_FORMAT_MODIFIER_INFO_EXT,
+        .pNext             = &listi,
+        .drmFormatModifier = mod.drmFormatModifier,
+        .sharingMode       = VK_SHARING_MODE_EXCLUSIVE,
+    };
+    VkPhysicalDeviceExternalImageFormatInfo efmti = {
+        .sType      = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO,
+        .pNext      = &modi,
+        .handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT,
+    };
+    VkPhysicalDeviceImageFormatInfo2 fmti = {
+        .sType  = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2,
+        .pNext  = &efmti,
+        .format = vkFormat,
+        .type   = VK_IMAGE_TYPE_2D,
+        .tiling = VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT,
+        .usage  = usage,
+        .flags  = vkSrgbFormat != VK_FORMAT_UNDEFINED ? VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT : 0,
+    };
+
+    VkExternalImageFormatProperties efmtp = {
+        .sType = VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES,
+    };
+    VkImageFormatProperties2 ifmtp = {
+        .sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2,
+        .pNext = &efmtp,
+    };
+    const VkExternalMemoryProperties* emp = &efmtp.externalMemoryProperties;
+
+    const auto                        res = vkGetPhysicalDeviceImageFormatProperties2(m_physicalDevice, &fmti, &ifmtp);
+
+    if (res != VK_SUCCESS) {
+        if (res == VK_ERROR_FORMAT_NOT_SUPPORTED)
+            Log::logger->log(Log::ERR, "Unsupported format {} ({})", (uint32_t)vkFormat, (uint32_t)vkSrgbFormat);
+        else
+            Log::logger->log(Log::ERR, "vkGetPhysicalDeviceImageFormatProperties2: {}", resultToStr(res));
+
+        return {};
+    } else if (!(emp->externalMemoryFeatures & VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT)) {
+        Log::logger->log(Log::ERR, "Format {} ({}) doesn't support import", (uint32_t)vkFormat, (uint32_t)vkSrgbFormat);
+        return {};
+    }
+
+    VkExtent3D me = ifmtp.imageFormatProperties.maxExtent;
+    return SVkFormatModifier{.props     = mod,
+                             .maxExtent = {
+                                 .width  = me.width,
+                                 .height = me.height,
+                             }};
+}
+
+CHyprVulkanDevice::~CHyprVulkanDevice() {
+    if (m_device) {
+        if (m_commandPool)
+            vkDestroyCommandPool(vkDevice(), m_commandPool, nullptr);
+
+        if (m_timelineSemaphore != VK_NULL_HANDLE)
+            vkDestroySemaphore(m_device, m_timelineSemaphore, nullptr);
+
+        vkDestroyDevice(m_device, nullptr);
+    }
+
+    if (m_drmFd >= 0)
+        close(m_drmFd);
+}

--- a/src/render/vulkan/Device.cpp
+++ b/src/render/vulkan/Device.cpp
@@ -227,7 +227,7 @@ std::optional<const SVkFormatProps> CHyprVulkanDevice::getFormat(const DRMFormat
 
 void CHyprVulkanDevice::loadFormats() {
     for (const auto& format : Render::VK::FORMATS) {
-        const auto props = getFormat(format.first);
+        const auto props = getFormat(format.second);
         if (props.has_value()) {
             Log::logger->log(Log::DEBUG, "Loaded format {}", NFormatUtils::drmFormatName(format.first));
             m_formats.emplace_back(props.value());

--- a/src/render/vulkan/Device.hpp
+++ b/src/render/vulkan/Device.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <cstdint>
+#include <set>
+#include <vulkan/vulkan.h>
+#include "helpers/Format.hpp"
+#include "types.hpp"
+
+namespace Render::VK {
+    class CHyprVulkanDevice {
+      public:
+        CHyprVulkanDevice(VkPhysicalDevice device, std::vector<VkExtensionProperties> extensions);
+        ~CHyprVulkanDevice();
+
+        struct {
+            PFN_vkGetMemoryFdPropertiesKHR     vkGetMemoryFdPropertiesKHR     = nullptr;
+            PFN_vkGetSemaphoreFdKHR            vkGetSemaphoreFdKHR            = nullptr;
+            PFN_vkImportSemaphoreFdKHR         vkImportSemaphoreFdKHR         = nullptr;
+            PFN_vkSetDebugUtilsObjectNameEXT   vkSetDebugUtilsObjectNameEXT   = nullptr;
+            PFN_vkQueueBeginDebugUtilsLabelEXT vkQueueBeginDebugUtilsLabelEXT = nullptr;
+            PFN_vkQueueEndDebugUtilsLabelEXT   vkQueueEndDebugUtilsLabelEXT   = nullptr;
+            PFN_vkCmdBeginDebugUtilsLabelEXT   vkCmdBeginDebugUtilsLabelEXT   = nullptr;
+            PFN_vkCmdEndDebugUtilsLabelEXT     vkCmdEndDebugUtilsLabelEXT     = nullptr;
+
+        } m_proc;
+
+        bool                                good();
+        void                                loadFormats();
+        VkDevice                            vkDevice();
+        VkPhysicalDevice                    physicalDevice();
+
+        uint32_t                            queueFamilyIndex();
+        VkQueue                             queue();
+        VkSemaphore                         timelineSemaphore();
+        uint64_t                            timelinePoint();
+        uint64_t                            m_timelinePoint = 0;
+
+        std::optional<const SVkFormatProps> getFormat(const DRMFormat format);
+        VkCommandPool                       commandPool();
+        const std::vector<SVkFormatProps>&  formats();
+
+      private:
+        inline void                            loadVulkanProc(void* pProc, const char* name);
+        std::optional<SVkFormatProps>          getFormat(const SVkFormatInfo& format);
+        std::optional<VkImageFormatProperties> getSupportedSHMProperties(VkFormat vkFormat, VkFormat vkSrgbFormat);
+        std::optional<SVkFormatModifier> getSupportedDRMProperties(VkFormat vkFormat, VkFormat vkSrgbFormat, VkImageUsageFlags usage, const VkDrmFormatModifierPropertiesEXT& mod);
+        bool                             getModifiers(SVkFormatProps& props, const size_t modifierCount);
+
+        VkPhysicalDevice                 m_physicalDevice    = VK_NULL_HANDLE;
+        VkDevice                         m_device            = VK_NULL_HANDLE;
+        VkQueue                          m_queue             = VK_NULL_HANDLE;
+        VkSemaphore                      m_timelineSemaphore = VK_NULL_HANDLE;
+        VkCommandPool                    m_commandPool       = VK_NULL_HANDLE;
+
+        int                              m_drmFd = -1;
+        std::vector<VkExtensionProperties> m_extensions;
+
+        bool                               m_good = false;
+
+        uint32_t                           m_queueFamilyIndex = 0;
+        bool                               m_canExplicitSync  = false;
+        bool                               m_canConvertYCC    = false;
+        std::set<DRMFormat>                m_shmTextureFormats;
+        std::set<DRMFormat>                m_dmaRenderFormats;
+        std::set<DRMFormat>                m_dmaTextureFormats;
+        std::vector<SVkFormatProps>        m_formats;
+    };
+}

--- a/src/render/vulkan/DeviceUser.cpp
+++ b/src/render/vulkan/DeviceUser.cpp
@@ -1,0 +1,10 @@
+#include "DeviceUser.hpp"
+#include <vulkan/vulkan_core.h>
+
+using namespace Render::VK;
+
+IDeviceUser::IDeviceUser(WP<CHyprVulkanDevice> device) : m_device(device) {}
+
+VkDevice IDeviceUser::vkDevice() {
+    return m_device.valid() ? m_device->vkDevice() : VK_NULL_HANDLE;
+}

--- a/src/render/vulkan/DeviceUser.hpp
+++ b/src/render/vulkan/DeviceUser.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "../../helpers/memory/Memory.hpp"
+#include "Device.hpp"
+
+namespace Render::VK {
+    class IDeviceUser {
+      public:
+        IDeviceUser(WP<CHyprVulkanDevice> device);
+
+        VkDevice vkDevice();
+
+      protected:
+        WP<CHyprVulkanDevice> m_device;
+    };
+}

--- a/src/render/vulkan/Framebuffer.cpp
+++ b/src/render/vulkan/Framebuffer.cpp
@@ -1,0 +1,157 @@
+#include "Framebuffer.hpp"
+#include "../../debug/log/Logger.hpp"
+#include "helpers/Format.hpp"
+#include "render/Framebuffer.hpp"
+#include "render/Renderbuffer.hpp"
+#include "render/Renderer.hpp"
+#include "render/VKRenderer.hpp"
+#include "render/vulkan/VKTexture.hpp"
+#include "render/vulkan/Vulkan.hpp"
+#include "utils.hpp"
+#include "types.hpp"
+#include "DeviceUser.hpp"
+#include <cstdint>
+#include <fcntl.h>
+#include <format>
+#include <hyprgraphics/egl/Egl.hpp>
+#include <hyprutils/memory/SharedPtr.hpp>
+#include <vulkan/vulkan_core.h>
+
+using namespace Render::VK;
+
+CHyprVkFramebuffer::CHyprVkFramebuffer(WP<CHyprVulkanDevice> device, int w, int h, uint32_t fmt, SP<ITexture> stencilTex) : IDeviceUser(device), m_stencilTex(stencilTex) {
+    const auto format = m_device->getFormat(fmt).value();
+
+    initImage(format, w, h);
+}
+
+CHyprVkFramebuffer::CHyprVkFramebuffer(WP<CHyprVulkanDevice> device, SP<Aquamarine::IBuffer> buffer) : IDeviceUser(device) {
+    const auto format = m_device->getFormat(buffer->dmabuf().format).value();
+
+    initImage(format, buffer->dmabuf());
+}
+
+void CHyprVkFramebuffer::initImage(SVkFormatProps props, int w, int h) {
+    const Vector2D size = {w, h};
+    m_tex = makeShared<CVKTexture>(props.format.drmFormat, size, false, false,
+                                   VULKAN_DMA_TEX_USAGE | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT |
+                                       VK_IMAGE_USAGE_SAMPLED_BIT);
+}
+
+void CHyprVkFramebuffer::initImage(SVkFormatProps props, const Aquamarine::SDMABUFAttrs& attrs) {
+    m_tex = makeShared<CVKTexture>(attrs, false,
+                                   VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
+}
+
+VkFramebuffer CHyprVkFramebuffer::vk() {
+    return m_framebuffer;
+}
+
+VkImage CHyprVkFramebuffer::vkImage() {
+    return m_tex->m_image;
+}
+
+SP<CVKTexture> CHyprVkFramebuffer::texture() {
+    return m_tex;
+}
+
+CHyprVkFramebuffer::~CHyprVkFramebuffer() {
+    if (m_framebuffer)
+        vkDestroyFramebuffer(vkDevice(), m_framebuffer, nullptr);
+}
+
+CVKRenderBuffer::CVKRenderBuffer(SP<Aquamarine::IBuffer> buffer, uint32_t format) : IRenderbuffer(buffer, format) {
+    m_framebuffer                                  = makeShared<CVKFramebuffer>();
+    m_framebuffer->m_drmFormat                     = format;
+    m_framebuffer->m_size                          = buffer->size;
+    auto fb                                        = makeShared<CHyprVkFramebuffer>(g_pHyprVulkan->device(), buffer);
+    dc<CVKFramebuffer*>(m_framebuffer.get())->m_FB = fb;
+    dc<CVKFramebuffer*>(m_framebuffer.get())->setTexture(fb->texture());
+    m_good = true;
+}
+
+CVKRenderBuffer::~CVKRenderBuffer() = default;
+
+void CVKRenderBuffer::bind() {
+    LOGM(Log::WARN, "fixme: unimplemented bind");
+}
+
+void CVKRenderBuffer::unbind() {
+    LOGM(Log::WARN, "fixme: unimplemented unbind");
+}
+
+CVKFramebuffer::CVKFramebuffer() : IFramebuffer() {}
+CVKFramebuffer::CVKFramebuffer(const std::string& name) : IFramebuffer(name) {}
+
+CVKFramebuffer::~CVKFramebuffer() {
+    m_FB.reset();
+}
+
+void CVKFramebuffer::bind() {
+    LOGM(Log::TRACE, "CVKFramebuffer::bind() is a noop. should be called only from IHyprRenderer::bindFB");
+}
+
+bool CVKFramebuffer::readPixels(CHLBufferReference buffer, uint32_t offsetX, uint32_t offsetY, uint32_t width, uint32_t height) {
+    if (!m_tex)
+        return false;
+
+    auto shm                      = buffer->shm();
+    auto [pixelData, fmt, bufLen] = buffer->beginDataPtr(0); // no need for end, cuz it's shm
+
+    const auto PFORMAT = Hyprgraphics::Egl::getPixelFormatFromDRM(shm.format);
+    if (!PFORMAT) {
+        LOGM(Log::ERR, "Can't copy: failed to find a pixel format");
+        return false;
+    }
+
+    uint32_t packStride = Hyprgraphics::Egl::minStride(PFORMAT, m_size.x);
+
+    LOGM(Log::DEBUG, "Read from tex {}x{}@{}x{}", m_size.x, m_size.y, offsetX, offsetY);
+    VKTEX(m_tex)->m_lastKnownLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    return VKTEX(m_tex)->read(shm.format, packStride, width > 0 ? width : m_size.x, height > 0 ? height : m_size.y, offsetX, offsetY, 0, 0, pixelData);
+}
+
+void CVKFramebuffer::release() {
+    m_FB.reset();
+    m_fbAllocated = false;
+};
+
+void CVKFramebuffer::addStencil(SP<ITexture> tex) {
+    if (m_stencilTex == tex)
+        return;
+
+    RASSERT(!m_fbAllocated, "Should add stencil tex prior to FB allocation")
+    m_stencilTex = tex;
+};
+
+void CVKFramebuffer::setName(const std::string& name) {
+    m_name = name;
+    if (m_FB && m_FB->texture() && m_FB->texture()->ok())
+        SET_VK_IMG_NAME(m_FB->vkImage(), std::format("IFramebuffer '{}' {} {}x{}", m_name.length() ? m_name : "?", NFormatUtils::drmFormatName(m_drmFormat), m_size.x, m_size.y));
+}
+
+bool CVKFramebuffer::internalAlloc(int w, int h, uint32_t fmt) {
+    m_drmFormat = fmt;
+    m_size      = {w, h};
+    m_FB        = makeShared<CHyprVkFramebuffer>(g_pHyprVulkan->device(), w, h, fmt, m_stencilTex);
+    if (m_FB)
+        m_tex = m_FB->texture();
+    if (m_tex && m_tex->ok()) {
+        setName(m_name);
+        g_pHyprVulkan->stageCB()->changeLayout(m_FB->vkImage(), //
+                                               {.layout = VK_IMAGE_LAYOUT_UNDEFINED, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = VK_ACCESS_TRANSFER_WRITE_BIT},
+                                               {.layout = VK_IMAGE_LAYOUT_GENERAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = 0});
+        m_lastKnownLayout   = VK_IMAGE_LAYOUT_GENERAL;
+        m_FB->m_initialized = true;
+    }
+    m_fbAllocated = true;
+    return m_FB;
+};
+
+void CVKFramebuffer::setTexture(SP<ITexture> tex) {
+    m_tex = tex;
+}
+
+SP<CHyprVkFramebuffer> CVKFramebuffer::fb() {
+    return m_FB;
+}

--- a/src/render/vulkan/Framebuffer.hpp
+++ b/src/render/vulkan/Framebuffer.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "../../helpers/memory/Memory.hpp"
+#include "../../helpers/Format.hpp"
+#include "DeviceUser.hpp"
+#include "../Framebuffer.hpp"
+#include "render/Renderbuffer.hpp"
+#include "render/Texture.hpp"
+#include "render/vulkan/VKTexture.hpp"
+#include <aquamarine/buffer/Buffer.hpp>
+#include <array>
+#include <vulkan/vulkan.h>
+#include <drm/drm_fourcc.h>
+
+namespace Render::VK {
+    class CVKTexture;
+
+    class CHyprVkFramebuffer : public IDeviceUser {
+      public:
+        CHyprVkFramebuffer(WP<CHyprVulkanDevice> device, int w, int h, uint32_t format, SP<ITexture> stencilTex = nullptr);
+        CHyprVkFramebuffer(WP<CHyprVulkanDevice> device, SP<Aquamarine::IBuffer> buffer);
+        ~CHyprVkFramebuffer();
+
+        bool           m_initialized = false;
+
+        VkFramebuffer  vk();
+        VkImage        vkImage();
+        SP<CVKTexture> texture();
+
+      private:
+        void           initImage(SVkFormatProps props, int w, int h);
+        void           initImage(SVkFormatProps props, const Aquamarine::SDMABUFAttrs& attrs);
+
+        VkFramebuffer  m_framebuffer = VK_NULL_HANDLE;
+        SP<CVKTexture> m_tex;
+        SP<ITexture>   m_stencilTex;
+    };
+
+    class CVKRenderBuffer : public IRenderbuffer {
+      public:
+        CVKRenderBuffer(SP<Aquamarine::IBuffer> buffer, uint32_t format);
+        ~CVKRenderBuffer();
+
+        virtual void bind() override;
+        virtual void unbind() override;
+    };
+
+    class CVKFramebuffer : public IFramebuffer {
+      public:
+        CVKFramebuffer();
+        CVKFramebuffer(const std::string& name);
+        ~CVKFramebuffer();
+
+        virtual void           bind() override;
+
+        bool                   readPixels(CHLBufferReference buffer, uint32_t offsetX = 0, uint32_t offsetY = 0, uint32_t width = 0, uint32_t height = 0) override;
+        void                   release() override;
+        void                   addStencil(SP<ITexture> tex) override;
+        void                   setName(const std::string& name) override;
+        SP<CHyprVkFramebuffer> fb();
+        VkImageLayout          m_lastKnownLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+
+      protected:
+        void                   setTexture(SP<ITexture> tex);
+        bool                   internalAlloc(int w, int h, uint32_t format = DRM_FORMAT_ARGB8888) override;
+        SP<CHyprVkFramebuffer> m_FB;
+        friend class CVKRenderBuffer;
+    };
+
+}
+#define VKFB(fb) dc<CVKFramebuffer*>(fb.get())

--- a/src/render/vulkan/MemoryBuffer.cpp
+++ b/src/render/vulkan/MemoryBuffer.cpp
@@ -1,0 +1,100 @@
+#include "MemoryBuffer.hpp"
+#include "MemorySpan.hpp"
+#include "utils.hpp"
+#include "../../debug/log/Logger.hpp"
+#include <hyprutils/memory/SharedPtr.hpp>
+
+using namespace Render::VK;
+
+SP<CVKMemoryBuffer> CVKMemoryBuffer::create(WP<CHyprVulkanDevice> device, VkDeviceSize bufferSize) {
+    auto self    = makeShared<CVKMemoryBuffer>(device, bufferSize);
+    self->m_self = self;
+    return self;
+}
+
+CVKMemoryBuffer::CVKMemoryBuffer(WP<CHyprVulkanDevice> device, VkDeviceSize bufferSize) : IDeviceUser(device) {
+    VkBufferCreateInfo bufInfo = {
+        .sType       = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .size        = bufferSize,
+        .usage       = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+    };
+
+    IF_VKFAIL(vkCreateBuffer, vkDevice(), &bufInfo, nullptr, &m_buffer) {
+        LOG_VKFAIL;
+        return;
+    }
+
+    VkMemoryRequirements memReqs;
+    vkGetBufferMemoryRequirements(vkDevice(), m_buffer, &memReqs);
+
+    const auto memTypeIndex = findVkMemType(m_device->physicalDevice(), VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, memReqs.memoryTypeBits);
+    if (memTypeIndex < 0) {
+        Log::logger->log(Log::ERR, "Failed to find memory type");
+        return;
+    }
+
+    VkMemoryAllocateInfo memInfo = {
+        .sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+        .allocationSize  = memReqs.size,
+        .memoryTypeIndex = memTypeIndex,
+    };
+    IF_VKFAIL(vkAllocateMemory, vkDevice(), &memInfo, nullptr, &m_memory) {
+        LOG_VKFAIL;
+        return;
+    }
+
+    IF_VKFAIL(vkBindBufferMemory, vkDevice(), m_buffer, m_memory, 0) {
+        LOG_VKFAIL;
+        return;
+    }
+
+    IF_VKFAIL(vkMapMemory, vkDevice(), m_memory, 0, VK_WHOLE_SIZE, 0, &m_cpuMapping) {
+        LOG_VKFAIL;
+        return;
+    }
+
+    m_bufferSize = bufferSize;
+
+    m_ok = true;
+};
+
+bool CVKMemoryBuffer::good() {
+    return m_ok;
+}
+
+VkDeviceSize CVKMemoryBuffer::available() {
+    return m_bufferSize - m_usedSize;
+}
+
+VkDeviceSize CVKMemoryBuffer::offset() {
+    return m_usedSize;
+}
+
+SP<CVKMemorySpan> CVKMemoryBuffer::allocate(VkDeviceSize size, VkDeviceSize offset) {
+    if (size + offset > available())
+        return nullptr;
+
+    const auto off = m_usedSize + offset;
+    m_usedSize += size + offset;
+    m_lastUsed.reset();
+    return m_allocations.emplace_back(makeShared<CVKMemorySpan>(m_self, size, off));
+}
+
+void CVKMemoryBuffer::clear() {
+    m_allocations.clear();
+    m_usedSize = 0;
+}
+
+CVKMemoryBuffer::~CVKMemoryBuffer() {
+    if (m_cpuMapping) {
+        vkUnmapMemory(vkDevice(), m_memory);
+        m_cpuMapping = nullptr;
+    }
+
+    if (m_buffer)
+        vkDestroyBuffer(vkDevice(), m_buffer, nullptr);
+
+    if (m_memory)
+        vkFreeMemory(vkDevice(), m_memory, nullptr);
+};

--- a/src/render/vulkan/MemoryBuffer.hpp
+++ b/src/render/vulkan/MemoryBuffer.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "../../helpers/time/Timer.hpp"
+#include "DeviceUser.hpp"
+#include <vector>
+#include <vulkan/vulkan_core.h>
+
+namespace Render::VK {
+    class CVKMemorySpan;
+
+    class CVKMemoryBuffer : public IDeviceUser {
+      public:
+        static SP<CVKMemoryBuffer> create(WP<CHyprVulkanDevice> device, VkDeviceSize bufferSize);
+        CVKMemoryBuffer(WP<CHyprVulkanDevice> device, VkDeviceSize bufferSize);
+        ~CVKMemoryBuffer();
+
+        bool              good();
+        VkDeviceSize      available();
+        VkDeviceSize      offset();
+        SP<CVKMemorySpan> allocate(VkDeviceSize size, VkDeviceSize offset = 0);
+        void              clear();
+
+      private:
+        WP<CVKMemoryBuffer>            m_self;
+        bool                           m_ok = false;
+
+        VkBuffer                       m_buffer;
+        VkDeviceMemory                 m_memory;
+        VkDeviceSize                   m_bufferSize = 0;
+        VkDeviceSize                   m_usedSize   = 0;
+        void*                          m_cpuMapping = nullptr;
+        CTimer                         m_lastUsed;
+
+        std::vector<SP<CVKMemorySpan>> m_allocations;
+
+        friend class CVKMemorySpan;
+        friend class CHyprVulkanImpl;
+    };
+}

--- a/src/render/vulkan/MemorySpan.cpp
+++ b/src/render/vulkan/MemorySpan.cpp
@@ -1,0 +1,21 @@
+#include "MemorySpan.hpp"
+
+using namespace Render::VK;
+
+CVKMemorySpan::CVKMemorySpan(WP<CVKMemoryBuffer> buffer, VkDeviceSize size, VkDeviceSize offset) : m_buffer(buffer), m_size(size), m_offset(offset) {}
+
+char* CVKMemorySpan::cpuMapping() {
+    return (char*)m_buffer->m_cpuMapping + m_offset;
+}
+
+VkDeviceSize CVKMemorySpan::size() {
+    return m_size;
+}
+
+VkDeviceSize CVKMemorySpan::offset() {
+    return m_offset;
+}
+
+VkBuffer CVKMemorySpan::vkBuffer() {
+    return m_buffer->m_buffer;
+}

--- a/src/render/vulkan/MemorySpan.hpp
+++ b/src/render/vulkan/MemorySpan.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "MemoryBuffer.hpp"
+
+namespace Render::VK {
+    class CVKMemorySpan {
+      public:
+        CVKMemorySpan(WP<CVKMemoryBuffer> buffer, VkDeviceSize size, VkDeviceSize offset);
+        // ~CVKMemorySpan();
+
+        struct SAllocation {
+            VkDeviceSize start;
+            VkDeviceSize size;
+        };
+
+        char*        cpuMapping();
+        VkDeviceSize size();
+        VkDeviceSize offset();
+        VkBuffer     vkBuffer();
+
+      private:
+        WP<CVKMemoryBuffer> m_buffer;
+        VkDeviceSize        m_size;
+        VkDeviceSize        m_offset;
+
+        friend class CVKMemoryBuffer;
+    };
+}

--- a/src/render/vulkan/Pipeline.cpp
+++ b/src/render/vulkan/Pipeline.cpp
@@ -1,0 +1,161 @@
+#include "Pipeline.hpp"
+#include "../VKRenderer.hpp"
+#include "utils.hpp"
+#include <format>
+#include <vector>
+#include <vulkan/vulkan_core.h>
+
+using namespace Render::VK;
+
+// TODO change api
+static CHyprVKRenderer* getRenderer() {
+    return dc<CHyprVKRenderer*>(g_pHyprRenderer.get());
+}
+
+void CVkPipeline::init(VkRenderPass renderPass, const void* pNext, WP<CVkShader> vert, WP<CVkShader> frag, const SSettings& settings) {
+    m_layout = getRenderer()->ensurePipelineLayout(vert->pushSize(), frag->pushSize(), settings.texCount, settings.uboCount);
+
+    VkSpecializationMapEntry specEntry = {
+        .constantID = 0,
+        .offset     = 0,
+        .size       = sizeof(uint32_t),
+    };
+
+    int                  colorTransformType = 0;
+
+    VkSpecializationInfo specialization = {
+        .mapEntryCount = 1,
+        .pMapEntries   = &specEntry,
+        .dataSize      = sizeof(uint32_t),
+        .pData         = &colorTransformType,
+    };
+
+    VkPipelineShaderStageCreateInfo        stages[2]{{
+                                                         .sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+                                                         .stage  = VK_SHADER_STAGE_VERTEX_BIT,
+                                                         .module = vert->module(),
+                                                         .pName  = "main",
+                                              },
+                                                     {
+                                                         .sType               = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+                                                         .stage               = VK_SHADER_STAGE_FRAGMENT_BIT,
+                                                         .module              = frag->module(),
+                                                         .pName               = "main",
+                                                         .pSpecializationInfo = &specialization,
+                                              }};
+
+    VkPipelineInputAssemblyStateCreateInfo assembly = {
+        .sType    = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
+        .topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN,
+    };
+
+    VkPipelineRasterizationStateCreateInfo rasterization = {
+        .sType       = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
+        .polygonMode = VK_POLYGON_MODE_FILL,
+        .cullMode    = VK_CULL_MODE_NONE,
+        .frontFace   = VK_FRONT_FACE_COUNTER_CLOCKWISE,
+        .lineWidth   = 1.f,
+    };
+
+    VkPipelineColorBlendAttachmentState blendAttachment = settings.blend ?
+        VkPipelineColorBlendAttachmentState{
+            .blendEnable         = true,
+            .srcColorBlendFactor = VK_BLEND_FACTOR_ONE,
+            .dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
+            .colorBlendOp        = VK_BLEND_OP_ADD,
+            .srcAlphaBlendFactor = VK_BLEND_FACTOR_ONE,
+            .dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA,
+            .alphaBlendOp        = VK_BLEND_OP_ADD,
+            .colorWriteMask      = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT,
+        } :
+        VkPipelineColorBlendAttachmentState{
+            .blendEnable    = false,
+            .colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT,
+        };
+
+    VkPipelineColorBlendStateCreateInfo blend = {
+        .sType           = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,
+        .attachmentCount = 1,
+        .pAttachments    = &blendAttachment,
+    };
+
+    VkPipelineMultisampleStateCreateInfo multisample = {
+        .sType                = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
+        .rasterizationSamples = VK_SAMPLE_COUNT_1_BIT,
+    };
+
+    VkPipelineViewportStateCreateInfo viewport = {
+        .sType         = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO,
+        .viewportCount = 1,
+        .scissorCount  = 1,
+    };
+
+    VkDynamicState dynStates[] = {
+        VK_DYNAMIC_STATE_VIEWPORT,
+        VK_DYNAMIC_STATE_SCISSOR,
+    };
+    VkPipelineDynamicStateCreateInfo dynamic = {
+        .sType             = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO,
+        .dynamicStateCount = sizeof(dynStates) / sizeof(dynStates[0]),
+        .pDynamicStates    = dynStates,
+    };
+
+    VkPipelineVertexInputStateCreateInfo vertex = {
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO,
+    };
+
+    VkGraphicsPipelineCreateInfo pinfo = {
+        .sType               = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO,
+        .pNext               = pNext,
+        .stageCount          = sizeof(stages) / sizeof(stages[0]),
+        .pStages             = stages,
+        .pVertexInputState   = &vertex,
+        .pInputAssemblyState = &assembly,
+        .pViewportState      = &viewport,
+        .pRasterizationState = &rasterization,
+        .pMultisampleState   = &multisample,
+        .pColorBlendState    = &blend,
+        .pDynamicState       = &dynamic,
+        .layout              = m_layout->vk(),
+        .renderPass          = renderPass,
+        .subpass             = settings.subpass,
+    };
+
+    VkPipelineCache cache = VK_NULL_HANDLE;
+    if (vkCreateGraphicsPipelines(vkDevice(), cache, 1, &pinfo, nullptr, &m_vkPipeline) != VK_SUCCESS) {
+        CRIT("failed to create vulkan pipelines");
+    }
+    SET_VK_PIPELINE_NAME(m_vkPipeline, std::format("Pipeline {}", frag->m_name))
+}
+
+CVkPipeline::CVkPipeline(WP<CHyprVulkanDevice> device, VkRenderPass renderPass, WP<CVkShader> vert, WP<CVkShader> frag, const SSettings& settings) :
+    IDeviceUser(device), m_key({vert->module(), frag->module()}) {
+    init(renderPass, nullptr, vert, frag, settings);
+}
+
+CVkPipeline::CVkPipeline(WP<CHyprVulkanDevice> device, VkFormat format, WP<CVkShader> vert, WP<CVkShader> frag, const SSettings& settings) :
+    IDeviceUser(device), m_key({vert->module(), frag->module()}) {
+    VkPipelineRenderingCreateInfo info = {
+        .sType                   = VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO,
+        .colorAttachmentCount    = 1,
+        .pColorAttachmentFormats = &format,
+    };
+    init(VK_NULL_HANDLE, &info, vert, frag, settings);
+}
+
+CVkPipeline::~CVkPipeline() {
+    if (m_vkPipeline)
+        vkDestroyPipeline(vkDevice(), m_vkPipeline, nullptr);
+}
+
+VkPipeline CVkPipeline::vk() {
+    return m_vkPipeline;
+}
+
+WP<CVkPipelineLayout> CVkPipeline::layout() {
+    return m_layout;
+}
+
+CVkPipeline::KEY CVkPipeline::key() {
+    return m_key;
+};

--- a/src/render/vulkan/Pipeline.hpp
+++ b/src/render/vulkan/Pipeline.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "DeviceUser.hpp"
+#include "PipelineLayout.hpp"
+#include "RenderPass.hpp"
+
+namespace Render::VK {
+    class CVkRenderPass;
+    class CVkShader;
+
+    class CVkPipeline : public IDeviceUser {
+      public:
+        using KEY = std::tuple<VkShaderModule, VkShaderModule>;
+        struct SSettings {
+            uint8_t texCount = 1;
+            uint8_t subpass  = 0;
+            bool    blend    = true;
+            uint8_t uboCount = 0;
+        };
+        CVkPipeline(WP<CHyprVulkanDevice> device, VkRenderPass renderPass, WP<CVkShader> vert, WP<CVkShader> frag,
+                    const SSettings& settings = {.texCount = 1, .subpass = 0, .blend = true, .uboCount = 0});
+        CVkPipeline(WP<CHyprVulkanDevice> device, VkFormat format, WP<CVkShader> vert, WP<CVkShader> frag,
+                    const SSettings& settings = {.texCount = 1, .subpass = 0, .blend = true, .uboCount = 0});
+        ~CVkPipeline();
+
+        VkPipeline            vk();
+        WP<CVkPipelineLayout> layout();
+        KEY                   key();
+
+      private:
+        void                  init(VkRenderPass renderPass, const void* pNext, WP<CVkShader> vert, WP<CVkShader> frag,
+                                   const SSettings& settings = {.texCount = 1, .subpass = 0, .blend = true, .uboCount = 0});
+        WP<CVkPipelineLayout> m_layout;
+        VkPipeline            m_vkPipeline;
+        KEY                   m_key;
+    };
+}

--- a/src/render/vulkan/PipelineLayout.cpp
+++ b/src/render/vulkan/PipelineLayout.cpp
@@ -1,0 +1,127 @@
+#include "PipelineLayout.hpp"
+#include "utils.hpp"
+#include <vulkan/vulkan_core.h>
+
+using namespace Render::VK;
+
+CVkPipelineLayout::CVkPipelineLayout(WP<CHyprVulkanDevice> device, KEY key) : IDeviceUser(device), m_key({key}) {
+    const auto [vertSize, fragSize, filter, texCount, uboCount] = key;
+
+    VkSamplerCreateInfo samplerCreateInfo = {
+        .sType        = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,
+        .magFilter    = filter,
+        .minFilter    = filter,
+        .mipmapMode   = VK_SAMPLER_MIPMAP_MODE_NEAREST,
+        .addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+        .addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+        .addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE,
+        .minLod       = 0.f,
+        .maxLod       = 0.25f,
+    };
+
+    // TODO YCC support
+    // if (YCC) {
+    //     VkSamplerYcbcrConversionCreateInfo conversionCreateInfo = {
+    //         .sType         = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO,
+    //         .format        = ,
+    //         .ycbcrModel    = ,
+    //         .ycbcrRange    = ,
+    //         .xChromaOffset = VK_CHROMA_LOCATION_MIDPOINT,
+    //         .yChromaOffset = VK_CHROMA_LOCATION_MIDPOINT,
+    //         .chromaFilter  = VK_FILTER_LINEAR,
+    //     };
+    //     if (vkCreateSamplerYcbcrConversion(vkDevice(), &conversionCreateInfo, NULL, &conversion) != VK_SUCCESS) {
+    //         CRIT("vkCreateSamplerYcbcrConversion");
+    //     }
+
+    //     VkSamplerYcbcrConversionInfo conversionInfo = {
+    //         .sType      = VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO,
+    //         .conversion = conversion,
+    //     };
+    //     samplerCreateInfo.pNext = &conversionInfo;
+    // }
+
+    if (vkCreateSampler(vkDevice(), &samplerCreateInfo, nullptr, &m_sampler) != VK_SUCCESS) {
+        CRIT("vkCreateSampler");
+    }
+
+    m_descriptorSets.resize(std::max((int)texCount, 1));
+    for (int i = 0; i < std::max((int)texCount, 1); i++) {
+        const auto                                tc = texCount > 0 ? 1 : 0;
+        std::vector<VkDescriptorSetLayoutBinding> dsBinding(tc + uboCount);
+        if (tc > 0) {
+            dsBinding[0] = {
+                .binding            = 0,
+                .descriptorType     = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+                .descriptorCount    = 1,
+                .stageFlags         = VK_SHADER_STAGE_FRAGMENT_BIT,
+                .pImmutableSamplers = &m_sampler,
+            };
+        }
+        for (int i = 0; i < uboCount; i++) {
+            dsBinding[tc + i] = {
+                .binding         = tc + i,
+                .descriptorType  = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+                .descriptorCount = 1,
+                .stageFlags      = VK_SHADER_STAGE_FRAGMENT_BIT,
+            };
+        }
+
+        VkDescriptorSetLayoutCreateInfo dsInfo = {
+            .sType        = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+            .bindingCount = dsBinding.size(),
+            .pBindings    = dsBinding.data(),
+        };
+
+        if (vkCreateDescriptorSetLayout(vkDevice(), &dsInfo, nullptr, &m_descriptorSets[i]) != VK_SUCCESS) {
+            CRIT("vkCreateDescriptorSetLayout");
+        }
+    }
+
+    VkPushConstantRange pcRanges[] = {
+        {
+            .stageFlags = VK_SHADER_STAGE_VERTEX_BIT,
+            .size       = vertSize,
+        },
+        {
+            .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
+            .offset     = vertSize,
+            .size       = fragSize,
+        },
+    };
+
+    VkPipelineLayoutCreateInfo plInfo = {
+        .sType                  = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+        .setLayoutCount         = m_descriptorSets.size(),
+        .pSetLayouts            = m_descriptorSets.data(),
+        .pushConstantRangeCount = pcRanges[1].size > 0 ? 2 : 1,
+        .pPushConstantRanges    = pcRanges,
+    };
+
+    if (vkCreatePipelineLayout(vkDevice(), &plInfo, nullptr, &m_layout) != VK_SUCCESS) {
+        CRIT("vkCreatePipelineLayout");
+    }
+}
+
+CVkPipelineLayout::KEY CVkPipelineLayout::key() {
+    return m_key;
+}
+
+VkPipelineLayout CVkPipelineLayout::vk() {
+    return m_layout;
+}
+
+std::vector<VkDescriptorSetLayout> CVkPipelineLayout::descriptorSets() {
+    return m_descriptorSets;
+}
+
+CVkPipelineLayout::~CVkPipelineLayout() {
+    if (m_layout)
+        vkDestroyPipelineLayout(vkDevice(), m_layout, nullptr);
+
+    for (const auto& ds : m_descriptorSets)
+        vkDestroyDescriptorSetLayout(vkDevice(), ds, nullptr);
+
+    if (m_sampler)
+        vkDestroySampler(vkDevice(), m_sampler, nullptr);
+}

--- a/src/render/vulkan/PipelineLayout.hpp
+++ b/src/render/vulkan/PipelineLayout.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "DeviceUser.hpp"
+
+namespace Render::VK {
+    class CVkPipelineLayout : public IDeviceUser {
+      public:
+        using KEY = std::tuple<uint32_t, uint32_t, VkFilter, uint8_t, uint8_t>;
+
+        CVkPipelineLayout(WP<CHyprVulkanDevice> device, KEY key);
+        CVkPipelineLayout(WP<CHyprVulkanDevice> device, uint32_t vertSize, uint32_t fragSize, VkFilter filter = VK_FILTER_LINEAR, uint8_t texCount = 1, uint8_t uboCount = 0) :
+            CVkPipelineLayout(device, {vertSize, fragSize, filter, texCount, uboCount}) {};
+        ~CVkPipelineLayout();
+
+        KEY                                key();
+        VkPipelineLayout                   vk();
+        std::vector<VkDescriptorSetLayout> descriptorSets();
+
+      private:
+        KEY                                m_key;
+
+        VkSampler                          m_sampler;
+        VkPipelineLayout                   m_layout;
+        std::vector<VkDescriptorSetLayout> m_descriptorSets;
+    };
+}

--- a/src/render/vulkan/RenderPass.cpp
+++ b/src/render/vulkan/RenderPass.cpp
@@ -1,0 +1,115 @@
+#include "RenderPass.hpp"
+#include "DeviceUser.hpp"
+#include "../../helpers/Format.hpp"
+#include "macros.hpp"
+#include "../ShaderLoader.hpp"
+#include "Vulkan.hpp"
+#include "utils.hpp"
+#include "types.hpp"
+#include <hyprutils/memory/Casts.hpp>
+#include <vulkan/vulkan_core.h>
+
+using namespace Render::VK;
+
+CVkRenderPass::CVkRenderPass(WP<CHyprVulkanDevice> device, DRMFormat format, SP<CVkShaders> shaders) : IDeviceUser(device), m_drmFormat(format), m_shaders(shaders) {
+    const auto info = m_device->getFormat(m_drmFormat);
+    RASSERT(info.has_value(), "No info for drm format {}", NFormatUtils::drmFormatName(m_drmFormat));
+    m_vkFormat = info->format.vkFormat;
+}
+
+WP<CVkPipeline> CVkRenderPass::borderPipeline(uint8_t features) {
+    return getPipeline(SH_FRAG_BORDER1, features, 0, 1);
+}
+
+WP<CVkPipeline> CVkRenderPass::rectPipeline(uint8_t features) {
+    return getPipeline(SH_FRAG_QUAD, features);
+}
+
+WP<CVkPipeline> CVkRenderPass::shadowPipeline(uint8_t features) {
+    return getPipeline(SH_FRAG_SHADOW, features);
+}
+
+WP<CVkPipeline> CVkRenderPass::texturePipeline(uint8_t features) {
+    return getPipeline(SH_FRAG_SURFACE, features, 2);
+}
+
+WP<CVkPipeline> CVkRenderPass::textureMattePipeline(uint8_t features) {
+    return getPipeline(SH_FRAG_MATTE, features, 2);
+}
+
+WP<CVkPipeline> CVkRenderPass::passPipeline(uint8_t features) {
+    return getPipeline(SH_FRAG_PASSTHRURGBA, features);
+}
+
+SP<CVkPipeline> CVkRenderPass::getPipeline(ePreparedFragmentShader frag, uint8_t features, int texCount, int uboCount) {
+    if (!m_pipelines[frag].contains(features))
+        m_pipelines[frag][features] = makeShared<CVkPipeline>(m_device, m_vkFormat, m_shaders->m_vert, m_shaders->getShaderVariant(frag, features),
+                                                              CVkPipeline::SSettings{.texCount = texCount, .uboCount = uboCount});
+
+    return m_pipelines[frag][features];
+}
+
+void CVkRenderPass::beginRendering(SP<CHyprVkCommandBuffer> cb, SP<CVKFramebuffer> target) {
+    ASSERT(!m_targetFB)
+    m_cmdBuffer = cb;
+    m_targetFB  = target;
+    VK_CB_LABEL_BEGIN(cb->vk(), "CVkRenderPass::beginRendering");
+    VK_CB_LABEL_BEGIN(cb->vk(), "render pass start");
+    cb->changeLayout(target, //
+                     {
+                         .layout     = target->m_lastKnownLayout,
+                         .stageMask  = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT,
+                         .accessMask = VK_ACCESS_2_COLOR_ATTACHMENT_READ_BIT,
+                     },
+                     {
+                         .layout     = VK_IMAGE_LAYOUT_GENERAL,
+                         .stageMask  = VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT,
+                         .accessMask = 0,
+                     });
+
+    VkRenderingAttachmentInfo attachment = {
+        .sType       = VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO,
+        .imageView   = VKTEX(target->getTexture())->vkView(),
+        .imageLayout = VK_IMAGE_LAYOUT_GENERAL,
+        .loadOp      = VK_ATTACHMENT_LOAD_OP_LOAD,
+        .storeOp     = VK_ATTACHMENT_STORE_OP_STORE,
+        .clearValue  = {.color = {{0.0f, 0.0f, 0.0f, 0.0f}}},
+    };
+
+    VkRenderingInfo info = {
+        .sType = VK_STRUCTURE_TYPE_RENDERING_INFO,
+        .renderArea =
+            {
+                .offset = {0, 0},
+                .extent = {target->m_size.x, target->m_size.y},
+            },
+        .layerCount           = 1,
+        .colorAttachmentCount = 1,
+        .pColorAttachments    = &attachment,
+    };
+
+    vkCmdBeginRendering(cb->vk(), &info);
+
+    VkViewport viewport = {
+        .width    = target->m_size.x,
+        .height   = target->m_size.y,
+        .maxDepth = 1,
+    };
+    vkCmdSetViewport(g_pHyprVulkan->renderCB()->vk(), 0, 1, &viewport);
+    VK_CB_LABEL_END(m_cmdBuffer->vk())
+}
+
+void CVkRenderPass::endRendering() {
+    VK_CB_LABEL_BEGIN(m_cmdBuffer->vk(), "render pass end");
+    vkCmdEndRendering(m_cmdBuffer->vk());
+
+    m_cmdBuffer->changeLayout(m_targetFB, //
+                              {.layout = m_targetFB->m_lastKnownLayout, .stageMask = VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, .accessMask = VK_ACCESS_TRANSFER_WRITE_BIT},
+                              {.layout = VK_IMAGE_LAYOUT_GENERAL, .stageMask = VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, .accessMask = 0});
+    VK_CB_LABEL_END(m_cmdBuffer->vk())
+    VK_CB_LABEL_END(m_cmdBuffer->vk())
+    m_targetFB.reset();
+    m_cmdBuffer.reset();
+}
+
+CVkRenderPass::~CVkRenderPass() = default;

--- a/src/render/vulkan/RenderPass.hpp
+++ b/src/render/vulkan/RenderPass.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "../../helpers/Format.hpp"
+#include "DeviceUser.hpp"
+#include "../ShaderLoader.hpp"
+#include "Pipeline.hpp"
+#include "Shaders.hpp"
+#include <vulkan/vulkan_core.h>
+
+namespace Render::VK {
+    class CVkPipeline;
+    class CHyprVkCommandBuffer;
+    class CVKFramebuffer;
+
+    class CVkRenderPass : IDeviceUser {
+      public:
+        CVkRenderPass(WP<CHyprVulkanDevice> device, DRMFormat format, SP<CVkShaders> shaders);
+        ~CVkRenderPass();
+
+        const DRMFormat m_drmFormat;
+        VkFormat        m_vkFormat;
+
+        WP<CVkPipeline> borderPipeline(uint8_t features = SH_FEAT_RGBA | SH_FEAT_ROUNDING);
+        WP<CVkPipeline> rectPipeline(uint8_t features = SH_FEAT_RGBA | SH_FEAT_ROUNDING);
+        WP<CVkPipeline> shadowPipeline(uint8_t features = SH_FEAT_RGBA | SH_FEAT_ROUNDING);
+        WP<CVkPipeline> texturePipeline(uint8_t features = SH_FEAT_RGBA | SH_FEAT_ROUNDING);
+        WP<CVkPipeline> textureMattePipeline(uint8_t features = SH_FEAT_RGBA | SH_FEAT_ROUNDING);
+        WP<CVkPipeline> passPipeline(uint8_t features = SH_FEAT_RGBA | SH_FEAT_ROUNDING);
+
+        void            beginRendering(SP<CHyprVkCommandBuffer> cb, SP<CVKFramebuffer> target);
+        void            endRendering();
+
+      private:
+        SP<CVkPipeline> getPipeline(ePreparedFragmentShader frag, uint8_t features = SH_FEAT_RGBA | SH_FEAT_ROUNDING, int texCount = 1, int uboCount = 0);
+        std::array<std::map<uint8_t, SP<CVkPipeline>>, SH_FRAG_LAST> m_pipelines;
+
+        SP<CVkShaders>                                               m_shaders;
+        SP<CHyprVkCommandBuffer>                                     m_cmdBuffer;
+        SP<CVKFramebuffer>                                           m_targetFB;
+    };
+}

--- a/src/render/vulkan/Shader.cpp
+++ b/src/render/vulkan/Shader.cpp
@@ -1,0 +1,113 @@
+#include "Shader.hpp"
+#include "debug/log/Logger.hpp"
+#include "macros.hpp"
+#include "render/vulkan/Vulkan.hpp"
+#include "utils.hpp"
+
+// based on https://github.com/KhronosGroup/glslang?tab=readme-ov-file#c-functional-interface-new
+#include <cmath>
+#include <cstdint>
+#include <glslang/Include/glslang_c_interface.h>
+#include <glslang/Public/resource_limits_c.h>
+
+// GLSLANG_TARGET_SPV_1_5 for shader "discard" op
+#define CLIENT_VERSION          GLSLANG_TARGET_VULKAN_1_4
+#define TARGET_LANGUAGE_VERSION GLSLANG_TARGET_SPV_1_5
+
+using namespace Render::VK;
+
+static std::optional<std::vector<uint32_t>> compileShader(glslang_stage_t stage, const std::string& shaderSource) {
+    const glslang_input_t input = {
+        .language                          = GLSLANG_SOURCE_GLSL,
+        .stage                             = stage,
+        .client                            = GLSLANG_CLIENT_VULKAN,
+        .client_version                    = CLIENT_VERSION,
+        .target_language                   = GLSLANG_TARGET_SPV,
+        .target_language_version           = TARGET_LANGUAGE_VERSION,
+        .code                              = shaderSource.c_str(),
+        .default_version                   = 100,
+        .default_profile                   = GLSLANG_NO_PROFILE,
+        .force_default_version_and_profile = false,
+        .forward_compatible                = false,
+        .messages                          = GLSLANG_MSG_DEFAULT_BIT,
+        .resource                          = glslang_default_resource(),
+    };
+
+    glslang_shader_t* shader = glslang_shader_create(&input);
+
+    if (!glslang_shader_preprocess(shader, &input)) {
+        Log::logger->log(Log::ERR, "GLSL preprocessing failed");
+        Log::logger->log(Log::ERR, "{}", glslang_shader_get_info_log(shader));
+        Log::logger->log(Log::ERR, "{}", glslang_shader_get_info_debug_log(shader));
+        Log::logger->log(Log::ERR, "{}", input.code);
+        glslang_shader_delete(shader);
+        return {};
+    }
+
+    if (!glslang_shader_parse(shader, &input)) {
+        Log::logger->log(Log::ERR, "GLSL parsing failed");
+        Log::logger->log(Log::ERR, "{}", glslang_shader_get_info_log(shader));
+        Log::logger->log(Log::ERR, "{}", glslang_shader_get_info_debug_log(shader));
+        Log::logger->log(Log::ERR, "{}", glslang_shader_get_preprocessed_code(shader));
+        glslang_shader_delete(shader);
+        return {};
+    }
+
+    glslang_program_t* program = glslang_program_create();
+    glslang_program_add_shader(program, shader);
+
+    if (!glslang_program_link(program, GLSLANG_MSG_SPV_RULES_BIT | GLSLANG_MSG_VULKAN_RULES_BIT)) {
+        Log::logger->log(Log::ERR, "GLSL linking failed");
+        Log::logger->log(Log::ERR, "{}", glslang_program_get_info_log(program));
+        Log::logger->log(Log::ERR, "{}", glslang_program_get_info_debug_log(program));
+        glslang_program_delete(program);
+        glslang_shader_delete(shader);
+        return {};
+    }
+
+    glslang_program_SPIRV_generate(program, stage);
+
+    const auto            size = glslang_program_SPIRV_get_size(program);
+    std::vector<uint32_t> binary(size);
+    glslang_program_SPIRV_get(program, binary.data());
+
+    const char* spirv_messages = glslang_program_SPIRV_get_messages(program);
+    if (spirv_messages)
+        Log::logger->log(Log::DEBUG, "{}", spirv_messages);
+
+    glslang_program_delete(program);
+    glslang_shader_delete(shader);
+
+    return binary;
+}
+
+CVkShader::CVkShader(WP<CHyprVulkanDevice> device, const std::string& source, uint32_t pushSize, eShaderType type, const std::string& name) :
+    IDeviceUser(device), m_name(name), m_pushSize(std::ceil(pushSize / 16.f) * 16) {
+    const auto binary = compileShader(type == SH_FRAG ? GLSLANG_STAGE_FRAGMENT : GLSLANG_STAGE_VERTEX, source);
+
+    ASSERT(binary.has_value());
+
+    VkShaderModuleCreateInfo info = {
+        .sType    = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO,
+        .codeSize = sizeof(uint32_t) * binary->size(),
+        .pCode    = binary->data(),
+    };
+    if (vkCreateShaderModule(vkDevice(), &info, nullptr, &m_module) != VK_SUCCESS) {
+        CRIT("vkCreateShaderModule");
+    }
+    if (m_name.length())
+        SET_VK_SHADER_NAME(m_module, m_name)
+}
+
+VkShaderModule CVkShader::module() {
+    return m_module;
+}
+
+uint32_t CVkShader::pushSize() {
+    return m_pushSize;
+}
+
+CVkShader::~CVkShader() {
+    if (m_module)
+        vkDestroyShaderModule(vkDevice(), m_module, nullptr);
+}

--- a/src/render/vulkan/Shader.hpp
+++ b/src/render/vulkan/Shader.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "DeviceUser.hpp"
+
+namespace Render::VK {
+    enum eShaderType : uint8_t {
+        SH_VERT,
+        SH_FRAG,
+    };
+
+    class CVkShader : public IDeviceUser {
+      public:
+        CVkShader(WP<CHyprVulkanDevice> device, const std::string& source, uint32_t pushSize, eShaderType type = SH_FRAG, const std::string& name = "");
+        ~CVkShader();
+
+        VkShaderModule    module();
+        uint32_t          pushSize();
+        const std::string m_name;
+
+      private:
+        VkShaderModule m_module;
+        uint32_t       m_pushSize;
+    };
+}

--- a/src/render/vulkan/Shaders.cpp
+++ b/src/render/vulkan/Shaders.cpp
@@ -1,0 +1,77 @@
+#include "Shaders.hpp"
+#include "Shader.hpp"
+#include "../ShaderLoader.hpp"
+#include "../../macros.hpp"
+#include "types.hpp"
+#include <hyprutils/memory/UniquePtr.hpp>
+#include "../../debug/log/Logger.hpp"
+
+using namespace Render;
+using namespace Render::VK;
+
+static const std::vector<std::string> SHADER_INCLUDES = {
+    "defines.h", "constants.h", "structs.h",   "cm_helpers.glsl",  "rounding.glsl", "CM.glsl",    "tonemap.glsl",
+    "gain.glsl", "border.glsl", "shadow.glsl", "blurprepare.glsl", "blur1.glsl",    "blur2.glsl", "blurFinish.glsl",
+};
+
+// TODO vulkan ext.frag, glitch.frag
+// order matters, see ePreparedFragmentShader
+const std::array<std::string, SH_FRAG_LAST> FRAG_SHADERS = {
+    "vk_quad.frag",        "vk_pass.frag",       "vk_matte.frag",  "ext.frag",    "vk_blur1.frag",  "vk_blur2.frag",
+    "vk_blurprepare.frag", "vk_blurfinish.frag", "vk_shadow.frag", "vk_tex.frag", "vk_border.frag", "glitch.frag",
+};
+
+#define VK_PUSH_MIN_SIZE 128
+
+CVkShaders::CVkShaders(WP<CHyprVulkanDevice> device, const std::string& shaderPath) : IDeviceUser(device) {
+    if (!g_pShaderLoader)
+        g_pShaderLoader = makeUnique<CShaderLoader>(SHADER_INCLUDES, FRAG_SHADERS, shaderPath);
+
+    if (sizeof(SVkVertShaderData) + sizeof(SVkFragShaderData) > VK_PUSH_MIN_SIZE)
+        Log::logger->log(Log::WARN, "Main texture shader push constants size ({}) is higher than the guaranteed size ({})", sizeof(SVkVertShaderData) + sizeof(SVkFragShaderData),
+                         VK_PUSH_MIN_SIZE);
+
+    m_vert = makeShared<CVkShader>(device, g_pShaderLoader->process("vulkan.vert"), sizeof(SVkVertShaderData), SH_VERT, "vert");
+}
+
+static int getShaderDataSize(ePreparedFragmentShader frag, uint8_t features) {
+    switch (frag) {
+        case SH_FRAG_QUAD: return sizeof(SVkRectShaderData) + (features & SH_FEAT_ROUNDING ? sizeof(SRounding) : 0);
+        case SH_FRAG_PASSTHRURGBA: return 0;
+        case SH_FRAG_MATTE: return 0;
+        case SH_FRAG_EXT: return 0; // unsupported
+        case SH_FRAG_BLUR1: return sizeof(SVkBlur1ShaderData);
+        case SH_FRAG_BLUR2: return sizeof(SVkBlur2ShaderData);
+        case SH_FRAG_BLURPREPARE: return sizeof(SVkPrepareShaderData) + (features & SH_FEAT_CM ? sizeof(SShaderCM) : 0);
+        case SH_FRAG_BLURFINISH: return sizeof(SVkFinishShaderData);
+        case SH_FRAG_SHADOW:
+            return sizeof(SVkShadowShaderData) + (features & SH_FEAT_ROUNDING ? sizeof(SRounding) : 0) + (features & SH_FEAT_CM ? sizeof(SShaderCM) : 0) +
+                (features & SH_FEAT_TONEMAP ? sizeof(SShaderTonemap) : 0) + (features & SH_FEAT_TONEMAP || features & SH_FEAT_SDR_MOD ? sizeof(SShaderTargetPrimaries) : 0);
+        case SH_FRAG_SURFACE:
+            return sizeof(SVkFragShaderData) + (features & SH_FEAT_ROUNDING ? sizeof(SRounding) : 0) + (features & SH_FEAT_CM ? sizeof(SShaderCM) : 0) +
+                (features & SH_FEAT_TONEMAP ? sizeof(SShaderTonemap) : 0) + (features & SH_FEAT_TONEMAP || features & SH_FEAT_SDR_MOD ? sizeof(SShaderTargetPrimaries) : 0);
+        case SH_FRAG_BORDER1:
+            return sizeof(SVkBorderShaderData) + (features & SH_FEAT_ROUNDING ? sizeof(SRounding) : 0) + (features & SH_FEAT_CM ? sizeof(SShaderCM) : 0) +
+                (features & SH_FEAT_TONEMAP ? sizeof(SShaderTonemap) : 0) + (features & SH_FEAT_TONEMAP || features & SH_FEAT_SDR_MOD ? sizeof(SShaderTargetPrimaries) : 0);
+        case SH_FRAG_GLITCH: return 0; // unsupported
+        default: UNREACHABLE();
+    }
+}
+
+WP<CVkShader> CVkShaders::getShaderVariant(ePreparedFragmentShader frag, uint8_t features) {
+    if (!m_fragVariants[frag].contains(features)) {
+        Log::logger->log(Log::INFO, "compiling feature set {} for {}", features, FRAG_SHADERS[frag]);
+
+        auto shader = makeShared<CVkShader>(m_device, g_pShaderLoader->getVariantSource(frag, features), getShaderDataSize(frag, features), SH_FRAG,
+                                            std::format("{}({})", FRAG_SHADERS[frag], features));
+
+        if (!shader)
+            Log::logger->log(Log::ERR, "shader features {} failed for {}", features, FRAG_SHADERS[frag]);
+
+        m_fragVariants[frag][features] = shader;
+        return shader;
+    }
+
+    ASSERT(m_fragVariants[frag][features]);
+    return m_fragVariants[frag][features];
+}

--- a/src/render/vulkan/Shaders.cpp
+++ b/src/render/vulkan/Shaders.cpp
@@ -14,11 +14,11 @@ static const std::vector<std::string> SHADER_INCLUDES = {
     "gain.glsl", "border.glsl", "shadow.glsl", "blurprepare.glsl", "blur1.glsl",    "blur2.glsl", "blurFinish.glsl",
 };
 
-// TODO vulkan ext.frag, glitch.frag
+// TODO vulkan ext.frag, glitch.frag, inner_glow.frag
 // order matters, see ePreparedFragmentShader
 const std::array<std::string, SH_FRAG_LAST> FRAG_SHADERS = {
-    "vk_quad.frag",        "vk_pass.frag",       "vk_matte.frag",  "ext.frag",    "vk_blur1.frag",  "vk_blur2.frag",
-    "vk_blurprepare.frag", "vk_blurfinish.frag", "vk_shadow.frag", "vk_tex.frag", "vk_border.frag", "glitch.frag",
+    "vk_quad.frag",       "vk_pass.frag",   "vk_matte.frag",   "ext.frag",    "vk_blur1.frag",  "vk_blur2.frag", "vk_blurprepare.frag",
+    "vk_blurfinish.frag", "vk_shadow.frag", "inner_glow.frag", "vk_tex.frag", "vk_border.frag", "glitch.frag",
 };
 
 #define VK_PUSH_MIN_SIZE 128

--- a/src/render/vulkan/Shaders.hpp
+++ b/src/render/vulkan/Shaders.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "DeviceUser.hpp"
+#include "Shader.hpp"
+#include "../ShaderLoader.hpp"
+#include <vulkan/vulkan.h>
+
+namespace Render::VK {
+    class CVkShaders : IDeviceUser {
+      public:
+        CVkShaders(WP<CHyprVulkanDevice> device, const std::string& shaderPath = "");
+        // ~CVkShaders();
+
+        SP<CVkShader> m_vert;
+        WP<CVkShader> getShaderVariant(ePreparedFragmentShader frag, uint8_t features = 0);
+
+      private:
+        std::array<std::map<uint8_t, SP<CVkShader>>, SH_FRAG_LAST> m_fragVariants;
+    };
+}

--- a/src/render/vulkan/VKElementRenderer.cpp
+++ b/src/render/vulkan/VKElementRenderer.cpp
@@ -1,0 +1,568 @@
+#include "VKElementRenderer.hpp"
+#include "../Renderer.hpp"
+#include "../decorations/CHyprDropShadowDecoration.hpp"
+#include "Vulkan.hpp"
+#include "../../desktop/view/Window.hpp"
+#include "../../protocols/ColorManagement.hpp"
+#include "utils.hpp"
+#include <cstdint>
+
+using namespace Render::VK;
+
+CVKElementRenderer::CVKElementRenderer(WP<CHyprVKRenderer> renderer) : m_renderer(renderer) {}
+
+void CVKElementRenderer::draw(WP<CBorderPassElement> element, const CRegion& damage) {
+    auto& m_renderData = m_renderer->m_renderData;
+    if (m_renderData.damage.empty())
+        return;
+
+    auto data   = element->m_data;
+    CBox newBox = data.box;
+    m_renderData.renderModif.applyToBox(newBox);
+
+    if (data.borderSize < 1)
+        return;
+
+    int scaledBorderSize = std::round(data.borderSize * m_renderData.pMonitor->m_scale);
+    scaledBorderSize     = std::round(scaledBorderSize * m_renderData.renderModif.combinedScale());
+
+    // adjust box
+    newBox.x -= scaledBorderSize;
+    newBox.y -= scaledBorderSize;
+    newBox.width += 2 * scaledBorderSize;
+    newBox.height += 2 * scaledBorderSize;
+
+    float round = data.round + (data.round == 0 ? 0 : scaledBorderSize);
+
+    // TODO handle transforms
+    CBox transformedBox = newBox;
+    transformedBox.transform(Math::wlTransformToHyprutils(Math::invertTransform(m_renderData.pMonitor->m_transform)), m_renderData.pMonitor->m_transformedSize.x,
+                             m_renderData.pMonitor->m_transformedSize.y);
+
+    const auto          TOPLEFT  = Vector2D(transformedBox.x, transformedBox.y);
+    const auto          FULLSIZE = Vector2D(transformedBox.width, transformedBox.height);
+
+    const auto          cb = g_pHyprVulkan->renderCB();
+
+    const auto&         vertData = matToVertShader(m_renderer->projectBoxToTarget(newBox).getMatrix());
+
+    const auto          gradientLength  = data.grad1.m_colorsOkLabA.size() / 4;
+    const auto          gradient2Length = data.grad2.m_colorsOkLabA.size() / 4;
+
+    SVkBorderShaderData fragData = {
+        .fullSizeUntransformed = {sc<float>(element->m_data.box.width), sc<float>(element->m_data.box.height)},
+        .radiusOuter           = data.outerRound == -1 ? round : data.outerRound,
+        .thick                 = scaledBorderSize,
+        .angle                 = sc<int>(data.grad1.m_angle / (std::numbers::pi / 180.0)) % 360 * (std::numbers::pi / 180.0),
+        .angle2                = sc<int>(data.grad2.m_angle / (std::numbers::pi / 180.0)) % 360 * (std::numbers::pi / 180.0),
+        .alpha                 = data.a,
+    };
+
+    SVkBorderGradientShaderData gradientData = {
+        .gradientLength  = gradientLength,
+        .gradient2Length = gradient2Length,
+        .gradientLerp    = data.lerp,
+    };
+
+    for (unsigned i = 0; i < gradientLength; i++) {
+        for (unsigned j = 0; j < 4; j++) {
+            gradientData.gradient[i][j] = data.grad1.m_colorsOkLabA.at(i * 4 + j);
+        }
+    }
+
+    for (unsigned i = 0; i < gradient2Length; i++) {
+        for (unsigned j = 0; j < 4; j++) {
+            gradientData.gradient2[i][j] = data.grad2.m_colorsOkLabA.at(i * 4 + j);
+        }
+    }
+
+    uint8_t   usedFeatures = 0;
+    SRounding roundingData = {
+        .radius   = round,
+        .power    = data.roundingPower,
+        .topLeft  = {sc<float>(TOPLEFT.x), sc<float>(TOPLEFT.y)},
+        .fullSize = {sc<float>(FULLSIZE.x), sc<float>(FULLSIZE.y)},
+    };
+    if (roundingData.radius > 0)
+        usedFeatures |= SH_FEAT_ROUNDING;
+
+    static const auto      PCM    = CConfigValue<Hyprlang::INT>("render:cm_enabled");
+    const bool             skipCM = !*PCM || m_renderData.pMonitor->m_imageDescription->id() == NColorManagement::getDefaultImageDescription()->id();
+    SShaderCM              cmData;
+    SShaderTonemap         tonemapData;
+    SShaderTargetPrimaries primariesData;
+    if (!skipCM) {
+        usedFeatures |= SH_FEAT_CM;
+        auto settings = m_renderer->getCMSettings(m_renderData.pMonitor->m_imageDescription, NColorManagement::getDefaultImageDescription(),
+                                                  m_renderData.surface.valid() ? m_renderData.surface.lock() : nullptr);
+        usedFeatures |= passCMUniforms(settings, cmData, tonemapData, primariesData);
+    }
+
+    auto       pipeline = m_renderer->m_currentRenderPass->borderPipeline(usedFeatures);
+    const auto layout   = pipeline->layout().lock();
+
+    m_renderer->bindPipeline(pipeline);
+
+    vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(vertData), &vertData);
+    vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, sizeof(vertData), sizeof(fragData), &fragData);
+    int featuresOffset = sizeof(vertData) + sizeof(fragData);
+    if (usedFeatures & SH_FEAT_ROUNDING) {
+        vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, featuresOffset, sizeof(roundingData), &roundingData);
+        featuresOffset += sizeof(roundingData);
+    }
+    if (usedFeatures & SH_FEAT_CM) {
+        vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, featuresOffset, sizeof(cmData), &cmData);
+        featuresOffset += sizeof(cmData);
+    }
+    if (usedFeatures & SH_FEAT_TONEMAP) {
+        vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, featuresOffset, sizeof(tonemapData), &tonemapData);
+        featuresOffset += sizeof(tonemapData);
+    }
+    if (usedFeatures & SH_FEAT_TONEMAP || usedFeatures & SH_FEAT_SDR_MOD) {
+        vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, featuresOffset, sizeof(primariesData), &primariesData);
+        featuresOffset += sizeof(primariesData);
+    }
+
+    auto ubo = m_renderer->getGradientForWindow(data.window);
+    if (ubo) {
+        auto ds = ubo->ds();
+        vkCmdBindDescriptorSets(cb->vk(), VK_PIPELINE_BIND_POINT_GRAPHICS, layout->vk(), 0, 1, &ds, 0, nullptr);
+        ubo->update(gradientData);
+    }
+
+    CRegion clipBox = m_renderData.damage.copy().intersect(newBox);
+    clipBox.subtract(element->m_data.box.copy().expand(-scaledBorderSize - round));
+
+    if (m_renderData.clipBox.width != 0 && m_renderData.clipBox.height != 0)
+        clipBox.intersect(m_renderData.clipBox);
+
+    drawRegionRects(clipBox, cb->vk());
+};
+
+void CVKElementRenderer::draw(WP<CClearPassElement> element, const CRegion& damage) {
+    auto& m_renderData = m_renderer->m_renderData;
+    if (m_renderer->m_hasBoundFB) {
+        auto dmg = damage.empty() ? m_renderData.damage : damage;
+        if (dmg.empty())
+            return;
+
+        VkClearAttachment clearAttachment = {
+            .aspectMask      = VK_IMAGE_ASPECT_COLOR_BIT,
+            .colorAttachment = 0,
+            .clearValue      = {.color = {{element->m_data.color.r, element->m_data.color.g, element->m_data.color.b, element->m_data.color.a}}},
+        };
+
+        std::vector<VkClearRect> rects;
+        const CBox               max = {{0, 0}, m_renderer->currentRBSize()};
+        m_renderData.renderModif.applyToRegion(dmg);
+        dmg.intersect(max).forEachRect([&](const auto& RECT) {
+            rects.push_back(VkClearRect{
+                .rect =
+                    {
+                        .offset = {.x = RECT.x1, .y = RECT.y1},
+                        .extent = {.width = RECT.x2 - RECT.x1, .height = RECT.y2 - RECT.y1},
+                    },
+                .baseArrayLayer = 0,
+                .layerCount     = 1,
+            });
+        });
+
+        if (rects.size())
+            vkCmdClearAttachments(g_pHyprVulkan->renderCB()->vk(), 1, &clearAttachment, rects.size(), rects.data());
+        // else {
+        //     VkClearRect rect = {
+        //         .rect =
+        //             {
+        //                 .offset = {.x = 0, .y = 0},
+        //                 .extent = {.width = currentRBSize().x, .height = currentRBSize().y},
+        //             },
+        //         .baseArrayLayer = 0,
+        //         .layerCount     = 1,
+        //     };
+        //     vkCmdClearAttachments(g_pHyprVulkan->renderCB()->vk(), 1, &clearAttachment, 1, &rect);
+        // }
+        return;
+    }
+
+    VkClearColorValue clearValue;
+    clearValue = {{element->m_data.color.r, element->m_data.color.g, element->m_data.color.b, element->m_data.color.a}};
+
+    VkImageSubresourceRange clearRange = {
+        .aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT,
+        .baseMipLevel   = 0,
+        .levelCount     = VK_REMAINING_MIP_LEVELS,
+        .baseArrayLayer = 0,
+        .layerCount     = VK_REMAINING_ARRAY_LAYERS,
+    };
+
+    vkCmdClearColorImage(g_pHyprVulkan->renderCB()->vk(), VKFB(m_renderData.currentFB)->fb()->vkImage(), VK_IMAGE_LAYOUT_GENERAL, &clearValue, 1, &clearRange);
+};
+
+void CVKElementRenderer::draw(WP<CFramebufferElement> element, const CRegion& damage) {
+    Log::logger->log(Log::ERR, "Deprecated CFramebufferElement. Use m_renderer->m_renderData and CTexPassElement instead");
+};
+
+void CVKElementRenderer::draw(WP<CPreBlurElement> element, const CRegion& damage) {
+    auto dmg = damage;
+    m_renderer->preBlurForCurrentMonitor(&dmg);
+};
+
+void CVKElementRenderer::draw(WP<CRectPassElement> element, const CRegion& damage) {
+    const auto&             data = element->m_data;
+
+    const auto&             vertData = matToVertShader(m_renderer->projectBoxToTarget(data.modifiedBox).getMatrix());
+    const SVkRectShaderData fragData = {
+        .color = {data.color.r * data.color.a, data.color.g * data.color.a, data.color.b * data.color.a, data.color.a},
+    };
+    uint8_t   usedFeatures = 0;
+    SRounding roundingData = {
+        .radius   = data.round,
+        .power    = data.roundingPower,
+        .topLeft  = {data.TOPLEFT[0], data.TOPLEFT[1]},
+        .fullSize = {data.FULLSIZE[0], data.FULLSIZE[1]},
+
+    };
+    if (roundingData.radius > 0)
+        usedFeatures |= SH_FEAT_ROUNDING;
+
+    const auto cb       = g_pHyprVulkan->renderCB();
+    const auto pipeline = m_renderer->m_currentRenderPass->rectPipeline(usedFeatures);
+    const auto layout   = pipeline->layout().lock();
+
+    m_renderer->bindPipeline(pipeline);
+
+    vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(vertData), &vertData);
+    vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, sizeof(vertData), sizeof(fragData), &fragData);
+    if (usedFeatures & SH_FEAT_ROUNDING)
+        vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, sizeof(vertData) + sizeof(fragData), sizeof(roundingData), &roundingData);
+
+    drawRegionRects(data.drawRegion, cb->vk());
+};
+
+void CVKElementRenderer::draw(WP<CShadowPassElement> element, const CRegion& damage) {
+    VK_CB_LABEL_BEGIN(m_renderer->m_currentCommandBuffer->vk(), "Shadow element")
+    auto&            m_renderData        = m_renderer->m_renderData;
+    static auto      PSHADOWIGNOREWINDOW = CConfigValue<Hyprlang::INT>("decoration:shadow:ignore_window");
+    SP<IFramebuffer> mirrorFB;
+    SP<IFramebuffer> mirrorSwapFB;
+    if (*PSHADOWIGNOREWINDOW) {
+        mirrorFB     = m_renderData.pMonitor->resources()->getUnusedWorkBuffer();
+        mirrorSwapFB = m_renderData.pMonitor->resources()->getUnusedWorkBuffer();
+        if (m_renderer->m_hasBoundFB)
+            m_renderer->m_currentRenderPass->endRendering();
+        m_renderer->m_currentCommandBuffer->changeLayout(
+            mirrorFB, //
+            {.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = VK_ACCESS_TRANSFER_WRITE_BIT},
+            {.layout = VK_IMAGE_LAYOUT_GENERAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = 0});
+        m_renderer->m_currentCommandBuffer->changeLayout(
+            mirrorSwapFB, //
+            {.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = VK_ACCESS_TRANSFER_WRITE_BIT},
+            {.layout = VK_IMAGE_LAYOUT_GENERAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = 0});
+
+        if (m_renderer->m_hasBoundFB)
+            m_renderer->m_currentRenderPass->beginRendering(m_renderer->m_currentCommandBuffer.lock(), m_renderer->m_hasBoundFB);
+    }
+
+    element->m_data.deco->render(m_renderData.pMonitor.lock(), element->m_data.a);
+
+    if (*PSHADOWIGNOREWINDOW) {
+        if (m_renderer->m_hasBoundFB)
+            m_renderer->m_currentRenderPass->endRendering();
+        m_renderer->m_currentCommandBuffer->changeLayout(
+            mirrorFB, //
+            {.layout = VK_IMAGE_LAYOUT_GENERAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = VK_ACCESS_TRANSFER_WRITE_BIT},
+            {.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = 0});
+        m_renderer->m_currentCommandBuffer->changeLayout(
+            mirrorSwapFB, //
+            {.layout = VK_IMAGE_LAYOUT_GENERAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = VK_ACCESS_TRANSFER_WRITE_BIT},
+            {.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = 0});
+
+        if (m_renderer->m_hasBoundFB)
+            m_renderer->m_currentRenderPass->beginRendering(m_renderer->m_currentCommandBuffer.lock(), m_renderer->m_hasBoundFB);
+    }
+    VK_CB_LABEL_END(m_renderer->m_currentCommandBuffer->vk())
+};
+
+void CVKElementRenderer::draw(WP<CInnerGlowPassElement> element, const CRegion& damage) {
+    Log::logger->log(Log::WARN, "Unimplimented draw for {}", element->passName());
+}
+
+void CVKElementRenderer::draw(WP<CTexPassElement> element, const CRegion& damage) {
+    auto&             m_renderData = m_renderer->m_renderData;
+    static const auto PPASS        = CConfigValue<Hyprlang::INT>("render:cm_fs_passthrough");
+    static const auto PCM          = CConfigValue<Hyprlang::INT>("render:cm_enabled");
+    const auto        sdrEOTF      = NTransferFunction::fromConfig();
+
+    auto              discardOpacity = element->m_data.ignoreAlpha.has_value() ? *element->m_data.ignoreAlpha : element->m_data.discardOpacity;
+    auto              discardMode    = element->m_data.ignoreAlpha.has_value() ? (uint32_t)DISCARD_ALPHA : element->m_data.discardMode;
+
+    const auto&       data   = element->m_data;
+    float             alpha  = std::clamp(data.a, 0.f, 1.f);
+    const auto        box    = element->m_data.box;
+    CBox              newBox = box;
+    m_renderer->m_renderData.renderModif.applyToBox(newBox);
+
+    CBox transformedBox = newBox;
+    transformedBox.transform(Math::wlTransformToHyprutils(Math::invertTransform(m_renderData.pMonitor->m_transform)), m_renderData.pMonitor->m_transformedSize.x,
+                             m_renderData.pMonitor->m_transformedSize.y);
+
+    const auto TOPLEFT  = Vector2D(transformedBox.x, transformedBox.y);
+    const auto FULLSIZE = Vector2D(transformedBox.width, transformedBox.height);
+
+    const auto cb = g_pHyprVulkan->renderCB();
+    cb->useTexture(element->m_data.tex);
+    const auto texture = VKTEX(element->m_data.tex);
+
+    // get the needed transform for this texture
+    const auto MONITOR_INVERTED = Math::wlTransformToHyprutils(Math::invertTransform(m_renderData.pMonitor->m_transform));
+    auto       TRANSFORM        = texture->m_transform;
+
+    if (m_renderer->monitorTransformEnabled())
+        TRANSFORM = Math::composeTransform(MONITOR_INVERTED, TRANSFORM);
+
+    const auto mat = m_renderer->projectBoxToTarget(element->m_data.box, TRANSFORM).getMatrix();
+
+    // const auto&       vertData = matToVertShader(mat);
+    SVkVertShaderData vertData = {
+        .mat4 =
+            {
+                {mat[0], mat[1], 0, mat[2]},
+                {mat[3], mat[4], 0, mat[5]},
+                {0, 0, 1, 0},
+                {0, 0, 0, 1},
+            },
+        .uvOffset = {element->m_data.box.x / m_renderData.pMonitor->m_transformedSize.x, element->m_data.box.y / m_renderData.pMonitor->m_transformedSize.y},
+        .uvSize   = {element->m_data.box.width / m_renderData.pMonitor->m_transformedSize.x, element->m_data.box.height / m_renderData.pMonitor->m_transformedSize.y},
+    };
+
+    SVkFragShaderData fragData = {
+        .alpha = alpha,
+    };
+    uint8_t usedFeatures = 0;
+
+    switch (texture->m_type) {
+        case TEXTURE_RGBA: usedFeatures |= SH_FEAT_RGBA; break;
+        case TEXTURE_RGBX: usedFeatures &= ~SH_FEAT_RGBA; break;
+
+        // TODO set correct features
+        case TEXTURE_EXTERNAL: break; // might be unused
+        default: RASSERT(false, "tex->m_iTarget unsupported!");
+    }
+    if (m_renderData.currentWindow && m_renderData.currentWindow->m_ruleApplicator->RGBX().valueOrDefault())
+        usedFeatures &= ~SH_FEAT_RGBA;
+
+    if (element->m_data.blur)
+        usedFeatures |= SH_FEAT_BLUR;
+
+    // if (element->m_data.blur) {
+    //     auto el = makeUnique<CTexPassElement>(CTexPassElement::SRenderData{
+    //         .tex = element->m_data.blurredBG,
+    //         .box = CBox{{0, 0}, m_renderData.pMonitor->m_transformedSize},
+    //         // .clipRegion = data.clipRegion,
+    //         .clipRegion = element->m_data.box,
+    //     });
+    //     draw(el.get(), damage);
+    // }
+
+    if (element->m_data.discardActive || (element->m_data.blur && discardMode != 0 && (!data.blockBlurOptimization || (discardMode & DISCARD_ALPHA)))) {
+        usedFeatures |= SH_FEAT_DISCARD;
+        fragData.discardMode       = discardMode;
+        fragData.discardAlphaValue = discardOpacity;
+    }
+
+    if (m_renderData.currentWindow && (m_renderData.currentWindow->m_notRespondingTint->value() > 0 || m_renderData.currentWindow->m_dimPercent->value() > 0)) {
+        usedFeatures |= SH_FEAT_TINT;
+        fragData.tint = 1.0f -
+            (m_renderer->m_renderData.currentWindow->m_notRespondingTint->value() > 0 ? m_renderer->m_renderData.currentWindow->m_notRespondingTint->value() :
+                                                                                        m_renderer->m_renderData.currentWindow->m_dimPercent->value());
+    }
+
+    SRounding roundingData = {
+        .radius   = element->m_data.round,
+        .power    = data.roundingPower,
+        .topLeft  = {sc<float>(TOPLEFT.x), sc<float>(TOPLEFT.y)},
+        .fullSize = {sc<float>(FULLSIZE.x), sc<float>(FULLSIZE.y)},
+    };
+    if (roundingData.radius > 0)
+        usedFeatures |= SH_FEAT_ROUNDING;
+
+    const auto surface           = m_renderer->m_renderData.surface;
+    const bool isHDRSurface      = surface.valid() && surface->m_colorManagement.valid() ? surface->m_colorManagement->isHDR() : false;
+    const bool canPassHDRSurface = isHDRSurface && !surface->m_colorManagement->isWindowsScRGB(); // windows scRGB requires CM shader
+
+    const auto imageDescription = surface.valid() && surface->m_colorManagement.valid() ?
+        NColorManagement::CImageDescription::from(surface->m_colorManagement->imageDescription()) :
+        (data.cmBackToSRGB ? data.cmBackToSRGBSource->m_imageDescription : NColorManagement::getDefaultImageDescription());
+
+    auto       chosenSdrEotf          = sdrEOTF != NTransferFunction::TF_SRGB ? NColorManagement::CM_TRANSFER_FUNCTION_GAMMA22 : NColorManagement::CM_TRANSFER_FUNCTION_SRGB;
+    const auto targetImageDescription = data.cmBackToSRGB ? NColorManagement::CImageDescription::from(NColorManagement::SImageDescription{.transferFunction = chosenSdrEotf}) :
+                                                            m_renderData.pMonitor->m_imageDescription;
+    const bool skipCM                 = !*PCM                                             /* CM unsupported or disabled */
+        || m_renderData.pMonitor->doesNoShaderCM()                                        /* no shader needed */
+        || (imageDescription->id() == targetImageDescription->id() && !data.cmBackToSRGB) /* Source and target have the same image description */
+        || (((*PPASS && canPassHDRSurface) ||
+             (*PPASS == 1 && !isHDRSurface && m_renderData.pMonitor->m_cmType != NCMType::CM_HDR && m_renderData.pMonitor->m_cmType != NCMType::CM_HDR_EDID)) &&
+            m_renderData.pMonitor->inFullscreenMode()) /* Fullscreen window with pass cm enabled */;
+    SShaderCM              cmData;
+    SShaderTonemap         tonemapData;
+    SShaderTargetPrimaries primariesData;
+    if (!skipCM) {
+        usedFeatures |= SH_FEAT_CM;
+        auto settings = m_renderer->getCMSettings(imageDescription, targetImageDescription, m_renderData.surface.valid() ? m_renderData.surface.lock() : nullptr);
+        usedFeatures |= passCMUniforms(settings, cmData, tonemapData, primariesData);
+    }
+
+    auto       pipeline = m_renderer->m_currentRenderPass->texturePipeline(usedFeatures);
+    const auto layout   = pipeline->layout().lock();
+    const auto view     = texture->getView(layout);
+    if (!view)
+        return;
+
+    m_renderer->bindPipeline(pipeline);
+
+    std::vector<VkDescriptorSet> ds = {view->vkDS()};
+
+    if (element->m_data.blur) {
+        const auto viewBlur = VKTEX(element->m_data.blurredBG)->getView(layout);
+        if (viewBlur)
+            ds.push_back(viewBlur->vkDS());
+    }
+
+    vkCmdBindDescriptorSets(cb->vk(), VK_PIPELINE_BIND_POINT_GRAPHICS, layout->vk(), 0, ds.size(), ds.data(), 0, nullptr);
+
+    vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(vertData), &vertData);
+    vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, sizeof(vertData), sizeof(fragData), &fragData);
+    int featuresOffset = sizeof(vertData) + sizeof(fragData);
+    if (usedFeatures & SH_FEAT_ROUNDING) {
+        vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, featuresOffset, sizeof(roundingData), &roundingData);
+        featuresOffset += sizeof(roundingData);
+    }
+    if (usedFeatures & SH_FEAT_CM) {
+        vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, featuresOffset, sizeof(cmData), &cmData);
+        featuresOffset += sizeof(cmData);
+    }
+    if (usedFeatures & SH_FEAT_TONEMAP) {
+        vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, featuresOffset, sizeof(tonemapData), &tonemapData);
+        featuresOffset += sizeof(tonemapData);
+    }
+    if (usedFeatures & SH_FEAT_TONEMAP || usedFeatures & SH_FEAT_SDR_MOD) {
+        vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_FRAGMENT_BIT, featuresOffset, sizeof(primariesData), &primariesData);
+        featuresOffset += sizeof(primariesData);
+    }
+
+    // Log::logger->log(Log::DEBUG, "DRAW TEX {}x{}@{}x{}, damage {}x{}@{}x{}, clipbox {}x{}@{}x{}, clipregion {}x{}@{}x{}", element->m_data.box.width, element->m_data.box.height,
+    //                  element->m_data.box.x, element->m_data.box.y,                                                                                                            //
+    //                  m_renderData.damage.getExtents().width, m_renderData.damage.getExtents().height, m_renderData.damage.getExtents().x, m_renderData.damage.getExtents().y, //
+    //                  m_renderData.clipBox.width, m_renderData.clipBox.height, m_renderData.clipBox.x, m_renderData.clipBox.y,                                                 //
+    //                  element->m_data.clipRegion.getExtents().width, element->m_data.clipRegion.getExtents().height, element->m_data.clipRegion.getExtents().x,
+    //                  element->m_data.clipRegion.getExtents().y //
+    // );
+
+    auto clipBox = !element->m_data.damage.empty() ? element->m_data.damage : (!damage.empty() ? damage : m_renderData.damage);
+    if (!m_renderData.clipBox.empty() || !element->m_data.clipRegion.empty()) {
+        CRegion damageClip = m_renderData.clipBox;
+
+        if (!element->m_data.clipRegion.empty()) {
+            if (m_renderData.clipBox.empty())
+                damageClip = element->m_data.clipRegion;
+            else
+                damageClip.intersect(element->m_data.clipRegion);
+        }
+        clipBox = damageClip;
+    }
+    clipBox = clipBox.intersect(element->m_data.box);
+
+    drawRegionRects(clipBox, cb->vk());
+
+    texture->m_lastUsedCB = cb;
+
+    if (element->m_data.tex->isDMA()) {
+        m_renderer->setTexBarriers(element->m_data.tex);
+
+        static bool warned = false;
+        if (!warned) {
+            warned = true;
+            Log::logger->log(Log::WARN, "fixme: vulkan draw dma texture sync");
+        }
+    }
+};
+
+void CVKElementRenderer::draw(WP<CTextureMatteElement> element, const CRegion& damage) {
+    VK_CB_LABEL_BEGIN(m_renderer->m_currentCommandBuffer->vk(), "Matte element")
+    auto&            m_renderData        = m_renderer->m_renderData;
+    static auto      PSHADOWIGNOREWINDOW = CConfigValue<Hyprlang::INT>("decoration:shadow:ignore_window");
+    SP<IFramebuffer> mirrorFB;
+    SP<IFramebuffer> mirrorSwapFB;
+    if (*PSHADOWIGNOREWINDOW) {
+        mirrorFB     = m_renderData.pMonitor->resources()->getUnusedWorkBuffer();
+        mirrorSwapFB = m_renderData.pMonitor->resources()->getUnusedWorkBuffer();
+        if (m_renderer->m_hasBoundFB)
+            m_renderer->m_currentRenderPass->endRendering();
+        m_renderer->m_currentCommandBuffer->changeLayout(
+            mirrorFB, //
+            {.layout = VK_IMAGE_LAYOUT_GENERAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = VK_ACCESS_TRANSFER_WRITE_BIT},
+            {.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = 0});
+        m_renderer->m_currentCommandBuffer->changeLayout(
+            mirrorSwapFB, //
+            {.layout = VK_IMAGE_LAYOUT_GENERAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = VK_ACCESS_TRANSFER_WRITE_BIT},
+            {.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = 0});
+
+        if (m_renderer->m_hasBoundFB)
+            m_renderer->m_currentRenderPass->beginRendering(m_renderer->m_currentCommandBuffer.lock(), m_renderer->m_hasBoundFB);
+    }
+
+    const auto cb       = g_pHyprVulkan->renderCB();
+    const auto tex      = element->m_data.tex;
+    const auto texMatte = element->m_data.fb->getTexture();
+    cb->useTexture(tex);
+    cb->useTexture(texMatte);
+    RASSERT((tex->ok()), "Attempted to draw nullptr texture!");
+
+    TRACY_GPU_ZONE("RenderTextureMatte");
+
+    CBox newBox = element->m_data.box;
+    m_renderData.renderModif.applyToBox(newBox);
+
+    const auto  mat = m_renderer->projectBoxToTarget(element->m_data.box).getMatrix();
+
+    const auto& vertData = matToVertShader(mat);
+
+    const auto  layout = m_renderer->m_currentRenderPass->textureMattePipeline()->layout().lock();
+
+    const auto  view = VKTEX(tex)->getView(layout);
+    if (!view) {
+        VK_CB_LABEL_END(m_renderer->m_currentCommandBuffer->vk())
+        return;
+    }
+
+    const auto viewMatte = VKTEX(texMatte)->getView(layout);
+    if (!viewMatte) {
+        VK_CB_LABEL_END(m_renderer->m_currentCommandBuffer->vk())
+        return;
+    }
+
+    m_renderer->bindPipeline(m_renderer->m_currentRenderPass->textureMattePipeline());
+
+    const std::array<VkDescriptorSet, 2> ds = {view->vkDS(), viewMatte->vkDS()};
+    vkCmdBindDescriptorSets(cb->vk(), VK_PIPELINE_BIND_POINT_GRAPHICS, layout->vk(), 0, ds.size(), ds.data(), 0, nullptr);
+
+    vkCmdPushConstants(cb->vk(), layout->vk(), VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(vertData), &vertData);
+    drawRegionRects(m_renderData.damage, cb->vk());
+
+    if (*PSHADOWIGNOREWINDOW) {
+        if (m_renderer->m_hasBoundFB)
+            m_renderer->m_currentRenderPass->endRendering();
+        m_renderer->m_currentCommandBuffer->changeLayout(
+            mirrorFB, //
+            {.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = VK_ACCESS_TRANSFER_WRITE_BIT},
+            {.layout = VK_IMAGE_LAYOUT_GENERAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = 0});
+        m_renderer->m_currentCommandBuffer->changeLayout(
+            mirrorSwapFB, //
+            {.layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = VK_ACCESS_TRANSFER_WRITE_BIT},
+            {.layout = VK_IMAGE_LAYOUT_GENERAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = 0});
+
+        if (m_renderer->m_hasBoundFB)
+            m_renderer->m_currentRenderPass->beginRendering(m_renderer->m_currentCommandBuffer.lock(), m_renderer->m_hasBoundFB);
+    }
+    VK_CB_LABEL_END(m_renderer->m_currentCommandBuffer->vk())
+};

--- a/src/render/vulkan/VKElementRenderer.cpp
+++ b/src/render/vulkan/VKElementRenderer.cpp
@@ -289,7 +289,6 @@ void CVKElementRenderer::draw(WP<CInnerGlowPassElement> element, const CRegion& 
 
 void CVKElementRenderer::draw(WP<CTexPassElement> element, const CRegion& damage) {
     auto&             m_renderData = m_renderer->m_renderData;
-    static const auto PPASS        = CConfigValue<Hyprlang::INT>("render:cm_fs_passthrough");
     static const auto PCM          = CConfigValue<Hyprlang::INT>("render:cm_enabled");
     const auto        sdrEOTF      = NTransferFunction::fromConfig();
 
@@ -386,9 +385,7 @@ void CVKElementRenderer::draw(WP<CTexPassElement> element, const CRegion& damage
     if (roundingData.radius > 0)
         usedFeatures |= SH_FEAT_ROUNDING;
 
-    const auto surface           = m_renderer->m_renderData.surface;
-    const bool isHDRSurface      = surface.valid() && surface->m_colorManagement.valid() ? surface->m_colorManagement->isHDR() : false;
-    const bool canPassHDRSurface = isHDRSurface && !surface->m_colorManagement->isWindowsScRGB(); // windows scRGB requires CM shader
+    const auto surface = m_renderer->m_renderData.surface;
 
     const auto imageDescription = surface.valid() && surface->m_colorManagement.valid() ?
         NColorManagement::CImageDescription::from(surface->m_colorManagement->imageDescription()) :
@@ -397,12 +394,9 @@ void CVKElementRenderer::draw(WP<CTexPassElement> element, const CRegion& damage
     auto       chosenSdrEotf          = sdrEOTF != NTransferFunction::TF_SRGB ? NColorManagement::CM_TRANSFER_FUNCTION_GAMMA22 : NColorManagement::CM_TRANSFER_FUNCTION_SRGB;
     const auto targetImageDescription = data.cmBackToSRGB ? NColorManagement::CImageDescription::from(NColorManagement::SImageDescription{.transferFunction = chosenSdrEotf}) :
                                                             m_renderData.pMonitor->m_imageDescription;
-    const bool skipCM                 = !*PCM                                             /* CM unsupported or disabled */
-        || m_renderData.pMonitor->doesNoShaderCM()                                        /* no shader needed */
-        || (imageDescription->id() == targetImageDescription->id() && !data.cmBackToSRGB) /* Source and target have the same image description */
-        || (((*PPASS && canPassHDRSurface) ||
-             (*PPASS == 1 && !isHDRSurface && m_renderData.pMonitor->m_cmType != NCMType::CM_HDR && m_renderData.pMonitor->m_cmType != NCMType::CM_HDR_EDID)) &&
-            m_renderData.pMonitor->inFullscreenMode()) /* Fullscreen window with pass cm enabled */;
+    const bool skipCM                 = !*PCM                                              /* CM unsupported or disabled */
+        || m_renderData.pMonitor->doesNoShaderCM()                                         /* no shader needed */
+        || (imageDescription->id() == targetImageDescription->id() && !data.cmBackToSRGB); /* Source and target have the same image description */
     SShaderCM              cmData;
     SShaderTonemap         tonemapData;
     SShaderTargetPrimaries primariesData;

--- a/src/render/vulkan/VKElementRenderer.hpp
+++ b/src/render/vulkan/VKElementRenderer.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "../ElementRenderer.hpp"
+#include "render/VKRenderer.hpp"
+
+namespace Render::VK {
+    class CVKElementRenderer : public Render::IElementRenderer {
+      public:
+        CVKElementRenderer(WP<CHyprVKRenderer> renderer);
+        ~CVKElementRenderer() = default;
+
+      private:
+        void                draw(WP<CBorderPassElement> element, const Hyprutils::Math::CRegion& damage) override;
+        void                draw(WP<CClearPassElement> element, const CRegion& damage) override;
+        void                draw(WP<CFramebufferElement> element, const CRegion& damage) override;
+        void                draw(WP<CPreBlurElement> element, const CRegion& damage) override;
+        void                draw(WP<CRectPassElement> element, const CRegion& damage) override;
+        void                draw(WP<CShadowPassElement> element, const CRegion& damage) override;
+        void                draw(WP<CInnerGlowPassElement> element, const CRegion& damage) override;
+        void                draw(WP<CTexPassElement> element, const CRegion& damage) override;
+        void                draw(WP<CTextureMatteElement> element, const CRegion& damage) override;
+
+        WP<CHyprVKRenderer> m_renderer;
+    };
+}

--- a/src/render/vulkan/VKTexture.cpp
+++ b/src/render/vulkan/VKTexture.cpp
@@ -1,0 +1,757 @@
+#include "VKTexture.hpp"
+#include "Vulkan.hpp"
+#include "debug/log/Logger.hpp"
+#include "helpers/Format.hpp"
+#include <array>
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+#include <drm_fourcc.h>
+#include <fcntl.h>
+#include <format>
+#include <hyprutils/math/Region.hpp>
+#include <hyprutils/memory/SharedPtr.hpp>
+#include <vector>
+#include <vulkan/vulkan_core.h>
+#include "macros.hpp"
+#include "render/Texture.hpp"
+#include "render/vulkan/CommandBuffer.hpp"
+#include "render/vulkan/DeviceUser.hpp"
+#include "render/vulkan/utils.hpp"
+#include "types.hpp"
+#include "utils.hpp"
+#include "MemorySpan.hpp"
+
+using namespace Render::VK;
+
+CVKTextureView::CVKTextureView(WP<CHyprVulkanDevice> device, VkImageView view, WP<CVkPipelineLayout> layout) : IDeviceUser(device), m_imageView(view) {
+    ;
+
+    m_dsPool = g_pHyprVulkan->allocateDescriptorSet(layout->descriptorSets()[0], &m_descriptorSet);
+    if (!m_dsPool) {
+        Log::logger->log(Log::ERR, "failed to allocate descriptor");
+        return;
+    }
+
+    VkDescriptorImageInfo dsInfo = {
+        .imageView   = m_imageView,
+        .imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+    };
+
+    VkWriteDescriptorSet dsWrite = {
+        .sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+        .dstSet          = m_descriptorSet,
+        .descriptorCount = 1,
+        .descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+        .pImageInfo      = &dsInfo,
+    };
+
+    vkUpdateDescriptorSets(vkDevice(), 1, &dsWrite, 0, nullptr);
+}
+
+CVKTextureView::CVKTextureView(WP<CHyprVulkanDevice> device, CVKTexture* texture, WP<CVkPipelineLayout> layout) : CVKTextureView(device, texture->createImageView(), layout) {
+    ;
+
+    m_dsPool = g_pHyprVulkan->allocateDescriptorSet(layout->descriptorSets()[0], &m_descriptorSet);
+    if (!m_dsPool) {
+        Log::logger->log(Log::ERR, "failed to allocate descriptor");
+        return;
+    }
+
+    VkDescriptorImageInfo dsInfo = {
+        .imageView   = m_imageView,
+        .imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+    };
+
+    VkWriteDescriptorSet dsWrite = {
+        .sType           = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+        .dstSet          = m_descriptorSet,
+        .descriptorCount = 1,
+        .descriptorType  = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+        .pImageInfo      = &dsInfo,
+    };
+
+    vkUpdateDescriptorSets(vkDevice(), 1, &dsWrite, 0, nullptr);
+}
+
+VkDescriptorSet CVKTextureView::vkDS() {
+    return m_descriptorSet;
+}
+
+VkImageView CVKTextureView::view() {
+    return m_imageView;
+}
+
+CVKTextureView::~CVKTextureView() {
+    if (m_descriptorSet)
+        vkFreeDescriptorSets(vkDevice(), m_dsPool->vkPool(), 1, &m_descriptorSet);
+
+    if (m_imageView)
+        vkDestroyImageView(g_pHyprVulkan->vkDevice(), m_imageView, nullptr);
+}
+
+CVKTexture::CVKTexture(bool opaque) {
+    m_opaque = opaque;
+};
+
+CVKTexture::CVKTexture(uint32_t drmFormat, const Vector2D& size, bool keepDataCopy, bool opaque, VkImageUsageFlags flags) :
+    ITexture(drmFormat, nullptr, 0, size, keepDataCopy, opaque) {
+    const auto device = g_pHyprVulkan->vkDevice();
+    const auto props  = g_pHyprVulkan->device()->getFormat(drmFormat);
+
+    if (!props.has_value() || props->format.isYCC) {
+        Log::logger->log(Log::ERR, "Unsupported DRM format {}", NFormatUtils::drmFormatName(drmFormat));
+        return;
+    }
+
+    if (size.x > props->shm.maxExtent.width || size.y > props->shm.maxExtent.height) {
+        Log::logger->log(Log::ERR, "Texture is too large {}x{} > {}x{}", size.x, size.y, props->shm.maxExtent.width, props->shm.maxExtent.height);
+        return;
+    }
+
+    VkImageCreateInfo imgInfo = {
+        .sType         = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+        .imageType     = VK_IMAGE_TYPE_2D,
+        .format        = props->format.vkFormat,
+        .extent        = {size.x, size.y, 1},
+        .mipLevels     = 1,
+        .arrayLayers   = 1,
+        .samples       = VK_SAMPLE_COUNT_1_BIT,
+        .tiling        = VK_IMAGE_TILING_OPTIMAL,
+        .usage         = flags,
+        .sharingMode   = VK_SHARING_MODE_EXCLUSIVE,
+        .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+    };
+    if (props->shm.canSrgb) {
+        imgInfo.flags |= VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
+        const auto                     viewFormats = std::to_array({
+            props->format.vkFormat,
+            props->format.vkSrgbFormat,
+        });
+        VkImageFormatListCreateInfoKHR listInfo    = {
+            .sType           = VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO_KHR,
+            .viewFormatCount = viewFormats.size(),
+            .pViewFormats    = viewFormats.data(),
+        };
+        imgInfo.pNext = &listInfo;
+    }
+
+    IF_VKFAIL(vkCreateImage, device, &imgInfo, nullptr, &m_image) {
+        LOG_VKFAIL;
+        return;
+    }
+
+    SET_VK_IMG_NAME(m_image, "empty ITexture");
+
+    VkMemoryRequirements memReqs;
+    vkGetImageMemoryRequirements(device, m_image, &memReqs);
+
+    const auto memTypeIndex = findVkMemType(g_pHyprVulkan->device()->physicalDevice(), VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, memReqs.memoryTypeBits);
+    if (memTypeIndex == -1) {
+        Log::logger->log(Log::ERR, "failed to find suitable vulkan memory type");
+        return;
+    }
+
+    VkMemoryAllocateInfo memInfo = {
+        .sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+        .allocationSize  = memReqs.size,
+        .memoryTypeIndex = memTypeIndex,
+    };
+
+    IF_VKFAIL(vkAllocateMemory, device, &memInfo, nullptr, &m_memory[0]) {
+        LOG_VKFAIL;
+        return;
+    }
+
+    IF_VKFAIL(vkBindImageMemory, device, m_image, m_memory[0], 0) {
+        LOG_VKFAIL;
+        return;
+    }
+
+    m_ok = true;
+}
+
+CVKTexture::CVKTexture(uint32_t drmFormat, uint8_t* pixels, uint32_t stride, const Vector2D& size, bool keepDataCopy, bool opaque) :
+    CVKTexture(drmFormat, size, keepDataCopy, opaque) {
+    m_ok = write(stride, {0, 0, size.x, size.y}, pixels, VK_IMAGE_LAYOUT_UNDEFINED, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0);
+    if (m_ok)
+        SET_VK_IMG_NAME(m_image, "SHM ITexture");
+};
+
+CVKTexture::CVKTexture(const Aquamarine::SDMABUFAttrs& attrs, bool opaque, VkImageUsageFlags flags) : ITexture(attrs.format, nullptr, 0, attrs.size, false, opaque), m_isDMA(true) {
+    ;
+    const auto    props      = g_pHyprVulkan->device()->getFormat(attrs.format).value();
+    const uint8_t planeCount = attrs.planes;
+    const auto    mod        = std::ranges::find_if(props.dmabuf.renderModifiers, [attrs](const auto m) { return m.props.drmFormatModifier == attrs.modifier; });
+
+    if (attrs.size.x > mod->maxExtent.width || attrs.size.y > mod->maxExtent.height) {
+        CRIT("DMA-BUF {}({}) is too large to import {}x{} > {}x{}", NFormatUtils::drmFormatName(attrs.format), NFormatUtils::drmModifierName(mod->props.drmFormatModifier),
+             attrs.size.x, attrs.size.y, mod->maxExtent.width, mod->maxExtent.height);
+    }
+
+    if (mod->props.drmFormatModifierPlaneCount != planeCount) {
+        CRIT("Number of planes {} != {}", planeCount, mod->props.drmFormatModifierPlaneCount);
+    }
+
+    // TODO support VK_FORMAT_FEATURE_DISJOINT_BIT
+
+    VkExternalMemoryHandleTypeFlagBits htype = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT;
+
+    VkSubresourceLayout                planeLayouts[4] = {};
+
+    for (int i = 0; i < planeCount; ++i) {
+        planeLayouts[i].offset   = attrs.offsets[i];
+        planeLayouts[i].rowPitch = attrs.strides[i];
+        planeLayouts[i].size     = 0;
+    }
+
+    VkImageDrmFormatModifierExplicitCreateInfoEXT modInfo = {
+        .sType                       = VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_EXPLICIT_CREATE_INFO_EXT,
+        .drmFormatModifier           = mod->props.drmFormatModifier,
+        .drmFormatModifierPlaneCount = planeCount,
+        .pPlaneLayouts               = planeLayouts,
+    };
+
+    VkExternalMemoryImageCreateInfo eimg = {
+        .sType       = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO,
+        .pNext       = &modInfo,
+        .handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT,
+    };
+
+    VkImageCreateInfo imgInfo = {
+        .sType       = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+        .pNext       = &eimg,
+        .imageType   = VK_IMAGE_TYPE_2D,
+        .format      = props.format.vkFormat,
+        .extent      = {attrs.size.x, attrs.size.y, 1},
+        .mipLevels   = 1,
+        .arrayLayers = 1,
+        .samples     = VK_SAMPLE_COUNT_1_BIT,
+        .tiling      = VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT,
+        // .usage       = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
+        .usage         = flags,
+        .sharingMode   = VK_SHARING_MODE_EXCLUSIVE,
+        .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+    };
+
+    if (mod->canSrgb) {
+        imgInfo.flags |= VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
+
+        VkFormat viewFormats[] = {
+            props.format.vkFormat,
+            props.format.vkSrgbFormat,
+        };
+        VkImageFormatListCreateInfoKHR listInfo = {
+            .sType           = VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO_KHR,
+            .viewFormatCount = sizeof(viewFormats) / sizeof(viewFormats[0]),
+            .pViewFormats    = viewFormats,
+        };
+        modInfo.pNext = &listInfo;
+    }
+
+    if (vkCreateImage(g_pHyprVulkan->vkDevice(), &imgInfo, nullptr, &m_image) != VK_SUCCESS) {
+        CRIT("vkCreateImage");
+    }
+
+    SET_VK_IMG_NAME(m_image, "DMA ITexture");
+
+    VkBindImageMemoryInfo bindi[4] = {};
+
+    const int             needMems = isDisjoint(attrs) ? planeCount : 1;
+    for (int i = 0; i < needMems; ++i) {
+        VkMemoryFdPropertiesKHR fdp = {
+            .sType = VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR,
+        };
+        if (g_pHyprVulkan->device()->m_proc.vkGetMemoryFdPropertiesKHR(g_pHyprVulkan->vkDevice(), htype, attrs.fds[i], &fdp) != VK_SUCCESS) {
+            CRIT("getMemoryFdPropertiesKHR");
+        }
+
+        VkImageMemoryRequirementsInfo2 memReqInfo = {
+            .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2,
+            .image = m_image,
+        };
+
+        VkMemoryRequirements2 memReq = {
+            .sType = VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2,
+        };
+
+        vkGetImageMemoryRequirements2(g_pHyprVulkan->vkDevice(), &memReqInfo, &memReq);
+        const auto memTypeIndex = findVkMemType(g_pHyprVulkan->device()->physicalDevice(), 0, memReq.memoryRequirements.memoryTypeBits & fdp.memoryTypeBits);
+        if (memTypeIndex < 0) {
+            CRIT("no valid memory type index");
+        }
+
+        int dfd = fcntl(attrs.fds[i], F_DUPFD_CLOEXEC, 0);
+        if (dfd < 0) {
+            CRIT("fcntl(F_DUPFD_CLOEXEC) failed");
+        }
+
+        VkMemoryDedicatedAllocateInfo dedicatedInfo = {
+            .sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO,
+            .image = m_image,
+        };
+
+        VkImportMemoryFdInfoKHR importInfo = {
+            .sType      = VK_STRUCTURE_TYPE_IMPORT_MEMORY_FD_INFO_KHR,
+            .pNext      = &dedicatedInfo,
+            .handleType = htype,
+            .fd         = dfd,
+        };
+
+        VkMemoryAllocateInfo memInfo = {
+            .sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+            .pNext           = &importInfo,
+            .allocationSize  = memReq.memoryRequirements.size,
+            .memoryTypeIndex = memTypeIndex,
+        };
+
+        if (vkAllocateMemory(g_pHyprVulkan->vkDevice(), &memInfo, nullptr, &m_memory[i]) != VK_SUCCESS) {
+            close(dfd);
+            CRIT("vkAllocateMemory failed");
+        }
+
+        // fill bind info
+        bindi[i].image        = m_image;
+        bindi[i].memory       = m_memory[i];
+        bindi[i].memoryOffset = 0;
+        bindi[i].sType        = VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_INFO;
+    }
+
+    if (vkBindImageMemory2(g_pHyprVulkan->vkDevice(), needMems, bindi) != VK_SUCCESS) {
+        CRIT("vkBindMemory failed");
+    }
+
+    m_imageView = createImageView();
+    m_ok        = m_imageView;
+};
+
+CVKTexture::~CVKTexture() {
+    m_views.clear();
+
+    if (m_imageView)
+        vkDestroyImageView(g_pHyprVulkan->vkDevice(), m_imageView, nullptr);
+
+    if (m_image)
+        vkDestroyImage(g_pHyprVulkan->vkDevice(), m_image, nullptr);
+
+    for (const auto mem : m_memory) {
+        if (mem)
+            vkFreeMemory(g_pHyprVulkan->vkDevice(), mem, nullptr);
+    }
+};
+
+void CVKTexture::setTexParameter(GLenum pname, GLint param) {
+    Log::logger->log(Log::WARN, "fixme: CVKTexture::setTexParameter");
+};
+
+void CVKTexture::allocate(const Vector2D& size, uint32_t drmFormat) {
+    m_size      = size;
+    m_drmFormat = drmFormat;
+    Log::logger->log(Log::WARN, "fixme: CVKTexture::allocate");
+};
+
+void CVKTexture::update(uint32_t drmFormat, uint8_t* pixels, uint32_t stride, const CRegion& damage) {
+    write(stride, damage, pixels);
+};
+
+bool CVKTexture::ok() {
+    return m_ok && m_memory[0] && m_image;
+}
+
+bool CVKTexture::isDMA() {
+    return m_isDMA;
+}
+
+VkImageView CVKTexture::vkView() {
+    if (!m_imageView)
+        m_imageView = createImageView();
+    return m_imageView;
+}
+
+SP<CVKTextureView> CVKTexture::getView(SP<CVkPipelineLayout> layout) {
+    if (m_views.contains(layout))
+        return m_views.at(layout);
+
+    auto view = makeShared<CVKTextureView>(g_pHyprVulkan->device(), this, layout);
+    m_views.insert({layout, view});
+    return view;
+}
+
+// for stencil
+CVKTexture::CVKTexture(VkFormat format, uint32_t width, uint32_t height, VkImageUsageFlags flags) :
+    ITexture(DRM_FORMAT_XRGB8888, nullptr, width, Vector2D{(int)width, (int)height}) {
+    VkImageCreateInfo imageCreateInfo = {
+        .sType         = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+        .imageType     = VK_IMAGE_TYPE_2D,
+        .format        = format,
+        .extent        = {.width = width, .height = height, .depth = 1},
+        .mipLevels     = 1,
+        .arrayLayers   = 1,
+        .samples       = VK_SAMPLE_COUNT_1_BIT,
+        .tiling        = VK_IMAGE_TILING_OPTIMAL,
+        .usage         = flags,
+        .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+    };
+    IF_VKFAIL(vkCreateImage, g_pHyprVulkan->vkDevice(), &imageCreateInfo, nullptr, &m_image) {
+        LOG_VKFAIL;
+        return;
+    }
+
+    SET_VK_IMG_NAME(m_image, "stencil")
+
+    VkMemoryRequirements memReqs;
+    vkGetImageMemoryRequirements(g_pHyprVulkan->vkDevice(), m_image, &memReqs);
+
+    const auto memTypeIndex = findVkMemType(g_pHyprVulkan->device()->physicalDevice(), VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, memReqs.memoryTypeBits);
+
+    if (memTypeIndex < 0) {
+        Log::logger->log(Log::ERR, "findVkMemType failed");
+        vkDestroyImage(g_pHyprVulkan->vkDevice(), m_image, nullptr);
+        m_image = VK_NULL_HANDLE;
+        return;
+    }
+
+    VkMemoryAllocateInfo memAllocInfo = {
+        .sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+        .allocationSize  = memReqs.size,
+        .memoryTypeIndex = memTypeIndex,
+    };
+
+    IF_VKFAIL(vkAllocateMemory, g_pHyprVulkan->vkDevice(), &memAllocInfo, nullptr, &m_memory[0]) {
+        LOG_VKFAIL;
+        return;
+    }
+    IF_VKFAIL(vkBindImageMemory, g_pHyprVulkan->vkDevice(), m_image, m_memory[0], 0) {
+        LOG_VKFAIL;
+        return;
+    }
+
+    m_ok = true;
+}
+
+// temp for CVKTexture::read
+CVKTexture::CVKTexture(uint32_t drmFormat, VkFormat format, uint32_t width, uint32_t height) : ITexture(drmFormat, nullptr, width, Vector2D{(int)width, (int)height}) {
+    VkImageCreateInfo imageCreateInfo = {
+        .sType         = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+        .imageType     = VK_IMAGE_TYPE_2D,
+        .format        = format,
+        .extent        = {.width = width, .height = height, .depth = 1},
+        .mipLevels     = 1,
+        .arrayLayers   = 1,
+        .samples       = VK_SAMPLE_COUNT_1_BIT,
+        .tiling        = VK_IMAGE_TILING_LINEAR,
+        .usage         = VK_IMAGE_USAGE_TRANSFER_DST_BIT,
+        .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+    };
+    IF_VKFAIL(vkCreateImage, g_pHyprVulkan->vkDevice(), &imageCreateInfo, nullptr, &m_image) {
+        LOG_VKFAIL;
+        return;
+    }
+
+    SET_VK_IMG_NAME(m_image, "read dstImage")
+
+    VkMemoryRequirements memReqs;
+    vkGetImageMemoryRequirements(g_pHyprVulkan->vkDevice(), m_image, &memReqs);
+
+    const auto memTypeIndex =
+        findVkMemType(g_pHyprVulkan->device()->physicalDevice(), VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT, memReqs.memoryTypeBits);
+
+    if (memTypeIndex < 0) {
+        Log::logger->log(Log::ERR, "findVkMemType failed");
+        vkDestroyImage(g_pHyprVulkan->vkDevice(), m_image, nullptr);
+        m_image = VK_NULL_HANDLE;
+        return;
+    }
+
+    VkMemoryAllocateInfo memAllocInfo = {
+        .sType           = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+        .allocationSize  = memReqs.size,
+        .memoryTypeIndex = memTypeIndex,
+    };
+
+    IF_VKFAIL(vkAllocateMemory, g_pHyprVulkan->vkDevice(), &memAllocInfo, nullptr, &m_memory[0]) {
+        LOG_VKFAIL;
+        return;
+    }
+    IF_VKFAIL(vkBindImageMemory, g_pHyprVulkan->vkDevice(), m_image, m_memory[0], 0) {
+        LOG_VKFAIL;
+        return;
+    }
+
+    m_ok = true;
+}
+
+bool CVKTexture::read(uint32_t drmFformat, uint32_t stride, uint32_t width, uint32_t height, uint32_t srcX, uint32_t srcY, uint32_t dstX, uint32_t dstY, void* data) {
+    const auto         srcProps = g_pHyprVulkan->device()->getFormat(m_drmFormat).value();
+    const auto         dstProps = g_pHyprVulkan->device()->getFormat(drmFformat).value();
+
+    VkFormat           srcFormat      = srcProps.format.vkFormat;
+    VkFormat           dstFormat      = dstProps.format.vkFormat;
+    VkFormatProperties dstFormatProps = {0};
+    VkFormatProperties srcFormatProps = {0};
+    vkGetPhysicalDeviceFormatProperties(g_pHyprVulkan->device()->physicalDevice(), dstFormat, &dstFormatProps);
+    vkGetPhysicalDeviceFormatProperties(g_pHyprVulkan->device()->physicalDevice(), srcFormat, &srcFormatProps);
+
+    const bool blitSupported = srcFormatProps.optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_SRC_BIT && dstFormatProps.linearTilingFeatures & VK_FORMAT_FEATURE_BLIT_DST_BIT;
+    if (!blitSupported && srcFormat != dstFormat) {
+        Log::logger->log(Log::ERR, "CVKTexture::read blit unsupported");
+        return false;
+    }
+
+    auto dstTexture = g_pHyprVulkan->getReadTexture(drmFformat, width, height);
+    if (!dstTexture || !dstTexture->ok())
+        return false;
+
+    VkImage        dstImage     = dstTexture->m_image;
+    VkDeviceMemory dstImgMemory = dstTexture->m_memory[0];
+
+    const auto     cb = g_pHyprVulkan->stageCB();
+    if (!cb || cb->vk() == VK_NULL_HANDLE)
+        return false;
+
+    cb->changeLayout(dstImage, //
+                     {.layout = VK_IMAGE_LAYOUT_UNDEFINED, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = 0},
+                     {.layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = VK_ACCESS_TRANSFER_WRITE_BIT});
+
+    cb->changeLayout(m_image, //
+                     {.layout = m_lastKnownLayout, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = VK_ACCESS_MEMORY_READ_BIT},
+                     {.layout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = VK_ACCESS_TRANSFER_READ_BIT});
+    m_lastKnownLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+
+    if (blitSupported) {
+        VkImageBlit imageBlitRegion = {.srcSubresource = {.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT, .layerCount = 1},
+                                       .srcOffsets     = {{
+                                                              .x = srcX,
+                                                              .y = srcY,
+                                                              .z = 0,
+                                                          },
+                                                          {
+                                                              .x = srcX + width,
+                                                              .y = srcY + height,
+                                                              .z = 1,
+                                                          }},
+                                       .dstSubresource = {.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT, .layerCount = 1},
+                                       .dstOffsets     = {{
+                                                              .x = dstX,
+                                                              .y = dstY,
+                                                              .z = 0,
+                                                          },
+                                                          {
+                                                              .x = dstX + width,
+                                                              .y = dstY + height,
+                                                              .z = 1,
+                                                          }}};
+        vkCmdBlitImage(cb->vk(), m_image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dstImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &imageBlitRegion, VK_FILTER_NEAREST);
+    } else {
+        VkImageCopy imageRegion = {.srcSubresource =
+                                       {
+                                           .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                                           .layerCount = 1,
+                                       },
+                                   .srcOffset =
+                                       {
+                                           .x = srcX,
+                                           .y = srcY,
+                                       },
+                                   .dstSubresource =
+                                       {
+                                           .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                                           .layerCount = 1,
+                                       },
+                                   .extent = {
+                                       .width  = width,
+                                       .height = height,
+                                       .depth  = 1,
+                                   }};
+        vkCmdCopyImage(cb->vk(), m_image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dstImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &imageRegion);
+    }
+
+    cb->changeLayout(dstImage, //
+                     {.layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = VK_ACCESS_TRANSFER_WRITE_BIT},
+                     {.layout = VK_IMAGE_LAYOUT_GENERAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = 0});
+
+    cb->changeLayout(m_image, //
+                     {.layout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = VK_ACCESS_TRANSFER_READ_BIT},
+                     {.layout = VK_IMAGE_LAYOUT_GENERAL, .stageMask = VK_PIPELINE_STAGE_TRANSFER_BIT, .accessMask = VK_ACCESS_MEMORY_READ_BIT});
+    m_lastKnownLayout = VK_IMAGE_LAYOUT_GENERAL;
+
+    if (!g_pHyprVulkan->submitStage())
+        return false;
+
+    VkImageSubresource imgSubRes = {
+        .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+        .mipLevel   = 0,
+        .arrayLayer = 0,
+    };
+    VkSubresourceLayout imgSubLayout;
+    vkGetImageSubresourceLayout(g_pHyprVulkan->vkDevice(), dstImage, &imgSubRes, &imgSubLayout);
+
+    void* v;
+    IF_VKFAIL(vkMapMemory, g_pHyprVulkan->vkDevice(), dstImgMemory, 0, VK_WHOLE_SIZE, 0, &v) {
+        LOG_VKFAIL;
+        return false;
+    }
+
+    VkMappedMemoryRange memRange = {
+        .sType  = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE,
+        .memory = dstImgMemory,
+        .offset = 0,
+        .size   = VK_WHOLE_SIZE,
+    };
+    IF_VKFAIL(vkInvalidateMappedMemoryRanges, g_pHyprVulkan->vkDevice(), 1, &memRange) {
+        LOG_VKFAIL;
+        vkUnmapMemory(g_pHyprVulkan->vkDevice(), dstImgMemory);
+        return false;
+    }
+
+    const char*    d          = (const char*)v + imgSubLayout.offset;
+    unsigned char* p          = (unsigned char*)data + sc<size_t>(dstY * stride);
+    uint32_t       bpp        = dstProps.bytesPerBlock();
+    uint32_t       packStride = imgSubLayout.rowPitch;
+    if (packStride == stride && dstX == 0) {
+        memcpy(p, d, sc<size_t>(height) * stride);
+    } else {
+        for (size_t i = 0; i < height; ++i) {
+            memcpy(p + (i * stride) + sc<size_t>(dstX * bpp), d + (i * packStride), sc<size_t>(width) * bpp);
+        }
+    }
+
+    vkUnmapMemory(g_pHyprVulkan->vkDevice(), dstImgMemory);
+    return true;
+}
+
+VkImageView CVKTexture::createImageView() {
+    const auto props = g_pHyprVulkan->device()->getFormat(m_drmFormat).value();
+    return createImageView(props.format.vkFormat, VK_IMAGE_ASPECT_COLOR_BIT, props.format.isYCC);
+}
+
+VkImageView CVKTexture::createImageView(VkFormat format, VkImageAspectFlags aspectMask, bool isYCC) {
+    RASSERT(m_image, "Failed to create image view for invalid VkImage");
+    VkImageView           imageView;
+
+    VkImageViewCreateInfo viewInfo = {
+        .sType      = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO,
+        .image      = m_image,
+        .viewType   = VK_IMAGE_VIEW_TYPE_2D,
+        .format     = format,
+        .components = {.r = VK_COMPONENT_SWIZZLE_IDENTITY,
+                       .g = VK_COMPONENT_SWIZZLE_IDENTITY,
+                       .b = VK_COMPONENT_SWIZZLE_IDENTITY,
+                       .a = !m_opaque || isYCC ? VK_COMPONENT_SWIZZLE_IDENTITY : VK_COMPONENT_SWIZZLE_ONE},
+        .subresourceRange =
+            {
+                .aspectMask     = aspectMask,
+                .baseMipLevel   = 0,
+                .levelCount     = 1,
+                .baseArrayLayer = 0,
+                .layerCount     = 1,
+            },
+    };
+
+    // TODO support YCC
+
+    IF_VKFAIL(vkCreateImageView, g_pHyprVulkan->vkDevice(), &viewInfo, nullptr, &imageView) {
+        LOG_VKFAIL;
+        return VK_NULL_HANDLE;
+    }
+
+    return imageView;
+}
+
+bool CVKTexture::write(uint32_t stride, const CRegion& region, const void* data, VkImageLayout oldLayout, VkPipelineStageFlags srcStage, VkAccessFlags srcAccess) {
+    const auto props = g_pHyprVulkan->device()->getFormat(m_drmFormat).value();
+
+    uint32_t   bsize = 0;
+
+    const auto rects = region.getRects();
+    for (const auto& rect : rects) {
+        uint32_t width  = rect.x2 - rect.x1;
+        uint32_t height = rect.y2 - rect.y1;
+
+        // make sure assumptions are met
+        ASSERT(rect.x2 <= m_size.x);
+        ASSERT(rect.y2 <= m_size.y);
+
+        bsize += height * props.minStride(width);
+    }
+
+    std::vector<VkBufferImageCopy> copies(rects.size());
+    const auto                     span = g_pHyprVulkan->getMemorySpan(bsize, props.bytesPerBlock());
+    if (!span.valid()) {
+        Log::logger->log(Log::ERR, "Failed to get memory span of size {}({})", bsize, props.bytesPerBlock());
+        return false;
+    }
+
+    auto     map       = span->cpuMapping();
+    uint32_t bufOffset = span->offset();
+    int      i         = 0;
+    for (const auto& rect : rects) {
+        const uint32_t width        = rect.x2 - rect.x1;
+        const uint32_t height       = rect.y2 - rect.y1;
+        const uint32_t srcX         = rect.x1;
+        const uint32_t srcY         = rect.y1;
+        const uint32_t packedStride = props.minStride(width);
+
+        const char*    pdata = (char*)data;
+        pdata += (size_t)stride * srcY;
+        pdata += (size_t)props.pixelFormat.bytesPerBlock * srcX;
+        if (srcX == 0 && width == m_size.x && stride == packedStride) {
+            memcpy(map, pdata, (size_t)packedStride * height);
+            map += (size_t)packedStride * height;
+        } else {
+            for (unsigned y = 0; y < height; ++y) {
+                memcpy(map, pdata, packedStride);
+                pdata += stride;
+                map += packedStride;
+            }
+        }
+
+        copies[i] = {
+            .bufferOffset      = bufOffset,
+            .bufferRowLength   = width,
+            .bufferImageHeight = height,
+            .imageSubresource =
+                {
+                    .aspectMask     = VK_IMAGE_ASPECT_COLOR_BIT,
+                    .mipLevel       = 0,
+                    .baseArrayLayer = 0,
+                    .layerCount     = 1,
+                },
+            .imageOffset = {srcX, srcY, 0},
+            .imageExtent = {width, height, 1},
+        };
+
+        bufOffset += height * packedStride;
+        i++;
+    }
+
+    const auto cb = g_pHyprVulkan->stageCB();
+    if (!cb || cb->vk() == VK_NULL_HANDLE)
+        return false;
+
+    const CHyprVkCommandBuffer::SImageLayoutSettings tmpLayout = {
+        .layout     = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+        .stageMask  = VK_PIPELINE_STAGE_TRANSFER_BIT,
+        .accessMask = VK_ACCESS_TRANSFER_WRITE_BIT,
+    };
+
+    cb->changeLayout(m_image,
+                     {
+                         .layout     = oldLayout,
+                         .stageMask  = srcStage,
+                         .accessMask = srcAccess,
+                     },
+                     tmpLayout);
+
+    vkCmdCopyBufferToImage(cb->vk(), span->vkBuffer(), m_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, copies.size(), copies.data());
+    cb->changeLayout(m_image, tmpLayout,
+                     {
+                         .layout     = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                         .stageMask  = VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
+                         .accessMask = VK_ACCESS_SHADER_READ_BIT,
+                     });
+
+    m_lastUsedCB = cb;
+
+    return true;
+}

--- a/src/render/vulkan/VKTexture.hpp
+++ b/src/render/vulkan/VKTexture.hpp
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "../Texture.hpp"
+#include "helpers/Format.hpp"
+#include "render/vulkan/CommandBuffer.hpp"
+#include "render/vulkan/DescriptorPool.hpp"
+#include "render/vulkan/DeviceUser.hpp"
+#include "render/vulkan/Framebuffer.hpp"
+#include "render/vulkan/PipelineLayout.hpp"
+#include "render/vulkan/types.hpp"
+#include <hyprutils/math/Vector2D.hpp>
+#include <vulkan/vulkan_core.h>
+
+namespace Render::VK {
+    class CVKTexture;
+    class CHyprVkFramebuffer;
+
+    class CVKTextureView : public IDeviceUser {
+      public:
+        CVKTextureView(WP<CHyprVulkanDevice> device, VkImageView view, WP<CVkPipelineLayout> layout);
+        CVKTextureView(WP<CHyprVulkanDevice> device, CVKTexture* texture, WP<CVkPipelineLayout> layout);
+        ~CVKTextureView();
+
+        VkDescriptorSet vkDS();
+        VkImageView     view();
+
+      private:
+        VkDescriptorSet       m_descriptorSet = VK_NULL_HANDLE;
+        VkImageView           m_imageView     = VK_NULL_HANDLE;
+        WP<CVKDescriptorPool> m_dsPool;
+
+        friend class CVKTexture;
+    };
+
+    class CVKTexture : public ITexture {
+      public:
+        CVKTexture(CVKTexture&)        = delete;
+        CVKTexture(CVKTexture&&)       = delete;
+        CVKTexture(const CVKTexture&&) = delete;
+        CVKTexture(const CVKTexture&)  = delete;
+
+        CVKTexture(bool opaque = false);
+        CVKTexture(uint32_t drmFormat, const Vector2D& size, bool keepDataCopy = false, bool opaque = false, VkImageUsageFlags flags = VULKAN_SHM_TEX_USAGE);
+        CVKTexture(uint32_t drmFormat, uint8_t* pixels, uint32_t stride, const Vector2D& size, bool keepDataCopy = false, bool opaque = false);
+        CVKTexture(const Aquamarine::SDMABUFAttrs&, bool opaque = false, VkImageUsageFlags flags = VULKAN_DMA_TEX_USAGE);
+        CVKTexture(VkFormat format, uint32_t width, uint32_t height, VkImageUsageFlags flags = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT); // for stencil
+        CVKTexture(uint32_t drmFormat, VkFormat format, uint32_t width, uint32_t height);                                                    // temp for CVKTexture::read
+        ~CVKTexture();
+
+        void setTexParameter(GLenum pname, GLint param) override;
+        void allocate(const Vector2D& size, uint32_t drmFormat = 0) override;
+        void update(uint32_t drmFormat, uint8_t* pixels, uint32_t stride, const CRegion& damage) override;
+        // virtual void                bind() {};
+        // virtual void                unbind() {};
+        bool                     ok() override;
+        bool                     isDMA() override;
+        WP<CHyprVkCommandBuffer> m_lastUsedCB;
+
+        VkImageView              vkView();
+        SP<CVKTextureView>       getView(SP<CVkPipelineLayout> layout);
+        bool    read(uint32_t drmFformat, uint32_t stride, uint32_t width, uint32_t height, uint32_t srcX, uint32_t srcY, uint32_t dstX, uint32_t dstY, void* data);
+
+        VkImage m_image       = VK_NULL_HANDLE; // TODO private
+        bool    m_barriersSet = false;
+
+      private:
+        VkImageLayout                 m_lastKnownLayout = VK_IMAGE_LAYOUT_GENERAL; // not guaranteed to be in sync with real layout
+        VkImageView                   createImageView();
+        VkImageView                   createImageView(VkFormat format, VkImageAspectFlags aspectMask = VK_IMAGE_ASPECT_COLOR_BIT, bool isYCC = false);
+        bool                          write(uint32_t stride, const CRegion& region, const void* data, VkImageLayout oldLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                                            VkPipelineStageFlags srcStage = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, VkAccessFlags srcAccess = VK_ACCESS_SHADER_READ_BIT);
+
+        VkImageView                   m_imageView = VK_NULL_HANDLE;
+        std::array<VkDeviceMemory, 4> m_memory    = {VK_NULL_HANDLE, VK_NULL_HANDLE, VK_NULL_HANDLE, VK_NULL_HANDLE};
+
+        std::map<SP<CVkPipelineLayout>, SP<CVKTextureView>> m_views;
+        bool                                                m_ok    = true;
+        bool                                                m_isDMA = false;
+
+        friend class CVKTextureView;
+        friend class CHyprVkFramebuffer;
+        friend class CVKFramebuffer;
+    };
+
+}
+
+#define VKTEX(tex) dc<CVKTexture*>(tex.get())

--- a/src/render/vulkan/Vulkan.cpp
+++ b/src/render/vulkan/Vulkan.cpp
@@ -1,0 +1,535 @@
+#include "Vulkan.hpp"
+#include "debug/log/Logger.hpp"
+#include "render/Renderer.hpp"
+#include "render/vulkan/CommandBuffer.hpp"
+#include "render/vulkan/DescriptorPool.hpp"
+#include "render/vulkan/MemoryBuffer.hpp"
+#include "render/vulkan/VKTexture.hpp"
+#include "utils.hpp"
+
+#include "../../macros.hpp"
+#include <algorithm>
+#include <drm_fourcc.h>
+#include <format>
+#include <hyprutils/memory/SharedPtr.hpp>
+#include <sys/stat.h>
+#include <cstdint>
+#include <string>
+#include <sys/sysmacros.h>
+#include <vector>
+#include <vulkan/vulkan_core.h>
+
+// DEBUG
+#include "Compositor.hpp"
+
+#define TARGET_VULKAN_VERSION VK_API_VERSION_1_4
+
+using namespace Render::VK;
+
+static const VkDeviceSize  MIN_SHARED_BUFFER_SIZE            = (VkDeviceSize)1024 * 1024;
+static const VkDeviceSize  MAX_SHARED_BUFFER_SIZE            = MIN_SHARED_BUFFER_SIZE * 256;
+static const int           MAX_SHARED_BUFFER_UNUSED_DURATION = 10000;
+static const size_t        INITIAL_DESCRIPTOR_POOL_SIZE      = 250;
+static const int           MAX_COMMAND_BUFFERS               = 64;
+
+static VKAPI_ATTR VkBool32 debugCallback(VkDebugUtilsMessageSeverityFlagBitsEXT severity, VkDebugUtilsMessageTypeFlagsEXT type,
+                                         const VkDebugUtilsMessengerCallbackDataEXT* debugData, void* data) {
+
+    if (debugData->pMessageIdName && isIgnoredDebugMessage(debugData->pMessageIdName))
+        return false;
+
+    Hyprutils::CLI::eLogLevel level;
+    switch (severity) {
+        case VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT: level = Log::WARN; break;
+        case VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT: level = Log::ERR; break;
+        default:
+        case VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT: level = Log::INFO; break;
+    }
+
+    std::string message = std::format("{} ({})", debugData->pMessage, debugData->pMessageIdName);
+
+    // if (debugData->queueLabelCount > 0) {
+    //     const char* name = debugData->pQueueLabels[0].pLabelName;
+    //     if (name)
+    //         Log::logger->log(level, "    last queue label '{}'", name);
+    // }
+
+    if (debugData->cmdBufLabelCount > 0) {
+        message += "\n\tOccured in ";
+        for (int i = debugData->cmdBufLabelCount - 1; i >= 0; i--) {
+            const char* name = debugData->pCmdBufLabels[i].pLabelName;
+            if (name)
+                message += std::format("{}{}", name, i > 0 ? " -> " : "");
+        }
+    }
+
+    for (uint32_t i = 0; i < debugData->objectCount; ++i) {
+        if (debugData->pObjects[i].pObjectName)
+            message += std::format("\n\tinvolving '{}'", debugData->pObjects[i].pObjectName);
+    }
+
+    Log::logger->log(level, message);
+
+    return false;
+}
+
+static void logDeviceInfo(const VkPhysicalDeviceProperties& props) {
+    std::string type = "unknown";
+    switch (props.deviceType) {
+        case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU: type = "integrated"; break;
+        case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU: type = "discrete"; break;
+        case VK_PHYSICAL_DEVICE_TYPE_CPU: type = "cpu"; break;
+        case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU: type = "vgpu"; break;
+        default: break;
+    }
+
+    Log::logger->log(Log::INFO, "Vulkan device: '{}'", props.deviceName);
+    Log::logger->log(Log::INFO, "  Device type: '{}'", type);
+    Log::logger->log(Log::INFO, "  Supported API version: {}.{}.{}", VK_VERSION_MAJOR(props.apiVersion), VK_VERSION_MINOR(props.apiVersion), VK_VERSION_PATCH(props.apiVersion));
+    Log::logger->log(Log::INFO, "  Driver version: {}.{}.{}", VK_VERSION_MAJOR(props.driverVersion), VK_VERSION_MINOR(props.driverVersion), VK_VERSION_PATCH(props.driverVersion));
+}
+
+inline void CHyprVulkanImpl::loadVulkanProc(void* pProc, const char* name) {
+    void* proc = rc<void*>(vkGetInstanceProcAddr(m_instance, name));
+    if (proc == nullptr) {
+        CRIT("[VULKAN] vkGetInstanceProcAddr({}) failed", name);
+    }
+    *sc<void**>(pProc) = proc;
+}
+
+CHyprVulkanImpl::CHyprVulkanImpl() {
+    Log::logger->log(Log::DEBUG, "Creating vulkan renderer");
+
+    loadVulkanProc(&m_proc.pfEnumInstanceVersion, "vkEnumerateInstanceVersion");
+
+    uint32_t version;
+    if (m_proc.pfEnumInstanceVersion(&version) != VK_SUCCESS || version < TARGET_VULKAN_VERSION) {
+        CRIT("[VULKAN] Version is {}, required is {}", version, TARGET_VULKAN_VERSION);
+    }
+
+    uint32_t extensionCount = 0;
+    auto     res            = vkEnumerateInstanceExtensionProperties(nullptr, &extensionCount, nullptr);
+    if (res != VK_SUCCESS || extensionCount == 0) {
+        CRIT("[VULKAN] Could not get extention count", version, TARGET_VULKAN_VERSION);
+    }
+
+    std::vector<VkExtensionProperties> extensions(extensionCount);
+    if (vkEnumerateInstanceExtensionProperties(nullptr, &extensionCount, extensions.data()) != VK_SUCCESS) {
+        CRIT("[VULKAN] Could not get extentions");
+    }
+
+    for (const auto& ext : extensions) {
+        Log::logger->log(Log::DEBUG, "[VULKAN] Extension {} {}", ext.extensionName, ext.specVersion);
+    }
+
+    std::vector<char*> enabledExtensions;
+
+    const bool         hasDebug = ISDEBUG && hasExtension(extensions, VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+    if (hasDebug)
+        enabledExtensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+
+    VkApplicationInfo application_info = {
+        .sType         = VK_STRUCTURE_TYPE_APPLICATION_INFO,
+        .pEngineName   = "hyprland",
+        .engineVersion = HYPRLAND_VERSION_MAJOR * 10000 + HYPRLAND_VERSION_MINOR * 100 + HYPRLAND_VERSION_PATCH,
+        .apiVersion    = TARGET_VULKAN_VERSION,
+    };
+
+    VkDebugUtilsMessengerCreateInfoEXT debugInfo = {
+        .sType           = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT,
+        .messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT,
+        .messageType     = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT,
+        .pfnUserCallback = &debugCallback,
+        .pUserData       = this,
+    };
+
+    VkInstanceCreateInfo instanceInfo = {.sType                   = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
+                                         .pNext                   = hasDebug ? &debugInfo : nullptr,
+                                         .pApplicationInfo        = &application_info,
+                                         .enabledLayerCount       = 0,
+                                         .ppEnabledLayerNames     = nullptr,
+                                         .enabledExtensionCount   = enabledExtensions.size(),
+                                         .ppEnabledExtensionNames = enabledExtensions.data()};
+
+    if (vkCreateInstance(&instanceInfo, nullptr, &m_instance) != VK_SUCCESS) {
+        CRIT("Could not create instance");
+    }
+
+    if (hasDebug) {
+        Log::logger->log(Log::DEBUG, "activating vulkan debug");
+        loadVulkanProc(&m_proc.vkCreateDebugUtilsMessengerEXT, "vkCreateDebugUtilsMessengerEXT");
+        loadVulkanProc(&m_proc.vkDestroyDebugUtilsMessengerEXT, "vkDestroyDebugUtilsMessengerEXT");
+
+        if (m_proc.vkCreateDebugUtilsMessengerEXT)
+            m_proc.vkCreateDebugUtilsMessengerEXT(m_instance, &debugInfo, nullptr, &m_debug);
+        else
+            Log::logger->log(Log::ERR, "vkCreateDebugUtilsMessengerEXT not found");
+    }
+
+    // DEBUG
+    m_device = getDevice(g_pCompositor->m_drmRenderNode.fd >= 0 ? g_pCompositor->m_drmRenderNode.fd : g_pCompositor->m_drm.fd);
+    Log::logger->log(Log::DEBUG, "[VULKAN] Init {}", m_device && m_device->good());
+    if (m_device->good())
+        m_device->loadFormats();
+}
+
+CHyprVulkanImpl::~CHyprVulkanImpl() {
+    Log::logger->log(Log::DEBUG, "Destroying vulkan renderer");
+
+    if (m_debug != VK_NULL_HANDLE && m_proc.vkDestroyDebugUtilsMessengerEXT)
+        m_proc.vkDestroyDebugUtilsMessengerEXT(m_instance, m_debug, nullptr);
+
+    if (m_instance != VK_NULL_HANDLE)
+        vkDestroyInstance(m_instance, nullptr);
+}
+
+SP<CHyprVulkanDevice> CHyprVulkanImpl::getDevice(int drmFd) {
+    uint32_t deviceCount;
+
+    IF_VKFAIL(vkEnumeratePhysicalDevices, m_instance, &deviceCount, nullptr) {
+        LOG_VKFAIL;
+        return nullptr;
+    }
+
+    std::vector<VkPhysicalDevice> devices(deviceCount);
+    IF_VKFAIL(vkEnumeratePhysicalDevices, m_instance, &deviceCount, devices.data()) {
+        LOG_VKFAIL;
+        return nullptr;
+    }
+
+    struct stat drmStat = {.st_dev = 0};
+    if (drmFd >= 0 && fstat(drmFd, &drmStat) != 0) {
+        Log::logger->log(Log::ERR, "fstat failed");
+        return nullptr;
+    }
+
+    for (const auto& device : devices) {
+        VkPhysicalDeviceProperties devProps;
+        vkGetPhysicalDeviceProperties(device, &devProps);
+
+        logDeviceInfo(devProps);
+
+        if (devProps.apiVersion < TARGET_VULKAN_VERSION)
+            continue;
+
+        uint32_t extCount = 0;
+        auto     res      = vkEnumerateDeviceExtensionProperties(device, nullptr, &extCount, nullptr);
+        if (res != VK_SUCCESS || !extCount) {
+            Log::logger->log(Log::ERR, "  Could not enumerate device extensions: {}", resultToStr(res));
+            continue;
+        }
+
+        std::vector<VkExtensionProperties> extensions(extCount);
+        res = vkEnumerateDeviceExtensionProperties(device, nullptr, &extCount, extensions.data());
+        if (res != VK_SUCCESS) {
+            Log::logger->log(Log::ERR, "  Could not enumerate device extensions", resultToStr(res));
+            continue;
+        }
+
+        const bool                       hasDrmProps    = hasExtension(extensions, VK_EXT_PHYSICAL_DEVICE_DRM_EXTENSION_NAME);
+        const bool                       hasDriverProps = hasExtension(extensions, VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME);
+
+        VkPhysicalDeviceProperties2      props    = {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2};
+        VkPhysicalDeviceDrmPropertiesEXT drmProps = {.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRM_PROPERTIES_EXT};
+        if (hasDrmProps) {
+            drmProps.pNext = props.pNext;
+            props.pNext    = &drmProps;
+        }
+
+        VkPhysicalDeviceDriverPropertiesKHR driverProps = {
+            .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES,
+        };
+        if (hasDriverProps) {
+            driverProps.pNext = props.pNext;
+            props.pNext       = &driverProps;
+        }
+
+        vkGetPhysicalDeviceProperties2(device, &props);
+
+        if (hasDriverProps)
+            Log::logger->log(Log::INFO, "  Driver name: {} ({})", driverProps.driverName, driverProps.driverInfo);
+
+        bool found;
+        if (drmFd >= 0) {
+            if (!hasDrmProps) {
+                Log::logger->log(Log::DEBUG, "  Ignoring physical device \"{}\": VK_EXT_physical_device_drm not supported", devProps.deviceName);
+                continue;
+            }
+
+            const auto primaryId = makedev(drmProps.primaryMajor, drmProps.primaryMinor);
+            const auto renderId  = makedev(drmProps.renderMajor, drmProps.renderMinor);
+            found                = primaryId == drmStat.st_rdev || renderId == drmStat.st_rdev;
+        } else
+            found = devProps.deviceType == VK_PHYSICAL_DEVICE_TYPE_CPU;
+
+        if (found) {
+            Log::logger->log(Log::INFO, "Found matching Vulkan physical device: {}", devProps.deviceName);
+            return makeShared<CHyprVulkanDevice>(device, extensions);
+        }
+    }
+
+    return nullptr;
+}
+
+bool CHyprVulkanImpl::waitCommandBuffer(WP<CHyprVkCommandBuffer> cb) {
+    ASSERT((cb && (cb->vk() != VK_NULL_HANDLE) && !cb->busy()));
+
+    const auto             semaphore = m_device->timelineSemaphore();
+    VkSemaphoreWaitInfoKHR waitInfo  = {
+        .sType          = VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO_KHR,
+        .semaphoreCount = 1,
+        .pSemaphores    = &semaphore,
+        .pValues        = &cb->m_timelinePoint,
+    };
+    IF_VKFAIL(vkWaitSemaphores, m_device->vkDevice(), &waitInfo, UINT64_MAX) {
+        LOG_VKFAIL;
+        return false;
+    }
+
+    return true;
+}
+
+SP<CHyprVkCommandBuffer> CHyprVulkanImpl::acquireCB() {
+    SP<CHyprVkCommandBuffer> commandBuffer;
+    SP<CHyprVkCommandBuffer> wait;
+    for (const auto& cb : m_commandBuffers) {
+        if (cb->busy())
+            continue;
+
+        if (cb->m_timelinePoint <= m_device->timelinePoint()) {
+            commandBuffer = cb;
+            break;
+        }
+
+        if (!wait || cb->m_timelinePoint < wait->m_timelinePoint)
+            wait = cb;
+    }
+
+    if (!commandBuffer && m_commandBuffers.size() < MAX_COMMAND_BUFFERS) {
+        commandBuffer = m_commandBuffers.emplace_back(makeShared<CHyprVkCommandBuffer>(m_device));
+    } else if (wait && waitCommandBuffer(wait))
+        commandBuffer = wait;
+
+    commandBuffer->begin();
+    if (g_pHyprRenderer->m_renderData.currentFB)
+        commandBuffer->useFB(VKFB(g_pHyprRenderer->m_renderData.currentFB)->fb());
+    return commandBuffer;
+}
+
+SP<CHyprVkCommandBuffer> CHyprVulkanImpl::begin() {
+    std::erase_if(m_sharedBuffers, [](const auto buf) { return buf->m_lastUsed.getMillis() > MAX_SHARED_BUFFER_UNUSED_DURATION; });
+
+    // TODO cleanup command buffers
+
+    m_currentRenderCB = acquireCB();
+    return m_currentRenderCB;
+}
+
+SP<CHyprVkCommandBuffer> CHyprVulkanImpl::endStage() {
+    const auto stage = stageCB().lock();
+    m_currentStageCB.reset();
+
+    m_device->m_timelinePoint++;
+    stage->end(m_device->m_timelinePoint);
+    return stage;
+}
+
+bool CHyprVulkanImpl::submitStage() {
+    auto stage = endStage();
+    if (!stage)
+        return false;
+
+    auto                             sem = m_device->timelineSemaphore();
+    auto                             cb  = stage->vk();
+
+    VkTimelineSemaphoreSubmitInfoKHR timelineSubmitInfo = {
+        .sType                     = VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO_KHR,
+        .signalSemaphoreValueCount = 1,
+        .pSignalSemaphoreValues    = &stage->m_timelinePoint,
+    };
+    VkSubmitInfo submitInfo = {
+        .sType                = VK_STRUCTURE_TYPE_SUBMIT_INFO,
+        .pNext                = &timelineSubmitInfo,
+        .commandBufferCount   = 1,
+        .pCommandBuffers      = &cb,
+        .signalSemaphoreCount = 1,
+        .pSignalSemaphores    = &sem,
+    };
+    IF_VKFAIL(vkQueueSubmit, m_device->queue(), 1, &submitInfo, VK_NULL_HANDLE) {
+        LOG_VKFAIL;
+        return false;
+    }
+
+    return waitCommandBuffer(stage);
+}
+
+void CHyprVulkanImpl::end() {
+    auto                      stage = endStage();
+
+    VkCommandBufferSubmitInfo stageInfo = {
+        .sType         = VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO,
+        .commandBuffer = stage->vk(),
+    };
+    VkSemaphoreSubmitInfo stageSignal = {
+        .sType     = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO,
+        .semaphore = m_device->timelineSemaphore(),
+        .value     = stage->m_timelinePoint,
+    };
+    VkSubmitInfo2 stageSubmit = {
+        .sType                    = VK_STRUCTURE_TYPE_SUBMIT_INFO_2,
+        .commandBufferInfoCount   = 1,
+        .pCommandBufferInfos      = &stageInfo,
+        .signalSemaphoreInfoCount = 1,
+        .pSignalSemaphoreInfos    = &stageSignal,
+    };
+
+    VkSemaphoreSubmitInfo stageWait;
+    if (m_lastStagePoint > 0) {
+        stageWait = {
+            .sType     = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO,
+            .semaphore = m_device->timelineSemaphore(),
+            .value     = m_lastStagePoint,
+            .stageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT,
+        };
+
+        stageSubmit.waitSemaphoreInfoCount = 1;
+        stageSubmit.pWaitSemaphoreInfos    = &stageWait;
+    }
+
+    m_lastStagePoint = stage->m_timelinePoint;
+
+    m_device->m_timelinePoint++;
+    m_currentRenderCB->end(m_device->m_timelinePoint);
+
+    std::vector<VkSemaphoreSubmitInfo> waitSemaphores;
+    std::vector<VkSemaphoreSubmitInfo> signalSemaphores;
+
+    // TODO sync
+    // waitSemaphores.push_back({
+    //     .sType     = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO,
+    //     .semaphore = m_waitSemaphore,
+    //     .stageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+    // });
+
+    // signalSemaphores.push_back({
+    //     .sType     = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO,
+    //     .semaphore = m_signalSemaphore,
+    //     .stageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+    // });
+
+    signalSemaphores.push_back({
+        .sType     = VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO,
+        .semaphore = m_device->timelineSemaphore(),
+        .value     = m_device->m_timelinePoint,
+        // .stageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+    });
+
+    const std::array<VkCommandBufferSubmitInfo, 1> cmdBufferInfo{{{
+        .sType         = VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO,
+        .commandBuffer = m_currentRenderCB->vk(),
+    }}};
+
+    const VkSubmitInfo2                            renderSubmit = {
+        .sType = VK_STRUCTURE_TYPE_SUBMIT_INFO_2,
+        // .waitSemaphoreInfoCount   = waitSemaphores.size(),
+        // .pWaitSemaphoreInfos      = waitSemaphores.data(),
+        .commandBufferInfoCount   = cmdBufferInfo.size(),
+        .pCommandBufferInfos      = cmdBufferInfo.data(),
+        .signalSemaphoreInfoCount = signalSemaphores.size(),
+        .pSignalSemaphoreInfos    = signalSemaphores.data(),
+    };
+    const std::array<VkSubmitInfo2, 2> submitInfo = {stageSubmit, renderSubmit};
+
+    if (vkQueueSubmit2(m_device->queue(), uint32_t(submitInfo.size()), submitInfo.data(), VK_NULL_HANDLE) != VK_SUCCESS) {
+        CRIT("vkQueueSubmit2 failed");
+    }
+}
+
+SP<CHyprVulkanDevice> CHyprVulkanImpl::device() {
+    return m_device;
+}
+
+VkDevice CHyprVulkanImpl::vkDevice() {
+    return m_device->vkDevice();
+}
+
+WP<CHyprVkCommandBuffer> CHyprVulkanImpl::renderCB() {
+    return m_currentRenderCB;
+}
+
+WP<CHyprVkCommandBuffer> CHyprVulkanImpl::stageCB() {
+    if (!m_currentStageCB)
+        m_currentStageCB = acquireCB();
+
+    return m_currentStageCB;
+};
+
+WP<CVKMemorySpan> CHyprVulkanImpl::getMemorySpan(VkDeviceSize size, VkDeviceSize alignment) {
+    for (const auto& buf : m_sharedBuffers) {
+        auto offset = buf->offset();
+        offset += alignment - 1 - ((offset + alignment - 1) % alignment);
+        if (buf->available() >= offset + size)
+            return buf->allocate(size, offset);
+    }
+
+    const auto bufSize = std::max(size * 2, MIN_SHARED_BUFFER_SIZE);
+    if (bufSize > MAX_SHARED_BUFFER_SIZE) {
+        Log::logger->log(Log::ERR, "Requested buffer size it too big {}({}) > {}", bufSize, size, MAX_SHARED_BUFFER_SIZE);
+        return SP<CVKMemorySpan>(nullptr);
+    }
+
+    const auto buffer = m_sharedBuffers.emplace_back(CVKMemoryBuffer::create(m_device, bufSize));
+    return buffer->allocate(size);
+}
+
+SP<CVKDescriptorPool> CHyprVulkanImpl::allocateDescriptorSet(VkDescriptorSetLayout layout, VkDescriptorSet* ds, CVKDescriptorPool::eDSPoolType type) {
+    for (const auto& pool : m_dsPools[type]) {
+        const auto res = pool->allocateSet(layout, ds);
+        switch (res) {
+            case VK_ERROR_FRAGMENTED_POOL:
+            case VK_ERROR_OUT_OF_POOL_MEMORY: continue;
+            case VK_SUCCESS: return pool;
+            default: Log::logger->log(Log::ERR, "failed to allocate descriptor set on existing pool: {}", (unsigned)res); return nullptr;
+        }
+    }
+
+    const auto size = m_lastDsPoolSize[type] ? m_lastDsPoolSize[type] * 2 : INITIAL_DESCRIPTOR_POOL_SIZE;
+    auto       pool = m_dsPools[type].emplace_back(
+        makeShared<CVKDescriptorPool>(m_device, type == CVKDescriptorPool::DSP_UBO ? VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER : VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, size));
+    const auto res = pool->allocateSet(layout, ds);
+
+    if (res == VK_SUCCESS)
+        return pool;
+
+    Log::logger->log(Log::ERR, "failed to allocate descriptor set on a new pool: {}", (unsigned)res);
+    return nullptr;
+}
+
+static const int MAX_READ_CACHE_SIZE = 10;
+
+SP<CVKTexture>   CHyprVulkanImpl::getReadTexture(uint32_t drmFformat, uint32_t width, uint32_t height) {
+    auto cached = std::ranges::find_if(m_readTexturesCache, [&](const auto& cache) {
+        return cache.texture && cache.texture->m_drmFormat == drmFformat && cache.texture->m_size.x == width && cache.texture->m_size.y == height;
+    });
+    if (cached != m_readTexturesCache.end()) {
+        cached->lastUsed = Time::steadyNow();
+        return cached->texture;
+    }
+
+    if (m_readTexturesCache.size() >= MAX_READ_CACHE_SIZE) {
+        auto remove = std::ranges::min_element(m_readTexturesCache, std::less<>{}, [](const auto& cache) { return cache.lastUsed; });
+        m_readTexturesCache.erase(remove);
+    }
+
+    const auto props = g_pHyprVulkan->device()->getFormat(drmFformat).value();
+    auto       tex   = makeShared<CVKTexture>(drmFformat, props.format.vkFormat, width, height);
+    if (!tex || !tex->ok())
+        return nullptr;
+
+    m_readTexturesCache.emplace_back(SCacheItem{
+        .texture  = tex,
+        .lastUsed = Time::steadyNow(),
+    });
+
+    return tex;
+}

--- a/src/render/vulkan/Vulkan.hpp
+++ b/src/render/vulkan/Vulkan.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <cstdint>
+#include <hyprutils/math/Vector2D.hpp>
+#include <vector>
+#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_core.h>
+
+#include "../../helpers/memory/Memory.hpp"
+#include "Device.hpp"
+#include "CommandBuffer.hpp"
+#include "render/vulkan/DescriptorPool.hpp"
+#include "render/vulkan/MemoryBuffer.hpp"
+#include "render/vulkan/VKTexture.hpp"
+
+namespace Render::VK {
+    class CHyprVulkanImpl {
+      public:
+        CHyprVulkanImpl();
+        ~CHyprVulkanImpl();
+
+        struct {
+            PFN_vkEnumerateInstanceVersion      pfEnumInstanceVersion           = nullptr;
+            PFN_vkCreateDebugUtilsMessengerEXT  vkCreateDebugUtilsMessengerEXT  = nullptr;
+            PFN_vkDestroyDebugUtilsMessengerEXT vkDestroyDebugUtilsMessengerEXT = nullptr;
+        } m_proc;
+
+        SP<CHyprVulkanDevice>    getDevice(int drmFd);
+        SP<CHyprVkCommandBuffer> begin();
+        SP<CHyprVkCommandBuffer> endStage();
+        bool                     submitStage();
+        void                     end();
+
+        SP<CHyprVulkanDevice>    device();
+        VkDevice                 vkDevice();
+        WP<CHyprVkCommandBuffer> renderCB();
+        WP<CHyprVkCommandBuffer> stageCB();
+        WP<CVKMemorySpan>        getMemorySpan(VkDeviceSize size, VkDeviceSize alignment = 1);
+        SP<CVKDescriptorPool>    allocateDescriptorSet(VkDescriptorSetLayout layout, VkDescriptorSet* ds, CVKDescriptorPool::eDSPoolType type = CVKDescriptorPool::DSP_SAMPLER);
+        SP<CVKTexture>           getReadTexture(uint32_t drmFformat, uint32_t width, uint32_t height);
+
+      private:
+        inline void                                       loadVulkanProc(void* pProc, const char* name);
+        bool                                              waitCommandBuffer(WP<CHyprVkCommandBuffer>);
+        SP<CHyprVkCommandBuffer>                          acquireCB();
+
+        VkInstance                                        m_instance = VK_NULL_HANDLE;
+        VkDebugUtilsMessengerEXT                          m_debug    = VK_NULL_HANDLE;
+
+        SP<CHyprVulkanDevice>                             m_device;
+        SP<CHyprVkCommandBuffer>                          m_currentStageCB;
+        SP<CHyprVkCommandBuffer>                          m_currentRenderCB;
+        std::vector<SP<CHyprVkCommandBuffer>>             m_commandBuffers;
+        std::vector<SP<CVKMemoryBuffer>>                  m_sharedBuffers;
+        std::array<std::vector<SP<CVKDescriptorPool>>, 2> m_dsPools;
+        std::array<size_t, 2>                             m_lastDsPoolSize = {0, 0};
+
+        uint64_t                                          m_lastStagePoint = 0;
+
+        struct SCacheItem {
+            SP<CVKTexture>  texture;
+            Time::steady_tp lastUsed;
+        };
+
+        std::vector<SCacheItem> m_readTexturesCache;
+
+        friend class CHyprVKRenderer;
+    };
+
+    inline UP<CHyprVulkanImpl> g_pHyprVulkan;
+}

--- a/src/render/vulkan/types.hpp
+++ b/src/render/vulkan/types.hpp
@@ -1,0 +1,162 @@
+#pragma once
+
+#include <cmath>
+#include <hyprgraphics/egl/Egl.hpp>
+#include <vulkan/vulkan.h>
+#include "../../helpers/Format.hpp"
+
+namespace Render::VK {
+
+    struct SVkFormatModifier {
+        VkDrmFormatModifierPropertiesEXT props;
+        VkExtent2D                       maxExtent;
+        bool                             canSrgb = false;
+    };
+
+    // TODO move to hyprgraphics
+    struct SVkFormatProps {
+        Hyprgraphics::Egl::SPixelFormat pixelFormat;
+        SVkFormatInfo                   format;
+
+        struct {
+            VkExtent2D           maxExtent;
+            VkFormatFeatureFlags features;
+            bool                 canSrgb = false;
+        } shm;
+
+        struct {
+            std::vector<SVkFormatModifier> renderModifiers;
+            std::vector<SVkFormatModifier> textureModifiers;
+        } dmabuf;
+
+        bool hasSrgb() const {
+            return format.vkSrgbFormat != VK_FORMAT_UNDEFINED;
+        }
+
+        uint32_t bytesPerBlock() const {
+            return pixelFormat.bytesPerBlock > 0 ? pixelFormat.bytesPerBlock : 4;
+        }
+
+        uint32_t pixelsPerBlock() const {
+            const int32_t pixels = pixelFormat.blockSize.size();
+            return std::max(pixels, 1);
+        }
+
+        int32_t minStride(int32_t width) const {
+            const int32_t pixels = pixelsPerBlock();
+            const int32_t bytes  = bytesPerBlock();
+            if (width > INT32_MAX / bytes)
+                return 0;
+
+            return std::ceil(width * bytes / pixels);
+        }
+    };
+
+    static const VkFormatFeatureFlags SHM_TEX_FEATURES =
+        VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT | VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT | VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT;
+    static const VkFormatFeatureFlags DMA_TEX_FEATURES = VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT | VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT;
+    static const VkFormatFeatureFlags YCC_TEX_FEATURES = VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT | VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT;
+
+    static const VkImageUsageFlags    VULKAN_SHM_TEX_USAGE = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+    static const VkImageUsageFlags    VULKAN_DMA_TEX_USAGE = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+
+    static const VkFormatFeatureFlags RENDER_FEATURES = VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT | VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT;
+
+    struct alignas(16) SShaderTargetPrimaries {
+        float xyz[3][3];
+        float sdrSaturation;
+        float sdrBrightnessMultiplier;
+    };
+
+    struct alignas(16) SShaderTonemap {
+        float maxLuminance;
+        float dstMaxLuminance;
+        float dstRefLuminance;
+    };
+
+    struct alignas(16) SShaderCM {
+        int   sourceTF; // eTransferFunction
+        int   targetTF; // eTransferFunction
+        float srcRefLuminance;
+
+        float srcTFRange[2];
+        float dstTFRange[2];
+
+        float convertMatrix[3][3];
+    };
+
+    struct alignas(16) SRounding {
+        float radius;
+        float power;
+        float topLeft[2];
+        float fullSize[2];
+    };
+
+    struct alignas(16) SVkVertShaderData {
+        float mat4[4][4];
+        float uvOffset[2];
+        float uvSize[2];
+    };
+
+    struct SVkFragShaderData {
+        float alpha             = 1.0f;
+        float tint              = 1.0f;
+        int   discardMode       = 0;
+        float discardAlphaValue = 0.0f;
+    };
+
+    static_assert(sizeof(SVkVertShaderData) + sizeof(SVkFragShaderData) + sizeof(SShaderTargetPrimaries) + sizeof(SShaderTonemap) + sizeof(SShaderCM) + sizeof(SRounding) <= 256,
+                  "Main texture shader push constants are too large");
+
+    struct alignas(16) SVkBorderShaderData {
+        float fullSizeUntransformed[2];
+        float radiusOuter;
+        float thick;
+        float angle;
+        float angle2;
+        float alpha;
+    };
+
+    struct alignas(16) SVkBorderGradientShaderData {
+        float gradient[10][4];
+        float gradient2[10][4];
+        int   gradientLength;
+        int   gradient2Length;
+        float gradientLerp;
+    };
+
+    struct alignas(16) SVkRectShaderData {
+        float color[4];
+    };
+
+    struct alignas(16) SVkShadowShaderData {
+        float color[4];
+        float bottomRight[2];
+        float range;
+        float shadowPower;
+    };
+
+    struct alignas(16) SVkPrepareShaderData {
+        float contrast;
+        float brightness;
+        float sdrBrightnessMultiplier = 1.0;
+    };
+
+    struct alignas(16) SVkBlur1ShaderData {
+        float radius;
+        float halfpixel[2];
+        int   passes;
+        float vibrancy;
+        float vibrancyDarkness;
+    };
+
+    struct alignas(16) SVkBlur2ShaderData {
+        float radius;
+        float halfpixel[2];
+    };
+
+    struct alignas(16) SVkFinishShaderData {
+        float noise;
+        float brightness;
+    };
+}

--- a/src/render/vulkan/utils.cpp
+++ b/src/render/vulkan/utils.cpp
@@ -1,0 +1,142 @@
+#include "utils.hpp"
+#include "../Renderer.hpp"
+
+namespace Render::VK {
+
+    // "UNASSIGNED-CoreValidation-Shader-OutputNotConsumed"
+    bool isIgnoredDebugMessage(const std::string& idName) {
+        return false;
+    }
+
+    std::string resultToStr(VkResult res) {
+        return std::to_string(res);
+    }
+
+    bool hasExtension(const std::vector<VkExtensionProperties>& extensions, const std::string& name) {
+        return std::ranges::any_of(extensions, [name](const auto& ext) { return ext.extensionName == name; });
+    };
+
+    int findVkMemType(VkPhysicalDevice dev, VkMemoryPropertyFlags flags, uint32_t bits) {
+        VkPhysicalDeviceMemoryProperties2 props = {
+            .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2,
+        };
+        vkGetPhysicalDeviceMemoryProperties2(dev, &props);
+
+        for (unsigned i = 0; i < props.memoryProperties.memoryTypeCount; ++i) {
+            if (bits & (1 << i)) {
+                if ((props.memoryProperties.memoryTypes[i].propertyFlags & flags) == flags)
+                    return i;
+            }
+        }
+
+        return -1;
+    }
+
+    bool isDisjoint(const Aquamarine::SDMABUFAttrs& attrs) {
+        if (attrs.planes == 1) {
+            return false;
+        }
+
+        struct stat fdStat;
+        if (fstat(attrs.fds[0], &fdStat) != 0)
+            return true;
+
+        for (int i = 1; i < attrs.planes; i++) {
+            struct stat fdStat2;
+            if (fstat(attrs.fds[i], &fdStat2) != 0)
+                return true;
+
+            if (fdStat.st_ino != fdStat2.st_ino) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    SVkVertShaderData matToVertShader(const std::array<float, 9> mat) {
+        return {
+            .mat4 =
+                {
+                    {mat[0], mat[1], 0, mat[2]},
+                    {mat[3], mat[4], 0, mat[5]},
+                    {0, 0, 1, 0},
+                    {0, 0, 0, 1},
+                },
+            .uvOffset = {0, 0},
+            .uvSize   = {1, 1},
+        };
+    }
+
+    void drawRegionRects(const CRegion& region, VkCommandBuffer cb, bool applyTransform) {
+        if (!region.empty()) {
+            const CBox max = {{0, 0}, {INT32_MAX, INT32_MAX}};
+            region.forEachRect([&](const auto& RECT) {
+                CBox box = {RECT.x1, RECT.y1, RECT.x2 - RECT.x1, RECT.y2 - RECT.y1};
+                if (applyTransform) {
+                    const auto TR = Math::wlTransformToHyprutils(Math::invertTransform(g_pHyprRenderer->m_renderData.pMonitor->m_transform));
+                    box.transform(TR, g_pHyprRenderer->m_renderData.pMonitor->m_transformedSize.x, g_pHyprRenderer->m_renderData.pMonitor->m_transformedSize.y);
+                }
+                box           = box.intersection(max);
+                VkRect2D rect = {
+                    .offset = {.x = box.x, .y = box.y},
+                    .extent = {.width = box.width, .height = box.height},
+                };
+
+                if (rect.offset.x < 0 || rect.offset.y < 0)
+                    Log::logger->log(Log::WARN, "vkCmdSetScissor tex {}x{}@{}x{}", rect.extent.width, rect.extent.height, rect.offset.x, rect.offset.y);
+
+                vkCmdSetScissor(cb, 0, 1, &rect);
+                vkCmdDraw(cb, 4, 1, 0, 0);
+            });
+        }
+    }
+
+    uint8_t passCMUniforms(const SCMSettings& settings, SShaderCM& cmData, SShaderTonemap& tonemapData, SShaderTargetPrimaries& primariesData) {
+        uint8_t     usedFeatures = 0;
+        const auto& mat          = settings.convertMatrix;
+
+        cmData = {
+            .sourceTF        = settings.sourceTF,
+            .targetTF        = settings.targetTF,
+            .srcRefLuminance = settings.srcRefLuminance,
+
+            .srcTFRange = {settings.srcTFRange.min, settings.srcTFRange.max},
+            .dstTFRange = {settings.dstTFRange.min, settings.dstTFRange.max},
+
+            .convertMatrix =
+                {
+                    {mat[0][0], mat[0][1], mat[0][2]}, //
+                    {mat[1][0], mat[1][1], mat[1][2]}, //
+                    {mat[2][0], mat[2][1], mat[2][2]}, //,
+                },
+        };
+
+        if (settings.needsTonemap) {
+            usedFeatures |= SH_FEAT_TONEMAP;
+            tonemapData = {
+                .maxLuminance    = settings.maxLuminance,
+                .dstMaxLuminance = settings.dstMaxLuminance,
+                .dstRefLuminance = settings.dstRefLuminance,
+            };
+        }
+
+        if (settings.needsTonemap || settings.needsSDRmod) {
+            if (settings.needsSDRmod)
+                usedFeatures |= SH_FEAT_SDR_MOD;
+
+            const auto& mat = settings.dstPrimaries2XYZ;
+            primariesData   = {
+                  .xyz =
+                    {
+                        {mat[0][0], mat[0][1], mat[0][2]}, //
+                        {mat[1][0], mat[1][1], mat[1][2]}, //
+                        {mat[2][0], mat[2][1], mat[2][2]}, //,
+                    },
+                  .sdrSaturation           = settings.sdrSaturation,
+                  .sdrBrightnessMultiplier = settings.sdrBrightnessMultiplier,
+            };
+        }
+        return usedFeatures;
+    }
+}

--- a/src/render/vulkan/utils.hpp
+++ b/src/render/vulkan/utils.hpp
@@ -1,0 +1,103 @@
+#pragma once
+
+#include <aquamarine/buffer/Buffer.hpp>
+#include <fcntl.h>
+#include <hyprutils/math/Vector2D.hpp>
+#include <sys/stat.h>
+#include <vulkan/vulkan.h>
+#include "../../debug/log/Logger.hpp"
+#include "../../macros.hpp"
+#include "../types.hpp"
+#include "types.hpp"
+
+#define CRIT(...)                                                                                                                                                                  \
+    Log::logger->log(Log::CRIT, __VA_ARGS__);                                                                                                                                      \
+    abort();
+
+#if ISDEBUG
+
+#include <vulkan/vk_enum_string_helper.h>
+#define IF_VKFAIL(proc, ...) if (const auto [callResult, callName] = std::tuple{proc(__VA_ARGS__), #proc}; callResult != VK_SUCCESS)
+#define LOG_VKFAIL           Log::logger->log(Log::ERR, "{} failed: {}", callName, string_VkResult(callResult))
+
+#define SET_VK_NAME(target, name, type)                                                                                                                                            \
+    {                                                                                                                                                                              \
+        const std::string             tmp  = name;                                                                                                                                 \
+        VkDebugUtilsObjectNameInfoEXT info = {                                                                                                                                     \
+            .sType        = VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT,                                                                                                    \
+            .objectType   = type,                                                                                                                                                  \
+            .objectHandle = (uintptr_t)(target),                                                                                                                                   \
+            .pObjectName  = tmp.c_str(),                                                                                                                                           \
+        };                                                                                                                                                                         \
+        if (g_pHyprVulkan->device()->m_proc.vkSetDebugUtilsObjectNameEXT)                                                                                                          \
+            g_pHyprVulkan->device()->m_proc.vkSetDebugUtilsObjectNameEXT(g_pHyprVulkan->vkDevice(), &info);                                                                        \
+    }
+
+#define VK_LABEL_BEGIN(name)                                                                                                                                                       \
+    {                                                                                                                                                                              \
+        const std::string    tmp  = name;                                                                                                                                          \
+        VkDebugUtilsLabelEXT info = {                                                                                                                                              \
+            .sType      = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT,                                                                                                                 \
+            .pLabelName = tmp.c_str(),                                                                                                                                             \
+        };                                                                                                                                                                         \
+        if (g_pHyprVulkan->device()->m_proc.vkQueueBeginDebugUtilsLabelEXT)                                                                                                        \
+            g_pHyprVulkan->device()->m_proc.vkQueueBeginDebugUtilsLabelEXT(g_pHyprVulkan->device()->queue(), &info);                                                               \
+    }
+
+#define VK_LABEL_END                                                                                                                                                               \
+    {                                                                                                                                                                              \
+        if (g_pHyprVulkan->device()->m_proc.vkQueueEndDebugUtilsLabelEXT)                                                                                                          \
+            g_pHyprVulkan->device()->m_proc.vkQueueEndDebugUtilsLabelEXT(g_pHyprVulkan->device()->queue());                                                                        \
+    }
+
+#define VK_CB_LABEL_BEGIN(cb, name)                                                                                                                                                \
+    {                                                                                                                                                                              \
+        const std::string    tmp  = name;                                                                                                                                          \
+        VkDebugUtilsLabelEXT info = {                                                                                                                                              \
+            .sType      = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT,                                                                                                                 \
+            .pLabelName = tmp.c_str(),                                                                                                                                             \
+        };                                                                                                                                                                         \
+        if (g_pHyprVulkan->device()->m_proc.vkCmdBeginDebugUtilsLabelEXT)                                                                                                          \
+            g_pHyprVulkan->device()->m_proc.vkCmdBeginDebugUtilsLabelEXT(cb, &info);                                                                                               \
+    }
+
+#define VK_CB_LABEL_END(cb)                                                                                                                                                        \
+    {                                                                                                                                                                              \
+        if (g_pHyprVulkan->device()->m_proc.vkCmdEndDebugUtilsLabelEXT)                                                                                                            \
+            g_pHyprVulkan->device()->m_proc.vkCmdEndDebugUtilsLabelEXT(cb);                                                                                                        \
+    }
+
+#else
+#define IF_VKFAIL(proc, ...)            if (proc(__VA_ARGS__) != VK_SUCCESS)
+#define LOG_VKFAIL                      ;
+#define SET_VK_NAME(target, name, type) ;
+#define VK_LABEL_BEGIN(name)            ;
+#define VK_LABEL_END                    ;
+#define VK_CB_LABEL_BEGIN(cb, name)     ;
+#define VK_CB_LABEL_END(cb)             ;
+#endif
+
+#define SET_VK_CB_NAME(target, name)       SET_VK_NAME(target, name, VK_OBJECT_TYPE_COMMAND_BUFFER);
+#define SET_VK_IMG_NAME(target, name)      SET_VK_NAME(target, name, VK_OBJECT_TYPE_IMAGE);
+#define SET_VK_IMG_VIEW_NAME(target, name) SET_VK_NAME(target, name, VK_OBJECT_TYPE_IMAGE_VIEW);
+#define SET_VK_SHADER_NAME(target, name)   SET_VK_NAME(target, name, VK_OBJECT_TYPE_SHADER_MODULE);
+#define SET_VK_PIPELINE_NAME(target, name) SET_VK_NAME(target, name, VK_OBJECT_TYPE_PIPELINE);
+#define SET_VK_PASS_NAME(target, name)     SET_VK_NAME(target, name, VK_OBJECT_TYPE_RENDER_PASS);
+
+// VK_OBJECT_TYPE_PIPELINE_CACHE = 16,
+// VK_OBJECT_TYPE_PIPELINE_LAYOUT = 17,
+// VK_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT = 20,
+// VK_OBJECT_TYPE_DESCRIPTOR_POOL = 22,
+// VK_OBJECT_TYPE_DESCRIPTOR_SET = 23,
+// VK_OBJECT_TYPE_FRAMEBUFFER = 24,
+
+namespace Render::VK {
+    bool              isIgnoredDebugMessage(const std::string& idName);
+    bool              hasExtension(const std::vector<VkExtensionProperties>& extensions, const std::string& name);
+    std::string       resultToStr(VkResult res);
+    int               findVkMemType(VkPhysicalDevice dev, VkMemoryPropertyFlags flags, uint32_t req_bits);
+    bool              isDisjoint(const Aquamarine::SDMABUFAttrs& attrs);
+    SVkVertShaderData matToVertShader(const std::array<float, 9> mat);
+    void              drawRegionRects(const CRegion& region, VkCommandBuffer cb, bool applyTransform = true);
+    uint8_t           passCMUniforms(const SCMSettings& settings, SShaderCM& cmData, SShaderTonemap& tonemapData, SShaderTargetPrimaries& primariesData);
+}


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Refactors rendering code and internal APIs
Adds a vulkan renderer `render:use_vulkan`


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
At the current state only basic things works and it'll crash often when some bits try to use g_pHyprOpenGL.
Better test it with `render:use_vulkan = 0` to verify that gl stuff doesn't break.
Some large structs are passed by value without need. Some internal render data is copied from one structs to almost identical ones. Some render data is stored several times in different structs.
OpenGL internal texture rendering has a bunch of flags that are never used for some codepaths. Final shader/crashing can be simplified.

#### Is it ready for merging, or does it need work?
After #13488 

- [x] Rendering loop
- [x] Hypr logo
- [x] Hypr splash
- [x] Hypr cursor
- [x] FB switch
- [x] Hide `g_pHyprOpenGL` from public #13488
  - [x] Layers
  - [x] Popups
  - [x] Windows
  - [x] Pointer manager
  - [x] Protocol manager
  - [x] Animations
  - [x] CLinuxDMABufV1Protocol
  - [x] Mesa drm
  - [x] CDMABuffer
  - [x] IHyprRenderer base impl
  - [x] Shadow deco
  - [x] Render pass
  - [x] CSurfacePassElement
- [x] Frame buffer api #13437
- [x] Render buffer api #13437
- [x] Move gl specific bits to `CHyprGLRenderer` or `CHyprOpenGLImpl` #13488
  - [ ] some extra tex parameters are unhandled (unneeded?)
- [ ] Fix rebase
  - [ ] damage
  - [ ] rotation
  - [ ] v0.55 changes
- [ ] Explicit sync for clients
- [x] DMA textures
- [ ] Screen export
- [x] Scaling
- [x] Rotation
  - [x] Hypr logo
  - [x] Hypr splash
  - [x] Screen export
  - [x] Blur
  - [x] Shadow
  - [x] Surface
- [ ] disable blend
  - [ ] copy FB to output
  - [x] blur FB
  - [ ] copy for mirror
  - [ ] render mirror
  - [ ] opaque surface without rounding
- [x] Blur
  - [x] pre
  - [x] live
  - [x] ~~stencil for~~ ignore alpha/opaque
- [ ] Render elements #13438
  - [x] Border
    - [x] gradients
  - [x] Clear
  - [x] Pre blur
  - [x] Rect
  - [x] Render hints
  - [ ] Shadow
    - [x] clipping
    - [x] matte
    - [ ] ignore window #14047
  - [x] Surface
    - [x] scaling, rotation, etc
  - [ ] Glow
  - [x] Texture
    - [x] SHM
    - [x] DMA
    - [ ] sync
  - [x] Texture matte
- [x] CM
  - [ ] ICC
- [ ] FP16
- [ ] HW cursor
- [x] Shader variants #13434
- [ ] Resource management
- [ ] cleanup
- [x] namespaces #13631
- [x] dynamic rendering
  - [ ] fix sync
- [ ] VK_EXT_host_image_copy / rebar?