### PR TITLE
algo/master: fix drag-swap with two tiled windows

### DIFF
--- a/hyprtester/plugin/src/main.cpp
+++ b/hyprtester/plugin/src/main.cpp
@@ -58,6 +58,40 @@ static SDispatchResult snapMove(std::string in) {
     return {};
 }
 
+// Perform a full move-drag of the window with the given class and drop it at (x, y).
+static SDispatchResult dragWindow(std::string in) {
+    CVarList2 data(std::move(in));
+
+    if (data.size() < 3)
+        return {.success = false, .error = "invalid input"};
+
+    const std::string cls = std::string{data[0]};
+
+    double            x;
+    double            y;
+    try {
+        x = std::stod(std::string{data[1]});
+        y = std::stod(std::string{data[2]});
+    } catch (...) { return {.success = false, .error = "invalid input"}; }
+
+    for (const auto& window : g_pCompositor->m_windows) {
+        if (window->m_class != cls)
+            continue;
+
+        const auto target = window->layoutTarget();
+        if (!target)
+            return {.success = false, .error = "Window has no layout target"};
+
+        g_pCompositor->warpCursorTo({x, y}, true);
+        g_layoutManager->beginDragTarget(target, MBIND_MOVE);
+        g_layoutManager->endDragTarget();
+
+        return {};
+    }
+
+    return {.success = false, .error = std::format("No window with class '{}'", cls)};
+}
+
 class CTestKeyboard : public IKeyboard {
   public:
     static SP<CTestKeyboard> create(bool isVirtual) {
@@ -566,6 +600,13 @@ static int luaSnapMove(lua_State* L) {
     return luaResult(L, ::snapMove(""));
 }
 
+static int luaDragWindow(lua_State* L) {
+    const auto cls = std::string{luaL_checkstring(L, 1)};
+    const auto x   = (double)luaL_checknumber(L, 2);
+    const auto y   = (double)luaL_checknumber(L, 3);
+    return luaResult(L, ::dragWindow(std::format("{},{},{}", cls, x, y)));
+}
+
 static int luaVkb(lua_State* L) {
     return luaResult(L, ::vkb(""));
 }
@@ -685,6 +726,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 
     addLuaFn("test", ::luaTest);
     addLuaFn("snapmove", ::luaSnapMove);
+    addLuaFn("drag_window", ::luaDragWindow);
     addLuaFn("vkb", ::luaVkb);
     addLuaFn("alt", ::luaAlt);
     addLuaFn("gesture", ::luaGesture);

--- a/hyprtester/src/tests/main/master.cpp
+++ b/hyprtester/src/tests/main/master.cpp
@@ -2,7 +2,9 @@
 #include "../../shared.hpp"
 #include "../../hyprctlCompat.hpp"
 #include <algorithm>
+#include <array>
 #include <cmath>
+#include <map>
 #include <string>
 #include <utility>
 #include <vector>
@@ -329,4 +331,64 @@ TEST_CASE(centerMasterColumnResize) {
     const double H0 = heightOf("slave1");
     OK(resizeY("slave1", 80));
     EXPECT_MAX_DELTA(heightOf("slave1"), H0, 2);
+}
+
+// In a centered master layout with three windows w1/w2/w3, return their classes ordered
+// visually left-to-right: { left slave, master (center), right slave }.
+static std::array<std::string, 3> detectCenterArrangement() {
+    std::vector<std::pair<int, std::string>> wins;
+    for (auto const& cls : {"w1", "w2", "w3"}) {
+        getFromSocket(std::format("/dispatch hl.dsp.focus({{ window = 'class:{}' }})", cls));
+        const auto at = Tests::getAttribute(getFromSocket("/activewindow"), "at");
+        wins.emplace_back(std::stoi(at.substr(0, at.find(','))), cls);
+    }
+    std::ranges::sort(wins, {}, &std::pair<int, std::string>::first);
+    return {wins[0].second, wins[1].second, wins[2].second};
+}
+
+// Drag the window currently playing role `pick` (one of "L"/"M"/"R", i.e. the left
+// slave, the master, or the right slave) and drop it on the left or right side of the
+// screen. Assert the windows end up in the expected left/center/right roles afterwards.
+SUBTEST(expectCenterDrop, const std::string& pick, bool dropRight, const std::string& expLeft, const std::string& expCenter, const std::string& expRight) {
+    // start from a fresh set of three windows
+    if (!Tests::killAllWindows())
+        FAIL_TEST("Could not clear windows{}", "");
+
+    for (auto const& win : {"w1", "w2", "w3"}) {
+        if (!Tests::spawnKitty(win))
+            FAIL_TEST("Could not spawn kitty with win class `{}`", win);
+    }
+    Tests::waitUntilWindowsN(3);
+
+    const auto                         INITIAL = detectCenterArrangement();
+    std::map<std::string, std::string> role    = {
+        {"L", INITIAL[0]},
+        {"M", INITIAL[1]},
+        {"R", INITIAL[2]},
+    };
+
+    const double DROPX = dropRight ? 1800.0 : 100.0;
+    NLog::log("{}Picking up {} ({}) and dropping it on the {} side", Colors::YELLOW, pick, role[pick], dropRight ? "right" : "left");
+
+    OK(getFromSocket(std::format("/eval hl.plugin.test.drag_window('{}', {}, {})", role[pick], DROPX, 540)));
+
+    const auto FINAL = detectCenterArrangement();
+    EXPECT(FINAL[0], role[expLeft]);
+    EXPECT(FINAL[1], role[expCenter]);
+    EXPECT(FINAL[2], role[expRight]);
+}
+
+TEST_CASE(masterCenterDropAtCursor) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'master' } })"));
+    OK(getFromSocket("/eval hl.config({ master = { orientation = 'center', new_status = 'slave', drop_at_cursor = true, slave_count_for_center_master = 0, center_master_fallback "
+                     "= 'left' } })"));
+
+    NLog::log("{}Testing center master drop_at_cursor rearrangement", Colors::GREEN);
+
+    CALL_SUBTEST(expectCenterDrop, "L", false, "L", "M", "R");
+    CALL_SUBTEST(expectCenterDrop, "L", true, "R", "M", "L");
+    CALL_SUBTEST(expectCenterDrop, "M", false, "M", "L", "R");
+    CALL_SUBTEST(expectCenterDrop, "M", true, "R", "L", "M");
+    CALL_SUBTEST(expectCenterDrop, "R", false, "R", "M", "L");
+    CALL_SUBTEST(expectCenterDrop, "R", true, "L", "M", "R");
 }

--- a/src/layout/algorithm/tiled/master/MasterAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/master/MasterAlgorithm.cpp
@@ -38,16 +38,23 @@ void CMasterAlgorithm::movedTarget(SP<ITarget> target, std::optional<Vector2D> f
 }
 
 void CMasterAlgorithm::addTarget(SP<ITarget> target, bool firstMap) {
-    static auto PNEWONACTIVE = CConfigValue<std::string>("master:new_on_active");
-    static auto PNEWONTOP    = CConfigValue<Config::INTEGER>("master:new_on_top");
-    static auto PNEWSTATUS   = CConfigValue<std::string>("master:new_status");
+    static auto PNEWONACTIVE      = CConfigValue<std::string>("master:new_on_active");
+    static auto PNEWONTOP         = CConfigValue<Config::INTEGER>("master:new_on_top");
+    static auto PNEWSTATUS        = CConfigValue<std::string>("master:new_status");
+    static auto PDROPATCURSOR     = CConfigValue<Config::INTEGER>("master:drop_at_cursor");
+    static auto PSLAVECOUNTCENTER = CConfigValue<Config::INTEGER>("master:slave_count_for_center_master");
 
     const auto  PWORKSPACE = m_parent->space()->workspace();
     const auto  PMONITOR   = PWORKSPACE->m_monitor;
 
     bool        dragOntoMaster = false;
 
-    if (g_layoutManager->dragController()->wasDraggingWindow()) {
+    const bool  DRAGMOVE = g_layoutManager->dragController()->mode() == MBIND_MOVE;
+
+    const bool  CENTERED         = getDynamicOrientation() == ORIENTATION_CENTER && getNodesNo() - getMastersNo() >= *PSLAVECOUNTCENTER;
+    const bool  CENTERCURSORDROP = *PDROPATCURSOR && DRAGMOVE && CENTERED;
+
+    if (g_layoutManager->dragController()->wasDraggingWindow() && (getNodesNo() > 1 || !*PDROPATCURSOR) && !CENTERCURSORDROP) {
         if (const auto n = getClosestNode(g_pInputManager->getMouseCoordsInternal()); n && n->isMaster)
             dragOntoMaster = true;
     }
@@ -78,15 +85,60 @@ void CMasterAlgorithm::addTarget(SP<ITarget> target, bool firstMap) {
         getNodeFromWindow(Desktop::focusState()->window()) :
         getMasterNode();
 
-    const auto   MOUSECOORDS   = g_pInputManager->getMouseCoordsInternal();
-    static auto  PDROPATCURSOR = CConfigValue<Config::INTEGER>("master:drop_at_cursor");
-    eOrientation orientation   = getDynamicOrientation();
-    const auto   NODEIT        = std::ranges::find(m_masterNodesData, PNODE);
+    const auto   MOUSECOORDS = g_pInputManager->getMouseCoordsInternal();
+    eOrientation orientation = getDynamicOrientation();
+    const auto   NODEIT      = std::ranges::find(m_masterNodesData, PNODE);
 
     bool         forceDropAsMaster = false;
     // if dragging window to move, drop it at the cursor position instead of bottom/top of stack
-    if (*PDROPATCURSOR && g_layoutManager->dragController()->mode() == MBIND_MOVE) {
-        if (WINDOWSONWORKSPACE > 2) {
+    if (*PDROPATCURSOR && DRAGMOVE) {
+        if (CENTERED) {
+            if (const auto PMASTER = getMasterNode(); PMASTER) {
+                const CBox MBOX = PMASTER->pTarget->position();
+                if (MOUSECOORDS.x >= MBOX.x && MOUSECOORDS.x <= MBOX.x + MBOX.w)
+                    forceDropAsMaster = true;
+                else {
+                    static auto CMFALLBACK = CConfigValue<std::string>("master:center_master_fallback");
+
+                    const bool  DROPRIGHT      = MOUSECOORDS.x > MBOX.middle().x;
+                    const bool  FIRSTSIDERIGHT = *CMFALLBACK == "right";
+
+                    auto&       v = m_masterNodesData;
+                    std::erase(v, PNODE);
+
+                    int slot     = 0;
+                    int slavesNo = 0;
+                    for (auto const& nd : v) {
+                        if (nd->isMaster)
+                            continue;
+                        const bool ndRight = (slavesNo % 2 == 0) == FIRSTSIDERIGHT;
+                        if (ndRight == DROPRIGHT && MOUSECOORDS.y > nd->pTarget->position().middle().y)
+                            ++slot;
+                        ++slavesNo;
+                    }
+
+                    const bool TARGETFIRSTSIDE = DROPRIGHT == FIRSTSIDERIGHT;
+                    const int  TOTALSLAVES     = slavesNo + 1;
+                    const int  TARGETCAP       = TARGETFIRSTSIDE ? (TOTALSLAVES + 1) / 2 : TOTALSLAVES / 2;
+                    if (TARGETCAP > 0)
+                        slot = std::min(slot, TARGETCAP - 1);
+                    const int   INSERTSLAVEPOS = TARGETCAP == 0 ? 0 : (TARGETFIRSTSIDE ? 2 * slot : 2 * slot + 1);
+
+                    std::size_t insertIndex = v.size();
+                    int         counted     = 0;
+                    for (std::size_t i = 0; i < v.size(); ++i) {
+                        if (counted == INSERTSLAVEPOS) {
+                            insertIndex = i;
+                            break;
+                        }
+                        if (!v[i]->isMaster)
+                            ++counted;
+                    }
+
+                    v.insert(v.begin() + sc<std::ptrdiff_t>(insertIndex), PNODE);
+                }
+            }
+        } else if (WINDOWSONWORKSPACE > 2) {
             auto&             v = m_masterNodesData;
 
             const std::size_t srcIndex = sc<std::size_t>(std::distance(v.begin(), NODEIT));


### PR DESCRIPTION
~~Dragging one of two tiled windows floats it and leaves a single tiled node, which is always the master and spans the whole workspace. So getClosestNode() always reported the drop as landing on the master, forcing the dropped window to become master regardless of cursor position and overriding the cursor-side check in the two-window branch: dragging the slave looked like a swap, while dragging the master snapped back. Only treat a drop as onto-master when more than one node exists.~~

Edit 2: Ok, so this ended up being way bigger than I originally thought. The master layout with a centered orientation and slave_count_for_center_master = 0 has always behaved weirdly when dragging windows around. See the table here:

Pick up | Drop on | Before PR | After PR
-- | -- | -- | --
L (left) | left side | [L, M, R] | [L, M, R]
L (left) | right side | [R, L, M] forced to master | [R, M, L]
M (master) | left side | [M, L, R] | [M, L, R]
M (master) | right side | [L, M, R] no-op | [R, L, M]
R (right) | left side | [R, M, L] | [R, M, L]
R (right) | right side | [L, R, M] forced to master | [L, M, R]

Obviously, this could be considered an opinionated change, so I'm wondering if this is something that needs "fixing", or if I should keep the patch just on my local fork.