### PR TITLE
InputManager: add guards to confineToRegion to avoid issues

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -266,10 +266,16 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
 
     // constraints
     auto confineToRegion = [&](const CRegion& rg, SP<Desktop::View::CWLSurface> surf) {
+        if (!surf)
+            return;
+
         const auto CLOSEST      = rg.closestPoint(mouseCoords);
         const auto BOX          = surf->getSurfaceBoxGlobal();
         const auto WINDOW       = Desktop::View::CWindow::fromView(surf->view());
         const auto CLOSESTLOCAL = (CLOSEST - (BOX.has_value() ? BOX->pos() : Vector2D{})) * (WINDOW ? WINDOW->m_X11SurfaceScaledBy : 1.0);
+
+        if (g_pSeatManager->m_state.pointerFocus != surf->resource())
+            g_pSeatManager->setPointerFocus(surf->resource(), CLOSESTLOCAL);
 
         g_pCompositor->warpCursorTo(CLOSEST, true);
         g_pSeatManager->sendPointerMotion(time, CLOSESTLOCAL);


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

after more extensive testing of the confine pointer rule i noticed some annoying bugs with the constraint behaviour. if you currently had the pointer constrained, moved to another workspace on the same monitor, then back, you'd be unable to click anything on the currently focused window. similar to my other thing https://github.com/hyprwm/Hyprland/discussions/12764

this seems to have fixed it for me on cs2

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

no

#### Is it ready for merging, or does it need work?

should be