### PR TITLE
screencopy: clear stale m_lastScanout when theres a pending frame

### DIFF
--- a/src/managers/screenshare/ScreenshareSession.cpp
+++ b/src/managers/screenshare/ScreenshareSession.cpp
@@ -174,6 +174,8 @@ UP<CScreenshareFrame> CScreenshareSession::nextFrame(bool overlayCursor) {
 
     // there is now a pending frame, so block ds
     g_pHyprRenderer->m_directScanoutBlocked = true;
+    if (const auto PMONITOR = monitor(); PMONITOR)
+        PMONITOR->m_lastScanout.reset();
 
     return frame;
 }


### PR DESCRIPTION

<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

fixes the scenario when using SHM screencopy in DS and having the output be more vibrant than what is visible on screen. explicitly reset m_lastScanout when there's a pending frame.

specifically noticed it with `non_shader_cm` 2. on 1 it worked fine either way


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

before, toplevel and shm screencopy would look different in DS. below shows minecraft. 2nd image is what is visible on screen and therefore the correct one.
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/b3a06620-4444-4c21-b293-d92106d7da89" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/07b7a84c-38f3-43e7-bd71-94b74cbc268e" />

after this change both `grim -o DP-3` and `grim -T <stableID>` look the same in DS scenarios.

#### Is it ready for merging, or does it need work?

i think so