### PR TITLE
compositor: dont unlock all states on empty commits

### DIFF
--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -512,7 +512,7 @@ void CWLSurfaceResource::scheduleState(WP<SSurfaceState> state) {
         g_pEventLoopManager->doOnReadable(std::move(state->buffer->m_syncFd), [state, whenReadable]() { whenReadable(state, LOCK_REASON_FENCE); });
     } else {
         // state commit without a buffer.
-        m_stateQueue.unlock(state, LOCK_REASON_FENCE);
+        m_stateQueue.tryProcess();
     }
 }
 


### PR DESCRIPTION
we cant unlock all states on empty commits, at best tryProcess them.

for example if a state is locked and waiting for a fence to become readable, and another commit comes in we cant unlock it until the fence has actually signaled.

