### PR TITLE
helpers: include numbers header

### DIFF
--- a/src/helpers/cm/ColorManagement.cpp
+++ b/src/helpers/cm/ColorManagement.cpp
@@ -8,6 +8,7 @@
 #include <map>
 #include <vector>
 #include <numeric>
+#include <numbers>
 
 using namespace NColorManagement;
 using namespace NTransferFunction;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

Adds a missing include for `numbers` on Gentoo Linux amd64 with clang/musl and `-stdlib=libc++`. On other platforms the header is already implicitly included.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)



<details>
<summary>Compilation error:</summary>

```bash
[581/840] /usr/lib/llvm/23/bin/clang++ -DDATAROOTDIR=\"/usr/share\" -DGLSLANG_IS_SHARED_LIBRARY=1 -DHAS_EXECINFO -DHYPRLAND_VERSION=\"0.55.0\" -I/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/. -I/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/src -I/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/protocols -isystem /usr/include/uuid -isystem /usr/include/pango-1.0 -isystem /usr/include/cairo -isystem /usr/include/libpng16 -isystem /usr/include/fribidi -isystem /usr/include/harfbuzz -isystem /usr/include/freetype2 -isystem /usr/include/pixman-1 -isystem /usr/include/libdrm -isystem /usr/lib/libffi/include -isystem /usr/include/glib-2.0 -isystem /usr/lib/glib-2.0/include -isystem /usr/include/libmount -isystem /usr/include/blkid -isystem /usr/include/lua5.4  -march=native -O3 -pipe -g0 -D_FORTIFY_SOURCE=3 -DNDEBUG -flto -stdlib=libc++ -std=gnu++26 -O3 -Wall -Wextra -Wpedantic -Wno-keyword-macro -Wno-unused-result -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wno-gnu-zero-variadic-macro-arguments -Wno-narrowing -Wno-pointer-arith -Wno-clobbered -frtti -fmacro-prefix-map=/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/= -fno-lto -pthread -Wno-float-conversion -Wno-implicit-float-conversion -Wno-implicit-int-float-conversion -Wno-unknown-warning-option -Wno-unused-command-line-argument -MD -MT CMakeFiles/hyprland_lib.dir/src/init/initHelpers.cpp.o -MF CMakeFiles/hyprland_lib.dir/src/init/initHelpers.cpp.o.d @CMakeFiles/hyprland_lib.dir/src/init/initHelpers.cpp.o.modmap -o CMakeFiles/hyprland_lib.dir/src/init/initHelpers.cpp.o -c /var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/src/init/initHelpers.cpp
[582/840] /usr/lib/llvm/23/bin/clang++ -DDATAROOTDIR=\"/usr/share\" -DGLSLANG_IS_SHARED_LIBRARY=1 -DHAS_EXECINFO -DHYPRLAND_VERSION=\"0.55.0\" -I/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/. -I/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/src -I/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/protocols -isystem /usr/include/uuid -isystem /usr/include/pango-1.0 -isystem /usr/include/cairo -isystem /usr/include/libpng16 -isystem /usr/include/fribidi -isystem /usr/include/harfbuzz -isystem /usr/include/freetype2 -isystem /usr/include/pixman-1 -isystem /usr/include/libdrm -isystem /usr/lib/libffi/include -isystem /usr/include/glib-2.0 -isystem /usr/lib/glib-2.0/include -isystem /usr/include/libmount -isystem /usr/include/blkid -isystem /usr/include/lua5.4  -march=native -O3 -pipe -g0 -D_FORTIFY_SOURCE=3 -DNDEBUG -flto -stdlib=libc++ -std=gnu++26 -O3 -Wall -Wextra -Wpedantic -Wno-keyword-macro -Wno-unused-result -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wno-gnu-zero-variadic-macro-arguments -Wno-narrowing -Wno-pointer-arith -Wno-clobbered -frtti -fmacro-prefix-map=/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/= -fno-lto -pthread -Wno-float-conversion -Wno-implicit-float-conversion -Wno-implicit-int-float-conversion -Wno-unknown-warning-option -Wno-unused-command-line-argument -MD -MT CMakeFiles/hyprland_lib.dir/src/helpers/cm/ColorManagement.cpp.o -MF CMakeFiles/hyprland_lib.dir/src/helpers/cm/ColorManagement.cpp.o.d @CMakeFiles/hyprland_lib.dir/src/helpers/cm/ColorManagement.cpp.o.modmap -o CMakeFiles/hyprland_lib.dir/src/helpers/cm/ColorManagement.cpp.o -c /var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/src/helpers/cm/ColorManagement.cpp
FAILED: [code=1] CMakeFiles/hyprland_lib.dir/src/helpers/cm/ColorManagement.cpp.o
/usr/lib/llvm/23/bin/clang++ -DDATAROOTDIR=\"/usr/share\" -DGLSLANG_IS_SHARED_LIBRARY=1 -DHAS_EXECINFO -DHYPRLAND_VERSION=\"0.55.0\" -I/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/. -I/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/src -I/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/protocols -isystem /usr/include/uuid -isystem /usr/include/pango-1.0 -isystem /usr/include/cairo -isystem /usr/include/libpng16 -isystem /usr/include/fribidi -isystem /usr/include/harfbuzz -isystem /usr/include/freetype2 -isystem /usr/include/pixman-1 -isystem /usr/include/libdrm -isystem /usr/lib/libffi/include -isystem /usr/include/glib-2.0 -isystem /usr/lib/glib-2.0/include -isystem /usr/include/libmount -isystem /usr/include/blkid -isystem /usr/include/lua5.4  -march=native -O3 -pipe -g0 -D_FORTIFY_SOURCE=3 -DNDEBUG -flto -stdlib=libc++ -std=gnu++26 -O3 -Wall -Wextra -Wpedantic -Wno-keyword-macro -Wno-unused-result -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wno-gnu-zero-variadic-macro-arguments -Wno-narrowing -Wno-pointer-arith -Wno-clobbered -frtti -fmacro-prefix-map=/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/= -fno-lto -pthread -Wno-float-conversion -Wno-implicit-float-conversion -Wno-implicit-int-float-conversion -Wno-unknown-warning-option -Wno-unused-command-line-argument -MD -MT CMakeFiles/hyprland_lib.dir/src/helpers/cm/ColorManagement.cpp.o -MF CMakeFiles/hyprland_lib.dir/src/helpers/cm/ColorManagement.cpp.o.d @CMakeFiles/hyprland_lib.dir/src/helpers/cm/ColorManagement.cpp.o.modmap -o CMakeFiles/hyprland_lib.dir/src/helpers/cm/ColorManagement.cpp.o -c /var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/src/helpers/cm/ColorManagement.cpp
/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/src/helpers/cm/ColorManagement.cpp:402:83: error: no member named 'numbers' in namespace 'std'
  402 |         color.v[i] = color.v[i] <= 0 ? 0.0 : exp((color.v[i] - 1.0) * mult * std::numbers::ln10);
      |                                                                              ~~~~~^
/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/src/helpers/cm/ColorManagement.cpp:409:77: error: no member named 'numbers' in namespace 'std'
  409 |         color.v[i] = color.v[i] <= min ? 0.0 : 1.0 + log(color.v[i]) / std::numbers::ln10 / mult;
      |                                                                        ~~~~~^
2 errors generated.
[583/840] /usr/lib/llvm/23/bin/clang++ -DDATAROOTDIR=\"/usr/share\" -DGLSLANG_IS_SHARED_LIBRARY=1 -DHAS_EXECINFO -DHYPRLAND_VERSION=\"0.55.0\" -I/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/. -I/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/src -I/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/protocols -isystem /usr/include/uuid -isystem /usr/include/pango-1.0 -isystem /usr/include/cairo -isystem /usr/include/libpng16 -isystem /usr/include/fribidi -isystem /usr/include/harfbuzz -isystem /usr/include/freetype2 -isystem /usr/include/pixman-1 -isystem /usr/include/libdrm -isystem /usr/lib/libffi/include -isystem /usr/include/glib-2.0 -isystem /usr/lib/glib-2.0/include -isystem /usr/include/libmount -isystem /usr/include/blkid -isystem /usr/include/lua5.4  -march=native -O3 -pipe -g0 -D_FORTIFY_SOURCE=3 -DNDEBUG -flto -stdlib=libc++ -std=gnu++26 -O3 -Wall -Wextra -Wpedantic -Wno-keyword-macro -Wno-unused-result -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wno-gnu-zero-variadic-macro-arguments -Wno-narrowing -Wno-pointer-arith -Wno-clobbered -frtti -fmacro-prefix-map=/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/= -fno-lto -pthread -Wno-float-conversion -Wno-implicit-float-conversion -Wno-implicit-int-float-conversion -Wno-unknown-warning-option -Wno-unused-command-line-argument -MD -MT CMakeFiles/hyprland_lib.dir/src/helpers/MonitorZoomController.cpp.o -MF CMakeFiles/hyprland_lib.dir/src/helpers/MonitorZoomController.cpp.o.d @CMakeFiles/hyprland_lib.dir/src/helpers/MonitorZoomController.cpp.o.modmap -o CMakeFiles/hyprland_lib.dir/src/helpers/MonitorZoomController.cpp.o -c /var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/src/helpers/MonitorZoomController.cpp
[584/840] /usr/lib/llvm/23/bin/clang++ -DDATAROOTDIR=\"/usr/share\" -DGLSLANG_IS_SHARED_LIBRARY=1 -DHAS_EXECINFO -DHYPRLAND_VERSION=\"0.55.0\" -I/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/. -I/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/src -I/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/protocols -isystem /usr/include/uuid -isystem /usr/include/pango-1.0 -isystem /usr/include/cairo -isystem /usr/include/libpng16 -isystem /usr/include/fribidi -isystem /usr/include/harfbuzz -isystem /usr/include/freetype2 -isystem /usr/include/pixman-1 -isystem /usr/include/libdrm -isystem /usr/lib/libffi/include -isystem /usr/include/glib-2.0 -isystem /usr/lib/glib-2.0/include -isystem /usr/include/libmount -isystem /usr/include/blkid -isystem /usr/include/lua5.4  -march=native -O3 -pipe -g0 -D_FORTIFY_SOURCE=3 -DNDEBUG -flto -stdlib=libc++ -std=gnu++26 -O3 -Wall -Wextra -Wpedantic -Wno-keyword-macro -Wno-unused-result -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wno-gnu-zero-variadic-macro-arguments -Wno-narrowing -Wno-pointer-arith -Wno-clobbered -frtti -fmacro-prefix-map=/var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/= -fno-lto -pthread -Wno-float-conversion -Wno-implicit-float-conversion -Wno-implicit-int-float-conversion -Wno-unknown-warning-option -Wno-unused-command-line-argument -MD -MT CMakeFiles/hyprland_lib.dir/src/layout/algorithm/ModeAlgorithm.cpp.o -MF CMakeFiles/hyprland_lib.dir/src/layout/algorithm/ModeAlgorithm.cpp.o.d @CMakeFiles/hyprland_lib.dir/src/layout/algorithm/ModeAlgorithm.cpp.o.modmap -o CMakeFiles/hyprland_lib.dir/src/layout/algorithm/ModeAlgorithm.cpp.o -c /var/tmp/portage/gui-wm/hyprland-9999/work/hyprland-9999/src/layout/algorithm/ModeAlgorithm.cpp
```
</details>


#### Is it ready for merging, or does it need work?

Ready for merging