### PR TITLE
window: fix wrong scale being applied after workspace rules change monitor

### DIFF
--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -688,8 +688,6 @@ void CWindow::onMap() {
     m_reportedSize = m_pendingReportedSize;
     m_animatingIn  = true;
 
-    updateSurfaceScaleTransformDetails(true);
-
     if (m_isX11)
         return;
 
@@ -2106,6 +2104,8 @@ void CWindow::mapWindow() {
         Log::logger->log(Log::DEBUG, "Requested monitor, applying to {:mw}", m_self.lock());
     }
 
+    PMONITOR = m_monitor.lock();
+
     // Verify window swallowing. Get the swallower before calling onWindowCreated(m_self.lock()) because getSwallower() wouldn't get it after if m_self.lock() gets auto grouped.
     const auto SWALLOWER = getSwallower();
     m_swallowed          = SWALLOWER;
@@ -2232,7 +2232,7 @@ void CWindow::mapWindow() {
     // recheck idle inhibitors
     g_pInputManager->recheckIdleInhibitorStatus();
 
-    updateToplevel();
+    updateSurfaceScaleTransformDetails(true);
     m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_ALL);
 
     if (workspaceSilent) {
@@ -2272,9 +2272,6 @@ void CWindow::mapWindow() {
     // avoid this window being visible
     if (PWORKSPACE->m_hasFullscreenWindow && !isFullscreen() && !m_isFloating)
         alpha(WINDOW_ALPHA_FULLSCREEN)->setValueAndWarp(0.f);
-
-    g_pCompositor->setPreferredScaleForSurface(wlSurface()->resource(), PMONITOR->m_scale);
-    g_pCompositor->setPreferredTransformForSurface(wlSurface()->resource(), PMONITOR->m_transform);
 
     if (g_pSeatManager->m_mouse.expired() || !g_pInputManager->isConstrained())
         g_pInputManager->sendMotionEventsToFocused();


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->

No AI.


#### Describe your PR, what does it fix/add?

Removes redundant surface scale and transform updates from mapWindow. The full tree of subsurfaces was being walked twice, and at the end the main surface was also being updated on its own. But PMONITOR wasn't being updated to the current monitor after applying workspace rules, so that last one was based on a stale monitor.

Fixes https://github.com/hyprwm/Hyprland/discussions/14726

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Tested locally and confirmed the scale was only being sent to the surface once, with the correct value, whether or not the target workspace already exists. There are no returns in mapWindow() after onMap() is called so I think the call in onMap is safe to remove.

#### Is it ready for merging, or does it need work?
Ready.