### PR TITLE
monitor: fix centered floating windows off-screen in special workspace

### DIFF
--- a/hyprtester/src/tests/main/window.cpp
+++ b/hyprtester/src/tests/main/window.cpp
@@ -588,6 +588,28 @@ TEST_CASE(issue14038) {
     // this should not crash hyprland. If we are alive, we good.
 }
 
+TEST_CASE(specialFloatRecenters) {
+    if (!spawnKitty("kitty_special_float_recenter"))
+        FAIL_TEST("Could not spawn kitty");
+
+    OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'set', window = 'class:kitty_special_float_recenter' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.resize({ x = 10, y = 10, window = 'class:kitty_special_float_recenter' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ workspace = 'special:recenter', follow = false, window = 'class:kitty_special_float_recenter' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ x = 50000, y = 50000, window = 'class:kitty_special_float_recenter' })"));
+
+    OK(getFromSocket("/dispatch hl.dsp.workspace.toggle_special('recenter')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:kitty_special_float_recenter' })"));
+
+    const auto active = getFromSocket("/activewindow");
+    EXPECT_CONTAINS(active, "class: kitty_special_float_recenter");
+    EXPECT_CONTAINS(active, "size: 10,10");
+    EXPECT_CONTAINS(active, "at: 955,535");
+
+    OK(getFromSocket("/dispatch hl.dsp.workspace.toggle_special('recenter')"));
+    Tests::killAllWindows();
+    ASSERT(Tests::windowCount(), 0);
+}
+
 // TODO: decompose this into multiple test cases
 TEST_CASE(windows) {
     // test on workspace "window"

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1564,7 +1564,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
                 if (VECNOTINRECT(MIDDLE, PMONFROMMIDDLE->m_position.x, PMONFROMMIDDLE->m_position.y, PMONFROMMIDDLE->m_position.x + PMONFROMMIDDLE->m_size.x,
                                  PMONFROMMIDDLE->m_position.y + PMONFROMMIDDLE->m_size.y)) {
                     // not on any monitor, center
-                    pos = middle() / 2.f - w->m_realSize->goal() / 2.f;
+                    pos = middle() - w->m_realSize->goal() / 2.f;
                 } else
                     pos = pos - PMONFROMMIDDLE->m_position + m_position;
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
This bug has existed for a long time, introduced by https://github.com/hyprwm/Hyprland/commit/9fb50252d3a128466e80bfc2fb67b45dc923ad41 . Correct logic should be `middle() - w->m_vRealSize.goalv() / 2.f` instead of centering on the top-left area

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

no

#### Is it ready for merging, or does it need work?

ready