### PR TITLE
protocols: fix image-copy-capture stop handling and remove non protocol errors

### DIFF
--- a/src/protocols/ImageCopyCapture.cpp
+++ b/src/protocols/ImageCopyCapture.cpp
@@ -40,7 +40,6 @@ CImageCopyCaptureSession::CImageCopyCaptureSession(SP<CExtImageCopyCaptureSessio
 
     if UNLIKELY (!m_session) {
         m_resource->sendStopped();
-        m_resource->error(-1, "unable to share screen");
         return;
     }
 
@@ -66,7 +65,6 @@ void CImageCopyCaptureSession::sendConstraints() {
 
     if UNLIKELY (formats.empty()) {
         m_session->stop();
-        m_resource->error(-1, "no formats available");
         return;
     }
 
@@ -144,7 +142,6 @@ CImageCopyCaptureCursorSession::CImageCopyCaptureCursorSession(SP<CExtImageCopyC
         m_session = Screenshare::mgr()->newCursorSession(pMgr->client(), m_pointer);
         if UNLIKELY (!m_session) {
             m_sessionResource->sendStopped();
-            m_sessionResource->error(-1, "unable to share cursor");
             return;
         }
 
@@ -282,7 +279,6 @@ void CImageCopyCaptureCursorSession::sendConstraints() {
     auto format = m_session->format();
     if UNLIKELY (format == DRM_FORMAT_INVALID) {
         m_session->stop();
-        m_sessionResource->error(-1, "no formats available");
         return;
     }
 
@@ -314,13 +310,8 @@ void CImageCopyCaptureCursorSession::sendConstraints() {
 
 void CImageCopyCaptureCursorSession::sendCursorEvents() {
     const auto PERM = g_pDynamicPermissionManager->clientPermissionMode(m_resource->client(), PERMISSION_TYPE_CURSOR_POS);
-    if (PERM != PERMISSION_RULE_ALLOW_MODE_ALLOW) {
-        if (PERM == PERMISSION_RULE_ALLOW_MODE_DENY) {
-            m_resource->error(-1, "client not allowed to capture cursor");
-            PROTO::imageCopyCapture->destroyResource(this);
-        }
+    if (PERM != PERMISSION_RULE_ALLOW_MODE_ALLOW)
         return;
-    }
 
     const auto PMONITOR  = m_source->m_monitor.expired() ? m_source->m_window->m_monitor.lock() : m_source->m_monitor.lock();
     CBox       sourceBox = m_source->logicalBox();
@@ -485,7 +476,7 @@ void CImageCopyCaptureProtocol::bindManager(wl_client* client, void* data, uint3
         SP<CImageCaptureSource> source = PROTO::imageCaptureSource->sourceFromResource(source_);
         if (!source) {
             LOGM(Log::ERR, "Client tried to create image copy capture session from invalid source");
-            destroyResource(pMgr);
+            pMgr->error(-1, "invalid image capture source");
             return;
         }
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
1. Fixes the session stop handler to send a stopped event instead of destroying the client resource to match the protocol and avoid causing protocol object use after frees.
2. Removes wayland error() calls that kill the client for conditions it had no control over, as they are not protocol errors.
3. Fixes resource destruction being sent in place of an error() which is confusing and causes use after frees again.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No. Tested with a client.

#### Is it ready for merging, or does it need work?
Ready to merge.

