### PR TITLE
InputManager: Fix touch monitor focus ordering

### DIFF
--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -32,12 +32,12 @@ void CInputManager::onTouchDown(ITouch::SDownEvent e) {
 
     PMONITOR = PMONITOR ? PMONITOR : Desktop::focusState()->monitor();
 
+    if (PMONITOR != Desktop::focusState()->monitor())
+        Desktop::focusState()->rawMonitorFocus(PMONITOR);
+
     const auto TOUCH_COORDS = PMONITOR->m_position + (e.pos * PMONITOR->m_size);
 
     refocus(TOUCH_COORDS);
-
-    if (PMONITOR != Desktop::focusState()->monitor())
-        Desktop::focusState()->rawMonitorFocus(PMONITOR);
 
     if (m_clickBehavior == CLICKMODE_KILL) {
         IPointer::SButtonEvent e;


### PR DESCRIPTION
This PR contains two small fixes.

## Fix touch handling for monitor-bound touch devices

When a touch device is bound to a specific monitor, `onTouchDown()` computes touch coordinates and calls `refocus()` before updating Hyprland's focused monitor. This causes touch input on layer-shell surfaces, such as bars, to not be recognised when another monitor is focused. Normal windows still receive the touch correctly, but layer-shell surfaces like Waybar or quickshell bars do not activate unless the touch-bound monitor is already focused. This should be the same issue discussed [here](https://github.com/hyprwm/Hyprland/discussions/13109), but their "solution" is just a dirty hack, while my patches fix this completely in my tests.

The patch simply moves `rawMonitorFocus(PMONITOR)` before coordinate handling, so Hyprland focuses the monitor associated with the touch device before routing the touch event.

## Fix zoom factor crash

While debugging, I noticed a startup crash due to a typo in `src/config/supplementary/propRefresher/PropRefresher.cpp` due to a typo: `CPropRefresher::scheduleRefresh()` requested `cursor.zoom_factor`, while it should be `cursor:zoom_factor`. This path also fixes that.
