### PR TITLE
Smol Makefile QoL patches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,14 +97,16 @@ asan:
 format-check:
 	@find src hyprctl hyprpm start tests hyprtester -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.h" \) \
 		! -path "src/render/shaders/Shaders.hpp" \
-		! -path "hyprctl/hw-protocols/*" | \
-		xargs clang-format --dry-run --Werror
+		! -path "hyprctl/hw-protocols/*" \
+		! -path "hyprtester/protocols/*" \
+		| xargs clang-format --dry-run --Werror
 
 format-fix:
 	@find src hyprctl hyprpm start tests hyprtester -type f \( -name "*.cpp" -o -name "*.hpp" -o -name "*.h" \) \
 		! -path "src/render/shaders/Shaders.hpp" \
-		! -path "hyprctl/hw-protocols/*" | \
-		xargs clang-format -i
+		! -path "hyprctl/hw-protocols/*" \
+		! -path "hyprtester/protocols/*" \
+		| xargs clang-format -i
 
 test:
 	$(MAKE) debug

--- a/Makefile
+++ b/Makefile
@@ -110,4 +110,4 @@ format-fix:
 
 test:
 	$(MAKE) debug
-	./build/hyprtester/hyprtester -c hyprtester/test.lua -b ./build/Hyprland -p hyprtester/plugin/hyprtestplugin.so
+	./build/hyprtester/hyprtester -c hyprtester/test.lua -b ./build/Hyprland -p hyprtester/plugin/hyprtestplugin.so $(TESTS)


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Two things:
- The `format-check` and `format-fix` targets now ignore the `hyprtester/protocols` directory, since that's all generated
- A `TESTS` variable that the `tests` target uses to run only selected tests, as supported by #15025. e.g. `make TESTS="asdf asdf2" test`

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Just a new feature and reduced false-positive format warnings!

#### Is it ready for merging, or does it need work?
Nope, ready to merge.