### PR TITLE
config: fix layers slide animation directions

### DIFF
--- a/src/managers/animation/AnimationManager.cpp
+++ b/src/managers/animation/AnimationManager.cpp
@@ -428,7 +428,7 @@ std::string CHyprAnimationManager::styleValidInConfigVar(const std::string& conf
             return "";
         return "unknown style";
     } else if (config.starts_with("layers")) {
-        if (style.empty() || style == "fade" || style == "slide")
+        if (style.empty() || style == "fade" || style.starts_with("slide"))
             return "";
         else if (style.starts_with("popin")) {
             // try parsing


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes layers slide animation directions broken in #15208, which "fixed" some very [silly code](https://github.com/hyprwm/Hyprland/pull/15208/changes#diff-a9a6b1d55697fefe790ae4fd3a7dc0099fc396fe303e0a30d479fea37888e88aL447-L448) that was coincidentally making slide directions work. Now works with a bit more intent.

#### Is it ready for merging, or does it need work?

Ready.
