### PR TITLE
Hide C++ symbols by default in hyprpm

### DIFF
--- a/hyprpm/CMakeLists.txt
+++ b/hyprpm/CMakeLists.txt
@@ -27,6 +27,7 @@ if (NOT glaze_FOUND)
 endif()
 
 add_executable(hyprpm ${SRCFILES})
+set_target_properties(hyprpm PROPERTIES CXX_VISIBILITY_PRESET hidden)
 
 target_link_libraries(hyprpm PUBLIC PkgConfig::hyprpm_deps glaze::glaze)
 


### PR DESCRIPTION
Reduces hyprpm binary file size: `600KB` -> `576KB`