### PR TITLE
dispatcher: default to active window for movetoworkspace dispatchers

### DIFF
--- a/src/config/legacy/DispatcherTranslator.cpp
+++ b/src/config/legacy/DispatcherTranslator.cpp
@@ -203,7 +203,7 @@ static SDispatchResult fullscreenstate(const std::string& args) {
 }
 
 static SDispatchResult movetoworkspace(const std::string& args) {
-    PHLWINDOW   PWINDOW = nullptr;
+    PHLWINDOW   PWINDOW = Desktop::focusState()->window();
     std::string wsArgs  = args;
 
     if (args.contains(',')) {
@@ -219,7 +219,7 @@ static SDispatchResult movetoworkspace(const std::string& args) {
 }
 
 static SDispatchResult movetoworkspacesilent(const std::string& args) {
-    PHLWINDOW   PWINDOW = nullptr;
+    PHLWINDOW   PWINDOW = Desktop::focusState()->window();
     std::string wsArgs  = args;
 
     if (args.contains(',')) {


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

Fixes a regression in movetoworkspace dispatcher behaviour introduced in #13817. Defaulting to the activewindow allows the [example configuration](https://github.com/hyprwm/Hyprland/blob/13d3695dd114f77da1258f041247306d485ed18e/example/hyprland.conf#L265) to continue to work while users move to lua.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

\-

#### Is it ready for merging, or does it need work?

Should be ready, assuming this is the correct way forward.