### PR TITLE
Fix: nested submaps and resets

### DIFF
--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -798,6 +798,8 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
 
             Config::Actions::state()->m_passPressed = sc<int>(pressed);
 
+            auto submapBefore = Config::Actions::state()->m_currentSubmap;
+
             // if the dispatchers says to pass event then we will
             if (k->handler == "mouse")
                 res = DISPATCHER->second((pressed ? "1" : "0") + k->arg);
@@ -810,8 +812,11 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
                 found = true; // don't process keybinds on submap change.
                 break;
             }
-            if (k->handler != "submap" && !k->submap.reset.empty()) // NOLINTNEXTLINE
-                Config::Actions::setSubmap(k->submap.reset);
+            if (k->handler != "submap" && !k->submap.reset.empty()) {
+                auto submapAfter = Config::Actions::state()->m_currentSubmap;
+                if (submapBefore == submapAfter)
+                    Config::Actions::setSubmap(k->submap.reset);
+            }
         }
 
         if (pressed && k->repeat) {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
After lua and the changes to handlers, we can no longer match only k->handlers to break out if the submap is changed / reset. So fixes that by storing what submap we were in before the handler was called.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Could impact performace, but shouldn't be a lot. Still need a rewrite of the entire manager imho.

#### Is it ready for merging, or does it need work?
Yes.