### PR TITLE
layout/scrolling: fix size_t underflow in idxForHeight

### DIFF
--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -190,10 +190,12 @@ size_t SColumnData::idx(SP<ITarget> t) {
 }
 
 size_t SColumnData::idxForHeight(float y) {
+    if (targetDatas.empty())
+        return 0;
     for (size_t i = 0; i < targetDatas.size(); ++i) {
         if (targetDatas[i]->target->position().y < y)
             continue;
-        return i - 1;
+        return i == 0 ? 0 : i - 1;
     }
     return targetDatas.size() - 1;
 }


### PR DESCRIPTION

#### Describe your PR, what does it fix/add?
Fixes a size_t underflow in idxForHeight where a wrapped-around value passed as int after would cause issues.
Also added an empty check on targetDatas to prevent the same possible bug.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nothing.

#### Is it ready for merging, or does it need work?
Yes.

