### PR TITLE
desktop/history: include ranges header

### DIFF
--- a/src/desktop/history/WorkspaceHistoryTracker.cpp
+++ b/src/desktop/history/WorkspaceHistoryTracker.cpp
@@ -9,6 +9,8 @@
 
 #include <hyprutils/utils/ScopeGuard.hpp>
 
+#include <ranges>
+
 using namespace Desktop;
 using namespace Desktop::History;
 


### PR DESCRIPTION
Fixes error `no member named 'views' in namespace 'std'` on llvm/musl

<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

I've added the ranges header for  [std::views](https://en.cppreference.com/w/cpp/header/ranges.html),
this fixes the error `no member named 'views' in namespace 'std'` on Gentoo Linux amd64 (musl/llvm).
<details>

```sh
[411/729] /usr/lib/llvm/21/bin/clang++ -DDATAROOTDIR=\"/usr/share\" -DGLSLANG_IS_SHARED_LIBRARY=1 -DHAS_EXECINFO -DHYPRLAND_VERSION=\"0.54.0\" -I/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/. -I/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/src -I/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/protocols -isystem /usr/include/uuid -isystem /usr/include/pango-1.0 -isystem /usr/include/cairo -isystem /usr/include/libpng16 -isystem /usr/include/fribidi -isystem /usr/include/harfbuzz -isystem /usr/include/freetype2 -isystem /usr/include/pixman-1 -isystem /usr/include/libdrm -isystem /usr/lib/libffi/include -isystem /usr/include/glib-2.0 -isystem /usr/lib/glib-2.0/include -isystem /usr/include/libmount -isystem /usr/include/blkid  -march=native -O3 -g0 -D_FORTIFY_SOURCE=3 -DNDEBUG -Wno-psabi -stdlib=libc++ -std=gnu++26 -O3 -Wall -Wextra -Wpedantic -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wno-gnu-zero-variadic-macro-arguments -Wno-narrowing -Wno-pointer-arith -Wno-clobbered -frtti -fmacro-prefix-map=/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/= -fno-lto -pthread -Wno-float-conversion -Wno-implicit-float-conversion -Wno-implicit-int-float-conversion -Wno-unknown-warning-option -Wno-unused-command-line-argument -MD -MT CMakeFiles/hyprland_lib.dir/src/desktop/history/WorkspaceHistoryTracker.cpp.o -MF CMakeFiles/hyprland_lib.dir/src/desktop/history/WorkspaceHistoryTracker.cpp.o.d @CMakeFiles/hyprland_lib.dir/src/desktop/history/WorkspaceHistoryTracker.cpp.o.modmap -o CMakeFiles/hyprland_lib.dir/src/desktop/history/WorkspaceHistoryTracker.cpp.o -c /var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/src/desktop/history/WorkspaceHistoryTracker.cpp
FAILED: [code=1] CMakeFiles/hyprland_lib.dir/src/desktop/history/WorkspaceHistoryTracker.cpp.o 
/usr/lib/llvm/21/bin/clang++ -DDATAROOTDIR=\"/usr/share\" -DGLSLANG_IS_SHARED_LIBRARY=1 -DHAS_EXECINFO -DHYPRLAND_VERSION=\"0.54.0\" -I/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/. -I/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/src -I/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/protocols -isystem /usr/include/uuid -isystem /usr/include/pango-1.0 -isystem /usr/include/cairo -isystem /usr/include/libpng16 -isystem /usr/include/fribidi -isystem /usr/include/harfbuzz -isystem /usr/include/freetype2 -isystem /usr/include/pixman-1 -isystem /usr/include/libdrm -isystem /usr/lib/libffi/include -isystem /usr/include/glib-2.0 -isystem /usr/lib/glib-2.0/include -isystem /usr/include/libmount -isystem /usr/include/blkid  -march=native -O3 -g0 -D_FORTIFY_SOURCE=3 -DNDEBUG -Wno-psabi -stdlib=libc++ -std=gnu++26 -O3 -Wall -Wextra -Wpedantic -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wno-gnu-zero-variadic-macro-arguments -Wno-narrowing -Wno-pointer-arith -Wno-clobbered -frtti -fmacro-prefix-map=/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/= -fno-lto -pthread -Wno-float-conversion -Wno-implicit-float-conversion -Wno-implicit-int-float-conversion -Wno-unknown-warning-option -Wno-unused-command-line-argument -MD -MT CMakeFiles/hyprland_lib.dir/src/desktop/history/WorkspaceHistoryTracker.cpp.o -MF CMakeFiles/hyprland_lib.dir/src/desktop/history/WorkspaceHistoryTracker.cpp.o.d @CMakeFiles/hyprland_lib.dir/src/desktop/history/WorkspaceHistoryTracker.cpp.o.modmap -o CMakeFiles/hyprland_lib.dir/src/desktop/history/WorkspaceHistoryTracker.cpp.o -c /var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/src/desktop/history/WorkspaceHistoryTracker.cpp
/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/src/desktop/history/WorkspaceHistoryTracker.cpp:56:42: error: no member named 'views' in namespace 'std'; did you mean 'std::ranges::views'?
   56 |         for (auto& mon : monitorCounts | std::views::drop(1)) {
      |                                          ^~~~~~~~~~
      |                                          std::ranges::views
/usr/include/c++/v1/__ranges/reverse_view.h:122:11: note: 'std::ranges::views' declared here
  122 | namespace views {
      |           ^
/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/src/desktop/history/WorkspaceHistoryTracker.cpp:56:54: error: no member named 'drop' in namespace 'std::ranges::views'
   56 |         for (auto& mon : monitorCounts | std::views::drop(1)) {
      |                                                      ^~~~
2 errors generated.
```
</details>



#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?

Ready for merging