### PR TITLE
a few protocol error touchups

### DIFF
--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -210,6 +210,11 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
     });
 
     m_resource->setSetBufferScale([this](CWlSurface* r, int32_t scale) {
+        if (scale <= 0) {
+            r->error(WL_SURFACE_ERROR_INVALID_SCALE, "buffer scale must be positive");
+            return;
+        }
+
         if (scale == m_pending.scale)
             return;
 
@@ -221,6 +226,11 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
     });
 
     m_resource->setSetBufferTransform([this](CWlSurface* r, uint32_t tr) {
+        if (tr > WL_OUTPUT_TRANSFORM_FLIPPED_270) {
+            r->error(WL_SURFACE_ERROR_INVALID_TRANSFORM, "invalid buffer transform");
+            return;
+        }
+
         if (tr == m_pending.transform)
             return;
 

--- a/src/protocols/core/Compositor.cpp
+++ b/src/protocols/core/Compositor.cpp
@@ -95,6 +95,12 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
     m_resource->setOnDestroy([this](CWlSurface* r) { destroy(); });
 
     m_resource->setAttach([this](CWlSurface* r, wl_resource* buffer, int32_t x, int32_t y) {
+        // version is 5 or higher, passing any non-zero x or y is a protocol violation
+        if (m_resource->version() >= 5 && (x != 0 || y != 0)) {
+            r->error(WL_SURFACE_ERROR_INVALID_OFFSET, "attach x and y must be 0 since version 5");
+            return;
+        }
+
         m_pending.updated.bits.buffer = true;
         m_pending.updated.bits.offset = true;
 
@@ -134,6 +140,15 @@ CWLSurfaceResource::CWLSurfaceResource(SP<CWlSurface> resource_) : m_resource(re
         else if (m_pending.viewport.hasSource)
             m_pending.size = m_pending.viewport.source.size();
         else {
+            // without a viewport, at commit time the supplied
+            // buffer size must be an integer multiple of the buffer_scale. If
+            // that's not the case, an invalid_size error is sent.
+            if (sc<int>(m_pending.bufferSize.x) % m_pending.scale != 0 || sc<int>(m_pending.bufferSize.y) % m_pending.scale != 0) {
+                r->error(WL_SURFACE_ERROR_INVALID_SIZE, "buffer size is not an integer multiple of the buffer scale");
+                dropPendingBuffer();
+                return;
+            }
+
             Vector2D tfs   = m_pending.transform % 2 == 1 ? Vector2D{m_pending.bufferSize.y, m_pending.bufferSize.x} : m_pending.bufferSize;
             m_pending.size = tfs / m_pending.scale;
         }

--- a/src/protocols/core/Seat.cpp
+++ b/src/protocols/core/Seat.cpp
@@ -125,7 +125,7 @@ CWLPointerResource::CWLPointerResource(SP<CWlPointer> resource_, SP<CWLSeatResou
         auto surfResource = surf ? CWLSurfaceResource::fromResource(surf) : nullptr;
 
         if (surfResource && surfResource->m_role->role() != SURFACE_ROLE_CURSOR && surfResource->m_role->role() != SURFACE_ROLE_UNASSIGNED) {
-            r->error(-1, "Cursor surface already has a different role");
+            r->error(WL_POINTER_ERROR_ROLE, "Cursor surface already has a different role");
             return;
         }
 
@@ -288,7 +288,9 @@ void CWLPointerResource::sendAxisStop(uint32_t timeMs, wl_pointer_axis axis) {
 }
 
 void CWLPointerResource::sendAxisDiscrete(wl_pointer_axis axis, int32_t discrete) {
-    if (!m_owner || !m_currentSurface || m_resource->version() < 5)
+    // This event is deprecated with wl_pointer version 8 - this event is not
+    // sent to clients supporting version 8 or later.
+    if (!m_owner || !m_currentSurface || m_resource->version() < 5 || m_resource->version() >= 8)
         return;
 
     if (!(PROTO::seat->m_currentCaps & eHIDCapabilityType::HID_INPUT_CAPABILITY_POINTER))

--- a/src/protocols/core/Shm.cpp
+++ b/src/protocols/core/Shm.cpp
@@ -100,24 +100,22 @@ void CSHMPool::resize(size_t size_) {
         LOGM(Log::ERR, "Couldn't mmap {} bytes from fd {} of shm client", m_size, m_fd.get());
 }
 
-static int shmIsSizeValid(CFileDescriptor& fd, size_t size) {
+static int shmIsSizeValid(CFileDescriptor& fd, int32_t size) {
+    if UNLIKELY (size <= 0)
+        return 0;
+
     struct stat st;
     if UNLIKELY (fstat(fd.get(), &st) == -1) {
         LOGM(Log::ERR, "Couldn't get stat for fd {} of shm client", fd.get());
         return 0;
     }
 
-    return sc<size_t>(st.st_size) >= size;
+    return sc<size_t>(st.st_size) >= sc<size_t>(size);
 }
 
 CWLSHMPoolResource::CWLSHMPoolResource(UP<CWlShmPool>&& resource_, CFileDescriptor fd_, size_t size_) : m_resource(std::move(resource_)) {
     if UNLIKELY (!good())
         return;
-
-    if UNLIKELY (!shmIsSizeValid(fd_, size_)) {
-        m_resource->error(-1, "The size of the file is not big enough for the shm pool");
-        return;
-    }
 
     m_pool = makeShared<CSHMPool>(std::move(fd_), size_);
 
@@ -126,11 +124,11 @@ CWLSHMPoolResource::CWLSHMPoolResource(UP<CWlShmPool>&& resource_, CFileDescript
 
     m_resource->setResize([this](CWlShmPool* r, int32_t size_) {
         if UNLIKELY (size_ < sc<int32_t>(m_pool->m_size)) {
-            r->error(-1, "Shrinking a shm pool is illegal");
+            r->error(WL_SHM_ERROR_INVALID_FD, "Shrinking a shm pool is illegal");
             return;
         }
         if UNLIKELY (!shmIsSizeValid(m_pool->m_fd, size_)) {
-            r->error(-1, "The size of the file is not big enough for the shm pool");
+            r->error(WL_SHM_ERROR_INVALID_STRIDE, "The pool size is invalid or the file is not big enough for it");
             return;
         }
 
@@ -139,7 +137,7 @@ CWLSHMPoolResource::CWLSHMPoolResource(UP<CWlShmPool>&& resource_, CFileDescript
 
     m_resource->setCreateBuffer([this](CWlShmPool* r, uint32_t id, int32_t offset, int32_t w, int32_t h, int32_t stride, uint32_t fmt) {
         if UNLIKELY (!m_pool || m_pool->m_data == MAP_FAILED) {
-            r->error(-1, "The provided shm pool failed to allocate properly");
+            r->error(WL_SHM_ERROR_INVALID_FD, "The provided shm pool failed to allocate properly");
             return;
         }
 
@@ -187,7 +185,14 @@ CWLSHMResource::CWLSHMResource(UP<CWlShm>&& resource_) : m_resource(std::move(re
 
     m_resource->setCreatePool([](CWlShm* r, uint32_t id, int32_t fd, int32_t size) {
         CFileDescriptor poolFd{fd};
-        const auto&     RESOURCE = PROTO::shm->m_pools.emplace_back(makeUnique<CWLSHMPoolResource>(makeUnique<CWlShmPool>(r->client(), r->version(), id), std::move(poolFd), size));
+
+        // validate size and backing file before creating the pool resource, so a rejected pool is never added to m_pools
+        if UNLIKELY (!shmIsSizeValid(poolFd, size)) {
+            r->error(WL_SHM_ERROR_INVALID_STRIDE, "The pool size is invalid or the file is not big enough for it");
+            return;
+        }
+
+        const auto& RESOURCE = PROTO::shm->m_pools.emplace_back(makeUnique<CWLSHMPoolResource>(makeUnique<CWlShmPool>(r->client(), r->version(), id), std::move(poolFd), size));
 
         if UNLIKELY (!RESOURCE->good()) {
             r->noMemory();

--- a/src/protocols/core/Subcompositor.cpp
+++ b/src/protocols/core/Subcompositor.cpp
@@ -29,7 +29,7 @@ CWLSubsurfaceResource::CWLSubsurfaceResource(SP<CWlSubsurface> resource_, SP<CWL
 
         if ((it == m_parent->m_subsurfaces.end() && m_parent != SURF) || SURF == m_surface) {
             // protocol error, this is not a valid surface
-            r->error(-1, "Invalid surface in placeAbove");
+            r->error(WL_SUBSURFACE_ERROR_BAD_SURFACE, "Invalid surface in placeAbove");
             return;
         }
 
@@ -59,7 +59,7 @@ CWLSubsurfaceResource::CWLSubsurfaceResource(SP<CWlSubsurface> resource_, SP<CWL
 
         if ((it == m_parent->m_subsurfaces.end() && m_parent != SURF) || SURF == m_surface) {
             // protocol error, this is not a valid surface
-            r->error(-1, "Invalid surface in placeBelow");
+            r->error(WL_SUBSURFACE_ERROR_BAD_SURFACE, "Invalid surface in placeBelow");
             return;
         }
 
@@ -161,13 +161,19 @@ CWLSubcompositorResource::CWLSubcompositorResource(SP<CWlSubcompositor> resource
         auto SURF   = CWLSurfaceResource::fromResource(surface);
         auto PARENT = CWLSurfaceResource::fromResource(parent);
 
-        if UNLIKELY (!SURF || !PARENT || SURF == PARENT) {
+        if UNLIKELY (!SURF || !PARENT) {
             r->error(WL_SUBCOMPOSITOR_ERROR_BAD_SURFACE, "Invalid surface/parent");
             return;
         }
 
+        // the parent must be different from the child surface, otherwise bad_parent is raised (wl_subcompositor spec)
+        if UNLIKELY (SURF == PARENT) {
+            r->error(WL_SUBCOMPOSITOR_ERROR_BAD_PARENT, "Parent surface must be different from the child surface");
+            return;
+        }
+
         if UNLIKELY (SURF->m_role->role() != SURFACE_ROLE_UNASSIGNED) {
-            r->error(-1, "Surface already has a different role");
+            r->error(WL_SUBCOMPOSITOR_ERROR_BAD_SURFACE, "Surface already has a different role");
             return;
         }
 


### PR DESCRIPTION
reduce bogus -1 errors, and try to honor spec as much as we can. 
there is more to go over in `protocols/*` and general logical flaws. but this should get most hard since version violations right.


