### PR TITLE
meta/stubs: update gesture hints to match new fields

### DIFF
--- a/meta/generateLuaStubs.py
+++ b/meta/generateLuaStubs.py
@@ -578,8 +578,9 @@ def generate_stub(root: Path) -> str:
                 ("action", "string", False),
                 ("mods", "string", True),
                 ("scale", "number", True),
-                ("arg", "string", True),
-                ("arg2", "string", True),
+                ("mode", "string", True),
+                ("zoom_level", "number", True),
+                ("workspace_name", "string", True),
                 ("disable_inhibit", "boolean", True),
             ],
         )

--- a/meta/hl.meta.lua
+++ b/meta/hl.meta.lua
@@ -411,8 +411,9 @@ local __HL_TimerOptions = {}
 ---@field action string
 ---@field mods? string
 ---@field scale? number
----@field arg? string
----@field arg2? string
+---@field mode? string
+---@field zoom_level? number
+---@field workspace_name? string
 ---@field disable_inhibit? boolean
 local __HL_GestureSpec = {}
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

Fixes the hl.gesture LSP hints so they show the new fields (arg and arg2 are deprecated). Also regenerated them for good measure.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Right now they show up in any gesture even though zoom_level and workspace_name only apply to one action each but I think that's fine, that much fine-grained control seems unnecesary.

#### Is it ready for merging, or does it need work?

Ready
