### PR TITLE
input/window: fix dragging pointer-locked and fullscreen game windows (gamescope)

### DIFF
--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -1350,7 +1350,12 @@ void CWindow::onUpdateState() {
     std::optional<MONITORID> requestsID = m_xdgSurface ? m_xdgSurface->m_toplevel->m_state.requestsFullscreenMonitor : MONITOR_INVALID;
     std::optional<bool>      requestsMX = m_xdgSurface ? m_xdgSurface->m_toplevel->m_state.requestsMaximize : m_xwaylandSurface->m_state.requestsMaximize;
 
-    if (requestsFS.has_value() && !(m_suppressedEvents & SUPPRESS_FULLSCREEN)) {
+    // a client re-asserting fullscreen every frame (notably gamescope) would snap the window back the instant
+    // the drag handler pulls it out of fullscreen, so ignore the request while this window is being dragged.
+    const auto DRAGTARGET         = g_layoutManager->dragController()->target();
+    const bool DRAGGINGTHISWINDOW = DRAGTARGET && DRAGTARGET->window() == m_self.lock();
+
+    if (requestsFS.has_value() && !(m_suppressedEvents & SUPPRESS_FULLSCREEN) && !DRAGGINGTHISWINDOW) {
         if (requestsID.has_value() && (requestsID.value() != MONITOR_INVALID) && !(m_suppressedEvents & SUPPRESS_FULLSCREEN_OUTPUT)) {
             if (m_isMapped) {
                 const auto monitor = State::monitorState()->query().id(requestsID.value()).run();

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1768,6 +1768,11 @@ bool CInputManager::isConstrained() {
         if (!WINDOW)
             return false;
 
+        // a window being interactively moved or resized ignores its pointer lock. the lock would otherwise warp
+        // the cursor back to the constraint hint every frame, so the window could never be dragged (e.g. gamescope).
+        if (const auto DRAG = g_layoutManager->dragController()->target(); DRAG && DRAG->window() == WINDOW)
+            return false;
+
         return !WINDOW->m_layoutFlags.cantLockCursor;
     });
 }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -141,7 +141,10 @@ void CInputManager::onMouseMoved(IPointer::SMotionEvent e) {
     if (e.mouse)
         recheckMouseWarpOnMouseInput();
 
-    PROTO::relativePointer->sendRelativeMotion(sc<uint64_t>(e.timeMs) * 1000, delta, unaccel);
+    // an interactive move or resize is an exclusive grab, so don't feed relative motion to the window being
+    // dragged. a pointer-locked game would otherwise pan its camera from the drag itself.
+    if (!g_layoutManager->dragController()->target())
+        PROTO::relativePointer->sendRelativeMotion(sc<uint64_t>(e.timeMs) * 1000, delta, unaccel);
     g_pPointerManager->move(DELTA);
 
     mouseMoveUnified(e.timeMs, false, e.mouse);


### PR DESCRIPTION
Three small focused fixes around dragging game windows, especially gamescope-wrapped ones. Kept as separate commits so they can be taken or dropped independently.

1. Don't re-fullscreen a window mid-drag. A client re-asserting fullscreen every frame (gamescope) snaps the window back the instant the drag pulls it out, so it oscillates and the move crawls. Ignored while it's the active drag target.

2. Ignore a pointer lock on a dragged window. A pointer-locked game couldn't be moved/resized; the lock warped the cursor back to the hint every frame. The active drag target is treated as unconstrained so the cursor drives the drag, and the lock resumes when the drag ends.

3. Don't send relative motion to a dragged window. An interactive grab should be exclusive; without this a locked game pans its camera from the drag motion.

Tested with gamescope games: dragging, resizing and tiling now behave like any normal window.