### PR TITLE
config: always call refresh after config reload

### DIFF
--- a/src/config/legacy/ConfigManager.cpp
+++ b/src/config/legacy/ConfigManager.cpp
@@ -1056,8 +1056,7 @@ void CConfigManager::postConfigReload(const Hyprlang::CParseResult& result) {
     // update plugins
     handlePluginLoads();
 
-    if (!m_isFirstLaunch)
-        Config::Supplementary::refresher()->scheduleRefresh(Supplementary::REFRESH_ALL);
+    Config::Supplementary::refresher()->scheduleRefresh(Supplementary::REFRESH_ALL);
 
     Event::bus()->m_events.config.reloaded.emit();
     if (g_pEventManager)

--- a/src/config/lua/ConfigManager.cpp
+++ b/src/config/lua/ConfigManager.cpp
@@ -562,8 +562,7 @@ void CConfigManager::postConfigReload() {
 
     handlePluginLoads();
 
-    if (!m_isFirstLaunch)
-        Config::Supplementary::refresher()->scheduleRefresh(Supplementary::REFRESH_ALL);
+    Config::Supplementary::refresher()->scheduleRefresh(Supplementary::REFRESH_ALL);
 
     Event::bus()->m_events.config.reloaded.emit();
     if (g_pEventManager)


### PR DESCRIPTION
Fixes the config not reloading properly