### PR TITLE
pointerwarp: allow warp on layer surfaces

### DIFF
--- a/src/protocols/PointerWarp.cpp
+++ b/src/protocols/PointerWarp.cpp
@@ -5,6 +5,9 @@
 #include "../managers/SeatManager.hpp"
 #include "../managers/PointerManager.hpp"
 #include "../desktop/view/Window.hpp"
+#include "desktop/view/LayerSurface.hpp"
+#include <hyprutils/math/Box.hpp>
+#include <hyprutils/math/Vector2D.hpp>
 
 CPointerWarpProtocol::CPointerWarpProtocol(const wl_interface* iface, const int& ver, const std::string& name) : IWaylandProtocol(iface, ver, name) {
     ;
@@ -27,14 +30,30 @@ void CPointerWarpProtocol::bindManager(wl_client* client, void* data, uint32_t v
         if (g_pSeatManager->m_state.pointerFocus != PSURFACE)
             return;
 
-        auto WINDOW = Desktop::View::CWindow::fromView(Desktop::View::CWLSurface::fromResource(PSURFACE)->view());
-        if (!WINDOW)
-            return;
+        CBox surfbox;
 
-        const auto SURFBOX   = WINDOW->getWindowMainSurfaceBox().expand(1);
-        const auto LOCALPOS  = Vector2D{wl_fixed_to_double(x), wl_fixed_to_double(y)};
-        const auto GLOBALPOS = LOCALPOS + SURFBOX.pos();
-        if (!SURFBOX.containsPoint(GLOBALPOS))
+        auto VIEW   = Desktop::View::CWLSurface::fromResource(PSURFACE)->view();
+        auto WINDOW = Desktop::View::CWindow::fromView(VIEW);
+        if (WINDOW)
+            surfbox = WINDOW->getWindowMainSurfaceBox();
+        else {
+            auto LAYERSURFACE = Desktop::View::CLayerSurface::fromView(VIEW);
+            if (!LAYERSURFACE)
+                return;
+
+            auto BOX = LAYERSURFACE->logicalBox();
+            if (!BOX.has_value())
+                return;
+
+            surfbox = BOX.value();
+        }
+
+        const auto LOCALPOS = Vector2D{wl_fixed_to_double(x), wl_fixed_to_double(y)};
+
+        // Allow a margin of 1px on all sides
+        surfbox.expand(1);
+        const auto GLOBALPOS = LOCALPOS + surfbox.pos() + Vector2D{1., 1.};
+        if (!surfbox.containsPoint(GLOBALPOS))
             return;
 
         const auto PSEAT = CWLPointerResource::fromResource(pointer)->m_owner.lock();


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
Allows pointer warp on layer surfaces, not just windows.

Fixes the 1px margin to be +-1px rather than +2px.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
The existing code doesn't take subsurfaces into account.

#### Is it ready for merging, or does it need work?
Ready.