### PR TITLE
keybinds: Remove removed keybinds

### DIFF
--- a/hyprtester/test.conf
+++ b/hyprtester/test.conf
@@ -250,7 +250,7 @@ bind = $mainMod, E, exec, $fileManager
 bind = $mainMod, V, togglefloating,
 bind = $mainMod, R, exec, $menu
 bind = $mainMod, P, pseudo, # dwindle
-bind = $mainMod, J, togglesplit, # dwindle
+bind = $mainMod, J, layoutmsg, togglesplit, # dwindle
 
 # Move focus with mainMod + arrow keys
 bind = $mainMod, left, movefocus, l

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -109,9 +109,6 @@ CKeybindManager::CKeybindManager() {
     m_dispatchers["togglegroup"]                    = toggleGroup;
     m_dispatchers["changegroupactive"]              = changeGroupActive;
     m_dispatchers["movegroupwindow"]                = moveGroupWindow;
-    m_dispatchers["togglesplit"]                    = toggleSplit;
-    m_dispatchers["swapsplit"]                      = swapSplit;
-    m_dispatchers["splitratio"]                     = alterSplitRatio;
     m_dispatchers["focusmonitor"]                   = focusMonitor;
     m_dispatchers["movecursortocorner"]             = moveCursorToCorner;
     m_dispatchers["movecursor"]                     = moveCursor;
@@ -1707,18 +1704,6 @@ SDispatchResult CKeybindManager::changeGroupActive(std::string args) {
         PWINDOW->m_group->moveCurrent(false);
 
     return {};
-}
-
-SDispatchResult CKeybindManager::toggleSplit(std::string args) {
-    return {.success = false, .error = "removed - use layoutmsg"};
-}
-
-SDispatchResult CKeybindManager::swapSplit(std::string args) {
-    return {.success = false, .error = "removed - use layoutmsg"};
-}
-
-SDispatchResult CKeybindManager::alterSplitRatio(std::string args) {
-    return {.success = false, .error = "removed - use layoutmsg"};
 }
 
 SDispatchResult CKeybindManager::focusMonitor(std::string arg) {

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -194,10 +194,7 @@ class CKeybindManager {
     static SDispatchResult swapActive(std::string);
     static SDispatchResult toggleGroup(std::string);
     static SDispatchResult changeGroupActive(std::string);
-    static SDispatchResult alterSplitRatio(std::string);
     static SDispatchResult focusMonitor(std::string);
-    static SDispatchResult toggleSplit(std::string);
-    static SDispatchResult swapSplit(std::string);
     static SDispatchResult moveCursorToCorner(std::string);
     static SDispatchResult moveCursor(std::string);
     static SDispatchResult workspaceOpt(std::string);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

There seems to be no reason for them to remain.

But if they are kept, no notification appears to warn a user that a dispatcher used in their config is no longer valid. The config remains valid, but the bindings do not work anymore.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Ready for merge, unless there was a reason that I missed to keep these dispatchers around.