### PR TITLE
nix: separate overlay with deps

### DIFF
--- a/nix/overlays.nix
+++ b/nix/overlays.nix
@@ -19,12 +19,12 @@ in
   default = lib.composeManyExtensions (
     with self.overlays;
     [
-      hyprland-packages
+      hyprland
       hyprland-extras
     ]
   );
 
-  # Packages for variations of Hyprland, dependencies included.
+  # Packages for variations of Hyprland, all dependencies included.
   hyprland-packages = lib.composeManyExtensions [
     # Dependencies
     inputs.aquamarine.overlays.default
@@ -36,50 +36,57 @@ in
     inputs.hyprutils.overlays.default
     inputs.hyprwayland-scanner.overlays.default
     inputs.hyprwire.overlays.default
-    self.overlays.udis86
-    self.overlays.glaze
-
     # Hyprland packages themselves
-    (
-      final: _prev:
-      let
-        date = mkDate (self.lastModifiedDate or "19700101");
-        version = "${ver}+date=${date}_${self.shortRev or "dirty"}";
-      in
-      {
-        hyprland = final.callPackage ./default.nix {
-          stdenv = final.gcc15Stdenv;
-          commit = self.rev or "";
-          revCount = self.sourceInfo.revCount or "";
-          inherit date version;
-        };
-        hyprland-unwrapped = final.hyprland.override { wrapRuntimeDeps = false; };
-
-        hyprland-with-tests = final.hyprland.override { withTests = true; };
-
-        hyprland-with-hyprtester = builtins.trace ''
-          hyprland-with-hyprtester was removed. Please use the hyprland package.
-          Hyprtester is always built now.
-        '' final.hyprland;
-
-        # deprecated packages
-        hyprland-legacy-renderer = builtins.trace ''
-          hyprland-legacy-renderer was removed. Please use the hyprland package.
-          Legacy renderer is no longer supported.
-        '' final.hyprland;
-
-        hyprland-nvidia = builtins.trace ''
-          hyprland-nvidia was removed. Please use the hyprland package.
-          Nvidia patches are no longer needed.
-        '' final.hyprland;
-
-        hyprland-hidpi = builtins.trace ''
-          hyprland-hidpi was removed. Please use the hyprland package.
-          For more information, refer to https://wiki.hypr.land/Configuring/XWayland.
-        '' final.hyprland;
-      }
-    )
+    self.overlays.hyprland
   ];
+
+  # Hyprland with its internal dependencies.
+  hyprland = lib.composeManyExtensions (with self.overlays; [
+    udis86
+    glaze
+    hyprland-no-deps
+  ]);
+
+  # Hyprland without any dependencies.
+  hyprland-no-deps =
+    final: _prev:
+    let
+      date = mkDate (self.lastModifiedDate or "19700101");
+      version = "${ver}+date=${date}_${self.shortRev or "dirty"}";
+    in
+    {
+      hyprland = final.callPackage ./default.nix {
+        stdenv = final.gcc15Stdenv;
+        commit = self.rev or "";
+        revCount = self.sourceInfo.revCount or "";
+        inherit date version;
+      };
+
+      hyprland-unwrapped = final.hyprland.override { wrapRuntimeDeps = false; };
+
+      hyprland-with-tests = final.hyprland.override { withTests = true; };
+
+      hyprland-with-hyprtester = builtins.trace ''
+        hyprland-with-hyprtester was removed. Please use the hyprland package.
+        Hyprtester is always built now.
+      '' final.hyprland;
+
+      # deprecated packages
+      hyprland-legacy-renderer = builtins.trace ''
+        hyprland-legacy-renderer was removed. Please use the hyprland package.
+        Legacy renderer is no longer supported.
+      '' final.hyprland;
+
+      hyprland-nvidia = builtins.trace ''
+        hyprland-nvidia was removed. Please use the hyprland package.
+        Nvidia patches are no longer needed.
+      '' final.hyprland;
+
+      hyprland-hidpi = builtins.trace ''
+        hyprland-hidpi was removed. Please use the hyprland package.
+        For more information, refer to https://wiki.hypr.land/Configuring/XWayland.
+      '' final.hyprland;
+    };
 
   # Debug
   hyprland-debug = lib.composeManyExtensions [


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

Separates Hyprland and its internal deps' overlays (udis, glaze) from "external" deps (hypr* stuff).

Users are free to choose whether to use the raw hyprland overlay or bring in dependencies.

Should avoid issues like https://github.com/hyprwm/Hyprland/discussions/13396 popping up again.

Wiki PR https://github.com/hyprwm/hyprland-wiki/pull/1419.

### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Not sure which overlay should be the default.

@spikespaz @NotAShelf and other Nix-inclined people, please take a look and chime in.

#### Is it ready for merging, or does it need work?

Not ready until we address the `default` issue.
