### PR TITLE
Add support for headless GPU

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -735,8 +735,7 @@ void CCompositor::removeLockFile() {
         std::filesystem::remove(PATH);
 }
 
-void CCompositor::prepareFallbackOutput() {
-    // create a backup monitor
+void CCompositor::prepareFallbackOutputs() {
     SP<Aquamarine::IBackendImplementation> headless;
     for (auto const& impl : m_aqBackend->getImplementations()) {
         if (impl->type() == Aquamarine::AQ_BACKEND_HEADLESS) {
@@ -746,14 +745,29 @@ void CCompositor::prepareFallbackOutput() {
     }
 
     if (!headless) {
-        Log::logger->log(Log::WARN, "No headless in prepareFallbackOutput?!");
+        Log::logger->log(Log::WARN, "No headless in prepareFallbackOutputs?!");
         return;
     }
 
+    // create a backup monitor
     headless->createOutput();
 
     if (m_monitors.empty())
         enterUnsafeState();
+
+    // create a headless monitor if no card support kms.
+    bool supportsKMS = false;
+    if (m_aqBackend->hasSession()) {
+        for (SP<CSessionDevice> dev : m_aqBackend->session->sessionDevices) {
+            supportsKMS |= dev->supportsKMS();
+        }
+    }
+
+    if (supportsKMS)
+        return;
+
+    Log::logger->log(Log::DEBUG, "Running on DRM-only gpu. Creating initial HEADLESS-0 output.");
+    headless->createOutput("HEADLESS-0");
 }
 
 void CCompositor::startCompositor() {
@@ -775,7 +789,7 @@ void CCompositor::startCompositor() {
 
     Log::logger->log(Log::DEBUG, "Running on WAYLAND_DISPLAY: {}", m_wlDisplaySocket);
 
-    prepareFallbackOutput();
+    prepareFallbackOutputs();
 
     g_pHyprRenderer->setCursorFromName("left_ptr");
 

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -178,7 +178,7 @@ class CCompositor {
     void                           cleanEnvironment();
     void                           setRandomSplash();
     void                           initManagers(eManagersInitStage stage);
-    void                           prepareFallbackOutput();
+    void                           prepareFallbackOutputs();
     void                           createLockFile();
     void                           removeLockFile();
     void                           setMallocThreshold();


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
<details>
<summary>Why this feature ?</summary>

With tools like [vgpu_unlock-rs](https://github.com/mbilker/vgpu_unlock-rs), old or recent professional AMD and NVIDIA GPU hitting the marketplace, and the Intel Arc Pro card release, more and more people are getting access to gpu that fully supports SR-IOV. 

SR-IOV is a virtualization extension. It permits to divide a physical graphics card into several virtual functions. It works extremely well for all kind of accelerated graphics workload (including gaming) on Windows and X11, but not on Wayland, because on Linux these cards have no outputs.

Currently the only two compositors confirmed to work with these graphics card are: 
- Sway with [its headless backend](https://forum.level1techs.com/t/virtualization-workstation-with-the-intel-arc-pro-b50/243577/12?u=the_vgpu_supplier). The usual setup is to access it with a streaming server like sunshine that capture the headless screen using a wayland protocol.
- GNOME mutter with this [pull request](https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/4561) enabling headless primary GPU. [Confirmed to work](https://forum.level1techs.com/t/proxmox-9-0-intel-b50-sr-iov-finally-its-almost-here-early-adopters-guide/238107/496?u=the_vgpu_supplier)

Other compositors are on the work to bring remote desktop capabilities for virtual machines, as part of the greater effort to abandon X11 in enterprise environment.

Hyprland is an awesome compositor, Supporting headless graphics card would permit many SR-IOV users to enjoy it in their virtual machines, and could pose as strategic feature for bringing more prosumers into it.
</details>

**This PR makes Hyprland generates an initial `HEADLESS-0` headless output if none of the session's graphics cards support KMS**

This PR requires the following aquamarine PR to allow No KMS GPUs to be accepted: https://github.com/hyprwm/aquamarine/pull/255

The combination of both enable remote desktop capabilities for Hyprland with virtualized graphics cards.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

For an unknown reason, the headless fallback output already in place did not activate, despite being listed in `hyprctl systeminfo` and exec directives are not triggered until a first display is on.

#### Is it ready for merging, or does it need work?

The patch is small and perfectly works but the user experience is not optimal. There is probably a batter way to let users enable this behavior than setting an environment variable.