### PR TITLE
Fix Keyboard focus lost when cursor crosses layer-shell panels

### DIFF
--- a/src/desktop/view/LayerSurface.cpp
+++ b/src/desktop/view/LayerSurface.cpp
@@ -273,6 +273,16 @@ void CLayerSurface::onUnmap() {
         (Desktop::focusState()->surface() && Desktop::focusState()->surface()->m_hlSurface && !Desktop::focusState()->surface()->m_hlSurface->keyboardFocusable())) {
         if (!g_pInputManager->refocusLastWindow(PMONITOR))
             g_pInputManager->refocus();
+
+        if (auto window = Desktop::focusState()->window()) {
+            if (auto surf = window->wlSurface()->resource()) {
+                if (g_pSeatManager->m_state.keyboardFocus != surf)
+                    g_pSeatManager->setKeyboardFocus(surf);
+            }
+        } else if (auto surf = Desktop::focusState()->surface()) {
+            if (g_pSeatManager->m_state.keyboardFocus != surf && surf->m_hlSurface && surf->m_hlSurface->keyboardFocusable())
+                g_pSeatManager->setKeyboardFocus(surf);
+        }
     } else if (Desktop::focusState()->surface() && Desktop::focusState()->surface() != m_wlSurface->resource())
         g_pSeatManager->setKeyboardFocus(Desktop::focusState()->surface());
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Keyboard wont refocus when cursor crosses layer-shell panels with follow_mouse != 1.
it fixes https://github.com/hyprwm/Hyprland/discussions/14285, https://github.com/hyprwm/Hyprland/discussions/14730
and i can reproduce using DankMaterialShell when bar pop up opened then closed, the keyboard wont refocus

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Already tested and i use AI to fix

#### Is it ready for merging, or does it need work?

ready
