### PR TITLE
fix(renderer): guard against null monitor in renderMonitor

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2284,6 +2284,8 @@ void IHyprRenderer::renderMirrored() {
 }
 
 void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
+    if (!pMonitor)
+        return;
     static std::chrono::high_resolution_clock::time_point renderStart        = std::chrono::high_resolution_clock::now();
     static std::chrono::high_resolution_clock::time_point renderStartOverlay = std::chrono::high_resolution_clock::now();
     static std::chrono::high_resolution_clock::time_point endRenderOverlay   = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
Adds a null check for  pMonitor  at the beginning of  renderMonitor.

renderMonitor  is called with  m_monitor.lock()  in several places, which can return  nullptr  if the weak pointer has expired. The function currently dereferences  pMonitor  without validation, which could lead to a null pointer dereference.

No functional changes intended. This is a defensive fix to prevent potential crashes.

Tested by:
- Building Hyprland successfully
- Running a full session
- Locking and unlocking the screen
- Opening and interacting with applications
