### PR TITLE
tests: fix ConfigLuaValueTypes - boolBadType test, 0 and 1 are allowe…

### DIFF
--- a/tests/config/lua/ConfigValueTypes.cpp
+++ b/tests/config/lua/ConfigValueTypes.cpp
@@ -89,7 +89,7 @@ TEST(ConfigLuaValueTypes, boolBadType) {
 
     CLuaConfigBool value(false);
 
-    lua_pushinteger(L, 1);
+    lua_pushinteger(L, 2);
     const auto err = value.parse(L);
     lua_pop(L, 1);
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
Fix one of the broken gtests test.
0 and 1 are allowed integer values for bool type, so to get error in test we need to pass value greater than 1.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
nothing


#### Is it ready for merging, or does it need work?
ready


