### PR TITLE
feat: Allow configuring the groupbar's position #11805

### DIFF
--- a/src/config/supplementary/ConfigDescriptions.hpp
+++ b/src/config/supplementary/ConfigDescriptions.hpp
@@ -1046,6 +1046,12 @@ namespace Config::Supplementary {
             .data        = SConfigOptionDescription::SBoolData{true},
         },
         SConfigOptionDescription{
+            .value       = "group:groupbar:position",
+            .description = "sets the position of the groupbar. top - 0, bottom - 1",
+            .type        = CONFIG_OPTION_INT,
+            .data        = SConfigOptionDescription::SRangeData{0, 0, 1},
+        },
+        SConfigOptionDescription{
             .value       = "group:groupbar:font_family",
             .description = "font used to display groupbar titles, use misc:font_family if not specified",
             .type        = CONFIG_OPTION_STRING_SHORT,

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -40,10 +40,12 @@ SDecorationPositioningInfo CHyprGroupBarDecoration::getPositioningInfo() {
     static auto                PSTACKED         = CConfigValue<Hyprlang::INT>("group:groupbar:stacked");
     static auto                POUTERGAP        = CConfigValue<Hyprlang::INT>("group:groupbar:gaps_out");
     static auto                PKEEPUPPERGAP    = CConfigValue<Hyprlang::INT>("group:groupbar:keep_upper_gap");
+    static auto                PPOSITION        = CConfigValue<Hyprlang::INT>("group:groupbar:position");
+
 
     SDecorationPositioningInfo info;
     info.policy   = DECORATION_POSITION_STICKY;
-    info.edges    = DECORATION_EDGE_TOP;
+    info.edges    = PPOSITION == 1 ? DECORATION_EDGE_BOTTOM : DECORATION_EDGE_TOP;
     info.priority = *PPRIORITY;
     info.reserved = true;
 
@@ -517,8 +519,10 @@ std::string CHyprGroupBarDecoration::getDisplayName() {
 }
 
 CBox CHyprGroupBarDecoration::assignedBoxGlobal() {
+    const auto PPOSITION = CConfigValue<Hyprlang::INT>("group:groupbar:position");
+
     CBox box = m_assignedBox;
-    box.translate(g_pDecorationPositioner->getEdgeDefinedPoint(DECORATION_EDGE_TOP, m_window));
+    box.translate(g_pDecorationPositioner->getEdgeDefinedPoint(PPOSITION == 1 ? DECORATION_EDGE_BOTTOM : DECORATION_EDGE_TOP, m_window));
 
     const auto PWORKSPACE = m_window->m_workspace;
 


### PR DESCRIPTION
Kinda works 

Needs to make the bar "after" the window
Not overlapping the bottom of it
Then it will be usable 