### PR TITLE
core: recheck floating windows after monitor layout changes

### DIFF
--- a/hyprtester/src/tests/main/window.cpp
+++ b/hyprtester/src/tests/main/window.cpp
@@ -1263,9 +1263,6 @@ TEST_CASE(monitorrule) {
     OK(getFromSocket("/output remove HEADLESS-3"));
 }
 
-// Verifies that floating windows offscreen are clamped back on-screen
-// after a monitor layout change, and their workspace is reassigned.
-// Regression test for https://github.com/hyprwm/Hyprland/issues/10030
 TEST_CASE(floatingWindowRecheckOnLayoutChange) {
     // Use HEADLESS-2 (1920x1080 at auto-right, so position 1920,0)
     OK(getFromSocket("/dispatch hl.dsp.focus({ monitor = 'HEADLESS-2' })"));
@@ -1273,70 +1270,51 @@ TEST_CASE(floatingWindowRecheckOnLayoutChange) {
     if (!spawnKitty("kitty_offscreen"))
         FAIL_TEST("Could not spawn kitty");
 
-    // Make it floating
     OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'set' })"));
 
-    // Move it way offscreen (beyond any monitor bounds)
     OK(getFromSocket("/dispatch hl.dsp.window.move({ x = 50000, y = 50000 })"));
-
-    // Verify the window is now offscreen
     {
         auto str = getFromSocket("/activewindow");
         ASSERT_CONTAINS(str, "class: kitty_offscreen");
         ASSERT_CONTAINS(str, "floating: 1");
     }
 
-    // Trigger a monitor layout change by re-applying a monitor rule.
-    // This calls arrangeMonitors() which triggers recheckFloatingWindowsOnScreen()
+    // re-apply monitor rule to trigger layout change
     OK(getFromSocket("/eval hl.monitor({ output = 'HEADLESS-2', mode = '1920x1080@60', position = 'auto-right', scale = '1' })"));
 
-    // Give doLater a moment to execute
+    // wait for doLater
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
-
-    // The window should now be clamped back on-screen (within HEADLESS-2's bounds)
     {
         auto str = getFromSocket("/activewindow");
         ASSERT_CONTAINS(str, "class: kitty_offscreen");
         ASSERT_CONTAINS(str, "floating: 1");
-
-        // Verify the window position is within reasonable bounds (not at 50000,50000 anymore)
         auto at = Tests::getAttribute(str, "at");
         EXPECT_NOT_CONTAINS(at, "50000");
     }
 }
 
-// Verifies that a floating window on a removed monitor gets moved to the
-// remaining monitor and its workspace is reassigned.
 TEST_CASE(floatingWindowWorkspaceReassignOnMonitorRemove) {
-    // Create a temporary third monitor
     OK(getFromSocket("/output create headless HEADLESS-FLOAT-TEST"));
     OK(getFromSocket("/eval hl.monitor({ output = 'HEADLESS-FLOAT-TEST', mode = '1920x1080@60', position = 'auto-right', scale = '1' })"));
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
-    // Focus the new monitor and spawn a floating window there
     OK(getFromSocket("/dispatch hl.dsp.focus({ monitor = 'HEADLESS-FLOAT-TEST' })"));
 
     if (!spawnKitty("kitty_reassign"))
         FAIL_TEST("Could not spawn kitty");
 
     OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'set' })"));
-
-    // Verify it's on the new monitor
     {
         auto str = getFromSocket("/activewindow");
         ASSERT_CONTAINS(str, "class: kitty_reassign");
         ASSERT_CONTAINS(str, "floating: 1");
     }
 
-    // Remove the monitor — the window should be moved and its workspace reassigned
     OK(getFromSocket("/output remove HEADLESS-FLOAT-TEST"));
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
-
-    // The window should still exist and be on a valid workspace
     {
         auto str = getFromSocket("/clients");
         ASSERT_CONTAINS(str, "class: kitty_reassign");
-        // It should NOT contain the removed monitor's name
         EXPECT_NOT_CONTAINS(str, "HEADLESS-FLOAT-TEST");
     }
 }

--- a/hyprtester/src/tests/main/window.cpp
+++ b/hyprtester/src/tests/main/window.cpp
@@ -1262,3 +1262,81 @@ TEST_CASE(monitorrule) {
 
     OK(getFromSocket("/output remove HEADLESS-3"));
 }
+
+// Verifies that floating windows offscreen are clamped back on-screen
+// after a monitor layout change, and their workspace is reassigned.
+// Regression test for https://github.com/hyprwm/Hyprland/issues/10030
+TEST_CASE(floatingWindowRecheckOnLayoutChange) {
+    // Use HEADLESS-2 (1920x1080 at auto-right, so position 1920,0)
+    OK(getFromSocket("/dispatch hl.dsp.focus({ monitor = 'HEADLESS-2' })"));
+
+    if (!spawnKitty("kitty_offscreen"))
+        FAIL_TEST("Could not spawn kitty");
+
+    // Make it floating
+    OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'set' })"));
+
+    // Move it way offscreen (beyond any monitor bounds)
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ x = 50000, y = 50000 })"));
+
+    // Verify the window is now offscreen
+    {
+        auto str = getFromSocket("/activewindow");
+        ASSERT_CONTAINS(str, "class: kitty_offscreen");
+        ASSERT_CONTAINS(str, "floating: 1");
+    }
+
+    // Trigger a monitor layout change by re-applying a monitor rule.
+    // This calls arrangeMonitors() which triggers recheckFloatingWindowsOnScreen()
+    OK(getFromSocket("/eval hl.monitor({ output = 'HEADLESS-2', mode = '1920x1080@60', position = 'auto-right', scale = '1' })"));
+
+    // Give doLater a moment to execute
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    // The window should now be clamped back on-screen (within HEADLESS-2's bounds)
+    {
+        auto str = getFromSocket("/activewindow");
+        ASSERT_CONTAINS(str, "class: kitty_offscreen");
+        ASSERT_CONTAINS(str, "floating: 1");
+
+        // Verify the window position is within reasonable bounds (not at 50000,50000 anymore)
+        auto at = Tests::getAttribute(str, "at");
+        EXPECT_NOT_CONTAINS(at, "50000");
+    }
+}
+
+// Verifies that a floating window on a removed monitor gets moved to the
+// remaining monitor and its workspace is reassigned.
+TEST_CASE(floatingWindowWorkspaceReassignOnMonitorRemove) {
+    // Create a temporary third monitor
+    OK(getFromSocket("/output create headless HEADLESS-FLOAT-TEST"));
+    OK(getFromSocket("/eval hl.monitor({ output = 'HEADLESS-FLOAT-TEST', mode = '1920x1080@60', position = 'auto-right', scale = '1' })"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    // Focus the new monitor and spawn a floating window there
+    OK(getFromSocket("/dispatch hl.dsp.focus({ monitor = 'HEADLESS-FLOAT-TEST' })"));
+
+    if (!spawnKitty("kitty_reassign"))
+        FAIL_TEST("Could not spawn kitty");
+
+    OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'set' })"));
+
+    // Verify it's on the new monitor
+    {
+        auto str = getFromSocket("/activewindow");
+        ASSERT_CONTAINS(str, "class: kitty_reassign");
+        ASSERT_CONTAINS(str, "floating: 1");
+    }
+
+    // Remove the monitor — the window should be moved and its workspace reassigned
+    OK(getFromSocket("/output remove HEADLESS-FLOAT-TEST"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    // The window should still exist and be on a valid workspace
+    {
+        auto str = getFromSocket("/clients");
+        ASSERT_CONTAINS(str, "class: kitty_reassign");
+        // It should NOT contain the removed monitor's name
+        EXPECT_NOT_CONTAINS(str, "HEADLESS-FLOAT-TEST");
+    }
+}

--- a/hyprtester/src/tests/main/window.cpp
+++ b/hyprtester/src/tests/main/window.cpp
@@ -1360,3 +1360,65 @@ TEST_CASE(mouseResize) {
     EXPECT_CONTAINS(getFromSocket("/clients"), "size: 700,200");
 #undef RESET_WINDOW
 }
+
+// Verifies that floating windows offscreen are clamped back on-screen
+// after a monitor layout change, and their workspace is reassigned.
+// Regression test for https://github.com/hyprwm/Hyprland/issues/10030
+TEST_CASE(floatingWindowRecheckOnLayoutChange) {
+    OK(getFromSocket("/dispatch hl.dsp.focus({ monitor = 'HEADLESS-2' })"));
+
+    if (!spawnKitty("kitty_offscreen"))
+        FAIL_TEST("Could not spawn kitty");
+
+    OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'set' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ x = 50000, y = 50000 })"));
+
+    {
+        auto str = getFromSocket("/activewindow");
+        ASSERT_CONTAINS(str, "class: kitty_offscreen");
+        ASSERT_CONTAINS(str, "floating: 1");
+    }
+
+    OK(getFromSocket("/eval hl.monitor({ output = 'HEADLESS-2', mode = '1920x1080@60', position = 'auto-right', scale = '1' })"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    {
+        auto str = getFromSocket("/activewindow");
+        ASSERT_CONTAINS(str, "class: kitty_offscreen");
+        ASSERT_CONTAINS(str, "floating: 1");
+
+        auto at = Tests::getAttribute(str, "at");
+        EXPECT_NOT_CONTAINS(at, "50000");
+    }
+}
+
+// Verifies that a floating window on a removed monitor gets moved to the
+// remaining monitor and its workspace is reassigned.
+// Regression test for https://github.com/hyprwm/Hyprland/issues/10030
+TEST_CASE(floatingWindowWorkspaceReassignOnMonitorRemove) {
+    OK(getFromSocket("/output create headless HEADLESS-FLOAT-TEST"));
+    OK(getFromSocket("/eval hl.monitor({ output = 'HEADLESS-FLOAT-TEST', mode = '1920x1080@60', position = 'auto-right', scale = '1' })"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ monitor = 'HEADLESS-FLOAT-TEST' })"));
+
+    if (!spawnKitty("kitty_reassign"))
+        FAIL_TEST("Could not spawn kitty");
+
+    OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'set' })"));
+
+    {
+        auto str = getFromSocket("/activewindow");
+        ASSERT_CONTAINS(str, "class: kitty_reassign");
+        ASSERT_CONTAINS(str, "floating: 1");
+    }
+
+    OK(getFromSocket("/output remove HEADLESS-FLOAT-TEST"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    {
+        auto str = getFromSocket("/clients");
+        ASSERT_CONTAINS(str, "class: kitty_reassign");
+        EXPECT_NOT_CONTAINS(str, "HEADLESS-FLOAT-TEST");
+    }
+}

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2903,6 +2903,9 @@ void CCompositor::arrangeMonitors() {
     PROTO::xdgOutput->updateAllOutputs();
     Event::bus()->m_events.monitor.layoutChanged.emit();
 
+    // Recheck floating windows after layout changes to prevent them going offscreen
+    g_pEventLoopManager->doLater([]() { g_pCompositor->recheckFloatingWindowsOnScreen(); });
+
 #ifndef NO_XWAYLAND
     const auto box = g_pCompositor->calculateX11WorkArea();
     if (g_pXWayland && g_pXWayland->m_wm) {
@@ -2913,6 +2916,46 @@ void CCompositor::arrangeMonitors() {
     }
 
 #endif
+}
+
+void CCompositor::recheckFloatingWindowsOnScreen() {
+    for (auto const& w : m_windows) {
+        if (!w->m_isMapped || !w->m_isFloating || w->m_pinned || w->isFullscreen())
+            continue;
+
+        const CBox WBOX = w->getWindowMainSurfaceBox();
+
+        // Check if the window intersects any enabled monitor
+        const bool IN = std::ranges::any_of(m_monitors, [&WBOX](const auto& m) {
+            if (!m->m_enabled)
+                return false;
+            CBox MONBOX = m->logicalBox();
+            return !MONBOX.intersection(WBOX).empty();
+        });
+
+        if (IN)
+            continue;
+
+        // Window is offscreen — find the best monitor to move it to
+        auto monitor = w->m_monitor.lock();
+
+        if (!monitor || !monitor->m_enabled)
+            monitor = getMonitorFromVector(WBOX.middle());
+
+        if (!monitor)
+            continue;
+
+        // Clamp the window position to the nearest edge/corner of the target monitor,
+        // preserving the user's positional intent rather than centering
+        const auto MONBOX = monitor->logicalBox();
+        const auto NEW_X  = std::clamp(WBOX.x, MONBOX.x, MONBOX.x + MONBOX.w - WBOX.w);
+        const auto NEW_Y  = std::clamp(WBOX.y, MONBOX.y, MONBOX.y + MONBOX.h - WBOX.h);
+        w->layoutTarget()->setPositionGlobal(CBox{NEW_X, NEW_Y, WBOX.w, WBOX.h});
+
+        // Reassign workspace if the window's current workspace doesn't belong to this monitor
+        if (w->m_workspace && w->m_workspace->m_monitor.lock() != monitor)
+            moveWindowToWorkspaceSafe(w, monitor->m_activeWorkspace);
+    }
 }
 
 void CCompositor::enterUnsafeState() {

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2400,6 +2400,51 @@ PHLWINDOW CCompositor::getForceFocus() {
     return nullptr;
 }
 
+void CCompositor::recheckFloatingWindowsOnScreen() {
+    const auto& realMonitors = State::monitorState()->monitors();
+
+    for (auto const& w : m_windows) {
+        if (!w->m_isMapped || !w->m_isFloating || w->m_pinned || w->isFullscreen())
+            continue;
+
+        const CBox WBOX = w->getWindowMainSurfaceBox();
+
+        const bool IN = std::ranges::any_of(realMonitors, [&WBOX](const auto& m) {
+            if (!m->m_enabled || m->m_name == State::FALLBACK_OUTPUT_NAME)
+                return false;
+            CBox MONBOX = m->logicalBox();
+            return !MONBOX.intersection(WBOX).empty();
+        });
+
+        if (IN)
+            continue;
+
+        // Window is offscreen — find the best monitor to move it to
+        auto monitor = w->m_monitor.lock();
+
+        if (!monitor || !monitor->m_enabled || monitor->m_name == State::FALLBACK_OUTPUT_NAME) {
+            const auto queryResult = State::monitorState()->query().vec(WBOX.middle()).run();
+            monitor                = queryResult ? dynamicPointerCast<Monitor::CMonitor>(queryResult) : nullptr;
+        }
+
+        // If still no valid monitor, use the focused monitor as last resort
+        if (!monitor || monitor->m_name == State::FALLBACK_OUTPUT_NAME)
+            monitor = Desktop::focusState()->monitor();
+
+        if (!monitor)
+            continue;
+
+        // Clamp to nearest edge/corner rather than centering, preserving positional intent
+        const auto MONBOX = monitor->logicalBox();
+        const auto NEW_X  = std::clamp(WBOX.x, MONBOX.x, MONBOX.x + MONBOX.w - WBOX.w);
+        const auto NEW_Y  = std::clamp(WBOX.y, MONBOX.y, MONBOX.y + MONBOX.h - WBOX.h);
+        w->layoutTarget()->setPositionGlobal(CBox{NEW_X, NEW_Y, WBOX.w, WBOX.h});
+
+        if (w->m_workspace && w->m_workspace->m_monitor.lock() != monitor)
+            moveWindowToWorkspaceSafe(w, monitor->m_activeWorkspace);
+    }
+}
+
 void CCompositor::setPreferredScaleForSurface(SP<CWLSurfaceResource> pSurface, double scale) {
     PROTO::fractional->sendScale(pSurface, scale);
     pSurface->sendPreferredScale(std::ceil(scale));

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -114,6 +114,7 @@ class CCompositor {
     void                   performUserChecks();
     void                   moveWindowToWorkspaceSafe(PHLWINDOW pWindow, PHLWORKSPACE pWorkspace);
     PHLWINDOW              getForceFocus();
+    void                   recheckFloatingWindowsOnScreen();
     void                   setPreferredScaleForSurface(SP<CWLSurfaceResource> pSurface, double scale);
     void                   setPreferredTransformForSurface(SP<CWLSurfaceResource> pSurface, wl_output_transform transform);
     void                   updateSuspendedStates();

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -156,6 +156,7 @@ class CCompositor {
     PHLWINDOW                           getForceFocus();
     void                                scheduleMonitorStateRecheck();
     void                                arrangeMonitors();
+    void                                recheckFloatingWindowsOnScreen();
     void                                checkMonitorOverlaps();
     void                                enterUnsafeState();
     void                                leaveUnsafeState();

--- a/src/state/MonitorLayoutController.cpp
+++ b/src/state/MonitorLayoutController.cpp
@@ -80,4 +80,7 @@ void CMonitorLayoutController::arrange() const {
     }
 
 #endif
+
+    // Recheck floating windows after layout changes to prevent them going offscreen
+    g_pEventLoopManager->doLater([]() { g_pCompositor->recheckFloatingWindowsOnScreen(); });
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

#### Fixes #10030

#### Supersedes #10031

##### Floating windows going offscreen when disconnected or layout changes.
###### Added To fix:
 - recheckFloatingWindowsOnScreen( ) added called after arrangeMonitors( ) function
 
 - works by clamping to nearest monitors edge

##### Workspace does not update when the window on a different monitor.
###### Added To fix:

- checking if windows workspace belongs to a different monitor after we reposition

- moveWindowToWorkspaceSafe( ) to reassign to the target monitors active workspace


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

[crthpl](https://github.com/crthpl)
[on Apr 15](https://github.com/hyprwm/Hyprland/issues/10030#issuecomment-4248358363)

mentioned here by them tried to work it out since no update for a while

#### Is it ready for merging, or does it need work?

yes, ready to merge