### PR TITLE
misc: reuse monitor pointer instead of repeated calls

### DIFF
--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -173,10 +173,11 @@ SWorkspaceIDName getWorkspaceIDNameFromString(const std::string& in) {
             }
         }
     } else if (in.starts_with("prev")) {
-        if (!Desktop::focusState()->monitor())
+        auto monitor = Desktop::focusState()->monitor();
+        if (!monitor)
             return {WORKSPACE_INVALID};
 
-        const auto PWORKSPACE = Desktop::focusState()->monitor()->m_activeWorkspace;
+        const auto PWORKSPACE = monitor->m_activeWorkspace;
 
         if (!valid(PWORKSPACE))
             return {WORKSPACE_INVALID};


### PR DESCRIPTION
Reuses the monitor pointer instead of calling Desktop::focusState()->monitor() multiple times in the same scope.

This improves readability and avoids repeated calls without changing behavior.

Built and tested locally (workspace switching, including prev case). No behavior changes observed.