### PR TITLE
workspace: parse numeric IDs as WORKSPACEID

### DIFF
--- a/src/helpers/MiscFunctions.cpp
+++ b/src/helpers/MiscFunctions.cpp
@@ -30,6 +30,7 @@
 #include <hyprutils/string/VarList.hpp>
 #include <hyprutils/os/Process.hpp>
 #include "../version.h"
+#include <charconv>
 
 using namespace Hyprutils::String;
 using namespace Hyprutils::OS;
@@ -457,9 +458,16 @@ SWorkspaceIDName getWorkspaceIDNameFromString(const std::string& in) {
                     Log::logger->log(Log::ERR, "Relative workspace on no mon!");
                     return {WORKSPACE_INVALID};
                 }
-            } else if (isNumber(in))
-                result.id = std::max(std::stoi(in), 1);
-            else {
+            } else if (isNumber(in)) {
+                WORKSPACEID workspaceID = 0;
+
+                const auto [ptr, ec] = std::from_chars(in.data(), in.data() + in.size(), workspaceID);
+
+                if (ec != std::errc{} || ptr != in.data() + in.size())
+                    return {WORKSPACE_INVALID};
+
+                result.id = std::max<WORKSPACEID>(workspaceID, 1);
+            } else {
                 // maybe name
                 const auto PWORKSPACE = State::workspaceState()->query().name(in).run();
                 if (PWORKSPACE)


### PR DESCRIPTION

## Description

Parse direct numeric workspace IDs as `WORKSPACEID` instead of `int`.

This raises the maximum direct numeric workspace ID from `INT_MAX` to
`INT64_MAX`, matching the existing `WORKSPACEID` type.

Values outside the `WORKSPACEID` range are rejected without throwing an
exception.

## Testing

- Built successfully with `make debug`
- All 269 tests passed