### PR TITLE
monitor: ensure swapchain is updated before mode test

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -623,8 +623,6 @@ void CMonitor::applyCMType(NCMType::eCMType cmType, NTransferFunction::eTF cmSdr
     }
 }
 
-
-
 bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule, bool force) {
 
     static auto PDISABLESCALECHECKS = CConfigValue<Hyprlang::INT>("debug:disable_scale_checks");
@@ -2489,7 +2487,6 @@ void CMonitorState::applyCustomModeWithSwapchain(const SP<Aquamarine::SOutputMod
     m_owner->m_output->state->setCustomMode(mode);
     updateSwapchain();
 }
-
 
 bool CMonitor::needsACopyFB() {
     return !m_mirrors.empty() || Screenshare::mgr()->isOutputBeingSSd(m_self.lock());

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -623,15 +623,7 @@ void CMonitor::applyCMType(NCMType::eCMType cmType, NTransferFunction::eTF cmSdr
     }
 }
 
-void CMonitor::applyModeWithSwapchain(const SP<Aquamarine::SOutputMode>& mode) {
-    m_output->state->setMode(mode);
-    m_state.updateSwapchain();
-}
 
-void CMonitor::applyCustomModeWithSwapchain(const SP<Aquamarine::SOutputMode>& mode) {
-    m_output->state->setCustomMode(mode);
-    m_state.updateSwapchain();
-}
 
 bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule, bool force) {
 
@@ -837,7 +829,7 @@ bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule, bool force)
         std::string modeStr = std::format("{:X0}@{:.2f}Hz", mode->pixelSize, mode->refreshRate / 1000.f);
 
         if (mode->modeInfo.has_value() && mode->modeInfo->type == DRM_MODE_TYPE_USERDEF) {
-            applyCustomModeWithSwapchain(mode);
+            m_state.applyCustomModeWithSwapchain(mode);
 
             if (!m_state.test()) {
                 Log::logger->log(Log::ERR, "Monitor {}: REJECTED custom mode {}!", m_name, modeStr);
@@ -846,7 +838,7 @@ bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule, bool force)
 
             m_customDrmMode = mode->modeInfo.value();
         } else {
-            applyModeWithSwapchain(mode);
+            m_state.applyModeWithSwapchain(mode);
 
             if (!m_state.test()) {
                 Log::logger->log(Log::ERR, "Monitor {}: REJECTED available mode {}!", m_name, modeStr);
@@ -880,7 +872,7 @@ bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule, bool force)
         auto        mode        = makeShared<Aquamarine::SOutputMode>(Aquamarine::SOutputMode{.pixelSize = RULE->m_resolution, .refreshRate = refreshRate});
         std::string modeStr     = std::format("{:X0}@{:.2f}Hz", mode->pixelSize, mode->refreshRate / 1000.f);
 
-        applyCustomModeWithSwapchain(mode);
+        m_state.applyCustomModeWithSwapchain(mode);
 
         if (m_state.test()) {
             Log::logger->log(Log::DEBUG, "Monitor {}: requested {}, using custom mode {}", m_name, requestedStr, modeStr);
@@ -898,7 +890,7 @@ bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule, bool force)
     // try any of the modes if none of the above work
     if (!success) {
         for (auto const& mode : m_output->modes) {
-            applyModeWithSwapchain(mode);
+            m_state.applyModeWithSwapchain(mode);
 
             if (!m_state.test())
                 continue;
@@ -2488,6 +2480,16 @@ bool CMonitorState::updateSwapchain() {
     options.size    = MODE->pixelSize;
     return m_owner->m_output->swapchain->reconfigure(options);
 }
+void CMonitorState::applyModeWithSwapchain(const SP<Aquamarine::SOutputMode>& mode) {
+    m_owner->m_output->state->setMode(mode);
+    updateSwapchain();
+}
+
+void CMonitorState::applyCustomModeWithSwapchain(const SP<Aquamarine::SOutputMode>& mode) {
+    m_owner->m_output->state->setCustomMode(mode);
+    updateSwapchain();
+}
+
 
 bool CMonitor::needsACopyFB() {
     return !m_mirrors.empty() || Screenshare::mgr()->isOutputBeingSSd(m_self.lock());

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -623,6 +623,18 @@ void CMonitor::applyCMType(NCMType::eCMType cmType, NTransferFunction::eTF cmSdr
     }
 }
 
+void CMonitor::applyModeWithSwapchain(const SP<Aquamarine::SOutputMode>& mode) {
+    m_output->state->setMode(mode);
+    m_state.updateSwapchain();
+}
+
+void CMonitor::applyCustomModeWithSwapchain(const SP<Aquamarine::SOutputMode>& mode) {
+    m_output->state->setCustomMode(mode);
+    m_state.updateSwapchain();
+}
+
+
+
 bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule, bool force) {
 
     static auto PDISABLESCALECHECKS = CConfigValue<Hyprlang::INT>("debug:disable_scale_checks");
@@ -827,7 +839,7 @@ bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule, bool force)
         std::string modeStr = std::format("{:X0}@{:.2f}Hz", mode->pixelSize, mode->refreshRate / 1000.f);
 
         if (mode->modeInfo.has_value() && mode->modeInfo->type == DRM_MODE_TYPE_USERDEF) {
-            m_output->state->setCustomMode(mode);
+            applyCustomModeWithSwapchain(mode);
 
             if (!m_state.test()) {
                 Log::logger->log(Log::ERR, "Monitor {}: REJECTED custom mode {}!", m_name, modeStr);
@@ -836,8 +848,7 @@ bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule, bool force)
 
             m_customDrmMode = mode->modeInfo.value();
         } else {
-            m_output->state->setMode(mode);
-            m_state.updateSwapchain();
+            applyModeWithSwapchain(mode);
 
             if (!m_state.test()) {
                 Log::logger->log(Log::ERR, "Monitor {}: REJECTED available mode {}!", m_name, modeStr);
@@ -871,8 +882,7 @@ bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule, bool force)
         auto        mode        = makeShared<Aquamarine::SOutputMode>(Aquamarine::SOutputMode{.pixelSize = RULE->m_resolution, .refreshRate = refreshRate});
         std::string modeStr     = std::format("{:X0}@{:.2f}Hz", mode->pixelSize, mode->refreshRate / 1000.f);
 
-        m_output->state->setCustomMode(mode);
-        m_state.updateSwapchain();
+        applyCustomModeWithSwapchain(mode);
 
         if (m_state.test()) {
             Log::logger->log(Log::DEBUG, "Monitor {}: requested {}, using custom mode {}", m_name, requestedStr, modeStr);
@@ -890,7 +900,7 @@ bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule, bool force)
     // try any of the modes if none of the above work
     if (!success) {
         for (auto const& mode : m_output->modes) {
-            m_output->state->setMode(mode);
+            applyModeWithSwapchain(mode);
 
             if (!m_state.test())
                 continue;

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -837,6 +837,7 @@ bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule, bool force)
             m_customDrmMode = mode->modeInfo.value();
         } else {
             m_output->state->setMode(mode);
+            m_state.updateSwapchain();
 
             if (!m_state.test()) {
                 Log::logger->log(Log::ERR, "Monitor {}: REJECTED available mode {}!", m_name, modeStr);
@@ -871,6 +872,7 @@ bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule, bool force)
         std::string modeStr     = std::format("{:X0}@{:.2f}Hz", mode->pixelSize, mode->refreshRate / 1000.f);
 
         m_output->state->setCustomMode(mode);
+        m_state.updateSwapchain();
 
         if (m_state.test()) {
             Log::logger->log(Log::DEBUG, "Monitor {}: requested {}, using custom mode {}", m_name, requestedStr, modeStr);

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -633,8 +633,6 @@ void CMonitor::applyCustomModeWithSwapchain(const SP<Aquamarine::SOutputMode>& m
     m_state.updateSwapchain();
 }
 
-
-
 bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule, bool force) {
 
     static auto PDISABLESCALECHECKS = CConfigValue<Hyprlang::INT>("debug:disable_scale_checks");

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -92,6 +92,8 @@ class CMonitorState {
     bool commit();
     bool test();
     bool updateSwapchain();
+    void applyModeWithSwapchain(const SP<Aquamarine::SOutputMode>& mode);
+    void applyCustomModeWithSwapchain(const SP<Aquamarine::SOutputMode>& mode);
 
   private:
     void      ensureBufferPresent();
@@ -299,8 +301,6 @@ class CMonitor {
     void        onDisconnect(bool destroy = false);
     void        applyCMType(NCMType::eCMType cmType, NTransferFunction::eTF cmSdrEotf);
     bool        applyMonitorRule(Config::CMonitorRule&& pMonitorRule, bool force = false);
-    void        applyModeWithSwapchain(const SP<Aquamarine::SOutputMode>& mode);
-    void        applyCustomModeWithSwapchain(const SP<Aquamarine::SOutputMode>& mode);
     void        addDamage(const pixman_region32_t* rg);
     void        addDamage(const CRegion& rg);
     void        addDamage(const CBox& box);

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -299,6 +299,8 @@ class CMonitor {
     void        onDisconnect(bool destroy = false);
     void        applyCMType(NCMType::eCMType cmType, NTransferFunction::eTF cmSdrEotf);
     bool        applyMonitorRule(Config::CMonitorRule&& pMonitorRule, bool force = false);
+    void        applyModeWithSwapchain(const SP<Aquamarine::SOutputMode>& mode);
+    void        applyCustomModeWithSwapchain(const SP<Aquamarine::SOutputMode>& mode);
     void        addDamage(const pixman_region32_t* rg);
     void        addDamage(const CRegion& rg);
     void        addDamage(const CBox& box);


### PR DESCRIPTION
This may be related to Aquamarine issue # 268:https://github.com/hyprwm/aquamarine/issues/268.

When testing modes, test() may be called before the swapchain is
updated to match the new mode size. This can result in a mismatch
between the framebuffer and the requested mode, causing atomic
test failures.

Ensure updateSwapchain() is called after setMode/setCustomMode
and before test(), so the buffer matches the mode being tested.

Builds successfully locally.

Tested by repeatedly switching monitor modes (1920x1080 <-> 1280x720)
and reloading the config multiple times.

Verified monitor state using hyprctl monitors after each change.

Checked DRM logs; no atomic commit or plane mismatch errors were observed.