### PR TITLE
config/lua: Refresh window states on border_size changes

### DIFF
--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -165,7 +165,7 @@ std::vector<SP<IValue>> Values::getConfigValues() {
          * general:
          */
 
-        MS<Int>("general:border_size", "size of the border around windows", 1, {.min = 0, .max = 20}),
+        MS<Int>("general:border_size", "size of the border around windows", 1, {.min = 0, .max = 20, .refresh = Supplementary::REFRESH_WINDOW_STATES}),
         MS<CssGap>("general:gaps_in", "gaps between windows", 5, {.refresh = Supplementary::REFRESH_LAYOUTS}),
         MS<CssGap>("general:gaps_out", "gaps between windows and monitor edges", 20, {.refresh = Supplementary::REFRESH_LAYOUTS}),
         MS<CssGap>("general:float_gaps", "gaps between windows and monitor edges for floating windows", 0, {.refresh = Supplementary::REFRESH_LAYOUTS}),


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
Fixes: https://github.com/hyprwm/Hyprland/discussions/14200

Changes:
1. Refresh window states on border_size changes

Changing `general:border_size` at runtime through Lua config API updates the stored config value but existing window borders aren't redrawn immediately. This patch makes it happen w/o flickering, just like before.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
There are probably more config options that require refresh bits but I only use border size

#### Is it ready for merging, or does it need work?
Ready