### PR TITLE
config: fix initial workspace tracking

### DIFF
--- a/hyprtester/src/tests/main/window.cpp
+++ b/hyprtester/src/tests/main/window.cpp
@@ -1270,8 +1270,9 @@ TEST_CASE(monitorrule) {
         OK(getFromSocket("/output remove HEADLESS-3"));
 
     OK(getFromSocket("/output create headless HEADLESS-3"));
+    const auto  MONALL = getFromSocket("/monitors all");
     CScopeGuard guard([&] {
-        if (getFromSocket("/monitors all").contains("HEADLESS-3"))
+        if (MONALL.contains("HEADLESS-3"))
             OK(getFromSocket("/output remove HEADLESS-3"));
     });
 
@@ -1280,7 +1281,8 @@ TEST_CASE(monitorrule) {
 
     Tests::spawnKitty("monitor_kitty");
     ASSERT(Tests::windowCount(), 1);
-    EXPECT_CONTAINS(getFromSocket("/activewindow"), "monitor: 2");
+    const auto MON_SRC_ID = Tests::getAttribute(getFromSocket("/activewindow"), "monitor");
+    ASSERT_CONTAINS(MONALL, "HEADLESS-3 (ID " + MON_SRC_ID);
     EXPECT_CONTAINS(getFromSocket("/activeworkspace"), "HEADLESS-3");
 
     Tests::killAllWindows();
@@ -1291,7 +1293,8 @@ TEST_CASE(monitorrule) {
 
     Tests::spawnKitty("silent_kitty");
     ASSERT(Tests::windowCount(), 1);
-    EXPECT_CONTAINS(getFromSocket("/clients"), "monitor: 2");
+    const auto SILENT_SRC_ID = Tests::getAttribute(getFromSocket("/clients"), "monitor");
+    ASSERT_CONTAINS(MONALL, "HEADLESS-3 (ID " + SILENT_SRC_ID);
     EXPECT_CONTAINS(getFromSocket("/activeworkspace"), "HEADLESS-2");
 }
 

--- a/src/config/legacy/ConfigManager.hpp
+++ b/src/config/legacy/ConfigManager.hpp
@@ -107,7 +107,6 @@ namespace Config::Legacy {
 
         std::string                m_configCurrentPath;
 
-        bool                       m_isLaunchingExecOnce                 = false; // For exec-once to skip initial ws tracking
         bool                       m_lastConfigVerificationWasSuccessful = true;
 
       private:

--- a/src/config/supplementary/executor/Executor.cpp
+++ b/src/config/supplementary/executor/Executor.cpp
@@ -25,6 +25,8 @@ CExecutor::CExecutor() {
         if (m_firstExecDispatched)
             return;
 
+        m_isLaunchingExecOnce = true;
+
         // update dbus env
         if (g_pCompositor->m_aqBackend->hasSession())
             spawnRaw(
@@ -48,6 +50,8 @@ CExecutor::CExecutor() {
         }
 
         m_execOnce.clear(); // free some kb of memory :P
+
+        m_isLaunchingExecOnce = false;
 
         // set input, fixes some certain issues
         g_pInputManager->setKeyboardLayout();
@@ -144,10 +148,10 @@ std::optional<uint64_t> CExecutor::spawnWithRules(std::string args, PHLWORKSPACE
     return spawnRawProc(args, pInitialWorkspace, execToken);
 }
 
-static std::vector<std::pair<std::string, std::string>> getHyprlandLaunchEnv(PHLWORKSPACE pInitialWorkspace) {
+std::vector<std::pair<std::string, std::string>> CExecutor::getHyprlandLaunchEnv(PHLWORKSPACE pInitialWorkspace) {
     static auto PINITIALWSTRACKING = CConfigValue<Config::INTEGER>("misc:initial_workspace_tracking");
 
-    if (!*PINITIALWSTRACKING)
+    if (!*PINITIALWSTRACKING || m_isLaunchingExecOnce)
         return {};
 
     const auto PMONITOR = Desktop::focusState()->monitor();

--- a/src/config/supplementary/executor/Executor.hpp
+++ b/src/config/supplementary/executor/Executor.hpp
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <optional>
+#include <utility>
 #include <cstdint>
 #include "../../../helpers/signal/Signal.hpp"
 #include "../../../helpers/memory/Memory.hpp"
@@ -36,9 +37,10 @@ namespace Config::Supplementary {
         std::optional<uint64_t> spawnWithRules(std::string, PHLWORKSPACE pInitialWorkspace = nullptr);
 
       private:
-        std::vector<SExecRequest> m_execOnce, m_execShutdown;
+        std::vector<SExecRequest>                        m_execOnce, m_execShutdown;
 
-        void                      applyRuleToProc(SP<Desktop::Rule::CWindowRule> rule, int64_t pid, const std::string& token);
+        void                                             applyRuleToProc(SP<Desktop::Rule::CWindowRule> rule, int64_t pid, const std::string& token);
+        std::vector<std::pair<std::string, std::string>> getHyprlandLaunchEnv(PHLWORKSPACE pInitialWorkspace);
 
         struct {
             CHyprSignalListener init;
@@ -46,6 +48,7 @@ namespace Config::Supplementary {
         } m_listeners;
 
         bool m_firstExecDispatched = false;
+        bool m_isLaunchingExecOnce = false;
     };
 
     UP<CExecutor>& executor();

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -1325,7 +1325,6 @@ std::unordered_map<std::string, std::string> CWindow::getEnv() {
         buffer.resize(buffer.size() + 512, '\0');
         needle += 512;
     }
-
     needle += ifs.gcount();
 #elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
     int    mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_ENV, sc<int>(PID)};


### PR DESCRIPTION
previous refactor over to Executor missed m_isLaunchingExecOnce meaning any hl.exec_cmd(hyprlauncher) got the token of 1337 month duration at the first launched workspace, so the initial launch of things gets that token and opens on the wrong workspace.

add m_isLaunchingExecOnce back, and make getHyprlandLaunchEnv a member of CExecutor aswell.

the needle counting also missed the final partial chunk if the read failed to read 512 bytes but still read a chunk.

fixes: https://github.com/hyprwm/Hyprland/discussions/14565


