### PR TITLE
pointer: fix two stale cursor images clearings

### DIFF
--- a/src/pointer/PointerManager.cpp
+++ b/src/pointer/PointerManager.cpp
@@ -288,6 +288,14 @@ void CPointerManager::resetCursorImage(bool apply) {
 void CPointerManager::updateCursorBackend() {
     const auto CURSORBOX = getCursorBoxGlobal();
 
+    const auto damageSoftwareLeftover = [](const SP<SMonitorPointerState>& state, const PHLMONITOR& m) {
+        if (!state->swRendered)
+            return;
+
+        state->swRendered = false;
+        m->addDamage(state->swRenderedBox.copy().expand(4).scale(m->m_scale).round());
+    };
+
     for (auto const& m : State::monitorState()->monitors()) {
         if (!m->m_enabled || !m->m_dpmsStatus) {
             Log::logger->log(Log::TRACE, "Not updating hw cursors: disabled / dpms off display");
@@ -297,10 +305,18 @@ void CPointerManager::updateCursorBackend() {
         auto CROSSES = !m->logicalBox().intersection(CURSORBOX).empty();
         auto state   = stateFor(m);
 
+        // previous display manager might have left a cursor on the plane.
+        // so clear the plane once, even if we never have set it ourselves.
+        if (!state->initialPlaneCleared)
+            state->initialPlaneCleared = state->cursorFrontBuffer ||
+                !(m->m_output->getBackend()->capabilities() & Aquamarine::IBackendImplementation::eBackendCapabilities::AQ_BACKEND_CAPABILITY_POINTER) ||
+                setHWCursorBuffer(state, nullptr);
+
         if (!CROSSES) {
             if (state->cursorFrontBuffer)
                 setHWCursorBuffer(state, nullptr);
 
+            damageSoftwareLeftover(state, m);
             continue;
         }
 
@@ -653,6 +669,8 @@ void CPointerManager::renderSoftwareCursorsFor(PHLMONITOR pMonitor, const Time::
     if (!texture)
         return;
 
+    const auto logicalBox = box.copy();
+
     box.scale(pMonitor->m_scale);
     box.x = std::round(box.x);
     box.y = std::round(box.y);
@@ -662,6 +680,12 @@ void CPointerManager::renderSoftwareCursorsFor(PHLMONITOR pMonitor, const Time::
     data.box = box.round();
 
     g_pHyprRenderer->m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
+
+    // to erase the leftover in updateCursorBackend()
+    if (!forceRender) {
+        state->swRendered    = true;
+        state->swRenderedBox = logicalBox;
+    }
 
     if (m_currentCursorImage.surface)
         m_currentCursorImage.surface->resource()->frame(now);

--- a/src/pointer/PointerManager.hpp
+++ b/src/pointer/PointerManager.hpp
@@ -175,9 +175,12 @@ namespace Pointer {
             int                     softwareLocks  = 0;
             bool                    hardwareFailed = false;
             CBox                    box; // logical
-            bool                    entered        = false;
-            bool                    hwApplied      = false;
-            bool                    cursorRendered = false;
+            bool                    entered             = false;
+            bool                    hwApplied           = false;
+            bool                    cursorRendered      = false;
+            bool                    initialPlaneCleared = false;
+            bool                    swRendered          = false;
+            CBox                    swRenderedBox; // logical, monitor local. valid only when swRendered
 
             SP<Aquamarine::IBuffer> cursorFrontBuffer;
         };


### PR DESCRIPTION
if previous display manager set a hwcursor and never clears it, we wont clear it until we actually set a new hw cursor ourself, so add initialPlaneCleared and clear it once on start. the !CROSSES if case only clears it if we have actually set it ourself.

if software cursor has been rendered and it now doesnt intersect with the monitor, clear it out once, guarded by swRendered.

