### PR TITLE
workspace: guard null monitor access on ws visibility check

### DIFF
--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -403,6 +403,9 @@ bool CWorkspace::isVisible() {
 
 bool CWorkspace::isVisibleNotCovered() {
     const auto PMONITOR = m_monitor.lock();
+    if (!PMONITOR)
+        return false;
+
     if (PMONITOR->m_activeSpecialWorkspace)
         return PMONITOR->m_activeSpecialWorkspace->m_id == m_id;
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Workspace only holds a weak pointer to monitor, which can probably get destroyed at an inopportune time during the refocus checks when a layer surface is being unmapped. Should hopefully fix #14118 (if it doesn't move the crash further down the line lol)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Not sure if the pointer management in workspace/inputmgr/layersurface is all halal especially during monitor removal situations, but can't really figure out if it can be done better. This should fix the crash at least.  

#### Is it ready for merging, or does it need work?

Ready

