### PR TITLE
layout->workspacealgomatcher: modified the workspacealgomatcher to use numerical ids instead of string comparisons making it more efficient; fixed the few now broken dependecies which required a string via an helper fn

### DIFF
--- a/src/config/lua/objects/LuaWindow.cpp
+++ b/src/config/lua/objects/LuaWindow.cpp
@@ -176,7 +176,7 @@ static int windowIndex(lua_State* L) {
         }
 
         const auto&       tiledAlgo = algo->tiledAlgo();
-        const std::string name      = Layout::Supplementary::algoMatcher()->getNameForTiledAlgo(tiledAlgo.get());
+        const std::string name      = Layout::Supplementary::algoMatcher()->getNameForID(Layout::Supplementary::algoMatcher()->getIDForTiledAlgo(tiledAlgo.get()).value());
 
         lua_newtable(L);
         lua_pushstring(L, name.c_str());

--- a/src/config/lua/objects/LuaWorkspace.cpp
+++ b/src/config/lua/objects/LuaWorkspace.cpp
@@ -136,7 +136,7 @@ static int workspaceIndex(lua_State* L) {
         std::string layoutName = "unknown";
         if (ws->m_space && ws->m_space->algorithm() && ws->m_space->algorithm()->tiledAlgo()) {
             const auto& TILED_ALGO = ws->m_space->algorithm()->tiledAlgo();
-            layoutName             = Layout::Supplementary::algoMatcher()->getNameForTiledAlgo(TILED_ALGO.get());
+            layoutName             = Layout::Supplementary::algoMatcher()->getNameForID(Layout::Supplementary::algoMatcher()->getIDForTiledAlgo(TILED_ALGO.get()).value());
         }
         lua_pushstring(L, layoutName.c_str());
     } else if (key == "last_window") {

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -478,7 +478,7 @@ std::string CHyprCtl::getWorkspaceData(PHLWORKSPACE w, eHyprCtlOutputFormat form
     std::string layoutName = "unknown";
     if (w->m_space && w->m_space->algorithm() && w->m_space->algorithm()->tiledAlgo()) {
         const auto& TILED_ALGO = w->m_space->algorithm()->tiledAlgo();
-        layoutName             = Layout::Supplementary::algoMatcher()->getNameForTiledAlgo(&typeid(*TILED_ALGO.get()));
+        layoutName             = Layout::Supplementary::algoMatcher()->getNameForID(Layout::Supplementary::algoMatcher()->getIDForTiledAlgo(TILED_ALGO.get()).value());
     }
 
     if (format == eHyprCtlOutputFormat::FORMAT_JSON) {

--- a/src/layout/supplementary/WorkspaceAlgoMatcher.cpp
+++ b/src/layout/supplementary/WorkspaceAlgoMatcher.cpp
@@ -27,15 +27,21 @@ const UP<CWorkspaceAlgoMatcher>& Supplementary::algoMatcher() {
 }
 
 CWorkspaceAlgoMatcher::CWorkspaceAlgoMatcher() {
+    const auto DWINDLE_ID   = nextAlgoID();
+    const auto MASTER_ID    = nextAlgoID();
+    const auto SCROLLING_ID = nextAlgoID();
+    const auto MONOCLE_ID   = nextAlgoID();
+    const auto DEFAULT_ID   = nextAlgoID();
+
     m_tiledAlgos = {
-        {"dwindle", [] { return makeUnique<Tiled::CDwindleAlgorithm>(); }},
-        {"master", [] { return makeUnique<Tiled::CMasterAlgorithm>(); }},
-        {"scrolling", [] { return makeUnique<Tiled::CScrollingAlgorithm>(); }},
-        {"monocle", [] { return makeUnique<Tiled::CMonocleAlgorithm>(); }},
+        {"dwindle", {.id = DWINDLE_ID, .factory = [] { return makeUnique<Tiled::CDwindleAlgorithm>(); }}},
+        {"master", {.id = MASTER_ID, .factory = [] { return makeUnique<Tiled::CMasterAlgorithm>(); }}},
+        {"scrolling", {.id = SCROLLING_ID, .factory = [] { return makeUnique<Tiled::CScrollingAlgorithm>(); }}},
+        {"monocle", {.id = MONOCLE_ID, .factory = [] { return makeUnique<Tiled::CMonocleAlgorithm>(); }}},
     };
 
     m_floatingAlgos = {
-        {"default", [] { return makeUnique<Floating::CDefaultFloatingAlgorithm>(); }},
+        {"default", {.id = DEFAULT_ID, .factory = [] { return makeUnique<Floating::CDefaultFloatingAlgorithm>(); }}},
     };
 
     m_algoNames = {
@@ -45,14 +51,40 @@ CWorkspaceAlgoMatcher::CWorkspaceAlgoMatcher() {
         {&typeid(Tiled::CMonocleAlgorithm), "monocle"},
         {&typeid(Floating::CDefaultFloatingAlgorithm), "default"},
     };
+
+    m_algoIDs = {
+        {&typeid(Tiled::CDwindleAlgorithm), DWINDLE_ID},
+        {&typeid(Tiled::CMasterAlgorithm), MASTER_ID},
+        {&typeid(Tiled::CScrollingAlgorithm), SCROLLING_ID},
+        {&typeid(Tiled::CMonocleAlgorithm), MONOCLE_ID},
+        {&typeid(Floating::CDefaultFloatingAlgorithm), DEFAULT_ID},
+    };
+
+    m_nameIDs = {
+        {"dwindle", DWINDLE_ID}, {"master", MASTER_ID}, {"scrolling", SCROLLING_ID}, {"monocle", MONOCLE_ID}, {"default", DEFAULT_ID},
+    };
+
+    m_idNames = {
+        {DWINDLE_ID, "dwindle"}, {MASTER_ID, "master"}, {SCROLLING_ID, "scrolling"}, {MONOCLE_ID, "monocle"}, {DEFAULT_ID, "default"},
+    };
 }
 
 bool CWorkspaceAlgoMatcher::registerTiledAlgo(const std::string& name, const std::type_info* typeInfo, std::function<UP<ITiledAlgorithm>()>&& factory) {
     if (m_tiledAlgos.contains(name) || m_floatingAlgos.contains(name))
         return false;
 
-    m_tiledAlgos.emplace(name, std::move(factory));
+    const auto ID = nextAlgoID();
+
+    m_tiledAlgos.emplace(name,
+                         STiledAlgoEntry{
+                             .id      = ID,
+                             .factory = std::move(factory),
+                         });
+
     m_algoNames.emplace(typeInfo, name);
+    m_algoIDs.emplace(typeInfo, ID);
+    m_nameIDs.emplace(name, ID);
+    m_idNames.emplace(ID, name);
 
     updateWorkspaceLayouts();
 
@@ -63,8 +95,18 @@ bool CWorkspaceAlgoMatcher::registerFloatingAlgo(const std::string& name, const 
     if (m_tiledAlgos.contains(name) || m_floatingAlgos.contains(name))
         return false;
 
-    m_floatingAlgos.emplace(name, std::move(factory));
+    const auto ID = nextAlgoID();
+
+    m_floatingAlgos.emplace(name,
+                            SFloatingAlgoEntry{
+                                .id      = ID,
+                                .factory = std::move(factory),
+                            });
+
     m_algoNames.emplace(typeInfo, name);
+    m_algoIDs.emplace(typeInfo, ID);
+    m_nameIDs.emplace(name, ID);
+    m_idNames.emplace(ID, name);
 
     updateWorkspaceLayouts();
 
@@ -75,12 +117,22 @@ bool CWorkspaceAlgoMatcher::unregisterAlgo(const std::string& name) {
     if (!m_tiledAlgos.contains(name) && !m_floatingAlgos.contains(name))
         return false;
 
+    std::erase_if(m_algoIDs, [this, &name](const auto& e) {
+        const auto NAME = m_algoNames.find(e.first);
+        return NAME != m_algoNames.end() && NAME->second == name;
+    });
+
     std::erase_if(m_algoNames, [&name](const auto& e) { return e.second == name; });
+
+    m_nameIDs.erase(name);
 
     if (m_floatingAlgos.contains(name))
         m_floatingAlgos.erase(name);
     else
         m_tiledAlgos.erase(name);
+
+    if (const auto ID = getIDForName(name); ID.has_value())
+        m_idNames.erase(*ID);
 
     // this is needed here to avoid situations where a plugin unloads and we still have a UP
     // to a plugin layout
@@ -89,16 +141,18 @@ bool CWorkspaceAlgoMatcher::unregisterAlgo(const std::string& name) {
     return true;
 }
 
-UP<ITiledAlgorithm> CWorkspaceAlgoMatcher::algoForNameTiled(const std::string& s) {
+UP<ITiledAlgorithm> CWorkspaceAlgoMatcher::algoForNameTiled(const std::string& s) const {
     if (m_tiledAlgos.contains(s))
-        return m_tiledAlgos.at(s)();
-    return m_tiledAlgos.at(DEFAULT_TILED_ALGO)();
+        return m_tiledAlgos.at(s).factory();
+
+    return m_tiledAlgos.at(DEFAULT_TILED_ALGO).factory();
 }
 
-UP<IFloatingAlgorithm> CWorkspaceAlgoMatcher::algoForNameFloat(const std::string& s) {
+UP<IFloatingAlgorithm> CWorkspaceAlgoMatcher::algoForNameFloat(const std::string& s) const {
     if (m_floatingAlgos.contains(s))
-        return m_floatingAlgos.at(s)();
-    return m_floatingAlgos.at(DEFAULT_FLOATING_ALGO)();
+        return m_floatingAlgos.at(s).factory();
+
+    return m_floatingAlgos.at(DEFAULT_FLOATING_ALGO).factory();
 }
 
 std::string CWorkspaceAlgoMatcher::tiledAlgoForWorkspace(const PHLWORKSPACE& w) {
@@ -108,12 +162,15 @@ std::string CWorkspaceAlgoMatcher::tiledAlgoForWorkspace(const PHLWORKSPACE& w) 
     return rule && rule->m_layout.has_value() ? rule->m_layout.value() : *PLAYOUT;
 }
 
+CWorkspaceAlgoMatcher::AlgoID CWorkspaceAlgoMatcher::nextAlgoID() {
+    return m_nextAlgoID++;
+}
+
 SP<CAlgorithm> CWorkspaceAlgoMatcher::createAlgorithmForWorkspace(PHLWORKSPACE w) {
     return CAlgorithm::create(algoForNameTiled(tiledAlgoForWorkspace(w)), makeUnique<Floating::CDefaultFloatingAlgorithm>(), w->m_space);
 }
 
 void CWorkspaceAlgoMatcher::updateWorkspaceLayouts() {
-    // TODO: make this ID-based, string comparison is slow
     for (const auto& ws : g_pCompositor->getWorkspaces()) {
         if (!ws)
             continue;
@@ -125,9 +182,13 @@ void CWorkspaceAlgoMatcher::updateWorkspaceLayouts() {
 
         const auto LAYOUT_TO_USE = tiledAlgoForWorkspace(ws.lock());
 
-        const auto CURRENT_LAYOUT = getNameForTiledAlgo(TILED_ALGO.get());
+        const auto CURRENT_LAYOUT_ID = getIDForTiledAlgo(TILED_ALGO.get());
+        auto       TARGET_LAYOUT_ID  = getIDForName(LAYOUT_TO_USE);
 
-        if (CURRENT_LAYOUT == LAYOUT_TO_USE && m_tiledAlgos.contains(LAYOUT_TO_USE))
+        if (!TARGET_LAYOUT_ID.has_value())
+            TARGET_LAYOUT_ID = getIDForName(DEFAULT_TILED_ALGO);
+
+        if (CURRENT_LAYOUT_ID.has_value() && TARGET_LAYOUT_ID.has_value() && *CURRENT_LAYOUT_ID == *TARGET_LAYOUT_ID)
             continue;
 
         // needs a switchup
@@ -135,18 +196,33 @@ void CWorkspaceAlgoMatcher::updateWorkspaceLayouts() {
     }
 }
 
-std::string CWorkspaceAlgoMatcher::getNameForTiledAlgo(const ITiledAlgorithm* algo) {
-    if (!algo)
-        return "unknown";
+std::optional<CWorkspaceAlgoMatcher::AlgoID> CWorkspaceAlgoMatcher::getIDForName(const std::string& name) {
+    if (m_nameIDs.contains(name))
+        return m_nameIDs.at(name);
 
-    if (const auto name = algo->layoutName(); name.has_value())
-        return *name;
-
-    return getNameForTiledAlgo(&typeid(*algo));
+    return std::nullopt;
 }
 
-std::string CWorkspaceAlgoMatcher::getNameForTiledAlgo(const std::type_info* type) {
-    if (m_algoNames.contains(type))
-        return m_algoNames.at(type);
+std::optional<CWorkspaceAlgoMatcher::AlgoID> CWorkspaceAlgoMatcher::getIDForTiledAlgo(const ITiledAlgorithm* algo) {
+    if (!algo)
+        return std::nullopt;
+
+    if (const auto NAME = algo->layoutName(); NAME.has_value())
+        return getIDForName(*NAME);
+
+    return getIDForTiledAlgo(&typeid(*algo));
+}
+
+std::optional<CWorkspaceAlgoMatcher::AlgoID> CWorkspaceAlgoMatcher::getIDForTiledAlgo(const std::type_info* type) {
+    if (m_algoIDs.contains(type))
+        return m_algoIDs.at(type);
+
+    return std::nullopt;
+}
+
+std::string CWorkspaceAlgoMatcher::getNameForID(const AlgoID id) {
+    if (m_idNames.contains(id))
+        return m_idNames.at(id);
+
     return "unknown";
 }

--- a/src/layout/supplementary/WorkspaceAlgoMatcher.hpp
+++ b/src/layout/supplementary/WorkspaceAlgoMatcher.hpp
@@ -3,7 +3,6 @@
 #include "../../desktop/DesktopTypes.hpp"
 
 #include <map>
-#include <type_traits>
 #include <functional>
 #include <string>
 
@@ -16,13 +15,17 @@ namespace Layout {
 namespace Layout::Supplementary {
     class CWorkspaceAlgoMatcher {
       public:
+        using AlgoID = uint32_t;
+
         CWorkspaceAlgoMatcher();
         ~CWorkspaceAlgoMatcher() = default;
 
-        SP<CAlgorithm> createAlgorithmForWorkspace(PHLWORKSPACE w);
-        void           updateWorkspaceLayouts();
-        std::string    getNameForTiledAlgo(const Layout::ITiledAlgorithm* algo);
-        std::string    getNameForTiledAlgo(const std::type_info* type);
+        SP<CAlgorithm>        createAlgorithmForWorkspace(PHLWORKSPACE w);
+        void                  updateWorkspaceLayouts();
+        std::optional<AlgoID> getIDForName(const std::string& name);
+        std::optional<AlgoID> getIDForTiledAlgo(const ITiledAlgorithm* algo);
+        std::optional<AlgoID> getIDForTiledAlgo(const std::type_info* type);
+        std::string           getNameForID(AlgoID id);
 
         // these fns can fail due to name collisions
         bool registerTiledAlgo(const std::string& name, const std::type_info* typeInfo, std::function<UP<ITiledAlgorithm>()>&& factory);
@@ -32,15 +35,32 @@ namespace Layout::Supplementary {
         bool unregisterAlgo(const std::string& name);
 
       private:
-        UP<ITiledAlgorithm>                                            algoForNameTiled(const std::string& s);
-        UP<IFloatingAlgorithm>                                         algoForNameFloat(const std::string& s);
+        struct STiledAlgoEntry {
+            AlgoID                               id = 0;
+            std::function<UP<ITiledAlgorithm>()> factory;
+        };
 
-        std::string                                                    tiledAlgoForWorkspace(const PHLWORKSPACE&);
+        struct SFloatingAlgoEntry {
+            AlgoID                                  id = 0;
+            std::function<UP<IFloatingAlgorithm>()> factory;
+        };
 
-        std::map<std::string, std::function<UP<ITiledAlgorithm>()>>    m_tiledAlgos;
-        std::map<std::string, std::function<UP<IFloatingAlgorithm>()>> m_floatingAlgos;
+        UP<ITiledAlgorithm>                          algoForNameTiled(const std::string& s) const;
+        UP<IFloatingAlgorithm>                       algoForNameFloat(const std::string& s) const;
 
-        std::map<const std::type_info*, std::string>                   m_algoNames;
+        std::string                                  tiledAlgoForWorkspace(const PHLWORKSPACE&);
+
+        AlgoID                                       nextAlgoID();
+
+        std::map<std::string, STiledAlgoEntry>       m_tiledAlgos;
+        std::map<std::string, SFloatingAlgoEntry>    m_floatingAlgos;
+
+        std::map<const std::type_info*, std::string> m_algoNames;
+        std::map<const std::type_info*, AlgoID>      m_algoIDs;
+        std::map<std::string, AlgoID>                m_nameIDs;
+        std::map<AlgoID, std::string>                m_idNames;
+
+        AlgoID                                       m_nextAlgoID = 1;
     };
 
     const UP<CWorkspaceAlgoMatcher>& algoMatcher();


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
it "fixes" the workspacealgomatcher by, as it was indicated in a TODO there, modifying the logic so that instead of using string compares and overall strings it will now use numerical ids, making it more efficient (there's still an helper fn to convert an id to its respective string obv). the structure remains the same, but i had to edit most functions there, in order to implement this

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
i have checked all previous external usages of functions from this file which required strings and i should have converted them all (just added a wrapper to convert the id back to a string there)

#### Is it ready for merging, or does it need work?
should be ready for directly merging yeah

