### PR TITLE
Fix use_cpu_buffer

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -1702,7 +1702,7 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
     },
     SConfigOptionDescription{
         .value       = "cursor:use_cpu_buffer",
-        .description = "Makes HW cursors use a CPU buffer. Required on Nvidia to have HW cursors. Experimental",
+        .description = "Makes HW cursors use a CPU buffer. Required on Nvidia to have HW cursors. 0 - off, 1 - on, 2 - auto (nvidia only)",
         .type        = CONFIG_OPTION_INT,
         .data        = SConfigOptionDescription::SRangeData{.value = 2, .min = 0, .max = 2},
     },


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
-->


#### Describe your PR, what does it fix/add?

SUPER small change. `use_cpu_buffer` should be of type int since it could be 0, 1, or 2.
#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

There isn't anything else I see that has the wrong type at a quick glance but I could be wrong.
#### Is it ready for merging, or does it need work?

Ready
