### PR TITLE
desktop/window: guard null monitor in xwaylandSizeToReal

### DIFF
--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -1364,7 +1364,7 @@ Vector2D CWindow::xwaylandSizeToReal(Vector2D size) {
 
     const auto  PMONITOR = m_monitor.lock();
     const auto  SIZE     = size.clamp(Vector2D{1, 1}, Math::VECTOR2D_MAX);
-    const auto  SCALE    = *PXWLFORCESCALEZERO ? PMONITOR->m_scale : 1.0f;
+    const auto  SCALE    = *PXWLFORCESCALEZERO && PMONITOR ? PMONITOR->m_scale : 1.0f;
 
     return SIZE / SCALE;
 }


### PR DESCRIPTION
  #### Describe your PR, what does it fix/add?

  Guards a null monitor in `CWindow::xwaylandSizeToReal()`.

  With `xwayland:force_zero_scaling` enabled, XWayland clients can still send
  `ConfigureRequest` events while outputs are being removed. In that state
  `m_monitor.lock()` may be null, which caused a crash when dereferencing
  `PMONITOR->m_scale`.

  I reproduced this reliably with WeChat on XWayland by opening it and then
  turning the monitor off.

  #### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

  Minimal fix only. Verified locally against the reported crash path.

  #### Is it ready for merging, or does it need work?

  Ready for review.