### PR TITLE
fix: popup crashes on destroy

### DIFF
--- a/src/desktop/view/Popup.cpp
+++ b/src/desktop/view/Popup.cpp
@@ -395,7 +395,7 @@ PHLLS CPopup::layerOwner() const {
 Vector2D CPopup::coordsRelativeToParent() const {
     Vector2D offset;
 
-    if (!m_resource)
+    if (!m_resource || m_resource->m_surface.expired())
         return m_lastPos;
 
     WP<CPopup> current = m_self;
@@ -559,6 +559,10 @@ const CBox& CPopup::popupTreeExtents() const {
     for (size_t i = 0; i < popups.size(); ++i) {
         const auto& popup = popups[i];
         if (!popup)
+            continue;
+
+        // a popup whose xdg surface has been destroyed but the XDDGPopupResource not yet recevied onDestroy()
+        if (popup->m_resource && popup->m_resource->m_surface.expired())
             continue;
 
         if (popup->wlSurface() && popup->wlSurface()->resource()) {

--- a/src/desktop/view/Popup.cpp
+++ b/src/desktop/view/Popup.cpp
@@ -402,8 +402,11 @@ Vector2D CPopup::coordsRelativeToParent() const {
     offset -= current->m_resource->m_surface->m_current.geometry.pos();
 
     while (current->m_parent && current->m_resource) {
+        const auto SURFACE = current->wlSurface();
+        if (!SURFACE || !SURFACE->resource())
+            return m_lastPos;
 
-        offset += current->wlSurface()->resource()->m_current.offset;
+        offset += SURFACE->resource()->m_current.offset;
         offset += current->m_resource->m_geometry.pos();
 
         current = current->m_parent;


### PR DESCRIPTION
the xdg_surface can be destroyed before the xdg_popup, so CPopup::onDestroy
hasnt run yet and the popup is still in its parents m_children with m_wlSurface set.
if guard it in popupTreeExtents.

popups can be fading out while the resource is dead, ifguard it and return m_lastPos if thats the case.

fixes: https://github.com/hyprwm/Hyprland/discussions/15412
