### PR TITLE
gestures: clamp toggle cursorZoom like mult and live

### DIFF
--- a/src/managers/input/trackpad/gestures/CursorZoomGesture.cpp
+++ b/src/managers/input/trackpad/gestures/CursorZoomGesture.cpp
@@ -43,7 +43,7 @@ void CCursorZoomTrackpadGesture::begin(const ITrackpadGesture::STrackpadGestureB
         switch (m_mode) {
             case MODE_TOGGLE:
                 static auto PZOOMFACTOR = CConfigValue<Config::FLOAT>("cursor:zoom_factor");
-                *m->m_cursorZoom        = m_zoomed ? m_zoomValue : *PZOOMFACTOR;
+                *m->m_cursorZoom        = std::clamp(m_zoomed ? m_zoomValue : *PZOOMFACTOR, 1.0F, 100.0F);
                 break;
             case MODE_MULT: *m->m_cursorZoom = std::clamp(m->m_cursorZoom->goal() * m_zoomValue, 1.0F, 100.0F); break;
             case MODE_LIVE: break;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

I noticed that `toggle`-mode `cursorZoom` writes `zoom_level` to `m_cursorZoom`
with no clamp, so e.g. `zoom_level = 300` sets an unusable 300x zoom.

This PR clamps the toggle write to `[1, 100]`, matching [`mult` and `live`](https://github.com/hyprwm/Hyprland/blob/ef9b62356dd01579ee0ea9921afe471fbcb9aa0a/src/managers/input/trackpad/gestures/CursorZoomGesture.cpp#L48-L62),
which already clamp to that range.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

n/a. however it would be nice to have this refactored out to perhaps reduce magic numbers?

#### Is it ready for merging, or does it need work?

r4r.