### PR TITLE
renderer/gl: release failed fence syncs

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -2676,7 +2676,12 @@ UP<CEGLSync> CEGLSync::create() {
 
     int fd = g_pHyprOpenGL->m_proc.eglDupNativeFenceFDANDROID(g_pHyprOpenGL->m_eglDisplay, sync);
     if UNLIKELY (fd == EGL_NO_NATIVE_FENCE_FD_ANDROID) {
-        Log::logger->log(Log::ERR, "eglDupNativeFenceFDANDROID failed");
+        const auto ERR = eglGetError();
+        Log::logger->log(Log::ERR, "eglDupNativeFenceFDANDROID failed: 0x{:x}", sc<int>(ERR));
+
+        if (g_pHyprOpenGL->m_proc.eglDestroySyncKHR(g_pHyprOpenGL->m_eglDisplay, sync) != EGL_TRUE)
+            Log::logger->log(Log::ERR, "eglDestroySyncKHR failed after eglDupNativeFenceFDANDROID failure");
+
         return nullptr;
     }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

A Framework Desktop crash on Hyprland 0.55.2 ended in the renderer begin path after Aquamarine reported EGL_BAD_PARAMETER from eglDupNativeFenceFDANDROID. Fix the failed export path because it creates an EGLSyncKHR before trying to export a native fence fd.

ERR from aquamarine ]: [EGL] Command eglDupNativeFenceFDANDROID errored out with EGL_BAD_PARAMETER (0x12300): eglDupNativeFenceFDANDROID

The coredump stack was:

                Stack trace of thread 5829:
                #0  0x00007fafef025808 abort (libc.so.6 + 0x25808)
                #1  0x0000561bbd621ee4 n/a (Hyprland + 0x3bbee4)
                #2  0x00007fafef044e30 n/a (libc.so.6 + 0x44e30)
                #3  0x00007fafef0ae9cb pthread_kill (libc.so.6 + 0xae9cb)
                #4  0x00007fafef044d08 raise (libc.so.6 + 0x44d08)
                #5  0x0000561bbdc2defa _ZN6Render2GL15CHyprOpenGLImpl5beginEN9Hyprutils6Memory14CSharedPointerI8CMonitorEERKNS2_4Math7CRegionENS4_INS_12IFramebufferEEESt8optionalIS8_E (Hyprland + 0x9c7efa)
                #6  0x0000561bbdc17ea1 _ZN6Render2GL15CHyprGLRenderer19beginRenderInternalEN9Hyprutils6Memory14CSharedPointerI8CMonitorEERNS2_4Math7CRegionEb (Hyprland + 0x9b1ea1)
                #7  0x0000561bbdc7b2f2 _ZN6Render13IHyprRenderer11beginRenderEN9Hyprutils6Memory14CSharedPointerI8CMonitorEERNS1_4Math7CRegionENS_11eRenderModeENS3_I9IHLBufferEENS3_INS_12IFramebufferEEEb (Hyprland + 0xa152f2)
                #8  0x0000561bbdc81579 _ZN6Render13IHyprRenderer13renderMonitorEN9Hyprutils6Memory14CSharedPointerI8CMonitorEEb (Hyprland + 0xa1b579)
                #9  0x0000561bbd84fc7c _ZN22CMonitorFrameScheduler7onFrameEv (Hyprland + 0x5e9c7c)
                #10 0x00007faff0dcb0f9 _ZN9Hyprutils6Signal15CSignalListener12emitInternalEPv (libhyprutils.so.12 + 0x450f9)
                #11 0x00007faff0dcb583 _ZN9Hyprutils6Signal11CSignalBase12emitInternalEPv (libhyprutils.so.12 + 0x45583)
                #12 0x00007faff0eac382 _ZN10Aquamarine8CBackend12dispatchIdleEv (libaquamarine.so.11 + 0x83382)
                #13 0x0000561bbd985c9a n/a (Hyprland + 0x71fc9a)
                #14 0x00007faff0c6ea62 wl_event_loop_dispatch (libwayland-server.so.0 + 0xaa62)
                #15 0x00007faff0c70d07 wl_display_run (libwayland-server.so.0 + 0xcd07)
                #16 0x0000561bbd9892a0 _ZN17CEventLoopManager9enterLoopEv (Hyprland + 0x7232a0)
                #17 0x0000561bbd4dad64 main (Hyprland + 0x274d64)
                #18 0x00007fafef027c4e n/a (libc.so.6 + 0x27c4e)
                #19 0x00007fafef027d8b __libc_start_main (libc.so.6 + 0x27d8b)
                #20 0x0000561bbd60be45 _start (Hyprland + 0x3a5e45)

Destroy the sync object before returning, so repeated failures do not leak EGL sync resources under an already resource-constrained GPU path. Also, log the EGL error value so future reports can distinguish this path from other export failures.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?


