### PR TITLE
minor egl changes

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1933,6 +1933,7 @@ void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox
 
         if (NEEDS_STENCIL) {
             scissor(nullptr); // allow the entire window and stencil to render
+            glStencilMask(0xFF);
             glClearStencil(0);
             glClear(GL_STENCIL_BUFFER_BIT);
 
@@ -1964,7 +1965,8 @@ void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox
             glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
 
             glStencilFunc(GL_EQUAL, 1, 0xFF);
-            glStencilOp(GL_KEEP, GL_KEEP, GL_REPLACE);
+            glStencilMask(0x00);
+            glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
         }
 
         // stencil done. Render everything.

--- a/src/render/gl/GLElementRenderer.cpp
+++ b/src/render/gl/GLElementRenderer.cpp
@@ -24,15 +24,17 @@ void CGLElementRenderer::draw(WP<CClearPassElement> element, const CRegion& dama
     RASSERT(g_pHyprRenderer->m_renderData.pMonitor, "Tried to render without begin()!");
 
     TRACY_GPU_ZONE("RenderClear");
-
-    GLCALL(glClearColor(color.r, color.g, color.b, color.a));
+    const std::array<GLfloat, 4> c = {sc<GLfloat>(color.r), sc<GLfloat>(color.g), sc<GLfloat>(color.b), sc<GLfloat>(color.a)};
 
     if (!g_pHyprRenderer->m_renderData.damage.empty()) {
-        g_pHyprRenderer->m_renderData.damage.forEachRect([](const auto& RECT) {
+        g_pHyprRenderer->m_renderData.damage.forEachRect([&c](const auto& RECT) {
             g_pHyprOpenGL->scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
-            glClear(GL_COLOR_BUFFER_BIT);
+            glClearBufferfv(GL_COLOR, 0, c.data());
         });
-    }
+
+        g_pHyprOpenGL->scissor(nullptr);
+    } else
+        glClearBufferfv(GL_COLOR, 0, c.data());
 };
 
 void CGLElementRenderer::draw(WP<CFramebufferElement> element, const CRegion& damage) {


### PR DESCRIPTION
explicitly set stencil mask 0xFF for writeable, and 0x00 for readonly. also set the stencilOp to GL_KEEP to ensure its only readonly. avoids potential future mishaps.


use more modern glClearBufferfv over glclear, reset scissor, and if no renderdamage and a clearpass was added. clear entire buffer.

