### PR TITLE
renderer: swizzle on shm screencopy

### DIFF
--- a/src/render/gl/GLFramebuffer.cpp
+++ b/src/render/gl/GLFramebuffer.cpp
@@ -127,21 +127,17 @@ bool CGLFramebuffer::readPixels(CHLBufferReference buffer, uint32_t offsetX, uin
     uint32_t packStride = minStride(PFORMAT, m_size.x);
     int      glFormat   = PFORMAT->glFormat;
 
-    if (glFormat == GL_RGBA)
-        glFormat = GL_BGRA_EXT;
-
-    if (glFormat != GL_BGRA_EXT && glFormat != GL_RGB) {
-        if (PFORMAT->swizzle.has_value()) {
-            if (PFORMAT->swizzle == SWIZZLE_RGBA)
-                glFormat = GL_RGBA;
-            else if (PFORMAT->swizzle == SWIZZLE_BGRA)
-                glFormat = GL_BGRA_EXT;
-            else {
-                LOGM(Log::ERR, "Copied frame via shm might be broken or color flipped");
-                glFormat = GL_RGBA;
-            }
+    if (PFORMAT->swizzle.has_value()) {
+        if (PFORMAT->swizzle == SWIZZLE_RGBA)
+            glFormat = GL_RGBA;
+        else if (PFORMAT->swizzle == SWIZZLE_BGRA)
+            glFormat = GL_BGRA_EXT;
+        else {
+            LOGM(Log::ERR, "Copied frame via shm might be broken or color flipped");
+            glFormat = GL_RGBA;
         }
-    }
+    } else if (glFormat == GL_RGBA)
+        glFormat = GL_BGRA_EXT;
 
     // This could be optimized by using a pixel buffer object to make this async,
     // but really clients should just use a dma buffer anyways.


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

in ds format (XBGR8888) the swizzle was pretty much being skipped. It would cause screenshots taken within DS, or apps which use screencopy like hyprpicker, wayfreeze, and still, to come out with the red and blue channels flipped.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

again idk if this is correct, could get some guidance from @ikalco , @UjinT34 , @gulafaran :)

#### Is it ready for merging, or does it need work?

should be ja. tested on minecraft and retroarch, screenshots are not flipped anymore :D

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/14d111c7-2a54-480a-9657-d6ae2c2a0367" />
no more red sea :(