### PR TITLE
scrolling: Fix scrolling fullscreen focus behaviour

### DIFF
--- a/hyprtester/src/tests/main/scroll.cpp
+++ b/hyprtester/src/tests/main/scroll.cpp
@@ -217,22 +217,22 @@ TEST_CASE(scrollFullscreen) {
         ASSERT_CONTAINS(str, "class: kitty_scroll_B");
     }
 
-    OK(getFromSocket("/dispatch hl.dsp.focus({ direction = \"left\" })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('focus left')"));
 
     {
         auto str = getFromSocket("/activewindow");
         ASSERT_CONTAINS(str, "class: kitty_scroll_A");
     }
 
-    OK(getFromSocket("/dispatch hl.dsp.focus({ direction = \"right\" })"));
-    OK(getFromSocket("/dispatch hl.dsp.focus({ direction = \"right\" })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('focus right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('focus right')"));
 
     {
         auto str = getFromSocket("/activewindow");
         ASSERT_CONTAINS(str, "class: kitty_scroll_C");
     }
 
-    OK(getFromSocket("/dispatch hl.dsp.focus({ direction = \"left\" })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('focus left')"));
 
     {
         auto str = getFromSocket("/activewindow");

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1546,7 +1546,7 @@ PHLWINDOW CCompositor::getWindowInDirection(const CBox& box, PHLWORKSPACE pWorks
                             intersectLength = std::max(0.0, std::min(POSA.y + SIZEA.y, POSB.y + SIZEB.y) - std::max(POSA.y, POSB.y));
                         break;
                     case Math::DIRECTION_RIGHT:
-                        if (isAdjacent(POSB.x, POSB.x + SIZEB.x, POSA.x, POSA.x + SIZEA.x))
+                        if (isAdjacent(POSB.x, POSB.x + SIZEB.x, POSA.x, POSA.x + SIZEA.x)) // ERSTARR -> bug here. logic flawed
                             intersectLength = std::max(0.0, std::min(POSA.y + SIZEA.y, POSB.y + SIZEB.y) - std::max(POSA.y, POSB.y));
                         break;
                     case Math::DIRECTION_UP:


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

when focused on a fullscreen window when not fully viewing it, focus(direction = "left/right") can't move the focus

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

WIP

#### Is it ready for merging, or does it need work?


- [ ] switching focus to another tiling window if a fullscreened is currently focus with window with focus({direction}) doesn't work: can't find the window in that direction

WIP
