### PR TITLE
Allow pointer constraints to work on subsurface

### DIFF
--- a/src/desktop/state/FocusState.cpp
+++ b/src/desktop/state/FocusState.cpp
@@ -238,8 +238,6 @@ void CFocusState::rawSurfaceFocus(SP<CWLSurfaceResource> pSurface, PHLWINDOW pWi
         return;
     }
 
-    const auto PLASTSURF = m_focusSurface.lock();
-
     // Unfocus last surface if should
     if (m_focusSurface && !pWindowOwner)
         g_pXWaylandManager->activateSurface(m_focusSurface.lock(), false);
@@ -265,15 +263,6 @@ void CFocusState::rawSurfaceFocus(SP<CWLSurfaceResource> pSurface, PHLWINDOW pWi
     m_focusSurface = pSurface;
 
     Event::bus()->m_events.input.keyboard.focus.emit(pSurface);
-
-    const auto SURF    = Desktop::View::CWLSurface::fromResource(pSurface);
-    const auto OLDSURF = Desktop::View::CWLSurface::fromResource(PLASTSURF);
-
-    if (OLDSURF && OLDSURF->constraint())
-        OLDSURF->constraint()->deactivate();
-
-    if (SURF && SURF->constraint())
-        SURF->constraint()->activate();
 }
 
 void CFocusState::rawMonitorFocus(PHLMONITOR pMonitor) {

--- a/src/desktop/view/LayerSurface.cpp
+++ b/src/desktop/view/LayerSurface.cpp
@@ -34,6 +34,7 @@ PHLLS CLayerSurface::create(SP<CLayerShellResource> resource) {
     pLS->m_namespace      = resource->m_layerNamespace;
     pLS->m_layer          = std::clamp(resource->m_current.layer, ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND, ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY);
     pLS->setPopupHead(CPopup::create(pLS));
+    pLS->setSubsurfaceHead(CSubsurface::create(pLS));
 
     Animation::mgr()->createAnimation(0.f, pLS->m_alpha.get(LS_ALPHA_FADE), Config::animationTree()->getAnimationPropertyConfig("fadeLayersIn"), pLS, AVARDAMAGE_ENTIRE);
     Animation::mgr()->createAnimation(Vector2D(0, 0), pLS->positionAnimation(), Config::animationTree()->getAnimationPropertyConfig("layersIn"), pLS, AVARDAMAGE_ENTIRE);
@@ -144,6 +145,7 @@ void CLayerSurface::onDestroy() {
     }
 
     resetPopupHead();
+    resetSubsurfaceHead();
 
     m_flags |= LAYER_FLAG_DEAD;
 
@@ -488,4 +490,8 @@ std::optional<uint8_t> CLayerSurface::alphaGenericToKey(eAlphaModifiableProp p) 
 
     static_assert(ALPHA_MODIFIABLE_LAST == 1);
     UNREACHABLE();
+}
+
+bool CLayerSurface::cantLockCursor() const {
+    return false;
 }

--- a/src/desktop/view/LayerSurface.cpp
+++ b/src/desktop/view/LayerSurface.cpp
@@ -35,6 +35,7 @@ PHLLS CLayerSurface::create(SP<CLayerShellResource> resource) {
     pLS->m_namespace      = resource->m_layerNamespace;
     pLS->m_layer          = std::clamp(resource->m_current.layer, ZWLR_LAYER_SHELL_V1_LAYER_BACKGROUND, ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY);
     pLS->setPopupHead(CPopup::create(pLS));
+    pLS->setSubsurfaceHead(CSubsurface::create(pLS));
 
     Animation::mgr()->createAnimation(0.f, pLS->m_alpha.get(LS_ALPHA_FADE), Config::animationTree()->getAnimationPropertyConfig("fadeLayersIn"), pLS, AVARDAMAGE_ENTIRE);
     Animation::mgr()->createAnimation(Vector2D(0, 0), pLS->positionAnimation(), Config::animationTree()->getAnimationPropertyConfig("layersIn"), pLS, AVARDAMAGE_ENTIRE);
@@ -144,6 +145,7 @@ void CLayerSurface::onDestroy() {
     }
 
     resetPopupHead();
+    resetSubsurfaceHead();
 
     m_flags |= LAYER_FLAG_DEAD;
 
@@ -495,4 +497,8 @@ bool CLayerSurface::shouldBlur() const {
         return !surface->m_blurRegion.empty();
 
     return m_ruleApplicator->blur().valueOrDefault();
+}
+
+bool CLayerSurface::cantLockCursor() const {
+    return false;
 }

--- a/src/desktop/view/LayerSurface.hpp
+++ b/src/desktop/view/LayerSurface.hpp
@@ -11,6 +11,7 @@
 #include "types/GeometricMovableAnimated.hpp"
 #include "types/AlphaModifiable.hpp"
 #include "surfaceTree/PopupOwner.hpp"
+#include "surfaceTree/SubsurfaceOwner.hpp"
 #include "animationControllers/LayerSurfaceAnimationController.hpp"
 
 class CLayerShellResource;
@@ -32,7 +33,11 @@ namespace Desktop::View {
     using enum eLayerFlags;
     EXPOSE_ENUM_AS_MASK(eLayerFlags, LayerFlags);
 
-    class CLayerSurface : public virtual IView, public virtual CGeometricMovableAnimated, public virtual IAlphaModifiable, public virtual CPopupOwner {
+    class CLayerSurface : public virtual IView,
+                          public virtual CGeometricMovableAnimated,
+                          public virtual IAlphaModifiable,
+                          public virtual CPopupOwner,
+                          public virtual CSubsurfaceOwner {
       public:
         static PHLLS create(SP<CLayerShellResource>);
         static PHLLS fromView(SP<IView>);
@@ -52,6 +57,7 @@ namespace Desktop::View {
         virtual Types::CMultiAVarContainer<float, uint8_t>&       alpha() override;
         virtual const Types::CMultiAVarContainer<float, uint8_t>& alpha() const override;
         virtual std::optional<uint8_t>                            alphaGenericToKey(eAlphaModifiableProp p) override;
+        virtual bool                                              cantLockCursor() const override;
 
         WP<CLayerShellResource>                                   m_layerSurface;
 

--- a/src/desktop/view/LayerSurface.hpp
+++ b/src/desktop/view/LayerSurface.hpp
@@ -11,6 +11,7 @@
 #include "types/GeometricMovableAnimated.hpp"
 #include "types/AlphaModifiable.hpp"
 #include "surfaceTree/PopupOwner.hpp"
+#include "surfaceTree/SubsurfaceOwner.hpp"
 #include "animationControllers/LayerSurfaceAnimationController.hpp"
 
 class CLayerShellResource;
@@ -32,7 +33,11 @@ namespace Desktop::View {
     using enum eLayerFlags;
     EXPOSE_ENUM_AS_MASK(eLayerFlags, LayerFlags);
 
-    class CLayerSurface : public virtual IView, public virtual CGeometricMovableAnimated, public virtual IAlphaModifiable, public virtual CPopupOwner {
+    class CLayerSurface : public virtual IView,
+                          public virtual CGeometricMovableAnimated,
+                          public virtual IAlphaModifiable,
+                          public virtual CPopupOwner,
+                          public virtual CSubsurfaceOwner {
       public:
         static PHLLS create(SP<CLayerShellResource>);
         static PHLLS fromView(SP<IView>);
@@ -52,6 +57,7 @@ namespace Desktop::View {
         virtual Types::CMultiAVarContainer<float, uint8_t>&       alpha() override;
         virtual const Types::CMultiAVarContainer<float, uint8_t>& alpha() const override;
         virtual std::optional<uint8_t>                            alphaGenericToKey(eAlphaModifiableProp p) override;
+        virtual bool                                              cantLockCursor() const override;
 
         WP<CLayerShellResource>                                   m_layerSurface;
         bool                                                      shouldBlur() const;

--- a/src/desktop/view/Popup.cpp
+++ b/src/desktop/view/Popup.cpp
@@ -726,3 +726,7 @@ std::optional<uint8_t> CPopup::alphaGenericToKey(eAlphaModifiableProp p) {
     static_assert(ALPHA_MODIFIABLE_LAST == 1);
     UNREACHABLE();
 }
+
+bool CPopup::cantLockCursor() const {
+    return false;
+}

--- a/src/desktop/view/Popup.cpp
+++ b/src/desktop/view/Popup.cpp
@@ -733,3 +733,14 @@ bool CPopup::shouldBlur() const {
 
     return *PBLURPOPUPS && *PBLUR;
 }
+
+bool CPopup::cantLockCursor() const {
+    if (!m_windowOwner.expired())
+        return m_windowOwner->cantLockCursor();
+    if (!m_layerOwner.expired())
+        return m_layerOwner->cantLockCursor();
+    if (m_parent)
+        return m_parent->cantLockCursor();
+
+    return false;
+}

--- a/src/desktop/view/Popup.hpp
+++ b/src/desktop/view/Popup.hpp
@@ -48,6 +48,7 @@ namespace Desktop::View {
         virtual Types::CMultiAVarContainer<float, uint8_t>&       alpha() override;
         virtual const Types::CMultiAVarContainer<float, uint8_t>& alpha() const override;
         virtual std::optional<uint8_t>                            alphaGenericToKey(eAlphaModifiableProp p) override;
+        virtual bool                                              cantLockCursor() const override;
 
         SP<Desktop::View::CWLSurface>                             getT1Owner() const;
         PHLLS                                                     layerOwner() const;

--- a/src/desktop/view/SessionLock.cpp
+++ b/src/desktop/view/SessionLock.cpp
@@ -93,3 +93,7 @@ PHLMONITOR View::CSessionLock::monitor() const {
         return m_surface->monitor();
     return nullptr;
 }
+
+bool View::CSessionLock::cantLockCursor() const {
+    return false;
+}

--- a/src/desktop/view/SessionLock.hpp
+++ b/src/desktop/view/SessionLock.hpp
@@ -26,6 +26,7 @@ namespace Desktop::View {
         virtual Vector2D            position(eGeometricValueType) const override;
         virtual Vector2D            size(eGeometricValueType) const override;
         virtual CBox                geometricBox(eGeometricValueType) const override;
+        virtual bool                cantLockCursor() const override;
 
         PHLMONITOR                  monitor() const;
 

--- a/src/desktop/view/Subsurface.cpp
+++ b/src/desktop/view/Subsurface.cpp
@@ -32,6 +32,16 @@ SP<CSubsurface> CSubsurface::create(WP<Desktop::View::CPopup> pOwner) {
     return subsurface;
 }
 
+SP<CSubsurface> CSubsurface::create(PHLLS pOwner) {
+    auto subsurface                  = SP<CSubsurface>(new CSubsurface());
+    subsurface->m_layerSurfaceParent = pOwner;
+    subsurface->m_self               = subsurface;
+    subsurface->initSignals();
+    subsurface->initExistingSubsurfaces(pOwner->wlSurface()->resource());
+    subsurface->initView(subsurface, VIEW_TYPE_SUBSURFACE);
+    return subsurface;
+}
+
 SP<CSubsurface> CSubsurface::create(SP<CWLSubsurfaceResource> pSubsurface, PHLWINDOW pOwner) {
     auto subsurface            = SP<CSubsurface>(new CSubsurface());
     subsurface->m_windowParent = pOwner;
@@ -52,6 +62,20 @@ SP<CSubsurface> CSubsurface::create(SP<CWLSubsurfaceResource> pSubsurface, WP<De
     subsurface->m_subsurface  = pSubsurface;
     subsurface->m_self        = subsurface;
     subsurface->wlSurface()   = CWLSurface::create();
+    subsurface->wlSurface()->assign(pSubsurface->m_surface.lock(), subsurface);
+    subsurface->initSignals();
+    subsurface->initExistingSubsurfaces(pSubsurface->m_surface.lock());
+    subsurface->initView(subsurface, VIEW_TYPE_SUBSURFACE);
+    subsurface->syncScaleTransform();
+    return subsurface;
+}
+
+SP<CSubsurface> CSubsurface::create(SP<CWLSubsurfaceResource> pSubsurface, PHLLS pOwner) {
+    auto subsurface                  = SP<CSubsurface>(new CSubsurface());
+    subsurface->m_layerSurfaceParent = pOwner;
+    subsurface->m_subsurface         = pSubsurface;
+    subsurface->m_self               = subsurface;
+    subsurface->wlSurface()          = CWLSurface::create();
     subsurface->wlSurface()->assign(pSubsurface->m_surface.lock(), subsurface);
     subsurface->initSignals();
     subsurface->initExistingSubsurfaces(pSubsurface->m_surface.lock());
@@ -85,6 +109,8 @@ bool CSubsurface::focusAvailable() const {
     }
     if (m_popupParent)
         return m_popupParent->mapped() && m_popupParent->acceptsInput();
+    if (!m_layerSurfaceParent.expired())
+        return m_layerSurfaceParent->focusAvailable();
     if (m_parent)
         return m_parent->mapped() && m_parent->acceptsInput();
 
@@ -133,6 +159,8 @@ void CSubsurface::initSignals() {
             m_listeners.newSubsurface = m_windowParent->wlSurface()->resource()->m_events.newSubsurface.listen([this](const auto& resource) { onNewSubsurface(resource); });
         else if (m_popupParent)
             m_listeners.newSubsurface = m_popupParent->wlSurface()->resource()->m_events.newSubsurface.listen([this](const auto& resource) { onNewSubsurface(resource); });
+        else if (!m_layerSurfaceParent.expired())
+            m_listeners.newSubsurface = m_layerSurfaceParent->wlSurface()->resource()->m_events.newSubsurface.listen([this](const auto& resource) { onNewSubsurface(resource); });
         else
             ASSERT(false);
     }
@@ -233,6 +261,8 @@ void CSubsurface::onNewSubsurface(SP<CWLSubsurfaceResource> pSubsurface) {
         PSUBSURFACE = m_children.emplace_back(CSubsurface::create(pSubsurface, m_windowParent.lock()));
     else if (m_popupParent)
         PSUBSURFACE = m_children.emplace_back(CSubsurface::create(pSubsurface, m_popupParent));
+    else if (!m_layerSurfaceParent.expired())
+        PSUBSURFACE = m_children.emplace_back(CSubsurface::create(pSubsurface, m_layerSurfaceParent.lock()));
 
     PSUBSURFACE->m_self = PSUBSURFACE;
 
@@ -253,6 +283,8 @@ void CSubsurface::onMap() {
 
     if (!m_windowParent.expired())
         m_windowParent->updateSurfaceScaleTransformDetails();
+    else if (!m_layerSurfaceParent.expired())
+        m_layerSurfaceParent->updateSurfaceScaleTransformDetails();
 }
 
 void CSubsurface::onUnmap() {
@@ -296,6 +328,8 @@ Vector2D CSubsurface::coordsGlobal() const {
         coords += m_windowParent->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT);
     else if (m_popupParent)
         coords += m_popupParent->coordsGlobal();
+    else if (!m_layerSurfaceParent.expired())
+        coords += m_layerSurfaceParent->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT);
 
     return coords;
 }
@@ -315,6 +349,8 @@ void CSubsurface::syncScaleTransform() const {
         pMonitor = m_windowParent->m_monitor.lock();
     else if (m_popupParent)
         pMonitor = m_popupParent->getMonitor();
+    else if (!m_layerSurfaceParent.expired())
+        pMonitor = m_layerSurfaceParent->m_monitor.lock();
 
     if (!pMonitor)
         return;
@@ -356,4 +392,17 @@ size_t CSubsurface::countChildren(bool onlyMapped) const {
     }
 
     return count;
+}
+
+bool CSubsurface::cantLockCursor() const {
+    if (!m_windowParent.expired())
+        return m_windowParent->cantLockCursor();
+    if (m_popupParent)
+        return m_popupParent->cantLockCursor();
+    if (!m_layerSurfaceParent.expired())
+        return m_layerSurfaceParent->cantLockCursor();
+    if (m_parent)
+        return m_parent->cantLockCursor();
+
+    return false;
 }

--- a/src/desktop/view/Subsurface.hpp
+++ b/src/desktop/view/Subsurface.hpp
@@ -16,10 +16,12 @@ namespace Desktop::View {
         // root dummy nodes
         static SP<CSubsurface> create(PHLWINDOW pOwner);
         static SP<CSubsurface> create(WP<Desktop::View::CPopup> pOwner);
+        static SP<CSubsurface> create(PHLLS pOwner);
 
         // real nodes
         static SP<CSubsurface> create(SP<CWLSubsurfaceResource> pSubsurface, PHLWINDOW pOwner);
         static SP<CSubsurface> create(SP<CWLSubsurfaceResource> pSubsurface, WP<Desktop::View::CPopup> pOwner);
+        static SP<CSubsurface> create(SP<CWLSubsurfaceResource> pSubsurface, PHLLS pOwner);
 
         static SP<CSubsurface> fromView(SP<IView>);
 
@@ -34,6 +36,7 @@ namespace Desktop::View {
         virtual Vector2D               position(eGeometricValueType) const override;
         virtual Vector2D               size(eGeometricValueType) const override;
         virtual CBox                   geometricBox(eGeometricValueType) const override;
+        virtual bool                   cantLockCursor() const override;
 
         Vector2D                       coordsRelativeToParent() const;
         Vector2D                       coordsGlobal() const;
@@ -75,6 +78,7 @@ namespace Desktop::View {
 
         PHLWINDOWREF                                m_windowParent;
         WP<Desktop::View::CPopup>                   m_popupParent;
+        PHLLSREF                                    m_layerSurfaceParent;
 
         std::vector<SP<Desktop::View::CSubsurface>> m_children;
 

--- a/src/desktop/view/View.hpp
+++ b/src/desktop/view/View.hpp
@@ -26,6 +26,7 @@ namespace Desktop::View {
         virtual bool                          desktopComponent() const  = 0;
         virtual std::optional<CBox>           logicalBox() const        = 0;
         virtual std::optional<CBox>           surfaceLogicalBox() const = 0;
+        virtual bool                          cantLockCursor() const    = 0;
 
       protected:
         IView(SP<Desktop::View::CWLSurface> pWlSurface);

--- a/src/desktop/view/window/Window.cpp
+++ b/src/desktop/view/window/Window.cpp
@@ -1890,6 +1890,11 @@ bool CWindow::isFloating() const {
 }
 
 bool CWindow::cantLockCursor() const {
+    // a window being interactively moved or resized ignores its pointer lock. the lock would otherwise warp
+    // the cursor back to the constraint hint every frame, so the window could never be dragged (e.g. gamescope).
+    if (const auto DRAG = g_layoutManager->dragController()->target(); DRAG && DRAG->window() == m_self)
+        return true;
+
     return m_target->cantLockCursor();
 }
 

--- a/src/desktop/view/window/Window.cpp
+++ b/src/desktop/view/window/Window.cpp
@@ -1915,6 +1915,11 @@ bool CWindow::isFloating() const {
 }
 
 bool CWindow::cantLockCursor() const {
+    // a window being interactively moved or resized ignores its pointer lock. the lock would otherwise warp
+    // the cursor back to the constraint hint every frame, so the window could never be dragged (e.g. gamescope).
+    if (const auto DRAG = g_layoutManager->dragController()->target(); DRAG && DRAG->window() == m_self)
+        return true;
+
     return m_target->cantLockCursor();
 }
 

--- a/src/desktop/view/window/Window.hpp
+++ b/src/desktop/view/window/Window.hpp
@@ -149,6 +149,7 @@ namespace Desktop::View {
         virtual Types::CMultiAVarContainer<float, uint8_t>&       alpha() override;
         virtual const Types::CMultiAVarContainer<float, uint8_t>& alpha() const override;
         virtual std::optional<uint8_t>                            alphaGenericToKey(eAlphaModifiableProp p) override;
+        virtual bool                                              cantLockCursor() const override;
 
         struct {
             CSignalT<> destroy;
@@ -239,7 +240,6 @@ namespace Desktop::View {
         SP<Layout::ITarget> layoutTarget();
         SP<Layout::ITarget> layoutTarget() const;
         bool                isFloating() const;
-        bool                cantLockCursor() const;
         void                sendClose();
         void                requestClientFullscreen(const SClientFullscreenRequest& request);
 

--- a/src/desktop/view/window/Window.hpp
+++ b/src/desktop/view/window/Window.hpp
@@ -149,6 +149,7 @@ namespace Desktop::View {
         virtual Types::CMultiAVarContainer<float, uint8_t>&       alpha() override;
         virtual const Types::CMultiAVarContainer<float, uint8_t>& alpha() const override;
         virtual std::optional<uint8_t>                            alphaGenericToKey(eAlphaModifiableProp p) override;
+        virtual bool                                              cantLockCursor() const override;
 
         struct {
             CSignalT<> destroy;
@@ -240,7 +241,6 @@ namespace Desktop::View {
         SP<Layout::ITarget> layoutTarget();
         SP<Layout::ITarget> layoutTarget() const;
         bool                isFloating() const;
-        bool                cantLockCursor() const;
         void                sendClose();
         void                requestClientFullscreen(const SClientFullscreenRequest& request);
 

--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -7,6 +7,7 @@
 #include "../protocols/core/Compositor.hpp"
 #include "../protocols/LayerShell.hpp"
 #include "../protocols/InputCapture.hpp"
+#include "../protocols/PointerConstraints.hpp"
 #include "../Compositor.hpp"
 #include "../desktop/state/FocusState.hpp"
 #include "../devices/IKeyboard.hpp"
@@ -309,6 +310,10 @@ void CSeatManager::setPointerFocus(SP<CWLSurfaceResource> surf, const Vector2D& 
 
     m_listeners.pointerSurfaceDestroy.reset();
 
+    const auto OLDSURF = Desktop::View::CWLSurface::fromResource(m_state.pointerFocus.lock());
+    if (OLDSURF && OLDSURF->constraint())
+        OLDSURF->constraint()->deactivate();
+
     for (auto const& p : PROTO::seat->m_pointers) {
         if (!p)
             continue;
@@ -327,6 +332,10 @@ void CSeatManager::setPointerFocus(SP<CWLSurfaceResource> surf, const Vector2D& 
         m_events.pointerFocusChange.emit();
         return;
     }
+
+    const auto SURF = Desktop::View::CWLSurface::fromResource(surf);
+    if (SURF && SURF->constraint())
+        SURF->constraint()->activate();
 
     m_state.dndPointerFocus = surf;
 

--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -7,6 +7,7 @@
 #include "../protocols/core/Compositor.hpp"
 #include "../protocols/LayerShell.hpp"
 #include "../protocols/InputCapture.hpp"
+#include "../protocols/PointerConstraints.hpp"
 #include "../Compositor.hpp"
 #include "../desktop/state/FocusState.hpp"
 #include "../devices/IKeyboard.hpp"
@@ -365,6 +366,10 @@ void CSeatManager::setPointerFocus(SP<CWLSurfaceResource> surf, const Vector2D& 
 
     m_listeners.pointerSurfaceDestroy.reset();
 
+    const auto OLDSURF = Desktop::View::CWLSurface::fromResource(m_state.pointerFocus.lock());
+    if (OLDSURF && OLDSURF->constraint())
+        OLDSURF->constraint()->deactivate();
+
     for (auto const& p : PROTO::seat->m_pointers) {
         if (!p)
             continue;
@@ -383,6 +388,10 @@ void CSeatManager::setPointerFocus(SP<CWLSurfaceResource> surf, const Vector2D& 
         m_events.pointerFocusChange.emit();
         return;
     }
+
+    const auto SURF = Desktop::View::CWLSurface::fromResource(surf);
+    if (SURF && SURF->constraint())
+        SURF->constraint()->activate();
 
     m_state.dndPointerFocus = surf;
 

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -311,7 +311,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
     };
 
     if (!g_pSeatManager->m_mouse.expired()) {
-        const auto SURF = Desktop::View::CWLSurface::fromResource(Desktop::focusState()->surface());
+        const auto SURF = Desktop::View::CWLSurface::fromResource(g_pSeatManager->m_state.pointerFocus.lock());
 
         if (isConstrained()) {
             const auto CONSTRAINT = SURF ? SURF->constraint() : nullptr;
@@ -1918,21 +1918,11 @@ bool CInputManager::isConstrained() {
     return std::ranges::any_of(m_constraints, [](auto const& c) {
         const auto constraint = c.lock();
 
-        if (!constraint || !constraint->isActive() || constraint->owner()->resource() != Desktop::focusState()->surface())
+        if (!constraint || !constraint->isActive() || constraint->owner()->resource() != g_pSeatManager->m_state.pointerFocus)
             return false;
 
-        const auto OWNER  = constraint->owner()->view();
-        const auto WINDOW = Desktop::View::CWindow::fromView(OWNER);
-
-        if (!WINDOW)
-            return false;
-
-        // a window being interactively moved or resized ignores its pointer lock. the lock would otherwise warp
-        // the cursor back to the constraint hint every frame, so the window could never be dragged (e.g. gamescope).
-        if (const auto DRAG = g_layoutManager->dragController()->target(); DRAG && DRAG->window() == WINDOW)
-            return false;
-
-        return !WINDOW->cantLockCursor();
+        const auto OWNER = constraint->owner()->view();
+        return OWNER && !OWNER->cantLockCursor();
     });
 }
 
@@ -1940,16 +1930,15 @@ bool CInputManager::isLocked() {
     if (!isConstrained())
         return false;
 
-    const auto SURF = Desktop::View::CWLSurface::fromResource(Desktop::focusState()->surface());
+    const auto SURF = Desktop::View::CWLSurface::fromResource(g_pSeatManager->m_state.pointerFocus.lock());
+    if (!SURF)
+        return false;
 
-    if (SURF) {
-        const auto WINDOW = Desktop::View::CWindow::fromView(SURF->view());
+    const auto VIEW = SURF->view();
+    if (!VIEW || VIEW->cantLockCursor())
+        return false;
 
-        if (WINDOW && WINDOW->cantLockCursor())
-            return false;
-    }
-
-    const auto CONSTRAINT = SURF ? SURF->constraint() : nullptr;
+    const auto CONSTRAINT = SURF->constraint();
 
     return CONSTRAINT && CONSTRAINT->isLocked();
 }

--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -318,7 +318,7 @@ void CInputManager::mouseMoveUnified(uint32_t time, bool refocus, bool mouse, st
     };
 
     if (!g_pSeatManager->m_mouse.expired()) {
-        const auto SURF = Desktop::View::CWLSurface::fromResource(Desktop::focusState()->surface());
+        const auto SURF = Desktop::View::CWLSurface::fromResource(g_pSeatManager->m_state.pointerFocus.lock());
 
         if (isConstrained()) {
             const auto CONSTRAINT = SURF ? SURF->constraint() : nullptr;
@@ -1913,21 +1913,11 @@ bool CInputManager::isConstrained() {
     return std::ranges::any_of(m_constraints, [](auto const& c) {
         const auto constraint = c.lock();
 
-        if (!constraint || !constraint->isActive() || constraint->owner()->resource() != Desktop::focusState()->surface())
+        if (!constraint || !constraint->isActive() || constraint->owner()->resource() != g_pSeatManager->m_state.pointerFocus)
             return false;
 
-        const auto OWNER  = constraint->owner()->view();
-        const auto WINDOW = Desktop::View::CWindow::fromView(OWNER);
-
-        if (!WINDOW)
-            return false;
-
-        // a window being interactively moved or resized ignores its pointer lock. the lock would otherwise warp
-        // the cursor back to the constraint hint every frame, so the window could never be dragged (e.g. gamescope).
-        if (const auto DRAG = g_layoutManager->dragController()->target(); DRAG && DRAG->window() == WINDOW)
-            return false;
-
-        return !WINDOW->cantLockCursor();
+        const auto OWNER = constraint->owner()->view();
+        return OWNER && OWNER->mapped() && !OWNER->cantLockCursor();
     });
 }
 
@@ -1935,16 +1925,15 @@ bool CInputManager::isLocked() {
     if (!isConstrained())
         return false;
 
-    const auto SURF = Desktop::View::CWLSurface::fromResource(Desktop::focusState()->surface());
+    const auto SURF = Desktop::View::CWLSurface::fromResource(g_pSeatManager->m_state.pointerFocus.lock());
+    if (!SURF)
+        return false;
 
-    if (SURF) {
-        const auto WINDOW = Desktop::View::CWindow::fromView(SURF->view());
+    const auto VIEW = SURF->view();
+    if (!VIEW || VIEW->cantLockCursor())
+        return false;
 
-        if (WINDOW && WINDOW->cantLockCursor())
-            return false;
-    }
-
-    const auto CONSTRAINT = SURF ? SURF->constraint() : nullptr;
+    const auto CONSTRAINT = SURF->constraint();
 
     return CONSTRAINT && CONSTRAINT->isLocked();
 }

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -1569,6 +1569,8 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace, bool noFocus)
 
     g_pHyprRenderer->damageMonitor(m_self.lock());
 
+    g_pInputManager->unconstrainMouse();
+
     if (!pWorkspace) {
         // remove special if exists
         if (m_activeSpecialWorkspace) {

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -1584,6 +1584,8 @@ void CMonitor::setSpecialWorkspace(const PHLWORKSPACE& pWorkspace, bool noFocus)
 
     g_pHyprRenderer->damageMonitor(m_self.lock());
 
+    g_pInputManager->unconstrainMouse();
+
     if (!pWorkspace) {
         // remove special if exists
         if (m_activeSpecialWorkspace) {

--- a/src/protocols/PointerConstraints.cpp
+++ b/src/protocols/PointerConstraints.cpp
@@ -121,7 +121,7 @@ void CPointerConstraint::activate() {
 
     // TODO: hack, probably not a super duper great idea
     if (g_pSeatManager->m_state.pointerFocus != m_hlSurface->resource()) {
-        if (const auto W = Desktop::View::CWindow::fromView(m_hlSurface->view()); !W || !W->cantLockCursor()) {
+        if (const auto VIEW = m_hlSurface->view(); !VIEW || !VIEW->cantLockCursor()) {
             const auto SURFBOX = m_hlSurface->getSurfaceBoxGlobal();
             const auto LOCAL   = SURFBOX.has_value() ? logicPositionHint() - SURFBOX->pos() : Vector2D{};
             g_pSeatManager->setPointerFocus(m_hlSurface->resource(), LOCAL);
@@ -239,7 +239,7 @@ void CPointerConstraintsProtocol::onNewConstraint(SP<CPointerConstraint> constra
 
     g_pInputManager->m_constraints.emplace_back(constraint);
 
-    if (Desktop::focusState()->surface() == OWNER->resource())
+    if (g_pSeatManager->m_state.pointerFocus == OWNER->resource())
         constraint->activate();
 }
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

Add support for pointer constraints on subsurface.

Godot use subsurface to embed game window into editor and debug window.
With godotengine/godot#120647 merged + this patch, mouse capture can then work on embedded game window.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?


