### PR TITLE
Reverse slide direction

### DIFF
--- a/src/config/legacy/ConfigManager.cpp
+++ b/src/config/legacy/ConfigManager.cpp
@@ -682,6 +682,7 @@ CConfigManager::CConfigManager() {
 
     registerConfigVar("animations:enabled", Hyprlang::INT{1});
     registerConfigVar("animations:workspace_wraparound", Hyprlang::INT{0});
+    registerConfigVar("animations:reverse_slide_direction", Hyprlang::INT{0});
 
     registerConfigVar("input:follow_mouse", Hyprlang::INT{1});
     registerConfigVar("input:follow_mouse_threshold", Hyprlang::FLOAT{0});

--- a/src/config/supplementary/ConfigDescriptions.hpp
+++ b/src/config/supplementary/ConfigDescriptions.hpp
@@ -501,6 +501,12 @@ namespace Config::Supplementary {
             .type        = CONFIG_OPTION_BOOL,
             .data        = SConfigOptionDescription::SBoolData{true},
         },
+        SConfigOptionDescription{
+            .value       = "animations:reverse_slide_direction",
+            .description = "reverses the direction of slide animations. Does not affect workspace wraparound animations.",
+            .type        = CONFIG_OPTION_BOOL,
+            .data        = SConfigOptionDescription::SBoolData{false},
+        },
 
         /*
      * input:

--- a/src/managers/animation/DesktopAnimationManager.cpp
+++ b/src/managers/animation/DesktopAnimationManager.cpp
@@ -249,8 +249,10 @@ void CDesktopAnimationManager::startAnimation(PHLWORKSPACE ws, eAnimationType ty
         ws->m_renderOffset->setConfig(Config::animationTree()->getAnimationPropertyConfig(ANIMNAME));
     }
     static auto PWORKSPACEGAP = CConfigValue<Hyprlang::INT>("general:gaps_workspaces");
+    static auto PREVERSESLIDE = CConfigValue<Hyprlang::INT>("animations:reverse_slide_direction");
     const auto  PMONITOR      = ws->m_monitor.lock();
     const auto  ANIMSTYLE     = style.value_or(ws->m_alpha->getStyle());
+    const auto  REVERSESLIDE  = *PREVERSESLIDE;
 
     float       movePerc = 100.f;
     // inverted for some reason. TODO: fix the cause
@@ -300,26 +302,38 @@ void CDesktopAnimationManager::startAnimation(PHLWORKSPACE ws, eAnimationType ty
         ws->m_renderOffset->setValueAndWarp(Vector2D(0, 0));
 
         if (vert) {
+            float yIn  = (left ? PMONITOR->m_size.y : -PMONITOR->m_size.y) * (movePerc / 100.f);
+            float yOut = (left ? -PMONITOR->m_size.y : PMONITOR->m_size.y) * (movePerc / 100.f);
+            if (REVERSESLIDE) {
+                yIn  = -yIn;
+                yOut = -yOut;
+            }
             if (IN) {
                 ws->m_alpha->setValueAndWarp(0.f);
-                ws->m_renderOffset->setValueAndWarp(Vector2D(0.0, (left ? PMONITOR->m_size.y : -PMONITOR->m_size.y) * (movePerc / 100.f)));
+                ws->m_renderOffset->setValueAndWarp(Vector2D(0.0, yIn));
                 *ws->m_alpha        = 1.f;
                 *ws->m_renderOffset = Vector2D(0, 0);
             } else {
                 ws->m_alpha->setValueAndWarp(1.f);
                 *ws->m_alpha        = 0.f;
-                *ws->m_renderOffset = Vector2D(0.0, (left ? -PMONITOR->m_size.y : PMONITOR->m_size.y) * (movePerc / 100.f));
+                *ws->m_renderOffset = Vector2D(0.0, yOut);
             }
         } else {
+            float xIn  = (left ? PMONITOR->m_size.x : -PMONITOR->m_size.x) * (movePerc / 100.f);
+            float xOut = (left ? -PMONITOR->m_size.x : PMONITOR->m_size.x) * (movePerc / 100.f);
+            if (REVERSESLIDE) {
+                xIn  = -xIn;
+                xOut = -xOut;
+            }
             if (IN) {
                 ws->m_alpha->setValueAndWarp(0.f);
-                ws->m_renderOffset->setValueAndWarp(Vector2D((left ? PMONITOR->m_size.x : -PMONITOR->m_size.x) * (movePerc / 100.f), 0.0));
+                ws->m_renderOffset->setValueAndWarp(Vector2D(xIn, 0.0));
                 *ws->m_alpha        = 1.f;
                 *ws->m_renderOffset = Vector2D(0, 0);
             } else {
                 ws->m_alpha->setValueAndWarp(1.f);
                 *ws->m_alpha        = 0.f;
-                *ws->m_renderOffset = Vector2D((left ? -PMONITOR->m_size.x : PMONITOR->m_size.x) * (movePerc / 100.f), 0.0);
+                *ws->m_renderOffset = Vector2D(xOut, 0.0);
             }
         }
     } else if (ANIMSTYLE == "fade") {
@@ -336,11 +350,17 @@ void CDesktopAnimationManager::startAnimation(PHLWORKSPACE ws, eAnimationType ty
         const auto YDISTANCE = (PMONITOR->m_size.y + *PWORKSPACEGAP) * (movePerc / 100.f);
         ws->m_alpha->setValueAndWarp(1.f); // fix a bug, if switching from fade -> slide.
 
+        float yIn  = (left ? YDISTANCE : -YDISTANCE);
+        float yOut = (left ? -YDISTANCE : YDISTANCE);
+        if (REVERSESLIDE) {
+            yIn  = -yIn;
+            yOut = -yOut;
+        }
         if (IN) {
-            ws->m_renderOffset->setValueAndWarp(Vector2D(0.0, left ? YDISTANCE : -YDISTANCE));
+            ws->m_renderOffset->setValueAndWarp(Vector2D(0.0, yIn));
             *ws->m_renderOffset = Vector2D(0, 0);
         } else {
-            *ws->m_renderOffset = Vector2D(0.0, left ? -YDISTANCE : YDISTANCE);
+            *ws->m_renderOffset = Vector2D(0.0, yOut);
         }
 
     } else {
@@ -348,11 +368,17 @@ void CDesktopAnimationManager::startAnimation(PHLWORKSPACE ws, eAnimationType ty
         const auto XDISTANCE = (PMONITOR->m_size.x + *PWORKSPACEGAP) * (movePerc / 100.f);
         ws->m_alpha->setValueAndWarp(1.f); // fix a bug, if switching from fade -> slide.
 
+        float xIn  = (left ? XDISTANCE : -XDISTANCE);
+        float xOut = (left ? -XDISTANCE : XDISTANCE);
+        if (REVERSESLIDE) {
+            xIn  = -xIn;
+            xOut = -xOut;
+        }
         if (IN) {
-            ws->m_renderOffset->setValueAndWarp(Vector2D(left ? XDISTANCE : -XDISTANCE, 0.0));
+            ws->m_renderOffset->setValueAndWarp(Vector2D(xIn, 0.0));
             *ws->m_renderOffset = Vector2D(0, 0);
         } else {
-            *ws->m_renderOffset = Vector2D(left ? -XDISTANCE : XDISTANCE, 0.0);
+            *ws->m_renderOffset = Vector2D(xOut, 0.0);
         }
     }
 

--- a/src/managers/input/UnifiedWorkspaceSwipeGesture.cpp
+++ b/src/managers/input/UnifiedWorkspaceSwipeGesture.cpp
@@ -41,10 +41,12 @@ void CUnifiedWorkspaceSwipeGesture::update(double delta) {
     static auto  PSWIPEFOREVER          = CConfigValue<Hyprlang::INT>("gestures:workspace_swipe_forever");
     static auto  PSWIPEUSER             = CConfigValue<Hyprlang::INT>("gestures:workspace_swipe_use_r");
     static auto  PWORKSPACEGAP          = CConfigValue<Hyprlang::INT>("general:gaps_workspaces");
+    static auto  PREVERSESLIDE          = CConfigValue<Hyprlang::INT>("animations:reverse_slide_direction");
 
     const auto   SWIPEDISTANCE = std::clamp(*PSWIPEDIST, sc<int64_t>(1LL), sc<int64_t>(UINT32_MAX));
     const auto   XDISTANCE     = m_monitor->m_size.x + *PWORKSPACEGAP;
     const auto   YDISTANCE     = m_monitor->m_size.y + *PWORKSPACEGAP;
+    const int    REVERSESLIDE  = *PREVERSESLIDE;
     const auto   ANIMSTYLE     = m_workspaceBegin->m_renderOffset->getStyle();
     const bool   VERTANIMS     = ANIMSTYLE == "slidevert" || ANIMSTYLE.starts_with("slidefadevert");
     const double d             = m_delta - delta;
@@ -88,10 +90,17 @@ void CUnifiedWorkspaceSwipeGesture::update(double delta) {
             if (*PSWIPENEW) {
                 g_pHyprRenderer->damageMonitor(m_monitor.lock());
 
-                if (VERTANIMS)
-                    m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(0.0, ((-m_delta) / SWIPEDISTANCE) * YDISTANCE));
-                else
-                    m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(((-m_delta) / SWIPEDISTANCE) * XDISTANCE, 0.0));
+                if (VERTANIMS) {
+                    float y = ((-m_delta) / SWIPEDISTANCE) * YDISTANCE;
+                    if (REVERSESLIDE)
+                        y = -y;
+                    m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(0.0, y));
+                } else {
+                    float x = ((-m_delta) / SWIPEDISTANCE) * XDISTANCE;
+                    if (REVERSESLIDE)
+                        x = -x;
+                    m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(x, 0.0));
+                }
 
                 m_workspaceBegin->updateWindowDecos();
                 return;
@@ -113,11 +122,23 @@ void CUnifiedWorkspaceSwipeGesture::update(double delta) {
         }
 
         if (VERTANIMS) {
-            PWORKSPACE->m_renderOffset->setValueAndWarp(Vector2D(0.0, ((-m_delta) / SWIPEDISTANCE) * YDISTANCE - YDISTANCE));
-            m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(0.0, ((-m_delta) / SWIPEDISTANCE) * YDISTANCE));
+            float y1 = ((-m_delta) / SWIPEDISTANCE) * YDISTANCE - YDISTANCE;
+            float y2 = ((-m_delta) / SWIPEDISTANCE) * YDISTANCE;
+            if (REVERSESLIDE) {
+                y1 = -y1;
+                y2 = -y2;
+            }
+            PWORKSPACE->m_renderOffset->setValueAndWarp(Vector2D(0.0, y1));
+            m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(0.0, y2));
         } else {
-            PWORKSPACE->m_renderOffset->setValueAndWarp(Vector2D(((-m_delta) / SWIPEDISTANCE) * XDISTANCE - XDISTANCE, 0.0));
-            m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(((-m_delta) / SWIPEDISTANCE) * XDISTANCE, 0.0));
+            float x1 = ((-m_delta) / SWIPEDISTANCE) * XDISTANCE - XDISTANCE;
+            float x2 = ((-m_delta) / SWIPEDISTANCE) * XDISTANCE;
+            if (REVERSESLIDE) {
+                x1 = -x1;
+                x2 = -x2;
+            }
+            PWORKSPACE->m_renderOffset->setValueAndWarp(Vector2D(x1, 0.0));
+            m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(x2, 0.0));
         }
 
         PWORKSPACE->updateWindowDecos();
@@ -128,10 +149,17 @@ void CUnifiedWorkspaceSwipeGesture::update(double delta) {
             if (*PSWIPENEW) {
                 g_pHyprRenderer->damageMonitor(m_monitor.lock());
 
-                if (VERTANIMS)
-                    m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(0.0, ((-m_delta) / SWIPEDISTANCE) * YDISTANCE));
-                else
-                    m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(((-m_delta) / SWIPEDISTANCE) * XDISTANCE, 0.0));
+                if (VERTANIMS) {
+                    float y = ((-m_delta) / SWIPEDISTANCE) * YDISTANCE;
+                    if (REVERSESLIDE)
+                        y = -y;
+                    m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(0.0, y));
+                } else {
+                    float x = ((-m_delta) / SWIPEDISTANCE) * XDISTANCE;
+                    if (REVERSESLIDE)
+                        x = -x;
+                    m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(x, 0.0));
+                }
 
                 m_workspaceBegin->updateWindowDecos();
                 return;
@@ -153,11 +181,23 @@ void CUnifiedWorkspaceSwipeGesture::update(double delta) {
         }
 
         if (VERTANIMS) {
-            PWORKSPACE->m_renderOffset->setValueAndWarp(Vector2D(0.0, ((-m_delta) / SWIPEDISTANCE) * YDISTANCE + YDISTANCE));
-            m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(0.0, ((-m_delta) / SWIPEDISTANCE) * YDISTANCE));
+            float y1 = ((-m_delta) / SWIPEDISTANCE) * YDISTANCE + YDISTANCE;
+            float y2 = ((-m_delta) / SWIPEDISTANCE) * YDISTANCE;
+            if (REVERSESLIDE) {
+                y1 = -y1;
+                y2 = -y2;
+            }
+            PWORKSPACE->m_renderOffset->setValueAndWarp(Vector2D(0.0, y1));
+            m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(0.0, y2));
         } else {
-            PWORKSPACE->m_renderOffset->setValueAndWarp(Vector2D(((-m_delta) / SWIPEDISTANCE) * XDISTANCE + XDISTANCE, 0.0));
-            m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(((-m_delta) / SWIPEDISTANCE) * XDISTANCE, 0.0));
+            float x1 = ((-m_delta) / SWIPEDISTANCE) * XDISTANCE + XDISTANCE;
+            float x2 = ((-m_delta) / SWIPEDISTANCE) * XDISTANCE;
+            if (REVERSESLIDE) {
+                x1 = -x1;
+                x2 = -x2;
+            }
+            PWORKSPACE->m_renderOffset->setValueAndWarp(Vector2D(x1, 0.0));
+            m_workspaceBegin->m_renderOffset->setValueAndWarp(Vector2D(x2, 0.0));
         }
 
         PWORKSPACE->updateWindowDecos();
@@ -185,8 +225,10 @@ void CUnifiedWorkspaceSwipeGesture::end() {
     static auto PSWIPENEW     = CConfigValue<Hyprlang::INT>("gestures:workspace_swipe_create_new");
     static auto PSWIPEUSER    = CConfigValue<Hyprlang::INT>("gestures:workspace_swipe_use_r");
     static auto PWORKSPACEGAP = CConfigValue<Hyprlang::INT>("general:gaps_workspaces");
+    static auto PREVERSESLIDE = CConfigValue<Hyprlang::INT>("animations:reverse_slide_direction");
     const auto  ANIMSTYLE     = m_workspaceBegin->m_renderOffset->getStyle();
     const bool  VERTANIMS     = ANIMSTYLE == "slidevert" || ANIMSTYLE.starts_with("slidefadevert");
+    const int   REVERSESLIDE  = *PREVERSESLIDE;
 
     // commit
     auto       workspaceIDLeft  = getWorkspaceIDNameFromString((*PSWIPEUSER ? "r-1" : "m-1")).id;
@@ -220,19 +262,32 @@ void CUnifiedWorkspaceSwipeGesture::end() {
                 // to left
 
                 if (PWORKSPACEL) {
-                    if (VERTANIMS)
-                        *PWORKSPACEL->m_renderOffset = Vector2D{0.0, -YDISTANCE};
-                    else
-                        *PWORKSPACEL->m_renderOffset = Vector2D{-XDISTANCE, 0.0};
+                    if (VERTANIMS) {
+                        float y = -YDISTANCE;
+                        if (REVERSESLIDE)
+                            y = -y;
+                        *PWORKSPACEL->m_renderOffset = Vector2D{0.0, y};
+                    } else {
+                        float x = -XDISTANCE;
+                        if (REVERSESLIDE)
+                            x = -x;
+                        *PWORKSPACEL->m_renderOffset = Vector2D{x, 0.0};
+                    }
                 }
             } else if (PWORKSPACER) {
                 // to right
-                if (VERTANIMS)
-                    *PWORKSPACER->m_renderOffset = Vector2D{0.0, YDISTANCE};
-                else
-                    *PWORKSPACER->m_renderOffset = Vector2D{XDISTANCE, 0.0};
+                if (VERTANIMS) {
+                    float y = YDISTANCE;
+                    if (REVERSESLIDE)
+                        y = -y;
+                    *PWORKSPACER->m_renderOffset = Vector2D{0.0, y};
+                } else {
+                    float x = XDISTANCE;
+                    if (REVERSESLIDE)
+                        x = -x;
+                    *PWORKSPACER->m_renderOffset = Vector2D{x, 0.0};
+                }
             }
-
             *m_workspaceBegin->m_renderOffset = Vector2D();
         }
 
@@ -252,10 +307,17 @@ void CUnifiedWorkspaceSwipeGesture::end() {
         PWORKSPACEL->m_alpha->setValueAndWarp(1.f);
 
         m_workspaceBegin->m_renderOffset->setValue(RENDEROFFSETMIDDLE);
-        if (VERTANIMS)
-            *m_workspaceBegin->m_renderOffset = Vector2D(0.0, YDISTANCE);
-        else
-            *m_workspaceBegin->m_renderOffset = Vector2D(XDISTANCE, 0.0);
+        if (VERTANIMS) {
+            float y = YDISTANCE;
+            if (REVERSESLIDE)
+                y = -y;
+            *m_workspaceBegin->m_renderOffset = Vector2D(0.0, y);
+        } else {
+            float x = XDISTANCE;
+            if (REVERSESLIDE)
+                x = -x;
+            *m_workspaceBegin->m_renderOffset = Vector2D(x, 0.0);
+        }
         m_workspaceBegin->m_alpha->setValueAndWarp(1.f);
 
         g_pInputManager->unconstrainMouse();
@@ -278,10 +340,17 @@ void CUnifiedWorkspaceSwipeGesture::end() {
         PWORKSPACER->m_alpha->setValueAndWarp(1.f);
 
         m_workspaceBegin->m_renderOffset->setValue(RENDEROFFSETMIDDLE);
-        if (VERTANIMS)
-            *m_workspaceBegin->m_renderOffset = Vector2D(0.0, -YDISTANCE);
-        else
-            *m_workspaceBegin->m_renderOffset = Vector2D(-XDISTANCE, 0.0);
+        if (VERTANIMS) {
+            float y = -YDISTANCE;
+            if (REVERSESLIDE)
+                y = -y;
+            *m_workspaceBegin->m_renderOffset = Vector2D(0.0, y);
+        } else {
+            float x = -XDISTANCE;
+            if (REVERSESLIDE)
+                x = -x;
+            *m_workspaceBegin->m_renderOffset = Vector2D(x, 0.0);
+        }
         m_workspaceBegin->m_alpha->setValueAndWarp(1.f);
 
         g_pInputManager->unconstrainMouse();


### PR DESCRIPTION
Hello,

This is my first contribution to the project, so hopefully everything is in check! Overall, I'm very new to the OSS space. I read the PR guidelines and tried to follow them appropriately.

#### Describe your PR, what does it fix/add?

Previously, the slide animation direction was fixed. This meant that with slidevert animation, the "first" workspace always felt to be at the top of the stack. Alternatively, in regular slide, the "first" workspace always felt as if it was the most left workspace.

For me, this created confusion with the slidevert animation, as mentally for me, the first workspace is the lowest in the stack. So I decided to create a setting for reversing the slide direction to allow for new options. I also thought that this was a great addition to the vast configurability of Hyprland.

So instead of simply requesting for the feature, I thought it's better to create it and share it with others by including a PR.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I'm new to the project, so my understanding of the project code base may not be the best. By my understanding, the feature should not break compatibility, nor did I find any bugs during my testing. 

#### Is it ready for merging, or does it need work?

The feature should be ready for merging.