### PR TITLE
layout: harden workspace layout refresh during monitor changes

### DIFF
--- a/hyprtester/src/tests/main/layout.cpp
+++ b/hyprtester/src/tests/main/layout.cpp
@@ -3,6 +3,25 @@
 #include "../../hyprctlCompat.hpp"
 #include "tests.hpp"
 
+#include <chrono>
+#include <format>
+#include <thread>
+
+#include <hyprutils/utils/ScopeGuard.hpp>
+
+using namespace Hyprutils::Utils;
+
+static bool waitForMonitor(const char* name) {
+    for (int i = 0; i < 50; ++i) {
+        if (getFromSocket("/monitors").contains(name))
+            return true;
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    return false;
+}
+
 TEST_CASE(single_window_aspect_ratio) {
     OK(getFromSocket("/eval hl.config({ layout = { single_window_aspect_ratio = '1 1' } })"));
 
@@ -50,6 +69,41 @@ TEST_CASE(crashOnGeomUpdate) {
 
     // restore HEADLESS-2 position so subsequent tests don't inherit the relocated monitor
     OK(getFromSocket("/eval hl.monitor({ output = 'HEADLESS-2', mode = '1920x1080@60', position = '0x0', scale = '1' })"));
+}
+
+// Don't crash when a pending layout refresh runs after monitor teardown.
+TEST_CASE(layoutRefreshDuringMonitorTeardown) {
+    static constexpr const char* TEST_OUTPUT = "HEADLESS-5";
+
+    getFromSocket(std::format("/output remove {}", TEST_OUTPUT));
+    OK(getFromSocket(std::format("/output create headless {}", TEST_OUTPUT)));
+    ASSERT(waitForMonitor(TEST_OUTPUT), true);
+
+    CScopeGuard guard = {[&]() {
+        Tests::killAllWindows();
+        getFromSocket(std::format("/output remove {}", TEST_OUTPUT));
+        OK(getFromSocket("/reload"));
+    }};
+
+    OK(getFromSocket("/eval hl.monitor({ output = 'HEADLESS-2', mode = '1920x1080@60', position = '0x0', scale = '1' })"));
+    OK(getFromSocket(std::format("/eval hl.monitor({{ output = '{}', disabled = false, mode = '1920x1080@60', position = '1920x0', scale = '1' }})", TEST_OUTPUT)));
+    ASSERT(waitForMonitor(TEST_OUTPUT), true);
+
+    OK(getFromSocket(std::format("/dispatch hl.dsp.focus({{ monitor = '{}' }})", TEST_OUTPUT)));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = '30' })"));
+    ASSERT(!!Tests::spawnKitty("layout_teardown_a"), true);
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = '31' })"));
+    ASSERT(!!Tests::spawnKitty("layout_teardown_b"), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ monitor = 'HEADLESS-2' })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = '1' })"));
+
+    OK(getFromSocket(std::format("/eval hl.monitor({{ output = '{}', disabled = true }}); hl.config({{ general = {{ layout = 'master' }} }})", TEST_OUTPUT)));
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    ASSERT_CONTAINS(getFromSocket("/version"), "Hyprland");
+    EXPECT_CONTAINS(getFromSocket("/monitors all"), TEST_OUTPUT);
 }
 
 // Test if size + pos is preserved after fs cycle

--- a/hyprtester/src/tests/main/layout.cpp
+++ b/hyprtester/src/tests/main/layout.cpp
@@ -22,6 +22,17 @@ static bool waitForMonitor(const char* name) {
     return false;
 }
 
+static bool waitForMonitorRemoved(const char* name) {
+    for (int i = 0; i < 50; ++i) {
+        if (!getFromSocket("/monitors").contains(name))
+            return true;
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    return false;
+}
+
 TEST_CASE(single_window_aspect_ratio) {
     OK(getFromSocket("/eval hl.config({ layout = { single_window_aspect_ratio = '1 1' } })"));
 
@@ -81,7 +92,10 @@ TEST_CASE(layoutRefreshDuringMonitorTeardown) {
 
     CScopeGuard guard = {[&]() {
         Tests::killAllWindows();
-        getFromSocket(std::format("/output remove {}", TEST_OUTPUT));
+        OK(getFromSocket(std::format("/eval hl.monitor({{ output = '{}', disabled = false, mode = '1920x1080@60', position = '1920x0', scale = '1' }})", TEST_OUTPUT)));
+        ASSERT(waitForMonitor(TEST_OUTPUT), true);
+        OK(getFromSocket(std::format("/output remove {}", TEST_OUTPUT)));
+        ASSERT(waitForMonitorRemoved(TEST_OUTPUT), true);
         OK(getFromSocket("/reload"));
     }};
 

--- a/src/layout/supplementary/WorkspaceAlgoMatcher.cpp
+++ b/src/layout/supplementary/WorkspaceAlgoMatcher.cpp
@@ -13,7 +13,6 @@
 #include "../algorithm/tiled/scrolling/ScrollingAlgorithm.hpp"
 #include "../algorithm/tiled/monocle/MonocleAlgorithm.hpp"
 
-#include "../../Compositor.hpp"
 #include "../../state/WorkspaceState.hpp"
 
 using namespace Layout;
@@ -114,17 +113,25 @@ SP<CAlgorithm> CWorkspaceAlgoMatcher::createAlgorithmForWorkspace(PHLWORKSPACE w
 }
 
 void CWorkspaceAlgoMatcher::updateWorkspaceLayouts() {
+    const auto WORKSPACES = State::workspaceState()->workspacesCopy();
+
     // TODO: make this ID-based, string comparison is slow
-    for (const auto& ws : State::workspaceState()->workspaces()) {
-        if (!ws)
+    for (const auto& WORKSPACE : WORKSPACES) {
+        // Workspaces can briefly outlive usable layout state while monitor
+        // changes move or destroy them.
+        if (!WORKSPACE || WORKSPACE->inert() || !WORKSPACE->m_monitor || !WORKSPACE->m_space)
             continue;
 
-        const auto& TILED_ALGO = ws->m_space->algorithm()->tiledAlgo();
+        const auto ALGORITHM = WORKSPACE->m_space->algorithm();
+        if (!ALGORITHM)
+            continue;
+
+        const auto& TILED_ALGO = ALGORITHM->tiledAlgo();
 
         if (!TILED_ALGO)
             continue;
 
-        const auto LAYOUT_TO_USE = tiledAlgoForWorkspace(ws.lock());
+        const auto LAYOUT_TO_USE = tiledAlgoForWorkspace(WORKSPACE);
 
         const auto CURRENT_LAYOUT = getNameForTiledAlgo(TILED_ALGO.get());
 
@@ -132,7 +139,7 @@ void CWorkspaceAlgoMatcher::updateWorkspaceLayouts() {
             continue;
 
         // needs a switchup
-        ws->m_space->algorithm()->updateTiledAlgo(algoForNameTiled(LAYOUT_TO_USE));
+        ALGORITHM->updateTiledAlgo(algoForNameTiled(LAYOUT_TO_USE));
     }
 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
`CWorkspaceAlgoMatcher::updateWorkspaceLayouts()` iterated `g_pCompositor->getWorkspaces()`, a live filtered view over weak workspace refs. During monitor teardown, that underlying workspace vector can be mutated, and surviving workspace objects may already be inert or missing monitor, space, algorithm, or tiled-layout state.

Take a strong workspace snapshot with `getWorkspacesCopy()` before iterating, and skip workspaces that are not safe to refresh. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I've been testing this patch for a while now (since lua conf was first implemented in Hyprland basically), as I came across this bug while scripting my monitors layout (Hyprland crashed when I switched from integrated-only to multi-screen quickly). Never had an issue with it so far afterwards.

Note that this patch was entirely written by codex.

#### Is it ready for merging, or does it need work?

The patch should be ready to be merged but feedback welcome + I guess I need to add some tests!