### PR TITLE
handle HDR -> SDR with cm_auto_hdr

### DIFF
--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2251,6 +2251,10 @@ void IHyprRenderer::handleFullscreenSettings(PHLMONITOR pMonitor) {
             }
         }
 
+        // Do it here instead of disabling the block above to allow hdr -> hdr metadata changes in fullscreen
+        if (!*PAUTOHDR && !pMonitor->m_lastScanout)
+            wantHDR = configuredHDR;
+
         if (!hdrIsHandled) {
             if (pMonitor->inHDR() != wantHDR) {
                 if (*PAUTOHDR && !(pMonitor->inHDR() && configuredHDR)) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Disable HDR -> SDR auto switch in fullscreen if `render:cm_auto_hdr = 0`.
Fixes https://github.com/hyprwm/Hyprland/pull/13860#issuecomment-4264973894

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Direct scanout is allowed to do SDR -> HDR and HDR -> SDR switches regardless of `cm_auto_hdr` setting. Both should be disabled to block any such automation.
A simple fix but untested.

#### Is it ready for merging, or does it need work?
Ready