### PR TITLE
config: use lua safe mode

### DIFF
--- a/src/config/ConfigManager.cpp
+++ b/src/config/ConfigManager.cpp
@@ -3,6 +3,7 @@
 #include "legacy/ConfigManager.hpp"
 #include "lua/ConfigManager.hpp"
 #include "../debug/log/Logger.hpp"
+#include "../Compositor.hpp"
 
 #include <hyprutils/path/Path.hpp>
 #include <filesystem>
@@ -61,7 +62,7 @@ bool Config::initConfigManager() {
         }
 
         // generate default
-        if (const auto v = g_mgr->generateDefaultConfig(filePath); !v) {
+        if (const auto v = g_mgr->generateDefaultConfig(filePath, g_pCompositor->m_safeMode); !v) {
             Log::logger->log(Log::CRIT, "[cfg] Couldn't generate default config: {}", v.error());
             return false;
         }

--- a/src/config/supplementary/jeremy/Jeremy.cpp
+++ b/src/config/supplementary/jeremy/Jeremy.cpp
@@ -16,7 +16,7 @@ std::expected<SConfigStateReply, std::string> Jeremy::getMainConfigPath() {
         lastSafeMode = g_pCompositor->m_safeMode;
 
         if (g_pCompositor->m_safeMode)
-            return SConfigStateReply{.path = (std::filesystem::path{g_pCompositor->m_instancePath} / "recoverycfg.conf").string(), .type = CONFIG_TYPE_SPECIAL};
+            return SConfigStateReply{.path = (std::filesystem::path{g_pCompositor->m_instancePath} / "recoverycfg.lua").string(), .type = CONFIG_TYPE_SPECIAL};
 
         if (!g_pCompositor->m_explicitConfigPath.empty())
             return SConfigStateReply{.path = g_pCompositor->m_explicitConfigPath, .type = CONFIG_TYPE_EXPLICIT};


### PR DESCRIPTION
For safe mode, assume we're running lua.

This will flip the problem from "safe mode breaks on lua" to "safe mode breaks on hyprlang". There is no good solution to do both.