### PR TITLE
gestures: fix toggle cursorZoom sharing a single on/off flag

### DIFF
--- a/src/managers/input/trackpad/gestures/CursorZoomGesture.hpp
+++ b/src/managers/input/trackpad/gestures/CursorZoomGesture.hpp
@@ -14,10 +14,10 @@ class CCursorZoomTrackpadGesture : public ITrackpadGesture {
     virtual void end(const ITrackpadGesture::STrackpadGestureEnd& e);
 
   private:
-    float              m_zoomValue = 1.0;
-    inline static bool m_zoomed    = false;
-    PHLMONITORREF      m_monitor;
-    float              m_zoomBegin = 1.0;
+    float         m_zoomValue = 1.0;
+    bool          m_zoomed    = false;
+    PHLMONITORREF m_monitor;
+    float         m_zoomBegin = 1.0;
 
     enum eMode : uint8_t {
         MODE_TOGGLE = 0,


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

While working with zoom, I bound 3-finger pinch to toggle a 2x magnifier, zoomed in to read something, tweaked my config, saved, re-loaded, and the magnifier dropped to 1x. . pinching to zoom did nothing; I had to pinch a *second* time.

This is because the `toggle` on/off flag `m_zoomed` is `static` so it survived the reload still remembering "on" while the zoom itself got reset to off.

Fix: make `m_zoomed` mot static.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

n/a

#### Is it ready for merging, or does it need work?

r4r.
