### PR TITLE
config/lua: cannot disable animation

### DIFF
--- a/meta/hl.meta.lua
+++ b/meta/hl.meta.lua
@@ -676,7 +676,7 @@ local __HL_Notification = {}
 local __HL_Timer = {}
 
 ---@class HL.Window
----@field acceptsInput boolean
+---@field accepts_input boolean
 ---@field active boolean|nil
 ---@field address string
 ---@field at integer|table

--- a/src/managers/animation/AnimationManager.cpp
+++ b/src/managers/animation/AnimationManager.cpp
@@ -142,9 +142,9 @@ static void handleUpdate(CAnimatedVariable<VarType>& av, bool warp) {
     const auto STEP = av.getCurveStep();
 
     if constexpr (std::same_as<VarType, CHyprColor>)
-        updateColorVariable(av, STEP.value, STEP.finished);
+        updateColorVariable(av, STEP.value, STEP.finished || animationsDisabled);
     else
-        updateVariable<VarType>(av, STEP.value, STEP.finished);
+        updateVariable<VarType>(av, STEP.value, STEP.finished || animationsDisabled);
 
     av.onUpdate();
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This config don't work for me
```lua
hl.config({ animations = { enabled = false } })
```
This seems regression from 9ee5ff1f7181cc5fa575f1702802ccb78c21ba12

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
N/A


#### Is it ready for merging, or does it need work?
Y
