### PR TITLE
pin: support workspace selectors for scoped pinning

### DIFF
--- a/hyprtester/src/tests/main/pin.cpp
+++ b/hyprtester/src/tests/main/pin.cpp
@@ -1,0 +1,299 @@
+#include "tests.hpp"
+#include "../../shared.hpp"
+#include "../../hyprctlCompat.hpp"
+#include "../shared.hpp"
+#include <thread>
+#include <chrono>
+
+static int ret = 0;
+
+static bool test() {
+    NLog::log("{}Testing scoped pin", Colors::GREEN);
+
+    getFromSocket("/dispatch workspace 1"); // no OK: we might already be on 1
+    Tests::killAllWindows();
+    EXPECT(Tests::windowCount(), 0);
+
+    // set up rules: float + pin to workspaces 2-3
+    OK(getFromSocket("/keyword windowrulev2 float, class:pintest"));
+    OK(getFromSocket("/keyword windowrulev2 pin 2-3, class:pintest"));
+
+    // spawn the window on workspace 2
+    NLog::log("{}Switching to workspace 2 and spawning pintest", Colors::YELLOW);
+    OK(getFromSocket("/dispatch workspace 2"));
+    auto kittyProc = Tests::spawnKitty("pintest");
+    if (!kittyProc) {
+        NLog::log("{}Error: pintest kitty did not spawn", Colors::RED);
+        return false;
+    }
+
+    // verify window is pinned with scoped workspaces
+    NLog::log("{}Verifying pinned state on workspace 2", Colors::YELLOW);
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_CONTAINS(str, "pinned: 1");
+        EXPECT_CONTAINS(str, "class: pintest");
+    }
+
+    // verify active window is pintest on workspace 2
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "class: pintest");
+        EXPECT_CONTAINS(str, "workspace: 2 (2)");
+    }
+
+    // switch to workspace 3 (in the pin set) -- window should follow
+    NLog::log("{}Switching to workspace 3 (in pin set), window should follow", Colors::YELLOW);
+    OK(getFromSocket("/dispatch workspace 3"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_CONTAINS(str, "class: pintest");
+        // window should now be on workspace 3
+        EXPECT_CONTAINS(str, "workspace: 3 (3)");
+    }
+
+    // switch to workspace 1 (NOT in the pin set) -- window should stay on 3
+    NLog::log("{}Switching to workspace 1 (not in pin set), window should hide", Colors::YELLOW);
+    OK(getFromSocket("/dispatch workspace 1"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        // pintest should still exist but be on workspace 3, not workspace 1
+        auto str = getFromSocket("/clients");
+        EXPECT_CONTAINS(str, "class: pintest");
+        EXPECT_NOT_CONTAINS(str, "workspace: 1 (1)\n\tfloating: 1\n\tpseudo: 0\n\tmonitor: 0\n\tclass: pintest");
+    }
+
+    // switch back to workspace 2 (in pin set) -- window should reappear from workspace 3
+    NLog::log("{}Switching to workspace 2 (in pin set), window should reappear", Colors::YELLOW);
+    OK(getFromSocket("/dispatch workspace 2"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_CONTAINS(str, "class: pintest");
+        // window should have moved to workspace 2
+        EXPECT_CONTAINS(str, "workspace: 2 (2)");
+    }
+
+    // test global pin: spawn a globally pinned window and verify it follows everywhere
+    NLog::log("{}Testing global pin still works", Colors::YELLOW);
+    OK(getFromSocket("/keyword windowrulev2 float, class:globalpin"));
+    OK(getFromSocket("/keyword windowrulev2 pin, class:globalpin"));
+
+    auto kittyGlobal = Tests::spawnKitty("globalpin");
+    if (!kittyGlobal) {
+        NLog::log("{}Error: globalpin kitty did not spawn", Colors::RED);
+        return false;
+    }
+
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_CONTAINS(str, "class: globalpin");
+        EXPECT_CONTAINS(str, "pinned: 1");
+    }
+
+    // switch to workspace 5 -- globally pinned window should follow
+    NLog::log("{}Switching to workspace 5, global pin should follow", Colors::YELLOW);
+    OK(getFromSocket("/dispatch workspace 5"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        auto str = getFromSocket("/clients");
+        // globalpin should be on workspace 5 now
+        // find the globalpin entry and check its workspace
+        auto pos = str.find("class: globalpin");
+        EXPECT(pos != std::string::npos, true);
+        if (pos != std::string::npos) {
+            auto before = str.substr(0, pos);
+            auto lastWs = before.rfind("workspace: ");
+            EXPECT(lastWs != std::string::npos, true);
+            if (lastWs != std::string::npos) {
+                EXPECT_CONTAINS(before.substr(lastWs), "workspace: 5 (5)");
+            }
+        }
+    }
+
+    // switch back to workspace 1 -- global pin should follow, scoped pin should not
+    NLog::log("{}Switching to workspace 1, verifying both pin types", Colors::YELLOW);
+    OK(getFromSocket("/dispatch workspace 1"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        auto str = getFromSocket("/clients");
+
+        // globalpin should be on workspace 1
+        auto gpos = str.find("class: globalpin");
+        EXPECT(gpos != std::string::npos, true);
+        if (gpos != std::string::npos) {
+            auto before = str.substr(0, gpos);
+            auto lastWs = before.rfind("workspace: ");
+            if (lastWs != std::string::npos) {
+                EXPECT_CONTAINS(before.substr(lastWs), "workspace: 1 (1)");
+            }
+        }
+
+        // pintest should NOT be on workspace 1
+        auto ppos = str.find("class: pintest");
+        EXPECT(ppos != std::string::npos, true);
+        if (ppos != std::string::npos) {
+            auto before = str.substr(0, ppos);
+            auto lastWs = before.rfind("workspace: ");
+            if (lastWs != std::string::npos) {
+                EXPECT_NOT_CONTAINS(before.substr(lastWs), "workspace: 1 (1)");
+            }
+        }
+    }
+
+    // test pin toggle via dispatcher clears scoped state
+    NLog::log("{}Testing pin toggle clears scoped state", Colors::YELLOW);
+    OK(getFromSocket("/dispatch workspace 2"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    OK(getFromSocket("/dispatch focuswindow class:pintest"));
+    OK(getFromSocket("/dispatch pin"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "class: pintest");
+        EXPECT_CONTAINS(str, "pinned: 0");
+    }
+
+    // re-pin via dispatcher should give global pin, not restore scoped state
+    NLog::log("{}Testing re-pin via dispatcher is global", Colors::YELLOW);
+    OK(getFromSocket("/dispatch pin"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "pinned: 1");
+        EXPECT_CONTAINS(str, "pinnedWorkspaces: \n");
+    }
+    OK(getFromSocket("/dispatch pin"));
+
+    Tests::killAllWindows();
+    EXPECT(Tests::windowCount(), 0);
+
+    // test individual workspace IDs (not a range)
+    NLog::log("{}Testing individual workspace IDs in pin rule", Colors::YELLOW);
+    OK(getFromSocket("/keyword windowrulev2 float, class:pinids"));
+    OK(getFromSocket("/keyword windowrulev2 pin 2 5 8, class:pinids"));
+    getFromSocket("/dispatch workspace 2"); // no OK: previous workspace may not exist after cleanup
+    auto kittyIds = Tests::spawnKitty("pinids");
+    if (!kittyIds) {
+        NLog::log("{}Error: pinids kitty did not spawn", Colors::RED);
+        return false;
+    }
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "class: pinids");
+        EXPECT_CONTAINS(str, "pinnedWorkspaces: 2 5 8");
+    }
+
+    // should follow to workspace 5 (in set)
+    OK(getFromSocket("/dispatch workspace 5"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        auto str = getFromSocket("/clients");
+        auto pos = str.find("class: pinids");
+        EXPECT(pos != std::string::npos, true);
+        if (pos != std::string::npos) {
+            auto before = str.substr(0, pos);
+            auto lastWs = before.rfind("workspace: ");
+            if (lastWs != std::string::npos)
+                EXPECT_CONTAINS(before.substr(lastWs), "workspace: 5 (5)");
+        }
+    }
+
+    // should NOT follow to workspace 4 (not in set)
+    OK(getFromSocket("/dispatch workspace 4"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        auto str = getFromSocket("/clients");
+        auto pos = str.find("class: pinids");
+        EXPECT(pos != std::string::npos, true);
+        if (pos != std::string::npos) {
+            auto before = str.substr(0, pos);
+            auto lastWs = before.rfind("workspace: ");
+            if (lastWs != std::string::npos)
+                EXPECT_NOT_CONTAINS(before.substr(lastWs), "workspace: 4 (4)");
+        }
+    }
+
+    Tests::killAllWindows();
+    EXPECT(Tests::windowCount(), 0);
+
+    // test two scoped-pinned windows with different sets
+    NLog::log("{}Testing multiple scoped pins with different sets", Colors::YELLOW);
+    OK(getFromSocket("/keyword windowrulev2 float, class:pinA"));
+    OK(getFromSocket("/keyword windowrulev2 pin 1-2, class:pinA"));
+    OK(getFromSocket("/keyword windowrulev2 float, class:pinB"));
+    OK(getFromSocket("/keyword windowrulev2 pin 3-4, class:pinB"));
+
+    OK(getFromSocket("/dispatch workspace 1"));
+    auto kittyA = Tests::spawnKitty("pinA");
+    if (!kittyA) {
+        NLog::log("{}Error: pinA kitty did not spawn", Colors::RED);
+        return false;
+    }
+
+    OK(getFromSocket("/dispatch workspace 3"));
+    auto kittyB = Tests::spawnKitty("pinB");
+    if (!kittyB) {
+        NLog::log("{}Error: pinB kitty did not spawn", Colors::RED);
+        return false;
+    }
+
+    // switch to workspace 2: pinA follows, pinB stays on 3
+    OK(getFromSocket("/dispatch workspace 2"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        auto str = getFromSocket("/clients");
+
+        auto posA = str.find("class: pinA");
+        EXPECT(posA != std::string::npos, true);
+        if (posA != std::string::npos) {
+            auto before = str.substr(0, posA);
+            auto lastWs = before.rfind("workspace: ");
+            if (lastWs != std::string::npos)
+                EXPECT_CONTAINS(before.substr(lastWs), "workspace: 2 (2)");
+        }
+
+        auto posB = str.find("class: pinB");
+        EXPECT(posB != std::string::npos, true);
+        if (posB != std::string::npos) {
+            auto before = str.substr(0, posB);
+            auto lastWs = before.rfind("workspace: ");
+            if (lastWs != std::string::npos)
+                EXPECT_NOT_CONTAINS(before.substr(lastWs), "workspace: 2 (2)");
+        }
+    }
+
+    // switch to workspace 4: pinB follows, pinA stays on 2
+    OK(getFromSocket("/dispatch workspace 4"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    {
+        auto str = getFromSocket("/clients");
+
+        auto posB = str.find("class: pinB");
+        EXPECT(posB != std::string::npos, true);
+        if (posB != std::string::npos) {
+            auto before = str.substr(0, posB);
+            auto lastWs = before.rfind("workspace: ");
+            if (lastWs != std::string::npos)
+                EXPECT_CONTAINS(before.substr(lastWs), "workspace: 4 (4)");
+        }
+
+        auto posA = str.find("class: pinA");
+        EXPECT(posA != std::string::npos, true);
+        if (posA != std::string::npos) {
+            auto before = str.substr(0, posA);
+            auto lastWs = before.rfind("workspace: ");
+            if (lastWs != std::string::npos)
+                EXPECT_NOT_CONTAINS(before.substr(lastWs), "workspace: 4 (4)");
+        }
+    }
+
+    NLog::log("{}Killing all windows", Colors::YELLOW);
+    Tests::killAllWindows();
+    EXPECT(Tests::windowCount(), 0);
+
+    return !ret;
+}
+
+REGISTER_TEST_FN(test)

--- a/hyprtester/src/tests/main/pin.cpp
+++ b/hyprtester/src/tests/main/pin.cpp
@@ -5,7 +5,7 @@
 #include <thread>
 #include <chrono>
 
-static int ret = 0;
+static int  ret = 0;
 
 static bool test() {
     NLog::log("{}Testing scoped pin", Colors::GREEN);
@@ -14,9 +14,9 @@ static bool test() {
     Tests::killAllWindows();
     EXPECT(Tests::windowCount(), 0);
 
-    // set up rules: float + pin to workspaces 2-3
+    // set up rules: float + pin to workspaces 2-3 using workspace selector
     OK(getFromSocket("/keyword windowrulev2 float, class:pintest"));
-    OK(getFromSocket("/keyword windowrulev2 pin 2-3, class:pintest"));
+    OK(getFromSocket("/keyword windowrulev2 pin r[2-3], class:pintest"));
 
     // spawn the window on workspace 2
     NLog::log("{}Switching to workspace 2 and spawning pintest", Colors::YELLOW);
@@ -162,17 +162,17 @@ static bool test() {
     {
         auto str = getFromSocket("/activewindow");
         EXPECT_CONTAINS(str, "pinned: 1");
-        EXPECT_CONTAINS(str, "pinnedWorkspaces: \n");
+        EXPECT_CONTAINS(str, "pinnedSelectors: \n");
     }
     OK(getFromSocket("/dispatch pin"));
 
     Tests::killAllWindows();
     EXPECT(Tests::windowCount(), 0);
 
-    // test individual workspace IDs (not a range)
-    NLog::log("{}Testing individual workspace IDs in pin rule", Colors::YELLOW);
+    // test individual workspace selectors (comma-separated)
+    NLog::log("{}Testing individual workspace selectors in pin rule", Colors::YELLOW);
     OK(getFromSocket("/keyword windowrulev2 float, class:pinids"));
-    OK(getFromSocket("/keyword windowrulev2 pin 2 5 8, class:pinids"));
+    OK(getFromSocket("/keyword windowrulev2 pin 2,5,8, class:pinids"));
     getFromSocket("/dispatch workspace 2"); // no OK: previous workspace may not exist after cleanup
     auto kittyIds = Tests::spawnKitty("pinids");
     if (!kittyIds) {
@@ -182,7 +182,7 @@ static bool test() {
     {
         auto str = getFromSocket("/activewindow");
         EXPECT_CONTAINS(str, "class: pinids");
-        EXPECT_CONTAINS(str, "pinnedWorkspaces: 2 5 8");
+        EXPECT_CONTAINS(str, "pinnedSelectors: 2, 5, 8");
     }
 
     // should follow to workspace 5 (in set)
@@ -221,9 +221,9 @@ static bool test() {
     // test two scoped-pinned windows with different sets
     NLog::log("{}Testing multiple scoped pins with different sets", Colors::YELLOW);
     OK(getFromSocket("/keyword windowrulev2 float, class:pinA"));
-    OK(getFromSocket("/keyword windowrulev2 pin 1-2, class:pinA"));
+    OK(getFromSocket("/keyword windowrulev2 pin r[1-2], class:pinA"));
     OK(getFromSocket("/keyword windowrulev2 float, class:pinB"));
-    OK(getFromSocket("/keyword windowrulev2 pin 3-4, class:pinB"));
+    OK(getFromSocket("/keyword windowrulev2 pin r[3-4], class:pinB"));
 
     OK(getFromSocket("/dispatch workspace 1"));
     auto kittyA = Tests::spawnKitty("pinA");

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -908,8 +908,8 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
             if (ONLY_PRIORITY && !w->priorityFocus())
                 continue;
 
-            if (w->m_isFloating && w->m_isMapped && !w->isHidden() && !w->m_X11ShouldntFocus && w->m_pinned && !w->m_ruleApplicator->noFocus().valueOrDefault() &&
-                w != pIgnoreWindow && !isShadowedByModal(w)) {
+            if (w->m_isFloating && w->m_isMapped && !w->isHidden() && !w->m_X11ShouldntFocus && w->isPinnedOnWorkspace(PMONITOR->activeWorkspaceID()) &&
+                !w->m_ruleApplicator->noFocus().valueOrDefault() && w != pIgnoreWindow && !isShadowedByModal(w)) {
                 const auto BB  = w->getWindowBoxUnified(properties);
                 CBox       box = BB.copy().expand(!w->isX11OverrideRedirect() ? BORDER_GRAB_AREA : 0);
                 if (box.containsPoint(g_pPointerManager->position()))
@@ -946,8 +946,9 @@ PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint8_t proper
                         continue;
                 }
 
-                if (w->m_isFloating && w->m_isMapped && w->m_workspace->isVisible() && !w->isHidden() && !w->m_pinned && !w->m_ruleApplicator->noFocus().valueOrDefault() &&
-                    w != pIgnoreWindow && (!aboveFullscreen || w->m_createdOverFullscreen) && !isShadowedByModal(w)) {
+                if (w->m_isFloating && w->m_isMapped && w->m_workspace->isVisible() && !w->isHidden() &&
+                    !w->isPinnedOnWorkspace(PWINDOWMONITOR ? PWINDOWMONITOR->activeWorkspaceID() : WORKSPACE_INVALID) &&
+                    !w->m_ruleApplicator->noFocus().valueOrDefault() && w != pIgnoreWindow && (!aboveFullscreen || w->m_createdOverFullscreen) && !isShadowedByModal(w)) {
                     // OR windows should add focus to parent
                     if (w->m_X11ShouldntFocus && !w->isX11OverrideRedirect())
                         continue;
@@ -2184,7 +2185,7 @@ void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, Desktop::Vie
 
     // make all windows and layers on the same workspace under the fullscreen window
     for (auto const& w : m_windows) {
-        if (w->m_workspace == PWORKSPACE && !w->isFullscreen() && !w->m_fadingOut && !w->m_pinned)
+        if (w->m_workspace == PWORKSPACE && !w->isFullscreen() && !w->m_fadingOut && !w->isPinnedOnWorkspace(PWORKSPACE->m_id))
             w->m_createdOverFullscreen = false;
     }
     for (auto const& ls : m_layers) {

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -352,23 +352,23 @@ static std::string getGroupedData(PHLWINDOW w, eHyprCtlOutputFormat format) {
     return result.str();
 }
 
-static std::string getPinnedWorkspacesData(PHLWINDOW w, eHyprCtlOutputFormat format) {
+static std::string getPinnedSelectorsData(PHLWINDOW w, eHyprCtlOutputFormat format) {
     std::string result;
     if (format == eHyprCtlOutputFormat::FORMAT_JSON) {
-        result = "[";
+        result     = "[";
         bool first = true;
-        for (const auto& id : w->m_pinnedWorkspaces) {
+        for (const auto& sel : w->m_pinnedSelectors) {
             if (!first)
                 result += ", ";
-            result += std::to_string(id);
+            result += "\"" + escapeJSONStrings(sel) + "\"";
             first = false;
         }
         result += "]";
     } else {
-        for (const auto& id : w->m_pinnedWorkspaces)
-            result += std::to_string(id) + " ";
-        if (!result.empty() && result.back() == ' ')
-            result.pop_back();
+        for (const auto& sel : w->m_pinnedSelectors)
+            result += sel + ", ";
+        if (result.size() >= 2 && result.substr(result.size() - 2) == ", ")
+            result.resize(result.size() - 2);
     }
     return result;
 }
@@ -404,7 +404,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
     "pid": {},
     "xwayland": {},
     "pinned": {},
-    "pinnedWorkspaces": {},
+    "pinnedSelectors": {},
     "fullscreen": {},
     "fullscreenClient": {},
     "overFullscreen": {},
@@ -422,7 +422,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             sc<int>(w->m_realPosition->goal().y), sc<int>(w->m_realSize->goal().x), sc<int>(w->m_realSize->goal().y), w->m_workspace ? w->workspaceID() : WORKSPACE_INVALID,
             escapeJSONStrings(!w->m_workspace ? "" : w->m_workspace->m_name), (sc<int>(w->m_isFloating) == 1 ? "true" : "false"), w->monitorID(), escapeJSONStrings(w->m_class),
             escapeJSONStrings(w->m_title), escapeJSONStrings(w->m_initialClass), escapeJSONStrings(w->m_initialTitle), w->getPID(), (sc<int>(w->m_isX11) == 1 ? "true" : "false"),
-            (w->m_pinned ? "true" : "false"), getPinnedWorkspacesData(w, format), sc<uint8_t>(w->m_fullscreenState.internal), sc<uint8_t>(w->m_fullscreenState.client),
+            (w->m_pinned ? "true" : "false"), getPinnedSelectorsData(w, format), sc<uint8_t>(w->m_fullscreenState.internal), sc<uint8_t>(w->m_fullscreenState.client),
             (w->m_createdOverFullscreen ? "true" : "false"), getGroupedData(w, format), getTagsData(w, format), rc<uintptr_t>(w->m_swallowed.get()), getFocusHistoryID(w),
             (g_pInputManager->isWindowInhibiting(w, false) ? "true" : "false"), escapeJSONStrings(w->xdgTag().value_or("")), escapeJSONStrings(w->xdgDescription().value_or("")),
             escapeJSONStrings(NContentType::toString(w->getContentType())), w->m_stableID);
@@ -431,14 +431,14 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             "Window {:x} -> {}:\n\tmapped: {}\n\thidden: {}\n\tat: {},{}\n\tsize: {},{}\n\tworkspace: {} ({})\n\tfloating: {}\n\tmonitor: {}\n\tclass: {}\n\ttitle: "
             "{}\n\tinitialClass: {}\n\tinitialTitle: {}\n\tpid: "
             "{}\n\txwayland: {}\n\tpinned: "
-            "{}\n\tpinnedWorkspaces: {}\n\tfullscreen: {}\n\tfullscreenClient: {}\n\toverFullscreen: {}\n\tgrouped: {}\n\ttags: {}\n\tswallowing: {:x}\n\tfocusHistoryID: "
+            "{}\n\tpinnedSelectors: {}\n\tfullscreen: {}\n\tfullscreenClient: {}\n\toverFullscreen: {}\n\tgrouped: {}\n\ttags: {}\n\tswallowing: {:x}\n\tfocusHistoryID: "
             "{}\n\tinhibitingIdle: "
             "{}\n\txdgTag: "
             "{}\n\txdgDescription: {}\n\tcontentType: {}\n\tstableID: {:x}\n\n",
             rc<uintptr_t>(w.get()), w->m_title, sc<int>(w->m_isMapped), sc<int>(w->isHidden()), sc<int>(w->m_realPosition->goal().x), sc<int>(w->m_realPosition->goal().y),
             sc<int>(w->m_realSize->goal().x), sc<int>(w->m_realSize->goal().y), w->m_workspace ? w->workspaceID() : WORKSPACE_INVALID,
             (!w->m_workspace ? "" : w->m_workspace->m_name), sc<int>(w->m_isFloating), w->monitorID(), w->m_class, w->m_title, w->m_initialClass, w->m_initialTitle, w->getPID(),
-            sc<int>(w->m_isX11), sc<int>(w->m_pinned), getPinnedWorkspacesData(w, format), sc<uint8_t>(w->m_fullscreenState.internal), sc<uint8_t>(w->m_fullscreenState.client),
+            sc<int>(w->m_isX11), sc<int>(w->m_pinned), getPinnedSelectorsData(w, format), sc<uint8_t>(w->m_fullscreenState.internal), sc<uint8_t>(w->m_fullscreenState.client),
             sc<int>(w->m_createdOverFullscreen), getGroupedData(w, format), getTagsData(w, format), rc<uintptr_t>(w->m_swallowed.get()), getFocusHistoryID(w),
             sc<int>(g_pInputManager->isWindowInhibiting(w, false)), w->xdgTag().value_or(""), w->xdgDescription().value_or(""), NContentType::toString(w->getContentType()),
             w->m_stableID);
@@ -515,11 +515,11 @@ static std::string getWorkspaceRuleData(const SWorkspaceRule& r, eHyprCtlOutputF
         const std::string default_    = sc<bool>(r.isDefault) ? std::format(",\n    \"default\": {}", boolToString(r.isDefault)) : "";
         const std::string persistent  = sc<bool>(r.isPersistent) ? std::format(",\n    \"persistent\": {}", boolToString(r.isPersistent)) : "";
         const std::string gapsIn      = sc<bool>(r.gapsIn) ?
-            std::format(",\n    \"gapsIn\": [{}, {}, {}, {}]", r.gapsIn.value().m_top, r.gapsIn.value().m_right, r.gapsIn.value().m_bottom, r.gapsIn.value().m_left) :
-            "";
+                 std::format(",\n    \"gapsIn\": [{}, {}, {}, {}]", r.gapsIn.value().m_top, r.gapsIn.value().m_right, r.gapsIn.value().m_bottom, r.gapsIn.value().m_left) :
+                 "";
         const std::string gapsOut     = sc<bool>(r.gapsOut) ?
-            std::format(",\n    \"gapsOut\": [{}, {}, {}, {}]", r.gapsOut.value().m_top, r.gapsOut.value().m_right, r.gapsOut.value().m_bottom, r.gapsOut.value().m_left) :
-            "";
+                std::format(",\n    \"gapsOut\": [{}, {}, {}, {}]", r.gapsOut.value().m_top, r.gapsOut.value().m_right, r.gapsOut.value().m_bottom, r.gapsOut.value().m_left) :
+                "";
         const std::string borderSize  = sc<bool>(r.borderSize) ? std::format(",\n    \"borderSize\": {}", r.borderSize.value()) : "";
         const std::string border      = sc<bool>(r.noBorder) ? std::format(",\n    \"border\": {}", boolToString(!r.noBorder.value())) : "";
         const std::string rounding    = sc<bool>(r.noRounding) ? std::format(",\n    \"rounding\": {}", boolToString(!r.noRounding.value())) : "";
@@ -542,9 +542,9 @@ static std::string getWorkspaceRuleData(const SWorkspaceRule& r, eHyprCtlOutputF
                                                                         std::to_string(r.gapsIn.value().m_bottom), std::to_string(r.gapsIn.value().m_left)) :
                                                             std::format("\tgapsIn: <unset>\n");
         const std::string gapsOut    = sc<bool>(r.gapsOut) ?
-            std::format("\tgapsOut: {} {} {} {}\n", std::to_string(r.gapsOut.value().m_top), std::to_string(r.gapsOut.value().m_right), std::to_string(r.gapsOut.value().m_bottom),
-                        std::to_string(r.gapsOut.value().m_left)) :
-            std::format("\tgapsOut: <unset>\n");
+               std::format("\tgapsOut: {} {} {} {}\n", std::to_string(r.gapsOut.value().m_top), std::to_string(r.gapsOut.value().m_right), std::to_string(r.gapsOut.value().m_bottom),
+                           std::to_string(r.gapsOut.value().m_left)) :
+               std::format("\tgapsOut: <unset>\n");
         const std::string borderSize = std::format("\tborderSize: {}\n", sc<bool>(r.borderSize) ? std::to_string(r.borderSize.value()) : "<unset>");
         const std::string border     = std::format("\tborder: {}\n", sc<bool>(r.noBorder) ? boolToString(!r.noBorder.value()) : "<unset>");
         const std::string rounding   = std::format("\trounding: {}\n", sc<bool>(r.noRounding) ? boolToString(!r.noRounding.value()) : "<unset>");

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -352,6 +352,27 @@ static std::string getGroupedData(PHLWINDOW w, eHyprCtlOutputFormat format) {
     return result.str();
 }
 
+static std::string getPinnedWorkspacesData(PHLWINDOW w, eHyprCtlOutputFormat format) {
+    std::string result;
+    if (format == eHyprCtlOutputFormat::FORMAT_JSON) {
+        result = "[";
+        bool first = true;
+        for (const auto& id : w->m_pinnedWorkspaces) {
+            if (!first)
+                result += ", ";
+            result += std::to_string(id);
+            first = false;
+        }
+        result += "]";
+    } else {
+        for (const auto& id : w->m_pinnedWorkspaces)
+            result += std::to_string(id) + " ";
+        if (!result.empty() && result.back() == ' ')
+            result.pop_back();
+    }
+    return result;
+}
+
 std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
     auto getFocusHistoryID = [](PHLWINDOW wnd) -> int {
         const auto& HISTORY = Desktop::History::windowTracker()->fullHistory();
@@ -383,6 +404,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
     "pid": {},
     "xwayland": {},
     "pinned": {},
+    "pinnedWorkspaces": {},
     "fullscreen": {},
     "fullscreenClient": {},
     "overFullscreen": {},
@@ -400,8 +422,8 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             sc<int>(w->m_realPosition->goal().y), sc<int>(w->m_realSize->goal().x), sc<int>(w->m_realSize->goal().y), w->m_workspace ? w->workspaceID() : WORKSPACE_INVALID,
             escapeJSONStrings(!w->m_workspace ? "" : w->m_workspace->m_name), (sc<int>(w->m_isFloating) == 1 ? "true" : "false"), w->monitorID(), escapeJSONStrings(w->m_class),
             escapeJSONStrings(w->m_title), escapeJSONStrings(w->m_initialClass), escapeJSONStrings(w->m_initialTitle), w->getPID(), (sc<int>(w->m_isX11) == 1 ? "true" : "false"),
-            (w->m_pinned ? "true" : "false"), sc<uint8_t>(w->m_fullscreenState.internal), sc<uint8_t>(w->m_fullscreenState.client), (w->m_createdOverFullscreen ? "true" : "false"),
-            getGroupedData(w, format), getTagsData(w, format), rc<uintptr_t>(w->m_swallowed.get()), getFocusHistoryID(w),
+            (w->m_pinned ? "true" : "false"), getPinnedWorkspacesData(w, format), sc<uint8_t>(w->m_fullscreenState.internal), sc<uint8_t>(w->m_fullscreenState.client),
+            (w->m_createdOverFullscreen ? "true" : "false"), getGroupedData(w, format), getTagsData(w, format), rc<uintptr_t>(w->m_swallowed.get()), getFocusHistoryID(w),
             (g_pInputManager->isWindowInhibiting(w, false) ? "true" : "false"), escapeJSONStrings(w->xdgTag().value_or("")), escapeJSONStrings(w->xdgDescription().value_or("")),
             escapeJSONStrings(NContentType::toString(w->getContentType())), w->m_stableID);
     } else {
@@ -409,15 +431,17 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             "Window {:x} -> {}:\n\tmapped: {}\n\thidden: {}\n\tat: {},{}\n\tsize: {},{}\n\tworkspace: {} ({})\n\tfloating: {}\n\tmonitor: {}\n\tclass: {}\n\ttitle: "
             "{}\n\tinitialClass: {}\n\tinitialTitle: {}\n\tpid: "
             "{}\n\txwayland: {}\n\tpinned: "
-            "{}\n\tfullscreen: {}\n\tfullscreenClient: {}\n\toverFullscreen: {}\n\tgrouped: {}\n\ttags: {}\n\tswallowing: {:x}\n\tfocusHistoryID: {}\n\tinhibitingIdle: "
+            "{}\n\tpinnedWorkspaces: {}\n\tfullscreen: {}\n\tfullscreenClient: {}\n\toverFullscreen: {}\n\tgrouped: {}\n\ttags: {}\n\tswallowing: {:x}\n\tfocusHistoryID: "
+            "{}\n\tinhibitingIdle: "
             "{}\n\txdgTag: "
             "{}\n\txdgDescription: {}\n\tcontentType: {}\n\tstableID: {:x}\n\n",
             rc<uintptr_t>(w.get()), w->m_title, sc<int>(w->m_isMapped), sc<int>(w->isHidden()), sc<int>(w->m_realPosition->goal().x), sc<int>(w->m_realPosition->goal().y),
             sc<int>(w->m_realSize->goal().x), sc<int>(w->m_realSize->goal().y), w->m_workspace ? w->workspaceID() : WORKSPACE_INVALID,
             (!w->m_workspace ? "" : w->m_workspace->m_name), sc<int>(w->m_isFloating), w->monitorID(), w->m_class, w->m_title, w->m_initialClass, w->m_initialTitle, w->getPID(),
-            sc<int>(w->m_isX11), sc<int>(w->m_pinned), sc<uint8_t>(w->m_fullscreenState.internal), sc<uint8_t>(w->m_fullscreenState.client), sc<int>(w->m_createdOverFullscreen),
-            getGroupedData(w, format), getTagsData(w, format), rc<uintptr_t>(w->m_swallowed.get()), getFocusHistoryID(w), sc<int>(g_pInputManager->isWindowInhibiting(w, false)),
-            w->xdgTag().value_or(""), w->xdgDescription().value_or(""), NContentType::toString(w->getContentType()), w->m_stableID);
+            sc<int>(w->m_isX11), sc<int>(w->m_pinned), getPinnedWorkspacesData(w, format), sc<uint8_t>(w->m_fullscreenState.internal), sc<uint8_t>(w->m_fullscreenState.client),
+            sc<int>(w->m_createdOverFullscreen), getGroupedData(w, format), getTagsData(w, format), rc<uintptr_t>(w->m_swallowed.get()), getFocusHistoryID(w),
+            sc<int>(g_pInputManager->isWindowInhibiting(w, false)), w->xdgTag().value_or(""), w->xdgDescription().value_or(""), NContentType::toString(w->getContentType()),
+            w->m_stableID);
     }
 }
 

--- a/src/desktop/rule/windowRule/WindowRuleApplicator.cpp
+++ b/src/desktop/rule/windowRule/WindowRuleApplicator.cpp
@@ -518,6 +518,41 @@ CWindowRuleApplicator::SRuleResult CWindowRuleApplicator::applyStaticRule(const 
             }
             case WINDOW_RULE_EFFECT_PIN: {
                 static_.pin = truthy(effect);
+                // Parse workspace IDs from the effect string.
+                // Syntax: "pin = 1 2 3" or "pin = 1-4" pins to specific workspaces.
+                // "pin = 1" or "pin = true" (single truthy token) pins to all workspaces.
+                static_.pinnedWorkspaces = std::nullopt;
+                CVarList2 pinVars(std::string{effect}, 0, ' ');
+                std::set<WORKSPACEID> wsSet;
+                bool                  hasRangeOrMultiple = false;
+                for (const auto& token : pinVars) {
+                    // Check if this token is a range like "1-4"
+                    const auto dashPos = token.find('-', 1); // skip leading minus
+                    if (dashPos != std::string_view::npos) {
+                        // range token
+                        try {
+                            WORKSPACEID from = std::stoll(std::string{token.substr(0, dashPos)});
+                            WORKSPACEID to   = std::stoll(std::string{token.substr(dashPos + 1)});
+                            if (from > to)
+                                std::swap(from, to);
+                            for (WORKSPACEID id = from; id <= to; ++id)
+                                wsSet.insert(id);
+                            hasRangeOrMultiple = true;
+                        } catch (...) { Log::logger->log(Log::ERR, "CWindowRuleApplicator::applyStaticRule: invalid pin workspace range {}", token); }
+                    } else {
+                        // single token - try to parse as integer workspace ID
+                        try {
+                            WORKSPACEID id = std::stoll(std::string{token});
+                            wsSet.insert(id);
+                        } catch (...) {
+                            // not a number (e.g. "true"/"false"/"1") - skip
+                        }
+                    }
+                }
+                // If we have 2+ workspace IDs, or any range, use workspace-scoped pin
+                // If there is exactly one integer "1", it could be the boolean truthy value - treat as pin to all
+                if (!wsSet.empty() && (hasRangeOrMultiple || wsSet.size() > 1 || (wsSet.size() == 1 && *wsSet.begin() != 1)))
+                    static_.pinnedWorkspaces = wsSet;
                 break;
             }
             case WINDOW_RULE_EFFECT_GROUP: {

--- a/src/desktop/rule/windowRule/WindowRuleApplicator.cpp
+++ b/src/desktop/rule/windowRule/WindowRuleApplicator.cpp
@@ -517,42 +517,20 @@ CWindowRuleApplicator::SRuleResult CWindowRuleApplicator::applyStaticRule(const 
                 break;
             }
             case WINDOW_RULE_EFFECT_PIN: {
-                static_.pin = truthy(effect);
-                // Parse workspace IDs from the effect string.
-                // Syntax: "pin = 1 2 3" or "pin = 1-4" pins to specific workspaces.
-                // "pin = 1" or "pin = true" (single truthy token) pins to all workspaces.
-                static_.pinnedWorkspaces = std::nullopt;
-                CVarList2 pinVars(std::string{effect}, 0, ' ');
-                std::set<WORKSPACEID> wsSet;
-                bool                  hasRangeOrMultiple = false;
-                for (const auto& token : pinVars) {
-                    // Check if this token is a range like "1-4"
-                    const auto dashPos = token.find('-', 1); // skip leading minus
-                    if (dashPos != std::string_view::npos) {
-                        // range token
-                        try {
-                            WORKSPACEID from = std::stoll(std::string{token.substr(0, dashPos)});
-                            WORKSPACEID to   = std::stoll(std::string{token.substr(dashPos + 1)});
-                            if (from > to)
-                                std::swap(from, to);
-                            for (WORKSPACEID id = from; id <= to; ++id)
-                                wsSet.insert(id);
-                            hasRangeOrMultiple = true;
-                        } catch (...) { Log::logger->log(Log::ERR, "CWindowRuleApplicator::applyStaticRule: invalid pin workspace range {}", token); }
-                    } else {
-                        // single token - try to parse as integer workspace ID
-                        try {
-                            WORKSPACEID id = std::stoll(std::string{token});
-                            wsSet.insert(id);
-                        } catch (...) {
-                            // not a number (e.g. "true"/"false"/"1") - skip
-                        }
+                static_.pin             = truthy(effect);
+                static_.pinnedSelectors = std::nullopt;
+                auto effectStr          = trim(std::string{effect});
+                if (!effectStr.empty() && effectStr != "1" && effectStr != "true" && effectStr != "0" && effectStr != "false") {
+                    CVarList2                pinVars(std::move(effectStr), 0, ',');
+                    std::vector<std::string> selectors;
+                    for (const auto& token : pinVars) {
+                        auto sel = trim(std::string{token});
+                        if (!sel.empty())
+                            selectors.emplace_back(std::move(sel));
                     }
+                    if (!selectors.empty())
+                        static_.pinnedSelectors = std::move(selectors);
                 }
-                // If we have 2+ workspace IDs, or any range, use workspace-scoped pin
-                // If there is exactly one integer "1", it could be the boolean truthy value - treat as pin to all
-                if (!wsSet.empty() && (hasRangeOrMultiple || wsSet.size() > 1 || (wsSet.size() == 1 && *wsSet.begin() != 1)))
-                    static_.pinnedWorkspaces = wsSet;
                 break;
             }
             case WINDOW_RULE_EFFECT_GROUP: {

--- a/src/desktop/rule/windowRule/WindowRuleApplicator.hpp
+++ b/src/desktop/rule/windowRule/WindowRuleApplicator.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <set>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -40,26 +39,26 @@ namespace Desktop::Rule {
 
         // static props
         struct {
-            std::string              monitor, workspace, group;
+            std::string                             monitor, workspace, group;
 
-            std::optional<bool>                  floating;
-            std::optional<bool>                  fullscreen;
-            std::optional<bool>                  maximize;
-            std::optional<bool>                  pseudo;
-            std::optional<bool>                  pin;
-            std::optional<std::set<WORKSPACEID>> pinnedWorkspaces;
-            std::optional<bool>                  noInitialFocus;
-            std::optional<bool>      center;
+            std::optional<bool>                     floating;
+            std::optional<bool>                     fullscreen;
+            std::optional<bool>                     maximize;
+            std::optional<bool>                     pseudo;
+            std::optional<bool>                     pin;
+            std::optional<std::vector<std::string>> pinnedSelectors;
+            std::optional<bool>                     noInitialFocus;
+            std::optional<bool>                     center;
 
-            std::optional<int>       fullscreenStateClient;
-            std::optional<int>       fullscreenStateInternal;
-            std::optional<int>       content;
-            std::optional<int>       noCloseFor;
+            std::optional<int>                      fullscreenStateClient;
+            std::optional<int>                      fullscreenStateInternal;
+            std::optional<int>                      content;
+            std::optional<int>                      noCloseFor;
 
-            std::string              size, position;
-            std::optional<float>     scrollingWidth;
+            std::string                             size, position;
+            std::optional<float>                    scrollingWidth;
 
-            std::vector<std::string> suppressEvent;
+            std::vector<std::string>                suppressEvent;
         } static_;
 
         struct SCustomPropContainer {

--- a/src/desktop/rule/windowRule/WindowRuleApplicator.hpp
+++ b/src/desktop/rule/windowRule/WindowRuleApplicator.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <set>
 #include <unordered_map>
 #include <unordered_set>
 
 #include "WindowRuleEffectContainer.hpp"
 #include "../../DesktopTypes.hpp"
+#include "../../../SharedDefs.hpp"
 #include "../Rule.hpp"
 #include "../../types/OverridableVar.hpp"
 #include "../../../helpers/math/Math.hpp"
@@ -40,12 +42,13 @@ namespace Desktop::Rule {
         struct {
             std::string              monitor, workspace, group;
 
-            std::optional<bool>      floating;
-            std::optional<bool>      fullscreen;
-            std::optional<bool>      maximize;
-            std::optional<bool>      pseudo;
-            std::optional<bool>      pin;
-            std::optional<bool>      noInitialFocus;
+            std::optional<bool>                  floating;
+            std::optional<bool>                  fullscreen;
+            std::optional<bool>                  maximize;
+            std::optional<bool>                  pseudo;
+            std::optional<bool>                  pin;
+            std::optional<std::set<WORKSPACEID>> pinnedWorkspaces;
+            std::optional<bool>                  noInitialFocus;
             std::optional<bool>      center;
 
             std::optional<int>       fullscreenStateClient;

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -865,7 +865,8 @@ void CWindow::setAnimationsToMove() {
 
 void CWindow::onWorkspaceAnimUpdate() {
     // clip box for animated offsets
-    if (!m_isFloating || m_pinned || isFullscreen()) {
+    const auto POFFSETMON = m_monitor.lock();
+    if (!m_isFloating || (POFFSETMON && isPinnedOnWorkspace(POFFSETMON->activeWorkspaceID())) || isFullscreen()) {
         m_floatingOffset = Vector2D(0, 0);
         return;
     }
@@ -1467,6 +1468,14 @@ bool CWindow::priorityFocus() {
     return !m_isX11 && CAsyncDialogBox::isPriorityDialogBox(getPID());
 }
 
+bool CWindow::isPinnedOnWorkspace(WORKSPACEID id) const {
+    if (!m_pinned)
+        return false;
+    if (m_pinnedWorkspaces.empty())
+        return true;
+    return m_pinnedWorkspaces.contains(id);
+}
+
 SP<CWLSurfaceResource> CWindow::getSolitaryResource() {
     if (!m_wlSurface || !m_wlSurface->resource())
         return nullptr;
@@ -1767,6 +1776,9 @@ void CWindow::mapWindow() {
         m_target->setPseudo(m_ruleApplicator->static_.pseudo.value_or(m_target->isPseudo()));
         m_noInitialFocus = m_ruleApplicator->static_.noInitialFocus.value_or(m_noInitialFocus);
         m_pinned         = m_ruleApplicator->static_.pin.value_or(m_pinned);
+        m_pinnedWorkspaces.clear();
+        if (m_ruleApplicator->static_.pinnedWorkspaces.has_value())
+            m_pinnedWorkspaces = *m_ruleApplicator->static_.pinnedWorkspaces;
 
         if (m_ruleApplicator->static_.fullscreenStateClient || m_ruleApplicator->static_.fullscreenStateInternal) {
             requestedFSState = Desktop::View::SFullscreenState{
@@ -1860,8 +1872,10 @@ void CWindow::mapWindow() {
         m_closeableSince = Time::steadyNow() + std::chrono::years(10 /* Should be enough, no? */);
 
     // disallow tiled pinned
-    if (m_pinned && !m_isFloating)
+    if (m_pinned && !m_isFloating) {
         m_pinned = false;
+        m_pinnedWorkspaces.clear();
+    }
 
     CVarList2 WORKSPACEARGS = CVarList2(std::move(requestedWorkspace), 0, ' ', false, false);
 

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -1471,9 +1471,16 @@ bool CWindow::priorityFocus() {
 bool CWindow::isPinnedOnWorkspace(WORKSPACEID id) const {
     if (!m_pinned)
         return false;
-    if (m_pinnedWorkspaces.empty())
+    if (m_pinnedSelectors.empty())
         return true;
-    return m_pinnedWorkspaces.contains(id);
+    const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(id);
+    if (!PWORKSPACE)
+        return false;
+    for (const auto& selector : m_pinnedSelectors) {
+        if (PWORKSPACE->matchesStaticSelector(selector))
+            return true;
+    }
+    return false;
 }
 
 SP<CWLSurfaceResource> CWindow::getSolitaryResource() {
@@ -1776,14 +1783,14 @@ void CWindow::mapWindow() {
         m_target->setPseudo(m_ruleApplicator->static_.pseudo.value_or(m_target->isPseudo()));
         m_noInitialFocus = m_ruleApplicator->static_.noInitialFocus.value_or(m_noInitialFocus);
         m_pinned         = m_ruleApplicator->static_.pin.value_or(m_pinned);
-        m_pinnedWorkspaces.clear();
-        if (m_ruleApplicator->static_.pinnedWorkspaces.has_value())
-            m_pinnedWorkspaces = *m_ruleApplicator->static_.pinnedWorkspaces;
+        m_pinnedSelectors.clear();
+        if (m_ruleApplicator->static_.pinnedSelectors.has_value())
+            m_pinnedSelectors = *m_ruleApplicator->static_.pinnedSelectors;
 
         if (m_ruleApplicator->static_.fullscreenStateClient || m_ruleApplicator->static_.fullscreenStateInternal) {
             requestedFSState = Desktop::View::SFullscreenState{
-                .internal = sc<eFullscreenMode>(m_ruleApplicator->static_.fullscreenStateInternal.value_or(0)),
-                .client   = sc<eFullscreenMode>(m_ruleApplicator->static_.fullscreenStateClient.value_or(0)),
+                     .internal = sc<eFullscreenMode>(m_ruleApplicator->static_.fullscreenStateInternal.value_or(0)),
+                     .client   = sc<eFullscreenMode>(m_ruleApplicator->static_.fullscreenStateClient.value_or(0)),
             };
         }
 
@@ -1874,7 +1881,7 @@ void CWindow::mapWindow() {
     // disallow tiled pinned
     if (m_pinned && !m_isFloating) {
         m_pinned = false;
-        m_pinnedWorkspaces.clear();
+        m_pinnedSelectors.clear();
     }
 
     CVarList2 WORKSPACEARGS = CVarList2(std::move(requestedWorkspace), 0, ' ', false, false);

--- a/src/desktop/view/Window.hpp
+++ b/src/desktop/view/Window.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <set>
 #include <vector>
 #include <string>
 #include <optional>
@@ -197,8 +196,8 @@ namespace Desktop::View {
         bool              m_animatingIn = false;
 
         // For pinned (sticky) windows
-        bool                  m_pinned           = false;
-        std::set<WORKSPACEID> m_pinnedWorkspaces; // empty = pinned to all workspaces
+        bool                     m_pinned = false;
+        std::vector<std::string> m_pinnedSelectors; // empty = pinned to all workspaces
 
         // For preserving pinned state when fullscreening a pinned window
         bool m_pinFullscreened = false;

--- a/src/desktop/view/Window.hpp
+++ b/src/desktop/view/Window.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <set>
 #include <vector>
 #include <string>
 #include <optional>
@@ -196,7 +197,8 @@ namespace Desktop::View {
         bool              m_animatingIn = false;
 
         // For pinned (sticky) windows
-        bool m_pinned = false;
+        bool                  m_pinned           = false;
+        std::set<WORKSPACEID> m_pinnedWorkspaces; // empty = pinned to all workspaces
 
         // For preserving pinned state when fullscreening a pinned window
         bool m_pinFullscreened = false;
@@ -343,6 +345,7 @@ namespace Desktop::View {
         std::optional<std::string> xdgDescription();
         PHLWINDOW                  parent();
         bool                       priorityFocus();
+        bool                       isPinnedOnWorkspace(WORKSPACEID id) const;
         SP<CWLSurfaceResource>     getSolitaryResource();
         Vector2D                   getReportedSize();
         std::optional<Vector2D>    calculateExpression(const std::string& s);

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1372,12 +1372,14 @@ void CMonitor::changeWorkspace(const PHLWORKSPACE& pWorkspace, bool internal, bo
 
         // move pinned windows
         for (auto const& w : g_pCompositor->m_windows) {
-            if (w->m_workspace == POLDWORKSPACE && w->m_pinned)
+            if (!w->m_pinned || w->m_workspace == pWorkspace)
+                continue;
+            if (w->isPinnedOnWorkspace(pWorkspace->m_id))
                 w->layoutTarget()->assignToSpace(pWorkspace->m_space);
         }
 
         if (!noFocus && !Desktop::focusState()->monitor()->m_activeSpecialWorkspace &&
-            !(Desktop::focusState()->window() && Desktop::focusState()->window()->m_pinned && Desktop::focusState()->window()->m_monitor == m_self)) {
+            !(Desktop::focusState()->window() && Desktop::focusState()->window()->isPinnedOnWorkspace(pWorkspace->m_id) && Desktop::focusState()->window()->m_monitor == m_self)) {
             static auto PFOLLOWMOUSE = CConfigValue<Hyprlang::INT>("input:follow_mouse");
             auto        pWindow      = pWorkspace->m_hasFullscreenWindow ? pWorkspace->getFullscreenWindow() : pWorkspace->getLastFocusedWindow();
 
@@ -1464,7 +1466,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
 
         g_layoutManager->recalculateMonitor(m_self.lock());
 
-        if (!(Desktop::focusState()->window() && Desktop::focusState()->window()->m_pinned && Desktop::focusState()->window()->m_monitor == m_self)) {
+        if (!(Desktop::focusState()->window() && Desktop::focusState()->window()->isPinnedOnWorkspace(m_activeWorkspace->m_id) && Desktop::focusState()->window()->m_monitor == m_self)) {
             if (const auto PLAST = m_activeWorkspace->getLastFocusedWindow(); PLAST)
                 Desktop::focusState()->fullWindowFocus(PLAST, Desktop::FOCUS_REASON_KEYBIND);
             else
@@ -1558,7 +1560,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
 
     g_layoutManager->recalculateMonitor(m_self.lock());
 
-    if (!(Desktop::focusState()->window() && Desktop::focusState()->window()->m_pinned && Desktop::focusState()->window()->m_monitor == m_self)) {
+    if (!(Desktop::focusState()->window() && Desktop::focusState()->window()->isPinnedOnWorkspace(pWorkspace->m_id) && Desktop::focusState()->window()->m_monitor == m_self)) {
         if (const auto PLAST = pWorkspace->getLastFocusedWindow(); PLAST)
             Desktop::focusState()->fullWindowFocus(PLAST, Desktop::FOCUS_REASON_KEYBIND);
         else

--- a/src/layout/supplementary/DragController.cpp
+++ b/src/layout/supplementary/DragController.cpp
@@ -48,7 +48,7 @@ bool CDragStateController::updateDragWindow() {
         const auto PWORKSPACE     = DRAGGINGTARGET->workspace();
         const auto DRAGGINGWINDOW = DRAGGINGTARGET->window();
 
-        if (PWORKSPACE->m_hasFullscreenWindow && (!DRAGGINGTARGET->floating() || (!DRAGGINGWINDOW->m_createdOverFullscreen && !DRAGGINGWINDOW->m_pinned))) {
+        if (PWORKSPACE->m_hasFullscreenWindow && (!DRAGGINGTARGET->floating() || (!DRAGGINGWINDOW->m_createdOverFullscreen && !DRAGGINGWINDOW->isPinnedOnWorkspace(PWORKSPACE->m_id)))) {
             Log::logger->log(Log::DEBUG, "Rejecting drag on a fullscreen workspace. (window under fullscreen)");
             CKeybindManager::changeMouseBindMode(MBIND_INVALID);
             return true;

--- a/src/layout/target/WindowTarget.cpp
+++ b/src/layout/target/WindowTarget.cpp
@@ -232,9 +232,9 @@ void CWindowTarget::setFloating(bool x) {
     if (x == m_window->m_isFloating)
         return;
 
-    m_window->m_isFloating     = x;
-    m_window->m_pinned         = false;
-    m_window->m_pinnedWorkspaces.clear();
+    m_window->m_isFloating = x;
+    m_window->m_pinned     = false;
+    m_window->m_pinnedSelectors.clear();
 
     m_window->m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_FLOATING);
 }

--- a/src/layout/target/WindowTarget.cpp
+++ b/src/layout/target/WindowTarget.cpp
@@ -232,8 +232,9 @@ void CWindowTarget::setFloating(bool x) {
     if (x == m_window->m_isFloating)
         return;
 
-    m_window->m_isFloating = x;
-    m_window->m_pinned     = false;
+    m_window->m_isFloating     = x;
+    m_window->m_pinned         = false;
+    m_window->m_pinnedWorkspaces.clear();
 
     m_window->m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_FLOATING);
 }

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2570,7 +2570,7 @@ SDispatchResult CKeybindManager::pinActive(std::string args) {
 
     PWINDOW->m_pinned = !PWINDOW->m_pinned;
     if (!PWINDOW->m_pinned)
-        PWINDOW->m_pinnedWorkspaces.clear();
+        PWINDOW->m_pinnedSelectors.clear();
 
     const auto PMONITOR = PWINDOW->m_monitor.lock();
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -2569,6 +2569,8 @@ SDispatchResult CKeybindManager::pinActive(std::string args) {
         return {.success = false, .error = "Window does not qualify to be pinned"};
 
     PWINDOW->m_pinned = !PWINDOW->m_pinned;
+    if (!PWINDOW->m_pinned)
+        PWINDOW->m_pinnedWorkspaces.clear();
 
     const auto PMONITOR = PWINDOW->m_monitor.lock();
 

--- a/src/managers/animation/AnimationManager.cpp
+++ b/src/managers/animation/AnimationManager.cpp
@@ -104,7 +104,7 @@ static void handleUpdate(CAnimatedVariable<VarType>& av, bool warp) {
             if (!w->m_isMapped || w->isHidden() || w->m_workspace != PWORKSPACE)
                 continue;
 
-            if (w->m_isFloating && !w->m_pinned) {
+            if (w->m_isFloating && !w->isPinnedOnWorkspace(PWORKSPACE->m_id)) {
                 // still doing the full damage hack for floating because sometimes when the window
                 // goes through multiple monitors the last rendered frame is missing damage somehow??
                 const CBox windowBoxNoOffset = w->getFullWindowBoundingBox();
@@ -119,7 +119,7 @@ static void handleUpdate(CAnimatedVariable<VarType>& av, bool warp) {
 
         // damage any workspace window that is on any monitor
         for (auto const& w : g_pCompositor->m_windows) {
-            if (!validMapped(w) || w->m_workspace != PWORKSPACE || w->m_pinned)
+            if (!validMapped(w) || w->m_workspace != PWORKSPACE || w->isPinnedOnWorkspace(PWORKSPACE->m_id))
                 continue;
 
             g_pHyprRenderer->damageWindow(w);
@@ -161,7 +161,7 @@ static void handleUpdate(CAnimatedVariable<VarType>& av, bool warp) {
                     w->updateWindowDecos();
 
                     // damage any workspace window that is on any monitor
-                    if (!w->m_pinned)
+                    if (!w->isPinnedOnWorkspace(PWORKSPACE->m_id))
                         g_pHyprRenderer->damageWindow(w);
                 }
             } else if (PLAYER) {

--- a/src/managers/animation/DesktopAnimationManager.cpp
+++ b/src/managers/animation/DesktopAnimationManager.cpp
@@ -465,7 +465,7 @@ void CDesktopAnimationManager::setFullscreenFadeAnimation(PHLWORKSPACE ws, eAnim
     for (auto const& w : g_pCompositor->m_windows) {
         if (w->m_workspace == ws) {
 
-            if (w->m_fadingOut || w->m_pinned || w->isFullscreen())
+            if (w->m_fadingOut || w->isPinnedOnWorkspace(ws->m_id) || w->isFullscreen())
                 continue;
 
             if (!FULLSCREEN)
@@ -501,7 +501,7 @@ void CDesktopAnimationManager::overrideFullscreenFadeAmount(PHLWORKSPACE ws, flo
             continue;
 
         if (w->m_workspace == ws) {
-            if (w->m_fadingOut || w->m_pinned || w->isFullscreen())
+            if (w->m_fadingOut || w->isPinnedOnWorkspace(ws->m_id) || w->isFullscreen())
                 continue;
 
             *w->m_alpha = fade;

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -425,7 +425,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
             }
 
             if (PWINDOWIDEAL &&
-                ((PWINDOWIDEAL->m_isFloating && (PWINDOWIDEAL->m_createdOverFullscreen || PWINDOWIDEAL->m_pinned)) /* floating over fullscreen or pinned */
+                ((PWINDOWIDEAL->m_isFloating && (PWINDOWIDEAL->m_createdOverFullscreen || PWINDOWIDEAL->isPinnedOnWorkspace(PMONITOR->activeWorkspaceID()))) /* floating over fullscreen or pinned */
                  || (PMONITOR->m_activeSpecialWorkspace == PWINDOWIDEAL->m_workspace) /* on an open special workspace */))
                 pFoundWindow = PWINDOWIDEAL;
 
@@ -463,7 +463,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
                             pFoundWindow =
                                 g_pCompositor->vectorToWindowUnified(mouseCoords, Desktop::View::RESERVED_EXTENTS | Desktop::View::INPUT_EXTENTS | Desktop::View::ALLOW_FLOATING);
 
-                        if (!(pFoundWindow && (pFoundWindow->m_isFloating && (pFoundWindow->m_createdOverFullscreen || pFoundWindow->m_pinned))))
+                        if (!(pFoundWindow && (pFoundWindow->m_isFloating && (pFoundWindow->m_createdOverFullscreen || pFoundWindow->isPinnedOnWorkspace(PMONITOR->activeWorkspaceID())))))
                             pFoundWindow = PWORKSPACE->getFullscreenWindow();
                     }
                 }

--- a/src/managers/screenshare/ScreenshareFrame.cpp
+++ b/src/managers/screenshare/ScreenshareFrame.cpp
@@ -251,7 +251,7 @@ void CScreenshareFrame::renderMonitor() {
         if UNLIKELY (!PWORKSPACE && !w->m_fadingOut && w->m_alpha->value() != 0.f)
             continue;
 
-        const auto renderOffset     = PWORKSPACE && !w->m_pinned ? PWORKSPACE->m_renderOffset->value() : Vector2D{};
+        const auto renderOffset     = PWORKSPACE && !w->isPinnedOnWorkspace(PMONITOR->activeWorkspaceID()) ? PWORKSPACE->m_renderOffset->value() : Vector2D{};
         const auto REALPOS          = w->m_realPosition->value() + renderOffset;
         const auto noScreenShareBox = CBox{REALPOS.x, REALPOS.y, std::max(w->m_realSize->value().x, 5.0), std::max(w->m_realSize->value().y, 5.0)}
                                           .translate(-PMONITOR->m_position)

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -292,7 +292,7 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow) {
     if (!pWindow->m_workspace)
         return false;
 
-    if ((pWindow->m_pinned && pWindow->m_pinnedWorkspaces.empty()) || PWORKSPACE->m_forceRendering)
+    if ((pWindow->m_pinned && pWindow->m_pinnedSelectors.empty()) || PWORKSPACE->m_forceRendering)
         return true;
 
     if (PWORKSPACE && PWORKSPACE->isVisible())
@@ -526,9 +526,9 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
 
     TRACY_GPU_ZONE("RenderWindow");
 
-    const auto                       PWORKSPACE = pWindow->m_workspace;
-    const auto                       REALPOS    = pWindow->m_realPosition->value() + (pWindow->isPinnedOnWorkspace(pMonitor->activeWorkspaceID()) ? Vector2D{} : PWORKSPACE->m_renderOffset->value());
-    static auto                      PDIMAROUND = CConfigValue<Hyprlang::FLOAT>("decoration:dim_around");
+    const auto  PWORKSPACE = pWindow->m_workspace;
+    const auto  REALPOS    = pWindow->m_realPosition->value() + (pWindow->isPinnedOnWorkspace(pMonitor->activeWorkspaceID()) ? Vector2D{} : PWORKSPACE->m_renderOffset->value());
+    static auto PDIMAROUND = CConfigValue<Hyprlang::FLOAT>("decoration:dim_around");
 
     CSurfacePassElement::SRenderData renderdata = {pMonitor, time};
     CBox                             textureBox = {REALPOS.x, REALPOS.y, std::max(pWindow->m_realSize->value().x, 5.0), std::max(pWindow->m_realSize->value().y, 5.0)};
@@ -557,7 +557,8 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
 
     renderdata.surface   = pWindow->wlSurface()->resource();
     renderdata.dontRound = pWindow->isEffectiveInternalFSMode(FSMODE_FULLSCREEN);
-    renderdata.fadeAlpha = pWindow->m_alpha->value() * (pWindow->isPinnedOnWorkspace(pMonitor->activeWorkspaceID()) || USE_WORKSPACE_FADE_ALPHA ? 1.f : PWORKSPACE->m_alpha->value()) *
+    renderdata.fadeAlpha = pWindow->m_alpha->value() *
+        (pWindow->isPinnedOnWorkspace(pMonitor->activeWorkspaceID()) || USE_WORKSPACE_FADE_ALPHA ? 1.f : PWORKSPACE->m_alpha->value()) *
         (USE_WORKSPACE_FADE_ALPHA ? pWindow->m_movingToWorkspaceAlpha->value() : 1.F) * pWindow->m_movingFromWorkspaceAlpha->value();
     renderdata.alpha         = pWindow->m_activeInactiveAlpha->value();
     renderdata.decorate      = decorate && !pWindow->m_X11DoesntWantBorders && !pWindow->isEffectiveInternalFSMode(FSMODE_FULLSCREEN);
@@ -596,7 +597,8 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     renderdata.pos.y += pWindow->m_floatingOffset.y;
 
     // if window is floating and we have a slide animation, clip it to its full bb
-    if (!ignorePosition && pWindow->m_isFloating && !pWindow->isFullscreen() && PWORKSPACE->m_renderOffset->isBeingAnimated() && !pWindow->isPinnedOnWorkspace(pMonitor->activeWorkspaceID())) {
+    if (!ignorePosition && pWindow->m_isFloating && !pWindow->isFullscreen() && PWORKSPACE->m_renderOffset->isBeingAnimated() &&
+        !pWindow->isPinnedOnWorkspace(pMonitor->activeWorkspaceID())) {
         CRegion rg =
             pWindow->getFullWindowBoundingBox().translate(-pMonitor->m_position + PWORKSPACE->m_renderOffset->value() + pWindow->m_floatingOffset).scale(pMonitor->m_scale);
         renderdata.clipBox = rg.getExtents();
@@ -2220,8 +2222,8 @@ SCMSettings IHyprRenderer::getCMSettings(const NColorManagement::PImageDescripti
     const bool  needsSDRmod     = modifySDR && isSDR2HDR(imageDescription->value(), targetImageDescription->value());
     const bool  needsHDRmod     = !needsSDRmod && isHDR2SDR(imageDescription->value(), targetImageDescription->value());
     const float maxLuminance    = needsHDRmod ?
-        imageDescription->value().getTFMaxLuminance(-1) :
-        (imageDescription->value().luminances.max > 0 ? imageDescription->value().luminances.max : imageDescription->value().luminances.reference);
+           imageDescription->value().getTFMaxLuminance(-1) :
+           (imageDescription->value().luminances.max > 0 ? imageDescription->value().luminances.max : imageDescription->value().luminances.reference);
     const auto  dstMaxLuminance = targetImageDescription->value().luminances.max > 0 ? targetImageDescription->value().luminances.max : 10000;
 
     auto        matrix = imageDescription->getPrimaries()->convertMatrix(targetImageDescription->getPrimaries());
@@ -2556,30 +2558,30 @@ static hdr_output_metadata       createHDRMetadata(SImageDescription settings, S
 
     auto       colorimetry = settings.getPrimaries();
     auto       luminances  = settings.masteringLuminances.max > 0 ? settings.masteringLuminances :
-                                                                    (settings.luminances != SImageDescription::SPCLuminances{} ?
-                                                                         SImageDescription::SPCMasteringLuminances{.min = settings.luminances.min, .max = settings.luminances.max} :
-                                                                         SImageDescription::SPCMasteringLuminances{.min = monitor->minLuminance(), .max = monitor->maxLuminance(10000)});
+                                                                          (settings.luminances != SImageDescription::SPCLuminances{} ?
+                                                                               SImageDescription::SPCMasteringLuminances{.min = settings.luminances.min, .max = settings.luminances.max} :
+                                                                               SImageDescription::SPCMasteringLuminances{.min = monitor->minLuminance(), .max = monitor->maxLuminance(10000)});
 
     Log::logger->log(Log::TRACE, "ColorManagement primaries {},{} {},{} {},{} {},{}", colorimetry.red.x, colorimetry.red.y, colorimetry.green.x, colorimetry.green.y,
-                     colorimetry.blue.x, colorimetry.blue.y, colorimetry.white.x, colorimetry.white.y);
+                           colorimetry.blue.x, colorimetry.blue.y, colorimetry.white.x, colorimetry.white.y);
     Log::logger->log(Log::TRACE, "ColorManagement min {}, max {}, cll {}, fall {}", luminances.min, luminances.max, settings.maxCLL, settings.maxFALL);
     return hdr_output_metadata{
-        .metadata_type = 0,
-        .hdmi_metadata_type1 =
+              .metadata_type = 0,
+              .hdmi_metadata_type1 =
             hdr_metadata_infoframe{
-                .eotf          = eotf,
-                .metadata_type = 0,
-                .display_primaries =
-                    {
+                      .eotf          = eotf,
+                      .metadata_type = 0,
+                      .display_primaries =
+                          {
                         {.x = to16Bit(colorimetry.red.x), .y = to16Bit(colorimetry.red.y)},
                         {.x = to16Bit(colorimetry.green.x), .y = to16Bit(colorimetry.green.y)},
                         {.x = to16Bit(colorimetry.blue.x), .y = to16Bit(colorimetry.blue.y)},
                     },
-                .white_point                     = {.x = to16Bit(colorimetry.white.x), .y = to16Bit(colorimetry.white.y)},
-                .max_display_mastering_luminance = toNits(luminances.max),
-                .min_display_mastering_luminance = toNits(luminances.min * 10000),
-                .max_cll                         = toNits(settings.maxCLL > 0 ? settings.maxCLL : monitor->maxCLL()),
-                .max_fall                        = toNits(settings.maxFALL > 0 ? settings.maxFALL : monitor->maxFALL()),
+                      .white_point                     = {.x = to16Bit(colorimetry.white.x), .y = to16Bit(colorimetry.white.y)},
+                      .max_display_mastering_luminance = toNits(luminances.max),
+                      .min_display_mastering_luminance = toNits(luminances.min * 10000),
+                      .max_cll                         = toNits(settings.maxCLL > 0 ? settings.maxCLL : monitor->maxCLL()),
+                      .max_fall                        = toNits(settings.maxFALL > 0 ? settings.maxFALL : monitor->maxFALL()),
             },
     };
 }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -226,7 +226,7 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
     if (!pWindow->m_workspace && pWindow->m_fadingOut)
         return pWindow->workspaceID() == pMonitor->activeWorkspaceID() || pWindow->workspaceID() == pMonitor->activeSpecialWorkspaceID();
 
-    if (pWindow->m_pinned)
+    if (pWindow->isPinnedOnWorkspace(pMonitor->activeWorkspaceID()))
         return true;
 
     // if the window is being moved to a workspace that is not invisible, and the alpha is > 0.F, render it.
@@ -292,7 +292,7 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow) {
     if (!pWindow->m_workspace)
         return false;
 
-    if (pWindow->m_pinned || PWORKSPACE->m_forceRendering)
+    if ((pWindow->m_pinned && pWindow->m_pinnedWorkspaces.empty()) || PWORKSPACE->m_forceRendering)
         return true;
 
     if (PWORKSPACE && PWORKSPACE->isVisible())
@@ -386,8 +386,8 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
 
     // then render windows over fullscreen.
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->workspaceID() != pWorkspaceWindow->workspaceID() || !w->m_isFloating || (!w->m_createdOverFullscreen && !w->m_pinned) || (!w->m_isMapped && !w->m_fadingOut) ||
-            w->isFullscreen())
+        if (w->workspaceID() != pWorkspaceWindow->workspaceID() || !w->m_isFloating || (!w->m_createdOverFullscreen && !w->isPinnedOnWorkspace(pWorkspace->m_id)) ||
+            (!w->m_isMapped && !w->m_fadingOut) || w->isFullscreen())
             continue;
 
         if (w->m_monitor == pWorkspace->m_monitor && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
@@ -481,7 +481,7 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
         if (!w)
             continue;
 
-        if (!w->m_isFloating || w->m_pinned)
+        if (!w->m_isFloating || w->isPinnedOnWorkspace(pWorkspace->m_id))
             continue;
 
         // some things may force us to ignore the special/not special disparity
@@ -527,7 +527,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     TRACY_GPU_ZONE("RenderWindow");
 
     const auto                       PWORKSPACE = pWindow->m_workspace;
-    const auto                       REALPOS    = pWindow->m_realPosition->value() + (pWindow->m_pinned ? Vector2D{} : PWORKSPACE->m_renderOffset->value());
+    const auto                       REALPOS    = pWindow->m_realPosition->value() + (pWindow->isPinnedOnWorkspace(pMonitor->activeWorkspaceID()) ? Vector2D{} : PWORKSPACE->m_renderOffset->value());
     static auto                      PDIMAROUND = CConfigValue<Hyprlang::FLOAT>("decoration:dim_around");
 
     CSurfacePassElement::SRenderData renderdata = {pMonitor, time};
@@ -557,7 +557,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
 
     renderdata.surface   = pWindow->wlSurface()->resource();
     renderdata.dontRound = pWindow->isEffectiveInternalFSMode(FSMODE_FULLSCREEN);
-    renderdata.fadeAlpha = pWindow->m_alpha->value() * (pWindow->m_pinned || USE_WORKSPACE_FADE_ALPHA ? 1.f : PWORKSPACE->m_alpha->value()) *
+    renderdata.fadeAlpha = pWindow->m_alpha->value() * (pWindow->isPinnedOnWorkspace(pMonitor->activeWorkspaceID()) || USE_WORKSPACE_FADE_ALPHA ? 1.f : PWORKSPACE->m_alpha->value()) *
         (USE_WORKSPACE_FADE_ALPHA ? pWindow->m_movingToWorkspaceAlpha->value() : 1.F) * pWindow->m_movingFromWorkspaceAlpha->value();
     renderdata.alpha         = pWindow->m_activeInactiveAlpha->value();
     renderdata.decorate      = decorate && !pWindow->m_X11DoesntWantBorders && !pWindow->isEffectiveInternalFSMode(FSMODE_FULLSCREEN);
@@ -596,7 +596,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
     renderdata.pos.y += pWindow->m_floatingOffset.y;
 
     // if window is floating and we have a slide animation, clip it to its full bb
-    if (!ignorePosition && pWindow->m_isFloating && !pWindow->isFullscreen() && PWORKSPACE->m_renderOffset->isBeingAnimated() && !pWindow->m_pinned) {
+    if (!ignorePosition && pWindow->m_isFloating && !pWindow->isFullscreen() && PWORKSPACE->m_renderOffset->isBeingAnimated() && !pWindow->isPinnedOnWorkspace(pMonitor->activeWorkspaceID())) {
         CRegion rg =
             pWindow->getFullWindowBoundingBox().translate(-pMonitor->m_position + PWORKSPACE->m_renderOffset->value() + pWindow->m_floatingOffset).scale(pMonitor->m_scale);
         renderdata.clipBox = rg.getExtents();
@@ -1448,7 +1448,7 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         if (w->isHidden() && !w->m_isMapped && !w->m_fadingOut)
             continue;
 
-        if (!w->m_pinned || !w->m_isFloating)
+        if (!w->isPinnedOnWorkspace(pMonitor->activeWorkspaceID()) || !w->m_isFloating)
             continue;
 
         if (!shouldRenderWindow(w, pMonitor))
@@ -2994,7 +2994,7 @@ void IHyprRenderer::damageWindow(PHLWINDOW pWindow, bool forceFull) {
 
     CBox       windowBox        = pWindow->getFullWindowBoundingBox();
     const auto PWINDOWWORKSPACE = pWindow->m_workspace;
-    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated() && !pWindow->m_pinned)
+    if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated() && !pWindow->isPinnedOnWorkspace(PWINDOWWORKSPACE->m_id))
         windowBox.translate(PWINDOWWORKSPACE->m_renderOffset->value());
     windowBox.translate(pWindow->m_floatingOffset);
 

--- a/src/render/decorations/CHyprBorderDecoration.cpp
+++ b/src/render/decorations/CHyprBorderDecoration.cpp
@@ -40,7 +40,8 @@ CBox CHyprBorderDecoration::assignedBoxGlobal() {
     if (!PWORKSPACE)
         return box;
 
-    const auto WORKSPACEOFFSET = PWORKSPACE && !m_window->m_pinned ? PWORKSPACE->m_renderOffset->value() : Vector2D();
+    const WORKSPACEID  ACTIVEWSID     = m_window->m_monitor.lock() ? m_window->m_monitor.lock()->activeWorkspaceID() : WORKSPACE_INVALID;
+    const auto WORKSPACEOFFSET = PWORKSPACE && !m_window->isPinnedOnWorkspace(ACTIVEWSID) ? PWORKSPACE->m_renderOffset->value() : Vector2D();
     return box.translate(WORKSPACEOFFSET);
 }
 

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -49,8 +49,9 @@ void CHyprDropShadowDecoration::damageEntire() {
     CBox       shadowBox = {pos.x - m_extents.topLeft.x, pos.y - m_extents.topLeft.y, pos.x + size.x + m_extents.bottomRight.x, pos.y + size.y + m_extents.bottomRight.y};
 
     const auto PWORKSPACE  = PWINDOW->m_workspace;
+    const WORKSPACEID SHADOWWSID    = PWINDOW->m_monitor.lock() ? PWINDOW->m_monitor.lock()->activeWorkspaceID() : WORKSPACE_INVALID;
     const auto applyOffset = [&](CBox& b) {
-        if (PWORKSPACE && PWORKSPACE->m_renderOffset->isBeingAnimated() && !PWINDOW->m_pinned)
+        if (PWORKSPACE && PWORKSPACE->m_renderOffset->isBeingAnimated() && !PWINDOW->isPinnedOnWorkspace(SHADOWWSID))
             b.translate(PWORKSPACE->m_renderOffset->value());
         b.translate(PWINDOW->m_floatingOffset);
     };
@@ -135,7 +136,8 @@ SShadowRenderData CHyprDropShadowDecoration::getRenderData(PHLMONITOR pMonitor, 
     const auto  CORRECTIONOFFSET = (BORDERSIZE * (M_SQRT2 - 1) * std::max(2.0 - ROUNDINGPOWER, 0.0));
     const auto  ROUNDING         = ROUNDINGBASE > 0 ? (ROUNDINGBASE + BORDERSIZE) - CORRECTIONOFFSET : 0;
     const auto  PWORKSPACE       = PWINDOW->m_workspace;
-    const auto  WORKSPACEOFFSET  = PWORKSPACE && !PWINDOW->m_pinned ? PWORKSPACE->m_renderOffset->value() : Vector2D();
+    const WORKSPACEID RENDERWSID     = PWINDOW->m_monitor.lock() ? PWINDOW->m_monitor.lock()->activeWorkspaceID() : WORKSPACE_INVALID;
+    const auto  WORKSPACEOFFSET  = PWORKSPACE && !PWINDOW->isPinnedOnWorkspace(RENDERWSID) ? PWORKSPACE->m_renderOffset->value() : Vector2D();
 
     // draw the shadow
     CBox fullBox = m_lastWindowBoxWithDecos;

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -527,7 +527,8 @@ CBox CHyprGroupBarDecoration::assignedBoxGlobal() {
 
     const auto PWORKSPACE = m_window->m_workspace;
 
-    if (PWORKSPACE && !m_window->m_pinned)
+    const WORKSPACEID GROUPBARWSID = m_window->m_monitor.lock() ? m_window->m_monitor.lock()->activeWorkspaceID() : WORKSPACE_INVALID;
+    if (PWORKSPACE && !m_window->isPinnedOnWorkspace(GROUPBARWSID))
         box.translate(PWORKSPACE->m_renderOffset->value());
 
     return box.round();


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
Extends the pin window rule to accept workspace IDs so a window can be sticky only on specific workspaces. pin alone still works as before. You can pass individual IDs or ranges:
```
windowrule = pin 1 3, class:^(myapp)$
windowrule = pin 1-4, class:^(myapp)$
```
Also adds pinnedWorkspaces to hyprctl clients output (empty = pinned to all workspaces).


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
hyprctl clients output format changes -- new pinnedWorkspaces field in JSON, new line in plain text. Anything parsing that output by position will break.

The pin dispatching action (pinActive) still toggles without workspace scope, it just clears pinnedWorkspaces on unpin. Not sure if that's the right behavior or if it should be extended too.


Parts of the test file were written with AI assistance (claude code with opus 4.6) and reviewed by me

#### Is it ready for merging, or does it need work?
Needs review, especially around the workspace switching logic in Monitor.cpp and whether the pinActive keybind should also support workspace arguments




