### PR TITLE
layout/scroll: fix `focus_on_active` not scrolling to the focused window after switching to its workspace

### DIFF
--- a/src/desktop/state/FocusState.cpp
+++ b/src/desktop/state/FocusState.cpp
@@ -166,9 +166,11 @@ void CFocusState::rawWindowFocus(PHLWINDOW pWindow, eFocusReason reason, SP<CWLS
         PWORKSPACE->m_lastFocusedWindow = pWindow;
         if (PWORKSPACE->m_isSpecialWorkspace)
             m_focusMonitor->changeWorkspace(PWORKSPACE, false, true); // if special ws, open on current monitor
-        else if (PMONITOR)
+        else if (PMONITOR) {
             PMONITOR->changeWorkspace(PWORKSPACE, false, true);
-        // changeworkspace already calls focusWindow
+            // Call again with a hard focus reason so that on scrolling layout the viewport scrolls to the focused window
+            Desktop::focusState()->fullWindowFocus(pWindow, Desktop::FOCUS_REASON_SWITCH_TO_WINDOW_HARD);
+        }
         return;
     }
 


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

It switches to the workspace but doesn't scroll to the window in question.

This MR fixes that


The fix causes double fullWindowFocus() calls but changing the reason of the call inside changeworkspace would regress https://github.com/hyprwm/Hyprland/pull/13974 (viewport move when you're focused on a column when changing to another workspace)

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

WIP
- [ ] Test
