### PR TITLE
fix(meta): capture of lua events

### DIFF
--- a/meta/generateLuaStubs.py
+++ b/meta/generateLuaStubs.py
@@ -385,7 +385,7 @@ def parse_descriptor_fields(root: Path) -> dict[str, dict[str, str]]:
 def parse_known_events(root: Path) -> list[str]:
     source = read_text(root / "src/config/lua/LuaEventHandler.cpp")
     block_match = re.search(
-        r"static const std::unordered_set<std::string> EVENTS = \{(.*?)\};",
+        r"std::unordered_set<std::string> EVENTS = \{(.*?)\};",
         source,
         flags=re.DOTALL,
     )


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes https://github.com/hyprwm/Hyprland/discussions/15027, 50b5169b91bf84e93b8886f1c4d11be0fc32fd13 broke the capture regex due to refactoring `EVENTS` to a local variable. This changes the regex to accommodate this.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Maybe change the event grabbing method in the feature, as this seems a bit prone to breakage. Alternatively maybe add assertions to the generator, e.g. fail when no events are found, as this shouldn't happen under normal circumstances.

#### Is it ready for merging, or does it need work?
Ready.

