### PR TITLE
fix: display lock died screen on restart after crash

### DIFF
--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -446,6 +446,13 @@ void CCompositor::initServer(std::string socketName, int socketFd) {
 
     initManagers(STAGE_LATE);
 
+    m_listeners.lock = g_pSessionLockManager->m_events.lock.listen([this] { writeWatchdogFd("lock"); });
+
+    m_listeners.unlock = g_pSessionLockManager->m_events.unlock.listen([this] {
+        m_lockedCrash = false;
+        writeWatchdogFd("unlock");
+    });
+
     if (m_lockedCrash)
         g_pSessionLockManager->forceLock();
 

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -446,15 +446,21 @@ void CCompositor::initServer(std::string socketName, int socketFd) {
 
     initManagers(STAGE_LATE);
 
-    m_listeners.lock = g_pSessionLockManager->m_events.lock.listen([this] { writeWatchdogFd("lock"); });
+    if (m_lockedCrash)
+        g_pSessionLockManager->forceLock();
+
+    m_listeners.lock = g_pSessionLockManager->m_events.lock.listen([this] {
+        if (m_lockedCrash) {
+            // Lock manager was restored
+            m_lockedCrash = false;
+        }
+        writeWatchdogFd("lock");
+    });
 
     m_listeners.unlock = g_pSessionLockManager->m_events.unlock.listen([this] {
         m_lockedCrash = false;
         writeWatchdogFd("unlock");
     });
-
-    if (m_lockedCrash)
-        g_pSessionLockManager->forceLock();
 
     for (auto const& o : pendingOutputs) {
         State::monitorState()->add(o);

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -152,6 +152,14 @@ bool CCompositor::setWatchdogFd(int fd) {
     return m_watchdogWriteFd.isValid() && !m_watchdogWriteFd.isClosed();
 }
 
+bool CCompositor::writeWatchdogFd(std::string str) {
+    if (!m_watchdogWriteFd.isValid())
+        return false;
+    str += '\n';
+    auto w = write(m_watchdogWriteFd.get(), str.c_str(), str.size());
+    return w >= 0;
+}
+
 void CCompositor::bumpNofile() {
     if (!getrlimit(RLIMIT_NOFILE, &m_originalNofile))
         Log::logger->log(Log::DEBUG, "Old rlimit: soft -> {}, hard -> {}", m_originalNofile.rlim_cur, m_originalNofile.rlim_max);
@@ -438,6 +446,9 @@ void CCompositor::initServer(std::string socketName, int socketFd) {
 
     initManagers(STAGE_LATE);
 
+    if (m_lockedCrash)
+        g_pSessionLockManager->forceLock();
+
     for (auto const& o : pendingOutputs) {
         State::monitorState()->add(o);
     }
@@ -551,8 +562,7 @@ void CCompositor::cleanup() {
     if (!m_wlDisplay)
         return;
 
-    if (m_watchdogWriteFd.isValid()) [[maybe_unused]]
-        auto w = write(m_watchdogWriteFd.get(), "end", 3);
+    writeWatchdogFd("end");
 
     signal(SIGABRT, SIG_DFL);
     signal(SIGSEGV, SIG_DFL);
@@ -805,7 +815,7 @@ void CCompositor::startCompositor() {
     Event::bus()->m_events.ready.emit();
 
     if (m_watchdogWriteFd.isValid()) {
-        if (write(m_watchdogWriteFd.get(), "vax", 3) < 0)
+        if (!writeWatchdogFd("vax"))
             Log::logger->log(Log::ERR, "startCompositor: failed to write to watchdogWriteFd {}: {}", m_watchdogWriteFd.get(), strerror(errno));
     }
 

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1,7 +1,6 @@
 #include <ranges>
 
 #include "Compositor.hpp"
-#include "config/lua/ConfigManager.hpp"
 #include "config/supplementary/executor/Executor.hpp"
 #include "debug/log/Logger.hpp"
 #include "desktop/DesktopTypes.hpp"
@@ -467,15 +466,8 @@ void CCompositor::initServer(std::string socketName, int socketFd) {
     if (m_startLocked) {
         g_pSessionLockManager->forceLock();
 
-        if (!m_startLockedCommand.empty()) {
-            if (Config::mgr()->type() != Config::CONFIG_LUA) {
-                Log::logger->log(Log::CRIT, "--locked [COMMAND] flag used with non lua config!");
-                throwError("--locked [COMMAND] used with non lua config!");
-            }
-
-            auto luaMgr = dynamicPointerCast<Config::Lua::CConfigManager>(WP<Config::IConfigManager>(Config::mgr()));
-            luaMgr->eval(std::format("hl.dispatch(hl.dsp.exec_cmd([[{}]]))", m_startLockedCommand), false);
-        }
+        if (!m_startLockedCommand.empty())
+            Config::Supplementary::executor()->spawn(m_startLockedCommand);
     }
 
     for (auto const& o : pendingOutputs) {

--- a/src/Compositor.cpp
+++ b/src/Compositor.cpp
@@ -1,6 +1,7 @@
 #include <ranges>
 
 #include "Compositor.hpp"
+#include "config/lua/ConfigManager.hpp"
 #include "config/supplementary/executor/Executor.hpp"
 #include "debug/log/Logger.hpp"
 #include "desktop/DesktopTypes.hpp"
@@ -446,21 +447,36 @@ void CCompositor::initServer(std::string socketName, int socketFd) {
 
     initManagers(STAGE_LATE);
 
-    if (m_lockedCrash)
-        g_pSessionLockManager->forceLock();
-
     m_listeners.lock = g_pSessionLockManager->m_events.lock.listen([this] {
-        if (m_lockedCrash) {
-            // Lock manager was restored
-            m_lockedCrash = false;
+        static int lock_count = 0;
+        // lock_count used to avoid triggering condition on initial forceLock()
+        if (m_startLocked && lock_count >= 1) {
+            // Lock manager has taken over
+            m_startLocked = false;
+            m_startLockedCommand.clear();
         }
+        lock_count++;
         writeWatchdogFd("lock");
     });
 
     m_listeners.unlock = g_pSessionLockManager->m_events.unlock.listen([this] {
-        m_lockedCrash = false;
+        m_startLocked = false;
         writeWatchdogFd("unlock");
     });
+
+    if (m_startLocked) {
+        g_pSessionLockManager->forceLock();
+
+        if (!m_startLockedCommand.empty()) {
+            if (Config::mgr()->type() != Config::CONFIG_LUA) {
+                Log::logger->log(Log::CRIT, "--locked [COMMAND] flag used with non lua config!");
+                throwError("--locked [COMMAND] used with non lua config!");
+            }
+
+            auto luaMgr = dynamicPointerCast<Config::Lua::CConfigManager>(WP<Config::IConfigManager>(Config::mgr()));
+            luaMgr->eval(std::format("hl.dispatch(hl.dsp.exec_cmd([[{}]]))", m_startLockedCommand), false);
+        }
+    }
 
     for (auto const& o : pendingOutputs) {
         State::monitorState()->add(o);

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -46,7 +46,7 @@ class CCompositor {
 
     bool                     m_initialized = false;
     bool                     m_safeMode    = false;
-    bool                     m_lockedCrash = false;
+    bool                     m_startLocked = false;
     SP<Aquamarine::CBackend> m_aqBackend;
 
     std::string              m_hyprTempDataRoot = "";
@@ -55,6 +55,8 @@ class CCompositor {
     std::string              m_instanceSignature = "";
     std::string              m_instancePath      = "";
     std::string              m_currentSplash     = "error";
+
+    std::string              m_startLockedCommand = "";
 
     void                     initServer(std::string socketName, int socketFd);
     void                     startCompositor();

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -105,6 +105,11 @@ class CCompositor {
     wl_event_source*               m_critSigSource  = nullptr;
     rlimit                         m_originalNofile = {};
     Hyprutils::OS::CFileDescriptor m_watchdogWriteFd;
+
+    struct {
+        CHyprSignalListener lock;
+        CHyprSignalListener unlock;
+    } m_listeners;
 };
 
 inline UP<CCompositor> g_pCompositor;

--- a/src/Compositor.hpp
+++ b/src/Compositor.hpp
@@ -46,6 +46,7 @@ class CCompositor {
 
     bool                     m_initialized = false;
     bool                     m_safeMode    = false;
+    bool                     m_lockedCrash = false;
     SP<Aquamarine::CBackend> m_aqBackend;
 
     std::string              m_hyprTempDataRoot = "";
@@ -62,6 +63,7 @@ class CCompositor {
     void                     bumpNofile();
     void                     restoreNofile();
     bool                     setWatchdogFd(int fd);
+    bool                     writeWatchdogFd(std::string);
 
     bool                     m_sessionActive          = true;
     bool                     m_dpmsStateOn            = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,7 +38,7 @@ static void help() {
     --verify-config              - Do not run Hyprland, only print if the config has any errors
     --version           -v       - Print this binary's version
     --version-json               - Print this binary's version as json
-    --locked-crash               - Used by start-hyprland)#");
+    --locked [COMMAND]           - Launches locker on startup via the provided command)#");
 }
 
 static void reapZombieChildrenAutomatically() {
@@ -71,8 +71,9 @@ int main(int argc, char** argv) {
     // parse some args
     std::string configPath;
     std::string socketName;
+    std::string startLockedCommand;
     int         socketFd   = -1;
-    bool        ignoreSudo = false, verifyConfig = false, safeMode = false, lockedCrash = false;
+    bool        ignoreSudo = false, verifyConfig = false, safeMode = false, startLocked = false;
     int         watchdogFd = -1;
 
     if (argc > 1) {
@@ -177,8 +178,17 @@ int main(int argc, char** argv) {
                     help();
                     return 1;
                 }
-            } else if (value == "--locked-crash") {
-                lockedCrash = true;
+            } else if (value == "--locked") {
+                startLocked = true;
+
+                if (std::next(it) != args.end()) {
+                    startLockedCommand = *std::next(it);
+                    if (!startLockedCommand.starts_with("-"))
+                        it++;
+                    else
+                        startLockedCommand.clear();
+                }
+                std::println("startLockedCommand: {}", startLockedCommand);
                 continue;
             } else {
                 std::println(stderr, "[ ERROR ] Unknown option '{}' !", value);
@@ -264,8 +274,10 @@ int main(int argc, char** argv) {
     if (safeMode)
         g_pCompositor->m_safeMode = true;
 
-    if (lockedCrash)
-        g_pCompositor->m_lockedCrash = true;
+    if (startLocked) {
+        g_pCompositor->m_startLocked        = true;
+        g_pCompositor->m_startLockedCommand = startLockedCommand;
+    }
 
     if (!watchdogOk && !verifyConfig)
         Log::logger->log(Log::WARN, "WARNING: Hyprland is being launched without start-hyprland. This is highly advised against.");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,7 +38,7 @@ static void help() {
     --verify-config              - Do not run Hyprland, only print if the config has any errors
     --version           -v       - Print this binary's version
     --version-json               - Print this binary's version as json
-    --locked-crash               - Hyprland crashed while locked)#");
+    --locked-crash               - Used by start-hyprland)#");
 }
 
 static void reapZombieChildrenAutomatically() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,7 +38,7 @@ static void help() {
     --verify-config              - Do not run Hyprland, only print if the config has any errors
     --version           -v       - Print this binary's version
     --version-json               - Print this binary's version as json
-    --locked [COMMAND]           - Launches locker on startup via the provided command)#");
+    --locked-cmd [COMMAND]       - Launches locker on startup via the provided command)#");
 }
 
 static void reapZombieChildrenAutomatically() {
@@ -178,17 +178,19 @@ int main(int argc, char** argv) {
                     help();
                     return 1;
                 }
+            } else if (value == "--locked-cmd") {
+                if (std::next(it) == args.end()) {
+                    help();
+                    return 1;
+                }
+
+                startLocked        = true;
+                startLockedCommand = *std::next(it);
+                it++;
+
+                continue;
             } else if (value == "--locked") {
                 startLocked = true;
-
-                if (std::next(it) != args.end()) {
-                    startLockedCommand = *std::next(it);
-                    if (!startLockedCommand.starts_with("-"))
-                        it++;
-                    else
-                        startLockedCommand.clear();
-                }
-                std::println("startLockedCommand: {}", startLockedCommand);
                 continue;
             } else {
                 std::println(stderr, "[ ERROR ] Unknown option '{}' !", value);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,8 @@ static void help() {
     --i-am-really-stupid         - Omits root user privileges check (why would you do that?)
     --verify-config              - Do not run Hyprland, only print if the config has any errors
     --version           -v       - Print this binary's version
-    --version-json               - Print this binary's version as json)#");
+    --version-json               - Print this binary's version as json
+    --locked-crash               - Hyprland crashed while locked)#");
 }
 
 static void reapZombieChildrenAutomatically() {
@@ -71,7 +72,7 @@ int main(int argc, char** argv) {
     std::string configPath;
     std::string socketName;
     int         socketFd   = -1;
-    bool        ignoreSudo = false, verifyConfig = false, safeMode = false;
+    bool        ignoreSudo = false, verifyConfig = false, safeMode = false, lockedCrash = false;
     int         watchdogFd = -1;
 
     if (argc > 1) {
@@ -176,6 +177,9 @@ int main(int argc, char** argv) {
                     help();
                     return 1;
                 }
+            } else if (value == "--locked-crash") {
+                lockedCrash = true;
+                continue;
             } else {
                 std::println(stderr, "[ ERROR ] Unknown option '{}' !", value);
                 help();
@@ -259,6 +263,9 @@ int main(int argc, char** argv) {
         watchdogOk = g_pCompositor->setWatchdogFd(watchdogFd);
     if (safeMode)
         g_pCompositor->m_safeMode = true;
+
+    if (lockedCrash)
+        g_pCompositor->m_lockedCrash = true;
 
     if (!watchdogOk && !verifyConfig)
         Log::logger->log(Log::WARN, "WARNING: Hyprland is being launched without start-hyprland. This is highly advised against.");

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -52,7 +52,7 @@ CSessionLockManager::CSessionLockManager() {
 void CSessionLockManager::onNewSessionLock(SP<CSessionLock> pLock) {
     static auto PALLOWRELOCK = CConfigValue<Config::INTEGER>("misc:allow_session_lock_restore");
 
-    if (PROTO::sessionLock->isLocked() && !*PALLOWRELOCK) {
+    if (PROTO::sessionLock->isLocked() && !*PALLOWRELOCK && g_pCompositor->m_startLockedCommand.empty()) {
         LOGM(Log::DEBUG, "Cannot re-lock, misc:allow_session_lock_restore is disabled");
         pLock->sendDenied();
         return;

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -78,8 +78,7 @@ void CSessionLockManager::onNewSessionLock(SP<CSessionLock> pLock) {
     });
 
     m_sessionLock->listeners.unlock = pLock->m_events.unlockAndDestroy.listen([this] {
-        g_pCompositor->m_lockedCrash = false;
-        g_pCompositor->writeWatchdogFd("unlock");
+        m_events.unlock.emit();
 
         m_sessionLock.reset();
         g_pInputManager->refocus();
@@ -96,7 +95,7 @@ void CSessionLockManager::onNewSessionLock(SP<CSessionLock> pLock) {
             g_pHyprRenderer->damageMonitor(m);
     });
 
-    g_pCompositor->writeWatchdogFd("lock");
+    m_events.lock.emit();
 
     Desktop::focusState()->rawSurfaceFocus(nullptr);
     g_pSeatManager->setGrab(nullptr);
@@ -223,8 +222,7 @@ bool CSessionLockManager::clientDenied() {
 
 void CSessionLockManager::forceUnlock() {
     PROTO::sessionLock->forceUnlock();
-    g_pCompositor->m_lockedCrash = false;
-    g_pCompositor->writeWatchdogFd("unlock");
+    m_events.unlock.emit();
     m_sessionLock = {};
 
     Desktop::focusState()->rawSurfaceFocus(nullptr);
@@ -236,6 +234,7 @@ void CSessionLockManager::forceUnlock() {
 
 void CSessionLockManager::forceLock() {
     PROTO::sessionLock->forceLock();
+    m_events.lock.emit();
 }
 
 bool CSessionLockManager::shallConsiderLockMissing() {

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -78,6 +78,9 @@ void CSessionLockManager::onNewSessionLock(SP<CSessionLock> pLock) {
     });
 
     m_sessionLock->listeners.unlock = pLock->m_events.unlockAndDestroy.listen([this] {
+        g_pCompositor->m_lockedCrash = false;
+        g_pCompositor->writeWatchdogFd("unlock");
+
         m_sessionLock.reset();
         g_pInputManager->refocus();
 
@@ -92,6 +95,8 @@ void CSessionLockManager::onNewSessionLock(SP<CSessionLock> pLock) {
         for (auto const& m : State::monitorState()->monitors())
             g_pHyprRenderer->damageMonitor(m);
     });
+
+    g_pCompositor->writeWatchdogFd("lock");
 
     Desktop::focusState()->rawSurfaceFocus(nullptr);
     g_pSeatManager->setGrab(nullptr);
@@ -218,6 +223,8 @@ bool CSessionLockManager::clientDenied() {
 
 void CSessionLockManager::forceUnlock() {
     PROTO::sessionLock->forceUnlock();
+    g_pCompositor->m_lockedCrash = false;
+    g_pCompositor->writeWatchdogFd("unlock");
     m_sessionLock = {};
 
     Desktop::focusState()->rawSurfaceFocus(nullptr);
@@ -225,6 +232,10 @@ void CSessionLockManager::forceUnlock() {
         g_pHyprRenderer->damageMonitor(m);
 
     g_pInputManager->refocus();
+}
+
+void CSessionLockManager::forceLock() {
+    PROTO::sessionLock->forceLock();
 }
 
 bool CSessionLockManager::shallConsiderLockMissing() {

--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -220,10 +220,14 @@ bool CSessionLockManager::clientDenied() {
     return m_sessionLock && m_sessionLock->hasSentDenied;
 }
 
-void CSessionLockManager::forceUnlock() {
-    PROTO::sessionLock->forceUnlock();
+void CSessionLockManager::clearSessionLock() {
     m_events.unlock.emit();
     m_sessionLock = {};
+}
+
+void CSessionLockManager::forceUnlock() {
+    PROTO::sessionLock->forceUnlock();
+    clearSessionLock();
 
     Desktop::focusState()->rawSurfaceFocus(nullptr);
     for (auto const& m : State::monitorState()->monitors())

--- a/src/managers/SessionLockManager.hpp
+++ b/src/managers/SessionLockManager.hpp
@@ -87,6 +87,7 @@ class CSessionLockManager {
 
     void onNewSessionLock(SP<CSessionLock> pWlrLock);
     void removeSendLockedTimer();
+    void clearSessionLock();
 };
 
 inline UP<CSessionLockManager> g_pSessionLockManager;

--- a/src/managers/SessionLockManager.hpp
+++ b/src/managers/SessionLockManager.hpp
@@ -73,6 +73,11 @@ class CSessionLockManager {
 
     bool                    shallConsiderLockMissing();
 
+    struct {
+        CSignalT<> lock;
+        CSignalT<> unlock;
+    } m_events;
+
   private:
     UP<SSessionLock> m_sessionLock;
 

--- a/src/managers/SessionLockManager.hpp
+++ b/src/managers/SessionLockManager.hpp
@@ -65,6 +65,7 @@ class CSessionLockManager {
     bool                    anySessionLockSurfacesPresent();
 
     void                    forceUnlock();
+    void                    forceLock();
 
     void                    removeSessionLockSurface(SSessionLockSurface*);
 

--- a/src/protocols/SessionLock.cpp
+++ b/src/protocols/SessionLock.cpp
@@ -248,3 +248,13 @@ void CSessionLockProtocol::forceUnlock() {
 
     PROTO::lockNotify->onUnlocked();
 }
+
+void CSessionLockProtocol::forceLock() {
+    m_locked = true;
+
+    for (const auto& l : m_locks) {
+        l->sendLocked();
+    }
+
+    PROTO::lockNotify->onLocked();
+}

--- a/src/protocols/SessionLock.hpp
+++ b/src/protocols/SessionLock.hpp
@@ -74,6 +74,7 @@ class CSessionLockProtocol : public IWaylandProtocol {
 
     bool         isLocked();
     void         forceUnlock();
+    void         forceLock();
 
     struct {
         CSignalT<SP<CSessionLock>> newLock;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1680,13 +1680,16 @@ void IHyprRenderer::renderSessionLockPrimer(PHLMONITOR pMonitor) {
 }
 
 void IHyprRenderer::renderSessionLockMissing(PHLMONITOR pMonitor) {
+    if (g_pCompositor->m_startLocked && !g_pCompositor->m_startLockedCommand.empty())
+        return;
+
     const bool ANY_PRESENT = g_pSessionLockManager->anySessionLockSurfacesPresent();
 
     // ANY_PRESENT: render image2, without instructions. Lock still "alive", unless texture dead
     // else: render image, with instructions. Lock is gone.
     CBox                         monbox = {{}, pMonitor->m_pixelSize};
     CTexPassElement::SRenderData data;
-    if (g_pCompositor->m_lockedCrash)
+    if (g_pCompositor->m_startLocked && g_pCompositor->m_startLockedCommand.empty())
         data.tex = m_lockDead3Texture;
     else
         data.tex = (ANY_PRESENT) ? m_lockDead2Texture : m_lockDeadTexture;
@@ -2124,11 +2127,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     bool renderCursor = true;
 
-    if (g_pCompositor->m_lockedCrash) {
-        ensureLockTexturesRendered(true);
-        renderSessionLockPrimer(pMonitor);
-        renderSessionLockMissing(pMonitor);
-    } else if (pMonitor->m_solitaryClient && (!finalDamage.empty() || *PSOLDAMAGE))
+    if (pMonitor->m_solitaryClient && (!finalDamage.empty() || *PSOLDAMAGE))
         renderWindow(pMonitor->m_solitaryClient.lock(), pMonitor, NOW, false, RENDER_PASS_MAIN /* solitary = no popups */);
     else if (!finalDamage.empty()) {
         if (pMonitor->isMirror()) {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -1616,6 +1616,7 @@ void IHyprRenderer::ensureLockTexturesRendered(bool load) {
         // this will cause a small hitch. I don't think we can do much, other than wasting VRAM and having this loaded all the time.
         m_lockDeadTexture  = loadAsset("lockdead.png");
         m_lockDead2Texture = loadAsset("lockdead2.png");
+        m_lockDead3Texture = loadAsset("lockdead.png");
 
         const auto VT = g_pCompositor->getVTNr();
 
@@ -1623,6 +1624,7 @@ void IHyprRenderer::ensureLockTexturesRendered(bool load) {
     } else {
         m_lockDeadTexture.reset();
         m_lockDead2Texture.reset();
+        m_lockDead3Texture.reset();
         m_lockTtyTextTexture.reset();
     }
 }
@@ -1684,7 +1686,10 @@ void IHyprRenderer::renderSessionLockMissing(PHLMONITOR pMonitor) {
     // else: render image, with instructions. Lock is gone.
     CBox                         monbox = {{}, pMonitor->m_pixelSize};
     CTexPassElement::SRenderData data;
-    data.tex = (ANY_PRESENT) ? m_lockDead2Texture : m_lockDeadTexture;
+    if (g_pCompositor->m_lockedCrash)
+        data.tex = m_lockDead3Texture;
+    else
+        data.tex = (ANY_PRESENT) ? m_lockDead2Texture : m_lockDeadTexture;
     data.box = monbox;
     data.a   = 1;
 
@@ -2119,7 +2124,11 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     bool renderCursor = true;
 
-    if (pMonitor->m_solitaryClient && (!finalDamage.empty() || *PSOLDAMAGE))
+    if (g_pCompositor->m_lockedCrash) {
+        ensureLockTexturesRendered(true);
+        renderSessionLockPrimer(pMonitor);
+        renderSessionLockMissing(pMonitor);
+    } else if (pMonitor->m_solitaryClient && (!finalDamage.empty() || *PSOLDAMAGE))
         renderWindow(pMonitor->m_solitaryClient.lock(), pMonitor, NOW, false, RENDER_PASS_MAIN /* solitary = no popups */);
     else if (!finalDamage.empty()) {
         if (pMonitor->isMirror()) {

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -250,6 +250,7 @@ namespace Render {
 
         SP<ITexture>                       m_lockDeadTexture;
         SP<ITexture>                       m_lockDead2Texture;
+        SP<ITexture>                       m_lockDead3Texture;
         SP<ITexture>                       m_lockTtyTextTexture;
         CRenderPass*                       m_currentPass             = nullptr;
         bool                               m_monitorTransformEnabled = false; // do not modify directly

--- a/start/src/core/Instance.cpp
+++ b/start/src/core/Instance.cpp
@@ -25,12 +25,15 @@ using namespace Hyprutils::OS;
 using namespace std::string_literals;
 
 //
-void CHyprlandInstance::runHyprlandThread(bool safeMode) {
+void CHyprlandInstance::runHyprlandThread(bool safeMode, bool lockedCrash) {
     std::vector<std::string> argsStd;
     argsStd.emplace_back("--watchdog-fd");
     argsStd.emplace_back(std::format("{}", m_toHlPid.get()));
     if (safeMode)
         argsStd.emplace_back("--safe-mode");
+
+    if (lockedCrash)
+        argsStd.emplace_back("--locked-crash");
 
     for (const auto& a : g_state->rawArgvNoBinPath) {
         argsStd.emplace_back(a);
@@ -134,10 +137,22 @@ void CHyprlandInstance::dispatchHyprlandEvent() {
             m_hyprlandExiting = true;
             continue;
         }
+
+        if (sv == "lock") {
+            // session locked
+            m_hyprlandLocked = true;
+            continue;
+        }
+
+        if (sv == "unlock") {
+            // session unlocked
+            m_hyprlandLocked = false;
+            continue;
+        }
     }
 }
 
-bool CHyprlandInstance::run(bool safeMode) {
+bool CHyprlandInstance::run(bool safeMode, bool lockedCrash) {
     int pipefds[2];
     if (pipe(pipefds) != 0) {
         g_logger->log(Hyprutils::CLI::LOG_ERR, "pipe() failed, exiting");
@@ -159,7 +174,9 @@ bool CHyprlandInstance::run(bool safeMode) {
     m_wakeupRead.setFlags(m_wakeupRead.getFlags() | FD_CLOEXEC);
     m_wakeupWrite.setFlags(m_wakeupWrite.getFlags() | FD_CLOEXEC);
 
-    runHyprlandThread(safeMode);
+    m_hyprlandLocked = lockedCrash;
+
+    runHyprlandThread(safeMode, lockedCrash);
 
     pollfd pollfds[2] = {
         {

--- a/start/src/core/Instance.cpp
+++ b/start/src/core/Instance.cpp
@@ -33,7 +33,7 @@ void CHyprlandInstance::runHyprlandThread(bool safeMode, bool lockedCrash) {
         argsStd.emplace_back("--safe-mode");
 
     if (lockedCrash)
-        argsStd.emplace_back("--locked-crash");
+        argsStd.emplace_back("--locked");
 
     for (const auto& a : g_state->rawArgvNoBinPath) {
         argsStd.emplace_back(a);

--- a/start/src/core/Instance.hpp
+++ b/start/src/core/Instance.hpp
@@ -17,7 +17,7 @@ class CHyprlandInstance {
     bool run(bool safeMode = false, bool lockedCrash = false); // if returns false, restart.
     void forceQuit();
 
-    bool                           m_hyprlandLocked     = false;
+    bool m_hyprlandLocked = false;
 
   private:
     void                           runHyprlandThread(bool safeMode, bool lockedCrash);

--- a/start/src/core/Instance.hpp
+++ b/start/src/core/Instance.hpp
@@ -14,11 +14,13 @@ class CHyprlandInstance {
     CHyprlandInstance(CHyprlandInstance&)       = delete;
     CHyprlandInstance(CHyprlandInstance&&)      = delete;
 
-    bool run(bool safeMode = false); // if returns false, restart.
+    bool run(bool safeMode = false, bool lockedCrash = false); // if returns false, restart.
     void forceQuit();
 
+    bool                           m_hyprlandLocked     = false;
+
   private:
-    void                           runHyprlandThread(bool safeMode);
+    void                           runHyprlandThread(bool safeMode, bool lockedCrash);
     void                           clearFd(const Hyprutils::OS::CFileDescriptor& fd);
     void                           dispatchHyprlandEvent();
 

--- a/start/src/main.cpp
+++ b/start/src/main.cpp
@@ -102,9 +102,12 @@ int main(int argc, const char** argv, const char** envp) {
         g_logger->log(Hyprutils::CLI::LOG_DEBUG, "Hyprland was compiled with Nix - will use nixGL");
 
     bool safeMode = false;
+    bool lockedCrash = false;
+
     while (true) {
         g_instance     = makeUnique<CHyprlandInstance>();
-        const bool RET = g_instance->run(safeMode);
+        const bool RET = g_instance->run(safeMode, lockedCrash);
+        lockedCrash = g_instance->m_hyprlandLocked;
         g_instance.reset();
 
         if (!RET) {

--- a/start/src/main.cpp
+++ b/start/src/main.cpp
@@ -101,13 +101,13 @@ int main(int argc, const char** argv, const char** envp) {
     if (Nix::shouldUseNixGL())
         g_logger->log(Hyprutils::CLI::LOG_DEBUG, "Hyprland was compiled with Nix - will use nixGL");
 
-    bool safeMode = false;
+    bool safeMode    = false;
     bool lockedCrash = false;
 
     while (true) {
         g_instance     = makeUnique<CHyprlandInstance>();
         const bool RET = g_instance->run(safeMode, lockedCrash);
-        lockedCrash = g_instance->m_hyprlandLocked;
+        lockedCrash    = g_instance->m_hyprlandLocked;
         g_instance.reset();
 
         if (!RET) {


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->
#### Describe your PR, what does it fix/add?

Fixes a case where Hyprland started with start-hyprland restarts unlocked after crashing with a locked session.

This expands the communication from Hyprland to start-hyprland and introduces a new Hyprland CLI flag to allow the restarted instance to preserve the locked state. The displayed screen is the existing `lockdead.png` crash screen.

Fixes [#15314](https://github.com/hyprwm/Hyprland/issues/15314)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No.

#### Is it ready for merging, or does it need work?

It's ready, please review.
