### PR TITLE
refactor(monocle): avoid repeated workspace monitor lock() calls

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1504,20 +1504,21 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
     bool wasActive = false;
     //close if open elsewhere
     const auto PMONITORWORKSPACEOWNER = pWorkspace->m_monitor.lock();
-    if (const auto PMWSOWNER = pWorkspace->m_monitor.lock(); PMWSOWNER && PMWSOWNER->m_activeSpecialWorkspace == pWorkspace) {
-        PMWSOWNER->m_activeSpecialWorkspace.reset();
-        g_layoutManager->recalculateMonitor(PMWSOWNER);
-        g_pHyprRenderer->damageMonitor(PMWSOWNER);
-        g_pEventManager->postEvent(SHyprIPCEvent{"activespecial", "," + PMWSOWNER->m_name});
-        g_pEventManager->postEvent(SHyprIPCEvent{"activespecialv2", ",," + PMWSOWNER->m_name});
+
+    if (PMONITORWORKSPACEOWNER && PMONITORWORKSPACEOWNER->m_activeSpecialWorkspace == pWorkspace) {
+        PMONITORWORKSPACEOWNER->m_activeSpecialWorkspace.reset();
+        g_layoutManager->recalculateMonitor(PMONITORWORKSPACEOWNER);
+        g_pHyprRenderer->damageMonitor(PMONITORWORKSPACEOWNER);
+        g_pEventManager->postEvent(SHyprIPCEvent{"activespecial", "," + PMONITORWORKSPACEOWNER->m_name});
+        g_pEventManager->postEvent(SHyprIPCEvent{"activespecialv2", ",," + PMONITORWORKSPACEOWNER->m_name});
 
         // Reset layer surfaces on the old monitor when special workspace is stolen
         for (auto const& ls : g_pCompositor->m_layers) {
-            if (ls->m_monitor == PMWSOWNER)
+            if (ls->m_monitor == PMONITORWORKSPACEOWNER)
                 ls->m_aboveFullscreen = false;
         }
 
-        const auto PACTIVEWORKSPACE = PMWSOWNER->m_activeWorkspace;
+        const auto PACTIVEWORKSPACE = PMONITORWORKSPACEOWNER->m_activeWorkspace;
         g_pDesktopAnimationManager->setFullscreenFadeAnimation(PACTIVEWORKSPACE,
                                                                PACTIVEWORKSPACE && PACTIVEWORKSPACE->m_hasFullscreenWindow ? CDesktopAnimationManager::ANIMATION_TYPE_IN :
                                                                                                                              CDesktopAnimationManager::ANIMATION_TYPE_OUT);

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1503,22 +1503,22 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
 
     bool wasActive = false;
     //close if open elsewhere
-    const auto PMONITORWORKSPACEOWNER = pWorkspace->m_monitor.lock();
+    const auto PMONITOR = pWorkspace->m_monitor.lock();
 
-    if (PMONITORWORKSPACEOWNER && PMONITORWORKSPACEOWNER->m_activeSpecialWorkspace == pWorkspace) {
-        PMONITORWORKSPACEOWNER->m_activeSpecialWorkspace.reset();
-        g_layoutManager->recalculateMonitor(PMONITORWORKSPACEOWNER);
-        g_pHyprRenderer->damageMonitor(PMONITORWORKSPACEOWNER);
-        g_pEventManager->postEvent(SHyprIPCEvent{"activespecial", "," + PMONITORWORKSPACEOWNER->m_name});
-        g_pEventManager->postEvent(SHyprIPCEvent{"activespecialv2", ",," + PMONITORWORKSPACEOWNER->m_name});
+    if (PMONITOR && PMONITOR->m_activeSpecialWorkspace == pWorkspace) {
+        PMONITOR->m_activeSpecialWorkspace.reset();
+        g_layoutManager->recalculateMonitor(PMONITOR);
+        g_pHyprRenderer->damageMonitor(PMONITOR);
+        g_pEventManager->postEvent(SHyprIPCEvent{"activespecial", "," + PMONITOR->m_name});
+        g_pEventManager->postEvent(SHyprIPCEvent{"activespecialv2", ",," + PMONITOR->m_name});
 
         // Reset layer surfaces on the old monitor when special workspace is stolen
         for (auto const& ls : g_pCompositor->m_layers) {
-            if (ls->m_monitor == PMONITORWORKSPACEOWNER)
+            if (ls->m_monitor == PMONITOR)
                 ls->m_aboveFullscreen = false;
         }
 
-        const auto PACTIVEWORKSPACE = PMONITORWORKSPACEOWNER->m_activeWorkspace;
+        const auto PACTIVEWORKSPACE = PMONITOR->m_activeWorkspace;
         g_pDesktopAnimationManager->setFullscreenFadeAnimation(PACTIVEWORKSPACE,
                                                                PACTIVEWORKSPACE && PACTIVEWORKSPACE->m_hasFullscreenWindow ? CDesktopAnimationManager::ANIMATION_TYPE_IN :
                                                                                                                              CDesktopAnimationManager::ANIMATION_TYPE_OUT);
@@ -1540,7 +1540,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
     if (POLDSPECIAL)
         POLDSPECIAL->m_events.activeChanged.emit();
 
-    if (PMONITORWORKSPACEOWNER != m_self)
+    if (PMONITOR != m_self)
         pWorkspace->m_events.monitorChanged.emit();
 
     if (!wasActive)

--- a/src/layout/algorithm/tiled/monocle/MonocleAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/monocle/MonocleAlgorithm.cpp
@@ -211,10 +211,11 @@ void CMonocleAlgorithm::moveTargetInDirection(SP<ITarget> t, Math::eDirection di
     if (!t || !t->space() || !t->space()->workspace())
         return;
 
-    const auto PMONINDIR = g_pCompositor->getMonitorInDirection(t->space()->workspace()->m_monitor.lock(), dir);
+    const auto PMONITOR = t->space()->workspace()->m_monitor.lock();
+    const auto PMONINDIR = g_pCompositor->getMonitorInDirection(PMONITOR, dir);
 
     // if we found a monitor, move the window there
-    if (PMONINDIR && PMONINDIR != t->space()->workspace()->m_monitor.lock()) {
+    if (PMONINDIR && PMONINDIR != PMONITOR) {
         const auto TARGETWS = PMONINDIR->m_activeWorkspace;
 
         if (t->window())

--- a/src/layout/algorithm/tiled/monocle/MonocleAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/monocle/MonocleAlgorithm.cpp
@@ -211,7 +211,7 @@ void CMonocleAlgorithm::moveTargetInDirection(SP<ITarget> t, Math::eDirection di
     if (!t || !t->space() || !t->space()->workspace())
         return;
 
-    const auto PMONITOR = t->space()->workspace()->m_monitor.lock();
+    const auto PMONITOR  = t->space()->workspace()->m_monitor.lock();
     const auto PMONINDIR = g_pCompositor->getMonitorInDirection(PMONITOR, dir);
 
     // if we found a monitor, move the window there

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -626,8 +626,11 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
             m_lastFocusOnLS = false;
             return; // don't enter any new surfaces
         } else {
-            if (allowKeyboardRefocus && ((FOLLOWMOUSE != 3 && (*PMOUSEREFOCUS || m_lastMouseFocus.lock() != pFoundWindow)) || refocus)) {
-                if (m_lastMouseFocus.lock() != pFoundWindow || Desktop::focusState()->window() != pFoundWindow || Desktop::focusState()->surface() != foundSurface || refocus) {
+            auto lastFocus = m_lastMouseFocus.lock();
+
+            if (allowKeyboardRefocus && ((FOLLOWMOUSE != 3 && (*PMOUSEREFOCUS || lastFocus != pFoundWindow)) || refocus)) {
+                if (lastFocus != pFoundWindow || Desktop::focusState()->window() != pFoundWindow || Desktop::focusState()->surface() != foundSurface || refocus) {
+
                     m_lastMouseFocus = pFoundWindow;
 
                     // TODO: this looks wrong. When over a popup, it constantly is switching.


### PR DESCRIPTION
Avoid repeated calls to t->space()->workspace()->m_monitor.lock() by caching
the result in a local variable.
This improves readability and avoids redundant weak_ptr locking while keeping
behavior unchanged.
 Testing
-Built Hyprland successfully after the change
-Tested window movement using movefocus keybinds
-Verified no crashes or regressions in single monitor setup
-Behavior remains unchanged