### PR TITLE
CI: do not auto-comment on PRs from contributors

### DIFF
--- a/.github/workflows/new-pr-comment.yml
+++ b/.github/workflows/new-pr-comment.yml
@@ -8,12 +8,10 @@ on:
 jobs:
   comment:
     if: >
-      github.event.pull_request.user.login != 'vaxerski' &&
-      github.event.pull_request.user.login != 'fufexan' &&
-      github.event.pull_request.user.login != 'gulafaran' &&
-      github.event.pull_request.user.login != 'ujint34' &&
-      github.event.pull_request.user.login != 'paideiadilemma' &&
-      github.event.pull_request.user.login != 'notashelf'
+      github.event.pull_request.author_association != 'OWNER' &&
+      github.event.pull_request.author_association != 'MEMBER' &&
+      github.event.pull_request.author_association != 'COLLABORATOR' &&
+      github.event.pull_request.author_association != 'CONTRIBUTOR'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Limits the set of users receiving the welcome PR message to first-time contributors.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

A potential concern is for people who, e.g., once (which brings them to the contributor category), then leave for a long time and forget about PR guidelines, tests, etc, and then return to make another contribution: they won't receive a new message in this case.

I hope it's ok. For reference, llvm [does](https://github.com/llvm/llvm-project/blob/b496d0623824060af20726f89bbf8fe662dd49e4/.github/workflows/new-prs.yml#L28-L34) the same.

#### Is it ready for merging, or does it need work?

From my side, ready for merge.