### PR TITLE
fix compiler warnings

### DIFF
--- a/src/xwayland/XSurface.hpp
+++ b/src/xwayland/XSurface.hpp
@@ -9,10 +9,10 @@ class CWLSurfaceResource;
 class CXWaylandSurfaceResource;
 
 #ifdef NO_XWAYLAND
-using xcb_pixmap_t         = uint32_t;
-using xcb_window_t         = uint32_t;
-using xcb_atom_t           = uint32_t;
-using xcb_icccm_wm_hints_t = struct {
+using xcb_pixmap_t = uint32_t;
+using xcb_window_t = uint32_t;
+using xcb_atom_t   = uint32_t;
+struct xcb_icccm_wm_hints_t {
     int32_t      flags;
     uint32_t     input;
     int32_t      initial_state;
@@ -22,7 +22,7 @@ using xcb_icccm_wm_hints_t = struct {
     xcb_pixmap_t icon_mask;
     xcb_window_t window_group;
 };
-using xcb_size_hints_t = struct {
+struct xcb_size_hints_t {
     uint32_t flags;
     int32_t  x, y;
     int32_t  width, height;


### PR DESCRIPTION
fixes warnings when compiling with `NO_XWAYLAND`
```
Hyprland/src/config/legacy/../../xwayland/XSurface.hpp:41:7: warning: ‘CXWaylandSurface’ has a field ‘UP<<unnamed struct> > CXWaylandSurface::m_hints’ whose type has internal linkage [-Wsubobject-linkage]
   41 | class CXWaylandSurface {
      |       ^~~~~~~~~~~~~~~~
Hyprland/src/config/legacy/../../xwayland/XSurface.hpp:41:7: warning: ‘CXWaylandSurface’ has a field ‘UP<<unnamed struct> > CXWaylandSurface::m_sizeHints’ whose type has internal linkage [-Wsubobject-linkage]
```
