### PR TITLE
core/fullscreen: Set pos/size of all group members to the same value when FSing groups, misc. optimisations

### DIFF
--- a/hyprtester/src/tests/main/dwindle.cpp
+++ b/hyprtester/src/tests/main/dwindle.cpp
@@ -450,7 +450,7 @@ TEST_CASE(dwindleTestFsingGroupedWindows) {
         OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'fullscreen', action = 'unset', layout_aware = false })"));
     }
 
-    // Maximized - TODO - fix pos and size
+    // Maximized
     {
         auto checkHiddenGroupMember = [&](const std::string& targetKitten) {
             auto clients  = getFromSocket("/clients");

--- a/hyprtester/src/tests/main/dwindle.cpp
+++ b/hyprtester/src/tests/main/dwindle.cpp
@@ -2,6 +2,7 @@
 #include "../../shared.hpp"
 #include "../../hyprctlCompat.hpp"
 #include "tests.hpp"
+#include <string_view>
 
 TEST_CASE(dwindleFloatClamp) {
     for (auto const& win : {"a", "b", "c"}) {
@@ -339,6 +340,184 @@ TEST_CASE(dwindleFullscreenMaximiseDispatchers) {
         auto str = getFromSocket("/activewindow");
         EXPECT_CONTAINS(str, "fullscreen: 2");
         EXPECT_CONTAINS(str, "fullscreenClient: 2");
+    }
+}
+
+TEST_CASE(dwindleTestFsingGroupedWindows) {
+
+    // Shared test among all default handled FS
+
+    /*
+      When a group of windows are FSed, all the windows in the group are expected to have the same size
+    */
+
+    OK(getFromSocket("/eval hl.config({ general = { layout = 'dwindle' } })"));
+
+    OK(getFromSocket("/eval hl.config({ group = { auto_group = true } })"));
+
+    // Config opt for adding gaps_out and border_size and a workspace rule that removes theo from maximised windows to make sure maximise works properly
+
+    OK(getFromSocket("r/eval hl.config({ general = { gaps_out = 10, border_size = 10 } })"));
+    OK(getFromSocket("/eval hl.workspace_rule({ workspace = 'f[1]', gaps_out = 0, border_size = 0 })"));
+
+    ASSERT(Tests::windowCount(), 0);
+    auto kitten1 = Tests::spawnKitty("kitten1");
+    if (!kitten1) {
+        FAIL_TEST("Could not spawn kitty");
+    }
+    OK(getFromSocket("/dispatch hl.dsp.group.toggle()"));
+
+    auto kitten2 = Tests::spawnKitty("kitten2");
+    if (!kitten2) {
+        FAIL_TEST("Could not spawn kitty");
+    }
+    ASSERT(Tests::windowCount(), 2);
+
+    // Fullscreen
+    {
+        auto checkHiddenGroupMember = [&](const std::string& targetKitten) {
+            auto clients  = getFromSocket("/clients");
+            auto classPos = clients.find("class: " + targetKitten);
+            if (classPos == std::string::npos) {
+                FAIL_TEST("Could not find specific kitten in clients output");
+            } else {
+                auto entryStart  = clients.rfind("Window ", classPos);
+                auto entryEnd    = clients.find("\n\n", classPos);
+                auto windowEntry = clients.substr(entryStart, entryEnd - entryStart);
+                EXPECT_CONTAINS(windowEntry, "size: 1920,1080");
+                EXPECT_CONTAINS(windowEntry, "at: 0,0");
+            }
+        };
+
+        // Tiled
+        OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'fullscreen', action = 'set', layout_aware = false })"));
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten2");
+            EXPECT_CONTAINS(str, "at: 0,0");
+            EXPECT_CONTAINS(str, "size: 1920,1080");
+        }
+        checkHiddenGroupMember("kitten1");
+
+        // try switching to next window in group
+        OK(getFromSocket("/dispatch hl.dsp.group.next()"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten1");
+            EXPECT_CONTAINS(str, "at: 0,0");
+            EXPECT_CONTAINS(str, "size: 1920,1080");
+        }
+        checkHiddenGroupMember("kitten2");
+
+        // go back for next test
+        OK(getFromSocket("/dispatch hl.dsp.group.prev()"));
+        // unset FS for next test
+        OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'fullscreen', action = 'unset', layout_aware = false })"));
+
+        // floating
+        OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'set' })"));
+        OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'fullscreen', action = 'set', layout_aware = false })"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten2");
+            EXPECT_CONTAINS(str, "at: 0,0");
+            EXPECT_CONTAINS(str, "size: 1920,1080");
+        }
+        checkHiddenGroupMember("kitten1");
+
+        // try switching to next window in group
+        OK(getFromSocket("/dispatch hl.dsp.group.next()"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten1");
+            EXPECT_CONTAINS(str, "at: 0,0");
+            EXPECT_CONTAINS(str, "size: 1920,1080");
+        }
+        checkHiddenGroupMember("kitten2");
+
+        // go back for next test
+        OK(getFromSocket("/dispatch hl.dsp.group.prev()"));
+
+        // prep for next test
+        OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'unset' })"));
+        OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'fullscreen', action = 'unset', layout_aware = false })"));
+    }
+
+    // Maximized - TODO - fix pos and size
+    {
+        auto checkHiddenGroupMember = [&](const std::string& targetKitten) {
+            auto clients  = getFromSocket("/clients");
+            auto classPos = clients.find("class: " + targetKitten);
+            if (classPos == std::string::npos) {
+                FAIL_TEST("Could not find specific kitten in clients output");
+            } else {
+                auto entryStart  = clients.rfind("Window ", classPos);
+                auto entryEnd    = clients.find("\n\n", classPos);
+                auto windowEntry = clients.substr(entryStart, entryEnd - entryStart);
+                EXPECT_CONTAINS(windowEntry, "size: 1920,1059");
+                EXPECT_CONTAINS(windowEntry, "at: 0,21");
+            }
+        };
+
+        // Tiled
+        OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'maximized', action = 'set', layout_aware = false })"));
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten2");
+            EXPECT_CONTAINS(str, "at: 0,21");
+            EXPECT_CONTAINS(str, "size: 1920,1059");
+        }
+        checkHiddenGroupMember("kitten1");
+
+        // try switching to next window in group
+        OK(getFromSocket("/dispatch hl.dsp.group.next()"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten1");
+            EXPECT_CONTAINS(str, "at: 0,21");
+            EXPECT_CONTAINS(str, "size: 1920,1059");
+        }
+        checkHiddenGroupMember("kitten2");
+
+        // go back for next test
+        OK(getFromSocket("/dispatch hl.dsp.group.prev()"));
+        // unset FS for next test
+        OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'maximized', action = 'unset', layout_aware = false })"));
+
+        // floating
+        OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'set' })"));
+        OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'maximized', action = 'set', layout_aware = false })"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten2");
+            EXPECT_CONTAINS(str, "at: 0,21");
+            EXPECT_CONTAINS(str, "size: 1920,1059");
+        }
+        checkHiddenGroupMember("kitten1");
+
+        // try switching to next window in group
+        OK(getFromSocket("/dispatch hl.dsp.group.next()"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten1");
+            EXPECT_CONTAINS(str, "at: 0,21");
+            EXPECT_CONTAINS(str, "size: 1920,1059");
+        }
+        checkHiddenGroupMember("kitten2");
     }
 }
 

--- a/hyprtester/src/tests/main/dwindle.cpp
+++ b/hyprtester/src/tests/main/dwindle.cpp
@@ -355,7 +355,7 @@ TEST_CASE(dwindleTestFsingGroupedWindows) {
 
     OK(getFromSocket("/eval hl.config({ group = { auto_group = true } })"));
 
-    // Config opt for adding gaps_out and border_size and a workspace rule that removes theo from maximised windows to make sure maximise works properly
+    // Config opt for adding gaps_out and border_size and a workspace rule that removes them from maximised windows to make sure maximise works properly
 
     OK(getFromSocket("r/eval hl.config({ general = { gaps_out = 10, border_size = 10 } })"));
     OK(getFromSocket("/eval hl.workspace_rule({ workspace = 'f[1]', gaps_out = 0, border_size = 0 })"));

--- a/hyprtester/src/tests/main/dwindle.cpp
+++ b/hyprtester/src/tests/main/dwindle.cpp
@@ -2,7 +2,6 @@
 #include "../../shared.hpp"
 #include "../../hyprctlCompat.hpp"
 #include "tests.hpp"
-#include <string_view>
 
 TEST_CASE(dwindleFloatClamp) {
     for (auto const& win : {"a", "b", "c"}) {

--- a/hyprtester/src/tests/main/scroll.cpp
+++ b/hyprtester/src/tests/main/scroll.cpp
@@ -360,7 +360,7 @@ TEST_CASE(scroll_LAYOUT_HANDLED_TestFsingGroupedWindows) {
     OK(getFromSocket("/eval hl.config({ scrolling = { follow_focus = false } })"));
     OK(getFromSocket("/eval hl.config({ scrolling = { wrap_swapcol = false } })"));
 
-    // Config opt for adding gaps_out and border_size and a workspace rule that removes theo from maximised windows to make sure maximise works properly
+    // Config opt for adding gaps_out and border_size and a workspace rule that removes them from maximised windows to make sure maximise works properly
 
     OK(getFromSocket("r/eval hl.config({ general = { gaps_out = 10, border_size = 10 } })"));
     OK(getFromSocket("/eval hl.workspace_rule({ workspace = 'f[1]', gaps_out = 0, border_size = 0 })"));
@@ -1657,7 +1657,7 @@ TEST_CASE(scroll_DEFAULT_HANDLED_TestFsingGroupedWindows) {
 
     OK(getFromSocket("/eval hl.config({ group = { auto_group = true } })"));
 
-    // Config opt for adding gaps_out and border_size and a workspace rule that removes theo from maximised windows to make sure maximise works properly
+    // Config opt for adding gaps_out and border_size and a workspace rule that removes them from maximised windows to make sure maximise works properly
 
     OK(getFromSocket("r/eval hl.config({ general = { gaps_out = 10, border_size = 10 } })"));
     OK(getFromSocket("/eval hl.workspace_rule({ workspace = 'f[1]', gaps_out = 0, border_size = 0 })"));

--- a/hyprtester/src/tests/main/scroll.cpp
+++ b/hyprtester/src/tests/main/scroll.cpp
@@ -344,6 +344,323 @@ TEST_CASE(scroll_LAYOUT_HANDLED_maximized) {
     }
 }
 
+TEST_CASE(scroll_LAYOUT_HANDLED_TestFsingGroupedWindows) {
+
+    /*
+      When a group of windows are FSed, all the windows in the group are expected to have the same size
+
+      In scrolling's layout FS handling, this is expected to hold true even when we scroll away from the window
+
+    */
+
+    OK(getFromSocket("/eval hl.config({ general = { layout = 'scrolling' } })"));
+
+    OK(getFromSocket("/eval hl.config({ group = { auto_group = true } })"));
+
+    OK(getFromSocket("/eval hl.config({ scrolling = { follow_focus = false } })"));
+    OK(getFromSocket("/eval hl.config({ scrolling = { wrap_swapcol = false } })"));
+
+    // Config opt for adding gaps_out and border_size and a workspace rule that removes theo from maximised windows to make sure maximise works properly
+
+    OK(getFromSocket("r/eval hl.config({ general = { gaps_out = 10, border_size = 10 } })"));
+    OK(getFromSocket("/eval hl.workspace_rule({ workspace = 'f[1]', gaps_out = 0, border_size = 0 })"));
+
+    // 2 grouped windows, 1 ungrouped window
+    ASSERT(Tests::windowCount(), 0);
+    auto kitten1 = Tests::spawnKitty("kitten1");
+    if (!kitten1) {
+        FAIL_TEST("Could not spawn kitty");
+    }
+    OK(getFromSocket("/dispatch hl.dsp.group.toggle()"));
+
+    auto kitten2 = Tests::spawnKitty("kitten2");
+    if (!kitten2) {
+        FAIL_TEST("Could not spawn kitty");
+    }
+
+    OK(getFromSocket("/eval hl.config({ group = { auto_group = false } })"));
+
+    auto kitten3 = Tests::spawnKitty("kitten3");
+    if (!kitten3) {
+        FAIL_TEST("Could not spawn kitty");
+    }
+
+    ASSERT(Tests::windowCount(), 3);
+    OK(getFromSocket("/dispatch hl.dsp.focus({window = 'class:kitten2'})"));
+
+    // Fullscreen
+    {
+        auto checkHiddenGroupMember = [&](const std::string& targetKitten) {
+            auto clients  = getFromSocket("/clients");
+            auto classPos = clients.find("class: " + targetKitten);
+            if (classPos == std::string::npos) {
+                FAIL_TEST("Could not find specific kitten in clients output");
+            } else {
+                auto entryStart  = clients.rfind("Window ", classPos);
+                auto entryEnd    = clients.find("\n\n", classPos);
+                auto windowEntry = clients.substr(entryStart, entryEnd - entryStart);
+                EXPECT_CONTAINS(windowEntry, "size: 1920,1080");
+                EXPECT_CONTAINS(windowEntry, "at: 0,0");
+            }
+        };
+
+        auto checkHiddenGroupMember_notCovering = [&](const std::string& targetKitten) {
+            auto clients  = getFromSocket("/clients");
+            auto classPos = clients.find("class: " + targetKitten);
+            if (classPos == std::string::npos) {
+                FAIL_TEST("Could not find specific kitten in clients output");
+            } else {
+                auto entryStart  = clients.rfind("Window ", classPos);
+                auto entryEnd    = clients.find("\n\n", classPos);
+                auto windowEntry = clients.substr(entryStart, entryEnd - entryStart);
+                EXPECT_CONTAINS(windowEntry, "at: -960,0");
+                // fullscreen windows are MONBOX sized so they disregard borders and gaps_out even when not covering
+                EXPECT_CONTAINS(windowEntry, "size: 1920,1080");
+                EXPECT_CONTAINS(windowEntry, "fullscreen: 2");
+            }
+        };
+
+        // Tiled
+        OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'fullscreen', action = 'set', layout_aware = true })"));
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten2");
+            EXPECT_CONTAINS(str, "at: 0,0");
+            EXPECT_CONTAINS(str, "size: 1920,1080");
+        }
+        checkHiddenGroupMember("kitten1");
+
+        // try switching to next window in group
+        OK(getFromSocket("/dispatch hl.dsp.group.next()"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten1");
+            EXPECT_CONTAINS(str, "at: 0,0");
+            EXPECT_CONTAINS(str, "size: 1920,1080");
+        }
+        checkHiddenGroupMember("kitten2");
+
+        // go back for next test
+        OK(getFromSocket("/dispatch hl.dsp.group.prev()"));
+
+        // Try scrolling away
+        OK(getFromSocket("/dispatch hl.dsp.layout('focus r')"));
+
+        // not scrolling onto it because follow_focus = false
+        OK(getFromSocket("/dispatch hl.dsp.focus({window = 'class:kitten2'})"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten2");
+            EXPECT_CONTAINS(str, "at: -960,0");
+            EXPECT_CONTAINS(str, "size: 1920,1080");
+        }
+        checkHiddenGroupMember_notCovering("kitten1");
+
+        // atm the viewport moves if you switch to next window in group, this it to compensate
+        OK(getFromSocket("/dispatch hl.dsp.layout('inhibit_scroll 1')"));
+        // try switching to next window in group when you have scrolled away
+        OK(getFromSocket("/dispatch hl.dsp.group.next()"));
+        OK(getFromSocket("/dispatch hl.dsp.layout('inhibit_scroll 0')"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten1");
+            EXPECT_CONTAINS(str, "at: -960,0");
+            EXPECT_CONTAINS(str, "size: 1920,1080");
+        }
+        checkHiddenGroupMember_notCovering("kitten2");
+
+        // go back for next test
+        OK(getFromSocket("/dispatch hl.dsp.group.prev()"));
+        // re-establish  covering status of FS group for the next test
+        OK(getFromSocket("/eval hl.config({ scrolling = { follow_focus = true } })"));
+        OK(getFromSocket("/dispatch hl.dsp.focus({window = 'class:kitten2'})"));
+        OK(getFromSocket("/eval hl.config({ scrolling = { follow_focus = false } })"));
+        // unset FS for next test
+        OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'fullscreen', action = 'unset', layout_aware = true })"));
+
+        // floating
+        OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'set' })"));
+        OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'fullscreen', action = 'set', layout_aware = true })"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten2");
+            EXPECT_CONTAINS(str, "at: 0,0");
+            EXPECT_CONTAINS(str, "size: 1920,1080");
+        }
+        checkHiddenGroupMember("kitten1");
+
+        // try switching to next window in group
+        OK(getFromSocket("/dispatch hl.dsp.group.next()"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten1");
+            EXPECT_CONTAINS(str, "at: 0,0");
+            EXPECT_CONTAINS(str, "size: 1920,1080");
+        }
+        checkHiddenGroupMember("kitten2");
+
+        // go back for next test
+        OK(getFromSocket("/dispatch hl.dsp.group.prev()"));
+
+        // prep for next test
+        OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'unset' })"));
+        OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'fullscreen', action = 'unset', layout_aware = true })"));
+        // The window may have been dropped from floating to tiling in the wrong place. make sure it is the leftmost
+        OK(getFromSocket("/dispatch hl.dsp.focus({window = 'class:kitten2'})"));
+        OK(getFromSocket("/dispatch hl.dsp.layout('swapcol l')"));
+    }
+
+    // Maximized
+    {
+        auto checkHiddenGroupMember_tiled = [&](const std::string& targetKitten) {
+            auto clients  = getFromSocket("/clients");
+            auto classPos = clients.find("class: " + targetKitten);
+            if (classPos == std::string::npos) {
+                FAIL_TEST("Could not find specific kitten in clients output");
+            } else {
+                auto entryStart  = clients.rfind("Window ", classPos);
+                auto entryEnd    = clients.find("\n\n", classPos);
+                auto windowEntry = clients.substr(entryStart, entryEnd - entryStart);
+                EXPECT_CONTAINS(windowEntry, "size: 1915,1059");
+                EXPECT_CONTAINS(windowEntry, "at: 0,21");
+            }
+        };
+
+        auto checkHiddenGroupMember_floating = [&](const std::string& targetKitten) {
+            auto clients  = getFromSocket("/clients");
+            auto classPos = clients.find("class: " + targetKitten);
+            if (classPos == std::string::npos) {
+                FAIL_TEST("Could not find specific kitten in clients output");
+            } else {
+                auto entryStart  = clients.rfind("Window ", classPos);
+                auto entryEnd    = clients.find("\n\n", classPos);
+                auto windowEntry = clients.substr(entryStart, entryEnd - entryStart);
+                EXPECT_CONTAINS(windowEntry, "size: 1920,1059");
+                EXPECT_CONTAINS(windowEntry, "at: 0,21");
+            }
+        };
+
+        auto checkHiddenGroupMember_notCovering = [&](const std::string& targetKitten) {
+            auto clients  = getFromSocket("/clients");
+            auto classPos = clients.find("class: " + targetKitten);
+            if (classPos == std::string::npos) {
+                FAIL_TEST("Could not find specific kitten in clients output");
+            } else {
+                auto entryStart  = clients.rfind("Window ", classPos);
+                auto entryEnd    = clients.find("\n\n", classPos);
+                auto windowEntry = clients.substr(entryStart, entryEnd - entryStart);
+                EXPECT_CONTAINS(windowEntry, "at: -940,41");
+                // cuz the gaps and borders workspace rule now applies as it is no longer covering
+                EXPECT_CONTAINS(windowEntry, "size: 1875,1019");
+                EXPECT_CONTAINS(windowEntry, "fullscreen: 1");
+            }
+        };
+
+        // Tiled
+        OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'maximized', action = 'set', layout_aware = true })"));
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten2");
+            EXPECT_CONTAINS(str, "at: 0,21");
+            EXPECT_CONTAINS(str, "size: 1915,1059");
+        }
+        checkHiddenGroupMember_tiled("kitten1");
+
+        // try switching to next window in group
+        OK(getFromSocket("/dispatch hl.dsp.group.next()"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten1");
+            EXPECT_CONTAINS(str, "at: 0,21");
+            EXPECT_CONTAINS(str, "size: 1915,1059");
+        }
+        checkHiddenGroupMember_tiled("kitten2");
+
+        // go back for next test
+        OK(getFromSocket("/dispatch hl.dsp.group.prev()"));
+
+        // Try scrolling away
+        OK(getFromSocket("/dispatch hl.dsp.layout('focus r')"));
+
+        // not scrolling onto it because follow_focus = false
+        OK(getFromSocket("/dispatch hl.dsp.focus({window = 'class:kitten2'})"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten2");
+            EXPECT_CONTAINS(str, "at: -940,41");
+            EXPECT_CONTAINS(str, "size: 1875,1019");
+            EXPECT_CONTAINS(str, "fullscreen: 1");
+        }
+        checkHiddenGroupMember_notCovering("kitten1");
+
+        // atm the viewport moves if you switch to next window in group, this it to compensate
+        OK(getFromSocket("/dispatch hl.dsp.layout('inhibit_scroll 1')"));
+        // try switching to next window in group when you have scrolled away
+        OK(getFromSocket("/dispatch hl.dsp.group.next()"));
+        OK(getFromSocket("/dispatch hl.dsp.layout('inhibit_scroll 0')"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten1");
+            EXPECT_CONTAINS(str, "at: -940,41");
+            EXPECT_CONTAINS(str, "size: 1875,1019");
+            EXPECT_CONTAINS(str, "fullscreen: 1");
+        }
+        checkHiddenGroupMember_notCovering("kitten2");
+
+        // go back for next test
+        OK(getFromSocket("/dispatch hl.dsp.group.prev()"));
+        // re-establish  covering status of FS group for the next test
+        OK(getFromSocket("/eval hl.config({ scrolling = { follow_focus = true } })"));
+        OK(getFromSocket("/dispatch hl.dsp.focus({window = 'class:kitten2'})"));
+        OK(getFromSocket("/eval hl.config({ scrolling = { follow_focus = false } })"));
+        // unset FS for next test
+        OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'maximized', action = 'unset', layout_aware = true })"));
+
+        // floating
+        OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'set' })"));
+        OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'maximized', action = 'set', layout_aware = true })"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten2");
+            EXPECT_CONTAINS(str, "at: 0,21");
+            EXPECT_CONTAINS(str, "size: 1920,1059");
+        }
+        checkHiddenGroupMember_floating("kitten1");
+
+        // try switching to next window in group
+        OK(getFromSocket("/dispatch hl.dsp.group.next()"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten1");
+            EXPECT_CONTAINS(str, "at: 0,21");
+            EXPECT_CONTAINS(str, "size: 1920,1059");
+        }
+        checkHiddenGroupMember_floating("kitten2");
+    }
+}
+
 TEST_CASE(scroll_LAYOUT_HANDLED_fullscreenRetainsGeometryWhileScrolling) {
     OK(getFromSocket("/eval hl.config({ general = { layout = 'scrolling' } })"));
 
@@ -1073,7 +1390,7 @@ TEST_CASE(scroll_LAYOUT_HANDLED_focusInDirectionFocusFollowFocusTrue) {
     // if on_focus_under_fullscreen = 0 focus({direction}) is disallowed from moving focus from FS window
     // if on_focus_under_fullscreen = 1/2, standard behaviour of the config option won't be followed but focus will move in the firection specified as if window was not FS
 
-    OK(getFromSocket("r/eval hl.config({ general = { layout = 'scrolling' } })"));
+    OK(getFromSocket("/eval hl.config({ general = { layout = 'scrolling' } })"));
 
     /*
             This test serves as a test for all layouts that use deafult FS behaviour
@@ -1328,16 +1645,14 @@ TEST_CASE(scroll_DEFAULT_HANDLED_fullscreenMaximiseDispatchers) {
     }
 }
 
-
 TEST_CASE(scroll_DEFAULT_HANDLED_TestFsingGroupedWindows) {
 
     // Shared test among all default handled FS
-    
+
     /*
       When a group of windows are FSed, all the windows in the group are expected to have the same size
     */
-    
-    
+
     OK(getFromSocket("/eval hl.config({ general = { layout = 'scrolling' } })"));
 
     OK(getFromSocket("/eval hl.config({ group = { auto_group = true } })"));
@@ -1409,7 +1724,7 @@ TEST_CASE(scroll_DEFAULT_HANDLED_TestFsingGroupedWindows) {
         OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'fullscreen', action = 'set', layout_aware = false })"));
 
         {
-            // check position and size for the focused group member (kitten2).
+            // check position and size for the focused group member.
             auto str = getFromSocket("/activewindow");
             EXPECT_CONTAINS(str, "class: kitten2");
             EXPECT_CONTAINS(str, "at: 0,0");
@@ -1421,7 +1736,7 @@ TEST_CASE(scroll_DEFAULT_HANDLED_TestFsingGroupedWindows) {
         OK(getFromSocket("/dispatch hl.dsp.group.next()"));
 
         {
-            // check position and size for the focused group member (kitten2).
+            // check position and size for the focused group member.
             auto str = getFromSocket("/activewindow");
             EXPECT_CONTAINS(str, "class: kitten1");
             EXPECT_CONTAINS(str, "at: 0,0");
@@ -1437,7 +1752,7 @@ TEST_CASE(scroll_DEFAULT_HANDLED_TestFsingGroupedWindows) {
         OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'fullscreen', action = 'unset', layout_aware = false })"));
     }
 
-    // Maximized - TODO - fix pos and size
+    // Maximized
     {
         auto checkHiddenGroupMember = [&](const std::string& targetKitten) {
             auto clients  = getFromSocket("/clients");
@@ -1468,7 +1783,7 @@ TEST_CASE(scroll_DEFAULT_HANDLED_TestFsingGroupedWindows) {
         OK(getFromSocket("/dispatch hl.dsp.group.next()"));
 
         {
-            // check position and size for the focused group member (kitten2).
+            // check position and size for the focused group member.
             auto str = getFromSocket("/activewindow");
             EXPECT_CONTAINS(str, "class: kitten1");
             EXPECT_CONTAINS(str, "at: 0,21");
@@ -1498,7 +1813,7 @@ TEST_CASE(scroll_DEFAULT_HANDLED_TestFsingGroupedWindows) {
         OK(getFromSocket("/dispatch hl.dsp.group.next()"));
 
         {
-            // check position and size for the focused group member (kitten2).
+            // check position and size for the focused group member (kitten1).
             auto str = getFromSocket("/activewindow");
             EXPECT_CONTAINS(str, "class: kitten1");
             EXPECT_CONTAINS(str, "at: 0,21");

--- a/hyprtester/src/tests/main/scroll.cpp
+++ b/hyprtester/src/tests/main/scroll.cpp
@@ -416,7 +416,7 @@ TEST_CASE(scroll_LAYOUT_HANDLED_TestFsingGroupedWindows) {
                 EXPECT_CONTAINS(windowEntry, "at: -960,0");
                 // fullscreen windows are MONBOX sized so they disregard borders and gaps_out even when not covering
                 EXPECT_CONTAINS(windowEntry, "size: 1920,1080");
-                EXPECT_CONTAINS(windowEntry, "fullscreen: 2");
+                EXPECT_CONTAINS(windowEntry, "fullscreen: 0");
             }
         };
 
@@ -563,7 +563,7 @@ TEST_CASE(scroll_LAYOUT_HANDLED_TestFsingGroupedWindows) {
                 EXPECT_CONTAINS(windowEntry, "at: -940,41");
                 // cuz the gaps and borders workspace rule now applies as it is no longer covering
                 EXPECT_CONTAINS(windowEntry, "size: 1875,1019");
-                EXPECT_CONTAINS(windowEntry, "fullscreen: 1");
+                EXPECT_CONTAINS(windowEntry, "fullscreen: 0");
             }
         };
 

--- a/hyprtester/src/tests/main/scroll.cpp
+++ b/hyprtester/src/tests/main/scroll.cpp
@@ -1328,6 +1328,186 @@ TEST_CASE(scroll_DEFAULT_HANDLED_fullscreenMaximiseDispatchers) {
     }
 }
 
+
+TEST_CASE(scroll_DEFAULT_HANDLED_TestFsingGroupedWindows) {
+
+    // Shared test among all default handled FS
+    
+    /*
+      When a group of windows are FSed, all the windows in the group are expected to have the same size
+    */
+    
+    
+    OK(getFromSocket("/eval hl.config({ general = { layout = 'scrolling' } })"));
+
+    OK(getFromSocket("/eval hl.config({ group = { auto_group = true } })"));
+
+    // Config opt for adding gaps_out and border_size and a workspace rule that removes theo from maximised windows to make sure maximise works properly
+
+    OK(getFromSocket("r/eval hl.config({ general = { gaps_out = 10, border_size = 10 } })"));
+    OK(getFromSocket("/eval hl.workspace_rule({ workspace = 'f[1]', gaps_out = 0, border_size = 0 })"));
+
+    ASSERT(Tests::windowCount(), 0);
+    auto kitten1 = Tests::spawnKitty("kitten1");
+    if (!kitten1) {
+        FAIL_TEST("Could not spawn kitty");
+    }
+    OK(getFromSocket("/dispatch hl.dsp.group.toggle()"));
+
+    auto kitten2 = Tests::spawnKitty("kitten2");
+    if (!kitten2) {
+        FAIL_TEST("Could not spawn kitty");
+    }
+    ASSERT(Tests::windowCount(), 2);
+
+    // Fullscreen
+    {
+        auto checkHiddenGroupMember = [&](const std::string& targetKitten) {
+            auto clients  = getFromSocket("/clients");
+            auto classPos = clients.find("class: " + targetKitten);
+            if (classPos == std::string::npos) {
+                FAIL_TEST("Could not find specific kitten in clients output");
+            } else {
+                auto entryStart  = clients.rfind("Window ", classPos);
+                auto entryEnd    = clients.find("\n\n", classPos);
+                auto windowEntry = clients.substr(entryStart, entryEnd - entryStart);
+                EXPECT_CONTAINS(windowEntry, "size: 1920,1080");
+                EXPECT_CONTAINS(windowEntry, "at: 0,0");
+            }
+        };
+
+        // Tiled
+        OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'fullscreen', action = 'set', layout_aware = false })"));
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten2");
+            EXPECT_CONTAINS(str, "at: 0,0");
+            EXPECT_CONTAINS(str, "size: 1920,1080");
+        }
+        checkHiddenGroupMember("kitten1");
+
+        // try switching to next window in group
+        OK(getFromSocket("/dispatch hl.dsp.group.next()"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten1");
+            EXPECT_CONTAINS(str, "at: 0,0");
+            EXPECT_CONTAINS(str, "size: 1920,1080");
+        }
+        checkHiddenGroupMember("kitten2");
+
+        // go back for next test
+        OK(getFromSocket("/dispatch hl.dsp.group.prev()"));
+        // unset FS for next test
+        OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'fullscreen', action = 'unset', layout_aware = false })"));
+
+        // floating
+        OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'set' })"));
+        OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'fullscreen', action = 'set', layout_aware = false })"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten2");
+            EXPECT_CONTAINS(str, "at: 0,0");
+            EXPECT_CONTAINS(str, "size: 1920,1080");
+        }
+        checkHiddenGroupMember("kitten1");
+
+        // try switching to next window in group
+        OK(getFromSocket("/dispatch hl.dsp.group.next()"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten1");
+            EXPECT_CONTAINS(str, "at: 0,0");
+            EXPECT_CONTAINS(str, "size: 1920,1080");
+        }
+        checkHiddenGroupMember("kitten2");
+
+        // go back for next test
+        OK(getFromSocket("/dispatch hl.dsp.group.prev()"));
+
+        // prep for next test
+        OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'unset' })"));
+        OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'fullscreen', action = 'unset', layout_aware = false })"));
+    }
+
+    // Maximized - TODO - fix pos and size
+    {
+        auto checkHiddenGroupMember = [&](const std::string& targetKitten) {
+            auto clients  = getFromSocket("/clients");
+            auto classPos = clients.find("class: " + targetKitten);
+            if (classPos == std::string::npos) {
+                FAIL_TEST("Could not find specific kitten in clients output");
+            } else {
+                auto entryStart  = clients.rfind("Window ", classPos);
+                auto entryEnd    = clients.find("\n\n", classPos);
+                auto windowEntry = clients.substr(entryStart, entryEnd - entryStart);
+                EXPECT_CONTAINS(windowEntry, "size: 1920,1059");
+                EXPECT_CONTAINS(windowEntry, "at: 0,21");
+            }
+        };
+
+        // Tiled
+        OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'maximized', action = 'set', layout_aware = false })"));
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten2");
+            EXPECT_CONTAINS(str, "at: 0,21");
+            EXPECT_CONTAINS(str, "size: 1920,1059");
+        }
+        checkHiddenGroupMember("kitten1");
+
+        // try switching to next window in group
+        OK(getFromSocket("/dispatch hl.dsp.group.next()"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten1");
+            EXPECT_CONTAINS(str, "at: 0,21");
+            EXPECT_CONTAINS(str, "size: 1920,1059");
+        }
+        checkHiddenGroupMember("kitten2");
+
+        // go back for next test
+        OK(getFromSocket("/dispatch hl.dsp.group.prev()"));
+        // unset FS for next test
+        OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'maximized', action = 'unset', layout_aware = false })"));
+
+        // floating
+        OK(getFromSocket("/dispatch hl.dsp.window.float({ action = 'set' })"));
+        OK(getFromSocket("/dispatch hl.dsp.window.fullscreen({ mode = 'maximized', action = 'set', layout_aware = false })"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten2");
+            EXPECT_CONTAINS(str, "at: 0,21");
+            EXPECT_CONTAINS(str, "size: 1920,1059");
+        }
+        checkHiddenGroupMember("kitten1");
+
+        // try switching to next window in group
+        OK(getFromSocket("/dispatch hl.dsp.group.next()"));
+
+        {
+            // check position and size for the focused group member (kitten2).
+            auto str = getFromSocket("/activewindow");
+            EXPECT_CONTAINS(str, "class: kitten1");
+            EXPECT_CONTAINS(str, "at: 0,21");
+            EXPECT_CONTAINS(str, "size: 1920,1059");
+        }
+        checkHiddenGroupMember("kitten2");
+    }
+}
+
 TEST_CASE(scroll_DEFAULT_HANDLED_testFsFocusUnderFSWindow) {
 
     // Shared test among all default handled FS

--- a/src/desktop/rule/windowRule/WindowRule.cpp
+++ b/src/desktop/rule/windowRule/WindowRule.cpp
@@ -11,7 +11,6 @@
 #include "desktop/rule/windowRule/WindowRuleEffectContainer.hpp"
 #include "../../../layout/target/Target.hpp"
 
-
 #include <hyprutils/string/Numeric.hpp>
 #include <hyprutils/string/String.hpp>
 #include <hyprutils/string/VarList.hpp>

--- a/src/desktop/rule/windowRule/WindowRule.cpp
+++ b/src/desktop/rule/windowRule/WindowRule.cpp
@@ -9,6 +9,8 @@
 #include "../../../protocols/types/ContentType.hpp"
 #include "../../../config/shared/parserUtils/ParserUtils.hpp"
 #include "desktop/rule/windowRule/WindowRuleEffectContainer.hpp"
+#include "../../../layout/target/Target.hpp"
+
 
 #include <hyprutils/string/Numeric.hpp>
 #include <hyprutils/string/String.hpp>
@@ -414,7 +416,8 @@ bool CWindowRule::matches(PHLWINDOW w, bool allowEnvLookup) {
                     return false;
                 break;
             case RULE_PROP_FULLSCREEN:
-                if (!engine->match(Fullscreen::controller()->isFullscreen(w)))
+                // FS states of a group are owned by the current window of the group
+                if (!engine->match(Fullscreen::controller()->isFullscreen(w->layoutTarget()->window())))
                     return false;
                 break;
             case RULE_PROP_PINNED:
@@ -434,11 +437,13 @@ bool CWindowRule::matches(PHLWINDOW w, bool allowEnvLookup) {
                     return false;
                 break;
             case RULE_PROP_FULLSCREENSTATE_INTERNAL:
-                if (!engine->match(Fullscreen::controller()->getFullscreenModes(w).internal))
+                // FS states of a group are owned by the current window of the group
+                if (!engine->match(Fullscreen::controller()->getFullscreenModes(w->layoutTarget()->window()).internal))
                     return false;
                 break;
             case RULE_PROP_FULLSCREENSTATE_CLIENT:
-                if (!engine->match(Fullscreen::controller()->getFullscreenModes(w).client))
+                // FS states of a group are owned by the current window of the group
+                if (!engine->match(Fullscreen::controller()->getFullscreenModes(w->layoutTarget()->window()).client))
                     return false;
                 break;
             case RULE_PROP_ON_WORKSPACE:

--- a/src/desktop/rule/windowRule/WindowRule.cpp
+++ b/src/desktop/rule/windowRule/WindowRule.cpp
@@ -8,9 +8,7 @@
 #include "../../../desktop/state/FocusState.hpp"
 #include "../../../protocols/types/ContentType.hpp"
 #include "../../../config/shared/parserUtils/ParserUtils.hpp"
-#include "../../../desktop/rule/windowRule/WindowRuleEffectContainer.hpp"
 #include "../../../desktop/view/Group.hpp"
-#include "../../../layout/target/Target.hpp"
 
 #include <hyprutils/string/Numeric.hpp>
 #include <hyprutils/string/String.hpp>

--- a/src/desktop/rule/windowRule/WindowRule.cpp
+++ b/src/desktop/rule/windowRule/WindowRule.cpp
@@ -8,7 +8,8 @@
 #include "../../../desktop/state/FocusState.hpp"
 #include "../../../protocols/types/ContentType.hpp"
 #include "../../../config/shared/parserUtils/ParserUtils.hpp"
-#include "desktop/rule/windowRule/WindowRuleEffectContainer.hpp"
+#include "../../../desktop/rule/windowRule/WindowRuleEffectContainer.hpp"
+#include "../../../desktop/view/Group.hpp"
 #include "../../../layout/target/Target.hpp"
 
 #include <hyprutils/string/Numeric.hpp>
@@ -416,7 +417,7 @@ bool CWindowRule::matches(PHLWINDOW w, bool allowEnvLookup) {
                 break;
             case RULE_PROP_FULLSCREEN:
                 // FS states of a group are owned by the current window of the group
-                if (!engine->match(Fullscreen::controller()->isFullscreen(w->layoutTarget()->window())))
+                if (!engine->match(Fullscreen::controller()->isFullscreen(w->m_group ? w->m_group->current() : w)))
                     return false;
                 break;
             case RULE_PROP_PINNED:
@@ -437,12 +438,12 @@ bool CWindowRule::matches(PHLWINDOW w, bool allowEnvLookup) {
                 break;
             case RULE_PROP_FULLSCREENSTATE_INTERNAL:
                 // FS states of a group are owned by the current window of the group
-                if (!engine->match(Fullscreen::controller()->getFullscreenModes(w->layoutTarget()->window()).internal))
+                if (!engine->match(Fullscreen::controller()->getFullscreenModes(w->m_group ? w->m_group->current() : w).internal))
                     return false;
                 break;
             case RULE_PROP_FULLSCREENSTATE_CLIENT:
                 // FS states of a group are owned by the current window of the group
-                if (!engine->match(Fullscreen::controller()->getFullscreenModes(w->layoutTarget()->window()).client))
+                if (!engine->match(Fullscreen::controller()->getFullscreenModes(w->m_group ? w->m_group->current() : w).client))
                     return false;
                 break;
             case RULE_PROP_ON_WORKSPACE:

--- a/src/desktop/view/Group.cpp
+++ b/src/desktop/view/Group.cpp
@@ -258,7 +258,6 @@ void CGroup::setCurrent(size_t idx) {
     if (IS_FULLSCREEN) {
         Fullscreen::controller()->setFullscreenMode(newWindow, FS_MODE_INTERNAL, std::nullopt, IS_LAYOUT_HANDLED);
         newWindow->m_target->warpPositionSize();
-        oldWindow->m_target->setPositionGlobal(newWindow->m_target->position()); // TODO: this is a hack and sucks
     }
 
     if (WASFOCUS)

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -20,7 +20,6 @@
 
 #include "../../../../managers/fullscreen/FullscreenController.hpp"
 #include "../../../../layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.hpp"
-#include "layout/target/Target.hpp"
 
 #include <hyprutils/string/VarList2.hpp>
 #include <hyprutils/string/VarList.hpp>

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -551,11 +551,7 @@ void SScrollingData::recalculate(bool forceInstant) {
                 if (targetIsCoveringFullscreen)
                     Fullscreen::controller()->m_windowPosSettingQueued = true;
                 // must set pos of the highest level target (i.e. if target a part of a group, must set that group's pos which will set the pos of all member targets)
-                TDATA->target->setPositionGlobal(targetBoxWithGaps(TDATA->layoutBox, i, j, COL_HAS_FS_TARGET && TARGET_FS_MODE == Fullscreen::FSMODE_FULLSCREEN),
-                                                 TARGET_FS_MODE != Fullscreen::FSMODE_NONE ?
-                                                     (TARGET_FS_MODE == Fullscreen::FSMODE_FULLSCREEN ? (TARGET_UPDATE_LAYOUT_HANDLED_FS | TARGET_UPDATE_FULLSCREEN) :
-                                                                                                        (TARGET_UPDATE_LAYOUT_HANDLED_FS | TARGET_UPDATE_MAXIMISED)) :
-                                                     TARGET_UPDATE_NONE);
+                TDATA->target->setPositionGlobal(targetBoxWithGaps(TDATA->layoutBox, i, j, COL_HAS_FS_TARGET && TARGET_FS_MODE == Fullscreen::FSMODE_FULLSCREEN));
                 Fullscreen::controller()->m_windowPosSettingQueued = false;
             }
 

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -548,11 +548,8 @@ void SScrollingData::recalculate(bool forceInstant) {
                 TDATA->layoutBox = controller->calculateTargetBox(i, j, USABLE, WORKAREA.pos(), *PFSONONE);
 
             if (TDATA->target) {
-                if (targetIsCoveringFullscreen) {
-                    // Scrolling onto or have a new FS window
-                    algorithm->m_scrollingFullscreenHandler->updateTargetRulesAndDecos(TARGET);
+                if (targetIsCoveringFullscreen)
                     Fullscreen::controller()->m_windowPosSettingQueued = true;
-                }
                 // must set pos of the highest level target (i.e. if target a part of a group, must set that group's pos which will set the pos of all member targets)
                 TDATA->target->setPositionGlobal(targetBoxWithGaps(TDATA->layoutBox, i, j, COL_HAS_FS_TARGET && TARGET_FS_MODE == Fullscreen::FSMODE_FULLSCREEN),
                                                  TARGET_FS_MODE != Fullscreen::FSMODE_NONE ?

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -549,10 +549,12 @@ void SScrollingData::recalculate(bool forceInstant) {
                 TDATA->layoutBox = controller->calculateTargetBox(i, j, USABLE, WORKAREA.pos(), *PFSONONE);
 
             if (TDATA->target) {
-                if (targetIsCoveringFullscreen)
+                if (targetIsCoveringFullscreen) {
+                    // Scrolling onto or have a new FS window
+                    algorithm->m_scrollingFullscreenHandler->updateTargetRulesAndDecos(TARGET);
                     Fullscreen::controller()->m_windowPosSettingQueued = true;
+                }
                 // must set pos of the highest level target (i.e. if target a part of a group, must set that group's pos which will set the pos of all member targets)
-                const auto TARGET_FS_MODE = Fullscreen::controller()->getFullscreenModes(TARGET->window()).internal;
                 TDATA->target->setPositionGlobal(targetBoxWithGaps(TDATA->layoutBox, i, j, COL_HAS_FS_TARGET && TARGET_FS_MODE == Fullscreen::FSMODE_FULLSCREEN),
                                                  TARGET_FS_MODE != Fullscreen::FSMODE_NONE ?
                                                      (TARGET_FS_MODE == Fullscreen::FSMODE_FULLSCREEN ? (TARGET_UPDATE_LAYOUT_HANDLED_FS | TARGET_UPDATE_FULLSCREEN) :

--- a/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingAlgorithm.cpp
@@ -20,6 +20,7 @@
 
 #include "../../../../managers/fullscreen/FullscreenController.hpp"
 #include "../../../../layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.hpp"
+#include "layout/target/Target.hpp"
 
 #include <hyprutils/string/VarList2.hpp>
 #include <hyprutils/string/VarList.hpp>
@@ -551,7 +552,13 @@ void SScrollingData::recalculate(bool forceInstant) {
                 if (targetIsCoveringFullscreen)
                     Fullscreen::controller()->m_windowPosSettingQueued = true;
                 // must set pos of the highest level target (i.e. if target a part of a group, must set that group's pos which will set the pos of all member targets)
-                TDATA->target->setPositionGlobal(targetBoxWithGaps(TDATA->layoutBox, i, j, COL_HAS_FS_TARGET && TARGET_FS_MODE == Fullscreen::FSMODE_FULLSCREEN));
+                const auto TARGET_FS_MODE = Fullscreen::controller()->getFullscreenModes(TARGET->window()).internal;
+                TDATA->target->setPositionGlobal(targetBoxWithGaps(TDATA->layoutBox, i, j, COL_HAS_FS_TARGET && TARGET_FS_MODE == Fullscreen::FSMODE_FULLSCREEN),
+                                                 TARGET_FS_MODE != Fullscreen::FSMODE_NONE ?
+                                                     (TARGET_FS_MODE == Fullscreen::FSMODE_FULLSCREEN ? (TARGET_UPDATE_LAYOUT_HANDLED_FS | TARGET_UPDATE_FULLSCREEN) :
+                                                                                                        (TARGET_UPDATE_LAYOUT_HANDLED_FS | TARGET_UPDATE_MAXIMISED)) :
+                                                     TARGET_UPDATE_NONE);
+                Fullscreen::controller()->m_windowPosSettingQueued = false;
             }
 
             if (forceInstant && TDATA->target)

--- a/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
@@ -46,8 +46,12 @@ bool CScrollingFullscreenHandler::isFullscreen(SP<Layout::ITarget> target, const
         return false;
 
     // A window group's FS state is considered to be owned by its current window
-    if (target->window() && target->window()->m_group)
-        target = target->window()->m_group->current()->m_target;
+    if (const auto WINDOW_GROUP_TARGET = dc<Layout::CWindowGroupTarget*>(target.get()); WINDOW_GROUP_TARGET && target->type() == Layout::TARGET_TYPE_GROUP) {
+        if (WINDOW_GROUP_TARGET->getGroup() && WINDOW_GROUP_TARGET->getGroup()->current() && WINDOW_GROUP_TARGET->getGroup()->current()->m_target)
+            target = WINDOW_GROUP_TARGET->getGroup()->current()->m_target;
+        else
+            return false;
+    }
 
     const auto ITR = m_fsTargets.find(target);
 
@@ -93,8 +97,12 @@ SFullscreenMode CScrollingFullscreenHandler::getFullscreenModes(SP<Layout::ITarg
         return {};
 
     // A window group's FS modes are considered to be owned by its current window
-    if (target->window() && target->window()->m_group)
-        target = target->window()->m_group->current()->m_target;
+    if (const auto WINDOW_GROUP_TARGET = dc<Layout::CWindowGroupTarget*>(target.get()); WINDOW_GROUP_TARGET && target->type() == Layout::TARGET_TYPE_GROUP) {
+        if (WINDOW_GROUP_TARGET->getGroup() && WINDOW_GROUP_TARGET->getGroup()->current() && WINDOW_GROUP_TARGET->getGroup()->current()->m_target)
+            target = WINDOW_GROUP_TARGET->getGroup()->current()->m_target;
+        else
+            return {};
+    }
 
     const auto ITR = m_fsTargets.find(target);
 

--- a/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
@@ -285,16 +285,15 @@ void CScrollingFullscreenHandler::updateTargetRulesAndDecos(const SP<Layout::ITa
 
     const auto MONITOR = target->workspace()->m_monitor.lock();
     const auto WINDOW  = target->window();
-    
+
     // If window is in a group, we need to update these values for ALL members of the group.
     if (WINDOW->m_group) {
         for (const auto& gm : WINDOW->m_group->windows()) {
             gm->m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_FULLSCREEN | Desktop::Rule::RULE_PROP_FULLSCREENSTATE_CLIENT |
-                                                        Desktop::Rule::RULE_PROP_FULLSCREENSTATE_INTERNAL | Desktop::Rule::RULE_PROP_ON_WORKSPACE);
+                                                    Desktop::Rule::RULE_PROP_FULLSCREENSTATE_INTERNAL | Desktop::Rule::RULE_PROP_ON_WORKSPACE);
             gm->updateDecorationValues();
         }
-    }
-    else {
+    } else {
         WINDOW->m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_FULLSCREEN | Desktop::Rule::RULE_PROP_FULLSCREENSTATE_CLIENT |
                                                     Desktop::Rule::RULE_PROP_FULLSCREENSTATE_INTERNAL | Desktop::Rule::RULE_PROP_ON_WORKSPACE);
         WINDOW->updateDecorationValues();
@@ -575,7 +574,7 @@ void CScrollingFullscreenHandler::sScrollingDataRecalculateHelper(const SP<Layou
                                                                   const bool TARGET_WORKSPACE_HAS_FS) {
     // TODO Decouple FS logic from SScrollingData::recalculate() to avoid having to schedule a prop refresh: it has to be here and it's a mess because recalculate() handled scrolling
     // onto/away from FS windows and this process doesn't call the controller's FS setters which are normally responsible for handling window rule checks.
-    
+
     // Scrolling away from an FS window
     if (m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow && !TARGET_WORKSPACE_HAS_FS) {
         const auto LAST_FS_TARGET = m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow->m_target;

--- a/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
@@ -576,10 +576,21 @@ void CScrollingFullscreenHandler::sScrollingDataRecalculateHelper(const SP<Layou
     // TODO Decouple FS logic from SScrollingData::recalculate() to avoid having to schedule a prop refresh: it has to be here and it's a mess because recalculate() handled scrolling
     // onto/away from FS windows and this process doesn't call the controller's FS setters which are normally responsible for handling window rule checks.
 
+    // Scrolling onto or have a new FS window
+    if ((TARGET_WORKSPACE_HAS_FS && CURRENT_FS_TDATA && CURRENT_FS_TDATA->target && CURRENT_FS_TDATA->target->window() &&
+         CURRENT_FS_TDATA->target->window() != m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow)) {
+
+        // If window group, get the current window
+        const auto LAST_FS_WINDOW_TARGET = CURRENT_FS_TDATA->target->window()->m_target;
+
+        updateTargetRulesAndDecos(LAST_FS_WINDOW_TARGET);
+
+    }
     // Scrolling away from an FS window
-    if (m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow && !TARGET_WORKSPACE_HAS_FS) {
-        const auto LAST_FS_TARGET = m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow->m_target;
-        updateTargetRulesAndDecos(LAST_FS_TARGET);
+    else if (m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow && !TARGET_WORKSPACE_HAS_FS) {
+        const auto LAST_FS_WINDOW = m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow.lock();
+
+        updateTargetRulesAndDecos(LAST_FS_WINDOW->m_target);
     }
 
     /* Setting DS and VRR */

--- a/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
@@ -573,25 +573,13 @@ eFullscreenHandler CScrollingFullscreenHandler::getFullscreenHandlerName() const
 
 void CScrollingFullscreenHandler::sScrollingDataRecalculateHelper(const SP<Layout::Tiled::SScrollingTargetData> CURRENT_FS_TDATA, const PHLMONITOR MONITOR,
                                                                   const bool TARGET_WORKSPACE_HAS_FS) {
-
     // TODO Decouple FS logic from SScrollingData::recalculate() to avoid having to schedule a prop refresh: it has to be here and it's a mess because recalculate() handled scrolling
     // onto/away from FS windows and this process doesn't call the controller's FS setters which are normally responsible for handling window rule checks.
-
-    // Scrolling onto or have a new FS window
-    if ((TARGET_WORKSPACE_HAS_FS && CURRENT_FS_TDATA && CURRENT_FS_TDATA->target && CURRENT_FS_TDATA->target->window() &&
-         CURRENT_FS_TDATA->target->window() != m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow)) {
-
-        // If window group, get the current window
-        const auto LAST_FS_WINDOW_TARGET = CURRENT_FS_TDATA->target->window()->m_target;
-
-        updateTargetRulesAndDecos(LAST_FS_WINDOW_TARGET);
-
-    }
+    
     // Scrolling away from an FS window
-    else if (m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow && !TARGET_WORKSPACE_HAS_FS) {
-        const auto LAST_FS_WINDOW = m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow.lock();
-
-        updateTargetRulesAndDecos(LAST_FS_WINDOW->m_target);
+    if (m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow && !TARGET_WORKSPACE_HAS_FS) {
+        const auto LAST_FS_TARGET = m_fullscreenWindowHidingState.lastTiledLayoutManagedFsWindow->m_target;
+        updateTargetRulesAndDecos(LAST_FS_TARGET);
     }
 
     /* Setting DS and VRR */

--- a/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
@@ -45,13 +45,9 @@ bool CScrollingFullscreenHandler::isFullscreen(SP<Layout::ITarget> target, const
     if (!target)
         return false;
 
-    // A window group's FS modes are considered to be owned by its current window
-    if (const auto WINDOW_GROUP_TARGET = dc<Layout::CWindowGroupTarget*>(target.get()); WINDOW_GROUP_TARGET && target->type() == Layout::TARGET_TYPE_GROUP) {
-        if (WINDOW_GROUP_TARGET->getGroup() && WINDOW_GROUP_TARGET->getGroup()->current() && WINDOW_GROUP_TARGET->getGroup()->current()->m_target)
-            target = WINDOW_GROUP_TARGET->getGroup()->current()->m_target;
-        else
-            return false;
-    }
+    // A window group's FS state is considered to be owned by its current window
+    if (target->window() && target->window()->m_group)
+        target = target->window()->m_group->current()->m_target;
 
     const auto ITR = m_fsTargets.find(target);
 
@@ -96,12 +92,9 @@ SFullscreenMode CScrollingFullscreenHandler::getFullscreenModes(SP<Layout::ITarg
     if (!target)
         return {};
 
-    if (const auto WINDOW_GROUP_TARGET = dc<Layout::CWindowGroupTarget*>(target.get()); WINDOW_GROUP_TARGET && target->type() == Layout::TARGET_TYPE_GROUP) {
-        if (WINDOW_GROUP_TARGET->getGroup() && WINDOW_GROUP_TARGET->getGroup()->current() && WINDOW_GROUP_TARGET->getGroup()->current()->m_target)
-            target = WINDOW_GROUP_TARGET->getGroup()->current()->m_target;
-        else
-            return {};
-    }
+    // A window group's FS modes are considered to be owned by its current window
+    if (target->window() && target->window()->m_group)
+        target = target->window()->m_group->current()->m_target;
 
     const auto ITR = m_fsTargets.find(target);
 

--- a/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
+++ b/src/layout/algorithm/tiled/scrolling/ScrollingFullscreenHandler.cpp
@@ -285,10 +285,20 @@ void CScrollingFullscreenHandler::updateTargetRulesAndDecos(const SP<Layout::ITa
 
     const auto MONITOR = target->workspace()->m_monitor.lock();
     const auto WINDOW  = target->window();
-
-    WINDOW->m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_FULLSCREEN | Desktop::Rule::RULE_PROP_FULLSCREENSTATE_CLIENT |
-                                                Desktop::Rule::RULE_PROP_FULLSCREENSTATE_INTERNAL | Desktop::Rule::RULE_PROP_ON_WORKSPACE);
-    WINDOW->updateDecorationValues();
+    
+    // If window is in a group, we need to update these values for ALL members of the group.
+    if (WINDOW->m_group) {
+        for (const auto& gm : WINDOW->m_group->windows()) {
+            gm->m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_FULLSCREEN | Desktop::Rule::RULE_PROP_FULLSCREENSTATE_CLIENT |
+                                                        Desktop::Rule::RULE_PROP_FULLSCREENSTATE_INTERNAL | Desktop::Rule::RULE_PROP_ON_WORKSPACE);
+            gm->updateDecorationValues();
+        }
+    }
+    else {
+        WINDOW->m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_FULLSCREEN | Desktop::Rule::RULE_PROP_FULLSCREENSTATE_CLIENT |
+                                                    Desktop::Rule::RULE_PROP_FULLSCREENSTATE_INTERNAL | Desktop::Rule::RULE_PROP_ON_WORKSPACE);
+        WINDOW->updateDecorationValues();
+    }
 
     // Normally, FS controller's FS state setter's method of handling window rules should be used; but calling g_layoutManager->recalculateMonitor(MONITOR) and getSpace()->recalculate()
     // here would lead to an inf recursion

--- a/src/layout/target/Target.hpp
+++ b/src/layout/target/Target.hpp
@@ -21,6 +21,11 @@ namespace Layout {
     enum eTargetUpdateFlags : uint8_t {
         TARGET_UPDATE_NONE                = 0,
         TARGET_UPDATE_NO_CLIENT_CONFIGURE = 1 << 0,
+        // FS handlers and modes
+        TARGET_UPDATE_DEFAULT_HANDLED_FS  = 1 << 2,
+        TARGET_UPDATE_LAYOUT_HANDLED_FS   = 1 << 3,
+        TARGET_UPDATE_FULLSCREEN          = 1 << 4,
+        TARGET_UPDATE_MAXIMISED           = 1 << 5,
     };
 
     class CSpace;

--- a/src/layout/target/Target.hpp
+++ b/src/layout/target/Target.hpp
@@ -22,10 +22,10 @@ namespace Layout {
         TARGET_UPDATE_NONE                = 0,
         TARGET_UPDATE_NO_CLIENT_CONFIGURE = 1 << 0,
         // FS handlers and modes
-        TARGET_UPDATE_DEFAULT_HANDLED_FS  = 1 << 2,
-        TARGET_UPDATE_LAYOUT_HANDLED_FS   = 1 << 3,
-        TARGET_UPDATE_FULLSCREEN          = 1 << 4,
-        TARGET_UPDATE_MAXIMISED           = 1 << 5,
+        TARGET_UPDATE_DEFAULT_HANDLED_FS = 1 << 2,
+        TARGET_UPDATE_LAYOUT_HANDLED_FS  = 1 << 3,
+        TARGET_UPDATE_FULLSCREEN         = 1 << 4,
+        TARGET_UPDATE_MAXIMISED          = 1 << 5,
     };
 
     class CSpace;

--- a/src/layout/target/Target.hpp
+++ b/src/layout/target/Target.hpp
@@ -21,11 +21,6 @@ namespace Layout {
     enum eTargetUpdateFlags : uint8_t {
         TARGET_UPDATE_NONE                = 0,
         TARGET_UPDATE_NO_CLIENT_CONFIGURE = 1 << 0,
-        // FS handlers and modes
-        TARGET_UPDATE_DEFAULT_HANDLED_FS = 1 << 2,
-        TARGET_UPDATE_LAYOUT_HANDLED_FS  = 1 << 3,
-        TARGET_UPDATE_FULLSCREEN         = 1 << 4,
-        TARGET_UPDATE_MAXIMISED          = 1 << 5,
     };
 
     class CSpace;

--- a/src/layout/target/WindowTarget.cpp
+++ b/src/layout/target/WindowTarget.cpp
@@ -13,6 +13,7 @@
 #include "../../state/MonitorState.hpp"
 #include "../../desktop/Workspace.hpp"
 #include "../../managers/fullscreen/FullscreenController.hpp"
+#include "layout/target/Target.hpp"
 
 #include <hyprutils/utils/ScopeGuard.hpp>
 
@@ -67,7 +68,7 @@ void CWindowTarget::updatePos(uint8_t flags) {
     }
 
     // Non-FS Floating Windows
-    if (floating() && m_window && !Fullscreen::controller()->isFullscreen(m_window.lock())) {
+    if (floating() && m_window && !Fullscreen::controller()->isFullscreen(window())) {
         m_window->setBox(m_box.logicalBox);
 
         if (CONFIGURECLIENT)
@@ -80,27 +81,25 @@ void CWindowTarget::updatePos(uint8_t flags) {
     /* FS Handling */
 
     // prevent re-setting an FS window's pos after it is set by the FS calls
-    if (m_window && Fullscreen::controller()->isFullscreen(m_window.lock(), std::nullopt, true)) {
+    if (m_window && Fullscreen::controller()->isFullscreen(window(), std::nullopt, true)) {
         if (!Fullscreen::controller()->m_windowPosSettingQueued)
             return;
-        Fullscreen::controller()->m_windowPosSettingQueued = false;
     }
 
     // Default Handled FS (floating or tiling)
-    if (const auto FSMODES = Fullscreen::controller()->getFullscreenModes(m_window.lock());
-        FSMODES.internal != Fullscreen::FSMODE_NONE && !Fullscreen::controller()->layoutManagedFS(m_self->window())) {
+    if (flags & TARGET_UPDATE_DEFAULT_HANDLED_FS) {
 
-        if (FSMODES.internal == Fullscreen::FSMODE_FULLSCREEN) {
+        if (flags & TARGET_UPDATE_FULLSCREEN) {
             m_window->setBox(m_box.logicalBox);
 
-        } else if (FSMODES.internal == Fullscreen::FSMODE_MAXIMIZED) {
+        } else if (flags & TARGET_UPDATE_MAXIMISED) {
             CBox nodeBox   = m_box.logicalBox;
             CBox visualBox = m_box.visualBox.empty() ? nodeBox : m_box.visualBox;
             nodeBox.round();
             visualBox.round();
 
             // Reserved area must be updated before this is called
-            const auto RESERVED = m_window->getFullWindowReservedArea();
+            const auto RESERVED = window()->getFullWindowReservedArea();
 
             m_window->setBox({visualBox.pos() + RESERVED.topLeft, visualBox.size() - (RESERVED.topLeft + RESERVED.bottomRight)});
         }
@@ -112,19 +111,18 @@ void CWindowTarget::updatePos(uint8_t flags) {
     }
 
     // Layout handled FS
-    if (const auto FSMODES = Fullscreen::controller()->getFullscreenModes(m_window.lock());
-        FSMODES.internal != Fullscreen::FSMODE_NONE && Fullscreen::controller()->layoutManagedFS(m_self->window())) {
+    if (flags & TARGET_UPDATE_LAYOUT_HANDLED_FS) {
 
         CBox nodeBox   = m_box.logicalBox;
         CBox visualBox = m_box.visualBox.empty() ? nodeBox : m_box.visualBox;
         nodeBox.round();
         visualBox.round();
-        if (FSMODES.internal == Fullscreen::FSMODE_FULLSCREEN) {
+        if (flags & TARGET_UPDATE_FULLSCREEN) {
             m_window->setBox(visualBox);
-        } else if (FSMODES.internal == Fullscreen::FSMODE_MAXIMIZED) {
+        } else if (flags & TARGET_UPDATE_MAXIMISED) {
 
             // Reserved area must be updated before this is called
-            const auto RESERVED = m_window->getFullWindowReservedArea();
+            const auto RESERVED = window()->getFullWindowReservedArea();
             m_window->setBox({visualBox.pos() + RESERVED.topLeft, visualBox.size() - (RESERVED.topLeft + RESERVED.bottomRight)});
         }
 
@@ -166,7 +164,7 @@ void CWindowTarget::updatePos(uint8_t flags) {
 
         Vector2D          ratioPadding;
 
-        if ((*REQUESTEDRATIO).y != 0 && m_space->algorithm()->tiledTargets() <= 1 && m_window && !Fullscreen::controller()->isFullscreen(m_window.lock())) {
+        if ((*REQUESTEDRATIO).y != 0 && m_space->algorithm()->tiledTargets() <= 1 && m_window && !Fullscreen::controller()->isFullscreen(window())) {
             const Vector2D originalSize = MONITOR_WORKAREA.size();
 
             const double   requestedRatio = (*REQUESTEDRATIO).x / (*REQUESTEDRATIO).y;
@@ -194,7 +192,7 @@ void CWindowTarget::updatePos(uint8_t flags) {
         calcSize = calcSize - GAPOFFSETTOPLEFT - GAPOFFSETBOTTOMRIGHT - ratioPadding;
     }
 
-    if (isPseudo() && m_window && !Fullscreen::controller()->isFullscreen(m_window.lock())) {
+    if (isPseudo() && m_window && !Fullscreen::controller()->isFullscreen(window())) {
         // Calculate pseudo
         float scale = 1;
 
@@ -227,7 +225,7 @@ void CWindowTarget::updatePos(uint8_t flags) {
     if (*PCLAMP_TILED) {
         Vector2D minSize = m_window->m_ruleApplicator->minSize().valueOr(Vector2D{MIN_WINDOW_SIZE, MIN_WINDOW_SIZE});
         Vector2D maxSize =
-            Fullscreen::controller()->isFullscreen(m_window.lock()) ? Vector2D{INFINITY, INFINITY} : m_window->m_ruleApplicator->maxSize().valueOr(Vector2D{INFINITY, INFINITY});
+            Fullscreen::controller()->isFullscreen(window()) ? Vector2D{INFINITY, INFINITY} : m_window->m_ruleApplicator->maxSize().valueOr(Vector2D{INFINITY, INFINITY});
         calcSize = calcSize.clamp(minSize, maxSize);
 
         calcPos += (availableSpace - calcSize) / 2.0;
@@ -236,7 +234,7 @@ void CWindowTarget::updatePos(uint8_t flags) {
         calcPos.y = std::clamp(calcPos.y, MONITOR_WORKAREA.y, std::max(MONITOR_WORKAREA.y, MONITOR_WORKAREA.y + MONITOR_WORKAREA.h - calcSize.y));
     }
 
-    if (m_window->onSpecialWorkspace() && m_window && !Fullscreen::controller()->isFullscreen(m_window.lock())) {
+    if (m_window->onSpecialWorkspace() && m_window && !Fullscreen::controller()->isFullscreen(window())) {
         // if special, we adjust the coords a bit
         static auto PSCALEFACTOR = CConfigValue<Config::FLOAT>("dwindle:special_scale_factor");
 

--- a/src/layout/target/WindowTarget.cpp
+++ b/src/layout/target/WindowTarget.cpp
@@ -13,7 +13,6 @@
 #include "../../state/MonitorState.hpp"
 #include "../../desktop/Workspace.hpp"
 #include "../../managers/fullscreen/FullscreenController.hpp"
-#include "layout/target/Target.hpp"
 
 #include <hyprutils/utils/ScopeGuard.hpp>
 

--- a/src/layout/target/WindowTarget.cpp
+++ b/src/layout/target/WindowTarget.cpp
@@ -104,7 +104,7 @@ void CWindowTarget::updatePos(uint8_t flags) {
             visualBox.round();
 
             // Reserved area must be updated before this is called
-            // Reserved area for all windows in a group are owned by the leading window. Other windows are hidden anyway so this simplay ensures their sizes are uniform when FSed
+            // Reserved area for all windows in a group are owned by the leading window. Other windows are hidden anyway so this simply ensures their sizes are uniform when FSed
             const auto RESERVED = effectiveWindow()->getFullWindowReservedArea();
 
             m_window->setBox({visualBox.pos() + RESERVED.topLeft, visualBox.size() - (RESERVED.topLeft + RESERVED.bottomRight)});
@@ -128,7 +128,7 @@ void CWindowTarget::updatePos(uint8_t flags) {
         } else if (flags & TARGET_UPDATE_MAXIMISED) {
 
             // Reserved area must be updated before this is called
-            // Reserved area for all windows in a group are owned by the leading window. Other windows are hidden anyway so this simplay ensures their sizes are uniform when FSed
+            // Reserved area for all windows in a group are owned by the leading window. Other windows are hidden anyway so this simply ensures their sizes are uniform when FSed
             const auto RESERVED = effectiveWindow()->getFullWindowReservedArea();
             m_window->setBox({visualBox.pos() + RESERVED.topLeft, visualBox.size() - (RESERVED.topLeft + RESERVED.bottomRight)});
         }

--- a/src/layout/target/WindowTarget.cpp
+++ b/src/layout/target/WindowTarget.cpp
@@ -13,6 +13,7 @@
 #include "../../state/MonitorState.hpp"
 #include "../../desktop/Workspace.hpp"
 #include "../../managers/fullscreen/FullscreenController.hpp"
+#include "../../desktop/view/Group.hpp"
 
 #include <hyprutils/utils/ScopeGuard.hpp>
 
@@ -44,6 +45,11 @@ void CWindowTarget::updatePos(uint8_t flags) {
     if (!m_window)
         return;
 
+    const auto effectiveWindow = [&]() {
+        // FS state of a window in a group is owned by the current window of that group.
+        return window()->m_group ? window()->m_group->current() : window();
+    };
+
     g_pHyprRenderer->damageWindow(m_window.lock());
     CScopeGuard x([this] { g_pHyprRenderer->damageWindow(m_window.lock()); });
 
@@ -67,7 +73,7 @@ void CWindowTarget::updatePos(uint8_t flags) {
     }
 
     // Non-FS Floating Windows
-    if (floating() && m_window && !Fullscreen::controller()->isFullscreen(window())) {
+    if (floating() && m_window && !Fullscreen::controller()->isFullscreen(effectiveWindow())) {
         m_window->setBox(m_box.logicalBox);
 
         if (CONFIGURECLIENT)
@@ -79,8 +85,8 @@ void CWindowTarget::updatePos(uint8_t flags) {
 
     /* FS Handling */
 
-    // prevent re-setting an FS window's pos after it is set by the FS calls
-    if (m_window && Fullscreen::controller()->isFullscreen(window(), std::nullopt, true)) {
+    // prevent re-setting a covering FS window's pos after it is set by the FS calls
+    if (m_window && Fullscreen::controller()->isFullscreen(effectiveWindow(), std::nullopt, true)) {
         if (!Fullscreen::controller()->m_windowPosSettingQueued)
             return;
     }
@@ -98,7 +104,8 @@ void CWindowTarget::updatePos(uint8_t flags) {
             visualBox.round();
 
             // Reserved area must be updated before this is called
-            const auto RESERVED = window()->getFullWindowReservedArea();
+            // Reserved area for all windows in a group are owned by the leading window. Other windows are hidden anyway so this simplay ensures their sizes are uniform when FSed
+            const auto RESERVED = effectiveWindow()->getFullWindowReservedArea();
 
             m_window->setBox({visualBox.pos() + RESERVED.topLeft, visualBox.size() - (RESERVED.topLeft + RESERVED.bottomRight)});
         }
@@ -121,7 +128,8 @@ void CWindowTarget::updatePos(uint8_t flags) {
         } else if (flags & TARGET_UPDATE_MAXIMISED) {
 
             // Reserved area must be updated before this is called
-            const auto RESERVED = window()->getFullWindowReservedArea();
+            // Reserved area for all windows in a group are owned by the leading window. Other windows are hidden anyway so this simplay ensures their sizes are uniform when FSed
+            const auto RESERVED = effectiveWindow()->getFullWindowReservedArea();
             m_window->setBox({visualBox.pos() + RESERVED.topLeft, visualBox.size() - (RESERVED.topLeft + RESERVED.bottomRight)});
         }
 
@@ -163,7 +171,7 @@ void CWindowTarget::updatePos(uint8_t flags) {
 
         Vector2D          ratioPadding;
 
-        if ((*REQUESTEDRATIO).y != 0 && m_space->algorithm()->tiledTargets() <= 1 && m_window && !Fullscreen::controller()->isFullscreen(window())) {
+        if ((*REQUESTEDRATIO).y != 0 && m_space->algorithm()->tiledTargets() <= 1 && m_window && !Fullscreen::controller()->isFullscreen(effectiveWindow())) {
             const Vector2D originalSize = MONITOR_WORKAREA.size();
 
             const double   requestedRatio = (*REQUESTEDRATIO).x / (*REQUESTEDRATIO).y;
@@ -191,7 +199,7 @@ void CWindowTarget::updatePos(uint8_t flags) {
         calcSize = calcSize - GAPOFFSETTOPLEFT - GAPOFFSETBOTTOMRIGHT - ratioPadding;
     }
 
-    if (isPseudo() && m_window && !Fullscreen::controller()->isFullscreen(window())) {
+    if (isPseudo() && m_window && !Fullscreen::controller()->isFullscreen(effectiveWindow())) {
         // Calculate pseudo
         float scale = 1;
 
@@ -224,7 +232,7 @@ void CWindowTarget::updatePos(uint8_t flags) {
     if (*PCLAMP_TILED) {
         Vector2D minSize = m_window->m_ruleApplicator->minSize().valueOr(Vector2D{MIN_WINDOW_SIZE, MIN_WINDOW_SIZE});
         Vector2D maxSize =
-            Fullscreen::controller()->isFullscreen(window()) ? Vector2D{INFINITY, INFINITY} : m_window->m_ruleApplicator->maxSize().valueOr(Vector2D{INFINITY, INFINITY});
+            Fullscreen::controller()->isFullscreen(effectiveWindow()) ? Vector2D{INFINITY, INFINITY} : m_window->m_ruleApplicator->maxSize().valueOr(Vector2D{INFINITY, INFINITY});
         calcSize = calcSize.clamp(minSize, maxSize);
 
         calcPos += (availableSpace - calcSize) / 2.0;
@@ -233,7 +241,7 @@ void CWindowTarget::updatePos(uint8_t flags) {
         calcPos.y = std::clamp(calcPos.y, MONITOR_WORKAREA.y, std::max(MONITOR_WORKAREA.y, MONITOR_WORKAREA.y + MONITOR_WORKAREA.h - calcSize.y));
     }
 
-    if (m_window->onSpecialWorkspace() && m_window && !Fullscreen::controller()->isFullscreen(window())) {
+    if (m_window->onSpecialWorkspace() && m_window && !Fullscreen::controller()->isFullscreen(effectiveWindow())) {
         // if special, we adjust the coords a bit
         static auto PSCALEFACTOR = CConfigValue<Config::FLOAT>("dwindle:special_scale_factor");
 

--- a/src/layout/target/WindowTarget.cpp
+++ b/src/layout/target/WindowTarget.cpp
@@ -92,12 +92,12 @@ void CWindowTarget::updatePos(uint8_t flags) {
     }
 
     // Default Handled FS (floating or tiling)
-    if (flags & TARGET_UPDATE_DEFAULT_HANDLED_FS) {
-
-        if (flags & TARGET_UPDATE_FULLSCREEN) {
+    if (const auto FSMODES = Fullscreen::controller()->getFullscreenModes(m_window.lock());
+        FSMODES.internal != Fullscreen::FSMODE_NONE && !Fullscreen::controller()->layoutManagedFS(m_self->window())) {
+        if (FSMODES.internal == Fullscreen::FSMODE_FULLSCREEN) {
             m_window->setBox(m_box.logicalBox);
 
-        } else if (flags & TARGET_UPDATE_MAXIMISED) {
+        } else if (FSMODES.internal == Fullscreen::FSMODE_MAXIMIZED) {
             CBox nodeBox   = m_box.logicalBox;
             CBox visualBox = m_box.visualBox.empty() ? nodeBox : m_box.visualBox;
             nodeBox.round();
@@ -116,16 +116,17 @@ void CWindowTarget::updatePos(uint8_t flags) {
         return;
     }
 
-    // Layout handled FS
-    if (flags & TARGET_UPDATE_LAYOUT_HANDLED_FS) {
+    // Layout handled FS (Tiled Only)
+    if (const auto FSMODES = Fullscreen::controller()->getFullscreenModes(m_window.lock());
+        FSMODES.internal != Fullscreen::FSMODE_NONE && Fullscreen::controller()->layoutManagedFS(m_self->window())) {
 
         CBox nodeBox   = m_box.logicalBox;
         CBox visualBox = m_box.visualBox.empty() ? nodeBox : m_box.visualBox;
         nodeBox.round();
         visualBox.round();
-        if (flags & TARGET_UPDATE_FULLSCREEN) {
+        if (FSMODES.internal == Fullscreen::FSMODE_FULLSCREEN) {
             m_window->setBox(visualBox);
-        } else if (flags & TARGET_UPDATE_MAXIMISED) {
+        } else if (FSMODES.internal == Fullscreen::FSMODE_MAXIMIZED) {
 
             // Reserved area must be updated before this is called
             // Reserved area for all windows in a group are owned by the leading window. Other windows are hidden anyway so this simply ensures their sizes are uniform when FSed
@@ -171,7 +172,7 @@ void CWindowTarget::updatePos(uint8_t flags) {
 
         Vector2D          ratioPadding;
 
-        if ((*REQUESTEDRATIO).y != 0 && m_space->algorithm()->tiledTargets() <= 1 && m_window && !Fullscreen::controller()->isFullscreen(effectiveWindow())) {
+        if ((*REQUESTEDRATIO).y != 0 && m_space->algorithm()->tiledTargets() <= 1 && m_window) {
             const Vector2D originalSize = MONITOR_WORKAREA.size();
 
             const double   requestedRatio = (*REQUESTEDRATIO).x / (*REQUESTEDRATIO).y;
@@ -199,7 +200,7 @@ void CWindowTarget::updatePos(uint8_t flags) {
         calcSize = calcSize - GAPOFFSETTOPLEFT - GAPOFFSETBOTTOMRIGHT - ratioPadding;
     }
 
-    if (isPseudo() && m_window && !Fullscreen::controller()->isFullscreen(effectiveWindow())) {
+    if (isPseudo() && m_window) {
         // Calculate pseudo
         float scale = 1;
 
@@ -231,8 +232,7 @@ void CWindowTarget::updatePos(uint8_t flags) {
 
     if (*PCLAMP_TILED) {
         Vector2D minSize = m_window->m_ruleApplicator->minSize().valueOr(Vector2D{MIN_WINDOW_SIZE, MIN_WINDOW_SIZE});
-        Vector2D maxSize =
-            Fullscreen::controller()->isFullscreen(effectiveWindow()) ? Vector2D{INFINITY, INFINITY} : m_window->m_ruleApplicator->maxSize().valueOr(Vector2D{INFINITY, INFINITY});
+        Vector2D maxSize = m_window->m_ruleApplicator->maxSize().valueOr(Vector2D{INFINITY, INFINITY});
         calcSize = calcSize.clamp(minSize, maxSize);
 
         calcPos += (availableSpace - calcSize) / 2.0;
@@ -241,7 +241,7 @@ void CWindowTarget::updatePos(uint8_t flags) {
         calcPos.y = std::clamp(calcPos.y, MONITOR_WORKAREA.y, std::max(MONITOR_WORKAREA.y, MONITOR_WORKAREA.y + MONITOR_WORKAREA.h - calcSize.y));
     }
 
-    if (m_window->onSpecialWorkspace() && m_window && !Fullscreen::controller()->isFullscreen(effectiveWindow())) {
+    if (m_window->onSpecialWorkspace() && m_window) {
         // if special, we adjust the coords a bit
         static auto PSCALEFACTOR = CConfigValue<Config::FLOAT>("dwindle:special_scale_factor");
 

--- a/src/layout/target/WindowTarget.cpp
+++ b/src/layout/target/WindowTarget.cpp
@@ -92,8 +92,8 @@ void CWindowTarget::updatePos(uint8_t flags) {
     }
 
     // Default Handled FS (floating or tiling)
-    if (const auto FSMODES = Fullscreen::controller()->getFullscreenModes(m_window.lock());
-        FSMODES.internal != Fullscreen::FSMODE_NONE && !Fullscreen::controller()->layoutManagedFS(m_self->window())) {
+    if (const auto FSMODES = Fullscreen::controller()->getFullscreenModes(effectiveWindow());
+        FSMODES.internal != Fullscreen::FSMODE_NONE && !Fullscreen::controller()->layoutManagedFS(effectiveWindow())) {
         if (FSMODES.internal == Fullscreen::FSMODE_FULLSCREEN) {
             m_window->setBox(m_box.logicalBox);
 
@@ -117,8 +117,8 @@ void CWindowTarget::updatePos(uint8_t flags) {
     }
 
     // Layout handled FS (Tiled Only)
-    if (const auto FSMODES = Fullscreen::controller()->getFullscreenModes(m_window.lock());
-        FSMODES.internal != Fullscreen::FSMODE_NONE && Fullscreen::controller()->layoutManagedFS(m_self->window())) {
+    if (const auto FSMODES = Fullscreen::controller()->getFullscreenModes(effectiveWindow());
+        FSMODES.internal != Fullscreen::FSMODE_NONE && Fullscreen::controller()->layoutManagedFS(effectiveWindow())) {
 
         CBox nodeBox   = m_box.logicalBox;
         CBox visualBox = m_box.visualBox.empty() ? nodeBox : m_box.visualBox;

--- a/src/layout/target/WindowTarget.cpp
+++ b/src/layout/target/WindowTarget.cpp
@@ -233,7 +233,7 @@ void CWindowTarget::updatePos(uint8_t flags) {
     if (*PCLAMP_TILED) {
         Vector2D minSize = m_window->m_ruleApplicator->minSize().valueOr(Vector2D{MIN_WINDOW_SIZE, MIN_WINDOW_SIZE});
         Vector2D maxSize = m_window->m_ruleApplicator->maxSize().valueOr(Vector2D{INFINITY, INFINITY});
-        calcSize = calcSize.clamp(minSize, maxSize);
+        calcSize         = calcSize.clamp(minSize, maxSize);
 
         calcPos += (availableSpace - calcSize) / 2.0;
 

--- a/src/managers/fullscreen/handler/FullscreenHandler.cpp
+++ b/src/managers/fullscreen/handler/FullscreenHandler.cpp
@@ -170,15 +170,13 @@ void IFullscreenHandler::updateTargetRulesAndDecos(const SP<Layout::ITarget> tar
     if (WINDOW->m_group) {
         for (const auto& gm : WINDOW->m_group->windows()) {
             gm->m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_FULLSCREEN | Desktop::Rule::RULE_PROP_FULLSCREENSTATE_CLIENT |
-                                                        Desktop::Rule::RULE_PROP_FULLSCREENSTATE_INTERNAL | Desktop::Rule::RULE_PROP_ON_WORKSPACE);
+                                                    Desktop::Rule::RULE_PROP_FULLSCREENSTATE_INTERNAL | Desktop::Rule::RULE_PROP_ON_WORKSPACE);
             gm->updateDecorationValues();
-
         }
-    }
-    else {
-            WINDOW->m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_FULLSCREEN | Desktop::Rule::RULE_PROP_FULLSCREENSTATE_CLIENT |
-                                                        Desktop::Rule::RULE_PROP_FULLSCREENSTATE_INTERNAL | Desktop::Rule::RULE_PROP_ON_WORKSPACE);
-            WINDOW->updateDecorationValues();
+    } else {
+        WINDOW->m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_FULLSCREEN | Desktop::Rule::RULE_PROP_FULLSCREENSTATE_CLIENT |
+                                                    Desktop::Rule::RULE_PROP_FULLSCREENSTATE_INTERNAL | Desktop::Rule::RULE_PROP_ON_WORKSPACE);
+        WINDOW->updateDecorationValues();
     }
     g_layoutManager->recalculateMonitor(MONITOR, Layout::CLayoutManager::RECALCULATE_MONITOR_REASON_TOGGLE_FULLSCREEN);
     getSpace()->recalculate(Layout::RECALCULATE_REASON_TOGGLE_DEFAULT_HANDLED_FULLSCREEN);

--- a/src/managers/fullscreen/handler/FullscreenHandler.cpp
+++ b/src/managers/fullscreen/handler/FullscreenHandler.cpp
@@ -165,9 +165,21 @@ void IFullscreenHandler::updateTargetRulesAndDecos(const SP<Layout::ITarget> tar
 
     // Target must be a fullscreen window as considered by window/workspace rule matchers by now.
     // update all the values necessary for FS windows to get correct window dimensions and pos
-    WINDOW->m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_FULLSCREEN | Desktop::Rule::RULE_PROP_FULLSCREENSTATE_CLIENT |
-                                                Desktop::Rule::RULE_PROP_FULLSCREENSTATE_INTERNAL | Desktop::Rule::RULE_PROP_ON_WORKSPACE);
-    WINDOW->updateDecorationValues();
+
+    // If window is in a group, we need to update these values for ALL members of the group.
+    if (WINDOW->m_group) {
+        for (const auto& gm : WINDOW->m_group->windows()) {
+            gm->m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_FULLSCREEN | Desktop::Rule::RULE_PROP_FULLSCREENSTATE_CLIENT |
+                                                        Desktop::Rule::RULE_PROP_FULLSCREENSTATE_INTERNAL | Desktop::Rule::RULE_PROP_ON_WORKSPACE);
+            gm->updateDecorationValues();
+
+        }
+    }
+    else {
+            WINDOW->m_ruleApplicator->propertiesChanged(Desktop::Rule::RULE_PROP_FULLSCREEN | Desktop::Rule::RULE_PROP_FULLSCREENSTATE_CLIENT |
+                                                        Desktop::Rule::RULE_PROP_FULLSCREENSTATE_INTERNAL | Desktop::Rule::RULE_PROP_ON_WORKSPACE);
+            WINDOW->updateDecorationValues();
+    }
     g_layoutManager->recalculateMonitor(MONITOR, Layout::CLayoutManager::RECALCULATE_MONITOR_REASON_TOGGLE_FULLSCREEN);
     getSpace()->recalculate(Layout::RECALCULATE_REASON_TOGGLE_DEFAULT_HANDLED_FULLSCREEN);
 }
@@ -191,12 +203,13 @@ void IFullscreenHandler::setTargetSizeAndPosition(const SP<Layout::ITarget> targ
     if (TARGET_INTERNAL_MODE == FSMODE_FULLSCREEN) {
         const CBox MONBOX                                  = MONITOR->logicalBox();
         Fullscreen::controller()->m_windowPosSettingQueued = true;
-        LAYOUT_TARGET->setPositionGlobal(MONBOX);
+        LAYOUT_TARGET->setPositionGlobal(MONBOX, Layout::TARGET_UPDATE_DEFAULT_HANDLED_FS | Layout::TARGET_UPDATE_FULLSCREEN);
     } else if (TARGET_INTERNAL_MODE == FSMODE_MAXIMIZED) {
         const CBox WORKAREA                                = WORKSPACE->m_space->workArea(target->floating());
         Fullscreen::controller()->m_windowPosSettingQueued = true;
-        LAYOUT_TARGET->setPositionGlobal(WORKAREA);
+        LAYOUT_TARGET->setPositionGlobal(WORKAREA, Layout::TARGET_UPDATE_DEFAULT_HANDLED_FS | Layout::TARGET_UPDATE_MAXIMISED);
     }
+    Fullscreen::controller()->m_windowPosSettingQueued = false;
 }
 
 void IFullscreenHandler::syncTargetSizeAndPosition() {
@@ -231,7 +244,7 @@ void IFullscreenHandler::syncTargetSizeAndPosition() {
         // No need to compare with current value also since it'll get overwritten by goal anyway
         if (CURRENT_REAL_POS_GOAL != EXPECTED_REAL_POS || CURRENT_REAL_SIZE_GOAL != EXPECTED_REAL_SIZE) {
             controller()->m_windowPosSettingQueued = true;
-            LAYOUT_TARGET->setPositionGlobal(MONBOX);
+            LAYOUT_TARGET->setPositionGlobal(MONBOX, Layout::TARGET_UPDATE_DEFAULT_HANDLED_FS | Layout::TARGET_UPDATE_FULLSCREEN);
         }
     } else if (TARGET_INTERNAL_MODE == FSMODE_MAXIMIZED) {
 
@@ -250,9 +263,10 @@ void IFullscreenHandler::syncTargetSizeAndPosition() {
 
         if (CURRENT_REAL_POS_GOAL != EXPECTED_REAL_POS || CURRENT_REAL_SIZE_GOAL != EXPECTED_REAL_SIZE) {
             controller()->m_windowPosSettingQueued = true;
-            LAYOUT_TARGET->setPositionGlobal(WORKSPACE->m_space->workArea(FS_TARGET->floating()));
+            LAYOUT_TARGET->setPositionGlobal(WORKSPACE->m_space->workArea(FS_TARGET->floating()), Layout::TARGET_UPDATE_DEFAULT_HANDLED_FS | Layout::TARGET_UPDATE_MAXIMISED);
         }
     }
+    Fullscreen::controller()->m_windowPosSettingQueued = false;
 }
 
 void IFullscreenHandler::setNoMembersAboveFullscreen() {

--- a/src/managers/fullscreen/handler/FullscreenHandler.cpp
+++ b/src/managers/fullscreen/handler/FullscreenHandler.cpp
@@ -38,13 +38,10 @@ bool IFullscreenHandler::isFullscreen(SP<Layout::ITarget> target, const std::opt
         !isFullscreen(target, std::nullopt, covering);
     }
 
-    // A window group's FS modes are considered to be owned by its current window
-    if (const auto WINDOW_GROUP_TARGET = dc<Layout::CWindowGroupTarget*>(target.get()); WINDOW_GROUP_TARGET && target->type() == Layout::TARGET_TYPE_GROUP) {
-        if (WINDOW_GROUP_TARGET->getGroup() && WINDOW_GROUP_TARGET->getGroup()->current() && WINDOW_GROUP_TARGET->getGroup()->current()->m_target)
-            target = WINDOW_GROUP_TARGET->getGroup()->current()->m_target;
-        else
-            return false;
-    }
+    // A window group's FS state is considered to be owned by its current window
+    if (target->window() && target->window()->m_group)
+        target = target->window()->m_group->current()->m_target;
+
 
     const auto& ITR = m_fsTargets.find(target);
 
@@ -70,12 +67,9 @@ SFullscreenMode IFullscreenHandler::getFullscreenModes(SP<Layout::ITarget> targe
     if (!target)
         return {};
 
-    if (const auto WINDOW_GROUP_TARGET = dc<Layout::CWindowGroupTarget*>(target.get()); WINDOW_GROUP_TARGET && target->type() == Layout::TARGET_TYPE_GROUP) {
-        if (WINDOW_GROUP_TARGET->getGroup() && WINDOW_GROUP_TARGET->getGroup()->current() && WINDOW_GROUP_TARGET->getGroup()->current()->m_target)
-            target = WINDOW_GROUP_TARGET->getGroup()->current()->m_target;
-        else
-            return {};
-    }
+    // A window group's FS modes are considered to be owned by its current window
+    if (target->window() && target->window()->m_group)
+        target = target->window()->m_group->current()->m_target;
 
     const auto ITR = m_fsTargets.find(target);
 

--- a/src/managers/fullscreen/handler/FullscreenHandler.cpp
+++ b/src/managers/fullscreen/handler/FullscreenHandler.cpp
@@ -202,11 +202,11 @@ void IFullscreenHandler::setTargetSizeAndPosition(const SP<Layout::ITarget> targ
     if (TARGET_INTERNAL_MODE == FSMODE_FULLSCREEN) {
         const CBox MONBOX                                  = MONITOR->logicalBox();
         Fullscreen::controller()->m_windowPosSettingQueued = true;
-        LAYOUT_TARGET->setPositionGlobal(MONBOX, Layout::TARGET_UPDATE_DEFAULT_HANDLED_FS | Layout::TARGET_UPDATE_FULLSCREEN);
+        LAYOUT_TARGET->setPositionGlobal(MONBOX);
     } else if (TARGET_INTERNAL_MODE == FSMODE_MAXIMIZED) {
         const CBox WORKAREA                                = WORKSPACE->m_space->workArea(target->floating());
         Fullscreen::controller()->m_windowPosSettingQueued = true;
-        LAYOUT_TARGET->setPositionGlobal(WORKAREA, Layout::TARGET_UPDATE_DEFAULT_HANDLED_FS | Layout::TARGET_UPDATE_MAXIMISED);
+        LAYOUT_TARGET->setPositionGlobal(WORKAREA);
     }
     Fullscreen::controller()->m_windowPosSettingQueued = false;
 }
@@ -243,7 +243,7 @@ void IFullscreenHandler::syncTargetSizeAndPosition() {
         // No need to compare with current value also since it'll get overwritten by goal anyway
         if (CURRENT_REAL_POS_GOAL != EXPECTED_REAL_POS || CURRENT_REAL_SIZE_GOAL != EXPECTED_REAL_SIZE) {
             controller()->m_windowPosSettingQueued = true;
-            LAYOUT_TARGET->setPositionGlobal(MONBOX, Layout::TARGET_UPDATE_DEFAULT_HANDLED_FS | Layout::TARGET_UPDATE_FULLSCREEN);
+            LAYOUT_TARGET->setPositionGlobal(MONBOX);
         }
     } else if (TARGET_INTERNAL_MODE == FSMODE_MAXIMIZED) {
 
@@ -262,7 +262,7 @@ void IFullscreenHandler::syncTargetSizeAndPosition() {
 
         if (CURRENT_REAL_POS_GOAL != EXPECTED_REAL_POS || CURRENT_REAL_SIZE_GOAL != EXPECTED_REAL_SIZE) {
             controller()->m_windowPosSettingQueued = true;
-            LAYOUT_TARGET->setPositionGlobal(WORKSPACE->m_space->workArea(FS_TARGET->floating()), Layout::TARGET_UPDATE_DEFAULT_HANDLED_FS | Layout::TARGET_UPDATE_MAXIMISED);
+            LAYOUT_TARGET->setPositionGlobal(WORKSPACE->m_space->workArea(FS_TARGET->floating()));
         }
     }
     Fullscreen::controller()->m_windowPosSettingQueued = false;

--- a/src/managers/fullscreen/handler/FullscreenHandler.cpp
+++ b/src/managers/fullscreen/handler/FullscreenHandler.cpp
@@ -39,8 +39,12 @@ bool IFullscreenHandler::isFullscreen(SP<Layout::ITarget> target, const std::opt
     }
 
     // A window group's FS state is considered to be owned by its current window
-    if (target->window() && target->window()->m_group)
-        target = target->window()->m_group->current()->m_target;
+    if (const auto WINDOW_GROUP_TARGET = dc<Layout::CWindowGroupTarget*>(target.get()); WINDOW_GROUP_TARGET && target->type() == Layout::TARGET_TYPE_GROUP) {
+        if (WINDOW_GROUP_TARGET->getGroup() && WINDOW_GROUP_TARGET->getGroup()->current() && WINDOW_GROUP_TARGET->getGroup()->current()->m_target)
+            target = WINDOW_GROUP_TARGET->getGroup()->current()->m_target;
+        else
+            return false;
+    }
 
     const auto& ITR = m_fsTargets.find(target);
 
@@ -67,8 +71,12 @@ SFullscreenMode IFullscreenHandler::getFullscreenModes(SP<Layout::ITarget> targe
         return {};
 
     // A window group's FS modes are considered to be owned by its current window
-    if (target->window() && target->window()->m_group)
-        target = target->window()->m_group->current()->m_target;
+    if (const auto WINDOW_GROUP_TARGET = dc<Layout::CWindowGroupTarget*>(target.get()); WINDOW_GROUP_TARGET && target->type() == Layout::TARGET_TYPE_GROUP) {
+        if (WINDOW_GROUP_TARGET->getGroup() && WINDOW_GROUP_TARGET->getGroup()->current() && WINDOW_GROUP_TARGET->getGroup()->current()->m_target)
+            target = WINDOW_GROUP_TARGET->getGroup()->current()->m_target;
+        else
+            return {};
+    }
 
     const auto ITR = m_fsTargets.find(target);
 

--- a/src/managers/fullscreen/handler/FullscreenHandler.cpp
+++ b/src/managers/fullscreen/handler/FullscreenHandler.cpp
@@ -42,7 +42,6 @@ bool IFullscreenHandler::isFullscreen(SP<Layout::ITarget> target, const std::opt
     if (target->window() && target->window()->m_group)
         target = target->window()->m_group->current()->m_target;
 
-
     const auto& ITR = m_fsTargets.find(target);
 
     if (ITR == m_fsTargets.end())


### PR DESCRIPTION
#### Describe your PR, what does it fix/add?

- Title (groups part)

- Optimisations for speed and error resilience 
  - Prevent repeatedly setting a FS window's pos more than necessary.
  - The info about if a window is being FSed is passed to `updatePos()` by the caller, preventing redundant FS state checks and making sure that the window gets the correct size even if the FS state checker functions are malfunctioning somehow. There are self-correction mechanism for those as well, so this prevents the window to have improperly set size before those kick in.
     
#### Is there anything you want to mention? (unchecked code, possible bugs, found problems, breaking compatibility, etc.)

No

#### Is it ready for merging, or does it need work?

- [x] Tests


