### PR TITLE
layout/monocle: correct visible window when toggle layout

### DIFF
--- a/src/layout/algorithm/tiled/monocle/MonocleAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/monocle/MonocleAlgorithm.cpp
@@ -64,7 +64,10 @@ SP<SMonocleTargetData> CMonocleAlgorithm::dataFor(SP<ITarget> t) {
 void CMonocleAlgorithm::newTarget(SP<ITarget> target) {
     const auto DATA = m_targetDatas.emplace_back(makeShared<SMonocleTargetData>(target));
 
-    m_currentVisibleIndex = m_targetDatas.size() - 1;
+    const auto WINDOW = target->window();
+    if (m_targetDatas.size() == 1 || (WINDOW && WINDOW == Desktop::focusState()->window())) {
+        m_currentVisibleIndex = m_targetDatas.size() - 1;
+    }
 
     recalculate();
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Problem: when toggle layout to monocle, visible
window is always changed to the last one

Solution: only update `m_currentVisibleIndex` on "active" window

AI-assisted: Gemini 2.5 Pro
 
Fix https://github.com/hyprwm/Hyprland/discussions/13804

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?

ready
