### PR TITLE
Lua: support workspace selectors in `hl.get_workspace()`

### DIFF
--- a/hyprtester/src/tests/main/workspaces.cpp
+++ b/hyprtester/src/tests/main/workspaces.cpp
@@ -985,3 +985,25 @@ TEST_CASE(workspaceRenameUpdatesRules) {
         ASSERT_CONTAINS(str, "at: 42,42");
     }
 }
+
+TEST_CASE(luaGetWorkspace) {
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 'name:test' })"));
+    {
+        auto str = getFromSocket("/activeworkspace");
+        ASSERT_CONTAINS(str, "workspace ID -1337 (test)");
+    }
+    Tests::spawnKitty();
+
+    ASSERT(getFromSocket("r/repl hl.get_workspace('name:test')"), "HL.Workspace(-1337:test)");
+    ASSERT(getFromSocket("r/repl hl.get_workspace('name:test') == hl.get_active_workspace()"), "true");
+
+    OK(getFromSocket("/dispatch hl.dsp.focus({ workspace = 1})"));
+    {
+        auto str = getFromSocket("/activeworkspace");
+        ASSERT_CONTAINS(str, "workspace ID 1 (1)");
+    }
+
+    ASSERT(getFromSocket("r/repl hl.get_workspace('e-1')"), "HL.Workspace(-1337:test)");
+    ASSERT(getFromSocket("r/repl hl.get_workspace('r+1')"), "nil");
+    ASSERT(getFromSocket("r/repl hl.get_workspace(42)"), "nil");
+}

--- a/src/config/lua/bindings/LuaBindingsInternal.cpp
+++ b/src/config/lua/bindings/LuaBindingsInternal.cpp
@@ -92,7 +92,7 @@ PHLWORKSPACE Internal::workspaceFromLuaSelectorOrObject(lua_State* L, int idx, c
     }
 
     if (lua_isstring(L, idx) || lua_isnumber(L, idx))
-        return State::workspaceState()->query().string(argStr(L, idx)).run();
+        return resolveWorkspaceStr(argStr(L, idx));
 
     Internal::configError(L, "{}: expected a workspace object or selector", fnName);
     return nullptr;

--- a/src/config/lua/bindings/LuaBindingsInternal.cpp
+++ b/src/config/lua/bindings/LuaBindingsInternal.cpp
@@ -91,8 +91,17 @@ PHLWORKSPACE Internal::workspaceFromLuaSelectorOrObject(lua_State* L, int idx, c
         return ws;
     }
 
-    if (lua_isstring(L, idx) || lua_isnumber(L, idx))
-        return resolveWorkspaceStr(argStr(L, idx));
+    if (lua_isstring(L, idx) || lua_isnumber(L, idx)) {
+        const auto id = getWorkspaceIDNameFromString(argStr(L, idx)).id;
+        if (id == WORKSPACE_INVALID)
+            return nullptr;
+
+        auto ws = State::workspaceState()->query().id(id).run();
+        if (!ws)
+            return nullptr;
+
+        return ws;
+    }
 
     Internal::configError(L, "{}: expected a workspace object or selector", fnName);
     return nullptr;


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

Rather than always treating string arguments to `hl.get_workspace()` as workspace names, this parses them as proper workspace selectors, so args like `e+1` work now. Names are still supported, but must be prefixed with `name:` as is standard for other spots where workspace selectors are used.

There's no wiki PR for this, because the wiki uh, *already* describes the argument as a "workspace selector" (which is what spawned this in the first place).

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
Nerp

#### Is it ready for merging, or does it need work?
Yerp