### PR TITLE
pointer: fix cursor bounds not updating on monitor layout changes

### DIFF
--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -43,6 +43,8 @@ CPointerManager::CPointerManager() {
         });
     });
 
+    m_hooks.monitorLayoutChanged = Event::bus()->m_events.monitor.layoutChanged.listen([this] { onMonitorLayoutChange(); });
+
     m_hooks.monitorPreRender = Event::bus()->m_events.monitor.preCommit.listen([this](PHLMONITOR monitor) {
         auto state = stateFor(monitor);
         if (!state)

--- a/src/managers/PointerManager.hpp
+++ b/src/managers/PointerManager.hpp
@@ -188,6 +188,7 @@ class CPointerManager {
 
     struct {
         CHyprSignalListener monitorAdded;
+        CHyprSignalListener monitorLayoutChanged;
         CHyprSignalListener monitorPreRender;
     } m_hooks;
 };


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

Fixes cursor hitting an invisible wall on monitors in multi-monitor setups, only being usable on a fraction of the screen. PointerManager built cursor boundary boxes when `monitor.added` fired, but `arrangeMonitors()` set the real positions afterward. PointerManager wasnt listening for `monitor.layoutChanged`, so the layout was never updated.

- https://github.com/hyprwm/Hyprland/discussions/14382

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
nope

#### Is it ready for merging, or does it need work?
ready
