### PR TITLE
blur: fix dim blur in HDR

### DIFF
--- a/src/render/GLRenderer.cpp
+++ b/src/render/GLRenderer.cpp
@@ -375,6 +375,7 @@ void CHyprGLRenderer::draw(CTexPassElement* element, const CRegion& damage) {
             .roundingPower      = m_data.roundingPower,
             .discardActive      = m_data.discardActive,
             .allowCustomUV      = m_data.allowCustomUV,
+            .sourceIsWorkBufferCM = m_data.sourceIsWorkBufferCM,
             .cmBackToSRGB       = m_data.cmBackToSRGB,
             .cmBackToSRGBSource = m_data.cmBackToSRGBSource,
             .discardMode        = m_data.ignoreAlpha.has_value() ? sc<uint32_t>(DISCARD_ALPHA) : m_data.discardMode,

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1038,8 +1038,8 @@ void CHyprOpenGLImpl::renderRectWithBlurInternal(const CBox& box, const CHyprCol
     g_pHyprRenderer->pushMonitorTransformEnabled(true);
     const auto SAVEDRENDERMODIF               = g_pHyprRenderer->m_renderData.renderModif;
     g_pHyprRenderer->m_renderData.renderModif = {}; // fix shit
-    renderTexture(POUTFB, MONITORBOX,
-                  STextureRenderData{.damage = &damage, .a = data.blurA, .round = data.round, .roundingPower = 2.F, .allowCustomUV = false, .allowDim = false, .noAA = false});
+    renderTexture( POUTFB, MONITORBOX,
+                  STextureRenderData{.damage = &damage, .a = data.blurA, .round = data.round, .roundingPower = 2.F, .allowCustomUV = false, .allowDim = false, .noAA = false, .sourceIsWorkBufferCM = true});
     g_pHyprRenderer->popMonitorTransformEnabled();
     g_pHyprRenderer->m_renderData.renderModif = SAVEDRENDERMODIF;
 
@@ -1135,6 +1135,10 @@ static bool isHDR2SDR(const NColorManagement::SImageDescription& imageDescriptio
             imageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_HLG) &&
         (targetImageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_SRGB ||
          targetImageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_GAMMA22);
+}
+
+static bool isHDRTransferFunction(uint32_t tf) {
+    return tf == NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ || tf == NColorManagement::CM_TRANSFER_FUNCTION_HLG || tf == NColorManagement::CM_TRANSFER_FUNCTION_EXT_LINEAR;
 }
 
 void CHyprOpenGLImpl::passCMUniforms(WP<CShader> shader, const NColorManagement::PImageDescription imageDescription,
@@ -1303,7 +1307,7 @@ WP<CShader> CHyprOpenGLImpl::renderToFBInternal(const STextureRenderData& data, 
 
         // otherwise, if we are CM'ing back into source, use chosen, because that's what our work buffer is in
         // the same applies to the final monitor CM
-        if (data.cmBackToSRGB || data.finalMonitorCM) // NOLINTNEXTLINE
+        if (data.sourceIsWorkBufferCM || data.cmBackToSRGB || data.finalMonitorCM) // NOLINTNEXTLINE
             return WORK_BUFFER_IMAGE_DESCRIPTION;
 
         // otherwise, default
@@ -1634,6 +1638,8 @@ SP<IFramebuffer> CHyprOpenGLImpl::blurFramebufferWithDamage(float a, CRegion* or
     static auto PBLURVIBRANCYDARKNESS = CConfigValue<Hyprlang::FLOAT>("decoration:blur:vibrancy_darkness");
 
     const auto  BLUR_PASSES = std::clamp(*PBLURPASSES, sc<int64_t>(1), sc<int64_t>(8));
+    const auto  TF          = g_pHyprRenderer->workBufferImageDescription()->value().transferFunction;
+    const auto  IS_HDR      = isHDRTransferFunction(TF);
 
     // prep damage
     CRegion damage{*originalDamage};
@@ -1646,6 +1652,25 @@ SP<IFramebuffer> CHyprOpenGLImpl::blurFramebufferWithDamage(float a, CRegion* or
     const auto PMIRRORSWAPFB = g_pHyprRenderer->m_renderData.pMonitor->m_mirrorSwapFB;
 
     auto       currentRenderToFB = PMIRRORFB;
+
+    if (IS_HDR) {
+        const auto BLEND_BEFORE_CLEAR  = m_blend;
+        const auto SCISSOR_WAS_ENABLED = glIsEnabled(GL_SCISSOR_TEST);
+
+        setCapStatus(GL_SCISSOR_TEST, false);
+        blend(false);
+        glClearColor(0.F, 0.F, 0.F, 0.F);
+
+        PMIRRORFB->bind();
+        glClear(GL_COLOR_BUFFER_BIT);
+
+        PMIRRORSWAPFB->bind();
+        glClear(GL_COLOR_BUFFER_BIT);
+
+        if (SCISSOR_WAS_ENABLED)
+            setCapStatus(GL_SCISSOR_TEST, true);
+        blend(BLEND_BEFORE_CLEAR);
+    }
 
     // Begin with base color adjustments - global brightness and contrast
     // TODO: make this a part of the first pass maybe to save on a drawcall?
@@ -1663,25 +1688,7 @@ SP<IFramebuffer> CHyprOpenGLImpl::blurFramebufferWithDamage(float a, CRegion* or
         currentTex->bind();
         currentTex->setTexParameter(GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
-        WP<CShader> shader;
-
-        // From FB to sRGB
-        const bool skipCM = !m_cmSupported || g_pHyprRenderer->workBufferImageDescription()->id() == DEFAULT_IMAGE_DESCRIPTION->id();
-        if (!skipCM) {
-            shader = useShader(getShaderVariant(SH_FRAG_BLURPREPARE, SH_FEAT_CM));
-            passCMUniforms(shader, m_renderData.pMonitor->m_imageDescription, DEFAULT_IMAGE_DESCRIPTION);
-            shader->setUniformFloat(SHADER_SDR_SATURATION,
-                                    m_renderData.pMonitor->m_sdrSaturation > 0 &&
-                                            m_renderData.pMonitor->m_imageDescription->value().transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ ?
-                                        m_renderData.pMonitor->m_sdrSaturation :
-                                        1.0f);
-            shader->setUniformFloat(SHADER_SDR_BRIGHTNESS,
-                                    m_renderData.pMonitor->m_sdrBrightness > 0 &&
-                                            m_renderData.pMonitor->m_imageDescription->value().transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ ?
-                                        m_renderData.pMonitor->m_sdrBrightness :
-                                        1.0f);
-        } else
-            shader = useShader(getShaderVariant(SH_FRAG_BLURPREPARE));
+        WP<CShader> shader = useShader(getShaderVariant(SH_FRAG_BLURPREPARE));
 
         const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(MONITORBOX, *PBLEND ? HYPRUTILS_TRANSFORM_NORMAL : TRANSFORM);
         shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
@@ -1965,19 +1972,20 @@ void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox
 
         renderTextureInternal(data.blurredBG, box,
                               STextureRenderData{
-                                  .damage         = data.damage,
-                                  .a              = (*PBLURIGNOREOPACITY ? data.blurA : data.a * data.blurA) * data.overallA,
-                                  .round          = data.round,
-                                  .roundingPower  = data.roundingPower,
-                                  .discardActive  = false,
-                                  .allowCustomUV  = true,
-                                  .noAA           = false,
-                                  .wrapX          = data.wrapX,
-                                  .wrapY          = data.wrapY,
-                                  .discardMode    = data.discardMode,
-                                  .discardOpacity = data.discardOpacity,
-                                  .clipRegion     = data.clipRegion,
-                                  .currentLS      = data.currentLS,
+                                  .damage               = data.damage,
+                                  .a                    = (*PBLURIGNOREOPACITY ? data.blurA : data.a * data.blurA) * data.overallA,
+                                  .round                = data.round,
+                                  .roundingPower        = data.roundingPower,
+                                  .discardActive        = false,
+                                  .allowCustomUV        = true,
+                                  .noAA                 = false,
+                                  .wrapX                = data.wrapX,
+                                  .wrapY                = data.wrapY,
+                                  .sourceIsWorkBufferCM = true,
+                                  .discardMode          = data.discardMode,
+                                  .discardOpacity       = data.discardOpacity,
+                                  .clipRegion           = data.clipRegion,
+                                  .currentLS            = data.currentLS,
 
                                   .primarySurfaceUVTopLeft     = monitorSpaceBox.pos() / m_renderData.pMonitor->m_transformedSize,
                                   .primarySurfaceUVBottomRight = (monitorSpaceBox.pos() + monitorSpaceBox.size()) / m_renderData.pMonitor->m_transformedSize,

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -196,6 +196,7 @@ class CHyprOpenGLImpl {
         bool                   allowDim      = true;
         bool                   noAA          = false; // unused
         GLenum                 wrapX = GL_CLAMP_TO_EDGE, wrapY = GL_CLAMP_TO_EDGE;
+        bool                   sourceIsWorkBufferCM = false;
         bool                   cmBackToSRGB   = false;
         bool                   finalMonitorCM = false;
         SP<CMonitor>           cmBackToSRGBSource;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -70,6 +70,9 @@ extern "C" {
 #include <xf86drm.h>
 }
 
+static bool     isHDRTransferFunction(uint32_t tf);
+static uint32_t blurIntermediateFormat(const NColorManagement::PImageDescription& imageDescription, uint32_t fallback);
+
 static int cursorTicker(void* data) {
     g_pHyprRenderer->ensureCursorRenderingMode();
     wl_event_source_timer_update(g_pHyprRenderer->m_cursorTicker, 500);
@@ -2023,11 +2026,15 @@ bool IHyprRenderer::beginRender(PHLMONITOR pMonitor, CRegion& damage, eRenderMod
         setProjectionType(RPT_MONITOR);
 
     if (!simple) {
-        const auto DRM_FORMAT = fb ? fb->m_drmFormat : pMonitor->m_output->state->state().drmFormat;
+        const auto DRM_FORMAT      = fb ? fb->m_drmFormat : pMonitor->m_output->state->state().drmFormat;
+        const auto BLUR_DRM_FORMAT = blurIntermediateFormat(pMonitor->m_imageDescription, DRM_FORMAT);
 
         // ensure a framebuffer for the monitor exists
         if (!m_renderData.pMonitor->m_offloadFB || m_renderData.pMonitor->m_offloadFB->m_size != pMonitor->m_pixelSize ||
-            DRM_FORMAT != m_renderData.pMonitor->m_offloadFB->m_drmFormat) {
+            DRM_FORMAT != m_renderData.pMonitor->m_offloadFB->m_drmFormat || !m_renderData.pMonitor->m_mirrorFB ||
+            BLUR_DRM_FORMAT != m_renderData.pMonitor->m_mirrorFB->m_drmFormat || !m_renderData.pMonitor->m_mirrorSwapFB ||
+            BLUR_DRM_FORMAT != m_renderData.pMonitor->m_mirrorSwapFB->m_drmFormat || !m_renderData.pMonitor->m_blurFB ||
+            BLUR_DRM_FORMAT != m_renderData.pMonitor->m_blurFB->m_drmFormat) {
             if (!m_renderData.pMonitor->m_stencilTex || m_renderData.pMonitor->m_stencilTex->m_size != pMonitor->m_pixelSize)
                 m_renderData.pMonitor->m_stencilTex = createStencilTexture(m_renderData.pMonitor->m_pixelSize.x, m_renderData.pMonitor->m_pixelSize.y);
 
@@ -2045,8 +2052,8 @@ bool IHyprRenderer::beginRender(PHLMONITOR pMonitor, CRegion& damage, eRenderMod
             m_renderData.pMonitor->m_offMainFB->addStencil(m_renderData.pMonitor->m_stencilTex);
 
             m_renderData.pMonitor->m_offloadFB->alloc(pMonitor->m_pixelSize.x, pMonitor->m_pixelSize.y, DRM_FORMAT);
-            m_renderData.pMonitor->m_mirrorFB->alloc(pMonitor->m_pixelSize.x, pMonitor->m_pixelSize.y, DRM_FORMAT);
-            m_renderData.pMonitor->m_mirrorSwapFB->alloc(pMonitor->m_pixelSize.x, pMonitor->m_pixelSize.y, DRM_FORMAT);
+            m_renderData.pMonitor->m_mirrorFB->alloc(pMonitor->m_pixelSize.x, pMonitor->m_pixelSize.y, BLUR_DRM_FORMAT);
+            m_renderData.pMonitor->m_mirrorSwapFB->alloc(pMonitor->m_pixelSize.x, pMonitor->m_pixelSize.y, BLUR_DRM_FORMAT);
             m_renderData.pMonitor->m_offMainFB->alloc(pMonitor->m_pixelSize.x, pMonitor->m_pixelSize.y, DRM_FORMAT);
         }
     }
@@ -2162,7 +2169,7 @@ void IHyprRenderer::preBlurForCurrentMonitor(CRegion* fakeDamage) {
     // render onto blurFB
     if (!m_renderData.pMonitor->m_blurFB)
         return;
-    m_renderData.pMonitor->m_blurFB->alloc(m_renderData.pMonitor->m_pixelSize.x, m_renderData.pMonitor->m_pixelSize.y, m_renderData.pMonitor->m_output->state->state().drmFormat);
+    m_renderData.pMonitor->m_blurFB->alloc(m_renderData.pMonitor->m_pixelSize.x, m_renderData.pMonitor->m_pixelSize.y, blurIntermediateFormat(m_renderData.pMonitor->m_imageDescription, m_renderData.pMonitor->m_output->state->state().drmFormat));
     m_renderData.pMonitor->m_blurFB->bind();
 
     draw(makeUnique<CClearPassElement>(CClearPassElement::SClearData{{0, 0, 0, 0}}), {});
@@ -2170,9 +2177,10 @@ void IHyprRenderer::preBlurForCurrentMonitor(CRegion* fakeDamage) {
     pushMonitorTransformEnabled(true);
 
     draw(makeUnique<CTexPassElement>(CTexPassElement::SRenderData{
-             .tex    = blurredTex,
-             .box    = CBox{0, 0, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y},
-             .damage = *fakeDamage,
+             .tex                  = blurredTex,
+             .box                  = CBox{0, 0, m_renderData.pMonitor->m_transformedSize.x, m_renderData.pMonitor->m_transformedSize.y},
+             .damage               = *fakeDamage,
+             .sourceIsWorkBufferCM = true,
          }),
          *fakeDamage); // .noAA = true
 
@@ -2195,6 +2203,15 @@ static bool isHDR2SDR(const NColorManagement::SImageDescription& imageDescriptio
             imageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_HLG) &&
         (targetImageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_SRGB ||
          targetImageDescription.transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_GAMMA22);
+}
+
+static bool isHDRTransferFunction(uint32_t tf) {
+    return tf == NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ || tf == NColorManagement::CM_TRANSFER_FUNCTION_HLG ||
+        tf == NColorManagement::CM_TRANSFER_FUNCTION_EXT_LINEAR;
+}
+
+static uint32_t blurIntermediateFormat(const NColorManagement::PImageDescription& imageDescription, uint32_t fallback) {
+    return imageDescription && isHDRTransferFunction(imageDescription->value().transferFunction) ? DRM_FORMAT_XBGR16161616F : fallback;
 }
 
 SCMSettings IHyprRenderer::getCMSettings(const NColorManagement::PImageDescription imageDescription, const NColorManagement::PImageDescription targetImageDescription,

--- a/src/render/pass/TexPassElement.hpp
+++ b/src/render/pass/TexPassElement.hpp
@@ -28,6 +28,7 @@ class CTexPassElement : public IPassElement {
         bool                   blur = false;
         std::optional<float>   ignoreAlpha;
         std::optional<bool>    blockBlurOptimization;
+        bool                   sourceIsWorkBufferCM = false;
         bool                   cmBackToSRGB = false;
         SP<CMonitor>           cmBackToSRGBSource;
 

--- a/src/render/shaders/glsl/blurprepare.frag
+++ b/src/render/shaders/glsl/blurprepare.frag
@@ -11,28 +11,9 @@ uniform sampler2D tex;
 uniform float     contrast;
 uniform float     brightness;
 
-uniform int       sourceTF; // eTransferFunction
-uniform int       targetTF; // eTransferFunction
-
-#if USE_CM
-uniform vec2  srcTFRange;
-uniform vec2  dstTFRange;
-
-uniform float srcRefLuminance;
-uniform mat3  convertMatrix;
-
-uniform float sdrBrightnessMultiplier;
-#include "cm_helpers.glsl"
-#endif
-
 #include "blurprepare.glsl"
 
 layout(location = 0) out vec4 fragColor;
 void main() {
-    fragColor = fragColor = blurPrepare(texture(tex, v_texcoord), contrast, brightness
-#if USE_CM
-                                        ,
-                                        sourceTF, targetTF, convertMatrix, srcTFRange, dstTFRange, srcRefLuminance, sdrBrightnessMultiplier
-#endif
-    );
+    fragColor = blurPrepare(texture(tex, v_texcoord), contrast, brightness);
 }

--- a/src/render/shaders/glsl/blurprepare.glsl
+++ b/src/render/shaders/glsl/blurprepare.glsl
@@ -5,27 +5,9 @@
 
 #include "defines.h"
 
-#if USE_CM
-#include "cm_helpers.glsl"
-#endif
-
 #include "gain.glsl"
 
-vec4 blurPrepare(vec4 pixColor, float contrast, float brightness
-#if USE_CM
-                 ,
-                 int sourceTF, int targetTF, mat3 convertMatrix, vec2 srcTFRange, vec2 dstTFRange, float srcRefLuminance, float sdrBrightnessMultiplier
-#endif
-) {
-#if USE_CM
-    if (sourceTF == CM_TRANSFER_FUNCTION_ST2084_PQ) {
-        pixColor.rgb /= sdrBrightnessMultiplier;
-    }
-    pixColor.rgb = convertMatrix * toLinearRGB(pixColor.rgb, sourceTF);
-    pixColor     = toNit(pixColor, vec2(srcTFRange[0], srcRefLuminance));
-    pixColor     = fromLinearNit(pixColor, targetTF, dstTFRange);
-#endif
-
+vec4 blurPrepare(vec4 pixColor, float contrast, float brightness) {
     // contrast
     if (contrast != 1.0)
         pixColor.rgb = gain(pixColor.rgb, contrast);


### PR DESCRIPTION
#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Full disclosure, I've never worked in this codebase before, so to lower my barrier of entry, I used opencode with GPT 5.4 for this fix. Afterwards, I reviewed what it changed and removed all changes that didn't seem to be necessary.

#### Describe your PR, what does it fix/add?
With cm=hdr enabled, blurring the wallpaper would also dim it by a lot. I experienced this bug on this version:
Hyprland 0.54.1 built from branch v0.54.1-b at commit 4b07770b9ef1cceb2e6f56d33538aaffb9186b9c clean ([gha] Nix: update inputs).
Date: 2026-03-03

Some images...

### Before
#### HDR
<img width="1762" height="1322" alt="image" src="https://github.com/user-attachments/assets/5532e164-1b7c-4a88-817b-917a82bf4320" />
<img width="1762" height="1322" alt="image" src="https://github.com/user-attachments/assets/174dc657-e1b4-422d-8771-df260c56c294" />

#### SDR
<img width="1762" height="1322" alt="image" src="https://github.com/user-attachments/assets/3eec653a-e52e-4c7f-8495-ad32a1644549" />
<img width="1762" height="1322" alt="image" src="https://github.com/user-attachments/assets/b4ddd056-cdff-4a90-b731-86f07c7d3ba5" />


### After
#### HDR
<img width="1762" height="1322" alt="image" src="https://github.com/user-attachments/assets/93a41e8c-f4bd-4111-8a40-5603373a5cb1" />
<img width="1762" height="1322" alt="image" src="https://github.com/user-attachments/assets/399b8084-888f-4e05-b047-225a979dae74" />

#### SDR
<img width="1762" height="1322" alt="image" src="https://github.com/user-attachments/assets/c34e0de3-429e-4b39-bc3e-b97b5d9288a1" />
<img width="1762" height="1322" alt="image" src="https://github.com/user-attachments/assets/3a51d55c-23c9-44e6-9c3a-13b7f61b921e" />

Excuse the pictures instead of screenshots, I have yet to find a program that properly takes screenshots in SDR. I have my own workaround where my screenshot utility automatically switches to SDR when taking screenshots, but then that would hide the bug. You can't tell in these images, but after my fix, the colors don't change at all when blurring in HDR, same as SDR


As for what was changed to fix this (GPT): 
Before, the blur pipeline converted the work buffer to SDR, applied blur, then converted the result back into the monitor/output color space. In HDR, that caused the blurred image to lose brightness.
My fix is to keep the blur pipeline in the work buffer’s native color-managed format instead of forcing it through that SDR conversion step. For HDR outputs, the intermediate blur buffers are also allocated in a floating-point HDR format, so blur is applied without losing HDR brightness/precision.

While working on this, I hit a bug with some wild artifacts on the right and bottom edge of the screen.

Removing this part of the patch brings those artifacts back.
<img width="3840" height="2160" alt="image" src="https://github.com/user-attachments/assets/bc7fb1e4-19d2-43f1-8398-7da0420403a4" />

Here are a couple images of the artifacts:
<img width="1016" height="762" alt="image" src="https://github.com/user-attachments/assets/a768b99c-5d23-46e4-ac64-02967b8bbbea" />
<img width="1016" height="762" alt="image" src="https://github.com/user-attachments/assets/3f6ccc11-737e-4e57-83da-41839cd7654e" />

According to GPT:
The edge artifacts were caused by the HDR blur intermediate buffers retaining stale pixel data outside the current damage region. Since blur is done with scissored/damage-limited passes, pixels near the screen edge could pick up those uncleared texels and produce visible color artifacts. The fix is to fully clear both HDR blur ping-pong framebuffers before running the blur passes, with scissor disabled and blending off, so the blur only samples clean data.

I'll admit I don't understand every detail, but after reviewing the code myself, GPT's descriptions of what changed seem to be accurate. 

#### Is it ready for merging, or does it need work?
This functions and doesn't seem to affect anything else. Someone who has more context about the code that was modified should probably check this. Assuming my changes don't have any non-obvious side effects, this PR's readiness depends on your taste.