### PR TITLE
protocols/toplevelExport: null-check pixel format

### DIFF
--- a/src/protocols/ToplevelExport.cpp
+++ b/src/protocols/ToplevelExport.cpp
@@ -76,7 +76,14 @@ CToplevelExportFrame::CToplevelExportFrame(SP<CHyprlandToplevelExportFrameV1> re
     auto       bufSize = m_frame->bufferSize();
 
     const auto PSHMINFO = getPixelFormatFromDRM(format);
-    const auto stride   = minStride(PSHMINFO, bufSize.x);
+
+    if (!PSHMINFO) {
+        LOGM(Log::ERR, "No pixel format for drm format");
+        m_resource->sendFailed();
+        return;
+    }
+
+    const auto stride = minStride(PSHMINFO, bufSize.x);
     m_resource->sendBuffer(NFormatUtils::drmToShm(format), bufSize.x, bufSize.y, stride);
 
     if LIKELY (format != DRM_FORMAT_INVALID)


### PR DESCRIPTION
`getPixelFormatFromDRM` returns `nullptr` for any DRM format not in hyprgraphics's table, and `minStride` then derefs it and segfaults the compositor. `Screencopy.cpp` already has this guard - this just mirrors it in `ToplevelExport.cpp`.

Repro: NVIDIA Blackwell (RTX 5070) + any toplevel-export client (e.g. quickshell window thumbnails in dots-hyprland). Hyprland goes down -> recovery cfg / safe mode.