### PR TITLE
crop popup snapshots to popup size

### DIFF
--- a/src/desktop/state/PopupFadeout.cpp
+++ b/src/desktop/state/PopupFadeout.cpp
@@ -44,6 +44,9 @@ SP<CPopupFadeout> CPopupFadeout::create(SP<CPopup> popup, SP<Render::IFramebuffe
     fadeout->m_monitor     = MONITOR;
     fadeout->m_framebuffer = snapshot;
 
+    const CBox EXTENTS   = popup->wlSurface()->resource()->extends();
+    fadeout->m_renderBox = CBox{popup->coordsGlobal() + EXTENTS.pos() - MONITOR->m_position, EXTENTS.size()}.scale(MONITOR->m_scale).round();
+
     static CConfigValue PBLURIGNOREA = CConfigValue<Config::FLOAT>("decoration:blur:popups_ignorealpha");
     if (shouldBlurPopup()) {
         fadeout->m_effects.textureBlur.enabled               = true;
@@ -81,8 +84,7 @@ int CPopupFadeout::zIndex() const {
 }
 
 CBox CPopupFadeout::renderBox() const {
-    const auto MONITOR = m_monitor.lock();
-    return MONITOR ? CBox{{}, MONITOR->m_transformedSize} : CBox{};
+    return m_renderBox;
 }
 
 float CPopupFadeout::alpha() const {

--- a/src/desktop/state/PopupFadeout.hpp
+++ b/src/desktop/state/PopupFadeout.hpp
@@ -21,5 +21,6 @@ namespace Desktop {
         PHLMONITORREF     m_monitor;
         int               m_zIndex = 0;
         PHLANIMVAR<float> m_alpha;
+        CBox              m_renderBox;
     };
 }

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -3135,21 +3135,34 @@ SP<IFramebuffer> IHyprRenderer::makeSnapshotFB(WP<Desktop::View::CPopup> popup) 
 
     Log::logger->log(Log::DEBUG, "renderer: making a snapshot of {:x}", rc<uintptr_t>(popup.get()));
 
-    CRegion    fakeDamage{0, 0, PMONITOR->m_transformedSize.x, PMONITOR->m_transformedSize.y};
+    const CBox EXTENTS    = popup->wlSurface()->resource()->extends();
+    const CBox LOGICALBOX = CBox{popup->coordsGlobal() + EXTENTS.pos() - PMONITOR->m_position, EXTENTS.size()}.scale(PMONITOR->m_scale).round();
 
-    const auto PFRAMEBUFFER = createFB("popup shapshot");
+    if (LOGICALBOX.width < 1 || LOGICALBOX.height < 1)
+        return nullptr;
 
-    PFRAMEBUFFER->alloc(PMONITOR->m_pixelSize.x, PMONITOR->m_pixelSize.y, DRM_FORMAT_ABGR8888);
+    CRegion    fakeDamage{0, 0, LOGICALBOX.width, LOGICALBOX.height};
+    const auto PFRAMEBUFFER = createFB("popup snapshot");
+
+    PFRAMEBUFFER->alloc(LOGICALBOX.width, LOGICALBOX.height, DRM_FORMAT_ABGR8888);
+    if (const auto TEX = PFRAMEBUFFER->getTexture(); TEX)
+        TEX->m_transform = Math::wlTransformToHyprutils(PMONITOR->m_transform);
     PFRAMEBUFFER->setImageDescription(PMONITOR->workBufferImageDescription());
 
     beginFullFakeRender(PMONITOR, fakeDamage, PFRAMEBUFFER);
+
+    m_renderData.fbSize          = LOGICALBOX.size();
+    m_renderData.transformDamage = false;
+    setProjectionType(RPT_EXPORT);
+    setViewport(0, 0, LOGICALBOX.width, LOGICALBOX.height);
 
     m_bRenderingSnapshot = true;
 
     draw(CClearPassElement::SClearData{CHyprColor(0, 0, 0, 0)});
 
     CSurfacePassElement::SRenderData renderdata;
-    renderdata.pos             = popup->coordsGlobal();
+    // place the extents' top-left at the framebuffer origin; getTexBox() computes pos + localPos - monitor pos
+    renderdata.pos             = PMONITOR->m_position - EXTENTS.pos();
     renderdata.alpha           = 1.F;
     renderdata.dontRound       = true; // don't round popups
     renderdata.pMonitor        = PMONITOR;
@@ -3177,6 +3190,7 @@ SP<IFramebuffer> IHyprRenderer::makeSnapshotFB(WP<Desktop::View::CPopup> popup) 
     endRender();
 
     m_bRenderingSnapshot = false;
+
     return PFRAMEBUFFER;
 }
 


### PR DESCRIPTION
crop the snapshot to the size of the popup instead of full monitor snapshots. reduces a lot of overhead in fading out popups. 

math is not my strong side, so the transform calculations might be off, but tried mimic it from the elementrenderer where transform/scale is calculated. locally tested rotating and scaling and seems to work.


