### PR TITLE
presentation: ensure feedbacks arent silently dropped

### DIFF
--- a/src/protocols/PresentationTime.cpp
+++ b/src/protocols/PresentationTime.cpp
@@ -125,8 +125,10 @@ void CPresentationProtocol::onGetFeedback(CWpPresentation* pMgr, wl_resource* su
         return;
     }
 
-    if (const auto SURFACE = CWLSurfaceResource::fromResource(surf); SURFACE)
+    if (const auto SURFACE = CWLSurfaceResource::fromResource(surf); SURFACE) {
         SURFACE->m_pending.presentationFeedbacks.emplace_back(RESOURCE);
+        SURFACE->m_pending.updated.bits.presentation = true;
+    }
 }
 
 void CPresentationProtocol::onPresented(PHLMONITOR pMonitor, const timespec& when, uint32_t untilRefreshNs, uint64_t seq, uint32_t reportedFlags) {

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -621,7 +621,8 @@ void CWLSurfaceResource::commitState(SSurfaceState& state) {
     if (!state.updated.all && m_mapped && state.fifoScheduled)
         return;
 
-    if (state.updated.all)
+    // only a new buffer supersedes the current, not yet presented content.
+    if (state.updated.bits.buffer)
         PROTO::presentation->discardFeedbacks(m_current.presentationFeedbacks);
 
     auto lastTexture = m_current.texture;

--- a/src/protocols/types/SurfaceState.cpp
+++ b/src/protocols/types/SurfaceState.cpp
@@ -135,7 +135,7 @@ void SSurfaceState::updateFrom(SSurfaceState& ref) {
         ref.callbacks.clear();
     }
 
-    if (!ref.presentationFeedbacks.empty()) {
+    if (ref.updated.bits.presentation) {
         presentationFeedbacks.insert(presentationFeedbacks.end(), std::make_move_iterator(ref.presentationFeedbacks.begin()),
                                      std::make_move_iterator(ref.presentationFeedbacks.end()));
         ref.presentationFeedbacks.clear();

--- a/src/protocols/types/SurfaceState.hpp
+++ b/src/protocols/types/SurfaceState.hpp
@@ -54,6 +54,7 @@ struct SSurfaceState {
             bool acked : 1;
             bool frame : 1;
             bool fifo : 1;
+            bool presentation : 1;
         } bits;
     } updated;
 


### PR DESCRIPTION
earlier codex complaint, if empty fifo commit happend but contained feedbacks it was silently dropped. also at the same time the only time we should discard current feedbacks if there are any is when a new buffer appears.

add a presentation bit flag, set it in onGetFeedback.

`codex quote`
When a surface uses wp_fifo and commits only a wait_barrier/presentation-feedback update, state.fifoScheduled is true while state.updated.all is false, so the early return above runs before this new feedback handling. CSurfaceStateQueue::tryProcess then pops the state immediately after commitState returns (src/protocols/types/SurfaceStateQueue.cpp:83-84), destroying state.presentationFeedbacks without moving them to m_current or sending discarded; clients waiting on that feedback can hang. Please resolve the state's feedbacks before returning from the FIFO no-op path.


