### PR TITLE
meta/stubs: fix notification icon type

### DIFF
--- a/meta/generateLuaStubs.py
+++ b/meta/generateLuaStubs.py
@@ -663,7 +663,7 @@ def generate_stub(root: Path) -> str:
             [
                 ("color", "string", True),
                 ("timeout", "number", True),
-                ("icon", "integer", True),
+                ("icon", "integer|string", True),
                 ("font_size", "number", True),
             ],
         )


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
notification icon type could be string, not only integer - https://github.com/hyprwm/Hyprland/blob/main/src/config/lua/objects/LuaNotification.cpp#L62

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
nothing


#### Is it ready for merging, or does it need work?
ready
