### PR TITLE
Add dispatch option to `fullscreen()` and `fullscreen_state()` calls for using the 'Default' fullscreen behaviour instead of the layout-specific ones

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2194,25 +2194,26 @@ bool CCompositor::workspaceIDOutOfBounds(const WORKSPACEID& id) {
 void CCompositor::changeWindowFullscreenModeClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE, const bool ON) {
     setWindowFullscreenClient(
         PWINDOW,
-        sc<eFullscreenMode>(ON ? sc<uint8_t>(PWINDOW->m_fullscreenState.client) | sc<uint8_t>(MODE) : (sc<uint8_t>(PWINDOW->m_fullscreenState.client) & sc<uint8_t>(~MODE))));
+        sc<eFullscreenMode>(ON ? sc<uint8_t>(PWINDOW->m_fullscreenState.client) | sc<uint8_t>(MODE) : (sc<uint8_t>(PWINDOW->m_fullscreenState.client) & sc<uint8_t>(~MODE))),
+        PWINDOW->m_fullscreen_LayoutHandled);
 }
 
 // TODO: move fs functions to Desktop::
-void CCompositor::setWindowFullscreenInternal(const PHLWINDOW PWINDOW, const eFullscreenMode MODE) {
+void CCompositor::setWindowFullscreenInternal(const PHLWINDOW PWINDOW, const eFullscreenMode MODE, bool layoutAware) {
     if (PWINDOW->m_ruleApplicator->syncFullscreen().valueOrDefault())
-        setWindowFullscreenState(PWINDOW, Desktop::View::SFullscreenState{.internal = MODE, .client = MODE});
+        setWindowFullscreenState(PWINDOW, Desktop::View::SFullscreenState{.internal = MODE, .client = MODE}, layoutAware);
     else
-        setWindowFullscreenState(PWINDOW, Desktop::View::SFullscreenState{.internal = MODE, .client = PWINDOW->m_fullscreenState.client});
+        setWindowFullscreenState(PWINDOW, Desktop::View::SFullscreenState{.internal = MODE, .client = PWINDOW->m_fullscreenState.client}, layoutAware);
 }
 
-void CCompositor::setWindowFullscreenClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE) {
+void CCompositor::setWindowFullscreenClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE, bool layoutAware) {
     if (PWINDOW->m_ruleApplicator->syncFullscreen().valueOrDefault())
-        setWindowFullscreenState(PWINDOW, Desktop::View::SFullscreenState{.internal = MODE, .client = MODE});
+        setWindowFullscreenState(PWINDOW, Desktop::View::SFullscreenState{.internal = MODE, .client = MODE}, layoutAware);
     else
-        setWindowFullscreenState(PWINDOW, Desktop::View::SFullscreenState{.internal = PWINDOW->m_fullscreenState.internal, .client = MODE});
+        setWindowFullscreenState(PWINDOW, Desktop::View::SFullscreenState{.internal = PWINDOW->m_fullscreenState.internal, .client = MODE}, layoutAware);
 }
 
-void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, Desktop::View::SFullscreenState state) {
+void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, Desktop::View::SFullscreenState state, bool layoutAware) {
     static auto PDIRECTSCANOUT      = CConfigValue<Config::INTEGER>("render:direct_scanout");
     static auto PALLOWPINFULLSCREEN = CConfigValue<Config::INTEGER>("binds:allow_pin_fullscreen");
 
@@ -2234,7 +2235,7 @@ void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, Desktop::Vie
     }
 
     if (PWORKSPACE->m_hasFullscreenWindow && !PWINDOW->isFullscreen())
-        setWindowFullscreenInternal(PWORKSPACE->getFullscreenWindow(), FSMODE_NONE);
+        setWindowFullscreenInternal(PWORKSPACE->getFullscreenWindow(), FSMODE_NONE, layoutAware);
 
     const bool CHANGEINTERNAL = !PWINDOW->m_pinned && PWINDOW->m_fullscreenState.internal != state.internal;
 
@@ -2272,14 +2273,17 @@ void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, Desktop::Vie
 
     PWORKSPACE->setNoMembersAboveFullscreen();
 
-    const auto FULLSCREEN_REQUEST_RESULT = g_layoutManager->fullscreenRequestForTarget(PWINDOW->layoutTarget(), OLD_EFFECTIVE_MODE, NEW_EFFECTIVE_MODE);
+    const auto FULLSCREEN_REQUEST_RESULT = g_layoutManager->fullscreenRequestForTarget(PWINDOW->layoutTarget(), OLD_EFFECTIVE_MODE, NEW_EFFECTIVE_MODE, layoutAware);
     const bool LAYOUT_HANDLED_FULLSCREEN = FULLSCREEN_REQUEST_RESULT == Layout::FULLSCREEN_REQUEST_HANDLED_BY_LAYOUT;
 
     if (LAYOUT_HANDLED_FULLSCREEN) {
-        PWORKSPACE->m_fullscreenMode      = FSMODE_NONE;
-        PWORKSPACE->m_hasFullscreenWindow = false;
-    } else
+        PWORKSPACE->m_fullscreenMode        = FSMODE_NONE;
+        PWORKSPACE->m_hasFullscreenWindow   = false;
+        PWINDOW->m_fullscreen_LayoutHandled = NEW_EFFECTIVE_MODE == FSMODE_NONE; // if fullscreened and layout handled the fullscreening
+    } else {
         PWINDOW->m_fullscreenState.internal = state.internal;
+        PWINDOW->m_fullscreen_LayoutHandled = false; // if not fullscreened or layout did not handle fullscreening
+    }
 
     g_pEventManager->postEvent(SHyprIPCEvent{.event = "fullscreen", .data = std::to_string(sc<int>(NEW_EFFECTIVE_MODE) != FSMODE_NONE)});
     Event::bus()->m_events.window.fullscreen.emit(PWINDOW);
@@ -2703,7 +2707,7 @@ void CCompositor::moveWindowToWorkspaceSafe(PHLWINDOW pWindow, PHLWORKSPACE pWor
     const bool WASVISIBLE     = pWindow->m_workspace && pWindow->m_workspace->isVisible();
 
     if (FULLSCREEN)
-        setWindowFullscreenInternal(pWindow, FSMODE_NONE);
+        setWindowFullscreenInternal(pWindow, FSMODE_NONE, pWindow->m_fullscreen_LayoutHandled);
 
     const PHLWINDOW pFirstWindowOnWorkspace   = pWorkspace->getFirstWindow();
     const int       visibleWindowsOnWorkspace = pWorkspace->getWindows(true, std::nullopt, true);
@@ -2732,7 +2736,7 @@ void CCompositor::moveWindowToWorkspaceSafe(PHLWINDOW pWindow, PHLWORKSPACE pWor
     g_layoutManager->newTarget(pWindow->layoutTarget(), pWorkspace->m_space);
 
     if (FULLSCREEN)
-        setWindowFullscreenInternal(pWindow, FULLSCREENMODE);
+        setWindowFullscreenInternal(pWindow, FULLSCREENMODE, pWindow->m_fullscreen_LayoutHandled);
 
     pWorkspace->updateWindows();
     if (pWindow->m_workspace)

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -134,9 +134,9 @@ class CCompositor {
     void                   swapActiveWorkspaces(PHLMONITOR, PHLMONITOR);
     PHLMONITOR             getMonitorFromString(const std::string&);
     bool                   workspaceIDOutOfBounds(const WORKSPACEID&);
-    void                   setWindowFullscreenInternal(const PHLWINDOW PWINDOW, const eFullscreenMode MODE);
-    void                   setWindowFullscreenClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE);
-    void                   setWindowFullscreenState(const PHLWINDOW PWINDOW, const Desktop::View::SFullscreenState state);
+    void                   setWindowFullscreenInternal(const PHLWINDOW PWINDOW, const eFullscreenMode MODE, bool layoutAware);
+    void                   setWindowFullscreenClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE, bool layoutAware);
+    void                   setWindowFullscreenState(const PHLWINDOW PWINDOW, const Desktop::View::SFullscreenState state, bool layoutAware);
     void                   changeWindowFullscreenModeClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE, const bool ON);
     PHLWINDOW              getX11Parent(PHLWINDOW);
     void                   scheduleFrameForMonitor(PHLMONITOR, Aquamarine::IOutput::scheduleFrameReason reason = Aquamarine::IOutput::AQ_SCHEDULE_CLIENT_UNKNOWN);

--- a/src/config/legacy/DispatcherTranslator.cpp
+++ b/src/config/legacy/DispatcherTranslator.cpp
@@ -160,7 +160,7 @@ static SDispatchResult fullscreen(const std::string& args) {
     const eFullscreenMode MODE = ARGS.size() > 0 && ARGS[0] == "1" ? FSMODE_MAXIMIZED : FSMODE_FULLSCREEN;
 
     if (ARGS.size() <= 1 || ARGS[1] == "toggle")
-        return wrap(Actions::fullscreenWindow(MODE));
+        return wrap(Actions::fullscreenWindow(MODE, true));
 
     // "set" means enable, "unset" means disable - but the Action toggles.
     // We need to check current state ourselves.
@@ -170,11 +170,11 @@ static SDispatchResult fullscreen(const std::string& args) {
 
     if (ARGS[1] == "set") {
         if (!PWINDOW->isEffectiveInternalFSMode(MODE))
-            return wrap(Actions::fullscreenWindow(MODE));
+            return wrap(Actions::fullscreenWindow(MODE, true));
         return {};
     } else if (ARGS[1] == "unset") {
         if (PWINDOW->isEffectiveInternalFSMode(MODE))
-            return wrap(Actions::fullscreenWindow(MODE));
+            return wrap(Actions::fullscreenWindow(MODE, true));
         return {};
     }
 
@@ -199,7 +199,7 @@ static SDispatchResult fullscreenstate(const std::string& args) {
     eFullscreenMode im = internalMode != -1 ? sc<eFullscreenMode>(internalMode) : PWINDOW->m_fullscreenState.internal;
     eFullscreenMode cm = clientMode != -1 ? sc<eFullscreenMode>(clientMode) : PWINDOW->m_fullscreenState.client;
 
-    return wrap(Actions::fullscreenWindow(im, cm));
+    return wrap(Actions::fullscreenWindow(im, cm, true));
 }
 
 static SDispatchResult movetoworkspace(const std::string& args) {

--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -454,16 +454,17 @@ static int dsp_floatWindow(lua_State* L) {
 }
 
 static int dsp_fullscreenWindow(lua_State* L) {
-    return Internal::checkResult(L, CA::fullscreenWindow(sc<eFullscreenMode>((int)lua_tonumber(L, lua_upvalueindex(1))), Internal::windowFromUpval(L, 2)));
+    return Internal::checkResult(L, CA::fullscreenWindow(sc<eFullscreenMode>((int)lua_tonumber(L, lua_upvalueindex(1))), lua_toboolean(L, lua_upvalueindex(2)), Internal::windowFromUpval(L, 3)));
 }
 
 static int dsp_fullscreenWindowWithAction(lua_State* L) {
     const auto mode      = sc<eFullscreenMode>((int)lua_tonumber(L, lua_upvalueindex(1)));
-    const int  actionRaw = (int)lua_tonumber(L, lua_upvalueindex(2));
-    auto       maybeW    = Internal::windowFromUpval(L, 3);
+    bool layoutAware = lua_toboolean(L, lua_upvalueindex(2));
+    const int  actionRaw = (int)lua_tonumber(L, lua_upvalueindex(3));
+    auto       maybeW    = Internal::windowFromUpval(L, 4);
 
     if (actionRaw == 0) {
-        return Internal::checkResult(L, CA::fullscreenWindow(mode, maybeW));
+        return Internal::checkResult(L, CA::fullscreenWindow(mode, layoutAware, maybeW));
     }
 
     const auto target = maybeW.value_or(Desktop::focusState()->window());
@@ -474,13 +475,13 @@ static int dsp_fullscreenWindowWithAction(lua_State* L) {
 
     if (actionRaw == 1) {
         if (!currentlyMode)
-            return Internal::checkResult(L, CA::fullscreenWindow(mode, maybeW));
+            return Internal::checkResult(L, CA::fullscreenWindow(mode, layoutAware, maybeW));
         return Internal::pushSuccessResult(L);
     }
 
     if (actionRaw == 2) {
         if (currentlyMode)
-            return Internal::checkResult(L, CA::fullscreenWindow(mode, maybeW));
+            return Internal::checkResult(L, CA::fullscreenWindow(mode, layoutAware, maybeW));
         return Internal::pushSuccessResult(L);
     }
 
@@ -491,7 +492,8 @@ static int dsp_fullscreenState(lua_State* L) {
     const auto desiredInternal = sc<eFullscreenMode>((int)lua_tonumber(L, lua_upvalueindex(1)));
     const auto desiredClient   = sc<eFullscreenMode>((int)lua_tonumber(L, lua_upvalueindex(2)));
     const int  actionRaw       = (int)lua_tonumber(L, lua_upvalueindex(3)); // 0: toggle, 1: set, 2: unset
-    auto       maybeW          = Internal::windowFromUpval(L, 4);
+    bool layoutAware = lua_toboolean(L, lua_upvalueindex(4));
+    auto       maybeW          = Internal::windowFromUpval(L, 5);
 
     const auto target = maybeW.value_or(Desktop::focusState()->window());
     if (!target)
@@ -501,18 +503,18 @@ static int dsp_fullscreenState(lua_State* L) {
     const bool atDesiredState = CURRENT.internal == desiredInternal && CURRENT.client == desiredClient;
 
     if (actionRaw == 0) {
-        return Internal::checkResult(L, CA::fullscreenWindow(desiredInternal, desiredClient, maybeW));
+        return Internal::checkResult(L, CA::fullscreenWindow(desiredInternal,  desiredClient, layoutAware, maybeW));
     }
 
     if (actionRaw == 1) {
         if (!atDesiredState)
-            return Internal::checkResult(L, CA::fullscreenWindow(desiredInternal, desiredClient, maybeW));
+            return Internal::checkResult(L, CA::fullscreenWindow(desiredInternal, desiredClient, layoutAware, maybeW));
         return Internal::pushSuccessResult(L);
     }
 
     if (actionRaw == 2) {
         if (atDesiredState)
-            return Internal::checkResult(L, CA::fullscreenWindow(desiredInternal, desiredClient, maybeW));
+            return Internal::checkResult(L, CA::fullscreenWindow(desiredInternal, desiredClient, layoutAware,maybeW));
         return Internal::pushSuccessResult(L);
     }
 
@@ -683,13 +685,19 @@ static int hlWindowFullscreen(lua_State* L) {
         }
     }
     lua_pushnumber(L, (int)mode);
+
+    // layout specific fullscreen behaviour or not
+    auto ls          = Internal::tableOptBool(L, 1, "layout_aware");
+    bool layoutAware = ls ? *ls : true; // default is true
+    lua_pushboolean(L, layoutAware);
+
     if (action == 0) {
         Internal::pushWindowUpval(L, 1);
-        lua_pushcclosure(L, dsp_fullscreenWindow, 2);
+        lua_pushcclosure(L, dsp_fullscreenWindow, 3);
     } else {
         lua_pushnumber(L, action);
         Internal::pushWindowUpval(L, 1);
-        lua_pushcclosure(L, dsp_fullscreenWindowWithAction, 3);
+        lua_pushcclosure(L, dsp_fullscreenWindowWithAction, 4);
     }
     return 1;
 }
@@ -715,11 +723,16 @@ static int hlWindowFullscreenState(lua_State* L) {
     if (!im || !cm)
         return Internal::configError(L, "hl.window.fullscreen_state: 'internal' and 'client' are required");
 
+    // layout specific fullscreen behaviour or not
+    auto ls          = Internal::tableOptBool(L, 1, "layout_aware");
+    bool layoutAware = ls ? *ls : true; // default is true
+
     lua_pushnumber(L, (int)*im);
     lua_pushnumber(L, (int)*cm);
     lua_pushnumber(L, action);
+    lua_pushboolean(L, layoutAware);
     Internal::pushWindowUpval(L, 1);
-    lua_pushcclosure(L, dsp_fullscreenState, 4);
+    lua_pushcclosure(L, dsp_fullscreenState, 5);
     return 1;
 }
 

--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -454,14 +454,15 @@ static int dsp_floatWindow(lua_State* L) {
 }
 
 static int dsp_fullscreenWindow(lua_State* L) {
-    return Internal::checkResult(L, CA::fullscreenWindow(sc<eFullscreenMode>((int)lua_tonumber(L, lua_upvalueindex(1))), lua_toboolean(L, lua_upvalueindex(2)), Internal::windowFromUpval(L, 3)));
+    return Internal::checkResult(
+        L, CA::fullscreenWindow(sc<eFullscreenMode>((int)lua_tonumber(L, lua_upvalueindex(1))), lua_toboolean(L, lua_upvalueindex(2)), Internal::windowFromUpval(L, 3)));
 }
 
 static int dsp_fullscreenWindowWithAction(lua_State* L) {
-    const auto mode      = sc<eFullscreenMode>((int)lua_tonumber(L, lua_upvalueindex(1)));
-    bool layoutAware = lua_toboolean(L, lua_upvalueindex(2));
-    const int  actionRaw = (int)lua_tonumber(L, lua_upvalueindex(3));
-    auto       maybeW    = Internal::windowFromUpval(L, 4);
+    const auto mode        = sc<eFullscreenMode>((int)lua_tonumber(L, lua_upvalueindex(1)));
+    bool       layoutAware = lua_toboolean(L, lua_upvalueindex(2));
+    const int  actionRaw   = (int)lua_tonumber(L, lua_upvalueindex(3));
+    auto       maybeW      = Internal::windowFromUpval(L, 4);
 
     if (actionRaw == 0) {
         return Internal::checkResult(L, CA::fullscreenWindow(mode, layoutAware, maybeW));
@@ -492,7 +493,7 @@ static int dsp_fullscreenState(lua_State* L) {
     const auto desiredInternal = sc<eFullscreenMode>((int)lua_tonumber(L, lua_upvalueindex(1)));
     const auto desiredClient   = sc<eFullscreenMode>((int)lua_tonumber(L, lua_upvalueindex(2)));
     const int  actionRaw       = (int)lua_tonumber(L, lua_upvalueindex(3)); // 0: toggle, 1: set, 2: unset
-    bool layoutAware = lua_toboolean(L, lua_upvalueindex(4));
+    bool       layoutAware     = lua_toboolean(L, lua_upvalueindex(4));
     auto       maybeW          = Internal::windowFromUpval(L, 5);
 
     const auto target = maybeW.value_or(Desktop::focusState()->window());
@@ -503,7 +504,7 @@ static int dsp_fullscreenState(lua_State* L) {
     const bool atDesiredState = CURRENT.internal == desiredInternal && CURRENT.client == desiredClient;
 
     if (actionRaw == 0) {
-        return Internal::checkResult(L, CA::fullscreenWindow(desiredInternal,  desiredClient, layoutAware, maybeW));
+        return Internal::checkResult(L, CA::fullscreenWindow(desiredInternal, desiredClient, layoutAware, maybeW));
     }
 
     if (actionRaw == 1) {
@@ -514,7 +515,7 @@ static int dsp_fullscreenState(lua_State* L) {
 
     if (actionRaw == 2) {
         if (atDesiredState)
-            return Internal::checkResult(L, CA::fullscreenWindow(desiredInternal, desiredClient, layoutAware,maybeW));
+            return Internal::checkResult(L, CA::fullscreenWindow(desiredInternal, desiredClient, layoutAware, maybeW));
         return Internal::pushSuccessResult(L);
     }
 

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -253,20 +253,20 @@ ActionResult Actions::pinWindow(eTogglableAction action, std::optional<PHLWINDOW
     return {};
 }
 
-ActionResult Actions::fullscreenWindow(eFullscreenMode mode, std::optional<PHLWINDOW> w) {
+ActionResult Actions::fullscreenWindow(eFullscreenMode mode, bool layoutAware, std::optional<PHLWINDOW> w) {
     auto window = xtract(w);
     if (!window)
         return {};
 
     if (window->isEffectiveInternalFSMode(mode))
-        g_pCompositor->setWindowFullscreenInternal(window, FSMODE_NONE);
+        g_pCompositor->setWindowFullscreenInternal(window, FSMODE_NONE, layoutAware);
     else
-        g_pCompositor->setWindowFullscreenInternal(window, mode);
+        g_pCompositor->setWindowFullscreenInternal(window, mode, layoutAware);
 
     return {};
 }
 
-ActionResult Actions::fullscreenWindow(eFullscreenMode internalMode, eFullscreenMode clientMode, std::optional<PHLWINDOW> w) {
+ActionResult Actions::fullscreenWindow(eFullscreenMode internalMode, eFullscreenMode clientMode, bool layoutAware, std::optional<PHLWINDOW> w) {
     auto window = xtract(w);
     if (!window)
         return {};
@@ -276,9 +276,9 @@ ActionResult Actions::fullscreenWindow(eFullscreenMode internalMode, eFullscreen
     const Desktop::View::SFullscreenState STATE = {.internal = internalMode, .client = clientMode};
 
     if (window->m_fullscreenState.internal == STATE.internal && window->m_fullscreenState.client == STATE.client)
-        g_pCompositor->setWindowFullscreenState(window, Desktop::View::SFullscreenState{.internal = FSMODE_NONE, .client = FSMODE_NONE});
+        g_pCompositor->setWindowFullscreenState(window, Desktop::View::SFullscreenState{.internal = FSMODE_NONE, .client = FSMODE_NONE}, layoutAware);
     else
-        g_pCompositor->setWindowFullscreenState(window, STATE);
+        g_pCompositor->setWindowFullscreenState(window, STATE, layoutAware);
 
     window->m_ruleApplicator->syncFullscreenOverride(
         Desktop::Types::COverridableVar(window->m_fullscreenState.internal == window->m_fullscreenState.client, Desktop::Types::PRIORITY_SET_PROP));
@@ -321,7 +321,7 @@ ActionResult Actions::moveToWorkspace(PHLWORKSPACE ws, bool silent, std::optiona
         g_pCompositor->moveWindowToWorkspaceSafe(window, ws);
         pMonitor = ws->m_monitor.lock();
         Desktop::focusState()->rawMonitorFocus(pMonitor);
-        g_pCompositor->setWindowFullscreenInternal(window, FULLSCREENMODE);
+        g_pCompositor->setWindowFullscreenInternal(window, FULLSCREENMODE, window->m_fullscreen_LayoutHandled);
 
         POLDWS->m_lastFocusedWindow = POLDWS->getFirstWindow();
 
@@ -851,7 +851,7 @@ ActionResult Actions::toggleGroup(std::optional<PHLWINDOW> w) {
         return {};
 
     if (window->isFullscreen())
-        g_pCompositor->setWindowFullscreenInternal(window, FSMODE_NONE);
+        g_pCompositor->setWindowFullscreenInternal(window, FSMODE_NONE, window->m_fullscreen_LayoutHandled);
 
     if (!window->m_group)
         window->m_group = Desktop::View::CGroup::create({window});

--- a/src/config/shared/actions/ConfigActions.hpp
+++ b/src/config/shared/actions/ConfigActions.hpp
@@ -37,8 +37,8 @@ namespace Config::Actions {
     ActionResult floatWindow(eTogglableAction action, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
     ActionResult pseudoWindow(eTogglableAction action, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
     ActionResult pinWindow(eTogglableAction action, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
-    ActionResult fullscreenWindow(eFullscreenMode mode, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
-    ActionResult fullscreenWindow(eFullscreenMode internalMode, eFullscreenMode clientMode, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
+    ActionResult fullscreenWindow(eFullscreenMode mode, bool layoutAware, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
+    ActionResult fullscreenWindow(eFullscreenMode internalMode, eFullscreenMode clientMode, bool layoutAware, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
     ActionResult moveToWorkspace(PHLWORKSPACE ws, bool silent, std::optional<PHLWINDOW> window = std::nullopt /* Active */);
     ActionResult moveFocus(Math::eDirection dir);
     ActionResult focus(PHLWINDOW window);

--- a/src/desktop/state/FocusState.cpp
+++ b/src/desktop/state/FocusState.cpp
@@ -52,14 +52,14 @@ static SFullscreenWorkspaceFocusResult onFullscreenWorkspaceFocusWindow(PHLWINDO
         case 2:
             // undo fs, unless we force a cycle
             if (!forceFSCycle) {
-                g_pCompositor->setWindowFullscreenInternal(FSWINDOW, FSMODE_NONE);
+                g_pCompositor->setWindowFullscreenInternal(FSWINDOW, FSMODE_NONE, FSWINDOW->m_fullscreen_LayoutHandled);
                 break;
             }
             [[fallthrough]];
         case 1:
             // replace fullscreen
-            g_pCompositor->setWindowFullscreenInternal(FSWINDOW, FSMODE_NONE);
-            g_pCompositor->setWindowFullscreenInternal(pWindow, FSMODE);
+            g_pCompositor->setWindowFullscreenInternal(FSWINDOW, FSMODE_NONE, FSWINDOW->m_fullscreen_LayoutHandled);
+            g_pCompositor->setWindowFullscreenInternal(pWindow, FSMODE, pWindow->m_fullscreen_LayoutHandled);
             break;
 
         default: Log::logger->log(Log::ERR, "Invalid misc:on_focus_under_fullscreen mode: {}", *PONFOCUSUNDERFS); break;

--- a/src/desktop/view/Group.cpp
+++ b/src/desktop/view/Group.cpp
@@ -205,7 +205,7 @@ void CGroup::setCurrent(size_t idx) {
     auto       oldWindow = m_windows.at(m_current).lock();
 
     if (FS_STATE != FSMODE_NONE)
-        g_pCompositor->setWindowFullscreenInternal(oldWindow, FSMODE_NONE);
+        g_pCompositor->setWindowFullscreenInternal(oldWindow, FSMODE_NONE, oldWindow->m_fullscreen_LayoutHandled);
 
     m_current = std::clamp(idx, sc<size_t>(0), m_windows.size() - 1);
     updateWindowVisibility();
@@ -213,7 +213,7 @@ void CGroup::setCurrent(size_t idx) {
     auto newWindow = m_windows.at(m_current).lock();
 
     if (FS_STATE != FSMODE_NONE) {
-        g_pCompositor->setWindowFullscreenInternal(newWindow, FS_STATE);
+        g_pCompositor->setWindowFullscreenInternal(newWindow, FS_STATE, oldWindow->m_fullscreen_LayoutHandled);
         newWindow->m_target->warpPositionSize();
         oldWindow->m_target->setPositionGlobal(newWindow->m_target->position()); // TODO: this is a hack and sucks
     }

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -2168,8 +2168,10 @@ void CWindow::mapWindow() {
             m_noInitialFocus = true;
         else if (*PNEWTAKESOVERFS == 1)
             requestedInternalFSMode = m_workspace->m_fullscreenMode;
-        else if (*PNEWTAKESOVERFS == 2)
-            g_pCompositor->setWindowFullscreenInternal(m_workspace->getFullscreenWindow(), FSMODE_NONE);
+        else if (*PNEWTAKESOVERFS == 2) {
+            auto fsWindow = m_workspace->getFullscreenWindow();
+            g_pCompositor->setWindowFullscreenInternal(fsWindow, FSMODE_NONE, fsWindow->m_fullscreen_LayoutHandled);
+        }
     }
 
     if (!m_ruleApplicator->noFocus().valueOrDefault() && !m_noInitialFocus && (!isX11OverrideRedirect() || (m_isX11 && m_xwaylandSurface->wantsFocus())) && !workspaceSilent &&
@@ -2180,7 +2182,7 @@ void CWindow::mapWindow() {
 
         if (IS_LAST_IN_FS && SAME_GROUP) {
             Desktop::focusState()->rawWindowFocus(m_self.lock(), FOCUS_REASON_NEW_WINDOW);
-            g_pCompositor->setWindowFullscreenInternal(m_self.lock(), LAST_FS_MODE);
+            g_pCompositor->setWindowFullscreenInternal(m_self.lock(), LAST_FS_MODE, m_self->m_fullscreen_LayoutHandled);
         } else
             Desktop::focusState()->fullWindowFocus(m_self.lock(), FOCUS_REASON_NEW_WINDOW);
 
@@ -2198,21 +2200,23 @@ void CWindow::mapWindow() {
 
     if (!m_noInitialFocus && (requestedInternalFSMode.has_value() || requestedClientFSMode.has_value() || requestedFSState.has_value())) {
         // fix fullscreen on requested (basically do a switcheroo)
-        if (m_workspace->m_hasFullscreenWindow)
-            g_pCompositor->setWindowFullscreenInternal(m_workspace->getFullscreenWindow(), FSMODE_NONE);
+        if (m_workspace->m_hasFullscreenWindow) {
+            auto fsWindow = m_workspace->getFullscreenWindow();
+            g_pCompositor->setWindowFullscreenInternal(fsWindow, FSMODE_NONE, fsWindow->m_fullscreen_LayoutHandled);
+        }
 
         m_realPosition->warp();
         m_realSize->warp();
         if (requestedFSState.has_value()) {
             m_ruleApplicator->syncFullscreenOverride(Desktop::Types::COverridableVar(false, Desktop::Types::PRIORITY_WINDOW_RULE));
-            g_pCompositor->setWindowFullscreenState(m_self.lock(), requestedFSState.value());
+            g_pCompositor->setWindowFullscreenState(m_self.lock(), requestedFSState.value(), true);
         } else if (requestedInternalFSMode.has_value() && requestedClientFSMode.has_value() && !m_ruleApplicator->syncFullscreen().valueOrDefault())
             g_pCompositor->setWindowFullscreenState(m_self.lock(),
-                                                    Desktop::View::SFullscreenState{.internal = requestedInternalFSMode.value(), .client = requestedClientFSMode.value()});
+                                                    Desktop::View::SFullscreenState{.internal = requestedInternalFSMode.value(), .client = requestedClientFSMode.value()}, true);
         else if (requestedInternalFSMode.has_value())
-            g_pCompositor->setWindowFullscreenInternal(m_self.lock(), requestedInternalFSMode.value());
+            g_pCompositor->setWindowFullscreenInternal(m_self.lock(), requestedInternalFSMode.value(), m_self->m_fullscreen_LayoutHandled);
         else if (requestedClientFSMode.has_value())
-            g_pCompositor->setWindowFullscreenClient(m_self.lock(), requestedClientFSMode.value());
+            g_pCompositor->setWindowFullscreenClient(m_self.lock(), requestedClientFSMode.value(), true);
     }
 
     // recheck idle inhibitors
@@ -2309,7 +2313,7 @@ void CWindow::unmapWindow() {
     }
 
     if (isFullscreen())
-        g_pCompositor->setWindowFullscreenInternal(m_self.lock(), FSMODE_NONE);
+        g_pCompositor->setWindowFullscreenInternal(m_self.lock(), FSMODE_NONE, m_self->m_fullscreen_LayoutHandled);
 
     // Allow the renderer to catch the last frame.
     if (g_pHyprRenderer->shouldRenderWindow(m_self.lock()))
@@ -2402,7 +2406,7 @@ void CWindow::unmapWindow() {
                 Desktop::focusState()->fullWindowFocus(candidate, m_self->m_isFloating ? FOCUS_REASON_UNMAP_WINDOW_FLOATING : FOCUS_REASON_UNMAP_WINDOW_TILING);
 
             if ((*PEXITRETAINSFS || candidate == nextInGroup) && CURRENTWINDOWFSSTATE)
-                g_pCompositor->setWindowFullscreenInternal(candidate, CURRENTFSMODE);
+                g_pCompositor->setWindowFullscreenInternal(candidate, CURRENTFSMODE, candidate->m_fullscreen_LayoutHandled);
         }
 
         if (!candidate && m_workspace && m_workspace->getWindows() == 0)

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -2182,7 +2182,8 @@ void CWindow::mapWindow() {
 
         if (IS_LAST_IN_FS && SAME_GROUP) {
             Desktop::focusState()->rawWindowFocus(m_self.lock(), FOCUS_REASON_NEW_WINDOW);
-            g_pCompositor->setWindowFullscreenInternal(m_self.lock(), LAST_FS_MODE, m_self->m_fullscreen_LayoutHandled);
+            // FS a new window to replace the old FSed window, use the old's layoutAware FS behaviour
+            g_pCompositor->setWindowFullscreenInternal(m_self.lock(), LAST_FS_MODE, LAST_FOCUS_WINDOW->m_fullscreen_LayoutHandled);
         } else
             Desktop::focusState()->fullWindowFocus(m_self.lock(), FOCUS_REASON_NEW_WINDOW);
 
@@ -2209,13 +2210,17 @@ void CWindow::mapWindow() {
         m_realSize->warp();
         if (requestedFSState.has_value()) {
             m_ruleApplicator->syncFullscreenOverride(Desktop::Types::COverridableVar(false, Desktop::Types::PRIORITY_WINDOW_RULE));
+            // windowrule always uses layout specific fullscreen bahaviour if it exists
             g_pCompositor->setWindowFullscreenState(m_self.lock(), requestedFSState.value(), true);
         } else if (requestedInternalFSMode.has_value() && requestedClientFSMode.has_value() && !m_ruleApplicator->syncFullscreen().valueOrDefault())
+            // windowrule always uses layout specific fullscreen bahaviour if it exists
             g_pCompositor->setWindowFullscreenState(m_self.lock(),
                                                     Desktop::View::SFullscreenState{.internal = requestedInternalFSMode.value(), .client = requestedClientFSMode.value()}, true);
         else if (requestedInternalFSMode.has_value())
-            g_pCompositor->setWindowFullscreenInternal(m_self.lock(), requestedInternalFSMode.value(), m_self->m_fullscreen_LayoutHandled);
+            // windowrule always uses layout specific fullscreen bahaviour if it exists
+            g_pCompositor->setWindowFullscreenInternal(m_self.lock(), requestedInternalFSMode.value(), true);
         else if (requestedClientFSMode.has_value())
+            // windowrule always uses layout specific fullscreen bahaviour if it exists
             g_pCompositor->setWindowFullscreenClient(m_self.lock(), requestedClientFSMode.value(), true);
     }
 
@@ -2406,7 +2411,8 @@ void CWindow::unmapWindow() {
                 Desktop::focusState()->fullWindowFocus(candidate, m_self->m_isFloating ? FOCUS_REASON_UNMAP_WINDOW_FLOATING : FOCUS_REASON_UNMAP_WINDOW_TILING);
 
             if ((*PEXITRETAINSFS || candidate == nextInGroup) && CURRENTWINDOWFSSTATE)
-                g_pCompositor->setWindowFullscreenInternal(candidate, CURRENTFSMODE, candidate->m_fullscreen_LayoutHandled);
+                // set the candidate to the current window's FS state - use the current window's layoutAware FS behaviour
+                g_pCompositor->setWindowFullscreenInternal(candidate, CURRENTFSMODE, m_self->m_fullscreen_LayoutHandled);
         }
 
         if (!candidate && m_workspace && m_workspace->getWindows() == 0)

--- a/src/desktop/view/Window.hpp
+++ b/src/desktop/view/Window.hpp
@@ -166,13 +166,14 @@ namespace Desktop::View {
         // for recovering relative cursor position
         Vector2D         m_relativeCursorCoordsOnLastWarp = Vector2D(-1, -1);
 
-        bool             m_firstMap        = false; // for layouts
-        bool             m_isFloating      = false;
-        SFullscreenState m_fullscreenState = {.internal = FSMODE_NONE, .client = FSMODE_NONE};
-        std::string      m_title           = "";
-        std::string      m_class           = "";
-        std::string      m_initialTitle    = "";
-        std::string      m_initialClass    = "";
+        bool             m_firstMap                 = false; // for layouts
+        bool             m_isFloating               = false;
+        SFullscreenState m_fullscreenState          = {.internal = FSMODE_NONE, .client = FSMODE_NONE};
+        bool             m_fullscreen_LayoutHandled = false; // if fullscreen was handled by the layout
+        std::string      m_title                    = "";
+        std::string      m_class                    = "";
+        std::string      m_initialTitle             = "";
+        std::string      m_initialClass             = "";
         PHLWORKSPACE     m_workspace;
         PHLMONITORREF    m_monitor, m_prevMonitor;
 

--- a/src/layout/LayoutManager.cpp
+++ b/src/layout/LayoutManager.cpp
@@ -94,9 +94,9 @@ void CLayoutManager::endDragTarget() {
     m_dragStateController->dragEnd();
 }
 
-eFullscreenRequestResult CLayoutManager::fullscreenRequestForTarget(SP<ITarget> target, eFullscreenMode currentEffectiveMode, eFullscreenMode effectiveMode) {
+eFullscreenRequestResult CLayoutManager::fullscreenRequestForTarget(SP<ITarget> target, eFullscreenMode currentEffectiveMode, eFullscreenMode effectiveMode, bool layoutAware) {
     if (target && target->space())
-        return target->space()->setFullscreen(target, currentEffectiveMode, effectiveMode);
+        return target->space()->setFullscreen(target, currentEffectiveMode, effectiveMode, layoutAware);
 
     return FULLSCREEN_REQUEST_DEFAULT;
 }

--- a/src/layout/LayoutManager.hpp
+++ b/src/layout/LayoutManager.hpp
@@ -71,7 +71,7 @@ namespace Layout {
 
         Config::ErrorResult      layoutMsg(const std::string_view& sv);
 
-        eFullscreenRequestResult fullscreenRequestForTarget(SP<ITarget> target, eFullscreenMode currentEffectiveMode, eFullscreenMode effectiveMode);
+        eFullscreenRequestResult fullscreenRequestForTarget(SP<ITarget> target, eFullscreenMode currentEffectiveMode, eFullscreenMode effectiveMode, bool layoutAware);
 
         void                     switchTargets(SP<ITarget> a, SP<ITarget> b, bool preserveFocus = true);
 

--- a/src/layout/algorithm/Algorithm.cpp
+++ b/src/layout/algorithm/Algorithm.cpp
@@ -154,11 +154,16 @@ void CAlgorithm::moveTarget(const Vector2D& Δ, SP<ITarget> target) {
         m_floating->moveTarget(Δ, target);
 }
 
-eFullscreenRequestResult CAlgorithm::requestFullscreen(SP<ITarget> target, eFullscreenMode currentEffectiveMode, eFullscreenMode effectiveMode) {
+eFullscreenRequestResult CAlgorithm::requestFullscreen(SP<ITarget> target, eFullscreenMode currentEffectiveMode, eFullscreenMode effectiveMode, bool layoutAware) {
     if (!target)
         return FULLSCREEN_REQUEST_DEFAULT;
 
     const SFullscreenRequest request = {.target = target, .currentEffectiveMode = currentEffectiveMode, .effectiveMode = effectiveMode};
+
+    // if the user wants non-layout-specific fullscreen behaviour
+    if (!layoutAware) {
+        return FULLSCREEN_REQUEST_DEFAULT;
+    }
     return target->floating() ? m_floating->requestFullscreen(request) : m_tiled->requestFullscreen(request);
 }
 

--- a/src/layout/algorithm/Algorithm.hpp
+++ b/src/layout/algorithm/Algorithm.hpp
@@ -43,7 +43,7 @@ namespace Layout {
 
         void                          setTargetGeom(const CBox& box, SP<ITarget> target); // only for float
 
-        eFullscreenRequestResult      requestFullscreen(SP<ITarget> target, eFullscreenMode currentEffectiveMode, eFullscreenMode effectiveMode);
+        eFullscreenRequestResult      requestFullscreen(SP<ITarget> target, eFullscreenMode currentEffectiveMode, eFullscreenMode effectiveMode, bool layoutAware);
         SP<ITarget>                   layoutFullscreenTarget() const;
         bool                          layoutFullscreenCoversMonitor() const;
 

--- a/src/layout/algorithm/tiled/dwindle/DwindleAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/dwindle/DwindleAlgorithm.cpp
@@ -266,8 +266,10 @@ void CDwindleAlgorithm::removeTarget(SP<ITarget> target) {
         return;
     }
 
-    if (target->fullscreenMode() != FSMODE_NONE)
-        g_pCompositor->setWindowFullscreenInternal(target->window(), FSMODE_NONE);
+    if (target->fullscreenMode() != FSMODE_NONE) {
+        auto window = target->window();
+        g_pCompositor->setWindowFullscreenInternal(window, FSMODE_NONE, window->m_fullscreen_LayoutHandled);
+    }
 
     const auto PPARENT = PNODE->pParent;
 

--- a/src/layout/algorithm/tiled/master/MasterAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/master/MasterAlgorithm.cpp
@@ -208,8 +208,10 @@ void CMasterAlgorithm::removeTarget(SP<ITarget> target) {
 
     const auto  PNODE = getNodeFromTarget(target);
 
-    if (target->fullscreenMode() != FSMODE_NONE)
-        g_pCompositor->setWindowFullscreenInternal(target->window(), FSMODE_NONE);
+    if (target->fullscreenMode() != FSMODE_NONE) {
+        auto window = target->window();
+        g_pCompositor->setWindowFullscreenInternal(window, FSMODE_NONE, window->m_fullscreen_LayoutHandled);
+    }
 
     if (PNODE->isMaster && (MASTERSLEFT <= 1 || *SMALLSPLIT == 1)) {
         // find a new master from top of the list
@@ -576,7 +578,7 @@ Config::ErrorResult CMasterAlgorithm::layoutMsg(const std::string_view& sv) {
         const auto PWINDOWTOSWAPWITH = getNextTarget(PWINDOW->layoutTarget(), true, !NOLOOP);
 
         if (PWINDOWTOSWAPWITH) {
-            g_pCompositor->setWindowFullscreenInternal(PWINDOW, FSMODE_NONE);
+            g_pCompositor->setWindowFullscreenInternal(PWINDOW, FSMODE_NONE, PWINDOW->m_fullscreen_LayoutHandled);
             g_layoutManager->switchTargets(PWINDOW->layoutTarget(), PWINDOWTOSWAPWITH);
             switchToWindow(PWINDOW->layoutTarget());
         }
@@ -593,7 +595,7 @@ Config::ErrorResult CMasterAlgorithm::layoutMsg(const std::string_view& sv) {
         const auto PWINDOWTOSWAPWITH = getNextTarget(PWINDOW->layoutTarget(), false, !NOLOOP);
 
         if (PWINDOWTOSWAPWITH) {
-            g_pCompositor->setWindowFullscreenInternal(PWINDOW, FSMODE_NONE);
+            g_pCompositor->setWindowFullscreenInternal(PWINDOW, FSMODE_NONE, PWINDOW->m_fullscreen_LayoutHandled);
             g_layoutManager->switchTargets(PWINDOW->layoutTarget(), PWINDOWTOSWAPWITH);
             switchToWindow(PWINDOW->layoutTarget());
         }
@@ -613,7 +615,7 @@ Config::ErrorResult CMasterAlgorithm::layoutMsg(const std::string_view& sv) {
         if (MASTERS + 2 > WINDOWS && *SMALLSPLIT == 0)
             return stateErr("nothing to do");
 
-        g_pCompositor->setWindowFullscreenInternal(PWINDOW, FSMODE_NONE);
+        g_pCompositor->setWindowFullscreenInternal(PWINDOW, FSMODE_NONE, PWINDOW->m_fullscreen_LayoutHandled);
 
         if (!PNODE || PNODE->isMaster) {
             // first non-master node
@@ -645,7 +647,7 @@ Config::ErrorResult CMasterAlgorithm::layoutMsg(const std::string_view& sv) {
         if (WINDOWS < 2 || MASTERS < 2)
             return stateErr("nothing to do");
 
-        g_pCompositor->setWindowFullscreenInternal(PWINDOW, FSMODE_NONE);
+        g_pCompositor->setWindowFullscreenInternal(PWINDOW, FSMODE_NONE, PWINDOW->m_fullscreen_LayoutHandled);
 
         if (!PNODE || !PNODE->isMaster) {
             // first non-master node
@@ -664,7 +666,7 @@ Config::ErrorResult CMasterAlgorithm::layoutMsg(const std::string_view& sv) {
         if (!PWINDOW)
             return noTarget("no window");
 
-        g_pCompositor->setWindowFullscreenInternal(PWINDOW, FSMODE_NONE);
+        g_pCompositor->setWindowFullscreenInternal(PWINDOW, FSMODE_NONE, PWINDOW->m_fullscreen_LayoutHandled);
 
         if (command == "orientationleft")
             m_workspaceData.explicitOrientation = ORIENTATION_LEFT;
@@ -886,7 +888,7 @@ void CMasterAlgorithm::runOrientationCycle(Hyprutils::String::CVarList2* vars, i
     if (!PWINDOW)
         return;
 
-    g_pCompositor->setWindowFullscreenInternal(PWINDOW, FSMODE_NONE);
+    g_pCompositor->setWindowFullscreenInternal(PWINDOW, FSMODE_NONE, PWINDOW->m_fullscreen_LayoutHandled);
 
     int nextOrPrev = 0;
     for (size_t i = 0; i < cycle.size(); ++i) {

--- a/src/layout/space/Space.cpp
+++ b/src/layout/space/Space.cpp
@@ -153,12 +153,11 @@ void CSpace::recalculate(eRecalculateReason reason) {
         m_algorithm->recalculate(reason);
 }
 
-eFullscreenRequestResult CSpace::setFullscreen(SP<ITarget> t, eFullscreenMode currentEffectiveMode, eFullscreenMode mode) {
+eFullscreenRequestResult CSpace::setFullscreen(SP<ITarget> t, eFullscreenMode currentEffectiveMode, eFullscreenMode mode, bool layoutAware) {
     if (!t)
         return FULLSCREEN_REQUEST_DEFAULT;
 
-    const auto REQUEST_RESULT = m_algorithm ? m_algorithm->requestFullscreen(t, currentEffectiveMode, mode) : FULLSCREEN_REQUEST_DEFAULT;
-
+    const auto REQUEST_RESULT = m_algorithm ? m_algorithm->requestFullscreen(t, currentEffectiveMode, mode, layoutAware) : FULLSCREEN_REQUEST_DEFAULT;
     t->setLayoutManagedFullscreen(REQUEST_RESULT == FULLSCREEN_REQUEST_HANDLED_BY_LAYOUT && mode == FSMODE_FULLSCREEN);
     if (REQUEST_RESULT != FULLSCREEN_REQUEST_HANDLED_BY_LAYOUT)
         t->setFullscreenMode(mode);

--- a/src/layout/space/Space.hpp
+++ b/src/layout/space/Space.hpp
@@ -42,7 +42,7 @@ namespace Layout {
 
         void                            setAlgorithmProvider(SP<CAlgorithm> algo);
         void                            recheckWorkArea();
-        eFullscreenRequestResult        setFullscreen(SP<ITarget> t, eFullscreenMode currentEffectiveMode, eFullscreenMode mode);
+        eFullscreenRequestResult        setFullscreen(SP<ITarget> t, eFullscreenMode currentEffectiveMode, eFullscreenMode mode, bool layoutAware);
 
         void                            moveTargetInDirection(SP<ITarget> t, Math::eDirection dir, bool silent);
 

--- a/src/layout/supplementary/DragController.cpp
+++ b/src/layout/supplementary/DragController.cpp
@@ -42,7 +42,8 @@ bool CDragStateController::updateDragWindow() {
     if (m_dragThresholdReached) {
         if (WAS_FULLSCREEN) {
             Log::logger->log(Log::DEBUG, "Dragging a fullscreen window");
-            g_pCompositor->setWindowFullscreenInternal(DRAGGINGTARGET->window(), FSMODE_NONE);
+            auto window = DRAGGINGTARGET->window();
+            g_pCompositor->setWindowFullscreenInternal(window, FSMODE_NONE, window->m_fullscreen_LayoutHandled);
         }
 
         const auto PWORKSPACE     = DRAGGINGTARGET->workspace();

--- a/src/managers/input/trackpad/gestures/FullscreenGesture.cpp
+++ b/src/managers/input/trackpad/gestures/FullscreenGesture.cpp
@@ -40,7 +40,7 @@ void CFullscreenTrackpadGesture::begin(const ITrackpadGesture::STrackpadGestureB
 
     m_originalMode = m_window->m_fullscreenState.internal;
 
-    g_pCompositor->setWindowFullscreenInternal(m_window.lock(), m_window->m_fullscreenState.internal == FSMODE_NONE ? fsModeForMode(m_mode) : FSMODE_NONE);
+    g_pCompositor->setWindowFullscreenInternal(m_window.lock(), m_window->m_fullscreenState.internal == FSMODE_NONE ? fsModeForMode(m_mode) : FSMODE_NONE, true);
 
     m_posTo  = m_window->m_realPosition->goal();
     m_sizeTo = m_window->m_realSize->goal();
@@ -78,7 +78,7 @@ void CFullscreenTrackpadGesture::end(const ITrackpadGesture::STrackpadGestureEnd
         // revert the animation
         g_pHyprRenderer->damageWindow(m_window.lock());
         g_pDesktopAnimationManager->overrideFullscreenFadeAmount(m_window->m_workspace, m_originalMode == FSMODE_NONE ? 1.F : 0.F, m_window.lock());
-        g_pCompositor->setWindowFullscreenInternal(m_window.lock(), m_window->m_fullscreenState.internal == FSMODE_NONE ? m_originalMode : FSMODE_NONE);
+        g_pCompositor->setWindowFullscreenInternal(m_window.lock(), m_window->m_fullscreenState.internal == FSMODE_NONE ? m_originalMode : FSMODE_NONE, true);
         return;
     }
 

--- a/src/managers/input/trackpad/gestures/FullscreenGesture.cpp
+++ b/src/managers/input/trackpad/gestures/FullscreenGesture.cpp
@@ -40,6 +40,7 @@ void CFullscreenTrackpadGesture::begin(const ITrackpadGesture::STrackpadGestureB
 
     m_originalMode = m_window->m_fullscreenState.internal;
 
+    // gesture fullscreen always uses layout specific fullscreen bahaviour if it exists
     g_pCompositor->setWindowFullscreenInternal(m_window.lock(), m_window->m_fullscreenState.internal == FSMODE_NONE ? fsModeForMode(m_mode) : FSMODE_NONE, true);
 
     m_posTo  = m_window->m_realPosition->goal();
@@ -78,6 +79,7 @@ void CFullscreenTrackpadGesture::end(const ITrackpadGesture::STrackpadGestureEnd
         // revert the animation
         g_pHyprRenderer->damageWindow(m_window.lock());
         g_pDesktopAnimationManager->overrideFullscreenFadeAmount(m_window->m_workspace, m_originalMode == FSMODE_NONE ? 1.F : 0.F, m_window.lock());
+        // gesture fullscreen always uses layout specific fullscreen bahaviour if it exists
         g_pCompositor->setWindowFullscreenInternal(m_window.lock(), m_window->m_fullscreenState.internal == FSMODE_NONE ? m_originalMode : FSMODE_NONE, true);
         return;
     }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Basically title. The new scroll fullscreen behaviour is unusable for me and I need the old FS behaviour back.

This is a toggle, so people can choose between: as/if new fullscreen behaviours are added to new/existing layouts, users can pick between "default" and layout-specific behaviours on a per-window basis.


---

Adds an attribute to all windows: "is the fullscreen handled by layout, or does it use default behaviour".

Adds an optional field to `.fullscreen({})` and `.fullscreen_state({})` dispatches, where the user can control which behaviour to use. Best of both worlds.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


WIP

#### Is it ready for merging, or does it need work?

- [ ] add test
- [ ] add wiki PR
- [ ] Ensure no test regression (if exists)

-> Can add a window rule for a certain window to always use either behaviour 

WIP
