### PR TITLE
config/propRefresher: add capability to execute scheduled prop refresh immediately with lua helper function, add event for prop refresh

### DIFF
--- a/hyprtester/src/tests/main/scroll.cpp
+++ b/hyprtester/src/tests/main/scroll.cpp
@@ -1027,55 +1027,6 @@ TEST_CASE(testScrollingViewBehaviourMoveFocusInGroupFollowFocusTrue) {
     }
 }
 
-TEST_CASE(testScrollingViewBehaviourScheduledPropRefresh) {
-
-    /*
-     Scheduled prop refresh must not move scrolling viewport.
-     The reason a prop refresh was queued is not saved, therefore it is not possible to clearly tell when and when not to move scrolling viewport
-     In this test, we test this by setting a workspace rule, which schedules a prop refresh
-     --------------------------------------------------------------------------------------------------------------------------------------
-    */
-
-    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling' } })"));
-
-    // ensure variables are correctly set for the test
-
-    OK(getFromSocket("/eval hl.config({scrolling = {follow_focus = false}})"));
-
-    if (!Tests::spawnKitty("a")) {
-        FAIL_TEST("Could not spawn kitty with win class `a`");
-        return;
-    }
-
-    OK(getFromSocket("/dispatch hl.dsp.layout('colresize 0.8')"));
-
-    if (!Tests::spawnKitty("b")) {
-        FAIL_TEST("Could not spawn kitty with win class `b`");
-        return;
-    }
-
-    // since follow_focus = false, viewport does not move
-    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:a' })"));
-
-    // setting a workspace rule queues a doLater() call in the Event Loop Manager
-    OK(getFromSocket("/eval hl.workspace_rule({workspace = hl.get_active_workspace().id,gaps_in = 0})"));
-
-    // Check that the workspace rule is set
-    ASSERT_CONTAINS(getFromSocket("/workspacerules"), "gapsIn: 0 0 0 0");
-
-    // The viewport must not have moved: left corner cords of window should be < 0
-    const std::string currentWindowPos  = Tests::getAttribute(getFromSocket("/activewindow"), "at");
-    const std::string currentWindowPosX = currentWindowPos.substr(0, currentWindowPos.find(','));
-    // test pass
-    if (std::stoi(currentWindowPosX) < 0) {
-        NLog ::log("{}Passed: {}window of class 'a' has negative x coordinates for its position: {}", Colors ::GREEN, Colors::RESET, currentWindowPosX);
-    }
-    // test fail
-    else {
-        FAIL_TEST("{}Failed: {}window of class 'a' does not have negative x coordinates for its position: {}", Colors::RED, Colors::RESET, currentWindowPosX);
-    }
-}
-
 TEST_CASE(testScrollInhibitor) {
 
     /*

--- a/hyprtester/src/tests/main/scroll.cpp
+++ b/hyprtester/src/tests/main/scroll.cpp
@@ -1027,6 +1027,55 @@ TEST_CASE(testScrollingViewBehaviourMoveFocusInGroupFollowFocusTrue) {
     }
 }
 
+TEST_CASE(testScrollingViewBehaviourScheduledPropRefresh) {
+
+    /*
+    Test that hl.exec_scheduled_prop_refresh_immediately() should immediately execute prop refresh. This is tested via inhibiting scrollin during helper functs dispatch; if it works, the viewport
+    should not move when a new workspace rule is created. If it doesn't, dispatch will miss because the refresh will be executed as another event 
+    --------------------------------------------------------------------------------------------------------------------------------------
+    */
+
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling' } })"));
+
+    // ensure variables are correctly set for the test
+
+    OK(getFromSocket("/eval hl.config({scrolling = {follow_focus = false}})"));
+
+    if (!Tests::spawnKitty("a")) {
+        FAIL_TEST("Could not spawn kitty with win class `a`");
+        return;
+    }
+
+    OK(getFromSocket("/dispatch hl.dsp.layout('colresize 0.8')"));
+
+    if (!Tests::spawnKitty("b")) {
+        FAIL_TEST("Could not spawn kitty with win class `b`");
+        return;
+    }
+
+    // since follow_focus = false, viewport does not move
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:a' })"));
+
+    // setting a workspace rule queues a doLater() call in the Event Loop Manager
+    OK(getFromSocket("/eval hl.dispatch(hl.dsp.layout('inhibit_scroll true')); hl.workspace_rule({workspace = hl.get_active_workspace().id,gaps_in = 0}); "
+                     "hl.exec_scheduled_prop_refresh_immediately(); hl.dispatch(hl.dsp.layout('inhibit_scroll false'));"));
+
+    // Check that the workspace rule is set
+    ASSERT_CONTAINS(getFromSocket("/workspacerules"), "gapsIn: 0 0 0 0");
+
+    // The viewport must not have moved: left corner cords of window should be < 0
+    const std::string currentWindowPos  = Tests::getAttribute(getFromSocket("/activewindow"), "at");
+    const std::string currentWindowPosX = currentWindowPos.substr(0, currentWindowPos.find(','));
+    // test pass
+    if (std::stoi(currentWindowPosX) < 0) {
+        NLog ::log("{}Passed: {}window of class 'a' has negative x coordinates for its position: {}", Colors ::GREEN, Colors::RESET, currentWindowPosX);
+    }
+    // test fail
+    else {
+        FAIL_TEST("{}Failed: {}window of class 'a' does not have negative x coordinates for its position: {}", Colors::RED, Colors::RESET, currentWindowPosX);
+    }
+}
+
 TEST_CASE(testScrollInhibitor) {
 
     /*

--- a/src/config/lua/LuaEventHandler.cpp
+++ b/src/config/lua/LuaEventHandler.cpp
@@ -148,6 +148,9 @@ CLuaEventHandler::CLuaEventHandler(lua_State* L) : m_lua(L) {
     }));
 
     m_listeners.push_back(bus()->m_events.config.reloaded.listen([this] { dispatch("config.reloaded", 0, [](lua_State* L) {}); }));
+    m_listeners.push_back(bus()->m_events.config.props_refreshed.listen(
+        [this](const bool execdAsScheduled) { dispatch("config.props_refreshed", 1, [&](lua_State* L) { lua_pushboolean(L, sc<lua_Integer>(execdAsScheduled)); }); }));
+
     m_listeners.push_back(
         bus()->m_events.keybinds.submap.listen([this](const std::string& submap) { dispatch("keybinds.submap", 1, [&](lua_State* L) { lua_pushstring(L, submap.c_str()); }); }));
     m_listeners.push_back(bus()->m_events.screenshare.state.listen([this](bool state, uint8_t type, const std::string& name) {
@@ -277,6 +280,7 @@ std::unordered_set<std::string> CLuaEventHandler::knownEvents() {
         "workspace.removed",
         "workspace.move_to_monitor",
         "config.reloaded",
+        "config.props_refreshed",
         "keybinds.submap",
         "screenshare.state",
         "hyprland.start",

--- a/src/config/lua/bindings/LuaBindingsToplevel.cpp
+++ b/src/config/lua/bindings/LuaBindingsToplevel.cpp
@@ -462,12 +462,9 @@ static int hlTimer(lua_State* L) {
     return 1;
 }
 
-static int hlExecuteScheduledRefreshImmediately(lua_State* L){
+static int hlExecuteScheduledRefreshImmediately(lua_State* L) {
 
-    // ERSTARR TODO - make executeScheduledRefreshImmediately return 1 if there's nothing to refresh. There should be no other errors as other errors would be quite fatal
-    Supplementary::refresher()->executeScheduledRefreshImmediately();
-
-    return 0;
+    return Supplementary::refresher()->executeScheduledRefreshImmediately();
 }
 
 void Internal::registerToplevelBindings(lua_State* L, CConfigManager* mgr) {

--- a/src/config/lua/bindings/LuaBindingsToplevel.cpp
+++ b/src/config/lua/bindings/LuaBindingsToplevel.cpp
@@ -462,6 +462,14 @@ static int hlTimer(lua_State* L) {
     return 1;
 }
 
+static int hlExecuteScheduledRefreshImmediately(lua_State* L){
+
+    // ERSTARR TODO - make executeScheduledRefreshImmediately return 1 if there's nothing to refresh. There should be no other errors as other errors would be quite fatal
+    Supplementary::refresher()->executeScheduledRefreshImmediately();
+
+    return 0;
+}
+
 void Internal::registerToplevelBindings(lua_State* L, CConfigManager* mgr) {
     Internal::setMgrFn(L, mgr, "on", hlOn);
     Internal::setMgrFn(L, mgr, "bind", hlBind);
@@ -472,6 +480,8 @@ void Internal::registerToplevelBindings(lua_State* L, CConfigManager* mgr) {
     Internal::setFn(L, "version", hlVersion);
     Internal::setFn(L, "get_loaded_plugins", hlGetPlugins);
     Internal::setFn(L, "exec_cmd", hlExecCmd);
+
+    Internal::setFn(L, "exec_scheduled_prop_refresh_immediately", hlExecuteScheduledRefreshImmediately);
 
     Internal::setFn(L, "unbind", hlUnbind);
 }

--- a/src/config/supplementary/propRefresher/PropRefresher.cpp
+++ b/src/config/supplementary/propRefresher/PropRefresher.cpp
@@ -25,38 +25,57 @@ UP<CPropRefresher>& Supplementary::refresher() {
 }
 
 void CPropRefresher::scheduleRefresh(PropRefreshBits prop) {
-    static auto PZOOMFACTOR = CConfigValue<Config::FLOAT>("cursor:zoom_factor");
 
     m_propsTripped |= prop;
 
     if (!m_scheduled && g_pEventLoopManager) {
-        g_pEventLoopManager->doLater([this, weak = WP<CPropRefresher>{refresher()}] {
+        m_scheduledRefreshSeq = g_pEventLoopManager->doLater([this, weak = WP<CPropRefresher>{refresher()}] {
             if (!weak)
                 return;
+            refreshProp();
+        });
 
-            if (m_propsTripped & REFRESH_INPUT_DEVICES) {
-                g_pInputManager->setKeyboardLayout();     // update kb layout
-                g_pInputManager->setPointerConfigs();     // update mouse cfgs
-                g_pInputManager->setTouchDeviceConfigs(); // update touch device cfgs
-                g_pInputManager->setTabletConfigs();      // update tablets
-                g_pInputManager->setTabletToolConfigs();  // update tablettools
-            }
+        m_scheduled = true;
+    }
+}
 
-            if (m_propsTripped & REFRESH_SCREEN_SHADER) {
-                g_pHyprRenderer->m_reloadScreenShader = true;
-                for (auto const& m : State::monitorState()->monitors()) {
-                    if (!m)
-                        continue;
+void CPropRefresher::executeScheduledRefreshImmediately() {
+
+    if (!m_scheduled || m_scheduledRefreshSeq == 0)
+        return;
+
+    g_pEventLoopManager->removeDoLater(m_scheduledRefreshSeq);
+    // m_scheduledRefreshSeq must be reset back to 0 during refreshProp() call
+    refreshProp();
+}
+
+void CPropRefresher::refreshProp() {
+
+    static auto PZOOMFACTOR = CConfigValue<Config::FLOAT>("cursor:zoom_factor");
+
+    if (m_propsTripped & REFRESH_INPUT_DEVICES) {
+        g_pInputManager->setKeyboardLayout();     // update kb layout
+        g_pInputManager->setPointerConfigs();     // update mouse cfgs
+        g_pInputManager->setTouchDeviceConfigs(); // update touch device cfgs
+        g_pInputManager->setTabletConfigs();      // update tablets
+        g_pInputManager->setTabletToolConfigs();  // update tablettools
+    }
+
+    if (m_propsTripped & REFRESH_SCREEN_SHADER) {
+        g_pHyprRenderer->m_reloadScreenShader = true;
+        for (auto const& m : State::monitorState()->monitors()) {
+            if (!m)
+                continue;
 
                     m->m_forceFullFrames = 2;
                     m->scheduleFrame();
                 }
             }
 
-            if (m_propsTripped & REFRESH_BLUR_FB) {
-                for (auto const& m : State::monitorState()->monitors()) {
-                    if (!m)
-                        continue;
+    if (m_propsTripped & REFRESH_BLUR_FB) {
+        for (auto const& m : State::monitorState()->monitors()) {
+            if (!m)
+                continue;
 
                     m->m_blurFBDirty     = true;
                     m->m_forceFullFrames = 2;
@@ -64,23 +83,23 @@ void CPropRefresher::scheduleRefresh(PropRefreshBits prop) {
                 }
             }
 
-            if (m_propsTripped & REFRESH_WINDOW_STATES) {
-                Desktop::Rule::ruleEngine()->updateAllRules();
+    if (m_propsTripped & REFRESH_WINDOW_STATES) {
+        Desktop::Rule::ruleEngine()->updateAllRules();
 
-                for (const auto& ws : State::workspaceState()->workspaces()) {
-                    if (!ws)
-                        continue;
+        for (const auto& ws : State::workspaceState()->workspaces()) {
+            if (!ws)
+                continue;
 
-                    ws->updateWindows();
-                    ws->updateWindowData();
-                    ws->updateWindowDecos();
-                }
+            ws->updateWindows();
+            ws->updateWindowData();
+            ws->updateWindowDecos();
+        }
 
-                g_pCompositor->updateAllWindowsAnimatedDecorationValues();
+        g_pCompositor->updateAllWindowsAnimatedDecorationValues();
 
-                for (auto const& m : State::monitorState()->monitors()) {
-                    if (!m)
-                        continue;
+        for (auto const& m : State::monitorState()->monitors()) {
+            if (!m)
+                continue;
 
                     m->m_forceFullFrames = 2;
                     g_pHyprRenderer->damageMonitor(m);
@@ -88,48 +107,45 @@ void CPropRefresher::scheduleRefresh(PropRefreshBits prop) {
                 }
             }
 
-            if (m_propsTripped & REFRESH_MONITOR_STATES) {
-                Config::monitorRuleMgr()->scheduleReload();
-                Config::monitorRuleMgr()->ensureVRR();
+    if (m_propsTripped & REFRESH_MONITOR_STATES) {
+        Config::monitorRuleMgr()->scheduleReload();
+        Config::monitorRuleMgr()->ensureVRR();
 
-                for (const auto& m : State::monitorState()->monitors()) {
-                    if (!m)
-                        continue;
+        for (const auto& m : State::monitorState()->monitors()) {
+            if (!m)
+                continue;
 
-                    g_layoutManager->recalculateMonitor(m, );
-                }
+            g_layoutManager->recalculateMonitor(m);
+        }
 
-                State::workspacePlacementController()->ensurePersistentWorkspacesPresent(
-                    nullptr, [](PHLWORKSPACE ws, PHLMONITOR mon, bool noWarp) { g_pCompositor->moveWorkspaceToMonitor(ws, mon, noWarp); });
-            }
-
-            if (m_propsTripped & REFRESH_LAYOUTS) {
-                Layout::Supplementary::algoMatcher()->updateWorkspaceLayouts();
-
-                for (auto const& m : State::monitorState()->monitors()) {
-                    g_layoutManager->recalculateMonitor(m);
-                    g_pHyprRenderer->damageMonitor(m);
-                }
-            }
-
-            if (m_propsTripped & REFRESH_CURSOR_ZOOMS) {
-                for (auto const& m : State::monitorState()->monitors()) {
-                    *(m->m_cursorZoom) = *PZOOMFACTOR;
-                    if (m->m_activeWorkspace)
-                        m->m_activeWorkspace->m_space->recalculate();
-                }
-            }
-
-            if (m_propsTripped & REFRESH_CONFIG_WATCHER)
-                Config::watcher()->update();
-
-            if (m_propsTripped & REFRESH_GRADIENTS_GROUPBAR)
-                refreshGroupBarGradients();
-
-            m_scheduled    = false;
-            m_propsTripped = 0;
-        });
-
-        m_scheduled = true;
+        State::workspacePlacementController()->ensurePersistentWorkspacesPresent(
+            nullptr, [](PHLWORKSPACE ws, PHLMONITOR mon, bool noWarp) { g_pCompositor->moveWorkspaceToMonitor(ws, mon, noWarp); });
     }
+
+    if (m_propsTripped & REFRESH_LAYOUTS) {
+        Layout::Supplementary::algoMatcher()->updateWorkspaceLayouts();
+
+        for (auto const& m : State::monitorState()->monitors()) {
+            g_layoutManager->recalculateMonitor(m);
+            g_pHyprRenderer->damageMonitor(m);
+        }
+    }
+
+    if (m_propsTripped & REFRESH_CURSOR_ZOOMS) {
+        for (auto const& m : State::monitorState()->monitors()) {
+            *(m->m_cursorZoom) = *PZOOMFACTOR;
+            if (m->m_activeWorkspace)
+                m->m_activeWorkspace->m_space->recalculate();
+        }
+    }
+
+    if (m_propsTripped & REFRESH_CONFIG_WATCHER)
+        Config::watcher()->update();
+
+    if (m_propsTripped & REFRESH_GRADIENTS_GROUPBAR)
+        refreshGroupBarGradients();
+
+    m_scheduled           = false;
+    m_scheduledRefreshSeq = 0;
+    m_propsTripped        = 0;
 }

--- a/src/config/supplementary/propRefresher/PropRefresher.cpp
+++ b/src/config/supplementary/propRefresher/PropRefresher.cpp
@@ -96,7 +96,7 @@ void CPropRefresher::scheduleRefresh(PropRefreshBits prop) {
                     if (!m)
                         continue;
 
-                    g_layoutManager->recalculateMonitor(m, Layout::CLayoutManager::RECALCULATE_MONITOR_REASON_PROP_REFRESH);
+                    g_layoutManager->recalculateMonitor(m, );
                 }
 
                 State::workspacePlacementController()->ensurePersistentWorkspacesPresent(
@@ -107,7 +107,7 @@ void CPropRefresher::scheduleRefresh(PropRefreshBits prop) {
                 Layout::Supplementary::algoMatcher()->updateWorkspaceLayouts();
 
                 for (auto const& m : State::monitorState()->monitors()) {
-                    g_layoutManager->recalculateMonitor(m, Layout::CLayoutManager::RECALCULATE_MONITOR_REASON_PROP_REFRESH);
+                    g_layoutManager->recalculateMonitor(m);
                     g_pHyprRenderer->damageMonitor(m);
                 }
             }

--- a/src/config/supplementary/propRefresher/PropRefresher.cpp
+++ b/src/config/supplementary/propRefresher/PropRefresher.cpp
@@ -69,21 +69,21 @@ void CPropRefresher::refreshProp(const bool execdAsScheduled) {
             if (!m)
                 continue;
 
-                    m->m_forceFullFrames = 2;
-                    m->scheduleFrame();
-                }
-            }
+            m->m_forceFullFrames = 2;
+            m->scheduleFrame();
+        }
+    }
 
     if (m_propsTripped & REFRESH_BLUR_FB) {
         for (auto const& m : State::monitorState()->monitors()) {
             if (!m)
                 continue;
 
-                    m->m_blurFBDirty     = true;
-                    m->m_forceFullFrames = 2;
-                    m->scheduleFrame();
-                }
-            }
+            m->m_blurFBDirty     = true;
+            m->m_forceFullFrames = 2;
+            m->scheduleFrame();
+        }
+    }
 
     if (m_propsTripped & REFRESH_WINDOW_STATES) {
         Desktop::Rule::ruleEngine()->updateAllRules();
@@ -103,11 +103,11 @@ void CPropRefresher::refreshProp(const bool execdAsScheduled) {
             if (!m)
                 continue;
 
-                    m->m_forceFullFrames = 2;
-                    g_pHyprRenderer->damageMonitor(m);
-                    m->scheduleFrame();
-                }
-            }
+            m->m_forceFullFrames = 2;
+            g_pHyprRenderer->damageMonitor(m);
+            m->scheduleFrame();
+        }
+    }
 
     if (m_propsTripped & REFRESH_MONITOR_STATES) {
         Config::monitorRuleMgr()->scheduleReload();

--- a/src/config/supplementary/propRefresher/PropRefresher.cpp
+++ b/src/config/supplementary/propRefresher/PropRefresher.cpp
@@ -15,6 +15,7 @@
 
 #include "../../shared/monitor/MonitorRuleManager.hpp"
 #include "../../shared/inotify/ConfigWatcher.hpp"
+#include "../../../event/EventBus.hpp"
 
 using namespace Config;
 using namespace Config::Supplementary;
@@ -32,24 +33,25 @@ void CPropRefresher::scheduleRefresh(PropRefreshBits prop) {
         m_scheduledRefreshSeq = g_pEventLoopManager->doLater([this, weak = WP<CPropRefresher>{refresher()}] {
             if (!weak)
                 return;
-            refreshProp();
+            refreshProp(true);
         });
 
         m_scheduled = true;
     }
 }
 
-void CPropRefresher::executeScheduledRefreshImmediately() {
+int CPropRefresher::executeScheduledRefreshImmediately() {
 
     if (!m_scheduled || m_scheduledRefreshSeq == 0)
-        return;
+        return 1;
 
     g_pEventLoopManager->removeDoLater(m_scheduledRefreshSeq);
     // m_scheduledRefreshSeq must be reset back to 0 during refreshProp() call
-    refreshProp();
+    refreshProp(false);
+    return 0;
 }
 
-void CPropRefresher::refreshProp() {
+void CPropRefresher::refreshProp(const bool execdAsScheduled) {
 
     static auto PZOOMFACTOR = CConfigValue<Config::FLOAT>("cursor:zoom_factor");
 
@@ -148,4 +150,6 @@ void CPropRefresher::refreshProp() {
     m_scheduled           = false;
     m_scheduledRefreshSeq = 0;
     m_propsTripped        = 0;
+
+    Event::bus()->m_events.config.props_refreshed.emit(execdAsScheduled);
 }

--- a/src/config/supplementary/propRefresher/PropRefresher.hpp
+++ b/src/config/supplementary/propRefresher/PropRefresher.hpp
@@ -26,13 +26,13 @@ namespace Config::Supplementary {
     class CPropRefresher {
       public:
         void scheduleRefresh(PropRefreshBits reason);
-        void executeScheduledRefreshImmediately();
+        int  executeScheduledRefreshImmediately();
 
       private:
-        void            refreshProp();
+        void            refreshProp(const bool execdAsScheduled);
 
         bool            m_scheduled           = false;
-        uint64_t        m_scheduledRefreshSeq = 0; // 0 if non refresh event scheduled
+        uint64_t        m_scheduledRefreshSeq = 0; // 0 if no refresh event scheduled
         PropRefreshBits m_propsTripped        = 0;
     };
 

--- a/src/config/supplementary/propRefresher/PropRefresher.hpp
+++ b/src/config/supplementary/propRefresher/PropRefresher.hpp
@@ -26,10 +26,14 @@ namespace Config::Supplementary {
     class CPropRefresher {
       public:
         void scheduleRefresh(PropRefreshBits reason);
+        void executeScheduledRefreshImmediately();
 
       private:
-        bool            m_scheduled    = false;
-        PropRefreshBits m_propsTripped = 0;
+        void            refreshProp();
+
+        bool            m_scheduled           = false;
+        uint64_t        m_scheduledRefreshSeq = 0; // 0 if non refresh event scheduled
+        PropRefreshBits m_propsTripped        = 0;
     };
 
     UP<CPropRefresher>& refresher();

--- a/src/event/EventBus.hpp
+++ b/src/event/EventBus.hpp
@@ -165,8 +165,9 @@ namespace Event {
             } workspace;
 
             struct {
-                Event<> preReload;
-                Event<> reloaded;
+                Event<>           preReload;
+                Event<>           reloaded;
+                Event<const bool> props_refreshed;
             } config;
 
             struct {

--- a/src/layout/LayoutManager.hpp
+++ b/src/layout/LayoutManager.hpp
@@ -52,7 +52,6 @@ namespace Layout {
 
         enum eRecalculateMonitorReason : uint8_t {
             RECALCULATE_MONITOR_REASON_UNKNOWN, // when the recalculate monitor reason is unknown or not important to preserve
-            RECALCULATE_MONITOR_REASON_PROP_REFRESH,
             RECALCULATE_MONITOR_REASON_WORKSPACE_CHANGE,
             RECALCULATE_MONITOR_REASON_TOGGLE_SPECIAL_WORKSPACE,
             RECALCULATE_MONITOR_REASON_TOGGLE_FULLSCREEN,

--- a/src/layout/space/Space.cpp
+++ b/src/layout/space/Space.cpp
@@ -32,7 +32,7 @@ CSpace::CSpace(PHLWORKSPACE parent) : m_parent(parent) {
         recheckWorkArea();
 
         if (m_algorithm)
-            m_algorithm->recalculate(RECALCULATE_REASON_CREATE_SPACE);
+            m_algorithm->recalculate();
     });
 }
 
@@ -219,9 +219,9 @@ SP<ITarget> CSpace::getNextCandidate(SP<ITarget> old) {
 }
 
 bool Layout::isHardRecalculateReason(eRecalculateReason reason) {
-    return reason != RECALCULATE_REASON_CREATE_SPACE && reason != RECALCULATE_REASON_PROP_REFRESH && reason != RECALCULATE_REASON_WORKSPACE_CHANGE &&
-        reason != RECALCULATE_REASON_SPECIAL_WORKSPACE_TOGGLE && reason != RECALCULATE_REASON_TOGGLE_LAYOUT_HANDLED_FULLSCREEN &&
-        reason != RECALCULATE_REASON_TOGGLE_DEFAULT_HANDLED_FULLSCREEN && reason != RECALCULATE_REASON_INVALIDATE_MONITOR_GEOMETRIES && reason != RECALCULATE_REASON_RENDER_MOINTOR;
+    return reason != RECALCULATE_REASON_WORKSPACE_CHANGE && reason != RECALCULATE_REASON_SPECIAL_WORKSPACE_TOGGLE &&
+        reason != RECALCULATE_REASON_TOGGLE_LAYOUT_HANDLED_FULLSCREEN && reason != RECALCULATE_REASON_TOGGLE_DEFAULT_HANDLED_FULLSCREEN &&
+        reason != RECALCULATE_REASON_INVALIDATE_MONITOR_GEOMETRIES && reason != RECALCULATE_REASON_RENDER_MOINTOR;
 }
 
 const std::vector<WP<ITarget>>& CSpace::targets() const {
@@ -234,7 +234,6 @@ eRecalculateReason Layout::recalcMonitorReasonToRecalcReason(CLayoutManager::eRe
         case CLayoutManager::RECALCULATE_MONITOR_REASON_TOGGLE_SPECIAL_WORKSPACE: return RECALCULATE_REASON_SPECIAL_WORKSPACE_TOGGLE;
         case CLayoutManager::RECALCULATE_MONITOR_REASON_WORKSPACE_CHANGE: return RECALCULATE_REASON_WORKSPACE_CHANGE;
         case CLayoutManager::RECALCULATE_MONITOR_REASON_TOGGLE_FULLSCREEN: return RECALCULATE_REASON_TOGGLE_DEFAULT_HANDLED_FULLSCREEN;
-        case CLayoutManager::RECALCULATE_MONITOR_REASON_PROP_REFRESH: return RECALCULATE_REASON_PROP_REFRESH;
         default: return RECALCULATE_REASON_UNKNOWN;
     }
 }

--- a/src/layout/space/Space.hpp
+++ b/src/layout/space/Space.hpp
@@ -15,8 +15,6 @@ namespace Layout {
 
     enum eRecalculateReason : uint8_t {
         RECALCULATE_REASON_UNKNOWN, // when the recalculate reason is unknown or not important to preserve
-        RECALCULATE_REASON_PROP_REFRESH,
-        RECALCULATE_REASON_CREATE_SPACE,
         RECALCULATE_REASON_WORKSPACE_CHANGE,
         RECALCULATE_REASON_SPECIAL_WORKSPACE_TOGGLE,
         RECALCULATE_REASON_TOGGLE_DEFAULT_HANDLED_FULLSCREEN,


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?


- Implement a lua helper function to execute a scheduled prop refresher immediately. If it's not executed immediately, it goes on to execute as scheduled

- Add an event for prop refresh execution. every time it is executed, this event is emitted. The information about if the event was executed as a result of "executed before schedule)" or "executed as scheduled" is passed to the used in the lua event.


This fixes the problem of not refreshing states when an action that requires it (workspace rule) but instead waits until the end of that function (i.e. all events of that function have already executed) to refresh states.

Example:


```lua

hl.bind(mainMod .. " + A", function ()

    local currentWorkspace = hl.get_active_workspace()

    hl.workspace_rule({
    workspace = currentWorkspace.name,
    gaps_in = 5,
    gaps_out = 5
    })


    hl.dispatch(hl.dsp.layout("focus right"))

end)
```

In this function, it is expected that the workspace rule will apply first, then we will focus on the column on the right (scrolling layout).

In reality, what happens is that the refresh event is queued, then we focus on the column on the right, and only then does the refresh event execute and apply the workspace rule. i.e: instead of workspaceRule -> focus right, what happened was focus right -> workspaceRule

practically: this makes the viewport move happen using the old gaps values, and with the updates gaps values the viewport move is not done properly (there's empty space on the right if the old gaps were < 5, and the column on the right isn't fully in view if gaps were > 5)



- This also makes https://github.com/hyprwm/Hyprland/pull/14594 redundant and undesirable, since that PR was a patch to try and fix unwanted scrolling viewport changes. With this change, it's trivial to inhibit scrolling correctly


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No


#### Is it ready for merging, or does it need work?

WIP

TODO

- [x] some non-`return 0` condition for helper function.

- [x] Add event. Save info on if it was executed immediately or as scheduled.

- [x] Wiki MR for the helper func and event. Also explain how prop refresh scheduling works and possible consequences of it