### PR TITLE
dmabuf: ensure both create and create_immed verify v4

### DIFF
--- a/src/protocols/LinuxDMABUF.cpp
+++ b/src/protocols/LinuxDMABUF.cpp
@@ -28,10 +28,9 @@ static std::optional<dev_t> devIDFromFD(int fd) {
 CDMABUFFormatTable::CDMABUFFormatTable(SDMABUFTranche _rendererTranche, std::vector<std::pair<PHLMONITORREF, SDMABUFTranche>> tranches_) :
     m_rendererTranche(_rendererTranche), m_monitorTranches(tranches_) {
 
-    static const auto                       PSKIP_NON_KMS = CConfigValue<Config::INTEGER>("quirks:skip_non_kms_dmabuf_formats");
+    static const auto                    PSKIP_NON_KMS = CConfigValue<Config::INTEGER>("quirks:skip_non_kms_dmabuf_formats");
 
-    std::vector<SDMABUFFormatTableEntry>    formatsVec;
-    std::set<std::pair<uint32_t, uint64_t>> formats;
+    std::vector<SDMABUFFormatTableEntry> formatsVec;
 
     // insert formats into vec if they got inserted into set, meaning they're unique
     size_t i = 0;
@@ -50,7 +49,7 @@ CDMABUFFormatTable::CDMABUFFormatTable(SDMABUFTranche _rendererTranche, std::vec
                     continue;
                 }
             }
-            auto [_, inserted] = formats.emplace(fmt.drmFormat, mod);
+            auto [_, inserted] = m_formats.emplace(fmt.drmFormat, mod);
             if (inserted) {
                 // if it was inserted into set, then its unique and will have a new index in vec
                 m_rendererTranche.indices.push_back(i++);
@@ -76,7 +75,7 @@ CDMABUFFormatTable::CDMABUFFormatTable(SDMABUFTranche _rendererTranche, std::vec
                 // apparently these can implode on planes, so don't use them
                 if (mod == DRM_FORMAT_MOD_INVALID || mod == DRM_FORMAT_MOD_LINEAR)
                     continue;
-                auto [_, inserted] = formats.emplace(fmt.drmFormat, mod);
+                auto [_, inserted] = m_formats.emplace(fmt.drmFormat, mod);
                 if (inserted) {
                     tranche.indices.push_back(i++);
                     formatsVec.push_back(SDMABUFFormatTableEntry{
@@ -108,6 +107,10 @@ CDMABUFFormatTable::CDMABUFFormatTable(SDMABUFTranche _rendererTranche, std::vec
     munmap(arr, m_tableSize);
 
     m_tableFD = std::move(fds[1]);
+}
+
+bool CDMABUFFormatTable::contains(uint32_t fmt, uint64_t modifier) const {
+    return m_formats.contains({fmt, modifier});
 }
 
 CLinuxDMABuffer::CLinuxDMABuffer(uint32_t id, wl_client* client, Aquamarine::SDMABUFAttrs attrs) {
@@ -186,13 +189,6 @@ CLinuxDMABUFParamsResource::CLinuxDMABUFParamsResource(UP<CZwpLinuxBufferParamsV
         if (flags > 0) {
             r->sendFailed();
             LOGM(Log::ERR, "DMABUF flags are not supported");
-            return;
-        }
-
-        if (m_resource->version() >= 4 && std::ranges::none_of(PROTO::linuxDma->m_formatTable->m_rendererTranche.formats, [this, fmt](const auto format) {
-                return format.drmFormat == fmt && std::ranges::any_of(format.modifiers, [this](const auto mod) { return !mod || mod == m_attrs->modifier; });
-            })) {
-            r->error(ZWP_LINUX_BUFFER_PARAMS_V1_ERROR_INVALID_FORMAT, "format + modifier pair is not supported");
             return;
         }
 
@@ -307,6 +303,12 @@ bool CLinuxDMABUFParamsResource::verify() {
 
     if UNLIKELY (m_attrs->size.x < 1 || m_attrs->size.y < 1) {
         m_resource->error(ZWP_LINUX_BUFFER_PARAMS_V1_ERROR_INVALID_DIMENSIONS, "x/y < 1");
+        return false;
+    }
+
+    // Starting from version 4, the invalid_format protocol error is sent if the format + modifier pair was not advertised as supported.
+    if (m_resource->version() >= 4 && !PROTO::linuxDma->m_formatTable->contains(m_attrs->format, m_attrs->modifier)) {
+        m_resource->error(ZWP_LINUX_BUFFER_PARAMS_V1_ERROR_INVALID_FORMAT, "format + modifier pair is not supported");
         return false;
     }
 

--- a/src/protocols/LinuxDMABUF.hpp
+++ b/src/protocols/LinuxDMABUF.hpp
@@ -2,6 +2,8 @@
 
 #include <vector>
 #include <cstdint>
+#include <set>
+#include <utility>
 #include "WaylandProtocol.hpp"
 #include "wayland.hpp"
 #include "linux-dmabuf-v1.hpp"
@@ -51,10 +53,13 @@ class CDMABUFFormatTable {
     CDMABUFFormatTable(SDMABUFTranche rendererTranche, std::vector<std::pair<PHLMONITORREF, SDMABUFTranche>> tranches);
     ~CDMABUFFormatTable() = default;
 
+    bool                                                  contains(uint32_t fmt, uint64_t modifier) const;
+
     Hyprutils::OS::CFileDescriptor                        m_tableFD;
     size_t                                                m_tableSize = 0;
     SDMABUFTranche                                        m_rendererTranche;
     std::vector<std::pair<PHLMONITORREF, SDMABUFTranche>> m_monitorTranches;
+    std::set<std::pair<uint32_t, uint64_t>>               m_formats;
 };
 
 class CLinuxDMABUFParamsResource {


### PR DESCRIPTION
invalid_format check was only done in the create handler and missed create_immed, move it into verify() instead so it catches both.

