### PR TITLE
screenshare/frame: set m_copied after shm copy succeeds

### DIFF
--- a/src/managers/screenshare/ScreenshareFrame.cpp
+++ b/src/managers/screenshare/ScreenshareFrame.cpp
@@ -441,6 +441,7 @@ bool CScreenshareFrame::copyShm() {
     if (!m_copied) {
         LOGM(Log::TRACE, "Copied frame via shm");
         m_callback(RESULT_COPIED);
+        m_copied = true;
     }
 
     return true;


### PR DESCRIPTION
b1g (large) fix for https://github.com/hyprwm/Hyprland/discussions/14123 and https://github.com/hyprwm/Hyprland/discussions/13952