### PR TITLE
bell: play a sound by default

### DIFF
--- a/.github/actions/setup_base/action.yml
+++ b/.github/actions/setup_base/action.yml
@@ -29,6 +29,7 @@ runs:
           hyprcursor \
           jq \
           libc++ \
+          libcanberra \
           libdisplay-info \
           libdrm \
           libei \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,7 @@ pkg_check_modules(deps
   re2
   muparser
   lcms2
+  libcanberra
 )
 
 pkg_search_module(LUA REQUIRED IMPORTED_TARGET GLOBAL lua55 lua5.5 lua-55 lua-5.5 lua>=5.5 lua<5.6)

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -23,6 +23,7 @@
   hyprwayland-scanner,
   hyprwire,
   lcms2,
+  libcanberra,
   libGL,
   libdrm,
   libei,
@@ -190,6 +191,7 @@ customStdenv.mkDerivation (finalAttrs: {
       hyprutils
       hyprwire
       lcms2
+      libcanberra
       libdrm
       libgbm
       libGL

--- a/src/config/lua/LuaEventHandler.cpp
+++ b/src/config/lua/LuaEventHandler.cpp
@@ -183,6 +183,8 @@ CLuaEventHandler::CLuaEventHandler(lua_State* L) : m_lua(L) {
             lua_pushinteger(L, keyEvent.state);
         });
     }));
+
+    m_listeners.push_back(bus()->m_events.bell.ring.listen([this] { dispatch("bell.ring", 0, [](lua_State* L) {}); }));
 }
 
 CLuaEventHandler::~CLuaEventHandler() {
@@ -296,6 +298,7 @@ std::unordered_set<std::string> CLuaEventHandler::knownEvents() {
         "hyprland.start",
         "hyprland.shutdown",
         "input.keyboard.key",
+        "bell.ring",
     };
     for (auto& kv : Event::bus()->m_events.plugin)
         EVENTS.emplace(kv.first);

--- a/src/config/lua/LuaEventHandler.cpp
+++ b/src/config/lua/LuaEventHandler.cpp
@@ -114,6 +114,7 @@ CLuaEventHandler::CLuaEventHandler(lua_State* L) : m_lua(L) {
             CLuaWorkspace::push(L, ws);
         });
     }));
+    m_listeners.push_back(bus()->m_events.window.bell.listen([this](PHLWINDOW w) { dispatch("window.bell", 1, [&](lua_State* L) { CLuaWindow::push(L, w); }); }));
 
     m_listeners.push_back(bus()->m_events.layer.opened.listen([this](PHLLS ls) { dispatch("layer.opened", 1, [&](lua_State* L) { CLuaLayerSurface::push(L, ls); }); }));
     m_listeners.push_back(bus()->m_events.layer.closed.listen([this](PHLLS ls) { dispatch("layer.closed", 1, [&](lua_State* L) { CLuaLayerSurface::push(L, ls); }); }));
@@ -183,8 +184,6 @@ CLuaEventHandler::CLuaEventHandler(lua_State* L) : m_lua(L) {
             lua_pushinteger(L, keyEvent.state);
         });
     }));
-
-    m_listeners.push_back(bus()->m_events.bell.ring.listen([this] { dispatch("bell.ring", 0, [](lua_State* L) {}); }));
 }
 
 CLuaEventHandler::~CLuaEventHandler() {
@@ -280,6 +279,7 @@ std::unordered_set<std::string> CLuaEventHandler::knownEvents() {
         "window.fullscreen",
         "window.update_rules",
         "window.move_to_workspace",
+        "window.bell",
         "layer.opened",
         "layer.closed",
         "monitor.added",
@@ -298,7 +298,6 @@ std::unordered_set<std::string> CLuaEventHandler::knownEvents() {
         "hyprland.start",
         "hyprland.shutdown",
         "input.keyboard.key",
-        "bell.ring",
     };
     for (auto& kv : Event::bus()->m_events.plugin)
         EVENTS.emplace(kv.first);

--- a/src/config/lua/LuaEventHandler.cpp
+++ b/src/config/lua/LuaEventHandler.cpp
@@ -114,7 +114,8 @@ CLuaEventHandler::CLuaEventHandler(lua_State* L) : m_lua(L) {
             CLuaWorkspace::push(L, ws);
         });
     }));
-    m_listeners.push_back(bus()->m_events.window.bell.listen([this](PHLWINDOW w) { dispatch("window.bell", 1, [&](lua_State* L) { CLuaWindow::push(L, w); }); }));
+    m_listeners.push_back(
+        bus()->m_events.window.bell.listen([this](PHLWINDOW w, Event::SCallbackInfo&) { dispatch("window.bell", 1, [&](lua_State* L) { CLuaWindow::push(L, w); }); }));
 
     m_listeners.push_back(bus()->m_events.layer.opened.listen([this](PHLLS ls) { dispatch("layer.opened", 1, [&](lua_State* L) { CLuaLayerSurface::push(L, ls); }); }));
     m_listeners.push_back(bus()->m_events.layer.closed.listen([this](PHLLS ls) { dispatch("layer.closed", 1, [&](lua_State* L) { CLuaLayerSurface::push(L, ls); }); }));

--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -517,6 +517,7 @@ std::vector<SP<IValue>> Values::getConfigValues() {
         MS<Bool>("misc:screencopy_force_8b", "forces 8 bit screencopy", true),
         MS<Bool>("misc:disable_scale_notification", "disables notification popup when a monitor fails to set a suitable scale", false),
         MS<Bool>("misc:size_limits_tiled", "whether to apply minsize and maxsize rules to tiled windows", false),
+        MS<String>("misc:bell_sound", "Path to sound file for the system bell. `none` or an empty value disable it.", "default"),
 
         /*
          * binds:

--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -517,7 +517,7 @@ std::vector<SP<IValue>> Values::getConfigValues() {
         MS<Bool>("misc:screencopy_force_8b", "forces 8 bit screencopy", true),
         MS<Bool>("misc:disable_scale_notification", "disables notification popup when a monitor fails to set a suitable scale", false),
         MS<Bool>("misc:size_limits_tiled", "whether to apply minsize and maxsize rules to tiled windows", false),
-        MS<String>("misc:bell_sound", "Path to sound file for the system bell. `none` or an empty value disable it.", "default"),
+        MS<String>("misc:bell_sound", "path to custom wav/ogg system bell. `none` or an empty string mute it. `default` uses the system's current one.", "default"),
         MS<Int>("misc:new_float_force_onscreen", "whether new floating windows must be placed fully/partially on-screen", 2),
         MS<Int>("misc:float_force_onscreen", "whether existing floating windows must remain fully/partially on-screen", 0),
 

--- a/src/event/EventBus.hpp
+++ b/src/event/EventBus.hpp
@@ -90,7 +90,7 @@ namespace Event {
                 Event<PHLWINDOW>                        floating;
                 Event<PHLWINDOW>                        updateRules;
                 Event<PHLWINDOW, PHLWORKSPACE>          moveToWorkspace;
-                Event<PHLWINDOW>                        bell;
+                Cancellable<PHLWINDOW>                  bell;
             } window;
 
             struct {

--- a/src/event/EventBus.hpp
+++ b/src/event/EventBus.hpp
@@ -187,6 +187,10 @@ namespace Event {
                 Event<const std::string&> submap;
             } keybinds;
 
+            struct {
+                Event<> ring;
+            } bell;
+
             Event<SP<CCustomEvent>>                           pluginEventAdded;
             Event<std::string>                                pluginEventRemoved;
             std::unordered_map<std::string, SP<CCustomEvent>> plugin;

--- a/src/event/EventBus.hpp
+++ b/src/event/EventBus.hpp
@@ -90,6 +90,7 @@ namespace Event {
                 Event<PHLWINDOW>                        floating;
                 Event<PHLWINDOW>                        updateRules;
                 Event<PHLWINDOW, PHLWORKSPACE>          moveToWorkspace;
+                Event<PHLWINDOW>                        bell;
             } window;
 
             struct {
@@ -186,10 +187,6 @@ namespace Event {
             struct {
                 Event<const std::string&> submap;
             } keybinds;
-
-            struct {
-                Event<> ring;
-            } bell;
 
             Event<SP<CCustomEvent>>                           pluginEventAdded;
             Event<std::string>                                pluginEventRemoved;

--- a/src/helpers/BellSound.cpp
+++ b/src/helpers/BellSound.cpp
@@ -1,0 +1,77 @@
+#include "BellSound.hpp"
+#include <canberra.h>
+#include "../config/ConfigValue.hpp"
+#include "../config/ConfigManager.hpp"
+#include "MiscFunctions.hpp"
+#include "../event/EventBus.hpp"
+#include "../debug/log/Logger.hpp"
+
+CBellSound::CBellSound() {
+    onNewConfig();
+    static auto configListener = Event::bus()->m_events.config.reloaded.listen([this] { onNewConfig(); });
+}
+
+CBellSound::~CBellSound() {
+    if (m_context) {
+        ca_context_destroy(m_context);
+        ca_proplist_destroy(m_sound);
+    }
+}
+
+void CBellSound::onNewConfig() {
+    const auto VALUE = *CConfigValue<std::string>("misc:bell_sound");
+
+    if (VALUE == "default") {
+        m_muted = false;
+        initializeSoundContext();
+        ca_proplist_sets(m_sound, CA_PROP_EVENT_ID, "bell-window-system");
+    } else if (VALUE.empty() || VALUE == "none")
+        m_muted = true;
+    else {
+        m_muted = false;
+        initializeSoundContext();
+
+        const auto RESOLVEDPATH = absolutePath(VALUE, Config::mgr()->getMainConfigPath());
+        ca_proplist_sets(m_sound, CA_PROP_MEDIA_FILENAME, RESOLVEDPATH.c_str());
+        ca_proplist_set(m_sound, CA_PROP_EVENT_ID, nullptr, 0);
+        int result = validateCustomSound();
+        if (result == CA_SUCCESS)
+            return;
+
+        ca_proplist_sets(m_sound, CA_PROP_EVENT_ID, "bell-window-system");
+        if (result == CA_ERROR_CORRUPT)
+            Log::logger->log(Log::WARN, "system bell: resolved custom sound path '{}' is not a valid wav/ogg file, falling back to default", RESOLVEDPATH);
+        else
+            Log::logger->log(Log::WARN, "system bell: validation for resolved custom sound path '{}' failed: '{}', falling back to default", RESOLVEDPATH, ca_strerror(result));
+    }
+}
+
+void CBellSound::initializeSoundContext() {
+    if (m_context)
+        return;
+
+    int result = ca_context_create(&m_context) || ca_proplist_create(&m_sound);
+    if UNLIKELY (result != CA_SUCCESS)
+        Log::logger->log(Log::ERR, "system bell: failed to create canberra context: '{}'", ca_strerror(result));
+
+    ca_context_change_props(m_context, CA_PROP_APPLICATION_NAME, "Hyprland", CA_PROP_MEDIA_NAME, "System Bell", CA_PROP_EVENT_DESCRIPTION, "Wayland system bell",
+                            CA_PROP_MEDIA_ROLE, "event", CA_PROP_MEDIA_ICON_NAME, "preferences-system-notifications", CA_PROP_CANBERRA_CACHE_CONTROL, "permanent", nullptr);
+}
+
+int CBellSound::validateCustomSound() {
+    ca_proplist_sets(m_sound, CA_PROP_CANBERRA_VOLUME, "-inf");
+    int result = ca_context_play_full(m_context, 0, m_sound, nullptr, nullptr);
+    ca_proplist_set(m_sound, CA_PROP_CANBERRA_VOLUME, nullptr, 0);
+    return result;
+}
+
+void CBellSound::play() {
+    static CBellSound instance;
+
+    if (instance.m_muted)
+        return;
+
+    int result = ca_context_play_full(instance.m_context, 0, instance.m_sound, nullptr, nullptr);
+    if (result != CA_SUCCESS)
+        Log::logger->log(Log::WARN, "system bell: failed to play sound, '{}'", ca_strerror(result));
+}

--- a/src/helpers/BellSound.cpp
+++ b/src/helpers/BellSound.cpp
@@ -2,13 +2,13 @@
 #include <canberra.h>
 #include "../config/ConfigValue.hpp"
 #include "../config/ConfigManager.hpp"
-#include "MiscFunctions.hpp"
+#include "./MiscFunctions.hpp"
 #include "../event/EventBus.hpp"
 #include "../debug/log/Logger.hpp"
 
 CBellSound::CBellSound() {
     onNewConfig();
-    static auto configListener = Event::bus()->m_events.config.reloaded.listen([this] { onNewConfig(); });
+    m_configListener = Event::bus()->m_events.config.reloaded.listen([this] { onNewConfig(); });
 }
 
 CBellSound::~CBellSound() {

--- a/src/helpers/BellSound.cpp
+++ b/src/helpers/BellSound.cpp
@@ -32,17 +32,15 @@ void CBellSound::onNewConfig() {
         initializeSoundContext();
 
         const auto RESOLVEDPATH = absolutePath(VALUE, Config::mgr()->getMainConfigPath());
-        ca_proplist_sets(m_sound, CA_PROP_MEDIA_FILENAME, RESOLVEDPATH.c_str());
-        ca_proplist_set(m_sound, CA_PROP_EVENT_ID, nullptr, 0);
-        int result = validateCustomSound();
-        if (result == CA_SUCCESS)
+
+        if (std::filesystem::exists(RESOLVEDPATH)) {
+            ca_proplist_sets(m_sound, CA_PROP_MEDIA_FILENAME, RESOLVEDPATH.c_str());
+            ca_proplist_set(m_sound, CA_PROP_EVENT_ID, nullptr, 0);
             return;
+        }
 
         ca_proplist_sets(m_sound, CA_PROP_EVENT_ID, "bell-window-system");
-        if (result == CA_ERROR_CORRUPT)
-            Log::logger->log(Log::WARN, "system bell: resolved custom sound path '{}' is not a valid wav/ogg file, falling back to default", RESOLVEDPATH);
-        else
-            Log::logger->log(Log::WARN, "system bell: validation for resolved custom sound path '{}' failed: '{}', falling back to default", RESOLVEDPATH, ca_strerror(result));
+        Log::logger->log(Log::WARN, "bell: resolved custom sound path '{}' doesn't exist, falling back to default", RESOLVEDPATH);
     }
 }
 
@@ -52,17 +50,10 @@ void CBellSound::initializeSoundContext() {
 
     int result = ca_context_create(&m_context) || ca_proplist_create(&m_sound);
     if UNLIKELY (result != CA_SUCCESS)
-        Log::logger->log(Log::ERR, "system bell: failed to create canberra context: '{}'", ca_strerror(result));
+        Log::logger->log(Log::ERR, "bell: failed to create canberra context, '{}'", ca_strerror(result));
 
     ca_context_change_props(m_context, CA_PROP_APPLICATION_NAME, "Hyprland", CA_PROP_MEDIA_NAME, "System Bell", CA_PROP_EVENT_DESCRIPTION, "Wayland system bell",
                             CA_PROP_MEDIA_ROLE, "event", CA_PROP_MEDIA_ICON_NAME, "preferences-system-notifications", CA_PROP_CANBERRA_CACHE_CONTROL, "permanent", nullptr);
-}
-
-int CBellSound::validateCustomSound() {
-    ca_proplist_sets(m_sound, CA_PROP_CANBERRA_VOLUME, "-inf");
-    int result = ca_context_play_full(m_context, 0, m_sound, nullptr, nullptr);
-    ca_proplist_set(m_sound, CA_PROP_CANBERRA_VOLUME, nullptr, 0);
-    return result;
 }
 
 void CBellSound::play() {
@@ -72,6 +63,10 @@ void CBellSound::play() {
         return;
 
     int result = ca_context_play_full(instance.m_context, 0, instance.m_sound, nullptr, nullptr);
-    if (result != CA_SUCCESS)
-        Log::logger->log(Log::WARN, "system bell: failed to play sound, '{}'", ca_strerror(result));
+    if UNLIKELY (result != CA_SUCCESS) {
+        if (result == CA_ERROR_CORRUPT)
+            Log::logger->log(Log::WARN, "bell: sound is not a wav/ogg file");
+        else
+            Log::logger->log(Log::WARN, "bell: failed to play sound, '{}'", ca_strerror(result));
+    }
 }

--- a/src/helpers/BellSound.hpp
+++ b/src/helpers/BellSound.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <hyprutils/signal/Listener.hpp>
+
 struct ca_context;
 struct ca_proplist;
 
@@ -11,10 +13,12 @@ class CBellSound {
     CBellSound();
     ~CBellSound();
 
-    void         onNewConfig();
-    void         initializeSoundContext();
+    void                                   onNewConfig();
+    void                                   initializeSoundContext();
 
-    bool         m_muted   = false;
-    ca_context*  m_context = nullptr;
-    ca_proplist* m_sound   = nullptr;
+    bool                                   m_muted   = false;
+    ca_proplist*                           m_sound   = nullptr;
+    ca_context*                            m_context = nullptr;
+
+    Hyprutils::Signal::CHyprSignalListener m_configListener;
 };

--- a/src/helpers/BellSound.hpp
+++ b/src/helpers/BellSound.hpp
@@ -12,8 +12,6 @@ class CBellSound {
     ~CBellSound();
 
     void         onNewConfig();
-
-    int          validateCustomSound();
     void         initializeSoundContext();
 
     bool         m_muted   = false;

--- a/src/helpers/BellSound.hpp
+++ b/src/helpers/BellSound.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+struct ca_context;
+struct ca_proplist;
+
+class CBellSound {
+  public:
+    static void play();
+
+  private:
+    CBellSound();
+    ~CBellSound();
+
+    void         onNewConfig();
+
+    int          validateCustomSound();
+    void         initializeSoundContext();
+
+    bool         m_muted   = false;
+    ca_context*  m_context = nullptr;
+    ca_proplist* m_sound   = nullptr;
+};

--- a/src/protocols/XDGBell.cpp
+++ b/src/protocols/XDGBell.cpp
@@ -35,7 +35,7 @@ namespace {
         if (value == "none")
             return {.mode = eBellSoundMode::NONE};
 
-        const auto resolvedPath = absolutePath(value, Config::mgr()->getMainConfigPath());
+        const auto      resolvedPath = absolutePath(value, Config::mgr()->getMainConfigPath());
 
         std::error_code ec;
         if (!std::filesystem::exists(resolvedPath, ec) || ec || !std::filesystem::is_regular_file(resolvedPath, ec) || ec) {
@@ -100,12 +100,7 @@ namespace {
                 return nullptr;
             }
 
-            result = ca_context_change_props(
-                m_context,
-                CA_PROP_APPLICATION_NAME, "Hyprland",
-                CA_PROP_APPLICATION_ID, "org.hyprland.Hyprland",
-                nullptr
-            );
+            result = ca_context_change_props(m_context, CA_PROP_APPLICATION_NAME, "Hyprland", CA_PROP_APPLICATION_ID, "org.hyprland.Hyprland", nullptr);
 
             if (result < 0)
                 Log::logger->log(Log::WARN, "bell: failed to set canberra context properties: {}", ca_strerror(result));
@@ -142,21 +137,9 @@ namespace {
         int result = 0;
 
         if (config.mode == eBellSoundMode::DEFAULT) {
-            result = ca_context_play(
-                CONTEXT,
-                0,
-                CA_PROP_EVENT_ID, "bell-window-system",
-                CA_PROP_EVENT_DESCRIPTION, "Wayland system bell",
-                nullptr
-            );
+            result = ca_context_play(CONTEXT, 0, CA_PROP_EVENT_ID, "bell-window-system", CA_PROP_EVENT_DESCRIPTION, "Wayland system bell", nullptr);
         } else {
-            result = ca_context_play(
-                CONTEXT,
-                0,
-                CA_PROP_MEDIA_FILENAME, config.filePath.c_str(),
-                CA_PROP_EVENT_DESCRIPTION, "Wayland system bell",
-                nullptr
-            );
+            result = ca_context_play(CONTEXT, 0, CA_PROP_MEDIA_FILENAME, config.filePath.c_str(), CA_PROP_EVENT_DESCRIPTION, "Wayland system bell", nullptr);
         }
 
         if (result < 0)
@@ -178,9 +161,7 @@ CXDGSystemBellManagerResource::CXDGSystemBellManagerResource(UP<CXdgSystemBellV1
     m_resource->setDestroy([this](CXdgSystemBellV1* r) { PROTO::xdgBell->destroyResource(this); });
     m_resource->setOnDestroy([this](CXdgSystemBellV1* r) { PROTO::xdgBell->destroyResource(this); });
 
-    m_resource->setRing([](CXdgSystemBellV1* r, wl_resource* surface) {
-        handleBell(surface);
-    });
+    m_resource->setRing([](CXdgSystemBellV1* r, wl_resource* surface) { handleBell(surface); });
 }
 
 bool CXDGSystemBellManagerResource::good() {
@@ -192,9 +173,7 @@ CXDGSystemBellProtocol::CXDGSystemBellProtocol(const wl_interface* iface, const 
 }
 
 void CXDGSystemBellProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = WP<CXDGSystemBellManagerResource>{
-        m_managers.emplace_back(makeUnique<CXDGSystemBellManagerResource>(makeUnique<CXdgSystemBellV1>(client, ver, id)))
-    };
+    const auto RESOURCE = WP<CXDGSystemBellManagerResource>{m_managers.emplace_back(makeUnique<CXDGSystemBellManagerResource>(makeUnique<CXdgSystemBellV1>(client, ver, id)))};
 
     if UNLIKELY (!RESOURCE->good()) {
         wl_client_post_no_memory(client);

--- a/src/protocols/XDGBell.cpp
+++ b/src/protocols/XDGBell.cpp
@@ -54,31 +54,30 @@ namespace {
         return parseBellSoundConfigValue(*PBELLSOUND);
     }
 
-    std::string getBellEventData(wl_resource* surface) {
+    PHLWINDOW getBellEventData(wl_resource* surface) {
         if (!surface)
-            return "";
+            return nullptr;
 
         const auto SURFACE = CWLSurfaceResource::fromResource(surface);
         if (!SURFACE)
-            return "";
+            return nullptr;
 
         for (const auto& w : Desktop::windowState()->windows()) {
             if (!w->m_isMapped || w->m_isX11 || !w->m_xdgSurface || !w->wlSurface())
                 continue;
 
             if (w->wlSurface()->resource() == SURFACE)
-                return std::format("{:x}", rc<uintptr_t>(w.get()));
+                return w;
         }
 
-        return "";
+        return nullptr;
     }
 
-    void emitBellEvent(const std::string& data) {
-        g_pEventManager->postEvent(SHyprIPCEvent{
-            .event = "bell",
-            .data  = data,
-        });
-        Event::bus()->m_events.bell.ring.emit();
+    void emitBellEvent(PHLWINDOW window) {
+        std::string address = window ? std::format("{:x}", rc<uintptr_t>(window.get())) : "";
+
+        g_pEventManager->postEvent(SHyprIPCEvent{.event = "bell", .data = address});
+        Event::bus()->m_events.window.bell.emit(window);
     }
 
     class CBellAudioContext {
@@ -158,10 +157,10 @@ CXDGSystemBellManagerResource::CXDGSystemBellManagerResource(UP<CXdgSystemBellV1
     if UNLIKELY (!good())
         return;
 
-    m_resource->setDestroy([this](CXdgSystemBellV1* r) { PROTO::xdgBell->destroyResource(this); });
-    m_resource->setOnDestroy([this](CXdgSystemBellV1* r) { PROTO::xdgBell->destroyResource(this); });
+    m_resource->setDestroy([this](CXdgSystemBellV1*) { PROTO::xdgBell->destroyResource(this); });
+    m_resource->setOnDestroy([this](CXdgSystemBellV1*) { PROTO::xdgBell->destroyResource(this); });
 
-    m_resource->setRing([](CXdgSystemBellV1* r, wl_resource* surface) { handleBell(surface); });
+    m_resource->setRing([](CXdgSystemBellV1*, wl_resource* surface) { handleBell(surface); });
 }
 
 bool CXDGSystemBellManagerResource::good() {

--- a/src/protocols/XDGBell.cpp
+++ b/src/protocols/XDGBell.cpp
@@ -2,6 +2,7 @@
 #include "core/Compositor.hpp"
 #include "../desktop/view/Window.hpp"
 #include "../ipc/s2/S2.hpp"
+#include "../event/EventBus.hpp"
 #include "../Compositor.hpp"
 
 #include "../config/ConfigManager.hpp"
@@ -77,6 +78,7 @@ namespace {
             .event = "bell",
             .data  = data,
         });
+        Event::bus()->m_events.bell.ring.emit();
     }
 
     class CBellAudioContext {

--- a/src/protocols/XDGBell.cpp
+++ b/src/protocols/XDGBell.cpp
@@ -1,157 +1,13 @@
 #include "XDGBell.hpp"
+#include "../helpers/BellSound.hpp"
 #include "core/Compositor.hpp"
+#include "../desktop/state/ViewState.hpp"
+#include "../desktop/state/ViewQuery.hpp"
 #include "../desktop/view/Window.hpp"
 #include "../ipc/s2/S2.hpp"
 #include "../event/EventBus.hpp"
-#include "../Compositor.hpp"
-
-#include "../config/ConfigManager.hpp"
-#include "../config/ConfigValue.hpp"
-#include "../helpers/MiscFunctions.hpp"
-#include "../debug/log/Logger.hpp"
-
-#include <canberra.h>
-
-#include <filesystem>
 #include <format>
 #include <string>
-
-namespace {
-    enum class eBellSoundMode : uint8_t {
-        DEFAULT,
-        NONE,
-        FILE,
-    };
-
-    struct SBellSoundConfig {
-        eBellSoundMode mode = eBellSoundMode::DEFAULT;
-        std::string    filePath;
-    };
-
-    SBellSoundConfig parseBellSoundConfigValue(const std::string& value) {
-        if (value.empty() || value == "default")
-            return {.mode = eBellSoundMode::DEFAULT};
-
-        if (value == "none")
-            return {.mode = eBellSoundMode::NONE};
-
-        const auto      resolvedPath = absolutePath(value, Config::mgr()->getMainConfigPath());
-
-        std::error_code ec;
-        if (!std::filesystem::exists(resolvedPath, ec) || ec || !std::filesystem::is_regular_file(resolvedPath, ec) || ec) {
-            Log::logger->log(Log::WARN, "bell: configured custom sound path '{}' is invalid, falling back to default bell sound", resolvedPath);
-            return {.mode = eBellSoundMode::DEFAULT};
-        }
-
-        return {
-            .mode     = eBellSoundMode::FILE,
-            .filePath = resolvedPath,
-        };
-    }
-
-    SBellSoundConfig getBellSoundConfig() {
-        static auto PBELLSOUND = CConfigValue<std::string>("misc:bell_sound");
-        return parseBellSoundConfigValue(*PBELLSOUND);
-    }
-
-    PHLWINDOW getBellEventData(wl_resource* surface) {
-        if (!surface)
-            return nullptr;
-
-        const auto SURFACE = CWLSurfaceResource::fromResource(surface);
-        if (!SURFACE)
-            return nullptr;
-
-        for (const auto& w : Desktop::windowState()->windows()) {
-            if (!w->m_isMapped || w->m_isX11 || !w->m_xdgSurface || !w->wlSurface())
-                continue;
-
-            if (w->wlSurface()->resource() == SURFACE)
-                return w;
-        }
-
-        return nullptr;
-    }
-
-    void emitBellEvent(PHLWINDOW window) {
-        std::string address = window ? std::format("{:x}", rc<uintptr_t>(window.get())) : "";
-
-        g_pEventManager->postEvent(SHyprIPCEvent{.event = "bell", .data = address});
-        Event::bus()->m_events.window.bell.emit(window);
-    }
-
-    class CBellAudioContext {
-      public:
-        ~CBellAudioContext() {
-            if (m_context)
-                ca_context_destroy(m_context);
-        }
-
-        ca_context* get() {
-            if (m_attemptedInit)
-                return m_context;
-
-            m_attemptedInit = true;
-
-            int result = ca_context_create(&m_context);
-            if (result < 0) {
-                Log::logger->log(Log::WARN, "bell: failed to create canberra context: {}", ca_strerror(result));
-                return nullptr;
-            }
-
-            result = ca_context_change_props(m_context, CA_PROP_APPLICATION_NAME, "Hyprland", CA_PROP_APPLICATION_ID, "org.hyprland.Hyprland", nullptr);
-
-            if (result < 0)
-                Log::logger->log(Log::WARN, "bell: failed to set canberra context properties: {}", ca_strerror(result));
-
-            result = ca_context_open(m_context);
-            if (result < 0) {
-                Log::logger->log(Log::WARN, "bell: failed to open canberra context: {}", ca_strerror(result));
-                ca_context_destroy(m_context);
-                m_context = nullptr;
-                return nullptr;
-            }
-
-            return m_context;
-        }
-
-      private:
-        bool        m_attemptedInit = false;
-        ca_context* m_context       = nullptr;
-    };
-
-    CBellAudioContext& getAudioContext() {
-        static CBellAudioContext context;
-        return context;
-    }
-
-    void playBellSound(const SBellSoundConfig& config) {
-        if (config.mode == eBellSoundMode::NONE)
-            return;
-
-        auto* const CONTEXT = getAudioContext().get();
-        if (!CONTEXT)
-            return;
-
-        int result = 0;
-
-        if (config.mode == eBellSoundMode::DEFAULT) {
-            result = ca_context_play(CONTEXT, 0, CA_PROP_EVENT_ID, "bell-window-system", CA_PROP_EVENT_DESCRIPTION, "Wayland system bell", nullptr);
-        } else {
-            result = ca_context_play(CONTEXT, 0, CA_PROP_MEDIA_FILENAME, config.filePath.c_str(), CA_PROP_EVENT_DESCRIPTION, "Wayland system bell", nullptr);
-        }
-
-        if (result < 0)
-            Log::logger->log(Log::WARN, "bell: failed to play sound: {}", ca_strerror(result));
-    }
-
-    void handleBell(wl_resource* surface) {
-        const auto bellData = getBellEventData(surface);
-
-        emitBellEvent(bellData);
-        playBellSound(getBellSoundConfig());
-    }
-}
 
 CXDGSystemBellManagerResource::CXDGSystemBellManagerResource(UP<CXdgSystemBellV1>&& resource) : m_resource(std::move(resource)) {
     if UNLIKELY (!good())
@@ -160,7 +16,15 @@ CXDGSystemBellManagerResource::CXDGSystemBellManagerResource(UP<CXdgSystemBellV1
     m_resource->setDestroy([this](CXdgSystemBellV1*) { PROTO::xdgBell->destroyResource(this); });
     m_resource->setOnDestroy([this](CXdgSystemBellV1*) { PROTO::xdgBell->destroyResource(this); });
 
-    m_resource->setRing([](CXdgSystemBellV1*, wl_resource* surface) { handleBell(surface); });
+    m_resource->setRing([](CXdgSystemBellV1*, wl_resource* surface) {
+        const auto WINDOW  = Desktop::viewState()->query().surface(CWLSurfaceResource::fromResource(surface)).type(Desktop::View::VIEW_TYPE_WINDOW).runWindow();
+        const auto ADDRESS = WINDOW ? std::format("{:x}", rc<uintptr_t>(WINDOW.get())) : "";
+
+        g_pEventManager->postEvent(SHyprIPCEvent{.event = "bell", .data = ADDRESS});
+        Event::bus()->m_events.window.bell.emit(WINDOW);
+
+        CBellSound::play();
+    });
 }
 
 bool CXDGSystemBellManagerResource::good() {

--- a/src/protocols/XDGBell.cpp
+++ b/src/protocols/XDGBell.cpp
@@ -3,11 +3,9 @@
 #include "core/Compositor.hpp"
 #include "../desktop/state/ViewState.hpp"
 #include "../desktop/state/ViewQuery.hpp"
-#include "../desktop/view/Window.hpp"
 #include "../ipc/s2/S2.hpp"
 #include "../event/EventBus.hpp"
 #include <format>
-#include <string>
 
 CXDGSystemBellManagerResource::CXDGSystemBellManagerResource(UP<CXdgSystemBellV1>&& resource) : m_resource(std::move(resource)) {
     if UNLIKELY (!good())
@@ -20,7 +18,7 @@ CXDGSystemBellManagerResource::CXDGSystemBellManagerResource(UP<CXdgSystemBellV1
         const auto WINDOW  = Desktop::viewState()->query().surface(CWLSurfaceResource::fromResource(surface)).type(Desktop::View::VIEW_TYPE_WINDOW).runWindow();
         const auto ADDRESS = WINDOW ? std::format("{:x}", rc<uintptr_t>(WINDOW.get())) : "";
 
-        g_pEventManager->postEvent(SHyprIPCEvent{.event = "bell", .data = ADDRESS});
+        IPC::Socket2::sock()->postEvent({.event = "bell", .data = ADDRESS});
         Event::bus()->m_events.window.bell.emit(WINDOW);
 
         CBellSound::play();

--- a/src/protocols/XDGBell.cpp
+++ b/src/protocols/XDGBell.cpp
@@ -4,6 +4,171 @@
 #include "../ipc/s2/S2.hpp"
 #include "../Compositor.hpp"
 
+#include "../config/ConfigManager.hpp"
+#include "../config/ConfigValue.hpp"
+#include "../helpers/MiscFunctions.hpp"
+#include "../debug/log/Logger.hpp"
+
+#include <canberra.h>
+
+#include <filesystem>
+#include <format>
+#include <string>
+
+namespace {
+    enum class eBellSoundMode : uint8_t {
+        DEFAULT,
+        NONE,
+        FILE,
+    };
+
+    struct SBellSoundConfig {
+        eBellSoundMode mode = eBellSoundMode::DEFAULT;
+        std::string    filePath;
+    };
+
+    SBellSoundConfig parseBellSoundConfigValue(const std::string& value) {
+        if (value.empty() || value == "default")
+            return {.mode = eBellSoundMode::DEFAULT};
+
+        if (value == "none")
+            return {.mode = eBellSoundMode::NONE};
+
+        const auto resolvedPath = absolutePath(value, Config::mgr()->getMainConfigPath());
+
+        std::error_code ec;
+        if (!std::filesystem::exists(resolvedPath, ec) || ec || !std::filesystem::is_regular_file(resolvedPath, ec) || ec) {
+            Log::logger->log(Log::WARN, "bell: configured custom sound path '{}' is invalid, falling back to default bell sound", resolvedPath);
+            return {.mode = eBellSoundMode::DEFAULT};
+        }
+
+        return {
+            .mode     = eBellSoundMode::FILE,
+            .filePath = resolvedPath,
+        };
+    }
+
+    SBellSoundConfig getBellSoundConfig() {
+        static auto PBELLSOUND = CConfigValue<std::string>("misc:bell_sound");
+        return parseBellSoundConfigValue(*PBELLSOUND);
+    }
+
+    std::string getBellEventData(wl_resource* surface) {
+        if (!surface)
+            return "";
+
+        const auto SURFACE = CWLSurfaceResource::fromResource(surface);
+        if (!SURFACE)
+            return "";
+
+        for (const auto& w : Desktop::windowState()->windows()) {
+            if (!w->m_isMapped || w->m_isX11 || !w->m_xdgSurface || !w->wlSurface())
+                continue;
+
+            if (w->wlSurface()->resource() == SURFACE)
+                return std::format("{:x}", rc<uintptr_t>(w.get()));
+        }
+
+        return "";
+    }
+
+    void emitBellEvent(const std::string& data) {
+        g_pEventManager->postEvent(SHyprIPCEvent{
+            .event = "bell",
+            .data  = data,
+        });
+    }
+
+    class CBellAudioContext {
+      public:
+        ~CBellAudioContext() {
+            if (m_context)
+                ca_context_destroy(m_context);
+        }
+
+        ca_context* get() {
+            if (m_attemptedInit)
+                return m_context;
+
+            m_attemptedInit = true;
+
+            int result = ca_context_create(&m_context);
+            if (result < 0) {
+                Log::logger->log(Log::WARN, "bell: failed to create canberra context: {}", ca_strerror(result));
+                return nullptr;
+            }
+
+            result = ca_context_change_props(
+                m_context,
+                CA_PROP_APPLICATION_NAME, "Hyprland",
+                CA_PROP_APPLICATION_ID, "org.hyprland.Hyprland",
+                nullptr
+            );
+
+            if (result < 0)
+                Log::logger->log(Log::WARN, "bell: failed to set canberra context properties: {}", ca_strerror(result));
+
+            result = ca_context_open(m_context);
+            if (result < 0) {
+                Log::logger->log(Log::WARN, "bell: failed to open canberra context: {}", ca_strerror(result));
+                ca_context_destroy(m_context);
+                m_context = nullptr;
+                return nullptr;
+            }
+
+            return m_context;
+        }
+
+      private:
+        bool        m_attemptedInit = false;
+        ca_context* m_context       = nullptr;
+    };
+
+    CBellAudioContext& getAudioContext() {
+        static CBellAudioContext context;
+        return context;
+    }
+
+    void playBellSound(const SBellSoundConfig& config) {
+        if (config.mode == eBellSoundMode::NONE)
+            return;
+
+        auto* const CONTEXT = getAudioContext().get();
+        if (!CONTEXT)
+            return;
+
+        int result = 0;
+
+        if (config.mode == eBellSoundMode::DEFAULT) {
+            result = ca_context_play(
+                CONTEXT,
+                0,
+                CA_PROP_EVENT_ID, "bell-window-system",
+                CA_PROP_EVENT_DESCRIPTION, "Wayland system bell",
+                nullptr
+            );
+        } else {
+            result = ca_context_play(
+                CONTEXT,
+                0,
+                CA_PROP_MEDIA_FILENAME, config.filePath.c_str(),
+                CA_PROP_EVENT_DESCRIPTION, "Wayland system bell",
+                nullptr
+            );
+        }
+
+        if (result < 0)
+            Log::logger->log(Log::WARN, "bell: failed to play sound: {}", ca_strerror(result));
+    }
+
+    void handleBell(wl_resource* surface) {
+        const auto bellData = getBellEventData(surface);
+
+        emitBellEvent(bellData);
+        playBellSound(getBellSoundConfig());
+    }
+}
+
 CXDGSystemBellManagerResource::CXDGSystemBellManagerResource(UP<CXdgSystemBellV1>&& resource) : m_resource(std::move(resource)) {
     if UNLIKELY (!good())
         return;
@@ -12,41 +177,7 @@ CXDGSystemBellManagerResource::CXDGSystemBellManagerResource(UP<CXdgSystemBellV1
     m_resource->setOnDestroy([this](CXdgSystemBellV1* r) { PROTO::xdgBell->destroyResource(this); });
 
     m_resource->setRing([](CXdgSystemBellV1* r, wl_resource* surface) {
-        if (!surface) {
-            IPC::Socket2::sock()->postEvent({
-                .event = "bell",
-                .data  = "",
-            });
-            return;
-        }
-
-        const auto SURFACE = CWLSurfaceResource::fromResource(surface);
-
-        if (!SURFACE) {
-            IPC::Socket2::sock()->postEvent({
-                .event = "bell",
-                .data  = "",
-            });
-            return;
-        }
-
-        for (const auto& w : Desktop::windowState()->windows()) {
-            if (!w->m_isMapped || w->m_isX11 || !w->m_xdgSurface || !w->wlSurface())
-                continue;
-
-            if (w->wlSurface()->resource() == SURFACE) {
-                IPC::Socket2::sock()->postEvent({
-                    .event = "bell",
-                    .data  = std::format("{:x}", rc<uintptr_t>(w.get())),
-                });
-                return;
-            }
-        }
-
-        IPC::Socket2::sock()->postEvent({
-            .event = "bell",
-            .data  = "",
-        });
+        handleBell(surface);
     });
 }
 
@@ -59,7 +190,9 @@ CXDGSystemBellProtocol::CXDGSystemBellProtocol(const wl_interface* iface, const 
 }
 
 void CXDGSystemBellProtocol::bindManager(wl_client* client, void* data, uint32_t ver, uint32_t id) {
-    const auto RESOURCE = WP<CXDGSystemBellManagerResource>{m_managers.emplace_back(makeUnique<CXDGSystemBellManagerResource>(makeUnique<CXdgSystemBellV1>(client, ver, id)))};
+    const auto RESOURCE = WP<CXDGSystemBellManagerResource>{
+        m_managers.emplace_back(makeUnique<CXDGSystemBellManagerResource>(makeUnique<CXdgSystemBellV1>(client, ver, id)))
+    };
 
     if UNLIKELY (!RESOURCE->good()) {
         wl_client_post_no_memory(client);

--- a/src/protocols/XDGBell.cpp
+++ b/src/protocols/XDGBell.cpp
@@ -1,10 +1,10 @@
 #include "XDGBell.hpp"
 #include "../helpers/BellSound.hpp"
-#include "core/Compositor.hpp"
+#include "./core/Compositor.hpp"
 #include "../desktop/state/ViewState.hpp"
 #include "../desktop/state/ViewQuery.hpp"
-#include "../ipc/s2/S2.hpp"
 #include "../event/EventBus.hpp"
+#include "../ipc/s2/S2.hpp"
 #include <format>
 
 CXDGSystemBellManagerResource::CXDGSystemBellManagerResource(UP<CXdgSystemBellV1>&& resource) : m_resource(std::move(resource)) {
@@ -15,12 +15,14 @@ CXDGSystemBellManagerResource::CXDGSystemBellManagerResource(UP<CXdgSystemBellV1
     m_resource->setOnDestroy([this](CXdgSystemBellV1*) { PROTO::xdgBell->destroyResource(this); });
 
     m_resource->setRing([](CXdgSystemBellV1*, wl_resource* surface) {
-        const auto WINDOW  = Desktop::viewState()->query().surface(CWLSurfaceResource::fromResource(surface)).type(Desktop::View::VIEW_TYPE_WINDOW).runWindow();
-        const auto ADDRESS = WINDOW ? std::format("{:x}", rc<uintptr_t>(WINDOW.get())) : "";
+        const auto           WINDOW = Desktop::viewState()->query().surface(CWLSurfaceResource::fromResource(surface)).type(Desktop::View::VIEW_TYPE_WINDOW).runWindow();
 
-        IPC::Socket2::sock()->postEvent({.event = "bell", .data = ADDRESS});
-        Event::bus()->m_events.window.bell.emit(WINDOW);
+        Event::SCallbackInfo info;
+        Event::bus()->m_events.window.bell.emit(WINDOW, info);
+        if (info.cancelled)
+            return;
 
+        IPC::Socket2::sock()->postEvent({.event = "bell", .data = WINDOW ? std::format("{:x}", rc<uintptr_t>(WINDOW.get())) : ""});
         CBellSound::play();
     });
 }


### PR DESCRIPTION
Rebased and updated version of #14036. Couldn't contribute to the original because the author is unavailable and abandoned the PR.

> ## Summary
> 
> This makes `xdg-system-bell-v1` produce a local sound by default while keeping the existing socket2 `bell` event behavior intact.
> 
> It adds a new `misc:bell_sound` config option with support for:
> 
> - `default`: play the themed system bell sound locally
> - `none`: stay silent locally but still emit the socket2 `bell` event
> - custom path: play a user-provided sound file
> 
> ## Changes
> 
> - add `misc:bell_sound` config registration
> - add config description/documentation
> - add lua event
> - keep emitting `bell` over socket2 as before
> - play the default bell locally via `libcanberra`
> - support custom sound file playback
> - add `libcanberra` to CMake, CI and Nix dependencies
> 
> ## Testing
> 
> Tested with a local debug build in a separate headless Hyprland instance using a small `xdg-system-bell-v1` test client.
> 
> Verified:
> 
> - `misc:bell_sound = "default"` emits `bell>>`, lua event and plays a sound
> - `misc:bell_sound = "none"` emits `bell>>`, lua event and stays silent
> - `misc:bell_sound = "bell/sound.ogg"` emits events and plays custom sound
> 
> ## Notes
> 
> - invalid custom sound paths currently fall back to the default bell sound
> - this change is intended to address #10488