### PR TITLE
fix(config): crash in safe mode due to null `Config::mgr()`

### DIFF
--- a/src/config/supplementary/jeremy/Jeremy.cpp
+++ b/src/config/supplementary/jeremy/Jeremy.cpp
@@ -1,7 +1,6 @@
 #include "Jeremy.hpp"
 
 #include "../../../Compositor.hpp"
-#include "../../ConfigManager.hpp"
 
 #include <hyprutils/path/Path.hpp>
 #include <filesystem>
@@ -13,13 +12,8 @@ std::expected<std::string, std::string> Config::Supplementary::Jeremy::getMainCo
     static auto getCfgPath   = []() -> std::expected<std::string, std::string> {
         lastSafeMode = g_pCompositor->m_safeMode;
 
-        if (g_pCompositor->m_safeMode) {
-            const std::filesystem::path CONFIGPATH = g_pCompositor->m_instancePath + "/recoverycfg.conf";
-            auto                        v          = Config::mgr()->generateDefaultConfig(CONFIGPATH);
-            if (!v)
-                return std::unexpected("safe mode: failed to generate config");
-            return CONFIGPATH.string();
-        }
+        if (g_pCompositor->m_safeMode)
+            return (std::filesystem::path{g_pCompositor->m_instancePath} / "recoverycfg.conf").string();
 
         if (!g_pCompositor->m_explicitConfigPath.empty())
             return g_pCompositor->m_explicitConfigPath;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

My hyprland randomly crashed. checking the logs, I found a SIGSEGV in `getMainConfigPath` when Hyprland restarts in safe mode. Here, the  safe mode branch dereferences a null `Config::mgr()` (i.e. before constructed by `initConfigManager()`---the underlying `g_mgr` has not been constructed I believe).

See the logs fro yourself here:

```
--------------------------------------------
   Hyprland Crash Report
--------------------------------------------
*thud*

Hyprland received signal 11(SEGV)
Version: eb141a6cd068f1319cb7caa1d3ad40f4957f65b1
Tag: v0.54.0
Date: 2026-03-26
Flags:

System info:
	System name: Linux
	Node name: xps15
	Release: 6.18.19
	Version: #1-NixOS SMP PREEMPT_DYNAMIC Thu Mar 19 15:08:51 UTC 2026

GPU:
	00:02.0 VGA compatible controller [0300]: Intel Corporation CometLake-H GT2 [UHD Graphics] [8086:9bc4] (rev 05) (prog-if 00 [VGA controller])
01:00.0 3D controller [0302]: NVIDIA Corporation TU117M [GeForce GTX 1650 Ti Mobile] [10de:1f95] (rev a1)


os-release:
	ANSI_COLOR="0;38;2;126;186;228"
	BUG_REPORT_URL="https://github.com/NixOS/nixpkgs/issues"
	BUILD_ID="26.05.20260323.fdc7b8f"
	CPE_NAME="cpe:/o:nixos:nixos:26.05"
	DEFAULT_HOSTNAME=nixos
	DOCUMENTATION_URL="https://nixos.org/learn.html"
	HOME_URL="https://nixos.org/"
	ID=nixos
	ID_LIKE=""
	IMAGE_ID=""
	IMAGE_VERSION=""
	LOGO="nix-snowflake"
	NAME=NixOS
	PRETTY_NAME="NixOS 26.05 (Yarara)"
	SUPPORT_URL="https://nixos.org/community.html"
	VARIANT=""
	VARIANT_ID=""
	VENDOR_NAME=NixOS
	VENDOR_URL="https://nixos.org/"
	VERSION="26.05 (Yarara)"
	VERSION_CODENAME=yarara
	VERSION_ID="26.05"

Libraries:
Hyprgraphics: built against 0.5.0, system has unknown
Hyprutils: built against 0.11.1, system has unknown
Hyprcursor: built against 0.1.13, system has unknown
Hyprlang: built against 0.6.8, system has unknown
Aquamarine: built against 0.10.0, system has unknown

Backtrace:
	# | /etc/profiles/per-user/barrett/bin/Hyprland(_Z12getBacktracev+0x5c) [0x561bb46bbdfc]
		getBacktrace()
		??:?
	#1 | /etc/profiles/per-user/barrett/bin/Hyprland(_ZN13CrashReporter18createAndSaveCrashEi+0xb34) [0x561bb45dca24]
		CrashReporter::createAndSaveCrash(int)
		??:?
	#2 | /etc/profiles/per-user/barrett/bin/Hyprland(+0x350685) [0x561bb44cd685]
		handleUnrecoverableSignal(int)
		??:?
	#3 | /nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib/libc.so.6(+0x42790) [0x7f021c842790]
		??
		??:0
	#4 | /etc/profiles/per-user/barrett/bin/Hyprland(+0x40ae66) [0x561bb4587e66]
		Config::Supplementary::Jeremy::getMainConfigPath[abi:cxx11]()::{lambda()#1}::operator()() const [clone .constprop.0]
		??:?
	#5 | /etc/profiles/per-user/barrett/bin/Hyprland(_ZN6Config13Supplementary6Jeremy17getMainConfigPathB5cxx11Ev+0x200) [0x561bb45889a0]
		Config::Supplementary::Jeremy::getMainConfigPath[abi:cxx11]()
		??:?
	#6 | /etc/profiles/per-user/barrett/bin/Hyprland(_ZN6Config17initConfigManagerEv+0x86) [0x561bb450f256]
		Config::initConfigManager()
		??:?
	#7 | /etc/profiles/per-user/barrett/bin/Hyprland(_ZN11CCompositor12initManagersE18eManagersInitStage+0xa3f) [0x561bb44cf70f]
		CCompositor::initManagers(eManagersInitStage)
		??:?
	#8 | /etc/profiles/per-user/barrett/bin/Hyprland(_ZN11CCompositor10initServerENSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEi+0x3cc) [0x561bb44f4b1c]
		CCompositor::initServer(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, int)
		??:?
	#9 | /etc/profiles/per-user/barrett/bin/Hyprland(main+0x1172) [0x561bb44bc882]
		main
		??:?
	#1 | /nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib/libc.so.6(+0x2b285) [0x7f021c82b285]
		??
		??:0
	#11 | /nix/store/jms7zxzm7w1whczwny5m3gkgdjghmi2r-glibc-2.42-51/lib/libc.so.6(__libc_start_main+0x88) [0x7f021c82b338]
		??
		??:0
	#12 | /etc/profiles/per-user/barrett/bin/Hyprland(_start+0x25) [0x561bb44b6365]
		_start
		??:?


Log tail:
DEBUG ]: Instance Signature: eb141a6cd068f1319cb7caa1d3ad40f4957f65b1_1774530393_1548054924
DEBUG ]: Runtime directory: /run/user/1000/hypr/eb141a6cd068f1319cb7caa1d3ad40f4957f65b1_1774530393_1548054924
DEBUG ]: Hyprland PID: 392173
DEBUG ]: ===== SYSTEM INFO: =====
DEBUG ]: System name: Linux
DEBUG ]: Node name: xps15
DEBUG ]: Release: 6.18.19
DEBUG ]: Version: #1-NixOS SMP PREEMPT_DYNAMIC Thu Mar 19 15:08:51 UTC 2026
DEBUG ]: 

DEBUG ]: GPU information:
00:02.0 VGA compatible controller [0300]: Intel Corporation CometLake-H GT2 [UHD Graphics] [8086:9bc4] (rev 05) (prog-if 00 [VGA controller])
01:00.0 3D controller [0302]: NVIDIA Corporation TU117M [GeForce GTX 1650 Ti Mobile] [10de:1f95] (rev a1)


WARN ]: Warning: you're using an NVIDIA GPU. Make sure you follow the instructions on the wiki if anything is amiss.

DEBUG ]: os-release:
DEBUG ]: ANSI_COLOR="0;38;2;126;186;228"
BUG_REPORT_URL="https://github.com/NixOS/nixpkgs/issues"
BUILD_ID="26.05.20260323.fdc7b8f"
CPE_NAME="cpe:/o:nixos:nixos:26.05"
DEFAULT_HOSTNAME=nixos
DOCUMENTATION_URL="https://nixos.org/learn.html"
HOME_URL="https://nixos.org/"
ID=nixos
ID_LIKE=""
IMAGE_ID=""
IMAGE_VERSION=""
LOGO="nix-snowflake"
NAME=NixOS
PRETTY_NAME="NixOS 26.05 (Yarara)"
SUPPORT_URL="https://nixos.org/community.html"
VARIANT=""
VARIANT_ID=""
VENDOR_NAME=NixOS
VENDOR_URL="https://nixos.org/"
VERSION="26.05 (Yarara)"
VERSION_CODENAME=yarara
VERSION_ID="26.05"
DEBUG ]: ========================
DEBUG ]: 


DEBUG ]: If you are crashing, or encounter any bugs, please consult https://wiki.hypr.land/Crashes-and-Bugs/


DEBUG ]: 
Current splash: Read the wiki.


DEBUG ]: Old rlimit: soft -> 1024, hard -> 524288
DEBUG ]: New rlimit: soft -> 524288, hard -> 524288
DEBUG ]: Creating the EventLoopManager!
DEBUG ]: Creating the KeybindManager!
DEBUG ]: Creating the AnimationManager!
DEBUG ]: Creating the DynamicPermissionManager!
DEBUG ]: Creating the ConfigManager!
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


1. _**This is by first contribution to Hyprland**_.
2. Implementation note: the function `initConfigManager()` already generates a default config for missing files after the config is constructed via `mgr()` is constructed,
i figured the `generateDefaultConfig()` call `getMainConfigPath` [here](https://github.com/hyprwm/Hyprland/blob/eb141a6cd068f1319cb7caa1d3ad40f4957f65b1/src/config/supplementary/jeremy/Jeremy.cpp#L18) can simply be removed. this also simplifies a lot of the code path for safe mode
3. I built it and actualy used it in regular & safe mode - worked fine (of
   course, this is not me claiming the fix is correct but that it is just not
   immediately destructive).

#### Is it ready for merging, or does it need work?

ready
