### PR TITLE
fix(windowrule): recheck eating the applied rule

### DIFF
--- a/hyprtester/src/tests/main/scroll.cpp
+++ b/hyprtester/src/tests/main/scroll.cpp
@@ -1,7 +1,6 @@
 #include "../shared.hpp"
 #include "../../shared.hpp"
 #include "../../hyprctlCompat.hpp"
-#include <thread>
 #include "tests.hpp"
 
 TEST_CASE(scrollFocusCycling) {
@@ -978,44 +977,4 @@ TEST_CASE(testScrollingViewBehaviourMoveFocusInGroupFollowFocusTrue) {
     else {
         NLog ::log("{}Passed: {}window of class 'a' has x coordinates >= 0 for its position: {}", Colors ::GREEN, Colors::RESET, currentWindowPosX);
     }
-}
-
-TEST_CASE(scrollHoverDelay) {
-    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling' } })"));
-    OK(getFromSocket("/eval hl.config({ scrolling = { focus_edge_ms = 250, follow_focus = true } })"));
-
-    for (auto const& win : {"a", "b", "c", "d"}) {
-        if (!Tests::spawnKitty(win)) {
-            FAIL_TEST("Could not spawn kitty with win class `{}`", win);
-        }
-    }
-
-    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:d' })"));
-
-    // We get the workspace data to check the scroll position, or just the window's position.
-    auto winA = getFromSocket("/clients");
-
-    // Send a mouse move to trigger focusOnInput with MOUSE instead of KB?
-    // How do we focus a window using the mouse in tests?
-    // Maybe dispatch focuswindow uses INPUT_MODE_KB? But the algorithm has:
-    // `if (m_scrollingData->visible(TARGETDATA->column.lock(), true) && input != INPUT_MODE_KB) return;`
-    // Wait, the patch actually does:
-    // `if (VISIBLE_LEN < MIN_LEN) { if (*PHOVERDELAY > 0) { ... timer ... focusOnInput(target, input); return; } }`
-    // It doesn't restrict to mouse only when checking PHOVERDELAY.
-
-    // Try dispatching focus directly
-    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:a' })"));
-
-    // wait a bit less than 250ms
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
-    // active window should be a, but it might not be scrolled yet.
-    auto str1 = getFromSocket("/activewindow");
-    ASSERT_CONTAINS(str1, "class: a");
-
-    // wait more to pass 250ms
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
-
-    auto str2 = getFromSocket("/activewindow");
-    ASSERT_CONTAINS(str2, "class: a");
 }

--- a/hyprtester/src/tests/main/scroll.cpp
+++ b/hyprtester/src/tests/main/scroll.cpp
@@ -1,6 +1,7 @@
 #include "../shared.hpp"
 #include "../../shared.hpp"
 #include "../../hyprctlCompat.hpp"
+#include <thread>
 #include "tests.hpp"
 
 TEST_CASE(scrollFocusCycling) {
@@ -977,4 +978,44 @@ TEST_CASE(testScrollingViewBehaviourMoveFocusInGroupFollowFocusTrue) {
     else {
         NLog ::log("{}Passed: {}window of class 'a' has x coordinates >= 0 for its position: {}", Colors ::GREEN, Colors::RESET, currentWindowPosX);
     }
+}
+
+TEST_CASE(scrollHoverDelay) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling' } })"));
+    OK(getFromSocket("/eval hl.config({ scrolling = { focus_edge_ms = 250, follow_focus = true } })"));
+
+    for (auto const& win : {"a", "b", "c", "d"}) {
+        if (!Tests::spawnKitty(win)) {
+            FAIL_TEST("Could not spawn kitty with win class `{}`", win);
+        }
+    }
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:d' })"));
+
+    // We get the workspace data to check the scroll position, or just the window's position.
+    auto winA = getFromSocket("/clients");
+
+    // Send a mouse move to trigger focusOnInput with MOUSE instead of KB?
+    // How do we focus a window using the mouse in tests?
+    // Maybe dispatch focuswindow uses INPUT_MODE_KB? But the algorithm has:
+    // `if (m_scrollingData->visible(TARGETDATA->column.lock(), true) && input != INPUT_MODE_KB) return;`
+    // Wait, the patch actually does:
+    // `if (VISIBLE_LEN < MIN_LEN) { if (*PHOVERDELAY > 0) { ... timer ... focusOnInput(target, input); return; } }`
+    // It doesn't restrict to mouse only when checking PHOVERDELAY.
+
+    // Try dispatching focus directly
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:a' })"));
+
+    // wait a bit less than 250ms
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    // active window should be a, but it might not be scrolled yet.
+    auto str1 = getFromSocket("/activewindow");
+    ASSERT_CONTAINS(str1, "class: a");
+
+    // wait more to pass 250ms
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    auto str2 = getFromSocket("/activewindow");
+    ASSERT_CONTAINS(str2, "class: a");
 }

--- a/hyprtester/src/tests/main/window.cpp
+++ b/hyprtester/src/tests/main/window.cpp
@@ -1206,3 +1206,32 @@ TEST_CASE(windowRuleExec) {
     std::filesystem::remove(tmpFilename);
     Tests::killAllWindows();
 }
+
+TEST_CASE(execRulesWorkspaceOverride) {
+    OK(getFromSocket("/eval hl.window_rule({ match = { class = 'kitty_exec_override' }, workspace = '2' })"));
+
+    OK(getFromSocket("/dispatch hl.dsp.exec_cmd('[workspace 3] kitty --class kitty_exec_override')"));
+
+    Tests::waitUntilWindowsN(1);
+
+    auto str = getFromSocket("/activewindow");
+    EXPECT_CONTAINS(str, "class: kitty_exec_override");
+    EXPECT_CONTAINS(str, "workspace: 3");
+
+    Tests::killAllWindows();
+}
+
+TEST_CASE(execRulesTagMutation) {
+    OK(getFromSocket("/eval hl.window_rule({ match = { class = 'kitty_tag_mutate' }, workspace = '2' })"));
+    OK(getFromSocket("/eval hl.window_rule({ match = { class = 'kitty_tag_mutate' }, tag = 'test_tag' })"));
+
+    OK(getFromSocket("/dispatch hl.dsp.exec_cmd('[workspace 3] kitty --class kitty_tag_mutate')"));
+
+    Tests::waitUntilWindowsN(1);
+
+    auto str = getFromSocket("/activewindow");
+    EXPECT_CONTAINS(str, "class: kitty_tag_mutate");
+    EXPECT_CONTAINS(str, "workspace: 3");
+
+    Tests::killAllWindows();
+}

--- a/hyprtester/src/tests/main/window.cpp
+++ b/hyprtester/src/tests/main/window.cpp
@@ -1174,39 +1174,6 @@ hl.window_rule({
     }
 }
 
-TEST_CASE(windowRuleExec) {
-    const std::string tmpFilename = (std::filesystem::temp_directory_path() / "hyprtester_exec_rule_test").string();
-    std::filesystem::remove(tmpFilename);
-
-    OK(getFromSocket(std::format("/eval hl.window_rule({{ match = {{ class = 'kitty_exec', fullscreen = true }}, exec = 'touch {}' }})", tmpFilename)));
-
-    if (!spawnKitty("kitty_exec")) {
-        FAIL_TEST("Could not spawn kitty");
-    }
-
-    // Window spawned but not fullscreen, rule shouldn't have matched yet
-    int cnt = 0;
-    while (!std::filesystem::exists(tmpFilename) && cnt < 10) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        cnt++;
-    }
-    EXPECT(std::filesystem::exists(tmpFilename), false);
-
-    // Make it fullscreen
-    OK(getFromSocket("/dispatch hl.dsp.window.fullscreen()"));
-
-    // Now it should trigger
-    cnt = 0;
-    while (!std::filesystem::exists(tmpFilename) && cnt < 50) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        cnt++;
-    }
-    EXPECT(std::filesystem::exists(tmpFilename), true);
-
-    std::filesystem::remove(tmpFilename);
-    Tests::killAllWindows();
-}
-
 TEST_CASE(execRulesWorkspaceOverride) {
     OK(getFromSocket("/eval hl.window_rule({ match = { class = 'kitty_exec_override' }, workspace = '2' })"));
 

--- a/hyprtester/src/tests/main/window.cpp
+++ b/hyprtester/src/tests/main/window.cpp
@@ -1173,3 +1173,36 @@ hl.window_rule({
         ASSERT_CONTAINS(str, "at: 967,22");
     }
 }
+
+TEST_CASE(windowRuleExec) {
+    const std::string tmpFilename = (std::filesystem::temp_directory_path() / "hyprtester_exec_rule_test").string();
+    std::filesystem::remove(tmpFilename);
+
+    OK(getFromSocket(std::format("/eval hl.window_rule({{ match = {{ class = 'kitty_exec', fullscreen = true }}, exec = 'touch {}' }})", tmpFilename)));
+
+    if (!spawnKitty("kitty_exec")) {
+        FAIL_TEST("Could not spawn kitty");
+    }
+
+    // Window spawned but not fullscreen, rule shouldn't have matched yet
+    int cnt = 0;
+    while (!std::filesystem::exists(tmpFilename) && cnt < 10) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        cnt++;
+    }
+    EXPECT(std::filesystem::exists(tmpFilename), false);
+
+    // Make it fullscreen
+    OK(getFromSocket("/dispatch hl.dsp.window.fullscreen()"));
+
+    // Now it should trigger
+    cnt = 0;
+    while (!std::filesystem::exists(tmpFilename) && cnt < 50) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        cnt++;
+    }
+    EXPECT(std::filesystem::exists(tmpFilename), true);
+
+    std::filesystem::remove(tmpFilename);
+    Tests::killAllWindows();
+}

--- a/src/desktop/rule/windowRule/WindowRuleApplicator.cpp
+++ b/src/desktop/rule/windowRule/WindowRuleApplicator.cpp
@@ -473,8 +473,8 @@ bool CWindowRuleApplicator::readStaticRules(bool preRead) {
 
     static_ = {};
 
-    std::vector<SP<CWindowRule>> execRules;
-    bool                         tagsWereChanged = false;
+    m_execRules.clear();
+    bool tagsWereChanged = false;
 
     for (const auto& r : ruleEngine()->rules()) {
         if (r->type() != RULE_TYPE_WINDOW)
@@ -486,7 +486,7 @@ bool CWindowRuleApplicator::readStaticRules(bool preRead) {
             continue;
 
         if (wr->isExecRule()) {
-            execRules.emplace_back(wr);
+            m_execRules.emplace_back(wr);
             continue;
         }
 
@@ -501,7 +501,7 @@ bool CWindowRuleApplicator::readStaticRules(bool preRead) {
     if (static_.content != NContentType::CONTENT_TYPE_NONE)
         propsToRecheck |= RULE_PROP_CONTENT;
 
-    for (const auto& wr : execRules) {
+    for (const auto& wr : m_execRules) {
         applyStaticRule(wr);
         applyDynamicRule(wr);
         if (!preRead)
@@ -523,6 +523,10 @@ void CWindowRuleApplicator::recheckStaticRules() {
         if (!wr->matches(m_window.lock(), true))
             continue;
 
+        applyStaticRule(wr);
+    }
+
+    for (const auto& wr : m_execRules) {
         applyStaticRule(wr);
     }
 }
@@ -547,6 +551,14 @@ void CWindowRuleApplicator::propertiesChanged(std::underlying_type_t<eRuleProper
             continue;
 
         const auto RES = applyDynamicRule(WR);
+        needsRelayout  = needsRelayout || RES.needsRelayout;
+    }
+
+    for (const auto& wr : m_execRules) {
+        if (!(wr->getPropertiesMask() & props) && !setsIntersect(wr->effectsSet(), effectsNeedingRecheck))
+            continue;
+
+        const auto RES = applyDynamicRule(wr);
         needsRelayout  = needsRelayout || RES.needsRelayout;
     }
 

--- a/src/desktop/rule/windowRule/WindowRuleApplicator.hpp
+++ b/src/desktop/rule/windowRule/WindowRuleApplicator.hpp
@@ -143,6 +143,7 @@ namespace Desktop::Rule {
 
       private:
         PHLWINDOWREF                          m_window;
+        std::vector<SP<CWindowRule>>          m_execRules;
         std::underlying_type_t<eRuleProperty> propsToRecheck = RULE_PROP_NONE;
 
         struct SRuleResult {


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
tag mutates it, causing a recheck, with the applied rule is gone as it
is unregistered after first applying
fixes https://github.com/hyprwm/Hyprland/discussions/13814


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
introduces some overhead as it introduces a new temp vec, open to suggestions to a better way of doing it


#### Is it ready for merging, or does it need work?
ready
