### PR TITLE
Input/KeybindManager : Don't process keybindings which are binded inside a submap

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -688,9 +688,8 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
         // If the keybind was found before and belongs to a different submap
         // Do not trigger it again since the same keybind might exist in the submap definition
         // with different action.
-        if (found && (key.submapAtPress.name != k->submap.name)) {
+        if (found && (key.submapAtPress.name != k->submap.name))
             continue;
-        }
 
         if (!pressed) {
             // Require mods to be matching when the key was first pressed.

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -601,7 +601,7 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
         if (!k->locked && g_pSessionLockManager->isSessionLocked())
             continue;
 
-        if (!IGNORECONDITIONS && ((modmask != k->modmask && !k->ignoreMods) || (k->submap.name != Config::Actions::state()->m_currentSubmap && !k->submapUniversal) || k->shadowed))
+        if (!IGNORECONDITIONS && ((modmask != k->modmask && !k->ignoreMods) || ((k->submap.name != key.submapAtPress.name) && !k->submapUniversal) || k->shadowed))
             continue;
 
         if (device) {
@@ -684,12 +684,6 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
             found = true; // suppress the event
             continue;
         }
-
-        // If the keybind was found before and belongs to a different submap
-        // Do not trigger it again since the same keybind might exist in the submap definition
-        // with different action.
-        if (found && (key.submapAtPress.name != k->submap.name))
-            continue;
 
         if (!pressed) {
             // Require mods to be matching when the key was first pressed.

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -601,6 +601,11 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
         if (!k->locked && g_pSessionLockManager->isSessionLocked())
             continue;
 
+        // only process submap's keybinds when within the submap at the time of trigger
+        // to prevent multiple dispatches for the same keybind in multiple submaps
+        if (key.submapAtPress.name != k->submap.name)
+            continue;
+
         if (!IGNORECONDITIONS && ((modmask != k->modmask && !k->ignoreMods) || (k->submap.name != Config::Actions::state()->m_currentSubmap && !k->submapUniversal) || k->shadowed))
             continue;
 

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -601,11 +601,6 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
         if (!k->locked && g_pSessionLockManager->isSessionLocked())
             continue;
 
-        // only process submap's keybinds when within the submap at the time of trigger
-        // to prevent multiple dispatches for the same keybind in multiple submaps
-        if (key.submapAtPress.name != k->submap.name)
-            continue;
-
         if (!IGNORECONDITIONS && ((modmask != k->modmask && !k->ignoreMods) || (k->submap.name != Config::Actions::state()->m_currentSubmap && !k->submapUniversal) || k->shadowed))
             continue;
 
@@ -687,6 +682,13 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
                 continue;
 
             found = true; // suppress the event
+            continue;
+        }
+
+        // If the keybind was found before and belongs to a different submap
+        // Do not trigger it again since the same keybind might exist in the submap definition
+        // with different action.
+        if (found && (key.submapAtPress.name != k->submap.name)) {
             continue;
         }
 


### PR DESCRIPTION
Issue:
- The master keybind for submap to disable and enable the keybinds doesnt work. It is defined in the docs here: (https://wiki.hypr.land/Configuring/Basics/Binds/#disabling-keybinds-with-one-master-keybind)

Changes:
- Ignore processing keybinds if the current keybind's submap is different that the submap at keypress event as the global state changes whilst processing the keybinds.

Context:
- After debugging the code a bit, `handleKeybinds` in the `KeybindManager` calls the lua dispatcher for all the matching keybindings in the list for the initial keybind that triggered the submap, and once more for the same keybind inside the keybindings list. This is seen in the `setSubmap` in `ConfigActions.cpp`
- TL;DR:
- Behavior before the change: `press combo -> setSubmap("gameMode") -> setSubmap("reset")`
- Behavior after:  `press combo -> setSubmap("gameMode")` | `press combo -> setSubmap("reset")`

Test:
- Ran CTests
- Tested with the following config in hyprlandd.lua which was not working before:-
```
hl.bind(mainMod .. " + SHIFT + G", hl.dsp.submap("gameMode"))
hl.define_submap("gameMode", function()
    hl.bind(mainMod .. " + SHIFT + G", hl.dsp.submap("reset"))
end)
```
Risks:
- I have ran the tests and tested with a few submaps and configurations I had, but I'm not fully aware of the advanced use cases of the submaps and not sure if this might break some other things.


