### PR TITLE
monitor: fix null deref in present listener on suspend/resume

### DIFF
--- a/src/helpers/Monitor.cpp
+++ b/src/helpers/Monitor.cpp
@@ -164,7 +164,8 @@ void CMonitor::onConnect(bool noRule) {
         auto mon = m_self.lock();
         if (!isMirror() && !g_pHyprRenderer->shouldRenderMonitor(mon)) {
             auto const NOW = Time::steadyNow();
-            g_pHyprRenderer->sendFrameEventsToWorkspace(mon, m_activeWorkspace, NOW);
+            if (m_activeWorkspace)
+                g_pHyprRenderer->sendFrameEventsToWorkspace(mon, m_activeWorkspace, NOW);
             if (m_activeSpecialWorkspace)
                 g_pHyprRenderer->sendFrameEventsToWorkspace(mon, m_activeSpecialWorkspace, NOW);
         }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2494,6 +2494,8 @@ void IHyprRenderer::renderWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace
 }
 
 void IHyprRenderer::sendFrameEventsToWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& now) {
+    if (!pWorkspace)
+        return;
     for (const auto& view : Desktop::View::getViewsForWorkspace(pWorkspace)) {
         if (!view->aliveAndVisible())
             continue;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

I notice hyprland occasionally crash after suspend/resume.
```
#0  0x00007f34ab09a29c in ??? () at /usr/lib/libc.so.6
#1  0x00007f34ab03e7d0 in raise () at /usr/lib/libc.so.6
#2  0x00007f34ab025681 in abort () at /usr/lib/libc.so.6
#3  0x000055c2255b4412 in handleUnrecoverableSignal(int) ()
#4  0x00007f34ab03e8f0 in <signal handler called> () at /usr/lib/libc.so.6
#5  0x000055c225d0b65e in Desktop::View::getViewsForWorkspace(Hyprutils::Memory::CSharedPointer<CWorkspace>) ()
#6  0x000055c225bc1f5f in Render::IHyprRenderer::sendFrameEventsToWorkspace(Hyprutils::Memory::CSharedPointer<CMonitor>, Hyprutils::Memory::CSharedPointer<CWorkspace
>, std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > > const&) ()
#7  0x000055c2257b6e01 in std::_Function_handler<void (Aquamarine::IOutput::SPresentEvent), CMonitor::onConnect(bool)::{lambda(Aquamarine::IOutput::SPresentEvent con
st&)#1}>::_M_invoke(std::_Any_data const&, Aquamarine::IOutput::SPresentEvent&&) ()
#8  0x000055c2257d1cfa in std::_Function_handler<void (void*), Hyprutils::Signal::CSignalT<Aquamarine::IOutput::SPresentEvent>::mkHandler(std::function<void (Aquamar
ine::IOutput::SPresentEvent)>)::{lambda(void*)#1}>::_M_invoke(std::_Any_data const&, void*&&) ()
#9  0x00007f34ad7f6e8d in Hyprutils::Signal::CSignalListener::emitInternal(void*) () at /usr/lib/libhyprutils.so.12
#10 0x00007f34ad7f7353 in Hyprutils::Signal::CSignalBase::emitInternal(void*) () at /usr/lib/libhyprutils.so.12
#11 0x00007f34ad8da19a in Aquamarine::CHeadlessOutput::commit() () at /usr/lib/libaquamarine.so.11
#12 0x000055c2257cda00 in CMonitor::applyMonitorRule(Config::CMonitorRule&&, bool) ()
#13 0x000055c2257c9b4c in CMonitor::onConnect(bool) ()
#14 0x000055c2255c0a2f in CCompositor::enterUnsafeState() ()
#15 0x000055c2257c7f61 in CMonitor::onDisconnect(bool) ()
#16 0x000055c2257c8690 in std::_Function_handler<void (), CMonitor::onConnect(bool)::{lambda()#6}>::_M_invoke(std::_Any_data const&) ()
#17 0x00007f34ad7f6e8d in Hyprutils::Signal::CSignalListener::emitInternal(void*) () at /usr/lib/libhyprutils.so.12
#18 0x00007f34ad7f7353 in Hyprutils::Signal::CSignalBase::emitInternal(void*) () at /usr/lib/libhyprutils.so.12
#19 0x00007f34ad910615 in Aquamarine::SDRMConnector::disconnect() () at /usr/lib/libaquamarine.so.11
#20 0x00007f34ad90b532 in Aquamarine::CDRMBackend::recheckOutputs() () at /usr/lib/libaquamarine.so.11
#21 0x00007f34ad9028d1 in Aquamarine::CDRMBackend::restoreAfterVT() () at /usr/lib/libaquamarine.so.11
#22 0x00007f34ad7f6e8d in Hyprutils::Signal::CSignalListener::emitInternal(void*) () at /usr/lib/libhyprutils.so.12
#23 0x00007f34ad7f7353 in Hyprutils::Signal::CSignalBase::emitInternal(void*) () at /usr/lib/libhyprutils.so.12
#24 0x00007f34ac8a4ce6 in ??? () at /usr/lib/libseat.so.1
#25 0x00007f34ac8a72f8 in ??? () at /usr/lib/libseat.so.1
#26 0x00007f34ad8e1c69 in Aquamarine::CSession::dispatchLibseatEvents() () at /usr/lib/libaquamarine.so.11
#27 0x000055c2259092d6 in aquamarineFDWrite(int, unsigned int, void*) ()
#28 0x00007f34ad6af3d2 in wl_event_loop_dispatch () at /usr/lib/libwayland-server.so.0
#29 0x00007f34ad6b1567 in wl_display_run () at /usr/lib/libwayland-server.so.0
#30 0x000055c22590c4b9 in CEventLoopManager::enterLoop() ()
#31 0x000055c22547b10e in main ()
```

The present listener introduced in 558936e2 calls
sendFrameEventsToWorkspace with m_activeWorkspace without null-checking it.
During resume, restoring the VT disconnects the real DRM monitor and
enterUnsafeState() re-enables the headless fallback. Its onConnect()
commits the headless state before setupDefaultWS() runs, so the present
event synchronously fires with m_activeWorkspace still null, crashing in
getViewsForWorkspace().

Guard the call site (matching the m_activeSpecialWorkspace check) and
add a defensive null check in sendFrameEventsToWorkspace itself for the
other call site in renderMonitor().

AI-assisted: opencode + minimax m3

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
