### PR TITLE
lua stubs: add missing notification text field and make timeout required

### DIFF
--- a/meta/generateLuaStubs.py
+++ b/meta/generateLuaStubs.py
@@ -662,8 +662,9 @@ def generate_stub(root: Path) -> str:
         emit_class_block(
             "HL.NotificationOptions",
             [
+                ("text", "string", False),
+                ("timeout", "number", False),
                 ("color", "string", True),
-                ("timeout", "number", True),
                 ("icon", "integer|string", True),
                 ("font_size", "number", True),
             ],


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Add the missing "text" docstring & make timeout required because it is

```bash
$ hyprctl eval 'hl.notification.create { timeout = 3000 }' 
error: hl.notification.create { timeout = 3000 }:1: hl.notification.create: 'text' is required

$ hyprctl eval 'hl.notification.create { text = "test" }'                                                 11:15:40
error: hl.notification.create { text = "test" }:1: hl.notification.create: 'duration' (or 'timeout' / 'time') is required
```

#### Is it ready for merging, or does it need work?

Yes
