### PR TITLE
main: gain SCHED_RR and drop CAP_SYS_NICE earlier

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -236,6 +236,9 @@ int main(int argc, char** argv) {
 
 
 )#");
+
+        if (!Env::envEnabled("HYPRLAND_NO_RT"))
+            NInit::gainRealTime();
     }
 
     // let's init the compositor.
@@ -264,9 +267,6 @@ int main(int argc, char** argv) {
 
     if (verifyConfig)
         return !Config::mgr()->configVerifPassed();
-
-    if (!Env::envEnabled("HYPRLAND_NO_RT"))
-        NInit::gainRealTime();
 
     Log::logger->log(Log::DEBUG, "Hyprland init finished.");
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Some NixOS users reported that CAP_SYS_NICE still isn't being dropped properly. Drop CAP_SYS_NICE before other threads are spawned so that it is properly inherited.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Ready
