### PR TITLE
Detect lua special dispatchers by reference

### DIFF
--- a/hyprtester/clients/keyboard-modifiers.cpp
+++ b/hyprtester/clients/keyboard-modifiers.cpp
@@ -22,27 +22,27 @@ using Hyprutils::Math::Vector2D;
 using namespace Hyprutils::Memory;
 
 struct SWlState {
-    wl_display*                    display;
-    CSharedPointer<CCWlRegistry>   registry;
+    wl_display*                                display;
+    CSharedPointer<CCWlRegistry>               registry;
 
-    CSharedPointer<CCWlCompositor> wlCompositor;
-    CSharedPointer<CCWlSeat>       wlSeat;
-    CSharedPointer<CCWlShm>        wlShm;
-    CSharedPointer<CCXdgWmBase>    xdgShell;
+    CSharedPointer<CCWlCompositor>             wlCompositor;
+    CSharedPointer<CCWlSeat>                   wlSeat;
+    CSharedPointer<CCWlShm>                    wlShm;
+    CSharedPointer<CCXdgWmBase>                xdgShell;
 
-    CSharedPointer<CCWlShmPool>    shmPool;
-    CSharedPointer<CCWlBuffer>     shmBuf;
-    int                            shmFd;
-    size_t                         shmBufSize;
-    bool                           xrgb8888_support = false;
+    CSharedPointer<CCWlShmPool>                shmPool;
+    CSharedPointer<CCWlBuffer>                 shmBuf;
+    int                                        shmFd;
+    size_t                                     shmBufSize;
+    bool                                       xrgb8888_support = false;
 
-    CSharedPointer<CCWlSurface>    surf;
-    CSharedPointer<CCXdgSurface>   xdgSurf;
-    CSharedPointer<CCXdgToplevel>  xdgToplevel;
-    Vector2D                       geom;
+    CSharedPointer<CCWlSurface>                surf;
+    CSharedPointer<CCXdgSurface>               xdgSurf;
+    CSharedPointer<CCXdgToplevel>              xdgToplevel;
+    Vector2D                                   geom;
 
-    CSharedPointer<CCWlKeyboard>   keyboard;
-    uint32_t                       lastLocked = 0;
+    CSharedPointer<CCWlKeyboard>               keyboard;
+    uint32_t                                   lastLocked = 0;
 
     std::vector<std::pair<uint32_t, uint32_t>> keyEvents;
 };

--- a/hyprtester/clients/keyboard-modifiers.cpp
+++ b/hyprtester/clients/keyboard-modifiers.cpp
@@ -8,6 +8,7 @@
 #include <string>
 #include <fstream>
 #include <utility>
+#include <vector>
 
 #include <wayland-client.h>
 #include <wayland.hpp>
@@ -42,6 +43,8 @@ struct SWlState {
 
     CSharedPointer<CCWlKeyboard>   keyboard;
     uint32_t                       lastLocked = 0;
+
+    std::vector<std::pair<uint32_t, uint32_t>> keyEvents;
 };
 
 static std::ofstream logfile;
@@ -211,7 +214,10 @@ static bool setupSeat(SWlState& state) {
         state.lastLocked = locked;
     });
 
-    state.keyboard->setKey([&](CCWlKeyboard* p, uint32_t serial, uint32_t time, uint32_t key, uint32_t state) { debugLog("Got key event: key={} state={}", key, state); });
+    state.keyboard->setKey([&](CCWlKeyboard* p, uint32_t serial, uint32_t time, uint32_t key, uint32_t keyState) {
+        state.keyEvents.emplace_back(key, keyState);
+        debugLog("Got key event: key={} state={}", key, keyState);
+    });
 
     return true;
 }
@@ -219,7 +225,16 @@ static bool setupSeat(SWlState& state) {
 static void parseRequest(SWlState& state, std::string req) {
     if (req.starts_with("get"))
         clientLog("{}", state.lastLocked);
-    else if (req.starts_with("exit"))
+    else if (req.starts_with("keys")) {
+        uint32_t pressed = 0, released = 0;
+        for (const auto& [code, keyState] : state.keyEvents) {
+            if (keyState == 1)
+                ++pressed;
+            else if (keyState == 0)
+                ++released;
+        }
+        clientLog("{} {}", pressed, released);
+    } else if (req.starts_with("exit"))
         shouldExit = true;
 }
 

--- a/hyprtester/src/tests/clients/keyboard-modifiers.cpp
+++ b/hyprtester/src/tests/clients/keyboard-modifiers.cpp
@@ -9,7 +9,9 @@
 #include <optional>
 #include <sys/poll.h>
 #include <csignal>
+#include <sstream>
 #include <thread>
+#include <utility>
 
 using namespace Hyprutils::OS;
 using namespace Hyprutils::Memory;
@@ -28,7 +30,9 @@ namespace {
         CClient();
         ~CClient();
         uint32_t getLockedMods();
-        pid_t    pid();
+        // total (pressCount, releaseCount) of wl_keyboard.key events this window has received
+        std::pair<uint32_t, uint32_t> getReceivedKeyCounts();
+        pid_t                         pid();
     };
 }
 
@@ -129,8 +133,35 @@ uint32_t CClient::getLockedMods() {
     } catch (...) { return 0; }
 }
 
+std::pair<uint32_t, uint32_t> CClient::getReceivedKeyCounts() {
+    std::string cmd = "keys\n";
+    if ((size_t)write(this->writeFd.get(), cmd.c_str(), cmd.length()) != cmd.length())
+        return {0, 0};
+
+    if (poll(&this->fds, 1, 1500) != 1 || !(this->fds.revents & POLLIN))
+        return {0, 0};
+    ssize_t bytesRead = read(this->fds.fd, this->readBuf.data(), 1023);
+    if (bytesRead == -1)
+        return {0, 0};
+
+    this->readBuf[bytesRead] = 0;
+    std::istringstream iss{std::string{this->readBuf.data()}};
+    uint32_t           pressed = 0, released = 0;
+    iss >> pressed >> released;
+    return {pressed, released};
+}
+
 pid_t CClient::pid() {
     return this->proc->pid();
+}
+
+// modifier index understood by hl.plugin.test.keybind (see eKeyboardModifierIndex in tests/main/keybinds.cpp)
+static constexpr uint32_t MOD_CTRL = 3;
+
+// inject a synthetic key press/release through the test plugin's virtual keyboard. `modifier` is the
+// modifier index reported as held while the event is processed (0 = none); `key` is the xkb keycode.
+static std::string keyCmd(bool pressed, uint32_t modifier, uint32_t key) {
+    return "/eval hl.plugin.test.keybind(" + std::to_string(pressed ? 1 : 0) + ", " + std::to_string(modifier) + ", " + std::to_string(key) + ")";
 }
 
 TEST_CASE(keyboardModifiersMergedOnFocus) {
@@ -159,4 +190,123 @@ TEST_CASE(keyboardModifiersMergedOnFocus) {
     const uint32_t locked = client->getLockedMods();
     NLog::log("{}Client reports locked mods: {}", Colors::BLUE, locked);
     EXPECT(locked, 18u);
+}
+
+// Regression: a Lua `pass` bound to a *modifier* keycode must forward BOTH the press and the release
+// to the target window. Before the back-fill fix in CKeybindManager, the press was forwarded but the
+// release was dropped (the modmask guard skips a modifier key on release unless the bind is tracked in
+// m_pressedSpecialBinds), leaving a key bound to a modifier (e.g. a push-to-talk key) latched "on" forever.
+TEST_CASE(luaPassForwardsModifierRelease) {
+    NLog::log("{}Testing Lua pass forwards a held modifier's release", Colors::GREEN);
+
+    std::optional<CClient> client;
+    try {
+        client.emplace();
+    } catch (...) { FAIL_TEST("Couldn't start the client"); }
+
+    OK(getFromSocket("/eval hl.bind('code:105', hl.dsp.pass({ window = 'class:keyboard-modifiers' }))"));
+
+    // drop keyboard focus so a dropped release cannot reach the recorder via normal event delivery -
+    // the recorder must only ever observe events that `pass` explicitly forwards to it.
+    OK(getFromSocket("/eval hl.plugin.test.nullfocus()"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    OK(getFromSocket(keyCmd(true, 0, 105)));         // press (modifier's own bit not yet applied)
+    OK(getFromSocket(keyCmd(false, MOD_CTRL, 105))); // release (Ctrl still applied)
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    const auto [pressed, released] = client->getReceivedKeyCounts();
+    EXPECT(pressed, 1u);
+    EXPECT(released, 1u); // 0 before the fix: the release is never forwarded
+
+    OK(getFromSocket("/eval hl.unbind('code:105')"));
+}
+
+// Guard against over-correction: a Lua `pass` on a *non-modifier* key (which already worked before the
+// fix, since the modmask guard does not skip non-modifier keys) must still forward both edges.
+TEST_CASE(luaPassForwardsNonModifierRelease) {
+    NLog::log("{}Testing Lua pass still forwards a non-modifier key's release", Colors::GREEN);
+
+    std::optional<CClient> client;
+    try {
+        client.emplace();
+    } catch (...) { FAIL_TEST("Couldn't start the client"); }
+
+    // keycode 31 is a normal (non-modifier) key; no modifier is held for either edge.
+    OK(getFromSocket("/eval hl.bind('code:31', hl.dsp.pass({ window = 'class:keyboard-modifiers' }))"));
+
+    OK(getFromSocket("/eval hl.plugin.test.nullfocus()"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    OK(getFromSocket(keyCmd(true, 0, 31)));
+    OK(getFromSocket(keyCmd(false, 0, 31)));
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    const auto [pressed, released] = client->getReceivedKeyCounts();
+    EXPECT(pressed, 1u);
+    EXPECT(released, 1u);
+
+    OK(getFromSocket("/eval hl.unbind('code:31')"));
+}
+
+// The fix is not pass-specific: every Lua dispatcher that marks itself special mid-dispatch via
+// releasePending benefits from the same back-fill. Exercise that path through `send_shortcut`, which
+// forwards a configured key ('a') to the target. Bound to a modifier keycode it has the identical
+// dropped-release bug before the fix.
+TEST_CASE(luaSendShortcutForwardsModifierRelease) {
+    NLog::log("{}Testing Lua send_shortcut forwards its release when bound to a modifier", Colors::GREEN);
+
+    std::optional<CClient> client;
+    try {
+        client.emplace();
+    } catch (...) { FAIL_TEST("Couldn't start the client"); }
+
+    OK(getFromSocket("/eval hl.bind('code:105', hl.dsp.send_shortcut({ mods = '', key = 'a', window = 'class:keyboard-modifiers' }))"));
+
+    OK(getFromSocket("/eval hl.plugin.test.nullfocus()"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    OK(getFromSocket(keyCmd(true, 0, 105)));
+    OK(getFromSocket(keyCmd(false, MOD_CTRL, 105)));
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    const auto [pressed, released] = client->getReceivedKeyCounts();
+    EXPECT(pressed, 1u);
+    EXPECT(released, 1u); // 0 before the fix: the shortcut key's release is never sent and it sticks down
+
+    OK(getFromSocket("/eval hl.unbind('code:105')"));
+}
+
+// Held-key path: while any other key stays down, m_pressedKeys never empties, so releasePending is not
+// reset between cycles and leaks into the next press. The `!SPECIALDISPATCHER` guard keeps the back-fill
+// and the top-of-loop add mutually exclusive there. Black-box check: each press/release cycle must still
+// forward exactly one press and one release - never zero (dropped) and never two (double-forwarded).
+TEST_CASE(luaPassModifierReleaseWithHeldKey) {
+    NLog::log("{}Testing Lua pass modifier release with an unrelated key held down", Colors::GREEN);
+
+    std::optional<CClient> client;
+    try {
+        client.emplace();
+    } catch (...) { FAIL_TEST("Couldn't start the client"); }
+
+    OK(getFromSocket("/eval hl.bind('code:105', hl.dsp.pass({ window = 'class:keyboard-modifiers' }))"));
+
+    OK(getFromSocket("/eval hl.plugin.test.nullfocus()"));
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // hold an unrelated, unbound key (keycode 40) down for the whole test so m_pressedKeys never empties
+    OK(getFromSocket(keyCmd(true, 0, 40)));
+
+    for (uint32_t i = 1; i <= 3; ++i) {
+        OK(getFromSocket(keyCmd(true, 0, 105)));
+        OK(getFromSocket(keyCmd(false, MOD_CTRL, 105)));
+        std::this_thread::sleep_for(std::chrono::milliseconds(40));
+
+        const auto [pressed, released] = client->getReceivedKeyCounts();
+        EXPECT(pressed, i);
+        EXPECT(released, i);
+    }
+
+    OK(getFromSocket(keyCmd(false, 0, 40))); // release the held key
+    OK(getFromSocket("/eval hl.unbind('code:105')"));
 }

--- a/hyprtester/src/tests/clients/keyboard-modifiers.cpp
+++ b/hyprtester/src/tests/clients/keyboard-modifiers.cpp
@@ -249,10 +249,9 @@ TEST_CASE(luaPassForwardsNonModifierRelease) {
     OK(getFromSocket("/eval hl.unbind('code:31')"));
 }
 
-// The fix is not pass-specific: every Lua dispatcher that marks itself special mid-dispatch via
-// releasePending benefits from the same back-fill. Exercise that path through `send_shortcut`, which
-// forwards a configured key ('a') to the target. Bound to a modifier keycode it has the identical
-// dropped-release bug before the fix.
+// The fix is not pass-specific: every Lua dispatcher that forwards an input edge mid-dispatch is tracked
+// for release the same way. Exercise that path through `send_shortcut`, which forwards a configured key
+// ('a') to the target. Bound to a modifier keycode it has the identical dropped-release bug before the fix.
 TEST_CASE(luaSendShortcutForwardsModifierRelease) {
     NLog::log("{}Testing Lua send_shortcut forwards its release when bound to a modifier", Colors::GREEN);
 
@@ -277,10 +276,10 @@ TEST_CASE(luaSendShortcutForwardsModifierRelease) {
     OK(getFromSocket("/eval hl.unbind('code:105')"));
 }
 
-// Held-key path: while any other key stays down, m_pressedKeys never empties, so releasePending is not
-// reset between cycles and leaks into the next press. The `!SPECIALDISPATCHER` guard keeps the back-fill
-// and the top-of-loop add mutually exclusive there. Black-box check: each press/release cycle must still
-// forward exactly one press and one release - never zero (dropped) and never two (double-forwarded).
+// Held-key path: a modifier `pass` bind must forward exactly one press and one release per cycle even while
+// another, unrelated key is held down for the whole test - guarding against any cross-cycle bookkeeping leak.
+// Black-box check: each press/release cycle increments the counts by exactly one - never zero (dropped) and
+// never two (double-forwarded).
 TEST_CASE(luaPassModifierReleaseWithHeldKey) {
     NLog::log("{}Testing Lua pass modifier release with an unrelated key held down", Colors::GREEN);
 

--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -185,7 +185,7 @@ static int dsp_pass(lua_State* L) {
         return Internal::dispatcherError(L, "hl.pass: window not found", WARN, C_NOTFOUND);
 
     if (g_pKeybindManager->m_currentKeybind)
-        g_pKeybindManager->m_currentKeybind->releasePending = true;
+        g_pKeybindManager->m_dispatchForwardedInput = true;
 
     return Internal::checkResult(L, CA::pass(PWINDOW));
 }
@@ -213,7 +213,7 @@ static int dsp_event(lua_State* L) {
 
 static int dsp_global(lua_State* L) {
     if (g_pKeybindManager->m_currentKeybind)
-        g_pKeybindManager->m_currentKeybind->releasePending = true;
+        g_pKeybindManager->m_dispatchForwardedInput = true;
 
     return Internal::checkResult(L, CA::global(lua_tostring(L, lua_upvalueindex(1))));
 }
@@ -411,7 +411,7 @@ static int dsp_sendShortcut(lua_State* L) {
     }
 
     if (g_pKeybindManager->m_currentKeybind)
-        g_pKeybindManager->m_currentKeybind->releasePending = true;
+        g_pKeybindManager->m_dispatchForwardedInput = true;
 
     return Internal::checkResult(L, CA::pass(modMask, *keycodeResult, window));
 }
@@ -676,14 +676,14 @@ static int dsp_denyFromGroup(lua_State* L) {
 
 static int dsp_mouseDrag(lua_State* L) {
     if (g_pKeybindManager->m_currentKeybind)
-        g_pKeybindManager->m_currentKeybind->releasePending = true;
+        g_pKeybindManager->m_dispatchForwardedInput = true;
 
     return Internal::checkResult(L, CA::mouse("movewindow"));
 }
 
 static int dsp_mouseResize(lua_State* L) {
     if (g_pKeybindManager->m_currentKeybind)
-        g_pKeybindManager->m_currentKeybind->releasePending = true;
+        g_pKeybindManager->m_dispatchForwardedInput = true;
 
     auto keepAspectRatio = Check::string(L, lua_upvalueindex(1));
     if (!keepAspectRatio)

--- a/src/config/lua/bindings/LuaBindingsDispatchers.cpp
+++ b/src/config/lua/bindings/LuaBindingsDispatchers.cpp
@@ -184,8 +184,7 @@ static int dsp_pass(lua_State* L) {
     if (!PWINDOW)
         return Internal::dispatcherError(L, "hl.pass: window not found", WARN, C_NOTFOUND);
 
-    if (g_pKeybindManager->m_currentKeybind)
-        g_pKeybindManager->m_dispatchForwardedInput = true;
+    g_pKeybindManager->trackForwardedInput();
 
     return Internal::checkResult(L, CA::pass(PWINDOW));
 }
@@ -212,8 +211,7 @@ static int dsp_event(lua_State* L) {
 }
 
 static int dsp_global(lua_State* L) {
-    if (g_pKeybindManager->m_currentKeybind)
-        g_pKeybindManager->m_dispatchForwardedInput = true;
+    g_pKeybindManager->trackForwardedInput();
 
     return Internal::checkResult(L, CA::global(lua_tostring(L, lua_upvalueindex(1))));
 }
@@ -410,8 +408,7 @@ static int dsp_sendShortcut(lua_State* L) {
             return Internal::dispatcherError(L, "send_shortcut: window not found", WARN, C_NOTFOUND);
     }
 
-    if (g_pKeybindManager->m_currentKeybind)
-        g_pKeybindManager->m_dispatchForwardedInput = true;
+    g_pKeybindManager->trackForwardedInput();
 
     return Internal::checkResult(L, CA::pass(modMask, *keycodeResult, window));
 }
@@ -675,15 +672,13 @@ static int dsp_denyFromGroup(lua_State* L) {
 }
 
 static int dsp_mouseDrag(lua_State* L) {
-    if (g_pKeybindManager->m_currentKeybind)
-        g_pKeybindManager->m_dispatchForwardedInput = true;
+    g_pKeybindManager->trackForwardedInput();
 
     return Internal::checkResult(L, CA::mouse("movewindow"));
 }
 
 static int dsp_mouseResize(lua_State* L) {
-    if (g_pKeybindManager->m_currentKeybind)
-        g_pKeybindManager->m_dispatchForwardedInput = true;
+    g_pKeybindManager->trackForwardedInput();
 
     auto keepAspectRatio = Check::string(L, lua_upvalueindex(1));
     if (!keepAspectRatio)

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -434,12 +434,6 @@ bool CKeybindManager::onKeyEvent(std::any event, SP<IKeyboard> pKeyboard) {
         shadowKeybinds();
     }
 
-    if (m_pressedKeys.empty()) {
-        for (const auto& k : m_keybinds) {
-            k->releasePending = false; // reset this flag once we don't press any keys to avoid stale
-        }
-    }
-
     return !suppressEvent && !mouseBindWasActive;
 }
 
@@ -635,8 +629,12 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
         if (PROTO::inputCapture->isCaptured() && !k->allowInputCapture)
             continue;
 
-        const bool SPECIALDISPATCHER = k->handler == "global" || k->handler == "pass" || k->handler == "sendshortcut" || k->handler == "mouse" || k->releasePending;
-        const bool SPECIALTRIGGERED  = std::ranges::find_if(m_pressedSpecialBinds, [&](const auto& other) { return other == k; }) != m_pressedSpecialBinds.end();
+        const bool SPECIALTRIGGERED = std::ranges::find_if(m_pressedSpecialBinds, [&](const auto& other) { return other == k; }) != m_pressedSpecialBinds.end();
+        // A bind is "special" if it forwards an input edge and so must release on key-up ignoring mods: a native
+        // special handler, or any bind currently tracked in m_pressedSpecialBinds (SPECIALTRIGGERED). The latter is
+        // how a Lua-wrapped dispatcher is recognized on its release pass - it gets back-filled into that vec right
+        // after it forwards input on press (see the dispatch loop below).
+        const bool SPECIALDISPATCHER = k->handler == "global" || k->handler == "pass" || k->handler == "sendshortcut" || k->handler == "mouse" || SPECIALTRIGGERED;
         const bool IGNORECONDITIONS =
             SPECIALDISPATCHER && !pressed && SPECIALTRIGGERED; // ignore mods. Pass, global dispatchers should be released immediately once the key is released.
 
@@ -779,19 +777,18 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
     }
 
     for (const auto& k : bindsHit) {
-        const bool SPECIALDISPATCHER = k->handler == "global" || k->handler == "pass" || k->handler == "sendshortcut" || k->handler == "mouse" || k->releasePending;
         const bool SPECIALTRIGGERED  = std::ranges::find_if(m_pressedSpecialBinds, [&](const auto& other) { return other == k; }) != m_pressedSpecialBinds.end();
+        const bool SPECIALDISPATCHER = k->handler == "global" || k->handler == "pass" || k->handler == "sendshortcut" || k->handler == "mouse" || SPECIALTRIGGERED;
 
         const auto DISPATCHER = m_dispatchers.find(k->mouse ? "mouse" : k->handler);
 
-        k->releasePending = false; // reset this flag if it's set
-        m_currentKeybind  = k;
+        m_currentKeybind = k;
 
         Hyprutils::Utils::CScopeGuard x([this] { m_currentKeybind.reset(); });
 
         if (SPECIALTRIGGERED && !pressed)
             std::erase_if(m_pressedSpecialBinds, [&](const auto& other) { return other == k; });
-        else if (SPECIALDISPATCHER && pressed)
+        else if (SPECIALDISPATCHER && pressed && !SPECIALTRIGGERED)
             m_pressedSpecialBinds.emplace_back(k);
 
         // Should never happen, as we check in the ConfigManager, but oh well
@@ -802,6 +799,7 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
             Log::logger->log(Log::DEBUG, "Keybind triggered, calling dispatcher ({}, {}, {}, {})", modmask, key.keyName, key.keysym, DISPATCHER->first);
 
             Config::Actions::state()->m_passPressed = sc<int>(pressed);
+            m_dispatchForwardedInput                = false; // a special dispatcher (incl. a Lua-wrapped one) sets this during the call below
 
             auto submapBefore = Config::Actions::state()->m_currentSubmap;
 
@@ -813,18 +811,15 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
 
             Config::Actions::state()->m_passPressed = -1;
 
-            // Back-fill m_pressedSpecialBinds for a bind that only became "special" mid-dispatch.
-            // Native special dispatchers (pass/global/sendshortcut/mouse) are known special up front, so the
-            // `else if (SPECIALDISPATCHER && pressed)` add above tracks them at press time. A Lua-wrapped dispatcher
-            // hides behind handler == "__lua" and instead sets k->releasePending from inside the dispatch call we
-            // just made - too late for that add to see it. Mirror the add here so SPECIALTRIGGERED, and thus
-            // IGNORECONDITIONS, holds on the release pass; otherwise the modmask guard in the selection loop skips
-            // the release of a modifier key and it never reaches the dispatcher.
-            // The two guards keep this mutually exclusive with the top-of-loop add (exactly one fires per press):
-            // !SPECIALDISPATCHER - if releasePending leaked from a prior cycle (a key held across the release skips
-            // the m_pressedKeys.empty() reset), the top-of-loop add already ran this iteration; !SPECIALTRIGGERED -
-            // don't re-add a bind that is already tracked.
-            if (pressed && k->releasePending && !SPECIALDISPATCHER && !SPECIALTRIGGERED)
+            // Back-fill m_pressedSpecialBinds for a bind that only revealed itself as special mid-dispatch.
+            // Native special dispatchers are known up front and were tracked by the top-of-loop add. A Lua bind
+            // hides behind handler == "__lua"; its wrapped pass/global/send_shortcut/mouse only sets
+            // m_dispatchForwardedInput from inside the call we just made - too late for that add to see it. Track it
+            // now so on the release pass SPECIALTRIGGERED (and thus the IGNORECONDITIONS mod-guard bypass) holds,
+            // exactly like a native bind; otherwise the modmask guard skips a modifier key's release and it is never
+            // forwarded. !SPECIALTRIGGERED keeps it idempotent; no leak guard is needed since m_dispatchForwardedInput
+            // is transient, reset just above before every dispatch.
+            if (pressed && m_dispatchForwardedInput && !SPECIALTRIGGERED)
                 m_pressedSpecialBinds.emplace_back(k);
 
             if (k->handler == "submap") {

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -813,6 +813,20 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
 
             Config::Actions::state()->m_passPressed = -1;
 
+            // Back-fill m_pressedSpecialBinds for a bind that only became "special" mid-dispatch.
+            // Native special dispatchers (pass/global/sendshortcut/mouse) are known special up front, so the
+            // `else if (SPECIALDISPATCHER && pressed)` add above tracks them at press time. A Lua-wrapped dispatcher
+            // hides behind handler == "__lua" and instead sets k->releasePending from inside the dispatch call we
+            // just made - too late for that add to see it. Mirror the add here so SPECIALTRIGGERED, and thus
+            // IGNORECONDITIONS, holds on the release pass; otherwise the modmask guard in the selection loop skips
+            // the release of a modifier key and it never reaches the dispatcher.
+            // The two guards keep this mutually exclusive with the top-of-loop add (exactly one fires per press):
+            // !SPECIALDISPATCHER - if releasePending leaked from a prior cycle (a key held across the release skips
+            // the m_pressedKeys.empty() reset), the top-of-loop add already ran this iteration; !SPECIALTRIGGERED -
+            // don't re-add a bind that is already tracked.
+            if (pressed && k->releasePending && !SPECIALDISPATCHER && !SPECIALTRIGGERED)
+                m_pressedSpecialBinds.emplace_back(k);
+
             if (k->handler == "submap") {
                 found = true; // don't process keybinds on submap change.
                 break;

--- a/src/managers/KeybindManager.cpp
+++ b/src/managers/KeybindManager.cpp
@@ -593,6 +593,20 @@ SSubmap CKeybindManager::getCurrentSubmap() {
     return SSubmap{.name = Config::Actions::state()->m_currentSubmap};
 }
 
+void CKeybindManager::trackForwardedInput() {
+    // Only meaningful mid-dispatch, on the press edge: the bind must be in m_pressedSpecialBinds when its release
+    // event arrives so the selection loop's IGNORECONDITIONS bypasses the modmask guard. The release edge runs
+    // through the dispatch loop's erase instead, so ignore it here (else this would re-add after that erase).
+    if (!m_currentKeybind || Config::Actions::state()->m_passPressed != 1)
+        return;
+
+    // idempotent: a nested hl.dispatch can reach the same bind twice within one press
+    if (std::ranges::find_if(m_pressedSpecialBinds, [&](const auto& other) { return other == m_currentKeybind; }) != m_pressedSpecialBinds.end())
+        return;
+
+    m_pressedSpecialBinds.emplace_back(m_currentKeybind);
+}
+
 SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SPressedKeyWithMods& key, bool pressed, SP<IKeyboard> keyboard, SP<IHID> device) {
     static auto     PDISABLEINHIBIT = CConfigValue<Config::INTEGER>("binds:disable_keybind_grabbing");
     static auto     PDRAGTHRESHOLD  = CConfigValue<Config::INTEGER>("binds:drag_threshold");
@@ -799,7 +813,6 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
             Log::logger->log(Log::DEBUG, "Keybind triggered, calling dispatcher ({}, {}, {}, {})", modmask, key.keyName, key.keysym, DISPATCHER->first);
 
             Config::Actions::state()->m_passPressed = sc<int>(pressed);
-            m_dispatchForwardedInput                = false; // a special dispatcher (incl. a Lua-wrapped one) sets this during the call below
 
             auto submapBefore = Config::Actions::state()->m_currentSubmap;
 
@@ -810,17 +823,6 @@ SDispatchResult CKeybindManager::handleKeybinds(const uint32_t modmask, const SP
                 res = DISPATCHER->second(k->arg);
 
             Config::Actions::state()->m_passPressed = -1;
-
-            // Back-fill m_pressedSpecialBinds for a bind that only revealed itself as special mid-dispatch.
-            // Native special dispatchers are known up front and were tracked by the top-of-loop add. A Lua bind
-            // hides behind handler == "__lua"; its wrapped pass/global/send_shortcut/mouse only sets
-            // m_dispatchForwardedInput from inside the call we just made - too late for that add to see it. Track it
-            // now so on the release pass SPECIALTRIGGERED (and thus the IGNORECONDITIONS mod-guard bypass) holds,
-            // exactly like a native bind; otherwise the modmask guard skips a modifier key's release and it is never
-            // forwarded. !SPECIALTRIGGERED keeps it idempotent; no leak guard is needed since m_dispatchForwardedInput
-            // is transient, reset just above before every dispatch.
-            if (pressed && m_dispatchForwardedInput && !SPECIALTRIGGERED)
-                m_pressedSpecialBinds.emplace_back(k);
 
             if (k->handler == "submap") {
                 found = true; // don't process keybinds on submap change.

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -65,8 +65,7 @@ struct SKeybind {
     std::string                     displayKey = "";
 
     // DO NOT INITIALIZE
-    bool shadowed       = false;
-    bool releasePending = false;
+    bool shadowed = false;
 };
 
 enum eFocusWindowMode : uint8_t {
@@ -141,6 +140,13 @@ class CKeybindManager {
     std::vector<SP<SKeybind>>                                                    m_keybinds;
 
     SP<SKeybind>                                                                 m_currentKeybind;
+
+    // Set by a special dispatcher (pass/global/send_shortcut/mouse drag+resize) while it runs, to signal that
+    // the current keybind forwarded an input edge and so must be released on key-up regardless of modifier
+    // state. Transient: cleared right before every dispatch in handleKeybinds and consumed immediately after, so
+    // it never persists across key events. Lets a Lua-wrapped special dispatcher (handler == "__lua") be tracked
+    // for release exactly like a native one, including when reached indirectly via hl.dispatch.
+    bool m_dispatchForwardedInput = false;
 
     //since we can't find keycode through keyname in xkb:
     //on sendshortcut call, we once search for keyname (e.g. "g") the correct keycode (e.g. 42)

--- a/src/managers/KeybindManager.hpp
+++ b/src/managers/KeybindManager.hpp
@@ -141,12 +141,12 @@ class CKeybindManager {
 
     SP<SKeybind>                                                                 m_currentKeybind;
 
-    // Set by a special dispatcher (pass/global/send_shortcut/mouse drag+resize) while it runs, to signal that
-    // the current keybind forwarded an input edge and so must be released on key-up regardless of modifier
-    // state. Transient: cleared right before every dispatch in handleKeybinds and consumed immediately after, so
-    // it never persists across key events. Lets a Lua-wrapped special dispatcher (handler == "__lua") be tracked
-    // for release exactly like a native one, including when reached indirectly via hl.dispatch.
-    bool m_dispatchForwardedInput = false;
+    // Called by a special dispatcher (pass/global/send_shortcut/mouse drag+resize) while it runs to declare that
+    // the current keybind forwarded an input edge, and so must be released on key-up regardless of modifier state.
+    // Records m_currentKeybind in m_pressedSpecialBinds itself, so a Lua-wrapped dispatcher (handler == "__lua") is
+    // tracked for release exactly like a native one - including when reached indirectly via hl.dispatch. No-op off
+    // the press edge (the release edge is consumed by the dispatch loop) and idempotent if already tracked.
+    void trackForwardedInput();
 
     //since we can't find keycode through keyname in xkb:
     //on sendshortcut call, we once search for keyname (e.g. "g") the correct keycode (e.g. 42)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This attempts to fix https://github.com/hyprwm/Hyprland/discussions/14417, where the `hl.dsp.pass` dispatcher does not function the same as the previous native `pass` dispatcher. e.g., 

```
# Original hyprlang .conf bind (working, with Discord started with `ELECTRON_OZONE_PLATFORM_HINT= uwsm app -- discord`)
# code:105 from wev key code number for Control_R
bind = , code:105, pass, class:^(discord)$

# Original Lua bind (not working, ought to be direct translation):
local D = hl.dsp
hl.bind("code:105", D.pass({ window = "class:^(discord)$" }))
```

In practice, this has manifested for me personally as the Push-to-talk _activating_, but never deactivating. So, PRESSED, but not RELEASED.

There are actually two fixes implemented here that I want to discuss which is preferred (or neither):

Commit 1 (9cbf8501e023613ca8512734ee87cb385b747212)

* Just hook into the existing `k->releasePending` machinery by backfilling `m_pressedSpecialBinds`
* Kinda detect the bug, then backfill as if it was special the whole time. Kinda hacky.

Commit 2 (ce1d603144c71f91b4ef7daae6afcd22e9fd8ba8)

* Fix the root cause by detecting the special bind _at bind time_ and handle it like the currently native special dispatchers.
* Ignores nested uses. e.g., `hl.bind("x", function() hl.dispatch(hl.dsp.pass(...)) end)`. Feature?
* This isn't really a _problem_ but I would prefer not matching on C pointers to identify the functions. An alternative would be to add a flag or some other field on `SDispatcherRef`. This is easy to add, if desired.

Oh, and I added some tests in Commit 1 - even if we go with the approach from Commit 2, they're useful. 

Commit 1 is narrower but hackier. Following the logic is difficult.

Commit 2 is a broader change but more aligned with how the prior generation of special dispatchers worked. I much prefer this version, but maybe I'm missing something and there is a good reason it was first implemented with `k->releasePending`.

##### Root Cause

[SPECIALDISPATCHER](https://github.com/hyprwm/Hyprland/blob/5a7078d20a14bb199ef9bb81faa4faeaf5e92117/src/managers/KeybindManager.cpp#L633) special cases several bind dispatchers. When the bind is in lua, the handler is `__lua`, not `pass` (as an example). The current code attempts to fix this by setting `releasePending` in the special dispatcher lua binding (e.g., [dsp_pass](https://github.com/hyprwm/Hyprland/blob/5a7078d20a14bb199ef9bb81faa4faeaf5e92117/src/config/lua/bindings/LuaBindingsDispatchers.cpp#L184-L185)). But, if I'm reading this correctly, the [DISPATCHER](https://github.com/hyprwm/Hyprland/blob/5a7078d20a14bb199ef9bb81faa4faeaf5e92117/src/managers/KeybindManager.cpp#L780) isn't called [until deep inside the loop](https://github.com/hyprwm/Hyprland/blob/5a7078d20a14bb199ef9bb81faa4faeaf5e92117/src/managers/KeybindManager.cpp#L802-L805), well after the SPECIALDISPATCHER is computed.

More succinctly, we check a condition at the top of the loop, but the condition variable is set INSIDE the dispatcher after that check is made.

#### Is it ready for merging, or does it need work?

Man, to quote [last time](https://github.com/hyprwm/Hyprland/pull/13590) (PR unrelated):

> I'm not 100% sure. I'm not 100% sure how to test this. I have read the [dev setup](https://wiki.hypr.land/Contributing-and-Debugging/) but I'm not sure how to test multiple monitors in the dev setup (and the easiest way to reproduce involves violating the suggestions of "don't use exec-once") nor how to run my branch on an actual login session on my computer.

Alright, it's not about multiple monitors this time but it does involve running discord inside an XWAYLAND session inside a debug build and I don't have confidence that that layering will be indicative one way or another. If there was a convenient way to restart my login session with the debug build, I'd do that.

##### AI Disclosure

I used Claude, particularly for the root causing, but gave it instructions on solutions. I have taken the time to understand the root cause and both solutions. I am a human writing this PR and you will only engage with me, a real human bean.