### PR TITLE
gestures: configure client to final size on fullscreen/float gesture completion

### DIFF
--- a/src/managers/input/trackpad/gestures/FloatGesture.cpp
+++ b/src/managers/input/trackpad/gestures/FloatGesture.cpp
@@ -85,4 +85,9 @@ void CFloatTrackpadGesture::end(const ITrackpadGesture::STrackpadGestureEnd& e) 
 
     *m_window->m_realPosition = m_posTo;
     *m_window->m_realSize     = m_sizeTo;
+
+    // the gesture warps m_realSize->goal() around during update(), which races the deferred
+    // sendWindowSize() queued when the size animation began and can leave the client configured to
+    // an intermediate size. force a configure to the final size so the client matches its box.
+    m_window->sendWindowSize(true);
 }

--- a/src/managers/input/trackpad/gestures/FullscreenGesture.cpp
+++ b/src/managers/input/trackpad/gestures/FullscreenGesture.cpp
@@ -84,6 +84,12 @@ void CFullscreenTrackpadGesture::end(const ITrackpadGesture::STrackpadGestureEnd
 
     *m_window->m_realPosition = m_posTo;
     *m_window->m_realSize     = m_sizeTo;
+
+    // the gesture warps m_realSize->goal() around during update(), which races the deferred
+    // sendWindowSize() queued when fullscreen began and can leave the client configured to an
+    // intermediate size. force a configure to the final size so the client matches its box.
+    m_window->sendWindowSize(true);
+
     g_pDesktopAnimationManager->overrideFullscreenFadeAmount(m_window->m_workspace, m_originalMode == FSMODE_NONE ? 0.F : 1.F);
 }
 


### PR DESCRIPTION
## What

The `fullscreen` and `float` trackpad gesture actions resize the window box but never reconfigure the client to the final size, so the client keeps rendering at its old size and Hyprland stretches the stale buffer. The fullscreen state itself is correct (`hyprctl clients` shows `fullscreen: 2` / `fullscreenClient: 2`); only the size configure is missing.

## Why

The client only learns its size via `CWindow::sendWindowSize()`, which is queued deferred from the `m_realSize` begin-callback when a size animation starts. The gestures repeatedly `setValueAndWarp()` `m_realSize->goal()` in `update()` — a warp, so it overwrites the goal without starting an animation or scheduling a new send. The single deferred send queued in `begin()` then runs after the goal was already warped to an intermediate value, and on completion the assignment in `end()` is often a no-op (the goal was already warped there by the last `update()`), so no corrected size is ever sent.

Forcing `sendWindowSize(true)` once the gesture commits fixes it, mirroring what `CCloseTrackpadGesture` already does and what the normal layout path (`CWindowTarget::setPositionGlobal`) does.

Affected actions are only `fullscreen` and `float`; `resize` re-sends each frame, `move` only changes position, `close` already forces a send.

Closes #14978

## Test plan

Tested on aarch64 (Fedora Asahi Remix, Apple M1) only:

- [x] `action = "fullscreen"` gesture on kitty → crisp fullscreen, client at full size
- [x] `action = "float"` gesture → client redraws at the new size, no stretching
- [x] keybind `fullscreen` / `togglefloating` unaffected
- [x] `resize` / `move` / `close` gestures unaffected

Not yet tested on x86_64.

---
Implemented with AI assistance (Claude Code); changes reviewed and tested by me.