### PR TITLE
fix(hyprctl): misaligned format args in JSON binds output

### DIFF
--- a/src/debug/HyprCtl.cpp
+++ b/src/debug/HyprCtl.cpp
@@ -1075,9 +1075,9 @@ static std::string bindsRequest(eHyprCtlOutputFormat format, std::string request
     "arg": "{}"
 }},)#",
                 kb->locked ? "true" : "false", kb->mouse ? "true" : "false", kb->release ? "true" : "false", kb->repeat ? "true" : "false", kb->longPress ? "true" : "false",
-                kb->nonConsuming ? "true" : "false", kb->autoConsuming ? "true" : "false", kb->allowInputCapture ? "true" : "false", kb->hasDescription ? "true" : "false",
+                kb->nonConsuming ? "true" : "false", kb->autoConsuming ? "true" : "false", kb->hasDescription ? "true" : "false",
                 kb->modmask, escapeJSONStrings(kb->submap.name), kb->submapUniversal, escapeJSONStrings(kb->key), kb->keycode, kb->catchAll ? "true" : "false",
-                escapeJSONStrings(kb->description), escapeJSONStrings(kb->handler), escapeJSONStrings(kb->arg));
+                escapeJSONStrings(kb->description), kb->allowInputCapture ? "true" : "false", escapeJSONStrings(kb->handler), escapeJSONStrings(kb->arg));
         }
         trimTrailingComma(ret);
         ret += "]";


### PR DESCRIPTION
#7919 added allow_input_capture to the format string at position 16 (after description) but inserted its argument at position 8 (after autoConsuming), shifting all subsequent args by one. This made keycode and allow_input_capture receive bare string values (kb->key and kb->description) without JSON quotes, producing unparseable JSON. jq fails with "Invalid numeric literal".

Found via Omarchy's keybinding viewer (SUPER+K) which silently received only 2 bindings due to jq parse failure.

Fixes: basecamp/omarchy#6328