### PR TITLE
Feat/scrollinglayout unsigned wrap

### DIFF
--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -260,6 +260,9 @@ bool SColumnData::up(SP<SScrollingTargetData> w) {
 }
 
 bool SColumnData::down(SP<SScrollingTargetData> w) {
+    if (targetDatas.empty())
+        return false;
+
     for (size_t i = 0; i < targetDatas.size() - 1; ++i) {
         if (targetDatas[i] != w)
             continue;


### PR DESCRIPTION



#### Describe your PR, what does it fix/add?
Fixes unsigned integer underflow in SColumnData::down() . if targetDatas is empty, this wraps around, causing the loop to iterate through invalid memory.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Same pattern exists in SColumnData::next()

#### Is it ready for merging, or does it need work?
Yes.

