### PR TITLE
group: fix crash on group destroy

### DIFF
--- a/src/desktop/view/Group.cpp
+++ b/src/desktop/view/Group.cpp
@@ -66,16 +66,13 @@ void CGroup::init() {
 }
 
 void CGroup::destroy() {
-    while (true) {
-        if (m_windows.size() == 1) {
-            remove(m_windows.at(0).lock());
-            break;
-        }
-
+    const size_t s = m_windows.size();
+    for (size_t i = 0; i < s; i++) {
         remove(m_windows.at(0).lock());
     }
 
-    g_pEventManager->postEvent(SHyprIPCEvent({.event = "togglegroup", .data = std::format("0,{:x}", rc<uintptr_t>(m_windows.at(0).get()))}));
+    if (!m_windows.empty())
+        g_pEventManager->postEvent(SHyprIPCEvent({.event = "togglegroup", .data = std::format("0,{:x}", rc<uintptr_t>(m_windows.at(0).get()))}));
 }
 
 CGroup::~CGroup() {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Vaxry why is this a while true loop

Dump that led to this
<details>
#0  __GI_abort () at abort.c:95
        act = {__sigaction_handler = {sa_handler = 0x0, sa_sigaction = 0x0}, sa_mask = {__val = {18446744073709551615, 0 <repeats 15 times>}}, sa_flags = 0, 
          sa_restorer = 0x0}
#1  0x00005560179824a4 in handleUnrecoverableSignal (sig=6) at /usr/src/debug/hyprland-git/hyprland/src/Compositor.cpp:135
No locals.
#2  <signal handler called>
No locals.
#3  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at pthread_kill.c:44
        tid = <optimized out>
        ret = 0
        pd = <optimized out>
        old_mask = {__val = {1}}
        ret = <optimized out>
#4  0x00007f82b7a9a363 in __pthread_kill_internal (threadid=<optimized out>, signo=6) at pthread_kill.c:89
No locals.
#5  0x00007f82b7a3e7d0 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
        ret = <optimized out>
#6  0x00007f82b7a25681 in __GI_abort () at abort.c:77
        act = {__sigaction_handler = {sa_handler = 0xa, sa_sigaction = 0xa}, sa_mask = {__val = {93871211740544, 140728401639216, 140199403778513, 69, 1, 140728401639280, 
              140199403779824, 69, 69, 1, 140199405372576, 93872006387736, 140199405372576, 140728401639328, 140199403761696, 93872006387736}}, sa_flags = -1209313627, 
          sa_restorer = 0x7ffde263b7a0}
#7  0x00007f82b7e9ac50 in __gnu_cxx::__verbose_terminate_handler () at /usr/src/debug/gcc/gcc/libstdc++-v3/libsupc++/vterminate.cc:95
        terminating = true
        t = <optimized out>
#8  0x00007f82b7eb673a in __cxxabiv1::__terminate (handler=<optimized out>) at /usr/src/debug/gcc/gcc/libstdc++-v3/libsupc++/eh_terminate.cc:48
No locals.
#9  0x00007f82b7e9a5e9 in std::terminate () at /usr/src/debug/gcc/gcc/libstdc++-v3/libsupc++/eh_terminate.cc:58
No locals.
#10 0x00007f82b7eb69f6 in __cxxabiv1::__cxa_throw (obj=<optimized out>, tinfo=0x7f82b80c38b8 <typeinfo for std::out_of_range>, 
    dest=0x7f82b7ecf0c0 <std::out_of_range::~out_of_range()>) at /usr/src/debug/gcc/gcc/libstdc++-v3/libsupc++/eh_throw.cc:98
        globals = <optimized out>
        header = 0x556047956f90
#11 0x00007f82b7e9f1f2 in std::__throw_out_of_range_fmt (__fmt=0x5560181699f0 "vector::_M_range_check: __n (which is %zu) >= this->size() (which is %zu)")
    at /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/functexcept.cc:100
        __len = <optimized out>
        __alloca_size = <optimized out>
        __s = 0x7ffde263b840 "vector::_M_range_check: __n (which is 0) >= this->size() (which is 0)"
        __ap = {{gp_offset = 24, fp_offset = 48, overflow_arg_area = 0x7ffde263bba0, reg_save_area = 0x7ffde263bac0}}
#12 0x0000556017763422 in std::__throw_out_of_range_fmt<unsigned long, unsigned long> (
    __s=0x5560181699f0 "vector::_M_range_check: __n (which is %zu) >= this->size() (which is %zu)") at /usr/include/c++/16.1.1/bits/stdexcept_throwdef.h:133
No locals.
#13 std::vector<Hyprutils::Memory::CWeakPointer<Desktop::View::CWindow>, std::allocator<Hyprutils::Memory::CWeakPointer<Desktop::View::CWindow> > >::_M_range_check (
    this=<optimized out>, __n=0) at /usr/include/c++/16.1.1/bits/stl_vector.h:1283
No locals.
#14 std::vector<Hyprutils::Memory::CWeakPointer<Desktop::View::CWindow>, std::allocator<Hyprutils::Memory::CWeakPointer<Desktop::View::CWindow> > >::at (
--Type <RET> for more, q to quit, c to continue without paging--c
    this=0x556047a52d40, __n=0) at /usr/include/c++/16.1.1/bits/stl_vector.h:1305
No locals.
#15 Desktop::View::CGroup::destroy (this=0x556047a52d20) at /usr/src/debug/hyprland-git/hyprland/src/desktop/view/Group.cpp:78
No locals.
</details>

#### Is it ready for merging, or does it need work?
yes