### PR TITLE
socket2: add back changefloatingmode and togglegroup events

### DIFF
--- a/src/desktop/view/Group.cpp
+++ b/src/desktop/view/Group.cpp
@@ -9,6 +9,7 @@
 #include "../../layout/LayoutManager.hpp"
 #include "../../desktop/state/FocusState.hpp"
 #include "../../Compositor.hpp"
+#include "managers/EventManager.hpp"
 
 #include <algorithm>
 
@@ -60,17 +61,15 @@ void CGroup::init() {
     }
 
     updateWindowVisibility();
+
+    g_pEventManager->postEvent(SHyprIPCEvent({.event = "togglegroup", .data = std::format("1,{:x}", rc<uintptr_t>(m_windows.at(0).get()))}));
 }
 
 void CGroup::destroy() {
-    while (true) {
-        if (m_windows.size() == 1) {
-            remove(m_windows.at(0).lock());
-            break;
-        }
+    g_pEventManager->postEvent(SHyprIPCEvent({.event = "togglegroup", .data = std::format("0,{:x}", rc<uintptr_t>(m_windows.at(0).get()))}));
 
+    while (!m_windows.empty())
         remove(m_windows.at(0).lock());
-    }
 }
 
 CGroup::~CGroup() {

--- a/src/desktop/view/Group.cpp
+++ b/src/desktop/view/Group.cpp
@@ -9,6 +9,7 @@
 #include "../../layout/LayoutManager.hpp"
 #include "../../desktop/state/FocusState.hpp"
 #include "../../Compositor.hpp"
+#include "managers/EventManager.hpp"
 
 #include <algorithm>
 
@@ -60,6 +61,8 @@ void CGroup::init() {
     }
 
     updateWindowVisibility();
+
+    g_pEventManager->postEvent(SHyprIPCEvent({.event = "togglegroup", .data = std::format("1,{:x}", rc<uintptr_t>(m_windows.at(0).get()))}));
 }
 
 void CGroup::destroy() {
@@ -71,6 +74,8 @@ void CGroup::destroy() {
 
         remove(m_windows.at(0).lock());
     }
+
+    g_pEventManager->postEvent(SHyprIPCEvent({.event = "togglegroup", .data = std::format("0,{:x}", rc<uintptr_t>(m_windows.at(0).get()))}));
 }
 
 CGroup::~CGroup() {

--- a/src/event/EventBus.hpp
+++ b/src/event/EventBus.hpp
@@ -50,6 +50,7 @@ namespace Event {
                 Event<PHLWINDOW>                        class_;
                 Event<PHLWINDOW>                        pin;
                 Event<PHLWINDOW>                        fullscreen;
+                Event<PHLWINDOW>                        floating;
                 Event<PHLWINDOW>                        updateRules;
                 Event<PHLWINDOW, PHLWORKSPACE>          moveToWorkspace;
             } window;

--- a/src/layout/LayoutManager.cpp
+++ b/src/layout/LayoutManager.cpp
@@ -1,5 +1,6 @@
 #include "LayoutManager.hpp"
 
+#include "managers/EventManager.hpp"
 #include "space/Space.hpp"
 #include "target/Target.hpp"
 
@@ -30,6 +31,12 @@ void CLayoutManager::changeFloatingMode(SP<ITarget> target) {
         return;
 
     target->space()->toggleTargetFloating(target);
+
+    g_pEventManager->postEvent(SHyprIPCEvent({
+        .event = "changefloatingmode",
+        .data  = std::format("{:x},{}", rc<uintptr_t>(target->window().get()), sc<int>(target->floating())),
+    }));
+    Event::bus()->m_events.window.floating.emit(target->window());
 }
 
 void CLayoutManager::beginDragTarget(SP<ITarget> target, eMouseBindMode mode) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

https://github.com/hyprwm/Hyprland/pull/12890 nuked `changefloatingmode` and `togglegroup` events from IPC. add them back. 

fixes #13721

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

(i honestly have no idea if i did this right)

i didnt add an event for groups to EventBus because the old togglegroup events also didn't emit anything and i dont know if we'll ever use it internally

#### Is it ready for merging, or does it need work?

should be ready, tested and works