### PR TITLE
dnd: fix touch-driven drag-and-drop

### DIFF
--- a/src/managers/input/InputManager.hpp
+++ b/src/managers/input/InputManager.hpp
@@ -60,6 +60,7 @@ struct STouchData {
     PHLLSREF                touchFocusLS;
     WP<CWLSurfaceResource>  touchFocusSurface;
     Vector2D                touchSurfaceOrigin;
+    Vector2D                lastTouchPos;
 };
 
 // The third row is always 0 0 1 and is not expected by `libinput_device_config_calibration_set_matrix`

--- a/src/managers/input/Touch.cpp
+++ b/src/managers/input/Touch.cpp
@@ -10,6 +10,7 @@
 #include "../../devices/ITouch.hpp"
 #include "../../event/EventBus.hpp"
 #include "../SeatManager.hpp"
+#include "../../protocols/core/DataDevice.hpp"
 #include "debug/log/Logger.hpp"
 #include "UnifiedWorkspaceSwipeGesture.hpp"
 
@@ -37,6 +38,8 @@ void CInputManager::onTouchDown(ITouch::SDownEvent e) {
         Desktop::focusState()->rawMonitorFocus(PMONITOR);
 
     const auto TOUCH_COORDS = PMONITOR->m_position + (e.pos * PMONITOR->m_size);
+
+    m_touchData.lastTouchPos = TOUCH_COORDS;
 
     refocus(TOUCH_COORDS);
 
@@ -138,6 +141,12 @@ void CInputManager::onTouchMove(ITouch::SMotionEvent e) {
 
     m_lastCursorMovement.reset();
 
+    // Cache the global touch position so listeners (in particular the dnd
+    // touchMove listener emitted just below) and renderers can resolve where
+    // the finger currently is in layout coordinates.
+    if (const auto PMONITOR = Desktop::focusState()->monitor(); PMONITOR)
+        m_touchData.lastTouchPos = PMONITOR->m_position + (e.pos * PMONITOR->m_size);
+
     Event::SCallbackInfo info;
     Event::bus()->m_events.input.touch.motion.emit(e, info);
     if (info.cancelled)
@@ -167,6 +176,14 @@ void CInputManager::onTouchMove(ITouch::SMotionEvent e) {
         else
             // go from 0 to SWIPEDISTANCE
             g_pUnifiedWorkspaceSwipe->update(SWIPEDISTANCE * (1 - (VERTANIMS ? e.pos.y : e.pos.x)));
+        return;
+    }
+    // During a drag-and-drop session, repick the surface under the finger so
+    // wl_data_device enter/leave/offer follow the touch point, the same way
+    // cursor motion drives pointer focus during mouse drags. Touch events are
+    // not delivered to surfaces during the drag (mouse drags work likewise).
+    if (PROTO::data->dndActive()) {
+        refocus(m_touchData.lastTouchPos);
         return;
     }
     if (m_touchData.touchFocusLockSurface) {

--- a/src/protocols/core/DataDevice.cpp
+++ b/src/protocols/core/DataDevice.cpp
@@ -564,6 +564,12 @@ void CWLDataDeviceProtocol::initiateDrag(WP<CWLDataSourceResource> currentSource
     Cursor::overrideController->setOverride("grabbing", Cursor::CURSOR_OVERRIDE_DND);
     m_dnd.overriddenCursor = true;
 
+    // For touch-initiated drags, anchor the drag icon to the touch point
+    // right away. Until the first touch motion arrives it would otherwise
+    // be rendered at the (possibly far away) mouse cursor position.
+    if (g_pInputManager->m_lastInputTouch)
+        m_dnd.touchPos = g_pInputManager->m_touchData.lastTouchPos;
+
     LOGM(Log::DEBUG, "initiateDrag: source {:x}, surface: {:x}, origin: {:x}", (uintptr_t)currentSource.get(), (uintptr_t)dragSurface, (uintptr_t)origin);
 
     currentSource->m_used = true;
@@ -623,6 +629,9 @@ void CWLDataDeviceProtocol::initiateDrag(WP<CWLDataSourceResource> currentSource
     });
 
     m_dnd.touchMove = Event::bus()->m_events.input.touch.motion.listen([this](ITouch::SMotionEvent e, Event::SCallbackInfo&) {
+        // Mirror the mouse drag path: the input layer (CInputManager::onTouchMove)
+        // refocuses dndPointerFocus from the global touch position; here we just
+        // send surface-local motion against the currently focused dnd surface.
         if (m_dnd.focusedDevice && g_pSeatManager->m_state.dndPointerFocus) {
             auto surf = Desktop::View::CWLSurface::fromResource(g_pSeatManager->m_state.dndPointerFocus.lock());
 
@@ -634,8 +643,12 @@ void CWLDataDeviceProtocol::initiateDrag(WP<CWLDataSourceResource> currentSource
             if (!box.has_value())
                 return;
 
-            m_dnd.focusedDevice->sendMotion(e.timeMs, e.pos);
-            LOGM(Log::DEBUG, "Drag motion {}", e.pos);
+            const auto POS = g_pInputManager->m_touchData.lastTouchPos;
+
+            m_dnd.touchPos = POS;
+
+            m_dnd.focusedDevice->sendMotion(e.timeMs, POS - box->pos());
+            LOGM(Log::DEBUG, "Drag motion {}", POS - box->pos());
         }
     });
 
@@ -707,6 +720,7 @@ void CWLDataDeviceProtocol::cleanupDndState(bool resetDevice, bool resetSource, 
     m_dnd.mouseMove.reset();
     m_dnd.touchUp.reset();
     m_dnd.touchMove.reset();
+    m_dnd.touchPos.reset();
     m_dnd.tabletTip.reset();
 
     if (resetDevice)
@@ -816,7 +830,7 @@ void CWLDataDeviceProtocol::renderDND(PHLMONITOR pMonitor, const Time::steady_tp
     if (!m_dnd.dndSurface || !m_dnd.dndSurface->m_current.texture)
         return;
 
-    const auto POS = g_pInputManager->getMouseCoordsInternal();
+    const auto POS = m_dnd.touchPos.value_or(g_pInputManager->getMouseCoordsInternal());
 
     Vector2D   surfacePos = POS;
 

--- a/src/protocols/core/DataDevice.hpp
+++ b/src/protocols/core/DataDevice.hpp
@@ -10,6 +10,7 @@
 
 #include <vector>
 #include <cstdint>
+#include <optional>
 #include "../WaylandProtocol.hpp"
 #include <wayland-server-protocol.h>
 #include "wayland.hpp"
@@ -168,13 +169,14 @@ class CWLDataDeviceProtocol : public IWaylandProtocol {
     void onDndPointerFocus();
 
     struct {
-        WP<IDataDevice>        focusedDevice;
-        WP<IDataSource>        currentSource;
-        WP<CWLSurfaceResource> dndSurface;
-        WP<CWLSurfaceResource> originSurface;
-        bool                   overriddenCursor = false;
-        CHyprSignalListener    dndSurfaceDestroy;
-        CHyprSignalListener    dndSurfaceCommit;
+        WP<IDataDevice>         focusedDevice;
+        WP<IDataSource>         currentSource;
+        WP<CWLSurfaceResource>  dndSurface;
+        WP<CWLSurfaceResource>  originSurface;
+        std::optional<Vector2D> touchPos;
+        bool                    overriddenCursor = false;
+        CHyprSignalListener     dndSurfaceDestroy;
+        CHyprSignalListener     dndSurfaceCommit;
 
         // for ending a dnd
         CHyprSignalListener mouseMove;


### PR DESCRIPTION
## Describe your PR, what does it fix/add?

Fixes drag-and-drop initiated from a touchscreen (long-press drag). Touch could *start* a drag, but not *drive* it:

- `wl_data_device.motion` was sent with `ITouch::SMotionEvent.pos` as-is. That value is normalized `[0, 1]` monitor-relative, not surface-local, so drop targets saw the drag permanently stuck in their top-left corner.
- `dndPointerFocus` is only updated by the pointer focus pipeline, so `enter`/`leave` never followed the finger.
- `renderDND()` draws the drag icon at the mouse cursor, which is unrelated to where the finger is.

Fix:

- translate the touch position to global layout coords (same mapping `CInputManager::onTouchMove` uses)
- call `refocus()` on touch motion during a drag, so the existing dnd focus path keeps `enter`/`leave`/offers correct, exactly like mouse drags
- send surface-local motion coords
- anchor the drag icon to the touch point, from the moment the drag starts

Tablets got the same treatment recently (#11270, #11390); touch was the last input type left behind.

## Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Tested on a touchscreen with Chromium (working on bringin touchdrag to chromium -> https://crbug.com/451651623)

## Is it ready for merging, or does it need work?

Ready for merging.
