### PR TITLE
Dwindle: fix moving windows across a split

### DIFF
--- a/hyprtester/src/tests/main/dwindle.cpp
+++ b/hyprtester/src/tests/main/dwindle.cpp
@@ -214,3 +214,52 @@ TEST_CASE(dwindleForceSplitOnMoveToWorkspace) {
     std::string activeWindow = getFromSocket("/activewindow");
     EXPECT(activeWindow.contains(posBefore), false);
 }
+
+TEST_CASE(dwindleMoveAcrossToggledSplit) {
+    // If we have a split whose orientation has been manually toggled (e.g.
+    // vertically stacked, when the split's aspect ratio is such that it would
+    // prefer to be horizontally stacked by default), moving a window across
+    // the split should NOT revert back to the preferred split orientation
+
+    OK(getFromSocket("/eval hl.config({ dwindle = { force_split = 2 } })"));
+    for (auto const& win : {"a", "b"}) {
+        if (!Tests::spawnKitty(win)) {
+            FAIL_TEST("Could not spawn kitty with win class `{}`", win);
+        }
+    }
+    OK(getFromSocket("/dispatch hl.dsp.layout('togglesplit')"));
+    // Window A, now on top, is to be moved
+
+    auto origWinB   = getFromSocket("/activewindow");
+    auto expectPos  = "at: " + Tests::getAttribute(origWinB, "at");
+    auto expectSize = "size: " + Tests::getAttribute(origWinB, "size");
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:a' })"));
+
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ direction = 'down' })"));
+
+    // Window A should be moved down, so position and size should swap with window B
+    auto newWinA = getFromSocket("/activewindow");
+    EXPECT_CONTAINS(newWinA, std::move(expectPos));
+    EXPECT_CONTAINS(newWinA, std::move(expectSize));
+}
+
+TEST_CASE(dwindleMoveSmallWindowAcrossSplit) {
+    // Small windows (<50% of their parent split's area) should be possible to
+    // move across a split. Focal point weirdness has broken this in the past.
+
+    OK(getFromSocket("/eval hl.config({ dwindle = { force_split = 1 } })"));
+    OK(getFromSocket("/eval hl.config({ dwindle = { default_split_ratio = 1.2 } })"));
+    for (auto const& win : {"a", "b"}) {
+        if (!Tests::spawnKitty(win)) {
+            FAIL_TEST("Could not spawn kitty with win class `{}`", win);
+        }
+    }
+    // Window B, on the left, is the smaller one
+
+    auto posBefore = "at: " + Tests::getAttribute(getFromSocket("/activewindow"), "at");
+
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ direction = 'right' })"));
+
+    // Window B should be moved right, so position should change
+    EXPECT_NOT_CONTAINS(getFromSocket("/activewindow"), posBefore);
+}

--- a/src/layout/algorithm/tiled/dwindle/DwindleAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/dwindle/DwindleAlgorithm.cpp
@@ -551,6 +551,22 @@ void CDwindleAlgorithm::moveTargetInDirection(SP<ITarget> t, Math::eDirection di
     if (PMONITORFOCAL != m_parent->space()->workspace()->m_monitor && !*PMONITORFALLBACK)
         return; // noop
 
+    // if we're moving directly toward the most immediate split divider, and
+    // our partner in the split is a single window, override the direction to
+    // guarantee we spawn on the opposite side of that partner
+    const auto PARENT = PNODE->pParent;
+    if (PARENT) {
+        // clang-format off
+        if (((dir == Math::DIRECTION_UP)    &&  PARENT->splitTop && (PARENT->children[1] == PNODE) && !PARENT->children[0]->isNode)  // moving up and we're on the bottom
+         || ((dir == Math::DIRECTION_DOWN)  &&  PARENT->splitTop && (PARENT->children[0] == PNODE) && !PARENT->children[1]->isNode)  // moving down and we're on the top
+         || ((dir == Math::DIRECTION_LEFT)  && !PARENT->splitTop && (PARENT->children[1] == PNODE) && !PARENT->children[0]->isNode)  // moving left and we're on the right
+         || ((dir == Math::DIRECTION_RIGHT) && !PARENT->splitTop && (PARENT->children[0] == PNODE) && !PARENT->children[1]->isNode)  // moving right and we're on the left
+        ) {
+            // clang-format on
+            m_overrideDirection = dir;
+        }
+    }
+
     t->window()->setAnimationsToMove();
 
     removeTarget(t);


### PR DESCRIPTION
This PR fixes two related window-move bugs in dwindle:
- Attempting to move a window that fills less than 50% of its split to the opposite side of said split, will just place the window back on the same side.
- A split's direction is forgotten during a move when it probably shouldn't be. e.g. you have a vertical-split node that you've explicitly made that way (via the togglesplit layout message), attempting to move a child of that node up or down makes the node revert to its original horizontal layout.

Both of these behaviors arise because the window-move logic works by choosing a "focus point" for new-window placement. That focus point works fine most of the time, except when we have two windows that are direct siblings of a layout node, and we try to move one of them toward the other.
In the small-window case, the focus point is on the same side of the split that the window-to-move was already on, so the window simply doesn't get moved.
In the togglesplit-forgetting case, the new layout node just falls back to whatever split orientation dwindle prefers, based on aspect ratio. This can result in you hitting, say, your move-up bind and having the window go right instead.

Both of these are resolved by identifying move operations where a) a window is pushed toward its most immediate split divider and b) its partner across that divider is not another subdivided node, and overriding the split direction to ensure the new window is placed on the opposite side of that partner. e.g. if you're on the left side of a horizontal split, moving right triggers the new logic.

I've also included a single test that covers both of the issues this change fixes. Let me know if two separate tests would be preferable, or if maybe some of this behavior isn't specified well enough to be worth testing(?).