### PR TITLE
fix: unguarded member access in moveWindowOrGroup

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2834,12 +2834,13 @@ SDispatchResult CKeybindManager::moveWindowOrGroup(std::string args) {
     const bool ISWINDOWGROUP       = PWINDOW->m_group;
     const bool ISWINDOWGROUPLOCKED = ISWINDOWGROUP && PWINDOW->m_group->locked();
     const bool ISWINDOWGROUPSINGLE = ISWINDOWGROUP && PWINDOW->m_group->size() == 1;
+    const bool ISWINDOWGROUPDENIED = ISWINDOWGROUP && PWINDOW->m_group->denied();
 
     updateRelativeCursorCoords();
 
     // note: PWINDOWINDIR is not null implies !PWINDOW->m_isFloating
     if (PWINDOWINDIR && PWINDOWINDIR->m_group) { // target is group
-        if (!*PIGNOREGROUPLOCK && (PWINDOWINDIR->m_group->locked() || ISWINDOWGROUPLOCKED || (ISWINDOWGROUP && PWINDOW->m_group->denied()))) {
+        if (!*PIGNOREGROUPLOCK && (PWINDOWINDIR->m_group->locked() || ISWINDOWGROUPLOCKED || ISWINDOWGROUPDENIED)) {
             g_layoutManager->moveInDirection(PWINDOW->layoutTarget(), args);
             PWINDOW->warpCursor();
         } else


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
We were checking if `m_group->denied()` without first checking if the window had an `m_group`, which will segfault. Probably fixes #13330

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
In a search for related bugs, `CKeybindManager::denyWindowFromGroup` logic looks hella sus to me, not sure what it's supposed to be doing but I think it might lead to similar crashes the way its written atm? But I don't know what it's meant to be doing so idk

#### Is it ready for merging, or does it need work?
Yes, notwithstanding above separate issue
