### PR TITLE
Fix isOutputBeingSSd

### DIFF
--- a/src/managers/screenshare/ScreenshareManager.cpp
+++ b/src/managers/screenshare/ScreenshareManager.cpp
@@ -156,7 +156,7 @@ bool CScreenshareManager::isOutputBeingSSd(PHLMONITOR monitor) {
     return std::ranges::any_of(m_sessions, [monitor](const auto& s) {
         if (!s)
             return false;
-        return (s->m_type == SHARE_MONITOR || s->m_type == SHARE_REGION) && s->m_monitor == monitor;
+        return s->isActive() && (s->m_type == SHARE_MONITOR || s->m_type == SHARE_REGION) && s->m_monitor == monitor;
     });
 }
 

--- a/src/managers/screenshare/ScreenshareManager.hpp
+++ b/src/managers/screenshare/ScreenshareManager.hpp
@@ -45,6 +45,7 @@ namespace Screenshare {
 
         UP<CScreenshareFrame> nextFrame(bool overlayCursor);
         void                  stop();
+        bool                  isActive();
 
         // constraints
         const std::vector<DRMFormat>& allowedFormats() const;

--- a/src/managers/screenshare/ScreenshareSession.cpp
+++ b/src/managers/screenshare/ScreenshareSession.cpp
@@ -61,6 +61,10 @@ void CScreenshareSession::stop() {
     screenshareEvents(false);
 }
 
+bool CScreenshareSession::isActive() {
+    return !m_stopped && m_sharing;
+}
+
 void CScreenshareSession::init() {
     uintptr_t ptr = m_type == SHARE_WINDOW && !m_window.expired() ? (uintptr_t)m_window.get() : (m_monitor.expired() ? (uintptr_t)nullptr : (uintptr_t)m_monitor.get());
     LOGM(Log::TRACE, "Created screenshare session for ({}): {}, {:x}", m_type, m_name, ptr);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Screen record sessions through pipewire aren't removed when the actual client stops recording or exits. Additional session state check is added to handle this case.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
Ready
