### PR TITLE
Fix duplicate entry in .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -112,7 +112,6 @@ Checks: >
   bugprone-*,
   -bugprone-easily-swappable-parameters,
   -bugprone-forward-declararion-namespace,
-  -bugprone-forward-declararion-namespace,
   -bugprone-macro-parentheses,
   -bugprone-narrowing-conversions,
   -bugprone-branch-clone,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,7 +9,6 @@ WarningsAsErrors: >
   -bugprone-unused-local-non-trivial-variable,
   -bugprone-easily-swappable-parameters,
   -bugprone-forward-declararion-namespace,
-  -bugprone-forward-declararion-namespace,
   -bugprone-macro-parentheses,
   -bugprone-narrowing-conversions,
   -bugprone-branch-clone,


### PR DESCRIPTION
Removed duplicate entry for 'bugprone-forward-declararion-namespace'.

<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

-bugprone-forward-declararion-namespace was mentioned twice in clang-tidy so just a small cleanup


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

nope

#### Is it ready for merging, or does it need work?

LGTM :)
