### PR TITLE
Window: onX11ConfigureRequest reject requests that violate window rules

### DIFF
--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -1498,32 +1498,22 @@ void CWindow::onX11ConfigureRequest(CBox box) {
         return;
     }
 
-    if (!m_ruleApplicator->static_.center.has_value() && m_ruleApplicator->static_.position.empty()) {
-        m_realPosition->setValueAndWarp(xwaylandPositionToReal(box.pos()));
-    } else {
-        Log::logger->log(Log::DEBUG, "onX11ConfigureRequest: window '{}' ({:#x}) requested pos={:.0f},{:.0f} but was rejected due to window rule", m_title, (uintptr_t)this, box.x,
-                         box.y);
-    }
+    if (box.size() > Vector2D{1, 1})
+        setHidden(false);
+    else
+        setHidden(true);
 
-    if (m_ruleApplicator->static_.size.empty()) {
-        if (box.size() > Vector2D{1, 1})
-            setHidden(false);
-        else
-            setHidden(true);
-
-        m_realSize->setValueAndWarp(xwaylandSizeToReal(box.size()));
-    } else {
-        Log::logger->log(Log::DEBUG, "onX11ConfigureRequest: window '{}' ({:#x}) requested size={:.0f},{:.0f} but was rejected due to window rule", m_title, (uintptr_t)this, box.w,
-                         box.h);
-    }
+    m_realPosition->setValueAndWarp(xwaylandPositionToReal(box.pos()));
+    m_realSize->setValueAndWarp(xwaylandSizeToReal(box.size()));
 
     m_position = m_realPosition->goal();
     m_size     = m_realSize->goal();
-    if (m_pendingReportedSize != m_size || m_reportedPosition != m_position) {
-        m_xwaylandSurface->configure({m_position, m_size});
-        m_reportedSize        = m_size;
-        m_pendingReportedSize = m_size;
-        m_reportedPosition    = m_position;
+
+    if (m_pendingReportedSize != box.size() || m_reportedPosition != box.pos()) {
+        m_xwaylandSurface->configure(box);
+        m_reportedSize        = box.size();
+        m_pendingReportedSize = box.size();
+        m_reportedPosition    = box.pos();
     }
 
     updateX11SurfaceScale();

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -1491,7 +1491,7 @@ void CWindow::onX11ConfigureRequest(CBox box) {
 
     g_pHyprRenderer->damageWindow(m_self.lock());
 
-    if (!m_isFloating || isFullscreen() || g_layoutManager->dragController()->target() == m_self) {
+    if (!m_isFloating || isFullscreen() || g_layoutManager->dragController()->target() == m_self || (m_suppressedEvents & Desktop::View::SUPPRESS_X11_CONFIGURE_REQUEST)) {
         sendWindowSize(true);
         g_pInputManager->refocus();
         g_pHyprRenderer->damageWindow(m_self.lock());
@@ -2130,7 +2130,9 @@ void CWindow::mapWindow() {
                 else if (var == "activatefocus")
                     m_suppressedEvents |= Desktop::View::SUPPRESS_ACTIVATE_FOCUSONLY;
                 else if (var == "fullscreenoutput")
-                    m_suppressedEvents |= Desktop::View::SUPPRESS_FULLSCREEN_OUTPUT;
+                    m_suppressedEvents |= Desktop::View::SUPPRESS_X11_CONFIGURE_REQUEST;
+                else if (var == "x11configurerequest")
+                    m_suppressedEvents |= Desktop::View::SUPPRESS_X11_CONFIGURE_REQUEST;
                 else
                     Log::logger->log(Log::ERR, "Error while parsing suppressevent windowrule: unknown event type {}", var);
             }

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -1498,22 +1498,32 @@ void CWindow::onX11ConfigureRequest(CBox box) {
         return;
     }
 
-    if (box.size() > Vector2D{1, 1})
-        setHidden(false);
-    else
-        setHidden(true);
+    if (!m_ruleApplicator->static_.center.has_value() && m_ruleApplicator->static_.position.empty()) {
+        m_realPosition->setValueAndWarp(xwaylandPositionToReal(box.pos()));
+    } else {
+        Log::logger->log(Log::DEBUG, "onX11ConfigureRequest: window '{}' ({:#x}) requested pos={:.0f},{:.0f} but was rejected due to window rule", m_title, (uintptr_t)this, box.x,
+                         box.y);
+    }
 
-    m_realPosition->setValueAndWarp(xwaylandPositionToReal(box.pos()));
-    m_realSize->setValueAndWarp(xwaylandSizeToReal(box.size()));
+    if (m_ruleApplicator->static_.size.empty()) {
+        if (box.size() > Vector2D{1, 1})
+            setHidden(false);
+        else
+            setHidden(true);
+
+        m_realSize->setValueAndWarp(xwaylandSizeToReal(box.size()));
+    } else {
+        Log::logger->log(Log::DEBUG, "onX11ConfigureRequest: window '{}' ({:#x}) requested size={:.0f},{:.0f} but was rejected due to window rule", m_title, (uintptr_t)this, box.w,
+                         box.h);
+    }
 
     m_position = m_realPosition->goal();
     m_size     = m_realSize->goal();
-
-    if (m_pendingReportedSize != box.size() || m_reportedPosition != box.pos()) {
-        m_xwaylandSurface->configure(box);
-        m_reportedSize        = box.size();
-        m_pendingReportedSize = box.size();
-        m_reportedPosition    = box.pos();
+    if (m_pendingReportedSize != m_size || m_reportedPosition != m_position) {
+        m_xwaylandSurface->configure({m_position, m_size});
+        m_reportedSize        = m_size;
+        m_pendingReportedSize = m_size;
+        m_reportedPosition    = m_position;
     }
 
     updateX11SurfaceScale();

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -2130,7 +2130,7 @@ void CWindow::mapWindow() {
                 else if (var == "activatefocus")
                     m_suppressedEvents |= Desktop::View::SUPPRESS_ACTIVATE_FOCUSONLY;
                 else if (var == "fullscreenoutput")
-                    m_suppressedEvents |= Desktop::View::SUPPRESS_X11_CONFIGURE_REQUEST;
+                    m_suppressedEvents |= Desktop::View::SUPPRESS_FULLSCREEN_OUTPUT;
                 else if (var == "x11configurerequest")
                     m_suppressedEvents |= Desktop::View::SUPPRESS_X11_CONFIGURE_REQUEST;
                 else

--- a/src/desktop/view/Window.hpp
+++ b/src/desktop/view/Window.hpp
@@ -68,12 +68,13 @@ namespace Desktop::View {
     };
 
     enum eSuppressEvents : uint8_t {
-        SUPPRESS_NONE               = 0,
-        SUPPRESS_FULLSCREEN         = 1 << 0,
-        SUPPRESS_MAXIMIZE           = 1 << 1,
-        SUPPRESS_ACTIVATE           = 1 << 2,
-        SUPPRESS_ACTIVATE_FOCUSONLY = 1 << 3,
-        SUPPRESS_FULLSCREEN_OUTPUT  = 1 << 4,
+        SUPPRESS_NONE                  = 0,
+        SUPPRESS_FULLSCREEN            = 1 << 0,
+        SUPPRESS_MAXIMIZE              = 1 << 1,
+        SUPPRESS_ACTIVATE              = 1 << 2,
+        SUPPRESS_ACTIVATE_FOCUSONLY    = 1 << 3,
+        SUPPRESS_FULLSCREEN_OUTPUT     = 1 << 4,
+        SUPPRESS_X11_CONFIGURE_REQUEST = 1 << 5,
     };
 
     enum eWindowAlpha : uint8_t {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Some xwayland apps (especially games) request changes in geometry that are very annoying because they happen out-of-band from the window rule system. Not a problem with fullscreen games but I find most games work best in floating windowed mode.

This PR adds a `suppressevent x11configurerequest` rule to supress x11configurerequests from modifying the geometry of the window. Normally this only happens for floating, non-fullscreen windows. When the suppressevent rule is present, floating windows will follow the same code-path as tiled or fullscreen windows on x11configurerequests (i.e. ignoring them). 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I am no expert on xwayland and I do not know if some apps may act strange or crash in response to a rejected geometry request (seems like it should be fine since tiled windows ignore them).

#### Is it ready for merging, or does it need work?
Ready