### PR TITLE
config/monitor: refresh splash texture on monitor reload

### DIFF
--- a/src/config/shared/monitor/MonitorRuleManager.cpp
+++ b/src/config/shared/monitor/MonitorRuleManager.cpp
@@ -124,6 +124,8 @@ void CMonitorRuleManager::performMonitorReload() {
         if (!m->m_output || m->m_isUnsafeFallback)
             continue;
 
+        m->m_splash = nullptr;
+
         auto rule = get(m);
 
         if (!m->applyMonitorRule(Config::CMonitorRule{rule})) {


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
fixes: #14611
As I depend on the splash color being changeable while hyprland is running, I added an explicit deletion of the splash texture on a monitor reload so that it gets re-rendered in the next render cycle. This would also fix scaling issues with monitor resolution changes and such things.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Should be good to go, it's a simple one-line fix. It runs smoothly on my system and produces the expected outcome but I didn't check the whole codebase for implications. Given that the `m_splash` value isn't used anywhere else though it should be fine.

#### Is it ready for merging, or does it need work?
Ready for merging