### PR TITLE
Surface buffer transform and viewport spec compliance

### DIFF
--- a/src/helpers/math/Math.cpp
+++ b/src/helpers/math/Math.cpp
@@ -34,6 +34,13 @@ eTransform Math::wlTransformToHyprutils(wl_output_transform t) {
     return eTransform::HYPRUTILS_TRANSFORM_NORMAL;
 }
 
+eTransform Math::invertTransform(eTransform tr) {
+    if ((tr & HYPRUTILS_TRANSFORM_90) && !(tr & HYPRUTILS_TRANSFORM_FLIPPED))
+        tr = sc<eTransform>(tr ^ sc<int>(HYPRUTILS_TRANSFORM_180));
+
+    return tr;
+}
+
 wl_output_transform Math::invertTransform(wl_output_transform tr) {
     if ((tr & WL_OUTPUT_TRANSFORM_90) && !(tr & WL_OUTPUT_TRANSFORM_FLIPPED))
         tr = sc<wl_output_transform>(tr ^ sc<int>(WL_OUTPUT_TRANSFORM_180));

--- a/src/helpers/math/Math.hpp
+++ b/src/helpers/math/Math.hpp
@@ -14,5 +14,6 @@ namespace Math {
 
     eTransform               wlTransformToHyprutils(wl_output_transform t);
     wl_output_transform      invertTransform(wl_output_transform tr);
+    eTransform               invertTransform(eTransform tr);
     eTransform               composeTransform(eTransform a, eTransform b);
 }

--- a/src/protocols/Viewporter.cpp
+++ b/src/protocols/Viewporter.cpp
@@ -85,7 +85,9 @@ CViewportResource::CViewportResource(SP<CWpViewport> resource_, SP<CWLSurfaceRes
                 return length > 0.0;
             };
 
-            if (!clampAxis(src.x, src.w, size.x) || !clampAxis(src.y, src.h, size.y)) {
+            // Viewporter spec order: 1. transform, 2. scale, 3. viewport
+            Vector2D sizeScaledTransformed = (m_surface->m_pending.transform % 2 == 1 ? Vector2D{size.y, size.x} : size) / m_surface->m_pending.scale;
+            if (!clampAxis(src.x, src.w, sizeScaledTransformed.x) || !clampAxis(src.y, src.h, sizeScaledTransformed.y)) {
                 m_resource->error(WP_VIEWPORT_ERROR_BAD_VALUE, "Box doesn't fit");
                 m_surface->m_pending.rejected = true;
                 return;

--- a/src/render/ElementRenderer.cpp
+++ b/src/render/ElementRenderer.cpp
@@ -62,7 +62,12 @@ void IElementRenderer::calculateUVForSurface(PHLWINDOW pWindow, SP<CWLSurfaceRes
         if (pSurface->m_current.viewport.hasSource) {
             // we stretch it to dest. if no dest, to 1,1
             Vector2D const& bufferSize   = pSurface->m_current.bufferSize;
-            auto const&     bufferSource = pSurface->m_current.viewport.source;
+            auto            bufferSource = pSurface->m_current.viewport.source;
+
+            // Viewporter spec order: 1. transform, 2. scale, 3. viewport
+            Vector2D const trc = pSurface->m_current.transform % 2 == 1 ? Vector2D{bufferSize.y, bufferSize.x} : bufferSize;
+            bufferSource.scale(pSurface->m_current.scale);
+            bufferSource.transform(Math::wlTransformToHyprutils(Math::invertTransform(pSurface->m_current.transform)), trc.x, trc.y);
 
             // calculate UV for the basic src_box. Assume dest == size. Scale to dest later
             uvTL = Vector2D(bufferSource.x / bufferSize.x, bufferSource.y / bufferSize.y);

--- a/src/render/ElementRenderer.cpp
+++ b/src/render/ElementRenderer.cpp
@@ -66,7 +66,12 @@ void IElementRenderer::calculateUVForSurface(PHLWINDOW pWindow, SP<CWLSurfaceRes
         if (pSurface->m_current.viewport.hasSource) {
             // we stretch it to dest. if no dest, to 1,1
             Vector2D const& bufferSize   = pSurface->m_current.bufferSize;
-            auto const&     bufferSource = pSurface->m_current.viewport.source;
+            auto            bufferSource = pSurface->m_current.viewport.source;
+
+            // Viewporter spec order: 1. transform, 2. scale, 3. viewport
+            Vector2D const trc = pSurface->m_current.transform % 2 == 1 ? Vector2D{bufferSize.y, bufferSize.x} : bufferSize;
+            bufferSource.scale(pSurface->m_current.scale);
+            bufferSource.transform(Math::wlTransformToHyprutils(Math::invertTransform(pSurface->m_current.transform)), trc.x, trc.y);
 
             // calculate UV for the basic src_box. Assume dest == size. Scale to dest later
             uvTL = Vector2D(bufferSource.x / bufferSize.x, bufferSource.y / bufferSize.y);

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1456,13 +1456,14 @@ void CHyprOpenGLImpl::renderTextureInternal(SP<ITexture> tex, const CBox& box, c
     g_pHyprRenderer->m_renderData.renderModif.applyToBox(newBox);
 
     // get the needed transform for this texture
-    const auto                  MONITOR_INVERTED = Math::wlTransformToHyprutils(Math::invertTransform(g_pHyprRenderer->m_renderData.pMonitor->m_transform));
-    Hyprutils::Math::eTransform TRANSFORM        = tex->m_transform;
+    const auto MONITOR_INVERTED = Math::wlTransformToHyprutils(Math::invertTransform(g_pHyprRenderer->m_renderData.pMonitor->m_transform));
+    // wl_surface::set_buffer_transform: "The compositor applies the inverse of this transformation whenever it uses the buffer contents."
+    auto TRANSFORM_INVERTED = Math::invertTransform(tex->m_transform);
 
     if (g_pHyprRenderer->monitorTransformEnabled())
-        TRANSFORM = Math::composeTransform(MONITOR_INVERTED, TRANSFORM);
+        TRANSFORM_INVERTED = Math::composeTransform(MONITOR_INVERTED, TRANSFORM_INVERTED);
 
-    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox, TRANSFORM);
+    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox, TRANSFORM_INVERTED);
 
     const bool  renderToOutput = m_applyFinalShader && g_pHyprRenderer->workBufferImageDescription()->id() == g_pHyprRenderer->m_renderData.pMonitor->m_imageDescription->id();
 

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1568,7 +1568,8 @@ void CHyprOpenGLImpl::renderTextureInternal(SP<ITexture> tex, const CBox& box, c
     g_pHyprRenderer->m_renderData.renderModif.applyToBox(newBox);
 
     // get the needed transform for this texture
-    Hyprutils::Math::eTransform TRANSFORM = tex->m_transform;
+    // wl_surface::set_buffer_transform: "The compositor applies the inverse of this transformation whenever it uses the buffer contents."
+    Hyprutils::Math::eTransform TRANSFORM = Math::invertTransform(tex->m_transform);
 
     const auto&                 glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox, TRANSFORM);
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

1. Fix [`wl_surface::set_buffer_transform`](https://wayland.app/protocols/wayland#wl_surface:request:set_buffer_transform) transform direction
    - "The compositor applies the inverse of this transformation whenever it uses the buffer contents."
2. Fix [`wp_viewport::set_source`](https://wayland.app/protocols/viewporter#wp_viewport:request:set_source) order of operations
    - "The coordinate transformations from buffer pixel coordinates up to the surface-local coordinates happen in the following order: 1. buffer_transform (wl_surface.set_buffer_transform) 2. buffer_scale (wl_surface.set_buffer_scale) 3. crop and scale (wp_viewport.set*) This means, that the source rectangle coordinates of crop and scale are given in the coordinates after the buffer transform and scale, i.e. in the coordinates that would be the surface-local coordinates if the crop and scale was not applied." - https://wayland.app/protocols/viewporter#wp_viewport.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I only addressed the specific issues I was encountering right now, to not bite over more than I could chew for my first PR here.

That being said, I recently also noticed some unexpected `wl_surface::damage_buffer` behavior, relative to the applied transform/scale/viewport. I'll open a discussion or a separate PR in the future if I can confirm any of these again.

#### Is it ready for merging, or does it need work?

Should be ready.