### PR TITLE
Fire off 'layoutchanged' event on layout change

### DIFF
--- a/hyprtester/src/tests/main/layout.cpp
+++ b/hyprtester/src/tests/main/layout.cpp
@@ -1,3 +1,6 @@
+#include <filesystem>
+#include <fstream>
+#include <thread>
 #include "../shared.hpp"
 #include "../../shared.hpp"
 #include "../../hyprctlCompat.hpp"
@@ -140,4 +143,36 @@ TEST_CASE(focusPreservedLayoutChange) {
         auto str = getFromSocket("/activewindow");
         EXPECT(str.contains("class: kitty_C"), true);
     }
+}
+
+static const std::string LAYOUT_FLAG = "/tmp/hyprtester-layout-changed.txt";
+
+static std::string       readLayoutFlag() {
+    std::ifstream f(LAYOUT_FLAG);
+    if (!f.good())
+        return "";
+    std::string content;
+    std::getline(f, content);
+    return content;
+}
+
+TEST_CASE(layoutChangedEventFires) {
+    std::filesystem::remove(LAYOUT_FLAG);
+
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'dwindle' } })"));
+
+    OK(getFromSocket("/eval hl.on('workspace.layout_changed', function(ws, layout) "
+                     "local f = io.open('/tmp/hyprtester-layout-changed.txt', 'w') "
+                     "f:write(layout) f:close() end)"));
+
+    ASSERT(!!Tests::spawnKitty(), true);
+
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'master' } })"));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    auto layout = readLayoutFlag();
+    EXPECT(layout, std::string("master"));
+
+    std::filesystem::remove(LAYOUT_FLAG);
 }

--- a/src/config/lua/LuaEventHandler.cpp
+++ b/src/config/lua/LuaEventHandler.cpp
@@ -146,6 +146,12 @@ CLuaEventHandler::CLuaEventHandler(lua_State* L) : m_lua(L) {
             CLuaMonitor::push(L, mon);
         });
     }));
+    m_listeners.push_back(bus()->m_events.workspace.layoutChanged.listen([this](PHLWORKSPACE ws, const std::string& layout) {
+        dispatch("workspace.layout_changed", 2, [&](lua_State* L) {
+            CLuaWorkspace::push(L, ws);
+            lua_pushstring(L, layout.c_str());
+        });
+    }));
 
     m_listeners.push_back(bus()->m_events.config.reloaded.listen([this] { dispatch("config.reloaded", 0, [](lua_State* L) {}); }));
     m_listeners.push_back(
@@ -276,6 +282,7 @@ std::unordered_set<std::string> CLuaEventHandler::knownEvents() {
         "workspace.created",
         "workspace.removed",
         "workspace.move_to_monitor",
+        "workspace.layout_changed",
         "config.reloaded",
         "keybinds.submap",
         "screenshare.state",

--- a/src/event/EventBus.hpp
+++ b/src/event/EventBus.hpp
@@ -157,11 +157,12 @@ namespace Event {
             } monitor;
 
             struct {
-                Event<PHLWORKSPACE, PHLMONITOR> moveToMonitor;
-                Event<PHLWORKSPACE>             active;
-                Event<PHLWORKSPACE, PHLMONITOR> specialActive;
-                Event<PHLWORKSPACEREF>          created;
-                Event<PHLWORKSPACEREF>          removed;
+                Event<PHLWORKSPACE, PHLMONITOR>         moveToMonitor;
+                Event<PHLWORKSPACE>                     active;
+                Event<PHLWORKSPACE, PHLMONITOR>         specialActive;
+                Event<PHLWORKSPACEREF>                  created;
+                Event<PHLWORKSPACEREF>                  removed;
+                Event<PHLWORKSPACE, const std::string&> layoutChanged;
             } workspace;
 
             struct {

--- a/src/layout/supplementary/WorkspaceAlgoMatcher.cpp
+++ b/src/layout/supplementary/WorkspaceAlgoMatcher.cpp
@@ -15,6 +15,7 @@
 
 #include "../../Compositor.hpp"
 #include "../../state/WorkspaceState.hpp"
+#include "../../event/EventBus.hpp"
 
 using namespace Layout;
 using namespace Layout::Supplementary;
@@ -133,6 +134,9 @@ void CWorkspaceAlgoMatcher::updateWorkspaceLayouts() {
 
         // needs a switchup
         ws->m_space->algorithm()->updateTiledAlgo(algoForNameTiled(LAYOUT_TO_USE));
+
+        const auto WSLOCK = ws.lock();
+        Event::bus()->m_events.workspace.layoutChanged.emit(WSLOCK, LAYOUT_TO_USE);
     }
 }
 

--- a/tests/config/lua/LuaEventHandler.cpp
+++ b/tests/config/lua/LuaEventHandler.cpp
@@ -177,3 +177,28 @@ TEST(ConfigLuaEventHandler, removeNonexistentCustomEventFails) {
 
     EXPECT_FALSE(handler.removeCustomEvent("plugin.nonexistent"));
 }
+
+TEST(ConfigLuaEventHandler, workspaceLayoutChangedEvent) {
+    CLuaState        S;
+    const auto       L = S.get();
+    CLuaEventHandler handler(L);
+
+    ASSERT_EQ(luaL_dostring(L, R"(
+        lastLayout = ""
+        function onLayoutChanged(ws, layout)
+            lastLayout = layout
+        end
+    )"),
+              LUA_OK);
+
+    const int  ref    = refGlobalFunction(L, "onLayoutChanged");
+    const auto handle = handler.registerEvent("workspace.layout_changed", ref);
+    ASSERT_TRUE(handle.has_value());
+
+    Event::bus()->m_events.workspace.layoutChanged.emit(nullptr, "master");
+
+    lua_getglobal(L, "lastLayout");
+    ASSERT_TRUE(lua_isstring(L, -1));
+    EXPECT_STREQ(lua_tostring(L, -1), "master");
+    lua_pop(L, 1);
+}


### PR DESCRIPTION
Currently there's no IPC event when a workspace's tiling layout changes (e.g. dwindle ->master), 
so external tools like bar widgets have no way to detect it without polling. 
This adds a layoutchanged event emitted on socket2 with the format

layoutchanged>>workspacename,layoutname, 

fired from updateWorkspaceLayouts() after the algorithm switch.


#### Is it ready for merging, or does it need work?
Ready for merging!

