### PR TITLE
Fix mouse pointer not refocussing after layer surface change

### DIFF
--- a/src/desktop/view/LayerSurface.cpp
+++ b/src/desktop/view/LayerSurface.cpp
@@ -336,6 +336,9 @@ void CLayerSurface::onCommit() {
 
             if (m_layer == ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND || m_layer == ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM)
                 PMONITOR->m_blurFBDirty = true; // so that blur is recalc'd
+
+            if (g_pSeatManager->m_state.pointerFocus == m_wlSurface->resource())
+                g_pInputManager->simulateMouseMovement();
         }
 
         g_pHyprRenderer->arrangeLayersForMonitor(PMONITOR->m_id);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Hi,
Currently there is a bug that when a layer surface changes its layer the mouse focus does not gets recalculated until a mouse movement.
`onUnmap()` already calls `simulateMouseMovement()` after removing a surface. \
There is also a `simulateMouseMovement()` call in at line 399, but it does not cover layer changes.

This fixes this issue that I have on Ashell that only occurred on Hyprland:
(https://github.com/MalpenZibo/ashell/issues/524) \
(most of the info that I provided is in the issue is now outdated, like it only happened using exec-once, you can just watch my latest video).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.

#### Is it ready for merging, or does it need work?
This is my first commit, so I would really like for someone to look at it before merging.
Also, let me know if you have questions.

Thank you.