### PR TITLE
view: send wl_surface.enter to subsurfaces of popups

### DIFF
--- a/src/desktop/view/Popup.cpp
+++ b/src/desktop/view/Popup.cpp
@@ -199,7 +199,7 @@ void CPopup::onMap() {
 
     //unconstrain();
     sendScale();
-    m_resource->m_surface->m_surface->enter(PMONITOR->m_self.lock());
+    m_wlSurface->resource()->breadthfirst([PMONITOR](SP<CWLSurfaceResource> s, const Vector2D& offset, void* d) { s->enter(PMONITOR->m_self.lock()); }, nullptr);
 
     if (!m_layerOwner.expired() && m_layerOwner->m_layer < ZWLR_LAYER_SHELL_V1_LAYER_TOP)
         g_pHyprOpenGL->markBlurDirtyForMonitor(g_pCompositor->getMonitorFromID(m_layerOwner->m_layer));


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fix https://github.com/hyprwm/Hyprland/discussions/13346

`CPopup::onMap()` was only sending `wl_surface.enter` to the popup's own surface. Subsurfaces of the popup never received `enter`

IntelliJ is using Fifo, commit got locked, but the subsurface to which it was bound was never presented due to missing `enter` resulting in complete freeze by the Fifo lock

Fix by using `breadthfirst` instead of a direct `enter()` call, matching what `CWindow::updateSurfaceScaleTransformDetails()` already does for window surfaces

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
- `CLayerSurface::onMap()` has the same single-surface `enter()` pattern and should probably also use `breadthfirst`
- `sendScale()` only sends preferred scale to the popup's own surface

#### Is it ready for merging, or does it need work?
Ready