### PR TITLE
fix null deref in setWindowFullscreenInternal when fullscreen state stale

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2196,6 +2196,8 @@ void CCompositor::changeWindowFullscreenModeClient(const PHLWINDOW PWINDOW, cons
 
 // TODO: move fs functions to Desktop::
 void CCompositor::setWindowFullscreenInternal(const PHLWINDOW PWINDOW, const eFullscreenMode MODE) {
+    if (!PWINDOW)
+        return;
     if (PWINDOW->m_ruleApplicator->syncFullscreen().valueOrDefault())
         setWindowFullscreenState(PWINDOW, Desktop::View::SFullscreenState{.internal = MODE, .client = MODE});
     else

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -1820,6 +1820,10 @@ void CWindow::mapWindow() {
         Desktop::focusState()->rawMonitorFocus(g_pCompositor->getMonitorFromVector({}));
         PMONITOR = Desktop::focusState()->monitor();
     }
+    if (!PMONITOR || (!PMONITOR->m_activeSpecialWorkspace && !PMONITOR->m_activeWorkspace)) {
+        Log::logger->log(Log::ERR, "mapWindow: no valid monitor/workspace, aborting map for {:x}", (uintptr_t)this);
+        return;
+    }
     auto PWORKSPACE = PMONITOR->m_activeSpecialWorkspace ? PMONITOR->m_activeSpecialWorkspace : PMONITOR->m_activeWorkspace;
     m_monitor       = PMONITOR;
     m_workspace     = PWORKSPACE;

--- a/src/managers/screenshare/ScreenshareFrame.cpp
+++ b/src/managers/screenshare/ScreenshareFrame.cpp
@@ -29,8 +29,11 @@ CScreenshareFrame::~CScreenshareFrame() {
     if (m_failed || !m_shared)
         return;
 
-    if (!m_copied && m_callback)
-        m_callback(RESULT_NOT_COPIED);
+    if (!m_copied && m_callback) {
+        FScreenshareCallback cb;
+        std::swap(cb, m_callback);
+        cb(RESULT_NOT_COPIED);
+    }
 }
 
 bool CScreenshareFrame::done() const {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
adds a null check on `setWindowFullscreenInternal` to prevent a SEGV when `m_hasFullscreenWindow` is stale and `getFullscreenWindow()` returns null. also guards `mapwindow` against null monitor or missing active workspace and fixes the screenshare destructor callback

reproduces reliably with forza horizon 6 via proton on startup.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
the `mapWindow` guard returns early on error which leaves the window unmapped rather than crashing; no further cleanup is done, but it looks like `unmapWindow` already handles this and `destroyWindow` cleans up unconditionally. open to suggestions if that's insufficient

#### Is it ready for merging, or does it need work?
ready, but open to review on the `mapWindow` early return

stacktrace:
[gdb.txt](https://github.com/user-attachments/files/28080337/gdb.txt)

