### PR TITLE
cursor: stop re-copying whole shm cursor

### DIFF
--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -565,13 +565,14 @@ void CWLSurfaceResource::commitState(SSurfaceState& state) {
     m_current.updateFrom(state);
 
     if (m_current.buffer) {
+        const auto bufferDamage = m_current.accumulateBufferDamage();
+
         if (m_current.buffer->isSynchronous())
-            m_current.updateSynchronousTexture(lastTexture);
+            m_current.updateSynchronousTexture(lastTexture, bufferDamage);
 
         // if the surface is a cursor, update the shm buffer
-        // TODO: don't update the entire texture
         if (m_role->role() == SURFACE_ROLE_CURSOR)
-            updateCursorShm(m_current.accumulateBufferDamage());
+            updateCursorShm(bufferDamage);
     }
 
     if (m_current.texture)
@@ -704,24 +705,35 @@ void CWLSurfaceResource::updateCursorShm(CRegion damage) {
     }
 
     damage.intersect(CBox{0, 0, buf->size.x, buf->size.y});
+    if (damage.empty())
+        return;
 
     // no need to end, shm.
     auto [pixelData, fmt, bufLen] = buf->beginDataPtr(0);
+    const auto packedStride        = sc<size_t>(buf->size.x) * 4;
+    const auto packedLen           = packedStride * sc<size_t>(buf->size.y);
+    (void)fmt;
 
-    shmData.resize(bufLen);
+    shmData.resize(packedLen);
 
-    if (const auto RECTS = damage.getRects(); RECTS.size() == 1 && RECTS.at(0).x2 == buf->size.x && RECTS.at(0).y2 == buf->size.y)
-        memcpy(shmData.data(), pixelData, bufLen);
+    if (const auto RECTS = damage.getRects();
+        RECTS.size() == 1 && RECTS.at(0).x1 == 0 && RECTS.at(0).y1 == 0 && RECTS.at(0).x2 == buf->size.x && RECTS.at(0).y2 == buf->size.y &&
+        sc<size_t>(shmAttrs.stride) == packedStride &&
+        packedLen <= bufLen)
+        memcpy(shmData.data(), pixelData, packedLen);
     else {
-        damage.forEachRect([&pixelData, &shmData](const auto& box) {
+        damage.forEachRect([&](const auto& box) {
             for (auto y = box.y1; y < box.y2; ++y) {
-                // bpp is 32 INSALLAH
-                auto begin = 4 * box.y1 * (box.x2 - box.x1) + box.x1;
-                auto len   = 4 * (box.x2 - box.x1);
-                memcpy(shmData.data() + begin, pixelData + begin, len);
+                const auto srcBegin = sc<size_t>(y) * shmAttrs.stride + sc<size_t>(box.x1) * 4;
+                const auto dstBegin = sc<size_t>(y) * packedStride + sc<size_t>(box.x1) * 4;
+                const auto len      = sc<size_t>(box.x2 - box.x1) * 4;
+
+                memcpy(shmData.data() + dstBegin, pixelData + srcBegin, len);
             }
         });
     }
+
+    buf->endDataPtr();
 }
 
 void CWLSurfaceResource::presentFeedback(const Time::steady_tp& when, PHLMONITOR pMonitor, bool discarded) {

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -710,16 +710,14 @@ void CWLSurfaceResource::updateCursorShm(CRegion damage) {
 
     // no need to end, shm.
     auto [pixelData, fmt, bufLen] = buf->beginDataPtr(0);
-    const auto packedStride        = sc<size_t>(buf->size.x) * 4;
-    const auto packedLen           = packedStride * sc<size_t>(buf->size.y);
+    const auto packedStride       = sc<size_t>(buf->size.x) * 4;
+    const auto packedLen          = packedStride * sc<size_t>(buf->size.y);
     (void)fmt;
 
     shmData.resize(packedLen);
 
-    if (const auto RECTS = damage.getRects();
-        RECTS.size() == 1 && RECTS.at(0).x1 == 0 && RECTS.at(0).y1 == 0 && RECTS.at(0).x2 == buf->size.x && RECTS.at(0).y2 == buf->size.y &&
-        sc<size_t>(shmAttrs.stride) == packedStride &&
-        packedLen <= bufLen)
+    if (const auto RECTS = damage.getRects(); RECTS.size() == 1 && RECTS.at(0).x1 == 0 && RECTS.at(0).y1 == 0 && RECTS.at(0).x2 == buf->size.x && RECTS.at(0).y2 == buf->size.y &&
+        sc<size_t>(shmAttrs.stride) == packedStride && packedLen <= bufLen)
         memcpy(shmData.data(), pixelData, packedLen);
     else {
         damage.forEachRect([&](const auto& box) {

--- a/src/protocols/types/SurfaceState.cpp
+++ b/src/protocols/types/SurfaceState.cpp
@@ -35,14 +35,14 @@ CRegion SSurfaceState::accumulateBufferDamage() {
     return bufferDamage;
 }
 
-void SSurfaceState::updateSynchronousTexture(SP<Render::ITexture> lastTexture) {
+void SSurfaceState::updateSynchronousTexture(SP<Render::ITexture> lastTexture, const CRegion& damage) {
     auto [dataPtr, fmt, size] = buffer->beginDataPtr(0);
     if (dataPtr) {
         auto drmFmt = NFormatUtils::shmToDRM(fmt);
         auto stride = bufferSize.y ? size / bufferSize.y : 0;
         if (lastTexture && lastTexture->m_isSynchronous && lastTexture->m_size == bufferSize) {
             texture = lastTexture;
-            texture->update(drmFmt, dataPtr, stride, accumulateBufferDamage());
+            texture->update(drmFmt, dataPtr, stride, damage);
         } else
             texture = g_pHyprRenderer->createTexture(drmFmt, dataPtr, stride, bufferSize);
     }

--- a/src/protocols/types/SurfaceState.hpp
+++ b/src/protocols/types/SurfaceState.hpp
@@ -91,7 +91,7 @@ struct SSurfaceState {
 
     // texture of surface content, used for rendering
     SP<Render::ITexture> texture;
-    void                 updateSynchronousTexture(SP<Render::ITexture> lastTexture);
+    void                 updateSynchronousTexture(SP<Render::ITexture> lastTexture, const CRegion& damage);
 
     // fifo
     bool barrierSet    = false;


### PR DESCRIPTION

this reuses the same damage region for the shm texture update and the cpu-side cursor copy, so we only touch the bits that changed.

