### PR TITLE
init: drop CAP_SYS_NICE from ambient set after gaining SCHED_RR

### DIFF
--- a/src/init/initHelpers.cpp
+++ b/src/init/initHelpers.cpp
@@ -1,3 +1,6 @@
+#include <linux/capability.h>
+#include <sys/prctl.h>
+
 #include "initHelpers.hpp"
 
 bool NInit::isSudo() {
@@ -20,6 +23,10 @@ void NInit::gainRealTime() {
         Log::logger->log(Log::WARN, "Failed to change process scheduling strategy");
         return;
     }
+
+    // NixOS-specific fix to prevent all children from inheriting
+    // CAP_SYS_NICE due to how the security wrapper works.
+    prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_LOWER, CAP_SYS_NICE, 0, 0);
 
     pthread_atfork(nullptr, nullptr, []() {
         const struct sched_param param = {.sched_priority = 0};


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Add a NixOS-specific fix that prevents all applications running under Hyprland from inheriting CAP_SYS_NICE.

There is no error check here since it's basically useless. Most other distributions will not put CAP_SYS_NICE in the ambient set, only the effective and permitted sets probably, which doesn't have the same behavior.

ref https://github.com/NixOS/nixpkgs/pull/507419

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

N/A

#### Is it ready for merging, or does it need work?

Ready