### PR TITLE
scrolling: use focus_edge_ms for focusing another window

### DIFF
--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -666,6 +666,7 @@ std::vector<SP<IValue>> Values::getConfigValues() {
         MS<Bool>("scrolling:follow_focus", "when a window is focused, should the layout move to bring it into view automatically", true),
         MS<Float>("scrolling:follow_min_visible", "when a window is focused, require that at least a given fraction of it is visible for focus to follow", 0.4,
                   {.min = 0.0, .max = 1.0}),
+        MS<Float>("scrolling:focus_edge_ms", "when a window is focused, require that at least a given amount of time of cursor hovering the edge", 250, {.min = 0, .max = 3000}),
         MS<String>("scrolling:explicit_column_widths", "A comma-separated list of preconfigured widths for colresize +conf/-conf", "0.333, 0.5, 0.667, 1.0"),
         MS<String>("scrolling:direction", "Direction in which new windows appear and the layout scrolls", "right", {.refresh = Supplementary::REFRESH_LAYOUTS}),
         MS<Bool>("scrolling:wrap_focus", "Determines if column focus wraps around", true),

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -613,13 +613,17 @@ CScrollingAlgorithm::~CScrollingAlgorithm() {
     m_configCallback.reset();
     m_focusCallback.reset();
 
-    if (m_hoverTimer)
+    if (m_hoverTimer) {
         m_hoverTimer->cancel();
+        if (g_pEventLoopManager)
+            g_pEventLoopManager->removeTimer(m_hoverTimer);
+        m_hoverTimer.reset();
+    }
 }
 
 void CScrollingAlgorithm::focusOnInput(SP<ITarget> target, eInputMode input) {
     static const auto PFOLLOW_FOCUS_MIN_PERC = CConfigValue<Config::FLOAT>("scrolling:follow_min_visible");
-    static const auto PHOVERDELAY            = CConfigValue<Config::FLOAT>("scrolling:focus_edge_ms");
+    static const auto PHOVERDELAY            = CConfigValue<Config::INTEGER>("scrolling:focus_edge_ms");
 
     if (!target || target->space() != m_parent->space())
         return;
@@ -642,15 +646,17 @@ void CScrollingAlgorithm::focusOnInput(SP<ITarget> target, eInputMode input) {
 
         // if the amount of visible X is below minimum, reject
         if (VISIBLE_LEN < (IS_HORIZ ? MON_BOX.w : MON_BOX.h) * std::clamp(*PFOLLOW_FOCUS_MIN_PERC, 0.F, 1.F)) {
-            if (*PHOVERDELAY > 0.F) {
+            if (*PHOVERDELAY > 0) {
                 if (m_hoveredTarget.lock() != target) {
                     m_hoveredTarget = target;
                     if (m_hoverTimer)
                         m_hoverTimer->cancel();
 
                     m_hoverTimer = makeShared<CEventLoopTimer>(
-                        std::chrono::milliseconds((int)*PHOVERDELAY),
-                        [this, target, input](SP<CEventLoopTimer> self, void* data) {
+                        std::chrono::milliseconds(*PHOVERDELAY),
+                        [this, weakTarget = WP<ITarget>(target), input](SP<CEventLoopTimer> self, void* data) {
+                            auto target = weakTarget.lock();
+                            if (!target) return;
                             if (m_hoveredTarget.lock() == target) {
                                 m_hoverTimer.reset();
                                 focusOnInput(target, input);
@@ -669,8 +675,11 @@ void CScrollingAlgorithm::focusOnInput(SP<ITarget> target, eInputMode input) {
     }
 
     m_hoveredTarget.reset();
-    if (m_hoverTimer)
+    if (m_hoverTimer) {
         m_hoverTimer->cancel();
+        g_pEventLoopManager->removeTimer(m_hoverTimer);
+        m_hoverTimer.reset();
+    }
 
     // if we moved via non-kb, and it's fully visible, ignore
     if (m_scrollingData->visible(TARGETDATA->column.lock(), true) && input != INPUT_MODE_KB)

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -614,6 +614,7 @@ CScrollingAlgorithm::~CScrollingAlgorithm() {
 
 void CScrollingAlgorithm::focusOnInput(SP<ITarget> target, eInputMode input) {
     static const auto PFOLLOW_FOCUS_MIN_PERC = CConfigValue<Config::FLOAT>("scrolling:follow_min_visible");
+    static const auto PHOVERDELAY            = CConfigValue<Config::FLOAT>("scrolling:focus_edge_ms");
 
     if (!target || target->space() != m_parent->space())
         return;
@@ -635,8 +636,19 @@ void CScrollingAlgorithm::focusOnInput(SP<ITarget> target, eInputMode input) {
             std::abs(std::min(MON_BOX.y + MON_BOX.h, TARGET_POS.y + TARGET_POS.h) - (std::max(MON_BOX.y, TARGET_POS.y)));
 
         // if the amount of visible X is below minimum, reject
-        if (VISIBLE_LEN < (IS_HORIZ ? MON_BOX.w : MON_BOX.h) * std::clamp(*PFOLLOW_FOCUS_MIN_PERC, 0.F, 1.F))
-            return;
+        if (VISIBLE_LEN < (IS_HORIZ ? MON_BOX.w : MON_BOX.h) * std::clamp(*PFOLLOW_FOCUS_MIN_PERC, 0.F, 1.F)) {
+            if (*PHOVERDELAY > 0.F) {
+                if (m_hoveredTarget.lock() != target) {
+                    m_hoveredTarget = target;
+                    m_hoverTimer.reset();
+                    return;
+                } else if (m_hoverTimer.getMillis() < *PHOVERDELAY) {
+                    return;
+                }
+            } else {
+                return;
+            }
+        }
     }
 
     // if we moved via non-kb, and it's fully visible, ignore

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -13,6 +13,8 @@
 #include "../../../../managers/input/InputManager.hpp"
 #include "../../../../managers/animation/DesktopAnimationManager.hpp"
 #include "../../../../event/EventBus.hpp"
+#include "../../../../managers/eventLoop/EventLoopTimer.hpp"
+#include "../../../../managers/eventLoop/EventLoopManager.hpp"
 
 #include <hyprutils/string/VarList2.hpp>
 #include <hyprutils/string/VarList.hpp>
@@ -610,6 +612,9 @@ CScrollingAlgorithm::~CScrollingAlgorithm() {
 
     m_configCallback.reset();
     m_focusCallback.reset();
+
+    if (m_hoverTimer)
+        m_hoverTimer->cancel();
 }
 
 void CScrollingAlgorithm::focusOnInput(SP<ITarget> target, eInputMode input) {
@@ -640,9 +645,21 @@ void CScrollingAlgorithm::focusOnInput(SP<ITarget> target, eInputMode input) {
             if (*PHOVERDELAY > 0.F) {
                 if (m_hoveredTarget.lock() != target) {
                     m_hoveredTarget = target;
-                    m_hoverTimer.reset();
+                    if (m_hoverTimer)
+                        m_hoverTimer->cancel();
+
+                    m_hoverTimer = makeShared<CEventLoopTimer>(
+                        std::chrono::milliseconds((int)*PHOVERDELAY),
+                        [this, target, input](SP<CEventLoopTimer> self, void* data) {
+                            if (m_hoveredTarget.lock() == target) {
+                                m_hoverTimer.reset();
+                                focusOnInput(target, input);
+                            }
+                        },
+                        nullptr);
+                    g_pEventLoopManager->addTimer(m_hoverTimer);
                     return;
-                } else if (m_hoverTimer.getMillis() < *PHOVERDELAY) {
+                } else if (m_hoverTimer && !m_hoverTimer->passed() && !m_hoverTimer->cancelled()) {
                     return;
                 }
             } else {
@@ -650,6 +667,10 @@ void CScrollingAlgorithm::focusOnInput(SP<ITarget> target, eInputMode input) {
             }
         }
     }
+
+    m_hoveredTarget.reset();
+    if (m_hoverTimer)
+        m_hoverTimer->cancel();
 
     // if we moved via non-kb, and it's fully visible, ignore
     if (m_scrollingData->visible(TARGETDATA->column.lock(), true) && input != INPUT_MODE_KB)

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.hpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.hpp
@@ -4,6 +4,7 @@
 #include "../../../../helpers/math/Direction.hpp"
 #include "ScrollTapeController.hpp"
 #include "../../../../helpers/signal/Signal.hpp"
+#include "../../../../helpers/time/Timer.hpp"
 
 #include <optional>
 #include <vector>
@@ -175,6 +176,9 @@ namespace Layout::Tiled {
 
         std::vector<SFullscreenScrollState> m_fullscreenTargets;
         bool                                m_lastFullscreenCover = false;
+
+        CTimer                              m_hoverTimer;
+        WP<ITarget>                         m_hoveredTarget;
 
         friend struct SScrollingData;
     };

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.hpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.hpp
@@ -4,7 +4,7 @@
 #include "../../../../helpers/math/Direction.hpp"
 #include "ScrollTapeController.hpp"
 #include "../../../../helpers/signal/Signal.hpp"
-#include "../../../../helpers/time/Timer.hpp"
+#include "../../../../managers/eventLoop/EventLoopTimer.hpp"
 
 #include <optional>
 #include <vector>
@@ -177,7 +177,7 @@ namespace Layout::Tiled {
         std::vector<SFullscreenScrollState> m_fullscreenTargets;
         bool                                m_lastFullscreenCover = false;
 
-        CTimer                              m_hoverTimer;
+        SP<CEventLoopTimer>                 m_hoverTimer;
         WP<ITarget>                         m_hoveredTarget;
 
         friend struct SScrollingData;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
right now you can only focus on another window via either clicking it or shrinking your view's window smaller so the window you're trying to focus is bigger then `follow_min_visible`
this adds a hover option which makes it focus after the set `scrolling:focus_edge_ms` duration


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
nope

#### Is it ready for merging, or does it need work?
ready
