### PR TITLE
desktop/view: fix IView virtual inheritance and erase_if ptr

### DIFF
--- a/src/desktop/state/LayerState.cpp
+++ b/src/desktop/state/LayerState.cpp
@@ -19,7 +19,7 @@ CLayerState::CLayerState() {
         if (event.type != View::VIEW_TYPE_LAYER_SURFACE)
             return;
 
-        std::erase_if(m_layers, [&](auto& x) { return !x || rc<uintptr_t>(sc<View::IView*>(x.get())) == event.address; });
+        std::erase_if(m_layers, [&](auto& x) { return !x || rc<uintptr_t>(dc<View::IView*>(x.get())) == event.address; });
     });
 }
 

--- a/src/desktop/state/LayerState.cpp
+++ b/src/desktop/state/LayerState.cpp
@@ -19,7 +19,7 @@ CLayerState::CLayerState() {
         if (event.type != View::VIEW_TYPE_LAYER_SURFACE)
             return;
 
-        std::erase_if(m_layers, [&](auto& x) { return !x || rc<uintptr_t>(x.get()) == event.address; });
+        std::erase_if(m_layers, [&](auto& x) { return !x || rc<uintptr_t>(sc<View::IView*>(x.get())) == event.address; });
     });
 }
 

--- a/src/desktop/state/LayerState.cpp
+++ b/src/desktop/state/LayerState.cpp
@@ -19,7 +19,7 @@ CLayerState::CLayerState() {
         if (event.type != View::VIEW_TYPE_LAYER_SURFACE)
             return;
 
-        std::erase_if(m_layers, [&](auto& x) { return !x || rc<uintptr_t>(dc<View::IView*>(x.get())) == event.address; });
+        std::erase_if(m_layers, [&](auto& x) { return !x || event.view == dynamicPointerCast<View::IView>(x->m_self); });
     });
 }
 

--- a/src/desktop/state/OtherViewState.cpp
+++ b/src/desktop/state/OtherViewState.cpp
@@ -18,10 +18,7 @@ COtherViewState::COtherViewState() {
         if (event.type != View::VIEW_TYPE_LOCK_SCREEN)
             return;
 
-        std::erase_if(m_views, [&](const auto& view) {
-            const auto VIEW = view.lock();
-            return !VIEW || rc<uintptr_t>(VIEW.get()) == event.address;
-        });
+        std::erase_if(m_views, [&](const auto& view) { return !view || event.view == view; });
     });
 }
 

--- a/src/desktop/state/WindowState.cpp
+++ b/src/desktop/state/WindowState.cpp
@@ -21,7 +21,7 @@ CWindowState::CWindowState() {
         if (event.type != View::VIEW_TYPE_WINDOW)
             return;
 
-        std::erase_if(m_windows, [&](auto& x) { return !x || rc<uintptr_t>(x.get()) == event.address; });
+        std::erase_if(m_windows, [&](auto& x) { return !x || rc<uintptr_t>(sc<View::IView*>(x.get())) == event.address; });
     });
 }
 

--- a/src/desktop/state/WindowState.cpp
+++ b/src/desktop/state/WindowState.cpp
@@ -21,7 +21,7 @@ CWindowState::CWindowState() {
         if (event.type != View::VIEW_TYPE_WINDOW)
             return;
 
-        std::erase_if(m_windows, [&](auto& x) { return !x || dynamicPointerCast<View::IView>(x->m_self); });
+        std::erase_if(m_windows, [&](auto& x) { return !x || event.view == dynamicPointerCast<View::IView>(x->m_self); });
     });
 }
 

--- a/src/desktop/state/WindowState.cpp
+++ b/src/desktop/state/WindowState.cpp
@@ -21,7 +21,7 @@ CWindowState::CWindowState() {
         if (event.type != View::VIEW_TYPE_WINDOW)
             return;
 
-        std::erase_if(m_windows, [&](auto& x) { return !x || rc<uintptr_t>(dc<View::IView*>(x.get())) == event.address; });
+        std::erase_if(m_windows, [&](auto& x) { return !x || dynamicPointerCast<View::IView>(x->m_self); });
     });
 }
 

--- a/src/desktop/state/WindowState.cpp
+++ b/src/desktop/state/WindowState.cpp
@@ -21,7 +21,7 @@ CWindowState::CWindowState() {
         if (event.type != View::VIEW_TYPE_WINDOW)
             return;
 
-        std::erase_if(m_windows, [&](auto& x) { return !x || rc<uintptr_t>(sc<View::IView*>(x.get())) == event.address; });
+        std::erase_if(m_windows, [&](auto& x) { return !x || rc<uintptr_t>(dc<View::IView*>(x.get())) == event.address; });
     });
 }
 

--- a/src/desktop/view/SessionLock.hpp
+++ b/src/desktop/view/SessionLock.hpp
@@ -9,7 +9,7 @@
 class CSessionLockSurface;
 
 namespace Desktop::View {
-    class CSessionLock : public IView, public virtual IGeometric {
+    class CSessionLock : public virtual IView, public virtual IGeometric {
       public:
         static SP<CSessionLock> create(SP<CSessionLockSurface> resource);
 

--- a/src/desktop/view/Subsurface.hpp
+++ b/src/desktop/view/Subsurface.hpp
@@ -10,7 +10,7 @@ class CWLSubsurfaceResource;
 
 namespace Desktop::View {
     class CPopup;
-    class CSubsurface : public IView, public virtual IGeometric {
+    class CSubsurface : public virtual IView, public virtual IGeometric {
       public:
         // root dummy nodes
         static SP<CSubsurface> create(PHLWINDOW pOwner);

--- a/src/desktop/view/View.cpp
+++ b/src/desktop/view/View.cpp
@@ -17,7 +17,7 @@ IView::~IView() {
     if (!m_initialized)
         return;
 
-    Event::bus()->m_events.view.destroy.emit({.view = m_self, .type = m_type, .address = m_address});
+    Event::bus()->m_events.view.destroy.emit({.view = m_self, .type = m_type});
 }
 
 void IView::initView(WP<IView> self, eViewType type) {

--- a/src/event/EventBus.hpp
+++ b/src/event/EventBus.hpp
@@ -26,8 +26,7 @@ namespace Event {
 
     struct SViewDestroyEvent {
         PHLVIEWREF               view;
-        Desktop::View::eViewType type    = Desktop::View::VIEW_TYPE_WINDOW;
-        uintptr_t                address = 0;
+        Desktop::View::eViewType type = Desktop::View::VIEW_TYPE_WINDOW;
     };
 
     class CEventBus {


### PR DESCRIPTION
CSubsurface and CSessionLock inherited IView non-virtually while CWindow/CLayerSurface/CPopup inherited it virtually.

erase_if compared event.address with the derived complete object pointer. under virtual inheritance those addresses differ.



