### PR TITLE
Refactor: rewrite deviceNameToInternalString using a single range pipeline

### DIFF
--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -927,12 +927,18 @@ std::expected<std::string, std::string> binaryNameForPid(pid_t pid) {
     return fullPath;
 }
 
-std::string deviceNameToInternalString(std::string in) {
-    std::ranges::replace(in, ' ', '-');
-    std::ranges::replace(in, '\n', '-');
-    std::ranges::replace(in, ',', '-');
-    std::ranges::transform(in, in.begin(), ::tolower);
-    return in;
+std::string deviceNameToInternalString(const std::string& in) {
+    auto result = in | std::views::transform([](unsigned char ch) -> char {
+                      switch (ch) {
+                          case ' ':
+                          case '\n':
+                          case ',': return '-';
+
+                          default: return static_cast<char>(std::tolower(ch));
+                      }
+                  });
+
+    return result | std::ranges::to<std::string>();
 }
 
 static const std::vector<const char*> PKGCONF_PATHS = {"/usr/lib/pkgconfig", "/usr/local/lib/pkgconfig"};

--- a/src/helpers/MiscFunctions.hpp
+++ b/src/helpers/MiscFunctions.hpp
@@ -42,7 +42,7 @@ float                                   stringToPercentage(const std::string& VA
 bool                                    isNvidiaDriverVersionAtLeast(int threshold);
 std::expected<std::string, std::string> binaryNameForWlClient(wl_client* client);
 std::expected<std::string, std::string> binaryNameForPid(pid_t pid);
-std::string                             deviceNameToInternalString(std::string in);
+std::string                             deviceNameToInternalString(const std::string& in);
 std::string                             getSystemLibraryVersion(const std::string& name);
 std::string                             getBuiltSystemLibraryNames();
 bool                                    truthy(const std::string& str);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This PR refactors and optimizes the deviceNameToInternalString function.
Replaced four sequential passes over the string (replace + transform) with a single std::views::transform pipeline.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No.

#### Is it ready for merging, or does it need work?
Ready for merging.

