### PR TITLE
input: implement follow_mouse_shrink

### DIFF
--- a/hyprtester/src/tests/main/follow_mouse_shrink.cpp
+++ b/hyprtester/src/tests/main/follow_mouse_shrink.cpp
@@ -1,0 +1,131 @@
+#include <chrono>
+#include <cstring>
+#include <thread>
+
+#include "../../shared.hpp"
+#include "../../hyprctlCompat.hpp"
+#include "../shared.hpp"
+#include "tests.hpp"
+
+static int  ret = 0;
+
+static bool spawnKitty(const std::string& class_) {
+    NLog::log("{}Spawning {}", Colors::YELLOW, class_);
+    if (!Tests::spawnKitty(class_)) {
+        NLog::log("{}Error: {} did not spawn", Colors::RED, class_);
+        return false;
+    }
+    return true;
+}
+
+static bool isActiveWindow(const std::string& class_, char fullscreen = '0', bool log = true) {
+    std::string activeWin     = getFromSocket("/activewindow");
+    auto        winClass      = Tests::getWindowAttribute(activeWin, "class:");
+    auto        winFullscreen = Tests::getWindowAttribute(activeWin, "fullscreen:").back();
+    if (winClass.substr(strlen("class: ")) == class_ && winFullscreen == fullscreen)
+        return true;
+    else {
+        if (log)
+            NLog::log("{}Wrong active window: expected class {} fullscreen '{}', found class {}, fullscreen '{}'", Colors::RED, class_, fullscreen, winClass, winFullscreen);
+        return false;
+    }
+}
+
+static bool waitForActiveWindow(const std::string& class_, char fullscreen = '0', bool logLastCheck = true, int maxTries = 50) {
+    int cnt = 0;
+    while (!isActiveWindow(class_, fullscreen, false)) {
+        ++cnt;
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        if (cnt > maxTries) {
+            return isActiveWindow(class_, fullscreen, logLastCheck);
+        }
+    }
+    return true;
+}
+
+static bool test() {
+    NLog::log("{}Testing follow_mouse_shrink", Colors::GREEN);
+
+    getFromSocket("/dispatch workspace name:follow_mouse_shrink");
+
+    // follow_mouse 2 so cursor position determines focus (mode 1's delta threshold
+    // is unreliable with movecursor/simulateMouseMovement). float_switch_override_focus 2
+    // enables focus switching between floating windows.
+    OK(getFromSocket("/keyword input:follow_mouse 2"));
+    OK(getFromSocket("/keyword input:float_switch_override_focus 2"));
+
+    // Spawn two floating windows with a 20px gap
+    // fms_a: position (100,100), size 400x400 -> hitbox [100,499] x [100,499]
+    if (!spawnKitty("fms_a"))
+        return false;
+    OK(getFromSocket("/dispatch setfloating"));
+    OK(getFromSocket("/dispatch resizewindowpixel exact 400 400,activewindow"));
+    OK(getFromSocket("/dispatch movewindowpixel exact 100 100,activewindow"));
+
+    // fms_b: position (520,100), size 400x400 -> hitbox [520,919] x [100,499]
+    if (!spawnKitty("fms_b"))
+        return false;
+    OK(getFromSocket("/dispatch setfloating"));
+    OK(getFromSocket("/dispatch resizewindowpixel exact 400 400,activewindow"));
+    OK(getFromSocket("/dispatch movewindowpixel exact 520 100,activewindow"));
+
+    // --- Test 1: Baseline shrink=0, edge focus works ---
+    NLog::log("{}Test 1: shrink=0, cursor at B's left edge focuses B", Colors::GREEN);
+    OK(getFromSocket("/keyword input:follow_mouse_shrink 0"));
+    // Focus A explicitly, then move cursor inside A so follow_mouse tracks it
+    OK(getFromSocket("/dispatch focuswindow class:fms_a"));
+    EXPECT(waitForActiveWindow("fms_a"), true);
+    OK(getFromSocket("/dispatch movecursor 300 300"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    // Move to just inside B's left edge
+    OK(getFromSocket("/dispatch movecursor 521 300"));
+    EXPECT(waitForActiveWindow("fms_b"), true);
+
+    // --- Test 2: Shrink=20, cursor in dead zone does NOT change focus ---
+    NLog::log("{}Test 2: shrink=20, cursor in B's dead zone stays on A", Colors::GREEN);
+    OK(getFromSocket("/keyword input:follow_mouse_shrink 20"));
+    // Focus A explicitly
+    OK(getFromSocket("/dispatch focuswindow class:fms_a"));
+    EXPECT(waitForActiveWindow("fms_a"), true);
+    OK(getFromSocket("/dispatch movecursor 300 300"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    // Move to 530,300 -- 10px inside B, within 20px shrink zone (B's shrunk hitbox starts at 540)
+    OK(getFromSocket("/dispatch movecursor 530 300"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    EXPECT(isActiveWindow("fms_a"), true);
+
+    // --- Test 3: Shrink=20, cursor well inside inactive window DOES focus it ---
+    NLog::log("{}Test 3: shrink=20, cursor at B's center focuses B", Colors::GREEN);
+    // Still focused on A from test 2
+    OK(getFromSocket("/dispatch movecursor 720 300"));
+    EXPECT(waitForActiveWindow("fms_b"), true);
+
+    // --- Test 4: Focused window's hitbox is NOT shrunk ---
+    NLog::log("{}Test 4a: focused window hitbox is not shrunk", Colors::GREEN);
+    // Focus A explicitly, move cursor inside A, then move near A's right edge
+    OK(getFromSocket("/dispatch focuswindow class:fms_a"));
+    EXPECT(waitForActiveWindow("fms_a"), true);
+    OK(getFromSocket("/dispatch movecursor 300 300"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    OK(getFromSocket("/dispatch movecursor 490 300"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    EXPECT(isActiveWindow("fms_a"), true);
+
+    NLog::log("{}Test 4b: inactive window hitbox IS shrunk at same position", Colors::GREEN);
+    // Focus B explicitly, then move to (490,300). Now A is inactive with shrunk box ending at 479, so 490 is outside A.
+    OK(getFromSocket("/dispatch focuswindow class:fms_b"));
+    EXPECT(waitForActiveWindow("fms_b"), true);
+    OK(getFromSocket("/dispatch movecursor 720 300"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    OK(getFromSocket("/dispatch movecursor 490 300"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    EXPECT(isActiveWindow("fms_b"), true);
+
+    // Cleanup
+    OK(getFromSocket("/reload"));
+    Tests::killAllWindows();
+
+    return ret == 0;
+}
+
+REGISTER_TEST_FN(test)

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -895,7 +895,7 @@ bool CCompositor::monitorExists(PHLMONITOR pMonitor) {
     return std::ranges::any_of(m_realMonitors, [&](const PHLMONITOR& m) { return m == pMonitor; });
 }
 
-PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t properties, PHLWINDOW pIgnoreWindow) {
+PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint16_t properties, PHLWINDOW pIgnoreWindow) {
     const auto PMONITOR = getMonitorFromVector(pos);
     if (!PMONITOR)
         return nullptr;
@@ -905,8 +905,12 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
     static auto PBORDERGRABEXTEND    = CConfigValue<Hyprlang::INT>("general:extend_border_grab_area");
     static auto PSPECIALFALLTHRU     = CConfigValue<Hyprlang::INT>("input:special_fallthrough");
     static auto PMODALPARENTBLOCKING = CConfigValue<Hyprlang::INT>("general:modal_parent_blocking");
+    static auto PFOLLOWMOUSESHRINK   = CConfigValue<Hyprlang::INT>("input:follow_mouse_shrink");
     const auto  BORDER_GRAB_AREA     = *PRESIZEONBORDER ? *PBORDERSIZE + *PBORDERGRABEXTEND : 0;
     const bool  ONLY_PRIORITY        = properties & Desktop::View::FOCUS_PRIORITY;
+    const bool  FOLLOW_MOUSE_CHECK   = properties & Desktop::View::FOLLOW_MOUSE_CHECK;
+    const auto  HITBOX_SHRINK        = FOLLOW_MOUSE_CHECK ? *PFOLLOWMOUSESHRINK : 0;
+    const auto  LASTFOCUSED          = Desktop::focusState()->window();
 
     const auto  isShadowedByModal = [](PHLWINDOW w) -> bool {
         return *PMODALPARENTBLOCKING && w->m_xdgSurface && w->m_xdgSurface->m_toplevel && w->m_xdgSurface->m_toplevel->anyChildModal();
@@ -922,6 +926,8 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
                 w != pIgnoreWindow && !isShadowedByModal(w)) {
                 const auto BB  = w->getWindowBoxUnified(properties);
                 CBox       box = BB.copy().expand(!w->isX11OverrideRedirect() ? BORDER_GRAB_AREA : 0);
+                if (HITBOX_SHRINK > 0 && w != LASTFOCUSED)
+                    box = box.copy().expand(-HITBOX_SHRINK);
                 if (box.containsPoint(pos))
                     return w;
 
@@ -964,6 +970,8 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
 
                     const auto BB  = w->getWindowBoxUnified(properties);
                     CBox       box = BB.copy().expand(!w->isX11OverrideRedirect() ? BORDER_GRAB_AREA : 0);
+                    if (HITBOX_SHRINK > 0 && w != LASTFOCUSED)
+                        box = box.copy().expand(-HITBOX_SHRINK);
                     if (box.containsPoint(pos)) {
 
                         if (w->m_isX11 && w->isX11OverrideRedirect() && !w->m_xwaylandSurface->wantsFocus()) {
@@ -1095,6 +1103,8 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
                     if (isWindowCloseToWorkAreaEdge(Math::eDirection::DIRECTION_DOWN))
                         box.height += BORDER_GRAB_AREA;
                 }
+                if (HITBOX_SHRINK > 0 && w != LASTFOCUSED)
+                    box = box.copy().expand(-HITBOX_SHRINK);
                 if (box.containsPoint(pos))
                     return w;
             }

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -99,7 +99,7 @@ class CCompositor {
     PHLMONITOR             getMonitorFromVector(const Vector2D&);
     void                   removeWindowFromVectorSafe(PHLWINDOW);
     bool                   monitorExists(PHLMONITOR);
-    PHLWINDOW              vectorToWindowUnified(const Vector2D&, uint8_t properties, PHLWINDOW pIgnoreWindow = nullptr);
+    PHLWINDOW              vectorToWindowUnified(const Vector2D&, uint16_t properties, PHLWINDOW pIgnoreWindow = nullptr);
     SP<CWLSurfaceResource> vectorToLayerSurface(const Vector2D&, std::vector<PHLLSREF>*, Vector2D*, PHLLS*, bool aboveLockscreen = false);
     SP<CWLSurfaceResource> vectorToLayerPopupSurface(const Vector2D&, PHLMONITOR monitor, Vector2D*, PHLLS*);
     SP<CWLSurfaceResource> vectorWindowToSurface(const Vector2D&, PHLWINDOW, Vector2D& sl);

--- a/src/config/legacy/ConfigManager.cpp
+++ b/src/config/legacy/ConfigManager.cpp
@@ -684,6 +684,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("animations:workspace_wraparound", Hyprlang::INT{0});
 
     registerConfigVar("input:follow_mouse", Hyprlang::INT{1});
+    registerConfigVar("input:follow_mouse_shrink", Hyprlang::INT{0});
     registerConfigVar("input:follow_mouse_threshold", Hyprlang::FLOAT{0});
     registerConfigVar("input:focus_on_close", Hyprlang::INT{0});
     registerConfigVar("input:mouse_refocus", Hyprlang::INT{1});

--- a/src/config/supplementary/ConfigDescriptions.hpp
+++ b/src/config/supplementary/ConfigDescriptions.hpp
@@ -646,6 +646,14 @@ namespace Config::Supplementary {
             .data        = SConfigOptionDescription::SRangeData{1, 0, 3},
         },
         SConfigOptionDescription{
+            .value = "input:follow_mouse_shrink",
+            .description =
+                "Shrinks the inactive window hitboxes used for focus detection by the specified number of pixels. This creates a dead zone in gaps between windows where "
+                "moving the cursor will not change focus. Works only with follow_mouse = 1.",
+            .type = CONFIG_OPTION_INT,
+            .data = SConfigOptionDescription::SRangeData{0, 0, 300},
+        },
+        SConfigOptionDescription{
             .value       = "input:follow_mouse_threshold",
             .description = "The smallest distance in logical pixels the mouse needs to travel for the window under it to get focused. Works only with follow_mouse = 1.",
             .type        = CONFIG_OPTION_FLOAT,

--- a/src/desktop/view/Window.hpp
+++ b/src/desktop/view/Window.hpp
@@ -55,7 +55,7 @@ namespace Desktop::View {
         GROUP_DENY        = 1 << 7, // deny
     };
 
-    enum eGetWindowProperties : uint8_t {
+    enum eGetWindowProperties : uint16_t {
         WINDOW_ONLY              = 0,
         RESERVED_EXTENTS         = 1 << 0,
         INPUT_EXTENTS            = 1 << 1,
@@ -65,6 +65,7 @@ namespace Desktop::View {
         USE_PROP_TILED           = 1 << 5,
         SKIP_FULLSCREEN_PRIORITY = 1 << 6,
         FOCUS_PRIORITY           = 1 << 7,
+        FOLLOW_MOUSE_CHECK       = 1 << 8,
     };
 
     enum eSuppressEvents : uint8_t {

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -419,7 +419,8 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
     PHLWINDOW  pWindowIdeal;
     const auto getWindowIdeal = [&]() -> const PHLWINDOW& {
         if (!windowIdealQueried) {
-            pWindowIdeal       = g_pCompositor->vectorToWindowUnified(mouseCoords, Desktop::View::RESERVED_EXTENTS | Desktop::View::INPUT_EXTENTS | Desktop::View::ALLOW_FLOATING);
+            pWindowIdeal = g_pCompositor->vectorToWindowUnified(
+                mouseCoords, Desktop::View::RESERVED_EXTENTS | Desktop::View::INPUT_EXTENTS | Desktop::View::ALLOW_FLOATING | Desktop::View::FOLLOW_MOUSE_CHECK);
             windowIdealQueried = true;
         }
 


### PR DESCRIPTION
## Summary
- Adds `input:follow_mouse_shrink` (INT, 0–300, default 0) that shrinks inactive window hitboxes by the specified pixel count for focus detection
- Creates a dead zone in gaps between windows where cursor movement won't trigger focus changes
- Only affects hover focus (`follow_mouse = 1`); click and scroll interactions are unaffected

Closes #9973

## Implementation
- New `FOLLOW_MOUSE_CHECK` flag in `eGetWindowProperties` passed from `mouseMoveUnified` calls
- In `vectorToWindowUnified`, when the flag is set and the window is not the currently focused one, the hitbox is shrunk by the configured amount
- Click/wheel handler call sites do not pass the flag, so interactions remain normal

## Test plan
- Set `input:follow_mouse_shrink = 12` with `follow_mouse = 1` and gaps between windows
- Verify cursor in gap area does not switch focus
- Verify clicking in the gap area still focuses the target window
- Verify the currently focused window's hitbox is not shrunk (no dead zone on the active window)
- Verify `follow_mouse_shrink = 0` (default) has no effect