### PR TITLE
protocols: allow xdg-foreign to be used by sandboxed apps

### DIFF
--- a/src/managers/ProtocolManager.cpp
+++ b/src/managers/ProtocolManager.cpp
@@ -364,6 +364,7 @@ bool CProtocolManager::isGlobalPrivileged(const wl_global* global) {
         PROTO::fifo->getGlobal(),
         PROTO::commitTiming->getGlobal(),
         PROTO::xdgForeignExporter->getGlobal(),
+        PROTO::xdgForeignImporter->getGlobal(),
         PROTO::sync     ? PROTO::sync->getGlobal()      : nullptr,
         PROTO::mesaDRM  ? PROTO::mesaDRM->getGlobal()   : nullptr,
         PROTO::linuxDma ? PROTO::linuxDma->getGlobal()  : nullptr,


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Adds xdgForeignExporter and xdgForeignImporter to the allow list for globals that are exposed to sandboxed apps. Fixes #13846

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

~~I assume we don't want to allow the importer in the sandbox since that would kinda defeat the purpose of the sandbox.~~ 
 
#### Is it ready for merging, or does it need work?

Ready

~~EDIT: Actually, does not fully fix #13846, because GIMP is weird and seems to want to use the importer for its own windows. But see above, it feels wrong to me if we allow the importer in the sandbox, apps inside sandbox should only be able to export their handles to the outside world, not be able to break the sandbox and import outside handles... maybe I'm missing something obvious though.~~
