### PR TITLE
fix(layout): guard null workspace in CWindowTarget::updatePos()

### DIFF
--- a/src/layout/target/WindowTarget.cpp
+++ b/src/layout/target/WindowTarget.cpp
@@ -66,6 +66,9 @@ void CWindowTarget::updatePos() {
     if (fullscreenMode() == FSMODE_MAXIMIZED)
         ITarget::setPositionGlobal({.logicalBox = m_space->workArea(floating())});
 
+    if (!m_space->workspace())
+        return;
+
     const auto PMONITOR         = m_space->workspace()->m_monitor;
     const auto PWORKSPACE       = m_space->workspace();
     const auto MONITOR_WORKAREA = m_space->workArea();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

I hit this crash 5 times over the past 3 weeks across v0.54.1, v0.54.2, and nightly, all with the same stack trace, all triggered by `movetoworkspacesilent` keybinds. I _constantly_ spam these in my config so this segfault is low key _really bad_/happens all the time (crash report below).

I found discussion #13583 which reports the same crash and was closed after it seemed to stop reproducing, but it persists on nightly `eb141a6` (and multiple times a day for me).

My best guess of the issue is this:

1. When the moved window holds the last strong ref to its old workspace,
`moveWindowToWorkspaceSafe` destroys the workspace [here](https://github.com/hyprwm/Hyprland/blob/eb141a6cd068f1319cb7caa1d3ad40f4957f65b1/src/Compositor.cpp#L2659).
2. `propertiesChanged` [here](https://github.com/hyprwm/Hyprland/blob/eb141a6cd068f1319cb7caa1d3ad40f4957f65b1/src/Compositor.cpp#L2672) then recalculates decorations against the stale space. The target HAS NOT been reassigned (that happens
[here](https://github.com/hyprwm/Hyprland/blob/eb141a6cd068f1319cb7caa1d3ad40f4957f65b1/src/Compositor.cpp#L2678)).
3. `m_space` is alive (held by the target), but `m_space->workspace()` is null
4. `updatePos()` dereferences it.
5. sigsegv

My solution:

Guard early and skip recalc, which later runs correctly later via `newTarget`, `assignToSpace`, `onUpdateSpace`, `updateWindowDecos`---here target is on the new workspace's space (boom).

**_Crash report_**:

```
Hyprland received signal 11(SEGV)

#4 | Layout::CWindowTarget::updatePos() [clone .cold]
#5 | CDecorationPositioner::onWindowUpdate(...)
#6 | CDecorationPositioner::repositionDeco(...)
#7 | CWindow::updateWindowDecos()
#8 | CWindowRuleApplicator::propertiesChanged(unsigned int)
#9 | CCompositor::moveWindowToWorkspaceSafe(...)
#10 | CKeybindManager::moveActiveToWorkspaceSilent(...)
```

#### Is it ready for merging, or does it need work?

r4r.