### PR TITLE
input: use fresh cursor pos when sending motion events

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -193,7 +193,7 @@ void CInputManager::sendMotionEventsToFocused() {
 
     m_emptyFocusCursorSet = false;
 
-    g_pSeatManager->setPointerFocus(Desktop::focusState()->surface(), m_lastCursorPosFloored - BOX->pos());
+    g_pSeatManager->setPointerFocus(Desktop::focusState()->surface(), getMouseCoordsInternal().floor() - BOX->pos());
 }
 
 void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, std::optional<Vector2D> overridePos) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

fixes #12764 
in commit beb1b578e89a21a32f6d0685dc52b7503c9541ff we were using `m_lastCursorPosFloored` which is wrong i guess when going between 2 monitors. They're in 2 different coordinate spaces whereas when switching workspace on the same monitor wouldn't really lead to issues (i have no idea what i'm talking about)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

yeah maybe i'm stupid or fix is somewhere else

#### Is it ready for merging, or does it need work?

yea ig :D

