### PR TITLE
monitor: defer reconnecting outputs while dpms is off

### DIFF
--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -1199,9 +1199,6 @@ ActionResult Actions::toggleSwallow() {
 
 ActionResult Actions::dpms(eTogglableAction action, std::optional<PHLMONITOR> mon) {
     for (auto const& m : State::monitorState()->allMonitors()) {
-        if (!m->m_enabled)
-            continue;
-
         if (mon.has_value() && m != mon.value())
             continue;
 
@@ -1210,6 +1207,16 @@ ActionResult Actions::dpms(eTogglableAction action, std::optional<PHLMONITOR> mo
             case TOGGLE_ACTION_TOGGLE: enable = !m->m_dpmsStatus; break;
             case TOGGLE_ACTION_ENABLE: enable = true; break;
             case TOGGLE_ACTION_DISABLE: enable = false; break;
+        }
+
+        if (!m->m_enabled) {
+            if (enable && !m->m_dpmsStatus && m->m_output && !m->m_output->nonDesktop) {
+                m->m_dpmsStatus = true;
+                m->onConnect(false);
+            }
+
+            g_pCompositor->m_dpmsStateOn = enable;
+            continue;
         }
 
         m->setDPMS(enable);

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -85,7 +85,7 @@ CMonitor::~CMonitor() {
         g_pHyprRenderer->glBackend()->destroyMonitorResources(m_self);
 }
 
-void CMonitor::onConnect(bool noRule) {
+void CMonitor::onConnect(bool noRule, bool initialDPMSOff) {
     Event::bus()->m_events.monitor.preAdded.emit(m_self.lock());
     CScopeGuard x = {[]() { g_pCompositor->arrangeMonitors(); }};
 
@@ -252,7 +252,6 @@ void CMonitor::onConnect(bool noRule) {
 
     // if it's disabled, disable and ignore
     if (monitorRule.m_disabled) {
-
         m_output->state->resetExplicitFences();
         m_output->state->setEnabled(false);
 
@@ -274,6 +273,26 @@ void CMonitor::onConnect(bool noRule) {
 
             lease->offer(m_self.lock());
         }
+
+        return;
+    }
+
+    if (initialDPMSOff) {
+        Log::logger->log(Log::DEBUG, "Deferring monitor {} connect because DPMS is off", m_name);
+
+        m_dpmsStatus = false;
+        m_events.dpmsChanged.emit();
+
+        m_listeners.frame.reset();
+        m_listeners.presented.reset();
+        m_listeners.needsFrame.reset();
+        m_listeners.commit.reset();
+
+        m_output->state->resetExplicitFences();
+        m_output->state->setEnabled(false);
+
+        if (!m_state.commit())
+            Log::logger->log(Log::WARN, "state.commit() failed while deferring output {} for DPMS off", m_name);
 
         return;
     }

--- a/src/output/Monitor.hpp
+++ b/src/output/Monitor.hpp
@@ -254,7 +254,7 @@ namespace Monitor {
         };
 
         // methods
-        void        onConnect(bool noRule);
+        void        onConnect(bool noRule, bool initialDPMSOff = false);
         void        onDisconnect(bool destroy = false);
         void        applyCMType(NCMType::eCMType cmType, NTransferFunction::eTF cmSdrEotf);
         void        addDamage(const pixman_region32_t* rg);

--- a/src/state/MonitorState.cpp
+++ b/src/state/MonitorState.cpp
@@ -115,7 +115,13 @@ void CMonitorStateTracker::add(PHLMONITOR mon) {
 
     Event::bus()->m_events.monitor.newMon.emit(mon);
 
-    mon->onConnect(false);
+    const bool ANY_EXISTING_ENABLED_MON = std::ranges::any_of(m_realMonitors, [&](const auto& m) { return m != mon && m->m_enabled; });
+    const bool ALL_EXISTING_DPMS_OFF =
+        ANY_EXISTING_ENABLED_MON && std::ranges::all_of(m_realMonitors, [&](const auto& m) { return m == mon || !m->m_enabled || !m->m_dpmsStatus; });
+
+    const bool INITIAL_DPMS_OFF = !g_pCompositor->m_dpmsStateOn || ALL_EXISTING_DPMS_OFF;
+
+    mon->onConnect(false, INITIAL_DPMS_OFF);
 
     if (!mon->m_enabled)
         return;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

After DPMS is disabled, some displays can continue to emit DRM hotplug events. In my case, an HDMI monitor repeatedly disconnects and reconnects while the outputs are supposed to stay off. Hyprland then treats every reconnect as a normal monitor add, applies the monitor rule again, and modesets the output before disabling it again. This results in a visible loop where the HDMI monitor switches between black and "HDMI no signal"  every ~8 seconds.

<details>
<summary>Video</summary>

https://github.com/user-attachments/assets/5c6760d4-ff19-430c-bf0e-3de5844f717e
</details>

This PR preserves the global DPMS-off state across monitor reconnects. When a new output appears while DPMS is off, Hyprland now defers the normal `onConnect` path: it records the monitor as DPMS-off, commits the output disabled, and returns without applying the monitor rule or modesetting the output.

It also allows a disabled DPMS-off monitor to be restored when DPMS is enabled again. Previously the DPMS dispatcher skipped disabled monitors entirely, so a monitor intentionally left disabled during the DPMS-off hotplug path would not be reconnected on DPMS enable.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

This is related to #14818, but that fix does not fully address the issue. It disables the monitor after the normal hotplug connect path has already run. On affected HDMI displays, that still allows the output to be configured/modeset briefly on every reconnect before being disabled again.

This seems to be a known problem documented on [Arch Wiki](https://wiki.archlinux.org/title/Display_Power_Management_Signaling#Monitor_won't_stay_suspended_and_wakes_up_every_10-15_seconds), however my monitor (MSI MP241X) doesn't have an option to turn off automatic input selection and setting `drm_kms_helper.poll=0` didn't resolve the issue for me. 

#### Is it ready for merging, or does it need work?

Ready for merging.