### PR TITLE
Fix json output for the submap command

### DIFF
--- a/hyprtester/src/tests/main/hyprctl.cpp
+++ b/hyprtester/src/tests/main/hyprctl.cpp
@@ -173,6 +173,13 @@ static bool testGetprop() {
     return true;
 }
 
+static void testSubmap() {
+    NLog::log("{}Testing hyprctl submap", Colors::GREEN);
+
+    EXPECT(getCommandStdOut("hyprctl submap"), "default\n");
+    EXPECT(getCommandStdOut("hyprctl submap -j | jq -r \".\""), "default");
+}
+
 static bool test() {
     NLog::log("{}Testing hyprctl", Colors::GREEN);
 
@@ -186,6 +193,7 @@ static bool test() {
 
     testGetprop();
     testDevicesActiveLayoutIndex();
+    testSubmap();
     getFromSocket("/reload");
 
     return !ret;

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -2046,7 +2046,7 @@ static std::string submapRequest(eHyprCtlOutputFormat format, std::string reques
     if (submap.empty())
         submap = "default";
 
-    return format == FORMAT_JSON ? std::format("{{\"{}\"}}\n", escapeJSONStrings(submap)) : (submap + "\n");
+    return format == FORMAT_JSON ? std::format("\"{}\"\n", escapeJSONStrings(submap)) : (submap + "\n");
 }
 
 static std::string reloadShaders(eHyprCtlOutputFormat format, std::string request) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

The JSON output of the `submap` command is not accepted by tools for parsing JSON e.g. jq or the json python module. This is a fix to allow these tools to parse the JSON output.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Since this commit changes the output of `hyprctl submap -j` it technically break compatibility if anything is consuming the current format. However, since the current JSON output for this command is not recognized by e.g. `jq` the impact may be limited. Since the output of the submap is simple, the existing usage may parse this as-is.

I also noticed seem to be getting pretty inconsistent results from `../build/hyprtester/hyprtester --plugin ./plugin/hyprtestplugin.so`. This is both on this commit and `origin/main`. But I don't think this commit had any impact here.

#### Is it ready for merging, or does it need work?

Ready. This is a very trivial one line change.