### PR TITLE
input: fix the multimon touch fix

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -261,7 +261,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
         g_pCompositor->scheduleFrameForMonitor(PMONITOR, Aquamarine::IOutput::AQ_SCHEDULE_CURSOR_MOVE);
 
     // constraints
-    if (mouse && !g_pSeatManager->m_mouse.expired() && isConstrained()) {
+    if (!overridePos.has_value() && !g_pSeatManager->m_mouse.expired() && isConstrained()) {
         const auto SURF       = Desktop::View::CWLSurface::fromResource(Desktop::focusState()->surface());
         const auto CONSTRAINT = SURF ? SURF->constraint() : nullptr;
 
@@ -342,8 +342,8 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
 
     // if we are holding a pointer button,
     // and we're not dnd-ing, don't refocus. Keep focus on last surface.
-    if (mouse && !PROTO::data->dndActive() && !m_currentlyHeldButtons.empty() && Desktop::focusState()->surface() && Desktop::focusState()->surface()->m_mapped &&
-        g_pSeatManager->m_state.pointerFocus && !m_hardInput) {
+    if (!overridePos.has_value() && !PROTO::data->dndActive() && !m_currentlyHeldButtons.empty() && Desktop::focusState()->surface() &&
+        Desktop::focusState()->surface()->m_mapped && g_pSeatManager->m_state.pointerFocus && !m_hardInput) {
         foundSurface = g_pSeatManager->m_state.pointerFocus.lock();
 
         // IME popups aren't desktop-like elements
@@ -648,7 +648,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
             m_lastFocusOnLS = true;
     }
 
-    if (mouse) {
+    if (!overridePos.has_value()) {
         g_pSeatManager->setPointerFocus(foundSurface, surfaceLocal);
         g_pSeatManager->sendPointerMotion(time, surfaceLocal);
     }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Had some kind of brainfart and thought `mouse` was actually set by default when used by the mouse functions in #13764. This way we should definitely only affect touch input, since touch is the only thing that uses overridePos. Although my own plugin also used it for fake mouse pos, hmmmm...

Much simpler fix might just be setting `mouse = true` by default, but that does affect some other logic and I really don't know how. I would prefer that if I only knew the repercussions.

Someone might want to split this function in the future so touch could only call the part that finds target surfaces for coords and skips the pointer related things.

- Fixes #13815

#### Is it ready for merging, or does it need work?

At least the gamers look happy again and my touch stuff still works as well

