### PR TITLE
desktop/view: fix SIGABRT in CWindow::onUnmap when monitor is expired

### DIFF
--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -575,8 +575,11 @@ void CWindow::onUnmap() {
     // if the special workspace now has 0 windows, it will be closed, and this
     // window will no longer pass render checks, cuz the workspace will be nuked.
     // throw it into the main one for the fadeout.
-    if (m_workspace->m_isSpecialWorkspace && m_workspace->getWindows() == 0)
-        m_lastWorkspace = m_monitor->activeWorkspaceID();
+    if (m_workspace->m_isSpecialWorkspace && m_workspace->getWindows() == 0) {
+        const auto PMONITOR = m_monitor.lock();
+        if (PMONITOR)
+            m_lastWorkspace = PMONITOR->activeWorkspaceID();
+    }
 
     if (*PCLOSEONLASTSPECIAL && m_workspace && m_workspace->getWindows() == 0 && onSpecialWorkspace()) {
         const auto PMONITOR = m_monitor.lock();


### PR DESCRIPTION
m_monitor is a WP<CMonitor> (weak_ptr). In onUnmap(), calling m_monitor->activeWorkspaceID() without .lock() causes SIGABRT when the monitor has been destroyed before the XWayland unmap event arrives, e.g. when a window on a special workspace is unmapped.

<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

Fixes SIGABRT in `CWindow::onUnmap()` when an XWayland window on a special workspace is unmapped after its monitor has been destroyed. `m_monitor->activeWorkspaceID()` dereferences a `WP<CMonitor>` without `.lock()`, consistent with the guard already used 3 lines below.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No behavior change for the normal path. When `.lock()` fails, `m_lastWorkspace` keeps its previous value, which is only used as a fallback for post-unmap rendering.

#### Is it ready for merging, or does it need work?

Ready for merging.

