### PR TITLE
protocols: avoid crash in lease

### DIFF
--- a/src/protocols/DRMLease.cpp
+++ b/src/protocols/DRMLease.cpp
@@ -74,14 +74,14 @@ CDRMLeaseResource::CDRMLeaseResource(SP<CWpDrmLeaseV1> resource_, SP<CDRMLeaseRe
         m->m_monitor->m_isBeingLeased = true;
     }
 
-    m_listeners.destroyLease = m_lease->events.destroy.listen([this] {
+    m_listeners.destroyLease = m_lease->events.destroy.listen([this, fd = m_lease->leaseFD] {
         for (auto const& m : m_requested) {
             if (m && m->m_monitor)
                 m->m_monitor->m_isBeingLeased = false;
         }
 
         m_resource->sendFinished();
-        LOGM(Log::DEBUG, "Revoking lease for fd {}", m_lease->leaseFD);
+        LOGM(Log::DEBUG, "Revoking lease for fd {}", fd);
     });
 
     LOGM(Log::DEBUG, "Granting lease, sending fd {}", m_lease->leaseFD);


### PR DESCRIPTION
dont have a device to test this with but should make sense i think.

when lease is destroyed the destroy listener nullptr deref m_lease, and all it uses it for is logging the fd number. capture the fd by value to avoid crashing.

fixes: https://github.com/hyprwm/Hyprland/discussions/15365