### PR TITLE
compositor: fix monitor re-enabling on hotplug when dpms is off

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -3048,6 +3048,13 @@ void CCompositor::onNewMonitor(SP<Aquamarine::IOutput> output) {
     if (!PNEWMONITOR->m_enabled || FALLBACK)
         return;
 
+    // Some monitors disconnect and reconnect when receiving no signal (e.g. during dpms off).
+    // Re-apply dpms off so the hotplug doesn't override a user-initiated power-off.
+    if (!g_pCompositor->m_dpmsStateOn) {
+        PNEWMONITOR->setDPMS(false);
+        return;
+    }
+
     // ready to process if we have a real monitor
 
     if ((!g_pHyprRenderer->m_mostHzMonitor || PNEWMONITOR->m_refreshRate > g_pHyprRenderer->m_mostHzMonitor->m_refreshRate) && PNEWMONITOR->m_enabled)


### PR DESCRIPTION
Used AI assistance to translate descriptions from Chinese to English,  and to help analyze the root cause by comparing with the niri repository.

 # Describe your PR, what does it fix/add?

Some monitors (e.g. MSI MP273U over HDMI) report a DRM connector disconnect when they receive no signal, then immediately reconnect. 
This causes a repeated hotplug loop after dpms off, where onNewMonitor unconditionally re-enables the monitor on each reconnect, waking the screen.

See discussion: #14817

## Fix
In onNewMonitor, after the monitor is connected and enabled, check  g_pCompositor->m_dpmsStateOn. If DPMS is currently off, call setDPMS(false) on the newly connected monitor and return early, preventing it from being re-enabled.

This the approach taken by niri in [src/backend/tty.rs](https://github.com/niri-wm/niri/blob/4294948cf1c70c50e938383c2c865d7ca455ac7e/src/backend/tty.rs#L1509)

## Testing

Tested on AMD HD 7750 with MSI MP273U (HDMI) and BenQ GL2450H (DP).  After the fix, hyprctl dispatch dpms off keeps both monitors off and works correctly.


# Is there anything you want to mention?
Only affects monitors with this specific behavior (disconnect-on-no-signal). Monitors that stay connected during dpms off are unaffected.

# Is it ready for merging, or does it need work?
  Ready for merging.
