### PR TITLE
fix(background-effect): out of bounds blur region

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1995,6 +1995,7 @@ void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox
         auto    PSURFACE       = Desktop::View::CWLSurface::fromResource(data.surface);
         if (PSURFACE && PSURFACE->m_hasBackgroundEffect && !PSURFACE->m_blurRegion.empty()) {
             CRegion protocolBlur = PSURFACE->m_blurRegion.copy();
+            protocolBlur.intersect(CBox{0, 0, box.width, box.height});
             protocolBlur.scale(m_renderData.pMonitor->m_scale);
             protocolBlur.translate(box.pos());
             if (blurClipRegion.empty())


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Follow up to https://github.com/hyprwm/Hyprland/pull/13211

Forgot to watch for out of bounds `wl_region` resulting in blur not getting applied correctly to some clients.
In this case it was because [foot](https://codeberg.org/dnkl/foot/src/commit/dea10e2e48162c6ab48ca564ceeca88dea886a04/wayland.c#L2537) sets the width and height to `INT_MAX`.

This makes sure we never exceed the box's region, so no overflow.

I tested this and can confirm blur now properly works on foot (with blur=true)



