### PR TITLE
monitor: delay commits if pending pageflip

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -2030,7 +2030,7 @@ bool CMonitor::attemptDirectScanout() {
 
     // no need to do explicit sync here as surface current can only ever be ready to read
 
-    bool ok = m_output->commit();
+    bool ok = m_state.commit(false);
 
     if (!ok) {
         Log::logger->log(Log::TRACE, "attemptDirectScanout: failed to scanout surface");
@@ -2038,6 +2038,7 @@ bool CMonitor::attemptDirectScanout() {
             m_output->state->setFormat(PREV_FORMAT);
             m_drmFormat = PREV_FORMAT;
         }
+
         m_lastScanout.reset();
         return false;
     }
@@ -2466,15 +2467,23 @@ void CMonitorState::ensureBufferPresent() {
     m_owner->m_output->swapchain->rollback(); // restore the counter, don't advance the swapchain
 }
 
-bool CMonitorState::commit() {
-    if (!updateSwapchain())
+bool CMonitorState::commit(bool update) {
+    if (update && !updateSwapchain())
         return false;
 
     Event::bus()->m_events.monitor.preCommit.emit(m_owner->m_self.lock());
 
-    ensureBufferPresent();
+    if (update)
+        ensureBufferPresent();
 
-    bool ret = m_owner->m_output->commit();
+    m_owner->m_delayedCommit = m_owner->m_output->pendingPageFlip();
+
+    bool ret = false;
+    if (!m_owner->m_delayedCommit)
+        ret = m_owner->m_output->commit();
+    else
+        Log::logger->log(Log::DEBUG, "CMonitorState::commit: tried to commit with a pendingPageFlip, delaying it.");
+
     return ret;
 }
 

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -89,7 +89,7 @@ class CMonitorState {
     CMonitorState(CMonitor* owner);
     ~CMonitorState() = default;
 
-    bool commit();
+    bool commit(bool update = true);
     bool test();
     bool updateSwapchain();
     void applyModeWithSwapchain(const SP<Aquamarine::SOutputMode>& mode);
@@ -160,6 +160,7 @@ class CMonitor {
     SP<CEventLoopTimer>         m_dpmsRetryTimer;
 
     bool                        m_pendingFrame    = false; // if we schedule a frame during rendering, reschedule it after
+    bool                        m_delayedCommit   = false;
     bool                        m_renderingActive = false;
 
     bool                        m_ratsScheduled = false;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1950,8 +1950,12 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
             pMonitor->m_activeWorkspace->m_space->recalculate();
     }
 
-    if (!pMonitor->m_output->needsFrame && pMonitor->m_forceFullFrames == 0)
+    if (!pMonitor->m_output->needsFrame && pMonitor->m_forceFullFrames == 0) {
+        if (pMonitor->m_delayedCommit)
+            pMonitor->m_state.commit();
+
         return;
+    }
 
     // tearing and DS first
     bool       shouldTear              = pMonitor->updateTearing();
@@ -1986,11 +1990,17 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     // check the damage
     bool hasChanged = pMonitor->m_output->needsFrame || pMonitor->m_damage.hasChanged();
 
-    if (!hasChanged && *PDAMAGETRACKINGMODE != DAMAGE_TRACKING_NONE && pMonitor->m_forceFullFrames == 0 && damageBlinkCleanup == 0)
+    if (!hasChanged && *PDAMAGETRACKINGMODE != DAMAGE_TRACKING_NONE && pMonitor->m_forceFullFrames == 0 && damageBlinkCleanup == 0) {
+        if (pMonitor->m_delayedCommit)
+            pMonitor->m_state.commit();
+
         return;
+    }
 
     if (*PDAMAGETRACKINGMODE == -1) {
         Log::logger->log(Log::CRIT, "Damage tracking mode -1 ????");
+        if (pMonitor->m_delayedCommit)
+            pMonitor->m_state.commit();
         return;
     }
 
@@ -2029,6 +2039,8 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     CRegion damage, finalDamage;
     if (!beginRender(pMonitor, damage, RENDER_MODE_NORMAL)) {
         Log::logger->log(Log::ERR, "renderer: couldn't beginRender()!");
+        if (pMonitor->m_delayedCommit)
+            pMonitor->m_state.commit();
         return;
     }
 
@@ -2141,6 +2153,8 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     if (commit)
         commitPendingAndDoExplicitSync(pMonitor);
+    else if (pMonitor->m_delayedCommit)
+        pMonitor->m_state.commit();
 
     if (shouldTear)
         pMonitor->m_tearingState.busy = true;


### PR DESCRIPTION
if we have pending pageflips we cant commit, so attempt to delay them.

requires: https://github.com/hyprwm/aquamarine/pull/251

if we have a pending page flip that pageflip will eventually call .frame() and this "delayed" commit will commit in renderMonitor instead.


