### PR TITLE
render: fix layer blur_popups ignoring ignore_alpha when blur is off

### DIFF
--- a/src/desktop/view/Popup.cpp
+++ b/src/desktop/view/Popup.cpp
@@ -352,6 +352,10 @@ SP<Desktop::View::CWLSurface> CPopup::getT1Owner() const {
         return m_layerOwner->wlSurface();
 }
 
+PHLLS CPopup::layerOwner() const {
+    return m_layerOwner.lock();
+}
+
 Vector2D CPopup::coordsRelativeToParent() const {
     Vector2D offset;
 

--- a/src/desktop/view/Popup.hpp
+++ b/src/desktop/view/Popup.hpp
@@ -32,6 +32,7 @@ namespace Desktop::View {
         virtual std::optional<CBox>   surfaceLogicalBox() const;
 
         SP<Desktop::View::CWLSurface> getT1Owner() const;
+        PHLLS                         layerOwner() const;
         Vector2D                      coordsRelativeToParent() const;
         Vector2D                      coordsGlobal() const;
         PHLMONITOR                    getMonitor() const;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -916,7 +916,6 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
     renderdata.blockBlurOptimization            = pLayer->m_layer == ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM || pLayer->m_layer == ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND;
 
     renderdata.clipBox = CBox{0, 0, pMonitor->m_size.x, pMonitor->m_size.y}.scale(pMonitor->m_scale);
-
     if (renderdata.blur && pLayer->m_ruleApplicator->ignoreAlpha().hasValue()) {
         renderdata.discardMode |= DISCARD_ALPHA;
         renderdata.discardOpacity = pLayer->m_ruleApplicator->ignoreAlpha().valueOrDefault();
@@ -944,7 +943,13 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
     renderdata.dontRound       = true;
     renderdata.popup           = true;
     renderdata.blur            = pLayer->m_ruleApplicator->blurPopups().valueOrDefault();
-    renderdata.surfaceCounter  = 0;
+    renderdata.discardMode &= ~DISCARD_ALPHA;
+    renderdata.discardOpacity = 0.F;
+    if (renderdata.blur && pLayer->m_ruleApplicator->ignoreAlpha().hasValue()) {
+        renderdata.discardMode |= DISCARD_ALPHA;
+        renderdata.discardOpacity = pLayer->m_ruleApplicator->ignoreAlpha().valueOrDefault();
+    }
+    renderdata.surfaceCounter = 0;
     if (popups) {
         pLayer->m_popupHead->breadthfirst(
             [this, &renderdata](WP<Desktop::View::CPopup> popup, void* data) {
@@ -3157,8 +3162,12 @@ void IHyprRenderer::renderSnapshot(WP<Desktop::View::CPopup> popup) {
     data.blur                  = SHOULD_BLUR;
     data.blurA                 = sqrt(popup->m_alpha->value()); // sqrt makes the blur fadeout more realistic.
     data.blockBlurOptimization = SHOULD_BLUR;                   // force no xray on this (popups never have xray)
-    if (SHOULD_BLUR)
-        data.ignoreAlpha = std::max(*PBLURIGNOREA, 0.01F); /* ignore the alpha 0 regions */
+    if (SHOULD_BLUR) {
+        if (const auto PLAYER = popup->layerOwner(); PLAYER && PLAYER->m_ruleApplicator->ignoreAlpha().hasValue())
+            data.ignoreAlpha = std::max(PLAYER->m_ruleApplicator->ignoreAlpha().valueOrDefault(), 0.01F);
+        else
+            data.ignoreAlpha = std::max(*PBLURIGNOREA, 0.01F); /* ignore the alpha 0 regions */
+    }
 
     m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
 }


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

Fixes layer rule `blur_popups` not taking into account `ignore_alpha` when `blur` is off.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

Ready likely.
