### PR TITLE
fix tokens for xdg-desktop-portals

### DIFF
--- a/src/config/supplementary/executor/Executor.cpp
+++ b/src/config/supplementary/executor/Executor.cpp
@@ -149,7 +149,8 @@ std::optional<uint64_t> CExecutor::spawnWithRules(std::string args, PHLWORKSPACE
 }
 
 std::vector<std::pair<std::string, std::string>> CExecutor::getHyprlandLaunchEnv(PHLWORKSPACE pInitialWorkspace) {
-    static auto PINITIALWSTRACKING = CConfigValue<Config::INTEGER>("misc:initial_workspace_tracking");
+    static auto PINITIALWSTRACKING        = CConfigValue<Config::INTEGER>("misc:initial_workspace_tracking");
+    static auto PINITIALWSTRACKINGTIMEOUT = CConfigValue<Config::INTEGER>("misc:initial_workspace_token_timeout");
 
     if (!*PINITIALWSTRACKING || m_isLaunchingExecOnce)
         return {};
@@ -167,7 +168,7 @@ std::vector<std::pair<std::string, std::string>> CExecutor::getHyprlandLaunchEnv
             pInitialWorkspace = PMONITOR->m_activeWorkspace;
     }
 
-    const auto TOKEN = (*PINITIALWSTRACKING == 2) ? std::chrono::months(1337) : std::chrono::seconds(10);
+    const auto TOKEN = (*PINITIALWSTRACKING == 2) ? std::chrono::seconds(std::chrono::months(1337)) : std::chrono::seconds(*PINITIALWSTRACKINGTIMEOUT);
     result.emplace_back("HL_INITIAL_WORKSPACE_TOKEN", g_pTokenManager->registerNewToken(Desktop::View::SInitialWorkspaceToken{{}, pInitialWorkspace->getConfigName()}, TOKEN));
 
     return result;

--- a/src/config/supplementary/executor/Executor.cpp
+++ b/src/config/supplementary/executor/Executor.cpp
@@ -167,8 +167,8 @@ std::vector<std::pair<std::string, std::string>> CExecutor::getHyprlandLaunchEnv
             pInitialWorkspace = PMONITOR->m_activeWorkspace;
     }
 
-    result.emplace_back("HL_INITIAL_WORKSPACE_TOKEN",
-                        g_pTokenManager->registerNewToken(Desktop::View::SInitialWorkspaceToken{{}, pInitialWorkspace->getConfigName()}, std::chrono::months(1337)));
+    const auto TOKEN = (*PINITIALWSTRACKING == 2) ? std::chrono::months(1337) : std::chrono::seconds(1);
+    result.emplace_back("HL_INITIAL_WORKSPACE_TOKEN", g_pTokenManager->registerNewToken(Desktop::View::SInitialWorkspaceToken{{}, pInitialWorkspace->getConfigName()}, TOKEN));
 
     return result;
 }

--- a/src/config/supplementary/executor/Executor.cpp
+++ b/src/config/supplementary/executor/Executor.cpp
@@ -168,8 +168,8 @@ std::vector<std::pair<std::string, std::string>> CExecutor::getHyprlandLaunchEnv
             pInitialWorkspace = PMONITOR->m_activeWorkspace;
     }
 
-    const auto TOKEN = (*PINITIALWSTRACKING == 2) ? std::chrono::seconds(std::chrono::months(1337)) : std::chrono::seconds(*PINITIALWSTRACKINGTIMEOUT);
-    result.emplace_back("HL_INITIAL_WORKSPACE_TOKEN", g_pTokenManager->registerNewToken(Desktop::View::SInitialWorkspaceToken{{}, pInitialWorkspace->getConfigName()}, TOKEN));
+    const auto TIMEOUT = (*PINITIALWSTRACKING == 2) ? std::chrono::seconds(std::chrono::months(1337)) : std::chrono::seconds(*PINITIALWSTRACKINGTIMEOUT);
+    result.emplace_back("HL_INITIAL_WORKSPACE_TOKEN", g_pTokenManager->registerNewToken(Desktop::View::SInitialWorkspaceToken{{}, pInitialWorkspace->getConfigName()}, TIMEOUT));
 
     return result;
 }

--- a/src/config/supplementary/executor/Executor.cpp
+++ b/src/config/supplementary/executor/Executor.cpp
@@ -167,7 +167,7 @@ std::vector<std::pair<std::string, std::string>> CExecutor::getHyprlandLaunchEnv
             pInitialWorkspace = PMONITOR->m_activeWorkspace;
     }
 
-    const auto TOKEN = (*PINITIALWSTRACKING == 2) ? std::chrono::months(1337) : std::chrono::seconds(1);
+    const auto TOKEN = (*PINITIALWSTRACKING == 2) ? std::chrono::months(1337) : std::chrono::seconds(10);
     result.emplace_back("HL_INITIAL_WORKSPACE_TOKEN", g_pTokenManager->registerNewToken(Desktop::View::SInitialWorkspaceToken{{}, pInitialWorkspace->getConfigName()}, TOKEN));
 
     return result;

--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -503,6 +503,8 @@ std::vector<SP<IValue>> Values::getConfigValues() {
                 {.min = 0, .max = 2, .map = OptionMap{{"ignore", 0}, {"take_over", 1}, {"exit_fullscreen", 2}}}),
         MS<Bool>("misc:exit_window_retains_fullscreen", "if true, closing a fullscreen window makes the next focused window fullscreen", false),
         MS<Int>("misc:initial_workspace_tracking", "if enabled, windows will open on the workspace they were invoked on.", 1, {.min = 0, .max = 2}),
+        MS<Int>("misc:initial_workspace_token_timeout", "the time in seconds a window has to open on its invoked workspace before the tracking token expires.", 10,
+                {.min = 1, .max = 3600}),
         MS<Bool>("misc:middle_click_paste", "whether to enable middle-click-paste (aka primary selection)", true),
         MS<Int>("misc:render_unfocused_fps", "the maximum limit for renderunfocused windows' fps in the background", 15, {.min = 1, .max = 120}),
         MS<Bool>("misc:disable_xdg_env_checks", "disable the warning if XDG environment is externally managed", false),


### PR DESCRIPTION
tokens are only removed once a window maps, so things like xdg-desktop-portal got the 1337 month duration token added and always first launch in the wrong workspace. check PINITIALWSTRACKING and if mode 1 just give them a 1 second token. like other code paths does.

