### PR TITLE
gestures: fix live cursorZoom anchoring to a mid-animation value

### DIFF
--- a/src/managers/input/trackpad/gestures/CursorZoomGesture.cpp
+++ b/src/managers/input/trackpad/gestures/CursorZoomGesture.cpp
@@ -30,7 +30,7 @@ void CCursorZoomTrackpadGesture::begin(const ITrackpadGesture::STrackpadGestureB
         if (!PMONITOR)
             return;
 
-        m_zoomBegin = std::clamp(PMONITOR->m_cursorZoom->value(), 1.0F, 100.0F);
+        m_zoomBegin = std::clamp(PMONITOR->m_cursorZoom->goal(), 1.0F, 100.0F);
         PMONITOR->m_cursorZoom->setValueAndWarp(m_zoomBegin);
         PMONITOR->m_zoomController.pinAnchor(g_pInputManager->getMouseCoordsInternal() - PMONITOR->m_position);
         return;


### PR DESCRIPTION
### Problem


`live` cursorZoom captures its starting zoom from `m_cursorZoom->value()` in `begin`, the current interpolated animation frame. If a pinch starts mid-animation the gesture anchors to a timing-dependent value.

### Solution

Reads `m_cursorZoom->goal()` instead.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

n/a

#### Is it ready for merging, or does it need work?

r4r.