### PR TITLE
protocols: Fix crash when creating inert workspace resource

### DIFF
--- a/src/protocols/ExtWorkspace.cpp
+++ b/src/protocols/ExtWorkspace.cpp
@@ -151,7 +151,10 @@ bool CExtWorkspaceResource::isActive() const {
     if (!m_workspace)
         return false;
 
-    auto const& monitor      = m_workspace->m_monitor;
+    auto const& monitor = m_workspace->m_monitor;
+    if (!monitor)
+        return false;
+
     auto const& cmpWorkspace = m_workspace->m_isSpecialWorkspace ? monitor->m_activeSpecialWorkspace : monitor->m_activeWorkspace;
     return m_workspace == cmpWorkspace;
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
When iterating over all workspace with the ext-workspace-v1 protocol, if a workspace has been marked as inert because all monitors were disconnected, isActive (called by sendState called by the workspace resource constructor) would result in a null pointer dereference as the workspace has no monitor. This PR simply adds a null pointer check for the monitor.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
AI diagnosed this issue from my stack trace, but I've manually confirmed that my stack trace does indeed correspond to a null pointer deref here. I also investigated the surrounding code and didn't find any other remaining similar issues.

#### Is it ready for merging, or does it need work?
Ready for merging