### PR TITLE
monitor: don't set back to 8 bit when applying rules

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -829,9 +829,10 @@ bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule, bool force)
     m_customDrmMode = {};
     m_currentMode   = nullptr;
 
-    m_output->state->setFormat(DRM_FORMAT_XRGB8888);
+    const auto initialFormat = m_drmFormat != DRM_FORMAT_INVALID ? m_drmFormat : DRM_FORMAT_XRGB8888;
+    m_output->state->setFormat(initialFormat);
     m_prevDrmFormat = m_drmFormat;
-    m_drmFormat     = DRM_FORMAT_XRGB8888;
+    m_drmFormat     = initialFormat;
     m_output->state->resetExplicitFences();
 
     if (Env::isTrace()) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

previously we'd always set format back to `DRM_FORMAT_XRGB8888` before setting our actual format.
on my system, this switch from an 8 bit format, and then to a 10 bit format would cause a visible black flicker.

For more info, the flicker isn't exactly 1 frame long, and I can also still see my hardware cursor on the screen.

This PR just tries to avoid that drop to 8-bit where its not needed, to make the application of monitor rules smoother. `hyprctl reload` specifically for me causes the black blink on my 10 bit monitor, after this it looks ok :)

still trying to investigate the actual problem, this won't fix it in direct scanout for example, but will fix it situations where you're already in the correct format

and also weirdly enough the blink doesn't happen when going from 10 bit to 8 bit. It happens specifically the other way. 8 bit to 10 bit 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

nah

#### Is it ready for merging, or does it need work?

ye
