### PR TITLE
Add physicalWidth and physicalHeight to lua's Monitor

### DIFF
--- a/src/config/lua/objects/LuaMonitor.cpp
+++ b/src/config/lua/objects/LuaMonitor.cpp
@@ -53,6 +53,10 @@ static int monitorIndex(lua_State* L) {
         lua_pushinteger(L, sc<int>(mon->m_pixelSize.x));
     else if (key == "height")
         lua_pushinteger(L, sc<int>(mon->m_pixelSize.y));
+    else if (key == "physical_width")
+        lua_pushinteger(L, sc<int>(mon->m_output->physicalSize.x));
+    else if (key == "physical_height")
+        lua_pushinteger(L, sc<int>(mon->m_output->physicalSize.y));
     else if (key == "refresh_rate")
         lua_pushnumber(L, mon->m_refreshRate);
     else if (key == "x")


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
This adds physicalWidth and physicalHeight to the lua api, which are currently missing and useful for doing scale calculations         

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

They are already visible in the cli.

#### Is it ready for merging, or does it need work?
Should be good to go.

