### PR TITLE
renderbuffer: avoid nullptr deref

### DIFF
--- a/src/render/gl/GLRenderbuffer.cpp
+++ b/src/render/gl/GLRenderbuffer.cpp
@@ -19,8 +19,10 @@ CGLRenderbuffer::~CGLRenderbuffer() {
 
     g_pHyprOpenGL->makeEGLCurrent();
 
-    unbind();
-    m_framebuffer->release();
+    if (m_framebuffer) {
+        unbind();
+        m_framebuffer->release();
+    }
 
     if (m_rbo)
         glDeleteRenderbuffers(1, &m_rbo);


### PR DESCRIPTION
if createEGLImage fails for some reason m_framebuffer is nullptr, and then the destructor will nullptr deref.


