### PR TITLE
fix submap enter bind == bind inside submap

### DIFF
--- a/hyprtester/src/tests/main/keybinds.cpp
+++ b/hyprtester/src/tests/main/keybinds.cpp
@@ -469,6 +469,14 @@ SUBTEST(submap) {
     press(KEY_P);
     EXPECT_CONTAINS(getFromSocket("/submap"), "default");
 
+    // submap 1 with identical keybind bound inside it
+    press(KEY_U, MOD_META);
+    EXPECT_CONTAINS(getFromSocket("/submap"), "submap1");
+    press(KEY_U, MOD_META);
+    EXPECT_CONTAINS(getFromSocket("/submap"), "submap3");
+    press(KEY_O);
+    Tests::waitUntilWindowsN(4);
+    EXPECT_CONTAINS(getFromSocket("/submap"), "default");
     Tests::killAllWindows();
 }
 

--- a/hyprtester/test.lua
+++ b/hyprtester/test.lua
@@ -201,6 +201,7 @@ hl.bind(mainMod .. " + u", hl.dsp.submap("submap1"))
 
 hl.define_submap("submap1", function()
     hl.bind("u", hl.dsp.submap("submap2"))
+    hl.bind(mainMod .. " + u", hl.dsp.submap("submap3"))
     hl.bind("i", hl.dsp.submap("submap3"))
     hl.bind("o", hl.dsp.exec_cmd(terminal))
     hl.bind("p", hl.dsp.submap("reset"))

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -613,7 +613,7 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
         if (!k->locked && g_pSessionLockManager->isSessionLocked())
             continue;
 
-        if (!IGNORECONDITIONS && ((modmask != k->modmask && !k->ignoreMods) || (k->submap.name != Config::Actions::state()->m_currentSubmap && !k->submapUniversal) || k->shadowed))
+        if (!IGNORECONDITIONS && ((modmask != k->modmask && !k->ignoreMods) || ((k->submap.name != key.submapAtPress.name) && !k->submapUniversal) || k->shadowed))
             continue;
 
         if (device) {


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
This adds the test vaxry wanted for #14578. As per the docs, the test case should fail without the fix, which it does. Adding the bind to `test.lua` without @codenameone-akshat's commit, causes the submap test to fail. With the change, the test passes.
  
#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

no

#### Is it ready for merging, or does it need work?

Ready, includes the test and the fix(in squashed form), but as this rudely supersedes @codenameone-akshat's PR, perhaps it would be better if they incorporated the test into their PR.
