### PR TITLE
core: fix --verify-config crash

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -286,8 +286,11 @@ int main(int argc, char** argv) {
 
     g_pCompositor->initServer(socketName, socketFd);
 
-    if (verifyConfig)
-        return !Config::mgr()->configVerifPassed();
+    if (verifyConfig) {
+        const auto verify = Config::mgr()->configVerifPassed();
+        Config::mgr().reset();
+        return !verify;
+    }
 
     Log::logger->log(Log::DEBUG, "Hyprland init finished.");
 


### PR DESCRIPTION
verify path returned early without cleanup(), which made it destruct to late and call CWorkspaceAlgoMatcher thats already destroyed.

fixes: https://github.com/hyprwm/Hyprland/discussions/15406


