### PR TITLE
binds/submap: fix mouse binds

### DIFF
--- a/hyprtester/src/tests/main/keybinds.cpp
+++ b/hyprtester/src/tests/main/keybinds.cpp
@@ -18,6 +18,10 @@ static std::string pluginScrollCmd(int delta) {
     return "/eval hl.plugin.test.scroll(" + std::to_string(delta) + ")";
 }
 
+static std::string pluginClickCmd(bool pressed, uint32_t button) {
+    return "/eval hl.plugin.test.click(" + std::to_string(button) + ", " + std::to_string(pressed ? 1 : 0) + ")";
+}
+
 // Because i don't feel like changing someone elses code.
 enum eKeyboardModifierIndex : uint8_t {
     MOD_SHIFT = 1,
@@ -480,6 +484,33 @@ SUBTEST(submap) {
     Tests::killAllWindows();
 }
 
+SUBTEST(submapMouseBinds) {
+    // regression #14856: scroll / mouse-button binds in a non-default submap stopped firing
+    NLog::log("{}Testing mouse binds inside a submap", Colors::GREEN);
+
+    EXPECT(checkFlag(), false);
+    EXPECT(getFromSocket("r/eval hl.config({ binds = { scroll_event_delay = 0 } })"), "ok");
+
+    // enter submap1 (SUPER+U); release with mods cleared so the modless mouse binds match
+    getFromSocket(pluginKeybindCmd(true, 7, 30));
+    getFromSocket(pluginKeybindCmd(false, 0, 30));
+    EXPECT_CONTAINS(getFromSocket("/submap"), "submap1");
+
+    // scroll
+    OK(getFromSocket(pluginScrollCmd(120)));
+    EXPECT(attemptCheckFlag(20, 50), true);
+
+    // mouse-button
+    OK(getFromSocket(pluginClickCmd(true, BTN_LEFT)));
+    OK(getFromSocket(pluginClickCmd(false, BTN_LEFT)));
+    EXPECT(attemptCheckFlag(20, 50), true);
+
+    // reset to default submap
+    getFromSocket(pluginKeybindCmd(true, 0, 33));
+    getFromSocket(pluginKeybindCmd(false, 0, 33));
+    EXPECT_CONTAINS(getFromSocket("/submap"), "default");
+}
+
 SUBTEST(bindsAfterScroll) {
     NLog::log("{}Testing binds after scroll", Colors::GREEN);
 
@@ -608,6 +639,7 @@ TEST_CASE(keybinds) {
     CALL_SUBTEST(shortcutRepeat);
     CALL_SUBTEST(shortcutRepeatKeyRelease);
     CALL_SUBTEST(submap);
+    CALL_SUBTEST(submapMouseBinds);
     CALL_SUBTEST(submapUniversal);
     CALL_SUBTEST(bindsAfterScroll);
     CALL_SUBTEST(perDeviceKeybind);

--- a/hyprtester/test.lua
+++ b/hyprtester/test.lua
@@ -205,6 +205,8 @@ hl.define_submap("submap1", function()
     hl.bind("i", hl.dsp.submap("submap3"))
     hl.bind("o", hl.dsp.exec_cmd(terminal))
     hl.bind("p", hl.dsp.submap("reset"))
+    hl.bind("mouse_down", hl.dsp.exec_cmd("touch /tmp/hyprtester-keybinds.txt"))
+    hl.bind("mouse:272", hl.dsp.exec_cmd("touch /tmp/hyprtester-keybinds.txt"))
 end)
 
 hl.define_submap("submap2", "submap1", function()

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -361,7 +361,7 @@ bool CKeybindManager::onKeyEvent(std::any event, SP<IKeyboard> pKeyboard) {
         .keycode            = KEYCODE,
         .modmaskAtPressTime = MODS,
         .sent               = true,
-        .submapAtPress      = SSubmap{.name = Config::Actions::state()->m_currentSubmap},
+        .submapAtPress      = getCurrentSubmap(),
         .mousePosAtPress    = g_pInputManager->getMouseCoordsInternal(),
     };
 
@@ -426,14 +426,14 @@ bool CKeybindManager::onAxisEvent(const IPointer::SAxisEvent& e, SP<IPointer> po
     bool found = false;
     if (e.source == WL_POINTER_AXIS_SOURCE_WHEEL && e.axis == WL_POINTER_AXIS_VERTICAL_SCROLL) {
         if (e.delta > 0)
-            found = !handleKeybinds(MODS, SPressedKeyWithMods{.keyName = "mouse_down"}, true, nullptr, pointer).passEvent;
+            found = !handleKeybinds(MODS, SPressedKeyWithMods{.keyName = "mouse_down", .submapAtPress = getCurrentSubmap()}, true, nullptr, pointer).passEvent;
         else
-            found = !handleKeybinds(MODS, SPressedKeyWithMods{.keyName = "mouse_up"}, true, nullptr, pointer).passEvent;
+            found = !handleKeybinds(MODS, SPressedKeyWithMods{.keyName = "mouse_up", .submapAtPress = getCurrentSubmap()}, true, nullptr, pointer).passEvent;
     } else if (e.source == WL_POINTER_AXIS_SOURCE_WHEEL && e.axis == WL_POINTER_AXIS_HORIZONTAL_SCROLL) {
         if (e.delta < 0)
-            found = !handleKeybinds(MODS, SPressedKeyWithMods{.keyName = "mouse_left"}, true, nullptr, pointer).passEvent;
+            found = !handleKeybinds(MODS, SPressedKeyWithMods{.keyName = "mouse_left", .submapAtPress = getCurrentSubmap()}, true, nullptr, pointer).passEvent;
         else
-            found = !handleKeybinds(MODS, SPressedKeyWithMods{.keyName = "mouse_right"}, true, nullptr, pointer).passEvent;
+            found = !handleKeybinds(MODS, SPressedKeyWithMods{.keyName = "mouse_right", .submapAtPress = getCurrentSubmap()}, true, nullptr, pointer).passEvent;
     }
 
     if (found)
@@ -458,6 +458,7 @@ bool CKeybindManager::onMouseEvent(const IPointer::SButtonEvent& e, SP<IPointer>
     const auto KEY = SPressedKeyWithMods{
         .keyName            = KEY_NAME,
         .modmaskAtPressTime = MODS,
+        .submapAtPress      = getCurrentSubmap(),
         .mousePosAtPress    = g_pInputManager->getMouseCoordsInternal(),
     };
 
@@ -501,15 +502,15 @@ void CKeybindManager::resizeWithBorder(const IPointer::SButtonEvent& e) {
 }
 
 void CKeybindManager::onSwitchEvent(const std::string& switchName) {
-    handleKeybinds(0, SPressedKeyWithMods{.keyName = "switch:" + switchName}, true, nullptr, nullptr);
+    handleKeybinds(0, SPressedKeyWithMods{.keyName = "switch:" + switchName, .submapAtPress = getCurrentSubmap()}, true, nullptr, nullptr);
 }
 
 void CKeybindManager::onSwitchOnEvent(const std::string& switchName) {
-    handleKeybinds(0, SPressedKeyWithMods{.keyName = "switch:on:" + switchName}, true, nullptr, nullptr);
+    handleKeybinds(0, SPressedKeyWithMods{.keyName = "switch:on:" + switchName, .submapAtPress = getCurrentSubmap()}, true, nullptr, nullptr);
 }
 
 void CKeybindManager::onSwitchOffEvent(const std::string& switchName) {
-    handleKeybinds(0, SPressedKeyWithMods{.keyName = "switch:off:" + switchName}, true, nullptr, nullptr);
+    handleKeybinds(0, SPressedKeyWithMods{.keyName = "switch:off:" + switchName, .submapAtPress = getCurrentSubmap()}, true, nullptr, nullptr);
 }
 
 eMultiKeyCase CKeybindManager::mkKeysymSetMatches(const std::vector<KeybindKey>& keybindKeysyms, const std::set<KeybindKey>& pressedKeysyms) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Scroll, mouse and switch binds inside non default submap ( != "") stopped working after #14856 because submapAtPress was only set for the keyboard. Also reuses an already existing helper function instead of inline at 364.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No new logic. Tested locally.

#### Is it ready for merging, or does it need work?

Should be ready to merge.
