### PR TITLE
Pass lua includes to hyprtester plugin

### DIFF
--- a/hyprtester/CMakeLists.txt
+++ b/hyprtester/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(hyprtester ${SRCFILES})
 add_custom_command(
   TARGET hyprtester
   POST_BUILD
-  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/plugin/build.sh
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/plugin/build.sh "${LUA_INCLUDE_DIRS}"
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/plugin)
 
 target_link_libraries(hyprtester PUBLIC PkgConfig::hyprtester_deps)

--- a/hyprtester/plugin/Makefile
+++ b/hyprtester/plugin/Makefile
@@ -8,7 +8,7 @@ TARGET = hyprtestplugin.so
 all: $(TARGET)
 
 $(TARGET): $(SRC)
-	$(CXX) $(CXXFLAGS) -I../.. -I../../protocols $(INCLUDES) $^ $> -o $@ $(LIBS) -O2
+	$(CXX) $(CXXFLAGS) -I../.. -I../../protocols $(INCLUDES) -I${LUA_INCLUDES} $^ $> -o $@ $(LIBS) -O2
 
 clean:
 	rm -f ./$(TARGET)

--- a/hyprtester/plugin/build.sh
+++ b/hyprtester/plugin/build.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 make clean
-make all
+make all LUA_INCLUDES="${1}"


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Passes lua includes to hyprtester plugin makefile so that `make debug` doesn't fail with missing `lua.h`.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Not sure why it wasn't noticed/fixed earlier and whether that's the correct way to do it.

#### Is it ready for merging, or does it need work?
Ready