### PR TITLE
protocols: fix SHM cursor partial damage copy

### DIFF
--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -762,10 +762,11 @@ void CWLSurfaceResource::updateCursorShm(CRegion damage) {
     if (rectsNum == 1 && rects[0].x2 == buf->size.x && rects[0].y2 == buf->size.y)
         memcpy(shmData.data(), pixelData, bufLen);
     else {
-        damage.forEachRect([&pixelData, &shmData](const auto& box) {
+        const auto stride = shmAttrs.stride;
+        damage.forEachRect([&pixelData, &shmData, stride](const auto& box) {
             for (auto y = box.y1; y < box.y2; ++y) {
                 // bpp is 32 INSALLAH
-                auto begin = 4 * box.y1 * (box.x2 - box.x1) + box.x1;
+                auto begin = y * stride + 4 * box.x1;
                 auto len   = 4 * (box.x2 - box.x1);
                 memcpy(shmData.data() + begin, pixelData + begin, len);
             }


### PR DESCRIPTION
use the current row and the SHM stride when calculating copy offsets, the previous code calculated the copy offset incorrectly by always using the first damaged row and by assuming each row as only as wide as the damaged region.


