### PR TITLE
fix(monitor): keep workspace monitor bindings on full reconnect

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -3042,6 +3042,27 @@ void CCompositor::ensurePersistentWorkspacesPresent(const std::vector<SWorkspace
     }
 }
 
+void CCompositor::ensureWorkspacesOnAssignedMonitors() {
+    for (auto const& ws : getWorkspacesCopy()) {
+        if (!valid(ws) || ws->m_isSpecialWorkspace)
+            continue;
+
+        const auto RULE = g_pConfigManager->getWorkspaceRuleFor(ws);
+        if (RULE.monitor.empty())
+            continue;
+
+        const auto PMONITOR = getMonitorFromString(RULE.monitor);
+        if (!PMONITOR)
+            continue;
+
+        if (ws->m_monitor == PMONITOR)
+            continue;
+
+        Log::logger->log(Log::DEBUG, "ensureWorkspacesOnAssignedMonitors: moving workspace {} to {}", ws->m_name, PMONITOR->m_name);
+        moveWorkspaceToMonitor(ws, PMONITOR, true);
+    }
+}
+
 std::optional<unsigned int> CCompositor::getVTNr() {
     if (!m_aqBackend->hasSession())
         return std::nullopt;

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -161,6 +161,7 @@ class CCompositor {
     void                                updateSuspendedStates();
     void                                onNewMonitor(SP<Aquamarine::IOutput> output);
     void                                ensurePersistentWorkspacesPresent(const std::vector<SWorkspaceRule>& rules, PHLWORKSPACE pWorkspace = nullptr);
+    void                                ensureWorkspacesOnAssignedMonitors();
     std::optional<unsigned int>         getVTNr();
     bool                                isVRRActiveOnAnyMonitor() const;
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
This PR fixes a monitor reconnect edge case where non-active workspaces could migrate to the wrong output after all monitors were disconnected and then reconnected.

Repro:
- With multiple monitors and workspace monitor rules configured
- Disconnect all monitors
- Reconnect one monitor
- Non-active workspaces from another monitor could get moved to the first reconnected output, ignoring monitor bindings

Fix:
- Preserve workspace ownership across cascaded disconnects by keeping the first recorded `m_lastMonitor`
- Only do temporary recovery for truly orphaned workspaces
- Re-apply assigned workspace monitor bindings on monitor connect `(ensureWorkspacesOnAssignedMonitors())`

Result:
- Non-active workspaces no longer migrate to the wrong output after full reconnect
- Workspace monitor rules are respected again after reconnect

https://github.com/hyprwm/Hyprland/issues/9580
https://github.com/hyprwm/Hyprland/discussions/9158

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No known breaking changes.
Behavior change is intentional: workspaces with explicit `workspace ... monitor:` bindings are now enforced on reconnect.

#### Is it ready for merging, or does it need work?
Ready for merging.

