### PR TITLE
Refactor: Add noreturn attribute to the throwError function declaration.

### DIFF
--- a/src/helpers/MiscFunctions.hpp
+++ b/src/helpers/MiscFunctions.hpp
@@ -35,7 +35,7 @@ Vector2D                                configStringToVector2D(const std::string
 std::optional<float>                    getPlusMinusKeywordResult(std::string in, float relative);
 double                                  normalizeAngleRad(double ang);
 std::vector<SCallstackFrameInfo>        getBacktrace();
-void                                    throwError(const std::string& err);
+[[noreturn]] void                       throwError(const std::string& err);
 Hyprutils::OS::CFileDescriptor          allocateSHMFile(size_t len);
 bool                                    allocateSHMFilePair(size_t size, Hyprutils::OS::CFileDescriptor& rw_fd_ptr, Hyprutils::OS::CFileDescriptor& ro_fd_ptr);
 float                                   stringToPercentage(const std::string& VALUE, const float REL);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This PR adds the standard [[noreturn]] attribute to the throwError function declaration.
Since this function always terminates by throwing an exception, it never returns control to the caller. 
The [[noreturn]] attribute explicitly indicates this behavior. 
This allows the compiler to perform better optimizations and improves code clarity for developers.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No. The change is completely safe, does not alter the program's logic, and does not break backward compatibility.

#### Is it ready for merging, or does it need work?
Ready for merging.


