### PR TITLE
fixed a group indicator rounding bug

### DIFF
--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -172,7 +172,7 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
             if (*PROUNDING) {
                 rectdata.round         = *PROUNDING;
                 rectdata.roundingPower = *PROUNDINGPOWER;
-                if (*PROUNDONLYEDGES) {
+                if (*PROUNDONLYEDGES && barsToDraw > 1) {
                     rectdata.round      = 0;
                     const double offset = *PROUNDING * 2;
                     if (i == 0) {
@@ -207,7 +207,7 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
                     if (*PGRADIENTROUNDING) {
                         data.round         = *PGRADIENTROUNDING;
                         data.roundingPower = *PGRADIENTROUNDINGPOWER;
-                        if (*PGRADIENTROUNDINGONLYEDGES) {
+                        if (*PGRADIENTROUNDINGONLYEDGES && barsToDraw > 1) {
                             data.round          = 0;
                             const double offset = *PGRADIENTROUNDING * 2;
                             if (i == 0) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Problem: When there is only a single window in a group, the rounding does not work as expected. The left side of the single window's indicator gets rounded, but the right side does not.

![before](https://github.com/user-attachments/assets/2247b532-a9e3-4cd1-9e02-3e34b410c88b)

Below is the after:

![after](https://github.com/user-attachments/assets/29904d02-3b82-4ae7-bea2-9e574f218fa4)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

-

#### Is it ready for merging, or does it need work?

It's ready.
