### PR TITLE
dispatcher(moveoutofgroup): optional direction arg

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2749,6 +2749,12 @@ void CKeybindManager::moveWindowOutOfGroup(PHLWINDOW pWindow, const std::string&
         group->current()->warpCursor();
     }
 
+    if (!dir.empty()) {
+        Math::eDirection direction = Math::fromChar(dir[0]);
+        if (direction != Math::DIRECTION_DEFAULT)
+            g_layoutManager->moveInDirection(pWindow->layoutTarget(), dir);
+    }
+
     g_pEventManager->postEvent(SHyprIPCEvent{"moveoutofgroup", std::format("{:x}", rc<uintptr_t>(pWindow.get()))});
 }
 
@@ -2791,12 +2797,23 @@ SDispatchResult CKeybindManager::moveOutOfGroup(std::string args) {
     if (!*PIGNOREGROUPLOCK && g_pKeybindManager->m_groupsLocked)
         return {.success = false, .error = "Groups locked"};
 
-    PHLWINDOW PWINDOW = nullptr;
+    PHLWINDOW   PWINDOW = nullptr;
+    std::string dir;
 
-    if (args != "active" && args.length() > 1)
-        PWINDOW = g_pCompositor->getWindowByRegex(args);
-    else
+    if (args.empty() || args == "active")
         PWINDOW = Desktop::focusState()->window();
+    else if (args.length() == 1 && std::string("lrutdb").find(args[0]) != std::string::npos) {
+        PWINDOW = Desktop::focusState()->window();
+        dir     = args;
+    } else {
+        size_t spacePos = args.find_last_of(' ');
+        if (spacePos != std::string::npos && std::string("lrutdb").find(args.back()) != std::string::npos) {
+            std::string windowRegex = args.substr(0, spacePos);
+            PWINDOW                 = g_pCompositor->getWindowByRegex(windowRegex);
+            dir                     = args.substr(spacePos + 1);
+        } else
+            PWINDOW = g_pCompositor->getWindowByRegex(args);
+    }
 
     if (!PWINDOW)
         return {.success = false, .error = "No window found"};
@@ -2804,7 +2821,7 @@ SDispatchResult CKeybindManager::moveOutOfGroup(std::string args) {
     if (!PWINDOW->m_group)
         return {.success = false, .error = "Window not in a group"};
 
-    moveWindowOutOfGroup(PWINDOW);
+    moveWindowOutOfGroup(PWINDOW, dir);
 
     return {};
 }


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
adds optional direction arg to moveoutofgroup


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
in [hyprscroller](https://github.com/nasirHo/hyprscroller) expelwindow disaptcher takes an arg


#### Is it ready for merging, or does it need work?
ready, tested


