### PR TITLE
config/monitor: invalidate wlr-output-management cache on user rule writes

### DIFF
--- a/src/config/shared/monitor/MonitorRuleManager.cpp
+++ b/src/config/shared/monitor/MonitorRuleManager.cpp
@@ -32,7 +32,14 @@ void CMonitorRuleManager::clear() {
 
 void CMonitorRuleManager::add(CMonitorRule&& x) {
     std::erase_if(m_rules, [&x](const auto& e) { return e.m_name == x.m_name; });
+    auto name = x.m_name;
     m_rules.emplace_back(std::move(x));
+
+    // A user-issued `monitor=` rule should take precedence over any state a
+    // wlr-output-management client (e.g. kanshi) cached for the same output.
+    // The cache repopulates the next time a wlr client commits, so this only
+    // resets the layered override; it doesn't break wlr-output-management.
+    PROTO::outputManagement->forgetMonitor(name);
 
     scheduleReload();
 }

--- a/src/protocols/OutputManagement.cpp
+++ b/src/protocols/OutputManagement.cpp
@@ -654,6 +654,15 @@ SP<SWlrManagerSavedOutputState> COutputManagementProtocol::getOutputStateFor(PHL
     return nullptr;
 }
 
+void COutputManagementProtocol::forgetMonitor(const std::string& name) {
+    if (name.empty())
+        return;
+
+    for (auto const& m : m_managers) {
+        m->m_monitorStates.erase(name);
+    }
+}
+
 void COutputManagementProtocol::sendPendingSuccessEvents() {
     if (m_pendingConfigurationSuccessEvents.empty())
         return;

--- a/src/protocols/OutputManagement.hpp
+++ b/src/protocols/OutputManagement.hpp
@@ -158,7 +158,12 @@ class COutputManagementProtocol : public IWaylandProtocol {
     // doesn't have to return one
     SP<SWlrManagerSavedOutputState> getOutputStateFor(PHLMONITOR pMonitor);
 
-    void                            sendPendingSuccessEvents();
+    // erase any cached wlr-output-management state for this output across all
+    // managers. used so that a freshly-written `monitor=` rule isn't shadowed
+    // by stale state from a wlr-output-management client (e.g. kanshi).
+    void forgetMonitor(const std::string& name);
+
+    void sendPendingSuccessEvents();
 
   private:
     void destroyResource(COutputManager* resource);


### PR DESCRIPTION
Addresses #14347 (the closed-issue equivalent was #14340).

## Background

`hyprctl keyword monitor "<name>, disable"` returns ok but the target
monitor stays enabled. Same result via `monitor=NAME, disable` in
`hyprland.conf` followed by `hyprctl reload`. Other monitor keyword
writes (scale, mode, position, transform, vrr) are similarly shadowed.

## Root cause

`CMonitorRuleManager::get` reads the user-declared rule, then
unconditionally overlays state from
`COutputManagementProtocol::getOutputStateFor` on top:

```cpp
rule.m_disabled = !CONFIG->enabled;
```

`COutputManagementProtocol::m_managers[*]->m_monitorStates` accumulates
state per wlr-output-management client and persists indefinitely. Once
kanshi (or any other wlr client) has prescribed state for an output,
subsequent `monitor=` directives never disable / re-mode / re-scale that
output: the user's write goes into `m_rules` correctly but is silently
shadowed on every read.

## Change

Add `forgetMonitor(name)` on `COutputManagementProtocol` that erases
entries across all manager caches for the given output. Call it from
`CMonitorRuleManager::add` whenever a rule lands. The next wlr-protocol
write repopulates the cache, so this only re-establishes precedence for
the user's most recent write; it doesn't break wlr-output-management's
ability to be the most recent writer.

## Scope

This is intentionally a tactical fix that restores the missing
precedence rule within the existing two-store design
(`m_monitorRules` for user directives, per-client `m_monitorStates`
for wlr-output-management state).

A more architectural alternative would collapse the two stores into
one, having `setDisableHead` / `applyTestConfiguration` flow through
`CMonitorRuleManager::add` with a merge step that preserves
wlr-output-management's partial-update semantics, plus add eviction
on wlr-client disconnect (the cache currently leaks indefinitely,
which is a separate latent bug). That's a 200-400 LOC refactor across
`OutputManagement.{cpp,hpp}` and `MonitorRuleManager.{cpp,hpp}` and
deserves its own design discussion.

Happy to take the refactor path if maintainers prefer that direction;
otherwise this PR is intentionally minimal and reversible, and the
unified-store work can land separately on top.

## Verification

Apple M1 Pro / Fedora Asahi 43 / locally patched aquamarine 0.11.0 (the
patch is unrelated to this code path; see hyprwm/aquamarine#291):

- Before: `hyprctl keyword monitor "eDP-1, disable"` returns ok,
  `disabled` stays `false`. Confirmed via runtime keyword and config +
  `hyprctl reload`.
- After: same command flips `disabled: true` and workspaces auto-migrate
  through the existing `onDisconnect` path.
- `hyprctl keyword monitor "eDP-1, preferred, auto, 1.5"` re-enables.

## Caveat / follow-up

On Asahi+aquamarine, the disable->enable round-trip via `hyprctl keyword`
exposes a separate downstream reliability issue: aquamarine's DRM atomic
commits intermittently fail with `ATOMIC_NONBLOCK PAGE_FLIP_EVENT busy`
during the modeset, occasionally leaving the panel stuck disabled or at
a wrong scale on re-enable. Tracked in #14348 (the closed-issue
equivalent was #14344); that's an aquamarine / atomic-commit issue
distinct from this precedence fix.