### PR TITLE
Fix teardown and wl_output surface iteration crashes

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -594,8 +594,8 @@ void CCompositor::cleanup() {
     g_pDebugOverlay.reset();
     g_pEventManager.reset();
     g_pSessionLockManager.reset();
-    g_pProtocolManager.reset();
     g_pHyprRenderer.reset();
+    g_pProtocolManager.reset();
     g_pHyprOpenGL.reset();
     Render::g_pShaderLoader.reset();
     Config::mgr().reset();

--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -211,10 +211,12 @@ void CSeatManager::sendKeyboardMods(uint32_t depressed, uint32_t latched, uint32
 }
 
 void CSeatManager::setPointerFocus(SP<CWLSurfaceResource> surf, const Vector2D& local) {
+    const bool dndActive = PROTO::data && PROTO::data->dndActive();
+
     if (m_state.pointerFocus == surf)
         return;
 
-    if (PROTO::data->dndActive() && surf) {
+    if (dndActive && surf) {
         if (m_state.dndPointerFocus == surf)
             return;
         Log::logger->log(Log::DEBUG, "[seatmgr] Refusing pointer focus during an active dnd, but setting dndPointerFocus");
@@ -304,7 +306,7 @@ void CSeatManager::sendPointerMotion(uint32_t timeMs, const Vector2D& local) {
 }
 
 void CSeatManager::sendPointerButton(uint32_t timeMs, uint32_t key, wl_pointer_button_state state_) {
-    if (!m_state.pointerFocusResource || PROTO::data->dndActive())
+    if (!m_state.pointerFocusResource || (PROTO::data && PROTO::data->dndActive()))
         return;
 
     for (auto const& s : m_seatResources) {

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -782,7 +782,12 @@ void CWLCompositorProtocol::destroyResource(CWLRegionResource* resource) {
 }
 
 void CWLCompositorProtocol::forEachSurface(std::function<void(SP<CWLSurfaceResource>)> fn) {
-    for (auto& surf : m_surfaces) {
+    const auto surfaces = m_surfaces;
+
+    for (auto& surf : surfaces) {
+        if (!surf)
+            continue;
+
         fn(surf);
     }
 }


### PR DESCRIPTION
Fixed two Hyprland crash paths observed in local core dumps.

- guard DnD checks in CSeatManager during compositor teardown
- destroy g_pHyprRenderer before g_pProtocolManager in cleanup
- iterate a snapshot in CWLCompositorProtocol::forEachSurface to avoid re-entrant surface vector invalidation during wl_output binding

This changes were made with codex xhigh, they may need more intense testing :)