### PR TITLE
ci: run unit tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,12 @@ jobs:
         run: |
           CFLAGS=-Werror CXXFLAGS=-Werror make nopch
 
+      - name: Build and run unit tests
+        run: |
+          cmake -B ./build -DWITH_TESTS=ON
+          cmake --build ./build --target hyprland_gtests -j`nproc 2>/dev/null || getconf NPROCESSORS_CONF`
+          ./build/hyprland_gtests
+
       - name: Compress and package artifacts
         run: |
           mkdir x86_64-pc-linux-gnu


### PR DESCRIPTION
The GTest unit tests are built in debug mode but never run in CI. This adds a step to the build workflow that builds and runs them after the main build completes.

Uses -DWITH_TESTS=ON to enable tests on top of the existing release build, then builds and runs the hyprland_gtests target. Currently 27 tests across Direction, ByteOperations, CMType, Color, TransferFunction, and ReservedArea.