### PR TITLE
scrolling: fix in-band resize for the first window of a band

### DIFF
--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -912,8 +912,8 @@ void CScrollingAlgorithm::resizeTarget(const Vector2D& delta, SP<ITarget> target
             float nextSize = CURR_COLUMN->getTargetSize(NEXT_TD);
             float currSize = CURR_COLUMN->getTargetSize(CURR_TD);
 
-            if (!(nextSize <= MIN_ROW_HEIGHT && delta.y >= 0)) {
-                float adjust = std::clamp((float)(delta.y / USABLE.h), (-currSize + MIN_ROW_HEIGHT), (nextSize - MIN_ROW_HEIGHT));
+            if (!(nextSize <= MIN_ROW_HEIGHT && modDelta.y >= 0)) {
+                float adjust = std::clamp((float)(modDelta.y / USABLE.h), (-currSize + MIN_ROW_HEIGHT), (nextSize - MIN_ROW_HEIGHT));
 
                 CURR_COLUMN->setTargetSize(NEXT_TD, std::clamp(nextSize - adjust, MIN_ROW_HEIGHT, MAX_ROW_HEIGHT));
                 CURR_COLUMN->setTargetSize(CURR_TD, std::clamp(currSize + adjust, MIN_ROW_HEIGHT, MAX_ROW_HEIGHT));


### PR DESCRIPTION
On vertical scroller layouts, `resizeactive 100 0` had no effect on the first (leftmost) window on a row/band with 2 or more windows.

The edgeBottom branch read delta.y instead of the axis-swapped modDelta.y, so horizontal resizeactive deltas were ignored for the first window of a shared band on vertical scrollers.

modDelta.y is identical to delta.y on horizontal scrollers and never negated on this branch, so those are unaffected.

Tested in a nested instance, verified both scroll directions work correctly.