### PR TITLE
windowstate/layerstate: don't dynamic_cast a view's self-ptr during destruction

### DIFF
--- a/src/desktop/state/LayerState.cpp
+++ b/src/desktop/state/LayerState.cpp
@@ -19,7 +19,10 @@ CLayerState::CLayerState() {
         if (event.type != View::VIEW_TYPE_LAYER_SURFACE)
             return;
 
-        std::erase_if(m_layers, [&](auto& x) { return !x || event.view == dynamicPointerCast<View::IView>(x->m_self); });
+        // A CLayerSurface is always an IView via a static upcast, so compare control-block identity directly.
+        // Must NOT dereference x->m_self here: this event is emitted from ~IView, by which point CLayerSurface's
+        // members (incl. m_self) are already destroyed. PHLVIEWREF{x} only reads x's own impl_/data pointer.
+        std::erase_if(m_layers, [&](auto& x) { return !x || event.view == PHLVIEWREF{x}; });
     });
 }
 

--- a/src/desktop/state/LayerState.cpp
+++ b/src/desktop/state/LayerState.cpp
@@ -14,16 +14,6 @@ CLayerState::CLayerState() {
 
         m_layers.emplace_back(LAYER);
     });
-
-    m_listeners.viewDestroy = Event::bus()->m_events.view.destroy.listen([this](const Event::SViewDestroyEvent& event) {
-        if (event.type != View::VIEW_TYPE_LAYER_SURFACE)
-            return;
-
-        // A CLayerSurface is always an IView via a static upcast, so compare control-block identity directly.
-        // Must NOT dereference x->m_self here: this event is emitted from ~IView, by which point CLayerSurface's
-        // members (incl. m_self) are already destroyed. PHLVIEWREF{x} only reads x's own impl_/data pointer.
-        std::erase_if(m_layers, [&](auto& x) { return !x || event.view == PHLVIEWREF{x}; });
-    });
 }
 
 const std::vector<PHLLS>& CLayerState::layers() const {

--- a/src/desktop/state/LayerState.hpp
+++ b/src/desktop/state/LayerState.hpp
@@ -21,7 +21,7 @@ namespace Desktop {
         std::vector<PHLLS> m_layers;
 
         struct {
-            CHyprSignalListener viewCreate, viewDestroy;
+            CHyprSignalListener viewCreate;
         } m_listeners;
     };
 

--- a/src/desktop/state/WindowState.cpp
+++ b/src/desktop/state/WindowState.cpp
@@ -21,7 +21,10 @@ CWindowState::CWindowState() {
         if (event.type != View::VIEW_TYPE_WINDOW)
             return;
 
-        std::erase_if(m_windows, [&](auto& x) { return !x || event.view == dynamicPointerCast<View::IView>(x->m_self); });
+        // A CWindow is always an IView via a static upcast, so compare control-block identity directly.
+        // Must NOT dereference x->m_self here: this event is emitted from ~IView, by which point CWindow's
+        // members (incl. m_self) are already destroyed. PHLVIEWREF{x} only reads x's own impl_/data pointer.
+        std::erase_if(m_windows, [&](auto& x) { return !x || event.view == PHLVIEWREF{x}; });
     });
 }
 

--- a/src/desktop/state/WindowState.cpp
+++ b/src/desktop/state/WindowState.cpp
@@ -16,16 +16,6 @@ CWindowState::CWindowState() {
 
         m_windows.emplace_back(WINDOW);
     });
-
-    m_listeners.viewDestroy = Event::bus()->m_events.view.destroy.listen([this](const Event::SViewDestroyEvent& event) {
-        if (event.type != View::VIEW_TYPE_WINDOW)
-            return;
-
-        // A CWindow is always an IView via a static upcast, so compare control-block identity directly.
-        // Must NOT dereference x->m_self here: this event is emitted from ~IView, by which point CWindow's
-        // members (incl. m_self) are already destroyed. PHLVIEWREF{x} only reads x's own impl_/data pointer.
-        std::erase_if(m_windows, [&](auto& x) { return !x || event.view == PHLVIEWREF{x}; });
-    });
 }
 
 void CWindowState::removeSafe(PHLWINDOW w) {

--- a/src/desktop/state/WindowState.hpp
+++ b/src/desktop/state/WindowState.hpp
@@ -32,7 +32,7 @@ namespace Desktop {
         void                   moveToZ(PHLWINDOW w, bool top);
 
         struct {
-            CHyprSignalListener viewCreate, viewDestroy;
+            CHyprSignalListener viewCreate;
         } m_listeners;
     };
 


### PR DESCRIPTION

The view.destroy listeners erase_if'd their containers by evaluating dynamicPointerCast<IView>(x->m_self). Since the event is emitted from ~IView, the matching view's derived member m_self is already destroyed by then, so reading it is UB. Compare control-block identity via PHLVIEWREF{x} instead, which never dereferences the dying object.

see: https://github.com/hyprwm/hyprutils/pull/118


im a bit out of my brainpower here so this is all robot code.


