### PR TITLE
renderer: fix SEGV on monitor disconnect

### DIFF
--- a/src/desktop/view/GlobalViewMethods.cpp
+++ b/src/desktop/view/GlobalViewMethods.cpp
@@ -17,6 +17,9 @@ using namespace Desktop::View;
 std::vector<SP<IView>> View::getViewsForWorkspace(PHLWORKSPACE ws) {
     std::vector<SP<IView>> views;
 
+    if (!ws)
+        return views;
+
     for (const auto& w : g_pCompositor->m_windows) {
         if (!w->aliveAndVisible() || w->m_workspace != ws)
             continue;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2192,7 +2192,8 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
             }
         }
     } else if (!pMonitor->isMirror()) {
-        sendFrameEventsToWorkspace(pMonitor, pMonitor->m_activeWorkspace, NOW);
+        if (pMonitor->m_activeWorkspace)
+            sendFrameEventsToWorkspace(pMonitor, pMonitor->m_activeWorkspace, NOW);
         if (pMonitor->m_activeSpecialWorkspace)
             sendFrameEventsToWorkspace(pMonitor, pMonitor->m_activeSpecialWorkspace, NOW);
     }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

adds null check in `View::getViewsFor Workspace` and guards the `m_activeWorkspace` frame events call, preventing a SEGV when a monitor disconnects hwile a frame event is pending. when a DP monitor drops its link (dpms off, suspend/resume), `m_activeWorkspace` can be null while a queued drm frame event still fires and `renderMonitor` passes it unconditionally to `sendFrameEventsToWorkspace`, handing it to `getViewsForWorkspace` where `ws->m_monitor` derefs null.

reproduces reliably on a 3x DP setup with `hyprctl dispatch dpms off`

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

backtrace is from the release package build (caught in normal use); i can produce a debug-build trace if needed, but the deref is visible from the trace + code. null workspace tick becomes a no-op which seems right.

#### Is it ready for merging, or does it need work?

ready; tested through dpms off/on cycles and suspend/resume on the affected setup and works fine now

[hyprlandCrashReport75844.txt](https://github.com/user-attachments/files/28777227/hyprlandCrashReport75844.txt)

