### PR TITLE
fix(build): remove auto-generated hyprctl/hw-protocols/ files during …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ nopch:
 clear:
 	rm -rf build
 	rm -f ./protocols/*.h ./protocols/*.c ./protocols/*.cpp ./protocols/*.hpp
+	rm -f ./hyprctl/hw-protocols/*.cpp ./hyprctl/hw-protocols/*.hpp
 
 all:
 	$(MAKE) clear


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

When compiling latest v0.54.0, got error due to stale files in `./hyprctl/hw-protocols/`
Remove those files as part of the `make clear` target.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Ready for merge.
