### PR TITLE
fix: include `setByUser` in `CConfigManager::getConfigValue`

### DIFF
--- a/src/config/legacy/ConfigManager.cpp
+++ b/src/config/legacy/ConfigManager.cpp
@@ -1482,7 +1482,7 @@ SConfigOptionReply CConfigManager::getConfigValue(const std::string& val) {
     if (!VAL)
         return {};
 
-    return {.dataptr = VAL->getDataStaticPtr(), .type = &VAL->getValue().type()};
+    return {.dataptr = VAL->getDataStaticPtr(), .type = &VAL->getValue().type(), .setByUser = VAL->m_bSetByUser};
 }
 
 Hyprlang::CConfigValue* CConfigManager::getHyprlangConfigValuePtr(const std::string& name, const std::string& specialCat) {


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
This PR fixes `CConfigManager::getConfigValue` by adding the missing `setByUser` field to the returned `SConfigOptionReply`

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
N/A

#### Is it ready for merging, or does it need work?
Ready

