### PR TITLE
fix(config/Lua): check "workspace" instead of "id" in hl.workspace.move/rename

### DIFF
--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -1167,9 +1167,9 @@ static int hlWorkspaceToggleSpecial(lua_State* L) {
 
 static int hlWorkspaceRename(lua_State* L) {
     if (!lua_istable(L, 1))
-        return Internal::configError(L, "hl.workspace.rename: expected a table { id, name? }");
+        return Internal::configError(L, "hl.workspace.rename: expected a table { workspace, name? }");
 
-    const auto id   = Internal::requireTableFieldWorkspaceSelector(L, 1, "id", "hl.workspace.rename");
+    const auto id   = Internal::requireTableFieldWorkspaceSelector(L, 1, "workspace", "hl.workspace.rename");
     auto       name = Internal::tableOptStr(L, 1, "name");
 
     lua_pushstring(L, id.c_str());
@@ -1187,7 +1187,7 @@ static int hlWorkspaceMove(lua_State* L) {
 
     const auto mon = Internal::requireTableFieldMonitorSelector(L, 1, "monitor", "hl.workspace.move");
 
-    auto       id = Internal::tableOptWorkspaceSelector(L, 1, "id", "hl.workspace.move");
+    auto       id = Internal::tableOptWorkspaceSelector(L, 1, "workspace", "hl.workspace.move");
     if (id) {
         lua_pushstring(L, id->c_str());
         lua_pushstring(L, mon.c_str());


### PR DESCRIPTION
According to the wiki, this should work:

`hl.dsp.workspace.move({ workspace = 1, monitor = "current" })`


<img width="608" height="180" alt="image" src="https://github.com/user-attachments/assets/ada8f2f0-5d84-4108-bb7a-0f51980f1d6d" />

_[source](https://wiki.hypr.land/Configuring/Basics/Dispatchers/#workspace-1)_

However, it doesn't, because "id" is expected in the Lua table instead of "workspace". "workspace" should be correct here because it's more descriptive and in line with all similar dispatchers. These were the only occurences of this mismatch I could find.

Very small and simple fix, so should be ready to merge.