### PR TITLE
Revert "lua: restrict package module loading to lua-only modules"

### DIFF
--- a/src/config/lua/ConfigManager.cpp
+++ b/src/config/lua/ConfigManager.cpp
@@ -297,21 +297,6 @@ void CConfigManager::reinitLuaState() {
     lua_getglobal(m_lua, "package");
     lua_pushstring(m_lua, luaPath.c_str());
     lua_setfield(m_lua, -2, "path");
-
-    lua_pushstring(m_lua, "");
-    lua_setfield(m_lua, -2, "cpath");
-    lua_pushnil(m_lua);
-    lua_setfield(m_lua, -2, "loadlib");
-
-    lua_getfield(m_lua, -1, "searchers");
-    if (lua_istable(m_lua, -1)) {
-        lua_pushnil(m_lua);
-        lua_rawseti(m_lua, -2, 4);
-        lua_pushnil(m_lua);
-        lua_rawseti(m_lua, -2, 3);
-    }
-    lua_pop(m_lua, 1);
-
     lua_pop(m_lua, 1);
 
     lua_getglobal(m_lua, "require");


### PR DESCRIPTION
Reverts hyprwm/Hyprland#14526

- No reason given for initial PR
- Prevents users from loading C modules for legitimate purposes
- Untrusted config code loading C modules is not a security issue since you can run any arbitrary shell code anyway