### PR TITLE
renderer: undo sdrBrightness in screencopy HDR→SDR path

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1373,12 +1373,20 @@ WP<CShader> CHyprOpenGLImpl::renderToFBInternal(const STextureRenderData& data, 
             if (maxLuminance >= dstMaxLuminance * 1.01)
                 shaderFeatures |= SH_FEAT_TONEMAP;
 
+            const bool monitorHasSDRMod =
+                ((g_pHyprRenderer->m_renderData.pMonitor->m_sdrSaturation > 0 && g_pHyprRenderer->m_renderData.pMonitor->m_sdrSaturation != 1.0f) ||
+                 (g_pHyprRenderer->m_renderData.pMonitor->m_sdrBrightness > 0 && g_pHyprRenderer->m_renderData.pMonitor->m_sdrBrightness != 1.0f));
+
+            // SDR→HDR: apply sdrBrightness boost (existing behavior)
             if (!data.finalMonitorCM &&
                 (SOURCE_IMAGE_DESCRIPTION->value().transferFunction == CM_TRANSFER_FUNCTION_SRGB ||
                  SOURCE_IMAGE_DESCRIPTION->value().transferFunction == CM_TRANSFER_FUNCTION_GAMMA22) &&
                 TARGET_IMAGE_DESCRIPTION->value().transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ &&
-                ((g_pHyprRenderer->m_renderData.pMonitor->m_sdrSaturation > 0 && g_pHyprRenderer->m_renderData.pMonitor->m_sdrSaturation != 1.0f) ||
-                 (g_pHyprRenderer->m_renderData.pMonitor->m_sdrBrightness > 0 && g_pHyprRenderer->m_renderData.pMonitor->m_sdrBrightness != 1.0f)))
+                monitorHasSDRMod)
+                shaderFeatures |= SH_FEAT_SDR_MOD;
+
+            // HDR→SDR (screencopy): undo sdrBrightness boost
+            if (data.cmBackToSRGB && needsHDRmod && monitorHasSDRMod)
                 shaderFeatures |= SH_FEAT_SDR_MOD;
         }
     }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2227,10 +2227,17 @@ SCMSettings IHyprRenderer::getCMSettings(const NColorManagement::PImageDescripti
     auto        matrix = imageDescription->getPrimaries()->convertMatrix(targetImageDescription->getPrimaries());
     auto        toXYZ  = targetImageDescription->getPrimaries()->value().toXYZ();
 
-    const bool needsMod = (imageDescription->value().transferFunction == CM_TRANSFER_FUNCTION_SRGB || imageDescription->value().transferFunction == CM_TRANSFER_FUNCTION_GAMMA22) &&
-        targetImageDescription->value().transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ &&
+    const bool monitorHasSDRMod =
         ((m_renderData.pMonitor->m_sdrSaturation > 0 && m_renderData.pMonitor->m_sdrSaturation != 1.0f) ||
          (m_renderData.pMonitor->m_sdrBrightness > 0 && m_renderData.pMonitor->m_sdrBrightness != 1.0f));
+
+    const bool needsMod = (imageDescription->value().transferFunction == CM_TRANSFER_FUNCTION_SRGB || imageDescription->value().transferFunction == CM_TRANSFER_FUNCTION_GAMMA22) &&
+        targetImageDescription->value().transferFunction == CM_TRANSFER_FUNCTION_ST2084_PQ && monitorHasSDRMod;
+
+    // Also need the multiplier for HDR→SDR (screencopy undo path)
+    const bool needsUndoMod = isHDR2SDR(imageDescription->value(), targetImageDescription->value()) && monitorHasSDRMod;
+
+    const bool anySDRmod = needsSDRmod || needsUndoMod;
 
     return {
         .sourceTF        = srcTF,
@@ -2247,9 +2254,9 @@ SCMSettings IHyprRenderer::getCMSettings(const NColorManagement::PImageDescripti
         .maxLuminance            = maxLuminance * targetImageDescription->value().luminances.reference / imageDescription->value().luminances.reference,
         .dstMaxLuminance         = dstMaxLuminance,
         .dstPrimaries2XYZ        = toXYZ.mat(),
-        .needsSDRmod             = needsMod,
-        .sdrSaturation           = needsSDRmod && m_renderData.pMonitor->m_sdrSaturation > 0 ? m_renderData.pMonitor->m_sdrSaturation : 1.0f,
-        .sdrBrightnessMultiplier = needsSDRmod && m_renderData.pMonitor->m_sdrBrightness > 0 ? m_renderData.pMonitor->m_sdrBrightness : 1.0f,
+        .needsSDRmod             = needsMod || needsUndoMod,
+        .sdrSaturation           = anySDRmod && m_renderData.pMonitor->m_sdrSaturation > 0 ? m_renderData.pMonitor->m_sdrSaturation : 1.0f,
+        .sdrBrightnessMultiplier = anySDRmod && m_renderData.pMonitor->m_sdrBrightness > 0 ? m_renderData.pMonitor->m_sdrBrightness : 1.0f,
     };
 }
 

--- a/src/render/shaders/glsl/cm_helpers.glsl
+++ b/src/render/shaders/glsl/cm_helpers.glsl
@@ -224,6 +224,12 @@ vec4 doColorManagement(vec4 pixColor, int srcTF, int dstTF, mat3 convertMatrix, 
 #endif
 ) {
     pixColor.rgb /= max(pixColor.a, 0.001);
+#if USE_SDR_MOD
+    // When source is HDR (PQ), undo the sdrBrightness boost in PQ space
+    // before decoding. Needed for screencopy HDR→SDR conversion.
+    if (srcTF == CM_TRANSFER_FUNCTION_ST2084_PQ)
+        pixColor.rgb /= sdrBrightnessMultiplier;
+#endif
     pixColor.rgb = toLinearRGB(pixColor.rgb, srcTF);
 #if USE_ICC
     pixColor.rgb = applyIcc3DLut(pixColor.rgb, iccLut3D, iccLutSize);
@@ -237,8 +243,12 @@ vec4 doColorManagement(vec4 pixColor, int srcTF, int dstTF, mat3 convertMatrix, 
 #endif
     pixColor = fromLinearNit(pixColor, dstTF, dstTFRange);
 #if USE_SDR_MOD
-    pixColor = saturate(pixColor, dstxyz, sdrSaturation);
-    pixColor.rgb *= sdrBrightnessMultiplier;
+    // When target is HDR (PQ), apply sdrBrightness/saturation in PQ space
+    // (original SDR→HDR rendering path).
+    if (dstTF == CM_TRANSFER_FUNCTION_ST2084_PQ) {
+        pixColor = saturate(pixColor, dstxyz, sdrSaturation);
+        pixColor.rgb *= sdrBrightnessMultiplier;
+    }
 #endif
 #endif
 


### PR DESCRIPTION
## Summary

When converting the monitor's HDR output back to SDR for non-CM-aware screencopy clients (e.g. `grim`/`grimblast`), the `sdrBrightness` multiplier applied in PQ space during normal rendering is not undone. This causes screenshots to appear overly bright when `sdrbrightness != 1.0`.

The blur preparation shader already handles this correctly by dividing by `sdrBrightnessMultiplier` before PQ decoding (`blurprepare.glsl:22`). This PR applies the same logic to the general CM conversion path used by screencopy.

## Changes

- **`cm_helpers.glsl`**: Make `SDR_MOD` direction-aware. When source is PQ (HDR→SDR screencopy), divide by `sdrBrightnessMultiplier` before decoding. When target is PQ (SDR→HDR normal rendering), apply the multiply after encoding — unchanged existing behavior.
- **`OpenGL.cpp`**: Enable `SH_FEAT_SDR_MOD` for the `cmBackToSRGB` + HDR→SDR case so the shader has the brightness uniform available.
- **`Renderer.cpp`**: Set `sdrBrightnessMultiplier` in `getCMSettings()` for HDR→SDR conversions (not just SDR→HDR), so the uniform value is correct for the undo path.

## How to reproduce

1. Set `sdrbrightness = 1.5` (or any value != 1.0) in `monitorv2` config with `cm = hdr`
2. Take a screenshot with `grimblast` (or any non-CM-aware screencopy client)
3. **Before fix**: screenshot is visibly brighter than the actual display content
4. **After fix**: screenshot matches the intended SDR appearance

## Related

- #11284 — CM causes screenshots to be washed out (original `cmBackToSRGB` addition)
- #13148 — Fix screen export shader variant selection (partial fix for bright captures)
- Discussion #11824 — HDR screenshare brightness/saturation issues