### PR TITLE
view: do not render monitor for tearing if it's blocked

### DIFF
--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -2758,7 +2758,8 @@ void CWindow::commitWindow() {
     }
 
     // tearing: if solitary, redraw it. This still might be a single surface window
-    if (PMONITOR && PMONITOR->m_solitaryClient.lock() == m_self.lock() && canBeTorn() && PMONITOR->m_tearingState.canTear && wlSurface()->resource()->m_current.texture) {
+    if (PMONITOR && PMONITOR->m_solitaryClient.lock() == m_self.lock() && canBeTorn() && PMONITOR->m_tearingState.canTear && wlSurface()->resource()->m_current.texture &&
+        !PMONITOR->isTearingBlocked()) {
         CRegion damageBox{wlSurface()->resource()->m_current.accumulateBufferDamage()};
 
         if (!damageBox.empty()) {


### PR DESCRIPTION
If tearing is blocked, we cannot start rendering. We'll start fucking the log and wasting resources