### PR TITLE
Add code owners via codeowners-plus

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -1,0 +1,10 @@
+# Reference: https://github.com/marketplace/actions/codeowners-plus#codeowners-file-spec
+
+# Fallback: request Vaxry's review
+* @vaxerski
+
+# CI: request @fufexan's review
+.github/workflows/** @fufexan
+
+# Hyprtester (framework): CC @kolayne
+? hyprtester/src/* @kolayne

--- a/.github/workflows/codeownersplus.yml
+++ b/.github/workflows/codeownersplus.yml
@@ -1,0 +1,33 @@
+name: 'Code Owners'
+
+concurrency:
+  group: codeowners-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    # Note: to support more features of codeowners-plus, more event triggers
+    # may be required. See https://github.com/marketplace/actions/codeowners-plus
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read       # required for @actions/checkout
+  pull-requests: write # required to request reviewers and leave comments
+
+jobs:
+  codeowners:
+    name: 'Run Codeowners Plus'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Code Repository'
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: 'Codeowners Plus'
+        uses: multimediallc/codeowners-plus@v1.9.1
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          pr: '${{ github.event.pull_request.number }}'
+          verbose: true
+          quiet: ${{ github.event.pull_request.draft }}

--- a/codeowners.toml
+++ b/codeowners.toml
@@ -1,0 +1,12 @@
+# Prevent codeowners-plus from adding a review status comment:
+# we only use it to request reviews, not to enforce approvals.
+#
+# Optional reviewers are still invited with a CC comment.
+disable_review_status_comments = true
+
+[enforcement]
+# Just request reviews, but do not enforce the approvals requirement.
+#
+# If `fail_check = true`, the codeowners-plus workflow will fail, unless sepcified reviewers
+# approve the PR.
+fail_check = false


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Adds the code owners reviewer assignment logic via the [codeowners-plus](https://github.com/marketplace/actions/codeowners-plus) action. Unlike GitHub's built-in CODEOWNERS, codeowners-plus allows to specify users without write access to the repository.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

Codeowners-plus recommends that each subdirectory includes its own `.codeowners` file. But I think it's more clear when everything is in one place, at the root of the repository.


#### Is it ready for merging, or does it need work?

Ready for merge. CC @fufexan 
