### PR TITLE
Fix/stale keyboard enter

### DIFF
--- a/hyprtester/CMakeLists.txt
+++ b/hyprtester/CMakeLists.txt
@@ -101,4 +101,5 @@ protocolnew("unstable/keyboard-shortcuts-inhibit" "keyboard-shortcuts-inhibit-un
 clientNew("pointer-warp" PROTOS "pointer-warp-v1" "xdg-shell")
 clientNew("pointer-scroll" PROTOS "xdg-shell")
 clientNew("child-window" PROTOS "xdg-shell")
+clientNew("keyboard-enter" PROTOS "xdg-shell")
 clientNew("shortcut-inhibitor" PROTOS "xdg-shell" "keyboard-shortcuts-inhibit-unstable-v1")

--- a/hyprtester/clients/keyboard-enter.cpp
+++ b/hyprtester/clients/keyboard-enter.cpp
@@ -1,0 +1,287 @@
+#include <cstring>
+#include <sys/poll.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <print>
+#include <format>
+#include <string>
+#include <vector>
+
+#include <wayland-client.h>
+#include <wayland.hpp>
+#include <xdg-shell.hpp>
+
+#include <hyprutils/memory/SharedPtr.hpp>
+#include <hyprutils/math/Vector2D.hpp>
+
+using Hyprutils::Math::Vector2D;
+using namespace Hyprutils::Memory;
+
+struct SWlState {
+    wl_display*                    display;
+    CSharedPointer<CCWlRegistry>   registry;
+
+    CSharedPointer<CCWlCompositor> wlCompositor;
+    CSharedPointer<CCWlSeat>       wlSeat;
+    CSharedPointer<CCWlShm>        wlShm;
+    CSharedPointer<CCXdgWmBase>    xdgShell;
+
+    CSharedPointer<CCWlShmPool>    shmPool;
+    CSharedPointer<CCWlBuffer>     shmBuf;
+    int                            shmFd           = -1;
+    size_t                         shmBufSize      = 0;
+    bool                           xrgb8888Support = false;
+
+    CSharedPointer<CCWlSurface>    surf;
+    CSharedPointer<CCXdgSurface>   xdgSurf;
+    CSharedPointer<CCXdgToplevel>  xdgToplevel;
+    Vector2D                       geom;
+
+    CSharedPointer<CCWlKeyboard>   keyboard;
+};
+
+static bool debug, started, shouldExit;
+
+template <typename... Args>
+static void clientLog(std::format_string<Args...> fmt, Args&&... args) {
+    std::println("{}", std::vformat(fmt.get(), std::make_format_args(args...)));
+    std::fflush(stdout);
+}
+
+template <typename... Args>
+static void debugLog(std::format_string<Args...> fmt, Args&&... args) {
+    if (!debug)
+        return;
+
+    std::println("{}", std::vformat(fmt.get(), std::make_format_args(args...)));
+    std::fflush(stdout);
+}
+
+static bool bindRegistry(SWlState& state) {
+    state.registry = makeShared<CCWlRegistry>((wl_proxy*)wl_display_get_registry(state.display));
+
+    state.registry->setGlobal([&](CCWlRegistry* r, uint32_t id, const char* name, uint32_t version) {
+        const std::string NAME = name;
+        if (NAME == "wl_compositor") {
+            debugLog("  > binding to global: {} (version {}) with id {}", name, version, id);
+            state.wlCompositor = makeShared<CCWlCompositor>((wl_proxy*)wl_registry_bind((wl_registry*)state.registry->resource(), id, &wl_compositor_interface, 6));
+        } else if (NAME == "wl_shm") {
+            debugLog("  > binding to global: {} (version {}) with id {}", name, version, id);
+            state.wlShm = makeShared<CCWlShm>((wl_proxy*)wl_registry_bind((wl_registry*)state.registry->resource(), id, &wl_shm_interface, 1));
+        } else if (NAME == "wl_seat") {
+            debugLog("  > binding to global: {} (version {}) with id {}", name, version, id);
+            state.wlSeat = makeShared<CCWlSeat>((wl_proxy*)wl_registry_bind((wl_registry*)state.registry->resource(), id, &wl_seat_interface, 9));
+        } else if (NAME == "xdg_wm_base") {
+            debugLog("  > binding to global: {} (version {}) with id {}", name, version, id);
+            state.xdgShell = makeShared<CCXdgWmBase>((wl_proxy*)wl_registry_bind((wl_registry*)state.registry->resource(), id, &xdg_wm_base_interface, 1));
+        }
+    });
+    state.registry->setGlobalRemove([](CCWlRegistry* r, uint32_t id) { debugLog("Global {} removed", id); });
+
+    wl_display_roundtrip(state.display);
+
+    if (!state.wlCompositor || !state.wlShm || !state.wlSeat || !state.xdgShell) {
+        clientLog("Failed to get protocols from Hyprland");
+        return false;
+    }
+
+    return true;
+}
+
+static bool createShm(SWlState& state, Vector2D geom) {
+    if (!state.xrgb8888Support)
+        return false;
+
+    const size_t stride = geom.x * 4;
+    const size_t size   = geom.y * stride;
+
+    if (!state.shmPool) {
+        const char* name = "/wl-shm-keyboard-enter";
+        state.shmFd      = shm_open(name, O_RDWR | O_CREAT | O_EXCL, 0600);
+        if (state.shmFd < 0)
+            return false;
+
+        if (shm_unlink(name) < 0 || ftruncate(state.shmFd, size) < 0) {
+            close(state.shmFd);
+            return false;
+        }
+
+        state.shmPool = makeShared<CCWlShmPool>(state.wlShm->sendCreatePool(state.shmFd, size));
+        if (!state.shmPool->resource()) {
+            close(state.shmFd);
+            state.shmFd = -1;
+            state.shmPool.reset();
+            return false;
+        }
+
+        state.shmBufSize = size;
+    } else if (size > state.shmBufSize) {
+        if (ftruncate(state.shmFd, size) < 0) {
+            close(state.shmFd);
+            state.shmFd = -1;
+            state.shmPool.reset();
+            return false;
+        }
+
+        state.shmPool->sendResize(size);
+        state.shmBufSize = size;
+    }
+
+    auto buf = makeShared<CCWlBuffer>(state.shmPool->sendCreateBuffer(0, geom.x, geom.y, stride, WL_SHM_FORMAT_XRGB8888));
+    if (!buf->resource())
+        return false;
+
+    if (state.shmBuf) {
+        state.shmBuf->sendDestroy();
+        state.shmBuf.reset();
+    }
+
+    state.shmBuf = buf;
+    return true;
+}
+
+static bool setupToplevel(SWlState& state, const std::string& appId) {
+    state.wlShm->setFormat([&](CCWlShm* p, uint32_t format) {
+        if (format == WL_SHM_FORMAT_XRGB8888)
+            state.xrgb8888Support = true;
+    });
+
+    state.xdgShell->setPing([&](CCXdgWmBase* p, uint32_t serial) { state.xdgShell->sendPong(serial); });
+
+    state.surf = makeShared<CCWlSurface>(state.wlCompositor->sendCreateSurface());
+    if (!state.surf->resource())
+        return false;
+
+    state.xdgSurf = makeShared<CCXdgSurface>(state.xdgShell->sendGetXdgSurface(state.surf->resource()));
+    if (!state.xdgSurf->resource())
+        return false;
+
+    state.xdgToplevel = makeShared<CCXdgToplevel>(state.xdgSurf->sendGetToplevel());
+    if (!state.xdgToplevel->resource())
+        return false;
+
+    state.xdgToplevel->setClose([&](CCXdgToplevel* p) { std::exit(0); });
+    state.xdgToplevel->setConfigure([&](CCXdgToplevel* p, int32_t w, int32_t h, wl_array* arr) {
+        state.geom = {640, 360};
+
+        if (!createShm(state, state.geom))
+            std::exit(-1);
+    });
+
+    state.xdgSurf->setConfigure([&](CCXdgSurface* p, uint32_t serial) {
+        state.xdgSurf->sendSetWindowGeometry(0, 0, state.geom.x, state.geom.y);
+        state.surf->sendAttach(state.shmBuf.get(), 0, 0);
+        state.surf->sendCommit();
+        state.xdgSurf->sendAckConfigure(serial);
+
+        if (!started) {
+            started = true;
+            clientLog("started");
+        }
+    });
+
+    state.xdgToplevel->sendSetTitle((appId + " test client").c_str());
+    state.xdgToplevel->sendSetAppId(appId.c_str());
+    state.surf->sendAttach(nullptr, 0, 0);
+    state.surf->sendCommit();
+
+    return true;
+}
+
+static std::string formatEnterKeys(wl_array* keys) {
+    std::vector<uint32_t> pressed;
+    pressed.reserve(keys ? keys->size / sizeof(uint32_t) : 0);
+
+    if (keys && keys->data) {
+        const auto* begin = static_cast<const uint32_t*>(keys->data);
+        const auto  count = keys->size / sizeof(uint32_t);
+        pressed.assign(begin, begin + count);
+    }
+
+    std::string out = std::format("enter {}", pressed.size());
+    for (const auto key : pressed) {
+        out += std::format(" {}", key);
+    }
+
+    return out;
+}
+
+static bool setupSeat(SWlState& state) {
+    state.keyboard = makeShared<CCWlKeyboard>(state.wlSeat->sendGetKeyboard());
+    if (!state.keyboard->resource())
+        return false;
+
+    state.keyboard->setKeymap([](CCWlKeyboard* p, enum wl_keyboard_keymap_format format, int32_t fd, uint32_t size) {
+        if (fd >= 0)
+            close(fd);
+    });
+    state.keyboard->setEnter([](CCWlKeyboard* p, uint32_t serial, wl_proxy* surf, wl_array* keys) { clientLog("{}", formatEnterKeys(keys)); });
+    state.keyboard->setLeave([](CCWlKeyboard* p, uint32_t serial, wl_proxy* surf) { debugLog("leave {}", serial); });
+    state.keyboard->setKey(
+        [](CCWlKeyboard* p, uint32_t serial, uint32_t time, uint32_t key, enum wl_keyboard_key_state state) { debugLog("key {} {}", key, static_cast<uint32_t>(state)); });
+    state.keyboard->setModifiers([](CCWlKeyboard* p, uint32_t serial, uint32_t depressed, uint32_t latched, uint32_t locked, uint32_t group) {
+        debugLog("mods dep={} lat={} lock={} grp={}", depressed, latched, locked, group);
+    });
+    state.keyboard->setRepeatInfo([](CCWlKeyboard* p, int32_t rate, int32_t delay) { debugLog("repeat rate={} delay={}", rate, delay); });
+
+    return true;
+}
+
+static void parseRequest(std::string req) {
+    if (req.contains("exit"))
+        shouldExit = true;
+}
+
+int main(int argc, char** argv) {
+    std::string appId = "keyboard-enter";
+    for (int i = 1; i < argc; ++i) {
+        if (std::string{argv[i]} == "--debug")
+            debug = true;
+        else
+            appId = argv[i];
+    }
+
+    SWlState state = {
+        .display = wl_display_connect(nullptr),
+    };
+
+    if (!state.display) {
+        clientLog("Wayland connection failed");
+        return 1;
+    }
+
+    if (!bindRegistry(state))
+        return 1;
+
+    if (!setupToplevel(state, appId))
+        return 1;
+
+    if (!setupSeat(state))
+        return 1;
+
+    while (!shouldExit) {
+        wl_display_dispatch_pending(state.display);
+        wl_display_flush(state.display);
+
+        struct pollfd fds[2] = {
+            {.fd = wl_display_get_fd(state.display), .events = POLLIN},
+            {.fd = STDIN_FILENO, .events = POLLIN},
+        };
+
+        if (poll(fds, 2, -1) < 0)
+            return 1;
+
+        if (fds[0].revents & POLLIN)
+            wl_display_dispatch(state.display);
+
+        if (fds[1].revents & POLLIN) {
+            std::array<char, 256> buf       = {};
+            const auto            bytesRead = read(STDIN_FILENO, buf.data(), buf.size() - 1);
+            if (bytesRead > 0)
+                parseRequest(std::string{buf.data(), static_cast<size_t>(bytesRead)});
+        }
+    }
+
+    return 0;
+}

--- a/hyprtester/plugin/src/main.cpp
+++ b/hyprtester/plugin/src/main.cpp
@@ -22,6 +22,7 @@
 #include <hyprutils/utils/ScopeGuard.hpp>
 #include <hyprutils/string/Numeric.hpp>
 #include <hyprutils/string/VarList.hpp>
+#include <array>
 using namespace Hyprutils::Utils;
 using namespace Hyprutils::String;
 
@@ -122,8 +123,19 @@ class CTestMouse : public IPointer {
     bool m_isVirtual = false;
 };
 
-SP<CTestMouse>         g_mouse;
-SP<CTestKeyboard>      g_keyboard;
+SP<CTestMouse>                   g_mouse;
+SP<CTestKeyboard>                g_keyboard;
+std::array<SP<CTestKeyboard>, 2> g_staleEnterKeyboards;
+
+static void cleanupStaleEnterKeyboards() {
+    for (auto& keyboard : g_staleEnterKeyboards) {
+        if (!keyboard)
+            continue;
+
+        keyboard->destroy();
+        keyboard.reset();
+    }
+}
 
 static SDispatchResult pressAlt(std::string in) {
     g_pInputManager->m_lastMods = in == "1" ? HL_MODIFIER_ALT : 0;
@@ -360,6 +372,64 @@ static SDispatchResult keybind(std::string in) {
     return {};
 }
 
+static SDispatchResult staleEnterSetup(std::string in) {
+    cleanupStaleEnterKeyboards();
+
+    for (size_t i = 0; i < g_staleEnterKeyboards.size(); ++i) {
+        auto keyboard          = CTestKeyboard::create(false);
+        keyboard->m_hlName     = std::format("test-stale-keyboard-{}", i);
+        keyboard->m_deviceName = keyboard->m_hlName;
+        g_pInputManager->newKeyboard(keyboard);
+        g_staleEnterKeyboards[i] = std::move(keyboard);
+    }
+
+    return {};
+}
+
+static SDispatchResult staleEnterKey(std::string in) {
+    CVarList2 data(std::move(in));
+
+    size_t    idx;
+    uint32_t  key;
+    bool      pressed;
+    try {
+        idx     = std::stoul(std::string{data[0]});
+        key     = std::stoul(std::string{data[1]});
+        pressed = std::stoul(std::string{data[2]}) == 1;
+    } catch (...) { return {.success = false, .error = "invalid input"}; }
+
+    if (idx >= g_staleEnterKeyboards.size())
+        return {.success = false, .error = "keyboard index out of range"};
+
+    if (!g_staleEnterKeyboards[idx])
+        return {.success = false, .error = "keyboard not initialized"};
+
+    g_staleEnterKeyboards[idx]->sendKey(key, pressed);
+    return {};
+}
+
+static SDispatchResult staleEnterDestroy(std::string in) {
+    size_t idx;
+    try {
+        idx = std::stoul(in);
+    } catch (...) { return {.success = false, .error = "invalid input"}; }
+
+    if (idx >= g_staleEnterKeyboards.size())
+        return {.success = false, .error = "keyboard index out of range"};
+
+    if (!g_staleEnterKeyboards[idx])
+        return {.success = false, .error = "keyboard not initialized"};
+
+    g_staleEnterKeyboards[idx]->destroy();
+    g_staleEnterKeyboards[idx].reset();
+    return {};
+}
+
+static SDispatchResult staleEnterCleanup(std::string in) {
+    cleanupStaleEnterKeyboards();
+    return {};
+}
+
 static Desktop::Rule::CWindowRuleEffectContainer::storageType windowRuleIDX = 0;
 
 //
@@ -583,6 +653,25 @@ static int luaFloatingFocusOnFullscreen(lua_State* L) {
     return luaResult(L, ::floatingFocusOnFullscreen(""));
 }
 
+static int luaStaleEnterSetup(lua_State* L) {
+    return luaResult(L, ::staleEnterSetup(""));
+}
+
+static int luaStaleEnterKey(lua_State* L) {
+    const auto idx     = (int)luaL_checkinteger(L, 1);
+    const auto key     = (int)luaL_checkinteger(L, 2);
+    const auto pressed = (int)luaL_checkinteger(L, 3);
+    return luaResult(L, ::staleEnterKey(std::format("{},{},{}", idx, key, pressed)));
+}
+
+static int luaStaleEnterDestroy(lua_State* L) {
+    return luaResult(L, ::staleEnterDestroy(std::to_string((int)luaL_checkinteger(L, 1))));
+}
+
+static int luaStaleEnterCleanup(lua_State* L) {
+    return luaResult(L, ::staleEnterCleanup(""));
+}
+
 APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     PHANDLE = handle;
 
@@ -609,6 +698,10 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     addLuaFn("check_pointer_focus_layer", ::luaCheckPointerFocusLayer);
     addLuaFn("set_pointer_focus_layer", ::luaSetPointerFocusLayer);
     addLuaFn("floating_focus_on_fullscreen", ::luaFloatingFocusOnFullscreen);
+    addLuaFn("stale_enter_setup", ::luaStaleEnterSetup);
+    addLuaFn("stale_enter_key", ::luaStaleEnterKey);
+    addLuaFn("stale_enter_destroy", ::luaStaleEnterDestroy);
+    addLuaFn("stale_enter_cleanup", ::luaStaleEnterCleanup);
 
     // init mouse
     g_mouse = CTestMouse::create(false);
@@ -622,6 +715,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 }
 
 APICALL EXPORT void PLUGIN_EXIT() {
+    cleanupStaleEnterKeyboards();
     g_mouse->destroy();
     g_mouse.reset();
     g_keyboard->destroy();

--- a/hyprtester/src/tests/clients/keyboard-enter.cpp
+++ b/hyprtester/src/tests/clients/keyboard-enter.cpp
@@ -1,0 +1,192 @@
+#include "../../hyprctlCompat.hpp"
+#include "../shared.hpp"
+#include "tests.hpp"
+#include "build.hpp"
+
+#include <hyprutils/os/FileDescriptor.hpp>
+#include <hyprutils/os/Process.hpp>
+
+#include <array>
+#include <optional>
+#include <sys/poll.h>
+#include <unistd.h>
+#include <csignal>
+#include <thread>
+#include <vector>
+#include <sstream>
+
+using namespace Hyprutils::OS;
+using namespace Hyprutils::Memory;
+
+#define SP CSharedPointer
+
+namespace {
+    class CKeyboardEnterClient {
+        SP<CProcess>               proc;
+        CFileDescriptor            readFd, writeFd;
+        struct pollfd              fd;
+        std::string                pending;
+
+        std::optional<std::string> readLine(int timeoutMs);
+
+      public:
+        explicit CKeyboardEnterClient(const std::string& appId);
+        ~CKeyboardEnterClient();
+
+        bool                            focus() const;
+        void                            drain();
+        std::optional<std::vector<int>> waitForEnter(int timeoutMs);
+    };
+}
+
+std::optional<std::string> CKeyboardEnterClient::readLine(int timeoutMs) {
+    const auto hasBufferedLine = [&]() { return pending.find('\n') != std::string::npos; };
+
+    while (!hasBufferedLine()) {
+        fd.revents = 0;
+        if (poll(&fd, 1, timeoutMs) != 1 || !(fd.revents & POLLIN))
+            return std::nullopt;
+
+        std::array<char, 512> buf       = {};
+        const auto            bytesRead = read(readFd.get(), buf.data(), buf.size() - 1);
+        if (bytesRead <= 0)
+            return std::nullopt;
+
+        pending.append(buf.data(), static_cast<size_t>(bytesRead));
+    }
+
+    const auto newlinePos = pending.find('\n');
+    auto       line       = pending.substr(0, newlinePos);
+    pending.erase(0, newlinePos + 1);
+    return line;
+}
+
+CKeyboardEnterClient::CKeyboardEnterClient(const std::string& appId) {
+    proc = makeShared<CProcess>(binaryDir + "/keyboard-enter", std::vector<std::string>{appId});
+    proc->addEnv("WAYLAND_DISPLAY", WLDISPLAY);
+
+    int stdoutPipe[2], stdinPipe[2];
+    if (pipe(stdoutPipe) != 0 || pipe(stdinPipe) != 0)
+        throw std::exception();
+
+    readFd  = CFileDescriptor(stdoutPipe[0]);
+    writeFd = CFileDescriptor(stdinPipe[1]);
+    proc->setStdoutFD(stdoutPipe[1]);
+    proc->setStdinFD(stdinPipe[0]);
+
+    const auto countBefore = Tests::windowCount();
+    proc->runAsync();
+
+    close(stdoutPipe[1]);
+    close(stdinPipe[0]);
+
+    fd = {.fd = readFd.get(), .events = POLLIN};
+
+    const auto startedLine = readLine(1500);
+    if (!startedLine || *startedLine != "started")
+        throw std::exception();
+
+    int counter = 0;
+    while (Tests::processAlive(proc->pid()) && Tests::windowCount() == countBefore) {
+        counter++;
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+        if (counter > 100)
+            throw std::exception();
+    }
+
+    if (getFromSocket(std::format("/dispatch hl.dsp.window.set_prop({{ window = 'pid:{}', prop = 'no_anim', value = '1' }})", proc->pid())) != "ok")
+        throw std::exception();
+}
+
+CKeyboardEnterClient::~CKeyboardEnterClient() {
+    if (writeFd.isValid()) {
+        const std::string cmd = "exit\n";
+        (void)write(writeFd.get(), cmd.c_str(), cmd.length());
+    }
+
+    if (proc) {
+        kill(proc->pid(), SIGKILL);
+        proc.reset();
+    }
+}
+
+bool CKeyboardEnterClient::focus() const {
+    return getFromSocket(std::format("/dispatch hl.dsp.focus({{ window = 'pid:{}' }})", proc->pid())) == "ok";
+}
+
+void CKeyboardEnterClient::drain() {
+    while (true) {
+        fd.revents = 0;
+        if (poll(&fd, 1, 20) != 1 || !(fd.revents & POLLIN))
+            return;
+
+        if (!readLine(20).has_value())
+            return;
+    }
+}
+
+std::optional<std::vector<int>> CKeyboardEnterClient::waitForEnter(int timeoutMs) {
+    const auto line = readLine(timeoutMs);
+    if (!line || !line->starts_with("enter "))
+        return std::nullopt;
+
+    std::stringstream ss(line->substr(6));
+    size_t            count = 0;
+    ss >> count;
+
+    std::vector<int> keys;
+    keys.reserve(count);
+
+    int key = 0;
+    while (ss >> key)
+        keys.emplace_back(key);
+
+    if (keys.size() != count)
+        return std::nullopt;
+
+    return keys;
+}
+
+TEST_CASE(keyboardEnterPressedKeysAfterDeviceDestroy) {
+    std::optional<CKeyboardEnterClient> clientA;
+    std::optional<CKeyboardEnterClient> clientB;
+
+    try {
+        clientA.emplace("keyboard-enter-a");
+        clientB.emplace("keyboard-enter-b");
+    } catch (...) { FAIL_TEST("Couldn't start keyboard-enter clients"); }
+
+    clientA->drain();
+    clientB->drain();
+
+    OK(getFromSocket("/eval hl.plugin.test.stale_enter_setup()"));
+
+    if (!clientA->focus())
+        FAIL_TEST("Couldn't focus client A");
+    const auto initialEnter = clientA->waitForEnter(1500);
+    if (!initialEnter.has_value())
+        FAIL_TEST("Client A didn't receive initial keyboard enter");
+    ASSERT(initialEnter->empty(), true);
+
+    OK(getFromSocket("/eval hl.plugin.test.stale_enter_key(0, 1, 1)"));
+
+    if (!clientB->focus())
+        FAIL_TEST("Couldn't focus client B");
+    const auto staleEnter = clientB->waitForEnter(1500);
+    if (!staleEnter.has_value())
+        FAIL_TEST("Client B didn't receive keyboard enter while key was pressed");
+    ASSERT(staleEnter->size(), 1);
+    ASSERT((*staleEnter)[0], 1);
+
+    OK(getFromSocket("/eval hl.plugin.test.stale_enter_destroy(0)"));
+
+    if (!clientA->focus())
+        FAIL_TEST("Couldn't refocus client A");
+    const auto cleanedEnter = clientA->waitForEnter(1500);
+    if (!cleanedEnter.has_value())
+        FAIL_TEST("Client A didn't receive keyboard enter after keyboard destroy");
+    ASSERT(cleanedEnter->empty(), true);
+
+    OK(getFromSocket("/eval hl.plugin.test.stale_enter_cleanup()"));
+}

--- a/src/devices/IKeyboard.cpp
+++ b/src/devices/IKeyboard.cpp
@@ -447,7 +447,11 @@ bool IKeyboard::getPressed(uint32_t key) {
     return std::ranges::contains(m_pressed, key);
 }
 
-bool IKeyboard::shareStates() {
+const std::vector<uint32_t>& IKeyboard::getPressedKeys() const {
+    return m_pressed;
+}
+
+bool IKeyboard::shareStates() const {
     return m_shareStates;
 }
 

--- a/src/devices/IKeyboard.hpp
+++ b/src/devices/IKeyboard.hpp
@@ -78,7 +78,8 @@ class IKeyboard : public IHID {
     void                              updateXkbStateWithKey(uint32_t xkbKey, bool pressed);
     void                              updateKeymapFD();
     bool                              getPressed(uint32_t key);
-    bool                              shareStates();
+    const std::vector<uint32_t>&      getPressedKeys() const;
+    bool                              shareStates() const;
     void                              setShareStatesAuto(bool shareStates);
 
     bool                              m_active     = false;

--- a/src/helpers/PressedKeyCache.cpp
+++ b/src/helpers/PressedKeyCache.cpp
@@ -1,0 +1,40 @@
+#include "PressedKeyCache.hpp"
+
+#include <algorithm>
+#include <ranges>
+
+namespace NInputUtils {
+    bool isKeyboardEligibleForPressedKeyCache(const IKeyboard& keyboard) {
+        return keyboard.m_enabled && keyboard.m_allowed && keyboard.shareStates();
+    }
+
+    std::vector<uint32_t> collectUniquePressedKeys(const std::vector<std::vector<uint32_t>>& pressedKeySets) {
+        std::vector<uint32_t> rebuiltPressedKeys;
+
+        for (const auto& pressedKeys : pressedKeySets) {
+            for (const auto& key : pressedKeys) {
+                if (!std::ranges::contains(rebuiltPressedKeys, key))
+                    rebuiltPressedKeys.emplace_back(key);
+            }
+        }
+
+        return rebuiltPressedKeys;
+    }
+
+    std::vector<uint32_t> collectPressedKeysFromKeyboards(const std::vector<SP<IKeyboard>>& keyboards) {
+        std::vector<std::vector<uint32_t>> pressedKeySets;
+        pressedKeySets.reserve(keyboards.size());
+
+        for (const auto& kb : keyboards) {
+            if (!kb)
+                continue;
+
+            if (!isKeyboardEligibleForPressedKeyCache(*kb))
+                continue;
+
+            pressedKeySets.emplace_back(kb->getPressedKeys());
+        }
+
+        return collectUniquePressedKeys(pressedKeySets);
+    }
+}

--- a/src/helpers/PressedKeyCache.hpp
+++ b/src/helpers/PressedKeyCache.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "../devices/IKeyboard.hpp"
+
+#include <vector>
+
+namespace NInputUtils {
+    bool                  isKeyboardEligibleForPressedKeyCache(const IKeyboard& keyboard);
+    std::vector<uint32_t> collectUniquePressedKeys(const std::vector<std::vector<uint32_t>>& pressedKeySets);
+    std::vector<uint32_t> collectPressedKeysFromKeyboards(const std::vector<SP<IKeyboard>>& keyboards);
+}

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -48,6 +48,7 @@
 
 #include "trackpad/TrackpadGestures.hpp"
 #include "../cursor/CursorShapeOverrideController.hpp"
+#include "../../helpers/PressedKeyCache.hpp"
 
 #include <aquamarine/input/Input.hpp>
 #include <hyprutils/string/VarList.hpp>
@@ -1472,10 +1473,31 @@ static void removeFromHIDs(WP<IHID> hid) {
     g_pInputManager->updateCapabilities();
 }
 
+void CInputManager::rebuildSeatPressedCacheFromKeyboards() {
+    std::vector<SP<IKeyboard>> eligibleKeyboards;
+    eligibleKeyboards.reserve(m_keyboards.size());
+
+    for (const auto& kb : m_keyboards) {
+        if (!kb)
+            continue;
+
+        if (!NInputUtils::isKeyboardEligibleForPressedKeyCache(*kb))
+            continue;
+
+        if (kb->isVirtual() && shouldIgnoreVirtualKeyboard(kb))
+            continue;
+
+        eligibleKeyboards.emplace_back(kb);
+    }
+
+    m_pressed = NInputUtils::collectPressedKeysFromKeyboards(eligibleKeyboards);
+}
+
 void CInputManager::destroyKeyboard(SP<IKeyboard> pKeyboard) {
     Log::logger->log(Log::DEBUG, "Keyboard at {:x} removed", rc<uintptr_t>(pKeyboard.get()));
 
     std::erase_if(m_keyboards, [pKeyboard](const auto& other) { return other == pKeyboard; });
+    rebuildSeatPressedCacheFromKeyboards();
 
     if (!m_keyboards.empty()) {
         bool found = false;

--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -298,6 +298,7 @@ class CInputManager {
 
     bool                  shareKeyFromAllKBs(uint32_t key, bool pressed);
     uint32_t              shareModsFromAllKBs(uint32_t depressed);
+    void                  rebuildSeatPressedCacheFromKeyboards();
     std::vector<uint32_t> m_pressed;
     uint32_t              m_lastMods = 0;
 

--- a/tests/helpers/PressedKeyCache.cpp
+++ b/tests/helpers/PressedKeyCache.cpp
@@ -1,0 +1,122 @@
+#include <helpers/PressedKeyCache.hpp>
+
+#include <gtest/gtest.h>
+
+using namespace NInputUtils;
+
+namespace {
+    class CFakeKeyboard final : public IKeyboard {
+      public:
+        explicit CFakeKeyboard(bool isVirtual = false) : m_isVirtual(isVirtual) {}
+
+        bool isVirtual() override {
+            return m_isVirtual;
+        }
+
+        SP<Aquamarine::IKeyboard> aq() override {
+            return nullptr;
+        }
+
+        void press(uint32_t key) {
+            updatePressed(key, true);
+        }
+
+        void setShareStates(bool share) {
+            m_shareStatesAuto = false;
+            m_shareStates     = share;
+        }
+
+        void setEnabled(bool enabled) {
+            m_enabled = enabled;
+        }
+
+        void setAllowed(bool allowed) {
+            m_allowed = allowed;
+        }
+
+      private:
+        bool m_isVirtual = false;
+    };
+} // namespace
+
+TEST(Helpers, deduplicatesAcrossKeySets) {
+    const auto rebuiltPressedKeys = collectUniquePressedKeys({
+        {164, 36},
+        {36, 50},
+    });
+
+    ASSERT_EQ(rebuiltPressedKeys.size(), 3U);
+    EXPECT_EQ(rebuiltPressedKeys[0], 164U);
+    EXPECT_EQ(rebuiltPressedKeys[1], 36U);
+    EXPECT_EQ(rebuiltPressedKeys[2], 50U);
+}
+
+TEST(Helpers, skipsEmptyKeySets) {
+    const auto rebuiltPressedKeys = collectUniquePressedKeys({
+        {},
+        {164},
+    });
+
+    ASSERT_EQ(rebuiltPressedKeys.size(), 1U);
+    EXPECT_EQ(rebuiltPressedKeys[0], 164U);
+}
+
+TEST(Helpers, returnsEmptyForEmptyInput) {
+    const auto rebuiltPressedKeys = collectUniquePressedKeys({});
+
+    EXPECT_TRUE(rebuiltPressedKeys.empty());
+}
+
+TEST(Helpers, preservesFirstSeenOrder) {
+    const auto rebuiltPressedKeys = collectUniquePressedKeys({
+        {50, 36},
+        {164, 36, 24},
+    });
+
+    ASSERT_EQ(rebuiltPressedKeys.size(), 4U);
+    EXPECT_EQ(rebuiltPressedKeys[0], 50U);
+    EXPECT_EQ(rebuiltPressedKeys[1], 36U);
+    EXPECT_EQ(rebuiltPressedKeys[2], 164U);
+    EXPECT_EQ(rebuiltPressedKeys[3], 24U);
+}
+
+TEST(Helpers, onlyCollectsEligibleKeyboards) {
+    auto active = makeShared<CFakeKeyboard>();
+    active->press(164);
+    active->press(36);
+
+    auto disabled = makeShared<CFakeKeyboard>();
+    disabled->press(50);
+    disabled->setEnabled(false);
+
+    auto disallowed = makeShared<CFakeKeyboard>();
+    disallowed->press(24);
+    disallowed->setAllowed(false);
+
+    auto sharedOff = makeShared<CFakeKeyboard>();
+    sharedOff->press(57);
+    sharedOff->setShareStates(false);
+
+    const auto rebuiltPressedKeys = collectPressedKeysFromKeyboards({active, disabled, disallowed, sharedOff});
+
+    ASSERT_EQ(rebuiltPressedKeys.size(), 2U);
+    EXPECT_EQ(rebuiltPressedKeys[0], 164U);
+    EXPECT_EQ(rebuiltPressedKeys[1], 36U);
+}
+
+TEST(Helpers, keyboardEligibilityMatchesSeatCacheRules) {
+    auto keyboard = makeShared<CFakeKeyboard>();
+
+    EXPECT_TRUE(isKeyboardEligibleForPressedKeyCache(*keyboard));
+
+    keyboard->setEnabled(false);
+    EXPECT_FALSE(isKeyboardEligibleForPressedKeyCache(*keyboard));
+
+    keyboard->setEnabled(true);
+    keyboard->setAllowed(false);
+    EXPECT_FALSE(isKeyboardEligibleForPressedKeyCache(*keyboard));
+
+    keyboard->setAllowed(true);
+    keyboard->setShareStates(false);
+    EXPECT_FALSE(isKeyboardEligibleForPressedKeyCache(*keyboard));
+}


### PR DESCRIPTION
### Describe your PR, what does it fix/add?



#### -bug
After  keyboard destroyed   seat 's pressedkey cache isn't rebuilt.



#### -The-fix
Rebuild the cache in the function : src/managers/input/InputManager.cpp > void CInputManager::destroyKeyboard



#### -what'files I added
1.The Helper: PressKeyCache and its test (accord with the "## Submitting new tests : must be gtest")

<details>
<summary>More notes</summary>

  (   For the helper tests we wrote, I can only find in "tests/config/lua/LuaConfigUtils.cpp" a case where file-inline fake objects are used to test methods.)
     While writing, there are things I need to pay attention to: for example, in tests, the "<gtest/gtest.h>" TEST method, I have these doubts:


   1. What does each parameter mean? Why does the first parameter not follow other tests and be written as helpers,
      but after compilation the tests can still pass? And it should be noted that the name does not need to add the corresponding test file name, just write its purpose.
      (sorry to say one more word here  that this is my first time to use gtest that I write down some of what I learn from this pr)
      
   2. And, this is my first time designing a function test: I need to think according to each function's features about what TESTs can be designed to verify it.

</details>

2.The hyprtester  :  hyprtester client + plugin + focus flow

<details>
<summary>More notes : (sorry for I write to many)</summary>

   About hyprtester/, I had never contacted this kind of technology before that can insert tests inside the process.

   So, when I added "rebuildSeatPressedCacheFromKeyboards" in "InputManager.cpp" for fixing the bug,
   I did not think of how to verify whether the seat level pressed-key cache is correctly rebuilt after the lifecycle change of "keyboard-like devices".

   After deeply analyzing the architecture and understanding how Hyprland "produces test scenarios in-process",
   I understood that this special hyprtest directory is used to test injecting into the real process.

   After analysis, I learned that "hyprtester/src/tests/clients/" is used to design for the client under "hyprtester/clients":
   
   1. how to start it
   2. how to communicate with it
   3. how to read its output
   4. how to turn output into assertions

   So, I was able to design hyprtester/clients/keyboard-enter.cpp:

   1 . when to start the client
   2 . when to call the plugin injection entry
   3 . when to switch focus
   4 . when to send key
   5 . when to destroy keyboard
   6 . when to read result
   7 . how to assert at the end
   
   Later I rethought that this is a bug triggered by me in emacs,and after multiple window focus it would all have such a problem :
   for example, my CX31988+97220 suddenly disconnected, then came back, after Hyprland received this matter of "m_events.destroy"
   the internal state was not cleaned up : like "XF86AudioPlay".
   (While in emacs ,it immediately reflect when I insert "Alt,ctrl,super.." :  s-<XF86AudioPlay> is undefine)
   
   So here it is necessary to design two surfaces / clients to switch back and forth, so as to stably trigger enter and observe the difference
   (for example, whether stale key exists / is cleared)
   So, when designing this "CKeyboardEnterClient" class, it is different from the output protocol designed by other clients in the same directory

   Then, first, I need to think about how to input the key, and can know that it is necessary to use plgin to simulate a tool for testing scenarios inside the compositor process

So need to design  
1. stale_enter_setup
    - create two test keyboards
2. stale_enter_key
    - send key to the specified keyboard
3. stale_enter_destroy
    - destroy the specified keyboard
4. stale_enter_cleanup
    - clean up residual state

( and then the bug can be tested from whether after destroy keyboard the seat pressed-key cache should be rebuilt )

 So, such a situation can be designed in the test  

   1. first register two clients as A and B respectively, and call plugin to create two keyboards
   2. then, by focusing to A (through the designed Client code, it can be ensured that it will output enter 0, ensuring that there are no residual keys in the initial state)
   3. press a key by using the 0th keyboard to set a seat shared-state key, then focus to B, ensuring that B can get this shared key
   4. when focusing B, destroy the 0th keyboard, then focus to A again  
      (it can be known that if the seat cache is not rebuilt, then the system will still incorrectly think that: key 1 is still in the pressed set, so when A receives enter again, it may still be: enter 1 1, and after verification, the code before the fix indeed has this situation)
      (so, after fixing it, when focusing to A again, it will trigger wl_keyboard.enter in the client,
       that is  the clientlog  when  there is no key)  
      (some design considerations on the client design side: because when a client is created, from example  by observing "/src/desktop/view/Window.cpp:2175", after a new window is mapped Hyprland will automatically give focus to it, causing enter to be triggered)
      (so it is necessary to design drain() and focus() well in "hyprtester/src/tests/clients/keyboard-enter.cpp")

</details>



### Is there anything you want to mention? 


emmm, I'm not sure it's fine design

1.The function "hyprtester/plugin/src/main.cpp > staleEnterSetup" :
     -I created using "g_staleEnterKeyboards" to let it use 2 keyboard to fit this hyprtest .
2. about src/devices/IKeyboard.hpp:
```
+    const std::vector<uint32_t>&      getPressedKeys() const;
+    bool                              shareStates() const;
```
  the two functions  "const"  for noting need to change the state of keyboard

3. I try my best to follow the code standards like the Same-level directory file, if there are some code break, I'll be sorry.


<details>
<summary>maybe ？</summary>

I don't know , because in my laptop,  it always has :
  - processSpawning
  - gestures
  - groups
  - keybinds
  - initialFloatSize
  - windows
  - childWindow
  - shortcutInhibitor
the eight problems (from ../build/hyprtester/hyprtester --plugin ./plugin/hyprtestplugin.so)
and with the message from start"unable to lock lockfile /run/user/1000/wayland-1.lock, maybe another compositor is running"
I'm confused, cause I'm using it, it generate the ".lock" : How can I avoid it ? 
The I reboot and use tty to advoid this, still had the eights, I don't know why. maybe It's my own problems...




(honestly, after confused with the eight, I even doubt that it is only my case..I hope it's not.)
</details>


<details>
<summary>myDevice</summary>

- `Distro`: Arch Linux
- `Kernel`: Linux 7.0.5-zen1-1-zen
- `Desktop`: hyprland
- `Session`: wayland
- `XDG_RUNTIME_DIR`: /run/user/1000
- `WAYLAND_DISPLAY`: wayland-1
- `DISPLAY`: :1
- `Wayland`: 1.25.0
- `Wayland protocols`: 1.48
- `Aquamarine`: 0.11.0-2
- `Hyprutils`: 0.13.1-1
- `Hyprland`: 0.54.3-4
- `xdg-desktop-portal-hyprland`: 1.3.12-2
- `OS`: Linux seeback 7.0.5-zen1-1-zen
- `CPU`: 12th Gen Intel(R) Core(TM) i5-12450H

</details>

### Is it ready for merging, or does it need work?

needs work ，cause  local  hyprtester  failed.

[hyprtester1.log](https://github.com/user-attachments/files/27572153/hyprtester1.log)
