### PR TITLE
hyprctl: getoption now supports 'category[id]:property' format

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -1784,6 +1784,9 @@ Hyprlang::CConfigValue* CConfigManager::getHyprlangConfigValuePtr(const std::str
     if (name.starts_with("plugin:"))
         return m_config->getSpecialConfigValuePtr("plugin", name.substr(7).c_str(), nullptr);
 
+    if (const auto OPEN = name.find('['), CLOSE = name.find("]:"); OPEN != std::string::npos && CLOSE != std::string::npos)
+        return m_config->getSpecialConfigValuePtr(name.substr(0, OPEN).c_str(), name.substr(CLOSE + 2).c_str(), name.substr(OPEN + 1, CLOSE - OPEN - 1).c_str());
+
     return m_config->getConfigValuePtr(name.c_str());
 }
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
This PR makes `hyprctl getoption` able to parse the `category[id]:property` syntax. This change allows users to read the state of specific windowrule, layerrule, etc. This change is needed to create robust toggle script.

Example:
- `hyprctl getoption 'windowrule[rule_name]:enable'`

#### Is it ready for merging, or does it need work?
Ready. Verified manually in a nested session.

