### PR TITLE
NotificationOverlay: take reserved space into account

### DIFF
--- a/src/notification/NotificationOverlay.cpp
+++ b/src/notification/NotificationOverlay.cpp
@@ -124,7 +124,10 @@ CBox CNotificationOverlay::notificationDamageForMonitor(PHLMONITOR pMonitor) {
     if (!pMonitor || m_notifications.empty())
         return {};
 
-    float       offsetY  = NOTIF_OFFSET_Y;
+    const float reservedTop   = pMonitor->m_reservedArea.top();
+    const float reservedRight = pMonitor->m_reservedArea.right();
+
+    float       offsetY  = NOTIF_OFFSET_Y + reservedTop;
     float       maxWidth = 0.F;
 
     static auto fontFamily = CConfigValue<std::string>("misc:font_family");
@@ -145,8 +148,8 @@ CBox CNotificationOverlay::notificationDamageForMonitor(PHLMONITOR pMonitor) {
             maxWidth = NOTIFSIZE.x;
     }
 
-    return CBox{sc<int>(pMonitor->m_position.x + pMonitor->m_size.x - maxWidth - NOTIF_DAMAGE_PAD_X), sc<int>(pMonitor->m_position.y), sc<int>(maxWidth + NOTIF_DAMAGE_PAD_X),
-                sc<int>(offsetY + NOTIF_OFFSET_Y)};
+    return CBox{sc<int>(pMonitor->m_position.x + pMonitor->m_size.x - reservedRight - maxWidth - NOTIF_DAMAGE_PAD_X), sc<int>(pMonitor->m_position.y + reservedTop),
+                sc<int>(maxWidth + NOTIF_DAMAGE_PAD_X), sc<int>(offsetY + NOTIF_OFFSET_Y - reservedTop)};
 }
 
 SP<CNotification> CNotificationOverlay::addNotification(const std::string& text, const CHyprColor& color, const float timeMs, const eIcons icon, const float fontSize) {
@@ -196,7 +199,10 @@ std::vector<SP<CNotification>> CNotificationOverlay::getNotifications() const {
 }
 
 CBox CNotificationOverlay::drawNotifications(PHLMONITOR pMonitor) {
-    float       offsetY  = NOTIF_OFFSET_Y;
+    const float reservedTopPx   = pMonitor->m_reservedArea.top() * pMonitor->m_scale;
+    const float reservedRightPx = pMonitor->m_reservedArea.right() * pMonitor->m_scale;
+
+    float       offsetY  = NOTIF_OFFSET_Y + reservedTopPx;
     float       maxWidth = 0;
 
     const auto  MONSIZE = pMonitor->m_transformedSize;
@@ -237,10 +243,10 @@ CBox CNotificationOverlay::drawNotifications(PHLMONITOR pMonitor) {
         // third rect (horiz, col)
         const float                 THIRDRECTPERC = std::clamp(elapsed / lifeMs, 0.F, 1.F);
 
-        const float                 firstRectX = MONSIZE.x - (NOTIFSIZE.x + NOTIF_LEFTBAR_SIZE) * FIRSTRECTPERC;
+        const float                 firstRectX = MONSIZE.x - reservedRightPx - (NOTIFSIZE.x + NOTIF_LEFTBAR_SIZE) * FIRSTRECTPERC;
         const float                 firstRectW = (NOTIFSIZE.x + NOTIF_LEFTBAR_SIZE) * FIRSTRECTPERC;
 
-        const float                 secondRectX = MONSIZE.x - NOTIFSIZE.x * SECONDRECTPERC;
+        const float                 secondRectX = MONSIZE.x - reservedRightPx - NOTIFSIZE.x * SECONDRECTPERC;
         const float                 secondRectW = NOTIFSIZE.x * SECONDRECTPERC;
 
         CRectPassElement::SRectData bgData;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

didn't take reserved space into account. now it does. before and after:
<img width="630" height="423" alt="Screenshot from 26 04 27 15:31:32" src="https://github.com/user-attachments/assets/098c69e0-32ea-4b6b-baae-2c2690442f70" />
<img width="515" height="443" alt="Screenshot from 26 04 27 16:53:48" src="https://github.com/user-attachments/assets/0ceb057f-db42-4e69-ab2b-4866a727fe93" />

works on normal notifs, and works with scaling
<img width="770" height="422" alt="Screenshot from 26 04 27 16:57:54" src="https://github.com/user-attachments/assets/5da96097-674e-4f33-99f8-5e557524f885" />
 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

idk

#### Is it ready for merging, or does it need work?

sure