### PR TITLE
Fix decoration colors with linear FP16

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -681,7 +681,7 @@ bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule, bool force)
 
     const bool sameTransform  = m_transform == RULE->m_transform;
     const bool sameColorProps = RULE->m_enable10bit == m_enabled10bit && RULE->m_cmType == m_cmType && RULE->m_sdrSaturation == m_sdrSaturation &&
-        RULE->m_sdrBrightness == m_sdrBrightness && RULE->m_sdrMinLuminance == m_minLuminance && RULE->m_sdrMaxLuminance == m_maxLuminance &&
+        RULE->m_sdrBrightness == m_sdrBrightness && RULE->m_sdrMinLuminance == m_sdrMinLuminance && RULE->m_sdrMaxLuminance == m_sdrMaxLuminance &&
         RULE->m_supportsWideColor == m_supportsWideColor && RULE->m_supportsHDR == m_supportsHDR && RULE->m_minLuminance == m_minLuminance &&
         RULE->m_maxLuminance == m_maxLuminance && RULE->m_maxAvgLuminance == m_maxAvgLuminance;
 

--- a/src/render/ElementRenderer.cpp
+++ b/src/render/ElementRenderer.cpp
@@ -2,6 +2,7 @@
 #include "Renderer.hpp"
 #include "../layout/LayoutManager.hpp"
 #include "../desktop/view/Window.hpp"
+#include "render/pass/ClearPassElement.hpp"
 #include <hyprutils/memory/SharedPtr.hpp>
 #include <hyprutils/memory/UniquePtr.hpp>
 #include <hyprutils/utils/ScopeGuard.hpp>
@@ -14,7 +15,7 @@ void IElementRenderer::drawElement(WP<IPassElement> element, const CRegion& dama
 
     switch (element->type()) {
         case EK_BORDER: draw(dynamicPointerCast<CBorderPassElement>(element), damage); break;
-        case EK_CLEAR: draw(dynamicPointerCast<CClearPassElement>(element), damage); break;
+        case EK_CLEAR: drawClear(dynamicPointerCast<CClearPassElement>(element), damage); break;
         case EK_FRAMEBUFFER: draw(dynamicPointerCast<CFramebufferElement>(element), damage); break;
         case EK_PRE_BLUR: drawPreBlur(dynamicPointerCast<CPreBlurElement>(element), damage); break;
         case EK_RECT: drawRect(dynamicPointerCast<CRectPassElement>(element), damage); break;
@@ -207,6 +208,11 @@ void IElementRenderer::drawPreBlur(WP<CPreBlurElement> element, const CRegion& d
     m_renderData.pMonitor->m_blurFBShouldRender = false;
 
     m_renderData.renderModif = SAVEDRENDERMODIF;
+}
+
+void IElementRenderer::drawClear(WP<CClearPassElement> element, const CRegion& damage) {
+    element->m_data.color = g_pHyprRenderer->getConvertedColor(element->m_data.color); // FIXME create element copy?
+    draw(element, damage);
 }
 
 void IElementRenderer::drawSurface(WP<CSurfacePassElement> element, const CRegion& damage) {

--- a/src/render/ElementRenderer.hpp
+++ b/src/render/ElementRenderer.hpp
@@ -39,6 +39,7 @@ namespace Render {
         void drawRect(WP<CRectPassElement> element, const CRegion& damage);
         void drawHints(WP<CRendererHintsPassElement> element, const CRegion& damage);
         void drawPreBlur(WP<CPreBlurElement> element, const CRegion& damage);
+        void drawClear(WP<CClearPassElement> element, const CRegion& damage);
         void drawSurface(WP<CSurfacePassElement> element, const CRegion& damage);
         void preDrawSurface(WP<CSurfacePassElement> element, const CRegion& damage);
         void drawTex(WP<CTexPassElement> element, const CRegion& damage);

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -2247,8 +2247,12 @@ void CHyprOpenGLImpl::renderRoundedShadow(const CBox& box, int round, float roun
 
     blend(true);
 
-    auto shader = useShader(getShaderVariant(SH_FRAG_SHADOW, globalFeatures()));
+    const auto TF      = m_renderData.currentFB->imageDescription()->value().transferFunction;
+    const bool needsCM = TF != CM_TRANSFER_FUNCTION_EXT_LINEAR;
+    auto       shader  = useShader(getShaderVariant(SH_FRAG_SHADOW, (needsCM ? SH_FEAT_CM : 0) | globalFeatures()));
 
+    if (needsCM)
+        shader->setUniformInt(SHADER_SOURCE_TF, TF);
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
     const auto converted = g_pHyprRenderer->getConvertedColor(col.stripA());
     shader->setUniformFloat4(SHADER_COLOR, converted.r, converted.g, converted.b, col.a * a);

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1064,20 +1064,6 @@ void CHyprOpenGLImpl::renderRectWithBlurInternal(const CBox& box, const CHyprCol
     renderRectWithDamageInternal(box, col, data);
 }
 
-using ColorConversionKey = std::tuple<float, float, float, float, uint64_t>;
-static std::map<ColorConversionKey, CHyprColor> colorConversionCache;
-
-//
-static CHyprColor getConvertedColor(const CHyprColor& color, PImageDescription imageDescription) {
-    const auto               targetId = imageDescription->id();
-    const ColorConversionKey key      = {color.r, color.g, color.b, color.a, targetId};
-    if (colorConversionCache.contains(key))
-        return colorConversionCache[key];
-    const auto converted      = convertColor(color, DEFAULT_SRGB_IMAGE_DESCRIPTION, g_pHyprRenderer->workBufferImageDescription());
-    colorConversionCache[key] = converted;
-    return converted;
-}
-
 void CHyprOpenGLImpl::renderRectWithDamageInternal(const CBox& box, const CHyprColor& col, const SRectRenderData& data) {
     auto& m_renderData = g_pHyprRenderer->m_renderData;
     RASSERT((box.width > 0 && box.height > 0), "Tried to render rect with width/height < 0!");
@@ -1095,7 +1081,7 @@ void CHyprOpenGLImpl::renderRectWithDamageInternal(const CBox& box, const CHyprC
 
     // premultiply the color as well as we don't work with straight alpha
     const auto premultiplied = CHyprColor(col.r * col.a, col.g * col.a, col.b * col.a, col.a);
-    const auto converted     = getConvertedColor(premultiplied, m_renderData.currentFB->imageDescription());
+    const auto converted     = g_pHyprRenderer->getConvertedColor(premultiplied);
     shader->setUniformFloat4(SHADER_COLOR, converted.r, converted.g, converted.b, converted.a);
     shader->setUniformFloat4(SHADER_COLOR_SRGB, premultiplied.r, premultiplied.g, premultiplied.b, premultiplied.a);
 
@@ -2264,7 +2250,7 @@ void CHyprOpenGLImpl::renderRoundedShadow(const CBox& box, int round, float roun
     auto shader = useShader(getShaderVariant(SH_FRAG_SHADOW, globalFeatures()));
 
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
-    const auto converted = getConvertedColor(col.stripA(), m_renderData.currentFB->imageDescription());
+    const auto converted = g_pHyprRenderer->getConvertedColor(col.stripA());
     shader->setUniformFloat4(SHADER_COLOR, converted.r, converted.g, converted.b, col.a * a);
     shader->setUniformFloat4(SHADER_COLOR_SRGB, col.r, col.g, col.b, col.a * a);
 
@@ -2356,7 +2342,7 @@ void CHyprOpenGLImpl::renderInnerGlow(const CBox& box, int round, float rounding
     auto shader = useShader(getShaderVariant(SH_FRAG_INNER_GLOW, globalFeatures()));
 
     shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
-    const auto converted = getConvertedColor(col.stripA(), m_renderData.currentFB->imageDescription());
+    const auto converted = g_pHyprRenderer->getConvertedColor(col.stripA());
     shader->setUniformFloat4(SHADER_COLOR, converted.r, converted.g, converted.b, col.a * a);
     shader->setUniformFloat4(SHADER_COLOR_SRGB, col.r, col.g, col.b, col.a * a);
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -3402,11 +3402,11 @@ using ColorConversionKey = std::tuple<float, float, float, float, uint64_t>;
 static std::map<ColorConversionKey, CHyprColor> colorConversionCache;
 
 CHyprColor                                      IHyprRenderer::getConvertedColor(const CHyprColor& color) {
-    const auto               targetId = m_renderData.currentFB->imageDescription();
-    const ColorConversionKey key      = {color.r, color.g, color.b, color.a, targetId};
+    const auto               DESCR = m_renderData.currentFB->imageDescription();
+    const ColorConversionKey key   = {color.r, color.g, color.b, color.a, DESCR->id()};
     if (colorConversionCache.contains(key))
         return colorConversionCache[key];
-    const auto converted      = convertColor(color, DEFAULT_SRGB_IMAGE_DESCRIPTION, workBufferImageDescription());
+    const auto converted      = convertColor(color, DEFAULT_SRGB_IMAGE_DESCRIPTION, DESCR);
     colorConversionCache[key] = converted;
     return converted;
 }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -3402,8 +3402,12 @@ using ColorConversionKey = std::tuple<float, float, float, float, uint64_t>;
 static std::map<ColorConversionKey, CHyprColor> colorConversionCache;
 
 CHyprColor                                      IHyprRenderer::getConvertedColor(const CHyprColor& color) {
-    const auto               DESCR = m_renderData.currentFB->imageDescription();
-    const ColorConversionKey key   = {color.r, color.g, color.b, color.a, DESCR->id()};
+    const auto DESCR = m_renderData.currentFB ? m_renderData.currentFB->imageDescription() : workBufferImageDescription();
+    if (!DESCR) {
+        Log::logger->log(Log::ERR, "getConvertedColor: failed to get image description");
+        return color;
+    }
+    const ColorConversionKey key = {color.r, color.g, color.b, color.a, DESCR->id()};
     if (colorConversionCache.contains(key))
         return colorConversionCache[key];
     const auto converted      = convertColor(color, DEFAULT_SRGB_IMAGE_DESCRIPTION, DESCR);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -3400,17 +3400,27 @@ SP<ITexture> IHyprRenderer::renderSplash(const std::function<SP<ITexture>(const 
 
 using ColorConversionKey = std::tuple<float, float, float, float, uint64_t>;
 static std::map<ColorConversionKey, CHyprColor> colorConversionCache;
+constexpr const size_t                          MAX_COLOR_CONVERSION_CACHE_SIZE = 4096;
 
-CHyprColor                                      IHyprRenderer::getConvertedColor(const CHyprColor& color) {
+//
+CHyprColor IHyprRenderer::getConvertedColor(const CHyprColor& color) {
     const auto DESCR = m_renderData.currentFB ? m_renderData.currentFB->imageDescription() : workBufferImageDescription();
+
     if (!DESCR) {
         Log::logger->log(Log::ERR, "getConvertedColor: failed to get image description");
         return color;
     }
+
+    if (colorConversionCache.size() >= MAX_COLOR_CONVERSION_CACHE_SIZE)
+        colorConversionCache.clear();
+
     const ColorConversionKey key = {color.r, color.g, color.b, color.a, DESCR->id()};
+
     if (colorConversionCache.contains(key))
         return colorConversionCache[key];
+
     const auto converted      = convertColor(color, DEFAULT_SRGB_IMAGE_DESCRIPTION, DESCR);
     colorConversionCache[key] = converted;
+
     return converted;
 }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -3397,3 +3397,16 @@ SP<ITexture> IHyprRenderer::renderSplash(const std::function<SP<ITexture>(const 
     cairo_destroy(CAIRO);
     return tex;
 }
+
+using ColorConversionKey = std::tuple<float, float, float, float, uint64_t>;
+static std::map<ColorConversionKey, CHyprColor> colorConversionCache;
+
+CHyprColor                                      IHyprRenderer::getConvertedColor(const CHyprColor& color) {
+    const auto               targetId = m_renderData.currentFB->imageDescription();
+    const ColorConversionKey key      = {color.r, color.g, color.b, color.a, targetId};
+    if (colorConversionCache.contains(key))
+        return colorConversionCache[key];
+    const auto converted      = convertColor(color, DEFAULT_SRGB_IMAGE_DESCRIPTION, workBufferImageDescription());
+    colorConversionCache[key] = converted;
+    return converted;
+}

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -133,13 +133,15 @@ namespace Render {
 
         SP<ITexture> renderSplash(const std::function<SP<ITexture>(const int, const int, unsigned char* const)>& handleData, const int fontSize, const int maxWidth = 1024,
                                   const int maxHeight = 1024);
+        CHyprColor   getConvertedColor(const CHyprColor& color);
 
-        virtual SP<IRenderbuffer>    getOrCreateRenderbuffer(SP<Aquamarine::IBuffer> buffer, uint32_t fmt); // TODO? move to protected and fix CPointerManager::renderHWCursorBuffer
-        bool                         commitPendingAndDoExplicitSync(PHLMONITOR pMonitor);                   // TODO? move to protected and fix CMonitorFrameScheduler::onPresented
-        SRenderData                  m_renderData;                                                          // TODO? move to protected and fix CRenderPass
-        SP<ITexture>                 m_screencopyDeniedTexture;                                             // TODO? make readonly
-        uint                         m_failedAssetsNo     = 0;                                              // TODO? make readonly
-        bool                         m_reloadScreenShader = true;                                           // at launch it can be set
+        virtual SP<IRenderbuffer>    getOrCreateRenderbuffer(SP<Aquamarine::IBuffer> buffer,
+                                                             uint32_t                fmt); // TODO? move to protected and fix CPointerManager::renderHWCursorBuffer
+        bool                         commitPendingAndDoExplicitSync(PHLMONITOR pMonitor);  // TODO? move to protected and fix CMonitorFrameScheduler::onPresented
+        SRenderData                  m_renderData;                                         // TODO? move to protected and fix CRenderPass
+        SP<ITexture>                 m_screencopyDeniedTexture;                            // TODO? make readonly
+        uint                         m_failedAssetsNo     = 0;                             // TODO? make readonly
+        bool                         m_reloadScreenShader = true;                          // at launch it can be set
         CTimer                       m_globalTimer;
 
         void                         draw(WP<IPassElement> element, const CRegion& damage = {});

--- a/src/render/decorations/CHyprDropShadowDecoration.cpp
+++ b/src/render/decorations/CHyprDropShadowDecoration.cpp
@@ -210,12 +210,14 @@ void CHyprDropShadowDecoration::drawShadowInternal(const CBox& box, int round, f
     color.a *= a;
 
     if (*PSHADOWSHARP)
-        g_pHyprRenderer->draw(CRectPassElement::SRectData{
-            .box           = box,
-            .color         = color,
-            .round         = round,
-            .roundingPower = roundingPower,
-        });
+        g_pHyprRenderer->draw(
+            CRectPassElement::SRectData{
+                .box           = box,
+                .color         = color,
+                .round         = round,
+                .roundingPower = roundingPower,
+            },
+            box);
     else
         g_pHyprRenderer->drawShadow(box, round, roundingPower, range, color, 1.F);
 }

--- a/src/render/shaders/glsl/blurFinish.glsl
+++ b/src/render/shaders/glsl/blurFinish.glsl
@@ -31,9 +31,9 @@ vec4 blurFinish(vec4 pixColor, vec2 v_texcoord, float noise, float brightness
 
 #if USE_CM
     if (targetTF == CM_TRANSFER_FUNCTION_EXT_LINEAR) {
-        pixColor = doColorManagement(pixColor, sourceTF, targetTF, convertMatrix, srcTFRange, vec2(0.0, 203.0)); // FIXME wtf
+        pixColor = doColorManagement(pixColor, 1.0, sourceTF, targetTF, convertMatrix, srcTFRange, vec2(0.0, 160.0)); // FIXME wtf
     } else {
-        pixColor = doColorManagement(pixColor, sourceTF, targetTF, convertMatrix, srcTFRange, dstTFRange);
+        pixColor = doColorManagement(pixColor, 1.0, sourceTF, targetTF, convertMatrix, srcTFRange, dstTFRange);
     }
 #endif
 

--- a/src/render/shaders/glsl/border.glsl
+++ b/src/render/shaders/glsl/border.glsl
@@ -181,30 +181,25 @@ vec4
     pixColor.rgb *= pixColor[3];
 
 #if USE_CM
-#if USE_MIRROR
-    vec4[2] pixColors =
-#else
-    pixColor =
-#endif
-        doColorManagement(pixColor, sourceTF, targetTF, convertMatrix, srcTFRange, dstTFRange
+    return doColorManagement(pixColor, alpha * additionalAlpha, sourceTF, targetTF, convertMatrix, srcTFRange, dstTFRange
 #if USE_ICC
-                          ,
-                          iccLut3D, iccLutSize
+                             ,
+                             iccLut3D, iccLutSize
 #else
 #if USE_TONEMAP || USE_SDR_MOD
-                          ,
-                          targetPrimariesXYZ
+                             ,
+                             targetPrimariesXYZ
 #endif
 #if USE_TONEMAP
-                          ,
-                          maxLuminance, dstMaxLuminance, dstRefLuminance, srcRefLuminance
+                             ,
+                             maxLuminance, dstMaxLuminance, dstRefLuminance, srcRefLuminance
 #endif
 #if USE_SDR_MOD
-                          ,
-                          sdrSaturation, sdrBrightnessMultiplier
+                             ,
+                             sdrSaturation, sdrBrightnessMultiplier
 #endif
 #endif
-        );
+    );
 #endif
 
 #if USE_MIRROR

--- a/src/render/shaders/glsl/cm_helpers.glsl
+++ b/src/render/shaders/glsl/cm_helpers.glsl
@@ -209,7 +209,7 @@ vec4[2]
 #else
 vec4
 #endif
-    doColorManagement(vec4 pixColor, int srcTF, int dstTF, mat3 convertMatrix, vec2 srcTFRange, vec2 dstTFRange
+    doColorManagement(vec4 pixColor, float additionalAlpha, int srcTF, int dstTF, mat3 convertMatrix, vec2 srcTFRange, vec2 dstTFRange
 #if USE_ICC
                       ,
                       highp sampler3D iccLut3D, float iccLutSize
@@ -232,12 +232,12 @@ vec4
     pixColor.rgb = toLinearRGB(pixColor.rgb, srcTF);
 #if USE_ICC
     pixColor.rgb = applyIcc3DLut(pixColor.rgb, iccLut3D, iccLutSize);
-    pixColor.rgb *= pixColor.a;
+    pixColor.rgb *= pixColor.a * additionalAlpha;
 #else
     pixColor.rgb = convertMatrix * pixColor.rgb;
     if (srcTF != CM_TRANSFER_FUNCTION_LINEAR)
         pixColor = toNit(pixColor, srcTFRange);
-    pixColor.rgb *= pixColor.a;
+    pixColor.rgb *= pixColor.a * additionalAlpha;
 #if USE_TONEMAP
     pixColor = tonemap(pixColor, dstxyz, maxLuminance, dstMaxLuminance, dstRefLuminance, srcRefLuminance);
 #endif
@@ -253,9 +253,12 @@ vec4
 #endif
 #endif
 
+    pixColor.a *= additionalAlpha;
+
 #if USE_MIRROR
     vec4[2] pixColors;
     pixColors[0] = pixColor;
+    mirrorColor.a *= additionalAlpha;
     pixColors[1] = mirrorColor;
     return pixColors;
 #else

--- a/src/render/shaders/glsl/shadow.frag
+++ b/src/render/shaders/glsl/shadow.frag
@@ -20,6 +20,10 @@ uniform float range;
 uniform float shadowPower;
 uniform float thick;
 
+#if USE_CM
+uniform int sourceTF; // eTransferFunction
+#endif
+
 #include "shadow.glsl"
 
 layout(location = 0) out vec4 fragColor;
@@ -33,7 +37,12 @@ void main() {
 #else
     fragColor =
 #endif
-    getShadow(pixColor, colorSRGB, v_texcoord, radius, roundingPower, topLeft, fullSize, range, shadowPower, bottomRight, windowTopLeft, windowBottomRight, thick);
+        getShadow(pixColor, colorSRGB, v_texcoord, radius, roundingPower, topLeft, fullSize, range, shadowPower, bottomRight, windowTopLeft, windowBottomRight, thick
+#if USE_CM
+                  ,
+                  sourceTF
+#endif
+        );
 #if USE_MIRROR
     fragColor   = pixColors[0];
     mirrorColor = pixColors[1];

--- a/src/render/shaders/glsl/shadow.glsl
+++ b/src/render/shaders/glsl/shadow.glsl
@@ -5,7 +5,11 @@
 #ifndef SHADOW_GLSL
 #define SHADOW_GLSL
 
+#include "defines.h"
 #include "rounding.glsl"
+#if USE_CM
+#include "cm_helpers.glsl"
+#endif
 
 float pixAlphaRoundedDistance(float distanceToCorner, float radius, float range, float shadowPower) {
     if (distanceToCorner > radius) {
@@ -53,8 +57,13 @@ vec4[2]
 #else
 vec4
 #endif
-    getShadow(vec4 pixColor, vec4 colorSRGB, vec2 v_texcoord, float borderRadius, float roundingPower, vec2 topLeft, vec2 fullSize, float range, float shadowPower, vec2 bottomRight,
-              vec2 windowTopLeft, vec2 windowBottomRight, float windowRadius) {
+    getShadow(vec4 pixColor, vec4 colorSRGB, vec2 v_texcoord, float borderRadius, float roundingPower, vec2 topLeft, vec2 fullSize, float range, float shadowPower,
+              vec2 bottomRight, vec2 windowTopLeft, vec2 windowBottomRight, float windowRadius
+#if USE_CM
+              ,
+              int srcTF
+#endif
+    ) {
     float radius        = range + borderRadius;
     float originalAlpha = pixColor[3];
 
@@ -68,21 +77,21 @@ vec4
         if (pixCoord[1] < topLeft[1]) {
             // top left
             pixColor[3] = pixColor[3] * pixAlphaRoundedDistance(modifiedLength(pixCoord - topLeft, roundingPower), radius, range, shadowPower);
-            done = true;
+            done        = true;
         } else if (pixCoord[1] > bottomRight[1]) {
             // bottom left
             pixColor[3] = pixColor[3] * pixAlphaRoundedDistance(modifiedLength(pixCoord - vec2(topLeft[0], bottomRight[1]), roundingPower), radius, range, shadowPower);
-            done = true;
+            done        = true;
         }
     } else if (pixCoord[0] > bottomRight[0]) {
         if (pixCoord[1] < topLeft[1]) {
             // top right
             pixColor[3] = pixColor[3] * pixAlphaRoundedDistance(modifiedLength(pixCoord - vec2(bottomRight[0], topLeft[1]), roundingPower), radius, range, shadowPower);
-            done = true;
+            done        = true;
         } else if (pixCoord[1] > bottomRight[1]) {
             // bottom right
             pixColor[3] = pixColor[3] * pixAlphaRoundedDistance(modifiedLength(pixCoord - bottomRight, roundingPower), radius, range, shadowPower);
-            done = true;
+            done        = true;
         }
     }
 
@@ -119,12 +128,18 @@ vec4
     }
 
     // premultiply
+#if USE_CM
+    pixColor.rgb = toLinearRGB(pixColor.rgb, srcTF);
     pixColor.rgb *= pixColor[3];
+    pixColor.rgb = fromLinearRGB(pixColor.rgb, srcTF);
+#else
+    pixColor.rgb *= pixColor[3];
+#endif
 
 #if USE_MIRROR
     vec4[2] pixColors;
-    pixColors[0] = pixColor;
-    pixColors[1] = colorSRGB;
+    pixColors[0]   = pixColor;
+    pixColors[1]   = colorSRGB;
     pixColors[1].a = pixColor.a;
     pixColors[1].rgb *= pixColors[1].a;
     return pixColors;

--- a/src/render/shaders/glsl/surface.frag
+++ b/src/render/shaders/glsl/surface.frag
@@ -71,7 +71,7 @@ void main() {
 #else
     pixColor =
 #endif
-        doColorManagement(pixColor, sourceTF, targetTF, convertMatrix, srcTFRange, dstTFRange
+        doColorManagement(pixColor, alpha, sourceTF, targetTF, convertMatrix, srcTFRange, dstTFRange
 #if USE_ICC
                           ,
                           iccLut3D, iccLutSize
@@ -103,7 +103,9 @@ void main() {
 #if USE_ROUNDING
     pixColor = rounding(pixColor, radius, roundingPower, topLeft, fullSize);
 #endif
+#if !USE_CM
     pixColor *= alpha;
+#endif
 #if USE_BLUR
 #if USE_DISCARD
     pixColor = mix(pixColor, vec4(mix(texture(blurredBG, v_texcoord * uvSize + uvOffset).rgb, pixColor.rgb, pixColor.a), 1.0),
@@ -122,7 +124,9 @@ void main() {
 #if USE_ROUNDING
     mirrorColor = rounding(mirrorColor, radius, roundingPower, topLeft, fullSize);
 #endif
-    mirrorColor = mirrorColor * alpha;
+#if !USE_CM
+    mirrorColor *= alpha;
+#endif
 #if USE_BLUR
 #if USE_DISCARD
     mirrorColor = mix(mirrorColor, vec4(mix(texture(blurredBG, v_texcoord * uvSize + uvOffset).rgb, mirrorColor.rgb, mirrorColor.a), 1.0),


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes some missing CM and incorrect values.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Makes most math to use linear. Not entirely correct and produces slight brightness differences but those are much smaller than before.
Might make sense to do the opposite and make some of linear math use non-linear space when the same happens with non-linear TFs. That will keep existing setups the same way it's on main but will require extra math.
The solution is a bit hacky and there might be a better way to apply additional alpha with premultiplied colors that will look the same with linear and non-linear TFs.

#### Is it ready for merging, or does it need work?
Ready

- [x] clear color
- [x] shadow
- [x] opacity