### PR TITLE
Fix windowsOut animation not triggering when fadeOut is disabled

### DIFF
--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -1648,17 +1648,6 @@ std::optional<Vector2D> CWindow::calculateExpression(const std::string& s) {
     return Vector2D{*LHS, *RHS};
 }
 
-static void setVector2DAnimToMove(WP<CBaseAnimatedVariable> pav) {
-    if (!pav)
-        return;
-
-    CAnimatedVariable<Vector2D>* animvar = dc<CAnimatedVariable<Vector2D>*>(pav.get());
-    animvar->setConfig(Config::animationTree()->getAnimationPropertyConfig("windowsMove"));
-
-    if (animvar->m_Context.pWindow)
-        animvar->m_Context.pWindow->m_animatingIn = false;
-}
-
 void CWindow::mapWindow() {
     static auto PINACTIVEALPHA     = CConfigValue<Hyprlang::FLOAT>("decoration:inactive_opacity");
     static auto PACTIVEALPHA       = CConfigValue<Hyprlang::FLOAT>("decoration:active_opacity");
@@ -2116,9 +2105,6 @@ void CWindow::mapWindow() {
 
     // do animations
     g_pDesktopAnimationManager->startAnimation(m_self.lock(), CDesktopAnimationManager::ANIMATION_TYPE_IN);
-
-    m_realPosition->setCallbackOnEnd(setVector2DAnimToMove);
-    m_realSize->setCallbackOnEnd(setVector2DAnimToMove);
 
     // recalc the values for this window
     updateDecorationValues();

--- a/src/managers/animation/DesktopAnimationManager.cpp
+++ b/src/managers/animation/DesktopAnimationManager.cpp
@@ -19,24 +19,38 @@
 
 using namespace Hyprutils::String;
 
+static void setVector2DAnimToMove(WP<Hyprutils::Animation::CBaseAnimatedVariable> pav) {
+    if (!pav)
+        return;
+
+    CAnimatedVariable<Vector2D>* animvar = dc<CAnimatedVariable<Vector2D>*>(pav.get());
+    animvar->setConfig(Config::animationTree()->getAnimationPropertyConfig("windowsMove"));
+
+    if (animvar->m_Context.pWindow)
+        animvar->m_Context.pWindow->m_animatingIn = false;
+}
+
+static void warpCloseAlphaToZero(PHLWINDOW pWindow) {
+    *pWindow->m_alpha = 0.F;
+    pWindow->m_alpha->warp(true, false);
+}
+
 void CDesktopAnimationManager::startAnimation(PHLWINDOW pWindow, eAnimationType type, bool force) {
     const bool CLOSE = type == ANIMATION_TYPE_OUT;
 
-    if (CLOSE)
-        *pWindow->m_alpha = 0.F;
-    else {
-        pWindow->m_alpha->setValueAndWarp(0.F);
-        *pWindow->m_alpha = 1.F;
-    }
-
-    if (!CLOSE) {
-        pWindow->m_realPosition->setConfig(Config::animationTree()->getAnimationPropertyConfig("windowsIn"));
-        pWindow->m_realSize->setConfig(Config::animationTree()->getAnimationPropertyConfig("windowsIn"));
-        pWindow->m_alpha->setConfig(Config::animationTree()->getAnimationPropertyConfig("fadeIn"));
-    } else {
+    if (CLOSE) {
         pWindow->m_realPosition->setConfig(Config::animationTree()->getAnimationPropertyConfig("windowsOut"));
         pWindow->m_realSize->setConfig(Config::animationTree()->getAnimationPropertyConfig("windowsOut"));
         pWindow->m_alpha->setConfig(Config::animationTree()->getAnimationPropertyConfig("fadeOut"));
+
+        if (pWindow->m_alpha->enabled())
+            *pWindow->m_alpha = 0.F;
+    } else {
+        pWindow->m_alpha->setValueAndWarp(0.F);
+        *pWindow->m_alpha = 1.F;
+        pWindow->m_realPosition->setConfig(Config::animationTree()->getAnimationPropertyConfig("windowsIn"));
+        pWindow->m_realSize->setConfig(Config::animationTree()->getAnimationPropertyConfig("windowsIn"));
+        pWindow->m_alpha->setConfig(Config::animationTree()->getAnimationPropertyConfig("fadeIn"));
     }
 
     std::string ANIMSTYLE = pWindow->m_realPosition->getStyle();
@@ -45,12 +59,18 @@ void CDesktopAnimationManager::startAnimation(PHLWINDOW pWindow, eAnimationType 
     CVarList animList(ANIMSTYLE, 0, 's');
 
     // if the window is not being animated, that means the layout set a fixed size for it, don't animate.
-    if (!pWindow->m_realPosition->isBeingAnimated() && !pWindow->m_realSize->isBeingAnimated() && !force)
+    if (!pWindow->m_realPosition->isBeingAnimated() && !pWindow->m_realSize->isBeingAnimated() && !force) {
+        if (CLOSE && !pWindow->m_alpha->enabled())
+            warpCloseAlphaToZero(pWindow);
         return;
+    }
 
     // if the animation is disabled and we are leaving, ignore the anim to prevent the snapshot being fucked
-    if (!pWindow->m_realPosition->enabled() && !force)
+    if (!pWindow->m_realPosition->enabled() && !force) {
+        if (CLOSE && !pWindow->m_alpha->enabled())
+            warpCloseAlphaToZero(pWindow);
         return;
+    }
 
     if (pWindow->m_ruleApplicator->animationStyle().hasValue()) {
         const auto STYLE = pWindow->m_ruleApplicator->animationStyle().value();
@@ -94,6 +114,34 @@ void CDesktopAnimationManager::startAnimation(PHLWINDOW pWindow, eAnimationType 
             }
 
             animationPopin(pWindow, CLOSE, minPerc / 100.f);
+        }
+    }
+
+    // set the default on end callbacks
+    pWindow->m_realPosition->setCallbackOnEnd(setVector2DAnimToMove);
+    pWindow->m_realSize->setCallbackOnEnd(setVector2DAnimToMove);
+
+    // set the opacity to 0 when the windowOut animation is finished, and fadeOut is disabled
+    if (CLOSE && !pWindow->m_alpha->enabled()) {
+        // if the window is not being animated, set the opacity to 0
+        if (!pWindow->m_realPosition->isBeingAnimated() && !pWindow->m_realSize->isBeingAnimated())
+            warpCloseAlphaToZero(pWindow);
+        // if the window is being animated, set the opacity to 0 when the animation is finished
+        else {
+            const auto onVector2DAnimEnd = [weak = PHLWINDOWREF{pWindow}](WP<Hyprutils::Animation::CBaseAnimatedVariable> pav) {
+                const auto PW = weak.lock();
+                if (!PW)
+                    return;
+
+                if (PW->m_fadingOut && !PW->m_realPosition->isBeingAnimated() && !PW->m_realSize->isBeingAnimated()) {
+                    warpCloseAlphaToZero(PW);
+                }
+
+                setVector2DAnimToMove(pav);
+            };
+
+            pWindow->m_realPosition->setCallbackOnEnd(onVector2DAnimEnd, false);
+            pWindow->m_realSize->setCallbackOnEnd(onVector2DAnimEnd, false);
         }
     }
 }


### PR DESCRIPTION
### ISSUE
When the `fadeOut` animation is disabled, we would immediately set the opacity of the window to 0 rather than running the fade animation. However, this caused the `windowsOut` animation to visually not function since the opacity was already 0 before it started.

https://github.com/hyprwm/Hyprland/issues/10352

### FIX
This moves the the animations onEnd callback out of `Window`, and into the `DesktopAnimationManager`.
This allows the animation manager to move the setting of the opacity to the onEnd rather than immediate.

### NOTES
Conceptually this issue exists in the other `windowsOut` style animations such as `layerOut`, but I don't have a good way to validate it. However similar code paths exist in `startAnimation` for the layers. (We immediately set opacity to 0)

### TESTS
All GA Tests passed
7 Failures on hyprtests, but there are 7 errors on main. (no net new)
