### PR TITLE
algo/scrolling: add expel, consume, and consume_or_expel

### DIFF
--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -1390,18 +1390,12 @@ std::expected<void, std::string> CScrollingAlgorithm::layoutMsg(const std::strin
             if (CURRENT_COL->targetDatas.size() < 2)
                 return std::unexpected("column has only one window");
 
-            const auto  lastTarget = CURRENT_COL->targetDatas.back();
-            const auto  currentIdx = m_scrollingData->idx(CURRENT_COL);
-            const auto  NEXT_COL   = m_scrollingData->next(CURRENT_COL);
-            const auto  insertIdx  = NEXT_COL ? std::nullopt : std::optional<int64_t>{currentIdx};
-            const auto& targetCol  = NEXT_COL ? NEXT_COL : nullptr;
+            const auto lastTarget = CURRENT_COL->targetDatas.back();
+            const auto currentIdx = m_scrollingData->idx(CURRENT_COL);
+            const auto NEXT_COL   = m_scrollingData->next(CURRENT_COL);
+            const auto insertIdx  = !NEXT_COL ? std::nullopt : std::optional<int64_t>{currentIdx};
 
-            if (targetCol) {
-                CURRENT_COL->remove(lastTarget->target.lock());
-                targetCol->add(lastTarget);
-                m_scrollingData->centerOrFitCol(CURRENT_COL);
-            } else
-                expelTarget(lastTarget, CURRENT_COL, insertIdx);
+            expelTarget(lastTarget, CURRENT_COL, insertIdx);
         } else if (ARGS[0] == "consume") {
             const auto NEXT_COL = m_scrollingData->next(CURRENT_COL);
             if (!NEXT_COL)

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -1368,8 +1368,8 @@ std::expected<void, std::string> CScrollingAlgorithm::layoutMsg(const std::strin
             return std::unexpected("no current col");
 
         // expel a target from srcCol into its own new column at insertIdx
-        auto expelTarget = [&](SP<SScrollingTargetData> tdata, SP<SColumnData> srcCol, ssize_t insertIdx) {
-            auto col = insertIdx == -1 ? m_scrollingData->add() : m_scrollingData->add(insertIdx);
+        auto expelTarget = [&](SP<SScrollingTargetData> tdata, SP<SColumnData> srcCol, std::optional<int64_t> insertIdx) {
+            auto col = !insertIdx ? m_scrollingData->add() : m_scrollingData->add(*insertIdx);
             srcCol->remove(tdata->target.lock());
             col->add(tdata);
             m_scrollingData->centerOrFitCol(col);
@@ -1385,7 +1385,7 @@ std::expected<void, std::string> CScrollingAlgorithm::layoutMsg(const std::strin
 
         if (ARGS[0] == "promote") {
             auto idx = m_scrollingData->idx(CURRENT_COL);
-            expelTarget(TDATA, CURRENT_COL, idx == -1 ? -1 : idx);
+            expelTarget(TDATA, CURRENT_COL, idx == -1 ? std::nullopt : std::optional<int64_t>{idx});
         } else if (ARGS[0] == "expel") {
             if (CURRENT_COL->targetDatas.size() < 2)
                 return std::unexpected("column has only one window");
@@ -1393,7 +1393,7 @@ std::expected<void, std::string> CScrollingAlgorithm::layoutMsg(const std::strin
             const auto  lastTarget = CURRENT_COL->targetDatas.back();
             const auto  currentIdx = m_scrollingData->idx(CURRENT_COL);
             const auto  NEXT_COL   = m_scrollingData->next(CURRENT_COL);
-            const auto  insertIdx  = NEXT_COL ? -1 : currentIdx; // -1 means append
+            const auto  insertIdx  = NEXT_COL ? std::nullopt : std::optional<int64_t>{currentIdx};
             const auto& targetCol  = NEXT_COL ? NEXT_COL : nullptr;
 
             if (targetCol) {

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -1358,18 +1358,80 @@ std::expected<void, std::string> CScrollingAlgorithm::layoutMsg(const std::strin
                     g_pCompositor->warpCursorTo(pTargetData->target->window()->middle());
             }
         }
-    } else if (ARGS[0] == "promote") {
+    } else if (ARGS[0] == "promote" || ARGS[0] == "consume" || ARGS[0] == "expel" || ARGS[0] == "consume_or_expel") {
         const auto TDATA = dataFor(Desktop::focusState()->window() ? Desktop::focusState()->window()->layoutTarget() : nullptr);
-
         if (!TDATA)
             return std::unexpected("no window focused");
 
-        auto idx = m_scrollingData->idx(TDATA->column.lock());
-        auto col = idx == -1 ? m_scrollingData->add() : m_scrollingData->add(idx);
+        const auto CURRENT_COL = TDATA->column.lock();
+        if (!CURRENT_COL)
+            return std::unexpected("no current col");
 
-        TDATA->column->remove(TDATA->target.lock());
+        // expel a target from srcCol into its own new column at insertIdx
+        auto expelTarget = [&](SP<SScrollingTargetData> tdata, SP<SColumnData> srcCol, ssize_t insertIdx) {
+            auto col = insertIdx == -1 ? m_scrollingData->add() : m_scrollingData->add(insertIdx);
+            srcCol->remove(tdata->target.lock());
+            col->add(tdata);
+            m_scrollingData->centerOrFitCol(col);
+        };
 
-        col->add(TDATA);
+        // consume the first target from adjCol into dstCol
+        auto consumeTarget = [&](SP<SColumnData> dstCol, SP<SColumnData> adjCol) {
+            const auto target = adjCol->targetDatas.front();
+            adjCol->remove(target->target.lock());
+            dstCol->add(target);
+            m_scrollingData->centerOrFitCol(dstCol);
+        };
+
+        if (ARGS[0] == "promote") {
+            auto idx = m_scrollingData->idx(CURRENT_COL);
+            expelTarget(TDATA, CURRENT_COL, idx == -1 ? -1 : idx);
+        } else if (ARGS[0] == "expel") {
+            if (CURRENT_COL->targetDatas.size() < 2)
+                return std::unexpected("column has only one window");
+
+            const auto  lastTarget = CURRENT_COL->targetDatas.back();
+            const auto  currentIdx = m_scrollingData->idx(CURRENT_COL);
+            const auto  NEXT_COL   = m_scrollingData->next(CURRENT_COL);
+            const auto  insertIdx  = NEXT_COL ? -1 : currentIdx; // -1 means append
+            const auto& targetCol  = NEXT_COL ? NEXT_COL : nullptr;
+
+            if (targetCol) {
+                CURRENT_COL->remove(lastTarget->target.lock());
+                targetCol->add(lastTarget);
+                m_scrollingData->centerOrFitCol(CURRENT_COL);
+            } else
+                expelTarget(lastTarget, CURRENT_COL, insertIdx);
+        } else if (ARGS[0] == "consume") {
+            const auto NEXT_COL = m_scrollingData->next(CURRENT_COL);
+            if (!NEXT_COL)
+                return std::unexpected("no next column");
+
+            consumeTarget(CURRENT_COL, NEXT_COL);
+        } else if (ARGS[0] == "consume_or_expel") {
+            if (ARGS.size() < 2)
+                return std::unexpected("not enough args");
+
+            const std::string& direction = ARGS[1];
+            const bool         prev      = direction == "prev";
+            const bool         next      = direction == "next";
+
+            if (!prev && !next)
+                return std::unexpected("invalid direction, expected prev or next");
+
+            if (CURRENT_COL->targetDatas.size() > 1) {
+                const auto currentIdx = m_scrollingData->idx(CURRENT_COL);
+                expelTarget(TDATA, CURRENT_COL, prev ? currentIdx - 1 : currentIdx);
+            } else {
+                const auto ADJ_COL = prev ? m_scrollingData->prev(CURRENT_COL) : m_scrollingData->next(CURRENT_COL);
+                if (!ADJ_COL)
+                    return std::unexpected("no adjacent column");
+
+                CURRENT_COL->remove(TDATA->target.lock());
+                ADJ_COL->add(TDATA);
+                m_scrollingData->centerOrFitCol(ADJ_COL);
+            }
+        }
 
         m_scrollingData->recalculate();
     } else if (ARGS[0] == "swapcol") {


### PR DESCRIPTION
ref https://github.com/hyprwm/Hyprland/discussions/13403\#discussioncomment-15972750

Adds `consume`, `expel`, and `consume_or_expel <next/prev>`

Needs testing from scroll folks to see if it meets their expectations

