### PR TITLE
config/lua: support string[] in hl.bind

### DIFF
--- a/meta/generateLuaStubs.py
+++ b/meta/generateLuaStubs.py
@@ -520,7 +520,7 @@ def generate_stub(root: Path) -> str:
 
     api_signatures: dict[str, str] = {
         "hl.on": "fun(event: HL.EventName, cb: fun(...)): HL.EventSubscription",
-        "hl.bind": "fun(keys: string, dispatcher: HL.Dispatcher|function, opts?: HL.BindOptions): HL.Keybind",
+        "hl.bind": "fun(keys: string|string[], dispatcher: HL.Dispatcher|function, opts?: HL.BindOptions): HL.Keybind",
         "hl.dispatch": "fun(dispatcher: HL.Dispatcher|function): any",
         "hl.define_submap": "fun(name: string, reset_or_fn: string|function, fn?: function): nil",
         "hl.timer": "fun(callback: function, opts: HL.TimerOptions): HL.Timer",

--- a/src/config/lua/bindings/LuaBindingsToplevel.cpp
+++ b/src/config/lua/bindings/LuaBindingsToplevel.cpp
@@ -55,20 +55,15 @@ static bool isSymSpecial(std::string_view sv) {
     return sv.starts_with("switch:") || sv.starts_with("mouse:");
 }
 
-static std::expected<void, std::string> parseKeyString(SKeybind& kb, std::string_view sv) {
+template <typename T>
+static std::expected<void, std::string> parseKeys(SKeybind& kb, T keysList) {
     bool                                                modsEnded = false, specialSym = false;
-    CVarList2                                           vl(sv, 0, '+', true);
 
     uint32_t                                            modMask = 0;
     std::vector<std::pair<xkb_keysym_t, xkb_keycode_t>> keysyms;
     std::string                                         lastKeyArg;
 
-    if (sv == "catchall") {
-        kb.catchAll = true;
-        return {};
-    }
-
-    for (const auto& a : vl) {
+    for (const auto& a : keysList) {
         auto arg = Hyprutils::String::trim(a);
 
         auto mask = modFromSv(arg);
@@ -129,21 +124,64 @@ static std::expected<void, std::string> parseKeyString(SKeybind& kb, std::string
     return {};
 }
 
+static std::expected<void, std::string> parseKeyString(SKeybind& kb, std::string_view sv) {
+    CVarList2 vl(sv, 0, '+', true);
+
+    if (sv == "catchall") {
+        kb.catchAll = true;
+        return {};
+    }
+
+    return parseKeys(kb, vl);
+}
+
 static int hlBind(lua_State* L) {
-    auto* mgr = sc<CConfigManager*>(lua_touserdata(L, lua_upvalueindex(1)));
+    auto*    mgr = sc<CConfigManager*>(lua_touserdata(L, lua_upvalueindex(1)));
 
-    auto  str = Check::string(L, 1);
-    if (!str)
-        return Internal::configError(L, std::format("bind: bad argument 1: {}", str.error()));
-
-    std::string_view keys = *str;
-
-    SKeybind         kb;
+    SKeybind kb;
     kb.submap.name  = mgr->m_currentSubmap;
     kb.submap.reset = mgr->m_currentSubmapReset;
 
-    if (auto res = parseKeyString(kb, keys); !res)
-        return Internal::configError(L, std::format("hl.bind: failed to parse key string: {}", res.error()));
+    int keysIdx = 1;
+    if (lua_istable(L, keysIdx)) {
+        int len = lua_rawlen(L, keysIdx);
+
+        if (len == 0)
+            return Internal::configError(L, "bind: keys must not be empty");
+
+        const int                     top = lua_gettop(L);
+        std::vector<std::string_view> keys;
+        keys.reserve(len);
+
+        for (int i = 1; i <= len; ++i) {
+            lua_rawgeti(L, keysIdx, i);
+            if (!lua_isstring(L, -1)) {
+                lua_settop(L, top);
+                return Internal::configError(L, std::format("bind: key at index {} must be a string.", i));
+            }
+            keys.emplace_back(lua_tostring(L, -1));
+        }
+
+        if (auto res = parseKeys(kb, keys); !res) {
+            lua_settop(L, top);
+            return Internal::configError(L, std::format("hl.bind: failed to parse key string array: {}", res.error()));
+        }
+
+        kb.displayKey = keys | std::views::join_with(std::string(" + ")) | std::ranges::to<std::string>();
+
+        lua_settop(L, top);
+    } else {
+        auto str = Check::string(L, keysIdx);
+        if (!str)
+            return Internal::configError(L, std::format("bind: bad argument 1: {}", str.error()));
+
+        std::string_view keys = *str;
+
+        if (auto res = parseKeyString(kb, keys); !res)
+            return Internal::configError(L, std::format("hl.bind: failed to parse key string: {}", res.error()));
+
+        kb.displayKey = keys;
+    }
 
     if (!Internal::pushDispatcherFunction(L, 2))
         return Internal::configError(L, "hl.bind: dispatcher must be a dispatcher (e.g. hl.dsp.window.close()) or a lua function");
@@ -151,10 +189,9 @@ static int hlBind(lua_State* L) {
     if (kb.catchAll && mgr->m_currentSubmap.empty())
         return Internal::configError(L, "hl.bind: catchall keybinds are only allowed in submaps.");
 
-    int ref       = luaL_ref(L, LUA_REGISTRYINDEX);
-    kb.handler    = "__lua";
-    kb.arg        = std::to_string(ref);
-    kb.displayKey = keys;
+    int ref    = luaL_ref(L, LUA_REGISTRYINDEX);
+    kb.handler = "__lua";
+    kb.arg     = std::to_string(ref);
 
     int optsIdx = 3;
 


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?

Add support for `string[]` for the keys parameter in hl.bind

I think use an actual array will be a better api than a string that acts like an array

and string[] is also much better if you want to use any variable in keys:
```lua
hl.bind(mainMod .. " + 1", hl.dsp.focus({ workspace = 1, on_current_monitor = true }))
-- to
hl.bind({ mainMod, "1" }, hl.dsp.focus({ workspace = 1, on_current_monitor = true }))

for i = 1, 10 do
	local key = tostring(i % 10)

	hl.bind(mainMod .. " + " .. alternative .. " + " .. key, hl.dsp.window.move({ workspace = i }))
	-- to
	hl.bind({ mainMod, alternative, key }, hl.dsp.window.move({ workspace = i }))
end
```

Alternative: use this lua function if user want to use string[]
```lua
---@param keys string | string[]
---@param dispatcher HL.Dispatcher | function
---@param opts? HL.BindOptions
local function bind(keys, dispatcher, opts)
	if type(keys) == "table" then
		keys = table.concat(keys, " + ")
	end
	hl.bind(keys, dispatcher, opts)
end
```


#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)


#### Is it ready for merging, or does it need work?


