### PR TITLE
fractionalscale: track if scale is known and send scales eagerly when known

### DIFF
--- a/src/protocols/FractionalScale.cpp
+++ b/src/protocols/FractionalScale.cpp
@@ -1,5 +1,6 @@
 #include "FractionalScale.hpp"
 #include <algorithm>
+#include "Compositor.hpp"
 #include "core/Compositor.hpp"
 
 CFractionalScaleProtocol::CFractionalScaleProtocol(const wl_interface* iface, const int& ver, const std::string& name) : IWaylandProtocol(iface, ver, name) {
@@ -44,11 +45,11 @@ void CFractionalScaleProtocol::onGetFractionalScale(CWpFractionalScaleManagerV1*
     PADDON->m_resource->setOnDestroy([this, PADDON](CWpFractionalScaleV1* self) { this->removeAddon(PADDON); });
     PADDON->m_resource->setDestroy([this, PADDON](CWpFractionalScaleV1* self) { this->removeAddon(PADDON); });
 
-    if (std::ranges::find_if(m_surfaceScales, [surface](const auto& e) { return e.first == surface; }) == m_surfaceScales.end())
-        m_surfaceScales.emplace(surface, 1.F);
-
-    if (surface->m_mapped)
+    // send known scale or default 1.0 if surface is already mapped without a known scale
+    if (hasKnownScale(surface))
         PADDON->setScale(m_surfaceScales.at(surface));
+    else if (surface->m_mapped)
+        PADDON->setScale(1.F);
 
     // clean old
     std::erase_if(m_surfaceScales, [](const auto& e) { return e.first.expired(); });
@@ -58,6 +59,10 @@ void CFractionalScaleProtocol::sendScale(SP<CWLSurfaceResource> surf, const floa
     m_surfaceScales[surf] = scale;
     if (m_addons.contains(surf))
         m_addons[surf]->setScale(scale);
+}
+
+bool CFractionalScaleProtocol::hasKnownScale(SP<CWLSurfaceResource> surf) {
+    return m_surfaceScales.contains(surf);
 }
 
 CFractionalScaleAddon::CFractionalScaleAddon(SP<CWpFractionalScaleV1> resource_, SP<CWLSurfaceResource> surf_) : m_resource(resource_), m_surface(surf_) {

--- a/src/protocols/FractionalScale.hpp
+++ b/src/protocols/FractionalScale.hpp
@@ -41,6 +41,7 @@ class CFractionalScaleProtocol : public IWaylandProtocol {
 
     void         onSurfaceDestroy(SP<CWLSurfaceResource> surf);
     void         sendScale(SP<CWLSurfaceResource> surf, const float& scale);
+    bool         hasKnownScale(SP<CWLSurfaceResource> surf);
 
   private:
     void removeAddon(CFractionalScaleAddon*);

--- a/src/protocols/LayerShell.cpp
+++ b/src/protocols/LayerShell.cpp
@@ -249,6 +249,11 @@ void CLayerShellProtocol::onGetLayerSurface(CZwlrLayerShellV1* pMgr, uint32_t id
     SURF->m_role = makeShared<CLayerShellRole>(RESOURCE);
     g_pCompositor->m_layers.emplace_back(Desktop::View::CLayerSurface::create(RESOURCE));
 
+    if (PMONITOR) {
+        g_pCompositor->setPreferredScaleForSurface(SURF, PMONITOR->m_scale);
+        g_pCompositor->setPreferredTransformForSurface(SURF, PMONITOR->m_transform);
+    }
+
     LOGM(Log::DEBUG, "New wlr_layer_surface {:x}", (uintptr_t)RESOURCE.get());
 }
 

--- a/src/protocols/core/Subcompositor.cpp
+++ b/src/protocols/core/Subcompositor.cpp
@@ -1,5 +1,7 @@
 #include "Subcompositor.hpp"
 #include "Compositor.hpp"
+#include "protocols/FractionalScale.hpp"
+#include "../../Compositor.hpp"
 #include <algorithm>
 
 CWLSubsurfaceResource::CWLSubsurfaceResource(SP<CWlSubsurface> resource_, SP<CWLSurfaceResource> surface_, SP<CWLSurfaceResource> parent_) :
@@ -196,6 +198,15 @@ CWLSubcompositorResource::CWLSubcompositorResource(SP<CWlSubcompositor> resource
         RESOURCE->m_self = RESOURCE;
         SURF->m_role     = makeShared<CSubsurfaceRole>(RESOURCE);
         PARENT->m_subsurfaces.emplace_back(RESOURCE);
+
+        if (PROTO::fractional->hasKnownScale(PARENT)) {
+            const auto PARENTSURFACE = Desktop::View::CWLSurface::fromResource(PARENT);
+
+            if (PARENTSURFACE) {
+                g_pCompositor->setPreferredScaleForSurface(SURF, PARENTSURFACE->m_lastScaleFloat);
+                g_pCompositor->setPreferredTransformForSurface(SURF, PARENTSURFACE->m_lastTransform);
+            }
+        }
 
         LOGM(Log::DEBUG, "New wl_subsurface with id {} at {:x}", id, (uintptr_t)RESOURCE.get());
 


### PR DESCRIPTION
No AI.

<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

This tracks whether a fractional scale has been explicitly set for a surface or not, and if one has been set it sends it when requested in onGetFractionalScale even if the surface is currently unmapped. That shouldn't ever be true for top level window surfaces unless they've been unmapped, but it means subsurfaces of unmapped surfaces will get the same scale as their parent.

Layers spawned on a specific monitor have the scale/transform immediately set from that monitor. This doesn't change the behaviour if the monitor's scale changes before mapping the layers.

Subsurfaces inherit the scales and transforms of their parents on creation, if known. This seems reasonable to me but it's the part I'm least confident about.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I looked into the bug report around double/redundant scale events (https://github.com/hyprwm/Hyprland/issues/9126) and confirmed this this does not regress it.

`kitty --debug-rendering` at 0.55.2 and this commit:
[kitty-55.2.log](https://github.com/user-attachments/files/28198366/kitty-55.2.log)
[kitty-debug.log](https://github.com/user-attachments/files/28198367/kitty-debug.log)

#### Is it ready for merging, or does it need work?

Worth reviewing closely but I think it's ready.

