### PR TITLE
config/lua: fix unbind behavior

### DIFF
--- a/hyprtester/src/tests/clients/shortcut-inhibitor.cpp
+++ b/hyprtester/src/tests/clients/shortcut-inhibitor.cpp
@@ -155,7 +155,7 @@ TEST_CASE(shortcutInhibitor) {
     OK(getFromSocket("/eval hl.plugin.test.keybind(1, 7, 29)"));
     EXPECT(attemptCheckFlag(20, 50), false);
     OK(getFromSocket("/eval hl.plugin.test.keybind(0, 0, 29)"));
-    EXPECT(getFromSocket("/eval hl.unbind('SUPER', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('SUPER + Y')"), "ok");
 
     //keybind bypass flag test
     EXPECT(checkFlag(), false);
@@ -163,7 +163,7 @@ TEST_CASE(shortcutInhibitor) {
     OK(getFromSocket("/eval hl.plugin.test.keybind(1, 7, 29)"));
     EXPECT(attemptCheckFlag(20, 50), true);
     OK(getFromSocket("/eval hl.plugin.test.keybind(0, 0, 29)"));
-    EXPECT(getFromSocket("/eval hl.unbind('SUPER', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('SUPER + Y')"), "ok");
 
     NLog::log("{}Testing gestures", Colors::GREEN);
     //basic gesture test

--- a/hyprtester/src/tests/main/keybinds.cpp
+++ b/hyprtester/src/tests/main/keybinds.cpp
@@ -144,7 +144,7 @@ SUBTEST(keyLongPress) {
     EXPECT(checkFlag(), true);
     // release keybind
     OK(getFromSocket(pluginKeybindCmd(false, 0, 29)));
-    EXPECT(getFromSocket("/eval hl.unbind('', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('Y')"), "ok");
 }
 
 SUBTEST(longPressRelease) {

--- a/hyprtester/src/tests/main/keybinds.cpp
+++ b/hyprtester/src/tests/main/keybinds.cpp
@@ -99,7 +99,7 @@ SUBTEST(bind) {
     EXPECT(attemptCheckFlag(20, 50), true);
     // release keybind
     OK(getFromSocket(pluginKeybindCmd(false, 0, 29)));
-    EXPECT(getFromSocket("/eval hl.unbind('SUPER', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('SUPER + Y')"), "ok");
 }
 
 SUBTEST(bindKey) {
@@ -111,7 +111,7 @@ SUBTEST(bindKey) {
     EXPECT(attemptCheckFlag(20, 50), true);
     // release keybind
     OK(getFromSocket(pluginKeybindCmd(false, 0, 29)));
-    EXPECT(getFromSocket("/eval hl.unbind('', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('Y')"), "ok");
 }
 
 SUBTEST(longPress) {
@@ -128,7 +128,7 @@ SUBTEST(longPress) {
     EXPECT(checkFlag(), true);
     // release keybind
     OK(getFromSocket(pluginKeybindCmd(false, 0, 29)));
-    EXPECT(getFromSocket("/eval hl.unbind('SUPER', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('SUPER + Y')"), "ok");
 }
 SUBTEST(keyLongPress) {
     EXPECT(checkFlag(), false);
@@ -161,7 +161,7 @@ SUBTEST(longPressRelease) {
     // await repeat delay
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     EXPECT(checkFlag(), false);
-    EXPECT(getFromSocket("/eval hl.unbind('SUPER', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('SUPER + Y')"), "ok");
 }
 SUBTEST(longPressOnlyKeyRelease) {
     EXPECT(checkFlag(), false);
@@ -178,7 +178,7 @@ SUBTEST(longPressOnlyKeyRelease) {
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     EXPECT(checkFlag(), false);
     OK(getFromSocket(pluginKeybindCmd(false, 0, 29)));
-    EXPECT(getFromSocket("/eval hl.unbind('SUPER', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('SUPER + Y')"), "ok");
 }
 
 SUBTEST(repeat) {
@@ -198,7 +198,7 @@ SUBTEST(repeat) {
     EXPECT(checkFlag(), true);
     // release keybind
     OK(getFromSocket(pluginKeybindCmd(false, 0, 29)));
-    EXPECT(getFromSocket("/eval hl.unbind('SUPER', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('SUPER + Y')"), "ok");
 }
 
 SUBTEST(keyRepeat) {
@@ -218,7 +218,7 @@ SUBTEST(keyRepeat) {
     EXPECT(checkFlag(), true);
     // release keybind
     OK(getFromSocket(pluginKeybindCmd(false, 0, 29)));
-    EXPECT(getFromSocket("/eval hl.unbind('', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('Y')"), "ok");
 }
 
 SUBTEST(repeatRelease) {
@@ -250,7 +250,7 @@ SUBTEST(repeatRelease) {
     // check that it is not repeating
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     EXPECT(checkFlag(), false);
-    EXPECT(getFromSocket("/eval hl.unbind('SUPER', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('SUPER + Y')"), "ok");
 }
 
 SUBTEST(repeatOnlyKeyRelease) {
@@ -273,7 +273,7 @@ SUBTEST(repeatOnlyKeyRelease) {
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
     EXPECT(checkFlag(), false);
     OK(getFromSocket(pluginKeybindCmd(false, 0, 29)));
-    EXPECT(getFromSocket("/eval hl.unbind('SUPER', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('SUPER + Y')"), "ok");
 }
 
 SUBTEST(shortcutBind) {
@@ -292,7 +292,7 @@ SUBTEST(shortcutBind) {
     const std::string output = readKittyOutput();
     EXPECT_COUNT_STRING(output, "y", 0);
     EXPECT(output.find("q") != std::string::npos, true);
-    EXPECT(getFromSocket("/eval hl.unbind('SUPER', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('SUPER + Y')"), "ok");
     Tests::killAllWindows();
 }
 
@@ -313,7 +313,7 @@ SUBTEST(shortcutBindKey) {
     EXPECT_COUNT_STRING(output, "y", 0);
     // disabled: doesn't work in CI
     // EXPECT_COUNT_STRING(output, "q", 1);
-    EXPECT(getFromSocket("/eval hl.unbind('', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('Y')"), "ok");
     Tests::killAllWindows();
 }
 
@@ -340,7 +340,7 @@ SUBTEST(shortcutLongPress) {
     // final release stop repeats, and shouldn't send any more
     EXPECT(true, yCount == 1 || yCount == 2);
     EXPECT_COUNT_STRING(output, "q", 1);
-    EXPECT(getFromSocket("/eval hl.unbind('SUPER', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('SUPER + Y')"), "ok");
     Tests::killAllWindows();
 }
 
@@ -365,7 +365,7 @@ SUBTEST(shortcutLongPressKeyRelease) {
     // EXPECT_COUNT_STRING(output, "y", 1);
     EXPECT_COUNT_STRING(output, "q", 0);
     OK(getFromSocket(pluginKeybindCmd(false, 0, 29)));
-    EXPECT(getFromSocket("/eval hl.unbind('SUPER', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('SUPER + Y')"), "ok");
     Tests::killAllWindows();
 }
 
@@ -393,7 +393,7 @@ SUBTEST(shortcutRepeat) {
     // then repeat triggers, sending 1 q
     // final release stop repeats, and shouldn't send any more
     EXPECT(true, qCount == 2 || qCount == 3);
-    EXPECT(getFromSocket("/eval hl.unbind('SUPER', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('SUPER + Y')"), "ok");
     Tests::killAllWindows();
 }
 
@@ -423,7 +423,7 @@ SUBTEST(shortcutRepeatKeyRelease) {
     // final release stop repeats, and shouldn't send any more
     EXPECT(true, qCount == 2 || qCount == 3);
     OK(getFromSocket(pluginKeybindCmd(false, 0, 29)));
-    EXPECT(getFromSocket("/eval hl.unbind('SUPER', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('SUPER + Y')"), "ok");
     Tests::killAllWindows();
 }
 
@@ -488,7 +488,7 @@ SUBTEST(bindsAfterScroll) {
     OK(getFromSocket(pluginKeybindCmd(false, 0, 108))); // Alt_R release
 
     clearFlag();
-    OK(getFromSocket("/eval hl.unbind('ALT', 'w')"));
+    OK(getFromSocket("/eval hl.unbind('ALT + w')"));
 }
 
 SUBTEST(submapUniversal) {
@@ -516,7 +516,7 @@ SUBTEST(submapUniversal) {
     getFromSocket(pluginKeybindCmd(false, 0, 33));
     EXPECT_CONTAINS(getFromSocket("/submap"), "default");
 
-    EXPECT(getFromSocket("/eval hl.unbind('SUPER', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('SUPER + Y')"), "ok");
 }
 
 SUBTEST(perDeviceKeybind) {
@@ -528,7 +528,7 @@ SUBTEST(perDeviceKeybind) {
     OK(getFromSocket(pluginKeybindCmd(true, 7, 29)));
     EXPECT(attemptCheckFlag(20, 50), true);
     OK(getFromSocket(pluginKeybindCmd(false, 0, 29)));
-    EXPECT(getFromSocket("/eval hl.unbind('SUPER', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('SUPER + Y')"), "ok");
 
     // Exclusive
     EXPECT(checkFlag(), false);
@@ -536,7 +536,7 @@ SUBTEST(perDeviceKeybind) {
     OK(getFromSocket(pluginKeybindCmd(true, 7, 29)));
     EXPECT(attemptCheckFlag(20, 50), false);
     OK(getFromSocket(pluginKeybindCmd(false, 0, 29)));
-    EXPECT(getFromSocket("/eval hl.unbind('SUPER', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('SUPER + Y')"), "ok");
 
     // With description
     EXPECT(checkFlag(), false);
@@ -546,7 +546,21 @@ SUBTEST(perDeviceKeybind) {
     OK(getFromSocket(pluginKeybindCmd(true, 7, 29)));
     EXPECT(attemptCheckFlag(20, 50), true);
     OK(getFromSocket(pluginKeybindCmd(false, 0, 29)));
-    EXPECT(getFromSocket("/eval hl.unbind('SUPER', 'Y')"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('SUPER + Y')"), "ok");
+}
+
+SUBTEST(unbind) {
+    NLog::log("{}Testing unbind behavior", Colors::GREEN);
+
+    // unbind should normalize the string: no spaces, lowercase OK
+    EXPECT(checkFlag(), false);
+    EXPECT(getFromSocket("/eval hl.bind('SUPER + Y', hl.dsp.exec_cmd('touch " + flagFile + "'), { device = { inclusive = true, list = { 'test-keyboard-1' } } })"), "ok");
+    EXPECT(getFromSocket("/eval hl.unbind('   super     +   y      ')"), "ok");
+
+    OK(getFromSocket(pluginKeybindCmd(true, 7, 29)));
+    OK(getFromSocket(pluginKeybindCmd(false, 0, 29)));
+
+    EXPECT(attemptCheckFlag(20, 50), false);
 }
 
 // TODO: remove this test after subtests above are properly isolated into independent tests
@@ -571,4 +585,5 @@ TEST_CASE(keybinds) {
     CALL_SUBTEST(submapUniversal);
     CALL_SUBTEST(bindsAfterScroll);
     CALL_SUBTEST(perDeviceKeybind);
+    CALL_SUBTEST(unbind);
 }

--- a/src/config/lua/bindings/LuaBindingsToplevel.cpp
+++ b/src/config/lua/bindings/LuaBindingsToplevel.cpp
@@ -337,23 +337,9 @@ static int hlUnbind(lua_State* L) {
         return 0;
     }
 
-    const char* mods   = luaL_checkstring(L, 1);
-    const char* keyStr = luaL_checkstring(L, 2);
+    const char* str = luaL_checkstring(L, 1);
+    g_pKeybindManager->removeKeybind(str);
 
-    uint32_t    mod = g_pKeybindManager->stringToModMask(mods);
-
-    SParsedKey  key;
-    std::string k = keyStr;
-    if (Hyprutils::String::isNumber(k) && std::stoi(k) > 9)
-        key = {.keycode = (uint32_t)std::stoi(k)};
-    else if (k.starts_with("code:") && Hyprutils::String::isNumber(k.substr(5)))
-        key = {.keycode = (uint32_t)std::stoi(k.substr(5))};
-    else if (k == "catchall")
-        key = {.catchAll = true};
-    else
-        key = {.key = k};
-
-    g_pKeybindManager->removeKeybind(mod, key);
     return 0;
 }
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -197,6 +197,23 @@ void CKeybindManager::removeKeybind(uint32_t mod, const SParsedKey& key) {
     m_lastLongPressKeybind.reset();
 }
 
+void CKeybindManager::removeKeybind(const std::string& displayKeys) {
+    static auto normalize = [](std::string x) -> std::string {
+        std::string n = x;
+        replaceInString(n, " ", "");
+        std::ranges::transform(n, n.begin(), ::tolower);
+        return n;
+    };
+
+    const auto DISPLAY_KEYS_NORMALIZED = normalize(displayKeys);
+
+    std::erase_if(m_keybinds,
+                  [&displayKeys, &DISPLAY_KEYS_NORMALIZED](const auto& el) { return el->displayKey == displayKeys || DISPLAY_KEYS_NORMALIZED == normalize(el->displayKey); });
+
+    m_activeKeybinds.clear();
+    m_lastLongPressKeybind.reset();
+}
+
 uint32_t CKeybindManager::stringToModMask(std::string mods) {
     uint32_t modMask = 0;
     std::ranges::transform(mods, mods.begin(), ::toupper);

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -116,6 +116,7 @@ class CKeybindManager {
 
     SP<SKeybind>                                                                 addKeybind(SKeybind);
     void                                                                         removeKeybind(uint32_t, const SParsedKey&);
+    void                                                                         removeKeybind(const std::string& displayKeys);
     uint32_t                                                                     stringToModMask(std::string);
     uint32_t                                                                     keycodeToModifier(xkb_keycode_t);
     void                                                                         clearKeybinds();


### PR DESCRIPTION
Lua unbind took two args for no good reason. Even wiki was wrong. Now it's good.