### PR TITLE
config/workspace_rules: add ability to pass workspace as object, fix passing workspace by ID

### DIFF
--- a/hyprtester/src/tests/main/workspaces.cpp
+++ b/hyprtester/src/tests/main/workspaces.cpp
@@ -752,6 +752,129 @@ TEST_CASE(workspacesCombined) {
     ASSERT(Tests::windowCount(), 0);
 }
 
+
+TEST_CASE() {
+
+
+    Tests::spawnKitty("kittycat");
+
+    // normal Workspace
+
+    // test both moving a window and focusing a workspace
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ workspace = 'id:2', silent = true })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'id:2' })"));
+    
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:kittycat' })"));
+    {
+        auto str = getFromSocket("/activewindow");
+        ASSERT_CONTAINS(str, "class: kittycat");
+        ASSERT_CONTAINS(str, "workspace: 2");
+ 
+    }
+
+
+    // Special Workspace
+
+    // test both moving a window and focusing a workspace
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ workspace = 'id:-99', silent = true })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'id:-99' })"));
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:kittycat' })"));
+    {
+        auto str = getFromSocket("/activewindow");
+        ASSERT_CONTAINS(str, "class: kittycat");
+        ASSERT_CONTAINS(str, "workspace: -99");
+ 
+    }
+
+}
+
+TEST_CASE(workspaceMoveFocusWithWorkspaceObject) {
+
+
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'id:2' })"));
+
+    OK(getFromSocket("/eval 'local workspaceVar = hl.get_active_workspace()'"));
+    
+    // Spawn a window to prevent from it being destroyed
+    Tests::spawnKitty("doorstopper");
+    
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'id:1' })"));
+
+    Tests::spawnKitty("traveller");
+
+    // test both moving a window and focusing a workspace
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ workspace = workspaceVar, silent = true })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = workspaceVar })"));
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:traveller' })"));
+
+    {
+        auto str = getFromSocket("/activewindow");
+        ASSERT_CONTAINS(str, "class: traveller");
+        ASSERT_CONTAINS(str, "workspace: 2");
+    }
+
+
+
+    // get rid of variable - clean start
+    OK(getFromSocket("/reload"));
+    
+
+    // Same test as above, but with a special workspace
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'id:-99' })"));
+
+    OK(getFromSocket("/eval 'local workspaceVar = hl.get_active_workspace()'"));
+    
+    // Spawn a window to prevent from it being destroyed
+    Tests::spawnKitty("doorstopper");
+    
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'id:1' })"));
+
+    Tests::spawnKitty("traveller");
+
+    // test both moving a window and focusing a workspace
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ workspace = workspaceVar, silent = true })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = workspaceVar })"));
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:traveller' })"));
+
+    {
+        auto str = getFromSocket("/activewindow");
+        ASSERT_CONTAINS(str, "class: traveller");
+        ASSERT_CONTAINS(str, "workspace: -99");
+    }
+}
+
+
+
+TEST_CASE(workspaceRuleWithID) {
+
+    // normal
+
+
+    // special
+
+}
+
+
+TEST_CASE(workspaceRuleWithWorkspaceObject) {
+
+
+
+
+
+
+
+}
+
+
+
+
+
+
 TEST_CASE(workspacesFollowProperNoGaps) {
     OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = \"100\" })"));
     OK(getFromSocket(R"#(/eval hl.workspace_rule({ workspace = "w[tv1]", gaps_out = 0, gaps_in = 0 })

--- a/src/config/lua/bindings/LuaBindingsConfigRules.cpp
+++ b/src/config/lua/bindings/LuaBindingsConfigRules.cpp
@@ -627,12 +627,15 @@ static int hlWorkspaceRule(lua_State* L) {
     const std::string sourceInfo = Internal::getSourceInfo(L);
 
     lua_getfield(L, 1, "workspace");
-    if (!lua_isstring(L, -1)) {
-        self->addError(std::format("{}: hl.workspace_rule: 'workspace' field is required and must be a string", sourceInfo));
+
+    const std::string wsStr = Internal::workspaceSelectorFromLuaSelectorOrObject(L, -1, "hl.workspace_rule").value_or("");
+
+    if (wsStr == "") {
+        self->addError(std::format("{}: hl.workspace_rule: 'workspace' field invalid. Must be a workspace object or selector string", sourceInfo));
         lua_pop(L, 1);
         return 0;
     }
-    const std::string wsStr = lua_tostring(L, -1);
+
     lua_pop(L, 1);
 
     bool enabled = true;

--- a/src/config/lua/bindings/LuaBindingsInternal.cpp
+++ b/src/config/lua/bindings/LuaBindingsInternal.cpp
@@ -189,7 +189,7 @@ std::optional<std::string> Internal::workspaceSelectorFromLuaSelectorOrObject(lu
             return std::nullopt;
         }
 
-        return std::to_string(ws->m_id);
+        return "id:" + std::to_string(ws->m_id);
     }
 
     if (lua_isstring(L, idx) || lua_isnumber(L, idx))

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -122,7 +122,14 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
     if (selector.empty())
         return true;
 
-    if (isNumber(selector)) {
+    if (selector.starts_with("id:")) {
+
+        // id:###
+        if (!isNumber(selector.substr(3))) {
+            Log::logger->log(Log::ERR, "id: is not numeric");
+            return false;
+        }
+
         const auto& [wsid, wsname, isAutoID] = getWorkspaceIDNameFromString(selector);
 
         if (wsid == WORKSPACE_INVALID)
@@ -134,7 +141,15 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
         return m_name == selector.substr(5);
     } else if (selector.starts_with("special")) {
         return m_name == selector;
-    } else {
+    } else if (isNumber(selector)) {
+        const auto& [wsid, wsname, isAutoID] = getWorkspaceIDNameFromString(selector);
+
+        if (wsid == WORKSPACE_INVALID)
+            return false;
+
+        return wsid == m_id;
+    }
+    else {
         // parse selector
 
         for (size_t i = 0; i < selector.length(); ++i) {

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -146,6 +146,28 @@ SWorkspaceIDName getWorkspaceIDNameFromString(const std::string& in) {
             result.id = WORKSPACE->m_id;
         }
         result.name = WORKSPACENAME;
+    } else if (in.starts_with("id:")) {
+        const std::string WORKSPACEIDSTRING = in.substr(in.find_first_of(':') + 1);
+
+        if (isNumber(WORKSPACEIDSTRING)) {
+            const int  WORKSPACEID = std::stoi(WORKSPACEIDSTRING);
+            const auto WORKSPACE   = State::workspaceState()->query().id(WORKSPACEID).run();
+
+            if (!WORKSPACE) {
+                const auto NEXT_AVAILABLE_WORKSPACE_ID = State::workspaceState()->nextAvailableNamedWorkspace();
+                const auto NEXT_AVAILABLE_WORKSPACE    = State::workspaceState()->query().id(NEXT_AVAILABLE_WORKSPACE_ID).run();
+
+                result.id   = NEXT_AVAILABLE_WORKSPACE_ID;
+                result.name = NEXT_AVAILABLE_WORKSPACE ? NEXT_AVAILABLE_WORKSPACE->m_name : "";
+            } else {
+                result.id   = WORKSPACE->m_id;
+                result.name = WORKSPACE->m_name;
+            }
+            return result;
+        } else {
+            Log::logger->log(Log::ERR, "id: is not numeric");
+            return {WORKSPACE_INVALID};
+        }
     } else if (in.starts_with("empty")) {
         const bool same_mon = in.substr(5).contains("m");
         const bool next     = in.substr(5).contains("n");


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

- Passing workspace object as selectors to workspace_rules do not work: add that ability to match the claims of the wiki

- Passing special workspace's ID doesn't work as the selector string parser interprets it as a relative workspace selector instead of an ID.

```lua
        hl.workspace_rule({
        workspace = currentWorkspace.id,
        gaps_in = 0,
        gaps_out = 0
    })
```

When on special workspace; it passes `-INT`, which is interpreted as a relative workspace.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

This should work with all dispatches that also accept workspaces as arguments as this checks IDs as a part of the selector string, and the object change was only necessary for workspace_rules

#### Is it ready for merging, or does it need work?

TODO:

- [x] Wiki PR for the ID change
