### PR TITLE
Fix filename string not being computed at compile time in RASSERT and GLCALL macros

### DIFF
--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <csignal>
 #include <print>
+#include <string_view>
 #include <utility>
 
 #include "helpers/memory/Memory.hpp"
@@ -47,7 +48,7 @@
     if (!(expr)) {                                                                                                                                                                 \
         Log::logger->log(Log::CRIT, "\n==========================================================================================\nASSERTION FAILED! \n\n{}\n\nat: line {} in {}", \
                          std::format(reason, ##__VA_ARGS__), __LINE__,                                                                                                             \
-                         ([]() constexpr -> std::string { return std::string(__FILE__).substr(std::string(__FILE__).find_last_of('/') + 1); })());                                 \
+                         ([]() consteval { return std::string_view(__FILE__).substr(std::string_view(__FILE__).find_last_of('/') + 1); })());                                      \
         std::print("Assertion failed! See the log in /tmp/hypr/hyprland.log for more info.");                                                                                      \
         raise(SIGABRT);                                                                                                                                                            \
     }
@@ -101,7 +102,7 @@
             auto err = glGetError();                                                                                                                                               \
             if (err != GL_NO_ERROR) {                                                                                                                                              \
                 Log::logger->log(Log::ERR, "[GLES] Error in call at {}@{}: 0x{:x}", __LINE__,                                                                                      \
-                                 ([]() constexpr -> std::string { return std::string(__FILE__).substr(std::string(__FILE__).find_last_of('/') + 1); })(), err);                    \
+                                 ([]() consteval { return std::string_view(__FILE__).substr(std::string_view(__FILE__).find_last_of('/') + 1); })(), err);                         \
             }                                                                                                                                                                      \
         }                                                                                                                                                                          \
     }


### PR DESCRIPTION
`constexpr` on functions and lambdas means the function can be evaluated at compile time but it does not have to. `consteval` forces compile time evaluation.