### PR TITLE
workspace rules: support modifying persistent and monitor

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1699,7 +1699,7 @@ WORKSPACEID CCompositor::getNextAvailableNamedWorkspace() {
 
     // Give priority to persistent workspaces to avoid any conflicts between them.
     for (auto const& rule : Config::workspaceRuleMgr()->getAllWorkspaceRules()) {
-        if (!rule.m_isPersistent)
+        if (!rule.m_isPersistent.value_or(false))
             continue;
         if (rule.m_workspaceId < -1 && rule.m_workspaceId < lowest)
             lowest = rule.m_workspaceId;
@@ -3096,7 +3096,7 @@ void CCompositor::ensurePersistentWorkspacesPresent(const std::vector<Config::CW
     std::vector<PHLWORKSPACE> persistentFound;
 
     for (const auto& rule : rules) {
-        if (!rule.m_isPersistent)
+        if (!rule.m_isPersistent.value_or(false))
             continue;
 
         PHLWORKSPACE PWORKSPACE = nullptr;

--- a/src/config/shared/workspace/WorkspaceRule.cpp
+++ b/src/config/shared/workspace/WorkspaceRule.cpp
@@ -12,8 +12,8 @@ void CWorkspaceRule::mergeLeft(const CWorkspaceRule& other) {
     if (m_workspaceId == WORKSPACE_INVALID)
         m_workspaceId = other.m_workspaceId;
 
-    if (other.m_isDefault)
-        m_isDefault = true;
+    if (other.m_isDefault.has_value())
+        m_isDefault = other.m_isDefault;
     if (other.m_isPersistent.has_value())
         m_isPersistent = other.m_isPersistent;
     if (other.m_gapsIn.has_value())

--- a/src/config/shared/workspace/WorkspaceRule.cpp
+++ b/src/config/shared/workspace/WorkspaceRule.cpp
@@ -3,7 +3,7 @@
 using namespace Config;
 
 void CWorkspaceRule::mergeLeft(const CWorkspaceRule& other) {
-    if (m_monitor.empty())
+    if (!other.m_monitor.empty())
         m_monitor = other.m_monitor;
     if (m_workspaceString.empty())
         m_workspaceString = other.m_workspaceString;
@@ -14,8 +14,8 @@ void CWorkspaceRule::mergeLeft(const CWorkspaceRule& other) {
 
     if (other.m_isDefault)
         m_isDefault = true;
-    if (other.m_isPersistent)
-        m_isPersistent = true;
+    if (other.m_isPersistent.has_value())
+        m_isPersistent = other.m_isPersistent;
     if (other.m_gapsIn.has_value())
         m_gapsIn = other.m_gapsIn;
     if (other.m_gapsOut.has_value())

--- a/src/config/shared/workspace/WorkspaceRule.hpp
+++ b/src/config/shared/workspace/WorkspaceRule.hpp
@@ -27,7 +27,7 @@ namespace Config {
         std::string                        m_workspaceString = "";
         std::string                        m_workspaceName   = "";
         WORKSPACEID                        m_workspaceId     = -1;
-        bool                               m_isDefault       = false;
+        std::optional<bool>                m_isDefault;
         std::optional<bool>                m_isPersistent;
         std::optional<CCssGapData>         m_gapsIn;
         std::optional<CCssGapData>         m_gapsOut;

--- a/src/config/shared/workspace/WorkspaceRule.hpp
+++ b/src/config/shared/workspace/WorkspaceRule.hpp
@@ -28,7 +28,7 @@ namespace Config {
         std::string                        m_workspaceName   = "";
         WORKSPACEID                        m_workspaceId     = -1;
         bool                               m_isDefault       = false;
-        bool                               m_isPersistent    = false;
+        std::optional<bool>                m_isPersistent;
         std::optional<CCssGapData>         m_gapsIn;
         std::optional<CCssGapData>         m_gapsOut;
         std::optional<CCssGapData>         m_floatGaps = m_gapsOut;

--- a/src/config/shared/workspace/WorkspaceRuleManager.cpp
+++ b/src/config/shared/workspace/WorkspaceRuleManager.cpp
@@ -55,7 +55,7 @@ std::string CWorkspaceRuleManager::getDefaultWorkspaceFor(const std::string& nam
         if (!other->m_enabled)
             continue;
 
-        if (other->m_isDefault) {
+        if (other->m_isDefault.value_or(false)) {
             if (other->m_monitor == name)
                 return other->m_workspaceString;
             if (other->m_monitor.starts_with("desc:")) {

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -507,7 +507,7 @@ static std::string getWorkspaceRuleData(const Config::CWorkspaceRule& r, eHyprCt
     const auto boolToString = [](const bool b) -> std::string { return b ? "true" : "false"; };
     if (format == eHyprCtlOutputFormat::FORMAT_JSON) {
         const std::string monitor     = r.m_monitor.empty() ? "" : std::format(",\n    \"monitor\": \"{}\"", escapeJSONStrings(r.m_monitor));
-        const std::string default_    = sc<bool>(r.m_isDefault) ? std::format(",\n    \"default\": {}", boolToString(r.m_isDefault)) : "";
+        const std::string default_    = sc<bool>(r.m_isDefault) ? std::format(",\n    \"default\": {}", boolToString(r.m_isDefault.value())) : "";
         const std::string persistent  = sc<bool>(r.m_isPersistent) ? std::format(",\n    \"persistent\": {}", boolToString(r.m_isPersistent.value())) : "";
         const std::string gapsIn      = sc<bool>(r.m_gapsIn) ?
             std::format(",\n    \"gapsIn\": [{}, {}, {}, {}]", r.m_gapsIn.value().m_top, r.m_gapsIn.value().m_right, r.m_gapsIn.value().m_bottom, r.m_gapsIn.value().m_left) :
@@ -531,7 +531,7 @@ static std::string getWorkspaceRuleData(const Config::CWorkspaceRule& r, eHyprCt
         return result;
     } else {
         const std::string monitor     = std::format("\tmonitor: {}\n", r.m_monitor.empty() ? "<unset>" : escapeJSONStrings(r.m_monitor));
-        const std::string default_    = std::format("\tdefault: {}\n", sc<bool>(r.m_isDefault) ? boolToString(r.m_isDefault) : "<unset>");
+        const std::string default_    = std::format("\tdefault: {}\n", sc<bool>(r.m_isDefault) ? boolToString(r.m_isDefault.value()) : "<unset>");
         const std::string persistent  = std::format("\tpersistent: {}\n", sc<bool>(r.m_isPersistent) ? boolToString(r.m_isPersistent.value()) : "<unset>");
         const std::string gapsIn      = sc<bool>(r.m_gapsIn) ?
             std::format("\tgapsIn: {} {} {} {}\n", std::to_string(r.m_gapsIn.value().m_top), std::to_string(r.m_gapsIn.value().m_right),

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -508,7 +508,7 @@ static std::string getWorkspaceRuleData(const Config::CWorkspaceRule& r, eHyprCt
     if (format == eHyprCtlOutputFormat::FORMAT_JSON) {
         const std::string monitor     = r.m_monitor.empty() ? "" : std::format(",\n    \"monitor\": \"{}\"", escapeJSONStrings(r.m_monitor));
         const std::string default_    = sc<bool>(r.m_isDefault) ? std::format(",\n    \"default\": {}", boolToString(r.m_isDefault)) : "";
-        const std::string persistent  = sc<bool>(r.m_isPersistent) ? std::format(",\n    \"persistent\": {}", boolToString(r.m_isPersistent)) : "";
+        const std::string persistent  = sc<bool>(r.m_isPersistent) ? std::format(",\n    \"persistent\": {}", boolToString(r.m_isPersistent.value())) : "";
         const std::string gapsIn      = sc<bool>(r.m_gapsIn) ?
             std::format(",\n    \"gapsIn\": [{}, {}, {}, {}]", r.m_gapsIn.value().m_top, r.m_gapsIn.value().m_right, r.m_gapsIn.value().m_bottom, r.m_gapsIn.value().m_left) :
             "";
@@ -532,7 +532,7 @@ static std::string getWorkspaceRuleData(const Config::CWorkspaceRule& r, eHyprCt
     } else {
         const std::string monitor     = std::format("\tmonitor: {}\n", r.m_monitor.empty() ? "<unset>" : escapeJSONStrings(r.m_monitor));
         const std::string default_    = std::format("\tdefault: {}\n", sc<bool>(r.m_isDefault) ? boolToString(r.m_isDefault) : "<unset>");
-        const std::string persistent  = std::format("\tpersistent: {}\n", sc<bool>(r.m_isPersistent) ? boolToString(r.m_isPersistent) : "<unset>");
+        const std::string persistent  = std::format("\tpersistent: {}\n", sc<bool>(r.m_isPersistent) ? boolToString(r.m_isPersistent.value()) : "<unset>");
         const std::string gapsIn      = sc<bool>(r.m_gapsIn) ?
             std::format("\tgapsIn: {} {} {} {}\n", std::to_string(r.m_gapsIn.value().m_top), std::to_string(r.m_gapsIn.value().m_right),
                         std::to_string(r.m_gapsIn.value().m_bottom), std::to_string(r.m_gapsIn.value().m_left)) :

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -52,7 +52,7 @@ void CWorkspace::init(PHLWORKSPACE self) {
     m_inert = false;
 
     const auto WORKSPACERULE = Config::workspaceRuleMgr()->getWorkspaceRuleFor(self).value_or(Config::CWorkspaceRule{});
-    setPersistent(WORKSPACERULE.m_isPersistent);
+    setPersistent(WORKSPACERULE.m_isPersistent.value_or(false));
 
     if (self->m_wasCreatedEmpty)
         if (auto cmd = WORKSPACERULE.m_onCreatedEmptyRunCmd)
@@ -517,9 +517,9 @@ void CWorkspace::rename(const std::string& name) {
     m_name = name;
 
     const auto WORKSPACERULE = Config::workspaceRuleMgr()->getWorkspaceRuleFor(m_self.lock()).value_or(Config::CWorkspaceRule{});
-    setPersistent(WORKSPACERULE.m_isPersistent);
+    setPersistent(WORKSPACERULE.m_isPersistent.value_or(false));
 
-    if (WORKSPACERULE.m_isPersistent)
+    if (WORKSPACERULE.m_isPersistent.value_or(false))
         g_pCompositor->ensurePersistentWorkspacesPresent(std::vector<Config::CWorkspaceRule>{WORKSPACERULE}, m_self.lock());
 
     g_pEventManager->postEvent({.event = "renameworkspace", .data = std::to_string(m_id) + "," + m_name});


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Allows merging monitor and persistent values into existing workspace rules.

Before this, if you tried to update workspace monitor or persistent, and had already defined them in a previous rule call, they silently wouldn't get merged into the new rule.

I'm trying to rewrite my plugin as lua library, but I need to be able to dynamically update workspace persistence and monitor based on the monitors that are connected.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
~~the same thing could maybe be done to isDefault? i didn't look too closely~~ I did the same thing to isDefault for consistency, it was only a few extra lines.

#### Is it ready for merging, or does it need work?
Ready

