### PR TITLE
Optimize Env::envEnabled()

### DIFF
--- a/src/helpers/env/Env.cpp
+++ b/src/helpers/env/Env.cpp
@@ -1,16 +1,10 @@
 #include "Env.hpp"
 
 #include <cstdlib>
-#include <string_view>
 
-bool Env::envEnabled(const std::string& env) {
-    auto ret = getenv(env.c_str());
-    if (!ret)
-        return false;
-
-    const std::string_view sv = ret;
-
-    return !sv.empty() && sv != "0";
+bool Env::envEnabled(const char* env) {
+    const auto ret = getenv(env);
+    return ret && ret[0] != '\0' && !(ret[0] == '0' && ret[1] == '\0');
 }
 
 bool Env::isTrace() {

--- a/src/helpers/env/Env.hpp
+++ b/src/helpers/env/Env.hpp
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <string>
-
 namespace Env {
-    bool envEnabled(const std::string& env);
+    bool envEnabled(const char* env);
     bool isTrace();
 }


### PR DESCRIPTION
- do not construct std::string
- do not compute string length when constructing std::string_view