### PR TITLE
renderer: implement window wobble

### DIFF
--- a/src/animation/AnimationManager.cpp
+++ b/src/animation/AnimationManager.cpp
@@ -307,7 +307,7 @@ void CHyprAnimationManager::tick() {
         if (!owner.window || !owner.trackWindowMotion)
             continue;
 
-        owner.window->recordMotionBlur(owner.previousFull, owner.window->getFullWindowBoundingBox());
+        owner.window->onPositionUpdate(owner.previousFull, owner.window->getFullWindowBoundingBox(), Desktop::View::WINDOW_UPDATE_ANIMATION);
     }
 
     // post-damage each owner once (new state) + schedule frames
@@ -344,7 +344,10 @@ void CHyprAnimationManager::tick() {
 void CHyprAnimationManager::frameTick() {
     onTicked();
 
-    if (!shouldTickForNext())
+    const bool MANUALTICK = m_manualTickRequested;
+    m_manualTickRequested = false;
+
+    if (!MANUALTICK && !shouldTickForNext())
         return;
 
     if UNLIKELY (!g_pCompositor->m_sessionActive || !std::ranges::any_of(State::monitorState()->monitors(), [](const auto& mon) { return mon->m_enabled && mon->m_output; }))
@@ -356,10 +359,16 @@ void CHyprAnimationManager::frameTick() {
 
         tick();
         Event::bus()->m_events.tick.emit();
-    }
+    } else if (MANUALTICK)
+        m_manualTickRequested = true;
 
-    if (shouldTickForNext())
+    if (m_manualTickRequested || shouldTickForNext())
         scheduleTick();
+}
+
+void CHyprAnimationManager::requestTick() {
+    m_manualTickRequested = true;
+    scheduleTick();
 }
 
 void CHyprAnimationManager::scheduleTick() {

--- a/src/animation/AnimationManager.hpp
+++ b/src/animation/AnimationManager.hpp
@@ -17,6 +17,7 @@ namespace Animation {
 
         void         tick();
         void         frameTick();
+        void         requestTick();
         virtual void scheduleTick();
         virtual void onTicked();
 
@@ -58,6 +59,7 @@ namespace Animation {
 
       private:
         bool   m_tickScheduled = false;
+        bool   m_manualTickRequested = false;
         bool   m_lastTickValid = false;
         CTimer m_lastTickTimer;
     };

--- a/src/animation/AnimationManager.hpp
+++ b/src/animation/AnimationManager.hpp
@@ -58,9 +58,9 @@ namespace Animation {
         float               m_lastTickTimeMs;
 
       private:
-        bool   m_tickScheduled = false;
+        bool   m_tickScheduled       = false;
         bool   m_manualTickRequested = false;
-        bool   m_lastTickValid = false;
+        bool   m_lastTickValid       = false;
         CTimer m_lastTickTimer;
     };
 

--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -256,6 +256,14 @@ std::vector<SP<IValue>> Values::getConfigValues() {
 
         MS<Bool>("decoration:motion_blur:enabled", "enable motion blur for moving and resizing windows", false, {.refresh = Supplementary::REFRESH_WINDOW_STATES}),
         MS<Int>("decoration:motion_blur:samples", "amount of samples used for motion blur", 7, {.min = 1, .max = 64, .refresh = Supplementary::REFRESH_WINDOW_STATES}),
+        MS<Bool>("decoration:wobble:enabled", "enable wobble deformation for moving and resizing windows", false, {.refresh = Supplementary::REFRESH_WINDOW_STATES}),
+        MS<Int>("decoration:wobble:mesh", "amount of wobble mesh vertices per edge", 12, {.min = 2, .max = 32, .refresh = Supplementary::REFRESH_WINDOW_STATES}),
+        MS<Float>("decoration:wobble:stiffness", "spring stiffness for wobble deformation", 200, {.min = 0.0001, .max = 1000}),
+        MS<Float>("decoration:wobble:damping", "spring damping for wobble deformation", 12, {.min = 0, .max = 1000}),
+        MS<Float>("decoration:wobble:mass", "spring mass for wobble deformation", 1, {.min = 0.0001, .max = 1000}),
+        MS<Float>("decoration:wobble:intensity", "wobble deformation impulse multiplier", 0.2, {.min = 0, .max = 2}),
+        MS<Float>("decoration:wobble:value_epsilon", "position epsilon below which wobble is considered stable", 0.25, {.min = 0, .max = 100}),
+        MS<Float>("decoration:wobble:velocity_epsilon", "velocity epsilon below which wobble is considered stable", 2, {.min = 0, .max = 1000}),
 
         /*
          * animations:

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -55,6 +55,7 @@
 #include "../../render/Renderer.hpp"
 #include "../../render/transformer/MotionBlurTransformer.hpp"
 #include "../../ipc/s2/S2.hpp"
+#include "../../render/transformer/WobbleTransformer.hpp"
 #include "../../managers/input/InputManager.hpp"
 #include "../../pointer/PointerController.hpp"
 #include "../../managers/KeybindManager.hpp"
@@ -613,24 +614,21 @@ static Render::CMotionBlurTransformer* motionBlurTransformer(CWindow* window) {
     if (!window)
         return nullptr;
 
-    for (auto const& transformer : window->m_transformers) {
-        if (const auto MOTIONBLUR = dc<Render::CMotionBlurTransformer*>(transformer.get()))
-            return MOTIONBLUR;
-    }
-
-    return nullptr;
+    return window->m_transformers.get<Render::CMotionBlurTransformer>();
 }
 
 static const Render::CMotionBlurTransformer* motionBlurTransformer(const CWindow* window) {
     if (!window)
         return nullptr;
 
-    for (auto const& transformer : window->m_transformers) {
-        if (const auto MOTIONBLUR = dc<const Render::CMotionBlurTransformer*>(transformer.get()))
-            return MOTIONBLUR;
-    }
+    return window->m_transformers.get<Render::CMotionBlurTransformer>();
+}
 
-    return nullptr;
+static Render::CWobbleTransformer* wobbleTransformer(CWindow* window) {
+    if (!window)
+        return nullptr;
+
+    return window->m_transformers.get<Render::CWobbleTransformer>();
 }
 
 std::optional<MotionBlur::SState> CWindow::motionBlurState(bool allowStale) const {
@@ -674,7 +672,7 @@ void CWindow::recordMotionBlur(const CBox& previous, const CBox& current) {
 
     auto MOTIONBLUR = motionBlurTransformer(this);
     if (!MOTIONBLUR) {
-        m_transformers.emplace_back(makeUnique<Render::CMotionBlurTransformer>(m_self));
+        m_transformers.emplace<Render::CMotionBlurTransformer>(m_self);
         MOTIONBLUR = motionBlurTransformer(this);
     }
 
@@ -688,14 +686,44 @@ void CWindow::recordMotionBlur(const CBox& previous, const CBox& current) {
 void CWindow::resetMotionBlur() {
     damageMotionBlur(true);
 
-    std::erase_if(m_transformers, [](auto const& transformer) {
-        const auto MOTIONBLUR = dc<Render::CMotionBlurTransformer*>(transformer.get());
-        if (!MOTIONBLUR)
-            return false;
-
+    if (auto MOTIONBLUR = motionBlurTransformer(this))
         MOTIONBLUR->reset();
-        return true;
-    });
+
+    m_transformers.removeInactive();
+}
+
+void CWindow::resetWobble() {
+    if (auto WOBBLE = wobbleTransformer(this))
+        WOBBLE->resetWithDamage();
+
+    m_transformers.removeInactive();
+}
+
+void CWindow::onPositionUpdate(const CBox& previous, const CBox& current, eWindowUpdateSource source) {
+    recordMotionBlur(previous, current);
+
+    if (previous == current)
+        return;
+
+    if (!Render::CWobbleTransformer::shouldEnable(m_self.lock())) {
+        resetWobble();
+        return;
+    }
+
+    auto WOBBLE = wobbleTransformer(this);
+    if (!WOBBLE) {
+        m_transformers.emplace<Render::CWobbleTransformer>(m_self);
+        WOBBLE = wobbleTransformer(this);
+    }
+
+    std::optional<Vector2D> grabPoint;
+    if (source == WINDOW_UPDATE_MOUSE && current.w > 0.F && current.h > 0.F) {
+        const auto MOUSE = g_pInputManager->getMouseCoordsInternal();
+        grabPoint        = Vector2D{std::clamp((MOUSE.x - current.x) / current.w, 0.0, 1.0), std::clamp((MOUSE.y - current.y) / current.h, 0.0, 1.0)};
+    }
+
+    if (WOBBLE)
+        WOBBLE->record(previous, current, grabPoint);
 }
 
 void CWindow::onUnmap() {
@@ -739,6 +767,7 @@ void CWindow::onUnmap() {
         PMONITOR->m_solitaryClient.reset();
 
     resetMotionBlur();
+    resetWobble();
 
     if (m_workspace) {
         m_workspace->updateWindows();
@@ -778,6 +807,7 @@ void CWindow::onMap() {
     alpha(WINDOW_ALPHA_MOVE_TO_WORKSPACE)->setValueAndWarp(1.F);
 
     resetMotionBlur();
+    resetWobble();
 
     if (m_borderAngleAnimationProgress->enabled()) {
         m_borderAngleAnimationProgress->setValueAndWarp(0.f);
@@ -2044,8 +2074,10 @@ static void setVector2DAnimToMove(WP<CBaseAnimatedVariable> pav) {
     if (animvar->m_Context.pWindow) {
         animvar->m_Context.pWindow->m_animatingIn = false;
 
-        if (!animvar->m_Context.pWindow->positionAnimation()->isBeingAnimated() && !animvar->m_Context.pWindow->sizeAnimation()->isBeingAnimated())
+        if (!animvar->m_Context.pWindow->positionAnimation()->isBeingAnimated() && !animvar->m_Context.pWindow->sizeAnimation()->isBeingAnimated()) {
             animvar->m_Context.pWindow->resetMotionBlur();
+            animvar->m_Context.pWindow->resetWobble();
+        }
     }
 }
 
@@ -2481,6 +2513,7 @@ void CWindow::mapWindow() {
         m_realPosition->warp();
         m_realSize->warp();
         resetMotionBlur();
+        resetWobble();
         if (requestedFSState.has_value()) {
             m_ruleApplicator->syncFullscreenOverride(Desktop::Types::COverridableVar(false, Desktop::Types::PRIORITY_WINDOW_RULE));
             Fullscreen::controller()->setFullscreenMode(m_self.lock(), requestedFSState.value().internal, requestedFSState.value().client, wasFullscreenLayoutHandled);

--- a/src/desktop/view/Window.hpp
+++ b/src/desktop/view/Window.hpp
@@ -12,7 +12,7 @@
 #include "../../macros.hpp"
 #include "../../managers/XWaylandManager.hpp"
 #include "../../render/decorations/IHyprWindowDecoration.hpp"
-#include "../../render/transformer/Transformer.hpp"
+#include "../../render/transformer/TransformerList.hpp"
 #include "../DesktopTypes.hpp"
 #include "../types/MultiAnimatedVariable.hpp"
 #include "Popup.hpp"
@@ -46,6 +46,12 @@ namespace Desktop {
 namespace Desktop::View {
 
     class CGroup;
+
+    enum eWindowUpdateSource : uint8_t {
+        WINDOW_UPDATE_ANIMATION = 0,
+        WINDOW_UPDATE_MOUSE,
+        WINDOW_UPDATE_LAYOUT,
+    };
 
     enum eGroupRules : uint8_t {
         // effective only during first map, except for _ALWAYS variant
@@ -236,7 +242,7 @@ namespace Desktop::View {
         UP<Desktop::Rule::CWindowRuleApplicator> m_ruleApplicator;
 
         // Transformers
-        std::vector<UP<Render::IWindowTransformer>> m_transformers;
+        Render::CWindowTransformerList m_transformers;
 
         // animated shadow color
         Config::CGradientValueData m_realShadowColor;
@@ -394,6 +400,8 @@ namespace Desktop::View {
         void                              damageMotionBlur(bool allowStale = false) const;
         void                              recordMotionBlur(const CBox& previous, const CBox& current);
         void                              resetMotionBlur();
+        void                              resetWobble();
+        void                              onPositionUpdate(const CBox& previous, const CBox& current, eWindowUpdateSource source);
         void                              onUpdateState();
         void                              onUpdateMeta();
         void                              onX11ConfigureRequest(CBox box);

--- a/src/helpers/DeformableMesh.cpp
+++ b/src/helpers/DeformableMesh.cpp
@@ -1,0 +1,191 @@
+#include "DeformableMesh.hpp"
+
+#include <hyprutils/animation/Spring.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <numbers>
+
+using namespace Hyprutils::Animation;
+
+CDeformableMesh::CDeformableMesh(size_t verticesPerEdge) {
+    setSize(verticesPerEdge);
+}
+
+void CDeformableMesh::setSize(size_t verticesPerEdge) {
+    verticesPerEdge = std::clamp(verticesPerEdge, static_cast<size_t>(2), static_cast<size_t>(32));
+    if (m_verticesPerEdge == verticesPerEdge && m_points.size() == verticesPerEdge * verticesPerEdge)
+        return;
+
+    m_verticesPerEdge = verticesPerEdge;
+    m_points.assign(m_verticesPerEdge * m_verticesPerEdge, {});
+}
+
+size_t CDeformableMesh::size() const {
+    return m_verticesPerEdge;
+}
+
+void CDeformableMesh::reset() {
+    for (auto& p : m_points) {
+        p.displacement = {};
+        p.velocity     = {};
+    }
+}
+
+void CDeformableMesh::onPositionUpdate(const CBox& previous, const CBox& current, float intensity, std::optional<Vector2D> grabPoint) {
+    if (previous == current || previous.w <= 0.F || previous.h <= 0.F || current.w <= 0.F || current.h <= 0.F)
+        return;
+
+    intensity                      = std::clamp(intensity, 0.F, 2.F);
+    const double   MAXDISPLACEMENT = std::clamp(std::min(current.w, current.h) * 0.25, 16.0, 160.0);
+
+    const double   PREVLEFT   = previous.x;
+    const double   PREVRIGHT  = previous.x + previous.w;
+    const double   PREVTOP    = previous.y;
+    const double   PREVBOTTOM = previous.y + previous.h;
+
+    const double   CURRLEFT   = current.x;
+    const double   CURRRIGHT  = current.x + current.w;
+    const double   CURRTOP    = current.y;
+    const double   CURRBOTTOM = current.y + current.h;
+
+    const Vector2D MOVEDELTA = current.pos() - previous.pos();
+    const double   LEFTDELTA = CURRLEFT - PREVLEFT, RIGHTDELTA = CURRRIGHT - PREVRIGHT;
+    const double   TOPDELTA = CURRTOP - PREVTOP, BOTTOMDELTA = CURRBOTTOM - PREVBOTTOM;
+
+    if (grabPoint)
+        *grabPoint = Vector2D{std::clamp(grabPoint->x, 0.0, 1.0), std::clamp(grabPoint->y, 0.0, 1.0)};
+
+    const double GRABMAXDISTANCE = grabPoint ? std::max(std::hypot(std::max(grabPoint->x, 1.0 - grabPoint->x), std::max(grabPoint->y, 1.0 - grabPoint->y)), 0.001) : 1.0;
+
+    for (size_t y = 0; y < m_verticesPerEdge; ++y) {
+        const double V = m_verticesPerEdge == 1 ? 0.0 : static_cast<double>(y) / static_cast<double>(m_verticesPerEdge - 1);
+        for (size_t x = 0; x < m_verticesPerEdge; ++x) {
+            const double U = m_verticesPerEdge == 1 ? 0.0 : static_cast<double>(x) / static_cast<double>(m_verticesPerEdge - 1);
+
+            const double MOVEWEIGHTX = 0.45 + 0.55 * std::sin(V * std::numbers::pi);
+            const double MOVEWEIGHTY = 0.45 + 0.55 * std::sin(U * std::numbers::pi);
+
+            Vector2D     impulse;
+            impulse.x = -MOVEDELTA.x * MOVEWEIGHTX;
+            impulse.y = -MOVEDELTA.y * MOVEWEIGHTY;
+
+            impulse.x += -(LEFTDELTA * (1.0 - U) + RIGHTDELTA * U);
+            impulse.y += -(TOPDELTA * (1.0 - V) + BOTTOMDELTA * V);
+
+            if (grabPoint) {
+                const double DISTANCE   = std::hypot(U - grabPoint->x, V - grabPoint->y);
+                const double GRABWEIGHT = std::clamp(DISTANCE / GRABMAXDISTANCE, 0.0, 1.0);
+
+                impulse = impulse * GRABWEIGHT;
+            }
+
+            point(x, y).displacement += impulse * intensity;
+        }
+    }
+
+    clampDisplacement(MAXDISPLACEMENT);
+}
+
+void CDeformableMesh::advance(const SSpringCurve& spring, std::chrono::duration<float> elapsed) {
+    for (auto& p : m_points) {
+        float valueX = 1.F + static_cast<float>(p.displacement.x);
+        float valueY = 1.F + static_cast<float>(p.displacement.y);
+        float velX   = static_cast<float>(p.velocity.x);
+        float velY   = static_cast<float>(p.velocity.y);
+
+        advanceSpring(valueX, velX, spring, elapsed);
+        advanceSpring(valueY, velY, spring, elapsed);
+
+        p.displacement.x = valueX - 1.F;
+        p.displacement.y = valueY - 1.F;
+        p.velocity.x     = velX;
+        p.velocity.y     = velY;
+    }
+}
+
+bool CDeformableMesh::stable(float positionEpsilon, float velocityEpsilon) const {
+    for (auto const& p : m_points) {
+        if (std::abs(p.displacement.x) > positionEpsilon || std::abs(p.displacement.y) > positionEpsilon || std::abs(p.velocity.x) > velocityEpsilon ||
+            std::abs(p.velocity.y) > velocityEpsilon)
+            return false;
+    }
+
+    return true;
+}
+
+CBox CDeformableMesh::transformedExtents(const CBox& box) const {
+    if (m_points.empty())
+        return box;
+
+    double minX = box.x, minY = box.y, maxX = box.x + box.w, maxY = box.y + box.h;
+    for (size_t y = 0; y < m_verticesPerEdge; ++y) {
+        for (size_t x = 0; x < m_verticesPerEdge; ++x) {
+            const Vector2D POS = restPoint(box, x, y) + point(x, y).displacement;
+            minX               = std::min(minX, POS.x);
+            minY               = std::min(minY, POS.y);
+            maxX               = std::max(maxX, POS.x);
+            maxY               = std::max(maxY, POS.y);
+        }
+    }
+
+    return {minX, minY, maxX - minX, maxY - minY};
+}
+
+std::vector<SMeshRenderVertex> CDeformableMesh::verticesForBox(const CBox& box, const CBox& outputBox, const Vector2D& textureSize, double displacementScale) const {
+    std::vector<SMeshRenderVertex> vertices;
+    if (m_verticesPerEdge < 2 || outputBox.w <= 0.F || outputBox.h <= 0.F || textureSize.x <= 0.F || textureSize.y <= 0.F)
+        return vertices;
+
+    vertices.reserve((m_verticesPerEdge - 1) * (m_verticesPerEdge - 1) * 6);
+
+    const auto makeVertex = [&](size_t x, size_t y) -> SMeshRenderVertex {
+        const Vector2D REST = restPoint(box, x, y);
+        const Vector2D POS  = REST + point(x, y).displacement * displacementScale;
+        return {
+            .x = static_cast<float>((POS.x - outputBox.x) / outputBox.w),
+            .y = static_cast<float>((POS.y - outputBox.y) / outputBox.h),
+            .u = static_cast<float>(REST.x / textureSize.x),
+            .v = static_cast<float>(REST.y / textureSize.y),
+        };
+    };
+
+    for (size_t y = 0; y < m_verticesPerEdge - 1; ++y) {
+        for (size_t x = 0; x < m_verticesPerEdge - 1; ++x) {
+            vertices.emplace_back(makeVertex(x, y));
+            vertices.emplace_back(makeVertex(x, y + 1));
+            vertices.emplace_back(makeVertex(x + 1, y));
+            vertices.emplace_back(makeVertex(x + 1, y));
+            vertices.emplace_back(makeVertex(x, y + 1));
+            vertices.emplace_back(makeVertex(x + 1, y + 1));
+        }
+    }
+
+    return vertices;
+}
+
+CDeformableMesh::SPoint& CDeformableMesh::point(size_t x, size_t y) {
+    return m_points[y * m_verticesPerEdge + x];
+}
+
+const CDeformableMesh::SPoint& CDeformableMesh::point(size_t x, size_t y) const {
+    return m_points[y * m_verticesPerEdge + x];
+}
+
+Vector2D CDeformableMesh::restPoint(const CBox& box, size_t x, size_t y) const {
+    const double U = m_verticesPerEdge == 1 ? 0.0 : static_cast<double>(x) / static_cast<double>(m_verticesPerEdge - 1);
+    const double V = m_verticesPerEdge == 1 ? 0.0 : static_cast<double>(y) / static_cast<double>(m_verticesPerEdge - 1);
+    return {box.x + box.w * U, box.y + box.h * V};
+}
+
+void CDeformableMesh::clampDisplacement(double maxDisplacement) {
+    maxDisplacement = std::max(maxDisplacement, 0.0);
+
+    for (auto& p : m_points) {
+        const double LENGTH = std::hypot(p.displacement.x, p.displacement.y);
+        if (LENGTH <= maxDisplacement || LENGTH <= 0.0)
+            continue;
+
+        p.displacement = p.displacement * (maxDisplacement / LENGTH);
+    }
+}

--- a/src/helpers/DeformableMesh.hpp
+++ b/src/helpers/DeformableMesh.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "math/Math.hpp"
+
+#include <chrono>
+#include <optional>
+#include <vector>
+
+namespace Hyprutils::Animation {
+    struct SSpringCurve;
+}
+
+struct SMeshRenderVertex {
+    float x = 0.F, y = 0.F;
+    float u = 0.F, v = 0.F;
+};
+
+class CDeformableMesh {
+  public:
+    explicit CDeformableMesh(size_t verticesPerEdge = 8);
+
+    void                           setSize(size_t verticesPerEdge);
+    size_t                         size() const;
+
+    void                           reset();
+    void                           onPositionUpdate(const CBox& previous, const CBox& current, float intensity, std::optional<Vector2D> grabPoint = std::nullopt);
+    void                           advance(const Hyprutils::Animation::SSpringCurve& spring, std::chrono::duration<float> elapsed);
+
+    bool                           stable(float positionEpsilon, float velocityEpsilon) const;
+    CBox                           transformedExtents(const CBox& box) const;
+    std::vector<SMeshRenderVertex> verticesForBox(const CBox& box, const CBox& outputBox, const Vector2D& textureSize, double displacementScale = 1.0) const;
+
+  private:
+    struct SPoint {
+        Vector2D displacement;
+        Vector2D velocity;
+    };
+
+    SPoint&             point(size_t x, size_t y);
+    const SPoint&       point(size_t x, size_t y) const;
+    Vector2D            restPoint(const CBox& box, size_t x, size_t y) const;
+    void                clampDisplacement(double maxDisplacement);
+
+    size_t              m_verticesPerEdge = 8;
+    std::vector<SPoint> m_points;
+};

--- a/src/layout/supplementary/DragController.cpp
+++ b/src/layout/supplementary/DragController.cpp
@@ -438,7 +438,7 @@ void CDragStateController::mouseMove(const Vector2D& mousePos) {
     }
 
     if (TRACKMOTION)
-        MOTIONWINDOW->recordMotionBlur(previousFull, MOTIONWINDOW->getFullWindowBoundingBox());
+        MOTIONWINDOW->onPositionUpdate(previousFull, MOTIONWINDOW->getFullWindowBoundingBox(), Desktop::View::WINDOW_UPDATE_MOUSE);
 
     // get middle point
     Vector2D middle = DRAGGINGTARGET->position().middle();

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -2066,6 +2066,12 @@ uint16_t CMonitor::isDSBlocked(bool full) {
         return reasons;
     }
 
+    if (PCANDIDATE->m_transformers.blocksDirectScanout()) {
+        reasons |= DS_BLOCK_TRANSFORM;
+        if (!full)
+            return reasons;
+    }
+
     const auto PSURFACE = PCANDIDATE->getSolitaryResource();
     if (!PSURFACE || !PSURFACE->m_current.texture || !PSURFACE->m_current.buffer) {
         reasons |= DS_BLOCK_SURFACE;

--- a/src/render/ElementRenderer.cpp
+++ b/src/render/ElementRenderer.cpp
@@ -166,7 +166,7 @@ void IElementRenderer::drawRect(WP<CRectPassElement> element, const CRegion& dam
     data.modifiedBox = data.box;
     m_renderData.renderModif.applyToBox(data.modifiedBox);
 
-    CBox transformedBox = data.box;
+    CBox transformedBox = data.modifiedBox;
     transformedBox.transform(Math::wlTransformToHyprutils(Math::invertTransform(m_renderData.pMonitor->m_transform)), m_renderData.pMonitor->m_transformedSize.x,
                              m_renderData.pMonitor->m_transformedSize.y);
 
@@ -268,12 +268,25 @@ void IElementRenderer::drawSurface(WP<CSurfacePassElement> element, const CRegio
 
     calculateUVForSurface(m_data.pWindow, m_data.surface, m_data.pMonitor->m_self.lock(), m_data.mainSurface, windowBox.size(), PROJSIZEUNSCALED, MISALIGNEDFSV1);
 
-    auto cancelRender = false;
-    auto clipRegion   = element->visibleRegion(cancelRender);
-    if (cancelRender) {
-        element->discard();
-        return;
+    auto    cancelRender = false;
+    CRegion clipRegion;
+
+    if (!m_renderData.renderingTransformedSource) {
+        clipRegion = element->visibleRegion(cancelRender);
+        if (cancelRender) {
+            element->discard();
+            return;
+        }
     }
+
+    const auto surfaceDamage = [&m_renderData, &windowBox] {
+        if (m_renderData.renderingTransformedSource)
+            return m_renderData.damage.copy();
+
+        CRegion renderDamage = m_renderData.damage.copy().intersect(windowBox);
+        m_renderData.renderModif.applyToRegion(renderDamage);
+        return renderDamage;
+    };
 
     // check for fractional scale surfaces misaligning the buffer size
     // in those cases it's better to just force nearest neighbor
@@ -324,7 +337,7 @@ void IElementRenderer::drawSurface(WP<CSurfacePassElement> element, const CRegio
                             .clipRegion            = clipRegion,
                             .currentLS             = m_data.pLS,
                         }),
-                        m_renderData.damage.copy().intersect(windowBox));
+                        surfaceDamage());
         else
             drawElement(makeShared<CTexPassElement>(CTexPassElement::SRenderData{
                             .tex            = TEXTURE,
@@ -342,7 +355,7 @@ void IElementRenderer::drawSurface(WP<CSurfacePassElement> element, const CRegio
                             .clipRegion     = clipRegion,
                             .currentLS      = m_data.pLS,
                         }),
-                        m_renderData.damage.copy().intersect(windowBox));
+                        surfaceDamage());
     } else {
         if (BLUR && m_data.popup)
             drawElement(makeShared<CTexPassElement>(CTexPassElement::SRenderData{
@@ -364,7 +377,7 @@ void IElementRenderer::drawSurface(WP<CSurfacePassElement> element, const CRegio
                             .clipRegion            = clipRegion,
                             .currentLS             = m_data.pLS,
                         }),
-                        m_renderData.damage.copy().intersect(windowBox));
+                        surfaceDamage());
         else
             drawElement(makeShared<CTexPassElement>(CTexPassElement::SRenderData{
                             .tex            = TEXTURE,
@@ -382,7 +395,7 @@ void IElementRenderer::drawSurface(WP<CSurfacePassElement> element, const CRegio
                             .clipRegion     = clipRegion,
                             .currentLS      = m_data.pLS,
                         }),
-                        m_renderData.damage.copy().intersect(windowBox));
+                        surfaceDamage());
     }
 
     g_pHyprRenderer->blend(true);
@@ -393,7 +406,7 @@ void IElementRenderer::drawSurface(WP<CSurfacePassElement> element, const CRegio
 
 void IElementRenderer::preDrawSurface(WP<CSurfacePassElement> element, const CRegion& damage) {
     auto& m_renderData              = g_pHyprRenderer->m_renderData;
-    m_renderData.clipBox            = element->m_data.clipBox;
+    m_renderData.clipBox            = m_renderData.renderingTransformedSource ? CBox{} : element->m_data.clipBox;
     m_renderData.useNearestNeighbor = element->m_data.useNearestNeighbor;
     g_pHyprRenderer->pushMonitorTransformEnabled(element->m_data.flipEndFrame);
     m_renderData.currentWindow = element->m_data.pWindow;
@@ -424,6 +437,12 @@ void IElementRenderer::drawTex(WP<CTexPassElement> element, const CRegion& damag
 
     m_renderData.surface = element->m_data.surface;
 
+    const auto transformClipRegion = [&element, &m_renderData] {
+        CRegion clipRegion = element->m_data.clipRegion.copy();
+        m_renderData.renderModif.applyToRegion(clipRegion);
+        element->m_data.clipRegion = clipRegion;
+    };
+
     Hyprutils::Utils::CScopeGuard x = {[useMirrorProjection = element->m_data.useMirrorProjection]() {
         g_pHyprRenderer->popMonitorTransformEnabled();
         if (useMirrorProjection)
@@ -435,7 +454,8 @@ void IElementRenderer::drawTex(WP<CTexPassElement> element, const CRegion& damag
     if (element->m_data.blur) {
         // make a damage region for this window
         CRegion texDamage{m_renderData.damage};
-        texDamage.intersect(element->m_data.box.x, element->m_data.box.y, element->m_data.box.width, element->m_data.box.height);
+        if (!m_renderData.renderingTransformedSource)
+            texDamage.intersect(element->m_data.box.x, element->m_data.box.y, element->m_data.box.width, element->m_data.box.height);
 
         // While renderTextureInternalWithDamage will clip the blur as well,
         // clipping texDamage here allows blur generation to be optimized.
@@ -461,6 +481,7 @@ void IElementRenderer::drawTex(WP<CTexPassElement> element, const CRegion& damag
 
             if (inverseOpaque.empty()) {
                 element->m_data.blur = false;
+                transformClipRegion();
                 draw(element, damage);
                 return;
             }
@@ -480,9 +501,12 @@ void IElementRenderer::drawTex(WP<CTexPassElement> element, const CRegion& damag
         } else
             element->m_data.blurredBG = m_renderData.pMonitor->resources()->m_blurFB->getTexture();
 
+        transformClipRegion();
         draw(element, damage);
-    } else
+    } else {
+        transformClipRegion();
         draw(element, damage);
+    }
 }
 
 void IElementRenderer::drawTexMatte(WP<CTextureMatteElement> element, const CRegion& damage) {
@@ -518,14 +542,24 @@ void IElementRenderer::drawTransformedWindow(WP<CTransformedWindowPassElement> e
 
     SP<IFramebuffer> last;
 
-    const auto       transformWindowFB = [&element](SP<IFramebuffer> in) {
+    CBox             currentBox = element->m_data.currentBox.copy();
+    CBox             sourceBox  = currentBox;
+
+    if (const auto PWINDOW = element->m_data.window.lock(); !element->m_data.standalone && !element->m_data.renderingSnapshot && PWINDOW)
+        sourceBox = PWINDOW->m_transformers.sourceBoxForRender(currentBox, CBox{{}, pMonitor->m_size});
+
+    const auto SOURCEOFFSET = (sourceBox.pos() - currentBox.pos()) * pMonitor->m_scale;
+
+    const auto transformWindowFB = [&element, &pMonitor, &sourceBox](SP<IFramebuffer> in) {
         SP<IFramebuffer> transformed = in;
 
-        if (const auto PWINDOW = element->m_data.window.lock()) {
-            for (auto const& t : PWINDOW->m_transformers) {
-                transformed = t->transform(transformed);
-            }
-        }
+        if (const auto PWINDOW = element->m_data.window.lock())
+            transformed = PWINDOW->m_transformers.transform(in,
+                                                            Render::SWindowTransformContext{.currentBox        = element->m_data.currentBox,
+                                                                                            .sourceBox         = sourceBox,
+                                                                                            .monitor           = pMonitor,
+                                                                                            .standalone        = element->m_data.standalone,
+                                                                                            .renderingSnapshot = element->m_data.renderingSnapshot});
 
         return transformed;
     };
@@ -540,9 +574,31 @@ void IElementRenderer::drawTransformedWindow(WP<CTransformedWindowPassElement> e
 
         g_pHyprRenderer->draw(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)});
 
-        CBox nestedDamage = element->m_data.currentBox.copy().scale(pMonitor->m_scale).round();
-        nestedDamage.expand(2);
-        element->m_data.pass->render(CRegion{nestedDamage});
+        const auto SAVEDRENDERMODIF       = renderData.renderModif;
+        const auto SAVEDNOSIMPLIFY        = renderData.noSimplify;
+        const auto SAVEDTRANSFORMEDSOURCE = renderData.renderingTransformedSource;
+
+        if (SOURCEOFFSET != Vector2D{}) {
+            renderData.renderModif.modifs.emplace_back(std::make_pair<>(SRenderModifData::eRenderModifType::RMOD_TYPE_TRANSLATE, SOURCEOFFSET));
+            renderData.noSimplify = true;
+        }
+
+        renderData.renderingTransformedSource = true;
+
+        CRegion nestedDamage;
+        if (SOURCEOFFSET != Vector2D{})
+            nestedDamage = CRegion{0, 0, sc<int>(pMonitor->m_transformedSize.x), sc<int>(pMonitor->m_transformedSize.y)};
+        else {
+            CBox nestedDamageBox = currentBox.copy().scale(pMonitor->m_scale).round();
+            nestedDamageBox.expand(2);
+            nestedDamage = CRegion{nestedDamageBox};
+        }
+
+        element->m_data.pass->render(nestedDamage);
+
+        renderData.renderModif                = SAVEDRENDERMODIF;
+        renderData.noSimplify                 = SAVEDNOSIMPLIFY;
+        renderData.renderingTransformedSource = SAVEDTRANSFORMEDSOURCE;
 
         last = transformWindowFB(fb);
     }
@@ -563,6 +619,11 @@ void IElementRenderer::drawTransformedWindow(WP<CTransformedWindowPassElement> e
                 renderData.damage  = CRegion{0, 0, sc<int>(pMonitor->m_transformedSize.x), sc<int>(pMonitor->m_transformedSize.y)};
 
                 g_pHyprRenderer->draw(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 1)});
+
+                const auto SAVEDRENDERMODIF = renderData.renderModif;
+                if (SOURCEOFFSET != Vector2D{})
+                    renderData.renderModif.modifs.emplace_back(std::make_pair<>(SRenderModifData::eRenderModifType::RMOD_TYPE_TRANSLATE, SOURCEOFFSET));
+
                 g_pHyprRenderer->draw(
                     CRectPassElement::SRectData{
                         .box           = element->m_data.blurBox,
@@ -571,6 +632,8 @@ void IElementRenderer::drawTransformedWindow(WP<CTransformedWindowPassElement> e
                         .roundingPower = element->m_data.blurRoundingPower,
                     },
                     renderData.damage);
+
+                renderData.renderModif = SAVEDRENDERMODIF;
 
                 matteLast = transformWindowFB(matteFB);
             }
@@ -592,8 +655,8 @@ void IElementRenderer::drawTransformedWindow(WP<CTransformedWindowPassElement> e
         return;
 
     SMotionBlurData motionBlur = element->m_data.motionBlur;
-    CBox            currentBox = element->m_data.currentBox.copy().round();
-    CBox            outputBox  = currentBox;
+    currentBox.round();
+    CBox outputBox = currentBox;
 
     if (motionBlur.enabled) {
         motionBlur.previous.scale(pMonitor->m_scale);

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1087,7 +1087,7 @@ void CHyprOpenGLImpl::renderRectWithDamageInternal(const CBox& box, const CHyprC
     shader->setUniformFloat4(SHADER_COLOR, converted.r, converted.g, converted.b, converted.a);
     shader->setUniformFloat4(SHADER_COLOR_SRGB, premultiplied.r, premultiplied.g, premultiplied.b, premultiplied.a);
 
-    CBox transformedBox = box;
+    CBox transformedBox = newBox;
     transformedBox.transform(Math::wlTransformToHyprutils(Math::invertTransform(m_renderData.pMonitor->m_transform)), m_renderData.pMonitor->m_transformedSize.x,
                              m_renderData.pMonitor->m_transformedSize.y);
 
@@ -1598,6 +1598,77 @@ void CHyprOpenGLImpl::renderTextureInternal(SP<ITexture> tex, const CBox& box, c
     tex->unbind();
 }
 
+void CHyprOpenGLImpl::renderTextureMesh(SP<ITexture> tex, const CBox& box, const std::vector<SMeshRenderVertex>& vertices, STextureRenderData data) {
+    RASSERT(g_pHyprRenderer->m_renderData.pMonitor, "Tried to render texture mesh without begin()!");
+    RASSERT(tex, "Attempted to draw nullptr texture mesh!");
+    RASSERT(tex->ok(), "Attempted to draw invalid texture mesh!");
+
+    if (!data.damage || data.damage->empty() || vertices.empty())
+        return;
+
+    CBox newBox = box;
+    g_pHyprRenderer->m_renderData.renderModif.applyToBox(newBox);
+
+    const auto                  MONITOR_INVERTED = Math::wlTransformToHyprutils(Math::invertTransform(g_pHyprRenderer->m_renderData.pMonitor->m_transform));
+    Hyprutils::Math::eTransform TRANSFORM        = tex->m_transform;
+
+    if (g_pHyprRenderer->monitorTransformEnabled())
+        TRANSFORM = Math::composeTransform(MONITOR_INVERTED, TRANSFORM);
+
+    const auto& glMatrix = g_pHyprRenderer->projectBoxToTarget(newBox, TRANSFORM);
+
+    glActiveTexture(GL_TEXTURE0);
+    tex->bind();
+
+    tex->setTexParameter(GL_TEXTURE_WRAP_S, wrapModeToGl(data.wrapX));
+    tex->setTexParameter(GL_TEXTURE_WRAP_T, wrapModeToGl(data.wrapY));
+
+    if (g_pHyprRenderer->m_renderData.useNearestNeighbor) {
+        tex->setTexParameter(GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+        tex->setTexParameter(GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+    } else {
+        tex->setTexParameter(GL_TEXTURE_MAG_FILTER, tex->magFilter);
+        tex->setTexParameter(GL_TEXTURE_MIN_FILTER, tex->minFilter);
+    }
+
+    auto shader = renderToFBInternal(tex, data, tex->m_type, newBox);
+
+    shader->setUniformMatrix3fv(SHADER_PROJ, 1, GL_TRUE, glMatrix.getMatrix());
+    shader->setUniformInt(SHADER_TEX, 0);
+    GLCALL(glBindVertexArray(shader->getUniformLocation(SHADER_SHADER_UV_VAO)));
+    GLCALL(glBindBuffer(GL_ARRAY_BUFFER, shader->getUniformLocation(SHADER_SHADER_UV_VBO)));
+
+    glBufferData(GL_ARRAY_BUFFER, sizeof(SMeshRenderVertex) * vertices.size(), nullptr, GL_DYNAMIC_DRAW);
+    glBufferSubData(GL_ARRAY_BUFFER, 0, sizeof(SMeshRenderVertex) * vertices.size(), vertices.data());
+
+    if (!g_pHyprRenderer->m_renderData.clipBox.empty() || !data.clipRegion.empty()) {
+        CRegion damageClip = g_pHyprRenderer->m_renderData.clipBox;
+
+        if (!data.clipRegion.empty()) {
+            if (g_pHyprRenderer->m_renderData.clipBox.empty())
+                damageClip = data.clipRegion;
+            else
+                damageClip.intersect(data.clipRegion);
+        }
+
+        if (!damageClip.empty()) {
+            damageClip.forEachRect([this, &vertices](const auto& RECT) {
+                scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+                glDrawArrays(GL_TRIANGLES, 0, sc<GLsizei>(vertices.size()));
+            });
+        }
+    } else {
+        data.damage->forEachRect([this, &vertices](const auto& RECT) {
+            scissor(&RECT, g_pHyprRenderer->m_renderData.transformDamage);
+            glDrawArrays(GL_TRIANGLES, 0, sc<GLsizei>(vertices.size()));
+        });
+    }
+
+    GLCALL(glBindVertexArray(0));
+    GLCALL(glBindBuffer(GL_ARRAY_BUFFER, 0));
+    tex->unbind();
+}
+
 void CHyprOpenGLImpl::renderTexturePrimitive(SP<ITexture> tex, const CBox& box) {
     RASSERT(g_pHyprRenderer->m_renderData.pMonitor, "Tried to render texture without begin()!");
     RASSERT((tex->ok()), "Attempted to draw nullptr texture!");
@@ -2010,7 +2081,8 @@ void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox
 
     static auto PBLEND        = CConfigValue<Config::INTEGER>("render:use_shader_blur_blend");
     const auto  NEEDS_STENCIL = data.discardMode != 0 && (!data.blockBlurOptimization || (data.discardMode & DISCARD_ALPHA));
-    if (!*PBLEND) {
+    const bool  SHADERBLEND   = *PBLEND || data.forceBlurBlend;
+    if (!SHADERBLEND) {
 
         if (NEEDS_STENCIL) {
             scissor(nullptr); // allow the entire window and stencil to render
@@ -2111,14 +2183,14 @@ void CHyprOpenGLImpl::renderTextureWithBlurInternal(SP<ITexture> tex, const CBox
     // draw window
     renderTextureInternal(tex, box,
                           STextureRenderData{
-                              .blur           = *PBLEND,
+                              .blur           = SHADERBLEND,
                               .blurredBG      = data.blurredBG,
                               .blurAlphaMatte = data.blurAlphaMatte,
                               .damage         = data.damage,
                               .a              = data.a * data.overallA,
                               .round          = data.round,
                               .roundingPower  = data.roundingPower,
-                              .discardActive  = *PBLEND && NEEDS_STENCIL,
+                              .discardActive  = SHADERBLEND && NEEDS_STENCIL,
                               .allowCustomUV  = true,
                               .allowDim       = true,
                               .noAA           = false,
@@ -2167,8 +2239,8 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValue
     if (g_pHyprRenderer->m_renderData.damage.empty())
         return;
 
-    CBox newBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(newBox);
+    CBox innerBox = box;
+    g_pHyprRenderer->m_renderData.renderModif.applyToBox(innerBox);
 
     if (data.borderSize < 1)
         return;
@@ -2177,6 +2249,7 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValue
     scaledBorderSize     = std::round(scaledBorderSize * g_pHyprRenderer->m_renderData.renderModif.combinedScale());
 
     // adjust box
+    CBox newBox = innerBox;
     newBox.x -= scaledBorderSize;
     newBox.y -= scaledBorderSize;
     newBox.width += 2 * scaledBorderSize;
@@ -2225,7 +2298,7 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValue
     // calculate the border's region, which we need to render over. No need to run the shader on
     // things outside there
     CRegion borderRegion = g_pHyprRenderer->m_renderData.damage.copy().intersect(newBox);
-    borderRegion.subtract(box.copy().expand(-scaledBorderSize - round));
+    borderRegion.subtract(innerBox.copy().expand(-scaledBorderSize - round));
 
     if (g_pHyprRenderer->m_renderData.clipBox.width != 0 && g_pHyprRenderer->m_renderData.clipBox.height != 0)
         borderRegion.intersect(g_pHyprRenderer->m_renderData.clipBox);
@@ -2252,8 +2325,8 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValue
     if (g_pHyprRenderer->m_renderData.damage.empty())
         return;
 
-    CBox newBox = box;
-    g_pHyprRenderer->m_renderData.renderModif.applyToBox(newBox);
+    CBox innerBox = box;
+    g_pHyprRenderer->m_renderData.renderModif.applyToBox(innerBox);
 
     if (data.borderSize < 1)
         return;
@@ -2262,6 +2335,7 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValue
     scaledBorderSize     = std::round(scaledBorderSize * g_pHyprRenderer->m_renderData.renderModif.combinedScale());
 
     // adjust box
+    CBox newBox = innerBox;
     newBox.x -= scaledBorderSize;
     newBox.y -= scaledBorderSize;
     newBox.width += 2 * scaledBorderSize;
@@ -2313,7 +2387,7 @@ void CHyprOpenGLImpl::renderBorder(const CBox& box, const Config::CGradientValue
     // calculate the border's region, which we need to render over. No need to run the shader on
     // things outside there
     CRegion borderRegion = g_pHyprRenderer->m_renderData.damage.copy().intersect(newBox);
-    borderRegion.subtract(box.copy().expand(-scaledBorderSize - round));
+    borderRegion.subtract(innerBox.copy().expand(-scaledBorderSize - round));
 
     if (g_pHyprRenderer->m_renderData.clipBox.width != 0 && g_pHyprRenderer->m_renderData.clipBox.height != 0)
         borderRegion.intersect(g_pHyprRenderer->m_renderData.clipBox);

--- a/src/render/OpenGL.hpp
+++ b/src/render/OpenGL.hpp
@@ -6,6 +6,7 @@
 #include "../helpers/time/Timer.hpp"
 #include "../helpers/math/Math.hpp"
 #include "../helpers/Format.hpp"
+#include "../helpers/DeformableMesh.hpp"
 #include "../helpers/sync/SyncTimeline.hpp"
 #include <GLES3/gl32.h>
 #include <cstdint>
@@ -105,13 +106,14 @@ namespace Render::GL {
         CRegion                  finalDamage; // damage used for final off -> main
 
         Render::SRenderModifData renderModif;
-        float                    mouseZoomFactor    = 1.f;
-        bool                     mouseZoomUseMouse  = true; // true by default
-        bool                     useNearestNeighbor = false;
-        bool                     blockScreenShader  = false;
-        bool                     simplePass         = false;
-        bool                     transformDamage    = true;
-        bool                     noSimplify         = false;
+        float                    mouseZoomFactor            = 1.f;
+        bool                     mouseZoomUseMouse          = true; // true by default
+        bool                     useNearestNeighbor         = false;
+        bool                     blockScreenShader          = false;
+        bool                     simplePass                 = false;
+        bool                     transformDamage            = true;
+        bool                     noSimplify                 = false;
+        bool                     renderingTransformedSource = false;
 
         Vector2D                 primarySurfaceUVTopLeft     = Vector2D(-1, -1);
         Vector2D                 primarySurfaceUVBottomRight = Vector2D(-1, -1);
@@ -204,6 +206,7 @@ namespace Render::GL {
 
         void renderRect(const CBox&, const CHyprColor&, SRectRenderData data);
         void renderTexture(SP<ITexture>, const CBox&, STextureRenderData data);
+        void renderTextureMesh(SP<ITexture>, const CBox&, const std::vector<SMeshRenderVertex>& vertices, STextureRenderData data);
         void renderRoundedShadow(const CBox&, int round, float roundingPower, int range, const Config::CGradientValueData& color, float a = 1.0);
         void renderRoundedShadow(const CBox&, int round, float roundingPower, int range, const Config::CGradientValueData& grad1, const Config::CGradientValueData& grad2,
                                  float lerp, float a = 1.0);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -649,9 +649,7 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
             passRedirect    = redirectPass(transformedPass.get());
             renderdata.blur = false;
 
-            for (auto const& t : pWindow->m_transformers) {
-                t->preWindowRender(&renderdata);
-            }
+            pWindow->m_transformers.preWindowRender(&renderdata);
         }
 
         if (renderdata.decorate) {
@@ -722,12 +720,11 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
 
             CBox currentBox = pWindow->getFullWindowBoundingBox();
             currentBox.translate((pWindow->m_pinned ? Vector2D{} : PWORKSPACE->m_renderOffset->value()) + pWindow->m_floatingOffset - pMonitor->m_position);
+            CBox            transformedBox = pWindow->m_transformers.transformedExtents(currentBox);
 
             SMotionBlurData windowMotionBlur;
             if (!standalone && !m_bRenderingSnapshot) {
-                for (auto const& t : pWindow->m_transformers) {
-                    t->amendTransformedRenderData(currentBox, &windowMotionBlur);
-                }
+                pWindow->m_transformers.amendTransformedRenderData(transformedBox, &windowMotionBlur);
             }
 
             CBox blurBox = {renderdata.pos.x - pMonitor->m_position.x, renderdata.pos.y - pMonitor->m_position.y, renderdata.w, renderdata.h};
@@ -742,7 +739,10 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
                 .blurA             = renderdata.fadeAlpha,
                 .blurRound         = renderdata.dontRound ? 0 : std::max(renderdata.rounding - 1, 0),
                 .blurRoundingPower = renderdata.roundingPower,
+                .transformedBox    = transformedBox,
                 .motionBlur        = windowMotionBlur,
+                .standalone        = standalone,
+                .renderingSnapshot = m_bRenderingSnapshot,
             }));
 
             renderdata.blur = windowBlur;
@@ -2763,6 +2763,7 @@ void IHyprRenderer::damageWindow(PHLWINDOW pWindow, bool forceFull) {
     if (PWINDOWWORKSPACE && PWINDOWWORKSPACE->m_renderOffset->isBeingAnimated() && !pWindow->m_pinned)
         windowBox.translate(PWINDOWWORKSPACE->m_renderOffset->value());
     windowBox.translate(pWindow->m_floatingOffset);
+    windowBox = pWindow->m_transformers.transformBoxForDamage(windowBox);
 
     for (auto const& m : State::monitorState()->monitors()) {
         if (forceFull || shouldRenderWindow(pWindow, m)) { // only damage if window is rendered on monitor

--- a/src/render/pass/TransformedWindowPassElement.cpp
+++ b/src/render/pass/TransformedWindowPassElement.cpp
@@ -16,7 +16,7 @@ std::optional<CBox> CTransformedWindowPassElement::boundingBox() {
     if (m_data.motionBlur.enabled)
         return m_data.motionBlur.extents();
 
-    return m_data.currentBox;
+    return m_data.transformedBox.empty() ? m_data.currentBox : m_data.transformedBox;
 }
 
 CRegion CTransformedWindowPassElement::opaqueRegion() {

--- a/src/render/pass/TransformedWindowPassElement.hpp
+++ b/src/render/pass/TransformedWindowPassElement.hpp
@@ -14,7 +14,10 @@ class CTransformedWindowPassElement : public IPassElement {
         float                   blurA             = 1.F;
         int                     blurRound         = 0;
         float                   blurRoundingPower = 2.F;
+        CBox                    transformedBox;
         SMotionBlurData         motionBlur;
+        bool                    standalone        = false;
+        bool                    renderingSnapshot = false;
     };
 
     CTransformedWindowPassElement(SData&& data);

--- a/src/render/shaders/glsl/surface.frag
+++ b/src/render/shaders/glsl/surface.frag
@@ -143,19 +143,22 @@ void main() {
     if (discardAlpha && pixColor.a <= discardAlphaValue)
         pixBlurAlphaMask = 0.0;
 #endif
-    vec3 blurredPixColor = mix(texture(blurredBG, v_texcoord * uvSize + uvOffset).rgb, pixColor.rgb, pixColor.a);
-    pixColor             = vec4(mix(pixColor.rgb, blurredPixColor, pixBlurAlphaMask), max(pixColor.a, pixBlurAlphaMask));
+    vec3 blurredPixColor = texture(blurredBG, v_texcoord * uvSize + uvOffset).rgb;
+    float pixBlurBgAlpha = (1.0 - pixColor.a) * pixBlurAlphaMask;
+    pixColor             = vec4(pixColor.rgb + blurredPixColor * pixBlurBgAlpha, pixColor.a + pixBlurBgAlpha);
 #else
 #if USE_BLUR_ALPHA_MASK
     if (pixColor.a <= 0.0)
         discard;
 #endif
 #if USE_DISCARD
-    pixColor = mix(pixColor, vec4(mix(texture(blurredBG, v_texcoord * uvSize + uvOffset).rgb, pixColor.rgb, pixColor.a), 1.0),
-                   discardAlpha && (pixColor.a <= discardAlphaValue) ? 0.0 : 1.0);
+    float pixBlurAlphaMask = discardAlpha && (pixColor.a <= discardAlphaValue) ? 0.0 : 1.0;
 #else
-    pixColor = vec4(mix(texture(blurredBG, v_texcoord * uvSize + uvOffset).rgb, pixColor.rgb, pixColor.a), 1.0);
+    float pixBlurAlphaMask = 1.0;
 #endif
+    vec3 blurredPixColor = texture(blurredBG, v_texcoord * uvSize + uvOffset).rgb;
+    float pixBlurBgAlpha = (1.0 - pixColor.a) * pixBlurAlphaMask;
+    pixColor             = vec4(pixColor.rgb + blurredPixColor * pixBlurBgAlpha, pixColor.a + pixBlurBgAlpha);
 #endif
 #endif
 
@@ -178,18 +181,21 @@ void main() {
     if (discardAlpha && mirrorColor.a <= discardAlphaValue)
         mirrorBlurAlphaMask = 0.0;
 #endif
-    vec3 blurredMirrorColor = mix(texture(blurredBG, v_texcoord * uvSize + uvOffset).rgb, mirrorColor.rgb, mirrorColor.a);
-    mirrorColor             = vec4(mix(mirrorColor.rgb, blurredMirrorColor, mirrorBlurAlphaMask), max(mirrorColor.a, mirrorBlurAlphaMask));
+    vec3 blurredMirrorColor = texture(blurredBG, v_texcoord * uvSize + uvOffset).rgb;
+    float mirrorBlurBgAlpha = (1.0 - mirrorColor.a) * mirrorBlurAlphaMask;
+    mirrorColor             = vec4(mirrorColor.rgb + blurredMirrorColor * mirrorBlurBgAlpha, mirrorColor.a + mirrorBlurBgAlpha);
 #else
 #if USE_BLUR_ALPHA_MASK
     if (mirrorColor.a > 0.0) {
 #endif
 #if USE_DISCARD
-        mirrorColor = mix(mirrorColor, vec4(mix(texture(blurredBG, v_texcoord * uvSize + uvOffset).rgb, mirrorColor.rgb, mirrorColor.a), 1.0),
-                          discardAlpha && (mirrorColor.a <= discardAlphaValue) ? 0.0 : 1.0);
+        float mirrorBlurAlphaMask = discardAlpha && (mirrorColor.a <= discardAlphaValue) ? 0.0 : 1.0;
 #else
-        mirrorColor = vec4(mix(texture(blurredBG, v_texcoord * uvSize + uvOffset).rgb, mirrorColor.rgb, mirrorColor.a), 1.0);
+        float mirrorBlurAlphaMask = 1.0;
 #endif
+        vec3 blurredMirrorColor = texture(blurredBG, v_texcoord * uvSize + uvOffset).rgb;
+        float mirrorBlurBgAlpha = (1.0 - mirrorColor.a) * mirrorBlurAlphaMask;
+        mirrorColor             = vec4(mirrorColor.rgb + blurredMirrorColor * mirrorBlurBgAlpha, mirrorColor.a + mirrorBlurBgAlpha);
 #if USE_BLUR_ALPHA_MASK
     } else
         mirrorColor = vec4(0.0);

--- a/src/render/transformer/MotionBlurTransformer.cpp
+++ b/src/render/transformer/MotionBlurTransformer.cpp
@@ -30,8 +30,31 @@ bool CMotionBlurTransformer::shouldEnable(PHLWINDOW window) {
     return *PMBENABLED && *PMBSAMPLES > 1 && !Fullscreen::controller()->isFullscreen(window);
 }
 
-SP<Render::IFramebuffer> CMotionBlurTransformer::transform(SP<Render::IFramebuffer> in) {
+SP<Render::IFramebuffer> CMotionBlurTransformer::transform(SP<Render::IFramebuffer> in, const SWindowTransformContext&) {
     return in;
+}
+
+int CMotionBlurTransformer::priority() const {
+    return 100;
+}
+
+bool CMotionBlurTransformer::active() const {
+    return state(true).has_value();
+}
+
+CBox CMotionBlurTransformer::transformBoxForDamage(const CBox& currentBox) const {
+    const auto STATE = state(true);
+    if (!STATE)
+        return currentBox;
+
+    const Vector2D relPos = currentBox.pos() - STATE->current.pos();
+    const Vector2D scale  = STATE->previous.size() / STATE->current.size();
+
+    CBox           previous = {STATE->previous.pos() + relPos * scale, currentBox.size() * scale};
+    CBox           damaged  = MotionBlur::extents(previous, currentBox);
+    damaged.expand(4.F);
+
+    return damaged;
 }
 
 void CMotionBlurTransformer::amendTransformedRenderData(const CBox& currentBox, SMotionBlurData* pMotionBlurData) {

--- a/src/render/transformer/MotionBlurTransformer.hpp
+++ b/src/render/transformer/MotionBlurTransformer.hpp
@@ -10,7 +10,10 @@ namespace Render {
 
         static bool                       shouldEnable(PHLWINDOW window);
 
-        virtual SP<Render::IFramebuffer>  transform(SP<Render::IFramebuffer> in);
+        virtual SP<Render::IFramebuffer>  transform(SP<Render::IFramebuffer> in, const SWindowTransformContext& context);
+        virtual int                       priority() const;
+        virtual bool                      active() const;
+        virtual CBox                      transformBoxForDamage(const CBox& currentBox) const;
         virtual void                      amendTransformedRenderData(const CBox& currentBox, SMotionBlurData* pMotionBlurData);
 
         void                              record(const CBox& previous, const CBox& current);

--- a/src/render/transformer/Transformer.cpp
+++ b/src/render/transformer/Transformer.cpp
@@ -6,6 +6,30 @@ void IWindowTransformer::preWindowRender(CSurfacePassElement::SRenderData* pRend
     ;
 }
 
+int IWindowTransformer::priority() const {
+    return 0;
+}
+
+bool IWindowTransformer::active() const {
+    return true;
+}
+
+bool IWindowTransformer::blocksDirectScanout() const {
+    return active();
+}
+
+CBox IWindowTransformer::transformedExtents(const CBox& currentBox) const {
+    return currentBox;
+}
+
+CBox IWindowTransformer::sourceBoxForRender(const CBox& currentBox, const CBox&) const {
+    return currentBox;
+}
+
+CBox IWindowTransformer::transformBoxForDamage(const CBox& currentBox) const {
+    return transformedExtents(currentBox);
+}
+
 void IWindowTransformer::amendTransformedRenderData(const CBox& currentBox, SMotionBlurData* pMotionBlurData) {
     ;
 }

--- a/src/render/transformer/Transformer.hpp
+++ b/src/render/transformer/Transformer.hpp
@@ -8,6 +8,14 @@
 class CEventLoopTimer;
 
 namespace Render {
+    struct SWindowTransformContext {
+        CBox          currentBox;
+        CBox          sourceBox;
+        PHLMONITORREF monitor;
+        bool          standalone        = false;
+        bool          renderingSnapshot = false;
+    };
+
     // A window transformer can be attached to a window.
     // If any is attached, Hyprland will render the window to a separate fb, then call the transform() func with it,
     // and finally render it back to the main fb after all transformers pass.
@@ -19,7 +27,14 @@ namespace Render {
 
         // called by Hyprland. For more data about what is being rendered, inspect render data.
         // returns the out fb.
-        virtual SP<Render::IFramebuffer> transform(SP<Render::IFramebuffer> in) = 0;
+        virtual SP<Render::IFramebuffer> transform(SP<Render::IFramebuffer> in, const SWindowTransformContext& context) = 0;
+
+        virtual int                      priority() const;
+        virtual bool                     active() const;
+        virtual bool                     blocksDirectScanout() const;
+        virtual CBox                     transformedExtents(const CBox& currentBox) const;
+        virtual CBox                     sourceBoxForRender(const CBox& currentBox, const CBox& monitorBox) const;
+        virtual CBox                     transformBoxForDamage(const CBox& currentBox) const;
 
         // called by Hyprland before a window main pass is started.
         virtual void preWindowRender(CSurfacePassElement::SRenderData* pRenderData);

--- a/src/render/transformer/TransformerList.cpp
+++ b/src/render/transformer/TransformerList.cpp
@@ -1,0 +1,81 @@
+#include "TransformerList.hpp"
+
+using namespace Render;
+
+bool CWindowTransformerList::empty() const {
+    return std::ranges::none_of(m_transformers, [](auto const& transformer) { return transformer->active(); });
+}
+
+bool CWindowTransformerList::blocksDirectScanout() const {
+    return std::ranges::any_of(m_transformers, [](auto const& transformer) { return transformer->blocksDirectScanout(); });
+}
+
+CBox CWindowTransformerList::transformedExtents(const CBox& currentBox) const {
+    CBox box = currentBox;
+    for (auto const& transformer : m_transformers) {
+        if (!transformer->active())
+            continue;
+
+        box = transformer->transformedExtents(box);
+    }
+
+    return box;
+}
+
+CBox CWindowTransformerList::sourceBoxForRender(const CBox& currentBox, const CBox& monitorBox) const {
+    CBox box = currentBox;
+    for (auto const& transformer : m_transformers) {
+        if (!transformer->active())
+            continue;
+
+        box = transformer->sourceBoxForRender(box, monitorBox);
+    }
+
+    return box;
+}
+
+CBox CWindowTransformerList::transformBoxForDamage(const CBox& currentBox) const {
+    CBox box = currentBox;
+    for (auto const& transformer : m_transformers) {
+        if (!transformer->active())
+            continue;
+
+        box = transformer->transformBoxForDamage(box);
+    }
+
+    return box;
+}
+
+void CWindowTransformerList::preWindowRender(CSurfacePassElement::SRenderData* pRenderData) const {
+    for (auto const& transformer : m_transformers) {
+        if (transformer->active())
+            transformer->preWindowRender(pRenderData);
+    }
+}
+
+void CWindowTransformerList::amendTransformedRenderData(const CBox& currentBox, SMotionBlurData* pMotionBlurData) const {
+    for (auto const& transformer : m_transformers) {
+        if (transformer->active())
+            transformer->amendTransformedRenderData(currentBox, pMotionBlurData);
+    }
+}
+
+SP<Render::IFramebuffer> CWindowTransformerList::transform(SP<Render::IFramebuffer> in, const SWindowTransformContext& context) const {
+    SP<Render::IFramebuffer> last = in;
+    for (auto const& transformer : m_transformers) {
+        if (!transformer->active())
+            continue;
+
+        last = transformer->transform(last, context);
+    }
+
+    return last;
+}
+
+void CWindowTransformerList::removeInactive() {
+    std::erase_if(m_transformers, [](auto const& transformer) { return !transformer->active(); });
+}
+
+void CWindowTransformerList::sort() {
+    std::ranges::stable_sort(m_transformers, [](auto const& lhs, auto const& rhs) { return lhs->priority() < rhs->priority(); });
+}

--- a/src/render/transformer/TransformerList.hpp
+++ b/src/render/transformer/TransformerList.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "Transformer.hpp"
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+namespace Render {
+    class CWindowTransformerList {
+      public:
+        template <typename T, typename... Args>
+        T* emplace(Args&&... args) {
+            auto transformer = makeUnique<T>(std::forward<Args>(args)...);
+            auto ptr         = transformer.get();
+            m_transformers.emplace_back(std::move(transformer));
+            sort();
+            return ptr;
+        }
+
+        template <typename T>
+        T* get() {
+            for (auto const& transformer : m_transformers) {
+                if (const auto TYPED = dc<T*>(transformer.get()))
+                    return TYPED;
+            }
+
+            return nullptr;
+        }
+
+        template <typename T>
+        const T* get() const {
+            for (auto const& transformer : m_transformers) {
+                if (const auto TYPED = dc<const T*>(transformer.get()))
+                    return TYPED;
+            }
+
+            return nullptr;
+        }
+
+        bool                     empty() const;
+        bool                     blocksDirectScanout() const;
+        CBox                     transformedExtents(const CBox& currentBox) const;
+        CBox                     sourceBoxForRender(const CBox& currentBox, const CBox& monitorBox) const;
+        CBox                     transformBoxForDamage(const CBox& currentBox) const;
+
+        void                     preWindowRender(CSurfacePassElement::SRenderData* pRenderData) const;
+        void                     amendTransformedRenderData(const CBox& currentBox, SMotionBlurData* pMotionBlurData) const;
+        SP<Render::IFramebuffer> transform(SP<Render::IFramebuffer> in, const SWindowTransformContext& context) const;
+
+        void                     removeInactive();
+
+      private:
+        void                                        sort();
+
+        std::vector<UP<Render::IWindowTransformer>> m_transformers;
+    };
+}

--- a/src/render/transformer/WobbleTransformer.cpp
+++ b/src/render/transformer/WobbleTransformer.cpp
@@ -1,0 +1,250 @@
+#include "WobbleTransformer.hpp"
+
+#include "../../Compositor.hpp"
+#include "../../config/ConfigValue.hpp"
+#include "../../desktop/view/Window.hpp"
+#include "../../desktop/state/WindowState.hpp"
+#include "../../event/EventBus.hpp"
+#include "../../output/Monitor.hpp"
+#include "../../animation/AnimationManager.hpp"
+#include "../../managers/fullscreen/FullscreenController.hpp"
+#include "../OpenGL.hpp"
+#include "../Renderer.hpp"
+#include "../pass/ClearPassElement.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+using namespace Render;
+using namespace Hyprutils::Animation;
+
+static CHyprSignalListener g_wobbleTickListener;
+static constexpr double    WOBBLE_EXTENTS_PADDING = 4.0;
+
+static double              sourceOffsetForAxis(double min, double size, double monitorSize) {
+    return monitorSize / 2.0 - (min + size / 2.0);
+}
+
+static void tickWobbles() {
+    bool anyActive = false;
+
+    for (auto const& window : Desktop::windowState()->windows()) {
+        if (!window)
+            continue;
+
+        auto WOBBLE = window->m_transformers.get<CWobbleTransformer>();
+        if (!WOBBLE)
+            continue;
+
+        anyActive = WOBBLE->tick() || anyActive;
+        window->m_transformers.removeInactive();
+    }
+
+    if (anyActive && Animation::mgr())
+        Animation::mgr()->requestTick();
+}
+
+CWobbleTransformer::CWobbleTransformer(PHLWINDOWREF window) : m_window(window), m_mesh(8) {
+    m_lastTick = std::chrono::steady_clock::now();
+    ensureTickListener();
+}
+
+bool CWobbleTransformer::shouldEnable(PHLWINDOW window) {
+    static auto PENABLED = CConfigValue<Config::INTEGER>("decoration:wobble:enabled");
+
+    if (!window)
+        return false;
+
+    return *PENABLED && !Fullscreen::controller()->isFullscreen(window);
+}
+
+void CWobbleTransformer::ensureTickListener() {
+    if (g_wobbleTickListener)
+        return;
+
+    g_wobbleTickListener = Event::bus()->m_events.tick.listen([] { tickWobbles(); });
+}
+
+SP<Render::IFramebuffer> CWobbleTransformer::transform(SP<Render::IFramebuffer> in, const SWindowTransformContext& context) {
+    if (!m_active || context.standalone || context.renderingSnapshot || !context.monitor || !in || !in->getTexture())
+        return in;
+
+    const auto PWINDOW = m_window.lock();
+    if (!shouldEnable(PWINDOW))
+        return in;
+
+    const auto OUT = context.monitor->resources()->getUnusedWorkBuffer();
+    if (!OUT)
+        return in;
+
+    const double SCALE           = context.monitor->m_scale;
+    CBox         sourceBox       = context.sourceBox.empty() ? context.currentBox.copy() : context.sourceBox.copy();
+    const auto   SOURCEOFFSET    = sourceBox.pos() - context.currentBox.pos();
+    CBox         sourceOutputBox = transformedExtents(context.currentBox).translate(SOURCEOFFSET).scale(SCALE).round();
+    CBox         outputBox       = transformedExtents(context.currentBox).scale(SCALE).round();
+    sourceBox.scale(SCALE).round();
+
+    if (sourceBox.empty() || outputBox.empty())
+        return in;
+
+    const auto VERTICES = m_mesh.verticesForBox(sourceBox, sourceOutputBox, in->getTexture()->m_size, SCALE);
+    if (VERTICES.empty())
+        return in;
+
+    auto&         renderData = g_pHyprRenderer->m_renderData;
+    const CRegion oldDamage  = renderData.damage.copy();
+
+    {
+        auto guard        = g_pHyprRenderer->bindTempFB(OUT);
+        renderData.damage = CRegion{0, 0, sc<int>(context.monitor->m_transformedSize.x), sc<int>(context.monitor->m_transformedSize.y)};
+
+        g_pHyprRenderer->draw(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)});
+        GL::g_pHyprOpenGL->renderTextureMesh(in->getTexture(), outputBox, VERTICES,
+                                             GL::CHyprOpenGLImpl::STextureRenderData{.damage = &renderData.damage, .a = 1.F, .allowCustomUV = true});
+    }
+
+    renderData.damage = oldDamage;
+    return OUT;
+}
+
+int CWobbleTransformer::priority() const {
+    return 10;
+}
+
+bool CWobbleTransformer::active() const {
+    const auto PWINDOW = m_window.lock();
+    return m_active && shouldEnable(PWINDOW);
+}
+
+bool CWobbleTransformer::blocksDirectScanout() const {
+    return active();
+}
+
+CBox CWobbleTransformer::transformedExtents(const CBox& currentBox) const {
+    if (!m_active)
+        return currentBox;
+
+    return m_mesh.transformedExtents(currentBox).expand(WOBBLE_EXTENTS_PADDING);
+}
+
+CBox CWobbleTransformer::sourceBoxForRender(const CBox& currentBox, const CBox& monitorBox) const {
+    if (!m_active || monitorBox.w <= 0.0 || monitorBox.h <= 0.0)
+        return currentBox;
+
+    const auto     EXTENTS = transformedExtents(currentBox);
+    const Vector2D OFFSET  = {
+        sourceOffsetForAxis(EXTENTS.x, EXTENTS.w, monitorBox.w),
+        sourceOffsetForAxis(EXTENTS.y, EXTENTS.h, monitorBox.h),
+    };
+
+    return currentBox.copy().translate(OFFSET);
+}
+
+void CWobbleTransformer::record(const CBox& previous, const CBox& current, std::optional<Vector2D> grabPoint) {
+    const auto PWINDOW = m_window.lock();
+    if (!shouldEnable(PWINDOW)) {
+        resetWithDamage();
+        return;
+    }
+
+    if (previous == current)
+        return;
+
+    const Vector2D DELTA        = current.pos() - previous.pos();
+    const Vector2D SIZEDELTA    = current.size() - previous.size();
+    const double   MAXDELTA     = std::max({std::abs(DELTA.x), std::abs(DELTA.y), std::abs(SIZEDELTA.x), std::abs(SIZEDELTA.y)});
+    const double   MAXDIMENSION = std::max({previous.w, previous.h, current.w, current.h, 1.0});
+    if (MAXDELTA > MAXDIMENSION * 1.5) {
+        resetWithDamage();
+        return;
+    }
+
+    static auto PMESH      = CConfigValue<Config::INTEGER>("decoration:wobble:mesh");
+    static auto PINTENSITY = CConfigValue<Config::FLOAT>("decoration:wobble:intensity");
+
+    damageCurrent();
+
+    m_mesh.setSize(std::clamp(sc<size_t>(*PMESH), static_cast<size_t>(2), static_cast<size_t>(32)));
+    m_mesh.onPositionUpdate(previous, current, *PINTENSITY, grabPoint);
+    if (!m_active)
+        m_lastTick = std::chrono::steady_clock::now();
+    m_active = true;
+
+    damageCurrent();
+    scheduleFrame();
+
+    ensureTickListener();
+    if (Animation::mgr())
+        Animation::mgr()->requestTick();
+}
+
+void CWobbleTransformer::reset() {
+    m_mesh.reset();
+    m_active = false;
+}
+
+void CWobbleTransformer::resetWithDamage() {
+    damageCurrent();
+    reset();
+    damageCurrent();
+    scheduleFrame();
+}
+
+bool CWobbleTransformer::tick() {
+    const auto PWINDOW = m_window.lock();
+    if (!m_active || !shouldEnable(PWINDOW)) {
+        resetWithDamage();
+        return false;
+    }
+
+    const auto NOW = std::chrono::steady_clock::now();
+    const auto DT  = NOW - m_lastTick;
+    m_lastTick     = NOW;
+
+    damageCurrent();
+    m_mesh.advance(spring(), DT);
+    damageCurrent();
+
+    static auto PVALUEEPS = CConfigValue<Config::FLOAT>("decoration:wobble:value_epsilon");
+    static auto PVELEPS   = CConfigValue<Config::FLOAT>("decoration:wobble:velocity_epsilon");
+
+    if (m_mesh.stable(*PVALUEEPS, *PVELEPS)) {
+        resetWithDamage();
+        return false;
+    }
+
+    scheduleFrame();
+
+    return true;
+}
+
+void CWobbleTransformer::damageCurrent() const {
+    const auto PWINDOW = m_window.lock();
+    if (PWINDOW)
+        g_pHyprRenderer->damageWindow(PWINDOW);
+}
+
+void CWobbleTransformer::scheduleFrame() const {
+    const auto PWINDOW = m_window.lock();
+    if (!PWINDOW)
+        return;
+
+    if (const auto PMONITOR = PWINDOW->m_monitor.lock())
+        PMONITOR->scheduleFrame(Aquamarine::IOutput::AQ_SCHEDULE_ANIMATION);
+}
+
+SSpringCurve CWobbleTransformer::spring() const {
+    static auto PSTIFFNESS = CConfigValue<Config::FLOAT>("decoration:wobble:stiffness");
+    static auto PDAMPING   = CConfigValue<Config::FLOAT>("decoration:wobble:damping");
+    static auto PMASS      = CConfigValue<Config::FLOAT>("decoration:wobble:mass");
+    static auto PVALUEEPS  = CConfigValue<Config::FLOAT>("decoration:wobble:value_epsilon");
+    static auto PVELEPS    = CConfigValue<Config::FLOAT>("decoration:wobble:velocity_epsilon");
+
+    return SSpringCurve{
+        .stiffness       = *PSTIFFNESS,
+        .damping         = *PDAMPING,
+        .mass            = *PMASS,
+        .valueEpsilon    = *PVALUEEPS,
+        .velocityEpsilon = *PVELEPS,
+    };
+}

--- a/src/render/transformer/WobbleTransformer.hpp
+++ b/src/render/transformer/WobbleTransformer.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "Transformer.hpp"
+#include "../../helpers/DeformableMesh.hpp"
+
+#include <chrono>
+#include <optional>
+#include <hyprutils/animation/AnimationManager.hpp>
+
+namespace Render {
+    class CWobbleTransformer : public IWindowTransformer {
+      public:
+        CWobbleTransformer(PHLWINDOWREF window);
+        virtual ~CWobbleTransformer() = default;
+
+        static bool                      shouldEnable(PHLWINDOW window);
+        static void                      ensureTickListener();
+
+        virtual SP<Render::IFramebuffer> transform(SP<Render::IFramebuffer> in, const SWindowTransformContext& context);
+        virtual int                      priority() const;
+        virtual bool                     active() const;
+        virtual bool                     blocksDirectScanout() const;
+        virtual CBox                     transformedExtents(const CBox& currentBox) const;
+        virtual CBox                     sourceBoxForRender(const CBox& currentBox, const CBox& monitorBox) const;
+
+        void                             record(const CBox& previous, const CBox& current, std::optional<Vector2D> grabPoint = std::nullopt);
+        void                             reset();
+        void                             resetWithDamage();
+        bool                             tick();
+
+      private:
+        Hyprutils::Animation::SSpringCurve    spring() const;
+        void                                  damageCurrent() const;
+        void                                  scheduleFrame() const;
+
+        PHLWINDOWREF                          m_window;
+        CDeformableMesh                       m_mesh;
+        std::chrono::steady_clock::time_point m_lastTick;
+        bool                                  m_active = false;
+    };
+}

--- a/src/render/types.hpp
+++ b/src/render/types.hpp
@@ -102,8 +102,9 @@ namespace Render {
         PHLWINDOWREF           currentWindow;
         WP<CWLSurfaceResource> surface;
 
-        bool                   transformDamage = true;
-        bool                   noSimplify      = false;
+        bool                   transformDamage            = true;
+        bool                   noSimplify                 = false;
+        bool                   renderingTransformedSource = false;
     };
 
     struct STFRange {

--- a/tests/helpers/DeformableMesh.cpp
+++ b/tests/helpers/DeformableMesh.cpp
@@ -1,0 +1,91 @@
+#include <helpers/DeformableMesh.hpp>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+
+TEST(Helpers, deformableMeshSetSizeClamps) {
+    CDeformableMesh mesh;
+
+    mesh.setSize(1);
+    EXPECT_EQ(mesh.size(), 2u);
+
+    mesh.setSize(64);
+    EXPECT_EQ(mesh.size(), 32u);
+}
+
+TEST(Helpers, deformableMeshNoopUpdateKeepsExtents) {
+    CDeformableMesh mesh(4);
+    CBox            box = {10, 20, 100, 50};
+
+    mesh.onPositionUpdate(box, box, 1.F);
+
+    const auto EXTENTS = mesh.transformedExtents(box);
+    EXPECT_DOUBLE_EQ(EXTENTS.x, box.x);
+    EXPECT_DOUBLE_EQ(EXTENTS.y, box.y);
+    EXPECT_DOUBLE_EQ(EXTENTS.w, box.w);
+    EXPECT_DOUBLE_EQ(EXTENTS.h, box.h);
+    EXPECT_TRUE(mesh.stable(0.F, 0.F));
+}
+
+TEST(Helpers, deformableMeshPositionUpdateExpandsExtents) {
+    CDeformableMesh mesh(4);
+
+    const CBox      PREVIOUS = {0, 0, 100, 50};
+    const CBox      CURRENT  = {10, 0, 100, 50};
+    mesh.onPositionUpdate(PREVIOUS, CURRENT, 1.F);
+
+    const auto EXTENTS = mesh.transformedExtents(CURRENT);
+    EXPECT_LT(EXTENTS.x, CURRENT.x);
+    EXPECT_GE(EXTENTS.x + EXTENTS.w, CURRENT.x + CURRENT.w);
+    EXPECT_FALSE(mesh.stable(0.F, 0.F));
+}
+
+TEST(Helpers, deformableMeshGrabPointAnchorsNearestVertices) {
+    CDeformableMesh mesh(3);
+
+    const CBox      PREVIOUS = {0, 0, 100, 100};
+    const CBox      CURRENT  = {0, 0, 100, 120};
+    mesh.onPositionUpdate(PREVIOUS, CURRENT, 1.F, Vector2D{0.5, 0.0});
+
+    const auto VERTICES = mesh.verticesForBox(CURRENT, CURRENT, {100, 120});
+
+    const auto TOPCENTER = std::ranges::find_if(VERTICES, [](const auto& v) { return v.u == 0.5F && v.v == 0.F; });
+    const auto CENTER    = std::ranges::find_if(VERTICES, [](const auto& v) { return v.u == 0.5F && v.v == 0.5F; });
+
+    ASSERT_NE(TOPCENTER, VERTICES.end());
+    ASSERT_NE(CENTER, VERTICES.end());
+    EXPECT_LT(std::abs(TOPCENTER->y - TOPCENTER->v), std::abs(CENTER->y - CENTER->v));
+}
+
+TEST(Helpers, deformableMeshPositionUpdateClampsDisplacement) {
+    CDeformableMesh mesh(4);
+
+    const CBox      PREVIOUS = {0, 0, 100, 50};
+    const CBox      CURRENT  = {1000, 1000, 100, 50};
+    mesh.onPositionUpdate(PREVIOUS, CURRENT, 2.F);
+
+    const auto EXTENTS = mesh.transformedExtents(CURRENT);
+    EXPECT_GE(EXTENTS.x, CURRENT.x - 16.001);
+    EXPECT_GE(EXTENTS.y, CURRENT.y - 16.001);
+    EXPECT_LE(EXTENTS.x + EXTENTS.w, CURRENT.x + CURRENT.w + 16.001);
+    EXPECT_LE(EXTENTS.y + EXTENTS.h, CURRENT.y + CURRENT.h + 16.001);
+}
+
+TEST(Helpers, deformableMeshVerticesForBoxBuildsTriangles) {
+    CDeformableMesh mesh(2);
+
+    const auto      VERTICES = mesh.verticesForBox({0, 0, 100, 50}, {0, 0, 100, 50}, {100, 50});
+
+    ASSERT_EQ(VERTICES.size(), 6u);
+    EXPECT_FLOAT_EQ(VERTICES.front().x, 0.F);
+    EXPECT_FLOAT_EQ(VERTICES.front().y, 0.F);
+    EXPECT_FLOAT_EQ(VERTICES.front().u, 0.F);
+    EXPECT_FLOAT_EQ(VERTICES.front().v, 0.F);
+
+    EXPECT_FLOAT_EQ(VERTICES.back().x, 1.F);
+    EXPECT_FLOAT_EQ(VERTICES.back().y, 1.F);
+    EXPECT_FLOAT_EQ(VERTICES.back().u, 1.F);
+    EXPECT_FLOAT_EQ(VERTICES.back().v, 1.F);
+}

--- a/tests/render/TransformerList.cpp
+++ b/tests/render/TransformerList.cpp
@@ -1,0 +1,62 @@
+#include <render/transformer/TransformerList.hpp>
+
+#include <gtest/gtest.h>
+
+class CTestDamageTransformer : public Render::IWindowTransformer {
+  public:
+    CTestDamageTransformer(int priority, double scale, double add, bool active = true) : m_priority(priority), m_scale(scale), m_add(add), m_active(active) {
+        ;
+    }
+
+    virtual SP<Render::IFramebuffer> transform(SP<Render::IFramebuffer> in, const Render::SWindowTransformContext& context) {
+        (void)context;
+        return in;
+    }
+
+    virtual int priority() const {
+        return m_priority;
+    }
+
+    virtual bool active() const {
+        return m_active;
+    }
+
+    virtual CBox transformBoxForDamage(const CBox& currentBox) const {
+        CBox box = currentBox;
+        box.x    = box.x * m_scale + m_add;
+        box.w *= m_scale;
+        return box;
+    }
+
+  private:
+    int    m_priority = 0;
+    double m_scale    = 1.0;
+    double m_add      = 0.0;
+    bool   m_active   = true;
+};
+
+TEST(Render, transformerListDamageBoxFollowsPriorityOrder) {
+    Render::CWindowTransformerList list;
+    list.emplace<CTestDamageTransformer>(20, 2.0, 0.0);
+    list.emplace<CTestDamageTransformer>(10, 1.0, 3.0);
+
+    const CBox BOX = {1, 2, 10, 20};
+    const auto OUT = list.transformBoxForDamage(BOX);
+
+    EXPECT_DOUBLE_EQ(OUT.x, 8.0);
+    EXPECT_DOUBLE_EQ(OUT.y, 2.0);
+    EXPECT_DOUBLE_EQ(OUT.w, 20.0);
+    EXPECT_DOUBLE_EQ(OUT.h, 20.0);
+}
+
+TEST(Render, transformerListDamageBoxSkipsInactiveTransformers) {
+    Render::CWindowTransformerList list;
+    list.emplace<CTestDamageTransformer>(10, 2.0, 0.0, false);
+    list.emplace<CTestDamageTransformer>(20, 1.0, 3.0);
+
+    const CBox BOX = {1, 2, 10, 20};
+    const auto OUT = list.transformBoxForDamage(BOX);
+
+    EXPECT_DOUBLE_EQ(OUT.x, 4.0);
+    EXPECT_DOUBLE_EQ(OUT.w, 10.0);
+}


### PR DESCRIPTION
Adds a new window transformer, and wobble framework.

This considerably builds on top of the fixed up transformers in #14911 and makes transformations more reliable overall.

Closes #14913 

Needs testing.


