### PR TITLE
input: fix wheel scroll events from virtual pointers being dropped

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -950,8 +950,12 @@ void CInputManager::onMouseWheel(IPointer::SAxisEvent e, SP<IPointer> pointer) {
     static auto PEMULATEDISCRETE      = CConfigValue<Config::INTEGER>("input:emulate_discrete_scroll");
     static auto PFOLLOWMOUSE          = CConfigValue<Config::INTEGER>("input:follow_mouse");
 
-    const bool  ISTOUCHPADSCROLL = *PTOUCHPADSCROLLFACTOR <= 0.f || e.source == WL_POINTER_AXIS_SOURCE_FINGER;
-    auto        factor           = ISTOUCHPADSCROLL ? *PTOUCHPADSCROLLFACTOR : *PINPUTSCROLLFACTOR;
+    // some virtual pointers send smooth-only wheel events: synthesize the missing discrete value (15 smooth units per 120-unit detent)
+    if (e.source == WL_POINTER_AXIS_SOURCE_WHEEL && e.deltaDiscrete == 0 && e.delta != 0)
+        e.deltaDiscrete = std::round(e.delta * 8.0);
+
+    const bool ISTOUCHPADSCROLL = *PTOUCHPADSCROLLFACTOR <= 0.f || e.source == WL_POINTER_AXIS_SOURCE_FINGER;
+    auto       factor           = ISTOUCHPADSCROLL ? *PTOUCHPADSCROLLFACTOR : *PINPUTSCROLLFACTOR;
 
     if (pointer && pointer->m_scrollFactor.has_value())
         factor = *pointer->m_scrollFactor;

--- a/src/protocols/VirtualPointer.cpp
+++ b/src/protocols/VirtualPointer.cpp
@@ -47,16 +47,17 @@ CVirtualPointerV1Resource::CVirtualPointerV1Resource(SP<CZwlrVirtualPointerV1> r
             return;
         }
 
-        m_axis               = axis_;
-        m_axisEvents[m_axis] = IPointer::SAxisEvent{.timeMs = timeMs, .axis = sc<wl_pointer_axis>(m_axis), .delta = wl_fixed_to_double(value)};
+        m_axis                     = axis_;
+        m_axisEvents[m_axis]       = IPointer::SAxisEvent{.timeMs = timeMs, .axis = sc<wl_pointer_axis>(m_axis), .delta = wl_fixed_to_double(value)};
+        m_axisEventPending[m_axis] = true;
     });
 
     m_resource->setFrame([this](CZwlrVirtualPointerV1* r) {
-        for (auto& e : m_axisEvents) {
-            if (!e.timeMs)
+        for (size_t i = 0; i < m_axisEvents.size(); ++i) {
+            if (!m_axisEventPending[i])
                 continue;
-            m_events.axis.emit(e);
-            e.timeMs = 0;
+            m_events.axis.emit(m_axisEvents[i]);
+            m_axisEventPending[i] = false;
         }
 
         m_events.frame.emit();
@@ -75,6 +76,7 @@ CVirtualPointerV1Resource::CVirtualPointerV1Resource(SP<CZwlrVirtualPointerV1> r
         m_axisEvents[m_axis].axis          = sc<wl_pointer_axis>(m_axis);
         m_axisEvents[m_axis].delta         = 0;
         m_axisEvents[m_axis].deltaDiscrete = 0;
+        m_axisEventPending[m_axis]         = true;
     });
 
     m_resource->setAxisDiscrete([this](CZwlrVirtualPointerV1* r, uint32_t timeMs, uint32_t axis_, wl_fixed_t value, int32_t discrete) {
@@ -88,6 +90,7 @@ CVirtualPointerV1Resource::CVirtualPointerV1Resource(SP<CZwlrVirtualPointerV1> r
         m_axisEvents[m_axis].axis          = sc<wl_pointer_axis>(m_axis);
         m_axisEvents[m_axis].delta         = wl_fixed_to_double(value);
         m_axisEvents[m_axis].deltaDiscrete = discrete * 120;
+        m_axisEventPending[m_axis]         = true;
     });
 }
 

--- a/src/protocols/VirtualPointer.hpp
+++ b/src/protocols/VirtualPointer.hpp
@@ -47,6 +47,7 @@ class CVirtualPointerV1Resource {
     uint32_t                            m_axis = 0;
 
     std::array<IPointer::SAxisEvent, 2> m_axisEvents;
+    std::array<bool, 2>                 m_axisEventPending = {false, false};
 };
 
 class CVirtualPointerProtocol : public IWaylandProtocol {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Fixes https://github.com/hyprwm/Hyprland/discussions/15318, which is 2 inter-connected issue. The first being the `timeMs == 0` events getting dropped silently, and the second being wheel-source events with no discrete value getting dropped.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

- Tested it locally. 
    - At first I tried just skipping the emulation branch in `InputManager.cpp` for smooth-only events (`deltaDiscrete == 0 && delta != 0`). My reasoning being that there's no discrete data to try and emulate. And that mostly worked with my apps, except for kitty, which made me realize Hyprland always passes `axis_value120` even if the value is zero, and kitty was using that value and ignoring delta. So I adjusted to account for that by synthesizing the missing discrete value
- Made sure `clang-format` passes


#### Is it ready for merging, or does it need work?
I think it's ready! I haven't written C++ code in a while so apologies if there are any obvious bugs.


