### PR TITLE
cleanup: avoid repeated weak_ptr lock() calls in conditions

### DIFF
--- a/src/desktop/view/LayerSurface.cpp
+++ b/src/desktop/view/LayerSurface.cpp
@@ -388,7 +388,10 @@ void CLayerSurface::onCommit() {
         if (!WASEXCLUSIVE && ISEXCLUSIVE)
             g_pInputManager->m_exclusiveLSes.push_back(m_self);
         else if (WASEXCLUSIVE && !ISEXCLUSIVE)
-            std::erase_if(g_pInputManager->m_exclusiveLSes, [this](const auto& other) { return !other.lock() || other.lock() == m_self.lock(); });
+            std::erase_if(g_pInputManager->m_exclusiveLSes, [this](const auto& other) {
+                auto locked = other.lock();
+                return !locked || locked == m_self.lock();
+            });
 
         // if the surface was focused and interactive but now isn't, refocus
         if (WASLASTFOCUS && m_layerSurface->m_current.interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE) {

--- a/src/desktop/view/LayerSurface.cpp
+++ b/src/desktop/view/LayerSurface.cpp
@@ -388,9 +388,7 @@ void CLayerSurface::onCommit() {
         if (!WASEXCLUSIVE && ISEXCLUSIVE)
             g_pInputManager->m_exclusiveLSes.push_back(m_self);
         else if (WASEXCLUSIVE && !ISEXCLUSIVE)
-            std::erase_if(g_pInputManager->m_exclusiveLSes, [this](const auto& other) {
-                return !other || other == m_self;
-            });
+            std::erase_if(g_pInputManager->m_exclusiveLSes, [this](const auto& other) { return !other || other == m_self; });
 
         // if the surface was focused and interactive but now isn't, refocus
         if (WASLASTFOCUS && m_layerSurface->m_current.interactivity == ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_NONE) {

--- a/src/desktop/view/LayerSurface.cpp
+++ b/src/desktop/view/LayerSurface.cpp
@@ -389,8 +389,7 @@ void CLayerSurface::onCommit() {
             g_pInputManager->m_exclusiveLSes.push_back(m_self);
         else if (WASEXCLUSIVE && !ISEXCLUSIVE)
             std::erase_if(g_pInputManager->m_exclusiveLSes, [this](const auto& other) {
-                auto locked = other.lock();
-                return !locked || locked == m_self.lock();
+                return !other || other == m_self;
             });
 
         // if the surface was focused and interactive but now isn't, refocus

--- a/src/layout/algorithm/tiled/dwindle/DwindleAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/dwindle/DwindleAlgorithm.cpp
@@ -129,7 +129,8 @@ void CDwindleAlgorithm::addTarget(SP<ITarget> target) {
     // last fail-safe to avoid duplicate fullscreens
     if ((!OPENINGON || OPENINGON->pTarget.lock() == target) && getNodes() > 1) {
         for (auto& node : m_dwindleNodesData) {
-            if (node->pTarget.lock() && node->pTarget.lock() != target) {
+            auto locked = node->pTarget.lock();
+            if (locked && locked != target) {
                 OPENINGON = node;
                 break;
             }


### PR DESCRIPTION
Avoid repeated weak_ptr::lock() calls in conditions.
Stores the result of lock() to avoid redundant calls and ensure consistent usage.
Build: successful locally 