### PR TITLE
compositor: fix floating input/visual z-order desync after fullscreen

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1292,6 +1292,8 @@ void CCompositor::changeWindowZOrder(PHLWINDOW pWindow, bool top) {
 
     if (top)
         pWindow->m_createdOverFullscreen = true;
+    else
+        pWindow->m_createdOverFullscreen = false;
 
     if (pWindow == (top ? m_windows.back() : m_windows.front()))
         return;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
<details>
<summary>EXTREMELY CONVOLUTED SETUP GO!!</summary>
OKAY SO, I have this setup where I use this script:

```shell
#!/usr/bin/env bash 

handle() {
  case $1 in
    activewindow*)
      window_class=$(echo "$1" | cut -d'>' -f3 | cut -d',' -f1)
      
      if [[ "$window_class" == "firefox" ]] then
        hyprctl dispatch alterzorder bottom,class:vesktop
      elif [[ "$window_class" == "vesktop" ]] then
        hyprctl dispatch alterzorder bottom,class:firefox
      fi
      ;;
  esac
}

socat -U - UNIX-CONNECT:"$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock" | while read -r line; do
  handle "$line"
done
```

Which will auto change z order based on which window is hovered. Basically when toggling fullscreen on and off on one of those programs the visual and actual z order get desynced because m_createdOverFullscreen isn't cleared when alterzorder bottom is called. It's easiest to see in the videos.

If you're wondering why I use bottom and not top, it's so it doesn't drown out other floating windows easily.
</details>

TLDR: Z order gets de-synced when fullscreening floating windows and then clicking on the window to get focus. This fixes that, and you can see the before and after below.

Before:

https://github.com/user-attachments/assets/85480101-9b3a-4ee0-a246-60221cfcfa68

After:

https://github.com/user-attachments/assets/bb80e646-a528-488e-834d-dc08844a9641

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Shouldn't break anything, as far as I can tell nothing else in the code calls alter z order bottom, only the dispatcher itself so it shouldn't have any weird consequences

#### Is it ready for merging, or does it need work?
Ready

