### PR TITLE
Upgrade stefanzweifel/git-auto-commit-action to v7

### DIFF
--- a/.github/workflows/man-update.yaml
+++ b/.github/workflows/man-update.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Build man pages
       run: make man
 
-    - uses: stefanzweifel/git-auto-commit-action@v5
+    - uses: stefanzweifel/git-auto-commit-action@v7
       name: Commit
       with:
         commit_message: "[gha] build man pages"

--- a/.github/workflows/nix-update-inputs.yml
+++ b/.github/workflows/nix-update-inputs.yml
@@ -23,6 +23,6 @@ jobs:
         run: nix/update-inputs.sh
 
       - name: Commit
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "[gha] Nix: update inputs"


### PR DESCRIPTION
stefanzweifel/git-auto-commit-action@v5 uses deprecated Node 20: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/