### PR TITLE
config/actions: fix null derefs in pin dispatcher

### DIFF
--- a/hyprtester/src/tests/main/window.cpp
+++ b/hyprtester/src/tests/main/window.cpp
@@ -588,6 +588,27 @@ TEST_CASE(issue14038) {
     // this should not crash hyprland. If we are alive, we good.
 }
 
+TEST_CASE(issue14134) {
+    OK(getFromSocket("/output create headless HEADLESS-4"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ monitor = 'HEADLESS-4' })"));
+
+    if (!spawnKitty("kitty_14134"))
+        FAIL_TEST("Could not spawn kitty");
+
+    OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'toggle', window = 'class:kitty_14134' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.pin({ action = 'toggle', window = 'class:kitty_14134' })"));
+
+    OK(getFromSocket("/eval hl.monitor({ output = 'HEADLESS-4', disabled = true })"));
+
+    // will return error, should not be OK.
+    getFromSocket("/dispatch hl.dsp.window.pin({ action = 'toggle', window = 'class:kitty_14134' })");
+
+    OK(getFromSocket("/reload"));
+    Tests::killAllWindows();
+    ASSERT(Tests::windowCount(), 0);
+    OK(getFromSocket("/output remove HEADLESS-4"));
+}
+
 TEST_CASE(specialFloatRecenters) {
     if (!spawnKitty("kitty_special_float_recenter"))
         FAIL_TEST("Could not spawn kitty");

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -230,15 +230,22 @@ ActionResult Actions::pinWindow(eTogglableAction action, std::optional<PHLWINDOW
     if (wantPin == window->m_pinned)
         return {};
 
-    window->m_pinned = wantPin;
-    window->updateFullscreenInputState();
-    *window->alpha(Desktop::View::WINDOW_ALPHA_FULLSCREEN) = window->isBlockedByFullscreen() ? 0.F : 1.F;
-
     const auto PMONITOR = window->m_monitor.lock();
     if (!PMONITOR)
         return actionError("Window has no monitor", eActionErrorLevel::WARNING, eActionErrorCode::INVALID_STATE);
 
-    window->layoutTarget()->assignToSpace(PMONITOR->m_activeWorkspace->m_space);
+    if (!PMONITOR->m_activeWorkspace || !PMONITOR->m_activeWorkspace->m_space)
+        return actionError("Monitor has no active workspace", eActionErrorLevel::WARNING, eActionErrorCode::INVALID_STATE);
+
+    const auto LAYOUTTARGET = window->layoutTarget();
+    if (!LAYOUTTARGET)
+        return actionError("Window has no layout target", eActionErrorLevel::WARNING, eActionErrorCode::INVALID_STATE);
+
+    window->m_pinned = wantPin;
+    window->updateFullscreenInputState();
+    *window->alpha(Desktop::View::WINDOW_ALPHA_FULLSCREEN) = window->isBlockedByFullscreen() ? 0.F : 1.F;
+
+    LAYOUTTARGET->assignToSpace(PMONITOR->m_activeWorkspace->m_space);
     window->m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_PINNED);
 
     const auto PWORKSPACE = window->m_workspace;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

 `layoutTarget()` call. The two new derefs aren't covered by the existing `PMONITOR` check — any of
  `PMONITOR->m_activeWorkspace`, `m_activeWorkspace->m_space`, or `window->layoutTarget()` being null crashes the
  compositor on `hyprctl dispatch pin`.

  I hit this with pyprland on a laptop: lid close disables the internal monitor, the pinned floating window's `m_monitor`
  weak_ptr still resolves (the `CMonitor` stays alive in `m_realMonitors`) but `m_activeWorkspace` got reset to null in
  `onDisconnect`. pyprland's next pin toggle then dereferences null and aborts the compositor.

from stack trace:
```
  Layout::CWindowTarget::assignToSpace   <- segv
  Config::Actions::pinWindow
  pin
  CDispatcherTranslator::run
  CHyprCtl::getReply
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I've run with the patched  version locally and i do not observe crashes anymore.
in addition i've added a test which trigger the crash before the fix. and the the whole test suite runs succesfully after it (including the new test added for this)

#### Is it ready for merging, or does it need work?
from what i understand it should be, just require review...
as mentioned above, it was verified locally via `nix build .#checks.x86_64-linux.tests`: `issue14134` passes;

Fixes #14134