### PR TITLE
core/output: don't destroy bound wl_output resources on same-name global replace

### DIFF
--- a/src/managers/ProtocolManager.cpp
+++ b/src/managers/ProtocolManager.cpp
@@ -87,6 +87,25 @@
 // * otherwise Hyprland might crash when exiting.                                             *
 // ********************************************************************************************
 
+// Retire the old wl_output global for `name` before a new one takes its map slot.
+// It must NOT be destroyed while clients still hold resources bound to it: destroying
+// them server-side makes each client's in-flight wl_output.release an "invalid object"
+// protocol error, fatally disconnecting every bound client (mass client kill on a fast
+// monitor unplug/replug, e.g. a power blip on an external screen).
+static void retireOutputGlobal(const std::string& name) {
+    if (!PROTO::outputs.contains(name))
+        return;
+
+    auto old = PROTO::outputs.at(name);
+    PROTO::outputs.erase(name);
+
+    if (!old->isDefunct())
+        old->remove();
+
+    if (old->hasBoundResources())
+        PROTO::defunctOutputs.emplace_back(old);
+}
+
 void CProtocolManager::onMonitorModeChange(PHLMONITOR pMonitor) {
     const bool ISMIRROR = pMonitor->isMirror();
 
@@ -97,8 +116,7 @@ void CProtocolManager::onMonitorModeChange(PHLMONITOR pMonitor) {
     if (ISMIRROR && PROTO::outputs.contains(pMonitor->m_name))
         PROTO::outputs.at(pMonitor->m_name)->remove();
     else if (!ISMIRROR && (!PROTO::outputs.contains(pMonitor->m_name) || PROTO::outputs.at(pMonitor->m_name)->isDefunct())) {
-        if (PROTO::outputs.contains(pMonitor->m_name))
-            PROTO::outputs.erase(pMonitor->m_name);
+        retireOutputGlobal(pMonitor->m_name);
         auto p = PROTO::outputs.emplace(pMonitor->m_name,
                                         makeShared<CWLOutputProtocol>(&wl_output_interface, 4, std::format("WLOutput ({})", pMonitor->m_name), pMonitor->m_self.lock()));
         p.first->second->m_self = p.first->second;
@@ -124,8 +142,7 @@ CProtocolManager::CProtocolManager() {
         if (M->isMirror())
             return;
 
-        if (PROTO::outputs.contains(M->m_name))
-            PROTO::outputs.erase(M->m_name);
+        retireOutputGlobal(M->m_name);
 
         auto ref = makeShared<CWLOutputProtocol>(&wl_output_interface, 4, std::format("WLOutput ({})", M->m_name), M->m_self.lock());
         PROTO::outputs.emplace(M->m_name, ref);
@@ -248,6 +265,7 @@ CProtocolManager::~CProtocolManager() {
 
     // Output
     PROTO::outputs.clear();
+    PROTO::defunctOutputs.clear();
 
     // Core
     PROTO::seat.reset();

--- a/src/managers/ProtocolManager.cpp
+++ b/src/managers/ProtocolManager.cpp
@@ -117,8 +117,8 @@ void CProtocolManager::onMonitorModeChange(PHLMONITOR pMonitor) {
         PROTO::outputs.at(pMonitor->m_name)->remove();
     else if (!ISMIRROR && (!PROTO::outputs.contains(pMonitor->m_name) || PROTO::outputs.at(pMonitor->m_name)->isDefunct())) {
         retireOutputGlobal(pMonitor->m_name);
-        auto p = PROTO::outputs.emplace(pMonitor->m_name,
-                                        makeShared<CWLOutputProtocol>(&wl_output_interface, 4, std::format("WLOutput ({})", pMonitor->m_name), pMonitor->m_self.lock()));
+        auto p                  = PROTO::outputs.emplace(pMonitor->m_name,
+                                                         makeShared<CWLOutputProtocol>(&wl_output_interface, 4, std::format("WLOutput ({})", pMonitor->m_name), pMonitor->m_self.lock()));
         p.first->second->m_self = p.first->second;
     }
 

--- a/src/managers/ProtocolManager.cpp
+++ b/src/managers/ProtocolManager.cpp
@@ -117,8 +117,8 @@ void CProtocolManager::onMonitorModeChange(PHLMONITOR pMonitor) {
         PROTO::outputs.at(pMonitor->m_name)->remove();
     else if (!ISMIRROR && (!PROTO::outputs.contains(pMonitor->m_name) || PROTO::outputs.at(pMonitor->m_name)->isDefunct())) {
         retireOutputGlobal(pMonitor->m_name);
-        auto p                  = PROTO::outputs.emplace(pMonitor->m_name,
-                                                         makeShared<CWLOutputProtocol>(&wl_output_interface, 4, std::format("WLOutput ({})", pMonitor->m_name), pMonitor->m_self.lock()));
+        auto p = PROTO::outputs.emplace(pMonitor->m_name,
+                                        makeShared<CWLOutputProtocol>(&wl_output_interface, 4, std::format("WLOutput ({})", pMonitor->m_name), pMonitor->m_self.lock()));
         p.first->second->m_self = p.first->second;
     }
 

--- a/src/protocols/core/Output.cpp
+++ b/src/protocols/core/Output.cpp
@@ -14,13 +14,16 @@ CWLOutputResource::CWLOutputResource(SP<CWlOutput> resource_, PHLMONITOR pMonito
     if (!m_monitor)
         return;
 
+    // route through the owning protocol object, not a name lookup: after a monitor
+    // unplug/replug PROTO::outputs.at(name) is a *new* global, and releases meant for the
+    // old defunct one would never drain it.
     m_resource->setOnDestroy([this](CWlOutput* r) {
-        if (m_monitor && PROTO::outputs.contains(m_monitor->m_name))
-            PROTO::outputs.at(m_monitor->m_name)->destroyResource(this);
+        if (m_owner)
+            m_owner->destroyResource(this);
     });
     m_resource->setRelease([this](CWlOutput* r) {
-        if (m_monitor && PROTO::outputs.contains(m_monitor->m_name))
-            PROTO::outputs.at(m_monitor->m_name)->destroyResource(this);
+        if (m_owner)
+            m_owner->destroyResource(this);
     });
 
     if (m_resource->version() >= 4) {
@@ -115,8 +118,19 @@ void CWLOutputProtocol::bindManager(wl_client* client, void* data, uint32_t ver,
 void CWLOutputProtocol::destroyResource(CWLOutputResource* resource) {
     std::erase_if(m_outputs, [&](const auto& other) { return other.get() == resource; });
 
-    if (m_outputs.empty() && m_defunct)
-        PROTO::outputs.erase(m_name);
+    if (m_outputs.empty() && m_defunct) {
+        // only erase the map entry if it is actually us: a new global with the same name may
+        // have replaced us (monitor replug), in which case we live in defunctOutputs.
+        // NOTE: either erase drops the last ref to `this` — nothing may run after it.
+        if (PROTO::outputs.contains(m_name) && PROTO::outputs.at(m_name).get() == this)
+            PROTO::outputs.erase(m_name);
+        else
+            std::erase_if(PROTO::defunctOutputs, [this](const auto& other) { return other.get() == this; });
+    }
+}
+
+bool CWLOutputProtocol::hasBoundResources() {
+    return !m_outputs.empty();
 }
 
 std::vector<SP<CWLOutputResource>> CWLOutputProtocol::outputResourcesFrom(wl_client* client) {

--- a/src/protocols/core/Output.hpp
+++ b/src/protocols/core/Output.hpp
@@ -67,9 +67,9 @@ class CWLOutputProtocol : public IWaylandProtocol {
 
 namespace PROTO {
     inline std::unordered_map<std::string, SP<CWLOutputProtocol>> outputs;
-    // defunct globals that were replaced by a new global with the same name but still have
-    // client-bound resources. Destroying those resources server-side would fatally error the
-    // clients ("invalid object" on their in-flight wl_output.release); they are kept here
-    // until every client has released, then drop out via destroyResource.
+    // defunct globals that are gone but not yet unref'd by all clients. Destroying their
+    // still-bound resources server-side would fatally error the clients ("invalid object"
+    // on their in-flight wl_output.release); they are kept here until every client has
+    // released, then drop out via destroyResource.
     inline std::vector<SP<CWLOutputProtocol>> defunctOutputs;
 };

--- a/src/protocols/core/Output.hpp
+++ b/src/protocols/core/Output.hpp
@@ -43,7 +43,8 @@ class CWLOutputProtocol : public IWaylandProtocol {
 
     // will mark the protocol for removal, will be removed when no. of bound outputs is 0 (or when overwritten by a new global)
     void remove();
-    bool isDefunct(); // true if above was called
+    bool isDefunct();        // true if above was called
+    bool hasBoundResources(); // true if any client still holds a wl_output resource of ours
 
     struct {
         CSignalT<SP<CWLOutputResource>> outputBound;
@@ -66,4 +67,9 @@ class CWLOutputProtocol : public IWaylandProtocol {
 
 namespace PROTO {
     inline std::unordered_map<std::string, SP<CWLOutputProtocol>> outputs;
+    // defunct globals that were replaced by a new global with the same name but still have
+    // client-bound resources. Destroying those resources server-side would fatally error the
+    // clients ("invalid object" on their in-flight wl_output.release); they are kept here
+    // until every client has released, then drop out via destroyResource.
+    inline std::vector<SP<CWLOutputProtocol>> defunctOutputs;
 };

--- a/src/protocols/core/Output.hpp
+++ b/src/protocols/core/Output.hpp
@@ -43,7 +43,7 @@ class CWLOutputProtocol : public IWaylandProtocol {
 
     // will mark the protocol for removal, will be removed when no. of bound outputs is 0 (or when overwritten by a new global)
     void remove();
-    bool isDefunct();        // true if above was called
+    bool isDefunct();         // true if above was called
     bool hasBoundResources(); // true if any client still holds a wl_output resource of ours
 
     struct {


### PR DESCRIPTION
# Describe your PR, what does it fix/add?

Fixes a mass client disconnect on fast monitor unplug/replug (e.g. an external HDMI screen losing power for a second, DPMS-adjacent output transitions).

When a monitor comes back with the same name while clients still hold `wl_output` resources of the old global, `CProtocolManager`'s `monitor.added` listener (and the same pattern in `onMonitorModeChange`) does `PROTO::outputs.erase(name)` before emplacing the new global. Erasing the map entry destructs the old `CWLOutputProtocol`, which destroys **server-side** every `wl_output` resource clients still hold. Each client then processes the `global_remove` it was just sent and answers with `wl_output.release` — but the id is already dead, so libwayland-server posts `invalid object N` on `wl_display` and fatally disconnects the client. On a real power blip this killed nearly every running app at once (Chrome, fcitx5, quickshell, xdg-desktop-portal-hyprland, …) with the compositor itself surviving.

Repro on v0.55.4 and current main, no hardware needed:

```
hyprctl output create headless test
# let any client bind it (any running app that binds wl_output), then:
hyprctl --batch "output remove test ; output create headless test"
# -> every client that bound "test" is disconnected with:
#    wl_display#1: error 0: invalid object NN
```

The fix retires the old global instead of destroying it:

- `retireOutputGlobal()` removes it from `PROTO::outputs` (and from the registry via `remove()` if not already defunct), but if clients still hold resources it is parked in `PROTO::defunctOutputs` and stays alive until they all release.
- `CWLOutputResource`'s destroy/release handlers route through `m_owner` instead of a `PROTO::outputs.at(name)` lookup, so releases reach the defunct global they actually belong to (the name now points at the new global).
- The self-erase in `destroyResource()` is identity-checked, so a draining defunct global can no longer erase the healthy same-name global that replaced it (latent variant of the same bug).

No new fields on any class (ABI-stable for plugins); one new inline vector `PROTO::defunctOutputs`, cleared in `~CProtocolManager`.

# Is it ready for merging, or does it need work?

Ready for review. Tested on v0.55.4 (patched via nixpkgs) and rebased on main: with the patch, the repro above leaves all clients connected; the defunct global drains once the last `release` arrives.
