### PR TITLE
config: schedule monitor reloads in event loop

### DIFF
--- a/src/config/shared/monitor/MonitorRuleManager.cpp
+++ b/src/config/shared/monitor/MonitorRuleManager.cpp
@@ -115,6 +115,13 @@ void CMonitorRuleManager::scheduleReload() {
         return;
 
     m_reloadScheduled = true;
+
+    g_pEventLoopManager->doLater([this] {
+        if (m_reloadScheduled) {
+            performMonitorReload();
+            m_reloadScheduled = false;
+        }
+    });
 }
 
 void CMonitorRuleManager::performMonitorReload() {


### PR DESCRIPTION

#### Describe your PR, what does it fix/add?

Context: #14230.

Fixes the situation when kanshi cannot re-enable a disabled monitor when applying a profile on disconnect.

The monitor config reloads are not applied when disconnecting a screen, in the context of docking a laptop and using wlr-output-management to enable/disable the internal screen when docked. Schedule the reload in the event loop forces the config reload to happen.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I don't think that using the event loop is the best place to schedule this event, but I haven't found a better solution.

#### Is it ready for merging, or does it need work?

Ready to merge (tested and confirmed by another user https://github.com/hyprwm/Hyprland/discussions/14230#discussioncomment-16887688).