### PR TITLE
frame: fix frame scheduling being skipped or one vblank off

### DIFF
--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -146,20 +146,19 @@ void CMonitor::onConnect(bool noRule) {
             }
         }
 
-        timespec* ts = event.when;
+        timespec ts{};
+        auto     flags = event.flags;
 
-        if (ts && ts->tv_sec <= 2) {
+        if (event.when && event.when->tv_sec > 2) {
             // drop this timestamp, it's not valid. Likely drm is cringe. We can't push it further because
             // a) it's wrong, b) our translations aren't 100% accurate and risk underflows
-            ts = nullptr;
+            ts = *event.when;
+        } else {
+            clock_gettime(CLOCK_MONOTONIC, &ts);
+            flags &= ~Aquamarine::IOutput::AQ_OUTPUT_PRESENT_HW_CLOCK;
         }
 
-        if (!ts) {
-            timespec mono{};
-            clock_gettime(CLOCK_MONOTONIC, &mono);
-            PROTO::presentation->onPresented(m_self.lock(), mono, event.refresh, event.seq, event.flags & ~Aquamarine::IOutput::AQ_OUTPUT_PRESENT_HW_CLOCK);
-        } else
-            PROTO::presentation->onPresented(m_self.lock(), *ts, event.refresh, event.seq, event.flags);
+        PROTO::presentation->onPresented(m_self.lock(), ts, event.refresh, event.seq, flags);
 
         if (m_zoomAnimFrameCounter < 5) {
             m_zoomAnimFrameCounter++;
@@ -196,7 +195,7 @@ void CMonitor::onConnect(bool noRule) {
 
         m_frameScheduler->onPresented();
 
-        m_events.presented.emit(ts ? std::optional<Time::steady_tp>{Time::fromTimespec(ts)} : std::nullopt);
+        m_events.presented.emit(Time::fromTimespec(&ts));
     });
 
     m_listeners.destroy = m_output->events.destroy.listen([this] {

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -196,7 +196,7 @@ void CMonitor::onConnect(bool noRule) {
 
         m_frameScheduler->onPresented();
 
-        m_events.presented.emit(ts ? Time::fromTimespec(ts) : Time::steadyNow());
+        m_events.presented.emit(ts ? std::optional<Time::steady_tp>{Time::fromTimespec(ts)} : std::nullopt);
     });
 
     m_listeners.destroy = m_output->events.destroy.listen([this] {

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -196,7 +196,7 @@ void CMonitor::onConnect(bool noRule) {
 
         m_frameScheduler->onPresented();
 
-        m_events.presented.emit();
+        m_events.presented.emit(ts ? Time::fromTimespec(ts) : Time::steadyNow());
     });
 
     m_listeners.destroy = m_output->events.destroy.listen([this] {

--- a/src/output/Monitor.hpp
+++ b/src/output/Monitor.hpp
@@ -183,13 +183,13 @@ namespace Monitor {
         } m_tearingState;
 
         struct {
-            CSignalT<>                commit;
-            CSignalT<>                destroy;
-            CSignalT<>                connect;
-            CSignalT<>                disconnect;
-            CSignalT<>                dpmsChanged;
-            CSignalT<>                modeChanged;
-            CSignalT<Time::steady_tp> presented;
+            CSignalT<>                               commit;
+            CSignalT<>                               destroy;
+            CSignalT<>                               connect;
+            CSignalT<>                               disconnect;
+            CSignalT<>                               dpmsChanged;
+            CSignalT<>                               modeChanged;
+            CSignalT<std::optional<Time::steady_tp>> presented;
         } m_events;
 
         std::array<std::vector<PHLLSREF>, 4> m_layerSurfaceLayers;

--- a/src/output/Monitor.hpp
+++ b/src/output/Monitor.hpp
@@ -183,13 +183,13 @@ namespace Monitor {
         } m_tearingState;
 
         struct {
-            CSignalT<>                               commit;
-            CSignalT<>                               destroy;
-            CSignalT<>                               connect;
-            CSignalT<>                               disconnect;
-            CSignalT<>                               dpmsChanged;
-            CSignalT<>                               modeChanged;
-            CSignalT<std::optional<Time::steady_tp>> presented;
+            CSignalT<>                commit;
+            CSignalT<>                destroy;
+            CSignalT<>                connect;
+            CSignalT<>                disconnect;
+            CSignalT<>                dpmsChanged;
+            CSignalT<>                modeChanged;
+            CSignalT<Time::steady_tp> presented;
         } m_events;
 
         std::array<std::vector<PHLLSREF>, 4> m_layerSurfaceLayers;

--- a/src/output/Monitor.hpp
+++ b/src/output/Monitor.hpp
@@ -183,13 +183,13 @@ namespace Monitor {
         } m_tearingState;
 
         struct {
-            CSignalT<> commit;
-            CSignalT<> destroy;
-            CSignalT<> connect;
-            CSignalT<> disconnect;
-            CSignalT<> dpmsChanged;
-            CSignalT<> modeChanged;
-            CSignalT<> presented;
+            CSignalT<>                commit;
+            CSignalT<>                destroy;
+            CSignalT<>                connect;
+            CSignalT<>                disconnect;
+            CSignalT<>                dpmsChanged;
+            CSignalT<>                modeChanged;
+            CSignalT<Time::steady_tp> presented;
         } m_events;
 
         std::array<std::vector<PHLLSREF>, 4> m_layerSurfaceLayers;

--- a/src/protocols/CommitTiming.cpp
+++ b/src/protocols/CommitTiming.cpp
@@ -29,8 +29,11 @@ CCommitTimerResource::CCommitTimerResource(UP<CWpCommitTimerV1>&& resource_, SP<
 
         if (delay.count() <= 0) {
             m_surface->m_pending.pendingTimeout.reset();
-        } else
-            m_surface->m_pending.pendingTimeout = delay;
+            m_surface->m_pending.commitTimingTarget.reset();
+        } else {
+            m_surface->m_pending.pendingTimeout     = delay;
+            m_surface->m_pending.commitTimingTarget = Time::steady_tp{std::chrono::seconds((((uint64_t)tvHi) << 32) | tvLo) + std::chrono::nanoseconds(tvNsec)};
+        }
     });
 
     m_listeners.surfaceStateCommit = m_surface->m_events.stateCommit2.listen([this](auto state) {
@@ -39,11 +42,7 @@ CCommitTimerResource::CCommitTimerResource(UP<CWpCommitTimerV1>&& resource_, SP<
 
         m_surface->m_stateQueue.lock(state, LOCK_REASON_TIMER);
 
-        // record the absolute target so onMonitorPresent can release the lock on the first vblank at or after
-        // it. Otherwise the wall clock timer releases it at the target, missing that vblank and delaying
-        // presentation by one refresh cycle.
         std::erase_if(m_pendingTimedStates, [](const WP<SSurfaceState>& ws) { return !ws; });
-        state->commitTimingTarget = Time::steadyNow() + *state->pendingTimeout;
         m_pendingTimedStates.emplace_back(state);
 
         if (!state->timer) {

--- a/src/protocols/CommitTiming.cpp
+++ b/src/protocols/CommitTiming.cpp
@@ -25,14 +25,19 @@ CCommitTimerResource::CCommitTimerResource(UP<CWpCommitTimerV1>&& resource_, SP<
             return;
         }
 
-        const auto delay = Time::till({.tv_sec = (((uint64_t)tvHi) << 32) | (uint64_t)tvLo, .tv_nsec = tvNsec});
+        const timespec target{
+            .tv_sec  = sc<time_t>((sc<uint64_t>(tvHi) << 32) | sc<uint64_t>(tvLo)),
+            .tv_nsec = sc<long>(tvNsec),
+        };
+
+        const auto delay = Time::till(target);
 
         if (delay.count() <= 0) {
             m_surface->m_pending.pendingTimeout.reset();
             m_surface->m_pending.commitTimingTarget.reset();
         } else {
             m_surface->m_pending.pendingTimeout     = delay;
-            m_surface->m_pending.commitTimingTarget = Time::steady_tp{std::chrono::seconds((((uint64_t)tvHi) << 32) | tvLo) + std::chrono::nanoseconds(tvNsec)};
+            m_surface->m_pending.commitTimingTarget = Time::fromTimespec(&target);
         }
     });
 
@@ -131,11 +136,11 @@ bool CCommitTimingManagerResource::good() {
 
 CCommitTimingProtocol::CCommitTimingProtocol(const wl_interface* iface, const int& ver, const std::string& name) : IWaylandProtocol(iface, ver, name) {
     static auto P = Event::bus()->m_events.monitor.added.listen([this](PHLMONITOR M) {
-        M->m_events.presented.listenStatic([this, m = PHLMONITORREF{M}](const std::optional<Time::steady_tp>& presentTime) {
-            if (!m || !PROTO::commitTiming || !presentTime)
+        M->m_events.presented.listenStatic([this, m = PHLMONITORREF{M}](const Time::steady_tp& presentTime) {
+            if (!m || !PROTO::commitTiming)
                 return;
 
-            onMonitorPresent(m.lock(), *presentTime);
+            onMonitorPresent(m.lock(), presentTime);
         });
     });
 }

--- a/src/protocols/CommitTiming.cpp
+++ b/src/protocols/CommitTiming.cpp
@@ -151,7 +151,7 @@ void CCommitTimingProtocol::onMonitorPresent(PHLMONITOR m, const Time::steady_tp
             continue;
 
         const auto& OUTPUTS = timer->m_surface->m_enteredOutputs;
-        if (std::ranges::none_of(OUTPUTS, [&m](const auto& mon) { return mon == m; }))
+        if (OUTPUTS.size() != 1 || OUTPUTS[0] != m)
             continue;
 
         timer->releaseDueStates(UPCOMING_FLIP);

--- a/src/protocols/CommitTiming.cpp
+++ b/src/protocols/CommitTiming.cpp
@@ -132,11 +132,11 @@ bool CCommitTimingManagerResource::good() {
 
 CCommitTimingProtocol::CCommitTimingProtocol(const wl_interface* iface, const int& ver, const std::string& name) : IWaylandProtocol(iface, ver, name) {
     static auto P = Event::bus()->m_events.monitor.added.listen([this](PHLMONITOR M) {
-        M->m_events.presented.listenStatic([this, m = PHLMONITORREF{M}](const Time::steady_tp& presentTime) {
-            if (!m || !PROTO::commitTiming)
+        M->m_events.presented.listenStatic([this, m = PHLMONITORREF{M}](const std::optional<Time::steady_tp>& presentTime) {
+            if (!m || !PROTO::commitTiming || !presentTime)
                 return;
 
-            onMonitorPresent(m.lock(), presentTime);
+            onMonitorPresent(m.lock(), *presentTime);
         });
     });
 }

--- a/src/protocols/CommitTiming.cpp
+++ b/src/protocols/CommitTiming.cpp
@@ -1,7 +1,10 @@
 #include "CommitTiming.hpp"
 #include "core/Compositor.hpp"
+#include "../output/Monitor.hpp"
+#include "../event/EventBus.hpp"
 #include "../managers/eventLoop/EventLoopManager.hpp"
 #include "../managers/eventLoop/EventLoopTimer.hpp"
+#include <algorithm>
 
 CCommitTimerResource::CCommitTimerResource(UP<CWpCommitTimerV1>&& resource_, SP<CWLSurfaceResource> surface) : m_resource(std::move(resource_)), m_surface(surface) {
     if UNLIKELY (!m_resource->resource())
@@ -36,6 +39,13 @@ CCommitTimerResource::CCommitTimerResource(UP<CWpCommitTimerV1>&& resource_, SP<
 
         m_surface->m_stateQueue.lock(state, LOCK_REASON_TIMER);
 
+        // record the absolute target so onMonitorPresent can release the lock on the first vblank at or after
+        // it. Otherwise the wall clock timer releases it at the target, missing that vblank and delaying
+        // presentation by one refresh cycle.
+        std::erase_if(m_pendingTimedStates, [](const WP<SSurfaceState>& ws) { return !ws; });
+        state->commitTimingTarget = Time::steadyNow() + *state->pendingTimeout;
+        m_pendingTimedStates.emplace_back(state);
+
         if (!state->timer) {
             state->timer = makeShared<CEventLoopTimer>(
                 state->pendingTimeout,
@@ -51,6 +61,22 @@ CCommitTimerResource::CCommitTimerResource(UP<CWpCommitTimerV1>&& resource_, SP<
             state->timer->updateTimeout(state->pendingTimeout);
 
         state->pendingTimeout.reset();
+    });
+}
+
+void CCommitTimerResource::releaseDueStates(const Time::steady_tp& upcomingFlip) {
+    if (!m_surface)
+        return;
+
+    std::erase_if(m_pendingTimedStates, [this, &upcomingFlip](const WP<SSurfaceState>& ws) {
+        if (!ws)
+            return true;
+
+        if (!ws->commitTimingTarget.has_value() || *ws->commitTimingTarget > upcomingFlip)
+            return false; // not due yet, keep waiting
+
+        m_surface->m_stateQueue.unlock(ws, LOCK_REASON_TIMER);
+        return true;
     });
 }
 
@@ -105,7 +131,31 @@ bool CCommitTimingManagerResource::good() {
 }
 
 CCommitTimingProtocol::CCommitTimingProtocol(const wl_interface* iface, const int& ver, const std::string& name) : IWaylandProtocol(iface, ver, name) {
-    ;
+    static auto P = Event::bus()->m_events.monitor.added.listen([this](PHLMONITOR M) {
+        M->m_events.presented.listenStatic([this, m = PHLMONITORREF{M}](const Time::steady_tp& presentTime) {
+            if (!m || !PROTO::commitTiming)
+                return;
+
+            onMonitorPresent(m.lock(), presentTime);
+        });
+    });
+}
+
+void CCommitTimingProtocol::onMonitorPresent(PHLMONITOR m, const Time::steady_tp& presentTime) {
+    if (!m || m->m_refreshRate <= 0.F)
+        return;
+
+    const auto UPCOMING_FLIP = presentTime + std::chrono::nanoseconds(static_cast<int64_t>(1'000'000'000.0 / m->m_refreshRate));
+    for (const auto& timer : m_timers) {
+        if (!timer->m_surface)
+            continue;
+
+        const auto& OUTPUTS = timer->m_surface->m_enteredOutputs;
+        if (std::ranges::none_of(OUTPUTS, [&m](const auto& mon) { return mon == m; }))
+            continue;
+
+        timer->releaseDueStates(UPCOMING_FLIP);
+    }
 }
 
 void CCommitTimingProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {

--- a/src/protocols/CommitTiming.hpp
+++ b/src/protocols/CommitTiming.hpp
@@ -9,6 +9,7 @@
 
 class CWLSurfaceResource;
 class CEventLoopTimer;
+struct SSurfaceState;
 
 class CCommitTimerResource {
   public:
@@ -19,6 +20,12 @@ class CCommitTimerResource {
   private:
     UP<CWpCommitTimerV1>   m_resource;
     WP<CWLSurfaceResource> m_surface;
+
+    // states this timer has TIMER-locked and not yet released; drained by the per-present path.
+    std::vector<WP<SSurfaceState>> m_pendingTimedStates;
+
+    // release the TIMER lock on any queued state whose target is at or before the upcoming flip.
+    void releaseDueStates(const Time::steady_tp& upcomingFlip);
 
     struct {
         CHyprSignalListener surfaceStateCommit;
@@ -48,7 +55,7 @@ class CCommitTimingProtocol : public IWaylandProtocol {
   private:
     void destroyResource(CCommitTimingManagerResource* resource);
     void destroyResource(CCommitTimerResource* resource);
-
+    void onMonitorPresent(PHLMONITOR m, const Time::steady_tp& presentTime);
     //
     std::vector<UP<CCommitTimingManagerResource>> m_managers;
     std::vector<UP<CCommitTimerResource>>         m_timers;

--- a/src/protocols/Fifo.cpp
+++ b/src/protocols/Fifo.cpp
@@ -155,7 +155,7 @@ bool CFifoManagerResource::good() {
 
 CFifoProtocol::CFifoProtocol(const wl_interface* iface, const int& ver, const std::string& name) : IWaylandProtocol(iface, ver, name) {
     static auto P = Event::bus()->m_events.monitor.added.listen([this](PHLMONITOR M) {
-        M->m_events.presented.listenStatic([this, m = PHLMONITORREF{M}](const Time::steady_tp&) {
+        M->m_events.presented.listenStatic([this, m = PHLMONITORREF{M}](const std::optional<Time::steady_tp>&) {
             if (!m || !PROTO::fifo)
                 return;
 

--- a/src/protocols/Fifo.cpp
+++ b/src/protocols/Fifo.cpp
@@ -155,7 +155,7 @@ bool CFifoManagerResource::good() {
 
 CFifoProtocol::CFifoProtocol(const wl_interface* iface, const int& ver, const std::string& name) : IWaylandProtocol(iface, ver, name) {
     static auto P = Event::bus()->m_events.monitor.added.listen([this](PHLMONITOR M) {
-        M->m_events.presented.listenStatic([this, m = PHLMONITORREF{M}](const std::optional<Time::steady_tp>&) {
+        M->m_events.presented.listenStatic([this, m = PHLMONITORREF{M}](const Time::steady_tp&) {
             if (!m || !PROTO::fifo)
                 return;
 

--- a/src/protocols/Fifo.cpp
+++ b/src/protocols/Fifo.cpp
@@ -155,7 +155,7 @@ bool CFifoManagerResource::good() {
 
 CFifoProtocol::CFifoProtocol(const wl_interface* iface, const int& ver, const std::string& name) : IWaylandProtocol(iface, ver, name) {
     static auto P = Event::bus()->m_events.monitor.added.listen([this](PHLMONITOR M) {
-        M->m_events.presented.listenStatic([this, m = PHLMONITORREF{M}]() {
+        M->m_events.presented.listenStatic([this, m = PHLMONITORREF{M}](const Time::steady_tp&) {
             if (!m || !PROTO::fifo)
                 return;
 

--- a/src/protocols/types/SurfaceState.cpp
+++ b/src/protocols/types/SurfaceState.cpp
@@ -80,6 +80,7 @@ void SSurfaceState::reset() {
     fifoScheduled = false;
 
     pendingTimeout.reset();
+    commitTimingTarget.reset();
     timer.reset(); // CEventLoopManager::nudgeTimers should handle it eventually
 }
 

--- a/src/protocols/types/SurfaceState.hpp
+++ b/src/protocols/types/SurfaceState.hpp
@@ -101,6 +101,7 @@ struct SSurfaceState {
 
     // commit timing
     std::optional<Time::steady_dur> pendingTimeout;
+    std::optional<Time::steady_tp>  commitTimingTarget;
     SP<CEventLoopTimer>             timer;
 
     // helpers

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2034,7 +2034,9 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
             pMonitor->m_activeWorkspace->m_space->recalculate(Layout::RECALCULATE_REASON_RENDER_MONITOR);
     }
 
-    if (!pMonitor->m_output->needsFrame && pMonitor->m_forceFullFrames == 0)
+    // needsFrame can be cleared by commits that didnt consume our damage like a
+    // commit while a pageflip was in flight, so pending damage must keep the frame alive.
+    if (!pMonitor->m_output->needsFrame && pMonitor->m_forceFullFrames == 0 && !pMonitor->m_damage.hasChanged())
         return;
 
     // tearing and DS first
@@ -2209,8 +2211,6 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     if (!pMonitor->m_mirrors.empty())
         damageMirrorsWith(pMonitor, frameDamage);
 
-    pMonitor->m_renderingActive = false;
-
     Event::bus()->m_events.render.stage.emit(RENDER_POST);
 
     pMonitor->m_output->state->addDamage(frameDamage);
@@ -2220,6 +2220,9 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     if (commit)
         commitPendingAndDoExplicitSync(pMonitor);
+
+    // cleared only after the commit
+    pMonitor->m_renderingActive = false;
 
     if (shouldTear)
         pMonitor->m_tearingState.busy = true;


### PR DESCRIPTION
in renderer we need to check if we have pending damage, needsFrame can be cleared by commits that was done while pageflip was in flight.

m_renderingActive also needs to be set after actually comitting.

add a commitTimingTarget that we check against on presentation otherwise the committiming timer runs only on duration and might miss the upcoming vblank period as in always being one vblank late. and use the timespec we get from presentation.

wants: https://github.com/hyprwm/aquamarine/pull/334


warrants a bit of VRR/DS testing because of the needsFrame changes.


