### PR TITLE
Fix inverted scrollwheel direction in keybinds

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -425,7 +425,7 @@ bool CKeybindManager::onAxisEvent(const IPointer::SAxisEvent& e, SP<IPointer> po
 
     bool found = false;
     if (e.source == WL_POINTER_AXIS_SOURCE_WHEEL && e.axis == WL_POINTER_AXIS_VERTICAL_SCROLL) {
-        if (e.delta < 0)
+        if (e.delta > 0)
             found = !handleKeybinds(MODS, SPressedKeyWithMods{.keyName = "mouse_down"}, true, nullptr, pointer).passEvent;
         else
             found = !handleKeybinds(MODS, SPressedKeyWithMods{.keyName = "mouse_up"}, true, nullptr, pointer).passEvent;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
```
hl.bind("mouse_down", function ()
    hl.notification.create({text = "Mouse down", timeout = 1000})
end)
hl.bind("mouse_up", function ()
    hl.notification.create({text = "Mouse up", timeout = 1000})
end)
```
The above binds are an easy way to show the issue: when scrolling down, you'll see the "Mouse up" notification and vice versa. The if statement needs to be inverted.

Checking with `wev`, scrolling down yields: 
```
[        15:      wl_pointer] axis: time: 14953488; axis: 0 (vertical), value: 15.000000
```
so a positive delta.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
This has been broken for 4 years (from its initial implementation in https://github.com/hyprwm/Hyprland/pull/265) so this might break some people's configs.


#### Is it ready for merging, or does it need work?
Ready. I didn't test it though but this seems pretty trivial.

