### PR TITLE
add xwayland-satellite support, an alternate xwayland implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,26 +364,33 @@ if(NO_XWAYLAND)
   message(STATUS "Using the NO_XWAYLAND flag, disabling XWayland!")
   add_compile_definitions(NO_XWAYLAND)
 else()
-  message(STATUS "XWAYLAND Enabled (NO_XWAYLAND not defined) checking deps...")
-  set(XWAYLAND_DEPENDENCIES
-    xcb
-    xcb-render
-    xcb-xfixes
-    xcb-icccm
-    xcb-composite
-    xcb-res
-    xcb-errors)
+  option(USE_XWAYLAND_SATELLITE "Use xwayland-satellite instead of built-in XWayland/XWM" ON)
 
-  pkg_check_modules(
-    xdeps
-    REQUIRED
-    IMPORTED_TARGET
-    ${XWAYLAND_DEPENDENCIES})
+  if(USE_XWAYLAND_SATELLITE)
+    message(STATUS "XWAYLAND Enabled via xwayland-satellite (USE_XWAYLAND_SATELLITE=ON)")
+    add_compile_definitions(USE_XWAYLAND_SATELLITE)
+  else()
+    message(STATUS "XWAYLAND Enabled with built-in XWM (USE_XWAYLAND_SATELLITE=OFF) checking deps...")
+    set(XWAYLAND_DEPENDENCIES
+      xcb
+      xcb-render
+      xcb-xfixes
+      xcb-icccm
+      xcb-composite
+      xcb-res
+      xcb-errors)
 
-  string(JOIN ", " PKGCONFIG_XWAYLAND_DEPENDENCIES ${XWAYLAND_DEPENDENCIES})
-  string(PREPEND PKGCONFIG_XWAYLAND_DEPENDENCIES ", ")
+    pkg_check_modules(
+      xdeps
+      REQUIRED
+      IMPORTED_TARGET
+      ${XWAYLAND_DEPENDENCIES})
 
-  target_link_libraries(hyprland_lib PUBLIC PkgConfig::xdeps)
+    string(JOIN ", " PKGCONFIG_XWAYLAND_DEPENDENCIES ${XWAYLAND_DEPENDENCIES})
+    string(PREPEND PKGCONFIG_XWAYLAND_DEPENDENCIES ", ")
+
+    target_link_libraries(hyprland_lib PUBLIC PkgConfig::xdeps)
+  endif()
 endif()
 
 configure_file(hyprland.pc.in hyprland.pc @ONLY)

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -49,9 +49,11 @@
   wayland-protocols,
   wayland-scanner,
   xwayland,
+  xwayland-satellite,
   debug ? false,
   withTests ? debug,
   enableXWayland ? true,
+  enableXWaylandSatellite ? true,
   withSystemd ? lib.meta.availableOn stdenv.hostPlatform systemd,
   wrapRuntimeDeps ? true,
   version ? "git",
@@ -125,7 +127,7 @@ customStdenv.mkDerivation (finalAttrs: {
             ../systemd
             ../VERSION
             (fs.fileFilter (file: file.hasExt "1") ../docs)
-            (fs.fileFilter (file: file.hasExt "conf" || file.hasExt "in" || file.hasExt "lua" ) ../example)
+            (fs.fileFilter (file: file.hasExt "conf" || file.hasExt "in" || file.hasExt "lua") ../example)
             (fs.fileFilter (file: file.hasExt "sh") ../scripts)
             (fs.fileFilter (file: file.name == "CMakeLists.txt") ../.)
             (optional withTests [
@@ -207,7 +209,7 @@ customStdenv.mkDerivation (finalAttrs: {
     ]
     (optionals customStdenv.hostPlatform.isBSD [ epoll-shim ])
     (optionals customStdenv.hostPlatform.isMusl [ libexecinfo ])
-    (optionals enableXWayland [
+    (optionals (enableXWayland && !enableXWaylandSatellite) [
       libxcb
       libxcb-errors
       libxcb-render-util
@@ -228,6 +230,7 @@ customStdenv.mkDerivation (finalAttrs: {
   cmakeFlags = mapAttrsToList cmakeBool {
     "BUILT_WITH_NIX" = true;
     "NO_XWAYLAND" = !enableXWayland;
+    "USE_XWAYLAND_SATELLITE" = enableXWayland && enableXWaylandSatellite;
     "LEGACY_RENDERER" = legacyRenderer;
     "NO_SYSTEMD" = !withSystemd;
     "CMAKE_DISABLE_PRECOMPILE_HEADERS" = true;
@@ -246,12 +249,15 @@ customStdenv.mkDerivation (finalAttrs: {
     ${optionalString wrapRuntimeDeps ''
       wrapProgram $out/bin/Hyprland \
         --suffix PATH : ${
-          makeBinPath [
-            binutils
-            hyprland-guiutils
-            pciutils
-            pkgconf
-          ]
+          makeBinPath (
+            [
+              binutils
+              hyprland-guiutils
+              pciutils
+              pkgconf
+            ]
+            ++ optional (enableXWayland && enableXWaylandSatellite) xwayland-satellite
+          )
         }
     ''}
 

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2905,7 +2905,7 @@ void CCompositor::arrangeMonitors() {
     PROTO::xdgOutput->updateAllOutputs();
     Event::bus()->m_events.monitor.layoutChanged.emit();
 
-#ifndef NO_XWAYLAND
+#if !defined(NO_XWAYLAND) && !defined(USE_XWAYLAND_SATELLITE)
     const auto box = g_pCompositor->calculateX11WorkArea();
     if (g_pXWayland && g_pXWayland->m_wm) {
         if (box)

--- a/src/managers/CursorManager.cpp
+++ b/src/managers/CursorManager.cpp
@@ -272,6 +272,7 @@ SCursorImageData CCursorManager::dataFor(const std::string& name) {
 }
 
 void CCursorManager::setXWaylandCursor() {
+#if !defined(NO_XWAYLAND) && !defined(USE_XWAYLAND_SATELLITE)
     static auto PUSEHYPRCURSOR = CConfigValue<Config::INTEGER>("cursor:enable_hyprcursor");
     const auto  CURSOR         = dataFor("left_ptr");
     if (CURSOR.surface && *PUSEHYPRCURSOR)
@@ -283,6 +284,7 @@ void CCursorManager::setXWaylandCursor() {
 
         g_pXWayland->setCursor(rc<uint8_t*>(icon.pixels.data()), icon.size.x * 4, icon.size, icon.hotspot);
     }
+#endif
 }
 
 void CCursorManager::updateTheme() {

--- a/src/managers/XWaylandManager.cpp
+++ b/src/managers/XWaylandManager.cpp
@@ -108,6 +108,7 @@ void CHyprXWaylandManager::sendCloseWindow(PHLWINDOW pWindow) {
 
 bool CHyprXWaylandManager::shouldBeFloated(PHLWINDOW pWindow, bool pending) {
     if (pWindow->m_isX11) {
+#if !defined(NO_XWAYLAND) && !defined(USE_XWAYLAND_SATELLITE)
         for (const auto& a : pWindow->m_xwaylandSurface->m_atoms)
             if (a == HYPRATOMS["_NET_WM_WINDOW_TYPE_DIALOG"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_SPLASH"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_TOOLBAR"] ||
                 a == HYPRATOMS["_NET_WM_WINDOW_TYPE_UTILITY"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_TOOLTIP"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_POPUP_MENU"] ||
@@ -122,6 +123,7 @@ bool CHyprXWaylandManager::shouldBeFloated(PHLWINDOW pWindow, bool pending) {
 
                 return true;
             }
+#endif
 
         if (pWindow->isModal() || pWindow->m_xwaylandSurface->m_transient ||
             (pWindow->m_xwaylandSurface->m_role.contains("task_dialog") || pWindow->m_xwaylandSurface->m_role.contains("pop-up")) || pWindow->m_xwaylandSurface->m_overrideRedirect)
@@ -149,6 +151,7 @@ void CHyprXWaylandManager::checkBorders(PHLWINDOW pWindow) {
     if (!pWindow->m_isX11)
         return;
 
+#if !defined(NO_XWAYLAND) && !defined(USE_XWAYLAND_SATELLITE)
     for (auto const& a : pWindow->m_xwaylandSurface->m_atoms) {
         if (a == HYPRATOMS["_NET_WM_WINDOW_TYPE_POPUP_MENU"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_NOTIFICATION"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_DROPDOWN_MENU"] ||
             a == HYPRATOMS["_NET_WM_WINDOW_TYPE_COMBO"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_MENU"] || a == HYPRATOMS["_NET_WM_WINDOW_TYPE_SPLASH"] ||
@@ -158,6 +161,7 @@ void CHyprXWaylandManager::checkBorders(PHLWINDOW pWindow) {
             return;
         }
     }
+#endif
 
     if (pWindow->isX11OverrideRedirect())
         pWindow->m_X11DoesntWantBorders = true;

--- a/src/protocols/XDGOutput.cpp
+++ b/src/protocols/XDGOutput.cpp
@@ -46,7 +46,7 @@ void CXDGOutputProtocol::onManagerGetXDGOutput(CZxdgOutputManagerV1* mgr, uint32
     const auto  CLIENT   = mgr->client();
 
     CXDGOutput* pXDGOutput = m_xdgOutputs.emplace_back(makeUnique<CXDGOutput>(makeShared<CZxdgOutputV1>(CLIENT, mgr->version(), id), PMONITOR)).get();
-#ifndef NO_XWAYLAND
+#if !defined(NO_XWAYLAND) && !defined(USE_XWAYLAND_SATELLITE)
     if (g_pXWayland && g_pXWayland->m_server && g_pXWayland->m_server->m_xwaylandClient == CLIENT)
         pXDGOutput->m_isXWayland = true;
 #endif

--- a/src/protocols/core/DataDevice.cpp
+++ b/src/protocols/core/DataDevice.cpp
@@ -427,7 +427,7 @@ void CWLDataDeviceProtocol::destroyResource(CWLDataOfferResource* resource) {
 }
 
 SP<IDataDevice> CWLDataDeviceProtocol::dataDeviceForClient(wl_client* c) {
-#ifndef NO_XWAYLAND
+#if !defined(NO_XWAYLAND) && !defined(USE_XWAYLAND_SATELLITE)
     if (g_pXWayland && g_pXWayland->m_server && c == g_pXWayland->m_server->m_xwaylandClient)
         return g_pXWayland->m_wm->getDataDevice();
 #endif
@@ -457,7 +457,7 @@ void CWLDataDeviceProtocol::sendSelectionToDevice(SP<IDataDevice> dev, SP<IDataS
         OFFER->m_self   = OFFER;
         offer           = OFFER;
     }
-#ifndef NO_XWAYLAND
+#if !defined(NO_XWAYLAND) && !defined(USE_XWAYLAND_SATELLITE)
     else if (const auto X11 = dev->getX11(); X11)
         offer = g_pXWayland->m_wm->createX11DataOffer(g_pSeatManager->m_state.keyboardFocus.lock(), sel);
 #endif
@@ -680,7 +680,7 @@ void CWLDataDeviceProtocol::updateDrag() {
         OFFER->m_self   = OFFER;
         offer           = OFFER;
     }
-#ifndef NO_XWAYLAND
+#if !defined(NO_XWAYLAND) && !defined(USE_XWAYLAND_SATELLITE)
     else if (const auto X11 = m_dnd.focusedDevice->getX11(); X11)
         offer = g_pXWayland->m_wm->createX11DataOffer(g_pSeatManager->m_state.keyboardFocus.lock(), m_dnd.currentSource.lock());
 #endif

--- a/src/xwayland/Dnd.cpp
+++ b/src/xwayland/Dnd.cpp
@@ -1,5 +1,5 @@
 #include "Dnd.hpp"
-#ifndef NO_XWAYLAND
+#if !defined(NO_XWAYLAND) && !defined(USE_XWAYLAND_SATELLITE)
 #include "XWM.hpp"
 #include "XWayland.hpp"
 #include "Server.hpp"
@@ -14,7 +14,7 @@ using namespace Hyprutils::OS;
 #define PROPERTY_LENGTH       1
 #define PROPERTY_OFFSET       0
 
-#ifndef NO_XWAYLAND
+#if !defined(NO_XWAYLAND) && !defined(USE_XWAYLAND_SATELLITE)
 static xcb_atom_t dndActionToAtom(uint32_t actions) {
     if (actions & WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY)
         return HYPRATOMS["XdndActionCopy"];
@@ -89,7 +89,7 @@ SP<IDataSource> CX11DataOffer::getSource() {
 }
 
 void CX11DataOffer::markDead() {
-#ifndef NO_XWAYLAND
+#if !defined(NO_XWAYLAND) && !defined(USE_XWAYLAND_SATELLITE)
     std::erase(g_pXWayland->m_wm->m_dndDataOffers, m_self);
 #endif
 }
@@ -99,7 +99,7 @@ void CX11DataDevice::sendDataOffer(SP<IDataOffer> offer) {
 }
 
 void CX11DataDevice::sendEnter(uint32_t serial, SP<CWLSurfaceResource> surf, const Vector2D& local, SP<IDataOffer> offer) {
-#ifndef NO_XWAYLAND
+#if !defined(NO_XWAYLAND) && !defined(USE_XWAYLAND_SATELLITE)
     auto XSURF = g_pXWayland->m_wm->windowForWayland(surf);
 
     if (!XSURF) {
@@ -158,7 +158,7 @@ void CX11DataDevice::cleanupState() {
 }
 
 void CX11DataDevice::sendLeave() {
-#ifndef NO_XWAYLAND
+#if !defined(NO_XWAYLAND) && !defined(USE_XWAYLAND_SATELLITE)
     if (!m_lastSurface)
         return;
 
@@ -174,7 +174,7 @@ void CX11DataDevice::sendLeave() {
 }
 
 void CX11DataDevice::sendMotion(uint32_t timeMs, const Vector2D& local) {
-#ifndef NO_XWAYLAND
+#if !defined(NO_XWAYLAND) && !defined(USE_XWAYLAND_SATELLITE)
     if (!m_lastSurface || !m_lastOffer || !m_lastOffer->getSource())
         return;
 
@@ -196,7 +196,7 @@ void CX11DataDevice::sendMotion(uint32_t timeMs, const Vector2D& local) {
 }
 
 void CX11DataDevice::sendDrop() {
-#ifndef NO_XWAYLAND
+#if !defined(NO_XWAYLAND) && !defined(USE_XWAYLAND_SATELLITE)
     if (!m_lastSurface || !m_lastOffer) {
         Log::logger->log(Log::ERR, "CX11DataDevice::sendDrop: No surface or offer");
         return;
@@ -282,7 +282,7 @@ void CX11DataSource::sendDndAction(wl_data_device_manager_dnd_action a) {
 }
 
 void CX11DataDevice::forceCleanupDnd() {
-#ifndef NO_XWAYLAND
+#if !defined(NO_XWAYLAND) && !defined(USE_XWAYLAND_SATELLITE)
     if (m_lastOffer) {
         auto source = m_lastOffer->getSource();
         if (source) {

--- a/src/xwayland/Server.cpp
+++ b/src/xwayland/Server.cpp
@@ -1,5 +1,5 @@
 #include <cstdint>
-#ifndef NO_XWAYLAND
+#if !defined(NO_XWAYLAND) && !defined(USE_XWAYLAND_SATELLITE)
 
 #include <format>
 #include <string>

--- a/src/xwayland/XDataSource.cpp
+++ b/src/xwayland/XDataSource.cpp
@@ -1,4 +1,4 @@
-#ifndef NO_XWAYLAND
+#if !defined(NO_XWAYLAND) && !defined(USE_XWAYLAND_SATELLITE)
 
 #include "XWayland.hpp"
 #include "../defines.hpp"

--- a/src/xwayland/XSurface.cpp
+++ b/src/xwayland/XSurface.cpp
@@ -5,7 +5,7 @@
 #include "../managers/ANRManager.hpp"
 #include "../helpers/time/Time.hpp"
 
-#ifndef NO_XWAYLAND
+#if !defined(NO_XWAYLAND) && !defined(USE_XWAYLAND_SATELLITE)
 
 CXWaylandSurface::CXWaylandSurface(uint32_t xID_, CBox geometry_, bool OR) : m_xID(xID_), m_geometry(geometry_), m_overrideRedirect(OR) {
     xcb_res_query_client_ids_cookie_t client_id_cookie = {0};

--- a/src/xwayland/XSurface.hpp
+++ b/src/xwayland/XSurface.hpp
@@ -8,7 +8,7 @@
 class CWLSurfaceResource;
 class CXWaylandSurfaceResource;
 
-#ifdef NO_XWAYLAND
+#if defined(NO_XWAYLAND) || defined(USE_XWAYLAND_SATELLITE)
 using xcb_pixmap_t = uint32_t;
 using xcb_window_t = uint32_t;
 using xcb_atom_t   = uint32_t;

--- a/src/xwayland/XWM.cpp
+++ b/src/xwayland/XWM.cpp
@@ -2,9 +2,9 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#if !defined(NO_XWAYLAND) && !defined(USE_XWAYLAND_SATELLITE)
 #include <xcb/xfixes.h>
 #include <xcb/xproto.h>
-#ifndef NO_XWAYLAND
 
 #include <fcntl.h>
 #include <cstring>

--- a/src/xwayland/XWayland.cpp
+++ b/src/xwayland/XWayland.cpp
@@ -5,6 +5,30 @@
 
 CXWayland::CXWayland(const bool wantsEnabled) {
 #ifndef NO_XWAYLAND
+
+#ifdef USE_XWAYLAND_SATELLITE
+    // xwayland-satellite mode
+    if (!wantsEnabled) {
+        Log::logger->log(Log::DEBUG, "XWayland has been disabled, cleaning up...");
+        unsetenv("DISPLAY");
+        m_enabled = false;
+        return;
+    }
+
+    Log::logger->log(Log::DEBUG, "Starting XWayland via xwayland-satellite");
+
+    m_satellite = makeUnique<CXWaylandSatellite>();
+
+    if (!m_satellite->setup(g_pCompositor->m_wlEventLoop)) {
+        Log::logger->log(Log::WARN, "XWayland satellite failed to set up: X11 apps will not work.");
+        m_satellite.reset();
+        return;
+    }
+
+    m_enabled = true;
+
+#else
+    // Built-in XWayland mode (legacy)
     // Disable Xwayland and clean up if the user disabled it.
     if (!wantsEnabled) {
         Log::logger->log(Log::DEBUG, "XWayland has been disabled, cleaning up...");
@@ -34,11 +58,14 @@ CXWayland::CXWayland(const bool wantsEnabled) {
     }
 
     m_enabled = true;
+#endif
+
 #else
     Log::logger->log(Log::DEBUG, "Not starting XWayland: disabled at compile time");
 #endif
 }
 
+#ifndef USE_XWAYLAND_SATELLITE
 void CXWayland::setCursor(unsigned char* pixData, uint32_t stride, const Vector2D& size, const Vector2D& hotspot) {
 #ifndef NO_XWAYLAND
     if (!m_wm) {
@@ -49,6 +76,7 @@ void CXWayland::setCursor(unsigned char* pixData, uint32_t stride, const Vector2
     m_wm->setCursor(pixData, stride, size, hotspot);
 #endif
 }
+#endif
 
 bool CXWayland::enabled() {
     return m_enabled;

--- a/src/xwayland/XWayland.hpp
+++ b/src/xwayland/XWayland.hpp
@@ -7,8 +7,14 @@
 #include "XSurface.hpp"
 
 #ifndef NO_XWAYLAND
+
+#ifdef USE_XWAYLAND_SATELLITE
+#include "XWaylandSatellite.hpp"
+#else
 #include "Server.hpp"
 #include "XWM.hpp"
+#endif
+
 #else
 class CXWaylandServer;
 class CXWM;
@@ -19,21 +25,27 @@ class CXWayland {
     CXWayland(const bool wantsEnabled);
 
 #ifndef NO_XWAYLAND
+#ifdef USE_XWAYLAND_SATELLITE
+    UP<CXWaylandSatellite> m_satellite;
+#else
     UP<CXWaylandServer> m_server;
     UP<CXWM>            m_wm;
 #endif
+#endif
     bool enabled();
 
+#ifndef USE_XWAYLAND_SATELLITE
     void setCursor(unsigned char* pixData, uint32_t stride, const Vector2D& size, const Vector2D& hotspot);
+#endif
 
   private:
     bool m_enabled = false;
 };
 
-inline UP<CXWayland>                             g_pXWayland;
+inline UP<CXWayland> g_pXWayland;
 
+#if !defined(NO_XWAYLAND) && !defined(USE_XWAYLAND_SATELLITE)
 inline std::unordered_map<std::string, uint32_t> HYPRATOMS = {
-#ifndef NO_XWAYLAND
     HYPRATOM("_NET_SUPPORTED"),
     HYPRATOM("_NET_SUPPORTING_WM_CHECK"),
     HYPRATOM("_NET_WM_NAME"),
@@ -127,5 +139,5 @@ inline std::unordered_map<std::string, uint32_t> HYPRATOMS = {
     HYPRATOM("DELETE"),
     HYPRATOM("TEXT"),
     HYPRATOM("INCR"),
-#endif
 };
+#endif

--- a/src/xwayland/XWaylandSatellite.cpp
+++ b/src/xwayland/XWaylandSatellite.cpp
@@ -1,0 +1,477 @@
+#ifdef USE_XWAYLAND_SATELLITE
+
+#include "XWaylandSatellite.hpp"
+#include "XWayland.hpp"
+#include "../Compositor.hpp"
+#include "../config/ConfigValue.hpp"
+#include "../debug/log/Logger.hpp"
+
+#include <cerrno>
+#include <csignal>
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+#include <fcntl.h>
+#include <format>
+#include <filesystem>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <sys/wait.h>
+#include <thread>
+#include <unistd.h>
+
+using namespace Hyprutils::OS;
+
+// Constants
+constexpr int SOCKET_DIR_PERMISSIONS = 0755;
+constexpr int SOCKET_BACKLOG         = 1;
+constexpr int MAX_DISPLAY_RETRIES    = 50;
+constexpr int LOCK_FILE_MODE         = 0444;
+
+static bool   safeRemove(const std::string& path) {
+    try {
+        return std::filesystem::remove(path);
+    } catch (const std::exception& e) { Log::logger->log(Log::ERR, "[XWayland-Satellite] Failed to remove {}", path); }
+
+    return false;
+}
+
+static std::string getSocketPath(int display, bool isLinux) {
+    if (isLinux)
+        return std::format("/tmp/.X11-unix/X{}", display);
+
+    return std::format("/tmp/.X11-unix/X{}_", display);
+}
+
+static CFileDescriptor createSocket(struct sockaddr_un* addr, size_t pathSize) {
+    const bool        isRegularSocket(addr->sun_path[0]);
+    const char        dbgSocketPathPrefix = isRegularSocket ? addr->sun_path[0] : '@';
+    const char* const dbgSocketPathRem    = addr->sun_path + 1;
+
+    socklen_t         size = offsetof(struct sockaddr_un, sun_path) + pathSize + 1;
+    CFileDescriptor   fd{socket(AF_UNIX, SOCK_STREAM, 0)};
+    if (!fd.isValid()) {
+        Log::logger->log(Log::ERR, "[XWayland-Satellite] Failed to create socket {}{}", dbgSocketPathPrefix, dbgSocketPathRem);
+        return {};
+    }
+
+    if (!fd.setFlags(fd.getFlags() | FD_CLOEXEC)) {
+        Log::logger->log(Log::ERR, "[XWayland-Satellite] Failed to set flags for socket {}{}", dbgSocketPathPrefix, dbgSocketPathRem);
+        return {};
+    }
+
+    if (isRegularSocket)
+        unlink(addr->sun_path);
+
+    if (bind(fd.get(), rc<struct sockaddr*>(addr), size) < 0) {
+        Log::logger->log(Log::ERR, "[XWayland-Satellite] Failed to bind socket {}{}", dbgSocketPathPrefix, dbgSocketPathRem);
+        if (isRegularSocket)
+            unlink(addr->sun_path);
+        return {};
+    }
+
+    if (isRegularSocket && chmod(addr->sun_path, 0666) < 0)
+        Log::logger->log(Log::ERR, "[XWayland-Satellite] Failed to set permission mode for socket {}{}", dbgSocketPathPrefix, dbgSocketPathRem);
+
+    if (listen(fd.get(), SOCKET_BACKLOG) < 0) {
+        Log::logger->log(Log::ERR, "[XWayland-Satellite] Failed to listen to socket {}{}", dbgSocketPathPrefix, dbgSocketPathRem);
+        if (isRegularSocket)
+            unlink(addr->sun_path);
+        return {};
+    }
+
+    return fd;
+}
+
+static bool checkPermissionsForSocketDir() {
+    struct stat buf;
+
+    if (lstat("/tmp/.X11-unix", &buf)) {
+        Log::logger->log(Log::ERR, "[XWayland-Satellite] Failed to stat X11 socket dir");
+        return false;
+    }
+
+    if (!(buf.st_mode & S_IFDIR)) {
+        Log::logger->log(Log::ERR, "[XWayland-Satellite] X11 socket dir is not a directory");
+        return false;
+    }
+
+    if ((buf.st_uid != 0) && (buf.st_uid != getuid())) {
+        Log::logger->log(Log::ERR, "[XWayland-Satellite] X11 socket dir is not owned by root or current user");
+        return false;
+    }
+
+    if (!(buf.st_mode & S_ISVTX)) {
+        if ((buf.st_mode & (S_IWGRP | S_IWOTH))) {
+            Log::logger->log(Log::ERR, "[XWayland-Satellite] X11 socket dir is writable by others without sticky bit");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static bool ensureSocketDirExists() {
+    if (mkdir("/tmp/.X11-unix", SOCKET_DIR_PERMISSIONS) != 0) {
+        if (errno == EEXIST)
+            return checkPermissionsForSocketDir();
+
+        Log::logger->log(Log::ERR, "[XWayland-Satellite] Couldn't create socket dir /tmp/.X11-unix");
+        return false;
+    }
+
+    return true;
+}
+
+static bool openSockets(std::array<CFileDescriptor, 2>& sockets, int display) {
+    static auto CREATEABSTRACTSOCKET = CConfigValue<Config::INTEGER>("xwayland:create_abstract_socket");
+
+    if (!ensureSocketDirExists())
+        return false;
+
+    sockaddr_un addr = {.sun_family = AF_UNIX};
+    std::string path;
+
+#ifdef __linux__
+    if (*CREATEABSTRACTSOCKET) {
+        addr.sun_path[0] = '\0';
+        path             = getSocketPath(display, true);
+
+        strncpy(addr.sun_path + 1, path.c_str(), sizeof(addr.sun_path) - 2);
+    } else {
+        path = getSocketPath(display, false);
+
+        strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
+        addr.sun_path[sizeof(addr.sun_path) - 1] = '\0';
+    }
+#else
+    if (*CREATEABSTRACTSOCKET)
+        Log::logger->log(Log::WARN, "[XWayland-Satellite] Abstract X11 socket is only available on Linux. A regular one will be created instead.");
+
+    path = getSocketPath(display, false);
+
+    strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
+    addr.sun_path[sizeof(addr.sun_path) - 1] = '\0';
+#endif
+
+    sockets[0] = CFileDescriptor{createSocket(&addr, path.length())};
+    if (!sockets[0].isValid())
+        return false;
+
+    path = getSocketPath(display, true);
+    strncpy(addr.sun_path, path.c_str(), path.length() + 1);
+
+    sockets[1] = CFileDescriptor{createSocket(&addr, path.length())};
+    if (!sockets[1].isValid()) {
+        sockets[0].reset();
+        return false;
+    }
+
+    return true;
+}
+
+CXWaylandSatellite::CXWaylandSatellite() {
+    ;
+}
+
+CXWaylandSatellite::~CXWaylandSatellite() {
+    removeWatches();
+
+    if (m_display < 0)
+        return;
+
+    std::string lockPath = std::format("/tmp/.X{}-lock", m_display);
+    safeRemove(lockPath);
+
+    std::string path;
+    for (bool isLinux : {true, false}) {
+        path = getSocketPath(m_display, isLinux);
+        safeRemove(path);
+    }
+
+    unsetenv("DISPLAY");
+}
+
+bool CXWaylandSatellite::tryOpenSockets() {
+    for (int i = 0; i <= MAX_DISPLAY_RETRIES; ++i) {
+        const std::string lockPath = std::format("/tmp/.X{}-lock", i);
+
+        CFileDescriptor   fd{open(lockPath.c_str(), O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, LOCK_FILE_MODE)};
+        if (fd.isValid()) {
+            if (!openSockets(m_xFDs, i)) {
+                safeRemove(lockPath);
+                continue;
+            }
+
+            const std::string pidStr = std::format("{:010d}\n", getpid());
+            if (write(fd.get(), pidStr.c_str(), 11) != 11L) {
+                m_xFDs[0].reset();
+                m_xFDs[1].reset();
+                safeRemove(lockPath);
+                continue;
+            }
+
+            m_display     = i;
+            m_displayName = std::format(":{}", m_display);
+            break;
+        }
+
+        fd = CFileDescriptor{open(lockPath.c_str(), O_RDONLY | O_CLOEXEC)};
+        if (!fd.isValid())
+            continue;
+
+        char pidstr[12] = {0};
+        if (read(fd.get(), pidstr, sizeof(pidstr) - 1) < 0)
+            continue;
+
+        int32_t pid = 0;
+        try {
+            pid = std::stoi(std::string{pidstr, 11});
+        } catch (...) { continue; }
+
+        if (kill(pid, 0) != 0 && errno == ESRCH) {
+            if (!safeRemove(lockPath))
+                continue;
+            i--;
+        }
+    }
+
+    if (m_display < 0) {
+        Log::logger->log(Log::ERR, "[XWayland-Satellite] Failed to find a suitable display socket");
+        return false;
+    }
+
+    Log::logger->log(Log::DEBUG, "[XWayland-Satellite] Found suitable display socket at DISPLAY: {}", m_displayName);
+    return true;
+}
+
+bool CXWaylandSatellite::testOnDemand() {
+    int pipefd[2];
+    if (pipe(pipefd) < 0) {
+        Log::logger->log(Log::ERR, "[XWayland-Satellite] pipe failed for test: {}", strerror(errno));
+        return false;
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        Log::logger->log(Log::ERR, "[XWayland-Satellite] fork failed for test: {}", strerror(errno));
+        close(pipefd[0]);
+        close(pipefd[1]);
+        return false;
+    }
+
+    if (pid == 0) {
+        close(pipefd[0]);
+
+        struct sigaction act;
+        act.sa_handler = SIG_DFL;
+        sigemptyset(&act.sa_mask);
+        act.sa_flags = 0;
+        sigaction(SIGCHLD, &act, nullptr);
+
+        pid_t pid2 = fork();
+        if (pid2 == 0) {
+            int devnull = open("/dev/null", O_WRONLY);
+            if (devnull >= 0) {
+                dup2(devnull, STDOUT_FILENO);
+                dup2(devnull, STDERR_FILENO);
+                close(devnull);
+            }
+
+            unsetenv("DISPLAY");
+            unsetenv("RUST_BACKTRACE");
+            unsetenv("RUST_LIB_BACKTRACE");
+
+            execlp("xwayland-satellite", "xwayland-satellite", ":0", "--test-listenfd-support", nullptr);
+            _exit(127);
+        }
+
+        int status = 0;
+        waitpid(pid2, &status, 0);
+        int exitCode = WIFEXITED(status) ? WEXITSTATUS(status) : 255;
+        if (write(pipefd[1], &exitCode, sizeof(exitCode)) < 0) {
+            // nothing we can do
+        }
+        _exit(0);
+    }
+
+    close(pipefd[1]);
+
+    int     exitCode  = -1;
+    ssize_t bytesRead = read(pipefd[0], &exitCode, sizeof(exitCode));
+    close(pipefd[0]);
+
+    if (bytesRead != sizeof(exitCode)) {
+        Log::logger->log(Log::INFO, "[XWayland-Satellite] Error waiting for xwayland-satellite test: Failed to read from pipe");
+        return false;
+    }
+
+    if (exitCode != 0) {
+        if (exitCode == 127)
+            Log::logger->log(Log::INFO, "[XWayland-Satellite] xwayland-satellite not found, disabling integration");
+        else
+            Log::logger->log(Log::INFO, "[XWayland-Satellite] xwayland-satellite doesn't support on-demand activation, disabling integration");
+
+        return false;
+    }
+
+    return true;
+}
+
+bool CXWaylandSatellite::setup(wl_event_loop* eventLoop) {
+    m_eventLoop = eventLoop;
+
+    if (!testOnDemand())
+        return false;
+
+    if (!tryOpenSockets())
+        return false;
+
+    setenv("DISPLAY", m_displayName.c_str(), true);
+    Log::logger->log(Log::INFO, "[XWayland-Satellite] Listening on X11 socket: {}", m_displayName);
+
+    m_enabled = true;
+    setupWatch();
+    return true;
+}
+
+void CXWaylandSatellite::clearPendingConnections(CFileDescriptor& fd) {
+    int flags = fcntl(fd.get(), F_GETFL);
+    if (flags < 0)
+        return;
+
+    fcntl(fd.get(), F_SETFL, flags | O_NONBLOCK);
+
+    struct sockaddr_un addr;
+    socklen_t          len = sizeof(addr);
+    while (true) {
+        int clientFd = accept(fd.get(), rc<struct sockaddr*>(&addr), &len);
+        if (clientFd < 0)
+            break;
+
+        close(clientFd);
+    }
+
+    fcntl(fd.get(), F_SETFL, flags);
+}
+
+void CXWaylandSatellite::removeWatches() {
+    if (m_abstractWatch) {
+        wl_event_source_remove(m_abstractWatch);
+        m_abstractWatch = nullptr;
+    }
+
+    if (m_unixWatch) {
+        wl_event_source_remove(m_unixWatch);
+        m_unixWatch = nullptr;
+    }
+}
+
+int CXWaylandSatellite::onSocketActivity(int fd, uint32_t mask, void* data) {
+    auto* self = static_cast<CXWaylandSatellite*>(data);
+
+    Log::logger->log(Log::DEBUG, "[XWayland-Satellite] Connection on X11 socket; spawning xwayland-satellite");
+
+    self->removeWatches();
+    self->spawn();
+
+    return 0;
+}
+
+void CXWaylandSatellite::setupWatch() {
+    removeWatches();
+
+    if (!m_eventLoop || !m_xFDs[0].isValid() || !m_xFDs[1].isValid())
+        return;
+
+    clearPendingConnections(m_xFDs[0]);
+    clearPendingConnections(m_xFDs[1]);
+
+    m_abstractWatch = wl_event_loop_add_fd(m_eventLoop, m_xFDs[0].get(), WL_EVENT_READABLE, onSocketActivity, this);
+    m_unixWatch     = wl_event_loop_add_fd(m_eventLoop, m_xFDs[1].get(), WL_EVENT_READABLE, onSocketActivity, this);
+}
+
+void CXWaylandSatellite::spawn() {
+    CFileDescriptor abstractFd{dup(m_xFDs[0].get())};
+    CFileDescriptor unixFd{dup(m_xFDs[1].get())};
+
+    if (!abstractFd.isValid() || !unixFd.isValid()) {
+        Log::logger->log(Log::ERR, "[XWayland-Satellite] Failed to dup socket fds");
+        setupWatch();
+        return;
+    }
+
+    int abstractRaw = abstractFd.get();
+    int unixRaw     = unixFd.get();
+
+    std::thread([this, abstractRaw, unixRaw, abstractFd = std::move(abstractFd), unixFd = std::move(unixFd)]() mutable {
+        pid_t pid = fork();
+        if (pid < 0) {
+            Log::logger->log(Log::ERR, "[XWayland-Satellite] fork failed: {}", strerror(errno));
+            wl_event_loop_add_idle(
+                m_eventLoop,
+                [](void* data) {
+                    auto* self = static_cast<CXWaylandSatellite*>(data);
+                    self->setupWatch();
+                },
+                this);
+            return;
+        }
+
+        if (pid == 0) {
+            fcntl(abstractRaw, F_SETFD, 0);
+            fcntl(unixRaw, F_SETFD, 0);
+
+            int devnull = open("/dev/null", O_WRONLY);
+            if (devnull >= 0) {
+                dup2(devnull, STDOUT_FILENO);
+                dup2(devnull, STDERR_FILENO);
+                close(devnull);
+            }
+
+            unsetenv("DISPLAY");
+            unsetenv("RUST_BACKTRACE");
+            unsetenv("RUST_LIB_BACKTRACE");
+
+            std::string abstractStr = std::to_string(abstractRaw);
+            std::string unixStr     = std::to_string(unixRaw);
+
+            execlp("xwayland-satellite", "xwayland-satellite", m_displayName.c_str(), "-listenfd", abstractStr.c_str(), "-listenfd", unixStr.c_str(), nullptr);
+
+            Log::logger->log(Log::ERR, "[XWayland-Satellite] Failed to exec xwayland-satellite: {}", strerror(errno));
+            _exit(127);
+        }
+
+        abstractFd.reset();
+        unixFd.reset();
+
+        int status = 0;
+        if (waitpid(pid, &status, 0) < 0) {
+            if (errno == ECHILD)
+                Log::logger->log(Log::WARN, "[XWayland-Satellite] xwayland-satellite terminated");
+            else
+                Log::logger->log(Log::WARN, "[XWayland-Satellite] Error waiting for xwayland-satellite: {}", strerror(errno));
+        } else
+            Log::logger->log(Log::WARN, "[XWayland-Satellite] xwayland-satellite exited with status {}", WEXITSTATUS(status));
+
+        wl_event_loop_add_idle(
+            m_eventLoop,
+            [](void* data) {
+                auto* self = static_cast<CXWaylandSatellite*>(data);
+                self->setupWatch();
+            },
+            this);
+    }).detach();
+}
+
+bool CXWaylandSatellite::enabled() const {
+    return m_enabled;
+}
+
+const std::string& CXWaylandSatellite::displayName() const {
+    return m_displayName;
+}
+
+#endif // USE_XWAYLAND_SATELLITE

--- a/src/xwayland/XWaylandSatellite.hpp
+++ b/src/xwayland/XWaylandSatellite.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#ifdef USE_XWAYLAND_SATELLITE
+
+#include <array>
+#include <string>
+#include <thread>
+#include <hyprutils/os/FileDescriptor.hpp>
+
+struct wl_event_source;
+struct wl_event_loop;
+
+class CXWaylandSatellite {
+  public:
+    CXWaylandSatellite();
+    ~CXWaylandSatellite();
+
+    // Initialize: create sockets, probe binary, set DISPLAY
+    bool setup(wl_event_loop* eventLoop);
+
+    // Register FD watchers for on-demand spawn
+    void               setupWatch();
+
+    bool               enabled() const;
+    const std::string& displayName() const;
+
+  private:
+    bool        tryOpenSockets();
+    bool        testOnDemand();
+    void        spawn();
+    void        clearPendingConnections(Hyprutils::OS::CFileDescriptor& fd);
+    void        removeWatches();
+
+    static int  onSocketActivity(int fd, uint32_t mask, void* data);
+
+    std::string m_displayName;
+    int         m_display = -1;
+
+    // X11 sockets: [0] = abstract or first regular, [1] = regular
+    std::array<Hyprutils::OS::CFileDescriptor, 2> m_xFDs;
+
+    wl_event_source*                              m_abstractWatch = nullptr;
+    wl_event_source*                              m_unixWatch     = nullptr;
+    wl_event_loop*                                m_eventLoop     = nullptr;
+    bool                                          m_enabled       = false;
+
+    // Lock file path for cleanup
+    std::string m_lockPath;
+    std::string m_socketPathRegular;
+    std::string m_socketPathAbstract; // only used on Linux with abstract sockets
+};
+
+#endif // USE_XWAYLAND_SATELLITE


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->

#### Describe your PR, what does it fix/add?

Adds support for [xwayland-satellite](https://github.com/Supreeeme/xwayland-satellite) as an alternative to Hyprland’s built-in XWayland/XWM stack.

Done:

- Added a new CMake option USE_XWAYLAND_SATELLITE.
- Updated Nix packaging support and runtime wrapping.

### Is there anything you want to mention? 

- SIGCHLD Workaround: The double-fork and pipe implementation in testOnDemand safely bypasses the compositor-wide SA_NOCLDWAIT handler for the probe check. However, in spawn(), waitpid will still yield ECHILD, which is expected and handled gracefully without blocking or crash loops.
- Abstract Sockets: Supports a configurable option xwayland:create_abstract_socket to determine whether Linux abstract sockets are utilized.
- Compatibility: Built-in XWM legacy features and direct X11 DND operations are skipped when USE_XWAYLAND_SATELLITE is enabled, as they are fully managed by the standalone satellite.


#### Is it ready for merging, or does it need work?

**NOT INTENDED** to be merged. It is primarily being submitted as a proof of concept implementation and demonstrate how xwayland-satellite could integrate with Hyprland, and to hopefully spark discussion or interest around an alternative XWayland/XWM implementation on Hyprland.

@vaxerski you can close or perhaps consider :) I do not currently have the time or sufficient C++ expertise to properly work on this PR.

Another motivation for this work was that the existing built-in XWayland implementation did not automatically expose the DISPLAY environment variable in a way that worked out-of-the-box for my setup, requiring manual configuration. In comparison, xwayland-satellite appeared significantly more robust and self-contained.

AI Disclaimer: This entire integration was generated with assistance from Claude Opus 4.6. The work was originally intended for personal use to evaluate how well xwayland-satellite integrates with Hyprland. The implementation was heavily informed by [niri’s xwayland-satellite integration PR](https://github.com/YaLTeR/niri/pull/1728/files).