### PR TITLE
MonitorState: Fix cursor option for default_monitor

### DIFF
--- a/src/state/MonitorState.cpp
+++ b/src/state/MonitorState.cpp
@@ -90,7 +90,8 @@ static void checkDefaultCursorWarp(PHLMONITOR monitor) {
     }
 
     if (!cursorDefaultDone && *PCURSORMONITOR != STRVAL_EMPTY) {
-        if (*PCURSORMONITOR == monitor->m_name) {
+        const auto MONITOR = State::monitorState()->query().configString(*PCURSORMONITOR).run();
+        if (MONITOR && MONITOR->m_id == monitor->m_id) {
             cursorDefaultDone = true;
             Pointer::pointerController()->warpTo(POS, true);
             g_pInputManager->refocus();


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
The `default_monitor` cursor setting wasn't making use of the monitor state query engine and only only able to match by monitor name.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
No

#### Is it ready for merging, or does it need work?
Ready

