### PR TITLE
X11-apps scaling per workspace while having force_zero_scaling = true

### DIFF
--- a/src/config/legacy/ConfigManager.cpp
+++ b/src/config/legacy/ConfigManager.cpp
@@ -1282,6 +1282,21 @@ void CConfigManager::postConfigReload(const Hyprlang::CParseResult& result) {
             m->m_activeWorkspace->m_space->recalculate();
     }
 
+    // refresh per-workspace X11 scale overrides from rules, then reconfigure X11 windows
+    for (auto const& wsRef : g_pCompositor->getWorkspaces()) {
+        const auto ws = wsRef.lock();
+        if (!ws || ws->inert())
+            continue;
+        const auto RULE = Config::workspaceRuleMgr()->getWorkspaceRuleFor(ws);
+        ws->m_xwaylandTargetScale = RULE.has_value() ? RULE->m_xwaylandScale.value_or(0.f) : 0.f;
+    }
+    for (auto const& w : g_pCompositor->m_windows) {
+        if (!w->m_isX11 || !w->m_isMapped || w->isHidden())
+            continue;
+        w->updateX11SurfaceScale();
+        w->sendWindowSize(true);
+    }
+
     // Update the keyboard layout to the cfg'd one if this is not the first launch
     if (!m_isFirstLaunch) {
         g_pInputManager->setKeyboardLayout();
@@ -2035,6 +2050,19 @@ std::optional<std::string> CConfigManager::handleWorkspaceRules(const std::strin
         } else if ((delim = rule.find("animation:")) != std::string::npos) {
             std::string animationStyle = rule.substr(delim + 10);
             wsRule.m_animationStyle    = std::move(animationStyle);
+        } else if ((delim = rule.find("xwaylandscale:")) != std::string::npos) {
+            static auto PXWLFORCESCALEZERO = CConfigValue<Hyprlang::INT>("xwayland:force_zero_scaling");
+            if (!*PXWLFORCESCALEZERO)
+                Log::logger->log(Log::WARN, "workspace rule xwaylandscale: has no effect without xwayland:force_zero_scaling = true");
+            try {
+                float s = std::stof(rule.substr(delim + 14));
+                if (s >= 0.25f)
+                    wsRule.m_xwaylandScale = s;
+                else {
+                    Log::logger->log(Log::ERR, "Invalid workspace rule xwaylandscale: {}, must be >= 0.25", s);
+                    return "Invalid workspace rule xwaylandscale: " + rule.substr(delim + 14);
+                }
+            } catch (...) { return "Error parsing workspace rule xwaylandscale: " + rule.substr(delim + 14); }
         }
 
         return {};

--- a/src/config/shared/workspace/WorkspaceRule.cpp
+++ b/src/config/shared/workspace/WorkspaceRule.cpp
@@ -45,4 +45,6 @@ void CWorkspaceRule::mergeLeft(const CWorkspaceRule& other) {
     }
     if (other.m_animationStyle.has_value())
         m_animationStyle = other.m_animationStyle;
+    if (other.m_xwaylandScale.has_value())
+        m_xwaylandScale = other.m_xwaylandScale;
 }

--- a/src/config/shared/workspace/WorkspaceRule.hpp
+++ b/src/config/shared/workspace/WorkspaceRule.hpp
@@ -39,6 +39,7 @@ namespace Config {
         std::optional<std::string>         m_onCreatedEmptyRunCmd;
         std::optional<std::string>         m_defaultName;
         std::optional<std::string>         m_layout;
+        std::optional<float>               m_xwaylandScale;
         std::map<std::string, std::string> m_layoutopts;
         std::optional<std::string>         m_animationStyle;
     };

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -511,13 +511,15 @@ static std::string getWorkspaceRuleData(const Config::CWorkspaceRule& r, eHyprCt
         const std::string rounding    = sc<bool>(r.m_noRounding) ? std::format(",\n    \"rounding\": {}", boolToString(!r.m_noRounding.value())) : "";
         const std::string decorate    = sc<bool>(r.m_decorate) ? std::format(",\n    \"decorate\": {}", boolToString(r.m_decorate.value())) : "";
         const std::string shadow      = sc<bool>(r.m_noShadow) ? std::format(",\n    \"shadow\": {}", boolToString(!r.m_noShadow.value())) : "";
-        const std::string defaultName = r.m_defaultName.has_value() ? std::format(",\n    \"defaultName\": \"{}\"", escapeJSONStrings(r.m_defaultName.value())) : "";
+        const std::string defaultName    = r.m_defaultName.has_value() ? std::format(",\n    \"defaultName\": \"{}\"", escapeJSONStrings(r.m_defaultName.value())) : "";
+        const std::string xwaylandScale = r.m_xwaylandScale.has_value() ? std::format(",\n    \"xwaylandScale\": {:.2f}", r.m_xwaylandScale.value()) : "";
 
         std::string       result =
             std::format(R"#({{
-    "workspaceString": "{}"{}{}{}{}{}{}{}{}{}{}{}
+    "workspaceString": "{}"{}{}{}{}{}{}{}{}{}{}{}{}
 }})#",
-                        escapeJSONStrings(r.m_workspaceString), monitor, default_, persistent, gapsIn, gapsOut, borderSize, border, rounding, decorate, shadow, defaultName);
+                        escapeJSONStrings(r.m_workspaceString), monitor, default_, persistent, gapsIn, gapsOut, borderSize, border, rounding, decorate, shadow, defaultName,
+                        xwaylandScale);
 
         return result;
     } else {
@@ -537,10 +539,11 @@ static std::string getWorkspaceRuleData(const Config::CWorkspaceRule& r, eHyprCt
         const std::string rounding    = std::format("\trounding: {}\n", sc<bool>(r.m_noRounding) ? boolToString(!r.m_noRounding.value()) : "<unset>");
         const std::string decorate    = std::format("\tdecorate: {}\n", sc<bool>(r.m_decorate) ? boolToString(r.m_decorate.value()) : "<unset>");
         const std::string shadow      = std::format("\tshadow: {}\n", sc<bool>(r.m_noShadow) ? boolToString(!r.m_noShadow.value()) : "<unset>");
-        const std::string defaultName = std::format("\tdefaultName: {}\n", r.m_defaultName.value_or("<unset>"));
+        const std::string defaultName    = std::format("\tdefaultName: {}\n", r.m_defaultName.value_or("<unset>"));
+        const std::string xwaylandScale = std::format("\txwaylandScale: {}\n", r.m_xwaylandScale.has_value() ? std::format("{:.2f}", r.m_xwaylandScale.value()) : "<unset>");
 
-        std::string result = std::format("Workspace rule {}:\n{}{}{}{}{}{}{}{}{}{}{}\n", escapeJSONStrings(r.m_workspaceString), monitor, default_, persistent, gapsIn, gapsOut,
-                                         borderSize, border, rounding, decorate, shadow, defaultName);
+        std::string result = std::format("Workspace rule {}:\n{}{}{}{}{}{}{}{}{}{}{}{}\n", escapeJSONStrings(r.m_workspaceString), monitor, default_, persistent, gapsIn, gapsOut,
+                                         borderSize, border, rounding, decorate, shadow, defaultName, xwaylandScale);
 
         return result;
     }

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -54,6 +54,9 @@ void CWorkspace::init(PHLWORKSPACE self) {
     const auto WORKSPACERULE = Config::workspaceRuleMgr()->getWorkspaceRuleFor(self).value_or(Config::CWorkspaceRule{});
     setPersistent(WORKSPACERULE.m_isPersistent);
 
+    if (WORKSPACERULE.m_xwaylandScale.has_value())
+        m_xwaylandTargetScale = WORKSPACERULE.m_xwaylandScale.value();
+
     if (self->m_wasCreatedEmpty)
         if (auto cmd = WORKSPACERULE.m_onCreatedEmptyRunCmd)
             Config::Supplementary::executor()->spawnWithRules(*cmd, self);
@@ -546,4 +549,10 @@ void CWorkspace::setPersistent(bool persistent) {
 
 bool CWorkspace::isPersistent() {
     return m_persistent;
+}
+
+float CWorkspace::resolveScale(float targetScale, float monitorBaseScale, float monitorDefaultScale) {
+    if (targetScale > 0.f)
+        return targetScale;
+    return monitorBaseScale > 0.1f ? monitorBaseScale : monitorDefaultScale;
 }

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -58,6 +58,11 @@ class CWorkspace {
     bool m_defaultFloating = false;
     bool m_defaultPseudo   = false;
 
+    // per-workspace X11 scale override. 0 means "no override, use monitor base scale".
+    // Only applied to XWayland windows under force_zero_scaling; Wayland clients are untouched.
+    float        m_xwaylandTargetScale = 0.f;
+    static float resolveScale(float targetScale, float monitorBaseScale, float monitorDefaultScale);
+
     // last monitor (used on reconnect)
     std::string m_lastMonitor = "";
 

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -501,6 +501,17 @@ void CWindow::moveToWorkspace(PHLWORKSPACE pWorkspace) {
 
     m_workspace = pWorkspace;
 
+    // If this is an X11 window and either the old or new workspace has a per-workspace
+    // scale override, reconfigure the X11 surface with the new effective size.
+    if (m_isX11) {
+        const bool OLD_HAD_SCALE = OLDWORKSPACE && OLDWORKSPACE->m_xwaylandTargetScale > 0.f;
+        const bool NEW_HAS_SCALE = pWorkspace && pWorkspace->m_xwaylandTargetScale > 0.f;
+        if (OLD_HAD_SCALE || NEW_HAS_SCALE) {
+            updateX11SurfaceScale();
+            sendWindowSize(true);
+        }
+    }
+
     setAnimationsToMove();
 
     g_pCompositor->updateAllWindowsAnimatedDecorationValues();
@@ -1354,7 +1365,7 @@ Vector2D CWindow::realToReportSize() {
 
     if (*PXWLFORCESCALEZERO && PMONITOR)
         // Keep X11 configure sizes integral to avoid truncation (e.g. 2879.999 -> 2879) later in xcb.
-        return (REPORTSIZE * PMONITOR->m_scale).round();
+        return (REPORTSIZE * effectiveX11Scale()).round();
 
     return REPORTSIZE;
 }
@@ -1371,7 +1382,7 @@ Vector2D CWindow::xwaylandSizeToReal(Vector2D size) {
 
     const auto  PMONITOR = m_monitor.lock();
     const auto  SIZE     = size.clamp(Vector2D{1, 1}, Math::VECTOR2D_MAX);
-    const auto  SCALE    = *PXWLFORCESCALEZERO && PMONITOR ? PMONITOR->m_scale : 1.0f;
+    const auto  SCALE = *PXWLFORCESCALEZERO ? effectiveX11Scale() : 1.0f;
 
     return SIZE / SCALE;
 }
@@ -1384,10 +1395,34 @@ void CWindow::updateX11SurfaceScale() {
     static auto PXWLFORCESCALEZERO = CConfigValue<Hyprlang::INT>("xwayland:force_zero_scaling");
 
     m_X11SurfaceScaledBy = 1.0f;
-    if (m_isX11 && *PXWLFORCESCALEZERO) {
-        if (const auto PMONITOR = m_monitor.lock(); PMONITOR)
-            m_X11SurfaceScaledBy = PMONITOR->m_scale;
-    }
+    if (m_isX11 && *PXWLFORCESCALEZERO && m_monitor.lock())
+        m_X11SurfaceScaledBy = effectiveX11Scale();
+}
+
+float CWindow::effectiveX11Scale() {
+    static auto PXWLFORCESCALEZERO = CConfigValue<Hyprlang::INT>("xwayland:force_zero_scaling");
+
+    const auto  PMONITOR = m_monitor.lock();
+    if (!PMONITOR)
+        return 1.0f;
+
+    // Without force_zero_scaling the normal m_scale path applies — no workspace adjustment.
+    if (!*PXWLFORCESCALEZERO)
+        return PMONITOR->m_scale;
+
+    const float BASE = CWorkspace::resolveScale(0.f, PMONITOR->m_setScale, PMONITOR->getDefaultScale());
+
+    // Per-workspace X11 scale only applies under force_zero_scaling, and only when the
+    // workspace has an xwaylandscale: rule. Outside of those cases we fall back to the monitor base.
+    const auto PWORKSPACE = m_workspace;
+    if (!PWORKSPACE || PWORKSPACE->m_xwaylandTargetScale <= 0.f)
+        return BASE;
+
+    // Derivation: normally an X11 window is configured with logical_size * BASE pixels
+    // and gets a 1:1 pixel mapping on screen. To make it appear (targetScale / BASE)
+    // times larger, we configure it with fewer pixels: logical_size * BASE / ratio,
+    // where ratio = targetScale / BASE. This simplifies to logical_size * BASE^2 / target.
+    return BASE * BASE / PWORKSPACE->m_xwaylandTargetScale;
 }
 
 void CWindow::sendWindowSize(bool force) {

--- a/src/desktop/view/Window.hpp
+++ b/src/desktop/view/Window.hpp
@@ -343,6 +343,12 @@ namespace Desktop::View {
         Vector2D                   xwaylandSizeToReal(Vector2D size);
         Vector2D                   xwaylandPositionToReal(Vector2D size);
         void                       updateX11SurfaceScale();
+        // Effective X11 scale factor for this window under force_zero_scaling.
+        // Normally equals the monitor's base scale. When the window's workspace has an
+        // xwaylandscale: rule, returns (baseScale^2 / workspaceTargetScale), which causes
+        // the X11 surface to be configured with fewer pixels and subsequently upscaled by
+        // the renderer — making X11 content appear larger without touching m_scale.
+        float                      effectiveX11Scale();
         void                       sendWindowSize(bool force = false);
         NContentType::eContentType getContentType();
         void                       setContentType(NContentType::eContentType contentType);

--- a/tests/desktop/WorkspaceScale.cpp
+++ b/tests/desktop/WorkspaceScale.cpp
@@ -1,0 +1,100 @@
+#include <desktop/Workspace.hpp>
+#include <config/shared/workspace/WorkspaceRule.hpp>
+
+#include <gtest/gtest.h>
+
+// CWorkspace::resolveScale — pure scale fallback logic.
+
+TEST(WorkspaceScale, ResolveScalePrefersTargetWhenSet) {
+    EXPECT_FLOAT_EQ(CWorkspace::resolveScale(2.0f, 1.0f, 1.5f), 2.0f);
+    EXPECT_FLOAT_EQ(CWorkspace::resolveScale(1.25f, 2.0f, 1.0f), 1.25f);
+}
+
+TEST(WorkspaceScale, ResolveScaleFallsBackToBaseWhenNoTarget) {
+    EXPECT_FLOAT_EQ(CWorkspace::resolveScale(0.0f, 1.6666f, 1.0f), 1.6666f);
+    EXPECT_FLOAT_EQ(CWorkspace::resolveScale(0.0f, 2.0f, 1.5f), 2.0f);
+}
+
+TEST(WorkspaceScale, ResolveScaleFallsBackToDefaultWhenBaseInvalid) {
+    EXPECT_FLOAT_EQ(CWorkspace::resolveScale(0.0f, 0.0f, 1.5f), 1.5f);
+    EXPECT_FLOAT_EQ(CWorkspace::resolveScale(0.0f, 0.05f, 2.0f), 2.0f);
+}
+
+TEST(WorkspaceScale, ResolveScaleNegativeTargetTreatedAsUnset) {
+    EXPECT_FLOAT_EQ(CWorkspace::resolveScale(-1.0f, 1.5f, 1.0f), 1.5f);
+}
+
+// CWorkspaceRule::mergeLeft — xwaylandScale merge semantics.
+
+TEST(WorkspaceScale, MergeRulesScaleOverride) {
+    Config::CWorkspaceRule a;
+    a.m_xwaylandScale = 1.5f;
+    Config::CWorkspaceRule b;
+    b.m_xwaylandScale = 2.0f;
+
+    a.mergeLeft(b);
+    ASSERT_TRUE(a.m_xwaylandScale.has_value());
+    EXPECT_FLOAT_EQ(a.m_xwaylandScale.value(), 2.0f);
+}
+
+TEST(WorkspaceScale, MergeRulesScalePreservedWhenOtherUnset) {
+    Config::CWorkspaceRule a;
+    a.m_xwaylandScale = 1.5f;
+    Config::CWorkspaceRule b;
+
+    a.mergeLeft(b);
+    ASSERT_TRUE(a.m_xwaylandScale.has_value());
+    EXPECT_FLOAT_EQ(a.m_xwaylandScale.value(), 1.5f);
+}
+
+TEST(WorkspaceScale, MergeRulesScaleUnsetWhenBothUnset) {
+    Config::CWorkspaceRule a;
+    Config::CWorkspaceRule b;
+
+    a.mergeLeft(b);
+    EXPECT_FALSE(a.m_xwaylandScale.has_value());
+}
+
+TEST(WorkspaceScale, MergeRulesScaleSetFromOtherOnly) {
+    Config::CWorkspaceRule a;
+    Config::CWorkspaceRule b;
+    b.m_xwaylandScale = 1.75f;
+
+    a.mergeLeft(b);
+    ASSERT_TRUE(a.m_xwaylandScale.has_value());
+    EXPECT_FLOAT_EQ(a.m_xwaylandScale.value(), 1.75f);
+}
+
+// Pure formula test for the X11 effective scale logic in CWindow::effectiveX11Scale.
+
+static float effectiveX11ScaleFormula(float base, float workspaceTargetScale) {
+    if (workspaceTargetScale <= 0.f)
+        return base;
+    return base * base / workspaceTargetScale;
+}
+
+TEST(WorkspaceScale, X11FormulaNoOverrideReturnsBase) {
+    EXPECT_FLOAT_EQ(effectiveX11ScaleFormula(1.0f, 0.0f), 1.0f);
+    EXPECT_FLOAT_EQ(effectiveX11ScaleFormula(1.6666f, 0.0f), 1.6666f);
+    EXPECT_FLOAT_EQ(effectiveX11ScaleFormula(2.0f, -1.0f), 2.0f);
+}
+
+TEST(WorkspaceScale, X11FormulaProducesUpscaleRatio) {
+    const float base   = 1.6666f;
+    const float target = 3.0f;
+    const float eff    = effectiveX11ScaleFormula(base, target);
+    const float logicalPixels  = 4608.f;
+    const float x11Pixels      = logicalPixels * eff;
+    const float monitorPx      = logicalPixels * base;
+    const float upscaleApplied = monitorPx / x11Pixels;
+    EXPECT_NEAR(upscaleApplied, target / base, 1e-4f);
+}
+
+TEST(WorkspaceScale, X11FormulaBase1Target2Gives0Point5) {
+    EXPECT_FLOAT_EQ(effectiveX11ScaleFormula(1.0f, 2.0f), 0.5f);
+}
+
+TEST(WorkspaceScale, X11FormulaIdentityWhenTargetEqualsBase) {
+    EXPECT_FLOAT_EQ(effectiveX11ScaleFormula(1.5f, 1.5f), 1.5f);
+    EXPECT_FLOAT_EQ(effectiveX11ScaleFormula(2.0f, 2.0f), 2.0f);
+}


### PR DESCRIPTION
**Describe your PR, what does fix/add?**

These changes add xwaylandscale: workspace rule for per-workspace X11 scaling when force_zero_scaling = true.

The main need for this is having X11-based games to work under native resolution, for that a user might configure force_zero_scaling = true ... but then the user might have a collection of X11-based applications for which zero scaling show really small UI components. Some of these apps, like DaVinci Resolve, become almost unusable. With this, you can keep playing X11 games at their native resolution and use certain X11 apps with a specific scale in a given workspace.

Config example: workspace = 5, xwaylandscale:3

**Is there anything you want to mention?**

Requires xwayland:force_zero_scaling = true. Logs a warning if the rule is used without it X11 apps will have some softness due to texture upscaling — there's no way around this without per-window X11 DPI support. 

Includes gtest coverage for scale resolution, merge logic, and the effective scale formula.

**Is it ready for merging, or does it need work?**

I tested this on a 7680x2160 ultrawide at scale 1.6666 with force_zero_scaling = true. Builds clean, 13/13 unit tests pass. But definitely this could use more testing on different monitor configurations and scale combinations.

