### PR TITLE
Avoid multiple instances of static variables being created in CLogger::log()

### DIFF
--- a/src/debug/log/Logger.cpp
+++ b/src/debug/log/Logger.cpp
@@ -7,19 +7,15 @@
 
 using namespace Log;
 
-CLogger::CLogger() {
-    const auto IS_TRACE = Env::isTrace();
-    m_logger.setLogLevel(IS_TRACE ? Hyprutils::CLI::LOG_TRACE : Hyprutils::CLI::LOG_DEBUG);
+CLogger::CLogger() : m_isTrace(Env::isTrace()) {
+    m_logger.setLogLevel(m_isTrace ? Hyprutils::CLI::LOG_TRACE : Hyprutils::CLI::LOG_DEBUG);
 }
 
 void CLogger::log(Hyprutils::CLI::eLogLevel level, const std::string_view& str) {
-
-    static bool TRACE = Env::isTrace();
-
     if (!m_logsEnabled)
         return;
 
-    if (level == Hyprutils::CLI::LOG_TRACE && !TRACE)
+    if (level == Hyprutils::CLI::LOG_TRACE && !m_isTrace)
         return;
 
     if (SRollingLogFollow::get().isRunning())

--- a/src/debug/log/Logger.hpp
+++ b/src/debug/log/Logger.hpp
@@ -19,12 +19,10 @@ namespace Log {
         template <typename... Args>
         //NOLINTNEXTLINE
         void log(Hyprutils::CLI::eLogLevel level, std::format_string<Args...> fmt, Args&&... args) {
-            static bool TRACE = Env::isTrace();
-
             if (!m_logsEnabled)
                 return;
 
-            if (level == Hyprutils::CLI::LOG_TRACE && !TRACE)
+            if (level == Hyprutils::CLI::LOG_TRACE && !m_isTrace)
                 return;
 
             std::string logMsg = "";
@@ -47,6 +45,7 @@ namespace Log {
 
         Hyprutils::CLI::CLogger m_logger;
         bool                    m_logsEnabled = true;
+        bool                    m_isTrace     = false;
     };
 
     inline UP<CLogger> logger = makeUnique<CLogger>();


### PR DESCRIPTION
Multiple instances of `static bool TRACE` existed because static variables inside template functions are created per template instantiation.