### PR TITLE
input: restrict border resizing logic to floating windows and multi-windows

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -595,7 +595,8 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
     if (pFoundWindow) {
         // change cursor icon if hovering over border
         if (*PRESIZEONBORDER && *PRESIZECURSORICON) {
-            if (!pFoundWindow->isFullscreen() && !pFoundWindow->hasPopupAt(mouseCoords))
+            if (!pFoundWindow->isFullscreen() && !pFoundWindow->hasPopupAt(mouseCoords) && PWORKSPACE->getWindows() > 1 &&
+                (pFoundWindow->m_isFloating || PWORKSPACE->getWindows(false) == 0))
                 setCursorIconOnBorder(pFoundWindow);
             else if (m_borderIconDirection != BORDERICON_NONE) {
                 m_borderIconDirection = BORDERICON_NONE;
@@ -807,12 +808,15 @@ void CInputManager::processMouseDownNormal(const IPointer::SButtonEvent& e, SP<I
     // TODO detect click on LS properly
     if (*PRESIZEONBORDER && !g_pSessionLockManager->isSessionLocked() && !m_lastFocusOnLS && e.state == WL_POINTER_BUTTON_STATE_PRESSED && (!w || !w->isX11OverrideRedirect())) {
         if (w && !w->isFullscreen()) {
-            const CBox real = {w->m_realPosition->value().x, w->m_realPosition->value().y, w->m_realSize->value().x, w->m_realSize->value().y};
-            const CBox grab = {real.x - BORDER_GRAB_AREA, real.y - BORDER_GRAB_AREA, real.width + 2 * BORDER_GRAB_AREA, real.height + 2 * BORDER_GRAB_AREA};
+            const auto PWORKSPACE = w->m_workspace;
+            if (PWORKSPACE && PWORKSPACE->getWindows() > 1 && (w->m_isFloating || PWORKSPACE->getWindows(false) == 0)) {
+                const CBox real = {w->m_realPosition->value().x, w->m_realPosition->value().y, w->m_realSize->value().x, w->m_realSize->value().y};
+                const CBox grab = {real.x - BORDER_GRAB_AREA, real.y - BORDER_GRAB_AREA, real.width + 2 * BORDER_GRAB_AREA, real.height + 2 * BORDER_GRAB_AREA};
 
-            if ((grab.containsPoint(mouseCoords) && (!real.containsPoint(mouseCoords) || w->isInCurvedCorner(mouseCoords.x, mouseCoords.y))) && !w->hasPopupAt(mouseCoords)) {
-                g_pKeybindManager->resizeWithBorder(e);
-                return;
+                if ((grab.containsPoint(mouseCoords) && (!real.containsPoint(mouseCoords) || w->isInCurvedCorner(mouseCoords.x, mouseCoords.y))) && !w->hasPopupAt(mouseCoords)) {
+                    g_pKeybindManager->resizeWithBorder(e);
+                    return;
+                }
             }
         }
     }


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines  
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/
Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->

#### Describe your PR, what does it fix/add?

Restricts border resizing logic to only apply to floating windows or when the workspace has more than 1 tiled window. This prevents unintended border resize behavior on single tiled windows.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

- Only affects `PRESIZEONBORDER` functionality
- Cursor icon change on border hover now requires: not fullscreen + workspace has multiple windows OR window is floating
- Border resize activation now follows the same conditions
- Related discussion: https://github.com/hyprwm/Hyprland/discussions/13581

#### Is it ready for merging, or does it need work? 

Ready for merging


