### PR TITLE
config: fix plugin variables with dashes

### DIFF
--- a/src/config/lua/ConfigManager.cpp
+++ b/src/config/lua/ConfigManager.cpp
@@ -726,23 +726,7 @@ SConfigOptionReply CConfigManager::getConfigValue(const std::string& s) {
         return SConfigOptionReply{.dataptr = cc<void* const*>(&m_configPtrMap.at(s)), .type = cv->underlying(), .setByUser = cv->setByUser()};
     }
 
-    // try replacing all . with : unless col.
-    std::string s2 = s;
-
-    for (size_t i = 0; i < s2.length(); ++i) {
-        if (s2[i] != ':')
-            continue;
-
-        if (i <= 3) {
-            s2[i] = '.';
-            continue;
-        }
-
-        if (s2[i - 1] == 'l' && s2[i - 2] == 'o' && s2[i - 3] == 'c')
-            continue;
-
-        s2[i] = '.';
-    }
+    std::string s2 = luaConfigValueName(s);
 
     if (!m_configValues.contains(s2))
         return SConfigOptionReply{.dataptr = nullptr};


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
Currently when trying to add a config variable containing a dash (e.g. `plugin:dynamic-cursors:enabled`) the compositor aborts with the following [here](https://github.com/hyprwm/Hyprland/blob/ce699f5284b944b585a9445f017a0b7d6bd55846/src/config/ConfigValue.cpp#L4-L16)
```
Something went really fucking wrong with config values
```

This is because during config value creation, the value is added with the dashes replaced by `_`, but then when reading the config variable, that replacement is not done. See the diff I guess.

The issue also is that I can't just add the config variables with `_` instead, because I would like for the legacy config to remain the same (and there my values contain `-`).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Honestly, I don't fucking know what was the thought (if any) behind that original piece of code. The comment is wrong, as it replaces `:` with `.` and not the other way round, and in this case `col.` doesn't matter anyways? If you remember what the intent here was, I would love to know.

Anyways, I have opted for `luaConfigValueName(s)` as that is used everywhere else, and also takes care of dashes. I can also change it to replace the dashes manually if that `col` thing is truly needed.

#### Is it ready for merging, or does it need work?
Yes, also would be great to have this in `0.55.1` cause it blocks my plugin.

