### PR TITLE
renderer: block solitary on fadeouts

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -137,13 +137,13 @@ static std::string availableModesForOutput(PHLMONITOR pMonitor, eHyprCtlOutputFo
 
 const std::array<const char*, Monitor::CMonitor::SC_CHECKS_COUNT> SOLITARY_REASONS_JSON = {
     "\"UNKNOWN\"",   "\"NOTIFICATION\"", "\"LOCK\"",      "\"WORKSPACE\"", "\"WINDOWED\"", "\"DND\"",        "\"SPECIAL\"",  "\"ALPHA\"",       "\"OFFSET\"",
-    "\"CANDIDATE\"", "\"OPAQUE\"",       "\"TRANSFORM\"", "\"OVERLAYS\"",  "\"FLOAT\"",    "\"WORKSPACES\"", "\"SURFACES\"", "\"CONFIGERROR\"",
+    "\"CANDIDATE\"", "\"OPAQUE\"",       "\"TRANSFORM\"", "\"OVERLAYS\"",  "\"FLOAT\"",    "\"WORKSPACES\"", "\"SURFACES\"", "\"CONFIGERROR\"", "\"FADEOUT\"",
 };
 
 const std::array<const char*, Monitor::CMonitor::SC_CHECKS_COUNT> SOLITARY_REASONS_TEXT = {
     "unknown reason",    "notification",     "session lock",     "invalid workspace", "windowed mode", "dnd active",
     "special workspace", "alpha channel",    "workspace offset", "missing candidate", "not opaque",    "surface transformations",
-    "other overlays",    "floating windows", "other workspaces", "subsurfaces",       "config error",
+    "other overlays",    "floating windows", "other workspaces", "subsurfaces",       "config error",  "fadeout in progress",
 };
 
 std::string CHyprCtl::getSolitaryBlockedReason(PHLMONITOR m, eHyprCtlOutputFormat format) {

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -44,6 +44,7 @@
 #include "../desktop/view/LayerSurface.hpp"
 #include "../desktop/state/GlobalWindowController.hpp"
 #include "../desktop/state/FocusState.hpp"
+#include "../desktop/state/FadingOutState.hpp"
 #include "../event/EventBus.hpp"
 #include "../helpers/Drm.hpp"
 #include "MonitorFrameScheduler.hpp"
@@ -1885,6 +1886,15 @@ uint32_t CMonitor::isSolitaryBlocked(bool full) {
             if (!full)
                 return reasons;
         }
+    }
+
+    for (auto const& fadeout : Desktop::fadingOutState()->fadeouts()) {
+        if (!fadeout || fadeout->monitor() != m_self)
+            continue;
+
+        reasons |= SC_FADEOUT;
+        if (!full)
+            return reasons;
     }
 
     for (auto const& w : Desktop::windowState()->windows()) {

--- a/src/output/Monitor.hpp
+++ b/src/output/Monitor.hpp
@@ -236,8 +236,9 @@ namespace Monitor {
             SC_WORKSPACES   = (1 << 14),
             SC_SURFACES     = (1 << 15),
             SC_ERRORBAR     = (1 << 16),
+            SC_FADEOUT      = (1 << 17),
 
-            SC_CHECKS_COUNT = 17,
+            SC_CHECKS_COUNT = 18,
         };
 
         // keep in sync with HyprCtl


### PR DESCRIPTION
after 254d6bae775258b554e1d3a4a853f3bc244190d9 fadeouts now live in fadingOutState() instead of the normal containers, so add SC_FADEOUT and iterate the new fadingOutState() and block solitary for fadeouts.

per request from @fxzzi 


