### PR TITLE
pin: add workspace-scoped pinning via "pin WORKSPACE_IDS..." rule

### DIFF
--- a/hyprtester/src/tests/main/pin.cpp
+++ b/hyprtester/src/tests/main/pin.cpp
@@ -1,0 +1,299 @@
+#include "tests.hpp"
+#include "../../shared.hpp"
+#include "../../hyprctlCompat.hpp"
+#include "../shared.hpp"
+#include <thread>
+#include <chrono>
+
+static int ret = 0;
+
+static bool test() {
+    NLog::log("{}Testing scoped pin", Colors::GREEN);
+
+    getFromSocket("/dispatch workspace 1"); // no OK: we might already be on 1
+    Tests::killAllWindows();
+    EXPECT(Tests::windowCount(), 0);
+
+    // set up rules: float + pin to workspaces 2-3
+    OK(getFromSocket("/keyword windowrulev2 float, class:pintest"));
+    OK(getFromSocket("/keyword windowrulev2 pin 2-3, class:pintest"));
+
+    // spawn the window on workspace 2
+    NLog::log("{}Switching to workspace 2 and spawning pintest", Colors::YELLOW);
+    OK(getFromSocket("/dispatch workspace 2"));
+    auto kittyProc = Tests::spawnKitty("pintest");
+    if (!kittyProc) {
+        NLog::log("{}Error: pintest kitty did not spawn", Colors::RED);
+        return false;
+    }
+
+    // verify window is pinned with scoped workspaces
+    NLog::log("{}Verifying pinned state on workspace 2", Colors::YELLOW);
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_CONTAINS(str, "pinned: 1");
+        EXPECT_CONTAINS(str, "class: pintest");
+    }
+
+    // verify active window is pintest on workspace 2
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "class: pintest");
+        EXPECT_CONTAINS(str, "workspace: 2 (2)");
+    }
+
+    // switch to workspace 3 (in the pin set) -- window should follow
+    NLog::log("{}Switching to workspace 3 (in pin set), window should follow", Colors::YELLOW);
+    OK(getFromSocket("/dispatch workspace 3"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_CONTAINS(str, "class: pintest");
+        // window should now be on workspace 3
+        EXPECT_CONTAINS(str, "workspace: 3 (3)");
+    }
+
+    // switch to workspace 1 (NOT in the pin set) -- window should stay on 3
+    NLog::log("{}Switching to workspace 1 (not in pin set), window should hide", Colors::YELLOW);
+    OK(getFromSocket("/dispatch workspace 1"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        // pintest should still exist but be on workspace 3, not workspace 1
+        auto str = getFromSocket("/clients");
+        EXPECT_CONTAINS(str, "class: pintest");
+        EXPECT_NOT_CONTAINS(str, "workspace: 1 (1)\n\tfloating: 1\n\tpseudo: 0\n\tmonitor: 0\n\tclass: pintest");
+    }
+
+    // switch back to workspace 2 (in pin set) -- window should reappear from workspace 3
+    NLog::log("{}Switching to workspace 2 (in pin set), window should reappear", Colors::YELLOW);
+    OK(getFromSocket("/dispatch workspace 2"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_CONTAINS(str, "class: pintest");
+        // window should have moved to workspace 2
+        EXPECT_CONTAINS(str, "workspace: 2 (2)");
+    }
+
+    // test global pin: spawn a globally pinned window and verify it follows everywhere
+    NLog::log("{}Testing global pin still works", Colors::YELLOW);
+    OK(getFromSocket("/keyword windowrulev2 float, class:globalpin"));
+    OK(getFromSocket("/keyword windowrulev2 pin, class:globalpin"));
+
+    auto kittyGlobal = Tests::spawnKitty("globalpin");
+    if (!kittyGlobal) {
+        NLog::log("{}Error: globalpin kitty did not spawn", Colors::RED);
+        return false;
+    }
+
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_CONTAINS(str, "class: globalpin");
+        EXPECT_CONTAINS(str, "pinned: 1");
+    }
+
+    // switch to workspace 5 -- globally pinned window should follow
+    NLog::log("{}Switching to workspace 5, global pin should follow", Colors::YELLOW);
+    OK(getFromSocket("/dispatch workspace 5"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        auto str = getFromSocket("/clients");
+        // globalpin should be on workspace 5 now
+        // find the globalpin entry and check its workspace
+        auto pos = str.find("class: globalpin");
+        EXPECT(pos != std::string::npos, true);
+        if (pos != std::string::npos) {
+            auto before = str.substr(0, pos);
+            auto lastWs = before.rfind("workspace: ");
+            EXPECT(lastWs != std::string::npos, true);
+            if (lastWs != std::string::npos) {
+                EXPECT_CONTAINS(before.substr(lastWs), "workspace: 5 (5)");
+            }
+        }
+    }
+
+    // switch back to workspace 1 -- global pin should follow, scoped pin should not
+    NLog::log("{}Switching to workspace 1, verifying both pin types", Colors::YELLOW);
+    OK(getFromSocket("/dispatch workspace 1"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        auto str = getFromSocket("/clients");
+
+        // globalpin should be on workspace 1
+        auto gpos = str.find("class: globalpin");
+        EXPECT(gpos != std::string::npos, true);
+        if (gpos != std::string::npos) {
+            auto before = str.substr(0, gpos);
+            auto lastWs = before.rfind("workspace: ");
+            if (lastWs != std::string::npos) {
+                EXPECT_CONTAINS(before.substr(lastWs), "workspace: 1 (1)");
+            }
+        }
+
+        // pintest should NOT be on workspace 1
+        auto ppos = str.find("class: pintest");
+        EXPECT(ppos != std::string::npos, true);
+        if (ppos != std::string::npos) {
+            auto before = str.substr(0, ppos);
+            auto lastWs = before.rfind("workspace: ");
+            if (lastWs != std::string::npos) {
+                EXPECT_NOT_CONTAINS(before.substr(lastWs), "workspace: 1 (1)");
+            }
+        }
+    }
+
+    // test pin toggle via dispatcher clears scoped state
+    NLog::log("{}Testing pin toggle clears scoped state", Colors::YELLOW);
+    OK(getFromSocket("/dispatch workspace 2"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    OK(getFromSocket("/dispatch focuswindow class:pintest"));
+    OK(getFromSocket("/dispatch pin"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "class: pintest");
+        EXPECT_CONTAINS(str, "pinned: 0");
+    }
+
+    // re-pin via dispatcher should give global pin, not restore scoped state
+    NLog::log("{}Testing re-pin via dispatcher is global", Colors::YELLOW);
+    OK(getFromSocket("/dispatch pin"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "pinned: 1");
+        EXPECT_CONTAINS(str, "pinnedWorkspaces: \n");
+    }
+    OK(getFromSocket("/dispatch pin"));
+
+    Tests::killAllWindows();
+    EXPECT(Tests::windowCount(), 0);
+
+    // test individual workspace IDs (not a range)
+    NLog::log("{}Testing individual workspace IDs in pin rule", Colors::YELLOW);
+    OK(getFromSocket("/keyword windowrulev2 float, class:pinids"));
+    OK(getFromSocket("/keyword windowrulev2 pin 2 5 8, class:pinids"));
+    getFromSocket("/dispatch workspace 2"); // no OK: previous workspace may not exist after cleanup
+    auto kittyIds = Tests::spawnKitty("pinids");
+    if (!kittyIds) {
+        NLog::log("{}Error: pinids kitty did not spawn", Colors::RED);
+        return false;
+    }
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "class: pinids");
+        EXPECT_CONTAINS(str, "pinnedWorkspaces: 2 5 8");
+    }
+
+    // should follow to workspace 5 (in set)
+    OK(getFromSocket("/dispatch workspace 5"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        auto str = getFromSocket("/clients");
+        auto pos = str.find("class: pinids");
+        EXPECT(pos != std::string::npos, true);
+        if (pos != std::string::npos) {
+            auto before = str.substr(0, pos);
+            auto lastWs = before.rfind("workspace: ");
+            if (lastWs != std::string::npos)
+                EXPECT_CONTAINS(before.substr(lastWs), "workspace: 5 (5)");
+        }
+    }
+
+    // should NOT follow to workspace 4 (not in set)
+    OK(getFromSocket("/dispatch workspace 4"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        auto str = getFromSocket("/clients");
+        auto pos = str.find("class: pinids");
+        EXPECT(pos != std::string::npos, true);
+        if (pos != std::string::npos) {
+            auto before = str.substr(0, pos);
+            auto lastWs = before.rfind("workspace: ");
+            if (lastWs != std::string::npos)
+                EXPECT_NOT_CONTAINS(before.substr(lastWs), "workspace: 4 (4)");
+        }
+    }
+
+    Tests::killAllWindows();
+    EXPECT(Tests::windowCount(), 0);
+
+    // test two scoped-pinned windows with different sets
+    NLog::log("{}Testing multiple scoped pins with different sets", Colors::YELLOW);
+    OK(getFromSocket("/keyword windowrulev2 float, class:pinA"));
+    OK(getFromSocket("/keyword windowrulev2 pin 1-2, class:pinA"));
+    OK(getFromSocket("/keyword windowrulev2 float, class:pinB"));
+    OK(getFromSocket("/keyword windowrulev2 pin 3-4, class:pinB"));
+
+    OK(getFromSocket("/dispatch workspace 1"));
+    auto kittyA = Tests::spawnKitty("pinA");
+    if (!kittyA) {
+        NLog::log("{}Error: pinA kitty did not spawn", Colors::RED);
+        return false;
+    }
+
+    OK(getFromSocket("/dispatch workspace 3"));
+    auto kittyB = Tests::spawnKitty("pinB");
+    if (!kittyB) {
+        NLog::log("{}Error: pinB kitty did not spawn", Colors::RED);
+        return false;
+    }
+
+    // switch to workspace 2: pinA follows, pinB stays on 3
+    OK(getFromSocket("/dispatch workspace 2"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        auto str = getFromSocket("/clients");
+
+        auto posA = str.find("class: pinA");
+        EXPECT(posA != std::string::npos, true);
+        if (posA != std::string::npos) {
+            auto before = str.substr(0, posA);
+            auto lastWs = before.rfind("workspace: ");
+            if (lastWs != std::string::npos)
+                EXPECT_CONTAINS(before.substr(lastWs), "workspace: 2 (2)");
+        }
+
+        auto posB = str.find("class: pinB");
+        EXPECT(posB != std::string::npos, true);
+        if (posB != std::string::npos) {
+            auto before = str.substr(0, posB);
+            auto lastWs = before.rfind("workspace: ");
+            if (lastWs != std::string::npos)
+                EXPECT_NOT_CONTAINS(before.substr(lastWs), "workspace: 2 (2)");
+        }
+    }
+
+    // switch to workspace 4: pinB follows, pinA stays on 2
+    OK(getFromSocket("/dispatch workspace 4"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        auto str = getFromSocket("/clients");
+
+        auto posB = str.find("class: pinB");
+        EXPECT(posB != std::string::npos, true);
+        if (posB != std::string::npos) {
+            auto before = str.substr(0, posB);
+            auto lastWs = before.rfind("workspace: ");
+            if (lastWs != std::string::npos)
+                EXPECT_CONTAINS(before.substr(lastWs), "workspace: 4 (4)");
+        }
+
+        auto posA = str.find("class: pinA");
+        EXPECT(posA != std::string::npos, true);
+        if (posA != std::string::npos) {
+            auto before = str.substr(0, posA);
+            auto lastWs = before.rfind("workspace: ");
+            if (lastWs != std::string::npos)
+                EXPECT_NOT_CONTAINS(before.substr(lastWs), "workspace: 4 (4)");
+        }
+    }
+
+    NLog::log("{}Killing all windows", Colors::YELLOW);
+    Tests::killAllWindows();
+    EXPECT(Tests::windowCount(), 0);
+
+    return !ret;
+}
+
+REGISTER_TEST_FN(test)

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -889,7 +889,8 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
             if (ONLY_PRIORITY && !w->priorityFocus())
                 continue;
 
-            if (w->m_isFloating && w->m_isMapped && !w->isHidden() && !w->m_X11ShouldntFocus && w->m_pinned && !w->m_windowData.noFocus.valueOrDefault() && w != pIgnoreWindow) {
+            if (w->m_isFloating && w->m_isMapped && !w->isHidden() && !w->m_X11ShouldntFocus && w->isPinnedOnWorkspace(PMONITOR->activeWorkspaceID()) &&
+                !w->m_windowData.noFocus.valueOrDefault() && w != pIgnoreWindow) {
                 const auto BB  = w->getWindowBoxUnified(properties);
                 CBox       box = BB.copy().expand(!w->isX11OverrideRedirect() ? BORDER_GRAB_AREA : 0);
                 if (box.containsPoint(g_pPointerManager->position()))
@@ -926,8 +927,8 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
                         continue;
                 }
 
-                if (w->m_isFloating && w->m_isMapped && w->m_workspace->isVisible() && !w->isHidden() && !w->m_pinned && !w->m_windowData.noFocus.valueOrDefault() &&
-                    w != pIgnoreWindow && (!aboveFullscreen || w->m_createdOverFullscreen)) {
+                if (w->m_isFloating && w->m_isMapped && w->m_workspace->isVisible() && !w->isHidden() && !w->isPinnedOnWorkspace(PMONITOR->activeWorkspaceID()) &&
+                    !w->m_windowData.noFocus.valueOrDefault() && w != pIgnoreWindow && (!aboveFullscreen || w->m_createdOverFullscreen)) {
                     // OR windows should add focus to parent
                     if (w->m_X11ShouldntFocus && !w->isX11OverrideRedirect())
                         continue;
@@ -1161,7 +1162,7 @@ void CCompositor::focusWindow(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface
     if (m_lastWindow.lock() == pWindow && g_pSeatManager->m_state.keyboardFocus == pSurface && g_pSeatManager->m_state.keyboardFocus)
         return;
 
-    if (pWindow->m_pinned)
+    if (pWindow->isPinnedOnWorkspace(m_lastMonitor->activeWorkspaceID()))
         pWindow->m_workspace = m_lastMonitor->m_activeWorkspace;
 
     const auto PMONITOR = pWindow->m_monitor.lock();
@@ -1185,7 +1186,8 @@ void CCompositor::focusWindow(PHLWINDOW pWindow, SP<CWLSurfaceResource> pSurface
 
     /* If special fallthrough is enabled, this behavior will be disabled, as I have no better idea of nicely tracking which
        window focuses are "via keybinds" and which ones aren't. */
-    if (PMONITOR && PMONITOR->m_activeSpecialWorkspace && PMONITOR->m_activeSpecialWorkspace != pWindow->m_workspace && !pWindow->m_pinned && !*PSPECIALFALLTHROUGH)
+    if (PMONITOR && PMONITOR->m_activeSpecialWorkspace && PMONITOR->m_activeSpecialWorkspace != pWindow->m_workspace && !pWindow->isPinnedOnWorkspace(PMONITOR->activeWorkspaceID()) &&
+        !*PSPECIALFALLTHROUGH)
         PMONITOR->setSpecialWorkspace(nullptr);
 
     // we need to make the PLASTWINDOW not equal to m_pLastWindow so that RENDERDATA is correct for an unfocused window
@@ -2289,7 +2291,7 @@ void CCompositor::updateFullscreenFadeOnWorkspace(PHLWORKSPACE pWorkspace) {
     for (auto const& w : g_pCompositor->m_windows) {
         if (w->m_workspace == pWorkspace) {
 
-            if (w->m_fadingOut || w->m_pinned || w->isFullscreen())
+            if (w->m_fadingOut || w->isPinnedOnWorkspace(pWorkspace->m_id) || w->isFullscreen())
                 continue;
 
             if (!FULLSCREEN)
@@ -2392,7 +2394,7 @@ void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, SFullscreenS
 
     // make all windows on the same workspace under the fullscreen window
     for (auto const& w : m_windows) {
-        if (w->m_workspace == PWORKSPACE && !w->isFullscreen() && !w->m_fadingOut && !w->m_pinned)
+        if (w->m_workspace == PWORKSPACE && !w->isFullscreen() && !w->m_fadingOut && !w->isPinnedOnWorkspace(PWORKSPACE->m_id))
             w->m_createdOverFullscreen = false;
     }
 

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -308,6 +308,16 @@ static std::string monitorsRequest(eHyprCtlOutputFormat format, std::string requ
     return result;
 }
 
+static std::string getPinnedWorkspacesData(PHLWINDOW w, eHyprCtlOutputFormat format) {
+    if (w->m_pinnedWorkspaces.empty())
+        return "";
+    if (format == eHyprCtlOutputFormat::FORMAT_JSON)
+        return std::ranges::fold_left(w->m_pinnedWorkspaces, std::string(),
+                                      [](const std::string& a, WORKSPACEID id) { return a.empty() ? std::to_string(id) : std::format("{}, {}", a, id); });
+    return std::ranges::fold_left(w->m_pinnedWorkspaces, std::string(),
+                                  [](const std::string& a, WORKSPACEID id) { return a.empty() ? std::to_string(id) : std::format("{} {}", a, id); });
+}
+
 static std::string getTagsData(PHLWINDOW w, eHyprCtlOutputFormat format) {
     const auto tags = w->m_tags.getTags();
 
@@ -373,6 +383,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
     "pid": {},
     "xwayland": {},
     "pinned": {},
+    "pinnedWorkspaces": [{}],
     "fullscreen": {},
     "fullscreenClient": {},
     "grouped": [{}],
@@ -387,22 +398,24 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             sc<int>(w->m_realPosition->goal().y), sc<int>(w->m_realSize->goal().x), sc<int>(w->m_realSize->goal().y), w->m_workspace ? w->workspaceID() : WORKSPACE_INVALID,
             escapeJSONStrings(!w->m_workspace ? "" : w->m_workspace->m_name), (sc<int>(w->m_isFloating) == 1 ? "true" : "false"), (w->m_isPseudotiled ? "true" : "false"),
             w->monitorID(), escapeJSONStrings(w->m_class), escapeJSONStrings(w->m_title), escapeJSONStrings(w->m_initialClass), escapeJSONStrings(w->m_initialTitle), w->getPID(),
-            (sc<int>(w->m_isX11) == 1 ? "true" : "false"), (w->m_pinned ? "true" : "false"), sc<uint8_t>(w->m_fullscreenState.internal), sc<uint8_t>(w->m_fullscreenState.client),
-            getGroupedData(w, format), getTagsData(w, format), rc<uintptr_t>(w->m_swallowed.get()), getFocusHistoryID(w),
-            (g_pInputManager->isWindowInhibiting(w, false) ? "true" : "false"), escapeJSONStrings(w->xdgTag().value_or("")), escapeJSONStrings(w->xdgDescription().value_or("")));
+            (sc<int>(w->m_isX11) == 1 ? "true" : "false"), (w->m_pinned ? "true" : "false"), getPinnedWorkspacesData(w, format),
+            sc<uint8_t>(w->m_fullscreenState.internal), sc<uint8_t>(w->m_fullscreenState.client), getGroupedData(w, format), getTagsData(w, format),
+            rc<uintptr_t>(w->m_swallowed.get()), getFocusHistoryID(w), (g_pInputManager->isWindowInhibiting(w, false) ? "true" : "false"),
+            escapeJSONStrings(w->xdgTag().value_or("")), escapeJSONStrings(w->xdgDescription().value_or("")));
     } else {
         return std::format(
             "Window {:x} -> {}:\n\tmapped: {}\n\thidden: {}\n\tat: {},{}\n\tsize: {},{}\n\tworkspace: {} ({})\n\tfloating: {}\n\tpseudo: {}\n\tmonitor: {}\n\tclass: {}\n\ttitle: "
             "{}\n\tinitialClass: {}\n\tinitialTitle: {}\n\tpid: "
             "{}\n\txwayland: {}\n\tpinned: "
-            "{}\n\tfullscreen: {}\n\tfullscreenClient: {}\n\tgrouped: {}\n\ttags: {}\n\tswallowing: {:x}\n\tfocusHistoryID: {}\n\tinhibitingIdle: {}\n\txdgTag: "
+            "{}\n\tpinnedWorkspaces: {}\n\tfullscreen: {}\n\tfullscreenClient: {}\n\tgrouped: {}\n\ttags: {}\n\tswallowing: {:x}\n\tfocusHistoryID: {}\n\tinhibitingIdle: {}\n\txdgTag: "
             "{}\n\txdgDescription: {}\n\n",
             rc<uintptr_t>(w.get()), w->m_title, sc<int>(w->m_isMapped), sc<int>(w->isHidden()), sc<int>(w->m_realPosition->goal().x), sc<int>(w->m_realPosition->goal().y),
             sc<int>(w->m_realSize->goal().x), sc<int>(w->m_realSize->goal().y), w->m_workspace ? w->workspaceID() : WORKSPACE_INVALID,
             (!w->m_workspace ? "" : w->m_workspace->m_name), sc<int>(w->m_isFloating), sc<int>(w->m_isPseudotiled), w->monitorID(), w->m_class, w->m_title, w->m_initialClass,
-            w->m_initialTitle, w->getPID(), sc<int>(w->m_isX11), sc<int>(w->m_pinned), sc<uint8_t>(w->m_fullscreenState.internal), sc<uint8_t>(w->m_fullscreenState.client),
-            getGroupedData(w, format), getTagsData(w, format), rc<uintptr_t>(w->m_swallowed.get()), getFocusHistoryID(w), sc<int>(g_pInputManager->isWindowInhibiting(w, false)),
-            w->xdgTag().value_or(""), w->xdgDescription().value_or(""));
+            w->m_initialTitle, w->getPID(), sc<int>(w->m_isX11), sc<int>(w->m_pinned), getPinnedWorkspacesData(w, format),
+            sc<uint8_t>(w->m_fullscreenState.internal), sc<uint8_t>(w->m_fullscreenState.client), getGroupedData(w, format), getTagsData(w, format),
+            rc<uintptr_t>(w->m_swallowed.get()), getFocusHistoryID(w), sc<int>(g_pInputManager->isWindowInhibiting(w, false)), w->xdgTag().value_or(""),
+            w->xdgDescription().value_or(""));
     }
 }
 

--- a/src/desktop/Window.cpp
+++ b/src/desktop/Window.cpp
@@ -1281,7 +1281,8 @@ void CWindow::setAnimationsToMove() {
 
 void CWindow::onWorkspaceAnimUpdate() {
     // clip box for animated offsets
-    if (!m_isFloating || m_pinned || isFullscreen() || m_draggingTiled) {
+    const auto POFFSETMON = m_monitor.lock();
+    if (!m_isFloating || (POFFSETMON && isPinnedOnWorkspace(POFFSETMON->activeWorkspaceID())) || isFullscreen() || m_draggingTiled) {
         m_floatingOffset = Vector2D(0, 0);
         return;
     }
@@ -1871,6 +1872,14 @@ PHLWINDOW CWindow::parent() {
 
 bool CWindow::priorityFocus() {
     return !m_isX11 && CAsyncDialogBox::isPriorityDialogBox(getPID());
+}
+
+bool CWindow::isPinnedOnWorkspace(WORKSPACEID id) const {
+    if (!m_pinned)
+        return false;
+    if (m_pinnedWorkspaces.empty())
+        return true;
+    return m_pinnedWorkspaces.contains(id);
 }
 
 SP<CWLSurfaceResource> CWindow::getSolitaryResource() {

--- a/src/desktop/Window.hpp
+++ b/src/desktop/Window.hpp
@@ -3,6 +3,7 @@
 #include <vector>
 #include <string>
 #include <optional>
+#include <set>
 
 #include "../config/ConfigDataValues.hpp"
 #include "../helpers/AnimatedVariable.hpp"
@@ -239,7 +240,8 @@ class CWindow {
     bool              m_animatingIn = false;
 
     // For pinned (sticky) windows
-    bool m_pinned = false;
+    bool                  m_pinned = false;
+    std::set<WORKSPACEID> m_pinnedWorkspaces; // empty = pinned to all workspaces
 
     // For preserving pinned state when fullscreening a pinned window
     bool m_pinFullscreened = false;
@@ -413,6 +415,7 @@ class CWindow {
     std::optional<std::string> xdgDescription();
     PHLWINDOW                  parent();
     bool                       priorityFocus();
+    bool                       isPinnedOnWorkspace(WORKSPACEID id) const;
     SP<CWLSurfaceResource>     getSolitaryResource();
 
     CBox                       getWindowMainSurfaceBox() const {

--- a/src/desktop/WindowRule.cpp
+++ b/src/desktop/WindowRule.cpp
@@ -5,12 +5,12 @@
 #include "../config/ConfigManager.hpp"
 
 static const auto RULES = std::unordered_set<std::string>{
-    "float", "fullscreen", "maximize", "noinitialfocus", "pin", "stayfocused", "tile", "renderunfocused", "persistentsize",
+    "float", "fullscreen", "maximize", "noinitialfocus", "stayfocused", "tile", "renderunfocused", "persistentsize",
 };
 static const auto RULES_PREFIX = std::unordered_set<std::string>{
     "animation",     "bordercolor", "bordersize", "center",  "content", "fullscreenstate", "group",    "idleinhibit",   "maxsize",     "minsize",        "monitor",
-    "move",          "noclosefor",  "opacity",    "plugin:", "prop",    "pseudo",          "rounding", "roundingpower", "scrollmouse", "scrolltouchpad", "size",
-    "suppressevent", "tag",         "workspace",  "xray",    "novrr",
+    "move",          "noclosefor",  "opacity",    "pin",     "plugin:", "prop",            "pseudo",   "rounding",      "roundingpower", "scrollmouse", "scrolltouchpad",
+    "size",          "suppressevent", "tag",       "workspace", "xray", "novrr",
 };
 
 CWindowRule::CWindowRule(const std::string& rule, const std::string& value, bool isV2, bool isExecRule) : m_value(value), m_rule(rule), m_v2(isV2), m_execRule(isExecRule) {
@@ -30,7 +30,7 @@ CWindowRule::CWindowRule(const std::string& rule, const std::string& value, bool
         m_ruleType = RULE_MAXIMIZE;
     else if (rule == "noinitialfocus")
         m_ruleType = RULE_NOINITIALFOCUS;
-    else if (rule == "pin")
+    else if (rule == "pin" || rule.starts_with("pin "))
         m_ruleType = RULE_PIN;
     else if (rule == "stayfocused")
         m_ruleType = RULE_STAYFOCUSED;

--- a/src/events/Windows.cpp
+++ b/src/events/Windows.cpp
@@ -246,6 +246,30 @@ void Events::listener_mapWindow(void* owner, void* data) {
             }
             case CWindowRule::RULE_PIN: {
                 PWINDOW->m_pinned = true;
+                PWINDOW->m_pinnedWorkspaces.clear();
+                const CVarList VARS(r->m_rule, 0, ' ');
+                for (size_t i = 1; i < VARS.size(); ++i) {
+                    const std::string token = VARS[i];
+                    if (token.empty())
+                        continue;
+                    const auto DASHPOS = token.find('-');
+                    if (DASHPOS != std::string::npos) {
+                        try {
+                            const int64_t rangeStart = std::stoll(token.substr(0, DASHPOS));
+                            const int64_t rangeEnd   = std::stoll(token.substr(DASHPOS + 1));
+                            for (int64_t ws = rangeStart; ws <= rangeEnd; ++ws)
+                                PWINDOW->m_pinnedWorkspaces.insert(ws);
+                        } catch (std::exception& e) {
+                            Debug::log(ERR, "Error parsing pin workspace range: {}", token);
+                        }
+                    } else {
+                        try {
+                            PWINDOW->m_pinnedWorkspaces.insert(std::stoll(token));
+                        } catch (std::exception& e) {
+                            Debug::log(ERR, "Error parsing pin workspace id: {}", token);
+                        }
+                    }
+                }
                 break;
             }
             case CWindowRule::RULE_FULLSCREEN: {
@@ -335,8 +359,10 @@ void Events::listener_mapWindow(void* owner, void* data) {
         PWINDOW->m_closeableSince = Time::steadyNow() + std::chrono::years(10 /* Should be enough, no? */);
 
     // disallow tiled pinned
-    if (PWINDOW->m_pinned && !PWINDOW->m_isFloating)
+    if (PWINDOW->m_pinned && !PWINDOW->m_isFloating) {
         PWINDOW->m_pinned = false;
+        PWINDOW->m_pinnedWorkspaces.clear();
+    }
 
     CVarList WORKSPACEARGS = CVarList(requestedWorkspace, 0, ' ');
 

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1238,14 +1238,16 @@ void CMonitor::changeWorkspace(const PHLWORKSPACE& pWorkspace, bool internal, bo
             POLDWORKSPACE->startAnim(false, ANIMTOLEFT);
         pWorkspace->startAnim(true, ANIMTOLEFT);
 
-        // move pinned windows
+        // move pinned windows to the new workspace if they should be visible on it
         for (auto const& w : g_pCompositor->m_windows) {
-            if (w->m_workspace == POLDWORKSPACE && w->m_pinned)
+            if (!w->m_pinned || w->m_workspace == pWorkspace)
+                continue;
+            if (w->isPinnedOnWorkspace(pWorkspace->m_id))
                 w->moveToWorkspace(pWorkspace);
         }
 
         if (!noFocus && !g_pCompositor->m_lastMonitor->m_activeSpecialWorkspace &&
-            !(g_pCompositor->m_lastWindow.lock() && g_pCompositor->m_lastWindow->m_pinned && g_pCompositor->m_lastWindow->m_monitor == m_self)) {
+            !(g_pCompositor->m_lastWindow.lock() && g_pCompositor->m_lastWindow->isPinnedOnWorkspace(pWorkspace->m_id) && g_pCompositor->m_lastWindow->m_monitor == m_self)) {
             static auto PFOLLOWMOUSE = CConfigValue<Hyprlang::INT>("input:follow_mouse");
             auto        pWindow      = pWorkspace->m_hasFullscreenWindow ? pWorkspace->getFullscreenWindow() : pWorkspace->getLastFocusedWindow();
 
@@ -1317,7 +1319,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
 
         g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m_id);
 
-        if (!(g_pCompositor->m_lastWindow.lock() && g_pCompositor->m_lastWindow->m_pinned && g_pCompositor->m_lastWindow->m_monitor == m_self)) {
+        if (!(g_pCompositor->m_lastWindow.lock() && g_pCompositor->m_lastWindow->isPinnedOnWorkspace(activeWorkspaceID()) && g_pCompositor->m_lastWindow->m_monitor == m_self)) {
             if (const auto PLAST = m_activeWorkspace->getLastFocusedWindow(); PLAST)
                 g_pCompositor->focusWindow(PLAST);
             else
@@ -1396,7 +1398,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
 
     g_pLayoutManager->getCurrentLayout()->recalculateMonitor(m_id);
 
-    if (!(g_pCompositor->m_lastWindow.lock() && g_pCompositor->m_lastWindow->m_pinned && g_pCompositor->m_lastWindow->m_monitor == m_self)) {
+    if (!(g_pCompositor->m_lastWindow.lock() && g_pCompositor->m_lastWindow->isPinnedOnWorkspace(activeWorkspaceID()) && g_pCompositor->m_lastWindow->m_monitor == m_self)) {
         if (const auto PLAST = pWorkspace->getLastFocusedWindow(); PLAST)
             g_pCompositor->focusWindow(PLAST);
         else

--- a/src/layout/IHyprLayout.cpp
+++ b/src/layout/IHyprLayout.cpp
@@ -739,6 +739,7 @@ void IHyprLayout::changeWindowFloatingMode(PHLWINDOW pWindow) {
     }
 
     pWindow->m_pinned = false;
+    pWindow->m_pinnedWorkspaces.clear();
 
     g_pHyprRenderer->damageWindow(pWindow, true);
 
@@ -998,7 +999,7 @@ bool IHyprLayout::updateDragWindow() {
 
         const auto PWORKSPACE = DRAGGINGWINDOW->m_workspace;
 
-        if (PWORKSPACE->m_hasFullscreenWindow && (!DRAGGINGWINDOW->m_isFloating || (!DRAGGINGWINDOW->m_createdOverFullscreen && !DRAGGINGWINDOW->m_pinned))) {
+        if (PWORKSPACE->m_hasFullscreenWindow && (!DRAGGINGWINDOW->m_isFloating || (!DRAGGINGWINDOW->m_createdOverFullscreen && !DRAGGINGWINDOW->isPinnedOnWorkspace(PWORKSPACE->m_id)))) {
             Debug::log(LOG, "Rejecting drag on a fullscreen workspace. (window under fullscreen)");
             g_pKeybindManager->changeMouseBindMode(MBIND_INVALID);
             return true;

--- a/src/managers/AnimationManager.cpp
+++ b/src/managers/AnimationManager.cpp
@@ -113,7 +113,7 @@ static void handleUpdate(CAnimatedVariable<VarType>& av, bool warp) {
             if (!w->m_isMapped || w->isHidden() || w->m_workspace != PWORKSPACE)
                 continue;
 
-            if (w->m_isFloating && !w->m_pinned) {
+            if (w->m_isFloating && !w->isPinnedOnWorkspace(PWORKSPACE->m_id)) {
                 // still doing the full damage hack for floating because sometimes when the window
                 // goes through multiple monitors the last rendered frame is missing damage somehow??
                 const CBox windowBoxNoOffset = w->getFullWindowBoundingBox();
@@ -128,7 +128,7 @@ static void handleUpdate(CAnimatedVariable<VarType>& av, bool warp) {
 
         // damage any workspace window that is on any monitor
         for (auto const& w : g_pCompositor->m_windows) {
-            if (!validMapped(w) || w->m_workspace != PWORKSPACE || w->m_pinned)
+            if (!validMapped(w) || w->m_workspace != PWORKSPACE || w->isPinnedOnWorkspace(PWORKSPACE->m_id))
                 continue;
 
             g_pHyprRenderer->damageWindow(w);
@@ -170,7 +170,7 @@ static void handleUpdate(CAnimatedVariable<VarType>& av, bool warp) {
                     w->updateWindowDecos();
 
                     // damage any workspace window that is on any monitor
-                    if (!w->m_pinned)
+                    if (!w->isPinnedOnWorkspace(PWORKSPACE->m_id))
                         g_pHyprRenderer->damageWindow(w);
                 }
             } else if (PLAYER) {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -393,12 +393,12 @@ void CKeybindManager::switchToWindow(PHLWINDOW PWINDOWTOCHANGETO, bool preserveF
         const auto PWORKSPACE = PLASTWINDOW->m_workspace;
         const auto MODE       = PWORKSPACE->m_fullscreenMode;
 
-        if (!PWINDOWTOCHANGETO->m_pinned)
+        if (!PWINDOWTOCHANGETO->isPinnedOnWorkspace(PWORKSPACE->m_id))
             g_pCompositor->setWindowFullscreenInternal(PLASTWINDOW, FSMODE_NONE);
 
         g_pCompositor->focusWindow(PWINDOWTOCHANGETO, nullptr, preserveFocusHistory);
 
-        if (!PWINDOWTOCHANGETO->m_pinned)
+        if (!PWINDOWTOCHANGETO->isPinnedOnWorkspace(PWORKSPACE->m_id))
             g_pCompositor->setWindowFullscreenInternal(PWINDOWTOCHANGETO, MODE);
 
         // warp the position + size animation, otherwise it looks weird.
@@ -2332,12 +2332,12 @@ SDispatchResult CKeybindManager::focusWindow(std::string regexp) {
 
             g_pCompositor->focusWindow(PWINDOW);
         } else {
-            if (FSWINDOW != PWINDOW && !PWINDOW->m_pinned)
+            if (FSWINDOW != PWINDOW && !PWINDOW->isPinnedOnWorkspace(PWORKSPACE->m_id))
                 g_pCompositor->setWindowFullscreenClient(FSWINDOW, FSMODE_NONE);
 
             g_pCompositor->focusWindow(PWINDOW);
 
-            if (FSWINDOW != PWINDOW && !PWINDOW->m_pinned)
+            if (FSWINDOW != PWINDOW && !PWINDOW->isPinnedOnWorkspace(PWORKSPACE->m_id))
                 g_pCompositor->setWindowFullscreenClient(PWINDOW, FSMODE);
 
             // warp the position + size animation, otherwise it looks weird.
@@ -2746,6 +2746,8 @@ SDispatchResult CKeybindManager::pinActive(std::string args) {
         return {.success = false, .error = "Window does not qualify to be pinned"};
 
     PWINDOW->m_pinned = !PWINDOW->m_pinned;
+    if (!PWINDOW->m_pinned)
+        PWINDOW->m_pinnedWorkspaces.clear();
 
     const auto PMONITOR = PWINDOW->m_monitor.lock();
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -375,8 +375,8 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
         }
 
         if (PWINDOWIDEAL &&
-            ((PWINDOWIDEAL->m_isFloating && (PWINDOWIDEAL->m_createdOverFullscreen || PWINDOWIDEAL->m_pinned)) /* floating over fullscreen or pinned */
-             || (PMONITOR->m_activeSpecialWorkspace == PWINDOWIDEAL->m_workspace) /* on an open special workspace */))
+            ((PWINDOWIDEAL->m_isFloating && (PWINDOWIDEAL->m_createdOverFullscreen || PWINDOWIDEAL->isPinnedOnWorkspace(PMONITOR->activeWorkspaceID())))
+             || (PMONITOR->m_activeSpecialWorkspace == PWINDOWIDEAL->m_workspace)))
             pFoundWindow = PWINDOWIDEAL;
 
         if (!pFoundWindow->m_isX11) {
@@ -410,7 +410,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
                         if (pFoundWindow != PWINDOWIDEAL)
                             pFoundWindow = g_pCompositor->vectorToWindowUnified(mouseCoords, RESERVED_EXTENTS | INPUT_EXTENTS | ALLOW_FLOATING);
 
-                        if (!(pFoundWindow && (pFoundWindow->m_isFloating && (pFoundWindow->m_createdOverFullscreen || pFoundWindow->m_pinned))))
+                        if (!(pFoundWindow && (pFoundWindow->m_isFloating && (pFoundWindow->m_createdOverFullscreen || pFoundWindow->isPinnedOnWorkspace(PMONITOR->activeWorkspaceID())))))
                             pFoundWindow = PWORKSPACE->getFullscreenWindow();
                     }
                 }

--- a/src/protocols/Screencopy.cpp
+++ b/src/protocols/Screencopy.cpp
@@ -226,7 +226,7 @@ void CScreencopyFrame::renderMon() {
         if UNLIKELY (!PWORKSPACE && !w->m_fadingOut && w->m_alpha->value() != 0.f)
             continue;
 
-        const auto renderOffset     = PWORKSPACE && !w->m_pinned ? PWORKSPACE->m_renderOffset->value() : Vector2D{};
+        const auto renderOffset     = PWORKSPACE && !w->isPinnedOnWorkspace(m_monitor->activeWorkspaceID()) ? PWORKSPACE->m_renderOffset->value() : Vector2D{};
         const auto REALPOS          = w->m_realPosition->value() + renderOffset;
         const auto noScreenShareBox = CBox{REALPOS.x, REALPOS.y, std::max(w->m_realSize->value().x, 5.0), std::max(w->m_realSize->value().y, 5.0)}
                                           .translate(-m_monitor->m_position)

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -190,7 +190,7 @@ bool CHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
     if (!pWindow->m_workspace && pWindow->m_fadingOut)
         return pWindow->workspaceID() == pMonitor->activeWorkspaceID() || pWindow->workspaceID() == pMonitor->activeSpecialWorkspaceID();
 
-    if (pWindow->m_pinned)
+    if (pWindow->isPinnedOnWorkspace(pMonitor->activeWorkspaceID()))
         return true;
 
     // if the window is being moved to a workspace that is not invisible, and the alpha is > 0.F, render it.
@@ -256,7 +256,7 @@ bool CHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow) {
     if (!pWindow->m_workspace)
         return false;
 
-    if (pWindow->m_pinned || PWORKSPACE->m_forceRendering)
+    if ((pWindow->m_pinned && pWindow->m_pinnedWorkspaces.empty()) || PWORKSPACE->m_forceRendering)
         return true;
 
     if (PWORKSPACE && PWORKSPACE->isVisible())
@@ -350,8 +350,8 @@ void CHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
 
     // then render windows over fullscreen.
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->workspaceID() != pWorkspaceWindow->workspaceID() || !w->m_isFloating || (!w->m_createdOverFullscreen && !w->m_pinned) || (!w->m_isMapped && !w->m_fadingOut) ||
-            w->isFullscreen())
+        if (w->workspaceID() != pWorkspaceWindow->workspaceID() || !w->m_isFloating ||
+            (!w->m_createdOverFullscreen && !w->isPinnedOnWorkspace(pWorkspace->m_id)) || (!w->m_isMapped && !w->m_fadingOut) || w->isFullscreen())
             continue;
 
         if (w->m_monitor == pWorkspace->m_monitor && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
@@ -445,7 +445,7 @@ void CHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
         if (!w)
             continue;
 
-        if (!w->m_isFloating || w->m_pinned)
+        if (!w->m_isFloating || w->isPinnedOnWorkspace(pWorkspace->m_id))
             continue;
 
         // some things may force us to ignore the special/not special disparity
@@ -478,7 +478,7 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     TRACY_GPU_ZONE("RenderWindow");
 
     const auto                       PWORKSPACE = pWindow->m_workspace;
-    const auto                       REALPOS    = pWindow->m_realPosition->value() + (pWindow->m_pinned ? Vector2D{} : PWORKSPACE->m_renderOffset->value());
+    const auto                       REALPOS    = pWindow->m_realPosition->value() + (pWindow->isPinnedOnWorkspace(pMonitor->activeWorkspaceID()) ? Vector2D{} : PWORKSPACE->m_renderOffset->value());
     static auto                      PDIMAROUND = CConfigValue<Hyprlang::FLOAT>("decoration:dim_around");
 
     CSurfacePassElement::SRenderData renderdata = {pMonitor, time};
@@ -508,7 +508,7 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
 
     renderdata.surface   = pWindow->m_wlSurface->resource();
     renderdata.dontRound = pWindow->isEffectiveInternalFSMode(FSMODE_FULLSCREEN) || pWindow->m_windowData.noRounding.valueOrDefault();
-    renderdata.fadeAlpha = pWindow->m_alpha->value() * (pWindow->m_pinned || USE_WORKSPACE_FADE_ALPHA ? 1.f : PWORKSPACE->m_alpha->value()) *
+    renderdata.fadeAlpha = pWindow->m_alpha->value() * (pWindow->isPinnedOnWorkspace(pMonitor->activeWorkspaceID()) || USE_WORKSPACE_FADE_ALPHA ? 1.f : PWORKSPACE->m_alpha->value()) *
         (USE_WORKSPACE_FADE_ALPHA ? pWindow->m_movingToWorkspaceAlpha->value() : 1.F) * pWindow->m_movingFromWorkspaceAlpha->value();
     renderdata.alpha         = pWindow->m_activeInactiveAlpha->value();
     renderdata.decorate      = decorate && !pWindow->m_X11DoesntWantBorders && !pWindow->isEffectiveInternalFSMode(FSMODE_FULLSCREEN);
@@ -547,7 +547,7 @@ void CHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     renderdata.pos.y += pWindow->m_floatingOffset.y;
 
     // if window is floating and we have a slide animation, clip it to its full bb
-    if (!ignorePosition && pWindow->m_isFloating && !pWindow->isFullscreen() && PWORKSPACE->m_renderOffset->isBeingAnimated() && !pWindow->m_pinned) {
+    if (!ignorePosition && pWindow->m_isFloating && !pWindow->isFullscreen() && PWORKSPACE->m_renderOffset->isBeingAnimated() && !pWindow->isPinnedOnWorkspace(pMonitor->activeWorkspaceID())) {
         CRegion rg =
             pWindow->getFullWindowBoundingBox().translate(-pMonitor->m_position + PWORKSPACE->m_renderOffset->value() + pWindow->m_floatingOffset).scale(pMonitor->m_scale);
         renderdata.clipBox = rg.getExtents();
@@ -974,13 +974,12 @@ void CHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         if (w->isHidden() && !w->m_isMapped && !w->m_fadingOut)
             continue;
 
-        if (!w->m_pinned || !w->m_isFloating)
+        if (!w->isPinnedOnWorkspace(pMonitor->activeWorkspaceID()) || !w->m_isFloating)
             continue;
 
         if (!shouldRenderWindow(w, pMonitor))
             continue;
 
-        // render the bad boy
         renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
     }
 
@@ -1881,7 +1880,9 @@ void CHyprRenderer::damageWindow(PHLWINDOW pWindow, bool forceFull) {
 
     CBox       windowBox        = pWindow->getFullWindowBoundingBox();
     const auto PWINDOWWORKSPACE = pWindow->m_workspace;
-    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated() && !pWindow->m_pinned)
+    const auto PDAMAGEMONITOR = PWINDOWWORKSPACE ? PWINDOWWORKSPACE->m_monitor.lock() : nullptr;
+    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated() &&
+        !(PDAMAGEMONITOR && pWindow->isPinnedOnWorkspace(PDAMAGEMONITOR->activeWorkspaceID())))
         windowBox.translate(PWINDOWWORKSPACE->m_renderOffset->value());
     windowBox.translate(pWindow->m_floatingOffset);
 

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -41,7 +41,9 @@ CBox CHyprBorderDecoration::assignedBoxGlobal() {
     if (!PWORKSPACE)
         return box;
 
-    const auto WORKSPACEOFFSET = PWORKSPACE && !m_window->m_pinned ? PWORKSPACE->m_renderOffset->value() : Vector2D();
+    const auto PWINDOWMONITOR  = m_window->m_monitor.lock();
+    const auto ACTIVEWSID      = PWINDOWMONITOR ? PWINDOWMONITOR->activeWorkspaceID() : WORKSPACE_INVALID;
+    const auto WORKSPACEOFFSET = PWORKSPACE && !m_window->isPinnedOnWorkspace(ACTIVEWSID) ? PWORKSPACE->m_renderOffset->value() : Vector2D();
     return box.translate(WORKSPACEOFFSET);
 }
 
@@ -120,7 +122,9 @@ void CHyprBorderDecoration::damageEntire() {
     const auto BORDERSIZE   = m_window->getRealBorderSize() + 1;
 
     const auto PWINDOWWORKSPACE = m_window->m_workspace;
-    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated() && !m_window->m_pinned)
+    const auto PBORDERMONITOR = m_window->m_monitor.lock();
+    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated() &&
+        !(PBORDERMONITOR && m_window->isPinnedOnWorkspace(PBORDERMONITOR->activeWorkspaceID())))
         surfaceBox.translate(PWINDOWWORKSPACE->m_renderOffset->value());
     surfaceBox.translate(m_window->m_floatingOffset);
 

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -47,8 +47,10 @@ void CHyprDropShadowDecoration::damageEntire() {
                             PWINDOW->m_realSize->value().x + m_extents.topLeft.x + m_extents.bottomRight.x,
                             PWINDOW->m_realSize->value().y + m_extents.topLeft.y + m_extents.bottomRight.y};
 
-    const auto PWORKSPACE = PWINDOW->m_workspace;
-    if (PWORKSPACE && PWORKSPACE->m_renderOffset->isBeingAnimated() && !PWINDOW->m_pinned)
+    const auto PWORKSPACE     = PWINDOW->m_workspace;
+    const auto PSHADOWMON     = PWINDOW->m_monitor.lock();
+    const auto SHADOWACTIVEWS = PSHADOWMON ? PSHADOWMON->activeWorkspaceID() : WORKSPACE_INVALID;
+    if (PWORKSPACE && PWORKSPACE->m_renderOffset->isBeingAnimated() && !PWINDOW->isPinnedOnWorkspace(SHADOWACTIVEWS))
         shadowBox.translate(PWORKSPACE->m_renderOffset->value());
     shadowBox.translate(PWINDOW->m_floatingOffset);
 
@@ -59,7 +61,7 @@ void CHyprDropShadowDecoration::damageEntire() {
     CRegion     shadowRegion(shadowBox);
     if (*PSHADOWIGNOREWINDOW) {
         CBox surfaceBox = PWINDOW->getWindowMainSurfaceBox();
-        if (PWORKSPACE && PWORKSPACE->m_renderOffset->isBeingAnimated() && !PWINDOW->m_pinned)
+        if (PWORKSPACE && PWORKSPACE->m_renderOffset->isBeingAnimated() && !PWINDOW->isPinnedOnWorkspace(SHADOWACTIVEWS))
             surfaceBox.translate(PWORKSPACE->m_renderOffset->value());
         surfaceBox.translate(PWINDOW->m_floatingOffset);
         surfaceBox.expand(-ROUNDINGSIZE);
@@ -121,7 +123,7 @@ void CHyprDropShadowDecoration::render(PHLMONITOR pMonitor, float const& a) {
     const auto ROUNDINGPOWER   = PWINDOW->roundingPower();
     const auto ROUNDING        = ROUNDINGBASE > 0 ? ROUNDINGBASE + PWINDOW->getRealBorderSize() : 0;
     const auto PWORKSPACE      = PWINDOW->m_workspace;
-    const auto WORKSPACEOFFSET = PWORKSPACE && !PWINDOW->m_pinned ? PWORKSPACE->m_renderOffset->value() : Vector2D();
+    const auto WORKSPACEOFFSET = PWORKSPACE && !PWINDOW->isPinnedOnWorkspace(pMonitor->activeWorkspaceID()) ? PWORKSPACE->m_renderOffset->value() : Vector2D();
 
     // draw the shadow
     CBox fullBox = m_lastWindowBoxWithDecos;

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -600,7 +600,8 @@ CBox CHyprGroupBarDecoration::assignedBoxGlobal() {
 
     const auto PWORKSPACE = m_window->m_workspace;
 
-    if (PWORKSPACE && !m_window->m_pinned)
+    const auto PGROUPMONITOR = m_window->m_monitor.lock();
+    if (PWORKSPACE && !(PGROUPMONITOR && m_window->isPinnedOnWorkspace(PGROUPMONITOR->activeWorkspaceID())))
         box.translate(PWORKSPACE->m_renderOffset->value());
 
     return box.round();


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
Extends the pin window rule to accept workspace IDs so a window can be sticky only on specific workspaces. pin alone still works as before. You can pass individual IDs or ranges:
```
windowrule = pin 1 3, class:^(myapp)$
windowrule = pin 1-4, class:^(myapp)$
```
Also adds pinnedWorkspaces to hyprctl clients output (empty = pinned to all workspaces).


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
hyprctl clients output format changes -- new pinnedWorkspaces field in JSON, new line in plain text. Anything parsing that output by position will break.

The pin dispatching action (pinActive) still toggles without workspace scope, it just clears pinnedWorkspaces on unpin. Not sure if that's the right behavior or if it should be extended too.


Parts of the test file were written with AI assistance (claude code with opus 4.6) and reviewed by me

#### Is it ready for merging, or does it need work?
Needs review, especially around the workspace switching logic in Monitor.cpp and whether the pinActive keybind should also support workspace arguments




