### PR TITLE
lua: change permissions stubs ("allow" -> "mode")

### DIFF
--- a/meta/generateLuaStubs.py
+++ b/meta/generateLuaStubs.py
@@ -651,7 +651,7 @@ def generate_stub(root: Path) -> str:
             [
                 ("binary", "string", False),
                 ("type", "string", False),
-                ("allow", "string", False),
+                ("mode", "string", False),
             ],
         )
     )


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
It fixes the lua lsp suggesting stuff like `hl.permission({binary = "a", type = "b", allow = "c"})` instead of `hl.permission({binary = "a", type = "b", mode = "c"})`

#### Is it ready for merging, or does it need work?
should be good, unless this needs to be changed somewhere else? wiki is fine

furthermore, `hl.monitor` seems to expect `scale` as a string according to the lsp (unrelated to this mr), but I haven't found where that is coming from
