### PR TITLE
cleanup: avoid repeated weak_ptr::lock() usage in MasterAlgorithm

### DIFF
--- a/src/layout/algorithm/tiled/master/MasterAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/master/MasterAlgorithm.cpp
@@ -476,6 +476,8 @@ Config::ErrorResult CMasterAlgorithm::layoutMsg(const std::string_view& sv) {
             return stateErr("no master node");
 
         const auto NEWCHILD = PMASTER->pTarget.lock();
+        if (!NEWCHILD)
+            return stateErr("master target expired");
 
         const bool IGNORE_IF_MASTER = vars.size() >= 2 && std::ranges::any_of(vars, [](const auto& e) { return e == "ignoremaster"; });
 

--- a/src/layout/algorithm/tiled/master/MasterAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/master/MasterAlgorithm.cpp
@@ -479,7 +479,7 @@ Config::ErrorResult CMasterAlgorithm::layoutMsg(const std::string_view& sv) {
 
         const bool IGNORE_IF_MASTER = vars.size() >= 2 && std::ranges::any_of(vars, [](const auto& e) { return e == "ignoremaster"; });
 
-        if (PMASTER->pTarget.lock() != PWINDOW->layoutTarget()) {
+        if (NEWCHILD != PWINDOW->layoutTarget()) {
             const auto& NEWMASTER       = PWINDOW->layoutTarget();
             const bool  newFocusToChild = vars.size() >= 2 && vars[1] == "child";
             g_layoutManager->switchTargets(NEWMASTER, NEWCHILD);
@@ -516,8 +516,10 @@ Config::ErrorResult CMasterAlgorithm::layoutMsg(const std::string_view& sv) {
 
         const auto& ARG = vars[1]; // returns empty string if out of bounds
 
-        if (PMASTER->pTarget.lock() != PWINDOW->layoutTarget()) {
-            switchToWindow(PMASTER->pTarget.lock());
+        const auto  TARGET = PMASTER->pTarget.lock();
+
+        if (TARGET != PWINDOW->layoutTarget()) {
+            switchToWindow(TARGET);
             // save previously focused window (only for `previous` mode)
             if (ARG == "previous")
                 m_workspaceData.focusMasterPrev = PWINDOW->layoutTarget();

--- a/src/layout/algorithm/tiled/master/MasterAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/master/MasterAlgorithm.cpp
@@ -519,6 +519,8 @@ Config::ErrorResult CMasterAlgorithm::layoutMsg(const std::string_view& sv) {
         const auto& ARG = vars[1]; // returns empty string if out of bounds
 
         const auto  TARGET = PMASTER->pTarget.lock();
+        if (!TARGET)
+            return stateErr("master target expired");
 
         if (TARGET != PWINDOW->layoutTarget()) {
             switchToWindow(TARGET);


### PR DESCRIPTION
Avoid repeated weak_ptr::lock() calls by reusing cached results.
-Reuse `NEWCHILD` instead of calling `pTarget.lock()` again in swapwithmaster
-Cache `pTarget.lock()` into a local `TARGET` in focusmaster
This improves consistency and avoids redundant locking.
No functional changes.(introduces an early return only when the master target is invalid)
Also adds a null check for the master target to guard against a potential expired weak_ptr.