### PR TITLE
monitor: fix top-layer bar visibility on workspace change with scrolling-layout fullscreen

### DIFF
--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -9,6 +9,7 @@
 #include "managers/animation/AnimationManager.hpp"
 #include "../managers/EventManager.hpp"
 #include "../helpers/Monitor.hpp"
+#include "../layout/algorithm/Algorithm.hpp"
 #include "../layout/space/Space.hpp"
 #include "../layout/target/Target.hpp"
 #include "../layout/supplementary/WorkspaceAlgoMatcher.hpp"
@@ -411,6 +412,12 @@ PHLWINDOW CWorkspace::getFullscreenWindow() {
     }
 
     return nullptr;
+}
+
+bool CWorkspace::hasFullscreen() {
+    if (m_hasFullscreenWindow)
+        return true;
+    return m_space && m_space->algorithm() && m_space->algorithm()->layoutFullscreenCoversMonitor();
 }
 
 bool CWorkspace::isVisible() {

--- a/src/desktop/Workspace.hpp
+++ b/src/desktop/Workspace.hpp
@@ -73,6 +73,7 @@ class CWorkspace {
     PHLWINDOW   getFirstWindow();
     PHLWINDOW   getTopLeftWindow();
     PHLWINDOW   getFullscreenWindow();
+    bool        hasFullscreen();
     bool        isVisible();
     bool        isVisibleNotCovered();
     void        rename(const std::string& name = "");

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -61,6 +61,19 @@ using namespace NColorManagement;
 using namespace Render::GL;
 using namespace Monitor;
 
+// True if the workspace has compositor-level OR layout-managed (e.g. scrolling) fullscreen.
+// Mirrors the check in CMonitor::inFullscreenMode so layer-fade decisions on workspace
+// change stay consistent with rendering, focus, and DS eligibility.
+namespace {
+    static bool workspaceHasFullscreen(const PHLWORKSPACE& ws) {
+        if (!ws)
+            return false;
+        if (ws->m_hasFullscreenWindow)
+            return true;
+        return ws->m_space && ws->m_space->algorithm() && ws->m_space->algorithm()->layoutFullscreenCoversMonitor();
+    }
+}
+
 CMonitor::CMonitor(SP<Aquamarine::IOutput> output_) : m_state(this), m_output(output_), m_imageDescription(getDefaultImageDescription()) {
     g_pAnimationManager->createAnimation(0.f, m_specialFade, Config::animationTree()->getAnimationPropertyConfig("specialWorkspaceIn"), AVARDAMAGE_NONE);
     m_specialFade->setUpdateCallback([this](auto) { g_pHyprRenderer->damageMonitor(m_self.lock()); });
@@ -1448,15 +1461,16 @@ void CMonitor::changeWorkspace(const PHLWORKSPACE& pWorkspace, bool internal, bo
     g_pHyprRenderer->damageMonitor(m_self.lock());
 
     g_pDesktopAnimationManager->setFullscreenFadeAnimation(
-        pWorkspace, pWorkspace->m_hasFullscreenWindow ? CDesktopAnimationManager::ANIMATION_TYPE_IN : CDesktopAnimationManager::ANIMATION_TYPE_OUT);
+        pWorkspace, workspaceHasFullscreen(pWorkspace) ? CDesktopAnimationManager::ANIMATION_TYPE_IN : CDesktopAnimationManager::ANIMATION_TYPE_OUT);
 
     Config::monitorRuleMgr()->ensureVRR(m_self.lock());
 
     g_pCompositor->updateSuspendedStates();
 
     if (m_activeSpecialWorkspace)
-        g_pDesktopAnimationManager->setFullscreenFadeAnimation(
-            m_activeSpecialWorkspace, m_activeSpecialWorkspace->m_hasFullscreenWindow ? CDesktopAnimationManager::ANIMATION_TYPE_IN : CDesktopAnimationManager::ANIMATION_TYPE_OUT);
+        g_pDesktopAnimationManager->setFullscreenFadeAnimation(m_activeSpecialWorkspace,
+                                                               workspaceHasFullscreen(m_activeSpecialWorkspace) ? CDesktopAnimationManager::ANIMATION_TYPE_IN :
+                                                                                                                  CDesktopAnimationManager::ANIMATION_TYPE_OUT);
 }
 
 void CMonitor::changeWorkspace(const WORKSPACEID& id, bool internal, bool noMouseMove, bool noFocus) {
@@ -1503,7 +1517,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
         }
 
         g_pDesktopAnimationManager->setFullscreenFadeAnimation(
-            m_activeWorkspace, m_activeWorkspace->m_hasFullscreenWindow ? CDesktopAnimationManager::ANIMATION_TYPE_IN : CDesktopAnimationManager::ANIMATION_TYPE_OUT);
+            m_activeWorkspace, workspaceHasFullscreen(m_activeWorkspace) ? CDesktopAnimationManager::ANIMATION_TYPE_IN : CDesktopAnimationManager::ANIMATION_TYPE_OUT);
 
         Config::monitorRuleMgr()->ensureVRR(m_self.lock());
 
@@ -1535,9 +1549,8 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
         }
 
         const auto PACTIVEWORKSPACE = PMONITOR->m_activeWorkspace;
-        g_pDesktopAnimationManager->setFullscreenFadeAnimation(PACTIVEWORKSPACE,
-                                                               PACTIVEWORKSPACE && PACTIVEWORKSPACE->m_hasFullscreenWindow ? CDesktopAnimationManager::ANIMATION_TYPE_IN :
-                                                                                                                             CDesktopAnimationManager::ANIMATION_TYPE_OUT);
+        g_pDesktopAnimationManager->setFullscreenFadeAnimation(
+            PACTIVEWORKSPACE, workspaceHasFullscreen(PACTIVEWORKSPACE) ? CDesktopAnimationManager::ANIMATION_TYPE_IN : CDesktopAnimationManager::ANIMATION_TYPE_OUT);
 
         wasActive = true;
     }
@@ -1603,7 +1616,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
     g_pHyprRenderer->damageMonitor(m_self.lock());
 
     g_pDesktopAnimationManager->setFullscreenFadeAnimation(
-        pWorkspace, pWorkspace->m_hasFullscreenWindow ? CDesktopAnimationManager::ANIMATION_TYPE_IN : CDesktopAnimationManager::ANIMATION_TYPE_OUT);
+        pWorkspace, workspaceHasFullscreen(pWorkspace) ? CDesktopAnimationManager::ANIMATION_TYPE_IN : CDesktopAnimationManager::ANIMATION_TYPE_OUT);
 
     Config::monitorRuleMgr()->ensureVRR(m_self.lock());
 

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -61,19 +61,6 @@ using namespace NColorManagement;
 using namespace Render::GL;
 using namespace Monitor;
 
-// True if the workspace has compositor-level OR layout-managed (e.g. scrolling) fullscreen.
-// Mirrors the check in CMonitor::inFullscreenMode so layer-fade decisions on workspace
-// change stay consistent with rendering, focus, and DS eligibility.
-namespace {
-    static bool workspaceHasFullscreen(const PHLWORKSPACE& ws) {
-        if (!ws)
-            return false;
-        if (ws->m_hasFullscreenWindow)
-            return true;
-        return ws->m_space && ws->m_space->algorithm() && ws->m_space->algorithm()->layoutFullscreenCoversMonitor();
-    }
-}
-
 CMonitor::CMonitor(SP<Aquamarine::IOutput> output_) : m_state(this), m_output(output_), m_imageDescription(getDefaultImageDescription()) {
     g_pAnimationManager->createAnimation(0.f, m_specialFade, Config::animationTree()->getAnimationPropertyConfig("specialWorkspaceIn"), AVARDAMAGE_NONE);
     m_specialFade->setUpdateCallback([this](auto) { g_pHyprRenderer->damageMonitor(m_self.lock()); });
@@ -1461,16 +1448,15 @@ void CMonitor::changeWorkspace(const PHLWORKSPACE& pWorkspace, bool internal, bo
     g_pHyprRenderer->damageMonitor(m_self.lock());
 
     g_pDesktopAnimationManager->setFullscreenFadeAnimation(
-        pWorkspace, workspaceHasFullscreen(pWorkspace) ? CDesktopAnimationManager::ANIMATION_TYPE_IN : CDesktopAnimationManager::ANIMATION_TYPE_OUT);
+        pWorkspace, pWorkspace->hasFullscreen() ? CDesktopAnimationManager::ANIMATION_TYPE_IN : CDesktopAnimationManager::ANIMATION_TYPE_OUT);
 
     Config::monitorRuleMgr()->ensureVRR(m_self.lock());
 
     g_pCompositor->updateSuspendedStates();
 
     if (m_activeSpecialWorkspace)
-        g_pDesktopAnimationManager->setFullscreenFadeAnimation(m_activeSpecialWorkspace,
-                                                               workspaceHasFullscreen(m_activeSpecialWorkspace) ? CDesktopAnimationManager::ANIMATION_TYPE_IN :
-                                                                                                                  CDesktopAnimationManager::ANIMATION_TYPE_OUT);
+        g_pDesktopAnimationManager->setFullscreenFadeAnimation(
+            m_activeSpecialWorkspace, m_activeSpecialWorkspace->hasFullscreen() ? CDesktopAnimationManager::ANIMATION_TYPE_IN : CDesktopAnimationManager::ANIMATION_TYPE_OUT);
 }
 
 void CMonitor::changeWorkspace(const WORKSPACEID& id, bool internal, bool noMouseMove, bool noFocus) {
@@ -1517,7 +1503,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
         }
 
         g_pDesktopAnimationManager->setFullscreenFadeAnimation(
-            m_activeWorkspace, workspaceHasFullscreen(m_activeWorkspace) ? CDesktopAnimationManager::ANIMATION_TYPE_IN : CDesktopAnimationManager::ANIMATION_TYPE_OUT);
+            m_activeWorkspace, m_activeWorkspace->hasFullscreen() ? CDesktopAnimationManager::ANIMATION_TYPE_IN : CDesktopAnimationManager::ANIMATION_TYPE_OUT);
 
         Config::monitorRuleMgr()->ensureVRR(m_self.lock());
 
@@ -1550,7 +1536,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
 
         const auto PACTIVEWORKSPACE = PMONITOR->m_activeWorkspace;
         g_pDesktopAnimationManager->setFullscreenFadeAnimation(
-            PACTIVEWORKSPACE, workspaceHasFullscreen(PACTIVEWORKSPACE) ? CDesktopAnimationManager::ANIMATION_TYPE_IN : CDesktopAnimationManager::ANIMATION_TYPE_OUT);
+            PACTIVEWORKSPACE, PACTIVEWORKSPACE && PACTIVEWORKSPACE->hasFullscreen() ? CDesktopAnimationManager::ANIMATION_TYPE_IN : CDesktopAnimationManager::ANIMATION_TYPE_OUT);
 
         wasActive = true;
     }
@@ -1616,7 +1602,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
     g_pHyprRenderer->damageMonitor(m_self.lock());
 
     g_pDesktopAnimationManager->setFullscreenFadeAnimation(
-        pWorkspace, workspaceHasFullscreen(pWorkspace) ? CDesktopAnimationManager::ANIMATION_TYPE_IN : CDesktopAnimationManager::ANIMATION_TYPE_OUT);
+        pWorkspace, pWorkspace->hasFullscreen() ? CDesktopAnimationManager::ANIMATION_TYPE_IN : CDesktopAnimationManager::ANIMATION_TYPE_OUT);
 
     Config::monitorRuleMgr()->ensureVRR(m_self.lock());
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
When a workspace uses the scrolling layout and one of its columns is fullscreen, switching away from that workspace and then back to it leaves shell bars (waybar, wayle, etc.) rendered on top of the fullscreen window. 

Scrolling between columns inside the workspace works fine insteaad, the bar fades out / in correctly instead.

This PR factors the check into a small `workspaceHasFullscreen` helper and uses it at all five call sites. After this patch, the bar is correctly hidden, tested on my machine with the patch applied.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Should definitely not have any side effect, the change is quite small

#### Is it ready for merging, or does it need work?
Ready for merging, already ran formatting as described in the guidelines

