### PR TITLE
input: keep pointer focus on layer surfaces during keyboard refocus

### DIFF
--- a/hyprtester/plugin/src/main.cpp
+++ b/hyprtester/plugin/src/main.cpp
@@ -7,6 +7,7 @@
 #define private public
 #include <src/managers/input/InputManager.hpp>
 #include <src/managers/PointerManager.hpp>
+#include <src/managers/SeatManager.hpp>
 #include <src/managers/input/trackpad/TrackpadGestures.hpp>
 #include <src/helpers/Monitor.hpp>
 #include <src/desktop/rule/windowRule/WindowRuleEffectContainer.hpp>
@@ -420,6 +421,49 @@ static SDispatchResult checkLayerRule(std::string in) {
     return {};
 }
 
+static SDispatchResult checkPointerFocusLayer(std::string in) {
+    const auto POINTERSURF = g_pSeatManager->m_state.pointerFocus.lock();
+
+    if (!POINTERSURF)
+        return {.success = false, .error = "No pointer focus"};
+
+    const auto HLSURF = Desktop::View::CWLSurface::fromResource(POINTERSURF);
+    const auto VIEW   = HLSURF ? HLSURF->view() : nullptr;
+    const auto LAYER  = Desktop::View::CLayerSurface::fromView(VIEW);
+
+    if (!LAYER) {
+        const auto WINDOW = g_pCompositor->getWindowFromSurface(POINTERSURF);
+        if (WINDOW)
+            return {.success = false, .error = std::format("Pointer focus is a window surface with class '{}'", WINDOW->m_class)};
+
+        return {.success = false, .error = std::format("Pointer focus is not a layer surface, view type is {}", VIEW ? sc<int>(VIEW->type()) : -1)};
+    }
+
+    if (LAYER->m_namespace != in)
+        return {.success = false, .error = std::format("Pointer focus layer namespace is '{}', expected '{}'", LAYER->m_namespace, in)};
+
+    return {};
+}
+
+static SDispatchResult setPointerFocusLayer(std::string in) {
+    for (const auto& layer : g_pCompositor->m_layers) {
+        if (layer->m_namespace != in)
+            continue;
+
+        const auto SURFACE = layer->wlSurface() ? layer->wlSurface()->resource() : nullptr;
+        if (!SURFACE)
+            return {.success = false, .error = std::format("Layer '{}' has no surface", in)};
+
+        const auto LOCAL = layer->m_geometry.size() / 2.0;
+
+        g_pSeatManager->setPointerFocus(SURFACE, LOCAL);
+        g_pSeatManager->sendPointerMotion(Time::millis(Time::steadyNow()), LOCAL);
+        return {};
+    }
+
+    return {.success = false, .error = std::format("No layer with namespace '{}'", in)};
+}
+
 static SDispatchResult floatingFocusOnFullscreen(std::string in) {
     const auto PLASTWINDOW = Desktop::focusState()->window();
 
@@ -527,6 +571,14 @@ static int luaCheckLayerRule(lua_State* L) {
     return luaResult(L, ::checkLayerRule(""));
 }
 
+static int luaCheckPointerFocusLayer(lua_State* L) {
+    return luaResult(L, ::checkPointerFocusLayer(luaL_checkstring(L, 1)));
+}
+
+static int luaSetPointerFocusLayer(lua_State* L) {
+    return luaResult(L, ::setPointerFocusLayer(luaL_checkstring(L, 1)));
+}
+
 static int luaFloatingFocusOnFullscreen(lua_State* L) {
     return luaResult(L, ::floatingFocusOnFullscreen(""));
 }
@@ -554,6 +606,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     addLuaFn("check_window_rule", ::luaCheckWindowRule);
     addLuaFn("add_layer_rule", ::luaAddLayerRule);
     addLuaFn("check_layer_rule", ::luaCheckLayerRule);
+    addLuaFn("check_pointer_focus_layer", ::luaCheckPointerFocusLayer);
+    addLuaFn("set_pointer_focus_layer", ::luaSetPointerFocusLayer);
     addLuaFn("floating_focus_on_fullscreen", ::luaFloatingFocusOnFullscreen);
 
     // init mouse

--- a/hyprtester/src/tests/main/layer.cpp
+++ b/hyprtester/src/tests/main/layer.cpp
@@ -3,15 +3,16 @@
 #include "tests.hpp"
 #include "../../shared.hpp"
 #include "../../hyprctlCompat.hpp"
+#include <format>
 #include <hyprutils/os/Process.hpp>
 #include <hyprutils/memory/WeakPtr.hpp>
 
 using namespace Hyprutils::OS;
 using namespace Hyprutils::Memory;
 
-static bool spawnLayer(const std::string& namespace_) {
+static bool spawnLayer(const std::string& namespace_, const std::vector<std::string>& args = {}) {
     NLog::log("{}Spawning kitty layer {}", Colors::YELLOW, namespace_);
-    if (!Tests::spawnLayerKitty(namespace_)) {
+    if (!Tests::spawnLayerKitty(namespace_, args)) {
         NLog::log("{}Error: {} layer did not spawn", Colors::RED, namespace_);
         return false;
     }
@@ -32,4 +33,28 @@ TEST_CASE(plugin_layerrules) {
     EXPECT(spawnLayer("norule-layer"), true);
 
     OK(getFromSocket("/eval hl.plugin.test.check_layer_rule()"));
+}
+
+TEST_CASE(layerPointerFocusPreservedOnKeyboardRefocus) {
+    static constexpr const char* LAYER_NAMESPACE = "pointer-focus-layer";
+
+    OK(getFromSocket("/eval hl.config({ input = { follow_mouse = 0 } })"));
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = '1' })"));
+    ASSERT(!!Tests::spawnKitty("pointer_focus_ws1"), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = '2' })"));
+    ASSERT(!!Tests::spawnKitty("pointer_focus_ws2"), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = '1' })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:pointer_focus_ws1' })"));
+
+    ASSERT(spawnLayer(LAYER_NAMESPACE, {"--edge=top", "--layer=top", "--lines=48px", "--focus-policy=not-allowed"}), true);
+
+    OK(getFromSocket(std::format("/eval hl.plugin.test.set_pointer_focus_layer('{}')", LAYER_NAMESPACE)));
+    OK(getFromSocket(std::format("/eval hl.plugin.test.check_pointer_focus_layer('{}')", LAYER_NAMESPACE)));
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = '2' })"));
+    ASSERT_CONTAINS(getFromSocket("/activewindow"), "class: pointer_focus_ws2\n");
+    OK(getFromSocket(std::format("/eval hl.plugin.test.check_pointer_focus_layer('{}')", LAYER_NAMESPACE)));
 }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -176,6 +176,16 @@ void CInputManager::sendMotionEventsToFocused() {
     if (!Desktop::focusState()->surface() || isConstrained())
         return;
 
+    const auto POINTERSURF = g_pSeatManager->m_state.pointerFocus.lock();
+    if (POINTERSURF) {
+        const auto POINTERHLSURF = Desktop::View::CWLSurface::fromResource(POINTERSURF);
+
+        // Keep pointer focus on desktop components such as bars or popups that are
+        // currently under the cursor. Keyboard focus changes should not steal it.
+        if (POINTERHLSURF && (!POINTERHLSURF->view() || POINTERHLSURF->view()->type() != Desktop::View::VIEW_TYPE_WINDOW))
+            return;
+    }
+
     const auto SURF = Desktop::focusState()->surface();
 
     if (!SURF)


### PR DESCRIPTION
I use Hyprland with waybar. When I want to switch workspaces on waybar with the mouse wheel, only the first scroll works. After that, I need to move the mouse at least one pixel to make scrolling work again.

waybar config:
```json
  "hyprland/workspaces" : {
    "format": "{name}",
    "on-scroll-up": "hyprctl dispatch workspace e-1",
    "on-scroll-down": "hyprctl dispatch workspace e+1",
  },
```
hyprland:
```
input {
  follow_mouse = 0
}
```

#### Describe your PR, what does it fix/add?
Fix pointer focus being stolen from layer-shell surfaces like waybar when `input:follow_mouse = 0`.
                                                                    
Before this change, focusing a window on workspace switch could call `sendMotionEventsToFocused()` and move pointer focus from waybar to the newly focused window even if the cursor was still over the bar.

This change makes `sendMotionEventsToFocused()` keep the current pointer focus when it is already on a non-window surface (for example waybar or a popup), so keyboard focus can move to the workspace window while pointer focus stays on the bar under the cursor. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?
It's ready, I use patched version for a few days without any issues