### PR TITLE
make resizewindow param accessible to lua

### DIFF
--- a/hyprtester/src/tests/main/window.cpp
+++ b/hyprtester/src/tests/main/window.cpp
@@ -1263,8 +1263,48 @@ TEST_CASE(monitorrule) {
     OK(getFromSocket("/output remove HEADLESS-3"));
 }
 
+
+
 TEST_CASE(mouseResize) {
-    OK(getFromSocket("/dispatch hl.dsp.window.resize(nil, { mouse = true })"));
+#define RESET_WINDOW() \
+      OK(getFromSocket("r/reload")); \
+      OK(getFromSocket("r/eval hl.unbind('mouse:273')")); \
+      OK(getFromSocket("/dispatch hl.dsp.window.resize({ x = 640, y = 400, window = 'class:kitty' })")); \
+      OK(getFromSocket("/dispatch hl.dsp.window.move({ x = 0, y = 0, window = 'class:kitty' })")); \
+      OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 640, y = 400 })")); \
+      EXPECT_CONTAINS(getFromSocket("/clients"), "size: 640,400"); \
+      EXPECT_CONTAINS(getFromSocket("/clients"), "at: 0,0");
+
+    OK(getFromSocket("/eval hl.window_rule({ match = { class = 'kitty' }, float = true })"));
+    Tests::spawnKitty();
+    ASSERT(Tests::windowCount(), 1);
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:kitty' })"));
+
+    RESET_WINDOW();
+    OK(getFromSocket("r/eval hl.bind('mouse:273', hl.dsp.window.resize(), { mouse = true })"));
+    OK(getFromSocket("/eval hl.plugin.test.click(273, 1)"));
+    OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 700, y = 200 })"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+    OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 700, y = 200 })")); // Socket needs a delayed second dispatch for the first time only, for some reason?
+    OK(getFromSocket("/eval hl.plugin.test.click(273, 0)"));
+    EXPECT_CONTAINS(getFromSocket("/clients"), "size: 700,200");
+
+    RESET_WINDOW();
+    OK(getFromSocket("r/eval hl.bind('mouse:273', hl.dsp.window.resize({ keep_aspect_ratio = true }), { mouse = true })"));
+    OK(getFromSocket("/eval hl.plugin.test.click(273, 1)"));
+    OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 1280, y = 100 })"));
+    OK(getFromSocket("/eval hl.plugin.test.click(273, 0)"));
+    EXPECT_CONTAINS(getFromSocket("/clients"), "size: 1280,800");
+
+    RESET_WINDOW();
+    OK(getFromSocket("/eval hl.window_rule({ match = { class = 'kitty' }, keep_aspect_ratio = true })"));
+    OK(getFromSocket("r/eval hl.bind('mouse:273', hl.dsp.window.resize({ keep_aspect_ratio = false }), { mouse = true })"));
+    OK(getFromSocket("/eval hl.plugin.test.click(273, 1)"));
+    OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 700, y = 200 })"));
+    OK(getFromSocket("/eval hl.plugin.test.click(273, 0)"));
+    EXPECT_CONTAINS(getFromSocket("/clients"), "size: 700,200");
+
     OK(getFromSocket("/dispatch hl.dsp.window.resize({ keep_aspect_ratio = true }, { mouse = true })"));
     OK(getFromSocket("/dispatch hl.dsp.window.resize({ keep_aspect_ratio = false }, { mouse = true })"));
+#undef RESET_WINDOW
 }

--- a/hyprtester/src/tests/main/window.cpp
+++ b/hyprtester/src/tests/main/window.cpp
@@ -1283,9 +1283,16 @@ TEST_CASE(mouseResize) {
     RESET_WINDOW();
     OK(getFromSocket("r/eval hl.bind('mouse:273', hl.dsp.window.resize(), { mouse = true })"));
     OK(getFromSocket("/eval hl.plugin.test.click(273, 1)"));
-    OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 700, y = 200 })"));
-    std::this_thread::sleep_for(std::chrono::milliseconds(2000));
-    OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 700, y = 200 })")); // Socket needs a delayed second dispatch for the first time only, for some reason?
+
+    // Position setting works immediately, but updating window sizes interactively doesn't.
+    for (size_t i = 0; i < 50; i++) {
+      OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 700, y = 200 })"));
+      if (getFromSocket("/clients").contains("size: 700,200")) {
+        break;
+      }
+
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
     OK(getFromSocket("/eval hl.plugin.test.click(273, 0)"));
     EXPECT_CONTAINS(getFromSocket("/clients"), "size: 700,200");
 
@@ -1303,8 +1310,5 @@ TEST_CASE(mouseResize) {
     OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 700, y = 200 })"));
     OK(getFromSocket("/eval hl.plugin.test.click(273, 0)"));
     EXPECT_CONTAINS(getFromSocket("/clients"), "size: 700,200");
-
-    OK(getFromSocket("/dispatch hl.dsp.window.resize({ keep_aspect_ratio = true }, { mouse = true })"));
-    OK(getFromSocket("/dispatch hl.dsp.window.resize({ keep_aspect_ratio = false }, { mouse = true })"));
 #undef RESET_WINDOW
 }

--- a/hyprtester/src/tests/main/window.cpp
+++ b/hyprtester/src/tests/main/window.cpp
@@ -1262,3 +1262,9 @@ TEST_CASE(monitorrule) {
 
     OK(getFromSocket("/output remove HEADLESS-3"));
 }
+
+TEST_CASE(mouseResize) {
+    OK(getFromSocket("/dispatch hl.dsp.window.resize(nil, { mouse = true })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.resize({ keep_aspect_ratio = true }, { mouse = true })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.resize({ keep_aspect_ratio = false }, { mouse = true })"));
+}

--- a/hyprtester/src/tests/main/window.cpp
+++ b/hyprtester/src/tests/main/window.cpp
@@ -1263,17 +1263,15 @@ TEST_CASE(monitorrule) {
     OK(getFromSocket("/output remove HEADLESS-3"));
 }
 
-
-
 TEST_CASE(mouseResize) {
-#define RESET_WINDOW() \
-      OK(getFromSocket("r/reload")); \
-      OK(getFromSocket("r/eval hl.unbind('mouse:273')")); \
-      OK(getFromSocket("/dispatch hl.dsp.window.resize({ x = 640, y = 400, window = 'class:kitty' })")); \
-      OK(getFromSocket("/dispatch hl.dsp.window.move({ x = 0, y = 0, window = 'class:kitty' })")); \
-      OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 640, y = 400 })")); \
-      EXPECT_CONTAINS(getFromSocket("/clients"), "size: 640,400"); \
-      EXPECT_CONTAINS(getFromSocket("/clients"), "at: 0,0");
+#define RESET_WINDOW()                                                                                                                                                             \
+    OK(getFromSocket("r/reload"));                                                                                                                                                 \
+    OK(getFromSocket("r/eval hl.unbind('mouse:273')"));                                                                                                                            \
+    OK(getFromSocket("/dispatch hl.dsp.window.resize({ x = 640, y = 400, window = 'class:kitty' })"));                                                                             \
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ x = 0, y = 0, window = 'class:kitty' })"));                                                                                   \
+    OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 640, y = 400 })"));                                                                                                       \
+    EXPECT_CONTAINS(getFromSocket("/clients"), "size: 640,400");                                                                                                                   \
+    EXPECT_CONTAINS(getFromSocket("/clients"), "at: 0,0");
 
     OK(getFromSocket("/eval hl.window_rule({ match = { class = 'kitty' }, float = true })"));
     Tests::spawnKitty();
@@ -1286,12 +1284,12 @@ TEST_CASE(mouseResize) {
 
     // Position setting works immediately, but updating window sizes interactively doesn't.
     for (size_t i = 0; i < 50; i++) {
-      OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 700, y = 200 })"));
-      if (getFromSocket("/clients").contains("size: 700,200")) {
-        break;
-      }
+        OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 700, y = 200 })"));
+        if (getFromSocket("/clients").contains("size: 700,200")) {
+            break;
+        }
 
-      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
     }
     OK(getFromSocket("/eval hl.plugin.test.click(273, 0)"));
     EXPECT_CONTAINS(getFromSocket("/clients"), "size: 700,200");

--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -2,7 +2,6 @@
 
 #include <hyprutils/string/String.hpp>
 #include <lua.h>
-#include <string>
 
 #include "Check.hpp"
 
@@ -670,10 +669,10 @@ static int dsp_mouseResize(lua_State* L) {
     if (g_pKeybindManager->m_currentKeybind)
         g_pKeybindManager->m_currentKeybind->releasePending = true;
 
-    int paramRaw = (int)lua_tonumber(L, lua_upvalueindex(1));
-    int param    = paramRaw < 0 ? 0 : paramRaw;
+    auto paramRaw = lua_tostring(L, lua_upvalueindex(1));
+    auto param = paramRaw == nullptr ? "0" : std::string(paramRaw);
 
-    return Internal::checkResult(L, CA::mouse("resizewindow " + std::to_string(param)));
+    return Internal::checkResult(L, CA::mouse("resizewindow " + param));
 }
 
 static int hlWindowClose(lua_State* L) {

--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -1,6 +1,8 @@
 #include "LuaBindingsInternal.hpp"
 
 #include <hyprutils/string/String.hpp>
+#include <lua.h>
+#include <string>
 
 #include "../../supplementary/executor/Executor.hpp"
 
@@ -638,7 +640,10 @@ static int dsp_mouseResize(lua_State* L) {
     if (g_pKeybindManager->m_currentKeybind)
         g_pKeybindManager->m_currentKeybind->releasePending = true;
 
-    return Internal::checkResult(L, CA::mouse("resizewindow"));
+    int paramRaw = (int)lua_tonumber(L, lua_upvalueindex(1));
+    int param    = paramRaw < 0 ? 0 : paramRaw;
+
+    return Internal::checkResult(L, CA::mouse("resizewindow " + std::to_string(param)));
 }
 
 static int hlWindowClose(lua_State* L) {
@@ -1014,13 +1019,13 @@ static int hlWindowDrag(lua_State* L) {
 }
 
 static int hlWindowResize(lua_State* L) {
-    if (lua_gettop(L) == 0 || lua_isnil(L, 1)) {
-        lua_pushcclosure(L, dsp_mouseResize, 0);
+    if (lua_gettop(L) == 0 || lua_isnil(L, 1) || lua_isnumber(L, 1)) {
+        lua_pushcclosure(L, dsp_mouseResize, 1);
         return 1;
     }
 
     if (!lua_istable(L, 1))
-        return Internal::configError(L, "hl.window.resize: expected no args, or a table { x, y, relative?, window? }");
+        return Internal::configError(L, "hl.window.resize: expected no args, a number, or a table { x, y, relative?, window? }");
 
     return hlWindowResizeExact(L);
 }

--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -2,7 +2,6 @@
 
 #include <hyprutils/string/String.hpp>
 #include <lua.h>
-#include <string>
 
 #include "../../supplementary/executor/Executor.hpp"
 
@@ -640,10 +639,10 @@ static int dsp_mouseResize(lua_State* L) {
     if (g_pKeybindManager->m_currentKeybind)
         g_pKeybindManager->m_currentKeybind->releasePending = true;
 
-    int paramRaw = (int)lua_tonumber(L, lua_upvalueindex(1));
-    int param    = paramRaw < 0 ? 0 : paramRaw;
+    auto paramRaw = lua_tostring(L, lua_upvalueindex(1));
+    auto param = paramRaw == nullptr ? "0" : std::string(paramRaw);
 
-    return Internal::checkResult(L, CA::mouse("resizewindow " + std::to_string(param)));
+    return Internal::checkResult(L, CA::mouse("resizewindow " + param));
 }
 
 static int hlWindowClose(lua_State* L) {

--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -668,10 +668,9 @@ static int dsp_mouseResize(lua_State* L) {
     if (g_pKeybindManager->m_currentKeybind)
         g_pKeybindManager->m_currentKeybind->releasePending = true;
 
-    auto paramRaw = lua_tostring(L, lua_upvalueindex(1));
-    auto param = paramRaw == nullptr ? "0" : std::string(paramRaw);
+    auto keepAspectRatio = lua_tostring(L, lua_upvalueindex(1));
 
-    return Internal::checkResult(L, CA::mouse("resizewindow " + param));
+    return Internal::checkResult(L, CA::mouse("resizewindow " + std::string(keepAspectRatio)));
 }
 
 static int hlWindowClose(lua_State* L) {
@@ -978,23 +977,6 @@ static int hlWindowToggleSwallow(lua_State* L) {
     lua_pushcclosure(L, dsp_toggleSwallow, 0);
     return 1;
 }
-
-static int hlWindowResizeExact(lua_State* L) {
-    if (!lua_istable(L, 1))
-        return Internal::configError(L, "hl.window.resize: expected a table { x, y, relative?, window? }");
-    auto x        = Internal::tableOptNum(L, 1, "x");
-    auto y        = Internal::tableOptNum(L, 1, "y");
-    bool relative = Internal::tableOptBool(L, 1, "relative").value_or(false);
-    if (!x || !y)
-        return Internal::configError(L, "hl.window.resize: 'x' and 'y' are required");
-    lua_pushnumber(L, *x);
-    lua_pushnumber(L, *y);
-    lua_pushboolean(L, relative);
-    Internal::pushWindowUpval(L, 1);
-    lua_pushcclosure(L, dsp_resize, 4);
-    return 1;
-}
-
 static int hlWindowPin(lua_State* L) {
     const auto action = Internal::tableToggleAction(L, 1);
 
@@ -1047,15 +1029,36 @@ static int hlWindowDrag(lua_State* L) {
 }
 
 static int hlWindowResize(lua_State* L) {
-    if (lua_gettop(L) == 0 || lua_isnil(L, 1) || lua_isnumber(L, 1)) {
+    if (lua_gettop(L) == 0 || lua_isnil(L, 1)) {
+        lua_pushnumber(L, 0);
         lua_pushcclosure(L, dsp_mouseResize, 1);
         return 1;
     }
 
     if (!lua_istable(L, 1))
-        return Internal::configError(L, "hl.window.resize: expected no args, a number, or a table { x, y, relative?, window? }");
+        return Internal::configError(L, "hl.window.resize: expected no args, a table { x, y, relative?, window? }, or a table { keep_aspect_ratio }");
+ 
+    auto x                = Internal::tableOptNum(L, 1, "x");
+    auto y                = Internal::tableOptNum(L, 1, "y");
+    if (x && y) {
+        bool relative     = Internal::tableOptBool(L, 1, "relative").value_or(false);
+        lua_pushnumber(L, *x);
+        lua_pushnumber(L, *y);
+        lua_pushboolean(L, relative);
+        Internal::pushWindowUpval(L, 1);
+        lua_pushcclosure(L, dsp_resize, 4);
+        return 1;
+    }
 
-    return hlWindowResizeExact(L);
+    auto keepAspectRatio = Internal::tableOptBool(L, 1, "keep_aspect_ratio");
+    if (keepAspectRatio) {
+        lua_pushnumber(L, *keepAspectRatio ? 1 : 2);
+        lua_pushcclosure(L, dsp_mouseResize, 1);
+        return 1;
+    }
+    
+
+    return Internal::configError(L, "hl.focus: unrecognized arguments. Expected positions (x & y) or keep_aspect_ratio");
 }
 
 static int dsp_moveFocus(lua_State* L) {

--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -1,6 +1,8 @@
 #include "LuaBindingsInternal.hpp"
 
 #include <hyprutils/string/String.hpp>
+#include <lua.h>
+#include <string>
 
 #include "Check.hpp"
 
@@ -668,7 +670,10 @@ static int dsp_mouseResize(lua_State* L) {
     if (g_pKeybindManager->m_currentKeybind)
         g_pKeybindManager->m_currentKeybind->releasePending = true;
 
-    return Internal::checkResult(L, CA::mouse("resizewindow"));
+    int paramRaw = (int)lua_tonumber(L, lua_upvalueindex(1));
+    int param    = paramRaw < 0 ? 0 : paramRaw;
+
+    return Internal::checkResult(L, CA::mouse("resizewindow " + std::to_string(param)));
 }
 
 static int hlWindowClose(lua_State* L) {
@@ -1044,13 +1049,13 @@ static int hlWindowDrag(lua_State* L) {
 }
 
 static int hlWindowResize(lua_State* L) {
-    if (lua_gettop(L) == 0 || lua_isnil(L, 1)) {
-        lua_pushcclosure(L, dsp_mouseResize, 0);
+    if (lua_gettop(L) == 0 || lua_isnil(L, 1) || lua_isnumber(L, 1)) {
+        lua_pushcclosure(L, dsp_mouseResize, 1);
         return 1;
     }
 
     if (!lua_istable(L, 1))
-        return Internal::configError(L, "hl.window.resize: expected no args, or a table { x, y, relative?, window? }");
+        return Internal::configError(L, "hl.window.resize: expected no args, a number, or a table { x, y, relative?, window? }");
 
     return hlWindowResizeExact(L);
 }

--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -1,7 +1,6 @@
 #include "LuaBindingsInternal.hpp"
 
 #include <hyprutils/string/String.hpp>
-#include <lua.h>
 
 #include "Check.hpp"
 

--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -1,7 +1,6 @@
 #include "LuaBindingsInternal.hpp"
 
 #include <hyprutils/string/String.hpp>
-#include <lua.h>
 
 #include "../../supplementary/executor/Executor.hpp"
 

--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -1039,11 +1039,11 @@ static int hlWindowResize(lua_State* L) {
 
     if (!lua_istable(L, 1))
         return Internal::configError(L, "hl.window.resize: expected no args, a table { x, y, relative?, window? }, or a table { keep_aspect_ratio }");
- 
-    auto x                = Internal::tableOptNum(L, 1, "x");
-    auto y                = Internal::tableOptNum(L, 1, "y");
+
+    auto x = Internal::tableOptNum(L, 1, "x");
+    auto y = Internal::tableOptNum(L, 1, "y");
     if (x && y) {
-        bool relative     = Internal::tableOptBool(L, 1, "relative").value_or(false);
+        bool relative = Internal::tableOptBool(L, 1, "relative").value_or(false);
         lua_pushnumber(L, *x);
         lua_pushnumber(L, *y);
         lua_pushboolean(L, relative);
@@ -1058,7 +1058,6 @@ static int hlWindowResize(lua_State* L) {
         lua_pushcclosure(L, dsp_mouseResize, 1);
         return 1;
     }
-    
 
     return Internal::configError(L, "hl.focus: unrecognized arguments. Expected positions (x & y) or keep_aspect_ratio");
 }

--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -668,9 +668,11 @@ static int dsp_mouseResize(lua_State* L) {
     if (g_pKeybindManager->m_currentKeybind)
         g_pKeybindManager->m_currentKeybind->releasePending = true;
 
-    auto keepAspectRatio = lua_tostring(L, lua_upvalueindex(1));
+    auto keepAspectRatio = Check::string(L, lua_upvalueindex(1));
+    if (!keepAspectRatio)
+        return Internal::configError(L, std::format("resize: bad argument 1: {}", keepAspectRatio.error()));
 
-    return Internal::checkResult(L, CA::mouse("resizewindow " + std::string(keepAspectRatio)));
+    return Internal::checkResult(L, CA::mouse("resizewindow " + *keepAspectRatio));
 }
 
 static int hlWindowClose(lua_State* L) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Makes `hl.dsp.window.resize()` take either nothing/nil, a number or a table to accommodate the previous `resizeparam` option (see https://github.com/hyprwm/Hyprland/discussions/14480).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nothing.

~~EDIT: I just noticed that this PR adds the `string` include because of my handling, imma see if i can improve that~~

#### Is it ready for merging, or does it need work?
Ready for merging

