### PR TITLE
layout/scrolling: add new layoutmsg: `fit_into_view`

### DIFF
--- a/hyprtester/src/tests/main/scroll.cpp
+++ b/hyprtester/src/tests/main/scroll.cpp
@@ -1121,6 +1121,38 @@ TEST_CASE(testScrollInhibitor) {
     }
 }
 
+TEST_CASE(layoutmsg_fit_into_view) {
+
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling' } })"));
+
+    // ensure variables are correctly set for the test
+    OK(getFromSocket("/eval hl.config({scrolling = {follow_focus = false}})"));
+
+    if (!Tests::spawnKitty("a")) {
+        FAIL_TEST("Could not spawn kitty with win class `a`");
+        return;
+    }
+
+    OK(getFromSocket("/dispatch hl.dsp.layout('colresize 0.8')"));
+
+    if (!Tests::spawnKitty("b")) {
+        FAIL_TEST("Could not spawn kitty with win class `b`");
+        return;
+    }
+
+    // class:a column is now off screen to the left
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:a' })"));
+
+    // fit class:a window into view
+
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit_into_view')"));
+
+    // If it worked, class:a window must now have at: ~= 0,0 -- 0,0 + gaps, border = 22,22.
+
+    ASSERT_CONTAINS(Tests::getAttribute(getFromSocket("/activewindow"), "at"), "22,22");
+}
+
 TEST_CASE(layoutRuleExpand) {
     // set current layout to scrolling
     OK(getFromSocket(

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -1979,7 +1979,24 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
         // Explicit Enable
         else
             inhibitScroll();
-    } else
+    } else if (ARGS[0] == "fit_into_view") {
+        // makes the currently active column complately visible
+
+        const auto PWINDOW = Desktop::focusState()->window();
+
+        if (!PWINDOW)
+            return noTarget("no focused window");
+
+        const auto WDATA = dataFor(PWINDOW->layoutTarget());
+
+        if (!WDATA || m_scrollingData->columns.size() == 0)
+            return stateErr("can't fit: no window or columns");
+
+        m_scrollingData->SScrollingData::centerOrFitCol(WDATA->column.lock());
+        m_scrollingData->recalculate();
+    }
+
+    else
         return invalidArg("no such layoutmsg for scrolling");
 
     return {};


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?


- Adds new layoutmsg: `fit_into_view`

This fits the currently active column fully into view. If it's already fully in view, does nothing.


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

no

#### Is it ready for merging, or does it need work?

Ready

- [x] Wiki MR

- [x] Add test

