### PR TITLE
layout/drag: add binds:drag_center_window

### DIFF
--- a/hyprtester/src/tests/main/drag.cpp
+++ b/hyprtester/src/tests/main/drag.cpp
@@ -1,0 +1,189 @@
+#include <cmath>
+#include <format>
+#include <string>
+#include <utility>
+
+#include "../../shared.hpp"
+#include "../../hyprctlCompat.hpp"
+#include "../shared.hpp"
+#include "tests.hpp"
+
+/// Parses an "X,Y" attribute (as returned by getAttribute for "at" and "size")
+/// into a pair of ints. Returns {0, 0} on a malformed value.
+static std::pair<int, int> parseXY(const std::string& value) {
+    const auto COMMA = value.find(',');
+    if (COMMA == std::string::npos)
+        return {0, 0};
+
+    try {
+        return {std::stoi(value.substr(0, COMMA)), std::stoi(value.substr(COMMA + 1))};
+    } catch (...) { return {0, 0}; }
+}
+
+/// Window geometry is subject to rounding, gaps and borders, so positions are
+/// compared with a small tolerance.
+static bool nearly(int a, int b, int tolerance = 4) {
+    return std::abs(a - b) <= tolerance;
+}
+
+static std::pair<int, int> activeWindowAt() {
+    return parseXY(Tests::getAttribute(getFromSocket("/activewindow"), "at"));
+}
+
+static std::pair<int, int> activeWindowSize() {
+    return parseXY(Tests::getAttribute(getFromSocket("/activewindow"), "size"));
+}
+
+/// Tests that dragging a tiled window with binds:drag_center_window enabled
+/// centers the window on the cursor once it becomes floating.
+TEST_CASE(dragTiledCentered) {
+    OK(getFromSocket("/eval hl.config({ binds = { drag_center_window = true } })"));
+    OK(getFromSocket("r/eval hl.unbind('SUPER + mouse:272')"));
+    OK(getFromSocket("r/eval hl.bind('mouse:272', hl.dsp.window.drag(), { mouse = true })"));
+
+    Tests::spawnKitty();
+    ASSERT(Tests::windowCount(), 1);
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:kitty' })"));
+
+    // grab well away from the center, so centering is observable
+    const auto [AT_X, AT_Y]     = activeWindowAt();
+    const auto [SIZE_X, SIZE_Y] = activeWindowSize();
+    const int GRAB_X            = AT_X + (SIZE_X * 3) / 4;
+    const int GRAB_Y            = AT_Y + (SIZE_Y * 3) / 4;
+
+    OK(getFromSocket(std::format("/dispatch hl.dsp.cursor.move({{ x = {}, y = {} }})", GRAB_X, GRAB_Y)));
+    OK(getFromSocket("/eval hl.plugin.test.click(272, 1)"));
+    OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 700, y = 500 })"));
+
+    {
+        // the grab point is ignored, the floating window is centered on the cursor
+        const auto [NEW_X, NEW_Y]           = activeWindowAt();
+        const auto [NEW_SIZE_X, NEW_SIZE_Y] = activeWindowSize();
+
+        EXPECT(nearly(NEW_X + NEW_SIZE_X / 2, 700), true);
+        EXPECT(nearly(NEW_Y + NEW_SIZE_Y / 2, 500), true);
+    }
+
+    OK(getFromSocket("/eval hl.plugin.test.click(272, 0)"));
+    OK(getFromSocket("/reload"));
+    Tests::killAllWindows();
+}
+
+/// Tests that dragging a tiled window with binds:drag_center_window disabled maps
+/// the grab point proportionally onto the smaller floating window, instead of
+/// centering it.
+TEST_CASE(dragTiledProportional) {
+    OK(getFromSocket("/eval hl.config({ binds = { drag_center_window = false } })"));
+    OK(getFromSocket("r/eval hl.unbind('SUPER + mouse:272')"));
+    OK(getFromSocket("r/eval hl.bind('mouse:272', hl.dsp.window.drag(), { mouse = true })"));
+
+    Tests::spawnKitty();
+    ASSERT(Tests::windowCount(), 1);
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:kitty' })"));
+
+    // grab three quarters across and down the tiled window
+    const auto [AT_X, AT_Y]     = activeWindowAt();
+    const auto [SIZE_X, SIZE_Y] = activeWindowSize();
+    const int GRAB_X            = AT_X + (SIZE_X * 3) / 4;
+    const int GRAB_Y            = AT_Y + (SIZE_Y * 3) / 4;
+
+    OK(getFromSocket(std::format("/dispatch hl.dsp.cursor.move({{ x = {}, y = {} }})", GRAB_X, GRAB_Y)));
+    OK(getFromSocket("/eval hl.plugin.test.click(272, 1)"));
+    OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 700, y = 500 })"));
+
+    {
+        // the window shrinks as it becomes floating, but the cursor should still
+        // sit three quarters across and down
+        const auto [NEW_X, NEW_Y]           = activeWindowAt();
+        const auto [NEW_SIZE_X, NEW_SIZE_Y] = activeWindowSize();
+
+        EXPECT(nearly(NEW_X + (NEW_SIZE_X * 3) / 4, 700), true);
+        EXPECT(nearly(NEW_Y + (NEW_SIZE_Y * 3) / 4, 500), true);
+    }
+
+    OK(getFromSocket("/eval hl.plugin.test.click(272, 0)"));
+    OK(getFromSocket("/reload"));
+    Tests::killAllWindows();
+}
+
+/// Tests that dragging a fullscreen window with binds:drag_center_window enabled
+/// centers it on the cursor once it is restored to its floating size.
+TEST_CASE(dragFullscreenCentered) {
+    OK(getFromSocket("/eval hl.config({ binds = { drag_center_window = true } })"));
+    OK(getFromSocket("r/eval hl.unbind('SUPER + mouse:272')"));
+    OK(getFromSocket("r/eval hl.bind('mouse:272', hl.dsp.window.drag(), { mouse = true })"));
+
+    Tests::spawnKitty();
+    ASSERT(Tests::windowCount(), 1);
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:kitty' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'set' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.resize({ x = 600, y = 400, window = 'class:kitty' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ x = 100, y = 100, window = 'class:kitty' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'fullscreen', action = 'set' })"));
+
+    // grab well away from the center, so centering is observable
+    const auto [AT_X, AT_Y]     = activeWindowAt();
+    const auto [SIZE_X, SIZE_Y] = activeWindowSize();
+    const int GRAB_X            = AT_X + (SIZE_X * 3) / 4;
+    const int GRAB_Y            = AT_Y + (SIZE_Y * 3) / 4;
+
+    OK(getFromSocket(std::format("/dispatch hl.dsp.cursor.move({{ x = {}, y = {} }})", GRAB_X, GRAB_Y)));
+    OK(getFromSocket("/eval hl.plugin.test.click(272, 1)"));
+    OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 700, y = 500 })"));
+
+    {
+        // the grab point is ignored, the restored window is centered on the cursor
+        const auto [NEW_X, NEW_Y]           = activeWindowAt();
+        const auto [NEW_SIZE_X, NEW_SIZE_Y] = activeWindowSize();
+
+        EXPECT_CONTAINS(getFromSocket("/activewindow"), "fullscreen: 0");
+        EXPECT(nearly(NEW_X + NEW_SIZE_X / 2, 700), true);
+        EXPECT(nearly(NEW_Y + NEW_SIZE_Y / 2, 500), true);
+    }
+
+    OK(getFromSocket("/eval hl.plugin.test.click(272, 0)"));
+    OK(getFromSocket("/reload"));
+    Tests::killAllWindows();
+}
+
+/// Tests that dragging a fullscreen window with binds:drag_center_window disabled
+/// maps the grab point proportionally onto the restored floating window.
+TEST_CASE(dragFullscreenProportional) {
+    OK(getFromSocket("/eval hl.config({ binds = { drag_center_window = false } })"));
+    OK(getFromSocket("r/eval hl.unbind('SUPER + mouse:272')"));
+    OK(getFromSocket("r/eval hl.bind('mouse:272', hl.dsp.window.drag(), { mouse = true })"));
+
+    Tests::spawnKitty();
+    ASSERT(Tests::windowCount(), 1);
+    OK(getFromSocket("/dispatch hl.dsp.focus({ window = 'class:kitty' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'set' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.resize({ x = 600, y = 400, window = 'class:kitty' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.move({ x = 100, y = 100, window = 'class:kitty' })"));
+    OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'fullscreen', action = 'set' })"));
+
+    // grab three quarters across and down the fullscreen surface, far away from
+    // where the restored floating window would otherwise end up
+    const auto [AT_X, AT_Y]     = activeWindowAt();
+    const auto [SIZE_X, SIZE_Y] = activeWindowSize();
+    const int GRAB_X            = AT_X + (SIZE_X * 3) / 4;
+    const int GRAB_Y            = AT_Y + (SIZE_Y * 3) / 4;
+
+    OK(getFromSocket(std::format("/dispatch hl.dsp.cursor.move({{ x = {}, y = {} }})", GRAB_X, GRAB_Y)));
+    OK(getFromSocket("/eval hl.plugin.test.click(272, 1)"));
+    OK(getFromSocket("/dispatch hl.dsp.cursor.move({ x = 700, y = 500 })"));
+
+    {
+        // the window shrinks back to its floating size, but the cursor should still
+        // sit three quarters across and down
+        const auto [NEW_X, NEW_Y]           = activeWindowAt();
+        const auto [NEW_SIZE_X, NEW_SIZE_Y] = activeWindowSize();
+
+        EXPECT_CONTAINS(getFromSocket("/activewindow"), "fullscreen: 0");
+        EXPECT(nearly(NEW_X + (NEW_SIZE_X * 3) / 4, 700, 8), true);
+        EXPECT(nearly(NEW_Y + (NEW_SIZE_Y * 3) / 4, 500, 8), true);
+    }
+
+    OK(getFromSocket("/eval hl.plugin.test.click(272, 0)"));
+    OK(getFromSocket("/reload"));
+    Tests::killAllWindows();
+}

--- a/src/config/values/ConfigValues.cpp
+++ b/src/config/values/ConfigValues.cpp
@@ -539,6 +539,7 @@ std::vector<SP<IValue>> Values::getConfigValues() {
         MS<Bool>("binds:allow_pin_fullscreen", "Allows fullscreen to pinned windows, and restore their pinned status afterwards", false),
         MS<Int>("binds:drag_threshold", "Movement threshold in pixels for window dragging and c/g bind flags. 0 to disable.", 0,
                 {.min = 0, .max = std::numeric_limits<int>::max()}),
+        MS<Bool>("binds:drag_center_window", "If enabled, dragging a tiled or fullscreen window will center it on the cursor when it becomes floating.", true),
 
         /*
          * xwayland:
@@ -721,7 +722,7 @@ std::vector<SP<IValue>> Values::getConfigValues() {
         MS<Bool>("experimental:wp_cm_1_2", "Allow wp-cm-v1 version 2", true),
 
         /*
-		 * input_capture: 
+		 * input_capture:
 		 */
         MS<Bool>("input-capture:capture_modifiers", "If enabled, modifiers are also captured and sent to the program", false),
         MS<Bool>("input-capture:enforce_barriers", "If enabled, throw a wayland error when a invalid barrier is received", true),

--- a/src/layout/supplementary/DragController.cpp
+++ b/src/layout/supplementary/DragController.cpp
@@ -80,8 +80,9 @@ bool CDragStateController::exclusiveDeviceGrab() const {
 }
 
 bool CDragStateController::updateDragWindow() {
-    const auto DRAGGINGTARGET = m_target.lock();
-    const bool WAS_FULLSCREEN = DRAGGINGTARGET->window() ? Fullscreen::controller()->isFullscreen(DRAGGINGTARGET->window()) : false;
+    const auto  DRAGGINGTARGET = m_target.lock();
+    const bool  WAS_FULLSCREEN = DRAGGINGTARGET->window() ? Fullscreen::controller()->isFullscreen(DRAGGINGTARGET->window()) : false;
+    static auto PDRAGCENTER    = CConfigValue<Config::BOOL>("binds:drag_center_window");
 
     if (m_dragThresholdReached) {
         if (WAS_FULLSCREEN) {
@@ -103,14 +104,17 @@ bool CDragStateController::updateDragWindow() {
     m_draggingWindowOriginalFloatSize = DRAGGINGTARGET->lastFloatingSize();
 
     if (WAS_FULLSCREEN && DRAGGINGTARGET->floating() && m_dragThresholdReached) {
-        const auto MOUSECOORDS = g_pInputManager->getMouseCoordsInternal();
-        DRAGGINGTARGET->setPositionGlobal(CBox{MOUSECOORDS - DRAGGINGTARGET->position().size() / 2.F, DRAGGINGTARGET->position().size()});
+        if (*PDRAGCENTER) {
+            const auto MOUSECOORDS = g_pInputManager->getMouseCoordsInternal();
+            DRAGGINGTARGET->setPositionGlobal(CBox{MOUSECOORDS - DRAGGINGTARGET->position().size() / 2.F, DRAGGINGTARGET->position().size()});
+        }
     } else if (!DRAGGINGTARGET->floating() && m_dragMode == MBIND_MOVE) {
         Vector2D MINSIZE = DRAGGINGTARGET->minSize().value_or(Vector2D{MIN_WINDOW_SIZE, MIN_WINDOW_SIZE});
         DRAGGINGTARGET->rememberFloatingSize((DRAGGINGTARGET->position().size() * 0.8489).clamp(MINSIZE, Vector2D{}).floor());
 
         if (m_dragThresholdReached) {
-            DRAGGINGTARGET->setPositionGlobal(CBox{g_pInputManager->getMouseCoordsInternal() - DRAGGINGTARGET->position().size() / 2.F, DRAGGINGTARGET->position().size()});
+            if (*PDRAGCENTER)
+                DRAGGINGTARGET->setPositionGlobal(CBox{g_pInputManager->getMouseCoordsInternal() - DRAGGINGTARGET->position().size() / 2.F, DRAGGINGTARGET->position().size()});
             g_layoutManager->changeFloatingMode(DRAGGINGTARGET);
             m_draggingTiled = true;
         }

--- a/src/layout/supplementary/DragController.cpp
+++ b/src/layout/supplementary/DragController.cpp
@@ -84,6 +84,28 @@ bool CDragStateController::updateDragWindow() {
     const bool  WAS_FULLSCREEN = DRAGGINGTARGET->window() ? Fullscreen::controller()->isFullscreen(DRAGGINGTARGET->window()) : false;
     static auto PDRAGCENTER    = CConfigValue<Config::BOOL>("binds:drag_center_window");
 
+    // geometry before we un-fullscreen / untile, needed to map the grab point onto the new window
+    const CBox PRE_DRAG_BOX = DRAGGINGTARGET->position();
+
+    // places the window under the cursor after its geometry changed. Without drag_center_window, the
+    // grab point keeps its relative position: grabbing 80% across the fullscreen surface leaves the
+    // cursor 80% across the restored window
+    const auto MAPDRAGHOTSPOT = [this](const SP<ITarget>& target, const CBox& oldBox) {
+        const auto MOUSECOORDS = g_pInputManager->getMouseCoordsInternal();
+        const auto NEWSIZE     = target->position().size();
+        const auto OLDSIZE     = oldBox.size();
+
+        if (*PDRAGCENTER)
+            m_dragHotspot = NEWSIZE / 2.F;
+        else {
+            const Vector2D REL = {OLDSIZE.x > 0 ? (MOUSECOORDS.x - oldBox.pos().x) / OLDSIZE.x : 0.5, OLDSIZE.y > 0 ? (MOUSECOORDS.y - oldBox.pos().y) / OLDSIZE.y : 0.5};
+
+            m_dragHotspot = REL.clamp(Vector2D{0.F, 0.F}, Vector2D{1.F, 1.F}) * NEWSIZE;
+        }
+
+        target->setPositionGlobal(CBox{MOUSECOORDS - m_dragHotspot, NEWSIZE});
+    };
+
     if (m_dragThresholdReached) {
         if (WAS_FULLSCREEN) {
             Log::logger->log(Log::DEBUG, "Dragging a fullscreen window");
@@ -104,19 +126,16 @@ bool CDragStateController::updateDragWindow() {
     m_draggingWindowOriginalFloatSize = DRAGGINGTARGET->lastFloatingSize();
 
     if (WAS_FULLSCREEN && DRAGGINGTARGET->floating() && m_dragThresholdReached) {
-        if (*PDRAGCENTER) {
-            const auto MOUSECOORDS = g_pInputManager->getMouseCoordsInternal();
-            DRAGGINGTARGET->setPositionGlobal(CBox{MOUSECOORDS - DRAGGINGTARGET->position().size() / 2.F, DRAGGINGTARGET->position().size()});
-        }
+        MAPDRAGHOTSPOT(DRAGGINGTARGET, PRE_DRAG_BOX);
     } else if (!DRAGGINGTARGET->floating() && m_dragMode == MBIND_MOVE) {
         Vector2D MINSIZE = DRAGGINGTARGET->minSize().value_or(Vector2D{MIN_WINDOW_SIZE, MIN_WINDOW_SIZE});
         DRAGGINGTARGET->rememberFloatingSize((DRAGGINGTARGET->position().size() * 0.8489).clamp(MINSIZE, Vector2D{}).floor());
 
         if (m_dragThresholdReached) {
-            if (*PDRAGCENTER)
-                DRAGGINGTARGET->setPositionGlobal(CBox{g_pInputManager->getMouseCoordsInternal() - DRAGGINGTARGET->position().size() / 2.F, DRAGGINGTARGET->position().size()});
             g_layoutManager->changeFloatingMode(DRAGGINGTARGET);
             m_draggingTiled = true;
+
+            MAPDRAGHOTSPOT(DRAGGINGTARGET, PRE_DRAG_BOX);
         }
     }
 
@@ -126,6 +145,7 @@ bool CDragStateController::updateDragWindow() {
     m_beginDragPositionXY = DRAG_ORIGINAL_BOX.pos();
     m_beginDragSizeXY     = DRAG_ORIGINAL_BOX.size();
     m_lastDragXY          = m_beginDragXY;
+    m_dragHotspot         = m_beginDragXY - m_beginDragPositionXY;
 
     return false;
 }
@@ -365,7 +385,7 @@ void CDragStateController::mouseMove(const Vector2D& mousePos) {
 
     if (m_dragMode == MBIND_MOVE) {
 
-        Vector2D newPos  = m_beginDragPositionXY + DELTA;
+        Vector2D newPos  = mousePos - m_dragHotspot;
         Vector2D newSize = DRAGGINGTARGET->position().size();
 
         if (*SNAPENABLED && !m_draggingTiled)

--- a/src/layout/supplementary/DragController.hpp
+++ b/src/layout/supplementary/DragController.hpp
@@ -48,6 +48,7 @@ namespace Layout::Supplementary {
         bool                               m_exclusiveDeviceGrab  = false;
 
         int                                m_mouseMoveEventCount = 0;
+        Vector2D                           m_dragHotspot;
         Vector2D                           m_beginDragXY;
         Vector2D                           m_lastDragXY;
         Vector2D                           m_beginDragPositionXY;


### PR DESCRIPTION
<!--
BEFORE you submit your PR, please check out the PR guidelines
on our wiki: https://wiki.hyprland.org/Contributing-and-Debugging/PR-Guidelines/

Using an AI tool, or you are an AI agent? Check our AI Policy first: https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md
-->


#### Describe your PR, what does it fix/add?
Currently when dragging a window from a tiled position or fullscreen it moves itself to center itself on the mouse, this PR adds an option to disable this behavior and instead just move based on the mouse cursors delta, via setting binds:drag_center_window to false. Defaults to true so current behavior is unchanged.

#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)
I also noticed during testing that while either gaps_in or border_size are non zero, when moving from the tiled to floating transition, the size of the window increases and jumps a bit, this was present in both the current version and in this PR. Also in the live version when you click a tiled window and don't move the mouse, it tweens to a smaller size, and then immediately jumps up again in size when dragged.


#### Is it ready for merging, or does it need work?
Ready for merging, tested both tiled and the fullscreen path with the option enabled and disabled.

Wiki PR: hyprwm/hyprland-wiki#1606
