### PR TITLE
Render: [WIP] Attempt to Handle GPU Resets

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2650,10 +2650,10 @@ void CCompositor::openSafeModeBox() {
 
     auto       box = CAsyncDialogBox::create(I18n::i18nEngine()->localize(I18n::TXT_KEY_SAFE_MODE_TITLE), I18n::i18nEngine()->localize(I18n::TXT_KEY_SAFE_MODE_DESCRIPTION),
                                              {
-                                           OPT_LOAD,
-                                           OPT_OPEN,
-                                           OPT_OK,
-                                       });
+                                                 OPT_LOAD,
+                                                 OPT_OPEN,
+                                                 OPT_OK,
+                                             });
 
     box->open()->then([OPT_LOAD, OPT_OK, OPT_OPEN, this](SP<CPromiseResult<std::string>> result) {
         if (result->hasError())

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -546,6 +546,55 @@ void CCompositor::stopCompositor() {
     m_isShuttingDown = true;
 }
 
+void CCompositor::handleGPUReset() {
+    // Time to pray
+    if (!m_wlDisplay)
+        RASSERT(false, "no wayland display and we reset???");
+
+    if (!g_pHyprRenderer->rendererLost())
+        return;
+
+    for (auto const& m : m_monitors) {
+        g_pHyprOpenGL->destroyMonitorResources(m);
+
+        // These are invalid, I am pretty sure
+        // Invalidate IFramebuffers
+        m->resetResources();
+        m->m_background.reset();
+        m->m_splash.reset();
+    }
+
+    Render::g_pShaderLoader.reset();
+
+    // vulkan reset will go in here too :)
+    // g_pHyprOpenGL gets reset here.
+    g_pHyprOpenGL = makeUnique<CHyprOpenGLImpl>();
+    g_pHyprRenderer->m_renderData.mainFB.reset();
+    g_pHyprRenderer->m_renderData.outFB.reset();
+    g_pHyprRenderer->m_renderData.currentFB.reset();
+
+    // Okay, try from a fresh start.
+    for (auto const& m : m_monitors) {
+        if (!m->m_enabled)
+            continue;
+
+        auto cpy = m->m_activeMonitorRule;
+        m->m_state.clearSwapchain();
+        // force reconfigure the monitors
+        m->applyMonitorRule(std::move(cpy), true);
+        scheduleFrameForMonitor(m, IOutput::scheduleFrameReason::AQ_SCHEDULE_RENDER_MONITOR);
+    }
+
+    // TODO: localize this if this stays.
+    g_pHyprNotificationOverlay->addNotification(
+        "Warning: Hyprland has recovered from a GPU reset. If you run into issues, consider collecting the logs and submitting them to https://github.com/hyprwm/Hyprland",
+        CHyprColor{1.0, 0.1, 0.1, 1.0}, 20000, ICON_WARNING);
+}
+
+void CCompositor::queueRendererReset() {
+    g_pEventLoopManager->doLater([] { g_pCompositor->handleGPUReset(); });
+}
+
 void CCompositor::cleanup() {
     if (!m_wlDisplay)
         return;
@@ -2601,10 +2650,10 @@ void CCompositor::openSafeModeBox() {
 
     auto       box = CAsyncDialogBox::create(I18n::i18nEngine()->localize(I18n::TXT_KEY_SAFE_MODE_TITLE), I18n::i18nEngine()->localize(I18n::TXT_KEY_SAFE_MODE_DESCRIPTION),
                                              {
-                                                 OPT_LOAD,
-                                                 OPT_OPEN,
-                                                 OPT_OK,
-                                             });
+                                           OPT_LOAD,
+                                           OPT_OPEN,
+                                           OPT_OK,
+                                       });
 
     box->open()->then([OPT_LOAD, OPT_OK, OPT_OPEN, this](SP<CPromiseResult<std::string>> result) {
         if (result->hasError())

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -551,8 +551,10 @@ void CCompositor::handleGPUReset(bool& awaitingReset) {
     if (!m_wlDisplay)
         RASSERT(false, "no wayland display and we reset???");
 
-    if UNLIKELY (!g_pHyprRenderer->rendererLost())
+    if UNLIKELY (!g_pHyprRenderer->rendererLost()) {
+        awaitingReset = false;
         return;
+    }
 
     for (auto const& m : m_monitors) {
         g_pHyprOpenGL->destroyMonitorResources(m);
@@ -581,6 +583,7 @@ void CCompositor::handleGPUReset(bool& awaitingReset) {
             continue;
 
         auto cpy = m->m_activeMonitorRule;
+        m->m_forceFullFrames = 5;
         m->m_state.clearSwapchain();
         // force reconfigure the monitors
         m->applyMonitorRule(std::move(cpy), true);

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -546,11 +546,10 @@ void CCompositor::stopCompositor() {
     m_isShuttingDown = true;
 }
 
+#include <protocols/types/DMABuffer.hpp>
+
 void CCompositor::handleGPUReset(bool& awaitingReset) {
     // Time to pray
-    if (!m_wlDisplay)
-        RASSERT(false, "no wayland display and we reset???");
-
     if UNLIKELY (!g_pHyprRenderer->rendererLost()) {
         awaitingReset = false;
         return;
@@ -559,12 +558,11 @@ void CCompositor::handleGPUReset(bool& awaitingReset) {
     for (auto const& m : m_monitors) {
         g_pHyprOpenGL->destroyMonitorResources(m);
 
-        // These are invalid, I am pretty sure
-        // Invalidate IFramebuffers
+        // Get rid of framebuffers as these will be referencing GPU mem
         m->resetResources();
         m->m_background.reset();
         m->m_splash.reset();
-        //m->m_cursorSwapchain.reset();
+        m->m_cursorSwapchain.reset();
     }
 
     Render::g_pShaderLoader.reset();
@@ -576,22 +574,46 @@ void CCompositor::handleGPUReset(bool& awaitingReset) {
     g_pHyprRenderer->m_renderData.mainFB.reset();
     g_pHyprRenderer->m_renderData.outFB.reset();
     g_pHyprRenderer->m_renderData.currentFB.reset();
+    g_pHyprRenderer->m_renderPass = {};
+    g_pHyprRenderer->clearRenderBuffers();
 
-    // Okay, try from a fresh start.
-    for (auto const& m : m_monitors) {
-        if (!m->m_enabled)
-            continue;
+    // Clear out the monitor swap chains as those buffers should be regenerated.
+    for (auto const& m : m_monitors | std::views::filter([](auto const& m) { return m->m_enabled; }))
+        m->m_state.clearSwapchain();
 
+    PROTO::compositor->forEachSurface([&](SP<CWLSurfaceResource> surf) {
+        auto& buf = surf->m_current.buffer;
+        if (!buf || !buf.m_buffer) {
+            if (surf->m_current.texture) {
+                surf->m_current.texture.reset();
+            }
+            return;
+        }
+
+        // DMA BUFs are toast, right?
+        if (buf.m_buffer->type() == Aquamarine::eBufferType::BUFFER_TYPE_DMABUF) {
+            auto dmaBuf = dc<CDMABuffer*>(buf.m_buffer.get());
+            dmaBuf->m_resource->sendRelease();
+        } else {
+            auto shm = buf.m_buffer->shm();
+            Log::logger->log(Log::DEBUG, "GPU Reset: invalidating SHM surface (mapped={}, size={}x{}, shm.success={}, fmt=0x{:x})", surf->m_mapped, surf->m_current.size.x,
+                             surf->m_current.size.y, shm.success, shm.format);
+            buf.m_buffer->m_texture.reset();
+            surf->m_current.texture.reset();
+        }
+    });
+
+    // Everything has been reset into a state that we should be ready to recover.
+    // Spin the frames back up.
+    for (auto const& m : m_monitors | std::views::filter([](auto const& m) { return m->m_enabled; })) {
         auto cpy = m->m_activeMonitorRule;
         m->m_forceFullFrames = 5;
-        m->m_state.clearSwapchain();
-        // force reconfigure the monitors
+        // force reconfigure the monitors, this should schedule frame for us
         m->applyMonitorRule(std::move(cpy), true);
-        scheduleFrameForMonitor(m, IOutput::scheduleFrameReason::AQ_SCHEDULE_RENDER_MONITOR);
+        scheduleFrameForMonitor(m, IOutput::scheduleFrameReason::AQ_SCHEDULE_DAMAGE);
     }
 
     awaitingReset = false;
-
     // TODO: localize this if this stays.
     g_pHyprNotificationOverlay->addNotification(
         "Warning: Hyprland has recovered from a GPU reset. If you run into issues, consider collecting the logs and submitting them to https://github.com/hyprwm/Hyprland",

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -546,12 +546,12 @@ void CCompositor::stopCompositor() {
     m_isShuttingDown = true;
 }
 
-void CCompositor::handleGPUReset() {
+void CCompositor::handleGPUReset(bool& awaitingReset) {
     // Time to pray
     if (!m_wlDisplay)
         RASSERT(false, "no wayland display and we reset???");
 
-    if (!g_pHyprRenderer->rendererLost())
+    if UNLIKELY (!g_pHyprRenderer->rendererLost())
         return;
 
     for (auto const& m : m_monitors) {
@@ -562,12 +562,14 @@ void CCompositor::handleGPUReset() {
         m->resetResources();
         m->m_background.reset();
         m->m_splash.reset();
+        //m->m_cursorSwapchain.reset();
     }
 
     Render::g_pShaderLoader.reset();
 
     // vulkan reset will go in here too :)
     // g_pHyprOpenGL gets reset here.
+    g_pHyprOpenGL.reset();
     g_pHyprOpenGL = makeUnique<CHyprOpenGLImpl>();
     g_pHyprRenderer->m_renderData.mainFB.reset();
     g_pHyprRenderer->m_renderData.outFB.reset();
@@ -585,6 +587,8 @@ void CCompositor::handleGPUReset() {
         scheduleFrameForMonitor(m, IOutput::scheduleFrameReason::AQ_SCHEDULE_RENDER_MONITOR);
     }
 
+    awaitingReset = false;
+
     // TODO: localize this if this stays.
     g_pHyprNotificationOverlay->addNotification(
         "Warning: Hyprland has recovered from a GPU reset. If you run into issues, consider collecting the logs and submitting them to https://github.com/hyprwm/Hyprland",
@@ -592,7 +596,11 @@ void CCompositor::handleGPUReset() {
 }
 
 void CCompositor::queueRendererReset() {
-    g_pEventLoopManager->doLater([] { g_pCompositor->handleGPUReset(); });
+    static bool awaitingReset = false;
+    if (awaitingReset)
+        return;
+    awaitingReset = true;
+    g_pEventLoopManager->doLater([] { g_pCompositor->handleGPUReset(awaitingReset); });
 }
 
 void CCompositor::cleanup() {

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -172,9 +172,11 @@ class CCompositor {
     bool                                shouldChangePreferredImageDescription();
 
     bool                                supportsDrmSyncobjTimeline() const;
+    void                                queueRendererReset();
     std::string                         m_explicitConfigPath;
 
   private:
+    void                           handleGPUReset();
     void                           initAllSignals();
     void                           removeAllSignals();
     void                           cleanEnvironment();

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -176,7 +176,7 @@ class CCompositor {
     std::string                         m_explicitConfigPath;
 
   private:
-    void                           handleGPUReset();
+    void                           handleGPUReset(bool&);
     void                           initAllSignals();
     void                           removeAllSignals();
     void                           cleanEnvironment();

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -2459,6 +2459,13 @@ bool CMonitorState::test() {
     return m_owner->m_output->test();
 }
 
+bool CMonitorState::clearSwapchain() {
+    auto options   = m_owner->m_output->swapchain->currentOptions();
+    options.length = 0;
+    options.size   = Hyprutils::Math::Vector2D{};
+    return m_owner->m_output->swapchain->reconfigure(options);
+}
+
 bool CMonitorState::updateSwapchain() {
     const auto& OPTIONS = m_owner->m_output->swapchain->currentOptions();
     const auto& STATE   = m_owner->m_output->state->state();
@@ -2512,4 +2519,8 @@ WP<CMonitorResources> CMonitor::resources() {
         m_resources = makeUnique<CMonitorResources>(m_self, DRM_FORMAT, m_pixelSize, useFP16() ? LINEAR_IMAGE_DESCRIPTION : m_imageDescription);
 
     return m_resources;
+}
+
+void CMonitor::resetResources() {
+    m_resources.reset();
 }

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -92,6 +92,7 @@ class CMonitorState {
     bool commit();
     bool test();
     bool updateSwapchain();
+    bool clearSwapchain();
 
   private:
     void      ensureBufferPresent();
@@ -395,6 +396,7 @@ class CMonitor {
     bool                           needsUnmodifiedCopy();
     bool                           useFP16();
     WP<Monitor::CMonitorResources> resources();
+    void                           resetResources();
 
   private:
     void                    updateMatrix();

--- a/src/render/GLRenderer.cpp
+++ b/src/render/GLRenderer.cpp
@@ -79,6 +79,9 @@ bool CHyprGLRenderer::beginFullFakeRenderInternal(PHLMONITOR pMonitor, CRegion& 
 }
 
 bool CHyprGLRenderer::beginRenderInternal(PHLMONITOR pMonitor, CRegion& damage, bool simple) {
+    if UNLIKELY (rendererLost())
+        return false;
+
     m_currentRenderbuffer->bind();
     if (simple)
         g_pHyprOpenGL->beginSimple(pMonitor, damage, m_currentRenderbuffer);
@@ -91,6 +94,11 @@ bool CHyprGLRenderer::beginRenderInternal(PHLMONITOR pMonitor, CRegion& damage, 
 void CHyprGLRenderer::endRender(const std::function<void()>& renderingDoneCallback) {
     const auto  PMONITOR           = g_pHyprRenderer->m_renderData.pMonitor;
     static auto PNVIDIAANTIFLICKER = CConfigValue<Hyprlang::INT>("opengl:nvidia_anti_flicker");
+
+    if UNLIKELY (rendererLost()) {
+        g_pCompositor->queueRendererReset();
+        return;
+    }
 
     g_pHyprRenderer->m_renderData.damage = m_renderPass.render(g_pHyprRenderer->m_renderData.damage);
 

--- a/src/render/GLRenderer.cpp
+++ b/src/render/GLRenderer.cpp
@@ -47,6 +47,10 @@ void CHyprGLRenderer::initRender() {
     g_pHyprRenderer->m_renderData.pMonitor = renderData().pMonitor;
 }
 
+bool CHyprGLRenderer::rendererLost() {
+    return g_pHyprOpenGL->gpuResetDetected();
+}
+
 bool CHyprGLRenderer::initRenderBuffer(SP<Aquamarine::IBuffer> buffer, uint32_t fmt) {
     try {
         m_currentRenderbuffer = getOrCreateRenderbuffer(m_currentBuffer, fmt);
@@ -61,17 +65,20 @@ bool CHyprGLRenderer::initRenderBuffer(SP<Aquamarine::IBuffer> buffer, uint32_t 
 bool CHyprGLRenderer::beginFullFakeRenderInternal(PHLMONITOR pMonitor, CRegion& damage, SP<IFramebuffer> fb, bool simple) {
     initRender();
 
+    if UNLIKELY (rendererLost())
+        return false;
+
     RASSERT(fb, "Cannot render FULL_FAKE without a provided fb!");
     bindFB(fb);
     if (simple)
         g_pHyprOpenGL->beginSimple(pMonitor, damage, nullptr, fb);
     else
         g_pHyprOpenGL->begin(pMonitor, damage, fb);
+
     return true;
 }
 
 bool CHyprGLRenderer::beginRenderInternal(PHLMONITOR pMonitor, CRegion& damage, bool simple) {
-
     m_currentRenderbuffer->bind();
     if (simple)
         g_pHyprOpenGL->beginSimple(pMonitor, damage, m_currentRenderbuffer);

--- a/src/render/GLRenderer.cpp
+++ b/src/render/GLRenderer.cpp
@@ -97,7 +97,7 @@ void CHyprGLRenderer::endRender(const std::function<void()>& renderingDoneCallba
     static auto PNVIDIAANTIFLICKER = CConfigValue<Hyprlang::INT>("opengl:nvidia_anti_flicker");
 
     if UNLIKELY (rendererLost()) {
-        g_pCompositor->queueRendererReset();
+        //g_pCompositor->queueRendererReset();
         return;
     }
 

--- a/src/render/GLRenderer.cpp
+++ b/src/render/GLRenderer.cpp
@@ -1,4 +1,5 @@
 #include "GLRenderer.hpp"
+#include "Compositor.hpp"
 #include "decorations/CHyprInnerGlowDecoration.hpp"
 #include <aquamarine/output/Output.hpp>
 #include "../config/ConfigValue.hpp"

--- a/src/render/GLRenderer.hpp
+++ b/src/render/GLRenderer.hpp
@@ -29,7 +29,7 @@ namespace Render::GL {
         SP<ITexture>            blurFramebuffer(SP<IFramebuffer> source, float a, CRegion* originalDamage) override;
         void                    setViewport(int x, int y, int width, int height) override;
         bool                    reloadShaders(const std::string& path = "") override;
-
+        bool                    rendererLost() override;
         void                    unsetEGL();
         WP<IElementRenderer>    elementRenderer() override;
 

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -6,6 +6,7 @@
 #include <hyprutils/string/String.hpp>
 #include <hyprutils/path/Path.hpp>
 #include <numbers>
+#include <optional>
 #include <random>
 #include <pango/pangocairo.h>
 #include "OpenGL.hpp"
@@ -105,6 +106,21 @@ static const char* eglErrorToString(EGLint error) {
 
 static void eglLog(EGLenum error, const char* command, EGLint type, EGLLabelKHR thread, EGLLabelKHR obj, const char* msg) {
     Log::logger->log(eglLogToLevel(type), "[EGL] Command {} errored out with {} (0x{}): {}", command, eglErrorToString(error), error, msg);
+}
+
+static std::optional<std::string> glGPUResetDetected() {
+    const GLenum RESETSTATUS = glGetGraphicsResetStatus();
+    if UNLIKELY (RESETSTATUS != GL_NO_ERROR) {
+        std::string errStr = "";
+        switch (RESETSTATUS) {
+            case GL_GUILTY_CONTEXT_RESET: errStr = "GL_GUILTY_CONTEXT_RESET"; break;
+            case GL_INNOCENT_CONTEXT_RESET: errStr = "GL_INNOCENT_CONTEXT_RESET"; break;
+            case GL_UNKNOWN_CONTEXT_RESET: errStr = "GL_UNKNOWN_CONTEXT_RESET"; break;
+            default: errStr = "UNKNOWN??"; break;
+        }
+        return {errStr};
+    }
+    return std::nullopt;
 }
 
 static int openRenderNode(int drmFd) {
@@ -460,6 +476,10 @@ CHyprOpenGLImpl::~CHyprOpenGLImpl() {
         gbm_device_destroy(m_gbmDevice);
 }
 
+bool CHyprOpenGLImpl::gpuResetDetected() const {
+    return m_gpuReset;
+}
+
 std::optional<std::vector<uint64_t>> CHyprOpenGLImpl::getModsForFormat(EGLint format) {
     // TODO: return std::expected when clang supports it
 
@@ -666,19 +686,6 @@ EGLImageKHR CHyprOpenGLImpl::createEGLImage(const Aquamarine::SDMABUFAttrs& attr
 void CHyprOpenGLImpl::beginSimple(PHLMONITOR pMonitor, const CRegion& damage, SP<IRenderbuffer> rb, SP<IFramebuffer> fb) {
     g_pHyprRenderer->m_renderData.pMonitor = pMonitor;
 
-    const GLenum RESETSTATUS = glGetGraphicsResetStatus();
-    if (RESETSTATUS != GL_NO_ERROR) {
-        std::string errStr = "";
-        switch (RESETSTATUS) {
-            case GL_GUILTY_CONTEXT_RESET: errStr = "GL_GUILTY_CONTEXT_RESET"; break;
-            case GL_INNOCENT_CONTEXT_RESET: errStr = "GL_INNOCENT_CONTEXT_RESET"; break;
-            case GL_UNKNOWN_CONTEXT_RESET: errStr = "GL_UNKNOWN_CONTEXT_RESET"; break;
-            default: errStr = "UNKNOWN??"; break;
-        }
-        RASSERT(false, "Aborting, glGetGraphicsResetStatus returned {}. Cannot continue until proper GPU reset handling is implemented.", errStr);
-        return;
-    }
-
     TRACY_GPU_ZONE("RenderBeginSimple");
 
     const auto FBO = rb ? rb->getFB() : fb;
@@ -709,23 +716,16 @@ void CHyprOpenGLImpl::makeEGLCurrent() {
 
     if (eglGetCurrentContext() != g_pHyprOpenGL->m_eglContext)
         eglMakeCurrent(g_pHyprOpenGL->m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, g_pHyprOpenGL->m_eglContext);
+
+    if UNLIKELY (const auto gpuResetErr = glGPUResetDetected(); gpuResetErr.has_value()) {
+        m_gpuReset = true;
+        Log::logger->log(Log::CRIT, "GPU Reset Detected! glGetGraphicsResetStatus returned {}! Attempting to recover...", gpuResetErr.value());
+        return;
+    }
 }
 
 void CHyprOpenGLImpl::begin(PHLMONITOR pMonitor, const CRegion& damage_, SP<IFramebuffer> fb, std::optional<CRegion> finalDamage) {
     g_pHyprRenderer->m_renderData.pMonitor = pMonitor;
-
-    const GLenum RESETSTATUS = glGetGraphicsResetStatus();
-    if (RESETSTATUS != GL_NO_ERROR) {
-        std::string errStr = "";
-        switch (RESETSTATUS) {
-            case GL_GUILTY_CONTEXT_RESET: errStr = "GL_GUILTY_CONTEXT_RESET"; break;
-            case GL_INNOCENT_CONTEXT_RESET: errStr = "GL_INNOCENT_CONTEXT_RESET"; break;
-            case GL_UNKNOWN_CONTEXT_RESET: errStr = "GL_UNKNOWN_CONTEXT_RESET"; break;
-            default: errStr = "UNKNOWN??"; break;
-        }
-        RASSERT(false, "Aborting, glGetGraphicsResetStatus returned {}. Cannot continue until proper GPU reset handling is implemented.", errStr);
-        return;
-    }
 
     TRACY_GPU_ZONE("RenderBegin");
 

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -718,6 +718,7 @@ void CHyprOpenGLImpl::makeEGLCurrent() {
         eglMakeCurrent(g_pHyprOpenGL->m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, g_pHyprOpenGL->m_eglContext);
 
     if UNLIKELY (const auto gpuResetErr = glGPUResetDetected(); gpuResetErr.has_value()) {
+        g_pCompositor->queueRendererReset();
         m_gpuReset = true;
         Log::logger->log(Log::CRIT, "GPU Reset Detected! glGetGraphicsResetStatus returned {}! Attempting to recover...", gpuResetErr.value());
         return;

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -199,6 +199,8 @@ namespace Render::GL {
         void                           beginSimple(PHLMONITOR, const CRegion& damage, SP<IRenderbuffer> rb = nullptr, SP<IFramebuffer> fb = nullptr);
         void                           end();
 
+        bool                           gpuResetDetected() const;
+
         void                           renderRect(const CBox&, const CHyprColor&, SRectRenderData data);
         void                           renderTexture(SP<ITexture>, const CBox&, STextureRenderData data);
         void                           renderRoundedShadow(const CBox&, int round, float roundingPower, int range, const CHyprColor& color, float a = 1.0);
@@ -314,6 +316,8 @@ namespace Render::GL {
         bool                             m_blend                = false;
         bool                             m_offloadedFramebuffer = false;
         bool                             m_cmSupported          = true;
+
+        bool                             m_gpuReset = false;
 
         SP<CShader>                      m_finalScreenShader;
         GLuint                           m_currentProgram;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1643,6 +1643,9 @@ bool IHyprRenderer::beginRender(PHLMONITOR pMonitor, CRegion& damage, eRenderMod
 
     initRender();
 
+    if (rendererLost())
+        return false;
+
     if (!initRenderBuffer(m_currentBuffer, pMonitor->m_output->state->state().drmFormat)) {
         Log::logger->log(Log::ERR, "failed to start a render pass for output {}, no RBO could be obtained", pMonitor->m_name);
         return false;
@@ -1803,8 +1806,8 @@ SCMSettings IHyprRenderer::getCMSettings(const NColorManagement::PImageDescripti
     const bool  needsSDRmod     = modifySDR && isSDR2HDR(imageDescription->value(), targetImageDescription->value());
     const bool  needsHDRmod     = !needsSDRmod && isHDR2SDR(imageDescription->value(), targetImageDescription->value());
     const float maxLuminance    = needsHDRmod ?
-        imageDescription->value().getTFMaxLuminance(-1) :
-        (imageDescription->value().luminances.max > 0 ? imageDescription->value().luminances.max : imageDescription->value().luminances.reference);
+           imageDescription->value().getTFMaxLuminance(-1) :
+           (imageDescription->value().luminances.max > 0 ? imageDescription->value().luminances.max : imageDescription->value().luminances.reference);
     const auto  dstMaxLuminance = targetImageDescription->value().luminances.max > 0 ? targetImageDescription->value().luminances.max : 10000;
 
     auto        matrix = imageDescription->getPrimaries()->convertMatrix(targetImageDescription->getPrimaries());
@@ -1884,6 +1887,9 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     static int                                            damageBlinkCleanup = 0; // because double-buffered
 
     const float                                           ZOOMFACTOR = pMonitor->m_cursorZoom->value();
+
+    if (rendererLost())
+        return;
 
     if (pMonitor->m_pixelSize.x < 1 || pMonitor->m_pixelSize.y < 1) {
         Log::logger->log(Log::ERR, "Refusing to render a monitor because of an invalid pixel size: {}", pMonitor->m_pixelSize);
@@ -1994,6 +2000,11 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     CRegion damage, finalDamage;
     if (!beginRender(pMonitor, damage, RENDER_MODE_NORMAL)) {
         Log::logger->log(Log::ERR, "renderer: couldn't beginRender()!");
+        return;
+    }
+
+    if UNLIKELY (rendererLost()) {
+        g_pCompositor->queueRendererReset();
         return;
     }
 
@@ -2147,30 +2158,30 @@ static hdr_output_metadata       createHDRMetadata(SImageDescription settings, S
 
     auto       colorimetry = settings.getPrimaries();
     auto       luminances  = settings.masteringLuminances.max > 0 ? settings.masteringLuminances :
-                                                                    (settings.luminances != SImageDescription::SPCLuminances{} ?
-                                                                         SImageDescription::SPCMasteringLuminances{.min = settings.luminances.min, .max = settings.luminances.max} :
-                                                                         SImageDescription::SPCMasteringLuminances{.min = monitor->minLuminance(), .max = monitor->maxLuminance(10000)});
+                                                                          (settings.luminances != SImageDescription::SPCLuminances{} ?
+                                                                               SImageDescription::SPCMasteringLuminances{.min = settings.luminances.min, .max = settings.luminances.max} :
+                                                                               SImageDescription::SPCMasteringLuminances{.min = monitor->minLuminance(), .max = monitor->maxLuminance(10000)});
 
     Log::logger->log(Log::TRACE, "ColorManagement primaries {},{} {},{} {},{} {},{}", colorimetry.red.x, colorimetry.red.y, colorimetry.green.x, colorimetry.green.y,
-                     colorimetry.blue.x, colorimetry.blue.y, colorimetry.white.x, colorimetry.white.y);
+                           colorimetry.blue.x, colorimetry.blue.y, colorimetry.white.x, colorimetry.white.y);
     Log::logger->log(Log::TRACE, "ColorManagement min {}, max {}, cll {}, fall {}", luminances.min, luminances.max, settings.maxCLL, settings.maxFALL);
     return hdr_output_metadata{
-        .metadata_type = 0,
-        .hdmi_metadata_type1 =
+              .metadata_type = 0,
+              .hdmi_metadata_type1 =
             hdr_metadata_infoframe{
-                .eotf          = eotf,
-                .metadata_type = 0,
-                .display_primaries =
-                    {
+                      .eotf          = eotf,
+                      .metadata_type = 0,
+                      .display_primaries =
+                          {
                         {.x = to16Bit(colorimetry.red.x), .y = to16Bit(colorimetry.red.y)},
                         {.x = to16Bit(colorimetry.green.x), .y = to16Bit(colorimetry.green.y)},
                         {.x = to16Bit(colorimetry.blue.x), .y = to16Bit(colorimetry.blue.y)},
                     },
-                .white_point                     = {.x = to16Bit(colorimetry.white.x), .y = to16Bit(colorimetry.white.y)},
-                .max_display_mastering_luminance = toNits(luminances.max),
-                .min_display_mastering_luminance = toNits(luminances.min * 10000),
-                .max_cll                         = toNits(settings.maxCLL > 0 ? settings.maxCLL : monitor->maxCLL()),
-                .max_fall                        = toNits(settings.maxFALL > 0 ? settings.maxFALL : monitor->maxFALL()),
+                      .white_point                     = {.x = to16Bit(colorimetry.white.x), .y = to16Bit(colorimetry.white.y)},
+                      .max_display_mastering_luminance = toNits(luminances.max),
+                      .min_display_mastering_luminance = toNits(luminances.min * 10000),
+                      .max_cll                         = toNits(settings.maxCLL > 0 ? settings.maxCLL : monitor->maxCLL()),
+                      .max_fall                        = toNits(settings.maxFALL > 0 ? settings.maxFALL : monitor->maxFALL()),
             },
     };
 }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1643,7 +1643,7 @@ bool IHyprRenderer::beginRender(PHLMONITOR pMonitor, CRegion& damage, eRenderMod
 
     initRender();
 
-    if (rendererLost())
+    if UNLIKELY (rendererLost())
         return false;
 
     if (!initRenderBuffer(m_currentBuffer, pMonitor->m_output->state->state().drmFormat)) {
@@ -1888,7 +1888,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     const float                                           ZOOMFACTOR = pMonitor->m_cursorZoom->value();
 
-    if (rendererLost())
+    if UNLIKELY (rendererLost())
         return;
 
     if (pMonitor->m_pixelSize.x < 1 || pMonitor->m_pixelSize.y < 1) {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2000,13 +2000,15 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     CRegion damage, finalDamage;
     if (!beginRender(pMonitor, damage, RENDER_MODE_NORMAL)) {
         Log::logger->log(Log::ERR, "renderer: couldn't beginRender()!");
+
+        if UNLIKELY (rendererLost())
+            ; //g_pCompositor->queueRendererReset();
+
         return;
     }
 
-    if UNLIKELY (rendererLost()) {
-        g_pCompositor->queueRendererReset();
+    if UNLIKELY (rendererLost())
         return;
-    }
 
     // if we have no tracking or full tracking, invalidate the entire monitor
     if (*PDAMAGETRACKINGMODE == DAMAGE_TRACKING_NONE || *PDAMAGETRACKINGMODE == DAMAGE_TRACKING_MONITOR || pMonitor->m_forceFullFrames > 0 || damageBlinkCleanup > 0)
@@ -2893,6 +2895,10 @@ bool IHyprRenderer::beginRenderToBuffer(PHLMONITOR pMonitor, CRegion& damage, SP
 
 void IHyprRenderer::onRenderbufferDestroy(IRenderbuffer* rb) {
     std::erase_if(m_renderbuffers, [&](const auto& rbo) { return rbo.get() == rb; });
+}
+
+void IHyprRenderer::clearRenderBuffers() {
+    m_renderbuffers.clear();
 }
 
 bool IHyprRenderer::isNvidia() {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1806,8 +1806,8 @@ SCMSettings IHyprRenderer::getCMSettings(const NColorManagement::PImageDescripti
     const bool  needsSDRmod     = modifySDR && isSDR2HDR(imageDescription->value(), targetImageDescription->value());
     const bool  needsHDRmod     = !needsSDRmod && isHDR2SDR(imageDescription->value(), targetImageDescription->value());
     const float maxLuminance    = needsHDRmod ?
-           imageDescription->value().getTFMaxLuminance(-1) :
-           (imageDescription->value().luminances.max > 0 ? imageDescription->value().luminances.max : imageDescription->value().luminances.reference);
+        imageDescription->value().getTFMaxLuminance(-1) :
+        (imageDescription->value().luminances.max > 0 ? imageDescription->value().luminances.max : imageDescription->value().luminances.reference);
     const auto  dstMaxLuminance = targetImageDescription->value().luminances.max > 0 ? targetImageDescription->value().luminances.max : 10000;
 
     auto        matrix = imageDescription->getPrimaries()->convertMatrix(targetImageDescription->getPrimaries());
@@ -2158,30 +2158,30 @@ static hdr_output_metadata       createHDRMetadata(SImageDescription settings, S
 
     auto       colorimetry = settings.getPrimaries();
     auto       luminances  = settings.masteringLuminances.max > 0 ? settings.masteringLuminances :
-                                                                          (settings.luminances != SImageDescription::SPCLuminances{} ?
-                                                                               SImageDescription::SPCMasteringLuminances{.min = settings.luminances.min, .max = settings.luminances.max} :
-                                                                               SImageDescription::SPCMasteringLuminances{.min = monitor->minLuminance(), .max = monitor->maxLuminance(10000)});
+                                                                    (settings.luminances != SImageDescription::SPCLuminances{} ?
+                                                                         SImageDescription::SPCMasteringLuminances{.min = settings.luminances.min, .max = settings.luminances.max} :
+                                                                         SImageDescription::SPCMasteringLuminances{.min = monitor->minLuminance(), .max = monitor->maxLuminance(10000)});
 
     Log::logger->log(Log::TRACE, "ColorManagement primaries {},{} {},{} {},{} {},{}", colorimetry.red.x, colorimetry.red.y, colorimetry.green.x, colorimetry.green.y,
-                           colorimetry.blue.x, colorimetry.blue.y, colorimetry.white.x, colorimetry.white.y);
+                     colorimetry.blue.x, colorimetry.blue.y, colorimetry.white.x, colorimetry.white.y);
     Log::logger->log(Log::TRACE, "ColorManagement min {}, max {}, cll {}, fall {}", luminances.min, luminances.max, settings.maxCLL, settings.maxFALL);
     return hdr_output_metadata{
-              .metadata_type = 0,
-              .hdmi_metadata_type1 =
+        .metadata_type = 0,
+        .hdmi_metadata_type1 =
             hdr_metadata_infoframe{
-                      .eotf          = eotf,
-                      .metadata_type = 0,
-                      .display_primaries =
-                          {
+                .eotf          = eotf,
+                .metadata_type = 0,
+                .display_primaries =
+                    {
                         {.x = to16Bit(colorimetry.red.x), .y = to16Bit(colorimetry.red.y)},
                         {.x = to16Bit(colorimetry.green.x), .y = to16Bit(colorimetry.green.y)},
                         {.x = to16Bit(colorimetry.blue.x), .y = to16Bit(colorimetry.blue.y)},
                     },
-                      .white_point                     = {.x = to16Bit(colorimetry.white.x), .y = to16Bit(colorimetry.white.y)},
-                      .max_display_mastering_luminance = toNits(luminances.max),
-                      .min_display_mastering_luminance = toNits(luminances.min * 10000),
-                      .max_cll                         = toNits(settings.maxCLL > 0 ? settings.maxCLL : monitor->maxCLL()),
-                      .max_fall                        = toNits(settings.maxFALL > 0 ? settings.maxFALL : monitor->maxFALL()),
+                .white_point                     = {.x = to16Bit(colorimetry.white.x), .y = to16Bit(colorimetry.white.y)},
+                .max_display_mastering_luminance = toNits(luminances.max),
+                .min_display_mastering_luminance = toNits(luminances.min * 10000),
+                .max_cll                         = toNits(settings.maxCLL > 0 ? settings.maxCLL : monitor->maxCLL()),
+                .max_fall                        = toNits(settings.maxFALL > 0 ? settings.maxFALL : monitor->maxFALL()),
             },
     };
 }

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -193,6 +193,7 @@ namespace Render {
                                                       SP<CWLSurfaceResource> surface = nullptr, bool modifySDR = false, float sdrMinLuminance = -1.0f, int sdrMaxLuminance = -1);
         void                            clearCMSettingsCache();
         virtual bool                    reloadShaders(const std::string& path = "") = 0;
+        virtual bool                    rendererLost()                              = 0;
 
       protected:
         virtual void              renderOffToMain(SP<IFramebuffer> off)                                         = 0;

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -193,6 +193,7 @@ namespace Render {
                                                       SP<CWLSurfaceResource> surface = nullptr, bool modifySDR = false, float sdrMinLuminance = -1.0f, int sdrMaxLuminance = -1);
         void                            clearCMSettingsCache();
         virtual bool                    reloadShaders(const std::string& path = "") = 0;
+        void                            clearRenderBuffers();
         virtual bool                    rendererLost()                              = 0;
 
       protected:

--- a/src/render/gl/GLRenderbuffer.cpp
+++ b/src/render/gl/GLRenderbuffer.cpp
@@ -20,7 +20,8 @@ CGLRenderbuffer::~CGLRenderbuffer() {
     g_pHyprOpenGL->makeEGLCurrent();
 
     unbind();
-    m_framebuffer->release();
+    if (m_framebuffer)
+        m_framebuffer->release();
 
     if (m_rbo)
         glDeleteRenderbuffers(1, &m_rbo);


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
Attempts to Fix:: #12485 

Right now, this branch should be able to at minimum not crash hyprland. Hyprland will gracefully recover and notify the user of the event. User will be able to continue to use Hyprland as normal, but currently windows will be lost.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
1. So far I have tested in AQ Wayland and DRM backends. I have only tested on an AMD GPU as I can manually invoke the reset by doing `sudo cat /sys/kernel/debug/dri/N/amdgpu_gpu_recover`
2. How do I setup a correct environment to debug the AQ DRM backend? I have been doing some hacky stuff that is not fun. (lots of prints and janky remote gdb)

#### Is it ready for merging, or does it need work?
WIP!
- [ ] Check works for NVIDIA
- [x] Check works for Intel
- [ ] Attempt to save clients?
- [ ] Testing

