### PR TITLE
layout/algos: Allow 'focus_on_close' to switch to most recently used window on closed

### DIFF
--- a/hyprtester/src/tests/main/layout.cpp
+++ b/hyprtester/src/tests/main/layout.cpp
@@ -103,6 +103,43 @@ static void testPosPreserve() {
     Tests::killAllWindows();
 }
 
+static bool testFocusMRUAfterClose() {
+    NLog::log("{}Testing focus after close (MRU order)", Colors::GREEN);
+
+    OK(getFromSocket("/reload"));
+    OK(getFromSocket("/keyword dwindle:default_split_ratio 1.25"));
+    OK(getFromSocket("/keyword input:focus_on_close 2"));
+
+    EXPECT(!!Tests::spawnKitty("kitty_A"), true);
+    EXPECT(!!Tests::spawnKitty("kitty_B"), true);
+    EXPECT(!!Tests::spawnKitty("kitty_C"), true);
+
+    OK(getFromSocket("/dispatch focuswindow class:kitty_A"));
+    OK(getFromSocket("/dispatch focuswindow class:kitty_B"));
+    OK(getFromSocket("/dispatch focuswindow class:kitty_C"));
+
+    OK(getFromSocket("/dispatch killactive"));
+    Tests::waitUntilWindowsN(2);
+
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT(str.contains("class: kitty_B"), true);
+    }
+
+    OK(getFromSocket("/dispatch killactive"));
+    Tests::waitUntilWindowsN(1);
+
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT(str.contains("class: kitty_A"), true);
+    }
+
+    NLog::log("{}Killing all windows", Colors::YELLOW);
+    Tests::killAllWindows();
+    EXPECT(Tests::windowCount(), 0);
+    return true;
+}
+
 static bool test() {
     NLog::log("{}Testing layout generic", Colors::GREEN);
 
@@ -115,6 +152,7 @@ static bool test() {
 
     testCrashOnGeomUpdate();
     testPosPreserve();
+    testFocusMRUAfterClose();
 
     // clean up
     NLog::log("Cleaning up", Colors::YELLOW);

--- a/src/config/supplementary/ConfigDescriptions.hpp
+++ b/src/config/supplementary/ConfigDescriptions.hpp
@@ -625,9 +625,9 @@ namespace Config::Supplementary {
             .value = "input:focus_on_close",
             .description =
                 "Controls the window focus behavior when a window is closed. When set to 0, focus will shift to the next window candidate. When set to 1, focus will shift "
-                "to the window under the cursor.",
+                "to the window under the cursor. When set to 2, focus will shift to the most recently used/active window.",
             .type = CONFIG_OPTION_CHOICE,
-            .data = SConfigOptionDescription::SChoiceData{0, "next,cursor"},
+            .data = SConfigOptionDescription::SChoiceData{0, "next,cursor,mru"},
         },
         SConfigOptionDescription{
             .value       = "input:mouse_refocus",
@@ -667,8 +667,8 @@ namespace Config::Supplementary {
         },
 
         /*
-     * input:touchpad:
-     */
+         * input:touchpad:
+         */
 
         SConfigOptionDescription{
             .value       = "input:touchpad:disable_while_typing",

--- a/src/layout/algorithm/Algorithm.cpp
+++ b/src/layout/algorithm/Algorithm.cpp
@@ -237,7 +237,9 @@ const UP<IFloatingAlgorithm>& CAlgorithm::floatingAlgo() const {
 }
 
 SP<ITarget> CAlgorithm::getNextCandidate(SP<ITarget> old) {
-    if (old->floating()) {
+    static auto FOCUSONCLOSE = CConfigValue<Hyprlang::INT>("input:focus_on_close");
+
+    if (old->floating() || *FOCUSONCLOSE == 2) {
         // use window history to determine best target
         for (const auto& w : Desktop::History::windowTracker()->fullHistory() | std::views::reverse) {
             if (!w->m_workspace || w->m_workspace->m_space != m_space || !w->layoutTarget() || !w->layoutTarget()->space())


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
Fixes: #10655 - Allows windows closed focus behavior to switch to the most recently focused window by allowing a new option for `focus_on_close`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
1. There was a previous MR open for this (#11204) but it seems to have been abandoned.
2. Let me know if the test needs to be moved or more coverage is needed.

#### Is it ready for merging, or does it need work?
If approved, will create necessary wiki MR, otherwise ready

