### PR TITLE
bell: play a sound by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,7 +268,8 @@ pkg_check_modules(
   gio-2.0
   re2
   muparser
-  lcms2)
+  lcms2
+  libcanberra)
 
 find_package(hyprwayland-scanner 0.3.10 REQUIRED)
 

--- a/example/hyprland.conf
+++ b/example/hyprland.conf
@@ -192,6 +192,9 @@ master {
 misc {
     force_default_wallpaper = -1 # Set to 0 or 1 to disable the anime mascot wallpapers
     disable_hyprland_logo = false # If true disables the random hyprland logo / anime girl background. :(
+    # bell_sound = default
+    # bell_sound = none
+    # bell_sound = ~/.config/hypr/bell.oga
 }
 
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -23,6 +23,7 @@
   hyprwayland-scanner,
   hyprwire,
   lcms2,
+  libcanberra,
   libGL,
   libdrm,
   libexecinfo,
@@ -183,6 +184,7 @@ customStdenv.mkDerivation (finalAttrs: {
       hyprutils
       hyprwire
       lcms2
+      libcanberra
       libdrm
       libgbm
       libGL

--- a/src/config/legacy/ConfigManager.cpp
+++ b/src/config/legacy/ConfigManager.cpp
@@ -498,6 +498,7 @@ CConfigManager::CConfigManager() {
     registerConfigVar("general:modal_parent_blocking", Hyprlang::INT{1});
     registerConfigVar("general:locale", {""});
 
+    registerConfigVar("misc:bell_sound", {"default"});
     registerConfigVar("misc:disable_hyprland_logo", Hyprlang::INT{0});
     registerConfigVar("misc:disable_splash_rendering", Hyprlang::INT{0});
     registerConfigVar("misc:col.splash", Hyprlang::INT{0x55ffffff});

--- a/src/config/supplementary/ConfigDescriptions.hpp
+++ b/src/config/supplementary/ConfigDescriptions.hpp
@@ -1261,6 +1261,12 @@ namespace Config::Supplementary {
             .data        = SConfigOptionDescription::SColorData{0xffffffff},
         },
         SConfigOptionDescription{
+            .value       = "misc:bell_sound",
+            .description = "`default`: play the system bell sound, `none`: stay silent locally but still emit the socket2 bell event, any other value: treat it as a sound file path.",
+            .type        = CONFIG_OPTION_STRING_SHORT,
+            .data        = SConfigOptionDescription::SStringData{"default"},
+        },
+        SConfigOptionDescription{
             .value       = "misc:font_family",
             .description = "Set the global default font to render the text including debug fps/notification, config error messages and etc., selected from system fonts.",
             .type        = CONFIG_OPTION_STRING_SHORT,

--- a/src/protocols/XDGBell.cpp
+++ b/src/protocols/XDGBell.cpp
@@ -4,6 +4,171 @@
 #include "../managers/EventManager.hpp"
 #include "../Compositor.hpp"
 
+#include "../config/ConfigManager.hpp"
+#include "../config/ConfigValue.hpp"
+#include "../helpers/MiscFunctions.hpp"
+#include "../debug/log/Logger.hpp"
+
+#include <canberra.h>
+
+#include <filesystem>
+#include <format>
+#include <string>
+
+namespace {
+    enum class eBellSoundMode : uint8_t {
+        DEFAULT,
+        NONE,
+        FILE,
+    };
+
+    struct SBellSoundConfig {
+        eBellSoundMode mode = eBellSoundMode::DEFAULT;
+        std::string    filePath;
+    };
+
+    SBellSoundConfig parseBellSoundConfigValue(const std::string& value) {
+        if (value.empty() || value == "default")
+            return {.mode = eBellSoundMode::DEFAULT};
+
+        if (value == "none")
+            return {.mode = eBellSoundMode::NONE};
+
+        const auto resolvedPath = absolutePath(value, Config::mgr()->getMainConfigPath());
+
+        std::error_code ec;
+        if (!std::filesystem::exists(resolvedPath, ec) || ec || !std::filesystem::is_regular_file(resolvedPath, ec) || ec) {
+            Log::logger->log(Log::WARN, "bell: configured custom sound path '{}' is invalid, falling back to default bell sound", resolvedPath);
+            return {.mode = eBellSoundMode::DEFAULT};
+        }
+
+        return {
+            .mode     = eBellSoundMode::FILE,
+            .filePath = resolvedPath,
+        };
+    }
+
+    SBellSoundConfig getBellSoundConfig() {
+        static auto PBELLSOUND = CConfigValue<std::string>("misc:bell_sound");
+        return parseBellSoundConfigValue(*PBELLSOUND);
+    }
+
+    std::string getBellEventData(wl_resource* surface) {
+        if (!surface)
+            return "";
+
+        const auto SURFACE = CWLSurfaceResource::fromResource(surface);
+        if (!SURFACE)
+            return "";
+
+        for (const auto& w : g_pCompositor->m_windows) {
+            if (!w->m_isMapped || w->m_isX11 || !w->m_xdgSurface || !w->wlSurface())
+                continue;
+
+            if (w->wlSurface()->resource() == SURFACE)
+                return std::format("{:x}", rc<uintptr_t>(w.get()));
+        }
+
+        return "";
+    }
+
+    void emitBellEvent(const std::string& data) {
+        g_pEventManager->postEvent(SHyprIPCEvent{
+            .event = "bell",
+            .data  = data,
+        });
+    }
+
+    class CBellAudioContext {
+      public:
+        ~CBellAudioContext() {
+            if (m_context)
+                ca_context_destroy(m_context);
+        }
+
+        ca_context* get() {
+            if (m_attemptedInit)
+                return m_context;
+
+            m_attemptedInit = true;
+
+            int result = ca_context_create(&m_context);
+            if (result < 0) {
+                Log::logger->log(Log::WARN, "bell: failed to create canberra context: {}", ca_strerror(result));
+                return nullptr;
+            }
+
+            result = ca_context_change_props(
+                m_context,
+                CA_PROP_APPLICATION_NAME, "Hyprland",
+                CA_PROP_APPLICATION_ID, "org.hyprland.Hyprland",
+                nullptr
+            );
+
+            if (result < 0)
+                Log::logger->log(Log::WARN, "bell: failed to set canberra context properties: {}", ca_strerror(result));
+
+            result = ca_context_open(m_context);
+            if (result < 0) {
+                Log::logger->log(Log::WARN, "bell: failed to open canberra context: {}", ca_strerror(result));
+                ca_context_destroy(m_context);
+                m_context = nullptr;
+                return nullptr;
+            }
+
+            return m_context;
+        }
+
+      private:
+        bool        m_attemptedInit = false;
+        ca_context* m_context       = nullptr;
+    };
+
+    CBellAudioContext& getAudioContext() {
+        static CBellAudioContext context;
+        return context;
+    }
+
+    void playBellSound(const SBellSoundConfig& config) {
+        if (config.mode == eBellSoundMode::NONE)
+            return;
+
+        auto* const CONTEXT = getAudioContext().get();
+        if (!CONTEXT)
+            return;
+
+        int result = 0;
+
+        if (config.mode == eBellSoundMode::DEFAULT) {
+            result = ca_context_play(
+                CONTEXT,
+                0,
+                CA_PROP_EVENT_ID, "bell-window-system",
+                CA_PROP_EVENT_DESCRIPTION, "Wayland system bell",
+                nullptr
+            );
+        } else {
+            result = ca_context_play(
+                CONTEXT,
+                0,
+                CA_PROP_MEDIA_FILENAME, config.filePath.c_str(),
+                CA_PROP_EVENT_DESCRIPTION, "Wayland system bell",
+                nullptr
+            );
+        }
+
+        if (result < 0)
+            Log::logger->log(Log::WARN, "bell: failed to play sound: {}", ca_strerror(result));
+    }
+
+    void handleBell(wl_resource* surface) {
+        const auto bellData = getBellEventData(surface);
+
+        emitBellEvent(bellData);
+        playBellSound(getBellSoundConfig());
+    }
+}
+
 CXDGSystemBellManagerResource::CXDGSystemBellManagerResource(UP<CXdgSystemBellV1>&& resource) : m_resource(std::move(resource)) {
     if UNLIKELY (!good())
         return;
@@ -12,41 +177,7 @@ CXDGSystemBellManagerResource::CXDGSystemBellManagerResource(UP<CXdgSystemBellV1
     m_resource->setOnDestroy([this](CXdgSystemBellV1* r) { PROTO::xdgBell->destroyResource(this); });
 
     m_resource->setRing([](CXdgSystemBellV1* r, wl_resource* surface) {
-        if (!surface) {
-            g_pEventManager->postEvent(SHyprIPCEvent{
-                .event = "bell",
-                .data  = "",
-            });
-            return;
-        }
-
-        const auto SURFACE = CWLSurfaceResource::fromResource(surface);
-
-        if (!SURFACE) {
-            g_pEventManager->postEvent(SHyprIPCEvent{
-                .event = "bell",
-                .data  = "",
-            });
-            return;
-        }
-
-        for (const auto& w : g_pCompositor->m_windows) {
-            if (!w->m_isMapped || w->m_isX11 || !w->m_xdgSurface || !w->wlSurface())
-                continue;
-
-            if (w->wlSurface()->resource() == SURFACE) {
-                g_pEventManager->postEvent(SHyprIPCEvent{
-                    .event = "bell",
-                    .data  = std::format("{:x}", rc<uintptr_t>(w.get())),
-                });
-                return;
-            }
-        }
-
-        g_pEventManager->postEvent(SHyprIPCEvent{
-            .event = "bell",
-            .data  = "",
-        });
+        handleBell(surface);
     });
 }
 
@@ -59,7 +190,9 @@ CXDGSystemBellProtocol::CXDGSystemBellProtocol(const wl_interface* iface, const 
 }
 
 void CXDGSystemBellProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = WP<CXDGSystemBellManagerResource>{m_managers.emplace_back(makeUnique<CXDGSystemBellManagerResource>(makeUnique<CXdgSystemBellV1>(client, ver, id)))};
+    const auto RESOURCE = WP<CXDGSystemBellManagerResource>{
+        m_managers.emplace_back(makeUnique<CXDGSystemBellManagerResource>(makeUnique<CXdgSystemBellV1>(client, ver, id)))
+    };
 
     if UNLIKELY (!RESOURCE->good()) {
         wl_client_post_no_memory(client);


### PR DESCRIPTION
## Summary

This makes `xdg-system-bell-v1` produce a local sound by default while keeping the existing socket2 `bell` event behavior intact.

It adds a new `misc:bell_sound` config option with support for:

- `default`: play the themed system bell sound locally
- `none`: stay silent locally but still emit the socket2 `bell` event
- custom path: play a user-provided sound file

## Changes

- add `misc:bell_sound` config registration
- add config description/documentation
- add example config entries
- keep emitting `bell` over socket2 as before
- play the default bell locally via `libcanberra`
- support custom sound file playback
- add `libcanberra` to CMake and Nix dependencies

## Testing

Tested with a local debug build in a separate headless Hyprland instance using a small `xdg-system-bell-v1` test client.

Verified:

- `misc:bell_sound = default` emits `bell>>` and plays a sound
- `misc:bell_sound = none` emits `bell>>` and stays silent

## Notes

- invalid custom sound paths currently fall back to the default bell sound
- this change is intended to address #10488
