### PR TITLE
keybinds: fix missing z-order update on floating toggle

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -1034,6 +1034,9 @@ static SDispatchResult toggleActiveFloatingCore(std::string args, std::optional<
 
     g_layoutManager->changeFloatingMode(PWINDOW->layoutTarget());
 
+    if (PWINDOW->m_isFloating)
+        g_pCompositor->changeWindowZOrder(PWINDOW, true);
+
     if (PWINDOW->m_workspace) {
         PWINDOW->m_workspace->updateWindows();
         PWINDOW->m_workspace->updateWindowData();


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
When spawning in a tiling window and changing it to floating, the z-order is not updated. If you have pre-existing floating windows before doing this, it causes the newly floated window to visually appear above the windows yet will be behind in the stack as though it was still a tiling window. If any part of the new floating window is visually overlapping with the old floating windows, attempting to click and grab the overlapping areas will cause your click to go through it and grab the prior windows. (as shown in the before video).

After bisecting, it seems the issue arose from PR #12890; Looks like during the rewrite the updating of the z-order was removed and not re-added (figured this wasn't intentional). Adding the z-order update on floating fixes the issue (and therefore discussion #13553).

(Notice how in the before video, the focus is only on the new floating window when the cursor is in the middle where it's not on top of any existing floating windows)
Before fix:

https://github.com/user-attachments/assets/cf99e0d9-e5a0-4fef-a4ed-797462a942a1

After fix:

https://github.com/user-attachments/assets/260a18d4-3108-4786-aec1-8ad43a21bdcb

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I'm not super familiar with the Hyprland codebase so if there's a more proper way to do this, would appreciate any changes!

#### Is it ready for merging, or does it need work?
Should be ready, didn't break anything in my personal testing and no test regressions.

