### PR TITLE
fix: add missing event ("workspace.special_active") from know events lists 

### DIFF
--- a/src/config/lua/LuaEventHandler.cpp
+++ b/src/config/lua/LuaEventHandler.cpp
@@ -276,6 +276,7 @@ std::unordered_set<std::string> CLuaEventHandler::knownEvents() {
         "monitor.focused",
         "monitor.layout_changed",
         "workspace.active",
+        "workspace.special_active",
         "workspace.created",
         "workspace.removed",
         "workspace.move_to_monitor",


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
It adds a missing event ("workspace.special_active") from the know events list. All the code is there for this events, but it's missing from the knowEvents list, so it's treated has an invalid event name even tho it's implemented and in the documentation.  

Fixes this error from hyprland when trying to register `workspace.special_active` as an event:

```bash
 hl.on: unknown event "workspace.special_active". Known events:hyprland.start, config.reloaded, workspace.active, monitor.layout_changed, hyprland.shutdown, workspace.move_to_monitor, monitor.removed, monitor.added, keybinds.submap, layer.opened, window.open, window.open_early, window.urgent, monitor.focused, window.close, layer.closed, window.destroy, screenshare.state, workspace.removed, workspace.created, window.kill, window.active, window.pin, window.title, window.fullscreen, window.class, window.update_rules, window.move_to_workspace
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No, it's one line 

#### Is it ready for merging, or does it need work?
Yes

