### PR TITLE
refactor: extract window skip conditions into named booleans

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -389,14 +389,20 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
 
     // then render windows over fullscreen.
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->workspaceID() != pWorkspaceWindow->workspaceID() || !w->m_isFloating || (!w->m_createdOverFullscreen && !w->m_pinned) || (!w->m_isMapped && !w->m_fadingOut) ||
-            w->isFullscreen())
+        const bool shouldSkipWindow = w->workspaceID() != pWorkspaceWindow->workspaceID() || !w->m_isFloating || (!w->m_createdOverFullscreen && !w->m_pinned) ||
+            (!w->m_isMapped && !w->m_fadingOut) || w->isFullscreen();
+
+        if (shouldSkipWindow)
             continue;
 
-        if (w->m_monitor == pWorkspace->m_monitor && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace())
+        const bool mismatchedSpecialWorkspace = w->m_monitor == pWorkspace->m_monitor && pWorkspace->m_isSpecialWorkspace != w->onSpecialWorkspace();
+
+        if (mismatchedSpecialWorkspace)
             continue;
 
-        if (pWorkspace->m_isSpecialWorkspace && w->m_monitor != pWorkspace->m_monitor)
+        const bool specialWorkspaceOnDifferentMonitor = pWorkspace->m_isSpecialWorkspace && w->m_monitor != pWorkspace->m_monitor;
+
+        if (specialWorkspaceOnDifferentMonitor)
             continue; // special on another are rendered as a part of the base pass
 
         renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
@@ -412,7 +418,9 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
     windows.reserve(g_pCompositor->m_windows.size());
 
     for (auto const& w : g_pCompositor->m_windows) {
-        if (w->isHidden() || (!w->m_isMapped && !w->m_fadingOut))
+        const bool isNotRenderable = w->isHidden() || (!w->m_isMapped && !w->m_fadingOut);
+
+        if (isNotRenderable)
             continue;
 
         if (!shouldRenderWindow(w, pMonitor))


### PR DESCRIPTION
Refactors complex inline conditions into named boolean variables in Renderer.cpp
Improves readability and maintainability of render loop logic
Keeps expressions identical, preserving evaluation and control flow
No functional or behavioral changes
Testing:
-Built successfully without warnings
-Tested manually with multiple windows, workspace switching, fullscreen and floating scenarios
-Verified no visual regressions (no flicker, missing or leaked windows)
-Ran compositor from local build; no crashes or errors observed