### PR TITLE
Config/Prop Refresh: Add a prop refresh event, add granular reasons for prop refresh, remove old hack for stopping prop refresh from moving scrolling viewport

### DIFF
--- a/hyprtester/src/tests/main/scroll.cpp
+++ b/hyprtester/src/tests/main/scroll.cpp
@@ -1023,55 +1023,6 @@ TEST_CASE(testScrollingViewBehaviourMoveFocusInGroupFollowFocusTrue) {
     }
 }
 
-TEST_CASE(testScrollingViewBehaviourScheduledPropRefresh) {
-
-    /*
-     Scheduled prop refresh must not move scrolling viewport.
-     The reason a prop refresh was queued is not saved, therefore it is not possible to clearly tell when and when not to move scrolling viewport
-     In this test, we test this by setting a workspace rule, which schedules a prop refresh
-     --------------------------------------------------------------------------------------------------------------------------------------
-    */
-
-    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling' } })"));
-
-    // ensure variables are correctly set for the test
-
-    OK(getFromSocket("/eval hl.config({scrolling = {follow_focus = false}})"));
-
-    if (!Tests::spawnKitty("a")) {
-        FAIL_TEST("Could not spawn kitty with win class `a`");
-        return;
-    }
-
-    OK(getFromSocket("/dispatch hl.dsp.layout('colresize 0.8')"));
-
-    if (!Tests::spawnKitty("b")) {
-        FAIL_TEST("Could not spawn kitty with win class `b`");
-        return;
-    }
-
-    // since follow_focus = false, viewport does not move
-    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:a' })"));
-
-    // setting a workspace rule queues a doLater() call in the Event Loop Manager
-    OK(getFromSocket("/eval hl.workspace_rule({workspace = hl.get_active_workspace().id,gaps_in = 0})"));
-
-    // Check that the workspace rule is set
-    ASSERT_CONTAINS(getFromSocket("/workspacerules"), "gapsIn: 0 0 0 0");
-
-    // The viewport must not have moved: left corner cords of window should be < 0
-    const std::string currentWindowPos  = Tests::getAttribute(getFromSocket("/activewindow"), "at");
-    const std::string currentWindowPosX = currentWindowPos.substr(0, currentWindowPos.find(','));
-    // test pass
-    if (std::stoi(currentWindowPosX) < 0) {
-        NLog ::log("{}Passed: {}window of class 'a' has negative x coordinates for its position: {}", Colors ::GREEN, Colors::RESET, currentWindowPosX);
-    }
-    // test fail
-    else {
-        FAIL_TEST("{}Failed: {}window of class 'a' does not have negative x coordinates for its position: {}", Colors::RED, Colors::RESET, currentWindowPosX);
-    }
-}
-
 TEST_CASE(testScrollInhibitor) {
 
     /*

--- a/src/config/supplementary/propRefresher/PropRefresher.cpp
+++ b/src/config/supplementary/propRefresher/PropRefresher.cpp
@@ -93,7 +93,7 @@ void CPropRefresher::scheduleRefresh(PropRefreshBits prop) {
                     if (!m)
                         continue;
 
-                    g_layoutManager->recalculateMonitor(m, Layout::CLayoutManager::RECALCULATE_MONITOR_REASON_PROP_REFRESH);
+                    g_layoutManager->recalculateMonitor(m, );
                 }
 
                 g_pCompositor->ensurePersistentWorkspacesPresent();
@@ -103,7 +103,7 @@ void CPropRefresher::scheduleRefresh(PropRefreshBits prop) {
                 Layout::Supplementary::algoMatcher()->updateWorkspaceLayouts();
 
                 for (auto const& m : g_pCompositor->m_monitors) {
-                    g_layoutManager->recalculateMonitor(m, Layout::CLayoutManager::RECALCULATE_MONITOR_REASON_PROP_REFRESH);
+                    g_layoutManager->recalculateMonitor(m);
                     g_pHyprRenderer->damageMonitor(m);
                 }
             }

--- a/src/layout/LayoutManager.hpp
+++ b/src/layout/LayoutManager.hpp
@@ -52,7 +52,6 @@ namespace Layout {
 
         enum eRecalculateMonitorReason : uint8_t {
             RECALCULATE_MONITOR_REASON_UNKNOWN, // when the recalculate monitor reason is unknown or not important to preserve
-            RECALCULATE_MONITOR_REASON_PROP_REFRESH,
             RECALCULATE_MONITOR_REASON_WORKSPACE_CHANGE,
             RECALCULATE_MONITOR_REASON_TOGGLE_SPECIAL_WORKSPACE,
             RECALCULATE_MONITOR_REASON_TOGGLE_FULLSCREEN,

--- a/src/layout/space/Space.cpp
+++ b/src/layout/space/Space.cpp
@@ -32,7 +32,7 @@ CSpace::CSpace(PHLWORKSPACE parent) : m_parent(parent) {
         recheckWorkArea();
 
         if (m_algorithm)
-            m_algorithm->recalculate(RECALCULATE_REASON_CREATE_SPACE);
+            m_algorithm->recalculate();
     });
 }
 
@@ -219,9 +219,9 @@ SP<ITarget> CSpace::getNextCandidate(SP<ITarget> old) {
 }
 
 bool Layout::isHardRecalculateReason(eRecalculateReason reason) {
-    return reason != RECALCULATE_REASON_CREATE_SPACE && reason != RECALCULATE_REASON_PROP_REFRESH && reason != RECALCULATE_REASON_WORKSPACE_CHANGE &&
-        reason != RECALCULATE_REASON_SPECIAL_WORKSPACE_TOGGLE && reason != RECALCULATE_REASON_TOGGLE_LAYOUT_HANDLED_FULLSCREEN &&
-        reason != RECALCULATE_REASON_TOGGLE_DEFAULT_HANDLED_FULLSCREEN && reason != RECALCULATE_REASON_INVALIDATE_MONITOR_GEOMETRIES && reason != RECALCULATE_REASON_RENDER_MOINTOR;
+    return reason != RECALCULATE_REASON_WORKSPACE_CHANGE && reason != RECALCULATE_REASON_SPECIAL_WORKSPACE_TOGGLE &&
+        reason != RECALCULATE_REASON_TOGGLE_LAYOUT_HANDLED_FULLSCREEN && reason != RECALCULATE_REASON_TOGGLE_DEFAULT_HANDLED_FULLSCREEN &&
+        reason != RECALCULATE_REASON_INVALIDATE_MONITOR_GEOMETRIES && reason != RECALCULATE_REASON_RENDER_MOINTOR;
 }
 
 const std::vector<WP<ITarget>>& CSpace::targets() const {
@@ -234,7 +234,6 @@ eRecalculateReason Layout::recalcMonitorReasonToRecalcReason(CLayoutManager::eRe
         case CLayoutManager::RECALCULATE_MONITOR_REASON_TOGGLE_SPECIAL_WORKSPACE: return RECALCULATE_REASON_SPECIAL_WORKSPACE_TOGGLE;
         case CLayoutManager::RECALCULATE_MONITOR_REASON_WORKSPACE_CHANGE: return RECALCULATE_REASON_WORKSPACE_CHANGE;
         case CLayoutManager::RECALCULATE_MONITOR_REASON_TOGGLE_FULLSCREEN: return RECALCULATE_REASON_TOGGLE_DEFAULT_HANDLED_FULLSCREEN;
-        case CLayoutManager::RECALCULATE_MONITOR_REASON_PROP_REFRESH: return RECALCULATE_REASON_PROP_REFRESH;
         default: return RECALCULATE_REASON_UNKNOWN;
     }
 }

--- a/src/layout/space/Space.hpp
+++ b/src/layout/space/Space.hpp
@@ -15,8 +15,6 @@ namespace Layout {
 
     enum eRecalculateReason : uint8_t {
         RECALCULATE_REASON_UNKNOWN, // when the recalculate reason is unknown or not important to preserve
-        RECALCULATE_REASON_PROP_REFRESH,
-        RECALCULATE_REASON_CREATE_SPACE,
         RECALCULATE_REASON_WORKSPACE_CHANGE,
         RECALCULATE_REASON_SPECIAL_WORKSPACE_TOGGLE,
         RECALCULATE_REASON_TOGGLE_DEFAULT_HANDLED_FULLSCREEN,


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

1. It reverts https://github.com/hyprwm/Hyprland/pull/14594:

In that PR, I sought to address the issue of prop refresh indiscriminately moving the scrolling view regardless of why it was fired. However, some causes of prop refresh should indeed move the scrolling viewport and to add scrolling specific code as exceptions to lua dispatch/config/workspace rule handlers is untidy and not sustainable.

2. To this end, I wish to take a different approach: The existence of the scroll inhibitor allows the prevention of viewport moves; the problem is the fact that the prop refresh is fired after the event ends and there is no good way to catch it and uninhibit scrolling. Even if we catch it using another event that it incidentally causes the firing of; the reason why that prop refresh is fired isn't available to us so we don't know if this prop refresh is the one we want to uninhibit on; or if the event was fired not as a result of a prop refresh at all.

For this, I will:

- Add a new event which will fire when a prop refresh happens
- Add a new enum member to `ePropRefreshProp`

Using these, save the fact that a prop refresh was enqueued because of a workspace rule change, and the reason for why a prop refresh is executed will be passed to the user as an `int` which they can capture using the lua event from the lua config.

The user can now tell exactly why the prop refresh was executed using that integer and uninhibit scrolling.


Note: In this PR, I will only introduce 1 new enum member. It is what I personally need to make my scripts work. Users can add new ones for their needs; and I can add them here if people ask me to in the 'comments'.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

WIP - but after it is done, it will not break anything.


#### Is it ready for merging, or does it need work?

TODO:

- [ ] Add new event

- [ ] Add new prop refresh reason