### PR TITLE
input: fix missing a pointer frame after absolute pointer motion

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -165,6 +165,8 @@ void CInputManager::onMouseWarp(IPointer::SMotionAbsoluteEvent e) {
 
     m_lastInputTouch  = false;
     m_lastInputTablet = false;
+
+    g_pSeatManager->sendPointerFrame();
 }
 
 void CInputManager::simulateMouseMovement() {


### PR DESCRIPTION
Send a pointer frame after absolute pointer motion.

`onMouseMoved()` already sends a pointer frame after *relative* motion. `onMouseWarp()` can also send pointer motion to clients via `mouseMoveUnified()`, but did not flush it with `wl_pointer.frame`. This can leave Wayland clients waiting to apply hover state until another framed pointer event, such as button or axis input.

This affects virtual-pointer absolute motion users, such as Sunshine remote desktop cursor-position updates.
