### PR TITLE
renderer: fix blockBlurOptimization check (fixes xray)

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1062,7 +1062,7 @@ void IHyprRenderer::drawTex(CTexPassElement* element, const CRegion& damage) {
             element->m_data.blockBlurOptimization.value_or(false) || !shouldUseNewBlurOptimizations(element->m_data.currentLS.lock(), m_renderData.currentWindow.lock());
 
         //   vvv TODO: layered blur fbs?
-        if (element->m_data.blockBlurOptimization) {
+        if (element->m_data.blockBlurOptimization.value_or(false)) {
             inverseOpaque.translate(box.pos());
             m_renderData.renderModif.applyToRegion(inverseOpaque);
             inverseOpaque.intersect(element->m_data.damage);


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
`std::optional<bool> blockBlurOptimization` was getting treated as just `bool` causing the if condition to be true when there's a value assigned to the optional, no matter what value the underlying bool holds.
xray was completely broken after #13488 (artifacts + not functional), this fixes that.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
ready to merge