### PR TITLE
windows/focus: add fallbacks when focussing workspaces

### DIFF
--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -94,7 +94,7 @@ static bool tryMoveFocusToMonitor(PHLMONITOR monitor) {
 
     const auto PNEWMAINWORKSPACE = monitor->m_activeWorkspace;
     const auto PNEWWORKSPACE     = monitor->m_activeSpecialWorkspace ? monitor->m_activeSpecialWorkspace : PNEWMAINWORKSPACE;
-    const auto PNEWWINDOW        = PNEWWORKSPACE->getLastFocusedWindow();
+    auto       PNEWWINDOW        = PNEWWORKSPACE->getFocusCandidate();
 
     if (PNEWWINDOW) {
         updateRelativeCursorCoords();
@@ -931,11 +931,13 @@ ActionResult Actions::changeWorkspace(PHLWORKSPACE ws) {
     PMONITORWORKSPACEOWNER->changeWorkspace(ws, false, true);
 
     if (PMONITOR != PMONITORWORKSPACEOWNER) {
-        Vector2D middle = PMONITORWORKSPACEOWNER->middle();
-        if (const auto PLAST = ws->getLastFocusedWindow(); PLAST) {
-            Desktop::focusState()->fullWindowFocus(PLAST, Desktop::FOCUS_REASON_KEYBIND);
+        Vector2D middle  = PMONITORWORKSPACEOWNER->middle();
+        auto     pWindow = ws->getFocusCandidate();
+
+        if (pWindow) {
+            Desktop::focusState()->fullWindowFocus(pWindow, Desktop::FOCUS_REASON_KEYBIND);
             if (*PWORKSPACECENTERON == 1)
-                middle = PLAST->middle();
+                middle = pWindow->middle();
         }
         g_pCompositor->warpCursorTo(middle);
     }

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -83,6 +83,18 @@ PHLWINDOW CWorkspace::getLastFocusedWindow() {
     return m_lastFocusedWindow.lock();
 }
 
+PHLWINDOW CWorkspace::getFocusCandidate() {
+    auto pWindow = getLastFocusedWindow();
+
+    if (!pWindow)
+        pWindow = getTopLeftWindow();
+
+    if (!pWindow)
+        pWindow = getFirstWindow();
+
+    return pWindow;
+}
+
 std::string CWorkspace::getConfigName() {
     if (m_isSpecialWorkspace) {
         return m_name;

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -61,6 +61,7 @@ class CWorkspace {
     bool        inert();
     MONITORID   monitorID();
     PHLWINDOW   getLastFocusedWindow();
+    PHLWINDOW   getFocusCandidate();
     std::string getConfigName();
     bool        matchesStaticSelector(const std::string& selector);
     void        markInert();

--- a/src/desktop/state/FocusState.cpp
+++ b/src/desktop/state/FocusState.cpp
@@ -167,8 +167,12 @@ void CFocusState::rawWindowFocus(PHLWINDOW pWindow, eFocusReason reason, SP<CWLS
         return;
     }
 
-    const auto PLASTWINDOW = m_focusWindow.lock();
-    m_focusWindow          = pWindow;
+    if (PMONITOR && !pWindow->m_pinned)
+        rawMonitorFocus(PMONITOR);
+
+    const auto PLASTWINDOW                    = m_focusWindow.lock();
+    m_focusWindow                             = pWindow;
+    pWindow->m_workspace->m_lastFocusedWindow = pWindow;
 
     /* If special fallthrough is enabled, this behavior will be disabled, as I have no better idea of nicely tracking which
        window focuses are "via keybinds" and which ones aren't. */

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1406,10 +1406,7 @@ void CMonitor::changeWorkspace(const PHLWORKSPACE& pWorkspace, bool internal, bo
                                                                    Desktop::View::RESERVED_EXTENTS | Desktop::View::INPUT_EXTENTS | Desktop::View::ALLOW_FLOATING);
 
                 if (!pWindow)
-                    pWindow = pWorkspace->getTopLeftWindow();
-
-                if (!pWindow)
-                    pWindow = pWorkspace->getFirstWindow();
+                    pWindow = pWorkspace->getFocusCandidate();
             }
 
             Desktop::focusState()->fullWindowFocus(pWindow, Desktop::FOCUS_REASON_KEYBIND);

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1694,7 +1694,8 @@ bool CInputManager::refocusLastWindow(PHLMONITOR pMonitor) {
             foundSurface = nullptr;
     }
 
-    if (!foundSurface && Desktop::focusState()->window() && Desktop::focusState()->window()->m_workspace && Desktop::focusState()->window()->m_workspace->isVisibleNotCovered()) {
+    if (!foundSurface && Desktop::focusState()->window() && Desktop::focusState()->window()->m_monitor == pMonitor && Desktop::focusState()->window()->m_workspace &&
+        Desktop::focusState()->window()->m_workspace->isVisibleNotCovered()) {
         // then the last focused window if we're on the same workspace as it
         const auto PLASTWINDOW = Desktop::focusState()->window();
         Desktop::focusState()->fullWindowFocus(PLASTWINDOW, Desktop::FOCUS_REASON_FFM);


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
fixes https://github.com/hyprwm/Hyprland/discussions/12790
in some cases it was possible to get into a state where there was no last focused window on a monitor. this meant that `movetoworkspace` would be successful, but the "active window" is still on your other monitor.

This would lead to cases for example, where i'd movetoworkspace to my second monitor, close a window, and it would end up closing an unintended window on my main monitor.

It also helps because if you were in this state whilst using `confine_pointer` if you did `movetoworkspace` to your secondary monitor, your mouse would warp back to game.

it also helps when using initial workspace tracking, as leaving the workspace whilst an app was launching would also lead to the same outcome where there is technically no "last focused window" on said workspace / monitor 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

maybe some of this isn't needed idk

#### Is it ready for merging, or does it need work?

looks like it

