### PR TITLE
hl.mata.lua: add string to NotificationOptions's icon param.

### DIFF
--- a/meta/hl.meta.lua
+++ b/meta/hl.meta.lua
@@ -459,7 +459,7 @@ local __HL_PermissionSpec = {}
 ---@class HL.NotificationOptions
 ---@field color? string
 ---@field timeout? number
----@field icon? integer
+---@field icon? integer|string
 ---@field font_size? number
 local __HL_NotificationOptions = {}
 


### PR DESCRIPTION

#### Describe your PR, what does it fix/add?
title. that field is auto generated anyway, and is auto added every build since the generated file is tracked and is currently missing the possible string value. This PR adds that there so this file can stop appearing in changed files on every build

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no

#### Is it ready for merging, or does it need work?
yes