### PR TITLE
group: disband_on_empty config

### DIFF
--- a/src/config/legacy/ConfigManager.cpp
+++ b/src/config/legacy/ConfigManager.cpp
@@ -545,6 +545,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("group:auto_group", Hyprlang::INT{1});
     registerConfigVar("group:drag_into_group", Hyprlang::INT{1});
     registerConfigVar("group:group_on_movetoworkspace", Hyprlang::INT{0});
+    registerConfigVar("group:disband_on_empty", Hyprlang::INT{0});
     registerConfigVar("group:groupbar:enabled", Hyprlang::INT{1});
     registerConfigVar("group:groupbar:font_family", {STRVAL_EMPTY});
     registerConfigVar("group:groupbar:font_weight_active", Hyprlang::CConfigCustomValueType{&configHandleFontWeightSet, configHandleFontWeightDestroy, "normal"});

--- a/src/config/supplementary/ConfigDescriptions.hpp
+++ b/src/config/supplementary/ConfigDescriptions.hpp
@@ -1004,6 +1004,12 @@ namespace Config::Supplementary {
             .type        = CONFIG_OPTION_BOOL,
             .data        = SConfigOptionDescription::SBoolData{false},
         },
+        SConfigOptionDescription{
+            .value       = "group:disband_on_empty",
+            .description = "whether to automatically disband a group when only one window remains",
+            .type        = CONFIG_OPTION_BOOL,
+            .data        = SConfigOptionDescription::SBoolData{false},
+        },
 
         /*
      * group:groupbar:

--- a/src/desktop/view/Group.cpp
+++ b/src/desktop/view/Group.cpp
@@ -123,6 +123,8 @@ void CGroup::add(PHLWINDOW w) {
 }
 
 void CGroup::remove(PHLWINDOW w, Math::eDirection dir) {
+    static auto           DISBAND_ON_EMPTY = CConfigValue<Hyprlang::INT>("group:disband_on_empty");
+
     std::optional<size_t> idx;
     for (size_t i = 0; i < m_windows.size(); ++i) {
         if (m_windows.at(i) == w) {
@@ -171,6 +173,12 @@ void CGroup::remove(PHLWINDOW w, Math::eDirection dir) {
             }
         }
         w->m_target->assignToSpace(m_target->space(), focalPoint);
+    }
+
+    // Disband group if only one window remains and disband_on_empty is enabled
+    if (*DISBAND_ON_EMPTY && m_windows.size() == 1) {
+        destroy();
+        return;
     }
 }
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
adds config to auto disband the group if only one window is left


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
in [hyprscroller](https://github.com/dawsers/hyprscroller) expelwindow doesnt need to disband the tab/group, but we do here so, adding this as an replacement


#### Is it ready for merging, or does it need work?
ready, tested


