### PR TITLE
fix: std::clamp assertion crash on resume from suspend

### DIFF
--- a/src/layout/algorithm/tiled/scrolling/ScrollTapeController.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollTapeController.cpp
@@ -240,7 +240,17 @@ void CScrollTapeController::fitStrip(size_t stripIndex, const CBox& usableArea, 
     const double stripStart    = calculateStripStart(stripIndex, usableArea, fullscreenOnOne);
     const double stripSize     = calculateStripSize(stripIndex, usableArea, fullscreenOnOne);
 
-    m_offset = std::clamp(m_offset, stripStart - usablePrimary + stripSize, stripStart);
+    const double lo = stripStart - usablePrimary + stripSize;
+    const double hi = stripStart;
+
+    if (lo > hi) {
+        // strip is wider than viewport (e.g. during monitor reconnection after suspend),
+        // center the strip instead of hitting the std::clamp assertion
+        m_offset = stripStart - (usablePrimary - stripSize) / 2.0;
+        return;
+    }
+
+    m_offset = std::clamp(m_offset, lo, hi);
 }
 
 bool CScrollTapeController::isStripVisible(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne, bool full) const {

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -795,6 +795,11 @@ void CScrollingAlgorithm::resizeTarget(const Vector2D& delta, SP<ITarget> target
 }
 
 void CScrollingAlgorithm::recalculate() {
+    // guard against recalculation during transitional monitor states
+    // (e.g. monitor reconnecting after suspend where workspace/monitor may not be ready)
+    if (!m_parent || !m_parent->space() || !m_parent->space()->workspace() || !m_parent->space()->workspace()->m_monitor)
+        return;
+
     if (Desktop::focusState()->window()) {
         const auto TARGET = Desktop::focusState()->window()->layoutTarget();
 
@@ -1516,6 +1521,12 @@ CBox CScrollingAlgorithm::usableArea() {
         return box;
 
     box.translate(-m_parent->space()->workspace()->m_monitor->m_position);
+
+    // ensure dimensions are never zero or negative, which can happen during
+    // monitor transitions (e.g. reconnection after suspend with stale reserved areas)
+    box.w = std::max(box.w, 1.0);
+    box.h = std::max(box.h, 1.0);
+
     return box;
 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes a crash in the scrolling tiled layout triggered by resuming from suspend. When the DRM backend reconnects outputs, the layout recalculation calls `fitStrip()` with bounds where `lo > hi`, violating the `std::clamp` precondition and aborting.

**Crash Details**

The assertion that fires:

```
/usr/include/c++/15.2.1/bits/stl_algo.h:3638:
constexpr const _Tp& std::clamp(const _Tp&, const _Tp&, const _Tp&)
[with _Tp = double]: Assertion '!(__hi < __lo)' failed.
```

Crash backtrace (trimmed):

```cpp
Layout::Tiled::SScrollingData::fitCol(CSharedPointer<SColumnData>)
Layout::Tiled::CScrollingAlgorithm::focusOnInput(CSharedPointer<ITarget>, eInputMode)
Layout::Tiled::CScrollingAlgorithm::recalculate()
Layout::CAlgorithm::recalculate()
CCompositor::arrangeMonitors()
CMonitor::onConnect(bool)
CCompositor::onNewMonitor(CSharedPointer<IOutput>)
Aquamarine::SDRMConnector::connect()
Aquamarine::CDRMBackend::recheckOutputs()
Aquamarine::CSession::dispatchUdevEvents()
```

Log tail shows repeated `ERR: drm: Session inactive` with buffers cycling through fallback resolutions (800x600, 640x480, etc.) as the session resumes.

**Root Cause**

In `CScrollTapeController::fitStrip()`:

```cpp
m_offset = std::clamp(m_offset, stripStart - usablePrimary + stripSize, stripStart);
```

This requires `stripSize <= usablePrimary`. During monitor reconnection after suspend, the usable area can have stale or reduced dimensions while column widths retain their pre-suspend values, making `stripSize > usablePrimary` and the clamp bounds invalid.

**Fixes**

1. `ScrollTapeController::fitStrip()` — when the strip is wider than the viewport (`lo > hi`), center the strip instead of crashing. This reuses the existing `centerStrip()` formula.

2. `CScrollingAlgorithm::recalculate()` — early return if the workspace or monitor isn't ready, preventing the entire recalculate/focusOnInput/fitCol chain from running during transitional monitor states.

3. `CScrollingAlgorithm::usableArea()` — clamp box dimensions to a minimum of 1.0, preventing zero or negative usable areas from propagating through the layout (e.g. from stale reserved areas being subtracted during reconnection).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Issue identified by Claude.

#### Is it ready for merging, or does it need work?

Testing locally, will report if there are any issues, so far so good.
