### PR TITLE
Don't skip trailing zeros when printing crash-related numbers

### DIFF
--- a/src/debug/crash/SignalSafe.hpp
+++ b/src/debug/crash/SignalSafe.hpp
@@ -112,7 +112,7 @@ namespace SignalSafe {
                 d *= 10;
             }
 
-            while (num > 0) {
+            while (d > 0) {
                 char c = '0' + (num / d);
                 write(c);
                 num %= d;


### PR DESCRIPTION
Tiny fix for the crashlog number-printing routine, so that trailing zeros are no longer skipped. Previously we'd have stuff like (note the stack-frame numbers):
```
Backtrace:
    # | Hyprland(_Z12getBacktracev+0x73) [0x5559546de7f3]
        getBacktrace()
        ??:?
    #1 | Hyprland(_ZN13CrashReporter18createAndSaveCrashEi+0xc8c) [0x5559546258dc]
--- 8< ---
    #9 | Hyprland(_ZN11Screenshare17CScreenshareFrame10copyDmabufEv+0xe4) [0x555954cbe6c4]
        Screenshare::CScreenshareFrame::copyDmabuf()
        ??:?
    #1 | Hyprland(_ZN11Screenshare17CScreenshareFrame4copyEv+0x240) [0x555954cbffb0]
        Screenshare::CScreenshareFrame::copy()
        ??:?
    #11 | Hyprland(_ZN11Screenshare19CScreenshareManager14onOutputCommitEN9Hyprutils6Memory14CSharedPointerI8CMonitorEE+0x42c) [0x5559548badac]
```
...which is just embarrassing :)

Might also fix a few cases of printing signal numbers, since those use the same function.