### PR TITLE
input: fix touch screen focus on multi monitor

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -257,7 +257,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
         g_pCompositor->scheduleFrameForMonitor(PMONITOR, Aquamarine::IOutput::AQ_SCHEDULE_CURSOR_MOVE);
 
     // constraints
-    if (!g_pSeatManager->m_mouse.expired() && isConstrained()) {
+    if (mouse && !g_pSeatManager->m_mouse.expired() && isConstrained()) {
         const auto SURF       = Desktop::View::CWLSurface::fromResource(Desktop::focusState()->surface());
         const auto CONSTRAINT = SURF ? SURF->constraint() : nullptr;
 
@@ -338,7 +338,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
 
     // if we are holding a pointer button,
     // and we're not dnd-ing, don't refocus. Keep focus on last surface.
-    if (!PROTO::data->dndActive() && !m_currentlyHeldButtons.empty() && Desktop::focusState()->surface() && Desktop::focusState()->surface()->m_mapped &&
+    if (mouse && !PROTO::data->dndActive() && !m_currentlyHeldButtons.empty() && Desktop::focusState()->surface() && Desktop::focusState()->surface()->m_mapped &&
         g_pSeatManager->m_state.pointerFocus && !m_hardInput) {
         foundSurface = g_pSeatManager->m_state.pointerFocus.lock();
 
@@ -644,8 +644,10 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
             m_lastFocusOnLS = true;
     }
 
-    g_pSeatManager->setPointerFocus(foundSurface, surfaceLocal);
-    g_pSeatManager->sendPointerMotion(time, surfaceLocal);
+    if (mouse) {
+        g_pSeatManager->setPointerFocus(foundSurface, surfaceLocal);
+        g_pSeatManager->sendPointerMotion(time, surfaceLocal);
+    }
 }
 
 void CInputManager::onMouseButton(IPointer::SButtonEvent e, SP<IPointer> mouse) {

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -241,7 +241,8 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
 
     m_lastCursorPosFloored = MOUSECOORDSFLOORED;
 
-    const auto PMONITOR = isLocked() && Desktop::focusState()->monitor() ? Desktop::focusState()->monitor() : g_pCompositor->getMonitorFromCursor();
+    // use mouseCoords specifically in case touch sent overridePos, otherwise touch doesn't work on non-focused monitor
+    const auto PMONITOR = isLocked() && Desktop::focusState()->monitor() ? Desktop::focusState()->monitor() : g_pCompositor->getMonitorFromVector(mouseCoords);
 
     // this can happen if there are no displays hooked up to Hyprland
     if (PMONITOR == nullptr)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes touch refocus using cursor position instead of touch position for monitor focus, which made it impossible to e.g. touch LS on non-focused monitor.

- Fixes https://github.com/hyprwm/Hyprland/discussions/12221
- Older forgotten pr that just seems more complicated https://github.com/hyprwm/Hyprland/pull/12646

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Nope, seems like a pretty simple logic error to me that overridePos was used for mouseCoords but mouseCoords wasn't used for focus.

#### Is it ready for merging, or does it need work?

Ready.

