### PR TITLE
config: add binds for window movement and workspace switching

### DIFF
--- a/example/hyprland.conf
+++ b/example/hyprland.conf
@@ -250,6 +250,12 @@ bind = $mainMod, right, movefocus, r
 bind = $mainMod, up, movefocus, u
 bind = $mainMod, down, movefocus, d
 
+# Move active window with mainMod + SHIFT + arrow keys
+bind = $mainMod SHIFT, left, swapwindow, l
+bind = $mainMod SHIFT, right, swapwindow, r
+bind = $mainMod SHIFT, up, swapwindow, u
+bind = $mainMod SHIFT, down, swapwindow, d
+
 # Switch workspaces with mainMod + [0-9]
 bind = $mainMod, 1, workspace, 1
 bind = $mainMod, 2, workspace, 2
@@ -262,6 +268,9 @@ bind = $mainMod, 8, workspace, 8
 bind = $mainMod, 9, workspace, 9
 bind = $mainMod, 0, workspace, 10
 
+# Switch to previous workspace with mainMod + TAB
+bind = $mainMod, TAB, workspace, previous
+
 # Move active window to a workspace with mainMod + SHIFT + [0-9]
 bind = $mainMod SHIFT, 1, movetoworkspace, 1
 bind = $mainMod SHIFT, 2, movetoworkspace, 2
@@ -273,6 +282,10 @@ bind = $mainMod SHIFT, 7, movetoworkspace, 7
 bind = $mainMod SHIFT, 8, movetoworkspace, 8
 bind = $mainMod SHIFT, 9, movetoworkspace, 9
 bind = $mainMod SHIFT, 0, movetoworkspace, 10
+
+# Move workspace to monitor with mainMod + SHIFT + Page Up / Page Down
+bind = $mainMod SHIFT, page_up, movecurrentworkspacetomonitor, +1
+bind = $mainMod SHIFT, page_down, movecurrentworkspacetomonitor, -1
 
 # Example special workspace (scratchpad)
 bind = $mainMod, S, togglespecialworkspace, magic


### PR DESCRIPTION
Adds some binds to the default configuration.
I've found those useful for myself and seems to be frequently asked stuff.

It may be worth to add vim like binds for window focus and movements, but those would require changing some existing binds, so let me know what you think first.