### PR TITLE
popup: fix subsurface scaling

### DIFF
--- a/src/desktop/view/Popup.cpp
+++ b/src/desktop/view/Popup.cpp
@@ -456,12 +456,21 @@ Vector2D CPopup::size() const {
 }
 
 void CPopup::sendScale() {
+    float scale;
     if (!m_windowOwner.expired())
-        g_pCompositor->setPreferredScaleForSurface(m_wlSurface->resource(), m_windowOwner->wlSurface()->m_lastScaleFloat);
+        scale = m_windowOwner->wlSurface()->m_lastScaleFloat;
     else if (!m_layerOwner.expired())
-        g_pCompositor->setPreferredScaleForSurface(m_wlSurface->resource(), m_layerOwner->wlSurface()->m_lastScaleFloat);
+        scale = m_layerOwner->wlSurface()->m_lastScaleFloat;
     else
         UNREACHABLE();
+
+    // Walk the whole surface tree, not just the popup's root surface: a popup
+    // can wrap its content in subsurfaces (e.g. Firefox/GTK render the popup
+    // content in a wp_viewport'd subsurface). Scaling only the root leaves
+    // those subsurfaces at the default 1.0 fractional scale, so under
+    // fractional scaling the content renders at the wrong size and the input
+    // geometry desyncs from the visible geometry. Mirrors CWindow::sendScale.
+    m_wlSurface->resource()->breadthfirst([scale](SP<CWLSurfaceResource> s, const Vector2D& offset, void* d) { g_pCompositor->setPreferredScaleForSurface(s, scale); }, nullptr);
 }
 
 void CPopup::bfHelper(std::vector<SP<CPopup>> const& nodes, std::function<void(SP<CPopup>, void*)> fn, void* data) {


### PR DESCRIPTION
I noticed a bug in the latest Firefox 150+ - see [Bugzilla 2035152](https://bugzilla.mozilla.org/show_bug.cgi?id=2035152) - where the pop-ups for extensions like Bitwarden and uBlock are buggy. Clicking on most buttons in the pop-up cause it to flicker and exit. The bug had already been isolated to Wayland + fractional scaling, but I unambiguously isolated it on my machine to Hyprland by looking at Firefox's trace logs and discovering that the extension subsurfaces are not receiving the fractional scaling values. Firefox does NOT cause subsurfaces to automatically inherit these from the root surface. It expects them from the compositor and defaults to 1.0 if not provided, and evidently it breaks these pop-ups to have misaligned scaling values (glitches vary by extension but they are all unusable). Running the browser with XWayland or integer scaling fixes it, but the correct fix is here in Hyprland. 

### Before (buggy)
```cpp
void CPopup::sendScale() {
    if (!m_windowOwner.expired())
        g_pCompositor->setPreferredScaleForSurface(m_wlSurface->resource(), m_windowOwner->wlSurface()->m_lastScaleFloat);
    else if (!m_layerOwner.expired())
        g_pCompositor->setPreferredScaleForSurface(m_wlSurface->resource(), m_layerOwner->wlSurface()->m_lastScaleFloat);
    else
        UNREACHABLE();
}
```
Each branch calls `setPreferredScaleForSurface(m_wlSurface->resource(), ...)`. 
`m_wlSurface->resource()` is the popup's root surface only. Child subsurfaces
never get told the scale, so they stay at the default 1.0.

### After (fixed)
```cpp
void CPopup::sendScale() {
    float scale;
    if (!m_windowOwner.expired())
        scale = m_windowOwner->wlSurface()->m_lastScaleFloat;
    else if (!m_layerOwner.expired())
        scale = m_layerOwner->wlSurface()->m_lastScaleFloat;
    else
        UNREACHABLE();

    // (comment block explaining why)
    m_wlSurface->resource()->breadthfirst([scale](SP<CWLSurfaceResource> s, const Vector2D& offset, void* d) { g_pCompositor->setPreferredScaleForSurface(s, scale); }, nullptr);
}
```
Two mechanical changes:
1. The if/else now just selects the scale value into a local `float scale`
   (instead of each branch doing the push itself).
2. One `breadthfirst(...)` call does the push for every surface in the tree.
   `breadthfirst` is Hyprland's existing surface-tree walker, same one this
   very function's caller (`onMap`, line ~208) already uses to send `enter`
   events to the whole tree. 

Proof it's an oversight:
- `CWindow::sendScale()` in `src/desktop/view/Window.cpp` (~line 466) already
  uses `m_wlSurface->resource()->breadthfirst(...)` to push scale to every
  surface. The window path recurses; the popup path didn't. 
- `CPopup::onMap()` (Popup.cpp ~line 208) calls `sendScale()` and then, on the
  very next line, does its own `breadthfirst(...)` over the same tree, but only
  to send `enter` events, not scale. The walker was right there.