### PR TITLE
glframebuffer: fix spurious incomplete framebuffer errors

### DIFF
--- a/src/render/gl/GLFramebuffer.cpp
+++ b/src/render/gl/GLFramebuffer.cpp
@@ -9,11 +9,12 @@
 using namespace Hyprgraphics::Egl;
 using namespace Render::GL;
 
-CGLFramebuffer::CGLFramebuffer() : IFramebuffer() {}
-CGLFramebuffer::CGLFramebuffer(const std::string& name) : IFramebuffer(name) {}
+CGLFramebuffer::CGLFramebuffer() : IFramebuffer(), m_tempBuf(true) {}
+CGLFramebuffer::CGLFramebuffer(const std::string& name) : IFramebuffer(name), m_tempBuf(true) {}
 
 bool CGLFramebuffer::internalAlloc(int w, int h, uint32_t drmFormat) {
     g_pHyprOpenGL->makeEGLCurrent();
+    m_tempBuf = false;
 
     if (!m_tex) {
         m_tex = g_pHyprRenderer->createTexture();
@@ -63,7 +64,13 @@ bool CGLFramebuffer::internalAlloc(int w, int h, uint32_t drmFormat) {
     Log::logger->log(Log::DEBUG, "Framebuffer \"{}\" created, status {}", m_name, status);
 
     glBindTexture(GL_TEXTURE_2D, 0);
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+
+    // this can run mid frame in enableMirror() in begin() restore the draw fb the renderer had bound
+    if (g_pHyprRenderer && g_pHyprRenderer->m_renderData.currentFB)
+        g_pHyprRenderer->m_renderData.currentFB->bind();
+    else
+        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
 
     return true;
 }
@@ -77,8 +84,15 @@ void CGLFramebuffer::addStencil(SP<ITexture> tex) {
 }
 
 void CGLFramebuffer::bind() {
-    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_fb);
+    // temp buffer, created without CGLFramebuffer::internalAlloc.
+    // that means its a temp buffer that we have to raw bind and not change the viewport.
+    // the temp buffer code binds this fb to add attachments themself
+    if (m_tempBuf) {
+        glBindFramebuffer(GL_FRAMEBUFFER, m_fb);
+        return;
+    }
 
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, m_fb);
     if (g_pHyprOpenGL) {
         const auto& size = g_pHyprRenderer->m_renderData.pMonitor ? g_pHyprRenderer->m_renderData.pMonitor->m_pixelSize : m_size;
         g_pHyprOpenGL->setViewport(0, 0, size.x, size.y);
@@ -96,9 +110,14 @@ void CGLFramebuffer::release() {
         glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
         if (m_mirrorTex)
             glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT1, GL_TEXTURE_2D, 0, 0);
-        glBindFramebuffer(GL_FRAMEBUFFER, 0);
 
         glDeleteFramebuffers(1, &m_fb);
+
+        // releasing can happen mid frame from a temp fb, rebind the fb the renderer
+        // had previously bound, otherwise draws continue into fb 0 and raise GL_INVALID_FRAMEBUFFER_OPERATION
+        if (g_pHyprRenderer && g_pHyprRenderer->m_renderData.currentFB && g_pHyprRenderer->m_renderData.currentFB.get() != this)
+            g_pHyprRenderer->m_renderData.currentFB->bind();
+
         m_fbAllocated = false;
         m_fb          = 0;
     }

--- a/src/render/gl/GLFramebuffer.hpp
+++ b/src/render/gl/GLFramebuffer.hpp
@@ -29,6 +29,7 @@ namespace Render::GL {
 
       private:
         GLuint m_fb      = -1;
+        bool   m_tempBuf = false;
         bool   m_cleared = false;
 
         friend class CGLRenderbuffer;


### PR DESCRIPTION
paths like enableMirror internalAllocs a new framebuffer in begin() which means the previously bound currenfFB is reset to 0. if guard it at end of alloc and restore the previously fb instead of setting it to 0.

there is also codepaths where manually allocated CFLFramebuffers are created renderbuffers that later called ->bind() that also expects to be able to read it. bind GL_FRAMEBUFFER in those cases in bind()

and same on release() can be called mid frame on temp buffers deleting the framebuffer and binding 0 while we still want currentFB bound.


was showing up with gl_debugging = true

````
ERR ]: [GLES] Error in call at 1599@OpenGL.cpp: 0x506
ERR ]: [GLES] Error in call at 1599@OpenGL.cpp: 0x506
ERR ]: [GLES] Error in call at 1599@OpenGL.cpp: 0x506
ERR ]: [GLES] Error in call at 1599@OpenGL.cpp: 0x506
ERR ]: [GLES] Error in call at 1599@OpenGL.cpp: 0x506
ERR ]: [GLES] Error in call at 1599@OpenGL.cpp: 0x506
ERR ]: [GLES] Error in call at 1010@OpenGL.cpp: 0x506
ERR ]: [GLES] Error in call at 1010@OpenGL.cpp: 0x506
ERR ]: [GLES] Error in call at 2621@OpenGL.cpp: 0x506
ERR ]: [GLES] Error in call at 1010@OpenGL.cpp: 0x506
ERR ]: [GLES] Error in call at 1010@OpenGL.cpp: 0x506
ERR ]: [GLES] Error in call at 1010@OpenGL.cpp: 0x506
ERR ]: [GLES] Error in call at 2621@OpenGL.cpp: 0x506
ERR ]: [GLES] Error in call at 2621@OpenGL.cpp: 0x506
ERR ]: [GLES] Error in call at 1599@OpenGL.cpp: 0x506
ERR ]: [GLES] Error in call at 1599@OpenGL.cpp: 0x506
ERR ]: [GLES] Error in call at 1599@OpenGL.cpp: 0x506

````


