### PR TITLE
config/lua: allow re-enabling monitors

### DIFF
--- a/src/config/lua/bindings/LuaBindingsConfigRules.cpp
+++ b/src/config/lua/bindings/LuaBindingsConfigRules.cpp
@@ -93,8 +93,7 @@ namespace {
          }},
         {"disabled", []() -> ILuaConfigValue* { return new CLuaConfigBool(false); },
          [](ILuaConfigValue* v, CMonitorRuleParser& p) {
-             if (*sc<const Config::BOOL*>(v->data()))
-                 p.setDisabled();
+             p.rule().m_disabled = *sc<const Config::BOOL*>(v->data());
              return true;
          }},
         {"transform", []() -> ILuaConfigValue* { return new CLuaConfigInt(0, 0, 7); },


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

This PR configures the Lua configuration setting `hl.monitor.disabled = false` to enable the monitor.

This allows Lua scripts to enable monitors that were previously disabled. Without this change, the only way I could find to re-enable a disabled monitor was to reload the entire configuration.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This is not how the original `hyprlang` configuration worked, so I totally understand if this is not a change that we want to make. However, I think the Lua configuration needs to provide some way to allow a user script to re-enable disabled monitors. Otherwise, I'm not sure how one would write a keybind that toggled a monitor on/off for example.

#### Is it ready for merging, or does it need work?

Ready for merging, very small change.
