### PR TITLE
renderer: skip invalidation clear on empty damage

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -750,7 +750,8 @@ void CHyprOpenGLImpl::begin(PHLMONITOR pMonitor, const CRegion& damage_, SP<IFra
 
     g_pHyprRenderer->bindFB(g_pHyprRenderer->m_renderData.pMonitor->resources()->getUnusedWorkBuffer());
     m_offloadedFramebuffer = true;
-    GLFB(g_pHyprRenderer->m_renderData.currentFB)->clearAfterInvalidation();
+    if (!g_pHyprRenderer->m_renderData.damage.empty())
+        GLFB(g_pHyprRenderer->m_renderData.currentFB)->clearAfterInvalidation();
 
     g_pHyprRenderer->m_renderData.mainFB = g_pHyprRenderer->m_renderData.currentFB;
     g_pHyprRenderer->m_renderData.outFB  = fb ? fb : dc<CHyprGLRenderer*>(g_pHyprRenderer.get())->m_currentRenderbuffer->getFB();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

I've observed some minor GPU usage when moving my mouse since v0.55.0 (~5% while mouse is moving, using hardware cursors with an Intel iGPU).

I used git bisect to track the regression to 39af3901b389f792a55176041dec9211c82ed1c9 (#14070) which added an unconditional call to `clearAfterInvalidation`.

This PR makes the clear conditional on actual render damage, preventing empty-damage frames from causing unnecessary GPU usage.