### PR TITLE
desktop/windowRules: fix matching on content prop

### DIFF
--- a/src/desktop/rule/windowRule/WindowRule.cpp
+++ b/src/desktop/rule/windowRule/WindowRule.cpp
@@ -97,7 +97,7 @@ bool CWindowRule::matches(PHLWINDOW w, bool allowEnvLookup) {
                     return false;
                 break;
             case RULE_PROP_CONTENT:
-                if (!engine->match(NContentType::toString(w->getContentType())))
+                if (!engine->match(w->getContentType()))
                     return false;
                 break;
             case RULE_PROP_XDG_TAG:


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Match checker for content type is `RULE_MATCH_ENGINE_INT`, but the switch was comparing input prop (int, as mentioned in wiki) to a string which doesn't work, so just use the content type enum directly instead. Fixes #12887. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

If you write `match:content game` in your rule or something similar, instead of `match:content 3`, every window will be matched against. But this behaviour is consistent for all other rules too, not unique for content type, and generally there's no validation/errors thrown for putting strings where ints should be/vice versa. 

Probably doesn't matter since it clearly mentions what the allowed rule values are in the wiki, but thought I'd mention it.

#### Is it ready for merging, or does it need work?

Ready!