### PR TITLE
renderer: fix blur cm for mirroring

### DIFF
--- a/src/render/shaders/glsl/surface.frag
+++ b/src/render/shaders/glsl/surface.frag
@@ -92,8 +92,12 @@ void main() {
         );
 #endif
 #if USE_MIRROR
+#if USE_CM
     pixColor    = pixColors[0];
     mirrorColor = pixColors[1];
+#else
+    mirrorColor = pixColor;
+#endif
 #endif
 
 #if USE_TINT


### PR DESCRIPTION
Setting non-default min or max SDR luminance with CM/HDR enabled mirror rendering, which broke special workspace blurring. No blur was visible. This patch fixed it for me.

Inspired by [#14574](https://github.com/hyprwm/Hyprland/pull/14574), which solved the same problem for window borders.