### PR TITLE
desktop/window: allow focus while held to non-OR X11 windows

### DIFF
--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -2187,7 +2187,8 @@ void CWindow::mapWindow() {
         !monitorSilent && (!PFORCEFOCUS || PFORCEFOCUS == m_self.lock()) && !g_pInputManager->isConstrained()) {
 
         // don't steal pointer focus with X11 when buttons are held (e.g., during drags)
-        if (!m_isX11 || !g_pInputManager->hasHeldButtons()) {
+        // if the incoming window is an OR
+        if (!m_isX11 || !g_pInputManager->hasHeldButtons() || !isX11OverrideRedirect()) {
             // this window should gain focus: if it's grouped, preserve fullscreen state.
             const bool SAME_GROUP = m_group && m_group->has(LAST_FOCUS_WINDOW);
 


### PR DESCRIPTION
the drag bug only happens on OR windows, so we should just skip those. Regular toplevels should be focusable.

should fix #14782

tagging @nynxz and @enzi for testing

