### PR TITLE
fix(xwayland): normalize override-redirect geometry to logical coords with force_zero_scaling

### DIFF
--- a/src/layout/algorithm/floating/default/DefaultFloatingAlgorithm.cpp
+++ b/src/layout/algorithm/floating/default/DefaultFloatingAlgorithm.cpp
@@ -102,13 +102,7 @@ void CDefaultFloatingAlgorithm::newTarget(SP<ITarget> target) {
 
     // TODO: not very OOP, is it?
     if (const auto WTARGET = dynamicPointerCast<CWindowTarget>(target); WTARGET) {
-        static auto PXWLFORCESCALEZERO = CConfigValue<Hyprlang::INT>("xwayland:force_zero_scaling");
-
-        const auto  PWINDOW  = WTARGET->window();
-        const auto  PMONITOR = WTARGET->space()->workspace()->m_monitor.lock();
-
-        if (*PXWLFORCESCALEZERO && PWINDOW->m_isX11)
-            *PWINDOW->m_realSize = PWINDOW->m_realSize->goal() / PMONITOR->m_scale;
+        const auto PWINDOW = WTARGET->window();
 
         if (PWINDOW->m_X11DoesntWantBorders || (PWINDOW->m_isX11 && PWINDOW->isX11OverrideRedirect())) {
             PWINDOW->m_realPosition->warp();

--- a/src/layout/target/WindowTarget.cpp
+++ b/src/layout/target/WindowTarget.cpp
@@ -266,6 +266,12 @@ std::expected<SGeometryRequested, eGeometryFailure> CWindowTarget::desiredGeomet
         return std::unexpected(GEOMETRY_NO_DESIRED);
     }
 
+    static auto PXWLFORCESCALEZERO = CConfigValue<Hyprlang::INT>("xwayland:force_zero_scaling");
+    const auto  toLogical          = [&](SGeometryRequested& req) {
+        if (m_window->m_isX11 && *PXWLFORCESCALEZERO && PMONITOR)
+            req.size /= PMONITOR->m_scale;
+    };
+
     if (DESIRED_GEOM.width <= 2 || DESIRED_GEOM.height <= 2) {
         const auto SURFACE = m_window->wlSurface()->resource();
 
@@ -273,6 +279,7 @@ std::expected<SGeometryRequested, eGeometryFailure> CWindowTarget::desiredGeomet
             // center on mon and call it a day
             requested.pos.reset();
             requested.size = clampSizeForDesired(SURFACE->m_current.size);
+            toLogical(requested);
             return requested;
         }
 
@@ -285,6 +292,7 @@ std::expected<SGeometryRequested, eGeometryFailure> CWindowTarget::desiredGeomet
             if (m_window->m_xwaylandSurface->m_geometry.x != 0 && m_window->m_xwaylandSurface->m_geometry.y != 0) {
                 requested.size = SIZE;
                 requested.pos  = g_pXWaylandManager->xwaylandToWaylandCoords(m_window->m_xwaylandSurface->m_geometry.pos());
+                toLogical(requested);
                 return requested;
             }
         }
@@ -318,6 +326,7 @@ std::expected<SGeometryRequested, eGeometryFailure> CWindowTarget::desiredGeomet
     if (DESIRED_GEOM.w <= 2 || DESIRED_GEOM.h <= 2)
         return std::unexpected(GEOMETRY_NO_DESIRED);
 
+    toLogical(requested);
     return requested;
 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes X11 popups, tooltips, and menus showing black boxes on scaled monitors with `xwayland:force_zero_scaling = 1` https://github.com/hyprwm/Hyprland/discussions/13334

`desiredGeometry()` was returning sizes in XWayland pixel coords, but everything downstream expects logical coords. This caused oversized buffers where content only filled part of the area.

Convert X11 sizes to logical in `desiredGeometry()` itself, remove the redundant downstream divisions and fix `unmanagedSetGeometry()` comparing pixel against logical.

#### Is there anything you want to mention?
No

#### Is it ready for merging, or does it need work?
Ready
