### PR TITLE
fix(hyprctl): dispatch v2 fallback

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1103,17 +1103,14 @@ static std::string dispatchRequest(eHyprCtlOutputFormat format, std::string in) 
     // get rid of the dispatch keyword
     in = in.substr(in.find_first_of(' ') + 1);
 
-    if (Config::mgr()->type() == Config::CONFIG_LUA) {
-        // For lua, this is just a wrapper for `eval("hl.dispatch(in)")
+    if (Config::mgr()->type() == Config::CONFIG_LUA && in.contains("(")) {
+        // Input contains parentheses, so it is a Lua expression (e.g.
+        // hl.plugin.foo.bar("arg")).  Evaluate it through the Lua config
+        // manager.  Dispatcher names registered via addDispatcherV2 never
+        // contain '(', so the direct lookup below will handle them.
         std::string evalStr = std::format("return hl.dispatch({})", in);
         auto        luaMgr  = dynamicPointerCast<Config::Lua::CConfigManager>(WP<Config::IConfigManager>(Config::mgr()));
-        auto        ret     = luaMgr->eval(evalStr).value_or("ok");
-
-        if (ret.starts_with("ok") || in.contains("(") /* this likely means the user is passing a valid lua dispatch string */)
-            return ret;
-
-        // the user likely is trying to dispatch old hyprlang stuff via lua, let them know
-        return ret + "\n\n → Note: dispatch in lua is a shorthand for hl.dispatch(...), your syntax might need to be updated.";
+        return luaMgr->eval(evalStr).value_or("ok");
     }
 
     const auto DISPATCHSTR = in.substr(0, in.find_first_of(' '));

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1103,14 +1103,20 @@ static std::string dispatchRequest(eHyprCtlOutputFormat format, std::string in) 
     // get rid of the dispatch keyword
     in = in.substr(in.find_first_of(' ') + 1);
 
-    if (Config::mgr()->type() == Config::CONFIG_LUA && in.contains("(")) {
-        // Input contains parentheses, so it is a Lua expression (e.g.
-        // hl.plugin.foo.bar("arg")).  Evaluate it through the Lua config
-        // manager.  Dispatcher names registered via addDispatcherV2 never
-        // contain '(', so the direct lookup below will handle them.
+    if (Config::mgr()->type() == Config::CONFIG_LUA) {
+        // Try Lua evaluation first for expressions (e.g.
+        // hl.plugin.foo.bar("arg")).
         std::string evalStr = std::format("return hl.dispatch({})", in);
         auto        luaMgr  = dynamicPointerCast<Config::Lua::CConfigManager>(WP<Config::IConfigManager>(Config::mgr()));
-        return luaMgr->eval(evalStr).value_or("ok");
+        auto        ret     = luaMgr->eval(evalStr).value_or("ok");
+
+        if (ret.starts_with("ok") || in.contains("("))
+            return ret;
+
+        // Lua evaluation failed and this is not an explicit Lua
+        // expression.  Fall through to the direct dispatcher lookup
+        // so that V2 dispatchers (e.g. plugin:action) still work
+        // regardless of config type.
     }
 
     const auto DISPATCHSTR = in.substr(0, in.find_first_of(' '));


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Since 0.55, hyprctl IPC calls are routed to lua evaluator when the user has Lua config active and just errors if the call failed either if it was a true lua call or a old-style hyprlang call. I judge that this behaviour is extreme and unnecessary. It's perfectly possible to reroute the calls to the hyprlang evaluator if Lua evaluator failed AND the input expression didn't have character `(` in it. It's in fact an heuristic that is used right now, but only to return blank evaluator return output. I think it would be fair to fall back to the direct m_dispatchers lookup before reporting a failure.

Why? Well, first because this program is an IPC program. It shouldn't care what config the user is using to handle IPC calls. This has **significant** impact on the ecosystem. More precisely, I maintain [hypr-layout](https://github.com/sim590/hypr-layout) which relies on hy3 dispatchers to function. This situation can seem very confusing for users of my program as hypr-layout will not fail at all when the user is running on 0.55 with hyprlang config, but it will fail to work properly when the user has Lua config.

I don't see any reason why the this backward compatibility fix could not be applied while 0.55 Hyprland still supports Hyprlang config. But again, I think that IPC calls shouldn't be impacted by users' configuration. I think that hyprlang based IPC should still continue to live even though users have passed on to lua config. At least for a while to give other hyprctl based tools developers the time to migrate their IPC calls.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

It's ready. I tested it. I'm running it right now and it fixed hypr-layout.