### PR TITLE
pointer-warp: fix forgetting enter serial

### DIFF
--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -62,9 +62,9 @@ uint32_t CSeatManager::nextSerial(SP<CWLSeatResource> seatResource, bool enter) 
 
     auto serial = wl_display_next_serial(g_pCompositor->m_wlDisplay);
 
-    if (enter) {
+    if (enter)
         container->enterSerial = serial;
-    } else {
+    else {
         container->serials.emplace_back(serial);
 
         if (container->serials.size() > MAX_SERIAL_STORE_LEN)

--- a/src/managers/SeatManager.cpp
+++ b/src/managers/SeatManager.cpp
@@ -52,7 +52,7 @@ SP<CSeatManager::SSeatResourceContainer> CSeatManager::containerForResource(SP<C
     return nullptr;
 }
 
-uint32_t CSeatManager::nextSerial(SP<CWLSeatResource> seatResource) {
+uint32_t CSeatManager::nextSerial(SP<CWLSeatResource> seatResource, bool enter) {
     if (!seatResource)
         return 0;
 
@@ -62,10 +62,14 @@ uint32_t CSeatManager::nextSerial(SP<CWLSeatResource> seatResource) {
 
     auto serial = wl_display_next_serial(g_pCompositor->m_wlDisplay);
 
-    container->serials.emplace_back(serial);
+    if (enter) {
+        container->enterSerial = serial;
+    } else {
+        container->serials.emplace_back(serial);
 
-    if (container->serials.size() > MAX_SERIAL_STORE_LEN)
-        container->serials.erase(container->serials.begin());
+        if (container->serials.size() > MAX_SERIAL_STORE_LEN)
+            container->serials.erase(container->serials.begin());
+    }
 
     return serial;
 }
@@ -77,6 +81,9 @@ bool CSeatManager::serialValid(SP<CWLSeatResource> seatResource, uint32_t serial
     auto container = containerForResource(seatResource);
 
     ASSERT(container);
+
+    if (container->enterSerial == serial)
+        return true;
 
     for (auto it = container->serials.begin(); it != container->serials.end(); ++it) {
         if (*it == serial) {

--- a/src/managers/SeatManager.hpp
+++ b/src/managers/SeatManager.hpp
@@ -74,7 +74,7 @@ class CSeatManager {
 
     void     resendEnterEvents();
 
-    uint32_t nextSerial(SP<CWLSeatResource> seatResource);
+    uint32_t nextSerial(SP<CWLSeatResource> seatResource, bool enter = false);
     // pops the serial if it was valid, meaning it is consumed.
     bool                serialValid(SP<CWLSeatResource> seatResource, uint32_t serial, bool erase = true);
     void                recordPointerButtonSerial(SP<CWLSeatResource> seatResource, uint32_t serial, SP<CWLSurfaceResource> surface, uint32_t button);
@@ -141,7 +141,8 @@ class CSeatManager {
         SSeatResourceContainer(SP<CWLSeatResource>);
 
         WP<CWLSeatResource>               resource;
-        std::vector<uint32_t>             serials; // old -> new
+        uint32_t                          enterSerial; // remember this forever
+        std::vector<uint32_t>             serials;     // old -> new
         std::vector<SPointerButtonSerial> pointerButtonSerials;
 
         struct {

--- a/src/managers/SeatManager.hpp
+++ b/src/managers/SeatManager.hpp
@@ -141,8 +141,8 @@ class CSeatManager {
         SSeatResourceContainer(SP<CWLSeatResource>);
 
         WP<CWLSeatResource>               resource;
-        uint32_t                          enterSerial; // remember this forever
-        std::vector<uint32_t>             serials;     // old -> new
+        uint32_t                          enterSerial = 0; // remember this forever
+        std::vector<uint32_t>             serials;         // old -> new
         std::vector<SPointerButtonSerial> pointerButtonSerials;
 
         struct {

--- a/src/protocols/core/Seat.cpp
+++ b/src/protocols/core/Seat.cpp
@@ -179,7 +179,7 @@ void CWLPointerResource::sendEnter(SP<CWLSurfaceResource> surface, const Vector2
 
     const auto fixedLocal = fixPosWithWlFixed(local);
 
-    m_resource->sendEnter(g_pSeatManager->nextSerial(m_owner.lock()), surface->getResource().get(), wl_fixed_from_double(fixedLocal.x), wl_fixed_from_double(fixedLocal.y));
+    m_resource->sendEnter(g_pSeatManager->nextSerial(m_owner.lock(), true), surface->getResource().get(), wl_fixed_from_double(fixedLocal.x), wl_fixed_from_double(fixedLocal.y));
 }
 
 void CWLPointerResource::sendLeave() {


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes pointer-warp proto that stops working after a while because the proto uses the latest serial from pointer::enter for validation, but that serial was kept in a common fifo that actually gets cleared pretty fast. Now keeps enterSerial forever, or until the next enter at least. Actually probably many protocols rely on this being kept safe.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

I have no idea if this box of serials the others are kept in makes any sense at all, I just extracted the enterSerial from it to be kept safe. I feel like technically many things should probably be validated *only* against the enterSerial, not a box of random ones, but I don't have all the details and don't want to get into it.

Relevant disco https://github.com/hyprwm/Hyprland/discussions/14622

Reprod simply with random SDL3 demo with `SDL_WarpMouseInWindow(window, 200.0f, 200.0f);` stuck in the middle. Initially window seems to lock pointer, but releases it after smashing asdf for a few seconds, which exhausts the serial buffer and forgets our enter serial.

#### Is it ready for merging, or does it need work?

Ready, but maybe someone test the real games too (cs2 radial menu, patched minecraft inventory etc)