### PR TITLE
config/executor: actually execute exec-shutdown

### DIFF
--- a/src/config/supplementary/executor/Executor.cpp
+++ b/src/config/supplementary/executor/Executor.cpp
@@ -51,6 +51,13 @@ CExecutor::CExecutor() {
         // check for user's possible errors with their setup and notify them if needed
         // this is additionally guarded because exiting safe mode will re-run this.
         g_pCompositor->performUserChecks();
+
+        m_listeners.shutdown = Event::bus()->m_events.exit.listen([this] {
+            for (auto const& c : m_execShutdown) {
+                c.withRules ? spawn(c.exec) : spawnRaw(c.exec);
+            }
+            m_execShutdown.clear();
+        });
     });
 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
`exec-shutdown` literally did nothing before lmao

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

tested with below exec-shutdowns

```
exec-shutdown = pkill -9 Discord
exec-shutdown = systemctl stop --user graphical-session.target
exec-shutdown = echo $(date) >> ~/teehee.txt
```

on latest master the file teehee.txt was never created and / or written to. was created and written to as expected with this PR.
other 2 are to stop hyprland from literally coredumping every hypr app + discord (hyprpaper, hyprsunset, xdph all coredump for me when `hyprctl dispatch exit`), this is an issue for another time i guess

hyprsunset still coredumps but others look ok
rip my coredumpctl, logs were like 10gb at some point

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/e51bf9ff-f52a-41ad-bba0-0c57e1c2be6b" />


#### Is it ready for merging, or does it need work?

i think this only works on `hyprctl dispatch exit`, not if triggering a reboot and closing hyprland that way for example. would be nice if it worked in those circumstances OR if i was just able to fix this issue with all my hypr things coredumping
