### PR TITLE
format: safeguard drmGetFormat functions

### DIFF
--- a/src/helpers/Format.cpp
+++ b/src/helpers/Format.cpp
@@ -314,14 +314,22 @@ uint32_t NFormatUtils::glFormatToType(uint32_t gl) {
 }
 
 std::string NFormatUtils::drmFormatName(DRMFormat drm) {
-    auto        n    = drmGetFormatName(drm);
+    auto n = drmGetFormatName(drm);
+
+    if (!n)
+        return "unknown";
+
     std::string name = n;
     free(n); // NOLINT(cppcoreguidelines-no-malloc,-warnings-as-errors)
     return name;
 }
 
 std::string NFormatUtils::drmModifierName(uint64_t mod) {
-    auto        n    = drmGetFormatModifierName(mod);
+    auto n = drmGetFormatModifierName(mod);
+
+    if (!n)
+        return "unknown";
+
     std::string name = n;
     free(n); // NOLINT(cppcoreguidelines-no-malloc,-warnings-as-errors)
     return name;


### PR DESCRIPTION
they can return null if not found.


