### PR TITLE
fix: hide the top layer in workspace swipe to scrolling layout fullsc…

### DIFF
--- a/src/managers/animation/DesktopAnimationManager.cpp
+++ b/src/managers/animation/DesktopAnimationManager.cpp
@@ -7,6 +7,7 @@
 #include "../../desktop/view/Window.hpp"
 #include "../../desktop/view/Group.hpp"
 #include "../../desktop/Workspace.hpp"
+#include "../../layout/target/Target.hpp"
 
 #include "../../config/shared/animation/AnimationTree.hpp"
 
@@ -486,9 +487,11 @@ void CDesktopAnimationManager::setFullscreenFadeAnimation(PHLWORKSPACE ws, eAnim
     const auto PMONITOR = ws->m_monitor.lock();
 
     if (ws->m_id == PMONITOR->activeWorkspaceID() || ws->m_id == PMONITOR->activeSpecialWorkspaceID()) {
+        const auto FSWINDOW = ws->getFullscreenWindow(true);
+        const auto FSMODE   = FSWINDOW ? FSWINDOW->m_target->fullscreenMode() : ws->m_fullscreenMode;
         for (auto const& ls : PMONITOR->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]) {
             if (!ls->m_fadingOut && !ls->m_aboveFullscreen)
-                *ls->m_alpha = FULLSCREEN && ws->m_fullscreenMode != FSMODE_MAXIMIZED ? 0.f : 1.f;
+                *ls->m_alpha = FULLSCREEN && FSMODE != FSMODE_MAXIMIZED ? 0.f : 1.f;
         }
     }
 }

--- a/src/managers/input/UnifiedWorkspaceSwipeGesture.cpp
+++ b/src/managers/input/UnifiedWorkspaceSwipeGesture.cpp
@@ -5,6 +5,8 @@
 #include "../../desktop/state/FocusState.hpp"
 #include "../../render/Renderer.hpp"
 #include "InputManager.hpp"
+#include "../../layout/space/Space.hpp"
+#include "../../layout/algorithm/Algorithm.hpp"
 
 bool CUnifiedWorkspaceSwipeGesture::isGestureInProgress() {
     return !!m_workspaceBegin;
@@ -24,7 +26,10 @@ void CUnifiedWorkspaceSwipeGesture::begin() {
     m_avgSpeed       = 0;
     m_speedPoints    = 0;
 
-    if (PWORKSPACE->m_hasFullscreenWindow) {
+    const auto FSWINDOW = PWORKSPACE->getFullscreenWindow(true);
+    const auto FSMODE   = FSWINDOW ? FSWINDOW->m_target->fullscreenMode() : PWORKSPACE->m_fullscreenMode;
+
+    if (FSMODE == FSMODE_FULLSCREEN) {
         for (auto const& ls : Desktop::focusState()->monitor()->m_layerSurfaceLayers[2]) {
             *ls->m_alpha = 1.f;
         }
@@ -306,7 +311,15 @@ void CUnifiedWorkspaceSwipeGesture::end() {
     g_pInputManager->refocus();
 
     // apply alpha
-    for (auto const& ls : Desktop::focusState()->monitor()->m_layerSurfaceLayers[2]) {
-        *ls->m_alpha = pSwitchedTo->m_hasFullscreenWindow && pSwitchedTo->m_fullscreenMode == FSMODE_FULLSCREEN ? 0.f : 1.f;
+    if (pSwitchedTo) {
+        const auto FSWINDOW = pSwitchedTo->getFullscreenWindow(true);
+        const auto FSMODE   = FSWINDOW ? FSWINDOW->m_target->fullscreenMode() : pSwitchedTo->m_fullscreenMode;
+        const bool HIDE     = FSMODE == FSMODE_FULLSCREEN &&
+            (!FSWINDOW || !FSWINDOW->m_target->layoutManagedFullscreen() ||
+             (pSwitchedTo->m_space && pSwitchedTo->m_space->algorithm() && pSwitchedTo->m_space->algorithm()->layoutFullscreenCoversMonitor()));
+
+        for (auto const& ls : Desktop::focusState()->monitor()->m_layerSurfaceLayers[2]) {
+            *ls->m_alpha = HIDE ? 0.f : 1.f;
+        }
     }
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?


Fixing bar visibility when swipe to a workspace containing a scrolling layout fullscreen 

Issue was caused by fullscreen checks relying on m_fullscreenMode and m_hasFullscreenWindow the code now workd out fullscreen state through getFullscreenWindow()

added isDirection(char) overload and sv.empty() 
Fixes #15053 and closes #14721


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


No


#### Is it ready for merging, or does it need work?


yes can review