### PR TITLE
remove manual format handling and pixelread parsing over to hyprgraphics

### DIFF
--- a/src/helpers/Format.cpp
+++ b/src/helpers/Format.cpp
@@ -101,24 +101,3 @@ std::string NFormatUtils::drmModifierName(uint64_t mod) {
     free(n); // NOLINT(cppcoreguidelines-no-malloc,-warnings-as-errors)
     return name;
 }
-
-DRMFormat NFormatUtils::alphaFormat(DRMFormat prevFormat) {
-    const auto format = getPixelFormatFromDRM(prevFormat);
-    if (format) {
-        if (format->alphaStripped != DRM_FORMAT_INVALID)
-            return format->alphaStripped;
-    }
-
-    Log::logger->log(Log::DEBUG, "NFormatUtils::alphaFormat format not found falling back to manual switch case handling");
-    switch (prevFormat) {
-        case DRM_FORMAT_XRGB8888: return DRM_FORMAT_ARGB8888;
-        case DRM_FORMAT_XBGR8888: return DRM_FORMAT_ABGR8888;
-        case DRM_FORMAT_BGRX8888: return DRM_FORMAT_BGRA8888;
-        case DRM_FORMAT_RGBX8888: return DRM_FORMAT_RGBA8888;
-        case DRM_FORMAT_XRGB2101010: return DRM_FORMAT_ARGB2101010;
-        case DRM_FORMAT_XBGR2101010: return DRM_FORMAT_ABGR2101010;
-        case DRM_FORMAT_RGBX1010102: return DRM_FORMAT_RGBA1010102;
-        case DRM_FORMAT_BGRX1010102: return DRM_FORMAT_BGRA1010102;
-        default: return 0;
-    }
-}

--- a/src/helpers/Format.cpp
+++ b/src/helpers/Format.cpp
@@ -5,6 +5,9 @@
 #include "../macros.hpp"
 #include <xf86drm.h>
 #include <drm_fourcc.h>
+#include <hyprgraphics/egl/Egl.hpp>
+
+using namespace Hyprgraphics::Egl;
 
 SHMFormat NFormatUtils::drmToShm(DRMFormat drm) {
     switch (drm) {
@@ -69,6 +72,13 @@ std::string NFormatUtils::drmModifierName(uint64_t mod) {
 }
 
 DRMFormat NFormatUtils::alphaFormat(DRMFormat prevFormat) {
+    const auto format = getPixelFormatFromDRM(prevFormat);
+    if (format) {
+        if (format->alphaStripped != DRM_FORMAT_INVALID)
+            return format->alphaStripped;
+    }
+
+    Log::logger->log(Log::DEBUG, "NFormatUtils::alphaFormat format not found falling back to manual switch case handling");
     switch (prevFormat) {
         case DRM_FORMAT_XRGB8888: return DRM_FORMAT_ARGB8888;
         case DRM_FORMAT_XBGR8888: return DRM_FORMAT_ABGR8888;

--- a/src/helpers/Format.cpp
+++ b/src/helpers/Format.cpp
@@ -103,6 +103,13 @@ std::string NFormatUtils::drmModifierName(uint64_t mod) {
 }
 
 DRMFormat NFormatUtils::alphaFormat(DRMFormat prevFormat) {
+    const auto format = getPixelFormatFromDRM(prevFormat);
+    if (format) {
+        if (format->alphaStripped != DRM_FORMAT_INVALID)
+            return format->alphaStripped;
+    }
+
+    Log::logger->log(Log::DEBUG, "NFormatUtils::alphaFormat format not found falling back to manual switch case handling");
     switch (prevFormat) {
         case DRM_FORMAT_XRGB8888: return DRM_FORMAT_ARGB8888;
         case DRM_FORMAT_XBGR8888: return DRM_FORMAT_ABGR8888;

--- a/src/helpers/Format.cpp
+++ b/src/helpers/Format.cpp
@@ -5,9 +5,6 @@
 #include "../macros.hpp"
 #include <xf86drm.h>
 #include <drm_fourcc.h>
-#include <hyprgraphics/egl/Egl.hpp>
-
-using namespace Hyprgraphics::Egl;
 
 SHMFormat NFormatUtils::drmToShm(DRMFormat drm) {
     switch (drm) {
@@ -69,25 +66,4 @@ std::string NFormatUtils::drmModifierName(uint64_t mod) {
     std::string name = n;
     free(n); // NOLINT(cppcoreguidelines-no-malloc,-warnings-as-errors)
     return name;
-}
-
-DRMFormat NFormatUtils::alphaFormat(DRMFormat prevFormat) {
-    const auto format = getPixelFormatFromDRM(prevFormat);
-    if (format) {
-        if (format->alphaStripped != DRM_FORMAT_INVALID)
-            return format->alphaStripped;
-    }
-
-    Log::logger->log(Log::DEBUG, "NFormatUtils::alphaFormat format not found falling back to manual switch case handling");
-    switch (prevFormat) {
-        case DRM_FORMAT_XRGB8888: return DRM_FORMAT_ARGB8888;
-        case DRM_FORMAT_XBGR8888: return DRM_FORMAT_ABGR8888;
-        case DRM_FORMAT_BGRX8888: return DRM_FORMAT_BGRA8888;
-        case DRM_FORMAT_RGBX8888: return DRM_FORMAT_RGBA8888;
-        case DRM_FORMAT_XRGB2101010: return DRM_FORMAT_ARGB2101010;
-        case DRM_FORMAT_XBGR2101010: return DRM_FORMAT_ABGR2101010;
-        case DRM_FORMAT_RGBX1010102: return DRM_FORMAT_RGBA1010102;
-        case DRM_FORMAT_BGRX1010102: return DRM_FORMAT_BGRA1010102;
-        default: return 0;
-    }
 }

--- a/src/helpers/Format.hpp
+++ b/src/helpers/Format.hpp
@@ -17,5 +17,4 @@ namespace NFormatUtils {
     bool        isFormatYUV(uint32_t drmFormat);
     std::string drmFormatName(DRMFormat drm);
     std::string drmModifierName(uint64_t mod);
-    DRMFormat   alphaFormat(DRMFormat prevFormat);
 };

--- a/src/helpers/Format.hpp
+++ b/src/helpers/Format.hpp
@@ -19,5 +19,4 @@ namespace NFormatUtils {
     bool        isShmBufferLayoutValid(DRMFormat drmFormat, const Vector2D& size, int32_t stride, int32_t offset, size_t poolSize);
     std::string drmFormatName(DRMFormat drm);
     std::string drmModifierName(uint64_t mod);
-    DRMFormat   alphaFormat(DRMFormat prevFormat);
 };

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -46,6 +46,7 @@
 #include <hyprutils/memory/UniquePtr.hpp>
 #include <hyprutils/string/String.hpp>
 #include <hyprutils/utils/ScopeGuard.hpp>
+#include <hyprgraphics/egl/Egl.hpp>
 #include <cstring>
 #include <climits>
 #include <optional>
@@ -56,6 +57,7 @@
 using namespace Hyprutils::String;
 using namespace Hyprutils::Utils;
 using namespace Hyprutils::OS;
+using namespace Hyprgraphics::Egl;
 using enum NContentType::eContentType;
 using namespace NColorManagement;
 using namespace Render::GL;
@@ -2373,11 +2375,16 @@ uint32_t CMonitor::getPreferredReadFormat() {
     static const auto PFORCE8BIT = CConfigValue<Config::INTEGER>("misc:screencopy_force_8b");
 
     auto              monFmt = m_output->state->state().drmFormat;
-
-    if (*PFORCE8BIT)
-        if (monFmt == DRM_FORMAT_BGRA1010102 || monFmt == DRM_FORMAT_ARGB2101010 || monFmt == DRM_FORMAT_XRGB2101010 || monFmt == DRM_FORMAT_BGRX1010102 ||
-            monFmt == DRM_FORMAT_XBGR2101010)
+    if (*PFORCE8BIT) {
+        const auto format = getPixelFormatFromDRM(monFmt);
+        if (format) {
+            if (getColorDepth(*format) >= 10)
+                monFmt = DRM_FORMAT_XRGB8888;
+        } else {
+            Log::logger->log(Log::DEBUG, "CMonitor::getPreferredReadFormat format not found falling back to DRM_FORMAT_XRGB8888");
             monFmt = DRM_FORMAT_XRGB8888;
+        }
+    }
 
     return monFmt;
 }

--- a/src/managers/screenshare/CursorshareSession.cpp
+++ b/src/managers/screenshare/CursorshareSession.cpp
@@ -185,24 +185,6 @@ bool CCursorshareSession::copy() {
 
         g_pHyprRenderer->endRender();
 
-        int glFormat = PFORMAT->glFormat;
-
-        if (glFormat == GL_RGBA)
-            glFormat = GL_BGRA_EXT;
-
-        if (glFormat != GL_BGRA_EXT && glFormat != GL_RGB) {
-            if (PFORMAT->swizzle.has_value()) {
-                if (PFORMAT->swizzle == SWIZZLE_RGBA)
-                    glFormat = GL_RGBA;
-                else if (PFORMAT->swizzle == SWIZZLE_BGRA)
-                    glFormat = GL_BGRA_EXT;
-                else {
-                    LOGM(Log::ERR, "Copied frame via shm might be broken or color flipped");
-                    glFormat = GL_RGBA;
-                }
-            }
-        }
-
         outFB->readPixels(m_pendingFrame.buffer, 0, 0, m_bufferSize.x, m_bufferSize.y);
 
         g_pHyprRenderer->m_renderData.pMonitor.reset();

--- a/src/managers/screenshare/CursorshareSession.cpp
+++ b/src/managers/screenshare/CursorshareSession.cpp
@@ -185,29 +185,7 @@ bool CCursorshareSession::copy() {
 
         g_pHyprRenderer->endRender();
 
-        int glFormat = PFORMAT->glFormat;
-
-        if (glFormat == GL_RGBA)
-            glFormat = GL_BGRA_EXT;
-
-        if (glFormat != GL_BGRA_EXT && glFormat != GL_RGB) {
-            if (PFORMAT->swizzle.has_value()) {
-                if (PFORMAT->swizzle == SWIZZLE_RGBA)
-                    glFormat = GL_RGBA;
-                else if (PFORMAT->swizzle == SWIZZLE_BGRA)
-                    glFormat = GL_BGRA_EXT;
-                else {
-                    LOGM(Log::ERR, "Copied frame via shm might be broken or color flipped");
-                    glFormat = GL_RGBA;
-                }
-            }
-        }
-
-        if (!outFB->readPixels(m_pendingFrame.buffer, 0, 0, m_bufferSize.x, m_bufferSize.y)) {
-            g_pHyprRenderer->m_renderData.pMonitor.reset();
-            LOGM(Log::ERR, "Can't copy: failed to read cursor pixels to shm");
-            return false;
-        }
+        outFB->readPixels(m_pendingFrame.buffer, 0, 0, m_bufferSize.x, m_bufferSize.y);
 
         g_pHyprRenderer->m_renderData.pMonitor.reset();
 

--- a/src/managers/screenshare/ScreenshareManager.hpp
+++ b/src/managers/screenshare/ScreenshareManager.hpp
@@ -87,6 +87,7 @@ namespace Screenshare {
             CHyprSignalListener windowDestroyed;
             CHyprSignalListener windowSizeChanged;
             CHyprSignalListener windowMonitorChanged;
+            CHyprSignalListener configReloaded;
         } m_listeners;
 
         void screenshareEvents(bool started);

--- a/src/managers/screenshare/ScreenshareSession.cpp
+++ b/src/managers/screenshare/ScreenshareSession.cpp
@@ -91,6 +91,14 @@ void CScreenshareSession::init() {
         calculateConstraints();
         m_events.constraintsChanged.emit();
     });
+    m_listeners.configReloaded     = Event::bus()->m_events.config.reloaded.listen([this] {
+        static const auto PFORCE8BIT = CConfigValue<Config::INTEGER>("misc:screencopy_force_8b");
+        static auto       prev       = *PFORCE8BIT;
+        if (prev != *PFORCE8BIT) {
+            prev = *PFORCE8BIT;
+            calculateConstraints();
+        }
+    });
 
     calculateConstraints();
 }

--- a/src/managers/screenshare/ScreenshareSession.cpp
+++ b/src/managers/screenshare/ScreenshareSession.cpp
@@ -112,17 +112,29 @@ void CScreenshareSession::calculateConstraints() {
         return;
     }
 
+    // GL_BGRA_EXT only works with GL_UNSIGNED_BYTE 8bit formats, gles limitation
+    // so force another format
+    const auto readbackFormat = getReadbackFormat(*format);
+    if (readbackFormat == GL_BGRA_EXT && format->glType != GL_UNSIGNED_BYTE) {
+        const auto colorDepth = getColorDepth(*format);
+        if (colorDepth <= 8)
+            format = getPixelFormatFromDRM(DRM_FORMAT_XBGR8888);
+        else if (colorDepth == 10)
+            format = getPixelFormatFromDRM(DRM_FORMAT_XBGR2101010);
+        else // 16bit
+            format = getPixelFormatFromDRM(DRM_FORMAT_XBGR16161616);
+
+        if (!format) {
+            LOGM(Log::ERR, "Missing support for fallback format, BUG REPORT this");
+            return;
+        }
+    }
+
     const auto altFormat = format->withAlpha ? format->alphaStripped : format->alphaAdded;
-    if (altFormat != DRM_FORMAT_INVALID && altFormat != preferredReadFormat)
+    if (altFormat != DRM_FORMAT_INVALID && altFormat != format->drmFormat)
         m_formats.push_back(altFormat);
 
-    m_formats.push_back(preferredReadFormat);
-
-    // TODO: hack, we can't bit flip so we'll format flip heh, GL_BGRA_EXT won't work here
-    for (auto& format : m_formats) {
-        if (format == DRM_FORMAT_XRGB2101010 || format == DRM_FORMAT_ARGB2101010)
-            format = DRM_FORMAT_XBGR2101010;
-    }
+    m_formats.push_back(format->drmFormat);
 
     switch (m_type) {
         case SHARE_MONITOR:

--- a/src/managers/screenshare/ScreenshareSession.cpp
+++ b/src/managers/screenshare/ScreenshareSession.cpp
@@ -5,7 +5,9 @@
 #include "../EventManager.hpp"
 #include "../eventLoop/EventLoopManager.hpp"
 #include "../../event/EventBus.hpp"
+#include <hyprgraphics/egl/Egl.hpp>
 
+using namespace Hyprgraphics::Egl;
 using namespace Screenshare;
 
 CScreenshareSession::CScreenshareSession(PHLMONITOR monitor, wl_client* client) : m_type(SHARE_MONITOR), m_monitor(monitor), m_client(client) {
@@ -102,8 +104,19 @@ void CScreenshareSession::calculateConstraints() {
 
     // TODO: maybe support more that just monitor format in the future?
     m_formats.clear();
-    m_formats.push_back(NFormatUtils::alphaFormat(PMONITOR->getPreferredReadFormat()));
-    m_formats.push_back(PMONITOR->getPreferredReadFormat()); // some clients don't like alpha formats
+    const auto preferredReadFormat = PMONITOR->getPreferredReadFormat();
+    auto       format              = getPixelFormatFromDRM(preferredReadFormat);
+
+    if (!format) {
+        LOGM(Log::ERR, "Missing support for format, BUG REPORT this");
+        return;
+    }
+
+    const auto altFormat = format->withAlpha ? format->alphaStripped : format->alphaAdded;
+    if (altFormat != DRM_FORMAT_INVALID && altFormat != preferredReadFormat)
+        m_formats.push_back(altFormat);
+
+    m_formats.push_back(preferredReadFormat);
 
     // TODO: hack, we can't bit flip so we'll format flip heh, GL_BGRA_EXT won't work here
     for (auto& format : m_formats) {

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -53,6 +53,7 @@
 #include <hyprutils/memory/UniquePtr.hpp>
 #include <hyprutils/string/String.hpp>
 #include <hyprutils/utils/ScopeGuard.hpp>
+#include <hyprgraphics/egl/Egl.hpp>
 #include <cstring>
 #include <climits>
 #include <optional>
@@ -63,6 +64,7 @@
 using namespace Hyprutils::String;
 using namespace Hyprutils::Utils;
 using namespace Hyprutils::OS;
+using namespace Hyprgraphics::Egl;
 using enum NContentType::eContentType;
 using namespace NColorManagement;
 using namespace Desktop::View;
@@ -2484,11 +2486,16 @@ uint32_t CMonitor::getPreferredReadFormat() {
     static const auto PFORCE8BIT = CConfigValue<Config::INTEGER>("misc:screencopy_force_8b");
 
     auto              monFmt = m_output->state->state().drmFormat;
-
-    if (*PFORCE8BIT)
-        if (monFmt == DRM_FORMAT_BGRA1010102 || monFmt == DRM_FORMAT_ARGB2101010 || monFmt == DRM_FORMAT_XRGB2101010 || monFmt == DRM_FORMAT_BGRX1010102 ||
-            monFmt == DRM_FORMAT_XBGR2101010)
+    if (*PFORCE8BIT) {
+        const auto format = getPixelFormatFromDRM(monFmt);
+        if (format) {
+            if (getColorDepth(*format) >= 10)
+                monFmt = DRM_FORMAT_XRGB8888;
+        } else {
+            Log::logger->log(Log::DEBUG, "CMonitor::getPreferredReadFormat format not found falling back to DRM_FORMAT_XRGB8888");
             monFmt = DRM_FORMAT_XRGB8888;
+        }
+    }
 
     return monFmt;
 }

--- a/src/render/gl/GLFramebuffer.cpp
+++ b/src/render/gl/GLFramebuffer.cpp
@@ -124,25 +124,8 @@ bool CGLFramebuffer::readPixels(CHLBufferReference buffer, uint32_t offsetX, uin
 
     glPixelStorei(GL_PACK_ALIGNMENT, 1);
 
-    uint32_t    packStride = minStride(PFORMAT, m_size.x);
-    int         glFormat   = PFORMAT->glFormat;
-
-    static auto stripSwizzleAlpha = [](std::array<GLint, 4> arr) {
-        arr[3] = GL_ONE;
-        return arr;
-    };
-
-    if (PFORMAT->swizzle.has_value()) {
-        if (stripSwizzleAlpha(*PFORMAT->swizzle) == stripSwizzleAlpha(SWIZZLE_RGBA))
-            glFormat = GL_RGBA;
-        else if (stripSwizzleAlpha(*PFORMAT->swizzle) == stripSwizzleAlpha(SWIZZLE_BGRA))
-            glFormat = GL_BGRA_EXT;
-        else {
-            LOGM(Log::ERR, "Copied frame via shm might be broken or color flipped");
-            glFormat = GL_RGBA;
-        }
-    } else if (glFormat == GL_RGBA)
-        glFormat = GL_BGRA_EXT;
+    uint32_t packStride = minStride(PFORMAT, m_size.x);
+    int      glFormat   = getReadbackFormat(*PFORMAT);
 
     // This could be optimized by using a pixel buffer object to make this async,
     // but really clients should just use a dma buffer anyways.

--- a/src/render/gl/GLFramebuffer.cpp
+++ b/src/render/gl/GLFramebuffer.cpp
@@ -183,24 +183,8 @@ bool CGLFramebuffer::readPixels(CHLBufferReference buffer, uint32_t offsetX, uin
 
     glPixelStorei(GL_PACK_ALIGNMENT, 1);
 
-    int         glFormat = PFORMAT->glFormat;
-
-    static auto stripSwizzleAlpha = [](std::array<GLint, 4> arr) {
-        arr[3] = GL_ONE;
-        return arr;
-    };
-
-    if (PFORMAT->swizzle.has_value()) {
-        if (stripSwizzleAlpha(*PFORMAT->swizzle) == stripSwizzleAlpha(SWIZZLE_RGBA))
-            glFormat = GL_RGBA;
-        else if (stripSwizzleAlpha(*PFORMAT->swizzle) == stripSwizzleAlpha(SWIZZLE_BGRA))
-            glFormat = GL_BGRA_EXT;
-        else {
-            LOGM(Log::ERR, "Copied frame via shm might be broken or color flipped");
-            glFormat = GL_RGBA;
-        }
-    } else if (glFormat == GL_RGBA)
-        glFormat = GL_BGRA_EXT;
+    uint32_t packStride = minStride(PFORMAT, m_size.x);
+    int      glFormat   = getReadbackFormat(*PFORMAT);
 
     // This could be optimized by using a pixel buffer object to make this async,
     // but really clients should just use a dma buffer anyways.

--- a/tests/helpers/Format.cpp
+++ b/tests/helpers/Format.cpp
@@ -91,8 +91,11 @@ TEST(Helpers, formatDrmFormatName) {
 }
 
 TEST(Helpers, formatAlphaFormat) {
-    EXPECT_EQ(alphaFormat(DRM_FORMAT_XRGB8888), DRM_FORMAT_ARGB8888);
-    EXPECT_EQ(alphaFormat(DRM_FORMAT_XBGR8888), DRM_FORMAT_ABGR8888);
-    // Format without alpha stripped entry returns DRM_FORMAT_INVALID (0)
-    EXPECT_EQ(alphaFormat(DRM_FORMAT_ARGB8888), 0u);
+    const auto* xrgb = getPixelFormatFromDRM(DRM_FORMAT_XRGB8888);
+    EXPECT_EQ(xrgb->alphaAdded, DRM_FORMAT_ARGB8888);
+    const auto* xbgr = getPixelFormatFromDRM(DRM_FORMAT_XRGB8888);
+    EXPECT_EQ(xbgr->alphaAdded, DRM_FORMAT_ABGR8888);
+    // Format without alphaAdded entry returns DRM_FORMAT_INVALID (0)
+    const auto* gr88 = getPixelFormatFromDRM(DRM_FORMAT_GR88);
+    EXPECT_EQ(gr88->alphaAdded, 0u);
 }

--- a/tests/helpers/Format.cpp
+++ b/tests/helpers/Format.cpp
@@ -72,8 +72,11 @@ TEST(Helpers, formatDrmFormatName) {
 }
 
 TEST(Helpers, formatAlphaFormat) {
-    EXPECT_EQ(alphaFormat(DRM_FORMAT_XRGB8888), DRM_FORMAT_ARGB8888);
-    EXPECT_EQ(alphaFormat(DRM_FORMAT_XBGR8888), DRM_FORMAT_ABGR8888);
-    // Format without alpha stripped entry returns DRM_FORMAT_INVALID (0)
-    EXPECT_EQ(alphaFormat(DRM_FORMAT_ARGB8888), 0u);
+    const auto* xrgb = getPixelFormatFromDRM(DRM_FORMAT_XRGB8888);
+    EXPECT_EQ(xrgb->alphaAdded, DRM_FORMAT_ARGB8888);
+    const auto* xbgr = getPixelFormatFromDRM(DRM_FORMAT_XRGB8888);
+    EXPECT_EQ(xbgr->alphaAdded, DRM_FORMAT_ABGR8888);
+    // Format without alphaAdded entry returns DRM_FORMAT_INVALID (0)
+    const auto* gr88 = getPixelFormatFromDRM(DRM_FORMAT_GR88);
+    EXPECT_EQ(gr88->alphaAdded, 0u);
 }


### PR DESCRIPTION
use newly added format helpers from hyprgraphics, and dont manually if else case the drm formats, stick to the format list we have in hyprgraphics to avoid conflicts or future missing formats.

requires: https://github.com/hyprwm/hyprgraphics/pull/46

