### PR TITLE
elementrenderer: allow smaller viewports near the top/left edges of the buffer

### DIFF
--- a/src/render/ElementRenderer.cpp
+++ b/src/render/ElementRenderer.cpp
@@ -68,7 +68,7 @@ void IElementRenderer::calculateUVForSurface(PHLWINDOW pWindow, SP<CWLSurfaceRes
             uvTL = Vector2D(bufferSource.x / bufferSize.x, bufferSource.y / bufferSize.y);
             uvBR = Vector2D((bufferSource.x + bufferSource.width) / bufferSize.x, (bufferSource.y + bufferSource.height) / bufferSize.y);
 
-            if (bufferSource.width < 1.0 || bufferSource.height < 1.0 || uvBR.x < 0.00001f || uvBR.y < 0.00001f) {
+            if (uvBR.x < 0.00001f || uvBR.y < 0.00001f) {
                 uvTL = Vector2D();
                 uvBR = Vector2D(1, 1);
             }

--- a/src/render/ElementRenderer.cpp
+++ b/src/render/ElementRenderer.cpp
@@ -68,7 +68,7 @@ void IElementRenderer::calculateUVForSurface(PHLWINDOW pWindow, SP<CWLSurfaceRes
             uvTL = Vector2D(bufferSource.x / bufferSize.x, bufferSource.y / bufferSize.y);
             uvBR = Vector2D((bufferSource.x + bufferSource.width) / bufferSize.x, (bufferSource.y + bufferSource.height) / bufferSize.y);
 
-            if (uvBR.x < 0.01f || uvBR.y < 0.01f) {
+            if (bufferSource.width < 1.0 || bufferSource.height < 1.0 || uvBR.x < 0.00001f || uvBR.y < 0.00001f) {
                 uvTL = Vector2D();
                 uvBR = Vector2D(1, 1);
             }


### PR DESCRIPTION

<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

Allows smaller viewport sources as long as they're at least 1 pixel in size and uvBR isn't excessively close to 0.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I was using a full output capture and a viewport to make a screen magnifier, but noticed it wasn't working near the left and top edges of the screen. The actual size of the viewport didn't matter, just that the bottom right corner was at least 1% from the left/top edge, so it seems safe to relax these checks.

#### Is it ready for merging, or does it need work?
Ready.