### PR TITLE
hyprctl: add interactive Lua REPL mode

### DIFF
--- a/hyprctl/CMakeLists.txt
+++ b/hyprctl/CMakeLists.txt
@@ -5,7 +5,7 @@ project(
     DESCRIPTION "Control utility for Hyprland"
 )
 
-pkg_check_modules(hyprctl_deps REQUIRED IMPORTED_TARGET hyprutils>=0.2.4 hyprwire re2)
+pkg_check_modules(hyprctl_deps REQUIRED IMPORTED_TARGET hyprutils>=0.2.4 hyprwire re2 readline)
 
 file(GLOB_RECURSE HYPRCTL_SRCFILES CONFIGURE_DEPENDS "src/*.cpp" "hw-protocols/*.cpp" "include/*.hpp")
 

--- a/hyprctl/src/Strings.hpp
+++ b/hyprctl/src/Strings.hpp
@@ -19,7 +19,7 @@ commands:
     dismissnotify [amount] → Dismisses all or up to AMOUNT notifications
     dispatch <dispatcher> [args] → Issue a dispatch to call a keybind
                           dispatcher with arguments
-    eval <code>         → Issue a Lua string to execute and return the result
+    eval <code>         → Issue a Lua string to execute
     getoption <option>  → Gets the config option status (values)
     globalshortcuts     → Lists all global shortcuts
     hyprpaper ...       → Issue a hyprpaper request
@@ -42,7 +42,8 @@ commands:
     plugin ...          → Issue a plugin request
     reload [config-only] → Issue a reload to force reload the config. Pass
                           'config-only' to disable monitor reload
-    repl                → Enter interactive Lua REPL mode (^D to exit)
+    repl [code]         → Enter interactive Lua REPL mode (^D to exit)
+                          or issue a Lua string and print the result
     rollinglog          → Prints tail of the log. Also supports -f/--follow
                           option
     setcursor <theme> <size> → Sets the cursor theme and reloads the cursor

--- a/hyprctl/src/Strings.hpp
+++ b/hyprctl/src/Strings.hpp
@@ -19,6 +19,7 @@ commands:
     dismissnotify [amount] → Dismisses all or up to AMOUNT notifications
     dispatch <dispatcher> [args] → Issue a dispatch to call a keybind
                           dispatcher with arguments
+    eval <code>         → Issue a Lua string to execute and return the result
     getoption <option>  → Gets the config option status (values)
     globalshortcuts     → Lists all global shortcuts
     hyprpaper ...       → Issue a hyprpaper request
@@ -41,6 +42,7 @@ commands:
     plugin ...          → Issue a plugin request
     reload [config-only] → Issue a reload to force reload the config. Pass
                           'config-only' to disable monitor reload
+    repl                → Enter interactive Lua REPL mode (^D to exit)
     rollinglog          → Prints tail of the log. Also supports -f/--follow
                           option
     setcursor <theme> <size> → Sets the cursor theme and reloads the cursor

--- a/hyprctl/src/main.cpp
+++ b/hyprctl/src/main.cpp
@@ -33,6 +33,9 @@ using namespace Hyprutils::Memory;
 #include "Strings.hpp"
 #include "hyprpaper/Hyprpaper.hpp"
 
+#include <readline/readline.h>
+#include <readline/history.h>
+
 std::string instanceSignature;
 bool        quiet = false;
 
@@ -532,7 +535,17 @@ int main(int argc, char** argv) {
         std::println("{}", USAGE);
     else if (fullRequest.contains("/rollinglog") && needRoll)
         exitStatus = request(fullRequest, 0, true);
-    else {
+    else if (fullRequest.contains("/repl")) {
+        char* input = nullptr;
+        while ((input = readline("> ")) != nullptr) {
+            std::string line(input);
+            if (!line.empty()) {
+                exitStatus = request("/eval " + line);
+                add_history(input);
+            }
+            free(input);
+        }
+    } else {
         exitStatus = request(fullRequest);
     }
 

--- a/hyprctl/src/main.cpp
+++ b/hyprctl/src/main.cpp
@@ -255,6 +255,9 @@ int request(std::string_view arg, int minArgs = 0, bool needRoll = false) {
 
     log(reply);
 
+    if (reply.starts_with("error:"))
+        return 7;
+
     return 0;
 }
 

--- a/hyprctl/src/main.cpp
+++ b/hyprctl/src/main.cpp
@@ -539,14 +539,20 @@ int main(int argc, char** argv) {
     else if (fullRequest.contains("/rollinglog") && needRoll)
         exitStatus = request(fullRequest, 0, true);
     else if (fullRequest.contains("/repl")) {
-        char* input = nullptr;
-        while ((input = readline("> ")) != nullptr) {
-            std::string line(input);
-            if (!line.empty()) {
-                exitStatus = request("/eval " + line);
-                add_history(input);
+        if (ARGS.size() > 1) {
+            // single command with output
+            exitStatus = request(fullRequest, 1);
+        } else {
+            // interactive REPL mode
+            char* input = nullptr;
+            while ((input = readline("> ")) != nullptr) {
+                std::string line(input);
+                if (!line.empty()) {
+                    exitStatus = request("/repl " + line);
+                    add_history(input);
+                }
+                free(input);
             }
-            free(input);
         }
     } else {
         exitStatus = request(fullRequest);

--- a/hyprtester/src/tests/main/hyprctl.cpp
+++ b/hyprtester/src/tests/main/hyprctl.cpp
@@ -171,3 +171,8 @@ TEST_CASE(hyprctlJsonErrors) {
     jqProc.runSync();
     EXPECT(jqProc.exitCode(), 0);
 }
+
+TEST_CASE(hyprctlREPL) {
+    EXPECT(getCommandStdOut("hyprctl repl 'print(type(hl))'"), "table");
+    EXPECT(getCommandStdOut("hyprctl eval 'print(type(hl))'"), "ok");
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -58,6 +58,7 @@
   commit,
   revCount,
   date,
+  readline,
   # deprecated flags
   enableNvidiaPatches ? false,
   nvidiaPatches ? false,
@@ -204,6 +205,7 @@ customStdenv.mkDerivation (finalAttrs: {
       wayland
       wayland-protocols
       wayland-scanner
+      readline
     ]
     (optionals customStdenv.hostPlatform.isBSD [ epoll-shim ])
     (optionals customStdenv.hostPlatform.isMusl [ libexecinfo ])

--- a/src/config/lua/ConfigManager.cpp
+++ b/src/config/lua/ConfigManager.cpp
@@ -623,17 +623,30 @@ std::optional<std::string> CConfigManager::eval(const std::string& code) {
     m_isEvaluating = true;
 
     Hyprutils::Utils::CScopeGuard x([this] { m_isEvaluating = false; });
-
-    if (luaL_loadstring(m_lua, code.c_str()) != LUA_OK) {
-        std::string err = lua_tostring(m_lua, -1);
+    if (luaL_loadstring(m_lua, code.starts_with("return") ? code.c_str() : std::format("return {};", code).c_str()) != LUA_OK) {
         lua_pop(m_lua, 1);
-        return std::format("error: {}", err);
+        if (luaL_loadstring(m_lua, code.c_str()) != LUA_OK) {
+            std::string err = lua_tostring(m_lua, -1);
+            lua_pop(m_lua, 1);
+            return std::format("error: {}", err);
+        }
     }
 
-    if (guardedPCall(0, 0, 0, LUA_TIMEOUT_EVAL_MS, "hyprctl eval") != LUA_OK) {
+    if (guardedPCall(0, LUA_MULTRET, 0, LUA_TIMEOUT_EVAL_MS, "hyprctl eval") != LUA_OK) {
         std::string err = lua_tostring(m_lua, -1);
         lua_pop(m_lua, 1);
         return std::format("error: {}", err);
+    } else if (lua_gettop(m_lua) > 0) {
+        int nstack = lua_gettop(m_lua);
+        std::string ret;
+        for (int i = 1; i <= nstack; ++i) {
+            if (i > 1)
+                ret += "\t";
+            ret += std::string(luaL_tolstring(m_lua, i, NULL));
+            lua_pop(m_lua, 1);
+        }
+        lua_pop(m_lua, nstack);
+        return ret;
     }
 
     if (!m_errors.empty() || !m_evalIssues.empty()) {

--- a/src/config/lua/ConfigManager.cpp
+++ b/src/config/lua/ConfigManager.cpp
@@ -361,6 +361,33 @@ void CConfigManager::reinitLuaState() {
         2);
     lua_rawseti(m_lua, -2, 2); // replace package.searchers[2]
     lua_pop(m_lua, 2);         // pop searchers, package
+
+    // hook print function to print to hyprctl eval/repl instead
+    lua_getglobal(m_lua, "print");
+    lua_pushcclosure(
+        m_lua,
+        [](lua_State* L) -> int {
+            auto* mgr    = CConfigManager::fromLuaState(L);
+            int   nstack = lua_gettop(L);
+            if (!mgr->isEvaluating()) {
+                // call original print function from upvalue if not eval
+                lua_pushvalue(L, lua_upvalueindex(1));
+                lua_insert(L, 1);
+                lua_call(L, nstack, LUA_MULTRET);
+            } else {
+                std::string out;
+                for (int i = 1; i <= nstack; ++i) {
+                    out += std::format("{}\t", luaL_tolstring(L, i, nullptr));
+                    lua_pop(L, 1);
+                }
+                lua_pop(L, nstack);
+                out.pop_back();
+                mgr->m_prints.emplace_back(out);
+            }
+            return 0;
+        },
+        1);
+    lua_setglobal(m_lua, "print");
 }
 
 void CConfigManager::init() {
@@ -620,6 +647,7 @@ std::optional<std::string> CConfigManager::eval(const std::string& code) {
 
     m_errors.clear();
     m_evalIssues.clear();
+    m_prints.clear();
     m_isEvaluating = true;
 
     Hyprutils::Utils::CScopeGuard x([this] { m_isEvaluating = false; });
@@ -637,16 +665,24 @@ std::optional<std::string> CConfigManager::eval(const std::string& code) {
         lua_pop(m_lua, 1);
         return std::format("error: {}", err);
     } else if (lua_gettop(m_lua) > 0) {
-        int nstack = lua_gettop(m_lua);
-        std::string ret;
+        // print returned values to repl
+        int         nstack = lua_gettop(m_lua);
+        std::string out;
         for (int i = 1; i <= nstack; ++i) {
-            if (i > 1)
-                ret += "\t";
-            ret += std::string(luaL_tolstring(m_lua, i, NULL));
+            out += std::format("{}\t", luaL_tolstring(m_lua, i, nullptr));
             lua_pop(m_lua, 1);
         }
         lua_pop(m_lua, nstack);
-        return ret;
+        out.pop_back();
+        m_prints.emplace_back(out);
+    }
+
+    if (!m_prints.empty()) {
+        std::string out;
+        for (auto& line : m_prints)
+            out += std::format("{}\n", line);
+        out.pop_back();
+        return out;
     }
 
     if (!m_errors.empty() || !m_evalIssues.empty()) {
@@ -671,6 +707,7 @@ std::optional<std::string> CConfigManager::eval(const std::string& code) {
 
     m_errors.clear();
     m_evalIssues.clear();
+    m_prints.clear();
 
     return std::nullopt;
 }
@@ -1093,6 +1130,10 @@ void CConfigManager::clearHeldLuaRefs() {
 
 bool CConfigManager::isDynamicParse() const {
     return !m_isParsingConfig || m_isEvaluating;
+}
+
+bool CConfigManager::isEvaluating() const {
+    return m_isEvaluating;
 }
 
 void CConfigManager::reregisterLuaPluginFns() {

--- a/src/config/lua/ConfigManager.cpp
+++ b/src/config/lua/ConfigManager.cpp
@@ -362,15 +362,15 @@ void CConfigManager::reinitLuaState() {
     lua_rawseti(m_lua, -2, 2); // replace package.searchers[2]
     lua_pop(m_lua, 2);         // pop searchers, package
 
-    // hook print function to print to hyprctl eval/repl instead
+    // hook print function to print to hyprctl repl instead
     lua_getglobal(m_lua, "print");
     lua_pushcclosure(
         m_lua,
         [](lua_State* L) -> int {
             auto* mgr    = CConfigManager::fromLuaState(L);
             int   nstack = lua_gettop(L);
-            if (!mgr->isEvaluating()) {
-                // call original print function from upvalue if not eval
+            if (!mgr->isREPL()) {
+                // call original print function from upvalue if not repl
                 lua_pushvalue(L, lua_upvalueindex(1));
                 lua_insert(L, 1);
                 lua_call(L, nstack, LUA_MULTRET);
@@ -641,7 +641,7 @@ void CConfigManager::addEvalIssue(const Config::SConfigError& err) {
         m_evalIssues.emplace_back(err);
 }
 
-std::optional<std::string> CConfigManager::eval(const std::string& code) {
+std::optional<std::string> CConfigManager::eval(const std::string& code, bool repl) {
     if (!m_lua)
         return "error: lua state not initialized";
 
@@ -649,8 +649,12 @@ std::optional<std::string> CConfigManager::eval(const std::string& code) {
     m_evalIssues.clear();
     m_prints.clear();
     m_isEvaluating = true;
+    m_isREPL       = repl;
 
-    Hyprutils::Utils::CScopeGuard x([this] { m_isEvaluating = false; });
+    Hyprutils::Utils::CScopeGuard x([this] {
+        m_isEvaluating = false;
+        m_isREPL       = false;
+    });
     if (luaL_loadstring(m_lua, code.starts_with("return") ? code.c_str() : std::format("return {};", code).c_str()) != LUA_OK) {
         lua_pop(m_lua, 1);
         if (luaL_loadstring(m_lua, code.c_str()) != LUA_OK) {
@@ -677,7 +681,7 @@ std::optional<std::string> CConfigManager::eval(const std::string& code) {
         m_prints.emplace_back(out);
     }
 
-    if (!m_prints.empty()) {
+    if (!m_prints.empty() && repl) {
         std::string out;
         for (auto& line : m_prints)
             out += std::format("{}\n", line);
@@ -1132,8 +1136,8 @@ bool CConfigManager::isDynamicParse() const {
     return !m_isParsingConfig || m_isEvaluating;
 }
 
-bool CConfigManager::isEvaluating() const {
-    return m_isEvaluating;
+bool CConfigManager::isREPL() const {
+    return m_isREPL;
 }
 
 void CConfigManager::reregisterLuaPluginFns() {

--- a/src/config/lua/ConfigManager.hpp
+++ b/src/config/lua/ConfigManager.hpp
@@ -113,6 +113,7 @@ namespace Config::Lua {
 
         bool                       isFirstLaunch() const;
         bool                       isDynamicParse() const;
+        bool                       isEvaluating() const;
 
         std::string                m_currentSubmap;
         std::string                m_currentSubmapReset;
@@ -136,7 +137,7 @@ namespace Config::Lua {
         };
 
         std::unordered_map<std::string, SDeviceConfig> m_deviceConfigs;
-        std::vector<std::string>                       m_errors, m_configPaths;
+        std::vector<std::string>                       m_errors, m_configPaths, m_prints;
         std::vector<Config::SConfigError>              m_evalIssues;
 
         // named window/layer rules for merge-on-redeclaration

--- a/src/config/lua/ConfigManager.hpp
+++ b/src/config/lua/ConfigManager.hpp
@@ -96,7 +96,7 @@ namespace Config::Lua {
         std::expected<void, std::string>         registerLuaLayoutProvider(std::string name, lua_State* L, int providerTableIdx);
 
         // execute an arbitrary lua string on the current state.
-        std::optional<std::string> eval(const std::string& code);
+        std::optional<std::string> eval(const std::string& code, bool repl = false);
 
         int                        guardedPCall(int nargs, int nresults, int errfunc, int timeoutMs, std::string_view context);
 
@@ -113,7 +113,7 @@ namespace Config::Lua {
 
         bool                       isFirstLaunch() const;
         bool                       isDynamicParse() const;
-        bool                       isEvaluating() const;
+        bool                       isREPL() const;
 
         std::string                m_currentSubmap;
         std::string                m_currentSubmapReset;
@@ -168,6 +168,7 @@ namespace Config::Lua {
         bool                                         m_watchdogActive                      = false;
         bool                                         m_isParsingConfig                     = false;
         bool                                         m_isEvaluating                        = false;
+        bool                                         m_isREPL                              = false;
 
         std::chrono::steady_clock::time_point        m_watchdogDeadline;
         std::string                                  m_watchdogContext;

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1097,7 +1097,7 @@ static std::string evalRequest(eHyprCtlOutputFormat format, std::string request)
     // strip the command name ("eval ") from the request
     auto code = request.substr(request.find_first_of(' ') + 1);
 
-    auto err = luaMgr->eval(code);
+    auto err = luaMgr->eval(code, request.starts_with("repl "));
     if (err)
         return *err;
 
@@ -2020,7 +2020,7 @@ CHyprCtl::CHyprCtl() {
     registerCommand(SHyprCtlCommand{"decorations", false, decorationRequest});
     registerCommand(SHyprCtlCommand{"[[BATCH]]", false, dispatchBatch});
     registerCommand(SHyprCtlCommand{"eval", false, evalRequest});
-
+    registerCommand(SHyprCtlCommand{"repl", false, evalRequest});
     startHyprCtlSocket();
 }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Adds interactive Lua REPL mode and better eval to hyprctl. Old eval only prints errors or "ok", this is not very useful.

- `hyprctl repl` with no arguments starts a readline loop, end with ^D
- `hyprctl repl 'lua code'` works like eval but prints anything returned through tostring
- `print()` is also hooked so anything printed during repl prints to hyprctl
- added exit status if output is an error

```sh
~  hyprctl eval 'hl.version()'
ok
~  hyprctl repl 'hl.version()'
0.55.0
~  hyprctl repl 'balls'
nil
~  hyprctl repl 'balls()'
error: [string "return balls();"]:1: attempt to call a nil value (global 'balls')
~  hyprctl repl                                                                                                                                          ✘ 7 
> hl.version()
0.55.0
> print("is hooked")
is hooked
> 1,2,3
1	2	3
> inspect(hl.dsp.workspace)
{
  move = <function 1>,
  rename = <function 2>,
  swap_monitors = <function 3>,
  toggle_special = <function 4>
}
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

- Didn't want to break "ok" support since all tests and probably other scripts depend on it
- Similar but not as sophisticated as Luas own repl
  - Tries to put "return" in front of everything and tests if that's valid. This is how `lua` does it too.
  - Tabulates multiple return values
  - Doesn't support incomplete multiline input though, maybe later
- Not a Lua stack expert yet, hopefully it's right

#### Is it ready for merging, or does it need work?

Ready. https://github.com/hyprwm/hyprland-wiki/pull/1557