### PR TITLE
fix: add path for lib64 pkgconfig for version-checking

### DIFF
--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -942,7 +942,7 @@ std::string deviceNameToInternalString(const std::string& in) {
     return result | std::ranges::to<std::string>();
 }
 
-static const std::vector<const char*> PKGCONF_PATHS = {"/usr/lib/pkgconfig", "/usr/local/lib/pkgconfig"};
+static const std::vector<const char*> PKGCONF_PATHS = {"/usr/lib/pkgconfig", "/usr/local/lib/pkgconfig", "/usr/lib64/pkgconfig"};
 
 //
 std::string getSystemLibraryVersion(const std::string& name) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fedora Linux uses `/usr/lib64` for 64-bit shared libraries. Because of that the pkgconfig dir on Fedora is `/usr/lib64/pkgconfig`.

This fixes `hyprctl version` from:
```bash
Libraries:
Hyprgraphics: built against 0.5.0, system has unknown
Hyprutils: built against 0.12.0, system has unknown
Hyprcursor: built against 0.1.13, system has unknown
Hyprlang: built against 0.6.8, system has unknown
Aquamarine: built against 0.10.0, system has unknown
```
to
```bash
Libraries:
Hyprgraphics: built against 0.5.1, system has 0.5.1
Hyprutils: built against 0.12.0, system has 0.12.0
Hyprcursor: built against 0.1.13, system has 0.1.13
Hyprlang: built against 0.6.8, system has 0.6.8
Aquamarine: built against 0.10.0, system has 0.10.0
```


#### Is it ready for merging, or does it need work?
Ready

