### PR TITLE
Screenshare fence and copy fixes

### DIFF
--- a/src/managers/screenshare/ScreenshareFrame.cpp
+++ b/src/managers/screenshare/ScreenshareFrame.cpp
@@ -143,7 +143,7 @@ eScreenshareError CScreenshareFrame::share(SP<IHLBuffer> buffer, const CRegion& 
 }
 
 void CScreenshareFrame::copy() {
-    if (done())
+    if (done() || m_copyInFlight)
         return;
 
     // tell client to send presented timestamp
@@ -404,8 +404,15 @@ bool CScreenshareFrame::copyDmabuf() {
 
     g_pHyprRenderer->m_renderData.blockScreenShader = true;
 
+    m_copyInFlight = true;
+
     g_pHyprRenderer->endRender([self = m_self]() {
-        if (!self || self.expired() || self->m_copied)
+        if (!self || self.expired())
+            return;
+
+        self->m_copyInFlight = false;
+
+        if (self->m_copied)
             return;
 
         LOGM(Log::TRACE, "Copied frame via dma");

--- a/src/managers/screenshare/ScreenshareManager.cpp
+++ b/src/managers/screenshare/ScreenshareManager.cpp
@@ -41,7 +41,7 @@ void CScreenshareManager::onOutputCommit(PHLMONITOR monitor) {
         frame->copy();
     });
 
-    std::erase_if(m_pendingFrames, [&](const WP<CScreenshareFrame>& frame) { return frame.expired(); });
+    std::erase_if(m_pendingFrames, [&](const WP<CScreenshareFrame>& frame) { return frame.expired() || frame->done(); });
 }
 
 UP<CScreenshareSession> CScreenshareManager::newSession(wl_client* client, PHLMONITOR monitor) {

--- a/src/managers/screenshare/ScreenshareManager.hpp
+++ b/src/managers/screenshare/ScreenshareManager.hpp
@@ -174,6 +174,7 @@ namespace Screenshare {
         Vector2D                m_bufferSize = Vector2D(0, 0);
         CRegion                 m_damage; // damage in buffer coords
         bool                    m_shared = false, m_copied = false, m_failed = false;
+        bool                    m_copyInFlight  = false; // a dmabuf copy is issued and waiting on its fence
         bool                    m_overlayCursor = true;
         bool                    m_isFirst       = false;
 


### PR DESCRIPTION
erase done frames from m_pendingFrames to avoid growing to huge
numbers. a finished frame copied/failed/session gone is skipped by the
copy but was only erased once it expired. a slow client could let the
vector grow.

don recopy a dmabuf while fence is pending
copy is called for every pending frame on the output commit. and output
commit fires on any output commit not just buffer ones. so the fence can
easily be not signaled yet.