### PR TITLE
desktop/view: sync layout's m_box in clampWindowSize

### DIFF
--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -1270,8 +1270,7 @@ bool CWindow::clampWindowSize(const std::optional<Vector2D> minSize, const std::
 
     if (changed) {
         const Vector2D DELTA = REALSIZE - NEWSIZE;
-        *m_realPosition      = m_realPosition->goal() + DELTA / 2.0;
-        *m_realSize          = NEWSIZE;
+        layoutTarget()->setPositionGlobal(CBox{m_realPosition->goal() + DELTA / 2.0, NEWSIZE});
     }
 
     return changed;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This fixes https://github.com/hyprwm/Hyprland/discussions/13539 where floating clamped-size windows flicker on drag

When xdg_toplevel min/max constraints are set on a floating window, flickering occurs on dragging/moving until the window is resized, because min/max constraints cause the `clampWindowSize` function to be called, but this function only updates members of CWindow which causes a desync to `m_box` when `setPositionGlobal` is called (when dragging, moving).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I only tested the two-line diff as applied to [v0.55.4](https://github.com/swomf/Hyprland-fixes/tree/discussion-13539). This commit applies the diff right onto the latest main, which I haven't tested yet.

#### Is it ready for merging, or does it need work?

It's ready for merging. It's a two line patch so I tested as a diff applied to v0.55.4 (built with gcc 15.3.0) and as a diff applied.

#### attachments

Here are two demonstrations of the build off of v0.55.4 on my local machine --- one in normal scaling, one in fractional scaling (just for completeness).

https://github.com/user-attachments/assets/271b9486-6e70-40bd-9bb1-dd75e0232e0f


https://github.com/user-attachments/assets/c998937f-680e-43b3-9ea1-f329a470a6a2

