### PR TITLE
Improve error handle-ability with Lua `require`

### DIFF
--- a/src/config/lua/ConfigManager.cpp
+++ b/src/config/lua/ConfigManager.cpp
@@ -122,6 +122,17 @@ static int safeLuaRequire(lua_State* L) {
         lua_pop(L, 1);
     }
 
+    // if we failed to resolve the require'd module, return that as an actual
+    // error (so the user can catch it via pcall)
+    {
+        std::string moduleErrPrefix = std::format("module '{}' not found", moduleName);
+        if (err.starts_with(moduleErrPrefix))
+            return luaL_error(L, err.c_str());
+    }
+
+    // otherwise, throw the error message into the config-errors list, and
+    // return an empty table to Lua (weird from a Lua perspective, but
+    // hopefully acceptable since the error is directly visible to the user)
     if (auto* mgr = CConfigManager::fromLuaState(L); mgr) {
         if (!moduleName.empty()) {
             trackRequiredLuaModulePath(L, mgr, moduleName);
@@ -132,7 +143,7 @@ static int safeLuaRequire(lua_State* L) {
 
     lua_pop(L, 1); // error object
 
-    lua_newtable(L); // fallback module
+    lua_newtable(L); // empty table as fallback return
     const int fallbackIdx = lua_gettop(L);
 
     if (!moduleName.empty()) {

--- a/src/config/lua/ConfigManager.cpp
+++ b/src/config/lua/ConfigManager.cpp
@@ -315,8 +315,10 @@ void CConfigManager::reinitLuaState() {
 
     lua_getglobal(m_lua, "require");
     if (lua_isfunction(m_lua, -1)) {
+        lua_pushvalue(m_lua, -1);
+        lua_setglobal(m_lua, "__require"); // original `require` as `__require`
         lua_pushcclosure(m_lua, safeLuaRequire, 1);
-        lua_setglobal(m_lua, "require");
+        lua_setglobal(m_lua, "require"); // safe require as `require`
     } else
         lua_pop(m_lua, 1);
 


### PR DESCRIPTION
Normally, `require` uses Lua's pcall facility to catch any errors, increasing reliability if the user splits their config into modules. Any errors from within those modules are sent to the config manager for eventual display in the config-errors bar.

However, this use of pcall also catches the error case where the user tries to require a nonexistent module. This forcibly displays a message to the user, while also making it impossible to catch or detect such errors from within Lua itself (i.e. `pcall(require, "nonexistent")` always indicates success).

This PR makes `require` throw a proper error if module resolution fails, while still hiding (and adding to the config-errors list) any other errors that occur from *inside* the `require`d module.

Would love feedback on a few details I'm not sure about:
- Currently, I detect module-resolution errors (as opposed to execution-time errors *within* the `require`'d module) just via string comparison, which feels kind of wrong. However, I don't think Lua gives us enough information to do this any other way — even the C return value from `lua_pcall()` is identical between the "nonexistent module" and "erroring module" cases (it's `LUA_ERRRUN`, specifically).
- Nested `require`s produce somewhat strange-looking error messages. I *thiiiink* this is probably okay, since it should still be clear where the error came from, but maybe we want to clean this up somehow?

Fixes #14534

---

Edit: This PR also makes Lua's original `require` available as `__require`, in case advanced users want to bypass Hyprland's error catching completely.