### PR TITLE
example/hyprland.lua: Use keycodes for switching workspaces

### DIFF
--- a/example/hyprland.lua
+++ b/example/hyprland.lua
@@ -272,10 +272,11 @@ hl.bind(mainMod .. " + down",  hl.dsp.focus({ direction = "down" }))
 
 -- Switch workspaces with mainMod + [0-9]
 -- Move active window to a workspace with mainMod + SHIFT + [0-9]
+-- Using keycodes for compatibility with some non-qwerty keyboard layouts
 for i = 1, 10 do
-    local key = i % 10 -- 10 maps to key 0
-    hl.bind(mainMod .. " + " .. key,             hl.dsp.focus({ workspace = i}))
-    hl.bind(mainMod .. " + SHIFT + " .. key,     hl.dsp.window.move({ workspace = i }))
+    local keycode = i + 9 -- 10 maps to keycode 19 (key 0)
+    hl.bind(mainMod .. " + code:" .. key,             hl.dsp.focus({ workspace = i}))
+    hl.bind(mainMod .. " + SHIFT + code:" .. key,     hl.dsp.window.move({ workspace = i }))
 end
 
 -- Example special workspace (scratchpad)


### PR DESCRIPTION
This should improve compatibility with some layouts (example: azerty), at no cost to existing qwerty users.

<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
The problem is [stated here](https://wiki.hypr.land/Configuring/Basics/Binds/#workspace-bindings-on-non-qwerty-layouts): azerty layouts use SHFIT + <key> for digits (I  agree that it is annoying; in practice most users use a numpad).

I am proposing to change the current workspace bindings to use keycodes. That should work transparently across more layouts. This also shows an example of keycode bindings in the default config.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Should I change the default bindings too? I am unsure if this example config is the one being used when no config file is present.


#### Is it ready for merging, or does it need work?
Ready to merge, though I can change the default config as well if it is located somewhere else.

