### PR TITLE
Rename 'allow' field to 'mode' in PermissionSpec

### DIFF
--- a/meta/hl.meta.lua
+++ b/meta/hl.meta.lua
@@ -419,7 +419,7 @@ local __HL_GestureSpec = {}
 ---@class HL.PermissionSpec
 ---@field binary string
 ---@field type string
----@field allow string
+---@field mode string
 local __HL_PermissionSpec = {}
 
 ---@class HL.NotificationOptions


### PR DESCRIPTION
I noticed this differs from what the wiki says, and I believe the wiki version is correct.



