### PR TITLE
fix: use after free in Popup

### DIFF
--- a/src/desktop/view/Popup.cpp
+++ b/src/desktop/view/Popup.cpp
@@ -109,9 +109,11 @@ void CPopup::initAllSignals() {
     m_alpha->setCallbackOnEnd(
         [this](auto) {
             if (inert()) {
-                g_pEventLoopManager->doLater([this] {
-                    g_pHyprRenderer->damageBox(CBox{coordsGlobal(), size()});
-                    fullyDestroy();
+                g_pEventLoopManager->doLater([p = m_self] {
+                    if (!p)
+                        return;
+                    g_pHyprRenderer->damageBox(CBox{p->coordsGlobal(), p->size()});
+                    p->fullyDestroy();
                 });
             }
         },


### PR DESCRIPTION
There was a uaf because you can't `fullyDestroy` a popup from `setCallbackOnEnd`, or the `tick` function which calls `setCallbackOnEnd` is already queued to go and touch `m_alpha` next, will causes the uaf.

The fix I made was to use `g_pEventLoopManager->doLater` so that the `fullyDestroy` is not called by the tick function.

I didn't investigate if there was a better fix that might solve this problem all together so that it doesn't happen in the future when someone uses `setCallbackOnEnd` like this.