### PR TITLE
Fix popup crash with nullptr mon

### DIFF
--- a/src/desktop/view/Popup.cpp
+++ b/src/desktop/view/Popup.cpp
@@ -199,9 +199,8 @@ void CPopup::onMap() {
     m_wlSurface->resource()->breadthfirst([PMONITOR](SP<CWLSurfaceResource> s, const Vector2D& offset, void* d) { s->enter(PMONITOR->m_self.lock()); }, nullptr);
 
     if (!m_layerOwner.expired() && m_layerOwner->m_layer < ZWLR_LAYER_SHELL_V1_LAYER_TOP) {
-        auto mon = g_pCompositor->getMonitorFromID(m_layerOwner->m_layer);
-        if (mon)
-            mon->m_blurFBDirty = true;
+        if (m_layerOwner->m_monitor)
+            m_layerOwner->m_monitor->m_blurFBDirty = true;
     }
 
     m_alpha->setConfig(g_pConfigManager->getAnimationPropertyConfig("fadePopupsIn"));
@@ -254,9 +253,8 @@ void CPopup::onUnmap() {
     m_subsurfaceHead.reset();
 
     if (!m_layerOwner.expired() && m_layerOwner->m_layer < ZWLR_LAYER_SHELL_V1_LAYER_TOP) {
-        const auto mon = g_pCompositor->getMonitorFromID(m_layerOwner->m_layer);
-        if (mon)
-            mon->m_blurFBDirty = true;
+        if (m_layerOwner->m_monitor)
+            m_layerOwner->m_monitor->m_blurFBDirty = true;
     }
 
     // damage all children
@@ -322,9 +320,8 @@ void CPopup::onCommit(bool ignoreSiblings) {
     m_requestedReposition = false;
 
     if (!m_layerOwner.expired() && m_layerOwner->m_layer < ZWLR_LAYER_SHELL_V1_LAYER_TOP) {
-        const auto mon = g_pCompositor->getMonitorFromID(m_layerOwner->m_layer);
-        if (mon)
-            mon->m_blurFBDirty = true;
+        if (m_layerOwner->m_monitor)
+            m_layerOwner->m_monitor->m_blurFBDirty = true;
     }
 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes https://github.com/hyprwm/Hyprland/discussions/13708

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No idea why `g_pCompositor->getMonitorFromID(m_layerOwner->m_layer)` return nullptr. Was this way before my changes, might be incorrect.

#### Is it ready for merging, or does it need work?
Ready