### PR TITLE
xwayland: don't fail selection reads on EINTR/EAGAIN

### DIFF
--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -1468,6 +1468,11 @@ int SXSelection::onRead(int fd, uint32_t mask) {
     ssize_t bytesRead = read(fd, transfer->data.data() + oldSize, INCR_CHUNK_SIZE - 1);
 
     if (bytesRead < 0) {
+        if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK) {
+            transfer->data.resize(oldSize);
+            return 1;
+        }
+
         Log::logger->log(Log::ERR, "[xwm] readDataSource died");
         g_pXWayland->m_wm->selectionSendNotify(&transfer->request, false);
         transfers.erase(it);


### PR DESCRIPTION
SXSelection::onRead currently treats any read() error as fatal, but
EINTR/EAGAIN/EWOULDBLOCK are just temporary conditions and can happen
in event-driven I/O.

Instead of aborting the transfer, handle these by restoring the buffer
and retrying on the next event loop iteration.

This avoids random clipboard / DnD failures when a read gets interrupted
or no data is available yet.

Tested with normal copy/paste and by spamming wl-copy in a loop --- no
regressions or unexpected failures observed.