### PR TITLE
MonitorQuery: fix monitor desc selector being treated as "down" selector

### DIFF
--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -113,12 +113,11 @@ std::optional<float> getPlusMinusKeywordResult(std::string source, float relativ
     }
 }
 
-bool isDirection(const std::string& arg) {
-    return arg == "l" || arg == "r" || arg == "u" || arg == "d" || arg == "t" || arg == "b";
-}
+bool isDirection(std::string_view sv) {
+    if (sv[0] == 'l' || sv[0] == 'r' || sv[0] == 'u' || sv[0] == 'd' || sv[0] == 't' || sv[0] == 'b')
+        return sv.length() == 1 || sv == "left" || sv == "right" || sv == "up" || sv == "down" || sv == "top" || sv == "bottom";
 
-bool isDirection(const char& arg) {
-    return arg == 'l' || arg == 'r' || arg == 'u' || arg == 'd' || arg == 't' || arg == 'b';
+    return false;
 }
 
 static bool isAutoIDdWorkspace(WORKSPACEID id) {

--- a/src/helpers/MiscFunctions.hpp
+++ b/src/helpers/MiscFunctions.hpp
@@ -23,8 +23,7 @@ struct SWorkspaceIDName {
 
 std::string                             absolutePath(const std::string&, const std::string&);
 std::string                             escapeJSONStrings(const std::string& str);
-bool                                    isDirection(const std::string&);
-bool                                    isDirection(const char&);
+bool                                    isDirection(std::string_view);
 SWorkspaceIDName                        getWorkspaceIDNameFromString(const std::string&);
 std::optional<std::string>              cleanCmdForWorkspace(const std::string&, std::string);
 float                                   vecToRectDistanceSquared(const Vector2D& vec, const Vector2D& p1, const Vector2D& p2);

--- a/src/state/MonitorQueryCore.cpp
+++ b/src/state/MonitorQueryCore.cpp
@@ -199,7 +199,7 @@ SP<Monitor::IMonitorQueryable> CMonitorQueryCore::fromConfigString(std::string_v
 
     if (sv == "current")
         return m_relativeTo;
-    else if (!sv.starts_with("desc:") && isDirection(sv[0])) // make sure sv doesn't start with "desc:" because isDirection() checks if it starts with 'd'
+    else if (isDirection(sv))
         return directionLookup(m_relativeTo, Math::fromChar(sv[0]));
     else if (sv[0] == '+' || sv[0] == '-') {
         if (m_monitors.size() == 1)

--- a/src/state/MonitorQueryCore.cpp
+++ b/src/state/MonitorQueryCore.cpp
@@ -199,7 +199,7 @@ SP<Monitor::IMonitorQueryable> CMonitorQueryCore::fromConfigString(std::string_v
 
     if (sv == "current")
         return m_relativeTo;
-    else if (!sv.empty() && isDirection(sv[0]))
+    else if (!sv.starts_with("desc:") && isDirection(sv[0])) // make sure sv doesn't start with "desc:" because isDirection() checks if it starts with 'd'
         return directionLookup(m_relativeTo, Math::fromChar(sv[0]));
     else if (sv[0] == '+' || sv[0] == '-') {
         if (m_monitors.size() == 1)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Monitor query by monitor description was broken because `isDirection(sv[0])` was called first and returns true when the first character is a 'd'. This PR adds a simple guard to prevent that happening when the selector starts with "desc:". Also removed a redundant `sv.empty()` check as it is already checked above. This section of the code seems like it could use some significant refactoring.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready

