### PR TITLE
Global  window counting

### DIFF
--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -257,7 +257,7 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
 
                 prop = prop.substr(2, prop.length() - 3);
 
-                int  wantsOnlyTiled    = -1;z
+                int  wantsOnlyTiled    = -1;
                 int  wantsOnlyPinned   = false;
                 bool wantsCountGroup   = false;
                 bool wantsCountVisible = false;

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -257,11 +257,12 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
 
                 prop = prop.substr(2, prop.length() - 3);
 
-                int  wantsOnlyTiled    = -1;
+                int  wantsOnlyTiled    = -1;z
                 int  wantsOnlyPinned   = false;
                 bool wantsCountGroup   = false;
                 bool wantsCountVisible = false;
-
+                bool wantsGlobal       = false;
+                
                 int  flagCount = 0;
                 for (auto const& flag : prop) {
                     if (flag == 't' && wantsOnlyTiled == -1) {
@@ -278,6 +279,9 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
                         flagCount++;
                     } else if (flag == 'v' && !wantsCountVisible) {
                         wantsCountVisible = true;
+                        flagCount++;
+                    } else if (flag == 'a' && !wantsGlobal) {
+                        wantsGlobal = true;
                         flagCount++;
                     } else {
                         break;

--- a/src/desktop/Workspace.cpp
+++ b/src/desktop/Workspace.cpp
@@ -151,6 +151,7 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
             //                  flag p to count only pinned windows, e.g. w[p1-2], w[pg4]
             //                  flag g to count groups instead of windows, e.g. w[t1-2], w[fg4]
             //                  flag v will count only visible windows
+            //                  flag a will count all windows with respect to the other flags
             // f - fullscreen state : f[-1], f[0], f[1], or f[2] for different fullscreen states
             //                        -1: no fullscreen, 0: fullscreen, 1: maximized, 2: fullscreen without sending fs state to window
 
@@ -305,14 +306,33 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
                     }
 
                     int count;
-                    if (wantsCountGroup)
-                        count = getGroups(wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>(sc<bool>(wantsOnlyTiled)),
-                                          wantsOnlyPinned ? std::optional<bool>(wantsOnlyPinned) : std::nullopt,
-                                          wantsCountVisible ? std::optional<bool>(wantsCountVisible) : std::nullopt);
-                    else
-                        count = getWindowCount(wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>(sc<bool>(wantsOnlyTiled)),
-                                               wantsOnlyPinned ? std::optional<bool>(wantsOnlyPinned) : std::nullopt,
-                                               wantsCountVisible ? std::optional<bool>(wantsCountVisible) : std::nullopt);
+                    if (wantsGlobal) {
+                        count = 0;
+                    
+                        for (auto const& ws : State::workspaceState()->workspaces()) {
+                            if (!ws)
+                                continue;
+                    
+                            if (wantsCountGroup)
+                                count += ws->getGroups(wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>(sc<bool>(wantsOnlyTiled)),
+                                                  wantsOnlyPinned ? std::optional<bool>(wantsOnlyPinned) : std::nullopt,
+                                                  wantsCountVisible ? std::optional<bool>(wantsCountVisible) : std::nullopt);
+                            else
+                                count += ws->getWindowCount(wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>(sc<bool>(wantsOnlyTiled)),
+                                                       wantsOnlyPinned ? std::optional<bool>(wantsOnlyPinned) : std::nullopt,
+                                                       wantsCountVisible ? std::optional<bool>(wantsCountVisible) : std::nullopt);
+                        }
+                    
+                    } else {
+                        if (wantsCountGroup)
+                            count = getGroups(wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>(sc<bool>(wantsOnlyTiled)),
+                                              wantsOnlyPinned ? std::optional<bool>(wantsOnlyPinned) : std::nullopt,
+                                              wantsCountVisible ? std::optional<bool>(wantsCountVisible) : std::nullopt);
+                        else
+                            count = getWindowCount(wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>(sc<bool>(wantsOnlyTiled)),
+                                                   wantsOnlyPinned ? std::optional<bool>(wantsOnlyPinned) : std::nullopt,
+                                                   wantsCountVisible ? std::optional<bool>(wantsCountVisible) : std::nullopt);
+                    }
 
                     if (count != from)
                         return false;
@@ -341,14 +361,40 @@ bool CWorkspace::matchesStaticSelector(const std::string& selector_) {
                 }
 
                 WORKSPACEID count;
-                if (wantsCountGroup)
-                    count =
-                        getGroups(wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>(sc<bool>(wantsOnlyTiled)),
-                                  wantsOnlyPinned ? std::optional<bool>(wantsOnlyPinned) : std::nullopt, wantsCountVisible ? std::optional<bool>(wantsCountVisible) : std::nullopt);
-                else
-                    count = getWindowCount(wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>(sc<bool>(wantsOnlyTiled)),
-                                           wantsOnlyPinned ? std::optional<bool>(wantsOnlyPinned) : std::nullopt,
-                                           wantsCountVisible ? std::optional<bool>(wantsCountVisible) : std::nullopt);
+                if (wantsGlobal) {
+                    count = 0;
+                
+                    for (auto const& ws : State::workspaceState()->workspaces()) {
+                        if (!ws)
+                            continue;
+                
+                        if (wantsCountGroup)
+                            count += ws->getGroups(
+                                wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>(sc<bool>(wantsOnlyTiled)),
+                                wantsOnlyPinned ? std::optional<bool>(wantsOnlyPinned) : std::nullopt,
+                                wantsCountVisible ? std::optional<bool>(wantsCountVisible) : std::nullopt
+                            );
+
+                        else
+                            count += ws->getWindowCount(
+                                wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>(sc<bool>(wantsOnlyTiled)),
+                                wantsOnlyPinned ? std::optional<bool>(wantsOnlyPinned) : std::nullopt,
+                                wantsCountVisible ? std::optional<bool>(wantsCountVisible) : std::nullopt
+                            );
+                } else {
+                    if (wantsCountGroup)
+                        count = getGroups(
+                            wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>(sc<bool>(wantsOnlyTiled)),
+                            wantsOnlyPinned ? std::optional<bool>(wantsOnlyPinned) : std::nullopt,
+                            wantsCountVisible ? std::optional<bool>(wantsCountVisible) : std::nullopt
+                        );
+                    else
+                        count = getWindowCount(
+                            wantsOnlyTiled == -1 ? std::nullopt : std::optional<bool>(sc<bool>(wantsOnlyTiled)),
+                            wantsOnlyPinned ? std::optional<bool>(wantsOnlyPinned) : std::nullopt,
+                            wantsCountVisible ? std::optional<bool>(wantsCountVisible) : std::nullopt
+                        );
+                }
 
                 if (std::clamp(count, from, to) != count)
                     return false;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

This PR adds a new selector flag `a` (ALL) to the `w[...]` workspace selector.

When `a` is present, the window/group count evaluation is performed across all workspaces instead of only the current workspace.

- With `a`: counts are aggregated globally across all workspaces in `WorkspaceState`.
- Without `a`: behavior remains unchanged and workspace-local.

This applies to both: `getWindowCount(...)` and `getGroups(...)`

---

#### Is there anything you want to mention? 

- The implementation iterates over all workspaces when `a` is present, which may introduce a performance cost in large workspace setups.
- Behavior of existing selectors is fully preserved when `a` is not used.

---

#### Is it ready for merging, or does it need work?

Ready for review.