### PR TITLE
CI: Fetch PR branch before running codeowners

### DIFF
--- a/.github/workflows/codeownersplus.yml
+++ b/.github/workflows/codeownersplus.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: 'Fetch PR Branch'
+        run: git fetch origin ${{ github.event.pull_request.head.sha }}
+
       - name: 'Codeowners Plus'
         uses: multimediallc/codeowners-plus@v1.9.1
         with:


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Fixes codeowners-plus not finding the tip of the PR it's supposed to analyze. ~~This also matches their own docs.~~

**Edit:** Switching back to `pull_request` doesn't always work, because GH refuses to let PRs from *forks* write to PRs (even their own). We should be able to just manually fetch the PR branch instead.

~~@vaxerski, it looks like you changed from `pull_request` to `pull_request_target` in #15383, but it's not clear why. Hopefully I'm not stepping on any toes by reverting that.~~

~~For verification that the above change was what broke it, notice that the [last successful run of this workflow](https://github.com/hyprwm/Hyprland/actions/runs/29197931363) took place on July 12 at 9:18AM, just before #15383 was merged, and every run since has failed with the same error.~~

~~Also, see LRitzdorf#1 for proof that this fix works.~~


#### Is it ready for merging, or does it need work?

Tested and ready to merge.
