### PR TITLE
feat(lua): add properties to workspace api

### DIFF
--- a/meta/hl.meta.lua
+++ b/meta/hl.meta.lua
@@ -703,14 +703,13 @@ local __HL_Window = {}
 local __HL_WindowRule = {}
 
 ---@class HL.Workspace
+---@field get_groups fun(self: HL.Workspace, ...): any
 ---@field get_windows fun(self: HL.Workspace, ...): any
 ---@field active boolean
 ---@field config_name string
----@field default_floating boolean
----@field default_pseudo boolean
 ---@field fullscreen_mode integer
 ---@field fullscreen_window HL.Window|nil
----@field groups integer
+---@field groups integer|nil
 ---@field has_fullscreen boolean
 ---@field has_urgent boolean
 ---@field id integer

--- a/meta/hl.meta.lua
+++ b/meta/hl.meta.lua
@@ -703,15 +703,24 @@ local __HL_Window = {}
 local __HL_WindowRule = {}
 
 ---@class HL.Workspace
+---@field get_windows fun(self: HL.Workspace, ...): any
 ---@field active boolean
+---@field config_name string
+---@field default_floating boolean
+---@field default_pseudo boolean
 ---@field fullscreen_mode integer
+---@field fullscreen_window HL.Window|nil
+---@field groups integer
 ---@field has_fullscreen boolean
 ---@field has_urgent boolean
 ---@field id integer
----@field is_persistent boolean|nil
+---@field is_empty boolean
+---@field is_persistent boolean
+---@field last_window HL.Window|nil
 ---@field monitor HL.Monitor|nil
 ---@field name string
 ---@field special boolean
+---@field tiled_layout string
 ---@field visible boolean
 ---@field windows integer
 local __HL_Workspace = {}

--- a/meta/hl.meta.lua
+++ b/meta/hl.meta.lua
@@ -565,6 +565,15 @@ local __HL_WorkspaceRuleSpec = {}
 ---@field remove fun(self: HL.EventSubscription, ...): any
 local __HL_EventSubscription = {}
 
+---@class HL.Group
+---@field current HL.Window|nil
+---@field current_index integer
+---@field denied boolean
+---@field locked boolean
+---@field members HL.Window|table|nil
+---@field size integer
+local __HL_Group = {}
+
 ---@class HL.Keybind
 ---@field is_enabled fun(self: HL.Keybind, ...): any
 ---@field remove fun(self: HL.Keybind, ...): any
@@ -676,7 +685,7 @@ local __HL_Timer = {}
 ---@field focus_history_id integer
 ---@field fullscreen integer
 ---@field fullscreen_client integer
----@field group HL.Window|boolean|integer|table|nil
+---@field group HL.Group|nil
 ---@field hidden boolean
 ---@field inhibiting_idle boolean
 ---@field initial_class string

--- a/src/config/lua/LuaEventHandler.cpp
+++ b/src/config/lua/LuaEventHandler.cpp
@@ -2,10 +2,10 @@
 #include "ConfigManager.hpp"
 #include "objects/LuaWindow.hpp"
 #include "objects/LuaWorkspace.hpp"
+#include "objects/LuaGroup.hpp"
 #include "objects/LuaMonitor.hpp"
 #include "objects/LuaLayerSurface.hpp"
 
-#include "../../defines.hpp"
 #include "../../event/EventBus.hpp"
 #include "../../desktop/state/FocusState.hpp"
 
@@ -14,7 +14,6 @@ extern "C" {
 }
 
 #include <format>
-#include <algorithm>
 
 using namespace Config::Lua;
 using namespace Config::Lua::Objects;
@@ -78,6 +77,7 @@ void CLuaEventHandler::dispatch(const std::string& name, int nargs, const std::f
 
 CLuaEventHandler::CLuaEventHandler(lua_State* L) : m_lua(L) {
     CLuaWindow{}.setup(L);
+    Objects::CLuaGroup{}.setup(L);
     CLuaWorkspace{}.setup(L);
     CLuaMonitor{}.setup(L);
     CLuaLayerSurface{}.setup(L);

--- a/src/config/lua/objects/LuaGroup.cpp
+++ b/src/config/lua/objects/LuaGroup.cpp
@@ -1,0 +1,83 @@
+#include "LuaGroup.hpp"
+#include "LuaWindow.hpp"
+#include "LuaObjectHelpers.hpp"
+
+#include "../../../desktop/view/Group.hpp"
+
+#include <string_view>
+
+using namespace Config::Lua;
+
+static constexpr const char* MT = "HL.Group";
+
+static int                   groupEq(lua_State* L) {
+    const auto* lhs = sc<WP<Desktop::View::CGroup>*>(luaL_checkudata(L, 1, MT));
+    const auto* rhs = sc<WP<Desktop::View::CGroup>*>(luaL_checkudata(L, 2, MT));
+
+    lua_pushboolean(L, lhs->lock() == rhs->lock());
+    return 1;
+}
+
+static int groupToString(lua_State* L) {
+    const auto* ref   = sc<WP<Desktop::View::CGroup>*>(luaL_checkudata(L, 1, MT));
+    const auto  group = ref->lock();
+
+    if (!group)
+        lua_pushstring(L, "HL.Group(expired)");
+    else
+        lua_pushfstring(L, "HL.Group(%p)", group.get());
+
+    return 1;
+}
+
+static int groupIndex(lua_State* L) {
+    auto*      ref   = sc<WP<Desktop::View::CGroup>*>(luaL_checkudata(L, 1, MT));
+    const auto group = ref->lock();
+    if (!group) {
+        Log::logger->log(Log::DEBUG, "[lua] Tried to access an expired object");
+        lua_pushnil(L);
+        return 1;
+    }
+
+    const std::string_view key = luaL_checkstring(L, 2);
+
+    if (key == "locked")
+        lua_pushboolean(L, group->locked());
+    else if (key == "denied")
+        lua_pushboolean(L, group->denied());
+    else if (key == "size")
+        lua_pushinteger(L, sc<lua_Integer>(group->size()));
+    else if (key == "current_index")
+        lua_pushinteger(L, sc<lua_Integer>(group->getCurrentIdx()) + 1);
+    else if (key == "current") {
+        const auto current = group->current();
+        if (current)
+            Objects::CLuaWindow::push(L, current);
+        else
+            lua_pushnil(L);
+    } else if (key == "members") {
+        lua_newtable(L);
+        int i = 1;
+        for (const auto& grouped : group->windows()) {
+            const auto groupedWindow = grouped.lock();
+            if (!groupedWindow)
+                continue;
+
+            Objects::CLuaWindow::push(L, groupedWindow);
+            lua_rawseti(L, -2, i++);
+        }
+    } else
+        lua_pushnil(L);
+
+    return 1;
+}
+
+void Objects::CLuaGroup::setup(lua_State* L) {
+    registerMetatable(L, MT, groupIndex, gcRef<WP<Desktop::View::CGroup>>, groupEq, groupToString);
+}
+
+void Objects::CLuaGroup::push(lua_State* L, SP<Desktop::View::CGroup> group) {
+    new (lua_newuserdata(L, sizeof(WP<Desktop::View::CGroup>))) WP<Desktop::View::CGroup>(group);
+    luaL_getmetatable(L, MT);
+    lua_setmetatable(L, -2);
+}

--- a/src/config/lua/objects/LuaGroup.hpp
+++ b/src/config/lua/objects/LuaGroup.hpp
@@ -5,14 +5,10 @@
 
 #include "../../../desktop/view/Group.hpp"
 
-namespace Config {
-    namespace Lua {
-        namespace Objects {
-            class CLuaGroup {
-              public:
-                static void setup(lua_State* L);
-                static void push(lua_State* L, SP<Desktop::View::CGroup> group);
-            };
-        };
+namespace Config::Lua::Objects {
+    class CLuaGroup {
+      public:
+        static void setup(lua_State* L);
+        static void push(lua_State* L, SP<Desktop::View::CGroup> group);
     };
 };

--- a/src/config/lua/objects/LuaGroup.hpp
+++ b/src/config/lua/objects/LuaGroup.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <hyprutils/memory/WeakPtr.hpp>
+#include <lua.hpp>
+
+#include "../../../desktop/view/Group.hpp"
+
+namespace Config {
+    namespace Lua {
+        namespace Objects {
+            class CLuaGroup {
+              public:
+                static void setup(lua_State* L);
+                static void push(lua_State* L, SP<Desktop::View::CGroup> group);
+            };
+        };
+    };
+};

--- a/src/config/lua/objects/LuaWindow.cpp
+++ b/src/config/lua/objects/LuaWindow.cpp
@@ -1,6 +1,7 @@
 #include "LuaWindow.hpp"
 #include "LuaWorkspace.hpp"
 #include "LuaMonitor.hpp"
+#include "LuaGroup.hpp"
 #include "LuaObjectHelpers.hpp"
 
 #include "../../../desktop/view/Window.hpp"
@@ -122,38 +123,7 @@ static int windowIndex(lua_State* L) {
             return 1;
         }
 
-        lua_newtable(L);
-
-        lua_pushboolean(L, w->m_group->locked());
-        lua_setfield(L, -2, "locked");
-
-        lua_pushboolean(L, w->m_group->denied());
-        lua_setfield(L, -2, "denied");
-
-        lua_pushinteger(L, sc<lua_Integer>(w->m_group->size()));
-        lua_setfield(L, -2, "size");
-
-        lua_pushinteger(L, sc<lua_Integer>(w->m_group->getCurrentIdx()) + 1);
-        lua_setfield(L, -2, "current_index");
-
-        const auto current = w->m_group->current();
-        if (current)
-            Objects::CLuaWindow::push(L, current);
-        else
-            lua_pushnil(L);
-        lua_setfield(L, -2, "current");
-
-        lua_newtable(L);
-        int i = 1;
-        for (const auto& grouped : w->m_group->windows()) {
-            const auto groupedWindow = grouped.lock();
-            if (!groupedWindow)
-                continue;
-
-            Objects::CLuaWindow::push(L, groupedWindow);
-            lua_rawseti(L, -2, i++);
-        }
-        lua_setfield(L, -2, "members");
+        Objects::CLuaGroup::push(L, w->m_group);
     } else if (key == "tags") {
         lua_newtable(L);
 

--- a/src/config/lua/objects/LuaWorkspace.cpp
+++ b/src/config/lua/objects/LuaWorkspace.cpp
@@ -1,9 +1,15 @@
 #include "LuaWorkspace.hpp"
 #include "LuaMonitor.hpp"
+#include "LuaWindow.hpp"
 #include "LuaObjectHelpers.hpp"
 
 #include "../../../desktop/Workspace.hpp"
 #include "../../../helpers/Monitor.hpp"
+#include "../../../layout/space/Space.hpp"
+#include "../../../layout/algorithm/Algorithm.hpp"
+#include "../../../layout/algorithm/TiledAlgorithm.hpp"
+#include "../../../layout/supplementary/WorkspaceAlgoMatcher.hpp"
+#include "../../../Compositor.hpp"
 
 #include <string_view>
 
@@ -29,6 +35,25 @@ static int workspaceToString(lua_State* L) {
     else
         lua_pushfstring(L, "HL.Workspace(%d:%s)", ws->m_id, ws->m_name.c_str());
 
+    return 1;
+}
+
+static int workspaceGetWindows(lua_State* L) {
+    auto*      ref = sc<PHLWORKSPACEREF*>(luaL_checkudata(L, 1, MT));
+    const auto ws  = ref->lock();
+    if (!ws || ws->inert()) {
+        lua_newtable(L);
+        return 1;
+    }
+
+    lua_newtable(L);
+    int idx = 1;
+    for (auto const& w : g_pCompositor->m_windows) {
+        if (w->m_workspace == ws) {
+            Objects::CLuaWindow::push(L, w);
+            lua_rawseti(L, -2, idx++);
+        }
+    }
     return 1;
 }
 
@@ -70,6 +95,37 @@ static int workspaceIndex(lua_State* L) {
         lua_pushboolean(L, ws->m_hasFullscreenWindow);
     else if (key == "is_persistent")
         lua_pushboolean(L, ws->isPersistent());
+    else if (key == "is_empty")
+        lua_pushboolean(L, ws->getWindows() == 0);
+    else if (key == "config_name")
+        lua_pushstring(L, ws->getConfigName().c_str());
+    else if (key == "default_floating")
+        lua_pushboolean(L, ws->m_defaultFloating);
+    else if (key == "default_pseudo")
+        lua_pushboolean(L, ws->m_defaultPseudo);
+    else if (key == "groups")
+        lua_pushinteger(L, sc<lua_Integer>(ws->getGroups()));
+    else if (key == "tiled_layout") {
+        std::string layoutName = "unknown";
+        if (ws->m_space && ws->m_space->algorithm() && ws->m_space->algorithm()->tiledAlgo()) {
+            const auto& TILED_ALGO = ws->m_space->algorithm()->tiledAlgo();
+            layoutName             = Layout::Supplementary::algoMatcher()->getNameForTiledAlgo(&typeid(*TILED_ALGO.get()));
+        }
+        lua_pushstring(L, layoutName.c_str());
+    } else if (key == "last_window") {
+        const auto lastWindow = ws->m_lastFocusedWindow.lock();
+        if (lastWindow)
+            Objects::CLuaWindow::push(L, lastWindow);
+        else
+            lua_pushnil(L);
+    } else if (key == "fullscreen_window") {
+        const auto fsWindow = ws->getFullscreenWindow();
+        if (fsWindow)
+            Objects::CLuaWindow::push(L, fsWindow);
+        else
+            lua_pushnil(L);
+    } else if (key == "get_windows")
+        lua_pushcfunction(L, workspaceGetWindows);
     else
         lua_pushnil(L);
 

--- a/src/config/lua/objects/LuaWorkspace.cpp
+++ b/src/config/lua/objects/LuaWorkspace.cpp
@@ -1,6 +1,7 @@
 #include "LuaWorkspace.hpp"
 #include "LuaMonitor.hpp"
 #include "LuaWindow.hpp"
+#include "LuaGroup.hpp"
 #include "LuaObjectHelpers.hpp"
 
 #include "../../../desktop/Workspace.hpp"
@@ -68,51 +69,20 @@ static int workspaceGetGroups(lua_State* L) {
     }
 
     lua_newtable(L);
-    int                idx = 1;
+    int                                 idx = 1;
 
-    std::vector<void*> pushedGroups;
+    std::vector<Desktop::View::CGroup*> pushedGroups;
 
     for (auto const& w : g_pCompositor->m_windows) {
         if (w->m_workspace != ws || !w->m_group)
             continue;
 
-        if (std::find(pushedGroups.begin(), pushedGroups.end(), (void*)w->m_group.get()) != pushedGroups.end())
+        if (std::ranges::find(pushedGroups, w->m_group.get()) != pushedGroups.end())
             continue;
 
-        pushedGroups.push_back((void*)w->m_group.get());
+        pushedGroups.push_back(w->m_group.get());
 
-        lua_newtable(L);
-
-        lua_pushboolean(L, w->m_group->locked());
-        lua_setfield(L, -2, "locked");
-
-        lua_pushboolean(L, w->m_group->denied());
-        lua_setfield(L, -2, "denied");
-
-        lua_pushinteger(L, sc<lua_Integer>(w->m_group->size()));
-        lua_setfield(L, -2, "size");
-
-        lua_pushinteger(L, sc<lua_Integer>(w->m_group->getCurrentIdx()) + 1);
-        lua_setfield(L, -2, "current_index");
-
-        const auto current = w->m_group->current();
-        if (current)
-            Objects::CLuaWindow::push(L, current);
-        else
-            lua_pushnil(L);
-        lua_setfield(L, -2, "current");
-
-        lua_newtable(L);
-        int wIdx = 1;
-        for (const auto& grouped : w->m_group->windows()) {
-            const auto groupedWindow = grouped.lock();
-            if (!groupedWindow)
-                continue;
-
-            Objects::CLuaWindow::push(L, groupedWindow);
-            lua_rawseti(L, -2, wIdx++);
-        }
-        lua_setfield(L, -2, "members");
+        Objects::CLuaGroup::push(L, w->m_group);
 
         lua_rawseti(L, -2, idx++);
     }

--- a/src/config/lua/objects/LuaWorkspace.cpp
+++ b/src/config/lua/objects/LuaWorkspace.cpp
@@ -4,6 +4,7 @@
 #include "LuaObjectHelpers.hpp"
 
 #include "../../../desktop/Workspace.hpp"
+#include "../../../desktop/view/Group.hpp"
 #include "../../../helpers/Monitor.hpp"
 #include "../../../layout/space/Space.hpp"
 #include "../../../layout/algorithm/Algorithm.hpp"
@@ -11,6 +12,7 @@
 #include "../../../layout/supplementary/WorkspaceAlgoMatcher.hpp"
 #include "../../../Compositor.hpp"
 
+#include <algorithm>
 #include <string_view>
 
 using namespace Config::Lua;
@@ -57,6 +59,67 @@ static int workspaceGetWindows(lua_State* L) {
     return 1;
 }
 
+static int workspaceGetGroups(lua_State* L) {
+    auto*      ref = sc<PHLWORKSPACEREF*>(luaL_checkudata(L, 1, MT));
+    const auto ws  = ref->lock();
+    if (!ws || ws->inert()) {
+        lua_newtable(L);
+        return 1;
+    }
+
+    lua_newtable(L);
+    int                idx = 1;
+
+    std::vector<void*> pushedGroups;
+
+    for (auto const& w : g_pCompositor->m_windows) {
+        if (w->m_workspace != ws || !w->m_group)
+            continue;
+
+        if (std::find(pushedGroups.begin(), pushedGroups.end(), (void*)w->m_group.get()) != pushedGroups.end())
+            continue;
+
+        pushedGroups.push_back((void*)w->m_group.get());
+
+        lua_newtable(L);
+
+        lua_pushboolean(L, w->m_group->locked());
+        lua_setfield(L, -2, "locked");
+
+        lua_pushboolean(L, w->m_group->denied());
+        lua_setfield(L, -2, "denied");
+
+        lua_pushinteger(L, sc<lua_Integer>(w->m_group->size()));
+        lua_setfield(L, -2, "size");
+
+        lua_pushinteger(L, sc<lua_Integer>(w->m_group->getCurrentIdx()) + 1);
+        lua_setfield(L, -2, "current_index");
+
+        const auto current = w->m_group->current();
+        if (current)
+            Objects::CLuaWindow::push(L, current);
+        else
+            lua_pushnil(L);
+        lua_setfield(L, -2, "current");
+
+        lua_newtable(L);
+        int wIdx = 1;
+        for (const auto& grouped : w->m_group->windows()) {
+            const auto groupedWindow = grouped.lock();
+            if (!groupedWindow)
+                continue;
+
+            Objects::CLuaWindow::push(L, groupedWindow);
+            lua_rawseti(L, -2, wIdx++);
+        }
+        lua_setfield(L, -2, "members");
+
+        lua_rawseti(L, -2, idx++);
+    }
+
+    return 1;
+}
+
 static int workspaceIndex(lua_State* L) {
     auto*      ref = sc<PHLWORKSPACEREF*>(luaL_checkudata(L, 1, MT));
     const auto ws  = ref->lock();
@@ -99,12 +162,6 @@ static int workspaceIndex(lua_State* L) {
         lua_pushboolean(L, ws->getWindows() == 0);
     else if (key == "config_name")
         lua_pushstring(L, ws->getConfigName().c_str());
-    else if (key == "default_floating")
-        lua_pushboolean(L, ws->m_defaultFloating);
-    else if (key == "default_pseudo")
-        lua_pushboolean(L, ws->m_defaultPseudo);
-    else if (key == "groups")
-        lua_pushinteger(L, sc<lua_Integer>(ws->getGroups()));
     else if (key == "tiled_layout") {
         std::string layoutName = "unknown";
         if (ws->m_space && ws->m_space->algorithm() && ws->m_space->algorithm()->tiledAlgo()) {
@@ -126,6 +183,10 @@ static int workspaceIndex(lua_State* L) {
             lua_pushnil(L);
     } else if (key == "get_windows")
         lua_pushcfunction(L, workspaceGetWindows);
+    else if (key == "get_groups")
+        lua_pushcfunction(L, workspaceGetGroups);
+    else if (key == "groups")
+        lua_pushinteger(L, sc<lua_Integer>(ws->getGroups()));
     else
         lua_pushnil(L);
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
The native Lua configuration API in Hyprland provides powerful scriptability, but the `CLuaWorkspace` object previously exposed a limited subset of workspace state. This update brings the Lua `workspace` object closer to feature parity with the C++ `CWorkspace` class and the `hyprctl -j workspaces` JSON output.

### Additions:

**`tiled_layout` (string)**
   - Returns the name of the active tiled algorithm (e.g., "dwindle", "master").
   - **Benefit:** Allows layout-aware keybinds in Lua without needing expensive `io.popen("hyprctl activeworkspace")` calls.
   - **Example:** `if hl.get_active_workspace().tiled_layout == "master" then ... end`

**`last_window` (HL.Window|nil)**
   - Returns the window that previously held focus in this workspace.
   - **Benefit:** Enables per-workspace "Alt-Tab" or focus-toggling logic natively in Lua.

**`fullscreen_window` (HL.Window|nil)**
   - Returns the currently fullscreened window object in the workspace.
   - **Benefit:** Direct interaction with the fullscreen application (e.g., toggling its state or moving it) without iterating through all windows.

**`is_empty` (boolean)**
   - Convenience property checking if the workspace has 0 windows.
   - **Benefit:** Cleaner and more explicit than checking `ws.windows == 0`.

**`config_name` (string)**
   - Returns the exact configuration string used for the workspace (e.g., `special:name` vs just `name`).
   - **Benefit:** Can be passed directly to `hl.dispatch("workspace", ws.config_name)` avoiding dispatch errors with special workspaces.

~~**`default_floating` / `default_pseudo` (boolean)**~~
~~- Exposes workspace-specific default rules.~~
~~- **Benefit:** Allows custom spawn logic or window placement scripts to respect the workspace's default behavior.~~

**`groups` (integer)**
   - Returns the number of window groups in the workspace.
   - **Benefit:** Aids window-group management scripts.

**`get_windows()` (function)**
   - Returns a list (`table`) of `HL.Window` objects belonging to the workspace.
   - **Benefit:** Enables batch operations (e.g., closing, moving, or tagging all windows in a specific workspace) purely in Lua.

**`get_groups()` (function)**
   - Returns a list (`table`) of group data for the workspace.
   - **Fields:** `locked`, `denied` (booleans), `size`, `current_index` (integers), `current` (HL.Window|nil), `members` (HL.Window[]).
   - **Benefit:** Deep introspection of window groups within a workspace for advanced window management scripts.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No breaking changes. Existing properties untouched.

#### Is it ready for merging, or does it need work?
Ready to merge
