### PR TITLE
recheckWorkArea() even when not active to prevent CReservedArea assert failure

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -47,6 +47,7 @@
 #include "protocols/core/Compositor.hpp"
 #include "protocols/core/Subcompositor.hpp"
 #include "desktop/view/LayerSurface.hpp"
+#include "layout/space/Space.hpp"
 #include "render/Renderer.hpp"
 #include "xwayland/XWayland.hpp"
 #include "helpers/ByteOperations.hpp"
@@ -1981,6 +1982,7 @@ void CCompositor::moveWorkspaceToMonitor(PHLWORKSPACE pWorkspace, PHLMONITOR pMo
 
     // move the workspace
     pWorkspace->m_monitor = pMonitor;
+    pWorkspace->m_space->recheckWorkArea();
     pWorkspace->m_events.monitorChanged.emit();
 
     for (auto const& w : m_windows) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This fixes a crash under a fairly niche but core use case involving multiple monitors. Ultimately it leads to violating the assertion in CReservedArea.

**Steps to reproduce the crash**

1. Configure a window to spawn on a workspace that we won't visit. e.g., `exec-once = [workspace 33 silent] uwsm app -- signal-desktop` in my case
2. For some reason, hyprland initializes this on monitor ID 2 at offset 0x0 at 4K with scale 2. That's not where I want it! I want it on monitor ID 1 at offset 5760x0 at 1080p with scale 1. (as an example)
3. *Do not navigate to workspace 33,* as there is an interaction with last focused window. (explained below)
4. With monitor ID 1 focused, run `hyprctl dispatch focusworkspaceoncurrentmonitor 33`.

It should crash due to the workspace work area being stale due to `recheckWorkArea()` not being called in this path, with the old stale work area reflecting the original monitor, which is not contained within the coordinates on the new monitor.

Note: this doesn't crash when active due to `recalculateMonitor()` inside the `SWITCHINGISACTIVE` branch ~L2017. 

Note: this doesn't crash when the workspace has had a focused window due to skipping `getTopLeftWindow()` and `getWindowIdealBoundingBoxIgnoreReserved()` when `pWindow` is non-null. (or I guess when there is a fullscreen window).

This was discovered using a plugin called hyprsplit (currently running off my own branch), but per above is reproducible on hyprland without the plugin. 

#### Is it ready for merging, or does it need work?

I'm not 100% sure. I'm not 100% sure how to test this. I have read the [dev setup](https://wiki.hypr.land/Contributing-and-Debugging/) but I'm not sure how to test multiple monitors in the dev setup (and the easiest way to reproduce involves violating the suggestions of "don't use exec-once") nor how to run my branch on an actual login session on my computer.

If this PR is not correct, I'm happy to convert it to a bugreport for someone more familiar with the codebase to take on.

I'm also not incredibly familiar with the standard hyprland lifecycle patterns, so perhaps `recheckWorkArea()` or a similar function should be hoisted to a calling function or something.