### PR TITLE
Improve cursor size logging

### DIFF
--- a/src/managers/CursorManager.cpp
+++ b/src/managers/CursorManager.cpp
@@ -79,7 +79,9 @@ CCursorManager::CCursorManager() {
         if (SIZE) {
             try {
                 m_size = std::stoi(SIZE);
-            } catch (...) { ; }
+            } catch (...) {
+                Log::logger->log(Log::WARN, "Invalid HYPRCURSOR_SIZE value \"{}\"", SIZE);
+            }
         }
 
         if (m_size <= 0) {
@@ -93,7 +95,9 @@ CCursorManager::CCursorManager() {
         if (SIZE) {
             try {
                 m_size = std::stoi(SIZE);
-            } catch (...) { ; }
+            } catch (...) {
+                Log::logger->log(Log::WARN, "Invalid XCURSOR_SIZE value \"{}\"", SIZE);
+            }
         }
 
         if (m_size <= 0) {

--- a/src/managers/CursorManager.cpp
+++ b/src/managers/CursorManager.cpp
@@ -79,9 +79,7 @@ CCursorManager::CCursorManager() {
         if (SIZE) {
             try {
                 m_size = std::stoi(SIZE);
-            } catch (...) {
-                Log::logger->log(Log::WARN, "Invalid HYPRCURSOR_SIZE value \"{}\"", SIZE);
-            }
+            } catch (...) { Log::logger->log(Log::WARN, "Invalid HYPRCURSOR_SIZE value \"{}\"", SIZE); }
         }
 
         if (m_size <= 0) {
@@ -95,9 +93,7 @@ CCursorManager::CCursorManager() {
         if (SIZE) {
             try {
                 m_size = std::stoi(SIZE);
-            } catch (...) {
-                Log::logger->log(Log::WARN, "Invalid XCURSOR_SIZE value \"{}\"", SIZE);
-            }
+            } catch (...) { Log::logger->log(Log::WARN, "Invalid XCURSOR_SIZE value \"{}\"", SIZE); }
         }
 
         if (m_size <= 0) {


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

Adds diagnostic logging when parsing `HYPRCURSOR_SIZE` and `XCURSOR_SIZE` environment variables. If these values are invalid (non-integer), a warning is now logged to help users debug configuration issues.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?

Ready
