### PR TITLE
desktop/group: fix movegroupwindow not following focus

### DIFF
--- a/hyprtester/src/tests/main/groups.cpp
+++ b/hyprtester/src/tests/main/groups.cpp
@@ -127,6 +127,34 @@ static bool test() {
         ret = 1;
     }
 
+    // test movegroupwindow: focus should follow the moved window
+    NLog::log("{}Test movegroupwindow focus follows window", Colors::YELLOW);
+    try {
+        auto str              = getFromSocket("/activewindow");
+        auto activeBeforeMove = std::stoull(str.substr(7, str.find(" -> ") - 7), nullptr, 16);
+        OK(getFromSocket("/dispatch movegroupwindow f"));
+        str                  = getFromSocket("/activewindow");
+        auto activeAfterMove = std::stoull(str.substr(7, str.find(" -> ") - 7), nullptr, 16);
+        EXPECT(activeAfterMove, activeBeforeMove);
+    } catch (...) {
+        NLog::log("{}Fail at getting prop", Colors::RED);
+        ret = 1;
+    }
+
+    // and backwards
+    NLog::log("{}Test movegroupwindow backwards", Colors::YELLOW);
+    try {
+        auto str              = getFromSocket("/activewindow");
+        auto activeBeforeMove = std::stoull(str.substr(7, str.find(" -> ") - 7), nullptr, 16);
+        OK(getFromSocket("/dispatch movegroupwindow b"));
+        str                  = getFromSocket("/activewindow");
+        auto activeAfterMove = std::stoull(str.substr(7, str.find(" -> ") - 7), nullptr, 16);
+        EXPECT(activeAfterMove, activeBeforeMove);
+    } catch (...) {
+        NLog::log("{}Fail at getting prop", Colors::RED);
+        ret = 1;
+    }
+
     NLog::log("{}Disable autogrouping", Colors::YELLOW);
     OK(getFromSocket("/keyword group:auto_group false"));
 

--- a/src/desktop/view/Group.cpp
+++ b/src/desktop/view/Group.cpp
@@ -317,6 +317,7 @@ void CGroup::swapWithNext() {
 
     size_t     idx = m_current + 1 >= m_windows.size() ? 0 : m_current + 1;
     std::iter_swap(m_windows.begin() + m_current, m_windows.begin() + idx);
+    m_current = idx;
 
     updateWindowVisibility();
 
@@ -329,6 +330,7 @@ void CGroup::swapWithLast() {
 
     size_t     idx = m_current == 0 ? m_windows.size() - 1 : m_current - 1;
     std::iter_swap(m_windows.begin() + m_current, m_windows.begin() + idx);
+    m_current = idx;
 
     updateWindowVisibility();
 


### PR DESCRIPTION
The `swapWithNext`/`swapWithLast` methods swap entries in the vector but don't update `m_current`, so focus stays on the old index (now occupied by the swapped-in window) instead of following the moved window.

Fix https://github.com/hyprwm/Hyprland/discussions/13424.