### PR TITLE
cmakelists: remove copying example .conf file on install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -630,10 +630,6 @@ file(GLOB_RECURSE INSTALLABLE_ASSETS "assets/install/*")
 install(FILES ${INSTALLABLE_ASSETS}
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/hypr)
 
-# default config
-install(FILES ${CMAKE_SOURCE_DIR}/example/hyprland.conf
-        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/hypr)
-
 # default lua config
 install(FILES ${CMAKE_SOURCE_DIR}/example/hyprland.lua
         DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/hypr)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Remove copying the example .conf file on install, as it's no longer in the repository.
Currently the installation fails due to missing file.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

It's ready for merging.
