### PR TITLE
groups: sync window monitor/workspace when added to a group

### DIFF
--- a/hyprtester/src/tests/main/moveintoorcreategroup.cpp
+++ b/hyprtester/src/tests/main/moveintoorcreategroup.cpp
@@ -95,3 +95,53 @@ TEST_CASE(moveIntoOrCreateGroup) {
         EXPECT_CONTAINS(str, "kitty_E");
     }
 }
+
+// Moving a window from a group on one monitor into a group on another monitor
+// must leave the moved window's monitor field set to the destination.
+TEST_CASE(crossMonitorGroupJoin) {
+    // We merge windows ourselves, suppress auto-grouping on spawn for predictability
+    OK(getFromSocket("/eval hl.config({ group = { auto_group = false } })"));
+
+    // Create a destination monitor to the right of the default one and pin the
+    // destination workspace to it
+    OK(getFromSocket("/eval hl.monitor({ output = 'HYPRTEST-CROSSGROUP', mode = '1920x1080@60', position = 'auto-right', scale = '1' })"));
+    OK(getFromSocket("/output create headless HYPRTEST-CROSSGROUP"));
+    OK(getFromSocket("/eval hl.workspace_rule({ workspace = 'name:groupcross-dst', monitor = 'HYPRTEST-CROSSGROUP' })"));
+
+    // Source group: 2 kittys on the default monitor, merged into one group
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'name:groupcross-src' })"));
+    auto srcA = Tests::spawnKitty("groupcross_srcA");
+    auto srcB = Tests::spawnKitty("groupcross_srcB");
+    if (!srcA || !srcB)
+        FAIL_TEST("Could not spawn source kittys");
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:groupcross_srcB' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ into_or_create_group = 'left' })"));
+    const auto MON_SRC_ID = Tests::getAttribute(getFromSocket("/activewindow"), "monitor");
+
+    // Destination group: 2 kittys on the new monitor, merged into one group
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'name:groupcross-dst' })"));
+    auto dstA = Tests::spawnKitty("groupcross_dstA");
+    auto dstB = Tests::spawnKitty("groupcross_dstB");
+    if (!dstA || !dstB)
+        FAIL_TEST("Could not spawn destination kittys");
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:groupcross_dstB' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ into_or_create_group = 'right' })"));
+    const auto MON_DST_ID = Tests::getAttribute(getFromSocket("/activewindow"), "monitor");
+
+    // Sanity check: the two groups really do live on different monitors
+    ASSERT_NOT(MON_SRC_ID, MON_DST_ID);
+
+    // move srcA out of the source group rightward into the destination group on
+    // the other monitor
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:groupcross_srcA' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ into_or_create_group = 'right' })"));
+
+    const auto active = getFromSocket("/activewindow");
+    // moved window becomes active
+    EXPECT_CONTAINS(active, "class: groupcross_srcA");
+    // and it now lives on the destination monitor
+    EXPECT(Tests::getAttribute(active, "monitor"), MON_DST_ID);
+
+    Tests::killAllWindows();
+    OK(getFromSocket("/output remove HYPRTEST-CROSSGROUP"));
+}

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -1259,11 +1259,6 @@ static void moveWindowIntoGroupHelper(PHLWINDOW pWindow, PHLWINDOW pWindowInDire
 
     updateRelativeCursorCoords();
 
-    if (pWindow->m_monitor != pWindowInDirection->m_monitor) {
-        pWindow->moveToWorkspace(pWindowInDirection->m_workspace);
-        pWindow->m_monitor = pWindowInDirection->m_monitor;
-    }
-
     if (pWindow->m_group)
         pWindow->m_group->remove(pWindow);
 

--- a/src/desktop/view/Group.cpp
+++ b/src/desktop/view/Group.cpp
@@ -109,6 +109,12 @@ void CGroup::add(PHLWINDOW w) {
     w->m_target->setSpaceGhost(m_target->space());
     w->m_target->setFloating(m_target->floating());
 
+    // a window in a group lives on the group's monitor/workspace
+    if (const auto WS = m_target->workspace(); WS && w->m_monitor != WS->m_monitor) {
+        w->m_monitor = WS->m_monitor;
+        w->moveToWorkspace(WS);
+    }
+
     if (*INSERT_AFTER_CURRENT) {
         m_windows.insert(m_windows.begin() + m_current + 1, w);
         m_current++;


### PR DESCRIPTION
When a window was moved from a group on one monitor into a group on another monitor, the target group's active tab (i.e. the window that was just moved into it) became invisible. Tab-switching restored visibility, confirming the window was a member of the target group but rendered on the wrong monitor. `moveWindowIntoGroupHelper` pre-set `pWindow->m_monitor`/`m_workspace` to the destination, but `CGroup::remove` immediately undid that via `assignToSpace(oldGroup.space)`, and `CGroup::add` then only set a `setSpaceGhost`, it never re-synced the incoming window.

This PR updates `CGroup::add` so that when an incoming window's `m_monitor` doesn't match the group's space's workspace monitor, it updates it. This enforces the invariant "a window in a group lives on the group's monitor" at the `CGroup` layer.