### PR TITLE
sessionlock: suppress lockdead when client is still alive

### DIFF
--- a/src/managers/SessionLockManager.cpp
+++ b/src/managers/SessionLockManager.cpp
@@ -245,7 +245,11 @@ bool CSessionLockManager::shallConsiderLockMissing() {
     if (!m_sessionLock)
         return true;
 
-    static auto LOCKDEAD_SCREEN_DELAY = CConfigValue<Config::INTEGER>("misc:lockdead_screen_delay");
+    // Lock client is still connected — surfaces may be temporarily gone
+    // during DPMS output recreation, not a real crash. Don't show lockdead.
+    if (m_sessionLock->lock && m_sessionLock->lock->good())
+        return false;
 
+    static auto LOCKDEAD_SCREEN_DELAY = CConfigValue<Config::INTEGER>("misc:lockdead_screen_delay");
     return m_sessionLock->lockTimer.getMillis() > *LOCKDEAD_SCREEN_DELAY;
 }


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?
During DPMS output recreation when a monitor disconnects and reconnects or sleep mode disconnects the screen from the host, the lock client may briefly have zero surfaces even though the connection is healthy.  This guard prevents `shallConsiderLockMissing` from showing the lockdead screen when the lock is still good.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Others have fixed other DPMS issues, this should be a defense in-depth approach to help prevent the annoying lockdead screen when your system goes to sleep.

#### Is it ready for merging, or does it need work?
ready to merge.

