### PR TITLE
algo/master: respect center_master_fallback when resizing slave cols

### DIFF
--- a/hyprtester/src/tests/main/master.cpp
+++ b/hyprtester/src/tests/main/master.cpp
@@ -2,6 +2,9 @@
 #include "../../shared.hpp"
 #include "../../hyprctlCompat.hpp"
 #include <algorithm>
+#include <cmath>
+#include <string>
+#include <utility>
 #include <vector>
 #include <thread>
 #include "tests.hpp"
@@ -242,4 +245,88 @@ TEST_CASE(focusMasterClose) {
     while (Tests::processAlive(pids[2]))
         std::this_thread::sleep_for(std::chrono::milliseconds(25l));
     ASSERT_CONTAINS(getFromSocket("/activewindow"), "class: master");
+}
+
+TEST_CASE(centerMasterColumnResize) {
+    // Center master, odd slave count. The fallback-side column holds the extra slave;
+    // resizeTarget() used to assume it went right, so with the default 'left' fallback the two left
+    // windows of a 1-master/3-slave layout silently refused to resize vertically.
+
+    // focus a window by class and read its {left edge x, height} from /activewindow
+    auto geomOf = [&](const std::string& cls) -> std::pair<double, double> {
+        getFromSocket("/dispatch hl.dsp.focus({ window = 'class:" + cls + "' })");
+        const auto STR = getFromSocket("/activewindow");
+        const auto AT  = Tests::getAttribute(STR, "at");   // "x,y"
+        const auto SZ  = Tests::getAttribute(STR, "size"); // "w,h"
+        return {std::stod(AT.substr(0, AT.find(','))), std::stod(SZ.substr(SZ.find(',') + 1))};
+    };
+    auto leftOf   = [&](const std::string& cls) { return geomOf(cls).first; };
+    auto heightOf = [&](const std::string& cls) { return geomOf(cls).second; };
+
+    // resizeactive-style relative resize of a specific window along y
+    auto resizeY = [&](const std::string& cls, int dy) {
+        return getFromSocket("/dispatch hl.dsp.window.resize({ x = 0, y = " + std::to_string(dy) + ", relative = true, window = 'class:" + cls + "' })");
+    };
+
+    // `top` and `bottom` share one column and must resize vertically (one grows, the other shrinks,
+    // total column height preserved); `single` lives in the other column and must stay untouched.
+    auto expectColumnResizes = [&](const std::string& top, const std::string& bottom, const std::string& single) {
+        const double TX = leftOf(top), BX = leftOf(bottom), SX = leftOf(single);
+        ASSERT_MAX_DELTA(BX, TX, 1);           // top & bottom share a column (same left edge)
+        ASSERT(std::abs(SX - TX) > 100, true); // single sits in the other column
+
+        const double T0 = heightOf(top), B0 = heightOf(bottom), S0 = heightOf(single);
+
+        OK(resizeY(top, 80)); // grow the upper window of the pair
+
+        const double T1 = heightOf(top), B1 = heightOf(bottom), S1 = heightOf(single);
+        EXPECT(T1 > T0, true);                 // upper window grew
+        EXPECT(B1 < B0, true);                 // lower window shrank to compensate
+        EXPECT_MAX_DELTA(T1 + B1, T0 + B0, 4); // column height preserved
+        EXPECT_MAX_DELTA(S1, S0, 2);           // the other column is untouched
+
+        OK(resizeY(top, -80)); // restore the split for later phases
+    };
+
+    // 1 master + 3 slaves => slaves slave1, slave2, slave3 in stack order (new_status = master)
+    OK(getFromSocket(
+        "r/eval hl.config({ general = { layout = 'master' }, master = { orientation = 'center', center_master_fallback = 'left', slave_count_for_center_master = 2 } })"));
+    for (auto const& win : {"slave1", "slave2", "slave3", "master"}) {
+        if (!Tests::spawnKitty(win))
+            FAIL_TEST("Could not spawn kitty with win class `{}`", win);
+    }
+
+    // default `left` fallback: slave1 (top) + slave3 (bottom) on the left, slave2 alone on the right
+    NLog::log("{}center master, left fallback, 3 slaves: left column must resize (smart_resizing on)", Colors::YELLOW);
+    expectColumnResizes("slave1", "slave3", "slave2");
+
+    NLog::log("{}center master, left fallback, 3 slaves: left column must resize (smart_resizing off)", Colors::YELLOW);
+    OK(getFromSocket("r/eval hl.config({ master = { smart_resizing = false } })"));
+    expectColumnResizes("slave1", "slave3", "slave2");
+    OK(getFromSocket("r/eval hl.config({ master = { smart_resizing = true } })"));
+
+    // symmetry: `right` fallback puts the pair (slave1, slave3) on the right, slave2 alone on the left
+    NLog::log("{}center master, right fallback, 3 slaves: right column must resize", Colors::YELLOW);
+    OK(getFromSocket("r/eval hl.config({ master = { center_master_fallback = 'right' } })"));
+    expectColumnResizes("slave1", "slave3", "slave2");
+
+    // even count, no regression: a 4th slave makes 2 left / 2 right; the left pair still resizes.
+    // new_status = master => `extra` becomes the master and `master` drops to the 4th slave.
+    NLog::log("{}center master, left fallback, 4 slaves: columns still resize (no regression)", Colors::YELLOW);
+    OK(getFromSocket("r/eval hl.config({ master = { center_master_fallback = 'left' } })"));
+    if (!Tests::spawnKitty("extra"))
+        FAIL_TEST("Could not spawn kitty with win class `{}`", "extra");
+    expectColumnResizes("slave1", "slave3", "slave2");
+
+    // even count, no regression: 2 slaves => 1 per column, so a vertical resize is a no-op
+    NLog::log("{}center master, 2 slaves: single-window columns don't resize (no regression)", Colors::YELLOW);
+    if (!Tests::killAllWindows())
+        FAIL_TEST("Could not kill all windows before the {}-slave phase", 2);
+    for (auto const& win : {"slave1", "slave2", "master"}) {
+        if (!Tests::spawnKitty(win))
+            FAIL_TEST("Could not spawn kitty with win class `{}`", win);
+    }
+    const double H0 = heightOf("slave1");
+    OK(resizeY("slave1", 80));
+    EXPECT_MAX_DELTA(heightOf("slave1"), H0, 2);
 }

--- a/src/layout/algorithm/tiled/master/MasterAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/master/MasterAlgorithm.cpp
@@ -19,6 +19,15 @@ using namespace Layout;
 using namespace Layout::Tiled;
 using namespace Hyprutils::String;
 
+// Center-master slaves alternate left/right columns starting on the fallback side, so an odd
+// count puts the extra slave there: left by default, right when extraToRight. calculateWorkspace
+// and resizeTarget must both split via this or they disagree for odd counts. Returns {left, right}.
+static std::pair<int, int> centerSlaveColumns(int slaveCount, bool extraToRight) {
+    const int LARGER  = 1 + (slaveCount - 1) / 2; // ceil, holds the odd one
+    const int SMALLER = slaveCount - LARGER;
+    return extraToRight ? std::pair{SMALLER, LARGER} : std::pair{LARGER, SMALLER};
+}
+
 void CMasterAlgorithm::newTarget(SP<ITarget> target) {
     addTarget(target, true);
 }
@@ -308,8 +317,18 @@ void CMasterAlgorithm::resizeTarget(const Vector2D& Δ, SP<ITarget> target, eRec
     const auto RESIZEDELTA = isStackVertical ? Δ.y : Δ.x;
 
     auto       nodesInSameColumn = PNODE->isMaster ? MASTERS : STACKWINDOWS;
-    if (orientation == ORIENTATION_CENTER && !PNODE->isMaster)
-        nodesInSameColumn = DISPLAYRIGHT ? (nodesInSameColumn + 1) / 2 : nodesInSameColumn / 2;
+    if (orientation == ORIENTATION_CENTER && !PNODE->isMaster) {
+        static auto CMFALLBACK   = CConfigValue<std::string>("master:center_master_fallback");
+        const bool  EXTRATORIGHT = *CMFALLBACK == "right";
+
+        // slaves alternate columns from the fallback side, so even slave index == fallback side
+        const auto NODEIT     = std::ranges::find(m_masterNodesData, PNODE);
+        const int  SLAVEINDEX = std::count_if(m_masterNodesData.begin(), NODEIT, [](const auto& n) { return !n->isMaster; });
+        const bool ONLEFT     = (SLAVEINDEX % 2 == 0) != EXTRATORIGHT;
+
+        const auto [SLAVESLEFT, SLAVESRIGHT] = centerSlaveColumns(STACKWINDOWS, EXTRATORIGHT);
+        nodesInSameColumn                    = ONLEFT ? SLAVESLEFT : SLAVESRIGHT;
+    }
 
     const auto SIZE = isStackVertical ? WORKAREA.h / nodesInSameColumn : WORKAREA.w / nodesInSameColumn;
 
@@ -1162,22 +1181,16 @@ void CMasterAlgorithm::calculateWorkspace() {
             nextY += HEIGHT;
         }
     } else { // slaves for centered master window(s)
-        const float WIDTH       = ((*PIGNORERESERVED ? UNRESERVED_WIDTH : WORKAREA.w) - PMASTERNODE->size.x) / 2.0;
-        float       heightLeft  = 0;
-        float       heightLeftL = WORKAREA.h;
-        float       heightLeftR = WORKAREA.h;
-        float       nextX       = 0;
-        float       nextY       = 0;
-        float       nextYL      = 0;
-        float       nextYR      = 0;
-        bool        onRight     = *CMFALLBACK == "right";
-        int         slavesLeftL = 1 + (slavesLeft - 1) / 2;
-        int         slavesLeftR = slavesLeft - slavesLeftL;
-
-        if (onRight) {
-            slavesLeftR = 1 + (slavesLeft - 1) / 2;
-            slavesLeftL = slavesLeft - slavesLeftR;
-        }
+        const float WIDTH               = ((*PIGNORERESERVED ? UNRESERVED_WIDTH : WORKAREA.w) - PMASTERNODE->size.x) / 2.0;
+        float       heightLeft          = 0;
+        float       heightLeftL         = WORKAREA.h;
+        float       heightLeftR         = WORKAREA.h;
+        float       nextX               = 0;
+        float       nextY               = 0;
+        float       nextYL              = 0;
+        float       nextYR              = 0;
+        bool        onRight             = *CMFALLBACK == "right";
+        auto [slavesLeftL, slavesLeftR] = centerSlaveColumns(slavesLeft, onRight);
 
         const float slaveAverageHeightL     = WORKAREA.h / slavesLeftL;
         const float slaveAverageHeightR     = WORKAREA.h / slavesLeftR;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes a bug that's been annoying me for a while, where the left windows can't be resized in a master layout with 3 slaves.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Not tested yet, hence marked as draft. Will mark ready once I'm sure it's safe. Test is slop-coded.

#### Is it ready for merging, or does it need work?

See above :)

Edit: Appears to work well.

