### PR TITLE
render: survive recoverable GPU resets instead of aborting

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2904,6 +2904,9 @@ void CCompositor::leaveUnsafeState() {
 }
 
 void CCompositor::setPreferredScaleForSurface(SP<CWLSurfaceResource> pSurface, double scale) {
+    if (!pSurface)
+        return;
+
     PROTO::fractional->sendScale(pSurface, scale);
     pSurface->sendPreferredScale(std::ceil(scale));
 
@@ -2918,6 +2921,9 @@ void CCompositor::setPreferredScaleForSurface(SP<CWLSurfaceResource> pSurface, d
 }
 
 void CCompositor::setPreferredTransformForSurface(SP<CWLSurfaceResource> pSurface, wl_output_transform transform) {
+    if (!pSurface)
+        return;
+
     pSurface->sendPreferredTransform(transform);
 
     const auto PSURFACE = Desktop::View::CWLSurface::fromResource(pSurface);

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -264,7 +264,7 @@ SP<CWLSurfaceResource> CWLSurfaceResource::fromResource(wl_resource* res) {
 }
 
 bool CWLSurfaceResource::good() {
-    return m_resource->resource();
+    return m_resource && m_resource->resource();
 }
 
 wl_client* CWLSurfaceResource::client() {
@@ -272,6 +272,9 @@ wl_client* CWLSurfaceResource::client() {
 }
 
 void CWLSurfaceResource::enter(PHLMONITOR monitor) {
+    if (!good())
+        return;
+
     if (std::ranges::find(m_enteredOutputs, monitor) != m_enteredOutputs.end())
         return;
 
@@ -304,6 +307,9 @@ void CWLSurfaceResource::enter(PHLMONITOR monitor) {
 }
 
 void CWLSurfaceResource::leave(PHLMONITOR monitor) {
+    if (!good())
+        return;
+
     if UNLIKELY (std::ranges::find(m_enteredOutputs, monitor) == m_enteredOutputs.end())
         return;
 
@@ -325,12 +331,16 @@ void CWLSurfaceResource::leave(PHLMONITOR monitor) {
 }
 
 void CWLSurfaceResource::sendPreferredTransform(wl_output_transform t) {
+    if (!good())
+        return;
     if (m_resource->version() < 6)
         return;
     m_resource->sendPreferredBufferTransform(t);
 }
 
 void CWLSurfaceResource::sendPreferredScale(int32_t scale) {
+    if (!good())
+        return;
     if (m_resource->version() < 6)
         return;
     m_resource->sendPreferredBufferScale(scale);
@@ -471,6 +481,8 @@ std::pair<SP<CWLSurfaceResource>, Vector2D> CWLSurfaceResource::at(const Vector2
 }
 
 uint32_t CWLSurfaceResource::id() {
+    if (!good())
+        return 0;
     return wl_resource_get_id(m_resource->resource());
 }
 
@@ -505,6 +517,8 @@ void CWLSurfaceResource::releaseBuffers(bool onlyCurrent) {
 }
 
 void CWLSurfaceResource::error(int code, const std::string& str) {
+    if (!good())
+        return;
     m_resource->error(code, str);
 }
 

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -663,8 +663,27 @@ EGLImageKHR CHyprOpenGLImpl::createEGLImage(const Aquamarine::SDMABUFAttrs& attr
     return image;
 }
 
+bool CHyprOpenGLImpl::attemptContextReset() {
+    Log::logger->log(Log::ERR, "GPU reset: attempting EGL context recovery...");
+    eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+    if (eglMakeCurrent(m_eglDisplay, EGL_NO_SURFACE, EGL_NO_SURFACE, m_eglContext) != EGL_TRUE) {
+        Log::logger->log(Log::ERR, "GPU reset: eglMakeCurrent failed, context may be lost");
+        return false;
+    }
+    m_shadersInitialized = false;
+    Log::logger->log(Log::WARN, "GPU reset: EGL context re-established, shaders will reinitialize on next frame.");
+    return true;
+}
+
 void CHyprOpenGLImpl::beginSimple(PHLMONITOR pMonitor, const CRegion& damage, SP<IRenderbuffer> rb, SP<IFramebuffer> fb) {
     g_pHyprRenderer->m_renderData.pMonitor = pMonitor;
+
+    if (m_gpuResetCooldown > 0) {
+        m_gpuResetCooldown--;
+        Log::logger->log(Log::WARN, "GPU reset recovery cooldown, skipping frame ({} remaining)", m_gpuResetCooldown);
+        g_pHyprRenderer->m_renderData.pMonitor.reset();
+        return;
+    }
 
     const GLenum RESETSTATUS = glGetGraphicsResetStatus();
     if (RESETSTATUS != GL_NO_ERROR) {
@@ -675,7 +694,14 @@ void CHyprOpenGLImpl::beginSimple(PHLMONITOR pMonitor, const CRegion& damage, SP
             case GL_UNKNOWN_CONTEXT_RESET: errStr = "GL_UNKNOWN_CONTEXT_RESET"; break;
             default: errStr = "UNKNOWN??"; break;
         }
-        RASSERT(false, "Aborting, glGetGraphicsResetStatus returned {}. Cannot continue until proper GPU reset handling is implemented.", errStr);
+        Log::logger->log(Log::ERR, "GPU reset detected in beginSimple: {}. Attempting EGL context recovery.", errStr);
+        if (!attemptContextReset()) {
+            Log::logger->log(Log::ERR, "GPU reset recovery failed. Skipping frames for cooldown.");
+            m_gpuResetCooldown = 60;
+        } else {
+            Log::logger->log(Log::WARN, "GPU reset recovery succeeded. Skipping current frame to reinitialize.");
+        }
+        g_pHyprRenderer->m_renderData.pMonitor.reset();
         return;
     }
 
@@ -714,6 +740,13 @@ void CHyprOpenGLImpl::makeEGLCurrent() {
 void CHyprOpenGLImpl::begin(PHLMONITOR pMonitor, const CRegion& damage_, SP<IFramebuffer> fb, std::optional<CRegion> finalDamage) {
     g_pHyprRenderer->m_renderData.pMonitor = pMonitor;
 
+    if (m_gpuResetCooldown > 0) {
+        m_gpuResetCooldown--;
+        Log::logger->log(Log::WARN, "GPU reset recovery cooldown, skipping frame ({} remaining)", m_gpuResetCooldown);
+        g_pHyprRenderer->m_renderData.pMonitor.reset();
+        return;
+    }
+
     const GLenum RESETSTATUS = glGetGraphicsResetStatus();
     if (RESETSTATUS != GL_NO_ERROR) {
         std::string errStr = "";
@@ -723,7 +756,14 @@ void CHyprOpenGLImpl::begin(PHLMONITOR pMonitor, const CRegion& damage_, SP<IFra
             case GL_UNKNOWN_CONTEXT_RESET: errStr = "GL_UNKNOWN_CONTEXT_RESET"; break;
             default: errStr = "UNKNOWN??"; break;
         }
-        RASSERT(false, "Aborting, glGetGraphicsResetStatus returned {}. Cannot continue until proper GPU reset handling is implemented.", errStr);
+        Log::logger->log(Log::ERR, "GPU reset detected in begin: {}. Attempting EGL context recovery.", errStr);
+        if (!attemptContextReset()) {
+            Log::logger->log(Log::ERR, "GPU reset recovery failed. Skipping frames for cooldown.");
+            m_gpuResetCooldown = 60;
+        } else {
+            Log::logger->log(Log::WARN, "GPU reset recovery succeeded. Skipping current frame to reinitialize.");
+        }
+        g_pHyprRenderer->m_renderData.pMonitor.reset();
         return;
     }
 
@@ -856,8 +896,10 @@ void CHyprOpenGLImpl::end() {
         // check for gl errors
         const GLenum ERR = glGetError();
 
-        if UNLIKELY (ERR == GL_CONTEXT_LOST) /* We don't have infra to recover from this */
-            RASSERT(false, "glGetError at Opengl::end() returned GL_CONTEXT_LOST. Cannot continue until proper GPU reset handling is implemented.");
+        if UNLIKELY (ERR == GL_CONTEXT_LOST) {
+            Log::logger->log(Log::ERR, "glGetError at Opengl::end() returned GL_CONTEXT_LOST. Recovery will trigger on next begin().");
+            m_gpuResetCooldown = 60;
+        }
     }
 }
 
@@ -1443,8 +1485,13 @@ WP<CShader> CHyprOpenGLImpl::renderToFBInternal(SP<ITexture> tex, const STexture
 
 void CHyprOpenGLImpl::renderTextureInternal(SP<ITexture> tex, const CBox& box, const STextureRenderData& data) {
     RASSERT(g_pHyprRenderer->m_renderData.pMonitor, "Tried to render texture without begin()!");
-    RASSERT(tex, "Attempted to draw nullptr texture!");
-    RASSERT(tex->ok(), "Attempted to draw invalid texture!");
+
+    if UNLIKELY (!tex || !tex->ok()) {
+        // After a GPU reset, textures become invalid. Skip the draw
+        // instead of aborting — recovery will happen on the next begin().
+        Log::logger->log(Log::ERR, "renderTextureInternal: invalid texture (likely GPU reset). Skipping draw.");
+        return;
+    }
 
     TRACY_GPU_ZONE("RenderTextureInternalWithDamage");
 

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1046,7 +1046,12 @@ void CHyprOpenGLImpl::renderRectWithBlurInternal(const CBox& box, const CHyprCol
     CRegion damage{g_pHyprRenderer->m_renderData.damage};
     damage.intersect(box);
 
-    auto blurredBG = data.xray ? g_pHyprRenderer->m_renderData.pMonitor->resources()->m_blurFB->getTexture() : g_pHyprRenderer->blurMainFramebuffer(data.blurA, &damage);
+    auto blurFB    = g_pHyprRenderer->m_renderData.pMonitor->resources()->m_blurFB;
+    auto blurredBG = data.xray ? (blurFB ? blurFB->getTexture() : nullptr) : g_pHyprRenderer->blurMainFramebuffer(data.blurA, &damage);
+    if (!blurredBG) {
+        Log::logger->log(Log::ERR, "renderTextureWithBlur: blur texture unavailable (likely GPU reset). Skipping blur.");
+        return;
+    }
 
     CBox MONITORBOX = {0, 0, g_pHyprRenderer->m_renderData.pMonitor->m_transformedSize.x, g_pHyprRenderer->m_renderData.pMonitor->m_transformedSize.y};
     g_pHyprRenderer->pushMonitorTransformEnabled(true);

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -313,6 +313,8 @@ namespace Render::GL {
         bool                             m_applyFinalShader     = false;
         bool                             m_blend                = false;
         bool                             m_offloadedFramebuffer = false;
+        int                              m_gpuResetCooldown     = 0;
+        bool                             attemptContextReset();
         bool                             m_cmSupported          = true;
 
         SP<CShader>                      m_finalScreenShader;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1395,6 +1395,8 @@ SP<ITexture> IHyprRenderer::loadAsset(const std::string& filename) {
 }
 
 SP<ITexture> IHyprRenderer::getBlurTexture(PHLMONITORREF pMonitor) {
+    if (!pMonitor || !pMonitor->resources()->m_blurFB)
+        return nullptr;
     return pMonitor->resources()->m_blurFB->getTexture();
 }
 
@@ -1721,9 +1723,10 @@ Mat3x3 IHyprRenderer::projectBoxToTarget(const CBox& box, std::optional<eTransfo
 }
 
 SP<ITexture> IHyprRenderer::blurMainFramebuffer(float a, CRegion* originalDamage) {
-    if (!m_renderData.currentFB->getTexture()) {
+    if (!m_renderData.currentFB || !m_renderData.currentFB->getTexture()) {
         Log::logger->log(Log::ERR, "BUG THIS: null fb texture while attempting to blur main fb?! (introspection off?!)");
-        return m_renderData.pMonitor->resources()->m_blurFB->getTexture(); // return something to sample from at least
+        auto blurFB = m_renderData.pMonitor->resources()->m_blurFB;
+        return blurFB ? blurFB->getTexture() : nullptr;
     }
 
     auto guard = bindTempFB(m_renderData.currentFB); // blurFramebuffer messes with FB bindings
@@ -1735,6 +1738,10 @@ void IHyprRenderer::preBlurForCurrentMonitor(CRegion* fakeDamage) {
     const auto blurredTex = blurMainFramebuffer(1, fakeDamage);
 
     // render onto blurFB
+    if (!m_renderData.pMonitor->resources()->m_blurFB) {
+        Log::logger->log(Log::ERR, "preBlurForCurrentMonitor: blurFB is null, skipping blur.");
+        return;
+    }
     auto       guard          = bindTempFB(m_renderData.pMonitor->resources()->m_blurFB);
     const auto SAVE_TRANSFORM = blurredTex->m_transform;
     blurredTex->m_transform   = Math::wlTransformToHyprutils(Math::invertTransform(m_renderData.pMonitor->m_transform));


### PR DESCRIPTION
## Summary
Hyprland currently `RASSERT`s (SIGABRT) whenever it observes a GPU reset signal: `glGetGraphicsResetStatus()` in `begin()`/`beginSimple()`, `GL_CONTEXT_LOST` in `end()`, or an invalid texture in `renderTextureInternal()`. The original abort message acknowledges this is incomplete: *"Cannot continue until proper GPU reset handling is implemented."*

On recent Intel (Xe driver, Meteor Lake / Arc graphics), TLB-invalidation timeouts produce recoverable GPU resets: the kernel re-arms the rendering engines, the EGL display survives, and userspace is expected to re-establish its context. The current behaviour kills the whole Hyprland session on what the kernel considers a handled fault — observed in the wild especially around suspend/resume and memory pressure.

This PR implements that recovery path and the null-safety it depends on. It's structured as three reviewable commits:

1. **`core/Compositor: null-guard CWLSurfaceResource against expired m_resource`** — `good()` itself segfaults if `m_resource` is null; fix that and have the forwarding methods (`enter`, `leave`, `sendPreferredTransform/Scale`, `id`, `error`) respect `good()` before dereferencing. Also null-check `pSurface` in `CCompositor::setPreferredScale/TransformForSurface`.

2. **`render: null-guard blur framebuffer accesses`** — `m_blurFB` can be null during monitor (re)init or after a GPU reset invalidates framebuffer objects. `getBlurTexture`, `blurMainFramebuffer`, `preBlurForCurrentMonitor`, and `renderRectWithBlurInternal` all bail gracefully instead of segfaulting. Skipping a blur pass is preferable to taking the session down.

3. **`render: replace fatal aborts on GPU reset with EGL context recovery`** — The main change: adds `attemptContextReset()` (unbinds + rebinds the EGL context, resets `m_shadersInitialized`) and an `m_gpuResetCooldown` frame counter. `begin()`/`beginSimple()` attempt recovery; on success, skip one frame to re-init; on failure, cooldown 60 frames to avoid tight-looping. `end()` no longer aborts on `GL_CONTEXT_LOST`, it just schedules recovery. `renderTextureInternal()` skips invalid-texture draws (post-reset, textures need reupload).

Commits 1 and 2 are the null-guards that surface during the recovery window opened by commit 3; without commit 3 they'd be unreachable in healthy operation.

## Motivation
Framework 13 / Intel Core Ultra (Meteor Lake, `8086:7d55`) on the Xe driver, kernels 6.18+. In the worst stretches the compositor was crashing multiple times per day — the machine became effectively unusable for real work, which is what prompted me to start working on these fixes rather than just reporting the issue. Each crash dropped me back to the TTY mid-task, with every open application gone. The stack always terminated in `CHyprRenderer::renderMonitor` → `__stack_chk_fail` (the `RASSERT`), while `dmesg` showed the kernel having cleanly reset the GPU and resumed — only Hyprland was dying on what was, from the kernel's perspective, a handled fault.

## Test plan
- [x] Builds cleanly against current `main`.
- [x] Running locally on a Framework 13 / Xe / Hyprland setup since early April 2026. GPU resets that previously aborted the compositor now produce a short log burst (`"GPU reset detected... Attempting EGL context recovery"`) followed by normal rendering. No session loss since the recovery path was enabled.
- [ ] Reviewer verification: (a) that `m_shadersInitialized = false` is sufficient state-reset, (b) that 60 frames is a reasonable cooldown (vs. e.g. time-based), (c) that the `pMonitor.reset()` on skipped frames doesn't break any invariants downstream.

## Scope limits / open questions
- Texture and shader state beyond the shader-init flag isn't explicitly reset; in practice the per-frame render pipeline re-creates what it needs. I'd welcome pointers to anything that caches GPU state across frames that would also need invalidation.
- 60-frame cooldown was chosen empirically (≈1 second at 60Hz). Happy to make it configurable or swap to a timestamp.
- Happy to split into separate PRs if preferred, though the three are causally linked.