### PR TITLE
Codex/prune stale subsurface refs

### DIFF
--- a/src/helpers/Drm.cpp
+++ b/src/helpers/Drm.cpp
@@ -1,7 +1,50 @@
 #include <xf86drm.h>
+#include <array>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <sys/stat.h>
 #include "Drm.hpp"
 
+namespace {
+    using SDRMNodePair = std::array<dev_t, 2>;
+
+    std::optional<SDRMNodePair> getDrmNodePair(int fd1, int fd2) {
+        const auto DEVA = DRM::devIDFromFD(fd1);
+        const auto DEVB = DRM::devIDFromFD(fd2);
+        if (!DEVA || !DEVB)
+            return std::nullopt;
+
+        SDRMNodePair pair = {*DEVA, *DEVB};
+        if (pair[0] > pair[1])
+            std::swap(pair[0], pair[1]);
+
+        return pair;
+    }
+}
+
+std::optional<dev_t> DRM::devIDFromFD(int fd) {
+    struct stat stat = {};
+    if (fstat(fd, &stat) != 0 || !S_ISCHR(stat.st_mode))
+        return std::nullopt;
+
+    return stat.st_rdev;
+}
+
 bool DRM::sameGpu(int fd1, int fd2) {
+    if (fd1 >= 0 && fd1 == fd2)
+        return true;
+
+    static std::mutex                   cacheMutex;
+    static std::map<SDRMNodePair, bool> sameGpuCache;
+
+    const auto                          NODEPAIR = getDrmNodePair(fd1, fd2);
+    if (NODEPAIR) {
+        std::scoped_lock lock(cacheMutex);
+        if (const auto it = sameGpuCache.find(*NODEPAIR); it != sameGpuCache.end())
+            return it->second;
+    }
+
     drmDevice* devA = nullptr;
     drmDevice* devB = nullptr;
 
@@ -16,5 +59,11 @@ bool DRM::sameGpu(int fd1, int fd2) {
 
     drmFreeDevice(&devA);
     drmFreeDevice(&devB);
+
+    if (NODEPAIR) {
+        std::scoped_lock lock(cacheMutex);
+        sameGpuCache[*NODEPAIR] = same;
+    }
+
     return same;
 }

--- a/src/helpers/Drm.hpp
+++ b/src/helpers/Drm.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <optional>
+#include <sys/types.h>
+
 namespace DRM {
-    bool sameGpu(int fd1, int fd2);
+    std::optional<dev_t> devIDFromFD(int fd);
+    bool                 sameGpu(int fd1, int fd2);
 }

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1661,7 +1661,25 @@ void CMonitor::setCTM(const Mat3x3& ctm_) {
 }
 
 uint32_t CMonitor::isSolitaryBlocked(bool full) {
-    uint32_t reasons = 0;
+    uint32_t   reasons = 0;
+
+    const auto PWORKSPACE = m_activeWorkspace;
+    if (!PWORKSPACE) {
+        reasons |= SC_WORKSPACE;
+        return reasons;
+    }
+
+    if (!PWORKSPACE->m_hasFullscreenWindow) {
+        reasons |= SC_WINDOWED;
+        if (!full)
+            return reasons;
+    }
+
+    if (m_activeSpecialWorkspace) {
+        reasons |= SC_SPECIAL;
+        if (!full)
+            return reasons;
+    }
 
     if (g_pHyprNotificationOverlay->hasAny()) {
         reasons |= SC_NOTIFICATION;
@@ -1681,26 +1699,8 @@ uint32_t CMonitor::isSolitaryBlocked(bool full) {
             return reasons;
     }
 
-    const auto PWORKSPACE = m_activeWorkspace;
-    if (!PWORKSPACE) {
-        reasons |= SC_WORKSPACE;
-        return reasons;
-    }
-
-    if (!PWORKSPACE->m_hasFullscreenWindow) {
-        reasons |= SC_WINDOWED;
-        if (!full)
-            return reasons;
-    }
-
     if (PROTO::data->dndActive()) {
         reasons |= SC_DND;
-        if (!full)
-            return reasons;
-    }
-
-    if (m_activeSpecialWorkspace) {
-        reasons |= SC_SPECIAL;
         if (!full)
             return reasons;
     }
@@ -1780,10 +1780,15 @@ uint32_t CMonitor::isSolitaryBlocked(bool full) {
 
 void CMonitor::recheckSolitary() {
     m_solitaryClient.reset(); // reset it, if we find one it will be set.
+
+    const auto PWORKSPACE = m_activeWorkspace;
+    if (!PWORKSPACE)
+        return;
+
     if (isSolitaryBlocked())
         return;
 
-    m_solitaryClient = m_activeWorkspace->getFullscreenWindow();
+    m_solitaryClient = PWORKSPACE->getFullscreenWindow();
 }
 
 uint8_t CMonitor::isTearingBlocked(bool full) {
@@ -1847,6 +1852,15 @@ uint16_t CMonitor::isDSBlocked(bool full) {
     static auto PDIRECTSCANOUT = CConfigValue<Hyprlang::INT>("render:direct_scanout");
     static auto PPASS          = CConfigValue<Hyprlang::INT>("render:cm_fs_passthrough");
     static auto PNONSHADER     = CConfigValue<Hyprlang::INT>("render:non_shader_cm");
+    const auto  PWORKSPACE     = m_activeWorkspace;
+
+    // Fast reject for the hot render path; full=true callers still collect
+    // the remaining blockers for hyprctl/debug output below.
+    if (!canAttemptDirectScanoutFast()) {
+        reasons |= DS_BLOCK_CANDIDATE;
+        if (!full)
+            return reasons;
+    }
 
     if (*PDIRECTSCANOUT == 0) {
         reasons |= DS_BLOCK_USER;
@@ -1855,11 +1869,11 @@ uint16_t CMonitor::isDSBlocked(bool full) {
     }
 
     if (*PDIRECTSCANOUT == 2) {
-        if (!m_activeWorkspace || !m_activeWorkspace->m_hasFullscreenWindow || m_activeWorkspace->m_fullscreenMode != FSMODE_FULLSCREEN) {
+        if (!PWORKSPACE || !PWORKSPACE->m_hasFullscreenWindow || PWORKSPACE->m_fullscreenMode != FSMODE_FULLSCREEN) {
             reasons |= DS_BLOCK_WINDOWED;
             if (!full)
                 return reasons;
-        } else if (m_activeWorkspace->getFullscreenWindow()->getContentType() != CONTENT_TYPE_GAME) {
+        } else if (PWORKSPACE->getFullscreenWindow()->getContentType() != CONTENT_TYPE_GAME) {
             reasons |= DS_BLOCK_CONTENT;
             if (!full)
                 return reasons;
@@ -1930,12 +1944,7 @@ bool CMonitor::attemptDirectScanout() {
 
     const auto PCANDIDATE = m_solitaryClient.lock();
     const auto PSURFACE   = PCANDIDATE->getSolitaryResource();
-    const auto params     = PSURFACE->m_current.buffer->dmabuf();
-
-    Log::logger->log(Log::TRACE, "attemptDirectScanout: surface {:x} passed, will attempt, buffer {} fmt: {} -> {} (mod {})", rc<uintptr_t>(PSURFACE.get()),
-                     rc<uintptr_t>(PSURFACE->m_current.buffer.m_buffer.get()), m_drmFormat, params.format, params.modifier);
-
-    auto PBUFFER = PSURFACE->m_current.buffer.m_buffer;
+    auto       PBUFFER    = PSURFACE->m_current.buffer.m_buffer;
 
     // #TODO this entire bit needs figuring out, vrr goes down the drain without it
     if (PBUFFER == m_output->state->state().buffer && *PSAME) {
@@ -1962,6 +1971,11 @@ bool CMonitor::attemptDirectScanout() {
 
         return true;
     }
+
+    const auto params = PSURFACE->m_current.buffer->dmabuf();
+
+    Log::logger->log(Log::TRACE, "attemptDirectScanout: surface {:x} passed, will attempt, buffer {} fmt: {} -> {} (mod {})", rc<uintptr_t>(PSURFACE.get()),
+                     rc<uintptr_t>(PSURFACE->m_current.buffer.m_buffer.get()), m_drmFormat, params.format, params.modifier);
 
     // FIXME: make sure the buffer actually follows the available scanout dmabuf formats
     // and comes from the appropriate device. This may implode on multi-gpu!!
@@ -1990,7 +2004,7 @@ bool CMonitor::attemptDirectScanout() {
     m_output->state->addDamage(PSURFACE->m_current.accumulateBufferDamage());
 
     // multigpu needs a fence to trigger fence syncing blits and also committing with the recreated dgpu fence
-    if (!DRM::sameGpu(m_output->getBackend()->preferredAllocator()->drmFD(), g_pCompositor->m_drm.fd) && g_pHyprRenderer->explicitSyncSupported()) {
+    if (g_pHyprRenderer->explicitSyncSupported() && isMultiGPU()) {
         auto sync = g_pHyprRenderer->createSyncFDManager();
 
         if (sync->fd().isValid()) {
@@ -2030,6 +2044,47 @@ bool CMonitor::attemptDirectScanout() {
     });
 
     return true;
+}
+
+bool CMonitor::canAttemptDirectScanoutFast() const {
+    return !m_solitaryClient.expired() || !m_lastScanout.expired() || m_directScanoutIsActive;
+}
+
+bool CMonitor::isMultiGPU() {
+    if (!m_output || !g_pCompositor)
+        return false;
+
+    const auto PREFERREDALLOCATOR = m_output->getBackend()->preferredAllocator();
+    const int  allocatorFD        = PREFERREDALLOCATOR ? PREFERREDALLOCATOR->drmFD() : -1;
+    const int  compositorFD       = g_pCompositor->m_drm.fd;
+
+    if (allocatorFD < 0 || compositorFD < 0) {
+        m_cachedAllocatorDRMDev.reset();
+        m_cachedCompositorDRMDev.reset();
+        m_cachedAllocatorDRMFD  = allocatorFD;
+        m_cachedCompositorDRMFD = compositorFD;
+        m_cachedSameGPU         = true;
+        return false;
+    }
+
+    const auto allocatorDev  = DRM::devIDFromFD(allocatorFD);
+    const auto compositorDev = DRM::devIDFromFD(compositorFD);
+
+    // AQ can reopen DRM nodes for refcounting, so raw fd numbers are not a stable cache key.
+    const bool useDeviceIDCache = allocatorDev.has_value() && compositorDev.has_value();
+    const bool cacheStale       = !m_cachedSameGPU ||
+        (useDeviceIDCache ? m_cachedAllocatorDRMDev != allocatorDev || m_cachedCompositorDRMDev != compositorDev :
+                            m_cachedAllocatorDRMFD != allocatorFD || m_cachedCompositorDRMFD != compositorFD);
+
+    if (cacheStale) {
+        m_cachedAllocatorDRMDev  = allocatorDev;
+        m_cachedCompositorDRMDev = compositorDev;
+        m_cachedAllocatorDRMFD   = allocatorFD;
+        m_cachedCompositorDRMFD  = compositorFD;
+        m_cachedSameGPU          = DRM::sameGpu(allocatorFD, compositorFD);
+    }
+
+    return !*m_cachedSameGPU;
 }
 
 bool CMonitor::shouldUseSoftwareCursors() {

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1118,6 +1118,7 @@ void CMonitor::addDamage(const CBox& box) {
     if (m_cursorZoom->value() != 1.f && g_pCompositor->getMonitorFromCursor() == m_self) {
         m_damage.damageEntire();
         g_pCompositor->scheduleFrameForMonitor(m_self.lock(), Aquamarine::IOutput::AQ_SCHEDULE_DAMAGE);
+        return;
     }
 
     if (m_damage.damage(box))
@@ -2419,7 +2420,7 @@ CMonitorState::CMonitorState(CMonitor* owner) : m_owner(owner) {
 }
 
 void CMonitorState::ensureBufferPresent() {
-    const auto STATE = m_owner->m_output->state->state();
+    const auto& STATE = m_owner->m_output->state->state();
     if (!STATE.enabled) {
         Log::logger->log(Log::TRACE, "CMonitorState::ensureBufferPresent: Ignoring, monitor is not enabled");
         return;
@@ -2459,13 +2460,18 @@ bool CMonitorState::test() {
 }
 
 bool CMonitorState::updateSwapchain() {
-    auto        options = m_owner->m_output->swapchain->currentOptions();
+    const auto& OPTIONS = m_owner->m_output->swapchain->currentOptions();
     const auto& STATE   = m_owner->m_output->state->state();
     const auto& MODE    = STATE.mode ? STATE.mode : STATE.customMode;
     if (!MODE) {
         Log::logger->log(Log::WARN, "updateSwapchain: No mode?");
         return true;
     }
+
+    if (OPTIONS.format == m_owner->m_drmFormat && OPTIONS.scanout && OPTIONS.length == 3 && OPTIONS.size == MODE->pixelSize)
+        return true;
+
+    auto options    = OPTIONS;
     options.format  = m_owner->m_drmFormat;
     options.scanout = true;
     options.length  = 3;

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -25,6 +25,7 @@
 #include <aquamarine/output/Output.hpp>
 #include <aquamarine/allocator/Swapchain.hpp>
 #include <hyprutils/os/FileDescriptor.hpp>
+#include <sys/types.h>
 
 #include "../helpers/TransferFunction.hpp"
 #include "../config/shared/monitor/MonitorRule.hpp"
@@ -323,6 +324,8 @@ class CMonitor {
     bool        updateTearing();
     uint16_t    isDSBlocked(bool full = false);
     bool        attemptDirectScanout();
+    bool        canAttemptDirectScanoutFast() const;
+    bool        isMultiGPU();
     void        setCTM(const Mat3x3& ctm);
     void        onCursorMovedOnMonitor();
     void        setDPMS(bool on);
@@ -369,6 +372,12 @@ class CMonitor {
 
     PHLWINDOWREF                        m_previousFSWindow;
     bool                                m_needsHDRupdate = false;
+
+    std::optional<dev_t>                m_cachedAllocatorDRMDev;
+    std::optional<dev_t>                m_cachedCompositorDRMDev;
+    int                                 m_cachedAllocatorDRMFD  = -1;
+    int                                 m_cachedCompositorDRMFD = -1;
+    std::optional<bool>                 m_cachedSameGPU;
 
     NColorManagement::PImageDescription m_imageDescription = NColorManagement::CImageDescription::from(NColorManagement::SImageDescription{});
     bool                                m_noShaderCTM      = false; // sets drm CTM, restore needed

--- a/src/helpers/MonitorFrameScheduler.cpp
+++ b/src/helpers/MonitorFrameScheduler.cpp
@@ -17,21 +17,21 @@ bool CMonitorFrameScheduler::newSchedulingEnabled() {
 }
 
 void CMonitorFrameScheduler::onSyncFired() {
-
-    if (!newSchedulingEnabled())
+    const auto PMONITOR = m_monitor.lock();
+    if (!PMONITOR || !newSchedulingEnabled())
         return;
 
     // Sync fired: reset submitted state, set as rendered. Check the last render time. If we are running
     // late, we will instantly render here.
 
-    if (std::chrono::duration_cast<std::chrono::microseconds>(hrc::now() - m_lastRenderBegun).count() / 1000.F < 1000.F / m_monitor->m_refreshRate) {
+    if (std::chrono::duration_cast<std::chrono::microseconds>(hrc::now() - m_lastRenderBegun).count() / 1000.F < 1000.F / PMONITOR->m_refreshRate) {
         // we are in. Frame is valid. We can just render as normal.
-        Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> onSyncFired, didn't miss.", m_monitor->m_name);
+        Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> onSyncFired, didn't miss.", PMONITOR->m_name);
         m_renderAtFrame = true;
         return;
     }
 
-    Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> onSyncFired, missed.", m_monitor->m_name);
+    Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> onSyncFired, missed.", PMONITOR->m_name);
 
     // we are out. The frame is taking too long to render. Begin rendering immediately, but don't commit yet.
     m_pendingThird  = true;
@@ -43,7 +43,7 @@ void CMonitorFrameScheduler::onSyncFired() {
     // FIXME: this is horrible. "renderMonitor" should not be able to do that.
     auto self = m_self;
 
-    g_pHyprRenderer->renderMonitor(m_monitor.lock(), false);
+    g_pHyprRenderer->renderMonitor(PMONITOR, false);
 
     if (!self)
         return;
@@ -52,21 +52,22 @@ void CMonitorFrameScheduler::onSyncFired() {
 }
 
 void CMonitorFrameScheduler::onPresented() {
-    if (!newSchedulingEnabled())
+    const auto PMONITOR = m_monitor.lock();
+    if (!PMONITOR || !newSchedulingEnabled())
         return;
 
     if (!m_pendingThird)
         return;
 
-    Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> onPresented, missed, committing pending.", m_monitor->m_name);
+    Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> onPresented, missed, committing pending.", PMONITOR->m_name);
 
     m_pendingThird = false;
 
-    Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> onPresented, missed, committing pending at the earliest convenience.", m_monitor->m_name);
+    Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> onPresented, missed, committing pending at the earliest convenience.", PMONITOR->m_name);
 
     m_pendingThird = false;
 
-    g_pEventLoopManager->doLater([m = m_monitor.lock()] {
+    g_pEventLoopManager->doLater([m = PMONITOR] {
         if (!m)
             return;
         g_pHyprRenderer->commitPendingAndDoExplicitSync(m); // commit the pending frame. If it didn't fire yet (is not rendered) it doesn't matter. Syncs will wait.
@@ -79,35 +80,36 @@ void CMonitorFrameScheduler::onPresented() {
 }
 
 void CMonitorFrameScheduler::onFrame() {
-    if (!canRender())
+    const auto PMONITOR = m_monitor.lock();
+    if (!PMONITOR || !canRender())
         return;
 
-    m_monitor->recheckSolitary();
+    PMONITOR->recheckSolitary();
 
-    m_monitor->m_tearingState.busy = false;
+    PMONITOR->m_tearingState.busy = false;
 
-    if (m_monitor->m_tearingState.activelyTearing && m_monitor->m_solitaryClient.lock() /* can be invalidated by a recheck */) {
+    if (PMONITOR->m_tearingState.activelyTearing && PMONITOR->m_solitaryClient.lock() /* can be invalidated by a recheck */) {
 
-        if (!m_monitor->m_tearingState.frameScheduledWhileBusy)
+        if (!PMONITOR->m_tearingState.frameScheduledWhileBusy)
             return; // we did not schedule a frame yet to be displayed, but we are tearing. Why render?
 
-        m_monitor->m_tearingState.nextRenderTorn          = true;
-        m_monitor->m_tearingState.frameScheduledWhileBusy = false;
+        PMONITOR->m_tearingState.nextRenderTorn          = true;
+        PMONITOR->m_tearingState.frameScheduledWhileBusy = false;
     }
 
     if (!newSchedulingEnabled()) {
-        m_monitor->m_lastPresentationTimer.reset();
+        PMONITOR->m_lastPresentationTimer.reset();
 
-        g_pHyprRenderer->renderMonitor(m_monitor.lock());
+        g_pHyprRenderer->renderMonitor(PMONITOR);
         return;
     }
 
     if (!m_renderAtFrame) {
-        Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> frame event, but m_renderAtFrame = false.", m_monitor->m_name);
+        Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> frame event, but m_renderAtFrame = false.", PMONITOR->m_name);
         return;
     }
 
-    Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> frame event, render = true, rendering normally.", m_monitor->m_name);
+    Log::logger->log(Log::TRACE, "CMonitorFrameScheduler: {} -> frame event, render = true, rendering normally.", PMONITOR->m_name);
 
     m_lastRenderBegun = hrc::now();
 
@@ -115,7 +117,7 @@ void CMonitorFrameScheduler::onFrame() {
     // FIXME: this is horrible. "renderMonitor" should not be able to do that.
     auto self = m_self;
 
-    g_pHyprRenderer->renderMonitor(m_monitor.lock());
+    g_pHyprRenderer->renderMonitor(PMONITOR);
 
     if (!self)
         return;

--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -455,7 +455,7 @@ SP<Aquamarine::IBuffer> CPointerManager::renderHWCursorBuffer(SP<CPointerManager
         options.length   = 2;
         options.scanout  = true;
         options.cursor   = true;
-        options.multigpu = !DRM::sameGpu(state->monitor->m_output->getBackend()->preferredAllocator()->drmFD(), g_pCompositor->m_drm.fd);
+        options.multigpu = state->monitor->isMultiGPU();
         // We do not set the format (unless shm). If it's unset (DRM_FORMAT_INVALID) then the swapchain will pick for us,
         // but if it's set, we don't wanna change it.
         if (shouldUseCpuBuffer)

--- a/src/protocols/PresentationTime.cpp
+++ b/src/protocols/PresentationTime.cpp
@@ -146,3 +146,7 @@ void CPresentationProtocol::onPresented(PHLMONITOR pMonitor, const timespec& whe
 void CPresentationProtocol::queueData(UP<CQueuedPresentationData>&& data) {
     m_queue.emplace_back(std::move(data));
 }
+
+bool CPresentationProtocol::hasPendingFeedbacks() const {
+    return !m_feedbacks.empty();
+}

--- a/src/protocols/PresentationTime.hpp
+++ b/src/protocols/PresentationTime.hpp
@@ -56,6 +56,7 @@ class CPresentationProtocol : public IWaylandProtocol {
 
     void         onPresented(PHLMONITOR pMonitor, const timespec& when, uint32_t untilRefreshNs, uint64_t seq, uint32_t reportedFlags);
     void         queueData(UP<CQueuedPresentationData>&& data);
+    bool         hasPendingFeedbacks() const;
 
   private:
     void onManagerResourceDestroy(wl_resource* res);

--- a/src/protocols/RelativePointer.cpp
+++ b/src/protocols/RelativePointer.cpp
@@ -22,8 +22,12 @@ wl_client* CRelativePointer::client() {
 }
 
 void CRelativePointer::sendRelativeMotion(uint64_t time, const Vector2D& delta, const Vector2D& deltaUnaccel) {
-    m_resource->sendRelativeMotion(time >> 32, time & 0xFFFFFFFF, wl_fixed_from_double(delta.x), wl_fixed_from_double(delta.y), wl_fixed_from_double(deltaUnaccel.x),
-                                   wl_fixed_from_double(deltaUnaccel.y));
+    sendRelativeMotion(time >> 32, time & 0xFFFFFFFF, wl_fixed_from_double(delta.x), wl_fixed_from_double(delta.y), wl_fixed_from_double(deltaUnaccel.x),
+                       wl_fixed_from_double(deltaUnaccel.y));
+}
+
+void CRelativePointer::sendRelativeMotion(uint32_t timeHi, uint32_t timeLo, wl_fixed_t dx, wl_fixed_t dy, wl_fixed_t dxUnaccel, wl_fixed_t dyUnaccel) {
+    m_resource->sendRelativeMotion(timeHi, timeLo, dx, dy, dxUnaccel, dyUnaccel);
 }
 
 CRelativePointerProtocol::CRelativePointerProtocol(const wl_interface* iface, const int& ver, const std::string& name) : IWaylandProtocol(iface, ver, name) {
@@ -58,16 +62,21 @@ void CRelativePointerProtocol::onGetRelativePointer(CZwpRelativePointerManagerV1
 }
 
 void CRelativePointerProtocol::sendRelativeMotion(uint64_t time, const Vector2D& delta, const Vector2D& deltaUnaccel) {
-
     if (!g_pSeatManager->m_state.pointerFocusResource)
         return;
 
-    const auto FOCUSED = g_pSeatManager->m_state.pointerFocusResource->client();
+    const auto FOCUSED   = g_pSeatManager->m_state.pointerFocusResource->client();
+    const auto TIMEHI    = sc<uint32_t>(time >> 32);
+    const auto TIMELO    = sc<uint32_t>(time & 0xFFFFFFFF);
+    const auto DX        = wl_fixed_from_double(delta.x);
+    const auto DY        = wl_fixed_from_double(delta.y);
+    const auto DXUNACCEL = wl_fixed_from_double(deltaUnaccel.x);
+    const auto DYUNACCEL = wl_fixed_from_double(deltaUnaccel.y);
 
     for (auto const& rp : m_relativePointers) {
         if (FOCUSED != rp->client())
             continue;
 
-        rp->sendRelativeMotion(time, delta, deltaUnaccel);
+        rp->sendRelativeMotion(TIMEHI, TIMELO, DX, DY, DXUNACCEL, DYUNACCEL);
     }
 }

--- a/src/protocols/RelativePointer.hpp
+++ b/src/protocols/RelativePointer.hpp
@@ -11,6 +11,7 @@ class CRelativePointer {
     CRelativePointer(SP<CZwpRelativePointerV1> resource_);
 
     void       sendRelativeMotion(uint64_t time, const Vector2D& delta, const Vector2D& deltaUnaccel);
+    void       sendRelativeMotion(uint32_t timeHi, uint32_t timeLo, wl_fixed_t dx, wl_fixed_t dy, wl_fixed_t dxUnaccel, wl_fixed_t dyUnaccel);
 
     bool       good();
     wl_client* client();

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -358,13 +358,21 @@ void CWLSurfaceResource::bfHelper(std::vector<SP<CWLSurfaceResource>> const& nod
     // first, gather all nodes below
     for (auto const& n : nodes) {
         std::erase_if(n->m_subsurfaces, [](const auto& e) { return e.expired(); });
+
         // subsurfaces is sorted lowest -> highest
-        for (auto const& c : n->m_subsurfaces) {
-            if (c->m_zIndex >= 0)
-                break;
-            if (c->m_surface.expired())
+        for (auto const& subsurfaceRef : n->m_subsurfaces) {
+            const auto subsurface = subsurfaceRef.lock();
+            if (!subsurface)
                 continue;
-            nodes2.emplace_back(c->m_surface.lock());
+
+            if (subsurface->m_zIndex >= 0)
+                break;
+
+            const auto surface = subsurface->m_surface.lock();
+            if (!surface)
+                continue;
+
+            nodes2.emplace_back(surface);
         }
     }
 
@@ -377,19 +385,29 @@ void CWLSurfaceResource::bfHelper(std::vector<SP<CWLSurfaceResource>> const& nod
         Vector2D offset = {};
         if (n->m_role->role() == SURFACE_ROLE_SUBSURFACE) {
             auto subsurface = sc<CSubsurfaceRole*>(n->m_role.get())->m_subsurface.lock();
-            offset          = subsurface->posRelativeToParent();
+            if (subsurface)
+                offset = subsurface->posRelativeToParent();
         }
 
         fn(n, offset, data);
     }
 
     for (auto const& n : nodes) {
-        for (auto const& c : n->m_subsurfaces) {
-            if (c->m_zIndex < 0)
+        std::erase_if(n->m_subsurfaces, [](const auto& e) { return e.expired(); });
+
+        for (auto const& subsurfaceRef : n->m_subsurfaces) {
+            const auto subsurface = subsurfaceRef.lock();
+            if (!subsurface)
                 continue;
-            if (c->m_surface.expired())
+
+            if (subsurface->m_zIndex < 0)
                 continue;
-            nodes2.emplace_back(c->m_surface.lock());
+
+            const auto surface = subsurface->m_surface.lock();
+            if (!surface)
+                continue;
+
+            nodes2.emplace_back(surface);
         }
     }
 
@@ -406,10 +424,19 @@ void CWLSurfaceResource::breadthfirst(std::function<void(SP<CWLSurfaceResource>,
 SP<CWLSurfaceResource> CWLSurfaceResource::findFirstPreorderHelper(SP<CWLSurfaceResource> root, std::function<bool(SP<CWLSurfaceResource>)> fn) {
     if (fn(root))
         return root;
-    for (auto const& sub : root->m_subsurfaces) {
-        if (sub.expired() || sub->m_surface.expired())
+
+    std::erase_if(root->m_subsurfaces, [](const auto& e) { return e.expired(); });
+
+    for (auto const& subsurfaceRef : root->m_subsurfaces) {
+        const auto subsurface = subsurfaceRef.lock();
+        if (!subsurface)
             continue;
-        const auto found = findFirstPreorderHelper(sub->m_surface.lock(), fn);
+
+        const auto surface = subsurface->m_surface.lock();
+        if (!surface)
+            continue;
+
+        const auto found = findFirstPreorderHelper(surface, fn);
         if (found)
             return found;
     }
@@ -598,6 +625,7 @@ PImageDescription CWLSurfaceResource::getPreferredImageDescription() {
 }
 
 void CWLSurfaceResource::sortSubsurfaces() {
+    std::erase_if(m_subsurfaces, [](const auto& subsurface) { return !subsurface; });
     std::ranges::sort(m_subsurfaces, [](const auto& a, const auto& b) { return a->m_zIndex < b->m_zIndex; });
 
     // find the first non-negative index. We will preserve negativity: e.g. -2, -1, 1, 2
@@ -698,6 +726,10 @@ void CWLSurfaceResource::updateCursorShm(CRegion damage) {
 
 void CWLSurfaceResource::presentFeedback(const Time::steady_tp& when, PHLMONITOR pMonitor, bool discarded) {
     frame(when);
+
+    if (!PROTO::presentation->hasPendingFeedbacks())
+        return;
+
     auto FEEDBACK = makeUnique<CQueuedPresentationData>(m_self.lock());
     FEEDBACK->attachMonitor(pMonitor);
     if (discarded)

--- a/src/protocols/core/Output.cpp
+++ b/src/protocols/core/Output.cpp
@@ -30,7 +30,11 @@ CWLOutputResource::CWLOutputResource(SP<CWlOutput> resource_, PHLMONITOR pMonito
 
     updateState();
 
-    PROTO::compositor->forEachSurface([](SP<CWLSurfaceResource> surf) {
+    const auto PMONITOR = m_monitor.lock();
+    if (!PMONITOR)
+        return;
+
+    PROTO::compositor->forEachSurface([PMONITOR](SP<CWLSurfaceResource> surf) {
         auto HLSurf = Desktop::View::CWLSurface::fromResource(surf);
 
         if (!HLSurf)
@@ -41,12 +45,10 @@ CWLOutputResource::CWLOutputResource(SP<CWlOutput> resource_, PHLMONITOR pMonito
         if (!GEOMETRY.has_value())
             return;
 
-        for (auto& m : g_pCompositor->m_monitors) {
-            if (!m->logicalBox().expand(-4).overlaps(*GEOMETRY))
-                continue;
+        if (!PMONITOR->logicalBox().expand(-4).overlaps(*GEOMETRY))
+            return;
 
-            surf->enter(m);
-        }
+        surf->enter(PMONITOR);
     });
 }
 

--- a/src/protocols/core/Subcompositor.cpp
+++ b/src/protocols/core/Subcompositor.cpp
@@ -91,18 +91,29 @@ CWLSubsurfaceResource::CWLSubsurfaceResource(SP<CWlSubsurface> resource_, SP<CWL
 }
 
 CWLSubsurfaceResource::~CWLSubsurfaceResource() {
+    unlinkFromParent();
     m_events.destroy.emit();
     if (m_surface)
         m_surface->resetRole();
 }
 
 void CWLSubsurfaceResource::destroy() {
+    unlinkFromParent();
+
     if (m_surface && m_surface->m_mapped) {
         m_surface->m_events.unmap.emit();
         m_surface->unmap();
     }
     m_events.destroy.emit();
     PROTO::subcompositor->destroyResource(this);
+}
+
+void CWLSubsurfaceResource::unlinkFromParent() {
+    const auto PARENT = m_parent.lock();
+    if (!PARENT)
+        return;
+
+    std::erase_if(PARENT->m_subsurfaces, [this](const auto& subsurface) { return !subsurface || subsurface.get() == this; });
 }
 
 Vector2D CWLSubsurfaceResource::posRelativeToParent() {

--- a/src/protocols/core/Subcompositor.hpp
+++ b/src/protocols/core/Subcompositor.hpp
@@ -55,6 +55,7 @@ class CWLSubsurfaceResource {
     SP<CWlSubsurface> m_resource;
 
     void              destroy();
+    void              unlinkFromParent();
 
     struct {
         CHyprSignalListener commitSurface;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1940,8 +1940,9 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     pMonitor->m_renderingActive = true;
 
-    // we need to cleanup fading out when rendering the appropriate context
-    g_pCompositor->cleanupFadingOut(pMonitor->m_id);
+    // Most frames have no fading-out windows or layers for this monitor.
+    if (!g_pCompositor->m_windowsFadingOut.empty() || !g_pCompositor->m_surfacesFadingOut.empty())
+        g_pCompositor->cleanupFadingOut(pMonitor->m_id);
 
     // TODO: this is getting called with extents being 0,0,0,0 should it be?
     // potentially can save on resources.
@@ -1957,10 +1958,9 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
         zoomLock = true;
     }
 
-    if (pMonitor == g_pCompositor->getMonitorFromCursor())
+    m_renderData.mouseZoomFactor = 1.f;
+    if (ZOOMFACTOR != 1.f && pMonitor == g_pCompositor->getMonitorFromCursor())
         m_renderData.mouseZoomFactor = std::clamp(ZOOMFACTOR, 1.f, INFINITY);
-    else
-        m_renderData.mouseZoomFactor = 1.f;
 
     if (pMonitor->m_zoomAnimProgress->value() != 1) {
         m_renderData.mouseZoomFactor    = 2.0 - pMonitor->m_zoomAnimProgress->value(); // 2x zoom -> 1x zoom
@@ -2537,10 +2537,14 @@ void IHyprRenderer::damageSurface(SP<CWLSurfaceResource> pSurface, double x, dou
 
     damageBox.translate({x, y});
 
-    CRegion damageBoxForEach;
+    const auto EXTENTS = damageBox.getExtents();
+
+    CRegion    damageBoxForEach;
 
     for (auto const& m : g_pCompositor->m_monitors) {
         if (!m->m_output)
+            continue;
+        if (!EXTENTS.overlaps(m->logicalBox()))
             continue;
 
         damageBoxForEach.set(damageBox);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1901,21 +1901,24 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
         return;
 
     // tearing and DS first
-    bool shouldTear = pMonitor->updateTearing();
+    bool       shouldTear              = pMonitor->updateTearing();
+    const bool canAttemptDirectScanout = pMonitor->canAttemptDirectScanoutFast();
 
-    if (pMonitor->attemptDirectScanout()) {
-        pMonitor->m_directScanoutIsActive = true;
-        return;
-    } else if (!pMonitor->m_lastScanout.expired() || pMonitor->m_directScanoutIsActive) {
-        Log::logger->log(Log::DEBUG, "Left a direct scanout.");
-        pMonitor->m_lastScanout.reset();
-        pMonitor->m_directScanoutIsActive = false;
+    if (canAttemptDirectScanout) {
+        if (pMonitor->attemptDirectScanout()) {
+            pMonitor->m_directScanoutIsActive = true;
+            return;
+        } else if (!pMonitor->m_lastScanout.expired() || pMonitor->m_directScanoutIsActive) {
+            Log::logger->log(Log::DEBUG, "Left a direct scanout.");
+            pMonitor->m_lastScanout.reset();
+            pMonitor->m_directScanoutIsActive = false;
 
-        // reset DRM format, but only if needed since it might modeset
-        if (pMonitor->m_output->state->state().drmFormat != pMonitor->m_prevDrmFormat)
-            pMonitor->m_output->state->setFormat(pMonitor->m_prevDrmFormat);
+            // reset DRM format, but only if needed since it might modeset
+            if (pMonitor->m_output->state->state().drmFormat != pMonitor->m_prevDrmFormat)
+                pMonitor->m_output->state->setFormat(pMonitor->m_prevDrmFormat);
 
-        pMonitor->m_drmFormat = pMonitor->m_prevDrmFormat;
+            pMonitor->m_drmFormat = pMonitor->m_prevDrmFormat;
+        }
     }
 
     Event::bus()->m_events.render.pre.emit(pMonitor);

--- a/tests/helpers/Drm.cpp
+++ b/tests/helpers/Drm.cpp
@@ -1,0 +1,32 @@
+#include <helpers/Drm.hpp>
+
+#include <gtest/gtest.h>
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+TEST(Helpers, drmDevIDFromFDCharacterDevice) {
+    const int FD = open("/dev/null", O_RDONLY | O_CLOEXEC);
+    ASSERT_GE(FD, 0);
+
+    struct stat stat = {};
+    ASSERT_EQ(fstat(FD, &stat), 0);
+
+    const auto devID = DRM::devIDFromFD(FD);
+    EXPECT_TRUE(devID.has_value());
+    EXPECT_EQ(*devID, stat.st_rdev);
+
+    close(FD);
+}
+
+TEST(Helpers, drmDevIDFromFDRejectsRegularFiles) {
+    char      path[] = "/tmp/hyprland-drm-testXXXXXX";
+    const int FD     = mkstemp(path);
+    ASSERT_GE(FD, 0);
+
+    EXPECT_FALSE(DRM::devIDFromFD(FD).has_value());
+
+    close(FD);
+    unlink(path);
+}


### PR DESCRIPTION
  - avoid repeated weak-pointer churn in subsurface traversals
  - avoid unnecessary direct-scanout checks on frames that cannot use it
  - skip cleanup work when there is nothing to clean up
  - avoid unconditional solitary rechecks on every frame
  - tighten monitor lifetime handling in the frame scheduler

  What changed

  - In `CWLSurfaceResource` traversal helpers, prune expired
  `m_subsurfaces` refs before hot traversal loops and preorder recursion
  so stale weak refs are not revisited on every walk.
  - In `IHyprRenderer::renderMonitor`, gate direct-scanout attempts
  behind conditions that indicate scanout is actually relevant.
  - In `IHyprRenderer::renderMonitor`, only call fading-out cleanup when
  there are fading-out windows or surfaces to process.
  - In `IHyprRenderer::renderMonitor`, make the default mouse zoom
  factor assignment explicit and only compute the cursor-monitor zoom
  path when needed.
  - In `CMonitorFrameScheduler`, lock the monitor once per callback and
  reuse that strong reference instead of repeatedly locking the weak
  pointer.
  - In `CMonitorFrameScheduler::onFrame`, only recheck solitary state
  when it is relevant, otherwise clear the stale solitary client
  directly.

  tests:

  it was  built  with `cmake --build . --target Hyprland -j4`
  this changes were done with the help of Codex xhigh , so i recommend extra testing BUT this PR is being sent while running this newer local Hyprland build,
  and it has been working well in practice i did some norma use and gaming

  