### PR TITLE
fix: `cycle_next` w/ `tiled = true` doesn't choose only tiled windows

### DIFF
--- a/hyprtester/src/tests/main/window.cpp
+++ b/hyprtester/src/tests/main/window.cpp
@@ -1052,3 +1052,75 @@ TEST_CASE(windows) {
 
     OK(getFromSocket("/eval hl.plugin.test.check_window_rule()"));
 }
+
+TEST_CASE(cycle_nextTiled) {
+    // If the user specifically requests a tiled window, give them a tiled window
+
+    if (!spawnKitty("a")) {
+        FAIL_TEST("Could not spawn kitty of class:a");
+    }
+
+    if (!spawnKitty("b")) {
+        FAIL_TEST("Could not spawn kitty of class:b");
+    }
+
+    if (!spawnKitty("c")) {
+        FAIL_TEST("Could not spawn kitty of class:c");
+    }
+
+    if (!spawnKitty("d")) {
+        FAIL_TEST("Could not spawn kitty of class:d");
+    }
+
+    // float the class:a window
+    OK(getFromSocket("/dispatch hl.dsp.window.float({action = 'enable', window = 'class:a'})"));
+    // float the class:c window
+    OK(getFromSocket("/dispatch hl.dsp.window.float({action = 'enable', window = 'class:c'})"));
+    // float the class:d window
+    OK(getFromSocket("/dispatch hl.dsp.window.float({action = 'enable', window = 'class:d'})"));
+
+    // establish focus history
+    OK(getFromSocket("/dispatch hl.dsp.focus({window = 'class:a'})")); // floating
+    OK(getFromSocket("/dispatch hl.dsp.focus({window = 'class:b'})")); // tiled  <-- What we want to focus on
+    OK(getFromSocket("/dispatch hl.dsp.focus({window = 'class:c'})")); // floating
+    OK(getFromSocket("/dispatch hl.dsp.focus({window = 'class:d'})")); // floating
+
+    // request a tiled window
+    OK(getFromSocket("/dispatch hl.dsp.window.cycle_next({ next = true, tiled = true, floating = false})"));
+
+    ASSERT_CONTAINS(getFromSocket("/activewindow"), "class: b");
+}
+
+TEST_CASE(cycle_nextFloating) {
+    // If the user specifically requests a floating window, give them a floating window
+
+    if (!spawnKitty("a")) {
+        FAIL_TEST("Could not spawn kitty of class:a");
+    }
+
+    if (!spawnKitty("b")) {
+        FAIL_TEST("Could not spawn kitty of class:b");
+    }
+
+    if (!spawnKitty("c")) {
+        FAIL_TEST("Could not spawn kitty of class:c");
+    }
+
+    if (!spawnKitty("d")) {
+        FAIL_TEST("Could not spawn kitty of class:d");
+    }
+
+    // float the class:b window
+    OK(getFromSocket("/dispatch hl.dsp.window.float({action = 'enable', window = 'class:b'})"));
+
+    // establish focus history
+    OK(getFromSocket("/dispatch hl.dsp.focus({window = 'class:a'})")); // tiled
+    OK(getFromSocket("/dispatch hl.dsp.focus({window = 'class:b'})")); // floating  <-- What we want to focus on
+    OK(getFromSocket("/dispatch hl.dsp.focus({window = 'class:c'})")); // tiled
+    OK(getFromSocket("/dispatch hl.dsp.focus({window = 'class:d'})")); // tiled
+
+    // request a floating window
+    OK(getFromSocket("/dispatch hl.dsp.window.cycle_next({ next = true, tiled = false, floating = true})"));
+
+    ASSERT_CONTAINS(getFromSocket("/activewindow"), "class: b");
+}

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -1664,9 +1664,6 @@ ActionResult Actions::cycleNext(const bool next, std::optional<bool> onlyTiled, 
         }
     }
 
-
-
-
     // true = floating
     // false = tiling
     // either-or = either-or
@@ -1674,7 +1671,6 @@ ActionResult Actions::cycleNext(const bool next, std::optional<bool> onlyTiled, 
 
     if (onlyTiled.value_or(false) != onlyFloating.value_or(false))
         tileOrFloatOnly = onlyFloating.value_or(false);
-
 
     const auto& cycled = g_pCompositor->getWindowCycle(window, true, tileOrFloatOnly, false, !next, window->m_workspace && window->m_workspace->m_hasFullscreenWindow);
 

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -1664,11 +1664,19 @@ ActionResult Actions::cycleNext(const bool next, std::optional<bool> onlyTiled, 
         }
     }
 
-    std::optional<bool> floatStatus = {};
-    if (onlyFloating.value_or(false))
-        floatStatus = true;
 
-    const auto& cycled = g_pCompositor->getWindowCycle(window, true, floatStatus, false, !next, window->m_workspace && window->m_workspace->m_hasFullscreenWindow);
+
+
+    // true = floating
+    // false = tiling
+    // either-or = either-or
+    std::optional<bool> tileOrFloatOnly = std::nullopt;
+
+    if (onlyTiled.value_or(false) != onlyFloating.value_or(false))
+        tileOrFloatOnly = onlyFloating.value_or(false);
+
+
+    const auto& cycled = g_pCompositor->getWindowCycle(window, true, tileOrFloatOnly, false, !next, window->m_workspace && window->m_workspace->m_hasFullscreenWindow);
 
     switchToWindow(cycled);
 


### PR DESCRIPTION

#### Describe your PR, what does it fix/add?

`cycle_next` when `tiled = true, floating = false` doesn't choose a non-floating window as it should.

e.g.
history: float_1 (currently focused) -> float_2 -> tiled_1

`cycle_next` chooses float_2 when it should have chosen tiled_1


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
yes

