### PR TITLE
fix: use hasFullscreen() in workspace swipe gesture for scrolling layout compatibility

### DIFF
--- a/src/managers/input/UnifiedWorkspaceSwipeGesture.cpp
+++ b/src/managers/input/UnifiedWorkspaceSwipeGesture.cpp
@@ -23,7 +23,7 @@ void CUnifiedWorkspaceSwipeGesture::begin() {
     m_avgSpeed       = 0;
     m_speedPoints    = 0;
 
-    if (PWORKSPACE->m_hasFullscreenWindow) {
+    if (PWORKSPACE->hasFullscreen()) {
         for (auto const& ls : Desktop::focusState()->monitor()->m_layerSurfaceLayers[2]) {
             *ls->m_alpha = 1.f;
         }
@@ -306,6 +306,6 @@ void CUnifiedWorkspaceSwipeGesture::end() {
 
     // apply alpha
     for (auto const& ls : Desktop::focusState()->monitor()->m_layerSurfaceLayers[2]) {
-        *ls->m_alpha = pSwitchedTo->m_hasFullscreenWindow && pSwitchedTo->m_fullscreenMode == FSMODE_FULLSCREEN ? 0.f : 1.f;
+        *ls->m_alpha = pSwitchedTo->hasFullscreen() && pSwitchedTo->m_fullscreenMode != FSMODE_MAXIMIZED ? 0.f : 1.f;
     }
 }


### PR DESCRIPTION
## Description

When using scrolling layout (`tiledLayout: scrolling`) with a TOP-layer bar (e.g. Waybar configured with `"layer": "top"`), the bar becomes visible on workspace switch via touchpad swipe gesture even when the target workspace has a fullscreen window.

### Root Cause

The workspace swipe gesture code in `UnifiedWorkspaceSwipeGesture.cpp` uses `m_hasFullscreenWindow` directly to determine layer-surface alpha. In scrolling layout, the layout algorithm handles fullscreen requests (`LAYOUT_HANDLED_FULLSCREEN`), causing `setWindowFullscreenState()` in `Compositor.cpp` to reset `m_hasFullscreenWindow = false` and `m_fullscreenMode = FSMODE_NONE`.

Since the swipe gesture checks `m_hasFullscreenWindow` (which is false) instead of `hasFullscreen()` (which also checks `layoutFullscreenCoversMonitor()`), the bar alpha is always set to 1.0 (fully visible) even when the target workspace has a fullscreen window that covers the entire monitor.

### Changes

Two lines in `src/managers/input/UnifiedWorkspaceSwipeGesture.cpp`:

1. **`begin()`** — Replace `PWORKSPACE->m_hasFullscreenWindow` with `PWORKSPACE->hasFullscreen()` so that layout-handled fullscreen is correctly detected when starting a swipe.

2. **`end()`** — Replace `pSwitchedTo->m_hasFullscreenWindow && pSwitchedTo->m_fullscreenMode == FSMODE_FULLSCREEN` with `pSwitchedTo->hasFullscreen() && pSwitchedTo->m_fullscreenMode != FSMODE_MAXIMIZED` to match the semantics of `setFullscreenFadeAnimation()` in `DesktopAnimationManager.cpp` (which also uses `ws->m_fullscreenMode != FSMODE_MAXIMIZED`).

### AI-Generated Note

This PR was generated by an AI assistant and should be used as a reference/template for producing a proper fix. The analysis and root cause identification are accurate, but the implementation has not been tested end-to-end and should not be merged as-is. Please review and validate before any merge.

### Related

PR #14425 introduced `hasFullscreen()` but only updated `Monitor.cpp` call sites. The swipe gesture code was missed.