### PR TITLE
layout/WindowTarget: fix crash when toggling float on oversized windows

### DIFF
--- a/src/layout/target/WindowTarget.cpp
+++ b/src/layout/target/WindowTarget.cpp
@@ -201,8 +201,8 @@ void CWindowTarget::updatePos() {
 
         calcPos += (availableSpace - calcSize) / 2.0;
 
-        calcPos.x = std::clamp(calcPos.x, MONITOR_WORKAREA.x, MONITOR_WORKAREA.x + MONITOR_WORKAREA.w - calcSize.x);
-        calcPos.y = std::clamp(calcPos.y, MONITOR_WORKAREA.y, MONITOR_WORKAREA.y + MONITOR_WORKAREA.h - calcSize.y);
+        calcPos.x = std::clamp(calcPos.x, MONITOR_WORKAREA.x, std::max(MONITOR_WORKAREA.x, MONITOR_WORKAREA.x + MONITOR_WORKAREA.w - calcSize.x));
+        calcPos.y = std::clamp(calcPos.y, MONITOR_WORKAREA.y, std::max(MONITOR_WORKAREA.y, MONITOR_WORKAREA.y + MONITOR_WORKAREA.h - calcSize.y));
     }
 
     if (m_window->onSpecialWorkspace() && !m_window->isFullscreen()) {


### PR DESCRIPTION
Fixes my issue related to this discussion: https://github.com/hyprwm/Hyprland/discussions/14537#discussion-10063053

I believe this should be simple enough to merge, unless someone believes otherwise. Hopefully this should prevent crashing the compositor by adding a safe fallback in the case the window's size exceeds the work area.

