### PR TITLE
seat: fix dropped wl_keyboard.enter after stale keyboardFocusResource

### DIFF
--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -226,19 +226,11 @@ void CSeatManager::setPointerFocus(SP<CWLSurfaceResource> surf, const Vector2D& 
 
     m_listeners.pointerSurfaceDestroy.reset();
 
-    if (m_state.pointerFocusResource) {
-        auto client = m_state.pointerFocusResource->client();
-        for (auto const& s : m_seatResources) {
-            if (s->resource->client() != client)
-                continue;
+    for (auto const& p : PROTO::seat->m_pointers) {
+        if (!p)
+            continue;
 
-            for (auto const& p : s->resource->m_pointers) {
-                if (!p)
-                    continue;
-
-                p->sendLeave();
-            }
-        }
+        p->sendLeave();
     }
 
     auto lastPointerFocusResource = m_state.pointerFocusResource;

--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -120,20 +120,14 @@ void CSeatManager::setKeyboardFocus(SP<CWLSurfaceResource> surf) {
 
     m_listeners.keyboardSurfaceDestroy.reset();
 
-    if (m_state.keyboardFocusResource) {
-        auto client = m_state.keyboardFocusResource->client();
-        for (auto const& s : m_seatResources) {
-            if (s->resource->client() != client)
-                continue;
+    // Don't gate leave on m_state.keyboardFocusResource — the WP can
+    // be stale. sendLeave no-ops on keyboards without m_currentSurface.
+    for (auto const& k : PROTO::seat->m_keyboards) {
+        if (!k)
+            continue;
 
-            for (auto const& k : s->resource->m_keyboards) {
-                if (!k)
-                    continue;
-
-                k->sendMods(0, m_keyboard->m_modifiersState.latched, m_keyboard->m_modifiersState.locked, m_keyboard->m_modifiersState.group);
-                k->sendLeave();
-            }
-        }
+        k->sendMods(0, m_keyboard->m_modifiersState.latched, m_keyboard->m_modifiersState.locked, m_keyboard->m_modifiersState.group);
+        k->sendLeave();
     }
 
     m_state.keyboardFocusResource.reset();


### PR DESCRIPTION
## Summary

`CSeatManager::setKeyboardFocus`'s leave loop is gated on `m_state.keyboardFocusResource` — a `WP<CWLSeatResource>`. When that weak pointer is expired between focus cycles the leave loop is skipped entirely, no `wl_keyboard.leave` is sent, and the previously-focused client's per-keyboard `CWLKeyboardResource::m_currentSurface` stays stuck on the old surface. On the next focus back, `sendEnter`'s `if (m_currentSurface == surface) return;` dedup silently drops the enter.

Fix: iterate `PROTO::seat->m_keyboards` (the global owning list) and let `sendLeave()`'s own `m_currentSurface` gate decide. `sendLeave()` and the `sendMods(0, …)` that precedes it are both no-ops for any keyboard that wasn't on the previous focus — identical semantics to the old seat-scoped loop when the WP is healthy, correct when it's stale.

Enter loop unchanged: it's driven by `surf->client()`, a cached `wl_client*` on the surface resource, which is stable across cycles.

## Related

Reported + reproducer at https://github.com/hyprwm/Hyprland/discussions/14141.

User-visible symptom: after a taskbar click / `Alt+Tab` / `hyprctl dispatch focuswindow`, the caret blinks in the target's text input but typed keys don't reach it. A mouse drag fixes it because `processMouseDownNormal → refocus() → mouseMoveUnified(refocus=true) → rawWindowFocus(…, foundSurface)` takes a different path that forces leave/enter through.

## How the WP goes stale

Two mechanisms found in-tree:

1. Explicit `.reset()` in `KeybindManager::passKeys` (the XWayland hack around line 2307 — the comment literally says *"Massive hack … please kill me"*). This runs on key-binding passthrough targeting X11 windows.
2. `CWLSeatResource` destruction in between cycles — e.g. some toolkit flows where a client releases and re-binds `wl_seat` after config-change or gaming-exclusive transitions. The `SSeatResourceContainer::listeners.destroy` callback in `CSeatManager` erases the container, the weak pointer in `m_state.keyboardFocusResource` expires.

Either way, the next `setKeyboardFocus` call evaluates `if (m_state.keyboardFocusResource)` as false, skips the leave loop, never resets the client's per-keyboard `m_currentSurface`, and then the enter dedup traps the return trip.

## Verification

Reproducer from discussion #14141 (two `wev` instances cycled with `hyprctl dispatch focuswindow`):

**Before fix** (v0.54.3):
```
wev-A: 3 enter, 2 leave, 5 modifiers (plateaus after cycle 3)
wev-B: 3 enter, 2 leave, 5 modifiers (plateaus after cycle 3)
```
Both windows' final `wl_keyboard` event is `enter` — they simultaneously believe they're focused.

**After fix** (same repro, same session):
```
wev-A: ends on leave, counts scale with cycle count
wev-B: ends on enter, counts scale with cycle count
```
Clean leave/enter pair per dispatch.

## Test plan
- [x] Builds clean against v0.54.3 and current `main`
- [x] Reproducer from #14141 passes against patched build
- [x] Manual confirmation on a live session (typing works after taskbar click / `Alt+Tab` / dispatcher focus)
- [ ] CI will exercise whatever compositor tests main has; no new tests added (no test harness for seat focus flow upstream yet)

## Notes

- Cost: one extra vector traversal per focus change. Worst case ~30 keyboard resources on a full session (per wl_seat get_keyboard across all mapped clients — GTK, Qt, Electron, XWayland bridge, terminal emulators). Submicrosecond.
- No API/ABI impact. No header changes.