### PR TITLE
desktop/fadeout: extract bad logic, simplify fadeouts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -261,11 +261,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782035033,
-        "narHash": "sha256-pUtCphVzH1iNUTMGdJr4+e/yzUXA6/DZwsn+cyfIVJU=",
+        "lastModified": 1782639496,
+        "narHash": "sha256-mjt47Xun3jPcGrXpGpYU85lzUnqvJ2rXLbQjVI1yvLo=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "9d8bf6e810597152eef8906c670b96679af2faec",
+        "rev": "d2b40ffe7bfcb001bbf5888bb56ff646de53e7db",
         "type": "github"
       },
       "original": {

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1186,7 +1186,7 @@ void CCompositor::setWindowFullscreenState(const PHLWINDOW PWINDOW, Desktop::Vie
     // make all windows and layers on the same workspace under the fullscreen window
     for (auto const& w : Desktop::windowState()->windows()) {
         if (w->m_workspace == PWORKSPACE) {
-            if (!w->isFullscreen() && !w->m_fadingOut && !w->m_pinned)
+            if (!w->isFullscreen() && !w->m_pinned)
                 w->m_createdOverFullscreen = false;
 
             w->updateFullscreenInputState();

--- a/src/desktop/DesktopTypes.hpp
+++ b/src/desktop/DesktopTypes.hpp
@@ -10,6 +10,7 @@ namespace Desktop::View {
     class IView;
     class CWindow;
     class CLayerSurface;
+    class CPopup;
 }
 
 namespace Monitor {

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -596,7 +596,7 @@ bool CWorkspace::isPersistent() {
 void CWorkspace::setNoMembersAboveFullscreen() {
     // make all windows and layers on the same workspace under the fullscreen window
     for (auto const& w : Desktop::windowState()->windows()) {
-        if (w->m_workspace == m_self && !w->isFullscreen() && !w->m_fadingOut && !w->m_pinned)
+        if (w->m_workspace == m_self && !w->isFullscreen() && !w->m_pinned)
             w->m_createdOverFullscreen = false;
     }
     for (auto const& ls : Desktop::layerState()->layers()) {

--- a/src/desktop/state/Fadeout.cpp
+++ b/src/desktop/state/Fadeout.cpp
@@ -1,0 +1,16 @@
+#include "Fadeout.hpp"
+
+using namespace Desktop;
+using namespace Desktop::View;
+
+SP<Render::IFramebuffer> IFadeout::framebuffer() const {
+    return m_framebuffer;
+}
+
+PHLWORKSPACEREF IFadeout::workspace() const {
+    return m_workspace;
+}
+
+SFadeoutRenderEffects IFadeout::effects() const {
+    return m_effects;
+}

--- a/src/desktop/state/Fadeout.hpp
+++ b/src/desktop/state/Fadeout.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "../DesktopTypes.hpp"
+#include "../view/types/GeometricAnimated.hpp"
+#include "../../helpers/AnimatedVariable.hpp"
+#include "../../helpers/time/Time.hpp"
+
+#include <optional>
+
+namespace Render {
+    class IFramebuffer;
+}
+
+namespace Desktop {
+    enum eFadeoutPlane : uint8_t {
+        FADEOUT_PLANE_LAYER_BACKGROUND = 0,
+        FADEOUT_PLANE_LAYER_BOTTOM,
+        FADEOUT_PLANE_WINDOW_TILED,
+        FADEOUT_PLANE_WINDOW_FLOATING,
+        FADEOUT_PLANE_WINDOW_OVER_FULLSCREEN,
+        FADEOUT_PLANE_LAYER_TOP,
+        FADEOUT_PLANE_LAYER_OVERLAY,
+        FADEOUT_PLANE_POPUP,
+    };
+
+    struct SFadeoutPreBlur {
+        CBox  box;
+        int   round         = 0;
+        float roundingPower = 2.F;
+        bool  xray          = false;
+        float alpha         = 1.F;
+    };
+
+    struct SFadeoutTextureBlur {
+        bool                 enabled    = false;
+        float                alpha      = 1.F;
+        bool                 forceBlend = false;
+        std::optional<float> ignoreAlpha;
+        std::optional<bool>  blockBlurOptimization;
+    };
+
+    struct SFadeoutRenderEffects {
+        float                          dimAroundAlpha = 0.F;
+        std::optional<SFadeoutPreBlur> preBlur;
+        SFadeoutTextureBlur            textureBlur;
+    };
+
+    class IFadeout : public virtual View::CGeometricAnimated {
+      public:
+        virtual ~IFadeout() = default;
+
+        virtual PHLMONITORREF         monitor() const = 0;
+        PHLWORKSPACEREF               workspace() const;
+        virtual eFadeoutPlane         plane() const  = 0;
+        virtual int                   zIndex() const = 0;
+        SP<Render::IFramebuffer>      framebuffer() const;
+        virtual CBox                  renderBox() const = 0;
+        virtual float                 alpha() const     = 0;
+        virtual bool                  done() const      = 0;
+        virtual SFadeoutRenderEffects effects() const;
+
+      protected:
+        IFadeout() = default;
+
+        SP<Render::IFramebuffer> m_framebuffer;
+        PHLWORKSPACEREF          m_workspace;
+        SFadeoutRenderEffects    m_effects;
+    };
+}

--- a/src/desktop/state/FadingOutState.cpp
+++ b/src/desktop/state/FadingOutState.cpp
@@ -1,126 +1,36 @@
 #include "FadingOutState.hpp"
-#include "LayerState.hpp"
-#include "WindowState.hpp"
-#include "../view/LayerSurface.hpp"
-#include "../view/Window.hpp"
 #include "../../debug/log/Logger.hpp"
-#include "../../protocols/LayerShell.hpp"
-#include "../../state/MonitorState.hpp"
+#include "../../output/Monitor.hpp"
 
 #include <algorithm>
 
 using namespace Desktop;
 
-const std::vector<PHLWINDOWREF>& CFadingOutState::windows() const {
-    return m_windows;
+const std::vector<SP<IFadeout>>& CFadingOutState::fadeouts() const {
+    return m_fadeouts;
 }
 
-const std::vector<PHLLSREF>& CFadingOutState::layers() const {
-    return m_layers;
-}
-
-void CFadingOutState::add(PHLWINDOW w) {
-    const auto FOUND = std::ranges::find_if(m_windows, [&](PHLWINDOWREF& other) { return other.lock() == w; });
-
-    if (FOUND != m_windows.end())
+void CFadingOutState::add(SP<IFadeout> fadeout) {
+    if (!fadeout)
         return;
 
-    m_windows.emplace_back(w);
+    m_fadeouts.emplace_back(fadeout);
 }
 
-void CFadingOutState::add(PHLLS ls) {
-    const auto FOUND = std::ranges::find_if(m_layers, [&](auto& other) { return other.lock() == ls; });
-
-    if (FOUND != m_layers.end())
+void CFadingOutState::cleanupForMonitor(PHLMONITOR monitor) {
+    if (!monitor)
         return;
 
-    m_layers.emplace_back(ls);
-}
+    const auto SIZEBEFORE = m_fadeouts.size();
 
-void CFadingOutState::remove(PHLWINDOW w) {
-    std::erase_if(m_windows, [&w](const auto& el) { return el.lock() == w; });
-}
+    std::erase_if(m_fadeouts, [&](const auto& fadeout) { return !fadeout || fadeout->monitor().expired() || (fadeout->monitor() == monitor && fadeout->done()); });
 
-void CFadingOutState::remove(PHLLS ls) {
-    std::erase_if(m_layers, [&ls](const auto& el) { return el.lock() == ls; });
-}
-
-void CFadingOutState::cleanupForMonitor(const MONITORID& monid) {
-    for (auto const& ww : m_windows) {
-        auto w = ww.lock();
-
-        if (!w)
-            continue;
-
-        if (w->monitorID() != monid && w->m_monitor)
-            continue;
-
-        if (!w->m_fadingOut || w->alphaValue(View::WINDOW_ALPHA_FADE) == 0.f) {
-            w->m_fadingOut = false;
-
-            if (!w->m_readyToDelete)
-                continue;
-
-            windowState()->removeSafe(w);
-            remove(w);
-
-            w.reset();
-
-            Log::logger->log(Log::DEBUG, "Cleanup: destroyed a window");
-            return;
-        }
-    }
-
-    bool layersDirty = false;
-
-    for (auto const& lsr : m_layers) {
-        auto ls = lsr.lock();
-
-        if (!ls) {
-            layersDirty = true;
-            continue;
-        }
-
-        if (ls->monitorID() != monid && ls->m_monitor)
-            continue;
-
-        // mark blur for recalc
-        if (ls->m_layer == ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND || ls->m_layer == ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM) {
-            auto mon = State::monitorState()->query().id(monid).run();
-            if (mon)
-                mon->m_blurFBDirty = true;
-        }
-
-        if (ls->m_fadingOut && ls->m_readyToDelete && ls->isFadedOut()) {
-            for (auto const& m : State::monitorState()->monitors()) {
-                for (auto& lsl : m->m_layerSurfaceLayers) {
-                    if (!lsl.empty() && std::ranges::find_if(lsl, [&](auto& other) { return other == ls; }) != lsl.end())
-                        std::erase_if(lsl, [&](auto& other) { return other == ls || !other; });
-                }
-            }
-
-            remove(ls);
-            layerState()->removeSafe(ls);
-
-            ls.reset();
-
-            Log::logger->log(Log::DEBUG, "Cleanup: destroyed a layersurface");
-
-            return;
-        }
-    }
-
-    if (layersDirty)
-        removeExpiredLayers();
-}
-
-void CFadingOutState::removeExpiredLayers() {
-    std::erase_if(m_layers, [](const auto& el) { return el.expired(); });
+    if (SIZEBEFORE != m_fadeouts.size())
+        Log::logger->log(Log::DEBUG, "Cleanup: removed {} fadeouts", SIZEBEFORE - m_fadeouts.size());
 }
 
 void CFadingOutState::clear() {
-    m_windows.clear();
-    m_layers.clear();
+    m_fadeouts.clear();
 }
 
 UP<CFadingOutState>& Desktop::fadingOutState() {

--- a/src/desktop/state/FadingOutState.hpp
+++ b/src/desktop/state/FadingOutState.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../../SharedDefs.hpp"
+#include "Fadeout.hpp"
 #include "../../helpers/memory/Memory.hpp"
 #include "../DesktopTypes.hpp"
 
@@ -12,20 +12,14 @@ namespace Desktop {
         CFadingOutState()  = default;
         ~CFadingOutState() = default;
 
-        const std::vector<PHLWINDOWREF>& windows() const;
-        const std::vector<PHLLSREF>&     layers() const;
+        const std::vector<SP<IFadeout>>& fadeouts() const;
 
-        void                             add(PHLWINDOW w);
-        void                             add(PHLLS ls);
-        void                             remove(PHLWINDOW w);
-        void                             remove(PHLLS ls);
-        void                             cleanupForMonitor(const MONITORID& monid);
-        void                             removeExpiredLayers();
+        void                             add(SP<IFadeout> fadeout);
+        void                             cleanupForMonitor(PHLMONITOR monitor);
         void                             clear();
 
       private:
-        std::vector<PHLWINDOWREF> m_windows;
-        std::vector<PHLLSREF>     m_layers;
+        std::vector<SP<IFadeout>> m_fadeouts;
     };
 
     UP<CFadingOutState>& fadingOutState();

--- a/src/desktop/state/LayerFadeout.cpp
+++ b/src/desktop/state/LayerFadeout.cpp
@@ -1,0 +1,144 @@
+#include "LayerFadeout.hpp"
+#include "../view/LayerSurface.hpp"
+#include "../../config/ConfigValue.hpp"
+#include "../../config/shared/animation/AnimationTree.hpp"
+#include "../../managers/animation/AnimationManager.hpp"
+#include "../../output/Monitor.hpp"
+#include "../../protocols/LayerShell.hpp"
+#include "../../render/Framebuffer.hpp"
+#include "../../render/Renderer.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+using namespace Desktop;
+using namespace Desktop::View;
+
+static int layerZIndex(PHLLS layer) {
+    const auto MONITOR = layer ? layer->m_monitor.lock() : nullptr;
+    if (!MONITOR || layer->m_layer >= MONITOR->m_layerSurfaceLayers.size())
+        return 0;
+
+    const auto& LAYERS = MONITOR->m_layerSurfaceLayers[layer->m_layer];
+    const auto  IT     = std::ranges::find_if(LAYERS, [&](const auto& other) { return other.lock() == layer; });
+    return IT == LAYERS.end() ? 0 : std::distance(LAYERS.begin(), IT);
+}
+
+static bool shouldBlurLayer(PHLLS layer) {
+    static auto PBLUR = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
+    if (!*PBLUR)
+        return false;
+
+    auto surface = layer->wlSurface();
+    if (surface && surface->m_hasBackgroundEffect)
+        return !surface->m_blurRegion.empty();
+
+    return layer->m_ruleApplicator->blur().valueOrDefault();
+}
+
+static void damageFadeoutMonitor(PHLMONITORREF monitor) {
+    if (const auto MONITOR = monitor.lock(); MONITOR)
+        g_pHyprRenderer->damageMonitor(MONITOR);
+}
+
+SP<CLayerFadeout> CLayerFadeout::create(PHLLS layer, SP<Render::IFramebuffer> snapshot, float sourceAlpha) {
+    if (!layer || !snapshot)
+        return nullptr;
+
+    const auto MONITOR = layer->m_monitor.lock();
+    if (!MONITOR)
+        return nullptr;
+
+    auto fadeout           = SP<CLayerFadeout>(new CLayerFadeout());
+    fadeout->m_monitor     = MONITOR;
+    fadeout->m_framebuffer = snapshot;
+    fadeout->m_geometry    = layer->m_geometry;
+    fadeout->m_zIndex      = layerZIndex(layer);
+
+    static auto PDIMAROUND = CConfigValue<Config::FLOAT>("decoration:dim_around");
+    if (*PDIMAROUND && layer->m_ruleApplicator->dimAround().valueOrDefault())
+        fadeout->m_effects.dimAroundAlpha = *PDIMAROUND;
+
+    fadeout->m_effects.textureBlur.enabled = shouldBlurLayer(layer);
+    if (fadeout->m_effects.textureBlur.enabled)
+        fadeout->m_effects.textureBlur.ignoreAlpha = layer->m_ruleApplicator->ignoreAlpha().valueOr(0.01F);
+
+    switch (layer->m_layer) {
+        case ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND: fadeout->m_plane = FADEOUT_PLANE_LAYER_BACKGROUND; break;
+        case ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM: fadeout->m_plane = FADEOUT_PLANE_LAYER_BOTTOM; break;
+        case ZWLR_LAYER_SHELL_V1_LAYER_TOP: fadeout->m_plane = FADEOUT_PLANE_LAYER_TOP; break;
+        case ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY: fadeout->m_plane = FADEOUT_PLANE_LAYER_OVERLAY; break;
+        default: fadeout->m_plane = FADEOUT_PLANE_LAYER_TOP; break;
+    }
+
+    fadeout->m_marksBlurDirty = layer->m_layer == ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND || layer->m_layer == ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM;
+
+    g_pAnimationManager->createAnimation(layer->m_realPosition->begun(), fadeout->m_realPosition, Config::animationTree()->getAnimationPropertyConfig("layersOut"),
+                                         AVARDAMAGE_NONE);
+    g_pAnimationManager->createAnimation(layer->m_realSize->begun(), fadeout->m_realSize, Config::animationTree()->getAnimationPropertyConfig("layersOut"), AVARDAMAGE_NONE);
+    g_pAnimationManager->createAnimation(sourceAlpha, fadeout->m_alpha, Config::animationTree()->getAnimationPropertyConfig("fadeLayersOut"), AVARDAMAGE_NONE);
+
+    const WP<CLayerFadeout> WEAK   = fadeout;
+    const auto              DAMAGE = [WEAK](auto) {
+        if (const auto FADEOUT = WEAK.lock(); FADEOUT) {
+            damageFadeoutMonitor(FADEOUT->m_monitor);
+            if (const auto MONITOR = FADEOUT->m_monitor.lock(); MONITOR && FADEOUT->m_marksBlurDirty)
+                MONITOR->m_blurFBDirty = true;
+        }
+    };
+    fadeout->m_realPosition->setUpdateCallback(DAMAGE);
+    fadeout->m_realSize->setUpdateCallback(DAMAGE);
+    fadeout->m_alpha->setUpdateCallback(DAMAGE);
+
+    fadeout->m_realPosition->setValueAndWarp(layer->m_realPosition->begun());
+    fadeout->m_realSize->setValueAndWarp(layer->m_realSize->begun());
+    fadeout->m_alpha->setValueAndWarp(sourceAlpha);
+
+    *fadeout->m_realPosition = layer->m_realPosition->goal();
+    *fadeout->m_realSize     = layer->m_realSize->goal();
+    *fadeout->m_alpha        = 0.F;
+
+    return fadeout;
+}
+
+PHLMONITORREF CLayerFadeout::monitor() const {
+    return m_monitor;
+}
+
+eFadeoutPlane CLayerFadeout::plane() const {
+    return m_plane;
+}
+
+int CLayerFadeout::zIndex() const {
+    return m_zIndex;
+}
+
+CBox CLayerFadeout::renderBox() const {
+    const auto MONITOR = m_monitor.lock();
+    if (!MONITOR || m_geometry.w == 0 || m_geometry.h == 0)
+        return {};
+
+    const Vector2D SCALE = {m_realSize->value().x / m_geometry.w, m_realSize->value().y / m_geometry.h};
+
+    return {((m_realPosition->value().x - MONITOR->m_position.x) * MONITOR->m_scale) - (((m_geometry.x - MONITOR->m_position.x) * MONITOR->m_scale) * SCALE.x),
+            ((m_realPosition->value().y - MONITOR->m_position.y) * MONITOR->m_scale) - (((m_geometry.y - MONITOR->m_position.y) * MONITOR->m_scale) * SCALE.y),
+            MONITOR->m_transformedSize.x * SCALE.x, MONITOR->m_transformedSize.y * SCALE.y};
+}
+
+float CLayerFadeout::alpha() const {
+    return m_alpha->value();
+}
+
+bool CLayerFadeout::done() const {
+    return m_alpha->value() == 0.F && !m_alpha->isBeingAnimated() && !m_realPosition->isBeingAnimated() && !m_realSize->isBeingAnimated();
+}
+
+SFadeoutRenderEffects CLayerFadeout::effects() const {
+    auto effects = m_effects;
+    effects.dimAroundAlpha *= alpha();
+
+    if (effects.textureBlur.enabled)
+        effects.textureBlur.alpha = std::sqrt(std::max(alpha(), 0.F));
+
+    return effects;
+}

--- a/src/desktop/state/LayerFadeout.hpp
+++ b/src/desktop/state/LayerFadeout.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "Fadeout.hpp"
+
+namespace Desktop {
+    class CLayerFadeout final : public IFadeout {
+      public:
+        static SP<CLayerFadeout>      create(PHLLS layer, SP<Render::IFramebuffer> snapshot, float sourceAlpha);
+
+        virtual PHLMONITORREF         monitor() const override;
+        virtual eFadeoutPlane         plane() const override;
+        virtual int                   zIndex() const override;
+        virtual CBox                  renderBox() const override;
+        virtual float                 alpha() const override;
+        virtual bool                  done() const override;
+        virtual SFadeoutRenderEffects effects() const override;
+
+      private:
+        CLayerFadeout() = default;
+
+        PHLMONITORREF     m_monitor;
+        eFadeoutPlane     m_plane  = FADEOUT_PLANE_LAYER_TOP;
+        int               m_zIndex = 0;
+        CBox              m_geometry;
+        PHLANIMVAR<float> m_alpha;
+        bool              m_marksBlurDirty = false;
+    };
+}

--- a/src/desktop/state/PopupFadeout.cpp
+++ b/src/desktop/state/PopupFadeout.cpp
@@ -1,0 +1,101 @@
+#include "PopupFadeout.hpp"
+#include "../view/LayerSurface.hpp"
+#include "../view/Popup.hpp"
+#include "../../config/ConfigValue.hpp"
+#include "../../config/shared/animation/AnimationTree.hpp"
+#include "../../managers/animation/AnimationManager.hpp"
+#include "../../output/Monitor.hpp"
+#include "../../render/Framebuffer.hpp"
+#include "../../render/Renderer.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+using namespace Desktop;
+using namespace Desktop::View;
+
+static bool shouldBlurPopup() {
+    static CConfigValue PBLURPOPUPS = CConfigValue<Config::INTEGER>("decoration:blur:popups");
+    static CConfigValue PBLUR       = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
+
+    return *PBLURPOPUPS && *PBLUR;
+}
+
+static void damageFadeoutMonitor(PHLMONITORREF monitor) {
+    if (const auto MONITOR = monitor.lock(); MONITOR)
+        g_pHyprRenderer->damageMonitor(MONITOR);
+}
+
+template <typename T>
+static void damageWeakFadeout(WP<T> fadeout) {
+    if (const auto FADEOUT = fadeout.lock(); FADEOUT)
+        damageFadeoutMonitor(FADEOUT->monitor());
+}
+
+SP<CPopupFadeout> CPopupFadeout::create(SP<CPopup> popup, SP<Render::IFramebuffer> snapshot, float sourceAlpha) {
+    if (!popup || !snapshot)
+        return nullptr;
+
+    const auto MONITOR = popup->getMonitor();
+    if (!MONITOR)
+        return nullptr;
+
+    auto fadeout           = SP<CPopupFadeout>(new CPopupFadeout());
+    fadeout->m_monitor     = MONITOR;
+    fadeout->m_framebuffer = snapshot;
+
+    static CConfigValue PBLURIGNOREA = CConfigValue<Config::FLOAT>("decoration:blur:popups_ignorealpha");
+    if (shouldBlurPopup()) {
+        fadeout->m_effects.textureBlur.enabled               = true;
+        fadeout->m_effects.textureBlur.blockBlurOptimization = true;
+
+        if (const auto PLAYER = popup->layerOwner(); PLAYER && PLAYER->m_ruleApplicator->ignoreAlpha().hasValue())
+            fadeout->m_effects.textureBlur.ignoreAlpha = std::max(PLAYER->m_ruleApplicator->ignoreAlpha().valueOrDefault(), 0.01F);
+        else
+            fadeout->m_effects.textureBlur.ignoreAlpha = std::max(*PBLURIGNOREA, 0.01F);
+    }
+
+    g_pAnimationManager->createAnimation(Vector2D{}, fadeout->m_realPosition, Config::animationTree()->getAnimationPropertyConfig("fadePopupsOut"), AVARDAMAGE_NONE);
+    g_pAnimationManager->createAnimation(MONITOR->m_transformedSize, fadeout->m_realSize, Config::animationTree()->getAnimationPropertyConfig("fadePopupsOut"), AVARDAMAGE_NONE);
+    g_pAnimationManager->createAnimation(sourceAlpha, fadeout->m_alpha, Config::animationTree()->getAnimationPropertyConfig("fadePopupsOut"), AVARDAMAGE_NONE);
+    const WP<CPopupFadeout> WEAK = fadeout;
+    fadeout->m_alpha->setUpdateCallback([WEAK](auto) { damageWeakFadeout(WEAK); });
+    fadeout->m_alpha->setValueAndWarp(sourceAlpha);
+    *fadeout->m_alpha = 0.F;
+
+    return fadeout;
+}
+
+PHLMONITORREF CPopupFadeout::monitor() const {
+    return m_monitor;
+}
+
+eFadeoutPlane CPopupFadeout::plane() const {
+    return FADEOUT_PLANE_POPUP;
+}
+
+int CPopupFadeout::zIndex() const {
+    return m_zIndex;
+}
+
+CBox CPopupFadeout::renderBox() const {
+    const auto MONITOR = m_monitor.lock();
+    return MONITOR ? CBox{{}, MONITOR->m_transformedSize} : CBox{};
+}
+
+float CPopupFadeout::alpha() const {
+    return m_alpha->value();
+}
+
+bool CPopupFadeout::done() const {
+    return m_alpha->value() == 0.F && !m_alpha->isBeingAnimated();
+}
+
+SFadeoutRenderEffects CPopupFadeout::effects() const {
+    auto effects = m_effects;
+
+    if (effects.textureBlur.enabled)
+        effects.textureBlur.alpha = std::sqrt(std::max(alpha(), 0.F));
+
+    return effects;
+}

--- a/src/desktop/state/PopupFadeout.hpp
+++ b/src/desktop/state/PopupFadeout.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Fadeout.hpp"
+
+namespace Desktop {
+    class CPopupFadeout final : public IFadeout {
+      public:
+        static SP<CPopupFadeout>      create(SP<View::CPopup> popup, SP<Render::IFramebuffer> snapshot, float sourceAlpha);
+
+        virtual PHLMONITORREF         monitor() const override;
+        virtual eFadeoutPlane         plane() const override;
+        virtual int                   zIndex() const override;
+        virtual CBox                  renderBox() const override;
+        virtual float                 alpha() const override;
+        virtual bool                  done() const override;
+        virtual SFadeoutRenderEffects effects() const override;
+
+      private:
+        CPopupFadeout() = default;
+
+        PHLMONITORREF     m_monitor;
+        int               m_zIndex = 0;
+        PHLANIMVAR<float> m_alpha;
+    };
+}

--- a/src/desktop/state/WindowFadeout.cpp
+++ b/src/desktop/state/WindowFadeout.cpp
@@ -1,0 +1,145 @@
+#include "WindowFadeout.hpp"
+#include "WindowState.hpp"
+#include "../view/Window.hpp"
+#include "../Workspace.hpp"
+#include "../../config/ConfigValue.hpp"
+#include "../../config/shared/animation/AnimationTree.hpp"
+#include "../../managers/animation/AnimationManager.hpp"
+#include "../../output/Monitor.hpp"
+#include "../../render/Framebuffer.hpp"
+#include "../../render/Renderer.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+using namespace Desktop;
+using namespace Desktop::View;
+
+static int windowZIndex(PHLWINDOW window) {
+    const auto& WINDOWS = windowState()->windows();
+    const auto  IT      = std::ranges::find(WINDOWS, window);
+    return IT == WINDOWS.end() ? 0 : std::distance(WINDOWS.begin(), IT);
+}
+
+static bool shouldBlurWindow(PHLWINDOW window) {
+    static auto PBLUR = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
+    if (!*PBLUR)
+        return false;
+
+    if (window->m_ruleApplicator->noBlur().valueOrDefault() || window->m_ruleApplicator->RGBX().valueOrDefault() || window->opaque())
+        return false;
+
+    auto surface = window->wlSurface();
+    if (surface && surface->m_hasBackgroundEffect)
+        return !surface->m_blurRegion.empty();
+
+    return true;
+}
+
+static void damageFadeoutMonitor(PHLMONITORREF monitor) {
+    if (const auto MONITOR = monitor.lock(); MONITOR)
+        g_pHyprRenderer->damageMonitor(MONITOR);
+}
+
+template <typename T>
+static void damageWeakFadeout(WP<T> fadeout) {
+    if (const auto FADEOUT = fadeout.lock(); FADEOUT)
+        damageFadeoutMonitor(FADEOUT->monitor());
+}
+
+SP<CWindowFadeout> CWindowFadeout::create(PHLWINDOW window, SP<Render::IFramebuffer> snapshot, float sourceAlpha) {
+    if (!window || !snapshot)
+        return nullptr;
+
+    const auto MONITOR = window->m_monitor.lock();
+    if (!MONITOR)
+        return nullptr;
+
+    auto fadeout              = SP<CWindowFadeout>(new CWindowFadeout());
+    fadeout->m_monitor        = MONITOR;
+    fadeout->m_workspace      = window->m_workspace;
+    fadeout->m_framebuffer    = snapshot;
+    fadeout->m_zIndex         = windowZIndex(window);
+    fadeout->m_sourcePos      = window->m_realPosition->value() - MONITOR->m_position;
+    fadeout->m_sourceSize     = window->m_realSize->value();
+    const bool OVERFULLSCREEN = window->m_isFloating && window->shouldRenderOverFullscreen() && window->m_workspace && window->m_workspace->m_hasFullscreenWindow;
+    fadeout->m_plane          = !window->m_isFloating ? FADEOUT_PLANE_WINDOW_TILED : (OVERFULLSCREEN ? FADEOUT_PLANE_WINDOW_OVER_FULLSCREEN : FADEOUT_PLANE_WINDOW_FLOATING);
+    fadeout->m_rounding       = window->rounding();
+    fadeout->m_roundingPower  = window->roundingPower();
+    fadeout->m_blur           = shouldBlurWindow(window);
+    fadeout->m_blurXray       = window->m_ruleApplicator->xray().valueOr(false);
+
+    static auto PDIMAROUND = CConfigValue<Config::FLOAT>("decoration:dim_around");
+    if (*PDIMAROUND && window->m_ruleApplicator->dimAround().valueOrDefault())
+        fadeout->m_effects.dimAroundAlpha = *PDIMAROUND;
+
+    g_pAnimationManager->createAnimation(window->m_realPosition->begun(), fadeout->m_realPosition, Config::animationTree()->getAnimationPropertyConfig("windowsOut"),
+                                         AVARDAMAGE_NONE);
+    g_pAnimationManager->createAnimation(window->m_realSize->begun(), fadeout->m_realSize, Config::animationTree()->getAnimationPropertyConfig("windowsOut"), AVARDAMAGE_NONE);
+    g_pAnimationManager->createAnimation(sourceAlpha, fadeout->m_alpha, Config::animationTree()->getAnimationPropertyConfig("fadeOut"), AVARDAMAGE_NONE);
+
+    const WP<CWindowFadeout> WEAK = fadeout;
+    fadeout->m_realPosition->setUpdateCallback([WEAK](auto) { damageWeakFadeout(WEAK); });
+    fadeout->m_realSize->setUpdateCallback([WEAK](auto) { damageWeakFadeout(WEAK); });
+    fadeout->m_alpha->setUpdateCallback([WEAK](auto) { damageWeakFadeout(WEAK); });
+
+    fadeout->m_realPosition->setValueAndWarp(window->m_realPosition->begun());
+    fadeout->m_realSize->setValueAndWarp(window->m_realSize->begun());
+    fadeout->m_alpha->setValueAndWarp(sourceAlpha);
+
+    *fadeout->m_realPosition = window->m_realPosition->goal();
+    *fadeout->m_realSize     = window->m_realSize->goal();
+    *fadeout->m_alpha        = 0.F;
+
+    return fadeout;
+}
+
+PHLMONITORREF CWindowFadeout::monitor() const {
+    return m_monitor;
+}
+
+eFadeoutPlane CWindowFadeout::plane() const {
+    return m_plane;
+}
+
+int CWindowFadeout::zIndex() const {
+    return m_zIndex;
+}
+
+CBox CWindowFadeout::renderBox() const {
+    const auto MONITOR = m_monitor.lock();
+    if (!MONITOR || m_sourceSize.x == 0 || m_sourceSize.y == 0)
+        return {};
+
+    const Vector2D SCALE = {m_realSize->value().x / m_sourceSize.x, m_realSize->value().y / m_sourceSize.y};
+
+    return {((m_realPosition->value().x - MONITOR->m_position.x) * MONITOR->m_scale) - ((m_sourcePos.x * MONITOR->m_scale) * SCALE.x),
+            ((m_realPosition->value().y - MONITOR->m_position.y) * MONITOR->m_scale) - ((m_sourcePos.y * MONITOR->m_scale) * SCALE.y), MONITOR->m_transformedSize.x * SCALE.x,
+            MONITOR->m_transformedSize.y * SCALE.y};
+}
+
+float CWindowFadeout::alpha() const {
+    return m_alpha->value();
+}
+
+bool CWindowFadeout::done() const {
+    return m_alpha->value() == 0.F && !m_alpha->isBeingAnimated() && !m_realPosition->isBeingAnimated() && !m_realSize->isBeingAnimated();
+}
+
+SFadeoutRenderEffects CWindowFadeout::effects() const {
+    auto effects = m_effects;
+    effects.dimAroundAlpha *= alpha();
+
+    const auto MONITOR = m_monitor.lock();
+    if (m_blur && MONITOR) {
+        effects.preBlur = SFadeoutPreBlur{
+            .box           = CBox{m_realPosition->value(), m_realSize->value()}.translate(-MONITOR->m_position).scale(MONITOR->m_scale).round(),
+            .round         = m_rounding,
+            .roundingPower = m_roundingPower,
+            .xray          = m_blurXray,
+            .alpha         = std::sqrt(std::max(alpha(), 0.F)),
+        };
+    }
+
+    return effects;
+}

--- a/src/desktop/state/WindowFadeout.hpp
+++ b/src/desktop/state/WindowFadeout.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "Fadeout.hpp"
+
+namespace Desktop {
+    class CWindowFadeout final : public IFadeout {
+      public:
+        static SP<CWindowFadeout>     create(PHLWINDOW window, SP<Render::IFramebuffer> snapshot, float sourceAlpha);
+
+        virtual PHLMONITORREF         monitor() const override;
+        virtual eFadeoutPlane         plane() const override;
+        virtual int                   zIndex() const override;
+        virtual CBox                  renderBox() const override;
+        virtual float                 alpha() const override;
+        virtual bool                  done() const override;
+        virtual SFadeoutRenderEffects effects() const override;
+
+      private:
+        CWindowFadeout() = default;
+
+        PHLMONITORREF     m_monitor;
+        eFadeoutPlane     m_plane  = FADEOUT_PLANE_WINDOW_TILED;
+        int               m_zIndex = 0;
+        Vector2D          m_sourcePos;
+        Vector2D          m_sourceSize;
+        PHLANIMVAR<float> m_alpha;
+
+        bool              m_blur          = false;
+        bool              m_blurXray      = false;
+        int               m_rounding      = 0;
+        float             m_roundingPower = 2.F;
+    };
+}

--- a/src/desktop/view/LayerSurface.cpp
+++ b/src/desktop/view/LayerSurface.cpp
@@ -128,10 +128,6 @@ void CLayerSurface::onDestroy() {
     if (m_mapped) {
         Log::logger->log(Log::DEBUG, "Forcing an unmap of a LS that did a straight destroy!");
         onUnmap();
-    } else {
-        Log::logger->log(Log::DEBUG, "Removing LayerSurface that wasn't mapped.");
-        if (m_alpha)
-            g_pDesktopAnimationManager->startAnimation(m_self.lock(), CDesktopAnimationManager::ANIMATION_TYPE_OUT);
     }
 
     m_popupHead.reset();
@@ -148,7 +144,6 @@ void CLayerSurface::onDestroy() {
         g_pHyprRenderer->damageBox(geomFixed);
     }
 
-    Desktop::layerState()->removeSafe(SELF);
     m_layerSurface.reset();
     if (m_wlSurface)
         m_wlSurface->unassign();
@@ -157,6 +152,8 @@ void CLayerSurface::onDestroy() {
     m_listeners.destroy.reset();
     m_listeners.map.reset();
     m_listeners.commit.reset();
+
+    Desktop::layerState()->removeSafe(SELF);
 }
 
 void CLayerSurface::onMap() {

--- a/src/desktop/view/LayerSurface.cpp
+++ b/src/desktop/view/LayerSurface.cpp
@@ -1,5 +1,8 @@
 #include "LayerSurface.hpp"
 #include "../state/FocusState.hpp"
+#include "../state/FadingOutState.hpp"
+#include "../state/LayerState.hpp"
+#include "../state/LayerFadeout.hpp"
 #include "../../Compositor.hpp"
 #include "../../protocols/LayerShell.hpp"
 #include "../../protocols/core/Compositor.hpp"
@@ -95,7 +98,7 @@ eViewType CLayerSurface::type() const {
 }
 
 bool CLayerSurface::visible() const {
-    return (m_mapped && m_layerSurface && m_layerSurface->m_mapped && m_wlSurface && m_wlSurface->resource()) || (m_fadingOut && m_alpha->value() > 0.F);
+    return m_mapped && m_layerSurface && m_layerSurface->m_mapped && m_wlSurface && m_wlSurface->resource();
 }
 
 std::optional<CBox> CLayerSurface::logicalBox() const {
@@ -116,22 +119,19 @@ bool CLayerSurface::desktopComponent() const {
 void CLayerSurface::onDestroy() {
     Log::logger->log(Log::DEBUG, "LayerSurface {:x} destroyed", rc<uintptr_t>(m_layerSurface.get()));
 
+    const auto SELF     = m_self.lock();
     const auto PMONITOR = m_monitor.lock();
 
     if (!PMONITOR)
         Log::logger->log(Log::WARN, "Layersurface destroyed on an invalid monitor (removed?)");
 
-    if (!m_fadingOut) {
-        if (m_mapped) {
-            Log::logger->log(Log::DEBUG, "Forcing an unmap of a LS that did a straight destroy!");
-            onUnmap();
-        } else {
-            Log::logger->log(Log::DEBUG, "Removing LayerSurface that wasn't mapped.");
-            if (m_alpha)
-                g_pDesktopAnimationManager->startAnimation(m_self.lock(), CDesktopAnimationManager::ANIMATION_TYPE_OUT);
-            m_fadingOut = true;
-            Desktop::fadingOutState()->add(m_self.lock());
-        }
+    if (m_mapped) {
+        Log::logger->log(Log::DEBUG, "Forcing an unmap of a LS that did a straight destroy!");
+        onUnmap();
+    } else {
+        Log::logger->log(Log::DEBUG, "Removing LayerSurface that wasn't mapped.");
+        if (m_alpha)
+            g_pDesktopAnimationManager->startAnimation(m_self.lock(), CDesktopAnimationManager::ANIMATION_TYPE_OUT);
     }
 
     m_popupHead.reset();
@@ -148,7 +148,7 @@ void CLayerSurface::onDestroy() {
         g_pHyprRenderer->damageBox(geomFixed);
     }
 
-    m_readyToDelete = true;
+    Desktop::layerState()->removeSafe(SELF);
     m_layerSurface.reset();
     if (m_wlSurface)
         m_wlSurface->unassign();
@@ -169,10 +169,6 @@ void CLayerSurface::onMap() {
     m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_ALL);
 
     m_layerSurface->m_surface->map();
-
-    // this layer might be re-mapped.
-    m_fadingOut = false;
-    Desktop::fadingOutState()->remove(m_self.lock());
 
     // fix if it changed its mon
     const auto PMONITOR = m_monitor.lock();
@@ -216,9 +212,6 @@ void CLayerSurface::onMap() {
 
     g_pDesktopAnimationManager->startAnimation(m_self.lock(), CDesktopAnimationManager::ANIMATION_TYPE_IN);
 
-    m_readyToDelete = false;
-    m_fadingOut     = false;
-
     g_pEventManager->postEvent(SHyprIPCEvent{.event = "openlayer", .data = m_namespace});
     Event::bus()->m_events.layer.opened.emit(m_self.lock());
 
@@ -236,8 +229,6 @@ void CLayerSurface::onUnmap() {
     if (!m_monitor) {
         Log::logger->log(Log::WARN, "Layersurface unmapping on invalid monitor (removed?) ignoring.");
 
-        Desktop::fadingOutState()->add(m_self.lock());
-
         m_mapped = false;
         if (m_layerSurface && m_layerSurface->m_surface)
             m_layerSurface->m_surface->unmap();
@@ -251,17 +242,16 @@ void CLayerSurface::onUnmap() {
     m_realSize->warp();
 
     // make a snapshot and start fade
-    g_pHyprRenderer->makeSnapshot(m_self.lock());
+    const auto SNAPSHOT    = g_pHyprRenderer->makeSnapshotFB(m_self.lock());
+    const auto SOURCEALPHA = m_alpha->value();
 
     g_pDesktopAnimationManager->startAnimation(m_self.lock(), CDesktopAnimationManager::ANIMATION_TYPE_OUT);
 
-    m_fadingOut = true;
+    Desktop::fadingOutState()->add(CLayerFadeout::create(m_self.lock(), SNAPSHOT, SOURCEALPHA));
 
     m_mapped = false;
     if (m_layerSurface && m_layerSurface->m_surface)
         m_layerSurface->m_surface->unmap();
-
-    Desktop::fadingOutState()->add(m_self.lock());
 
     const auto PMONITOR = m_monitor.lock();
 
@@ -298,8 +288,7 @@ void CLayerSurface::onCommit() {
     if (!m_mapped) {
         // we're re-mapping if this is the case
         if (m_layerSurface->m_surface && !m_layerSurface->m_surface->m_current.texture) {
-            m_fadingOut = false;
-            m_geometry  = {};
+            m_geometry = {};
             g_pHyprRenderer->arrangeLayersForMonitor(monitorID());
         }
 
@@ -419,15 +408,8 @@ void CLayerSurface::onCommit() {
     updateSurfaceScaleTransformDetails();
 }
 
-bool CLayerSurface::isFadedOut() {
-    if (!m_fadingOut)
-        return false;
-
-    return !m_realPosition->isBeingAnimated() && !m_realSize->isBeingAnimated() && !m_alpha->isBeingAnimated();
-}
-
 int CLayerSurface::popupsCount() {
-    if (!m_layerSurface || !m_mapped || m_fadingOut || !m_popupHead)
+    if (!m_layerSurface || !m_mapped || !m_popupHead)
         return 0;
 
     return m_popupHead->popupTreeCount();

--- a/src/desktop/view/LayerSurface.hpp
+++ b/src/desktop/view/LayerSurface.hpp
@@ -30,7 +30,6 @@ namespace Desktop::View {
         virtual bool                desktopComponent() const;
         virtual std::optional<CBox> surfaceLogicalBox() const;
 
-        bool                        isFadedOut();
         int                         popupsCount();
 
         using CGeometricMovableAnimated::m_realPosition;
@@ -48,8 +47,6 @@ namespace Desktop::View {
 
         PHLMONITORREF                           m_monitor;
 
-        bool                                    m_fadingOut       = false;
-        bool                                    m_readyToDelete   = false;
         bool                                    m_noProcess       = false;
         bool                                    m_aboveFullscreen = true;
 
@@ -61,8 +58,6 @@ namespace Desktop::View {
         Vector2D                                m_position;
         std::string                             m_namespace = "";
         SP<Desktop::View::CPopup>               m_popupHead;
-
-        SP<Render::IFramebuffer>                m_snapshotFB;
 
         pid_t                                   getPID();
         void                                    updateSurfaceScaleTransformDetails();

--- a/src/desktop/view/Popup.cpp
+++ b/src/desktop/view/Popup.cpp
@@ -2,6 +2,8 @@
 #include "../../config/ConfigValue.hpp"
 #include "../../config/shared/animation/AnimationTree.hpp"
 #include "../../Compositor.hpp"
+#include "../state/FadingOutState.hpp"
+#include "../state/PopupFadeout.hpp"
 #include "../../protocols/LayerShell.hpp"
 #include "../../protocols/XDGShell.hpp"
 #include "../../protocols/core/Compositor.hpp"
@@ -74,9 +76,6 @@ eViewType CPopup::type() const {
 }
 
 bool CPopup::visible() const {
-    if (m_fadingOut && m_alpha->value() > 0.F)
-        return true;
-
     if (!m_mapped || !m_wlSurface->resource())
         return false;
 
@@ -185,11 +184,6 @@ void CPopup::onDestroy() {
     m_listeners.commit.reset();
     m_listeners.newPopup.reset();
 
-    if (m_fadingOut && m_alpha->isBeingAnimated()) {
-        Log::logger->log(Log::DEBUG, "popup {:x}: skipping full destroy, animating", rc<uintptr_t>(this));
-        return;
-    }
-
     fullyDestroy();
 }
 
@@ -272,12 +266,14 @@ void CPopup::onUnmap() {
 
     m_lastSize = MAX_DAMAGE_SIZE;
 
-    g_pHyprRenderer->makeSnapshot(m_self);
+    const auto SNAPSHOT    = g_pHyprRenderer->makeSnapshotFB(m_self);
+    const auto SOURCEALPHA = m_alpha->value();
 
-    m_fadingOut = true;
     m_alpha->setConfig(Config::animationTree()->getAnimationPropertyConfig("fadePopupsOut"));
     m_alpha->setValueAndWarp(1.F);
     *m_alpha = 0.F;
+
+    Desktop::fadingOutState()->add(CPopupFadeout::create(m_self.lock(), SNAPSHOT, SOURCEALPHA));
 
     m_mapped = false;
 

--- a/src/desktop/view/Popup.hpp
+++ b/src/desktop/view/Popup.hpp
@@ -67,10 +67,7 @@ namespace Desktop::View {
         bool                      m_mapped = false;
 
         // fade in-out
-        PHLANIMVAR<float>        m_alpha;
-        bool                     m_fadingOut = false;
-
-        SP<Render::IFramebuffer> m_snapshotFB;
+        PHLANIMVAR<float> m_alpha;
 
       private:
         CPopup();

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -2763,8 +2763,7 @@ void CWindow::destroyWindow() {
     m_listeners.map.reset();
     m_listeners.commit.reset();
 
-    Log::logger->log(Log::DEBUG, "Unmapped {} removed instantly", m_self.lock());
-    Desktop::windowState()->removeSafe(m_self.lock()); // most likely X11 unmanaged or sumn
+    Desktop::windowState()->removeSafe(m_self.lock());
 }
 
 void CWindow::activateX11() {

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -21,6 +21,8 @@
 #include "LayerSurface.hpp"
 #include "../state/FocusState.hpp"
 #include "../state/FloatState.hpp"
+#include "../state/FadingOutState.hpp"
+#include "../state/WindowFadeout.hpp"
 #include "../state/WindowState.hpp"
 #include "../history/WindowHistoryTracker.hpp"
 #include "../../Compositor.hpp"
@@ -212,7 +214,7 @@ eViewType CWindow::type() const {
 }
 
 bool CWindow::visible() const {
-    return !m_hidden && ((m_isMapped && m_wlSurface && m_wlSurface->resource()) || m_fadingOut) && visibleByAlpha();
+    return !m_hidden && m_isMapped && m_wlSurface && m_wlSurface->resource() && visibleByAlpha();
 }
 
 std::optional<CBox> CWindow::logicalBox() const {
@@ -228,9 +230,6 @@ std::optional<CBox> CWindow::surfaceLogicalBox() const {
 }
 
 SBoxExtents CWindow::getFullWindowExtents() const {
-    if (m_fadingOut)
-        return m_originalClosedExtents;
-
     const int BORDERSIZE = getRealBorderSize();
 
     if (m_ruleApplicator->dimAround().valueOrDefault()) {
@@ -284,7 +283,7 @@ CBox CWindow::getFullWindowBoundingBox() const {
 }
 
 bool CWindow::operator==(const CWindow& rhs) const {
-    return m_xdgSurface == rhs.m_xdgSurface && m_xwaylandSurface == rhs.m_xwaylandSurface && layoutBox() == rhs.layoutBox() && m_fadingOut == rhs.m_fadingOut;
+    return m_xdgSurface == rhs.m_xdgSurface && m_xwaylandSurface == rhs.m_xwaylandSurface && layoutBox() == rhs.layoutBox();
 }
 
 CBox CWindow::layoutBox() const {
@@ -1008,7 +1007,7 @@ bool CWindow::visibleByAlphaGoal() const {
 }
 
 bool CWindow::targetVisible() const {
-    return !m_hidden && ((m_isMapped && m_wlSurface && m_wlSurface->resource()) || m_fadingOut) && visibleByAlphaGoal();
+    return !m_hidden && m_isMapped && m_wlSurface && m_wlSurface->resource() && visibleByAlphaGoal();
 }
 
 // check if the point is "hidden" under a rounded corner of the window
@@ -2052,8 +2051,7 @@ void CWindow::mapWindow() {
     m_monitor       = PMONITOR;
     m_workspace     = PWORKSPACE;
     m_isMapped      = true;
-    m_readyToDelete = false;
-    m_fadingOut     = false;
+    m_animatingIn   = true;
     m_title         = fetchTitle();
     m_firstMap      = true;
     m_initialTitle  = m_title;
@@ -2533,16 +2531,10 @@ void CWindow::unmapWindow() {
 
     if (!wlSurface()->exists() || !m_isMapped) {
         Log::logger->log(Log::WARN, "{} unmapped without being mapped??", m_self.lock());
-        m_fadingOut = false;
         return;
     }
 
     const auto PMONITOR = m_monitor.lock();
-    if (PMONITOR) {
-        m_originalClosedPos     = m_realPosition->value() - PMONITOR->m_position;
-        m_originalClosedSize    = m_realSize->value();
-        m_originalClosedExtents = getFullWindowExtents();
-    }
 
     m_events.unmap.emit();
     g_pEventManager->postEvent(SHyprIPCEvent{"closewindow", std::format("{:x}", m_self.lock())});
@@ -2557,8 +2549,7 @@ void CWindow::unmapWindow() {
         g_pCompositor->setWindowFullscreenInternal(m_self.lock(), FSMODE_NONE);
 
     // Allow the renderer to catch the last frame.
-    if (g_pHyprRenderer->shouldRenderWindow(m_self.lock()))
-        g_pHyprRenderer->makeSnapshot(m_self.lock());
+    const auto SNAPSHOT = g_pHyprRenderer->shouldRenderWindow(m_self.lock()) ? g_pHyprRenderer->makeSnapshotFB(m_self.lock()) : nullptr;
 
     // swallowing
     if (const auto SWALLOWEE = m_swallowee.lock()) {
@@ -2667,15 +2658,15 @@ void CWindow::unmapWindow() {
         Log::logger->log(Log::DEBUG, "Unmapped was not focused, ignoring a refocus.");
     }
 
-    m_fadingOut = true;
-
-    Desktop::fadingOutState()->add(m_self.lock());
-
     if (!m_X11DoesntWantBorders)                                            // don't animate out if they weren't animated in.
         *m_realPosition = m_realPosition->value() + Vector2D(0.01f, 0.01f); // it has to be animated, otherwise CesktopAnimationManager will ignore it
 
+    const float FADEOUTALPHA = alphaValue(WINDOW_ALPHA_FADE) * alphaValue(WINDOW_ALPHA_FULLSCREEN) * alphaValue(WINDOW_ALPHA_LAYOUT);
+
     // anims
     g_pDesktopAnimationManager->startAnimation(m_self.lock(), CDesktopAnimationManager::ANIMATION_TYPE_OUT);
+
+    Desktop::fadingOutState()->add(CWindowFadeout::create(m_self.lock(), SNAPSHOT, FADEOUTALPHA));
 
     // recheck idle inhibitors
     g_pInputManager->recheckIdleInhibitorStatus();
@@ -2765,8 +2756,6 @@ void CWindow::destroyWindow() {
 
     g_layoutManager->removeTarget(m_target);
 
-    m_readyToDelete = true;
-
     m_xdgSurface.reset();
 
     m_listeners.unmap.reset();
@@ -2774,10 +2763,8 @@ void CWindow::destroyWindow() {
     m_listeners.map.reset();
     m_listeners.commit.reset();
 
-    if (!m_fadingOut) {
-        Log::logger->log(Log::DEBUG, "Unmapped {} removed instantly", m_self.lock());
-        Desktop::windowState()->removeSafe(m_self.lock()); // most likely X11 unmanaged or sumn
-    }
+    Log::logger->log(Log::DEBUG, "Unmapped {} removed instantly", m_self.lock());
+    Desktop::windowState()->removeSafe(m_self.lock()); // most likely X11 unmanaged or sumn
 }
 
 void CWindow::activateX11() {

--- a/src/desktop/view/Window.hpp
+++ b/src/desktop/view/Window.hpp
@@ -211,11 +211,6 @@ namespace Desktop::View {
 
         // Fade in-out
         Desktop::Types::CMultiAVarContainer<float, eWindowAlpha, WINDOW_ALPHA_LAST> m_alpha;
-        bool                                                                        m_fadingOut     = false;
-        bool                                                                        m_readyToDelete = false;
-        Vector2D                                                                    m_originalClosedPos;  // these will be used for calculations later on in
-        Vector2D                                                                    m_originalClosedSize; // drawing the closing animations
-        SBoxExtents                                                                 m_originalClosedExtents;
         bool                                                                        m_animatingIn = false;
 
         // For pinned (sticky) windows
@@ -279,9 +274,6 @@ namespace Desktop::View {
 
         // Stable ID for ext_foreign_toplevel_list
         const uint64_t m_stableID = 0x2137;
-
-        // snapshots
-        SP<Render::IFramebuffer> m_snapshotFB;
 
         // ANR
         PHLANIMVAR<float> m_notRespondingTint;

--- a/src/desktop/view/types/GeometricAnimated.cpp
+++ b/src/desktop/view/types/GeometricAnimated.cpp
@@ -31,3 +31,8 @@ CBox CGeometricAnimated::geometricBox(eGeometricValueType t) const {
 
     std::unreachable();
 }
+
+void CGeometricAnimated::finishAnimation() {
+    m_realPosition->warp();
+    m_realSize->warp();
+}

--- a/src/layout/LayoutManager.cpp
+++ b/src/layout/LayoutManager.cpp
@@ -227,7 +227,7 @@ void CLayoutManager::performSnap(Vector2D& sourcePos, Vector2D& sourceSize, SP<I
         const double GAPSY  = GAPSIN->m_top + GAPSIN->m_bottom;
 
         for (auto& other : Desktop::windowState()->windows()) {
-            if ((HASFULLSCREEN && !other->isAllowedOverFullscreen()) || other == DRAGGINGWINDOW || other->workspaceID() != WSID || !other->m_isMapped || other->m_fadingOut ||
+            if ((HASFULLSCREEN && !other->isAllowedOverFullscreen()) || other == DRAGGINGWINDOW || other->workspaceID() != WSID || !other->m_isMapped ||
                 other->isX11OverrideRedirect())
                 continue;
 

--- a/src/managers/animation/DesktopAnimationManager.cpp
+++ b/src/managers/animation/DesktopAnimationManager.cpp
@@ -476,7 +476,7 @@ void CDesktopAnimationManager::setFullscreenFadeAnimation(PHLWORKSPACE ws, eAnim
         if (w->m_workspace == ws) {
             w->updateFullscreenInputState();
 
-            if (w->m_fadingOut || w->m_pinned || w->isFullscreen())
+            if (w->m_pinned || w->isFullscreen())
                 continue;
 
             if (!FULLSCREEN)
@@ -493,14 +493,14 @@ void CDesktopAnimationManager::setFullscreenFadeAnimation(PHLWORKSPACE ws, eAnim
         const auto FSWINDOW = ws->getFullscreenWindow(true);
         const auto FSMODE   = FSWINDOW ? FSWINDOW->m_target->fullscreenMode() : ws->m_fullscreenMode;
         for (auto const& ls : PMONITOR->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]) {
-            if (!ls->m_fadingOut && !ls->m_aboveFullscreen)
+            if (!ls->m_aboveFullscreen)
                 *ls->m_alpha = FULLSCREEN && FSMODE != FSMODE_MAXIMIZED ? 0.f : 1.f;
         }
     }
 }
 
 void CDesktopAnimationManager::setFullscreenFloatingFade(PHLWINDOW pWindow, float fade) {
-    if (pWindow->m_fadingOut || !pWindow->m_isFloating)
+    if (!pWindow->m_isFloating)
         return;
 
     *pWindow->alpha(WINDOW_ALPHA_FULLSCREEN) = fade;
@@ -513,7 +513,7 @@ void CDesktopAnimationManager::overrideFullscreenFadeAmount(PHLWORKSPACE ws, flo
             continue;
 
         if (w->m_workspace == ws) {
-            if (w->m_fadingOut || w->m_pinned || w->isFullscreen())
+            if (w->m_pinned || w->isFullscreen())
                 continue;
 
             *w->alpha(WINDOW_ALPHA_FULLSCREEN) = fade;
@@ -525,8 +525,7 @@ void CDesktopAnimationManager::overrideFullscreenFadeAmount(PHLWORKSPACE ws, flo
 
     if (ws->m_id == PMONITOR->activeWorkspaceID() || ws->m_id == PMONITOR->activeSpecialWorkspaceID()) {
         for (auto const& ls : PMONITOR->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]) {
-            if (!ls->m_fadingOut)
-                *ls->m_alpha = fade;
+            *ls->m_alpha = fade;
         }
     }
 }

--- a/src/managers/input/trackpad/gestures/SpecialWorkspaceGesture.cpp
+++ b/src/managers/input/trackpad/gestures/SpecialWorkspaceGesture.cpp
@@ -61,8 +61,12 @@ void CSpecialWorkspaceGesture::begin(const ITrackpadGesture::STrackpadGestureBeg
     if (!m_specialWorkspace)
         return;
 
-    m_monitorDimFrom      = m_monitor->m_specialFade->begun();
-    m_monitorDimTo        = m_monitor->m_specialFade->goal();
+    m_monitorFadeFrom     = m_monitor->m_specialFade->begun();
+    m_monitorFadeTo       = m_monitor->m_specialFade->goal();
+    m_monitorDimFrom      = m_monitor->m_specialDim->begun();
+    m_monitorDimTo        = m_monitor->m_specialDim->goal();
+    m_monitorBlurFrom     = m_monitor->m_specialBlur->begun();
+    m_monitorBlurTo       = m_monitor->m_specialBlur->goal();
     m_workspaceAlphaFrom  = m_specialWorkspace->m_alpha->begun();
     m_workspaceAlphaTo    = m_specialWorkspace->m_alpha->goal();
     m_workspaceOffsetFrom = m_specialWorkspace->m_renderOffset->begun();
@@ -79,7 +83,9 @@ void CSpecialWorkspaceGesture::update(const ITrackpadGesture::STrackpadGestureUp
 
     const auto FADEPERCENT = m_animatingOut ? 1.F - std::clamp(m_lastDelta / MAX_DISTANCE, 0.F, 1.F) : std::clamp(m_lastDelta / MAX_DISTANCE, 0.F, 1.F);
 
-    m_monitor->m_specialFade->setValueAndWarp(lerpVal(m_monitorDimFrom, m_monitorDimTo, FADEPERCENT));
+    m_monitor->m_specialFade->setValueAndWarp(lerpVal(m_monitorFadeFrom, m_monitorFadeTo, FADEPERCENT));
+    m_monitor->m_specialDim->setValueAndWarp(lerpVal(m_monitorDimFrom, m_monitorDimTo, FADEPERCENT));
+    m_monitor->m_specialBlur->setValueAndWarp(lerpVal(m_monitorBlurFrom, m_monitorBlurTo, FADEPERCENT));
     m_specialWorkspace->m_alpha->setValueAndWarp(lerpVal(m_workspaceAlphaFrom, m_workspaceAlphaTo, FADEPERCENT));
     m_specialWorkspace->m_renderOffset->setValueAndWarp(lerpVal(m_workspaceOffsetFrom, m_workspaceOffsetTo, FADEPERCENT));
 }
@@ -98,7 +104,9 @@ void CSpecialWorkspaceGesture::end(const ITrackpadGesture::STrackpadGestureEnd& 
         if (m_animatingOut) {
             m_workspaceOffsetTo = m_workspaceOffsetFrom;
             m_workspaceAlphaTo  = m_workspaceAlphaFrom;
+            m_monitorFadeTo     = m_monitorFadeFrom;
             m_monitorDimTo      = m_monitorDimFrom;
+            m_monitorBlurTo     = m_monitorBlurFrom;
         }
     }
 
@@ -106,6 +114,8 @@ void CSpecialWorkspaceGesture::end(const ITrackpadGesture::STrackpadGestureEnd& 
         const auto CURR_WS_ALPHA  = m_specialWorkspace->m_alpha->value();
         const auto CURR_WS_OFFSET = m_specialWorkspace->m_renderOffset->value();
         const auto CURR_MON_FADE  = m_monitor->m_specialFade->value();
+        const auto CURR_MON_DIM   = m_monitor->m_specialDim->value();
+        const auto CURR_MON_BLUR  = m_monitor->m_specialBlur->value();
 
         m_monitor->setSpecialWorkspace(nullptr);
 
@@ -113,14 +123,20 @@ void CSpecialWorkspaceGesture::end(const ITrackpadGesture::STrackpadGestureEnd& 
         const auto GOAL_WS_OFFSET = m_specialWorkspace->m_renderOffset->goal();
 
         m_monitor->m_specialFade->setValueAndWarp(CURR_MON_FADE);
+        m_monitor->m_specialDim->setValueAndWarp(CURR_MON_DIM);
+        m_monitor->m_specialBlur->setValueAndWarp(CURR_MON_BLUR);
         m_specialWorkspace->m_alpha->setValueAndWarp(CURR_WS_ALPHA);
         m_specialWorkspace->m_renderOffset->setValueAndWarp(CURR_WS_OFFSET);
 
         *m_monitor->m_specialFade           = 0.F;
+        *m_monitor->m_specialDim            = 0.F;
+        *m_monitor->m_specialBlur           = 0.F;
         *m_specialWorkspace->m_alpha        = GOAL_WS_ALPHA;
         *m_specialWorkspace->m_renderOffset = GOAL_WS_OFFSET;
     } else {
-        *m_monitor->m_specialFade           = m_monitorDimTo;
+        *m_monitor->m_specialFade           = m_monitorFadeTo;
+        *m_monitor->m_specialDim            = m_monitorDimTo;
+        *m_monitor->m_specialBlur           = m_monitorBlurTo;
         *m_specialWorkspace->m_renderOffset = m_workspaceOffsetTo;
         *m_specialWorkspace->m_alpha        = m_workspaceAlphaTo;
     }

--- a/src/managers/input/trackpad/gestures/SpecialWorkspaceGesture.hpp
+++ b/src/managers/input/trackpad/gestures/SpecialWorkspaceGesture.hpp
@@ -21,7 +21,9 @@ class CSpecialWorkspaceGesture : public ITrackpadGesture {
     float         m_lastDelta    = 0.F;
 
     // animated properties, kinda sucks
+    float    m_monitorFadeFrom = 0.F, m_monitorFadeTo = 0.F;
     float    m_monitorDimFrom = 0.F, m_monitorDimTo = 0.F;
+    float    m_monitorBlurFrom = 0.F, m_monitorBlurTo = 0.F;
     float    m_workspaceAlphaFrom = 0.F, m_workspaceAlphaTo = 0.F;
     Vector2D m_workspaceOffsetFrom = {}, m_workspaceOffsetTo = {};
 };

--- a/src/managers/screenshare/ScreenshareFrame.cpp
+++ b/src/managers/screenshare/ScreenshareFrame.cpp
@@ -271,7 +271,7 @@ void CScreenshareFrame::renderMonitor() {
 
         const auto PWORKSPACE = w->m_workspace;
 
-        if UNLIKELY (!PWORKSPACE && !w->m_fadingOut && w->alphaValue(WINDOW_ALPHA_FADE) * w->alphaValue(WINDOW_ALPHA_FULLSCREEN) != 0.f)
+        if UNLIKELY (!PWORKSPACE && w->alphaValue(WINDOW_ALPHA_FADE) * w->alphaValue(WINDOW_ALPHA_FULLSCREEN) != 0.f)
             continue;
 
         const auto renderOffset     = PWORKSPACE && !w->m_pinned ? PWORKSPACE->m_renderOffset->value() : Vector2D{};

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -80,6 +80,10 @@ constexpr const char* drmFormatToString(uint32_t drmFormat) {
 CMonitor::CMonitor(SP<Aquamarine::IOutput> output_) : m_name(output_->name), m_state(this), m_output(output_), m_imageDescription(getDefaultImageDescription()) {
     g_pAnimationManager->createAnimation(0.f, m_specialFade, Config::animationTree()->getAnimationPropertyConfig("specialWorkspaceIn"), AVARDAMAGE_NONE);
     m_specialFade->setUpdateCallback([this](auto) { g_pHyprRenderer->damageMonitor(m_self.lock()); });
+    g_pAnimationManager->createAnimation(0.f, m_specialDim, Config::animationTree()->getAnimationPropertyConfig("specialWorkspaceIn"), AVARDAMAGE_NONE);
+    m_specialDim->setUpdateCallback([this](auto) { g_pHyprRenderer->damageMonitor(m_self.lock()); });
+    g_pAnimationManager->createAnimation(0.f, m_specialBlur, Config::animationTree()->getAnimationPropertyConfig("specialWorkspaceIn"), AVARDAMAGE_NONE);
+    m_specialBlur->setUpdateCallback([this](auto) { g_pHyprRenderer->damageMonitor(m_self.lock()); });
     static auto PZOOMFACTOR = CConfigValue<Config::FLOAT>("cursor:zoom_factor");
     g_pAnimationManager->createAnimation(*PZOOMFACTOR, m_cursorZoom, Config::animationTree()->getAnimationPropertyConfig("zoomFactor"), AVARDAMAGE_NONE);
     m_cursorZoom->setUpdateCallback([this](auto) { g_pHyprRenderer->damageMonitor(m_self.lock()); });
@@ -442,7 +446,7 @@ void CMonitor::onDisconnect(bool destroy) {
 
     for (size_t i = 0; i < 4; ++i) {
         for (auto const& ls : m_layerSurfaceLayers[i]) {
-            if (ls->m_layerSurface && !ls->m_fadingOut)
+            if (ls->m_layerSurface)
                 ls->m_layerSurface->sendClosed();
         }
         m_layerSurfaceLayers[i].clear();
@@ -1527,10 +1531,18 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace) {
     if (m_activeSpecialWorkspace == pWorkspace)
         return;
 
-    const auto POLDSPECIAL = m_activeSpecialWorkspace;
+    const auto  POLDSPECIAL = m_activeSpecialWorkspace;
+
+    static auto PDIMSPECIAL  = CConfigValue<Config::FLOAT>("decoration:dim_special");
+    static auto PBLURSPECIAL = CConfigValue<Config::INTEGER>("decoration:blur:special");
+    static auto PBLUR        = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
 
     m_specialFade->setConfig(Config::animationTree()->getAnimationPropertyConfig(pWorkspace ? "specialWorkspaceIn" : "specialWorkspaceOut"));
     *m_specialFade = pWorkspace ? 1.F : 0.F;
+    m_specialDim->setConfig(Config::animationTree()->getAnimationPropertyConfig(pWorkspace ? "specialWorkspaceIn" : "specialWorkspaceOut"));
+    *m_specialDim = pWorkspace ? *PDIMSPECIAL : 0.F;
+    m_specialBlur->setConfig(Config::animationTree()->getAnimationPropertyConfig(pWorkspace ? "specialWorkspaceIn" : "specialWorkspaceOut"));
+    *m_specialBlur = pWorkspace && *PBLURSPECIAL && *PBLUR ? 1.F : 0.F;
 
     g_pHyprRenderer->damageMonitor(m_self.lock());
 
@@ -1850,7 +1862,7 @@ uint32_t CMonitor::isSolitaryBlocked(bool full) {
     }
 
     for (auto const& w : Desktop::windowState()->windows()) {
-        if (w == PCANDIDATE || (!w->m_isMapped && !w->m_fadingOut) || !w->visible())
+        if (w == PCANDIDATE || !w->m_isMapped || !w->visible())
             continue;
 
         if (w->workspaceID() == PCANDIDATE->workspaceID() && w->m_isFloating && w->isAllowedOverFullscreen() && w->visibleOnMonitor(m_self.lock())) {

--- a/src/output/Monitor.hpp
+++ b/src/output/Monitor.hpp
@@ -155,6 +155,8 @@ namespace Monitor {
 
         // for special fade/blur
         PHLANIMVAR<float> m_specialFade;
+        PHLANIMVAR<float> m_specialDim;
+        PHLANIMVAR<float> m_specialBlur;
 
         // for dpms off anim
         PHLANIMVAR<float> m_dpmsBlackOpacity;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -15,6 +15,7 @@
 #include "../desktop/view/LayerSurface.hpp"
 #include "../desktop/view/GlobalViewMethods.hpp"
 #include "../desktop/state/FocusState.hpp"
+#include "../desktop/state/FadingOutState.hpp"
 #include "../protocols/SessionLock.hpp"
 #include "../protocols/LayerShell.hpp"
 #include "../protocols/XDGShell.hpp"
@@ -226,11 +227,8 @@ bool IHyprRenderer::shouldRenderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor) {
     if (!pWindow->visibleOnMonitor(pMonitor))
         return false;
 
-    if (!pWindow->m_workspace && !pWindow->m_fadingOut)
+    if (!pWindow->m_workspace)
         return false;
-
-    if (!pWindow->m_workspace && pWindow->m_fadingOut)
-        return pWindow->workspaceID() == pMonitor->activeWorkspaceID() || pWindow->workspaceID() == pMonitor->activeSpecialWorkspaceID();
 
     if (pWindow->m_pinned)
         return true;
@@ -357,6 +355,7 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
 
         renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
     }
+    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
 
     // and floating ones too
     for (auto const& w : windows) {
@@ -374,6 +373,7 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
 
         renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
     }
+    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
 
     // TODO: this pass sucks
     for (auto const& w : Desktop::windowState()->windows()) {
@@ -411,7 +411,7 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
     // then render windows over fullscreen.
     for (auto const& w : Desktop::windowState()->windows()) {
         const bool shouldSkipWindow =
-            w->workspaceID() != pWorkspaceWindow->workspaceID() || !w->m_isFloating || !w->shouldRenderOverFullscreen() || (!w->m_isMapped && !w->m_fadingOut) || w->isFullscreen();
+            w->workspaceID() != pWorkspaceWindow->workspaceID() || !w->m_isFloating || !w->shouldRenderOverFullscreen() || !w->m_isMapped || w->isFullscreen();
 
         if (shouldSkipWindow)
             continue;
@@ -428,6 +428,7 @@ void IHyprRenderer::renderWorkspaceWindowsFullscreen(PHLMONITOR pMonitor, PHLWOR
 
         renderWindow(w, pMonitor, time, true, RENDER_PASS_ALL);
     }
+    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_OVER_FULLSCREEN, pWorkspace);
 }
 
 void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& time) {
@@ -435,11 +436,11 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
 
     Event::bus()->m_events.render.stage.emit(RENDER_PRE_WINDOWS);
 
-    std::vector<PHLWINDOWREF> windows, tiledFadingOut;
+    std::vector<PHLWINDOWREF> windows;
     windows.reserve(Desktop::windowState()->windows().size());
 
     for (auto const& w : Desktop::windowState()->windows()) {
-        const bool isNotRenderable = w->isHidden() || (!w->m_isMapped && !w->m_fadingOut);
+        const bool isNotRenderable = w->isHidden() || !w->m_isMapped;
 
         if (isNotRenderable)
             continue;
@@ -467,13 +468,6 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
             continue;
         }
 
-        // render tiled fading out after others
-        if (w->m_fadingOut) {
-            tiledFadingOut.emplace_back(w);
-            w.reset();
-            continue;
-        }
-
         // render the bad boy
         renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_MAIN);
         w.reset();
@@ -484,10 +478,7 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
 
     lastWindow.reset();
 
-    // render tiled windows that are fading out after other tiled to not hide them behind
-    for (auto& w : tiledFadingOut) {
-        renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_MAIN);
-    }
+    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_TILED, pWorkspace);
 
     // Non-floating popup
     for (auto& w : windows) {
@@ -528,6 +519,7 @@ void IHyprRenderer::renderWorkspaceWindows(PHLMONITOR pMonitor, PHLWORKSPACE pWo
         // render the bad boy
         renderWindow(w.lock(), pMonitor, time, true, RENDER_PASS_ALL);
     }
+    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_WINDOW_FLOATING, pWorkspace);
 }
 
 void IHyprRenderer::bindOffMain() {
@@ -559,12 +551,6 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
 
     if (!standalone && pWindow->effectiveAlpha() == 0.F && !pWindow->m_alpha.isBeingAnimated())
         return;
-
-    if (pWindow->m_fadingOut) {
-        if (pMonitor == pWindow->m_monitor) // TODO: fix this
-            renderSnapshot(pWindow);
-        return;
-    }
 
     if (!pWindow->m_isMapped)
         return;
@@ -789,11 +775,6 @@ void IHyprRenderer::renderWindow(PHLWINDOW pWindow, PHLMONITOR pMonitor, const T
 
             pWindow->m_popupHead->breadthfirst(
                 [this, &renderdata](WP<Desktop::View::CPopup> popup, void* data) {
-                    if (popup->m_fadingOut) {
-                        renderSnapshot(popup);
-                        return;
-                    }
-
                     if (!popup->aliveAndVisible())
                         return;
 
@@ -953,6 +934,9 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
     if (!pLayer)
         return;
 
+    if (!pLayer->visible())
+        return;
+
     // skip rendering based on abovelock rule and make sure to not render abovelock layers twice
     if ((pLayer->m_ruleApplicator->aboveLock().valueOrDefault() && !lockscreen && g_pSessionLockManager->isSessionLocked()) ||
         (lockscreen && !pLayer->m_ruleApplicator->aboveLock().valueOrDefault()))
@@ -965,12 +949,6 @@ void IHyprRenderer::renderLayer(PHLLS pLayer, PHLMONITOR pMonitor, const Time::s
         data.box   = {0, 0, pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y};
         data.color = CHyprColor(0, 0, 0, *PDIMAROUND * pLayer->m_alpha->value());
         m_renderPass.add(makeUnique<CRectPassElement>(data));
-    }
-
-    if (pLayer->m_fadingOut) {
-        if (!popups)
-            renderSnapshot(pLayer);
-        return;
     }
 
     TRACY_GPU_ZONE("RenderLayer");
@@ -1117,9 +1095,6 @@ void IHyprRenderer::renderSessionLockSurface(WP<SSessionLockSurface> pSurface, P
 }
 
 void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPACE pWorkspace, const Time::steady_tp& time, const Vector2D& translate, const float& scale) {
-    static auto PDIMSPECIAL      = CConfigValue<Config::FLOAT>("decoration:dim_special");
-    static auto PBLURSPECIAL     = CConfigValue<Config::INTEGER>("decoration:blur:special");
-    static auto PBLUR            = CConfigValue<Config::INTEGER>("decoration:blur:enabled");
     static auto PXPMODE          = CConfigValue<Config::INTEGER>("render:xp_mode");
     static auto PSESSIONLOCKXRAY = CConfigValue<Config::INTEGER>("misc:session_lock_xray");
 
@@ -1156,20 +1131,24 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]) {
             renderLayer(ls.lock(), pMonitor, time);
         }
+        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_BACKGROUND);
 
         Event::bus()->m_events.render.stage.emit(RENDER_POST_WALLPAPER);
 
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]) {
             renderLayer(ls.lock(), pMonitor, time);
         }
+        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_BOTTOM);
 
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]) {
             renderLayer(ls.lock(), pMonitor, time);
         }
+        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_TOP);
 
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]) {
             renderLayer(ls.lock(), pMonitor, time);
         }
+        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_OVERLAY);
 
         return;
     }
@@ -1180,12 +1159,14 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND]) {
             renderLayer(ls.lock(), pMonitor, time);
         }
+        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_BACKGROUND);
 
         Event::bus()->m_events.render.stage.emit(RENDER_POST_WALLPAPER);
 
         for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM]) {
             renderLayer(ls.lock(), pMonitor, time);
         }
+        renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_BOTTOM);
     }
 
     // pre window pass
@@ -1198,27 +1179,22 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
         renderWorkspaceWindows(pMonitor, pWorkspace, time);
 
     // and then special
-    if UNLIKELY (pMonitor->m_specialFade->value() != 0.F) {
-        const auto SPECIALANIMPROGRS = pMonitor->m_specialFade->getCurveValue();
-        const bool ANIMOUT           = !pMonitor->m_activeSpecialWorkspace;
+    if UNLIKELY (pMonitor->m_specialDim->value() != 0.F) {
+        CRectPassElement::SRectData data;
+        data.box   = {translate.x, translate.y, pMonitor->m_transformedSize.x * scale, pMonitor->m_transformedSize.y * scale};
+        data.color = CHyprColor(0, 0, 0, pMonitor->m_specialDim->value());
 
-        if (*PDIMSPECIAL != 0.f) {
-            CRectPassElement::SRectData data;
-            data.box   = {translate.x, translate.y, pMonitor->m_transformedSize.x * scale, pMonitor->m_transformedSize.y * scale};
-            data.color = CHyprColor(0, 0, 0, *PDIMSPECIAL * (ANIMOUT ? (1.0 - SPECIALANIMPROGRS) : SPECIALANIMPROGRS));
+        m_renderPass.add(makeUnique<CRectPassElement>(data));
+    }
 
-            m_renderPass.add(makeUnique<CRectPassElement>(data));
-        }
+    if UNLIKELY (pMonitor->m_specialBlur->value() != 0.F) {
+        CRectPassElement::SRectData data;
+        data.box   = {translate.x, translate.y, pMonitor->m_transformedSize.x * scale, pMonitor->m_transformedSize.y * scale};
+        data.color = CHyprColor(0, 0, 0, 0);
+        data.blur  = true;
+        data.blurA = pMonitor->m_specialBlur->value();
 
-        if (*PBLURSPECIAL && *PBLUR) {
-            CRectPassElement::SRectData data;
-            data.box   = {translate.x, translate.y, pMonitor->m_transformedSize.x * scale, pMonitor->m_transformedSize.y * scale};
-            data.color = CHyprColor(0, 0, 0, 0);
-            data.blur  = true;
-            data.blurA = (ANIMOUT ? (1.0 - SPECIALANIMPROGRS) : SPECIALANIMPROGRS);
-
-            m_renderPass.add(makeUnique<CRectPassElement>(data));
-        }
+        m_renderPass.add(makeUnique<CRectPassElement>(data));
     }
 
     // special
@@ -1234,7 +1210,7 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
 
     // pinned always above
     for (auto const& w : Desktop::windowState()->windows()) {
-        if (w->isHidden() && !w->m_isMapped && !w->m_fadingOut)
+        if (w->isHidden() && !w->m_isMapped)
             continue;
 
         if (!w->m_pinned || !w->m_isFloating)
@@ -1253,6 +1229,7 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
     for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_TOP]) {
         renderLayer(ls.lock(), pMonitor, time);
     }
+    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_TOP);
 
     // Render IME popups
     for (auto const& imep : g_pInputManager->m_relay.m_inputMethodPopups) {
@@ -1262,12 +1239,14 @@ void IHyprRenderer::renderAllClientsForWorkspace(PHLMONITOR pMonitor, PHLWORKSPA
     for (auto const& ls : pMonitor->m_layerSurfaceLayers[ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY]) {
         renderLayer(ls.lock(), pMonitor, time);
     }
+    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_LAYER_OVERLAY);
 
     for (auto const& lsl : pMonitor->m_layerSurfaceLayers) {
         for (auto const& ls : lsl) {
             renderLayer(ls.lock(), pMonitor, time, true);
         }
     }
+    renderFadeouts(pMonitor, Desktop::FADEOUT_PLANE_POPUP);
 
     renderDragIcon(pMonitor, time);
 }
@@ -2086,8 +2065,8 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     pMonitor->m_renderingActive = true;
 
     // Most frames have no fading-out windows or layers for this monitor.
-    if (!Desktop::fadingOutState()->windows().empty() || !Desktop::fadingOutState()->layers().empty())
-        Desktop::fadingOutState()->cleanupForMonitor(pMonitor->m_id);
+    if (!Desktop::fadingOutState()->fadeouts().empty())
+        Desktop::fadingOutState()->cleanupForMonitor(pMonitor);
 
     // TODO: this is getting called with extents being 0,0,0,0 should it be?
     // potentially can save on resources.
@@ -2561,7 +2540,7 @@ void IHyprRenderer::arrangeLayerArray(PHLMONITOR pMonitor, const std::vector<PHL
     CBox full_area = {pMonitor->m_position.x, pMonitor->m_position.y, pMonitor->m_size.x, pMonitor->m_size.y};
 
     for (auto const& ls : layerSurfaces) {
-        if (!ls || ls->m_fadingOut || ls->m_readyToDelete || !ls->m_layerSurface || ls->m_noProcess)
+        if (!ls || !ls->m_mapped || !ls->m_layerSurface || ls->m_noProcess)
             continue;
 
         const auto PLAYER = ls->m_layerSurface;
@@ -3058,29 +3037,24 @@ void IHyprRenderer::addWindowToRenderUnfocused(PHLWINDOW window) {
         m_renderUnfocusedTimer->updateTimeout(std::chrono::milliseconds(1000 / *PFPS));
 }
 
-void IHyprRenderer::makeSnapshot(PHLWINDOW pWindow) {
+SP<IFramebuffer> IHyprRenderer::makeSnapshotFB(PHLWINDOW pWindow) {
     // we trust the window is valid.
     const auto PMONITOR = pWindow->m_monitor.lock();
 
     if (!PMONITOR || !PMONITOR->m_output || PMONITOR->m_pixelSize.x <= 0 || PMONITOR->m_pixelSize.y <= 0)
-        return;
+        return nullptr;
 
     if (!shouldRenderWindow(pWindow))
-        return; // ignore, window is not being rendered
+        return nullptr; // ignore, window is not being rendered
 
     Log::logger->log(Log::DEBUG, "renderer: making a snapshot of {:x}", rc<uintptr_t>(pWindow.get()));
 
     // we need to "damage" the entire monitor
     // so that we render the entire window
     // this is temporary, doesn't mess with the actual damage
-    CRegion      fakeDamage{0, 0, sc<int>(PMONITOR->m_transformedSize.x), sc<int>(PMONITOR->m_transformedSize.y)};
+    CRegion    fakeDamage{0, 0, sc<int>(PMONITOR->m_transformedSize.x), sc<int>(PMONITOR->m_transformedSize.y)};
 
-    PHLWINDOWREF ref{pWindow};
-
-    if (!ref->m_snapshotFB)
-        ref->m_snapshotFB = createFB("window snapshot");
-
-    const auto PFRAMEBUFFER = ref->m_snapshotFB;
+    const auto PFRAMEBUFFER = createFB("window snapshot");
 
     PFRAMEBUFFER->alloc(PMONITOR->m_pixelSize.x, PMONITOR->m_pixelSize.y, DRM_FORMAT_ABGR8888);
     PFRAMEBUFFER->setImageDescription(PMONITOR->workBufferImageDescription());
@@ -3103,26 +3077,24 @@ void IHyprRenderer::makeSnapshot(PHLWINDOW pWindow) {
     Log::logger->log(Log::DEBUG, "renderer: made a snapshot of {:x}", rc<uintptr_t>(pWindow.get()));
 
     m_bRenderingSnapshot = false;
+    return PFRAMEBUFFER;
 }
 
-void IHyprRenderer::makeSnapshot(PHLLS pLayer) {
+SP<IFramebuffer> IHyprRenderer::makeSnapshotFB(PHLLS pLayer) {
     // we trust the window is valid.
     const auto PMONITOR = pLayer->m_monitor.lock();
 
     if (!PMONITOR || !PMONITOR->m_output || PMONITOR->m_pixelSize.x <= 0 || PMONITOR->m_pixelSize.y <= 0)
-        return;
+        return nullptr;
 
     Log::logger->log(Log::DEBUG, "renderer: making a snapshot of layer {:x}", rc<uintptr_t>(pLayer.get()));
 
     // we need to "damage" the entire monitor
     // so that we render the entire window
     // this is temporary, doesn't mess with the actual damage
-    CRegion fakeDamage{0, 0, sc<int>(PMONITOR->m_transformedSize.x), sc<int>(PMONITOR->m_transformedSize.y)};
+    CRegion    fakeDamage{0, 0, sc<int>(PMONITOR->m_transformedSize.x), sc<int>(PMONITOR->m_transformedSize.y)};
 
-    if (!pLayer->m_snapshotFB)
-        pLayer->m_snapshotFB = createFB("layer snapshot");
-
-    const auto PFRAMEBUFFER = pLayer->m_snapshotFB;
+    const auto PFRAMEBUFFER = createFB("layer snapshot");
 
     PFRAMEBUFFER->alloc(PMONITOR->m_pixelSize.x, PMONITOR->m_pixelSize.y, DRM_FORMAT_ABGR8888);
     PFRAMEBUFFER->setImageDescription(PMONITOR->workBufferImageDescription());
@@ -3146,26 +3118,24 @@ void IHyprRenderer::makeSnapshot(PHLLS pLayer) {
     Log::logger->log(Log::DEBUG, "renderer: made a snapshot of layer {:x}", rc<uintptr_t>(pLayer.get()));
 
     m_bRenderingSnapshot = false;
+    return PFRAMEBUFFER;
 }
 
-void IHyprRenderer::makeSnapshot(WP<Desktop::View::CPopup> popup) {
+SP<IFramebuffer> IHyprRenderer::makeSnapshotFB(WP<Desktop::View::CPopup> popup) {
     // we trust the window is valid.
     const auto PMONITOR = popup->getMonitor();
 
     if (!PMONITOR || !PMONITOR->m_output || PMONITOR->m_pixelSize.x <= 0 || PMONITOR->m_pixelSize.y <= 0)
-        return;
+        return nullptr;
 
     if (!popup->aliveAndVisible())
-        return;
+        return nullptr;
 
     Log::logger->log(Log::DEBUG, "renderer: making a snapshot of {:x}", rc<uintptr_t>(popup.get()));
 
-    CRegion fakeDamage{0, 0, PMONITOR->m_transformedSize.x, PMONITOR->m_transformedSize.y};
+    CRegion    fakeDamage{0, 0, PMONITOR->m_transformedSize.x, PMONITOR->m_transformedSize.y};
 
-    if (!popup->m_snapshotFB)
-        popup->m_snapshotFB = createFB("popup shapshot");
-
-    const auto PFRAMEBUFFER = popup->m_snapshotFB;
+    const auto PFRAMEBUFFER = createFB("popup shapshot");
 
     PFRAMEBUFFER->alloc(PMONITOR->m_pixelSize.x, PMONITOR->m_pixelSize.y, DRM_FORMAT_ABGR8888);
     PFRAMEBUFFER->setImageDescription(PMONITOR->workBufferImageDescription());
@@ -3205,149 +3175,67 @@ void IHyprRenderer::makeSnapshot(WP<Desktop::View::CPopup> popup) {
     endRender();
 
     m_bRenderingSnapshot = false;
+    return PFRAMEBUFFER;
 }
 
-void IHyprRenderer::renderSnapshot(PHLWINDOW pWindow) {
-    static auto  PDIMAROUND = CConfigValue<Config::FLOAT>("decoration:dim_around");
-
-    PHLWINDOWREF ref{pWindow};
-
-    if (!ref->m_snapshotFB)
+void IHyprRenderer::renderFadeouts(PHLMONITOR monitor, Desktop::eFadeoutPlane plane, PHLWORKSPACE workspace) {
+    if (!monitor)
         return;
 
-    const auto FBDATA = ref->m_snapshotFB;
+    std::vector<SP<Desktop::IFadeout>> fadeouts;
+    for (auto const& fadeout : Desktop::fadingOutState()->fadeouts()) {
+        if (!fadeout || fadeout->monitor() != monitor || fadeout->plane() != plane)
+            continue;
 
-    if (!FBDATA->getTexture())
-        return;
+        if (fadeout->workspace() && fadeout->workspace() != workspace)
+            continue;
 
-    const auto PMONITOR = pWindow->m_monitor.lock();
-
-    CBox       windowBox;
-    // some mafs to figure out the correct box
-    // the originalClosedPos is relative to the monitor's pos
-    Vector2D scaleXY = Vector2D((PMONITOR->m_scale * pWindow->m_realSize->value().x / (pWindow->m_originalClosedSize.x * PMONITOR->m_scale)),
-                                (PMONITOR->m_scale * pWindow->m_realSize->value().y / (pWindow->m_originalClosedSize.y * PMONITOR->m_scale)));
-
-    windowBox.width  = PMONITOR->m_transformedSize.x * scaleXY.x;
-    windowBox.height = PMONITOR->m_transformedSize.y * scaleXY.y;
-    windowBox.x      = ((pWindow->m_realPosition->value().x - PMONITOR->m_position.x) * PMONITOR->m_scale) - ((pWindow->m_originalClosedPos.x * PMONITOR->m_scale) * scaleXY.x);
-    windowBox.y      = ((pWindow->m_realPosition->value().y - PMONITOR->m_position.y) * PMONITOR->m_scale) - ((pWindow->m_originalClosedPos.y * PMONITOR->m_scale) * scaleXY.y);
-
-    CRegion fakeDamage{0, 0, PMONITOR->m_transformedSize.x, PMONITOR->m_transformedSize.y};
-
-    if (*PDIMAROUND && pWindow->m_ruleApplicator->dimAround().valueOrDefault()) {
-        CRectPassElement::SRectData data;
-
-        data.box = {0, 0, m_renderData.pMonitor->m_pixelSize.x, m_renderData.pMonitor->m_pixelSize.y};
-        data.color =
-            CHyprColor(0, 0, 0, *PDIMAROUND * pWindow->alphaValue(WINDOW_ALPHA_FADE) * pWindow->alphaValue(WINDOW_ALPHA_FULLSCREEN) * pWindow->alphaValue(WINDOW_ALPHA_LAYOUT));
-
-        m_renderPass.add(makeUnique<CRectPassElement>(data));
+        fadeouts.emplace_back(fadeout);
     }
 
-    if (shouldBlur(pWindow)) {
-        CRectPassElement::SRectData data;
-        data.box           = CBox{pWindow->m_realPosition->value(), pWindow->m_realSize->value()}.translate(-PMONITOR->m_position).scale(PMONITOR->m_scale).round();
-        data.color         = CHyprColor{0, 0, 0, 0};
-        data.blur          = true;
-        data.blurA         = sqrt(pWindow->alphaValue(WINDOW_ALPHA_FADE) * pWindow->alphaValue(WINDOW_ALPHA_FULLSCREEN) *
-                                  pWindow->alphaValue(WINDOW_ALPHA_LAYOUT)); // sqrt makes the blur fadeout more realistic.
-        data.round         = pWindow->rounding();
-        data.roundingPower = pWindow->roundingPower();
-        data.xray          = pWindow->m_ruleApplicator->xray().valueOr(false);
+    std::ranges::sort(fadeouts, {}, [](const auto& fadeout) { return fadeout->zIndex(); });
 
-        m_renderPass.add(makeUnique<CRectPassElement>(data));
+    CRegion fakeDamage{0, 0, monitor->m_transformedSize.x, monitor->m_transformedSize.y};
+    for (auto const& fadeout : fadeouts) {
+        const auto FB = fadeout->framebuffer();
+        if (!FB || !FB->getTexture())
+            continue;
+
+        const auto EFFECTS = fadeout->effects();
+
+        if (EFFECTS.dimAroundAlpha > 0.F) {
+            CRectPassElement::SRectData data;
+            data.box   = {0, 0, monitor->m_transformedSize.x, monitor->m_transformedSize.y};
+            data.color = CHyprColor(0, 0, 0, EFFECTS.dimAroundAlpha);
+            m_renderPass.add(makeUnique<CRectPassElement>(data));
+        }
+
+        if (EFFECTS.preBlur) {
+            CRectPassElement::SRectData data;
+            data.box           = EFFECTS.preBlur->box;
+            data.color         = CHyprColor(0, 0, 0, 0);
+            data.blur          = true;
+            data.blurA         = EFFECTS.preBlur->alpha;
+            data.round         = EFFECTS.preBlur->round;
+            data.roundingPower = EFFECTS.preBlur->roundingPower;
+            data.xray          = EFFECTS.preBlur->xray;
+            m_renderPass.add(makeUnique<CRectPassElement>(data));
+        }
+
+        CTexPassElement::SRenderData data;
+        data.flipEndFrame          = true;
+        data.tex                   = FB->getTexture();
+        data.box                   = fadeout->renderBox();
+        data.a                     = fadeout->alpha();
+        data.damage                = fakeDamage;
+        data.blur                  = EFFECTS.textureBlur.enabled;
+        data.blurA                 = EFFECTS.textureBlur.alpha;
+        data.forceBlurBlend        = EFFECTS.textureBlur.forceBlend;
+        data.ignoreAlpha           = EFFECTS.textureBlur.ignoreAlpha;
+        data.blockBlurOptimization = EFFECTS.textureBlur.blockBlurOptimization;
+
+        m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
     }
-
-    CTexPassElement::SRenderData data;
-    data.flipEndFrame = true;
-    data.tex          = FBDATA->getTexture();
-    data.box          = windowBox;
-    data.a            = pWindow->alphaValue(WINDOW_ALPHA_FADE) * pWindow->alphaValue(WINDOW_ALPHA_FULLSCREEN) * pWindow->alphaValue(WINDOW_ALPHA_LAYOUT);
-    data.damage       = fakeDamage;
-
-    m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
-}
-
-void IHyprRenderer::renderSnapshot(PHLLS pLayer) {
-    if (!pLayer->m_snapshotFB)
-        return;
-
-    const auto FBDATA = pLayer->m_snapshotFB;
-
-    if (!FBDATA->getTexture())
-        return;
-
-    const auto PMONITOR = pLayer->m_monitor.lock();
-
-    CBox       layerBox;
-    // some mafs to figure out the correct box
-    // the originalClosedPos is relative to the monitor's pos
-    Vector2D scaleXY = Vector2D((PMONITOR->m_scale * pLayer->m_realSize->value().x / (pLayer->m_geometry.w * PMONITOR->m_scale)),
-                                (PMONITOR->m_scale * pLayer->m_realSize->value().y / (pLayer->m_geometry.h * PMONITOR->m_scale)));
-
-    layerBox.width  = PMONITOR->m_transformedSize.x * scaleXY.x;
-    layerBox.height = PMONITOR->m_transformedSize.y * scaleXY.y;
-    layerBox.x =
-        ((pLayer->m_realPosition->value().x - PMONITOR->m_position.x) * PMONITOR->m_scale) - (((pLayer->m_geometry.x - PMONITOR->m_position.x) * PMONITOR->m_scale) * scaleXY.x);
-    layerBox.y =
-        ((pLayer->m_realPosition->value().y - PMONITOR->m_position.y) * PMONITOR->m_scale) - (((pLayer->m_geometry.y - PMONITOR->m_position.y) * PMONITOR->m_scale) * scaleXY.y);
-
-    CRegion                      fakeDamage{0, 0, PMONITOR->m_transformedSize.x, PMONITOR->m_transformedSize.y};
-
-    const bool                   SHOULD_BLUR = shouldBlur(pLayer);
-
-    CTexPassElement::SRenderData data;
-    data.flipEndFrame = true;
-    data.tex          = FBDATA->getTexture();
-    data.box          = layerBox;
-    data.a            = pLayer->m_alpha->value();
-    data.damage       = fakeDamage;
-    data.blur         = SHOULD_BLUR;
-    data.blurA        = sqrt(pLayer->m_alpha->value()); // sqrt makes the blur fadeout more realistic.
-    if (SHOULD_BLUR)
-        data.ignoreAlpha = pLayer->m_ruleApplicator->ignoreAlpha().valueOr(0.01F) /* ignore the alpha 0 regions */;
-
-    m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
-}
-
-void IHyprRenderer::renderSnapshot(WP<Desktop::View::CPopup> popup) {
-    if (!popup->m_snapshotFB)
-        return;
-
-    static CConfigValue PBLURIGNOREA = CConfigValue<Config::FLOAT>("decoration:blur:popups_ignorealpha");
-
-    const auto          FBDATA = popup->m_snapshotFB;
-
-    if (!FBDATA->getTexture())
-        return;
-
-    const auto PMONITOR = popup->getMonitor();
-
-    if (!PMONITOR)
-        return;
-
-    CRegion                      fakeDamage{0, 0, PMONITOR->m_transformedSize.x, PMONITOR->m_transformedSize.y};
-
-    const bool                   SHOULD_BLUR = shouldBlur(popup);
-
-    CTexPassElement::SRenderData data;
-    data.flipEndFrame          = true;
-    data.tex                   = FBDATA->getTexture();
-    data.box                   = {{}, PMONITOR->m_transformedSize};
-    data.a                     = popup->m_alpha->value();
-    data.damage                = fakeDamage;
-    data.blur                  = SHOULD_BLUR;
-    data.blurA                 = sqrt(popup->m_alpha->value()); // sqrt makes the blur fadeout more realistic.
-    data.blockBlurOptimization = SHOULD_BLUR;                   // force no xray on this (popups never have xray)
-    if (SHOULD_BLUR) {
-        if (const auto PLAYER = popup->layerOwner(); PLAYER && PLAYER->m_ruleApplicator->ignoreAlpha().hasValue())
-            data.ignoreAlpha = std::max(PLAYER->m_ruleApplicator->ignoreAlpha().valueOrDefault(), 0.01F);
-        else
-            data.ignoreAlpha = std::max(*PBLURIGNOREA, 0.01F); /* ignore the alpha 0 regions */
-    }
-
-    m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
 }
 
 NColorManagement::PImageDescription IHyprRenderer::workBufferImageDescription() {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2540,7 +2540,7 @@ void IHyprRenderer::arrangeLayerArray(PHLMONITOR pMonitor, const std::vector<PHL
     CBox full_area = {pMonitor->m_position.x, pMonitor->m_position.y, pMonitor->m_size.x, pMonitor->m_size.y};
 
     for (auto const& ls : layerSurfaces) {
-        if (!ls || !ls->m_mapped || !ls->m_layerSurface || ls->m_noProcess)
+        if (!ls || !ls->m_layerSurface || ls->m_noProcess)
             continue;
 
         const auto PLAYER = ls->m_layerSurface;

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -22,6 +22,7 @@
 #include "./pass/TransformedWindowPassElement.hpp"
 #include "types.hpp"
 #include "../output/Monitor.hpp"
+#include "../desktop/state/Fadeout.hpp"
 #include "../desktop/view/LayerSurface.hpp"
 #include "Renderbuffer.hpp"
 #include "../helpers/time/Timer.hpp"
@@ -92,12 +93,10 @@ namespace Render {
         bool                                isSoftware();
         bool                                isMgpu();
         void                                addWindowToRenderUnfocused(PHLWINDOW window);
-        void                                makeSnapshot(PHLWINDOW);
-        void                                makeSnapshot(PHLLS);
-        void                                makeSnapshot(WP<Desktop::View::CPopup>);
-        void                                renderSnapshot(PHLWINDOW);
-        void                                renderSnapshot(PHLLS);
-        void                                renderSnapshot(WP<Desktop::View::CPopup>);
+        SP<IFramebuffer>                    makeSnapshotFB(PHLWINDOW);
+        SP<IFramebuffer>                    makeSnapshotFB(PHLLS);
+        SP<IFramebuffer>                    makeSnapshotFB(WP<Desktop::View::CPopup>);
+        void                                renderFadeouts(PHLMONITOR monitor, Desktop::eFadeoutPlane plane, PHLWORKSPACE workspace = nullptr);
         bool                                beginFullFakeRender(PHLMONITOR pMonitor, CRegion& damage, SP<IFramebuffer> fb);
         bool                                beginRenderToBuffer(PHLMONITOR pMonitor, CRegion& damage, SP<IHLBuffer> buffer, bool simple = false);
         virtual void                        startRenderPass() {};

--- a/src/render/transformer/MotionBlurTransformer.cpp
+++ b/src/render/transformer/MotionBlurTransformer.cpp
@@ -26,7 +26,7 @@ bool CMotionBlurTransformer::shouldEnable(PHLWINDOW window) {
     if (!window)
         return false;
 
-    return *PMBENABLED && *PMBSAMPLES > 1 && !window->isFullscreen() && !window->m_fadingOut;
+    return *PMBENABLED && *PMBSAMPLES > 1 && !window->isFullscreen();
 }
 
 SP<Render::IFramebuffer> CMotionBlurTransformer::transform(SP<Render::IFramebuffer> in) {


### PR DESCRIPTION
This is a touchy, but much needed refactor:

- unifies fadeouts into one single type
- removes spaghetti logic keeping objects alive when they werent
- cleanups in general

Needs testing of various animated shit, fadeouts, dims, etc.