### PR TITLE
layouts: fix crash on missed relayout updates

### DIFF
--- a/hyprtester/src/tests/main/layout.cpp
+++ b/hyprtester/src/tests/main/layout.cpp
@@ -33,6 +33,19 @@ static void swar() {
     Tests::killAllWindows();
 }
 
+// Don't crash when focus after global geometry changes
+static void testCrashOnGeomUpdate() {
+    Tests::spawnKitty();
+    Tests::spawnKitty();
+    Tests::spawnKitty();
+
+    // move the layout
+    OK(getFromSocket("/keyword monitor HEADLESS-2,1920x1080@60,1000x0,1"));
+
+    // shouldnt crash
+    OK(getFromSocket("/dispatch movefocus r"));
+}
+
 static bool test() {
     NLog::log("{}Testing layout generic", Colors::GREEN);
 
@@ -42,6 +55,8 @@ static bool test() {
     // test
     NLog::log("{}Testing `single_window_aspect_ratio`", Colors::GREEN);
     swar();
+
+    testCrashOnGeomUpdate();
 
     // clean up
     NLog::log("Cleaning up", Colors::YELLOW);

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2772,6 +2772,7 @@ void CCompositor::arrangeMonitors() {
     }
 
     PROTO::xdgOutput->updateAllOutputs();
+    Event::bus()->m_events.monitor.layoutChanged.emit();
 
 #ifndef NO_XWAYLAND
     const auto box = g_pCompositor->calculateX11WorkArea();

--- a/src/layout/LayoutManager.cpp
+++ b/src/layout/LayoutManager.cpp
@@ -11,13 +11,7 @@
 
 using namespace Layout;
 
-CLayoutManager::CLayoutManager() {
-    static auto P = Event::bus()->m_events.monitor.layoutChanged.listen([] {
-        for (const auto& ws : g_pCompositor->getWorkspaces()) {
-            ws->m_space->recheckWorkArea();
-        }
-    });
-}
+CLayoutManager::CLayoutManager() = default;
 
 void CLayoutManager::newTarget(SP<ITarget> target, SP<CSpace> space) {
     // on a new target: remember desired pos for float, if available

--- a/src/layout/space/Space.cpp
+++ b/src/layout/space/Space.cpp
@@ -6,6 +6,7 @@
 #include "../../debug/log/Logger.hpp"
 #include "../../desktop/Workspace.hpp"
 #include "../../config/ConfigManager.hpp"
+#include "../../event/EventBus.hpp"
 
 using namespace Layout;
 
@@ -17,6 +18,12 @@ SP<CSpace> CSpace::create(PHLWORKSPACE w) {
 
 CSpace::CSpace(PHLWORKSPACE parent) : m_parent(parent) {
     recheckWorkArea();
+
+    // NOLINTNEXTLINE
+    m_geomUpdateCallback = Event::bus()->m_events.monitor.layoutChanged.listen([this] {
+        recheckWorkArea();
+        m_algorithm->recalculate();
+    });
 }
 
 void CSpace::add(SP<ITarget> t) {

--- a/src/layout/space/Space.hpp
+++ b/src/layout/space/Space.hpp
@@ -63,5 +63,8 @@ namespace Layout {
 
         // work area is in global coords
         CBox m_workArea, m_floatingWorkArea;
+
+        // for recalc
+        CHyprSignalListener m_geomUpdateCallback;
     };
 };


### PR DESCRIPTION
Fixes a crash when layout is updated and we don't manually trigger a workspace update