### PR TITLE
general: add focus_based_zorder option

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -971,6 +971,84 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
             return nullptr;
         };
 
+        static auto PFOCUSZORDER = CConfigValue<Hyprlang::INT>("general:focus_based_zorder");
+
+        if (*PFOCUSZORDER && !(properties & Desktop::View::FLOATING_ONLY)) {
+            // Focus-based z-order: hit-test all windows by focus order (most recent first)
+            const WORKSPACEID WSPID      = special ? PMONITOR->activeSpecialWorkspaceID() : PMONITOR->activeWorkspaceID();
+            const auto        PWORKSPACE = getWorkspaceByID(WSPID);
+
+            if (PWORKSPACE->m_hasFullscreenWindow && !(properties & Desktop::View::SKIP_FULLSCREEN_PRIORITY) && !ONLY_PRIORITY) {
+                const auto FS_WINDOW = PWORKSPACE->getFullscreenWindow();
+
+                if (!FS_WINDOW)
+                    return nullptr;
+
+                if (FS_WINDOW->m_fullscreenState.internal != FSMODE_MAXIMIZED || FS_WINDOW->getWindowBoxUnified(properties).containsPoint(pos))
+                    return PWORKSPACE->getFullscreenWindow();
+                else
+                    return nullptr;
+            }
+
+            // Build candidate list and sort by focus order descending (most recently focused first)
+            std::vector<PHLWINDOW> candidates;
+            for (auto const& w : m_windows) {
+                if (!w->m_isMapped || w->isHidden() || w->m_pinned || !w->m_workspace || !w->m_workspace->isVisible())
+                    continue;
+                if (ONLY_PRIORITY && !w->priorityFocus())
+                    continue;
+                if (w->m_ruleApplicator->noFocus().valueOrDefault() || w == pIgnoreWindow || isShadowedByModal(w))
+                    continue;
+                if (special != w->onSpecialWorkspace())
+                    continue;
+                if (!w->m_isFloating && w->workspaceID() != WSPID)
+                    continue;
+                if (w->m_X11ShouldntFocus && !(w->m_isX11 && w->isX11OverrideRedirect()))
+                    continue;
+
+                if (w->m_isFloating) {
+                    const auto PWINDOWMONITOR = w->m_monitor.lock();
+                    if (!*PSPECIALFALLTHRU && PWINDOWMONITOR && PWINDOWMONITOR->m_activeSpecialWorkspace && w->m_workspace != PWINDOWMONITOR->m_activeSpecialWorkspace) {
+                        const auto BB = w->getWindowBoxUnified(properties);
+                        if (BB.x >= PWINDOWMONITOR->m_position.x && BB.y >= PWINDOWMONITOR->m_position.y &&
+                            BB.x + BB.width <= PWINDOWMONITOR->m_position.x + PWINDOWMONITOR->m_size.x &&
+                            BB.y + BB.height <= PWINDOWMONITOR->m_position.y + PWINDOWMONITOR->m_size.y)
+                            continue;
+                    }
+                }
+
+                candidates.push_back(w);
+            }
+
+            std::sort(candidates.begin(), candidates.end(), [](const PHLWINDOW& a, const PHLWINDOW& b) { return a->m_focusOrder > b->m_focusOrder; });
+
+            // Check popups first (in focus order)
+            for (auto const& w : candidates) {
+                if (!w->m_isX11 && w->hasPopupAt(pos))
+                    return w;
+            }
+
+            // Check window bodies (in focus order)
+            for (auto const& w : candidates) {
+                CBox box;
+                if (w->m_isFloating) {
+                    box = w->getWindowBoxUnified(properties).copy().expand(!w->isX11OverrideRedirect() ? BORDER_GRAB_AREA : 0);
+                } else {
+                    box = (properties & Desktop::View::USE_PROP_TILED) ? w->getWindowBoxUnified(properties) : CBox{w->m_position, w->m_size};
+                    if ((properties & Desktop::View::INPUT_EXTENTS) && BORDER_GRAB_AREA > 0 && !w->isX11OverrideRedirect())
+                        box.expand(BORDER_GRAB_AREA);
+                }
+
+                if (box.containsPoint(pos)) {
+                    if (w->m_isX11 && w->isX11OverrideRedirect() && !w->m_xwaylandSurface->wantsFocus())
+                        return Desktop::focusState()->window();
+                    return w;
+                }
+            }
+
+            return nullptr;
+        }
+
         if (properties & Desktop::View::ALLOW_FLOATING) {
             // first loop over floating cuz they're above, m_lWindows should be sorted bottom->top, for tiled it doesn't matter.
             auto found = floating(true);

--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -474,6 +474,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("general:snap:monitor_gap", Hyprlang::INT{10});
     registerConfigVar("general:snap:border_overlap", Hyprlang::INT{0});
     registerConfigVar("general:snap:respect_gaps", Hyprlang::INT{0});
+    registerConfigVar("general:focus_based_zorder", Hyprlang::INT{0});
     registerConfigVar("general:col.active_border", Hyprlang::CConfigCustomValueType{&configHandleGradientSet, configHandleGradientDestroy, "0xffffffff"});
     registerConfigVar("general:col.inactive_border", Hyprlang::CConfigCustomValueType{&configHandleGradientSet, configHandleGradientDestroy, "0xff444444"});
     registerConfigVar("general:col.nogroup_border", Hyprlang::CConfigCustomValueType{&configHandleGradientSet, configHandleGradientDestroy, "0xffffaaff"});

--- a/src/desktop/state/FocusState.cpp
+++ b/src/desktop/state/FocusState.cpp
@@ -193,6 +193,10 @@ void CFocusState::rawWindowFocus(PHLWINDOW pWindow, eFocusReason reason, SP<CWLS
     pWindow->onFocusAnimUpdate();
     pWindow->updateDecorationValues();
 
+    // Update focus order for focus-based z-ordering
+    static uint64_t focusOrderCounter = 0;
+    pWindow->m_focusOrder             = ++focusOrderCounter;
+
     if (pWindow->m_isUrgent)
         pWindow->m_isUrgent = false;
 

--- a/src/desktop/view/Window.hpp
+++ b/src/desktop/view/Window.hpp
@@ -254,6 +254,9 @@ namespace Desktop::View {
         // ANR
         PHLANIMVAR<float> m_notRespondingTint;
 
+        // For focus-based z-order rendering
+        uint64_t m_focusOrder = 0;
+
         // For the noclosefor windowrule
         Time::steady_tp m_closeableSince = Time::steadyNow();
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -395,83 +395,114 @@ void CHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
         windows.emplace_back(w);
     }
 
-    // Non-floating main
-    for (auto& w : windows) {
-        if (w->m_isFloating)
-            continue; // floating are in the second pass
+    static auto PFOCUSZORDER = CConfigValue<Hyprlang::INT>("general:focus_based_zorder");
 
-        // some things may force us to ignore the special/not special disparity
-        const bool IGNORE_SPECIAL_CHECK = w->m_monitorMovedFrom != -1 && (w->m_workspace && !w->m_workspace->isVisible());
+    if (*PFOCUSZORDER) {
+        // Focus-based z-order: render all windows in focus order, regardless of tiled/floating status.
+        // Windows with higher m_focusOrder were focused more recently and render on top.
+        std::stable_sort(windows.begin(), windows.end(), [](const PHLWINDOWREF& a, const PHLWINDOWREF& b) { return a->m_focusOrder < b->m_focusOrder; });
 
-        if (!IGNORE_SPECIAL_CHECK && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
-            continue;
+        // Main + popup pass for all non-pinned windows
+        for (auto& w : windows) {
+            if (w->m_pinned)
+                continue;
 
-        // render active window after all others of this pass
-        if (w == Desktop::focusState()->window()) {
-            lastWindow = w.lock();
-            continue;
+            const bool IGNORE_SPECIAL_CHECK = w->m_monitorMovedFrom != -1 && (w->m_workspace && !w->m_workspace->isVisible());
+
+            if (!IGNORE_SPECIAL_CHECK && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
+                continue;
+
+            if (w->m_isFloating && pWorkspace->m_isSpecialWorkspace && w->m_monitor != pWorkspace->m_monitor)
+                continue;
+
+            if (w->m_fadingOut) {
+                renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_MAIN);
+                continue;
+            }
+
+            renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_ALL);
         }
+    } else {
+        // Default behavior: tiled windows first, floating on top.
 
-        // render tiled fading out after others
-        if (w->m_fadingOut) {
-            tiledFadingOut.emplace_back(w);
+        // Non-floating main
+        for (auto& w : windows) {
+            if (w->m_isFloating)
+                continue; // floating are in the second pass
+
+            // some things may force us to ignore the special/not special disparity
+            const bool IGNORE_SPECIAL_CHECK = w->m_monitorMovedFrom != -1 && (w->m_workspace && !w->m_workspace->isVisible());
+
+            if (!IGNORE_SPECIAL_CHECK && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
+                continue;
+
+            // render active window after all others of this pass
+            if (w == Desktop::focusState()->window()) {
+                lastWindow = w.lock();
+                continue;
+            }
+
+            // render tiled fading out after others
+            if (w->m_fadingOut) {
+                tiledFadingOut.emplace_back(w);
+                w.reset();
+                continue;
+            }
+
+            // render the bad boy
+            renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_MAIN);
             w.reset();
-            continue;
         }
 
-        // render the bad boy
-        renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_MAIN);
-        w.reset();
-    }
+        if (lastWindow)
+            renderWindow(lastWindow, pMonitor, time, true, RENDER_PASS_MAIN);
 
-    if (lastWindow)
-        renderWindow(lastWindow, pMonitor, time, true, RENDER_PASS_MAIN);
+        lastWindow.reset();
 
-    lastWindow.reset();
+        // render tiled windows that are fading out after other tiled to not hide them behind
+        for (auto& w : tiledFadingOut) {
+            renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_MAIN);
+        }
 
-    // render tiled windows that are fading out after other tiled to not hide them behind
-    for (auto& w : tiledFadingOut) {
-        renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_MAIN);
-    }
+        // Non-floating popup
+        for (auto& w : windows) {
+            if (!w)
+                continue;
 
-    // Non-floating popup
-    for (auto& w : windows) {
-        if (!w)
-            continue;
+            if (w->m_isFloating)
+                continue; // floating are in the second pass
 
-        if (w->m_isFloating)
-            continue; // floating are in the second pass
+            // some things may force us to ignore the special/not special disparity
+            const bool IGNORE_SPECIAL_CHECK = w->m_monitorMovedFrom != -1 && (w->m_workspace && !w->m_workspace->isVisible());
 
-        // some things may force us to ignore the special/not special disparity
-        const bool IGNORE_SPECIAL_CHECK = w->m_monitorMovedFrom != -1 && (w->m_workspace && !w->m_workspace->isVisible());
+            if (!IGNORE_SPECIAL_CHECK && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
+                continue;
 
-        if (!IGNORE_SPECIAL_CHECK && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
-            continue;
+            // render the bad boy
+            renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_POPUP);
+            w.reset();
+        }
 
-        // render the bad boy
-        renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_POPUP);
-        w.reset();
-    }
+        // floating on top
+        for (auto& w : windows) {
+            if (!w)
+                continue;
 
-    // floating on top
-    for (auto& w : windows) {
-        if (!w)
-            continue;
+            if (!w->m_isFloating || w->m_pinned)
+                continue;
 
-        if (!w->m_isFloating || w->m_pinned)
-            continue;
+            // some things may force us to ignore the special/not special disparity
+            const bool IGNORE_SPECIAL_CHECK = w->m_monitorMovedFrom != -1 && (w->m_workspace && !w->m_workspace->isVisible());
 
-        // some things may force us to ignore the special/not special disparity
-        const bool IGNORE_SPECIAL_CHECK = w->m_monitorMovedFrom != -1 && (w->m_workspace && !w->m_workspace->isVisible());
+            if (!IGNORE_SPECIAL_CHECK && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
+                continue;
 
-        if (!IGNORE_SPECIAL_CHECK && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
-            continue;
+            if (pWorkspace->m_isSpecialWorkspace && w->m_monitor != pWorkspace->m_monitor)
+                continue; // special on another are rendered as a part of the base pass
 
-        if (pWorkspace->m_isSpecialWorkspace && w->m_monitor != pWorkspace->m_monitor)
-            continue; // special on another are rendered as a part of the base pass
-
-        // render the bad boy
-        renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_ALL);
+            // render the bad boy
+            renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_ALL);
+        }
     }
 }
 


### PR DESCRIPTION
Adds `general:focus_based_zorder` (default false) which makes z-order follow focus history instead of always rendering floating above tiled.

When enabled, the most recently focused window renders on top regardless of type. Input hit-testing is also updated to match the visual stacking.