### PR TITLE
config: fix cycle_next using nonexist layoutmsg for prev

### DIFF
--- a/src/config/shared/actions/ConfigActions.cpp
+++ b/src/config/shared/actions/ConfigActions.cpp
@@ -1699,7 +1699,7 @@ ActionResult Actions::cycleNext(const bool next, std::optional<bool> onlyTiled, 
 
             if (std::ranges::contains(LAYOUTS_WITH_CYCLE_NEXT, &typeid(*SPACE->algorithm()->tiledAlgo().get()))) {
                 // NOLINTNEXTLINE
-                Actions::layoutMessage(!next ? "cyclenext, b" : "cyclenext");
+                Actions::layoutMessage(!next ? "cycleprev" : "cyclenext");
                 return {};
             }
         }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes cycling backwards 🚴🏻‍♂️➡️ with common dispatchers.

`hl.bind('ALT+SHIFT+Tab', hl.dsp.window.cycle_next({tiled = true, next = false}))` used some weird layoutmsg instead of `cycleprev`, which these  layouts actually have.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

Ready
