### PR TITLE
debug: print log when window is mapped

### DIFF
--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -2,7 +2,6 @@
 #include <ranges>
 #include <hyprutils/animation/AnimatedVariable.hpp>
 #include <re2/re2.h>
--
 #include "Group.hpp"
 #include <iostream>
 


### PR DESCRIPTION
This adds a simple debug output when a window is mapped in `CWindow::onMap()`.

It helps track window lifecycle events during debugging, especially for focus and stacking related issues.

Tested locally by building Hyprland from source and verifying output when launching applications.

This change does not modify any functional behavior.
