### PR TITLE
screenshare: only copy fb for pending frames

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -2573,7 +2573,7 @@ void CMonitorState::applyCustomModeWithSwapchain(const SP<Aquamarine::SOutputMod
 }
 
 bool CMonitor::needsACopyFB() {
-    return !m_mirrors.empty() || Screenshare::mgr()->isOutputBeingSSd(m_self.lock());
+    return !m_mirrors.empty() || Screenshare::mgr()->outputNeedsCopyFB(m_self.lock());
 }
 
 bool CMonitor::needsUnmodifiedCopy() {

--- a/src/managers/screenshare/ScreenshareManager.cpp
+++ b/src/managers/screenshare/ScreenshareManager.cpp
@@ -162,6 +162,43 @@ bool CScreenshareManager::isOutputBeingSSd(PHLMONITOR monitor) {
     });
 }
 
+bool CScreenshareManager::outputNeedsCopyFB(PHLMONITOR monitor) {
+    return outputCopyFBState(monitor).needsCopyFB();
+}
+
+CScreenshareManager::SOutputCopyFBState CScreenshareManager::outputCopyFBState(PHLMONITOR monitor) {
+    SOutputCopyFBState state;
+
+    for (const auto& session : m_sessions) {
+        if (!session || !session->isActive() || (session->m_type != SHARE_MONITOR && session->m_type != SHARE_REGION) || session->m_monitor != monitor)
+            continue;
+
+        state.activeSessions++;
+        if (session->m_sharing)
+            state.sharingSessions++;
+
+        if (session->m_type == SHARE_MONITOR)
+            state.monitorSessions++;
+        else if (session->m_type == SHARE_REGION)
+            state.regionSessions++;
+    }
+
+    for (const auto& frame : m_pendingFrames) {
+        if (!frame || frame->done() || !frame->m_shared || frame->m_session->monitor() != monitor)
+            continue;
+
+        if (frame->m_session->m_type == SHARE_MONITOR) {
+            state.pendingFrames++;
+            state.pendingMonitorFrames++;
+        } else if (frame->m_session->m_type == SHARE_REGION) {
+            state.pendingFrames++;
+            state.pendingRegionFrames++;
+        }
+    }
+
+    return state;
+}
+
 CScreenshareManager::SManagedSession::SManagedSession(UP<CScreenshareSession>&& session) : m_session(std::move(session)) {
     ;
 }

--- a/src/managers/screenshare/ScreenshareManager.hpp
+++ b/src/managers/screenshare/ScreenshareManager.hpp
@@ -197,6 +197,20 @@ namespace Screenshare {
       public:
         CScreenshareManager();
 
+        struct SOutputCopyFBState {
+            uint32_t activeSessions       = 0;
+            uint32_t sharingSessions      = 0;
+            uint32_t pendingFrames        = 0;
+            uint32_t monitorSessions      = 0;
+            uint32_t regionSessions       = 0;
+            uint32_t pendingMonitorFrames = 0;
+            uint32_t pendingRegionFrames  = 0;
+
+            bool     needsCopyFB() const {
+                return pendingFrames > 0;
+            }
+        };
+
         UP<CScreenshareSession> newSession(wl_client* client, PHLMONITOR monitor);
         UP<CScreenshareSession> newSession(wl_client* client, PHLMONITOR monitor, CBox captureRegion);
         UP<CScreenshareSession> newSession(wl_client* client, PHLWINDOW window);
@@ -209,6 +223,8 @@ namespace Screenshare {
 
         void                    onOutputCommit(PHLMONITOR monitor);
         bool                    isOutputBeingSSd(PHLMONITOR monitor);
+        bool                    outputNeedsCopyFB(PHLMONITOR monitor);
+        SOutputCopyFBState      outputCopyFBState(PHLMONITOR monitor);
 
       private:
         std::vector<WP<CScreenshareSession>> m_sessions;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
- This changes monitor copy-FB activation for screencopy sessions so the compositor only keeps/copies the unmodified framebuffer when a monitor or region screencopy frame is actually pending.
- Previously, `CMonitor::needsACopyFB()` treated any active monitor/region screenshare session as requiring a copy framebuffer. That could keep the extra copy path enabled even when no client frame was waiting to be copied. The new logic tracks output copy-FB state through `CScreenshareManager` and bases the decision on pending shared frames instead.

This reduces unnecessary render/copy work during idle screenshare sessions while preserving the copy path when a screencopy frame needs data.


#### Is it ready for merging, or does it need work?
Ready

