### PR TITLE
algo/scrolling: add `inhibit_scroll` dispatch for scrolling algorithm

### DIFF
--- a/hyprtester/src/tests/main/scroll.cpp
+++ b/hyprtester/src/tests/main/scroll.cpp
@@ -989,22 +989,18 @@ TEST_CASE(testScrollInhibitor) {
     // set current layout to scrolling
     OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling' } })"));
 
-
-
     NLog::log("{}Testing inhibit_scroll", Colors::GREEN);
 
-
     if (!Tests::spawnKitty("a")) {
-    FAIL_TEST("Could not spawn kitty with win class `a`");
-    return;
+        FAIL_TEST("Could not spawn kitty with win class `a`");
+        return;
     }
 
     OK(getFromSocket("/dispatch hl.dsp.layout('colresize 0.8')"));
 
-
     if (!Tests::spawnKitty("b")) {
-    FAIL_TEST("Could not spawn kitty with win class `b`");
-    return;
+        FAIL_TEST("Could not spawn kitty with win class `b`");
+        return;
     }
 
     // Currently, we are focused on window class:b
@@ -1026,7 +1022,6 @@ TEST_CASE(testScrollInhibitor) {
         FAIL_TEST("{}Failed: {}Expected the x coordinate of window of class \"a\" to be < 0, got {}.", Colors::RED, Colors::RESET, posAx);
         return;
     }
-
 
     // clean up
 

--- a/hyprtester/src/tests/main/scroll.cpp
+++ b/hyprtester/src/tests/main/scroll.cpp
@@ -1014,8 +1014,8 @@ TEST_CASE(testScrollInhibitor) {
     // the focus must have moved regardless of the state of the inhibitor (it only prevents the scrolling view from moving). We are now focused on window class:a
 
     // if the view does not move, we expect the x coordinate of the window of class "a" to be negative, as it would be to the left of the viewport
-    const std::string posA  = Tests::getWindowAttribute(getFromSocket("/activewindow"), "at:");
-    const int         posAx = std::stoi(posA.substr(4, posA.find(',') - 4));
+    const std::string posA  = Tests::getAttribute(getFromSocket("/activewindow"), "at");
+    const int         posAx = std::stoi(posA.substr(0, posA.find(',')));
     if (posAx < 0) {
         NLog::log("{}Passed: {}Expected the x coordinate of window of class \"a\" to be < 0, got {}.", Colors::GREEN, Colors::RESET, posAx);
     } else {

--- a/hyprtester/src/tests/main/scroll.cpp
+++ b/hyprtester/src/tests/main/scroll.cpp
@@ -978,3 +978,63 @@ TEST_CASE(testScrollingViewBehaviourMoveFocusInGroupFollowFocusTrue) {
         NLog ::log("{}Passed: {}window of class 'a' has x coordinates >= 0 for its position: {}", Colors ::GREEN, Colors::RESET, currentWindowPosX);
     }
 }
+
+TEST_CASE(testScrollInhibitor) {
+
+    /*
+        scroll inhibitor prevent the scrolling view from moving
+        ---------------------------------------------------------------------------------
+    */
+
+    // set current layout to scrolling
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling' } })"));
+
+
+
+    NLog::log("{}Testing inhibit_scroll", Colors::GREEN);
+
+
+    if (!Tests::spawnKitty("a")) {
+    FAIL_TEST("Could not spawn kitty with win class `a`");
+    return;
+    }
+
+    OK(getFromSocket("/dispatch hl.dsp.layout('colresize 0.8')"));
+
+
+    if (!Tests::spawnKitty("b")) {
+    FAIL_TEST("Could not spawn kitty with win class `b`");
+    return;
+    }
+
+    // Currently, we are focused on window class:b
+
+    // enable scroll inhibitor
+    OK(getFromSocket("/dispatch hl.dsp.layout('inhibit_scroll 1')"));
+
+    // dispatching `layoutmsg focus l` will move scrolling view regardless of follow_focus if inhibitor is not working
+    OK(getFromSocket("/dispatch hl.dsp.layout('focus l')"));
+
+    // the focus must have moved regardless of the state of the inhibitor (it only prevents the scrolling view from moving). We are now focused on window class:a
+
+    // if the view does not move, we expect the x coordinate of the window of class "a" to be negative, as it would be to the left of the viewport
+    const std::string posA  = Tests::getWindowAttribute(getFromSocket("/activewindow"), "at:");
+    const int         posAx = std::stoi(posA.substr(4, posA.find(',') - 4));
+    if (posAx < 0) {
+        NLog::log("{}Passed: {}Expected the x coordinate of window of class \"a\" to be < 0, got {}.", Colors::GREEN, Colors::RESET, posAx);
+    } else {
+        FAIL_TEST("{}Failed: {}Expected the x coordinate of window of class \"a\" to be < 0, got {}.", Colors::RED, Colors::RESET, posAx);
+        return;
+    }
+
+
+    // clean up
+
+    // disable scroll inhibitor
+    OK(getFromSocket("/dispatch hl.dsp.layout('inhibit_scroll 0')"));
+
+    // kill all windows
+    NLog::log("{}Killing all windows", Colors::YELLOW);
+    Tests::killAllWindows();
+    ASSERT(Tests::windowCount(), 0);
+}

--- a/hyprtester/src/tests/main/scroll.cpp
+++ b/hyprtester/src/tests/main/scroll.cpp
@@ -1022,14 +1022,4 @@ TEST_CASE(testScrollInhibitor) {
         FAIL_TEST("{}Failed: {}Expected the x coordinate of window of class \"a\" to be < 0, got {}.", Colors::RED, Colors::RESET, posAx);
         return;
     }
-
-    // clean up
-
-    // disable scroll inhibitor
-    OK(getFromSocket("/dispatch hl.dsp.layout('inhibit_scroll 0')"));
-
-    // kill all windows
-    NLog::log("{}Killing all windows", Colors::YELLOW);
-    Tests::killAllWindows();
-    ASSERT(Tests::windowCount(), 0);
 }

--- a/src/layout/algorithm/tiled/scrolling/ScrollTapeController.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollTapeController.cpp
@@ -54,7 +54,7 @@ void CScrollTapeController::adjustOffset(double delta) {
     m_offset += delta;
 }
 
-struct SScrollingInhibitor& CScrollTapeController::getScrollInhibitor() {
+struct SScrollInhibitor& CScrollTapeController::getScrollInhibitor() {
     return m_scrollInhibitor;
 }
 

--- a/src/layout/algorithm/tiled/scrolling/ScrollTapeController.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollTapeController.cpp
@@ -39,7 +39,11 @@ const SStripData& CScrollTapeController::getStrip(size_t index) const {
 }
 
 void CScrollTapeController::setOffset(double offset) {
-    m_offset = offset;
+    if (getScrollInhibitor().isInhibited) {
+        m_offset = getScrollInhibitor().offsetWhenInhibited;
+        Log::logger->log(Log::DEBUG, "m_offset not set - scrolling inhibited");
+    } else
+        m_offset = offset;
 }
 
 double CScrollTapeController::getOffset() const {
@@ -48,6 +52,10 @@ double CScrollTapeController::getOffset() const {
 
 void CScrollTapeController::adjustOffset(double delta) {
     m_offset += delta;
+}
+
+struct SScrollingInhibitor& CScrollTapeController::getScrollInhibitor() {
+    return m_scrollInhibitor;
 }
 
 size_t CScrollTapeController::addStrip(float size) {
@@ -222,12 +230,12 @@ double CScrollTapeController::calculateCameraOffset(const CBox& usableArea, bool
 
     // if the content fits in viewport, center it
     if (maxExtent < usablePrimary)
-        m_offset = std::round((maxExtent - usablePrimary) / 2.0);
+        setOffset(std::round((maxExtent - usablePrimary) / 2.0));
 
     // if the offset is negative but we already extended and fit method is not center, reset offset to 0
     static const auto PFITMETHOD = CConfigValue<Hyprlang::INT>("scrolling:focus_fit_method");
     if (maxExtent > usablePrimary && m_offset < 0.0 && *PFITMETHOD != 0)
-        m_offset = 0.0;
+        setOffset(0.0);
 
     return m_offset;
 }
@@ -249,7 +257,7 @@ void CScrollTapeController::centerStrip(size_t stripIndex, const CBox& usableAre
     const double stripStart    = calculateStripStart(stripIndex, usableArea, fullscreenOnOne);
     const double stripSize     = calculateStripSize(stripIndex, usableArea, fullscreenOnOne);
 
-    m_offset = stripStart - (usablePrimary - stripSize) / 2.0;
+    setOffset(stripStart - (usablePrimary - stripSize) / 2.0);
 }
 
 void CScrollTapeController::fitStrip(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne) {
@@ -266,11 +274,11 @@ void CScrollTapeController::fitStrip(size_t stripIndex, const CBox& usableArea, 
     if (lo > hi) {
         // strip is wider than viewport (e.g. during monitor reconnection after suspend),
         // center the strip instead of hitting the std::clamp assertion
-        m_offset = stripStart - (usablePrimary - stripSize) / 2.0;
+        setOffset(stripStart - (usablePrimary - stripSize) / 2.0);
         return;
     }
 
-    m_offset = std::clamp(m_offset, lo, hi);
+    setOffset(std::clamp(m_offset, lo, hi));
 }
 
 bool CScrollTapeController::isStripVisible(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne, bool full) const {

--- a/src/layout/algorithm/tiled/scrolling/ScrollTapeController.hpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollTapeController.hpp
@@ -29,56 +29,63 @@ namespace Layout::Tiled {
         size_t targetIndex = 0;
     };
 
+    struct SScrollingInhibitor {
+        bool   isInhibited         = false;
+        double offsetWhenInhibited = 0; // The position of the m_offset when inhibited is necessary to keep the viewport static
+    };
+
     class CScrollTapeController {
       public:
         CScrollTapeController(eScrollDirection direction = SCROLL_DIR_RIGHT);
         ~CScrollTapeController() = default;
 
-        void              setDirection(eScrollDirection dir);
-        eScrollDirection  getDirection() const;
-        bool              isPrimaryHorizontal() const;
-        bool              isReversed() const;
+        void                        setDirection(eScrollDirection dir);
+        eScrollDirection            getDirection() const;
+        bool                        isPrimaryHorizontal() const;
+        bool                        isReversed() const;
 
-        size_t            addStrip(float size = 1.0F);
-        void              insertStrip(ssize_t afterIndex, float size = 1.0F);
-        void              removeStrip(size_t index);
-        size_t            stripCount() const;
-        SStripData&       getStrip(size_t index);
-        const SStripData& getStrip(size_t index) const;
-        void              swapStrips(size_t a, size_t b);
+        size_t                      addStrip(float size = 1.0F);
+        void                        insertStrip(ssize_t afterIndex, float size = 1.0F);
+        void                        removeStrip(size_t index);
+        size_t                      stripCount() const;
+        SStripData&                 getStrip(size_t index);
+        const SStripData&           getStrip(size_t index) const;
+        void                        swapStrips(size_t a, size_t b);
 
-        void              setOffset(double offset);
-        double            getOffset() const;
-        void              adjustOffset(double delta);
+        void                        setOffset(double offset);
+        double                      getOffset() const;
+        void                        adjustOffset(double delta);
+        struct SScrollingInhibitor& getScrollInhibitor();
 
-        double            calculateMaxExtent(const CBox& usableArea, bool fullscreenOnOne = false) const;
-        double            calculateStripStart(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false) const;
-        double            calculateStripSize(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false) const;
+        double                      calculateMaxExtent(const CBox& usableArea, bool fullscreenOnOne = false) const;
+        double                      calculateStripStart(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false) const;
+        double                      calculateStripSize(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false) const;
 
         CBox              calculateStripBox(size_t stripIndex, const CBox& usableArea, const Vector2D& workspaceOffset, bool fullscreenOnOne = false);
         CBox              calculateTargetBox(size_t stripIndex, size_t targetIndex, const CBox& usableArea, const Vector2D& workspaceOffset, bool fullscreenOnOne = false);
 
-        double            calculateCameraOffset(const CBox& usableArea, bool fullscreenOnOne = false);
-        Vector2D          getCameraTranslation(const CBox& usableArea, bool fullscreenOnOne = false);
+        double   calculateCameraOffset(const CBox& usableArea, bool fullscreenOnOne = false);
+        Vector2D getCameraTranslation(const CBox& usableArea, bool fullscreenOnOne = false);
 
-        void              centerStrip(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false);
-        void              fitStrip(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false);
+        void     centerStrip(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false);
+        void     fitStrip(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false);
 
-        bool              isStripVisible(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false, bool full = false) const;
+        bool     isStripVisible(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false, bool full = false) const;
 
-        size_t            getStripAtCenter(const CBox& usableArea, bool fullscreenOnOne = false) const;
+        size_t   getStripAtCenter(const CBox& usableArea, bool fullscreenOnOne = false) const;
 
       private:
-        eScrollDirection        m_direction = SCROLL_DIR_RIGHT;
-        std::vector<SStripData> m_strips;
-        double                  m_offset = 0.0;
+        eScrollDirection           m_direction = SCROLL_DIR_RIGHT;
+        std::vector<SStripData>    m_strips;
+        double                     m_offset = 0.0;
+        struct SScrollingInhibitor m_scrollInhibitor; // for inhibiting scrolling (prevents the viewport from moving)
 
-        double                  getPrimary(const Vector2D& v) const;
-        double                  getSecondary(const Vector2D& v) const;
-        void                    setPrimary(Vector2D& v, double val) const;
-        void                    setSecondary(Vector2D& v, double val) const;
-        bool                    isBeingDragged() const;
+        double                     getPrimary(const Vector2D& v) const;
+        double                     getSecondary(const Vector2D& v) const;
+        void                       setPrimary(Vector2D& v, double val) const;
+        void                       setSecondary(Vector2D& v, double val) const;
+        bool                       isBeingDragged() const;
 
-        Vector2D                makeVector(double primary, double secondary) const;
+        Vector2D                   makeVector(double primary, double secondary) const;
     };
 };

--- a/src/layout/algorithm/tiled/scrolling/ScrollTapeController.hpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollTapeController.hpp
@@ -29,7 +29,7 @@ namespace Layout::Tiled {
         size_t targetIndex = 0;
     };
 
-    struct SScrollingInhibitor {
+    struct SScrollInhibitor {
         bool   isInhibited         = false;
         double offsetWhenInhibited = 0; // The position of the m_offset when inhibited is necessary to keep the viewport static
     };
@@ -55,7 +55,7 @@ namespace Layout::Tiled {
         void                        setOffset(double offset);
         double                      getOffset() const;
         void                        adjustOffset(double delta);
-        struct SScrollingInhibitor& getScrollInhibitor();
+        struct SScrollInhibitor& getScrollInhibitor();
 
         double                      calculateMaxExtent(const CBox& usableArea, bool fullscreenOnOne = false) const;
         double                      calculateStripStart(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false) const;
@@ -78,7 +78,7 @@ namespace Layout::Tiled {
         eScrollDirection           m_direction = SCROLL_DIR_RIGHT;
         std::vector<SStripData>    m_strips;
         double                     m_offset = 0.0;
-        struct SScrollingInhibitor m_scrollInhibitor; // for inhibiting scrolling (prevents the viewport from moving)
+        struct SScrollInhibitor m_scrollInhibitor; // for inhibiting scrolling (prevents the viewport from moving)
 
         double                     getPrimary(const Vector2D& v) const;
         double                     getSecondary(const Vector2D& v) const;

--- a/src/layout/algorithm/tiled/scrolling/ScrollTapeController.hpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollTapeController.hpp
@@ -39,53 +39,53 @@ namespace Layout::Tiled {
         CScrollTapeController(eScrollDirection direction = SCROLL_DIR_RIGHT);
         ~CScrollTapeController() = default;
 
-        void                        setDirection(eScrollDirection dir);
-        eScrollDirection            getDirection() const;
-        bool                        isPrimaryHorizontal() const;
-        bool                        isReversed() const;
+        void                     setDirection(eScrollDirection dir);
+        eScrollDirection         getDirection() const;
+        bool                     isPrimaryHorizontal() const;
+        bool                     isReversed() const;
 
-        size_t                      addStrip(float size = 1.0F);
-        void                        insertStrip(ssize_t afterIndex, float size = 1.0F);
-        void                        removeStrip(size_t index);
-        size_t                      stripCount() const;
-        SStripData&                 getStrip(size_t index);
-        const SStripData&           getStrip(size_t index) const;
-        void                        swapStrips(size_t a, size_t b);
+        size_t                   addStrip(float size = 1.0F);
+        void                     insertStrip(ssize_t afterIndex, float size = 1.0F);
+        void                     removeStrip(size_t index);
+        size_t                   stripCount() const;
+        SStripData&              getStrip(size_t index);
+        const SStripData&        getStrip(size_t index) const;
+        void                     swapStrips(size_t a, size_t b);
 
-        void                        setOffset(double offset);
-        double                      getOffset() const;
-        void                        adjustOffset(double delta);
+        void                     setOffset(double offset);
+        double                   getOffset() const;
+        void                     adjustOffset(double delta);
         struct SScrollInhibitor& getScrollInhibitor();
 
-        double                      calculateMaxExtent(const CBox& usableArea, bool fullscreenOnOne = false) const;
-        double                      calculateStripStart(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false) const;
-        double                      calculateStripSize(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false) const;
+        double                   calculateMaxExtent(const CBox& usableArea, bool fullscreenOnOne = false) const;
+        double                   calculateStripStart(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false) const;
+        double                   calculateStripSize(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false) const;
 
         CBox              calculateStripBox(size_t stripIndex, const CBox& usableArea, const Vector2D& workspaceOffset, bool fullscreenOnOne = false);
         CBox              calculateTargetBox(size_t stripIndex, size_t targetIndex, const CBox& usableArea, const Vector2D& workspaceOffset, bool fullscreenOnOne = false);
 
-        double   calculateCameraOffset(const CBox& usableArea, bool fullscreenOnOne = false);
-        Vector2D getCameraTranslation(const CBox& usableArea, bool fullscreenOnOne = false);
+        double                   calculateCameraOffset(const CBox& usableArea, bool fullscreenOnOne = false);
+        Vector2D                 getCameraTranslation(const CBox& usableArea, bool fullscreenOnOne = false);
 
-        void     centerStrip(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false);
-        void     fitStrip(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false);
+        void                     centerStrip(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false);
+        void                     fitStrip(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false);
 
-        bool     isStripVisible(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false, bool full = false) const;
+        bool                     isStripVisible(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false, bool full = false) const;
 
-        size_t   getStripAtCenter(const CBox& usableArea, bool fullscreenOnOne = false) const;
+        size_t                   getStripAtCenter(const CBox& usableArea, bool fullscreenOnOne = false) const;
 
       private:
-        eScrollDirection           m_direction = SCROLL_DIR_RIGHT;
-        std::vector<SStripData>    m_strips;
-        double                     m_offset = 0.0;
+        eScrollDirection        m_direction = SCROLL_DIR_RIGHT;
+        std::vector<SStripData> m_strips;
+        double                  m_offset = 0.0;
         struct SScrollInhibitor m_scrollInhibitor; // for inhibiting scrolling (prevents the viewport from moving)
 
-        double                     getPrimary(const Vector2D& v) const;
-        double                     getSecondary(const Vector2D& v) const;
-        void                       setPrimary(Vector2D& v, double val) const;
-        void                       setSecondary(Vector2D& v, double val) const;
-        bool                       isBeingDragged() const;
+        double                  getPrimary(const Vector2D& v) const;
+        double                  getSecondary(const Vector2D& v) const;
+        void                    setPrimary(Vector2D& v, double val) const;
+        void                    setSecondary(Vector2D& v, double val) const;
+        bool                    isBeingDragged() const;
 
-        Vector2D                   makeVector(double primary, double secondary) const;
+        Vector2D                makeVector(double primary, double secondary) const;
     };
 };

--- a/src/layout/algorithm/tiled/scrolling/ScrollTapeController.hpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollTapeController.hpp
@@ -61,8 +61,8 @@ namespace Layout::Tiled {
         double                   calculateStripStart(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false) const;
         double                   calculateStripSize(size_t stripIndex, const CBox& usableArea, bool fullscreenOnOne = false) const;
 
-        CBox              calculateStripBox(size_t stripIndex, const CBox& usableArea, const Vector2D& workspaceOffset, bool fullscreenOnOne = false);
-        CBox              calculateTargetBox(size_t stripIndex, size_t targetIndex, const CBox& usableArea, const Vector2D& workspaceOffset, bool fullscreenOnOne = false);
+        CBox                     calculateStripBox(size_t stripIndex, const CBox& usableArea, const Vector2D& workspaceOffset, bool fullscreenOnOne = false);
+        CBox                     calculateTargetBox(size_t stripIndex, size_t targetIndex, const CBox& usableArea, const Vector2D& workspaceOffset, bool fullscreenOnOne = false);
 
         double                   calculateCameraOffset(const CBox& usableArea, bool fullscreenOnOne = false);
         Vector2D                 getCameraTranslation(const CBox& usableArea, bool fullscreenOnOne = false);

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -1866,6 +1866,22 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
 
         m_scrollingData->centerCol(CURRENT_COL);
         m_scrollingData->recalculate();
+    } else if (ARGS[0] == "inhibit_scroll") {
+        // Inhibits/Uninhibits scrolling: The tape does not move for the currently active workspace while this option is active
+
+        if (ARGS.size() > 2)
+            return std::unexpected("too many args");
+
+        // Toggle
+        if (ARGS.size() == 1)
+            m_scrollingData->controller->getScrollInhibitor().isInhibited ? uninhibitScroll() : inhibitScroll();
+        // Explicit Disable
+        else if (ARGS[1] == "0" || ARGS[1] == "false")
+            uninhibitScroll();
+        // Explicit Enable
+        else
+            inhibitScroll();
+
     } else
         return invalidArg("no such layoutmsg for scrolling");
 
@@ -2132,6 +2148,20 @@ CBox CScrollingAlgorithm::usableArea() const {
     box.h = std::max(box.h, 1.0);
 
     return box;
+}
+
+void CScrollingAlgorithm::inhibitScroll() {
+
+    m_scrollingData->controller->getScrollInhibitor().offsetWhenInhibited = m_scrollingData->controller->getOffset();
+    m_scrollingData->controller->getScrollInhibitor().isInhibited         = true;
+
+    Log::logger->log(Log::INFO, "Scrolling inhibited");
+}
+
+void CScrollingAlgorithm::uninhibitScroll() {
+    m_scrollingData->controller->getScrollInhibitor().isInhibited = false;
+
+    Log::logger->log(Log::INFO, "Scrolling uninhibited");
 }
 
 float CScrollingAlgorithm::defaultColumnWidth() {

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -1870,7 +1870,7 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
         // Inhibits/Uninhibits scrolling: The tape does not move for the currently active workspace while this option is active
 
         if (ARGS.size() > 2)
-            return std::unexpected("too many args");
+            return invalidArg("too many args");
 
         // Toggle
         if (ARGS.size() == 1)

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.hpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.hpp
@@ -128,6 +128,9 @@ namespace Layout::Tiled {
         CBox                             usableArea() const;
         SP<SScrollingTargetData>         dataFor(SP<ITarget> t) const;
 
+        void                                     inhibitScroll();
+        void                                     uninhibitScroll();
+
         enum eInputMode : uint8_t {
             INPUT_MODE_SOFT = 0,
             INPUT_MODE_CLICK,

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.hpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.hpp
@@ -128,8 +128,8 @@ namespace Layout::Tiled {
         CBox                             usableArea() const;
         SP<SScrollingTargetData>         dataFor(SP<ITarget> t) const;
 
-        void                            inhibitScroll();
-        void                            uninhibitScroll();
+        void                             inhibitScroll();
+        void                             uninhibitScroll();
 
         enum eInputMode : uint8_t {
             INPUT_MODE_SOFT = 0,

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.hpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.hpp
@@ -128,8 +128,8 @@ namespace Layout::Tiled {
         CBox                             usableArea() const;
         SP<SScrollingTargetData>         dataFor(SP<ITarget> t) const;
 
-        void                                     inhibitScroll();
-        void                                     uninhibitScroll();
+        void                            inhibitScroll();
+        void                            uninhibitScroll();
 
         enum eInputMode : uint8_t {
             INPUT_MODE_SOFT = 0,


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Adds a `layoutmsg inhibit_scroll` dispatch for inhibiting the scrolling tape from moving for the currently active workspace when active.
It is a per-workspace toggle.

This is useful if users don't want a specific action that would normally cause scrolling view changes to not cause scrolling view changes; providing a greater degree of control over scrolling view behaviour to the user.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

None.


#### Is it ready for merging, or does it need work?

Should be good to go.