### PR TITLE
Upgrade actions/upload-artifact to v7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
           tar -cvJf Hyprland.tar.xz hyprland
 
       - name: Release
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: Build archive
           path: Hyprland.tar.xz

--- a/.github/workflows/nix-test.yml
+++ b/.github/workflows/nix-test.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: logs
           path: result


### PR DESCRIPTION
actions/upload-artifact@v4 uses deprecated Node 20: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/