### PR TITLE
gestures/scrolling: add move_natural to invert scroll_move direction

### DIFF
--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -410,6 +410,7 @@ std::vector<SP<IValue>> Values::getConfigValues() {
         MS<Int>("gestures:close_max_timeout", "Timeout for closing windows with the close gesture, in ms.", 1000, {.min = 10, .max = 2000}),
         MS<Bool>("gestures:scrolling:move_snap_to_grid", "When releasing the scroll move gesture, whether it shoud try to snap to the grid.", true),
         MS<Bool>("gestures:scrolling:move_snap_cursor", "When releasing the scroll move gesture, whether it shoud snap the cursor to the newly focused window.", true),
+        MS<Bool>("gestures:scrolling:move_natural", "When enabled, inverts the scroll move gesture direction so the content tracks the fingers (natural scrolling).", false),
         /*
          * group:
          */

--- a/src/managers/input/trackpad/gestures/ScrollMoveGesture.cpp
+++ b/src/managers/input/trackpad/gestures/ScrollMoveGesture.cpp
@@ -70,7 +70,9 @@ void CScrollMoveTrackpadGesture::update(const ITrackpadGesture::STrackpadGesture
     if (!SCROLLING)
         return;
 
-    const float  DELTA   = deltaForUpdate(e);
+    static auto  PNATURAL = CConfigValue<Config::BOOL>("gestures:scrolling:move_natural");
+
+    const float  DELTA   = deltaForUpdate(e) * (*PNATURAL ? -1.F : 1.F);
     const double PRIMARY = SCROLLING->primaryViewportSize();
 
     if (DELTA == 0.F || PRIMARY <= 0.0)


### PR DESCRIPTION
Adds a new boolean option gestures:scrolling:move_natural (default false) that inverts the scroll_move trackpad gesture so the tape/content tracks the fingers, matching natural-scrolling behavior found elsewhere.

I tried using negative scale but did not work on my laptop.

<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

It fixes the following problem: https://github.com/hyprwm/Hyprland/discussions/14723

 No automated test added. The hyprtester gesture simulator only sends modifier-less swipes, and every
unmodified finger-count/axis combination in the shared test.lua is already bound to non-scroll actions
 that the existing gestures test depends on.


