### PR TITLE
desktop/window: reduce window deco updates

### DIFF
--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -658,12 +658,21 @@ void CWindow::onMap() {
         false);
 
     m_realSize->setUpdateCallback([this](auto) {
-        if (m_isMapped)
-            m_events.resize.emit();
+        if (!m_isMapped)
+            return;
+
+        updateWindowDecos();
+
+        m_events.resize.emit();
     });
 
     m_realPosition->setUpdateCallback([this](auto) {
-        if (m_isMapped && m_monitor != m_prevMonitor) {
+        if (!m_isMapped)
+            return;
+
+        updateWindowDecos();
+
+        if (m_monitor != m_prevMonitor) {
             m_prevMonitor = m_monitor;
             m_events.monitorChanged.emit();
         }

--- a/src/managers/animation/AnimationManager.cpp
+++ b/src/managers/animation/AnimationManager.cpp
@@ -150,15 +150,12 @@ static void handleUpdate(CAnimatedVariable<VarType>& av, bool warp) {
 
     switch (av.m_Context.eDamagePolicy) {
         case AVARDAMAGE_ENTIRE: {
-            if (PWINDOW) {
-                PWINDOW->updateWindowDecos();
+            if (PWINDOW)
                 g_pHyprRenderer->damageWindow(PWINDOW);
-            } else if (PWORKSPACE) {
+            else if (PWORKSPACE) {
                 for (auto const& w : g_pCompositor->m_windows) {
                     if (!validMapped(w) || w->m_workspace != PWORKSPACE)
                         continue;
-
-                    w->updateWindowDecos();
 
                     // damage any workspace window that is on any monitor
                     if (!w->m_pinned)


### PR DESCRIPTION
`AVARDAMAGE_ENTIRE` doesn't mean the geometry changed, so no point in an expensive update



