### PR TITLE
Upgrade github/codeql-action/upload-sarif to v4

### DIFF
--- a/.github/workflows/security-checks.yml
+++ b/.github/workflows/security-checks.yml
@@ -22,6 +22,6 @@ jobs:
           output: 'flawfinder_results.sarif'
 
       - name: Upload analysis results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: ${{github.workspace}}/flawfinder_results.sarif


### PR DESCRIPTION
github/codeql-action/upload-sarif@v2 is deprecated: https://github.blog/changelog/2025-01-10-code-scanning-codeql-action-v2-is-now-deprecated/

