### PR TITLE
input: avoid repeated weak_ptr::lock() and ensure consistent usage

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -255,9 +255,12 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
     if (PMONITOR->m_cursorZoom->value() != 1.f)
         g_pHyprRenderer->damageMonitor(PMONITOR);
 
-    bool skipFrameSchedule = PMONITOR->shouldSkipScheduleFrameOnMouseEvent();
+    bool       skipFrameSchedule = PMONITOR->shouldSkipScheduleFrameOnMouseEvent();
 
-    if (!PMONITOR->m_solitaryClient.lock() && g_pHyprRenderer->shouldRenderCursor() && g_pPointerManager->softwareLockedFor(PMONITOR->m_self.lock()) && !skipFrameSchedule)
+    const auto solitary = PMONITOR->m_solitaryClient.lock();
+    const auto self     = PMONITOR->m_self.lock();
+
+    if (!solitary && g_pHyprRenderer->shouldRenderCursor() && g_pPointerManager->softwareLockedFor(self) && !skipFrameSchedule)
         g_pCompositor->scheduleFrameForMonitor(PMONITOR, Aquamarine::IOutput::AQ_SCHEDULE_CURSOR_MOVE);
 
     // constraints
@@ -513,7 +516,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
     if (!foundSurface)
         foundSurface = g_pCompositor->vectorToLayerSurface(mouseCoords, &PMONITOR->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND], &surfaceCoords, &pFoundLayerSurface);
 
-    if (g_pPointerManager->softwareLockedFor(PMONITOR->m_self.lock()) > 0 && !skipFrameSchedule)
+    if (g_pPointerManager->softwareLockedFor(self) > 0 && !skipFrameSchedule)
         g_pCompositor->scheduleFrameForMonitor(Desktop::focusState()->monitor(), Aquamarine::IOutput::AQ_SCHEDULE_CURSOR_MOVE);
 
     // FIXME: This will be disabled during DnD operations because we do not exactly follow the spec


### PR DESCRIPTION
m_solitaryClient and m_self are weak_ptrs and were accessed via
multiple lock() calls within the same condition.

While unlikely, the underlying object could expire between calls,
leading to inconsistent evaluation. This change locks them once and
reuses the resulting shared_ptrs to ensure a consistent snapshot.
No functional changes intended.
Tested:
-Built Hyprland successfully
-Tested cursor movement across windows and monitors
-Tested rapid mouse movement and dragging operations
-Verified no regressions in cursor behavior or focus handling
-No crashes or performance issues observed