### PR TITLE
renderer: dont send frame on discarded elements

### DIFF
--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -725,7 +725,8 @@ void CWLSurfaceResource::updateCursorShm(CRegion damage) {
 }
 
 void CWLSurfaceResource::presentFeedback(const Time::steady_tp& when, PHLMONITOR pMonitor, bool discarded) {
-    frame(when);
+    if (!discarded)
+        frame(when);
 
     auto FEEDBACK = makeUnique<CQueuedPresentationData>(m_self.lock());
     FEEDBACK->attachMonitor(pMonitor);

--- a/src/render/ElementRenderer.cpp
+++ b/src/render/ElementRenderer.cpp
@@ -265,8 +265,10 @@ void IElementRenderer::drawSurface(WP<CSurfacePassElement> element, const CRegio
 
     auto cancelRender = false;
     auto clipRegion   = element->visibleRegion(cancelRender);
-    if (cancelRender)
+    if (cancelRender) {
+        element->discard();
         return;
+    }
 
     // check for fractional scale surfaces misaligning the buffer size
     // in those cases it's better to just force nearest neighbor

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -195,7 +195,12 @@ IHyprRenderer::IHyprRenderer() {
                 w->wlSurface()->resource()->breadthfirst(
                     [](SP<CWLSurfaceResource> surf, const Vector2D& offset, void* data) {
                         surf->m_stateQueue.unlockFirst(LOCK_REASON_FENCE | LOCK_REASON_FIFO | LOCK_REASON_TIMER);
-                        surf->presentFeedback(Time::steadyNow(), Desktop::focusState()->monitor(), true);
+
+                        //#TODO: figure out if renderunfocused should send discarded or not here.
+                        // if we dont discard it presentFeedback will send a frame callback.
+                        auto NOW = Time::steadyNow();
+                        surf->presentFeedback(NOW, Desktop::focusState()->monitor(), true);
+                        surf->frame(NOW);
                     },
                     nullptr);
             }


### PR DESCRIPTION
as wl_surface::frame says.
A server should avoid signaling the frame callbacks if the surface is not visible in any way, e.g. the surface is off-screen, or completely obscured by other opaque surfaces.

also discard if the element renderer early outs if its not visible.

to not regress firefox further it requires: https://github.com/hyprwm/Hyprland/pull/14849

lowers gpu usage drasticly here.