### PR TITLE
renderer: fix crash when shader path isn't a file

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -889,10 +889,21 @@ void CHyprOpenGLImpl::applyScreenShader(const std::string& path) {
     if (path.empty() || path == STRVAL_EMPTY)
         return;
 
-    std::ifstream infile(absolutePath(path, g_pConfigManager->getMainConfigPath()));
+    std::string     absPath = absolutePath(path, g_pConfigManager->getMainConfigPath());
+
+    std::error_code ec;
+    if (!std::filesystem::is_regular_file(absPath, ec)) {
+        if (ec)
+            g_pConfigManager->addParseError("Screen shader parser: Failed to check screen shader path: " + ec.message());
+        else
+            g_pConfigManager->addParseError("Screen shader parser: Screen shader path is not a regular file");
+        return;
+    }
+
+    std::ifstream infile(absPath);
 
     if (!infile.good()) {
-        g_pConfigManager->addParseError("Screen shader parser: Screen shader path not found");
+        g_pConfigManager->addParseError("Screen shader parser: Failed to open screen shader");
         return;
     }
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

Hyprland crashes if `decoration:screen_shader` is set to a directory path instead of a file.

https://github.com/hyprwm/Hyprland/blob/30c498acf4173930dfd8afd6279ebceacb1941e9/src/render/OpenGL.cpp#L892-L899

```shell
$ hyprctl keyword decoration:screen_shader '/'
```

I implemented a check for the file type.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I do not know the C++ idiomatic way to check for this kind of issues, so I used `fstat`.

#### Is it ready for merging, or does it need work?

Should be good to merge
