### PR TITLE
fix: replace C++23 insert_range with compatible insert for GCC 14

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -702,7 +702,8 @@ bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule, bool force)
         std::ranges::sort(sortedModes, sortFunc);
         if (sortedModes.size() > 3)
             sortedModes.erase(sortedModes.begin() + 3, sortedModes.end());
-        requestedModes.insert_range(requestedModes.end(), sortedModes | std::views::reverse);
+                auto reversed = sortedModes | std::views::reverse;
+        requestedModes.insert(requestedModes.end(), reversed.begin(), reversed.end());
     };
 
     // last fallback is always preferred mode


### PR DESCRIPTION
Hyprland recently moved to C++26 features. This change replaces  with a C++20/23 compatible  call to allow the project to build on systems using GCC 14.2 (like current Void Linux stable) until GCC 15/Clang 22 with full range support is more widely available.