### PR TITLE
compositor: move SessionLockManager init from STAGE_LATE to STAGE_BASICINIT

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -673,6 +673,9 @@ void CCompositor::initManagers(eManagersInitStage stage) {
             Log::logger->log(Log::DEBUG, "Creating the SeatManager!");
             g_pSeatManager = makeUnique<CSeatManager>();
 
+            Log::logger->log(Log::DEBUG, "Creating the SessionLockManager!");
+            g_pSessionLockManager = makeUnique<CSessionLockManager>();
+
             // init focus state els
             Desktop::History::windowTracker();
             Desktop::History::workspaceTracker();
@@ -687,9 +690,6 @@ void CCompositor::initManagers(eManagersInitStage stage) {
 
             Log::logger->log(Log::DEBUG, "Creating the XWaylandManager!");
             g_pXWaylandManager = makeUnique<CHyprXWaylandManager>();
-
-            Log::logger->log(Log::DEBUG, "Creating the SessionLockManager!");
-            g_pSessionLockManager = makeUnique<CSessionLockManager>();
 
             Log::logger->log(Log::DEBUG, "Creating the Debug Overlay!");
             Debug::overlay();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes https://github.com/hyprwm/hyprlock/issues/999

See also https://github.com/hyprwm/hyprlock/pull/1007

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I have not looked into why the protocol is actually missing from the registry with STAGE_LATE, but I was able to reproduce the issue and wasn't able to reproduce it with this change.

#### Is it ready for merging, or does it need work?

Ready.
