### PR TITLE
New per-device bind syntax

### DIFF
--- a/hyprtester/src/tests/main/keybinds.cpp
+++ b/hyprtester/src/tests/main/keybinds.cpp
@@ -551,14 +551,6 @@ static void testPerDeviceKeybind() {
     EXPECT(attemptCheckFlag(20, 50), true);
     OK(getFromSocket("/dispatch plugin:test:keybind 0,0,29"));
     EXPECT(getFromSocket("/keyword unbind SUPER,Y"), "ok");
-
-    // Tags
-    EXPECT(checkFlag(), false);
-    EXPECT(getFromSocket("/keyword bindk{test-tag} SUPER,Y,exec,touch " + flagFile), "ok");
-    OK(getFromSocket("/dispatch plugin:test:keybind 1,7,29"));
-    EXPECT(attemptCheckFlag(20, 50), true);
-    OK(getFromSocket("/dispatch plugin:test:keybind 0,0,29"));
-    EXPECT(getFromSocket("/keyword unbind SUPER,Y"), "ok");
 }
 
 static bool test() {

--- a/hyprtester/test.conf
+++ b/hyprtester/test.conf
@@ -230,11 +230,6 @@ device {
     sensitivity = -0.5
 }
 
-device {
-    name = test-keyboard-1
-    tags = test-tag
-}
-
 debug {
     disable_logs = false
 }

--- a/src/config/legacy/ConfigManager.cpp
+++ b/src/config/legacy/ConfigManager.cpp
@@ -891,7 +891,6 @@ CConfigManager::CConfigManager() {
     m_config->addSpecialConfigValue("device", "keybinds", Hyprlang::INT{1});                 // enable/disable keybinds
     m_config->addSpecialConfigValue("device", "share_states", Hyprlang::INT{0});             // only for virtualkeyboards
     m_config->addSpecialConfigValue("device", "release_pressed_on_close", Hyprlang::INT{0}); // only for virtualkeyboards
-    m_config->addSpecialConfigValue("device", "tags", STRVAL_EMPTY);                         // only for keyboards and mice
 
     m_config->addSpecialCategory("monitorv2", {.key = "output"});
     m_config->addSpecialConfigValue("monitorv2", "disabled", Hyprlang::INT{0});

--- a/src/devices/IHID.hpp
+++ b/src/devices/IHID.hpp
@@ -2,7 +2,6 @@
 
 #include <cstdint>
 #include <string>
-#include <set>
 #include "../helpers/signal/Signal.hpp"
 
 enum eHIDCapabilityType : uint8_t {
@@ -37,7 +36,6 @@ class IHID {
         CSignalT<> destroy;
     } m_events;
 
-    std::string           m_deviceName;
-    std::string           m_hlName;
-    std::set<std::string> m_deviceTags;
+    std::string m_deviceName;
+    std::string m_hlName;
 };

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -664,14 +664,8 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
             continue;
 
         if (device) {
-            bool istagValid = false;
-            for (const auto& tag : device->m_deviceTags) {
-                if (k->devices.contains(tag))
-                    istagValid = true;
-            }
-            if (k->deviceInclusive ^ (k->devices.contains(device->m_hlName) || istagValid))
+            if (k->devicemap.inclusive ^ k->devicemap.devices.contains(device->m_hlName))
                 continue;
-            }
         }
 
         if (k->multiKey) {

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1120,11 +1120,6 @@ void CInputManager::applyConfigToKeyboard(SP<IKeyboard> pKeyboard) {
 
     const auto ENABLED    = HASCONFIG ? Config::mgr()->getDeviceInt(devname, "enabled") : true;
     const auto ALLOWBINDS = HASCONFIG ? Config::mgr()->getDeviceInt(devname, "keybinds") : true;
-    const auto DEVICETAGS = HASCONFIG ? Config::mgr()->getDeviceString(devname, "tags") : "";
-
-    for (const auto tagString : std::ranges::views::split(DEVICETAGS, ',')) {
-        pKeyboard->m_deviceTags.emplace(std::string_view(tagString));
-    }
 
     pKeyboard->m_enabled           = ENABLED;
     pKeyboard->m_resolveBindsBySym = RESOLVEBINDSBYSYM;
@@ -1251,11 +1246,6 @@ void CInputManager::setPointerConfigs() {
             } else if (!ENABLED && m->m_connected) {
                 g_pPointerManager->detachPointer(m);
                 m->m_connected = false;
-            }
-
-            const auto DEVICETAGS = Config::mgr()->getDeviceString(devname, "tags");
-            for (const auto tagString : std::ranges::views::split(DEVICETAGS, ',')) {
-                m->m_deviceTags.emplace(std::string_view(tagString));
             }
         }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Replaces per-device syntax with two new syntaxes based on ideas in #13728

1. Devicemap syntax
This is similar in style to submaps
Devices are specified in a comma separated list
'reset' is used to reset the devicemap and make binds available to all devices
```
devicemap = test-keyboard-1
bind = SUPER, Q, exec, kitty     // Only works for test-keyboard-1
bind = SUPER, T, togglefloating  // Only works for test-keyboard-1

devicemap = reset
bind = SUPER, J, exec kitty      // Works for all devices
```
2.  Inline syntax
The direct replacement for current syntax
Devices are specified in a comma separated list
```
bindk{test-keyboard-1} = SUPER, Q, exec, kitty       // Only works for test-keyboard-1
bindrk{test-keyboard-1}u = SUPER, T, togglefloating  // Other flags can be placed before and after the 'k' flag
```

`!` can be used at the front of the list for either to make it exclusive selection (Anything except what is in the list).

wiki mr: hyprwm/hyprland-wiki#1422

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I know that lua config is being worked on right now, but I would prefer this to be merged to make the legacy version of this complete, especially if there will be a release before lua config is finished.

#### Is it ready for merging, or does it need work?
Yes


