### PR TITLE
build: add glaze dependency with FetchContent fallback

### DIFF
--- a/hyprpm/CMakeLists.txt
+++ b/hyprpm/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_CXX_STANDARD 23)
 
 pkg_check_modules(hyprpm_deps REQUIRED IMPORTED_TARGET tomlplusplus hyprutils>=0.7.0)
 
-find_package(glaze 7 QUIET)
+find_package(glaze 7...<8 QUIET)
 if (NOT glaze_FOUND)
     set(GLAZE_VERSION v7.2.0)
     message(STATUS "hyprpm: glaze dependency not found, retrieving ${GLAZE_VERSION} with FetchContent")

--- a/start/CMakeLists.txt
+++ b/start/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(starthyprland_deps REQUIRED IMPORTED_TARGET hyprutils>=0.10.3)
 
-find_package(glaze 7 QUIET)
+find_package(glaze 7...<8 QUIET)
 if (NOT glaze_FOUND)
     set(GLAZE_VERSION v7.2.0)
     message(STATUS "start: glaze dependency not found, retrieving ${GLAZE_VERSION} with FetchContent")


### PR DESCRIPTION
Fixes this build error:
```
hyprland/start/src/helpers/Nix.cpp:13:10: fatal error: glaze/glaze.hpp: No such file or directory
   13 | #include <glaze/glaze.hpp>
      |          ^~~~~~~~~~~~~~~~~
compilation terminated.
```

Same has been done for hyprpm, see https://github.com/hyprwm/Hyprland/pull/8899

>Use FetchContent to retrieve glaze dependency if not available with find_package.
>Allows to build hyprpm w/o installing glaze at system level (on some distros is not available in official repositories).
>
>Inspired from glaze documentation (ref. https://github.com/stephenberry/glaze?tab=readme-ov-file#see-this-example-repository-for-how-to-use-glaze-in-a-new-project and https://github.com/stephenberry/glaze_example/blob/main/CMakeLists.txt), let me know if there's a better way to achieve that.

**EDIT**

It seems that build on nix fails with `error: could not find git for clone of glaze-populate`
I have read https://github.com/hyprwm/Hyprland/discussions/13043 but tbh I have no idea about how to fix it (dunno nix).