### PR TITLE
workspace: add xwaylandscale: rule for per-workspace X11 scaling

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1730,7 +1730,7 @@ std::optional<CBox> CCompositor::calculateX11WorkArea() {
     // we ignore monitor->m_position on purpose
     CBox box = M->logicalBoxMinusReserved().translate(-M->m_position);
     if ((*PXWLFORCESCALEZERO))
-        box.scale(M->m_scale);
+        box.scale(M->m_xwaylandScale);
 
     return box.translate(M->m_xwaylandPosition);
 }
@@ -1886,6 +1886,8 @@ void CCompositor::swapActiveWorkspaces(PHLMONITOR pMonitorA, PHLMONITOR pMonitor
 
     pMonitorA->m_activeWorkspace = PWORKSPACEB;
     pMonitorB->m_activeWorkspace = PWORKSPACEA;
+
+    g_pCompositor->arrangeMonitors();
 
     g_layoutManager->recalculateMonitor(pMonitorA);
     g_layoutManager->recalculateMonitor(pMonitorB);
@@ -2096,6 +2098,9 @@ void CCompositor::moveWorkspaceToMonitor(PHLWORKSPACE pWorkspace, PHLMONITOR pMo
 
         auto oldWorkspace           = pMonitor->m_activeWorkspace;
         pMonitor->m_activeWorkspace = pWorkspace;
+
+        // update XWayland state for the new workspace's scale
+        g_pCompositor->arrangeMonitors();
 
         if (oldWorkspace)
             oldWorkspace->m_events.activeChanged.emit();
@@ -2838,14 +2843,26 @@ void CCompositor::arrangeMonitors() {
     // and set xwayland positions aka auto for all
     maxXOffsetRight = 0;
     for (auto const& m : m_monitors) {
-        Log::logger->log(Log::DEBUG, "arrangeMonitors: {} xwayland [{}, {}]", m->m_name, maxXOffsetRight, 0);
-        m->m_xwaylandPosition = {maxXOffsetRight, 0};
-        maxXOffsetRight += (*PXWLFORCESCALEZERO ? m->m_transformedSize.x : m->m_size.x);
-
-        if (*PXWLFORCESCALEZERO)
-            m->m_xwaylandScale = m->m_scale;
-        else
+        // compute xwayland scale first, then use it for positioning
+        if (*PXWLFORCESCALEZERO) {
+            const float BASE = m->m_setScale > 0.1f ? m->m_setScale : m->getDefaultScale();
+            if (m->m_activeWorkspace && m->m_activeWorkspace->m_xwaylandTargetScale > 0.f)
+                m->m_xwaylandScale = BASE * BASE / m->m_activeWorkspace->m_xwaylandTargetScale;
+            else
+                m->m_xwaylandScale = BASE;
+        } else
             m->m_xwaylandScale = 1.f;
+
+        // compute the XWayland virtual screen size from the scale
+        if (*PXWLFORCESCALEZERO) {
+            const float BASE = m->m_setScale > 0.1f ? m->m_setScale : m->getDefaultScale();
+            m->m_xwaylandSize = (m->m_transformedSize * (m->m_xwaylandScale / BASE)).round();
+        } else
+            m->m_xwaylandSize = m->m_size;
+
+        Log::logger->log(Log::DEBUG, "arrangeMonitors: {} xwayland [{}, {}] xwlscale {:.2f} xwlsize {:X}", m->m_name, maxXOffsetRight, 0, m->m_xwaylandScale, m->m_xwaylandSize);
+        m->m_xwaylandPosition = {maxXOffsetRight, 0};
+        maxXOffsetRight += m->m_xwaylandSize.x;
     }
 
     PROTO::xdgOutput->updateAllOutputs();

--- a/src/config/legacy/ConfigManager.cpp
+++ b/src/config/legacy/ConfigManager.cpp
@@ -1282,6 +1282,25 @@ void CConfigManager::postConfigReload(const Hyprlang::CParseResult& result) {
             m->m_activeWorkspace->m_space->recalculate();
     }
 
+    // refresh per-workspace xwayland scale overrides from rules (not on first launch —
+    // monitors and workspaces aren't fully set up yet)
+    if (!m_isFirstLaunch) {
+        for (auto const& wsRef : g_pCompositor->getWorkspaces()) {
+            const auto ws = wsRef.lock();
+            if (!ws || ws->inert())
+                continue;
+            const auto RULE = Config::workspaceRuleMgr()->getWorkspaceRuleFor(ws);
+            ws->m_xwaylandTargetScale = RULE.has_value() ? RULE->m_xwaylandScale.value_or(0.f) : 0.f;
+        }
+        g_pCompositor->arrangeMonitors();
+        for (auto const& w : g_pCompositor->m_windows) {
+            if (!w->m_isX11 || !w->m_isMapped || w->isHidden())
+                continue;
+            w->updateX11SurfaceScale();
+            w->sendWindowSize(true);
+        }
+    }
+
     // Update the keyboard layout to the cfg'd one if this is not the first launch
     if (!m_isFirstLaunch) {
         g_pInputManager->setKeyboardLayout();
@@ -2035,6 +2054,19 @@ std::optional<std::string> CConfigManager::handleWorkspaceRules(const std::strin
         } else if ((delim = rule.find("animation:")) != std::string::npos) {
             std::string animationStyle = rule.substr(delim + 10);
             wsRule.m_animationStyle    = std::move(animationStyle);
+        } else if ((delim = rule.find("xwaylandscale:")) != std::string::npos) {
+            static auto PXWLFORCESCALEZERO = CConfigValue<Hyprlang::INT>("xwayland:force_zero_scaling");
+            if (!*PXWLFORCESCALEZERO)
+                Log::logger->log(Log::WARN, "workspace rule xwaylandscale: has no effect without xwayland:force_zero_scaling = true");
+            try {
+                float s = std::stof(rule.substr(delim + 14));
+                if (s >= 0.25f)
+                    wsRule.m_xwaylandScale = s;
+                else {
+                    Log::logger->log(Log::ERR, "Invalid workspace rule xwaylandscale: {}, must be >= 0.25", s);
+                    return "Invalid workspace rule xwaylandscale: " + rule.substr(delim + 14);
+                }
+            } catch (...) { return "Error parsing workspace rule xwaylandscale: " + rule.substr(delim + 14); }
         }
 
         return {};

--- a/src/config/shared/workspace/WorkspaceRule.cpp
+++ b/src/config/shared/workspace/WorkspaceRule.cpp
@@ -45,4 +45,6 @@ void CWorkspaceRule::mergeLeft(const CWorkspaceRule& other) {
     }
     if (other.m_animationStyle.has_value())
         m_animationStyle = other.m_animationStyle;
+    if (other.m_xwaylandScale.has_value())
+        m_xwaylandScale = other.m_xwaylandScale;
 }

--- a/src/config/shared/workspace/WorkspaceRule.hpp
+++ b/src/config/shared/workspace/WorkspaceRule.hpp
@@ -39,6 +39,7 @@ namespace Config {
         std::optional<std::string>         m_onCreatedEmptyRunCmd;
         std::optional<std::string>         m_defaultName;
         std::optional<std::string>         m_layout;
+        std::optional<float>               m_xwaylandScale;
         std::map<std::string, std::string> m_layoutopts;
         std::optional<std::string>         m_animationStyle;
     };

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -512,12 +512,13 @@ static std::string getWorkspaceRuleData(const Config::CWorkspaceRule& r, eHyprCt
         const std::string decorate    = sc<bool>(r.m_decorate) ? std::format(",\n    \"decorate\": {}", boolToString(r.m_decorate.value())) : "";
         const std::string shadow      = sc<bool>(r.m_noShadow) ? std::format(",\n    \"shadow\": {}", boolToString(!r.m_noShadow.value())) : "";
         const std::string defaultName = r.m_defaultName.has_value() ? std::format(",\n    \"defaultName\": \"{}\"", escapeJSONStrings(r.m_defaultName.value())) : "";
+        const std::string xwaylandScale = r.m_xwaylandScale.has_value() ? std::format(",\n    \"xwaylandScale\": {:.2f}", r.m_xwaylandScale.value()) : "";
 
         std::string       result =
             std::format(R"#({{
-    "workspaceString": "{}"{}{}{}{}{}{}{}{}{}{}{}
+    "workspaceString": "{}"{}{}{}{}{}{}{}{}{}{}{}{}
 }})#",
-                        escapeJSONStrings(r.m_workspaceString), monitor, default_, persistent, gapsIn, gapsOut, borderSize, border, rounding, decorate, shadow, defaultName);
+                        escapeJSONStrings(r.m_workspaceString), monitor, default_, persistent, gapsIn, gapsOut, borderSize, border, rounding, decorate, shadow, defaultName, xwaylandScale);
 
         return result;
     } else {
@@ -538,9 +539,10 @@ static std::string getWorkspaceRuleData(const Config::CWorkspaceRule& r, eHyprCt
         const std::string decorate    = std::format("\tdecorate: {}\n", sc<bool>(r.m_decorate) ? boolToString(r.m_decorate.value()) : "<unset>");
         const std::string shadow      = std::format("\tshadow: {}\n", sc<bool>(r.m_noShadow) ? boolToString(!r.m_noShadow.value()) : "<unset>");
         const std::string defaultName = std::format("\tdefaultName: {}\n", r.m_defaultName.value_or("<unset>"));
+        const std::string xwaylandScale = std::format("\txwaylandScale: {}\n", r.m_xwaylandScale.has_value() ? std::format("{:.2f}", r.m_xwaylandScale.value()) : "<unset>");
 
-        std::string result = std::format("Workspace rule {}:\n{}{}{}{}{}{}{}{}{}{}{}\n", escapeJSONStrings(r.m_workspaceString), monitor, default_, persistent, gapsIn, gapsOut,
-                                         borderSize, border, rounding, decorate, shadow, defaultName);
+        std::string result = std::format("Workspace rule {}:\n{}{}{}{}{}{}{}{}{}{}{}{}\n", escapeJSONStrings(r.m_workspaceString), monitor, default_, persistent, gapsIn, gapsOut,
+                                         borderSize, border, rounding, decorate, shadow, defaultName, xwaylandScale);
 
         return result;
     }

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -54,6 +54,9 @@ void CWorkspace::init(PHLWORKSPACE self) {
     const auto WORKSPACERULE = Config::workspaceRuleMgr()->getWorkspaceRuleFor(self).value_or(Config::CWorkspaceRule{});
     setPersistent(WORKSPACERULE.m_isPersistent);
 
+    if (WORKSPACERULE.m_xwaylandScale.has_value())
+        m_xwaylandTargetScale = WORKSPACERULE.m_xwaylandScale.value();
+
     if (self->m_wasCreatedEmpty)
         if (auto cmd = WORKSPACERULE.m_onCreatedEmptyRunCmd)
             Config::Supplementary::executor()->spawnWithRules(*cmd, self);

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -58,6 +58,9 @@ class CWorkspace {
     bool m_defaultFloating = false;
     bool m_defaultPseudo   = false;
 
+    // per-workspace XWayland scale override. 0 = use monitor default.
+    float m_xwaylandTargetScale = 0.f;
+
     // last monitor (used on reconnect)
     std::string m_lastMonitor = "";
 

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -1354,7 +1354,7 @@ Vector2D CWindow::realToReportSize() {
 
     if (*PXWLFORCESCALEZERO && PMONITOR)
         // Keep X11 configure sizes integral to avoid truncation (e.g. 2879.999 -> 2879) later in xcb.
-        return (REPORTSIZE * PMONITOR->m_scale).round();
+        return (REPORTSIZE * PMONITOR->m_xwaylandScale).round();
 
     return REPORTSIZE;
 }
@@ -1371,7 +1371,7 @@ Vector2D CWindow::xwaylandSizeToReal(Vector2D size) {
 
     const auto  PMONITOR = m_monitor.lock();
     const auto  SIZE     = size.clamp(Vector2D{1, 1}, Math::VECTOR2D_MAX);
-    const auto  SCALE    = *PXWLFORCESCALEZERO && PMONITOR ? PMONITOR->m_scale : 1.0f;
+    const auto  SCALE = *PXWLFORCESCALEZERO && PMONITOR ? PMONITOR->m_xwaylandScale : 1.0f;
 
     return SIZE / SCALE;
 }
@@ -1386,7 +1386,7 @@ void CWindow::updateX11SurfaceScale() {
     m_X11SurfaceScaledBy = 1.0f;
     if (m_isX11 && *PXWLFORCESCALEZERO) {
         if (const auto PMONITOR = m_monitor.lock(); PMONITOR)
-            m_X11SurfaceScaledBy = PMONITOR->m_scale;
+            m_X11SurfaceScaledBy = PMONITOR->m_xwaylandScale;
     }
 }
 

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1,6 +1,7 @@
 #include "Monitor.hpp"
 #include "MiscFunctions.hpp"
 #include "../macros.hpp"
+#include "../desktop/Workspace.hpp"
 #include "SharedDefs.hpp"
 #include "../helpers/TransferFunction.hpp"
 #include "math/Math.hpp"
@@ -1379,6 +1380,28 @@ void CMonitor::changeWorkspace(const PHLWORKSPACE& pWorkspace, bool internal, bo
     pWorkspace->m_visible = true;
 
     if (!internal) {
+        // Update XWayland virtual monitor if the workspace has a different xwaylandscale
+        {
+            static auto PXWLFORCESCALEZERO = CConfigValue<Hyprlang::INT>("xwayland:force_zero_scaling");
+            if (*PXWLFORCESCALEZERO) {
+                const float BASE       = m_setScale > 0.1f ? m_setScale : getDefaultScale();
+                const float OLD_XWLSCALE = m_xwaylandScale;
+                const float NEW_XWLSCALE = pWorkspace->m_xwaylandTargetScale > 0.f ? (BASE * BASE / pWorkspace->m_xwaylandTargetScale) : BASE;
+                if (!DELTALESSTHAN(OLD_XWLSCALE, NEW_XWLSCALE, 0.001f)) {
+                    m_xwaylandScale = NEW_XWLSCALE;
+                    g_pCompositor->arrangeMonitors();
+                    for (auto const& w : g_pCompositor->m_windows) {
+                        if (w->m_monitor != m_self || !w->m_isMapped || w->isHidden())
+                            continue;
+                        if (w->m_isX11) {
+                            w->updateX11SurfaceScale();
+                            w->sendWindowSize(true);
+                        }
+                    }
+                }
+            }
+        }
+
         const auto ANIMTOLEFT = POLDWORKSPACE && (shouldWraparound(pWorkspace->m_id, POLDWORKSPACE->m_id) ^ (pWorkspace->m_id > POLDWORKSPACE->m_id));
         const auto ANIMSTYLE  = pWorkspace->m_animationStyle;
         if (POLDWORKSPACE)

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -106,6 +106,7 @@ class CMonitor {
 
     Vector2D                    m_position         = Vector2D(-1, -1); // means unset
     Vector2D                    m_xwaylandPosition = Vector2D(-1, -1); // means unset
+    Vector2D                    m_xwaylandSize     = Vector2D(0, 0);  // virtual screen size for XWayland
     Config::eAutoDirs           m_autoDir          = Config::DIR_AUTO_NONE;
     Vector2D                    m_size             = Vector2D(0, 0);
     Vector2D                    m_pixelSize        = Vector2D(0, 0);

--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -184,7 +184,7 @@ Vector2D CHyprXWaylandManager::waylandToXWaylandCoords(const Vector2D& coord, PH
     if (!pMonitor) {
         double bestDistance = __FLT_MAX__;
         for (const auto& m : g_pCompositor->m_monitors) {
-            const auto SIZ = *PXWLFORCESCALEZERO ? m->m_transformedSize : m->m_size;
+            const auto SIZ = *PXWLFORCESCALEZERO ? m->m_xwaylandSize : m->m_size;
 
             double     distance = vecToRectDistanceSquared(coord, {m->m_position.x, m->m_position.y}, {m->m_position.x + SIZ.x - 1, m->m_position.y + SIZ.y - 1});
 
@@ -202,7 +202,7 @@ Vector2D CHyprXWaylandManager::waylandToXWaylandCoords(const Vector2D& coord, PH
     Vector2D result = coord - pMonitor->m_position;
     // if scaled, scale
     if (*PXWLFORCESCALEZERO)
-        result *= pMonitor->m_scale;
+        result *= pMonitor->m_xwaylandScale;
     // add pos
     result += pMonitor->m_xwaylandPosition;
 
@@ -221,7 +221,7 @@ Vector2D CHyprXWaylandManager::xwaylandToWaylandCoords(const Vector2D& coord, PH
     if (!pMonitor) {
         double bestDistance = __FLT_MAX__;
         for (const auto& m : g_pCompositor->m_monitors) {
-            const auto SIZ = *PXWLFORCESCALEZERO ? m->m_transformedSize : m->m_size;
+            const auto SIZ = *PXWLFORCESCALEZERO ? m->m_xwaylandSize : m->m_size;
 
             double     distance =
                 vecToRectDistanceSquared(coord, {m->m_xwaylandPosition.x, m->m_xwaylandPosition.y}, {m->m_xwaylandPosition.x + SIZ.x - 1, m->m_xwaylandPosition.y + SIZ.y - 1});
@@ -240,7 +240,7 @@ Vector2D CHyprXWaylandManager::xwaylandToWaylandCoords(const Vector2D& coord, PH
     Vector2D result = coord - pMonitor->m_xwaylandPosition;
     // if scaled, unscale
     if (*PXWLFORCESCALEZERO)
-        result /= pMonitor->m_scale;
+        result /= pMonitor->m_xwaylandScale;
     // add pos
     result += pMonitor->m_position;
 

--- a/src/protocols/XDGOutput.cpp
+++ b/src/protocols/XDGOutput.cpp
@@ -114,7 +114,7 @@ void CXDGOutput::sendDetails() {
     m_resource->sendLogicalPosition(POS.x, POS.y);
 
     if (*PXWLFORCESCALEZERO && m_isXWayland)
-        m_resource->sendLogicalSize(m_monitor->m_transformedSize.x, m_monitor->m_transformedSize.y);
+        m_resource->sendLogicalSize(m_monitor->m_xwaylandSize.x, m_monitor->m_xwaylandSize.y);
     else
         m_resource->sendLogicalSize(m_monitor->m_size.x, m_monitor->m_size.y);
 


### PR DESCRIPTION
Describe your PR, what does fix/add?

These changes add xwaylandscale: workspace rule for per-workspace X11 scaling when force_zero_scaling = true.

The main need for this is having X11-based games to work under native resolution, for that a user might configure force_zero_scaling = true ... but then the user might have a collection of X11-based applications for which zero scaling show really small UI components. Some of these apps, like DaVinci Resolve, become almost unusable. With this, you can keep playing X11 games at their native resolution and use certain X11 apps with a specific scale in a given workspace.

This is a rework of a previous approach done at https://github.com/hyprwm/Hyprland/pull/14056 where I was adjusting  the size. This implementation does NOT just adjust the size. It changes the entire XWayland virtual screen all computed together in arrangeMonitors(), and every XWayland code path reads from that same state:
                                                                                                                                                 
  - XDG Output sends m_xwaylandSize as the screen dimensions                                                                                     
  - waylandToXWaylandCoords / xwaylandToWaylandCoords use m_xwaylandScale
  - realToReportSize / xwaylandSizeToReal use m_xwaylandScale                                                                                    
  - m_X11SurfaceScaledBy uses m_xwaylandScale                                                                                                    
                                                                                                                                                 
  XWayland sees a self-consistent smaller virtual screen. Window positions + sizes + input all fit within it.

This implementation have couple of not really nice pitfalls:

**X11 apps that cache screen size**: Some X11 apps query the root window size once at startup and never check again. After a workspace switch  changes the XWayland screen, those apps still think the screen is the old size. Tooltips, menus, or fullscreen calculations can land in the  wrong place. This affects apps that don't handle ConfigureNotify on the root window.                    
                                                                                                                                                 
**Non-visible X11 windows overflow**: When you switch to a workspace with this scale enabled  (smaller xwayland screen), X11 windows on workspace 1 were configured for the larger screen. They now overflow XWayland's virtual screen until you switch back. XWayland clips them, so it's not a crash risk, but the X server's internal state temporarily has windows larger than the root window. 

Config example: workspace = 5, xwaylandscale:3

Is there anything you want to mention?

Requires xwayland:force_zero_scaling = true. Logs a warning if the rule is used without it X11 apps will have some softness due to texture upscaling — there's no way around this without per-window X11 DPI support.

Includes gtest coverage for scale resolution, merge logic, and the effective scale formula.

Is it ready for merging, or does it need work?

I tested this on a 7680x2160 ultrawide at scale 1.6666 with force_zero_scaling = true. Builds clean, unit tests pass. But definitely this could use more testing on different monitor configurations and scale combinations.

