### PR TITLE
groups: add groupbar disable_when_only option

### DIFF
--- a/hyprtester/src/tests/main/groups.cpp
+++ b/hyprtester/src/tests/main/groups.cpp
@@ -109,7 +109,15 @@ TEST_CASE(groups) {
 
     // disable the groupbar for ease of testing for now
     NLog::log("{}Disable groupbar", Colors::YELLOW);
-    OK(getFromSocket("r/eval hl.config({ group = { groupbar = { enabled = 0 } } })"));
+    OK(getFromSocket("/eval hl.config({ group = { groupbar = { enabled = 0 } } })"));
+
+    // check the height of the window now
+    NLog::log("{}Recheck kitty dimensions", Colors::YELLOW);
+    {
+        auto str = getFromSocket("/clients");
+        EXPECT_CONTAINS(str, "at: 22,22");
+        EXPECT_CONTAINS(str, "size: 1876,1036");
+    }
 
     // kill all
     NLog::log("{}Kill windows", Colors::YELLOW);

--- a/hyprtester/src/tests/main/groups.cpp
+++ b/hyprtester/src/tests/main/groups.cpp
@@ -647,3 +647,75 @@ TEST_CASE(groupsLuaApiFullscreen) {
     Tests::killAllWindows();
     ASSERT(Tests::windowCount(), 0);
 }
+
+TEST_CASE(groups_disable_when_only) {
+    ASSERT(Tests::windowCount(), 0);
+
+    NLog::log("{}Testing disable_when_only ", Colors::YELLOW);
+    auto kittyA = Tests::spawnKitty("kittyA");
+    if (!kittyA) {
+        FAIL_TEST("Could not spawn kitty");
+    }
+    ASSERT(Tests::windowCount(), 1);
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:kittyA' })"));
+
+    // check kitty properties. One kitty should take the entire screen, minus the gaps.
+    NLog::log("{}Check kittyA dimensions", Colors::YELLOW);
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_COUNT_STRING(str, "at: 22,22", 1);
+        EXPECT_COUNT_STRING(str, "size: 1876,1036", 1);
+    }
+
+    OK(getFromSocket("/dispatch hl.dsp.group.toggle()"));
+    OK(getFromSocket("/eval hl.config({ group = { groupbar = { disable_when_only = true } } })"));
+
+    // check kittyA properties. groupbar should be hidden due to disable_when_only
+    NLog::log("{}Check kittyA dimensions", Colors::YELLOW);
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_COUNT_STRING(str, "at: 22,22", 1);
+        EXPECT_COUNT_STRING(str, "size: 1876,1036", 1);
+    }
+
+    auto kittyB = Tests::spawnKitty("kittyB");
+    if (!kittyB) {
+        FAIL_TEST("Could not spawn kitty");
+    }
+    ASSERT(Tests::windowCount(), 2);
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:kittyB' })"));
+
+    // check kittyB properties. groupbar is visible
+    NLog::log("{}Check kittyB dimensions", Colors::YELLOW);
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_CONTAINS(str, "at: 22,43");
+        EXPECT_COUNT_STRING(str, "size: 1876,1015", 1);
+    }
+
+    OK(getFromSocket("/dispatch hl.dsp.window.kill()"));
+    Tests::waitUntilWindowsN(1);
+    ASSERT(Tests::windowCount(), 1);
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:kittyA' })"));
+
+    // check kittyA properties. groupbar should be hidden due to disable_when_only
+    NLog::log("{}Check kittyA dimensions", Colors::YELLOW);
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_COUNT_STRING(str, "at: 22,22", 1);
+        EXPECT_COUNT_STRING(str, "size: 1876,1036", 1);
+    }
+
+    OK(getFromSocket("/eval hl.config({ group = { groupbar = { disable_when_only = false } } })"));
+
+    // check kittyA properties. groupbar should be visible due to disable_when_only == false
+    NLog::log("{}Check kittyA dimensions", Colors::YELLOW);
+    {
+        auto str = getFromSocket("/activewindow");
+        EXPECT_COUNT_STRING(str, "at: 22,43", 1);
+        EXPECT_COUNT_STRING(str, "size: 1876,1015", 1);
+    }
+
+    Tests::killAllWindows();
+    ASSERT(Tests::windowCount(), 0);
+}

--- a/src/config/supplementary/propRefresher/PropRefresher.cpp
+++ b/src/config/supplementary/propRefresher/PropRefresher.cpp
@@ -89,6 +89,9 @@ void CPropRefresher::refreshProp(const bool execdAsScheduled) {
     if (m_propsTripped & REFRESH_WINDOW_STATES) {
         Desktop::Rule::ruleEngine()->updateAllRules();
 
+        for (auto const& w : Desktop::windowState()->windows())
+            w->uncacheWindowDecos();
+
         for (const auto& ws : State::workspaceState()->workspaces()) {
             if (!ws)
                 continue;

--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -434,6 +434,7 @@ std::vector<SP<IValue>> Values::getConfigValues() {
          */
 
         MS<Bool>("group:groupbar:enabled", "enables groupbars", true),
+        MS<Bool>("group:groupbar:disable_when_only", "disable if contains single window. Considered only if enabled == true", false),
         MS<String>("group:groupbar:font_family", "font used to display groupbar titles", "[[EMPTY]]"),
         MS<FontWeight>("group:groupbar:font_weight_active", "weight of the font used to display active groupbar titles"),
         MS<FontWeight>("group:groupbar:font_weight_inactive", "weight of the font used to display inactive groupbar titles"),

--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -433,8 +433,9 @@ std::vector<SP<IValue>> Values::getConfigValues() {
          * group:groupbar:
          */
 
-        MS<Bool>("group:groupbar:enabled", "enables groupbars", true),
-        MS<Bool>("group:groupbar:disable_when_only", "disable if contains single window. Considered only if enabled == true", false),
+        MS<Bool>("group:groupbar:enabled", "enables groupbars", true, {.refresh = Supplementary::REFRESH_WINDOW_STATES}),
+        MS<Bool>("group:groupbar:disable_when_only", "disable if contains single window. Considered only if enabled == true", false,
+                 {.refresh = Supplementary::REFRESH_WINDOW_STATES}),
         MS<String>("group:groupbar:font_family", "font used to display groupbar titles", "[[EMPTY]]"),
         MS<FontWeight>("group:groupbar:font_weight_active", "weight of the font used to display active groupbar titles"),
         MS<FontWeight>("group:groupbar:font_weight_inactive", "weight of the font used to display inactive groupbar titles"),

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -101,8 +101,10 @@ void CHyprGroupBarDecoration::draw(PHLMONITOR pMonitor, float const& a) {
 
     const bool VISIBLE = visible();
 
-    if (VISIBLE != m_bLastVisibilityStatus)
+    if (!m_bLastVisibilityStatus.has_value() || VISIBLE != *m_bLastVisibilityStatus) {
         g_pDecorationPositioner->repositionDeco(this);
+        m_bLastVisibilityStatus = VISIBLE;
+    }
 
     if (!VISIBLE)
         return;

--- a/src/render/decorations/CHyprGroupBarDecoration.cpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.cpp
@@ -25,8 +25,8 @@ static SP<ITexture> m_tGradientLockedInactive;
 constexpr int       BAR_TEXT_PAD = 2;
 
 CHyprGroupBarDecoration::CHyprGroupBarDecoration(PHLWINDOW pWindow) : IHyprWindowDecoration(pWindow), m_window(pWindow) {
-    static auto PGRADIENTS = CConfigValue<Config::INTEGER>("group:groupbar:enabled");
-    static auto PENABLED   = CConfigValue<Config::INTEGER>("group:groupbar:gradients");
+    static auto PENABLED   = CConfigValue<Config::INTEGER>("group:groupbar:enabled");
+    static auto PGRADIENTS = CConfigValue<Config::INTEGER>("group:groupbar:gradients");
 
     if (*PENABLED && *PGRADIENTS)
         refreshGroupBarGradients();
@@ -353,8 +353,8 @@ static SP<ITexture> renderGradient(Config::CGradientValueData* grad) {
 }
 
 void refreshGroupBarGradients() {
-    static auto PGRADIENTS = CConfigValue<Config::INTEGER>("group:groupbar:enabled");
-    static auto PENABLED   = CConfigValue<Config::INTEGER>("group:groupbar:gradients");
+    static auto PENABLED   = CConfigValue<Config::BOOL>("group:groupbar:enabled");
+    static auto PGRADIENTS = CConfigValue<Config::BOOL>("group:groupbar:gradients");
 
     static auto PGROUPCOLACTIVE         = CConfigValue<Config::IComplexConfigValue>("group:groupbar:col.active");
     static auto PGROUPCOLINACTIVE       = CConfigValue<Config::IComplexConfigValue>("group:groupbar:col.inactive");
@@ -535,6 +535,7 @@ CBox CHyprGroupBarDecoration::assignedBoxGlobal() {
 }
 
 bool CHyprGroupBarDecoration::visible() {
-    static auto PENABLED = CConfigValue<Config::INTEGER>("group:groupbar:enabled");
-    return *PENABLED && m_window->m_ruleApplicator->decorate().valueOrDefault();
+    static auto PENABLED = CConfigValue<Config::BOOL>("group:groupbar:enabled");
+    static auto PDISABLE = CConfigValue<Config::BOOL>("group:groupbar:disable_when_only");
+    return *PENABLED && (!*PDISABLE || m_dwGroupMembers.size() > 1) && m_window->m_ruleApplicator->decorate().valueOrDefault();
 }

--- a/src/render/decorations/CHyprGroupBarDecoration.hpp
+++ b/src/render/decorations/CHyprGroupBarDecoration.hpp
@@ -58,7 +58,7 @@ class CHyprGroupBarDecoration : public IHyprWindowDecoration {
     float                     m_barWidth;
     float                     m_barHeight;
 
-    bool                      m_bLastVisibilityStatus = true;
+    std::optional<bool>       m_bLastVisibilityStatus;
 
     CTitleTex*                textureFromTitle(const std::string&);
     void                      invalidateTextures();


### PR DESCRIPTION
#### group:groupbar:disable_when_only

Option allow to hide groupbar if it contains only single window.
This is especially useful with rule:
```lua
-- any window will be opened in group
hl.window_rule({ match = { title = ".*" }, group = "set" })
```

#### Possible issues

- option was added looking at `group:groupbar:enable`, but in `refreshGroupBarGradients` there is no availible active group to properly check option `disable_when_only`
  I think this check unnecessary here because same scenario already exist when there is no windows with groupbar, but option `enabled == true`. But unsure - require review.
- new hyprtest is unstable for some reason. Sometimes fail, and sometimes succeed. Maybe this is related to error "(EE) failed to read Wayland events: Broken pipe" which printed in stdout when I launched hyprtest. Anyway, I tested it in practice - launching Hyprland with this patch as single window manager - and feature works well.

#### Is it ready for merging, or does it need work?

First of all it is need an approve - do we need such feature at all. Then - I tried my best to do this PR as possible as ready for merge. But I'm open for critique and suggestions.

---

wiki PR - hyprwm/hyprland-wiki#1551


