### PR TITLE
add new focus_fit_method: clamped_center

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -2067,7 +2067,7 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .value       = "scrolling:focus_fit_method",
         .description = "When a column is focused, what method should be used to bring it into view",
         .type        = CONFIG_OPTION_CHOICE,
-        .data        = SConfigOptionDescription::SChoiceData{.firstIndex = 0, .choices = "center,fit"},
+        .data        = SConfigOptionDescription::SChoiceData{.firstIndex = 0, .choices = "center,fit,clamped_center"},
     },
     SConfigOptionDescription{
         .value       = "scrolling:follow_focus",

--- a/src/layout/algorithm/tiled/scrolling/ScrollTapeController.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollTapeController.cpp
@@ -241,6 +241,22 @@ void CScrollTapeController::fitStrip(size_t stripIndex, const CBox& usableArea, 
     m_offset = std::clamp(m_offset, stripStart - usablePrimary + stripSize, stripStart);
 }
 
+void CScrollTapeController::clampedCenterStrip(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne) {
+    if (stripIndex >= m_strips.size())
+        return;
+
+    const double usablePrimary = getPrimary(usableArea.size());
+    const double stripStart    = calculateStripStart(stripIndex, usableArea, fullscreenOnOne);
+    const double stripSize     = calculateStripSize(stripIndex, usableArea, fullscreenOnOne);
+
+    const double maxExtent = calculateMaxExtent(usableArea, fullscreenOnOne);
+    const double limit     = std::max(0., maxExtent - usablePrimary);
+
+    const double center = stripStart - (usablePrimary - stripSize) / 2.0;
+
+    m_offset = std::clamp(center, 0., limit);
+}
+
 bool CScrollTapeController::isStripVisible(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne) const {
     if (stripIndex >= m_strips.size())
         return false;

--- a/src/layout/algorithm/tiled/scrolling/ScrollTapeController.hpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollTapeController.hpp
@@ -62,6 +62,7 @@ namespace Layout::Tiled {
 
         void              centerStrip(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false);
         void              fitStrip(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false);
+        void              clampedCenterStrip(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false);
 
         bool              isStripVisible(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false) const;
 

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -894,8 +894,6 @@ void CScrollingAlgorithm::moveTargetTo(SP<ITarget> t, Math::eDirection dir, bool
 }
 
 std::expected<void, std::string> CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
-    auto       centerOrFit = [this](const SP<SColumnData> COL) -> void { m_scrollingData->centerOrFitCol(COL); };
-
     const auto ARGS = CVarList(std::string{sv}, 0, ' ');
     if (ARGS[0] == "move") {
         if (ARGS[1] == "+col" || ARGS[1] == "col") {
@@ -913,7 +911,7 @@ std::expected<void, std::string> CScrollingAlgorithm::layoutMsg(const std::strin
                 return {};
             }
 
-            centerOrFit(COL);
+            m_scrollingData->centerOrFitCol(COL);
             m_scrollingData->recalculate();
 
             focusTargetUpdate(COL->targetDatas.front()->target.lock());
@@ -939,7 +937,7 @@ std::expected<void, std::string> CScrollingAlgorithm::layoutMsg(const std::strin
             if (!COL)
                 return {};
 
-            centerOrFit(COL);
+            m_scrollingData->centerOrFitCol(COL);
             m_scrollingData->recalculate();
 
             focusTargetUpdate(COL->targetDatas.back()->target.lock());
@@ -1220,7 +1218,7 @@ std::expected<void, std::string> CScrollingAlgorithm::layoutMsg(const std::strin
             auto PREV = m_scrollingData->prev(TDATA->column.lock());
             if (!PREV) {
                 if (*PNOFALLBACK) {
-                    centerOrFit(TDATA->column.lock());
+                    m_scrollingData->centerOrFitCol(TDATA->column.lock());
                     m_scrollingData->recalculate();
                     if (TDATA->target->window())
                         g_pCompositor->warpCursorTo(TDATA->target->window()->middle());
@@ -1232,7 +1230,7 @@ std::expected<void, std::string> CScrollingAlgorithm::layoutMsg(const std::strin
             auto pTargetData = findBestNeighbor(TDATA, PREV);
             if (pTargetData) {
                 focusTargetUpdate(pTargetData->target.lock());
-                centerOrFit(PREV);
+                m_scrollingData->centerOrFitCol(PREV);
                 m_scrollingData->recalculate();
                 if (pTargetData->target->window())
                     g_pCompositor->warpCursorTo(pTargetData->target->window()->middle());
@@ -1242,7 +1240,7 @@ std::expected<void, std::string> CScrollingAlgorithm::layoutMsg(const std::strin
             auto NEXT = m_scrollingData->next(TDATA->column.lock());
             if (!NEXT) {
                 if (*PNOFALLBACK) {
-                    centerOrFit(TDATA->column.lock());
+                    m_scrollingData->centerOrFitCol(TDATA->column.lock());
                     m_scrollingData->recalculate();
                     if (TDATA->target->window())
                         g_pCompositor->warpCursorTo(TDATA->target->window()->middle());
@@ -1254,7 +1252,7 @@ std::expected<void, std::string> CScrollingAlgorithm::layoutMsg(const std::strin
             auto pTargetData = findBestNeighbor(TDATA, NEXT);
             if (pTargetData) {
                 focusTargetUpdate(pTargetData->target.lock());
-                centerOrFit(NEXT);
+                m_scrollingData->centerOrFitCol(NEXT);
                 m_scrollingData->recalculate();
                 if (pTargetData->target->window())
                     g_pCompositor->warpCursorTo(pTargetData->target->window()->middle());

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.hpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.hpp
@@ -80,6 +80,7 @@ namespace Layout::Tiled {
         bool                         visible(SP<SColumnData> c);
         void                         centerCol(SP<SColumnData> c);
         void                         fitCol(SP<SColumnData> c);
+        void                         clampedCenterCol(SP<SColumnData> c);
         void                         centerOrFitCol(SP<SColumnData> c);
 
         void                         recalculate(bool forceInstant = false);


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

I like `center` `focus_fit_method`, however I think it looks cringy when I focus the last strip:

https://github.com/user-attachments/assets/d4033c11-f510-4114-b653-f5f9b26e4c7f

This PR adds a new `focus_fit_method` called `clamped_center` (2) which combines best of the fit and center worlds:

https://github.com/user-attachments/assets/7823375e-8d8a-455f-8f93-433cc58c71e5

No ugly empty space past the last strip now.

I also removed some code duplicating the `centerOrFitCol` contents.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?

Idk seems to work