### PR TITLE
window: Refactor isInputBlocked funcs; compositor: Allow to request focusing windows behind fullscreen

### DIFF
--- a/hyprtester/src/main.cpp
+++ b/hyprtester/src/main.cpp
@@ -137,7 +137,7 @@ static SSettings parseSettings(const std::span<const char*> args) {
             settings.requestedTests.emplace_back(value);
         } else {
             std::println(stderr, "[ ERROR ] Unknown option '{}' !", *it);
-            helpAndDie(EXIT_SUCCESS);
+            helpAndDie(EXIT_FAILURE);
         }
     }
 

--- a/hyprtester/src/tests/main/window.cpp
+++ b/hyprtester/src/tests/main/window.cpp
@@ -300,6 +300,50 @@ TEST_CASE(windowFocusOnFullscreenConflict) {
     }
 }
 
+TEST_CASE(focusFloatingOrTilingUnderFullscreen) {
+    OK(getFromSocket("/eval hl.config({ misc = { focus_on_activate = true } })"));
+    OK(getFromSocket("/eval hl.config({ misc = { on_focus_under_fullscreen = 2 } })"));
+
+    ASSERT(!!Tests::spawnKitty("kitty_a"), true);
+    ASSERT(!!Tests::spawnKitty("kitty_b"), true);
+
+    ASSERT(isActiveWindow("kitty_b", '0'), true);
+    OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'set' })"));
+
+    // Test 1: focus floating from fullscreen tiled
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:kitty_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'fullscreen', action = 'set' })"));
+    ASSERT(isActiveWindow("kitty_a", '2'), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'floating' })"));
+    std::string active = getFromSocket("/activewindow");
+    EXPECT_CONTAINS(Tests::getAttribute(active, "class"), "kitty_b");
+    std::string kitty_a = getFromSocket("/clients");
+    // Assuming clients appear in the same order that they connected in
+    kitty_a = kitty_a.substr(0, kitty_a.size() - active.size());
+    ASSERT_COUNT_STRING(kitty_a, "class:", 1); // Check that the cut is right
+    EXPECT(Tests::getAttribute(kitty_a, "class") == "kitty_a", true);
+    // Remains fullscreen, since we just focused a floating window over it
+    EXPECT(Tests::getAttribute(kitty_a, "fullscreen") == "2", true);
+    EXPECT(Tests::getAttribute(kitty_a, "fullscreenClient") == "2", true);
+
+    // Test 2: focus tiled from fullscreen floating
+
+    OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'fullscreen', action = 'set' })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'tiled' })"));
+    active = getFromSocket("/activewindow");
+    EXPECT_CONTAINS(Tests::getAttribute(active, "class"), "kitty_a");
+    std::string kitty_b = getFromSocket("/clients");
+    // Assuming clients appear in the same order that they connected in
+    kitty_b = kitty_b.substr(active.size());
+    ASSERT_COUNT_STRING(kitty_b, "class:", 1); // Check that the cut is right
+    EXPECT(Tests::getAttribute(kitty_b, "class") == "kitty_b", true);
+    // Exited fullscreen, since we switched focus to a window under it
+    EXPECT(Tests::getAttribute(kitty_b, "fullscreen") == "0", true);
+    EXPECT(Tests::getAttribute(kitty_b, "fullscreen") == "0", true);
+}
+
 TEST_CASE(windowMaximizeSize) {
     SPAWN_KITTY("kitty_A");
 

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -453,8 +453,8 @@ int CWorkspace::getWindowCount(std::optional<bool> onlyTiled, std::optional<bool
         if (!t)
             continue;
 
-        const auto visibilityFulfilled =
-            t->window() && !t->window()->isHidden() && !t->window()->isInputBlocked(INPUT_BLOCK_GROUP_INACTIVE | INPUT_BLOCK_MONOCLE_INACTIVE | INPUT_BLOCK_BELOW_FULLSCREEN);
+        const auto visibilityFulfilled = t->window() && !t->window()->isHidden() &&
+            !t->window()->isInputBlockedReasonAnyOf(INPUT_BLOCK_GROUP_INACTIVE | INPUT_BLOCK_MONOCLE_INACTIVE | INPUT_BLOCK_BELOW_FULLSCREEN);
 
         if (onlyTiled.has_value() && t->floating() == onlyTiled.value())
             continue;
@@ -473,8 +473,8 @@ int CWorkspace::getGroups(std::optional<bool> onlyTiled, std::optional<bool> onl
     for (auto const& g : Desktop::View::groups()) {
         const auto HEAD = g->head();
 
-        const auto visibilityFulfilled =
-            g->current() && !g->current()->isHidden() && !g->current()->isInputBlocked(INPUT_BLOCK_GROUP_INACTIVE | INPUT_BLOCK_MONOCLE_INACTIVE | INPUT_BLOCK_BELOW_FULLSCREEN);
+        const auto visibilityFulfilled = g->current() && !g->current()->isHidden() &&
+            !g->current()->isInputBlockedReasonAnyOf(INPUT_BLOCK_GROUP_INACTIVE | INPUT_BLOCK_MONOCLE_INACTIVE | INPUT_BLOCK_BELOW_FULLSCREEN);
 
         if (HEAD->workspaceID() != m_id || !HEAD->m_isMapped)
             continue;

--- a/src/desktop/state/ViewQuery.cpp
+++ b/src/desktop/state/ViewQuery.cpp
@@ -106,7 +106,8 @@ PHLWINDOW CViewQuery::bySelector() const {
         const bool FLOAT = regexp.starts_with("floating");
 
         for (auto const& w : m_tracker.windows()) {
-            if (!w->m_isMapped || w->m_isFloating != FLOAT || w->m_workspace != focusState()->window()->m_workspace || !w->acceptsInput())
+            if (!w->m_isMapped || w->m_isFloating != FLOAT || w->m_workspace != focusState()->window()->m_workspace ||
+                w->hasInputBlockedReasonsBesides(Desktop::View::INPUT_BLOCK_BELOW_FULLSCREEN))
                 continue;
 
             return w;

--- a/src/desktop/state/WindowQuery.cpp
+++ b/src/desktop/state/WindowQuery.cpp
@@ -101,8 +101,7 @@ PHLWINDOW CWindowQuery::inDirection(const SWindowDirectionQuery& query) const {
                 if (w->isHidden())
                     continue;
 
-                // check if the input is blocked by anything except BELOW_FULLSCREEN
-                if (w->isInputBlocked(INPUT_BLOCK_ALL & (~INPUT_BLOCK_BELOW_FULLSCREEN)))
+                if (w->hasInputBlockedReasonsBesides(INPUT_BLOCK_BELOW_FULLSCREEN))
                     continue;
 
                 if (query.workspace->m_monitor == w->m_monitor && query.workspace != w->m_workspace)
@@ -257,7 +256,7 @@ static bool acceptsInputForCycle(WINDOWPTR w, bool allowFullscreenBlocked) {
     if (w->acceptsInput())
         return true;
 
-    return allowFullscreenBlocked && !w->isHidden() && w->isInputBlockedOnly(INPUT_BLOCK_BELOW_FULLSCREEN);
+    return allowFullscreenBlocked && !w->isHidden() && w->noInputBlockedReasonsBesides(INPUT_BLOCK_BELOW_FULLSCREEN);
 }
 
 template <typename WINDOWPTR>

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -918,12 +918,16 @@ bool CWindow::isInputBlocked() const {
     return m_inputBlockReasons != INPUT_BLOCK_NONE;
 }
 
-bool CWindow::isInputBlocked(std::underlying_type_t<eWindowInputBlockReason> reasons) const {
+bool CWindow::isInputBlockedReasonAnyOf(std::underlying_type_t<eWindowInputBlockReason> reasons) const {
     return (m_inputBlockReasons & reasons) != 0;
 }
 
-bool CWindow::isInputBlockedOnly(eWindowInputBlockReason reason) const {
-    return m_inputBlockReasons == reason;
+bool CWindow::noInputBlockedReasonsBesides(std::underlying_type_t<eWindowInputBlockReason> reason) const {
+    return (m_inputBlockReasons & ~reason) == 0;
+}
+
+bool CWindow::hasInputBlockedReasonsBesides(std::underlying_type_t<eWindowInputBlockReason> reason) const {
+    return (m_inputBlockReasons & ~reason) != 0;
 }
 
 bool CWindow::acceptsInput() const {

--- a/src/desktop/view/Window.hpp
+++ b/src/desktop/view/Window.hpp
@@ -295,31 +295,53 @@ namespace Desktop::View {
         bool operator==(const CWindow& rhs) const;
 
         // methods
-        CBox                              getFullWindowBoundingBox() const;
-        CBox                              layoutBox() const;
-        SBoxExtents                       getFullWindowExtents() const;
-        CBox                              getWindowBoxUnified(uint64_t props);
-        SBoxExtents                       getWindowExtentsUnified(uint64_t props);
-        CBox                              getWindowIdealBoundingBoxIgnoreReserved();
-        void                              addWindowDeco(UP<IHyprWindowDecoration> deco);
-        void                              updateWindowDecos();
-        void                              removeWindowDeco(IHyprWindowDecoration* deco);
-        void                              uncacheWindowDecos();
-        bool                              checkInputOnDecos(const eInputType, const Vector2D&, std::any = {});
-        pid_t                             getPID();
-        IHyprWindowDecoration*            getDecorationByType(eDecorationType);
-        void                              updateToplevel();
-        void                              updateSurfaceScaleTransformDetails(bool force = false);
-        void                              moveToWorkspace(PHLWORKSPACE);
-        PHLWINDOW                         x11Parent() const;
-        void                              onUnmap();
-        void                              onMap();
-        void                              setHidden(bool hidden);
-        bool                              isHidden() const;
-        void                              setInputBlocked(eWindowInputBlockReason reason, bool blocked);
-        bool                              isInputBlocked() const;
-        bool                              isInputBlocked(std::underlying_type_t<eWindowInputBlockReason> reasons) const;
-        bool                              isInputBlockedOnly(eWindowInputBlockReason reason) const;
+        CBox                   getFullWindowBoundingBox() const;
+        CBox                   layoutBox() const;
+        SBoxExtents            getFullWindowExtents() const;
+        CBox                   getWindowBoxUnified(uint64_t props);
+        SBoxExtents            getWindowExtentsUnified(uint64_t props);
+        CBox                   getWindowIdealBoundingBoxIgnoreReserved();
+        void                   addWindowDeco(UP<IHyprWindowDecoration> deco);
+        void                   updateWindowDecos();
+        void                   removeWindowDeco(IHyprWindowDecoration* deco);
+        void                   uncacheWindowDecos();
+        bool                   checkInputOnDecos(const eInputType, const Vector2D&, std::any = {});
+        pid_t                  getPID();
+        IHyprWindowDecoration* getDecorationByType(eDecorationType);
+        void                   updateToplevel();
+        void                   updateSurfaceScaleTransformDetails(bool force = false);
+        void                   moveToWorkspace(PHLWORKSPACE);
+        PHLWINDOW              x11Parent() const;
+        void                   onUnmap();
+        void                   onMap();
+        void                   setHidden(bool hidden);
+        bool                   isHidden() const;
+        void                   setInputBlocked(eWindowInputBlockReason reason, bool blocked);
+        /// Returns `true` if the input is blocked for this window for any reason.
+        bool isInputBlocked() const;
+        /// Returns `true` if any of the provided `reasons` is one of the reasons why input is blocked for this window.
+        bool isInputBlockedReasonAnyOf(std::underlying_type_t<eWindowInputBlockReason> reasons) const;
+        /**
+         * Returns `true` if all the reasons why input is blocked for this window are contained in the provided `reason`, i.e.,
+         * `reason` is the superset of reasons why input is blocked for this window.
+         *
+         * Note that the return value of `true` does not necessarily mean that input is blocked for all of the provided `reason`s,
+         * or that input is blocked at all! If input is not blocked, the function returns `true` regardless of the argument value.
+         *
+         * This function is a negation of `hasInputBlockedReasonsBesides`. They exist together for the sake of readability:
+         * when either of them is negated in a condition, the condition becomes hard to grasp.
+         */
+        bool noInputBlockedReasonsBesides(std::underlying_type_t<eWindowInputBlockReason> reason) const;
+        /**
+         * Returns `true` if there is a reason why input is blocked for this window that is not contained in the provided `reason`.
+         *
+         * Note that the return value of `false` does not mean that all the listed reasons are effective, or that the input is
+         * blocked at all! If input is not blocked, the function returns `false` regardless of the argument value.
+         *
+         * This function is a negation of `noInputBlockedReasonsBesides`. They exist together for the sake of readability:
+         * when either of them is negated in a condition, the condition becomes hard to grasp.
+         */
+        bool                              hasInputBlockedReasonsBesides(std::underlying_type_t<eWindowInputBlockReason> reason) const;
         bool                              acceptsInput() const;
         bool                              isAllowedOverFullscreen() const;
         bool                              isBlockedByFullscreen() const;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes requests to focus a tiling/floating window when the active window is fullscreen.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Ready
