### PR TITLE
state/monitorQuery: implement monitor query, move logic off of Compositor

### DIFF
--- a/hyprtester/plugin/src/main.cpp
+++ b/hyprtester/plugin/src/main.cpp
@@ -16,6 +16,7 @@
 #include <src/desktop/view/LayerSurface.hpp>
 #include <src/Compositor.hpp>
 #include <src/desktop/state/FocusState.hpp>
+#include <src/state/MonitorState.hpp>
 #include <src/layout/LayoutManager.hpp>
 #undef private
 
@@ -251,7 +252,7 @@ static SDispatchResult expectCursorZoom(std::string in) {
             return {.success = false, .error = "invalid input"};
     }
 
-    const auto PMONITOR = g_pCompositor->getMonitorFromVector(g_pInputManager->getMouseCoordsInternal());
+    const auto PMONITOR = State::monitorState()->query().vec(g_pInputManager->getMouseCoordsInternal()).run();
 
     if (!PMONITOR)
         return {.success = false, .error = "No monitor under cursor"};

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -795,75 +795,6 @@ void CCompositor::startCompositor() {
     g_pEventLoopManager->enterLoop();
 }
 
-PHLMONITOR CCompositor::getMonitorFromID(const MONITORID& id) {
-    for (auto const& m : State::monitorState()->monitors()) {
-        if (m->m_id == id) {
-            return m;
-        }
-    }
-
-    return nullptr;
-}
-
-PHLMONITOR CCompositor::getMonitorFromName(const std::string& name) {
-    for (auto const& m : State::monitorState()->monitors()) {
-        if (m->m_name == name) {
-            return m;
-        }
-    }
-    return nullptr;
-}
-
-PHLMONITOR CCompositor::getMonitorFromDesc(const std::string& desc) {
-    for (auto const& m : State::monitorState()->monitors()) {
-        if (m->m_description.starts_with(desc))
-            return m;
-    }
-    return nullptr;
-}
-
-PHLMONITOR CCompositor::getMonitorFromCursor() {
-    return getMonitorFromVector(g_pPointerManager->position());
-}
-
-PHLMONITOR CCompositor::getMonitorFromVector(const Vector2D& point) {
-    if (State::monitorState()->monitors().empty()) {
-        Log::logger->log(Log::WARN, "getMonitorFromVector called with empty monitor list");
-        return nullptr;
-    }
-
-    PHLMONITOR mon;
-    for (auto const& m : State::monitorState()->monitors()) {
-        if (CBox{m->m_position, m->m_size}.containsPoint(point)) {
-            mon = m;
-            break;
-        }
-    }
-
-    if (!mon) {
-        float      bestDistance = 0.f;
-        PHLMONITOR pBestMon;
-
-        for (auto const& m : State::monitorState()->monitors()) {
-            float dist = vecToRectDistanceSquared(point, m->m_position, m->m_position + m->m_size);
-
-            if (dist < bestDistance || !pBestMon) {
-                bestDistance = dist;
-                pBestMon     = m;
-            }
-        }
-
-        if (!pBestMon) { // ?????
-            Log::logger->log(Log::WARN, "getMonitorFromVector no close mon???");
-            return State::monitorState()->monitors().front();
-        }
-
-        return pBestMon;
-    }
-
-    return mon;
-}
-
 void CCompositor::removeWindowFromVectorSafe(PHLWINDOW pWindow) {
     if (!pWindow->m_fadingOut) {
         Event::bus()->m_events.window.destroy.emit(pWindow);
@@ -873,12 +804,8 @@ void CCompositor::removeWindowFromVectorSafe(PHLWINDOW pWindow) {
     }
 }
 
-bool CCompositor::monitorExists(PHLMONITOR pMonitor) {
-    return std::ranges::any_of(State::monitorState()->allMonitors(), [&](const PHLMONITOR& m) { return m == pMonitor; });
-}
-
 PHLWINDOW CCompositor::vectorToWindowUnified(const Vector2D& pos, uint16_t properties, PHLWINDOW pIgnoreWindow) {
-    const auto PMONITOR = getMonitorFromVector(pos);
+    const auto PMONITOR = State::monitorState()->query().vec(pos).run();
     if (!PMONITOR)
         return nullptr;
 
@@ -1160,26 +1087,6 @@ Vector2D CCompositor::vectorToSurfaceLocal(const Vector2D& vec, PHLWINDOW pWindo
     return vec - pWindow->m_realPosition->goal() - std::get<1>(iterData) + Vector2D{geom.x, geom.y};
 }
 
-PHLMONITOR CCompositor::getMonitorFromOutput(SP<Aquamarine::IOutput> out) {
-    for (auto const& m : State::monitorState()->monitors()) {
-        if (m->m_output == out) {
-            return m;
-        }
-    }
-
-    return nullptr;
-}
-
-PHLMONITOR CCompositor::getRealMonitorFromOutput(SP<Aquamarine::IOutput> out) {
-    for (auto const& m : State::monitorState()->allMonitors()) {
-        if (m->m_output == out) {
-            return m;
-        }
-    }
-
-    return nullptr;
-}
-
 SP<CWLSurfaceResource> CCompositor::vectorToLayerPopupSurface(const Vector2D& pos, PHLMONITOR monitor, Vector2D* sCoords, PHLLS* ppLayerSurfaceFound) {
     for (auto const& lsl : monitor->m_layerSurfaceLayers | std::views::reverse) {
         for (auto const& ls : lsl | std::views::reverse) {
@@ -1378,7 +1285,7 @@ void CCompositor::cleanupFadingOut(const MONITORID& monid) {
 
         // mark blur for recalc
         if (ls->m_layer == ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND || ls->m_layer == ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM) {
-            auto mon = getMonitorFromID(monid);
+            auto mon = State::monitorState()->query().id(monid).run();
             if (mon)
                 mon->m_blurFBDirty = true;
         }
@@ -1745,7 +1652,7 @@ bool CCompositor::isPointOnAnyMonitor(const Vector2D& point) {
 }
 
 bool CCompositor::isPointOnReservedArea(const Vector2D& point, const PHLMONITOR pMonitor) {
-    const auto PMONITOR = pMonitor ? pMonitor : getMonitorFromVector(point);
+    const auto PMONITOR = pMonitor ? pMonitor : State::monitorState()->query().vec(point).run();
 
     auto       box = PMONITOR->logicalBox();
     if (VECNOTINRECT(point, box.x - 1, box.y - 1, box.x + box.w + 1, box.y + box.h + 1))
@@ -1771,73 +1678,6 @@ std::optional<CBox> CCompositor::calculateX11WorkArea() {
         box.scale(M->m_scale);
 
     return box.translate(M->m_xwaylandPosition);
-}
-
-PHLMONITOR CCompositor::getMonitorInDirection(Math::eDirection dir) {
-    return getMonitorInDirection(Desktop::focusState()->monitor(), dir);
-}
-
-PHLMONITOR CCompositor::getMonitorInDirection(PHLMONITOR pSourceMonitor, Math::eDirection dir) {
-    if (!pSourceMonitor)
-        return nullptr;
-
-    const auto POSA  = pSourceMonitor->m_position;
-    const auto SIZEA = pSourceMonitor->m_size;
-
-    auto       longestIntersect        = -1;
-    PHLMONITOR longestIntersectMonitor = nullptr;
-
-    for (auto const& m : State::monitorState()->monitors()) {
-        if (m == pSourceMonitor)
-            continue;
-
-        const auto POSB  = m->m_position;
-        const auto SIZEB = m->m_size;
-        switch (dir) {
-            case Math::DIRECTION_LEFT:
-                if (STICKS(POSA.x, POSB.x + SIZEB.x)) {
-                    const auto INTERSECTLEN = std::max(0.0, std::min(POSA.y + SIZEA.y, POSB.y + SIZEB.y) - std::max(POSA.y, POSB.y));
-                    if (INTERSECTLEN > longestIntersect) {
-                        longestIntersect        = INTERSECTLEN;
-                        longestIntersectMonitor = m;
-                    }
-                }
-                break;
-            case Math::DIRECTION_RIGHT:
-                if (STICKS(POSA.x + SIZEA.x, POSB.x)) {
-                    const auto INTERSECTLEN = std::max(0.0, std::min(POSA.y + SIZEA.y, POSB.y + SIZEB.y) - std::max(POSA.y, POSB.y));
-                    if (INTERSECTLEN > longestIntersect) {
-                        longestIntersect        = INTERSECTLEN;
-                        longestIntersectMonitor = m;
-                    }
-                }
-                break;
-            case Math::DIRECTION_UP:
-                if (STICKS(POSA.y, POSB.y + SIZEB.y)) {
-                    const auto INTERSECTLEN = std::max(0.0, std::min(POSA.x + SIZEA.x, POSB.x + SIZEB.x) - std::max(POSA.x, POSB.x));
-                    if (INTERSECTLEN > longestIntersect) {
-                        longestIntersect        = INTERSECTLEN;
-                        longestIntersectMonitor = m;
-                    }
-                }
-                break;
-            case Math::DIRECTION_DOWN:
-                if (STICKS(POSA.y + SIZEA.y, POSB.y)) {
-                    const auto INTERSECTLEN = std::max(0.0, std::min(POSA.x + SIZEA.x, POSB.x + SIZEB.x) - std::max(POSA.x, POSB.x));
-                    if (INTERSECTLEN > longestIntersect) {
-                        longestIntersect        = INTERSECTLEN;
-                        longestIntersectMonitor = m;
-                    }
-                }
-                break;
-            default: break;
-        }
-    }
-
-    if (longestIntersect != -1)
-        return longestIntersectMonitor;
-
-    return nullptr;
 }
 
 void CCompositor::updateAllWindowsAnimatedDecorationValues() {
@@ -1939,80 +1779,6 @@ void CCompositor::swapActiveWorkspaces(PHLMONITOR pMonitorA, PHLMONITOR pMonitor
 
     Event::bus()->m_events.workspace.moveToMonitor.emit(PWORKSPACEA, pMonitorB);
     Event::bus()->m_events.workspace.moveToMonitor.emit(PWORKSPACEB, pMonitorA);
-}
-
-PHLMONITOR CCompositor::getMonitorFromString(const std::string& name) {
-    if (name == "current")
-        return Desktop::focusState()->monitor();
-    else if (isDirection(name))
-        return getMonitorInDirection(Math::fromChar(name[0]));
-    else if (name[0] == '+' || name[0] == '-') {
-        // relative
-
-        if (State::monitorState()->monitors().size() == 1)
-            return *State::monitorState()->monitors().begin();
-
-        const auto OFFSET = name[0] == '-' ? name : name.substr(1);
-
-        if (!isNumber(OFFSET)) {
-            Log::logger->log(Log::ERR, "Error in getMonitorFromString: Not a number in relative.");
-            return nullptr;
-        }
-
-        int offsetLeft = std::stoi(OFFSET);
-        offsetLeft     = offsetLeft < 0 ? -((-offsetLeft) % State::monitorState()->monitors().size()) : offsetLeft % State::monitorState()->monitors().size();
-
-        int currentPlace = 0;
-        for (int i = 0; i < sc<int>(State::monitorState()->monitors().size()); i++) {
-            if (State::monitorState()->monitors()[i] == Desktop::focusState()->monitor()) {
-                currentPlace = i;
-                break;
-            }
-        }
-
-        currentPlace += offsetLeft;
-
-        if (currentPlace < 0) {
-            currentPlace = State::monitorState()->monitors().size() + currentPlace;
-        } else {
-            currentPlace = currentPlace % State::monitorState()->monitors().size();
-        }
-
-        if (currentPlace != std::clamp(currentPlace, 0, sc<int>(State::monitorState()->monitors().size()) - 1)) {
-            Log::logger->log(Log::WARN, "Error in getMonitorFromString: Vaxry's code sucks.");
-            currentPlace = std::clamp(currentPlace, 0, sc<int>(State::monitorState()->monitors().size()) - 1);
-        }
-
-        return State::monitorState()->monitors()[currentPlace];
-    } else if (isNumber(name)) {
-        // change by ID
-        MONITORID monID = MONITOR_INVALID;
-        try {
-            monID = std::stoi(name);
-        } catch (std::exception& e) {
-            // shouldn't happen but jic
-            Log::logger->log(Log::ERR, "Error in getMonitorFromString: invalid num");
-            return nullptr;
-        }
-
-        if (monID > -1 && monID < sc<MONITORID>(State::monitorState()->monitors().size())) {
-            return getMonitorFromID(monID);
-        } else {
-            Log::logger->log(Log::ERR, "Error in getMonitorFromString: invalid arg 1");
-            return nullptr;
-        }
-    } else {
-        for (auto const& m : State::monitorState()->monitors()) {
-            if (!m->m_output)
-                continue;
-
-            if (m->matchesStaticSelector(name)) {
-                return m;
-            }
-        }
-    }
-
-    return nullptr;
 }
 
 void CCompositor::moveWorkspaceToMonitor(PHLWORKSPACE pWorkspace, PHLMONITOR pMonitor, bool noWarpCursor) {
@@ -2460,14 +2226,14 @@ void CCompositor::warpCursorTo(const Vector2D& pos, bool force) {
     static auto PNOWARPS = CConfigValue<Config::INTEGER>("cursor:no_warps");
 
     if (*PNOWARPS && !force) {
-        const auto PMONITORNEW = getMonitorFromVector(pos);
+        const auto PMONITORNEW = State::monitorState()->query().vec(pos).run();
         Desktop::focusState()->rawMonitorFocus(PMONITORNEW);
         return;
     }
 
     g_pPointerManager->warpTo(pos);
 
-    const auto PMONITORNEW = getMonitorFromVector(pos);
+    const auto PMONITORNEW = State::monitorState()->query().vec(pos).run();
     Desktop::focusState()->rawMonitorFocus(PMONITORNEW);
 }
 
@@ -2557,7 +2323,7 @@ PHLWORKSPACE CCompositor::createNewWorkspace(const WORKSPACEID& id, const MONITO
 
     const bool SPECIAL = id >= SPECIAL_WORKSPACE_START && id <= -2;
 
-    const auto PMONITOR = getMonitorFromID(monID);
+    const auto PMONITOR = State::monitorState()->query().id(monID).run();
     if (!PMONITOR) {
         Log::logger->log(Log::ERR, "BUG THIS: No pMonitor for new workspace in createNewWorkspace");
         return nullptr;
@@ -2992,7 +2758,7 @@ void CCompositor::ensurePersistentWorkspacesPresent(const std::vector<Config::CW
                 continue;
         }
 
-        auto PMONITOR = getMonitorFromString(rule.m_monitor);
+        auto PMONITOR = State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(rule.m_monitor).run();
 
         if (!rule.m_monitor.empty() && !PMONITOR)
             continue; // don't do anything yet, as the monitor is not yet present.
@@ -3071,7 +2837,7 @@ void CCompositor::ensureWorkspacesOnAssignedMonitors() {
         if (!RULE || RULE->m_monitor.empty())
             continue;
 
-        const auto PMONITOR = getMonitorFromString(RULE->m_monitor);
+        const auto PMONITOR = State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(RULE->m_monitor).run();
         if (!PMONITOR)
             continue;
 

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -86,20 +86,12 @@ class CCompositor {
 
     //
 
-    PHLMONITOR             getMonitorFromID(const MONITORID&);
-    PHLMONITOR             getMonitorFromName(const std::string&);
-    PHLMONITOR             getMonitorFromDesc(const std::string&);
-    PHLMONITOR             getMonitorFromCursor();
-    PHLMONITOR             getMonitorFromVector(const Vector2D&);
     void                   removeWindowFromVectorSafe(PHLWINDOW);
-    bool                   monitorExists(PHLMONITOR);
     PHLWINDOW              vectorToWindowUnified(const Vector2D&, uint16_t properties, PHLWINDOW pIgnoreWindow = nullptr);
     SP<CWLSurfaceResource> vectorToLayerSurface(const Vector2D&, std::vector<PHLLSREF>*, Vector2D*, PHLLS*, bool aboveLockscreen = false);
     SP<CWLSurfaceResource> vectorToLayerPopupSurface(const Vector2D&, PHLMONITOR monitor, Vector2D*, PHLLS*);
     SP<CWLSurfaceResource> vectorWindowToSurface(const Vector2D&, PHLWINDOW, Vector2D& sl);
     Vector2D               vectorToSurfaceLocal(const Vector2D&, PHLWINDOW, SP<CWLSurfaceResource>);
-    PHLMONITOR             getMonitorFromOutput(SP<Aquamarine::IOutput>);
-    PHLMONITOR             getRealMonitorFromOutput(SP<Aquamarine::IOutput>);
     PHLWINDOW              getWindowFromSurface(SP<CWLSurfaceResource>);
     PHLWINDOW              getWindowFromHandle(uint32_t);
     PHLWORKSPACE           getWorkspaceByID(const WORKSPACEID&);
@@ -120,12 +112,9 @@ class CCompositor {
     bool                   isPointOnAnyMonitor(const Vector2D&);
     bool                   isPointOnReservedArea(const Vector2D& point, const PHLMONITOR monitor = nullptr);
     std::optional<CBox>    calculateX11WorkArea();
-    PHLMONITOR             getMonitorInDirection(Math::eDirection);
-    PHLMONITOR             getMonitorInDirection(PHLMONITOR, Math::eDirection);
     void                   updateAllWindowsAnimatedDecorationValues();
     void                   moveWorkspaceToMonitor(PHLWORKSPACE, PHLMONITOR, bool noWarpCursor = false);
     void                   swapActiveWorkspaces(PHLMONITOR, PHLMONITOR);
-    PHLMONITOR             getMonitorFromString(const std::string&);
     bool                   workspaceIDOutOfBounds(const WORKSPACEID&);
     void                   setWindowFullscreenInternal(const PHLWINDOW PWINDOW, const eFullscreenMode MODE);
     void                   setWindowFullscreenClient(const PHLWINDOW PWINDOW, const eFullscreenMode MODE);

--- a/src/config/legacy/DispatcherTranslator.cpp
+++ b/src/config/legacy/DispatcherTranslator.cpp
@@ -10,6 +10,7 @@
 #include "../../managers/SeatManager.hpp"
 #include "../../managers/input/InputManager.hpp"
 #include "../../layout/LayoutManager.hpp"
+#include "../../state/MonitorState.hpp"
 
 #include <hyprutils/string/String.hpp>
 #include <hyprutils/string/VarList2.hpp>
@@ -248,7 +249,7 @@ static SDispatchResult movewindow(const std::string& args) {
     auto cleanArgs = silent ? args.substr(0, args.length() - 7) : args;
 
     if (cleanArgs.starts_with("mon:")) {
-        const auto PNEWMONITOR = g_pCompositor->getMonitorFromString(cleanArgs.substr(4));
+        const auto PNEWMONITOR = State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(cleanArgs.substr(4)).run();
         if (!PNEWMONITOR)
             return {.success = false, .error = std::format("Monitor {} not found", cleanArgs.substr(4))};
 
@@ -323,7 +324,7 @@ static SDispatchResult movegroupwindow(const std::string& args) {
 }
 
 static SDispatchResult focusmonitor(const std::string& args) {
-    const auto PMONITOR = g_pCompositor->getMonitorFromString(args);
+    const auto PMONITOR = State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(args).run();
     if (!PMONITOR)
         return {.success = false, .error = "Monitor not found"};
     return wrap(Actions::focusMonitor(PMONITOR));
@@ -358,7 +359,7 @@ static SDispatchResult exitHyprland(const std::string&) {
 }
 
 static SDispatchResult movecurrentworkspacetomonitor(const std::string& args) {
-    const auto PMONITOR = g_pCompositor->getMonitorFromString(args);
+    const auto PMONITOR = State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(args).run();
     if (!PMONITOR)
         return {.success = false, .error = "Monitor not found"};
 
@@ -376,7 +377,7 @@ static SDispatchResult moveworkspacetomonitor(const std::string& args) {
     std::string wsStr  = args.substr(0, args.find_first_of(' '));
     std::string monStr = args.substr(args.find_first_of(' ') + 1);
 
-    const auto  PMONITOR = g_pCompositor->getMonitorFromString(monStr);
+    const auto  PMONITOR = State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(monStr).run();
     if (!PMONITOR)
         return {.success = false, .error = "Monitor not found"};
 
@@ -638,7 +639,7 @@ static SDispatchResult dpmsDispatcher(const std::string& arg) {
     std::optional<PHLMONITOR> mon = std::nullopt;
     if (arg.find_first_of(' ') != std::string::npos) {
         auto port = arg.substr(arg.find_first_of(' ') + 1);
-        auto pMon = g_pCompositor->getMonitorFromString(port);
+        auto pMon = State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(port).run();
         if (pMon)
             mon = pMon;
     }
@@ -654,8 +655,8 @@ static SDispatchResult swapactiveworkspaces(const std::string& args) {
     const auto MON1 = args.substr(0, args.find_first_of(' '));
     const auto MON2 = args.substr(args.find_first_of(' ') + 1);
 
-    const auto PMON1 = g_pCompositor->getMonitorFromString(MON1);
-    const auto PMON2 = g_pCompositor->getMonitorFromString(MON2);
+    const auto PMON1 = State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(MON1).run();
+    const auto PMON2 = State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(MON2).run();
 
     if (!PMON1 || !PMON2)
         return {.success = false, .error = "Monitor not found"};

--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -7,6 +7,7 @@
 #include "../../supplementary/executor/Executor.hpp"
 
 #include "../../../managers/SeatManager.hpp"
+#include "../../../state/MonitorState.hpp"
 #include "../../../devices/IKeyboard.hpp"
 #include "../../../desktop/rule/windowRule/WindowRule.hpp"
 
@@ -194,7 +195,7 @@ static int dsp_dpms(lua_State* L) {
     std::optional<PHLMONITOR> mon    = std::nullopt;
 
     if (!lua_isnil(L, lua_upvalueindex(2))) {
-        auto m = g_pCompositor->getMonitorFromString(lua_tostring(L, lua_upvalueindex(2)));
+        auto m = State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(lua_tostring(L, lua_upvalueindex(2))).run();
         if (m)
             mon = m;
     }
@@ -1067,7 +1068,7 @@ static int dsp_moveFocus(lua_State* L) {
 }
 
 static int dsp_focusMonitor(lua_State* L) {
-    const auto PMONITOR = g_pCompositor->getMonitorFromString(lua_tostring(L, lua_upvalueindex(1)));
+    const auto PMONITOR = State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(lua_tostring(L, lua_upvalueindex(1))).run();
     if (!PMONITOR)
         return Internal::dispatcherError(L, "hl.focus.monitor: monitor not found", WARN, C_NOTFOUND);
     return Internal::checkResult(L, CA::focusMonitor(PMONITOR));
@@ -1198,14 +1199,14 @@ static int dsp_moveWorkspaceToMonitor(lua_State* L) {
     const auto PWORKSPACE = g_pCompositor->getWorkspaceByID(WORKSPACEID);
     if (!PWORKSPACE)
         return Internal::dispatcherError(L, "Workspace not found", WARN, C_NOTFOUND);
-    const auto PMONITOR = g_pCompositor->getMonitorFromString(lua_tostring(L, lua_upvalueindex(2)));
+    const auto PMONITOR = State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(lua_tostring(L, lua_upvalueindex(2))).run();
     if (!PMONITOR)
         return Internal::dispatcherError(L, "Monitor not found", WARN, C_NOTFOUND);
     return Internal::checkResult(L, CA::moveToMonitor(PWORKSPACE, PMONITOR));
 }
 
 static int dsp_moveCurrentWorkspaceToMonitor(lua_State* L) {
-    const auto PMONITOR = g_pCompositor->getMonitorFromString(lua_tostring(L, lua_upvalueindex(1)));
+    const auto PMONITOR = State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(lua_tostring(L, lua_upvalueindex(1))).run();
     if (!PMONITOR)
         return Internal::dispatcherError(L, "Monitor not found", WARN, C_NOTFOUND);
     const auto PCURRENTWORKSPACE = Desktop::focusState()->monitor()->m_activeWorkspace;
@@ -1215,8 +1216,8 @@ static int dsp_moveCurrentWorkspaceToMonitor(lua_State* L) {
 }
 
 static int dsp_swapActiveWorkspaces(lua_State* L) {
-    const auto PMON1 = g_pCompositor->getMonitorFromString(lua_tostring(L, lua_upvalueindex(1)));
-    const auto PMON2 = g_pCompositor->getMonitorFromString(lua_tostring(L, lua_upvalueindex(2)));
+    const auto PMON1 = State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(lua_tostring(L, lua_upvalueindex(1))).run();
+    const auto PMON2 = State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(lua_tostring(L, lua_upvalueindex(2))).run();
     if (!PMON1 || !PMON2)
         return Internal::dispatcherError(L, "Monitor not found", WARN, C_NOTFOUND);
     return Internal::checkResult(L, CA::swapActiveWorkspaces(PMON1, PMON2));

--- a/src/config/lua/bindings/LuaBindingsInternal.cpp
+++ b/src/config/lua/bindings/LuaBindingsInternal.cpp
@@ -1,6 +1,7 @@
 #include "LuaBindingsInternal.hpp"
 
 #include "../../../desktop/rule/windowRule/WindowRule.hpp"
+#include "../../../state/MonitorState.hpp"
 
 using namespace Config;
 using namespace Config::Lua;
@@ -69,7 +70,7 @@ PHLMONITOR Internal::monitorFromLuaSelectorOrObject(lua_State* L, int idx, const
         return ref->lock();
 
     if (lua_isstring(L, idx) || lua_isnumber(L, idx))
-        return g_pCompositor->getMonitorFromString(argStr(L, idx));
+        return State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(argStr(L, idx)).run();
 
     Internal::configError(L, "{}: expected a monitor object or selector", fnName);
     return nullptr;
@@ -400,7 +401,7 @@ PHLWORKSPACE Internal::resolveWorkspaceStr(const std::string& args) {
 }
 
 PHLMONITOR Internal::resolveMonitorStr(const std::string& args) {
-    auto mon = g_pCompositor->getMonitorFromString(args);
+    auto mon = State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(args).run();
     return mon;
 }
 

--- a/src/config/lua/bindings/LuaBindingsQuery.cpp
+++ b/src/config/lua/bindings/LuaBindingsQuery.cpp
@@ -257,7 +257,7 @@ static int hlGetMonitorAt(lua_State* L) {
         y = *ty;
     }
 
-    const auto PMONITOR = g_pCompositor->getMonitorFromVector(Vector2D{x, y});
+    const auto PMONITOR = State::monitorState()->query().vec(Vector2D{x, y}).run();
     if (!PMONITOR) {
         lua_pushnil(L);
         return 1;
@@ -268,7 +268,7 @@ static int hlGetMonitorAt(lua_State* L) {
 }
 
 static int hlGetMonitorAtCursor(lua_State* L) {
-    const auto PMONITOR = g_pCompositor->getMonitorFromCursor();
+    const auto PMONITOR = State::monitorState()->query().vec(g_pInputManager->getMouseCoordsInternal()).run();
     if (!PMONITOR) {
         lua_pushnil(L);
         return 1;

--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -355,7 +355,7 @@ ActionResult Actions::moveFocus(Math::eDirection dir) {
     const auto  PLASTWINDOW = Desktop::focusState()->window();
     if (!PLASTWINDOW || !PLASTWINDOW->aliveAndVisible()) {
         if (*PMONITORFALLBACK)
-            tryMoveFocusToMonitor(g_pCompositor->getMonitorInDirection(dir));
+            tryMoveFocusToMonitor(State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).inDirection(dir).run());
         return {};
     }
 
@@ -379,7 +379,7 @@ ActionResult Actions::moveFocus(Math::eDirection dir) {
         return {};
     }
 
-    if (*PMONITORFALLBACK && tryMoveFocusToMonitor(g_pCompositor->getMonitorInDirection(dir)))
+    if (*PMONITORFALLBACK && tryMoveFocusToMonitor(State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).inDirection(dir).run()))
         return {};
 
     static auto PNOFALLBACK = CConfigValue<Config::INTEGER>("general:no_focus_fallback");

--- a/src/config/shared/workspace/WorkspaceRuleManager.cpp
+++ b/src/config/shared/workspace/WorkspaceRuleManager.cpp
@@ -2,6 +2,7 @@
 
 #include "../../../Compositor.hpp"
 #include "../../../output/Monitor.hpp"
+#include "../../../state/MonitorState.hpp"
 
 #include <hyprutils/string/String.hpp>
 
@@ -59,7 +60,7 @@ std::string CWorkspaceRuleManager::getDefaultWorkspaceFor(const std::string& nam
             if (other->m_monitor == name)
                 return other->m_workspaceString;
             if (other->m_monitor.starts_with("desc:")) {
-                auto const monitor = g_pCompositor->getMonitorFromDesc(trim(other->m_monitor.substr(5)));
+                auto const monitor = State::monitorState()->query().description(trim(other->m_monitor.substr(5))).run();
                 if (monitor && monitor->m_name == name)
                     return other->m_workspaceString;
             }
@@ -71,9 +72,9 @@ std::string CWorkspaceRuleManager::getDefaultWorkspaceFor(const std::string& nam
 PHLMONITOR CWorkspaceRuleManager::getBoundMonitorForWS(const std::string& wsname) {
     auto monitor = getBoundMonitorStringForWS(wsname);
     if (monitor.starts_with("desc:"))
-        return g_pCompositor->getMonitorFromDesc(trim(monitor.substr(5)));
+        return State::monitorState()->query().description(trim(monitor.substr(5))).run();
     else
-        return g_pCompositor->getMonitorFromName(monitor);
+        return State::monitorState()->query().name(monitor).run();
 }
 
 std::string CWorkspaceRuleManager::getBoundMonitorStringForWS(const std::string& wsname) {

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1755,7 +1755,7 @@ static std::string dispatchOutput(eHyprCtlOutputFormat format, std::string reque
     }
 
     if (MODE == "create" || MODE == "add") {
-        if (g_pCompositor->getMonitorFromName(vars[3]))
+        if (State::monitorState()->query().name(vars[3]).run())
             return "A real monitor already uses that name.";
 
         for (auto const& impl : g_pCompositor->m_aqBackend->getImplementations() | std::views::reverse) {
@@ -1778,7 +1778,7 @@ static std::string dispatchOutput(eHyprCtlOutputFormat format, std::string reque
             return "no backend replied to the request";
 
     } else if (MODE == "destroy" || MODE == "remove") {
-        const auto PMONITOR = g_pCompositor->getMonitorFromName(vars[2]);
+        const auto PMONITOR = State::monitorState()->query().name(vars[2]).run();
 
         if (!PMONITOR)
             return "output not found";

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -1,6 +1,7 @@
 #include "Workspace.hpp"
 #include "view/Group.hpp"
 #include "view/LayerSurface.hpp"
+#include "state/FocusState.hpp"
 #include "../Compositor.hpp"
 #include "../config/shared/parserUtils/ParserUtils.hpp"
 #include "../config/shared/animation/AnimationTree.hpp"
@@ -9,6 +10,7 @@
 #include "managers/animation/AnimationManager.hpp"
 #include "../managers/EventManager.hpp"
 #include "../output/Monitor.hpp"
+#include "../state/MonitorState.hpp"
 #include "../layout/algorithm/Algorithm.hpp"
 #include "../layout/space/Space.hpp"
 #include "../layout/target/Target.hpp"
@@ -216,7 +218,7 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
 
                 prop = prop.substr(2, prop.length() - 3);
 
-                const auto PMONITOR = g_pCompositor->getMonitorFromString(prop);
+                const auto PMONITOR = State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(prop).run();
 
                 if (!(PMONITOR ? PMONITOR == m_monitor : false))
                     return false;

--- a/src/desktop/view/LayerSurface.cpp
+++ b/src/desktop/view/LayerSurface.cpp
@@ -20,7 +20,7 @@ using namespace Desktop::View;
 PHLLS CLayerSurface::create(SP<CLayerShellResource> resource) {
     PHLLS pLS = SP<CLayerSurface>(new CLayerSurface(resource));
 
-    auto  pMonitor = resource->m_monitor.empty() ? Desktop::focusState()->monitor() : g_pCompositor->getMonitorFromName(resource->m_monitor);
+    auto  pMonitor = resource->m_monitor.empty() ? Desktop::focusState()->monitor() : State::monitorState()->query().name(resource->m_monitor).run();
 
     pLS->m_wlSurface->assign(resource->m_surface.lock(), pLS);
 

--- a/src/desktop/view/Popup.cpp
+++ b/src/desktop/view/Popup.cpp
@@ -12,6 +12,7 @@
 #include "../../managers/eventLoop/EventLoopManager.hpp"
 #include "../../render/Renderer.hpp"
 #include "../../render/OpenGL.hpp"
+#include "../../state/MonitorState.hpp"
 #include <array>
 #include <ranges>
 
@@ -193,7 +194,7 @@ void CPopup::onMap() {
     m_lastSize = m_resource->m_surface->m_surface->m_current.size;
 
     const auto COORDS   = coordsGlobal();
-    const auto PMONITOR = g_pCompositor->getMonitorFromVector(COORDS);
+    const auto PMONITOR = State::monitorState()->query().vec(COORDS).run();
 
     CBox       box = m_wlSurface->resource()->extends();
     box.translate(COORDS).expand(4);
@@ -359,7 +360,7 @@ void CPopup::onReposition() {
 
 void CPopup::reposition() {
     const auto COORDS   = t1ParentCoords();
-    const auto PMONITOR = g_pCompositor->getMonitorFromVector(COORDS);
+    const auto PMONITOR = State::monitorState()->query().vec(COORDS).run();
 
     if (!PMONITOR)
         return;

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -32,6 +32,7 @@
 #include "../../config/ConfigManager.hpp"
 #include "../../config/shared/animation/AnimationTree.hpp"
 #include "../../config/shared/workspace/WorkspaceRuleManager.hpp"
+#include "../../state/MonitorState.hpp"
 #include "../../managers/TokenManager.hpp"
 #include "../../managers/animation/AnimationManager.hpp"
 #include "../../managers/ANRManager.hpp"
@@ -459,7 +460,7 @@ void CWindow::updateSurfaceScaleTransformDetails(bool force) {
     if (!m_isMapped || m_hidden)
         return;
 
-    const auto PLASTMONITOR = g_pCompositor->getMonitorFromID(m_lastSurfaceMonitorID);
+    const auto PLASTMONITOR = State::monitorState()->query().id(m_lastSurfaceMonitorID).run();
 
     m_lastSurfaceMonitorID = monitorID();
 
@@ -1315,7 +1316,7 @@ void CWindow::onUpdateState() {
     if (requestsFS.has_value() && !(m_suppressedEvents & SUPPRESS_FULLSCREEN)) {
         if (requestsID.has_value() && (requestsID.value() != MONITOR_INVALID) && !(m_suppressedEvents & SUPPRESS_FULLSCREEN_OUTPUT)) {
             if (m_isMapped) {
-                const auto monitor = g_pCompositor->getMonitorFromID(requestsID.value());
+                const auto monitor = State::monitorState()->query().id(requestsID.value()).run();
                 g_pCompositor->moveWindowToWorkspaceSafe(m_self.lock(), monitor->m_activeWorkspace);
                 Desktop::focusState()->rawMonitorFocus(monitor);
             }
@@ -1484,7 +1485,7 @@ void CWindow::onX11ConfigureRequest(CBox box) {
     if (!m_workspace || !m_workspace->isVisible())
         return; // further things are only for visible windows
 
-    const auto monitorByRequestedPosition = g_pCompositor->getMonitorFromVector(m_realPosition->goal() + m_realSize->goal() / 2.f);
+    const auto monitorByRequestedPosition = State::monitorState()->query().vec(m_realPosition->goal() + m_realSize->goal() / 2.f).run();
     const auto currentMonitor             = m_workspace->m_monitor.lock();
 
     Log::logger->log(
@@ -1926,7 +1927,7 @@ void CWindow::mapWindow() {
 
     auto        PMONITOR = Desktop::focusState()->monitor();
     if (!Desktop::focusState()->monitor()) {
-        Desktop::focusState()->rawMonitorFocus(g_pCompositor->getMonitorFromVector({}));
+        Desktop::focusState()->rawMonitorFocus(State::monitorState()->query().vec({}).run());
         PMONITOR = Desktop::focusState()->monitor();
     }
     if (!PMONITOR || (!PMONITOR->m_activeSpecialWorkspace && !PMONITOR->m_activeWorkspace)) {
@@ -2010,9 +2011,10 @@ void CWindow::mapWindow() {
             if (MONITORSTR == "unset")
                 m_monitor = PMONITOR;
             else {
-                const auto ARGPOS  = MONITORSTR.find_last_of(' ');
-                monitorSilent      = ARGPOS != std::string::npos && MONITORSTR.substr(ARGPOS).contains("silent");
-                const auto MONITOR = g_pCompositor->getMonitorFromString(monitorSilent ? MONITORSTR.substr(0, ARGPOS) : MONITORSTR);
+                const auto ARGPOS = MONITORSTR.find_last_of(' ');
+                monitorSilent     = ARGPOS != std::string::npos && MONITORSTR.substr(ARGPOS).contains("silent");
+                const auto MONITOR =
+                    State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(monitorSilent ? MONITORSTR.substr(0, ARGPOS) : MONITORSTR).run();
 
                 if (MONITOR) {
                     m_monitor = MONITOR;
@@ -2200,7 +2202,7 @@ void CWindow::mapWindow() {
     if (m_suppressedEvents & Desktop::View::SUPPRESS_FULLSCREEN_OUTPUT)
         requestedFSMonitor = MONITOR_INVALID;
     else if (requestedFSMonitor != MONITOR_INVALID) {
-        if (const auto PM = g_pCompositor->getMonitorFromID(requestedFSMonitor); PM)
+        if (const auto PM = State::monitorState()->query().id(requestedFSMonitor).run(); PM)
             m_monitor = PM;
 
         const auto PMONITORFROMID = m_monitor.lock();
@@ -2720,7 +2722,7 @@ void CWindow::unmanagedSetGeometry() {
         m_position = m_realPosition->goal();
         m_size     = m_realSize->goal();
 
-        m_workspace = g_pCompositor->getMonitorFromVector(m_realPosition->value() + m_realSize->value() / 2.f)->m_activeWorkspace;
+        m_workspace = State::monitorState()->query().vec(m_realPosition->value() + m_realSize->value() / 2.f).run()->m_activeWorkspace;
 
         g_pCompositor->changeWindowZOrder(m_self.lock(), true);
         updateWindowDecos();

--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -6,6 +6,7 @@
 #include "../desktop/state/FocusState.hpp"
 #include "../desktop/history/WorkspaceHistoryTracker.hpp"
 #include "../output/Monitor.hpp"
+#include "../state/MonitorState.hpp"
 #include "../config/shared/workspace/WorkspaceRuleManager.hpp"
 #include "fs/FsUtils.hpp"
 #include <optional>
@@ -158,7 +159,7 @@ SWorkspaceIDName getWorkspaceIDNameFromString(const std::string& in) {
         std::set<WORKSPACEID> invalidWSes;
         if (same_mon) {
             for (auto const& rule : Config::workspaceRuleMgr()->getAllWorkspaceRules()) {
-                const auto PMONITOR = g_pCompositor->getMonitorFromString(rule.m_monitor);
+                const auto PMONITOR = State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(rule.m_monitor).run();
                 if (PMONITOR && (PMONITOR->m_id != Desktop::focusState()->monitor()->m_id))
                     invalidWSes.insert(rule.m_workspaceId);
             }
@@ -238,7 +239,7 @@ SWorkspaceIDName getWorkspaceIDNameFromString(const std::string& in) {
                 }
             }
             for (auto const& rule : Config::workspaceRuleMgr()->getAllWorkspaceRules()) {
-                const auto PMONITOR = g_pCompositor->getMonitorFromString(rule.m_monitor);
+                const auto PMONITOR = State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(rule.m_monitor).run();
                 if (!PMONITOR || PMONITOR->m_id == Desktop::focusState()->monitor()->m_id) {
                     // Can't be invalid
                     continue;

--- a/src/layout/algorithm/floating/default/DefaultFloatingAlgorithm.cpp
+++ b/src/layout/algorithm/floating/default/DefaultFloatingAlgorithm.cpp
@@ -7,6 +7,7 @@
 
 #include "../../../../Compositor.hpp"
 #include "../../../../output/Monitor.hpp"
+#include "../../../../state/MonitorState.hpp"
 
 using namespace Layout;
 using namespace Layout::Floating;
@@ -162,7 +163,7 @@ void CDefaultFloatingAlgorithm::movedTarget(SP<ITarget> target, std::optional<Ve
         // calculate new position
         const auto THIS_MON_POS = m_parent->space()->workspace()->m_monitor->m_position;
         const auto OLD_POS      = target->position().pos();
-        const auto MON_FROM_OLD = g_pCompositor->getMonitorFromVector(OLD_POS);
+        const auto MON_FROM_OLD = State::monitorState()->query().vec(OLD_POS).run();
         const auto NEW_POS      = MON_FROM_OLD ? OLD_POS - MON_FROM_OLD->m_position + THIS_MON_POS : OLD_POS;
 
         // put around the current center, fit in workArea

--- a/src/layout/algorithm/tiled/dwindle/DwindleAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/dwindle/DwindleAlgorithm.cpp
@@ -9,6 +9,7 @@
 #include "../../../../desktop/state/FocusState.hpp"
 #include "../../../../output/Monitor.hpp"
 #include "../../../../Compositor.hpp"
+#include "../../../../state/MonitorState.hpp"
 
 #include <hyprutils/utils/ScopeGuard.hpp>
 #include <hyprutils/string/VarList2.hpp>
@@ -545,7 +546,7 @@ void CDwindleAlgorithm::moveTargetInDirection(SP<ITarget> t, Math::eDirection di
 
     const auto FOCAL_POINT = focalPointForDir(t, dir);
 
-    const auto PMONITORFOCAL = g_pCompositor->getMonitorFromVector(FOCAL_POINT.value_or(t->position().middle()));
+    const auto PMONITORFOCAL = State::monitorState()->query().vec(FOCAL_POINT.value_or(t->position().middle())).run();
 
     if (PMONITORFOCAL != m_parent->space()->workspace()->m_monitor && !*PMONITORFALLBACK)
         return; // noop

--- a/src/layout/algorithm/tiled/master/MasterAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/master/MasterAlgorithm.cpp
@@ -11,6 +11,7 @@
 #include "../../../../output/Monitor.hpp"
 #include "../../../../Compositor.hpp"
 #include "../../../../render/Renderer.hpp"
+#include "../../../../state/MonitorState.hpp"
 
 #include <hyprutils/utils/ScopeGuard.hpp>
 #include <hyprutils/string/VarList2.hpp>
@@ -401,7 +402,7 @@ void CMasterAlgorithm::moveTargetInDirection(SP<ITarget> t, Math::eDirection dir
 
     if (!PWINDOW2 && t->space() && t->space()->workspace()) {
         // try to find a monitor in dir
-        const auto PMONINDIR = g_pCompositor->getMonitorInDirection(t->space()->workspace()->m_monitor.lock(), dir);
+        const auto PMONINDIR = State::monitorState()->query().relativeTo(t->space()->workspace()->m_monitor.lock()).inDirection(dir).run();
         if (PMONINDIR)
             targetWs = PMONINDIR->m_activeWorkspace;
     } else

--- a/src/layout/algorithm/tiled/monocle/MonocleAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/monocle/MonocleAlgorithm.cpp
@@ -10,6 +10,7 @@
 #include "../../../../desktop/history/WindowHistoryTracker.hpp"
 #include "../../../../output/Monitor.hpp"
 #include "../../../../Compositor.hpp"
+#include "../../../../state/MonitorState.hpp"
 #include "../../../../event/EventBus.hpp"
 
 #include <hyprutils/string/VarList2.hpp>
@@ -217,7 +218,7 @@ void CMonocleAlgorithm::moveTargetInDirection(SP<ITarget> t, Math::eDirection di
         return;
 
     const auto PMONITOR  = t->space()->workspace()->m_monitor.lock();
-    const auto PMONINDIR = g_pCompositor->getMonitorInDirection(PMONITOR, dir);
+    const auto PMONINDIR = State::monitorState()->query().relativeTo(PMONITOR).inDirection(dir).run();
 
     // if we found a monitor, move the window there
     if (PMONINDIR && PMONINDIR != PMONITOR) {

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -10,6 +10,7 @@
 #include "../../../../config/ConfigValue.hpp"
 #include "../../../../config/shared/workspace/WorkspaceRuleManager.hpp"
 #include "../../../../render/Renderer.hpp"
+#include "../../../../state/MonitorState.hpp"
 #include "../../../../managers/input/InputManager.hpp"
 #include "../../../../managers/PointerManager.hpp"
 #include "../../../../managers/animation/DesktopAnimationManager.hpp"
@@ -1431,7 +1432,7 @@ void CScrollingAlgorithm::moveTargetTo(SP<ITarget> t, Math::eDirection dir, bool
         if (!*PMONITORFALLBACK)
             return; // noop
 
-        const auto MONINDIR = g_pCompositor->getMonitorInDirection(m_parent->space()->workspace()->m_monitor.lock(), dir);
+        const auto MONINDIR = State::monitorState()->query().relativeTo(m_parent->space()->workspace()->m_monitor.lock()).inDirection(dir).run();
         if (MONINDIR && MONINDIR != m_parent->space()->workspace()->m_monitor && MONINDIR->m_activeWorkspace) {
             t->assignToSpace(MONINDIR->m_activeWorkspace->m_space, focalPointForDir(t, dir));
 

--- a/src/layout/supplementary/DragController.cpp
+++ b/src/layout/supplementary/DragController.cpp
@@ -7,6 +7,7 @@
 #include "../../desktop/state/FocusState.hpp"
 #include "../../desktop/view/Group.hpp"
 #include "../../render/Renderer.hpp"
+#include "../../state/MonitorState.hpp"
 
 using namespace Layout;
 using namespace Layout::Supplementary;
@@ -376,7 +377,7 @@ void CDragStateController::mouseMove(const Vector2D& mousePos) {
     Vector2D middle = DRAGGINGTARGET->position().middle();
 
     // and check its monitor
-    const auto PMONITOR = g_pCompositor->getMonitorFromVector(middle);
+    const auto PMONITOR = State::monitorState()->query().vec(middle).run();
 
     if (PMONITOR && PMONITOR->m_activeWorkspace && DRAGGINGTARGET->floating() /* If we're resaizing a tiled target, don't do this */) {
         const auto WS = PMONITOR->m_activeSpecialWorkspace ? PMONITOR->m_activeSpecialWorkspace : PMONITOR->m_activeWorkspace;

--- a/src/layout/target/WindowTarget.cpp
+++ b/src/layout/target/WindowTarget.cpp
@@ -10,6 +10,7 @@
 #include "../../Compositor.hpp"
 #include "../../render/Renderer.hpp"
 #include "../../desktop/state/FloatState.hpp"
+#include "../../state/MonitorState.hpp"
 
 #include <hyprutils/utils/ScopeGuard.hpp>
 
@@ -349,7 +350,7 @@ std::expected<SGeometryRequested, eGeometryFailure> CWindowTarget::desiredGeomet
 
         Vector2D pos;
 
-        if (const auto POPENMON = g_pCompositor->getMonitorFromVector(DESIRED_GEOM.middle()); POPENMON->m_id != PMONITOR->m_id)
+        if (const auto POPENMON = State::monitorState()->query().vec(DESIRED_GEOM.middle()).run(); POPENMON->m_id != PMONITOR->m_id)
             pos = Vector2D(DESIRED_GEOM.x, DESIRED_GEOM.y) - POPENMON->m_position + PMONITOR->m_position;
         else
             pos = Vector2D(DESIRED_GEOM.x, DESIRED_GEOM.y);

--- a/src/managers/PointerManager.cpp
+++ b/src/managers/PointerManager.cpp
@@ -836,7 +836,7 @@ void CPointerManager::warpAbsolute(Vector2D abs, SP<IHID> dev) {
         if (output == "current") {
             if (const auto PLASTMONITOR = Desktop::focusState()->monitor(); PLASTMONITOR)
                 return PLASTMONITOR->logicalBox();
-        } else if (const auto PMONITOR = g_pCompositor->getMonitorFromString(output); PMONITOR)
+        } else if (const auto PMONITOR = State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(output).run(); PMONITOR)
             return PMONITOR->logicalBox();
         return mappedArea;
     };

--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -11,6 +11,7 @@
 #include "../devices/IKeyboard.hpp"
 #include "../desktop/view/LayerSurface.hpp"
 #include "../managers/input/InputManager.hpp"
+#include "../state/MonitorState.hpp"
 #include "wlr-layer-shell-unstable-v1.hpp"
 #include <algorithm>
 #include <hyprutils/utils/ScopeGuard.hpp>
@@ -661,7 +662,7 @@ void CSeatManager::setGrab(SP<CSeatGrab> grab) {
         } else {
             static auto PFOLLOWMOUSE = CConfigValue<Config::INTEGER>("input:follow_mouse");
             if (*PFOLLOWMOUSE == 0 || *PFOLLOWMOUSE == 2 || *PFOLLOWMOUSE == 3) {
-                const auto PMONITOR = g_pCompositor->getMonitorFromCursor();
+                const auto PMONITOR = State::monitorState()->query().vec(g_pInputManager->getMouseCoordsInternal()).run();
 
                 // If this was a popup grab, focus its parent window to maintain context
                 if (validMapped(parentWindow)) {
@@ -701,7 +702,7 @@ void CSeatManager::setGrab(SP<CSeatGrab> grab) {
             if (candidate && candidate->m_workspace && candidate->m_workspace->isVisibleNotCovered())
                 Desktop::focusState()->rawWindowFocus(candidate, Desktop::FOCUS_REASON_FFM);
             else {
-                const auto PMONITOR = g_pCompositor->getMonitorFromCursor();
+                const auto PMONITOR = State::monitorState()->query().vec(g_pInputManager->getMouseCoordsInternal()).run();
                 g_pInputManager->refocusLastWindow(PMONITOR);
             }
         }

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -21,7 +21,7 @@ SSessionLockSurface::SSessionLockSurface(SP<CSessionLockSurface> surface_) : sur
 
         g_pInputManager->simulateMouseMovement();
 
-        const auto PMONITOR = g_pCompositor->getMonitorFromID(iMonitorID);
+        const auto PMONITOR = State::monitorState()->query().id(iMonitorID).run();
 
         if (PMONITOR)
             g_pHyprRenderer->damageMonitor(PMONITOR);
@@ -35,7 +35,7 @@ SSessionLockSurface::SSessionLockSurface(SP<CSessionLockSurface> surface_) : sur
     });
 
     listeners.commit = surface_->m_events.commit.listen([this] {
-        const auto PMONITOR = g_pCompositor->getMonitorFromID(iMonitorID);
+        const auto PMONITOR = State::monitorState()->query().id(iMonitorID).run();
 
         if (mapped && !Desktop::focusState()->surface())
             g_pInputManager->simulateMouseMovement();

--- a/src/managers/animation/AnimationManager.cpp
+++ b/src/managers/animation/AnimationManager.cpp
@@ -135,7 +135,7 @@ static void handleUpdate(CAnimatedVariable<VarType>& av, bool warp) {
         if (!ws->m_monitor.lock())
             return;
     } else if (auto ls = av.m_Context.pLayer.lock()) {
-        if (!g_pCompositor->getMonitorFromVector(ls->m_realPosition->goal() + ls->m_realSize->goal() / 2.F))
+        if (!State::monitorState()->query().vec(ls->m_realPosition->goal() + ls->m_realSize->goal() / 2.F).run())
             return;
         animationsDisabled = animationsDisabled || ls->m_ruleApplicator->noanim().valueOrDefault();
     }
@@ -226,7 +226,7 @@ void CHyprAnimationManager::tick() {
                 }
             }
             if (!owner) {
-                auto monitor = g_pCompositor->getMonitorFromVector(ls->m_realPosition->goal() + ls->m_realSize->goal() / 2.F);
+                auto monitor = State::monitorState()->query().vec(ls->m_realPosition->goal() + ls->m_realSize->goal() / 2.F).run();
                 if (!monitor)
                     continue;
                 owners.emplace_back(SDamageOwner{.layer = ls, .monitor = monitor});

--- a/src/managers/animation/DesktopAnimationManager.cpp
+++ b/src/managers/animation/DesktopAnimationManager.cpp
@@ -12,6 +12,7 @@
 
 #include "../../output/Monitor.hpp"
 #include "../../Compositor.hpp"
+#include "../../state/MonitorState.hpp"
 #include "desktop/DesktopTypes.hpp"
 #include "wlr-layer-shell-unstable-v1.hpp"
 
@@ -123,7 +124,7 @@ void CDesktopAnimationManager::startAnimation(PHLLS ls, eAnimationType type, boo
         // get closest edge
         const auto MIDDLE = ls->m_geometry.middle();
 
-        const auto PMONITOR = g_pCompositor->getMonitorFromVector(MIDDLE);
+        const auto PMONITOR = State::monitorState()->query().vec(MIDDLE).run();
 
         if (!PMONITOR) { // can rarely happen on exit
             ls->m_alpha->setValueAndWarp(IN ? 1.F : 0.F);

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -38,6 +38,7 @@
 #include "../../render/Renderer.hpp"
 #include "../../managers/EventManager.hpp"
 #include "../../managers/permissions/DynamicPermissionManager.hpp"
+#include "../../state/MonitorState.hpp"
 
 #include "../../helpers/time/Time.hpp"
 #include "../../helpers/MiscFunctions.hpp"
@@ -257,7 +258,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
     m_lastCursorPosFloored = MOUSECOORDSFLOORED;
 
     // use mouseCoords specifically in case touch sent overridePos, otherwise touch doesn't work on non-focused monitor
-    const auto PMONITOR = isLocked() && Desktop::focusState()->monitor() ? Desktop::focusState()->monitor() : g_pCompositor->getMonitorFromVector(mouseCoords);
+    const auto PMONITOR = isLocked() && Desktop::focusState()->monitor() ? Desktop::focusState()->monitor() : State::monitorState()->query().vec(mouseCoords).run();
 
     // this can happen if there are no displays hooked up to Hyprland
     if (PMONITOR == nullptr)
@@ -891,7 +892,7 @@ void CInputManager::processMouseDownNormal(const IPointer::SButtonEvent& e, SP<I
     // notify app if we didn't handle it
     g_pSeatManager->sendPointerButton(e.timeMs, e.button, e.state);
 
-    if (const auto PMON = g_pCompositor->getMonitorFromVector(mouseCoords); PMON != Desktop::focusState()->monitor() && PMON)
+    if (const auto PMON = State::monitorState()->query().vec(mouseCoords).run(); PMON != Desktop::focusState()->monitor() && PMON)
         Desktop::focusState()->rawMonitorFocus(PMON);
 
     if (g_pSeatManager->m_seatGrab && e.state == WL_POINTER_BUTTON_STATE_PRESSED) {
@@ -1919,7 +1920,7 @@ void CInputManager::setTouchDeviceConfigs(SP<ITouch> dev) {
                 // }
             }
             PTOUCHDEV->m_boundOutput = bound ? output : "";
-            const auto PMONITOR      = bound ? g_pCompositor->getMonitorFromName(output) : nullptr;
+            const auto PMONITOR      = bound ? State::monitorState()->query().name(output).run() : nullptr;
             if (PMONITOR) {
                 Log::logger->log(Log::DEBUG, "Binding touch device {} to output {}", PTOUCHDEV->m_hlName, PMONITOR->m_name);
                 // wlr_cursor_map_input_to_output(g_pCompositor->m_sWLRCursor, &PTOUCHDEV->wlr()->base, PMONITOR->output);

--- a/src/managers/input/InputMethodPopup.cpp
+++ b/src/managers/input/InputMethodPopup.cpp
@@ -5,6 +5,7 @@
 #include "../../protocols/InputMethodV2.hpp"
 #include "../../protocols/core/Compositor.hpp"
 #include "../../output/Monitor.hpp"
+#include "../../state/MonitorState.hpp"
 #include "../../render/Renderer.hpp"
 
 CInputPopup::CInputPopup(SP<CInputMethodPopupV2> popup_) : m_popup(popup_) {
@@ -35,7 +36,7 @@ void CInputPopup::onMap() {
     updateBox();
     damageEntire();
 
-    const auto PMONITOR = g_pCompositor->getMonitorFromVector(globalBox().middle());
+    const auto PMONITOR = State::monitorState()->query().vec(globalBox().middle()).run();
 
     if (!PMONITOR)
         return;
@@ -104,7 +105,7 @@ void CInputPopup::updateBox() {
 
     Vector2D   currentPopupSize = m_surface->getViewporterCorrectedSize() / m_surface->resource()->m_current.scale;
 
-    PHLMONITOR pMonitor = g_pCompositor->getMonitorFromVector(parentBox.middle());
+    PHLMONITOR pMonitor = State::monitorState()->query().vec(parentBox.middle()).run();
 
     Vector2D   popupOffset(0, 0);
 
@@ -134,8 +135,8 @@ void CInputPopup::updateBox() {
 
     damageSurface();
 
-    if (const auto PM = g_pCompositor->getMonitorFromCursor(); PM && PM->m_id != m_lastMonitor) {
-        const auto PML = g_pCompositor->getMonitorFromID(m_lastMonitor);
+    if (const auto PM = State::monitorState()->query().vec(g_pInputManager->getMouseCoordsInternal()).run(); PM && PM->m_id != m_lastMonitor) {
+        const auto PML = State::monitorState()->query().id(m_lastMonitor).run();
 
         if (PML)
             m_surface->resource()->leave(PML->m_self.lock());

--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -6,6 +6,7 @@
 #include "../../desktop/state/FocusState.hpp"
 #include "../../config/ConfigValue.hpp"
 #include "../../output/Monitor.hpp"
+#include "../../state/MonitorState.hpp"
 #include "../../devices/ITouch.hpp"
 #include "../../event/EventBus.hpp"
 #include "../SeatManager.hpp"
@@ -28,7 +29,7 @@ void CInputManager::onTouchDown(ITouch::SDownEvent e) {
     if (info.cancelled)
         return;
 
-    auto PMONITOR = g_pCompositor->getMonitorFromName(!e.device->m_boundOutput.empty() ? e.device->m_boundOutput : "");
+    auto PMONITOR = State::monitorState()->query().name(!e.device->m_boundOutput.empty() ? e.device->m_boundOutput : "").run();
 
     PMONITOR = PMONITOR ? PMONITOR : Desktop::focusState()->monitor();
 
@@ -169,7 +170,7 @@ void CInputManager::onTouchMove(ITouch::SMotionEvent e) {
         return;
     }
     if (m_touchData.touchFocusLockSurface) {
-        const auto PMONITOR     = g_pCompositor->getMonitorFromID(m_touchData.touchFocusLockSurface->iMonitorID);
+        const auto PMONITOR     = State::monitorState()->query().id(m_touchData.touchFocusLockSurface->iMonitorID).run();
         const auto TOUCH_COORDS = PMONITOR->m_position + (e.pos * PMONITOR->m_size);
         const auto LOCAL        = TOUCH_COORDS - PMONITOR->m_position;
         g_pSeatManager->sendTouchMotion(e.timeMs, e.touchID, LOCAL);

--- a/src/managers/input/trackpad/gestures/CursorZoomGesture.cpp
+++ b/src/managers/input/trackpad/gestures/CursorZoomGesture.cpp
@@ -23,7 +23,7 @@ void CCursorZoomTrackpadGesture::begin(const ITrackpadGesture::STrackpadGestureB
         if (!e.pinch)
             return;
 
-        m_monitor = g_pCompositor->getMonitorFromCursor();
+        m_monitor = State::monitorState()->query().vec(g_pInputManager->getMouseCoordsInternal()).run();
         if (!m_monitor)
             return;
 

--- a/src/managers/screenshare/ScreenshareFrame.cpp
+++ b/src/managers/screenshare/ScreenshareFrame.cpp
@@ -8,6 +8,7 @@
 #include "../../render/Renderer.hpp"
 #include "../../render/OpenGL.hpp"
 #include "../../output/Monitor.hpp"
+#include "../../state/MonitorState.hpp"
 #include "../../desktop/view/Window.hpp"
 #include "../../desktop/state/FocusState.hpp"
 #include "../../render/pass/ClearPassElement.hpp"
@@ -71,7 +72,7 @@ eScreenshareError CScreenshareFrame::share(SP<IHLBuffer> buffer, const CRegion& 
     if UNLIKELY (done())
         return ERROR_STOPPED;
 
-    if UNLIKELY (!m_session->monitor() || !g_pCompositor->monitorExists(m_session->monitor())) {
+    if UNLIKELY (!m_session->monitor() || !State::monitorState()->contains(m_session->monitor())) {
         LOGM(Log::ERR, "Client requested sharing of a monitor that is gone");
         m_failed = true;
         return ERROR_STOPPED;

--- a/src/managers/screenshare/ScreenshareManager.cpp
+++ b/src/managers/screenshare/ScreenshareManager.cpp
@@ -3,6 +3,7 @@
 #include "../../Compositor.hpp"
 #include "../../desktop/view/Window.hpp"
 #include "../../protocols/core/Seat.hpp"
+#include "../../state/MonitorState.hpp"
 
 using namespace Screenshare;
 
@@ -44,7 +45,7 @@ void CScreenshareManager::onOutputCommit(PHLMONITOR monitor) {
 }
 
 UP<CScreenshareSession> CScreenshareManager::newSession(wl_client* client, PHLMONITOR monitor) {
-    if UNLIKELY (!monitor || !g_pCompositor->monitorExists(monitor)) {
+    if UNLIKELY (!monitor || !State::monitorState()->contains(monitor)) {
         LOGM(Log::ERR, "Client requested sharing of a monitor that is gone");
         return nullptr;
     }
@@ -58,7 +59,7 @@ UP<CScreenshareSession> CScreenshareManager::newSession(wl_client* client, PHLMO
 }
 
 UP<CScreenshareSession> CScreenshareManager::newSession(wl_client* client, PHLMONITOR monitor, CBox captureRegion) {
-    if UNLIKELY (!monitor || !g_pCompositor->monitorExists(monitor)) {
+    if UNLIKELY (!monitor || !State::monitorState()->contains(monitor)) {
         LOGM(Log::ERR, "Client requested sharing of a monitor that is gone");
         return nullptr;
     }

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -1116,7 +1116,7 @@ void CMonitor::clearModeRetry() {
 }
 
 void CMonitor::addDamage(const pixman_region32_t* rg) {
-    if (m_cursorZoom->value() != 1.f && g_pCompositor->getMonitorFromCursor() == m_self) {
+    if (m_cursorZoom->value() != 1.f && State::monitorState()->query().vec(g_pPointerManager->position()).run() == m_self) {
         m_damage.damageEntire();
         g_pCompositor->scheduleFrameForMonitor(m_self.lock(), Aquamarine::IOutput::AQ_SCHEDULE_DAMAGE);
     } else if (m_damage.damage(rg))
@@ -1128,7 +1128,7 @@ void CMonitor::addDamage(const CRegion& rg) {
 }
 
 void CMonitor::addDamage(const CBox& box) {
-    if (m_cursorZoom->value() != 1.f && g_pCompositor->getMonitorFromCursor() == m_self) {
+    if (m_cursorZoom->value() != 1.f && State::monitorState()->query().vec(g_pPointerManager->position()).run() == m_self) {
         m_damage.damageEntire();
         g_pCompositor->scheduleFrameForMonitor(m_self.lock(), Aquamarine::IOutput::AQ_SCHEDULE_DAMAGE);
         return;
@@ -1162,7 +1162,7 @@ bool CMonitor::isMirror() {
     return m_mirrorOf != nullptr;
 }
 
-bool CMonitor::matchesStaticSelector(const std::string& selector) const {
+bool CMonitor::matchesStaticSelector(std::string_view selector) const {
     if (selector.starts_with("desc:")) {
         // match by description
         const auto DESCRIPTIONSELECTOR = trim(selector.substr(5));
@@ -1233,7 +1233,7 @@ void CMonitor::setupDefaultWS(const Config::CMonitorRule& monitorRule) {
 }
 
 void CMonitor::setMirror(const std::string& mirrorOf) {
-    const auto PMIRRORMON = g_pCompositor->getMonitorFromString(mirrorOf);
+    const auto PMIRRORMON = State::monitorState()->query().relativeTo(Desktop::focusState()->monitor()).configString(mirrorOf).run();
 
     if (PMIRRORMON == m_mirrorOf)
         return;
@@ -1546,7 +1546,7 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
             const auto MIDDLE = w->middle();
             if (w->m_isFloating && VECNOTINRECT(MIDDLE, m_position.x, m_position.y, m_position.x + m_size.x, m_position.y + m_size.y) && !w->isX11OverrideRedirect()) {
                 // if it's floating and the middle isn't on the current mon, move it to the center
-                const auto PMONFROMMIDDLE = g_pCompositor->getMonitorFromVector(MIDDLE);
+                const auto PMONFROMMIDDLE = State::monitorState()->query().vec(MIDDLE).run();
                 Vector2D   pos            = w->m_realPosition->goal();
                 if (VECNOTINRECT(MIDDLE, PMONFROMMIDDLE->m_position.x, PMONFROMMIDDLE->m_position.y, PMONFROMMIDDLE->m_position.x + PMONFROMMIDDLE->m_size.x,
                                  PMONFROMMIDDLE->m_position.y + PMONFROMMIDDLE->m_size.y)) {

--- a/src/output/Monitor.hpp
+++ b/src/output/Monitor.hpp
@@ -261,7 +261,7 @@ namespace Monitor {
         bool        shouldSkipScheduleFrameOnMouseEvent();
         void        setMirror(const std::string&);
         bool        isMirror();
-        bool        matchesStaticSelector(const std::string& selector) const;
+        bool        matchesStaticSelector(std::string_view selector) const;
         float       getDefaultScale();
         void        changeWorkspace(const PHLWORKSPACE& pWorkspace, bool internal = false, bool noMouseMove = false, bool noFocus = false);
         void        changeWorkspace(const WORKSPACEID& id, bool internal = false, bool noMouseMove = false, bool noFocus = false);

--- a/src/protocols/ForeignToplevelWlr.cpp
+++ b/src/protocols/ForeignToplevelWlr.cpp
@@ -7,6 +7,7 @@
 #include "../render/Renderer.hpp"
 #include "../managers/EventManager.hpp"
 #include "../event/EventBus.hpp"
+#include "../state/MonitorState.hpp"
 
 CForeignToplevelHandleWlr::CForeignToplevelHandleWlr(SP<CZwlrForeignToplevelHandleV1> resource_, PHLWINDOW pWindow_) : m_resource(resource_), m_window(pWindow_) {
     if UNLIKELY (!resource_->resource())
@@ -153,7 +154,7 @@ void CForeignToplevelHandleWlr::sendMonitor(PHLMONITOR pMonitor) {
 
     const auto CLIENT = m_resource->client();
 
-    if (const auto PLASTMONITOR = g_pCompositor->getMonitorFromID(m_lastMonitorID); PLASTMONITOR && PROTO::outputs.contains(PLASTMONITOR->m_name)) {
+    if (const auto PLASTMONITOR = State::monitorState()->query().id(m_lastMonitorID).run(); PLASTMONITOR && PROTO::outputs.contains(PLASTMONITOR->m_name)) {
         const auto OLDRESOURCES = PROTO::outputs.at(PLASTMONITOR->m_name)->outputResourcesFrom(CLIENT);
 
         if LIKELY (!OLDRESOURCES.empty()) {

--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -438,7 +438,7 @@ CHyprOpenGLImpl::CHyprOpenGLImpl() : m_drmFD(g_pCompositor->m_drmRenderNode.fd >
     });
 
     static auto P3 = Event::bus()->m_events.input.touch.down.listen([](ITouch::SDownEvent e, Event::SCallbackInfo&) {
-        auto PMONITOR = g_pCompositor->getMonitorFromName(!e.device->m_boundOutput.empty() ? e.device->m_boundOutput : "");
+        auto PMONITOR = State::monitorState()->query().name(!e.device->m_boundOutput.empty() ? e.device->m_boundOutput : "").run();
 
         PMONITOR = PMONITOR ? PMONITOR : Desktop::focusState()->monitor();
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2124,7 +2124,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     }
 
     m_renderData.mouseZoomFactor = 1.f;
-    if (ZOOMFACTOR != 1.f && pMonitor == g_pCompositor->getMonitorFromCursor())
+    if (ZOOMFACTOR != 1.f && pMonitor == State::monitorState()->query().vec(g_pPointerManager->position()).run())
         m_renderData.mouseZoomFactor = std::clamp(ZOOMFACTOR, 1.f, INFINITY);
 
     if (pMonitor->m_zoomAnimProgress->value() != 1) {
@@ -2665,7 +2665,7 @@ void IHyprRenderer::arrangeLayerArray(PHLMONITOR pMonitor, const std::vector<PHL
 }
 
 void IHyprRenderer::arrangeLayersForMonitor(const MONITORID& monitor) {
-    const auto PMONITOR = g_pCompositor->getMonitorFromID(monitor);
+    const auto PMONITOR = State::monitorState()->query().id(monitor).run();
 
     if (!PMONITOR || PMONITOR->m_size.x <= 0 || PMONITOR->m_size.y <= 0)
         return;

--- a/src/state/MonitorQuery.cpp
+++ b/src/state/MonitorQuery.cpp
@@ -1,0 +1,277 @@
+#include "MonitorQuery.hpp"
+#include "MonitorStateTracker.hpp"
+
+#include <utility>
+#include <hyprutils/string/String.hpp>
+#include <hyprutils/string/Numeric.hpp>
+
+using namespace State;
+using namespace Hyprutils::String;
+
+CMonitorQuery::CMonitorQuery(const IMonitorStateTracker& t) : m_tracker(t) {
+    ;
+}
+
+CMonitorQuery&& CMonitorQuery::id(MONITORID id) && {
+    m_id = id;
+    return std::move(*this);
+}
+
+CMonitorQuery&& CMonitorQuery::name(std::string_view name) && {
+    m_name = name;
+    return std::move(*this);
+}
+
+CMonitorQuery&& CMonitorQuery::description(std::string_view desc) && {
+    m_desc = desc;
+    return std::move(*this);
+}
+
+CMonitorQuery&& CMonitorQuery::selector(std::string_view str) && {
+    m_str = str;
+    return std::move(*this);
+}
+
+CMonitorQuery&& CMonitorQuery::configString(std::string_view str) && {
+    m_configString = str;
+    return std::move(*this);
+}
+
+CMonitorQuery&& CMonitorQuery::vec(Vector2D vec) && {
+    m_vec = vec;
+    return std::move(*this);
+}
+
+CMonitorQuery&& CMonitorQuery::output(SP<Aquamarine::IOutput> output) && {
+    m_output = output;
+    return std::move(*this);
+}
+
+CMonitorQuery&& CMonitorQuery::relativeTo(PHLMONITOR reference) && {
+    m_relativeTo = reference;
+    return std::move(*this);
+}
+
+CMonitorQuery&& CMonitorQuery::inDirection(Math::eDirection dir) && {
+    m_dir = dir;
+    return std::move(*this);
+}
+
+CMonitorQuery&& CMonitorQuery::includeDisabled(bool inc) && {
+    m_includeDisabled = inc;
+    return std::move(*this);
+}
+
+PHLMONITOR CMonitorQuery::run() && {
+    if (m_vec && !m_desc && !m_str && !m_id && !m_name && !m_output && !m_dir) {
+        // legacy path for closest-monitor
+        return closestTo(*m_vec);
+    }
+
+    if (m_dir) {
+        // path for getting a monitor in a direction
+        return directionLookup(m_relativeTo.value_or(nullptr), *m_dir);
+    }
+
+    if (m_configString) {
+        // path for getting from a config string
+        return fromConfigString(*m_configString);
+    }
+
+    for (const auto& m : mons()) {
+        if (m_desc && !m->m_description.starts_with(*m_desc))
+            continue;
+
+        if (m_name && *m_name != m->m_name)
+            continue;
+
+        if (m_id && *m_id != m->m_id)
+            continue;
+
+        if (m_output && *m_output != m->m_output)
+            continue;
+
+        if (m_vec && !m->logicalBox().containsPoint(*m_vec))
+            continue;
+
+        if (m_str && !m->matchesStaticSelector(*m_str))
+            continue;
+
+        return m;
+    }
+
+    return nullptr;
+}
+
+const std::vector<PHLMONITOR>& CMonitorQuery::mons() const {
+    return m_includeDisabled ? m_tracker.allMonitors() : m_tracker.monitors();
+}
+
+PHLMONITOR CMonitorQuery::closestTo(const Vector2D& vec) const {
+    PHLMONITOR mon;
+    for (auto const& m : mons()) {
+        if (CBox{m->m_position, m->m_size}.containsPoint(vec)) {
+            mon = m;
+            break;
+        }
+    }
+
+    if (!mon) {
+        float      bestDistance = 0.f;
+        PHLMONITOR pBestMon;
+
+        for (auto const& m : mons()) {
+            float dist = vecToRectDistanceSquared(vec, m->m_position, m->m_position + m->m_size);
+
+            if (dist < bestDistance || !pBestMon) {
+                bestDistance = dist;
+                pBestMon     = m;
+            }
+        }
+
+        if (!pBestMon) { // ?????
+            Log::logger->log(Log::WARN, "CMonitorQuery::closestTo: no close mon???");
+            return nullptr;
+        }
+
+        return pBestMon;
+    }
+
+    return mon;
+}
+
+PHLMONITOR CMonitorQuery::directionLookup(PHLMONITOR ref, Math::eDirection dir) const {
+    if (!ref)
+        return nullptr;
+
+    const auto POSA  = ref->m_position;
+    const auto SIZEA = ref->m_size;
+
+    auto       longestIntersect        = -1;
+    PHLMONITOR longestIntersectMonitor = nullptr;
+
+    for (auto const& m : mons()) {
+        if (m == ref)
+            continue;
+
+        const auto POSB  = m->m_position;
+        const auto SIZEB = m->m_size;
+        switch (dir) {
+            case Math::DIRECTION_LEFT:
+                if (STICKS(POSA.x, POSB.x + SIZEB.x)) {
+                    const auto INTERSECTLEN = std::max(0.0, std::min(POSA.y + SIZEA.y, POSB.y + SIZEB.y) - std::max(POSA.y, POSB.y));
+                    if (INTERSECTLEN > longestIntersect) {
+                        longestIntersect        = INTERSECTLEN;
+                        longestIntersectMonitor = m;
+                    }
+                }
+                break;
+            case Math::DIRECTION_RIGHT:
+                if (STICKS(POSA.x + SIZEA.x, POSB.x)) {
+                    const auto INTERSECTLEN = std::max(0.0, std::min(POSA.y + SIZEA.y, POSB.y + SIZEB.y) - std::max(POSA.y, POSB.y));
+                    if (INTERSECTLEN > longestIntersect) {
+                        longestIntersect        = INTERSECTLEN;
+                        longestIntersectMonitor = m;
+                    }
+                }
+                break;
+            case Math::DIRECTION_UP:
+                if (STICKS(POSA.y, POSB.y + SIZEB.y)) {
+                    const auto INTERSECTLEN = std::max(0.0, std::min(POSA.x + SIZEA.x, POSB.x + SIZEB.x) - std::max(POSA.x, POSB.x));
+                    if (INTERSECTLEN > longestIntersect) {
+                        longestIntersect        = INTERSECTLEN;
+                        longestIntersectMonitor = m;
+                    }
+                }
+                break;
+            case Math::DIRECTION_DOWN:
+                if (STICKS(POSA.y + SIZEA.y, POSB.y)) {
+                    const auto INTERSECTLEN = std::max(0.0, std::min(POSA.x + SIZEA.x, POSB.x + SIZEB.x) - std::max(POSA.x, POSB.x));
+                    if (INTERSECTLEN > longestIntersect) {
+                        longestIntersect        = INTERSECTLEN;
+                        longestIntersectMonitor = m;
+                    }
+                }
+                break;
+            default: break;
+        }
+    }
+
+    if (longestIntersect != -1)
+        return longestIntersectMonitor;
+
+    return nullptr;
+}
+
+PHLMONITOR CMonitorQuery::fromConfigString(std::string_view sv) const {
+    if (sv.empty())
+        return nullptr;
+
+    if (sv == "current")
+        return m_relativeTo.value_or(nullptr);
+    else if (!sv.empty() && isDirection(sv[0]))
+        return directionLookup(m_relativeTo.value_or(nullptr), Math::fromChar(sv[0]));
+    else if (sv[0] == '+' || sv[0] == '-') {
+        // relative
+
+        if (mons().size() == 1)
+            return *mons().begin();
+
+        const auto OFFSET = sv[0] == '-' ? sv : sv.substr(1);
+
+        if (!isNumber(std::string{OFFSET})) {
+            Log::logger->log(Log::ERR, "Error in CMonitorQuery::fromConfigString: Not a number in relative.");
+            return nullptr;
+        }
+
+        int offsetLeft = strToNumber<int>(OFFSET).value_or(0);
+        offsetLeft     = offsetLeft < 0 ? -((-offsetLeft) % mons().size()) : offsetLeft % mons().size();
+
+        int currentPlace = 0;
+        for (int i = 0; i < sc<int>(mons().size()); i++) {
+            if (mons()[i] == m_relativeTo.value_or(nullptr)) {
+                currentPlace = i;
+                break;
+            }
+        }
+
+        currentPlace += offsetLeft;
+
+        if (currentPlace < 0)
+            currentPlace = mons().size() + currentPlace;
+        else
+            currentPlace = currentPlace % mons().size();
+
+        if (currentPlace != std::clamp(currentPlace, 0, sc<int>(mons().size()) - 1)) {
+            Log::logger->log(Log::WARN, "Error in CMonitorQuery::fromConfigString: Vaxry's code sucks.");
+            currentPlace = std::clamp(currentPlace, 0, sc<int>(mons().size()) - 1);
+        }
+
+        return mons()[currentPlace];
+    } else if (isNumber(std::string{sv})) {
+        // change by ID
+        auto monID = strToNumber<MONITORID>(sv);
+        if (!monID) {
+            // shouldn't happen but jic
+            Log::logger->log(Log::ERR, "Error in CMonitorQuery::fromConfigString: invalid num");
+            return nullptr;
+        }
+
+        if (*monID > -1 && *monID < sc<MONITORID>(mons().size())) {
+            return CMonitorQuery{m_tracker}.id(*monID).run();
+        } else {
+            Log::logger->log(Log::ERR, "Error in CMonitorQuery::fromConfigString: invalid arg 1");
+            return nullptr;
+        }
+    } else {
+        for (auto const& m : mons()) {
+            if (!m->m_output)
+                continue;
+
+            if (m->matchesStaticSelector(sv))
+                return m;
+        }
+    }
+
+    return nullptr;
+}

--- a/src/state/MonitorQuery.hpp
+++ b/src/state/MonitorQuery.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "../output/Monitor.hpp"
+#include "../helpers/math/Direction.hpp"
+
+#include <string_view>
+#include <optional>
+
+namespace Aquamarine {
+    class IOutput;
+}
+
+namespace State {
+    class IMonitorStateTracker;
+
+    class CMonitorQuery {
+      public:
+        CMonitorQuery(const IMonitorStateTracker&);
+        ~CMonitorQuery() = default;
+
+        CMonitorQuery(const CMonitorQuery&) = delete;
+        CMonitorQuery(CMonitorQuery&)       = delete;
+        CMonitorQuery(CMonitorQuery&&)      = delete;
+
+        CMonitorQuery&& id(MONITORID id) &&;
+        CMonitorQuery&& name(std::string_view name) &&;
+        CMonitorQuery&& description(std::string_view desc) &&;
+        CMonitorQuery&& selector(std::string_view str) &&;
+        CMonitorQuery&& configString(std::string_view str) &&;
+        CMonitorQuery&& vec(Vector2D vec) &&;
+        CMonitorQuery&& output(SP<Aquamarine::IOutput> output) &&;
+        CMonitorQuery&& inDirection(Math::eDirection dir) &&;
+        CMonitorQuery&& relativeTo(PHLMONITOR reference) &&;
+        CMonitorQuery&& includeDisabled(bool inc) &&;
+
+        PHLMONITOR      run() &&;
+
+      private:
+        PHLMONITOR                             closestTo(const Vector2D& vec) const;
+        PHLMONITOR                             directionLookup(PHLMONITOR ref, Math::eDirection dir) const;
+        PHLMONITOR                             fromConfigString(std::string_view sv) const;
+
+        const std::vector<PHLMONITOR>&         mons() const;
+
+        std::optional<MONITORID>               m_id;
+        std::optional<std::string_view>        m_name, m_desc, m_str, m_configString;
+        std::optional<SP<Aquamarine::IOutput>> m_output;
+        std::optional<PHLMONITOR>              m_relativeTo;
+        std::optional<Math::eDirection>        m_dir;
+        std::optional<Vector2D>                m_vec;
+        bool                                   m_includeDisabled = false;
+        const IMonitorStateTracker&            m_tracker;
+    };
+}

--- a/src/state/MonitorState.cpp
+++ b/src/state/MonitorState.cpp
@@ -9,6 +9,7 @@
 #include "../output/MonitorFrameScheduler.hpp"
 #include "../Compositor.hpp"
 #include "../managers/input/InputManager.hpp"
+#include "../managers/PointerManager.hpp"
 
 #include <unordered_set>
 
@@ -97,7 +98,7 @@ static void checkDefaultCursorWarp(PHLMONITOR monitor) {
     }
 
     // modechange happened check if cursor is on that monitor and warp it to middle to not place it out of bounds if resolution changed.
-    if (g_pCompositor->getMonitorFromCursor() == monitor) {
+    if (State::monitorState()->query().vec(g_pPointerManager->position()).run() == monitor) {
         g_pCompositor->warpCursorTo(POS, true);
         g_pInputManager->refocus();
     }

--- a/src/state/MonitorState.hpp
+++ b/src/state/MonitorState.hpp
@@ -4,24 +4,26 @@
 #include <unordered_map>
 #include <aquamarine/output/Output.hpp>
 
+#include "MonitorStateTracker.hpp"
+
 #include "../desktop/DesktopTypes.hpp"
 #include "../helpers/signal/Signal.hpp"
 #include "../SharedDefs.hpp"
 
 namespace State {
-    class CMonitorStateTracker {
+    class CMonitorStateTracker : public IMonitorStateTracker {
       public:
         CMonitorStateTracker();
-        ~CMonitorStateTracker() = default;
+        virtual ~CMonitorStateTracker() override = default;
 
-        const std::vector<PHLMONITOR>& allMonitors() const;
-        const std::vector<PHLMONITOR>& monitors() const;
+        virtual const std::vector<PHLMONITOR>& allMonitors() const override;
+        virtual const std::vector<PHLMONITOR>& monitors() const override;
 
-        void                           add(PHLMONITOR mon);
-        void                           add(SP<Aquamarine::IOutput> output);
-        void                           remove(PHLMONITOR mon);
+        void                                   add(PHLMONITOR mon);
+        void                                   add(SP<Aquamarine::IOutput> output);
+        void                                   remove(PHLMONITOR mon);
 
-        void                           finish();
+        void                                   finish();
 
       private:
         MONITORID                                  getNextAvailableMonitorID(const std::string& name);

--- a/src/state/MonitorStateTracker.cpp
+++ b/src/state/MonitorStateTracker.cpp
@@ -1,0 +1,14 @@
+#include "MonitorStateTracker.hpp"
+#include "MonitorQuery.hpp"
+
+#include <algorithm>
+
+using namespace State;
+
+CMonitorQuery IMonitorStateTracker::query() const {
+    return CMonitorQuery{*this};
+}
+
+bool IMonitorStateTracker::contains(PHLMONITOR monitor) const {
+    return std::ranges::contains(allMonitors(), monitor);
+}

--- a/src/state/MonitorStateTracker.hpp
+++ b/src/state/MonitorStateTracker.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <vector>
+
+#include "../desktop/DesktopTypes.hpp"
+#include "MonitorQuery.hpp"
+
+namespace State {
+    class IMonitorStateTracker {
+      public:
+        virtual ~IMonitorStateTracker() = default;
+
+        virtual const std::vector<PHLMONITOR>& allMonitors() const = 0;
+        virtual const std::vector<PHLMONITOR>& monitors() const    = 0;
+
+        virtual CMonitorQuery                  query() const;
+        virtual bool                           contains(PHLMONITOR monitor) const;
+
+      protected:
+        IMonitorStateTracker() = default;
+    };
+}


### PR DESCRIPTION
Reduce god-classiness of CCompositor, part 1: monitor lookups


