### PR TITLE
fix uniqueptr .lock() in animation

### DIFF
--- a/src/animation/AnimationManager.cpp
+++ b/src/animation/AnimationManager.cpp
@@ -281,8 +281,7 @@ void CHyprAnimationManager::tick() {
         if (!PAV)
             continue;
 
-        const auto LOCK = PAV.lock();
-        bool       warp = !*PANIMENABLED || !PAV->enabled();
+        bool warp = !*PANIMENABLED || !PAV->enabled();
 
         switch (PAV->m_Type) {
             case AVARTYPE_FLOAT: {


### PR DESCRIPTION
in AnimationManager.cpp.
animationManager.hpp does makeUnique<CAnimatedVariable<VarType>>() , so this has never worked.


