### PR TITLE
input: disable libinput send events when pointer device is disabled

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1329,6 +1329,13 @@ void CInputManager::setPointerConfigs() {
                 m->m_connected = false;
             }
 
+            if (m->aq() && m->aq()->getLibinputHandle()) {
+                const auto LIBINPUTDEV = m->aq()->getLibinputHandle();
+                const auto mode        = ENABLED ? LIBINPUT_CONFIG_SEND_EVENTS_ENABLED : LIBINPUT_CONFIG_SEND_EVENTS_DISABLED;
+                if (libinput_device_config_send_events_get_mode(LIBINPUTDEV) != mode)
+                    libinput_device_config_send_events_set_mode(LIBINPUTDEV, mode);
+            }
+
             for (const auto tagString : CVarList2(Config::mgr()->getDeviceString(devname, "tags"))) {
                 m->m_deviceTags.emplace(std::string_view(tagString));
             }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
When a pointer device is configured with `enabled = false` in Hyprland, only the Hyprland-side listener is detached via `detachPointer()`. The device remains active at the libinput level, meaning libinput still processes its events and includes its state in the seat-wide button count returned by `libinput_event_pointer_get_seat_button_count()`.

Aquamarine uses this seat count as a guard when dispatching button events:

https://github.com/hyprwm/aquamarine/blob/6d6e2384f381def4ea4ea81543cba4bbdac72457/src/backend/Session.cpp#L581
```cpp
        case LIBINPUT_EVENT_POINTER_BUTTON: {
            auto       pe        = libinput_event_get_pointer_event(e);
            const auto SEATCOUNT = libinput_event_pointer_get_seat_button_count(pe);
            const bool PRESSED   = libinput_event_pointer_get_button_state(pe) == LIBINPUT_BUTTON_STATE_PRESSED;

            if ((PRESSED && SEATCOUNT != 1) || (!PRESSED && SEATCOUNT != 0))
                break;  // <-- event silently dropped
```

Because the disabled device's button state still contributes to `SEATCOUNT`, the guard incorrectly suppresses events from other pointer devices on the same seat. 

#### Steps to reproduce:
1. Disable a pointer device via Hyprland config (`enabled = false`).
2. Press a button down on that disabled device.
3. `SEATCOUNT` is now == 1 because the device is still tracked by libinput.
4. press the same button on any *healthy* pointer device. The event is dropped by the guard ( `SEATCOUNT == 2`).
5. The healthy device is now permanently stuck —— its button events can never arrive because the disabled device's button state keeps `SEATCOUNT` non-zero.

---

The fix disables the device at the libinput level via `libinput_device_config_send_events_set_mode(DISABLED)`, mirroring what `setTouchDeviceConfigs()` already does.
https://github.com/hyprwm/Hyprland/blob/7a5214614b2f5bec4dbe1d0bddbc128c79cd2dfb/src/managers/input/InputManager.cpp#L1916-L1924
I'm not aware of any adverse side effects from this change, and it has been working well in my testing so far.

---

*(I'm not a native English speaker. I wrote this PR myself and used AI to polish the wording.)*