### PR TITLE
Add `stableid:` window selector

### DIFF
--- a/hyprtester/src/tests/main/window.cpp
+++ b/hyprtester/src/tests/main/window.cpp
@@ -631,6 +631,34 @@ TEST_CASE(specialFloatRecenters) {
     ASSERT(Tests::windowCount(), 0);
 }
 
+TEST_CASE(exactWindowSelectors) {
+    if (!spawnKitty("kitty_A"))
+        FAIL_TEST("Could not spawn kitty");
+    if (!spawnKitty("kitty_B"))
+        FAIL_TEST("Could not spawn kitty");
+
+    getFromSocket("/dispatch hl.dsp.focus({ window = 'class:kitty_B' })");
+    auto target    = getFromSocket("/activewindow");
+    auto addr      = getWindowAddress(target);
+    auto pid       = Tests::getAttribute(target, "pid");
+    auto stable_id = Tests::getAttribute(target, "stableID");
+
+    getFromSocket("/dispatch hl.dsp.focus({ window = 'class:kitty_A' })");
+    // Focus window by address
+    OK(getFromSocket(std::format("/dispatch hl.dsp.focus({{ window = 'address:0x{}' }})", addr)));
+    EXPECT_CONTAINS(getFromSocket("/activewindow"), "class: kitty_B");
+
+    getFromSocket("/dispatch hl.dsp.focus({ window = 'class:kitty_A' })");
+    // Focus window by PID
+    OK(getFromSocket(std::format("/dispatch hl.dsp.focus({{ window = 'pid:{}' }})", pid)));
+    EXPECT_CONTAINS(getFromSocket("/activewindow"), "class: kitty_B");
+
+    getFromSocket("/dispatch hl.dsp.focus({ window = 'class:kitty_A' })");
+    // Focus window by stable ID
+    OK(getFromSocket(std::format("/dispatch hl.dsp.focus({{ window = 'stableid:{}' }})", stable_id)));
+    EXPECT_CONTAINS(getFromSocket("/activewindow"), "class: kitty_B");
+}
+
 // TODO: decompose this into multiple test cases
 TEST_CASE(windows) {
     // test on workspace "window"

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -2403,6 +2403,9 @@ PHLWINDOW CCompositor::getWindowByRegex(const std::string& regexp_) {
     } else if (regexp.starts_with("tag:")) {
         mode       = MODE_TAG_REGEX;
         regexCheck = regexp.substr(4);
+    } else if (regexp.starts_with("stableid:")) {
+        mode       = MODE_STABLE_ID;
+        matchCheck = regexp.substr(9);
     } else if (regexp.starts_with("address:")) {
         mode       = MODE_ADDRESS;
         matchCheck = regexp.substr(8);
@@ -2449,6 +2452,12 @@ PHLWINDOW CCompositor::getWindowByRegex(const std::string& regexp_) {
                     }
                 }
                 if (!tagMatched)
+                    continue;
+                break;
+            }
+            case MODE_STABLE_ID: {
+                std::string stable_id = std::format("{:x}", w->m_stableID);
+                if (matchCheck != stable_id)
                     continue;
                 break;
             }

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -70,6 +70,7 @@ enum eFocusWindowMode : uint8_t {
     MODE_TITLE_REGEX,
     MODE_INITIAL_TITLE_REGEX,
     MODE_TAG_REGEX,
+    MODE_STABLE_ID,
     MODE_ADDRESS,
     MODE_PID,
     MODE_ACTIVE_WINDOW


### PR DESCRIPTION
A natively-supported selector for grabbing windows by their "stable ID" would be nice for interoperability with other programs, especially ones that speak the `ext-foreign-toplevel-list` protocol (which [exposes these IDs](https://wayland.app/protocols/ext-foreign-toplevel-list-v1#ext_foreign_toplevel_handle_v1:event:identifier)).

With the introduction of Lua, it was already possible to act on windows by stable ID with an invocation like:
```sh
hyprctl eval 'for _,w in ipairs(hl.get_windows()) do if w.stable_id == WHATEVER then hl.dispatch(hl.dsp.window.move({ window = w, workspace = "+0" })) return end end'
```
...but that's pretty clunky. Instead, we could have:
```sh
hyprctl dispatch 'hl.dsp.window.move({ window = "stableid:WHATEVER", workspace = "+0" })'
```

Doing this matching inside the compositor itself is straightforward enough, and would let clients that speak the ext toplevel protocol more directly do useful stuff with the stable IDs they're given. Also, maintenance cost should be basically zero.