### PR TITLE
algo/scroll: reverse horizontal dir mapping of vertical scrolling directions

### DIFF
--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -875,8 +875,8 @@ void CScrollingAlgorithm::moveTargetTo(SP<ITarget> t, Math::eDirection dir, bool
                 switch (dir) {
                     case Math::DIRECTION_UP: return Math::DIRECTION_RIGHT;
                     case Math::DIRECTION_DOWN: return Math::DIRECTION_LEFT;
-                    case Math::DIRECTION_LEFT: return Math::DIRECTION_DOWN;
-                    case Math::DIRECTION_RIGHT: return Math::DIRECTION_UP;
+                    case Math::DIRECTION_LEFT: return Math::DIRECTION_UP;
+                    case Math::DIRECTION_RIGHT: return Math::DIRECTION_DOWN;
                     default: break;
                 }
 
@@ -886,8 +886,8 @@ void CScrollingAlgorithm::moveTargetTo(SP<ITarget> t, Math::eDirection dir, bool
                 switch (dir) {
                     case Math::DIRECTION_UP: return Math::DIRECTION_LEFT;
                     case Math::DIRECTION_DOWN: return Math::DIRECTION_RIGHT;
-                    case Math::DIRECTION_LEFT: return Math::DIRECTION_DOWN;
-                    case Math::DIRECTION_RIGHT: return Math::DIRECTION_UP;
+                    case Math::DIRECTION_LEFT: return Math::DIRECTION_UP;
+                    case Math::DIRECTION_RIGHT: return Math::DIRECTION_DOWN;
                     default: break;
                 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This PR reverses the horizontal direction mapping of vertical scrolling directions. The current mapping feels unintuitive as demonstrated in the screen capture.

https://github.com/user-attachments/assets/a8a46267-d01f-4433-b3c5-9d70ab366043


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This change will alter existing behavior for vertical scrolling directions.

#### Is it ready for merging, or does it need work?

It's ready.