### PR TITLE
config/scrolling: add `follow_focus = 2` config option, modify behaviour of `= 1` and `= 0`

### DIFF
--- a/hyprtester/test.conf
+++ b/hyprtester/test.conf
@@ -183,7 +183,7 @@ scrolling {
     fullscreen_on_one_column = true
     column_width = 0.5
     focus_fit_method = 1
-    follow_focus = true
+    follow_focus = 2
     follow_min_visible = 1
     explicit_column_widths = 0.25, 0.333, 0.5, 0.667, 0.75, 1.0
     wrap_focus = true

--- a/src/config/legacy/ConfigManager.cpp
+++ b/src/config/legacy/ConfigManager.cpp
@@ -673,7 +673,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("scrolling:fullscreen_on_one_column", Hyprlang::INT{1});
     registerConfigVar("scrolling:column_width", Hyprlang::FLOAT{0.5F});
     registerConfigVar("scrolling:focus_fit_method", Hyprlang::INT{1});
-    registerConfigVar("scrolling:follow_focus", Hyprlang::INT{1});
+    registerConfigVar("scrolling:follow_focus", Hyprlang::INT{2});
     registerConfigVar("scrolling:follow_min_visible", Hyprlang::FLOAT{0.4});
     registerConfigVar("scrolling:explicit_column_widths", Hyprlang::STRING{"0.333, 0.5, 0.667, 1.0"});
     registerConfigVar("scrolling:direction", Hyprlang::STRING{"right"});

--- a/src/config/supplementary/ConfigDescriptions.hpp
+++ b/src/config/supplementary/ConfigDescriptions.hpp
@@ -2216,8 +2216,8 @@ namespace Config::Supplementary {
         SConfigOptionDescription{
             .value       = "scrolling:follow_focus",
             .description = "when a window is focused, should the layout move to bring it into view automatically",
-            .type        = CONFIG_OPTION_BOOL,
-            .data        = SConfigOptionDescription::SBoolData{.value = true},
+            .type        = CONFIG_OPTION_INT,
+            .data        = SConfigOptionDescription::SRangeData{.value = 2, .min = 0, .max = 2},
         },
         SConfigOptionDescription{
             .value       = "scrolling:follow_min_visible",

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -515,7 +515,7 @@ CScrollingAlgorithm::CScrollingAlgorithm() {
     m_mouseButtonCallback = Event::bus()->m_events.input.mouse.button.listen([this](IPointer::SButtonEvent e, Event::SCallbackInfo&) {
         static const auto PFOLLOW_FOCUS = CConfigValue<Hyprlang::INT>("scrolling:follow_focus");
 
-        if (*PFOLLOW_FOCUS && e.state == WL_POINTER_BUTTON_STATE_RELEASED && Desktop::focusState()->window())
+        if (*PFOLLOW_FOCUS == 2 && e.state == WL_POINTER_BUTTON_STATE_RELEASED && Desktop::focusState()->window())
             focusOnInput(Desktop::focusState()->window()->layoutTarget(), INPUT_MODE_CLICK);
     });
 
@@ -525,7 +525,7 @@ CScrollingAlgorithm::CScrollingAlgorithm() {
 
         static const auto PFOLLOW_FOCUS = CConfigValue<Hyprlang::INT>("scrolling:follow_focus");
 
-        if (!*PFOLLOW_FOCUS && !Desktop::isHardInputFocusReason(reason))
+        if (*PFOLLOW_FOCUS != 2 && !Desktop::isHardInputFocusReason(reason))
             return;
 
         if (pWindow->m_workspace != m_parent->space()->workspace())

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -35,6 +35,7 @@
 #include "../layout/algorithm/tiled/monocle/MonocleAlgorithm.hpp"
 #include "../event/EventBus.hpp"
 #include "../config/supplementary/executor/Executor.hpp"
+#include "../layout/supplementary/WorkspaceAlgoMatcher.hpp"
 
 #include <optional>
 #include <iterator>
@@ -369,10 +370,14 @@ bool CKeybindManager::tryMoveFocusToMonitor(PHLMONITOR monitor) {
 }
 
 void CKeybindManager::switchToWindow(PHLWINDOW PWINDOWTOCHANGETO, bool forceFSCycle) {
-    static auto PFOLLOWMOUSE = CConfigValue<Hyprlang::INT>("input:follow_mouse");
-    static auto PNOWARPS     = CConfigValue<Hyprlang::INT>("cursor:no_warps");
+    static auto       PFOLLOWMOUSE = CConfigValue<Hyprlang::INT>("input:follow_mouse");
+    static auto       PNOWARPS     = CConfigValue<Hyprlang::INT>("cursor:no_warps");
+    static auto       PFOLLOWFOCUS = CConfigValue<Hyprlang::INT>("scrolling:follow_focus");
 
-    const auto  PLASTWINDOW = Desktop::focusState()->window();
+    std::string const PLAYOUTOFWINDOWTOSWITCHTO =
+        Layout::Supplementary::algoMatcher()->getNameForTiledAlgo(&typeid(*PWINDOWTOCHANGETO->m_workspace->m_space->algorithm()->tiledAlgo()));
+
+    const auto PLASTWINDOW = Desktop::focusState()->window();
 
     if (PWINDOWTOCHANGETO == PLASTWINDOW || !PWINDOWTOCHANGETO)
         return;
@@ -384,7 +389,13 @@ void CKeybindManager::switchToWindow(PHLWINDOW PWINDOWTOCHANGETO, bool forceFSCy
         Desktop::focusState()->fullWindowFocus(PWINDOWTOCHANGETO, Desktop::FOCUS_REASON_KEYBIND, nullptr, forceFSCycle);
     else {
         updateRelativeCursorCoords();
-        Desktop::focusState()->fullWindowFocus(PWINDOWTOCHANGETO, Desktop::FOCUS_REASON_KEYBIND, nullptr, forceFSCycle);
+
+        // follow_focus = 0 on scrolling layout disallows the use of movefocus dispatch to move scrolling view, therefore a FOCUS_REASON that resolves to 'Soft' focus reason is desired
+        if (PLAYOUTOFWINDOWTOSWITCHTO == "scrolling" && *PFOLLOWFOCUS == 0)
+            Desktop::focusState()->fullWindowFocus(PWINDOWTOCHANGETO, Desktop::FOCUS_REASON_OTHER, nullptr, forceFSCycle);
+        else
+            Desktop::focusState()->fullWindowFocus(PWINDOWTOCHANGETO, Desktop::FOCUS_REASON_KEYBIND, nullptr, forceFSCycle);
+
         PWINDOWTOCHANGETO->warpCursor();
 
         // Move mouse focus to the new window if required by current follow_mouse and warp modes


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Adds a new value to `follow_focus` config option in scrolling layout.

`follow_focus = 2`: both mouse and `movefocus` dispatches (hyprctl or keyboard) move the view in addition to `layoutmsg` dispatches that scroll has, which may always move the view. This new option mirrors the `= 1` of the previous behaviour.

`follow_focus = 1`:  Compared to `follow_focus = 2`, Mouse movements cannot move the view. This mirrors the '= 0` of the previous behaviour.

`follow_focus = 0`: Matches the behaviour of the plugin; only scrolling's `layoutmsg` dispatches are allowed to move the view compared to `follow_focus = 2`

This addresses '1-' in https://github.com/hyprwm/Hyprland/discussions/13562#discussion-9572471 


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Nothing for this PR.

#### Is it ready for merging, or does it need work?

Adressed in https://github.com/hyprwm/Hyprland/pull/13974