### PR TITLE
config/propRefresher: avoid crash if event loop manager isn't loaded

### DIFF
--- a/src/config/supplementary/propRefresher/PropRefresher.cpp
+++ b/src/config/supplementary/propRefresher/PropRefresher.cpp
@@ -26,7 +26,7 @@ void CPropRefresher::scheduleRefresh(PropRefreshBits prop) {
 
     m_propsTripped |= prop;
 
-    if (!m_scheduled) {
+    if (!m_scheduled && g_pEventLoopManager) {
         g_pEventLoopManager->doLater([this, weak = WP<CPropRefresher>{refresher()}] {
             if (!weak)
                 return;


### PR DESCRIPTION
ref #14414

