### PR TITLE
config/windowrules: allow requiring multiple tags in window rules

### DIFF
--- a/src/config/lua/bindings/LuaBindingsConfigRules.cpp
+++ b/src/config/lua/bindings/LuaBindingsConfigRules.cpp
@@ -1112,8 +1112,21 @@ static int hlWindowRule(lua_State* L) {
                     matchVal = std::to_string(lua_tointeger(L, -1));
                 else if (lua_isstring(L, -1))
                     matchVal = lua_tostring(L, -1);
-                else {
-                    self->addError(std::format("{}: hl.window_rule: match value for '{}' must be string, bool, or number", sourceInfo, matchKey));
+                else if (lua_istable(L, -1) && matchKey == "tag") {
+                    int         tblIdx = lua_gettop(L);
+                    std::string combined;
+                    lua_pushnil(L);
+                    while (lua_next(L, tblIdx) != 0) {
+                        if (lua_isstring(L, -1)) {
+                            if (!combined.empty())
+                                combined += " + ";
+                            combined += lua_tostring(L, -1);
+                        }
+                        lua_pop(L, 1);
+                    }
+                    matchVal = combined;
+                } else {
+                    self->addError(std::format("{}: hl.window_rule: match value for '{}' must be string, bool, number, or table of strings", sourceInfo, matchKey));
                     lua_pop(L, 1);
                     continue;
                 }

--- a/src/desktop/rule/matchEngine/TagMatchEngine.cpp
+++ b/src/desktop/rule/matchEngine/TagMatchEngine.cpp
@@ -1,13 +1,26 @@
 #include "TagMatchEngine.hpp"
 #include "../../../helpers/TagKeeper.hpp"
+#include <hyprutils/string/String.hpp>
+#include <hyprutils/string/VarList2.hpp>
 #include <string>
 
 using namespace Desktop::Rule;
 
-CTagMatchEngine::CTagMatchEngine(const std::string& tag) : m_tag(tag) {
-    ;
+CTagMatchEngine::CTagMatchEngine(const std::string& tag) {
+    Hyprutils::String::CVarList2 tagsList(tag, 0, '+', true);
+    for (const auto& t : tagsList) {
+        m_tags.emplace_back(Hyprutils::String::trim(t));
+    }
 }
 
 bool CTagMatchEngine::match(const CTagKeeper& keeper) {
-    return keeper.isTagged(m_tag);
+    if (m_tags.empty())
+        return false;
+
+    for (const auto& tag : m_tags) {
+        if (!keeper.isTagged(tag))
+            return false;
+    }
+
+    return true;
 }

--- a/src/desktop/rule/matchEngine/TagMatchEngine.hpp
+++ b/src/desktop/rule/matchEngine/TagMatchEngine.hpp
@@ -2,6 +2,7 @@
 
 #include "MatchEngine.hpp"
 #include <string>
+#include <vector>
 
 namespace Desktop::Rule {
     class CTagMatchEngine : public IMatchEngine {
@@ -12,6 +13,6 @@ namespace Desktop::Rule {
         virtual bool match(const CTagKeeper& keeper);
 
       private:
-        std::string m_tag;
+        std::vector<std::string> m_tags;
     };
 }

--- a/tests/desktop/rule/matchEngine/TagMatchEngine.cpp
+++ b/tests/desktop/rule/matchEngine/TagMatchEngine.cpp
@@ -66,3 +66,30 @@ TEST(TagMatchEngine, tagRemoval) {
     CTagMatchEngine engine("myTag");
     EXPECT_FALSE(engine.match(keeper));
 }
+
+TEST(TagMatchEngine, matchesMultipleTags) {
+    CTagKeeper keeper;
+    keeper.applyTag("tag1");
+    keeper.applyTag("tag2");
+
+    CTagMatchEngine engine("tag1 + tag2");
+    EXPECT_TRUE(engine.match(keeper));
+
+    CTagMatchEngine engineWhitespace("  tag1   +    tag2  ");
+    EXPECT_TRUE(engineWhitespace.match(keeper));
+
+    CTagMatchEngine missingOne("tag1 + tag3");
+    EXPECT_FALSE(missingOne.match(keeper));
+}
+
+TEST(TagMatchEngine, multipleTagsNegative) {
+    CTagKeeper keeper;
+    keeper.applyTag("tag1");
+    keeper.applyTag("tag2");
+
+    CTagMatchEngine engineNegative("tag1 + negative:tag3");
+    EXPECT_TRUE(engineNegative.match(keeper));
+
+    CTagMatchEngine engineNegativeFail("tag1 + negative:tag2");
+    EXPECT_FALSE(engineNegativeFail.match(keeper));
+}


### PR DESCRIPTION
Describe your PR, what does it fix/add?

Allow requiring multiple tags for window rules (e.g. `tag = tag1 + tag2`).
This is done by splitting the tag rule match string by `+`, trimming whitespace around each tag, and checking that all required tags are present. Also added Unit tests to verify multiple tag matching behavior and integration with negative matching.

Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

Is it ready for merging, or does it need work?

Ready.

Fixes #14970 