### PR TITLE
renderer/cm: fix blur clipping with HDR

### DIFF
--- a/src/render/OpenGL.cpp
+++ b/src/render/OpenGL.cpp
@@ -1684,6 +1684,16 @@ void CHyprOpenGLImpl::renderTextureMatte(SP<ITexture> tex, const CBox& box, SP<I
     tex->unbind();
 }
 
+static SCMSettings blurIntermediateCMSettings(bool toIntermediate) {
+    const auto WORKBUFFER   = g_pHyprRenderer->workBufferImageDescription();
+    const auto INTERMEDIATE = getDefaultImageDescription();
+
+    auto       settings = toIntermediate ? g_pHyprRenderer->getCMSettings(WORKBUFFER, INTERMEDIATE) : g_pHyprRenderer->getCMSettings(INTERMEDIATE, WORKBUFFER);
+    auto&      range    = toIntermediate ? settings.dstTFRange : settings.srcTFRange;
+    range.max           = std::max(range.max, sc<float>(WORKBUFFER->value().luminances.max));
+    return settings;
+}
+
 // This probably isn't the fastest
 // but it works... well, I guess?
 //
@@ -1745,7 +1755,9 @@ SP<IFramebuffer> CHyprOpenGLImpl::blurFramebufferWithDamage(float a, CRegion* or
         const bool skipCM = !m_cmSupported || !g_pHyprRenderer->workBufferImageDescription()->needsCM(getDefaultImageDescription());
         if (!skipCM) {
             shader = useShader(getShaderVariant(SH_FRAG_BLURPREPARE, SH_FEAT_CM));
-            passCMUniforms(shader, g_pHyprRenderer->workBufferImageDescription(), getDefaultImageDescription());
+
+            passCMUniforms(shader, g_pHyprRenderer->workBufferImageDescription(), getDefaultImageDescription(), false, -1.F, -1,
+                           blurIntermediateCMSettings(/* toIntermediate */ true));
             shader->setUniformFloat(SHADER_SDR_SATURATION,
                                     m_renderData.pMonitor->m_sdrSaturation > 0 &&
                                             g_pHyprRenderer->workBufferImageDescription()->value().transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ ?
@@ -1866,7 +1878,9 @@ SP<IFramebuffer> CHyprOpenGLImpl::blurFramebufferWithDamage(float a, CRegion* or
         const bool skipCM = !m_cmSupported || !g_pHyprRenderer->workBufferImageDescription()->needsCM(getDefaultImageDescription());
         if (!skipCM) {
             shader = useShader(getShaderVariant(SH_FRAG_BLURFINISH, SH_FEAT_CM));
-            passCMUniforms(shader, getDefaultImageDescription(), g_pHyprRenderer->workBufferImageDescription());
+
+            passCMUniforms(shader, getDefaultImageDescription(), g_pHyprRenderer->workBufferImageDescription(), false, -1.F, -1,
+                           blurIntermediateCMSettings(/* toIntermediate */ false));
             shader->setUniformFloat(SHADER_SDR_SATURATION,
                                     m_renderData.pMonitor->m_sdrSaturation > 0 &&
                                             g_pHyprRenderer->workBufferImageDescription()->value().transferFunction == NColorManagement::CM_TRANSFER_FUNCTION_ST2084_PQ ?

--- a/src/render/shaders/glsl/blurFinish.glsl
+++ b/src/render/shaders/glsl/blurFinish.glsl
@@ -30,11 +30,7 @@ vec4 blurFinish(vec4 pixColor, vec2 v_texcoord, float noise, float brightness
     pixColor.rgb *= min(1.0, brightness);
 
 #if USE_CM
-    if (targetTF == CM_TRANSFER_FUNCTION_EXT_LINEAR) {
-        pixColor = doColorManagement(pixColor, 1.0, sourceTF, targetTF, convertMatrix, srcTFRange, vec2(0.0, 160.0)); // FIXME wtf
-    } else {
-        pixColor = doColorManagement(pixColor, 1.0, sourceTF, targetTF, convertMatrix, srcTFRange, dstTFRange);
-    }
+    pixColor = doColorManagement(pixColor, 1.0, sourceTF, targetTF, convertMatrix, srcTFRange, dstTFRange);
 #endif
 
     return pixColor;

--- a/src/render/shaders/glsl/blurprepare.glsl
+++ b/src/render/shaders/glsl/blurprepare.glsl
@@ -22,7 +22,7 @@ vec4 blurPrepare(vec4 pixColor, float contrast, float brightness
         pixColor.rgb /= sdrBrightnessMultiplier;
     }
     pixColor.rgb = convertMatrix * toLinearRGB(pixColor.rgb, sourceTF);
-    pixColor     = toNit(pixColor, vec2(srcTFRange[0], srcRefLuminance));
+    pixColor     = toNit(pixColor, srcTFRange);
     pixColor     = fromLinearNit(pixColor, targetTF, dstTFRange);
 #endif
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

Problem: The blurprepare intermediate used an 80-nit range but HDR pixels can be much brighter. A 200-nit pixel was encoded as:

    (200/80)^(1/2.2) = 1.52

which would get clamped to 1 causing clipping.

Solution: Use the workbuffer's configured max luminance (1000, for example) for the range so that a 200-nit pixel becomes:

    (200/1000)^(1/2.2) = 0.48

We also must consistently use the EXT_LINEAR transfer function range in blurprepare/blurFinish.

Note: KDE somewhat similarly uses gamma 2.2 encoding where 1.0 == max luminance of monitor:
https://zamundaaa.github.io/wayland/2024/11/02/hdr-and-color-management-in-kwin-part-4.html


Before Picture (note bad clipping of the highlights):

<img width="4284" height="5712" alt="before" src="https://github.com/user-attachments/assets/baff0da0-49c7-41d2-964f-e1019b0f92ea" />


After Picture (no clipping):

<img width="4284" height="5712" alt="after" src="https://github.com/user-attachments/assets/ae2eab5b-58ce-43e4-88a2-70041fbb1881" />


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No issues that I am aware of.

#### Is it ready for merging, or does it need work?

Ready
