### PR TITLE
buffer: wait on seperate fences instead of merging

### DIFF
--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -151,8 +151,8 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
         m_events.stateCommit.emit(state);
 
         if (state->buffer && state->buffer->type() == Aquamarine::BUFFER_TYPE_DMABUF && state->buffer->dmabuf().success && !state->updated.bits.acquire) {
-            state->buffer->m_syncFd = dc<CDMABuffer*>(state->buffer.m_buffer.get())->exportSyncFile();
-            if (state->buffer->m_syncFd.isValid())
+            state->buffer->m_syncFds = dc<CDMABuffer*>(state->buffer.m_buffer.get())->exportSyncFiles();
+            if (!state->buffer->m_syncFds.empty())
                 m_stateQueue.lock(state, LOCK_REASON_FENCE);
         }
 
@@ -548,13 +548,34 @@ void CWLSurfaceResource::scheduleState(WP<SSurfaceState> state) {
     } else if (state->buffer && state->buffer->isSynchronous()) {
         // synchronous (shm) buffers can be read immediately
         m_stateQueue.unlock(state, LOCK_REASON_FENCE);
-    } else if (state->buffer && state->buffer->m_syncFd.isValid()) {
+    } else if (state->buffer && !state->buffer->m_syncFds.empty()) {
         // async buffer and is dmabuf, then we can wait on implicit fences
-        g_pEventLoopManager->doOnReadable(std::move(state->buffer->m_syncFd), [state, whenReadable]() { whenReadable(state, LOCK_REASON_FENCE); });
+        drainSyncFds(state, LOCK_REASON_FENCE);
     } else {
         // state commit without a buffer.
         m_stateQueue.tryProcess();
     }
+}
+
+void CWLSurfaceResource::drainSyncFds(WP<SSurfaceState> state, eLockReason reason) {
+    auto& fds = state->buffer->m_syncFds;
+
+    while (!fds.empty() && fds.front().isReadable())
+        fds.erase(fds.begin());
+
+    if (!fds.empty()) {
+        auto fd = std::move(fds.front());
+        fds.erase(fds.begin());
+        g_pEventLoopManager->doOnReadable(std::move(fd), [this, surf = m_self, state, reason]() {
+            if (!surf || !state)
+                return;
+
+            drainSyncFds(state, reason);
+        });
+        return;
+    }
+
+    m_stateQueue.unlock(state, reason);
 }
 
 void CWLSurfaceResource::commitState(SSurfaceState& state) {

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -560,8 +560,7 @@ void CWLSurfaceResource::scheduleState(WP<SSurfaceState> state) {
 void CWLSurfaceResource::drainSyncFds(WP<SSurfaceState> state, eLockReason reason) {
     auto& fds = state->buffer->m_syncFds;
 
-    while (!fds.empty() && fds.front().isReadable())
-        fds.erase(fds.begin());
+    std::erase_if(fds, [](const auto& fd) { return fd.isReadable(); });
 
     if (!fds.empty()) {
         auto fd = std::move(fds.front());

--- a/src/protocols/core/Compositor.hpp
+++ b/src/protocols/core/Compositor.hpp
@@ -124,6 +124,7 @@ class CWLSurfaceResource {
     SP<CWLSurfaceResource>                 findWithCM();
     void                                   presentFeedback(const Time::steady_tp& when, PHLMONITOR pMonitor, bool discarded = false);
     void                                   scheduleState(WP<SSurfaceState> state);
+    void                                   drainSyncFds(WP<SSurfaceState> state, eLockReason reason);
     void                                   commitState(SSurfaceState& state);
     NColorManagement::PImageDescription    getPreferredImageDescription();
     void                                   sortSubsurfaces();

--- a/src/protocols/types/Buffer.hpp
+++ b/src/protocols/types/Buffer.hpp
@@ -13,24 +13,24 @@ class CHLBufferReference;
 class IHLBuffer : public Aquamarine::IBuffer {
   public:
     virtual ~IHLBuffer();
-    virtual Aquamarine::eBufferCapability caps()                        = 0;
-    virtual Aquamarine::eBufferType       type()                        = 0;
-    virtual void                          update(const CRegion& damage) = 0;
-    virtual bool                          isSynchronous()               = 0; // whether the updates to this buffer are synchronous, aka happen over cpu
-    virtual bool                          good()                        = 0;
-    virtual void                          sendRelease();
-    virtual void                          lock();
-    virtual void                          unlock();
-    virtual bool                          locked();
+    virtual Aquamarine::eBufferCapability       caps()                        = 0;
+    virtual Aquamarine::eBufferType             type()                        = 0;
+    virtual void                                update(const CRegion& damage) = 0;
+    virtual bool                                isSynchronous()               = 0; // whether the updates to this buffer are synchronous, aka happen over cpu
+    virtual bool                                good()                        = 0;
+    virtual void                                sendRelease();
+    virtual void                                lock();
+    virtual void                                unlock();
+    virtual bool                                locked();
 
-    void                                  onBackendRelease(const std::function<void()>& fn);
-    void                                  addReleasePoint(CDRMSyncPointState& point);
+    void                                        onBackendRelease(const std::function<void()>& fn);
+    void                                        addReleasePoint(CDRMSyncPointState& point);
 
-    SP<Render::ITexture>                  m_texture;
-    bool                                  m_opaque = false;
-    SP<CWLBufferResource>                 m_resource;
-    std::vector<UP<CSyncReleaser>>        m_syncReleasers;
-    Hyprutils::OS::CFileDescriptor        m_syncFd;
+    SP<Render::ITexture>                        m_texture;
+    bool                                        m_opaque = false;
+    SP<CWLBufferResource>                       m_resource;
+    std::vector<UP<CSyncReleaser>>              m_syncReleasers;
+    std::vector<Hyprutils::OS::CFileDescriptor> m_syncFds;
 
     struct {
         CHyprSignalListener backendRelease;

--- a/src/protocols/types/DMABuffer.cpp
+++ b/src/protocols/types/DMABuffer.cpp
@@ -87,7 +87,7 @@ void CDMABuffer::closeFDs() {
     m_attrs.planes = 0;
 }
 
-CFileDescriptor CDMABuffer::exportSyncFile() {
+std::vector<CFileDescriptor> CDMABuffer::exportSyncFiles() {
     if (!good())
         return {};
 
@@ -113,19 +113,6 @@ CFileDescriptor CDMABuffer::exportSyncFile() {
             syncFds.emplace_back(std::move(fence));
     }
 
-    if (syncFds.empty())
-        return {};
-
-    CFileDescriptor syncFd;
-    for (auto& fd : syncFds) {
-        if (!syncFd.isValid()) {
-            syncFd = std::move(fd);
-            continue;
-        }
-
-        syncFd = DRM::mergeFence(syncFd, fd);
-    }
-
-    return syncFd;
+    return syncFds;
 #endif
 }

--- a/src/protocols/types/DMABuffer.hpp
+++ b/src/protocols/types/DMABuffer.hpp
@@ -17,7 +17,7 @@ class CDMABuffer : public IHLBuffer {
     virtual void                                   endDataPtr();
     bool                                           good();
     void                                           closeFDs();
-    Hyprutils::OS::CFileDescriptor                 exportSyncFile();
+    std::vector<Hyprutils::OS::CFileDescriptor>    exportSyncFiles();
     bool                                           m_success = false;
 
   private:


### PR DESCRIPTION
most likely a lot of these fences will signal at the same time and merging them creates unneeded syscalls, just wait independently on each one of them and drain them as they become readable.


