### PR TITLE
add autoConsume bind

### DIFF
--- a/meta/hl.meta.lua
+++ b/meta/hl.meta.lua
@@ -570,6 +570,7 @@ local __HL_EventSubscription = {}
 ---@field set_enabled fun(self: HL.Keybind, ...): any
 ---@field unbind fun(self: HL.Keybind, ...): any
 ---@field arg string
+---@field auto_consuming boolean
 ---@field catchall boolean
 ---@field click boolean
 ---@field description any

--- a/src/config/legacy/ConfigManager.cpp
+++ b/src/config/legacy/ConfigManager.cpp
@@ -1472,6 +1472,7 @@ std::optional<std::string> CConfigManager::handleBind(const std::string& command
     bool       repeat          = false;
     bool       mouse           = false;
     bool       nonConsuming    = false;
+    bool       autoConsuming   = false;
     bool       transparent     = false;
     bool       ignoreMods      = false;
     bool       multiKey        = false;
@@ -1491,6 +1492,7 @@ std::optional<std::string> CConfigManager::handleBind(const std::string& command
             case 'e': repeat = true; break;
             case 'm': mouse = true; break;
             case 'n': nonConsuming = true; break;
+            case 'a': autoConsuming = true; break;
             case 't': transparent = true; break;
             case 'i': ignoreMods = true; break;
             case 's': multiKey = true; break;
@@ -1590,10 +1592,33 @@ std::optional<std::string> CConfigManager::handleBind(const std::string& command
             return "Invalid catchall, catchall keybinds are only allowed in submaps.";
         }
 
-        g_pKeybindManager->addKeybind(SKeybind{parsedKey.key, KEYSYMS,      parsedKey.keycode, parsedKey.catchAll, MOD,      MODS,           HANDLER,
-                                               COMMAND,       locked,       m_currentSubmap,   DESCRIPTION,        release,  repeat,         longPress,
-                                               mouse,         nonConsuming, transparent,       ignoreMods,         multiKey, hasDescription, dontInhibit,
-                                               click,         drag,         submapUniversal,   deviceInclusive,    devices});
+        g_pKeybindManager->addKeybind(SKeybind{parsedKey.key,
+                                               KEYSYMS,
+                                               parsedKey.keycode,
+                                               parsedKey.catchAll,
+                                               MOD,
+                                               MODS,
+                                               HANDLER,
+                                               COMMAND,
+                                               locked,
+                                               m_currentSubmap,
+                                               DESCRIPTION,
+                                               release,
+                                               repeat,
+                                               longPress,
+                                               mouse,
+                                               nonConsuming,
+                                               autoConsuming,
+                                               transparent,
+                                               ignoreMods,
+                                               multiKey,
+                                               hasDescription,
+                                               dontInhibit,
+                                               click,
+                                               drag,
+                                               submapUniversal,
+                                               deviceInclusive,
+                                               devices});
     }
 
     return {};

--- a/src/config/lua/bindings/LuaBindingsToplevel.cpp
+++ b/src/config/lua/bindings/LuaBindingsToplevel.cpp
@@ -166,6 +166,7 @@ static int hlBind(lua_State* L) {
         kb.locked          = getBool("locked");
         kb.release         = getBool("release");
         kb.nonConsuming    = getBool("non_consuming");
+        kb.autoConsuming   = getBool("auto_consuming");
         kb.transparent     = getBool("transparent");
         kb.ignoreMods      = getBool("ignore_mods");
         kb.dontInhibit     = getBool("dont_inhibit");

--- a/src/config/lua/objects/LuaKeybind.cpp
+++ b/src/config/lua/objects/LuaKeybind.cpp
@@ -143,6 +143,8 @@ static int keybindIndex(lua_State* L) {
         lua_pushboolean(L, (*keybind)->release);
     else if (key == "non_consuming")
         lua_pushboolean(L, (*keybind)->nonConsuming);
+    else if (key == "auto_consuming")
+        lua_pushboolean(L, (*keybind)->autoConsuming);
     else if (key == "transparent")
         lua_pushboolean(L, (*keybind)->transparent);
     else if (key == "ignore_mods")

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1010,6 +1010,8 @@ static std::string bindsRequest(eHyprCtlOutputFormat format, std::string request
                 ret += "e";
             if (kb->nonConsuming)
                 ret += "n";
+            if (kb->autoConsuming)
+                ret += "a";
             if (kb->hasDescription)
                 ret += "d";
 
@@ -1029,6 +1031,7 @@ static std::string bindsRequest(eHyprCtlOutputFormat format, std::string request
     "repeat": {},
     "longPress": {},
     "non_consuming": {},
+    "auto_consuming": {},
     "has_description": {},
     "modmask": {},
     "submap": "{}",
@@ -1041,8 +1044,8 @@ static std::string bindsRequest(eHyprCtlOutputFormat format, std::string request
     "arg": "{}"
 }},)#",
                 kb->locked ? "true" : "false", kb->mouse ? "true" : "false", kb->release ? "true" : "false", kb->repeat ? "true" : "false", kb->longPress ? "true" : "false",
-                kb->nonConsuming ? "true" : "false", kb->hasDescription ? "true" : "false", kb->modmask, escapeJSONStrings(kb->submap.name), kb->submapUniversal,
-                escapeJSONStrings(kb->key), kb->keycode, kb->catchAll ? "true" : "false", escapeJSONStrings(kb->description), escapeJSONStrings(kb->handler),
+                kb->nonConsuming ? "true" : "false", kb->autoConsuming ? "true" : "false", kb->hasDescription ? "true" : "false", kb->modmask, escapeJSONStrings(kb->submap.name),
+                kb->submapUniversal, escapeJSONStrings(kb->key), kb->keycode, kb->catchAll ? "true" : "false", escapeJSONStrings(kb->description), escapeJSONStrings(kb->handler),
                 escapeJSONStrings(kb->arg));
         }
         trimTrailingComma(ret);

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -636,7 +636,7 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
         }
 
         if (pressed && k->release && !SPECIALDISPATCHER) {
-            if (k->nonConsuming)
+            if (k->nonConsuming || k->autoConsuming)
                 continue;
 
             found = true; // suppress the event
@@ -655,7 +655,7 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
                     continue;
 
             } else if (!k->release && !SPECIALDISPATCHER) {
-                if (k->nonConsuming)
+                if (k->nonConsuming || k->autoConsuming)
                     continue;
 
                 found = true; // suppress the event
@@ -720,7 +720,7 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
             m_repeatKeyTimer->updateTimeout(std::chrono::milliseconds(KEEB->m_repeatDelay));
         }
 
-        if (!k->nonConsuming)
+        if (!k->nonConsuming && !(k->autoConsuming && !res.success))
             found = true;
     }
 

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -42,6 +42,7 @@ struct SKeybind {
     bool                            longPress       = false;
     bool                            mouse           = false;
     bool                            nonConsuming    = false;
+    bool                            autoConsuming   = false;
     bool                            transparent     = false;
     bool                            ignoreMods      = false;
     bool                            multiKey        = false;


### PR DESCRIPTION
Adds `binda`
`a | auto-consuming | Key/mouse events will be passed to the active window if the dispatcher doesn't succeed.`
Usecase: If a group window is active and `binda = ALT, tab, movegroupwindow` then consume it, but if not pass it to a VM, for example.