### PR TITLE
keybinds: add repeat delay and rate to binds config

### DIFF
--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -501,6 +501,8 @@ std::vector<SP<IValue>> Values::getConfigValues() {
         MS<Bool>("binds:allow_pin_fullscreen", "Allows fullscreen to pinned windows, and restore their pinned status afterwards", false),
         MS<Int>("binds:drag_threshold", "Movement threshold in pixels for window dragging and c/g bind flags. 0 to disable.", 0,
                 {.min = 0, .max = std::numeric_limits<int>::max()}),
+        MS<Int>("binds:repeat_rate", "if 0, will use input:repeat_rate / how frequently bind repeats", 0),
+        MS<Int>("binds:repeat_delay", "if 0, will use input:repeat_delay / delay before bind starts repeating", 0),
 
         /*
          * xwayland:

--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -501,8 +501,8 @@ std::vector<SP<IValue>> Values::getConfigValues() {
         MS<Bool>("binds:allow_pin_fullscreen", "Allows fullscreen to pinned windows, and restore their pinned status afterwards", false),
         MS<Int>("binds:drag_threshold", "Movement threshold in pixels for window dragging and c/g bind flags. 0 to disable.", 0,
                 {.min = 0, .max = std::numeric_limits<int>::max()}),
-        MS<Int>("binds:repeat_rate", "if 0, will use input:repeat_rate / how frequently bind repeats", 0),
-        MS<Int>("binds:repeat_delay", "if 0, will use input:repeat_delay / delay before bind starts repeating", 0),
+        MS<Int>("binds:repeat_rate", "if 0, will use input:repeat_rate / how frequently bind repeats", 0, {.min = 0, .max = 200}),
+        MS<Int>("binds:repeat_delay", "if 0, will use input:repeat_delay / delay before bind starts repeating", 0, {.min = 0, .max = 2000}),
 
         /*
          * xwayland:

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -562,6 +562,8 @@ SSubmap CKeybindManager::getCurrentSubmap() {
 SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SPressedKeyWithMods& key, bool pressed, SP<IKeyboard> keyboard, SP<IHID> device) {
     static auto     PDISABLEINHIBIT = CConfigValue<Config::INTEGER>("binds:disable_keybind_grabbing");
     static auto     PDRAGTHRESHOLD  = CConfigValue<Config::INTEGER>("binds:drag_threshold");
+    static auto     PREPEATRATE     = CConfigValue<Config::INTEGER>("binds:repeat_rate");
+    static auto     PREPEATDELAY    = CConfigValue<Config::INTEGER>("binds:repeat_delay");
 
     bool            found = false;
     SDispatchResult res;
@@ -755,11 +757,12 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
         }
 
         if (pressed && k->repeat) {
-            const auto KEEB = keyboard ? keyboard : g_pSeatManager->m_keyboard.lock();
-            m_repeatKeyRate = KEEB->m_repeatRate;
+            const auto KEEB  = keyboard ? keyboard : g_pSeatManager->m_keyboard.lock();
+            m_repeatKeyRate  = (*PREPEATRATE <= 0) ? KEEB->m_repeatRate : *PREPEATRATE;
+            auto repeatDelay = (*PREPEATDELAY <= 0) ? KEEB->m_repeatDelay : *PREPEATDELAY;
 
             m_activeKeybinds.emplace_back(k);
-            m_repeatKeyTimer->updateTimeout(std::chrono::milliseconds(KEEB->m_repeatDelay));
+            m_repeatKeyTimer->updateTimeout(std::chrono::milliseconds(repeatDelay));
         }
 
         if (!k->nonConsuming && !(k->autoConsuming && !res.success))


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Add new config options `binds:repeat_delay` and `binds:repeat_rate` (INT, 0-inf, default fall back to values from input configuration). I just don't want to use input variables because they would also change values for text typing.

https://github.com/user-attachments/assets/28d1d525-095e-419f-a58e-064dae397171

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No known issues.

#### Is it ready for merging, or does it need work?
Please, let me know if documentation should be added first.

I'm also considering adding the same options for submaps, but not sure if that's good idea. I would be happy to receive feedback.