### PR TITLE
config/lua: Add clear_tags function

### DIFF
--- a/meta/hl.meta.lua
+++ b/meta/hl.meta.lua
@@ -826,6 +826,7 @@ local __HL_DspGroupNamespace = {}
 ---@field alter_zorder fun(...): HL.Dispatcher
 ---@field bring_to_top fun(...): HL.Dispatcher
 ---@field center fun(...): HL.Dispatcher
+---@field clear_tags fun(...): HL.Dispatcher
 ---@field close fun(...): HL.Dispatcher
 ---@field cycle_next fun(...): HL.Dispatcher
 ---@field deny_from_group fun(...): HL.Dispatcher

--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -563,6 +563,10 @@ static int dsp_tagWindow(lua_State* L) {
     return Internal::checkResult(L, CA::tag(lua_tostring(L, lua_upvalueindex(1)), Internal::windowFromUpval(L, 2)));
 }
 
+static int dsp_clearTags(lua_State* L) {
+    return Internal::checkResult(L, CA::clearTags(Internal::windowFromUpval(L, 1)));
+}
+
 static int dsp_toggleSwallow(lua_State* L) {
     return Internal::checkResult(L, CA::toggleSwallow());
 }
@@ -915,6 +919,12 @@ static int hlWindowTag(lua_State* L) {
     return 1;
 }
 
+static int hlWindowClearTags(lua_State* L) {
+    Internal::pushWindowUpval(L, 1);
+    lua_pushcclosure(L, dsp_clearTags, 1);
+    return 1;
+}
+
 static int hlWindowToggleSwallow(lua_State* L) {
     lua_pushcclosure(L, dsp_toggleSwallow, 0);
     return 1;
@@ -1248,6 +1258,7 @@ void Internal::registerDispatcherBindings(lua_State* L) {
         Internal::setFn(L, "center", hlWindowCenter);
         Internal::setFn(L, "cycle_next", hlWindowCycleNext);
         Internal::setFn(L, "tag", hlWindowTag);
+        Internal::setFn(L, "clear_tags", hlWindowClearTags);
         Internal::setFn(L, "toggle_swallow", hlWindowToggleSwallow);
         Internal::setFn(L, "pin", hlWindowPin);
         Internal::setFn(L, "bring_to_top", hlWindowBringToTop);

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -605,6 +605,19 @@ ActionResult Actions::tag(const std::string& tagStr, std::optional<PHLWINDOW> w)
     return {};
 }
 
+ActionResult Actions::clearTags(std::optional<PHLWINDOW> w) {
+    auto window = xtract(w);
+    if (!window)
+        return {};
+
+    if (window->m_ruleApplicator->m_tagKeeper.clearTags()) {
+        window->m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_TAG);
+        window->updateDecorationValues();
+    }
+
+    return {};
+}
+
 ActionResult Actions::swapNext(const bool next, std::optional<PHLWINDOW> w) {
     auto window = xtract(w);
     if (!window)

--- a/src/config/shared/actions/ConfigActions.hpp
+++ b/src/config/shared/actions/ConfigActions.hpp
@@ -53,6 +53,7 @@ namespace Config::Actions {
     ActionResult move(const Vector2D& pos, bool relative = false, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
     ActionResult cycleNext(const bool next, std::optional<bool> onlyTiled, std::optional<bool> onlyFloating, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
     ActionResult tag(const std::string& tag, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
+    ActionResult clearTags(std::optional<PHLWINDOW> w = std::nullopt);
     ActionResult pass(std::optional<PHLWINDOW> window = std::nullopt /* Active */);
     ActionResult pass(uint32_t modMask, uint32_t key, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
     ActionResult sendKeyState(uint32_t modMask, uint32_t key, uint32_t state, std::optional<PHLWINDOW> window = std::nullopt /* Active */);

--- a/src/helpers/TagKeeper.cpp
+++ b/src/helpers/TagKeeper.cpp
@@ -38,6 +38,15 @@ bool CTagKeeper::applyTag(const std::string& tag, bool dynamic) {
     return true;
 }
 
+bool CTagKeeper::clearTags() {
+    if (!m_tags.empty()) {
+        m_tags.clear();
+        return true;
+    }
+
+    return false;
+}
+
 bool CTagKeeper::removeDynamicTag(const std::string& s) {
     return std::erase_if(m_tags, [&s](const auto& tag) { return tag == s + "*"; });
 }

--- a/src/helpers/TagKeeper.hpp
+++ b/src/helpers/TagKeeper.hpp
@@ -8,6 +8,7 @@ class CTagKeeper {
     bool        isTagged(const std::string& tag, bool strict = false) const;
     bool        applyTag(const std::string& tag, bool dynamic = false);
     bool        removeDynamicTag(const std::string& tag);
+    bool        clearTags();
 
     const auto& getTags() const {
         return m_tags;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Adds a new function to clear all tags from a window. I've been using tags more with lua configs and found removing them to be a bit clunky.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Should be ready. I will need to update the wiki as well.

