### PR TITLE
hyprpm: allow distro packagers to provide extra cflags for building plugins

### DIFF
--- a/hyprpm/src/core/PluginManager.cpp
+++ b/hyprpm/src/core/PluginManager.cpp
@@ -313,8 +313,10 @@ bool CPluginManager::addNewPluginRepo(const std::string& url, const std::string&
 
         progress.printMessageAbove(infoString("Building {}", p.name));
 
+        const auto env = getPluginBuildEnv();
+
         for (auto const& bs : p.buildSteps) {
-            const auto CMD_RAW = nixDevelopIfNeeded(std::format("cd {} && PKG_CONFIG_PATH=\"{}\" {}", m_szWorkingPluginDirectory, getPkgConfigPath(), bs), HLVER);
+            const auto CMD_RAW = nixDevelopIfNeeded(std::format("cd {} && {} {}", m_szWorkingPluginDirectory, env, bs), HLVER);
 
             if (!CMD_RAW) {
                 progress.printMessageAbove(failureString("Failed to build {}: {}", p.name, CMD_RAW.error()));
@@ -766,8 +768,10 @@ bool CPluginManager::updatePlugins(bool forceUpdateAll) {
 
             progress.printMessageAbove(infoString("Building {}", p.name));
 
+            const auto env = getPluginBuildEnv();
+
             for (auto const& bs : p.buildSteps) {
-                const auto CMD_RAW = nixDevelopIfNeeded(std::format("cd {} && PKG_CONFIG_PATH=\"{}\" {}", m_szWorkingPluginDirectory, getPkgConfigPath(), bs), HLVER);
+                const auto CMD_RAW = nixDevelopIfNeeded(std::format("cd {} && {} {}", m_szWorkingPluginDirectory, env, bs), HLVER);
 
                 if (!CMD_RAW) {
                     progress.printMessageAbove(failureString("Failed to build {}: {}", p.name, CMD_RAW.error()));
@@ -1033,6 +1037,22 @@ bool CPluginManager::hasDeps() {
     }
 
     return hasAllDeps;
+}
+
+std::string CPluginManager::getPluginBuildEnv() {
+    std::string env = std::format("PKG_CONFIG_PATH=\"{}\"", getPkgConfigPath());
+
+#if defined(HYPRPM_EXTRA_CFLAGS)
+    if (std::string_view{HYPRPM_EXTRA_CFLAGS}.size() > 0)
+        env += std::format(" CFLAGS=\"{} $CFLAGS\"", HYPRPM_EXTRA_CFLAGS);
+#endif
+
+#if defined(HYPRPM_EXTRA_CXXFLAGS)
+    if (std::string_view{HYPRPM_EXTRA_CXXFLAGS}.size() > 0)
+        env += std::format(" CXXFLAGS=\"{} $CXXFLAGS\"", HYPRPM_EXTRA_CXXFLAGS);
+#endif
+
+    return env;
 }
 
 const std::string& CPluginManager::getPkgConfigPath() {

--- a/hyprpm/src/core/PluginManager.hpp
+++ b/hyprpm/src/core/PluginManager.hpp
@@ -66,6 +66,7 @@ class CPluginManager {
 
     void                   notify(const eNotifyIcons icon, uint32_t color, int durationMs, const std::string& message);
 
+    std::string            getPluginBuildEnv();
     const std::string&     getPkgConfigPath();
 
     bool                   hasDeps();


### PR DESCRIPTION


<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

This PR allows distro packagers to inject extra CFLAGS when `hyprpm` is building plugins.

I make this because `hyprpm` cannot build many plugins on Gentoo. For example, `hyprbars` uses `#include <lua.h>`, but does not use `pkg-config` to search `lua` properly. On many systems, like Gentoo and Debian, multiple versions installing  of Lua is allowed, and `/usr/include/lua.{c,cpp}` does not exist. The headers are inside `/usr/include/luax.y/`, so they are not visible globally.

Since versioned include directories can happen on many distros, I think it's good to add this optional compile-time macro for packagers to append extra `CFLAGS` and `CXXFLAGS` to `hyprpm` plugin build steps.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Tested on my Gentoo.

#### Is it ready for merging, or does it need work?

It should be ready.
