### PR TITLE
fix(xwayland): validate size hints before floating

### DIFF
--- a/hyprtester/src/tests/main/window.cpp
+++ b/hyprtester/src/tests/main/window.cpp
@@ -679,14 +679,14 @@ static bool test() {
     EXPECT(Tests::windowCount(), 3);
 
     NLog::log("{}Checking props of xeyes", Colors::YELLOW);
-    // check some window props of xeyes, try to tile them
+    // check some window props of xeyes, try to float it
     {
         auto str = getFromSocket("/clients");
-        EXPECT_CONTAINS(str, "floating: 1");
-        getFromSocket("/dispatch settiled class:XEyes");
+        EXPECT_NOT_CONTAINS(str, "floating: 1");
+        getFromSocket("/dispatch setfloating class:XEyes");
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
         str = getFromSocket("/clients");
-        EXPECT_NOT_CONTAINS(str, "floating: 1");
+        EXPECT_CONTAINS(str, "floating: 1");
     }
 
     // kill all

--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -129,7 +129,8 @@ bool CHyprXWaylandManager::shouldBeFloated(PHLWINDOW pWindow, bool pending) {
 
         const auto SIZEHINTS = pWindow->m_xwaylandSurface->m_sizeHints.get();
         if (pWindow->m_xwaylandSurface->m_transient || pWindow->m_xwaylandSurface->m_parent ||
-            (SIZEHINTS && (SIZEHINTS->min_width == SIZEHINTS->max_width) && (SIZEHINTS->min_height == SIZEHINTS->max_height)))
+            (SIZEHINTS && SIZEHINTS->min_width > 0 && SIZEHINTS->min_height > 0 && SIZEHINTS->max_width > 0 && SIZEHINTS->max_height > 0 &&
+             (SIZEHINTS->min_width == SIZEHINTS->max_width) && (SIZEHINTS->min_height == SIZEHINTS->max_height)))
             return true;
     } else {
         if (!pWindow->m_xdgSurface || !pWindow->m_xdgSurface->m_toplevel)


### PR DESCRIPTION
Some xwayland clients may not send min/max size hints `WM_NORMAL_HINTS` and hyprland as a placeholder makes them all -1 then it compares if max == min and since it matches hyprland makes the window float.

Fix it by ensuring all sizes are greater than 0

Fixes https://github.com/hyprwm/Hyprland/discussions/12786

I am not sure if it's the correct fix but it works