### PR TITLE
refactor(layout): use enum-based layout IDs for layout matching

### DIFF
--- a/src/layout/supplementary/WorkspaceAlgoMatcher.cpp
+++ b/src/layout/supplementary/WorkspaceAlgoMatcher.cpp
@@ -151,8 +151,14 @@ void CWorkspaceAlgoMatcher::updateWorkspaceLayouts() {
         const auto type = &typeid(*TILED_ALGO.get());
 
         const auto it = m_algoIDs.find(type);
-        if (it != m_algoIDs.end() && it->second == layoutID)
-            continue;
+        if (it != m_algoIDs.end()) {
+            if (layoutID != LayoutID::UNKNOWN && it->second == layoutID)
+                continue;
+
+            // fallback for unknown layouts (plugins)
+            if (layoutID == LayoutID::UNKNOWN && m_algoNames.contains(type) && m_algoNames.at(type) == layoutStr)
+                continue;
+        }
 
         // needs a switchup
         ws->m_space->algorithm()->updateTiledAlgo(algoForNameTiled(layoutStr));

--- a/src/layout/supplementary/WorkspaceAlgoMatcher.cpp
+++ b/src/layout/supplementary/WorkspaceAlgoMatcher.cpp
@@ -19,6 +19,10 @@ static LayoutID layoutIDFromString(const std::string& s) {
         return LayoutID::DWINDLE;
     if (s == "master")
         return LayoutID::MASTER;
+    if (s == "scrolling")
+        return LayoutID::SCROLLING;
+    if (s == "monocle")
+        return LayoutID::MONOCLE;
     if (s == "floating")
         return LayoutID::FLOATING;
     return LayoutID::UNKNOWN;
@@ -57,8 +61,8 @@ CWorkspaceAlgoMatcher::CWorkspaceAlgoMatcher() {
     m_algoIDs = {
         {&typeid(Tiled::CDwindleAlgorithm), LayoutID::DWINDLE},
         {&typeid(Tiled::CMasterAlgorithm), LayoutID::MASTER},
-        {&typeid(Tiled::CScrollingAlgorithm), LayoutID::UNKNOWN},
-        {&typeid(Tiled::CMonocleAlgorithm), LayoutID::UNKNOWN},
+        {&typeid(Tiled::CScrollingAlgorithm), LayoutID::SCROLLING},
+        {&typeid(Tiled::CMonocleAlgorithm), LayoutID::MONOCLE},
         {&typeid(Floating::CDefaultFloatingAlgorithm), LayoutID::FLOATING},
     };
 }

--- a/src/layout/supplementary/WorkspaceAlgoMatcher.cpp
+++ b/src/layout/supplementary/WorkspaceAlgoMatcher.cpp
@@ -14,6 +14,16 @@
 
 #include "../../Compositor.hpp"
 
+static LayoutID layoutIDFromString(const std::string& s) {
+    if (s == "dwindle")
+        return LayoutID::DWINDLE;
+    if (s == "master")
+        return LayoutID::MASTER;
+    if (s == "floating")
+        return LayoutID::FLOATING;
+    return LayoutID::UNKNOWN;
+}
+
 using namespace Layout;
 using namespace Layout::Supplementary;
 
@@ -44,6 +54,13 @@ CWorkspaceAlgoMatcher::CWorkspaceAlgoMatcher() {
         {&typeid(Tiled::CMonocleAlgorithm), "monocle"},
         {&typeid(Floating::CDefaultFloatingAlgorithm), "default"},
     };
+    m_algoIDs = {
+        {&typeid(Tiled::CDwindleAlgorithm), LayoutID::DWINDLE},
+        {&typeid(Tiled::CMasterAlgorithm), LayoutID::MASTER},
+        {&typeid(Tiled::CScrollingAlgorithm), LayoutID::UNKNOWN},
+        {&typeid(Tiled::CMonocleAlgorithm), LayoutID::UNKNOWN},
+        {&typeid(Floating::CDefaultFloatingAlgorithm), LayoutID::FLOATING},
+    };
 }
 
 bool CWorkspaceAlgoMatcher::registerTiledAlgo(const std::string& name, const std::type_info* typeInfo, std::function<UP<ITiledAlgorithm>()>&& factory) {
@@ -52,6 +69,7 @@ bool CWorkspaceAlgoMatcher::registerTiledAlgo(const std::string& name, const std
 
     m_tiledAlgos.emplace(name, std::move(factory));
     m_algoNames.emplace(typeInfo, name);
+    m_algoIDs.emplace(typeInfo, layoutIDFromString(name));
 
     updateWorkspaceLayouts();
 
@@ -64,6 +82,7 @@ bool CWorkspaceAlgoMatcher::registerFloatingAlgo(const std::string& name, const 
 
     m_floatingAlgos.emplace(name, std::move(factory));
     m_algoNames.emplace(typeInfo, name);
+    m_algoIDs.emplace(typeInfo, layoutIDFromString(name));
 
     updateWorkspaceLayouts();
 
@@ -112,7 +131,7 @@ SP<CAlgorithm> CWorkspaceAlgoMatcher::createAlgorithmForWorkspace(PHLWORKSPACE w
 }
 
 void CWorkspaceAlgoMatcher::updateWorkspaceLayouts() {
-    // TODO: make this ID-based, string comparison is slow
+
     for (const auto& ws : g_pCompositor->getWorkspaces()) {
         if (!ws)
             continue;
@@ -122,13 +141,17 @@ void CWorkspaceAlgoMatcher::updateWorkspaceLayouts() {
         if (!TILED_ALGO)
             continue;
 
-        const auto LAYOUT_TO_USE = tiledAlgoForWorkspace(ws.lock());
+        const auto layoutStr = tiledAlgoForWorkspace(ws.lock());
+        const auto layoutID  = layoutIDFromString(layoutStr);
 
-        if (m_algoNames.contains(&typeid(*TILED_ALGO.get())) && m_algoNames.at(&typeid(*TILED_ALGO.get())) == LAYOUT_TO_USE)
+        const auto type = &typeid(*TILED_ALGO.get());
+
+        const auto it = m_algoIDs.find(type);
+        if (it != m_algoIDs.end() && it->second == layoutID)
             continue;
 
         // needs a switchup
-        ws->m_space->algorithm()->updateTiledAlgo(algoForNameTiled(LAYOUT_TO_USE));
+        ws->m_space->algorithm()->updateTiledAlgo(algoForNameTiled(layoutStr));
     }
 }
 

--- a/src/layout/supplementary/WorkspaceAlgoMatcher.hpp
+++ b/src/layout/supplementary/WorkspaceAlgoMatcher.hpp
@@ -3,9 +3,17 @@
 #include "../../desktop/DesktopTypes.hpp"
 
 #include <map>
+#include <unordered_map>
 #include <type_traits>
 #include <functional>
 #include <string>
+
+enum class LayoutID {
+    DWINDLE,
+    MASTER,
+    FLOATING,
+    UNKNOWN
+};
 
 namespace Layout {
     class CAlgorithm;
@@ -40,6 +48,7 @@ namespace Layout::Supplementary {
         std::map<std::string, std::function<UP<IFloatingAlgorithm>()>> m_floatingAlgos;
 
         std::map<const std::type_info*, std::string>                   m_algoNames;
+        std::unordered_map<const std::type_info*, LayoutID>            m_algoIDs;
     };
 
     const UP<CWorkspaceAlgoMatcher>& algoMatcher();

--- a/src/layout/supplementary/WorkspaceAlgoMatcher.hpp
+++ b/src/layout/supplementary/WorkspaceAlgoMatcher.hpp
@@ -11,6 +11,8 @@
 enum class LayoutID {
     DWINDLE,
     MASTER,
+    SCROLLING,
+    MONOCLE,
     FLOATING,
     UNKNOWN
 };


### PR DESCRIPTION
Replaces string comparisons in updateWorkspaceLayouts with enum-based ID matching.

Previously, layout matching relied on comparing strings retrieved from m_algoNames.
This change introduces a LayoutID enum along with a cached type → ID mapping (m_algoIDs),
allowing comparisons to be expressed using enums while preserving behavior.

This also resolves the existing TODO about replacing string-based layout matching with an ID-based approach.

The layout string is converted to LayoutID once per iteration, and the workspace loop
compares enum values when possible. For layouts not covered by the enum (e.g. plugin
layouts), the code falls back to the original string comparison to maintain compatibility.

Testing:
- Verified layout switching between "dwindle", "master", "scrolling", and "monocle" using hyprctl
- Tested with multiple windows to confirm correct layout behavior
- Tested workspace switching and config reload
- Verified plugin layouts (e.g. grid via hyprpm) work correctly with fallback
- No crashes or regressions observed during runtime

Performance:
A synthetic benchmark simulating updateWorkspaceLayouts shows that performance is similar
or slightly slower due to the added conversion and branching.

Since this function is not a hot path, the real-world impact is negligible.

The primary goal of this change is to simplify comparison logic and make layout matching
more explicit while preserving existing behavior.

Benchmark code:
https://gist.github.com/B2krobbery/7fc2aa6abc7d6f21f2f750493224d3f4