### PR TITLE
Window Rule: Use original monitorstr if not silent

### DIFF
--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -1899,7 +1899,7 @@ void CWindow::mapWindow() {
             else {
                 const auto ARGPOS  = MONITORSTR.find_last_of(' ');
                 monitorSilent      = ARGPOS != std::string::npos && MONITORSTR.substr(ARGPOS).contains("silent");
-                const auto MONITOR = g_pCompositor->getMonitorFromString(MONITORSTR.substr(0, ARGPOS));
+                const auto MONITOR = g_pCompositor->getMonitorFromString(monitorSilent ? MONITORSTR.substr(0, ARGPOS) : MONITORSTR);
 
                 if (MONITOR) {
                     m_monitor = MONITOR;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This is a fix for the regression in the discussion I made here: https://github.com/hyprwm/Hyprland/discussions/14620

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
There are no problems, but personally I think the original feature should be reverted and reimplemented with `silent` being a first-class lua property, similar to how `movetoworkspacesilent` became the `follow` property when specifying a workspace.

#### Is it ready for merging, or does it need work?
Ready to merge

