### PR TITLE
fix SIGSEGV on dladdr1 failure

### DIFF
--- a/src/debug/crash/CrashReporter.cpp
+++ b/src/debug/crash/CrashReporter.cpp
@@ -216,9 +216,8 @@ void CrashReporter::createAndSaveCrash(int sig) {
         // convert in memory address to VMA address
         Dl_info          info;
         struct link_map* linkMap;
-        if (dladdr1(CALLSTACK[i].adr, &info, rc<void**>(&linkMap), RTLD_DL_LINKMAP)) {
+        if (dladdr1(CALLSTACK[i].adr, &info, rc<void**>(&linkMap), RTLD_DL_LINKMAP))
             vmaAddr = rc<size_t>(CALLSTACK[i].adr) - linkMap->l_addr;
-        }
 #else
         // musl doesn't define dladdr1
 #endif

--- a/src/debug/crash/CrashReporter.cpp
+++ b/src/debug/crash/CrashReporter.cpp
@@ -211,17 +211,17 @@ void CrashReporter::createAndSaveCrash(int sig) {
 
     std::string addrs = "";
     for (size_t i = 0; i < CALLSTACK.size(); ++i) {
+        size_t vmaAddr = (size_t)CALLSTACK[i].adr;
 #ifdef __GLIBC__
         // convert in memory address to VMA address
         Dl_info          info;
         struct link_map* linkMap;
-        dladdr1(CALLSTACK[i].adr, &info, rc<void**>(&linkMap), RTLD_DL_LINKMAP);
-        size_t vmaAddr = rc<size_t>(CALLSTACK[i].adr) - linkMap->l_addr;
+        if (dladdr1(CALLSTACK[i].adr, &info, rc<void**>(&linkMap), RTLD_DL_LINKMAP)) {
+            vmaAddr = rc<size_t>(CALLSTACK[i].adr) - linkMap->l_addr;
+        }
 #else
         // musl doesn't define dladdr1
-        size_t vmaAddr = (size_t)CALLSTACK[i].adr;
 #endif
-
         addrs += std::format("0x{:x} ", vmaAddr);
     }
 #ifdef __clang__


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

When crash happens because of malformed instruction pointer - attempt to unwrap its `vmaAddr` via `dladdr1` call fails since there is no .so mapped to this callstack entry and dereference of uninitialized `link_map` object leads to another SIGSEGV, this time in CrashReporter itself.

#### Is it ready for merging, or does it need work?

I think so