### PR TITLE
layersurface: inform layer surfaces of scale changes

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -3068,6 +3068,28 @@ void CCompositor::onNewMonitor(SP<Aquamarine::IOutput> output) {
         }
     }
 
+    for (auto const& lsl : PNEWMONITOR->m_layerSurfaceLayers) {
+        for (auto const& ls : lsl) {
+            if (!ls->aliveAndVisible())
+                continue;
+
+            auto SURF = ls->m_layerSurface->m_surface.lock();
+            if (!SURF)
+                continue;
+
+            SURF->breadthfirst(
+                [PNEWMONITOR](SP<CWLSurfaceResource> s, const Vector2D& offset, void* d) {
+                    const auto PSURFACE = CWLSurface::fromResource(s);
+                    if (PSURFACE && PSURFACE->m_lastScaleFloat == PNEWMONITOR->m_scale)
+                        return;
+
+                    g_pCompositor->setPreferredScaleForSurface(s, PNEWMONITOR->m_scale);
+                    g_pCompositor->setPreferredTransformForSurface(s, PNEWMONITOR->m_transform);
+                },
+                nullptr);
+        }
+    }
+
     g_pHyprRenderer->damageMonitor(PNEWMONITOR);
     PNEWMONITOR->m_frameScheduler->onFrame();
 

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -3064,31 +3064,10 @@ void CCompositor::onNewMonitor(SP<Aquamarine::IOutput> output) {
     for (auto const& w : g_pCompositor->m_windows) {
         if (w->m_monitor == PNEWMONITOR) {
             w->m_lastSurfaceMonitorID = MONITOR_INVALID;
-            w->updateSurfaceScaleTransformDetails();
         }
     }
 
-    for (auto const& lsl : PNEWMONITOR->m_layerSurfaceLayers) {
-        for (auto const& ls : lsl) {
-            if (!ls->aliveAndVisible())
-                continue;
-
-            auto SURF = ls->m_layerSurface->m_surface.lock();
-            if (!SURF)
-                continue;
-
-            SURF->breadthfirst(
-                [PNEWMONITOR](SP<CWLSurfaceResource> s, const Vector2D& offset, void* d) {
-                    const auto PSURFACE = CWLSurface::fromResource(s);
-                    if (PSURFACE && PSURFACE->m_lastScaleFloat == PNEWMONITOR->m_scale)
-                        return;
-
-                    g_pCompositor->setPreferredScaleForSurface(s, PNEWMONITOR->m_scale);
-                    g_pCompositor->setPreferredTransformForSurface(s, PNEWMONITOR->m_transform);
-                },
-                nullptr);
-        }
-    }
+    PNEWMONITOR->updateSurfaceScaleTransformDetails();
 
     g_pHyprRenderer->damageMonitor(PNEWMONITOR);
     PNEWMONITOR->m_frameScheduler->onFrame();

--- a/src/desktop/view/LayerSurface.cpp
+++ b/src/desktop/view/LayerSurface.cpp
@@ -219,8 +219,7 @@ void CLayerSurface::onMap() {
     g_pEventManager->postEvent(SHyprIPCEvent{.event = "openlayer", .data = m_namespace});
     Event::bus()->m_events.layer.opened.emit(m_self.lock());
 
-    g_pCompositor->setPreferredScaleForSurface(m_wlSurface->resource(), PMONITOR->m_scale);
-    g_pCompositor->setPreferredTransformForSurface(m_wlSurface->resource(), PMONITOR->m_transform);
+    updateSurfaceScaleTransformDetails();
 }
 
 void CLayerSurface::onUnmap() {
@@ -414,8 +413,7 @@ void CLayerSurface::onCommit() {
 
     g_pHyprRenderer->damageSurface(m_wlSurface->resource(), m_position.x, m_position.y);
 
-    g_pCompositor->setPreferredScaleForSurface(m_wlSurface->resource(), PMONITOR->m_scale);
-    g_pCompositor->setPreferredTransformForSurface(m_wlSurface->resource(), PMONITOR->m_transform);
+    updateSurfaceScaleTransformDetails();
 }
 
 bool CLayerSurface::isFadedOut() {
@@ -446,4 +444,30 @@ pid_t CLayerSurface::getPID() {
     wl_client_get_credentials(m_layerSurface->m_surface->getResource()->client(), &PID, nullptr, nullptr);
 
     return PID;
+}
+
+void CLayerSurface::updateSurfaceScaleTransformDetails() {
+    if (!aliveAndVisible() || g_pCompositor->m_unsafeState)
+        return;
+
+    const auto PMONITOR = m_monitor.lock();
+
+    if (!PMONITOR)
+        return;
+
+    auto surf = m_layerSurface->m_surface.lock();
+
+    if (!surf)
+        return;
+
+    surf->breadthfirst(
+        [PMONITOR](SP<CWLSurfaceResource> s, const Vector2D& offset, void* d) {
+            const auto PSURFACE = CWLSurface::fromResource(s);
+            if (PSURFACE && PSURFACE->m_lastScaleFloat == PMONITOR->m_scale)
+                return;
+
+            g_pCompositor->setPreferredScaleForSurface(s, PMONITOR->m_scale);
+            g_pCompositor->setPreferredTransformForSurface(s, PMONITOR->m_transform);
+        },
+        nullptr);
 }

--- a/src/desktop/view/LayerSurface.hpp
+++ b/src/desktop/view/LayerSurface.hpp
@@ -63,6 +63,7 @@ namespace Desktop::View {
         SP<Render::IFramebuffer>                m_snapshotFB;
 
         pid_t                                   getPID();
+        void                                    updateSurfaceScaleTransformDetails();
 
         void                                    onDestroy();
         void                                    onMap();

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -58,6 +58,7 @@ using namespace Hyprutils::Utils;
 using namespace Hyprutils::OS;
 using enum NContentType::eContentType;
 using namespace NColorManagement;
+using namespace Desktop::View;
 using namespace Render::GL;
 using namespace Monitor;
 
@@ -1114,7 +1115,30 @@ bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule, bool force)
         for (auto const& w : g_pCompositor->m_windows) {
             w->updateSurfaceScaleTransformDetails();
         }
+
+        for (auto const& lsl : m_layerSurfaceLayers) {
+            for (auto const& ls : lsl) {
+                if (!ls->aliveAndVisible())
+                    continue;
+
+                auto SURF = ls->m_layerSurface->m_surface.lock();
+                if (!SURF)
+                    continue;
+
+                SURF->breadthfirst(
+                    [this](SP<CWLSurfaceResource> s, const Vector2D& offset, void* d) {
+                        const auto PSURFACE = CWLSurface::fromResource(s);
+                        if (PSURFACE && PSURFACE->m_lastScaleFloat == m_scale)
+                            return;
+
+                        g_pCompositor->setPreferredScaleForSurface(s, m_scale);
+                        g_pCompositor->setPreferredTransformForSurface(s, m_transform);
+                    },
+                    nullptr);
+            }
+        }
     }
+
     // updato us
     g_pHyprRenderer->arrangeLayersForMonitor(m_id);
 

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1875,23 +1875,7 @@ void CMonitor::updateSurfaceScaleTransformDetails() {
 
     for (auto const& lsl : m_layerSurfaceLayers) {
         for (auto const& ls : lsl) {
-            if (!ls->aliveAndVisible())
-                continue;
-
-            auto surf = ls->m_layerSurface->m_surface.lock();
-            if (!surf)
-                continue;
-
-            surf->breadthfirst(
-                [this](SP<CWLSurfaceResource> s, const Vector2D& offset, void* d) {
-                    const auto PSURFACE = CWLSurface::fromResource(s);
-                    if (PSURFACE && PSURFACE->m_lastScaleFloat == m_scale)
-                        return;
-
-                    g_pCompositor->setPreferredScaleForSurface(s, m_scale);
-                    g_pCompositor->setPreferredTransformForSurface(s, m_transform);
-                },
-                nullptr);
+            ls->updateSurfaceScaleTransformDetails();
         }
     }
 }

--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -1109,35 +1109,7 @@ bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule, bool force)
 
     updateVCGTRamps();
 
-    // Set scale for all surfaces on this monitor, needed for some clients
-    // but not on unsafe state to avoid crashes
-    if (!g_pCompositor->m_unsafeState) {
-        for (auto const& w : g_pCompositor->m_windows) {
-            w->updateSurfaceScaleTransformDetails();
-        }
-
-        for (auto const& lsl : m_layerSurfaceLayers) {
-            for (auto const& ls : lsl) {
-                if (!ls->aliveAndVisible())
-                    continue;
-
-                auto SURF = ls->m_layerSurface->m_surface.lock();
-                if (!SURF)
-                    continue;
-
-                SURF->breadthfirst(
-                    [this](SP<CWLSurfaceResource> s, const Vector2D& offset, void* d) {
-                        const auto PSURFACE = CWLSurface::fromResource(s);
-                        if (PSURFACE && PSURFACE->m_lastScaleFloat == m_scale)
-                            return;
-
-                        g_pCompositor->setPreferredScaleForSurface(s, m_scale);
-                        g_pCompositor->setPreferredTransformForSurface(s, m_transform);
-                    },
-                    nullptr);
-            }
-        }
-    }
+    updateSurfaceScaleTransformDetails();
 
     // updato us
     g_pHyprRenderer->arrangeLayersForMonitor(m_id);
@@ -1890,6 +1862,38 @@ uint8_t CMonitor::isTearingBlocked(bool full) {
         reasons |= TC_WINDOW;
 
     return reasons;
+}
+
+void CMonitor::updateSurfaceScaleTransformDetails() {
+    if (g_pCompositor->m_unsafeState)
+        return;
+
+    for (auto const& w : g_pCompositor->m_windows) {
+        if (w->m_monitor == m_self)
+            w->updateSurfaceScaleTransformDetails();
+    }
+
+    for (auto const& lsl : m_layerSurfaceLayers) {
+        for (auto const& ls : lsl) {
+            if (!ls->aliveAndVisible())
+                continue;
+
+            auto surf = ls->m_layerSurface->m_surface.lock();
+            if (!surf)
+                continue;
+
+            surf->breadthfirst(
+                [this](SP<CWLSurfaceResource> s, const Vector2D& offset, void* d) {
+                    const auto PSURFACE = CWLSurface::fromResource(s);
+                    if (PSURFACE && PSURFACE->m_lastScaleFloat == m_scale)
+                        return;
+
+                    g_pCompositor->setPreferredScaleForSurface(s, m_scale);
+                    g_pCompositor->setPreferredTransformForSurface(s, m_transform);
+                },
+                nullptr);
+        }
+    }
 }
 
 bool CMonitor::updateTearing() {

--- a/src/helpers/Monitor.hpp
+++ b/src/helpers/Monitor.hpp
@@ -323,6 +323,7 @@ class CMonitor {
     uint32_t    isSolitaryBlocked(bool full = false);
     void        recheckSolitary();
     uint8_t     isTearingBlocked(bool full = false);
+    void        updateSurfaceScaleTransformDetails();
     bool        updateTearing();
     uint16_t    isDSBlocked(bool full = false);
     bool        attemptDirectScanout();


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->
No AI.


#### Describe your PR, what does it fix/add?
Informs layer surfaces of monitor scale/transform changes at the same time window surfaces are informed. This has the same logic as `CWindow::updateSurfaceScaleTransformDetails`.

Also fixes https://github.com/hyprwm/Hyprland/discussions/13085 - layer subsurfaces not receiving scales on map/commit.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I am not sure if the code in onNewMonitor is actually reachable or if m_layerSurfaceLayers will always be empty at that point.

ctest passes, but I wasn't able to complete a hyprtester run before or after making the change. It didn't regress any tests that it was able to complete. 

#### Is it ready for merging, or does it need work?
Ready. 

