### PR TITLE
input: fix focus_on_close=2 (MRU) routing to cursor path instead of getNextCandidate

### DIFF
--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -2250,7 +2250,7 @@ void CWindow::unmapWindow() {
         PHLWINDOW   candidate    = nextInGroup;
 
         if (!candidate) {
-            if (*FOCUSONCLOSE)
+            if (*FOCUSONCLOSE == 1)
                 candidate = (g_pCompositor->vectorToWindowUnified(g_pInputManager->getMouseCoordsInternal(),
                                                                   Desktop::View::RESERVED_EXTENTS | Desktop::View::INPUT_EXTENTS | Desktop::View::ALLOW_FLOATING));
             else {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

PR #13769 added `focus_on_close=2` (MRU mode) with the history lookup logic in `Algorithm::getNextCandidate`, but the caller in `Window.cpp` at `unmapWindow()` uses `if (*FOCUSONCLOSE)` — which is truthy for both 1 (cursor) and 2 (mru). So setting `focus_on_close=2` actually routes into the cursor-based `vectorToWindowUnified` path and never reaches `getNextCandidate` where the MRU histroy logic lives.

The fix changes `if (*FOCUSONCLOSE)` to `if (*FOCUSONCLOSE == 1)` so that only value 1 enters the cursor path, and value 2 falls through to `getNextCandidate` which already handles MRU correctly.

No impact on existing users:
- `focus_on_close=0` (next): still goes to else branch → spatial focus. Same behavior.
- `focus_on_close=1` (cursor): still matches `== 1` → cursor focus. Same behavor.
- `focus_on_close=2` (mru): now correctly falls through to `getNextCandidate` → MRU history focus. Fixed.

**To reproduce**: set `input:focus_on_close = 2`, open 3 windows (A, B, C), focus them in order A→B→C, close C. Without fix: focuses spatially adjacent window. With fix: focuses B (most recently used).

I noticed this while using the scrolling layout with `column_width=1.0` — closing a window always focused the adjacent column instead of the previously focused one.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

One line change, pretty straightforward. The existing test from #13769 in `hyprtester/src/tests/main/layout.cpp` (`testFocusMRUAfterClose`) should now actually test the intended code path instead of accidentaly passing because of cursor position.

#### Is it ready for merging, or does it need work?

Ready for merge.