### PR TITLE
protocols: schedule done after output update in ext-workspace

### DIFF
--- a/src/protocols/ExtWorkspace.cpp
+++ b/src/protocols/ExtWorkspace.cpp
@@ -33,8 +33,13 @@ CExtWorkspaceGroupResource::CExtWorkspaceGroupResource(WP<CExtWorkspaceManagerRe
     }
 
     m_listeners.outputBound = output->m_events.outputBound.listen([this](const SP<CWLOutputResource>& output) {
-        if (output->client() == m_resource->client())
-            m_resource->sendOutputEnter(output->getResource()->resource());
+        if (output->client() != m_resource->client())
+            return;
+
+        m_resource->sendOutputEnter(output->getResource()->resource());
+
+        if (m_manager)
+            m_manager->scheduleDone();
     });
 }
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
done() wasn't being scheduled after a workspace group entered a monitor. In practice that means correctly implemented clients wouldn't acknowledge the enter until another event triggered done().

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready to merge

