### PR TITLE
[WIP] Scrolling layout - windows span columns

### DIFF
--- a/hyprtester/src/tests/main/scroll.cpp
+++ b/hyprtester/src/tests/main/scroll.cpp
@@ -282,7 +282,7 @@ TEST_CASE(scrollSpanExpandShrinkCollapse) {
     ASSERT_MAX_DELTA(BASE_B->w, 960, 4);
     ASSERT_MAX_DELTA(BASE_B->h, 540, 4);
 
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto EXPANDED_B = scrollClientBoxForClass("span_b");
     const auto C_ABOVE    = scrollClientBoxForClass("span_c");
@@ -297,7 +297,7 @@ TEST_CASE(scrollSpanExpandShrinkCollapse) {
     ASSERT((C_ABOVE->y + C_ABOVE->h) <= EXPANDED_B->y, true);
     ASSERT((D_ABOVE->y + D_ABOVE->h) <= EXPANDED_B->y, true);
 
-    OK(getFromSocket("/dispatch hl.dsp.layout('shrink right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('shrink next')"));
 
     const auto SHRUNK_B = scrollClientBoxForClass("span_b");
     if (!SHRUNK_B)
@@ -306,7 +306,7 @@ TEST_CASE(scrollSpanExpandShrinkCollapse) {
     ASSERT_MAX_DELTA(SHRUNK_B->x, 0, 4);
     ASSERT_MAX_DELTA(SHRUNK_B->w, 960, 4);
 
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
     OK(getFromSocket("/dispatch hl.dsp.layout('collapse')"));
 
     const auto COLLAPSED_B = scrollClientBoxForClass("span_b");
@@ -317,7 +317,7 @@ TEST_CASE(scrollSpanExpandShrinkCollapse) {
     ASSERT_MAX_DELTA(COLLAPSED_B->w, 960, 4);
 
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_d' })"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand left')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand prev')"));
 
     const auto EXPANDED_D = scrollClientBoxForClass("span_d");
     if (!EXPANDED_D)
@@ -328,7 +328,7 @@ TEST_CASE(scrollSpanExpandShrinkCollapse) {
     ASSERT_MAX_DELTA(EXPANDED_D->w, 1920, 4);
     ASSERT_MAX_DELTA(EXPANDED_D->h, 540, 4);
 
-    OK(getFromSocket("/dispatch hl.dsp.layout('shrink left')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('shrink prev')"));
 
     const auto SHRUNK_D = scrollClientBoxForClass("span_d");
     if (!SHRUNK_D)
@@ -347,7 +347,7 @@ TEST_CASE(scrollSpanFitActiveKeepsWindowInView) {
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_fit_active_a' })"));
     OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_fit_active_b' })"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
     OK(getFromSocket("/dispatch hl.dsp.layout('fit active')"));
 
     const auto AFTER_B = scrollClientBoxForClass("span_fit_active_b");
@@ -370,7 +370,7 @@ TEST_CASE(scrollSpanRejectsFullHeightCollision) {
     if (!BEFORE_A || !BEFORE_B)
         FAIL_TEST("Could not find full-height span-blocking geometry before expansion");
 
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto AFTER_A = scrollClientBoxForClass("span_block_a");
     const auto AFTER_B = scrollClientBoxForClass("span_block_b");
@@ -400,7 +400,7 @@ TEST_CASE(scrollSpanExpandsBelowExistingSpan) {
     OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
 
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_stack_a' })"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto BEFORE_A = scrollClientBoxForClass("span_expand_stack_a");
     const auto BEFORE_B = scrollClientBoxForClass("span_expand_stack_b");
@@ -411,7 +411,7 @@ TEST_CASE(scrollSpanExpandsBelowExistingSpan) {
     ASSERT_MAX_DELTA(BEFORE_B->w, 960, 4);
 
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_stack_b' })"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto AFTER_A = scrollClientBoxForClass("span_expand_stack_a");
     const auto AFTER_B = scrollClientBoxForClass("span_expand_stack_b");
@@ -440,7 +440,7 @@ TEST_CASE(scrollSpanExpandsMiddleRowBelowExistingSpan) {
     OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
 
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_middle_a' })"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto BEFORE_A = scrollClientBoxForClass("span_expand_middle_a");
     const auto BEFORE_B = scrollClientBoxForClass("span_expand_middle_b");
@@ -451,7 +451,7 @@ TEST_CASE(scrollSpanExpandsMiddleRowBelowExistingSpan) {
     ASSERT_MAX_DELTA(BEFORE_B->w, 640, 4);
 
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_middle_b' })"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto AFTER_A = scrollClientBoxForClass("span_expand_middle_a");
     const auto AFTER_B = scrollClientBoxForClass("span_expand_middle_b");
@@ -483,7 +483,7 @@ TEST_CASE(scrollSpanExpandsFromCoveredColumn) {
     OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
 
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_covered_a' })"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto BEFORE_A = scrollClientBoxForClass("span_expand_covered_a");
     const auto BEFORE_E = scrollClientBoxForClass("span_expand_covered_e");
@@ -494,7 +494,7 @@ TEST_CASE(scrollSpanExpandsFromCoveredColumn) {
     ASSERT_MAX_DELTA(BEFORE_E->w, 640, 4);
 
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_covered_e' })"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto AFTER_A = scrollClientBoxForClass("span_expand_covered_a");
     const auto AFTER_D = scrollClientBoxForClass("span_expand_covered_d");
@@ -526,7 +526,7 @@ TEST_CASE(scrollSpanExpandsLeftFromCoveredColumn) {
     OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
 
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_left_covered_a' })"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto BEFORE_A = scrollClientBoxForClass("span_expand_left_covered_a");
     const auto BEFORE_E = scrollClientBoxForClass("span_expand_left_covered_e");
@@ -537,7 +537,7 @@ TEST_CASE(scrollSpanExpandsLeftFromCoveredColumn) {
     ASSERT_MAX_DELTA(BEFORE_E->w, 640, 4);
 
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_left_covered_e' })"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand left')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand prev')"));
 
     const auto AFTER_A = scrollClientBoxForClass("span_expand_left_covered_a");
     const auto AFTER_C = scrollClientBoxForClass("span_expand_left_covered_c");
@@ -562,7 +562,7 @@ TEST_CASE(scrollSpanRejectsExpansionBelowExistingSpanWithoutClearing) {
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_reject_a' })"));
     OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
     OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto BEFORE_A = scrollClientBoxForClass("span_expand_reject_a");
     const auto BEFORE_B = scrollClientBoxForClass("span_expand_reject_b");
@@ -573,7 +573,7 @@ TEST_CASE(scrollSpanRejectsExpansionBelowExistingSpanWithoutClearing) {
     ASSERT_MAX_DELTA(BEFORE_B->w, 960, 4);
 
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_reject_b' })"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto AFTER_A = scrollClientBoxForClass("span_expand_reject_a");
     const auto AFTER_B = scrollClientBoxForClass("span_expand_reject_b");
@@ -593,7 +593,7 @@ TEST_CASE(scrollSpanKeepsVirtualGapsAligned) {
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_gap_a' })"));
     OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
     OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto B = scrollClientBoxForClass("span_gap_b");
     const auto C = scrollClientBoxForClass("span_gap_c");
@@ -613,7 +613,7 @@ TEST_CASE(scrollSpanKeepsInsertedColumnOutsideSpan) {
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_insert_a' })"));
     OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
     OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto BEFORE_A = scrollClientBoxForClass("span_insert_a");
     if (!BEFORE_A)
@@ -639,8 +639,8 @@ TEST_CASE(scrollSpanShrinksWhenMiddleColumnRemoved) {
     OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
     OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_remove_b' })"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto BEFORE_B = scrollClientBoxForClass("span_remove_b");
     if (!BEFORE_B)
@@ -669,7 +669,7 @@ TEST_CASE(scrollSpanSurvivesClosingWindowInCoveredColumn) {
     OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
     OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_close_b' })"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto BEFORE_B = scrollClientBoxForClass("span_close_b");
     if (!BEFORE_B)
@@ -703,7 +703,7 @@ TEST_CASE(scrollSpanSurvivesUnrelatedConsume) {
     OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
     OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_consume_b' })"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto BEFORE_B = scrollClientBoxForClass("span_consume_b");
     if (!BEFORE_B)
@@ -731,7 +731,7 @@ TEST_CASE(scrollSpanSurvivesConsumeIntoCoveredColumn) {
     OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
     OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_consume_into_b' })"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto BEFORE_B = scrollClientBoxForClass("span_consume_into_b");
     if (!BEFORE_B)
@@ -762,7 +762,7 @@ TEST_CASE(scrollSpanSurvivesUnrelatedWindowMove) {
     OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
     OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_move_b' })"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto BEFORE_B = scrollClientBoxForClass("span_move_b");
     if (!BEFORE_B)
@@ -788,7 +788,7 @@ TEST_CASE(scrollSpanSurvivesMoveIntoCoveredColumn) {
     OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
     OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_move_into_b' })"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto BEFORE_B = scrollClientBoxForClass("span_move_into_b");
     if (!BEFORE_B)
@@ -819,7 +819,7 @@ TEST_CASE(scrollSpanSurvivesSwapInCoveredColumn) {
     OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
     OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_swap_b' })"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto BEFORE_B = scrollClientBoxForClass("span_swap_b");
     const auto BEFORE_C = scrollClientBoxForClass("span_swap_c");
@@ -866,7 +866,7 @@ TEST_CASE(scrollSpanSurvivesMovingCoveredColumnToMonitor) {
     OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
     OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_monitor_b' })"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto BEFORE_B = scrollClientBoxForClass("span_monitor_b");
     if (!BEFORE_B)
@@ -908,7 +908,7 @@ TEST_CASE(scrollSpanSurvivesConsumeOrExpelFromCoveredColumn) {
     OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
     OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
     OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expel_b' })"));
-    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
 
     const auto BEFORE_B = scrollClientBoxForClass("span_expel_b");
     if (!BEFORE_B)
@@ -2066,4 +2066,126 @@ TEST_CASE(properFocusBehvaior) {
 
     OK(getFromSocket("/eval hl.config({ binds = { focus_preferred_method = 1 } })")); // set length mode
     test();
+}
+
+TEST_CASE(scrollSpanExpandShrinkVertical) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 0, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'down', column_width = 0.5, follow_focus = false } })"));
+
+    ASSERT(scrollSpawnWindows({"vspan_a", "vspan_b", "vspan_c", "vspan_d"}), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:vspan_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:vspan_c' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:vspan_b' })"));
+
+    const auto BASE_B = scrollClientBoxForClass("vspan_b");
+    if (!BASE_B)
+        FAIL_TEST("Could not find vspan_b geometry");
+
+    // Two strips: strip 0 (top) has a, strip 1 (bottom) has b, c, d.
+    // Window b should be in strip 1, at half height.
+    ASSERT_MAX_DELTA(BASE_B->y, 540, 4);
+    ASSERT_MAX_DELTA(BASE_B->h, 540, 4);
+
+    // Expand into strip 0 (prev = up in DOWN mode).
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand prev')"));
+
+    const auto EXPANDED_B = scrollClientBoxForClass("vspan_b");
+    if (!EXPANDED_B)
+        FAIL_TEST("Could not find vspan_b geometry after expanding prev");
+
+    // Should now span both strips (full height).
+    ASSERT_MAX_DELTA(EXPANDED_B->y, 0, 4);
+    ASSERT_MAX_DELTA(EXPANDED_B->h, 1080, 4);
+
+    // Shrink back.
+    OK(getFromSocket("/dispatch hl.dsp.layout('shrink prev')"));
+
+    const auto SHRUNK_B = scrollClientBoxForClass("vspan_b");
+    if (!SHRUNK_B)
+        FAIL_TEST("Could not find vspan_b geometry after shrinking prev");
+
+    ASSERT_MAX_DELTA(SHRUNK_B->y, 540, 4);
+    ASSERT_MAX_DELTA(SHRUNK_B->h, 540, 4);
+
+    // Expand into next strip (down in DOWN mode = next strip; boundary test).
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
+    const auto AT_BOUNDARY = scrollClientBoxForClass("vspan_b");
+    if (!AT_BOUNDARY)
+        FAIL_TEST("Could not find vspan_b geometry after expand next");
+    ASSERT_MAX_DELTA(AT_BOUNDARY->y, 540, 4);
+
+    // Collapse.
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand prev')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('collapse')"));
+
+    const auto COLLAPSED_B = scrollClientBoxForClass("vspan_b");
+    if (!COLLAPSED_B)
+        FAIL_TEST("Could not find vspan_b geometry after collapse");
+    ASSERT_MAX_DELTA(COLLAPSED_B->y, 540, 4);
+    ASSERT_MAX_DELTA(COLLAPSED_B->h, 540, 4);
+}
+
+TEST_CASE(scrollSpanRejectsFullWidthCollisionVertical) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 0, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'down', column_width = 0.5, follow_focus = false } })"));
+
+    ASSERT(scrollSpawnWindows({"fwc_a", "fwc_b", "fwc_c", "fwc_d"}), true);
+
+    // Create a single strip: consume all windows into one strip.
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:fwc_b' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:fwc_c' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:fwc_d' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+
+    // One strip has all 4 windows stacked horizontally. fwc_b occupies part of the secondary axis.
+    // Expanding forward should fail if it creates a collision with another strip.
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:fwc_b' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand prev')"));
+
+    // Verify geometry is unchanged (expand was rejected or window still in single strip).
+    const auto B_AFTER = scrollClientBoxForClass("fwc_b");
+    if (!B_AFTER)
+        FAIL_TEST("Could not find fwc_b geometry");
+    ASSERT((B_AFTER->h < 1080), true);
+}
+
+TEST_CASE(scrollSpanSurvivesDirectionChange) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 0, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'right', column_width = 0.5, follow_focus = false } })"));
+
+    ASSERT(scrollSpawnWindows({"sdc_a", "sdc_b", "sdc_c", "sdc_d"}), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:sdc_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:sdc_c' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:sdc_b' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand next')"));
+
+    // Verify the span is active (window spans full width).
+    const auto EXPANDED = scrollClientBoxForClass("sdc_b");
+    if (!EXPANDED)
+        FAIL_TEST("Could not find sdc_b geometry after expand next");
+    ASSERT_MAX_DELTA(EXPANDED->w, 1920, 4);
+
+    // Change direction to vertical -- spans should be cleared.
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'down' } })"));
+
+    // Force recalculate.
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
+
+    const auto AFTER_DIR_CHANGE = scrollClientBoxForClass("sdc_b");
+    if (!AFTER_DIR_CHANGE)
+        FAIL_TEST("Could not find sdc_b geometry after direction change");
+    // Window should no longer span full height (span was cleared).
+    ASSERT((AFTER_DIR_CHANGE->h < 1080), true);
 }

--- a/hyprtester/src/tests/main/scroll.cpp
+++ b/hyprtester/src/tests/main/scroll.cpp
@@ -7,6 +7,62 @@
 
 using namespace Hyprutils::Utils;
 
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+struct SScrollClientBox {
+    int x = 0;
+    int y = 0;
+    int w = 0;
+    int h = 0;
+};
+
+static std::optional<std::string> scrollClientSectionForClass(const std::string& class_) {
+    const auto CLIENTS    = getFromSocket("/clients");
+    const auto CLASS_POS  = CLIENTS.find("class: " + class_);
+    const auto ENTRY_POS  = CLASS_POS == std::string::npos ? std::string::npos : CLIENTS.rfind("Window ", CLASS_POS);
+    const auto ENTRY_NEXT = CLASS_POS == std::string::npos ? std::string::npos : CLIENTS.find("\nWindow ", CLASS_POS);
+
+    if (CLASS_POS == std::string::npos || ENTRY_POS == std::string::npos)
+        return std::nullopt;
+
+    return CLIENTS.substr(ENTRY_POS, ENTRY_NEXT == std::string::npos ? std::string::npos : ENTRY_NEXT - ENTRY_POS);
+}
+
+static std::optional<std::pair<int, int>> scrollParsePair(const std::string& value) {
+    const auto COMMA = value.find(',');
+    if (COMMA == std::string::npos)
+        return std::nullopt;
+
+    try {
+        return std::pair{std::stoi(value.substr(0, COMMA)), std::stoi(value.substr(COMMA + 1))};
+    } catch (...) { return std::nullopt; }
+}
+
+static std::optional<SScrollClientBox> scrollClientBoxForClass(const std::string& class_) {
+    const auto SECTION = scrollClientSectionForClass(class_);
+    if (!SECTION)
+        return std::nullopt;
+
+    const auto AT   = scrollParsePair(Tests::getAttribute(*SECTION, "at"));
+    const auto SIZE = scrollParsePair(Tests::getAttribute(*SECTION, "size"));
+    if (!AT || !SIZE)
+        return std::nullopt;
+
+    return SScrollClientBox{.x = AT->first, .y = AT->second, .w = SIZE->first, .h = SIZE->second};
+}
+
+static bool scrollSpawnWindows(const std::vector<std::string>& classes) {
+    for (const auto& class_ : classes) {
+        if (!Tests::spawnKitty(class_))
+            return false;
+    }
+
+    return true;
+}
+
 TEST_CASE(scrollFocusCycling) {
     OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling' } })"));
 
@@ -201,6 +257,678 @@ TEST_CASE(scrollWindowRule) {
     // not the greatest test, but as long as res and gaps don't change, we good.
     // if this test breaks, it's likely you broke equal sizing
     ASSERT_CONTAINS(getFromSocket("/activewindow"), "size: 179,1036");
+}
+
+TEST_CASE(scrollSpanExpandShrinkCollapse) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 0, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'right', column_width = 0.5, follow_focus = false } })"));
+
+    ASSERT(scrollSpawnWindows({"span_a", "span_b", "span_c", "span_d"}), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_c' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_b' })"));
+
+    const auto BASE_B = scrollClientBoxForClass("span_b");
+    if (!BASE_B)
+        FAIL_TEST("Could not find span_b geometry");
+
+    ASSERT_MAX_DELTA(BASE_B->x, 0, 4);
+    ASSERT_MAX_DELTA(BASE_B->y, 540, 4);
+    ASSERT_MAX_DELTA(BASE_B->w, 960, 4);
+    ASSERT_MAX_DELTA(BASE_B->h, 540, 4);
+
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto EXPANDED_B = scrollClientBoxForClass("span_b");
+    const auto C_ABOVE    = scrollClientBoxForClass("span_c");
+    const auto D_ABOVE    = scrollClientBoxForClass("span_d");
+    if (!EXPANDED_B || !C_ABOVE || !D_ABOVE)
+        FAIL_TEST("Could not find geometry after expanding span_b right");
+
+    ASSERT_MAX_DELTA(EXPANDED_B->x, 0, 4);
+    ASSERT_MAX_DELTA(EXPANDED_B->y, 540, 4);
+    ASSERT_MAX_DELTA(EXPANDED_B->w, 1920, 4);
+    ASSERT_MAX_DELTA(EXPANDED_B->h, 540, 4);
+    ASSERT((C_ABOVE->y + C_ABOVE->h) <= EXPANDED_B->y, true);
+    ASSERT((D_ABOVE->y + D_ABOVE->h) <= EXPANDED_B->y, true);
+
+    OK(getFromSocket("/dispatch hl.dsp.layout('shrink right')"));
+
+    const auto SHRUNK_B = scrollClientBoxForClass("span_b");
+    if (!SHRUNK_B)
+        FAIL_TEST("Could not find span_b geometry after shrinking right");
+
+    ASSERT_MAX_DELTA(SHRUNK_B->x, 0, 4);
+    ASSERT_MAX_DELTA(SHRUNK_B->w, 960, 4);
+
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('collapse')"));
+
+    const auto COLLAPSED_B = scrollClientBoxForClass("span_b");
+    if (!COLLAPSED_B)
+        FAIL_TEST("Could not find span_b geometry after collapse");
+
+    ASSERT_MAX_DELTA(COLLAPSED_B->x, 0, 4);
+    ASSERT_MAX_DELTA(COLLAPSED_B->w, 960, 4);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_d' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand left')"));
+
+    const auto EXPANDED_D = scrollClientBoxForClass("span_d");
+    if (!EXPANDED_D)
+        FAIL_TEST("Could not find span_d geometry after expanding left");
+
+    ASSERT_MAX_DELTA(EXPANDED_D->x, 0, 4);
+    ASSERT_MAX_DELTA(EXPANDED_D->y, 540, 4);
+    ASSERT_MAX_DELTA(EXPANDED_D->w, 1920, 4);
+    ASSERT_MAX_DELTA(EXPANDED_D->h, 540, 4);
+
+    OK(getFromSocket("/dispatch hl.dsp.layout('shrink left')"));
+
+    const auto SHRUNK_D = scrollClientBoxForClass("span_d");
+    if (!SHRUNK_D)
+        FAIL_TEST("Could not find span_d geometry after shrinking left");
+
+    ASSERT_MAX_DELTA(SHRUNK_D->x, 960, 4);
+    ASSERT_MAX_DELTA(SHRUNK_D->w, 960, 4);
+}
+
+TEST_CASE(scrollSpanFitActiveKeepsWindowInView) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 0, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'right', column_width = 0.5, follow_focus = false } })"));
+
+    ASSERT(scrollSpawnWindows({"span_fit_active_a", "span_fit_active_b", "span_fit_active_c", "span_fit_active_d"}), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_fit_active_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_fit_active_b' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit active')"));
+
+    const auto AFTER_B = scrollClientBoxForClass("span_fit_active_b");
+    if (!AFTER_B)
+        FAIL_TEST("Could not find span_fit_active_b geometry after fit active");
+
+    ASSERT((AFTER_B->w <= 1920), true);
+}
+
+TEST_CASE(scrollSpanRejectsFullHeightCollision) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 0, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'right', column_width = 0.5, follow_focus = false } })"));
+
+    ASSERT(scrollSpawnWindows({"span_block_a", "span_block_b"}), true);
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_block_a' })"));
+
+    const auto BEFORE_A = scrollClientBoxForClass("span_block_a");
+    const auto BEFORE_B = scrollClientBoxForClass("span_block_b");
+    if (!BEFORE_A || !BEFORE_B)
+        FAIL_TEST("Could not find full-height span-blocking geometry before expansion");
+
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto AFTER_A = scrollClientBoxForClass("span_block_a");
+    const auto AFTER_B = scrollClientBoxForClass("span_block_b");
+    if (!AFTER_A || !AFTER_B)
+        FAIL_TEST("Could not find full-height span-blocking geometry after expansion");
+
+    ASSERT_MAX_DELTA(AFTER_A->x, BEFORE_A->x, 4);
+    ASSERT_MAX_DELTA(AFTER_A->y, BEFORE_A->y, 4);
+    ASSERT_MAX_DELTA(AFTER_A->w, BEFORE_A->w, 4);
+    ASSERT_MAX_DELTA(AFTER_A->h, BEFORE_A->h, 4);
+    ASSERT_MAX_DELTA(AFTER_B->x, BEFORE_B->x, 4);
+    ASSERT_MAX_DELTA(AFTER_B->y, BEFORE_B->y, 4);
+    ASSERT_MAX_DELTA(AFTER_B->w, BEFORE_B->w, 4);
+    ASSERT_MAX_DELTA(AFTER_B->h, BEFORE_B->h, 4);
+}
+
+TEST_CASE(scrollSpanExpandsBelowExistingSpan) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 0, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'right', column_width = 0.5, follow_focus = false } })"));
+
+    ASSERT(scrollSpawnWindows({"span_expand_stack_a", "span_expand_stack_b", "span_expand_stack_c", "span_expand_stack_d"}), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_stack_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_stack_b' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_stack_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto BEFORE_A = scrollClientBoxForClass("span_expand_stack_a");
+    const auto BEFORE_B = scrollClientBoxForClass("span_expand_stack_b");
+    if (!BEFORE_A || !BEFORE_B)
+        FAIL_TEST("Could not find geometry before expanding below existing span");
+
+    ASSERT_MAX_DELTA(BEFORE_A->w, 1920, 4);
+    ASSERT_MAX_DELTA(BEFORE_B->w, 960, 4);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_stack_b' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto AFTER_A = scrollClientBoxForClass("span_expand_stack_a");
+    const auto AFTER_B = scrollClientBoxForClass("span_expand_stack_b");
+    const auto AFTER_D = scrollClientBoxForClass("span_expand_stack_d");
+    if (!AFTER_A || !AFTER_B || !AFTER_D)
+        FAIL_TEST("Could not find geometry after expanding below existing span");
+
+    ASSERT_MAX_DELTA(AFTER_A->w, BEFORE_A->w, 4);
+    ASSERT_MAX_DELTA(AFTER_B->w, 1920, 4);
+    ASSERT(AFTER_D->y >= AFTER_B->y + AFTER_B->h, true);
+}
+
+TEST_CASE(scrollSpanExpandsMiddleRowBelowExistingSpan) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 0, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'right', column_width = 0.333333, follow_focus = false } })"));
+
+    ASSERT(scrollSpawnWindows({"span_expand_middle_a", "span_expand_middle_b", "span_expand_middle_c", "span_expand_middle_d", "span_expand_middle_e", "span_expand_middle_f"}),
+           true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_middle_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_middle_b' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_middle_d' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_middle_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto BEFORE_A = scrollClientBoxForClass("span_expand_middle_a");
+    const auto BEFORE_B = scrollClientBoxForClass("span_expand_middle_b");
+    if (!BEFORE_A || !BEFORE_B)
+        FAIL_TEST("Could not find geometry before expanding middle row below existing span");
+
+    ASSERT_MAX_DELTA(BEFORE_A->w, 1280, 4);
+    ASSERT_MAX_DELTA(BEFORE_B->w, 640, 4);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_middle_b' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto AFTER_A = scrollClientBoxForClass("span_expand_middle_a");
+    const auto AFTER_B = scrollClientBoxForClass("span_expand_middle_b");
+    const auto AFTER_D = scrollClientBoxForClass("span_expand_middle_d");
+    const auto AFTER_E = scrollClientBoxForClass("span_expand_middle_e");
+    if (!AFTER_A || !AFTER_B || !AFTER_D || !AFTER_E)
+        FAIL_TEST("Could not find geometry after expanding middle row below existing span");
+
+    ASSERT_MAX_DELTA(AFTER_A->w, BEFORE_A->w, 4);
+    ASSERT_MAX_DELTA(AFTER_B->w, 1280, 4);
+    ASSERT(AFTER_D->y >= AFTER_B->y + AFTER_B->h, true);
+    ASSERT(AFTER_E->y >= AFTER_D->y + AFTER_D->h, true);
+}
+
+TEST_CASE(scrollSpanExpandsFromCoveredColumn) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 0, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'right', column_width = 0.333333, follow_focus = false } })"));
+
+    ASSERT(
+        scrollSpawnWindows({"span_expand_covered_a", "span_expand_covered_b", "span_expand_covered_c", "span_expand_covered_d", "span_expand_covered_e", "span_expand_covered_f"}),
+        true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_covered_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_covered_b' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_covered_d' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_covered_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto BEFORE_A = scrollClientBoxForClass("span_expand_covered_a");
+    const auto BEFORE_E = scrollClientBoxForClass("span_expand_covered_e");
+    if (!BEFORE_A || !BEFORE_E)
+        FAIL_TEST("Could not find geometry before expanding from covered column");
+
+    ASSERT_MAX_DELTA(BEFORE_A->w, 1280, 4);
+    ASSERT_MAX_DELTA(BEFORE_E->w, 640, 4);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_covered_e' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto AFTER_A = scrollClientBoxForClass("span_expand_covered_a");
+    const auto AFTER_D = scrollClientBoxForClass("span_expand_covered_d");
+    const auto AFTER_E = scrollClientBoxForClass("span_expand_covered_e");
+    const auto AFTER_F = scrollClientBoxForClass("span_expand_covered_f");
+    if (!AFTER_A || !AFTER_D || !AFTER_E || !AFTER_F)
+        FAIL_TEST("Could not find geometry after expanding from covered column");
+
+    ASSERT_MAX_DELTA(AFTER_A->w, BEFORE_A->w, 4);
+    ASSERT_MAX_DELTA(AFTER_E->w, 1280, 4);
+    ASSERT(AFTER_E->y >= AFTER_D->y + AFTER_D->h, true);
+    ASSERT_MAX_DELTA(AFTER_F->y + AFTER_F->h, AFTER_E->y, 4);
+}
+
+TEST_CASE(scrollSpanExpandsLeftFromCoveredColumn) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 0, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'right', column_width = 0.333333, follow_focus = false } })"));
+
+    ASSERT(scrollSpawnWindows({"span_expand_left_covered_a", "span_expand_left_covered_b", "span_expand_left_covered_c", "span_expand_left_covered_d", "span_expand_left_covered_e",
+                               "span_expand_left_covered_f"}),
+           true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_left_covered_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_left_covered_b' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_left_covered_d' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_left_covered_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto BEFORE_A = scrollClientBoxForClass("span_expand_left_covered_a");
+    const auto BEFORE_E = scrollClientBoxForClass("span_expand_left_covered_e");
+    if (!BEFORE_A || !BEFORE_E)
+        FAIL_TEST("Could not find geometry before expanding left from covered column");
+
+    ASSERT_MAX_DELTA(BEFORE_A->w, 1280, 4);
+    ASSERT_MAX_DELTA(BEFORE_E->w, 640, 4);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_left_covered_e' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand left')"));
+
+    const auto AFTER_A = scrollClientBoxForClass("span_expand_left_covered_a");
+    const auto AFTER_C = scrollClientBoxForClass("span_expand_left_covered_c");
+    const auto AFTER_D = scrollClientBoxForClass("span_expand_left_covered_d");
+    const auto AFTER_E = scrollClientBoxForClass("span_expand_left_covered_e");
+    if (!AFTER_A || !AFTER_C || !AFTER_D || !AFTER_E)
+        FAIL_TEST("Could not find geometry after expanding left from covered column");
+
+    ASSERT_MAX_DELTA(AFTER_A->w, BEFORE_A->w, 4);
+    ASSERT_MAX_DELTA(AFTER_E->x, 0, 4);
+    ASSERT_MAX_DELTA(AFTER_E->w, 1280, 4);
+    ASSERT(AFTER_E->y >= AFTER_C->y + AFTER_C->h, true);
+    ASSERT(AFTER_E->y >= AFTER_D->y + AFTER_D->h, true);
+}
+
+TEST_CASE(scrollSpanRejectsExpansionBelowExistingSpanWithoutClearing) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 0, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'right', column_width = 0.5, follow_focus = false } })"));
+
+    ASSERT(scrollSpawnWindows({"span_expand_reject_a", "span_expand_reject_b", "span_expand_reject_c"}), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_reject_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto BEFORE_A = scrollClientBoxForClass("span_expand_reject_a");
+    const auto BEFORE_B = scrollClientBoxForClass("span_expand_reject_b");
+    if (!BEFORE_A || !BEFORE_B)
+        FAIL_TEST("Could not find geometry before rejected expansion below existing span");
+
+    ASSERT_MAX_DELTA(BEFORE_A->w, 1920, 4);
+    ASSERT_MAX_DELTA(BEFORE_B->w, 960, 4);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expand_reject_b' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto AFTER_A = scrollClientBoxForClass("span_expand_reject_a");
+    const auto AFTER_B = scrollClientBoxForClass("span_expand_reject_b");
+    if (!AFTER_A || !AFTER_B)
+        FAIL_TEST("Could not find geometry after rejected expansion below existing span");
+
+    ASSERT_MAX_DELTA(AFTER_A->w, BEFORE_A->w, 4);
+    ASSERT_MAX_DELTA(AFTER_B->w, BEFORE_B->w, 4);
+}
+
+TEST_CASE(scrollSpanKeepsVirtualGapsAligned) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 10, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'right', column_width = 0.5, follow_focus = false } })"));
+
+    ASSERT(scrollSpawnWindows({"span_gap_a", "span_gap_b", "span_gap_c"}), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_gap_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto B = scrollClientBoxForClass("span_gap_b");
+    const auto C = scrollClientBoxForClass("span_gap_c");
+    if (!B || !C)
+        FAIL_TEST("Could not find geometry after expanding span_gap_a right");
+
+    ASSERT_MAX_DELTA(B->y, C->y, 4);
+    ASSERT_MAX_DELTA(B->h, C->h, 4);
+}
+
+TEST_CASE(scrollSpanKeepsInsertedColumnOutsideSpan) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 0, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'right', column_width = 0.5, follow_focus = false } })"));
+
+    ASSERT(scrollSpawnWindows({"span_insert_a", "span_insert_b", "span_insert_c"}), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_insert_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto BEFORE_A = scrollClientBoxForClass("span_insert_a");
+    if (!BEFORE_A)
+        FAIL_TEST("Could not find span_insert_a geometry before inserting column");
+
+    if (!Tests::spawnKitty("span_insert_d"))
+        FAIL_TEST("Could not spawn span_insert_d");
+
+    const auto AFTER_A = scrollClientBoxForClass("span_insert_a");
+    if (!AFTER_A)
+        FAIL_TEST("Could not find span_insert_a geometry after inserting column");
+
+    ASSERT_MAX_DELTA(AFTER_A->w, BEFORE_A->w, 4);
+}
+
+TEST_CASE(scrollSpanShrinksWhenMiddleColumnRemoved) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 0, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'right', column_width = 0.333333, follow_focus = false } })"));
+
+    ASSERT(scrollSpawnWindows({"span_remove_a", "span_remove_b", "span_remove_c", "span_remove_d"}), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_remove_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_remove_b' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto BEFORE_B = scrollClientBoxForClass("span_remove_b");
+    if (!BEFORE_B)
+        FAIL_TEST("Could not find span_remove_b geometry before removing middle column");
+
+    ASSERT_MAX_DELTA(BEFORE_B->w, 1920, 4);
+
+    OK(getFromSocket("/dispatch hl.dsp.window.kill({ window = 'class:span_remove_c' })"));
+    Tests::waitUntilWindowsN(3);
+
+    const auto AFTER_B = scrollClientBoxForClass("span_remove_b");
+    if (!AFTER_B)
+        FAIL_TEST("Could not find span_remove_b geometry after removing middle column");
+
+    ASSERT_MAX_DELTA(AFTER_B->w, 1280, 4);
+    ASSERT(AFTER_B->w < BEFORE_B->w, true);
+}
+
+TEST_CASE(scrollSpanSurvivesClosingWindowInCoveredColumn) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 0, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'right', column_width = 0.5, follow_focus = false } })"));
+
+    ASSERT(scrollSpawnWindows({"span_close_a", "span_close_b", "span_close_c", "span_close_d"}), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_close_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_close_b' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto BEFORE_B = scrollClientBoxForClass("span_close_b");
+    if (!BEFORE_B)
+        FAIL_TEST("Could not find span_close_b geometry before closing window in covered column");
+
+    ASSERT_MAX_DELTA(BEFORE_B->w, 1280, 4);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_close_c' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.window.kill({ window = 'class:span_close_c' })"));
+    Tests::waitUntilWindowsN(3);
+
+    const auto AFTER_B = scrollClientBoxForClass("span_close_b");
+    const auto AFTER_C = scrollClientBoxForClass("span_close_c");
+    const auto AFTER_D = scrollClientBoxForClass("span_close_d");
+    if (!AFTER_B || !AFTER_D)
+        FAIL_TEST("Could not find geometry after closing window in covered column");
+
+    ASSERT(!AFTER_C, true);
+    ASSERT_MAX_DELTA(AFTER_B->w, BEFORE_B->w, 4);
+    ASSERT(AFTER_D->x >= BEFORE_B->x && AFTER_D->x < BEFORE_B->x + BEFORE_B->w, true);
+}
+
+TEST_CASE(scrollSpanSurvivesUnrelatedConsume) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 0, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'right', column_width = 0.5, follow_focus = false } })"));
+
+    ASSERT(scrollSpawnWindows({"span_consume_a", "span_consume_b", "span_consume_c", "span_consume_d", "span_consume_e"}), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_consume_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_consume_b' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto BEFORE_B = scrollClientBoxForClass("span_consume_b");
+    if (!BEFORE_B)
+        FAIL_TEST("Could not find span_consume_b geometry before unrelated consume");
+
+    ASSERT_MAX_DELTA(BEFORE_B->w, 960, 4);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_consume_d' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+
+    const auto AFTER_B = scrollClientBoxForClass("span_consume_b");
+    if (!AFTER_B)
+        FAIL_TEST("Could not find span_consume_b geometry after unrelated consume");
+
+    ASSERT_MAX_DELTA(AFTER_B->w, BEFORE_B->w, 4);
+}
+
+TEST_CASE(scrollSpanSurvivesConsumeIntoCoveredColumn) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 0, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'right', column_width = 0.5, follow_focus = false } })"));
+
+    ASSERT(scrollSpawnWindows({"span_consume_into_a", "span_consume_into_b", "span_consume_into_c", "span_consume_into_d"}), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_consume_into_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_consume_into_b' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto BEFORE_B = scrollClientBoxForClass("span_consume_into_b");
+    if (!BEFORE_B)
+        FAIL_TEST("Could not find span_consume_into_b geometry before consuming into covered column");
+
+    ASSERT_MAX_DELTA(BEFORE_B->w, 1280, 4);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_consume_into_c' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+
+    const auto AFTER_B = scrollClientBoxForClass("span_consume_into_b");
+    const auto AFTER_C = scrollClientBoxForClass("span_consume_into_c");
+    const auto AFTER_D = scrollClientBoxForClass("span_consume_into_d");
+    if (!AFTER_B || !AFTER_C || !AFTER_D)
+        FAIL_TEST("Could not find geometry after consuming into covered column");
+
+    ASSERT_MAX_DELTA(AFTER_B->w, BEFORE_B->w, 4);
+    ASSERT((AFTER_C->y + AFTER_C->h) <= AFTER_D->y || (AFTER_D->y + AFTER_D->h) <= AFTER_C->y, true);
+}
+
+TEST_CASE(scrollSpanSurvivesUnrelatedWindowMove) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 0, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'right', column_width = 0.5, follow_focus = false } })"));
+
+    ASSERT(scrollSpawnWindows({"span_move_a", "span_move_b", "span_move_c", "span_move_d", "span_move_e"}), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_move_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_move_b' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto BEFORE_B = scrollClientBoxForClass("span_move_b");
+    if (!BEFORE_B)
+        FAIL_TEST("Could not find span_move_b geometry before unrelated move");
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_move_e' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ direction = 'left' })"));
+
+    const auto AFTER_B = scrollClientBoxForClass("span_move_b");
+    if (!AFTER_B)
+        FAIL_TEST("Could not find span_move_b geometry after unrelated move");
+
+    ASSERT_MAX_DELTA(AFTER_B->w, BEFORE_B->w, 4);
+}
+
+TEST_CASE(scrollSpanSurvivesMoveIntoCoveredColumn) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 0, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'right', column_width = 0.5, follow_focus = false } })"));
+
+    ASSERT(scrollSpawnWindows({"span_move_into_a", "span_move_into_b", "span_move_into_c", "span_move_into_d"}), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_move_into_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_move_into_b' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto BEFORE_B = scrollClientBoxForClass("span_move_into_b");
+    if (!BEFORE_B)
+        FAIL_TEST("Could not find span_move_into_b geometry before moving into covered column");
+
+    ASSERT_MAX_DELTA(BEFORE_B->w, 1280, 4);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_move_into_d' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ direction = 'left' })"));
+
+    const auto AFTER_B = scrollClientBoxForClass("span_move_into_b");
+    const auto AFTER_C = scrollClientBoxForClass("span_move_into_c");
+    const auto AFTER_D = scrollClientBoxForClass("span_move_into_d");
+    if (!AFTER_B || !AFTER_C || !AFTER_D)
+        FAIL_TEST("Could not find geometry after moving into covered column");
+
+    ASSERT_MAX_DELTA(AFTER_B->w, BEFORE_B->w, 4);
+    ASSERT((AFTER_C->y + AFTER_C->h) <= AFTER_D->y || (AFTER_D->y + AFTER_D->h) <= AFTER_C->y, true);
+}
+
+TEST_CASE(scrollSpanSurvivesSwapInCoveredColumn) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 0, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'right', column_width = 0.5, follow_focus = false } })"));
+
+    ASSERT(scrollSpawnWindows({"span_swap_a", "span_swap_b", "span_swap_c", "span_swap_d"}), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_swap_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_swap_b' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto BEFORE_B = scrollClientBoxForClass("span_swap_b");
+    const auto BEFORE_C = scrollClientBoxForClass("span_swap_c");
+    const auto BEFORE_D = scrollClientBoxForClass("span_swap_d");
+    if (!BEFORE_B || !BEFORE_C || !BEFORE_D)
+        FAIL_TEST("Could not find geometry before swapping in covered column");
+
+    ASSERT_MAX_DELTA(BEFORE_B->w, 1280, 4);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_swap_c' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.swap({ target = 'class:span_swap_d' })"));
+
+    const auto AFTER_B = scrollClientBoxForClass("span_swap_b");
+    const auto AFTER_C = scrollClientBoxForClass("span_swap_c");
+    const auto AFTER_D = scrollClientBoxForClass("span_swap_d");
+    if (!AFTER_B || !AFTER_C || !AFTER_D)
+        FAIL_TEST("Could not find geometry after swapping in covered column");
+
+    ASSERT_MAX_DELTA(AFTER_B->w, BEFORE_B->w, 4);
+    ASSERT_MAX_DELTA(AFTER_C->x, BEFORE_D->x, 4);
+    ASSERT_MAX_DELTA(AFTER_D->x, BEFORE_C->x, 4);
+}
+
+TEST_CASE(scrollSpanSurvivesMovingCoveredColumnToMonitor) {
+    OK(getFromSocket("/eval hl.monitor({ output = 'HEADLESS-2', mode = '1920x1080@60', position = '0x1080', scale = '1' })"));
+    OK(getFromSocket("/eval hl.monitor({ output = 'HYPRTEST-SPAN-MON', mode = '1920x1080@60', position = '0x0', scale = '1' })"));
+    OK(getFromSocket("/output create headless HYPRTEST-SPAN-MON"));
+    OK(getFromSocket("/eval hl.workspace_rule({ workspace = 'name:span_monitor_src', monitor = 'HEADLESS-2' })"));
+    OK(getFromSocket("/eval hl.workspace_rule({ workspace = 'name:span_monitor_dst', monitor = 'HYPRTEST-SPAN-MON' })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ monitor = 'HYPRTEST-SPAN-MON' })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'name:span_monitor_dst' })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ monitor = 'HEADLESS-2' })"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'name:span_monitor_src' })"));
+
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 0, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ binds = { window_direction_monitor_fallback = true } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'right', column_width = 0.333333, follow_focus = false } })"));
+
+    ASSERT(scrollSpawnWindows({"span_monitor_a", "span_monitor_b", "span_monitor_c", "span_monitor_d"}), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_monitor_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_monitor_c' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_monitor_b' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto BEFORE_B = scrollClientBoxForClass("span_monitor_b");
+    if (!BEFORE_B)
+        FAIL_TEST("Could not find span_monitor_b geometry before moving covered column to monitor");
+
+    ASSERT_MAX_DELTA(BEFORE_B->w, 1920, 4);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_monitor_c' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ direction = 'up' })"));
+
+    const auto AFTER_B = scrollClientBoxForClass("span_monitor_b");
+    const auto AFTER_C = scrollClientBoxForClass("span_monitor_c");
+    const auto AFTER_D = scrollClientBoxForClass("span_monitor_d");
+    if (!AFTER_B || !AFTER_C || !AFTER_D)
+        FAIL_TEST("Could not find geometry after moving covered column to monitor");
+
+    const auto AFTER_B_SECTION = scrollClientSectionForClass("span_monitor_b");
+    const auto AFTER_C_SECTION = scrollClientSectionForClass("span_monitor_c");
+    const auto AFTER_D_SECTION = scrollClientSectionForClass("span_monitor_d");
+    if (!AFTER_B_SECTION || !AFTER_C_SECTION || !AFTER_D_SECTION)
+        FAIL_TEST("Could not find client sections after moving covered column to monitor");
+
+    ASSERT_NOT(Tests::getAttribute(*AFTER_C_SECTION, "monitor"), Tests::getAttribute(*AFTER_B_SECTION, "monitor"));
+    ASSERT(Tests::getAttribute(*AFTER_D_SECTION, "monitor"), Tests::getAttribute(*AFTER_B_SECTION, "monitor"));
+    ASSERT_MAX_DELTA(AFTER_B->w, BEFORE_B->w, 4);
+    ASSERT(AFTER_D->x >= AFTER_B->x && AFTER_D->x < AFTER_B->x + AFTER_B->w, true);
+    ASSERT((AFTER_D->y + AFTER_D->h) <= AFTER_B->y || (AFTER_B->y + AFTER_B->h) <= AFTER_D->y, true);
+
+    OK(getFromSocket("/output remove HYPRTEST-SPAN-MON"));
+}
+
+TEST_CASE(scrollSpanSurvivesConsumeOrExpelFromCoveredColumn) {
+    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling', gaps_in = 0, gaps_out = 0, border_size = 0 } })"));
+    OK(getFromSocket("r/eval hl.config({ scrolling = { direction = 'right', column_width = 0.5, follow_focus = false } })"));
+
+    ASSERT(scrollSpawnWindows({"span_expel_a", "span_expel_b", "span_expel_c", "span_expel_d"}), true);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expel_a' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('fit all')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expel_b' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('expand right')"));
+
+    const auto BEFORE_B = scrollClientBoxForClass("span_expel_b");
+    if (!BEFORE_B)
+        FAIL_TEST("Could not find span_expel_b geometry before expelling from covered column");
+
+    ASSERT_MAX_DELTA(BEFORE_B->w, 1280, 4);
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expel_c' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume')"));
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:span_expel_d' })"));
+    OK(getFromSocket("/dispatch hl.dsp.layout('consume_or_expel next')"));
+
+    const auto AFTER_B = scrollClientBoxForClass("span_expel_b");
+    const auto AFTER_C = scrollClientBoxForClass("span_expel_c");
+    const auto AFTER_D = scrollClientBoxForClass("span_expel_d");
+    if (!AFTER_B || !AFTER_C || !AFTER_D)
+        FAIL_TEST("Could not find geometry after expelling from covered column");
+
+    ASSERT_MAX_DELTA(AFTER_B->w, BEFORE_B->w, 4);
+    ASSERT(AFTER_D->x >= AFTER_C->x + AFTER_C->w, true);
 }
 
 TEST_CASE(scrollFullscreen) {
@@ -1223,7 +1951,6 @@ TEST_CASE(scrollTapeOnClickOutOfWindow) {
         FAIL_TEST("{}Failed: {}Expected the x coordinate of window of class \"A\" to be < 0, got {}.", Colors::RED, Colors::RESET, posAx);
     }
 }
-
 TEST_CASE(properFocusBehvaior) {
     // test that focus history does not fuck with proper workspace preference
 

--- a/src/layout/algorithm/tiled/scrolling/ScrollTapeController.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollTapeController.cpp
@@ -335,3 +335,42 @@ bool CScrollTapeController::isBeingDragged() const {
 
     return false;
 }
+
+SSpanReservationParams CScrollTapeController::extractSpanReservation(const CBox& anchorBox, const CBox& usable, const Vector2D& workspaceOffset) const {
+    if (isPrimaryHorizontal()) {
+        return SSpanReservationParams{
+            .start = sc<float>((anchorBox.y - workspaceOffset.y) / usable.h),
+            .size  = sc<float>(anchorBox.h / usable.h),
+        };
+    } else {
+        return SSpanReservationParams{
+            .start = sc<float>((anchorBox.x - workspaceOffset.x) / usable.w),
+            .size  = sc<float>(anchorBox.w / usable.w),
+        };
+    }
+}
+
+void CScrollTapeController::applySpanReservation(CBox& box, const SRealTargetLayout& layout, const CBox& stripBox, const CBox& usable,
+                                                  const Vector2D& workspaceOffset) const {
+    if (isPrimaryHorizontal()) {
+        box.y = workspaceOffset.y + layout.start * usable.h;
+        box.h = layout.size * usable.h;
+    } else {
+        box.x = workspaceOffset.x + layout.start * usable.w;
+        box.w = layout.size * usable.w;
+    }
+}
+
+void CScrollTapeController::mergeSpanStripBoxes(CBox& result, const CBox& first, const CBox& last) const {
+    if (isPrimaryHorizontal()) {
+        const auto LEFT  = std::min(first.x, last.x);
+        const auto RIGHT = std::max(first.x + first.w, last.x + last.w);
+        result.x         = LEFT;
+        result.w         = RIGHT - LEFT;
+    } else {
+        const auto TOP    = std::min(first.y, last.y);
+        const auto BOTTOM = std::max(first.y + first.h, last.y + last.h);
+        result.y          = TOP;
+        result.h          = BOTTOM - TOP;
+    }
+}

--- a/src/layout/algorithm/tiled/scrolling/ScrollTapeController.hpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollTapeController.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "ScrollingSpanLayout.hpp"
+
 #include "../../../../helpers/math/Math.hpp"
 #include "../../../../helpers/memory/Memory.hpp"
 #include <vector>
@@ -63,6 +65,12 @@ namespace Layout::Tiled {
 
         CBox                     calculateStripBox(size_t stripIndex, const CBox& usableArea, const Vector2D& workspaceOffset, bool fullscreenOnOne = false);
         CBox                     calculateTargetBox(size_t stripIndex, size_t targetIndex, const CBox& usableArea, const Vector2D& workspaceOffset, bool fullscreenOnOne = false);
+
+        // Span helpers — axis-aware reservation extraction, application, and strip merging.
+        SSpanReservationParams extractSpanReservation(const CBox& anchorBox, const CBox& usable, const Vector2D& workspaceOffset) const;
+        void                   applySpanReservation(CBox& box, const SRealTargetLayout& layout, const CBox& stripBox, const CBox& usable,
+                                                    const Vector2D& workspaceOffset) const;
+        void                   mergeSpanStripBoxes(CBox& result, const CBox& first, const CBox& last) const;
 
         double                   calculateCameraOffset(const CBox& usableArea, bool fullscreenOnOne = false);
         Vector2D                 getCameraTranslation(const CBox& usableArea, bool fullscreenOnOne = false);

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -2634,8 +2634,8 @@ void CScrollingAlgorithm::clearSpansCoveringColumn(SP<SColumnData> column) {
     if (!m_scrollingData || !column)
         return;
 
-    const int64_t columnIdx = m_scrollingData->idx(column);
-    if (columnIdx < 0)
+    const int64_t COLUMN_IDX = m_scrollingData->idx(column);
+    if (COLUMN_IDX < 0)
         return;
 
     const auto COLUMN_COUNT = m_scrollingData->columns.size();
@@ -2650,7 +2650,7 @@ void CScrollingAlgorithm::clearSpansCoveringColumn(SP<SColumnData> column) {
             }
 
             const auto RANGE = spanRangeFor(anchorIdx, target->span, COLUMN_COUNT);
-            if (!RANGE || RANGE->contains(sc<size_t>(columnIdx)))
+            if (!RANGE || RANGE->contains(sc<size_t>(COLUMN_IDX)))
                 clearSpan(target);
         }
     }
@@ -2892,7 +2892,8 @@ std::vector<std::vector<SSpanAdjustedTargetBox>> CScrollingAlgorithm::spanAdjust
     if (!m_scrollingData || !m_scrollingData->controller)
         return {};
 
-    return resolveSpanLayout(usable, workspaceOffset).boxes;
+    const auto RESOLVED = resolveSpanLayout(usable, workspaceOffset);
+    return RESOLVED.valid ? RESOLVED.boxes : std::vector<std::vector<SSpanAdjustedTargetBox>>{};
 }
 
 std::optional<CBox> CScrollingAlgorithm::spannedLayoutBox(SP<SScrollingTargetData> target, size_t anchorIdx, const CBox& usable, const Vector2D& workspaceOffset) const {
@@ -2928,50 +2929,50 @@ std::optional<CBox> CScrollingAlgorithm::spannedLayoutBox(SP<SScrollingTargetDat
 
 bool CScrollingAlgorithm::tryUpdateSpan(SP<SScrollingTargetData> target, int deltaLeft, int deltaRight) {
     if (!target) {
-        Log::logger->log(Log::INFO, "tryUpdateSpan: no target");
+        Log::logger->log(Log::TRACE, "tryUpdateSpan: no target");
         return false;
     }
 
     const auto TARGET = target->target.lock();
     if (!TARGET || TARGET->layoutManagedFullscreen() || TARGET->fullscreenMode() != FSMODE_NONE) {
-        Log::logger->log(Log::INFO, "tryUpdateSpan: target invalid, fullscreen, or maximized");
+        Log::logger->log(Log::TRACE, "tryUpdateSpan: target invalid, fullscreen, or maximized");
         return false;
     }
 
     const auto COLUMN = target->column.lock();
     if (!COLUMN) {
-        Log::logger->log(Log::INFO, "tryUpdateSpan: no column");
+        Log::logger->log(Log::TRACE, "tryUpdateSpan: no column");
         return false;
     }
 
     if (!columnSpansSupportedForPrimaryAxis(m_scrollingData->controller->isPrimaryHorizontal())) {
-        Log::logger->log(Log::INFO, "tryUpdateSpan: not horizontal primary axis");
+        Log::logger->log(Log::TRACE, "tryUpdateSpan: not horizontal primary axis");
         return false;
     }
 
     const int64_t ANCHOR_IDX = m_scrollingData->idx(COLUMN);
     if (ANCHOR_IDX < 0) {
-        Log::logger->log(Log::INFO, "tryUpdateSpan: anchor idx < 0");
+        Log::logger->log(Log::TRACE, "tryUpdateSpan: anchor idx < 0");
         return false;
     }
 
     if (deltaLeft > 0 && ANCHOR_IDX - target->span.left <= 0) {
-        Log::logger->log(Log::INFO, "tryUpdateSpan: at left boundary (anchor={}, span.left={}, deltaLeft={})", ANCHOR_IDX, target->span.left, deltaLeft);
+        Log::logger->log(Log::TRACE, "tryUpdateSpan: at left boundary (anchor={}, span.left={}, deltaLeft={})", ANCHOR_IDX, target->span.left, deltaLeft);
         return false;
     }
 
     if (deltaRight > 0 && ANCHOR_IDX + target->span.right >= sc<int64_t>(m_scrollingData->columns.size()) - 1) {
-        Log::logger->log(Log::INFO, "tryUpdateSpan: at right boundary (anchor={}, span.right={}, columns={})", ANCHOR_IDX, target->span.right, m_scrollingData->columns.size());
+        Log::logger->log(Log::TRACE, "tryUpdateSpan: at right boundary (anchor={}, span.right={}, columns={})", ANCHOR_IDX, target->span.right, m_scrollingData->columns.size());
         return false;
     }
 
     if (deltaLeft < 0 && target->span.left == 0) {
-        Log::logger->log(Log::INFO, "tryUpdateSpan: cannot shrink left, already 0");
+        Log::logger->log(Log::TRACE, "tryUpdateSpan: cannot shrink left, already 0");
         return false;
     }
 
     if (deltaRight < 0 && target->span.right == 0) {
-        Log::logger->log(Log::INFO, "tryUpdateSpan: cannot shrink right, already 0");
+        Log::logger->log(Log::TRACE, "tryUpdateSpan: cannot shrink right, already 0");
         return false;
     }
 
@@ -2979,7 +2980,7 @@ bool CScrollingAlgorithm::tryUpdateSpan(SP<SScrollingTargetData> target, int del
     target->span.left  = std::max(0, target->span.left + deltaLeft);
     target->span.right = std::max(0, target->span.right + deltaRight);
 
-    Log::logger->log(Log::INFO, "tryUpdateSpan: tentative span left={} right={}, validating...", target->span.left, target->span.right);
+    Log::logger->log(Log::TRACE, "tryUpdateSpan: tentative span left={} right={}, validating...", target->span.left, target->span.right);
 
     if (!validateCurrentSpans()) {
         Log::logger->log(Log::INFO, "tryUpdateSpan: validateCurrentSpans rejected");

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -21,6 +21,10 @@
 #include <hyprutils/string/ConstVarList.hpp>
 #include <hyprutils/utils/ScopeGuard.hpp>
 
+#include <algorithm>
+#include <functional>
+#include <queue>
+
 using namespace Hyprutils::String;
 using namespace Hyprutils::Utils;
 using namespace Layout;
@@ -30,6 +34,33 @@ constexpr float MIN_COLUMN_WIDTH = 0.05F;
 constexpr float MAX_COLUMN_WIDTH = 1.F;
 constexpr float MIN_ROW_HEIGHT   = 0.1F;
 constexpr float MAX_ROW_HEIGHT   = 1.F;
+
+static bool     renderableSpanSource(const SP<SScrollingTargetData>& target) {
+    if (!target || !target->span.active())
+        return false;
+
+    const auto TARGET = target->target.lock();
+    if (!TARGET)
+        return false;
+
+    const auto WINDOW = TARGET->window();
+    return WINDOW && Desktop::View::validMapped(WINDOW) && !WINDOW->isHidden();
+}
+
+static std::optional<SSpanRange> renderableSpanRangeFor(const SP<SScrollingTargetData>& target, size_t anchorIdx, size_t columnCount) {
+    if (!renderableSpanSource(target) || anchorIdx >= columnCount)
+        return std::nullopt;
+
+    if (target->span.left < 0 || target->span.right < 0)
+        return std::nullopt;
+
+    const auto SPAN_LEFT  = sc<size_t>(target->span.left);
+    const auto SPAN_RIGHT = sc<size_t>(target->span.right);
+    if (SPAN_LEFT > anchorIdx || SPAN_RIGHT >= columnCount - anchorIdx)
+        return std::nullopt;
+
+    return spanRangeFor(anchorIdx, target->span, columnCount);
+}
 
 //
 float SColumnData::getColumnWidth() const {
@@ -452,19 +483,26 @@ void SScrollingData::recalculate(bool forceInstant) {
     }
 
     controller->setDirection(algorithm->getDynamicDirection());
+    algorithm->sanitizeCurrentSpans();
+
     algorithm->updateFullscreenFade(anyFullscreenCovers);
 
-    const auto targetBoxWithGaps = [&](const CBox& logical, size_t colIdx, size_t targetIdx, bool fullscreenOrHidden) -> STargetBox {
+    const auto SPAN_BOXES = algorithm->spanAdjustedColumnBoxes(USABLE, WORKAREA.pos());
+
+    const auto targetBoxWithGaps = [&](const CBox& logical, size_t colIdx, size_t virtualIndex, size_t virtualCount, bool fullscreenOrHidden,
+                                       const std::optional<SSpanRange>& spanRange = std::nullopt) -> STargetBox {
         if (fullscreenOrHidden)
             return {.logicalBox = logical, .visualBox = logical};
 
         CBox       visual        = logical;
         const bool PRIMARY_HORIZ = controller->isPrimaryHorizontal();
 
-        const bool COL_NOT_LEFT      = controller->isReversed() ? colIdx + 1 < columns.size() : colIdx > 0;
-        const bool COL_NOT_RIGHT     = controller->isReversed() ? colIdx > 0 : colIdx + 1 < columns.size();
-        const bool TARGET_NOT_TOP    = controller->isReversed() ? targetIdx + 1 < columns[colIdx]->targetDatas.size() : targetIdx > 0;
-        const bool TARGET_NOT_BOTTOM = controller->isReversed() ? targetIdx > 0 : targetIdx + 1 < columns[colIdx]->targetDatas.size();
+        const auto FIRST_COL         = spanRange ? spanRange->first : colIdx;
+        const auto LAST_COL          = spanRange ? spanRange->last : colIdx;
+        const bool COL_NOT_LEFT      = controller->isReversed() ? LAST_COL + 1 < columns.size() : FIRST_COL > 0;
+        const bool COL_NOT_RIGHT     = controller->isReversed() ? FIRST_COL > 0 : LAST_COL + 1 < columns.size();
+        const bool TARGET_NOT_TOP    = controller->isReversed() ? virtualIndex + 1 < virtualCount : virtualIndex > 0;
+        const bool TARGET_NOT_BOTTOM = controller->isReversed() ? virtualIndex > 0 : virtualIndex + 1 < virtualCount;
 
         const bool GAP_LEFT   = PRIMARY_HORIZ ? COL_NOT_LEFT : TARGET_NOT_TOP;
         const bool GAP_RIGHT  = PRIMARY_HORIZ ? COL_NOT_RIGHT : TARGET_NOT_BOTTOM;
@@ -487,7 +525,8 @@ void SScrollingData::recalculate(bool forceInstant) {
         const auto  FS  = algorithm->fullscreenTargetDataForColumn(COL);
 
         for (size_t j = 0; j < COL->targetDatas.size(); ++j) {
-            const auto& TARGET = COL->targetDatas[j];
+            const auto&               TARGET = COL->targetDatas[j];
+            std::optional<SSpanRange> spanRange;
 
             if (FS) {
                 if (TARGET == FS && TARGET->target->fullscreenMode() == FSMODE_FULLSCREEN) {
@@ -518,11 +557,22 @@ void SScrollingData::recalculate(bool forceInstant) {
                     }
                 } else
                     TARGET->layoutBox = CBox{WORKAREA.pos() - Vector2D{100000.0, 100000.0}, Vector2D{1.0, 1.0}};
-            } else
-                TARGET->layoutBox = controller->calculateTargetBox(i, j, USABLE, WORKAREA.pos(), *PFSONONE);
+            } else {
+                TARGET->layoutBox =
+                    i < SPAN_BOXES.size() && j < SPAN_BOXES[i].size() ? SPAN_BOXES[i][j].box : controller->calculateTargetBox(i, j, USABLE, WORKAREA.pos(), *PFSONONE);
 
-            if (TARGET->target)
-                TARGET->target->setPositionGlobal(targetBoxWithGaps(TARGET->layoutBox, i, j, FS && TARGET->target->fullscreenMode() == FSMODE_FULLSCREEN));
+                if (auto SPANNED = algorithm->spannedLayoutBox(TARGET, i, USABLE, WORKAREA.pos()); SPANNED) {
+                    TARGET->layoutBox = *SPANNED;
+                    spanRange         = renderableSpanRangeFor(TARGET, i, columns.size());
+                }
+            }
+
+            if (TARGET->target) {
+                const size_t VIRTUAL_INDEX = i < SPAN_BOXES.size() && j < SPAN_BOXES[i].size() ? SPAN_BOXES[i][j].virtualIndex : j;
+                const size_t VIRTUAL_COUNT = i < SPAN_BOXES.size() && j < SPAN_BOXES[i].size() ? SPAN_BOXES[i][j].virtualCount : COL->targetDatas.size();
+                TARGET->target->setPositionGlobal(
+                    targetBoxWithGaps(TARGET->layoutBox, i, VIRTUAL_INDEX, VIRTUAL_COUNT, FS && TARGET->target->fullscreenMode() == FSMODE_FULLSCREEN, spanRange));
+            }
 
             if (forceInstant && TARGET->target)
                 TARGET->target->warpPositionSize();
@@ -673,14 +723,10 @@ void CScrollingAlgorithm::focusOnInput(SP<ITarget> target, eInputMode input) {
         return;
 
     // if we moved via non-kb, and it's fully visible, ignore
-    if (m_scrollingData->visible(TARGETDATA->column.lock(), true) && input != INPUT_MODE_HARD)
+    if (targetDataVisible(TARGETDATA, true) && input != INPUT_MODE_HARD)
         return;
 
-    static const auto PFITMETHOD = CConfigValue<Config::INTEGER>("scrolling:focus_fit_method");
-    if (*PFITMETHOD == 1)
-        m_scrollingData->fitCol(TARGETDATA->column.lock());
-    else
-        m_scrollingData->centerCol(TARGETDATA->column.lock());
+    centerOrFitTargetData(TARGETDATA);
     m_scrollingData->recalculate();
 }
 
@@ -700,6 +746,8 @@ void CScrollingAlgorithm::newTarget(SP<ITarget> target) {
         m_scrollingData->fitCol(col);
     } else {
         if (g_layoutManager->dragController()->wasDraggingWindow() && g_layoutManager->dragController()->draggingTiled()) {
+            clearSpansCoveringColumn(droppingColumn);
+
             if (droppingOn) {
                 const auto IDX = droppingColumn->idx(droppingOn->layoutTarget());
                 const auto TOP = droppingOn->getWindowIdealBoundingBoxIgnoreReserved().middle().y > g_pInputManager->getMouseCoordsInternal().y;
@@ -708,12 +756,24 @@ void CScrollingAlgorithm::newTarget(SP<ITarget> target) {
                 droppingColumn->add(target);
             m_scrollingData->fitCol(droppingColumn);
         } else {
-            auto idx = m_scrollingData->idx(droppingColumn);
-            auto col = idx == -1 ? m_scrollingData->add(width) : m_scrollingData->add(idx, width);
+            const auto   IDX                 = m_scrollingData->idx(droppingColumn);
+            const size_t COLUMN_COUNT_BEFORE = m_scrollingData->columns.size();
+            const size_t INSERT_IDX          = IDX == -1 ?
+                         COLUMN_COUNT_BEFORE :
+                         (droppingData && droppingData->span.active() ? columnInsertAfterFocusedSpan(sc<size_t>(IDX), droppingData->span, COLUMN_COUNT_BEFORE) : sc<size_t>(IDX + 1));
+
+            adjustSpansAfterColumnInsert(INSERT_IDX, COLUMN_COUNT_BEFORE);
+
+            auto col = INSERT_IDX >= COLUMN_COUNT_BEFORE ? m_scrollingData->add(width) : m_scrollingData->add(sc<int>(INSERT_IDX - 1), width);
             col->add(target);
             m_scrollingData->fitCol(col);
         }
     }
+
+    m_scrollingData->recalculate(true);
+
+    if (!validateCurrentSpans())
+        clearAllSpans();
 
     m_scrollingData->recalculate();
 }
@@ -729,6 +789,17 @@ void CScrollingAlgorithm::removeTarget(SP<ITarget> target) {
         return;
 
     clearFullscreenTarget((target->fullscreenMode() == FSMODE_MAXIMIZED ? m_maximizeTargets : m_fullscreenTargets), target);
+
+    const auto OLD_COL      = DATA->column.lock();
+    const bool REMOVING_COL = OLD_COL && OLD_COL->targetDatas.size() <= 1;
+
+    if (REMOVING_COL) {
+        const int64_t REMOVED_IDX = m_scrollingData->idx(OLD_COL);
+        if (REMOVED_IDX >= 0)
+            adjustSpansAfterColumnRemove(sc<size_t>(REMOVED_IDX), m_scrollingData->columns.size(), DATA);
+    }
+
+    clearSpan(DATA);
 
     if (!m_scrollingData->next(DATA->column.lock()) && DATA->column->targetDatas.size() <= 1) {
         // move the view if this is the last column
@@ -747,6 +818,15 @@ void CScrollingAlgorithm::removeTarget(SP<ITarget> target) {
         const double usablePrimary  = isPrimaryHoriz ? USABLE.w : USABLE.h;
         const double newOffset      = std::clamp(m_scrollingData->controller->getOffset(), 0.0, std::max(m_scrollingData->maxWidth() - usablePrimary, 1.0));
         m_scrollingData->controller->setOffset(newOffset);
+    }
+
+    m_scrollingData->recalculate(true);
+
+    if (!validateCurrentSpans()) {
+        if (REMOVING_COL)
+            clearAllSpans();
+        else
+            clearSpansCoveringColumn(OLD_COL);
     }
 
     m_scrollingData->recalculate();
@@ -840,9 +920,20 @@ void CScrollingAlgorithm::resizeTarget(const Vector2D& delta, SP<ITarget> target
     }
 
     if (DATA->column->targetDatas.size() > 1) {
-        const auto& CURR_TD = DATA;
-        const auto  NEXT_TD = DATA->column->next(DATA);
-        const auto  PREV_TD = DATA->column->prev(DATA);
+        const auto& CURR_TD        = DATA;
+        const auto  NEXT_TD        = DATA->column->next(DATA);
+        const auto  PREV_TD        = DATA->column->prev(DATA);
+        bool        rowSizeChanged = false;
+
+        const auto  rollbackRowResizeIfInvalid = [&]() {
+            m_scrollingData->recalculate(true);
+
+            if (validateCurrentSpans())
+                return false;
+
+            return true;
+        };
+
         if (corner == CORNER_NONE) {
             if (!PREV_TD)
                 corner = CORNER_BOTTOMRIGHT;
@@ -868,6 +959,14 @@ void CScrollingAlgorithm::resizeTarget(const Vector2D& delta, SP<ITarget> target
 
                 CURR_COLUMN->setTargetSize(NEXT_TD, std::clamp(nextSize - adjust, MIN_ROW_HEIGHT, MAX_ROW_HEIGHT));
                 CURR_COLUMN->setTargetSize(CURR_TD, std::clamp(currSize + adjust, MIN_ROW_HEIGHT, MAX_ROW_HEIGHT));
+                rowSizeChanged = true;
+
+                if (rollbackRowResizeIfInvalid()) {
+                    CURR_COLUMN->setTargetSize(NEXT_TD, nextSize);
+                    CURR_COLUMN->setTargetSize(CURR_TD, currSize);
+                    m_scrollingData->recalculate(true);
+                    return;
+                }
                 break;
             }
             case CORNER_TOPLEFT:
@@ -885,11 +984,22 @@ void CScrollingAlgorithm::resizeTarget(const Vector2D& delta, SP<ITarget> target
 
                 CURR_COLUMN->setTargetSize(PREV_TD, std::clamp(prevSize + adjust, MIN_ROW_HEIGHT, MAX_ROW_HEIGHT));
                 CURR_COLUMN->setTargetSize(CURR_TD, std::clamp(currSize - adjust, MIN_ROW_HEIGHT, MAX_ROW_HEIGHT));
+                rowSizeChanged = true;
+
+                if (rollbackRowResizeIfInvalid()) {
+                    CURR_COLUMN->setTargetSize(PREV_TD, prevSize);
+                    CURR_COLUMN->setTargetSize(CURR_TD, currSize);
+                    m_scrollingData->recalculate(true);
+                    return;
+                }
                 break;
             }
 
             default: break;
         }
+
+        if (rowSizeChanged)
+            return;
     }
 
     m_scrollingData->recalculate(true);
@@ -1001,11 +1111,19 @@ CScrollingAlgorithm::SFullscreenScrollState* CScrollingAlgorithm::fullscreenStat
     return fullscreenStateForTarget(target->target.lock(), targetFullscreenMode);
 }
 
-void CScrollingAlgorithm::expelTarget(SP<SScrollingTargetData> tdata, SP<SColumnData> srcCol, std::optional<int64_t> insertIdx) {
+SP<SColumnData> CScrollingAlgorithm::expelTarget(SP<SScrollingTargetData> tdata, SP<SColumnData> srcCol, std::optional<int64_t> insertIdx) {
+    const size_t COLUMN_COUNT_BEFORE = m_scrollingData->columns.size();
+    const size_t INSERT_IDX          = !insertIdx ? COLUMN_COUNT_BEFORE : std::min(sc<size_t>(std::max<int64_t>(*insertIdx + 1, 0)), COLUMN_COUNT_BEFORE);
+
+    adjustSpansAfterColumnInsert(INSERT_IDX, COLUMN_COUNT_BEFORE, tdata);
+
     auto col = !insertIdx ? m_scrollingData->add() : m_scrollingData->add(*insertIdx);
+    clearSpan(tdata);
     srcCol->remove(tdata->target.lock());
     col->add(tdata);
     m_scrollingData->centerOrFitCol(col);
+
+    return col;
 }
 
 eFullscreenRequestResult CScrollingAlgorithm::requestFullscreen(const SFullscreenRequest& request) {
@@ -1016,9 +1134,13 @@ eFullscreenRequestResult CScrollingAlgorithm::requestFullscreen(const SFullscree
     if (!TDATA)
         return FULLSCREEN_REQUEST_DEFAULT;
 
-    if (request.effectiveMode == FSMODE_FULLSCREEN) {
-        const auto CURRENT_COL = TDATA->column.lock();
+    const auto CURRENT_COL = TDATA->column.lock();
+    if (request.effectiveMode == FSMODE_FULLSCREEN || request.effectiveMode == FSMODE_MAXIMIZED) {
+        clearSpan(TDATA);
+        clearSpansCoveringColumn(CURRENT_COL);
+    }
 
+    if (request.effectiveMode == FSMODE_FULLSCREEN) {
         if (!fullscreenStateForTarget(request.target, FSMODE_FULLSCREEN)) {
             m_fullscreenTargets.emplace_back(
                 SFullscreenScrollState{.target = request.target, .restoreColumnWidth = CURRENT_COL ? std::optional<float>{CURRENT_COL->getColumnWidth()} : std::nullopt});
@@ -1049,8 +1171,6 @@ eFullscreenRequestResult CScrollingAlgorithm::requestFullscreen(const SFullscree
 
         return FULLSCREEN_REQUEST_HANDLED_BY_LAYOUT;
     } else if (request.effectiveMode == FSMODE_MAXIMIZED) {
-
-        const auto CURRENT_COL = TDATA->column.lock();
 
         if (!fullscreenStateForTarget(request.target, FSMODE_MAXIMIZED)) {
             m_maximizeTargets.emplace_back(
@@ -1305,13 +1425,26 @@ SP<ITarget> CScrollingAlgorithm::getNextCandidate(SP<ITarget> old) {
 }
 
 void CScrollingAlgorithm::swapTargets(SP<ITarget> a, SP<ITarget> b) {
-    auto nodeA = dataFor(a);
-    auto nodeB = dataFor(b);
+    auto       nodeA = dataFor(a);
+    auto       nodeB = dataFor(b);
+
+    const auto colA = nodeA ? nodeA->column.lock() : nullptr;
+    const auto colB = nodeB ? nodeB->column.lock() : nullptr;
+
+    clearSpan(nodeA);
+    clearSpan(nodeB);
 
     if (nodeA)
         nodeA->target = b;
     if (nodeB)
         nodeB->target = a;
+
+    m_scrollingData->recalculate(true);
+    if (!validateCurrentSpans()) {
+        clearSpansCoveringColumn(colA);
+        if (colB != colA)
+            clearSpansCoveringColumn(colB);
+    }
 
     m_scrollingData->recalculate();
 }
@@ -1373,12 +1506,20 @@ void CScrollingAlgorithm::moveTargetTo(SP<ITarget> t, Math::eDirection dir, bool
 
     auto       commenceDir = [&]() -> bool {
         if (ROTATED_DIR == Math::DIRECTION_LEFT) {
-            const auto COL = m_scrollingData->prev(DATA->column.lock());
+            const auto SRC_COL = DATA->column.lock();
+            const auto COL     = m_scrollingData->prev(SRC_COL);
 
             // ignore moves to the origin if we are alone
             if (!COL && current_idx == 0 && DATA->column->targetDatas.size() == 1)
                 return false;
 
+            const bool    REMOVING_SRC_COL    = SRC_COL && SRC_COL->targetDatas.size() <= 1;
+            const int64_t REMOVED_IDX         = REMOVING_SRC_COL ? m_scrollingData->idx(SRC_COL) : -1;
+            const size_t  COLUMN_COUNT_BEFORE = m_scrollingData->columns.size();
+
+            clearSpan(DATA);
+            if (REMOVED_IDX >= 0)
+                adjustSpansAfterColumnRemove(sc<size_t>(REMOVED_IDX), COLUMN_COUNT_BEFORE, DATA);
             DATA->column->remove(t);
 
             if (!COL) {
@@ -1395,12 +1536,20 @@ void CScrollingAlgorithm::moveTargetTo(SP<ITarget> t, Math::eDirection dir, bool
 
             return true;
         } else if (ROTATED_DIR == Math::DIRECTION_RIGHT) {
-            const auto COL = m_scrollingData->next(DATA->column.lock());
+            const auto SRC_COL = DATA->column.lock();
+            const auto COL     = m_scrollingData->next(SRC_COL);
 
             // ignore move to the right when there is no next column and we're alone
             if (!COL && current_idx == (int64_t)m_scrollingData->columns.size() - 1 && DATA->column->targetDatas.size() == 1)
                 return false;
 
+            const bool    REMOVING_SRC_COL    = SRC_COL && SRC_COL->targetDatas.size() <= 1;
+            const int64_t REMOVED_IDX         = REMOVING_SRC_COL ? m_scrollingData->idx(SRC_COL) : -1;
+            const size_t  COLUMN_COUNT_BEFORE = m_scrollingData->columns.size();
+
+            clearSpan(DATA);
+            if (REMOVED_IDX >= 0)
+                adjustSpansAfterColumnRemove(sc<size_t>(REMOVED_IDX), COLUMN_COUNT_BEFORE, DATA);
             DATA->column->remove(t);
 
             if (!COL) {
@@ -1417,10 +1566,25 @@ void CScrollingAlgorithm::moveTargetTo(SP<ITarget> t, Math::eDirection dir, bool
             }
 
             return true;
-        } else if (ROTATED_DIR == Math::DIRECTION_UP)
-            return DATA->column->up(DATA);
-        else if (ROTATED_DIR == Math::DIRECTION_DOWN)
-            return DATA->column->down(DATA);
+        } else if (ROTATED_DIR == Math::DIRECTION_UP || ROTATED_DIR == Math::DIRECTION_DOWN) {
+            const auto COL = DATA->column.lock();
+            if (!COL)
+                return false;
+
+            const auto OLD_ORDER = COL->targetDatas;
+            const bool MOVED     = ROTATED_DIR == Math::DIRECTION_UP ? COL->up(DATA) : COL->down(DATA);
+            if (!MOVED)
+                return false;
+
+            m_scrollingData->recalculate(true);
+
+            if (!validateCurrentSpans()) {
+                COL->targetDatas = OLD_ORDER;
+                m_scrollingData->recalculate(true);
+            }
+
+            return true;
+        }
 
         return false;
     };
@@ -1434,6 +1598,7 @@ void CScrollingAlgorithm::moveTargetTo(SP<ITarget> t, Math::eDirection dir, bool
 
         const auto MONINDIR = State::monitorState()->query().relativeTo(m_parent->space()->workspace()->m_monitor.lock()).inDirection(dir).run();
         if (MONINDIR && MONINDIR != m_parent->space()->workspace()->m_monitor && MONINDIR->m_activeWorkspace) {
+            clearSpan(DATA);
             t->assignToSpace(MONINDIR->m_activeWorkspace->m_space, focalPointForDir(t, dir));
 
             m_scrollingData->recalculate();
@@ -1441,6 +1606,11 @@ void CScrollingAlgorithm::moveTargetTo(SP<ITarget> t, Math::eDirection dir, bool
             return;
         }
     }
+
+    m_scrollingData->recalculate(true);
+
+    if (!validateCurrentSpans())
+        clearAllSpans();
 
     m_scrollingData->recalculate();
     focusTargetUpdate(t);
@@ -1452,14 +1622,6 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
     const auto notFound   = [](std::string msg) { return Config::configError(std::move(msg), Config::eConfigErrorLevel::WARNING, Config::eConfigErrorCode::NOT_FOUND); };
     const auto stateErr   = [](std::string msg) { return Config::configError(std::move(msg), Config::eConfigErrorLevel::WARNING, Config::eConfigErrorCode::INVALID_STATE); };
 
-    auto       centerOrFit = [this](const SP<SColumnData> COL) -> void {
-        static const auto PFITMETHOD = CConfigValue<Config::INTEGER>("scrolling:focus_fit_method");
-        if (*PFITMETHOD == 1)
-            m_scrollingData->fitCol(COL);
-        else
-            m_scrollingData->centerCol(COL);
-    };
-
     const auto ARGS = CVarList(std::string{sv}, 0, ' ');
     if (ARGS[0] == "move") {
         if (ARGS[1] == "+col" || ARGS[1] == "col") {
@@ -1467,7 +1629,7 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
             if (!TDATA)
                 return noTarget("no window");
 
-            const auto COL = m_scrollingData->next(TDATA->column.lock());
+            const auto COL = nextColumnForTargetData(TDATA);
             if (!COL) {
                 // move to max
                 double maxOffset = m_scrollingData->maxWidth();
@@ -1477,12 +1639,13 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
                 return {};
             }
 
-            centerOrFit(COL);
+            const auto TARGET = COL->targetDatas.front();
+            centerOrFitTargetData(TARGET);
             m_scrollingData->recalculate();
 
-            focusTargetUpdate(COL->targetDatas.front()->target.lock());
-            if (COL->targetDatas.front()->target->window())
-                g_pCompositor->warpCursorTo(COL->targetDatas.front()->target->window()->middle());
+            focusTargetUpdate(TARGET->target.lock());
+            if (TARGET->target->window())
+                g_pCompositor->warpCursorTo(TARGET->target->window()->middle());
 
             return {};
         } else if (ARGS[1] == "-col") {
@@ -1499,16 +1662,17 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
                 return {};
             }
 
-            const auto COL = m_scrollingData->prev(TDATA->column.lock());
+            const auto COL = prevColumnForTargetData(TDATA);
             if (!COL)
                 return {};
 
-            centerOrFit(COL);
+            const auto TARGET = COL->targetDatas.back();
+            centerOrFitTargetData(TARGET);
             m_scrollingData->recalculate();
 
-            focusTargetUpdate(COL->targetDatas.back()->target.lock());
-            if (COL->targetDatas.front()->target->window())
-                g_pCompositor->warpCursorTo(COL->targetDatas.front()->target->window()->middle());
+            focusTargetUpdate(TARGET->target.lock());
+            if (TARGET->target->window())
+                g_pCompositor->warpCursorTo(TARGET->target->window()->middle());
 
             return {};
         }
@@ -1548,7 +1712,7 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
             auto col = TDATA->column.lock();
             if (col) {
                 col->setColumnWidth(std::clamp(col->getColumnWidth(), MIN_COLUMN_WIDTH, MAX_COLUMN_WIDTH));
-                m_scrollingData->centerOrFitCol(col);
+                centerOrFitTargetData(TDATA);
             }
             m_scrollingData->recalculate();
         });
@@ -1618,14 +1782,37 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
             return stateErr("can't fit: no window or columns");
 
         if (ARGS[1] == "active") {
-            // fit the current column to 1.F
+            // Fit the current visual column range to the viewport.
             const auto USABLE = usableArea();
 
-            WDATA->column->setColumnWidth(1.F);
+            bool       fitSpan = false;
+            size_t     fitFrom = 0;
+            size_t     fitTo   = 0;
+
+            if (columnSpansSupportedForPrimaryAxis(m_scrollingData->controller->isPrimaryHorizontal()) && WDATA->span.active()) {
+                const auto COL = WDATA->column.lock();
+                if (COL) {
+                    const int64_t ANCHOR_IDX = m_scrollingData->idx(COL);
+                    if (ANCHOR_IDX >= 0) {
+                        if (const auto RANGE = renderableSpanRangeFor(WDATA, sc<size_t>(ANCHOR_IDX), m_scrollingData->columns.size()); RANGE) {
+                            fitSpan = true;
+                            fitFrom = RANGE->first;
+                            fitTo   = RANGE->last;
+                        }
+                    }
+                }
+            }
+
+            if (fitSpan) {
+                const float WIDTH = 1.F / sc<float>(fitTo - fitFrom + 1);
+                for (size_t i = fitFrom; i <= fitTo; ++i)
+                    m_scrollingData->columns[i]->setColumnWidth(WIDTH);
+            } else
+                WDATA->column->setColumnWidth(1.F);
 
             double off = 0.F;
             for (size_t i = 0; i < m_scrollingData->columns.size(); ++i) {
-                if (m_scrollingData->columns[i]->has(PWINDOW->layoutTarget()))
+                if (fitSpan ? i == fitFrom : m_scrollingData->columns[i]->has(PWINDOW->layoutTarget()))
                     break;
 
                 off += USABLE.w * m_scrollingData->columns[i]->getColumnWidth();
@@ -1649,7 +1836,7 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
                 WDATA->column->setColumnWidth(rem);
 
                 m_scrollingData->controller->setOffset(0);
-                centerOrFit(USED_COL);
+                m_scrollingData->centerOrFitCol(USED_COL);
                 m_scrollingData->recalculate();
             }
 
@@ -1666,7 +1853,15 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
             // fit all columns on screen that start from the current and end on the last
             bool   begun   = false;
             size_t foundAt = 0;
+            if (const auto RANGE = spanRangeForTargetData(WDATA); RANGE) {
+                begun   = true;
+                foundAt = RANGE->first;
+            }
+
             for (size_t i = 0; i < m_scrollingData->columns.size(); ++i) {
+                if (begun && i < foundAt)
+                    continue;
+
                 if (!begun && !m_scrollingData->columns[i]->has(PWINDOW->layoutTarget()))
                     continue;
 
@@ -1694,7 +1889,15 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
             // fit all columns on screen that start from the current and end on the last
             bool   begun   = false;
             size_t foundAt = 0;
+            if (const auto RANGE = spanRangeForTargetData(WDATA); RANGE) {
+                begun   = true;
+                foundAt = RANGE->last;
+            }
+
             for (int64_t i = (int64_t)m_scrollingData->columns.size() - 1; i >= 0; --i) {
+                if (begun && sc<size_t>(i) > foundAt)
+                    continue;
+
                 if (!begun && !m_scrollingData->columns[i]->has(PWINDOW->layoutTarget()))
                     continue;
 
@@ -1785,6 +1988,10 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
             }
 
             focusTargetUpdate(PREV->target.lock());
+            if (!targetDataVisible(PREV, true)) {
+                centerOrFitTargetData(PREV);
+                m_scrollingData->recalculate();
+            }
             if (PREV->target->window())
                 g_pCompositor->warpCursorTo(PREV->target->window()->middle());
         } else if (isNextInStrip) {
@@ -1798,14 +2005,18 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
             }
 
             focusTargetUpdate(NEXT->target.lock());
+            if (!targetDataVisible(NEXT, true)) {
+                centerOrFitTargetData(NEXT);
+                m_scrollingData->recalculate();
+            }
             if (NEXT->target->window())
                 g_pCompositor->warpCursorTo(NEXT->target->window()->middle());
         } else if (isPrevStrip) {
             // Move to previous strip
-            auto PREV = m_scrollingData->prev(TDATA->column.lock());
+            auto PREV = prevColumnForTargetData(TDATA);
             if (!PREV) {
                 if (*PNOFALLBACK) {
-                    centerOrFit(TDATA->column.lock());
+                    centerOrFitTargetData(TDATA);
                     m_scrollingData->recalculate();
                     if (TDATA->target->window())
                         g_pCompositor->warpCursorTo(TDATA->target->window()->middle());
@@ -1817,17 +2028,17 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
             auto pTargetData = findBestNeighbor(TDATA, PREV);
             if (pTargetData) {
                 focusTargetUpdate(pTargetData->target.lock());
-                centerOrFit(PREV);
+                centerOrFitTargetData(pTargetData);
                 m_scrollingData->recalculate();
                 if (pTargetData->target->window())
                     g_pCompositor->warpCursorTo(pTargetData->target->window()->middle());
             }
         } else if (isNextStrip) {
             // Move to next strip
-            auto NEXT = m_scrollingData->next(TDATA->column.lock());
+            auto NEXT = nextColumnForTargetData(TDATA);
             if (!NEXT) {
                 if (*PNOFALLBACK) {
-                    centerOrFit(TDATA->column.lock());
+                    centerOrFitTargetData(TDATA);
                     m_scrollingData->recalculate();
                     if (TDATA->target->window())
                         g_pCompositor->warpCursorTo(TDATA->target->window()->middle());
@@ -1839,7 +2050,7 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
             auto pTargetData = findBestNeighbor(TDATA, NEXT);
             if (pTargetData) {
                 focusTargetUpdate(pTargetData->target.lock());
-                centerOrFit(NEXT);
+                centerOrFitTargetData(pTargetData);
                 m_scrollingData->recalculate();
                 if (pTargetData->target->window())
                     g_pCompositor->warpCursorTo(pTargetData->target->window()->middle());
@@ -1856,15 +2067,40 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
 
         // consume the first target from adjCol into dstCol
         auto consumeTarget = [&](SP<SColumnData> dstCol, SP<SColumnData> adjCol) {
-            const auto target = adjCol->targetDatas.front();
+            const auto target              = adjCol->targetDatas.front();
+            const bool REMOVING_ADJ_COL    = adjCol->targetDatas.size() <= 1;
+            const auto REMOVED_IDX         = REMOVING_ADJ_COL ? m_scrollingData->idx(adjCol) : -1;
+            const auto COLUMN_COUNT_BEFORE = m_scrollingData->columns.size();
+
+            clearSpan(target);
+            if (REMOVED_IDX >= 0)
+                adjustSpansAfterColumnRemove(sc<size_t>(REMOVED_IDX), COLUMN_COUNT_BEFORE, target);
+
             adjCol->remove(target->target.lock());
             dstCol->add(target);
             m_scrollingData->centerOrFitCol(dstCol);
+
+            m_scrollingData->recalculate(true);
+            if (!validateCurrentSpans()) {
+                clearSpansCoveringColumn(dstCol);
+                clearSpansCoveringColumn(adjCol);
+            }
+        };
+
+        auto expelTargetPreservingSpans = [&](SP<SScrollingTargetData> target, SP<SColumnData> srcCol, std::optional<int64_t> insertIdx) {
+            const auto NEW_COL = expelTarget(target, srcCol, insertIdx);
+
+            m_scrollingData->recalculate(true);
+            if (!validateCurrentSpans()) {
+                clearSpansCoveringColumn(srcCol);
+                clearSpansCoveringColumn(NEW_COL);
+            }
         };
 
         if (ARGS[0] == "promote") {
             auto idx = m_scrollingData->idx(CURRENT_COL);
-            expelTarget(TDATA, CURRENT_COL, idx == -1 ? std::nullopt : std::optional<int64_t>{idx});
+
+            expelTargetPreservingSpans(TDATA, CURRENT_COL, idx == -1 ? std::nullopt : std::optional<int64_t>{idx});
         } else if (ARGS[0] == "expel") {
             if (CURRENT_COL->targetDatas.size() < 2)
                 return stateErr("column has only one window");
@@ -1874,7 +2110,7 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
             const auto NEXT_COL   = m_scrollingData->next(CURRENT_COL);
             const auto insertIdx  = !NEXT_COL ? std::nullopt : std::optional<int64_t>{currentIdx};
 
-            expelTarget(lastTarget, CURRENT_COL, insertIdx);
+            expelTargetPreservingSpans(lastTarget, CURRENT_COL, insertIdx);
         } else if (ARGS[0] == "consume") {
             const auto NEXT_COL = m_scrollingData->next(CURRENT_COL);
             if (!NEXT_COL)
@@ -1894,15 +2130,29 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
 
             if (CURRENT_COL->targetDatas.size() > 1) {
                 const auto currentIdx = m_scrollingData->idx(CURRENT_COL);
-                expelTarget(TDATA, CURRENT_COL, prev ? currentIdx - 1 : currentIdx);
+
+                expelTargetPreservingSpans(TDATA, CURRENT_COL, prev ? currentIdx - 1 : currentIdx);
             } else {
                 const auto ADJ_COL = prev ? m_scrollingData->prev(CURRENT_COL) : m_scrollingData->next(CURRENT_COL);
                 if (!ADJ_COL)
                     return notFound("no adjacent column");
 
+                const auto REMOVED_IDX         = m_scrollingData->idx(CURRENT_COL);
+                const auto COLUMN_COUNT_BEFORE = m_scrollingData->columns.size();
+
+                clearSpan(TDATA);
+                if (REMOVED_IDX >= 0)
+                    adjustSpansAfterColumnRemove(sc<size_t>(REMOVED_IDX), COLUMN_COUNT_BEFORE, TDATA);
+
                 CURRENT_COL->remove(TDATA->target.lock());
                 ADJ_COL->add(TDATA);
                 m_scrollingData->centerOrFitCol(ADJ_COL);
+
+                m_scrollingData->recalculate(true);
+                if (!validateCurrentSpans()) {
+                    clearSpansCoveringColumn(CURRENT_COL);
+                    clearSpansCoveringColumn(ADJ_COL);
+                }
             }
         }
 
@@ -1948,6 +2198,14 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
             return invalidArg("no target (invalid direction?)");
         ;
 
+        if (currentIdx == targetIdx)
+            return {};
+
+        const auto TARGET_COL = m_scrollingData->columns.at(targetIdx);
+        clearSpansCoveringColumn(CURRENT_COL);
+        clearSpansCoveringColumn(TARGET_COL);
+
+        // Any span that could be retargeted by this swap was cleared above.
         std::swap(m_scrollingData->columns.at(currentIdx), m_scrollingData->columns.at(targetIdx));
 
         m_scrollingData->controller->swapStrips(currentIdx, targetIdx);
@@ -1963,7 +2221,7 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
         if (!CURRENT_COL)
             return stateErr("no current col");
 
-        m_scrollingData->centerCol(CURRENT_COL);
+        centerTargetData(TDATA);
         m_scrollingData->recalculate();
     } else if (ARGS[0] == "inhibit_scroll") {
         // Inhibits/Uninhibits scrolling: The tape does not move for the currently active workspace while this option is active
@@ -1995,9 +2253,54 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
 
         m_scrollingData->SScrollingData::centerOrFitCol(WDATA->column.lock());
         m_scrollingData->recalculate();
-    }
+    } else if (ARGS[0] == "expand" || ARGS[0] == "shrink") {
+        if (ARGS.size() < 2)
+            return invalidArg("not enough args");
 
-    else
+        const auto TDATA = dataFor(Desktop::focusState()->window() ? Desktop::focusState()->window()->layoutTarget() : nullptr);
+        if (!TDATA)
+            return noTarget("no window");
+
+        const bool EXPAND = ARGS[0] == "expand";
+        const int  DELTA  = EXPAND ? 1 : -1;
+        const bool LEFT   = ARGS[1] == "left";
+        const bool RIGHT  = ARGS[1] == "right";
+
+        if (!LEFT && !RIGHT)
+            return invalidArg("invalid span direction, expected left or right");
+
+        if (!columnSpansSupportedForPrimaryAxis(m_scrollingData->controller->isPrimaryHorizontal()))
+            return invalidArg("span expansion requires horizontal scrolling direction");
+
+        const bool REVERSED = m_scrollingData->controller->isReversed();
+
+        auto       updateSpan = [this, TDATA](int deltaLeft, int deltaRight) {
+            // Edge and validation failures are intentional no-ops for span layout messages.
+            tryUpdateSpan(TDATA, deltaLeft, deltaRight);
+        };
+
+        if (LEFT) {
+            if (REVERSED)
+                updateSpan(0, DELTA);
+            else
+                updateSpan(DELTA, 0);
+            return {};
+        }
+
+        if (REVERSED)
+            updateSpan(DELTA, 0);
+        else
+            updateSpan(0, DELTA);
+        return {};
+    } else if (ARGS[0] == "collapse") {
+        const auto TDATA = dataFor(Desktop::focusState()->window() ? Desktop::focusState()->window()->layoutTarget() : nullptr);
+        if (!TDATA)
+            return noTarget("no window");
+
+        clearSpan(TDATA);
+        m_scrollingData->recalculate();
+        return {};
+    } else
         return invalidArg("no such layoutmsg for scrolling");
 
     return {};
@@ -2173,6 +2476,498 @@ void CScrollingAlgorithm::focusTargetUpdate(SP<ITarget> target) {
         if (auto col = TARGETDATA->column.lock())
             col->lastFocusedTarget = TARGETDATA;
     }
+}
+
+std::optional<SSpanRange> CScrollingAlgorithm::spanRangeForTargetData(SP<SScrollingTargetData> target) const {
+    if (!target || !m_scrollingData || !m_scrollingData->controller)
+        return std::nullopt;
+
+    if (!columnSpansSupportedForPrimaryAxis(m_scrollingData->controller->isPrimaryHorizontal()))
+        return std::nullopt;
+
+    const auto COL = target->column.lock();
+    if (!COL)
+        return std::nullopt;
+
+    const int64_t ANCHOR_IDX = m_scrollingData->idx(COL);
+    if (ANCHOR_IDX < 0)
+        return std::nullopt;
+
+    return renderableSpanRangeFor(target, sc<size_t>(ANCHOR_IDX), m_scrollingData->columns.size());
+}
+
+bool CScrollingAlgorithm::targetDataVisible(SP<SScrollingTargetData> target, bool full) const {
+    if (!target || !m_scrollingData)
+        return false;
+
+    if (const auto RANGE = spanRangeForTargetData(target); RANGE) {
+        bool anyVisible = false;
+        for (size_t i = RANGE->first; i <= RANGE->last; ++i) {
+            if (i >= m_scrollingData->columns.size())
+                return false;
+
+            const bool VISIBLE = m_scrollingData->visible(m_scrollingData->columns[i], full);
+            if (full && !VISIBLE)
+                return false;
+
+            anyVisible = anyVisible || VISIBLE;
+        }
+
+        return full || anyVisible;
+    }
+
+    return m_scrollingData->visible(target->column.lock(), full);
+}
+
+void CScrollingAlgorithm::centerSpanRange(const SSpanRange& range) {
+    if (!m_scrollingData || !m_scrollingData->controller || range.first >= m_scrollingData->columns.size() || range.last >= m_scrollingData->columns.size())
+        return;
+
+    static const auto PFSONONE = CConfigValue<Config::INTEGER>("scrolling:fullscreen_on_one_column");
+
+    const auto        USABLE  = usableArea();
+    const double      PRIMARY = m_scrollingData->controller->isPrimaryHorizontal() ? USABLE.w : USABLE.h;
+    if (PRIMARY <= 0.0)
+        return;
+
+    const double START = m_scrollingData->controller->calculateStripStart(range.first, USABLE, *PFSONONE);
+    const double END =
+        m_scrollingData->controller->calculateStripStart(range.last, USABLE, *PFSONONE) + m_scrollingData->controller->calculateStripSize(range.last, USABLE, *PFSONONE);
+    const double SIZE = END - START;
+
+    m_scrollingData->controller->setOffset(START - (PRIMARY - SIZE) / 2.0);
+}
+
+void CScrollingAlgorithm::fitSpanRange(const SSpanRange& range) {
+    if (!m_scrollingData || !m_scrollingData->controller || range.first >= m_scrollingData->columns.size() || range.last >= m_scrollingData->columns.size())
+        return;
+
+    static const auto PFSONONE = CConfigValue<Config::INTEGER>("scrolling:fullscreen_on_one_column");
+
+    const auto        USABLE  = usableArea();
+    const double      PRIMARY = m_scrollingData->controller->isPrimaryHorizontal() ? USABLE.w : USABLE.h;
+    if (PRIMARY <= 0.0)
+        return;
+
+    const double START = m_scrollingData->controller->calculateStripStart(range.first, USABLE, *PFSONONE);
+    const double END =
+        m_scrollingData->controller->calculateStripStart(range.last, USABLE, *PFSONONE) + m_scrollingData->controller->calculateStripSize(range.last, USABLE, *PFSONONE);
+    const double SIZE = END - START;
+    const double LO   = START - PRIMARY + SIZE;
+    const double HI   = START;
+
+    if (LO > HI) {
+        centerSpanRange(range);
+        return;
+    }
+
+    m_scrollingData->controller->setOffset(std::clamp(m_scrollingData->controller->getOffset(), LO, HI));
+}
+
+void CScrollingAlgorithm::centerTargetData(SP<SScrollingTargetData> target) {
+    if (const auto RANGE = spanRangeForTargetData(target); RANGE) {
+        centerSpanRange(*RANGE);
+        return;
+    }
+
+    if (target)
+        m_scrollingData->centerCol(target->column.lock());
+}
+
+void CScrollingAlgorithm::fitTargetData(SP<SScrollingTargetData> target) {
+    if (const auto RANGE = spanRangeForTargetData(target); RANGE) {
+        fitSpanRange(*RANGE);
+        return;
+    }
+
+    if (target)
+        m_scrollingData->fitCol(target->column.lock());
+}
+
+void CScrollingAlgorithm::centerOrFitTargetData(SP<SScrollingTargetData> target) {
+    static const auto PFITMETHOD = CConfigValue<Config::INTEGER>("scrolling:focus_fit_method");
+
+    if (*PFITMETHOD == 1)
+        fitTargetData(target);
+    else
+        centerTargetData(target);
+}
+
+SP<SColumnData> CScrollingAlgorithm::nextColumnForTargetData(SP<SScrollingTargetData> target) {
+    if (!target || !m_scrollingData)
+        return nullptr;
+
+    if (const auto RANGE = spanRangeForTargetData(target); RANGE)
+        return RANGE->last + 1 < m_scrollingData->columns.size() ? m_scrollingData->columns[RANGE->last + 1] : nullptr;
+
+    return m_scrollingData->next(target->column.lock());
+}
+
+SP<SColumnData> CScrollingAlgorithm::prevColumnForTargetData(SP<SScrollingTargetData> target) {
+    if (!target || !m_scrollingData)
+        return nullptr;
+
+    if (const auto RANGE = spanRangeForTargetData(target); RANGE)
+        return RANGE->first > 0 ? m_scrollingData->columns[RANGE->first - 1] : nullptr;
+
+    return m_scrollingData->prev(target->column.lock());
+}
+
+void CScrollingAlgorithm::clearSpan(SP<SScrollingTargetData> target) {
+    if (!target)
+        return;
+
+    target->span = {};
+}
+
+void CScrollingAlgorithm::clearAllSpans() {
+    if (!m_scrollingData)
+        return;
+
+    for (const auto& col : m_scrollingData->columns) {
+        for (const auto& target : col->targetDatas)
+            clearSpan(target);
+    }
+}
+
+void CScrollingAlgorithm::clearSpansCoveringColumn(SP<SColumnData> column) {
+    if (!m_scrollingData || !column)
+        return;
+
+    const int64_t columnIdx = m_scrollingData->idx(column);
+    if (columnIdx < 0)
+        return;
+
+    const auto COLUMN_COUNT = m_scrollingData->columns.size();
+    for (size_t anchorIdx = 0; anchorIdx < COLUMN_COUNT; ++anchorIdx) {
+        for (const auto& target : m_scrollingData->columns[anchorIdx]->targetDatas) {
+            if (!target->span.active())
+                continue;
+
+            if (target->span.left < 0 || target->span.right < 0) {
+                clearSpan(target);
+                continue;
+            }
+
+            const auto RANGE = spanRangeFor(anchorIdx, target->span, COLUMN_COUNT);
+            if (!RANGE || RANGE->contains(sc<size_t>(columnIdx)))
+                clearSpan(target);
+        }
+    }
+}
+
+void CScrollingAlgorithm::adjustSpansAfterColumnInsert(size_t insertedColumn, size_t columnCountBefore, SP<SScrollingTargetData> ignoredTarget) {
+    if (!m_scrollingData || insertedColumn > columnCountBefore)
+        return;
+
+    for (size_t anchorIdx = 0; anchorIdx < columnCountBefore; ++anchorIdx) {
+        for (const auto& target : m_scrollingData->columns[anchorIdx]->targetDatas) {
+            if (target == ignoredTarget || !target->span.active())
+                continue;
+
+            if (const auto SPAN = spanAfterColumnInsert(anchorIdx, target->span, insertedColumn, columnCountBefore); SPAN)
+                target->span = *SPAN;
+            else
+                clearSpan(target);
+        }
+    }
+}
+
+void CScrollingAlgorithm::adjustSpansAfterColumnRemove(size_t removedColumn, size_t columnCountBefore, SP<SScrollingTargetData> ignoredTarget) {
+    if (!m_scrollingData || removedColumn >= columnCountBefore || columnCountBefore > m_scrollingData->columns.size())
+        return;
+
+    for (size_t anchorIdx = 0; anchorIdx < columnCountBefore; ++anchorIdx) {
+        for (const auto& target : m_scrollingData->columns[anchorIdx]->targetDatas) {
+            if (target == ignoredTarget || !target->span.active())
+                continue;
+
+            if (target->span.left < 0 || target->span.right < 0) {
+                clearSpan(target);
+                continue;
+            }
+
+            if (const auto SPAN = spanAfterColumnRemove(anchorIdx, target->span, removedColumn, columnCountBefore); SPAN)
+                target->span = *SPAN;
+            else
+                clearSpan(target);
+        }
+    }
+}
+
+void CScrollingAlgorithm::sanitizeCurrentSpans() {
+    if (!m_scrollingData || !m_scrollingData->controller)
+        return;
+
+    if (!columnSpansSupportedForPrimaryAxis(m_scrollingData->controller->isPrimaryHorizontal()))
+        return;
+
+    if (!validateCurrentSpans())
+        clearAllSpans();
+}
+
+bool CScrollingAlgorithm::validateCurrentSpans() const {
+    if (!m_scrollingData || !m_scrollingData->controller)
+        return true;
+
+    if (!m_parent || !m_parent->space())
+        return true;
+
+    if (!columnSpansSupportedForPrimaryAxis(m_scrollingData->controller->isPrimaryHorizontal()))
+        return true;
+
+    const auto USABLE   = usableArea();
+    const auto WORKAREA = m_parent->space()->workArea();
+    if (WORKAREA.h <= 0.0)
+        return false;
+
+    return resolveSpanLayout(USABLE, WORKAREA.pos()).valid;
+}
+
+CScrollingAlgorithm::SSpanResolvedLayout CScrollingAlgorithm::resolveSpanLayout(const CBox& usable, const Vector2D& workspaceOffset) const {
+    static const auto PFSONONE = CConfigValue<Config::INTEGER>("scrolling:fullscreen_on_one_column");
+
+    const auto        COLUMN_COUNT = m_scrollingData->columns.size();
+    auto&             controller   = m_scrollingData->controller;
+
+    // Build base (unadjusted) target boxes for every column.
+    std::vector<std::vector<SSpanAdjustedTargetBox>> boxes;
+    boxes.resize(COLUMN_COUNT);
+
+    for (size_t colIdx = 0; colIdx < COLUMN_COUNT; ++colIdx) {
+        const auto& COL = m_scrollingData->columns[colIdx];
+        boxes[colIdx].reserve(COL->targetDatas.size());
+
+        for (size_t targetIdx = 0; targetIdx < COL->targetDatas.size(); ++targetIdx) {
+            boxes[colIdx].emplace_back(SSpanAdjustedTargetBox{
+                .box          = controller->calculateTargetBox(colIdx, targetIdx, usable, workspaceOffset, *PFSONONE),
+                .virtualIndex = targetIdx,
+                .virtualCount = COL->targetDatas.size(),
+            });
+        }
+    }
+
+    if (!columnSpansSupportedForPrimaryAxis(controller->isPrimaryHorizontal()))
+        return {.valid = true, .boxes = std::move(boxes)};
+
+    if (usable.h <= 0.F)
+        return {.valid = false, .boxes = std::move(boxes)};
+
+    // Collect renderable span sources and build the dependency graph.
+    std::vector<std::vector<SSpanState>> columnSpans;
+    columnSpans.resize(COLUMN_COUNT);
+
+    std::vector<std::vector<size_t>> outgoingEdges;
+    outgoingEdges.resize(COLUMN_COUNT);
+
+    std::vector<size_t> inDegree;
+    inDegree.resize(COLUMN_COUNT, 0);
+
+    for (size_t colIdx = 0; colIdx < COLUMN_COUNT; ++colIdx) {
+        columnSpans[colIdx].reserve(m_scrollingData->columns[colIdx]->targetDatas.size());
+
+        // Track which destination columns already have an edge from this anchor
+        // (multiple targets in the same column may span to the same destination).
+        std::vector<bool> edgeAdded;
+        edgeAdded.resize(COLUMN_COUNT, false);
+
+        for (const auto& TDATA : m_scrollingData->columns[colIdx]->targetDatas) {
+            const auto RANGE = renderableSpanRangeFor(TDATA, colIdx, COLUMN_COUNT);
+            if (!RANGE)
+                continue;
+
+            columnSpans[colIdx].emplace_back(TDATA->span);
+
+            for (size_t destIdx = RANGE->first; destIdx <= RANGE->last; ++destIdx) {
+                if (destIdx != colIdx && !edgeAdded[destIdx]) {
+                    outgoingEdges[colIdx].push_back(destIdx);
+                    inDegree[destIdx]++;
+                    edgeAdded[destIdx] = true;
+                }
+            }
+        }
+    }
+
+    if (hasSpanDependencyCycle(columnSpans, COLUMN_COUNT))
+        return {.valid = false, .boxes = std::move(boxes)};
+
+    // Kahn's algorithm: start with columns that have no incoming span dependencies.
+    std::queue<size_t> queue;
+    for (size_t i = 0; i < COLUMN_COUNT; ++i) {
+        if (inDegree[i] == 0)
+            queue.push(i);
+    }
+
+    // Per-column validations, populated incrementally as anchors are resolved.
+    std::vector<SColumnSpanValidation> validations;
+    validations.resize(COLUMN_COUNT);
+
+    std::vector<bool> affectedColumns;
+    affectedColumns.resize(COLUMN_COUNT, false);
+
+    for (size_t colIdx = 0; colIdx < COLUMN_COUNT; ++colIdx)
+        validations[colIdx].realTargetCount = m_scrollingData->columns[colIdx]->targetDatas.size();
+
+    bool valid = true;
+
+    while (!queue.empty()) {
+        const size_t colIdx = queue.front();
+        queue.pop();
+
+        // Step 1: Apply incoming reservations (if any) to this column's target boxes.
+        if (affectedColumns[colIdx]) {
+            const auto&        COL = m_scrollingData->columns[colIdx];
+            std::vector<float> targetSizes;
+            targetSizes.reserve(COL->targetDatas.size());
+
+            for (size_t targetIdx = 0; targetIdx < COL->targetDatas.size(); ++targetIdx)
+                targetSizes.emplace_back(COL->getTargetSize(targetIdx));
+
+            const auto RESULT = layoutColumnWithReservations(validations[colIdx], targetSizes, MIN_ROW_HEIGHT);
+            if (!RESULT.valid()) {
+                valid = false;
+                // Continue processing other columns so they still get laid out.
+            } else {
+                const auto STRIP_BOX = controller->calculateStripBox(colIdx, usable, workspaceOffset, *PFSONONE);
+                for (const auto& REAL_TARGET : RESULT.realTargets) {
+                    if (REAL_TARGET.index >= boxes[colIdx].size())
+                        continue;
+
+                    auto& BOX        = boxes[colIdx][REAL_TARGET.index];
+                    BOX.box          = STRIP_BOX;
+                    BOX.box.y        = workspaceOffset.y + REAL_TARGET.start * usable.h;
+                    BOX.box.h        = REAL_TARGET.size * usable.h;
+                    BOX.virtualIndex = REAL_TARGET.virtualIndex;
+                    BOX.virtualCount = REAL_TARGET.virtualCount;
+                }
+            }
+        }
+
+        // Step 2: Generate outgoing reservations from this column's anchor targets,
+        // using the (possibly adjusted) box positions from step 1.
+        const auto& COL = m_scrollingData->columns[colIdx];
+
+        for (size_t targetIdx = 0; targetIdx < COL->targetDatas.size(); ++targetIdx) {
+            const auto& TDATA = COL->targetDatas[targetIdx];
+            const auto  RANGE = renderableSpanRangeFor(TDATA, colIdx, COLUMN_COUNT);
+            if (!RANGE)
+                continue;
+
+            if (fullscreenTargetDataForColumn(COL))
+                return {.valid = false, .boxes = std::move(boxes)};
+
+            if (targetIdx >= boxes[colIdx].size())
+                return {.valid = false, .boxes = std::move(boxes)};
+
+            const auto& ANCHOR_BOX = boxes[colIdx][targetIdx].box;
+            const float START      = sc<float>((ANCHOR_BOX.y - workspaceOffset.y) / usable.h);
+            const float SIZE       = sc<float>(ANCHOR_BOX.h / usable.h);
+
+            for (size_t destIdx = RANGE->first; destIdx <= RANGE->last; ++destIdx) {
+                if (destIdx == colIdx)
+                    continue;
+
+                if (fullscreenTargetDataForColumn(m_scrollingData->columns[destIdx]))
+                    return {.valid = false, .boxes = std::move(boxes)};
+
+                const auto SLOT     = virtualSlotFor(targetIdx, COL->targetDatas.size(), m_scrollingData->columns[destIdx]->targetDatas.size());
+                auto&      validate = validations[destIdx];
+                validate.reservations.emplace_back(SSpanReservation{.slot = SLOT, .start = START, .size = SIZE});
+                affectedColumns[destIdx] = true;
+            }
+        }
+
+        // Step 3: Notify downstream columns. When a column's last incoming
+        // anchor has been resolved, it becomes ready for processing.
+        for (size_t destIdx : outgoingEdges[colIdx]) {
+            if (--inDegree[destIdx] == 0)
+                queue.push(destIdx);
+        }
+    }
+
+    return {.valid = valid, .boxes = std::move(boxes)};
+}
+
+std::vector<std::vector<SSpanAdjustedTargetBox>> CScrollingAlgorithm::spanAdjustedColumnBoxes(const CBox& usable, const Vector2D& workspaceOffset) const {
+    if (!m_scrollingData || !m_scrollingData->controller)
+        return {};
+
+    return resolveSpanLayout(usable, workspaceOffset).boxes;
+}
+
+std::optional<CBox> CScrollingAlgorithm::spannedLayoutBox(SP<SScrollingTargetData> target, size_t anchorIdx, const CBox& usable, const Vector2D& workspaceOffset) const {
+    if (!m_scrollingData || !m_scrollingData->controller)
+        return std::nullopt;
+
+    static const auto PFSONONE = CConfigValue<Config::INTEGER>("scrolling:fullscreen_on_one_column");
+
+    const auto&       CONTROLLER = m_scrollingData->controller;
+    if (!columnSpansSupportedForPrimaryAxis(CONTROLLER->isPrimaryHorizontal()))
+        return std::nullopt;
+
+    const auto RANGE = renderableSpanRangeFor(target, anchorIdx, m_scrollingData->columns.size());
+    if (!RANGE)
+        return std::nullopt;
+
+    for (size_t colIdx = RANGE->first; colIdx <= RANGE->last; ++colIdx) {
+        if (fullscreenTargetDataForColumn(m_scrollingData->columns[colIdx]))
+            return std::nullopt;
+    }
+
+    const auto FIRST = CONTROLLER->calculateStripBox(RANGE->first, usable, workspaceOffset, *PFSONONE);
+    const auto LAST  = CONTROLLER->calculateStripBox(RANGE->last, usable, workspaceOffset, *PFSONONE);
+
+    CBox       result = target->layoutBox;
+    const auto LEFT   = std::min(FIRST.x, LAST.x);
+    const auto RIGHT  = std::max(FIRST.x + FIRST.w, LAST.x + LAST.w);
+    result.x          = LEFT;
+    result.w          = RIGHT - LEFT;
+
+    return result;
+}
+
+bool CScrollingAlgorithm::tryUpdateSpan(SP<SScrollingTargetData> target, int deltaLeft, int deltaRight) {
+    if (!target)
+        return false;
+
+    const auto TARGET = target->target.lock();
+    if (!TARGET || TARGET->layoutManagedFullscreen() || TARGET->fullscreenMode() != FSMODE_NONE)
+        return false;
+
+    const auto COLUMN = target->column.lock();
+    if (!COLUMN)
+        return false;
+
+    if (!columnSpansSupportedForPrimaryAxis(m_scrollingData->controller->isPrimaryHorizontal()))
+        return false;
+
+    const int64_t ANCHOR_IDX = m_scrollingData->idx(COLUMN);
+    if (ANCHOR_IDX < 0)
+        return false;
+
+    if (deltaLeft > 0 && ANCHOR_IDX - target->span.left <= 0)
+        return false;
+
+    if (deltaRight > 0 && ANCHOR_IDX + target->span.right >= sc<int64_t>(m_scrollingData->columns.size()) - 1)
+        return false;
+
+    if (deltaLeft < 0 && target->span.left == 0)
+        return false;
+
+    if (deltaRight < 0 && target->span.right == 0)
+        return false;
+
+    const auto OLDSPAN = target->span;
+    target->span.left  = std::max(0, target->span.left + deltaLeft);
+    target->span.right = std::max(0, target->span.right + deltaRight);
+
+    if (!validateCurrentSpans()) {
+        target->span = OLDSPAN;
+        return false;
+    }
+
+    m_scrollingData->recalculate();
+    return true;
 }
 
 SP<SScrollingTargetData> CScrollingAlgorithm::findBestNeighbor(SP<SScrollingTargetData> pCurrent, SP<SColumnData> pTargetCol) {

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -2927,46 +2927,68 @@ std::optional<CBox> CScrollingAlgorithm::spannedLayoutBox(SP<SScrollingTargetDat
 }
 
 bool CScrollingAlgorithm::tryUpdateSpan(SP<SScrollingTargetData> target, int deltaLeft, int deltaRight) {
-    if (!target)
+    if (!target) {
+        Log::logger->log(Log::INFO, "tryUpdateSpan: no target");
         return false;
+    }
 
     const auto TARGET = target->target.lock();
-    if (!TARGET || TARGET->layoutManagedFullscreen() || TARGET->fullscreenMode() != FSMODE_NONE)
+    if (!TARGET || TARGET->layoutManagedFullscreen() || TARGET->fullscreenMode() != FSMODE_NONE) {
+        Log::logger->log(Log::INFO, "tryUpdateSpan: target invalid, fullscreen, or maximized");
         return false;
+    }
 
     const auto COLUMN = target->column.lock();
-    if (!COLUMN)
+    if (!COLUMN) {
+        Log::logger->log(Log::INFO, "tryUpdateSpan: no column");
         return false;
+    }
 
-    if (!columnSpansSupportedForPrimaryAxis(m_scrollingData->controller->isPrimaryHorizontal()))
+    if (!columnSpansSupportedForPrimaryAxis(m_scrollingData->controller->isPrimaryHorizontal())) {
+        Log::logger->log(Log::INFO, "tryUpdateSpan: not horizontal primary axis");
         return false;
+    }
 
     const int64_t ANCHOR_IDX = m_scrollingData->idx(COLUMN);
-    if (ANCHOR_IDX < 0)
+    if (ANCHOR_IDX < 0) {
+        Log::logger->log(Log::INFO, "tryUpdateSpan: anchor idx < 0");
         return false;
+    }
 
-    if (deltaLeft > 0 && ANCHOR_IDX - target->span.left <= 0)
+    if (deltaLeft > 0 && ANCHOR_IDX - target->span.left <= 0) {
+        Log::logger->log(Log::INFO, "tryUpdateSpan: at left boundary (anchor={}, span.left={}, deltaLeft={})", ANCHOR_IDX, target->span.left, deltaLeft);
         return false;
+    }
 
-    if (deltaRight > 0 && ANCHOR_IDX + target->span.right >= sc<int64_t>(m_scrollingData->columns.size()) - 1)
+    if (deltaRight > 0 && ANCHOR_IDX + target->span.right >= sc<int64_t>(m_scrollingData->columns.size()) - 1) {
+        Log::logger->log(Log::INFO, "tryUpdateSpan: at right boundary (anchor={}, span.right={}, columns={})", ANCHOR_IDX, target->span.right, m_scrollingData->columns.size());
         return false;
+    }
 
-    if (deltaLeft < 0 && target->span.left == 0)
+    if (deltaLeft < 0 && target->span.left == 0) {
+        Log::logger->log(Log::INFO, "tryUpdateSpan: cannot shrink left, already 0");
         return false;
+    }
 
-    if (deltaRight < 0 && target->span.right == 0)
+    if (deltaRight < 0 && target->span.right == 0) {
+        Log::logger->log(Log::INFO, "tryUpdateSpan: cannot shrink right, already 0");
         return false;
+    }
 
     const auto OLDSPAN = target->span;
     target->span.left  = std::max(0, target->span.left + deltaLeft);
     target->span.right = std::max(0, target->span.right + deltaRight);
 
+    Log::logger->log(Log::INFO, "tryUpdateSpan: tentative span left={} right={}, validating...", target->span.left, target->span.right);
+
     if (!validateCurrentSpans()) {
+        Log::logger->log(Log::INFO, "tryUpdateSpan: validateCurrentSpans rejected");
         target->span = OLDSPAN;
         return false;
     }
 
     m_scrollingData->recalculate();
+    Log::logger->log(Log::INFO, "tryUpdateSpan: accepted");
     return true;
 }
 

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -51,12 +51,12 @@ static std::optional<SSpanRange> renderableSpanRangeFor(const SP<SScrollingTarge
     if (!renderableSpanSource(target) || anchorIdx >= columnCount)
         return std::nullopt;
 
-    if (target->span.left < 0 || target->span.right < 0)
+    if (target->span.prev < 0 || target->span.next < 0)
         return std::nullopt;
 
-    const auto SPAN_LEFT  = sc<size_t>(target->span.left);
-    const auto SPAN_RIGHT = sc<size_t>(target->span.right);
-    if (SPAN_LEFT > anchorIdx || SPAN_RIGHT >= columnCount - anchorIdx)
+    const auto SPAN_PREV  = sc<size_t>(target->span.prev);
+    const auto SPAN_NEXT = sc<size_t>(target->span.next);
+    if (SPAN_PREV > anchorIdx || SPAN_NEXT >= columnCount - anchorIdx)
         return std::nullopt;
 
     return spanRangeFor(anchorIdx, target->span, columnCount);
@@ -482,7 +482,14 @@ void SScrollingData::recalculate(bool forceInstant) {
         }
     }
 
-    controller->setDirection(algorithm->getDynamicDirection());
+    const auto CURRENT_DIR = algorithm->getDynamicDirection();
+    controller->setDirection(CURRENT_DIR);
+
+    // Clear spans when scroll direction changes -- prev/next semantics rotate.
+    if (CURRENT_DIR != algorithm->m_lastDynamicDirection) {
+        algorithm->clearAllSpans();
+        algorithm->m_lastDynamicDirection = CURRENT_DIR;
+    }
     algorithm->sanitizeCurrentSpans();
 
     algorithm->updateFullscreenFade(anyFullscreenCovers);
@@ -1789,7 +1796,7 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
             size_t     fitFrom = 0;
             size_t     fitTo   = 0;
 
-            if (columnSpansSupportedForPrimaryAxis(m_scrollingData->controller->isPrimaryHorizontal()) && WDATA->span.active()) {
+            if (WDATA->span.active()) {
                 const auto COL = WDATA->column.lock();
                 if (COL) {
                     const int64_t ANCHOR_IDX = m_scrollingData->idx(COL);
@@ -2263,34 +2270,18 @@ Config::ErrorResult CScrollingAlgorithm::layoutMsg(const std::string_view& sv) {
 
         const bool EXPAND = ARGS[0] == "expand";
         const int  DELTA  = EXPAND ? 1 : -1;
-        const bool LEFT   = ARGS[1] == "left";
-        const bool RIGHT  = ARGS[1] == "right";
+        const bool PREV   = ARGS[1] == "prev";
+        const bool NEXT   = ARGS[1] == "next";
 
-        if (!LEFT && !RIGHT)
-            return invalidArg("invalid span direction, expected left or right");
+        if (!PREV && !NEXT)
+            return invalidArg("invalid span direction, expected prev or next");
 
-        if (!columnSpansSupportedForPrimaryAxis(m_scrollingData->controller->isPrimaryHorizontal()))
-            return invalidArg("span expansion requires horizontal scrolling direction");
-
-        const bool REVERSED = m_scrollingData->controller->isReversed();
-
-        auto       updateSpan = [this, TDATA](int deltaLeft, int deltaRight) {
-            // Edge and validation failures are intentional no-ops for span layout messages.
-            tryUpdateSpan(TDATA, deltaLeft, deltaRight);
-        };
-
-        if (LEFT) {
-            if (REVERSED)
-                updateSpan(0, DELTA);
-            else
-                updateSpan(DELTA, 0);
-            return {};
-        }
-
-        if (REVERSED)
-            updateSpan(DELTA, 0);
+        // prev always means decreasing strip index, next always means increasing strip index.
+        // No reversal logic needed — prev/next are axis-agnostic.
+        if (PREV)
+            tryUpdateSpan(TDATA, DELTA, 0);
         else
-            updateSpan(0, DELTA);
+            tryUpdateSpan(TDATA, 0, DELTA);
         return {};
     } else if (ARGS[0] == "collapse") {
         const auto TDATA = dataFor(Desktop::focusState()->window() ? Desktop::focusState()->window()->layoutTarget() : nullptr);
@@ -2482,9 +2473,6 @@ std::optional<SSpanRange> CScrollingAlgorithm::spanRangeForTargetData(SP<SScroll
     if (!target || !m_scrollingData || !m_scrollingData->controller)
         return std::nullopt;
 
-    if (!columnSpansSupportedForPrimaryAxis(m_scrollingData->controller->isPrimaryHorizontal()))
-        return std::nullopt;
-
     const auto COL = target->column.lock();
     if (!COL)
         return std::nullopt;
@@ -2644,7 +2632,7 @@ void CScrollingAlgorithm::clearSpansCoveringColumn(SP<SColumnData> column) {
             if (!target->span.active())
                 continue;
 
-            if (target->span.left < 0 || target->span.right < 0) {
+            if (target->span.prev < 0 || target->span.next < 0) {
                 clearSpan(target);
                 continue;
             }
@@ -2682,7 +2670,7 @@ void CScrollingAlgorithm::adjustSpansAfterColumnRemove(size_t removedColumn, siz
             if (target == ignoredTarget || !target->span.active())
                 continue;
 
-            if (target->span.left < 0 || target->span.right < 0) {
+            if (target->span.prev < 0 || target->span.next < 0) {
                 clearSpan(target);
                 continue;
             }
@@ -2699,9 +2687,6 @@ void CScrollingAlgorithm::sanitizeCurrentSpans() {
     if (!m_scrollingData || !m_scrollingData->controller)
         return;
 
-    if (!columnSpansSupportedForPrimaryAxis(m_scrollingData->controller->isPrimaryHorizontal()))
-        return;
-
     if (!validateCurrentSpans())
         clearAllSpans();
 }
@@ -2711,9 +2696,6 @@ bool CScrollingAlgorithm::validateCurrentSpans() const {
         return true;
 
     if (!m_parent || !m_parent->space())
-        return true;
-
-    if (!columnSpansSupportedForPrimaryAxis(m_scrollingData->controller->isPrimaryHorizontal()))
         return true;
 
     const auto USABLE   = usableArea();
@@ -2746,9 +2728,6 @@ CScrollingAlgorithm::SSpanResolvedLayout CScrollingAlgorithm::resolveSpanLayout(
             });
         }
     }
-
-    if (!columnSpansSupportedForPrimaryAxis(controller->isPrimaryHorizontal()))
-        return {.valid = true, .boxes = std::move(boxes)};
 
     if (usable.h <= 0.F)
         return {.valid = false, .boxes = std::move(boxes)};
@@ -2835,8 +2814,7 @@ CScrollingAlgorithm::SSpanResolvedLayout CScrollingAlgorithm::resolveSpanLayout(
 
                     auto& BOX        = boxes[colIdx][REAL_TARGET.index];
                     BOX.box          = STRIP_BOX;
-                    BOX.box.y        = workspaceOffset.y + REAL_TARGET.start * usable.h;
-                    BOX.box.h        = REAL_TARGET.size * usable.h;
+                    controller->applySpanReservation(BOX.box, REAL_TARGET, STRIP_BOX, usable, workspaceOffset);
                     BOX.virtualIndex = REAL_TARGET.virtualIndex;
                     BOX.virtualCount = REAL_TARGET.virtualCount;
                 }
@@ -2860,8 +2838,9 @@ CScrollingAlgorithm::SSpanResolvedLayout CScrollingAlgorithm::resolveSpanLayout(
                 return {.valid = false, .boxes = std::move(boxes)};
 
             const auto& ANCHOR_BOX = boxes[colIdx][targetIdx].box;
-            const float START      = sc<float>((ANCHOR_BOX.y - workspaceOffset.y) / usable.h);
-            const float SIZE       = sc<float>(ANCHOR_BOX.h / usable.h);
+            const auto  PARAMS     = controller->extractSpanReservation(ANCHOR_BOX, usable, workspaceOffset);
+            const float START      = PARAMS.start;
+            const float SIZE       = PARAMS.size;
 
             for (size_t destIdx = RANGE->first; destIdx <= RANGE->last; ++destIdx) {
                 if (destIdx == colIdx)
@@ -2903,8 +2882,6 @@ std::optional<CBox> CScrollingAlgorithm::spannedLayoutBox(SP<SScrollingTargetDat
     static const auto PFSONONE = CConfigValue<Config::INTEGER>("scrolling:fullscreen_on_one_column");
 
     const auto&       CONTROLLER = m_scrollingData->controller;
-    if (!columnSpansSupportedForPrimaryAxis(CONTROLLER->isPrimaryHorizontal()))
-        return std::nullopt;
 
     const auto RANGE = renderableSpanRangeFor(target, anchorIdx, m_scrollingData->columns.size());
     if (!RANGE)
@@ -2918,16 +2895,13 @@ std::optional<CBox> CScrollingAlgorithm::spannedLayoutBox(SP<SScrollingTargetDat
     const auto FIRST = CONTROLLER->calculateStripBox(RANGE->first, usable, workspaceOffset, *PFSONONE);
     const auto LAST  = CONTROLLER->calculateStripBox(RANGE->last, usable, workspaceOffset, *PFSONONE);
 
-    CBox       result = target->layoutBox;
-    const auto LEFT   = std::min(FIRST.x, LAST.x);
-    const auto RIGHT  = std::max(FIRST.x + FIRST.w, LAST.x + LAST.w);
-    result.x          = LEFT;
-    result.w          = RIGHT - LEFT;
+    CBox result = target->layoutBox;
+    CONTROLLER->mergeSpanStripBoxes(result, FIRST, LAST);
 
     return result;
 }
 
-bool CScrollingAlgorithm::tryUpdateSpan(SP<SScrollingTargetData> target, int deltaLeft, int deltaRight) {
+bool CScrollingAlgorithm::tryUpdateSpan(SP<SScrollingTargetData> target, int deltaPrev, int deltaNext) {
     if (!target) {
         Log::logger->log(Log::TRACE, "tryUpdateSpan: no target");
         return false;
@@ -2945,42 +2919,37 @@ bool CScrollingAlgorithm::tryUpdateSpan(SP<SScrollingTargetData> target, int del
         return false;
     }
 
-    if (!columnSpansSupportedForPrimaryAxis(m_scrollingData->controller->isPrimaryHorizontal())) {
-        Log::logger->log(Log::TRACE, "tryUpdateSpan: not horizontal primary axis");
-        return false;
-    }
-
     const int64_t ANCHOR_IDX = m_scrollingData->idx(COLUMN);
     if (ANCHOR_IDX < 0) {
         Log::logger->log(Log::TRACE, "tryUpdateSpan: anchor idx < 0");
         return false;
     }
 
-    if (deltaLeft > 0 && ANCHOR_IDX - target->span.left <= 0) {
-        Log::logger->log(Log::TRACE, "tryUpdateSpan: at left boundary (anchor={}, span.left={}, deltaLeft={})", ANCHOR_IDX, target->span.left, deltaLeft);
+    if (deltaPrev > 0 && ANCHOR_IDX - target->span.prev <= 0) {
+        Log::logger->log(Log::TRACE, "tryUpdateSpan: at prev boundary (anchor={}, span.prev={}, deltaPrev={})", ANCHOR_IDX, target->span.prev, deltaPrev);
         return false;
     }
 
-    if (deltaRight > 0 && ANCHOR_IDX + target->span.right >= sc<int64_t>(m_scrollingData->columns.size()) - 1) {
-        Log::logger->log(Log::TRACE, "tryUpdateSpan: at right boundary (anchor={}, span.right={}, columns={})", ANCHOR_IDX, target->span.right, m_scrollingData->columns.size());
+    if (deltaNext > 0 && ANCHOR_IDX + target->span.next >= sc<int64_t>(m_scrollingData->columns.size()) - 1) {
+        Log::logger->log(Log::TRACE, "tryUpdateSpan: at next boundary (anchor={}, span.next={}, columns={})", ANCHOR_IDX, target->span.next, m_scrollingData->columns.size());
         return false;
     }
 
-    if (deltaLeft < 0 && target->span.left == 0) {
-        Log::logger->log(Log::TRACE, "tryUpdateSpan: cannot shrink left, already 0");
+    if (deltaPrev < 0 && target->span.prev == 0) {
+        Log::logger->log(Log::TRACE, "tryUpdateSpan: cannot shrink prev, already 0");
         return false;
     }
 
-    if (deltaRight < 0 && target->span.right == 0) {
-        Log::logger->log(Log::TRACE, "tryUpdateSpan: cannot shrink right, already 0");
+    if (deltaNext < 0 && target->span.next == 0) {
+        Log::logger->log(Log::TRACE, "tryUpdateSpan: cannot shrink next, already 0");
         return false;
     }
 
     const auto OLDSPAN = target->span;
-    target->span.left  = std::max(0, target->span.left + deltaLeft);
-    target->span.right = std::max(0, target->span.right + deltaRight);
+    target->span.prev  = std::max(0, target->span.prev + deltaPrev);
+    target->span.next = std::max(0, target->span.next + deltaNext);
 
-    Log::logger->log(Log::TRACE, "tryUpdateSpan: tentative span left={} right={}, validating...", target->span.left, target->span.right);
+    Log::logger->log(Log::TRACE, "tryUpdateSpan: tentative span prev={} next={}, validating...", target->span.prev, target->span.next);
 
     if (!validateCurrentSpans()) {
         Log::logger->log(Log::INFO, "tryUpdateSpan: validateCurrentSpans rejected");

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.hpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.hpp
@@ -157,6 +157,7 @@ namespace Layout::Tiled {
         } m_config;
 
         eScrollDirection getDynamicDirection();
+        eScrollDirection m_lastDynamicDirection = SCROLL_DIR_RIGHT;
 
         struct SFullscreenScrollState {
             WP<ITarget>          target;
@@ -186,7 +187,7 @@ namespace Layout::Tiled {
         void                      centerOrFitTargetData(SP<SScrollingTargetData> target);
         SP<SColumnData>           nextColumnForTargetData(SP<SScrollingTargetData> target);
         SP<SColumnData>           prevColumnForTargetData(SP<SScrollingTargetData> target);
-        bool                      tryUpdateSpan(SP<SScrollingTargetData> target, int deltaLeft, int deltaRight);
+        bool                      tryUpdateSpan(SP<SScrollingTargetData> target, int deltaPrev, int deltaNext);
         void                      clearSpan(SP<SScrollingTargetData> target);
         void                      clearAllSpans();
         void                      clearSpansCoveringColumn(SP<SColumnData> column);

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.hpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.hpp
@@ -3,6 +3,7 @@
 #include "../../TiledAlgorithm.hpp"
 #include "../../../../helpers/math/Direction.hpp"
 #include "ScrollTapeController.hpp"
+#include "ScrollingSpanLayout.hpp"
 #include "../../../../helpers/signal/Signal.hpp"
 
 #include <optional>
@@ -22,7 +23,14 @@ namespace Layout::Tiled {
         WP<SColumnData> column;
         bool            ignoreFullscreenChecks = false;
 
+        SSpanState      span;
         CBox            layoutBox;
+    };
+
+    struct SSpanAdjustedTargetBox {
+        CBox   box;
+        size_t virtualIndex = 0;
+        size_t virtualCount = 0;
     };
 
     struct SColumnData {
@@ -155,24 +163,49 @@ namespace Layout::Tiled {
             std::optional<float> restoreColumnWidth;
         };
 
-        void                                syncFullscreenTargets();
-        SFullscreenScrollState*             fullscreenStateForTarget(SP<ITarget> target, eFullscreenMode targetFullscreenMode);
-        SFullscreenScrollState*             fullscreenStateForData(SP<SScrollingTargetData> target, eFullscreenMode targetFullscreenMode);
-        SP<SScrollingTargetData>            fullscreenTargetDataForColumn(SP<SColumnData> col) const;
-        bool                                isFullscreenTarget(SP<SScrollingTargetData> target) const;
-        float                               fullscreenColumnWidth() const;
-        bool                                fullscreenColumnCoversMonitor(SP<SColumnData> col) const;
-        void                                updateFullscreenFade(bool coversMonitor);
-        void                                clearFullscreenTarget(std::vector<SFullscreenScrollState>& fullscreenTargetList, SP<ITarget> target = nullptr);
+        void                      syncFullscreenTargets();
+        SFullscreenScrollState*   fullscreenStateForTarget(SP<ITarget> target, eFullscreenMode targetFullscreenMode);
+        SFullscreenScrollState*   fullscreenStateForData(SP<SScrollingTargetData> target, eFullscreenMode targetFullscreenMode);
+        SP<SScrollingTargetData>  fullscreenTargetDataForColumn(SP<SColumnData> col) const;
+        bool                      isFullscreenTarget(SP<SScrollingTargetData> target) const;
+        float                     fullscreenColumnWidth() const;
+        bool                      fullscreenColumnCoversMonitor(SP<SColumnData> col) const;
+        void                      updateFullscreenFade(bool coversMonitor);
+        void                      clearFullscreenTarget(std::vector<SFullscreenScrollState>& fullscreenTargetList, SP<ITarget> target = nullptr);
 
-        SP<SScrollingTargetData>            findBestNeighbor(SP<SScrollingTargetData> pCurrent, SP<SColumnData> pTargetCol);
-        SP<SScrollingTargetData>            closestNode(const Vector2D& posGlobglobgabgalab);
+        SP<SScrollingTargetData>  findBestNeighbor(SP<SScrollingTargetData> pCurrent, SP<SColumnData> pTargetCol);
+        SP<SScrollingTargetData>  closestNode(const Vector2D& posGlobglobgabgalab);
 
-        void                                focusTargetUpdate(SP<ITarget> target);
+        void                      focusTargetUpdate(SP<ITarget> target);
+        std::optional<SSpanRange> spanRangeForTargetData(SP<SScrollingTargetData> target) const;
+        bool                      targetDataVisible(SP<SScrollingTargetData> target, bool full = false) const;
+        void                      centerSpanRange(const SSpanRange& range);
+        void                      fitSpanRange(const SSpanRange& range);
+        void                      centerTargetData(SP<SScrollingTargetData> target);
+        void                      fitTargetData(SP<SScrollingTargetData> target);
+        void                      centerOrFitTargetData(SP<SScrollingTargetData> target);
+        SP<SColumnData>           nextColumnForTargetData(SP<SScrollingTargetData> target);
+        SP<SColumnData>           prevColumnForTargetData(SP<SScrollingTargetData> target);
+        bool                      tryUpdateSpan(SP<SScrollingTargetData> target, int deltaLeft, int deltaRight);
+        void                      clearSpan(SP<SScrollingTargetData> target);
+        void                      clearAllSpans();
+        void                      clearSpansCoveringColumn(SP<SColumnData> column);
+        void                      adjustSpansAfterColumnInsert(size_t insertedColumn, size_t columnCountBefore, SP<SScrollingTargetData> ignoredTarget = nullptr);
+        void                      adjustSpansAfterColumnRemove(size_t removedColumn, size_t columnCountBefore, SP<SScrollingTargetData> ignoredTarget = nullptr);
+        void                      sanitizeCurrentSpans();
+        bool                      validateCurrentSpans() const;
+
+        struct SSpanResolvedLayout {
+            bool                                             valid = true;
+            std::vector<std::vector<SSpanAdjustedTargetBox>> boxes;
+        };
+        SSpanResolvedLayout                              resolveSpanLayout(const CBox& usable, const Vector2D& workspaceOffset) const;
+        std::vector<std::vector<SSpanAdjustedTargetBox>> spanAdjustedColumnBoxes(const CBox& usable, const Vector2D& workspaceOffset) const;
+        std::optional<CBox>                 spannedLayoutBox(SP<SScrollingTargetData> target, size_t anchorIdx, const CBox& usable, const Vector2D& workspaceOffset) const;
         void                                moveTargetTo(SP<ITarget> t, Math::eDirection dir, bool silent);
         void                                focusOnInput(SP<ITarget> target, eInputMode input);
 
-        void                                expelTarget(SP<SScrollingTargetData> tdata, SP<SColumnData> srcCol, std::optional<int64_t> insertIdx);
+        SP<SColumnData>                     expelTarget(SP<SScrollingTargetData> tdata, SP<SColumnData> srcCol, std::optional<int64_t> insertIdx);
 
         float                               defaultColumnWidth();
 

--- a/src/layout/algorithm/tiled/scrolling/ScrollingSpanLayout.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingSpanLayout.cpp
@@ -167,6 +167,13 @@ SColumnSpanValidationResult Layout::Tiled::validateColumnReservations(const SCol
             return {.valid = false, .error = "reservation bands overlap"};
     }
 
+    // The first reservation must cover the column origin. Without this
+    // check, a span shrink that vacates the top of a destination column
+    // leaves an uncovered gap that no real target fills (the column is
+    // no longer in affectedColumns so it was never validated at all).
+    if (!reservations.empty() && reservations[0].start > 0.0001F)
+        return {.valid = false, .error = "first reservation does not cover column origin"};
+
     // Walk reservations in vertical order. When a gap between two
     // reservations is too small for the real targets that should fit
     // there, overflow the excess targets to later gaps. Only fail

--- a/src/layout/algorithm/tiled/scrolling/ScrollingSpanLayout.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingSpanLayout.cpp
@@ -15,7 +15,7 @@ namespace {
 }
 
 bool SSpanState::active() const {
-    return left > 0 || right > 0;
+    return prev > 0 || next > 0;
 }
 
 bool SSpanRange::contains(size_t column) const {
@@ -26,8 +26,8 @@ std::optional<SSpanRange> Layout::Tiled::spanRangeFor(size_t anchorColumn, const
     if (columnCount == 0 || anchorColumn >= columnCount)
         return std::nullopt;
 
-    const size_t left     = sc<size_t>(std::max(span.left, 0));
-    const size_t right    = sc<size_t>(std::max(span.right, 0));
+    const size_t left     = sc<size_t>(std::max(span.prev, 0));
+    const size_t right    = sc<size_t>(std::max(span.next, 0));
     const size_t maxRight = columnCount - 1 - anchorColumn;
 
     return SSpanRange{
@@ -51,7 +51,7 @@ std::optional<SSpanState> Layout::Tiled::spanAfterColumnInsert(size_t anchorColu
     if (newFirst > newAnchor || newLast < newAnchor)
         return std::nullopt;
 
-    return SSpanState{.left = sc<int>(newAnchor - newFirst), .right = sc<int>(newLast - newAnchor)};
+    return SSpanState{.prev = sc<int>(newAnchor - newFirst), .next = sc<int>(newLast - newAnchor)};
 }
 
 size_t Layout::Tiled::columnInsertAfterFocusedSpan(size_t anchorColumn, const SSpanState& span, size_t columnCount) {
@@ -77,11 +77,7 @@ std::optional<SSpanState> Layout::Tiled::spanAfterColumnRemove(size_t anchorColu
     if (newFirst > newAnchor || newLast < newAnchor)
         return std::nullopt;
 
-    return SSpanState{.left = sc<int>(newAnchor - newFirst), .right = sc<int>(newLast - newAnchor)};
-}
-
-bool Layout::Tiled::columnSpansSupportedForPrimaryAxis(bool primaryHorizontal) {
-    return primaryHorizontal;
+    return SSpanState{.prev = sc<int>(newAnchor - newFirst), .next = sc<int>(newLast - newAnchor)};
 }
 
 size_t Layout::Tiled::virtualSlotFor(size_t sourceIndex, size_t sourceCount, size_t destinationRealCount) {

--- a/src/layout/algorithm/tiled/scrolling/ScrollingSpanLayout.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingSpanLayout.cpp
@@ -172,21 +172,30 @@ SColumnSpanValidationResult Layout::Tiled::validateColumnReservations(const SCol
             return {.valid = false, .error = "reservation bands overlap"};
     }
 
-    size_t previousSlot = 0;
-    float  previousEnd  = 0.F;
+    // Walk reservations in vertical order. When a gap between two
+    // reservations is too small for the real targets that should fit
+    // there, overflow the excess targets to later gaps. Only fail
+    // when the final gap cannot accommodate everything.
+    size_t previousSlot    = 0;
+    float  previousEnd     = 0.F;
+    size_t overflowTargets = 0;
 
     for (const auto& reservation : reservations) {
-        const size_t realTargetsInGap = reservation.slot - previousSlot;
-        const float  gapSize          = reservation.start - previousEnd;
+        const size_t targetsToPlace = reservation.slot - previousSlot + overflowTargets;
+        const float  gapSize        = reservation.start - previousEnd;
+        const size_t fitCount       = sc<size_t>(std::floor((std::max(gapSize, 0.F) + 0.0001F) / minRowHeight));
 
-        if (gapSize < sc<float>(realTargetsInGap) * minRowHeight)
-            return {.valid = false, .error = "not enough space for real targets around reservations"};
+        if (fitCount >= targetsToPlace) {
+            overflowTargets = 0;
+        } else {
+            overflowTargets = targetsToPlace - fitCount;
+        }
 
         previousSlot = reservation.slot;
         previousEnd  = reservation.start + reservation.size;
     }
 
-    const size_t realTargetsInLastGap = column.realTargetCount - previousSlot;
+    const size_t realTargetsInLastGap = column.realTargetCount - previousSlot + overflowTargets;
     const float  lastGapSize          = 1.F - previousEnd;
 
     if (lastGapSize < sc<float>(realTargetsInLastGap) * minRowHeight)
@@ -213,7 +222,7 @@ SColumnSpanLayoutResult Layout::Tiled::layoutColumnWithReservations(const SColum
 
     SColumnSpanLayoutResult result{.validation = {}};
 
-    size_t                  previousSlot = 0;
+    size_t                  adjustedSlot = 0;
     float                   previousEnd  = 0.F;
     size_t                  virtualIndex = 0;
     const size_t            virtualCount = column.realTargetCount + reservations.size();
@@ -247,14 +256,26 @@ SColumnSpanLayoutResult Layout::Tiled::layoutColumnWithReservations(const SColum
         }
     };
 
-    for (const auto& reservation : reservations) {
-        placeGap(previousSlot, reservation.slot, previousEnd, reservation.start);
-        previousSlot = reservation.slot;
-        previousEnd  = reservation.start + reservation.size;
-        ++virtualIndex;
+    for (size_t i = 0; i < reservations.size(); ++i) {
+        const auto& reservation = reservations[i];
+
+        // Adjust the slot so that the gap places only as many real
+        // targets as can physically fit. Targets that cannot fit
+        // overflow to later gaps.
+        const size_t expectedInGap = reservation.slot - adjustedSlot;
+        const float  gapSize       = std::max(reservation.start - previousEnd, 0.F);
+        const size_t fitCount      = sc<size_t>(std::floor((gapSize + 0.0001F) / minRowHeight));
+        const size_t placed        = std::min(expectedInGap, fitCount);
+
+        placeGap(adjustedSlot, adjustedSlot + placed, previousEnd, reservation.start);
+        adjustedSlot += placed;
+        virtualIndex += (expectedInGap - placed); // overflow targets defer their virtual index
+        previousEnd = reservation.start + reservation.size;
+        ++virtualIndex; // reservation itself
     }
 
-    placeGap(previousSlot, column.realTargetCount, previousEnd, 1.F);
+    // Final gap: place all remaining real targets.
+    placeGap(adjustedSlot, column.realTargetCount, previousEnd, 1.F);
 
     return result;
 }

--- a/src/layout/algorithm/tiled/scrolling/ScrollingSpanLayout.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingSpanLayout.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <functional>
 
 using namespace Layout::Tiled;
 
@@ -119,21 +118,21 @@ bool Layout::Tiled::hasSpanDependencyCycle(const std::vector<std::vector<SSpanSt
     }
 
     // DFS with three-color marking to detect cycles.
-    enum Color : uint8_t {
+    enum eColor : uint8_t {
         WHITE,
         GRAY,
         BLACK
     };
-    std::vector<Color>          color(columnCount, WHITE);
+    std::vector<eColor> color(columnCount, WHITE);
 
-    std::function<bool(size_t)> dfs = [&](size_t node) -> bool {
+    auto                dfs = [&](this auto&& self, size_t node) -> bool {
         color[node] = GRAY;
         for (size_t neighbor : adjacency[node]) {
             if (neighbor >= columnCount)
                 continue;
             if (color[neighbor] == GRAY)
                 return true; // back edge
-            if (color[neighbor] == WHITE && dfs(neighbor))
+            if (color[neighbor] == WHITE && self(neighbor))
                 return true;
         }
         color[node] = BLACK;
@@ -198,7 +197,7 @@ SColumnSpanValidationResult Layout::Tiled::validateColumnReservations(const SCol
     const size_t realTargetsInLastGap = column.realTargetCount - previousSlot + overflowTargets;
     const float  lastGapSize          = 1.F - previousEnd;
 
-    if (lastGapSize < sc<float>(realTargetsInLastGap) * minRowHeight)
+    if (lastGapSize + 0.0001F < sc<float>(realTargetsInLastGap) * minRowHeight)
         return {.valid = false, .error = "not enough space for real targets around reservations"};
 
     return {};

--- a/src/layout/algorithm/tiled/scrolling/ScrollingSpanLayout.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingSpanLayout.cpp
@@ -1,0 +1,260 @@
+#include "ScrollingSpanLayout.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <functional>
+
+using namespace Layout::Tiled;
+
+namespace {
+    bool reservationSlotOrder(const SSpanReservation& lhs, const SSpanReservation& rhs) {
+        if (lhs.slot != rhs.slot)
+            return lhs.slot < rhs.slot;
+
+        return lhs.start < rhs.start;
+    }
+}
+
+bool SSpanState::active() const {
+    return left > 0 || right > 0;
+}
+
+bool SSpanRange::contains(size_t column) const {
+    return column >= first && column <= last;
+}
+
+std::optional<SSpanRange> Layout::Tiled::spanRangeFor(size_t anchorColumn, const SSpanState& span, size_t columnCount) {
+    if (columnCount == 0 || anchorColumn >= columnCount)
+        return std::nullopt;
+
+    const size_t left     = sc<size_t>(std::max(span.left, 0));
+    const size_t right    = sc<size_t>(std::max(span.right, 0));
+    const size_t maxRight = columnCount - 1 - anchorColumn;
+
+    return SSpanRange{
+        .first = anchorColumn > left ? anchorColumn - left : 0,
+        .last  = anchorColumn + std::min(right, maxRight),
+    };
+}
+
+std::optional<SSpanState> Layout::Tiled::spanAfterColumnInsert(size_t anchorColumn, const SSpanState& span, size_t insertedColumn, size_t columnCountBefore) {
+    if (insertedColumn > columnCountBefore)
+        return std::nullopt;
+
+    const auto RANGE = spanRangeFor(anchorColumn, span, columnCountBefore);
+    if (!RANGE)
+        return std::nullopt;
+
+    const size_t newAnchor = anchorColumn + (insertedColumn <= anchorColumn ? 1 : 0);
+    const size_t newFirst  = RANGE->first + (insertedColumn <= RANGE->first ? 1 : 0);
+    const size_t newLast   = RANGE->last + (insertedColumn <= RANGE->last ? 1 : 0);
+
+    if (newFirst > newAnchor || newLast < newAnchor)
+        return std::nullopt;
+
+    return SSpanState{.left = sc<int>(newAnchor - newFirst), .right = sc<int>(newLast - newAnchor)};
+}
+
+size_t Layout::Tiled::columnInsertAfterFocusedSpan(size_t anchorColumn, const SSpanState& span, size_t columnCount) {
+    const auto RANGE = spanRangeFor(anchorColumn, span, columnCount);
+    if (!RANGE)
+        return columnCount;
+
+    return std::min(RANGE->last + 1, columnCount);
+}
+
+std::optional<SSpanState> Layout::Tiled::spanAfterColumnRemove(size_t anchorColumn, const SSpanState& span, size_t removedColumn, size_t columnCountBefore) {
+    if (removedColumn >= columnCountBefore || removedColumn == anchorColumn)
+        return std::nullopt;
+
+    const auto RANGE = spanRangeFor(anchorColumn, span, columnCountBefore);
+    if (!RANGE)
+        return std::nullopt;
+
+    const size_t newAnchor = anchorColumn - (removedColumn < anchorColumn ? 1 : 0);
+    const size_t newFirst  = RANGE->first - (removedColumn < RANGE->first ? 1 : 0);
+    const size_t newLast   = RANGE->last - (removedColumn <= RANGE->last ? 1 : 0);
+
+    if (newFirst > newAnchor || newLast < newAnchor)
+        return std::nullopt;
+
+    return SSpanState{.left = sc<int>(newAnchor - newFirst), .right = sc<int>(newLast - newAnchor)};
+}
+
+bool Layout::Tiled::columnSpansSupportedForPrimaryAxis(bool primaryHorizontal) {
+    return primaryHorizontal;
+}
+
+size_t Layout::Tiled::virtualSlotFor(size_t sourceIndex, size_t sourceCount, size_t destinationRealCount) {
+    if (sourceCount <= 1)
+        return destinationRealCount;
+
+    const size_t sourceLast  = sourceCount - 1;
+    const size_t numerator   = sourceIndex * destinationRealCount;
+    const size_t denominator = sourceLast;
+    const size_t mapped      = (2 * numerator + denominator - 1) / (2 * denominator);
+
+    return std::min(mapped, destinationRealCount);
+}
+
+bool Layout::Tiled::hasSpanDependencyCycle(const std::vector<std::vector<SSpanState>>& columnSpans, size_t columnCount) {
+    // Build adjacency list: anchor → destination columns.
+    std::vector<std::vector<size_t>> adjacency;
+    adjacency.resize(columnCount);
+
+    for (size_t anchorIdx = 0; anchorIdx < columnCount && anchorIdx < columnSpans.size(); ++anchorIdx) {
+        for (const auto& span : columnSpans[anchorIdx]) {
+            if (!span.active())
+                continue;
+
+            const auto RANGE = spanRangeFor(anchorIdx, span, columnCount);
+            if (!RANGE)
+                continue;
+
+            for (size_t destIdx = RANGE->first; destIdx <= RANGE->last; ++destIdx) {
+                if (destIdx != anchorIdx)
+                    adjacency[anchorIdx].push_back(destIdx);
+            }
+        }
+    }
+
+    // DFS with three-color marking to detect cycles.
+    enum Color : uint8_t {
+        WHITE,
+        GRAY,
+        BLACK
+    };
+    std::vector<Color>          color(columnCount, WHITE);
+
+    std::function<bool(size_t)> dfs = [&](size_t node) -> bool {
+        color[node] = GRAY;
+        for (size_t neighbor : adjacency[node]) {
+            if (neighbor >= columnCount)
+                continue;
+            if (color[neighbor] == GRAY)
+                return true; // back edge
+            if (color[neighbor] == WHITE && dfs(neighbor))
+                return true;
+        }
+        color[node] = BLACK;
+        return false;
+    };
+
+    for (size_t i = 0; i < columnCount; ++i) {
+        if (color[i] == WHITE && dfs(i))
+            return true;
+    }
+
+    return false;
+}
+
+SColumnSpanValidationResult Layout::Tiled::validateColumnReservations(const SColumnSpanValidation& column, float minRowHeight) {
+    auto reservations = column.reservations;
+
+    for (const auto& reservation : reservations) {
+        if (reservation.slot > column.realTargetCount)
+            return {.valid = false, .error = "reservation slot out of range"};
+
+        if (reservation.start < 0.F || reservation.size <= 0.F || reservation.start + reservation.size > 1.F)
+            return {.valid = false, .error = "reservation band out of range"};
+    }
+
+    std::ranges::sort(reservations, reservationSlotOrder);
+
+    for (size_t i = 1; i < reservations.size(); ++i) {
+        if (reservations[i - 1].start > reservations[i].start)
+            return {.valid = false, .error = "reservation slot order conflicts with band order"};
+    }
+
+    std::ranges::sort(reservations, {}, &SSpanReservation::start);
+    for (size_t i = 1; i < reservations.size(); ++i) {
+        if (reservations[i - 1].start + reservations[i - 1].size > reservations[i].start)
+            return {.valid = false, .error = "reservation bands overlap"};
+    }
+
+    size_t previousSlot = 0;
+    float  previousEnd  = 0.F;
+
+    for (const auto& reservation : reservations) {
+        const size_t realTargetsInGap = reservation.slot - previousSlot;
+        const float  gapSize          = reservation.start - previousEnd;
+
+        if (gapSize < sc<float>(realTargetsInGap) * minRowHeight)
+            return {.valid = false, .error = "not enough space for real targets around reservations"};
+
+        previousSlot = reservation.slot;
+        previousEnd  = reservation.start + reservation.size;
+    }
+
+    const size_t realTargetsInLastGap = column.realTargetCount - previousSlot;
+    const float  lastGapSize          = 1.F - previousEnd;
+
+    if (lastGapSize < sc<float>(realTargetsInLastGap) * minRowHeight)
+        return {.valid = false, .error = "not enough space for real targets around reservations"};
+
+    return {};
+}
+
+bool SColumnSpanLayoutResult::valid() const {
+    return validation.valid;
+}
+
+SColumnSpanLayoutResult Layout::Tiled::layoutColumnWithReservations(const SColumnSpanValidation& column, const std::vector<float>& realTargetSizes, float minRowHeight) {
+    auto validation = validateColumnReservations(column, minRowHeight);
+    if (!validation.valid)
+        return {.validation = std::move(validation)};
+
+    std::vector<float> sizes = realTargetSizes;
+    if (sizes.size() < column.realTargetCount)
+        sizes.resize(column.realTargetCount, 1.F);
+
+    auto reservations = column.reservations;
+    std::ranges::sort(reservations, reservationSlotOrder);
+
+    SColumnSpanLayoutResult result{.validation = {}};
+
+    size_t                  previousSlot = 0;
+    float                   previousEnd  = 0.F;
+    size_t                  virtualIndex = 0;
+    const size_t            virtualCount = column.realTargetCount + reservations.size();
+
+    // Intermediate calculations use double to avoid cumulative
+    // floating-point drift in the cursor across many targets.
+    // Final values are stored as float (range [0, 1]).
+    auto placeGap = [&](size_t begin, size_t end, float gapStart, float gapEnd) {
+        if (begin >= end)
+            return;
+
+        const double gapSize    = sc<double>(gapEnd) - sc<double>(gapStart);
+        const size_t gapTargets = end - begin;
+        const double reserved   = sc<double>(gapTargets) * sc<double>(minRowHeight);
+        const double extra      = std::max(gapSize - reserved, 0.0);
+        double       total      = 0.0;
+        for (size_t i = begin; i < end; ++i)
+            total += std::max(sc<double>(sizes[i]), sc<double>(minRowHeight));
+
+        double cursor = sc<double>(gapStart);
+        for (size_t i = begin; i < end; ++i) {
+            const double fraction          = total > 0.0 ? std::max(sc<double>(sizes[i]), sc<double>(minRowHeight)) / total : 1.0 / sc<double>(end - begin);
+            const double remainingMinSpace = sc<double>(end - i - 1) * sc<double>(minRowHeight);
+            const double size              = i + 1 == end ?
+                             std::max(sc<double>(gapEnd) - cursor, sc<double>(minRowHeight)) :
+                             std::max(std::min(sc<double>(minRowHeight) + extra * fraction, sc<double>(gapEnd) - cursor - remainingMinSpace), sc<double>(minRowHeight));
+            result.realTargets.emplace_back(
+                SRealTargetLayout{.index = i, .start = sc<float>(cursor), .size = sc<float>(size), .virtualIndex = virtualIndex, .virtualCount = virtualCount});
+            cursor += size;
+            ++virtualIndex;
+        }
+    };
+
+    for (const auto& reservation : reservations) {
+        placeGap(previousSlot, reservation.slot, previousEnd, reservation.start);
+        previousSlot = reservation.slot;
+        previousEnd  = reservation.start + reservation.size;
+        ++virtualIndex;
+    }
+
+    placeGap(previousSlot, column.realTargetCount, previousEnd, 1.F);
+
+    return result;
+}

--- a/src/layout/algorithm/tiled/scrolling/ScrollingSpanLayout.hpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingSpanLayout.hpp
@@ -8,8 +8,8 @@
 
 namespace Layout::Tiled {
     struct SSpanState {
-        int  left  = 0;
-        int  right = 0;
+        int  prev = 0;
+        int  next = 0;
 
         bool active() const;
     };
@@ -25,6 +25,11 @@ namespace Layout::Tiled {
         size_t slot  = 0;
         float  start = 0.F;
         float  size  = 0.F;
+    };
+
+    struct SSpanReservationParams {
+        float start = 0.F; // normalized [0, 1]
+        float size  = 0.F; // normalized [0, 1]
     };
 
     struct SColumnSpanValidation {
@@ -56,7 +61,6 @@ namespace Layout::Tiled {
     std::optional<SSpanState> spanAfterColumnInsert(size_t anchorColumn, const SSpanState& span, size_t insertedColumn, size_t columnCountBefore);
     size_t                    columnInsertAfterFocusedSpan(size_t anchorColumn, const SSpanState& span, size_t columnCount);
     std::optional<SSpanState> spanAfterColumnRemove(size_t anchorColumn, const SSpanState& span, size_t removedColumn, size_t columnCountBefore);
-    bool                      columnSpansSupportedForPrimaryAxis(bool primaryHorizontal);
     /**
      * Map a source target's vertical position (sourceIndex of sourceCount)
      * into a virtual slot index in a destination column with destinationRealCount

--- a/src/layout/algorithm/tiled/scrolling/ScrollingSpanLayout.hpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingSpanLayout.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include "../../../../macros.hpp"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace Layout::Tiled {
+    struct SSpanState {
+        int  left  = 0;
+        int  right = 0;
+
+        bool active() const;
+    };
+
+    struct SSpanRange {
+        size_t first = 0;
+        size_t last  = 0;
+
+        bool   contains(size_t column) const;
+    };
+
+    struct SSpanReservation {
+        size_t slot  = 0;
+        float  start = 0.F;
+        float  size  = 0.F;
+    };
+
+    struct SColumnSpanValidation {
+        size_t                        realTargetCount = 0;
+        std::vector<SSpanReservation> reservations;
+    };
+
+    struct SColumnSpanValidationResult {
+        bool        valid = true;
+        std::string error;
+    };
+
+    struct SRealTargetLayout {
+        size_t index        = 0;
+        float  start        = 0.F;
+        float  size         = 0.F;
+        size_t virtualIndex = 0;
+        size_t virtualCount = 0;
+    };
+
+    struct SColumnSpanLayoutResult {
+        SColumnSpanValidationResult    validation;
+        std::vector<SRealTargetLayout> realTargets;
+
+        bool                           valid() const;
+    };
+
+    std::optional<SSpanRange> spanRangeFor(size_t anchorColumn, const SSpanState& span, size_t columnCount);
+    std::optional<SSpanState> spanAfterColumnInsert(size_t anchorColumn, const SSpanState& span, size_t insertedColumn, size_t columnCountBefore);
+    size_t                    columnInsertAfterFocusedSpan(size_t anchorColumn, const SSpanState& span, size_t columnCount);
+    std::optional<SSpanState> spanAfterColumnRemove(size_t anchorColumn, const SSpanState& span, size_t removedColumn, size_t columnCountBefore);
+    bool                      columnSpansSupportedForPrimaryAxis(bool primaryHorizontal);
+    /**
+     * Map a source target's vertical position (sourceIndex of sourceCount)
+     * into a virtual slot index in a destination column with destinationRealCount
+     * real targets.
+     *
+     * Rules:
+     * - First source target (index 0) maps to slot 0 (top).
+     * - Last source target (index sourceCount-1) maps to slot destinationRealCount
+     *   (bottom, after all real targets).
+     * - Middle positions map proportionally with half-up rounding.
+     * - Single or empty source returns destinationRealCount (bottom).
+     *
+     * The returned slot is in [0, destinationRealCount]. A slot of
+     * destinationRealCount means the reservation sits below all real targets.
+     */
+    size_t                      virtualSlotFor(size_t sourceIndex, size_t sourceCount, size_t destinationRealCount);
+    bool                        hasSpanDependencyCycle(const std::vector<std::vector<SSpanState>>& columnSpans, size_t columnCount);
+    SColumnSpanValidationResult validateColumnReservations(const SColumnSpanValidation& column, float minRowHeight);
+    SColumnSpanLayoutResult     layoutColumnWithReservations(const SColumnSpanValidation& column, const std::vector<float>& realTargetSizes, float minRowHeight);
+};

--- a/tests/layout/scrolling/ScrollingSpanLayout.cpp
+++ b/tests/layout/scrolling/ScrollingSpanLayout.cpp
@@ -1,3 +1,4 @@
+#include <layout/algorithm/tiled/scrolling/ScrollTapeController.hpp>
 #include <layout/algorithm/tiled/scrolling/ScrollingSpanLayout.hpp>
 
 #include <gtest/gtest.h>
@@ -6,8 +7,83 @@
 
 using namespace Layout::Tiled;
 
+TEST(ScrollingSpanLayout, extractSpanReservationUsesVerticalSecondaryInHorizontalMode) {
+    // In horizontal mode (primary=X, secondary=Y): reservation is (y, h) / usable.h
+    CScrollTapeController controller(SCROLL_DIR_RIGHT);
+    const CBox            anchorBox       = {0, 200, 800, 400};
+    const CBox            usable          = {0, 0, 1920, 1080};
+    const Vector2D        workspaceOffset = {0, 0};
+
+    const auto            params = controller.extractSpanReservation(anchorBox, usable, workspaceOffset);
+    EXPECT_NEAR(params.start, 200.0F / 1080.0F, 0.0001F);
+    EXPECT_NEAR(params.size, 400.0F / 1080.0F, 0.0001F);
+}
+
+TEST(ScrollingSpanLayout, extractSpanReservationUsesHorizontalSecondaryInVerticalMode) {
+    // In vertical mode (primary=Y, secondary=X): reservation is (x, w) / usable.w
+    CScrollTapeController controller(SCROLL_DIR_DOWN);
+    const CBox            anchorBox       = {200, 0, 400, 800};
+    const CBox            usable          = {0, 0, 1920, 1080};
+    const Vector2D        workspaceOffset = {0, 0};
+
+    const auto            params = controller.extractSpanReservation(anchorBox, usable, workspaceOffset);
+    EXPECT_NEAR(params.start, 200.0F / 1920.0F, 0.0001F);
+    EXPECT_NEAR(params.size, 400.0F / 1920.0F, 0.0001F);
+}
+
+TEST(ScrollingSpanLayout, extractSpanReservationHandlesWorkspaceOffset) {
+    CScrollTapeController controller(SCROLL_DIR_RIGHT);
+    const CBox            anchorBox       = {0, 300, 800, 400};
+    const CBox            usable          = {0, 100, 1920, 980};
+    const Vector2D        workspaceOffset = {0, 100};
+
+    const auto            params = controller.extractSpanReservation(anchorBox, usable, workspaceOffset);
+    EXPECT_NEAR(params.start, 200.0F / 980.0F, 0.0001F);  // (300 - 100) / 980
+    EXPECT_NEAR(params.size, 400.0F / 980.0F, 0.0001F);
+}
+
+TEST(ScrollingSpanLayout, mergeSpanStripBoxesMergesHorizontalInPrimaryHorizontalMode) {
+    CScrollTapeController controller(SCROLL_DIR_RIGHT);
+    CBox                  result = {10, 100, 200, 300};  // secondary axis: y=100, h=300
+    const CBox            first  = {0, 0, 640, 1080};
+    const CBox            last   = {1280, 0, 640, 1080};
+
+    controller.mergeSpanStripBoxes(result, first, last);
+    EXPECT_NEAR(result.x, 0.0, 0.01);
+    EXPECT_NEAR(result.w, 1920.0, 0.01);
+    // secondary axis must be untouched
+    EXPECT_NEAR(result.y, 100.0, 0.01);
+    EXPECT_NEAR(result.h, 300.0, 0.01);
+}
+
+TEST(ScrollingSpanLayout, mergeSpanStripBoxesMergesVerticalInPrimaryVerticalMode) {
+    CScrollTapeController controller(SCROLL_DIR_DOWN);
+    CBox                  result = {100, 10, 300, 200};  // secondary axis: x=100, w=300
+    const CBox            first  = {0, 0, 1920, 540};
+    const CBox            last   = {0, 540, 1920, 540};
+
+    controller.mergeSpanStripBoxes(result, first, last);
+    EXPECT_NEAR(result.y, 0.0, 0.01);
+    EXPECT_NEAR(result.h, 1080.0, 0.01);
+    // secondary axis must be untouched
+    EXPECT_NEAR(result.x, 100.0, 0.01);
+    EXPECT_NEAR(result.w, 300.0, 0.01);
+}
+
+TEST(ScrollingSpanLayout, mergeSpanStripBoxesHandlesReversedOrder) {
+    // first/last might be in any spatial order (reversed scrolling)
+    CScrollTapeController controller(SCROLL_DIR_RIGHT);
+    CBox                  result = {0, 50, 100, 150};
+    const CBox            first  = {1280, 0, 640, 1080};
+    const CBox            last   = {0, 0, 640, 1080};
+
+    controller.mergeSpanStripBoxes(result, first, last);
+    EXPECT_NEAR(result.x, 0.0, 0.01);
+    EXPECT_NEAR(result.w, 1920.0, 0.01);
+}
+
 TEST(ScrollingSpanLayout, spanRangeClampsToExistingColumns) {
-    const auto range = spanRangeFor(2, SSpanState{.left = 4, .right = 3}, 5);
+    const auto range = spanRangeFor(2, SSpanState{.prev = 4, .next = 3}, 5);
 
     ASSERT_TRUE(range.has_value());
     EXPECT_EQ(range->first, 0);
@@ -19,13 +95,13 @@ TEST(ScrollingSpanLayout, spanRangeClampsToExistingColumns) {
 }
 
 TEST(ScrollingSpanLayout, spanRangeRejectsInvalidAnchor) {
-    EXPECT_FALSE(spanRangeFor(3, SSpanState{.left = 1, .right = 1}, 3).has_value());
-    EXPECT_FALSE(spanRangeFor(0, SSpanState{.left = 0, .right = 0}, 0).has_value());
+    EXPECT_FALSE(spanRangeFor(3, SSpanState{.prev = 1, .next = 1}, 3).has_value());
+    EXPECT_FALSE(spanRangeFor(0, SSpanState{.prev = 0, .next = 0}, 0).has_value());
 }
 
 TEST(ScrollingSpanLayout, spanRangeClampsRightWithoutOverflow) {
     const size_t anchorColumn = std::numeric_limits<size_t>::max() - 2;
-    const auto   range        = spanRangeFor(anchorColumn, SSpanState{.left = 0, .right = 5}, anchorColumn + 2);
+    const auto   range        = spanRangeFor(anchorColumn, SSpanState{.prev = 0, .next = 5}, anchorColumn + 2);
 
     ASSERT_TRUE(range.has_value());
     EXPECT_EQ(range->first, anchorColumn);
@@ -34,16 +110,11 @@ TEST(ScrollingSpanLayout, spanRangeClampsRightWithoutOverflow) {
 }
 
 TEST(ScrollingSpanLayout, spanRangeTreatsNegativeSpanAsZero) {
-    const auto range = spanRangeFor(2, SSpanState{.left = -1, .right = -2}, 5);
+    const auto range = spanRangeFor(2, SSpanState{.prev = -1, .next = -2}, 5);
 
     ASSERT_TRUE(range.has_value());
     EXPECT_EQ(range->first, 2);
     EXPECT_EQ(range->last, 2);
-}
-
-TEST(ScrollingSpanLayout, columnSpansAreHorizontalOnly) {
-    EXPECT_TRUE(columnSpansSupportedForPrimaryAxis(true));
-    EXPECT_FALSE(columnSpansSupportedForPrimaryAxis(false));
 }
 
 TEST(ScrollingSpanLayout, virtualSlotPreservesTopMiddleAndBottomOrder) {
@@ -70,8 +141,8 @@ TEST(ScrollingSpanLayout, spanDependencyCycleDetectsMutualSpanning) {
     // Column 0 spans right into column 1.
     // Column 1 spans left into column 0. This is a cycle.
     const std::vector<std::vector<SSpanState>> spans = {
-        {SSpanState{.right = 1}}, // col 0 → col 1
-        {SSpanState{.left = 1}},  // col 1 → col 0
+        {SSpanState{.next = 1}}, // col 0 → col 1
+        {SSpanState{.prev = 1}},  // col 1 → col 0
         {},
     };
 
@@ -82,8 +153,8 @@ TEST(ScrollingSpanLayout, spanDependencyCycleAllowsLinearChain) {
     // Column 0 → column 1 → column 2. No cycle.
     // Column 1 IS covered by column 0 but this is not a cycle.
     const std::vector<std::vector<SSpanState>> spans = {
-        {SSpanState{.right = 2}}, // col 0 → col 1, col 2
-        {SSpanState{.right = 1}}, // col 1 → col 2
+        {SSpanState{.next = 2}}, // col 0 → col 1, col 2
+        {SSpanState{.next = 1}}, // col 1 → col 2
         {},
     };
 
@@ -94,9 +165,9 @@ TEST(ScrollingSpanLayout, spanDependencyCycleAllowsUnaffectedActiveAnchor) {
     // Column 0 spans right into column 1. Column 2 has an inactive span.
     // No column is both anchor and covered → no cycle.
     const std::vector<std::vector<SSpanState>> spans = {
-        {SSpanState{.right = 1}},
+        {SSpanState{.next = 1}},
         {},
-        {SSpanState{.left = 0, .right = 0}},
+        {SSpanState{.prev = 0, .next = 0}},
     };
 
     EXPECT_FALSE(hasSpanDependencyCycle(spans, 3));
@@ -284,67 +355,67 @@ TEST(ScrollingSpanLayout, columnLayoutKeepsUnevenTargetsAtLeastMinimumHeight) {
 }
 
 TEST(ScrollingSpanLayout, spanAfterColumnInsertGrowsRightSpanInsideRange) {
-    const auto span = spanAfterColumnInsert(1, SSpanState{.right = 1}, 2, 3);
+    const auto span = spanAfterColumnInsert(1, SSpanState{.next = 1}, 2, 3);
 
     ASSERT_TRUE(span.has_value());
-    EXPECT_EQ(span->left, 0);
-    EXPECT_EQ(span->right, 2);
+    EXPECT_EQ(span->prev, 0);
+    EXPECT_EQ(span->next, 2);
 }
 
 TEST(ScrollingSpanLayout, spanAfterColumnInsertGrowsLeftSpanInsideRange) {
-    const auto span = spanAfterColumnInsert(1, SSpanState{.left = 1}, 1, 3);
+    const auto span = spanAfterColumnInsert(1, SSpanState{.prev = 1}, 1, 3);
 
     ASSERT_TRUE(span.has_value());
-    EXPECT_EQ(span->left, 2);
-    EXPECT_EQ(span->right, 0);
+    EXPECT_EQ(span->prev, 2);
+    EXPECT_EQ(span->next, 0);
 }
 
 TEST(ScrollingSpanLayout, spanAfterColumnInsertLeavesSpanOutsideRangeUnchanged) {
-    const auto span = spanAfterColumnInsert(1, SSpanState{.right = 1}, 3, 3);
+    const auto span = spanAfterColumnInsert(1, SSpanState{.next = 1}, 3, 3);
 
     ASSERT_TRUE(span.has_value());
-    EXPECT_EQ(span->left, 0);
-    EXPECT_EQ(span->right, 1);
+    EXPECT_EQ(span->prev, 0);
+    EXPECT_EQ(span->next, 1);
 }
 
 TEST(ScrollingSpanLayout, columnInsertAfterFocusedSpanUsesRightEdgeOfSpan) {
-    EXPECT_EQ(columnInsertAfterFocusedSpan(1, SSpanState{.right = 1}, 3), 3);
+    EXPECT_EQ(columnInsertAfterFocusedSpan(1, SSpanState{.next = 1}, 3), 3);
 }
 
 TEST(ScrollingSpanLayout, columnInsertAfterFocusedSpanClampsAtColumnCount) {
-    EXPECT_EQ(columnInsertAfterFocusedSpan(1, SSpanState{.right = 3}, 3), 3);
+    EXPECT_EQ(columnInsertAfterFocusedSpan(1, SSpanState{.next = 3}, 3), 3);
 }
 
 TEST(ScrollingSpanLayout, columnInsertAfterFocusedSpanUsesAnchorForLeftOnlySpan) {
-    EXPECT_EQ(columnInsertAfterFocusedSpan(2, SSpanState{.left = 2}, 4), 3);
+    EXPECT_EQ(columnInsertAfterFocusedSpan(2, SSpanState{.prev = 2}, 4), 3);
 }
 
 TEST(ScrollingSpanLayout, spanAfterColumnRemoveShrinksRightSpanInsideRange) {
-    const auto span = spanAfterColumnRemove(1, SSpanState{.right = 3}, 2, 5);
+    const auto span = spanAfterColumnRemove(1, SSpanState{.next = 3}, 2, 5);
 
     ASSERT_TRUE(span.has_value());
-    EXPECT_EQ(span->left, 0);
-    EXPECT_EQ(span->right, 2);
+    EXPECT_EQ(span->prev, 0);
+    EXPECT_EQ(span->next, 2);
 }
 
 TEST(ScrollingSpanLayout, spanAfterColumnRemoveShrinksLeftSpanInsideRange) {
-    const auto span = spanAfterColumnRemove(3, SSpanState{.left = 3}, 2, 5);
+    const auto span = spanAfterColumnRemove(3, SSpanState{.prev = 3}, 2, 5);
 
     ASSERT_TRUE(span.has_value());
-    EXPECT_EQ(span->left, 2);
-    EXPECT_EQ(span->right, 0);
+    EXPECT_EQ(span->prev, 2);
+    EXPECT_EQ(span->next, 0);
 }
 
 TEST(ScrollingSpanLayout, spanAfterColumnRemoveShiftsSpanOutsideRange) {
-    const auto span = spanAfterColumnRemove(3, SSpanState{.right = 1}, 1, 5);
+    const auto span = spanAfterColumnRemove(3, SSpanState{.next = 1}, 1, 5);
 
     ASSERT_TRUE(span.has_value());
-    EXPECT_EQ(span->left, 0);
-    EXPECT_EQ(span->right, 1);
+    EXPECT_EQ(span->prev, 0);
+    EXPECT_EQ(span->next, 1);
 }
 
 TEST(ScrollingSpanLayout, spanAfterColumnRemoveRejectsRemovedAnchor) {
-    EXPECT_FALSE(spanAfterColumnRemove(1, SSpanState{.right = 1}, 1, 3).has_value());
+    EXPECT_FALSE(spanAfterColumnRemove(1, SSpanState{.next = 1}, 1, 3).has_value());
 }
 
 TEST(ScrollingSpanLayout, columnLayoutRejectsWhenTotalSpaceCannotFitOverflowTargets) {

--- a/tests/layout/scrolling/ScrollingSpanLayout.cpp
+++ b/tests/layout/scrolling/ScrollingSpanLayout.cpp
@@ -347,19 +347,48 @@ TEST(ScrollingSpanLayout, spanAfterColumnRemoveRejectsRemovedAnchor) {
     EXPECT_FALSE(spanAfterColumnRemove(1, SSpanState{.right = 1}, 1, 3).has_value());
 }
 
-TEST(ScrollingSpanLayout, columnLayoutRejectsGapSlightlyBelowMinimumBudget) {
+TEST(ScrollingSpanLayout, columnLayoutRejectsWhenTotalSpaceCannotFitOverflowTargets) {
+    // 2 real targets, reservation occupying 0.30→0.80.
+    // Gap 1 (0→0.30): 1 target expected, fitCount=0 → 1 overflows.
+    // Final gap (0.80→1.0): 1 target + 1 overflow = 2 needed, fitCount=0 → rejected.
     const auto result = layoutColumnWithReservations(
         SColumnSpanValidation{
             .realTargetCount = 2,
             .reservations =
                 {
-                    SSpanReservation{.slot = 2, .start = 0.79995F, .size = 0.20005F},
+                    SSpanReservation{.slot = 1, .start = 0.30F, .size = 0.50F},
                 },
         },
         {100.F, 1.F}, 0.40F);
 
     EXPECT_FALSE(result.valid());
     EXPECT_EQ(result.validation.error, "not enough space for real targets around reservations");
+}
+
+TEST(ScrollingSpanLayout, columnLayoutOverflowsTargetsWhenAdjacentReservationsTouch) {
+    // Two reservations touching end-to-end (0→0.33 and 0.33→0.66) at
+    // slots 0 and 1. The gap between them has 0 space for the 1 real
+    // target expected between slot 0 and slot 1, so it overflows to
+    // the final gap. 2 real targets total, both placed below the
+    // reservations.
+    const auto result = layoutColumnWithReservations(
+        SColumnSpanValidation{
+            .realTargetCount = 2,
+            .reservations =
+                {
+                    SSpanReservation{.slot = 0, .start = 0.F, .size = 0.33F},
+                    SSpanReservation{.slot = 1, .start = 0.33F, .size = 0.33F},
+                },
+        },
+        {1.F, 1.F}, 0.10F);
+
+    ASSERT_TRUE(result.valid()) << result.validation.error;
+    ASSERT_EQ(result.realTargets.size(), 2);
+    // Both real targets placed in the final gap below both reservations.
+    EXPECT_GE(result.realTargets[0].start, 0.66F);
+    EXPECT_GE(result.realTargets[1].start, 0.66F);
+    EXPECT_GE(result.realTargets[0].size, 0.10F);
+    EXPECT_GE(result.realTargets[1].size, 0.10F);
 }
 
 TEST(ScrollingSpanLayout, columnLayoutKeepsFinalTargetAtLeastMinimumHeight) {

--- a/tests/layout/scrolling/ScrollingSpanLayout.cpp
+++ b/tests/layout/scrolling/ScrollingSpanLayout.cpp
@@ -1,0 +1,380 @@
+#include <layout/algorithm/tiled/scrolling/ScrollingSpanLayout.hpp>
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+using namespace Layout::Tiled;
+
+TEST(ScrollingSpanLayout, spanRangeClampsToExistingColumns) {
+    const auto range = spanRangeFor(2, SSpanState{.left = 4, .right = 3}, 5);
+
+    ASSERT_TRUE(range.has_value());
+    EXPECT_EQ(range->first, 0);
+    EXPECT_EQ(range->last, 4);
+    EXPECT_TRUE(range->contains(0));
+    EXPECT_TRUE(range->contains(2));
+    EXPECT_TRUE(range->contains(4));
+    EXPECT_FALSE(range->contains(5));
+}
+
+TEST(ScrollingSpanLayout, spanRangeRejectsInvalidAnchor) {
+    EXPECT_FALSE(spanRangeFor(3, SSpanState{.left = 1, .right = 1}, 3).has_value());
+    EXPECT_FALSE(spanRangeFor(0, SSpanState{.left = 0, .right = 0}, 0).has_value());
+}
+
+TEST(ScrollingSpanLayout, spanRangeClampsRightWithoutOverflow) {
+    const size_t anchorColumn = std::numeric_limits<size_t>::max() - 2;
+    const auto   range        = spanRangeFor(anchorColumn, SSpanState{.left = 0, .right = 5}, anchorColumn + 2);
+
+    ASSERT_TRUE(range.has_value());
+    EXPECT_EQ(range->first, anchorColumn);
+    EXPECT_EQ(range->last, anchorColumn + 1);
+    EXPECT_GE(range->last, anchorColumn);
+}
+
+TEST(ScrollingSpanLayout, spanRangeTreatsNegativeSpanAsZero) {
+    const auto range = spanRangeFor(2, SSpanState{.left = -1, .right = -2}, 5);
+
+    ASSERT_TRUE(range.has_value());
+    EXPECT_EQ(range->first, 2);
+    EXPECT_EQ(range->last, 2);
+}
+
+TEST(ScrollingSpanLayout, columnSpansAreHorizontalOnly) {
+    EXPECT_TRUE(columnSpansSupportedForPrimaryAxis(true));
+    EXPECT_FALSE(columnSpansSupportedForPrimaryAxis(false));
+}
+
+TEST(ScrollingSpanLayout, virtualSlotPreservesTopMiddleAndBottomOrder) {
+    EXPECT_EQ(virtualSlotFor(0, 3, 2), 0);
+    EXPECT_EQ(virtualSlotFor(1, 3, 2), 1);
+    EXPECT_EQ(virtualSlotFor(2, 3, 2), 2);
+
+    EXPECT_EQ(virtualSlotFor(0, 3, 1), 0);
+    EXPECT_EQ(virtualSlotFor(1, 3, 1), 0);
+    EXPECT_EQ(virtualSlotFor(2, 3, 1), 1);
+
+    EXPECT_EQ(virtualSlotFor(0, 4, 1), 0);
+    EXPECT_EQ(virtualSlotFor(1, 4, 1), 0);
+    EXPECT_EQ(virtualSlotFor(2, 4, 1), 1);
+    EXPECT_EQ(virtualSlotFor(3, 4, 1), 1);
+}
+
+TEST(ScrollingSpanLayout, virtualSlotSingleOrEmptySourceReturnsDestinationRealCount) {
+    EXPECT_EQ(virtualSlotFor(0, 0, 7), 7);
+    EXPECT_EQ(virtualSlotFor(0, 1, 7), 7);
+}
+
+TEST(ScrollingSpanLayout, spanDependencyCycleDetectsMutualSpanning) {
+    // Column 0 spans right into column 1.
+    // Column 1 spans left into column 0. This is a cycle.
+    const std::vector<std::vector<SSpanState>> spans = {
+        {SSpanState{.right = 1}}, // col 0 → col 1
+        {SSpanState{.left = 1}},  // col 1 → col 0
+        {},
+    };
+
+    EXPECT_TRUE(hasSpanDependencyCycle(spans, 3));
+}
+
+TEST(ScrollingSpanLayout, spanDependencyCycleAllowsLinearChain) {
+    // Column 0 → column 1 → column 2. No cycle.
+    // Column 1 IS covered by column 0 but this is not a cycle.
+    const std::vector<std::vector<SSpanState>> spans = {
+        {SSpanState{.right = 2}}, // col 0 → col 1, col 2
+        {SSpanState{.right = 1}}, // col 1 → col 2
+        {},
+    };
+
+    EXPECT_FALSE(hasSpanDependencyCycle(spans, 3));
+}
+
+TEST(ScrollingSpanLayout, spanDependencyCycleAllowsUnaffectedActiveAnchor) {
+    // Column 0 spans right into column 1. Column 2 has an inactive span.
+    // No column is both anchor and covered → no cycle.
+    const std::vector<std::vector<SSpanState>> spans = {
+        {SSpanState{.right = 1}},
+        {},
+        {SSpanState{.left = 0, .right = 0}},
+    };
+
+    EXPECT_FALSE(hasSpanDependencyCycle(spans, 3));
+}
+
+TEST(ScrollingSpanLayout, columnValidationAcceptsGapsWithEnoughRoom) {
+    const auto result = validateColumnReservations(
+        SColumnSpanValidation{
+            .realTargetCount = 2,
+            .reservations =
+                {
+                    SSpanReservation{.slot = 1, .start = 0.40F, .size = 0.20F},
+                },
+        },
+        0.10F);
+
+    EXPECT_TRUE(result.valid) << result.error;
+}
+
+TEST(ScrollingSpanLayout, columnValidationRejectsFullHeightReservationWithRemainingWindow) {
+    const auto result = validateColumnReservations(
+        SColumnSpanValidation{
+            .realTargetCount = 1,
+            .reservations =
+                {
+                    SSpanReservation{.slot = 1, .start = 0.F, .size = 1.F},
+                },
+        },
+        0.10F);
+
+    EXPECT_FALSE(result.valid);
+    EXPECT_EQ(result.error, "not enough space for real targets around reservations");
+}
+
+TEST(ScrollingSpanLayout, columnValidationRejectsOverlappingBands) {
+    const auto result = validateColumnReservations(
+        SColumnSpanValidation{
+            .realTargetCount = 2,
+            .reservations =
+                {
+                    SSpanReservation{.slot = 0, .start = 0.20F, .size = 0.40F},
+                    SSpanReservation{.slot = 2, .start = 0.50F, .size = 0.20F},
+                },
+        },
+        0.10F);
+
+    EXPECT_FALSE(result.valid);
+    EXPECT_EQ(result.error, "reservation bands overlap");
+}
+
+TEST(ScrollingSpanLayout, columnValidationAcceptsRepeatedSlotsWhenBandsDoNotOverlap) {
+    const auto result = validateColumnReservations(
+        SColumnSpanValidation{
+            .realTargetCount = 2,
+            .reservations =
+                {
+                    SSpanReservation{.slot = 1, .start = 0.20F, .size = 0.20F},
+                    SSpanReservation{.slot = 1, .start = 0.60F, .size = 0.20F},
+                },
+        },
+        0.10F);
+
+    EXPECT_TRUE(result.valid) << result.error;
+}
+
+TEST(ScrollingSpanLayout, columnValidationRejectsSlotOutOfRange) {
+    const auto result = validateColumnReservations(
+        SColumnSpanValidation{
+            .realTargetCount = 1,
+            .reservations =
+                {
+                    SSpanReservation{.slot = 2, .start = 0.20F, .size = 0.20F},
+                },
+        },
+        0.10F);
+
+    EXPECT_FALSE(result.valid);
+    EXPECT_EQ(result.error, "reservation slot out of range");
+}
+
+TEST(ScrollingSpanLayout, columnValidationRejectsBandOutOfRange) {
+    const auto result = validateColumnReservations(
+        SColumnSpanValidation{
+            .realTargetCount = 1,
+            .reservations =
+                {
+                    SSpanReservation{.slot = 0, .start = 0.90F, .size = 0.20F},
+                },
+        },
+        0.10F);
+
+    EXPECT_FALSE(result.valid);
+    EXPECT_EQ(result.error, "reservation band out of range");
+}
+
+TEST(ScrollingSpanLayout, columnValidationRejectsSlotOrderConflictingWithBandOrder) {
+    const auto result = validateColumnReservations(
+        SColumnSpanValidation{
+            .realTargetCount = 2,
+            .reservations =
+                {
+                    SSpanReservation{.slot = 0, .start = 0.60F, .size = 0.10F},
+                    SSpanReservation{.slot = 1, .start = 0.20F, .size = 0.10F},
+                },
+        },
+        0.10F);
+
+    EXPECT_FALSE(result.valid);
+    EXPECT_EQ(result.error, "reservation slot order conflicts with band order");
+}
+
+TEST(ScrollingSpanLayout, columnLayoutFitsRealTargetsAroundReservation) {
+    const auto result = layoutColumnWithReservations(
+        SColumnSpanValidation{
+            .realTargetCount = 2,
+            .reservations =
+                {
+                    SSpanReservation{.slot = 1, .start = 0.40F, .size = 0.20F},
+                },
+        },
+        {1.F, 1.F}, 0.10F);
+
+    ASSERT_TRUE(result.valid()) << result.validation.error;
+    ASSERT_EQ(result.realTargets.size(), 2);
+    EXPECT_EQ(result.realTargets[0].index, 0);
+    EXPECT_FLOAT_EQ(result.realTargets[0].start, 0.F);
+    EXPECT_FLOAT_EQ(result.realTargets[0].size, 0.40F);
+    EXPECT_EQ(result.realTargets[1].index, 1);
+    EXPECT_FLOAT_EQ(result.realTargets[1].start, 0.60F);
+    EXPECT_FLOAT_EQ(result.realTargets[1].size, 0.40F);
+}
+
+TEST(ScrollingSpanLayout, columnLayoutReportsVirtualRowsAroundReservations) {
+    const auto result = layoutColumnWithReservations(
+        SColumnSpanValidation{
+            .realTargetCount = 1,
+            .reservations =
+                {
+                    SSpanReservation{.slot = 0, .start = 0.F, .size = 0.50F},
+                },
+        },
+        {1.F}, 0.10F);
+
+    ASSERT_TRUE(result.valid()) << result.validation.error;
+    ASSERT_EQ(result.realTargets.size(), 1);
+    EXPECT_EQ(result.realTargets[0].index, 0);
+    EXPECT_FLOAT_EQ(result.realTargets[0].start, 0.50F);
+    EXPECT_FLOAT_EQ(result.realTargets[0].size, 0.50F);
+    EXPECT_EQ(result.realTargets[0].virtualIndex, 1);
+    EXPECT_EQ(result.realTargets[0].virtualCount, 2);
+}
+
+TEST(ScrollingSpanLayout, columnLayoutPlacesRealTargetAfterRepeatedSlotReservations) {
+    const auto result = layoutColumnWithReservations(
+        SColumnSpanValidation{
+            .realTargetCount = 1,
+            .reservations =
+                {
+                    SSpanReservation{.slot = 0, .start = 0.F, .size = 0.33F},
+                    SSpanReservation{.slot = 0, .start = 0.33F, .size = 0.33F},
+                },
+        },
+        {1.F}, 0.10F);
+
+    ASSERT_TRUE(result.valid()) << result.validation.error;
+    ASSERT_EQ(result.realTargets.size(), 1);
+    EXPECT_EQ(result.realTargets[0].index, 0);
+    EXPECT_FLOAT_EQ(result.realTargets[0].start, 0.66F);
+    EXPECT_FLOAT_EQ(result.realTargets[0].size, 0.34F);
+    EXPECT_EQ(result.realTargets[0].virtualIndex, 2);
+    EXPECT_EQ(result.realTargets[0].virtualCount, 3);
+}
+
+TEST(ScrollingSpanLayout, columnLayoutKeepsUnevenTargetsAtLeastMinimumHeight) {
+    const auto result = layoutColumnWithReservations(
+        SColumnSpanValidation{
+            .realTargetCount = 2,
+        },
+        {100.F, 1.F}, 0.40F);
+
+    ASSERT_TRUE(result.valid()) << result.validation.error;
+    ASSERT_EQ(result.realTargets.size(), 2);
+    EXPECT_GE(result.realTargets[0].size, 0.40F);
+    EXPECT_GE(result.realTargets[1].size, 0.40F);
+}
+
+TEST(ScrollingSpanLayout, spanAfterColumnInsertGrowsRightSpanInsideRange) {
+    const auto span = spanAfterColumnInsert(1, SSpanState{.right = 1}, 2, 3);
+
+    ASSERT_TRUE(span.has_value());
+    EXPECT_EQ(span->left, 0);
+    EXPECT_EQ(span->right, 2);
+}
+
+TEST(ScrollingSpanLayout, spanAfterColumnInsertGrowsLeftSpanInsideRange) {
+    const auto span = spanAfterColumnInsert(1, SSpanState{.left = 1}, 1, 3);
+
+    ASSERT_TRUE(span.has_value());
+    EXPECT_EQ(span->left, 2);
+    EXPECT_EQ(span->right, 0);
+}
+
+TEST(ScrollingSpanLayout, spanAfterColumnInsertLeavesSpanOutsideRangeUnchanged) {
+    const auto span = spanAfterColumnInsert(1, SSpanState{.right = 1}, 3, 3);
+
+    ASSERT_TRUE(span.has_value());
+    EXPECT_EQ(span->left, 0);
+    EXPECT_EQ(span->right, 1);
+}
+
+TEST(ScrollingSpanLayout, columnInsertAfterFocusedSpanUsesRightEdgeOfSpan) {
+    EXPECT_EQ(columnInsertAfterFocusedSpan(1, SSpanState{.right = 1}, 3), 3);
+}
+
+TEST(ScrollingSpanLayout, columnInsertAfterFocusedSpanClampsAtColumnCount) {
+    EXPECT_EQ(columnInsertAfterFocusedSpan(1, SSpanState{.right = 3}, 3), 3);
+}
+
+TEST(ScrollingSpanLayout, columnInsertAfterFocusedSpanUsesAnchorForLeftOnlySpan) {
+    EXPECT_EQ(columnInsertAfterFocusedSpan(2, SSpanState{.left = 2}, 4), 3);
+}
+
+TEST(ScrollingSpanLayout, spanAfterColumnRemoveShrinksRightSpanInsideRange) {
+    const auto span = spanAfterColumnRemove(1, SSpanState{.right = 3}, 2, 5);
+
+    ASSERT_TRUE(span.has_value());
+    EXPECT_EQ(span->left, 0);
+    EXPECT_EQ(span->right, 2);
+}
+
+TEST(ScrollingSpanLayout, spanAfterColumnRemoveShrinksLeftSpanInsideRange) {
+    const auto span = spanAfterColumnRemove(3, SSpanState{.left = 3}, 2, 5);
+
+    ASSERT_TRUE(span.has_value());
+    EXPECT_EQ(span->left, 2);
+    EXPECT_EQ(span->right, 0);
+}
+
+TEST(ScrollingSpanLayout, spanAfterColumnRemoveShiftsSpanOutsideRange) {
+    const auto span = spanAfterColumnRemove(3, SSpanState{.right = 1}, 1, 5);
+
+    ASSERT_TRUE(span.has_value());
+    EXPECT_EQ(span->left, 0);
+    EXPECT_EQ(span->right, 1);
+}
+
+TEST(ScrollingSpanLayout, spanAfterColumnRemoveRejectsRemovedAnchor) {
+    EXPECT_FALSE(spanAfterColumnRemove(1, SSpanState{.right = 1}, 1, 3).has_value());
+}
+
+TEST(ScrollingSpanLayout, columnLayoutRejectsGapSlightlyBelowMinimumBudget) {
+    const auto result = layoutColumnWithReservations(
+        SColumnSpanValidation{
+            .realTargetCount = 2,
+            .reservations =
+                {
+                    SSpanReservation{.slot = 2, .start = 0.79995F, .size = 0.20005F},
+                },
+        },
+        {100.F, 1.F}, 0.40F);
+
+    EXPECT_FALSE(result.valid());
+    EXPECT_EQ(result.validation.error, "not enough space for real targets around reservations");
+}
+
+TEST(ScrollingSpanLayout, columnLayoutKeepsFinalTargetAtLeastMinimumHeight) {
+    const auto result = layoutColumnWithReservations(
+        SColumnSpanValidation{
+            .realTargetCount = 2,
+            .reservations =
+                {
+                    SSpanReservation{.slot = 0, .start = 0.F, .size = 0.20F},
+                },
+        },
+        {100.F, 1.F}, 0.40F);
+
+    ASSERT_TRUE(result.valid()) << result.validation.error;
+    ASSERT_EQ(result.realTargets.size(), 2);
+    EXPECT_GE(result.realTargets[0].size, 0.40F);
+    EXPECT_GE(result.realTargets[1].size, 0.40F);
+}

--- a/tests/layout/scrolling/ScrollingSpanLayout.cpp
+++ b/tests/layout/scrolling/ScrollingSpanLayout.cpp
@@ -38,13 +38,13 @@ TEST(ScrollingSpanLayout, extractSpanReservationHandlesWorkspaceOffset) {
     const Vector2D        workspaceOffset = {0, 100};
 
     const auto            params = controller.extractSpanReservation(anchorBox, usable, workspaceOffset);
-    EXPECT_NEAR(params.start, 200.0F / 980.0F, 0.0001F);  // (300 - 100) / 980
+    EXPECT_NEAR(params.start, 200.0F / 980.0F, 0.0001F); // (300 - 100) / 980
     EXPECT_NEAR(params.size, 400.0F / 980.0F, 0.0001F);
 }
 
 TEST(ScrollingSpanLayout, mergeSpanStripBoxesMergesHorizontalInPrimaryHorizontalMode) {
     CScrollTapeController controller(SCROLL_DIR_RIGHT);
-    CBox                  result = {10, 100, 200, 300};  // secondary axis: y=100, h=300
+    CBox                  result = {10, 100, 200, 300}; // secondary axis: y=100, h=300
     const CBox            first  = {0, 0, 640, 1080};
     const CBox            last   = {1280, 0, 640, 1080};
 
@@ -58,7 +58,7 @@ TEST(ScrollingSpanLayout, mergeSpanStripBoxesMergesHorizontalInPrimaryHorizontal
 
 TEST(ScrollingSpanLayout, mergeSpanStripBoxesMergesVerticalInPrimaryVerticalMode) {
     CScrollTapeController controller(SCROLL_DIR_DOWN);
-    CBox                  result = {100, 10, 300, 200};  // secondary axis: x=100, w=300
+    CBox                  result = {100, 10, 300, 200}; // secondary axis: x=100, w=300
     const CBox            first  = {0, 0, 1920, 540};
     const CBox            last   = {0, 540, 1920, 540};
 
@@ -142,7 +142,7 @@ TEST(ScrollingSpanLayout, spanDependencyCycleDetectsMutualSpanning) {
     // Column 1 spans left into column 0. This is a cycle.
     const std::vector<std::vector<SSpanState>> spans = {
         {SSpanState{.next = 1}}, // col 0 → col 1
-        {SSpanState{.prev = 1}},  // col 1 → col 0
+        {SSpanState{.prev = 1}}, // col 1 → col 0
         {},
     };
 
@@ -179,7 +179,7 @@ TEST(ScrollingSpanLayout, columnValidationAcceptsGapsWithEnoughRoom) {
             .realTargetCount = 2,
             .reservations =
                 {
-                    SSpanReservation{.slot = 1, .start = 0.40F, .size = 0.20F},
+                    SSpanReservation{.slot = 1, .start = 0.F, .size = 0.20F},
                 },
         },
         0.10F);
@@ -224,7 +224,7 @@ TEST(ScrollingSpanLayout, columnValidationAcceptsRepeatedSlotsWhenBandsDoNotOver
             .realTargetCount = 2,
             .reservations =
                 {
-                    SSpanReservation{.slot = 1, .start = 0.20F, .size = 0.20F},
+                    SSpanReservation{.slot = 1, .start = 0.F, .size = 0.20F},
                     SSpanReservation{.slot = 1, .start = 0.60F, .size = 0.20F},
                 },
         },
@@ -279,8 +279,10 @@ TEST(ScrollingSpanLayout, columnValidationRejectsSlotOrderConflictingWithBandOrd
     EXPECT_EQ(result.error, "reservation slot order conflicts with band order");
 }
 
-TEST(ScrollingSpanLayout, columnLayoutFitsRealTargetsAroundReservation) {
-    const auto result = layoutColumnWithReservations(
+TEST(ScrollingSpanLayout, columnValidationRejectsFirstReservationNotAtColumnOrigin) {
+    // A shrink that vacates the top of a destination column leaves the
+    // first reservation floating above position 0. This must be rejected.
+    const auto result = validateColumnReservations(
         SColumnSpanValidation{
             .realTargetCount = 2,
             .reservations =
@@ -288,12 +290,27 @@ TEST(ScrollingSpanLayout, columnLayoutFitsRealTargetsAroundReservation) {
                     SSpanReservation{.slot = 1, .start = 0.40F, .size = 0.20F},
                 },
         },
+        0.10F);
+
+    EXPECT_FALSE(result.valid);
+    EXPECT_EQ(result.error, "first reservation does not cover column origin");
+}
+
+TEST(ScrollingSpanLayout, columnLayoutFitsRealTargetsAroundReservation) {
+    const auto result = layoutColumnWithReservations(
+        SColumnSpanValidation{
+            .realTargetCount = 2,
+            .reservations =
+                {
+                    SSpanReservation{.slot = 1, .start = 0.F, .size = 0.20F},
+                },
+        },
         {1.F, 1.F}, 0.10F);
 
     ASSERT_TRUE(result.valid()) << result.validation.error;
     ASSERT_EQ(result.realTargets.size(), 2);
     EXPECT_EQ(result.realTargets[0].index, 0);
-    EXPECT_FLOAT_EQ(result.realTargets[0].start, 0.F);
+    EXPECT_FLOAT_EQ(result.realTargets[0].start, 0.20F);
     EXPECT_FLOAT_EQ(result.realTargets[0].size, 0.40F);
     EXPECT_EQ(result.realTargets[1].index, 1);
     EXPECT_FLOAT_EQ(result.realTargets[1].start, 0.60F);
@@ -419,15 +436,18 @@ TEST(ScrollingSpanLayout, spanAfterColumnRemoveRejectsRemovedAnchor) {
 }
 
 TEST(ScrollingSpanLayout, columnLayoutRejectsWhenTotalSpaceCannotFitOverflowTargets) {
-    // 2 real targets, reservation occupying 0.30→0.80.
-    // Gap 1 (0→0.30): 1 target expected, fitCount=0 → 1 overflows.
-    // Final gap (0.80→1.0): 1 target + 1 overflow = 2 needed, fitCount=0 → rejected.
+    // 2 real targets, 2 reservations.
+    // Reservation 0 (slot 0, 0→0.01): covers origin, negligible size.
+    // Reservation 1 (slot 1, 0.31→0.81): occupies middle of the column.
+    // Gap between reservations (0.01→0.31): 1 target, fitCount=0 → 1 overflows.
+    // Final gap (0.81→1.0): 1 target + 1 overflow = 2 needed, fitCount=0 → rejected.
     const auto result = layoutColumnWithReservations(
         SColumnSpanValidation{
             .realTargetCount = 2,
             .reservations =
                 {
-                    SSpanReservation{.slot = 1, .start = 0.30F, .size = 0.50F},
+                    SSpanReservation{.slot = 0, .start = 0.F, .size = 0.01F},
+                    SSpanReservation{.slot = 1, .start = 0.31F, .size = 0.50F},
                 },
         },
         {100.F, 1.F}, 0.40F);


### PR DESCRIPTION
AI Use Disclosure: All code in this PR is AI generated.

#### Describe your PR, what does it fix/add?
<table>
<tr>
  <td colspan="2" align="center" height="60"><b>Window A</b><br>(span = 2)</td>
</tr>
<tr>
  <td align="center" width="200" height="60"><b>Window B</b></td>
  <td align="center" width="200" height="60"><b>Window C</b></td>
</tr>
</table>

- Adds window spans to Scrolling layout, allowing a window to occupy multiple columns.
- `expand` / `shrink` layout dispatchers

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
- Windows are anchored to their base column and when expanded into adjacent columns add reservations to those columns to occupy the position and vertical size.
- When a window spans into an adjacent column, existing windows in that column are resized and pushed above or below the spanned window.

```
hl.bind("SUPER + ALT + bracketright", hl.dsp.layout("expand next"))
hl.bind("SUPER + ALT + bracketleft", hl.dsp.layout("shrink next"))
hl.bind("SUPER + CTRL + bracketright", hl.dsp.layout("shrink prev"))
hl.bind("SUPER + CTRL + bracketleft", hl.dsp.layout("expand prev"))
```

#### Is it ready for merging, or does it need work?
This is a work in progress. It is currently functional, stable, and feature complete. Still identifying edge cases that don't work as expected.

- Attempting to span a window which would cause an invalid layout should be a no-op. Like two windows side by side and trying to expand one into the other column would be an invalid layout. Looking for conditions that allow an invalid layout to be rendered.
- Also looking for examples where an expand should work but does not.

#### TODO:
- [x] Support vertical axis scrolling. (needs testing. I don't use vertical)




