### PR TITLE
Expose tearingHint in hyprctl clients

### DIFF
--- a/src/config/lua/objects/LuaWindow.cpp
+++ b/src/config/lua/objects/LuaWindow.cpp
@@ -239,6 +239,8 @@ static int windowIndex(lua_State* L) {
         }
     } else if (key == "active") {
         lua_pushboolean(L, w == Desktop::focusState()->window());
+    } else if (key == "tearing_hint") {
+        lua_pushboolean(L, w->m_tearingHint);
     } else
         lua_pushnil(L);
 

--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -419,6 +419,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
     "xdgTag": "{}",
     "xdgDescription": "{}",
     "contentType": "{}",
+    "tearingHint": {},
     "stableId": "{:x}"
 }},)#",
             rc<uintptr_t>(w.get()), (w->m_isMapped ? "true" : "false"), (w->isHidden() ? "true" : "false"), (w->visible() ? "true" : "false"),
@@ -431,7 +432,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             sc<uint8_t>(Fullscreen::controller()->getFullscreenModes(w).client), escapeJSONStrings(Fullscreen::controller()->getFullscreenHandlerNameAsString(w)),
             (w->m_allowedOverFullscreen ? "true" : "false"), getGroupedData(w, format), getTagsData(w, format), rc<uintptr_t>(w->m_swallowee.get()), getFocusHistoryID(w),
             (g_pInputManager->isWindowInhibiting(w, false) ? "true" : "false"), escapeJSONStrings(w->xdgTag().value_or("")), escapeJSONStrings(w->xdgDescription().value_or("")),
-            escapeJSONStrings(NContentType::toString(w->getContentType())), w->m_stableID);
+            escapeJSONStrings(NContentType::toString(w->getContentType())), (w->m_tearingHint ? "true" : "false"), w->m_stableID);
     } else {
         return std::format(
             "Window {:x} -> {}:\n\tmapped: {}\n\thidden: {}\n\tvisible: {}\n\tacceptsInput: {}\n\tat: {},{}\n\tsize: {},{}\n\tworkspace: {} ({})\n\tfloating: {}\n\tmonitor: "
@@ -441,7 +442,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             "{}\n\tfullscreen: {}\n\tfullscreenClient: {}\n\tfullscreenHandler: {}\n\tallowedOverFullscreen: {}\n\tgrouped: {}\n\ttags: {}\n\tswallowing: {:x}\n\tfocusHistoryID: "
             "{}\n\tinhibitingIdle: "
             "{}\n\txdgTag: "
-            "{}\n\txdgDescription: {}\n\tcontentType: {}\n\tstableID: {:x}\n\n",
+            "{}\n\txdgDescription: {}\n\tcontentType: {}\n\ttearingHint: {}\n\tstableID: {:x}\n\n",
             rc<uintptr_t>(w.get()), w->m_title, sc<int>(w->m_isMapped), sc<int>(w->isHidden()), sc<int>(w->visible()), sc<int>(w->acceptsInput()),
             sc<int>(w->position(Desktop::View::IGeometric::GEOMETRIC_GOAL).x), sc<int>(w->position(Desktop::View::IGeometric::GEOMETRIC_GOAL).y),
             sc<int>(w->size(Desktop::View::IGeometric::GEOMETRIC_GOAL).x), sc<int>(w->size(Desktop::View::IGeometric::GEOMETRIC_GOAL).y),
@@ -450,7 +451,7 @@ std::string CHyprCtl::getWindowData(PHLWINDOW w, eHyprCtlOutputFormat format) {
             sc<uint8_t>(Fullscreen::controller()->getFullscreenModes(w).internal), sc<uint8_t>(Fullscreen::controller()->getFullscreenModes(w).client),
             Fullscreen::controller()->getFullscreenHandlerNameAsString(w), sc<int>(w->m_allowedOverFullscreen), getGroupedData(w, format), getTagsData(w, format),
             rc<uintptr_t>(w->m_swallowee.get()), getFocusHistoryID(w), sc<int>(g_pInputManager->isWindowInhibiting(w, false)), w->xdgTag().value_or(""),
-            w->xdgDescription().value_or(""), NContentType::toString(w->getContentType()), w->m_stableID);
+            w->xdgDescription().value_or(""), NContentType::toString(w->getContentType()), sc<int>(w->m_tearingHint), w->m_stableID);
     }
 }
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

I was looking for a way to check why a window was or wasn't tearing. In particular, to check if my config was setting the immediate prop on the window somehow or if the window itself requested it. Unfortunately it wasn't straightforward for meto check if the window itself requested to be teared or the user (me) configured it to be. I could just check the value of the prop with `hyprctl getprop window immediate` & if it's false while the window IS tearing, then it must be requesting it by yourself. But in my opinion it's kinda awkward to check.

This PR adds a tearingHint field to the output of `hyprctl clients`. This way it can be figured out why the window is or isn't tearing. 

```
$ hyprctl clients
Window 55dfbf7d0580 -> Horizon Forbidden West™ Complete Edition v1.5.80.0:
	mapped: 1
	hidden: 0
	visible: 1
	acceptsInput: 1
	at: 0,0
	size: 2048,1152
	workspace: 8 (8)
	floating: 0
	monitor: 0
	class: steam_app_2420110
	title: Horizon Forbidden West™ Complete Edition v1.5.80.0
	initialClass: steam_app_2420110
	initialTitle: Horizon Forbidden West™ Complete Edition v1.5.80.0
	pid: 48217
	xwayland: 1
	pinned: 0
	fullscreen: 2
	fullscreenClient: 2
	overFullscreen: 1
	grouped: 0
	tags:
	swallowing: 0
	focusHistoryID: 2
	inhibitingIdle: 0
	xdgTag:
	xdgDescription:
	contentType: none
	tearingHint: 1
	stableID: 1800014b

$ hyprctl clients -j
{
    "address": "0x55dfbf7d0580",
    "mapped": true,
    "hidden": false,
    "visible": true,
    "acceptsInput": true,
    "at": [0, 0],
    "size": [2048, 1152],
    "workspace": {
        "id": 8,
        "name": "8"
    },
    "floating": false,
    "monitor": 0,
    "class": "steam_app_2420110",
    "title": "Horizon Forbidden West™ Complete Edition v1.5.80.0",
    "initialClass": "steam_app_2420110",
    "initialTitle": "Horizon Forbidden West™ Complete Edition v1.5.80.0",
    "pid": 48217,
    "xwayland": true,
    "pinned": false,
    "fullscreen": 2,
    "fullscreenClient": 2,
    "overFullscreen": true,
    "grouped": [],
    "tags": [],
    "swallowing": "0x0",
    "focusHistoryID": 3,
    "inhibitingIdle": false,
    "xdgTag": "",
    "xdgDescription": "",
    "contentType": "none",
    "tearingHint": true,
    "stableId": "1800014b"
}
```

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

The code is incredibly trivial and just exposes a field from inside the window object.

#### Is it ready for merging, or does it need work?

There's barely anything added here, so it's ready.