### PR TITLE
focus: don't skip window refocus when surface focus is cleared

### DIFF
--- a/hyprtester/plugin/src/main.cpp
+++ b/hyprtester/plugin/src/main.cpp
@@ -415,6 +415,11 @@ static SDispatchResult nullfocus(std::string in) {
     return {};
 }
 
+static SDispatchResult clearSurfaceFocus(std::string in) {
+    Desktop::focusState()->rawSurfaceFocus(nullptr);
+    return {};
+}
+
 static Desktop::Rule::CWindowRuleEffectContainer::storageType windowRuleIDX = 0;
 
 //
@@ -496,6 +501,23 @@ static SDispatchResult checkPointerFocusLayer(std::string in) {
 
     if (LAYER->m_namespace != in)
         return {.success = false, .error = std::format("Pointer focus layer namespace is '{}', expected '{}'", LAYER->m_namespace, in)};
+
+    return {};
+}
+
+static SDispatchResult checkKeyboardFocusWindow(std::string in) {
+    const auto KEYBOARDSURF = g_pSeatManager->m_state.keyboardFocus.lock();
+
+    if (!KEYBOARDSURF)
+        return {.success = false, .error = "No keyboard focus"};
+
+    const auto WINDOW = g_pCompositor->getWindowFromSurface(KEYBOARDSURF);
+
+    if (!WINDOW)
+        return {.success = false, .error = "Keyboard focus is not a window surface"};
+
+    if (WINDOW->m_class != in)
+        return {.success = false, .error = std::format("Keyboard focus window class is '{}', expected '{}'", WINDOW->m_class, in)};
 
     return {};
 }
@@ -642,6 +664,10 @@ static int luaNullfocus(lua_State* L) {
     return luaResult(L, ::nullfocus(""));
 }
 
+static int luaClearSurfaceFocus(lua_State* L) {
+    return luaResult(L, ::clearSurfaceFocus(""));
+}
+
 static int luaAddWindowRule(lua_State* L) {
     return luaResult(L, ::addWindowRule(""));
 }
@@ -660,6 +686,10 @@ static int luaCheckLayerRule(lua_State* L) {
 
 static int luaCheckPointerFocusLayer(lua_State* L) {
     return luaResult(L, ::checkPointerFocusLayer(luaL_checkstring(L, 1)));
+}
+
+static int luaCheckKeyboardFocusWindow(lua_State* L) {
+    return luaResult(L, ::checkKeyboardFocusWindow(luaL_checkstring(L, 1)));
 }
 
 static int luaSetPointerFocusLayer(lua_State* L) {
@@ -696,11 +726,13 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
     addLuaFn("keybind2", ::luaKeybind2);
     addLuaFn("set_mods", ::luaSetMods);
     addLuaFn("nullfocus", ::luaNullfocus);
+    addLuaFn("clear_surface_focus", ::luaClearSurfaceFocus);
     addLuaFn("add_window_rule", ::luaAddWindowRule);
     addLuaFn("check_window_rule", ::luaCheckWindowRule);
     addLuaFn("add_layer_rule", ::luaAddLayerRule);
     addLuaFn("check_layer_rule", ::luaCheckLayerRule);
     addLuaFn("check_pointer_focus_layer", ::luaCheckPointerFocusLayer);
+    addLuaFn("check_keyboard_focus_window", ::luaCheckKeyboardFocusWindow);
     addLuaFn("set_pointer_focus_layer", ::luaSetPointerFocusLayer);
     addLuaFn("window_soft_focus", ::luaSoftFocusWindowByClass);
     addLuaFn("floating_focus_on_fullscreen", ::luaFloatingFocusOnFullscreen);

--- a/hyprtester/src/tests/main/layer.cpp
+++ b/hyprtester/src/tests/main/layer.cpp
@@ -58,3 +58,18 @@ TEST_CASE(layerPointerFocusPreservedOnKeyboardRefocus) {
     ASSERT_CONTAINS(getFromSocket("/activewindow"), "class: pointer_focus_ws2\n");
     OK(getFromSocket(std::format("/eval hl.plugin.test.check_pointer_focus_layer('{}')", LAYER_NAMESPACE)));
 }
+
+TEST_CASE(windowRefocusRestoresKeyboardFocusAfterSurfaceFocusCleared) {
+    static constexpr const char* WINDOW_CLASS = "keyboard_refocus_target";
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = '1' })"));
+    ASSERT(!!Tests::spawnKitty(WINDOW_CLASS), true);
+    OK(getFromSocket(std::format("/dispatch hl.dsp.focus({{ window = 'class:{}' }})", WINDOW_CLASS)));
+    ASSERT_CONTAINS(getFromSocket("/activewindow"), std::format("class: {}\n", WINDOW_CLASS));
+    OK(getFromSocket(std::format("/eval hl.plugin.test.check_keyboard_focus_window('{}')", WINDOW_CLASS)));
+
+    OK(getFromSocket("/eval hl.plugin.test.clear_surface_focus()"));
+    OK(getFromSocket(std::format("/eval hl.plugin.test.window_soft_focus('{}')", WINDOW_CLASS)));
+
+    OK(getFromSocket(std::format("/eval hl.plugin.test.check_keyboard_focus_window('{}')", WINDOW_CLASS)));
+}

--- a/src/desktop/state/FocusState.cpp
+++ b/src/desktop/state/FocusState.cpp
@@ -95,9 +95,6 @@ void CFocusState::rawWindowFocus(PHLWINDOW pWindow, eFocusReason reason, SP<CWLS
     static auto PFOLLOWMOUSE        = CConfigValue<Config::INTEGER>("input:follow_mouse");
     static auto PSPECIALFALLTHROUGH = CConfigValue<Config::INTEGER>("input:special_fallthrough");
 
-    if (pWindow == m_focusWindow && surface == m_focusSurface)
-        return;
-
     if (!pWindow || !pWindow->priorityFocus()) {
         if (g_pSessionLockManager->isSessionLocked()) {
             Log::logger->log(Log::DEBUG, "Refusing a keyboard focus to a window because of a sessionlock");


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

This pr is inspired by #14853 and should fix the same things:
> Keyboard wont refocus when cursor crosses layer-shell panels with follow_mouse != 1.
it fixes https://github.com/hyprwm/Hyprland/discussions/14285, https://github.com/hyprwm/Hyprland/discussions/14730
and i can reproduce using DankMaterialShell when bar pop up opened then closed, the keyboard wont refocus

But I implement the fix in a different way. I try to remove the breaking codes instead of writing new fixing code. More specifically, this pr removes the same-window/same-surface early return added in #14190 from `rawWindowFocus()`.

The guard conflates `surface == nullptr` as an optional argument meaning "use the window's main surface" with `m_focusSurface == nullptr` meaning "no focused surface". As a result, a window refocus can return before restoring seat keyboard focus.

I also add a new test to cover this scene. It basically simulates the following steps:
1. Focus a normal window.
2. Clear surface focus while leaving `m_focusWindow` intact, e.g. layer-shell/unmap path.
3. Soft-focus the same window again.
4. `rawWindowFocus()` returns early and seat keyboard focus remains null.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I use AI to fix, mainly for writing tests. This pr passed all the ci tests. However, this may break the fix in #14190.

#### Is it ready for merging, or does it need work?

It needs work. #14190 also fixed/mitigated scrolling fullscreen focus/cursor-lock issues, so I’d like confirmation that this guard was not required for that behavior.