### PR TITLE
Scrolling: fix mouse clicks ignoring follow_focus

### DIFF
--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -462,7 +462,6 @@ bool SScrollingData::visible(SP<SColumnData> c) {
 CScrollingAlgorithm::CScrollingAlgorithm() {
     static const auto PCONFWIDTHS    = CConfigValue<Hyprlang::STRING>("scrolling:explicit_column_widths");
     static const auto PCONFDIRECTION = CConfigValue<Hyprlang::STRING>("scrolling:direction");
-    static const auto PFOLLOW_FOCUS  = CConfigValue<Hyprlang::INT>("scrolling:follow_focus");
 
     m_scrollingData       = makeShared<SScrollingData>(this);
     m_scrollingData->self = m_scrollingData;
@@ -497,16 +496,20 @@ CScrollingAlgorithm::CScrollingAlgorithm() {
         m_scrollingData->controller->setDirection(parseDirection(*PCONFDIRECTION));
     });
 
-    if (*PFOLLOW_FOCUS) {
-        m_mouseButtonCallback = Event::bus()->m_events.input.mouse.button.listen([this](IPointer::SButtonEvent e, Event::SCallbackInfo&) {
-            if (e.state == WL_POINTER_BUTTON_STATE_RELEASED && Desktop::focusState()->window())
-                focusOnInput(Desktop::focusState()->window()->layoutTarget(), true);
-        });
-    }
+    m_mouseButtonCallback = Event::bus()->m_events.input.mouse.button.listen([this](IPointer::SButtonEvent e, Event::SCallbackInfo&) {
+        static const auto PFOLLOW_FOCUS = CConfigValue<Hyprlang::INT>("scrolling:follow_focus");
+        if (!*PFOLLOW_FOCUS)
+            return;
+
+        if (e.state == WL_POINTER_BUTTON_STATE_RELEASED && Desktop::focusState()->window())
+            focusOnInput(Desktop::focusState()->window()->layoutTarget(), true);
+    });
 
     m_focusCallback = Event::bus()->m_events.window.active.listen([this](PHLWINDOW pWindow, Desktop::eFocusReason reason) {
         if (!pWindow)
             return;
+
+        static const auto PFOLLOW_FOCUS = CConfigValue<Hyprlang::INT>("scrolling:follow_focus");
 
         if (!*PFOLLOW_FOCUS && !Desktop::isHardInputFocusReason(reason))
             return;


### PR DESCRIPTION
There was a major regression introduced with #12890 that significantly impacted my workflow.
Having `scrolling:follow_focus = 0`, I'd expect mouse events such as hovering and clicking to have no impact on the layout.
However, since this pr, that hasn't been the case at all.
Whenever I'd try to select a side app to write something, or even drag and drop an image onto discord, it would get focused and my layout would shift to the side.
There's more info on the original forum post I made about this issue:
https://forum.hypr.land/t/scrolling-layout-regressions/1427

I would like to mention that I am not familiar with the codebase, I simply opened the file that seemed the most relevant, looked for `mouse`, and just happened to find what caused my issue.
Fully commenting the thing out works too, but I decided to add an if check just in case that's preferred.
Although I am failing to see when you would run into a case where the window is clicked, but not previously focused, which `scrolling:follow_focus = 1` would already take care of anyways.
I did some light testing on my end, and this significantly improved my experience with no unexpected issues.

This would require a deeper review and more serious testing that I haven't done.
I would also like to note that I defined `PFOLLOW_FOCUS` on top of the function as it's used in multiple places, do let me know if this should be changed.