### PR TITLE
fix: two memcpy calls in the shared memory (shm) buf... in...

### DIFF
--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -718,6 +718,8 @@ void CWLSurfaceResource::updateCursorShm(CRegion damage) {
                 // bpp is 32 INSALLAH
                 auto begin = 4 * box.y1 * (box.x2 - box.x1) + box.x1;
                 auto len   = 4 * (box.x2 - box.x1);
+                if (len == 0 || begin > shmData.size() || len > shmData.size() - begin)
+                    return;
                 memcpy(shmData.data() + begin, pixelData + begin, len);
             }
         });

--- a/src/protocols/core/Shm.cpp
+++ b/src/protocols/core/Shm.cpp
@@ -63,7 +63,9 @@ Aquamarine::SSHMAttrs CWLSHMBuffer::shm() {
 }
 
 std::tuple<uint8_t*, uint32_t, size_t> CWLSHMBuffer::beginDataPtr(uint32_t flags) {
-    return {sc<uint8_t*>(m_pool->m_data) + m_offset, m_fmt, m_stride * size.y};
+    const size_t maxAvailable = m_pool->m_size > (size_t)m_offset ? m_pool->m_size - (size_t)m_offset : 0;
+    const size_t bufLen       = (size_t)m_stride * (size_t)size.y;
+    return {sc<uint8_t*>(m_pool->m_data) + m_offset, m_fmt, std::min(bufLen, maxAvailable)};
 }
 
 void CWLSHMBuffer::endDataPtr() {


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `src/protocols/core/Compositor.cpp`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `src/protocols/core/Compositor.cpp:714` |

**Description**: Two memcpy calls in the shared memory (SHM) buffer handling code copy client-supplied pixel data into the compositor's internal buffer without validating that bufLen or len does not exceed the destination buffer's actual capacity. A malicious Wayland client can create a wl_shm_pool with a small actual allocation but advertise inflated width, height, and stride parameters, causing the compositor to compute a bufLen larger than shmData's allocated size and overflow the heap buffer.

## Changes
- `src/protocols/core/Shm.cpp`
- `src/protocols/core/Compositor.cpp`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
