### PR TITLE
Upgrade actions/checkout to v6

### DIFF
--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -113,7 +113,7 @@ runs:
           xorg-xwayland
 
     - name: Checkout Hyprland
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
       image: archlinux
     steps:
       - name: Checkout repository actions
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           sparse-checkout: .github/actions
 
@@ -50,7 +50,7 @@ jobs:
       image: archlinux
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install clang-format
         run: |

--- a/.github/workflows/man-update.yaml
+++ b/.github/workflows/man-update.yaml
@@ -17,7 +17,7 @@ jobs:
       run: sudo apt install pandoc
 
     - name: Clone repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         token: ${{ secrets.PAT }}
 

--- a/.github/workflows/nix-update-inputs.yml
+++ b/.github/workflows/nix-update-inputs.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.PAT }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -13,7 +13,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Scan with Flawfinder
         uses: david-a-wheeler/flawfinder@8e4a779ad59dbfaee5da586aa9210853b701959c

--- a/.github/workflows/translation-ai-check.yml
+++ b/.github/workflows/translation-ai-check.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - uses: dorny/paths-filter@v3
         id: changes


### PR DESCRIPTION
actions/checkout@v4 uses deprecated Node 20: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/