### PR TITLE
Feedback fixes

### DIFF
--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -580,6 +580,10 @@ std::vector<SP<IValue>> Values::getConfigValues() {
         MS<Int>("render:non_shader_cm_interop", "non_shader_cm interaction with ctm proto (hyprsunset and similar).", 2,
                 {.min = 0, .max = 2, .map = OptionMap{{"disable", 0}, {"enable", 1}, {"auto", 2}}}),
         MS<Int>("render:fp16_sdr_tf", "Internal workbuffer transfer function for fp16 in SDR mode", 0, {.min = 0, .max = 1, .map = OptionMap{{"monitor", 0}, {"linear", 1}}}),
+        MS<Int>("render:not_shown_fifo_lock",
+                "Control fifo locking for not shown surfaces. always - use fifo lock for any surface, ignore_unfocused - ignore render_unfocused windows, never - skip locking "
+                "invisible surfaces",
+                0, {.min = 0, .max = 2, .map = OptionMap{{"always", 0}, {"ignore_unfocused", 1}, {"never", 2}}}),
 
         /*
          * cursor:

--- a/src/protocols/Fifo.cpp
+++ b/src/protocols/Fifo.cpp
@@ -6,6 +6,7 @@
 #include "../state/MonitorState.hpp"
 #include "../desktop/view/View.hpp"
 #include "../render/Renderer.hpp"
+#include <algorithm>
 #include <hyprutils/memory/WeakPtr.hpp>
 
 CFifoResource::CFifoResource(UP<CWpFifoV1>&& resource_, SP<CWLSurfaceResource> surface) : m_resource(std::move(resource_)), m_surface(surface) {
@@ -68,7 +69,10 @@ CFifoResource::CFifoResource(UP<CWpFifoV1>&& resource_, SP<CWLSurfaceResource> s
                 const auto& view = m_surface->m_hlSurface->view();
                 if (view) {
                     const auto& window    = view->type() == Desktop::View::VIEW_TYPE_WINDOW ? dynamicPointerCast<Desktop::View::CWindow>(view) : nullptr;
-                    const bool  isVisible = (view && view->visible() && (!window || g_pHyprRenderer->shouldRenderWindow(window)));
+                    const bool  isVisible = (view && view->visible() && //
+                                             (!window || std::ranges::any_of(State::monitorState()->monitors(), [window](const auto& mon) {
+                                                return g_pHyprRenderer->shouldRenderWindow(window, mon);
+                                             })));
                     if (isVisible)
                         shouldLock = true;
                     else if (*PINVIS == 2) // never

--- a/src/protocols/Fifo.cpp
+++ b/src/protocols/Fifo.cpp
@@ -63,7 +63,7 @@ CFifoResource::CFifoResource(UP<CWpFifoV1>&& resource_, SP<CWLSurfaceResource> s
 
         // only lock once its mapped and visible
         if (m_surface->m_mapped) {
-            bool shouldLock = *PINVIS == 0; // always
+            bool shouldLock = *PINVIS == 0 || !m_surface->m_hlSurface; // always && unknown
             if (!shouldLock && m_surface->m_hlSurface) {
                 const auto& view = m_surface->m_hlSurface->view();
                 if (view) {
@@ -77,7 +77,8 @@ CFifoResource::CFifoResource(UP<CWpFifoV1>&& resource_, SP<CWLSurfaceResource> s
                         shouldLock = false; // ignore render_unfocused
                     else
                         shouldLock = true;
-                }
+                } else
+                    shouldLock = true;
             }
             if (shouldLock)
                 m_surface->m_stateQueue.lock(state, LOCK_REASON_FIFO);

--- a/src/protocols/Fifo.cpp
+++ b/src/protocols/Fifo.cpp
@@ -48,7 +48,8 @@ CFifoResource::CFifoResource(UP<CWpFifoV1>&& resource_, SP<CWLSurfaceResource> s
         if (!state || !state->surfaceLocked)
             return;
 
-        static const auto PPEND = CConfigValue<Config::INTEGER>("debug:fifo_pending_workaround");
+        static const auto PPEND  = CConfigValue<Config::INTEGER>("debug:fifo_pending_workaround");
+        static const auto PINVIS = CConfigValue<Hyprlang::INT>("render:not_shown_fifo_lock");
 
         //#TODO:
         // this feels wrong, but if we have no pending frames, presented might never come because
@@ -61,10 +62,24 @@ CFifoResource::CFifoResource(UP<CWpFifoV1>&& resource_, SP<CWLSurfaceResource> s
             return;
 
         // only lock once its mapped and visible
-        if (m_surface->m_mapped && m_surface->m_hlSurface) {
-            const auto& view = m_surface->m_hlSurface->view();
-            if (view && view->visible() &&
-                (view->type() != Desktop::View::VIEW_TYPE_WINDOW || g_pHyprRenderer->shouldRenderWindow(dynamicPointerCast<Desktop::View::CWindow>(view))))
+        if (m_surface->m_mapped) {
+            bool shouldLock = *PINVIS == 0; // always
+            if (!shouldLock && m_surface->m_hlSurface) {
+                const auto& view = m_surface->m_hlSurface->view();
+                if (view) {
+                    const auto& window    = view->type() == Desktop::View::VIEW_TYPE_WINDOW ? dynamicPointerCast<Desktop::View::CWindow>(view) : nullptr;
+                    const bool  isVisible = (view && view->visible() && (!window || g_pHyprRenderer->shouldRenderWindow(window)));
+                    if (isVisible)
+                        shouldLock = true;
+                    else if (*PINVIS == 2) // never
+                        shouldLock = false;
+                    else if (window && window->m_ruleApplicator->renderUnfocused().valueOr(false))
+                        shouldLock = false; // ignore render_unfocused
+                    else
+                        shouldLock = true;
+                }
+            }
+            if (shouldLock)
                 m_surface->m_stateQueue.lock(state, LOCK_REASON_FIFO);
         }
     });

--- a/src/protocols/Fifo.cpp
+++ b/src/protocols/Fifo.cpp
@@ -4,6 +4,9 @@
 #include "../output/Monitor.hpp"
 #include "../event/EventBus.hpp"
 #include "../state/MonitorState.hpp"
+#include "../desktop/view/View.hpp"
+#include "../render/Renderer.hpp"
+#include <hyprutils/memory/WeakPtr.hpp>
 
 CFifoResource::CFifoResource(UP<CWpFifoV1>&& resource_, SP<CWLSurfaceResource> surface) : m_resource(std::move(resource_)), m_surface(surface) {
     if UNLIKELY (!m_resource->resource())
@@ -57,9 +60,13 @@ CFifoResource::CFifoResource(UP<CWpFifoV1>&& resource_, SP<CWLSurfaceResource> s
         if (!state->fifoScheduled)
             return;
 
-        // only lock once its mapped.
-        if (m_surface->m_mapped)
-            m_surface->m_stateQueue.lock(state, LOCK_REASON_FIFO);
+        // only lock once its mapped and visible
+        if (m_surface->m_mapped && m_surface->m_hlSurface) {
+            const auto& view = m_surface->m_hlSurface->view();
+            if (view && view->visible() &&
+                (view->type() != Desktop::View::VIEW_TYPE_WINDOW || g_pHyprRenderer->shouldRenderWindow(dynamicPointerCast<Desktop::View::CWindow>(view))))
+                m_surface->m_stateQueue.lock(state, LOCK_REASON_FIFO);
+        }
     });
 }
 

--- a/src/protocols/PresentationTime.cpp
+++ b/src/protocols/PresentationTime.cpp
@@ -201,11 +201,3 @@ void CPresentationProtocol::discardFeedbacksForSurface(WP<CWLSurfaceResource> su
 bool CPresentationProtocol::hasPendingFeedbacks() const {
     return !m_feedbacks.empty();
 }
-
-WP<CPresentationFeedback> CPresentationProtocol::getFeedback(WP<CWLSurfaceResource> forSurface) {
-    const auto FB = std::ranges::find_if(m_feedbacks, [forSurface](const auto& fb) { return fb->m_surface == forSurface; });
-    if (FB == m_feedbacks.end())
-        return nullptr;
-
-    return *FB;
-}

--- a/src/protocols/PresentationTime.cpp
+++ b/src/protocols/PresentationTime.cpp
@@ -164,7 +164,7 @@ void CPresentationProtocol::onPresented(PHLMONITOR pMonitor, const timespec& whe
     }
 
     std::erase_if(m_feedbacks, [](const auto& other) { return !other->m_surface || other->m_done; });
-    std::erase_if(m_queue, [pMonitor](const auto& other) { return !other->m_surface || other->m_monitor == pMonitor || !other->m_monitor || other->m_done; });
+    std::erase_if(m_queue, [pMonitor](const auto& other) { return !other->m_surface || other->m_monitor == pMonitor || !other->m_monitor; });
 }
 
 void CPresentationProtocol::queueData(UP<CQueuedPresentationData>&& data) {
@@ -200,4 +200,12 @@ void CPresentationProtocol::discardFeedbacksForSurface(WP<CWLSurfaceResource> su
 
 bool CPresentationProtocol::hasPendingFeedbacks() const {
     return !m_feedbacks.empty();
+}
+
+WP<CPresentationFeedback> CPresentationProtocol::getFeedback(WP<CWLSurfaceResource> forSurface) {
+    const auto FB = std::ranges::find_if(m_feedbacks, [forSurface](const auto& fb) { return fb->m_surface == forSurface; });
+    if (FB == m_feedbacks.end())
+        return nullptr;
+
+    return *FB;
 }

--- a/src/protocols/PresentationTime.hpp
+++ b/src/protocols/PresentationTime.hpp
@@ -52,14 +52,13 @@ class CPresentationProtocol : public IWaylandProtocol {
   public:
     CPresentationProtocol(const wl_interface* iface, const int& ver, const std::string& name);
 
-    virtual void              bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id);
+    virtual void bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id);
 
-    void                      onPresented(PHLMONITOR pMonitor, const timespec& when, uint32_t untilRefreshNs, uint64_t seq, uint32_t reportedFlags);
-    void                      queueData(UP<CQueuedPresentationData>&& data);
-    void                      discardFeedbacks(std::vector<WP<CPresentationFeedback>>& feedbacks);
-    void                      discardFeedbacksForSurface(WP<CWLSurfaceResource> surface);
-    bool                      hasPendingFeedbacks() const;
-    WP<CPresentationFeedback> getFeedback(WP<CWLSurfaceResource> forSurface);
+    void         onPresented(PHLMONITOR pMonitor, const timespec& when, uint32_t untilRefreshNs, uint64_t seq, uint32_t reportedFlags);
+    void         queueData(UP<CQueuedPresentationData>&& data);
+    void         discardFeedbacks(std::vector<WP<CPresentationFeedback>>& feedbacks);
+    void         discardFeedbacksForSurface(WP<CWLSurfaceResource> surface);
+    bool         hasPendingFeedbacks() const;
 
   private:
     void onManagerResourceDestroy(wl_resource* res);

--- a/src/protocols/PresentationTime.hpp
+++ b/src/protocols/PresentationTime.hpp
@@ -20,8 +20,6 @@ class CQueuedPresentationData {
     void presented();
     void discarded();
 
-    bool m_done = false;
-
   private:
     bool                                   m_wasPresented = false;
     bool                                   m_zeroCopy     = false;
@@ -54,13 +52,14 @@ class CPresentationProtocol : public IWaylandProtocol {
   public:
     CPresentationProtocol(const wl_interface* iface, const int& ver, const std::string& name);
 
-    virtual void bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id);
+    virtual void              bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id);
 
-    void         onPresented(PHLMONITOR pMonitor, const timespec& when, uint32_t untilRefreshNs, uint64_t seq, uint32_t reportedFlags);
-    void         queueData(UP<CQueuedPresentationData>&& data);
-    void         discardFeedbacks(std::vector<WP<CPresentationFeedback>>& feedbacks);
-    void         discardFeedbacksForSurface(WP<CWLSurfaceResource> surface);
-    bool         hasPendingFeedbacks() const;
+    void                      onPresented(PHLMONITOR pMonitor, const timespec& when, uint32_t untilRefreshNs, uint64_t seq, uint32_t reportedFlags);
+    void                      queueData(UP<CQueuedPresentationData>&& data);
+    void                      discardFeedbacks(std::vector<WP<CPresentationFeedback>>& feedbacks);
+    void                      discardFeedbacksForSurface(WP<CWLSurfaceResource> surface);
+    bool                      hasPendingFeedbacks() const;
+    WP<CPresentationFeedback> getFeedback(WP<CWLSurfaceResource> forSurface);
 
   private:
     void onManagerResourceDestroy(wl_resource* res);

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -795,7 +795,8 @@ void CWLSurfaceResource::updateCursorShm(CRegion damage) {
 void CWLSurfaceResource::presentFeedback(const Time::steady_tp& when, PHLMONITOR pMonitor, bool discarded) {
     frame(when);
 
-    if (!PROTO::presentation->getFeedback(m_self))
+    // if it's empty then CPresentationProtocol::m_feedbacks doesn't contain any feedback listeners for this surface and frame
+    if (m_current.presentationFeedbacks.empty())
         return;
 
     auto FEEDBACK = makeUnique<CQueuedPresentationData>(m_self.lock(), std::move(m_current.presentationFeedbacks));

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -795,6 +795,9 @@ void CWLSurfaceResource::updateCursorShm(CRegion damage) {
 void CWLSurfaceResource::presentFeedback(const Time::steady_tp& when, PHLMONITOR pMonitor, bool discarded) {
     frame(when);
 
+    if (!PROTO::presentation->getFeedback(m_self))
+        return;
+
     auto FEEDBACK = makeUnique<CQueuedPresentationData>(m_self.lock(), std::move(m_current.presentationFeedbacks));
     FEEDBACK->attachMonitor(pMonitor);
     if (discarded)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Removed unused `CQueuedPresentationData::m_done`.
Avoid queueing unneeded presentation feedbacks.
Adds `render:not_shown_fifo_lock` to control fifo locking for invisible surfaces. 0 - always (current behavior), 1- ignore_unfocused (don't lock render_unfocused windows), 2 - never (don't lock any invisible surface) https://github.com/hyprwm/hyprland-wiki/pull/1599
> If the surface is not being updated by the compositor (off-screen, occluded) the compositor may ignore the constraint.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Doesn't seem to break anything but needs more testing. The presentation feedback part should solve potential issues with #14718

#### Is it ready for merging, or does it need work?
Ready