### PR TITLE
dwindle: don't warn when splitting with only 1 window

### DIFF
--- a/src/layout/algorithm/tiled/dwindle/DwindleAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/dwindle/DwindleAlgorithm.cpp
@@ -644,6 +644,8 @@ std::expected<void, std::string> CDwindleAlgorithm::layoutMsg(const std::string_
 
     if (ARGS[0] == "togglesplit") {
         if (CURRENT_NODE) {
+            if (!CURRENT_NODE->pParent)
+                return {};
             if (!toggleSplit(CURRENT_NODE))
                 return std::unexpected("can't togglesplit in the current workspace");
         }


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
don't warn when splitting with only 1 window
<img width="630" height="423" alt="image" src="https://github.com/user-attachments/assets/2cbc2790-b570-4544-b81b-13a7398a4c00" />

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?


