### PR TITLE
config/lua: allow any callable object for dispatch/actions

### DIFF
--- a/meta/generateLuaStubs.py
+++ b/meta/generateLuaStubs.py
@@ -13,6 +13,7 @@ from typing import Iterable
 @dataclass
 class ApiNode:
     methods: set[str] = field(default_factory=set)
+    fields: dict[str, str] = field(default_factory=dict)
     children: dict[str, "ApiNode"] = field(default_factory=dict)
 
 
@@ -64,7 +65,9 @@ def find_matching_brace(text: str, open_brace_idx: int) -> int:
     raise ValueError("Unbalanced braces while parsing C++ source")
 
 
-def extract_function_bodies(source: str, header_pattern: re.Pattern[str]) -> list[tuple[re.Match[str], str]]:
+def extract_function_bodies(
+    source: str, header_pattern: re.Pattern[str]
+) -> list[tuple[re.Match[str], str]]:
     out: list[tuple[re.Match[str], str]] = []
     for match in header_pattern.finditer(source):
         open_idx = source.find("{", match.end() - 1)
@@ -93,9 +96,12 @@ def parse_binding_tree(root: Path) -> tuple[ApiNode, set[str]]:
     callable_namespaces: set[str] = set()
 
     register_header = re.compile(
-        r"void\s+(?:(?:Config::Lua::Bindings::)?Internal::)?register\w+Bindings\s*\([^)]*\)\s*\{", re.MULTILINE
+        r"void\s+(?:(?:Config::Lua::Bindings::)?Internal::)?register\w+Bindings\s*\([^)]*\)\s*\{",
+        re.MULTILINE,
     )
-    set_fn = re.compile(r'(?:Internal::)?set(?:Mgr)?Fn\(\s*L\s*,(?:\s*mgr\s*,)?\s*"([^"]+)"\s*,')
+    set_fn = re.compile(
+        r'(?:Internal::)?set(?:Mgr)?Fn\(\s*L\s*,(?:\s*mgr\s*,)?\s*"([^"]+)"\s*,'
+    )
     set_field = re.compile(r'lua_setfield\(L,\s*-2,\s*"([^"]+)"\s*\);')
 
     for cpp in sorted(lua_dir.rglob("*.cpp")):
@@ -119,6 +125,16 @@ def parse_binding_tree(root: Path) -> tuple[ApiNode, set[str]]:
             for raw_line in body.splitlines():
                 line = raw_line.strip()
                 if not line:
+                    continue
+
+                if line.startswith("//! @fields:"):
+                    fields = [f.strip() for f in line[12:].strip()[1:-1].split(",")]
+
+                    for f in fields:
+                        name, *type_part = f.split(":")
+                        field_type = type_part[0] if type_part else "any"
+
+                        stack[-1].fields[name.strip()] = field_type.strip()
                     continue
 
                 if "lua_newtable(L)" in line:
@@ -156,7 +172,9 @@ def parse_binding_tree(root: Path) -> tuple[ApiNode, set[str]]:
 def parse_object_classes(root: Path) -> dict[str, ObjectClass]:
     objects_dir = root / "src/config/lua/objects"
     mt_regex = re.compile(r'static constexpr const char\* MT = "([^"]+)";')
-    index_header = re.compile(r"static int\s+\w*Index\s*\(lua_State\* L\)\s*\{", re.MULTILINE)
+    index_header = re.compile(
+        r"static int\s+\w*Index\s*\(lua_State\* L\)\s*\{", re.MULTILINE
+    )
     cond_regex = re.compile(r"(?:if|else\s+if)\s*\(([^)]*\bkey\b[^)]*)\)")
     push_class_regex = re.compile(r"Objects::CLua([A-Za-z0-9_]+)::push")
 
@@ -185,7 +203,9 @@ def parse_object_classes(root: Path) -> dict[str, ObjectClass]:
 
         for i, cond in enumerate(cond_matches):
             start = cond.start()
-            end = cond_matches[i + 1].start() if i + 1 < len(cond_matches) else len(body)
+            end = (
+                cond_matches[i + 1].start() if i + 1 < len(cond_matches) else len(body)
+            )
             segment = body[start:end]
 
             keys = re.findall(r'"([^"]+)"', cond.group(1))
@@ -226,7 +246,9 @@ def parse_object_classes(root: Path) -> dict[str, ObjectClass]:
                 if key in obj.fields:
                     existing = set(obj.fields[key].split("|"))
                     merged = existing | set(type_str.split("|"))
-                    obj.fields[key] = "|".join(sorted(merged, key=lambda t: (t == "nil", t)))
+                    obj.fields[key] = "|".join(
+                        sorted(merged, key=lambda t: (t == "nil", t))
+                    )
                 else:
                     obj.fields[key] = type_str
 
@@ -372,7 +394,9 @@ def query_struct_to_type(struct_name: str) -> str:
     return f"HL.{name}"
 
 
-def parse_query_filter_types(root: Path) -> tuple[dict[str, dict[str, str]], dict[str, str]]:
+def parse_query_filter_types(
+    root: Path,
+) -> tuple[dict[str, dict[str, str]], dict[str, str]]:
     source = read_text(root / "src/config/lua/bindings/LuaBindingsQuery.cpp")
 
     parse_header = re.compile(
@@ -398,7 +422,9 @@ def parse_query_filter_types(root: Path) -> tuple[dict[str, dict[str, str]], dic
             helper = dm.group(2)
             query_types[type_name][field_name] = helper_to_lua_type(helper)
 
-        helper_calls = re.finditer(r'Internal::tableOpt([A-Za-z_]+)\(L,\s*idx,\s*"([^"]+)"', body)
+        helper_calls = re.finditer(
+            r'Internal::tableOpt([A-Za-z_]+)\(L,\s*idx,\s*"([^"]+)"', body
+        )
         for hm in helper_calls:
             helper = hm.group(1)
             field_name = hm.group(2)
@@ -435,7 +461,11 @@ def format_union_alias(name: str, values: Iterable[str]) -> list[str]:
     return lines
 
 
-def emit_class_block(class_name: str, fields: list[tuple[str, str, bool]], operator_call: str | None = None) -> list[str]:
+def emit_class_block(
+    class_name: str,
+    fields: list[tuple[str, str, bool]],
+    operator_call: str | None = None,
+) -> list[str]:
     lines = [f"---@class {class_name}"]
     if operator_call:
         lines.append(f"---@operator call:{operator_call}")
@@ -522,8 +552,12 @@ def generate_stub(root: Path) -> str:
     lines.append("---@alias HL.MonitorSelector string|integer|HL.Monitor")
     lines.append("---@alias HL.WorkspaceSelector string|integer|HL.Workspace")
     lines.append("---@alias HL.WindowSelector string|integer|HL.Window")
-    lines.append("---@alias HL.Vec2Like HL.Vec2|{x:number, y:number}|{number, number}|string")
-    lines.append("---@alias HL.CssGap integer|{top?:integer, right?:integer, bottom?:integer, left?:integer}")
+    lines.append(
+        "---@alias HL.Vec2Like HL.Vec2|{x:number, y:number}|{number, number}|string"
+    )
+    lines.append(
+        "---@alias HL.CssGap integer|{top?:integer, right?:integer, bottom?:integer, left?:integer}"
+    )
     lines.append("---@alias HL.Gradient string|{colors:string[], angle?:number}")
     lines.append("")
     lines.append("---@class HL.Dispatcher")
@@ -574,10 +608,26 @@ def generate_stub(root: Path) -> str:
             [
                 ("area", "HL.Box", False),
                 ("targets", "HL.LayoutTarget[]", False),
-                ("grid_cell", "fun(self: HL.LayoutContext, i: integer, cols: integer, rows?: integer): HL.Box", False),
-                ("column", "fun(self: HL.LayoutContext, i: integer, n: integer): HL.Box", False),
-                ("row", "fun(self: HL.LayoutContext, i: integer, n: integer): HL.Box", False),
-                ("split", "fun(self: HL.LayoutContext, box: HL.Box, side: 'left'|'right'|'top'|'bottom'|'up'|'down', ratio: number): HL.Box", False),
+                (
+                    "grid_cell",
+                    "fun(self: HL.LayoutContext, i: integer, cols: integer, rows?: integer): HL.Box",
+                    False,
+                ),
+                (
+                    "column",
+                    "fun(self: HL.LayoutContext, i: integer, n: integer): HL.Box",
+                    False,
+                ),
+                (
+                    "row",
+                    "fun(self: HL.LayoutContext, i: integer, n: integer): HL.Box",
+                    False,
+                ),
+                (
+                    "split",
+                    "fun(self: HL.LayoutContext, box: HL.Box, side: 'left'|'right'|'top'|'bottom'|'up'|'down', ratio: number): HL.Box",
+                    False,
+                ),
             ],
         )
     )
@@ -588,7 +638,11 @@ def generate_stub(root: Path) -> str:
             "HL.LayoutProvider",
             [
                 ("recalculate", "fun(ctx: HL.LayoutContext): nil", False),
-                ("layout_msg", "fun(ctx: HL.LayoutContext, msg: string): boolean|string|nil", True),
+                (
+                    "layout_msg",
+                    "fun(ctx: HL.LayoutContext, msg: string): boolean|string|nil",
+                    True,
+                ),
             ],
         )
     )
@@ -634,7 +688,7 @@ def generate_stub(root: Path) -> str:
             [
                 ("fingers", "integer", False),
                 ("direction", "string", False),
-                ("action", "string|function", False),
+                ("action", "integer|function", False),
                 ("mods", "string", True),
                 ("scale", "number", True),
                 ("mode", "string", True),
@@ -673,7 +727,9 @@ def generate_stub(root: Path) -> str:
     lines.append("")
 
     for class_name in sorted(query_types.keys()):
-        fields = [(name, typ, True) for name, typ in sorted(query_types[class_name].items())]
+        fields = [
+            (name, typ, True) for name, typ in sorted(query_types[class_name].items())
+        ]
         lines.extend(emit_class_block(class_name, fields))
         lines.append("")
 
@@ -709,14 +765,28 @@ def generate_stub(root: Path) -> str:
 
         full_prefix = "hl" + ("." + ".".join(path) if path else "")
 
+        for field in sorted(node.fields):
+            full_name = f"{full_prefix}.{field}"
+            fields.append((field, node.fields[field], False))
+
         for method in sorted(node.methods):
             full_name = f"{full_prefix}.{method}"
-            default_method_type = "fun(...): HL.Dispatcher" if path and path[0] == "dsp" else "fun(...): any"
+            default_method_type = (
+                "fun(...): HL.Dispatcher"
+                if path and path[0] == "dsp"
+                else "fun(...): any"
+            )
             method_type = api_signatures.get(full_name, default_method_type)
             fields.append((method, method_type, False))
 
         for child_name in sorted(node.children.keys()):
-            fields.append((child_name, namespace_class_name(path + [child_name]), False))
+            child_type = namespace_class_name(path + [child_name])
+            if child_name in callable_namespaces:
+                # wider suppor for this rather than ---@operator
+                child_type += " | " + api_signatures.get(f"{full_prefix}.{child_name}", "fun(...): any")
+            fields.append(
+                (child_name, child_type, False)
+            )
 
         if path == ["plugin"]:
             fields.append(("[string]", "any", False))
@@ -759,7 +829,9 @@ def write_if_changed(path: Path, content: str) -> bool:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Generate LuaLS stubs for Hyprland Lua config API")
+    parser = argparse.ArgumentParser(
+        description="Generate LuaLS stubs for Hyprland Lua config API"
+    )
     parser.add_argument(
         "--root",
         type=Path,
@@ -791,7 +863,10 @@ def main() -> int:
 
         existing = read_text(output)
         if existing != content:
-            print(f"[lua-stubs] generated stubs are out of date: {output}", file=sys.stderr)
+            print(
+                f"[lua-stubs] generated stubs are out of date: {output}",
+                file=sys.stderr,
+            )
             return 1
 
         print(f"[lua-stubs] up to date: {output}")

--- a/src/config/lua/bindings/LuaBindingsConfigRules.cpp
+++ b/src/config/lua/bindings/LuaBindingsConfigRules.cpp
@@ -6,6 +6,7 @@
 #include "../types/LuaConfigBool.hpp"
 #include "../types/LuaConfigCssGap.hpp"
 #include "../types/LuaConfigFloat.hpp"
+#include "../types/LuaConfigGestureAction.hpp"
 #include "../types/LuaConfigGradient.hpp"
 #include "../types/LuaConfigInt.hpp"
 #include "../types/LuaConfigString.hpp"
@@ -33,6 +34,7 @@
 #include "../../../managers/input/trackpad/gestures/DispatcherGesture.hpp"
 #include "../../../managers/input/trackpad/gestures/FloatGesture.hpp"
 #include "../../../managers/input/trackpad/gestures/FullscreenGesture.hpp"
+#include "../../../managers/input/trackpad/gestures/ITrackpadGesture.hpp"
 #include "../../../managers/input/trackpad/gestures/LuaFunctionGesture.hpp"
 #include "../../../managers/input/trackpad/gestures/MoveGesture.hpp"
 #include "../../../managers/input/trackpad/gestures/ResizeGesture.hpp"
@@ -42,6 +44,7 @@
 #include "../../../managers/permissions/DynamicPermissionManager.hpp"
 
 #include <hyprutils/utils/ScopeGuard.hpp>
+#include <lua.h>
 
 using namespace Config;
 using namespace Config::Lua;
@@ -720,6 +723,7 @@ static int hlWorkspaceRule(lua_State* L) {
 }
 
 static int hlGesture(lua_State* L) {
+    lua_remove(L, 1); // skip self from __call(self, args)
     if (!lua_istable(L, 1))
         return Internal::configError(L, R"(hl.gesture: expected a table, e.g. { fingers = 3, direction = "horizontal", action = "workspace" })");
 
@@ -746,13 +750,30 @@ static int hlGesture(lua_State* L) {
         // we can ref that fucker and call him later
         lua_getfield(L, 1, "action");
 
+        if (lua_isnil(L, -1)) {
+            lua_pop(L, 1);
+            return Internal::configError(L, "hl.gesture: 'action' field expected to be callable, or one of hl.gesture.* constants");
+        }
+
+        bool is_callable = false;
+
         if (lua_isfunction(L, -1)) {
+            is_callable = true;
+        } else if (lua_getmetatable(L, -1)) {
+            lua_getfield(L, -1, "__call");
+            is_callable = lua_isfunction(L, -1);
+            lua_pop(L, 2);
+        }
+
+        if (is_callable) {
             lua_pushvalue(L, -1);
             functionRef = luaL_ref(L, LUA_REGISTRYINDEX);
             Lua::mgr()->registerLuaRef(functionRef);
+        } else if (!lua_isinteger(L, -1)) {
+            const char* bad_type = lua_typename(L, lua_type(L, -1));
+            lua_pop(L, 1);
+            return Internal::configError(L, "hl.gesture: 'action' must be a callable or an hl.gesture constant (got %s)", bad_type);
         }
-
-        lua_pop(L, 1);
     }
 
     // bitch ass macro because it's kinda long to get these things and it's ugly
@@ -818,38 +839,42 @@ static int hlGesture(lua_State* L) {
     std::expected<void, std::string> result;
 
     if (functionRef != LUA_NOREF) {
-        // this is a lua fn gesture
         result = g_pTrackpadGestures->addGesture(makeUnique<CLuaFunctionGesture>(functionRef), fingerCount, direction, modMask, deltaScale, disableInhibit);
-    } else {
-        CLuaConfigString actionParser("");
-        auto             actionErr = Internal::parseTableField(L, 1, "action", actionParser);
-        if (actionErr.errorCode != PARSE_ERROR_OK)
-            return Internal::configError(L, std::format("hl.gesture: {}", actionErr.message));
+        if (!result)
+            return Internal::configError(L, std::format("hl.gesture: {}", result.error()));
+        return 0;
+    }
 
-        const auto& action = actionParser.parsed();
+    lua_getfield(L, 1, "action");
+    if (!lua_isnumber(L, -1)) {
+        lua_pop(L, 1);
+        return Internal::configError(L, "hl.gesture: 'action' must be a valid enum integer (e.g., hl.gesture.WORKSPACE)!");
+    }
 
-        if (action == "workspace")
-            result = g_pTrackpadGestures->addGesture(makeUnique<CWorkspaceSwipeGesture>(), fingerCount, direction, modMask, deltaScale, disableInhibit);
-        else if (action == "resize")
-            result = g_pTrackpadGestures->addGesture(makeUnique<CResizeTrackpadGesture>(), fingerCount, direction, modMask, deltaScale, disableInhibit);
-        else if (action == "move")
-            result = g_pTrackpadGestures->addGesture(makeUnique<CMoveTrackpadGesture>(), fingerCount, direction, modMask, deltaScale, disableInhibit);
-        else if (action == "special")
-            result = g_pTrackpadGestures->addGesture(makeUnique<CSpecialWorkspaceGesture>(workspaceName), fingerCount, direction, modMask, deltaScale, disableInhibit);
-        else if (action == "close")
-            result = g_pTrackpadGestures->addGesture(makeUnique<CCloseTrackpadGesture>(), fingerCount, direction, modMask, deltaScale, disableInhibit);
-        else if (action == "float")
-            result = g_pTrackpadGestures->addGesture(makeUnique<CFloatTrackpadGesture>(mode), fingerCount, direction, modMask, deltaScale, disableInhibit);
-        else if (action == "fullscreen")
-            result = g_pTrackpadGestures->addGesture(makeUnique<CFullscreenTrackpadGesture>(mode), fingerCount, direction, modMask, deltaScale, disableInhibit);
-        else if (action == "cursor_zoom" || action == "cursorZoom")
-            result = g_pTrackpadGestures->addGesture(makeUnique<CCursorZoomTrackpadGesture>(zoomLevel, mode), fingerCount, direction, modMask, deltaScale, disableInhibit);
-        else if (action == "scroll_move")
-            result = g_pTrackpadGestures->addGesture(makeUnique<CScrollMoveTrackpadGesture>(), fingerCount, direction, modMask, deltaScale, disableInhibit);
-        else if (action == "unset")
-            result = g_pTrackpadGestures->removeGesture(fingerCount, direction, modMask, deltaScale, disableInhibit);
-        else
-            return Internal::configError(L, std::format("hl.gesture: unknown action \"{}\"", action));
+    int rawAction = lua_tointeger(L, -1);
+    lua_pop(L, 1);
+
+    eGestureAction                   action  = static_cast<eGestureAction>(rawAction);
+    CUniquePointer<ITrackpadGesture> gesture = nullptr;
+
+    switch (action) {
+        case eGestureAction::WORKSPACE: gesture = makeUnique<CWorkspaceSwipeGesture>(); break;
+        case eGestureAction::RESIZE: gesture = makeUnique<CResizeTrackpadGesture>(); break;
+        case eGestureAction::MOVE: gesture = makeUnique<CMoveTrackpadGesture>(); break;
+        case eGestureAction::SPECIAL: gesture = makeUnique<CSpecialWorkspaceGesture>(workspaceName); break;
+        case eGestureAction::CLOSE: gesture = makeUnique<CCloseTrackpadGesture>(); break;
+        case eGestureAction::FLOAT: gesture = makeUnique<CFloatTrackpadGesture>(mode); break;
+        case eGestureAction::FULLSCREEN: gesture = makeUnique<CFullscreenTrackpadGesture>(mode); break;
+        case eGestureAction::CURSOR_ZOOM: gesture = makeUnique<CCursorZoomTrackpadGesture>(zoomLevel, mode); break;
+        case eGestureAction::SCROLL_MOVE: gesture = makeUnique<CScrollMoveTrackpadGesture>(); break;
+
+        case eGestureAction::UNSET: result = g_pTrackpadGestures->removeGesture(fingerCount, direction, modMask, deltaScale, disableInhibit); break;
+
+        default: return Internal::configError(L, std::format("hl.gesture: unknown action ID {}", rawAction));
+    }
+
+    if (gesture) {
+        result = g_pTrackpadGestures->addGesture(std::move(gesture), fingerCount, direction, modMask, deltaScale, disableInhibit);
     }
 
     if (!result)
@@ -1292,7 +1317,24 @@ void Internal::registerConfigRuleBindings(lua_State* L, CConfigManager* mgr) {
     Internal::setMgrFn(L, mgr, "load", hlPluginLoad);
     lua_setfield(L, -2, "plugin");
 
-    Internal::setFn(L, "gesture", hlGesture);
     Internal::setFn(L, "curve", hlCurve);
     Internal::setFn(L, "animation", hlAnimation);
+
+    lua_newtable(L);
+    int gestureTableIdx = lua_gettop(L);
+
+    //! @fields: [WORKSPACE:integer, RESIZE:integer, SCROLL_MOVE:integer]
+    //! @fields: [SPECIAL:integer, CLOSE:integer, FLOAT:integer, MOVE:integer]
+    //! @fields: [UNSET:integer, FULLSCREEN:integer, CURSOR_ZOOM:integer]
+    for (size_t i = 0; i < GESTURE_ACTION_NAMES.size(); ++i) {
+        lua_pushinteger(L, static_cast<int>(i));
+        lua_setfield(L, gestureTableIdx, GESTURE_ACTION_NAMES[i]);
+    }
+
+    lua_newtable(L);
+    lua_pushcfunction(L, hlGesture);
+    lua_setfield(L, -2, "__call");
+
+    lua_setmetatable(L, -2);
+    lua_setfield(L, -2, "gesture");
 }

--- a/src/config/lua/bindings/LuaBindingsConfigRules.cpp
+++ b/src/config/lua/bindings/LuaBindingsConfigRules.cpp
@@ -755,25 +755,19 @@ static int hlGesture(lua_State* L) {
             return Internal::configError(L, "hl.gesture: 'action' field expected to be callable, or one of hl.gesture.* constants");
         }
 
-        bool is_callable = false;
-
-        if (lua_isfunction(L, -1)) {
-            is_callable = true;
-        } else if (lua_getmetatable(L, -1)) {
-            lua_getfield(L, -1, "__call");
-            is_callable = lua_isfunction(L, -1);
-            lua_pop(L, 2);
-        }
-
-        if (is_callable) {
+        if (Internal::isLuaCallable(L, -1)) {
             lua_pushvalue(L, -1);
             functionRef = luaL_ref(L, LUA_REGISTRYINDEX);
             Lua::mgr()->registerLuaRef(functionRef);
-        } else if (!lua_isinteger(L, -1)) {
+        }
+
+        else if (!lua_isinteger(L, -1)) {
             const char* bad_type = lua_typename(L, lua_type(L, -1));
             lua_pop(L, 1);
             return Internal::configError(L, "hl.gesture: 'action' must be a callable or an hl.gesture constant (got %s)", bad_type);
         }
+
+        lua_pop(L, 1);
     }
 
     // bitch ass macro because it's kinda long to get these things and it's ugly

--- a/src/config/lua/bindings/LuaBindingsDispatcherUtils.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatcherUtils.cpp
@@ -132,13 +132,25 @@ bool Internal::pushDispatcherFunction(lua_State* L, int idx) {
     }
 
     auto* dispatcher = sc<SDispatcherRef*>(luaL_testudata(L, idx, DISPATCHER_MT));
-    if (!dispatcher || dispatcher->ref == LUA_NOREF)
+    if (dispatcher && dispatcher->ref != LUA_NOREF) {
+        lua_rawgeti(L, LUA_REGISTRYINDEX, dispatcher->ref);
+        if (lua_isfunction(L, -1))
+            return true;
+
+        lua_pop(L, 1);
+        return false;
+    }
+
+    if (!lua_getmetatable(L, idx))
         return false;
 
-    lua_rawgeti(L, LUA_REGISTRYINDEX, dispatcher->ref);
-    if (lua_isfunction(L, -1))
+    lua_getfield(L, -1, "__call");
+    if (lua_isfunction(L, -1)) {
+        lua_pop(L, 2);
+        lua_pushvalue(L, idx);
         return true;
+    }
+    lua_pop(L, 2);
 
-    lua_pop(L, 1);
     return false;
 }

--- a/src/config/lua/bindings/LuaBindingsDispatcherUtils.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatcherUtils.cpp
@@ -126,31 +126,19 @@ int Internal::wrapDispatcher(lua_State* L) {
 }
 
 bool Internal::pushDispatcherFunction(lua_State* L, int idx) {
-    if (lua_isfunction(L, idx)) {
-        lua_pushvalue(L, idx);
-        return true;
-    }
-
     auto* dispatcher = sc<SDispatcherRef*>(luaL_testudata(L, idx, DISPATCHER_MT));
-    if (dispatcher && dispatcher->ref != LUA_NOREF) {
-        lua_rawgeti(L, LUA_REGISTRYINDEX, dispatcher->ref);
-        if (lua_isfunction(L, -1))
-            return true;
+    if (!dispatcher || dispatcher->ref == LUA_NOREF) {
+        if (!Internal::isLuaCallable(L, idx))
+            return false;
 
-        lua_pop(L, 1);
-        return false;
-    }
-
-    if (!lua_getmetatable(L, idx))
-        return false;
-
-    lua_getfield(L, -1, "__call");
-    if (lua_isfunction(L, -1)) {
-        lua_pop(L, 2);
         lua_pushvalue(L, idx);
         return true;
     }
-    lua_pop(L, 2);
 
+    lua_rawgeti(L, LUA_REGISTRYINDEX, dispatcher->ref);
+    if (lua_isfunction(L, -1))
+        return true;
+
+    lua_pop(L, 1);
     return false;
 }

--- a/src/config/lua/bindings/LuaBindingsInternal.cpp
+++ b/src/config/lua/bindings/LuaBindingsInternal.cpp
@@ -580,3 +580,23 @@ bool Internal::hasTableField(lua_State* L, int tableIdx, const char* field) {
     lua_pop(L, 1);
     return true;
 }
+
+bool Internal::isLuaCallable(lua_State* L, int idx) {
+    if (lua_isfunction(L, idx))
+        return true;
+
+    if (!lua_getmetatable(L, idx))
+        return false;
+
+    lua_getfield(L, -1, "__call");
+    bool callable = lua_isfunction(L, -1);
+
+    if (!callable && lua_getmetatable(L, -1)) {
+        lua_getfield(L, -1, "__call");
+        callable = lua_isfunction(L, -1);
+        lua_pop(L, 2);
+    }
+
+    lua_pop(L, 2);
+    return callable;
+}

--- a/src/config/lua/bindings/LuaBindingsInternal.hpp
+++ b/src/config/lua/bindings/LuaBindingsInternal.hpp
@@ -184,6 +184,7 @@ namespace Config::Lua::Bindings::Internal {
     void markDispatcherTable(lua_State* L);
     int  wrapDispatcher(lua_State* L);
     bool pushDispatcherFunction(lua_State* L, int idx);
+    bool isLuaCallable(lua_State* L, int idx);
 
     template <typename T>
     SParseError parseTableField(lua_State* L, int tableIdx, const char* field, T& parser) {

--- a/src/config/lua/bindings/LuaBindingsToplevel.cpp
+++ b/src/config/lua/bindings/LuaBindingsToplevel.cpp
@@ -347,7 +347,9 @@ static int hlDispatch(lua_State* L) {
 static int hlOn(lua_State* L) {
     auto*       mgr       = sc<CConfigManager*>(lua_touserdata(L, lua_upvalueindex(1)));
     const char* eventName = luaL_checkstring(L, 1);
-    luaL_checktype(L, 2, LUA_TFUNCTION);
+
+    if (!Internal::isLuaCallable(L, 2))
+        return Internal::configError(L, "hl.on: arg #2 'callback' must be a lua callable (e.g. a function)");
 
     lua_pushvalue(L, 2);
     int        ref = luaL_ref(L, LUA_REGISTRYINDEX);
@@ -384,7 +386,8 @@ static int hlUnbind(lua_State* L) {
 static int hlTimer(lua_State* L) {
     auto* mgr = sc<CConfigManager*>(lua_touserdata(L, lua_upvalueindex(1)));
 
-    luaL_checktype(L, 1, LUA_TFUNCTION);
+    if (!Internal::isLuaCallable(L, 1))
+        return Internal::configError(L, "hl.timer: arg #1 'callback' must be a lua callable (e.g. a function)");
     luaL_checktype(L, 2, LUA_TTABLE);
 
     lua_getfield(L, 2, "timeout");

--- a/src/config/lua/bindings/LuaBindingsToplevel.cpp
+++ b/src/config/lua/bindings/LuaBindingsToplevel.cpp
@@ -134,7 +134,7 @@ static int hlBind(lua_State* L) {
         return Internal::configError(L, std::format("hl.bind: failed to parse key string: {}", res.error()));
 
     if (!Internal::pushDispatcherFunction(L, 2))
-        return Internal::configError(L, "hl.bind: dispatcher must be a dispatcher (e.g. hl.dsp.window.close()) or a lua function");
+        return Internal::configError(L, "hl.bind: dispatcher must be a callable object (e.g. a function, or hl.dsp.window.close())");
 
     if (kb.catchAll && mgr->m_currentSubmap.empty())
         return Internal::configError(L, "hl.bind: catchall keybinds are only allowed in submaps.");
@@ -321,7 +321,7 @@ static int hlExecCmd(lua_State* L) {
 
 static int hlDispatch(lua_State* L) {
     if (!Internal::pushDispatcherFunction(L, 1))
-        return Internal::configError(L, "hl.dispatch: expected a dispatcher (e.g. hl.dsp.window.close())");
+        return Internal::configError(L, "hl.dispatch: expected a function or callable object (e.g. hl.dsp.window.close())");
 
     int status = LUA_OK;
     if (auto* mgr = CConfigManager::fromLuaState(L); mgr)

--- a/src/config/lua/types/LuaConfigGestureAction.hpp
+++ b/src/config/lua/types/LuaConfigGestureAction.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#define GESTURE_ACTIONS_LIST(X)                                                                                                                                                    \
+    X(UNSET)                                                                                                                                                                       \
+    X(WORKSPACE)                                                                                                                                                                   \
+    X(RESIZE)                                                                                                                                                                      \
+    X(MOVE)                                                                                                                                                                        \
+    X(SPECIAL)                                                                                                                                                                     \
+    X(CLOSE)                                                                                                                                                                       \
+    X(FLOAT)                                                                                                                                                                       \
+    X(FULLSCREEN)                                                                                                                                                                  \
+    X(CURSOR_ZOOM)                                                                                                                                                                 \
+    X(SCROLL_MOVE)
+
+enum class eGestureAction : std::uint8_t {
+#define AS_ENUM_VARIANT(name) name,
+    GESTURE_ACTIONS_LIST(AS_ENUM_VARIANT)
+#undef AS_ENUM_VARIANT
+    COUNT
+};
+
+inline constexpr std::array<const char*, static_cast<size_t>(eGestureAction::COUNT)> GESTURE_ACTION_NAMES = {
+#define AS_STRING_LITERAL(name) #name,
+    GESTURE_ACTIONS_LIST(AS_STRING_LITERAL)
+#undef AS_STRING_LITERAL
+};


### PR DESCRIPTION
## Allow callable values (`__call`) as dispatchers in `hl.bind` and `hl.dispatch`

Previously, `hl.bind` only accepted the following:
- Lua functions
- native dispatcher userdata (`hl.dsp.*`)

This changes dispatcher resolution to also accept any value with a `__call` metamethod. The reason behind is to make a declarative way to run commands, avoiding wrapping them in dispatchers or helper functions

```lua
-- From only
local function bash (s) return function () hl.exec_cmd (s) end end
hl.bind ("XF86AudioPrev", bash ("playerctl previous"))
hl.bind ("XF86AudioNext", hl.dsp.exec_cmd ("playerctl next"))

-- now also allow this
getmetatable ("").__call = hl.exec_cmd
hl.bind ("META+L", "dms ipc call lock lock")
```

This also works with `hyprctl`

```bash
hyprctl dispatch "'www-browser'" # somewhat pointless for my example
```

There's not much behavior change on this change; aside of maybe changing Lua stubs, this was not implemented on gestures, as gestures use string configurations. 

## [Breaking] Drop string actions in favor of runtime values

Previously `hl.gesture(spec)` action accepted:
- Lua functions
- Strings, named actions

This changes from strings to runtime values in a callable table `hl.gesture`

```lua
getmetatable ("").__call = hl.exec_cmd
local gestures = {
  {
    fingers = 3,
    direction = "horizontal",
    action = hl.gesture.WORKSPACE, -- previous "workspace"
  },
  {
    fingers = 3,
    direction = "vertical",
    action = "notify send 'Hi from Lua' 'I just swiped on my trackpad!'" -- since __call is set
  },
  {
    fingers = 2,
    direction = "vertical",
    action = function ()
      hl.notification.create ({ text = "Bruh", duration = 60000 })
    end
  }
}

for _, g in ipairs (gestures) then
  hl.gesture (g)
end
```

### Changes on generateLuaStubs.py

They only help for fields added from a loop, explicit fields

```cpp
lua_newtable(L);
//! @fields: [FOO:string, BAR:integer|string, BAZ:table]
```

Callable tables had the `---@operator call:<signature>`, added the signature after type, since LSP didn't pick it up correctly

PR is ready to merge, no known bugs