### PR TITLE
input-capture: fix `allow_input_capture` bind flag with `capture_modifiers` enabled

### DIFF
--- a/src/managers/input/InputManager.cpp
+++ b/src/managers/input/InputManager.cpp
@@ -1691,8 +1691,10 @@ void CInputManager::onKeyboardMod(SP<IKeyboard> pKeyboard) {
     if (*PSENDMOD) {
         PROTO::inputCapture->modifiers(MODS.depressed, MODS.latched, MODS.locked, MODS.group);
 
-        if (PROTO::inputCapture->isCaptured())
+        if (PROTO::inputCapture->isCaptured()) {
+            m_lastMods = shareModsFromAllKBs(MODS.depressed);
             return;
+        }
     }
 
     // use merged mods states when sending to ime or when sending to seat with no ime


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
`allow_input_capture` bind flag was being ignored when `capture_modifiers` was on


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
no


#### Is it ready for merging, or does it need work?
ready


