### PR TITLE
fix: check if resource is good before accessing it in DnD functions

### DIFF
--- a/src/protocols/core/DataDevice.cpp
+++ b/src/protocols/core/DataDevice.cpp
@@ -167,6 +167,8 @@ bool CWLDataSourceResource::good() {
 }
 
 void CWLDataSourceResource::accepted(const std::string& mime) {
+    if (!good())
+        return;
     if (mime.empty()) {
         m_resource->sendTarget(nullptr);
         return;
@@ -185,6 +187,8 @@ std::vector<std::string> CWLDataSourceResource::mimes() {
 }
 
 void CWLDataSourceResource::send(const std::string& mime, CFileDescriptor fd) {
+    if (!good())
+        return;
     if (std::ranges::find(m_mimeTypes, mime) == m_mimeTypes.end()) {
         LOGM(Log::ERR, "Compositor/App bug: CWLDataSourceResource::sendAskSend with non-existent mime");
         return;
@@ -194,6 +198,8 @@ void CWLDataSourceResource::send(const std::string& mime, CFileDescriptor fd) {
 }
 
 void CWLDataSourceResource::cancelled() {
+    if (!good())
+        return;
     m_resource->sendCancelled();
 }
 
@@ -206,24 +212,26 @@ bool CWLDataSourceResource::dndDone() {
 }
 
 void CWLDataSourceResource::error(uint32_t code, const std::string& msg) {
+    if (!good())
+        return;
     m_resource->error(code, msg);
 }
 
 void CWLDataSourceResource::sendDndDropPerformed() {
-    if (m_resource->version() < 3)
+    if (!good() || m_resource->version() < 3)
         return;
     m_resource->sendDndDropPerformed();
     m_dropped = true;
 }
 
 void CWLDataSourceResource::sendDndFinished() {
-    if (m_resource->version() < 3)
+    if (!good() || m_resource->version() < 3)
         return;
     m_resource->sendDndFinished();
 }
 
 void CWLDataSourceResource::sendDndAction(wl_data_device_manager_dnd_action a) {
-    if (m_resource->version() < 3)
+    if (!good() || m_resource->version() < 3)
         return;
     m_resource->sendAction(a);
 }


### PR DESCRIPTION
Prevent use-after-free crash when accessing wayland resources that may have been destroyed. Add good() checks to all `CWLDataSourceResource `methods that access m_resource directly.

Fixes crash in `sendDndFinished()` when called from `forceCleanupDnd()` during xwayland dnd cleanup.

<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->

#### Describe your PR, what does it fix/add?
 this pr fixes a crash in dnd code. The crash happens when im dragging a file from GNOME file manager (nautilus) to vscode and it brings me to the safe mode.  

I add `good()` checks to all `CWLDataSourceResource` methods. These checks make sure the resource is valid before anyone could use it.

  the crash was in `sendDndFinished()` when called from `forceCleanupDnd()` during xwayland dnd cleanup.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
  The crash happens sometimes when stopping DnD operations with XWayland apps. The backtrace shows:
  wl_resource_get_version()
  CWLDataSourceResource::sendDndFinished()
  CX11DataDevice::forceCleanupDnd()
  CWLDataDeviceProtocol::abortDrag() 

It's not replicatable stably on my environment, so im having trouble doing a further test over it.

#### Is it ready for merging, or does it need work?
I want someone with same problem to have a test for me, if my work isnt pure garbage(

*sorry for bad English :(*