### PR TITLE
groupbar: add border support for tabs

### DIFF
--- a/src/config/ConfigDescriptions.hpp
+++ b/src/config/ConfigDescriptions.hpp
@@ -984,6 +984,12 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .data        = SConfigOptionDescription::SRangeData{3, 1, 64},
     },
     SConfigOptionDescription{
+        .value       = "group:groupbar:border_size",
+        .description = "thickness of the groupbar border",
+        .type        = CONFIG_OPTION_INT,
+        .data        = SConfigOptionDescription::SRangeData{0, 0, 64},
+    },
+    SConfigOptionDescription{
         .value       = "group:groupbar:stacked",
         .description = "render the groupbar as a vertical stack",
         .type        = CONFIG_OPTION_BOOL,
@@ -1090,6 +1096,30 @@ inline static const std::vector<SConfigOptionDescription> CONFIG_OPTIONS = {
         .description = "controls the group bar text color",
         .type        = CONFIG_OPTION_COLOR,
         .data        = SConfigOptionDescription::SColorData{0x66775500},
+    },
+    SConfigOptionDescription{
+        .value       = "group:groupbar:col.border_active",
+        .description = "border color for active tab",
+        .type        = CONFIG_OPTION_COLOR,
+        .data        = SConfigOptionDescription::SColorData{0x00000000},
+    },
+    SConfigOptionDescription{
+        .value       = "group:groupbar:col.border_inactive",
+        .description = "border color for inactive tabs",
+        .type        = CONFIG_OPTION_COLOR,
+        .data        = SConfigOptionDescription::SColorData{0x00000000},
+    },
+    SConfigOptionDescription{
+        .value       = "group:groupbar:col.border_locked_active",
+        .description = "border color for active locked tab",
+        .type        = CONFIG_OPTION_COLOR,
+        .data        = SConfigOptionDescription::SColorData{0x00000000},
+    },
+    SConfigOptionDescription{
+        .value       = "group:groupbar:col.border_locked_inactive",
+        .description = "border color for inactive locked tabs",
+        .type        = CONFIG_OPTION_COLOR,
+        .data        = SConfigOptionDescription::SColorData{0x00000000},
     },
     SConfigOptionDescription{
         .value       = "group:groupbar:gaps_out",

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -538,6 +538,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("group:groupbar:height", Hyprlang::INT{14});
     registerConfigVar("group:groupbar:indicator_gap", Hyprlang::INT{0});
     registerConfigVar("group:groupbar:indicator_height", Hyprlang::INT{3});
+    registerConfigVar("group:groupbar:border_size", Hyprlang::INT{0});
     registerConfigVar("group:groupbar:priority", Hyprlang::INT{3});
     registerConfigVar("group:groupbar:render_titles", Hyprlang::INT{1});
     registerConfigVar("group:groupbar:scrolling", Hyprlang::INT{1});
@@ -784,6 +785,10 @@ CConfigManager::CConfigManager() {
     registerConfigVar("group:groupbar:col.inactive", Hyprlang::CConfigCustomValueType{&configHandleGradientSet, configHandleGradientDestroy, "0x66777700"});
     registerConfigVar("group:groupbar:col.locked_active", Hyprlang::CConfigCustomValueType{&configHandleGradientSet, configHandleGradientDestroy, "0x66ff5500"});
     registerConfigVar("group:groupbar:col.locked_inactive", Hyprlang::CConfigCustomValueType{&configHandleGradientSet, configHandleGradientDestroy, "0x66775500"});
+    registerConfigVar("group:groupbar:col.border_active", Hyprlang::CConfigCustomValueType{&configHandleGradientSet, configHandleGradientDestroy, "0x00000000"});
+    registerConfigVar("group:groupbar:col.border_inactive", Hyprlang::CConfigCustomValueType{&configHandleGradientSet, configHandleGradientDestroy, "0x00000000"});
+    registerConfigVar("group:groupbar:col.border_locked_active", Hyprlang::CConfigCustomValueType{&configHandleGradientSet, configHandleGradientDestroy, "0x00000000"});
+    registerConfigVar("group:groupbar:col.border_locked_inactive", Hyprlang::CConfigCustomValueType{&configHandleGradientSet, configHandleGradientDestroy, "0x00000000"});
 
     registerConfigVar("render:direct_scanout", Hyprlang::INT{0});
     registerConfigVar("render:expand_undersized_textures", Hyprlang::INT{1});

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -276,24 +276,96 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
         const int BORDERSIZE = std::round(*PGROUPBARBORDERSIZE * pMonitor->m_scale);
 
         if (BORDERSIZE > 0 && !borderGradient.m_colors.empty() && borderGradient.m_colors[0].a > 0) {
-            CBox fullTabBox = {ASSIGNEDBOX.x + xoff - pMonitor->m_position.x + m_window->m_floatingOffset.x,
-                               ASSIGNEDBOX.y + ASSIGNEDBOX.h - floor(yoff) - ONEBARHEIGHT - pMonitor->m_position.y + m_window->m_floatingOffset.y, m_barWidth,
-                               (double)(ONEBARHEIGHT - *POUTERGAP)};
-            fullTabBox.scale(pMonitor->m_scale).round();
-
-            CBorderPassElement::SBorderData borderData;
-            borderData.box = fullTabBox.copy().expand(-BORDERSIZE).round();
-            if (borderData.box.w > 0 && borderData.box.h > 0) {
-                borderData.grad1      = borderGradient;
-                borderData.borderSize = BORDERSIZE;
-                borderData.a          = 1.0;
-
-                if (*PROUNDING || *PGRADIENTROUNDING) {
-                    borderData.round         = std::max(0.0, std::max((double)*PROUNDING, (double)*PGRADIENTROUNDING) * pMonitor->m_scale - BORDERSIZE);
-                    borderData.outerRound    = std::max((double)*PROUNDING, (double)*PGRADIENTROUNDING) * pMonitor->m_scale;
-                    borderData.roundingPower = std::max(*PROUNDINGPOWER, *PGRADIENTROUNDINGPOWER);
+            auto drawBorder = [&](const CBox& box, const CBox& clipBox, int round, float roundingPower) {
+                CBorderPassElement::SBorderData borderData;
+                borderData.box = box.copy().expand(-BORDERSIZE).round();
+                if (borderData.box.w > 0 && borderData.box.h > 0) {
+                    borderData.grad1      = borderGradient;
+                    borderData.borderSize = BORDERSIZE;
+                    borderData.a          = 1.0;
+                    borderData.clipBox    = clipBox;
+                    if (round > 0) {
+                        borderData.round         = std::max(0, (int)(round * pMonitor->m_scale - BORDERSIZE));
+                        borderData.outerRound    = (int)(round * pMonitor->m_scale);
+                        borderData.roundingPower = roundingPower;
+                    }
+                    g_pHyprRenderer->m_renderPass.add(makeUnique<CBorderPassElement>(borderData));
                 }
-                g_pHyprRenderer->m_renderPass.add(makeUnique<CBorderPassElement>(borderData));
+            };
+
+            if (*PINDICATORGAP == 0) {
+                CBox fullTabBox = {ASSIGNEDBOX.x + xoff - pMonitor->m_position.x + m_window->m_floatingOffset.x,
+                                   ASSIGNEDBOX.y + ASSIGNEDBOX.h - floor(yoff) - ONEBARHEIGHT - pMonitor->m_position.y + m_window->m_floatingOffset.y, m_barWidth,
+                                   (double)(ONEBARHEIGHT - *POUTERGAP)};
+                fullTabBox.scale(pMonitor->m_scale).round();
+
+                CBox  box = fullTabBox;
+                CBox  clipBox;
+                int   round         = std::max(*PROUNDING, *PGRADIENTROUNDING);
+                float roundingPower = std::max(*PROUNDINGPOWER, *PGRADIENTROUNDINGPOWER);
+
+                if (*PROUNDONLYEDGES || *PGRADIENTROUNDINGONLYEDGES) {
+                    round               = 0;
+                    const double offset = std::max(*PROUNDING, *PGRADIENTROUNDING) * 2;
+                    if (i == 0) {
+                        round   = std::max(*PROUNDING, *PGRADIENTROUNDING);
+                        clipBox = fullTabBox;
+                        box     = CBox{fullTabBox.pos(), Vector2D{fullTabBox.w + offset, fullTabBox.h}};
+                    } else if (i == barsToDraw - 1) {
+                        round   = std::max(*PROUNDING, *PGRADIENTROUNDING);
+                        clipBox = fullTabBox;
+                        box     = CBox{fullTabBox.pos() - Vector2D{offset, 0.F}, Vector2D{fullTabBox.w + offset, fullTabBox.h}};
+                    }
+                }
+                drawBorder(box, clipBox, round, roundingPower);
+            } else {
+                if (*PGRADIENTS || *PRENDERTITLES) {
+                    CBox titleBox = {ASSIGNEDBOX.x + xoff - pMonitor->m_position.x + m_window->m_floatingOffset.x,
+                                     ASSIGNEDBOX.y + ASSIGNEDBOX.h - floor(yoff) - ONEBARHEIGHT - pMonitor->m_position.y + m_window->m_floatingOffset.y, m_barWidth,
+                                     (double)(*PGRADIENTS || *PRENDERTITLES ? *PHEIGHT : 0)};
+                    titleBox.scale(pMonitor->m_scale).round();
+
+                    CBox box = titleBox;
+                    CBox clipBox;
+                    int  round = *PGRADIENTROUNDING;
+                    if (*PGRADIENTROUNDINGONLYEDGES) {
+                        round               = 0;
+                        const double offset = *PGRADIENTROUNDING * 2;
+                        if (i == 0) {
+                            round   = *PGRADIENTROUNDING;
+                            clipBox = titleBox;
+                            box     = CBox{titleBox.pos(), Vector2D{titleBox.w + offset, titleBox.h}};
+                        } else if (i == barsToDraw - 1) {
+                            round   = *PGRADIENTROUNDING;
+                            clipBox = titleBox;
+                            box     = CBox{titleBox.pos() - Vector2D{offset, 0.F}, Vector2D{titleBox.w + offset, titleBox.h}};
+                        }
+                    }
+                    drawBorder(box, clipBox, round, *PGRADIENTROUNDINGPOWER);
+                }
+
+                CBox indicatorBox = {ASSIGNEDBOX.x + xoff - pMonitor->m_position.x + m_window->m_floatingOffset.x,
+                                     ASSIGNEDBOX.y + ASSIGNEDBOX.h - floor(yoff) - *PINDICATORHEIGHT - *POUTERGAP - pMonitor->m_position.y + m_window->m_floatingOffset.y,
+                                     m_barWidth, (double)*PINDICATORHEIGHT};
+                indicatorBox.scale(pMonitor->m_scale).round();
+
+                CBox box = indicatorBox;
+                CBox clipBox;
+                int  round = *PROUNDING;
+                if (*PROUNDONLYEDGES) {
+                    round               = 0;
+                    const double offset = *PROUNDING * 2;
+                    if (i == 0) {
+                        round   = *PROUNDING;
+                        clipBox = indicatorBox;
+                        box     = CBox{indicatorBox.pos(), Vector2D{indicatorBox.w + offset, indicatorBox.h}};
+                    } else if (i == barsToDraw - 1) {
+                        round   = *PROUNDING;
+                        clipBox = indicatorBox;
+                        box     = CBox{indicatorBox.pos() - Vector2D{offset, 0.F}, Vector2D{indicatorBox.w + offset, indicatorBox.h}};
+                    }
+                }
+                drawBorder(box, clipBox, round, *PROUNDINGPOWER);
             }
         }
 

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -7,6 +7,7 @@
 #include <pango/pangocairo.h>
 #include "../pass/TexPassElement.hpp"
 #include "../pass/RectPassElement.hpp"
+#include "../pass/BorderPassElement.hpp"
 #include "../Renderer.hpp"
 #include "../../managers/input/InputManager.hpp"
 #include "../../layout/LayoutManager.hpp"
@@ -103,33 +104,42 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
     if (!VISIBLE)
         return;
 
-    static auto PRENDERTITLES              = CConfigValue<Hyprlang::INT>("group:groupbar:render_titles");
-    static auto PTITLEFONTSIZE             = CConfigValue<Hyprlang::INT>("group:groupbar:font_size");
-    static auto PHEIGHT                    = CConfigValue<Hyprlang::INT>("group:groupbar:height");
-    static auto PINDICATORGAP              = CConfigValue<Hyprlang::INT>("group:groupbar:indicator_gap");
-    static auto PINDICATORHEIGHT           = CConfigValue<Hyprlang::INT>("group:groupbar:indicator_height");
-    static auto PGRADIENTS                 = CConfigValue<Hyprlang::INT>("group:groupbar:gradients");
-    static auto PSTACKED                   = CConfigValue<Hyprlang::INT>("group:groupbar:stacked");
-    static auto PROUNDING                  = CConfigValue<Hyprlang::INT>("group:groupbar:rounding");
-    static auto PROUNDINGPOWER             = CConfigValue<Hyprlang::FLOAT>("group:groupbar:rounding_power");
-    static auto PGRADIENTROUNDING          = CConfigValue<Hyprlang::INT>("group:groupbar:gradient_rounding");
-    static auto PGRADIENTROUNDINGPOWER     = CConfigValue<Hyprlang::FLOAT>("group:groupbar:gradient_rounding_power");
-    static auto PGRADIENTROUNDINGONLYEDGES = CConfigValue<Hyprlang::INT>("group:groupbar:gradient_round_only_edges");
-    static auto PROUNDONLYEDGES            = CConfigValue<Hyprlang::INT>("group:groupbar:round_only_edges");
-    static auto PGROUPCOLACTIVE            = CConfigValue<Hyprlang::CUSTOMTYPE>("group:groupbar:col.active");
-    static auto PGROUPCOLINACTIVE          = CConfigValue<Hyprlang::CUSTOMTYPE>("group:groupbar:col.inactive");
-    static auto PGROUPCOLACTIVELOCKED      = CConfigValue<Hyprlang::CUSTOMTYPE>("group:groupbar:col.locked_active");
-    static auto PGROUPCOLINACTIVELOCKED    = CConfigValue<Hyprlang::CUSTOMTYPE>("group:groupbar:col.locked_inactive");
-    static auto POUTERGAP                  = CConfigValue<Hyprlang::INT>("group:groupbar:gaps_out");
-    static auto PINNERGAP                  = CConfigValue<Hyprlang::INT>("group:groupbar:gaps_in");
-    static auto PKEEPUPPERGAP              = CConfigValue<Hyprlang::INT>("group:groupbar:keep_upper_gap");
-    static auto PTEXTOFFSET                = CConfigValue<Hyprlang::INT>("group:groupbar:text_offset");
-    static auto PTEXTPADDING               = CConfigValue<Hyprlang::INT>("group:groupbar:text_padding");
-    static auto PBLUR                      = CConfigValue<Hyprlang::INT>("group:groupbar:blur");
-    auto* const GROUPCOLACTIVE             = sc<CGradientValueData*>((PGROUPCOLACTIVE.ptr())->getData());
-    auto* const GROUPCOLINACTIVE           = sc<CGradientValueData*>((PGROUPCOLINACTIVE.ptr())->getData());
-    auto* const GROUPCOLACTIVELOCKED       = sc<CGradientValueData*>((PGROUPCOLACTIVELOCKED.ptr())->getData());
-    auto* const GROUPCOLINACTIVELOCKED     = sc<CGradientValueData*>((PGROUPCOLINACTIVELOCKED.ptr())->getData());
+    static auto PRENDERTITLES                 = CConfigValue<Hyprlang::INT>("group:groupbar:render_titles");
+    static auto PTITLEFONTSIZE                = CConfigValue<Hyprlang::INT>("group:groupbar:font_size");
+    static auto PHEIGHT                       = CConfigValue<Hyprlang::INT>("group:groupbar:height");
+    static auto PINDICATORGAP                 = CConfigValue<Hyprlang::INT>("group:groupbar:indicator_gap");
+    static auto PINDICATORHEIGHT              = CConfigValue<Hyprlang::INT>("group:groupbar:indicator_height");
+    static auto PGRADIENTS                    = CConfigValue<Hyprlang::INT>("group:groupbar:gradients");
+    static auto PSTACKED                      = CConfigValue<Hyprlang::INT>("group:groupbar:stacked");
+    static auto PROUNDING                     = CConfigValue<Hyprlang::INT>("group:groupbar:rounding");
+    static auto PROUNDINGPOWER                = CConfigValue<Hyprlang::FLOAT>("group:groupbar:rounding_power");
+    static auto PGRADIENTROUNDING             = CConfigValue<Hyprlang::INT>("group:groupbar:gradient_rounding");
+    static auto PGRADIENTROUNDINGPOWER        = CConfigValue<Hyprlang::FLOAT>("group:groupbar:gradient_rounding_power");
+    static auto PGRADIENTROUNDINGONLYEDGES    = CConfigValue<Hyprlang::INT>("group:groupbar:gradient_round_only_edges");
+    static auto PROUNDONLYEDGES               = CConfigValue<Hyprlang::INT>("group:groupbar:round_only_edges");
+    static auto PGROUPCOLACTIVE               = CConfigValue<Hyprlang::CUSTOMTYPE>("group:groupbar:col.active");
+    static auto PGROUPCOLINACTIVE             = CConfigValue<Hyprlang::CUSTOMTYPE>("group:groupbar:col.inactive");
+    static auto PGROUPCOLACTIVELOCKED         = CConfigValue<Hyprlang::CUSTOMTYPE>("group:groupbar:col.locked_active");
+    static auto PGROUPCOLINACTIVELOCKED       = CConfigValue<Hyprlang::CUSTOMTYPE>("group:groupbar:col.locked_inactive");
+    static auto PGROUPBARBORDERSIZE           = CConfigValue<Hyprlang::INT>("group:groupbar:border_size");
+    static auto PGROUPCOLBORDERACTIVE         = CConfigValue<Hyprlang::CUSTOMTYPE>("group:groupbar:col.border_active");
+    static auto PGROUPCOLBORDERINACTIVE       = CConfigValue<Hyprlang::CUSTOMTYPE>("group:groupbar:col.border_inactive");
+    static auto PGROUPCOLBORDERLOCKEDACTIVE   = CConfigValue<Hyprlang::CUSTOMTYPE>("group:groupbar:col.border_locked_active");
+    static auto PGROUPCOLBORDERLOCKEDINACTIVE = CConfigValue<Hyprlang::CUSTOMTYPE>("group:groupbar:col.border_locked_inactive");
+    static auto POUTERGAP                     = CConfigValue<Hyprlang::INT>("group:groupbar:gaps_out");
+    static auto PINNERGAP                     = CConfigValue<Hyprlang::INT>("group:groupbar:gaps_in");
+    static auto PKEEPUPPERGAP                 = CConfigValue<Hyprlang::INT>("group:groupbar:keep_upper_gap");
+    static auto PTEXTOFFSET                   = CConfigValue<Hyprlang::INT>("group:groupbar:text_offset");
+    static auto PTEXTPADDING                  = CConfigValue<Hyprlang::INT>("group:groupbar:text_padding");
+    static auto PBLUR                         = CConfigValue<Hyprlang::INT>("group:groupbar:blur");
+    auto* const GROUPCOLACTIVE                = sc<CGradientValueData*>((PGROUPCOLACTIVE.ptr())->getData());
+    auto* const GROUPCOLINACTIVE              = sc<CGradientValueData*>((PGROUPCOLINACTIVE.ptr())->getData());
+    auto* const GROUPCOLACTIVELOCKED          = sc<CGradientValueData*>((PGROUPCOLACTIVELOCKED.ptr())->getData());
+    auto* const GROUPCOLINACTIVELOCKED        = sc<CGradientValueData*>((PGROUPCOLINACTIVELOCKED.ptr())->getData());
+    auto* const GROUPCOLBORDERACTIVE          = sc<CGradientValueData*>((PGROUPCOLBORDERACTIVE.ptr())->getData());
+    auto* const GROUPCOLBORDERINACTIVE        = sc<CGradientValueData*>((PGROUPCOLBORDERINACTIVE.ptr())->getData());
+    auto* const GROUPCOLBORDERLOCKEDACTIVE    = sc<CGradientValueData*>((PGROUPCOLBORDERLOCKEDACTIVE.ptr())->getData());
+    auto* const GROUPCOLBORDERLOCKEDINACTIVE  = sc<CGradientValueData*>((PGROUPCOLBORDERLOCKEDINACTIVE.ptr())->getData());
 
     const auto  ASSIGNEDBOX = assignedBoxGlobal();
 
@@ -251,6 +261,39 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
                 data.box = rect;
                 data.a   = a;
                 g_pHyprRenderer->m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
+            }
+        }
+
+        const bool         ISACTIVE        = m_dwGroupMembers[WINDOWINDEX].lock() == Desktop::focusState()->window();
+        const auto* const  PBORDERACTIVE   = GROUPLOCKED ? GROUPCOLBORDERLOCKEDACTIVE : GROUPCOLBORDERACTIVE;
+        const auto* const  PBORDERINACTIVE = GROUPLOCKED ? GROUPCOLBORDERLOCKEDINACTIVE : GROUPCOLBORDERINACTIVE;
+        CGradientValueData borderGradient  = ISACTIVE ? *PBORDERACTIVE : *PBORDERINACTIVE;
+
+        for (auto& color : borderGradient.m_colors)
+            color.a *= a;
+        borderGradient.updateColorsOk();
+
+        const int BORDERSIZE = std::round(*PGROUPBARBORDERSIZE * pMonitor->m_scale);
+
+        if (BORDERSIZE > 0 && !borderGradient.m_colors.empty() && borderGradient.m_colors[0].a > 0) {
+            CBox fullTabBox = {ASSIGNEDBOX.x + xoff - pMonitor->m_position.x + m_window->m_floatingOffset.x,
+                               ASSIGNEDBOX.y + ASSIGNEDBOX.h - floor(yoff) - ONEBARHEIGHT - pMonitor->m_position.y + m_window->m_floatingOffset.y, m_barWidth,
+                               (double)(ONEBARHEIGHT - *POUTERGAP)};
+            fullTabBox.scale(pMonitor->m_scale).round();
+
+            CBorderPassElement::SBorderData borderData;
+            borderData.box = fullTabBox.copy().expand(-BORDERSIZE).round();
+            if (borderData.box.w > 0 && borderData.box.h > 0) {
+                borderData.grad1      = borderGradient;
+                borderData.borderSize = BORDERSIZE;
+                borderData.a          = 1.0;
+
+                if (*PROUNDING || *PGRADIENTROUNDING) {
+                    borderData.round         = std::max(0.0, std::max((double)*PROUNDING, (double)*PGRADIENTROUNDING) * pMonitor->m_scale - BORDERSIZE);
+                    borderData.outerRound    = std::max((double)*PROUNDING, (double)*PGRADIENTROUNDING) * pMonitor->m_scale;
+                    borderData.roundingPower = std::max(*PROUNDINGPOWER, *PGRADIENTROUNDINGPOWER);
+                }
+                g_pHyprRenderer->m_renderPass.add(makeUnique<CBorderPassElement>(borderData));
             }
         }
 

--- a/src/render/pass/BorderPassElement.cpp
+++ b/src/render/pass/BorderPassElement.cpp
@@ -6,6 +6,9 @@ CBorderPassElement::CBorderPassElement(const CBorderPassElement::SBorderData& da
 }
 
 void CBorderPassElement::draw(const CRegion& damage) {
+    if (!m_data.clipBox.empty())
+        g_pHyprOpenGL->m_renderData.clipBox = m_data.clipBox;
+
     if (m_data.hasGrad2)
         g_pHyprOpenGL->renderBorder(
             m_data.box, m_data.grad1, m_data.grad2, m_data.lerp,
@@ -14,6 +17,8 @@ void CBorderPassElement::draw(const CRegion& damage) {
         g_pHyprOpenGL->renderBorder(
             m_data.box, m_data.grad1,
             {.round = m_data.round, .roundingPower = m_data.roundingPower, .borderSize = m_data.borderSize, .a = m_data.a, .outerRound = m_data.outerRound});
+
+    g_pHyprOpenGL->m_renderData.clipBox = {};
 }
 
 bool CBorderPassElement::needsLiveBlur() {

--- a/src/render/pass/BorderPassElement.hpp
+++ b/src/render/pass/BorderPassElement.hpp
@@ -13,6 +13,7 @@ class CBorderPassElement : public IPassElement {
         float              lerp = 0.F, a = 1.F;
         int                round = 0, borderSize = 1, outerRound = -1;
         float              roundingPower = 2.F;
+        CBox               clipBox;
     };
 
     CBorderPassElement(const SBorderData& data_);


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
 this PR adds border support around groupbar tabs

<img width="1364" height="112" alt="image" src="https://github.com/user-attachments/assets/62788839-4d27-449f-bd73-6aa657726f4d" />

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
 tested and working fine. no known regressions or broken features

#### Is it ready for merging, or does it need work?
nope, should be ready

