### PR TITLE
render: keep blur work buffers in default image description with ICC

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -2551,7 +2551,7 @@ bool CMonitor::useFP16() {
 
 WP<CMonitorResources> CMonitor::resources() {
     const auto DRM_FORMAT = useFP16() ? DRM_FORMAT_ABGR16161616F : m_output->state->state().drmFormat;
-    const auto DESC       = useFP16() ? LINEAR_IMAGE_DESCRIPTION : m_imageDescription;
+    const auto DESC       = useFP16() ? LINEAR_IMAGE_DESCRIPTION : (m_imageDescription->value().icc.present ? getDefaultImageDescription() : m_imageDescription);
 
     if (!m_resources || m_resources->m_drmFormat != DRM_FORMAT || m_resources->m_size != m_pixelSize)
         m_resources = makeUnique<CMonitorResources>(m_self, DRM_FORMAT, m_pixelSize, DESC);

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1789,10 +1789,11 @@ SP<IFramebuffer> CHyprOpenGLImpl::blurFramebufferWithDamage(float a, CRegion* or
 
         currentTex->setTexParameter(GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
-        // From FB to sRGB
+        // From sRGB back to the work buffer/output description
         const bool skipCM = !m_cmSupported || !g_pHyprRenderer->workBufferImageDescription()->needsCM(getDefaultImageDescription());
+        const bool isICC  = g_pHyprRenderer->workBufferImageDescription()->value().icc.present;
         if (!skipCM) {
-            shader = useShader(getShaderVariant(SH_FRAG_BLURFINISH, SH_FEAT_CM));
+            shader = useShader(getShaderVariant(SH_FRAG_BLURFINISH, SH_FEAT_CM | (isICC ? SH_FEAT_ICC : 0)));
             passCMUniforms(shader, getDefaultImageDescription(), g_pHyprRenderer->workBufferImageDescription());
             shader->setUniformFloat(SHADER_SDR_SATURATION,
                                     m_renderData.pMonitor->m_sdrSaturation > 0 &&

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -3256,14 +3256,9 @@ void IHyprRenderer::renderSnapshot(WP<Desktop::View::CPopup> popup) {
 }
 
 NColorManagement::PImageDescription IHyprRenderer::workBufferImageDescription() {
-    // TODO
-    // const bool  IS_MONITOR_ICC  = m_renderData.pMonitor->m_imageDescription.valid() && m_renderData.pMonitor->m_imageDescription->value().icc.present;
-    // const auto  sdrEOTF         = NTransferFunction::fromConfig(IS_MONITOR_ICC);
-    // const auto  CHOSEN_SDR_EOTF = sdrEOTF != NTransferFunction::TF_SRGB ? NColorManagement::CM_TRANSFER_FUNCTION_GAMMA22 : NColorManagement::CM_TRANSFER_FUNCTION_SRGB;
-
-    return m_renderData.pMonitor->useFP16() ?
-        LINEAR_IMAGE_DESCRIPTION :
-        m_renderData.pMonitor->m_imageDescription; //CImageDescription::from(NColorManagement::SImageDescription{.transferFunction = CHOSEN_SDR_EOTF});
+    return m_renderData.pMonitor->useFP16() ? LINEAR_IMAGE_DESCRIPTION :
+                                              // Keep intermediate passes in the default SDR space and apply monitor ICC on the final output pass.
+        (m_renderData.pMonitor->m_imageDescription->value().icc.present ? getDefaultImageDescription() : m_renderData.pMonitor->m_imageDescription);
 }
 
 bool IHyprRenderer::shouldBlur(PHLLS ls) {

--- a/src/render/shaders/glsl/blurFinish.glsl
+++ b/src/render/shaders/glsl/blurFinish.glsl
@@ -19,6 +19,10 @@ vec4 blurFinish(vec4 pixColor, vec2 v_texcoord, float noise, float brightness
 #if USE_CM
                 ,
                 int sourceTF, int targetTF, mat3 convertMatrix, vec2 srcTFRange, vec2 dstTFRange
+#if USE_ICC
+                ,
+                highp sampler3D iccLut3D, float iccLutSize
+#endif
 #endif
 ) {
     // noise
@@ -30,7 +34,12 @@ vec4 blurFinish(vec4 pixColor, vec2 v_texcoord, float noise, float brightness
     pixColor.rgb *= min(1.0, brightness);
 
 #if USE_CM
-    pixColor = doColorManagement(pixColor, sourceTF, targetTF, convertMatrix, srcTFRange, dstTFRange);
+    pixColor = doColorManagement(pixColor, sourceTF, targetTF, convertMatrix, srcTFRange, dstTFRange
+#if USE_ICC
+                                 ,
+                                 iccLut3D, iccLutSize
+#endif
+    );
 #endif
 
     return pixColor;

--- a/src/render/shaders/glsl/blurfinish.frag
+++ b/src/render/shaders/glsl/blurfinish.frag
@@ -26,6 +26,10 @@ void main() {
 #if USE_CM
                            ,
                            sourceTF, targetTF, convertMatrix, srcTFRange, dstTFRange
+#if USE_ICC
+                           ,
+                           iccLut3D, iccLutSize
+#endif
 #endif
     );
 }


### PR DESCRIPTION
## Problem
On my laptop display, when ICC is enabled for the monitor,  kitty with opacity and blur becomes black. However when the ICC is turned off,  kitty will display normal blur and opacity as usual.

##  What I found
From my debugging, this seems related to the monitor ICC description being used for the intermediate work buffer. I have not fully traced the exact shader-side reason why the result becomes black. Blur/transparency should have run in Hyprland's default SDR/sRGB-like working space, instead of the ICC output description.

##  What changed
This patch keeps the work buffer/resources in the default image description when ICC is enabled.
The final output still uses the monitor ICC description, so this does not disable ICC.
I also added the missing ICC LUT uniforms for the blur finish shader path.
I cannot fully explain the pixel-level reason for the black result, but this change fixes the issue on my setup.

##  Testing
 - ICC enabled: transparent blurred kitty no longer becomes black.
 - ICC disabled: blur still works
 - Tested several normal apps: no new rendering issue observed.
 - Ran ctest: 200/203 passed.

The 3 failing ConfigLua tests also fail on the base commit and upstream/main, so they do not seem related to this patch.