### PR TITLE
Fixed an issue with focus grab returning focus to the wrong workspace.

### DIFF
--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -688,8 +688,12 @@ void CSeatManager::setGrab(SP<CSeatGrab> grab) {
         if (refocus) {
             auto candidate = Desktop::focusState()->window();
 
-            if (candidate)
+            if (candidate && candidate->m_workspace && candidate->m_workspace->isVisibleNotCovered())
                 Desktop::focusState()->rawWindowFocus(candidate, Desktop::FOCUS_REASON_FFM);
+            else {
+                const auto PMONITOR = g_pCompositor->getMonitorFromCursor();
+                g_pInputManager->refocusLastWindow(PMONITOR);
+            }
         }
 
         if (oldGrab->m_onEnd)


### PR DESCRIPTION
Path to reproduce
Switch to empty workspace
Open special workspace and focus/open a program on it
Hide special workspace
Open quickshell panel
Close quickshell panel

This was refocusing and sending me back to the now hidden special workspace, when it should just return me to the empty normal workspace
This caused pretty annoying issues when using the quickshell app launcher, it would cause apps to launch on the special workspace I just left instead of the normal workspace I was trying to open them on