### PR TITLE
popup: check for expired weak ptr

### DIFF
--- a/src/desktop/view/Popup.cpp
+++ b/src/desktop/view/Popup.cpp
@@ -403,7 +403,7 @@ void CPopup::recheckChildrenRecursive() {
     std::vector<WP<CPopup>> cpy;
     std::ranges::for_each(m_children, [&cpy](const auto& el) { cpy.emplace_back(el); });
     for (auto const& c : cpy) {
-        if (!c->visible())
+        if (!c || !c->visible())
             continue;
         c->onCommit(true);
         c->recheckChildrenRecursive();


### PR DESCRIPTION
onCommit can destroy popups while the vector CPY still holds a weak ptr to it, check if the weak ptr is still valid



