### PR TITLE
refactor rendermonitor and early out on no damage frames

### DIFF
--- a/src/config/shared/monitor/MonitorRuleManager.cpp
+++ b/src/config/shared/monitor/MonitorRuleManager.cpp
@@ -206,7 +206,7 @@ void CMonitorRuleManager::ensureVRR(PHLMONITOR pMonitor) {
                 m->m_output->state->resetExplicitFences();
                 m->m_output->state->setAdaptiveSync(false);
 
-                if (!m->m_state.commit())
+                if (!m->m_state.commit(false))
                     Log::logger->log(Log::ERR, "Couldn't commit output {} in ensureVRR -> false", m->m_output->name);
             }
             m->m_vrrActive = false;
@@ -230,7 +230,7 @@ void CMonitorRuleManager::ensureVRR(PHLMONITOR pMonitor) {
                         m->m_output->state->setAdaptiveSync(false);
                     }
 
-                    if (!m->m_state.commit())
+                    if (!m->m_state.commit(false))
                         Log::logger->log(Log::ERR, "Couldn't commit output {} in ensureVRR -> true", m->m_output->name);
                 }
                 m->m_vrrActive = true;
@@ -239,7 +239,7 @@ void CMonitorRuleManager::ensureVRR(PHLMONITOR pMonitor) {
                     m->m_output->state->resetExplicitFences();
                     m->m_output->state->setAdaptiveSync(false);
 
-                    if (!m->m_state.commit())
+                    if (!m->m_state.commit(false))
                         Log::logger->log(Log::ERR, "Couldn't commit output {} in ensureVRR -> false", m->m_output->name);
                 }
                 m->m_vrrActive = false;

--- a/src/debug/Overlay.cpp
+++ b/src/debug/Overlay.cpp
@@ -107,6 +107,10 @@ UP<COverlay>& Debug::overlay() {
 
 COverlay::COverlay() {
     m_frameTimer.reset();
+    m_renderStart        = std::chrono::high_resolution_clock::now();
+    m_renderEnd          = std::chrono::high_resolution_clock::now();
+    m_renderStartOverlay = std::chrono::high_resolution_clock::now();
+    m_endRenderOverlay   = std::chrono::high_resolution_clock::now();
 }
 
 void CMonitorOverlay::renderData(PHLMONITOR pMonitor, float durationUs) {
@@ -342,6 +346,45 @@ void COverlay::renderDataNoOverlay(PHLMONITOR pMonitor, float durationUs) {
         return;
 
     m_monitorOverlays[pMonitor].renderDataNoOverlay(pMonitor, durationUs);
+}
+
+void COverlay::renderStart(PHLMONITOR pMonitor) {
+    static auto PDEBUGOVERLAY = CConfigValue<Config::INTEGER>("debug:overlay");
+
+    if (!*PDEBUGOVERLAY)
+        return;
+
+    m_renderStart = std::chrono::high_resolution_clock::now();
+    frameData(pMonitor);
+}
+
+void COverlay::renderOverlay(PHLMONITOR pMonitor) {
+    static auto PDEBUGOVERLAY = CConfigValue<Config::INTEGER>("debug:overlay");
+
+    if (!*PDEBUGOVERLAY)
+        return;
+
+    if (!State::monitorState()->monitors().empty() && pMonitor == State::monitorState()->monitors().front()) {
+        m_renderStartOverlay = std::chrono::high_resolution_clock::now();
+        Debug::overlay()->draw();
+        m_endRenderOverlay = std::chrono::high_resolution_clock::now();
+    }
+}
+
+void COverlay::renderEnd(PHLMONITOR pMonitor) {
+    static auto PDEBUGOVERLAY = CConfigValue<Config::INTEGER>("debug:overlay");
+
+    if (!*PDEBUGOVERLAY)
+        return;
+
+    const float durationUs = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - m_renderStart).count() / 1000.f;
+    Debug::overlay()->renderData(pMonitor, durationUs);
+
+    if (pMonitor == State::monitorState()->monitors().front()) {
+        const float noOverlayUs = durationUs - std::chrono::duration_cast<std::chrono::nanoseconds>(m_endRenderOverlay - m_renderStartOverlay).count() / 1000.f;
+        Debug::overlay()->renderDataNoOverlay(pMonitor, noOverlayUs);
+    } else
+        Debug::overlay()->renderDataNoOverlay(pMonitor, durationUs);
 }
 
 void COverlay::frameData(PHLMONITOR pMonitor) {

--- a/src/debug/Overlay.cpp
+++ b/src/debug/Overlay.cpp
@@ -541,7 +541,11 @@ void COverlay::draw() {
     }
 
     if (m_frameTimer.getMillis() >= OVERLAY_REFRESH_INTERVAL_MS) {
-        PMONITOR->scheduleFrame();
+        if (m_lastDrawnBox.width > 0 && m_lastDrawnBox.height > 0)
+            g_pHyprRenderer->damageBox(m_lastDrawnBox);
+        else
+            PMONITOR->scheduleFrame();
+
         m_frameTimer.reset();
     }
 }

--- a/src/debug/Overlay.hpp
+++ b/src/debug/Overlay.hpp
@@ -69,16 +69,23 @@ namespace Debug {
         void draw();
         void renderData(PHLMONITOR, float durationUs);
         void renderDataNoOverlay(PHLMONITOR, float durationUs);
+        void renderStart(PHLMONITOR pMonitor);
+        void renderOverlay(PHLMONITOR pMonitor);
+        void renderEnd(PHLMONITOR pMonitor);
         void frameData(PHLMONITOR);
 
       private:
-        std::map<PHLMONITORREF, CMonitorOverlay> m_monitorOverlays;
-        CBox                                     m_lastDrawnBox;
-        CTimer                                   m_frameTimer;
+        std::map<PHLMONITORREF, CMonitorOverlay>       m_monitorOverlays;
+        CBox                                           m_lastDrawnBox;
+        CTimer                                         m_frameTimer;
+        std::chrono::high_resolution_clock::time_point m_renderStart;
+        std::chrono::high_resolution_clock::time_point m_renderEnd;
+        std::chrono::high_resolution_clock::time_point m_renderStartOverlay;
+        std::chrono::high_resolution_clock::time_point m_endRenderOverlay;
 
-        void                                     createWarningTexture(float maxW);
-        SP<Render::ITexture>                     m_warningTexture;
-        float                                    m_warningTextureMaxW = 0;
+        void                                           createWarningTexture(float maxW);
+        SP<Render::ITexture>                           m_warningTexture;
+        float                                          m_warningTextureMaxW = 0;
 
         friend class CHyprMonitorDebugOverlay;
         friend class Render::IHyprRenderer;

--- a/src/desktop/view/Window.cpp
+++ b/src/desktop/view/Window.cpp
@@ -2793,8 +2793,7 @@ void CWindow::commitWindow() {
     }
 
     // tearing: if solitary, redraw it. This still might be a single surface window
-    if (PMONITOR && PMONITOR->m_solitaryClient.lock() == m_self.lock() && canBeTorn() && PMONITOR->m_tearingState.canTear && wlSurface()->resource()->m_current.texture &&
-        !PMONITOR->isTearingBlocked()) {
+    if (PMONITOR && PMONITOR->m_solitaryClient.lock() == m_self.lock() && canBeTorn() && PMONITOR->m_tearingState.canTear && wlSurface()->resource()->m_current.texture) {
         CRegion damageBox{wlSurface()->resource()->m_current.accumulateBufferDamage()};
 
         if (!damageBox.empty()) {

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -2673,14 +2673,10 @@ bool CMonitorState::commit(bool updateSwapChain) {
             return false;
     }
 
-    if (m_owner->m_output->pendingPageFlip()) {
-        // cant commit this, this will early return in AQ anyways. next renderMonitor or frame will pick it up.
-        return false;
-    }
-
     Event::bus()->m_events.monitor.preCommit.emit(m_owner->m_self.lock());
 
-    if (updateSwapChain)
+    // a modeset needs a buffer matching the new mode
+    if (updateSwapChain || m_owner->m_output->state->needsReconfig())
         ensureBufferPresent();
 
     bool ret = m_owner->m_output->commit();

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -267,7 +267,7 @@ void CMonitor::onConnect(bool noRule) {
 
         m_output->state->resetExplicitFences();
         m_output->state->setEnabled(true);
-        m_state.commit();
+        m_state.commit(false);
         return;
     }
 
@@ -278,7 +278,7 @@ void CMonitor::onConnect(bool noRule) {
         m_output->state->setEnabled(false);
         m_usedAsyncBuffers.clear();
 
-        if (!m_state.commit())
+        if (!m_state.commit(false))
             Log::logger->log(Log::ERR, "Couldn't commit disabled state on output {}", m_name);
 
         m_enabled = false;
@@ -311,7 +311,7 @@ void CMonitor::onConnect(bool noRule) {
         applyMonitorRule(std::move(cpy));
     }
 
-    if (!m_state.commit())
+    if (!m_state.commit(false))
         Log::logger->log(Log::WARN, "state.commit() failed in CMonitor::onCommit");
 
     m_damage.setSize(m_transformedSize);
@@ -499,7 +499,7 @@ void CMonitor::onDisconnect(bool destroy) {
         m_output->state->setAdaptiveSync(false);
         m_output->state->setEnabled(false);
 
-        if (!m_state.commit())
+        if (!m_state.commit(false))
             Log::logger->log(Log::WARN, "state.commit() failed in CMonitor::onDisconnect");
     }
 
@@ -736,7 +736,7 @@ bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule) {
 
         m_activeMonitorRule = std::move(pMonitorRule);
 
-        if (!m_state.commit())
+        if (!m_state.commit(false))
             Log::logger->log(Log::WARN, "state.commit() failed in CMonitor::applyMonitorRule");
 
         m_events.modeChanged.emit();
@@ -1053,7 +1053,7 @@ bool CMonitor::applyMonitorRule(Config::CMonitorRule&& pMonitorRule) {
 
     m_output->scheduleFrame();
 
-    if (!m_state.commit())
+    if (!m_state.commit(false))
         Log::logger->log(Log::ERR, "Couldn't commit output named {}", m_name);
 
     Vector2D xfmd     = m_transform % 2 == 1 ? Vector2D{m_pixelSize.y, m_pixelSize.x} : m_pixelSize;
@@ -2129,7 +2129,7 @@ bool CMonitor::attemptDirectScanout() {
                 return false;
             }
 
-            if (!m_output->commit()) {
+            if (!m_state.commit(false)) {
                 Log::logger->log(Log::TRACE, "attemptDirectScanout: failed to commit cursor update");
                 m_lastScanout.reset();
                 return false;
@@ -2208,7 +2208,7 @@ bool CMonitor::attemptDirectScanout() {
 
     // no need to do explicit sync here as surface current can only ever be ready to read
 
-    bool ok = m_output->commit();
+    bool ok = m_state.commit(false);
 
     if (!ok) {
         Log::logger->log(Log::TRACE, "attemptDirectScanout: failed to scanout surface");
@@ -2353,7 +2353,7 @@ void CMonitor::commitDPMSState(bool state) {
     if (!state)
         m_usedAsyncBuffers.clear();
 
-    if (!m_state.commit()) {
+    if (!m_state.commit(false)) {
         Log::logger->log(Log::ERR, "Couldn't commit output {} for DPMS = {}, will retry.", m_name, state);
 
         // retry in 2 frames. This could happen when the DRM backend rejects our commit
@@ -2367,10 +2367,11 @@ void CMonitor::commitDPMSState(bool state) {
 
                 m_output->state->resetExplicitFences();
                 m_output->state->setEnabled(m_dpmsStatus);
+
                 if (!m_dpmsStatus)
                     m_usedAsyncBuffers.clear();
 
-                if (!m_state.commit()) {
+                if (!m_state.commit(false)) {
                     Log::logger->log(Log::ERR, "Couldn't retry committing output {} for DPMS = {}", m_name, m_dpmsStatus);
                     return;
                 }
@@ -2666,13 +2667,21 @@ void CMonitorState::ensureBufferPresent() {
     m_owner->m_output->swapchain->rollback(); // restore the counter, don't advance the swapchain
 }
 
-bool CMonitorState::commit() {
-    if (!updateSwapchain())
+bool CMonitorState::commit(bool updateSwapChain) {
+    if (updateSwapChain) {
+        if (!updateSwapchain())
+            return false;
+    }
+
+    if (m_owner->m_output->pendingPageFlip()) {
+        // cant commit this, this will early return in AQ anyways. next renderMonitor or frame will pick it up.
         return false;
+    }
 
     Event::bus()->m_events.monitor.preCommit.emit(m_owner->m_self.lock());
 
-    ensureBufferPresent();
+    if (updateSwapChain)
+        ensureBufferPresent();
 
     bool ret = m_owner->m_output->commit();
     return ret;

--- a/src/output/Monitor.cpp
+++ b/src/output/Monitor.cpp
@@ -2353,7 +2353,8 @@ void CMonitor::commitDPMSState(bool state) {
     if (!state)
         m_usedAsyncBuffers.clear();
 
-    if (!m_state.commit(false)) {
+    // re-enabling needs a configured swapchain, the backend may have cleared it while we were off
+    if (!m_state.commit(state)) {
         Log::logger->log(Log::ERR, "Couldn't commit output {} for DPMS = {}, will retry.", m_name, state);
 
         // retry in 2 frames. This could happen when the DRM backend rejects our commit
@@ -2371,7 +2372,7 @@ void CMonitor::commitDPMSState(bool state) {
                 if (!m_dpmsStatus)
                     m_usedAsyncBuffers.clear();
 
-                if (!m_state.commit(false)) {
+                if (!m_state.commit(m_dpmsStatus)) {
                     Log::logger->log(Log::ERR, "Couldn't retry committing output {} for DPMS = {}", m_name, m_dpmsStatus);
                     return;
                 }

--- a/src/output/Monitor.hpp
+++ b/src/output/Monitor.hpp
@@ -47,7 +47,7 @@ namespace Monitor {
         CMonitorState(CMonitor* owner);
         ~CMonitorState() = default;
 
-        bool commit();
+        bool commit(bool updateSwapChain);
         bool test();
         bool updateSwapchain();
         void applyModeWithSwapchain(const SP<Aquamarine::SOutputMode>& mode);

--- a/src/output/MonitorFrameScheduler.cpp
+++ b/src/output/MonitorFrameScheduler.cpp
@@ -72,7 +72,7 @@ void CMonitorFrameScheduler::onPresented() {
 
         auto ml = m.lock();
 
-        g_pHyprRenderer->commitPendingAndDoExplicitSync(ml); // commit the pending frame. If it didn't fire yet (is not rendered) it doesn't matter. Syncs will wait.
+        g_pHyprRenderer->commitPendingAndDoExplicitSync(ml, true); // commit the pending frame. If it didn't fire yet (is not rendered) it doesn't matter. Syncs will wait.
 
         // schedule a frame: we might have some missed damage, which got cleared due to the above commit.
         // TODO: this is not always necessary, but doesn't hurt in general. We likely won't hit this if nothing's happening anyways.

--- a/src/pointer/PointerManager.cpp
+++ b/src/pointer/PointerManager.cpp
@@ -646,8 +646,7 @@ void CPointerManager::renderSoftwareCursorsFor(PHLMONITOR pMonitor, const Time::
     auto state = stateFor(pMonitor);
 
     if (!state->hardwareFailed && state->softwareLocks == 0 && !screencopy) {
-        if (m_currentCursorImage.surface)
-            m_currentCursorImage.surface->resource()->frame(now);
+        sendCursorSurfaceFrame(now);
         return;
     }
 
@@ -690,6 +689,10 @@ void CPointerManager::renderSoftwareCursorsFor(PHLMONITOR pMonitor, const Time::
         state->swRenderedBox = logicalBox;
     }
 
+    sendCursorSurfaceFrame(now);
+}
+
+void CPointerManager::sendCursorSurfaceFrame(const Time::steady_tp& now) {
     if (m_currentCursorImage.surface)
         m_currentCursorImage.surface->resource()->frame(now);
 }

--- a/src/pointer/PointerManager.hpp
+++ b/src/pointer/PointerManager.hpp
@@ -57,6 +57,7 @@ namespace Pointer {
 
         void renderSoftwareCursorsFor(PHLMONITOR pMonitor, const Time::steady_tp& now, CRegion& damage /* logical */, std::optional<Vector2D> overridePos = {} /* monitor-local */,
                                       bool screencopy = false, bool forceRender = false);
+        void sendCursorSurfaceFrame(const Time::steady_tp& now);
 
         // this is needed e.g. during screensharing where
         // the software cursors aren't locked during the cursor move, but they

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2089,13 +2089,9 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     if (Animation::mgr())
         Animation::mgr()->frameTick();
 
-    {
-        static bool once = true;
-        if (once) {
-            Event::bus()->m_events.start.emit();
-            once = false;
-        }
-    }
+    static bool firstFrame = true;
+    if (std::exchange(firstFrame, false))
+        Event::bus()->m_events.start.emit();
 
     if (pMonitor->m_scheduledRecalc) {
         pMonitor->m_scheduledRecalc = false;

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2016,6 +2016,29 @@ void IHyprRenderer::renderMirrored() {
     m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
 }
 
+void IHyprRenderer::applyCursorZoom(PHLMONITOR pMonitor, SRenderData& data) {
+    static bool zoomLock   = false;
+    const float ZOOMFACTOR = pMonitor->m_cursorZoom->value();
+
+    if (zoomLock && ZOOMFACTOR == 1.f) {
+        Pointer::mgr()->unlockSoftwareAll();
+        zoomLock = false;
+    } else if (!zoomLock && ZOOMFACTOR != 1.f) {
+        Pointer::mgr()->lockSoftwareAll();
+        zoomLock = true;
+    }
+
+    m_renderData.mouseZoomFactor = 1.f;
+    if (ZOOMFACTOR != 1.f && pMonitor == State::monitorState()->query().vec(Pointer::mgr()->position()).run())
+        m_renderData.mouseZoomFactor = std::clamp(ZOOMFACTOR, 1.f, INFINITY);
+
+    if (pMonitor->m_zoomAnimProgress->value() != 1) {
+        m_renderData.mouseZoomFactor    = 2.0 - pMonitor->m_zoomAnimProgress->value(); // 2x zoom -> 1x zoom
+        m_renderData.mouseZoomUseMouse  = false;
+        m_renderData.useNearestNeighbor = false;
+    }
+}
+
 bool IHyprRenderer::renderDirectScanout(PHLMONITOR pMonitor) {
     const bool canAttemptDirectScanout = pMonitor->canAttemptDirectScanoutFast();
 
@@ -2047,8 +2070,6 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     static auto PVFR                = CConfigValue<Config::INTEGER>("debug:vfr");
 
     static int  damageBlinkCleanup = 0; // because double-buffered
-
-    const float ZOOMFACTOR = pMonitor->m_cursorZoom->value();
 
     if (pMonitor->m_pixelSize.x < 1 || pMonitor->m_pixelSize.y < 1) {
         Log::logger->log(Log::ERR, "Refusing to render a monitor because of an invalid pixel size: {}", pMonitor->m_pixelSize);
@@ -2117,24 +2138,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     TRACY_GPU_ZONE("Render");
 
-    static bool zoomLock = false;
-    if (zoomLock && ZOOMFACTOR == 1.f) {
-        Pointer::mgr()->unlockSoftwareAll();
-        zoomLock = false;
-    } else if (!zoomLock && ZOOMFACTOR != 1.f) {
-        Pointer::mgr()->lockSoftwareAll();
-        zoomLock = true;
-    }
-
-    m_renderData.mouseZoomFactor = 1.f;
-    if (ZOOMFACTOR != 1.f && pMonitor == State::monitorState()->query().vec(Pointer::mgr()->position()).run())
-        m_renderData.mouseZoomFactor = std::clamp(ZOOMFACTOR, 1.f, INFINITY);
-
-    if (pMonitor->m_zoomAnimProgress->value() != 1) {
-        m_renderData.mouseZoomFactor    = 2.0 - pMonitor->m_zoomAnimProgress->value(); // 2x zoom -> 1x zoom
-        m_renderData.mouseZoomUseMouse  = false;
-        m_renderData.useNearestNeighbor = false;
-    }
+    applyCursorZoom(pMonitor, m_renderData);
 
     CRegion damage, finalDamage;
     if (!beginRender(pMonitor, damage, RENDER_MODE_NORMAL)) {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2064,6 +2064,14 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     if (!pMonitor)
         return;
 
+    if (pMonitor->m_pixelSize.x < 1 || pMonitor->m_pixelSize.y < 1) {
+        Log::logger->log(Log::ERR, "Refusing to render a monitor because of an invalid pixel size: {}", pMonitor->m_pixelSize);
+        return;
+    }
+
+    if (!g_pCompositor->m_sessionActive)
+        return;
+
     static auto PDAMAGETRACKINGMODE = CConfigValue<Config::INTEGER>("debug:damage_tracking");
     static auto PDAMAGEBLINK        = CConfigValue<Config::INTEGER>("debug:damage_blink");
     static auto PSOLDAMAGE          = CConfigValue<Config::INTEGER>("debug:render_solitary_wo_damage");
@@ -2071,18 +2079,10 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     static int  damageBlinkCleanup = 0; // because double-buffered
 
-    if (pMonitor->m_pixelSize.x < 1 || pMonitor->m_pixelSize.y < 1) {
-        Log::logger->log(Log::ERR, "Refusing to render a monitor because of an invalid pixel size: {}", pMonitor->m_pixelSize);
-        return;
-    }
-
     if (!*PDAMAGEBLINK)
         damageBlinkCleanup = 0;
 
     Debug::overlay()->renderStart(pMonitor);
-
-    if (!g_pCompositor->m_sessionActive)
-        return;
 
     Event::bus()->m_events.render.preChecks.emit(pMonitor);
 
@@ -2111,15 +2111,8 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     Event::bus()->m_events.render.pre.emit(pMonitor);
 
-    const auto NOW = Time::steadyNow();
-
     if (!shouldRenderMonitor(pMonitor) && damageBlinkCleanup == 0)
         return;
-
-    if (*PDAMAGETRACKINGMODE == -1) {
-        Log::logger->log(Log::CRIT, "Damage tracking mode -1 ????");
-        return;
-    }
 
     Event::bus()->m_events.render.stage.emit(RENDER_PRE);
 
@@ -2159,7 +2152,8 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     Event::bus()->m_events.render.stage.emit(RENDER_BEGIN);
 
-    bool renderCursor = true;
+    bool       renderCursor = true;
+    const auto NOW          = Time::steadyNow();
 
     if (pMonitor->m_solitaryClient && (!finalDamage.empty() || *PSOLDAMAGE))
         renderWindow(pMonitor->m_solitaryClient.lock(), pMonitor, NOW, false, RENDER_PASS_MAIN /* solitary = no popups */);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2019,32 +2019,28 @@ void IHyprRenderer::renderMirrored() {
 void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     if (!pMonitor)
         return;
-    static std::chrono::high_resolution_clock::time_point renderStart        = std::chrono::high_resolution_clock::now();
-    static std::chrono::high_resolution_clock::time_point renderStartOverlay = std::chrono::high_resolution_clock::now();
-    static std::chrono::high_resolution_clock::time_point endRenderOverlay   = std::chrono::high_resolution_clock::now();
 
-    static auto                                           PDEBUGOVERLAY       = CConfigValue<Config::INTEGER>("debug:overlay");
-    static auto                                           PDAMAGETRACKINGMODE = CConfigValue<Config::INTEGER>("debug:damage_tracking");
-    static auto                                           PDAMAGEBLINK        = CConfigValue<Config::INTEGER>("debug:damage_blink");
-    static auto                                           PSOLDAMAGE          = CConfigValue<Config::INTEGER>("debug:render_solitary_wo_damage");
-    static auto                                           PVFR                = CConfigValue<Config::INTEGER>("debug:vfr");
+    static auto PDAMAGETRACKINGMODE = CConfigValue<Config::INTEGER>("debug:damage_tracking");
+    static auto PDAMAGEBLINK        = CConfigValue<Config::INTEGER>("debug:damage_blink");
+    static auto PSOLDAMAGE          = CConfigValue<Config::INTEGER>("debug:render_solitary_wo_damage");
+    static auto PVFR                = CConfigValue<Config::INTEGER>("debug:vfr");
 
-    static int                                            damageBlinkCleanup = 0; // because double-buffered
+    static int  damageBlinkCleanup = 0; // because double-buffered
 
-    const float                                           ZOOMFACTOR = pMonitor->m_cursorZoom->value();
+    const float ZOOMFACTOR = pMonitor->m_cursorZoom->value();
 
     if (pMonitor->m_pixelSize.x < 1 || pMonitor->m_pixelSize.y < 1) {
         Log::logger->log(Log::ERR, "Refusing to render a monitor because of an invalid pixel size: {}", pMonitor->m_pixelSize);
         return;
     }
 
+    if (!g_pCompositor->m_sessionActive)
+        return;
+
     if (!*PDAMAGEBLINK)
         damageBlinkCleanup = 0;
 
-    if (*PDEBUGOVERLAY == 1) {
-        renderStart = std::chrono::high_resolution_clock::now();
-        Debug::overlay()->frameData(pMonitor);
-    }
+    Debug::overlay()->renderStart(pMonitor);
 
     if (!g_pCompositor->m_sessionActive)
         return;
@@ -2184,11 +2180,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
             }
 
             // for drawing the debug overlay
-            if (!State::monitorState()->monitors().empty() && pMonitor == State::monitorState()->monitors().front() && *PDEBUGOVERLAY == 1) {
-                renderStartOverlay = std::chrono::high_resolution_clock::now();
-                Debug::overlay()->draw();
-                endRenderOverlay = std::chrono::high_resolution_clock::now();
-            }
+            Debug::overlay()->renderOverlay(pMonitor);
 
             if (*PDAMAGEBLINK && damageBlinkCleanup == 0) {
                 CRectPassElement::SRectData data;
@@ -2268,16 +2260,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     pMonitor->m_pendingFrame = false;
 
-    if (*PDEBUGOVERLAY == 1) {
-        const float durationUs = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::high_resolution_clock::now() - renderStart).count() / 1000.f;
-        Debug::overlay()->renderData(pMonitor, durationUs);
-
-        if (pMonitor == State::monitorState()->monitors().front()) {
-            const float noOverlayUs = durationUs - std::chrono::duration_cast<std::chrono::nanoseconds>(endRenderOverlay - renderStartOverlay).count() / 1000.f;
-            Debug::overlay()->renderDataNoOverlay(pMonitor, noOverlayUs);
-        } else
-            Debug::overlay()->renderDataNoOverlay(pMonitor, durationUs);
-    }
+    Debug::overlay()->renderEnd(pMonitor);
 }
 
 static const hdr_output_metadata NO_HDR_METADATA = {.hdmi_metadata_type1 = hdr_metadata_infoframe{.eotf = 0}};

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2074,6 +2074,28 @@ bool IHyprRenderer::renderDirectScanout(PHLMONITOR pMonitor) {
     return false;
 }
 
+// if the monitor image actually needs to be redrawn. If it doesnt, the buffer currently
+// being scanned out is still a correct picture of the monitor, and there is no point in acquiring
+// a new swapchain buffer and running a render pass over it.
+static bool monitorNeedsRedraw(PHLMONITOR pMonitor, int damageBlinkCleanup) {
+    static auto PDAMAGETRACKINGMODE = CConfigValue<Config::INTEGER>("debug:damage_tracking");
+    static auto PSOLDAMAGE          = CConfigValue<Config::INTEGER>("debug:render_solitary_wo_damage");
+
+    // these all redraw the entire monitor every frame by definition
+    if (*PDAMAGETRACKINGMODE != DAMAGE_TRACKING_FULL || pMonitor->m_forceFullFrames > 0 || damageBlinkCleanup > 0)
+        return true;
+
+    if (pMonitor->m_damage.hasChanged())
+        return true;
+
+    if (pMonitor->m_solitaryClient && *PSOLDAMAGE)
+        return true;
+
+    // mirrors and screenshare consumers read the mirror FB, which is only refreshed as a side
+    // effect of rendering, so keep rendering while it's stale.
+    return pMonitor->needsACopyFB() && !pMonitor->resources()->pendingMirrorFBDamage().empty();
+}
+
 void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     if (!pMonitor)
         return;
@@ -2089,7 +2111,6 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     static auto PDAMAGETRACKINGMODE = CConfigValue<Config::INTEGER>("debug:damage_tracking");
     static auto PDAMAGEBLINK        = CConfigValue<Config::INTEGER>("debug:damage_blink");
     static auto PSOLDAMAGE          = CConfigValue<Config::INTEGER>("debug:render_solitary_wo_damage");
-    static auto PVFR                = CConfigValue<Config::INTEGER>("debug:vfr");
 
     static int  damageBlinkCleanup = 0; // because double-buffered
 
@@ -2125,12 +2146,29 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     Event::bus()->m_events.render.pre.emit(pMonitor);
 
-    if (!shouldRenderMonitor(pMonitor) && damageBlinkCleanup == 0)
+    pMonitor->m_renderingActive = true;
+
+    // a frame was scheduled, but nothing on this monitor changed, a hw cursor plane update, a
+    // client that only wants frame events, a bare scheduleFrame(). the scanned out buffer is still
+    // correct, so push the pending output state without rendering anything.
+    if (!monitorNeedsRedraw(pMonitor, damageBlinkCleanup)) {
+        const auto NOW = Time::steadyNow();
+
+        if (!pMonitor->isMirror()) {
+            if (pMonitor->m_activeWorkspace)
+                sendFrameEventsToWorkspace(pMonitor, pMonitor->m_activeWorkspace, NOW);
+            if (pMonitor->m_activeSpecialWorkspace)
+                sendFrameEventsToWorkspace(pMonitor, pMonitor->m_activeSpecialWorkspace, NOW);
+        }
+
+        // an animated hw cursor keeps animating off its own frame callback
+        Pointer::mgr()->sendCursorSurfaceFrame(NOW);
+
+        endRenderMonitor(pMonitor, commit, shouldTear);
         return;
+    }
 
     Event::bus()->m_events.render.stage.emit(RENDER_PRE);
-
-    pMonitor->m_renderingActive = true;
 
     // Most frames have no fading-out windows or layers for this monitor.
     if (!Desktop::fadingOutState()->fadeouts().empty())
@@ -2146,6 +2184,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     CRegion damage, finalDamage;
     if (!beginRender(pMonitor, damage, RENDER_MODE_NORMAL)) {
         Log::logger->log(Log::ERR, "renderer: couldn't beginRender()!");
+        pMonitor->m_renderingActive = false;
         return;
     }
 
@@ -2245,6 +2284,14 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     Event::bus()->m_events.render.stage.emit(RENDER_POST);
 
     pMonitor->m_output->state->addDamage(frameDamage);
+
+    endRenderMonitor(pMonitor, commit, shouldTear);
+}
+
+void IHyprRenderer::endRenderMonitor(PHLMONITOR pMonitor, bool commit, bool shouldTear) {
+    static auto PDAMAGEBLINK = CConfigValue<Config::INTEGER>("debug:damage_blink");
+    static auto PVFR         = CConfigValue<Config::INTEGER>("debug:vfr");
+
     auto presentationMode = shouldTear ? Aquamarine::eOutputPresentationMode::AQ_OUTPUT_PRESENTATION_IMMEDIATE : Aquamarine::eOutputPresentationMode::AQ_OUTPUT_PRESENTATION_VSYNC;
     if (pMonitor->m_output->state->state().presentationMode != presentationMode)
         pMonitor->m_output->state->setPresentationMode(presentationMode);

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2151,6 +2151,7 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     // a frame was scheduled, but nothing on this monitor changed, a hw cursor plane update, a
     // client that only wants frame events, a bare scheduleFrame(). the scanned out buffer is still
     // correct, so push the pending output state without rendering anything.
+    bool updateSwapChain = false;
     if (!monitorNeedsRedraw(pMonitor, damageBlinkCleanup)) {
         const auto NOW = Time::steadyNow();
 
@@ -2164,9 +2165,12 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
         // an animated hw cursor keeps animating off its own frame callback
         Pointer::mgr()->sendCursorSurfaceFrame(NOW);
 
-        endRenderMonitor(pMonitor, commit, shouldTear);
+        pMonitor->output()->state->resetExplicitFences();
+        pMonitor->m_inFence.reset();
+        endRenderMonitor(pMonitor, commit, shouldTear, updateSwapChain);
         return;
-    }
+    } else
+        updateSwapChain = true;
 
     Event::bus()->m_events.render.stage.emit(RENDER_PRE);
 
@@ -2285,10 +2289,10 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
 
     pMonitor->m_output->state->addDamage(frameDamage);
 
-    endRenderMonitor(pMonitor, commit, shouldTear);
+    endRenderMonitor(pMonitor, commit, shouldTear, updateSwapChain);
 }
 
-void IHyprRenderer::endRenderMonitor(PHLMONITOR pMonitor, bool commit, bool shouldTear) {
+void IHyprRenderer::endRenderMonitor(PHLMONITOR pMonitor, bool commit, bool shouldTear, bool updateSwapChain) {
     static auto PDAMAGEBLINK = CConfigValue<Config::INTEGER>("debug:damage_blink");
     static auto PVFR         = CConfigValue<Config::INTEGER>("debug:vfr");
 
@@ -2297,7 +2301,7 @@ void IHyprRenderer::endRenderMonitor(PHLMONITOR pMonitor, bool commit, bool shou
         pMonitor->m_output->state->setPresentationMode(presentationMode);
 
     if (commit)
-        commitPendingAndDoExplicitSync(pMonitor);
+        commitPendingAndDoExplicitSync(pMonitor, updateSwapChain);
 
     // cleared only after the commit
     pMonitor->m_renderingActive = false;
@@ -2503,15 +2507,15 @@ void IHyprRenderer::handleFullscreenSettings(PHLMONITOR pMonitor) {
     pMonitor->m_previousFSWindow = FULLSCREEN_WINDOW;
 }
 
-bool IHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor) {
+bool IHyprRenderer::commitPendingAndDoExplicitSync(PHLMONITOR pMonitor, bool updateSwapChain) {
     handleFullscreenSettings(pMonitor);
 
-    bool ok = pMonitor->m_state.commit();
+    bool ok = pMonitor->m_state.commit(updateSwapChain);
     if (!ok) {
         if (pMonitor->m_inFence.isValid()) {
             Log::logger->log(Log::TRACE, "Monitor state commit failed, retrying without a fence");
             pMonitor->m_output->state->resetExplicitFences();
-            ok = pMonitor->m_state.commit();
+            ok = pMonitor->m_state.commit(updateSwapChain);
         }
 
         if (!ok) {

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2016,6 +2016,27 @@ void IHyprRenderer::renderMirrored() {
     m_renderPass.add(makeUnique<CTexPassElement>(std::move(data)));
 }
 
+bool IHyprRenderer::renderDirectScanout(PHLMONITOR pMonitor) {
+    const bool canAttemptDirectScanout = pMonitor->canAttemptDirectScanoutFast();
+
+    if (canAttemptDirectScanout) {
+        if (pMonitor->attemptDirectScanout()) {
+            if (!pMonitor->needsACopyFB())
+                pMonitor->resources()->markMirrorFBStale();
+
+            if (!pMonitor->m_directScanoutIsActive) {
+                pMonitor->m_previousFSWindow.reset(); // recalc fs settings
+                pMonitor->m_directScanoutIsActive = true;
+            }
+            handleFullscreenSettings(pMonitor);
+            return true;
+        } else if (!pMonitor->m_lastScanout.expired() || pMonitor->m_directScanoutIsActive)
+            pMonitor->handleDSleave();
+    }
+
+    return false;
+}
+
 void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
     if (!pMonitor)
         return;
@@ -2033,9 +2054,6 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
         Log::logger->log(Log::ERR, "Refusing to render a monitor because of an invalid pixel size: {}", pMonitor->m_pixelSize);
         return;
     }
-
-    if (!g_pCompositor->m_sessionActive)
-        return;
 
     if (!*PDAMAGEBLINK)
         damageBlinkCleanup = 0;
@@ -2070,23 +2088,9 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
         return;
 
     // tearing and DS first
-    bool       shouldTear              = pMonitor->updateTearing();
-    const bool canAttemptDirectScanout = pMonitor->canAttemptDirectScanoutFast();
-
-    if (canAttemptDirectScanout) {
-        if (pMonitor->attemptDirectScanout()) {
-            if (!pMonitor->needsACopyFB())
-                pMonitor->resources()->markMirrorFBStale();
-
-            if (!pMonitor->m_directScanoutIsActive) {
-                pMonitor->m_previousFSWindow.reset(); // recalc fs settings
-                pMonitor->m_directScanoutIsActive = true;
-            }
-            handleFullscreenSettings(pMonitor);
-            return;
-        } else if (!pMonitor->m_lastScanout.expired() || pMonitor->m_directScanoutIsActive)
-            pMonitor->handleDSleave();
-    }
+    bool shouldTear = pMonitor->updateTearing();
+    if (renderDirectScanout(pMonitor))
+        return;
 
     Event::bus()->m_events.render.pre.emit(pMonitor);
 

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -2039,6 +2039,20 @@ void IHyprRenderer::applyCursorZoom(PHLMONITOR pMonitor, SRenderData& data) {
     }
 }
 
+void IHyprRenderer::renderDamageBlink(PHLMONITOR pMonitor, int& damageBlinkCleanup) {
+    if (damageBlinkCleanup == 0) {
+        CRectPassElement::SRectData data;
+        data.box   = {0, 0, pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y};
+        data.color = CHyprColor(1.0, 0.0, 1.0, 100.0 / 255.0);
+        m_renderPass.add(makeUnique<CRectPassElement>(data));
+        damageBlinkCleanup = 1;
+    } else {
+        damageBlinkCleanup++;
+        if (damageBlinkCleanup > 3)
+            damageBlinkCleanup = 0;
+    }
+}
+
 bool IHyprRenderer::renderDirectScanout(PHLMONITOR pMonitor) {
     const bool canAttemptDirectScanout = pMonitor->canAttemptDirectScanoutFast();
 
@@ -2180,17 +2194,8 @@ void IHyprRenderer::renderMonitor(PHLMONITOR pMonitor, bool commit) {
             // for drawing the debug overlay
             Debug::overlay()->renderOverlay(pMonitor);
 
-            if (*PDAMAGEBLINK && damageBlinkCleanup == 0) {
-                CRectPassElement::SRectData data;
-                data.box   = {0, 0, pMonitor->m_transformedSize.x, pMonitor->m_transformedSize.y};
-                data.color = CHyprColor(1.0, 0.0, 1.0, 100.0 / 255.0);
-                m_renderPass.add(makeUnique<CRectPassElement>(data));
-                damageBlinkCleanup = 1;
-            } else if (*PDAMAGEBLINK) {
-                damageBlinkCleanup++;
-                if (damageBlinkCleanup > 3)
-                    damageBlinkCleanup = 0;
-            }
+            if (*PDAMAGEBLINK)
+                renderDamageBlink(pMonitor, damageBlinkCleanup);
         }
     } else if (!pMonitor->isMirror()) {
         if (pMonitor->m_activeWorkspace)

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -72,6 +72,7 @@ namespace Render {
         WP<Render::GL::CHyprOpenGLImpl>     glBackend();
 
         void                                applyCursorZoom(PHLMONITOR pMonitor, SRenderData& data);
+        void                                renderDamageBlink(PHLMONITOR pMonitor, int& damageBlinkCleanup);
         bool                                renderDirectScanout(PHLMONITOR pMonitor);
         void                                renderMonitor(PHLMONITOR pMonitor, bool commit = true);
         void                                arrangeLayersForMonitor(const MONITORID&);

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -71,6 +71,7 @@ namespace Render {
         virtual eType                       type() = 0;
         WP<Render::GL::CHyprOpenGLImpl>     glBackend();
 
+        bool                                renderDirectScanout(PHLMONITOR pMonitor);
         void                                renderMonitor(PHLMONITOR pMonitor, bool commit = true);
         void                                arrangeLayersForMonitor(const MONITORID&);
         void                                damageSurface(SP<CWLSurfaceResource>, double, double, double scale = 1.0);

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -75,7 +75,7 @@ namespace Render {
         void                                renderDamageBlink(PHLMONITOR pMonitor, int& damageBlinkCleanup);
         bool                                renderDirectScanout(PHLMONITOR pMonitor);
         void                                renderMonitor(PHLMONITOR pMonitor, bool commit = true);
-        void                                endRenderMonitor(PHLMONITOR pMonitor, bool commit, bool shouldTear);
+        void                                endRenderMonitor(PHLMONITOR pMonitor, bool commit, bool shouldTear, bool updateSwapChain);
         void                                arrangeLayersForMonitor(const MONITORID&);
         void                                damageSurface(SP<CWLSurfaceResource>, double, double, double scale = 1.0);
         void                                damageWindow(PHLWINDOW, bool forceFull = false);
@@ -147,28 +147,28 @@ namespace Render {
                                      const int maxHeight = 1024);
         CHyprColor      getConvertedColor(const CHyprColor& color);
 
-        virtual SP<IRenderbuffer>    getOrCreateRenderbuffer(SP<Aquamarine::IBuffer> buffer,
-                                                             uint32_t                fmt); // TODO? move to protected and fix CPointerManager::renderHWCursorBuffer
-        bool                         commitPendingAndDoExplicitSync(PHLMONITOR pMonitor);  // TODO? move to protected and fix CMonitorFrameScheduler::onPresented
-        SRenderData                  m_renderData;                                         // TODO? move to protected and fix CRenderPass
-        SP<ITexture>                 m_screencopyDeniedTexture;                            // TODO? make readonly
-        uint                         m_failedAssetsNo     = 0;                             // TODO? make readonly
-        bool                         m_reloadScreenShader = true;                          // at launch it can be set
-        CTimer                       m_globalTimer;
+        virtual SP<IRenderbuffer>  getOrCreateRenderbuffer(SP<Aquamarine::IBuffer> buffer,
+                                                           uint32_t                fmt); // TODO? move to protected and fix CPointerManager::renderHWCursorBuffer
+        bool                       commitPendingAndDoExplicitSync(PHLMONITOR pMonitor, bool updateSwapChain); // TODO? move to protected and fix CMonitorFrameScheduler::onPresented
+        SRenderData                m_renderData;                                                              // TODO? move to protected and fix CRenderPass
+        SP<ITexture>               m_screencopyDeniedTexture;                                                 // TODO? make readonly
+        uint                       m_failedAssetsNo     = 0;                                                  // TODO? make readonly
+        bool                       m_reloadScreenShader = true;                                               // at launch it can be set
+        CTimer                     m_globalTimer;
 
-        void                         draw(WP<IPassElement> element, const CRegion& damage = {});
-        void                         draw(const CBorderPassElement::SBorderData& data, const CRegion& damage = {});
-        void                         draw(const CClearPassElement::SClearData& data, const CRegion& damage = {});
-        void                         draw(const CFramebufferElement::SFramebufferElementData& data, const CRegion& damage = {});
-        void                         draw(const CRectPassElement::SRectData& data, const CRegion& damage = {});
-        void                         draw(const CRendererHintsPassElement::SData& data, const CRegion& damage = {});
-        void                         draw(const CShadowPassElement::SShadowData& data, const CRegion& damage = {});
-        void                         draw(const CSurfacePassElement::SRenderData& data, const CRegion& damage = {});
-        void                         draw(const CTexPassElement::SRenderData& data, const CRegion& damage = {});
-        void                         draw(const CTextureMatteElement::STextureMatteData& data, const CRegion& damage = {});
-        virtual void                 bindFB(SP<IFramebuffer> fb);
-        UP<CScopeGuard>              bindTempFB(SP<IFramebuffer> fb);
-        virtual UP<ISyncFDManager>   createSyncFDManager()                                                                                                                     = 0;
+        void                       draw(WP<IPassElement> element, const CRegion& damage = {});
+        void                       draw(const CBorderPassElement::SBorderData& data, const CRegion& damage = {});
+        void                       draw(const CClearPassElement::SClearData& data, const CRegion& damage = {});
+        void                       draw(const CFramebufferElement::SFramebufferElementData& data, const CRegion& damage = {});
+        void                       draw(const CRectPassElement::SRectData& data, const CRegion& damage = {});
+        void                       draw(const CRendererHintsPassElement::SData& data, const CRegion& damage = {});
+        void                       draw(const CShadowPassElement::SShadowData& data, const CRegion& damage = {});
+        void                       draw(const CSurfacePassElement::SRenderData& data, const CRegion& damage = {});
+        void                       draw(const CTexPassElement::SRenderData& data, const CRegion& damage = {});
+        void                       draw(const CTextureMatteElement::STextureMatteData& data, const CRegion& damage = {});
+        virtual void               bindFB(SP<IFramebuffer> fb);
+        UP<CScopeGuard>            bindTempFB(SP<IFramebuffer> fb);
+        virtual UP<ISyncFDManager> createSyncFDManager()                                                                                                                       = 0;
         virtual WP<IElementRenderer> elementRenderer()                                                                                                                         = 0;
         virtual SP<ITexture>         createStencilTexture(const int width, const int height)                                                                                   = 0;
         virtual SP<ITexture>         createTexture(bool opaque = false)                                                                                                        = 0;

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -75,6 +75,7 @@ namespace Render {
         void                                renderDamageBlink(PHLMONITOR pMonitor, int& damageBlinkCleanup);
         bool                                renderDirectScanout(PHLMONITOR pMonitor);
         void                                renderMonitor(PHLMONITOR pMonitor, bool commit = true);
+        void                                endRenderMonitor(PHLMONITOR pMonitor, bool commit, bool shouldTear);
         void                                arrangeLayersForMonitor(const MONITORID&);
         void                                damageSurface(SP<CWLSurfaceResource>, double, double, double scale = 1.0);
         void                                damageWindow(PHLWINDOW, bool forceFull = false);

--- a/src/render/Renderer.hpp
+++ b/src/render/Renderer.hpp
@@ -71,6 +71,7 @@ namespace Render {
         virtual eType                       type() = 0;
         WP<Render::GL::CHyprOpenGLImpl>     glBackend();
 
+        void                                applyCursorZoom(PHLMONITOR pMonitor, SRenderData& data);
         bool                                renderDirectScanout(PHLMONITOR pMonitor);
         void                                renderMonitor(PHLMONITOR pMonitor, bool commit = true);
         void                                arrangeLayersForMonitor(const MONITORID&);


### PR DESCRIPTION
just reduce the amount of nested code in renderMonitor() so the fun stuff as actually figuring out the proper early returns, hw cursor move commits that doesnt need a swapchain/m_infence commit, the needsFrame but no damage added paths.

shouldnt change any logic, only moved code into helpers, and timers into COverlay class, or variables down where they actually are used. and the proper fail early returns at top of renderMonitor.

but with [cc94c04](https://github.com/hyprwm/Hyprland/pull/15580/commits/cc94c048f901aa010f727f967e04127d2946ed20) and forward we begin the fun stuff, actually skipping swapchain, monitor infence, etc. this is gonna require some testing to ensure we dont regress. i placed it below direct scanout for now.


commit [9ca9903](https://github.com/hyprwm/Hyprland/pull/15580/commits/9ca9903f25fc04decb737af919d980b47fb3ce2d) requires , https://github.com/hyprwm/aquamarine/pull/342 

- [x] dpms/restorevt.
- [x] hw cursor commits.
- [x] modesets, pageflips, dual gpu.
- [x] VRR?
- [x] tearing?
- [x] just overall edge cases missed here?
