### PR TITLE
build: remove commented-out clang-format action from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,11 +52,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # - name: clang-format check
-      #   uses: jidicula/clang-format-action@v4.16.0
-      #   with:
-      #     exclude-regex: ^subprojects$
-
       - name: Install clang-format
         run: |
           pacman --noconfirm --noprogressbar -Syyu


### PR DESCRIPTION
Removes the commented-out jidicula/clang-format-action block from ci.yaml. This was left behind when the clang-format check migrated to the custom clang-format-check.sh script. The standalone clang-format.yml workflow using this action was already removed in #13887.