### PR TITLE
helpers: fallback for std::ranges::starts_with on GCC 15

### DIFF
--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -832,7 +832,16 @@ bool truthy(const std::string& str) {
     });
 
     return [&](auto&&... prefixes) -> bool {
-        return (... || std::ranges::starts_with(str_view, prefixes));
+        auto starts_with = [](auto&& range, std::string_view prefix) {
+            auto it = std::ranges::begin(range);
+            auto end = std::ranges::end(range);
+            for (char c : prefix) {
+                if (it == end || *it != c) return false;
+                ++it;
+            }
+            return true;
+        };
+        return (... || starts_with(str_view, prefixes));
     }("true"sv, "yes"sv, "on"sv);
     // clang-format on
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
Hyprland recently introduced `std::ranges::starts_with` in `src/helpers/MiscFunctions.cpp`. This C++23 feature is only implemented in libstdc++ starting with GCC 16. 

This PR replaces `std::ranges::starts_with` with a custom zero-allocation lambda to allow Hyprland to build successfully on GCC 15. 

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

NOTHING

#### Is it ready for merging, or does it need work?

READY
