### PR TITLE
config: monitors default to "preferred" res, "auto" pos and scale

### DIFF
--- a/src/config/shared/monitor/MonitorRule.hpp
+++ b/src/config/shared/monitor/MonitorRule.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <optional>
+#include <cstdint>
 #include <xf86drmMode.h>
 
 #include "../../../helpers/math/Math.hpp"
@@ -39,8 +40,8 @@ namespace Config {
 
         eAutoDirs                    m_autoDir       = DIR_AUTO_NONE;
         std::string                  m_name          = "";
-        Vector2D                     m_resolution    = Vector2D(1280, 720);
-        Vector2D                     m_offset        = Vector2D(0, 0);
+        Vector2D                     m_resolution    = Vector2D();
+        Vector2D                     m_offset        = Vector2D(-INT32_MAX, -INT32_MAX);
         float                        m_scale         = -1;
         float                        m_refreshRate   = 60; // Hz
         bool                         m_disabled      = false;

--- a/src/config/shared/monitor/Parser.cpp
+++ b/src/config/shared/monitor/Parser.cpp
@@ -108,7 +108,7 @@ std::optional<std::string> CMonitorRuleParser::getError() {
 }
 
 bool CMonitorRuleParser::parseMode(const std::string& value) {
-    if (value.starts_with("pref"))
+    if (value.empty() || value.starts_with("pref"))
         m_rule.m_resolution = Vector2D();
     else if (value.starts_with("highrr"))
         m_rule.m_resolution = Vector2D(-1, -1);
@@ -143,10 +143,10 @@ bool CMonitorRuleParser::parseMode(const std::string& value) {
 }
 
 bool CMonitorRuleParser::parsePosition(const std::string& value, bool isFirst) {
-    if (value.starts_with("auto")) {
+    if (value.empty() || value.starts_with("auto")) {
         m_rule.m_offset = Vector2D(-INT32_MAX, -INT32_MAX);
         // If this is the first monitor rule needs to be on the right.
-        if (value == "auto-right" || value == "auto" || isFirst)
+        if (value.empty() || value == "auto-right" || value == "auto" || isFirst)
             m_rule.m_autoDir = eAutoDirs::DIR_AUTO_RIGHT;
         else if (value == "auto-left")
             m_rule.m_autoDir = eAutoDirs::DIR_AUTO_LEFT;
@@ -191,7 +191,7 @@ bool CMonitorRuleParser::parsePosition(const std::string& value, bool isFirst) {
 }
 
 bool CMonitorRuleParser::parseScale(const std::string& value) {
-    if (value.starts_with("auto"))
+    if (value.empty() || value.starts_with("auto"))
         m_rule.m_scale = -1;
     else {
         if (!isNumber(value, true)) {

--- a/tests/config/MonitorParser.cpp
+++ b/tests/config/MonitorParser.cpp
@@ -10,6 +10,15 @@ TEST(Config, monitorParserName) {
     EXPECT_FALSE(parser.getError().has_value());
 }
 
+TEST(Config, monitorParserDefaults) {
+    // when a field's key is absent entirely
+    CMonitorRuleParser parser("DP-1");
+    EXPECT_EQ(parser.rule().m_resolution, Vector2D());                   // preferred
+    EXPECT_EQ(parser.rule().m_offset, Vector2D(-INT32_MAX, -INT32_MAX)); // auto
+    EXPECT_FLOAT_EQ(parser.rule().m_scale, -1.0f);                       // auto
+    EXPECT_FALSE(parser.getError().has_value());
+}
+
 TEST(Config, monitorParserModeStandard) {
     CMonitorRuleParser parser("DP-1");
     EXPECT_TRUE(parser.parseMode("1920x1080"));
@@ -42,6 +51,13 @@ TEST(Config, monitorParserModeKeywords) {
     CMonitorRuleParser p4("DP-1");
     EXPECT_TRUE(p4.parseMode("maxwidth"));
     EXPECT_EQ(p4.rule().m_resolution, Vector2D(-1, -3));
+}
+
+TEST(Config, monitorParserModeOmitted) {
+    CMonitorRuleParser parser("DP-1");
+    EXPECT_TRUE(parser.parseMode("")); // defaults to "preferred"
+    EXPECT_EQ(parser.rule().m_resolution, Vector2D());
+    EXPECT_FALSE(parser.getError().has_value());
 }
 
 TEST(Config, monitorParserModeInvalid) {
@@ -82,6 +98,14 @@ TEST(Config, monitorParserPositionAuto) {
     EXPECT_EQ(p5.rule().m_autoDir, DIR_AUTO_RIGHT);
 }
 
+TEST(Config, monitorParserPositionOmitted) {
+    CMonitorRuleParser parser("DP-1");
+    EXPECT_TRUE(parser.parsePosition("")); // defaults to "auto"
+    EXPECT_EQ(parser.rule().m_offset, Vector2D(-INT32_MAX, -INT32_MAX));
+    EXPECT_EQ(parser.rule().m_autoDir, DIR_AUTO_RIGHT);
+    EXPECT_FALSE(parser.getError().has_value());
+}
+
 TEST(Config, monitorParserPositionAutoCenter) {
     CMonitorRuleParser p1("DP-1");
     EXPECT_TRUE(p1.parsePosition("auto-center-right"));
@@ -116,6 +140,13 @@ TEST(Config, monitorParserScaleValid) {
     CMonitorRuleParser p4("DP-1");
     EXPECT_TRUE(p4.parseScale("0.25"));
     EXPECT_FLOAT_EQ(p4.rule().m_scale, 0.25f);
+}
+
+TEST(Config, monitorParserScaleOmitted) {
+    CMonitorRuleParser parser("DP-1");
+    EXPECT_TRUE(parser.parseScale("")); // defaults to "auto"
+    EXPECT_FLOAT_EQ(parser.rule().m_scale, -1.0f);
+    EXPECT_FALSE(parser.getError().has_value());
 }
 
 TEST(Config, monitorParserScaleInvalid) {


### PR DESCRIPTION
It is now possible to omit the keys entirely.

This way common monitors config entries can be more concise.

