### PR TITLE
build: add format-check and format-fix Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,13 +96,13 @@ asan:
 
 format-check:
 	@find src hyprctl hyprpm start tests -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.h" \) \
-		! -path "src/render/shaders/Shaders.hpp" ! -path "src/render/shaders/*.inc" \
+		! -path "src/render/shaders/Shaders.hpp" \
 		! -path "hyprctl/hw-protocols/*" | \
 		xargs clang-format --dry-run --Werror
 
 format-fix:
 	@find src hyprctl hyprpm start tests -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.h" \) \
-		! -path "src/render/shaders/Shaders.hpp" ! -path "src/render/shaders/*.inc" \
+		! -path "src/render/shaders/Shaders.hpp" \
 		! -path "hyprctl/hw-protocols/*" | \
 		xargs clang-format -i
 


### PR DESCRIPTION
Adds two convenience Makefile targets for local development:

  - `make format-check` — runs clang-format in dry-run mode on all source files, exits with error if any formatting issues are found. Lets developers replicate the CI style check locally before pushing.
  - `make format-fix` — runs clang-format in-place on all source files to auto-fix formatting.

Both targets skip generated files (Shaders.hpp, shader .inc files, hw-protocols) that are not tracked in git.